### PR TITLE
PageForward: Do not redirect if the jumpTo page is not published

### DIFF
--- a/core-bundle/src/Resources/contao/pages/PageForward.php
+++ b/core-bundle/src/Resources/contao/pages/PageForward.php
@@ -57,8 +57,7 @@ class PageForward extends \Frontend
 	{
 		if ($objPage->jumpTo)
 		{
-			/** @var PageModel $objNextPage */
-			$objNextPage = $objPage->getRelated('jumpTo');
+			$objNextPage = \PageModel::findPublishedById($objPage->jumpTo);
 		}
 		else
 		{


### PR DESCRIPTION
# Issue

* Create a page `foo` with a subpage `bar`.
* For `foo`, set page type "forward". Set `bar` as the `jumpTo` target.
* Unpublish `bar`.
* Call `example.test/foo.html`

Result: You are redirected to `example.test/bar.html` and then get a 404.
Expected behavior: No redirect happens, `ForwardPageNotFoundException()` is triggered. This is the intended behavior that happens for "first subpage" redirects.

Note: This issue creates much more notable mayhem when `folderUrl` is activated: If your top page is `foo` and your subpage `foo/bar`, a whole chain of redirects happens, resulting in `example.test/foo/bar/bar/bar/bar.html`.

# Context and Fix

In `Contao\PageForward::getForwardUrl()`, the `jumpTo` page is retrieved using `getRelated()`. This means that whether the page is published or not is not taken into account:
https://github.com/contao/contao/blob/3693a54b78f4342f0757a46a38d10d0b0f20bb2b/core-bundle/src/Resources/contao/pages/PageForward.php#L58-L62

Initially, `PageModel::findPublishedById()` was used, but that was changed here:
https://github.com/contao/contao/commit/de75fc162dfcb1ccefe96f5d39657850b53bf09b#diff-d8dbdb2a76bab80729993135a47246a8

From what I understand, it doesn't look like the switch from `PageModel::findPublishedById()` to `$objPage->getRelated()` was directly related to the language-related code of that commit. However, even if it was, that code was removed after `$strForceLang` in `Contao\Controller::generateFrontendUrl()` was deprecated[1]. So, whatever the case, it looks like we can safely go back to using `PageModel::findPublishedById()`.

---
[1] https://github.com/contao/contao/commit/a8bd6513bbdf936f297e53a163a9bb5017582534#diff-48ed239ef4b634e096714a387890666f