### PR TITLE
Handle exceptions in the initialize.php

### DIFF
--- a/core-bundle/src/Controller/InitializeController.php
+++ b/core-bundle/src/Controller/InitializeController.php
@@ -13,7 +13,6 @@ namespace Contao\CoreBundle\Controller;
 use Contao\CoreBundle\Response\InitializeControllerResponse;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
 use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 use Symfony\Component\HttpKernel\HttpKernel;
@@ -80,14 +79,10 @@ class InitializeController extends Controller
     }
 
     /**
-     * Handles an exception by trying to convert it to a Response.
+     * Handles an exception by trying to convert it to a Response object.
      *
-     * @param \Exception $e       An \Exception instance
-     * @param Request    $request A Request instance
-     * @param int        $type    The type of the request (one of HttpKernelInterface::MASTER_REQUEST or HttpKernelInterface::SUB_REQUEST)
+     * @param int $type HttpKernelInterface::MASTER_REQUEST or HttpKernelInterface::SUB_REQUEST
      *
-     * @return Response
-     * @throws \Exception
      * @see HttpKernel::handleException()
      */
     private function handleException(\Exception $e, Request $request, $type)
@@ -95,7 +90,7 @@ class InitializeController extends Controller
         $event = new GetResponseForExceptionEvent($this->get('http_kernel'), $request, $type, $e);
         $this->get('event_dispatcher')->dispatch(KernelEvents::EXCEPTION, $event);
 
-        // a listener might have replaced the exception
+        // A listener might have replaced the exception
         $e = $event->getException();
 
         if (!$event->hasResponse()) {
@@ -104,11 +99,16 @@ class InitializeController extends Controller
 
         $response = $event->getResponse();
 
-        // the developer asked for a specific status code
-        if (!$event->isAllowingCustomResponseCode() && !$response->isClientError() && !$response->isServerError() && !$response->isRedirect()) {
-            // ensure that we actually have an error response
+        // The developer asked for a specific status code
+        if (
+            !$event->isAllowingCustomResponseCode()
+            && !$response->isClientError()
+            && !$response->isServerError()
+            && !$response->isRedirect()
+        ) {
+            // Ensure that we actually have an error response
             if ($e instanceof HttpExceptionInterface) {
-                // keep the HTTP status code and headers
+                // Keep the HTTP status code and headers
                 $response->setStatusCode($e->getStatusCode());
                 $response->headers->add($e->getHeaders());
             } else {

--- a/core-bundle/src/Controller/InitializeController.php
+++ b/core-bundle/src/Controller/InitializeController.php
@@ -13,6 +13,12 @@ namespace Contao\CoreBundle\Controller;
 use Contao\CoreBundle\Response\InitializeControllerResponse;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
+use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
+use Symfony\Component\HttpKernel\HttpKernel;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
@@ -48,6 +54,11 @@ class InitializeController extends Controller
 
         $realRequest->attributes->replace($masterRequest->attributes->all());
 
+        // Empty the request stack to make our real request the master
+        do {
+            $pop = $this->get('request_stack')->pop();
+        } while ($pop);
+
         // Initialize the framework with the real request
         $this->get('request_stack')->push($realRequest);
         $this->get('contao.framework')->initialize();
@@ -56,6 +67,57 @@ class InitializeController extends Controller
         // it will pop the current request, resulting in the real request being active.
         $this->get('request_stack')->push($masterRequest);
 
+        set_exception_handler(function ($e) use ($realRequest) {
+            // Do not catch PHP7 Throwables
+            if (!$e instanceof \Exception) {
+                throw $e;
+            }
+
+            $this->handleException($e, $realRequest, HttpKernelInterface::MASTER_REQUEST);
+        });
+
         return new InitializeControllerResponse('', 204);
+    }
+
+    /**
+     * Handles an exception by trying to convert it to a Response.
+     *
+     * @param \Exception $e       An \Exception instance
+     * @param Request    $request A Request instance
+     * @param int        $type    The type of the request (one of HttpKernelInterface::MASTER_REQUEST or HttpKernelInterface::SUB_REQUEST)
+     *
+     * @return Response
+     * @throws \Exception
+     * @see HttpKernel::handleException()
+     */
+    private function handleException(\Exception $e, Request $request, $type)
+    {
+        $event = new GetResponseForExceptionEvent($this->get('http_kernel'), $request, $type, $e);
+        $this->get('event_dispatcher')->dispatch(KernelEvents::EXCEPTION, $event);
+
+        // a listener might have replaced the exception
+        $e = $event->getException();
+
+        if (!$event->hasResponse()) {
+            throw $e;
+        }
+
+        $response = $event->getResponse();
+
+        // the developer asked for a specific status code
+        if (!$event->isAllowingCustomResponseCode() && !$response->isClientError() && !$response->isServerError() && !$response->isRedirect()) {
+            // ensure that we actually have an error response
+            if ($e instanceof HttpExceptionInterface) {
+                // keep the HTTP status code and headers
+                $response->setStatusCode($e->getStatusCode());
+                $response->headers->add($e->getHeaders());
+            } else {
+                $response->setStatusCode(500);
+            }
+        }
+
+        $response->send();
+        $this->get('kernel')->terminate($request, $response);
+        exit;
     }
 }


### PR DESCRIPTION
On custom entry points (using `initialize.php`), `ResponseException`s are not caught and not converted to a response. This attempts to fix this (and also automatically adds debug output etc. if `kernel.debug` is enabled.

see https://github.com/isotope/core/issues/1993

Be aware that some code needs to be updated when merging this into master!