### PR TITLE
Fix for #169

### DIFF
--- a/installation-bundle/src/Database/Installer.php
+++ b/installation-bundle/src/Database/Installer.php
@@ -167,7 +167,7 @@ class Installer
             }
         }
 
-        $this->checkEngineAndCollation($return, $fromSchema, $toSchema);
+        $this->checkEngineAndCollation($return, $order, $fromSchema, $toSchema);
 
         $return = array_filter($return);
 
@@ -188,13 +188,13 @@ class Installer
         }
 
         $this->commands = $return;
-        $this->commandOrder = $order;
+        $this->commandOrder = array_unique($order);
     }
 
     /**
      * Checks engine and collation and adds the ALTER TABLE queries.
      */
-    private function checkEngineAndCollation(array &$sql, Schema $fromSchema, Schema $toSchema): void
+    private function checkEngineAndCollation(array &$sql, array &$order, Schema $fromSchema, Schema $toSchema): void
     {
         $tables = $toSchema->getTables();
         $dynamic = $this->hasDynamicRowFormat();
@@ -275,11 +275,13 @@ class Installer
                     }
 
                     $sql['ALTER_TABLE'][$strKey] = $indexCommand;
+                    $order[] = $strKey;
                 }
             }
 
             foreach ($alterTables as $k => $alterTable) {
                 $sql['ALTER_TABLE'][$k] = $alterTable;
+                $order[] = $k;
             }
         }
     }


### PR DESCRIPTION
Followup to #169 

Now commands in `checkEngineAndCollation()` are also tracked.

Quick note: These lines...
https://github.com/contao/contao/blob/0670398703691e33dafb18842ec67460a50e4a1e/installation-bundle/src/Database/Installer.php#L273-L275
... probably make sure there are no duplicates shown in the GUI. However, we need the first entry for the correct order. I am therefore adding all hashes no matter what and later calling `array_unique` on the order array to ensure only the first entries are kept.