### PR TITLE
[RTM] Support clearing any proxy cache in system maintenance

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "doctrine/doctrine-bundle": "^1.7.2",
         "doctrine/doctrine-cache-bundle": "^1.3",
         "firebase/php-jwt": "^4.0",
-        "friendsofsymfony/http-cache": "^2.5",
+        "friendsofsymfony/http-cache": "^2.6",
         "friendsofsymfony/http-cache-bundle": "^2.6",
         "imagine/imagine": "^0.7 || ^1.0",
         "knplabs/knp-menu-bundle": "^2.1",

--- a/core-bundle/composer.json
+++ b/core-bundle/composer.json
@@ -43,7 +43,7 @@
         "doctrine/doctrine-bundle": "^1.7.2",
         "doctrine/doctrine-cache-bundle": "^1.3",
         "firebase/php-jwt": "^4.0",
-        "friendsofsymfony/http-cache": "^2.5",
+        "friendsofsymfony/http-cache": "^2.6",
         "friendsofsymfony/http-cache-bundle": "^2.6",
         "imagine/imagine": "^0.7 || ^1.0",
         "knplabs/knp-menu-bundle": "^2.1",

--- a/core-bundle/src/Resources/contao/config/config.php
+++ b/core-bundle/src/Resources/contao/config/config.php
@@ -314,11 +314,6 @@ $GLOBALS['TL_PURGE'] = array
 			'callback' => array('Contao\Automator', 'purgeScriptCache'),
 			'affected' => array('assets/js', 'assets/css')
 		),
-		'pages' => array
-		(
-			'callback' => array('Contao\Automator', 'purgePageCache'),
-			'affected' => array('%s/http_cache')
-		),
 		'search' => array
 		(
 			'callback' => array('Contao\Automator', 'purgeSearchCache'),
@@ -332,6 +327,10 @@ $GLOBALS['TL_PURGE'] = array
 	),
 	'custom' => array
 	(
+		'pages' => array
+		(
+			'callback' => array('Contao\Automator', 'purgePageCache'),
+		),
 		'xml' => array
 		(
 			'callback' => array('Contao\Automator', 'generateXmlFiles')

--- a/manager-bundle/composer.json
+++ b/manager-bundle/composer.json
@@ -18,7 +18,7 @@
         "doctrine/dbal": "^2.5",
         "doctrine/doctrine-bundle": "^1.7.2",
         "doctrine/doctrine-cache-bundle": "^1.3",
-        "friendsofsymfony/http-cache": "^2.5",
+        "friendsofsymfony/http-cache": "^2.6",
         "friendsofsymfony/http-cache-bundle": "^2.6",
         "lexik/maintenance-bundle": "^2.1.3",
         "nelmio/cors-bundle": "^1.5.3",


### PR DESCRIPTION
Right now it only works for the `http_cache` because it purges the folder.
So I worked on the implementation in `FOSHttpCache` (https://github.com/FriendsOfSymfony/FOSHttpCache/pull/437) and the upcoming version 2.6 will now support clearing the reverse proxy cache completely.

This means whatever proxy you configured (by default it's the built in HttpCache so it still works just the same) it will be supported in the future 🎉 