### PR TITLE
Make the insert tags in picker providers configurable

### DIFF
--- a/calendar-bundle/src/Picker/EventPickerProvider.php
+++ b/calendar-bundle/src/Picker/EventPickerProvider.php
@@ -70,11 +70,7 @@ class EventPickerProvider extends AbstractPickerProvider implements DcaPickerPro
         }
 
         if ($this->supportsValue($config)) {
-            $attributes['value'] = str_replace(
-                $this->getInsertTagChunks($config),
-                '',
-                $config->getValue()
-            );
+            $attributes['value'] = str_replace($this->getInsertTagChunks($config), '', $config->getValue());
         }
 
         return $attributes;
@@ -99,13 +95,11 @@ class EventPickerProvider extends AbstractPickerProvider implements DcaPickerPro
             return $params;
         }
 
-        $insertTagChunks = $this->getInsertTagChunks($config);
-
-        if (false === strpos($config->getValue(), $insertTagChunks[0])) {
+        if (!$this->supportsValue($config)) {
             return $params;
         }
 
-        $value = str_replace($insertTagChunks, '', $config->getValue());
+        $value = str_replace($this->getInsertTagChunks($config), '', $config->getValue());
 
         if (null !== ($calendarId = $this->getCalendarId($value))) {
             $params['table'] = 'tl_calendar_events';

--- a/calendar-bundle/src/Picker/EventPickerProvider.php
+++ b/calendar-bundle/src/Picker/EventPickerProvider.php
@@ -47,9 +47,7 @@ class EventPickerProvider extends AbstractPickerProvider implements DcaPickerPro
      */
     public function supportsValue(PickerConfig $config): bool
     {
-        $insertTagChunks = explode('%s', $this->getInsertTag($config, self::DEFAULT_INSERTTAG), 2);
-
-        return false !== strpos($config->getValue(), $insertTagChunks[0]);
+        return false !== strpos($config->getValue(), $this->getInsertTagChunks($config, self::DEFAULT_INSERTTAG)[0]);
     }
 
     /**
@@ -72,9 +70,11 @@ class EventPickerProvider extends AbstractPickerProvider implements DcaPickerPro
         }
 
         if ($this->supportsValue($config)) {
-            $insertTagChunks = explode('%s', $this->getInsertTag($config, self::DEFAULT_INSERTTAG), 2);
-
-            $attributes['value'] = str_replace($insertTagChunks, '',  $config->getValue());
+            $attributes['value'] = str_replace(
+                $this->getInsertTagChunks($config, self::DEFAULT_INSERTTAG),
+                '',
+                $config->getValue()
+            );
         }
 
         return $attributes;
@@ -99,13 +99,13 @@ class EventPickerProvider extends AbstractPickerProvider implements DcaPickerPro
             return $params;
         }
 
-        $insertTagChunks = explode('%s', $this->getInsertTag($config, self::DEFAULT_INSERTTAG), 2);
+        $insertTagChunks = $this->getInsertTagChunks($config, self::DEFAULT_INSERTTAG);
 
         if (false === strpos($config->getValue(), $insertTagChunks[0])) {
             return $params;
         }
 
-        $value = str_replace($insertTagChunks, '',  $config->getValue());
+        $value = str_replace($insertTagChunks, '', $config->getValue());
 
         if (null !== ($calendarId = $this->getCalendarId($value))) {
             $params['table'] = 'tl_calendar_events';

--- a/calendar-bundle/src/Picker/EventPickerProvider.php
+++ b/calendar-bundle/src/Picker/EventPickerProvider.php
@@ -16,11 +16,11 @@ use Contao\CalendarEventsModel;
 use Contao\CalendarModel;
 use Contao\CoreBundle\Framework\FrameworkAwareInterface;
 use Contao\CoreBundle\Framework\FrameworkAwareTrait;
-use Contao\CoreBundle\Picker\AbstractPickerProvider;
+use Contao\CoreBundle\Picker\AbstractInsertTagPickerProvider;
 use Contao\CoreBundle\Picker\DcaPickerProviderInterface;
 use Contao\CoreBundle\Picker\PickerConfig;
 
-class EventPickerProvider extends AbstractPickerProvider implements DcaPickerProviderInterface, FrameworkAwareInterface
+class EventPickerProvider extends AbstractInsertTagPickerProvider implements DcaPickerProviderInterface, FrameworkAwareInterface
 {
     use FrameworkAwareTrait;
 

--- a/calendar-bundle/src/Picker/EventPickerProvider.php
+++ b/calendar-bundle/src/Picker/EventPickerProvider.php
@@ -70,7 +70,7 @@ class EventPickerProvider extends AbstractPickerProvider implements DcaPickerPro
         }
 
         if ($this->supportsValue($config)) {
-            $attributes['value'] = str_replace($this->getInsertTagChunks($config), '', $config->getValue());
+            $attributes['value'] = $this->getValue($config);
         }
 
         return $attributes;
@@ -91,17 +91,11 @@ class EventPickerProvider extends AbstractPickerProvider implements DcaPickerPro
     {
         $params = ['do' => 'calendar'];
 
-        if (null === $config || !$config->getValue()) {
+        if (null === $config || !$config->getValue() || !$this->supportsValue($config)) {
             return $params;
         }
 
-        if (!$this->supportsValue($config)) {
-            return $params;
-        }
-
-        $value = str_replace($this->getInsertTagChunks($config), '', $config->getValue());
-
-        if (null !== ($calendarId = $this->getCalendarId($value))) {
+        if (null !== ($calendarId = $this->getCalendarId($this->getValue($config)))) {
             $params['table'] = 'tl_calendar_events';
             $params['id'] = $calendarId;
         }

--- a/calendar-bundle/src/Picker/EventPickerProvider.php
+++ b/calendar-bundle/src/Picker/EventPickerProvider.php
@@ -24,8 +24,6 @@ class EventPickerProvider extends AbstractPickerProvider implements DcaPickerPro
 {
     use FrameworkAwareTrait;
 
-    protected const DEFAULT_INSERTTAG = '{{event_url::%s}}';
-
     /**
      * {@inheritdoc}
      */
@@ -47,7 +45,7 @@ class EventPickerProvider extends AbstractPickerProvider implements DcaPickerPro
      */
     public function supportsValue(PickerConfig $config): bool
     {
-        return false !== strpos($config->getValue(), $this->getInsertTagChunks($config, self::DEFAULT_INSERTTAG)[0]);
+        return false !== strpos($config->getValue(), $this->getInsertTagChunks($config)[0]);
     }
 
     /**
@@ -71,7 +69,7 @@ class EventPickerProvider extends AbstractPickerProvider implements DcaPickerPro
 
         if ($this->supportsValue($config)) {
             $attributes['value'] = str_replace(
-                $this->getInsertTagChunks($config, self::DEFAULT_INSERTTAG),
+                $this->getInsertTagChunks($config),
                 '',
                 $config->getValue()
             );
@@ -85,7 +83,7 @@ class EventPickerProvider extends AbstractPickerProvider implements DcaPickerPro
      */
     public function convertDcaValue(PickerConfig $config, $value): string
     {
-        return sprintf($this->getInsertTag($config, self::DEFAULT_INSERTTAG), $value);
+        return sprintf($this->getInsertTag($config), $value);
     }
 
     /**
@@ -99,7 +97,7 @@ class EventPickerProvider extends AbstractPickerProvider implements DcaPickerPro
             return $params;
         }
 
-        $insertTagChunks = $this->getInsertTagChunks($config, self::DEFAULT_INSERTTAG);
+        $insertTagChunks = $this->getInsertTagChunks($config);
 
         if (false === strpos($config->getValue(), $insertTagChunks[0])) {
             return $params;
@@ -113,6 +111,14 @@ class EventPickerProvider extends AbstractPickerProvider implements DcaPickerPro
         }
 
         return $params;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getFallbackInsertTag(): string
+    {
+        return '{{event_url::%s}}';
     }
 
     /**

--- a/calendar-bundle/src/Picker/EventPickerProvider.php
+++ b/calendar-bundle/src/Picker/EventPickerProvider.php
@@ -47,7 +47,7 @@ class EventPickerProvider extends AbstractPickerProvider implements DcaPickerPro
      */
     public function supportsValue(PickerConfig $config): bool
     {
-        return false !== strpos($config->getValue(), $this->getInsertTagChunks($config)[0]);
+        return $this->isMatchingTag($config);
     }
 
     /**

--- a/calendar-bundle/src/Picker/EventPickerProvider.php
+++ b/calendar-bundle/src/Picker/EventPickerProvider.php
@@ -24,6 +24,8 @@ class EventPickerProvider extends AbstractPickerProvider implements DcaPickerPro
 {
     use FrameworkAwareTrait;
 
+    protected const INSERTTAG = '{{event_url::%s}}';
+
     /**
      * {@inheritdoc}
      */
@@ -111,14 +113,6 @@ class EventPickerProvider extends AbstractPickerProvider implements DcaPickerPro
         }
 
         return $params;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function getFallbackInsertTag(): string
-    {
-        return '{{event_url::%s}}';
     }
 
     /**

--- a/calendar-bundle/src/Picker/EventPickerProvider.php
+++ b/calendar-bundle/src/Picker/EventPickerProvider.php
@@ -47,7 +47,7 @@ class EventPickerProvider extends AbstractPickerProvider implements DcaPickerPro
      */
     public function supportsValue(PickerConfig $config): bool
     {
-        return $this->isMatchingTag($config);
+        return $this->isMatchingInsertTag($config);
     }
 
     /**
@@ -70,7 +70,7 @@ class EventPickerProvider extends AbstractPickerProvider implements DcaPickerPro
         }
 
         if ($this->supportsValue($config)) {
-            $attributes['value'] = $this->getValue($config);
+            $attributes['value'] = $this->getInsertTagValue($config);
         }
 
         return $attributes;
@@ -95,7 +95,7 @@ class EventPickerProvider extends AbstractPickerProvider implements DcaPickerPro
             return $params;
         }
 
-        if (null !== ($calendarId = $this->getCalendarId($this->getValue($config)))) {
+        if (null !== ($calendarId = $this->getCalendarId($this->getInsertTagValue($config)))) {
             $params['table'] = 'tl_calendar_events';
             $params['id'] = $calendarId;
         }

--- a/calendar-bundle/tests/Picker/EventPickerProviderTest.php
+++ b/calendar-bundle/tests/Picker/EventPickerProviderTest.php
@@ -201,9 +201,12 @@ class EventPickerProviderTest extends ContaoTestCase
         $this->assertSame('{{event_url::5}}', $this->provider->convertDcaValue(new PickerConfig('link'), 5));
     }
 
-    public function testConvertsTheDcaValueWithCustomInsertTag(): void
+    public function testConvertsTheDcaValueWithACustomInsertTag(): void
     {
-        $this->assertSame('{{event_title::5}}', $this->provider->convertDcaValue(new PickerConfig('link', ['insertTag' => '{{event_title::%s}}']), 5));
+        $this->assertSame(
+            '{{event_title::5}}',
+            $this->provider->convertDcaValue(new PickerConfig('link', ['insertTag' => '{{event_title::%s}}']), 5)
+        );
     }
 
     public function testAddsTableAndIdIfThereIsAValue(): void

--- a/calendar-bundle/tests/Picker/EventPickerProviderTest.php
+++ b/calendar-bundle/tests/Picker/EventPickerProviderTest.php
@@ -201,6 +201,11 @@ class EventPickerProviderTest extends ContaoTestCase
         $this->assertSame('{{event_url::5}}', $this->provider->convertDcaValue(new PickerConfig('link'), 5));
     }
 
+    public function testConvertsTheDcaValueWithCustomInsertTag(): void
+    {
+        $this->assertSame('{{event_title::5}}', $this->provider->convertDcaValue(new PickerConfig('link', ['insertTag' => '{{event_title::%s}}']), 5));
+    }
+
     public function testAddsTableAndIdIfThereIsAValue(): void
     {
         /** @var CalendarModel|MockObject $calendarModel */

--- a/core-bundle/src/Picker/AbstractInsertTagPickerProvider.php
+++ b/core-bundle/src/Picker/AbstractInsertTagPickerProvider.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Picker;
+
+abstract class AbstractInsertTagPickerProvider extends AbstractPickerProvider
+{
+    protected const INSERTTAG = null;
+
+    /**
+     * Returns the configured insert tag or the default one.
+     */
+    protected function getInsertTag(PickerConfig $config): string
+    {
+        if ($insertTag = $config->getExtraForProvider('insertTag', $this->getName())) {
+            return (string) $insertTag;
+        }
+
+        if (null === static::INSERTTAG) {
+            throw new \LogicException('Please add a protected INSERTTAG constant in your picker provider class');
+        }
+
+        return (string) static::INSERTTAG;
+    }
+
+    /**
+     * Splits an insert tag at the placeholder (%s) and returns the chunks.
+     */
+    protected function getInsertTagChunks(PickerConfig $config): array
+    {
+        return explode('%s', $this->getInsertTag($config), 2);
+    }
+
+    /**
+     * Returns the value without the surrounding insert tag chunks.
+     */
+    protected function getInsertTagValue(PickerConfig $config)
+    {
+        return str_replace($this->getInsertTagChunks($config), '', $config->getValue());
+    }
+
+    /**
+     * Checks if the value matches the insert tag.
+     */
+    protected function isMatchingInsertTag(PickerConfig $config): bool
+    {
+        return false !== strpos($config->getValue(), $this->getInsertTagChunks($config)[0]);
+    }
+}

--- a/core-bundle/src/Picker/AbstractPickerProvider.php
+++ b/core-bundle/src/Picker/AbstractPickerProvider.php
@@ -120,6 +120,18 @@ abstract class AbstractPickerProvider implements PickerProviderInterface
     }
 
     /**
+     * Provides a shortcut to get the "insertTag" extra value for child classes.
+     */
+    protected function getInsertTag(PickerConfig $config, string $default): string
+    {
+        if ($insertTag = $config->getExtra('insertTag')) {
+            return (string) $insertTag;
+        }
+
+        return $default;
+    }
+
+    /**
      * Returns the routing parameters for the back end picker.
      *
      * @return array<string,string|int>

--- a/core-bundle/src/Picker/AbstractPickerProvider.php
+++ b/core-bundle/src/Picker/AbstractPickerProvider.php
@@ -122,7 +122,7 @@ abstract class AbstractPickerProvider implements PickerProviderInterface
     }
 
     /**
-     * Provides a shortcut to get the "insertTag" extra value for child classes.
+     * Returns the configured insert tag or the default one.
      */
     protected function getInsertTag(PickerConfig $config): string
     {
@@ -134,12 +134,11 @@ abstract class AbstractPickerProvider implements PickerProviderInterface
             throw new \LogicException('Please add a protected INSERTTAG constant in your picker provider class');
         }
 
