### PR TITLE
Fix model relations when using entities

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/DcaExtractor.php
+++ b/core-bundle/src/Resources/contao/library/Contao/DcaExtractor.php
@@ -496,6 +496,22 @@ class DcaExtractor extends Controller
 				}
 			}
 		}
+		
+		// Relations
+		if (!empty($arrRelations))
+		{
+			$this->arrRelations = array();
+
+			foreach ($arrRelations as $field=>$config)
+			{
+				$this->arrRelations[$field] = array();
+
+				foreach ($config as $k=>$v)
+				{
+					$this->arrRelations[$field][$k] = $v;
+				}
+			}
+		}
 
 		// Not a database table or no field information
 		if (empty($sql) || empty($fields))
@@ -565,22 +581,6 @@ class DcaExtractor extends Controller
 				if ($type == 'unique')
 				{
 					$this->arrUniqueFields[] = $field;
-				}
-			}
-		}
-
-		// Relations
-		if (!empty($arrRelations))
-		{
-			$this->arrRelations = array();
-
-			foreach ($arrRelations as $field=>$config)
-			{
-				$this->arrRelations[$field] = array();
-
-				foreach ($config as $k=>$v)
-				{
-					$this->arrRelations[$field][$k] = $v;
 				}
 			}
 		}


### PR DESCRIPTION
Set relations before the check if the the `$sql` var is empty on line 517. When you use Entites `$sql` must be empty in the DCA file. 

With this fix you can still use Model relations.