### PR TITLE
Disable zlib.output_compression on CLI

### DIFF
--- a/manager-bundle/bin/contao-api
+++ b/manager-bundle/bin/contao-api
@@ -13,10 +13,11 @@ declare(strict_types=1);
 
 use Contao\ManagerBundle\Api\Application;
 
+error_reporting(-1);
 set_time_limit(0);
-ini_set('error_reporting', '-1');
-ini_set('display_startup_errors', '1');
-ini_set('display_errors', '1');
+@ini_set('display_startup_errors', '1');
+@ini_set('display_errors', '1');
+@ini_set('zlib.output_compression', 0);
 
 $projectDir = \dirname(__DIR__, 4);
 

--- a/manager-bundle/bin/contao-console
+++ b/manager-bundle/bin/contao-console
@@ -16,6 +16,7 @@ use Contao\ManagerBundle\HttpKernel\ContaoKernel;
 use Symfony\Component\Console\Input\ArgvInput;
 
 set_time_limit(0);
+@ini_set('zlib.output_compression', 0);
 
 if (file_exists(__DIR__.'/../autoload.php')) {
     $projectDir = \dirname(__DIR__, 2);


### PR DESCRIPTION
Spotted due to https://github.com/contao/contao-manager/issues/445