### PR TITLE
Fix mime type for MP3

### DIFF
--- a/core-bundle/src/Resources/contao/config/mimetypes.php
+++ b/core-bundle/src/Resources/contao/config/mimetypes.php
@@ -76,7 +76,7 @@ $GLOBALS['TL_MIME'] = array
 
 	// Audio files
 	'm4a'   => array('audio/x-m4a', 'iconM4A.svg'),
-	'mp3'   => array('audio/mp3', 'iconMP3.svg'),
+	'mp3'   => array('audio/mpeg', 'iconMP3.svg'),
 	'wma'   => array('audio/wma', 'iconWMA.svg'),
 	'mpeg'  => array('audio/mpeg', 'iconMPEG.svg'),
 	'wav'   => array('audio/wav', 'iconWAV.svg'),


### PR DESCRIPTION
The current mime type mapping sets the mime type for MP3 files to `audio/mp3`. However [according to the specs](https://www.iana.org/assignments/media-types/audio/mpeg) it should be `audio/mpeg`.

This causes problems for Audio elements in the front end with certain browsers, e.g. Firefox.

### Reproduction

1. Create a new audio element.
2. Select an MP3 file.
3. Open the front end in Firefox.

The html output will be something like this:

```html
<audio width="100%" preload="none" controls="">
  <source type="audio/mp3" src="files/foo/bar.mp3">
</audio>
```

The server will (probably) correctly use the `audio/mpeg` mime type for the file in the response header for the file.

Firefox will not be able to play the file via the HTML5 element. The following error message will show up in the console:

```
Media resource https://example.org/files/foo/bar.mp3 could not be decoded.
```

Firefox will still be able to play the file, when opened directly.