### PR TITLE
Add public constructor to Newsletter.php

### DIFF
--- a/newsletter-bundle/src/Resources/contao/classes/Newsletter.php
+++ b/newsletter-bundle/src/Resources/contao/classes/Newsletter.php
@@ -21,6 +21,11 @@ use Symfony\Component\HttpFoundation\Session\SessionInterface;
 class Newsletter extends \Backend
 {
 
+	public function __construct()
+	{
+		parent::__construct();
+	}
+	
 	/**
 	 * Return a form to choose an existing style sheet and import it
 	 *


### PR DESCRIPTION
see #322 

Other option: Make `Backend` instantiable. But to be honest, this class only holds static functions (and the 3 or 4 instance methods do not share common data, they only access a common database / user instance object). It's a BC fix; from a system design point of view the Newsletter class imo would not need to have a base class at all.