### PR TITLE
[RTM] Added voter that checks BackendUser::hasAccess

### DIFF
--- a/core-bundle/src/Security/Voter/BackendAccessVoter.php
+++ b/core-bundle/src/Security/Voter/BackendAccessVoter.php
@@ -5,7 +5,6 @@ namespace Contao\CoreBundle\Security\Voter;
 use Contao\BackendUser;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\Voter;
-use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
 class BackendAccessVoter extends Voter
 {
@@ -14,7 +13,7 @@ class BackendAccessVoter extends Voter
      */
     protected function supports($attribute, $subject)
     {
-        return 0 === strpos($attribute, 'contao_user.') && (\is_scalar($subject) || \is_array($subject));
+        return 0 === strpos($attribute, 'contao_user.');
     }
 
     /**
@@ -23,12 +22,12 @@ class BackendAccessVoter extends Voter
     protected function voteOnAttribute($attribute, $subject, TokenInterface $token)
     {
         $user = $token->getUser();
-        [$table, $field] = explode('.', $attribute, 2);
+        [,$field] = explode('.', $attribute, 2);
 
-        if (!$user instanceof BackendUser || 'contao_user' !== $table) {
-            return VoterInterface::ACCESS_ABSTAIN;
+        if (!$user instanceof BackendUser || (!\is_scalar($subject) && !\is_array($subject))) {
+            return false;
         }
 
-        return $user->hasAccess($subject, $field) ? VoterInterface::ACCESS_GRANTED : VoterInterface::ACCESS_DENIED;
+        return $user->hasAccess($subject, $field);
     }
 }

--- a/core-bundle/src/Security/Voter/BackendAccessVoter.php
+++ b/core-bundle/src/Security/Voter/BackendAccessVoter.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Contao\CoreBundle\Security\Voter;
+
+use Contao\BackendUser;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+
+class BackendAccessVoter extends Voter
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function supports($attribute, $subject)
+    {
+        return 0 === strpos($attribute, 'contao_user.') && (\is_scalar($subject) || \is_array($subject));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function voteOnAttribute($attribute, $subject, TokenInterface $token)
+    {
+        $user = $token->getUser();
+        [$table, $field] = explode('.', $attribute, 2);
+
+        if (!$user instanceof BackendUser || 'contao_user' !== $table) {
+            return VoterInterface::ACCESS_ABSTAIN;
+        }
+
+        return $user->hasAccess($subject, $field) ? VoterInterface::ACCESS_GRANTED : VoterInterface::ACCESS_DENIED;
+    }
+}

--- a/core-bundle/src/Security/Voter/BackendAccessVoter.php
+++ b/core-bundle/src/Security/Voter/BackendAccessVoter.php
@@ -1,5 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
 namespace Contao\CoreBundle\Security\Voter;
 
 use Contao\BackendUser;
@@ -11,7 +21,7 @@ class BackendAccessVoter extends Voter
     /**
      * {@inheritdoc}
      */
-    protected function supports($attribute, $subject)
+    protected function supports($attribute, $subject): bool
     {
         return 0 === strpos($attribute, 'contao_user.');
     }
@@ -19,10 +29,10 @@ class BackendAccessVoter extends Voter
     /**
      * {@inheritdoc}
      */
-    protected function voteOnAttribute($attribute, $subject, TokenInterface $token)
+    protected function voteOnAttribute($attribute, $subject, TokenInterface $token): bool
     {
         $user = $token->getUser();
-        [,$field] = explode('.', $attribute, 2);
+        [, $field] = explode('.', $attribute, 2);
 
         if (!$user instanceof BackendUser || (!\is_scalar($subject) && !\is_array($subject))) {
             return false;

--- a/core-bundle/tests/Security/Voter/BackendAccessVoterTest.php
+++ b/core-bundle/tests/Security/Voter/BackendAccessVoterTest.php
@@ -25,14 +25,14 @@ class BackendAccessVoterTest extends TestCase
      */
     private $voter;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
         $this->voter = new BackendAccessVoter();
     }
 
-    public function testAbstainsNonContaoUserAttributes(): void
+    public function testAbstainsIfThereIsNoContaoUserAttribute(): void
     {
         $token = $this->createMock(TokenInterface::class);
         $attributes = ['foo', 'bar', 'contao.', 'contao_user_name'];
@@ -40,19 +40,19 @@ class BackendAccessVoterTest extends TestCase
         $this->assertSame(VoterInterface::ACCESS_ABSTAIN, $this->voter->vote($token, 'foo', $attributes));
     }
 
-    public function testVotesDeniedIfTokenDoesNotHaveABackendUser()
+    public function testDeniesAccessIfTheTokenDoesNotHaveABackendUser(): void
     {
         $token = $this->createMock(TokenInterface::class);
         $token
             ->expects($this->once())
             ->method('getUser')
-            ->willReturn('not a user')
+            ->willReturn(null)
         ;
 
         $this->assertSame(VoterInterface::ACCESS_DENIED, $this->voter->vote($token, 'alexf', ['contao_user.']));
     }
 
-    public function testVotesDeniedIfSubjectIsNotScalarOrArray()
+    public function testDeniesAccessIfTheSubjectIsNotAScalarOrArray(): void
     {
         $token = $this->createMock(TokenInterface::class);
         $token
@@ -64,7 +64,7 @@ class BackendAccessVoterTest extends TestCase
         $this->assertSame(VoterInterface::ACCESS_DENIED, $this->voter->vote($token, new \stdClass(), ['contao_user.']));
     }
 
-    public function testVotesDeniedIfUserDeniesAccess()
+    public function testDeniesAccessIfTheUserObjectDeniesAccess(): void
     {
         $user = $this->createMock(BackendUser::class);
         $user
@@ -83,7 +83,7 @@ class BackendAccessVoterTest extends TestCase
         $this->assertSame(VoterInterface::ACCESS_DENIED, $this->voter->vote($token, 'alexf', ['contao_user.']));
     }
 
-    public function testVotesGrantedIfUserAllowsAccess()
+    public function testGrantsAccessIfTheUserObjectGrantsAccess(): void
     {
         $user = $this->createMock(BackendUser::class);
         $user

--- a/core-bundle/tests/Security/Voter/BackendAccessVoterTest.php
+++ b/core-bundle/tests/Security/Voter/BackendAccessVoterTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\Security\Voter;
+
+use Contao\BackendUser;
+use Contao\CoreBundle\Security\Voter\BackendAccessVoter;
+use Contao\CoreBundle\Tests\TestCase;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+
+class BackendAccessVoterTest extends TestCase
+{
+    /**
+     * @var BackendAccessVoter
+     */
+    private $voter;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->voter = new BackendAccessVoter();
+    }
+
+    public function testAbstainsNonContaoUserAttributes(): void
+    {
+        $token = $this->createMock(TokenInterface::class);
+        $attributes = ['foo', 'bar', 'contao.', 'contao_user_name'];
+
+        $this->assertSame(VoterInterface::ACCESS_ABSTAIN, $this->voter->vote($token, 'foo', $attributes));
+    }
+
+    public function testVotesDeniedIfTokenDoesNotHaveABackendUser()
+    {
+        $token = $this->createMock(TokenInterface::class);
+        $token
+            ->expects($this->once())
+            ->method('getUser')
+            ->willReturn('not a user')
+        ;
+
+        $this->assertSame(VoterInterface::ACCESS_DENIED, $this->voter->vote($token, 'alexf', ['contao_user.']));
+    }
+
+    public function testVotesDeniedIfSubjectIsNotScalarOrArray()
+    {
+        $token = $this->createMock(TokenInterface::class);
+        $token
+            ->expects($this->once())
+            ->method('getUser')
+            ->willReturn($this->createMock(BackendUser::class))
+        ;
+
+        $this->assertSame(VoterInterface::ACCESS_DENIED, $this->voter->vote($token, new \stdClass(), ['contao_user.']));
+    }
+
+    public function testVotesDeniedIfUserDeniesAccess()
+    {
+        $user = $this->createMock(BackendUser::class);
+        $user
+            ->expects($this->once())
+            ->method('hasAccess')
+            ->willReturn(false)
+        ;
+
+        $token = $this->createMock(TokenInterface::class);
+        $token
+            ->expects($this->once())
+            ->method('getUser')
+            ->willReturn($user)
+        ;
+
+        $this->assertSame(VoterInterface::ACCESS_DENIED, $this->voter->vote($token, 'alexf', ['contao_user.']));
+    }
+
+    public function testVotesGrantedIfUserAllowsAccess()
+    {
+        $user = $this->createMock(BackendUser::class);
+        $user
+            ->expects($this->once())
+            ->method('hasAccess')
+            ->willReturn(true)
+        ;
+
+        $token = $this->createMock(TokenInterface::class);
+        $token
+            ->expects($this->once())
+            ->method('getUser')
+            ->willReturn($user)
+        ;
+
+        $this->assertSame(VoterInterface::ACCESS_GRANTED, $this->voter->vote($token, 'alexf', ['contao_user.']));
+    }
+}


### PR DESCRIPTION
This allows to perform basic access permissions in the Backend.

Examples:

```php
// User has access to form ID 5
$authorizationChecker->isGranted('contao_user.forms', 5);

// User is allowed to access field "published" of table "tl_page"
$authorizationChecker->isGranted('contao_user.alexf', 'tl_page::published');

// Check access to folder
$authorizationChecker->isGranted('contao_user.filemounts', '/files/foo/bar`);
```