### PR TITLE
Hide opt-in resend button if no mail content given

### DIFF
--- a/core-bundle/src/Resources/contao/dca/tl_opt_in.php
+++ b/core-bundle/src/Resources/contao/dca/tl_opt_in.php
@@ -201,6 +201,6 @@ class tl_opt_in extends Contao\Backend
 	 */
 	public function resendButton($row, $href, $label, $title, $icon, $attributes)
 	{
-		return (!$row['confirmedOn'] && $row['createdOn'] > strtotime('-24 hours')) ? '<a href="'.$this->addToUrl($href.'&amp;id='.$row['id']).'" title="'.Contao\StringUtil::specialchars($title).'"'.$attributes.'>'.Contao\Image::getHtml($icon, $label).'</a> ' : '';
+		return (!$row['confirmedOn'] && $row['createdOn'] > strtotime('-24 hours') && $row['emailSubject'] && $row['emailText']) ? '<a href="'.$this->addToUrl($href.'&amp;id='.$row['id']).'" title="'.Contao\StringUtil::specialchars($title).'"'.$attributes.'>'.Contao\Image::getHtml($icon, $label).'</a> ' : '';
 	}
 }

--- a/core-bundle/src/Resources/contao/dca/tl_opt_in.php
+++ b/core-bundle/src/Resources/contao/dca/tl_opt_in.php
@@ -201,6 +201,6 @@ class tl_opt_in extends Contao\Backend
 	 */
 	public function resendButton($row, $href, $label, $title, $icon, $attributes)
 	{
-		return (!$row['confirmedOn'] && $row['createdOn'] > strtotime('-24 hours') && $row['emailSubject'] && $row['emailText']) ? '<a href="'.$this->addToUrl($href.'&amp;id='.$row['id']).'" title="'.Contao\StringUtil::specialchars($title).'"'.$attributes.'>'.Contao\Image::getHtml($icon, $label).'</a> ' : '';
+		return (!$row['confirmedOn'] && $row['emailSubject'] && $row['emailText'] && $row['createdOn'] > strtotime('-24 hours')) ? '<a href="'.$this->addToUrl($href.'&amp;id='.$row['id']).'" title="'.Contao\StringUtil::specialchars($title).'"'.$attributes.'>'.Contao\Image::getHtml($icon, $label).'</a> ' : '';
 	}
 }


### PR DESCRIPTION
The button to resend an opt-in mail must only be available if a mail text and mail subject is given.

Otherwise, an error occurs:
<img width="917" alt="screen shot 2019-03-07 at 10 55 56" src="https://user-images.githubusercontent.com/1284725/53948477-2e8adc80-40c8-11e9-9d56-4451b7256126.png">

In case the opt-in mail was not sent by Contao, but a third party extension, such as the notification_center, no mail subject nor mail text is given.