### PR TITLE
Adjustments to functional tests

### DIFF
--- a/core-bundle/tests/Functional/RoutingTest.php
+++ b/core-bundle/tests/Functional/RoutingTest.php
@@ -70,7 +70,7 @@ class RoutingTest extends WebTestCase
 
         $this->assertSame($query, $_GET);
         $this->assertSame($statusCode, $response->getStatusCode());
-        $this->assertSame($pageTitle, $title);
+        $this->assertContains($pageTitle, $title);
     }
 
     /**
@@ -109,7 +109,7 @@ class RoutingTest extends WebTestCase
             'Renders the 404 page if the URL suffix does not match' => [
                 '/home.xml',
                 404,
-                'Page not found: http://root-with-home.local/home.xml (404 Not Found)',
+                '(404 Not Found)',
                 [],
                 'root-with-home.local',
                 false,
@@ -118,7 +118,7 @@ class RoutingTest extends WebTestCase
             'Renders the 404 page if the URL contains the "auto_item" keyword' => [
                 '/home/auto_item/foo.html',
                 404,
-                'Page not found: http://root-with-home.local/home/auto_item/foo.html (404 Not Found)',
+                '(404 Not Found)',
                 [],
                 'root-with-home.local',
                 false,
@@ -127,7 +127,7 @@ class RoutingTest extends WebTestCase
             'Renders the 404 page if the path contains duplicate keys' => [
                 '/home/foo/bar1/foo/bar2.html',
                 404,
-                'Page not found: http://root-with-home.local/home/foo/bar1/foo/bar2.html (404 Not Found)',
+                '(404 Not Found)',
                 ['foo' => 'bar1'],
                 'root-with-home.local',
                 false,
@@ -136,7 +136,7 @@ class RoutingTest extends WebTestCase
             'Renders the 404 page if the path contains unused arguments' => [
                 '/home/foo/bar.html',
                 404,
-                'Page not found: http://root-with-home.local/home/foo/bar.html (404 Not Found)',
+                '(404 Not Found)',
                 ['foo' => 'bar'],
                 'root-with-home.local',
                 false,
@@ -190,7 +190,7 @@ class RoutingTest extends WebTestCase
             'Renders the 404 page if auto items are enabled and the URL contains the "auto_item" keyword' => [
                 '/home/auto_item/foo.html',
                 404,
-                'Page not found: http://root-with-home.local/home/auto_item/foo.html (404 Not Found)',
+                '(404 Not Found)',
                 [],
                 'root-with-home.local',
                 true,
@@ -199,7 +199,7 @@ class RoutingTest extends WebTestCase
             'Renders the 404 page if auto items are enabled and the URL contains an auto item keyword' => [
                 '/home/items/foobar.html',
                 404,
-                'Page not found: http://root-with-home.local/home/items/foobar.html (404 Not Found)',
+                '(404 Not Found)',
                 [],
                 'root-with-home.local',
                 true,
@@ -244,7 +244,7 @@ class RoutingTest extends WebTestCase
             'Renders the 404 page if auto items are enabled and the folder URL contains the "auto_item" keyword' => [
                 '/folder/url/home/auto_item/foo.html',
                 404,
-                'Page not found: http://root-with-folder-urls.local/folder/url/home/auto_item/foo.html (404 Not Found)',
+                '(404 Not Found)',
                 [],
                 'root-with-folder-urls.local',
                 true,
@@ -253,7 +253,7 @@ class RoutingTest extends WebTestCase
             'Renders the 404 page if auto items are enabled and the folder URL contains an auto item keyword' => [
                 '/folder/url/home/items/foobar.html',
                 404,
-                'Page not found: http://root-with-folder-urls.local/folder/url/home/items/foobar.html (404 Not Found)',
+                '(404 Not Found)',
                 [],
                 'root-with-folder-urls.local',
                 true,
@@ -284,7 +284,7 @@ class RoutingTest extends WebTestCase
 
         $this->assertSame($query, $_GET);
         $this->assertSame($statusCode, $response->getStatusCode());
-        $this->assertSame($pageTitle, $title);
+        $this->assertContains($pageTitle, $title);
     }
 
     /**
@@ -323,7 +323,7 @@ class RoutingTest extends WebTestCase
             'Renders the 404 page if the URL suffix does not match' => [
                 '/en/home.xml',
                 404,
-                'Page not found: http://root-with-home.local/en/home.xml (404 Not Found)',
+                '(404 Not Found)',
                 [],
                 'root-with-home.local',
                 false,
@@ -332,7 +332,7 @@ class RoutingTest extends WebTestCase
             'Renders the 404 page if the URL contains the "auto_item" keyword' => [
                 '/en/home/auto_item/foo.html',
                 404,
-                'Page not found: http://root-with-home.local/en/home/auto_item/foo.html (404 Not Found)',
+                '(404 Not Found)',
                 [],
                 'root-with-home.local',
                 false,
@@ -341,7 +341,7 @@ class RoutingTest extends WebTestCase
             'Renders the 404 page if the path contains duplicate keys' => [
                 '/en/home/foo/bar1/foo/bar2.html',
                 404,
-                'Page not found: http://root-with-home.local/en/home/foo/bar1/foo/bar2.html (404 Not Found)',
+                '(404 Not Found)',
                 ['language' => 'en', 'foo' => 'bar1'],
                 'root-with-home.local',
                 false,
@@ -350,7 +350,7 @@ class RoutingTest extends WebTestCase
             'Renders the 404 page if the path contains unused arguments' => [
                 '/en/home/foo/bar.html',
                 404,
-                'Page not found: http://root-with-home.local/en/home/foo/bar.html (404 Not Found)',
+                '(404 Not Found)',
                 ['language' => 'en', 'foo' => 'bar'],
                 'root-with-home.local',
                 false,
@@ -404,7 +404,7 @@ class RoutingTest extends WebTestCase
             'Renders the 404 page if auto items are enabled and the URL contains the "auto_item" keyword' => [
                 '/en/home/auto_item/foo.html',
                 404,
-                'Page not found: http://root-with-home.local/en/home/auto_item/foo.html (404 Not Found)',
+                '(404 Not Found)',
                 [],
                 'root-with-home.local',
                 true,
@@ -413,7 +413,7 @@ class RoutingTest extends WebTestCase
             'Renders the 404 page if auto items are enabled and the URL contains an auto item keyword' => [
                 '/en/home/items/foobar.html',
                 404,
-                'Page not found: http://root-with-home.local/en/home/items/foobar.html (404 Not Found)',
+                '(404 Not Found)',
                 ['language' => 'en'],
                 'root-with-home.local',
                 true,
@@ -449,7 +449,7 @@ class RoutingTest extends WebTestCase
             'Renders the 404 page if auto items are enabled and the folder URL contains the "auto_item" keyword' => [
                 '/en/folder/url/home/auto_item/foo.html',
                 404,
-                'Page not found: http://root-with-folder-urls.local/en/folder/url/home/auto_item/foo.html (404 Not Found)',
+                '(404 Not Found)',
                 [],
                 'root-with-folder-urls.local',
                 true,
@@ -458,7 +458,7 @@ class RoutingTest extends WebTestCase
             'Renders the 404 page if auto items are enabled and the folder URL contains an auto item keyword' => [
                 '/en/folder/url/home/items/foobar.html',
                 404,
-                'Page not found: http://root-with-folder-urls.local/en/folder/url/home/items/foobar.html (404 Not Found)',
+                '(404 Not Found)',
                 ['language' => 'en'],
                 'root-with-folder-urls.local',
                 true,
@@ -489,7 +489,7 @@ class RoutingTest extends WebTestCase
 
         $this->assertSame($query, $_GET);
         $this->assertSame($statusCode, $response->getStatusCode());
-        $this->assertSame($pageTitle, $title);
+        $this->assertContains($pageTitle, $title);
     }
 
     /**
@@ -528,7 +528,7 @@ class RoutingTest extends WebTestCase
             'Renders the 404 page if the URL suffix does not match' => [
                 '/home.xml',
                 404,
-                'Page not found: http://root-with-home.local/home.xml (404 Not Found)',
+                '(404 Not Found)',
                 [],
                 'root-with-home.local',
                 false,
@@ -537,7 +537,7 @@ class RoutingTest extends WebTestCase
             'Renders the 404 page if the URL contains the "auto_item" keyword' => [
                 '/home/auto_item/foo',
                 404,
-                'Page not found: http://root-with-home.local/home/auto_item/foo (404 Not Found)',
+                '(404 Not Found)',
                 [],
                 'root-with-home.local',
                 false,
@@ -546,7 +546,7 @@ class RoutingTest extends WebTestCase
             'Renders the 404 page if the path contains duplicate keys' => [
                 '/home/foo/bar1/foo/bar2',
                 404,
-                'Page not found: http://root-with-home.local/home/foo/bar1/foo/bar2 (404 Not Found)',
+                '(404 Not Found)',
                 ['foo' => 'bar1'],
                 'root-with-home.local',
                 false,
@@ -555,7 +555,7 @@ class RoutingTest extends WebTestCase
             'Renders the 404 page if the path contains unused arguments' => [
                 '/home/foo/bar',
                 404,
-                'Page not found: http://root-with-home.local/home/foo/bar (404 Not Found)',
+                '(404 Not Found)',
                 ['foo' => 'bar'],
                 'root-with-home.local',
                 false,
@@ -600,7 +600,7 @@ class RoutingTest extends WebTestCase
             'Renders the 404 page if auto items are enabled and the URL contains the "auto_item" keyword' => [
                 '/home/auto_item/foo',
                 404,
-                'Page not found: http://root-with-home.local/home/auto_item/foo (404 Not Found)',
+                '(404 Not Found)',
                 [],
                 'root-with-home.local',
                 true,
@@ -609,7 +609,7 @@ class RoutingTest extends WebTestCase
             'Renders the 404 page if auto items are enabled and the URL contains an auto item keyword' => [
                 '/home/items/foobar',
                 404,
-                'Page not found: http://root-with-home.local/home/items/foobar (404 Not Found)',
+                '(404 Not Found)',
                 [],
                 'root-with-home.local',
                 true,
@@ -654,7 +654,7 @@ class RoutingTest extends WebTestCase
             'Renders the 404 page if auto items are enabled and the folder URL contains the "auto_item" keyword' => [
                 '/folder/url/home/auto_item/foo',
                 404,
-                'Page not found: http://root-with-folder-urls.local/folder/url/home/auto_item/foo (404 Not Found)',
+                '(404 Not Found)',
                 [],
                 'root-with-folder-urls.local',
                 true,
@@ -663,7 +663,7 @@ class RoutingTest extends WebTestCase
             'Renders the 404 page if auto items are enabled and the folder URL contains an auto item keyword' => [
                 '/folder/url/home/items/foobar',
                 404,
-                'Page not found: http://root-with-folder-urls.local/folder/url/home/items/foobar (404 Not Found)',
+                '(404 Not Found)',
                 [],
                 'root-with-folder-urls.local',
                 true,
@@ -691,7 +691,7 @@ class RoutingTest extends WebTestCase
         $response = $client->getResponse();
 
         $this->assertSame($statusCode, $response->getStatusCode());
-        $this->assertSame($pageTitle, $title);
+        $this->assertContains($pageTitle, $title);
     }
 
     /**
@@ -764,7 +764,7 @@ class RoutingTest extends WebTestCase
         $response = $client->getResponse();
 
         $this->assertSame($statusCode, $response->getStatusCode());
-        $this->assertSame($pageTitle, $title);
+        $this->assertContains($pageTitle, $title);
     }
 
     /**
@@ -804,7 +804,7 @@ class RoutingTest extends WebTestCase
             'Renders the 404 page if the locale does not match' => [
                 '/de/',
                 404,
-                'Page not found: http://root-with-index.local/de/ (404 Not Found)',
+                '(404 Not Found)',
                 'de,fr',
                 'root-with-index.local',
             ],

--- a/core-bundle/tests/Functional/RoutingTest.php
+++ b/core-bundle/tests/Functional/RoutingTest.php
@@ -68,8 +68,8 @@ class RoutingTest extends WebTestCase
         $title = trim($crawler->filterXPath('//head/title')->text());
         $response = $client->getResponse();
 
-        $this->assertSame($query, $_GET);
         $this->assertSame($statusCode, $response->getStatusCode());
+        $this->assertSame($query, $_GET);
         $this->assertContains($pageTitle, $title);
     }
 
@@ -282,8 +282,8 @@ class RoutingTest extends WebTestCase
         $title = trim($crawler->filterXPath('//head/title')->text());
         $response = $client->getResponse();
 
-        $this->assertSame($query, $_GET);
         $this->assertSame($statusCode, $response->getStatusCode());
+        $this->assertSame($query, $_GET);
         $this->assertContains($pageTitle, $title);
     }
 
@@ -487,8 +487,8 @@ class RoutingTest extends WebTestCase
         $title = trim($crawler->filterXPath('//head/title')->text());
         $response = $client->getResponse();
 
-        $this->assertSame($query, $_GET);
         $this->assertSame($statusCode, $response->getStatusCode());
+        $this->assertSame($query, $_GET);
         $this->assertContains($pageTitle, $title);
     }
 

--- a/core-bundle/tests/Functional/RoutingTest.php
+++ b/core-bundle/tests/Functional/RoutingTest.php
@@ -58,11 +58,11 @@ class RoutingTest extends WebTestCase
         Config::set('urlSuffix', '.html');
         Config::set('addLanguageToUrl', false);
 
-        $client = $this->createClient();
-        System::setContainer($client->getContainer());
-
         $_SERVER['REQUEST_URI'] = $request;
         $_SERVER['HTTP_HOST'] = $host;
+
+        $client = $this->createClient([], $_SERVER);
+        System::setContainer($client->getContainer());
 
         $crawler = $client->request('GET', $request);
         $title = trim($crawler->filterXPath('//head/title')->text());
@@ -272,11 +272,11 @@ class RoutingTest extends WebTestCase
         Config::set('urlSuffix', '.html');
         Config::set('addLanguageToUrl', true);
 
-        $client = $this->createClient(['environment' => 'locale']);
-        System::setContainer($client->getContainer());
-
         $_SERVER['REQUEST_URI'] = $request;
         $_SERVER['HTTP_HOST'] = $host;
+
+        $client = $this->createClient(['environment' => 'locale'], $_SERVER);
+        System::setContainer($client->getContainer());
 
         $crawler = $client->request('GET', $request);
         $title = trim($crawler->filterXPath('//head/title')->text());
@@ -477,11 +477,11 @@ class RoutingTest extends WebTestCase
         Config::set('urlSuffix', '');
         Config::set('addLanguageToUrl', false);
 
-        $client = $this->createClient(['environment' => 'suffix']);
-        System::setContainer($client->getContainer());
-
         $_SERVER['REQUEST_URI'] = $request;
         $_SERVER['HTTP_HOST'] = $host;
+
+        $client = $this->createClient(['environment' => 'suffix'], $_SERVER);
+        System::setContainer($client->getContainer());
 
         $crawler = $client->request('GET', $request);
         $title = trim($crawler->filterXPath('//head/title')->text());
@@ -679,12 +679,12 @@ class RoutingTest extends WebTestCase
     {
         Config::set('addLanguageToUrl', false);
 
-        $client = $this->createClient();
-        System::setContainer($client->getContainer());
-
         $_SERVER['REQUEST_URI'] = $request;
         $_SERVER['HTTP_HOST'] = $host;
         $_SERVER['HTTP_ACCEPT_LANGUAGE'] = $acceptLanguages;
+
+        $client = $this->createClient([], $_SERVER);
+        System::setContainer($client->getContainer());
 
         $crawler = $client->request('GET', $request);
         $title = trim($crawler->filterXPath('//head/title')->text());
@@ -752,12 +752,12 @@ class RoutingTest extends WebTestCase
     {
         Config::set('addLanguageToUrl', true);
 
-        $client = $this->createClient(['environment' => 'locale']);
-        System::setContainer($client->getContainer());
-
         $_SERVER['REQUEST_URI'] = $request;
         $_SERVER['HTTP_HOST'] = $host;
         $_SERVER['HTTP_ACCEPT_LANGUAGE'] = $acceptLanguages;
+
+        $client = $this->createClient(['environment' => 'locale'], $_SERVER);
+        System::setContainer($client->getContainer());
 
         $crawler = $client->request('GET', $request);
         $title = trim($crawler->filterXPath('//head/title')->text());


### PR DESCRIPTION
1. Only test for a partial match of the page title. This is forward compatible with Symfony Routing (#95) because the 404 message will not be identical.
2. Pass the server variables to the test client, otherwise they will not appear in `$request`
3. Test HTTP status code before `$_GET` parameters