### PR TITLE
Use the security helper

### DIFF
--- a/calendar-bundle/src/Picker/EventPickerProvider.php
+++ b/calendar-bundle/src/Picker/EventPickerProvider.php
@@ -19,10 +19,26 @@ use Contao\CoreBundle\Framework\FrameworkAwareTrait;
 use Contao\CoreBundle\Picker\AbstractInsertTagPickerProvider;
 use Contao\CoreBundle\Picker\DcaPickerProviderInterface;
 use Contao\CoreBundle\Picker\PickerConfig;
+use Knp\Menu\FactoryInterface;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Security\Core\Security;
+use Symfony\Component\Translation\TranslatorInterface;
 
 class EventPickerProvider extends AbstractInsertTagPickerProvider implements DcaPickerProviderInterface, FrameworkAwareInterface
 {
     use FrameworkAwareTrait;
+
+    /**
+     * @var Security
+     */
+    private $security;
+
+    public function __construct(Security $security, FactoryInterface $menuFactory, RouterInterface $router, TranslatorInterface $translator = null)
+    {
+        parent::__construct($menuFactory, $router, $translator);
+
+        $this->security = $security;
+    }
 
     /**
      * {@inheritdoc}
@@ -37,7 +53,7 @@ class EventPickerProvider extends AbstractInsertTagPickerProvider implements Dca
      */
     public function supportsContext($context): bool
     {
-        return 'link' === $context && $this->getUser()->hasAccess('calendar', 'modules');
+        return 'link' === $context && $this->security->isGranted('contao_user.modules', 'calendar');
     }
 
     /**

--- a/calendar-bundle/src/Resources/config/services.yml
+++ b/calendar-bundle/src/Resources/config/services.yml
@@ -7,10 +7,9 @@ services:
     contao_calendar.picker.event_provider:
         class: Contao\CalendarBundle\Picker\EventPickerProvider
         arguments:
+            - '@security.helper'
             - '@knp_menu.factory'
             - '@router'
             - '@translator'
-        calls:
-            - [setTokenStorage, ['@security.token_storage']]
         tags:
             - { name: contao.picker_provider, priority: 96 }

--- a/calendar-bundle/tests/DependencyInjection/ContaoCalendarExtensionTest.php
+++ b/calendar-bundle/tests/DependencyInjection/ContaoCalendarExtensionTest.php
@@ -106,9 +106,10 @@ class ContaoCalendarExtensionTest extends TestCase
         $definition = $this->container->getDefinition('contao_calendar.picker.event_provider');
 
         $this->assertSame(EventPickerProvider::class, $definition->getClass());
-        $this->assertSame('knp_menu.factory', (string) $definition->getArgument(0));
-        $this->assertSame('router', (string) $definition->getArgument(1));
-        $this->assertSame('translator', (string) $definition->getArgument(2));
+        $this->assertSame('security.helper', (string) $definition->getArgument(0));
+        $this->assertSame('knp_menu.factory', (string) $definition->getArgument(1));
+        $this->assertSame('router', (string) $definition->getArgument(2));
+        $this->assertSame('translator', (string) $definition->getArgument(3));
 
         $conditionals = $definition->getInstanceofConditionals();
 
@@ -119,8 +120,6 @@ class ContaoCalendarExtensionTest extends TestCase
         $this->assertSame('setFramework', $childDefinition->getMethodCalls()[0][0]);
 
         $tags = $definition->getTags();
-
-        $this->assertSame('setTokenStorage', $definition->getMethodCalls()[0][0]);
 
         $this->assertArrayHasKey('contao.picker_provider', $tags);
         $this->assertSame(96, $tags['contao.picker_provider'][0]['priority']);

--- a/calendar-bundle/tests/Picker/EventPickerProviderTest.php
+++ b/calendar-bundle/tests/Picker/EventPickerProviderTest.php
@@ -29,8 +29,6 @@ class EventPickerProviderTest extends ContaoTestCase
 {
     public function testCreatesTheMenuItem(): void
     {
-        $picker = $this->getPicker();
-
         $config = json_encode([
             'context' => 'link',
             'extras' => [],
@@ -42,6 +40,7 @@ class EventPickerProviderTest extends ContaoTestCase
             $config = $encoded;
         }
 
+        $picker = $this->getPicker();
         $item = $picker->createMenuItem(new PickerConfig('link', [], '', 'eventPicker'));
         $uri = 'contao_backend?do=calendar&popup=1&picker='.strtr(base64_encode($config), '+/=', '-_,');
 
@@ -99,7 +98,6 @@ class EventPickerProviderTest extends ContaoTestCase
     public function testReturnsTheDcaAttributes(): void
     {
         $picker = $this->getPicker();
-
         $extra = ['source' => 'tl_calendar_events.2'];
 
         $this->assertSame(

--- a/calendar-bundle/tests/Picker/EventPickerProviderTest.php
+++ b/calendar-bundle/tests/Picker/EventPickerProviderTest.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 
 namespace Contao\CalendarBundle\Tests\Picker;
 
-use Contao\BackendUser;
 use Contao\CalendarBundle\Picker\EventPickerProvider;
 use Contao\CalendarEventsModel;
 use Contao\CalendarModel;
@@ -23,23 +22,209 @@ use Knp\Menu\ItemInterface;
 use Knp\Menu\MenuItem;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Routing\RouterInterface;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
-use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Security;
 use Symfony\Component\Translation\TranslatorInterface;
 
 class EventPickerProviderTest extends ContaoTestCase
 {
-    /**
-     * @var EventPickerProvider
-     */
-    private $provider;
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function setUp(): void
+    public function testCreatesTheMenuItem(): void
     {
-        parent::setUp();
+        $picker = $this->getPicker();
+
+        $config = json_encode([
+            'context' => 'link',
+            'extras' => [],
+            'current' => 'eventPicker',
+            'value' => '',
+        ]);
+
+        if (\function_exists('gzencode') && false !== ($encoded = @gzencode($config))) {
+            $config = $encoded;
+        }
+
+        $item = $picker->createMenuItem(new PickerConfig('link', [], '', 'eventPicker'));
+        $uri = 'contao_backend?do=calendar&popup=1&picker='.strtr(base64_encode($config), '+/=', '-_,');
+
+        $this->assertSame('Event picker', $item->getLabel());
+        $this->assertSame(['class' => 'eventPicker'], $item->getLinkAttributes());
+        $this->assertTrue($item->isCurrent());
+        $this->assertSame($uri, $item->getUri());
+    }
+
+    public function testChecksIfAMenuItemIsCurrent(): void
+    {
+        $picker = $this->getPicker();
+
+        $this->assertTrue($picker->isCurrent(new PickerConfig('link', [], '', 'eventPicker')));
+        $this->assertFalse($picker->isCurrent(new PickerConfig('link', [], '', 'filePicker')));
+    }
+
+    public function testReturnsTheCorrectName(): void
+    {
+        $picker = $this->getPicker();
+
+        $this->assertSame('eventPicker', $picker->getName());
+    }
+
+    public function testChecksIfAContextIsSupported(): void
+    {
+        $picker = $this->getPicker(true);
+
+        $this->assertTrue($picker->supportsContext('link'));
+        $this->assertFalse($picker->supportsContext('file'));
+    }
+
+    public function testChecksIfModuleAccessIsGranted(): void
+    {
+        $picker = $this->getPicker(false);
+
+        $this->assertFalse($picker->supportsContext('link'));
+    }
+
+    public function testChecksIfAValueIsSupported(): void
+    {
+        $picker = $this->getPicker();
+
+        $this->assertTrue($picker->supportsValue(new PickerConfig('link', [], '{{event_url::5}}')));
+        $this->assertFalse($picker->supportsValue(new PickerConfig('link', [], '{{link_url::5}}')));
+    }
+
+    public function testReturnsTheDcaTable(): void
+    {
+        $picker = $this->getPicker();
+
+        $this->assertSame('tl_calendar_events', $picker->getDcaTable());
+    }
+
+    public function testReturnsTheDcaAttributes(): void
+    {
+        $picker = $this->getPicker();
+
+        $extra = ['source' => 'tl_calendar_events.2'];
+
+        $this->assertSame(
+            [
+                'fieldType' => 'radio',
+                'preserveRecord' => 'tl_calendar_events.2',
+                'value' => '5',
+            ],
+            $picker->getDcaAttributes(new PickerConfig('link', $extra, '{{event_url::5}}'))
+        );
+
+        $this->assertSame(
+            [
+                'fieldType' => 'radio',
+                'preserveRecord' => 'tl_calendar_events.2',
+            ],
+            $picker->getDcaAttributes(new PickerConfig('link', $extra, '{{link_url::5}}'))
+        );
+    }
+
+    public function testConvertsTheDcaValue(): void
+    {
+        $picker = $this->getPicker();
+
+        $this->assertSame('{{event_url::5}}', $picker->convertDcaValue(new PickerConfig('link'), 5));
+    }
+
+    public function testConvertsTheDcaValueWithACustomInsertTag(): void
+    {
+        $picker = $this->getPicker();
+
+        $this->assertSame(
+            '{{event_title::5}}',
+            $picker->convertDcaValue(new PickerConfig('link', ['insertTag' => '{{event_title::%s}}']), 5)
+        );
+    }
+
+    public function testAddsTableAndIdIfThereIsAValue(): void
+    {
+        /** @var CalendarModel&MockObject $calendarModel */
+        $calendarModel = $this->mockClassWithProperties(CalendarModel::class);
+        $calendarModel->id = 1;
+
+        $calendarEvents = $this->createMock(CalendarEventsModel::class);
+        $calendarEvents
+            ->expects($this->once())
+            ->method('getRelated')
+            ->with('pid')
+            ->willReturn($calendarModel)
+        ;
+
+        $config = new PickerConfig('link', [], '{{event_url::1}}', 'eventPicker');
+
+        $adapters = [
+            CalendarEventsModel::class => $this->mockConfiguredAdapter(['findById' => $calendarEvents]),
+        ];
+
+        $picker = $this->getPicker();
+        $picker->setFramework($this->mockContaoFramework($adapters));
+
+        $method = new \ReflectionMethod(EventPickerProvider::class, 'getRouteParameters');
+        $method->setAccessible(true);
+        $params = $method->invokeArgs($picker, [$config]);
+
+        $this->assertSame('calendar', $params['do']);
+        $this->assertSame('tl_calendar_events', $params['table']);
+        $this->assertSame(1, $params['id']);
+    }
+
+    public function testDoesNotAddTableAndIdIfThereIsNoEventsModel(): void
+    {
+        $config = new PickerConfig('link', [], '{{event_url::1}}', 'eventPicker');
+
+        $adapters = [
+            CalendarEventsModel::class => $this->mockConfiguredAdapter(['findById' => null]),
+        ];
+
+        $picker = $this->getPicker();
+        $picker->setFramework($this->mockContaoFramework($adapters));
+
+        $method = new \ReflectionMethod(EventPickerProvider::class, 'getRouteParameters');
+        $method->setAccessible(true);
+        $params = $method->invokeArgs($picker, [$config]);
+
+        $this->assertSame('calendar', $params['do']);
+        $this->assertArrayNotHasKey('tl_calendar_events', $params);
+        $this->assertArrayNotHasKey('id', $params);
+    }
+
+    public function testDoesNotAddTableAndIdIfThereIsNoCalendarModel(): void
+    {
+        $calendarEvents = $this->createMock(CalendarEventsModel::class);
+        $calendarEvents
+            ->expects($this->once())
+            ->method('getRelated')
+            ->with('pid')
+            ->willReturn(null)
+        ;
+
+        $config = new PickerConfig('link', [], '{{event_url::1}}', 'eventPicker');
+
+        $adapters = [
+            CalendarEventsModel::class => $this->mockConfiguredAdapter(['findById' => $calendarEvents]),
+        ];
+
+        $picker = $this->getPicker();
+        $picker->setFramework($this->mockContaoFramework($adapters));
+
+        $method = new \ReflectionMethod(EventPickerProvider::class, 'getRouteParameters');
+        $method->setAccessible(true);
+        $params = $method->invokeArgs($picker, [$config]);
+
+        $this->assertSame('calendar', $params['do']);
+        $this->assertArrayNotHasKey('tl_calendar_events', $params);
+        $this->assertArrayNotHasKey('id', $params);
+    }
+
+    private function getPicker(bool $accessGranted = null): EventPickerProvider
+    {
+        $security = $this->createMock(Security::class);
+        $security
+            ->expects(null === $accessGranted ? $this->never() : $this->once())
+            ->method('isGranted')
+            ->willReturn($accessGranted)
+        ;
 
         $menuFactory = $this->createMock(FactoryInterface::class);
         $menuFactory
@@ -73,216 +258,6 @@ class EventPickerProviderTest extends ContaoTestCase
             ->willReturn('Event picker')
         ;
 
-        $this->provider = new EventPickerProvider($menuFactory, $router, $translator);
-    }
-
-    public function testCreatesTheMenuItem(): void
-    {
-        $picker = json_encode([
-            'context' => 'link',
-            'extras' => [],
-            'current' => 'eventPicker',
-            'value' => '',
-        ]);
-
-        if (\function_exists('gzencode') && false !== ($encoded = @gzencode($picker))) {
-            $picker = $encoded;
-        }
-
-        $item = $this->provider->createMenuItem(new PickerConfig('link', [], '', 'eventPicker'));
-        $uri = 'contao_backend?do=calendar&popup=1&picker='.strtr(base64_encode($picker), '+/=', '-_,');
-
-        $this->assertSame('Event picker', $item->getLabel());
-        $this->assertSame(['class' => 'eventPicker'], $item->getLinkAttributes());
-        $this->assertTrue($item->isCurrent());
-        $this->assertSame($uri, $item->getUri());
-    }
-
-    public function testChecksIfAMenuItemIsCurrent(): void
-    {
-        $this->assertTrue($this->provider->isCurrent(new PickerConfig('link', [], '', 'eventPicker')));
-        $this->assertFalse($this->provider->isCurrent(new PickerConfig('link', [], '', 'filePicker')));
-    }
-
-    public function testReturnsTheCorrectName(): void
-    {
-        $this->assertSame('eventPicker', $this->provider->getName());
-    }
-
-    public function testChecksIfAContextIsSupported(): void
-    {
-        $this->provider->setTokenStorage($this->mockTokenStorage(BackendUser::class));
-
-        $this->assertTrue($this->provider->supportsContext('link'));
-        $this->assertFalse($this->provider->supportsContext('file'));
-    }
-
-    public function testFailsToCheckTheContextIfThereIsNoTokenStorage(): void
-    {
-        $this->expectException('RuntimeException');
-        $this->expectExceptionMessage('No token storage provided');
-
-        $this->provider->supportsContext('link');
-    }
-
-    public function testFailsToCheckTheContextIfThereIsNoToken(): void
-    {
-        $tokenStorage = $this->createMock(TokenStorageInterface::class);
-        $tokenStorage
-            ->method('getToken')
-            ->willReturn(null)
-        ;
-
-        $this->provider->setTokenStorage($tokenStorage);
-
-        $this->expectException('RuntimeException');
-        $this->expectExceptionMessage('No token provided');
-
-        $this->provider->supportsContext('link');
-    }
-
-    public function testFailsToCheckTheContextIfThereIsNoUser(): void
-    {
-        $token = $this->createMock(TokenInterface::class);
-        $token
-            ->method('getUser')
-            ->willReturn(null)
-        ;
-
-        $tokenStorage = $this->createMock(TokenStorageInterface::class);
-        $tokenStorage
-            ->method('getToken')
-            ->willReturn($token)
-        ;
-
-        $this->provider->setTokenStorage($tokenStorage);
-
-        $this->expectException('RuntimeException');
-        $this->expectExceptionMessage('The token does not contain a back end user object');
-
-        $this->provider->supportsContext('link');
-    }
-
-    public function testChecksIfAValueIsSupported(): void
-    {
-        $this->assertTrue($this->provider->supportsValue(new PickerConfig('link', [], '{{event_url::5}}')));
-        $this->assertFalse($this->provider->supportsValue(new PickerConfig('link', [], '{{link_url::5}}')));
-    }
-
-    public function testReturnsTheDcaTable(): void
-    {
-        $this->assertSame('tl_calendar_events', $this->provider->getDcaTable());
-    }
-
-    public function testReturnsTheDcaAttributes(): void
-    {
-        $extra = ['source' => 'tl_calendar_events.2'];
-
-        $this->assertSame(
-            [
-                'fieldType' => 'radio',
-                'preserveRecord' => 'tl_calendar_events.2',
-                'value' => '5',
-            ],
-            $this->provider->getDcaAttributes(new PickerConfig('link', $extra, '{{event_url::5}}'))
-        );
-
-        $this->assertSame(
-            [
-                'fieldType' => 'radio',
-                'preserveRecord' => 'tl_calendar_events.2',
-            ],
-            $this->provider->getDcaAttributes(new PickerConfig('link', $extra, '{{link_url::5}}'))
-        );
-    }
-
-    public function testConvertsTheDcaValue(): void
-    {
-        $this->assertSame('{{event_url::5}}', $this->provider->convertDcaValue(new PickerConfig('link'), 5));
-    }
-
-    public function testConvertsTheDcaValueWithACustomInsertTag(): void
-    {
-        $this->assertSame(
-            '{{event_title::5}}',
-            $this->provider->convertDcaValue(new PickerConfig('link', ['insertTag' => '{{event_title::%s}}']), 5)
-        );
-    }
-
-    public function testAddsTableAndIdIfThereIsAValue(): void
-    {
-        /** @var CalendarModel&MockObject $calendarModel */
-        $calendarModel = $this->mockClassWithProperties(CalendarModel::class);
-        $calendarModel->id = 1;
-
-        $calendarEvents = $this->createMock(CalendarEventsModel::class);
-        $calendarEvents
-            ->expects($this->once())
-            ->method('getRelated')
-            ->with('pid')
-            ->willReturn($calendarModel)
-        ;
-
-        $config = new PickerConfig('link', [], '{{event_url::1}}', 'eventPicker');
-
-        $adapters = [
-            CalendarEventsModel::class => $this->mockConfiguredAdapter(['findById' => $calendarEvents]),
-        ];
-
-        $this->provider->setFramework($this->mockContaoFramework($adapters));
-
-        $method = new \ReflectionMethod(EventPickerProvider::class, 'getRouteParameters');
-        $method->setAccessible(true);
-        $params = $method->invokeArgs($this->provider, [$config]);
-
-        $this->assertSame('calendar', $params['do']);
-        $this->assertSame('tl_calendar_events', $params['table']);
-        $this->assertSame(1, $params['id']);
-    }
-
-    public function testDoesNotAddTableAndIdIfThereIsNoEventsModel(): void
-    {
-        $config = new PickerConfig('link', [], '{{event_url::1}}', 'eventPicker');
-
-        $adapters = [
-            CalendarEventsModel::class => $this->mockConfiguredAdapter(['findById' => null]),
-        ];
-
-        $this->provider->setFramework($this->mockContaoFramework($adapters));
-
-        $method = new \ReflectionMethod(EventPickerProvider::class, 'getRouteParameters');
-        $method->setAccessible(true);
-        $params = $method->invokeArgs($this->provider, [$config]);
-
-        $this->assertSame('calendar', $params['do']);
-        $this->assertArrayNotHasKey('tl_calendar_events', $params);
-        $this->assertArrayNotHasKey('id', $params);
-    }
-
-    public function testDoesNotAddTableAndIdIfThereIsNoCalendarModel(): void
-    {
-        $calendarEvents = $this->createMock(CalendarEventsModel::class);
-        $calendarEvents
-            ->expects($this->once())
-            ->method('getRelated')
-            ->with('pid')
-            ->willReturn(null)
-        ;
-
-        $config = new PickerConfig('link', [], '{{event_url::1}}', 'eventPicker');
-
-        $adapters = [
-            CalendarEventsModel::class => $this->mockConfiguredAdapter(['findById' => $calendarEvents]),
-        ];
-
-        $this->provider->setFramework($this->mockContaoFramework($adapters));
-
-        $method = new \ReflectionMethod(EventPickerProvider::class, 'getRouteParameters');
-        $method->setAccessible(true);
-        $params = $method->invokeArgs($this->provider, [$config]);
-
-        $this->assertSame('calendar', $params['do']);
-        $this->assertArrayNotHasKey('tl_calendar_events', $params);
-        $this->assertArrayNotHasKey('id', $params);
+        return new EventPickerProvider($security, $menuFactory, $router, $translator);
     }
 }

--- a/core-bundle/src/EventListener/BackendLocaleListener.php
+++ b/core-bundle/src/EventListener/BackendLocaleListener.php
@@ -14,25 +14,24 @@ namespace Contao\CoreBundle\EventListener;
 
 use Contao\BackendUser;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
