### PR TITLE
Support security encoder and added support for argon2 and co.

### DIFF
--- a/core-bundle/README.md
+++ b/core-bundle/README.md
@@ -36,8 +36,8 @@ Install Contao and all its dependencies by executing the following command:
 
 ```
 composer require \
-    contao/core-bundle:4.7.* \
-    contao/installation-bundle:^4.7 \
+    contao/core-bundle:4.8.* \
+    contao/installation-bundle:^4.8 \
     php-http/guzzle6-adapter:^1.1
 ```
 

--- a/core-bundle/README.md
+++ b/core-bundle/README.md
@@ -80,7 +80,7 @@ security:
 
     encoders:
         Contao\User:
-            algorithm: bcrypt
+            algorithm: auto
 
     firewalls:
         dev:

--- a/core-bundle/src/Command/UserPasswordCommand.php
+++ b/core-bundle/src/Command/UserPasswordCommand.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Command;
 
+use Contao\BackendUser;
 use Contao\Config;
 use Contao\CoreBundle\Framework\ContaoFramework;
 use Doctrine\DBAL\Connection;
@@ -26,6 +27,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
 
 /**
  * Changes the password of a Contao back end user.
@@ -42,10 +44,16 @@ class UserPasswordCommand extends Command
      */
     private $connection;
 
-    public function __construct(ContaoFramework $framework, Connection $connection)
+    /**
+     * @var EncoderFactoryInterface
+     */
+    private $encoderFactory;
+
+    public function __construct(ContaoFramework $framework, Connection $connection, EncoderFactoryInterface $encoderFactory)
     {
         $this->framework = $framework;
         $this->connection = $connection;
+        $this->encoderFactory = $encoderFactory;
 
         parent::__construct();
     }
@@ -150,6 +158,8 @@ class UserPasswordCommand extends Command
             );
         }
 
-        return password_hash($password, PASSWORD_DEFAULT);
+        $encoder = $this->encoderFactory->getEncoder(BackendUser::class);
+
+        return $encoder->encodePassword($password, null);
     }
 }

--- a/core-bundle/src/DependencyInjection/Compiler/MakeServicesPublicPass.php
+++ b/core-bundle/src/DependencyInjection/Compiler/MakeServicesPublicPass.php
@@ -47,6 +47,7 @@ class MakeServicesPublicPass implements CompilerPassInterface
         static $aliases = [
             'database_connection',
             'swiftmailer.mailer',
+            'security.encoder_factory',
         ];
 
         foreach ($aliases as $alias) {

--- a/core-bundle/src/Resources/config/commands.yml
+++ b/core-bundle/src/Resources/config/commands.yml
@@ -52,6 +52,7 @@ services:
         arguments:
             - '@contao.framework'
             - '@database_connection'
+            - '@security.encoder_factory'
 
     contao.command.version:
         class: Contao\CoreBundle\Command\VersionCommand

--- a/core-bundle/src/Resources/contao/config/default.php
+++ b/core-bundle/src/Resources/contao/config/default.php
@@ -53,7 +53,6 @@ $GLOBALS['TL_CONFIG']['dbCollation'] = 'utf8mb4_unicode_ci';
 // Encryption
 $GLOBALS['TL_CONFIG']['encryptionMode']   = 'cfb';
 $GLOBALS['TL_CONFIG']['encryptionCipher'] = 'rijndael-256';
-$GLOBALS['TL_CONFIG']['bcryptCost']       = 10;
 
 // File uploads
 $GLOBALS['TL_CONFIG']['uploadTypes']

--- a/core-bundle/src/Resources/contao/controllers/BackendPassword.php
+++ b/core-bundle/src/Resources/contao/controllers/BackendPassword.php
@@ -14,6 +14,7 @@ use Contao\CoreBundle\Exception\AccessDeniedException;
 use Patchwork\Utf8;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
 
 /**
  * Back end help wizard.
@@ -81,8 +82,12 @@ class BackendPassword extends Backend
 			// Save the data
 			else
 			{
+				/** @var EncoderFactoryInterface $encoderFactory */
+				$encoderFactory = System::getContainer()->get('security.encoder_factory');
+				$encoder = $encoderFactory->getEncoder(BackendUser::class);
+
 				// Make sure the password has been changed
-				if (password_verify($pw, $this->User->password))
+				if ($encoder->isPasswordValid($this->User->password, $pw, null))
 				{
 					Message::addError($GLOBALS['TL_LANG']['MSC']['pw_change']);
 				}
@@ -112,7 +117,7 @@ class BackendPassword extends Backend
 
 					$objUser = UserModel::findByPk($this->User->id);
 					$objUser->pwChange = '';
-					$objUser->password = password_hash($pw, PASSWORD_DEFAULT);
+					$objUser->password = $encoder->encodePassword($pw, null);
 					$objUser->save();
 
 					Message::addConfirmation($GLOBALS['TL_LANG']['MSC']['pw_changed']);

--- a/core-bundle/src/Resources/contao/controllers/BackendPassword.php
+++ b/core-bundle/src/Resources/contao/controllers/BackendPassword.php
@@ -14,7 +14,6 @@ use Contao\CoreBundle\Exception\AccessDeniedException;
 use Patchwork\Utf8;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
 
 /**
  * Back end help wizard.
@@ -82,9 +81,7 @@ class BackendPassword extends Backend
 			// Save the data
 			else
 			{
-				/** @var EncoderFactoryInterface $encoderFactory */
-				$encoderFactory = System::getContainer()->get('security.encoder_factory');
-				$encoder = $encoderFactory->getEncoder(BackendUser::class);
+				$encoder = System::getContainer()->get('security.encoder_factory')->getEncoder(BackendUser::class);
 
 				// Make sure the password has been changed
 				if ($encoder->isPasswordValid($this->User->password, $pw, null))

--- a/core-bundle/src/Resources/contao/forms/FormPassword.php
+++ b/core-bundle/src/Resources/contao/forms/FormPassword.php
@@ -142,7 +142,7 @@ class FormPassword extends Widget
 
 			/** @var EncoderFactoryInterface $encoderFactory */
 			$encoderFactory = System::getContainer()->get('security.encoder_factory');
-			$encoder = $encoderFactory->getEncoder(BackendUser::class);
+			$encoder = $encoderFactory->getEncoder(FrontendUser::class);
 
 			return $encoder->encodePassword($varInput, null);
 		}

