### PR TITLE
Enable skipIfDimensionsMatch for empty resize configurations

### DIFF
--- a/core-bundle/src/Image/ImageFactory.php
+++ b/core-bundle/src/Image/ImageFactory.php
@@ -170,6 +170,10 @@ class ImageFactory implements ImageFactoryInterface
 
         if (!$options instanceof ResizeOptions) {
             $options = new ResizeOptions();
+
+            if (!$size instanceof ResizeConfiguration && $resizeConfig->isEmpty()) {
+                $options->setSkipIfDimensionsMatch(true);
+            }
         }
 
         if (null !== $targetPath) {

--- a/core-bundle/src/Image/PictureFactory.php
+++ b/core-bundle/src/Image/PictureFactory.php
@@ -242,6 +242,10 @@ class PictureFactory implements PictureFactoryInterface
             $resizeConfig->setMode($size[2]);
         }
 
+        if ($resizeConfig->isEmpty()) {
+            $options->setSkipIfDimensionsMatch(true);
+        }
+
         $configItem = new PictureConfigurationItem();
         $configItem->setResizeConfig($resizeConfig);
 

--- a/core-bundle/tests/Image/ImageFactoryTest.php
+++ b/core-bundle/tests/Image/ImageFactoryTest.php
@@ -88,6 +88,13 @@ class ImageFactoryTest extends TestCase
 
                         return true;
                     }
+                ),
+                $this->callback(
+                    function (ResizeOptions $options): bool {
+                        $this->assertFalse($options->getSkipIfDimensionsMatch());
+
+                        return true;
+                    }
                 )
             )
             ->willReturn($imageMock)
@@ -112,6 +119,56 @@ class ImageFactoryTest extends TestCase
         file_put_contents($path, '');
 
         $image = $imageFactory->create($path, [100, 200, ResizeConfiguration::MODE_BOX]);
+
+        $this->assertSameImage($imageMock, $image);
+    }
+
+    public function testCreatesAnImageObjectFromAnImagePathWithEmptySize(): void
+    {
+        $path = $this->getFixturesDir().'/images/dummy.jpg';
+        $imageMock = $this->createMock(ImageInterface::class);
+
+        $resizer = $this->createMock(ResizerInterface::class);
+        $resizer
+            ->expects($this->exactly(2))
+            ->method('resize')
+            ->with(
+                $this->callback(
+                    function (Image $image) use (&$path): bool {
+                        $this->assertSame($path, $image->getPath());
+
+                        return true;
+                    }
+                ),
+                $this->callback(
+                    function (ResizeConfiguration $config): bool {
+                        $this->assertTrue($config->isEmpty());
+
+                        return true;
+                    }
+                ),
+                $this->callback(
+                    function (ResizeOptions $options): bool {
+                        $this->assertTrue($options->getSkipIfDimensionsMatch());
+
+                        return true;
+                    }
+                )
+            )
+            ->willReturn($imageMock)
+        ;
+
+        /** @var FilesModel&MockObject $filesModel */
+        $filesModel = $this->mockClassWithProperties(FilesModel::class);
+
+        $filesAdapter = $this->mockConfiguredAdapter(['findByPath' => $filesModel]);
+        $framework = $this->mockContaoFramework([FilesModel::class => $filesAdapter]);
+        $imageFactory = $this->getImageFactory($resizer, null, null, null, $framework);
+        $image = $imageFactory->create($path, ['', '', '']);
+
+        $this->assertSameImage($imageMock, $image);
+
+        $image = $imageFactory->create($path, [0, 0, 'box']);
 
         $this->assertSameImage($imageMock, $image);
     }

--- a/core-bundle/tests/Image/ImageFactoryTest.php
+++ b/core-bundle/tests/Image/ImageFactoryTest.php
@@ -160,7 +160,6 @@ class ImageFactoryTest extends TestCase
 
         /** @var FilesModel&MockObject $filesModel */
         $filesModel = $this->mockClassWithProperties(FilesModel::class);
-
         $filesAdapter = $this->mockConfiguredAdapter(['findByPath' => $filesModel]);
         $framework = $this->mockContaoFramework([FilesModel::class => $filesAdapter]);
         $imageFactory = $this->getImageFactory($resizer, null, null, null, $framework);

