### PR TITLE
add folder attribute if no label callback is used

### DIFF
--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -3899,7 +3899,7 @@ class DC_Table extends \DataContainer implements \listable, \editable
 		}
 		else
 		{
-			$return .= \Image::getHtml('iconPLAIN.svg', '') . ' ' . $label;
+			$return .= \Image::getHtml('iconPLAIN.svg', '', $folderAttribute) . ' ' . $label;
 		}
 
 		$return .= '</div> <div class="tl_right">';


### PR DESCRIPTION
If you are using list mode _5_ in your DCA (tree view) but don't use a custom label callback, the tree view will look off if you have mixed nodes with and without children. This is because in such a case Contao ignores its `$folderAttribute` variable which contains the `style="margin-left:20px"` for nodes that have no children, so that it looks in line with nodes that have children (and thus have the +/- in front of it).

Affects Contao 4.4 and 4.6.

/cc @srhinow this fixes the tree view for your theme content bundle