### PR TITLE
Get pagetree picker url parameters via own method

### DIFF
--- a/core-bundle/src/Resources/contao/widgets/PageTree.php
+++ b/core-bundle/src/Resources/contao/widgets/PageTree.php
@@ -261,7 +261,7 @@ class PageTree extends Widget
 	}
 
 	/**
-	 * Return the extra parameters for picker url
+	 * Return the extra parameters for the picker URL
 	 *
 	 * @param array $values
 	 *

--- a/core-bundle/src/Resources/contao/widgets/PageTree.php
+++ b/core-bundle/src/Resources/contao/widgets/PageTree.php
@@ -228,16 +228,7 @@ class PageTree extends Widget
 		}
 		else
 		{
-			$extras = array
-			(
-				'fieldType' => $this->fieldType,
-				'source' => $this->strTable . '.' . $this->currentRecord,
-			);
-
-			if (\is_array($this->rootNodes))
-			{
-				$extras['rootNodes'] = array_values($this->rootNodes);
-			}
+			$extras = $this->getPickerUrlExtras($arrValues);
 
 			$return .= '
     <p><a href="' . ampersand(System::getContainer()->get('contao.picker.builder')->getUrl('page', $extras)) . '" class="tl_submit" id="pt_' . $this->strName . '">' . $GLOBALS['TL_LANG']['MSC']['changeSelection'] . '</a></p>
@@ -267,6 +258,26 @@ class PageTree extends Widget
 		$return = '<div>' . $return . '</div></div>';
 
 		return $return;
+	}
+
+	/**
+	 * Return the extra parameters for picker url
+	 *
+	 * @param array $values
+	 *
+	 * @return array
+	 */
+	protected function getPickerUrlExtras($values = [])
+	{
+		$extras = [];
+		$extras['fieldType'] = $this->fieldType;
+		$extras['source'] = $this->strTable.'.'.$this->currentRecord;
+
+		if (\is_array($this->rootNodes))
+		{
+			$extras['rootNodes'] = array_values($this->rootNodes);
+		}
+		return $extras;
 	}
 }
 

--- a/core-bundle/src/Resources/contao/widgets/PageTree.php
+++ b/core-bundle/src/Resources/contao/widgets/PageTree.php
@@ -267,16 +267,17 @@ class PageTree extends Widget
 	 *
 	 * @return array
 	 */
-	protected function getPickerUrlExtras($values = [])
+	protected function getPickerUrlExtras($values = array())
 	{
-		$extras = [];
+		$extras = array();
 		$extras['fieldType'] = $this->fieldType;
-		$extras['source'] = $this->strTable.'.'.$this->currentRecord;
+		$extras['source'] = $this->strTable . '.' . $this->currentRecord;
 
 		if (\is_array($this->rootNodes))
 		{
 			$extras['rootNodes'] = array_values($this->rootNodes);
 		}
+
 		return $extras;
 	}
 }


### PR DESCRIPTION
Get the picker url parameters via own method, to get the possibility to overwrite/extend it in own extensions.

Sorry for the second PR, just didn't want to use my feature for filetree.
After https://github.com/contao/contao/pull/579 I just realized, that in pagetree is similar logic.