### PR TITLE
Decode entities if the "decodeEntities" flag is not set

### DIFF
--- a/core-bundle/src/Resources/contao/classes/Versions.php
+++ b/core-bundle/src/Resources/contao/classes/Versions.php
@@ -541,6 +541,13 @@ class Versions extends \Controller
 							$from[$k] = \Date::parse(\Config::get('datimFormat'), $from[$k] ?: '');
 						}
 
+						// Decode entities if the "decodeEntities" flag is not set (see #360)
+						if (empty($GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['eval']['decodeEntities']))
+						{
+							$to[$k] = StringUtil::specialchars(StringUtil::decodeEntities($to[$k]));
+							$from[$k] = StringUtil::specialchars(StringUtil::decodeEntities($from[$k]));
+						}
+
 						// Convert strings into arrays
 						if (!\is_array($to[$k]))
 						{

--- a/core-bundle/src/Resources/contao/classes/Versions.php
+++ b/core-bundle/src/Resources/contao/classes/Versions.php
@@ -541,6 +541,13 @@ class Versions extends \Controller
 							$from[$k] = \Date::parse(\Config::get('datimFormat'), $from[$k] ?: '');
 						}
 
+						// Decode entities if the "decodeEntities" flag is not set (see #360)
+						if (empty($GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['eval']['decodeEntities']))
+						{
+							$to[$k] = StringUtil::decodeEntities($to[$k]);
+							$from[$k] = StringUtil::decodeEntities($from[$k]);
+						}
+
 						// Convert strings into arrays
 						if (!\is_array($to[$k]))
 						{
@@ -552,12 +559,7 @@ class Versions extends \Controller
 						}
 
 						$objDiff = new \Diff($from[$k], $to[$k]);
-
-						$strBuffer .= $objDiff->render(new DiffRenderer(array
-						(
-							'field' => ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['label'][0] ?: (isset($GLOBALS['TL_LANG']['MSC'][$k]) ? (\is_array($GLOBALS['TL_LANG']['MSC'][$k]) ? $GLOBALS['TL_LANG']['MSC'][$k][0] : $GLOBALS['TL_LANG']['MSC'][$k]) : $k)),
-							'decodeEntities' => empty($GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['eval']['decodeEntities'])
-						)));
+						$strBuffer .= $objDiff->render(new DiffRenderer(array('field'=>($GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['label'][0] ?: (isset($GLOBALS['TL_LANG']['MSC'][$k]) ? (\is_array($GLOBALS['TL_LANG']['MSC'][$k]) ? $GLOBALS['TL_LANG']['MSC'][$k][0] : $GLOBALS['TL_LANG']['MSC'][$k]) : $k)))));
 					}
 				}
 			}

--- a/core-bundle/src/Resources/contao/classes/Versions.php
+++ b/core-bundle/src/Resources/contao/classes/Versions.php
@@ -541,13 +541,6 @@ class Versions extends \Controller
 							$from[$k] = \Date::parse(\Config::get('datimFormat'), $from[$k] ?: '');
 						}
 
-						// Decode entities if the "decodeEntities" flag is not set (see #360)
-						if (empty($GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['eval']['decodeEntities']))
-						{
-							$to[$k] = StringUtil::specialchars(StringUtil::decodeEntities($to[$k]));
-							$from[$k] = StringUtil::specialchars(StringUtil::decodeEntities($from[$k]));
-						}
-
 						// Convert strings into arrays
 						if (!\is_array($to[$k]))
 						{
@@ -559,7 +552,12 @@ class Versions extends \Controller
 						}
 
 						$objDiff = new \Diff($from[$k], $to[$k]);
-						$strBuffer .= $objDiff->render(new DiffRenderer(array('field'=>($GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['label'][0] ?: (isset($GLOBALS['TL_LANG']['MSC'][$k]) ? (\is_array($GLOBALS['TL_LANG']['MSC'][$k]) ? $GLOBALS['TL_LANG']['MSC'][$k][0] : $GLOBALS['TL_LANG']['MSC'][$k]) : $k)))));
+
+						$strBuffer .= $objDiff->render(new DiffRenderer(array
+						(
+							'field' => ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['label'][0] ?: (isset($GLOBALS['TL_LANG']['MSC'][$k]) ? (\is_array($GLOBALS['TL_LANG']['MSC'][$k]) ? $GLOBALS['TL_LANG']['MSC'][$k][0] : $GLOBALS['TL_LANG']['MSC'][$k]) : $k)),
+							'decodeEntities' => empty($GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['eval']['decodeEntities'])
+						)));
 					}
 				}
 			}

