### PR TITLE
Pass the mime type to the download element links

### DIFF
--- a/core-bundle/src/Resources/contao/templates/elements/ce_download.html5
+++ b/core-bundle/src/Resources/contao/templates/elements/ce_download.html5
@@ -3,7 +3,7 @@
 <?php $this->block('content'); ?>
 
   <p class="download-element ext-<?= $this->extension ?>">
-    <a href="<?= $this->href ?>" title="<?= $this->title ?>"><?= $this->link ?> <span class="size">(<?= $this->filesize ?>)</span></a>
+    <a href="<?= $this->href ?>" title="<?= $this->title ?>" type="<?= $this->mime ?>"><?= $this->link ?> <span class="size">(<?= $this->filesize ?>)</span></a>
   </p>
 
 <?php $this->endblock(); ?>

--- a/core-bundle/src/Resources/contao/templates/elements/ce_downloads.html5
+++ b/core-bundle/src/Resources/contao/templates/elements/ce_downloads.html5
@@ -5,7 +5,7 @@
   <ul>
     <?php foreach ($this->files as $file): ?>
       <li class="download-element ext-<?= $file['extension'] ?>">
-        <a href="<?= $file['href'] ?>" title="<?= $file['title'] ?>"><?= $file['link'] ?> <span class="size">(<?= $file['filesize'] ?>)</span></a>
+        <a href="<?= $file['href'] ?>" title="<?= $file['title'] ?>" type="<?= $file['mime'] ?>"><?= $file['link'] ?> <span class="size">(<?= $file['filesize'] ?>)</span></a>
       </li>
     <?php endforeach; ?>
   </ul>


### PR DESCRIPTION
It's a completely optional attribute but we allow e.g. search engines to not follow these links if they don't want to (e.g. if they do not support indexing pdf files etc.) as they can check the content type.

