### PR TITLE
[RFC] Added the onshow_callback to DC_Table

### DIFF
--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -637,8 +637,8 @@ class DC_Table extends DataContainer implements \listable, \editable
 			{
 				$class = (($index % 2) !== 0) ? ' class="tl_bg"' : '';
 
-                // Always encode special characters (thanks to Oliver Klee)
-                $return .= '
+				// Always encode special characters (thanks to Oliver Klee)
+				$return .= '
   <tr>
     <td'.$class.'><span class="tl_label">'.$item['label'].': </span></td>
     <td'.$class.'>'.\StringUtil::specialchars($item['value']).'</td>

--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -637,7 +637,8 @@ class DC_Table extends DataContainer implements \listable, \editable
 			{
 				$class = (($index % 2) !== 0) ? ' class="tl_bg"' : '';
 
-				$return .= '
+                // Always encode special characters (thanks to Oliver Klee)
+                $return .= '
   <tr>
     <td'.$class.'><span class="tl_label">'.$item['label'].': </span></td>
     <td'.$class.'>'.\StringUtil::specialchars($item['value']).'</td>

--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -618,20 +618,17 @@ class DC_Table extends DataContainer implements \listable, \editable
 			{
 				$return .= '
   <tr>
-    <td colspan="2" style="height:5em"></td>
+    <td colspan="2" style="height:1em"></td>
   </tr>';
 			}
 
-			// Add the table name if there are multiple (e.g. tl_undo);
-			if (count($data) > 1)
-			{
-				$return .= '
+			// Add the table name
+			$return .= '
   <tr>
     <td class="tl_folder_top"><span class="tl_label">'.$GLOBALS['TL_LANG']['MSC']['table'].': </span></td>
     <td class="tl_folder_top">'.$table.'</td>
   </tr>
 ';
-			}
 
 			foreach (array_values($items) as $index => $item)
 			{


### PR DESCRIPTION
This adds the `onshow_callback` to `DC_Table` which can be used to alter the tables displayed in popup when clicking the `show` record operation. The syntax is as follows:

```php
$GLOBALS['TL_DCA']['tl_table']['config']['onshow_callback'][] = [TableListener::class, 'onShowCallback'];

class TableListener {
    /**
     * On data container record show callback.
     * 
     * @param array         $data The computed table data.
     * @param array         $row  The genuine row data.
     * @param DataContainer $dc
     *
     * @return array
     */
    public function onShowCallback(array $data, array $row, DataContainer $dc): array 
    {
        $data[$dc->table]['my_field']['value'] = strtoupper($row['my_field']);
        
        return $data;
    }
}
```

I have also tweaked a display of the `tl_undo` table a bit as you can see on the screenshot:

![tl_undo](https://user-images.githubusercontent.com/193483/49938876-750ed780-fedb-11e8-9177-f911ab151777.png)

The regular view remains the same:

![tl_movie](https://user-images.githubusercontent.com/193483/49938885-7e983f80-fedb-11e8-84c9-da27a1965873.png)

With regards to #225.