### PR TITLE
Fix time sensitive test

### DIFF
--- a/core-bundle/phpunit.xml.dist
+++ b/core-bundle/phpunit.xml.dist
@@ -48,6 +48,17 @@
     </filter>
 
     <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener">
+            <arguments>
+                <array>
+                    <element key="time-sensitive">
+                        <array>
+                            <element key="0"><string>Contao\CoreBundle\Command</string></element>
+                            <element key="1"><string>Contao\CoreBundle\Tests\Command</string></element>
+                        </array>
+                    </element>
+                </array>
+            </arguments>
+        </listener>
     </listeners>
 </phpunit>


### PR DESCRIPTION
This should finally fix the `Failed asserting that … matches PCRE pattern "/Time limit of 0.0001 seconds reached/".` error.

Why this change to the phpunit configuration is necessary is described in the Symfony documentation: <https://symfony.com/doc/current/components/phpunit_bridge.html#troubleshooting>