### PR TITLE
[RTM] Add compatibility with Imagine 1.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "doctrine/doctrine-bundle": "^1.6",
         "doctrine/doctrine-cache-bundle": "^1.3",
         "friendsofsymfony/http-cache": "^2.0",
-        "imagine/imagine": "^0.6 || ^0.7",
+        "imagine/imagine": "^0.6 || ^0.7 || ^1.0",
         "knplabs/knp-menu-bundle": "^2.1",
         "knplabs/knp-time-bundle": "^1.5.2",
         "leafo/scssphp": "^0.6 || ^0.7",

--- a/core-bundle/composer.json
+++ b/core-bundle/composer.json
@@ -40,7 +40,7 @@
         "doctrine/dbal": "^2.5",
         "doctrine/doctrine-bundle": "^1.6",
         "doctrine/doctrine-cache-bundle": "^1.3",
-        "imagine/imagine": "^0.6 || ^0.7",
+        "imagine/imagine": "^0.6 || ^0.7 || ^1.0",
         "knplabs/knp-menu-bundle": "^2.1",
         "knplabs/knp-time-bundle": "^1.5.2",
         "leafo/scssphp": "^0.6 || ^0.7",


### PR DESCRIPTION
Fixes #412

When merging upstream into 4.7 we should probably use `"imagine/imagine": "^0.7 || ^1.0",` there.