### PR TITLE
Reload the page if a rememberme cookie was set

### DIFF
--- a/core-bundle/src/EventListener/RemembermeReloadListener.php
+++ b/core-bundle/src/EventListener/RemembermeReloadListener.php
@@ -1,5 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
 namespace Contao\CoreBundle\EventListener;
 
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -10,7 +20,7 @@ use Symfony\Component\Security\Http\RememberMe\RememberMeServicesInterface;
 
 class RemembermeReloadListener
 {
-    public function onKernelRequest(GetResponseEvent $event)
+    public function onKernelRequest(GetResponseEvent $event): void
     {
         $request = $event->getRequest();
 

--- a/core-bundle/src/EventListener/RemembermeReloadListener.php
+++ b/core-bundle/src/EventListener/RemembermeReloadListener.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Contao\CoreBundle\EventListener;
+
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\Security\Http\RememberMe\RememberMeServicesInterface;
+
+class RemembermeReloadListener
+{
+    public function onKernelRequest(GetResponseEvent $event)
+    {
+        $request = $event->getRequest();
+
+        if (
+            !$event->isMasterRequest()
+            || !$request->isMethod(Request::METHOD_GET)
+            || !$request->attributes->has(RememberMeServicesInterface::COOKIE_ATTR_NAME)
+        ) {
+            return;
+        }
+
+        $response = new RedirectResponse($request->getRequestUri(), Response::HTTP_FOUND);
+        $response->headers->setCookie($request->attributes->get(RememberMeServicesInterface::COOKIE_ATTR_NAME));
+
+        $event->setResponse($response);
+    }
+}

--- a/core-bundle/src/Resources/config/listener.yml
+++ b/core-bundle/src/Resources/config/listener.yml
@@ -133,6 +133,12 @@ services:
             # The priority must be lower than the one of the Symfony route listener (defaults to 32)
             - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: 20 }
 
+    contao.listener.rememberme_reload:
+        class: Contao\CoreBundle\EventListener\RemembermeReloadListener
+        tags:
+            # The priority must be lower than the one of the Symfony firewall listener (defaults to 8)
+            - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: 7 }
+
     contao.listener.request_token:
         class: Contao\CoreBundle\EventListener\RequestTokenListener
         arguments:


### PR DESCRIPTION
see https://github.com/contao/contao/issues/400

I'm not exactly sure if `kernel.response` listeners are called as well. If not, we might need to manually merge the session cookie.