### PR TITLE
Use annotations to tag services

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -97,7 +97,7 @@
         "symfony/twig-bundle": "4.2.* || 4.3.*",
         "symfony/web-profiler-bundle": "4.2.* || 4.3.*",
         "symfony/yaml": "4.2.* || 4.3.*",
-        "terminal42/service-annotation-bundle": "dev-master",
+        "terminal42/service-annotation-bundle": "^1.0",
         "toflar/psr6-symfony-http-cache-store": "^2.0",
         "true/punycode": "^2.1",
         "twig/twig": "^2.7"

--- a/composer.json
+++ b/composer.json
@@ -97,6 +97,7 @@
         "symfony/twig-bundle": "4.2.* || 4.3.*",
         "symfony/web-profiler-bundle": "4.2.* || 4.3.*",
         "symfony/yaml": "4.2.* || 4.3.*",
+        "terminal42/service-annotation-bundle": "dev-master",
         "toflar/psr6-symfony-http-cache-store": "^2.0",
         "true/punycode": "^2.1",
         "twig/twig": "^2.7"

--- a/core-bundle/composer.json
+++ b/core-bundle/composer.json
@@ -85,7 +85,7 @@
         "symfony/translation": "4.2.* || 4.3.*",
         "symfony/twig-bundle": "4.2.* || 4.3.*",
         "symfony/yaml": "4.2.* || 4.3.*",
-        "terminal42/service-annotation-bundle": "dev-master",
+        "terminal42/service-annotation-bundle": "^1.0",
         "true/punycode": "^2.1",
         "twig/twig": "^2.7"
     },

--- a/core-bundle/composer.json
+++ b/core-bundle/composer.json
@@ -85,6 +85,7 @@
         "symfony/translation": "4.2.* || 4.3.*",
         "symfony/twig-bundle": "4.2.* || 4.3.*",
         "symfony/yaml": "4.2.* || 4.3.*",
+        "terminal42/service-annotation-bundle": "dev-master",
         "true/punycode": "^2.1",
         "twig/twig": "^2.7"
     },

--- a/core-bundle/src/ContaoManager/Plugin.php
+++ b/core-bundle/src/ContaoManager/Plugin.php
@@ -35,6 +35,7 @@ use Symfony\Cmf\Bundle\RoutingBundle\CmfRoutingBundle;
 use Symfony\Component\Config\Loader\LoaderResolverInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\Routing\RouteCollection;
