### PR TITLE
Do not add .gitignore files in the contao:install command

### DIFF
--- a/core-bundle/src/Command/InstallCommand.php
+++ b/core-bundle/src/Command/InstallCommand.php
@@ -105,7 +105,6 @@ class InstallCommand extends Command
         $this->webDir = rtrim($input->getArgument('target'), '/');
 
         $this->addEmptyDirs();
-        $this->addIgnoredDirs();
 
         if (!empty($this->rows)) {
             $this->io->newLine();
@@ -120,9 +119,16 @@ class InstallCommand extends Command
     private function addEmptyDirs(): void
     {
         static $emptyDirs = [
+            'assets/css',
+            'assets/js',
             'system',
+            'system/cache',
             'system/config',
+            'system/modules',
+            'system/themes',
+            'system/tmp',
             'templates',
+            '%s/share',
             '%s/system',
         ];
 
@@ -130,6 +136,7 @@ class InstallCommand extends Command
             $this->addEmptyDir($this->rootDir.'/'.sprintf($path, $this->webDir));
         }
 
+        $this->addEmptyDir($this->imageDir);
         $this->addEmptyDir($this->rootDir.'/'.$this->uploadPath);
     }
 
@@ -142,38 +149,5 @@ class InstallCommand extends Command
         $this->fs->mkdir($path);
 
         $this->rows[] = str_replace($this->rootDir.'/', '', $path);
-    }
-
-    private function addIgnoredDirs(): void
-    {
-        static $ignoredDirs = [
-            'assets/css',
-            'assets/js',
-            'system/cache',
-            'system/modules',
-            'system/themes',
-            'system/tmp',
-            '%s/share',
-        ];
-
-        foreach ($ignoredDirs as $path) {
-            $this->addIgnoredDir($this->rootDir.'/'.sprintf($path, $this->webDir));
-        }
-
-        $this->addIgnoredDir($this->imageDir);
-    }
-
-    private function addIgnoredDir(string $path): void
-    {
-        $this->addEmptyDir($path);
-
-        if ($this->fs->exists($path.'/.gitignore')) {
-            return;
-        }
-
-        $this->fs->dumpFile(
-            $path.'/.gitignore',
-            "# Create the folder and ignore its content\n*\n!.gitignore\n"
-        );
     }
 }

--- a/core-bundle/tests/Command/InstallCommandTest.php
+++ b/core-bundle/tests/Command/InstallCommandTest.php
@@ -52,14 +52,14 @@ class InstallCommandTest extends TestCase
         $output = $tester->getDisplay();
 
         $this->assertSame(0, $code);
-        $this->assertContains(' * templates', $output);
-        $this->assertContains(' * web/system', $output);
         $this->assertContains(' * assets/css', $output);
         $this->assertContains(' * assets/images', $output);
         $this->assertContains(' * assets/js', $output);
         $this->assertContains(' * system/cache', $output);
         $this->assertContains(' * system/config', $output);
         $this->assertContains(' * system/tmp', $output);
+        $this->assertContains(' * templates', $output);
+        $this->assertContains(' * web/system', $output);
     }
 
     public function testHandlesCustomFilesAndImagesPaths(): void


### PR DESCRIPTION
The `contao:install` command adds the following `.gitignore` file to certain folders:

```
# Create the folder and ignore its content
*
!.gitignore
```

However, these rules are already in the [.gitignore file in the root folder](https://github.com/contao/managed-edition/blob/master/.gitignore), therefore we should not create them again.