### PR TITLE
[POC] Annotations for fragments

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,7 @@
         "contao/image": "^0.3.5",
         "contao/imagine-svg": "^0.1.2 || ^0.2",
         "contao/manager-plugin": "^2.6.2",
+        "doctrine/annotations": "^1.6",
         "doctrine/dbal": "^2.6",
         "doctrine/doctrine-bundle": "^1.8",
         "doctrine/doctrine-cache-bundle": "^1.3.1",

--- a/core-bundle/composer.json
+++ b/core-bundle/composer.json
@@ -39,6 +39,7 @@
         "contao-components/tinymce4": "^4.7",
         "contao/image": "^0.3.5",
         "contao/imagine-svg": "^0.1.2 || ^0.2",
+        "doctrine/annotations": "^1.6",
         "doctrine/dbal": "^2.6",
         "doctrine/doctrine-bundle": "^1.8",
         "doctrine/doctrine-cache-bundle": "^1.3.1",

--- a/core-bundle/src/DependencyInjection/Compiler/RegisterFragmentsPass.php
+++ b/core-bundle/src/DependencyInjection/Compiler/RegisterFragmentsPass.php
@@ -163,7 +163,7 @@ class RegisterFragmentsPass implements CompilerPassInterface
 
         // Remove all the arrays from tag attribute as they are not supported
         $definition->addTag($tag, array_filter($attributes, function ($v) {
-            return !is_array($v);
+            return is_scalar($v);
         }));
 
         $this->addPreHandlers($container, $preHandlers);

--- a/core-bundle/src/DependencyInjection/Compiler/RegisterFragmentsPass.php
+++ b/core-bundle/src/DependencyInjection/Compiler/RegisterFragmentsPass.php
@@ -101,9 +101,9 @@ class RegisterFragmentsPass implements CompilerPassInterface
                 $attributes = [
                     'category' => $annotation->category,
                     'method' => '__invoke', // TODO
-                    //'options' => $annotation->options, // TODO
-                    'renderer' => $annotation->renderer,
+                    'options' => $annotation->options,
                     'template' => $annotation->template,
+                    'renderer' => $annotation->renderer,
                     'type' => $annotation->type,
                 ];
 
@@ -160,7 +160,11 @@ class RegisterFragmentsPass implements CompilerPassInterface
         }
 
         $registry->addMethodCall('add', [$identifier, $config]);
-        $definition->addTag($tag, $attributes);
+
+        // Remove all the arrays from tag attribute as they are not supported
+        $definition->addTag($tag, array_filter($attributes, function ($v) {
+            return !is_array($v);
+        }));
 
         $this->addPreHandlers($container, $preHandlers);
     }