-use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Security;
 use Symfony\Component\Translation\TranslatorInterface;
 
 class BackendLocaleListener
 {
     /**
-     * @var TokenStorageInterface
+     * @var Security
      */
-    private $tokenStorage;
+    private $security;
 
     /**
      * @var TranslatorInterface
      */
     private $translator;
 
-    public function __construct(TokenStorageInterface $tokenStorage, TranslatorInterface $translator)
+    public function __construct(Security $security, TranslatorInterface $translator)
     {
-        $this->tokenStorage = $tokenStorage;
+        $this->security = $security;
         $this->translator = $translator;
     }
 
@@ -41,13 +40,7 @@ class BackendLocaleListener
      */
     public function onKernelRequest(GetResponseEvent $event): void
     {
-        $token = $this->tokenStorage->getToken();
-
-        if (!$token instanceof TokenInterface) {
-            return;
-        }
-
-        $user = $token->getUser();
+        $user = $this->security->getUser();
 
         if (!$user instanceof BackendUser || !$user->language) {
             return;

--- a/core-bundle/src/EventListener/BackendMenuListener.php
+++ b/core-bundle/src/EventListener/BackendMenuListener.php
@@ -16,18 +16,18 @@ use Contao\BackendUser;
 use Contao\CoreBundle\Event\MenuEvent;
 use Knp\Menu\FactoryInterface;
 use Knp\Menu\ItemInterface;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Security;
 
 class BackendMenuListener
 {
     /**
-     * @var TokenStorageInterface
+     * @var Security
      */
-    private $tokenStorage;
+    private $security;
 
-    public function __construct(TokenStorageInterface $tokenStorage)
+    public function __construct(Security $security)
     {
-        $this->tokenStorage = $tokenStorage;
+        $this->security = $security;
     }
 
     /**
@@ -35,13 +35,7 @@ class BackendMenuListener
      */
     public function onBuild(MenuEvent $event): void
     {
-        $token = $this->tokenStorage->getToken();
-
-        if (null === $token) {
-            return;
-        }
-
-        $user = $token->getUser();
+        $user = $this->security->getUser();
 
         if (!$user instanceof BackendUser) {
             return;

--- a/core-bundle/src/EventListener/PrettyErrorScreenListener.php
+++ b/core-bundle/src/EventListener/PrettyErrorScreenListener.php
@@ -28,6 +28,7 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\Exception\ServiceUnavailableHttpException;
 use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException;
 use Symfony\Component\Security\Core\Security;
 use Twig\Environment;
 use Twig\Error\Error;
@@ -94,8 +95,14 @@ class PrettyErrorScreenListener
     {
         $exception = $event->getException();
 
+        try {
+            $isBackendUser = $this->security->isGranted('ROLE_USER');
+        } catch (AuthenticationCredentialsNotFoundException $e) {
+            $isBackendUser = false;
+        }
+
         switch (true) {
-            case $this->security->isGranted('ROLE_USER'):
+            case $isBackendUser:
                 $this->renderBackendException($event);
                 break;
 

--- a/core-bundle/src/EventListener/StoreRefererListener.php
+++ b/core-bundle/src/EventListener/StoreRefererListener.php
@@ -13,32 +13,26 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\EventListener;
 
 use Contao\CoreBundle\Routing\ScopeMatcher;
+use Contao\User;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
-use Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolverInterface;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Security;
 
 class StoreRefererListener
 {
     /**
-     * @var TokenStorageInterface
+     * @var Security
      */
-    private $tokenStorage;
-
-    /**
-     * @var AuthenticationTrustResolverInterface
-     */
-    private $authenticationTrustResolver;
+    private $security;
 
     /**
      * @var ScopeMatcher
      */
     private $scopeMatcher;
 
-    public function __construct(TokenStorageInterface $tokenStorage, AuthenticationTrustResolverInterface $authenticationTrustResolver, ScopeMatcher $scopeMatcher)
+    public function __construct(Security $security, ScopeMatcher $scopeMatcher)
     {
-        $this->tokenStorage = $tokenStorage;
-        $this->authenticationTrustResolver = $authenticationTrustResolver;
+        $this->security = $security;
         $this->scopeMatcher = $scopeMatcher;
     }
 
@@ -63,9 +57,9 @@ class StoreRefererListener
             return;
         }
 
-        $token = $this->tokenStorage->getToken();
+        $user = $this->security->getUser();
 
-        if (null === $token || $this->authenticationTrustResolver->isAnonymous($token)) {
+        if (!$user instanceof User) {
             return;
         }
 

--- a/core-bundle/src/EventListener/SwitchUserListener.php
+++ b/core-bundle/src/EventListener/SwitchUserListener.php
@@ -49,11 +49,7 @@ class SwitchUserListener
             throw new \RuntimeException('The token storage did not contain a token.');
         }
 
-        $sourceUser = $token->getUser();
-
-        if ($sourceUser instanceof UserInterface) {
-            $sourceUser = $sourceUser->getUsername();
-        }
+        $sourceUser = $token->getUsername();
 
         $targetUser = $event->getTargetUser();
 

--- a/core-bundle/src/EventListener/UserSessionListener.php
+++ b/core-bundle/src/EventListener/UserSessionListener.php
@@ -22,8 +22,7 @@ use Symfony\Component\HttpFoundation\Session\SessionBagInterface;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
-use Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolverInterface;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Security;
 
 class UserSessionListener
 {
@@ -33,14 +32,9 @@ class UserSessionListener
     private $connection;
 
     /**
-     * @var TokenStorageInterface
+     * @var Security
      */
-    private $tokenStorage;
-
-    /**
-     * @var AuthenticationTrustResolverInterface
-     */
-    private $authenticationTrustResolver;
+    private $security;
 
     /**
      * @var ScopeMatcher
@@ -52,11 +46,10 @@ class UserSessionListener
      */
     private $eventDispatcher;
 
-    public function __construct(Connection $connection, TokenStorageInterface $tokenStorage, AuthenticationTrustResolverInterface $authenticationTrustResolver, ScopeMatcher $scopeMatcher, EventDispatcherInterface $eventDispatcher)
+    public function __construct(Connection $connection, Security $security, ScopeMatcher $scopeMatcher, EventDispatcherInterface $eventDispatcher)
     {
         $this->connection = $connection;
-        $this->tokenStorage = $tokenStorage;
-        $this->authenticationTrustResolver = $authenticationTrustResolver;
+        $this->security = $security;
         $this->scopeMatcher = $scopeMatcher;
         $this->eventDispatcher = $eventDispatcher;
     }
@@ -70,13 +63,7 @@ class UserSessionListener
             return;
         }
 
-        $token = $this->tokenStorage->getToken();
-
-        if (null === $token || $this->authenticationTrustResolver->isAnonymous($token)) {
-            return;
-        }
-
-        $user = $token->getUser();
+        $user = $this->security->getUser();
 
         if (!$user instanceof User) {
             return;
@@ -103,13 +90,7 @@ class UserSessionListener
             return;
         }
 
-        $token = $this->tokenStorage->getToken();
-
-        if (null === $token || $this->authenticationTrustResolver->isAnonymous($token)) {
-            return;
-        }
-
-        $user = $token->getUser();
+        $user = $this->security->getUser();
 
         if (!$user instanceof User) {
             return;

--- a/core-bundle/src/Picker/AbstractPickerProvider.php
+++ b/core-bundle/src/Picker/AbstractPickerProvider.php
@@ -81,11 +81,12 @@ abstract class AbstractPickerProvider implements PickerProviderInterface
     }
 
     /**
-     * @deprecated Deprecated since Contao 4.8. Use Symfony\Component\Security\Core\Security instead.
+     * @deprecated Deprecated since Contao 4.8, to be removed in Contao 5.0;
+     *             use Symfony security instead
      */
     public function setTokenStorage(TokenStorageInterface $tokenStorage): void
     {
-        @trigger_error('Using '.__METHOD__.' is deprecated since Contao 4.8. Use Symfony\Component\Security\Core\Security instead.', E_USER_DEPRECATED);
+        @trigger_error('Using AbstractPickerProvider::setTokenStorage() has been deprecated and will no longer work in Contao 5.0. Use Symfony security instead.', E_USER_DEPRECATED);
 
         $this->tokenStorage = $tokenStorage;
     }
@@ -103,11 +104,12 @@ abstract class AbstractPickerProvider implements PickerProviderInterface
      *
      * @throws \RuntimeException
      *
-     * @deprecated Deprecated since Contao 4.8. Use Symfony\Component\Security\Core\Security instead.
+     * @deprecated Deprecated since Contao 4.8, to be removed in Contao 5.0;
+     *             use Symfony security instead
      */
     protected function getUser(): BackendUser
     {
-        @trigger_error('Using '.__METHOD__.' is deprecated since Contao 4.8. Use Symfony\Component\Security\Core\Security instead.', E_USER_DEPRECATED);
+        @trigger_error('Using AbstractPickerProvider::getUser() has been deprecated and will no longer work in Contao 5.0. Use Symfony security instead.', E_USER_DEPRECATED);
 
         if (null === $this->tokenStorage) {
             throw new \RuntimeException('No token storage provided');

--- a/core-bundle/src/Picker/AbstractPickerProvider.php
+++ b/core-bundle/src/Picker/AbstractPickerProvider.php
@@ -80,8 +80,13 @@ abstract class AbstractPickerProvider implements PickerProviderInterface
         );
     }
 
+    /**
+     * @deprecated Deprecated since Contao 4.8. Use Symfony\Component\Security\Core\Security instead.
+     */
     public function setTokenStorage(TokenStorageInterface $tokenStorage): void
     {
+        @trigger_error('Using '.__METHOD__.' is deprecated since Contao 4.8. Use Symfony\Component\Security\Core\Security instead.', E_USER_DEPRECATED);
+
         $this->tokenStorage = $tokenStorage;
     }
 
@@ -97,9 +102,13 @@ abstract class AbstractPickerProvider implements PickerProviderInterface
      * Returns the back end user object.
      *
      * @throws \RuntimeException
+     *
+     * @deprecated Deprecated since Contao 4.8. Use Symfony\Component\Security\Core\Security instead.
      */
     protected function getUser(): BackendUser
     {
+        @trigger_error('Using '.__METHOD__.' is deprecated since Contao 4.8. Use Symfony\Component\Security\Core\Security instead.', E_USER_DEPRECATED);
+
         if (null === $this->tokenStorage) {
             throw new \RuntimeException('No token storage provided');
         }

--- a/core-bundle/src/Picker/ArticlePickerProvider.php
+++ b/core-bundle/src/Picker/ArticlePickerProvider.php
@@ -12,8 +12,25 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Picker;
 
+use Knp\Menu\FactoryInterface;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Security\Core\Security;
+use Symfony\Component\Translation\TranslatorInterface;
+
 class ArticlePickerProvider extends AbstractInsertTagPickerProvider implements DcaPickerProviderInterface
 {
+    /**
+     * @var Security
+     */
+    private $security;
+
+    public function __construct(Security $security, FactoryInterface $menuFactory, RouterInterface $router, TranslatorInterface $translator = null)
+    {
+        parent::__construct($menuFactory, $router, $translator);
+
+        $this->security = $security;
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -27,7 +44,7 @@ class ArticlePickerProvider extends AbstractInsertTagPickerProvider implements D
      */
     public function supportsContext($context): bool
     {
-        return 'link' === $context && $this->getUser()->hasAccess('article', 'modules');
+        return 'link' === $context && $this->security->isGranted('contao_user.modules', 'article');
     }
 
     /**

--- a/core-bundle/src/Picker/FilePickerProvider.php
+++ b/core-bundle/src/Picker/FilePickerProvider.php
@@ -36,7 +36,7 @@ class FilePickerProvider extends AbstractInsertTagPickerProvider implements DcaP
      */
     private $uploadPath;
 
-    public function __construct(Security $security, FactoryInterface $menuFactory, RouterInterface $router, TranslatorInterface $translator, string $uploadPath)
+    public function __construct(Security $security, string $uploadPath, FactoryInterface $menuFactory, RouterInterface $router, TranslatorInterface $translator = null)
     {
         parent::__construct($menuFactory, $router, $translator);
 

--- a/core-bundle/src/Picker/FilePickerProvider.php
+++ b/core-bundle/src/Picker/FilePickerProvider.php
@@ -19,6 +19,7 @@ use Contao\StringUtil;
 use Contao\Validator;
 use Knp\Menu\FactoryInterface;
 use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Security\Core\Security;
 use Symfony\Component\Translation\TranslatorInterface;
 
 class FilePickerProvider extends AbstractInsertTagPickerProvider implements DcaPickerProviderInterface, FrameworkAwareInterface
@@ -26,14 +27,20 @@ class FilePickerProvider extends AbstractInsertTagPickerProvider implements DcaP
     use FrameworkAwareTrait;
 
     /**
+     * @var Security
+     */
+    private $security;
+
+    /**
      * @var string
      */
     private $uploadPath;
 
-    public function __construct(FactoryInterface $menuFactory, RouterInterface $router, TranslatorInterface $translator, string $uploadPath)
+    public function __construct(Security $security, FactoryInterface $menuFactory, RouterInterface $router, TranslatorInterface $translator, string $uploadPath)
     {
         parent::__construct($menuFactory, $router, $translator);
 
+        $this->security = $security;
         $this->uploadPath = $uploadPath;
     }
 
@@ -50,7 +57,7 @@ class FilePickerProvider extends AbstractInsertTagPickerProvider implements DcaP
      */
     public function supportsContext($context): bool
     {
-        return \in_array($context, ['file', 'link'], true) && $this->getUser()->hasAccess('files', 'modules');
+        return \in_array($context, ['file', 'link'], true) && $this->security->isGranted('contao_user.modules', 'files');
     }
 
     /**

--- a/core-bundle/src/Picker/PagePickerProvider.php
+++ b/core-bundle/src/Picker/PagePickerProvider.php
@@ -12,8 +12,25 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Picker;
 
+use Knp\Menu\FactoryInterface;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Security\Core\Security;
+use Symfony\Component\Translation\TranslatorInterface;
+
 class PagePickerProvider extends AbstractInsertTagPickerProvider implements DcaPickerProviderInterface
 {
+    /**
+     * @var Security
+     */
+    private $security;
+
+    public function __construct(Security $security, FactoryInterface $menuFactory, RouterInterface $router, TranslatorInterface $translator = null)
+    {
+        parent::__construct($menuFactory, $router, $translator);
+
+        $this->security = $security;
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -27,7 +44,7 @@ class PagePickerProvider extends AbstractInsertTagPickerProvider implements DcaP
      */
     public function supportsContext($context): bool
     {
-        return \in_array($context, ['page', 'link'], true) && $this->getUser()->hasAccess('page', 'modules');
+        return \in_array($context, ['page', 'link'], true) && $this->security->isGranted('contao_user.modules', 'page');
     }
 
     /**

--- a/core-bundle/src/Resources/config/listener.yml
+++ b/core-bundle/src/Resources/config/listener.yml
@@ -19,7 +19,7 @@ services:
     contao.listener.backend_locale:
         class: Contao\CoreBundle\EventListener\BackendLocaleListener
         arguments:
-            - '@security.token_storage'
+            - '@security.helper'
             - '@translator'
         tags:
             # The priority must be lower than the one of the firewall listener (defaults to 8)
@@ -28,7 +28,7 @@ services:
     contao.listener.backend_menu_listener:
         class: Contao\CoreBundle\EventListener\BackendMenuListener
         arguments:
-            - '@security.token_storage'
+            - '@security.helper'
         tags:
             - { name: kernel.event_listener, event: contao.backend_menu_build, method: onBuild }
 
@@ -134,7 +134,7 @@ services:
             - '%contao.pretty_error_screens%'
             - '@twig'
             - '@contao.framework'
-            - '@security.token_storage'
+            - '@security.helper'
             - '@logger'
         tags:
             # The priority must be higher than the one of the Twig exception listener (defaults to -128)
@@ -170,8 +170,7 @@ services:
     contao.listener.store_referer:
         class: Contao\CoreBundle\EventListener\StoreRefererListener
         arguments:
-            - '@security.token_storage'
-            - '@security.authentication.trust_resolver'
+            - '@security.helper'
             - '@contao.routing.scope_matcher'
         tags:
             - { name: kernel.event_listener, event: kernel.response, method: onKernelResponse }
@@ -198,8 +197,7 @@ services:
         class: Contao\CoreBundle\EventListener\UserSessionListener
         arguments:
             - '@database_connection'
-            - '@security.token_storage'
-            - '@security.authentication.trust_resolver'
+            - '@security.helper'
             - '@contao.routing.scope_matcher'
             - '@event_dispatcher'
         tags:

--- a/core-bundle/src/Resources/config/services.yml
+++ b/core-bundle/src/Resources/config/services.yml
@@ -298,34 +298,31 @@ services:
     contao.picker.page_provider:
         class: Contao\CoreBundle\Picker\PagePickerProvider
         arguments:
+            - '@security.helper'
             - '@knp_menu.factory'
             - '@router'
             - '@translator'
-        calls:
-            - [setTokenStorage, ['@security.token_storage']]
         tags:
             - { name: contao.picker_provider, priority: 192 }
 
     contao.picker.file_provider:
         class: Contao\CoreBundle\Picker\FilePickerProvider
         arguments:
+            - '@security.helper'
             - '@knp_menu.factory'
             - '@router'
             - '@translator'
             - '%contao.upload_path%'
-        calls:
-            - [setTokenStorage, ['@security.token_storage']]
         tags:
             - { name: contao.picker_provider, priority: 160 }
 
     contao.picker.article_provider:
         class: Contao\CoreBundle\Picker\ArticlePickerProvider
         arguments:
+            - '@security.helper'
             - '@knp_menu.factory'
             - '@router'
             - '@translator'
-        calls:
-            - [setTokenStorage, ['@security.token_storage']]
         tags:
             - { name: contao.picker_provider }
 

--- a/core-bundle/src/Resources/config/services.yml
+++ b/core-bundle/src/Resources/config/services.yml
@@ -309,10 +309,10 @@ services:
         class: Contao\CoreBundle\Picker\FilePickerProvider
         arguments:
             - '@security.helper'
+            - '%contao.upload_path%'
             - '@knp_menu.factory'
             - '@router'
             - '@translator'
-            - '%contao.upload_path%'
         tags:
             - { name: contao.picker_provider, priority: 160 }
 

--- a/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
+++ b/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
@@ -272,7 +272,7 @@ class ContaoCoreExtensionTest extends TestCase
 
         $this->assertSame(BackendLocaleListener::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
-        $this->assertSame('security.token_storage', (string) $definition->getArgument(0));
+        $this->assertSame('security.helper', (string) $definition->getArgument(0));
         $this->assertSame('translator', (string) $definition->getArgument(1));
 
         $tags = $definition->getTags();
@@ -291,7 +291,7 @@ class ContaoCoreExtensionTest extends TestCase
 
         $this->assertSame(BackendMenuListener::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
-        $this->assertSame('security.token_storage', (string) $definition->getArgument(0));
+        $this->assertSame('security.helper', (string) $definition->getArgument(0));
 
         $tags = $definition->getTags();
 
@@ -533,7 +533,7 @@ class ContaoCoreExtensionTest extends TestCase
         $this->assertSame('%contao.pretty_error_screens%', (string) $definition->getArgument(0));
         $this->assertSame('twig', (string) $definition->getArgument(1));
         $this->assertSame('contao.framework', (string) $definition->getArgument(2));
-        $this->assertSame('security.token_storage', (string) $definition->getArgument(3));
+        $this->assertSame('security.helper', (string) $definition->getArgument(3));
         $this->assertSame('logger', (string) $definition->getArgument(4));
 
         $tags = $definition->getTags();
@@ -610,9 +610,8 @@ class ContaoCoreExtensionTest extends TestCase
 
         $this->assertSame(StoreRefererListener::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
-        $this->assertSame('security.token_storage', (string) $definition->getArgument(0));
-        $this->assertSame('security.authentication.trust_resolver', (string) $definition->getArgument(1));
-        $this->assertSame('contao.routing.scope_matcher', (string) $definition->getArgument(2));
+        $this->assertSame('security.helper', (string) $definition->getArgument(0));
+        $this->assertSame('contao.routing.scope_matcher', (string) $definition->getArgument(1));
 
         $tags = $definition->getTags();
 
@@ -668,10 +667,9 @@ class ContaoCoreExtensionTest extends TestCase
         $this->assertSame(EventUserSessionListener::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
         $this->assertSame('database_connection', (string) $definition->getArgument(0));
-        $this->assertSame('security.token_storage', (string) $definition->getArgument(1));
-        $this->assertSame('security.authentication.trust_resolver', (string) $definition->getArgument(2));
-        $this->assertSame('contao.routing.scope_matcher', (string) $definition->getArgument(3));
-        $this->assertSame('event_dispatcher', (string) $definition->getArgument(4));
+        $this->assertSame('security.helper', (string) $definition->getArgument(1));
+        $this->assertSame('contao.routing.scope_matcher', (string) $definition->getArgument(2));
+        $this->assertSame('event_dispatcher', (string) $definition->getArgument(3));
 
         $tags = $definition->getTags();
 

--- a/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
+++ b/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
@@ -1204,14 +1204,10 @@ class ContaoCoreExtensionTest extends TestCase
 
         $this->assertSame(PagePickerProvider::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
-        $this->assertSame('knp_menu.factory', (string) $definition->getArgument(0));
-        $this->assertSame('router', (string) $definition->getArgument(1));
-        $this->assertSame('translator', (string) $definition->getArgument(2));
-
-        $calls = $definition->getMethodCalls();
-
-        $this->assertSame('setTokenStorage', $calls[0][0]);
-        $this->assertSame('security.token_storage', (string) $calls[0][1][0]);
+        $this->assertSame('security.helper', (string) $definition->getArgument(0));
+        $this->assertSame('knp_menu.factory', (string) $definition->getArgument(1));
+        $this->assertSame('router', (string) $definition->getArgument(2));
+        $this->assertSame('translator', (string) $definition->getArgument(3));
 
         $tags = $definition->getTags();
 
@@ -1227,15 +1223,11 @@ class ContaoCoreExtensionTest extends TestCase
 
         $this->assertSame(FilePickerProvider::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
-        $this->assertSame('knp_menu.factory', (string) $definition->getArgument(0));
-        $this->assertSame('router', (string) $definition->getArgument(1));
-        $this->assertSame('translator', (string) $definition->getArgument(2));
-        $this->assertSame('%contao.upload_path%', (string) $definition->getArgument(3));
-
-        $calls = $definition->getMethodCalls();
-
-        $this->assertSame('setTokenStorage', $calls[0][0]);
-        $this->assertSame('security.token_storage', (string) $calls[0][1][0]);
+        $this->assertSame('security.helper', (string) $definition->getArgument(0));
+        $this->assertSame('knp_menu.factory', (string) $definition->getArgument(1));
+        $this->assertSame('router', (string) $definition->getArgument(2));
+        $this->assertSame('translator', (string) $definition->getArgument(3));
+        $this->assertSame('%contao.upload_path%', (string) $definition->getArgument(4));
 
         $tags = $definition->getTags();
 
@@ -1251,14 +1243,10 @@ class ContaoCoreExtensionTest extends TestCase
 
         $this->assertSame(ArticlePickerProvider::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
-        $this->assertSame('knp_menu.factory', (string) $definition->getArgument(0));
-        $this->assertSame('router', (string) $definition->getArgument(1));
-        $this->assertSame('translator', (string) $definition->getArgument(2));
-
-        $calls = $definition->getMethodCalls();
-
-        $this->assertSame('setTokenStorage', $calls[0][0]);
-        $this->assertSame('security.token_storage', (string) $calls[0][1][0]);
+        $this->assertSame('security.helper', (string) $definition->getArgument(0));
+        $this->assertSame('knp_menu.factory', (string) $definition->getArgument(1));
+        $this->assertSame('router', (string) $definition->getArgument(2));
+        $this->assertSame('translator', (string) $definition->getArgument(3));
 
         $tags = $definition->getTags();
 

--- a/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
+++ b/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
@@ -1224,10 +1224,10 @@ class ContaoCoreExtensionTest extends TestCase
         $this->assertSame(FilePickerProvider::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
         $this->assertSame('security.helper', (string) $definition->getArgument(0));
-        $this->assertSame('knp_menu.factory', (string) $definition->getArgument(1));
-        $this->assertSame('router', (string) $definition->getArgument(2));
-        $this->assertSame('translator', (string) $definition->getArgument(3));
-        $this->assertSame('%contao.upload_path%', (string) $definition->getArgument(4));
+        $this->assertSame('%contao.upload_path%', (string) $definition->getArgument(1));
+        $this->assertSame('knp_menu.factory', (string) $definition->getArgument(2));
+        $this->assertSame('router', (string) $definition->getArgument(3));
+        $this->assertSame('translator', (string) $definition->getArgument(4));
 
         $tags = $definition->getTags();
 

--- a/core-bundle/tests/EventListener/BackendMenuListenerTest.php
+++ b/core-bundle/tests/EventListener/BackendMenuListenerTest.php
@@ -18,8 +18,7 @@ use Contao\CoreBundle\EventListener\BackendMenuListener;
 use Knp\Menu\ItemInterface;
 use Knp\Menu\MenuFactory;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
-use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Security;
 use Symfony\Component\Security\Core\User\UserInterface;
 
 class BackendMenuListenerTest extends TestCase
@@ -27,10 +26,6 @@ class BackendMenuListenerTest extends TestCase
     public function testCreatesANodeListFromTheBackendUserMenuArray(): void
     {
         $user = $this->createPartialMock(BackendUser::class, ['hasAccess', 'navigation']);
-        $user
-            ->method('hasAccess')
-            ->willReturn(true)
-        ;
 
         $user
             ->method('navigation')
@@ -67,22 +62,16 @@ class BackendMenuListenerTest extends TestCase
             ])
         ;
 
-        $token = $this->createMock(TokenInterface::class);
-        $token
+        $security = $this->createMock(Security::class);
+        $security
             ->method('getUser')
             ->willReturn($user)
-        ;
-
-        $tokenStorage = $this->createMock(TokenStorageInterface::class);
-        $tokenStorage
-            ->method('getToken')
-            ->willReturn($token)
         ;
 
         $nodeFactory = new MenuFactory();
         $event = new MenuEvent($nodeFactory, $nodeFactory->createItem('root'));
 
-        $listener = new BackendMenuListener($tokenStorage);
+        $listener = new BackendMenuListener($security);
         $listener->onBuild($event);
 
         $tree = $event->getTree();
@@ -124,45 +113,20 @@ class BackendMenuListenerTest extends TestCase
         $this->assertSame('node2', $childNode->getAttribute('class'));
     }
 
-    public function testDoesNotModifyTheTreeIfNoTokenIsGiven(): void
-    {
-        $tokenStorage = $this->createMock(TokenStorageInterface::class);
-        $tokenStorage
-            ->method('getToken')
-            ->willReturn(null)
-        ;
-
-        $nodeFactory = new MenuFactory();
-        $event = new MenuEvent($nodeFactory, $nodeFactory->createItem('root'));
-
-        $listener = new BackendMenuListener($tokenStorage);
-        $listener->onBuild($event);
-
-        $tree = $event->getTree();
-
-        $this->assertCount(0, $tree->getChildren());
-    }
-
     public function testDoesNotModifyTheTreeIfNoBackendUserIsGiven(): void
     {
         $user = $this->createMock(UserInterface::class);
 
-        $token = $this->createMock(TokenInterface::class);
-        $token
+        $security = $this->createMock(Security::class);
+        $security
             ->method('getUser')
             ->willReturn($user)
-        ;
-
-        $tokenStorage = $this->createMock(TokenStorageInterface::class);
-        $tokenStorage
-            ->method('getToken')
-            ->willReturn($token)
         ;
 
         $nodeFactory = new MenuFactory();
         $event = new MenuEvent($nodeFactory, $nodeFactory->createItem('root'));
 
-        $listener = new BackendMenuListener($tokenStorage);
+        $listener = new BackendMenuListener($security);
         $listener->onBuild($event);
 
         $tree = $event->getTree();

--- a/core-bundle/tests/EventListener/BackendMenuListenerTest.php
+++ b/core-bundle/tests/EventListener/BackendMenuListenerTest.php
@@ -26,7 +26,6 @@ class BackendMenuListenerTest extends TestCase
     public function testCreatesANodeListFromTheBackendUserMenuArray(): void
     {
         $user = $this->createPartialMock(BackendUser::class, ['hasAccess', 'navigation']);
-
         $user
             ->method('navigation')
             ->willReturn([

--- a/core-bundle/tests/EventListener/PrettyErrorScreenListenerTest.php
+++ b/core-bundle/tests/EventListener/PrettyErrorScreenListenerTest.php
@@ -90,7 +90,7 @@ class PrettyErrorScreenListenerTest extends TestCase
 
         $event = $this->getResponseEvent($exception, $this->getRequest('frontend'));
 
-        $listener = $this->getListener(false);
+        $listener = $this->getListener();
         $listener->onKernelException($event);
 
         $this->assertTrue($event->hasResponse());
@@ -113,7 +113,7 @@ class PrettyErrorScreenListenerTest extends TestCase
         $exception = new AccessDeniedHttpException('', new AccessDeniedException());
         $event = $this->getResponseEvent($exception, $this->getRequest('frontend'));
 
-        $listener = $this->getListener(false);
+        $listener = $this->getListener();
         $listener->onKernelException($event);
 
         $this->assertTrue($event->hasResponse());
@@ -128,7 +128,7 @@ class PrettyErrorScreenListenerTest extends TestCase
         $exception = new AccessDeniedHttpException('', new AccessDeniedException());
         $event = $this->getResponseEvent($exception, $this->getRequest('frontend'));
 
-        $listener = $this->getListener(false);
+        $listener = $this->getListener();
         $listener->onKernelException($event);
 
         $this->assertFalse($event->hasResponse());
@@ -141,7 +141,7 @@ class PrettyErrorScreenListenerTest extends TestCase
         $exception = new ServiceUnavailableHttpException(null, null, new ServiceUnavailableException());
         $event = $this->getResponseEvent($exception, $this->getRequest('frontend'));
 
-        $listener = $this->getListener(false);
+        $listener = $this->getListener();
         $listener->onKernelException($event);
 
         $this->assertTrue($event->hasResponse());
@@ -274,7 +274,7 @@ class PrettyErrorScreenListenerTest extends TestCase
         $exception = new AccessDeniedHttpException('', new AccessDeniedException());
         $event = $this->getResponseEvent($exception);
 
-        $listener = $this->getListener(false);
+        $listener = $this->getListener();
         $listener->onKernelException($event);
 
         $this->assertFalse($event->hasResponse());
@@ -285,7 +285,7 @@ class PrettyErrorScreenListenerTest extends TestCase
         $exception = new InternalServerErrorHttpException('', new InsecureInstallationException());
         $event = $this->getResponseEvent($exception);
 
-        $listener = $this->getListener(false);
+        $listener = $this->getListener();
         $listener->onKernelException($event);
 
         $this->assertTrue($event->hasResponse());
@@ -295,7 +295,7 @@ class PrettyErrorScreenListenerTest extends TestCase
     /**
      * @param Environment&MockObject $twig
      */
-    private function getListener(bool $isBackendUser, bool $expectLogging = false, Environment $twig = null): PrettyErrorScreenListener
+    private function getListener(bool $isBackendUser = false, bool $expectLogging = false, Environment $twig = null): PrettyErrorScreenListener
     {
         if (null === $twig) {
             $twig = $this->createMock(Environment::class);

--- a/core-bundle/tests/EventListener/PrettyErrorScreenListenerTest.php
+++ b/core-bundle/tests/EventListener/PrettyErrorScreenListenerTest.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Tests\EventListener;
 
-use Contao\BackendUser;
 use Contao\CoreBundle\EventListener\PrettyErrorScreenListener;
 use Contao\CoreBundle\Exception\AccessDeniedException;
 use Contao\CoreBundle\Exception\ForwardPageNotFoundException;
@@ -23,7 +22,6 @@ use Contao\CoreBundle\Exception\InternalServerErrorHttpException;
 use Contao\CoreBundle\Exception\PageNotFoundException;
 use Contao\CoreBundle\Fixtures\Exception\PageErrorResponseException;
 use Contao\CoreBundle\Tests\TestCase;
-use Contao\FrontendUser;
 use Lexik\Bundle\MaintenanceBundle\Exception\ServiceUnavailableException;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
@@ -37,8 +35,7 @@ use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\HttpKernel\KernelInterface;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
-use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Security;
 use Twig\Environment;
 use Twig\Error\Error;
 
@@ -49,22 +46,23 @@ class PrettyErrorScreenListenerTest extends TestCase
         $exception = new InternalServerErrorHttpException('', new InternalServerErrorException());
         $event = $this->getResponseEvent($exception);
 
-        $listener = $this->getListener(BackendUser::class, true);
+        $listener = $this->getListener(true, true);
         $listener->onKernelException($event);
 
         $this->assertTrue($event->hasResponse());
         $this->assertSame(500, $event->getResponse()->getStatusCode());
     }
 
-    public function testDoesNotRenderBackEndExceptionsIfThereIsNoToken(): void
+    public function testChecksIsGrantedBeforeRenderingBackEndExceptions(): void
     {
         $twig = $this->createMock(Environment::class);
         $framework = $this->mockContaoFramework();
 
-        $tokenStorage = $this->createMock(TokenStorageInterface::class);
-        $tokenStorage
-            ->method('getToken')
-            ->willReturn(null)
+        $security = $this->createMock(Security::class);
+        $security
+            ->method('isGranted')
+            ->with('ROLE_USER')
+            ->willReturn(false)
         ;
 
         $logger = $this->createMock(LoggerInterface::class);
@@ -76,40 +74,7 @@ class PrettyErrorScreenListenerTest extends TestCase
         $exception = new InternalServerErrorHttpException('', new InternalServerErrorException());
         $event = $this->getResponseEvent($exception);
 
-        $listener = new PrettyErrorScreenListener(true, $twig, $framework, $tokenStorage, $logger);
-        $listener->onKernelException($event);
-
-        $this->assertTrue($event->hasResponse());
-        $this->assertSame(500, $event->getResponse()->getStatusCode());
-    }
-
-    public function testDoesNotRenderBackEndExceptionsIfThereIsNoUser(): void
-    {
-        $twig = $this->createMock(Environment::class);
-        $framework = $this->mockContaoFramework();
-
-        $token = $this->createMock(TokenInterface::class);
-        $token
-            ->method('getUser')
-            ->willReturn(null)
-        ;
-
-        $tokenStorage = $this->createMock(TokenStorageInterface::class);
-        $tokenStorage
-            ->method('getToken')
-            ->willReturn($token)
-        ;
-
-        $logger = $this->createMock(LoggerInterface::class);
-        $logger
-            ->expects(Kernel::VERSION_ID >= 40100 ? $this->never() : $this->once())
-            ->method('critical')
-        ;
-
-        $exception = new InternalServerErrorHttpException('', new InternalServerErrorException());
-        $event = $this->getResponseEvent($exception);
-
-        $listener = new PrettyErrorScreenListener(true, $twig, $framework, $tokenStorage, $logger);
+        $listener = new PrettyErrorScreenListener(true, $twig, $framework, $security, $logger);
         $listener->onKernelException($event);
 
         $this->assertTrue($event->hasResponse());
@@ -125,7 +90,7 @@ class PrettyErrorScreenListenerTest extends TestCase
 
         $event = $this->getResponseEvent($exception, $this->getRequest('frontend'));
 
-        $listener = $this->getListener(FrontendUser::class);
+        $listener = $this->getListener(false);
         $listener->onKernelException($event);
 
         $this->assertTrue($event->hasResponse());
@@ -148,7 +113,7 @@ class PrettyErrorScreenListenerTest extends TestCase
         $exception = new AccessDeniedHttpException('', new AccessDeniedException());
         $event = $this->getResponseEvent($exception, $this->getRequest('frontend'));
 
-        $listener = $this->getListener(FrontendUser::class);
+        $listener = $this->getListener(false);
         $listener->onKernelException($event);
 
         $this->assertTrue($event->hasResponse());
@@ -163,7 +128,7 @@ class PrettyErrorScreenListenerTest extends TestCase
         $exception = new AccessDeniedHttpException('', new AccessDeniedException());
         $event = $this->getResponseEvent($exception, $this->getRequest('frontend'));
 
-        $listener = $this->getListener(FrontendUser::class);
+        $listener = $this->getListener(false);
         $listener->onKernelException($event);
 
         $this->assertFalse($event->hasResponse());
@@ -176,7 +141,7 @@ class PrettyErrorScreenListenerTest extends TestCase
         $exception = new ServiceUnavailableHttpException(null, null, new ServiceUnavailableException());
         $event = $this->getResponseEvent($exception, $this->getRequest('frontend'));
 
-        $listener = $this->getListener(FrontendUser::class);
+        $listener = $this->getListener(false);
         $listener->onKernelException($event);
 
         $this->assertTrue($event->hasResponse());
@@ -190,9 +155,15 @@ class PrettyErrorScreenListenerTest extends TestCase
 
         $twig = $this->createMock(Environment::class);
         $framework = $this->mockContaoFramework();
-        $tokenStorage = $this->mockTokenStorage(FrontendUser::class);
 
-        $listener = new PrettyErrorScreenListener(false, $twig, $framework, $tokenStorage);
+        $security = $this->createMock(Security::class);
+        $security
+            ->method('isGranted')
+            ->with('ROLE_USER')
+            ->willReturn(false)
+        ;
+
+        $listener = new PrettyErrorScreenListener(false, $twig, $framework, $security);
         $listener->onKernelException($event);
 
         $this->assertFalse($event->hasResponse());
@@ -202,12 +173,18 @@ class PrettyErrorScreenListenerTest extends TestCase
     {
         $twig = $this->createMock(Environment::class);
         $framework = $this->mockContaoFramework();
-        $tokenStorage = $this->mockTokenStorage(BackendUser::class);
+
+        $security = $this->createMock(Security::class);
+        $security
+            ->method('isGranted')
+            ->with('ROLE_USER')
+            ->willReturn(true)
+        ;
 
         $exception = new ServiceUnavailableHttpException(null, null, new ServiceUnavailableException());
         $event = $this->getResponseEvent($exception, null, true);
 
-        $listener = new PrettyErrorScreenListener(true, $twig, $framework, $tokenStorage);
+        $listener = new PrettyErrorScreenListener(true, $twig, $framework, $security);
         $listener->onKernelException($event);
 
         $this->assertFalse($event->hasResponse());
@@ -217,7 +194,7 @@ class PrettyErrorScreenListenerTest extends TestCase
     {
         $event = $this->getResponseEvent(new ConflictHttpException(), $this->getRequest('frontend'));
 
-        $listener = $this->getListener(FrontendUser::class, true);
+        $listener = $this->getListener(false, true);
         $listener->onKernelException($event);
 
         $this->assertTrue($event->hasResponse());
@@ -240,7 +217,7 @@ class PrettyErrorScreenListenerTest extends TestCase
             })
         ;
 
-        $listener = $this->getListener(FrontendUser::class, true, $twig);
+        $listener = $this->getListener(false, true, $twig);
         $listener->onKernelException($event);
 
         $this->assertTrue($event->hasResponse());
@@ -251,12 +228,18 @@ class PrettyErrorScreenListenerTest extends TestCase
     {
         $twig = $this->createMock(Environment::class);
         $framework = $this->mockContaoFramework();
-        $tokenStorage = $this->mockTokenStorage(BackendUser::class);
+
+        $security = $this->createMock(Security::class);
+        $security
+            ->method('isGranted')
+            ->with('ROLE_USER')
+            ->willReturn(true)
+        ;
 
         $exception = new InternalServerErrorHttpException('', new InsecureInstallationException());
         $event = $this->getResponseEvent($exception, $this->getRequest('frontend', 'json'));
 
-        $listener = new PrettyErrorScreenListener(true, $twig, $framework, $tokenStorage);
+        $listener = new PrettyErrorScreenListener(true, $twig, $framework, $security);
         $listener->onKernelException($event);
 
         $this->assertFalse($event->hasResponse());
@@ -269,12 +252,18 @@ class PrettyErrorScreenListenerTest extends TestCase
     {
         $twig = $this->createMock(Environment::class);
         $framework = $this->mockContaoFramework();
-        $tokenStorage = $this->mockTokenStorage(BackendUser::class);
+
+        $security = $this->createMock(Security::class);
+        $security
+            ->method('isGranted')
+            ->with('ROLE_USER')
+            ->willReturn(true)
+        ;
 
         $exception = new InternalServerErrorHttpException('', new InsecureInstallationException());
         $event = $this->getResponseEvent($exception, $this->getRequest('backend', 'html', 'application/json'));
 
-        $listener = new PrettyErrorScreenListener(true, $twig, $framework, $tokenStorage);
+        $listener = new PrettyErrorScreenListener(true, $twig, $framework, $security);
         $listener->onKernelException($event);
 
         $this->assertFalse($event->hasResponse());
@@ -285,7 +274,7 @@ class PrettyErrorScreenListenerTest extends TestCase
         $exception = new AccessDeniedHttpException('', new AccessDeniedException());
         $event = $this->getResponseEvent($exception);
 
-        $listener = $this->getListener(FrontendUser::class);
+        $listener = $this->getListener(false);
         $listener->onKernelException($event);
 
         $this->assertFalse($event->hasResponse());
@@ -296,7 +285,7 @@ class PrettyErrorScreenListenerTest extends TestCase
         $exception = new InternalServerErrorHttpException('', new InsecureInstallationException());
         $event = $this->getResponseEvent($exception);
 
-        $listener = $this->getListener(FrontendUser::class);
+        $listener = $this->getListener(false);
         $listener->onKernelException($event);
 
         $this->assertTrue($event->hasResponse());
@@ -306,14 +295,20 @@ class PrettyErrorScreenListenerTest extends TestCase
     /**
      * @param Environment&MockObject $twig
      */
-    private function getListener(string $userClass, bool $expectLogging = false, Environment $twig = null): PrettyErrorScreenListener
+    private function getListener(bool $isBackendUser, bool $expectLogging = false, Environment $twig = null): PrettyErrorScreenListener
     {
         if (null === $twig) {
             $twig = $this->createMock(Environment::class);
         }
 
         $framework = $this->mockContaoFramework();
-        $tokenStorage = $this->mockTokenStorage($userClass);
+
+        $security = $this->createMock(Security::class);
+        $security
+            ->method('isGranted')
+            ->with('ROLE_USER')
+            ->willReturn($isBackendUser)
+        ;
 
         $logger = $this->createMock(LoggerInterface::class);
         $logger
@@ -325,7 +320,7 @@ class PrettyErrorScreenListenerTest extends TestCase
             ->method('critical')
         ;
 
-        return new PrettyErrorScreenListener(true, $twig, $framework, $tokenStorage, $logger);
+        return new PrettyErrorScreenListener(true, $twig, $framework, $security, $logger);
     }
 
     private function getRequest(string $scope = 'backend', string $format = 'html', string $accept = 'text/html'): Request

--- a/core-bundle/tests/EventListener/SwitchUserListenerTest.php
+++ b/core-bundle/tests/EventListener/SwitchUserListenerTest.php
@@ -93,8 +93,8 @@ class SwitchUserListenerTest extends TestCase
             $token = $this->createMock(TokenInterface::class);
             $token
                 ->expects($this->once())
-                ->method('getUser')
-                ->willReturn($this->mockBackendUser($username))
+                ->method('getUsername')
+                ->willReturn($username)
             ;
 
             $tokenStorage
@@ -105,24 +105,6 @@ class SwitchUserListenerTest extends TestCase
         }
 
         return $tokenStorage;
-    }
-
-    /**
-     * @return BackendUser&MockObject
-     */
-    private function mockBackendUser(string $username = null): BackendUser
-    {
-        $user = $this->createPartialMock(BackendUser::class, ['getUsername']);
-
-        if (null !== $username) {
-            $user
-                ->expects($this->once())
-                ->method('getUsername')
-                ->willReturn($username)
-            ;
-        }
-
-        return $user;
     }
 
     private function mockSwitchUserEvent(string $username = null): SwitchUserEvent

--- a/core-bundle/tests/EventListener/UserSessionListenerTest.php
+++ b/core-bundle/tests/EventListener/UserSessionListenerTest.php
@@ -29,11 +29,7 @@ use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\HttpKernel\KernelInterface;
-use Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolver;
-use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
-use Symfony\Component\Security\Core\Authentication\Token\RememberMeToken;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
-use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Core\Security;
 use Symfony\Component\Security\Core\User\User;
 
 class UserSessionListenerTest extends TestCase
@@ -52,16 +48,10 @@ class UserSessionListenerTest extends TestCase
         $user = $this->mockClassWithProperties($userClass);
         $user->session = $sessionValues;
 
-        $token = $this->createMock(UsernamePasswordToken::class);
-        $token
+        $security = $this->createMock(Security::class);
+        $security
             ->method('getUser')
             ->willReturn($user)
-        ;
-
-        $tokenStorage = $this->createMock(TokenStorageInterface::class);
-        $tokenStorage
-            ->method('getToken')
-            ->willReturn($token)
         ;
 
         $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
@@ -77,7 +67,7 @@ class UserSessionListenerTest extends TestCase
         $request->setSession($session);
         $request->attributes->set('_scope', $scope);
 
-        $listener = $this->getListener(null, $tokenStorage, $eventDispatcher);
+        $listener = $this->getListener(null, $security, $eventDispatcher);
         $listener->onKernelRequest($this->getGetResponseEvent($request));
 
         /** @var AttributeBagInterface $bag */
@@ -109,23 +99,17 @@ class UserSessionListenerTest extends TestCase
             ->willReturn($userTable)
         ;
 
-        $token = $this->createMock(UsernamePasswordToken::class);
-        $token
+        $security = $this->createMock(Security::class);
+        $security
             ->method('getUser')
             ->willReturn($user)
-        ;
-
-        $tokenStorage = $this->createMock(TokenStorageInterface::class);
-        $tokenStorage
-            ->method('getToken')
-            ->willReturn($token)
         ;
 
         $request = new Request();
         $request->setSession($this->mockSession());
         $request->attributes->set('_scope', $scope);
 
-        $listener = $this->getListener($connection, $tokenStorage);
+        $listener = $this->getListener($connection, $security);
         $listener->onKernelResponse($this->getFilterResponseEvent($request));
     }
 
@@ -135,10 +119,7 @@ class UserSessionListenerTest extends TestCase
         yield [ContaoCoreBundle::SCOPE_FRONTEND, FrontendUser::class, 'tl_member'];
     }
 
-    /**
-     * @dataProvider noUserProvider
-     */
-    public function testDoesNotReplaceTheSessionIfThereIsNoUser(AnonymousToken $token = null): void
+    public function testDoesNotReplaceTheSessionIfThereIsNoUser(): void
     {
         $session = $this->createMock(SessionInterface::class);
         $session
@@ -146,25 +127,21 @@ class UserSessionListenerTest extends TestCase
             ->method('getBag')
         ;
 
-        $tokenStorage = $this->createMock(TokenStorageInterface::class);
-        $tokenStorage
-            ->expects($this->once())
-            ->method('getToken')
-            ->willReturn($token)
+        $security = $this->createMock(Security::class);
+        $security
+            ->method('getUser')
+            ->willReturn(null)
         ;
 
         $request = new Request();
         $request->setSession($session);
         $request->attributes->set('_scope', ContaoCoreBundle::SCOPE_BACKEND);
 
-        $listener = $this->getListener(null, $tokenStorage);
+        $listener = $this->getListener(null, $security);
         $listener->onKernelRequest($this->getGetResponseEvent($request));
     }
 
-    /**
-     * @dataProvider noUserProvider
-     */
-    public function testDoesNotStoreTheSessionIfThereIsNoUser(AnonymousToken $token = null): void
+    public function testDoesNotStoreTheSessionIfThereIsNoUser(): void
     {
         $session = $this->createMock(SessionInterface::class);
         $session
@@ -172,11 +149,10 @@ class UserSessionListenerTest extends TestCase
             ->method('getBag')
         ;
 
-        $tokenStorage = $this->createMock(TokenStorageInterface::class);
-        $tokenStorage
-            ->expects($this->once())
-            ->method('getToken')
-            ->willReturn($token)
+        $security = $this->createMock(Security::class);
+        $security
+            ->method('getUser')
+            ->willReturn(null)
         ;
 
         $connection = $this->createMock(Connection::class);
@@ -189,14 +165,8 @@ class UserSessionListenerTest extends TestCase
         $request->setSession($session);
         $request->attributes->set('_scope', ContaoCoreBundle::SCOPE_BACKEND);
 
-        $listener = $this->getListener($connection, $tokenStorage);
+        $listener = $this->getListener($connection, $security);
         $listener->onKernelResponse($this->getFilterResponseEvent($request));
-    }
-
-    public function noUserProvider(): \Generator
-    {
-        yield [null];
-        yield [new AnonymousToken('key', 'anon.')];
     }
 
     public function testDoesNotReplaceTheSessionUponSubrequests(): void
@@ -281,19 +251,13 @@ class UserSessionListenerTest extends TestCase
 
     public function testDoesNotReplaceTheSessionIfTheUserIsNotAContaoUser(): void
     {
-        $token = $this->createMock(UsernamePasswordToken::class);
-        $token
+        $security = $this->createMock(Security::class);
+        $security
             ->method('getUser')
             ->willReturn(new User('foo', 'bar'))
         ;
 
-        $tokenStorage = $this->createMock(TokenStorageInterface::class);
-        $tokenStorage
-            ->method('getToken')
-            ->willReturn($token)
-        ;
-
-        $listener = $this->getListener($this->createMock(Connection::class), $tokenStorage);
+        $listener = $this->getListener($this->createMock(Connection::class), $security);
 
         $request = new Request();
         $request->attributes->set('_scope', ContaoCoreBundle::SCOPE_BACKEND);
@@ -305,20 +269,14 @@ class UserSessionListenerTest extends TestCase
 
     public function testDoesNotStoreTheSessionIfTheUserIsNotAContaoUser(): void
     {
-        $token = $this->createMock(UsernamePasswordToken::class);
-        $token
+        $security = $this->createMock(Security::class);
+        $security
             ->method('getUser')
             ->willReturn(new User('foo', 'bar'))
         ;
 
-        $tokenStorage = $this->createMock(TokenStorageInterface::class);
-        $tokenStorage
-            ->method('getToken')
-            ->willReturn($token)
-        ;
-
         $connection = $this->createMock(Connection::class);
-        $listener = $this->getListener($connection, $tokenStorage);
+        $listener = $this->getListener($connection, $security);
 
         $request = new Request();
         $request->setSession($this->mockSession());
@@ -335,22 +293,16 @@ class UserSessionListenerTest extends TestCase
         $user = $this->mockClassWithProperties(BackendUser::class);
         $user->session = [];
 
-        $token = $this->createMock(UsernamePasswordToken::class);
-        $token
+        $security = $this->createMock(Security::class);
+        $security
             ->method('getUser')
             ->willReturn($user)
-        ;
-
-        $tokenStorage = $this->createMock(TokenStorageInterface::class);
-        $tokenStorage
-            ->method('getToken')
-            ->willReturn($token)
         ;
 
         $request = new Request();
         $request->attributes->set('_scope', ContaoCoreBundle::SCOPE_BACKEND);
 
-        $listener = $this->getListener(null, $tokenStorage);
+        $listener = $this->getListener(null, $security);
 
         $this->expectException('RuntimeException');
         $this->expectExceptionMessage('The request did not contain a session.');
@@ -366,22 +318,16 @@ class UserSessionListenerTest extends TestCase
             ->willReturn('tl_user')
         ;
 
-        $token = $this->createMock(UsernamePasswordToken::class);
-        $token
+        $security = $this->createMock(Security::class);
+        $security
             ->method('getUser')
             ->willReturn($user)
-        ;
-
-        $tokenStorage = $this->createMock(TokenStorageInterface::class);
-        $tokenStorage
-            ->method('getToken')
-            ->willReturn($token)
         ;
 
         $request = new Request();
         $request->attributes->set('_scope', ContaoCoreBundle::SCOPE_BACKEND);
 
-        $listener = $this->getListener(null, $tokenStorage);
+        $listener = $this->getListener(null, $security);
 
         $this->expectException('RuntimeException');
         $this->expectExceptionMessage('The request did not contain a session.');
@@ -393,27 +339,25 @@ class UserSessionListenerTest extends TestCase
      * Mocks a session listener.
      *
      * @param Connection&MockObject               $connection
-     * @param TokenStorageInterface&MockObject    $tokenStorage
      * @param EventDispatcherInterface&MockObject $eventDispatcher
      */
-    private function getListener(Connection $connection = null, TokenStorageInterface $tokenStorage = null, EventDispatcherInterface $eventDispatcher = null): UserSessionListener
+    private function getListener(Connection $connection = null, Security $security = null, EventDispatcherInterface $eventDispatcher = null): UserSessionListener
     {
         if (null === $connection) {
             $connection = $this->createMock(Connection::class);
         }
 
-        if (null === $tokenStorage) {
-            $tokenStorage = $this->createMock(TokenStorageInterface::class);
+        if (null === $security) {
+            $security = $this->createMock(Security::class);
         }
 
-        $trustResolver = new AuthenticationTrustResolver(AnonymousToken::class, RememberMeToken::class);
         $scopeMatcher = $this->mockScopeMatcher();
 
         if (null === $eventDispatcher) {
             $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
         }
 
-        return new UserSessionListener($connection, $tokenStorage, $trustResolver, $scopeMatcher, $eventDispatcher);
+        return new UserSessionListener($connection, $security, $scopeMatcher, $eventDispatcher);
     }
 
     private function getGetResponseEvent(Request $request = null): GetResponseEvent

--- a/core-bundle/tests/EventListener/UserSessionListenerTest.php
+++ b/core-bundle/tests/EventListener/UserSessionListenerTest.php
@@ -339,6 +339,7 @@ class UserSessionListenerTest extends TestCase
      * Mocks a session listener.
      *
      * @param Connection&MockObject               $connection
+     * @param Security&MockObject                 $security
      * @param EventDispatcherInterface&MockObject $eventDispatcher
      */
     private function getListener(Connection $connection = null, Security $security = null, EventDispatcherInterface $eventDispatcher = null): UserSessionListener

--- a/core-bundle/tests/Picker/ArticlePickerProviderTest.php
+++ b/core-bundle/tests/Picker/ArticlePickerProviderTest.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Tests\Picker;
 
-use Contao\BackendUser;
 use Contao\CoreBundle\Picker\ArticlePickerProvider;
 use Contao\CoreBundle\Picker\PickerConfig;
 use Contao\TestCase\ContaoTestCase;
@@ -20,16 +19,10 @@ use Knp\Menu\FactoryInterface;
 use Knp\Menu\ItemInterface;
 use Knp\Menu\MenuItem;
 use Symfony\Component\Routing\RouterInterface;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
-use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Security;
 
 class ArticlePickerProviderTest extends ContaoTestCase
 {
-    /**
-     * @var ArticlePickerProvider
-     */
-    private $provider;
-
     /**
      * {@inheritdoc}
      */
@@ -51,11 +44,128 @@ class ArticlePickerProviderTest extends ContaoTestCase
     }
 
     /**
-     * {@inheritdoc}
+     * @group legacy
+     *
+     * @expectedDeprecation Using a picker provider without injecting the translator service has been deprecated %s.
      */
-    protected function setUp(): void
+    public function testCreatesTheMenuItem(): void
     {
-        parent::setUp();
+        $picker = $this->getPicker();
+
+        $config = json_encode([
+            'context' => 'link',
+            'extras' => [],
+            'current' => 'articlePicker',
+            'value' => '',
+        ]);
+
+        if (\function_exists('gzencode') && false !== ($encoded = @gzencode($config))) {
+            $config = $encoded;
+        }
+
+        $item = $picker->createMenuItem(new PickerConfig('link', [], '', 'articlePicker'));
+        $uri = 'contao_backend?do=article&popup=1&picker='.strtr(base64_encode($config), '+/=', '-_,');
+
+        $this->assertSame('Article picker', $item->getLabel());
+        $this->assertSame(['class' => 'articlePicker'], $item->getLinkAttributes());
+        $this->assertTrue($item->isCurrent());
+        $this->assertSame($uri, $item->getUri());
+    }
+
+    public function testChecksIfAMenuItemIsCurrent(): void
+    {
+        $picker = $this->getPicker();
+
+        $this->assertTrue($picker->isCurrent(new PickerConfig('link', [], '', 'articlePicker')));
+        $this->assertFalse($picker->isCurrent(new PickerConfig('link', [], '', 'filePicker')));
+    }
+
+    public function testReturnsTheCorrectName(): void
+    {
+        $picker = $this->getPicker();
+
+        $this->assertSame('articlePicker', $picker->getName());
+    }
+
+    public function testChecksIfAContextIsSupported(): void
+    {
+        $picker = $this->getPicker(true);
+
+        $this->assertTrue($picker->supportsContext('link'));
+        $this->assertFalse($picker->supportsContext('file'));
+    }
+
+    public function testChecksIfModuleAccessIsGranted(): void
+    {
+        $picker = $this->getPicker(false);
+
+        $this->assertFalse($picker->supportsContext('link'));
+    }
+
+    public function testChecksIfAValueIsSupported(): void
+    {
+        $picker = $this->getPicker();
+
+        $this->assertTrue($picker->supportsValue(new PickerConfig('link', [], '{{article_url::5}}')));
+        $this->assertFalse($picker->supportsValue(new PickerConfig('link', [], '{{link_url::5}}')));
+    }
+
+    public function testReturnsTheDcaTable(): void
+    {
+        $picker = $this->getPicker();
+
+        $this->assertSame('tl_article', $picker->getDcaTable());
+    }
+
+    public function testReturnsTheDcaAttributes(): void
+    {
+        $picker = $this->getPicker();
+
+        $extra = ['source' => 'tl_article.2'];
+
+        $this->assertSame(
+            [
+                'fieldType' => 'radio',
+                'preserveRecord' => 'tl_article.2',
+                'value' => '5',
+            ],
+            $picker->getDcaAttributes(new PickerConfig('link', $extra, '{{article_url::5}}'))
+        );
+
+        $this->assertSame(
+            [
+                'fieldType' => 'radio',
+                'preserveRecord' => 'tl_article.2',
+            ],
+            $picker->getDcaAttributes(new PickerConfig('link', $extra, '{{link_url::5}}'))
+        );
+    }
+
+    public function testConvertsTheDcaValue(): void
+    {
+        $picker = $this->getPicker();
+
+        $this->assertSame('{{article_url::5}}', $picker->convertDcaValue(new PickerConfig('link'), 5));
+    }
+
+    public function testConvertsTheDcaValueWithACustomInsertTag(): void
+    {
+        $picker = $this->getPicker();
+
+        $this->assertSame(
+            '{{article_title::5}}',
+            $picker->convertDcaValue(new PickerConfig('link', ['insertTag' => '{{article_title::%s}}']), 5)
+        );
+    }
+
+    private function getPicker(bool $accessGranted = null): ArticlePickerProvider
+    {
+        $security = $this->createMock(Security::class);
+        $security
+            ->expects(null === $accessGranted ? $this->never() : $this->once())
+            ->method('isGranted')
+            ->willReturn($accessGranted)
+        ;
 
         $menuFactory = $this->createMock(FactoryInterface::class);
         $menuFactory
@@ -83,144 +193,6 @@ class ArticlePickerProviderTest extends ContaoTestCase
             )
         ;
 
-        $this->provider = new ArticlePickerProvider($menuFactory, $router);
-    }
-
-    /**
-     * @group legacy
-     *
-     * @expectedDeprecation Using a picker provider without injecting the translator service has been deprecated %s.
-     */
-    public function testCreatesTheMenuItem(): void
-    {
-        $picker = json_encode([
-            'context' => 'link',
-            'extras' => [],
-            'current' => 'articlePicker',
-            'value' => '',
-        ]);
-
-        if (\function_exists('gzencode') && false !== ($encoded = @gzencode($picker))) {
-            $picker = $encoded;
-        }
-
-        $item = $this->provider->createMenuItem(new PickerConfig('link', [], '', 'articlePicker'));
-        $uri = 'contao_backend?do=article&popup=1&picker='.strtr(base64_encode($picker), '+/=', '-_,');
-
-        $this->assertSame('Article picker', $item->getLabel());
-        $this->assertSame(['class' => 'articlePicker'], $item->getLinkAttributes());
-        $this->assertTrue($item->isCurrent());
-        $this->assertSame($uri, $item->getUri());
-    }
-
-    public function testChecksIfAMenuItemIsCurrent(): void
-    {
-        $this->assertTrue($this->provider->isCurrent(new PickerConfig('link', [], '', 'articlePicker')));
-        $this->assertFalse($this->provider->isCurrent(new PickerConfig('link', [], '', 'filePicker')));
-    }
-
-    public function testReturnsTheCorrectName(): void
-    {
-        $this->assertSame('articlePicker', $this->provider->getName());
-    }
-
-    public function testChecksIfAContextIsSupported(): void
-    {
-        $this->provider->setTokenStorage($this->mockTokenStorage(BackendUser::class));
-
-        $this->assertTrue($this->provider->supportsContext('link'));
-        $this->assertFalse($this->provider->supportsContext('file'));
-    }
-
-    public function testFailsToCheckTheContextIfThereIsNoTokenStorage(): void
-    {
-        $this->expectException('RuntimeException');
-        $this->expectExceptionMessage('No token storage provided');
-
-        $this->provider->supportsContext('link');
-    }
-
-    public function testFailsToCheckTheContextIfThereIsNoToken(): void
-    {
-        $tokenStorage = $this->createMock(TokenStorageInterface::class);
-        $tokenStorage
-            ->method('getToken')
-            ->willReturn(null)
-        ;
-
-        $this->provider->setTokenStorage($tokenStorage);
-
-        $this->expectException('RuntimeException');
-        $this->expectExceptionMessage('No token provided');
-
-        $this->provider->supportsContext('link');
-    }
-
-    public function testFailsToCheckTheContextIfThereIsNoUser(): void
-    {
-        $token = $this->createMock(TokenInterface::class);
-        $token
-            ->method('getUser')
-            ->willReturn(null)
-        ;
-
-        $tokenStorage = $this->createMock(TokenStorageInterface::class);
-        $tokenStorage
-            ->method('getToken')
-            ->willReturn($token)
-        ;
-
-        $this->provider->setTokenStorage($tokenStorage);
-
-        $this->expectException('RuntimeException');
-        $this->expectExceptionMessage('The token does not contain a back end user object');
-
-        $this->provider->supportsContext('link');
-    }
-
-    public function testChecksIfAValueIsSupported(): void
-    {
-        $this->assertTrue($this->provider->supportsValue(new PickerConfig('link', [], '{{article_url::5}}')));
-        $this->assertFalse($this->provider->supportsValue(new PickerConfig('link', [], '{{link_url::5}}')));
-    }
-
-    public function testReturnsTheDcaTable(): void
-    {
-        $this->assertSame('tl_article', $this->provider->getDcaTable());
-    }
-
-    public function testReturnsTheDcaAttributes(): void
-    {
-        $extra = ['source' => 'tl_article.2'];
-
-        $this->assertSame(
-            [
-                'fieldType' => 'radio',
-                'preserveRecord' => 'tl_article.2',
-                'value' => '5',
-            ],
-            $this->provider->getDcaAttributes(new PickerConfig('link', $extra, '{{article_url::5}}'))
-        );
-
-        $this->assertSame(
-            [
-                'fieldType' => 'radio',
-                'preserveRecord' => 'tl_article.2',
-            ],
-            $this->provider->getDcaAttributes(new PickerConfig('link', $extra, '{{link_url::5}}'))
-        );
-    }
-
-    public function testConvertsTheDcaValue(): void
-    {
-        $this->assertSame('{{article_url::5}}', $this->provider->convertDcaValue(new PickerConfig('link'), 5));
-    }
-
-    public function testConvertsTheDcaValueWithACustomInsertTag(): void
-    {
-        $this->assertSame(
-            '{{article_title::5}}',
-            $this->provider->convertDcaValue(new PickerConfig('link', ['insertTag' => '{{article_title::%s}}']), 5)
-        );
+        return new ArticlePickerProvider($security, $menuFactory, $router);
     }
 }

--- a/core-bundle/tests/Picker/ArticlePickerProviderTest.php
+++ b/core-bundle/tests/Picker/ArticlePickerProviderTest.php
@@ -50,8 +50,6 @@ class ArticlePickerProviderTest extends ContaoTestCase
      */
     public function testCreatesTheMenuItem(): void
     {
-        $picker = $this->getPicker();
-
         $config = json_encode([
             'context' => 'link',
             'extras' => [],
@@ -63,6 +61,7 @@ class ArticlePickerProviderTest extends ContaoTestCase
             $config = $encoded;
         }
 
+        $picker = $this->getPicker();
         $item = $picker->createMenuItem(new PickerConfig('link', [], '', 'articlePicker'));
         $uri = 'contao_backend?do=article&popup=1&picker='.strtr(base64_encode($config), '+/=', '-_,');
 
@@ -120,7 +119,6 @@ class ArticlePickerProviderTest extends ContaoTestCase
     public function testReturnsTheDcaAttributes(): void
     {
         $picker = $this->getPicker();
-
         $extra = ['source' => 'tl_article.2'];
 
         $this->assertSame(

--- a/core-bundle/tests/Picker/FilePickerProviderTest.php
+++ b/core-bundle/tests/Picker/FilePickerProviderTest.php
@@ -29,8 +29,6 @@ class FilePickerProviderTest extends ContaoTestCase
 {
     public function testCreatesTheMenuItem(): void
     {
-        $picker = $this->getPicker();
-
         $config = json_encode([
             'context' => 'link',
             'extras' => [],
@@ -42,6 +40,7 @@ class FilePickerProviderTest extends ContaoTestCase
             $config = $encoded;
         }
 
+        $picker = $this->getPicker();
         $item = $picker->createMenuItem(new PickerConfig('link', [], '', 'filePicker'));
         $uri = 'contao_backend?do=files&popup=1&picker='.strtr(base64_encode($config), '+/=', '-_,');
 
@@ -87,7 +86,6 @@ class FilePickerProviderTest extends ContaoTestCase
     public function testChecksIfAValueIsSupported(): void
     {
         $picker = $this->getPicker();
-
         $uuid = '82243f46-a4c3-11e3-8e29-000c29e44aea';
 
         $this->assertTrue($picker->supportsValue(new PickerConfig('file', [], $uuid)));
@@ -277,7 +275,7 @@ class FilePickerProviderTest extends ContaoTestCase
             ->willReturn('File picker')
         ;
 
-        $picker = new FilePickerProvider($security, $menuFactory, $router, $translator, __DIR__);
+        $picker = new FilePickerProvider($security, __DIR__, $menuFactory, $router, $translator);
         $picker->setFramework($framwork);
 
         return $picker;

--- a/core-bundle/tests/Picker/FilePickerProviderTest.php
+++ b/core-bundle/tests/Picker/FilePickerProviderTest.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Tests\Picker;
 
-use Contao\BackendUser;
 use Contao\CoreBundle\Picker\FilePickerProvider;
 use Contao\CoreBundle\Picker\PickerConfig;
 use Contao\FilesModel;
@@ -23,23 +22,210 @@ use Knp\Menu\ItemInterface;
 use Knp\Menu\MenuItem;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Routing\RouterInterface;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
-use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Security;
 use Symfony\Component\Translation\TranslatorInterface;
 
 class FilePickerProviderTest extends ContaoTestCase
 {
-    /**
-     * @var FilePickerProvider
-     */
-    private $provider;
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function setUp(): void
+    public function testCreatesTheMenuItem(): void
     {
-        parent::setUp();
+        $picker = $this->getPicker();
+
+        $config = json_encode([
+            'context' => 'link',
+            'extras' => [],
+            'current' => 'filePicker',
+            'value' => '',
+        ]);
+
+        if (\function_exists('gzencode') && false !== ($encoded = @gzencode($config))) {
+            $config = $encoded;
+        }
+
+        $item = $picker->createMenuItem(new PickerConfig('link', [], '', 'filePicker'));
+        $uri = 'contao_backend?do=files&popup=1&picker='.strtr(base64_encode($config), '+/=', '-_,');
+
+        $this->assertSame('File picker', $item->getLabel());
+        $this->assertSame(['class' => 'filePicker'], $item->getLinkAttributes());
+        $this->assertTrue($item->isCurrent());
+        $this->assertSame($uri, $item->getUri());
+    }
+
+    public function testChecksIfAMenuItemIsCurrent(): void
+    {
+        $picker = $this->getPicker();
+
+        $this->assertTrue($picker->isCurrent(new PickerConfig('file', [], '', 'filePicker')));
+        $this->assertFalse($picker->isCurrent(new PickerConfig('file', [], '', 'pagePicker')));
+        $this->assertTrue($picker->isCurrent(new PickerConfig('link', [], '', 'filePicker')));
+        $this->assertFalse($picker->isCurrent(new PickerConfig('link', [], '', 'pagePicker')));
+    }
+
+    public function testReturnsTheCorrectName(): void
+    {
+        $picker = $this->getPicker();
+
+        $this->assertSame('filePicker', $picker->getName());
+    }
+
+    public function testChecksIfAContextIsSupported(): void
+    {
+        $picker = $this->getPicker(true);
+
+        $this->assertTrue($picker->supportsContext('file'));
+        $this->assertTrue($picker->supportsContext('link'));
+        $this->assertFalse($picker->supportsContext('page'));
+    }
+
+    public function testChecksIfModuleAccessIsGranted(): void
+    {
+        $picker = $this->getPicker(false);
+
+        $this->assertFalse($picker->supportsContext('link'));
+    }
+
+    public function testChecksIfAValueIsSupported(): void
+    {
+        $picker = $this->getPicker();
+
+        $uuid = '82243f46-a4c3-11e3-8e29-000c29e44aea';
+
+        $this->assertTrue($picker->supportsValue(new PickerConfig('file', [], $uuid)));
+        $this->assertFalse($picker->supportsValue(new PickerConfig('file', [], '/home/foobar.txt')));
+        $this->assertTrue($picker->supportsValue(new PickerConfig('link', [], '{{file::'.$uuid.'}}')));
+        $this->assertFalse($picker->supportsValue(new PickerConfig('link', [], '/home/foobar.txt')));
+    }
+
+    public function testReturnsTheDcaTable(): void
+    {
+        $picker = $this->getPicker();
+
+        $this->assertSame('tl_files', $picker->getDcaTable());
+    }
+
+    public function testReturnsTheDcaAttributes(): void
+    {
+        $picker = $this->getPicker();
+
+        $extra = [
+            'fieldType' => 'checkbox',
+            'files' => true,
+        ];
+
+        $uuid = '82243f46-a4c3-11e3-8e29-000c29e44aea';
+
+        $this->assertSame(
+            [
+                'fieldType' => 'checkbox',
+                'files' => true,
+                'value' => ['/foobar'],
+            ],
+            $picker->getDcaAttributes(new PickerConfig('file', $extra, $uuid))
+        );
+
+        $this->assertSame(
+            [
+                'files' => true,
+                'fieldType' => 'radio',
+                'value' => ['/foobar'],
+            ],
+            $picker->getDcaAttributes(new PickerConfig('file', ['files' => true], $uuid))
+        );
+
+        $this->assertSame(
+            [
+                'fieldType' => 'radio',
+                'filesOnly' => true,
+                'value' => '/foobar',
+            ],
+            $picker->getDcaAttributes(new PickerConfig('link', $extra, '{{file::'.$uuid.'}}'))
+        );
+
+        $this->assertSame(
+            [
+                'fieldType' => 'radio',
+                'filesOnly' => true,
+                'value' => 'foo/bar.jpg',
+            ],
+            $picker->getDcaAttributes(new PickerConfig('link', $extra, 'foo/bar.jpg'))
+        );
+
+        $this->assertSame(
+            [
+                'fieldType' => 'radio',
+                'filesOnly' => true,
+                'value' => '/foobar',
+            ],
+            $picker->getDcaAttributes(new PickerConfig('link', [], '/foobar'))
+        );
+
+        $this->assertSame(
+            [
+                'fieldType' => 'radio',
+                'filesOnly' => true,
+                'value' => str_replace('%2F', '/', rawurlencode('foo/bär baz.jpg')),
+            ],
+            $picker->getDcaAttributes(new PickerConfig('link', [], 'foo/bär baz.jpg'))
+        );
+
+        $this->assertSame(
+            [
+                'fieldType' => 'radio',
+                'filesOnly' => true,
+                'value' => str_replace('%2F', '/', rawurlencode(__DIR__.'/foobar.jpg')),
+            ],
+            $picker->getDcaAttributes(new PickerConfig('link', [], __DIR__.'/foobar.jpg'))
+        );
+    }
+
+    public function testConvertsTheDcaValue(): void
+    {
+        $picker = $this->getPicker();
+
+        $this->assertSame(
+            '/foobar',
+            $picker->convertDcaValue(new PickerConfig('file'), '/foobar')
+        );
+
+        $this->assertSame(
+            '{{file::82243f46-a4c3-11e3-8e29-000c29e44aea}}',
+            $picker->convertDcaValue(new PickerConfig('link'), '/foobar')
+        );
+
+        $this->assertSame(
+            '/foobar',
+            $picker->convertDcaValue(new PickerConfig('link'), '/foobar')
+        );
+    }
+
+    public function testConvertsTheDcaValueWithACustomInsertTag(): void
+    {
+        $picker = $this->getPicker();
+
+        $this->assertSame(
+            '/foobar',
+            $picker->convertDcaValue(new PickerConfig('file', ['insertTag' => '{{file_name::%s}}']), '/foobar')
+        );
+
+        $this->assertSame(
+            '{{file_name::82243f46-a4c3-11e3-8e29-000c29e44aea}}',
+            $picker->convertDcaValue(new PickerConfig('link', ['insertTag' => '{{file_name::%s}}']), '/foobar')
+        );
+
+        $this->assertSame(
+            '/foobar',
+            $picker->convertDcaValue(new PickerConfig('link', ['insertTag' => '{{file_name::%s}}']), '/foobar')
+        );
+    }
+
+    private function getPicker(bool $accessGranted = null): FilePickerProvider
+    {
+        $security = $this->createMock(Security::class);
+        $security
+            ->expects(null === $accessGranted ? $this->never() : $this->atLeastOnce())
+            ->method('isGranted')
+            ->willReturn($accessGranted)
+        ;
 
         $menuFactory = $this->createMock(FactoryInterface::class);
         $menuFactory
@@ -91,221 +277,9 @@ class FilePickerProviderTest extends ContaoTestCase
             ->willReturn('File picker')
         ;
 
-        $this->provider = new FilePickerProvider($menuFactory, $router, $translator, __DIR__);
-        $this->provider->setFramework($framwork);
-    }
+        $picker = new FilePickerProvider($security, $menuFactory, $router, $translator, __DIR__);
+        $picker->setFramework($framwork);
 
-    public function testCreatesTheMenuItem(): void
-    {
-        $picker = json_encode([
-            'context' => 'link',
-            'extras' => [],
-            'current' => 'filePicker',
-            'value' => '',
-        ]);
-
-        if (\function_exists('gzencode') && false !== ($encoded = @gzencode($picker))) {
-            $picker = $encoded;
-        }
-
-        $item = $this->provider->createMenuItem(new PickerConfig('link', [], '', 'filePicker'));
-        $uri = 'contao_backend?do=files&popup=1&picker='.strtr(base64_encode($picker), '+/=', '-_,');
-
-        $this->assertSame('File picker', $item->getLabel());
-        $this->assertSame(['class' => 'filePicker'], $item->getLinkAttributes());
-        $this->assertTrue($item->isCurrent());
-        $this->assertSame($uri, $item->getUri());
-    }
-
-    public function testChecksIfAMenuItemIsCurrent(): void
-    {
-        $this->assertTrue($this->provider->isCurrent(new PickerConfig('file', [], '', 'filePicker')));
-        $this->assertFalse($this->provider->isCurrent(new PickerConfig('file', [], '', 'pagePicker')));
-        $this->assertTrue($this->provider->isCurrent(new PickerConfig('link', [], '', 'filePicker')));
-        $this->assertFalse($this->provider->isCurrent(new PickerConfig('link', [], '', 'pagePicker')));
-    }
-
-    public function testReturnsTheCorrectName(): void
-    {
-        $this->assertSame('filePicker', $this->provider->getName());
-    }
-
-    public function testChecksIfAContextIsSupported(): void
-    {
-        $this->provider->setTokenStorage($this->mockTokenStorage(BackendUser::class));
-
-        $this->assertTrue($this->provider->supportsContext('file'));
-        $this->assertTrue($this->provider->supportsContext('link'));
-        $this->assertFalse($this->provider->supportsContext('page'));
-    }
-
-    public function testFailsToCheckTheContextIfThereIsNoTokenStorage(): void
-    {
-        $this->expectException('RuntimeException');
-        $this->expectExceptionMessage('No token storage provided');
-
-        $this->provider->supportsContext('link');
-    }
-
-    public function testFailsToCheckTheContextIfThereIsNoToken(): void
-    {
-        $tokenStorage = $this->createMock(TokenStorageInterface::class);
-        $tokenStorage
-            ->method('getToken')
-            ->willReturn(null)
-        ;
-
-        $this->provider->setTokenStorage($tokenStorage);
-
-        $this->expectException('RuntimeException');
-        $this->expectExceptionMessage('No token provided');
-
-        $this->provider->supportsContext('link');
-    }
-
-    public function testFailsToCheckTheContextIfThereIsNoUser(): void
-    {
-        $token = $this->createMock(TokenInterface::class);
-        $token
-            ->method('getUser')
-            ->willReturn(null)
-        ;
-
-        $tokenStorage = $this->createMock(TokenStorageInterface::class);
-        $tokenStorage
-            ->method('getToken')
-            ->willReturn($token)
-        ;
-
-        $this->provider->setTokenStorage($tokenStorage);
-
-        $this->expectException('RuntimeException');
-        $this->expectExceptionMessage('The token does not contain a back end user object');
-
-        $this->provider->supportsContext('link');
-    }
-
-    public function testChecksIfAValueIsSupported(): void
-    {
-        $uuid = '82243f46-a4c3-11e3-8e29-000c29e44aea';
-
-        $this->assertTrue($this->provider->supportsValue(new PickerConfig('file', [], $uuid)));
-        $this->assertFalse($this->provider->supportsValue(new PickerConfig('file', [], '/home/foobar.txt')));
-        $this->assertTrue($this->provider->supportsValue(new PickerConfig('link', [], '{{file::'.$uuid.'}}')));
-        $this->assertFalse($this->provider->supportsValue(new PickerConfig('link', [], '/home/foobar.txt')));
-    }
-
-    public function testReturnsTheDcaTable(): void
-    {
-        $this->assertSame('tl_files', $this->provider->getDcaTable());
-    }
-
-    public function testReturnsTheDcaAttributes(): void
-    {
-        $extra = [
-            'fieldType' => 'checkbox',
-            'files' => true,
-        ];
-
-        $uuid = '82243f46-a4c3-11e3-8e29-000c29e44aea';
-
-        $this->assertSame(
-            [
-                'fieldType' => 'checkbox',
-                'files' => true,
-                'value' => ['/foobar'],
-            ],
-            $this->provider->getDcaAttributes(new PickerConfig('file', $extra, $uuid))
-        );
-
-        $this->assertSame(
-            [
-                'files' => true,
-                'fieldType' => 'radio',
-                'value' => ['/foobar'],
-            ],
-            $this->provider->getDcaAttributes(new PickerConfig('file', ['files' => true], $uuid))
-        );
-
-        $this->assertSame(
-            [
-                'fieldType' => 'radio',
-                'filesOnly' => true,
-                'value' => '/foobar',
-            ],
-            $this->provider->getDcaAttributes(new PickerConfig('link', $extra, '{{file::'.$uuid.'}}'))
-        );
-
-        $this->assertSame(
-            [
-                'fieldType' => 'radio',
-                'filesOnly' => true,
-                'value' => 'foo/bar.jpg',
-            ],
-            $this->provider->getDcaAttributes(new PickerConfig('link', $extra, 'foo/bar.jpg'))
-        );
-
-        $this->assertSame(
-            [
-                'fieldType' => 'radio',
-                'filesOnly' => true,
-                'value' => '/foobar',
-            ],
-            $this->provider->getDcaAttributes(new PickerConfig('link', [], '/foobar'))
-        );
-
-        $this->assertSame(
-            [
-                'fieldType' => 'radio',
-                'filesOnly' => true,
-                'value' => str_replace('%2F', '/', rawurlencode('foo/bär baz.jpg')),
-            ],
-            $this->provider->getDcaAttributes(new PickerConfig('link', [], 'foo/bär baz.jpg'))
-        );
-
-        $this->assertSame(
-            [
-                'fieldType' => 'radio',
-                'filesOnly' => true,
-                'value' => str_replace('%2F', '/', rawurlencode(__DIR__.'/foobar.jpg')),
-            ],
-            $this->provider->getDcaAttributes(new PickerConfig('link', [], __DIR__.'/foobar.jpg'))
-        );
-    }
-
-    public function testConvertsTheDcaValue(): void
-    {
-        $this->assertSame(
-            '/foobar',
-            $this->provider->convertDcaValue(new PickerConfig('file'), '/foobar')
-        );
-
-        $this->assertSame(
-            '{{file::82243f46-a4c3-11e3-8e29-000c29e44aea}}',
-            $this->provider->convertDcaValue(new PickerConfig('link'), '/foobar')
-        );
-
-        $this->assertSame(
-            '/foobar',
-            $this->provider->convertDcaValue(new PickerConfig('link'), '/foobar')
-        );
-    }
-
-    public function testConvertsTheDcaValueWithACustomInsertTag(): void
-    {
-        $this->assertSame(
-            '/foobar',
-            $this->provider->convertDcaValue(new PickerConfig('file', ['insertTag' => '{{file_name::%s}}']), '/foobar')
-        );
-
-        $this->assertSame(
-            '{{file_name::82243f46-a4c3-11e3-8e29-000c29e44aea}}',
-            $this->provider->convertDcaValue(new PickerConfig('link', ['insertTag' => '{{file_name::%s}}']), '/foobar')
-        );
-
-        $this->assertSame(
-            '/foobar',
-            $this->provider->convertDcaValue(new PickerConfig('link', ['insertTag' => '{{file_name::%s}}']), '/foobar')
-        );
+        return $picker;
     }
 }

--- a/core-bundle/tests/Picker/PagePickerProviderTest.php
+++ b/core-bundle/tests/Picker/PagePickerProviderTest.php
@@ -26,8 +26,6 @@ class PagePickerProviderTest extends ContaoTestCase
 {
     public function testCreatesTheMenuItem(): void
     {
-        $picker = $this->getPicker();
-
         $config = json_encode([
             'context' => 'link',
             'extras' => [],
@@ -39,6 +37,7 @@ class PagePickerProviderTest extends ContaoTestCase
             $config = $encoded;
         }
 
+        $picker = $this->getPicker();
         $item = $picker->createMenuItem(new PickerConfig('link', [], '', 'pagePicker'));
         $uri = 'contao_backend?do=page&popup=1&picker='.strtr(base64_encode($config), '+/=', '-_,');
 

--- a/core-bundle/tests/Picker/PagePickerProviderTest.php
+++ b/core-bundle/tests/Picker/PagePickerProviderTest.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Tests\Picker;
 
-use Contao\BackendUser;
 use Contao\CoreBundle\Picker\PagePickerProvider;
 use Contao\CoreBundle\Picker\PickerConfig;
 use Contao\TestCase\ContaoTestCase;
@@ -20,23 +19,174 @@ use Knp\Menu\FactoryInterface;
 use Knp\Menu\ItemInterface;
 use Knp\Menu\MenuItem;
 use Symfony\Component\Routing\RouterInterface;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
-use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Security;
 use Symfony\Component\Translation\TranslatorInterface;
 
 class PagePickerProviderTest extends ContaoTestCase
 {
-    /**
-     * @var PagePickerProvider
-     */
-    private $provider;
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function setUp(): void
+    public function testCreatesTheMenuItem(): void
     {
-        parent::setUp();
+        $picker = $this->getPicker();
+
+        $config = json_encode([
+            'context' => 'link',
+            'extras' => [],
+            'current' => 'pagePicker',
+            'value' => '',
+        ]);
+
+        if (\function_exists('gzencode') && false !== ($encoded = @gzencode($config))) {
+            $config = $encoded;
+        }
+
+        $item = $picker->createMenuItem(new PickerConfig('link', [], '', 'pagePicker'));
+        $uri = 'contao_backend?do=page&popup=1&picker='.strtr(base64_encode($config), '+/=', '-_,');
+
+        $this->assertSame('Page picker', $item->getLabel());
+        $this->assertSame(['class' => 'pagePicker'], $item->getLinkAttributes());
+        $this->assertTrue($item->isCurrent());
+        $this->assertSame($uri, $item->getUri());
+    }
+
+    public function testChecksIfAMenuItemIsCurrent(): void
+    {
+        $picker = $this->getPicker();
+
+        $this->assertTrue($picker->isCurrent(new PickerConfig('page', [], '', 'pagePicker')));
+        $this->assertFalse($picker->isCurrent(new PickerConfig('page', [], '', 'filePicker')));
+        $this->assertTrue($picker->isCurrent(new PickerConfig('link', [], '', 'pagePicker')));
+        $this->assertFalse($picker->isCurrent(new PickerConfig('link', [], '', 'filePicker')));
+    }
+
+    public function testReturnsTheCorrectName(): void
+    {
+        $picker = $this->getPicker();
+
+        $this->assertSame('pagePicker', $picker->getName());
+    }
+
+    public function testChecksIfAContextIsSupported(): void
+    {
+        $picker = $this->getPicker(true);
+
+        $this->assertTrue($picker->supportsContext('page'));
+        $this->assertTrue($picker->supportsContext('link'));
+        $this->assertFalse($picker->supportsContext('file'));
+    }
+
+    public function testChecksIfModuleAccessIsGranted(): void
+    {
+        $picker = $this->getPicker(false);
+
+        $this->assertFalse($picker->supportsContext('link'));
+    }
+
+    public function testChecksIfAValueIsSupported(): void
+    {
+        $picker = $this->getPicker();
+
+        $this->assertTrue($picker->supportsValue(new PickerConfig('page', [], 5)));
+        $this->assertFalse($picker->supportsValue(new PickerConfig('page', [], '{{article_url::5}}')));
+        $this->assertTrue($picker->supportsValue(new PickerConfig('link', [], '{{link_url::5}}')));
+        $this->assertFalse($picker->supportsValue(new PickerConfig('link', [], '{{article_url::5}}')));
+    }
+
+    public function testReturnsTheDcaTable(): void
+    {
+        $picker = $this->getPicker();
+
+        $this->assertSame('tl_page', $picker->getDcaTable());
+    }
+
+    public function testReturnsTheDcaAttributes(): void
+    {
+        $picker = $this->getPicker();
+
+        $extra = [
+            'fieldType' => 'checkbox',
+            'rootNodes' => [1, 2, 3],
+            'source' => 'tl_page.2',
+        ];
+
+        $this->assertSame(
+            [
+                'fieldType' => 'checkbox',
+                'preserveRecord' => 'tl_page.2',
+                'rootNodes' => [1, 2, 3],
+                'value' => [5],
+            ],
+            $picker->getDcaAttributes(new PickerConfig('page', $extra, '5'))
+        );
+
+        $this->assertSame(
+            [
+                'fieldType' => 'radio',
+                'value' => '5',
+            ],
+            $picker->getDcaAttributes(new PickerConfig('link', [], '{{link_url::5}}'))
+        );
+
+        $this->assertSame(
+            ['fieldType' => 'radio'],
+            $picker->getDcaAttributes(new PickerConfig('link', [], '{{article_url::5}}'))
+        );
+    }
+
+    public function testConvertsTheDcaValue(): void
+    {
+        $picker = $this->getPicker();
+
+        $this->assertSame(5, $picker->convertDcaValue(new PickerConfig('page'), 5));
+        $this->assertSame('{{link_url::5}}', $picker->convertDcaValue(new PickerConfig('link'), 5));
+    }
+
+    public function testConvertsTheDcaValueWithACustomInsertTag(): void
+    {
+        $picker = $this->getPicker();
+
+        // General insertTag extra
+        $this->assertSame(
+            5,
+            $picker->convertDcaValue(
+                new PickerConfig('page', ['insertTag' => '{{link_url::%s|absolute}}']),
+                5
+            )
+        );
+
+        $this->assertSame(
+            '{{link_url::5|absolute}}',
+            $picker->convertDcaValue(
+                new PickerConfig('link', ['insertTag' => '{{link_url::%s|absolute}}']),
+                5
+            )
+        );
+
+        // Picker specific insertTag extra
+        $this->assertSame(
+            5,
+            $picker->convertDcaValue(
+                new PickerConfig('page', ['pagePicker' => ['insertTag' => '{{specific_insert_tag::%s}}']]),
+                5
+            )
+        );
+
+        $this->assertSame(
+            '{{specific_insert_tag::5}}',
+            $picker->convertDcaValue(
+                new PickerConfig('link', ['pagePicker' => ['insertTag' => '{{specific_insert_tag::%s}}']]),
+                5
+            )
+        );
+    }
+
+    private function getPicker(bool $accessGranted = null): PagePickerProvider
+    {
+        $security = $this->createMock(Security::class);
+        $security
+            ->expects(null === $accessGranted ? $this->never() : $this->atLeastOnce())
+            ->method('isGranted')
+            ->willReturn($accessGranted)
+        ;
 
         $menuFactory = $this->createMock(FactoryInterface::class);
         $menuFactory
@@ -70,184 +220,6 @@ class PagePickerProviderTest extends ContaoTestCase
             ->willReturn('Page picker')
         ;
 
-        $this->provider = new PagePickerProvider($menuFactory, $router, $translator);
-    }
-
-    public function testCreatesTheMenuItem(): void
-    {
-        $picker = json_encode([
-            'context' => 'link',
-            'extras' => [],
-            'current' => 'pagePicker',
-            'value' => '',
-        ]);
-
-        if (\function_exists('gzencode') && false !== ($encoded = @gzencode($picker))) {
-            $picker = $encoded;
-        }
-
-        $item = $this->provider->createMenuItem(new PickerConfig('link', [], '', 'pagePicker'));
-        $uri = 'contao_backend?do=page&popup=1&picker='.strtr(base64_encode($picker), '+/=', '-_,');
-
-        $this->assertSame('Page picker', $item->getLabel());
-        $this->assertSame(['class' => 'pagePicker'], $item->getLinkAttributes());
-        $this->assertTrue($item->isCurrent());
-        $this->assertSame($uri, $item->getUri());
-    }
-
-    public function testChecksIfAMenuItemIsCurrent(): void
-    {
-        $this->assertTrue($this->provider->isCurrent(new PickerConfig('page', [], '', 'pagePicker')));
-        $this->assertFalse($this->provider->isCurrent(new PickerConfig('page', [], '', 'filePicker')));
-        $this->assertTrue($this->provider->isCurrent(new PickerConfig('link', [], '', 'pagePicker')));
-        $this->assertFalse($this->provider->isCurrent(new PickerConfig('link', [], '', 'filePicker')));
-    }
-
-    public function testReturnsTheCorrectName(): void
-    {
-        $this->assertSame('pagePicker', $this->provider->getName());
-    }
-
-    public function testChecksIfAContextIsSupported(): void
-    {
-        $this->provider->setTokenStorage($this->mockTokenStorage(BackendUser::class));
-
-        $this->assertTrue($this->provider->supportsContext('page'));
-        $this->assertTrue($this->provider->supportsContext('link'));
-        $this->assertFalse($this->provider->supportsContext('file'));
-    }
-
-    public function testFailsToCheckTheContextIfThereIsNoTokenStorage(): void
-    {
-        $this->expectException('RuntimeException');
-        $this->expectExceptionMessage('No token storage provided');
-
-        $this->provider->supportsContext('link');
-    }
-
-    public function testFailsToCheckTheContextIfThereIsNoToken(): void
-    {
-        $tokenStorage = $this->createMock(TokenStorageInterface::class);
-        $tokenStorage
-            ->method('getToken')
-            ->willReturn(null)
-        ;
-
-        $this->provider->setTokenStorage($tokenStorage);
-
-        $this->expectException('RuntimeException');
-        $this->expectExceptionMessage('No token provided');
-
-        $this->provider->supportsContext('link');
-    }
-
-    public function testFailsToCheckTheContextIfThereIsNoUser(): void
-    {
-        $token = $this->createMock(TokenInterface::class);
-        $token
-            ->method('getUser')
-            ->willReturn(null)
-        ;
-
-        $tokenStorage = $this->createMock(TokenStorageInterface::class);
-        $tokenStorage
-            ->method('getToken')
-            ->willReturn($token)
-        ;
-
-        $this->provider->setTokenStorage($tokenStorage);
-
-        $this->expectException('RuntimeException');
-        $this->expectExceptionMessage('The token does not contain a back end user object');
-
-        $this->provider->supportsContext('link');
-    }
-
-    public function testChecksIfAValueIsSupported(): void
-    {
-        $this->assertTrue($this->provider->supportsValue(new PickerConfig('page', [], 5)));
-        $this->assertFalse($this->provider->supportsValue(new PickerConfig('page', [], '{{article_url::5}}')));
-        $this->assertTrue($this->provider->supportsValue(new PickerConfig('link', [], '{{link_url::5}}')));
-        $this->assertFalse($this->provider->supportsValue(new PickerConfig('link', [], '{{article_url::5}}')));
-    }
-
-    public function testReturnsTheDcaTable(): void
-    {
-        $this->assertSame('tl_page', $this->provider->getDcaTable());
-    }
-
-    public function testReturnsTheDcaAttributes(): void
-    {
-        $extra = [
-            'fieldType' => 'checkbox',
-            'rootNodes' => [1, 2, 3],
-            'source' => 'tl_page.2',
-        ];
-
-        $this->assertSame(
-            [
-                'fieldType' => 'checkbox',
-                'preserveRecord' => 'tl_page.2',
-                'rootNodes' => [1, 2, 3],
-                'value' => [5],
-            ],
-            $this->provider->getDcaAttributes(new PickerConfig('page', $extra, '5'))
-        );
-
-        $this->assertSame(
-            [
-                'fieldType' => 'radio',
-                'value' => '5',
-            ],
-            $this->provider->getDcaAttributes(new PickerConfig('link', [], '{{link_url::5}}'))
-        );
-
-        $this->assertSame(
-            ['fieldType' => 'radio'],
-            $this->provider->getDcaAttributes(new PickerConfig('link', [], '{{article_url::5}}'))
-        );
-    }
-
-    public function testConvertsTheDcaValue(): void
-    {
-        $this->assertSame(5, $this->provider->convertDcaValue(new PickerConfig('page'), 5));
-        $this->assertSame('{{link_url::5}}', $this->provider->convertDcaValue(new PickerConfig('link'), 5));
-    }
-
-    public function testConvertsTheDcaValueWithACustomInsertTag(): void
-    {
-        // General insertTag extra
-        $this->assertSame(
-            5,
-            $this->provider->convertDcaValue(
-                new PickerConfig('page', ['insertTag' => '{{link_url::%s|absolute}}']),
-                5
-            )
-        );
-
-        $this->assertSame(
-            '{{link_url::5|absolute}}',
-            $this->provider->convertDcaValue(
-                new PickerConfig('link', ['insertTag' => '{{link_url::%s|absolute}}']),
-                5
-            )
-        );
-
-        // Picker specific insertTag extra
-        $this->assertSame(
-            5,
-            $this->provider->convertDcaValue(
-                new PickerConfig('page', ['pagePicker' => ['insertTag' => '{{specific_insert_tag::%s}}']]),
-                5
-            )
-        );
-
-        $this->assertSame(
-            '{{specific_insert_tag::5}}',
-            $this->provider->convertDcaValue(
-                new PickerConfig('link', ['pagePicker' => ['insertTag' => '{{specific_insert_tag::%s}}']]),
-                5
-            )
-        );
+        return new PagePickerProvider($security, $menuFactory, $router, $translator);
     }
 }

--- a/core-bundle/tests/Picker/PickerBuilderTest.php
+++ b/core-bundle/tests/Picker/PickerBuilderTest.php
@@ -55,7 +55,7 @@ class PickerBuilderTest extends ContaoTestCase
 
         $this->builder->addProvider($pageProvider);
 
-        $fileProvider = new FilePickerProvider($this->getSecurityHelper(), $factory, $router, $translator, __DIR__);
+        $fileProvider = new FilePickerProvider($this->getSecurityHelper(), __DIR__, $factory, $router, $translator);
 
         $this->builder->addProvider($fileProvider);
 
@@ -136,7 +136,6 @@ class PickerBuilderTest extends ContaoTestCase
     private function getSecurityHelper(): Security
     {
         $security = $this->createMock(Security::class);
-
         $security
             ->method('isGranted')
             ->willReturn(true)

--- a/core-bundle/tests/Picker/PickerBuilderTest.php
+++ b/core-bundle/tests/Picker/PickerBuilderTest.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Tests\Picker;
 
-use Contao\BackendUser;
 use Contao\CoreBundle\Picker\FilePickerProvider;
 use Contao\CoreBundle\Picker\PagePickerProvider;
 use Contao\CoreBundle\Picker\PickerBuilder;
@@ -20,6 +19,7 @@ use Contao\CoreBundle\Picker\PickerConfig;
 use Contao\TestCase\ContaoTestCase;
 use Knp\Menu\MenuFactory;
 use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Security\Core\Security;
 use Symfony\Component\Translation\TranslatorInterface;
 
 class PickerBuilderTest extends ContaoTestCase
@@ -51,12 +51,11 @@ class PickerBuilderTest extends ContaoTestCase
         $router = $this->createMock(RouterInterface::class);
         $translator = $this->createMock(TranslatorInterface::class);
 
-        $pageProvider = new PagePickerProvider($factory, $router);
-        $pageProvider->setTokenStorage($this->mockTokenStorage(BackendUser::class));
+        $pageProvider = new PagePickerProvider($this->getSecurityHelper(), $factory, $router);
 
         $this->builder->addProvider($pageProvider);
 
-        $fileProvider = new FilePickerProvider($factory, $router, $translator, __DIR__);
+        $fileProvider = new FilePickerProvider($this->getSecurityHelper(), $factory, $router, $translator, __DIR__);
 
         $this->builder->addProvider($fileProvider);
 
@@ -81,8 +80,7 @@ class PickerBuilderTest extends ContaoTestCase
         $factory = new MenuFactory();
         $router = $this->createMock(RouterInterface::class);
 
-        $provider = new PagePickerProvider($factory, $router);
-        $provider->setTokenStorage($this->mockTokenStorage(BackendUser::class));
+        $provider = new PagePickerProvider($this->getSecurityHelper(), $factory, $router);
 
         $this->builder->addProvider($provider);
 
@@ -97,8 +95,7 @@ class PickerBuilderTest extends ContaoTestCase
         $factory = new MenuFactory();
         $router = $this->createMock(RouterInterface::class);
 
-        $provider = new PagePickerProvider($factory, $router);
-        $provider->setTokenStorage($this->mockTokenStorage(BackendUser::class));
+        $provider = new PagePickerProvider($this->getSecurityHelper(), $factory, $router);
 
         $this->builder->addProvider($provider);
 
@@ -110,8 +107,7 @@ class PickerBuilderTest extends ContaoTestCase
         $factory = new MenuFactory();
         $router = $this->createMock(RouterInterface::class);
 
-        $provider = new PagePickerProvider($factory, $router);
-        $provider->setTokenStorage($this->mockTokenStorage(BackendUser::class));
+        $provider = new PagePickerProvider($this->getSecurityHelper(), $factory, $router);
 
         $this->builder->addProvider($provider);
 
@@ -125,8 +121,7 @@ class PickerBuilderTest extends ContaoTestCase
         $factory = new MenuFactory();
         $router = $this->createMock(RouterInterface::class);
 
-        $provider = new PagePickerProvider($factory, $router);
-        $provider->setTokenStorage($this->mockTokenStorage(BackendUser::class));
+        $provider = new PagePickerProvider($this->getSecurityHelper(), $factory, $router);
 
         $this->builder->addProvider($provider);
 
@@ -136,5 +131,17 @@ class PickerBuilderTest extends ContaoTestCase
     public function testReturnsAnEmptyPickerUrlIfTheContextIsNotSupported(): void
     {
         $this->assertSame('', $this->builder->getUrl('foo'));
+    }
+
+    private function getSecurityHelper(): Security
+    {
+        $security = $this->createMock(Security::class);
+
+        $security
+            ->method('isGranted')
+            ->willReturn(true)
+        ;
+
+        return $security;
     }
 }

--- a/core-bundle/tests/Picker/PickerTest.php
+++ b/core-bundle/tests/Picker/PickerTest.php
@@ -121,7 +121,6 @@ class PickerTest extends TestCase
     private function getSecurityHelper(): Security
     {
         $security = $this->createMock(Security::class);
-
         $security
             ->method('isGranted')
             ->willReturn(true)

--- a/core-bundle/tests/Picker/PickerTest.php
+++ b/core-bundle/tests/Picker/PickerTest.php
@@ -18,6 +18,7 @@ use Contao\CoreBundle\Picker\PickerConfig;
 use Knp\Menu\MenuFactory;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Security\Core\Security;
 use Symfony\Component\Translation\TranslatorInterface;
 
 class PickerTest extends TestCase
@@ -42,7 +43,7 @@ class PickerTest extends TestCase
 
         $factory = new MenuFactory();
         $router = $this->createMock(RouterInterface::class);
-        $provider = new PagePickerProvider($factory, $router, $translator);
+        $provider = new PagePickerProvider($this->getSecurityHelper(), $factory, $router, $translator);
         $config = new PickerConfig('page', [], 5, 'pagePicker');
 
         $this->picker = new Picker($factory, [$provider], $config);
@@ -81,7 +82,7 @@ class PickerTest extends TestCase
     {
         $factory = new MenuFactory();
         $router = $this->createMock(RouterInterface::class);
-        $provider = new PagePickerProvider($factory, $router);
+        $provider = new PagePickerProvider($this->getSecurityHelper(), $factory, $router);
         $config = new PickerConfig('page');
         $picker = new Picker($factory, [$provider], $config);
 
@@ -98,7 +99,7 @@ class PickerTest extends TestCase
         $factory = new MenuFactory();
         $router = $this->createMock(RouterInterface::class);
         $translator = $this->createMock(TranslatorInterface::class);
-        $provider = new PagePickerProvider($factory, $router, $translator);
+        $provider = new PagePickerProvider($this->getSecurityHelper(), $factory, $router, $translator);
         $config = new PickerConfig('page');
         $picker = new Picker($factory, [$provider], $config);
 
@@ -115,5 +116,17 @@ class PickerTest extends TestCase
         $this->expectExceptionMessage('No picker menu items found');
 
         $picker->getCurrentUrl();
+    }
+
+    private function getSecurityHelper(): Security
+    {
+        $security = $this->createMock(Security::class);
+
+        $security
+            ->method('isGranted')
+            ->willReturn(true)
+        ;
+
+        return $security;
     }
 }

--- a/faq-bundle/src/Picker/FaqPickerProvider.php
+++ b/faq-bundle/src/Picker/FaqPickerProvider.php
@@ -19,10 +19,26 @@ use Contao\CoreBundle\Picker\DcaPickerProviderInterface;
 use Contao\CoreBundle\Picker\PickerConfig;
 use Contao\FaqCategoryModel;
 use Contao\FaqModel;
+use Knp\Menu\FactoryInterface;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Security\Core\Security;
+use Symfony\Component\Translation\TranslatorInterface;
 
 class FaqPickerProvider extends AbstractInsertTagPickerProvider implements DcaPickerProviderInterface, FrameworkAwareInterface
 {
     use FrameworkAwareTrait;
+
+    /**
+     * @var Security
+     */
+    private $security;
+
+    public function __construct(Security $security, FactoryInterface $menuFactory, RouterInterface $router, TranslatorInterface $translator = null)
+    {
+        parent::__construct($menuFactory, $router, $translator);
+
+        $this->security = $security;
+    }
 
     /**
      * {@inheritdoc}
@@ -37,7 +53,7 @@ class FaqPickerProvider extends AbstractInsertTagPickerProvider implements DcaPi
      */
     public function supportsContext($context): bool
     {
-        return 'link' === $context && $this->getUser()->hasAccess('faq', 'modules');
+        return 'link' === $context && $this->security->isGranted('contao_user.modules', 'faq');
     }
 
     /**

--- a/faq-bundle/src/Resources/config/services.yml
+++ b/faq-bundle/src/Resources/config/services.yml
@@ -7,10 +7,9 @@ services:
     contao_faq.picker.faq_provider:
         class: Contao\FaqBundle\Picker\FaqPickerProvider
         arguments:
+            - '@security.helper'
             - '@knp_menu.factory'
             - '@router'
             - '@translator'
-        calls:
-            - [setTokenStorage, ['@security.token_storage']]
         tags:
             - { name: contao.picker_provider, priority: 64 }

--- a/faq-bundle/tests/DependencyInjection/ContaoFaqExtensionTest.php
+++ b/faq-bundle/tests/DependencyInjection/ContaoFaqExtensionTest.php
@@ -58,9 +58,10 @@ class ContaoFaqExtensionTest extends TestCase
         $definition = $this->container->getDefinition('contao_faq.picker.faq_provider');
 
         $this->assertSame(FaqPickerProvider::class, $definition->getClass());
-        $this->assertSame('knp_menu.factory', (string) $definition->getArgument(0));
-        $this->assertSame('router', (string) $definition->getArgument(1));
-        $this->assertSame('translator', (string) $definition->getArgument(2));
+        $this->assertSame('security.helper', (string) $definition->getArgument(0));
+        $this->assertSame('knp_menu.factory', (string) $definition->getArgument(1));
+        $this->assertSame('router', (string) $definition->getArgument(2));
+        $this->assertSame('translator', (string) $definition->getArgument(3));
 
         $conditionals = $definition->getInstanceofConditionals();
 
@@ -71,8 +72,6 @@ class ContaoFaqExtensionTest extends TestCase
         $this->assertSame('setFramework', $childDefinition->getMethodCalls()[0][0]);
 
         $tags = $definition->getTags();
-
-        $this->assertSame('setTokenStorage', $definition->getMethodCalls()[0][0]);
 
         $this->assertArrayHasKey('contao.picker_provider', $tags);
         $this->assertSame(64, $tags['contao.picker_provider'][0]['priority']);

--- a/faq-bundle/tests/Picker/FaqPickerProviderTest.php
+++ b/faq-bundle/tests/Picker/FaqPickerProviderTest.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 
 namespace Contao\FaqBundle\Tests\Picker;
 
-use Contao\BackendUser;
 use Contao\CoreBundle\Picker\PickerConfig;
 use Contao\FaqBundle\Picker\FaqPickerProvider;
 use Contao\FaqCategoryModel;
@@ -23,23 +22,209 @@ use Knp\Menu\ItemInterface;
 use Knp\Menu\MenuItem;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Routing\RouterInterface;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
-use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Security;
 use Symfony\Component\Translation\TranslatorInterface;
 
 class FaqPickerProviderTest extends ContaoTestCase
 {
-    /**
-     * @var FaqPickerProvider
-     */
-    private $provider;
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function setUp(): void
+    public function testCreatesTheMenuItem(): void
     {
-        parent::setUp();
+        $picker = $this->getPicker();
+
+        $config = json_encode([
+            'context' => 'link',
+            'extras' => [],
+            'current' => 'faqPicker',
+            'value' => '',
+        ]);
+
+        if (\function_exists('gzencode') && false !== ($encoded = @gzencode($config))) {
+            $config = $encoded;
+        }
+
+        $item = $picker->createMenuItem(new PickerConfig('link', [], '', 'faqPicker'));
+        $uri = 'contao_backend?do=faq&popup=1&picker='.urlencode(strtr(base64_encode($config), '+/=', '-_,'));
+
+        $this->assertSame('Faq picker', $item->getLabel());
+        $this->assertSame(['class' => 'faqPicker'], $item->getLinkAttributes());
+        $this->assertTrue($item->isCurrent());
+        $this->assertSame($uri, $item->getUri());
+    }
+
+    public function testChecksIfAMenuItemIsCurrent(): void
+    {
+        $picker = $this->getPicker();
+
+        $this->assertTrue($picker->isCurrent(new PickerConfig('link', [], '', 'faqPicker')));
+        $this->assertFalse($picker->isCurrent(new PickerConfig('link', [], '', 'filePicker')));
+    }
+
+    public function testReturnsTheCorrectName(): void
+    {
+        $picker = $this->getPicker();
+
+        $this->assertSame('faqPicker', $picker->getName());
+    }
+
+    public function testChecksIfAContextIsSupported(): void
+    {
+        $picker = $this->getPicker(true);
+
+        $this->assertTrue($picker->supportsContext('link'));
+        $this->assertFalse($picker->supportsContext('file'));
+    }
+
+    public function testChecksIfModuleAccessIsGranted(): void
+    {
+        $picker = $this->getPicker(false);
+
+        $this->assertFalse($picker->supportsContext('link'));
+    }
+
+    public function testChecksIfAValueIsSupported(): void
+    {
+        $picker = $this->getPicker();
+
+        $this->assertTrue($picker->supportsValue(new PickerConfig('link', [], '{{faq_url::5}}')));
+        $this->assertFalse($picker->supportsValue(new PickerConfig('link', [], '{{link_url::5}}')));
+    }
+
+    public function testReturnsTheDcaTable(): void
+    {
+        $picker = $this->getPicker();
+
+        $this->assertSame('tl_faq', $picker->getDcaTable());
+    }
+
+    public function testReturnsTheDcaAttributes(): void
+    {
+        $picker = $this->getPicker();
+
+        $extra = ['source' => 'tl_faq.2'];
+
+        $this->assertSame(
+            [
+                'fieldType' => 'radio',
+                'preserveRecord' => 'tl_faq.2',
+                'value' => '5',
+            ],
+            $picker->getDcaAttributes(new PickerConfig('link', $extra, '{{faq_url::5}}'))
+        );
+
+        $this->assertSame(
+            [
+                'fieldType' => 'radio',
+                'preserveRecord' => 'tl_faq.2',
+            ],
+            $picker->getDcaAttributes(new PickerConfig('link', $extra, '{{link_url::5}}'))
+        );
+    }
+
+    public function testConvertsTheDcaValue(): void
+    {
+        $picker = $this->getPicker();
+
+        $this->assertSame('{{faq_url::5}}', $picker->convertDcaValue(new PickerConfig('link'), 5));
+    }
+
+    public function testConvertsTheDcaValueWithACustomInsertTag(): void
+    {
+        $picker = $this->getPicker();
+
+        $this->assertSame(
+            '{{faq_title::5}}',
+            $picker->convertDcaValue(new PickerConfig('link', ['insertTag' => '{{faq_title::%s}}']), 5)
+        );
+    }
+
+    public function testAddsTableAndIdIfThereIsAValue(): void
+    {
+        /** @var FaqCategoryModel&MockObject $model */
+        $model = $this->mockClassWithProperties(FaqCategoryModel::class);
+        $model->id = 1;
+
+        $faq = $this->createMock(FaqModel::class);
+        $faq
+            ->expects($this->once())
+            ->method('getRelated')
+            ->with('pid')
+            ->willReturn($model)
+        ;
+
+        $config = new PickerConfig('link', [], '{{faq_url::1}}', 'faqPicker');
+
+        $adapters = [
+            FaqModel::class => $this->mockConfiguredAdapter(['findById' => $faq]),
+        ];
+
+        $picker = $this->getPicker();
+        $picker->setFramework($this->mockContaoFramework($adapters));
+
+        $method = new \ReflectionMethod(FaqPickerProvider::class, 'getRouteParameters');
+        $method->setAccessible(true);
+        $params = $method->invokeArgs($picker, [$config]);
+
+        $this->assertSame('faq', $params['do']);
+        $this->assertSame('tl_faq', $params['table']);
+        $this->assertSame(1, $params['id']);
+    }
+
+    public function testDoesNotAddTableAndIdIfThereIsNoEventsModel(): void
+    {
+        $config = new PickerConfig('link', [], '{{faq_url::1}}', 'faqPicker');
+
+        $adapters = [
+            FaqModel::class => $this->mockConfiguredAdapter(['findById' => null]),
+        ];
+
+        $picker = $this->getPicker();
+        $picker->setFramework($this->mockContaoFramework($adapters));
+
+        $method = new \ReflectionMethod(FaqPickerProvider::class, 'getRouteParameters');
+        $method->setAccessible(true);
+        $params = $method->invokeArgs($picker, [$config]);
+
+        $this->assertSame('faq', $params['do']);
+        $this->assertArrayNotHasKey('tl_faq', $params);
+        $this->assertArrayNotHasKey('id', $params);
+    }
+
+    public function testDoesNotAddTableAndIdIfThereIsNoCalendarModel(): void
+    {
+        $faq = $this->createMock(FaqModel::class);
+        $faq
+            ->expects($this->once())
+            ->method('getRelated')
+            ->with('pid')
+            ->willReturn(null)
+        ;
+
+        $config = new PickerConfig('link', [], '{{faq_url::1}}', 'faqPicker');
+
+        $adapters = [
+            FaqModel::class => $this->mockConfiguredAdapter(['findById' => $faq]),
+        ];
+
+        $picker = $this->getPicker();
+        $picker->setFramework($this->mockContaoFramework($adapters));
+
+        $method = new \ReflectionMethod(FaqPickerProvider::class, 'getRouteParameters');
+        $method->setAccessible(true);
+        $params = $method->invokeArgs($picker, [$config]);
+
+        $this->assertSame('faq', $params['do']);
+        $this->assertArrayNotHasKey('tl_faq', $params);
+        $this->assertArrayNotHasKey('id', $params);
+    }
+
+    private function getPicker(bool $accessGranted = null): FaqPickerProvider
+    {
+        $security = $this->createMock(Security::class);
+        $security
+            ->expects(null === $accessGranted ? $this->never() : $this->once())
+            ->method('isGranted')
+            ->willReturn($accessGranted)
+        ;
 
         $menuFactory = $this->createMock(FactoryInterface::class);
         $menuFactory
@@ -73,216 +258,6 @@ class FaqPickerProviderTest extends ContaoTestCase
             ->willReturn('Faq picker')
         ;
 
-        $this->provider = new FaqPickerProvider($menuFactory, $router, $translator);
-    }
-
-    public function testCreatesTheMenuItem(): void
-    {
-        $picker = json_encode([
-            'context' => 'link',
-            'extras' => [],
-            'current' => 'faqPicker',
-            'value' => '',
-        ]);
-
-        if (\function_exists('gzencode') && false !== ($encoded = @gzencode($picker))) {
-            $picker = $encoded;
-        }
-
-        $item = $this->provider->createMenuItem(new PickerConfig('link', [], '', 'faqPicker'));
-        $uri = 'contao_backend?do=faq&popup=1&picker='.urlencode(strtr(base64_encode($picker), '+/=', '-_,'));
-
-        $this->assertSame('Faq picker', $item->getLabel());
-        $this->assertSame(['class' => 'faqPicker'], $item->getLinkAttributes());
-        $this->assertTrue($item->isCurrent());
-        $this->assertSame($uri, $item->getUri());
-    }
-
-    public function testChecksIfAMenuItemIsCurrent(): void
-    {
-        $this->assertTrue($this->provider->isCurrent(new PickerConfig('link', [], '', 'faqPicker')));
-        $this->assertFalse($this->provider->isCurrent(new PickerConfig('link', [], '', 'filePicker')));
-    }
-
-    public function testReturnsTheCorrectName(): void
-    {
-        $this->assertSame('faqPicker', $this->provider->getName());
-    }
-
-    public function testChecksIfAContextIsSupported(): void
-    {
-        $this->provider->setTokenStorage($this->mockTokenStorage(BackendUser::class));
-
-        $this->assertTrue($this->provider->supportsContext('link'));
-        $this->assertFalse($this->provider->supportsContext('file'));
-    }
-
-    public function testFailsToCheckTheContextIfThereIsNoTokenStorage(): void
-    {
-        $this->expectException('RuntimeException');
-        $this->expectExceptionMessage('No token storage provided');
-
-        $this->provider->supportsContext('link');
-    }
-
-    public function testFailsToCheckTheContextIfThereIsNoToken(): void
-    {
-        $tokenStorage = $this->createMock(TokenStorageInterface::class);
-        $tokenStorage
-            ->method('getToken')
-            ->willReturn(null)
-        ;
-
-        $this->provider->setTokenStorage($tokenStorage);
-
-        $this->expectException('RuntimeException');
-        $this->expectExceptionMessage('No token provided');
-
-        $this->provider->supportsContext('link');
-    }
-
-    public function testFailsToCheckTheContextIfThereIsNoUser(): void
-    {
-        $token = $this->createMock(TokenInterface::class);
-        $token
-            ->method('getUser')
-            ->willReturn(null)
-        ;
-
-        $tokenStorage = $this->createMock(TokenStorageInterface::class);
-        $tokenStorage
-            ->method('getToken')
-            ->willReturn($token)
-        ;
-
-        $this->provider->setTokenStorage($tokenStorage);
-
-        $this->expectException('RuntimeException');
-        $this->expectExceptionMessage('The token does not contain a back end user object');
-
-        $this->provider->supportsContext('link');
-    }
-
-    public function testChecksIfAValueIsSupported(): void
-    {
-        $this->assertTrue($this->provider->supportsValue(new PickerConfig('link', [], '{{faq_url::5}}')));
-        $this->assertFalse($this->provider->supportsValue(new PickerConfig('link', [], '{{link_url::5}}')));
-    }
-
-    public function testReturnsTheDcaTable(): void
-    {
-        $this->assertSame('tl_faq', $this->provider->getDcaTable());
-    }
-
-    public function testReturnsTheDcaAttributes(): void
-    {
-        $extra = ['source' => 'tl_faq.2'];
-
-        $this->assertSame(
-            [
-                'fieldType' => 'radio',
-                'preserveRecord' => 'tl_faq.2',
-                'value' => '5',
-            ],
-            $this->provider->getDcaAttributes(new PickerConfig('link', $extra, '{{faq_url::5}}'))
-        );
-
-        $this->assertSame(
-            [
-                'fieldType' => 'radio',
-                'preserveRecord' => 'tl_faq.2',
-            ],
-            $this->provider->getDcaAttributes(new PickerConfig('link', $extra, '{{link_url::5}}'))
-        );
-    }
-
-    public function testConvertsTheDcaValue(): void
-    {
-        $this->assertSame('{{faq_url::5}}', $this->provider->convertDcaValue(new PickerConfig('link'), 5));
-    }
-
-    public function testConvertsTheDcaValueWithACustomInsertTag(): void
-    {
-        $this->assertSame(
-            '{{faq_title::5}}',
-            $this->provider->convertDcaValue(new PickerConfig('link', ['insertTag' => '{{faq_title::%s}}']), 5)
-        );
-    }
-
-    public function testAddsTableAndIdIfThereIsAValue(): void
-    {
-        /** @var FaqCategoryModel&MockObject $model */
-        $model = $this->mockClassWithProperties(FaqCategoryModel::class);
-        $model->id = 1;
-
-        $faq = $this->createMock(FaqModel::class);
-        $faq
-            ->expects($this->once())
-            ->method('getRelated')
-            ->with('pid')
-            ->willReturn($model)
-        ;
-
-        $config = new PickerConfig('link', [], '{{faq_url::1}}', 'faqPicker');
-
-        $adapters = [
-            FaqModel::class => $this->mockConfiguredAdapter(['findById' => $faq]),
-        ];
-
-        $this->provider->setFramework($this->mockContaoFramework($adapters));
-
-        $method = new \ReflectionMethod(FaqPickerProvider::class, 'getRouteParameters');
-        $method->setAccessible(true);
-        $params = $method->invokeArgs($this->provider, [$config]);
-
-        $this->assertSame('faq', $params['do']);
-        $this->assertSame('tl_faq', $params['table']);
-        $this->assertSame(1, $params['id']);
-    }
-
-    public function testDoesNotAddTableAndIdIfThereIsNoEventsModel(): void
-    {
-        $config = new PickerConfig('link', [], '{{faq_url::1}}', 'faqPicker');
-
-        $adapters = [
-            FaqModel::class => $this->mockConfiguredAdapter(['findById' => null]),
-        ];
-
-        $this->provider->setFramework($this->mockContaoFramework($adapters));
-
-        $method = new \ReflectionMethod(FaqPickerProvider::class, 'getRouteParameters');
-        $method->setAccessible(true);
-        $params = $method->invokeArgs($this->provider, [$config]);
-
-        $this->assertSame('faq', $params['do']);
-        $this->assertArrayNotHasKey('tl_faq', $params);
-        $this->assertArrayNotHasKey('id', $params);
-    }
-
-    public function testDoesNotAddTableAndIdIfThereIsNoCalendarModel(): void
-    {
-        $faq = $this->createMock(FaqModel::class);
-        $faq
-            ->expects($this->once())
-            ->method('getRelated')
-            ->with('pid')
-            ->willReturn(null)
-        ;
-
-        $config = new PickerConfig('link', [], '{{faq_url::1}}', 'faqPicker');
-
-        $adapters = [
-            FaqModel::class => $this->mockConfiguredAdapter(['findById' => $faq]),
-        ];
-
-        $this->provider->setFramework($this->mockContaoFramework($adapters));
-
-        $method = new \ReflectionMethod(FaqPickerProvider::class, 'getRouteParameters');
-        $method->setAccessible(true);
-        $params = $method->invokeArgs($this->provider, [$config]);
-
-        $this->assertSame('faq', $params['do']);
-        $this->assertArrayNotHasKey('tl_faq', $params);
-        $this->assertArrayNotHasKey('id', $params);
+        return new FaqPickerProvider($security, $menuFactory, $router, $translator);
     }
 }

--- a/faq-bundle/tests/Picker/FaqPickerProviderTest.php
+++ b/faq-bundle/tests/Picker/FaqPickerProviderTest.php
@@ -29,8 +29,6 @@ class FaqPickerProviderTest extends ContaoTestCase
 {
     public function testCreatesTheMenuItem(): void
     {
-        $picker = $this->getPicker();
-
         $config = json_encode([
             'context' => 'link',
             'extras' => [],
@@ -42,6 +40,7 @@ class FaqPickerProviderTest extends ContaoTestCase
             $config = $encoded;
         }
 
+        $picker = $this->getPicker();
         $item = $picker->createMenuItem(new PickerConfig('link', [], '', 'faqPicker'));
         $uri = 'contao_backend?do=faq&popup=1&picker='.urlencode(strtr(base64_encode($config), '+/=', '-_,'));
 
@@ -99,7 +98,6 @@ class FaqPickerProviderTest extends ContaoTestCase
     public function testReturnsTheDcaAttributes(): void
     {
         $picker = $this->getPicker();
-
         $extra = ['source' => 'tl_faq.2'];
 
         $this->assertSame(

--- a/manager-bundle/src/EventListener/BackendMenuListener.php
+++ b/manager-bundle/src/EventListener/BackendMenuListener.php
@@ -12,25 +12,24 @@ declare(strict_types=1);
 
 namespace Contao\ManagerBundle\EventListener;
 
-use Contao\BackendUser;
 use Contao\CoreBundle\Event\MenuEvent;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Security;
 
 final class BackendMenuListener
 {
     /**
-     * @var TokenStorageInterface
+     * @var Security
      */
-    private $tokenStorage;
+    private $security;
 
     /**
      * @var string
      */
     private $managerPath;
 
-    public function __construct(TokenStorageInterface $tokenStorage, ?string $managerPath)
+    public function __construct(Security $security, ?string $managerPath)
     {
-        $this->tokenStorage = $tokenStorage;
+        $this->security = $security;
         $this->managerPath = $managerPath;
     }
 
@@ -39,7 +38,7 @@ final class BackendMenuListener
      */
     public function onBuild(MenuEvent $event): void
     {
-        if (null === $this->managerPath || !$this->isAdminUser()) {
+        if (null === $this->managerPath || !$this->security->isGranted('ROLE_ADMIN')) {
             return;
         }
 
@@ -62,22 +61,5 @@ final class BackendMenuListener
         );
 
         $categoryNode->addChild($item);
-    }
-
-    private function isAdminUser(): bool
-    {
-        $token = $this->tokenStorage->getToken();
-
-        if (null === $token) {
-            return false;
-        }
-
-        $user = $token->getUser();
-
-        if (!$user instanceof BackendUser) {
-            return false;
-        }
-
-        return $user->isAdmin;
     }
 }

--- a/manager-bundle/src/Resources/config/listener.yml
+++ b/manager-bundle/src/Resources/config/listener.yml
@@ -2,7 +2,7 @@ services:
     contao_manager.listener.backend_menu_listener:
         class: Contao\ManagerBundle\EventListener\BackendMenuListener
         arguments:
-            - '@security.token_storage'
+            - '@security.helper'
             - '%contao_manager.manager_path%'
         tags:
             - { name: kernel.event_listener, event: contao.backend_menu_build, method: onBuild, priority: -10 }

--- a/manager-bundle/tests/EventListener/BackendMenuListenerTest.php
+++ b/manager-bundle/tests/EventListener/BackendMenuListenerTest.php
@@ -12,15 +12,12 @@ declare(strict_types=1);
 
 namespace Contao\ManagerBundle\Tests\EventListener;
 
-use Contao\BackendUser;
 use Contao\CoreBundle\Event\MenuEvent;
 use Contao\ManagerBundle\EventListener\BackendMenuListener;
 use Contao\TestCase\ContaoTestCase;
 use Knp\Menu\FactoryInterface;
 use Knp\Menu\MenuItem;
-use PHPUnit\Framework\MockObject\MockObject;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
-use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Security;
 
 class BackendMenuListenerTest extends ContaoTestCase
 {
@@ -65,22 +62,13 @@ class BackendMenuListenerTest extends ContaoTestCase
 
     private function getListener(bool $isAdmin, string $path = null): BackendMenuListener
     {
-        /** @var BackendUser&MockObject $model */
-        $model = $this->mockClassWithProperties(BackendUser::class);
-        $model->isAdmin = $isAdmin;
-
-        $token = $this->createMock(TokenInterface::class);
-        $token
-            ->method('getUser')
-            ->willReturn($model)
+        $security = $this->createMock(Security::class);
+        $security
+            ->method('isGranted')
+            ->with('ROLE_ADMIN')
+            ->willReturn($isAdmin)
         ;
 
-        $tokenStorage = $this->createMock(TokenStorageInterface::class);
-        $tokenStorage
-            ->method('getToken')
-            ->willReturn($token)
-        ;
-
-        return new BackendMenuListener($tokenStorage, $path);
+        return new BackendMenuListener($security, $path);
     }
 }

--- a/news-bundle/src/Picker/NewsPickerProvider.php
+++ b/news-bundle/src/Picker/NewsPickerProvider.php
@@ -19,10 +19,26 @@ use Contao\CoreBundle\Picker\DcaPickerProviderInterface;
 use Contao\CoreBundle\Picker\PickerConfig;
 use Contao\NewsArchiveModel;
 use Contao\NewsModel;
+use Knp\Menu\FactoryInterface;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Security\Core\Security;
+use Symfony\Component\Translation\TranslatorInterface;
 
 class NewsPickerProvider extends AbstractInsertTagPickerProvider implements DcaPickerProviderInterface, FrameworkAwareInterface
 {
     use FrameworkAwareTrait;
+
+    /**
+     * @var Security
+     */
+    private $security;
+
+    public function __construct(Security $security, FactoryInterface $menuFactory, RouterInterface $router, TranslatorInterface $translator = null)
+    {
+        parent::__construct($menuFactory, $router, $translator);
+
+        $this->security = $security;
+    }
 
     /**
      * {@inheritdoc}
@@ -37,7 +53,7 @@ class NewsPickerProvider extends AbstractInsertTagPickerProvider implements DcaP
      */
     public function supportsContext($context): bool
     {
-        return 'link' === $context && $this->getUser()->hasAccess('news', 'modules');
+        return 'link' === $context && $this->security->isGranted('contao_user.modules', 'news');
     }
 
     /**

--- a/news-bundle/src/Resources/config/services.yml
+++ b/news-bundle/src/Resources/config/services.yml
@@ -7,10 +7,9 @@ services:
     contao_news.picker.news_provider:
         class: Contao\NewsBundle\Picker\NewsPickerProvider
         arguments:
+            - '@security.helper'
             - '@knp_menu.factory'
             - '@router'
             - '@translator'
-        calls:
-            - [setTokenStorage, ['@security.token_storage']]
         tags:
             - { name: contao.picker_provider, priority: 128 }

--- a/news-bundle/tests/DependencyInjection/ContaoNewsExtensionTest.php
+++ b/news-bundle/tests/DependencyInjection/ContaoNewsExtensionTest.php
@@ -106,9 +106,10 @@ class ContaoNewsExtensionTest extends TestCase
         $definition = $this->container->getDefinition('contao_news.picker.news_provider');
 
         $this->assertSame(NewsPickerProvider::class, $definition->getClass());
-        $this->assertSame('knp_menu.factory', (string) $definition->getArgument(0));
-        $this->assertSame('router', (string) $definition->getArgument(1));
-        $this->assertSame('translator', (string) $definition->getArgument(2));
+        $this->assertSame('security.helper', (string) $definition->getArgument(0));
+        $this->assertSame('knp_menu.factory', (string) $definition->getArgument(1));
+        $this->assertSame('router', (string) $definition->getArgument(2));
+        $this->assertSame('translator', (string) $definition->getArgument(3));
 
         $conditionals = $definition->getInstanceofConditionals();
 
@@ -119,8 +120,6 @@ class ContaoNewsExtensionTest extends TestCase
         $this->assertSame('setFramework', $childDefinition->getMethodCalls()[0][0]);
 
         $tags = $definition->getTags();
-
-        $this->assertSame('setTokenStorage', $definition->getMethodCalls()[0][0]);
 
         $this->assertArrayHasKey('contao.picker_provider', $tags);
         $this->assertSame(128, $tags['contao.picker_provider'][0]['priority']);

--- a/news-bundle/tests/Picker/NewsPickerProviderTest.php
+++ b/news-bundle/tests/Picker/NewsPickerProviderTest.php
@@ -29,8 +29,6 @@ class NewsPickerProviderTest extends ContaoTestCase
 {
     public function testCreatesTheMenuItem(): void
     {
-        $picker = $this->getPicker();
-
         $config = json_encode([
             'context' => 'link',
             'extras' => [],
@@ -42,6 +40,7 @@ class NewsPickerProviderTest extends ContaoTestCase
             $config = $encoded;
         }
 
+        $picker = $this->getPicker();
         $item = $picker->createMenuItem(new PickerConfig('link', [], '', 'newsPicker'));
         $uri = 'contao_backend?do=news&popup=1&picker='.strtr(base64_encode($config), '+/=', '-_,');
 

--- a/news-bundle/tests/Picker/NewsPickerProviderTest.php
+++ b/news-bundle/tests/Picker/NewsPickerProviderTest.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 
 namespace Contao\NewsBundle\Tests\Picker;
 
-use Contao\BackendUser;
 use Contao\CoreBundle\Picker\PickerConfig;
 use Contao\NewsArchiveModel;
 use Contao\NewsBundle\Picker\NewsPickerProvider;
@@ -23,23 +22,208 @@ use Knp\Menu\ItemInterface;
 use Knp\Menu\MenuItem;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Routing\RouterInterface;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
-use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Security;
 use Symfony\Component\Translation\TranslatorInterface;
 
 class NewsPickerProviderTest extends ContaoTestCase
 {
-    /**
-     * @var NewsPickerProvider
-     */
-    private $provider;
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function setUp(): void
+    public function testCreatesTheMenuItem(): void
     {
-        parent::setUp();
+        $picker = $this->getPicker();
+
+        $config = json_encode([
+            'context' => 'link',
+            'extras' => [],
+            'current' => 'newsPicker',
+            'value' => '',
+        ]);
+
+        if (\function_exists('gzencode') && false !== ($encoded = @gzencode($config))) {
+            $config = $encoded;
+        }
+
+        $item = $picker->createMenuItem(new PickerConfig('link', [], '', 'newsPicker'));
+        $uri = 'contao_backend?do=news&popup=1&picker='.strtr(base64_encode($config), '+/=', '-_,');
+
+        $this->assertSame('News picker', $item->getLabel());
+        $this->assertSame(['class' => 'newsPicker'], $item->getLinkAttributes());
+        $this->assertTrue($item->isCurrent());
+        $this->assertSame($uri, $item->getUri());
+    }
+
+    public function testChecksIfAMenuItemIsCurrent(): void
+    {
+        $picker = $this->getPicker();
+
+        $this->assertTrue($picker->isCurrent(new PickerConfig('link', [], '', 'newsPicker')));
+        $this->assertFalse($picker->isCurrent(new PickerConfig('link', [], '', 'filePicker')));
+    }
+
+    public function testReturnsTheCorrectName(): void
+    {
+        $picker = $this->getPicker();
+
+        $this->assertSame('newsPicker', $picker->getName());
+    }
+
+    public function testChecksIfAContextIsSupported(): void
+    {
+        $picker = $this->getPicker(true);
+
+        $this->assertTrue($picker->supportsContext('link'));
+        $this->assertFalse($picker->supportsContext('file'));
+    }
+
+    public function testChecksIfModuleAccessIsGranted(): void
+    {
+        $picker = $this->getPicker(false);
+
+        $this->assertFalse($picker->supportsContext('link'));
+    }
+
+    public function testChecksIfAValueIsSupported(): void
+    {
+        $picker = $this->getPicker();
+
+        $this->assertTrue($picker->supportsValue(new PickerConfig('link', [], '{{news_url::5}}')));
+        $this->assertFalse($picker->supportsValue(new PickerConfig('link', [], '{{link_url::5}}')));
+    }
+
+    public function testReturnsTheDcaTable(): void
+    {
+        $picker = $this->getPicker();
+
+        $this->assertSame('tl_news', $picker->getDcaTable());
+    }
+
+    public function testReturnsTheDcaAttributes(): void
+    {
+        $picker = $this->getPicker();
+        $extra = ['source' => 'tl_news.2'];
+
+        $this->assertSame(
+            [
+                'fieldType' => 'radio',
+                'preserveRecord' => 'tl_news.2',
+                'value' => '5',
+            ],
+            $picker->getDcaAttributes(new PickerConfig('link', $extra, '{{news_url::5}}'))
+        );
+
+        $this->assertSame(
+            [
+                'fieldType' => 'radio',
+                'preserveRecord' => 'tl_news.2',
+            ],
+            $picker->getDcaAttributes(new PickerConfig('link', $extra, '{{link_url::5}}'))
+        );
+    }
+
+    public function testConvertsTheDcaValue(): void
+    {
+        $picker = $this->getPicker();
+
+        $this->assertSame('{{news_url::5}}', $picker->convertDcaValue(new PickerConfig('link'), 5));
+    }
+
+    public function testConvertsTheDcaValueWithACustomInsertTag(): void
+    {
+        $picker = $this->getPicker();
+
+        $this->assertSame(
+            '{{news_title::5}}',
+            $picker->convertDcaValue(new PickerConfig('link', ['insertTag' => '{{news_title::%s}}']), 5)
+        );
+    }
+
+    public function testAddsTableAndIdIfThereIsAValue(): void
+    {
+        /** @var NewsArchiveModel&MockObject $model */
+        $model = $this->mockClassWithProperties(NewsArchiveModel::class);
+        $model->id = 1;
+
+        $news = $this->createMock(NewsModel::class);
+        $news
+            ->expects($this->once())
+            ->method('getRelated')
+            ->with('pid')
+            ->willReturn($model)
+        ;
+
+        $config = new PickerConfig('link', [], '{{news_url::1}}', 'newsPicker');
+
+        $adapters = [
+            NewsModel::class => $this->mockConfiguredAdapter(['findById' => $news]),
+        ];
+
+        $picker = $this->getPicker();
+        $picker->setFramework($this->mockContaoFramework($adapters));
+
+        $method = new \ReflectionMethod(NewsPickerProvider::class, 'getRouteParameters');
+        $method->setAccessible(true);
+        $params = $method->invokeArgs($picker, [$config]);
+
+        $this->assertSame('news', $params['do']);
+        $this->assertSame('tl_news', $params['table']);
+        $this->assertSame(1, $params['id']);
+    }
+
+    public function testDoesNotAddTableAndIdIfThereIsNoEventsModel(): void
+    {
+        $config = new PickerConfig('link', [], '{{news_url::1}}', 'newsPicker');
+
+        $adapters = [
+            NewsModel::class => $this->mockConfiguredAdapter(['findById' => null]),
+        ];
+
+        $picker = $this->getPicker();
+        $picker->setFramework($this->mockContaoFramework($adapters));
+
+        $method = new \ReflectionMethod(NewsPickerProvider::class, 'getRouteParameters');
+        $method->setAccessible(true);
+        $params = $method->invokeArgs($picker, [$config]);
+
+        $this->assertSame('news', $params['do']);
+        $this->assertArrayNotHasKey('tl_news', $params);
+        $this->assertArrayNotHasKey('id', $params);
+    }
+
+    public function testDoesNotAddTableAndIdIfThereIsNoModel(): void
+    {
+        $news = $this->createMock(NewsModel::class);
+        $news
+            ->expects($this->once())
+            ->method('getRelated')
+            ->with('pid')
+            ->willReturn(null)
+        ;
+
+        $config = new PickerConfig('link', [], '{{news_url::1}}', 'newsPicker');
+
+        $adapters = [
+            NewsModel::class => $this->mockConfiguredAdapter(['findById' => $news]),
+        ];
+
+        $picker = $this->getPicker();
+        $picker->setFramework($this->mockContaoFramework($adapters));
+
+        $method = new \ReflectionMethod(NewsPickerProvider::class, 'getRouteParameters');
+        $method->setAccessible(true);
+        $params = $method->invokeArgs($picker, [$config]);
+
+        $this->assertSame('news', $params['do']);
+        $this->assertArrayNotHasKey('tl_news', $params);
+        $this->assertArrayNotHasKey('id', $params);
+    }
+
+    private function getPicker(bool $accessGranted = null): NewsPickerProvider
+    {
+        $security = $this->createMock(Security::class);
+        $security
+            ->expects(null === $accessGranted ? $this->never() : $this->once())
+            ->method('isGranted')
+            ->willReturn($accessGranted)
+        ;
 
         $menuFactory = $this->createMock(FactoryInterface::class);
         $menuFactory
@@ -73,216 +257,6 @@ class NewsPickerProviderTest extends ContaoTestCase
             ->willReturn('News picker')
         ;
 
-        $this->provider = new NewsPickerProvider($menuFactory, $router, $translator);
-    }
-
-    public function testCreatesTheMenuItem(): void
-    {
-        $picker = json_encode([
-            'context' => 'link',
-            'extras' => [],
-            'current' => 'newsPicker',
-            'value' => '',
-        ]);
-
-        if (\function_exists('gzencode') && false !== ($encoded = @gzencode($picker))) {
-            $picker = $encoded;
-        }
-
-        $item = $this->provider->createMenuItem(new PickerConfig('link', [], '', 'newsPicker'));
-        $uri = 'contao_backend?do=news&popup=1&picker='.strtr(base64_encode($picker), '+/=', '-_,');
-
-        $this->assertSame('News picker', $item->getLabel());
-        $this->assertSame(['class' => 'newsPicker'], $item->getLinkAttributes());
-        $this->assertTrue($item->isCurrent());
-        $this->assertSame($uri, $item->getUri());
-    }
-
-    public function testChecksIfAMenuItemIsCurrent(): void
-    {
-        $this->assertTrue($this->provider->isCurrent(new PickerConfig('link', [], '', 'newsPicker')));
-        $this->assertFalse($this->provider->isCurrent(new PickerConfig('link', [], '', 'filePicker')));
-    }
-
-    public function testReturnsTheCorrectName(): void
-    {
-        $this->assertSame('newsPicker', $this->provider->getName());
-    }
-
-    public function testChecksIfAContextIsSupported(): void
-    {
-        $this->provider->setTokenStorage($this->mockTokenStorage(BackendUser::class));
-
-        $this->assertTrue($this->provider->supportsContext('link'));
-        $this->assertFalse($this->provider->supportsContext('file'));
-    }
-
-    public function testFailsToCheckTheContextIfThereIsNoTokenStorage(): void
-    {
-        $this->expectException('RuntimeException');
-        $this->expectExceptionMessage('No token storage provided');
-
-        $this->provider->supportsContext('link');
-    }
-
-    public function testFailsToCheckTheContextIfThereIsNoToken(): void
-    {
-        $tokenStorage = $this->createMock(TokenStorageInterface::class);
-        $tokenStorage
-            ->method('getToken')
-            ->willReturn(null)
-        ;
-
-        $this->provider->setTokenStorage($tokenStorage);
-
-        $this->expectException('RuntimeException');
-        $this->expectExceptionMessage('No token provided');
-
-        $this->provider->supportsContext('link');
-    }
-
-    public function testFailsToCheckTheContextIfThereIsNoUser(): void
-    {
-        $token = $this->createMock(TokenInterface::class);
-        $token
-            ->method('getUser')
-            ->willReturn(null)
-        ;
-
-        $tokenStorage = $this->createMock(TokenStorageInterface::class);
-        $tokenStorage
-            ->method('getToken')
-            ->willReturn($token)
-        ;
-
-        $this->provider->setTokenStorage($tokenStorage);
-
-        $this->expectException('RuntimeException');
-        $this->expectExceptionMessage('The token does not contain a back end user object');
-
-        $this->provider->supportsContext('link');
-    }
-
-    public function testChecksIfAValueIsSupported(): void
-    {
-        $this->assertTrue($this->provider->supportsValue(new PickerConfig('link', [], '{{news_url::5}}')));
-        $this->assertFalse($this->provider->supportsValue(new PickerConfig('link', [], '{{link_url::5}}')));
-    }
-
-    public function testReturnsTheDcaTable(): void
-    {
-        $this->assertSame('tl_news', $this->provider->getDcaTable());
-    }
-
-    public function testReturnsTheDcaAttributes(): void
-    {
-        $extra = ['source' => 'tl_news.2'];
-
-        $this->assertSame(
-            [
-                'fieldType' => 'radio',
-                'preserveRecord' => 'tl_news.2',
-                'value' => '5',
-            ],
-            $this->provider->getDcaAttributes(new PickerConfig('link', $extra, '{{news_url::5}}'))
-        );
-
-        $this->assertSame(
-            [
-                'fieldType' => 'radio',
-                'preserveRecord' => 'tl_news.2',
-            ],
-            $this->provider->getDcaAttributes(new PickerConfig('link', $extra, '{{link_url::5}}'))
-        );
-    }
-
-    public function testConvertsTheDcaValue(): void
-    {
-        $this->assertSame('{{news_url::5}}', $this->provider->convertDcaValue(new PickerConfig('link'), 5));
-    }
-
-    public function testConvertsTheDcaValueWithACustomInsertTag(): void
-    {
-        $this->assertSame(
-            '{{news_title::5}}',
-            $this->provider->convertDcaValue(new PickerConfig('link', ['insertTag' => '{{news_title::%s}}']), 5)
-        );
-    }
-
-    public function testAddsTableAndIdIfThereIsAValue(): void
-    {
-        /** @var NewsArchiveModel&MockObject $model */
-        $model = $this->mockClassWithProperties(NewsArchiveModel::class);
-        $model->id = 1;
-
-        $news = $this->createMock(NewsModel::class);
-        $news
-            ->expects($this->once())
-            ->method('getRelated')
-            ->with('pid')
-            ->willReturn($model)
-        ;
-
-        $config = new PickerConfig('link', [], '{{news_url::1}}', 'newsPicker');
-
-        $adapters = [
-            NewsModel::class => $this->mockConfiguredAdapter(['findById' => $news]),
-        ];
-
-        $this->provider->setFramework($this->mockContaoFramework($adapters));
-
-        $method = new \ReflectionMethod(NewsPickerProvider::class, 'getRouteParameters');
-        $method->setAccessible(true);
-        $params = $method->invokeArgs($this->provider, [$config]);
-
-        $this->assertSame('news', $params['do']);
-        $this->assertSame('tl_news', $params['table']);
-        $this->assertSame(1, $params['id']);
-    }
-
-    public function testDoesNotAddTableAndIdIfThereIsNoEventsModel(): void
-    {
-        $config = new PickerConfig('link', [], '{{news_url::1}}', 'newsPicker');
-
-        $adapters = [
-            NewsModel::class => $this->mockConfiguredAdapter(['findById' => null]),
-        ];
-
-        $this->provider->setFramework($this->mockContaoFramework($adapters));
-
-        $method = new \ReflectionMethod(NewsPickerProvider::class, 'getRouteParameters');
-        $method->setAccessible(true);
-        $params = $method->invokeArgs($this->provider, [$config]);
-
-        $this->assertSame('news', $params['do']);
-        $this->assertArrayNotHasKey('tl_news', $params);
-        $this->assertArrayNotHasKey('id', $params);
-    }
-
-    public function testDoesNotAddTableAndIdIfThereIsNoCalendarModel(): void
-    {
-        $news = $this->createMock(NewsModel::class);
-        $news
-            ->expects($this->once())
-            ->method('getRelated')
-            ->with('pid')
-            ->willReturn(null)
-        ;
-
-        $config = new PickerConfig('link', [], '{{news_url::1}}', 'newsPicker');
-
-        $adapters = [
-            NewsModel::class => $this->mockConfiguredAdapter(['findById' => $news]),
-        ];
-
-        $this->provider->setFramework($this->mockContaoFramework($adapters));
-
-        $method = new \ReflectionMethod(NewsPickerProvider::class, 'getRouteParameters');
-        $method->setAccessible(true);
-        $params = $method->invokeArgs($this->provider, [$config]);
-
-        $this->assertSame('news', $params['do']);
-        $this->assertArrayNotHasKey('tl_news', $params);
-        $this->assertArrayNotHasKey('id', $params);
+        return new NewsPickerProvider($security, $menuFactory, $router, $translator);
     }
 }


### PR DESCRIPTION
The Security Helper has been added in Symfony 3.4: https://github.com/symfony/symfony/pull/24337

This PR does two things:
 1. It uses `isGranted` instead of checking the Contao user object, which is totally incorrect in a Symfony context
 2. It simplifies a lot of code because the helper class already abstracts a `null` token when fetching the user.

I consider this a bug fix because we **must** always use `isGranted` and not check the Contao user.

~~There are usages of the user in the pickers as well, but I'm not (yet) sure how to migrate that.~~ fixed in f0981e7cf6546bac6a776a64826ab7b96fe956d4