### PR TITLE
Relax symfony HTTP kernel requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -82,7 +82,7 @@
         "symfony/finder": "3.4.* || 4.1.*",
         "symfony/framework-bundle": "3.4.* || 4.1.*",
         "symfony/http-foundation": "3.4.* || 4.1.*",
-        "symfony/http-kernel": "4.1.*",
+        "symfony/http-kernel": "3.4.* || 4.1.*",
         "symfony/lock": "3.4.* || 4.1.*",
         "symfony/monolog-bridge": "4.1.*",
         "symfony/monolog-bundle": "^3.1",

--- a/core-bundle/composer.json
+++ b/core-bundle/composer.json
@@ -73,7 +73,7 @@
         "symfony/finder": "3.4.* || 4.1.*",
         "symfony/framework-bundle": "3.4.* || 4.1.*",
         "symfony/http-foundation": "3.4.* || 4.1.*",
-        "symfony/http-kernel": "4.1.*",
+        "symfony/http-kernel": "3.4.* || 4.1.*",
         "symfony/lock": "3.4.* || 4.1.*",
         "symfony/process": "3.4.* || 4.1.*",
         "symfony/routing": "3.4.* || 4.1.*",

--- a/core-bundle/src/EventListener/PrettyErrorScreenListener.php
+++ b/core-bundle/src/EventListener/PrettyErrorScreenListener.php
@@ -34,6 +34,7 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\Exception\ServiceUnavailableHttpException;
 use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
