### PR TITLE
Add support for lazy loading images

### DIFF
--- a/core-bundle/src/DependencyInjection/Configuration.php
+++ b/core-bundle/src/DependencyInjection/Configuration.php
@@ -238,6 +238,8 @@ class Configuration implements ConfigurationInterface
                                     ->end()
                                     ->scalarNode('cssClass')
                                     ->end()
+                                    ->booleanNode('lazyLoading')
+                                    ->end()
                                     ->scalarNode('densities')
                                     ->end()
                                     ->scalarNode('sizes')

--- a/core-bundle/src/Image/PictureFactory.php
+++ b/core-bundle/src/Image/PictureFactory.php
@@ -181,8 +181,13 @@ class PictureFactory implements PictureFactoryInterface
                     ));
                 }
 
-                if ($imageSizes && $imageSizes->cssClass) {
-                    $attributes['class'] = $imageSizes->cssClass;
+                if ($imageSizes) {
+                    if ($imageSizes->cssClass) {
+                        $attributes['class'] = $imageSizes->cssClass;
+                    }
+                    if ($imageSizes->lazyLoading) {
+                        $attributes['loading'] = 'lazy';
+                    }
                 }
 
                 /** @var ImageSizeItemModel $imageSizeItemModel */
@@ -210,8 +215,12 @@ class PictureFactory implements PictureFactoryInterface
                 $config->setFormats($imageSizes['formats'] ?? []);
                 $options->setSkipIfDimensionsMatch($imageSizes['skipIfDimensionsMatch'] ?? false);
 
-                if ($imageSizes && isset($imageSizes['cssClass']) && $imageSizes['cssClass']) {
+                if (!empty($imageSizes['cssClass'])) {
                     $attributes['class'] = $imageSizes['cssClass'];
+                }
+
+                if (!empty($imageSizes['lazyLoading'])) {
+                    $attributes['loading'] = 'lazy';
                 }
 
                 if (\count($imageSizes['items']) > 0) {

--- a/core-bundle/src/Image/PictureFactory.php
+++ b/core-bundle/src/Image/PictureFactory.php
@@ -185,6 +185,7 @@ class PictureFactory implements PictureFactoryInterface
                     if ($imageSizes->cssClass) {
                         $attributes['class'] = $imageSizes->cssClass;
                     }
+
                     if ($imageSizes->lazyLoading) {
                         $attributes['loading'] = 'lazy';
                     }

--- a/core-bundle/src/Resources/contao/dca/tl_image_size.php
+++ b/core-bundle/src/Resources/contao/dca/tl_image_size.php
@@ -103,7 +103,7 @@ $GLOBALS['TL_DCA']['tl_image_size'] = array
 	// Palettes
 	'palettes' => array
 	(
-		'default'                     => '{title_legend},name,width,height,resizeMode,zoom;{source_legend},densities,sizes;{expert_legend:hide},formats,cssClass,skipIfDimensionsMatch'
+		'default'                     => '{title_legend},name,width,height,resizeMode,zoom;{source_legend},densities,sizes;{expert_legend:hide},formats,cssClass,skipIfDimensionsMatch,lazyLoading'
 	),
 
 	// Fields
@@ -198,6 +198,13 @@ $GLOBALS['TL_DCA']['tl_image_size'] = array
 		'skipIfDimensionsMatch' => array
 		(
 			'label'                   => &$GLOBALS['TL_LANG']['tl_image_size']['skipIfDimensionsMatch'],
+			'inputType'               => 'checkbox',
+			'exclude'                 => true,
+			'eval'                    => array('tl_class'=>'w50 m12'),
+			'sql'                     => "char(1) NOT NULL default ''"
+		),
+		'lazyLoading' => array
+		(
 			'inputType'               => 'checkbox',
 			'exclude'                 => true,
 			'eval'                    => array('tl_class'=>'w50 m12'),

--- a/core-bundle/src/Resources/contao/dca/tl_image_size.php
+++ b/core-bundle/src/Resources/contao/dca/tl_image_size.php
@@ -103,7 +103,7 @@ $GLOBALS['TL_DCA']['tl_image_size'] = array
 	// Palettes
 	'palettes' => array
 	(
-		'default'                     => '{title_legend},name,width,height,resizeMode,zoom;{source_legend},densities,sizes;{expert_legend:hide},formats,cssClass,skipIfDimensionsMatch,lazyLoading'
+		'default'                     => '{title_legend},name,width,height,resizeMode,zoom;{source_legend},densities,sizes;{loading_legend},lazyLoading;{expert_legend:hide},formats,cssClass,skipIfDimensionsMatch'
 	),
 
 	// Fields
@@ -207,7 +207,7 @@ $GLOBALS['TL_DCA']['tl_image_size'] = array
 		(
 			'inputType'               => 'checkbox',
 			'exclude'                 => true,
-			'eval'                    => array('tl_class'=>'w50 m12'),
+			'eval'                    => array('tl_class'=>'w50'),
 			'sql'                     => "char(1) NOT NULL default ''"
 		)
 	)

--- a/core-bundle/src/Resources/contao/languages/en/tl_image_size.xlf
+++ b/core-bundle/src/Resources/contao/languages/en/tl_image_size.xlf
@@ -65,6 +65,12 @@
       <trans-unit id="tl_image_size.skipIfDimensionsMatch.1">
         <source>Note that no optimizations such as meta data stripping or JPEG compression will be applied in this case.</source>
       </trans-unit>
+      <trans-unit id="tl_image_size.lazyLoading.0">
+        <source>Enable lazy loading</source>
+      </trans-unit>
+      <trans-unit id="tl_image_size.lazyLoading.1">
+        <source>Adds loading=&amp;quot;lazy&amp;quot; to the &amp;lt;img&amp;gt; tag to defer loading the image until it is scrolled into the viewport.</source>
+      </trans-unit>
       <trans-unit id="tl_image_size.tstamp.0">
         <source>Revision date</source>
       </trans-unit>

--- a/core-bundle/src/Resources/contao/languages/en/tl_image_size.xlf
+++ b/core-bundle/src/Resources/contao/languages/en/tl_image_size.xlf
@@ -83,6 +83,9 @@
       <trans-unit id="tl_image_size.source_legend">
         <source>Image source settings</source>
       </trans-unit>
+      <trans-unit id="tl_image_size.loading_legend">
+        <source>Loading options</source>
+      </trans-unit>
       <trans-unit id="tl_image_size.expert_legend">
         <source>Expert settings</source>
       </trans-unit>

--- a/core-bundle/src/Resources/contao/models/ImageSizeModel.php
+++ b/core-bundle/src/Resources/contao/models/ImageSizeModel.php
@@ -28,6 +28,7 @@ use Contao\Model\Collection;
  * @property integer $zoom
  * @property string  $formats
  * @property boolean $skipIfDimensionsMatch
+ * @property boolean $lazyLoading
  *
  * @method static ImageSizeModel|null findById($id, array $opt=array())
  * @method static ImageSizeModel|null findByPk($id, array $opt=array())
@@ -45,6 +46,7 @@ use Contao\Model\Collection;
  * @method static ImageSizeModel|null findOneByZoom($val, array $opt=array())
  * @method static ImageSizeModel|null findOneByFormats($val, array $opt=array())
  * @method static ImageSizeModel|null findOneBySkipIfDimensionsMatch($val, array $opt=array())
+ * @method static ImageSizeModel|null findOneByLazyLoading($val, array $opt=array())
  *
  * @method static Collection|ImageSizeModel[]|ImageSizeModel|null findByPid($val, array $opt=array())
  * @method static Collection|ImageSizeModel[]|ImageSizeModel|null findByTstamp($val, array $opt=array())
@@ -58,6 +60,7 @@ use Contao\Model\Collection;
  * @method static Collection|ImageSizeModel[]|ImageSizeModel|null findByZoom($val, array $opt=array())
  * @method static Collection|ImageSizeModel[]|ImageSizeModel|null findByFormats($val, array $opt=array())
  * @method static Collection|ImageSizeModel[]|ImageSizeModel|null findBySkipIfDimensionsMatch($val, array $opt=array())
+ * @method static Collection|ImageSizeModel[]|ImageSizeModel|null findByLazyLoading($val, array $opt=array())
  * @method static Collection|ImageSizeModel[]|ImageSizeModel|null findMultipleByIds($val, array $opt=array())
  * @method static Collection|ImageSizeModel[]|ImageSizeModel|null findBy($col, $val, array $opt=array())
  * @method static Collection|ImageSizeModel[]|ImageSizeModel|null findAll(array $opt=array())
@@ -75,6 +78,7 @@ use Contao\Model\Collection;
  * @method static integer countByZoom($val, array $opt=array())
  * @method static integer countByFormats($val, array $opt=array())
  * @method static integer countBySkipIfDimensionsMatch($val, array $opt=array())
+ * @method static integer countByLazyLoading($val, array $opt=array())
  *
  * @author Leo Feyer <https://github.com/leofeyer>
  */

--- a/core-bundle/src/Resources/contao/templates/picture/picture_default.html5
+++ b/core-bundle/src/Resources/contao/templates/picture/picture_default.html5
@@ -6,7 +6,7 @@
     <?php endforeach; ?>
 <?php endif; ?>
 
-<img src="<?= $this->img['src'] ?>"<?php if ($this->img['srcset'] !== $this->img['src']): ?> srcset="<?= $this->img['srcset'] ?>"<?php endif; ?><?php if (!empty($this->img['sizes'])): ?> sizes="<?= $this->img['sizes'] ?>"<?php elseif (!$this->sources && !empty($this->img['width']) && !empty($this->img['height'])): ?> width="<?= $this->img['width'] ?>" height="<?= $this->img['height'] ?>"<?php endif; ?> alt="<?= $this->alt ?>"<?php if ($this->title): ?> title="<?= $this->title ?>"<?php endif; ?><?php if ($this->class || !empty($this->img['class'])): ?> class="<?= trim($this->class.' '.$this->img['class']) ?>"<?php endif; ?><?= $this->attributes ?> itemprop="image">
+<img src="<?= $this->img['src'] ?>"<?php if ($this->img['srcset'] !== $this->img['src']): ?> srcset="<?= $this->img['srcset'] ?>"<?php endif; ?><?php if (!empty($this->img['sizes'])): ?> sizes="<?= $this->img['sizes'] ?>"<?php elseif (!$this->sources && !empty($this->img['width']) && !empty($this->img['height'])): ?> width="<?= $this->img['width'] ?>" height="<?= $this->img['height'] ?>"<?php endif; ?> alt="<?= $this->alt ?>"<?php if (!empty($this->img['loading'])): ?> loading="<?= $this->img['loading'] ?>"<?php endif; ?><?php if ($this->title): ?> title="<?= $this->title ?>"<?php endif; ?><?php if ($this->class || !empty($this->img['class'])): ?> class="<?= trim($this->class.' '.$this->img['class']) ?>"<?php endif; ?><?= $this->attributes ?> itemprop="image">
 
 <?php if ($this->sources): ?>
   </picture>

--- a/core-bundle/tests/Image/PictureFactoryTest.php
+++ b/core-bundle/tests/Image/PictureFactoryTest.php
@@ -118,6 +118,7 @@ class PictureFactoryTest extends TestCase
             'sizes' => '100vw',
             'densities' => '1x, 2x',
             'cssClass' => 'my-size',
+            'lazyLoading' => true,
         ];
 
         /** @var ImageSizeModel&MockObject $imageSizeModel */
@@ -161,6 +162,7 @@ class PictureFactoryTest extends TestCase
 
         $this->assertSame($imageMock, $picture->getImg()['src']);
         $this->assertSame('my-size', $picture->getImg()['class']);
+        $this->assertSame('lazy', $picture->getImg()['loading']);
     }
 
     public function testCreatesAPictureObjectFromAnImageObjectWithAPredefinedImageSize(): void
@@ -174,6 +176,7 @@ class PictureFactoryTest extends TestCase
                 'densities' => '1x, 2x',
                 'sizes' => '100vw',
                 'cssClass' => 'foobar-class',
+                'lazyLoading' => true,
                 'skipIfDimensionsMatch' => true,
                 'formats' => [
                     'jpg' => ['webp', 'jpg'],
@@ -274,6 +277,7 @@ class PictureFactoryTest extends TestCase
 
         $this->assertSame($imageMock, $picture->getImg()['src']);
         $this->assertSame($predefinedSizes['foobar']['cssClass'], $picture->getImg()['class']);
+        $this->assertSame('lazy', $picture->getImg()['loading']);
     }
 
     public function testCreatesAPictureObjectFromAnImageObjectWithAPictureConfiguration(): void


### PR DESCRIPTION
See #433

I only added support for `loading="lazy"` for now because `eager` and `auto` don’t change the default browser behavior currently. 