--- a/core-bundle/tests/Image/PictureFactoryTest.php
+++ b/core-bundle/tests/Image/PictureFactoryTest.php
@@ -447,6 +447,13 @@ class PictureFactoryTest extends TestCase
 
                         return true;
                     }
+                ),
+                $this->callback(
+                    function (ResizeOptions $options): bool {
+                        $this->assertFalse($options->getSkipIfDimensionsMatch());
+
+                        return true;
+                    }
                 )
             )
             ->willReturn($pictureMock)
@@ -482,6 +489,80 @@ class PictureFactoryTest extends TestCase
         $defaultDensities = '1x, 2x';
         $pictureFactory->setDefaultDensities($defaultDensities);
         $picture = $pictureFactory->create($path, [100, 200, ResizeConfiguration::MODE_BOX]);
+
+        $this->assertSame($pictureMock, $picture);
+    }
+
+    public function testCreatesAPictureObjectWithEmptyConfig(): void
+    {
+        $defaultDensities = '';
+        $path = $this->getTempDir().'/images/dummy.jpg';
+        $imageMock = $this->createMock(ImageInterface::class);
+        $pictureMock = $this->createMock(PictureInterface::class);
+
+        $pictureGenerator = $this->createMock(PictureGeneratorInterface::class);
+        $pictureGenerator
+            ->method('generate')
+            ->with(
+                $this->callback(
+                    function (ImageInterface $image) use ($imageMock): bool {
+                        $this->assertSame($imageMock, $image);
+
+                        return true;
+                    }
+                ),
+                $this->callback(
+                    function (PictureConfiguration $pictureConfig) use (&$defaultDensities): bool {
+                        $this->assertTrue($pictureConfig->getSize()->getResizeConfig()->isEmpty());
+
+                        $this->assertSame(0, $pictureConfig->getSize()->getResizeConfig()->getZoomLevel());
+                        $this->assertSame($defaultDensities, $pictureConfig->getSize()->getDensities());
+                        $this->assertSame('', $pictureConfig->getSize()->getSizes());
+
+                        return true;
+                    }
+                ),
+                $this->callback(
+                    function (ResizeOptions $options): bool {
+                        $this->assertTrue($options->getSkipIfDimensionsMatch());
+
+                        return true;
+                    }
+                )
+            )
+            ->willReturn($pictureMock)
+        ;
+
+        $imageFactory = $this->createMock(ImageFactoryInterface::class);
+        $imageFactory
+            ->method('create')
+            ->with(
+                $this->callback(
+                    function (string $imagePath) use ($path): bool {
+                        $this->assertSame($path, $imagePath);
+
+                        return true;
+                    }
+                ),
+                $this->callback(
+                    function (?ResizeConfiguration $size): bool {
+                        $this->assertNull($size);
+
+                        return true;
+                    }
+                )
+            )
+            ->willReturn($imageMock)
+        ;
+
+        $pictureFactory = $this->getPictureFactory($pictureGenerator, $imageFactory);
+        $picture = $pictureFactory->create($path, ['', '', '']);
+
+        $this->assertSame($pictureMock, $picture);
+
+        $defaultDensities = '1x, 2x';
+        $pictureFactory->setDefaultDensities($defaultDensities);
+        $picture = $pictureFactory->create($path, [0, 0, ResizeConfiguration::MODE_BOX]);
 
         $this->assertSame($pictureMock, $picture);
     }

--- a/core-bundle/tests/Image/PictureFactoryTest.php
+++ b/core-bundle/tests/Image/PictureFactoryTest.php
@@ -514,7 +514,6 @@ class PictureFactoryTest extends TestCase
                 $this->callback(
                     function (PictureConfiguration $pictureConfig) use (&$defaultDensities): bool {
                         $this->assertTrue($pictureConfig->getSize()->getResizeConfig()->isEmpty());
-
                         $this->assertSame(0, $pictureConfig->getSize()->getResizeConfig()->getZoomLevel());
                         $this->assertSame($defaultDensities, $pictureConfig->getSize()->getDensities());
                         $this->assertSame('', $pictureConfig->getSize()->getSizes());


### PR DESCRIPTION
As discussed in https://github.com/contao/contao/issues/745#issuecomment-530717457

If no image size is selected or configured the image should not get modified by Contao and the original image should be used instead.

An exception to this rule is if the image has an EXIF orientation tag, in this case the image gets rotated.