### PR TITLE
Hash the autologin token in the database

### DIFF
--- a/core-bundle/src/Resources/config/services.yml
+++ b/core-bundle/src/Resources/config/services.yml
@@ -380,6 +380,7 @@ services:
         class: Contao\CoreBundle\Security\Authentication\RememberMe\DatabaseTokenProvider
         arguments:
             - "@database_connection"
+            - "%kernel.secret%"
 
     contao.security.backend_user_provider:
         class: Contao\CoreBundle\Security\User\ContaoUserProvider

--- a/core-bundle/src/Security/Authentication/RememberMe/DatabaseTokenProvider.php
+++ b/core-bundle/src/Security/Authentication/RememberMe/DatabaseTokenProvider.php
@@ -25,9 +25,15 @@ class DatabaseTokenProvider implements TokenProviderInterface
      */
     private $connection;
 
-    public function __construct(Connection $connection)
+    /**
+     * @var string
+     */
+    private $secret;
+
+    public function __construct(Connection $connection, string $secret)
     {
         $this->connection = $connection;
+        $this->secret = $secret;
     }
 
     /**
@@ -45,7 +51,7 @@ class DatabaseTokenProvider implements TokenProviderInterface
         ';
 
         $values = [
-            'series' => $series,
+            'series' => hash_hmac('sha256', $series, $this->secret),
         ];
 
         $types = [
@@ -74,7 +80,7 @@ class DatabaseTokenProvider implements TokenProviderInterface
         ';
 
         $values = [
-            'series' => $series,
+            'series' => hash_hmac('sha256', $series, $this->secret),
         ];
 
         $types = [
@@ -101,7 +107,7 @@ class DatabaseTokenProvider implements TokenProviderInterface
         $values = [
             'value' => $tokenValue,
             'lastUsed' => $lastUsed,
-            'series' => $series,
+            'series' => hash_hmac('sha256', $series, $this->secret),
         ];
 
         $types = [
@@ -133,7 +139,7 @@ class DatabaseTokenProvider implements TokenProviderInterface
         $values = [
             'class' => $token->getClass(),
             'username' => $token->getUsername(),
-            'series' => $token->getSeries(),
+            'series' => hash_hmac('sha256', $token->getSeries(), $this->secret),
             'value' => $token->getTokenValue(),
             'lastUsed' => $token->getLastUsed(),
         ];

--- a/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
+++ b/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
@@ -81,6 +81,7 @@ use Contao\CoreBundle\Security\Authentication\AuthenticationFailureHandler;
 use Contao\CoreBundle\Security\Authentication\AuthenticationSuccessHandler;
 use Contao\CoreBundle\Security\Authentication\FrontendPreviewAuthenticator;
 use Contao\CoreBundle\Security\Authentication\Provider\AuthenticationProvider;
+use Contao\CoreBundle\Security\Authentication\RememberMe\DatabaseTokenProvider;
 use Contao\CoreBundle\Security\Authentication\Token\TokenChecker;
 use Contao\CoreBundle\Security\Logout\LogoutHandler;
 use Contao\CoreBundle\Security\Logout\LogoutSuccessHandler;
@@ -1320,6 +1321,18 @@ class ContaoCoreExtensionTest extends TestCase
         $this->assertSame('security.http_utils', (string) $definition->getArgument(0));
         $this->assertSame('contao.framework', (string) $definition->getArgument(1));
         $this->assertSame('logger', (string) $definition->getArgument(2));
+    }
+
+    public function testRegistersTheSecurityDatabaseTokenProvider(): void
+    {
+        $this->assertTrue($this->container->has('contao.security.database_token_provider'));
+
+        $definition = $this->container->getDefinition('contao.security.database_token_provider');
+
+        $this->assertSame(DatabaseTokenProvider::class, $definition->getClass());
+        $this->assertTrue($definition->isPrivate());
+        $this->assertSame('database_connection', (string) $definition->getArgument(0));
+        $this->assertSame('%kernel.secret%', (string) $definition->getArgument(1));
     }
 
     public function testRegistersTheSecurityBackendUserProvider(): void

--- a/core-bundle/tests/Security/Authentication/RememberMe/DatabaseTokenProviderTest.php
+++ b/core-bundle/tests/Security/Authentication/RememberMe/DatabaseTokenProviderTest.php
@@ -25,7 +25,7 @@ class DatabaseTokenProviderTest extends TestCase
 {
     public function testCanBeInstantiated(): void
     {
-        $provider = new DatabaseTokenProvider($this->createMock(Connection::class));
+        $provider = new DatabaseTokenProvider($this->createMock(Connection::class), 'secret');
 
         $this->assertInstanceOf(
             'Contao\CoreBundle\Security\Authentication\RememberMe\DatabaseTokenProvider',
@@ -74,7 +74,7 @@ class DatabaseTokenProviderTest extends TestCase
             ->willReturn($stmt)
         ;
 
-        $provider = new DatabaseTokenProvider($connection);
+        $provider = new DatabaseTokenProvider($connection, 'secret');
         $token = $provider->loadTokenBySeries('series');
 
         $this->assertInstanceOf('Contao\CoreBundle\Security\Authentication\RememberMe\PersistentToken', $token);
@@ -101,7 +101,7 @@ class DatabaseTokenProviderTest extends TestCase
             ->willReturn($stmt)
         ;
 
-        $provider = new DatabaseTokenProvider($connection);
+        $provider = new DatabaseTokenProvider($connection, 'secret');
 
         $this->expectException(TokenNotFoundException::class);
 
@@ -132,7 +132,7 @@ class DatabaseTokenProviderTest extends TestCase
             ->with($sql, $values, $types)
         ;
 
-        $provider = new DatabaseTokenProvider($connection);
+        $provider = new DatabaseTokenProvider($connection, 'secret');
         $provider->deleteTokenBySeries('series');
     }
 
@@ -169,7 +169,7 @@ class DatabaseTokenProviderTest extends TestCase
             ->willReturn(1)
         ;
 
-        $provider = new DatabaseTokenProvider($connection);
+        $provider = new DatabaseTokenProvider($connection, 'secret');
         $provider->updateToken('series', 'value', $dateTime);
 
         $this->addToAssertionCount(1); // does not throw an exception
@@ -184,7 +184,7 @@ class DatabaseTokenProviderTest extends TestCase
             ->willReturn(0)
         ;
 
-        $provider = new DatabaseTokenProvider($connection);
+        $provider = new DatabaseTokenProvider($connection, 'secret');
 
         $this->expectException(TokenNotFoundException::class);
 
@@ -227,7 +227,7 @@ class DatabaseTokenProviderTest extends TestCase
             ->willReturn(1)
         ;
 
-        $provider = new DatabaseTokenProvider($connection);
+        $provider = new DatabaseTokenProvider($connection, 'secret');
         $provider->createNewToken($token);
     }
 }

--- a/core-bundle/tests/Security/Authentication/RememberMe/DatabaseTokenProviderTest.php
+++ b/core-bundle/tests/Security/Authentication/RememberMe/DatabaseTokenProviderTest.php
@@ -45,7 +45,7 @@ class DatabaseTokenProviderTest extends TestCase
         ';
 
         $values = [
-            'series' => 'series',
+            'series' => hash_hmac('sha256', 'series', 'secret'),
         ];
 
         $types = [
@@ -118,7 +118,7 @@ class DatabaseTokenProviderTest extends TestCase
         ';
 
         $values = [
-            'series' => 'series',
+            'series' => hash_hmac('sha256', 'series', 'secret'),
         ];
 
         $types = [
@@ -152,7 +152,7 @@ class DatabaseTokenProviderTest extends TestCase
         $values = [
             'value' => 'value',
             'lastUsed' => $dateTime,
-            'series' => 'series',
+            'series' => hash_hmac('sha256', 'series', 'secret'),
         ];
 
         $types = [
@@ -206,7 +206,7 @@ class DatabaseTokenProviderTest extends TestCase
         $values = [
             'class' => $token->getClass(),
             'username' => $token->getUsername(),
-            'series' => $token->getSeries(),
+            'series' => hash_hmac('sha256', $token->getSeries(), 'secret'),
             'value' => $token->getTokenValue(),
             'lastUsed' => $token->getLastUsed(),
         ];


### PR DESCRIPTION
This PR implements contao/core#8888 for Contao 4.6. Thanks to our database token provider, the implementation was not too hard. 😄 