### PR TITLE
Fixed unhandled null case in contao framework

### DIFF
--- a/core-bundle/src/Framework/ContaoFramework.php
+++ b/core-bundle/src/Framework/ContaoFramework.php
@@ -264,12 +264,18 @@ class ContaoFramework implements ContaoFrameworkInterface, ContainerAwareInterfa
         $attributes = $this->request->attributes;
 
         try {
-            $route = $this->router->generate($attributes->get('_route'), $attributes->get('_route_params'));
+            $route = (string) $this->router->generate($attributes->get('_route'), $attributes->get('_route_params'));
         } catch (\Exception $e) {
             return null;
         }
 
-        return substr($route, \strlen($this->request->getBasePath()) + 1);
+        $basePath = $this->request->getBasePath() . '/';
+
+        if (strncmp($route, $basePath, \strlen($basePath)) !== 0) {
+            return null;
+        }
+
+        return substr($route, \strlen($basePath));
     }
 
     /**

--- a/core-bundle/tests/Framework/ContaoFrameworkTest.php
+++ b/core-bundle/tests/Framework/ContaoFrameworkTest.php
@@ -25,6 +25,7 @@ use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\RouteCollection;
+use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Csrf\CsrfTokenManager;
 
 /**
@@ -176,6 +177,41 @@ class ContaoFrameworkTest extends TestCase
         $container->set('routing.loader', $routingLoader);
 
         $framework = $this->mockContaoFramework($container->get('request_stack'), new Router($container, []));
+        $framework->setContainer($container);
+        $framework->initialize();
+
+        $this->assertTrue(\defined('TL_MODE'));
+        $this->assertTrue(\defined('TL_START'));
+        $this->assertTrue(\defined('TL_ROOT'));
+        $this->assertTrue(\defined('TL_REFERER_ID'));
+        $this->assertTrue(\defined('TL_SCRIPT'));
+        $this->assertTrue(\defined('BE_USER_LOGGED_IN'));
+        $this->assertTrue(\defined('FE_USER_LOGGED_IN'));
+        $this->assertTrue(\defined('TL_PATH'));
+        $this->assertNull(TL_MODE);
+        $this->assertSame($this->getRootDir(), TL_ROOT);
+        $this->assertSame('', TL_REFERER_ID);
+        $this->assertNull(TL_SCRIPT);
+        $this->assertSame('', TL_PATH);
+        $this->assertSame('de', $GLOBALS['TL_LANGUAGE']);
+    }
+
+    /**
+     * Tests initializing the framework with router not returning a string
+     *
+     * @runInSeparateProcess
+     */
+    public function testInitializesTheFrameworkWithRouterNotReturningAString()
+    {
+        $request = new Request();
+        $request->setLocale('de');
+
+        $container = $this->mockContainerWithContaoScopes();
+        $container->get('request_stack')->push($request);
+
+        $router = $this->createMock(RouterInterface::class);
+
+        $framework = $this->mockContaoFramework($container->get('request_stack'), $router);
         $framework->setContainer($container);
         $framework->initialize();
 

--- a/core-bundle/tests/Framework/ContaoFrameworkTest.php
+++ b/core-bundle/tests/Framework/ContaoFrameworkTest.php
@@ -197,11 +197,11 @@ class ContaoFrameworkTest extends TestCase
     }
 
     /**
-     * Tests initializing the framework with router not returning a string
+     * Tests initializing the framework with an empty route.
      *
      * @runInSeparateProcess
      */
-    public function testInitializesTheFrameworkWithRouterNotReturningAString()
+    public function testInitializesTheFrameworkWithAnEmptyRoute()
     {
         $request = new Request();
         $request->setLocale('de');


### PR DESCRIPTION
As outlined in https://github.com/symfony/symfony/pull/28321 we cannot rely on the url generator of the router to always return a string. This was an issue in the interface docs of Symfony.