### PR TITLE
fix mtime check in generateScriptTag

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Template.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Template.php
@@ -537,7 +537,7 @@ abstract class Template extends Controller
 	public static function generateScriptTag($src, $async=false, $mtime=false)
 	{
 		// Add the filemtime if not given and not an external file
-		if ($mtime === null && !preg_match('@^https?://@', $src))
+		if ($mtime === false && !preg_match('@^https?://@', $src))
 		{
 			if (file_exists(TL_ROOT . '/' . $src))
 			{


### PR DESCRIPTION
If you use `Template::generateScriptTag(…)` without a custom `$mtime` parameter, the expected behaviour would be that the filemtime is pulled automatically from the file. However this does not work currently since the default value for that parameter is `false` and the function checks for `$mtime === null` instead of `$mtime === false`.