### PR TITLE
[RTM] Feature add link to contao manager in the backend

### DIFF
--- a/core-bundle/src/Resources/views/Backend/be_menu.html.twig
+++ b/core-bundle/src/Resources/views/Backend/be_menu.html.twig
@@ -12,7 +12,7 @@
                     <ul class="tl_level_2">
                         {% for child in item.children %}
                             <li{% if child is knp_menu_current %} class="active"{% endif %}>
-                                <a href="{{ child.attributes.href ?: item.uri }}" title="{{ child.attributes.title }}" class="{{ child.attributes.class }}">{{ child.label|raw }}</a>
+                                <a href="{{ child.attributes.href ?: item.uri }}" title="{{ child.attributes.title }}" class="{{ child.attributes.class }}"{% if child.attributes.target %} target="{{ child.attributes.target }}"{% endif %}>{{ child.label|raw }}</a>
                             </li>
                         {% endfor %}
                     </ul>

--- a/core-bundle/src/Resources/views/Backend/be_menu.html.twig
+++ b/core-bundle/src/Resources/views/Backend/be_menu.html.twig
@@ -12,7 +12,7 @@
                     <ul class="tl_level_2">
                         {% for child in item.children %}
                             <li{% if child is knp_menu_current %} class="active"{% endif %}>
-                                <a href="{{ child.attributes.href ?: item.uri }}" title="{{ child.attributes.title }}" class="{{ child.attributes.class }}"{% if child.attributes.target %} target="{{ child.attributes.target }}"{% endif %}>{{ child.label|raw }}</a>
+                                <a href="{{ child.attributes.href ?: item.uri }}" title="{{ child.attributes.title }}" class="{{ child.attributes.class }}"{% if child.attributes.target is defined %} target="{{ child.attributes.target }}"{% endif %}>{{ child.label|raw }}</a>
                             </li>
                         {% endfor %}
                     </ul>

