### PR TITLE
Fixed displaying wrong root nodes for tree structure in picker

### DIFF
--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -5996,7 +5996,8 @@ class DC_Table extends \DataContainer implements \listable, \editable
 		// Predefined node set (see #3563)
 		if (isset($attributes['rootNodes']))
 		{
-			$arrRoot = $this->eliminateNestedPages((array) $attributes['rootNodes']);
+			$blnHasSorting = $this->Database->fieldExists('sorting', $this->strTable);
+			$arrRoot = $this->eliminateNestedPages((array) $attributes['rootNodes'], $this->strTable, $blnHasSorting);
 
 			// Calculate the intersection of the root nodes with the mounted nodes (see #1001)
 			if (!empty($this->root) && $arrRoot != $this->root)
@@ -6006,7 +6007,8 @@ class DC_Table extends \DataContainer implements \listable, \editable
 						array_merge($arrRoot, $this->Database->getChildRecords($arrRoot, $this->strTable)),
 						array_merge($this->root, $this->Database->getChildRecords($this->root, $this->strTable))
 					),
-					$this->strTable
+					$this->strTable,
+					$blnHasSorting
 				);
 			}
 


### PR DESCRIPTION
This issue affected the data containers with sorting mode 5 (tree) but not `tl_page` since it is a fallback value if you do not provide the second argument in `eliminateNestedPages` method.