### PR TITLE
Check all enabled modules for article

### DIFF
--- a/core-bundle/src/Resources/contao/pages/PageRegular.php
+++ b/core-bundle/src/Resources/contao/pages/PageRegular.php
@@ -123,7 +123,7 @@ class PageRegular extends \Frontend
 		// Get all modules in a single DB query
 		$objModules = \ModuleModel::findMultipleByIds($arrModuleIds);
 
-		if ($objModules !== null || $arrModules[0]['mod'] == 0) // see #4137
+		if ($objModules !== null || \in_array(0, $arrModuleIds)) // see #4137
 		{
 			$arrMapper = array();
 


### PR DESCRIPTION
This fixes #465 

**Cause:**
If all modules but article are disabled `$objModules` is null and `$objModules !== null` returns false. Since `$arrModules` still contains the disabled modules `$arrModules[0]['mod'] == 0` also returns false if article isn't the first module. Both checks fail and article is not rendered.

**Hafway solution**
By checking `$arrModuleIds` (which only contains ids of enabled modules) instead of `$arrModules` the problem is circumvented.
However simply checking `$arrModuleIds[0] == 0` suffers from a similar issue, if there is another enabled but deleted module positioned before article.
It was deleted, so `$objModules === null`, and it is in the first position, so `$arrModuleIds[0]` is whatever id the deleted module had. Again both checks fail and article is not rendered.

**Solution**
By using in_array any enabled module is checked if it is an article. The second check now returns true and the article is once again rendered.