### PR TITLE
[4.5] Fix dependencies

### DIFF
--- a/calendar-bundle/composer.json
+++ b/calendar-bundle/composer.json
@@ -20,12 +20,12 @@
     },
     "require-dev": {
         "contao/manager-plugin": "^2.0",
-        "contao/test-case": "^1.1",
+        "contao/test-case": "^1.3",
         "php-coveralls/php-coveralls": "^2.1",
         "php-http/guzzle6-adapter": "^1.1",
         "php-http/message-factory": "^1.0.2",
-        "phpunit/phpunit": "^6.1",
-        "symfony/phpunit-bridge": "^3.3.11"
+        "phpunit/phpunit": "^6.5",
+        "symfony/phpunit-bridge": "^3.4"
     },
     "extra": {
         "branch-alias": {

--- a/core-bundle/composer.json
+++ b/core-bundle/composer.json
@@ -87,7 +87,7 @@
         "ext-fileinfo": "*",
         "composer/composer": "^1.0",
         "contao/manager-plugin": "^2.2",
-        "contao/test-case": "^1.1",
+        "contao/test-case": "^1.3",
         "doctrine/doctrine-migrations-bundle": "^1.1",
         "doctrine/orm": "^2.5",
         "lexik/maintenance-bundle": "^2.1.3",
@@ -95,8 +95,8 @@
         "php-coveralls/php-coveralls": "^2.1",
         "php-http/guzzle6-adapter": "^1.1",
         "php-http/message-factory": "^1.0.2",
-        "phpunit/phpunit": "^6.1",
-        "symfony/phpunit-bridge": "^3.3.11"
+        "phpunit/phpunit": "^6.5",
+        "symfony/phpunit-bridge": "^3.4"
     },
     "suggest": {
         "lexik/maintenance-bundle": "To put the application into maintenance mode"

--- a/faq-bundle/composer.json
+++ b/faq-bundle/composer.json
@@ -20,12 +20,12 @@
     },
     "require-dev": {
         "contao/manager-plugin": "^2.0",
-        "contao/test-case": "^1.1",
+        "contao/test-case": "^1.3",
         "php-coveralls/php-coveralls": "^2.1",
         "php-http/guzzle6-adapter": "^1.1",
         "php-http/message-factory": "^1.0.2",
-        "phpunit/phpunit": "^6.1",
-        "symfony/phpunit-bridge": "^3.3.11"
+        "phpunit/phpunit": "^6.5",
+        "symfony/phpunit-bridge": "^3.4"
     },
     "extra": {
         "branch-alias": {

--- a/installation-bundle/composer.json
+++ b/installation-bundle/composer.json
@@ -26,8 +26,8 @@
         "php-coveralls/php-coveralls": "^2.1",
         "php-http/guzzle6-adapter": "^1.1",
         "php-http/message-factory": "^1.0.2",
-        "phpunit/phpunit": "^6.1",
-        "symfony/phpunit-bridge": "^3.3.11"
+        "phpunit/phpunit": "^6.5",
+        "symfony/phpunit-bridge": "^3.4"
     },
     "extra": {
         "branch-alias": {

--- a/manager-bundle/composer.json
+++ b/manager-bundle/composer.json
@@ -28,12 +28,12 @@
     },
     "require-dev": {
         "composer/composer": "^1.0",
-        "contao/test-case": "^1.1",
+        "contao/test-case": "^1.3",
         "php-coveralls/php-coveralls": "^2.1",
         "ocramius/proxy-manager": "^2.0",
         "php-http/message-factory": "^1.0.2",
-        "phpunit/phpunit": "^6.1",
-        "symfony/phpunit-bridge": "^3.3.11"
+        "phpunit/phpunit": "^6.5",
+        "symfony/phpunit-bridge": "^3.4"
     },
     "extra": {
         "branch-alias": {

--- a/monorepo.yml
+++ b/monorepo.yml
@@ -6,10 +6,7 @@ composer:
         'contao/manager-plugin': '^2.6.2'
     require-dev:
         'contao/monorepo-tools': 'dev-master'
-        'contao/test-case': '^1.3'
         'friendsofphp/php-cs-fixer': '^2.12'
-        'phpunit/phpunit': '^6.5'
-        'symfony/phpunit-bridge': '^3.4'
 
 repositories:
     calendar-bundle:

--- a/news-bundle/composer.json
+++ b/news-bundle/composer.json
@@ -20,12 +20,12 @@
     },
     "require-dev": {
         "contao/manager-plugin": "^2.0",
-        "contao/test-case": "^1.1",
+        "contao/test-case": "^1.3",
         "php-coveralls/php-coveralls": "^2.1",
         "php-http/guzzle6-adapter": "^1.1",
         "php-http/message-factory": "^1.0.2",
-        "phpunit/phpunit": "^6.1",
-        "symfony/phpunit-bridge": "^3.3.11"
+        "phpunit/phpunit": "^6.5",
+        "symfony/phpunit-bridge": "^3.4"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
IMO it’s better to increase the required versions in the `require-dev` config of all splits instead of adding special requirements only for `contao/contao`.