### PR TITLE
Do not use sqlite during read operations for performance reasons

### DIFF
--- a/manager-bundle/src/HttpKernel/ContaoCache.php
+++ b/manager-bundle/src/HttpKernel/ContaoCache.php
@@ -85,17 +85,9 @@ class ContaoCache extends HttpCache implements CacheInvalidation
             $itemsCache = new FilesystemAdapter('', 0, $cacheDir);
         }
 
-        $tagsCache = $itemsCache;
-
-        if (class_exists('SQLite3', false)) {
-            $tagsCache = new PdoAdapter(
-                DriverManager::getConnection(['url' => 'sqlite:///'.$cacheDir.'/tag_versions.sqlite'])
-            );
-        }
-
         return new Psr6Store([
             'cache_directory' => $cacheDir,
-            'cache' => new TagAwareAdapter($itemsCache, $tagsCache),
+            'cache' => new TagAwareAdapter($itemsCache),
             'cache_tags_header' => TagHeaderFormatter::DEFAULT_HEADER_NAME,
             'prune_threshold' => 5000,
         ]);


### PR DESCRIPTION
This basically restores Contao 4.7 behaviour except for the fact that we're now leveraging opcode cache if supported.

So in fact, as explained [here](https://github.com/contao/contao/issues/606#issuecomment-515398927) the `FilesystemTagAwareAdapter` is not really a good choice for our use case.
We have so many tags that it generates loads of symlinks and thus, pruning takes way too long to do during a write operation. The SQLite alternative is indeed better but we cannot use it the way it's implemented currently because it will be loadeded on every **read** operation causing a performance overhead of 10 - 15ms. 

So to sum up, here's the 3 requirements our cache adapter implementation needs to fulfil:

1. Must be fast on read
2. Must not be ultra-slow when pruning (cleaning up expired entries)
3. Must not generate too many files.

And here's the current situation:

* The files-only `TagAwareAdapter` of Contao 4.7 (and what this PR restores) fulfils `1` and `2`.
* The `FilesystemTagAwareAdapter` we tried to use fulfils `1`.
* The SQLite-enhanced `TagAwareAdapter` fulfils `2` and `3`.

We will have to find an alternative implementation that can fulfil all of the 3 requirements listed above. Maybe also in combination with some cron job that prunes the entries but we'll see.

I know that's bad news for @xchs but that's just the way it is for now.