--- a/manager-bundle/src/DependencyInjection/Configuration.php
+++ b/manager-bundle/src/DependencyInjection/Configuration.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\ManagerBundle\DependencyInjection;
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+
+final class Configuration implements ConfigurationInterface
+{
+    /**
+     * @var string
+     */
+    private $projectDir;
+
+    /**
+     *  @param string $projectDir
+     */
+    public function __construct(string $projectDir)
+    {
+        $this->projectDir = $projectDir;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getConfigTreeBuilder()
+    {
+        $treeBuilder = new TreeBuilder();
+        $rootNode    = $treeBuilder->root('contao_manager');
+
+        $rootNode->children()
+            ->scalarNode('manager_path')
+                ->info('Path to the manager relative to the web dir.')
+                ->defaultValue(null)
+                ->validate()
+                    ->always(
+                        function (?string $path): ?string {
+                            if (null === $path || is_file($this->projectDir . '/web/' . $path)) {
+                                return $path;
+                            }
+
+                            throw new InvalidConfigurationException(
+                                sprintf(
+                                    'contao_manager.manager_path is configured but file "%s" does not exist.',
+                                    $this->projectDir . '/web/' . $path
+                                )
+                            );
+                        }
+                    )
+            ->end();
+
+        return $treeBuilder;
+    }
+}

--- a/manager-bundle/src/DependencyInjection/Configuration.php
+++ b/manager-bundle/src/DependencyInjection/Configuration.php
@@ -23,9 +23,6 @@ final class Configuration implements ConfigurationInterface
      */
     private $webDir;
 
-    /**
-     *  @param string $webDir
-     */
     public function __construct(string $webDir)
     {
         $this->webDir = $webDir;
@@ -37,28 +34,32 @@ final class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder();
-        $rootNode    = $treeBuilder->root('contao_manager');
 
-        $rootNode->children()
-            ->scalarNode('manager_path')
-                ->info('Path to the manager relative to the web dir.')
-                ->defaultValue(null)
-                ->validate()
-                    ->always(
-                        function (?string $path): ?string {
-                            if (null === $path || is_file($this->webDir . '/' . $path)) {
-                                return $path;
+        $rootNode = $treeBuilder->root('contao_manager');
+        $rootNode
+            ->children()
+                ->scalarNode('manager_path')
+                    ->defaultValue(null)
+                    ->validate()
+                        ->always(
+                            function (?string $path): ?string {
+                                if (null === $path || is_file($this->webDir.'/'.$path)) {
+                                    return $path;
+                                }
+
+                                throw new InvalidConfigurationException(
+                                    sprintf(
+                                        'contao_manager.manager_path is configured but file "%s" does not exist.',
+                                        $this->webDir.'/'.$path
+                                    )
+                                );
                             }
-
-                            throw new InvalidConfigurationException(
-                                sprintf(
-                                    'contao_manager.manager_path is configured but file "%s" does not exist.',
-                                    $this->webDir . '/' . $path
-                                )
-                            );
-                        }
-                    )
-            ->end();
+                        )
+                    ->end()
+                    ->info('Path to the manager relative to the web dir.')
+                ->end()
+            ->end()
+        ;
 
         return $treeBuilder;
     }

--- a/manager-bundle/src/DependencyInjection/Configuration.php
+++ b/manager-bundle/src/DependencyInjection/Configuration.php
@@ -21,20 +21,20 @@ final class Configuration implements ConfigurationInterface
     /**
      * @var string
      */
-    private $projectDir;
+    private $webDir;
 
     /**
-     *  @param string $projectDir
+     *  @param string $webDir
      */
-    public function __construct(string $projectDir)
+    public function __construct(string $webDir)
     {
-        $this->projectDir = $projectDir;
+        $this->webDir = $webDir;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder();
         $rootNode    = $treeBuilder->root('contao_manager');
@@ -46,14 +46,14 @@ final class Configuration implements ConfigurationInterface
                 ->validate()
                     ->always(
                         function (?string $path): ?string {
-                            if (null === $path || is_file($this->projectDir . '/web/' . $path)) {
+                            if (null === $path || is_file($this->webDir . '/' . $path)) {
                                 return $path;
                             }
 
                             throw new InvalidConfigurationException(
                                 sprintf(
                                     'contao_manager.manager_path is configured but file "%s" does not exist.',
-                                    $this->projectDir . '/web/' . $path
+                                    $this->webDir . '/' . $path
                                 )
                             );
                         }

--- a/manager-bundle/src/DependencyInjection/ContaoManagerExtension.php
+++ b/manager-bundle/src/DependencyInjection/ContaoManagerExtension.php
@@ -20,14 +20,6 @@ use Symfony\Component\HttpKernel\DependencyInjection\ConfigurableExtension;
 class ContaoManagerExtension extends ConfigurableExtension
 {
     /**
-     * @var array
-     */
-    private static $managerPaths = [
-        'contao-manager.phar.php',
-        'contao-manager.php'
-    ];
-
-    /**
      * {@inheritdoc}
      */
     public function getConfiguration(array $config, ContainerBuilder $container)
@@ -57,23 +49,18 @@ class ContaoManagerExtension extends ConfigurableExtension
      */
     protected function configureManagerUrlParameter(array $mergedConfig, ContainerBuilder $container): void
     {
-        $managerUrl = null;
+        $managerPath = null;
 
         if ($mergedConfig['manager_path']) {
-            $managerUrl = $mergedConfig['manager_path'];
+            $managerPath = $mergedConfig['manager_path'];
         } else {
             $projectDir = $container->getParameter('kernel.project_dir');
 
-            foreach (static::$managerPaths as $path) {
-                if (!is_file($projectDir . '/web/' . $path)) {
-                    continue;
-                }
-
-                $managerUrl = $path;
-                break;
+            if (is_file($projectDir . '/web/contao-manager.phar.php')) {
+                $managerPath = 'contao-manager.phar.php';
             }
         }
 
-        $container->setParameter('contao_manager.manager_path', $managerUrl);
+        $container->setParameter('contao_manager.manager_path', $managerPath);
     }
 }

--- a/manager-bundle/src/DependencyInjection/ContaoManagerExtension.php
+++ b/manager-bundle/src/DependencyInjection/ContaoManagerExtension.php
@@ -22,7 +22,7 @@ class ContaoManagerExtension extends ConfigurableExtension
     /**
      * {@inheritdoc}
      */
-    public function getConfiguration(array $config, ContainerBuilder $container)
+    public function getConfiguration(array $config, ContainerBuilder $container): Configuration
     {
         return new Configuration($container->getParameter('contao.web_dir'));
     }
@@ -30,7 +30,7 @@ class ContaoManagerExtension extends ConfigurableExtension
     /**
      * {@inheritdoc}
      */
-    protected function loadInternal(array $mergedConfig, ContainerBuilder $container)
+    protected function loadInternal(array $mergedConfig, ContainerBuilder $container): void
     {
         $loader = new YamlFileLoader(
             $container,
@@ -41,13 +41,10 @@ class ContaoManagerExtension extends ConfigurableExtension
         $loader->load('listener.yml');
         $loader->load('services.yml');
 
-        $this->configureManagerUrlParameter($mergedConfig, $container);
+        $this->addContaoManagerPath($mergedConfig, $container);
     }
 
-    /**
-     * Configure the manager url porameter by checking configuration or default paths.
-     */
-    protected function configureManagerUrlParameter(array $mergedConfig, ContainerBuilder $container): void
+    protected function addContaoManagerPath(array $mergedConfig, ContainerBuilder $container): void
     {
         $managerPath = null;
 
@@ -56,7 +53,7 @@ class ContaoManagerExtension extends ConfigurableExtension
         } else {
             $webDir = $container->getParameter('contao.web_dir');
 
-            if (is_file($webDir . '/contao-manager.phar.php')) {
+            if (is_file($webDir.'/contao-manager.phar.php')) {
                 $managerPath = 'contao-manager.phar.php';
             }
         }

--- a/manager-bundle/src/DependencyInjection/ContaoManagerExtension.php
+++ b/manager-bundle/src/DependencyInjection/ContaoManagerExtension.php
@@ -24,7 +24,7 @@ class ContaoManagerExtension extends ConfigurableExtension
      */
     public function getConfiguration(array $config, ContainerBuilder $container)
     {
-        return new Configuration($container->getParameter('kernel.project_dir'));
+        return new Configuration($container->getParameter('contao.web_dir'));
     }
 
     /**

--- a/manager-bundle/src/DependencyInjection/ContaoManagerExtension.php
+++ b/manager-bundle/src/DependencyInjection/ContaoManagerExtension.php
@@ -54,9 +54,9 @@ class ContaoManagerExtension extends ConfigurableExtension
         if ($mergedConfig['manager_path']) {
             $managerPath = $mergedConfig['manager_path'];
         } else {
-            $projectDir = $container->getParameter('kernel.project_dir');
+            $webDir = $container->getParameter('contao.web_dir');
 
-            if (is_file($projectDir . '/web/contao-manager.phar.php')) {
+            if (is_file($webDir . '/contao-manager.phar.php')) {
                 $managerPath = 'contao-manager.phar.php';
             }
         }

--- a/manager-bundle/src/EventListener/BackendMenuListener.php
+++ b/manager-bundle/src/EventListener/BackendMenuListener.php
@@ -28,24 +28,18 @@ final class BackendMenuListener
      */
     private $managerPath;
 
-    /**
-     * BackendMenuListener constructor.
-     *
-     * @param TokenStorageInterface $tokenStorage
-     * @param string|null           $managerPath
-     */
     public function __construct(TokenStorageInterface $tokenStorage, ?string $managerPath)
     {
         $this->tokenStorage = $tokenStorage;
-        $this->managerPath  = $managerPath;
+        $this->managerPath = $managerPath;
     }
 
     /**
-     * Adds the contao manager to the backend navigation.
+     * Adds a link to the Contao Manager to the back end navigation.
      */
     public function onBuild(MenuEvent $event): void
     {
-        if ($this->managerPath === null || !$this->isAdminUser()) {
+        if (null === $this->managerPath || !$this->isAdminUser()) {
             return;
         }
 
@@ -63,9 +57,9 @@ final class BackendMenuListener
                 'label' => 'Contao Manager',
                 'attributes' => [
                     'title' => 'Contao Manager',
-                    'href' => '/' . $this->managerPath,
+                    'href' => '/'.$this->managerPath,
                     'target' => '_blank',
-                    'class' => 'navigation contao_manager'
+                    'class' => 'navigation contao_manager',
                 ],
             ]
         );

--- a/manager-bundle/src/EventListener/BackendMenuListener.php
+++ b/manager-bundle/src/EventListener/BackendMenuListener.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\ManagerBundle\EventListener;
+
+use Contao\BackendUser;
+use Contao\CoreBundle\Event\MenuEvent;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+
+final class BackendMenuListener
+{
+    /**
+     * @var TokenStorageInterface
+     */
+    private $tokenStorage;
+
+    /**
+     * @var string
+     */
+    private $managerPath;
+
+    /**
+     * BackendMenuListener constructor.
+     *
+     * @param TokenStorageInterface $tokenStorage
+     * @param string|null           $managerPath
+     */
+    public function __construct(TokenStorageInterface $tokenStorage, ?string $managerPath)
+    {
+        $this->tokenStorage = $tokenStorage;
+        $this->managerPath  = $managerPath;
+    }
+
+    /**
+     * Adds the contao manager to the backend navigation.
+     */
+    public function onBuild(MenuEvent $event): void
+    {
+        if ($this->managerPath === null || !$this->isAdminUser()) {
+            return;
+        }
+
+        $factory = $event->getFactory();
+        $tree = $event->getTree();
+        $categoryNode = $tree->getChild('system');
+
+        if (null === $categoryNode) {
+            return;
+        }
+
+        $item = $factory->createItem(
+            'contao_manager',
+            [
+                'label' => 'Contao Manager',
+                'attributes' => [
+                    'title' => 'Contao Manager',
+                    'href' => '/' . $this->managerPath,
+                    'target' => '_blank',
+                    'class' => 'navigation contao_manager'
+                ],
+            ]
+        );
+
+        $categoryNode->addChild($item);
+    }
+
+    private function isAdminUser(): bool
+    {
+        $token = $this->tokenStorage->getToken();
+
+        if (null === $token) {
+            return false;
+        }
+
+        $user = $token->getUser();
+
+        if (!$user instanceof BackendUser) {
+            return false;
+        }
+
+        return $user->isAdmin;
+    }
+}

--- a/manager-bundle/src/Resources/config/listener.yml
+++ b/manager-bundle/src/Resources/config/listener.yml
@@ -12,3 +12,11 @@ services:
             - "%kernel.project_dir%"
         tags:
             - { name: kernel.event_listener, event: console.terminate }
+
+    contao_manager.listener.backend_menu_listener:
+        class: Contao\ManagerBundle\EventListener\BackendMenuListener
+        arguments:
+            - "@security.token_storage"
+            - "%contao_manager.manager_path%"
+        tags:
+            - { name: kernel.event_listener, event: contao.backend_menu_build, method: onBuild, priority: -10 }

--- a/manager-bundle/src/Resources/config/listener.yml
+++ b/manager-bundle/src/Resources/config/listener.yml
@@ -1,4 +1,12 @@
 services:
+    contao_manager.listener.backend_menu_listener:
+        class: Contao\ManagerBundle\EventListener\BackendMenuListener
+        arguments:
+            - "@security.token_storage"
+            - "%contao_manager.manager_path%"
+        tags:
+            - { name: kernel.event_listener, event: contao.backend_menu_build, method: onBuild, priority: -10 }
+
     contao_manager.listener.initialize_application:
         class: Contao\ManagerBundle\EventListener\InitializeApplicationListener
         arguments:
@@ -12,11 +20,3 @@ services:
             - "%kernel.project_dir%"
         tags:
             - { name: kernel.event_listener, event: console.terminate }
-
-    contao_manager.listener.backend_menu_listener:
-        class: Contao\ManagerBundle\EventListener\BackendMenuListener
-        arguments:
-            - "@security.token_storage"
-            - "%contao_manager.manager_path%"
-        tags:
-            - { name: kernel.event_listener, event: contao.backend_menu_build, method: onBuild, priority: -10 }

--- a/manager-bundle/tests/DependencyInjection/ConfigurationTest.php
+++ b/manager-bundle/tests/DependencyInjection/ConfigurationTest.php
@@ -14,7 +14,7 @@ namespace Contao\ManagerBundle\Tests\DependencyInjection;
 
 use Contao\CoreBundle\Tests\TestCase;
 use Contao\ManagerBundle\DependencyInjection\Configuration;
-use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\Filesystem\Filesystem;
 
@@ -35,27 +35,19 @@ class ConfigurationTest extends TestCase
         $this->configuration = new Configuration($this->getTempDir());
     }
 
-    public function testCanBeInstantiated(): void
-    {
-        $this->assertInstanceOf(\Contao\ManagerBundle\DependencyInjection\Configuration::class, $this->configuration);
-
-        $treeBuilder = $this->configuration->getConfigTreeBuilder();
-
-        $this->assertInstanceOf(TreeBuilder::class, $treeBuilder);
-    }
-
     public function testCustomManagerPath(): void
     {
         $fs = new Filesystem();
-        $fs->dumpFile($this->getTempDir() . '/custom.phar.php', '');
+        $fs->dumpFile($this->getTempDir().'/custom.phar.php', '');
 
         $params = [
             'contao_manager' => [
-                'manager_path' => 'custom.phar.php'
-            ]
+                'manager_path' => 'custom.phar.php',
+            ],
         ];
 
         $configuration = (new Processor())->processConfiguration($this->configuration, $params);
+
         $this->assertSame('custom.phar.php', $configuration['manager_path']);
     }
 
@@ -63,11 +55,12 @@ class ConfigurationTest extends TestCase
     {
         $params = [
             'contao_manager' => [
-                'manager_path' => 'custom.php'
-            ]
+                'manager_path' => 'custom.php',
+            ],
         ];
 
-        $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
+        $this->expectException(InvalidConfigurationException::class);
+
         (new Processor())->processConfiguration($this->configuration, $params);
     }
 }

--- a/manager-bundle/tests/DependencyInjection/ConfigurationTest.php
+++ b/manager-bundle/tests/DependencyInjection/ConfigurationTest.php
@@ -47,7 +47,7 @@ class ConfigurationTest extends TestCase
     public function testCustomManagerPath(): void
     {
         $fs = new Filesystem();
-        $fs->dumpFile($this->getTempDir() . '/web/custom.phar.php', '');
+        $fs->dumpFile($this->getTempDir() . '/custom.phar.php', '');
 
         $params = [
             'contao_manager' => [

--- a/manager-bundle/tests/DependencyInjection/ConfigurationTest.php
+++ b/manager-bundle/tests/DependencyInjection/ConfigurationTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\ManagerBundle\Tests\DependencyInjection;
+
+use Contao\CoreBundle\Tests\TestCase;
+use Contao\ManagerBundle\DependencyInjection\Configuration;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\Processor;
+use Symfony\Component\Filesystem\Filesystem;
+
+class ConfigurationTest extends TestCase
+{
+    /**
+     * @var Configuration
+     */
+    private $configuration;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->configuration = new Configuration($this->getTempDir());
+    }
+
+    public function testCanBeInstantiated(): void
+    {
+        $this->assertInstanceOf(\Contao\ManagerBundle\DependencyInjection\Configuration::class, $this->configuration);
+
+        $treeBuilder = $this->configuration->getConfigTreeBuilder();
+
+        $this->assertInstanceOf(TreeBuilder::class, $treeBuilder);
+    }
+
+    public function testCustomManagerPath(): void
+    {
+        $fs = new Filesystem();
+        $fs->dumpFile($this->getTempDir() . '/web/custom.phar.php', '');
+
+        $params = [
+            'contao_manager' => [
+                'manager_path' => 'custom.phar.php'
+            ]
+        ];
+
+        $configuration = (new Processor())->processConfiguration($this->configuration, $params);
+        $this->assertSame('custom.phar.php', $configuration['manager_path']);
+    }
+
+    public function testExceptionIsThrownIfPathNotExists(): void
+    {
+        $params = [
+            'contao_manager' => [
+                'manager_path' => 'custom.php'
+            ]
+        ];
+
+        $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
+        (new Processor())->processConfiguration($this->configuration, $params);
+    }
+}

--- a/manager-bundle/tests/DependencyInjection/ContaoManagerExtensionTest.php
+++ b/manager-bundle/tests/DependencyInjection/ContaoManagerExtensionTest.php
@@ -35,6 +35,7 @@ class ContaoManagerExtensionTest extends TestCase
         parent::setUp();
 
         $this->container = new ContainerBuilder();
+        $this->container->setParameter('kernel.project_dir', '');
 
         $extension = new ContaoManagerExtension();
         $extension->load([], $this->container);

--- a/manager-bundle/tests/DependencyInjection/ContaoManagerExtensionTest.php
+++ b/manager-bundle/tests/DependencyInjection/ContaoManagerExtensionTest.php
@@ -112,11 +112,9 @@ class ContaoManagerExtensionTest extends ContaoTestCase
         $this->assertSame('%kernel.project_dir%', (string) $definition->getArgument(3));
     }
 
-    /**
-     * @dataProvider getDefaultManagerPaths
-     */
-    public function testDefaultContaoManagerPathIsRegisteredAutomatically(string $defaultPath): void
+    public function testDefaultContaoManagerPathIsRegisteredAutomatically(): void
     {
+        $defaultPath = 'contao-manager.phar.php';
         $container = new ContainerBuilder();
         $container->setParameter('kernel.project_dir', $this->getTempDir());
 
@@ -150,13 +148,5 @@ class ContaoManagerExtensionTest extends ContaoTestCase
         $this->assertSame('custom.phar.php', $container->getParameter('contao_manager.manager_path'));
 
         $fs->remove($tmpDir . '/web/custom.phar.php');
-    }
-
-    public function getDefaultManagerPaths(): array
-    {
-        return [
-            ['contao-manager.phar.php'],
-            ['contao-manager.php']
-        ];
     }
 }

--- a/manager-bundle/tests/DependencyInjection/ContaoManagerExtensionTest.php
+++ b/manager-bundle/tests/DependencyInjection/ContaoManagerExtensionTest.php
@@ -112,35 +112,33 @@ class ContaoManagerExtensionTest extends ContaoTestCase
         $this->assertSame('%kernel.project_dir%', (string) $definition->getArgument(3));
     }
 
-    public function testRegistersTheDefaultContaoManagerPath(): void
+    /**
+     * @dataProvider getManagerPaths
+     */
+    public function testRegistersTheContaoManagerPath(string $file, array $config): void
     {
         $webDir = $this->container->getParameter('contao.web_dir');
 
         $fs = new Filesystem();
-        $fs->dumpFile($webDir.'/contao-manager.phar.php', '');
+        $fs->dumpFile($webDir.'/'.$file, '');
 
         $extension = new ContaoManagerExtension();
-        $extension->load([], $this->container);
+        $extension->load([$config], $this->container);
 
-        $this->assertFileExists($webDir.'/contao-manager.phar.php');
-        $this->assertSame('contao-manager.phar.php', $this->container->getParameter('contao_manager.manager_path'));
+        $this->assertFileExists($webDir.'/'.$file);
+        $this->assertSame($file, $this->container->getParameter('contao_manager.manager_path'));
 
-        $fs->remove($webDir.'/contao-manager.phar.php');
+        $fs->remove($webDir.'/'.$file);
     }
 
-    public function testRegistersACustomContaoManagerPath(): void
+    /**
+     * @return array<int,array<int,array<string,string>|string>>
+     */
+    public function getManagerPaths(): array
     {
-        $webDir = $this->container->getParameter('contao.web_dir');
-
-        $fs = new Filesystem();
-        $fs->dumpFile($webDir.'/custom.phar.php', '');
-
-        $extension = new ContaoManagerExtension();
-        $extension->load([['manager_path' => 'custom.phar.php']], $this->container);
-
-        $this->assertFileExists($webDir.'/custom.phar.php');
-        $this->assertSame('custom.phar.php', $this->container->getParameter('contao_manager.manager_path'));
-
-        $fs->remove($webDir.'/custom.phar.php');
+        return [
+            ['contao-manager.phar.php', []],
+            ['custom.phar.php', ['manager_path' => 'custom.phar.php']],
+        ];
     }
 }

--- a/manager-bundle/tests/DependencyInjection/ContaoManagerExtensionTest.php
+++ b/manager-bundle/tests/DependencyInjection/ContaoManagerExtensionTest.php
@@ -36,8 +36,7 @@ class ContaoManagerExtensionTest extends ContaoTestCase
         parent::setUp();
 
         $this->container = new ContainerBuilder();
-        $this->container->setParameter('kernel.project_dir', $this->getTempDir());
-        $this->container->setParameter('contao.web_dir', $this->getTempDir() . '/web');
+        $this->container->setParameter('contao.web_dir', $this->getTempDir().'/web');
 
         $extension = new ContaoManagerExtension();
         $extension->load([], $this->container);
@@ -113,37 +112,35 @@ class ContaoManagerExtensionTest extends ContaoTestCase
         $this->assertSame('%kernel.project_dir%', (string) $definition->getArgument(3));
     }
 
-    public function testDefaultContaoManagerPathIsRegisteredAutomatically(): void
-    {
-        $defaultPath = 'contao-manager.phar.php';
-        $webDir      = $this->container->getParameter('contao.web_dir');
-
-        $fs = new Filesystem();
-        $fs->dumpFile($webDir . '/' . $defaultPath, '');
-
-        $extension = new ContaoManagerExtension();
-        $extension->load([], $this->container);
-
-        $this->assertFileExists($webDir . '/' . $defaultPath);
-        $this->assertSame($defaultPath, $this->container->getParameter('contao_manager.manager_path'));
-
-        $fs->remove($webDir . '/' . $defaultPath);
-    }
-
-    public function testCustomContaoManagerPathIsRegistered(): void
+    public function testRegistersTheDefaultContaoManagerPath(): void
     {
         $webDir = $this->container->getParameter('contao.web_dir');
 
         $fs = new Filesystem();
-        $fs->dumpFile($webDir . '/custom.phar.php' , '');
+        $fs->dumpFile($webDir.'/contao-manager.phar.php', '');
 
-        $config    = ['manager_path' => 'custom.phar.php'];
         $extension = new ContaoManagerExtension();
-        $extension->load([$config], $this->container);
+        $extension->load([], $this->container);
 
-        $this->assertFileExists($webDir . '/custom.phar.php');
+        $this->assertFileExists($webDir.'/contao-manager.phar.php');
+        $this->assertSame('contao-manager.phar.php', $this->container->getParameter('contao_manager.manager_path'));
+
+        $fs->remove($webDir.'/contao-manager.phar.php');
+    }
+
+    public function testRegistersACustomContaoManagerPath(): void
+    {
+        $webDir = $this->container->getParameter('contao.web_dir');
+
+        $fs = new Filesystem();
+        $fs->dumpFile($webDir.'/custom.phar.php', '');
+
+        $extension = new ContaoManagerExtension();
+        $extension->load([['manager_path' => 'custom.phar.php']], $this->container);
+
+        $this->assertFileExists($webDir.'/custom.phar.php');
         $this->assertSame('custom.phar.php', $this->container->getParameter('contao_manager.manager_path'));
 
-        $fs->remove($webDir . '/custom.phar.php');
+        $fs->remove($webDir.'/custom.phar.php');
     }
 }

