### PR TITLE
Always have HttpCache available for production environment

### DIFF
--- a/manager-bundle/src/HttpKernel/ContaoCache.php
+++ b/manager-bundle/src/HttpKernel/ContaoCache.php
@@ -36,8 +36,6 @@ class ContaoCache extends HttpCache implements CacheInvalidation
         $this->addSubscriber(new PurgeTagsListener());
         $this->addSubscriber(new HeaderReplaySubscriber(['ignore_cookies' => ['/^csrf_./']]));
         $this->addSubscriber(new CleanupCacheTagsListener());
-
-        $kernel->setHttpCache($this);
     }
 
     /**

--- a/manager-bundle/src/HttpKernel/ContaoKernel.php
+++ b/manager-bundle/src/HttpKernel/ContaoKernel.php
@@ -21,7 +21,6 @@ use Contao\ManagerPlugin\Bundle\Parser\JsonParser;
 use Contao\ManagerPlugin\Config\ConfigPluginInterface;
 use Contao\ManagerPlugin\Config\ContainerBuilder as PluginContainerBuilder;
 use Contao\ManagerPlugin\PluginLoader;
-use FOS\HttpCache\SymfonyCache\HttpCacheAware;
 use FOS\HttpCache\SymfonyCache\HttpCacheProvider;
 use ProxyManager\Configuration;
 use Symfony\Bridge\ProxyManager\LazyProxy\Instantiator\RuntimeInstantiator;
@@ -30,8 +29,6 @@ use Symfony\Component\HttpKernel\Kernel;
 
 class ContaoKernel extends Kernel implements HttpCacheProvider
 {
-    use HttpCacheAware;
-
     /**
      * @var string
      */
@@ -51,6 +48,11 @@ class ContaoKernel extends Kernel implements HttpCacheProvider
      * @var ManagerConfig
      */
     private $managerConfig;
+
+    /**
+     * @var ContaoCache
+     */
+    private $httpCache;
 
     /**
      * {@inheritdoc}
@@ -195,6 +197,18 @@ class ContaoKernel extends Kernel implements HttpCacheProvider
     public static function setProjectDir(string $projectDir): void
     {
         self::$projectDir = realpath($projectDir) ?: $projectDir;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getHttpCache()
+    {
+        if (null !== $this->httpCache) {
+            return $this->httpCache;
+        }
+
+        return $this->httpCache = new ContaoCache($this, $this->getProjectDir().'/var/cache/prod/http_cache');
     }
 
     /**

--- a/manager-bundle/src/Resources/skeleton/web/app.php
+++ b/manager-bundle/src/Resources/skeleton/web/app.php
@@ -11,7 +11,6 @@ declare(strict_types=1);
  */
 
 use Contao\ManagerBundle\ContaoManager\Plugin;
-use Contao\ManagerBundle\HttpKernel\ContaoCache;
 use Contao\ManagerBundle\HttpKernel\ContaoKernel;
 use Symfony\Component\Dotenv\Dotenv;
 use Symfony\Component\HttpFoundation\Request;
@@ -44,7 +43,7 @@ $kernel = new ContaoKernel('prod', false);
 
 // Enable the Symfony reverse proxy
 if (!($_SERVER['DISABLE_HTTP_CACHE'] ?? false)) {
-    $kernel = new ContaoCache($kernel);
+    $kernel = $kernel->getHttpCache();
 }
 
 Request::enableHttpMethodParameterOverride();


### PR DESCRIPTION
This fix ensures that the `HttpCache` instance is always available, and always configured for production environment. This will make sure the backend can purge cache data even when running in dev environment, as well as that the command line can purge the http cache.