-        return static::INSERTTAG;
+        return (string) static::INSERTTAG;
     }
 
     /**
-     * Provides a shortcut get the "insertTag" extra value for child classes and
-     * split them at the placeholder (%s).
+     * Splits an insert tag at the placeholder (%s) and returns the chunks.
      */
     protected function getInsertTagChunks(PickerConfig $config): array
     {

--- a/core-bundle/src/Picker/AbstractPickerProvider.php
+++ b/core-bundle/src/Picker/AbstractPickerProvider.php
@@ -132,6 +132,15 @@ abstract class AbstractPickerProvider implements PickerProviderInterface
     }
 
     /**
+     * Provides a shortcut get the "insertTag" extra value for child classes and
+     * split them at the placeholder (%s).
+     */
+    protected function getInsertTagChunks(PickerConfig $config, string $default): array
+    {
+        return explode('%s', $this->getInsertTag($config, $default), 2);
+    }
+
+    /**
      * Returns the routing parameters for the back end picker.
      *
      * @return array<string,string|int>

--- a/core-bundle/src/Picker/AbstractPickerProvider.php
+++ b/core-bundle/src/Picker/AbstractPickerProvider.php
@@ -124,7 +124,7 @@ abstract class AbstractPickerProvider implements PickerProviderInterface
      */
     protected function getInsertTag(PickerConfig $config, string $default): string
     {
-        if ($insertTag = $config->getExtra('insertTag')) {
+        if ($insertTag = $config->getExtraForProvider('insertTag', $this->getName())) {
             return (string) $insertTag;
         }
 

--- a/core-bundle/src/Picker/AbstractPickerProvider.php
+++ b/core-bundle/src/Picker/AbstractPickerProvider.php
@@ -146,6 +146,14 @@ abstract class AbstractPickerProvider implements PickerProviderInterface
     }
 
     /**
+     * Returns the value without the surrounding insert tag chunks.
+     */
+    protected function getValue(PickerConfig $config)
+    {
+        return str_replace($this->getInsertTagChunks($config), '', $config->getValue());
+    }
+
+    /**
      * Returns the routing parameters for the back end picker.
      *
      * @return array<string,string|int>

--- a/core-bundle/src/Picker/AbstractPickerProvider.php
+++ b/core-bundle/src/Picker/AbstractPickerProvider.php
@@ -148,7 +148,7 @@ abstract class AbstractPickerProvider implements PickerProviderInterface
     /**
      * Returns the value without the surrounding insert tag chunks.
      */
-    protected function getValue(PickerConfig $config)
+    protected function getInsertTagValue(PickerConfig $config)
     {
         return str_replace($this->getInsertTagChunks($config), '', $config->getValue());
     }
@@ -156,7 +156,7 @@ abstract class AbstractPickerProvider implements PickerProviderInterface
     /**
      * Checks if the value matches the insert tag.
      */
-    protected function isMatchingTag(PickerConfig $config): bool
+    protected function isMatchingInsertTag(PickerConfig $config): bool
     {
         return false !== strpos($config->getValue(), $this->getInsertTagChunks($config)[0]);
     }

--- a/core-bundle/src/Picker/AbstractPickerProvider.php
+++ b/core-bundle/src/Picker/AbstractPickerProvider.php
@@ -20,6 +20,8 @@ use Symfony\Component\Translation\TranslatorInterface;
 
 abstract class AbstractPickerProvider implements PickerProviderInterface
 {
+    protected const INSERTTAG = null;
+
     /**
      * @var FactoryInterface
      */
@@ -128,7 +130,11 @@ abstract class AbstractPickerProvider implements PickerProviderInterface
             return (string) $insertTag;
         }
 
-        return $this->getFallbackInsertTag();
+        if (null === static::INSERTTAG) {
+            throw new \LogicException('Please add a protected INSERTTAG constant in your picker provider class');
+        }
+
+        return static::INSERTTAG;
     }
 
     /**
@@ -138,17 +144,6 @@ abstract class AbstractPickerProvider implements PickerProviderInterface
     protected function getInsertTagChunks(PickerConfig $config): array
     {
         return explode('%s', $this->getInsertTag($config), 2);
-    }
-
-    /**
-     * Defines the fallback insert tag to work with if no specifc configuration
-     * was provided.
-     */
-    protected function getFallbackInsertTag(): string
-    {
-        throw new \RuntimeException('If you deal with insert tags in your picker provider you have to specify a
-        fallback insert tag in case no specific insert tag was passed on via configuration. You must override
-        the AbstractPickerProvider::getFallbackInsertTag() method.');
     }
 
     /**

--- a/core-bundle/src/Picker/AbstractPickerProvider.php
+++ b/core-bundle/src/Picker/AbstractPickerProvider.php
@@ -122,22 +122,33 @@ abstract class AbstractPickerProvider implements PickerProviderInterface
     /**
      * Provides a shortcut to get the "insertTag" extra value for child classes.
      */
-    protected function getInsertTag(PickerConfig $config, string $default): string
+    protected function getInsertTag(PickerConfig $config): string
     {
         if ($insertTag = $config->getExtraForProvider('insertTag', $this->getName())) {
             return (string) $insertTag;
         }
 
-        return $default;
+        return $this->getFallbackInsertTag();
     }
 
     /**
      * Provides a shortcut get the "insertTag" extra value for child classes and
      * split them at the placeholder (%s).
      */
-    protected function getInsertTagChunks(PickerConfig $config, string $default): array
+    protected function getInsertTagChunks(PickerConfig $config): array
     {
-        return explode('%s', $this->getInsertTag($config, $default), 2);
+        return explode('%s', $this->getInsertTag($config), 2);
+    }
+
+    /**
+     * Defines the fallback insert tag to work with if no specifc configuration
+     * was provided.
+     */
+    protected function getFallbackInsertTag(): string
+    {
+        throw new \RuntimeException('If you deal with insert tags in your picker provider you have to specify a
+        fallback insert tag in case no specific insert tag was passed on via configuration. You must override
+        the AbstractPickerProvider::getFallbackInsertTag() method.');
     }
 
     /**

--- a/core-bundle/src/Picker/AbstractPickerProvider.php
+++ b/core-bundle/src/Picker/AbstractPickerProvider.php
@@ -154,6 +154,14 @@ abstract class AbstractPickerProvider implements PickerProviderInterface
     }
 
     /**
+     * Checks if the value matches the insert tag.
+     */
+    protected function isMatchingTag(PickerConfig $config): bool
+    {
+        return false !== strpos($config->getValue(), $this->getInsertTagChunks($config)[0]);
+    }
+
+    /**
      * Returns the routing parameters for the back end picker.
      *
      * @return array<string,string|int>

--- a/core-bundle/src/Picker/AbstractPickerProvider.php
+++ b/core-bundle/src/Picker/AbstractPickerProvider.php
@@ -20,8 +20,6 @@ use Symfony\Component\Translation\TranslatorInterface;
 
 abstract class AbstractPickerProvider implements PickerProviderInterface
 {
-    protected const INSERTTAG = null;
-
     /**
      * @var FactoryInterface
      */
@@ -119,46 +117,6 @@ abstract class AbstractPickerProvider implements PickerProviderInterface
         }
 
         return $user;
-    }
-
-    /**
-     * Returns the configured insert tag or the default one.
-     */
-    protected function getInsertTag(PickerConfig $config): string
-    {
-        if ($insertTag = $config->getExtraForProvider('insertTag', $this->getName())) {
-            return (string) $insertTag;
-        }
-
-        if (null === static::INSERTTAG) {
-            throw new \LogicException('Please add a protected INSERTTAG constant in your picker provider class');
-        }
-
-        return (string) static::INSERTTAG;
-    }
-
-    /**
-     * Splits an insert tag at the placeholder (%s) and returns the chunks.
-     */
-    protected function getInsertTagChunks(PickerConfig $config): array
-    {
-        return explode('%s', $this->getInsertTag($config), 2);
-    }
-
-    /**
-     * Returns the value without the surrounding insert tag chunks.
-     */
-    protected function getInsertTagValue(PickerConfig $config)
-    {
-        return str_replace($this->getInsertTagChunks($config), '', $config->getValue());
-    }
-
-    /**
-     * Checks if the value matches the insert tag.
-     */
-    protected function isMatchingInsertTag(PickerConfig $config): bool
-    {
-        return false !== strpos($config->getValue(), $this->getInsertTagChunks($config)[0]);
     }
 
     /**

--- a/core-bundle/src/Picker/ArticlePickerProvider.php
+++ b/core-bundle/src/Picker/ArticlePickerProvider.php
@@ -37,7 +37,7 @@ class ArticlePickerProvider extends AbstractPickerProvider implements DcaPickerP
      */
     public function supportsValue(PickerConfig $config): bool
     {
-        return $this->isMatchingTag($config);
+        return $this->isMatchingInsertTag($config);
     }
 
     /**
@@ -60,7 +60,7 @@ class ArticlePickerProvider extends AbstractPickerProvider implements DcaPickerP
         }
 
         if ($this->supportsValue($config)) {
-            $attributes['value'] = $this->getValue($config);
+            $attributes['value'] = $this->getInsertTagValue($config);
         }
 
         return $attributes;

--- a/core-bundle/src/Picker/ArticlePickerProvider.php
+++ b/core-bundle/src/Picker/ArticlePickerProvider.php
@@ -14,6 +14,8 @@ namespace Contao\CoreBundle\Picker;
 
 class ArticlePickerProvider extends AbstractPickerProvider implements DcaPickerProviderInterface
 {
+    protected const DEFAULT_INSERTTAG = '{{article_url::%s}}';
+
     /**
      * {@inheritdoc}
      */
