### PR TITLE
Drop usage of SECURITY_SESSION_KEY constant

### DIFF
--- a/core-bundle/src/Resources/contao/classes/BackendUser.php
+++ b/core-bundle/src/Resources/contao/classes/BackendUser.php
@@ -67,6 +67,13 @@ class BackendUser extends User
 	const CAN_DELETE_ARTICLES = 6;
 
 	/**
+	 * Symfony Security session key
+	 * @var string
+	 * @deprecated Deprecated since Contao 4.8, to be removed in Contao 5.0
+	 */
+	const SECURITY_SESSION_KEY = '_security_contao_backend';
+
+	/**
 	 * Current object instance (do not remove)
 	 * @var BackendUser
 	 */

--- a/core-bundle/src/Resources/contao/classes/BackendUser.php
+++ b/core-bundle/src/Resources/contao/classes/BackendUser.php
@@ -67,12 +67,6 @@ class BackendUser extends User
 	const CAN_DELETE_ARTICLES = 6;
 
 	/**
-	 * Symfony Security session key
-	 * @var string
-	 */
-	const SECURITY_SESSION_KEY = '_security_contao_backend';
-
-	/**
 	 * Current object instance (do not remove)
 	 * @var BackendUser
 	 */

--- a/core-bundle/src/Resources/contao/classes/FrontendUser.php
+++ b/core-bundle/src/Resources/contao/classes/FrontendUser.php
@@ -20,6 +20,14 @@ namespace Contao;
  */
 class FrontendUser extends User
 {
+
+	/**
+	 * Symfony Security session key
+	 * @var string
+	 * @deprecated Deprecated since Contao 4.8, to be removed in Contao 5.0
+	 */
+	const SECURITY_SESSION_KEY = '_security_contao_frontend';
+
 	/**
 	 * Current object instance (do not remove)
 	 * @var FrontendUser

--- a/core-bundle/src/Resources/contao/classes/FrontendUser.php
+++ b/core-bundle/src/Resources/contao/classes/FrontendUser.php
@@ -20,13 +20,6 @@ namespace Contao;
  */
 class FrontendUser extends User
 {
-
-	/**
-	 * Symfony Security session key
-	 * @var string
-	 */
-	const SECURITY_SESSION_KEY = '_security_contao_frontend';
-
 	/**
 	 * Current object instance (do not remove)
 	 * @var FrontendUser

--- a/core-bundle/src/Security/Authentication/FrontendPreviewAuthenticator.php
+++ b/core-bundle/src/Security/Authentication/FrontendPreviewAuthenticator.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Security\Authentication;
 
 use Contao\BackendUser;
+use Contao\CoreBundle\ContaoCoreBundle;
 use Contao\CoreBundle\Monolog\ContaoContext;
 use Contao\CoreBundle\Security\Authentication\Token\FrontendPreviewToken;
 use Contao\FrontendUser;
@@ -25,6 +26,8 @@ use Symfony\Component\Security\Core\User\UserProviderInterface;
 
 class FrontendPreviewAuthenticator
 {
+    private const SECURITY_SESSION_KEY = '_security_contao_'.ContaoCoreBundle::SCOPE_FRONTEND;
+
     /**
      * @var SessionInterface
      */
@@ -74,7 +77,7 @@ class FrontendPreviewAuthenticator
 
         $token = new FrontendPreviewToken($frontendUser, $showUnpublished);
 
-        $this->session->set(FrontendUser::SECURITY_SESSION_KEY, serialize($token));
+        $this->session->set(self::SECURITY_SESSION_KEY, serialize($token));
 
         return true;
     }
@@ -89,7 +92,7 @@ class FrontendPreviewAuthenticator
 
         $token = new FrontendPreviewToken(null, $showUnpublished);
 
-        $this->session->set(FrontendUser::SECURITY_SESSION_KEY, serialize($token));
+        $this->session->set(self::SECURITY_SESSION_KEY, serialize($token));
 
         return true;
     }
