### PR TITLE
Remove a page's search index entries when its alias is changed

### DIFF
--- a/core-bundle/src/Resources/contao/dca/tl_page.php
+++ b/core-bundle/src/Resources/contao/dca/tl_page.php
@@ -1154,6 +1154,11 @@ class tl_page extends Backend
 			}
 		}
 
+		if ($autoAlias === false && $varValue !== $dc->activeRecord->alias)
+		{
+			$this->purgeSearchIndex($dc);
+		}
+
 		return $varValue;
 	}
 

--- a/core-bundle/src/Resources/contao/dca/tl_page.php
+++ b/core-bundle/src/Resources/contao/dca/tl_page.php
@@ -1154,7 +1154,7 @@ class tl_page extends Backend
 			}
 		}
 
-		if (Input::post('VERSION_NUMBER') > 0 && $varValue !== $dc->activeRecord->alias)
+		if ($varValue != $dc->activeRecord->alias)
 		{
 			$this->purgeSearchIndex($dc);
 		}

--- a/core-bundle/src/Resources/contao/dca/tl_page.php
+++ b/core-bundle/src/Resources/contao/dca/tl_page.php
@@ -1154,7 +1154,7 @@ class tl_page extends Backend
 			}
 		}
 
-		if ($autoAlias === false && $varValue !== $dc->activeRecord->alias)
+		if (Input::post('VERSION_NUMBER') > 0 && $varValue !== $dc->activeRecord->alias)
 		{
 			$this->purgeSearchIndex($dc);
 		}


### PR DESCRIPTION
**How to reproduce the issue:**

* Create a page with the alias `foo`.

* Once you call `example.test/foo.html`, the page gets an entry in `tl_search`.

* Now change the alias to `bar`.

Currently, the entry with the now-outdated URL remains in `tl_search`, which means it shows up in the search results. It only gets removed once you call the outdated URL and get a 404, e. g. by visiting the outdated search result listing.

Also note that if you change only the alias, the page with the new URL does not get added once you visit it. If you change the alias and, e. g., the title, the new URL does get added, but the old one still remains.

**Suggested solution:**

A page's search index entries already get removed when the page is deleted[1]. We should do the same when the alias changes.

---
[1] https://github.com/contao/contao/commit/ba075d0d28c9c3f7de558b7b294fe1becf34e02d