### PR TITLE
Fix BC break in file upload

### DIFF
--- a/core-bundle/src/Resources/contao/classes/DropZone.php
+++ b/core-bundle/src/Resources/contao/classes/DropZone.php
@@ -26,7 +26,7 @@ class DropZone extends FileUpload
 	public function generateMarkup()
 	{
 		// Maximum file size in MB
-		$intMaxSize = round($this->getMaximumUploadSize() / 1024 / 1024);
+		$intMaxSize = round(static::getMaxUploadSize() / 1024 / 1024);
 
 		// String of accepted file extensions
 		$strAccepted = implode(',', array_map(function ($a) { return '.' . $a; }, \StringUtil::trimsplit(',', strtolower(\Config::get('uploadTypes')))));
@@ -79,7 +79,7 @@ class DropZone extends FileUpload
 		if (isset($GLOBALS['TL_LANG']['tl_files']['fileupload'][1]))
 		{
 			$return .= '
-  <p class="tl_help tl_tip">' . sprintf($GLOBALS['TL_LANG']['tl_files']['fileupload'][1], \System::getReadableSize($this->getMaximumUploadSize()), \Config::get('gdMaxImgWidth') . 'x' . \Config::get('gdMaxImgHeight')) . '</p>';
+  <p class="tl_help tl_tip">' . sprintf($GLOBALS['TL_LANG']['tl_files']['fileupload'][1], \System::getReadableSize(static::getMaxUploadSize()), \Config::get('gdMaxImgWidth') . 'x' . \Config::get('gdMaxImgHeight')) . '</p>';
 		}
 
 		return $return;

--- a/core-bundle/src/Resources/contao/classes/FileUpload.php
+++ b/core-bundle/src/Resources/contao/classes/FileUpload.php
@@ -10,6 +10,8 @@
 
 namespace Contao;
 
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+
 /**
  * Provide methods to handle file uploads in the back end.
  *
@@ -256,14 +258,14 @@ class FileUpload extends Backend
 	/**
 	 * Return the maximum upload file size in bytes
 	 *
-	 * @deprecated Deprecated since Contao 4.6, to be removed in Contao 5.0.
-	 *             Use static::getMaxUploadSize() instead.
-	 *
 	 * @return string
+	 *
+	 * @deprecated Deprecated since Contao 4.6, to be removed in Contao 5.0.
+	 *             Use FileUpload::getMaxUploadSize() instead.
 	 */
 	protected function getMaximumUploadSize()
 	{
-		@trigger_error('Using FileUpload->getMaximumUploadSize() has been deprecated and will no longer work in Contao 5.0. Use FileUpload::getMaxUploadSize() instead.', E_USER_DEPRECATED);
+		@trigger_error('Using FileUpload::getMaximumUploadSize() has been deprecated and will no longer work in Contao 5.0. Use FileUpload::getMaxUploadSize() instead.', E_USER_DEPRECATED);
 
 		return static::getMaxUploadSize();
 	}
@@ -275,7 +277,7 @@ class FileUpload extends Backend
 	 */
 	public static function getMaxUploadSize()
 	{
-		return min(\Symfony\Component\HttpFoundation\File\UploadedFile::getMaxFilesize(), \Config::get('maxFileSize'));
+		return min(UploadedFile::getMaxFilesize(), \Config::get('maxFileSize'));
 	}
 
 	/**

--- a/core-bundle/src/Resources/contao/classes/FileUpload.php
+++ b/core-bundle/src/Resources/contao/classes/FileUpload.php
@@ -275,24 +275,7 @@ class FileUpload extends Backend
 	 */
 	public static function getMaxUploadSize()
 	{
-		// Get the upload_max_filesize from the php.ini
-		$upload_max_filesize = ini_get('upload_max_filesize');
-
-		// Convert the value to bytes
-		if (stripos($upload_max_filesize, 'K') !== false)
-		{
-			$upload_max_filesize = round(str_replace('K', '', $upload_max_filesize) * 1024);
-		}
-		elseif (stripos($upload_max_filesize, 'M') !== false)
-		{
-			$upload_max_filesize = round(str_replace('M', '', $upload_max_filesize) * 1024 * 1024);
-		}
-		elseif (stripos($upload_max_filesize, 'G') !== false)
-		{
-			$upload_max_filesize = round(str_replace('G', '', $upload_max_filesize) * 1024 * 1024 * 1024);
-		}
-
-		return min($upload_max_filesize, \Config::get('maxFileSize'));
+		return min(\Symfony\Component\HttpFoundation\File\UploadedFile::getMaxFilesize(), \Config::get('maxFileSize'));
 	}
 
 	/**

--- a/core-bundle/src/Resources/contao/classes/FileUpload.php
+++ b/core-bundle/src/Resources/contao/classes/FileUpload.php
@@ -90,7 +90,7 @@ class FileUpload extends Backend
 			throw new \InvalidArgumentException('Invalid target path ' . $strTarget);
 		}
 
-		$maxlength_kb = $this->getMaximumUploadSize();
+		$maxlength_kb = static::getMaxUploadSize();
 		$maxlength_kb_readable = $this->getReadableSize($maxlength_kb);
 		$arrUploaded = array();
 		$arrFiles = $this->getFilesFromGlobal();
@@ -211,7 +211,7 @@ class FileUpload extends Backend
 		if (isset($GLOBALS['TL_LANG']['tl_files']['fileupload'][1]))
 		{
 			$return .= '
-  <p class="tl_help tl_tip">' . sprintf($GLOBALS['TL_LANG']['tl_files']['fileupload'][1], \System::getReadableSize($this->getMaximumUploadSize()), \Config::get('gdMaxImgWidth') . 'x' . \Config::get('gdMaxImgHeight')) . '</p>';
+  <p class="tl_help tl_tip">' . sprintf($GLOBALS['TL_LANG']['tl_files']['fileupload'][1], \System::getReadableSize(static::getMaxUploadSize()), \Config::get('gdMaxImgWidth') . 'x' . \Config::get('gdMaxImgHeight')) . '</p>';
 		}
 
 		return $return;
@@ -256,10 +256,15 @@ class FileUpload extends Backend
 	/**
 	 * Return the maximum upload file size in bytes
 	 *
+	 * @deprecated Deprecated since Contao 4.6, to be removed in Contao 5.0.
+	 *             Use static::getMaxUploadSize() instead.
+	 *
 	 * @return string
 	 */
 	protected function getMaximumUploadSize()
 	{
+		@trigger_error('Using FileUpload->getMaximumUploadSize() has been deprecated and will no longer work in Contao 5.0. Use FileUpload::getMaxUploadSize() instead.', E_USER_DEPRECATED);
+
 		return static::getMaxUploadSize();
 	}
 

--- a/core-bundle/src/Resources/contao/classes/FileUpload.php
+++ b/core-bundle/src/Resources/contao/classes/FileUpload.php
@@ -258,7 +258,17 @@ class FileUpload extends Backend
 	 *
 	 * @return string
 	 */
-	public static function getMaximumUploadSize()
+	protected function getMaximumUploadSize()
+	{
+		return static::getMaxUploadSize();
+	}
+
+	/**
+	 * Return the maximum upload file size in bytes
+	 *
+	 * @return string
+	 */
+	public static function getMaxUploadSize()
 	{
 		// Get the upload_max_filesize from the php.ini
 		$upload_max_filesize = ini_get('upload_max_filesize');

--- a/core-bundle/src/Resources/contao/drivers/DC_Folder.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Folder.php
@@ -520,7 +520,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 			$GLOBALS['TL_JAVASCRIPT'][] = 'assets/dropzone/js/dropzone.min.js';
 
 			$strAccepted = implode(',', array_map(function ($a) { return '.' . $a; }, \StringUtil::trimsplit(',', strtolower(\Config::get('uploadTypes')))));
-			$intMaxSize = round(\FileUpload::getMaximumUploadSize() / 1024 / 1024);
+			$intMaxSize = round(\FileUpload::getMaxUploadSize() / 1024 / 1024);
 
 			$return .= '<script>'
 				.'Dropzone.autoDiscover = false;'

--- a/core-bundle/src/Resources/contao/forms/FormFileUpload.php
+++ b/core-bundle/src/Resources/contao/forms/FormFileUpload.php
@@ -321,7 +321,7 @@ class FormFileUpload extends Widget implements \uploadable
 			return $this->maxlength;
 		}
 
-		return FileUpload::getMaxUploadSize();
+		return \FileUpload::getMaxUploadSize();
 	}
 }
 