+use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 class PrettyErrorScreenListener
@@ -252,7 +253,7 @@ class PrettyErrorScreenListener
 
     private function logException(\Exception $exception): void
     {
-        if (null === $this->logger || !$this->isLoggable($exception)) {
+        if (Kernel::VERSION_ID >= 40100 || null === $this->logger || !$this->isLoggable($exception)) {
             return;
         }
 

--- a/core-bundle/src/EventListener/PrettyErrorScreenListener.php
+++ b/core-bundle/src/EventListener/PrettyErrorScreenListener.php
@@ -260,9 +260,6 @@ class PrettyErrorScreenListener
         $this->logger->critical('An exception occurred.', ['exception' => $exception]);
     }
 
-    /**
-     * Checks if an extension is loggable.
-     */
     private function isLoggable(\Exception $exception): bool
     {
         do {

--- a/core-bundle/src/EventListener/PrettyErrorScreenListener.php
+++ b/core-bundle/src/EventListener/PrettyErrorScreenListener.php
@@ -26,6 +26,7 @@ use Contao\CoreBundle\Framework\ContaoFrameworkInterface;
 use Contao\CoreBundle\Routing\ScopeMatcher;
 use Contao\PageError404;
 use Contao\StringUtil;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
@@ -63,6 +64,11 @@ class PrettyErrorScreenListener
     private $scopeMatcher;
 
     /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
      * @var array
      */
     private static $mapper = [
@@ -75,13 +81,14 @@ class PrettyErrorScreenListener
         NoRootPageFoundException::class => 'no_root_page_found',
     ];
 
-    public function __construct(bool $prettyErrorScreens, \Twig_Environment $twig, ContaoFrameworkInterface $framework, TokenStorageInterface $tokenStorage, ScopeMatcher $scopeMatcher)
+    public function __construct(bool $prettyErrorScreens, \Twig_Environment $twig, ContaoFrameworkInterface $framework, TokenStorageInterface $tokenStorage, ScopeMatcher $scopeMatcher, LoggerInterface $logger = null)
     {
         $this->prettyErrorScreens = $prettyErrorScreens;
         $this->twig = $twig;
         $this->framework = $framework;
         $this->tokenStorage = $tokenStorage;
         $this->scopeMatcher = $scopeMatcher;
+        $this->logger = $logger;
     }
 
     /**
@@ -136,6 +143,7 @@ class PrettyErrorScreenListener
     {
         $exception = $event->getException();
 
+        $this->logException($exception);
         $this->renderTemplate('backend', $this->getStatusCodeForException($exception), $event);
     }
 
@@ -185,6 +193,8 @@ class PrettyErrorScreenListener
     {
         $exception = $event->getException();
         $statusCode = $this->getStatusCodeForException($exception);
+
+        $this->logException($exception);
 
         // Look for a template
         do {
@@ -238,6 +248,33 @@ class PrettyErrorScreenListener
             'adminEmail' => '&#109;&#97;&#105;&#108;&#116;&#111;&#58;'.$encoded,
             'exception' => $event->getException()->getMessage(),
         ];
+    }
+
+    private function logException(\Exception $exception): void
+    {
+        if (null === $this->logger || !$this->isLoggable($exception)) {
+            return;
+        }
+
+        $this->logger->critical('An exception occurred.', ['exception' => $exception]);
+    }
+
+    /**
+     * Checks if an extension is loggable.
+     */
+    private function isLoggable(\Exception $exception): bool
+    {
+        do {
+            if ($exception instanceof ForwardPageNotFoundException) {
+                return true;
+            }
+
+            if (isset(self::$mapper[\get_class($exception)])) {
+                return false;
+            }
+        } while (null !== ($exception = $exception->getPrevious()));
+
+        return true;
     }
 
     private function isBackendUser(): bool

--- a/core-bundle/src/Resources/config/listener.yml
+++ b/core-bundle/src/Resources/config/listener.yml
@@ -130,6 +130,7 @@ services:
             - "@contao.framework"
             - "@security.token_storage"
             - "@contao.routing.scope_matcher"
+            - "@logger"
         tags:
             # The priority must be higher than the one of the Twig exception listener (defaults to -128)
             - { name: kernel.event_listener, event: kernel.exception, method: onKernelException, priority: -96 }

--- a/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
+++ b/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
@@ -454,6 +454,7 @@ class ContaoCoreExtensionTest extends TestCase
         $this->assertSame('contao.framework', (string) $definition->getArgument(2));
         $this->assertSame('security.token_storage', (string) $definition->getArgument(3));
         $this->assertSame('contao.routing.scope_matcher', (string) $definition->getArgument(4));
+        $this->assertSame('logger', (string) $definition->getArgument(5));
 
         $tags = $definition->getTags();
 

--- a/core-bundle/tests/EventListener/PrettyErrorScreenListenerTest.php
+++ b/core-bundle/tests/EventListener/PrettyErrorScreenListenerTest.php
@@ -347,9 +347,10 @@ class PrettyErrorScreenListenerTest extends TestCase
 
         $logger = $this->createMock(LoggerInterface::class);
         $logger
-            ->expects(($expectLogging && Kernel::VERSION_ID < 40100)
-                ? $this->once()
-                : $this->never()
+            ->expects(
+                ($expectLogging && Kernel::VERSION_ID < 40100)
+                    ? $this->once()
+                    : $this->never()
             )
             ->method('critical')
         ;

--- a/core-bundle/tests/EventListener/PrettyErrorScreenListenerTest.php
+++ b/core-bundle/tests/EventListener/PrettyErrorScreenListenerTest.php
@@ -25,6 +25,7 @@ use Contao\CoreBundle\Routing\ScopeMatcher;
 use Contao\CoreBundle\Tests\TestCase;
 use Contao\FrontendUser;
 use Lexik\Bundle\MaintenanceBundle\Exception\ServiceUnavailableException;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
@@ -74,10 +75,16 @@ class PrettyErrorScreenListenerTest extends TestCase
             ->willReturn(null)
         ;
 
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger
+            ->expects($this->once())
+            ->method('critical')
+        ;
+
         $exception = new InternalServerErrorHttpException('', new InternalServerErrorException());
         $event = $this->mockResponseEvent($exception);
 
-        $listener = new PrettyErrorScreenListener(true, $twig, $framework, $tokenStorage, $scopeMatcher);
+        $listener = new PrettyErrorScreenListener(true, $twig, $framework, $tokenStorage, $scopeMatcher, $logger);
         $listener->onKernelException($event);
 
         $this->assertTrue($event->hasResponse());
@@ -106,10 +113,16 @@ class PrettyErrorScreenListenerTest extends TestCase
             ->willReturn($token)
         ;
 
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger
+            ->expects($this->once())
+            ->method('critical')
+        ;
+
         $exception = new InternalServerErrorHttpException('', new InternalServerErrorException());
         $event = $this->mockResponseEvent($exception);
 
-        $listener = new PrettyErrorScreenListener(true, $twig, $framework, $tokenStorage, $scopeMatcher);
+        $listener = new PrettyErrorScreenListener(true, $twig, $framework, $tokenStorage, $scopeMatcher, $logger);
         $listener->onKernelException($event);
 
         $this->assertTrue($event->hasResponse());
@@ -331,7 +344,13 @@ class PrettyErrorScreenListenerTest extends TestCase
         $tokenStorage = $this->mockTokenStorage($userClass);
         $scopeMatcher = $this->mockScopeMatcher();
 
-        return new PrettyErrorScreenListener(true, $twig, $framework, $tokenStorage, $scopeMatcher);
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger
+            ->expects($expectLogging ? $this->once() : $this->never())
+            ->method('critical')
+        ;
+
+        return new PrettyErrorScreenListener(true, $twig, $framework, $tokenStorage, $scopeMatcher, $logger);
     }
 
     private function mockResponseEvent(\Exception $exception, Request $request = null, bool $isSubRequest = false): GetResponseForExceptionEvent

--- a/core-bundle/tests/EventListener/PrettyErrorScreenListenerTest.php
+++ b/core-bundle/tests/EventListener/PrettyErrorScreenListenerTest.php
@@ -34,6 +34,7 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\Exception\ServiceUnavailableHttpException;
 use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
@@ -77,7 +78,7 @@ class PrettyErrorScreenListenerTest extends TestCase
 
         $logger = $this->createMock(LoggerInterface::class);
         $logger
-            ->expects($this->once())
+            ->expects(Kernel::VERSION_ID >= 40100 ? $this->never() : $this->once())
             ->method('critical')
         ;
 
@@ -115,7 +116,7 @@ class PrettyErrorScreenListenerTest extends TestCase
 
         $logger = $this->createMock(LoggerInterface::class);
         $logger
-            ->expects($this->once())
+            ->expects(Kernel::VERSION_ID >= 40100 ? $this->never() : $this->once())
             ->method('critical')
         ;
 
@@ -346,7 +347,10 @@ class PrettyErrorScreenListenerTest extends TestCase
 
         $logger = $this->createMock(LoggerInterface::class);
         $logger
-            ->expects($expectLogging ? $this->once() : $this->never())
+            ->expects(($expectLogging && Kernel::VERSION_ID < 40100)
+                ? $this->once()
+                : $this->never()
+            )
             ->method('critical')
         ;
 


### PR DESCRIPTION
This fixes #30, Installing Contao 4.6 with `symfony/dependency-injection:^3.0` would then be possible.

The only downside is that exceptions would no longer be logged if Contao 4.6 is installed with Symfony HTTP kernel 3.4 because logging was removed in e285e1ddef3d696d8eb5c38ac94cbbca302b432b.

The requirement for `symfony/monolog-bridge:4.1.*` can stay as it is I think, because it is not closely tied to other Symfony packages.