### PR TITLE
Use environment variables for app config

### DIFF
--- a/manager-bundle/src/Resources/skeleton/config/config.yml
+++ b/manager-bundle/src/Resources/skeleton/config/config.yml
@@ -11,7 +11,7 @@ parameters:
 framework:
     esi: { enabled: true }
     translator: { fallbacks: ['%locale%'] }
-    secret: '%secret%'
+    secret: '%env(APP_SECRET)%'
     router:
         resource: 'contao_manager.routing_loader::loadFromPlugins'
         type: service
@@ -35,12 +35,7 @@ doctrine:
         default_connection: default
         connections:
             default:
-                driver: pdo_mysql
-                host: '%database_host%'
-                port: '%database_port%'
-                user: '%database_user%'
-                password: '%database_password%'
-                dbname: '%database_name%'
+                url: '%env(DATABASE_URL)%'
                 charset: utf8mb4
                 default_table_options:
                     charset: utf8mb4

--- a/manager-bundle/src/Resources/skeleton/config/parameters.yml
+++ b/manager-bundle/src/Resources/skeleton/config/parameters.yml
@@ -1,5 +1,7 @@
 # Default parameters
 parameters:
+    env(APP_SECRET): '%secret%'
+    env(DATABASE_URL): 'mysql://%database_user%:%database_password%@%database_host%:%database_port%/%database_name%'
     database_host: localhost
     database_port: 3306
     database_user: ~


### PR DESCRIPTION
This allows to use `.env` files for the application configuration, as is best practice in Symfony.

FYI
 - If the env variable is not set, the old parameters are still applied, so there should be full BC
 - That also means the install tool does not need to be updated
 - The Contao API already provides support for reading + writing the `.env` variables, so the Manager would already be able to configure the database connection 😎 