@@ -35,7 +37,9 @@ class ArticlePickerProvider extends AbstractPickerProvider implements DcaPickerP
      */
     public function supportsValue(PickerConfig $config): bool
     {
-        return false !== strpos($config->getValue(), '{{article_url::');
+        $insertTagChunks = explode('%s', $this->getInsertTag($config, self::DEFAULT_INSERTTAG), 2);
+
+        return false !== strpos($config->getValue(), $insertTagChunks[0]);
     }
 
     /**
@@ -58,7 +62,9 @@ class ArticlePickerProvider extends AbstractPickerProvider implements DcaPickerP
         }
 
         if ($this->supportsValue($config)) {
-            $attributes['value'] = str_replace(['{{article_url::', '}}'], '', $config->getValue());
+            $insertTagChunks = explode('%s', $this->getInsertTag($config, self::DEFAULT_INSERTTAG), 2);
+
+            $attributes['value'] = str_replace($insertTagChunks, '',  $config->getValue());
         }
 
         return $attributes;
@@ -69,7 +75,7 @@ class ArticlePickerProvider extends AbstractPickerProvider implements DcaPickerP
      */
     public function convertDcaValue(PickerConfig $config, $value): string
     {
-        return '{{article_url::'.$value.'}}';
+        return sprintf($this->getInsertTag($config, self::DEFAULT_INSERTTAG), $value);
     }
 
     /**

--- a/core-bundle/src/Picker/ArticlePickerProvider.php
+++ b/core-bundle/src/Picker/ArticlePickerProvider.php
@@ -14,6 +14,8 @@ namespace Contao\CoreBundle\Picker;
 
 class ArticlePickerProvider extends AbstractPickerProvider implements DcaPickerProviderInterface
 {
+    protected const INSERTTAG = '{{article_url::%s}}';
+
     /**
      * {@inheritdoc}
      */
@@ -82,13 +84,5 @@ class ArticlePickerProvider extends AbstractPickerProvider implements DcaPickerP
     protected function getRouteParameters(PickerConfig $config = null): array
     {
         return ['do' => 'article'];
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function getFallbackInsertTag(): string
-    {
-        return '{{article_url::%s}}';
     }
 }

--- a/core-bundle/src/Picker/ArticlePickerProvider.php
+++ b/core-bundle/src/Picker/ArticlePickerProvider.php
@@ -37,9 +37,7 @@ class ArticlePickerProvider extends AbstractPickerProvider implements DcaPickerP
      */
     public function supportsValue(PickerConfig $config): bool
     {
-        $insertTagChunks = explode('%s', $this->getInsertTag($config, self::DEFAULT_INSERTTAG), 2);
-
-        return false !== strpos($config->getValue(), $insertTagChunks[0]);
+        return false !== strpos($config->getValue(), $this->getInsertTagChunks($config, self::DEFAULT_INSERTTAG)[0]);
     }
 
     /**
@@ -62,9 +60,11 @@ class ArticlePickerProvider extends AbstractPickerProvider implements DcaPickerP
         }
 
         if ($this->supportsValue($config)) {
-            $insertTagChunks = explode('%s', $this->getInsertTag($config, self::DEFAULT_INSERTTAG), 2);
-
-            $attributes['value'] = str_replace($insertTagChunks, '',  $config->getValue());
+            $attributes['value'] = str_replace(
+                $this->getInsertTagChunks($config, self::DEFAULT_INSERTTAG),
+                '',
+                $config->getValue()
+            );
         }
 
         return $attributes;

--- a/core-bundle/src/Picker/ArticlePickerProvider.php
+++ b/core-bundle/src/Picker/ArticlePickerProvider.php
@@ -60,11 +60,7 @@ class ArticlePickerProvider extends AbstractPickerProvider implements DcaPickerP
         }
 
         if ($this->supportsValue($config)) {
-            $attributes['value'] = str_replace(
-                $this->getInsertTagChunks($config),
-                '',
-                $config->getValue()
-            );
+            $attributes['value'] = str_replace($this->getInsertTagChunks($config), '', $config->getValue());
         }
 
         return $attributes;

--- a/core-bundle/src/Picker/ArticlePickerProvider.php
+++ b/core-bundle/src/Picker/ArticlePickerProvider.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Picker;
 
-class ArticlePickerProvider extends AbstractPickerProvider implements DcaPickerProviderInterface
+class ArticlePickerProvider extends AbstractInsertTagPickerProvider implements DcaPickerProviderInterface
 {
     protected const INSERTTAG = '{{article_url::%s}}';
 

--- a/core-bundle/src/Picker/ArticlePickerProvider.php
+++ b/core-bundle/src/Picker/ArticlePickerProvider.php
@@ -37,7 +37,7 @@ class ArticlePickerProvider extends AbstractPickerProvider implements DcaPickerP
      */
     public function supportsValue(PickerConfig $config): bool
     {
-        return false !== strpos($config->getValue(), $this->getInsertTagChunks($config)[0]);
+        return $this->isMatchingTag($config);
     }
 
     /**

--- a/core-bundle/src/Picker/ArticlePickerProvider.php
+++ b/core-bundle/src/Picker/ArticlePickerProvider.php
@@ -14,8 +14,6 @@ namespace Contao\CoreBundle\Picker;
 
 class ArticlePickerProvider extends AbstractPickerProvider implements DcaPickerProviderInterface
 {
-    protected const DEFAULT_INSERTTAG = '{{article_url::%s}}';
-
     /**
      * {@inheritdoc}
      */
@@ -37,7 +35,7 @@ class ArticlePickerProvider extends AbstractPickerProvider implements DcaPickerP
      */
     public function supportsValue(PickerConfig $config): bool
     {
-        return false !== strpos($config->getValue(), $this->getInsertTagChunks($config, self::DEFAULT_INSERTTAG)[0]);
+        return false !== strpos($config->getValue(), $this->getInsertTagChunks($config)[0]);
     }
 
     /**
@@ -61,7 +59,7 @@ class ArticlePickerProvider extends AbstractPickerProvider implements DcaPickerP
 
         if ($this->supportsValue($config)) {
             $attributes['value'] = str_replace(
-                $this->getInsertTagChunks($config, self::DEFAULT_INSERTTAG),
+                $this->getInsertTagChunks($config),
                 '',
                 $config->getValue()
             );
@@ -75,7 +73,7 @@ class ArticlePickerProvider extends AbstractPickerProvider implements DcaPickerP
      */
     public function convertDcaValue(PickerConfig $config, $value): string
     {
-        return sprintf($this->getInsertTag($config, self::DEFAULT_INSERTTAG), $value);
+        return sprintf($this->getInsertTag($config), $value);
     }
 
     /**
@@ -84,5 +82,13 @@ class ArticlePickerProvider extends AbstractPickerProvider implements DcaPickerP
     protected function getRouteParameters(PickerConfig $config = null): array
     {
         return ['do' => 'article'];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getFallbackInsertTag(): string
+    {
+        return '{{article_url::%s}}';
     }
 }

--- a/core-bundle/src/Picker/ArticlePickerProvider.php
+++ b/core-bundle/src/Picker/ArticlePickerProvider.php
@@ -60,7 +60,7 @@ class ArticlePickerProvider extends AbstractPickerProvider implements DcaPickerP
         }
 
         if ($this->supportsValue($config)) {
-            $attributes['value'] = str_replace($this->getInsertTagChunks($config), '', $config->getValue());
+            $attributes['value'] = $this->getValue($config);
         }
 
         return $attributes;

--- a/core-bundle/src/Picker/FilePickerProvider.php
+++ b/core-bundle/src/Picker/FilePickerProvider.php
@@ -25,8 +25,6 @@ class FilePickerProvider extends AbstractPickerProvider implements DcaPickerProv
 {
     use FrameworkAwareTrait;
 
-    protected const DEFAULT_INSERTTAG = '{{file::%s}}';
-
     /**
      * @var string
      */
