### PR TITLE
Added command to debug/dump a DCA

### DIFF
--- a/core-bundle/src/Command/DebugDcaCommand.php
+++ b/core-bundle/src/Command/DebugDcaCommand.php
@@ -14,7 +14,6 @@ namespace Contao\CoreBundle\Command;
 
 use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\DcaLoader;
-use Doctrine\DBAL\Connection;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -32,15 +31,9 @@ class DebugDcaCommand extends Command
      */
     private $framework;
 
-    /**
-     * @var Connection
-     */
-    private $connection;
-
-    public function __construct(ContaoFramework $framework, Connection $connection)
+    public function __construct(ContaoFramework $framework)
     {
         $this->framework = $framework;
-        $this->connection = $connection;
 
         parent::__construct();
     }

--- a/core-bundle/src/Command/DebugDcaCommand.php
+++ b/core-bundle/src/Command/DebugDcaCommand.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Command;
+
+use Contao\CoreBundle\Framework\ContaoFramework;
+use Contao\DcaLoader;
+use Doctrine\DBAL\Connection;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\VarDumper\Cloner\VarCloner;
+use Symfony\Component\VarDumper\Dumper\CliDumper;
+
+/**
+ * Dumps debug information about a Contao DCA.
+ */
+class DebugDcaCommand extends Command
+{
+    /**
+     * @var ContaoFramework
+     */
+    private $framework;
+
+    /**
+     * @var Connection
+     */
+    private $connection;
+
+    public function __construct(ContaoFramework $framework, Connection $connection)
+    {
+        $this->framework = $framework;
+        $this->connection = $connection;
+
+        parent::__construct();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure(): void
+    {
+        $this
+            ->setName('debug:dca')
+            ->addArgument('table', InputArgument::REQUIRED, 'The DCA table name')
+            ->setDescription('Dumps the DCA configuration for a table.')
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $table = $input->getArgument('table');
+
+        $dcaLoader = $this->framework->createInstance(DcaLoader::class, [$table]);
+        $dcaLoader->load();
+
+        $cloner = new VarCloner();
+        $dumper = new CliDumper();
+
+        $dumper->dump($cloner->cloneVar($GLOBALS['TL_DCA'][$table]));
+
+        return 0;
+    }
+}

--- a/core-bundle/src/Command/DebugDcaCommand.php
+++ b/core-bundle/src/Command/DebugDcaCommand.php
@@ -45,7 +45,7 @@ class DebugDcaCommand extends Command
     {
         $this
             ->setName('debug:dca')
-            ->addArgument('table', InputArgument::REQUIRED, 'The DCA table name')
+            ->addArgument('table', InputArgument::REQUIRED, 'The table name')
             ->setDescription('Dumps the DCA configuration for a table.')
         ;
     }

--- a/core-bundle/src/Resources/config/commands.yml
+++ b/core-bundle/src/Resources/config/commands.yml
@@ -16,7 +16,6 @@ services:
         class: Contao\CoreBundle\Command\DebugDcaCommand
         arguments:
             - '@contao.framework'
-            - '@database_connection'
 
     contao.command.filesync:
         class: Contao\CoreBundle\Command\FilesyncCommand

--- a/core-bundle/src/Resources/config/commands.yml
+++ b/core-bundle/src/Resources/config/commands.yml
@@ -12,6 +12,12 @@ services:
         arguments:
             - '@contao.framework'
 
+    contao.command.debug_dca:
+        class: Contao\CoreBundle\Command\DebugDcaCommand
+        arguments:
+            - '@contao.framework'
+            - '@database_connection'
+
     contao.command.filesync:
         class: Contao\CoreBundle\Command\FilesyncCommand
 


### PR DESCRIPTION
A simple command that dumps a DCA configuration. I needed this because it also shows which callbacks are registered from a service definition.