### PR TITLE
Cast possible integer to string

### DIFF
--- a/core-bundle/src/EventListener/CsrfTokenCookieListener.php
+++ b/core-bundle/src/EventListener/CsrfTokenCookieListener.php
@@ -107,8 +107,8 @@ class CsrfTokenCookieListener
         $tokens = [];
 
         foreach ($cookies as $key => $value) {
-            if (0 === strpos($key, $this->cookiePrefix) && preg_match('/^[a-z0-9_-]+$/i', $value)) {
-                $tokens[substr($key, \strlen($this->cookiePrefix))] = $value;
+            if (0 === strpos((string) $key, $this->cookiePrefix) && preg_match('/^[a-z0-9_-]+$/i', $value)) {
+                $tokens[substr((string) $key, \strlen($this->cookiePrefix))] = $value;
             }
         }
 

--- a/core-bundle/tests/EventListener/CsrfTokenCookieListenerTest.php
+++ b/core-bundle/tests/EventListener/CsrfTokenCookieListenerTest.php
@@ -43,6 +43,7 @@ class CsrfTokenCookieListenerTest extends TestCase
             'csrf_generated' => $generatedToken,
             'not_csrf' => 'baz',
             'csrf_bar' => '"<>!&', // ignore invalid characters
+            0 => 'foobar', // test integer key
         ]);
 
         $requestEvent = $this->createMock(GetResponseEvent::class);


### PR DESCRIPTION
In my error logs following error showed up randomly:

```
[2019-02-09 04:48:53] app.CRITICAL: An exception occurred. {"exception":"[object] (Symfony\\Component\\Debug\\Exception\\FatalThrowableError(code: 0): Type error: strpos() expects parameter 1 to be string, integer given at /home/deploy/production/releases/20181210091124/vendor/contao/core-bundle/src/EventListener/CsrfTokenCookieListener.php:89)"} []
```
You can reproduce this by dropping a cookie with a numerical name (here with name `0`):
![screen-shot-2019-02-12-at-10 20 22](https://user-images.githubusercontent.com/754921/52626057-aa6f7b80-2eb2-11e9-8921-148d8f995850.png)
