### PR TITLE
Use the jumpTo value from post data if set

### DIFF
--- a/core-bundle/src/Resources/contao/dca/tl_form.php
+++ b/core-bundle/src/Resources/contao/dca/tl_form.php
@@ -497,7 +497,7 @@ class tl_form extends Contao\Backend
 		// Generate an alias if there is none
 		if ($varValue == '')
 		{
-			$varValue = Contao\System::getContainer()->get('contao.slug')->generate($dc->activeRecord->title, $dc->activeRecord->jumpTo, $aliasExists);
+			$varValue = Contao\System::getContainer()->get('contao.slug')->generate($dc->activeRecord->title, Contao\Input::post('jumpTo') ?: $dc->activeRecord->jumpTo, $aliasExists);
 		}
 		elseif ($aliasExists($varValue))
 		{


### PR DESCRIPTION
Currently, if you create a new form, set the title and select a jumpTo page the slug settings from the selected root page are not used. This PR fixes that issue.