### PR TITLE
Get filetree picker url parameters via own method

### DIFF
--- a/core-bundle/src/Resources/contao/widgets/FileTree.php
+++ b/core-bundle/src/Resources/contao/widgets/FileTree.php
@@ -407,9 +407,9 @@ class FileTree extends Widget
 	 *
 	 * @return array
 	 */
-	protected function getPickerUrlExtras($values = [])
+	protected function getPickerUrlExtras($values = array())
 	{
-		$extras = [];
+		$extras = array();
 		$extras['fieldType'] = $this->fieldType;
 
 		if ($this->files)

--- a/core-bundle/src/Resources/contao/widgets/FileTree.php
+++ b/core-bundle/src/Resources/contao/widgets/FileTree.php
@@ -401,7 +401,7 @@ class FileTree extends Widget
 	}
 
 	/**
-	 * Return the extra parameters for picker url
+	 * Return the extra parameters for the picker URL
 	 *
 	 * @param array $values
 	 *

--- a/core-bundle/src/Resources/contao/widgets/FileTree.php
+++ b/core-bundle/src/Resources/contao/widgets/FileTree.php
@@ -368,27 +368,7 @@ class FileTree extends Widget
 		}
 		else
 		{
-			$extras = array('fieldType'=>$this->fieldType);
-
-			if ($this->files)
-			{
-				$extras['files'] = (bool) $this->files;
-			}
-
-			if ($this->filesOnly)
-			{
-				$extras['filesOnly'] = (bool) $this->filesOnly;
-			}
-
-			if ($this->path)
-			{
-				$extras['path'] = (string) $this->path;
-			}
-
-			if ($this->extensions)
-			{
-				$extras['extensions'] = (string) $this->extensions;
-			}
+			$extras = $this->getPickerUrlExtras($arrValues);
 
 			$return .= '
     <p><a href="' . ampersand(System::getContainer()->get('contao.picker.builder')->getUrl('file', $extras)) . '" class="tl_submit" id="ft_' . $this->strName . '">' . $GLOBALS['TL_LANG']['MSC']['changeSelection'] . '</a></p>
@@ -418,6 +398,41 @@ class FileTree extends Widget
 		$return = '<div>' . $return . '</div></div>';
 
 		return $return;
+	}
+
+	/**
+	 * Return the extra parameters for picker url
+	 *
+	 * @param array $values
+	 *
+	 * @return array
+	 */
+	protected function getPickerUrlExtras($values = [])
+	{
+		$extras = [];
+		$extras['fieldType'] = $this->fieldType;
+
+		if ($this->files)
+		{
+			$extras['files'] = (bool) $this->files;
+		}
+
+		if ($this->filesOnly)
+		{
+			$extras['filesOnly'] = (bool) $this->filesOnly;
+		}
+
+		if ($this->path)
+		{
+			$extras['path'] = (string) $this->path;
+		}
+
+		if ($this->extensions)
+		{
+			$extras['extensions'] = (string) $this->extensions;
+		}
+
+		return $extras;
 	}
 
 	/**


### PR DESCRIPTION
Get the picker url parameters via own method, to get the possibility to overwrite/extend it in own extensions.