### PR TITLE
[WIP] Access data container definitions without globals

### DIFF
--- a/core-bundle/src/DataContainer/DefinitionInterface.php
+++ b/core-bundle/src/DataContainer/DefinitionInterface.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\DataContainer;
+
+/**
+ * Interface DefinitionInterface
+ *
+ * @package Contao\CoreBundle\DataContainer
+ */
+interface DefinitionInterface
+{
+    /**
+     * Get the name of the definition. The name is usually the table name.
+     */
+    public function getName(): string;
+
+    /**
+     * Check if a configuration path exist.
+     */
+    public function has(array $path): bool;
+
+    /**
+     * Get an value from a path. Return default of value does not exist.
+     */
+    public function get(array $path, $default = null);
+
+    /**
+     * Set a value to a specific path. Each node in the path have to be an array or must not exist.
+     */
+    public function set(array $path, $value);
+
+    /**
+     * Get the value from a path and modify it with an callback. The callback has to return the modified value.
+     */
+    public function modify($path, callable $callback): void;
+}

--- a/core-bundle/src/DataContainer/DefinitionManagerInterface.php
+++ b/core-bundle/src/DataContainer/DefinitionManagerInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\DataContainer;
+
+/**
+ * The definition manager is responsible to manage all data container definitions.
+ */
+interface DefinitionManagerInterface
+{
+    /**
+     * Get the data container definition by name.
+     */
+    public function getDefinition(string $name, bool $ignoreCache = false): DefinitionInterface;
+
+    /**
+     * Check if definition exist.
+     */
+    public function hasDefinition(string $name): bool;
+}


### PR DESCRIPTION
The goal of this pull request is to implement a solution to access the data container definitions (dca) from a service.

**Why**
Atm you have to access the globals `$GLOBALS['TL_DCA']` to access the dca definitions. Relying on global states makes it hard to write scenarious/specs/test for code based on definitions. Furthermore get rid of the globals in the future is not possible without providing a new way to access the information. 

**Proposed solution**

- This proposed solution allows to deprecate globals access by providing an `DefinitionManager` as the new locator for data container definitions. 
- The `Definition` does not provide any explicit data structure so that changing the dca structure in the future will be possible. Maybe adding a version number would allow to work on `v2` of the dca structure.
 - Atm I use an array type of the definition path. Supporting dot separated strings might be possible as 
well.

**Current state**
 I don't know if there are any plans/roadmap how to work on this area. That's why I just provide the interfaces now, so I will know if it's worth to go further.

 - [x] Provide interfaces as basis for discussion
 - [ ] Provide implementation for globals based 

**Example**
```php
$definition = $this->definitionManger->getDefinition('tl_content');
$definition->modify(
    ['list', 'operations'],
    function ($operations) {
        unset($operations['edit']);

        return $operations;
    }
);
```