--- a/manager-bundle/tests/DependencyInjection/ContaoManagerExtensionTest.php
+++ b/manager-bundle/tests/DependencyInjection/ContaoManagerExtensionTest.php
@@ -37,6 +37,7 @@ class ContaoManagerExtensionTest extends ContaoTestCase
 
         $this->container = new ContainerBuilder();
         $this->container->setParameter('kernel.project_dir', $this->getTempDir());
+        $this->container->setParameter('contao.web_dir', $this->getTempDir() . '/web');
 
         $extension = new ContaoManagerExtension();
         $extension->load([], $this->container);
@@ -115,38 +116,34 @@ class ContaoManagerExtensionTest extends ContaoTestCase
     public function testDefaultContaoManagerPathIsRegisteredAutomatically(): void
     {
         $defaultPath = 'contao-manager.phar.php';
-        $container = new ContainerBuilder();
-        $container->setParameter('kernel.project_dir', $this->getTempDir());
+        $webDir      = $this->container->getParameter('contao.web_dir');
 
-        $tmpDir = $this->getTempDir();
         $fs = new Filesystem();
-        $fs->dumpFile($tmpDir . '/web/' . $defaultPath, '');
+        $fs->dumpFile($webDir . '/' . $defaultPath, '');
 
         $extension = new ContaoManagerExtension();
-        $extension->load([], $container);
+        $extension->load([], $this->container);
 
-        $this->assertFileExists($tmpDir . '/web/' . $defaultPath);
-        $this->assertSame($defaultPath, $container->getParameter('contao_manager.manager_path'));
+        $this->assertFileExists($webDir . '/' . $defaultPath);
+        $this->assertSame($defaultPath, $this->container->getParameter('contao_manager.manager_path'));
 
-        $fs->remove($tmpDir . '/web/' . $defaultPath);
+        $fs->remove($webDir . '/' . $defaultPath);
     }
 
     public function testCustomContaoManagerPathIsRegistered(): void
     {
-        $container = new ContainerBuilder();
-        $container->setParameter('kernel.project_dir', $this->getTempDir());
+        $webDir = $this->container->getParameter('contao.web_dir');
 
-        $tmpDir = $this->getTempDir();
         $fs = new Filesystem();
-        $fs->dumpFile($tmpDir . '/web/custom.phar.php' , '');
+        $fs->dumpFile($webDir . '/custom.phar.php' , '');
 
         $config    = ['manager_path' => 'custom.phar.php'];
         $extension = new ContaoManagerExtension();
-        $extension->load([$config], $container);
+        $extension->load([$config], $this->container);
 
-        $this->assertFileExists($tmpDir . '/web/custom.phar.php');
-        $this->assertSame('custom.phar.php', $container->getParameter('contao_manager.manager_path'));
+        $this->assertFileExists($webDir . '/custom.phar.php');
+        $this->assertSame('custom.phar.php', $this->container->getParameter('contao_manager.manager_path'));
 
-        $fs->remove($tmpDir . '/web/custom.phar.php');
+        $fs->remove($webDir . '/custom.phar.php');
     }
 }