--- a/core-bundle/src/Resources/contao/dca/tl_files.php
+++ b/core-bundle/src/Resources/contao/dca/tl_files.php
@@ -218,7 +218,7 @@ $GLOBALS['TL_DCA']['tl_files'] = array
 		(
 			'label'                   => &$GLOBALS['TL_LANG']['tl_files']['meta'],
 			'inputType'               => 'metaWizard',
-			'eval'                    => array('allowHtml'=>true, 'metaFields'=>array('title'=>'maxlength="255"', 'alt'=>'maxlength="255"', 'link'=>'maxlength="255"', 'caption'=>'maxlength="255"')),
+			'eval'                    => array('allowHtml'=>true, 'multiple'=>true, 'metaFields'=>array('title'=>'maxlength="255"', 'alt'=>'maxlength="255"', 'link'=>'maxlength="255"', 'caption'=>'maxlength="255"')),
 			'sql'                     => "blob NULL"
 		)
 	)

--- a/core-bundle/src/Resources/contao/library/Contao/DiffRenderer.php
+++ b/core-bundle/src/Resources/contao/library/Contao/DiffRenderer.php
@@ -56,7 +56,7 @@ class DiffRenderer extends \Diff_Renderer_Html_Array
 				{
 					foreach ($change['base']['lines'] as $line)
 					{
-						$html .= "\n  " . '<dt class="' . $change['tag'] . ' left">' . ($line ? $this->specialchars($line) : '&nbsp;') . '</dt>';
+						$html .= "\n  " . '<dt class="' . $change['tag'] . ' left">' . ($line ?: '&nbsp;') . '</dt>';
 					}
 
 				}
@@ -66,7 +66,7 @@ class DiffRenderer extends \Diff_Renderer_Html_Array
 				{
 					foreach ($change['changed']['lines'] as $line)
 					{
-						$html .= "\n " . '<dt class="' . $change['tag'] . ' right"><ins>' . ($line ? $this->specialchars($line) : '&nbsp;') . '</ins></dt>';
+						$html .= "\n " . '<dt class="' . $change['tag'] . ' right"><ins>' . ($line ?: '&nbsp;') . '</ins></dt>';
 					}
 				}
 
@@ -75,7 +75,7 @@ class DiffRenderer extends \Diff_Renderer_Html_Array
 				{
 					foreach ($change['base']['lines'] as $line)
 					{
-						$html .= "\n  " . '<dt class="' . $change['tag'] . ' left"><del>' . ($line ? $this->specialchars($line) : '&nbsp;') . '</del></dt>';
+						$html .= "\n  " . '<dt class="' . $change['tag'] . ' left"><del>' . ($line ?: '&nbsp;') . '</del></dt>';
 					}
 				}
 
@@ -84,12 +84,12 @@ class DiffRenderer extends \Diff_Renderer_Html_Array
 				{
 					foreach ($change['base']['lines'] as $line)
 					{
-						$html .= "\n  " . '<dt class="' . $change['tag'] . ' left"><span>' . ($line ? $this->specialchars($line) : '&nbsp;') . '</span></dt>';
+						$html .= "\n  " . '<dt class="' . $change['tag'] . ' left"><span>' . ($line ?: '&nbsp;') . '</span></dt>';
 					}
 
 					foreach ($change['changed']['lines'] as $line)
 					{
-						$html .= "\n  " . '<dd class="' . $change['tag'] . ' right"><span>' . ($line ? $this->specialchars($line) : '&nbsp;') . '</span></dd>';
+						$html .= "\n  " . '<dd class="' . $change['tag'] . ' right"><span>' . ($line ?: '&nbsp;') . '</span></dd>';
 					}
 				}
 			}