--- a/core-bundle/src/DependencyInjection/Compiler/RegisterFragmentsPass.php
+++ b/core-bundle/src/DependencyInjection/Compiler/RegisterFragmentsPass.php
@@ -143,9 +143,11 @@ class RegisterFragmentsPass implements CompilerPassInterface
         foreach ($this->findAndSortTaggedServices($tag, $container) as $priority => $reference) {
             $definition = $container->findDefinition($reference);
 
-            foreach ($definition->getTag($tag) as $attributes) {
-                // Clear the tag before registering a fragment
-                $definition = $definition->clearTag($tag);
+            // Get the tag and then clear it
+            $definitionTag = $definition->getTag($tag);
+            $definition->clearTag($tag);
+
+            foreach ($definitionTag as $attributes) {
                 $this->registerFragment($container, $reference, $tag, $attributes);
             }
         }

--- a/core-bundle/src/DependencyInjection/Compiler/RegisterFragmentsPass.php
+++ b/core-bundle/src/DependencyInjection/Compiler/RegisterFragmentsPass.php
@@ -20,7 +20,6 @@ use Contao\CoreBundle\Fragment\FragmentPreHandlerInterface;
 use Contao\CoreBundle\Fragment\Reference\ContentElementReference;
 use Contao\CoreBundle\Fragment\Reference\FrontendModuleReference;
 use Doctrine\Common\Annotations\AnnotationReader;
-use Doctrine\Common\Annotations\AnnotationRegistry;
 use Doctrine\Common\Annotations\DocParser;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Config\Resource\DirectoryResource;
@@ -74,75 +73,69 @@ class RegisterFragmentsPass implements CompilerPassInterface
 
             /** @var SplFileInfo $file */
             foreach ($finder as $file) {
-                $class = $namespace . '\\' . $file->getFilenameWithoutExtension();
+                $class = $namespace . '\\' . \pathinfo($file->getFilename(), PATHINFO_FILENAME);
 
                 if (!class_exists($class)) {
                     continue;
                 }
 
                 $reflection = new \ReflectionClass($class);
-                $annotation = $annotationReader->getClassAnnotation($reflection, ContentElement::class);
 
-                // The annotation might be a front end module
-                if ($annotation === null) {
-                    /** @var ContentElement|FrontendModule $annotation */
-                    $annotation = $annotationReader->getClassAnnotation($reflection, FrontendModule::class);
-
-                    if ($annotation === null) {
+                foreach ($annotationReader->getClassAnnotations($reflection) as $annotation) {
+                    if (!$annotation instanceof ContentElement || !$annotation instanceof FrontendModule) {
                         continue;
                     }
+
+                    var_dump($class, $annotation);
+                    $serviceId = $annotation->service ?: $class;
+
+                    if ($container->hasDefinition($serviceId)) {
+                        $definition = $container->getDefinition($serviceId);
+                    } else {
+                        $definition = new Definition($class);
+                        $container->setDefinition($serviceId, $definition);
+                    }
+
+                    $definition->setPublic(true);
+
+                    $attributes = [
+                        'category' => $annotation->category,
+                        'method' => '__invoke', // TODO
+                        //'options' => $annotation->options, // TODO
+                        'renderer' => $annotation->renderer,
+                        'template' => $annotation->template,
+                        'type' => $annotation->type,
+                    ];
+
+                    $attributes['type'] = $this->getFragmentType($definition, $attributes);
+
+                    $tag = ($annotation instanceof ContentElement) ? ContentElementReference::TAG_NAME : FrontendModuleReference::TAG_NAME;
+
+                    $identifier = sprintf('%s.%s', $tag, $attributes['type']);
+                    $reference = new Reference($serviceId);
+                    $config = $this->getFragmentConfig($container, $reference, $attributes);
+
+                    if (is_a($definition->getClass(), FragmentPreHandlerInterface::class, true)) {
+                        $preHandlers[$identifier] = $reference;
+                    }
+
+                    if (is_a($definition->getClass(), FragmentOptionsAwareInterface::class, true)) {
+                        $definition->addMethodCall('setFragmentOptions', [$attributes]);
+                    }
+
+                    $registry->addMethodCall('add', [$identifier, $config]);
                 }
-
-                $serviceId = $annotation->service ?: $class;
-
-                if ($container->hasDefinition($serviceId)) {
-                    $definition = $container->getDefinition($serviceId);
-                } else {
-                    $definition = new Definition($class);
-                    $container->setDefinition($serviceId, $definition);
-                }
-
-                $definition->setPublic(true);
-
-                $attributes = [
-                    'category' => $annotation->category,
-                    'method' => '__invoke', // TODO
-                    //'options' => $annotation->options, // TODO
-                    'renderer' => $annotation->renderer,
-                    'template' => $annotation->template,
-                    'type' => $annotation->type,
-                ];
-
-                $attributes['type'] = $this->getFragmentType($definition, $attributes);
-
-                $tag = ($annotation instanceof ContentElement) ? ContentElementReference::TAG_NAME : FrontendModuleReference::TAG_NAME;
-
-                $identifier = sprintf('%s.%s', $tag, $attributes['type']);
-                $reference = new Reference($serviceId);
-                $config = $this->getFragmentConfig($container, $reference, $attributes);
-
-                if (is_a($definition->getClass(), FragmentPreHandlerInterface::class, true)) {
-                    $preHandlers[$identifier] = $reference;
-                }
-
-                if (is_a($definition->getClass(), FragmentOptionsAwareInterface::class, true)) {
-                    $definition->addMethodCall('setFragmentOptions', [$attributes]);
-                }
-
-                $registry->addMethodCall('add', [$identifier, $config]);
             }
         }
 
         $this->addPreHandlers($container, $preHandlers);
-
-        exit;
     }
 
     private function getAnnotatedControllersDirs(ContainerBuilder $container)
     {
         $dirs = [];
 
-        foreach ($container->get('kernel.bundles') as $name => $class) {
+        foreach ($container->getParameter('kernel.bundles') as $name => $class) {
             $bundle = new \ReflectionClass($class);
             $dirs[\dirname($bundle->getFileName())] = $bundle->getNamespaceName() . '\\Controller';
         }

--- a/core-bundle/src/DependencyInjection/Compiler/RegisterFragmentsPass.php
+++ b/core-bundle/src/DependencyInjection/Compiler/RegisterFragmentsPass.php
@@ -12,15 +12,13 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\DependencyInjection\Compiler;
 
-use Contao\CoreBundle\Fragment\Annotations\ContentElement;
-use Contao\CoreBundle\Fragment\Annotations\FrontendModule;
+use Contao\CoreBundle\Fragment\Annotation\ContentElement;
+use Contao\CoreBundle\Fragment\Annotation\FrontendModule;
 use Contao\CoreBundle\Fragment\FragmentConfig;
 use Contao\CoreBundle\Fragment\FragmentOptionsAwareInterface;
 use Contao\CoreBundle\Fragment\FragmentPreHandlerInterface;
 use Contao\CoreBundle\Fragment\Reference\ContentElementReference;
 use Contao\CoreBundle\Fragment\Reference\FrontendModuleReference;
-use Doctrine\Common\Annotations\AnnotationReader;
-use Doctrine\Common\Annotations\DocParser;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Config\Resource\DirectoryResource;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
@@ -64,7 +62,7 @@ class RegisterFragmentsPass implements CompilerPassInterface
 
         $preHandlers = [];
         $registry = $container->findDefinition('contao.fragment.registry');
-        $annotationReader = new AnnotationReader(new DocParser());
+        $annotationReader = $container->get('annotations.cached_reader');
 
         foreach ($dirs as $dir => $namespace) {
             $container->addResource(new DirectoryResource($dir, '/\.php$/'));
@@ -86,7 +84,6 @@ class RegisterFragmentsPass implements CompilerPassInterface
                         continue;
                     }
 
-                    var_dump($class, $annotation);
                     $serviceId = $annotation->service ?: $class;
 
                     if ($container->hasDefinition($serviceId)) {

--- a/core-bundle/src/DependencyInjection/Compiler/RegisterFragmentsPass.php
+++ b/core-bundle/src/DependencyInjection/Compiler/RegisterFragmentsPass.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\DependencyInjection\Compiler;
 
-use Contao\CoreBundle\Fragment\Annotation\Base;
+use Contao\CoreBundle\Fragment\Annotation\AbstractFragmentAnnotation;
 use Contao\CoreBundle\Fragment\Annotation\ContentElement;
 use Contao\CoreBundle\Fragment\Annotation\FrontendModule;
 use Contao\CoreBundle\Fragment\FragmentConfig;
@@ -90,14 +90,14 @@ class RegisterFragmentsPass implements CompilerPassInterface
                 $reflection = new \ReflectionClass($class);
 
                 // Class annotations
-                /** @var $annotation Base */
+                /** @var $annotation AbstractFragmentAnnotation */
                 if (($annotation = $annotationReader->getClassAnnotation($reflection, $annotationName)) !== null) {
                     $this->registerAnnotationFragment($container, $annotation, $tag, $class);
                 }
 
                 // Method annotations
                 foreach ($reflection->getMethods() as $method) {
-                    /** @var $annotation Base */
+                    /** @var $annotation AbstractFragmentAnnotation */
                     if (($annotation = $annotationReader->getMethodAnnotation($method, $annotationName)) !== null) {
                         $this->registerAnnotationFragment($container, $annotation, $tag, $class, $method->getName());
                     }
@@ -106,7 +106,7 @@ class RegisterFragmentsPass implements CompilerPassInterface
         }
     }
 
-    private function registerAnnotationFragment(ContainerBuilder $container, Base $annotation, string $tag, string $class, string $method = null): void
+    private function registerAnnotationFragment(ContainerBuilder $container, AbstractFragmentAnnotation $annotation, string $tag, string $class, string $method = null): void
     {
         $serviceId = $annotation->service ?: $class;
 

--- a/core-bundle/src/DependencyInjection/Compiler/RegisterFragmentsPass.php
+++ b/core-bundle/src/DependencyInjection/Compiler/RegisterFragmentsPass.php
@@ -163,7 +163,7 @@ class RegisterFragmentsPass implements CompilerPassInterface
 
         // Remove all the arrays from tag attribute as they are not supported
         $definition->addTag($tag, array_filter($attributes, function ($v) {
-            return !is_scalar($v);
+            return !is_array($v);
         }));
 
         $this->addPreHandlers($container, $preHandlers);

--- a/core-bundle/src/DependencyInjection/Compiler/RegisterFragmentsPass.php
+++ b/core-bundle/src/DependencyInjection/Compiler/RegisterFragmentsPass.php
@@ -163,7 +163,7 @@ class RegisterFragmentsPass implements CompilerPassInterface
 
         // Remove all the arrays from tag attribute as they are not supported
         $definition->addTag($tag, array_filter($attributes, function ($v) {
-            return !is_array($v);
+            return !is_scalar($v);
         }));
 
         $this->addPreHandlers($container, $preHandlers);

--- a/core-bundle/src/DependencyInjection/Compiler/RegisterFragmentsPass.php
+++ b/core-bundle/src/DependencyInjection/Compiler/RegisterFragmentsPass.php
@@ -92,7 +92,7 @@ class RegisterFragmentsPass implements CompilerPassInterface
                 // Class annotations
                 /** @var $annotation Base */
                 if (($annotation = $annotationReader->getClassAnnotation($reflection, $annotationName)) !== null) {
-                    $this->registerAnnotationFragment($container, $annotation, $tag, $class, '__invoke');
+                    $this->registerAnnotationFragment($container, $annotation, $tag, $class);
                 }
 
                 // Method annotations
@@ -106,7 +106,7 @@ class RegisterFragmentsPass implements CompilerPassInterface
         }
     }
 
-    private function registerAnnotationFragment(ContainerBuilder $container, Base $annotation, string $tag, string $class, string $method): void
+    private function registerAnnotationFragment(ContainerBuilder $container, Base $annotation, string $tag, string $class, string $method = null): void
     {
         $serviceId = $annotation->service ?: $class;
 

--- a/core-bundle/src/Fragment/Annotation/AbstractFragmentAnnotation.php
+++ b/core-bundle/src/Fragment/Annotation/AbstractFragmentAnnotation.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Fragment\Annotation;
 
-abstract class Base
+abstract class AbstractFragmentAnnotation
 {
     /**
      * @var string

--- a/core-bundle/src/Fragment/Annotation/Base.php
+++ b/core-bundle/src/Fragment/Annotation/Base.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Fragment\Annotation;
+
+abstract class Base
+{
+    /**
+     * @var string
+     */
+    public $category;
+
+    /**
+     * @var array
+     */
+    public $options = [];
+
+    /**
+     * @var string
+     */
+    public $renderer;
+
+    /**
+     * @var string
+     */
+    public $service;
+
+    /**
+     * @var string
+     */
+    public $template;
+
+    /**
+     * @var string
+     */
+    public $type;
+
+    /**
+     * Annotation constructor.
+     *
+     * @param array $values
+     */
+    public function __construct(array $values)
+    {
+        $this->category = $values['category'];
+        $this->options = (array) $values['options'];
+        $this->service = $values['service'];
+        $this->renderer = $values['renderer'];
+        $this->template = $values['template'];
+        $this->type = $values['type'];
+    }
+}

--- a/core-bundle/src/Fragment/Annotation/Base.php
+++ b/core-bundle/src/Fragment/Annotation/Base.php
@@ -25,22 +25,22 @@ abstract class Base
     public $options = [];
 
     /**
-     * @var string
+     * @var string|null
      */
     public $renderer;
 
     /**
-     * @var string
+     * @var string|null
      */
     public $service;
 
     /**
-     * @var string
+     * @var string|null
      */
     public $template;
 
     /**
-     * @var string
+     * @var string|null
      */
     public $type;
 
@@ -52,10 +52,10 @@ abstract class Base
     public function __construct(array $values)
     {
         $this->category = $values['category'];
-        $this->options = (array) $values['options'];
-        $this->service = $values['service'];
-        $this->renderer = $values['renderer'];
-        $this->template = $values['template'];
-        $this->type = $values['type'];
+        $this->options = $values['options'] ?? [];
+        $this->service = $values['service'] ?? null;
+        $this->renderer = $values['renderer'] ?? null;
+        $this->template = $values['template'] ?? null;
+        $this->type = $values['type'] ?? null;
     }
 }

--- a/core-bundle/src/Fragment/Annotation/ContentElement.php
+++ b/core-bundle/src/Fragment/Annotation/ContentElement.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
  * @license LGPL-3.0-or-later
  */
 
-namespace Contao\CoreBundle\Fragment\Annotations;
+namespace Contao\CoreBundle\Fragment\Annotation;
 
 use Doctrine\Common\Annotations\Annotation\Attribute;
 use Doctrine\Common\Annotations\Annotation\Attributes;
@@ -20,7 +20,7 @@ use Doctrine\Common\Annotations\Annotation\Target;
  * Annotation that can be used to define controller as a content element.
  *
  * @Annotation
- * @Target("CLASS", "METHOD")
+ * @Target({"CLASS", "METHOD"})
  * @Attributes({
  *     @Attribute("category", required = true, type = "string"),
  *     @Attribute("options", type = "array"),
@@ -30,50 +30,6 @@ use Doctrine\Common\Annotations\Annotation\Target;
  *     @Attribute("type", type = "string"),
  * })
  */
-final class ContentElement
+final class ContentElement extends Base
 {
-    /**
-     * @var string
-     */
-    public $category;
-
-    /**
-     * @var array
-     */
-    public $options = [];
-
-    /**
-     * @var string
-     */
-    public $renderer;
-
-    /**
-     * @var string
-     */
-    public $service;
-
-    /**
-     * @var string
-     */
-    public $template;
-
-    /**
-     * @var string
-     */
-    public $type;
-
-    /**
-     * Annotation constructor.
-     *
-     * @param array $values
-     */
-    public function __construct(array $values)
-    {
-        $this->category = $values['category'];
-        $this->options = (array) $values['options'];
-        $this->service = $values['service'];
-        $this->renderer = $values['renderer'];
-        $this->template = $values['template'];
-        $this->type = $values['type'];
-    }
 }

--- a/core-bundle/src/Fragment/Annotation/ContentElement.php
+++ b/core-bundle/src/Fragment/Annotation/ContentElement.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Fragment\Annotations;
+
+use Doctrine\Common\Annotations\Annotation\Attribute;
+use Doctrine\Common\Annotations\Annotation\Attributes;
+use Doctrine\Common\Annotations\Annotation\Target;
+
+/**
+ * Annotation that can be used to define controller as a content element.
+ *
+ * @Annotation
+ * @Target("CLASS", "METHOD")
+ * @Attributes({
+ *     @Attribute("category", required = true, type = "string"),
+ *     @Attribute("options", type = "array"),
+ *     @Attribute("renderer", type = "string"),
+ *     @Attribute("service", type = "string"),
+ *     @Attribute("template", type = "string"),
+ *     @Attribute("type", type = "string"),
+ * })
+ */
+final class ContentElement
+{
+    /**
+     * @var string
+     */
+    public $category;
+
+    /**
+     * @var array
+     */
+    public $options = [];
+
+    /**
+     * @var string
+     */
+    public $renderer;
+
+    /**
+     * @var string
+     */
+    public $service;
+
+    /**
+     * @var string
+     */
+    public $template;
+
+    /**
+     * @var string
+     */
+    public $type;
+
+    /**
+     * Annotation constructor.
+     *
+     * @param array $values
+     */
+    public function __construct(array $values)
+    {
+        $this->category = $values['category'];
+        $this->options = (array) $values['options'];
+        $this->service = $values['service'];
+        $this->renderer = $values['renderer'];
+        $this->template = $values['template'];
+        $this->type = $values['type'];
+    }
+}

--- a/core-bundle/src/Fragment/Annotation/ContentElement.php
+++ b/core-bundle/src/Fragment/Annotation/ContentElement.php
@@ -30,6 +30,6 @@ use Doctrine\Common\Annotations\Annotation\Target;
  *     @Attribute("type", type = "string"),
  * })
  */
