### PR TITLE
Make sure that the DoctrineMigrations diff command we override is set to public

### DIFF
--- a/core-bundle/src/DependencyInjection/Compiler/DoctrineMigrationsPass.php
+++ b/core-bundle/src/DependencyInjection/Compiler/DoctrineMigrationsPass.php
@@ -38,6 +38,7 @@ class DoctrineMigrationsPass implements CompilerPassInterface
         $command = new Definition(DoctrineMigrationsDiffCommand::class);
         $command->setArguments([$provider]);
         $command->addTag('console.command');
+        $command->setPublic(true);
 
         $container->setDefinition(DoctrineMigrationsDiffCommand::COMMAND_ID, $command);
 

--- a/core-bundle/tests/DependencyInjection/Compiler/DoctrineMigrationsPassTest.php
+++ b/core-bundle/tests/DependencyInjection/Compiler/DoctrineMigrationsPassTest.php
@@ -40,6 +40,7 @@ class DoctrineMigrationsPassTest extends TestCase
         $pass->process($container);
 
         $this->assertTrue($container->hasDefinition(DoctrineMigrationsDiffCommand::COMMAND_ID));
+        $this->assertTrue($container->getDefinition(DoctrineMigrationsDiffCommand::COMMAND_ID)->isPublic());
     }
 
     public function testDoesNotAddTheDefinitionIfTheMigrationsBundleIsNotInstalled(): void


### PR DESCRIPTION
We use DoctrineMigrations and after updating to 4.6 we noticed the following error:

![2018-09-26 at 09 51](https://user-images.githubusercontent.com/193483/46066723-6d118800-c175-11e8-93ee-c02b3254316b.png)

I am not sure but 4.4 can also be affected, so that's why I decided to base the fix on LTS branch.

Do we also need to update the unit tests here?