### PR TITLE
[CMF routing] Matching fails if getPageIdFromUrl hook is present and domain is defined in page root.

### DIFF
--- a/core-bundle/src/Routing/Matcher/LegacyMatcher.php
+++ b/core-bundle/src/Routing/Matcher/LegacyMatcher.php
@@ -96,7 +96,7 @@ class LegacyMatcher implements RequestMatcherInterface
         }
 
         $fragments = $this->executeLegacyHook($fragments);
-        $pathInfo = $this->createPathFromFragments($fragments, $locale);
+        $pathInfo = $this->createPathFromFragments($fragments, $request, $locale);
 
         return $this->requestMatcher->matchRequest(Request::create($pathInfo));
     }
@@ -157,7 +157,7 @@ class LegacyMatcher implements RequestMatcherInterface
         return $fragments;
     }
 
-    private function createPathFromFragments(array $fragments, ?string $locale): string
+    private function createPathFromFragments(array $fragments, Request $request, ?string $locale): string
     {
         /** @var Config $config */
         $config = $this->framework->getAdapter(Config::class);
@@ -170,6 +170,12 @@ class LegacyMatcher implements RequestMatcherInterface
 
         if ($this->prependLocale) {
             $pathInfo = $locale.'/'.$pathInfo;
+        }
+
+        if ($request->getHost()) {
+            // Add the host to the path
+            // The host will become 'localhost' otherwise and the host regex check in the url matcher will fail
+            return '//'.$request->getHost().'/'.$pathInfo;
         }
 
         return '/'.$pathInfo;


### PR DESCRIPTION
Please remember #280, in which the host regex failed if a port was present in the domain.

When I say "the host regex fails" I mean exactly this point in the Url matcher:
https://github.com/symfony/routing/blob/v4.2.2/Matcher/UrlMatcher.php#L178
As a result, no page can be found with the error **No route found for "GET /"**.

I encountered another case, in which the host regex fails (see https://github.com/contao/contao/pull/280#issuecomment-455128803) and this PR fixes this:

Whenever a listener for the `getPageIdFromUrl` hook is present (as in Isotope, for example), the `LegacyMatcher` applies some extra logic.

In https://github.com/contao/core-bundle/blob/4.7.0-RC3/src/Routing/Matcher/LegacyMatcher.php#L101 a new request is created based on the result of the hook.
However, `Request::create()` will set the `HTTP_HOST` to `localhost` by default. Here again, the host regex will fail in case you have set a custom domain in the page root. The fix is to keep the original host from the request.