### PR TITLE
Allow to customize tmp dir

### DIFF
--- a/core-bundle/src/Command/AbstractLockedCommand.php
+++ b/core-bundle/src/Command/AbstractLockedCommand.php
@@ -57,7 +57,7 @@ abstract class AbstractLockedCommand extends ContainerAwareCommand
     private function getTempDir(): string
     {
         $container = $this->getContainer();
-        $tmpDir = sys_get_temp_dir().'/'.md5($container->getParameter('kernel.project_dir'));
+        $tmpDir = $container->getParameter('contao.tmp_dir').'/'.md5($container->getParameter('kernel.project_dir'));
 
         if (!is_dir($tmpDir)) {
             $container->get('filesystem')->mkdir($tmpDir);

--- a/core-bundle/src/DependencyInjection/Configuration.php
+++ b/core-bundle/src/DependencyInjection/Configuration.php
@@ -66,6 +66,17 @@ class Configuration implements ConfigurationInterface
                         )
                     ->end()
                 ->end()
+                ->scalarNode('tmp_dir')
+                    ->cannotBeEmpty()
+                    ->defaultValue(\sys_get_temp_dir())
+                    ->validate()
+                        ->always(
+                            function (string $value): string {
+                                return $this->canonicalize($value);
+                            }
+                        )
+                    ->end()
+                ->end()
                 ->booleanNode('prepend_locale')
                     ->defaultFalse()
                 ->end()

--- a/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
+++ b/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
@@ -68,6 +68,7 @@ class ContaoCoreExtension extends ConfigurableExtension
         }
 
         $container->setParameter('contao.web_dir', $mergedConfig['web_dir']);
+        $container->setParameter('contao.tmp_dir', $mergedConfig['tmp_dir']);
         $container->setParameter('contao.prepend_locale', $mergedConfig['prepend_locale']);
         $container->setParameter('contao.encryption_key', $mergedConfig['encryption_key']);
         $container->setParameter('contao.url_suffix', $mergedConfig['url_suffix']);

--- a/core-bundle/tests/Command/AutomatorCommandTest.php
+++ b/core-bundle/tests/Command/AutomatorCommandTest.php
@@ -37,7 +37,9 @@ class AutomatorCommandTest extends CommandTestCase
 
     public function testIsLockedWhileRunning(): void
     {
-        $tmpDir = sys_get_temp_dir().'/'.md5($this->getFixturesDir());
+        $application = $this->mockApplication();
+        $contaoTmpDir = $application->getKernel()->getContainer()->getParameter('contao.tmp_dir');
+        $tmpDir = $contaoTmpDir.'/'.md5($this->getFixturesDir());
 
         if (!is_dir($tmpDir)) {
             (new Filesystem())->mkdir($tmpDir);
@@ -48,7 +50,7 @@ class AutomatorCommandTest extends CommandTestCase
         $lock = $factory->createLock('contao:automator');
         $lock->acquire();
 
-        $this->command->setApplication($this->mockApplication());
+        $this->command->setApplication($application);
 
         $tester = new CommandTester($this->command);
         $tester->setInputs(["\n"]);

--- a/core-bundle/tests/Command/CommandTestCase.php
+++ b/core-bundle/tests/Command/CommandTestCase.php
@@ -24,6 +24,7 @@ abstract class CommandTestCase extends TestCase
     {
         $container = new ContainerBuilder();
         $container->setParameter('kernel.project_dir', $this->getFixturesDir());
+        $container->setParameter('contao.tmp_dir', self::getTempDir() . '/tmp');
         $container->set('filesystem', new Filesystem());
 
         $kernel = $this->createMock(KernelInterface::class);

--- a/manager-bundle/tests/Command/InstallWebDirCommandTest.php
+++ b/manager-bundle/tests/Command/InstallWebDirCommandTest.php
@@ -273,6 +273,7 @@ class InstallWebDirCommandTest extends ContaoTestCase
     {
         $container = new ContainerBuilder();
         $container->setParameter('kernel.project_dir', 'foobar');
+        $container->setParameter('contao.tmp_dir', self::getTempDir() . '/tmp');
         $container->set('filesystem', new Filesystem());
 
         $kernel = $this->createMock(ContaoKernel::class);


### PR DESCRIPTION
Contao uses `sys_get_temp_dir()` by default to create temporary files, especially for locking commands. Using system standards is great but might create issues on several hosting configurations.

At my current project I had the setup, that the system temp env variables were set in the php-cgi-wrapper. So Contao could use the right temp directory. However, then making a file public, the `symlinks` command is called, which runs as a cli command. The env variables are ignored here and causes issues. 

To avoid similar hosting configurations which might leads to issues, a I'd like to introduce a new configuration parameter to customize the temp directory.