### PR TITLE
Automatically generate response from template in fragment controllers

### DIFF
--- a/core-bundle/src/Controller/ContentElement/AbstractContentElementController.php
+++ b/core-bundle/src/Controller/ContentElement/AbstractContentElementController.php
@@ -30,7 +30,13 @@ abstract class AbstractContentElementController extends AbstractFragmentControll
         $this->addSectionToTemplate($template, $section);
         $this->tagResponse(['contao.db.tl_content.'.$model->id]);
 
-        return $this->getResponse($template, $model, $request);
+        $response = $this->getResponse($template, $model, $request);
+
+        if (null === $response) {
+            $response = new Response($template->parse());
+        }
+
+        return $response;
     }
 
     protected function addSharedMaxAgeToResponse(Response $response, ContentModel $model): void
@@ -53,5 +59,5 @@ abstract class AbstractContentElementController extends AbstractFragmentControll
         $response->setSharedMaxAge(min($min));
     }
 
-    abstract protected function getResponse(Template $template, ContentModel $model, Request $request): Response;
+    abstract protected function getResponse(Template $template, ContentModel $model, Request $request): ?Response;
 }

--- a/core-bundle/src/Controller/FrontendModule/AbstractFrontendModuleController.php
+++ b/core-bundle/src/Controller/FrontendModule/AbstractFrontendModuleController.php
@@ -37,7 +37,13 @@ abstract class AbstractFrontendModuleController extends AbstractFragmentControll
         $this->addSectionToTemplate($template, $section);
         $this->tagResponse(['contao.db.tl_module.'.$model->id]);
 
-        return $this->getResponse($template, $model, $request);
+        $response = $this->getResponse($template, $model, $request);
+
+        if (null === $response) {
+            $response = new Response($template->parse());
+        }
+
+        return $response;
     }
 
     /**
@@ -69,8 +75,8 @@ abstract class AbstractFrontendModuleController extends AbstractFragmentControll
         $template->link = $module->name;
         $template->href = $href;
 
-        return $template->getResponse();
+        return new Response($template->parse());
     }
 
-    abstract protected function getResponse(Template $template, ModuleModel $model, Request $request): Response;
+    abstract protected function getResponse(Template $template, ModuleModel $model, Request $request): ?Response;
 }


### PR DESCRIPTION
This PR fixes and improves two things:

1. The `$template->getResponse()` method will add cache headers for the current page, because it _assumes_ it needs to generate the response for a page type. Therefore we should **never** use that method.

2. The PR also simplifies the controller, because I no longer need to generate anything.

Due to the BC promise, we cannot change the `getResponse` method name. But we can *weaken* the response type, because existing child classes will *enforce* a response return, which is fine.