@@ -66,7 +64,7 @@ class FilePickerProvider extends AbstractPickerProvider implements DcaPickerProv
             return Validator::isUuid($value);
         }
 
-        return false !== strpos($config->getValue(), $this->getInsertTagChunks($config, self::DEFAULT_INSERTTAG)[0])
+        return false !== strpos($config->getValue(), $this->getInsertTagChunks($config)[0])
             || 0 === strpos($value, $this->uploadPath);
     }
 
@@ -104,7 +102,7 @@ class FilePickerProvider extends AbstractPickerProvider implements DcaPickerProv
         $filesModel = $filesAdapter->findByPath(rawurldecode($value));
 
         if ($filesModel instanceof FilesModel) {
-            return sprintf($this->getInsertTag($config, self::DEFAULT_INSERTTAG), StringUtil::binToUuid($filesModel->uuid));
+            return sprintf($this->getInsertTag($config), StringUtil::binToUuid($filesModel->uuid));
         }
 
         return $value;
@@ -116,6 +114,14 @@ class FilePickerProvider extends AbstractPickerProvider implements DcaPickerProv
     protected function getRouteParameters(PickerConfig $config = null): array
     {
         return ['do' => 'files'];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getFallbackInsertTag(): string
+    {
+        return '{{file::%s}}';
     }
 
     /**
@@ -183,7 +189,7 @@ class FilePickerProvider extends AbstractPickerProvider implements DcaPickerProv
         $value = $config->getValue();
 
         if ($value) {
-            $insertTagChunks = $this->getInsertTagChunks($config, self::DEFAULT_INSERTTAG);
+            $insertTagChunks = $this->getInsertTagChunks($config);
 
             if (false !== strpos($value, $insertTagChunks[0])) {
                 $value = str_replace($insertTagChunks, '', $value);

--- a/core-bundle/src/Picker/FilePickerProvider.php
+++ b/core-bundle/src/Picker/FilePickerProvider.php
@@ -25,6 +25,8 @@ class FilePickerProvider extends AbstractPickerProvider implements DcaPickerProv
 {
     use FrameworkAwareTrait;
 
+    protected const INSERTTAG = '{{file::%s}}';
+
     /**
      * @var string
      */
@@ -114,14 +116,6 @@ class FilePickerProvider extends AbstractPickerProvider implements DcaPickerProv
     protected function getRouteParameters(PickerConfig $config = null): array
     {
         return ['do' => 'files'];
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function getFallbackInsertTag(): string
-    {
-        return '{{file::%s}}';
     }
 
     /**

--- a/core-bundle/src/Picker/FilePickerProvider.php
+++ b/core-bundle/src/Picker/FilePickerProvider.php
@@ -64,7 +64,7 @@ class FilePickerProvider extends AbstractPickerProvider implements DcaPickerProv
             return Validator::isUuid($config->getValue());
         }
 
-        return $this->isMatchingTag($config) || 0 === strpos($config->getValue(), $this->uploadPath.'/');
+        return $this->isMatchingInsertTag($config) || 0 === strpos($config->getValue(), $this->uploadPath.'/');
     }
 
     /**

--- a/core-bundle/src/Picker/FilePickerProvider.php
+++ b/core-bundle/src/Picker/FilePickerProvider.php
@@ -66,8 +66,9 @@ class FilePickerProvider extends AbstractPickerProvider implements DcaPickerProv
             return Validator::isUuid($value);
         }
 
-        return false !== strpos($config->getValue(), $this->getInsertTagChunks($config)[0])
-            || 0 === strpos($value, $this->uploadPath);
+        return 0 === strpos($value, $this->uploadPath)
+            || false !== strpos($config->getValue(), $this->getInsertTagChunks($config)[0])
+        ;
     }
 
     /**

--- a/core-bundle/src/Picker/FilePickerProvider.php
+++ b/core-bundle/src/Picker/FilePickerProvider.php
@@ -66,7 +66,7 @@ class FilePickerProvider extends AbstractPickerProvider implements DcaPickerProv
             return Validator::isUuid($value);
         }
 
-        return 0 === strpos($value, $this->uploadPath)
+        return 0 === strpos($value, $this->uploadPath.'/')
             || false !== strpos($config->getValue(), $this->getInsertTagChunks($config)[0])
         ;
     }
@@ -184,10 +184,10 @@ class FilePickerProvider extends AbstractPickerProvider implements DcaPickerProv
         $value = $config->getValue();
 
         if ($value) {
-            $insertTagChunks = $this->getInsertTagChunks($config);
+            $chunks = $this->getInsertTagChunks($config);
 
-            if (false !== strpos($value, $insertTagChunks[0])) {
-                $value = str_replace($insertTagChunks, '', $value);
+            if (false !== strpos($value, $chunks[0])) {
+                $value = str_replace($chunks, '', $value);
             }
 
             if (0 === strpos($value, $this->uploadPath.'/')) {

--- a/core-bundle/src/Picker/FilePickerProvider.php
+++ b/core-bundle/src/Picker/FilePickerProvider.php
@@ -21,7 +21,7 @@ use Knp\Menu\FactoryInterface;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 
-class FilePickerProvider extends AbstractPickerProvider implements DcaPickerProviderInterface, FrameworkAwareInterface
+class FilePickerProvider extends AbstractInsertTagPickerProvider implements DcaPickerProviderInterface, FrameworkAwareInterface
 {
     use FrameworkAwareTrait;
 

--- a/core-bundle/src/Picker/FilePickerProvider.php
+++ b/core-bundle/src/Picker/FilePickerProvider.php
@@ -60,15 +60,11 @@ class FilePickerProvider extends AbstractPickerProvider implements DcaPickerProv
      */
     public function supportsValue(PickerConfig $config): bool
     {
-        $value = $config->getValue();
-
         if ('file' === $config->getContext()) {
-            return Validator::isUuid($value);
+            return Validator::isUuid($config->getValue());
         }
 
-        return 0 === strpos($value, $this->uploadPath.'/')
-            || false !== strpos($config->getValue(), $this->getInsertTagChunks($config)[0])
-        ;
+        return $this->isMatchingTag($config) || 0 === strpos($config->getValue(), $this->uploadPath.'/');
     }
 
     /**

--- a/core-bundle/src/Picker/FilePickerProvider.php
+++ b/core-bundle/src/Picker/FilePickerProvider.php
@@ -66,9 +66,8 @@ class FilePickerProvider extends AbstractPickerProvider implements DcaPickerProv
             return Validator::isUuid($value);
         }
 
-        $insertTagChunks = explode('%s', $this->getInsertTag($config, self::DEFAULT_INSERTTAG), 2);
-
-        return false !== strpos($config->getValue(), $insertTagChunks[0]) || 0 === strpos($value, $this->uploadPath);
+        return false !== strpos($config->getValue(), $this->getInsertTagChunks($config, self::DEFAULT_INSERTTAG)[0])
+            || 0 === strpos($value, $this->uploadPath);
     }
 
     /**
@@ -105,7 +104,6 @@ class FilePickerProvider extends AbstractPickerProvider implements DcaPickerProv
         $filesModel = $filesAdapter->findByPath(rawurldecode($value));
 
         if ($filesModel instanceof FilesModel) {
-
             return sprintf($this->getInsertTag($config, self::DEFAULT_INSERTTAG), StringUtil::binToUuid($filesModel->uuid));
         }
 
@@ -185,8 +183,7 @@ class FilePickerProvider extends AbstractPickerProvider implements DcaPickerProv
         $value = $config->getValue();
 
         if ($value) {
-
-            $insertTagChunks = explode('%s', $this->getInsertTag($config, self::DEFAULT_INSERTTAG), 2);
+            $insertTagChunks = $this->getInsertTagChunks($config, self::DEFAULT_INSERTTAG);
 
             if (false !== strpos($value, $insertTagChunks[0])) {
                 $value = str_replace($insertTagChunks, '', $value);

--- a/core-bundle/src/Picker/PagePickerProvider.php
+++ b/core-bundle/src/Picker/PagePickerProvider.php
@@ -14,6 +14,8 @@ namespace Contao\CoreBundle\Picker;
 
 class PagePickerProvider extends AbstractPickerProvider implements DcaPickerProviderInterface
 {
+    protected const DEFAULT_INSERTTAG = '{{link_url::%s}}';
+
     /**
      * {@inheritdoc}
      */
@@ -39,7 +41,9 @@ class PagePickerProvider extends AbstractPickerProvider implements DcaPickerProv
             return is_numeric($config->getValue());
         }
 
-        return false !== strpos($config->getValue(), '{{link_url::');
+        $insertTagChunks = explode('%s', $this->getInsertTag($config, self::DEFAULT_INSERTTAG), 2);
+
+        return false !== strpos($config->getValue(), $insertTagChunks[0]);
     }
 
     /**
@@ -82,8 +86,10 @@ class PagePickerProvider extends AbstractPickerProvider implements DcaPickerProv
             return $attributes;
         }
 
-        if ($value && false !== strpos($value, '{{link_url::')) {
-            $attributes['value'] = str_replace(['{{link_url::', '}}'], '', $value);
+        $insertTagChunks = explode('%s', $this->getInsertTag($config, self::DEFAULT_INSERTTAG), 2);
+
+        if ($value && false !== strpos($value, $insertTagChunks[0])) {
+            $attributes['value'] = str_replace($insertTagChunks, '', $value);
         }
 
         return $attributes;
@@ -98,7 +104,7 @@ class PagePickerProvider extends AbstractPickerProvider implements DcaPickerProv
             return (int) $value;
         }
 
-        return '{{link_url::'.$value.'}}';
+        return sprintf($this->getInsertTag($config, self::DEFAULT_INSERTTAG), $value);
     }
 
     /**

--- a/core-bundle/src/Picker/PagePickerProvider.php
+++ b/core-bundle/src/Picker/PagePickerProvider.php
@@ -41,9 +41,7 @@ class PagePickerProvider extends AbstractPickerProvider implements DcaPickerProv
             return is_numeric($config->getValue());
         }
 
-        $insertTagChunks = explode('%s', $this->getInsertTag($config, self::DEFAULT_INSERTTAG), 2);
-
-        return false !== strpos($config->getValue(), $insertTagChunks[0]);
+        return false !== strpos($config->getValue(), $this->getInsertTagChunks($config, self::DEFAULT_INSERTTAG)[0]);
     }
 
     /**
@@ -86,7 +84,7 @@ class PagePickerProvider extends AbstractPickerProvider implements DcaPickerProv
             return $attributes;
         }
 
-        $insertTagChunks = explode('%s', $this->getInsertTag($config, self::DEFAULT_INSERTTAG), 2);
+        $insertTagChunks = $this->getInsertTagChunks($config, self::DEFAULT_INSERTTAG);
 
         if ($value && false !== strpos($value, $insertTagChunks[0])) {
             $attributes['value'] = str_replace($insertTagChunks, '', $value);

--- a/core-bundle/src/Picker/PagePickerProvider.php
+++ b/core-bundle/src/Picker/PagePickerProvider.php
@@ -41,7 +41,7 @@ class PagePickerProvider extends AbstractPickerProvider implements DcaPickerProv
             return is_numeric($config->getValue());
         }
 
-        return $this->isMatchingTag($config);
+        return $this->isMatchingInsertTag($config);
     }
 
     /**

--- a/core-bundle/src/Picker/PagePickerProvider.php
+++ b/core-bundle/src/Picker/PagePickerProvider.php
@@ -41,7 +41,7 @@ class PagePickerProvider extends AbstractPickerProvider implements DcaPickerProv
             return is_numeric($config->getValue());
         }
 
-        return false !== strpos($config->getValue(), $this->getInsertTagChunks($config)[0]);
+        return $this->isMatchingTag($config);
     }
 
     /**

--- a/core-bundle/src/Picker/PagePickerProvider.php
+++ b/core-bundle/src/Picker/PagePickerProvider.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Picker;
 
-class PagePickerProvider extends AbstractPickerProvider implements DcaPickerProviderInterface
+class PagePickerProvider extends AbstractInsertTagPickerProvider implements DcaPickerProviderInterface
 {
     protected const INSERTTAG = '{{link_url::%s}}';
 

--- a/core-bundle/src/Picker/PagePickerProvider.php
+++ b/core-bundle/src/Picker/PagePickerProvider.php
@@ -14,6 +14,8 @@ namespace Contao\CoreBundle\Picker;
 
 class PagePickerProvider extends AbstractPickerProvider implements DcaPickerProviderInterface
 {
+    protected const INSERTTAG = '{{link_url::%s}}';
+
     /**
      * {@inheritdoc}
      */
