### PR TITLE
Do not install the tests with "prefer-dist"

### DIFF
--- a/calendar-bundle/.gitattributes
+++ b/calendar-bundle/.gitattributes
@@ -1,0 +1,5 @@
+/.tx export-ignore
+/tests export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/phpunit.xml.dist export-ignore

--- a/comments-bundle/.gitattributes
+++ b/comments-bundle/.gitattributes
@@ -1,0 +1,3 @@
+/.tx export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore

--- a/core-bundle/.gitattributes
+++ b/core-bundle/.gitattributes
@@ -1,0 +1,5 @@
+/.tx export-ignore
+/tests export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/phpunit.xml.dist export-ignore

--- a/faq-bundle/.gitattributes
+++ b/faq-bundle/.gitattributes
@@ -1,0 +1,5 @@
+/.tx export-ignore
+/tests export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/phpunit.xml.dist export-ignore

--- a/installation-bundle/.gitattributes
+++ b/installation-bundle/.gitattributes
@@ -1,0 +1,5 @@
+/.tx export-ignore
+/tests export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/phpunit.xml.dist export-ignore

--- a/listing-bundle/.gitattributes
+++ b/listing-bundle/.gitattributes
@@ -1,0 +1,3 @@
+/.tx export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore

--- a/manager-bundle/.gitattributes
+++ b/manager-bundle/.gitattributes
@@ -1,0 +1,5 @@
+/.tx export-ignore
+/tests export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/phpunit.xml.dist export-ignore

--- a/news-bundle/.gitattributes
+++ b/news-bundle/.gitattributes
@@ -1,0 +1,5 @@
+/.tx export-ignore
+/tests export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/phpunit.xml.dist export-ignore

--- a/newsletter-bundle/.gitattributes
+++ b/newsletter-bundle/.gitattributes
@@ -1,0 +1,3 @@
+/.tx export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore


### PR DESCRIPTION
This PR adds a `.gitattributes` file to exclude the tests when installing from dist. The related discussion is here: https://github.com/symfony/symfony/pull/33579