### PR TITLE
Fix a potential error if the URL has a percentage in it

### DIFF
--- a/core-bundle/src/Resources/config/services.yml
+++ b/core-bundle/src/Resources/config/services.yml
@@ -575,7 +575,6 @@ services:
         class: Contao\CoreBundle\Routing\RouteProvider
         arguments:
             - '@contao.framework'
-            - '@database_connection'
             - '%contao.url_suffix%'
             - '%contao.prepend_locale%'
 

--- a/core-bundle/src/Routing/RouteProvider.php
+++ b/core-bundle/src/Routing/RouteProvider.php
@@ -20,7 +20,6 @@ use Contao\Model;
 use Contao\Model\Collection;
 use Contao\PageModel;
 use Contao\System;
-use Doctrine\DBAL\Connection;
 use Symfony\Cmf\Component\Routing\RouteProviderInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Exception\RouteNotFoundException;
@@ -35,11 +34,6 @@ class RouteProvider implements RouteProviderInterface
     private $framework;
 
     /**
-     * @var Connection
-     */
-    private $database;
-
-    /**
      * @var string
      */
     private $urlSuffix;
@@ -52,10 +46,9 @@ class RouteProvider implements RouteProviderInterface
     /**
      * @internal Do not inherit from this class; decorate the "contao.routing.route_provider" service instead
      */
-    public function __construct(ContaoFramework $framework, Connection $database, string $urlSuffix, bool $prependLocale)
+    public function __construct(ContaoFramework $framework, string $urlSuffix, bool $prependLocale)
     {
         $this->framework = $framework;
-        $this->database = $database;
         $this->urlSuffix = $urlSuffix;
         $this->prependLocale = $prependLocale;
     }
@@ -66,8 +59,8 @@ class RouteProvider implements RouteProviderInterface
 
         $pathInfo = rawurldecode($request->getPathInfo());
 
-        // The request string must not contain "auto_item" (see #4012) or a percentage character (which means it was double encoded (see #619))
-        if (false !== strpos($pathInfo, '/auto_item/') || false !== strpos($pathInfo, '%')) {
+        // The request string must not contain "auto_item" (see #4012)
+        if (false !== strpos($pathInfo, '/auto_item/')) {
             return new RouteCollection();
         }
 
@@ -482,7 +475,7 @@ class RouteProvider implements RouteProviderInterface
             if (is_numeric($candidate)) {
                 $ids[] = (int) $candidate;
             } else {
-                $aliases[] = $this->database->quote($candidate);
+                $aliases[] = $candidate;
             }
         }
 
@@ -493,12 +486,12 @@ class RouteProvider implements RouteProviderInterface
         }
 
         if (!empty($aliases)) {
-            $conditions[] = 'tl_page.alias IN ('.implode(',', $aliases).')';
+            $conditions[] = 'tl_page.alias IN ('.implode(',', array_fill(0, \count($aliases), '?')).')';
         }
 
         /** @var PageModel $pageModel */
         $pageModel = $this->framework->getAdapter(PageModel::class);
