### PR TITLE
Fix trimsplit cache bug

### DIFF
--- a/core-bundle/src/Resources/contao/helper/functions.php
+++ b/core-bundle/src/Resources/contao/helper/functions.php
@@ -235,16 +235,6 @@ function trimsplit($strPattern, $strString)
 {
 	@trigger_error('Using trimsplit() has been deprecated and will no longer work in Contao 5.0. Use StringUtil::trimsplit() instead.', E_USER_DEPRECATED);
 
-	global $arrSplitCache;
-
-	$strKey = md5($strPattern.$strString);
-
-	// Load from cache
-	if (isset($arrSplitCache[$strKey]))
-	{
-		return $arrSplitCache[$strKey];
-	}
-
 	// Split
 	if (\strlen($strPattern) == 1)
 	{
@@ -260,8 +250,6 @@ function trimsplit($strPattern, $strString)
 	{
 		$arrFragments = array();
 	}
-
-	$arrSplitCache[$strKey] = $arrFragments;
 
 	return $arrFragments;
 }

--- a/core-bundle/src/Resources/contao/library/Contao/StringUtil.php
+++ b/core-bundle/src/Resources/contao/library/Contao/StringUtil.php
@@ -28,12 +28,6 @@ class StringUtil
 {
 
 	/**
-	 * Trimsplit cache
-	 * @var array
-	 */
-	protected static $arrSplitCache = array();
-
-	/**
 	 * Shorten a string to a given number of characters
 	 *
 	 * The function preserves words, so the result might be a bit shorter or
@@ -1065,14 +1059,6 @@ class StringUtil
 	 */
 	public static function trimsplit($strPattern, $strString)
 	{
-		$strKey = md5($strPattern.$strString);
-
-		// Load from cache
-		if (isset(static::$arrSplitCache[$strKey]))
-		{
-			return static::$arrSplitCache[$strKey];
-		}
-
 		// Split
 		if (\strlen($strPattern) == 1)
 		{
@@ -1088,8 +1074,6 @@ class StringUtil
 		{
 			$arrFragments = array();
 		}
-
-		static::$arrSplitCache[$strKey] = $arrFragments;
 
 		return $arrFragments;
 	}

--- a/core-bundle/tests/Contao/StringUtilTest.php
+++ b/core-bundle/tests/Contao/StringUtilTest.php
@@ -543,4 +543,55 @@ class StringUtilTest extends TestCase
 
         StringUtil::stripRootDir($this->getRootDir());
     }
+
+    /**
+     * @param string $pattern
+     * @param string $string
+     * @param array  $expected
+     *
+     * @dataProvider trimsplitProvider
+     */
+    public function testTrimsplit($pattern, $string, array $expected)
+    {
+        $this->assertSame($expected, StringUtil::trimsplit($pattern, $string));
+    }
+
+    /**
+     * @return array
+     */
+    public function trimsplitProvider()
+    {
+        return [
+            'Test regular split' => [
+                ',',
+                'foo,bar',
+                ['foo', 'bar'],
+            ],
+            'Test split with trim' => [
+                ',',
+                " \n \r \t foo \n \r \t , \n \r \t bar \n \r \t ",
+                ['foo', 'bar'],
+            ],
+            'Test regex split' => [
+                '[,;]',
+                'foo,bar;baz',
+                ['foo', 'bar', 'baz'],
+            ],
+            'Test regex split with trim' => [
+                '[,;]',
+                " \n \r \t foo \n \r \t , \n \r \t bar \n \r \t ; \n \r \t baz \n \r \t ",
+                ['foo', 'bar', 'baz'],
+            ],
+            'Test split cache bug 1' => [
+                ',',
+                ',foo,,bar',
+                ['', 'foo', '', 'bar'],
+            ],
+            'Test split cache bug 2' => [
+                ',,',
+                'foo,,bar',
+                ['foo', 'bar'],
+            ],
+        ];
+    }
 }

--- a/core-bundle/tests/Contao/StringUtilTest.php
+++ b/core-bundle/tests/Contao/StringUtilTest.php
@@ -545,6 +545,8 @@ class StringUtilTest extends TestCase
     }
 
     /**
+     * Tests splitting and trimming a string.
+     *
      * @param string $pattern
      * @param string $string
      * @param array  $expected


### PR DESCRIPTION
The current cache implementation in `StringUtil::trimsplit()` doesn’t work correctly.

`trimsplit(',', ',foo,,bar')` returns the same result as `trimsplit(',,', 'foo,,bar')` because of the cache.

I think the cache is unnecessary, probably doesn’t improve performance and should be removed.