@@ -98,23 +98,5 @@ class DiffRenderer extends \Diff_Renderer_Html_Array
 		$html .= "\n</dl>\n</div>\n";
 
 		return $html;
-	}
-
-	/**
-	 * Converts special characters to HTML entities preserving <ins> and <del> tags
-	 *
-	 * @param string $line
-	 *
-	 * @return string
-	 */
-	private function specialchars($line)
-	{
-		if ($this->options['decodeEntities'])
-		{
-			$line = StringUtil::specialchars($line);
-			$line = str_replace(array('&lt;ins&gt;', '&lt;/ins&gt;', '&lt;del&gt;', '&lt;/del&gt;'), array('<ins>', '</ins>', '<del>', '</del>'), $line);
-		}
-
-		return $line;
 	}
 }

--- a/core-bundle/src/Resources/contao/library/Contao/DiffRenderer.php
+++ b/core-bundle/src/Resources/contao/library/Contao/DiffRenderer.php
@@ -56,7 +56,7 @@ class DiffRenderer extends \Diff_Renderer_Html_Array
 				{
 					foreach ($change['base']['lines'] as $line)
 					{
-						$html .= "\n  " . '<dt class="' . $change['tag'] . ' left">' . ($line ? $this->decodeEntities($line) : '&nbsp;') . '</dt>';
+						$html .= "\n  " . '<dt class="' . $change['tag'] . ' left">' . ($line ? $this->specialchars($line) : '&nbsp;') . '</dt>';
 					}
 
 				}
@@ -66,7 +66,7 @@ class DiffRenderer extends \Diff_Renderer_Html_Array
 				{
 					foreach ($change['changed']['lines'] as $line)
 					{
-						$html .= "\n " . '<dt class="' . $change['tag'] . ' right"><ins>' . ($line ? $this->decodeEntities($line) : '&nbsp;') . '</ins></dt>';
+						$html .= "\n " . '<dt class="' . $change['tag'] . ' right"><ins>' . ($line ? $this->specialchars($line) : '&nbsp;') . '</ins></dt>';
 					}
 				}
 
@@ -75,7 +75,7 @@ class DiffRenderer extends \Diff_Renderer_Html_Array
 				{
 					foreach ($change['base']['lines'] as $line)
 					{
-						$html .= "\n  " . '<dt class="' . $change['tag'] . ' left"><del>' . ($line ? $this->decodeEntities($line) : '&nbsp;') . '</del></dt>';
+						$html .= "\n  " . '<dt class="' . $change['tag'] . ' left"><del>' . ($line ? $this->specialchars($line) : '&nbsp;') . '</del></dt>';
 					}
 				}
 
@@ -84,12 +84,12 @@ class DiffRenderer extends \Diff_Renderer_Html_Array
 				{
 					foreach ($change['base']['lines'] as $line)
 					{
-						$html .= "\n  " . '<dt class="' . $change['tag'] . ' left"><span>' . ($line ? $this->decodeEntities($line) : '&nbsp;') . '</span></dt>';
+						$html .= "\n  " . '<dt class="' . $change['tag'] . ' left"><span>' . ($line ? $this->specialchars($line) : '&nbsp;') . '</span></dt>';
 					}
 
 					foreach ($change['changed']['lines'] as $line)
 					{
-						$html .= "\n  " . '<dd class="' . $change['tag'] . ' right"><span>' . ($line ? $this->decodeEntities($line) : '&nbsp;') . '</span></dd>';
+						$html .= "\n  " . '<dd class="' . $change['tag'] . ' right"><span>' . ($line ? $this->specialchars($line) : '&nbsp;') . '</span></dd>';
 					}
 				}
 			}
@@ -101,17 +101,17 @@ class DiffRenderer extends \Diff_Renderer_Html_Array
 	}
 
 	/**
-	 * Decodes entities and escapes specialchars (except <ins> and <del>)
+	 * Converts special characters to HTML entities preserving <ins> and <del> tags
 	 *
 	 * @param string $line
 	 *
 	 * @return string
 	 */
