### PR TITLE
Validate primary key when registering or saving a Model

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Model.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Model.php
@@ -416,19 +416,6 @@ abstract class Model
 			throw new \RuntimeException('The model instance has been detached and cannot be saved');
 		}
 
-		$intPk = $this->{static::$strPk};
-
-		// Track primary key changes
-		if (isset($this->arrModified[static::$strPk]))
-		{
-			$intPk = $this->arrModified[static::$strPk];
-		}
-
-		if ($intPk !== null && empty($intPk))
-		{
-			throw new \RuntimeException('Model cannot be saved: Invalid primary key (' . static::$strPk . ')');
-		}
-
 		$objDatabase = \Database::getInstance();
 		$arrFields = $objDatabase->getFieldNames(static::$strTable);
 
@@ -454,6 +441,19 @@ abstract class Model
 			if (empty($arrSet))
 			{
 				return $this;
+			}
+
+			$intPk = $this->{static::$strPk};
+
+			// Track primary key changes
+			if (isset($this->arrModified[static::$strPk]))
+			{
+				$intPk = $this->arrModified[static::$strPk];
+			}
+
+			if ($intPk === null)
+			{
+				throw new \RuntimeException('The primary key has not been set');
 			}
 
 			// Update the row

--- a/core-bundle/src/Resources/contao/library/Contao/Model.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Model.php
@@ -416,6 +416,19 @@ abstract class Model
 			throw new \RuntimeException('The model instance has been detached and cannot be saved');
 		}
 
+		$intPk = $this->{static::$strPk};
+
+		// Track primary key changes
+		if (isset($this->arrModified[static::$strPk]))
+		{
+			$intPk = $this->arrModified[static::$strPk];
+		}
+
+		if ($intPk !== null && empty($intPk))
+		{
+			throw new \RuntimeException('Model cannot be saved: Invalid primary key (' . static::$strPk . ')');
+		}
+
 		$objDatabase = \Database::getInstance();
 		$arrFields = $objDatabase->getFieldNames(static::$strTable);
 
@@ -441,14 +454,6 @@ abstract class Model
 			if (empty($arrSet))
 			{
 				return $this;
-			}
-
-			$intPk = $this->{static::$strPk};
-
-			// Track primary key changes
-			if (isset($this->arrModified[static::$strPk]))
-			{
-				$intPk = $this->arrModified[static::$strPk];
 			}
 
 			// Update the row

--- a/core-bundle/src/Resources/contao/library/Contao/Model/Registry.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Model/Registry.php
@@ -168,6 +168,13 @@ class Registry implements \Countable
 		$strPk = $objModel->getPk();
 		$varPk = $objModel->$strPk;
 
+		if ($varPk === null || $varPk === '')
+		{
+			throw new \RuntimeException(
+				"Cannot register a model with a primary key that is null or empty string ($strTable::$strPk)"
+			);
+		}
+
 		// Another model object is pointing to the DB record already
 		if (isset($this->arrRegistry[$strTable][$varPk]))
 		{

--- a/core-bundle/src/Resources/contao/library/Contao/Model/Registry.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Model/Registry.php
@@ -168,11 +168,9 @@ class Registry implements \Countable
 		$strPk = $objModel->getPk();
 		$varPk = $objModel->$strPk;
 
-		if ($varPk === null || $varPk === '')
+		if ($varPk === null)
 		{
-			throw new \RuntimeException(
-				"Cannot register a model with a primary key that is null or empty string ($strTable::$strPk)"
-			);
+			throw new \RuntimeException('The primary key has not been set');
 		}
 
 		// Another model object is pointing to the DB record already


### PR DESCRIPTION
Consider the following:
```
$model = new Contao\PageModel();
$model->title = 'Foo';
$model->attach();
```
This works once per table (in this example, `tl_page`), because `Contao\Model\Registry::arrRegistry` then has one key for that table that is `""` (empty string):
```
array(13) {
  // …
  ["tl_page"]=>
  array(58) {
    [1]=>
    object(Contao\PageModel)#641 (6) { /* … */ }
    [4]=>
    object(Contao\PageModel)#768 (6) { /* … */ }
    // …
    [""]=>
    object(Contao\PageModel)#2094 (6) { /* Our Model */ }
  }
  // …
}
```
Once we do the same thing again:
```
$model2 = new Contao\PageModel();
$model2->title = 'Bar';
$model2->attach();
```
we suddenly get an exception:
> The registry already contains an instance for tl_page::id()

Obviously, this is not the expected behavior. The Registry should either categorically allow registering a model without a primary key or categorically not allow it. This fix implements the latter. It does not use `empty()` because that would overshoot and prevent the primary key from being `0` or `"0"`, which may not be recommendable, but does not have to be forbidden in this context.