-final class ContentElement extends Base
+final class ContentElement extends AbstractFragmentAnnotation
 {
 }

--- a/core-bundle/src/Fragment/Annotation/FrontendModule.php
+++ b/core-bundle/src/Fragment/Annotation/FrontendModule.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Fragment\Annotations;
+
+use Doctrine\Common\Annotations\Annotation\Attribute;
+use Doctrine\Common\Annotations\Annotation\Attributes;
+use Doctrine\Common\Annotations\Annotation\Target;
+
+/**
+ * Annotation that can be used to define controller as a frontend module.
+ *
+ * @Annotation
+ * @Target("CLASS", "METHOD")
+ * @Attributes({
+ *     @Attribute("category", required = true, type = "string"),
+ *     @Attribute("options", type = "array"),
+ *     @Attribute("renderer", type = "string"),
+ *     @Attribute("service", type = "string"),
+ *     @Attribute("template", type = "string"),
+ *     @Attribute("type", type = "string"),
+ * })
+ */
+final class FrontendModule
+{
+    /**
+     * @var string
+     */
+    public $category;
+
+    /**
+     * @var array
+     */
+    public $options = [];
+
+    /**
+     * @var string
+     */
+    public $renderer;
+
+    /**
+     * @var string
+     */
+    public $service;
+
+    /**
+     * @var string
+     */
+    public $template;
+
+    /**
+     * @var string
+     */
+    public $type;
+
+    /**
+     * Annotation constructor.
+     *
+     * @param array $values
+     */
+    public function __construct(array $values)
+    {
+        $this->category = $values['category'];
+        $this->options = (array) $values['options'];
+        $this->service = $values['service'];
+        $this->renderer = $values['renderer'];
+        $this->template = $values['template'];
+        $this->type = $values['type'];
+    }
+}

