### PR TITLE
Force array in table content element

### DIFF
--- a/core-bundle/src/Resources/contao/elements/ContentTable.php
+++ b/core-bundle/src/Resources/contao/elements/ContentTable.php
@@ -29,7 +29,7 @@ class ContentTable extends ContentElement
 	 */
 	protected function compile()
 	{
-		$rows = StringUtil::deserialize($this->tableitems);
+		$rows = StringUtil::deserialize($this->tableitems, true);
 
 		$this->Template->id = 'table_' . $this->id;
 		$this->Template->summary = StringUtil::specialchars($this->summary);


### PR DESCRIPTION
It will prevent from `count(): Parameter must be an array or an object that implements Countable` (on line 74) errors if the element does not contain any items.