### PR TITLE
Fix redirect behaviour without 401 autoforward page

### DIFF
--- a/core-bundle/src/EventListener/TwoFactorFrontendListener.php
+++ b/core-bundle/src/EventListener/TwoFactorFrontendListener.php
@@ -114,11 +114,7 @@ class TwoFactorFrontendListener
         // Search 401 error page
         $unauthorizedPage = $adapter->find401ByPid($page->rootId);
 
-        if ($unauthorizedPage instanceof PageModel) {
-            if (!$unauthorizedPage->autoforward) {
-                return;
-            }
-
+        if ($unauthorizedPage instanceof PageModel && $unauthorizedPage->autoforward) {
             $redirect = $adapter->findPublishedById($unauthorizedPage->jumpTo);
 
             if ($redirect instanceof PageModel && $page->id === $redirect->id) {


### PR DESCRIPTION
Redirect to target path, if there is no 401 page with autoforward enabled.
See #567.