### PR TITLE
Only split the monorepo if the whole build is successful

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,10 +25,6 @@ matrix:
     - php: 7.1
     - php: 7.2
 
-    # Split the monorepo
-    - php: 7.2
-      env: MONOREPO_SPLIT=true
-
     # Generate the coverage with the latest PHP version
     - php: 7.2
       env: COVERAGE='--exclude-group contao3'
@@ -39,6 +35,18 @@ matrix:
     - php: 7.2
       env: COMPOSER_FLAGS='--prefer-lowest --prefer-stable'
   fast_finish: true
+
+jobs:
+  include:
+    # Split the monorepo
+    - stage: split
+      if: 'type = push AND branch =~ /^(master|\d+\.\d+)$/'
+      php: 7.2
+      install:
+        # Project dependencies don’t need to be installed for the split script
+        - rm composer.json
+        - composer require contao/monorepo-tools:dev-master#ab059e16bee36ca70941d13719c13719f3b34733 --no-interaction
+      script: vendor/bin/monorepo-tools split $TRAVIS_BRANCH --cache-dir $HOME/.monorepo-split-cache
 
 before_install:
   - if [[ ! $COVERAGE ]]; then phpenv config-rm xdebug.ini || true; fi
@@ -58,7 +66,6 @@ script:
   - if [[ $COVERAGE ]]; then php vendor/bin/phpunit -c installation-bundle $COVERAGE --coverage-clover build/logs/installation-bundle.xml; else php vendor/bin/phpunit -c installation-bundle; fi
   - if [[ $COVERAGE ]]; then php vendor/bin/phpunit -c manager-bundle $COVERAGE --coverage-clover build/logs/manager-bundle.xml; else php vendor/bin/phpunit -c manager-bundle; fi
   - if [[ $COVERAGE ]]; then php vendor/bin/phpunit -c news-bundle $COVERAGE --coverage-clover build/logs/news-bundle.xml; else php vendor/bin/phpunit -c news-bundle; fi
-  - if [[ $MONOREPO_SPLIT == true && $TRAVIS_EVENT_TYPE == "push" ]]; then composer require contao/monorepo-tools:dev-master; vendor/bin/monorepo-tools split $TRAVIS_BRANCH --cache-dir $HOME/.monorepo-split-cache; fi
 
 after_script:
   - if [[ $COVERAGE ]]; then php vendor/bin/php-coveralls -x build/logs/calendar-bundle.xml -x build/logs/core-bundle.xml -x build/logs/faq-bundle.xml -x build/logs/installation-bundle.xml -x build/logs/manager-bundle.xml -x build/logs/news-bundle.xml; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ jobs:
       install:
         # Project dependencies don’t need to be installed for the split script
         - rm composer.json
-        - composer require contao/monorepo-tools:dev-master#ab059e16bee36ca70941d13719c13719f3b34733 --no-interaction
+        - composer require contao/monorepo-tools:dev-master --no-interaction
       script: vendor/bin/monorepo-tools split $TRAVIS_BRANCH --cache-dir $HOME/.monorepo-split-cache
 
 before_install:


### PR DESCRIPTION
The logic when the split runs on Travis CI is currently not very reasonable I think. If the tests fail in PHP 7.1 but are fine in PHP 7.2, the split still gets executed. Additionally the tests in PHP 7.2 run twice which is a waste of time and resources.

For such use cases travis has build stages that makes it possible to run jobs only if a group of other jobs succeeded.

~~I also changed the requirement for `contao/monorepo-tools` to a specific commit hash to avoid incompatibilities in future updates to the lib.~~