### PR TITLE
Check for innodb_file_format only if the innodb_file_per_table variable is enabled

### DIFF
--- a/core-bundle/src/Doctrine/Schema/DcaSchemaProvider.php
+++ b/core-bundle/src/Doctrine/Schema/DcaSchemaProvider.php
@@ -408,20 +408,22 @@ class DcaSchemaProvider
             ->fetch(\PDO::FETCH_OBJ)
         ;
 
-        // Check for innodb_file_format only if the innodb_file_per_table variable is enabled
-        if (\in_array(strtolower((string) $filePerTable->Value), ['1', 'on'], true)) {
-            $fileFormat = $this->doctrine
-                ->getConnection()
-                ->query("SHOW VARIABLES LIKE 'innodb_file_format'")
-                ->fetch(\PDO::FETCH_OBJ)
-            ;
+        // The innodb_file_per_table option is disabled
+        if (!\in_array(strtolower((string) $filePerTable->Value), ['1', 'on'], true)) {
+            return 767;
+        }
 
-            if (
-                'barracuda' === strtolower((string) $fileFormat->Value)
-                && \in_array(strtolower((string) $largePrefix->Value), ['1', 'on'], true)
-            ) {
-                return 3072;
-            }
+        $fileFormat = $this->doctrine
+            ->getConnection()
+            ->query("SHOW VARIABLES LIKE 'innodb_file_format'")
+            ->fetch(\PDO::FETCH_OBJ)
+        ;
+
+        if (
+            'barracuda' === strtolower((string) $fileFormat->Value)
+            && \in_array(strtolower((string) $largePrefix->Value), ['1', 'on'], true)
+        ) {
+            return 3072;
         }
 
         return 767;

--- a/core-bundle/src/Doctrine/Schema/DcaSchemaProvider.php
+++ b/core-bundle/src/Doctrine/Schema/DcaSchemaProvider.php
@@ -402,17 +402,26 @@ class DcaSchemaProvider
             return 3072;
         }
 
-        $fileFormat = $this->doctrine
+        $filePerTable = $this->doctrine
             ->getConnection()
-            ->query("SHOW VARIABLES LIKE 'innodb_file_format'")
+            ->query("SHOW VARIABLES LIKE 'innodb_file_per_table'")
             ->fetch(\PDO::FETCH_OBJ)
         ;
 
