### PR TITLE
Use download count of core-bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![](https://img.shields.io/travis/contao/contao/master.svg?style=flat-square)](https://travis-ci.org/contao/contao/)
 [![](https://img.shields.io/coveralls/contao/contao/master.svg?style=flat-square)](https://coveralls.io/github/contao/contao)
 [![](https://img.shields.io/packagist/v/contao/contao.svg?style=flat-square)](https://packagist.org/packages/contao/contao)
-[![](https://img.shields.io/packagist/dt/contao/contao.svg?style=flat-square)](https://packagist.org/packages/contao/contao)
+[![](https://img.shields.io/packagist/dt/contao/core-bundle.svg?style=flat-square)](https://packagist.org/packages/contao/contao)
 
 This is a monorepo holding the official Contao 4 bundles.
 


### PR DESCRIPTION
The `contao/contao` package itself shouldn’t have too many downloads, as we recommend to install the bundles instead.

I think we should show the download count of the core-bundle in the readme file.