### PR TITLE
Add an abstract controller for common service tasks

### DIFF
--- a/core-bundle/src/Controller/AbstractController.php
+++ b/core-bundle/src/Controller/AbstractController.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Contao\CoreBundle\Controller;
+
+use Contao\CoreBundle\Framework\ContaoFramework;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController as SymfonyAbstractController;
+use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
+
+abstract class AbstractController extends SymfonyAbstractController implements ServiceAnnotationInterface
+{
+    /**
+     * Initializes the Contao framework.
+     */
+    protected function initializeContao()
+    {
+        $this->get('contao.framework')->initialize();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedServices()
+    {
+        $services = parent::getSubscribedServices();
+
+        $services['contao.framework'] = ContaoFramework::class;
+
+        return $services;
+    }
+}

--- a/core-bundle/src/Controller/AbstractController.php
+++ b/core-bundle/src/Controller/AbstractController.php
@@ -11,7 +11,7 @@ abstract class AbstractController extends SymfonyAbstractController implements S
     /**
      * Initializes the Contao framework.
      */
-    protected function initializeContao()
+    protected function initializeContaoFramework()
     {
         $this->get('contao.framework')->initialize();
     }

--- a/core-bundle/src/Controller/AbstractController.php
+++ b/core-bundle/src/Controller/AbstractController.php
@@ -1,5 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
 namespace Contao\CoreBundle\Controller;
 
 use Contao\CoreBundle\Framework\ContaoFramework;
@@ -9,26 +19,6 @@ use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
 abstract class AbstractController extends SymfonyAbstractController implements ServiceAnnotationInterface
 {
-    /**
-     * Initializes the Contao framework.
-     */
-    protected function initializeContaoFramework()
-    {
-        $this->get('contao.framework')->initialize();
-    }
-
-    /**
-     * @param array $tags
-     */
-    protected function tagResponse(array $tags): void
-    {
-        if (!$this->has('fos_http_cache.http.symfony_response_tagger')) {
-            return;
-        }
-
-        $this->get('fos_http_cache.http.symfony_response_tagger')->addTags($tags);
-    }
-
     /**
      * {@inheritdoc}
      */
@@ -40,5 +30,22 @@ abstract class AbstractController extends SymfonyAbstractController implements S
         $services['fos_http_cache.http.symfony_response_tagger'] = '?'.SymfonyResponseTagger::class;
 
         return $services;
+    }
+
+    /**
+     * Initializes the Contao framework.
+     */
+    protected function initializeContaoFramework(): void
+    {
+        $this->get('contao.framework')->initialize();
+    }
+
+    protected function tagResponse(array $tags): void
+    {
+        if (!$this->has('fos_http_cache.http.symfony_response_tagger')) {
+            return;
+        }
+
+        $this->get('fos_http_cache.http.symfony_response_tagger')->addTags($tags);
     }
 }

--- a/core-bundle/src/Controller/AbstractController.php
+++ b/core-bundle/src/Controller/AbstractController.php
@@ -3,6 +3,7 @@
 namespace Contao\CoreBundle\Controller;
 
 use Contao\CoreBundle\Framework\ContaoFramework;
+use FOS\HttpCacheBundle\Http\SymfonyResponseTagger;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController as SymfonyAbstractController;
 use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
@@ -17,6 +18,18 @@ abstract class AbstractController extends SymfonyAbstractController implements S
     }
 
     /**
+     * @param array $tags
+     */
+    protected function tagResponse(array $tags): void
+    {
+        if (!$this->has('fos_http_cache.http.symfony_response_tagger')) {
+            return;
+        }
+
+        $this->get('fos_http_cache.http.symfony_response_tagger')->addTags($tags);
+    }
+
+    /**
      * {@inheritdoc}
      */
     public static function getSubscribedServices()
@@ -24,6 +37,7 @@ abstract class AbstractController extends SymfonyAbstractController implements S
         $services = parent::getSubscribedServices();
 
         $services['contao.framework'] = ContaoFramework::class;
+        $services['fos_http_cache.http.symfony_response_tagger'] = '?'.SymfonyResponseTagger::class;
 
         return $services;
     }

--- a/core-bundle/src/Controller/AbstractController.php
+++ b/core-bundle/src/Controller/AbstractController.php
@@ -32,9 +32,6 @@ abstract class AbstractController extends SymfonyAbstractController implements S
         return $services;
     }
 
