### PR TITLE
[RFC] Made the assets directory truly configurable

### DIFF
--- a/core-bundle/src/Command/InstallCommand.php
+++ b/core-bundle/src/Command/InstallCommand.php
@@ -48,6 +48,11 @@ class InstallCommand extends Command
     /**
      * @var string
      */
+    private $assetsDir;
+
+    /**
+     * @var string
+     */
     private $uploadPath;
 
     /**
@@ -65,9 +70,10 @@ class InstallCommand extends Command
      */
     private $webDir;
 
-    public function __construct(string $rootDir, string $uploadPath, string $imageDir, LockInterface $lock)
+    public function __construct(string $rootDir, string $assetsDir, string $uploadPath, string $imageDir, LockInterface $lock)
     {
         $this->rootDir = $rootDir;
+        $this->assetsDir = $assetsDir;
         $this->uploadPath = $uploadPath;
         $this->imageDir = $imageDir;
         $this->lock = $lock;
@@ -146,18 +152,18 @@ class InstallCommand extends Command
 
     private function addIgnoredDirs(): void
     {
-        static $ignoredDirs = [
-            'assets/css',
-            'assets/js',
+        $ignoredDirs = [
+            sprintf('%s/css', $this->assetsDir),
+            sprintf('%s/js', $this->assetsDir),
             'system/cache',
             'system/modules',
             'system/themes',
             'system/tmp',
-            '%s/share',
+            sprintf('%s/%s/share', $this->rootDir, $this->webDir),
         ];
 
         foreach ($ignoredDirs as $path) {
-            $this->addIgnoredDir($this->rootDir.'/'.sprintf($path, $this->webDir));
+            $this->addIgnoredDir($path);
         }
 
         $this->addIgnoredDir($this->imageDir);

--- a/core-bundle/src/Command/SymlinksCommand.php
+++ b/core-bundle/src/Command/SymlinksCommand.php
@@ -51,6 +51,11 @@ class SymlinksCommand extends Command
     /**
      * @var string
      */
+    private $assetsDir;
+
+    /**
+     * @var string
+     */
     private $webDir;
 
     /**
@@ -83,9 +88,10 @@ class SymlinksCommand extends Command
      */
     private $statusCode = 0;
 
-    public function __construct(string $rootDir, string $uploadPath, string $logsDir, ResourceFinderInterface $resourceFinder, EventDispatcherInterface $eventDispatcher, LockInterface $lock)
+    public function __construct(string $rootDir, string $assetsDir, string $uploadPath, string $logsDir, ResourceFinderInterface $resourceFinder, EventDispatcherInterface $eventDispatcher, LockInterface $lock)
     {
         $this->rootDir = $rootDir;
+        $this->assetsDir = $assetsDir;
         $this->uploadPath = $uploadPath;
         $this->logsDir = $logsDir;
         $this->resourceFinder = $resourceFinder;
@@ -152,7 +158,7 @@ class SymlinksCommand extends Command
         $this->symlinkThemes();
 
         // Symlink the assets and themes directory
-        $this->symlink('assets', $this->webDir.'/assets');
+        $this->symlink($this->assetsDir, $this->webDir.'/assets');
         $this->symlink('system/themes', $this->webDir.'/system/themes');
 
         // Symlinks the logs directory

--- a/core-bundle/src/DependencyInjection/Configuration.php
+++ b/core-bundle/src/DependencyInjection/Configuration.php
@@ -60,6 +60,17 @@ class Configuration implements ConfigurationInterface
                         )
                     ->end()
                 ->end()
+                ->scalarNode('assets_dir')
+                    ->cannotBeEmpty()
+                    ->defaultValue($this->canonicalize($this->projectDir.'/assets'))
+                    ->validate()
+                        ->always(
+                            function (string $value): string {
+                                return $this->canonicalize($value);
+                            }
+                        )
+                    ->end()
+                ->end()
                 ->booleanNode('prepend_locale')
                     ->defaultFalse()
                 ->end()

--- a/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
+++ b/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
@@ -70,6 +70,7 @@ class ContaoCoreExtension extends Extension
         }
 
         $container->setParameter('contao.web_dir', $config['web_dir']);
+        $container->setParameter('contao.assets_dir', $config['assets_dir']);
         $container->setParameter('contao.prepend_locale', $config['prepend_locale']);
         $container->setParameter('contao.encryption_key', $config['encryption_key']);
         $container->setParameter('contao.url_suffix', $config['url_suffix']);

--- a/core-bundle/src/Resources/config/commands.yml
+++ b/core-bundle/src/Resources/config/commands.yml
@@ -22,6 +22,7 @@ services:
         class: Contao\CoreBundle\Command\InstallCommand
         arguments:
             - '%kernel.project_dir%'
+            - '%contao.assets_dir%'
             - '%contao.upload_path%'
             - '%contao.image.target_dir%'
             - "@lock"
@@ -31,6 +32,7 @@ services:
         class: Contao\CoreBundle\Command\SymlinksCommand
         arguments:
             - '%kernel.project_dir%'
+            - '%contao.assets_dir%'
             - '%contao.upload_path%'
             - '%kernel.logs_dir%'
             - '@contao.resource_finder'

--- a/core-bundle/src/Resources/contao/library/Contao/Automator.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Automator.php
@@ -124,8 +124,10 @@ class Automator extends System
 	 */
 	public function purgeScriptCache()
 	{
-		// assets/js and assets/css
-		foreach (array('assets/js', 'assets/css') as $dir)
+		$container = System::getContainer();
+		$strAssetsDir = $container->getParameter('contao.assets_dir');
+
+		foreach (array($strAssetsDir.'/js', $strAssetsDir.'/css') as $dir)
 		{
 			// Purge the folder
 			$objFolder = new Folder($dir);

--- a/core-bundle/tests/Command/InstallCommandTest.php
+++ b/core-bundle/tests/Command/InstallCommandTest.php
@@ -46,7 +46,7 @@ class InstallCommandTest extends TestCase
 
     public function testCreatesTheContaoFolders(): void
     {
-        $command = $this->mockCommand('files', $this->getTempDir().'/assets/images');
+        $command = $this->mockCommand('assets', 'files', $this->getTempDir().'/assets/images');
         $tester = new CommandTester($command);
         $code = $tester->execute([]);
         $output = $tester->getDisplay();
@@ -64,7 +64,7 @@ class InstallCommandTest extends TestCase
 
     public function testHandlesCustomFilesAndImagesPaths(): void
     {
-        $command = $this->mockCommand('files_test', $this->getTempDir().'/assets/images_test');
+        $command = $this->mockCommand('assets', 'files_test', $this->getTempDir().'/assets/images_test');
         $tester = new CommandTester($command);
         $code = $tester->execute([]);
         $display = $tester->getDisplay();
@@ -76,7 +76,7 @@ class InstallCommandTest extends TestCase
 
     public function testIsLockedWhileRunning(): void
     {
-        $command = $this->mockCommand('files', $this->getTempDir().'/assets/images', true);
+        $command = $this->mockCommand('assets', 'files', $this->getTempDir().'/assets/images', true);
         $tester = new CommandTester($command);
         $code = $tester->execute([]);
 
@@ -84,7 +84,7 @@ class InstallCommandTest extends TestCase
         $this->assertContains('The command is already running in another process.', $tester->getDisplay());
     }
 
-    private function mockCommand(string $uploadPath, string $imageDir, bool $isLocked = false): InstallCommand
+    private function mockCommand(string $assetsDir, string $uploadPath, string $imageDir, bool $isLocked = false): InstallCommand
     {
         $lock = $this->createMock(LockInterface::class);
         $lock
@@ -98,6 +98,6 @@ class InstallCommandTest extends TestCase
             ->method('release')
         ;
 
-        return new InstallCommand($this->getTempDir(), $uploadPath, $imageDir, $lock);
+        return new InstallCommand($this->getTempDir(), $assetsDir, $uploadPath, $imageDir, $lock);
     }
 }

--- a/core-bundle/tests/Command/SymlinksCommandTest.php
+++ b/core-bundle/tests/Command/SymlinksCommandTest.php
@@ -111,6 +111,7 @@ class SymlinksCommandTest extends TestCase
 
         return new SymlinksCommand(
             $this->getFixturesDir(),
+            'assets',
             'files',
             $this->getFixturesDir().'/var/logs',
             new ResourceFinder($this->getFixturesDir().'/vendor/contao/test-bundle/Resources/contao'),

--- a/core-bundle/tests/DependencyInjection/ConfigurationTest.php
+++ b/core-bundle/tests/DependencyInjection/ConfigurationTest.php
@@ -62,6 +62,7 @@ class ConfigurationTest extends TestCase
         $params = [
             'contao' => [
                 'web_dir' => $unix,
+                'assets_dir' => $unix,
                 'image' => [
                     'target_dir' => $windows,
                 ],
@@ -71,6 +72,7 @@ class ConfigurationTest extends TestCase
         $configuration = (new Processor())->processConfiguration($this->configuration, $params);
 
         $this->assertSame('/tmp/contao', $configuration['web_dir']);
+        $this->assertSame('/tmp/contao', $configuration['assets_dir']);
         $this->assertSame('C:\Temp\contao', $configuration['image']['target_dir']);
     }
 


### PR DESCRIPTION
This PR allows you to configure the `assets_dir` in the `contao` bundle configuration. I'm not so sure I caught  every single case.

For example: If you want to move the `/assets` directory to `/contao/assets`, you'll need to configure Contao like this:

```yaml
# config/packages/contao.yml
contao:
    assets_dir: "%kernel.project_dir%/contao/assets"
    images:
        target_dir: "%kernel.project_dir%/contao/assets/images"
```

```json
# composer.json
{
    "extra": {
        "contao-component-dir": "contao/assets",
    },
}
```

Maybe we will find a way to unify this even more.
