### PR TITLE
Check for non existing options in install tool when used outside managed edition

### DIFF
--- a/installation-bundle/src/InstallTool.php
+++ b/installation-bundle/src/InstallTool.php
@@ -195,6 +195,11 @@ class InstallTool
 
         $options = $this->connection->getParams()['defaultTableOptions'];
 
+        // If Contao is used as bundle and there are no custom settings
+        if (empty($options)) {
+            return false;
+        }
+
         // Check the collation if the user has configured it
         if (isset($options['collate'])) {
             $statement = $this->connection->query("SHOW COLLATION LIKE '".$options['collate']."'");

--- a/installation-bundle/src/InstallTool.php
+++ b/installation-bundle/src/InstallTool.php
@@ -234,14 +234,9 @@ class InstallTool
             }
         } else {
             // Use default engine if none is configured
-            $statement = $this->connection->query('SHOW ENGINES');
-
-            while (false !== ($row = $statement->fetch(\PDO::FETCH_OBJ))) {
-                if ($row['support'] === 'DEFAULT') {
-                    $options['engine'] = $row['engine'];
-                    break;
-                }
-            }
+            $statement = $this->connection->query('SHOW VARIABLES WHERE variable_name = "default_storage_engine"');
+            $row = $statement->fetch(\PDO::FETCH_ASSOC);
+            $options['engine'] = $row['value'];
         }
 
         // Check if utf8mb4 can be used if the user has configured it


### PR DESCRIPTION
When using the Contao as a bundle, there is an error if you don't specifically set `InnoDB` as engine. This pull request checks for non existing options and exists the `hasConfigurationError()` method without error.

@leofeyer I hope this is what you meant. If not, please let me know.

It's a replacement of this pull request https://github.com/contao/contao/pull/69