### PR TITLE
DC_Table filter select box values

### DIFF
--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -5570,7 +5570,7 @@ class DC_Table extends \DataContainer implements \listable, \editable
 
 					foreach ($options as $k=>$v)
 					{
-						if ($v == '')
+						if ($v == '0')
 						{
 							$options[$v] = '-';
 						}
@@ -5590,7 +5590,7 @@ class DC_Table extends \DataContainer implements \listable, \editable
 
 					foreach ($options as $k=>$v)
 					{
-						if ($v == '')
+						if ($v == '0')
 						{
 							$options[$v] = '-';
 						}
@@ -5616,7 +5616,7 @@ class DC_Table extends \DataContainer implements \listable, \editable
 
 					foreach ($options as $k=>$v)
 					{
-						if ($v == '')
+						if ($v == '0')
 						{
 							$options[$v] = '-';
 						}


### PR DESCRIPTION
When DC_Table creates filters in filterMenu() for fields using date sorting flags (5, 6, 7, 8, 9, 10), then the SQL query that fetches its values uses UNIX_TIMESTAMP in its SELECT, causing all empty values like "" to turn into "0". 

The IF statement that checks for empty values checks for a "", not a "0" and will run all "0"s through a date filter. Every filter will have a "1970"-type date as a label instead of "-". 

An example when this can happen is when adding a filter on the news articles' Show From or Show Until field.

![screenshot 2019-02-28 at 16 51 58](https://user-images.githubusercontent.com/3846481/53574968-4ec31480-3b79-11e9-9a29-7f40f05cf787.png)
