### PR TITLE
Use the current firewall token if it matches the context

### DIFF
--- a/core-bundle/src/Resources/config/services.yml
+++ b/core-bundle/src/Resources/config/services.yml
@@ -510,6 +510,9 @@ services:
     contao.security.token_checker:
         class: Contao\CoreBundle\Security\Authentication\Token\TokenChecker
         arguments:
+            - '@request_stack'
+            - '@security.firewall.map'
+            - '@security.token_storage'
             - '@session'
             - '@security.authentication.trust_resolver'
         public: true

--- a/core-bundle/src/Security/Authentication/Token/TokenChecker.php
+++ b/core-bundle/src/Security/Authentication/Token/TokenChecker.php
@@ -162,6 +162,12 @@ class TokenChecker
             return null;
         }
 
-        return unserialize($this->session->get($sessionKey), ['allowed_classes' => true]);
+        $token = unserialize($this->session->get($sessionKey), ['allowed_classes' => true]);
+
+        if (!$token instanceof TokenInterface) {
+            return null;
+        }
+
+        return $token;
     }
 }

--- a/core-bundle/src/Security/Authentication/Token/TokenChecker.php
+++ b/core-bundle/src/Security/Authentication/Token/TokenChecker.php
@@ -25,6 +25,9 @@ use Symfony\Component\Security\Http\FirewallMapInterface;
 
 class TokenChecker
 {
+    private const FRONTEND_FIREWALL = 'contao_frontend';
+    private const BACKEND_FIREWALL = 'contao_backend';
+
     /**
      * @var RequestStack
      */
@@ -64,7 +67,7 @@ class TokenChecker
      */
     public function hasFrontendUser(): bool
     {
-        $token = $this->getToken(FrontendUser::SECURITY_SESSION_KEY);
+        $token = $this->getToken(self::FRONTEND_FIREWALL);
 
         return null !== $token && $token->getUser() instanceof FrontendUser;
     }
@@ -74,7 +77,7 @@ class TokenChecker
      */
     public function hasBackendUser(): bool
     {
-        $token = $this->getToken(BackendUser::SECURITY_SESSION_KEY);
+        $token = $this->getToken(self::BACKEND_FIREWALL);
 
         return null !== $token && $token->getUser() instanceof BackendUser;
     }
@@ -84,7 +87,7 @@ class TokenChecker
      */
     public function getFrontendUsername(): ?string
     {
-        $token = $this->getToken(FrontendUser::SECURITY_SESSION_KEY);
+        $token = $this->getToken(self::FRONTEND_FIREWALL);
 
         if (null === $token || !$token->getUser() instanceof FrontendUser) {
             return null;
@@ -98,7 +101,7 @@ class TokenChecker
      */
     public function getBackendUsername(): ?string
     {
-        $token = $this->getToken(BackendUser::SECURITY_SESSION_KEY);
+        $token = $this->getToken(self::BACKEND_FIREWALL);
 
         if (null === $token || !$token->getUser() instanceof BackendUser) {
             return null;
@@ -112,17 +115,17 @@ class TokenChecker
      */
     public function isPreviewMode(): bool
     {
-        $token = $this->getToken(FrontendUser::SECURITY_SESSION_KEY);
+        $token = $this->getToken(self::FRONTEND_FIREWALL);
 
         return $token instanceof FrontendPreviewToken && $token->showUnpublished();
     }
 
-    private function getToken(string $sessionKey): ?TokenInterface
+    private function getToken(string $context): ?TokenInterface
     {
-        $token = $this->getTokenFromStorage(substr($sessionKey, 10));
+        $token = $this->getTokenFromStorage($context);
 
         if (null === $token) {
-            $token = $this->getTokenFromSession($sessionKey);
+            $token = $this->getTokenFromSession('_security_'.$context);
         }
 
         if (!$token instanceof TokenInterface || !$token->isAuthenticated()) {

--- a/core-bundle/src/Security/Authentication/Token/TokenChecker.php
+++ b/core-bundle/src/Security/Authentication/Token/TokenChecker.php
@@ -156,7 +156,7 @@ class TokenChecker
         return $this->tokenStorage->getToken();
     }
 
-    private function getTokenFromSession(string $sessionKey)
+    private function getTokenFromSession(string $sessionKey): ?TokenInterface
     {
         if (!$this->session->isStarted() || !$this->session->has($sessionKey)) {
             return null;

--- a/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
+++ b/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
@@ -1622,8 +1622,11 @@ class ContaoCoreExtensionTest extends TestCase
 
         $this->assertSame(TokenChecker::class, $definition->getClass());
         $this->assertTrue($definition->isPublic());
-        $this->assertSame('session', (string) $definition->getArgument(0));
-        $this->assertSame('security.authentication.trust_resolver', (string) $definition->getArgument(1));
+        $this->assertSame('request_stack', (string) $definition->getArgument(0));
+        $this->assertSame('security.firewall.map', (string) $definition->getArgument(1));
+        $this->assertSame('security.token_storage', (string) $definition->getArgument(2));
+        $this->assertSame('session', (string) $definition->getArgument(3));
+        $this->assertSame('security.authentication.trust_resolver', (string) $definition->getArgument(4));
     }
 
     public function testRegistersTheSecurityTwoFactorAuthenticator(): void

--- a/core-bundle/tests/Security/Authentication/Token/TokenCheckerTest.php
+++ b/core-bundle/tests/Security/Authentication/Token/TokenCheckerTest.php
@@ -71,7 +71,11 @@ class TokenCheckerTest extends TestCase
             $this->trustResolver
         );
 
-        $this->assertTrue(FrontendUser::class === $class ? $tokenChecker->hasFrontendUser() : $tokenChecker->hasBackendUser());
+        if (FrontendUser::class === $class) {
+            $this->assertTrue($tokenChecker->hasFrontendUser());
+        } else {
+            $this->assertTrue($tokenChecker->hasBackendUser());
+        }
     }
 
     public function getUserInTokenStorageData(): \Generator
@@ -96,7 +100,11 @@ class TokenCheckerTest extends TestCase
             $this->trustResolver
         );
 
-        $this->assertTrue(FrontendUser::class === $class ? $tokenChecker->hasFrontendUser() : $tokenChecker->hasBackendUser());
+        if (FrontendUser::class === $class) {
+            $this->assertTrue($tokenChecker->hasFrontendUser());
+        } else {
+            $this->assertTrue($tokenChecker->hasBackendUser());
+        }
     }
 
     public function getUserInSessionData(): \Generator
@@ -284,14 +292,13 @@ class TokenCheckerTest extends TestCase
     }
 
     /**
-     * @return RequestStack|MockObject
+     * @return RequestStack&MockObject
      */
     private function mockRequestStack(): RequestStack
     {
         $requestStack = $this->createMock(RequestStack::class);
 
         $requestStack
-            ->expects($this->any())
             ->method('getMasterRequest')
             ->willReturn($this->createMock(Request::class))
         ;
@@ -300,7 +307,7 @@ class TokenCheckerTest extends TestCase
     }
 
     /**
-     * @return FirewallMap|MockObject
+     * @return FirewallMap&MockObject
      */
     private function mockFirewallMapWithConfigContext(string $context): FirewallMap
     {
@@ -308,7 +315,6 @@ class TokenCheckerTest extends TestCase
 
         $map = $this->createMock(FirewallMap::class);
         $map
-            ->expects($this->any())
             ->method('getFirewallConfig')
             ->willReturn($config)
         ;
@@ -316,10 +322,12 @@ class TokenCheckerTest extends TestCase
         return $map;
     }
 
-    private function mockSessionWithToken(TokenInterface $token)
+    /**
+     * @return SessionInterface&MockObject
+     */
+    private function mockSessionWithToken(TokenInterface $token): SessionInterface
     {
         $session = $this->createMock(SessionInterface::class);
-
         $session
             ->expects($this->once())
             ->method('isStarted')

--- a/core-bundle/tests/Security/Authentication/Token/TokenCheckerTest.php
+++ b/core-bundle/tests/Security/Authentication/Token/TokenCheckerTest.php
@@ -27,6 +27,7 @@ use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolver;
 use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
 use Symfony\Component\Security\Core\Authentication\Token\RememberMeToken;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
@@ -47,16 +48,25 @@ class TokenCheckerTest extends TestCase
      */
     public function testChecksForUserInTokenStorageIfFirewallContextDoesMatch(string $class, string $firewallContext): void
     {
+        $user = $this->mockUser($class);
+        $token = new UsernamePasswordToken($user, 'password', 'provider', ['ROLE_USER']);
+
         $session = $this->createMock(SessionInterface::class);
         $session
             ->expects($this->never())
             ->method('isStarted')
         ;
 
+        $tokenStorage = $this->createMock(TokenStorageInterface::class);
+        $tokenStorage
+            ->method('getToken')
+            ->willReturn($token)
+        ;
+
         $tokenChecker = new TokenChecker(
             $this->mockRequestStack(),
             $this->mockFirewallMapWithConfigContext($firewallContext),
-            $this->mockTokenStorage($class),
+            $tokenStorage,
             $session,
             $this->trustResolver
         );

--- a/core-bundle/tests/Security/Authentication/Token/TokenCheckerTest.php
+++ b/core-bundle/tests/Security/Authentication/Token/TokenCheckerTest.php
@@ -25,7 +25,6 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolver;
-use Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolverInterface;
 use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
 use Symfony\Component\Security\Core\Authentication\Token\RememberMeToken;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
@@ -38,7 +37,7 @@ class TokenCheckerTest extends TestCase
      */
     private $trustResolver;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->trustResolver = new AuthenticationTrustResolver(AnonymousToken::class, RememberMeToken::class);
     }
@@ -46,7 +45,7 @@ class TokenCheckerTest extends TestCase
     /**
      * @dataProvider getUserInTokenStorageData
      */
-    public function testChecksForUserInTokenStorageIfFirewallContextDoesMatch(string $class, string $firewallContext)
+    public function testChecksForUserInTokenStorageIfFirewallContextDoesMatch(string $class, string $firewallContext): void
     {
         $session = $this->createMock(SessionInterface::class);
         $session
@@ -74,7 +73,7 @@ class TokenCheckerTest extends TestCase
     /**
      * @dataProvider getUserInSessionData
      */
-    public function testChecksForUserInSessionIfFirewallContextDoesNotMatch(string $class, string $firewallContext)
+    public function testChecksForUserInSessionIfFirewallContextDoesNotMatch(string $class, string $firewallContext): void
     {
         $user = $this->mockUser($class);
         $token = new UsernamePasswordToken($user, 'password', 'provider', ['ROLE_USER']);


### PR DESCRIPTION
If the user is logged in in the current request (e.g. through *rememberme*), the session key does not exist, but the user exists in the firewall. We must always use/respect the current firewall if it matches the requested scope.