### PR TITLE
Fix exception inheritance of palette exceptions

### DIFF
--- a/core-bundle/src/DataContainer/PaletteNotFoundException.php
+++ b/core-bundle/src/DataContainer/PaletteNotFoundException.php
@@ -12,6 +12,6 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\DataContainer;
 
-class PaletteNotFoundException extends \InvalidArgumentException
+class PaletteNotFoundException extends \Contao\CoreBundle\Exception\PaletteNotFoundException
 {
 }

--- a/core-bundle/src/DataContainer/PalettePositionException.php
+++ b/core-bundle/src/DataContainer/PalettePositionException.php
@@ -12,6 +12,6 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\DataContainer;
 
-class PalettePositionException extends \InvalidArgumentException
+class PalettePositionException extends \Contao\CoreBundle\Exception\PalettePositionException
 {
 }

--- a/core-bundle/src/Exception/PaletteNotFoundException.php
+++ b/core-bundle/src/Exception/PaletteNotFoundException.php
@@ -18,6 +18,6 @@ namespace Contao\CoreBundle\Exception;
  * @deprecated Deprecated since Contao 4.7, to be removed in Contao 5.0; use the
  *             Contao\CoreBundle\DataContainer\PaletteNotFoundException instead
  */
-class PaletteNotFoundException extends \Contao\CoreBundle\DataContainer\PaletteNotFoundException
+class PaletteNotFoundException extends \InvalidArgumentException
 {
 }

--- a/core-bundle/src/Exception/PalettePositionException.php
+++ b/core-bundle/src/Exception/PalettePositionException.php
@@ -18,6 +18,6 @@ namespace Contao\CoreBundle\Exception;
  * @deprecated Deprecated since Contao 4.7, to be removed in Contao 5.0; use the
  *             Contao\CoreBundle\DataContainer\PalettePositionException instead
  */
-class PalettePositionException extends \Contao\CoreBundle\DataContainer\PalettePositionException
+class PalettePositionException extends \InvalidArgumentException
 {
 }

--- a/core-bundle/tests/DataContainer/PaletteManipulatorTest.php
+++ b/core-bundle/tests/DataContainer/PaletteManipulatorTest.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Tests\DataContainer;
 
 use Contao\CoreBundle\DataContainer\PaletteManipulator;
+use Contao\CoreBundle\DataContainer\PaletteNotFoundException;
+use Contao\CoreBundle\DataContainer\PalettePositionException;
 use PHPUnit\Framework\TestCase;
 
 class PaletteManipulatorTest extends TestCase
@@ -325,7 +327,7 @@ class PaletteManipulatorTest extends TestCase
         // Make sure the palette is not here (for whatever reason another test might have set it)
         unset($GLOBALS['TL_DCA']['tl_test']['palettes']['default']);
 
-        $this->expectException('InvalidArgumentException');
+        $this->expectException(PaletteNotFoundException::class);
 
         $pm->applyToPalette('default', 'tl_test');
     }
@@ -339,14 +341,14 @@ class PaletteManipulatorTest extends TestCase
         // Make sure the palette is not here (for whatever reason another test might have set it)
         unset($GLOBALS['TL_DCA']['tl_test']['subpalettes']['name']);
 
-        $this->expectException('InvalidArgumentException');
+        $this->expectException(PaletteNotFoundException::class);
 
         $pm->applyToSubpalette('name', 'tl_test');
     }
 
     public function testFailsIfThePositionIsInvalid(): void
     {
-        $this->expectException('LogicException');
+        $this->expectException(PalettePositionException::class);
 
         PaletteManipulator::create()
             ->addField('bar', 'foo', 'foo_position')
@@ -356,7 +358,7 @@ class PaletteManipulatorTest extends TestCase
 
     public function testFailsIfTheFallbackPositionIsInvalid(): void
     {
-        $this->expectException('InvalidArgumentException');
+        $this->expectException(PalettePositionException::class);
 
         PaletteManipulator::create()
             ->addField('bar', 'foo', 'after', 'foobar_legend', 'after')

--- a/core-bundle/tests/DataContainer/PaletteNotFoundExceptionTest.php
+++ b/core-bundle/tests/DataContainer/PaletteNotFoundExceptionTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\DataContainer;
+
+use Contao\CoreBundle\DataContainer\PaletteNotFoundException;
+use PHPUnit\Framework\TestCase;
+
+class PaletteNotFoundExceptionTest extends TestCase
+{
+    public function testExceptionInheritance(): void
+    {
+        $exception = new PaletteNotFoundException();
+
+        $this->assertInstanceOf(\InvalidArgumentException::class, $exception);
+        $this->assertInstanceOf(\Contao\CoreBundle\Exception\PaletteNotFoundException::class, $exception);
+    }
+}

--- a/core-bundle/tests/DataContainer/PalettePositionExceptionTest.php
+++ b/core-bundle/tests/DataContainer/PalettePositionExceptionTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\DataContainer;
+
+use Contao\CoreBundle\DataContainer\PalettePositionException;
+use PHPUnit\Framework\TestCase;
+
+class PalettePositionExceptionTest extends TestCase
+{
+    public function testExceptionInheritance(): void
+    {
+        $exception = new PalettePositionException();
+
+        $this->assertInstanceOf(\InvalidArgumentException::class, $exception);
+        $this->assertInstanceOf(\Contao\CoreBundle\Exception\PalettePositionException::class, $exception);
+    }
+}


### PR DESCRIPTION
This PR resolves #378 and makes the expected exceptions more explicit in the tests.

The current implementation would trigger the deprecation notice all the time. Maybe it can be changed that it's only triggered when the old classes are instantiated directly.