--- a/manager-bundle/tests/EventListener/BackendMenuListenerTest.php
+++ b/manager-bundle/tests/EventListener/BackendMenuListenerTest.php
@@ -1,0 +1,126 @@
+<?php
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\ManagerBundle\Tests\EventListener;
+
+use Contao\BackendUser;
+use Contao\CoreBundle\Event\MenuEvent;
+use Contao\CoreBundle\Tests\TestCase;
+use Contao\ManagerBundle\EventListener\BackendMenuListener;
+use Knp\Menu\FactoryInterface;
+use Knp\Menu\ItemInterface;
+use Knp\Menu\MenuItem;
+use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+
+class BackendMenuListenerTest extends TestCase
+{
+    /**
+     * @var TokenStorageInterface
+     */
+    private $tokenStorage;
+
+    /**
+     * @var ItemInterface
+     */
+    private $tree;
+
+    /**
+     * @var MenuItem|MockObject
+     */
+    private $systemNode;
+
+    /**
+     * @var FactoryInterface|MockObject
+     */
+    private $factory;
+
+    /**
+     * @var \Contao\BackendUser
+     */
+    private $backendUser;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->tokenStorage = $this->createMock(TokenStorageInterface::class);
+        $this->factory      = $this->createMock(FactoryInterface::class);
+        $this->tree         = new MenuItem('root', $this->factory);
+
+        $this->factory->method('createItem')->willReturnCallback(
+            function (string $name) {
+                return new MenuItem($name, $this->factory);
+            }
+        );
+
+        $this->systemNode = $this->createPartialMock(MenuItem::class, ['addChild', 'getName']);
+        $this->systemNode->method('getName')->willReturn('system');
+
+        $this->backendUser = $this->createPartialMock(BackendUser::class, ['__get']);
+
+        $token = $this->createMock(TokenInterface::class);
+        $token->method('getUser')->willReturn($this->backendUser);
+
+        $this->tokenStorage->method('getToken')->willReturn($token);
+
+        $this->tree->addChild($this->factory->createItem('system'));
+    }
+
+    public function testContaoManagerBackendNavItemIsAddedForAdminUser(): void
+    {
+        $listener = new BackendMenuListener($this->tokenStorage, 'contao-manager.phar.php');
+        $event    = new MenuEvent($this->factory, $this->tree);
+
+        $this->backendUser->method('__get')->with('isAdmin')->willReturn(true);
+
+        $this->tree->addChild($this->systemNode);
+
+        $this->systemNode
+            ->expects($this->once())
+            ->method('addChild');
+
+        $listener->onBuild($event);
+    }
+
+    public function testContaoManagerBackendNavItemIsNotAddedForNonAdminUser(): void
+    {
+        $listener = new BackendMenuListener($this->tokenStorage, 'contao-manager.phar.php');
+        $event    = new MenuEvent($this->factory, $this->tree);
+
+        $this->backendUser->method('__get')->with('isAdmin')->willReturn(false);
+
+        $this->tree->addChild($this->systemNode);
+
+        $this->systemNode
+            ->expects($this->never())
+            ->method('addChild');
+
+        $listener->onBuild($event);
+    }
+
+    public function testContaoManagerBackendNavItemIsNotAddedForMissingConfig(): void
+    {
+        $listener = new BackendMenuListener($this->tokenStorage, null);
+        $event    = new MenuEvent($this->factory, $this->tree);
+
+        $this->backendUser->method('__get')->with('isAdmin')->willReturn(true);
+
+        $this->tree->addChild($this->systemNode);
+
+        $this->systemNode
+            ->expects($this->never())
+            ->method('addChild');
+
+        $listener->onBuild($event);
+    }
+}