@@ -109,13 +111,5 @@ class PagePickerProvider extends AbstractPickerProvider implements DcaPickerProv
     protected function getRouteParameters(PickerConfig $config = null): array
     {
         return ['do' => 'page'];
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function getFallbackInsertTag(): string
-    {
-        return '{{link_url::%s}}';
     }
 }

--- a/core-bundle/src/Picker/PagePickerProvider.php
+++ b/core-bundle/src/Picker/PagePickerProvider.php
@@ -84,10 +84,10 @@ class PagePickerProvider extends AbstractPickerProvider implements DcaPickerProv
             return $attributes;
         }
 
-        $insertTagChunks = $this->getInsertTagChunks($config);
+        $chunks = $this->getInsertTagChunks($config);
 
-        if ($value && false !== strpos($value, $insertTagChunks[0])) {
-            $attributes['value'] = str_replace($insertTagChunks, '', $value);
+        if ($value && false !== strpos($value, $chunks[0])) {
+            $attributes['value'] = str_replace($chunks, '', $value);
         }
 
         return $attributes;

--- a/core-bundle/src/Picker/PagePickerProvider.php
+++ b/core-bundle/src/Picker/PagePickerProvider.php
@@ -14,8 +14,6 @@ namespace Contao\CoreBundle\Picker;
 
 class PagePickerProvider extends AbstractPickerProvider implements DcaPickerProviderInterface
 {
-    protected const DEFAULT_INSERTTAG = '{{link_url::%s}}';
-
     /**
      * {@inheritdoc}
      */
@@ -41,7 +39,7 @@ class PagePickerProvider extends AbstractPickerProvider implements DcaPickerProv
             return is_numeric($config->getValue());
         }
 
-        return false !== strpos($config->getValue(), $this->getInsertTagChunks($config, self::DEFAULT_INSERTTAG)[0]);
+        return false !== strpos($config->getValue(), $this->getInsertTagChunks($config)[0]);
     }
 
     /**
@@ -84,7 +82,7 @@ class PagePickerProvider extends AbstractPickerProvider implements DcaPickerProv
             return $attributes;
         }
 
-        $insertTagChunks = $this->getInsertTagChunks($config, self::DEFAULT_INSERTTAG);
+        $insertTagChunks = $this->getInsertTagChunks($config);
 
         if ($value && false !== strpos($value, $insertTagChunks[0])) {
             $attributes['value'] = str_replace($insertTagChunks, '', $value);
@@ -102,7 +100,7 @@ class PagePickerProvider extends AbstractPickerProvider implements DcaPickerProv
             return (int) $value;
         }
 
-        return sprintf($this->getInsertTag($config, self::DEFAULT_INSERTTAG), $value);
+        return sprintf($this->getInsertTag($config), $value);
     }
 
     /**
@@ -111,5 +109,13 @@ class PagePickerProvider extends AbstractPickerProvider implements DcaPickerProv
     protected function getRouteParameters(PickerConfig $config = null): array
     {
         return ['do' => 'page'];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getFallbackInsertTag(): string
+    {
+        return '{{link_url::%s}}';
     }
 }

--- a/core-bundle/src/Picker/PickerConfig.php
+++ b/core-bundle/src/Picker/PickerConfig.php
@@ -72,8 +72,7 @@ class PickerConfig implements \JsonSerializable
     }
 
     /**
-     * Checks if there's an extra value for a given provider and if not,
-     * falls back to the general extra.
+     * Returns an extra value for a given provider or the general extra value.
      */
     public function getExtraForProvider(string $name, string $provider)
     {

--- a/core-bundle/src/Picker/PickerConfig.php
+++ b/core-bundle/src/Picker/PickerConfig.php
@@ -71,6 +71,15 @@ class PickerConfig implements \JsonSerializable
         return $this->current;
     }
 
+    /**
+     * Checks if there's an extra value for a given provider and if not,
+     * falls back to the general extra.
+     */
+    public function getExtraForProvider(string $name, string $provider)
+    {
+        return $this->extras[$provider][$name] ?? $this->getExtra($name);
+    }
+
     public function getExtra(string $name)
     {
         return $this->extras[$name] ?? null;

--- a/core-bundle/tests/Picker/ArticlePickerProviderTest.php
+++ b/core-bundle/tests/Picker/ArticlePickerProviderTest.php
@@ -215,4 +215,9 @@ class ArticlePickerProviderTest extends ContaoTestCase
     {
         $this->assertSame('{{article_url::5}}', $this->provider->convertDcaValue(new PickerConfig('link'), 5));
     }
+
+    public function testConvertsTheDcaValueWithCustomInsertTag(): void
+    {
+        $this->assertSame('{{article_title::5}}', $this->provider->convertDcaValue(new PickerConfig('link', ['insertTag' => '{{article_title::%s}}']), 5));
+    }
 }

--- a/core-bundle/tests/Picker/ArticlePickerProviderTest.php
+++ b/core-bundle/tests/Picker/ArticlePickerProviderTest.php
@@ -216,8 +216,11 @@ class ArticlePickerProviderTest extends ContaoTestCase
         $this->assertSame('{{article_url::5}}', $this->provider->convertDcaValue(new PickerConfig('link'), 5));
     }
 
-    public function testConvertsTheDcaValueWithCustomInsertTag(): void
+    public function testConvertsTheDcaValueWithACustomInsertTag(): void
     {
-        $this->assertSame('{{article_title::5}}', $this->provider->convertDcaValue(new PickerConfig('link', ['insertTag' => '{{article_title::%s}}']), 5));
+        $this->assertSame(
+            '{{article_title::5}}',
+            $this->provider->convertDcaValue(new PickerConfig('link', ['insertTag' => '{{article_title::%s}}']), 5)
+        );
     }
 }

--- a/core-bundle/tests/Picker/FilePickerProviderTest.php
+++ b/core-bundle/tests/Picker/FilePickerProviderTest.php
@@ -291,7 +291,7 @@ class FilePickerProviderTest extends ContaoTestCase
         );
     }
 
-    public function testConvertsTheDcaValueWithCustomInsertTag(): void
+    public function testConvertsTheDcaValueWithACustomInsertTag(): void
     {
         $this->assertSame(
             '/foobar',

--- a/core-bundle/tests/Picker/FilePickerProviderTest.php
+++ b/core-bundle/tests/Picker/FilePickerProviderTest.php
@@ -290,4 +290,22 @@ class FilePickerProviderTest extends ContaoTestCase
             $this->provider->convertDcaValue(new PickerConfig('link'), '/foobar')
         );
     }
+
+    public function testConvertsTheDcaValueWithCustomInsertTag(): void
+    {
+        $this->assertSame(
+            '/foobar',
+            $this->provider->convertDcaValue(new PickerConfig('file', ['insertTag' => '{{file_name::%s}}']), '/foobar')
+        );
+
+        $this->assertSame(
+            '{{file_name::82243f46-a4c3-11e3-8e29-000c29e44aea}}',
+            $this->provider->convertDcaValue(new PickerConfig('link', ['insertTag' => '{{file_name::%s}}']), '/foobar')
+        );
+
+        $this->assertSame(
+            '/foobar',
+            $this->provider->convertDcaValue(new PickerConfig('link', ['insertTag' => '{{file_name::%s}}']), '/foobar')
+        );
+    }
 }

