### PR TITLE
Use $_SERVER instead of getenv()

### DIFF
--- a/manager-bundle/src/HttpKernel/ContaoCache.php
+++ b/manager-bundle/src/HttpKernel/ContaoCache.php
@@ -41,7 +41,7 @@ class ContaoCache extends HttpCache implements CacheInvalidation
 
         $this->isDebug = $kernel->isDebug();
 
-        $this->addSubscriber(new StripCookiesSubscriber(array_filter(explode(',', getenv('COOKIE_WHITELIST') ?: ''))));
+        $this->addSubscriber(new StripCookiesSubscriber(array_filter(explode(',', $_SERVER['COOKIE_WHITELIST'] ?? ''))));
         $this->addSubscriber(new PurgeListener());
         $this->addSubscriber(new PurgeTagsListener());
         $this->addSubscriber(new CleanupCacheTagsListener());

--- a/manager-bundle/tests/HttpKernel/ContaoCacheTest.php
+++ b/manager-bundle/tests/HttpKernel/ContaoCacheTest.php
@@ -45,7 +45,7 @@ class ContaoCacheTest extends ContaoTestCase
      */
     public function testCookieWhiteListEnvVariable(string $env, array $expectedList): void
     {
-        putenv('COOKIE_WHITELIST='.$env);
+        $_SERVER['COOKIE_WHITELIST'] = $env;
 
         $cache = new ContaoCache($this->createMock(ContaoKernel::class), $this->getTempDir());
         $dispatcher = $cache->getEventDispatcher();
@@ -57,7 +57,7 @@ class ContaoCacheTest extends ContaoTestCase
         $this->assertSame($expectedList, $cookieSubscriber->getWhitelist());
 
         // Cleanup
-        putenv('COOKIE_WHITELIST=null');
+        unset($_SERVER['COOKIE_WHITELIST']);
     }
 
     public function testCreatesTheCacheStore(): void


### PR DESCRIPTION
Ohterwise `.env` files are not going to be supported.