--- a/core-bundle/src/Resources/contao/forms/FormFileUpload.php
+++ b/core-bundle/src/Resources/contao/forms/FormFileUpload.php
@@ -321,24 +321,7 @@ class FormFileUpload extends Widget implements \uploadable
 			return $this->maxlength;
 		}
 
-		// Get the upload_max_filesize from the php.ini
-		$upload_max_filesize = ini_get('upload_max_filesize');
-
-		// Convert the value to bytes
-		if (stripos($upload_max_filesize, 'K') !== false)
-		{
-			$upload_max_filesize = round($upload_max_filesize * 1024);
-		}
-		elseif (stripos($upload_max_filesize, 'M') !== false)
-		{
-			$upload_max_filesize = round($upload_max_filesize * 1024 * 1024);
-		}
-		elseif (stripos($upload_max_filesize, 'G') !== false)
-		{
-			$upload_max_filesize = round($upload_max_filesize * 1024 * 1024 * 1024);
-		}
-
-		return min($upload_max_filesize, \Config::get('maxFileSize'));
+		return FileUpload::getMaxUploadSize();
 	}
 }
 


### PR DESCRIPTION
Fixes BC break codefog/contao-haste#135 which was introduced in 5a284eb8883c1b8a5bbdabdc1ab48cc64a5a8a69.

@leofeyer should we deprecate the protected method `getMaximumUploadSize()` and use the static one everywhere instead?