### PR TITLE
fix DCA compiler & listener

### DIFF
--- a/core-bundle/src/DependencyInjection/Compiler/DataContainerCallbackPass.php
+++ b/core-bundle/src/DependencyInjection/Compiler/DataContainerCallbackPass.php
@@ -75,7 +75,7 @@ class DataContainerCallbackPass implements CompilerPassInterface
             );
         }
 
-        if (substr_compare($attributes['target'], '.wizard', -7) && '_callback' !== substr($attributes['target'], -9)) {
+        if (!\in_array(substr($attributes['target'], -7), ['.wizard', '.xlabel']) && '_callback' !== substr($attributes['target'], -9)) {
             $attributes['target'] .= '_callback';
         }
 

--- a/core-bundle/src/EventListener/DataContainerCallbackListener.php
+++ b/core-bundle/src/EventListener/DataContainerCallbackListener.php
@@ -23,6 +23,7 @@ class DataContainerCallbackListener
         'child_record_callback',
         'input_field_callback',
         'options_callback',
+        'group_callback',
     ];
 
     /**

--- a/core-bundle/tests/DependencyInjection/Compiler/DataContainerCallbackPassTest.php
+++ b/core-bundle/tests/DependencyInjection/Compiler/DataContainerCallbackPassTest.php
@@ -203,6 +203,38 @@ class DataContainerCallbackPassTest extends TestCase
         );
     }
 
+    public function testDoesNotAppendCallbackSuffixForXlabel(): void
+    {
+        $attributes = [
+            'table' => 'tl_content',
+            'target' => 'fields.listitems.xlabel',
+            'priority' => 10,
+            'method' => 'onListitemsXlabel',
+        ];
+
+        $definition = new Definition('Test\CallbackListener');
+        $definition->addTag('contao.callback', $attributes);
+
+        $container = $this->getContainerBuilder();
+        $container->setDefinition('test.callback_listener', $definition);
+
+        $pass = new DataContainerCallbackPass();
+        $pass->process($container);
+
+        $this->assertSame(
+            [
+                'tl_content' => [
+                    'fields.listitems.xlabel' => [
+                        10 => [
+                            ['test.callback_listener', 'onListitemsXlabel'],
+                        ],
+                    ],
+                ],
+            ],
+            $this->getCallbacksFromDefinition($container)[0]
+        );
+    }
+
     public function testHandlesMultipleCallbacks(): void
     {
         $definition = new Definition('Test\CallbackListener');


### PR DESCRIPTION
While adding/updating the DCA documentation, I noticed some bugs in the DCA compiler & listener:

* It would still add `_callback` to the `xlabel` callback.
* `group_callback` was not treated as a singleton callback.

I changed the check to an `in_array` for the first case, since both `.widget` and `.xlabel` are 7 characters long. Or use two `substr_compare`, does not really matter.