### PR TITLE
add timestamp to all calendar cells

### DIFF
--- a/calendar-bundle/src/Resources/contao/modules/ModuleCalendar.php
+++ b/calendar-bundle/src/Resources/contao/modules/ModuleCalendar.php
@@ -239,6 +239,9 @@ class ModuleCalendar extends Events
 			$strClass = ($intCurrentDay < 2) ? ' weekend' : '';
 			$strClass .= ($i == 1 || $i == 8 || $i == 15 || $i == 22 || $i == 29 || $i == 36) ? ' col_first' : '';
 			$strClass .= ($i == 7 || $i == 14 || $i == 21 || $i == 28 || $i == 35 || $i == 42) ? ' col_last' : '';
+			
+			// Add timestamp to all cells
+			$arrDays[$strWeekClass][$i]['timestamp'] = strtotime(($intDay - 1) . ' day', $this->Date->monthBegin);
 
 			// Empty cell
 			if ($intDay < 1 || $intDay > $intDaysInMonth)


### PR DESCRIPTION
Whenever I have to use the calendar module for a website, the layout/design concept usually requires additional information to be shown in the calendar, e.g. days of previous and following months or week numbers for example. 

However, currently this is pretty tedious to implement. You either have to use ugly code within the calendar template or duplicate some core module code for your own calendar module.

It would be a lot easier, if each cell already had a timestamp, with which you can simply do anything you want.