### PR TITLE
Remove deprecated logout_on_user_change setting

### DIFF
--- a/core-bundle/README.md
+++ b/core-bundle/README.md
@@ -98,7 +98,6 @@ security:
             user_checker: contao.security.user_checker
             anonymous: ~
             switch_user: true
-            logout_on_user_change: true
 
             contao_login:
                 login_path: contao_backend_login
@@ -125,7 +124,6 @@ security:
             user_checker: contao.security.user_checker
             anonymous: ~
             switch_user: false
-            logout_on_user_change: true
 
             contao_login:
                 login_path: contao_frontend_login

--- a/core-bundle/tests/Functional/app/config/security.yml
+++ b/core-bundle/tests/Functional/app/config/security.yml
@@ -26,7 +26,6 @@ security:
             user_checker: contao.security.user_checker
             anonymous: ~
             switch_user: true
-            logout_on_user_change: true
 
             contao_login:
                 login_path: contao_backend_login
@@ -53,7 +52,6 @@ security:
             user_checker: contao.security.user_checker
             anonymous: ~
             switch_user: false
-            logout_on_user_change: true
 
             contao_login:
                 login_path: contao_frontend_login

--- a/manager-bundle/src/Resources/skeleton/app/security.yml
+++ b/manager-bundle/src/Resources/skeleton/app/security.yml
@@ -26,7 +26,6 @@ security:
             user_checker: contao.security.user_checker
             anonymous: ~
             switch_user: true
-            logout_on_user_change: true
 
             contao_login:
                 login_path: contao_backend_login
@@ -53,7 +52,6 @@ security:
             user_checker: contao.security.user_checker
             anonymous: ~
             switch_user: false
-            logout_on_user_change: true
 
             contao_login:
                 login_path: contao_frontend_login


### PR DESCRIPTION
Since we implement the `EquatableInterface` on our `User`:
https://symfony.com/doc/current/reference/configuration/security.html#logout-on-user-change