### PR TITLE
do not load cache kernel in dev environment

### DIFF
--- a/manager-bundle/src/Resources/skeleton/web/index.php
+++ b/manager-bundle/src/Resources/skeleton/web/index.php
@@ -27,12 +27,6 @@ $loader = require __DIR__.'/../vendor/autoload.php';
 
 $request = Request::createFromGlobals();
 $kernel = ContaoKernel::fromRequest(\dirname(__DIR__), $request);
-$cache = $kernel->getHttpCache();
-
-// Enable the Symfony reverse proxy if request has no surrogate capability
-if (null !== $cache->getSurrogate() && !$cache->getSurrogate()->hasSurrogateCapability($request)) {
-    $kernel = $cache;
-}
 
 $response = $kernel->handle($request);
 $response->send();

--- a/manager-bundle/tests/Console/ContaoApplicationTest.php
+++ b/manager-bundle/tests/Console/ContaoApplicationTest.php
@@ -16,13 +16,14 @@ use Contao\CoreBundle\Util\PackageUtil;
 use Contao\ManagerBundle\Console\ContaoApplication;
 use Contao\ManagerBundle\HttpKernel\ContaoKernel;
 use Contao\TestCase\ContaoTestCase;
+use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\HttpFoundation\Request;
 
 class ContaoApplicationTest extends ContaoTestCase
 {
     public function testApplicationNameAndVersion(): void
     {
-        $app = new ContaoApplication(ContaoKernel::fromRequest(sys_get_temp_dir(), Request::create('/')));
+        $app = new ContaoApplication(ContaoKernel::fromInput(sys_get_temp_dir(), new ArgvInput()));
 
         $this->assertSame('Contao Managed Edition', $app->getName());
         $this->assertSame(PackageUtil::getContaoVersion(), $app->getVersion());
@@ -30,7 +31,7 @@ class ContaoApplicationTest extends ContaoTestCase
 
     public function testDoesNotHaveNoDebugOption(): void
     {
-        $app = new ContaoApplication(ContaoKernel::fromRequest(sys_get_temp_dir(), Request::create('/')));
+        $app = new ContaoApplication(ContaoKernel::fromInput(sys_get_temp_dir(), new ArgvInput()));
         $options = $app->getDefinition()->getOptions();
 
         $this->assertArrayNotHasKey('no-debug', $options);

--- a/manager-bundle/tests/HttpKernel/ContaoKernelTest.php
+++ b/manager-bundle/tests/HttpKernel/ContaoKernelTest.php
@@ -232,16 +232,6 @@ class ContaoKernelTest extends ContaoTestCase
         $this->assertSame($cache, $kernel->getHttpCache());
     }
 
-    public function testSetsProjectDirFromRequest(): void
-    {
-        $_SERVER['APP_ENV'] = 'dev';
-        $tempDir = realpath($this->getTempDir());
-        $kernel = ContaoKernel::fromRequest($tempDir, Request::create('/'));
-        unset($_SERVER['APP_ENV']);
-
-        $this->assertSame($tempDir, $kernel->getProjectDir());
-    }
-
     public function testSetsRequestTrustedProxiesFromEnvVars(): void
     {
         $this->assertSame([], Request::getTrustedProxies());
@@ -312,6 +302,51 @@ class ContaoKernelTest extends ContaoTestCase
 
         $input = new ArgvInput(['list', '--env=foo']);
         ContaoKernel::fromInput(sys_get_temp_dir(), $input);
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function testGetActualKernel(): void
+    {
+        unset($_SERVER['APP_ENV']);
+        $_SERVER['SYMFONY_ENV'] = 'dev';
+
+        $tempDir = realpath($this->getTempDir());
+        $kernel = ContaoKernel::fromRequest($tempDir, Request::create('/'));
+        
+        $this->assertInstanceOf(ContaoKernel::class, $kernel);
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function testGetCacheKernel(): void
+    {
+        unset($_SERVER['APP_ENV']);
+        $_SERVER['SYMFONY_ENV'] = 'prod';
+
+        $tempDir = realpath($this->getTempDir());
+        $kernel = ContaoKernel::fromRequest($tempDir, Request::create('/'));
+
+        $this->assertInstanceOf(ContaoCache::class, $kernel);
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function testSetsProjectDirFromRequest(): void
+    {
+        unset($_SERVER['APP_ENV']);
+        $_SERVER['SYMFONY_ENV'] = 'dev';
+
+        $tempDir = realpath($this->getTempDir());
+        $kernel = ContaoKernel::fromRequest($tempDir, Request::create('/'));
+
+        $this->assertSame($tempDir, $kernel->getProjectDir());
     }
 
     /**

--- a/manager-bundle/tests/HttpKernel/ContaoKernelTest.php
+++ b/manager-bundle/tests/HttpKernel/ContaoKernelTest.php
@@ -308,14 +308,14 @@ class ContaoKernelTest extends ContaoTestCase
      * @runInSeparateProcess
      * @preserveGlobalState disabled
      */
-    public function testGetActualKernel(): void
+    public function testReturnsTheContaoKernelInDevMode(): void
     {
         unset($_SERVER['APP_ENV']);
         $_SERVER['SYMFONY_ENV'] = 'dev';
 
         $tempDir = realpath($this->getTempDir());
         $kernel = ContaoKernel::fromRequest($tempDir, Request::create('/'));
-        
+
         $this->assertInstanceOf(ContaoKernel::class, $kernel);
     }
 
@@ -323,7 +323,7 @@ class ContaoKernelTest extends ContaoTestCase
      * @runInSeparateProcess
      * @preserveGlobalState disabled
      */
-    public function testGetCacheKernel(): void
+    public function testReturnsTheContaoCacheInProdMode(): void
     {
         unset($_SERVER['APP_ENV']);
         $_SERVER['SYMFONY_ENV'] = 'prod';

--- a/manager-bundle/tests/HttpKernel/ContaoKernelTest.php
+++ b/manager-bundle/tests/HttpKernel/ContaoKernelTest.php
@@ -234,8 +234,10 @@ class ContaoKernelTest extends ContaoTestCase
 
     public function testSetsProjectDirFromRequest(): void
     {
+        $_SERVER['APP_ENV'] = 'dev';
         $tempDir = realpath($this->getTempDir());
         $kernel = ContaoKernel::fromRequest($tempDir, Request::create('/'));
+        unset($_SERVER['APP_ENV']);
 
         $this->assertSame($tempDir, $kernel->getProjectDir());
     }


### PR DESCRIPTION
This PR resolves https://github.com/contao/contao/issues/649. It won't load the Cache-Kernel while in `dev` environment. I'm not sure this is the way to go but it solves my problems with it.