### PR TITLE
Store the rememberme series and value as binary strings

### DIFF
--- a/core-bundle/src/Entity/RememberMe.php
+++ b/core-bundle/src/Entity/RememberMe.php
@@ -43,14 +43,14 @@ class RememberMe
     /**
      * @var string
      *
-     * @ORM\Column(type="binary_string", length=32, options={"fixed"=true})
+     * @ORM\Column(type="binary_string", length=32, nullable=false, options={"fixed"=true})
      */
     protected $series;
 
     /**
      * @var string
      *
-     * @ORM\Column(type="binary_string", length=64, options={"fixed"=true})
+     * @ORM\Column(type="binary_string", length=64, nullable=false, options={"fixed"=true})
      */
     protected $value;
 

--- a/core-bundle/src/Entity/RememberMe.php
+++ b/core-bundle/src/Entity/RememberMe.php
@@ -43,14 +43,14 @@ class RememberMe
     /**
      * @var string
      *
-     * @ORM\Column(type="string", length=64, nullable=false, options={"fixed"=true})
+     * @ORM\Column(type="binary_string", length=32, options={"fixed"=true})
      */
     protected $series;
 
     /**
      * @var string
      *
-     * @ORM\Column(type="string", length=88, nullable=false, options={"fixed"=true})
+     * @ORM\Column(type="binary_string", length=64, options={"fixed"=true})
      */
     protected $value;
 
@@ -82,11 +82,11 @@ class RememberMe
      */
     protected $username;
 
-    public function __construct(UserInterface $user, string $encodedSeries)
+    public function __construct(UserInterface $user, string $series)
     {
         $this->class = \get_class($user);
-        $this->series = $encodedSeries;
-        $this->value = base64_encode(random_bytes(64));
+        $this->series = $series;
+        $this->value = random_bytes(64);
         $this->username = $user->getUsername();
         $this->lastUsed = new \DateTime();
         $this->expires = null;
@@ -141,7 +141,7 @@ class RememberMe
     public function cloneWithNewValue(): self
     {
         $clone = clone $this;
-        $clone->value = base64_encode(random_bytes(64));
+        $clone->value = random_bytes(64);
 
         return $clone;
     }

--- a/core-bundle/src/Repository/RememberMeRepository.php
+++ b/core-bundle/src/Repository/RememberMeRepository.php
@@ -48,7 +48,7 @@ class RememberMeRepository extends ServiceEntityRepository
     /**
      * @return RememberMe[]
      */
-    public function findBySeries(string $encodedSeries): array
+    public function findBySeries(string $series): array
     {
         $qb = $this->createQueryBuilder('rm');
         $qb
@@ -59,7 +59,7 @@ class RememberMeRepository extends ServiceEntityRepository
                     $qb->expr()->lte('rm.expires', ':now')
                 )
             )
-            ->setParameter('series', $encodedSeries)
+            ->setParameter('series', $series)
             ->setParameter('now', new \DateTime())
             ->orderBy('rm.expires', 'ASC')
         ;
@@ -72,8 +72,8 @@ class RememberMeRepository extends ServiceEntityRepository
         $qb = $this->_em->createQueryBuilder();
         $qb
             ->delete($this->_entityName, 'rm')
-            ->where('rm.series=:series')
-            ->andWhere('rm.value!=:value')
+            ->where('rm.series = :series')
+            ->andWhere('rm.value != :value')
             ->setParameter('series', $entity->getSeries())
             ->setParameter('value', $entity->getValue())
         ;
@@ -81,13 +81,13 @@ class RememberMeRepository extends ServiceEntityRepository
         $qb->getQuery()->execute();
     }
 
-    public function deleteBySeries(string $encodedSeries): void
+    public function deleteBySeries(string $series): void
     {
         $qb = $this->_em->createQueryBuilder();
         $qb
             ->delete($this->_entityName, 'rm')
-            ->where('rm.series=:series')
-            ->setParameter('series', $encodedSeries)
+            ->where('rm.series = :series')
+            ->setParameter('series', $series)
         ;
 
         $qb->getQuery()->execute();
@@ -98,8 +98,8 @@ class RememberMeRepository extends ServiceEntityRepository
         $qb = $this->_em->createQueryBuilder();
         $qb
             ->delete($this->_entityName, 'rm')
-            ->where('rm.lastUsed<:lastUsed')
-            ->orWhere('rm.expires<:expires')
+            ->where('rm.lastUsed < :lastUsed')
+            ->orWhere('rm.expires < :expires')
             ->setParameter('lastUsed', (new \DateTime())->sub(new \DateInterval('PT'.$lastUsedLifetime.'S')))
             ->setParameter('expires', (new \DateTime())->sub(new \DateInterval('PT'.$expiresLifetime.'S')))
         ;

--- a/core-bundle/src/Security/Authentication/RememberMe/ExpiringTokenBasedRememberMeServices.php
+++ b/core-bundle/src/Security/Authentication/RememberMe/ExpiringTokenBasedRememberMeServices.php
@@ -182,6 +182,6 @@ class ExpiringTokenBasedRememberMeServices extends AbstractRememberMeServices
 
     private function encodeSeries(string $series): string
     {
-        return hash_hmac('sha256', $series, $this->secret);
+        return hash_hmac('sha256', $series, $this->secret, true);
     }
 }

