### PR TITLE
Require symfony/var-dumper

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -95,6 +95,7 @@
         "symfony/swiftmailer-bundle": "^2.6 || ^3.1.5",
         "symfony/translation": "4.2.* || 4.3.*",
         "symfony/twig-bundle": "4.2.* || 4.3.*",
+        "symfony/var-dumper": "4.2.* || 4.3.*",
         "symfony/web-profiler-bundle": "4.2.* || 4.3.*",
         "symfony/yaml": "4.2.* || 4.3.*",
         "terminal42/service-annotation-bundle": "^1.0",
@@ -149,9 +150,9 @@
     },
     "extra": {
         "contao-manager-plugin": {
-            "contao/core-bundle": "Contao\\CoreBundle\\ContaoManager\\Plugin",
             "contao/calendar-bundle": "Contao\\CalendarBundle\\ContaoManager\\Plugin",
             "contao/comments-bundle": "Contao\\CommentsBundle\\ContaoManager\\Plugin",
+            "contao/core-bundle": "Contao\\CoreBundle\\ContaoManager\\Plugin",
             "contao/faq-bundle": "Contao\\FaqBundle\\ContaoManager\\Plugin",
             "contao/installation-bundle": "Contao\\InstallationBundle\\ContaoManager\\Plugin",
             "contao/listing-bundle": "Contao\\ListingBundle\\ContaoManager\\Plugin",

--- a/core-bundle/composer.json
+++ b/core-bundle/composer.json
@@ -84,6 +84,7 @@
         "symfony/swiftmailer-bundle": "^2.6 || ^3.1.5",
         "symfony/translation": "4.2.* || 4.3.*",
         "symfony/twig-bundle": "4.2.* || 4.3.*",
+        "symfony/var-dumper": "4.2.* || 4.3.*",
         "symfony/yaml": "4.2.* || 4.3.*",
         "terminal42/service-annotation-bundle": "^1.0",
         "true/punycode": "^2.1",

--- a/core-bundle/tests/Contao/TemplateTest.php
+++ b/core-bundle/tests/Contao/TemplateTest.php
@@ -231,16 +231,16 @@ EOF
     public function testCanDumpTemplateVars(): void
     {
         $template = new FrontendTemplate();
-        $template->test = 1;
+        $template->setData(['test' => 1]);
 
         $dump = null;
 
         VarDumper::setHandler(static function ($var) use (&$dump): void {
             $dump = $var;
         });
-        
+
         $template->dumpTemplateVars();
-        
+
         $this->assertSame(['test' => 1], $dump);
     }
 }

--- a/core-bundle/tests/Contao/TemplateTest.php
+++ b/core-bundle/tests/Contao/TemplateTest.php
@@ -235,17 +235,14 @@ EOF
         $template = new FrontendTemplate();
         $template->test = 1;
 
-        // Manually set the VarDumper handler so we can fetch the output buffer
-        VarDumper::setHandler(static function ($var): void {
-            $cloner = new VarCloner();
-            $dumper = new CliDumper('php://output');
-            $dumper->dump($cloner->cloneVar($var));
+        $dump = null;
+
+        VarDumper::setHandler(static function ($var) use (&$dump): void {
+            $dump = $var;
         });
-
-        ob_start();
-
+        
         $template->dumpTemplateVars();
-
-        $this->assertSame("array:1 [\n  \"test\" => 1\n]\n", ob_get_clean());
+        
+        $this->assertSame(['test' => 1], $dump);
     }
 }

--- a/core-bundle/tests/Contao/TemplateTest.php
+++ b/core-bundle/tests/Contao/TemplateTest.php
@@ -19,8 +19,6 @@ use Contao\FrontendTemplate;
 use Contao\System;
 use Symfony\Component\Asset\Packages;
 use Symfony\Component\Filesystem\Filesystem;
-use Symfony\Component\VarDumper\Cloner\VarCloner;
-use Symfony\Component\VarDumper\Dumper\CliDumper;
 use Symfony\Component\VarDumper\VarDumper;
 
 class TemplateTest extends TestCase


### PR DESCRIPTION
While writing tests for #708 I noticed that the `VarDumper` component isn't actually required by the `core-bundle`, even though `\Contao\Template::dumpTemplateVars()` uses it. This PR adds the dependency and also adds a test for it.

_Note:_ this needs to be added to the `composer.json` of the `contao/contao` mono repository as well presumably, but I am not sure what the procedure here is?

_Note:_ this requirement is not needed for the `4.4` branch - but the test could be added there. I can provide a separate PR for that.