-        if (
-            'barracuda' === strtolower((string) $fileFormat->Value)
-            && \in_array(strtolower((string) $largePrefix->Value), ['1', 'on'], true)
-        ) {
-            return 3072;
+        // Check for innodb_file_format only if the innodb_file_per_table variable is enabled
+        if (\in_array(strtolower((string) $filePerTable->Value), ['1', 'on'], true)) {
+            $fileFormat = $this->doctrine
+                ->getConnection()
+                ->query("SHOW VARIABLES LIKE 'innodb_file_format'")
+                ->fetch(\PDO::FETCH_OBJ)
+            ;
+
+            if (
+                'barracuda' === strtolower((string) $fileFormat->Value)
+                && \in_array(strtolower((string) $largePrefix->Value), ['1', 'on'], true)
+            ) {
+                return 3072;
+            }
         }
 
         return 767;

--- a/core-bundle/tests/Doctrine/Schema/DcaSchemaProviderTest.php
+++ b/core-bundle/tests/Doctrine/Schema/DcaSchemaProviderTest.php
@@ -395,34 +395,18 @@ class DcaSchemaProviderTest extends DoctrineTestCase
 
             // Large prefixes ENABLED, file per table DISABLED
             [null, 'ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE utf8_unicode_ci', 'On', 'Off'],
-            [191, 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci', 'On', 'Off'],
-
-            // Large prefixes ENABLED, file per table DISABLED
-            [null, 'ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE utf8_unicode_ci', 'On', '0'],
             [191, 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci', 'On', '0'],
 
             // Large prefixes ENABLED, file per table DISABLED, file system PROVIDED
-            [null, 'ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE utf8_unicode_ci', 'On', '0', 'barracuda'],
-            [191, 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci', 'On', '0', 'barracuda'],
-
-            // Large prefixes ENABLED, file per table DISABLED, file system PROVIDED
             [null, 'ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE utf8_unicode_ci', 'On', 'Off', 'barracuda'],
-            [191, 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci', 'On', 'Off', 'barracuda'],
+            [191, 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci', 'On', '0', 'barracuda'],
 
             // Large prefixes ENABLED, file per table ENABLED
             [null, 'ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE utf8_unicode_ci', 'On', 'On'],
-            [191, 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci', 'On', 'On'],
-
-            // Large prefixes ENABLED, file per table ENABLED
-            [null, 'ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE utf8_unicode_ci', 'On', '1'],
             [191, 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci', 'On', '1'],
 
             // Large prefixes ENABLED, file per table ENABLED, file system PROVIDED
             [null, 'ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE utf8_unicode_ci', 'On', 'On', 'barracuda'],
-            [null, 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci', 'On', 'On', 'barracuda'],
-
-            // Large prefixes ENABLED, file per table ENABLED, file system PROVIDED
-            [null, 'ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE utf8_unicode_ci', 'On', '1', 'barracuda'],
             [null, 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci', 'On', '1', 'barracuda'],
         ];
     }

--- a/core-bundle/tests/Doctrine/Schema/DcaSchemaProviderTest.php
+++ b/core-bundle/tests/Doctrine/Schema/DcaSchemaProviderTest.php
@@ -326,13 +326,14 @@ class DcaSchemaProviderTest extends DoctrineTestCase
     /**
      * @dataProvider getIndexes
      */
-    public function testAddsTheIndexLength(?int $expected, string $tableOptions, string $largePrefixes = '', string $fileSystem = 'antelope'): void
+    public function testAddsTheIndexLength(?int $expected, string $tableOptions, string $largePrefixes = '', string $filePerTable = '', string $fileSystem = 'antelope'): void
     {
         $statement = $this->createMock(Statement::class);
         $statement
             ->method('fetch')
             ->willReturnOnConsecutiveCalls(
                 (object) ['Value' => $largePrefixes],
+                (object) ['Value' => $filePerTable],
                 (object) ['Value' => $fileSystem]
             )
         ;
@@ -380,14 +381,49 @@ class DcaSchemaProviderTest extends DoctrineTestCase
     public function getIndexes(): array
     {
         return [
+            // Default
             [null, 'ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE utf8_unicode_ci'],
             [250, 'ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci'],
+
+            // Large prefixes DISABLED
             [null, 'ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE utf8_unicode_ci', 'Off'],
             [191, 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci', '0'],
+
+            // Large prefixes ENABLED
             [null, 'ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE utf8_unicode_ci', 'On'],
             [191, 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci', '1'],
-            [null, 'ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE utf8_unicode_ci', 'On', 'barracuda'],
-            [null, 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci', '1', 'barracuda'],
+
+            // Large prefixes ENABLED, file per table DISABLED
+            [null, 'ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE utf8_unicode_ci', 'On', 'Off'],
+            [191, 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci', 'On', 'Off'],
+
+            // Large prefixes ENABLED, file per table DISABLED
+            [null, 'ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE utf8_unicode_ci', 'On', '0'],
+            [191, 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci', 'On', '0'],
+
+            // Large prefixes ENABLED, file per table DISABLED, file system PROVIDED
+            [null, 'ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE utf8_unicode_ci', 'On', '0', 'barracuda'],
+            [191, 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci', 'On', '0', 'barracuda'],
+
+            // Large prefixes ENABLED, file per table DISABLED, file system PROVIDED
+            [null, 'ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE utf8_unicode_ci', 'On', 'Off', 'barracuda'],
+            [191, 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci', 'On', 'Off', 'barracuda'],
+
+            // Large prefixes ENABLED, file per table ENABLED
+            [null, 'ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE utf8_unicode_ci', 'On', 'On'],
+            [191, 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci', 'On', 'On'],
+
+            // Large prefixes ENABLED, file per table ENABLED
+            [null, 'ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE utf8_unicode_ci', 'On', '1'],
+            [191, 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci', 'On', '1'],
+
+            // Large prefixes ENABLED, file per table ENABLED, file system PROVIDED
+            [null, 'ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE utf8_unicode_ci', 'On', 'On', 'barracuda'],
+            [null, 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci', 'On', 'On', 'barracuda'],
+
+            // Large prefixes ENABLED, file per table ENABLED, file system PROVIDED
+            [null, 'ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE utf8_unicode_ci', 'On', '1', 'barracuda'],
+            [null, 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci', 'On', '1', 'barracuda'],
         ];
     }
 


### PR DESCRIPTION
With @Toflar we had troubles updating the Contao 4.5 database to 4.6 and being more explicit it was about the index column size being too large:

```
Message: "An exception occurred while executing 'ALTER TABLE tl_files ENGINE = InnoDB ROW_FORMAT = DYNAMIC':  SQLSTATE[HY000]: General error: 1709 Index column size too large. The maximum column size is 767 bytes.
```

It's not only the `tl_files.path` index that was causing the error but also all the others with length of 255, e.g. `tl_member.email` caused this error:

```
Doctrine\DBAL\Exception\DriverException: An exception occurred while executing 'ALTER TABLE tl_member CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci':
PDOException: SQLSTATE[HY000]: General error: 1709 Index column size too large. The maximum column size is 767 bytes.
```

We have dropped faulty indexes and then the switch to InnoDB engine was successful. However when Contao tried to re-create them, the error arose again. What we have found out is that for the MySQL version we are using (maybe for others as well, not sure about that) the `innodb_file_per_table` variable must be enabled for large indexes. Thus if it is not, the default index length should be 767 bytes.

Our MySQL server version is: 5.5.5-10.0.34-MariaDB

Also see: https://stackoverflow.com/a/43403017/3628692

**I will add the necessary unit tests if you first approve this commit.**