@@ -99,11 +102,11 @@ class FrontendPreviewAuthenticator
      */
     public function removeFrontendAuthentication(): bool
     {
-        if (!$this->session->isStarted() || !$this->session->has(FrontendUser::SECURITY_SESSION_KEY)) {
+        if (!$this->session->isStarted() || !$this->session->has(self::SECURITY_SESSION_KEY)) {
             return false;
         }
 
-        $this->session->remove(FrontendUser::SECURITY_SESSION_KEY);
+        $this->session->remove(self::SECURITY_SESSION_KEY);
 
         return true;
     }

--- a/core-bundle/src/Security/Authentication/FrontendPreviewAuthenticator.php
+++ b/core-bundle/src/Security/Authentication/FrontendPreviewAuthenticator.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Security\Authentication;
 
 use Contao\BackendUser;
-use Contao\CoreBundle\ContaoCoreBundle;
 use Contao\CoreBundle\Monolog\ContaoContext;
 use Contao\CoreBundle\Security\Authentication\Token\FrontendPreviewToken;
 use Contao\FrontendUser;
@@ -26,7 +25,7 @@ use Symfony\Component\Security\Core\User\UserProviderInterface;
 
 class FrontendPreviewAuthenticator
 {
-    private const SECURITY_SESSION_KEY = '_security_contao_'.ContaoCoreBundle::SCOPE_FRONTEND;
+    private const SECURITY_SESSION_KEY = '_security_contao_frontend';
 
     /**
      * @var SessionInterface

--- a/core-bundle/src/Security/Authentication/FrontendPreviewAuthenticator.php
+++ b/core-bundle/src/Security/Authentication/FrontendPreviewAuthenticator.php
@@ -25,8 +25,6 @@ use Symfony\Component\Security\Core\User\UserProviderInterface;
 
 class FrontendPreviewAuthenticator
 {
-    private const SECURITY_SESSION_KEY = '_security_contao_frontend';
-
     /**
      * @var SessionInterface
      */
@@ -76,7 +74,7 @@ class FrontendPreviewAuthenticator
 
         $token = new FrontendPreviewToken($frontendUser, $showUnpublished);
 
-        $this->session->set(self::SECURITY_SESSION_KEY, serialize($token));
+        $this->session->set('_security_contao_frontend', serialize($token));
 
         return true;
     }
@@ -91,7 +89,7 @@ class FrontendPreviewAuthenticator
 
         $token = new FrontendPreviewToken(null, $showUnpublished);
 
-        $this->session->set(self::SECURITY_SESSION_KEY, serialize($token));
+        $this->session->set('_security_contao_frontend', serialize($token));
 
         return true;
     }
