### PR TITLE
Validate allowed characters in image size name

### DIFF
--- a/core-bundle/src/DependencyInjection/Configuration.php
+++ b/core-bundle/src/DependencyInjection/Configuration.php
@@ -204,6 +204,7 @@ class Configuration implements ConfigurationInterface
                                                     )
                                                 );
                                             }
+
                                             if (preg_match('/[^a-z0-9_]/', (string) $name)) {
                                                 throw new \InvalidArgumentException(
                                                     sprintf(

--- a/core-bundle/src/DependencyInjection/Configuration.php
+++ b/core-bundle/src/DependencyInjection/Configuration.php
@@ -204,6 +204,14 @@ class Configuration implements ConfigurationInterface
                                                     )
                                                 );
                                             }
+                                            if (preg_match('/[^a-z0-9_]/', (string) $name)) {
+                                                throw new \InvalidArgumentException(
+                                                    sprintf(
+                                                        'The image size name "%s" must consist of lowercase letters, digits and underscores only',
+                                                        $name
+                                                    )
+                                                );
+                                            }
                                         }
 
                                         return $value;


### PR DESCRIPTION
Fixes #633

Only `a-z0-9_` is allowed for image size names, see https://github.com/contao/contao/blob/879e05ecc75a6bf70aabc1c3d867eb420f291f60/core-bundle/src/Resources/contao/widgets/ImageSize.php#L78