### PR TITLE
Fix empty mariadb variables

### DIFF
--- a/core-bundle/src/Doctrine/Schema/DcaSchemaProvider.php
+++ b/core-bundle/src/Doctrine/Schema/DcaSchemaProvider.php
@@ -413,7 +413,7 @@ class DcaSchemaProvider
         ;
 
         // The variable no longer exists as of MySQL 8 and MariaDB 10.3
-        if (false === $largePrefix) {
+        if (false === $largePrefix || '' === $largePrefix->Value) {
             return 3072;
         }
 
@@ -458,7 +458,7 @@ class DcaSchemaProvider
         ;
 
         // The InnoDB file format is not Barracuda
-        if ('barracuda' !== strtolower((string) $fileFormat->Value)) {
+        if ('barracuda' !== strtolower((string) $fileFormat->Value) && '' !== $fileFormat->Value) {
             return 767;
         }
 

--- a/core-bundle/src/Doctrine/Schema/DcaSchemaProvider.php
+++ b/core-bundle/src/Doctrine/Schema/DcaSchemaProvider.php
@@ -458,7 +458,7 @@ class DcaSchemaProvider
         ;
 
         // The InnoDB file format is not Barracuda
-        if ('barracuda' !== strtolower((string) $fileFormat->Value) && '' !== $fileFormat->Value) {
+        if ('' !== $fileFormat->Value && 'barracuda' !== strtolower((string) $fileFormat->Value)) {
             return 767;
         }
 

--- a/installation-bundle/src/Database/Installer.php
+++ b/installation-bundle/src/Database/Installer.php
@@ -280,7 +280,7 @@ class Installer
         ;
 
         // MySQL 8 and MariaDB 10.3 no longer have the "innodb_file_format" setting
-        if (false === $fileFormat) {
+        if (false === $fileFormat || '' === $fileFormat->Value) {
             return true;
         }
 

--- a/installation-bundle/src/InstallTool.php
+++ b/installation-bundle/src/InstallTool.php
@@ -245,7 +245,7 @@ class InstallTool
             ;
 
             // The variable no longer exists as of MySQL 8 and MariaDB 10.3
-            if (false === $row) {
+            if (false === $row || '' === $row->Value) {
                 return false;
             }
 
@@ -284,7 +284,7 @@ class InstallTool
             ;
 
             // The InnoDB file format is not Barracuda
-            if ('barracuda' !== strtolower((string) $row->Value)) {
+            if ('barracuda' !== strtolower((string) $row->Value) && '' !== $row->Value) {
                 $context['errorCode'] = 6;
 
                 return true;

--- a/installation-bundle/src/InstallTool.php
+++ b/installation-bundle/src/InstallTool.php
@@ -284,7 +284,7 @@ class InstallTool
             ;
 
             // The InnoDB file format is not Barracuda
-            if ('barracuda' !== strtolower((string) $row->Value) && '' !== $row->Value) {
+            if ('' !== $row->Value && 'barracuda' !== strtolower((string) $row->Value)) {
                 $context['errorCode'] = 6;
 
                 return true;

--- a/installation-bundle/tests/Database/InstallerTest.php
+++ b/installation-bundle/tests/Database/InstallerTest.php
@@ -436,7 +436,7 @@ class InstallerTest extends TestCase
                                 ->method('fetch')
                                 ->willReturn((object) [
                                     'Engine' => 'InnoDB',
-                                    'Row_format' => 'COMPATCT',
+                                    'Create_options' => 'row_format=COMPATCT',
                                     'Collation' => 'utf8mb4_unicode_ci',
                                 ])
                             ;


### PR DESCRIPTION
Currently, Contao assumes that in newer MySQL and MariaDB versions, certain MySQL variables, like `innodb_large_prefix` or `innodb_file_format` do not exist any more and thus querying them returns `false`. However, in my local setup, using MariaDB `10.3.16` and now `10.4.7`, those variables are still present, yet empty.

This PR adjusts those checks accordingly.

Sorry for the additional commits and merge commits in this PR. I am still doing something wrong when updating my fork -_-