### PR TITLE
Use tablesort.js 4 (supports localStorage)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "contao-components/respimage": "^1.4",
         "contao-components/simplemodal": "^2.1",
         "contao-components/swipe": "^2.0.3",
-        "contao-components/tablesort": "^3.4.5",
+        "contao-components/tablesort": "^4.0",
         "contao-components/tablesorter": "^2.1",
         "contao-components/tinymce4": "^4.7",
         "contao/image": "^0.3.5",

--- a/core-bundle/composer.json
+++ b/core-bundle/composer.json
@@ -38,7 +38,7 @@
         "contao-components/respimage": "^1.4",
         "contao-components/simplemodal": "^2.1",
         "contao-components/swipe": "^2.0.3",
-        "contao-components/tablesort": "^3.4.5",
+        "contao-components/tablesort": "^4.0",
         "contao-components/tablesorter": "^2.1",
         "contao-components/tinymce4": "^4.7",
         "contao/image": "^0.3.5",

--- a/core-bundle/src/Resources/contao/elements/ContentTable.php
+++ b/core-bundle/src/Resources/contao/elements/ContentTable.php
@@ -37,6 +37,12 @@ class ContentTable extends ContentElement
 		$this->Template->useFooter = $this->tfoot ? true : false;
 		$this->Template->useLeftTh = $this->tleft ? true : false;
 		$this->Template->sortable = $this->sortable ? true : false;
+		$this->Template->sortDefault = false;
+
+		if ($this->sortable)
+		{
+			$this->Template->sortDefault = $this->sortIndex . '|' . ($this->sortOrder == 'descending' ? 'desc' : 'asc');
+		}
 
 		$arrHeader = array();
 		$arrBody = array();
@@ -47,19 +53,6 @@ class ContentTable extends ContentElement
 		{
 			foreach ($rows[0] as $i=>$v)
 			{
-				// Set table sort cookie
-				if ($this->sortable && $i == $this->sortIndex)
-				{
-					$co = 'TS_TABLE_' . $this->id;
-					$so = ($this->sortOrder == 'descending') ? 'desc' : 'asc';
-
-					if (Input::cookie($co) == '')
-					{
-						System::setCookie($co, $i . '|' . $so, 0);
-					}
-				}
-
-				// Add cell
 				$arrHeader[] = array
 				(
 					'class' => 'head_'.$i . (($i == 0) ? ' col_first' : '') . (($i == (\count($rows[0]) - 1)) ? ' col_last' : '') . (($i == 0 && $this->tleft) ? ' unsortable' : ''),

--- a/core-bundle/src/Resources/contao/elements/ContentTable.php
+++ b/core-bundle/src/Resources/contao/elements/ContentTable.php
@@ -37,7 +37,6 @@ class ContentTable extends ContentElement
 		$this->Template->useFooter = $this->tfoot ? true : false;
 		$this->Template->useLeftTh = $this->tleft ? true : false;
 		$this->Template->sortable = $this->sortable ? true : false;
-		$this->Template->sortDefault = false;
 
 		if ($this->sortable)
 		{

--- a/core-bundle/src/Resources/contao/templates/elements/ce_table.html5
+++ b/core-bundle/src/Resources/contao/templates/elements/ce_table.html5
@@ -2,9 +2,9 @@
 
 <?php $this->block('content'); ?>
 
-  <table id="<?= $this->id ?>"<?php if ($this->sortable): ?> class="sortable"<?php endif; ?>>
+  <table id="<?= $this->id ?>"<?php if ($this->sortable) echo ' class="sortable"' ?><?php if ($this->sortDefault) echo ' data-sort-default="' . $this->sortDefault . '"' ?>>
 
-    <?php if ($this->summary != ''): ?>
+    <?php if ($this->summary): ?>
       <caption><?= $this->summary ?></caption>
     <?php endif; ?>
 

--- a/core-bundle/src/Resources/contao/templates/elements/ce_table.html5
+++ b/core-bundle/src/Resources/contao/templates/elements/ce_table.html5
@@ -2,7 +2,7 @@
 
 <?php $this->block('content'); ?>
 
-  <table id="<?= $this->id ?>"<?php if ($this->sortable) echo ' class="sortable"' ?><?php if ($this->sortDefault) echo ' data-sort-default="' . $this->sortDefault . '"' ?>>
+  <table id="<?= $this->id ?>"<?php if ($this->sortable): ?> class="sortable" data-sort-default="<?= $this->sortDefault ?>"<?php endif; ?>>
 
     <?php if ($this->summary): ?>
       <caption><?= $this->summary ?></caption>


### PR DESCRIPTION
This PR updates [contao-components/tablesort](https://github.com/contao-components/tablesort) to version 4 (see #459). It now uses localStorage instead of cookies and reads the default sorting from the `data-sort-default` attribute.