### PR TITLE
Sort unpreferred languages by root page priority

### DIFF
--- a/core-bundle/src/Resources/contao/models/PageModel.php
+++ b/core-bundle/src/Resources/contao/models/PageModel.php
@@ -82,6 +82,7 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
  * @property string  $rootAlias
  * @property string  $rootTitle
  * @property string  $rootPageTitle
+ * @property integer $rootSorting
  * @property string  $domain
  * @property string  $rootLanguage
  * @property boolean $rootIsPublic
@@ -957,6 +958,7 @@ class PageModel extends Model
 			$this->rootAlias = $objParentPage->alias;
 			$this->rootTitle = $objParentPage->title;
 			$this->rootPageTitle = $objParentPage->pageTitle ?: $objParentPage->title;
+			$this->rootSorting = $objParentPage->rootSorting;
 			$this->domain = $objParentPage->dns;
 			$this->rootLanguage = $objParentPage->language;
 			$this->language = $objParentPage->language;

--- a/core-bundle/src/Routing/RouteProvider.php
+++ b/core-bundle/src/Routing/RouteProvider.php
@@ -421,7 +421,7 @@ class RouteProvider implements RouteProviderInterface
                         return -1;
                     }
 
-                    return $pageB->rootIsFallback ? 1 : 0;
+                    return $pageB->rootIsFallback ? 1 : strcmp($pageA->rootSorting, $pageB->rootSorting);
                 }
 
                 if (null === $langA && null !== $langB) {

--- a/core-bundle/src/Routing/RouteProvider.php
+++ b/core-bundle/src/Routing/RouteProvider.php
@@ -421,7 +421,7 @@ class RouteProvider implements RouteProviderInterface
                         return -1;
                     }
 
-                    return $pageB->rootIsFallback ? 1 : strcmp($pageA->rootSorting, $pageB->rootSorting);
+                    return $pageB->rootIsFallback ? 1 : strnatcmp((string) $pageA->rootSorting, (string) $pageB->rootSorting);
                 }
 
                 if (null === $langA && null !== $langB) {

--- a/core-bundle/tests/Routing/RouteProviderTest.php
+++ b/core-bundle/tests/Routing/RouteProviderTest.php
@@ -405,15 +405,26 @@ class RouteProviderTest extends TestCase
             ['en'],
         ];
 
-        yield 'Complex sorting (1)' => [
+        yield 'Sorts fallback root first' => [
             [
-                2 => $this->createPage('de', 'foo'),
-                1 => $this->createPage('de', 'foo/bar'),
+                2 => $this->createPage('de', 'foo', false),
+                4 => $this->createPage('en', 'foo', false),
+                1 => $this->createPage('de', 'foo/bar', false),
                 0 => $this->createPage('en', 'foo', true, 'example.com'),
-                4 => $this->createPage('en', 'foo'),
-                3 => $this->createPage('en', 'foo/bar'),
+                3 => $this->createPage('en', 'foo/bar', false),
             ],
             ['de', 'fr'],
+        ];
+
+        // createPage() generates a rootSorting value from the language, so the test order is by language
+        yield 'Sorts by root page sorting if none of the languages is fallback' => [
+            [
+                1 => $this->createPage('en', 'foo', false),
+                3 => $this->createPage('ru', 'foo', false),
+                2 => $this->createPage('fr', 'foo', false),
+                0 => $this->createPage('en', 'foo/bar', false),
+            ],
+            ['de'],
         ];
     }
 
@@ -545,6 +556,7 @@ class RouteProviderTest extends TestCase
                 'rootLanguage' => $language,
                 'rootIsFallback' => $fallback,
                 'rootUseSSL' => 'https' === $scheme,
+                'rootSorting' => array_reduce((array) $language, function ($c, $i) { return $c + ord($i); }, 0),
             ]
         );
     }


### PR DESCRIPTION
My case was this:

 - `folderUrl` is enabled
 - my browser prefers `de` as language
 - I have four pages, which are fetched in this order from the DB
   1. Alias `foo` with language `en`
   2. Alias `foo` with language `fr`
   3. Alias `foo` with language `zh`
   4. Alias `foo/bar` with language `en`

Because none of the languages is in my browser preferences, the items are currently not re-sorted. So Page 1 is never compared to page 4, which means they are not sorted by alias.

I have not yet created a unit test, it probably needs a new test method and can't be accomplished within the existing data providers.