### PR TITLE
Fix time sensitive unit test

### DIFF
--- a/core-bundle/tests/Command/ResizeImagesCommandTest.php
+++ b/core-bundle/tests/Command/ResizeImagesCommandTest.php
@@ -90,6 +90,9 @@ class ResizeImagesCommandTest extends TestCase
         $this->assertRegExp('/All images resized/', $display);
     }
 
+    /**
+     * @group time-sensitive
+     */
     public function testTimeLimit(): void
     {
         $fs = new Filesystem();


### PR DESCRIPTION
Uses the `ClockMock` class from the Symfony PHPUnit bridge to mock the `sleep()` and `time()` functions. See <https://symfony.com/doc/current/components/phpunit_bridge.html#clock-mocking>