### PR TITLE
Use custom console application to optimize arguments

### DIFF
--- a/manager-bundle/bin/contao-console
+++ b/manager-bundle/bin/contao-console
@@ -11,8 +11,8 @@ declare(strict_types=1);
  * @license LGPL-3.0-or-later
  */
 
+use Contao\ManagerBundle\Console\ContaoApplication;
 use Contao\ManagerBundle\HttpKernel\ContaoKernel;
-use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\ArgvInput;
 
 set_time_limit(0);
@@ -38,5 +38,5 @@ if ('dev' !== $env && 'prod' !== $env) {
 }
 
 $kernel = ContaoKernel::create($projectDir, 'prod' !== $env);
-$application = new Application($kernel);
+$application = new ContaoApplication($kernel);
 $application->run($input);

--- a/manager-bundle/src/Console/ContaoApplication.php
+++ b/manager-bundle/src/Console/ContaoApplication.php
@@ -2,7 +2,7 @@
 
 namespace Contao\ManagerBundle\Console;
 
-use PackageVersions\Versions;
+use Contao\CoreBundle\Util\PackageUtil;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\HttpKernel\KernelInterface;
 
@@ -13,13 +13,19 @@ class ContaoApplication extends Application
         parent::__construct($kernel);
 
         $this->setName('Contao Managed Edition');
-        $this->setVersion(Versions::VERSIONS['contao/contao'] ?? Versions::getVersion('contao/core-bundle'));
+
+        try {
+            $this->setVersion(PackageUtil::getVersion('contao/core-bundle'));
+        } catch (\OutOfBoundsException $e) {
+            $this->setVersion(PackageUtil::getVersion('contao/contao'));
+        }
 
         $inputDefinition = $this->getDefinition();
         $options = $inputDefinition->getOptions();
 
         foreach ($options as $k => $option) {
             if ('no-debug' === $option->getName()) {
+                // We do not support the no-debug option, so unset it
                 unset($options[$k]);
                 break;
             }

--- a/manager-bundle/src/Console/ContaoApplication.php
+++ b/manager-bundle/src/Console/ContaoApplication.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Contao\ManagerBundle\Console;
+
+use PackageVersions\Versions;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+class ContaoApplication extends Application
+{
+    public function __construct(KernelInterface $kernel)
+    {
+        parent::__construct($kernel);
+
+        $this->setName('Contao Managed Edition');
+        $this->setVersion(Versions::VERSIONS['contao/contao'] ?? Versions::getVersion('contao/core-bundle'));
+
+        $inputDefinition = $this->getDefinition();
+        $options = $inputDefinition->getOptions();
+
+        foreach ($options as $k => $option) {
+            if ('no-debug' === $option->getName()) {
+                unset($options[$k]);
+                break;
+            }
+        }
+
+        $inputDefinition->setOptions($options);
+    }
+}


### PR DESCRIPTION
This optimizes the `contao-console` application

 1. It will correctly show as "Contao Managed Edition" instead of Symfony
 2. The `--no-debug` option is not supported, the debug mode is always enable for `dev` env and disabled for `prod`