--- a/manager-bundle/tests/EventListener/BackendMenuListenerTest.php
+++ b/manager-bundle/tests/EventListener/BackendMenuListenerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /*
@@ -49,77 +50,103 @@ class BackendMenuListenerTest extends TestCase
      */
     private $backendUser;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
-        $this->tokenStorage = $this->createMock(TokenStorageInterface::class);
-        $this->factory      = $this->createMock(FactoryInterface::class);
-        $this->tree         = new MenuItem('root', $this->factory);
-
-        $this->factory->method('createItem')->willReturnCallback(
-            function (string $name) {
-                return new MenuItem($name, $this->factory);
-            }
-        );
+        $this->factory = $this->createMock(FactoryInterface::class);
+        $this->factory
+            ->method('createItem')
+            ->willReturnCallback(
+                function (string $name) {
+                    return new MenuItem($name, $this->factory);
+                }
+            )
+        ;
 
         $this->systemNode = $this->createPartialMock(MenuItem::class, ['addChild', 'getName']);
-        $this->systemNode->method('getName')->willReturn('system');
+        $this->systemNode
+            ->method('getName')
+            ->willReturn('system')
+        ;
 
         $this->backendUser = $this->createPartialMock(BackendUser::class, ['__get']);
 
         $token = $this->createMock(TokenInterface::class);