--- a/core-bundle/tests/Picker/PagePickerProviderTest.php
+++ b/core-bundle/tests/Picker/PagePickerProviderTest.php
@@ -213,4 +213,10 @@ class PagePickerProviderTest extends ContaoTestCase
         $this->assertSame(5, $this->provider->convertDcaValue(new PickerConfig('page'), 5));
         $this->assertSame('{{link_url::5}}', $this->provider->convertDcaValue(new PickerConfig('link'), 5));
     }
+
+    public function testConvertsTheDcaValueWithCustomInsertTag(): void
+    {
+        $this->assertSame(5, $this->provider->convertDcaValue(new PickerConfig('page', ['insertTag' => '{{link_url::%s|absolute}}']), 5));
+        $this->assertSame('{{link_url::5|absolute}}', $this->provider->convertDcaValue(new PickerConfig('link', ['insertTag' => '{{link_url::%s|absolute}}']), 5));
+    }
 }

--- a/core-bundle/tests/Picker/PagePickerProviderTest.php
+++ b/core-bundle/tests/Picker/PagePickerProviderTest.php
@@ -216,7 +216,12 @@ class PagePickerProviderTest extends ContaoTestCase
 
     public function testConvertsTheDcaValueWithCustomInsertTag(): void
     {
+        // General insertTag extra
         $this->assertSame(5, $this->provider->convertDcaValue(new PickerConfig('page', ['insertTag' => '{{link_url::%s|absolute}}']), 5));
         $this->assertSame('{{link_url::5|absolute}}', $this->provider->convertDcaValue(new PickerConfig('link', ['insertTag' => '{{link_url::%s|absolute}}']), 5));
+
+        // Picker specific insertTag extra
+        $this->assertSame(5, $this->provider->convertDcaValue(new PickerConfig('page', ['pagePicker' => ['insertTag' => '{{specific_insert_tag::%s}}']]), 5));
+        $this->assertSame('{{specific_insert_tag::5}}', $this->provider->convertDcaValue(new PickerConfig('link', ['pagePicker' => ['insertTag' => '{{specific_insert_tag::%s}}']]), 5));
     }
 }

--- a/core-bundle/tests/Picker/PagePickerProviderTest.php
+++ b/core-bundle/tests/Picker/PagePickerProviderTest.php
@@ -214,14 +214,40 @@ class PagePickerProviderTest extends ContaoTestCase
         $this->assertSame('{{link_url::5}}', $this->provider->convertDcaValue(new PickerConfig('link'), 5));
     }
 
-    public function testConvertsTheDcaValueWithCustomInsertTag(): void
+    public function testConvertsTheDcaValueWithACustomInsertTag(): void
     {
         // General insertTag extra
-        $this->assertSame(5, $this->provider->convertDcaValue(new PickerConfig('page', ['insertTag' => '{{link_url::%s|absolute}}']), 5));
-        $this->assertSame('{{link_url::5|absolute}}', $this->provider->convertDcaValue(new PickerConfig('link', ['insertTag' => '{{link_url::%s|absolute}}']), 5));
+        $this->assertSame(
+            5,
+            $this->provider->convertDcaValue(
+                new PickerConfig('page', ['insertTag' => '{{link_url::%s|absolute}}']),
+                5
+            )
+        );
+
+        $this->assertSame(
+            '{{link_url::5|absolute}}',
+            $this->provider->convertDcaValue(
+                new PickerConfig('link', ['insertTag' => '{{link_url::%s|absolute}}']),
+                5
+            )
+        );
 
         // Picker specific insertTag extra
-        $this->assertSame(5, $this->provider->convertDcaValue(new PickerConfig('page', ['pagePicker' => ['insertTag' => '{{specific_insert_tag::%s}}']]), 5));
-        $this->assertSame('{{specific_insert_tag::5}}', $this->provider->convertDcaValue(new PickerConfig('link', ['pagePicker' => ['insertTag' => '{{specific_insert_tag::%s}}']]), 5));
+        $this->assertSame(
+            5,
+            $this->provider->convertDcaValue(
+                new PickerConfig('page', ['pagePicker' => ['insertTag' => '{{specific_insert_tag::%s}}']]),
+                5
+            )
+        );
+
+        $this->assertSame(
+            '{{specific_insert_tag::5}}',
+            $this->provider->convertDcaValue(
+                new PickerConfig('link', ['pagePicker' => ['insertTag' => '{{specific_insert_tag::%s}}']]),
+                5
+            )
+        );
     }
 }

--- a/core-bundle/tests/Picker/PickerConfigTest.php
+++ b/core-bundle/tests/Picker/PickerConfigTest.php
@@ -53,12 +53,10 @@ class PickerConfigTest extends TestCase
     public function testCanReadProviderExtras(): void
     {
         $this->config->setExtra('insertTag', '{{fallback}}');
-        $this->config->setExtra('foobarProvider', [
-            'insertTag' => '{{foobarProviderSpecific}}',
-        ]);
+        $this->config->setExtra('foobar', ['insertTag' => '{{foobarSpecific}}']);
 
         $this->assertSame('{{fallback}}', $this->config->getExtraForProvider('insertTag', 'notExistingProvider'));
-        $this->assertSame('{{foobarProviderSpecific}}', $this->config->getExtraForProvider('insertTag', 'foobarProvider'));
+        $this->assertSame('{{foobarSpecific}}', $this->config->getExtraForProvider('insertTag', 'foobar'));
     }
 
     public function testClonesTheCurrentObject(): void

--- a/core-bundle/tests/Picker/PickerConfigTest.php
+++ b/core-bundle/tests/Picker/PickerConfigTest.php
@@ -50,6 +50,17 @@ class PickerConfigTest extends TestCase
         $this->assertSame('bar', $this->config->getExtra('foo'));
     }
 
