### PR TITLE
Optimize DBAFS file sync

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Dbafs.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Dbafs.php
@@ -494,17 +494,10 @@ class Dbafs
 		}
 
 		$objDatabase = Database::getInstance();
-		$objDatabaseEngine = $objDatabase
-			->prepare("SELECT ENGINE FROM information_schema.TABLES WHERE TABLE_NAME = 'tl_files' AND TABLE_SCHEMA = ?")
-			->execute(Config::get('dbDatabase'));
-		$blnDatabaseSupportsTransaction = 1 === $objDatabaseEngine->numRows && 'InnoDB' === $objDatabaseEngine->fetchRow()[0];
 
 		// Begin atomic database access
-		if($blnDatabaseSupportsTransaction) {
-			$objDatabase->beginTransaction();
-		} else {
-			$objDatabase->lockTables(array('tl_files'=>'WRITE'));
-		}
+		$objDatabase->lockTables(array('tl_files'=>'WRITE'));
+		$objDatabase->beginTransaction();
 
 		// Reset the "found" flag
 		$objDatabase->query("UPDATE tl_files SET found=''");
@@ -757,11 +750,8 @@ class Dbafs
 		$objDatabase->query("UPDATE tl_files SET found=1 WHERE found=2");
 
 		// Finalize database access
-		if($blnDatabaseSupportsTransaction) {
-			$objDatabase->commitTransaction();
-		} else {
-			$objDatabase->unlockTables();
-		}
+		$objDatabase->commitTransaction();
+		$objDatabase->unlockTables();
 
 		// Return the path to the log file
 		return $strLog;


### PR DESCRIPTION
The DBAFS file sync gets slow with lots of files. Here is an idea on how to improve it without changing the sync procedure (spoiler alert: only works for InnoDB tables).

#### Background
I profiled the sync routine for a bit: Nearly all of the time is needed for actual inserting into or updating the database (e.g. https://github.com/contao/contao/blob/master/core-bundle/src/Resources/contao/library/Contao/Dbafs.php#L576-L588). Using models vs. native queries doesn't make a big difference. Lots of multiple single inserts just aren't that effective in MySQL. :smile:  If we wrap the whole thing in a transaction, things can be handled way more effectively (think of allocation or index manipulation for instance). Sidenote: It doesn't do anything better when leaving the table locking in place (not exactly sure why), but that shouldn't be needed anymore in this case.

This only works for InnoDB tables of course - for MyISAM we need to fallback to table locking. There probably is a nicer way to find out which engine is beeing used or if transactions are available.

#### Comparison
Here are some measurements (synchronizing 1600 images, around 970MB) on my local machine. I triggered the synchronization via the console and simply measured the time that `Dbafs::syncFiles();` took to complete.

Original:
``` 
Time spent: 16.840146064758s | Memory peak usage: 21.987663269043MiB
Synchronization complete (see system/tmp/d2d28f47cb00fbddd47a8bcab78b345c).
```

With this PR:
```
Time spent: 4.7125709056854s | Memory peak usage: 21.98282623291MiB
Synchronization complete (see system/tmp/34f891232625a5d3eea230725ddb60c1).
```

In my test this reduced the time down to arround **28%** the original duration. 