### PR TITLE
Add a new sorting option for featured news.

### DIFF
--- a/news-bundle/src/Resources/contao/dca/tl_module.php
+++ b/news-bundle/src/Resources/contao/dca/tl_module.php
@@ -246,6 +246,6 @@ class tl_module_news extends Contao\Backend
 			return array('order_date_asc', 'order_date_desc');
 		}
 
-		return array('order_date_asc', 'order_date_desc', 'order_headline_asc', 'order_headline_desc', 'order_random', 'order_featured_desc');
+		return array('order_date_asc', 'order_date_desc', 'order_headline_asc', 'order_headline_desc', 'order_random', 'order_featured_asc', 'order_featured_desc');
 	}
 }

--- a/news-bundle/src/Resources/contao/dca/tl_module.php
+++ b/news-bundle/src/Resources/contao/dca/tl_module.php
@@ -246,6 +246,6 @@ class tl_module_news extends Contao\Backend
 			return array('order_date_asc', 'order_date_desc');
 		}
 
-		return array('order_date_asc', 'order_date_desc', 'order_headline_asc', 'order_headline_desc', 'order_random');
+		return array('order_date_asc', 'order_date_desc', 'order_headline_asc', 'order_headline_desc', 'order_random', 'order_featured_desc');
 	}
 }

--- a/news-bundle/src/Resources/contao/dca/tl_module.php
+++ b/news-bundle/src/Resources/contao/dca/tl_module.php
@@ -246,6 +246,6 @@ class tl_module_news extends Contao\Backend
 			return array('order_date_asc', 'order_date_desc');
 		}
 
-		return array('order_date_asc', 'order_date_desc', 'order_headline_asc', 'order_headline_desc', 'order_random', 'order_featured_asc', 'order_featured_desc');
+		return array('order_date_asc', 'order_date_desc', 'order_headline_asc', 'order_headline_desc', 'order_featured_asc', 'order_featured_desc', 'order_random');
 	}
 }

--- a/news-bundle/src/Resources/contao/languages/en/tl_module.xlf
+++ b/news-bundle/src/Resources/contao/languages/en/tl_module.xlf
@@ -98,14 +98,14 @@
       <trans-unit id="tl_module.order_headline_desc">
         <source>Headline descending</source>
       </trans-unit>
-      <trans-unit id="tl_module.order_random">
-        <source>Random order</source>
-      </trans-unit>
       <trans-unit id="tl_module.order_featured_asc">
-        <source>Featured (date ascending)</source>
+        <source>Featured first, date ascending</source>
       </trans-unit>
       <trans-unit id="tl_module.order_featured_desc">
-        <source>Featured (date descending)</source>
+        <source>Featured first, date descending</source>
+      </trans-unit>
+      <trans-unit id="tl_module.order_random">
+        <source>Random order</source>
       </trans-unit>
     </body>
   </file>

--- a/news-bundle/src/Resources/contao/languages/en/tl_module.xlf
+++ b/news-bundle/src/Resources/contao/languages/en/tl_module.xlf
@@ -101,6 +101,9 @@
       <trans-unit id="tl_module.order_random">
         <source>Random order</source>
       </trans-unit>
+      <trans-unit id="tl_module.order_featured_asc">
+        <source>Featured (date ascending)</source>
+      </trans-unit>
       <trans-unit id="tl_module.order_featured_desc">
         <source>Featured (date descending)</source>
       </trans-unit>

--- a/news-bundle/src/Resources/contao/languages/en/tl_module.xlf
+++ b/news-bundle/src/Resources/contao/languages/en/tl_module.xlf
@@ -101,6 +101,9 @@
       <trans-unit id="tl_module.order_random">
         <source>Random order</source>
       </trans-unit>
+      <trans-unit id="tl_module.order_featured_desc">
+        <source>Featured (date descending)</source>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/news-bundle/src/Resources/contao/modules/ModuleNewsArchive.php
+++ b/news-bundle/src/Resources/contao/modules/ModuleNewsArchive.php
@@ -200,6 +200,10 @@ class ModuleNewsArchive extends ModuleNews
 				$arrOptions['order'] = "RAND()";
 				break;
 
+			case 'order_featured_desc':
+				$arrOptions['order'] = "$t.featured DESC, $t.date DESC";
+				break;
+
 			case 'order_date_asc':
 				$arrOptions['order'] = "$t.date";
 				break;

--- a/news-bundle/src/Resources/contao/modules/ModuleNewsArchive.php
+++ b/news-bundle/src/Resources/contao/modules/ModuleNewsArchive.php
@@ -200,6 +200,10 @@ class ModuleNewsArchive extends ModuleNews
 				$arrOptions['order'] = "RAND()";
 				break;
 
+			case 'order_featured_asc':
+				$arrOptions['order'] = "$t.featured DESC, $t.date";
+				break;
+
 			case 'order_featured_desc':
 				$arrOptions['order'] = "$t.featured DESC, $t.date DESC";
 				break;

--- a/news-bundle/src/Resources/contao/modules/ModuleNewsList.php
+++ b/news-bundle/src/Resources/contao/modules/ModuleNewsList.php
@@ -232,6 +232,10 @@ class ModuleNewsList extends ModuleNews
 				$arrOptions['order'] = "RAND()";
 				break;
 
+			case 'order_featured_desc':
+				$arrOptions['order'] = "$t.featured DESC, $t.date DESC";
+				break;
+
 			case 'order_date_asc':
 				$arrOptions['order'] = "$t.date";
 				break;

--- a/news-bundle/src/Resources/contao/modules/ModuleNewsList.php
+++ b/news-bundle/src/Resources/contao/modules/ModuleNewsList.php
@@ -232,6 +232,10 @@ class ModuleNewsList extends ModuleNews
 				$arrOptions['order'] = "RAND()";
 				break;
 
+			case 'order_featured_asc':
+				$arrOptions['order'] = "$t.featured DESC, $t.date";
+				break;
+
 			case 'order_featured_desc':
 				$arrOptions['order'] = "$t.featured DESC, $t.date DESC";
 				break;


### PR DESCRIPTION
This implements a new sorting option for featured news. News items marked as "featured" are therefore always listed before all other items.

This could be handy in some situations when you can accomplish this kind of sorting with only one newslist module instead of two.