@@ -101,11 +99,11 @@ class FrontendPreviewAuthenticator
      */
     public function removeFrontendAuthentication(): bool
     {
-        if (!$this->session->isStarted() || !$this->session->has(self::SECURITY_SESSION_KEY)) {
+        if (!$this->session->isStarted() || !$this->session->has('_security_contao_frontend')) {
             return false;
         }
 
-        $this->session->remove(self::SECURITY_SESSION_KEY);
+        $this->session->remove('_security_contao_frontend');
 
         return true;
     }

--- a/core-bundle/tests/Security/Authentication/FrontendPreviewAuthenticatorTest.php
+++ b/core-bundle/tests/Security/Authentication/FrontendPreviewAuthenticatorTest.php
@@ -306,9 +306,9 @@ class FrontendPreviewAuthenticatorTest extends TestCase
         $authenticator = $this->getAuthenticator($session, $tokenStorage, $userProvider);
 
         $this->assertTrue($authenticator->authenticateFrontendUser('foobar', false));
-        $this->assertTrue($session->has(FrontendUser::SECURITY_SESSION_KEY));
+        $this->assertTrue($session->has('_security_contao_frontend'));
 
-        $token = unserialize($session->get(FrontendUser::SECURITY_SESSION_KEY), ['allowed_classes' => true]);
+        $token = unserialize($session->get('_security_contao_frontend'), ['allowed_classes' => true]);
 
         $this->assertInstanceOf(FrontendPreviewToken::class, $token);
         $this->assertInstanceOf(FrontendUser::class, $token->getUser());
@@ -360,9 +360,9 @@ class FrontendPreviewAuthenticatorTest extends TestCase
         $authenticator = $this->getAuthenticator($session, $tokenStorage, $userProvider);
 
         $this->assertTrue($authenticator->authenticateFrontendUser('foobar', true));
-        $this->assertTrue($session->has(FrontendUser::SECURITY_SESSION_KEY));
+        $this->assertTrue($session->has('_security_contao_frontend'));
 
-        $token = unserialize($session->get(FrontendUser::SECURITY_SESSION_KEY), ['allowed_classes' => true]);
+        $token = unserialize($session->get('_security_contao_frontend'), ['allowed_classes' => true]);
 
         $this->assertInstanceOf(FrontendPreviewToken::class, $token);
         $this->assertInstanceOf(FrontendUser::class, $token->getUser());
@@ -414,9 +414,9 @@ class FrontendPreviewAuthenticatorTest extends TestCase
         $authenticator = $this->getAuthenticator($session, $tokenStorage);
 
         $this->assertTrue($authenticator->authenticateFrontendGuest(false));
-        $this->assertTrue($session->has(FrontendUser::SECURITY_SESSION_KEY));
+        $this->assertTrue($session->has('_security_contao_frontend'));
 
-        $token = unserialize($session->get(FrontendUser::SECURITY_SESSION_KEY), ['allowed_classes' => true]);
+        $token = unserialize($session->get('_security_contao_frontend'), ['allowed_classes' => true]);
 
         $this->assertInstanceOf(FrontendPreviewToken::class, $token);
         $this->assertSame('anon.', $token->getUser());
@@ -451,9 +451,9 @@ class FrontendPreviewAuthenticatorTest extends TestCase
         $authenticator = $this->getAuthenticator($session, $tokenStorage);
 
         $this->assertTrue($authenticator->authenticateFrontendGuest(true));
-        $this->assertTrue($session->has(FrontendUser::SECURITY_SESSION_KEY));
+        $this->assertTrue($session->has('_security_contao_frontend'));
 
-        $token = unserialize($session->get(FrontendUser::SECURITY_SESSION_KEY), ['allowed_classes' => true]);
+        $token = unserialize($session->get('_security_contao_frontend'), ['allowed_classes' => true]);
 
         $this->assertInstanceOf(FrontendPreviewToken::class, $token);
         $this->assertSame('anon.', $token->getUser());
@@ -472,14 +472,14 @@ class FrontendPreviewAuthenticatorTest extends TestCase
         $session
             ->expects($this->once())
             ->method('has')
-            ->with(FrontendUser::SECURITY_SESSION_KEY)
+            ->with('_security_contao_frontend')
             ->willReturn(true)
         ;
 
         $session
             ->expects($this->once())
             ->method('remove')
-            ->with(FrontendUser::SECURITY_SESSION_KEY)
+            ->with('_security_contao_frontend')
         ;
 
         $authenticator = $this->getAuthenticator($session);
@@ -513,7 +513,7 @@ class FrontendPreviewAuthenticatorTest extends TestCase
         $session
             ->expects($this->once())
             ->method('has')
-            ->with(FrontendUser::SECURITY_SESSION_KEY)
+            ->with('_security_contao_frontend')
             ->willReturn(false)
         ;
 


### PR DESCRIPTION
as discussed in https://github.com/contao/contao/pull/513#discussion_r293304498, they should not have been there in the first place imho. The session key is hardcoded in Symfony, as in `_security_` and your firewall name. The `FrontendUser` or `BackendUser` class is not the definition of the firewall name.

I would suggest to merge https://github.com/contao/contao/pull/513 first so this can be adjusted accordingly.