### PR TITLE
Fix the template loading

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Controller.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Controller.php
@@ -80,20 +80,25 @@ abstract class Controller extends System
 	/**
 	 * Return all template files of a particular group as array
 	 *
-	 * @param string $strPrefix The template name prefix (e.g. "ce_")
+	 * @param string $strPrefix           The template name prefix (e.g. "ce_")
+	 * @param array  $arrAdditionalMapper An additional mapper array
 	 *
 	 * @return array An array of template names
 	 */
-	public static function getTemplateGroup($strPrefix)
+	public static function getTemplateGroup($strPrefix, array $arrAdditionalMapper=array())
 	{
 		$arrTemplates = array();
 		$arrBundleTemplates = array();
 
-		$arrMapper = array
+		$arrMapper = array_merge
 		(
-			'ce' => 'TL_CTE',
-			'form' => 'TL_FFL',
-			'mod' => 'FE_MOD',
+			$arrAdditionalMapper,
+			array
+			(
+				'ce' => array_keys(array_merge(...array_values($GLOBALS['TL_CTE']))),
+				'form' => array_keys($GLOBALS['TL_FFL']),
+				'mod' => array_keys(array_merge(...array_values($GLOBALS['FE_MOD']))),
+			)
 		);
 
 		// Get the default templates
@@ -103,16 +108,10 @@ abstract class Controller extends System
 			{
 				list($k, $strKey) = explode('_', $strTemplate, 2);
 
-				if (isset($arrMapper[$k]))
+				if (isset($arrMapper[$k]) && \in_array($strKey, $arrMapper[$k]))
 				{
-					foreach ($GLOBALS[$arrMapper[$k]] as $arrMappings)
-					{
-						if (isset($arrMappings[$strKey]))
-						{
-							$arrBundleTemplates[] = $strTemplate;
-							continue 2;
-						}
-					}
+					$arrBundleTemplates[] = $strTemplate;
+					continue;
 				}
 			}
 

--- a/core-bundle/src/Resources/contao/library/Contao/Controller.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Controller.php
@@ -87,7 +87,7 @@ abstract class Controller extends System
 	public static function getTemplateGroup($strPrefix)
 	{
 		$arrTemplates = array();
-		$arrOthers = array();
+		$arrBundleTemplates = array();
 
 		$arrMapper = array
 		(
@@ -109,7 +109,7 @@ abstract class Controller extends System
 					{
 						if (isset($arrMappings[$strKey]))
 						{
-							$arrOthers[] = $strTemplate;
+							$arrBundleTemplates[] = $strTemplate;
 							continue 2;
 						}
 					}
@@ -129,16 +129,15 @@ abstract class Controller extends System
 			{
 				$strTemplate = basename($strFile, strrchr($strFile, '.'));
 
-				// If the template name is in $arrOthers, it is a root template and not a
-				// customized template, e.g. mod_article and mod_article_list
-				if (\in_array($strTemplate, $arrOthers))
+				// Ignore bundle templates, e.g. mod_article and mod_article_list
+				if (\in_array($strTemplate, $arrBundleTemplates))
 				{
 					continue;
 				}
 
-				// Also ignore customized templates belonging to different root templates,
+				// Also ignore custom templates belonging to a different bundle template,
 				// e.g. mod_article and mod_article_list_custom
-				foreach ($arrOthers as $strKey)
+				foreach ($arrBundleTemplates as $strKey)
 				{
 					if (strpos($strTemplate, $strKey . '_') === 0)
 					{

--- a/core-bundle/tests/Contao/TemplateLoaderTest.php
+++ b/core-bundle/tests/Contao/TemplateLoaderTest.php
@@ -31,6 +31,7 @@ class TemplateLoaderTest extends TestCase
         $fs->mkdir($this->getFixturesDir().'/templates');
 
         $GLOBALS['TL_LANG']['MSC']['global'] = 'global';
+        $GLOBALS['FE_MOD']['miscellaneous']['article_list'] = ['Contao\ModuleArticleList'];
 
         System::setContainer($this->getContainerWithContaoConfiguration($this->getFixturesDir()));
     }
@@ -45,7 +46,7 @@ class TemplateLoaderTest extends TestCase
         $fs = new Filesystem();
         $fs->remove($this->getFixturesDir().'/templates');
 
-        unset($GLOBALS['TL_LANG']);
+        unset($GLOBALS['TL_LANG'], $GLOBALS['FE_MOD']);
     }
 
     public function testReturnsACustomTemplateInTemplates(): void
@@ -142,6 +143,57 @@ class TemplateLoaderTest extends TestCase
             ],
             Controller::getTemplateGroup('ctlg_view_')
         );
+
+        TemplateLoader::reset();
+    }
+
+    public function testReturnsATemplateGroup(): void
+    {
+        $fs = new Filesystem();
+        $fs->touch($this->getFixturesDir().'/templates/mod_article_custom.html5');
+        $fs->touch($this->getFixturesDir().'/templates/mod_article_list_custom.html5');
+
+        TemplateLoader::addFile('mod_article', 'core-bundle/src/Resources/contao/templates/modules');
+        TemplateLoader::addFile('mod_article_list', 'core-bundle/src/Resources/contao/templates/modules');
+        TemplateLoader::addFile('mod_article_foo', 'article-bundle/src/Resources/contao/templates/modules');
+        TemplateLoader::addFile('mod_article_bar', 'contao/templates');
+
+        $this->assertSame(
+            [
+                'mod_article' => 'mod_article',
+                'mod_article_bar' => 'mod_article_bar',
+                'mod_article_custom' => 'mod_article_custom (global)',
+                'mod_article_foo' => 'mod_article_foo',
+            ],
+            Controller::getTemplateGroup('mod_article')
+        );
+
+        $this->assertSame(
+            [
+                'mod_article_bar' => 'mod_article_bar',
+                'mod_article_custom' => 'mod_article_custom (global)',
+                'mod_article_foo' => 'mod_article_foo',
+            ],
+            Controller::getTemplateGroup('mod_article_')
+        );
+
+        $this->assertSame(
+            [
+                'mod_article_list' => 'mod_article_list',
+                'mod_article_list_custom' => 'mod_article_list_custom (global)',
+            ],
+            Controller::getTemplateGroup('mod_article_list')
+        );
+
+        $this->assertSame(
+            [
+                'mod_article_list_custom' => 'mod_article_list_custom (global)',
+            ],
+            Controller::getTemplateGroup('mod_article_list_')
+        );
+
+        $fs->remove($this->getFixturesDir().'/templates/mod_article_custom.html5');
+        $fs->remove($this->getFixturesDir().'/templates/mod_article_list_custom.html5');
 
         TemplateLoader::reset();
     }


### PR DESCRIPTION
This is a follow-up on #657, #677 and #682. It implements the new template loading by looking up the keys in `TL_CTE`, `TL_FFL` and `FE_MOD` as discussed in Mumble on August 29th.