### PR TITLE
Track profiler messages in the Contao translator

### DIFF
--- a/core-bundle/src/ContaoCoreBundle.php
+++ b/core-bundle/src/ContaoCoreBundle.php
@@ -23,6 +23,7 @@ use Contao\CoreBundle\DependencyInjection\Compiler\PickerProviderPass;
 use Contao\CoreBundle\DependencyInjection\Compiler\RegisterFragmentsPass;
 use Contao\CoreBundle\DependencyInjection\Compiler\RegisterHookListenersPass;
 use Contao\CoreBundle\DependencyInjection\Compiler\RemembermeServicesPass;
+use Contao\CoreBundle\DependencyInjection\Compiler\TranslationDataCollectorPass;
 use Contao\CoreBundle\DependencyInjection\ContaoCoreExtension;
 use Contao\CoreBundle\DependencyInjection\Security\ContaoLoginFactory;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\SecurityExtension;
@@ -75,6 +76,7 @@ class ContaoCoreBundle extends Bundle
         $container->addCompilerPass(new RemembermeServicesPass('contao_frontend'));
         $container->addCompilerPass(new MapFragmentsToGlobalsPass());
         $container->addCompilerPass(new DataContainerCallbackPass());
+        $container->addCompilerPass(new TranslationDataCollectorPass());
         $container->addCompilerPass(new RegisterHookListenersPass(), PassConfig::TYPE_OPTIMIZE);
     }
 }

--- a/core-bundle/src/DependencyInjection/Compiler/TranslationDataCollectorPass.php
+++ b/core-bundle/src/DependencyInjection/Compiler/TranslationDataCollectorPass.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+class TranslationDataCollectorPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$container->hasDefinition('translator.data_collector')) {
+            return;
+        }
+
+        $definition = $container->getDefinition('contao.translation.translator.data_collector');
+        $definition->setDecoratedService('translator');
+
+        $definition = $container->getDefinition('data_collector.translation');
+        $definition->replaceArgument(0, new Reference('contao.translation.translator.data_collector'));
+    }
+}

--- a/core-bundle/src/Resources/config/services.yml
+++ b/core-bundle/src/Resources/config/services.yml
@@ -620,6 +620,11 @@ services:
             - '@contao.translation.translator.inner'
             - '@contao.framework'
 
+    contao.translation.translator.data_collector:
+        class: Contao\CoreBundle\Translation\DataCollectorTranslator
+        arguments:
+            - '@contao.translation.translator.data_collector.inner'
+
     contao.twig.template_extension:
         class: Contao\CoreBundle\Twig\Extension\ContaoTemplateExtension
         arguments:

