### PR TITLE
do not use tstamp from tl_files as the mtime

### DIFF
--- a/core-bundle/src/Resources/contao/pages/PageRegular.php
+++ b/core-bundle/src/Resources/contao/pages/PageRegular.php
@@ -563,7 +563,7 @@ class PageRegular extends Frontend
 
 							if ($objFile !== null)
 							{
-								$strStyleSheet = \Template::generateStyleTag(\Controller::addFilesUrlTo($objFile->path), $media, $objFile->tstamp);
+								$strStyleSheet = \Template::generateStyleTag(\Controller::addFilesUrlTo($objFile->path), $media, null);
 							}
 						}
 						else
@@ -808,7 +808,7 @@ class PageRegular extends Frontend
 			{
 				if (file_exists(TL_ROOT . '/' . $objFiles->path))
 				{
-					$strScripts .= \Template::generateScriptTag($objFiles->path);
+					$strScripts .= \Template::generateScriptTag($objFiles->path, false, null);
 				}
 			}
 		}

--- a/core-bundle/src/Resources/contao/pages/PageRegular.php
+++ b/core-bundle/src/Resources/contao/pages/PageRegular.php
@@ -808,7 +808,7 @@ class PageRegular extends Frontend
 			{
 				if (file_exists(TL_ROOT . '/' . $objFiles->path))
 				{
-					$strScripts .= \Template::generateScriptTag($objFiles->path, false);
+					$strScripts .= \Template::generateScriptTag($objFiles->path);
 				}
 			}
 		}

--- a/core-bundle/src/Resources/contao/pages/PageRegular.php
+++ b/core-bundle/src/Resources/contao/pages/PageRegular.php
@@ -808,7 +808,7 @@ class PageRegular extends Frontend
 			{
 				if (file_exists(TL_ROOT . '/' . $objFiles->path))
 				{
-					$strScripts .= \Template::generateScriptTag($objFiles->path, false, $objFiles->tstamp);
+					$strScripts .= \Template::generateScriptTag($objFiles->path, false);
 				}
 			}
 		}


### PR DESCRIPTION
Currently, the cache busting parameter that is automatically appended via `Template::generateScriptTag` will not change for `externalJs` files of the page layout whenever those files change, since the current code uses the `tstamp` from `tl_files` rather than the `mtime` of the actual file. The `tl_files.tstamp` will of course only change if you change something in the file manager in the back end for that file.

### Reproduction

1. Add an external JavaScript file to the page layout.
2. Open the front end and note the `?v=` parameter appended to that file.
3. Change the content of the JavaScript file.
4. Open the front end again.

The `?v=` parameter will still be the same.