--- a/core-bundle/src/Resources/contao/forms/FormPassword.php
+++ b/core-bundle/src/Resources/contao/forms/FormPassword.php
@@ -11,6 +11,7 @@
 namespace Contao;
 
 use Patchwork\Utf8;
+use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
 
 /**
  * Class FormPassword
@@ -139,7 +140,11 @@ class FormPassword extends Widget
 		{
 			$this->blnSubmitInput = true;
 
-			return password_hash($varInput, PASSWORD_DEFAULT);
+			/** @var EncoderFactoryInterface $encoderFactory */
+			$encoderFactory = System::getContainer()->get('security.encoder_factory');
+			$encoder = $encoderFactory->getEncoder(BackendUser::class);
+
+			return $encoder->encodePassword($varInput, null);
 		}
 
 		return '';

--- a/core-bundle/src/Resources/contao/forms/FormPassword.php
+++ b/core-bundle/src/Resources/contao/forms/FormPassword.php
@@ -11,7 +11,6 @@
 namespace Contao;
 
 use Patchwork\Utf8;
-use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
 
 /**
  * Class FormPassword
@@ -139,10 +138,7 @@ class FormPassword extends Widget
 		if (!$this->hasErrors())
 		{
 			$this->blnSubmitInput = true;
-
-			/** @var EncoderFactoryInterface $encoderFactory */
-			$encoderFactory = System::getContainer()->get('security.encoder_factory');
-			$encoder = $encoderFactory->getEncoder(FrontendUser::class);
+			$encoder = System::getContainer()->get('security.encoder_factory')->getEncoder(FrontendUser::class);
 
 			return $encoder->encodePassword($varInput, null);
 		}

--- a/core-bundle/src/Resources/contao/library/Contao/Encryption.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Encryption.php
@@ -10,8 +10,6 @@
 
 namespace Contao;
 
-use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
-
 @trigger_error('Using the Contao\Encryption class has been deprecated and will no longer work in Contao 5.0. Use the PHP password_* functions and a third-party library such as OpenSSL or phpseclib instead.', E_USER_DEPRECATED);
 
 /**
@@ -170,9 +168,7 @@ class Encryption
 	 */
 	public static function hash($strPassword)
 	{
-		/** @var EncoderFactoryInterface $encoderFactory */
-		$encoderFactory = System::getContainer()->get('security.encoder_factory');
-		$encoder = $encoderFactory->getEncoder(User::class);
+		$encoder = System::getContainer()->get('security.encoder_factory')->getEncoder(User::class);
 
 		return $encoder->encodePassword($strPassword, null);
 	}
