### PR TITLE
[RFC] Execute sql commands in the original order of the schema diff

### DIFF
--- a/installation-bundle/src/Controller/InstallationController.php
+++ b/installation-bundle/src/Controller/InstallationController.php
@@ -434,9 +434,7 @@ class InstallationController implements ContainerAwareInterface
         $sql = $request->request->get('sql');
 
         if (!empty($sql) && \is_array($sql)) {
-            foreach ($sql as $hash) {
-                $installer->execCommand($hash);
-            }
+            $installer->execCommands($sql);
         }
 
         return $this->getRedirectResponse();

--- a/installation-bundle/src/Database/Installer.php
+++ b/installation-bundle/src/Database/Installer.php
@@ -180,7 +180,7 @@ class Installer
             // make sure commands added via the hook are also appended to the command order
             foreach ($return as $commandSet) {
                 foreach ($commandSet as $hash => $sql) {
-                    if (!isset($order[$hash])) {
+					if (!\in_array($hash, $order, true)) {
                         $order[] = $hash;
                     }
                 }

--- a/installation-bundle/src/Database/Installer.php
+++ b/installation-bundle/src/Database/Installer.php
@@ -67,10 +67,7 @@ class Installer
             $this->compileCommands();
         }
 
-        $commands = [];
-        array_map(function ($c) use (&$commands): void {
-            $commands += $c;
-        }, $this->commands);
+		$commands = array_reduce($this->commands, 'array_merge', []);
 
         if(!empty($unmappedHashes = array_diff($hashes, array_keys($commands)))) {
 			throw new \InvalidArgumentException(

--- a/installation-bundle/src/Database/Installer.php
+++ b/installation-bundle/src/Database/Installer.php
@@ -72,6 +72,12 @@ class Installer
             $commands += $c;
         }, $this->commands);
 
+        if(!empty($unmappedHashes = array_diff($hashes, array_keys($commands)))) {
+			throw new \InvalidArgumentException(
+				sprintf('Invalid SQL hash(es): %s', implode(', ', $unmappedHashes))
+			);
+		}
+
         foreach (array_intersect($this->commandOrder, $hashes) as $hash) {
             $this->connection->query($commands[$hash]);
         }

--- a/installation-bundle/src/Database/Installer.php
+++ b/installation-bundle/src/Database/Installer.php
@@ -67,13 +67,13 @@ class Installer
             $this->compileCommands();
         }
 
-		$commands = array_reduce($this->commands, 'array_merge', []);
+        $commands = array_reduce($this->commands, 'array_merge', []);
 
