### PR TITLE
Remove the failure handler for 2FA authentication

### DIFF
--- a/manager-bundle/src/Resources/skeleton/config/security.yml
+++ b/manager-bundle/src/Resources/skeleton/config/security.yml
@@ -40,7 +40,6 @@ security:
                 check_path: contao_backend_two_factor
                 default_target_path: contao_backend
                 success_handler: contao.security.authentication_success_handler
-                failure_handler: contao.security.authentication_failure_handler
                 auth_code_parameter_name: verify
 
             logout:
@@ -72,7 +71,6 @@ security:
                 check_path: contao_frontend_two_factor
                 default_target_path: contao_root
                 success_handler: contao.security.authentication_success_handler
-                failure_handler: contao.security.authentication_failure_handler
                 auth_code_parameter_name: verify
 
             remember_me:


### PR DESCRIPTION
The 2FA failure handler is incorrect in this case, because

1. It is only an implementation to log login errors, which should only happen to username/pw logins and not 2FA passwords
2. It extends the wrong parent class for 2FA authentication. The default 2FA failure handler uses a different firewall config flag for the redirect URL.

You can currently see the issue by enabling 2FA in the backend user, enter your username+password but not the 2FA code. Then go to `contao/two-factor`. It should redirect to `/contao/login` but it redirects to `/login` (the "random" default of Scheb/TwoFactorBundle`)