+    public function testCanReadProviderExtras(): void
+    {
+        $this->config->setExtra('insertTag', '{{fallback}}');
+        $this->config->setExtra('foobarProvider', [
+            'insertTag' => '{{foobarProviderSpecific}}',
+        ]);
+
+        $this->assertSame('{{fallback}}', $this->config->getExtraForProvider('insertTag', 'notExistingProvider'));
+        $this->assertSame('{{foobarProviderSpecific}}', $this->config->getExtraForProvider('insertTag', 'foobarProvider'));
+    }
+
     public function testClonesTheCurrentObject(): void
     {
         $clone = $this->config->cloneForCurrent('new-alias');

--- a/faq-bundle/src/Picker/FaqPickerProvider.php
+++ b/faq-bundle/src/Picker/FaqPickerProvider.php
@@ -24,8 +24,6 @@ class FaqPickerProvider extends AbstractPickerProvider implements DcaPickerProvi
 {
     use FrameworkAwareTrait;
 
-    protected const DEFAULT_INSERTTAG = '{{faq_url::%s}}';
-
     /**
      * {@inheritdoc}
      */
@@ -47,7 +45,7 @@ class FaqPickerProvider extends AbstractPickerProvider implements DcaPickerProvi
      */
     public function supportsValue(PickerConfig $config): bool
     {
-        return false !== strpos($config->getValue(), $this->getInsertTagChunks($config, self::DEFAULT_INSERTTAG)[0]);
+        return false !== strpos($config->getValue(), $this->getInsertTagChunks($config)[0]);
     }
 
     /**
@@ -71,7 +69,7 @@ class FaqPickerProvider extends AbstractPickerProvider implements DcaPickerProvi
 
         if ($this->supportsValue($config)) {
             $attributes['value'] = str_replace(
-                $this->getInsertTagChunks($config, self::DEFAULT_INSERTTAG),
+                $this->getInsertTagChunks($config),
                 '',
                 $config->getValue()
             );
@@ -85,7 +83,7 @@ class FaqPickerProvider extends AbstractPickerProvider implements DcaPickerProvi
      */
     public function convertDcaValue(PickerConfig $config, $value): string
     {
-        return sprintf($this->getInsertTag($config, self::DEFAULT_INSERTTAG), $value);
+        return sprintf($this->getInsertTag($config), $value);
     }
 
     /**
@@ -99,7 +97,7 @@ class FaqPickerProvider extends AbstractPickerProvider implements DcaPickerProvi
             return $params;
         }
 
-        $insertTagChunks = $this->getInsertTagChunks($config, self::DEFAULT_INSERTTAG);
+        $insertTagChunks = $this->getInsertTagChunks($config);
 
         if (false === strpos($config->getValue(), $insertTagChunks[0])) {
             return $params;
@@ -113,6 +111,14 @@ class FaqPickerProvider extends AbstractPickerProvider implements DcaPickerProvi
         }
 
         return $params;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getFallbackInsertTag(): string
+    {
+        return '{{faq_url::%s}}';
     }
 
     /**

--- a/faq-bundle/src/Picker/FaqPickerProvider.php
+++ b/faq-bundle/src/Picker/FaqPickerProvider.php
@@ -24,6 +24,8 @@ class FaqPickerProvider extends AbstractPickerProvider implements DcaPickerProvi
 {
     use FrameworkAwareTrait;
 
+    protected const INSERTTAG = '{{faq_url::%s}}';
+
     /**
      * {@inheritdoc}
      */
@@ -111,14 +113,6 @@ class FaqPickerProvider extends AbstractPickerProvider implements DcaPickerProvi
         }
 
         return $params;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function getFallbackInsertTag(): string
-    {
-        return '{{faq_url::%s}}';
     }
 
     /**

--- a/faq-bundle/src/Picker/FaqPickerProvider.php
+++ b/faq-bundle/src/Picker/FaqPickerProvider.php
@@ -70,7 +70,7 @@ class FaqPickerProvider extends AbstractPickerProvider implements DcaPickerProvi
         }
 
         if ($this->supportsValue($config)) {
-            $attributes['value'] = str_replace($this->getInsertTagChunks($config), '', $config->getValue());
+            $attributes['value'] = $this->getValue($config);
         }
 
         return $attributes;
@@ -91,17 +91,11 @@ class FaqPickerProvider extends AbstractPickerProvider implements DcaPickerProvi
     {
         $params = ['do' => 'faq'];
 
-        if (null === $config || !$config->getValue()) {
+        if (null === $config || !$config->getValue() || !$this->supportsValue($config)) {
             return $params;
         }
 
-        if (!$this->supportsValue($config)) {
-            return $params;
-        }
-
-        $value = str_replace($this->getInsertTagChunks($config), '', $config->getValue());
-
-        if (null !== ($faqId = $this->getFaqCategoryId($value))) {
+        if (null !== ($faqId = $this->getFaqCategoryId($this->getValue($config)))) {
             $params['table'] = 'tl_faq';
             $params['id'] = $faqId;
         }

--- a/faq-bundle/src/Picker/FaqPickerProvider.php
+++ b/faq-bundle/src/Picker/FaqPickerProvider.php
@@ -47,7 +47,7 @@ class FaqPickerProvider extends AbstractPickerProvider implements DcaPickerProvi
      */
     public function supportsValue(PickerConfig $config): bool
     {
-        return false !== strpos($config->getValue(), $this->getInsertTagChunks($config)[0]);
+        return $this->isMatchingTag($config);
     }
 
     /**

--- a/faq-bundle/src/Picker/FaqPickerProvider.php
+++ b/faq-bundle/src/Picker/FaqPickerProvider.php
@@ -14,13 +14,13 @@ namespace Contao\FaqBundle\Picker;
 
 use Contao\CoreBundle\Framework\FrameworkAwareInterface;
 use Contao\CoreBundle\Framework\FrameworkAwareTrait;
-use Contao\CoreBundle\Picker\AbstractPickerProvider;
+use Contao\CoreBundle\Picker\AbstractInsertTagPickerProvider;
 use Contao\CoreBundle\Picker\DcaPickerProviderInterface;
 use Contao\CoreBundle\Picker\PickerConfig;
 use Contao\FaqCategoryModel;
 use Contao\FaqModel;
 
-class FaqPickerProvider extends AbstractPickerProvider implements DcaPickerProviderInterface, FrameworkAwareInterface
+class FaqPickerProvider extends AbstractInsertTagPickerProvider implements DcaPickerProviderInterface, FrameworkAwareInterface
 {
     use FrameworkAwareTrait;
 

--- a/faq-bundle/src/Picker/FaqPickerProvider.php
+++ b/faq-bundle/src/Picker/FaqPickerProvider.php
@@ -70,11 +70,7 @@ class FaqPickerProvider extends AbstractPickerProvider implements DcaPickerProvi
         }
 
         if ($this->supportsValue($config)) {
-            $attributes['value'] = str_replace(
-                $this->getInsertTagChunks($config),
-                '',
-                $config->getValue()
-            );
+            $attributes['value'] = str_replace($this->getInsertTagChunks($config), '', $config->getValue());
         }
 
         return $attributes;
@@ -99,13 +95,11 @@ class FaqPickerProvider extends AbstractPickerProvider implements DcaPickerProvi
             return $params;
         }
 
-        $insertTagChunks = $this->getInsertTagChunks($config);
-
-        if (false === strpos($config->getValue(), $insertTagChunks[0])) {
+        if (!$this->supportsValue($config)) {
             return $params;
         }
 
-        $value = str_replace($insertTagChunks, '', $config->getValue());
+        $value = str_replace($this->getInsertTagChunks($config), '', $config->getValue());
 
         if (null !== ($faqId = $this->getFaqCategoryId($value))) {
             $params['table'] = 'tl_faq';

--- a/faq-bundle/src/Picker/FaqPickerProvider.php
+++ b/faq-bundle/src/Picker/FaqPickerProvider.php
@@ -47,7 +47,7 @@ class FaqPickerProvider extends AbstractPickerProvider implements DcaPickerProvi
      */
     public function supportsValue(PickerConfig $config): bool
     {
-        return $this->isMatchingTag($config);
+        return $this->isMatchingInsertTag($config);
     }
 
     /**
@@ -70,7 +70,7 @@ class FaqPickerProvider extends AbstractPickerProvider implements DcaPickerProvi
         }
 
         if ($this->supportsValue($config)) {
-            $attributes['value'] = $this->getValue($config);
+            $attributes['value'] = $this->getInsertTagValue($config);
         }
 
         return $attributes;
@@ -95,7 +95,7 @@ class FaqPickerProvider extends AbstractPickerProvider implements DcaPickerProvi
             return $params;
         }
 
-        if (null !== ($faqId = $this->getFaqCategoryId($this->getValue($config)))) {
+        if (null !== ($faqId = $this->getFaqCategoryId($this->getInsertTagValue($config)))) {
             $params['table'] = 'tl_faq';
             $params['id'] = $faqId;
         }

--- a/faq-bundle/src/Picker/FaqPickerProvider.php
+++ b/faq-bundle/src/Picker/FaqPickerProvider.php
@@ -47,9 +47,7 @@ class FaqPickerProvider extends AbstractPickerProvider implements DcaPickerProvi
      */
     public function supportsValue(PickerConfig $config): bool
     {
-        $insertTagChunks = explode('%s', $this->getInsertTag($config, self::DEFAULT_INSERTTAG), 2);
-
-        return false !== strpos($config->getValue(), $insertTagChunks[0]);
+        return false !== strpos($config->getValue(), $this->getInsertTagChunks($config, self::DEFAULT_INSERTTAG)[0]);
     }
 
     /**
@@ -72,10 +70,11 @@ class FaqPickerProvider extends AbstractPickerProvider implements DcaPickerProvi
         }
 
         if ($this->supportsValue($config)) {
-
-            $insertTagChunks = explode('%s', $this->getInsertTag($config, self::DEFAULT_INSERTTAG), 2);
-
-            $attributes['value'] = str_replace($insertTagChunks, '',  $config->getValue());
+            $attributes['value'] = str_replace(
+                $this->getInsertTagChunks($config, self::DEFAULT_INSERTTAG),
+                '',
+                $config->getValue()
+            );
         }
 
         return $attributes;
@@ -96,11 +95,11 @@ class FaqPickerProvider extends AbstractPickerProvider implements DcaPickerProvi
     {
         $params = ['do' => 'faq'];
 
-        if (null === $config ||!$config->getValue()) {
+        if (null === $config || !$config->getValue()) {
             return $params;
         }
 
-        $insertTagChunks = explode('%s', $this->getInsertTag($config, self::DEFAULT_INSERTTAG), 2);
+        $insertTagChunks = $this->getInsertTagChunks($config, self::DEFAULT_INSERTTAG);
 
         if (false === strpos($config->getValue(), $insertTagChunks[0])) {
             return $params;

--- a/faq-bundle/tests/Picker/FaqPickerProviderTest.php
+++ b/faq-bundle/tests/Picker/FaqPickerProviderTest.php
@@ -201,6 +201,11 @@ class FaqPickerProviderTest extends ContaoTestCase
         $this->assertSame('{{faq_url::5}}', $this->provider->convertDcaValue(new PickerConfig('link'), 5));
     }
 
+    public function testConvertsTheDcaValueWithCustomInsertTag(): void
+    {
+        $this->assertSame('{{faq_title::5}}', $this->provider->convertDcaValue(new PickerConfig('link', ['insertTag' => '{{faq_title::%s}}']), 5));
+    }
+
     public function testAddsTableAndIdIfThereIsAValue(): void
     {
         /** @var FaqCategoryModel|MockObject $model */

--- a/faq-bundle/tests/Picker/FaqPickerProviderTest.php
+++ b/faq-bundle/tests/Picker/FaqPickerProviderTest.php
@@ -201,9 +201,12 @@ class FaqPickerProviderTest extends ContaoTestCase
         $this->assertSame('{{faq_url::5}}', $this->provider->convertDcaValue(new PickerConfig('link'), 5));
     }
 
-    public function testConvertsTheDcaValueWithCustomInsertTag(): void
+    public function testConvertsTheDcaValueWithACustomInsertTag(): void
     {
-        $this->assertSame('{{faq_title::5}}', $this->provider->convertDcaValue(new PickerConfig('link', ['insertTag' => '{{faq_title::%s}}']), 5));
+        $this->assertSame(
+            '{{faq_title::5}}',
+            $this->provider->convertDcaValue(new PickerConfig('link', ['insertTag' => '{{faq_title::%s}}']), 5)
+        );
     }
 
     public function testAddsTableAndIdIfThereIsAValue(): void

