### PR TITLE
Added support for routes in DCA operations

### DIFF
--- a/core-bundle/src/Resources/contao/classes/DataContainer.php
+++ b/core-bundle/src/Resources/contao/classes/DataContainer.php
@@ -805,11 +805,29 @@ abstract class DataContainer extends Backend
 			{
 				if ($k == 'show')
 				{
-					$return .= '<a href="'.$this->addToUrl($v['href'].'&amp;id='.$arrRow['id'].'&amp;popup=1').'" title="'.\StringUtil::specialchars($title).'" onclick="Backend.openModalIframe({\'title\':\''.\StringUtil::specialchars(str_replace("'", "\\'", sprintf($GLOBALS['TL_LANG'][$strTable]['show'][1], $arrRow['id']))).'\',\'url\':this.href});return false"'.$attributes.'>'.\Image::getHtml($v['icon'], $label).'</a> ';
+					if ($v['route'])
+					{
+						$href = \System::getContainer()->get('router')->generate($v['route'], ['id' => $arrRow['id'], 'popup' => '1']);
+					}
+					else
+					{
+						$href = $this->addToUrl($v['href'].'&amp;id='.$arrRow['id'].'&amp;popup=1');
+					}
+
+					$return .= '<a href="'.$href.'" title="'.\StringUtil::specialchars($title).'" onclick="Backend.openModalIframe({\'title\':\''.\StringUtil::specialchars(str_replace("'", "\\'", sprintf($GLOBALS['TL_LANG'][$strTable]['show'][1], $arrRow['id']))).'\',\'url\':this.href});return false"'.$attributes.'>'.\Image::getHtml($v['icon'], $label).'</a> ';
 				}
 				else
 				{
-					$return .= '<a href="'.$this->addToUrl($v['href'].'&amp;id='.$arrRow['id'].(\Input::get('nb') ? '&amp;nc=1' : '')).'" title="'.\StringUtil::specialchars($title).'"'.$attributes.'>'.\Image::getHtml($v['icon'], $label).'</a> ';
+					if ($v['route'])
+					{
+						$href = \System::getContainer()->get('router')->generate($v['route'], ['id' => $arrRow['id']]);
+					}
+					else
+					{
+						$href = $this->addToUrl($v['href'].'&amp;id='.$arrRow['id'].(\Input::get('nb') ? '&amp;nc=1' : ''));
+					}
+
+					$return .= '<a href="'.$href.'" title="'.\StringUtil::specialchars($title).'"'.$attributes.'>'.\Image::getHtml($v['icon'], $label).'</a> ';
 				}
 
 				continue;
@@ -902,7 +920,16 @@ abstract class DataContainer extends Backend
 				continue;
 			}
 
-			$return .= '<a href="'.$this->addToUrl($v['href']).'" class="'.$v['class'].'" title="'.\StringUtil::specialchars($title).'"'.$attributes.'>'.$label.'</a> ';
+			if ($v['route'])
+			{
+				$href = \System::getContainer()->get('router')->generate($v['route']);
+			}
+			else
+			{
+				$href = $this->addToUrl($v['href']);
+			}
+
+			$return .= '<a href="'.$href.'" class="'.$v['class'].'" title="'.\StringUtil::specialchars($title).'"'.$attributes.'>'.$label.'</a> ';
 		}
 
 		return $return;
@@ -974,11 +1001,29 @@ abstract class DataContainer extends Backend
 
 			if ($k == 'show')
 			{
-				$return .= '<a href="'.$this->addToUrl($v['href'].'&amp;id='.$arrRow['id'].'&amp;popup=1').'" title="'.\StringUtil::specialchars($title).'" onclick="Backend.openModalIframe({\'title\':\''.\StringUtil::specialchars(str_replace("'", "\\'", sprintf($GLOBALS['TL_LANG'][$strPtable]['show'][1], $arrRow['id']))).'\',\'url\':this.href});return false"'.$attributes.'>'.\Image::getHtml($v['icon'], $label).'</a> ';
+				if ($v['route'])
+				{
+					$href = \System::getContainer()->get('router')->generate($v['route'], ['id' => $arrRow['id'], 'popup' => '1']);
+				}
+				else
+				{
+					$href = $this->addToUrl($v['href'].'&amp;id='.$arrRow['id'].'&amp;popup=1');
+				}
+
+				$return .= '<a href="'.$href.'" title="'.\StringUtil::specialchars($title).'" onclick="Backend.openModalIframe({\'title\':\''.\StringUtil::specialchars(str_replace("'", "\\'", sprintf($GLOBALS['TL_LANG'][$strPtable]['show'][1], $arrRow['id']))).'\',\'url\':this.href});return false"'.$attributes.'>'.\Image::getHtml($v['icon'], $label).'</a> ';
 			}
 			else
 			{
-				$return .= '<a href="'.$this->addToUrl($v['href'].'&amp;id='.$arrRow['id'].(\Input::get('nb') ? '&amp;nc=1' : '')).'" title="'.\StringUtil::specialchars($title).'"'.$attributes.'>'.\Image::getHtml($v['icon'], $label).'</a> ';
+				if ($v['route'])
+				{
+					$href = \System::getContainer()->get('router')->generate($v['route'], ['id' => $arrRow['id']]);
+				}
+				else
+				{
+					$href = $this->addToUrl($v['href'].'&amp;id='.$arrRow['id'].(\Input::get('nb') ? '&amp;nc=1' : ''));
+				}
+
+				$return .= '<a href="'.$href.'" title="'.\StringUtil::specialchars($title).'"'.$attributes.'>'.\Image::getHtml($v['icon'], $label).'</a> ';
 			}
 		}
 


### PR DESCRIPTION
Use routes in DCA operations and global operations. Useful if you use the new backend controller feature.

```php
$GLOBALS['TL_DCA']['tl_my_table']['list']['operations']['foo'] => [
	'label'	=> &$GLOBALS['TL_LANG']['tl_my_table']['foo'],
//	'href'	=> 'key=foo',
	'route'	=> 'my_bundle.custom_route',
	'icon'	=> 'foo.svg'
]
```