### PR TITLE
Retain the actual origId in chained alias elements

### DIFF
--- a/core-bundle/src/Resources/contao/elements/ContentAlias.php
+++ b/core-bundle/src/Resources/contao/elements/ContentAlias.php
@@ -39,7 +39,7 @@ class ContentAlias extends \ContentElement
 			return '';
 		}
 
-		$objElement->origId = $objElement->id;
+		$objElement->origId = $objElement->origId ?: $objElement->id;
 		$objElement->id = $this->id;
 		$objElement->typePrefix = 'ce_';
 


### PR DESCRIPTION
# Issue

(Tested in Contao 4.4)

## How to reproduce

- Create a regular content element (ID 1)
- Create an alias include element (ID 2) that references ID 1
- Create another alias element (ID 3) that references ID 2

Edit the original content element's template to show the element's `origId`, e. g. add:
```
data-id="<?= $this->id ?>" data-orig-id="<?= $this->origId ?>"
```

## Result
```
data-id="1" data-orig-id=""
data-id="2" data-orig-id="1"
data-id="3" data-orig-id="2"
```
The `origId` is always the ID of the included element, not the ID of the original, non-alias element.

## Expected result
```
data-id="1" data-orig-id=""
data-id="2" data-orig-id="1"
data-id="3" data-orig-id="1"
```
The `origId` should be the ID of the original, non-alias element.

# Solution

Check in `Contao\ContentAlias::generate()` whether there already is an `origId` and if there is, use it.

# Context

Commit that introduced `origId`:
7d0e13604df0bc35a1c9557cf7211c9236ddc4aa

PR referenced in the commit:
https://github.com/contao/core/pull/6638