### PR TITLE
Filter fallback routes if the accepted languages do not match

### DIFF
--- a/core-bundle/src/Resources/config/services.yml
+++ b/core-bundle/src/Resources/config/services.yml
@@ -353,6 +353,11 @@ services:
             - "@contao.framework"
             - "%contao.prepend_locale%"
 
+    contao.routing.language_filter:
+        class: Contao\CoreBundle\Routing\Matcher\LanguageFilter
+        arguments:
+            - "%contao.prepend_locale%"
+
     contao.routing.legacy_matcher:
         class: Contao\CoreBundle\Routing\Matcher\LegacyMatcher
         decorates: contao.routing.nested_matcher
@@ -377,6 +382,7 @@ services:
         calls:
             - ["addRouteFilter", ["@contao.routing.domain_filter"]]
             - ["addRouteFilter", ["@contao.routing.published_filter"]]
+            - ["addRouteFilter", ["@contao.routing.language_filter"]]
         public: true
 
     contao.routing.page_router:

--- a/core-bundle/src/Routing/Matcher/DomainFilter.php
+++ b/core-bundle/src/Routing/Matcher/DomainFilter.php
@@ -42,7 +42,9 @@ class DomainFilter implements RouteFilterInterface
 
         if ($hasDomainMatch) {
             foreach ($collection->all() as $name => $route) {
-                if (!$route->getHost()) {
+                $host = $route->getHost();
+
+                if (!$host || $host !== $httpHost) {
                     $collection->remove($name);
                 }
             }

--- a/core-bundle/src/Routing/Matcher/DomainFilter.php
+++ b/core-bundle/src/Routing/Matcher/DomainFilter.php
@@ -17,9 +17,9 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\RouteCollection;
 
 /**
- * Removes routes without hostname if there are routes for the current
- * hostname. This prevents the fallback (empty) domain from matching if a root
- * page for the current domain exists.
+ * Removes routes with a different or no hostname if there are routes for the
+ * current hostname. This prevents the fallback (empty) domain from matching if
+ * a root page for the current domain exists.
  */
 class DomainFilter implements RouteFilterInterface
 {

--- a/core-bundle/src/Routing/Matcher/LanguageFilter.php
+++ b/core-bundle/src/Routing/Matcher/LanguageFilter.php
@@ -47,15 +47,11 @@ class LanguageFilter implements RouteFilterInterface
             /** @var PageModel $pageModel */
             $pageModel = $route->getDefault('pageModel');
 
-            if ($pageModel->rootIsFallback) {
-                continue;
-            }
-
-            $language = $pageModel->rootLanguage;
-
             if (
-                \in_array($language, $languages, true)
-                || preg_grep('/'.preg_quote($language, '/').'_[A-Z]{2}/', $languages)
+                !$pageModel instanceof PageModel
+                || $pageModel->rootIsFallback
+                || \in_array($pageModel->rootLanguage, $languages, true)
+                || preg_grep('/'.preg_quote($pageModel->rootLanguage, '/').'_[A-Z]{2}/', $languages)
             ) {
                 continue;
             }

--- a/core-bundle/src/Routing/Matcher/LanguageFilter.php
+++ b/core-bundle/src/Routing/Matcher/LanguageFilter.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Routing\Matcher;
+
+use Contao\PageModel;
+use Symfony\Cmf\Component\Routing\NestedMatcher\RouteFilterInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * Removes fallback routes if the accepted languages do not match (see #430).
+ */
+class LanguageFilter implements RouteFilterInterface
+{
+    /**
+     * @var bool
+     */
+    private $prependLocale;
+
+    public function __construct(bool $prependLocale)
+    {
+        $this->prependLocale = $prependLocale;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function filter(RouteCollection $collection, Request $request): RouteCollection
+    {
+        $languages = $request->getLanguages();
+
+        foreach ($collection->all() as $name => $route) {
+            if ('.fallback' !== substr($name, -9) && ($this->prependLocale || '.root' !== substr($name, -5))) {
+                continue;
+            }
+
+            /** @var PageModel $pageModel */
+            $pageModel = $route->getDefault('pageModel');
+
+            if ($pageModel->rootIsFallback) {
+                continue;
+            }
+
+            $language = $pageModel->rootLanguage;
+
+            if (
+                \in_array($language, $languages, true)
+                || preg_grep('/'.preg_quote($language, '/').'_[A-Z]{2}/', $languages)
+            ) {
+                continue;
+            }
+
+            $collection->remove($name);
+        }
+
+        return $collection;
+    }
+}

--- a/core-bundle/src/Routing/RouteProvider.php
+++ b/core-bundle/src/Routing/RouteProvider.php
@@ -287,16 +287,11 @@ class RouteProvider implements RouteProviderInterface
 
         $path = '/';
         $requirements = [];
-        $condition = null;
         $defaults = $this->getRouteDefaults($page);
 
         if ($this->prependLocale) {
             $path = '/{_locale}'.$path;
             $requirements['_locale'] = $page->rootLanguage;
-        }
-
-        if (!$page->rootIsFallback) {
-            $condition = "'{$page->rootLanguage}' in request.getLanguages()";
         }
 
         $routes['tl_page.'.$page->id.'.root'] = new Route(
@@ -306,8 +301,7 @@ class RouteProvider implements RouteProviderInterface
             [],
             $page->domain,
             $page->rootUseSSL ? 'https' : null,
-            [],
-            $this->prependLocale ? null : $condition
+            []
         );
 
         /** @var Config $config */
@@ -326,8 +320,7 @@ class RouteProvider implements RouteProviderInterface
             [],
             $page->domain,
             $page->rootUseSSL ? 'https' : null,
-            [],
-            $condition
+            []
         );
     }
 

--- a/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
+++ b/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
@@ -80,6 +80,7 @@ use Contao\CoreBundle\Routing\Enhancer\InputEnhancer;
 use Contao\CoreBundle\Routing\FrontendLoader;
 use Contao\CoreBundle\Routing\LegacyRouteProvider;
 use Contao\CoreBundle\Routing\Matcher\DomainFilter;
+use Contao\CoreBundle\Routing\Matcher\LanguageFilter;
 use Contao\CoreBundle\Routing\Matcher\LegacyMatcher;
 use Contao\CoreBundle\Routing\Matcher\PublishedFilter;
 use Contao\CoreBundle\Routing\Matcher\UrlMatcher;
@@ -1371,6 +1372,17 @@ class ContaoCoreExtensionTest extends TestCase
         $this->assertSame('%contao.prepend_locale%', (string) $definition->getArgument(1));
     }
 
+    public function testRegistersTheRoutingLanguageFilter(): void
+    {
+        $this->assertTrue($this->container->has('contao.routing.language_filter'));
+
+        $definition = $this->container->getDefinition('contao.routing.language_filter');
+
+        $this->assertSame(LanguageFilter::class, $definition->getClass());
+        $this->assertTrue($definition->isPrivate());
+        $this->assertSame('%contao.prepend_locale%', (string) $definition->getArgument(0));
+    }
+
     public function testRegistersTheRoutingLegacyMatcher(): void
     {
         $this->assertTrue($this->container->has('contao.routing.legacy_matcher'));
@@ -1415,6 +1427,8 @@ class ContaoCoreExtensionTest extends TestCase
         $this->assertSame('contao.routing.domain_filter', (string) $methodCalls[0][1][0]);
         $this->assertSame('addRouteFilter', $methodCalls[1][0]);
         $this->assertSame('contao.routing.published_filter', (string) $methodCalls[1][1][0]);
+        $this->assertSame('addRouteFilter', $methodCalls[2][0]);
+        $this->assertSame('contao.routing.language_filter', (string) $methodCalls[2][1][0]);
     }
 
     public function testRegistersTheRoutingPageRouter(): void

--- a/core-bundle/tests/Functional/RoutingTest.php
+++ b/core-bundle/tests/Functional/RoutingTest.php
@@ -877,6 +877,27 @@ class RoutingTest extends WebTestCase
                 'fr,es',
                 'same-domain-root.local',
             ],
+            'Redirects to "de" if "de-CH" is accepted and "de" is not' => [
+                '/',
+                301,
+                'Redirecting to http://same-domain-root.local/de/',
+                'de-CH',
+                'same-domain-root.local',
+            ],
+            'Ignores the case of the language code' => [
+                '/',
+                301,
+                'Redirecting to http://same-domain-root.local/de/',
+                'dE-at',
+                'same-domain-root.local',
+            ],
+            'Redirects to "en" if "de-CH" and "en" are accepted and "de" is not' => [
+                '/',
+                301,
+                'Redirecting to http://same-domain-root.local/en/',
+                'de-CH,en',
+                'same-domain-root.local',
+            ],
             'Renders the 404 page if none of the accept languages matches' => [
                 '/',
                 404,

--- a/core-bundle/tests/Routing/Matcher/DomainFilterTest.php
+++ b/core-bundle/tests/Routing/Matcher/DomainFilterTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\Routing\Matcher;
+
+use Contao\CoreBundle\Routing\Matcher\DomainFilter;
+use Contao\CoreBundle\Tests\TestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
+
+class DomainFilterTest extends TestCase
+{
+    public function testRemovesRoutesIfTheHostnameDoesNotMatch(): void
+    {
+        $routes = [
+            'nohost' => $this->mockRouteWithHost(''),
+            'foobar' => $this->mockRouteWithHost('foobar.com'),
+            'barfoo' => $this->mockRouteWithHost('barfoo.com'),
+        ];
+
+        $collection = $this->createMock(RouteCollection::class);
+        $collection
+            ->expects($this->exactly(2))
+            ->method('all')
+            ->willReturn($routes)
+        ;
+
+        $collection
+            ->expects($this->exactly(2))
+            ->method('remove')
+            ->withConsecutive(['nohost'], ['barfoo'])
+        ;
+
+        $request = Request::create('/');
+        $request->headers->set('Host', 'foobar.com');
+
+        $filter = new DomainFilter();
+        $filter->filter($collection, $request);
+    }
+
+    public function testDoesNotRemoveRoutesIfThereAreNoRoutesForTheCurrentHostname(): void
+    {
+        $routes = [
+            'nohost' => $this->mockRouteWithHost(''),
+            'foobar' => $this->mockRouteWithHost('foobar.com'),
+        ];
+
+        $collection = $this->createMock(RouteCollection::class);
+        $collection
+            ->expects($this->once())
+            ->method('all')
+            ->willReturn($routes)
+        ;
+
+        $collection
+            ->expects($this->never())
+            ->method('remove')
+        ;
+
+        $request = Request::create('/');
+        $request->headers->set('Host', 'barfoo.com');
+
+        $filter = new DomainFilter();
+        $filter->filter($collection, $request);
+    }
+
+    /**
+     * @return Route|MockObject
+     */
+    private function mockRouteWithHost(string $host): Route
+    {
+        $route = $this->createMock(Route::class);
+        $route
+            ->method('getHost')
+            ->willReturn($host)
+        ;
+
+        return $route;
+    }
+}

--- a/core-bundle/tests/Routing/Matcher/LanguageFilterTest.php
+++ b/core-bundle/tests/Routing/Matcher/LanguageFilterTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\Routing\Matcher;
+
+use Contao\CoreBundle\Routing\Matcher\LanguageFilter;
+use Contao\CoreBundle\Tests\TestCase;
+use Contao\PageModel;
+use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
+
+class LanguageFilterTest extends TestCase
+{
+    /**
+     * @param PageModel|MockObject|null $page
+     *
+     * @dataProvider getRoutesAndLanguages
+     */
+    public function testRemovesARouteIfTheAcceptedLanguagesDoNotMatch(string $name, ?PageModel $page, string $acceptLanguage, bool $expectPageModel, bool $expectRemoval, bool $prependLocale = false): void
+    {
+        $route = $this->createMock(Route::class);
+        $route
+            ->expects($expectPageModel ? $this->once() : $this->never())
+            ->method('getDefault')
+            ->with('pageModel')
+            ->willReturn($page)
+        ;
+
+        $collection = $this->createMock(RouteCollection::class);
+        $collection
+            ->expects($this->once())
+            ->method('all')
+            ->willReturn([$name => $route])
+        ;
+
+        $collection
+            ->expects($expectRemoval ? $this->once() : $this->never())
+            ->method('remove')
+        ;
+
+        $request = Request::create('/');
+        $request->headers->set('Accept-Language', $acceptLanguage);
+
+        $filter = new LanguageFilter($prependLocale);
+        $filter->filter($collection, $request);
+    }
+
+    public function getRoutesAndLanguages(): \Generator
+    {
+        yield 'Removes a fallback page route if the accepted language does not match' => [
+            'tl_page.2.fallback',
+            $this->mockClassWithProperties(PageModel::class, ['rootIsFallback' => false, 'rootLanguage' => 'en']),
+            'de',
+            true,
+            true,
+        ];
+
+        yield 'Removes a root page route if the accepted language does not match' => [
+            'tl_page.2.root',
+            $this->mockClassWithProperties(PageModel::class, ['rootIsFallback' => false, 'rootLanguage' => 'en']),
+            'de',
+            true,
+            true,
+        ];
+
+        yield 'Does not remove a root page route if contao.prepend_locale is enabled' => [
+            'tl_page.2.root',
+            $this->mockClassWithProperties(PageModel::class, ['rootIsFallback' => false, 'rootLanguage' => 'en']),
+            'de',
+            false,
+            false,
+            true,
+        ];
+
+        yield 'Does not remove a route if there is no Contao page object' => [
+            'tl_page.2.fallback',
+            null,
+            'de',
+            true,
+            false,
+        ];
+
+        yield 'Does not remove a route if the root page is the language fallback' => [
+            'tl_page.2.root',
+            $this->mockClassWithProperties(PageModel::class, ['rootIsFallback' => true, 'rootLanguage' => 'en']),
+            'de',
+            true,
+            false,
+        ];
+
+        yield 'Does not remove a route if the root page language is accepted' => [
+            'tl_page.2.root',
+            $this->mockClassWithProperties(PageModel::class, ['rootIsFallback' => false, 'rootLanguage' => 'de']),
+            'de',
+            true,
+            false,
+        ];
+
+        yield 'Does not remove a route if the root page language with region code is accepted' => [
+            'tl_page.2.root',
+            $this->mockClassWithProperties(PageModel::class, ['rootIsFallback' => false, 'rootLanguage' => 'de']),
+            'de-CH',
+            true,
+            false,
+        ];
+    }
+}

--- a/core-bundle/tests/Routing/Matcher/PublishedFilterTest.php
+++ b/core-bundle/tests/Routing/Matcher/PublishedFilterTest.php
@@ -65,7 +65,7 @@ class PublishedFilterTest extends TestCase
     {
         $route = $this->createMock(Route::class);
         $route
-            ->expects($this->atLeastOnce())
+            ->expects($this->once())
             ->method('getDefault')
             ->with('pageModel')
             ->willReturn($this->mockClassWithProperties(PageModel::class, ['rootIsPublic' => false]))
@@ -92,7 +92,7 @@ class PublishedFilterTest extends TestCase
     {
         $route = $this->createMock(Route::class);
         $route
-            ->expects($this->atLeastOnce())
+            ->expects($this->once())
             ->method('getDefault')
             ->with('pageModel')
             ->willReturn($this->mockClassWithProperties(PageModel::class, ['rootIsPublic' => true]))


### PR DESCRIPTION
This PR fixed #430 by filtering fallback routes if the accepted languages do not match.

- [x] Unit tests

I will add the unit tests as soon as we have agreed on the implementation. 😉 