--- a/core-bundle/src/Security/Authentication/RememberMe/ExpiringTokenBasedRememberMeServices.php
+++ b/core-bundle/src/Security/Authentication/RememberMe/ExpiringTokenBasedRememberMeServices.php
@@ -119,12 +119,22 @@ class ExpiringTokenBasedRememberMeServices extends AbstractRememberMeServices
             return;
         }
 
-        $series = base64_encode(random_bytes(64));
+        $series = random_bytes(64);
 
         $entity = new RememberMe($user, $this->encodeSeries($series));
         $this->repository->persist($entity);
 
         $response->headers->setCookie($this->createRememberMeCookie($request, $series, $entity->getValue()));
+    }
+
+    protected function decodeCookie($rawCookie): array
+    {
+        return array_map('base64_decode', explode('-', $rawCookie));
+    }
+
+    protected function encodeCookie(array $cookieParts): string
+    {
+        return implode('-', array_map('base64_encode', $cookieParts));
     }
 
     private function migrateToken(RememberMe $token): RememberMe

--- a/core-bundle/tests/Security/Authentication/RememberMe/ExpiringTokenBasedRememberMeServicesTest.php
+++ b/core-bundle/tests/Security/Authentication/RememberMe/ExpiringTokenBasedRememberMeServicesTest.php
@@ -295,7 +295,7 @@ class ExpiringTokenBasedRememberMeServicesTest extends TestCase
         $this->repository
             ->expects($this->once())
             ->method('findBySeries')
-            ->with(hash_hmac('sha256', 'foo', self::SECRET))
+            ->with(hash_hmac('sha256', 'foo', self::SECRET, true))
             ->willReturn($entities)
         ;
 
@@ -311,7 +311,7 @@ class ExpiringTokenBasedRememberMeServicesTest extends TestCase
         $this->repository
             ->expects($this->once())
             ->method('deleteBySeries')
-            ->with(hash_hmac('sha256', $series, self::SECRET))
+            ->with(hash_hmac('sha256', $series, self::SECRET, true))
         ;
     }
 

--- a/core-bundle/tests/Security/Authentication/RememberMe/ExpiringTokenBasedRememberMeServicesTest.php
+++ b/core-bundle/tests/Security/Authentication/RememberMe/ExpiringTokenBasedRememberMeServicesTest.php
@@ -245,7 +245,7 @@ class ExpiringTokenBasedRememberMeServicesTest extends TestCase
     private function mockRequestWithCookie(string $series, string $value): Request
     {
         $request = new Request();
-        $value = base64_encode(implode(AbstractRememberMeServices::COOKIE_DELIMITER, [$series, $value]));
+        $value = implode('-', array_map('base64_encode', [$series, $value]));
 
         $request->cookies->set('REMEMBERME', $value);
 
@@ -347,7 +347,7 @@ class ExpiringTokenBasedRememberMeServicesTest extends TestCase
 
     private function assertRememberMeCookie(Cookie $cookie, ?string $series, string $value): void
     {
-        $parts = explode(AbstractRememberMeServices::COOKIE_DELIMITER, base64_decode($cookie->getValue(), true));
+        $parts = array_map('base64_decode', explode('-', $cookie->getValue()));
 
         $this->assertSame($value, $parts[1]);
 


### PR DESCRIPTION
As explained by @ausi, we should store the rememberme series and value as binary strings.

> Ein `hash_hmac('sha256')` sollte als `BINARY(32)` in der DB gespeichert werden und ein `random_bytes(64)` als `BINARY(64)` (ohne Base64 codierung).
> 
> `CHAR(88)` braucht zum einen 11x so viel platz wie `BINARY(32)` und zum anderen sollten wir Base64 werte nicht mit einer case-insensitive collation nutzen da Base64 case sensitive ist (würde also den hash schwächen bzw. die Kollisionswahrscheinlichkeit erhöhen).
> 
> Ein `BINARY(32)` als primary key sehe ich nicht als problematisch.

This PR makes the necessary changes.