### PR TITLE
Make the `contao.routing.scope_matcher` service public.

### DIFF
--- a/core-bundle/src/Resources/config/services.yml
+++ b/core-bundle/src/Resources/config/services.yml
@@ -338,6 +338,7 @@ services:
         arguments:
             - "@contao.routing.backend_matcher"
             - "@contao.routing.frontend_matcher"
+        public: true
 
     contao.routing.backend_matcher:
         class: Symfony\Component\HttpFoundation\RequestMatcher

--- a/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
+++ b/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
@@ -1244,7 +1244,7 @@ class ContaoCoreExtensionTest extends TestCase
         $definition = $this->container->getDefinition('contao.routing.scope_matcher');
 
         $this->assertSame(ScopeMatcher::class, $definition->getClass());
-        $this->assertTrue($definition->isPrivate());
+        $this->assertTrue($definition->isPublic());
         $this->assertSame('contao.routing.backend_matcher', (string) $definition->getArgument(0));
         $this->assertSame('contao.routing.frontend_matcher', (string) $definition->getArgument(1));
     }


### PR DESCRIPTION
## Issue and description

It is otherwise incompatible with the [`AbstractFrontendModuleController`](https://github.com/contao/contao/blob/4.6.0/core-bundle/src/Controller/FrontendModule/AbstractFrontendModuleController.php#L26) since `symfony/dependency-injection` v4.0.

## Affected versions

Contao 4.6 (supports dep. inj. v. 4.1)