@@ -218,9 +214,7 @@ class Encryption
 	 */
 	public static function verify($strPassword, $strHash)
 	{
-		/** @var EncoderFactoryInterface $encoderFactory */
-		$encoderFactory = System::getContainer()->get('security.encoder_factory');
-		$encoder = $encoderFactory->getEncoder(User::class);
+		$encoder = System::getContainer()->get('security.encoder_factory')->getEncoder(User::class);
 
 		return $encoder->isPasswordValid($strHash, $strPassword, null);
 	}

--- a/core-bundle/src/Resources/contao/library/Contao/Encryption.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Encryption.php
@@ -172,7 +172,7 @@ class Encryption
 	{
 		/** @var EncoderFactoryInterface $encoderFactory */
 		$encoderFactory = System::getContainer()->get('security.encoder_factory');
-		$encoder = $encoderFactory->getEncoder(BackendUser::class); // This is hardcoded (BE and FE users/members should not have a different algo anyway but if you need it, do not rely on a deprecated class but use the services instead)
+		$encoder = $encoderFactory->getEncoder(User::class);
 
 		return $encoder->encodePassword($strPassword, null);
 	}
@@ -220,7 +220,7 @@ class Encryption
 	{
 		/** @var EncoderFactoryInterface $encoderFactory */
 		$encoderFactory = System::getContainer()->get('security.encoder_factory');
-		$encoder = $encoderFactory->getEncoder(BackendUser::class); // This is hardcoded (BE and FE users/members should not have a different algo anyway but if you need it, do not rely on a deprecated class but use the services instead)
+		$encoder = $encoderFactory->getEncoder(User::class);
 
 		return $encoder->isPasswordValid($strHash, $strPassword, null);
 	}

--- a/core-bundle/src/Resources/contao/library/Contao/Encryption.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Encryption.php
@@ -10,6 +10,8 @@
 
 namespace Contao;
 
+use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
+
 @trigger_error('Using the Contao\Encryption class has been deprecated and will no longer work in Contao 5.0. Use the PHP password_* functions and a third-party library such as OpenSSL or phpseclib instead.', E_USER_DEPRECATED);
 
 /**
@@ -168,7 +170,11 @@ class Encryption
 	 */
 	public static function hash($strPassword)
 	{
-		return password_hash($strPassword, PASSWORD_DEFAULT);
+		/** @var EncoderFactoryInterface $encoderFactory */
+		$encoderFactory = System::getContainer()->get('security.encoder_factory');
+		$encoder = $encoderFactory->getEncoder(BackendUser::class); // This is hardcoded (BE and FE users/members should not have a different algo anyway but if you need it, do not rely on a deprecated class but use the services instead)
+
+		return $encoder->encodePassword($strPassword, null);
 	}
 
 	/**
@@ -212,7 +218,11 @@ class Encryption
 	 */
 	public static function verify($strPassword, $strHash)
 	{
-		return password_verify($strPassword, $strHash);
+		/** @var EncoderFactoryInterface $encoderFactory */
+		$encoderFactory = System::getContainer()->get('security.encoder_factory');
+		$encoder = $encoderFactory->getEncoder(BackendUser::class); // This is hardcoded (BE and FE users/members should not have a different algo anyway but if you need it, do not rely on a deprecated class but use the services instead)
+
+		return $encoder->isPasswordValid($strHash, $strPassword, null);
 	}
 
 	/**

--- a/core-bundle/src/Resources/contao/library/Contao/User.php
+++ b/core-bundle/src/Resources/contao/library/Contao/User.php
@@ -12,7 +12,6 @@ namespace Contao;
 
 use Contao\CoreBundle\Exception\RedirectResponseException;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\User\EquatableInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
@@ -494,16 +493,6 @@ abstract class User extends System implements UserInterface, EquatableInterface,
 			{
 				return null;
 			}
-		}
-
-		// Check if a passwords needs rehashing (see contao/core#8820)
-		if ($isLogin)
-		{
-			/** @var EncoderFactoryInterface $encoderFactory */
-			$encoderFactory = System::getContainer()->get('security.encoder_factory');
-			$encoder = $encoderFactory->getEncoder(static::class);
-
-			$blnAuthenticated = $encoder->isPasswordValid($user->password, $request->request->get('password'), null);
 		}
 
 		$user->setUserFromDb();

--- a/core-bundle/src/Resources/contao/modules/ModuleChangePassword.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleChangePassword.php
@@ -11,6 +11,7 @@
 namespace Contao;
 
 use Patchwork\Utf8;
+use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
 
 /**
  * Front end module "change password".
@@ -142,8 +143,12 @@ class ModuleChangePassword extends Module
 			{
 				$objWidget->validate();
 
+				/** @var EncoderFactoryInterface $encoderFactory */
+				$encoderFactory = System::getContainer()->get('security.encoder_factory');
+				$encoder = $encoderFactory->getEncoder(FrontendUser::class);
+
 				// Validate the old password