-        $token->method('getUser')->willReturn($this->backendUser);
+        $token
+            ->method('getUser')
+            ->willReturn($this->backendUser)
+        ;
 
-        $this->tokenStorage->method('getToken')->willReturn($token);
+        $this->tokenStorage = $this->createMock(TokenStorageInterface::class);
+        $this->tokenStorage
+            ->method('getToken')
+            ->willReturn($token)
+        ;
 
+        $this->tree = new MenuItem('root', $this->factory);
         $this->tree->addChild($this->factory->createItem('system'));
     }
 
     public function testContaoManagerBackendNavItemIsAddedForAdminUser(): void
     {
+        $event = new MenuEvent($this->factory, $this->tree);
         $listener = new BackendMenuListener($this->tokenStorage, 'contao-manager.phar.php');
-        $event    = new MenuEvent($this->factory, $this->tree);
 
-        $this->backendUser->method('__get')->with('isAdmin')->willReturn(true);
+        $this->backendUser
+            ->method('__get')
+            ->with('isAdmin')
+            ->willReturn(true)
+        ;
 
         $this->tree->addChild($this->systemNode);
 
         $this->systemNode
             ->expects($this->once())
-            ->method('addChild');
+            ->method('addChild')
+        ;
 
         $listener->onBuild($event);
     }
 
     public function testContaoManagerBackendNavItemIsNotAddedForNonAdminUser(): void
     {
+        $event = new MenuEvent($this->factory, $this->tree);
         $listener = new BackendMenuListener($this->tokenStorage, 'contao-manager.phar.php');
-        $event    = new MenuEvent($this->factory, $this->tree);
 
-        $this->backendUser->method('__get')->with('isAdmin')->willReturn(false);
+        $this->backendUser
+            ->method('__get')
+            ->with('isAdmin')
+            ->willReturn(false)
+        ;
 
         $this->tree->addChild($this->systemNode);
 
         $this->systemNode
             ->expects($this->never())
-            ->method('addChild');
+            ->method('addChild')
+        ;
 
         $listener->onBuild($event);
     }
 
     public function testContaoManagerBackendNavItemIsNotAddedForMissingConfig(): void
     {
+        $event = new MenuEvent($this->factory, $this->tree);
         $listener = new BackendMenuListener($this->tokenStorage, null);
-        $event    = new MenuEvent($this->factory, $this->tree);
 
-        $this->backendUser->method('__get')->with('isAdmin')->willReturn(true);
+        $this->backendUser
+            ->method('__get')
+            ->with('isAdmin')
+            ->willReturn(true)
+        ;
 
         $this->tree->addChild($this->systemNode);
 
         $this->systemNode
             ->expects($this->never())
-            ->method('addChild');
+            ->method('addChild')
+        ;
 
         $listener->onBuild($event);
     }


### PR DESCRIPTION
This is the follow up PR for https://github.com/contao/contao/issues/26 and automatically adds a link to the Contao manager in the backend navigation for admin users.

Marked as WIP as unit tests yet missing. 

Some questions which might be discussed in the meantime:
 - Should the label "Contao Manager" be translated or is it treated as a trade name?
 - Atm the link is not added if the system group is not available. Should it be created otherwise?
 - Link is added with a target attribute. Don't mind to remove it again.
 - Any idea how to test the configuration (it checks if the configured file exists)?