### PR TITLE
Do not index pages when "keywords" is present

### DIFF
--- a/core-bundle/src/Resources/contao/config/config.php
+++ b/core-bundle/src/Resources/contao/config/config.php
@@ -389,7 +389,7 @@ $GLOBALS['TL_HOOKS'] = array
 $GLOBALS['TL_AUTO_ITEM'] = array('items', 'events');
 
 // Do not index a page if one of the following parameters is set
-$GLOBALS['TL_NOINDEX_KEYS'] = array('id', 'file', 'token', 'day', 'month', 'year', 'page', 'PHPSESSID');
+$GLOBALS['TL_NOINDEX_KEYS'] = array('id', 'file', 'token', 'day', 'month', 'year', 'page', 'PHPSESSID', 'keywords');
 
 // Register the supported CSS units
 $GLOBALS['TL_CSS_UNITS'] = array('px', '%', 'em', 'rem', 'vw', 'vh', 'vmin', 'vmax', 'ex', 'pt', 'pc', 'in', 'cm', 'mm');


### PR DESCRIPTION
Not sure if this fix is correct or how we should implement it properly but the search result pages are currently being indexed in the internal search.
So I can keep searching stuff and by doing so, I keep on feeding the search index with useless search results. We could also call an `$objPage->noSearch = 1;` in `ModuleSearch` in case there are results. That would be my other idea.