-    /**
-     * Initializes the Contao framework.
-     */
     protected function initializeContaoFramework(): void
     {
         $this->get('contao.framework')->initialize();

--- a/core-bundle/src/Controller/AbstractFragmentController.php
+++ b/core-bundle/src/Controller/AbstractFragmentController.php
@@ -19,11 +19,9 @@ use Contao\Model;
 use Contao\StringUtil;
 use Contao\Template;
 use FOS\HttpCacheBundle\Http\SymfonyResponseTagger;
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\DependencyInjection\Container;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-abstract class AbstractFragmentController extends AbstractController implements FragmentOptionsAwareInterface, ServiceAnnotationInterface
+abstract class AbstractFragmentController extends AbstractController implements FragmentOptionsAwareInterface
 {
     /**
      * @var array
@@ -40,12 +38,12 @@ abstract class AbstractFragmentController extends AbstractController implements 
      */
     public static function getSubscribedServices(): array
     {
-        $services = parent::getSubscribedServices();
-
-        $services['contao.framework'] = ContaoFramework::class;
-        $services['fos_http_cache.http.symfony_response_tagger'] = '?'.SymfonyResponseTagger::class;
-
-        return $services;
+        return array_merge(
+            parent::getSubscribedServices(),
+            [
+                'fos_http_cache.http.symfony_response_tagger' => '?'.SymfonyResponseTagger::class,
+            ]
+        );
     }
 
     /**

--- a/core-bundle/src/Controller/AbstractFragmentController.php
+++ b/core-bundle/src/Controller/AbstractFragmentController.php
@@ -13,12 +13,10 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Controller;
 
 use Contao\CoreBundle\Fragment\FragmentOptionsAwareInterface;
-use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\FrontendTemplate;
 use Contao\Model;
 use Contao\StringUtil;
 use Contao\Template;
-use FOS\HttpCacheBundle\Http\SymfonyResponseTagger;
 use Symfony\Component\DependencyInjection\Container;
 
 abstract class AbstractFragmentController extends AbstractController implements FragmentOptionsAwareInterface
@@ -31,19 +29,6 @@ abstract class AbstractFragmentController extends AbstractController implements 
     public function setFragmentOptions(array $options): void
     {
         $this->options = $options;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public static function getSubscribedServices(): array
-    {
-        return array_merge(
-            parent::getSubscribedServices(),
-            [
-                'fos_http_cache.http.symfony_response_tagger' => '?'.SymfonyResponseTagger::class,
-            ]
-        );
     }
 
     /**
@@ -92,15 +77,6 @@ abstract class AbstractFragmentController extends AbstractController implements 
     protected function addSectionToTemplate(Template $template, string $section): void
     {
         $template->inColumn = $section;
-    }
-
-    protected function tagResponse(array $tags): void
-    {
-        if (!$this->has('fos_http_cache.http.symfony_response_tagger')) {
-            return;
-        }
-
-        $this->get('fos_http_cache.http.symfony_response_tagger')->addTags($tags);
     }
 
     /**

--- a/core-bundle/src/Controller/BackendController.php
+++ b/core-bundle/src/Controller/BackendController.php
@@ -42,7 +42,7 @@ class BackendController extends AbstractController
      */
     public function mainAction(): Response
     {
-        $this->initializeContao();
+        $this->initializeContaoFramework();
 
         $controller = new BackendMain();
 
@@ -54,7 +54,7 @@ class BackendController extends AbstractController
      */
     public function loginAction(Request $request): Response
     {
-        $this->initializeContao();
+        $this->initializeContaoFramework();
 
         if ($this->isGranted('IS_AUTHENTICATED_FULLY')) {
             $queryString = '';
@@ -86,7 +86,7 @@ class BackendController extends AbstractController
      */
     public function passwordAction(): Response
     {
-        $this->initializeContao();
+        $this->initializeContaoFramework();
 
         $controller = new BackendPassword();
 
@@ -104,7 +104,7 @@ class BackendController extends AbstractController
             return $this->redirect($previewScript.$request->getRequestUri());
         }
 
-        $this->initializeContao();
+        $this->initializeContaoFramework();
 
         $controller = new BackendPreview();
 
@@ -116,7 +116,7 @@ class BackendController extends AbstractController
      */
     public function confirmAction(): Response
     {
-        $this->initializeContao();
+        $this->initializeContaoFramework();
 
         $controller = new BackendConfirm();
 
@@ -128,7 +128,7 @@ class BackendController extends AbstractController
      */
     public function fileAction(): Response
     {
-        $this->initializeContao();
+        $this->initializeContaoFramework();
 
         $controller = new BackendFile();
 
@@ -140,7 +140,7 @@ class BackendController extends AbstractController
      */
     public function helpAction(): Response
     {
-        $this->initializeContao();
+        $this->initializeContaoFramework();
 
         $controller = new BackendHelp();
 
@@ -152,7 +152,7 @@ class BackendController extends AbstractController
      */
     public function pageAction(): Response
     {
-        $this->initializeContao();
+        $this->initializeContaoFramework();
 
         $controller = new BackendPage();
 
@@ -164,7 +164,7 @@ class BackendController extends AbstractController
      */
     public function popupAction(): Response
     {
-        $this->initializeContao();
+        $this->initializeContaoFramework();
 
         $controller = new BackendPopup();
 
@@ -176,7 +176,7 @@ class BackendController extends AbstractController
      */
     public function switchAction(): Response
     {
-        $this->initializeContao();
+        $this->initializeContaoFramework();
 
         $controller = new BackendSwitch();
 
@@ -188,7 +188,7 @@ class BackendController extends AbstractController
      */
     public function alertsAction(): Response
     {
-        $this->initializeContao();
+        $this->initializeContaoFramework();
 
         $controller = new BackendAlerts();
 

--- a/core-bundle/src/Controller/BackendController.php
+++ b/core-bundle/src/Controller/BackendController.php
@@ -23,7 +23,6 @@ use Contao\BackendPassword;
 use Contao\BackendPopup;
 use Contao\BackendPreview;
 use Contao\BackendSwitch;
-use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\CoreBundle\Picker\PickerBuilderInterface;
 use Contao\CoreBundle\Picker\PickerConfig;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -244,7 +243,6 @@ class BackendController extends AbstractController
     {
         $services = parent::getSubscribedServices();
 
-        $services['contao.framework'] = ContaoFramework::class;
         $services['contao.picker.builder'] = PickerBuilderInterface::class;
 
         return $services;

--- a/core-bundle/src/Controller/BackendController.php
+++ b/core-bundle/src/Controller/BackendController.php
@@ -26,7 +26,6 @@ use Contao\BackendSwitch;
 use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\CoreBundle\Picker\PickerBuilderInterface;
 use Contao\CoreBundle\Picker\PickerConfig;
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -43,7 +42,7 @@ class BackendController extends AbstractController
      */
     public function mainAction(): Response
     {
-        $this->get('contao.framework')->initialize();
+        $this->initializeContao();
 
         $controller = new BackendMain();
 
@@ -55,7 +54,7 @@ class BackendController extends AbstractController
      */
     public function loginAction(Request $request): Response
     {
-        $this->get('contao.framework')->initialize();
+        $this->initializeContao();
 
         if ($this->isGranted('IS_AUTHENTICATED_FULLY')) {
             $queryString = '';
@@ -87,7 +86,7 @@ class BackendController extends AbstractController
      */
     public function passwordAction(): Response
     {
-        $this->get('contao.framework')->initialize();
+        $this->initializeContao();
 
         $controller = new BackendPassword();
 
@@ -105,7 +104,7 @@ class BackendController extends AbstractController
             return $this->redirect($previewScript.$request->getRequestUri());
         }
 
-        $this->get('contao.framework')->initialize();
+        $this->initializeContao();
 
         $controller = new BackendPreview();
 
@@ -117,7 +116,7 @@ class BackendController extends AbstractController
      */
     public function confirmAction(): Response
     {
-        $this->get('contao.framework')->initialize();
+        $this->initializeContao();
 
         $controller = new BackendConfirm();
 
@@ -129,7 +128,7 @@ class BackendController extends AbstractController
      */
     public function fileAction(): Response
     {
-        $this->get('contao.framework')->initialize();
+        $this->initializeContao();
 
         $controller = new BackendFile();
 
@@ -141,7 +140,7 @@ class BackendController extends AbstractController
      */
     public function helpAction(): Response
     {
-        $this->get('contao.framework')->initialize();
+        $this->initializeContao();
 
         $controller = new BackendHelp();
 
@@ -153,7 +152,7 @@ class BackendController extends AbstractController
      */
     public function pageAction(): Response
     {
-        $this->get('contao.framework')->initialize();
+        $this->initializeContao();
 
         $controller = new BackendPage();
 
@@ -165,7 +164,7 @@ class BackendController extends AbstractController
      */
     public function popupAction(): Response
     {
-        $this->get('contao.framework')->initialize();
+        $this->initializeContao();
 
         $controller = new BackendPopup();
 
@@ -177,7 +176,7 @@ class BackendController extends AbstractController
      */
     public function switchAction(): Response
     {
-        $this->get('contao.framework')->initialize();
+        $this->initializeContao();
 
         $controller = new BackendSwitch();
 
@@ -189,7 +188,7 @@ class BackendController extends AbstractController
      */
     public function alertsAction(): Response
     {
-        $this->get('contao.framework')->initialize();
+        $this->initializeContao();
 
         $controller = new BackendAlerts();
 

--- a/core-bundle/src/Controller/FrontendController.php
+++ b/core-bundle/src/Controller/FrontendController.php
@@ -14,7 +14,6 @@ namespace Contao\CoreBundle\Controller;
 
 use Contao\CoreBundle\Exception\InsufficientAuthenticationException;
 use Contao\CoreBundle\Exception\ResponseException;
-use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\FrontendCron;
 use Contao\FrontendIndex;
 use Contao\FrontendShare;
@@ -184,7 +183,6 @@ class FrontendController extends AbstractController
     {
         $services = parent::getSubscribedServices();
 
-        $services['contao.framework'] = ContaoFramework::class;
         $services['contao.csrf.token_manager'] = CsrfTokenManagerInterface::class;
 
         return $services;

--- a/core-bundle/src/Controller/FrontendController.php
+++ b/core-bundle/src/Controller/FrontendController.php
@@ -19,7 +19,6 @@ use Contao\FrontendCron;
 use Contao\FrontendIndex;
 use Contao\FrontendShare;
 use Contao\PageError401;
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
@@ -34,7 +33,7 @@ class FrontendController extends AbstractController
 {
     public function indexAction(): Response
     {
-        $this->get('contao.framework')->initialize();
+        $this->initializeContao();
 
         $controller = new FrontendIndex();
 
@@ -46,7 +45,7 @@ class FrontendController extends AbstractController
      */
     public function cronAction(): Response
     {
-        $this->get('contao.framework')->initialize();
+        $this->initializeContao();
 
         $controller = new FrontendCron();
 
@@ -58,7 +57,7 @@ class FrontendController extends AbstractController
      */
     public function shareAction(): RedirectResponse
     {
-        $this->get('contao.framework')->initialize();
+        $this->initializeContao();
 
         $controller = new FrontendShare();
 
@@ -74,7 +73,7 @@ class FrontendController extends AbstractController
      */
     public function loginAction(): Response
     {
-        $this->get('contao.framework')->initialize();
+        $this->initializeContao();
 
         if (!isset($GLOBALS['TL_PTY']['error_401']) || !class_exists($GLOBALS['TL_PTY']['error_401'])) {
             throw new UnauthorizedHttpException('', 'Not authorized');
@@ -160,7 +159,7 @@ class FrontendController extends AbstractController
      */
     public function twoFactorAuthenticationAction(): Response
     {
-        $this->get('contao.framework')->initialize();
+        $this->initializeContao();
 
         if (!isset($GLOBALS['TL_PTY']['error_401']) || !class_exists($GLOBALS['TL_PTY']['error_401'])) {
             throw new UnauthorizedHttpException('', 'Not authorized');

--- a/core-bundle/src/Controller/FrontendController.php
+++ b/core-bundle/src/Controller/FrontendController.php
@@ -33,7 +33,7 @@ class FrontendController extends AbstractController
 {
     public function indexAction(): Response
     {
-        $this->initializeContao();
+        $this->initializeContaoFramework();
 
         $controller = new FrontendIndex();
 
@@ -45,7 +45,7 @@ class FrontendController extends AbstractController
      */
     public function cronAction(): Response
     {
-        $this->initializeContao();
+        $this->initializeContaoFramework();
 
         $controller = new FrontendCron();
 
@@ -57,7 +57,7 @@ class FrontendController extends AbstractController
      */
     public function shareAction(): RedirectResponse
     {
-        $this->initializeContao();
+        $this->initializeContaoFramework();
 
         $controller = new FrontendShare();
 
@@ -73,7 +73,7 @@ class FrontendController extends AbstractController
      */
     public function loginAction(): Response
     {
-        $this->initializeContao();
+        $this->initializeContaoFramework();
 
         if (!isset($GLOBALS['TL_PTY']['error_401']) || !class_exists($GLOBALS['TL_PTY']['error_401'])) {
             throw new UnauthorizedHttpException('', 'Not authorized');
@@ -159,7 +159,7 @@ class FrontendController extends AbstractController
      */
     public function twoFactorAuthenticationAction(): Response
     {
-        $this->initializeContao();
+        $this->initializeContaoFramework();
 
         if (!isset($GLOBALS['TL_PTY']['error_401']) || !class_exists($GLOBALS['TL_PTY']['error_401'])) {
             throw new UnauthorizedHttpException('', 'Not authorized');


### PR DESCRIPTION
The Symfony `AbstractController` combines several useful features into simple method calls. We could do the same for Controllers that usually need the same Contao stuff. There's more that I can imagine, like

 - getting the front end or back end user (across firewall scopes)
 - checking if front end preview is enabled
 - generating a response from a Contao template
 - checking front end or back end scopes