### PR TITLE
PrettyErrorScreenListener: Only look up templates for Exceptions

### DIFF
--- a/core-bundle/src/EventListener/PrettyErrorScreenListener.php
+++ b/core-bundle/src/EventListener/PrettyErrorScreenListener.php
@@ -235,7 +235,9 @@ class PrettyErrorScreenListener
 
         // Look for a template
         do {
-            $template = $this->getTemplateForException($exception);
+            if ($exception instanceof \Exception) {
+                $template = $this->getTemplateForException($exception);
+            }
         } while (null === $template && null !== ($exception = $exception->getPrevious()));
 
         $this->renderTemplate($template ?: 'error', $statusCode, $event);


### PR DESCRIPTION
Hi!

## Issue

Argument 1 passed to [Contao\CoreBundle\EventListener\PrettyErrorScreenListener::getTemplateForException()](https://github.com/contao/contao/blob/4.6/core-bundle/src/EventListener/PrettyErrorScreenListener.php#L197-L206) must be an instance of Exception, instance of Error given, called in [vendor/contao/core-bundle/src/EventListener/PrettyErrorScreenListener.php on line 191](https://github.com/contao/contao/blob/4.6/core-bundle/src/EventListener/PrettyErrorScreenListener.php#L191)

<hr/>

In my case, the exception has been a `\InvalidArgumentException`. The top-level exception is always a type of `\Exception` (PHPDoc saying so), however, `$exception->getPrevious()` returns a `\Throwable`, which might be an `\Error`.

## Affected versions (PHP / Contao)

All Contao versions 4.4 - 4.6 are affected. The occurred in a Contao 4.6 project for me.

As of http://php.net/manual/en/exception.getprevious.php, an `\Exception` might return a `\Throwable`.
This error might occur since PHP 7.0 (see changelog of the link above).