-        $pages = $pageModel->findBy([implode(' OR ', $conditions)], []);
+        $pages = $pageModel->findBy([implode(' OR ', $conditions)], $aliases);
 
         if (!$pages instanceof Collection) {
             return [];

--- a/core-bundle/src/Routing/RouteProvider.php
+++ b/core-bundle/src/Routing/RouteProvider.php
@@ -66,7 +66,7 @@ class RouteProvider implements RouteProviderInterface
 
         $pathInfo = rawurldecode($request->getPathInfo());
 
-        // The request string must not contain "auto_item" (see #4012) or a percentage character
+        // The request string must not contain "auto_item" (see #4012) or a percentage character (which means it was double encoded (see #619))
         if (false !== strpos($pathInfo, '/auto_item/') || false !== strpos($pathInfo, '%')) {
             return new RouteCollection();
         }

--- a/core-bundle/src/Routing/RouteProvider.php
+++ b/core-bundle/src/Routing/RouteProvider.php
@@ -66,8 +66,8 @@ class RouteProvider implements RouteProviderInterface
 
         $pathInfo = rawurldecode($request->getPathInfo());
 
-        // The request string must not contain "auto_item" (see #4012)
-        if (false !== strpos($pathInfo, '/auto_item/')) {
+        // The request string must not contain "auto_item" (see #4012) or a percentage character
+        if (false !== strpos($pathInfo, '/auto_item/') || false !== strpos($pathInfo, '%')) {
             return new RouteCollection();
         }
 

--- a/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
+++ b/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
@@ -2598,7 +2598,6 @@ class ContaoCoreExtensionTest extends TestCase
         $this->assertEquals(
             [
                 new Reference('contao.framework'),
-                new Reference('database_connection'),
                 new Reference('%contao.url_suffix%'),
                 new Reference('%contao.prepend_locale%'),
             ],

--- a/core-bundle/tests/Routing/RouteProviderTest.php
+++ b/core-bundle/tests/Routing/RouteProviderTest.php
@@ -182,7 +182,7 @@ class RouteProviderTest extends TestCase
     {
         $request = $this->mockRequestWithPath('/drachenlochmuseum-v%25c3%25a4ttis.html');
 
-        $this->assertEmpty($this->getRouteProvider()->getRouteCollectionForRequest($request));
+        $this->assertEmpty($this->mockRouteProvider()->getRouteCollectionForRequest($request));
     }
 
     public function testReturnsAnEmptyCollectionIfTheUrlSuffixDoesNotMatch(): void

--- a/core-bundle/tests/Routing/RouteProviderTest.php
+++ b/core-bundle/tests/Routing/RouteProviderTest.php
@@ -178,6 +178,13 @@ class RouteProviderTest extends TestCase
         $this->assertEmpty($this->getRouteProvider()->getRouteCollectionForRequest($request));
     }
 
+    public function testReturnsAnEmptyCollectionIfThePathContainsPercentageCharacter(): void
+    {
+        $request = $this->mockRequestWithPath('/drachenlochmuseum-v%25c3%25a4ttis.html');
+
+        $this->assertEmpty($this->getRouteProvider()->getRouteCollectionForRequest($request));
+    }
+
     public function testReturnsAnEmptyCollectionIfTheUrlSuffixDoesNotMatch(): void
     {
         $request = $this->mockRequestWithPath('/foo.php');

--- a/core-bundle/tests/Routing/RouteProviderTest.php
+++ b/core-bundle/tests/Routing/RouteProviderTest.php
@@ -20,7 +20,6 @@ use Contao\CoreBundle\Routing\RouteProvider;
 use Contao\CoreBundle\Tests\TestCase;
 use Contao\Model\Collection;
 use Contao\PageModel;
-use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Exception\RouteNotFoundException;
@@ -178,13 +177,6 @@ class RouteProviderTest extends TestCase
         $this->assertEmpty($this->getRouteProvider()->getRouteCollectionForRequest($request));
     }
 
-    public function testReturnsAnEmptyCollectionIfThePathContainsPercentageCharacter(): void
-    {
-        $request = $this->mockRequestWithPath('/drachenlochmuseum-v%25c3%25a4ttis.html');
-
-        $this->assertEmpty($this->mockRouteProvider()->getRouteCollectionForRequest($request));
-    }
-
     public function testReturnsAnEmptyCollectionIfTheUrlSuffixDoesNotMatch(): void
     {
         $request = $this->mockRequestWithPath('/foo.php');
@@ -212,14 +204,14 @@ class RouteProviderTest extends TestCase
         }
 
         if (!empty($aliases)) {
-            $conditions[] = 'tl_page.alias IN ('.implode(',', $aliases).')';
+            $conditions[] = 'tl_page.alias IN ('.implode(',', array_fill(0, \count($aliases), '?')).')';
         }
 
         $pageAdapter = $this->mockAdapter(['findBy']);
         $pageAdapter
             ->expects($this->once())
             ->method('findBy')
-            ->with([implode(' OR ', $conditions)], [])
+            ->with([implode(' OR ', $conditions)], $aliases)
             ->willReturn(null)
         ;
 
@@ -696,12 +688,6 @@ class RouteProviderTest extends TestCase
             $framework = $this->mockContaoFramework();
         }
 
-        $connection = $this->createMock(Connection::class);
-        $connection
-            ->method('quote')
-            ->willReturnArgument(0)
-        ;
-
-        return new RouteProvider($framework, $connection, $urlSuffix, $prependLocale);
+        return new RouteProvider($framework, $urlSuffix, $prependLocale);
     }
 }


