### PR TITLE
Check for dynamic row format more consistently 

### DIFF
--- a/installation-bundle/src/Database/Installer.php
+++ b/installation-bundle/src/Database/Installer.php
@@ -213,9 +213,7 @@ class Installer
                 $deleteIndexes = true;
                 $alterTables[md5($command)] = $command;
             } elseif ($innodb && $dynamic) {
-                $rowFormat = $table->getOption('row_format');
-
-                if ($rowFormat && strtolower($tableOptions->Row_format) !== strtolower($rowFormat)) {
+                if (false === stripos($tableOptions->Create_options, 'row_format=dynamic')) {
                     $command = 'ALTER TABLE '.$tableName.' ENGINE = '.$engine.' ROW_FORMAT = DYNAMIC';
                     $alterTables[md5($command)] = $command;
                 }


### PR DESCRIPTION
Currently, Contao retrieves the `ROW_FORMAT` of a table via the `Row_format` field of `SHOW TABLE STATUS` in order to decide whether or not to include a
```
ALTER TABLE ... ENGINE = ... ROW_FORMAT = DYNAMIC
```
statement in the Install Tool.

However, `Row_format` includes the information of `innodb_default_row_format` and thus this might be skipped.

Why is this a problem? Consider the following:

* A Contao 3 installation is updated to Contao 4.
* The environment during the update is using MariaDB `10.3`.
* After the update, the Contao installation plus its database is deployed on another environment running MariaDB `10.1`.

This causes a problem during the import of the SQL dump because the MariaDB `10.1` version of the target environment does _not_ use a default row format of `DYNAMIC`. In MariaDB `10.1` the default row format is still `COMPACT`. Thus the SQL export of the update environment will be incompatible with the target environment, because the `ROW_FORMAT=DYNAMIC` create options of all the tables will be missing - which causes problems with index key lengths, since the limit will be `767` when using `ROW_FORMAT=COMPACT`.

This is not a problem when doing a fresh installation, as Contao 4 will always add `ROW_FORMAT=DYNAMIC` to the create options of the table then. It is however a problem, if you update the database from Contao 3 to 4.

Instead of checking the `Row_format` of a table, this PR instead checks the `Create_options` to see wether they already contain `ROW_FORMAT=DYNAMIC` or not.