--- a/core-bundle/src/Fragment/Annotation/FrontendModule.php
+++ b/core-bundle/src/Fragment/Annotation/FrontendModule.php
@@ -30,6 +30,6 @@ use Doctrine\Common\Annotations\Annotation\Target;
  *     @Attribute("type", type = "string"),
  * })
  */
-final class FrontendModule extends Base
+final class FrontendModule extends AbstractFragmentAnnotation
 {
 }

--- a/core-bundle/src/Fragment/Annotation/FrontendModule.php
+++ b/core-bundle/src/Fragment/Annotation/FrontendModule.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
  * @license LGPL-3.0-or-later
  */
 
-namespace Contao\CoreBundle\Fragment\Annotations;
+namespace Contao\CoreBundle\Fragment\Annotation;
 
 use Doctrine\Common\Annotations\Annotation\Attribute;
 use Doctrine\Common\Annotations\Annotation\Attributes;
@@ -20,7 +20,7 @@ use Doctrine\Common\Annotations\Annotation\Target;
  * Annotation that can be used to define controller as a frontend module.
  *
  * @Annotation
- * @Target("CLASS", "METHOD")
+ * @Target({"CLASS", "METHOD"})
  * @Attributes({
  *     @Attribute("category", required = true, type = "string"),
  *     @Attribute("options", type = "array"),
@@ -30,50 +30,6 @@ use Doctrine\Common\Annotations\Annotation\Target;
  *     @Attribute("type", type = "string"),
  * })
  */