-	private function decodeEntities($line)
+	private function specialchars($line)
 	{
 		if ($this->options['decodeEntities'])
 		{
-			$line = StringUtil::specialchars(StringUtil::decodeEntities($line));
+			$line = StringUtil::specialchars($line);
 			$line = str_replace(array('&lt;ins&gt;', '&lt;/ins&gt;', '&lt;del&gt;', '&lt;/del&gt;'), array('<ins>', '</ins>', '<del>', '</del>'), $line);
 		}
 

--- a/core-bundle/src/Resources/contao/library/Contao/DiffRenderer.php
+++ b/core-bundle/src/Resources/contao/library/Contao/DiffRenderer.php
@@ -56,7 +56,7 @@ class DiffRenderer extends \Diff_Renderer_Html_Array
 				{
 					foreach ($change['base']['lines'] as $line)
 					{
-						$html .= "\n  " . '<dt class="' . $change['tag'] . ' left">' . ($line ?: '&nbsp;') . '</dt>';
+						$html .= "\n  " . '<dt class="' . $change['tag'] . ' left">' . ($line ? $this->decodeEntities($line) : '&nbsp;') . '</dt>';
 					}
 
 				}
@@ -66,7 +66,7 @@ class DiffRenderer extends \Diff_Renderer_Html_Array
 				{
 					foreach ($change['changed']['lines'] as $line)
 					{
-						$html .= "\n " . '<dt class="' . $change['tag'] . ' right"><ins>' . ($line ?: '&nbsp;') . '</ins></dt>';
+						$html .= "\n " . '<dt class="' . $change['tag'] . ' right"><ins>' . ($line ? $this->decodeEntities($line) : '&nbsp;') . '</ins></dt>';
 					}
 				}
 
@@ -75,7 +75,7 @@ class DiffRenderer extends \Diff_Renderer_Html_Array
 				{
 					foreach ($change['base']['lines'] as $line)
 					{
-						$html .= "\n  " . '<dt class="' . $change['tag'] . ' left"><del>' . ($line ?: '&nbsp;') . '</del></dt>';
+						$html .= "\n  " . '<dt class="' . $change['tag'] . ' left"><del>' . ($line ? $this->decodeEntities($line) : '&nbsp;') . '</del></dt>';
 					}
 				}
 
@@ -84,12 +84,12 @@ class DiffRenderer extends \Diff_Renderer_Html_Array
 				{
 					foreach ($change['base']['lines'] as $line)
 					{
-						$html .= "\n  " . '<dt class="' . $change['tag'] . ' left"><span>' . ($line ?: '&nbsp;') . '</span></dt>';
+						$html .= "\n  " . '<dt class="' . $change['tag'] . ' left"><span>' . ($line ? $this->decodeEntities($line) : '&nbsp;') . '</span></dt>';
 					}
 
 					foreach ($change['changed']['lines'] as $line)
 					{
-						$html .= "\n  " . '<dd class="' . $change['tag'] . ' right"><span>' . ($line ?: '&nbsp;') . '</span></dd>';
+						$html .= "\n  " . '<dd class="' . $change['tag'] . ' right"><span>' . ($line ? $this->decodeEntities($line) : '&nbsp;') . '</span></dd>';
 					}
 				}
 			}
@@ -98,5 +98,23 @@ class DiffRenderer extends \Diff_Renderer_Html_Array
 		$html .= "\n</dl>\n</div>\n";
 
 		return $html;
+	}
+
+	/**
+	 * Decodes entities and escapes specialchars (except <ins> and <del>)
+	 *
+	 * @param string $line
+	 *
+	 * @return string
+	 */
+	private function decodeEntities($line)
+	{
+		if ($this->options['decodeEntities'])
+		{
+			$line = StringUtil::specialchars(StringUtil::decodeEntities($line));
+			$line = str_replace(array('&lt;ins&gt;', '&lt;/ins&gt;', '&lt;del&gt;', '&lt;/del&gt;'), array('<ins>', '</ins>', '<del>', '</del>'), $line);
+		}
+
+		return $line;
 	}
 }


### PR DESCRIPTION
This PR fixes #360 by decoding entities in the diff view if the `decodeEntities` flag is not set.