### PR TITLE
Tag the responses within ContentModule

### DIFF
--- a/core-bundle/src/Resources/contao/elements/ContentModule.php
+++ b/core-bundle/src/Resources/contao/elements/ContentModule.php
@@ -10,6 +10,8 @@
 
 namespace Contao;
 
+use FOS\HttpCache\ResponseTagger;
+
 /**
  * Front end content element "module".
  *
@@ -64,6 +66,14 @@ class ContentModule extends ContentElement
 		}
 
 		$objModule->cssID = $cssID;
+		
+		// Tag the response
+		if (System::getContainer()->has('fos_http_cache.http.symfony_response_tagger'))
+		{
+			/** @var ResponseTagger $responseTagger */
+			$responseTagger = System::getContainer()->get('fos_http_cache.http.symfony_response_tagger');
+			$responseTagger->addTags(array('contao.db.tl_content.' . $this->id));
+		}
 
 		return $objModule->generate();
 	}


### PR DESCRIPTION
Tag the response with a `contao.tb.tl_content` tag as well. While the response already has a `tl_module` tag, the `tl_content` tag is necessary since the content element can hold a custom CSS ID which requires the response to become invalidated post change.

### How to reproduce
1. Activate shared caching
1. Create module (e.g. news list)
1. Include module (ContentModule)
1. Request page in frontend
1. Change cssId of the content element including module
1. Reload the page; the page should be expired.

I am not experienced with caching, and I came up with this kind of heuristically, so please evaluate.