### PR TITLE
Add conflict with scheb/two-factor-bundle 4.7.0 (broken 2FA in frontend)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -122,6 +122,7 @@
         "doctrine/orm": "<2.4",
         "knplabs/knp-time-bundle": "1.9.0",
         "lexik/maintenance-bundle": "2.1.4",
+        "scheb/two-factor-bundle": ">=4.7.0",
         "symfony/doctrine-bridge": "<3.4",
         "symfony/security-core": "4.2.* <4.2.3",
         "symfony/swiftmailer-bundle": "2.6.* <2.6.2",

--- a/core-bundle/composer.json
+++ b/core-bundle/composer.json
@@ -99,6 +99,7 @@
         "doctrine/orm": "<2.4",
         "knplabs/knp-time-bundle": "1.9.0",
         "lexik/maintenance-bundle": "2.1.4",
+        "scheb/two-factor-bundle": ">=4.7.0",
         "symfony/doctrine-bridge": "<3.4",
         "symfony/security-core": "4.2.* <4.2.3",
         "symfony/swiftmailer-bundle": "2.6.* <2.6.2",


### PR DESCRIPTION
Somehow 2FA is broken with `scheb/two-factor-bundle` in version `4.7.0` (never ending redirects after submitting the verify code). I need to investigate why.