--- a/core-bundle/src/Translation/DataCollectorTranslator.php
+++ b/core-bundle/src/Translation/DataCollectorTranslator.php
@@ -21,7 +21,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 class DataCollectorTranslator extends SymfonyDataCollectorTranslator
 {
     /**
-     * @var TranslatorInterface|TranslatorBagInterface|LegacyTranslatorInterface
+     * @var TranslatorInterface&TranslatorBagInterface&LegacyTranslatorInterface
      */
     private $translator;
 

--- a/core-bundle/src/Translation/DataCollectorTranslator.php
+++ b/core-bundle/src/Translation/DataCollectorTranslator.php
@@ -25,6 +25,9 @@ class DataCollectorTranslator extends SymfonyDataCollectorTranslator
 
     private $messages = [];
 
+    /**
+     * @param TranslatorInterface $translator
+     */
     public function __construct($translator)
     {
         parent::__construct($translator);
@@ -35,9 +38,8 @@ class DataCollectorTranslator extends SymfonyDataCollectorTranslator
     /**
      * {@inheritdoc}
      *
-     * Gets the translation from Contao’s $GLOBALS['TL_LANG'] array if the
-     * message domain starts with "contao_". The locale parameter is ignored in
-     * this case.
+     * Gets the translation from Contao’s $GLOBALS['TL_LANG'] array if the message
+     * domain starts with "contao_". The locale parameter is ignored in this case.
      */
     public function trans($id, array $parameters = [], $domain = null, $locale = null): string
     {
@@ -61,6 +63,9 @@ class DataCollectorTranslator extends SymfonyDataCollectorTranslator
         return $this->translator->transChoice($id, $number, $parameters, $domain, $locale);
     }
 
+    /**
+     * Merges the collected messages from the decorated translator.
+     */
     public function getCollectedMessages(): array
     {
         if (method_exists($this->translator, 'getCollectedMessages')) {

--- a/core-bundle/src/Translation/DataCollectorTranslator.php
+++ b/core-bundle/src/Translation/DataCollectorTranslator.php
@@ -13,15 +13,13 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Translation;
 
 use Symfony\Component\Translation\DataCollectorTranslator as SymfonyDataCollectorTranslator;
-use Symfony\Component\Translation\MessageCatalogueInterface;
-use Symfony\Component\Translation\TranslatorBagInterface;
 use Symfony\Component\Translation\TranslatorInterface as LegacyTranslatorInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class DataCollectorTranslator extends SymfonyDataCollectorTranslator
 {
     /**
-     * @var TranslatorInterface&TranslatorBagInterface&LegacyTranslatorInterface
+     * @var TranslatorInterface|LegacyTranslatorInterface
      */
     private $translator;
 
@@ -37,8 +35,9 @@ class DataCollectorTranslator extends SymfonyDataCollectorTranslator
     /**
      * {@inheritdoc}
      *
-     * Gets the translation from Contao’s $GLOBALS['TL_LANG'] array if the message domain starts with
-     * "contao_". The locale parameter is ignored in this case.
+     * Gets the translation from Contao’s $GLOBALS['TL_LANG'] array if the
+     * message domain starts with "contao_". The locale parameter is ignored in
+     * this case.
      */
     public function trans($id, array $parameters = [], $domain = null, $locale = null): string
     {
@@ -62,34 +61,7 @@ class DataCollectorTranslator extends SymfonyDataCollectorTranslator
         return $this->translator->transChoice($id, $number, $parameters, $domain, $locale);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function setLocale($locale): ?string
-    {
-        return $this->translator->setLocale($locale);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getLocale(): string
-    {
-        return $this->translator->getLocale();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getCatalogue($locale = null): MessageCatalogueInterface
-    {
-        return $this->translator->getCatalogue($locale);
-    }
-
-    /**
-     * @return array
-     */
-    public function getCollectedMessages()
+    public function getCollectedMessages(): array
     {
         if (method_exists($this->translator, 'getCollectedMessages')) {
             return array_merge($this->translator->getCollectedMessages(), $this->messages);

--- a/core-bundle/src/Translation/DataCollectorTranslator.php
+++ b/core-bundle/src/Translation/DataCollectorTranslator.php
@@ -13,13 +13,15 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Translation;
 
 use Symfony\Component\Translation\DataCollectorTranslator as SymfonyDataCollectorTranslator;
+use Symfony\Component\Translation\MessageCatalogueInterface;
+use Symfony\Component\Translation\TranslatorBagInterface;
 use Symfony\Component\Translation\TranslatorInterface as LegacyTranslatorInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class DataCollectorTranslator extends SymfonyDataCollectorTranslator
 {
     /**
-     * @var TranslatorInterface|LegacyTranslatorInterface
+     * @var TranslatorInterface|TranslatorBagInterface|LegacyTranslatorInterface
      */
     private $translator;
 
@@ -61,6 +63,30 @@ class DataCollectorTranslator extends SymfonyDataCollectorTranslator
     public function transChoice($id, $number, array $parameters = [], $domain = null, $locale = null): string
     {
         return $this->translator->transChoice($id, $number, $parameters, $domain, $locale);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setLocale($locale): ?string
+    {
+        return $this->translator->setLocale($locale);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getLocale(): string
+    {
+        return $this->translator->getLocale();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCatalogue($locale = null): MessageCatalogueInterface
+    {
+        return $this->translator->getCatalogue($locale);
     }
 
     /**

--- a/core-bundle/src/Translation/DataCollectorTranslator.php
+++ b/core-bundle/src/Translation/DataCollectorTranslator.php
@@ -15,12 +15,13 @@ namespace Contao\CoreBundle\Translation;
 use Symfony\Component\Translation\DataCollectorTranslator as SymfonyDataCollectorTranslator;
 use Symfony\Component\Translation\MessageCatalogueInterface;
 use Symfony\Component\Translation\TranslatorBagInterface;
-use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Component\Translation\TranslatorInterface as LegacyTranslatorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
-class DataCollectorTranslator extends SymfonyDataCollectorTranslator implements TranslatorInterface, TranslatorBagInterface
+class DataCollectorTranslator extends SymfonyDataCollectorTranslator
 {
     /**
-     * @var TranslatorInterface|TranslatorBagInterface
+     * @var TranslatorInterface|TranslatorBagInterface|LegacyTranslatorInterface
      */
     private $translator;
 
@@ -90,21 +91,14 @@ class DataCollectorTranslator extends SymfonyDataCollectorTranslator implements 
      */
     public function getCollectedMessages()
     {
-        if (\method_exists($this->translator, 'getCollectedMessages')) {
+        if (method_exists($this->translator, 'getCollectedMessages')) {
             return array_merge($this->translator->getCollectedMessages(), $this->messages);
         }
 
         return $this->messages;
     }
 
-    /**
-     * @param string $locale
-     * @param string $domain
-     * @param string $id
-     * @param string $translation
-     * @param array  $parameters
-     */
-    private function collectMessage(string $locale, string $domain, string $id, string $translation, array $parameters = [])
+    private function collectMessage(string $locale, string $domain, string $id, string $translation, array $parameters = []): void
     {
         if ($id === $translation) {
             $state = SymfonyDataCollectorTranslator::MESSAGE_MISSING;

--- a/core-bundle/src/Translation/DataCollectorTranslator.php
+++ b/core-bundle/src/Translation/DataCollectorTranslator.php
@@ -50,7 +50,7 @@ class DataCollectorTranslator extends SymfonyDataCollectorTranslator
             return $translated;
         }
 
-        $this->collectMessage($GLOBALS['TL_LANGUAGE'] ?? '', (string) $domain, $id, $translated, $parameters);
+        $this->collectMessage($this->getLocale(), (string) $domain, $id, $translated, $parameters);
 
         return $translated;
     }

--- a/core-bundle/src/Translation/DataCollectorTranslator.php
+++ b/core-bundle/src/Translation/DataCollectorTranslator.php
@@ -28,7 +28,7 @@ class DataCollectorTranslator extends SymfonyDataCollectorTranslator
     private $messages = [];
 
     /**
-     * @param TranslatorInterface $translator
+     * @param TranslatorInterface|TranslatorBagInterface|LegacyTranslatorInterface $translator
      */
     public function __construct($translator)
     {

--- a/core-bundle/src/Translation/Translator.php
+++ b/core-bundle/src/Translation/Translator.php
@@ -99,7 +99,7 @@ class Translator implements TranslatorInterface, TranslatorBagInterface
 
     public function getCollectedMessages(): array
     {
-        if (\method_exists($this->translator, 'getCollectedMessages')) {
+        if (method_exists($this->translator, 'getCollectedMessages')) {
             return $this->translator->getCollectedMessages();
         }
 

--- a/core-bundle/src/Translation/Translator.php
+++ b/core-bundle/src/Translation/Translator.php
@@ -50,7 +50,7 @@ class Translator implements TranslatorInterface, TranslatorBagInterface
         }
 
         $this->framework->initialize();
-        $this->loadLanguageFile(substr($domain, 7));
+        $this->loadLanguageFile(substr($domain, 7), $locale);
 
         $translated = $this->getFromGlobals($id);
 
@@ -146,10 +146,10 @@ class Translator implements TranslatorInterface, TranslatorBagInterface
     /**
      * Loads a Contao framework language file.
      */
-    private function loadLanguageFile(string $name): void
+    private function loadLanguageFile(string $name, string $locale = null): void
     {
         /** @var System $system */
         $system = $this->framework->getAdapter(System::class);
-        $system->loadLanguageFile($name);
+        $system->loadLanguageFile($name, $locale);
     }
 }

--- a/core-bundle/src/Translation/Translator.php
+++ b/core-bundle/src/Translation/Translator.php
@@ -39,8 +39,8 @@ class Translator implements TranslatorInterface, TranslatorBagInterface
     /**
      * {@inheritdoc}
      *
-     * Gets the translation from Contao’s $GLOBALS['TL_LANG'] array if the message domain starts with
-     * "contao_". The locale parameter is ignored in this case.
+     * Gets the translation from Contao’s $GLOBALS['TL_LANG'] array if the message
+     * domain starts with "contao_". The locale parameter is ignored in this case.
      */
     public function trans($id, array $parameters = [], $domain = null, $locale = null): string
     {
@@ -97,10 +97,25 @@ class Translator implements TranslatorInterface, TranslatorBagInterface
         return $this->translator->getCatalogue($locale);
     }
 
+    /**
+     * Returns the collected messages of the decorated translator.
+     */
     public function getCollectedMessages(): array
     {
         if (method_exists($this->translator, 'getCollectedMessages')) {
             return $this->translator->getCollectedMessages();
+        }
+
+        return [];
+    }
+
+    /**
+     * Returns the fallback locales of the decorated translator.
+     */
+    public function getFallbackLocales(): array
+    {
+        if (method_exists($this->translator, 'getFallbackLocales')) {
+            return $this->translator->getFallbackLocales();
         }
 
         return [];

--- a/core-bundle/tests/ContaoCoreBundleTest.php
+++ b/core-bundle/tests/ContaoCoreBundleTest.php
@@ -24,6 +24,7 @@ use Contao\CoreBundle\DependencyInjection\Compiler\PickerProviderPass;
 use Contao\CoreBundle\DependencyInjection\Compiler\RegisterFragmentsPass;
 use Contao\CoreBundle\DependencyInjection\Compiler\RegisterHookListenersPass;
 use Contao\CoreBundle\DependencyInjection\Compiler\RemembermeServicesPass;
+use Contao\CoreBundle\DependencyInjection\Compiler\TranslationDataCollectorPass;
 use Contao\CoreBundle\DependencyInjection\Security\ContaoLoginFactory;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\SecurityExtension;
 use Symfony\Component\Console\Application;
@@ -57,6 +58,7 @@ class ContaoCoreBundleTest extends TestCase
             RemembermeServicesPass::class,
             MapFragmentsToGlobalsPass::class,
             DataContainerCallbackPass::class,
+            TranslationDataCollectorPass::class,
             RegisterHookListenersPass::class,
         ];
 

--- a/core-bundle/tests/DependencyInjection/Compiler/TranslationDataCollectorPassTest.php
+++ b/core-bundle/tests/DependencyInjection/Compiler/TranslationDataCollectorPassTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\DependencyInjection\Compiler;
+
+use Contao\CoreBundle\DependencyInjection\Compiler\TranslationDataCollectorPass;
+use Contao\CoreBundle\Tests\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+class TranslationDataCollectorPassTest extends TestCase
+{
+    public function testReturnsIfTheDataCollectorServiceDoesNotExist(): void
+    {
+        $container = $this->createMock(ContainerBuilder::class);
+        $container
+            ->expects($this->once())
+            ->method('hasDefinition')
+            ->with('translator.data_collector')
+            ->willReturn(false)
+        ;
+
+        $container
+            ->expects($this->never())
+            ->method('getDefinition')
+        ;
+
+        $pass = new TranslationDataCollectorPass();
+        $pass->process($container);
+    }
+
+    public function testSetsTheDecoratedService(): void
+    {
+        $definition = new Definition();
+        $definition->setArgument(0, new Reference('translator.data_collector'));
+
+        $container = new ContainerBuilder();
+        $container->setDefinition('translator.data_collector', new Definition());
+        $container->setDefinition('contao.translation.translator.data_collector', new Definition());
+        $container->setDefinition('data_collector.translation', $definition);
+
+        $pass = new TranslationDataCollectorPass();
+        $pass->process($container);
+
+        $dataCollector = $container->getDefinition('data_collector.translation');
+
+        $this->assertSame('contao.translation.translator.data_collector', (string) $dataCollector->getArgument(0));
+
+        $contaoDataCollector = $container->getDefinition('contao.translation.translator.data_collector');
+
+        $this->assertSame(['translator', null, 0], $contaoDataCollector->getDecoratedService());
+    }
+}

--- a/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
+++ b/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
@@ -105,6 +105,7 @@ use Contao\CoreBundle\Session\Attribute\ArrayAttributeBag;
 use Contao\CoreBundle\Slug\Slug;
 use Contao\CoreBundle\Slug\ValidCharacters;
 use Contao\CoreBundle\Tests\TestCase;
+use Contao\CoreBundle\Translation\DataCollectorTranslator;
 use Contao\CoreBundle\Translation\Translator;
 use Contao\CoreBundle\Twig\Extension\ContaoTemplateExtension;
 use Contao\FrontendUser;
@@ -1790,6 +1791,18 @@ class ContaoCoreExtensionTest extends TestCase
         $this->assertSame('translator', $definition->getDecoratedService()[0]);
         $this->assertSame('contao.translation.translator.inner', (string) $definition->getArgument(0));
         $this->assertSame('contao.framework', (string) $definition->getArgument(1));
+    }
+
+    public function testRegistersTheContaoTranslatorDataCollector(): void
+    {
+        $this->assertTrue($this->container->has('contao.translation.translator.data_collector'));
+
+        $definition = $this->container->getDefinition('contao.translation.translator.data_collector');
+
+        $this->assertSame(DataCollectorTranslator::class, $definition->getClass());
+        $this->assertTrue($definition->isPrivate());
+        $this->assertSame(null, $definition->getDecoratedService()[0]);
+        $this->assertSame('contao.translation.translator.data_collector.inner', (string) $definition->getArgument(0));
     }
 
     public function testRegistersTheTwigTemplateExtension(): void

--- a/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
+++ b/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
@@ -1801,7 +1801,7 @@ class ContaoCoreExtensionTest extends TestCase
 
         $this->assertSame(DataCollectorTranslator::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
-        $this->assertSame(null, $definition->getDecoratedService()[0]);
+        $this->assertNull($definition->getDecoratedService()[0]);
         $this->assertSame('contao.translation.translator.data_collector.inner', (string) $definition->getArgument(0));
     }
 

--- a/core-bundle/tests/Translation/DataCollectorTranslatorTest.php
+++ b/core-bundle/tests/Translation/DataCollectorTranslatorTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\Translation;
+
+use Contao\CoreBundle\Tests\TestCase;
+use Contao\CoreBundle\Translation\DataCollectorTranslator;
+use Symfony\Component\Translation\DataCollectorTranslator as SymfonyDataCollectorTranslator;
+
+class DataCollectorTranslatorTest extends TestCase
+{
+    public function testCollectsMessages(): void
+    {
+        $originalTranslator = $this->createMock(SymfonyDataCollectorTranslator::class);
+        $originalTranslator
+            ->expects($this->once())
+            ->method('trans')
+            ->with('MSC.mainNavigation', [], 'contao_default', 'en')
+            ->willReturn('Main navigation')
+        ;
+
+        $originalTranslator
+            ->expects($this->once())
+            ->method('getLocale')
+            ->willReturn('en')
+        ;
+
+        $originalTranslator
+            ->expects($this->once())
+            ->method('getCollectedMessages')
+            ->willReturn([])
+        ;
+
+        $translator = new DataCollectorTranslator($originalTranslator);
+        $translator->trans('MSC.mainNavigation', [], 'contao_default', 'en');
+
+        $this->assertSame(
+            [[
+                'locale' => 'en',
+                'domain' => 'contao_default',
+                'id' => 'MSC.mainNavigation',
+                'translation' => 'Main navigation',
+                'parameters' => [],
+                'state' => 0,
+                'transChoiceNumber' => null,
+            ]],
+            $translator->getCollectedMessages()
+        );
+    }
+
+    public function testDoesNotCollectMessagesIfTheDomainIsNotAContaoDomain(): void
+    {
+        $originalTranslator = $this->createMock(SymfonyDataCollectorTranslator::class);
+        $originalTranslator
+            ->expects($this->once())
+            ->method('trans')
+            ->with('translation_key', [], 'message_domain', 'en')
+            ->willReturn('translation')
+        ;
+
+        $originalTranslator
+            ->expects($this->never())
+            ->method('getCollectedMessages')
+        ;
+
+        $translator = new DataCollectorTranslator($originalTranslator);
+
+        $this->assertSame('translation', $translator->trans('translation_key', [], 'message_domain', 'en'));
+    }
+}


### PR DESCRIPTION
Implements https://github.com/contao/contao/issues/317

Currently does not track "fallback messages", but thats very hard in Contao. The only way I can see would be to always load english and then re-load the actual language, but that seems kinda overkill…