### PR TITLE
Fixed the potential no first page error in breadcrumb

### DIFF
--- a/core-bundle/src/Resources/contao/modules/ModuleBreadcrumb.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleBreadcrumb.php
@@ -88,7 +88,7 @@ class ModuleBreadcrumb extends \Module
 				'href'     => (($objFirstPage !== null) ? $objFirstPage->getFrontendUrl() : \Environment::get('base')),
 				'title'    => \StringUtil::specialchars($objPages->pageTitle ?: $objPages->title, true),
 				'link'     => $objPages->title,
-				'data'     => $objFirstPage->row(),
+				'data'     => (($objFirstPage !== null) ? $objFirstPage->row() : []),
 				'class'    => ''
 			);
 


### PR DESCRIPTION
Okay this one is a bit strange as we've got only one log in Sentry about this and I was not able to reproduce it myself. So the thing is that `$objFirstPage` in the breadcrumb could _potentially_ return a null value. We do check it when generating the frontend URL on line 88 but we don't for getting the row data.

Error log:

```
Error: Call to a member function row() on null
#36 vendor/contao/core-bundle/src/Resources/contao/modules/ModuleBreadcrumb.php(89): compile
#35 vendor/contao/core-bundle/src/Resources/contao/modules/Module.php(214): generate
#34 vendor/contao/core-bundle/src/Resources/contao/modules/ModuleBreadcrumb.php(48): generate
#33 vendor/contao/core-bundle/src/Resources/contao/library/Contao/Controller.php(326): getFrontendModule
…
```