### PR TITLE
[RFC] Update scheb/two-factor-bundle to ^4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -69,7 +69,7 @@
         "phpspec/php-diff": "^1.0",
         "phpunit/php-token-stream": "^1.4 || ^2.0 || ^3.0",
         "psr/log": "^1.0",
-        "scheb/two-factor-bundle": "^3.7",
+        "scheb/two-factor-bundle": "^4.0",
         "sensiolabs/ansi-to-html": "^1.1",
         "simplepie/simplepie": "^1.3",
         "spomky-labs/otphp": "^9.1",

--- a/core-bundle/composer.json
+++ b/core-bundle/composer.json
@@ -64,7 +64,7 @@
         "phpspec/php-diff": "^1.0",
         "phpunit/php-token-stream": "^1.4 || ^2.0 || ^3.0",
         "psr/log": "^1.0",
-        "scheb/two-factor-bundle": "^3.7",
+        "scheb/two-factor-bundle": "^4.0",
         "simplepie/simplepie": "^1.3",
         "spomky-labs/otphp": "^9.1",
         "symfony-cmf/routing-bundle": "^2.1",

--- a/core-bundle/src/Security/TwoFactor/Provider.php
+++ b/core-bundle/src/Security/TwoFactor/Provider.php
@@ -72,4 +72,11 @@ class Provider implements TwoFactorProviderInterface
     {
         return $this->formRenderer;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function prepareAuthentication($user): void
+    {
+    }
 }

--- a/core-bundle/tests/Security/TwoFactor/ProviderTest.php
+++ b/core-bundle/tests/Security/TwoFactor/ProviderTest.php
@@ -128,18 +128,4 @@ class ProviderTest extends TestCase
 
         $this->assertTrue($provider->validateAuthenticationCode($user, '123456'));
     }
-
-    public function testPreparesTheAuthentication(): void
-    {
-        /** @var User|MockObject $user */
-        $user = $this->mockClassWithProperties(User::class);
-
-        $renderer = $this->createMock(BackendFormRenderer::class);
-        $authenticator = $this->createMock(Authenticator::class);
-
-        $provider = new Provider($authenticator, $renderer);
-        $provider->prepareAuthentication($user);
-
-        $this->assertTrue(true);
-    }
 }

--- a/core-bundle/tests/Security/TwoFactor/ProviderTest.php
+++ b/core-bundle/tests/Security/TwoFactor/ProviderTest.php
@@ -128,4 +128,18 @@ class ProviderTest extends TestCase
 
         $this->assertTrue($provider->validateAuthenticationCode($user, '123456'));
     }
+
+    public function testPreparesTheAuthentication(): void
+    {
+        /** @var User|MockObject $user */
+        $user = $this->mockClassWithProperties(User::class);
+
+        $renderer = $this->createMock(BackendFormRenderer::class);
+        $authenticator = $this->createMock(Authenticator::class);
+
+        $provider = new Provider($authenticator, $renderer);
+        $provider->prepareAuthentication($user);
+
+        $this->assertTrue(true);
+    }
 }


### PR DESCRIPTION
This PR will update the `scheb/two-factor-bundle` to version `^4.0`.

The only significant change for us is an additional method (`prepareAuthentication($user): void`) from the `Scheb\TwoFactorBundle\Security\TwoFactor\Provider\TwoFactorProviderInterface` which we will use when we generate authentication backup codes and the like.

And we get rid of a unused dependency `sonata-project/google-authenticator`. 🙂 