### PR TITLE
Improve the template group loading

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Controller.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Controller.php
@@ -113,14 +113,15 @@ abstract class Controller extends System
 			{
 				$strTemplate = basename($strFile, strrchr($strFile, '.'));
 
-				// If the template name is in $arrOthers, it is a root template and not
-				// a customized template (e.g. mod_article and mod_article_list)
+				// If the template name is in $arrOthers, it is a root template and not a
+				// customized template, e.g. mod_article and mod_article_list
 				if (\in_array($strTemplate, $arrOthers))
 				{
 					continue;
 				}
 
-				// Also ignore customized root templates
+				// Also ignore customized templates belonging to different root templates,
+				// e.g. mod_article and mod_article_list_custom
 				foreach ($arrOthers as $strKey)
 				{
 					if (strpos($strTemplate, $strKey . '_') === 0)

--- a/core-bundle/src/Resources/contao/library/Contao/Controller.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Controller.php
@@ -87,11 +87,20 @@ abstract class Controller extends System
 	public static function getTemplateGroup($strPrefix)
 	{
 		$arrTemplates = array();
+		$arrOthers = array();
+		$blnSeparateOthers = substr_count($strPrefix, '_') > 1;
 
 		// Get the default templates
 		foreach (TemplateLoader::getPrefixedFiles($strPrefix) as $strTemplate)
 		{
-			$arrTemplates[$strTemplate][] = 'root';
+			if ($blnSeparateOthers)
+			{
+				$arrOthers[] = $strTemplate;
+			}
+			else
+			{
+				$arrTemplates[$strTemplate][] = 'root';
+			}
 		}
 
 		$rootDir = System::getContainer()->getParameter('kernel.project_dir');
@@ -103,6 +112,23 @@ abstract class Controller extends System
 			foreach ($arrCustomized as $strFile)
 			{
 				$strTemplate = basename($strFile, strrchr($strFile, '.'));
+
+				// If the template name is in $arrOthers, it is a root template and not
+				// a customized template (e.g. mod_article and mod_article_list)
+				if (\in_array($strTemplate, $arrOthers))
+				{
+					continue;
+				}
+
+				// Also ignore customized root templates
+				foreach ($arrOthers as $strKey)
+				{
+					if (strpos($strTemplate, $strKey . '_') === 0)
+					{
+						continue 2;
+					}
+				}
+
 				$arrTemplates[$strTemplate][] = $GLOBALS['TL_LANG']['MSC']['global'];
 			}
 		}

--- a/core-bundle/src/Resources/contao/library/Contao/Controller.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Controller.php
@@ -93,7 +93,7 @@ abstract class Controller extends System
 		// Get the default templates
 		foreach (TemplateLoader::getPrefixedFiles($strPrefix) as $strTemplate)
 		{
-			if ($blnSeparateOthers)
+			if ($blnSeparateOthers && $strTemplate != $strPrefix)
 			{
 				$arrOthers[] = $strTemplate;
 			}

--- a/core-bundle/tests/Contao/TemplateLoaderTest.php
+++ b/core-bundle/tests/Contao/TemplateLoaderTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\Contao;
+
+use Contao\Controller;
+use Contao\CoreBundle\Tests\TestCase;
+use Contao\System;
+use Contao\TemplateLoader;
+use Symfony\Component\Filesystem\Filesystem;
+
+class TemplateLoaderTest extends TestCase
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $fs = new Filesystem();
+        $fs->mkdir($this->getFixturesDir().'/templates');
+        $fs->touch($this->getFixturesDir().'/templates/mod_article_custom.html5');
+        $fs->touch($this->getFixturesDir().'/templates/mod_article_list_custom.html5');
+
+        $GLOBALS['TL_LANG']['MSC']['global'] = 'global';
+
+        System::setContainer($this->getContainerWithContaoConfiguration($this->getFixturesDir()));
+
+        TemplateLoader::addFile('mod_article', 'src/Resources/contao/templates/modules');
+        TemplateLoader::addFile('mod_article_list', 'src/Resources/contao/templates/modules');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        $fs = new Filesystem();
+        $fs->remove($this->getFixturesDir().'/templates');
+
+        unset($GLOBALS['TL_LANG']);
+    }
+
+    public function testReturnsAllTemplatesOfAGroup(): void
+    {
+        $this->assertSame(
+            [
+                'mod_article' => 'mod_article',
+                'mod_article_custom' => 'mod_article_custom (global)',
+                'mod_article_list' => 'mod_article_list',
+                'mod_article_list_custom' => 'mod_article_list_custom (global)',
+            ],
+            Controller::getTemplateGroup('mod_')
+        );
+    }
+
+    public function testReturnsTheCustomTemplatesForAGivenTemplate(): void
+    {
+        $this->assertSame(
+            [
+                'mod_article_custom' => 'mod_article_custom (global)',
+            ],
+            Controller::getTemplateGroup('mod_article_')
+        );
+
+        $this->assertSame(
+            [
+                'mod_article_list_custom' => 'mod_article_list_custom (global)',
+            ],
+            Controller::getTemplateGroup('mod_article_list_')
+        );
+    }
+
+    public function testIncludesTheTempateItselfIfThereIsNoTrailingUnderscore(): void
+    {
+        $this->assertSame(
+            [
+                'mod_article_list' => 'mod_article_list',
+                'mod_article_list_custom' => 'mod_article_list_custom (global)',
+            ],
+            Controller::getTemplateGroup('mod_article_list')
+        );
+    }
+}


### PR DESCRIPTION
Since our fragment controllers automatically look for a template that matches their class name in snake case (e.g. `mod_two_factor`), we have to adjust the `loadTemplateGroup()` method so it does not return `mod_article_list` as a customized version of `mod_article`.