-				if ($strKey == 'oldPassword' && !password_verify($objWidget->value, $objMember->password))
+				if ($strKey == 'oldPassword' && !$encoder->isPasswordValid($objMember->password, $objWidget->value, null))
 				{
 					$objWidget->value = '';
 					$objWidget->addError($GLOBALS['TL_LANG']['MSC']['oldPasswordWrong']);

--- a/core-bundle/src/Resources/contao/modules/ModuleChangePassword.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleChangePassword.php
@@ -11,7 +11,6 @@
 namespace Contao;
 
 use Patchwork\Utf8;
-use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
 
 /**
  * Front end module "change password".
@@ -143,16 +142,17 @@ class ModuleChangePassword extends Module
 			{
 				$objWidget->validate();
 
-				/** @var EncoderFactoryInterface $encoderFactory */
-				$encoderFactory = System::getContainer()->get('security.encoder_factory');
-				$encoder = $encoderFactory->getEncoder(FrontendUser::class);
-
 				// Validate the old password
-				if ($strKey == 'oldPassword' && !$encoder->isPasswordValid($objMember->password, $objWidget->value, null))
+				if ($strKey == 'oldPassword')
 				{
-					$objWidget->value = '';
-					$objWidget->addError($GLOBALS['TL_LANG']['MSC']['oldPasswordWrong']);
-					sleep(2); // Wait 2 seconds while brute forcing :)
+					$encoder = System::getContainer()->get('security.encoder_factory')->getEncoder(FrontendUser::class);
+
+					if (!$encoder->isPasswordValid($objMember->password, $objWidget->value, null))
+					{
+						$objWidget->value = '';
+						$objWidget->addError($GLOBALS['TL_LANG']['MSC']['oldPasswordWrong']);
+						sleep(2); // Wait 2 seconds while brute forcing :)
+					}
 				}
 
 				if ($objWidget->hasErrors())

--- a/core-bundle/src/Resources/contao/modules/ModuleCloseAccount.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleCloseAccount.php
@@ -11,6 +11,7 @@
 namespace Contao;
 
 use Patchwork\Utf8;
+use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
 
 /**
  * Front end module "close account".
@@ -80,8 +81,12 @@ class ModuleCloseAccount extends Module
 		{
 			$objWidget->validate();
 
+			/** @var EncoderFactoryInterface $encoderFactory */
+			$encoderFactory = System::getContainer()->get('security.encoder_factory');
+			$encoder = $encoderFactory->getEncoder(FrontendUser::class);
+
 			// Validate the password
-			if (!$objWidget->hasErrors() && !password_verify($objWidget->value, $this->User->password))
+			if (!$objWidget->hasErrors() && !$encoder->isPasswordValid($this->User->password, $objWidget->value, null))
 			{
 				$objWidget->value = '';
 				$objWidget->addError($GLOBALS['TL_LANG']['ERR']['invalidPass']);

--- a/core-bundle/src/Resources/contao/modules/ModuleCloseAccount.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleCloseAccount.php
@@ -11,7 +11,6 @@
 namespace Contao;
 
 use Patchwork\Utf8;
-use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
 
 /**
  * Front end module "close account".
@@ -81,9 +80,7 @@ class ModuleCloseAccount extends Module
 		{
 			$objWidget->validate();
 
-			/** @var EncoderFactoryInterface $encoderFactory */
-			$encoderFactory = System::getContainer()->get('security.encoder_factory');
-			$encoder = $encoderFactory->getEncoder(FrontendUser::class);
+			$encoder = System::getContainer()->get('security.encoder_factory')->getEncoder(FrontendUser::class);
 
 			// Validate the password
 			if (!$objWidget->hasErrors() && !$encoder->isPasswordValid($this->User->password, $objWidget->value, null))

--- a/core-bundle/src/Resources/contao/modules/ModuleRegistration.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleRegistration.php
@@ -12,7 +12,6 @@ namespace Contao;
 
 use Contao\CoreBundle\OptIn\OptIn;
 use Patchwork\Utf8;
-use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
 
 /**
  * Front end module "registration".
@@ -219,15 +218,12 @@ class ModuleRegistration extends Module
 			if (Input::post('FORM_SUBMIT') == $strFormId)
 			{
 				$objWidget->validate();
+
 				$varValue = $objWidget->value;
-
-
-				/** @var EncoderFactoryInterface $encoderFactory */
-				$encoderFactory = System::getContainer()->get('security.encoder_factory');
-				$encoder = $encoderFactory->getEncoder(FrontendUser::class);
+				$encoder = System::getContainer()->get('security.encoder_factory')->getEncoder(FrontendUser::class);
 
 				// Check whether the password matches the username
-				if ($objWidget instanceof FormPassword && $encoder->isPasswordValid($varValue, Input::post('username')))
+				if ($objWidget instanceof FormPassword && $encoder->isPasswordValid($varValue, Input::post('username'), null))
 				{
 					$objWidget->addError($GLOBALS['TL_LANG']['ERR']['passwordName']);
 				}

--- a/core-bundle/src/Resources/contao/modules/ModuleRegistration.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleRegistration.php
@@ -12,6 +12,7 @@ namespace Contao;
 
 use Contao\CoreBundle\OptIn\OptIn;
 use Patchwork\Utf8;
+use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
 
 /**
  * Front end module "registration".
@@ -220,8 +221,13 @@ class ModuleRegistration extends Module
 				$objWidget->validate();
 				$varValue = $objWidget->value;
 
+
+				/** @var EncoderFactoryInterface $encoderFactory */
+				$encoderFactory = System::getContainer()->get('security.encoder_factory');
+				$encoder = $encoderFactory->getEncoder(FrontendUser::class);
+
 				// Check whether the password matches the username
-				if ($objWidget instanceof FormPassword && password_verify(Input::post('username'), $varValue))
+				if ($objWidget instanceof FormPassword && $encoder->isPasswordValid($varValue, Input::post('username')))
 				{
 					$objWidget->addError($GLOBALS['TL_LANG']['ERR']['passwordName']);
 				}

--- a/core-bundle/src/Resources/contao/widgets/Password.php
+++ b/core-bundle/src/Resources/contao/widgets/Password.php
@@ -11,6 +11,7 @@
 namespace Contao;
 
 use Patchwork\Utf8;
+use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
 
 /**
  * Provide methods to handle password fields.
@@ -135,7 +136,11 @@ class Password extends Widget
 			$this->blnSubmitInput = true;
 			Message::addConfirmation($GLOBALS['TL_LANG']['MSC']['pw_changed']);
 
-			return password_hash($varInput, PASSWORD_DEFAULT);
+			/** @var EncoderFactoryInterface $encoderFactory */
+			$encoderFactory = System::getContainer()->get('security.encoder_factory');
+			$encoder = $encoderFactory->getEncoder(BackendUser::class);
+
+			return $encoder->encodePassword($varInput, null);
 		}
 
 		return '';

--- a/core-bundle/src/Resources/contao/widgets/Password.php
+++ b/core-bundle/src/Resources/contao/widgets/Password.php
@@ -11,7 +11,6 @@
 namespace Contao;
 
 use Patchwork\Utf8;
-use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
 
 /**
  * Provide methods to handle password fields.
@@ -136,9 +135,7 @@ class Password extends Widget
 			$this->blnSubmitInput = true;
 			Message::addConfirmation($GLOBALS['TL_LANG']['MSC']['pw_changed']);
 
-			/** @var EncoderFactoryInterface $encoderFactory */
-			$encoderFactory = System::getContainer()->get('security.encoder_factory');
-			$encoder = $encoderFactory->getEncoder(BackendUser::class);
+			$encoder = System::getContainer()->get('security.encoder_factory')->getEncoder(BackendUser::class);
 
 			return $encoder->encodePassword($varInput, null);
 		}