-        if(!empty($unmappedHashes = array_diff($hashes, array_keys($commands)))) {
-			throw new \InvalidArgumentException(
-				sprintf('Invalid SQL hash(es): %s', implode(', ', $unmappedHashes))
-			);
-		}
+        if (!empty($unmappedHashes = array_diff($hashes, array_keys($commands)))) {
+            throw new \InvalidArgumentException(
+                sprintf('Invalid SQL hash(es): %s', implode(', ', $unmappedHashes))
+            );
+        }
 
         foreach (array_intersect($this->commandOrder, $hashes) as $hash) {
             $this->connection->query($commands[$hash]);
@@ -180,7 +180,7 @@ class Installer
             // make sure commands added via the hook are also appended to the command order
             foreach ($return as $commandSet) {
                 foreach ($commandSet as $hash => $sql) {
-					if (!\in_array($hash, $order, true)) {
+                    if (!\in_array($hash, $order, true)) {
                         $order[] = $hash;
                     }
                 }

--- a/installation-bundle/src/Database/Installer.php
+++ b/installation-bundle/src/Database/Installer.php
@@ -111,25 +111,27 @@ class Installer
         $diff = $fromSchema->getMigrateToSql($toSchema, $this->connection->getDatabasePlatform());
 
         foreach ($diff as $sql) {
-            $order[] = md5($sql);
-
             switch (true) {
                 case 0 === strncmp($sql, 'CREATE TABLE ', 13):
                     $return['CREATE'][md5($sql)] = $sql;
+                    $order[] = md5($sql);
                     break;
 
                 case 0 === strncmp($sql, 'DROP TABLE ', 11):
                     $return['DROP'][md5($sql)] = $sql;
+                    $order[] = md5($sql);
                     break;
 
                 case 0 === strncmp($sql, 'CREATE INDEX ', 13):
                 case 0 === strncmp($sql, 'CREATE UNIQUE INDEX ', 20):
                 case 0 === strncmp($sql, 'CREATE FULLTEXT INDEX ', 22):
                     $return['ALTER_ADD'][md5($sql)] = $sql;
+                    $order[] = md5($sql);
                     break;
 
                 case 0 === strncmp($sql, 'DROP INDEX', 10):
                     $return['ALTER_CHANGE'][md5($sql)] = $sql;
+                    $order[] = md5($sql);
                     break;
 
                 case preg_match('/^(ALTER TABLE [^ ]+) /', $sql, $matches):
@@ -144,15 +146,18 @@ class Installer
                         switch (true) {
                             case 0 === strncmp($part, 'DROP ', 5):
                                 $return['ALTER_DROP'][md5($command)] = $command;
+                                $order[] = md5($command);
                                 break;
 
                             case 0 === strncmp($part, 'ADD ', 4):
                                 $return['ALTER_ADD'][md5($command)] = $command;
+                                $order[] = md5($command);
                                 break;
 
                             case 0 === strncmp($part, 'CHANGE ', 7):
                             case 0 === strncmp($part, 'RENAME ', 7):
                                 $return['ALTER_CHANGE'][md5($command)] = $command;
+                                $order[] = md5($command);
                                 break;
 
                             default:

--- a/installation-bundle/src/Database/Installer.php
+++ b/installation-bundle/src/Database/Installer.php
@@ -57,10 +57,6 @@ class Installer
         return $this->commands;
     }
 
-    /**
-     * @throws \InvalidArgumentException
-     * @throws \Doctrine\DBAL\DBALException
-     */
     public function execCommands(array $hashes): void
     {
         if (null === $this->commands) {
@@ -68,11 +64,10 @@ class Installer
         }
 
         $commands = array_reduce($this->commands, 'array_merge', []);
+        $unmappedHashes = array_diff($hashes, array_keys($commands));
 
-        if (!empty($unmappedHashes = array_diff($hashes, array_keys($commands)))) {
-            throw new \InvalidArgumentException(
-                sprintf('Invalid SQL hash(es): %s', implode(', ', $unmappedHashes))
-            );
+        if (!empty($unmappedHashes)) {
+            throw new \InvalidArgumentException(sprintf('Invalid SQL hashes: %s', implode(', ', $unmappedHashes)));
         }
 
         foreach (array_intersect($this->commandOrder, $hashes) as $hash) {
@@ -93,8 +88,8 @@ class Installer
             'DROP' => [],
             'ALTER_DROP' => [],
         ];
-        $order = [];
 
+        $order = [];
         $config = $this->connection->getConfiguration();
 
         // Overwrite the schema filter (see #78)
@@ -182,7 +177,7 @@ class Installer
                 $return = \System::importStatic($callback[0])->{$callback[1]}($return);
             }
 
-            // make sure commands added via the hook are also appended to the command order
+            // Make sure commands added via the hook are also appended to the command order
             foreach ($return as $commandSet) {
                 foreach ($commandSet as $hash => $sql) {
                     if (!\in_array($hash, $order, true)) {


### PR DESCRIPTION
The result from doctrine's schema diff is already ordered to prevent collisions - e.g. foreign keys get dropped before deleting the respective tables. Currently we ignore the order when grouping the commands and letting the user decide which ones to execute (add table, modify table, drop table, and so on). 

This PR adds tracking of the original order for execution.