### PR TITLE
Always generate secret urls when request is secure

### DIFF
--- a/core-bundle/src/Resources/contao/models/PageModel.php
+++ b/core-bundle/src/Resources/contao/models/PageModel.php
@@ -1048,7 +1048,7 @@ class PageModel extends Model
 			(
 				'_locale' => ($strForceLang ?: $this->rootLanguage),
 				'_domain' => $this->domain,
-				'_ssl' => (bool) $this->rootUseSSL,
+				'_ssl' => Environment::get('ssl') || (bool) $this->rootUseSSL,
 			)
 		);
 
@@ -1083,7 +1083,7 @@ class PageModel extends Model
 			(
 				'_locale' => $this->rootLanguage,
 				'_domain' => $this->domain,
-				'_ssl' => (bool) $this->rootUseSSL,
+				'_ssl' => Environment::get('ssl') || (bool) $this->rootUseSSL,
 			),
 			UrlGeneratorInterface::ABSOLUTE_URL
 		);


### PR DESCRIPTION
Ignore `rootUseSSL` setting, when request is already secure (`https`).