### PR TITLE
fix service tagging for panel_callback

### DIFF
--- a/core-bundle/src/DependencyInjection/Compiler/DataContainerCallbackPass.php
+++ b/core-bundle/src/DependencyInjection/Compiler/DataContainerCallbackPass.php
@@ -75,7 +75,7 @@ class DataContainerCallbackPass implements CompilerPassInterface
             );
         }
 
-        if (substr_compare($attributes['target'], '.wizard', -7) && '_callback' !== substr($attributes['target'], -9)) {
+        if (!\in_array(substr($attributes['target'], -7), ['.wizard', '.xlabel']) && '_callback' !== substr($attributes['target'], -9)) {
             $attributes['target'] .= '_callback';
         }
 

--- a/core-bundle/src/DependencyInjection/Compiler/DataContainerCallbackPass.php
+++ b/core-bundle/src/DependencyInjection/Compiler/DataContainerCallbackPass.php
@@ -75,7 +75,9 @@ class DataContainerCallbackPass implements CompilerPassInterface
             );
         }
 
-        if (!\in_array(substr($attributes['target'], -7), ['.wizard', '.xlabel']) && '_callback' !== substr($attributes['target'], -9)) {
+        if (!\in_array(substr($attributes['target'], -7), ['.wizard', '.xlabel'])
+         && strpos($attributes['target'], '.panel_callback.') === false 
+         && '_callback' !== substr($attributes['target'], -9)) {
             $attributes['target'] .= '_callback';
         }
 

--- a/core-bundle/src/EventListener/DataContainerCallbackListener.php
+++ b/core-bundle/src/EventListener/DataContainerCallbackListener.php
@@ -23,6 +23,7 @@ class DataContainerCallbackListener
         'child_record_callback',
         'input_field_callback',
         'options_callback',
+        'group_callback',
     ];
 
     /**

--- a/core-bundle/src/EventListener/DataContainerCallbackListener.php
+++ b/core-bundle/src/EventListener/DataContainerCallbackListener.php
@@ -46,7 +46,7 @@ class DataContainerCallbackListener
             $keys = explode('.', $target);
             $dcaRef = &$this->getDcaReference($table, $keys);
 
-            if (\in_array(end($keys), self::SINGLETONS, true)) {
+            if ((isset($keys[2]) && 'panel_callback' === $keys[2]) || \in_array(end($keys), self::SINGLETONS, true)) {
                 $this->updateSingleton($dcaRef, $callbacks);
             } else {
                 $this->addCallbacks($dcaRef, $callbacks);

--- a/core-bundle/tests/DependencyInjection/Compiler/DataContainerCallbackPassTest.php
+++ b/core-bundle/tests/DependencyInjection/Compiler/DataContainerCallbackPassTest.php
@@ -235,6 +235,37 @@ class DataContainerCallbackPassTest extends TestCase
         );
     }
 
+    public function testDoesNotAppendCallbackSuffixForPanelCallback(): void
+    {
+        $attributes = [
+            'table' => 'tl_content',
+            'target' => 'list.sorting.panel_callback.foobar',
+            'method' => 'onFoobarCallback',
+        ];
+
+        $definition = new Definition('Test\CallbackListener');
+        $definition->addTag('contao.callback', $attributes);
+
+        $container = $this->getContainerBuilder();
+        $container->setDefinition('test.callback_listener', $definition);
+
+        $pass = new DataContainerCallbackPass();
+        $pass->process($container);
+
+        $this->assertSame(
+            [
+                'tl_content' => [
+                    'list.sorting.panel_callback.foobar' => [
+                        0 => [
+                            ['test.callback_listener', 'onFoobarCallback'],
+                        ],
+                    ],
+                ],
+            ],
+            $this->getCallbacksFromDefinition($container)[0]
+        );
+    }
+
     public function testHandlesMultipleCallbacks(): void
     {
         $definition = new Definition('Test\CallbackListener');

--- a/core-bundle/tests/DependencyInjection/Compiler/DataContainerCallbackPassTest.php
+++ b/core-bundle/tests/DependencyInjection/Compiler/DataContainerCallbackPassTest.php
@@ -203,6 +203,38 @@ class DataContainerCallbackPassTest extends TestCase
         );
     }
 
+    public function testDoesNotAppendCallbackSuffixForXlabel(): void
+    {
+        $attributes = [
+            'table' => 'tl_content',
+            'target' => 'fields.listitems.xlabel',
+            'priority' => 10,
+            'method' => 'onListitemsXlabel',
+        ];
+
+        $definition = new Definition('Test\CallbackListener');
+        $definition->addTag('contao.callback', $attributes);
+
+        $container = $this->getContainerBuilder();
+        $container->setDefinition('test.callback_listener', $definition);
+
+        $pass = new DataContainerCallbackPass();
+        $pass->process($container);
+
+        $this->assertSame(
+            [
+                'tl_content' => [
+                    'fields.listitems.xlabel' => [
+                        10 => [
+                            ['test.callback_listener', 'onListitemsXlabel'],
+                        ],
+                    ],
+                ],
+            ],
+            $this->getCallbacksFromDefinition($container)[0]
+        );
+    }
+
     public function testHandlesMultipleCallbacks(): void
     {
         $definition = new Definition('Test\CallbackListener');

--- a/core-bundle/tests/EventListener/DataContainerCallbackListenerTest.php
+++ b/core-bundle/tests/EventListener/DataContainerCallbackListenerTest.php
@@ -145,6 +145,42 @@ class DataContainerCallbackListenerTest extends TestCase
         );
     }
 
+    public function testPanelLayoutCallbacks(): void
+    {
+        $GLOBALS['TL_DCA']['tl_page'] = [];
+
+        $this->listener->setCallbacks(
+            [
+                'tl_page' => [
+                    'list.sorting.panel_callback.foobar' =>  [
+                        0 => [
+                            ['Test\CallbackListener', 'onFoobarCallback'],
+                        ],
+                    ]
+                ],
+            ]
+        );
+
+        $this->assertEmpty($GLOBALS['TL_DCA']['tl_page']);
+
+        $this->listener->onLoadDataContainer('tl_page');
+
+        $this->assertNotEmpty($GLOBALS['TL_DCA']['tl_page']);
+
+        $this->assertSame(
+            [
+                'list' => [
+                    'sorting' => [
+                        'panel_callback' => [
+                            'foobar' => ['Test\CallbackListener', 'onFoobarCallback'],
+                        ],
+                    ],
+                ],
+            ],
+            $GLOBALS['TL_DCA']['tl_page']
+        );
+    }
+
     public function testRegistersCallbacksByPriority(): void
     {
         $GLOBALS['TL_DCA']['tl_page'] = [];


### PR DESCRIPTION
This fixes service tagging for the `panel_callback`.

The `panel_callback` is unique, since the single callback is defined for each custom panel as a sub key of the `panel_callback` key in the DCA. 

https://github.com/contao/contao/blob/53f0ac3393c997999c7619fe0c2865137f673c5b/core-bundle/src/Resources/contao/classes/DataContainer.php#L1157-L1171

Thus it needs special handling in the current implementation.