--- a/core-bundle/tests/Command/UserPasswordCommandTest.php
+++ b/core-bundle/tests/Command/UserPasswordCommandTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Tests\Command;
 
+use Contao\BackendUser;
 use Contao\CoreBundle\Command\UserPasswordCommand;
 use Contao\CoreBundle\Tests\TestCase;
 use Doctrine\DBAL\Connection;
@@ -21,34 +22,18 @@ use Symfony\Component\Console\Exception\InvalidArgumentException;
 use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
+use Symfony\Component\Security\Core\Encoder\PasswordEncoderInterface;
 
 class UserPasswordCommandTest extends TestCase
 {
-    /**
-     * @var UserPasswordCommand
-     */
-    private $command;
-
-    /**
-     * {@inheritdoc}
-     */
-    public function setUp(): void
-    {
-        parent::setUp();
-
-        $this->command = new UserPasswordCommand(
-            $this->mockContaoFramework(),
-            $this->createMock(Connection::class)
-        );
-
-        $this->command->setApplication(new Application());
-    }
-
     public function testDefinesUsernameAndPassword(): void
     {
-        $this->assertNotEmpty($this->command->getDescription());
+        $command = $this->getCommand();
 
-        $definition = $this->command->getDefinition();
+        $this->assertNotEmpty($command->getDescription());
+
+        $definition = $command->getDefinition();
 
         $this->assertTrue($definition->hasArgument('username'));
         $this->assertTrue($definition->hasOption('password'));
@@ -56,64 +41,76 @@ class UserPasswordCommandTest extends TestCase
 
     public function testTakesAPasswordAsArgument(): void
     {
+        $command = $this->getCommand();
+
         $input = [
             'username' => 'foobar',
             '--password' => '12345678',
         ];
 
-        $code = (new CommandTester($this->command))->execute($input);
+        $code = (new CommandTester($command))->execute($input);
 
         $this->assertSame(0, $code);
     }
 
     public function testAsksForThePasswordIfNotGiven(): void
     {
+        $command = $this->getCommand();
+
         $question = $this->createMock(QuestionHelper::class);
         $question
             ->method('ask')
             ->willReturn('12345678')
         ;
 
-        $this->command->getHelperSet()->set($question, 'question');
+        $command->getHelperSet()->set($question, 'question');
 
-        $code = (new CommandTester($this->command))->execute(['username' => 'foobar']);
+        $code = (new CommandTester($command))->execute(['username' => 'foobar']);
 
         $this->assertSame(0, $code);
     }
 
     public function testFailsIfThePasswordsDoNotMatch(): void
     {
+        $command = $this->getCommand();
+
         $question = $this->createMock(QuestionHelper::class);
         $question
             ->method('ask')
             ->willReturnOnConsecutiveCalls('12345678', '87654321')
         ;
 
-        $this->command->getHelperSet()->set($question, 'question');
+        $command->getHelperSet()->set($question, 'question');
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('The passwords do not match.');
 
-        (new CommandTester($this->command))->execute(['username' => 'foobar']);
+        (new CommandTester($command))->execute(['username' => 'foobar']);
     }
 
     public function testFailsWithoutUsername(): void
     {
+        $command = $this->getCommand();
+
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Please provide the username as argument.');
 
-        (new CommandTester($this->command))->execute([]);
+        (new CommandTester($command))->execute([]);
     }
 
     public function testFailsWithoutPasswordIfNotInteractive(): void
     {
-        $code = (new CommandTester($this->command))->execute(['username' => 'foobar'], ['interactive' => false]);
+        $command = $this->getCommand();
+
+        $code = (new CommandTester($command))->execute(['username' => 'foobar'], ['interactive' => false]);
 
         $this->assertSame(1, $code);
     }
 
     public function testRequiresAMinimumPasswordLength(): void
     {
+        $command = $this->getCommand();
+
         unset($GLOBALS['TL_CONFIG']['minPasswordLength']);
 
         $input = [
@@ -124,11 +121,13 @@ class UserPasswordCommandTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The password must be at least 8 characters long.');
 
-        (new CommandTester($this->command))->execute($input, ['interactive' => false]);
+        (new CommandTester($command))->execute($input, ['interactive' => false]);
     }
 
     public function testHandlesACustomMinimumPasswordLength(): void
     {
+        $command = $this->getCommand();
+
         $GLOBALS['TL_CONFIG']['minPasswordLength'] = 16;
 
         $input = [
@@ -139,7 +138,7 @@ class UserPasswordCommandTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The password must be at least 16 characters long.');
 
-        (new CommandTester($this->command))->execute($input, ['interactive' => false]);
+        (new CommandTester($command))->execute($input, ['interactive' => false]);
     }
 
     public function testFailsIfTheUsernameIsUnknown(): void
@@ -152,12 +151,12 @@ class UserPasswordCommandTest extends TestCase
             ->willReturn(0)
         ;
 
+        $command = $this->getCommand($connection);
+
         $input = [
             'username' => 'foobar',
             '--password' => '12345678',
         ];
-
-        $command = new UserPasswordCommand($this->mockContaoFramework(), $connection);
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid username: foobar');
@@ -177,21 +176,7 @@ class UserPasswordCommandTest extends TestCase
             ->method('update')
             ->with(
                 'tl_user',
-                $this->callback(
-                    function ($data) {
-                        $this->assertArrayHasKey('password', $data);
-
-                        // In PHP 7.4, the PASSWORD_DEFAULT constant will be null and the bcrypt identifier
-                        // changes to "2y" (see https://wiki.php.net/rfc/password_registry)
-                        if (null === PASSWORD_DEFAULT) {
-                            $this->assertSame('2y', password_get_info($data['password'])['algo']);
-                        } else {
-                            $this->assertSame(PASSWORD_DEFAULT, password_get_info($data['password'])['algo']);
-                        }
-
-                        return true;
-                    }
-                ),
+                ['password' => '$argon2id$v=19$m=65536,t=6,p=1$T+WK0xPOk21CQ2dX9AFplw$2uCrfvt7Tby81Dhc8Y7wHQQGP1HnPC3nDEb4FtXsfrQ'],
                 ['username' => $username]
             )
             ->willReturn(1)
@@ -202,7 +187,7 @@ class UserPasswordCommandTest extends TestCase
             '--password' => $password,
         ];
 
-        $command = new UserPasswordCommand($this->mockContaoFramework(), $connection);
+        $command = $this->getCommand($connection, $password);
 
         (new CommandTester($command))->execute($input, ['interactive' => false]);
     }
@@ -211,5 +196,41 @@ class UserPasswordCommandTest extends TestCase
     {
         yield ['foobar', '12345678'];
         yield ['k.jones', 'kevinjones'];
+    }
+
+    private function getCommand($connection = null, $password = null)
+    {
+        if (null === $connection) {
+            $connection = $this->createMock(Connection::class);
+        }
+
+        if (null === $password) {
+            $password = '12345678';
+        }
+
+        $encoder = $this->createMock(PasswordEncoderInterface::class);
+        $encoder
+            ->expects($this->any())
+            ->method('encodePassword')
+            ->with($password, null)
+            ->willReturn('$argon2id$v=19$m=65536,t=6,p=1$T+WK0xPOk21CQ2dX9AFplw$2uCrfvt7Tby81Dhc8Y7wHQQGP1HnPC3nDEb4FtXsfrQ')
+        ;
+
+        $encoderFactory = $this->createMock(EncoderFactoryInterface::class);
+        $encoderFactory
+            ->expects($this->any())
+            ->method('getEncoder')
+            ->with(BackendUser::class)
+            ->willReturn($encoder)
+        ;
+
+        $command = new UserPasswordCommand(
+            $this->mockContaoFramework(),
+            $connection,
+            $encoderFactory
+        );
+        $command->setApplication(new Application());
+
+        return $command;
     }
 }

--- a/core-bundle/tests/Command/UserPasswordCommandTest.php
+++ b/core-bundle/tests/Command/UserPasswordCommandTest.php
@@ -101,7 +101,6 @@ class UserPasswordCommandTest extends TestCase
     public function testFailsWithoutPasswordIfNotInteractive(): void
     {
         $command = $this->getCommand();
-
         $code = (new CommandTester($command))->execute(['username' => 'foobar'], ['interactive' => false]);
 
         $this->assertSame(1, $code);
@@ -198,7 +197,10 @@ class UserPasswordCommandTest extends TestCase
         yield ['k.jones', 'kevinjones'];
     }
 
-    private function getCommand($connection = null, $password = null)
+    /**
+     * @param Connection&MockObject $connection
+     */
+    private function getCommand(Connection $connection = null, string $password = null): UserPasswordCommand
     {
         if (null === $connection) {
             $connection = $this->createMock(Connection::class);
@@ -210,7 +212,6 @@ class UserPasswordCommandTest extends TestCase
 
         $encoder = $this->createMock(PasswordEncoderInterface::class);
         $encoder
-            ->expects($this->any())
             ->method('encodePassword')
             ->with($password, null)
             ->willReturn('$argon2id$v=19$m=65536,t=6,p=1$T+WK0xPOk21CQ2dX9AFplw$2uCrfvt7Tby81Dhc8Y7wHQQGP1HnPC3nDEb4FtXsfrQ')
@@ -218,17 +219,12 @@ class UserPasswordCommandTest extends TestCase
 
         $encoderFactory = $this->createMock(EncoderFactoryInterface::class);
         $encoderFactory
-            ->expects($this->any())
             ->method('getEncoder')
             ->with(BackendUser::class)
             ->willReturn($encoder)
         ;
 
-        $command = new UserPasswordCommand(
-            $this->mockContaoFramework(),
-            $connection,
-            $encoderFactory
-        );
+        $command = new UserPasswordCommand($this->mockContaoFramework(), $connection, $encoderFactory);
         $command->setApplication(new Application());
 
         return $command;

--- a/core-bundle/tests/DependencyInjection/Compiler/MakeServicesPublicPassTest.php
+++ b/core-bundle/tests/DependencyInjection/Compiler/MakeServicesPublicPassTest.php
@@ -39,6 +39,7 @@ class MakeServicesPublicPassTest extends TestCase
         // Aliases
         $container->setAlias('database_connection', 'doctrine.dbal.default_connection');
         $container->setAlias('swiftmailer.mailer', 'swiftmailer.mailer.default');
+        $container->setAlias('security.encoder_factory', 'security.encoder_factory.generic');
 
         $pass = new MakeServicesPublicPass();
         $pass->process($container);
@@ -55,5 +56,6 @@ class MakeServicesPublicPassTest extends TestCase
         // Aliases
         $this->assertTrue($container->getAlias('database_connection')->isPublic());
         $this->assertTrue($container->getAlias('swiftmailer.mailer')->isPublic());
+        $this->assertTrue($container->getAlias('security.encoder_factory')->isPublic());
     }
 }

--- a/core-bundle/tests/Functional/app/config/security.yml
+++ b/core-bundle/tests/Functional/app/config/security.yml
@@ -8,7 +8,7 @@ security:
 
     encoders:
         Contao\User:
-            algorithm: bcrypt
+            algorithm: auto
 
     firewalls:
         dev:

--- a/manager-bundle/src/Resources/skeleton/app/security.yml
+++ b/manager-bundle/src/Resources/skeleton/app/security.yml
@@ -8,7 +8,7 @@ security:
 
     encoders:
         Contao\User:
-            algorithm: bcrypt
+            algorithm: auto
 
     firewalls:
         dev:

--- a/manager-bundle/tests/ContaoManager/PluginTest.php
+++ b/manager-bundle/tests/ContaoManager/PluginTest.php
@@ -261,7 +261,7 @@ class PluginTest extends ContaoTestCase
         $this->assertSame($expect, $extensionConfig);
     }
 
