### PR TITLE
Page root domain with custom port does not work with CMF routing.

### DIFF
--- a/core-bundle/src/Routing/RouteProvider.php
+++ b/core-bundle/src/Routing/RouteProvider.php
@@ -259,7 +259,7 @@ class RouteProvider implements RouteProviderInterface
 
         $requirements = ['parameters' => '(/.+)?'];
         $path = sprintf('/%s{parameters}%s', $page->alias ?: $page->id, $this->urlSuffix);
-        $host = ($page->domain) ? strtok($page->domain, ':') : null;
+        $host = $page->domain ? strtok($page->domain, ':') : null;
 
         if ($this->prependLocale) {
             $path = '/{_locale}'.$path;
@@ -289,7 +289,7 @@ class RouteProvider implements RouteProviderInterface
         $path = '/';
         $requirements = [];
         $defaults = $this->getRouteDefaults($page);
-        $host = ($page->domain) ? strtok($page->domain, ':') : null;
+        $host = $page->domain ? strtok($page->domain, ':') : null;
 
         if ($this->prependLocale) {
             $path = '/{_locale}'.$path;

--- a/core-bundle/src/Routing/RouteProvider.php
+++ b/core-bundle/src/Routing/RouteProvider.php
@@ -259,7 +259,7 @@ class RouteProvider implements RouteProviderInterface
 
         $requirements = ['parameters' => '(/.+)?'];
         $path = sprintf('/%s{parameters}%s', $page->alias ?: $page->id, $this->urlSuffix);
-        $host = strtok((string) $page->domain, ':') ?: $page->domain;
+        $host = ($page->domain) ? strtok($page->domain, ':') : null;
 
         if ($this->prependLocale) {
             $path = '/{_locale}'.$path;
@@ -289,7 +289,7 @@ class RouteProvider implements RouteProviderInterface
         $path = '/';
         $requirements = [];
         $defaults = $this->getRouteDefaults($page);
-        $host = strtok((string) $page->domain, ':') ?: $page->domain;
+        $host = ($page->domain) ? strtok($page->domain, ':') : null;
 
         if ($this->prependLocale) {
             $path = '/{_locale}'.$path;

--- a/core-bundle/src/Routing/RouteProvider.php
+++ b/core-bundle/src/Routing/RouteProvider.php
@@ -270,7 +270,7 @@ class RouteProvider implements RouteProviderInterface
             $defaults,
             $requirements,
             ['utf8' => true],
-            $page->domain,
+            strtok($page->domain, ':'),
             null
         );
 
@@ -299,7 +299,7 @@ class RouteProvider implements RouteProviderInterface
             $defaults,
             $requirements,
             [],
-            $page->domain,
+            strtok($page->domain, ':'),
             null
         );
 

--- a/core-bundle/src/Routing/RouteProvider.php
+++ b/core-bundle/src/Routing/RouteProvider.php
@@ -259,6 +259,7 @@ class RouteProvider implements RouteProviderInterface
 
         $requirements = ['parameters' => '(/.+)?'];
         $path = sprintf('/%s{parameters}%s', $page->alias ?: $page->id, $this->urlSuffix);
+        $host = strtok((string) $page->domain, ':') ?: $page->domain;
 
         if ($this->prependLocale) {
             $path = '/{_locale}'.$path;
@@ -270,7 +271,7 @@ class RouteProvider implements RouteProviderInterface
             $defaults,
             $requirements,
             ['utf8' => true],
-            strtok($page->domain, ':'),
+            $host,
             null
         );
 
@@ -288,6 +289,7 @@ class RouteProvider implements RouteProviderInterface
         $path = '/';
         $requirements = [];
         $defaults = $this->getRouteDefaults($page);
+        $host = strtok((string) $page->domain, ':') ?: $page->domain;
 
         if ($this->prependLocale) {
             $path = '/{_locale}'.$path;
@@ -299,7 +301,7 @@ class RouteProvider implements RouteProviderInterface
             $defaults,
             $requirements,
             [],
-            strtok($page->domain, ':'),
+            $host,
             null
         );
 
@@ -321,7 +323,7 @@ class RouteProvider implements RouteProviderInterface
             $defaults,
             [],
             [],
-            $page->domain,
+            $host,
             null
         );
     }

