### PR TITLE
Make possible to use Versions from the CLI

### DIFF
--- a/core-bundle/src/Resources/contao/classes/Versions.php
+++ b/core-bundle/src/Resources/contao/classes/Versions.php
@@ -776,7 +776,7 @@ class Versions extends Controller
 
 		$this->import(BackendUser::class, 'User');
 
-		return $this->User->username ?: php_sapi_name();
+		return $this->User->username ?: '';
 	}
 
 	/**

--- a/core-bundle/src/Resources/contao/classes/Versions.php
+++ b/core-bundle/src/Resources/contao/classes/Versions.php
@@ -776,7 +776,7 @@ class Versions extends Controller
 
 		$this->import(BackendUser::class, 'User');
 
-		return $this->User->username;
+		return $this->User->username ?: php_sapi_name();
 	}
 
 	/**
@@ -793,7 +793,7 @@ class Versions extends Controller
 
 		$this->import(BackendUser::class, 'User');
 
-		return $this->User->id;
+		return $this->User->id ?: 0;
 	}
 
 	/**

--- a/core-bundle/src/Resources/contao/classes/Versions.php
+++ b/core-bundle/src/Resources/contao/classes/Versions.php
@@ -776,7 +776,7 @@ class Versions extends Controller
 
 		$this->import(BackendUser::class, 'User');
 
-		return $this->User->username ?: '';
+		return $this->User->username ?? '';
 	}
 
 	/**
@@ -793,7 +793,7 @@ class Versions extends Controller
 
 		$this->import(BackendUser::class, 'User');
 
-		return $this->User->id ?: 0;
+		return $this->User->id ?? 0;
 	}
 
 	/**


### PR DESCRIPTION
If you use Versions from cli or in cronjobs the username and userid are allways null

```
Integrity constraint violation: 1048 Column 'userid' cannot be null
Integrity constraint violation: 1048 Column 'username' cannot be null
```

The username and userid field must not be null

The username return can also be an empty string or 'Unkown'

No BC break