-    public function testFallsBackToBcryptIfAutoModeIsNotAvailable()
+    public function testFallsBackToBcryptIfAutoModeIsNotAvailable(): void
     {
         if (class_exists(NativePasswordEncoder::class)) {
             $this->markTestSkipped('Cannot test fallback as the auto mode is available.');

--- a/manager-bundle/tests/ContaoManager/PluginTest.php
+++ b/manager-bundle/tests/ContaoManager/PluginTest.php
@@ -17,6 +17,7 @@ use Contao\ManagerPlugin\Bundle\Parser\ParserInterface;
 use Contao\ManagerPlugin\Config\ContainerBuilder as PluginContainerBuilder;
 use Contao\ManagerPlugin\PluginLoader;
 use Contao\TestCase\ContaoTestCase;
+use Contao\User;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\Config\Loader\LoaderResolverInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -264,27 +265,26 @@ class PluginTest extends ContaoTestCase
     public function testFallsBackToBcryptIfAutoModeIsNotAvailable(): void
     {
         if (class_exists(NativePasswordEncoder::class)) {
-            $this->markTestSkipped('Cannot test fallback as the auto mode is available.');
+            $this->markTestSkipped('This test is only relevant for symfony/security <4.3');
         }
 
-        $pluginLoader = $this->createMock(PluginLoader::class);
-        $container = new PluginContainerBuilder($pluginLoader, []);
-
-        $extensionConfigs = [
+        $expect = [
             [
                 'encoders' => [
-                    'Contao\User' => [
-                        'algorithm' => 'auto',
+                    User::class => [
+                        'algorithm' => 'bcrypt',
                     ],
                 ],
             ],
         ];
 
-        $expect = [
+        $container = new PluginContainerBuilder($this->createMock(PluginLoader::class), []);
+
+        $extensionConfigs = [
             [
                 'encoders' => [
-                    'Contao\User' => [
-                        'algorithm' => 'bcrypt',
+                    User::class => [
+                        'algorithm' => 'auto',
                     ],
                 ],
             ],


### PR DESCRIPTION
In Symfony 4.3, a new security encoder named `auto` was introduced. It will choose the best password hashing algorithm based on what Symfony and/or the PHP community decides.

Currently this would mean as of PHP 7.2 if you did compile your PHP using libsodium, you'll have argon2 available. I wanted to make sure my setup benefits from the strongest algorithms available so I've implemented the `auto` configuration by default and it will fall back to the current `bcrypt` configuration in case you are not yet on Symfony 4.3. Of course `auto` may still take `bcrypt` in case your system does not support libsodium.

While implementing I noticed that we still use the password hashing API directly instead of relying on the Symfony components. This means you can configure a different algorithm in the security configuration but it will never work 😄 So I fixed this by replacing all our direct password hashing API calls with the underlying Symfony security components.

BTW: I had to remove the usage of `password_needs_rehash()` to completely rely on the Symfony encoder configured. This means right now you cannot automatically upgrade which is why currently the `SodiumPasswordEncoder` will also verify bcrypt passwords. Symfony will address this in 4.4 so we can (https://github.com/symfony/symfony/pull/31843) completely rely on what Symfony is doing very soon. As of now, there are only `bcrypt` and `argon2` anyway and those will be handled properly.