--- a/core-bundle/tests/Routing/RouteProviderTest.php
+++ b/core-bundle/tests/Routing/RouteProviderTest.php
@@ -96,6 +96,43 @@ class RouteProviderTest extends TestCase
         $this->assertCount(2, $routes);
     }
 
+    public function testRoutesWithPortInDomain(): void
+    {
+        $page = $this->mockClassWithProperties(PageModel::class, ['id' => 17, 'domain' => 'example.org:4430']);
+
+        $pageAdapter = $this->mockAdapter(['findByPk']);
+        $pageAdapter
+            ->expects($this->once())
+            ->method('findByPk')
+            ->with(17)
+            ->willReturn($page)
+        ;
+
+        $framework = $this->mockFramework($pageAdapter);
+        $route = $this->mockRouteProvider($framework)->getRouteByName('tl_page.17');
+
+        $this->assertSame('example.org', $route->getHost());
+    }
+
+
+    public function testRoutesWithDomain(): void
+    {
+        $page = $this->mockClassWithProperties(PageModel::class, ['id' => 17, 'domain' => 'example.org']);
+
+        $pageAdapter = $this->mockAdapter(['findByPk']);
+        $pageAdapter
+            ->expects($this->once())
+            ->method('findByPk')
+            ->with(17)
+            ->willReturn($page)
+        ;
+
+        $framework = $this->mockFramework($pageAdapter);
+        $route = $this->mockRouteProvider($framework)->getRouteByName('tl_page.17');
+
+        $this->assertSame('example.org', $route->getHost());
+    }
+
     public function testFindsAllPagesForGetRoutesByNamesWithNullArgument(): void
     {
         $pageAdapter = $this->mockAdapter(['findAll']);

--- a/core-bundle/tests/Routing/RouteProviderTest.php
+++ b/core-bundle/tests/Routing/RouteProviderTest.php
@@ -96,9 +96,9 @@ class RouteProviderTest extends TestCase
         $this->assertCount(2, $routes);
     }
 
-    public function testRoutesWithPortInDomain(): void
+    public function testHandlesRoutesWithDomain(): void
     {
-        $page = $this->mockClassWithProperties(PageModel::class, ['id' => 17, 'domain' => 'example.org:4430']);
+        $page = $this->mockClassWithProperties(PageModel::class, ['id' => 17, 'domain' => 'example.org']);
 
         $pageAdapter = $this->mockAdapter(['findByPk']);
         $pageAdapter
@@ -114,10 +114,9 @@ class RouteProviderTest extends TestCase
         $this->assertSame('example.org', $route->getHost());
     }
 
-
-    public function testRoutesWithDomain(): void
+    public function testHandlesRoutesWithDomainAndPort(): void
     {
-        $page = $this->mockClassWithProperties(PageModel::class, ['id' => 17, 'domain' => 'example.org']);
+        $page = $this->mockClassWithProperties(PageModel::class, ['id' => 17, 'domain' => 'example.org:443']);
 
         $pageAdapter = $this->mockAdapter(['findByPk']);
         $pageAdapter


### PR DESCRIPTION
I am using a custom port in the domain setting of the root page.
Adding the port to the domain always have been necessary.
<img width="823" alt="screen shot 2019-01-16 at 22 27 11" src="https://user-images.githubusercontent.com/1284725/51279893-941eee80-19de-11e9-9c1f-ad45938a01eb.png">

However, this setting is not compatible with the CMF routing implementation, because the host regex check fails in the routing matcher.
Cutting of the port of the domain while translating the page model to a route works out.

If you already are aware of this bug, feel free to close the PR.