### PR TITLE
Allow to enable debug mode in index.php via env var

### DIFF
--- a/manager-bundle/src/HttpKernel/ContaoKernel.php
+++ b/manager-bundle/src/HttpKernel/ContaoKernel.php
@@ -224,7 +224,7 @@ class ContaoKernel extends Kernel implements HttpCacheProvider
             (new Dotenv(false))->load($projectDir.'/.env');
         }
         
-        if (!$debug && $_SERVER['APP_DEBUG']) {
+        if ($_SERVER['APP_DEBUG']) {
             $debug = true;
         }
 

--- a/manager-bundle/src/HttpKernel/ContaoKernel.php
+++ b/manager-bundle/src/HttpKernel/ContaoKernel.php
@@ -223,6 +223,10 @@ class ContaoKernel extends Kernel implements HttpCacheProvider
         if (file_exists($projectDir.'/.env')) {
             (new Dotenv(false))->load($projectDir.'/.env');
         }
+        
+        if (!$debug && $_SERVER['APP_DEBUG']) {
+            $debug = true;
+        }
 
         // TODO: use manager config to load settings
 


### PR DESCRIPTION
Currently you cannot enable the debug mode without accessing the back end and enabling it in your profile. That's really inconvenient in development environments.

Now you can by passing an `APP_DEBUG=true` env variable to your server or adding it to your `.env` file.