--- a/news-bundle/src/Picker/NewsPickerProvider.php
+++ b/news-bundle/src/Picker/NewsPickerProvider.php
@@ -24,8 +24,6 @@ class NewsPickerProvider extends AbstractPickerProvider implements DcaPickerProv
 {
     use FrameworkAwareTrait;
 
-    protected const DEFAULT_INSERTTAG = '{{news_url::%s}}';
-
     /**
      * {@inheritdoc}
      */
@@ -47,7 +45,7 @@ class NewsPickerProvider extends AbstractPickerProvider implements DcaPickerProv
      */
     public function supportsValue(PickerConfig $config): bool
     {
-        return false !== strpos($config->getValue(), $this->getInsertTagChunks($config, self::DEFAULT_INSERTTAG)[0]);
+        return false !== strpos($config->getValue(), $this->getInsertTagChunks($config)[0]);
     }
 
     /**
@@ -71,7 +69,7 @@ class NewsPickerProvider extends AbstractPickerProvider implements DcaPickerProv
 
         if ($this->supportsValue($config)) {
             $attributes['value'] = str_replace(
-                $this->getInsertTagChunks($config, self::DEFAULT_INSERTTAG),
+                $this->getInsertTagChunks($config),
                 '',
                 $config->getValue()
             );
@@ -85,7 +83,7 @@ class NewsPickerProvider extends AbstractPickerProvider implements DcaPickerProv
      */
     public function convertDcaValue(PickerConfig $config, $value): string
     {
-        return sprintf($this->getInsertTag($config, self::DEFAULT_INSERTTAG), $value);
+        return sprintf($this->getInsertTag($config), $value);
     }
 
     /**
@@ -99,7 +97,7 @@ class NewsPickerProvider extends AbstractPickerProvider implements DcaPickerProv
             return $params;
         }
 
-        $insertTagChunks = $this->getInsertTagChunks($config, self::DEFAULT_INSERTTAG);
+        $insertTagChunks = $this->getInsertTagChunks($config);
 
         if (false === strpos($config->getValue(), $insertTagChunks[0])) {
             return $params;
@@ -113,6 +111,14 @@ class NewsPickerProvider extends AbstractPickerProvider implements DcaPickerProv
         }
 
         return $params;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getFallbackInsertTag(): string
+    {
+        return '{{news_url::%s}}';
     }
 
     /**

--- a/news-bundle/src/Picker/NewsPickerProvider.php
+++ b/news-bundle/src/Picker/NewsPickerProvider.php
@@ -70,7 +70,7 @@ class NewsPickerProvider extends AbstractPickerProvider implements DcaPickerProv
         }
 
         if ($this->supportsValue($config)) {
-            $attributes['value'] = str_replace($this->getInsertTagChunks($config), '', $config->getValue());
+            $attributes['value'] = $this->getValue($config);
         }
 
         return $attributes;
@@ -91,17 +91,11 @@ class NewsPickerProvider extends AbstractPickerProvider implements DcaPickerProv
     {
         $params = ['do' => 'news'];
 
-        if (null === $config || !$config->getValue()) {
+        if (null === $config || !$config->getValue() || !$this->supportsValue($config)) {
             return $params;
         }
 
-        if (!$this->supportsValue($config)) {
-            return $params;
-        }
-
-        $value = str_replace($this->getInsertTagChunks($config), '', $config->getValue());
-
-        if (null !== ($newsArchiveId = $this->getNewsArchiveId($value))) {
+        if (null !== ($newsArchiveId = $this->getNewsArchiveId($this->getValue($config)))) {
             $params['table'] = 'tl_news';
             $params['id'] = $newsArchiveId;
         }

--- a/news-bundle/src/Picker/NewsPickerProvider.php
+++ b/news-bundle/src/Picker/NewsPickerProvider.php
@@ -47,7 +47,7 @@ class NewsPickerProvider extends AbstractPickerProvider implements DcaPickerProv
      */
     public function supportsValue(PickerConfig $config): bool
     {
-        return $this->isMatchingTag($config);
+        return $this->isMatchingInsertTag($config);
     }
 
     /**
@@ -70,7 +70,7 @@ class NewsPickerProvider extends AbstractPickerProvider implements DcaPickerProv
         }
 
         if ($this->supportsValue($config)) {
-            $attributes['value'] = $this->getValue($config);
+            $attributes['value'] = $this->getInsertTagValue($config);
         }
 
         return $attributes;
@@ -95,7 +95,7 @@ class NewsPickerProvider extends AbstractPickerProvider implements DcaPickerProv
             return $params;
         }
 
-        if (null !== ($newsArchiveId = $this->getNewsArchiveId($this->getValue($config)))) {
+        if (null !== ($newsArchiveId = $this->getNewsArchiveId($this->getInsertTagValue($config)))) {
             $params['table'] = 'tl_news';
             $params['id'] = $newsArchiveId;
         }

--- a/news-bundle/src/Picker/NewsPickerProvider.php
+++ b/news-bundle/src/Picker/NewsPickerProvider.php
@@ -14,13 +14,13 @@ namespace Contao\NewsBundle\Picker;
 
 use Contao\CoreBundle\Framework\FrameworkAwareInterface;
 use Contao\CoreBundle\Framework\FrameworkAwareTrait;
-use Contao\CoreBundle\Picker\AbstractPickerProvider;
+use Contao\CoreBundle\Picker\AbstractInsertTagPickerProvider;
 use Contao\CoreBundle\Picker\DcaPickerProviderInterface;
 use Contao\CoreBundle\Picker\PickerConfig;
 use Contao\NewsArchiveModel;
 use Contao\NewsModel;
 
-class NewsPickerProvider extends AbstractPickerProvider implements DcaPickerProviderInterface, FrameworkAwareInterface
+class NewsPickerProvider extends AbstractInsertTagPickerProvider implements DcaPickerProviderInterface, FrameworkAwareInterface
 {
     use FrameworkAwareTrait;
 

--- a/news-bundle/src/Picker/NewsPickerProvider.php
+++ b/news-bundle/src/Picker/NewsPickerProvider.php
@@ -70,11 +70,7 @@ class NewsPickerProvider extends AbstractPickerProvider implements DcaPickerProv
         }
 
         if ($this->supportsValue($config)) {
-            $attributes['value'] = str_replace(
-                $this->getInsertTagChunks($config),
-                '',
-                $config->getValue()
-            );
+            $attributes['value'] = str_replace($this->getInsertTagChunks($config), '', $config->getValue());
         }
 
         return $attributes;
@@ -99,13 +95,11 @@ class NewsPickerProvider extends AbstractPickerProvider implements DcaPickerProv
             return $params;
         }
 
-        $insertTagChunks = $this->getInsertTagChunks($config);
-
-        if (false === strpos($config->getValue(), $insertTagChunks[0])) {
+        if (!$this->supportsValue($config)) {
             return $params;
         }
 
-        $value = str_replace($insertTagChunks, '', $config->getValue());
+        $value = str_replace($this->getInsertTagChunks($config), '', $config->getValue());
 
         if (null !== ($newsArchiveId = $this->getNewsArchiveId($value))) {
             $params['table'] = 'tl_news';

--- a/news-bundle/src/Picker/NewsPickerProvider.php
+++ b/news-bundle/src/Picker/NewsPickerProvider.php
@@ -47,9 +47,7 @@ class NewsPickerProvider extends AbstractPickerProvider implements DcaPickerProv
      */
     public function supportsValue(PickerConfig $config): bool
     {
-        $insertTagChunks = explode('%s', $this->getInsertTag($config, self::DEFAULT_INSERTTAG), 2);
-
-        return false !== strpos($config->getValue(), $insertTagChunks[0]);
+        return false !== strpos($config->getValue(), $this->getInsertTagChunks($config, self::DEFAULT_INSERTTAG)[0]);
     }
 
     /**
@@ -72,9 +70,11 @@ class NewsPickerProvider extends AbstractPickerProvider implements DcaPickerProv
         }
 
         if ($this->supportsValue($config)) {
-            $insertTagChunks = explode('%s', $this->getInsertTag($config, self::DEFAULT_INSERTTAG), 2);
-
-            $attributes['value'] = str_replace($insertTagChunks, '',  $config->getValue());
+            $attributes['value'] = str_replace(
+                $this->getInsertTagChunks($config, self::DEFAULT_INSERTTAG),
+                '',
+                $config->getValue()
+            );
         }
 
         return $attributes;
@@ -99,7 +99,7 @@ class NewsPickerProvider extends AbstractPickerProvider implements DcaPickerProv
             return $params;
         }
 
-        $insertTagChunks = explode('%s', $this->getInsertTag($config, self::DEFAULT_INSERTTAG), 2);
+        $insertTagChunks = $this->getInsertTagChunks($config, self::DEFAULT_INSERTTAG);
 
         if (false === strpos($config->getValue(), $insertTagChunks[0])) {
             return $params;

--- a/news-bundle/src/Picker/NewsPickerProvider.php
+++ b/news-bundle/src/Picker/NewsPickerProvider.php
@@ -47,7 +47,7 @@ class NewsPickerProvider extends AbstractPickerProvider implements DcaPickerProv
      */
     public function supportsValue(PickerConfig $config): bool
     {
-        return false !== strpos($config->getValue(), $this->getInsertTagChunks($config)[0]);
+        return $this->isMatchingTag($config);
     }
 
     /**

--- a/news-bundle/src/Picker/NewsPickerProvider.php
+++ b/news-bundle/src/Picker/NewsPickerProvider.php
@@ -24,6 +24,8 @@ class NewsPickerProvider extends AbstractPickerProvider implements DcaPickerProv
 {
     use FrameworkAwareTrait;
 
+    protected const INSERTTAG = '{{news_url::%s}}';
+
     /**
      * {@inheritdoc}
      */
@@ -111,14 +113,6 @@ class NewsPickerProvider extends AbstractPickerProvider implements DcaPickerProv
         }
 
         return $params;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function getFallbackInsertTag(): string
-    {
-        return '{{news_url::%s}}';
     }
 
     /**

--- a/news-bundle/tests/Picker/NewsPickerProviderTest.php
+++ b/news-bundle/tests/Picker/NewsPickerProviderTest.php
@@ -201,9 +201,12 @@ class NewsPickerProviderTest extends ContaoTestCase
         $this->assertSame('{{news_url::5}}', $this->provider->convertDcaValue(new PickerConfig('link'), 5));
     }
 
-    public function testConvertsTheDcaValueWithCustomInsertTag(): void
+    public function testConvertsTheDcaValueWithACustomInsertTag(): void
     {
-        $this->assertSame('{{news_title::5}}', $this->provider->convertDcaValue(new PickerConfig('link', ['insertTag' => '{{news_title::%s}}']), 5));
+        $this->assertSame(
+            '{{news_title::5}}',
+            $this->provider->convertDcaValue(new PickerConfig('link', ['insertTag' => '{{news_title::%s}}']), 5)
+        );
     }
 
     public function testAddsTableAndIdIfThereIsAValue(): void

--- a/news-bundle/tests/Picker/NewsPickerProviderTest.php
+++ b/news-bundle/tests/Picker/NewsPickerProviderTest.php
@@ -201,6 +201,11 @@ class NewsPickerProviderTest extends ContaoTestCase
         $this->assertSame('{{news_url::5}}', $this->provider->convertDcaValue(new PickerConfig('link'), 5));
     }
 
+    public function testConvertsTheDcaValueWithCustomInsertTag(): void
+    {
+        $this->assertSame('{{news_title::5}}', $this->provider->convertDcaValue(new PickerConfig('link', ['insertTag' => '{{news_title::%s}}']), 5));
+    }
+
     public function testAddsTableAndIdIfThereIsAValue(): void
     {
         /** @var NewsArchiveModel|MockObject $model */


### PR DESCRIPTION
I just had the problem that I wanted to use the page picker but not with the default `{{link_url::<value>}}` insert tag because I need absolute links, so I want the `|absolute` flag to always be added.
I noticed that the insert tag is unfortunately hard coded which I find a very limiting factor for a general picker provider.
So here we go, you can now specify whatever insert tag you like by specifying 

```php
'eval' => [
    'dcaPicker' => [
        'insertTag' => '{{my_super_insert_tag::%s}}',
    ],
],
```

which will take the insert tag for **all** picker providers (news, page etc.), though.
However, you can also do this:

```php
'eval' => [
    'dcaPicker' => [
        'pagePicker' => [
            'insertTag' => '{{link_url::%s}}',
        ],
        'newsPicker' => [
            'insertTag' => '{{news_url::%s}}',
        ],
    ],
],
```

I've implemented it for **all** the core pickers so it will also work for news, faq, events etc. not just for the page picker provider 😊 
Also there's a new `$config->getExtraForProvider()` so pickers can implement fetching provider specific extras falling back to general extras if they want to.