### PR DESCRIPTION
With @Toflar we have discovered by accident that if a URL is double-encoded (for some reason, doesn't matter) the Contao's `RouteProvider` will eventually throw an error trying to query a database.

```
URL original: drachenlochmuseum-v%25c3%25a4ttis.html
URL decoded: drachenlochmuseum-v%c3%a4ttis.html
URL decoded 2nd time: drachenlochmuseum-vättis.html
```

The decoded URL is used in the database query and that fails because the database driver would like to replace wildcards `%c` with parameters that were not provided.

Stack trace:

```
Exception: Too few arguments to build the query string
#27 vendor/contao/core-bundle/src/Resources/contao/library/Contao/Database/Statement.php(304): replaceWildcards
#26 vendor/contao/core-bundle/src/Resources/contao/library/Contao/Database/Statement.php(249): execute
#25 vendor/contao/core-bundle/src/Resources/contao/library/Contao/Model.php(1102): find
#24 vendor/contao/core-bundle/src/Resources/contao/library/Contao/Model.php(973): findBy
#23 vendor/contao/core-bundle/src/Framework/Adapter.php(38): __call
#22 vendor/contao/core-bundle/src/Routing/RouteProvider.php(493): findPages
#21 vendor/contao/core-bundle/src/Routing/RouteProvider.php(88): getRouteCollectionForRequest
#20 vendor/contao/core-bundle/src/Routing/LegacyRouteProvider.php(43): getRouteCollectionForRequest
#19 vendor/symfony-cmf/routing/src/NestedMatcher/NestedMatcher.php(141): matchRequest
#18 vendor/contao/core-bundle/src/Routing/Matcher/LegacyMatcher.php(69): matchRequest
#17 vendor/symfony-cmf/routing/src/DynamicRouter.php(271): matchRequest
#16 vendor/symfony-cmf/routing/src/ChainRouter.php(188): doMatch
#15 vendor/symfony-cmf/routing/src/ChainRouter.php(158): matchRequest
#14 vendor/symfony/http-kernel/EventListener/RouterListener.php(115): onKernelRequest
#13 vendor/symfony/event-dispatcher/EventDispatcher.php(212): doDispatch
#12 vendor/symfony/event-dispatcher/EventDispatcher.php(44): dispatch
#11 vendor/symfony/http-kernel/HttpKernel.php(126): handleRaw
#10 vendor/symfony/http-kernel/HttpKernel.php(67): handle
#9 vendor/symfony/http-kernel/Kernel.php(198): handle
#8 vendor/symfony/http-kernel/HttpCache/SubRequestHandler.php(85): handle
#7 vendor/symfony/http-kernel/HttpCache/HttpCache.php(448): forward
#6 vendor/symfony/framework-bundle/HttpCache/HttpCache.php(57): forward
#5 vendor/symfony/http-kernel/HttpCache/HttpCache.php(420): fetch
#4 vendor/contao/manager-bundle/src/HttpKernel/ContaoCache.php(46): fetch
#3 vendor/symfony/http-kernel/HttpCache/HttpCache.php(317): lookup
#2 vendor/symfony/http-kernel/HttpCache/HttpCache.php(192): handle
#1 vendor/friendsofsymfony/http-cache/src/SymfonyCache/EventDispatchingHttpCache.php(98): handle
#0 web/app.php(58): null
```