### PR TITLE
Disable the phar stream wrapper

### DIFF
--- a/manager-bundle/src/Resources/system/initialize.php
+++ b/manager-bundle/src/Resources/system/initialize.php
@@ -9,6 +9,11 @@ if (!defined('TL_SCRIPT')) {
     die('Your script is not compatible with Contao 4.');
 }
 
+// Disable the phar stream wrapper for security reasons (see #105)
+if (\in_array('phar', stream_get_wrappers(), true)) {
+    stream_wrapper_unregister('phar');
+}
+
 /** @var Composer\Autoload\ClassLoader */
 $loader = require __DIR__.'/../vendor/autoload.php';
 

--- a/manager-bundle/src/Resources/web/app.php
+++ b/manager-bundle/src/Resources/web/app.php
@@ -16,6 +16,11 @@ use Symfony\Component\HttpFoundation\Request;
 // Suppress error messages (see #1422)
 @ini_set('display_errors', 0);
 
+// Disable the phar stream wrapper for security reasons (see #105)
+if (\in_array('phar', stream_get_wrappers(), true)) {
+    stream_wrapper_unregister('phar');
+}
+
 /** @var Composer\Autoload\ClassLoader */
 $loader = require __DIR__.'/../vendor/autoload.php';
 

--- a/manager-bundle/src/Resources/web/app_dev.php
+++ b/manager-bundle/src/Resources/web/app_dev.php
@@ -14,6 +14,11 @@ use Symfony\Component\Debug\Debug;
 use Symfony\Component\Dotenv\Dotenv;
 use Symfony\Component\HttpFoundation\Request;
 
+// Disable the phar stream wrapper for security reasons (see #105)
+if (\in_array('phar', stream_get_wrappers(), true)) {
+    stream_wrapper_unregister('phar');
+}
+
 /** @var Composer\Autoload\ClassLoader */
 $loader = require __DIR__.'/../vendor/autoload.php';
 


### PR DESCRIPTION
As of the newly discovered unserialization attack via the `phar://` stream wrapper ([Black Hat talk](https://www.blackhat.com/us-18/briefings/schedule/index.html#its-a-php-unserialization-vulnerability-jim-but-not-as-we-know-it-11078)), we should disable the phar stream wrapper for the whole application.

It should be noted that this is **only a preventive measure** and shouldn’t be considered a “fix” for this kind of attacks. **We must never pass user controlled values directly to any file operation functions without validating them.**

If anybody needs the stream wrapper for a specific use case in their project or extension, I think the following code snippet should be safe to use:

```php
if ($pharDisabled = !\in_array('phar', stream_get_wrappers(), true)) {
	stream_wrapper_restore('phar');
}
try {
	// Your code using phar://...
}
finally {
	if ($pharDisabled) {
		stream_wrapper_unregister('phar');
	}
}
```