-final class FrontendModule
+final class FrontendModule extends Base
 {
-    /**
-     * @var string
-     */
-    public $category;
-
-    /**
-     * @var array
-     */
-    public $options = [];
-
-    /**
-     * @var string
-     */
-    public $renderer;
-
-    /**
-     * @var string
-     */
-    public $service;
-
-    /**
-     * @var string
-     */
-    public $template;
-
-    /**
-     * @var string
-     */
-    public $type;
-
-    /**
-     * Annotation constructor.
-     *
-     * @param array $values
-     */
-    public function __construct(array $values)
-    {
-        $this->category = $values['category'];
-        $this->options = (array) $values['options'];
-        $this->service = $values['service'];
-        $this->renderer = $values['renderer'];
-        $this->template = $values['template'];
-        $this->type = $values['type'];
-    }
 }


### PR DESCRIPTION
Allows to use annotations for fragments to define the content elements / frontend modules instead of service tags.

```php
<?php

use Contao\CoreBundle\Fragment\Annotations\FrontendModule;

/**
 * @FrontendModule(category="miscellaneous", type="app_foobar", template="mod_app_foobar")
 */
class FoobarController
{
    public function __invoke()
    {
        //
    }
}
```

Method annotations are also supported:

```php
<?php

use Contao\CoreBundle\Fragment\Annotations\FrontendModule;

class FoobarController
{
    /**
     * @FrontendModule(category="miscellaneous", type="app_foobar_index")
     */
    public function indexAction()
    {
        //
    }

    /**
     * @FrontendModule(category="miscellaneous", type="app_foobar_list")
     */
    public function listAction()
    {
        //
    }
}
```