+use Terminal42\ServiceAnnotationBundle\Terminal42ServiceAnnotationBundle;
 
 class Plugin implements BundlePluginInterface, RoutingPluginInterface
 {
@@ -48,6 +49,7 @@ class Plugin implements BundlePluginInterface, RoutingPluginInterface
             BundleConfig::create(KnpTimeBundle::class),
             BundleConfig::create(SchebTwoFactorBundle::class),
             BundleConfig::create(CmfRoutingBundle::class),
+            BundleConfig::create(Terminal42ServiceAnnotationBundle::class),
             BundleConfig::create(ContaoCoreBundle::class)
                 ->setReplace(['core'])
                 ->setLoadAfter(

--- a/core-bundle/src/Controller/AbstractFragmentController.php
+++ b/core-bundle/src/Controller/AbstractFragmentController.php
@@ -21,7 +21,7 @@ use Contao\Template;
 use FOS\HttpCacheBundle\Http\SymfonyResponseTagger;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\DependencyInjection\Container;
-use Terminal42\ServiceAnnotationBundle\Annotation\ServiceAnnotationInterface;
+use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
 abstract class AbstractFragmentController extends AbstractController implements FragmentOptionsAwareInterface, ServiceAnnotationInterface
 {

--- a/core-bundle/src/Controller/AbstractFragmentController.php
+++ b/core-bundle/src/Controller/AbstractFragmentController.php
@@ -21,8 +21,9 @@ use Contao\Template;
 use FOS\HttpCacheBundle\Http\SymfonyResponseTagger;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\DependencyInjection\Container;
+use Terminal42\ServiceAnnotationBundle\Annotation\ServiceAnnotationInterface;
 
-abstract class AbstractFragmentController extends AbstractController implements FragmentOptionsAwareInterface
+abstract class AbstractFragmentController extends AbstractController implements FragmentOptionsAwareInterface, ServiceAnnotationInterface
 {
     /**
      * @var array

--- a/core-bundle/src/ServiceAnnotation/AbstractFragmentAnnotation.php
+++ b/core-bundle/src/ServiceAnnotation/AbstractFragmentAnnotation.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\ServiceAnnotation;
 
+use Doctrine\Common\Annotations\AnnotationException;
 use Terminal42\ServiceAnnotationBundle\Annotation\ServiceTag;
 
 abstract class AbstractFragmentAnnotation extends ServiceTag
@@ -40,6 +41,10 @@ abstract class AbstractFragmentAnnotation extends ServiceTag
     {
         parent::__construct($values);
 
+        if (empty($values['category'])) {
+            throw AnnotationException::typeError('Attribute "category" of @'.static::class.' should not be null.');
+        }
+
         $this->type = $values['type'] ?? null;
         $this->category = $values['category'];
         $this->template = $values['template'] ?? null;
@@ -49,18 +54,19 @@ abstract class AbstractFragmentAnnotation extends ServiceTag
     public function getAttributes(): array
     {
         $attributes = parent::getAttributes();
-        $attributes['category'] = $this->category;
 
         if ($this->type) {
             $attributes['type'] = $this->type;
         }
 
-        if ($this->renderer) {
-            $attributes['renderer'] = $this->renderer;
-        }
+        $attributes['category'] = $this->category;
 
         if ($this->template) {
             $attributes['template'] = $this->template;
+        }
+
+        if ($this->renderer) {
+            $attributes['renderer'] = $this->renderer;
         }
 
         return $attributes;

--- a/core-bundle/src/ServiceAnnotation/AbstractFragmentAnnotation.php
+++ b/core-bundle/src/ServiceAnnotation/AbstractFragmentAnnotation.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\ServiceAnnotation;
+
+use Terminal42\ServiceAnnotationBundle\Annotation\ServiceTag;
+
+abstract class AbstractFragmentAnnotation extends ServiceTag
+{
+    /**
+     * @var string|null
+     */
+    protected $type;
+
+    /**
+     * @var string
+     */
+    protected $category;
+
+    /**
+     * @var string|null
+     */
+    protected $renderer;
+
+    /**
+     * @var string|null
+     */
+    protected $template;
+
+    public function __construct(array $values)
+    {
+        parent::__construct($values);
+
+        $this->type = $values['type'] ?? null;
+        $this->category = $values['category'];
+        $this->template = $values['template'] ?? null;
+        $this->renderer = $values['renderer'] ?? null;
+    }
+
+    public function getAttributes(): array
+    {
+        $attributes = parent::getAttributes();
+        $attributes['category'] = $this->category;
+
+        if ($this->type) {
+            $attributes['type'] = $this->type;
+        }
+
+        if ($this->renderer) {
+            $attributes['renderer'] = $this->renderer;
+        }
+
+        if ($this->template) {
+            $attributes['template'] = $this->template;
+        }
+
+        return $attributes;
+    }
+}

--- a/core-bundle/src/ServiceAnnotation/AbstractFragmentAnnotation.php
+++ b/core-bundle/src/ServiceAnnotation/AbstractFragmentAnnotation.php
@@ -12,63 +12,27 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\ServiceAnnotation;
 
-use Doctrine\Common\Annotations\AnnotationException;
-use Terminal42\ServiceAnnotationBundle\Annotation\ServiceTag;
+use Terminal42\ServiceAnnotationBundle\Annotation\ServiceTagInterface;
 
-abstract class AbstractFragmentAnnotation extends ServiceTag
+abstract class AbstractFragmentAnnotation implements ServiceTagInterface
 {
     /**
-     * @var string|null
+     * @var array
      */
-    protected $type;
+    private $attributes;
 
-    /**
-     * @var string
-     */
-    protected $category;
-
-    /**
-     * @var string|null
-     */
-    protected $renderer;
-
-    /**
-     * @var string|null
-     */
-    protected $template;
-
-    public function __construct(array $values)
+    public function __construct(array $attributes)
     {
-        parent::__construct($values);
-
-        if (empty($values['category'])) {
-            throw AnnotationException::typeError('Attribute "category" of @'.static::class.' should not be null.');
+        if (isset($attributes['value'])) {
+            $attributes['type'] = $attributes['value'];
+            unset($attributes['value']);
         }
 
-        $this->type = $values['type'] ?? null;
-        $this->category = $values['category'];
-        $this->template = $values['template'] ?? null;
-        $this->renderer = $values['renderer'] ?? null;
+        $this->attributes = $attributes;
     }
 
     public function getAttributes(): array
     {
-        $attributes = parent::getAttributes();
-
-        if ($this->type) {
-            $attributes['type'] = $this->type;
-        }
-
-        $attributes['category'] = $this->category;
-
-        if ($this->template) {
-            $attributes['template'] = $this->template;
-        }
-
-        if ($this->renderer) {
-            $attributes['renderer'] = $this->renderer;
-        }
-
-        return $attributes;
+        return $this->attributes;
     }
 }

--- a/core-bundle/src/ServiceAnnotation/Callback.php
+++ b/core-bundle/src/ServiceAnnotation/Callback.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\ServiceAnnotation;
+
+use Doctrine\Common\Annotations\Annotation\Attribute;
+use Doctrine\Common\Annotations\Annotation\Attributes;
+use Doctrine\Common\Annotations\Annotation\Target;
+
+/**
+ * Annotation that can be used to register a DCA callback.
+ *
+ * @Annotation
+ * @Target({"METHOD"})
+ * @Attributes({
+ *     @Attribute("table", type="string", required=true),
+ *     @Attribute("target", type="string", required=true),
+ *     @Attribute("priority", type="int"),
+ * })
+ */
+final class Callback extends AbstractFragmentAnnotation
+{
+    /**
+     * @var string
+     */
+    private $table;
+
+    /**
+     * @var string
+     */
+    private $target;
+
+    /**
+     * @var int|null
+     */
+    private $priority;
+
+    public function __construct(array $values)
+    {
+        parent::__construct($values);
+
+        $this->name = 'contao.callback';
+        $this->table = $values['table'] ?? null;
+        $this->target = $values['target'] ?? null;
+        $this->priority = $values['priority'] ?? null;
+    }
+
+    public function getAttributes(): array
+    {
+        $attributes = parent::getAttributes();
+        $attributes['table'] = $this->table;
+        $attributes['target'] = $this->target;
+
+        if ($this->priority) {
+            $attributes['priority'] = $this->priority;
+        }
+
+        return $attributes;
+    }
+}

--- a/core-bundle/src/ServiceAnnotation/Callback.php
+++ b/core-bundle/src/ServiceAnnotation/Callback.php
@@ -15,6 +15,7 @@ namespace Contao\CoreBundle\ServiceAnnotation;
 use Doctrine\Common\Annotations\Annotation\Attribute;
 use Doctrine\Common\Annotations\Annotation\Attributes;
 use Doctrine\Common\Annotations\Annotation\Target;
+use Doctrine\Common\Annotations\AnnotationException;
 use Terminal42\ServiceAnnotationBundle\Annotation\ServiceTag;
 
 /**
@@ -47,19 +48,28 @@ final class Callback extends ServiceTag
 
     public function __construct(array $values)
     {
-        parent::__construct($values);
+        parent::__construct([]);
+
+        if (empty($values['table'])) {
+            throw AnnotationException::typeError('Attribute "table" of @'.static::class.' should not be null.');
+        }
+
+        if (empty($values['target'])) {
+            throw AnnotationException::typeError('Attribute "target" of @'.static::class.' should not be null.');
+        }
 
         $this->name = 'contao.callback';
-        $this->table = $values['table'] ?? null;
-        $this->target = $values['target'] ?? null;
+        $this->table = $values['table'];
+        $this->target = $values['target'];
         $this->priority = $values['priority'] ?? null;
     }
 
     public function getAttributes(): array
     {
-        $attributes = parent::getAttributes();
-        $attributes['table'] = $this->table;
-        $attributes['target'] = $this->target;
+        $attributes = [
+            'table' => $this->table,
+            'target' => $this->target,
+        ];
 
         if ($this->priority) {
             $attributes['priority'] = $this->priority;

--- a/core-bundle/src/ServiceAnnotation/Callback.php
+++ b/core-bundle/src/ServiceAnnotation/Callback.php
@@ -18,7 +18,7 @@ use Doctrine\Common\Annotations\Annotation\Target;
 use Terminal42\ServiceAnnotationBundle\Annotation\ServiceTagInterface;
 
 /**
- * Annotation that can be used to register a DCA callback.
+ * Annotation to register a DCA callback.
  *
  * @Annotation
  * @Target({"METHOD"})

--- a/core-bundle/src/ServiceAnnotation/Callback.php
+++ b/core-bundle/src/ServiceAnnotation/Callback.php
@@ -15,6 +15,7 @@ namespace Contao\CoreBundle\ServiceAnnotation;
 use Doctrine\Common\Annotations\Annotation\Attribute;
 use Doctrine\Common\Annotations\Annotation\Attributes;
 use Doctrine\Common\Annotations\Annotation\Target;
+use Terminal42\ServiceAnnotationBundle\Annotation\ServiceTag;
 
 /**
  * Annotation that can be used to register a DCA callback.
@@ -27,7 +28,7 @@ use Doctrine\Common\Annotations\Annotation\Target;
  *     @Attribute("priority", type="int"),
  * })
  */
-final class Callback extends AbstractFragmentAnnotation
+final class Callback extends ServiceTag
 {
     /**
      * @var string

--- a/core-bundle/src/ServiceAnnotation/Callback.php
+++ b/core-bundle/src/ServiceAnnotation/Callback.php
@@ -15,8 +15,7 @@ namespace Contao\CoreBundle\ServiceAnnotation;
 use Doctrine\Common\Annotations\Annotation\Attribute;
 use Doctrine\Common\Annotations\Annotation\Attributes;
 use Doctrine\Common\Annotations\Annotation\Target;
-use Doctrine\Common\Annotations\AnnotationException;
-use Terminal42\ServiceAnnotationBundle\Annotation\ServiceTag;
+use Terminal42\ServiceAnnotationBundle\Annotation\ServiceTagInterface;
 
 /**
  * Annotation that can be used to register a DCA callback.
@@ -29,39 +28,26 @@ use Terminal42\ServiceAnnotationBundle\Annotation\ServiceTag;
  *     @Attribute("priority", type="int"),
  * })
  */
-final class Callback extends ServiceTag
+final class Callback implements ServiceTagInterface
 {
     /**
      * @var string
      */
-    private $table;
+    public $table;
 
     /**
      * @var string
      */
-    private $target;
+    public $target;
 
     /**
      * @var int|null
      */
-    private $priority;
+    public $priority;
 
-    public function __construct(array $values)
+    public function getName(): string
     {
-        parent::__construct([]);
-
-        if (empty($values['table'])) {
-            throw AnnotationException::typeError('Attribute "table" of @'.static::class.' should not be null.');
-        }
-
-        if (empty($values['target'])) {
-            throw AnnotationException::typeError('Attribute "target" of @'.static::class.' should not be null.');
-        }
-
-        $this->name = 'contao.callback';
-        $this->table = $values['table'];
-        $this->target = $values['target'];
-        $this->priority = $values['priority'] ?? null;
+        return 'contao.callback';
     }
 
     public function getAttributes(): array

--- a/core-bundle/src/ServiceAnnotation/ContentElement.php
+++ b/core-bundle/src/ServiceAnnotation/ContentElement.php
@@ -18,7 +18,7 @@ use Doctrine\Common\Annotations\Annotation\Attributes;
 use Doctrine\Common\Annotations\Annotation\Target;
 
 /**
- * Annotation that can be used to define controller as a content element.
+ * Annotation to define a controller as content element.
  *
  * @Annotation
  * @Target({"CLASS", "METHOD"})

--- a/core-bundle/src/ServiceAnnotation/ContentElement.php
+++ b/core-bundle/src/ServiceAnnotation/ContentElement.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\ServiceAnnotation;
+
+use Contao\CoreBundle\Fragment\Reference\ContentElementReference;
+use Doctrine\Common\Annotations\Annotation\Attribute;
+use Doctrine\Common\Annotations\Annotation\Attributes;
+use Doctrine\Common\Annotations\Annotation\Target;
+
+/**
+ * Annotation that can be used to define controller as a content element.
+ *
+ * @Annotation
+ * @Target({"CLASS", "METHOD"})
+ * @Attributes({
+ *     @Attribute("type", type = "string"),
+ *     @Attribute("category", required = true, type = "string"),
+ *     @Attribute("template", type = "string"),
+ *     @Attribute("renderer", type = "string"),
+ *     @Attribute("attributes", type = "array"),
+ * })
+ */
+final class ContentElement extends AbstractFragmentAnnotation
+{
+    public function __construct(array $values)
+    {
+        parent::__construct($values);
+
+        $this->name = ContentElementReference::TAG_NAME;
+    }
+}

--- a/core-bundle/src/ServiceAnnotation/ContentElement.php
+++ b/core-bundle/src/ServiceAnnotation/ContentElement.php
@@ -23,7 +23,7 @@ use Doctrine\Common\Annotations\Annotation\Target;
  * @Annotation
  * @Target({"CLASS", "METHOD"})
  * @Attributes({
- *     @Attribute("type", type = "string"),
+ *     @Attribute("value", type = "string"),
  *     @Attribute("category", required = true, type = "string"),
  *     @Attribute("template", type = "string"),
  *     @Attribute("renderer", type = "string"),
@@ -32,10 +32,8 @@ use Doctrine\Common\Annotations\Annotation\Target;
  */
 final class ContentElement extends AbstractFragmentAnnotation
 {
-    public function __construct(array $values)
+    public function getName(): string
     {
-        parent::__construct($values);
-
-        $this->name = ContentElementReference::TAG_NAME;
+        return ContentElementReference::TAG_NAME;
     }
 }

--- a/core-bundle/src/ServiceAnnotation/FrontendModule.php
+++ b/core-bundle/src/ServiceAnnotation/FrontendModule.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\ServiceAnnotation;
+
+use Contao\CoreBundle\Fragment\Reference\FrontendModuleReference;
+use Doctrine\Common\Annotations\Annotation\Attribute;
+use Doctrine\Common\Annotations\Annotation\Attributes;
+use Doctrine\Common\Annotations\Annotation\Target;
+
+/**
+ * Annotation that can be used to define controller as a frontend module.
+ *
+ * @Annotation
+ * @Target({"CLASS", "METHOD"})
+ * @Attributes({
+ *     @Attribute("type", type = "string"),
+ *     @Attribute("category", required = true, type = "string"),
+ *     @Attribute("template", type = "string"),
+ *     @Attribute("renderer", type = "string"),
+ *     @Attribute("attributes", type = "array"),
+ * })
+ */
+final class FrontendModule extends AbstractFragmentAnnotation
+{
+    public function __construct(array $values)
+    {
+        parent::__construct($values);
+
+        $this->name = FrontendModuleReference::TAG_NAME;
+    }
+}

--- a/core-bundle/src/ServiceAnnotation/FrontendModule.php
+++ b/core-bundle/src/ServiceAnnotation/FrontendModule.php
@@ -23,11 +23,11 @@ use Doctrine\Common\Annotations\Annotation\Target;
  * @Annotation
  * @Target({"CLASS", "METHOD"})
  * @Attributes({
- *     @Attribute("type", type = "string"),
- *     @Attribute("category", required = true, type = "string"),
- *     @Attribute("template", type = "string"),
- *     @Attribute("renderer", type = "string"),
- *     @Attribute("attributes", type = "array"),
+ *     @Attribute("type", type="string"),
+ *     @Attribute("category", type="string", required = true),
+ *     @Attribute("template", type="string"),
+ *     @Attribute("renderer", type="string"),
+ *     @Attribute("attributes", type="array"),
  * })
  */
 final class FrontendModule extends AbstractFragmentAnnotation

--- a/core-bundle/src/ServiceAnnotation/FrontendModule.php
+++ b/core-bundle/src/ServiceAnnotation/FrontendModule.php
@@ -18,7 +18,7 @@ use Doctrine\Common\Annotations\Annotation\Attributes;
 use Doctrine\Common\Annotations\Annotation\Target;
 
 /**
- * Annotation that can be used to define controller as a frontend module.
+ * Annotation to define a controller as frontend module.
  *
  * @Annotation
  * @Target({"CLASS", "METHOD"})

--- a/core-bundle/src/ServiceAnnotation/FrontendModule.php
+++ b/core-bundle/src/ServiceAnnotation/FrontendModule.php
@@ -23,19 +23,16 @@ use Doctrine\Common\Annotations\Annotation\Target;
  * @Annotation
  * @Target({"CLASS", "METHOD"})
  * @Attributes({
- *     @Attribute("type", type="string"),
+ *     @Attribute("value", type="string"),
  *     @Attribute("category", type="string", required = true),
  *     @Attribute("template", type="string"),
  *     @Attribute("renderer", type="string"),
- *     @Attribute("attributes", type="array"),
  * })
  */
 final class FrontendModule extends AbstractFragmentAnnotation
 {
-    public function __construct(array $values)
+    public function getName(): string
     {
-        parent::__construct($values);
-
-        $this->name = FrontendModuleReference::TAG_NAME;
+        return FrontendModuleReference::TAG_NAME;
     }
 }

--- a/core-bundle/src/ServiceAnnotation/Hook.php
+++ b/core-bundle/src/ServiceAnnotation/Hook.php
@@ -15,6 +15,7 @@ namespace Contao\CoreBundle\ServiceAnnotation;
 use Doctrine\Common\Annotations\Annotation\Attribute;
 use Doctrine\Common\Annotations\Annotation\Attributes;
 use Doctrine\Common\Annotations\Annotation\Target;
+use Doctrine\Common\Annotations\AnnotationException;
 use Terminal42\ServiceAnnotationBundle\Annotation\ServiceTag;
 
 /**
@@ -41,17 +42,20 @@ final class Hook extends ServiceTag
 
     public function __construct(array $values)
     {
-        parent::__construct($values);
+        parent::__construct([]);
+
+        if (empty($values['hook'])) {
+            throw AnnotationException::typeError('Attribute "hook" of @'.static::class.' should not be null.');
+        }
 
         $this->name = 'contao.hook';
-        $this->hook = $values['hook'] ?? null;
+        $this->hook = $values['hook'];
         $this->priority = $values['priority'] ?? null;
     }
 
     public function getAttributes(): array
     {
-        $attributes = parent::getAttributes();
-        $attributes['hook'] = $this->hook;
+        $attributes = ['hook' => $this->hook];
 
         if ($this->priority) {
             $attributes['priority'] = $this->priority;

--- a/core-bundle/src/ServiceAnnotation/Hook.php
+++ b/core-bundle/src/ServiceAnnotation/Hook.php
@@ -18,7 +18,7 @@ use Doctrine\Common\Annotations\Annotation\Target;
 use Terminal42\ServiceAnnotationBundle\Annotation\ServiceTagInterface;
 
 /**
- * Annotation that can be used to register a Contao hook.
+ * Annotation to register a Contao hook.
  *
  * @Annotation
  * @Target({"METHOD"})

--- a/core-bundle/src/ServiceAnnotation/Hook.php
+++ b/core-bundle/src/ServiceAnnotation/Hook.php
@@ -15,8 +15,7 @@ namespace Contao\CoreBundle\ServiceAnnotation;
 use Doctrine\Common\Annotations\Annotation\Attribute;
 use Doctrine\Common\Annotations\Annotation\Attributes;
 use Doctrine\Common\Annotations\Annotation\Target;
-use Doctrine\Common\Annotations\AnnotationException;
-use Terminal42\ServiceAnnotationBundle\Annotation\ServiceTag;
+use Terminal42\ServiceAnnotationBundle\Annotation\ServiceTagInterface;
 
 /**
  * Annotation that can be used to register a Contao hook.
@@ -24,38 +23,30 @@ use Terminal42\ServiceAnnotationBundle\Annotation\ServiceTag;
  * @Annotation
  * @Target({"METHOD"})
  * @Attributes({
- *     @Attribute("hook", type="string", required=true),
+ *     @Attribute("value", type="string", required=true),
  *     @Attribute("priority", type="int"),
  * })
  */
-final class Hook extends ServiceTag
+final class Hook implements ServiceTagInterface
 {
     /**
      * @var string
      */
-    private $hook;
+    public $value;
 
     /**
      * @var int|null
      */
-    private $priority;
+    public $priority;
 
-    public function __construct(array $values)
+    public function getName(): string
     {
-        parent::__construct([]);
-
-        if (empty($values['hook'])) {
-            throw AnnotationException::typeError('Attribute "hook" of @'.static::class.' should not be null.');
-        }
-
-        $this->name = 'contao.hook';
-        $this->hook = $values['hook'];
-        $this->priority = $values['priority'] ?? null;
+        return 'contao.hook';
     }
 
     public function getAttributes(): array
     {
-        $attributes = ['hook' => $this->hook];
+        $attributes = ['hook' => $this->value];
 
         if ($this->priority) {
             $attributes['priority'] = $this->priority;

--- a/core-bundle/src/ServiceAnnotation/Hook.php
+++ b/core-bundle/src/ServiceAnnotation/Hook.php
@@ -15,6 +15,7 @@ namespace Contao\CoreBundle\ServiceAnnotation;
 use Doctrine\Common\Annotations\Annotation\Attribute;
 use Doctrine\Common\Annotations\Annotation\Attributes;
 use Doctrine\Common\Annotations\Annotation\Target;
+use Terminal42\ServiceAnnotationBundle\Annotation\ServiceTag;
 
 /**
  * Annotation that can be used to register a Contao hook.
@@ -26,7 +27,7 @@ use Doctrine\Common\Annotations\Annotation\Target;
  *     @Attribute("priority", type="int"),
  * })
  */
-final class Hook extends AbstractFragmentAnnotation
+final class Hook extends ServiceTag
 {
     /**
      * @var string

--- a/core-bundle/src/ServiceAnnotation/Hook.php
+++ b/core-bundle/src/ServiceAnnotation/Hook.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\ServiceAnnotation;
+
+use Doctrine\Common\Annotations\Annotation\Attribute;
+use Doctrine\Common\Annotations\Annotation\Attributes;
+use Doctrine\Common\Annotations\Annotation\Target;
+
+/**
+ * Annotation that can be used to register a Contao hook.
+ *
+ * @Annotation
+ * @Target({"METHOD"})
+ * @Attributes({
+ *     @Attribute("hook", type="string", required=true),
+ *     @Attribute("priority", type="int"),
+ * })
+ */
+final class Hook extends AbstractFragmentAnnotation
+{
+    /**
+     * @var string
+     */
+    private $hook;
+
+    /**
+     * @var int|null
+     */
+    private $priority;
+
+    public function __construct(array $values)
+    {
+        parent::__construct($values);
+
+        $this->name = 'contao.hook';
+        $this->hook = $values['hook'] ?? null;
+        $this->priority = $values['priority'] ?? null;
+    }
+
+    public function getAttributes(): array
+    {
+        $attributes = parent::getAttributes();
+        $attributes['hook'] = $this->hook;
+
+        if ($this->priority) {
+            $attributes['priority'] = $this->priority;
+        }
+
+        return $attributes;
+    }
+}

--- a/core-bundle/src/ServiceAnnotation/PickerProvider.php
+++ b/core-bundle/src/ServiceAnnotation/PickerProvider.php
@@ -15,7 +15,7 @@ namespace Contao\CoreBundle\ServiceAnnotation;
 use Doctrine\Common\Annotations\Annotation\Attribute;
 use Doctrine\Common\Annotations\Annotation\Attributes;
 use Doctrine\Common\Annotations\Annotation\Target;
-use Terminal42\ServiceAnnotationBundle\Annotation\ServiceTag;
+use Terminal42\ServiceAnnotationBundle\Annotation\ServiceTagInterface;
 
 /**
  * Annotation that can be used to register a Contao picker.
@@ -26,19 +26,16 @@ use Terminal42\ServiceAnnotationBundle\Annotation\ServiceTag;
  *     @Attribute("priority", type="int"),
  * })
  */
-final class PickerProvider extends ServiceTag
+final class PickerProvider implements ServiceTagInterface
 {
     /**
      * @var int|null
      */
-    private $priority;
+    public $priority;
 
-    public function __construct(array $values)
+    public function getName(): string
     {
-        parent::__construct([]);
-
-        $this->name = 'contao.picker_provider';
-        $this->priority = $values['priority'] ?? null;
+        return 'contao.picker_provider';
     }
 
     public function getAttributes(): array

--- a/core-bundle/src/ServiceAnnotation/PickerProvider.php
+++ b/core-bundle/src/ServiceAnnotation/PickerProvider.php
@@ -18,7 +18,7 @@ use Doctrine\Common\Annotations\Annotation\Target;
 use Terminal42\ServiceAnnotationBundle\Annotation\ServiceTagInterface;
 
 /**
- * Annotation that can be used to register a Contao picker.
+ * Annotation to register a Contao picker.
  *
  * @Annotation
  * @Target({"CLASS"})

--- a/core-bundle/src/ServiceAnnotation/PickerProvider.php
+++ b/core-bundle/src/ServiceAnnotation/PickerProvider.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\ServiceAnnotation;
+
+use Doctrine\Common\Annotations\Annotation\Attribute;
+use Doctrine\Common\Annotations\Annotation\Attributes;
+use Doctrine\Common\Annotations\Annotation\Target;
+use Terminal42\ServiceAnnotationBundle\Annotation\ServiceTag;
+
+/**
+ * Annotation that can be used to register a Contao picker.
+ *
+ * @Annotation
+ * @Target({"CLASS"})
+ * @Attributes({
+ *     @Attribute("priority", type="int"),
+ * })
+ */
+final class PickerProvider extends ServiceTag
+{
+    /**
+     * @var int|null
+     */
+    private $priority;
+
+    public function __construct(array $values)
+    {
+        parent::__construct($values);
+
+        $this->name = 'contao.picker_provider';
+        $this->priority = $values['priority'] ?? null;
+    }
+
+    public function getAttributes(): array
+    {
+        $attributes = parent::getAttributes();
+
+        if ($this->priority) {
+            $attributes['priority'] = $this->priority;
+        }
+
+        return $attributes;
+    }
+}

--- a/core-bundle/src/ServiceAnnotation/PickerProvider.php
+++ b/core-bundle/src/ServiceAnnotation/PickerProvider.php
@@ -35,7 +35,7 @@ final class PickerProvider extends ServiceTag
 
     public function __construct(array $values)
     {
-        parent::__construct($values);
+        parent::__construct([]);
 
         $this->name = 'contao.picker_provider';
         $this->priority = $values['priority'] ?? null;
@@ -43,12 +43,10 @@ final class PickerProvider extends ServiceTag
 
     public function getAttributes(): array
     {
-        $attributes = parent::getAttributes();
-
         if ($this->priority) {
-            $attributes['priority'] = $this->priority;
+            return ['priority' => $this->priority];
         }
 
-        return $attributes;
+        return [];
     }
 }

--- a/core-bundle/tests/ContaoManager/PluginTest.php
+++ b/core-bundle/tests/ContaoManager/PluginTest.php
@@ -35,6 +35,7 @@ use Symfony\Cmf\Bundle\RoutingBundle\CmfRoutingBundle;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\Config\Loader\LoaderResolverInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
+use Terminal42\ServiceAnnotationBundle\Terminal42ServiceAnnotationBundle;
 
 class PluginTest extends TestCase
 {
@@ -45,7 +46,7 @@ class PluginTest extends TestCase
         /** @var BundleConfig[]|array $bundles */
         $bundles = $plugin->getBundles(new DelegatingParser());
 
-        $this->assertCount(5, $bundles);
+        $this->assertCount(6, $bundles);
 
         $this->assertSame(KnpMenuBundle::class, $bundles[0]->getName());
         $this->assertSame([], $bundles[0]->getReplace());
@@ -63,8 +64,12 @@ class PluginTest extends TestCase
         $this->assertSame([], $bundles[3]->getReplace());
         $this->assertSame([], $bundles[3]->getLoadAfter());
 
-        $this->assertSame(ContaoCoreBundle::class, $bundles[4]->getName());
-        $this->assertSame(['core'], $bundles[4]->getReplace());
+        $this->assertSame(Terminal42ServiceAnnotationBundle::class, $bundles[4]->getName());
+        $this->assertSame([], $bundles[4]->getReplace());
+        $this->assertSame([], $bundles[4]->getLoadAfter());
+
+        $this->assertSame(ContaoCoreBundle::class, $bundles[5]->getName());
+        $this->assertSame(['core'], $bundles[5]->getReplace());
 
         $this->assertSame(
             [
@@ -84,7 +89,7 @@ class PluginTest extends TestCase
                 CmfRoutingBundle::class,
                 ContaoManagerBundle::class,
             ],
-            $bundles[4]->getLoadAfter()
+            $bundles[5]->getLoadAfter()
         );
     }
 

--- a/core-bundle/tests/ServiceAnnotation/CallbackTest.php
+++ b/core-bundle/tests/ServiceAnnotation/CallbackTest.php
@@ -33,10 +33,13 @@ class CallbackTest extends TestCase
         $annotation->target = 'foo.bar';
         $annotation->priority = 17;
 
-        $this->assertSame(['table' => 'tl_foobar', 'target' => 'foo.bar', 'priority' => 17], $annotation->getAttributes());
+        $this->assertSame(
+            ['table' => 'tl_foobar', 'target' => 'foo.bar', 'priority' => 17],
+            $annotation->getAttributes()
+        );
     }
 
-    public function testDoesNotReturnPriorityIfNotSet(): void
+    public function testDoesNotReturnThePriorityIfNotSet(): void
     {
         $annotation = new Callback();
         $annotation->table = 'tl_foobar';

--- a/core-bundle/tests/ServiceAnnotation/CallbackTest.php
+++ b/core-bundle/tests/ServiceAnnotation/CallbackTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\ServiceAnnotation;
+
+use Contao\CoreBundle\ServiceAnnotation\Callback;
+use Doctrine\Common\Annotations\AnnotationException;
+use PHPUnit\Framework\TestCase;
+
+class CallbackTest extends TestCase
+{
+    public function testReturnsTheTagName(): void
+    {
+        $annotation = new Callback(['table' => 'tl_foobar', 'target' => 'foo.bar']);
+
+        $this->assertSame('contao.callback', $annotation->getName());
+    }
+
+    public function testTheNameCannotBeSet(): void
+    {
+        $annotation = new Callback(['name' => 'foobar', 'table' => 'tl_foobar', 'target' => 'foo.bar']);
+
+        $this->assertSame('contao.callback', $annotation->getName());
+    }
+
+    public function testReturnsTheArguments(): void
+    {
+        $annotation = new Callback(['table' => 'tl_foobar', 'target' => 'foo.bar', 'priority' => 17]);
+
+        $this->assertSame(['table' => 'tl_foobar', 'target' => 'foo.bar', 'priority' => 17], $annotation->getAttributes());
+    }
+
+    public function testDoesNotReturnPriorityIfNotSet(): void
+    {
+        $annotation = new Callback(['table' => 'tl_foobar', 'target' => 'foo.bar']);
+
+        $this->assertSame(['table' => 'tl_foobar', 'target' => 'foo.bar'], $annotation->getAttributes());
+    }
+
+    public function testIgnoresUnknownAttributes(): void
+    {
+        $annotation = new Callback(['table' => 'tl_foobar', 'target' => 'foo.bar', 'foo' => 'bar']);
+
+        $this->assertSame(['table' => 'tl_foobar', 'target' => 'foo.bar'], $annotation->getAttributes());
+    }
+
+    public function testThrowsExceptionIfTheTableAttributeIsNotSet(): void
+    {
+        $this->expectException(AnnotationException::class);
+        $this->expectExceptionMessage('[Type Error] Attribute "table" of @Contao\CoreBundle\ServiceAnnotation\Callback should not be null.');
+
+        new Callback([]);
+    }
+
+    public function testThrowsExceptionIfTheTargetAttributeIsNotSet(): void
+    {
+        $this->expectException(AnnotationException::class);
+        $this->expectExceptionMessage('[Type Error] Attribute "target" of @Contao\CoreBundle\ServiceAnnotation\Callback should not be null.');
+
+        new Callback(['table' => 'tl_foobar']);
+    }
+}

--- a/core-bundle/tests/ServiceAnnotation/CallbackTest.php
+++ b/core-bundle/tests/ServiceAnnotation/CallbackTest.php
@@ -13,59 +13,35 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Tests\ServiceAnnotation;
 
 use Contao\CoreBundle\ServiceAnnotation\Callback;
-use Doctrine\Common\Annotations\AnnotationException;
 use PHPUnit\Framework\TestCase;
 
 class CallbackTest extends TestCase
 {
     public function testReturnsTheTagName(): void
     {
-        $annotation = new Callback(['table' => 'tl_foobar', 'target' => 'foo.bar']);
-
-        $this->assertSame('contao.callback', $annotation->getName());
-    }
-
-    public function testTheNameCannotBeSet(): void
-    {
-        $annotation = new Callback(['name' => 'foobar', 'table' => 'tl_foobar', 'target' => 'foo.bar']);
+        $annotation = new Callback();
+        $annotation->table = 'tl_foobar';
+        $annotation->target = 'foo.bar';
 
         $this->assertSame('contao.callback', $annotation->getName());
     }
 
     public function testReturnsTheArguments(): void
     {
-        $annotation = new Callback(['table' => 'tl_foobar', 'target' => 'foo.bar', 'priority' => 17]);
+        $annotation = new Callback();
+        $annotation->table = 'tl_foobar';
+        $annotation->target = 'foo.bar';
+        $annotation->priority = 17;
 
         $this->assertSame(['table' => 'tl_foobar', 'target' => 'foo.bar', 'priority' => 17], $annotation->getAttributes());
     }
 
     public function testDoesNotReturnPriorityIfNotSet(): void
     {
-        $annotation = new Callback(['table' => 'tl_foobar', 'target' => 'foo.bar']);
+        $annotation = new Callback();
+        $annotation->table = 'tl_foobar';
+        $annotation->target = 'foo.bar';
 
         $this->assertSame(['table' => 'tl_foobar', 'target' => 'foo.bar'], $annotation->getAttributes());
-    }
-
-    public function testIgnoresUnknownAttributes(): void
-    {
-        $annotation = new Callback(['table' => 'tl_foobar', 'target' => 'foo.bar', 'foo' => 'bar']);
-
-        $this->assertSame(['table' => 'tl_foobar', 'target' => 'foo.bar'], $annotation->getAttributes());
-    }
-
-    public function testThrowsExceptionIfTheTableAttributeIsNotSet(): void
-    {
-        $this->expectException(AnnotationException::class);
-        $this->expectExceptionMessage('[Type Error] Attribute "table" of @Contao\CoreBundle\ServiceAnnotation\Callback should not be null.');
-
-        new Callback([]);
-    }
-
-    public function testThrowsExceptionIfTheTargetAttributeIsNotSet(): void
-    {
-        $this->expectException(AnnotationException::class);
-        $this->expectExceptionMessage('[Type Error] Attribute "target" of @Contao\CoreBundle\ServiceAnnotation\Callback should not be null.');
-
-        new Callback(['table' => 'tl_foobar']);
     }
 }

--- a/core-bundle/tests/ServiceAnnotation/ContentElementTest.php
+++ b/core-bundle/tests/ServiceAnnotation/ContentElementTest.php
@@ -14,7 +14,6 @@ namespace Contao\CoreBundle\Tests\ServiceAnnotation;
 
 use Contao\CoreBundle\Fragment\Reference\ContentElementReference;
 use Contao\CoreBundle\ServiceAnnotation\ContentElement;
-use Doctrine\Common\Annotations\AnnotationException;
 use PHPUnit\Framework\TestCase;
 
 class ContentElementTest extends TestCase
@@ -26,16 +25,9 @@ class ContentElementTest extends TestCase
         $this->assertSame(ContentElementReference::TAG_NAME, $annotation->getName());
     }
 
-    public function testTheNameCannotBeSet(): void
-    {
-        $annotation = new ContentElement(['category' => 'foobar', 'name' => 'foobar']);
-
-        $this->assertSame(ContentElementReference::TAG_NAME, $annotation->getName());
-    }
-
     public function testReturnsTheArguments(): void
     {
-        $annotation = new ContentElement(['type' => 'foobar', 'category' => 'foobar', 'template' => 'mod_foobar', 'renderer' => 'esi']);
+        $annotation = new ContentElement(['value' => 'foobar', 'category' => 'foobar', 'template' => 'mod_foobar', 'renderer' => 'esi']);
 
         $this->assertSame(['type' => 'foobar', 'category' => 'foobar', 'template' => 'mod_foobar', 'renderer' => 'esi'], $annotation->getAttributes());
     }
@@ -47,25 +39,10 @@ class ContentElementTest extends TestCase
         $this->assertSame(['category' => 'foobar'], $annotation->getAttributes());
     }
 
-    public function testIgnoresUnknownAttributes(): void
+    public function testReturnsAdditionalAttributes(): void
     {
         $annotation = new ContentElement(['category' => 'foobar', 'foo' => 'bar']);
 
-        $this->assertSame(['category' => 'foobar'], $annotation->getAttributes());
-    }
-
-    public function testReturnsAdditionalAttributes(): void
-    {
-        $annotation = new ContentElement(['category' => 'foobar', 'attributes' => ['foo' => 'bar']]);
-
-        $this->assertSame(['foo' => 'bar', 'category' => 'foobar'], $annotation->getAttributes());
-    }
-
-    public function testThrowsExceptionIfTheTableAttributeIsNotSet(): void
-    {
-        $this->expectException(AnnotationException::class);
-        $this->expectExceptionMessage('[Type Error] Attribute "category" of @Contao\CoreBundle\ServiceAnnotation\ContentElement should not be null.');
-
-        new ContentElement([]);
+        $this->assertSame(['category' => 'foobar', 'foo' => 'bar'], $annotation->getAttributes());
     }
 }

--- a/core-bundle/tests/ServiceAnnotation/ContentElementTest.php
+++ b/core-bundle/tests/ServiceAnnotation/ContentElementTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\ServiceAnnotation;
+
+use Contao\CoreBundle\Fragment\Reference\ContentElementReference;
+use Contao\CoreBundle\ServiceAnnotation\ContentElement;
+use Doctrine\Common\Annotations\AnnotationException;
+use PHPUnit\Framework\TestCase;
+
+class ContentElementTest extends TestCase
+{
+    public function testReturnsTheTagName(): void
+    {
+        $annotation = new ContentElement(['category' => 'foobar']);
+
+        $this->assertSame(ContentElementReference::TAG_NAME, $annotation->getName());
+    }
+
+    public function testTheNameCannotBeSet(): void
+    {
+        $annotation = new ContentElement(['category' => 'foobar', 'name' => 'foobar']);
+
+        $this->assertSame(ContentElementReference::TAG_NAME, $annotation->getName());
+    }
+
+    public function testReturnsTheArguments(): void
+    {
+        $annotation = new ContentElement(['type' => 'foobar', 'category' => 'foobar', 'template' => 'mod_foobar', 'renderer' => 'esi']);
+
+        $this->assertSame(['type' => 'foobar', 'category' => 'foobar', 'template' => 'mod_foobar', 'renderer' => 'esi'], $annotation->getAttributes());
+    }
+
+    public function testDoesNotReturnOptionalArguments(): void
+    {
+        $annotation = new ContentElement(['category' => 'foobar']);
+
+        $this->assertSame(['category' => 'foobar'], $annotation->getAttributes());
+    }
+
+    public function testIgnoresUnknownAttributes(): void
+    {
+        $annotation = new ContentElement(['category' => 'foobar', 'foo' => 'bar']);
+
+        $this->assertSame(['category' => 'foobar'], $annotation->getAttributes());
+    }
+
+    public function testReturnsAdditionalAttributes(): void
+    {
+        $annotation = new ContentElement(['category' => 'foobar', 'attributes' => ['foo' => 'bar']]);
+
+        $this->assertSame(['foo' => 'bar', 'category' => 'foobar'], $annotation->getAttributes());
+    }
+
+    public function testThrowsExceptionIfTheTableAttributeIsNotSet(): void
+    {
+        $this->expectException(AnnotationException::class);
+        $this->expectExceptionMessage('[Type Error] Attribute "category" of @Contao\CoreBundle\ServiceAnnotation\ContentElement should not be null.');
+
+        new ContentElement([]);
+    }
+}

--- a/core-bundle/tests/ServiceAnnotation/ContentElementTest.php
+++ b/core-bundle/tests/ServiceAnnotation/ContentElementTest.php
@@ -36,10 +36,10 @@ class ContentElementTest extends TestCase
 
         $this->assertSame(
             [
-                'type' => 'foobar',
                 'category' => 'foobar',
                 'template' => 'mod_foobar',
                 'renderer' => 'esi',
+                'type' => 'foobar',
             ],
             $annotation->getAttributes()
         );

--- a/core-bundle/tests/ServiceAnnotation/ContentElementTest.php
+++ b/core-bundle/tests/ServiceAnnotation/ContentElementTest.php
@@ -27,9 +27,22 @@ class ContentElementTest extends TestCase
 
     public function testReturnsTheArguments(): void
     {
-        $annotation = new ContentElement(['value' => 'foobar', 'category' => 'foobar', 'template' => 'mod_foobar', 'renderer' => 'esi']);
+        $annotation = new ContentElement([
+            'value' => 'foobar',
+            'category' => 'foobar',
+            'template' => 'mod_foobar',
+            'renderer' => 'esi',
+        ]);
 
-        $this->assertSame(['type' => 'foobar', 'category' => 'foobar', 'template' => 'mod_foobar', 'renderer' => 'esi'], $annotation->getAttributes());
+        $this->assertSame(
+            [
+                'type' => 'foobar',
+                'category' => 'foobar',
+                'template' => 'mod_foobar',
+                'renderer' => 'esi',
+            ],
+            $annotation->getAttributes()
+        );
     }
 
     public function testDoesNotReturnOptionalArguments(): void

--- a/core-bundle/tests/ServiceAnnotation/FrontendModuleTest.php
+++ b/core-bundle/tests/ServiceAnnotation/FrontendModuleTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\ServiceAnnotation;
+
+use Contao\CoreBundle\Fragment\Reference\FrontendModuleReference;
+use Contao\CoreBundle\ServiceAnnotation\FrontendModule;
+use Doctrine\Common\Annotations\AnnotationException;
+use PHPUnit\Framework\TestCase;
+
+class FrontendModuleTest extends TestCase
+{
+    public function testReturnsTheTagName(): void
+    {
+        $annotation = new FrontendModule(['category' => 'foobar']);
+
+        $this->assertSame(FrontendModuleReference::TAG_NAME, $annotation->getName());
+    }
+
+    public function testTheNameCannotBeSet(): void
+    {
+        $annotation = new FrontendModule(['category' => 'foobar', 'name' => 'foobar']);
+
+        $this->assertSame(FrontendModuleReference::TAG_NAME, $annotation->getName());
+    }
+
+    public function testReturnsTheArguments(): void
+    {
+        $annotation = new FrontendModule(['type' => 'foobar', 'category' => 'foobar', 'template' => 'mod_foobar', 'renderer' => 'esi']);
+
+        $this->assertSame(['type' => 'foobar', 'category' => 'foobar', 'template' => 'mod_foobar', 'renderer' => 'esi'], $annotation->getAttributes());
+    }
+
+    public function testDoesNotReturnOptionalArguments(): void
+    {
+        $annotation = new FrontendModule(['category' => 'foobar']);
+
+        $this->assertSame(['category' => 'foobar'], $annotation->getAttributes());
+    }
+
+    public function testIgnoresUnknownAttributes(): void
+    {
+        $annotation = new FrontendModule(['category' => 'foobar', 'foo' => 'bar']);
+
+        $this->assertSame(['category' => 'foobar'], $annotation->getAttributes());
+    }
+
+    public function testReturnsAdditionalAttributes(): void
+    {
+        $annotation = new FrontendModule(['category' => 'foobar', 'attributes' => ['foo' => 'bar']]);
+
+        $this->assertSame(['foo' => 'bar', 'category' => 'foobar'], $annotation->getAttributes());
+    }
+
+    public function testThrowsExceptionIfTheTableAttributeIsNotSet(): void
+    {
+        $this->expectException(AnnotationException::class);
+        $this->expectExceptionMessage('[Type Error] Attribute "category" of @Contao\CoreBundle\ServiceAnnotation\FrontendModule should not be null.');
+
+        new FrontendModule([]);
+    }
+}

--- a/core-bundle/tests/ServiceAnnotation/FrontendModuleTest.php
+++ b/core-bundle/tests/ServiceAnnotation/FrontendModuleTest.php
@@ -36,10 +36,10 @@ class FrontendModuleTest extends TestCase
 
         $this->assertSame(
             [
-                'type' => 'foobar',
                 'category' => 'foobar',
                 'template' => 'mod_foobar',
                 'renderer' => 'esi',
+                'type' => 'foobar',
             ],
             $annotation->getAttributes()
         );

--- a/core-bundle/tests/ServiceAnnotation/FrontendModuleTest.php
+++ b/core-bundle/tests/ServiceAnnotation/FrontendModuleTest.php
@@ -27,9 +27,22 @@ class FrontendModuleTest extends TestCase
 
     public function testReturnsTheArguments(): void
     {
-        $annotation = new FrontendModule(['value' => 'foobar', 'category' => 'foobar', 'template' => 'mod_foobar', 'renderer' => 'esi']);
+        $annotation = new FrontendModule([
+            'value' => 'foobar',
+            'category' => 'foobar',
+            'template' => 'mod_foobar',
+            'renderer' => 'esi',
+        ]);
 
-        $this->assertSame(['type' => 'foobar', 'category' => 'foobar', 'template' => 'mod_foobar', 'renderer' => 'esi'], $annotation->getAttributes());
+        $this->assertSame(
+            [
+                'type' => 'foobar',
+                'category' => 'foobar',
+                'template' => 'mod_foobar',
+                'renderer' => 'esi',
+            ],
+            $annotation->getAttributes()
+        );
     }
 
     public function testDoesNotReturnOptionalArguments(): void

--- a/core-bundle/tests/ServiceAnnotation/FrontendModuleTest.php
+++ b/core-bundle/tests/ServiceAnnotation/FrontendModuleTest.php
@@ -14,7 +14,6 @@ namespace Contao\CoreBundle\Tests\ServiceAnnotation;
 
 use Contao\CoreBundle\Fragment\Reference\FrontendModuleReference;
 use Contao\CoreBundle\ServiceAnnotation\FrontendModule;
-use Doctrine\Common\Annotations\AnnotationException;
 use PHPUnit\Framework\TestCase;
 
 class FrontendModuleTest extends TestCase
@@ -26,16 +25,9 @@ class FrontendModuleTest extends TestCase
         $this->assertSame(FrontendModuleReference::TAG_NAME, $annotation->getName());
     }
 
-    public function testTheNameCannotBeSet(): void
-    {
-        $annotation = new FrontendModule(['category' => 'foobar', 'name' => 'foobar']);
-
-        $this->assertSame(FrontendModuleReference::TAG_NAME, $annotation->getName());
-    }
-
     public function testReturnsTheArguments(): void
     {
-        $annotation = new FrontendModule(['type' => 'foobar', 'category' => 'foobar', 'template' => 'mod_foobar', 'renderer' => 'esi']);
+        $annotation = new FrontendModule(['value' => 'foobar', 'category' => 'foobar', 'template' => 'mod_foobar', 'renderer' => 'esi']);
 
         $this->assertSame(['type' => 'foobar', 'category' => 'foobar', 'template' => 'mod_foobar', 'renderer' => 'esi'], $annotation->getAttributes());
     }
@@ -47,25 +39,10 @@ class FrontendModuleTest extends TestCase
         $this->assertSame(['category' => 'foobar'], $annotation->getAttributes());
     }
 
-    public function testIgnoresUnknownAttributes(): void
+    public function testReturnsAdditionalAttributes(): void
     {
         $annotation = new FrontendModule(['category' => 'foobar', 'foo' => 'bar']);
 
-        $this->assertSame(['category' => 'foobar'], $annotation->getAttributes());
-    }
-
-    public function testReturnsAdditionalAttributes(): void
-    {
-        $annotation = new FrontendModule(['category' => 'foobar', 'attributes' => ['foo' => 'bar']]);
-
-        $this->assertSame(['foo' => 'bar', 'category' => 'foobar'], $annotation->getAttributes());
-    }
-
-    public function testThrowsExceptionIfTheTableAttributeIsNotSet(): void
-    {
-        $this->expectException(AnnotationException::class);
-        $this->expectExceptionMessage('[Type Error] Attribute "category" of @Contao\CoreBundle\ServiceAnnotation\FrontendModule should not be null.');
-
-        new FrontendModule([]);
+        $this->assertSame(['category' => 'foobar', 'foo' => 'bar'], $annotation->getAttributes());
     }
 }

--- a/core-bundle/tests/ServiceAnnotation/HookTest.php
+++ b/core-bundle/tests/ServiceAnnotation/HookTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\ServiceAnnotation;
+
+use Contao\CoreBundle\ServiceAnnotation\Hook;
+use Doctrine\Common\Annotations\AnnotationException;
+use PHPUnit\Framework\TestCase;
+
+class HookTest extends TestCase
+{
+    public function testReturnsTheTagName(): void
+    {
+        $annotation = new Hook(['hook' => 'foobar']);
+
+        $this->assertSame('contao.hook', $annotation->getName());
+    }
+
+    public function testTheNameCannotBeSet(): void
+    {
+        $annotation = new Hook(['name' => 'foobar', 'hook' => 'foobar']);
+
+        $this->assertSame('contao.hook', $annotation->getName());
+    }
+
+    public function testReturnsTheArguments(): void
+    {
+        $annotation = new Hook(['hook' => 'foobar', 'priority' => 17]);
+
+        $this->assertSame(['hook' => 'foobar', 'priority' => 17], $annotation->getAttributes());
+    }
+
+    public function testDoesNotReturnPriorityIfNotSet(): void
+    {
+        $annotation = new Hook(['hook' => 'foobar']);
+
+        $this->assertSame(['hook' => 'foobar'], $annotation->getAttributes());
+    }
+
+    public function testIgnoresUnknownAttributes(): void
+    {
+        $annotation = new Hook(['hook' => 'foobar', 'foo' => 'bar']);
+
+        $this->assertSame(['hook' => 'foobar'], $annotation->getAttributes());
+    }
+
+    public function testThrowsExceptionIfTheHookAttributeIsNotSet(): void
+    {
+        $this->expectException(AnnotationException::class);
+        $this->expectExceptionMessage('[Type Error] Attribute "hook" of @Contao\CoreBundle\ServiceAnnotation\Hook should not be null.');
+
+        new Hook([]);
+    }
+}

--- a/core-bundle/tests/ServiceAnnotation/HookTest.php
+++ b/core-bundle/tests/ServiceAnnotation/HookTest.php
@@ -33,7 +33,7 @@ class HookTest extends TestCase
         $this->assertSame(['hook' => 'foobar', 'priority' => 17], $annotation->getAttributes());
     }
 
-    public function testDoesNotReturnPriorityIfNotSet(): void
+    public function testDoesNotReturnThePriorityIfNotSet(): void
     {
         $annotation = new Hook();
         $annotation->value = 'foobar';

--- a/core-bundle/tests/ServiceAnnotation/HookTest.php
+++ b/core-bundle/tests/ServiceAnnotation/HookTest.php
@@ -13,51 +13,31 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Tests\ServiceAnnotation;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
-use Doctrine\Common\Annotations\AnnotationException;
 use PHPUnit\Framework\TestCase;
 
 class HookTest extends TestCase
 {
     public function testReturnsTheTagName(): void
     {
-        $annotation = new Hook(['hook' => 'foobar']);
-
-        $this->assertSame('contao.hook', $annotation->getName());
-    }
-
-    public function testTheNameCannotBeSet(): void
-    {
-        $annotation = new Hook(['name' => 'foobar', 'hook' => 'foobar']);
+        $annotation = new Hook();
 
         $this->assertSame('contao.hook', $annotation->getName());
     }
 
     public function testReturnsTheArguments(): void
     {
-        $annotation = new Hook(['hook' => 'foobar', 'priority' => 17]);
+        $annotation = new Hook();
+        $annotation->value = 'foobar';
+        $annotation->priority = 17;
 
         $this->assertSame(['hook' => 'foobar', 'priority' => 17], $annotation->getAttributes());
     }
 
     public function testDoesNotReturnPriorityIfNotSet(): void
     {
-        $annotation = new Hook(['hook' => 'foobar']);
+        $annotation = new Hook();
+        $annotation->value = 'foobar';
 
         $this->assertSame(['hook' => 'foobar'], $annotation->getAttributes());
-    }
-
-    public function testIgnoresUnknownAttributes(): void
-    {
-        $annotation = new Hook(['hook' => 'foobar', 'foo' => 'bar']);
-
-        $this->assertSame(['hook' => 'foobar'], $annotation->getAttributes());
-    }
-
-    public function testThrowsExceptionIfTheHookAttributeIsNotSet(): void
-    {
-        $this->expectException(AnnotationException::class);
-        $this->expectExceptionMessage('[Type Error] Attribute "hook" of @Contao\CoreBundle\ServiceAnnotation\Hook should not be null.');
-
-        new Hook([]);
     }
 }

--- a/core-bundle/tests/ServiceAnnotation/PickerProviderTest.php
+++ b/core-bundle/tests/ServiceAnnotation/PickerProviderTest.php
@@ -19,36 +19,23 @@ class PickerProviderTest extends TestCase
 {
     public function testReturnsTheTagName(): void
     {
-        $annotation = new PickerProvider([]);
-
-        $this->assertSame('contao.picker_provider', $annotation->getName());
-    }
-
-    public function testTheNameCannotBeSet(): void
-    {
-        $annotation = new PickerProvider(['name' => 'foobar']);
+        $annotation = new PickerProvider();
 
         $this->assertSame('contao.picker_provider', $annotation->getName());
     }
 
     public function testReturnsTheArguments(): void
     {
-        $annotation = new PickerProvider(['priority' => 17]);
+        $annotation = new PickerProvider();
+        $annotation->priority = 17;
 
         $this->assertSame(['priority' => 17], $annotation->getAttributes());
     }
 
     public function testDoesNotReturnPriorityIfNotSet(): void
     {
-        $annotation = new PickerProvider([]);
+        $annotation = new PickerProvider();
 
         $this->assertSame([], $annotation->getAttributes());
-    }
-
-    public function testIgnoresUnknownAttributes(): void
-    {
-        $annotation = new PickerProvider(['priority' => 17, 'foo' => 'bar']);
-
-        $this->assertSame(['priority' => 17], $annotation->getAttributes());
     }
 }

--- a/core-bundle/tests/ServiceAnnotation/PickerProviderTest.php
+++ b/core-bundle/tests/ServiceAnnotation/PickerProviderTest.php
@@ -32,7 +32,7 @@ class PickerProviderTest extends TestCase
         $this->assertSame(['priority' => 17], $annotation->getAttributes());
     }
 
-    public function testDoesNotReturnPriorityIfNotSet(): void
+    public function testDoesNotReturnThePriorityIfNotSet(): void
     {
         $annotation = new PickerProvider();
 

--- a/core-bundle/tests/ServiceAnnotation/PickerProviderTest.php
+++ b/core-bundle/tests/ServiceAnnotation/PickerProviderTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\ServiceAnnotation;
+
+use Contao\CoreBundle\ServiceAnnotation\PickerProvider;
+use PHPUnit\Framework\TestCase;
+
+class PickerProviderTest extends TestCase
+{
+    public function testReturnsTheTagName(): void
+    {
+        $annotation = new PickerProvider([]);
+
+        $this->assertSame('contao.picker_provider', $annotation->getName());
+    }
+
+    public function testTheNameCannotBeSet(): void
+    {
+        $annotation = new PickerProvider(['name' => 'foobar']);
+
+        $this->assertSame('contao.picker_provider', $annotation->getName());
+    }
+
+    public function testReturnsTheArguments(): void
+    {
+        $annotation = new PickerProvider(['priority' => 17]);
+
+        $this->assertSame(['priority' => 17], $annotation->getAttributes());
+    }
+
+    public function testDoesNotReturnPriorityIfNotSet(): void
+    {
+        $annotation = new PickerProvider([]);
+
+        $this->assertSame([], $annotation->getAttributes());
+    }
+
+    public function testIgnoresUnknownAttributes(): void
+    {
+        $annotation = new PickerProvider(['priority' => 17, 'foo' => 'bar']);
+
+        $this->assertSame(['priority' => 17], $annotation->getAttributes());
+    }
+}


### PR DESCRIPTION
This is the successor of https://github.com/contao/contao/pull/526

As discussed, the `terminal42/service-annotation-bundle` allows any service to use annotations to define tags. In Contao, we can use this and extend it for our own tags, providing specific annotations.

```php
use Contao\CoreBundle\ServiceAnnotation\FrontendModule;

/**
 * @FrontendModule(category="miscellaneous")
 */
class FoobarController extends AbstractFrontendModuleController
{
    public function getResponse()
    {
    }
}
```

Contrary to #526, we don't explicitly parse fragments, but simply add tags to the service container which will then again be read by later compiler passes.

*TODO:*
 - [x] Support hooks and callbacks
 - [x] Better docs
 - [x] Release 1.0 of `terminal42/service-annotation-bundle`
 - [x] Unit Tests
