### PR TITLE
Use classnames instead of service IDs

### DIFF
--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -42,7 +42,7 @@ $container = System::getContainer();
 $rootDir = $container->getParameter('kernel.project_dir');
 
 $image = $container
-    ->get('contao.image.image_factory')
+    ->get('Contao\CoreBundle\Image\ImageFactory')
     ->create($rootDir.'/'.$objSubfiles->path, [80, 60, 'center_center'])
     ->getUrl($rootDir)
 ;
@@ -62,7 +62,7 @@ $container = System::getContainer();
 $rootDir = $container->getParameter('kernel.project_dir');
 
 $image = $container
-    ->get('contao.image.image_factory')
+    ->get('Contao\CoreBundle\Image\ImageFactory')
     ->create(
         $rootDir.'/'.$path,
         (new ResizeConfiguration())
@@ -85,7 +85,7 @@ $container = System::getContainer();
 $rootDir = $container->getParameter('kernel.project_dir');
 
 $picture = $container
-    ->get('contao.image.picture_factory')
+    ->get('Contao\CoreBundle\Image\PictureFactory')
     ->create($rootDir.'/'.$path, $imageSize)
 ;
 

--- a/calendar-bundle/src/DependencyInjection/ContaoCalendarExtension.php
+++ b/calendar-bundle/src/DependencyInjection/ContaoCalendarExtension.php
@@ -31,5 +31,8 @@ class ContaoCalendarExtension extends Extension
 
         $loader->load('listener.yml');
         $loader->load('services.yml');
+
+        // Backwards compatibility
+        $loader->load('legacy_aliases.yml');
     }
 }

--- a/calendar-bundle/src/Resources/config/legacy_aliases.yml
+++ b/calendar-bundle/src/Resources/config/legacy_aliases.yml
@@ -1,0 +1,6 @@
+services:
+    _defaults:
+        public: true
+
+    contao_calendar.listener.generate_page: '@Contao\CalendarBundle\EventListener\GeneratePageListener'
+    contao_calendar.listener.insert_tags: '@Contao\CalendarBundle\EventListener\InsertTagsListener'

--- a/calendar-bundle/src/Resources/config/listener.yml
+++ b/calendar-bundle/src/Resources/config/listener.yml
@@ -1,26 +1,22 @@
 services:
-    contao_calendar.listener.generate_page:
-        class: Contao\CalendarBundle\EventListener\GeneratePageListener
+    Contao\CalendarBundle\EventListener\GeneratePageListener:
         arguments:
             - '@Contao\CoreBundle\Framework\ContaoFramework'
         public: true
 
-    contao_calendar.listener.insert_tags:
-        class: Contao\CalendarBundle\EventListener\InsertTagsListener
+    Contao\CalendarBundle\EventListener\InsertTagsListener:
         arguments:
             - '@Contao\CoreBundle\Framework\ContaoFramework'
         public: true
 
-    contao_calendar.listener.preview_url_create:
-        class: Contao\CalendarBundle\EventListener\PreviewUrlCreateListener
+    Contao\CalendarBundle\EventListener\PreviewUrlCreateListener:
         arguments:
             - '@request_stack'
             - '@Contao\CoreBundle\Framework\ContaoFramework'
         tags:
             - { name: kernel.event_listener, event: contao.preview_url_create, method: onPreviewUrlCreate }
 
-    contao_calendar.listener.preview_url_convert:
-        class: Contao\CalendarBundle\EventListener\PreviewUrlConvertListener
+    Contao\CalendarBundle\EventListener\PreviewUrlConvertListener:
         arguments:
             - '@request_stack'
             - '@Contao\CoreBundle\Framework\ContaoFramework'

--- a/calendar-bundle/src/Resources/config/listener.yml
+++ b/calendar-bundle/src/Resources/config/listener.yml
@@ -2,20 +2,20 @@ services:
     contao_calendar.listener.generate_page:
         class: Contao\CalendarBundle\EventListener\GeneratePageListener
         arguments:
-            - '@contao.framework'
+            - '@Contao\CoreBundle\Framework\ContaoFramework'
         public: true
 
     contao_calendar.listener.insert_tags:
         class: Contao\CalendarBundle\EventListener\InsertTagsListener
         arguments:
-            - '@contao.framework'
+            - '@Contao\CoreBundle\Framework\ContaoFramework'
         public: true
 
     contao_calendar.listener.preview_url_create:
         class: Contao\CalendarBundle\EventListener\PreviewUrlCreateListener
         arguments:
             - '@request_stack'
-            - '@contao.framework'
+            - '@Contao\CoreBundle\Framework\ContaoFramework'
         tags:
             - { name: kernel.event_listener, event: contao.preview_url_create, method: onPreviewUrlCreate }
 
@@ -23,6 +23,6 @@ services:
         class: Contao\CalendarBundle\EventListener\PreviewUrlConvertListener
         arguments:
             - '@request_stack'
-            - '@contao.framework'
+            - '@Contao\CoreBundle\Framework\ContaoFramework'
         tags:
             - { name: kernel.event_listener, event: contao.preview_url_convert, method: onPreviewUrlConvert }

--- a/calendar-bundle/src/Resources/config/services.yml
+++ b/calendar-bundle/src/Resources/config/services.yml
@@ -9,6 +9,6 @@ services:
             - '@knp_menu.factory'
             - '@router'
             - '@?translator'
-            - '@Symfony\Component\Security\Core\Security'
+            - '@security.helper'
         tags:
             - { name: contao.picker_provider, priority: 96 }

--- a/calendar-bundle/src/Resources/config/services.yml
+++ b/calendar-bundle/src/Resources/config/services.yml
@@ -2,7 +2,7 @@ services:
     _instanceof:
         Contao\CoreBundle\Framework\FrameworkAwareInterface:
             calls:
-                - ['setFramework', ['@contao.framework']]
+                - ['setFramework', ['@Contao\CoreBundle\Framework\ContaoFramework']]
 
     contao_calendar.picker.event_provider:
         class: Contao\CalendarBundle\Picker\EventPickerProvider

--- a/calendar-bundle/src/Resources/config/services.yml
+++ b/calendar-bundle/src/Resources/config/services.yml
@@ -4,12 +4,11 @@ services:
             calls:
                 - ['setFramework', ['@Contao\CoreBundle\Framework\ContaoFramework']]
 
-    contao_calendar.picker.event_provider:
-        class: Contao\CalendarBundle\Picker\EventPickerProvider
+    Contao\CalendarBundle\Picker\EventPickerProvider:
         arguments:
             - '@knp_menu.factory'
             - '@router'
             - '@?translator'
-            - '@security.helper'
+            - '@Symfony\Component\Security\Core\Security'
         tags:
             - { name: contao.picker_provider, priority: 96 }

--- a/calendar-bundle/src/Resources/contao/config/config.php
+++ b/calendar-bundle/src/Resources/contao/config/config.php
@@ -43,9 +43,9 @@ if (\defined('TL_MODE') && TL_MODE == 'BE')
 // Register hooks
 $GLOBALS['TL_HOOKS']['removeOldFeeds'][] = array('Contao\Calendar', 'purgeOldFeeds');
 $GLOBALS['TL_HOOKS']['getSearchablePages'][] = array('Contao\Calendar', 'getSearchablePages');
-$GLOBALS['TL_HOOKS']['generatePage'][] = array('contao_calendar.listener.generate_page', 'onGeneratePage');
+$GLOBALS['TL_HOOKS']['generatePage'][] = array('Contao\CalendarBundle\EventListener\GeneratePageListener', 'onGeneratePage');
 $GLOBALS['TL_HOOKS']['generateXmlFiles'][] = array('Contao\Calendar', 'generateFeeds');
-$GLOBALS['TL_HOOKS']['replaceInsertTags'][] = array('contao_calendar.listener.insert_tags', 'onReplaceInsertTags');
+$GLOBALS['TL_HOOKS']['replaceInsertTags'][] = array('Contao\CalendarBundle\EventListener\InsertTagsListener', 'onReplaceInsertTags');
 
 // Add permissions
 $GLOBALS['TL_PERMISSIONS'][] = 'calendars';

--- a/calendar-bundle/src/Resources/contao/dca/tl_calendar_events.php
+++ b/calendar-bundle/src/Resources/contao/dca/tl_calendar_events.php
@@ -335,7 +335,7 @@ $GLOBALS['TL_DCA']['tl_calendar_events'] = array
 			'eval'                    => array('rgxp'=>'natural', 'includeBlankOption'=>true, 'nospace'=>true, 'helpwizard'=>true, 'tl_class'=>'w50'),
 			'options_callback' => static function ()
 			{
-				return Contao\System::getContainer()->get('contao.image.image_sizes')->getOptionsForUser(Contao\BackendUser::getInstance());
+				return Contao\System::getContainer()->get('Contao\CoreBundle\Image\ImageSizes')->getOptionsForUser(Contao\BackendUser::getInstance());
 			},
 			'sql'                     => "varchar(64) NOT NULL default ''"
 		),
@@ -669,7 +669,7 @@ class tl_calendar_events extends Contao\Backend
 		// Generate the alias if there is none
 		if ($varValue == '')
 		{
-			$varValue = Contao\System::getContainer()->get('contao.slug')->generate($dc->activeRecord->title, Contao\CalendarModel::findByPk($dc->activeRecord->pid)->jumpTo, $aliasExists);
+			$varValue = Contao\System::getContainer()->get('Contao\CoreBundle\Slug\Slug')->generate($dc->activeRecord->title, Contao\CalendarModel::findByPk($dc->activeRecord->pid)->jumpTo, $aliasExists);
 		}
 		elseif ($aliasExists($varValue))
 		{
@@ -825,7 +825,7 @@ class tl_calendar_events extends Contao\Backend
 	{
 		$event = Contao\CalendarEventsModel::findByPk($dc->activeRecord->id);
 		$url = Contao\Events::generateEventUrl($event, true);
-		$suffix = substr($dc->inputName, strlen($dc->field));
+		$suffix = substr($dc->inputName, \strlen($dc->field));
 
 		list($baseUrl) = explode($event->alias ?: $event->id, $url);
 

--- a/calendar-bundle/tests/DependencyInjection/ContaoCalendarExtensionTest.php
+++ b/calendar-bundle/tests/DependencyInjection/ContaoCalendarExtensionTest.php
@@ -23,7 +23,6 @@ use Contao\CoreBundle\Framework\FrameworkAwareInterface;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
-use Symfony\Component\Security\Core\Security;
 
 class ContaoCalendarExtensionTest extends TestCase
 {
@@ -106,7 +105,7 @@ class ContaoCalendarExtensionTest extends TestCase
         $this->assertSame('knp_menu.factory', (string) $definition->getArgument(0));
         $this->assertSame('router', (string) $definition->getArgument(1));
         $this->assertSame('translator', (string) $definition->getArgument(2));
-        $this->assertSame(Security::class, (string) $definition->getArgument(3));
+        $this->assertSame('security.helper', (string) $definition->getArgument(3));
 
         $conditionals = $definition->getInstanceofConditionals();
 

--- a/calendar-bundle/tests/DependencyInjection/ContaoCalendarExtensionTest.php
+++ b/calendar-bundle/tests/DependencyInjection/ContaoCalendarExtensionTest.php
@@ -23,6 +23,7 @@ use Contao\CoreBundle\Framework\FrameworkAwareInterface;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+use Symfony\Component\Security\Core\Security;
 
 class ContaoCalendarExtensionTest extends TestCase
 {
@@ -46,33 +47,30 @@ class ContaoCalendarExtensionTest extends TestCase
 
     public function testRegistersTheGeneratePageListener(): void
     {
-        $this->assertTrue($this->container->has('contao_calendar.listener.generate_page'));
+        $this->assertTrue($this->container->has(GeneratePageListener::class));
 
-        $definition = $this->container->getDefinition('contao_calendar.listener.generate_page');
+        $definition = $this->container->getDefinition(GeneratePageListener::class);
 
-        $this->assertSame(GeneratePageListener::class, $definition->getClass());
         $this->assertTrue($definition->isPublic());
         $this->assertSame(ContaoFramework::class, (string) $definition->getArgument(0));
     }
 
     public function testRegistersTheInsertTagsListener(): void
     {
-        $this->assertTrue($this->container->has('contao_calendar.listener.insert_tags'));
+        $this->assertTrue($this->container->has(InsertTagsListener::class));
 
-        $definition = $this->container->getDefinition('contao_calendar.listener.insert_tags');
+        $definition = $this->container->getDefinition(InsertTagsListener::class);
 
-        $this->assertSame(InsertTagsListener::class, $definition->getClass());
         $this->assertTrue($definition->isPublic());
         $this->assertSame(ContaoFramework::class, (string) $definition->getArgument(0));
     }
 
     public function testRegistersThePreviewUrlCreateListener(): void
     {
-        $this->assertTrue($this->container->has('contao_calendar.listener.preview_url_create'));
+        $this->assertTrue($this->container->has(PreviewUrlCreateListener::class));
 
-        $definition = $this->container->getDefinition('contao_calendar.listener.preview_url_create');
+        $definition = $this->container->getDefinition(PreviewUrlCreateListener::class);
 
-        $this->assertSame(PreviewUrlCreateListener::class, $definition->getClass());
         $this->assertSame('request_stack', (string) $definition->getArgument(0));
         $this->assertSame(ContaoFramework::class, (string) $definition->getArgument(1));
 
@@ -85,11 +83,10 @@ class ContaoCalendarExtensionTest extends TestCase
 
     public function testRegistersThePreviewUrlConvertListener(): void
     {
-        $this->assertTrue($this->container->has('contao_calendar.listener.preview_url_convert'));
+        $this->assertTrue($this->container->has(PreviewUrlConvertListener::class));
 
-        $definition = $this->container->getDefinition('contao_calendar.listener.preview_url_convert');
+        $definition = $this->container->getDefinition(PreviewUrlConvertListener::class);
 
-        $this->assertSame(PreviewUrlConvertListener::class, $definition->getClass());
         $this->assertSame('request_stack', (string) $definition->getArgument(0));
         $this->assertSame(ContaoFramework::class, (string) $definition->getArgument(1));
 
@@ -102,15 +99,14 @@ class ContaoCalendarExtensionTest extends TestCase
 
     public function testRegistersTheEventPickerProvider(): void
     {
-        $this->assertTrue($this->container->has('contao_calendar.picker.event_provider'));
+        $this->assertTrue($this->container->has(EventPickerProvider::class));
 
-        $definition = $this->container->getDefinition('contao_calendar.picker.event_provider');
+        $definition = $this->container->getDefinition(EventPickerProvider::class);
 
-        $this->assertSame(EventPickerProvider::class, $definition->getClass());
         $this->assertSame('knp_menu.factory', (string) $definition->getArgument(0));
         $this->assertSame('router', (string) $definition->getArgument(1));
         $this->assertSame('translator', (string) $definition->getArgument(2));
-        $this->assertSame('security.helper', (string) $definition->getArgument(3));
+        $this->assertSame(Security::class, (string) $definition->getArgument(3));
 
         $conditionals = $definition->getInstanceofConditionals();
 

--- a/calendar-bundle/tests/DependencyInjection/ContaoCalendarExtensionTest.php
+++ b/calendar-bundle/tests/DependencyInjection/ContaoCalendarExtensionTest.php
@@ -18,6 +18,7 @@ use Contao\CalendarBundle\EventListener\InsertTagsListener;
 use Contao\CalendarBundle\EventListener\PreviewUrlConvertListener;
 use Contao\CalendarBundle\EventListener\PreviewUrlCreateListener;
 use Contao\CalendarBundle\Picker\EventPickerProvider;
+use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\CoreBundle\Framework\FrameworkAwareInterface;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -51,7 +52,7 @@ class ContaoCalendarExtensionTest extends TestCase
 
         $this->assertSame(GeneratePageListener::class, $definition->getClass());
         $this->assertTrue($definition->isPublic());
-        $this->assertSame('contao.framework', (string) $definition->getArgument(0));
+        $this->assertSame(ContaoFramework::class, (string) $definition->getArgument(0));
     }
 
     public function testRegistersTheInsertTagsListener(): void
@@ -62,7 +63,7 @@ class ContaoCalendarExtensionTest extends TestCase
 
         $this->assertSame(InsertTagsListener::class, $definition->getClass());
         $this->assertTrue($definition->isPublic());
-        $this->assertSame('contao.framework', (string) $definition->getArgument(0));
+        $this->assertSame(ContaoFramework::class, (string) $definition->getArgument(0));
     }
 
     public function testRegistersThePreviewUrlCreateListener(): void
@@ -73,7 +74,7 @@ class ContaoCalendarExtensionTest extends TestCase
 
         $this->assertSame(PreviewUrlCreateListener::class, $definition->getClass());
         $this->assertSame('request_stack', (string) $definition->getArgument(0));
-        $this->assertSame('contao.framework', (string) $definition->getArgument(1));
+        $this->assertSame(ContaoFramework::class, (string) $definition->getArgument(1));
 
         $tags = $definition->getTags();
 
@@ -90,7 +91,7 @@ class ContaoCalendarExtensionTest extends TestCase
 
         $this->assertSame(PreviewUrlConvertListener::class, $definition->getClass());
         $this->assertSame('request_stack', (string) $definition->getArgument(0));
-        $this->assertSame('contao.framework', (string) $definition->getArgument(1));
+        $this->assertSame(ContaoFramework::class, (string) $definition->getArgument(1));
 
         $tags = $definition->getTags();
 

--- a/comments-bundle/src/Resources/contao/classes/Comments.php
+++ b/comments-bundle/src/Resources/contao/classes/Comments.php
@@ -12,6 +12,7 @@ namespace Contao;
 
 use Contao\CoreBundle\Exception\PageNotFoundException;
 use Contao\CoreBundle\OptIn\OptIn;
+use Contao\CoreBundle\Security\Authentication\Token\TokenChecker;
 use FOS\HttpCache\ResponseTagger;
 
 /**
@@ -331,7 +332,7 @@ class Comments extends Frontend
 
 			$intMember = 0;
 
-			if (System::getContainer()->get('contao.security.token_checker')->hasFrontendUser())
+			if (System::getContainer()->get(TokenChecker::class)->hasFrontendUser())
 			{
 				$intMember = FrontendUser::getInstance()->id;
 			}
@@ -579,7 +580,7 @@ class Comments extends Frontend
 		$strConnector = (strpos($strUrl, '?') !== false) ? '&' : '?';
 
 		/** @var OptIn $optIn */
-		$optIn = System::getContainer()->get('contao.opt-in');
+		$optIn = System::getContainer()->get(OptIn::class);
 		$optInToken = $optIn->create('com', $objComment->email, array('tl_comments_notify'=>array($objNotify->id)));
 
 		// Send the token
@@ -596,7 +597,7 @@ class Comments extends Frontend
 		if (strncmp(Input::get('token'), 'com-', 4) === 0)
 		{
 			/** @var OptIn $optIn */
-			$optIn = System::getContainer()->get('contao.opt-in');
+			$optIn = System::getContainer()->get(OptIn::class);
 
 			// Find an unconfirmed token with only one related record
 			if ((!$optInToken = $optIn->find(Input::get('token'))) || !$optInToken->isValid() || \count($arrRelated = $optInToken->getRelatedRecords()) != 1 || key($arrRelated) != 'tl_comments_notify' || \count($arrIds = current($arrRelated)) != 1 || (!$objNotify = CommentsNotifyModel::findByPk($arrIds[0])))

--- a/core-bundle/README.md
+++ b/core-bundle/README.md
@@ -118,7 +118,7 @@ security:
                 path: contao_backend_logout
                 handlers:
                     - contao.security.logout_handler
-                    - contao_manager.security.logout_handler
+                    - Contao\ManagerBundle\Security\Logout\LogoutHandler
                 success_handler: contao.security.logout_success_handler
 
         contao_frontend:

--- a/core-bundle/src/Controller/AbstractFragmentController.php
+++ b/core-bundle/src/Controller/AbstractFragmentController.php
@@ -42,10 +42,7 @@ abstract class AbstractFragmentController extends AbstractController implements 
     {
         return array_merge(
             parent::getSubscribedServices(),
-            [
-                'contao.framework' => ContaoFramework::class,
-                'fos_http_cache.http.symfony_response_tagger' => '?'.SymfonyResponseTagger::class,
-            ]
+            ['fos_http_cache.http.symfony_response_tagger' => '?'.SymfonyResponseTagger::class]
         );
     }
 
@@ -62,7 +59,7 @@ abstract class AbstractFragmentController extends AbstractController implements 
             $templateName = $model->customTpl;
         }
 
-        $template = $this->get('contao.framework')->createInstance(FrontendTemplate::class, [$templateName]);
+        $template = $this->get(ContaoFramework::class)->createInstance(FrontendTemplate::class, [$templateName]);
         $template->setData($model->row());
 
         return $template;

--- a/core-bundle/src/Controller/BackendController.php
+++ b/core-bundle/src/Controller/BackendController.php
@@ -44,7 +44,7 @@ class BackendController extends AbstractController
      */
     public function mainAction(): Response
     {
-        $this->get('contao.framework')->initialize();
+        $this->get(ContaoFramework::class)->initialize();
 
         $controller = new BackendMain();
 
@@ -56,7 +56,7 @@ class BackendController extends AbstractController
      */
     public function loginAction(Request $request): Response
     {
-        $this->get('contao.framework')->initialize();
+        $this->get(ContaoFramework::class)->initialize();
 
         if ($this->isGranted('IS_AUTHENTICATED_FULLY')) {
             $queryString = '';
@@ -88,7 +88,7 @@ class BackendController extends AbstractController
      */
     public function passwordAction(): Response
     {
-        $this->get('contao.framework')->initialize();
+        $this->get(ContaoFramework::class)->initialize();
 
         $controller = new BackendPassword();
 
@@ -106,7 +106,7 @@ class BackendController extends AbstractController
             return $this->redirect($previewScript.$request->getRequestUri());
         }
 
-        $this->get('contao.framework')->initialize();
+        $this->get(ContaoFramework::class)->initialize();
 
         $controller = new BackendPreview();
 
@@ -118,7 +118,7 @@ class BackendController extends AbstractController
      */
     public function confirmAction(): Response
     {
-        $this->get('contao.framework')->initialize();
+        $this->get(ContaoFramework::class)->initialize();
 
         $controller = new BackendConfirm();
 
@@ -130,7 +130,7 @@ class BackendController extends AbstractController
      */
     public function fileAction(): Response
     {
-        $this->get('contao.framework')->initialize();
+        $this->get(ContaoFramework::class)->initialize();
 
         $controller = new BackendFile();
 
@@ -142,7 +142,7 @@ class BackendController extends AbstractController
      */
     public function helpAction(): Response
     {
-        $this->get('contao.framework')->initialize();
+        $this->get(ContaoFramework::class)->initialize();
 
         $controller = new BackendHelp();
 
@@ -154,7 +154,7 @@ class BackendController extends AbstractController
      */
     public function pageAction(): Response
     {
-        $this->get('contao.framework')->initialize();
+        $this->get(ContaoFramework::class)->initialize();
 
         $controller = new BackendPage();
 
@@ -166,7 +166,7 @@ class BackendController extends AbstractController
      */
     public function popupAction(): Response
     {
-        $this->get('contao.framework')->initialize();
+        $this->get(ContaoFramework::class)->initialize();
 
         $controller = new BackendPopup();
 
@@ -178,7 +178,7 @@ class BackendController extends AbstractController
      */
     public function switchAction(): Response
     {
-        $this->get('contao.framework')->initialize();
+        $this->get(ContaoFramework::class)->initialize();
 
         $controller = new BackendSwitch();
 
@@ -190,7 +190,7 @@ class BackendController extends AbstractController
      */
     public function alertsAction(): Response
     {
-        $this->get('contao.framework')->initialize();
+        $this->get(ContaoFramework::class)->initialize();
 
         $controller = new BackendAlerts();
 
@@ -246,7 +246,7 @@ class BackendController extends AbstractController
     {
         $services = parent::getSubscribedServices();
 
-        $services['contao.framework'] = ContaoFramework::class;
+        $services[ContaoFramework::class] = ContaoFramework::class;
         $services[PickerBuilder::class] = PickerBuilderInterface::class;
 
         return $services;

--- a/core-bundle/src/Controller/BackendController.php
+++ b/core-bundle/src/Controller/BackendController.php
@@ -24,6 +24,7 @@ use Contao\BackendPopup;
 use Contao\BackendPreview;
 use Contao\BackendSwitch;
 use Contao\CoreBundle\Framework\ContaoFramework;
+use Contao\CoreBundle\Picker\PickerBuilder;
 use Contao\CoreBundle\Picker\PickerBuilderInterface;
 use Contao\CoreBundle\Picker\PickerConfig;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -218,7 +219,7 @@ class BackendController extends AbstractController
         }
 
         $config = new PickerConfig($request->query->get('context'), $extras, $request->query->get('value'));
-        $picker = $this->get('contao.picker.builder')->create($config);
+        $picker = $this->get(PickerBuilder::class)->create($config);
 
         if (null === $picker) {
             throw new BadRequestHttpException('Unsupported picker context');
@@ -246,7 +247,7 @@ class BackendController extends AbstractController
         $services = parent::getSubscribedServices();
 
         $services['contao.framework'] = ContaoFramework::class;
-        $services['contao.picker.builder'] = PickerBuilderInterface::class;
+        $services[PickerBuilder::class] = PickerBuilderInterface::class;
 
         return $services;
     }

--- a/core-bundle/src/Controller/FrontendModule/AbstractFrontendModuleController.php
+++ b/core-bundle/src/Controller/FrontendModule/AbstractFrontendModuleController.php
@@ -25,7 +25,7 @@ abstract class AbstractFrontendModuleController extends AbstractFragmentControll
 {
     public function __invoke(Request $request, ModuleModel $model, string $section, array $classes = null): Response
     {
-        if ($this->get('contao.routing.scope_matcher')->isBackendRequest($request)) {
+        if ($this->get(ScopeMatcher::class)->isBackendRequest($request)) {
             return $this->getBackendWildcard($model);
         }
 
@@ -55,7 +55,7 @@ abstract class AbstractFrontendModuleController extends AbstractFragmentControll
             parent::getSubscribedServices(),
             [
                 'translator' => TranslatorInterface::class,
-                'contao.routing.scope_matcher' => ScopeMatcher::class,
+                ScopeMatcher::class => ScopeMatcher::class,
             ]
         );
     }

--- a/core-bundle/src/Controller/FrontendModule/TwoFactorController.php
+++ b/core-bundle/src/Controller/FrontendModule/TwoFactorController.php
@@ -42,7 +42,7 @@ class TwoFactorController extends AbstractFrontendModuleController
 
         if (
             $this->page instanceof PageModel
-            && $this->get('contao.routing.scope_matcher')->isFrontendRequest($request)
+            && $this->get(ScopeMatcher::class)->isFrontendRequest($request)
         ) {
             $this->page->loadDetails();
         }
@@ -55,8 +55,8 @@ class TwoFactorController extends AbstractFrontendModuleController
         $services = parent::getSubscribedServices();
 
         $services['contao.framework'] = ContaoFramework::class;
-        $services['contao.routing.scope_matcher'] = ScopeMatcher::class;
-        $services['contao.security.two_factor.authenticator'] = Authenticator::class;
+        $services[ScopeMatcher::class] = ScopeMatcher::class;
+        $services[Authenticator::class] = Authenticator::class;
         $services['security.authentication_utils'] = AuthenticationUtils::class;
         $services['security.token_storage'] = TokenStorageInterface::class;
         $services['translator'] = TranslatorInterface::class;
@@ -130,7 +130,7 @@ class TwoFactorController extends AbstractFrontendModuleController
         }
 
         $translator = $this->get('translator');
-        $authenticator = $this->get('contao.security.two_factor.authenticator');
+        $authenticator = $this->get(Authenticator::class);
         $exception = $this->get('security.authentication_utils')->getLastAuthenticationError();
 
         if ($exception instanceof InvalidTwoFactorCodeException) {

--- a/core-bundle/src/Controller/FrontendModule/TwoFactorController.php
+++ b/core-bundle/src/Controller/FrontendModule/TwoFactorController.php
@@ -54,9 +54,6 @@ class TwoFactorController extends AbstractFrontendModuleController
     {
         $services = parent::getSubscribedServices();
 
-        $services['contao.framework'] = ContaoFramework::class;
-        $services[ScopeMatcher::class] = ScopeMatcher::class;
-        $services[Authenticator::class] = Authenticator::class;
         $services['security.authentication_utils'] = AuthenticationUtils::class;
         $services['security.token_storage'] = TokenStorageInterface::class;
         $services['translator'] = TranslatorInterface::class;
@@ -79,7 +76,7 @@ class TwoFactorController extends AbstractFrontendModuleController
         }
 
         /** @var PageModel $adapter */
-        $adapter = $this->get('contao.framework')->getAdapter(PageModel::class);
+        $adapter = $this->get(ContaoFramework::class)->getAdapter(PageModel::class);
 
         $redirectPage = $model->jumpTo > 0 ? $adapter->findByPk($model->jumpTo) : null;
         $return = $redirectPage instanceof PageModel ? $redirectPage->getAbsoluteUrl() : $this->page->getAbsoluteUrl();

--- a/core-bundle/src/Controller/InitializeController.php
+++ b/core-bundle/src/Controller/InitializeController.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Controller;
 
+use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\CoreBundle\Response\InitializeControllerResponse;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
@@ -67,7 +68,7 @@ class InitializeController extends AbstractController
 
         // Initialize the framework with the real request
         $this->get('request_stack')->push($realRequest);
-        $this->get('contao.framework')->initialize();
+        $this->get(ContaoFramework::class)->initialize();
 
         // Add the master request again. When Kernel::handle() is finished,
         // it will pop the current request, resulting in the real request being active.

--- a/core-bundle/src/DependencyInjection/Compiler/PickerProviderPass.php
+++ b/core-bundle/src/DependencyInjection/Compiler/PickerProviderPass.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\DependencyInjection\Compiler;
 
+use Contao\CoreBundle\Picker\PickerBuilder;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Compiler\PriorityTaggedServiceTrait;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -25,11 +26,11 @@ class PickerProviderPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container): void
     {
-        if (!$container->has('contao.picker.builder')) {
+        if (!$container->has(PickerBuilder::class)) {
             return;
         }
 
-        $definition = $container->findDefinition('contao.picker.builder');
+        $definition = $container->findDefinition(PickerBuilder::class);
         $references = $this->findAndSortTaggedServices('contao.picker_provider', $container);
 
         foreach ($references as $reference) {

--- a/core-bundle/src/DependencyInjection/Compiler/RegisterHookListenersPass.php
+++ b/core-bundle/src/DependencyInjection/Compiler/RegisterHookListenersPass.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\DependencyInjection\Compiler;
 
+use Contao\CoreBundle\Framework\ContaoFramework;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -23,7 +24,7 @@ class RegisterHookListenersPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container): void
     {
-        if (!$container->hasDefinition('contao.framework')) {
+        if (!$container->hasDefinition(ContaoFramework::class)) {
             return;
         }
 
@@ -38,7 +39,7 @@ class RegisterHookListenersPass implements CompilerPassInterface
             krsort($hooks[$hook]);
         }
 
-        $definition = $container->getDefinition('contao.framework');
+        $definition = $container->getDefinition(ContaoFramework::class);
         $definition->addMethodCall('setHookListeners', [$hooks]);
     }
 

--- a/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
+++ b/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
@@ -12,6 +12,9 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\DependencyInjection;
 
+use Contao\CoreBundle\Image\ImageFactory;
+use Contao\CoreBundle\Image\ImageSizes;
+use Contao\CoreBundle\Image\PictureFactory;
 use Contao\CoreBundle\Picker\PickerProviderInterface;
 use Imagine\Exception\RuntimeException;
 use Imagine\Gd\Imagine;
@@ -110,10 +113,12 @@ class ContaoCoreExtension extends Extension
             $imageSizes['_'.$name] = $value;
         }
 
-        $services = ['contao.image.image_sizes', 'contao.image.image_factory', 'contao.image.picture_factory'];
+        $services = [ImageSizes::class, ImageFactory::class, PictureFactory::class];
 
         foreach ($services as $service) {
-            if (method_exists($container->getDefinition($service)->getClass(), 'setPredefinedSizes')) {
+            $class = $container->getDefinition($service)->getClass() ?: $service;
+
+            if (method_exists($class, 'setPredefinedSizes')) {
                 $container->getDefinition($service)->addMethodCall('setPredefinedSizes', [$imageSizes]);
             }
         }

--- a/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
+++ b/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
@@ -66,6 +66,9 @@ class ContaoCoreExtension extends Extension
         $loader->load('listener.yml');
         $loader->load('services.yml');
 
+        // Backwards compatibility
+        $loader->load('legacy_aliases.yml');
+
         $container->setParameter('contao.web_dir', $config['web_dir']);
         $container->setParameter('contao.prepend_locale', $config['prepend_locale']);
         $container->setParameter('contao.encryption_key', $config['encryption_key']);

--- a/core-bundle/src/Framework/ContaoFramework.php
+++ b/core-bundle/src/Framework/ContaoFramework.php
@@ -29,7 +29,8 @@ use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
 /**
- * @internal Do not instantiate this class in your code; use the "contao.framework" service instead
+ * @internal Do not instantiate this class in your code;
+ *           use the "Contao\CoreBundle\Framework\ContaoFramework" service instead
  */
 class ContaoFramework implements ContaoFrameworkInterface, ContainerAwareInterface
 {

--- a/core-bundle/src/Framework/ScopeAwareTrait.php
+++ b/core-bundle/src/Framework/ScopeAwareTrait.php
@@ -13,14 +13,15 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Framework;
 
 use Contao\CoreBundle\ContaoCoreBundle;
+use Contao\CoreBundle\Routing\ScopeMatcher;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Symfony\Component\HttpKernel\Event\KernelEvent;
 
-@trigger_error('Using the "Contao\CoreBundle\Framework\ScopeAwareTrait" trait has been deprecated and will no longer work in Contao 5.0. Use the "contao.routing.scope_matcher" service instead.', E_USER_DEPRECATED);
+@trigger_error('Using the "Contao\CoreBundle\Framework\ScopeAwareTrait" trait has been deprecated and will no longer work in Contao 5.0. Use the "Contao\CoreBundle\Routing\ScopeMatcher" service instead.', E_USER_DEPRECATED);
 
 /**
  * @deprecated Deprecated since Contao 4.4, to be removed in Contao 5.0; use
- *             the contao.routing.scope_matcher service instead
+ *             the Contao\CoreBundle\Routing\ScopeMatcher service instead
  */
 trait ScopeAwareTrait
 {
@@ -68,7 +69,7 @@ trait ScopeAwareTrait
             return false;
         }
 
-        $matcher = $this->container->get('contao.routing.scope_matcher');
+        $matcher = $this->container->get(ScopeMatcher::class);
 
         if (ContaoCoreBundle::SCOPE_BACKEND === $scope) {
             return $matcher->isBackendRequest($request);

--- a/core-bundle/src/Image/LegacyResizer.php
+++ b/core-bundle/src/Image/LegacyResizer.php
@@ -47,7 +47,7 @@ class LegacyResizer extends ImageResizer implements FrameworkAwareInterface
         $rootDir = System::getContainer()->getParameter('kernel.project_dir');
 
         if ($this->hasExecuteResizeHook() || $this->hasGetImageHook()) {
-            @trigger_error('Using the "executeResize" and "getImage" hooks has been deprecated and will no longer work in Contao 5.0. Replace the "contao.image.resizer" service instead.', E_USER_DEPRECATED);
+            @trigger_error('Using the "executeResize" and "getImage" hooks has been deprecated and will no longer work in Contao 5.0. Replace the "Contao\CoreBundle\Image\LegacyResizer" service instead.', E_USER_DEPRECATED);
 
             $this->legacyImage = null;
             $legacyPath = $image->getPath();

--- a/core-bundle/src/Monolog/ContaoTableHandler.php
+++ b/core-bundle/src/Monolog/ContaoTableHandler.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Monolog;
 
+use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\StringUtil;
 use Contao\System;
 use Doctrine\DBAL\Connection;
@@ -136,11 +137,11 @@ class ContaoTableHandler extends AbstractProcessingHandler implements ContainerA
      */
     private function executeHook(string $message, ContaoContext $context): void
     {
-        if (null === $this->container || !$this->container->has('contao.framework')) {
+        if (null === $this->container || !$this->container->has(ContaoFramework::class)) {
             return;
         }
 
-        $framework = $this->container->get('contao.framework');
+        $framework = $this->container->get(ContaoFramework::class);
 
         if (!$this->hasAddLogEntryHook() || !$framework->isInitialized()) {
             return;

--- a/core-bundle/src/Resources/config/commands.yml
+++ b/core-bundle/src/Resources/config/commands.yml
@@ -31,8 +31,8 @@ services:
     contao.command.resize_images:
         class: Contao\CoreBundle\Command\ResizeImagesCommand
         arguments:
-            - '@contao.image.image_factory'
-            - '@contao.image.resizer'
+            - '@Contao\CoreBundle\Image\ImageFactory'
+            - '@Contao\CoreBundle\Image\LegacyResizer'
             - '%contao.image.target_dir%'
             - '@contao.image.deferred_image_storage'
             - '@?filesystem'
@@ -43,7 +43,7 @@ services:
             - '%kernel.project_dir%'
             - '%contao.upload_path%'
             - '%kernel.logs_dir%'
-            - '@contao.resource_finder'
+            - '@Contao\CoreBundle\Config\ResourceFinder'
             - '@event_dispatcher'
         public: true
 

--- a/core-bundle/src/Resources/config/commands.yml
+++ b/core-bundle/src/Resources/config/commands.yml
@@ -5,17 +5,17 @@ services:
     _instanceof:
         Contao\CoreBundle\Framework\FrameworkAwareInterface:
             calls:
-                - ['setFramework', ['@contao.framework']]
+                - ['setFramework', ['@Contao\CoreBundle\Framework\ContaoFramework']]
 
     contao.command.automator:
         class: Contao\CoreBundle\Command\AutomatorCommand
         arguments:
-            - '@contao.framework'
+            - '@Contao\CoreBundle\Framework\ContaoFramework'
 
     contao.command.debug_dca:
         class: Contao\CoreBundle\Command\DebugDcaCommand
         arguments:
-            - '@contao.framework'
+            - '@Contao\CoreBundle\Framework\ContaoFramework'
 
     contao.command.filesync:
         class: Contao\CoreBundle\Command\FilesyncCommand
@@ -50,7 +50,7 @@ services:
     contao.command.user_password_command:
         class: Contao\CoreBundle\Command\UserPasswordCommand
         arguments:
-            - '@contao.framework'
+            - '@Contao\CoreBundle\Framework\ContaoFramework'
             - '@database_connection'
             - '@security.encoder_factory'
 

--- a/core-bundle/src/Resources/config/legacy_aliases.yml
+++ b/core-bundle/src/Resources/config/legacy_aliases.yml
@@ -1,0 +1,26 @@
+services:
+    _defaults:
+        public: true
+
+    contao.controller.backend_csv_import: '@Contao\CoreBundle\Controller\BackendCsvImportController'
+    contao.controller.images: '@Contao\CoreBundle\Controller\ImagesController'
+    contao.controller.insert_tags: '@Contao\CoreBundle\Controller\InsertTagsController'
+    contao.framework: '@Contao\CoreBundle\Framework\ContaoFramework'
+    contao.image.resizer: '@Contao\CoreBundle\Image\LegacyResizer'
+    contao.image.image_factory: '@Contao\CoreBundle\Image\ImageFactory'
+    contao.image.image_sizes: '@Contao\CoreBundle\Image\ImageSizes'
+    contao.image.picture_generator: '@Contao\Image\PictureGenerator'
+    contao.image.picture_factory: '@Contao\CoreBundle\Image\PictureFactory'
+    contao.menu.backend_menu_builder: '@Contao\CoreBundle\Menu\BackendMenuBuilder'
+    contao.menu.backend_menu_renderer: '@Contao\CoreBundle\Menu\BackendMenuRenderer'
+    contao.model_argument_resolver: '@Contao\CoreBundle\HttpKernel\ModelArgumentResolver'
+    contao.opt-in: '@Contao\CoreBundle\OptIn\OptIn'
+    contao.picker.builder: '@Contao\CoreBundle\Picker\PickerBuilder'
+    contao.resource_finder: '@Contao\CoreBundle\Config\ResourceFinder'
+    contao.routing.scope_matcher: '@Contao\CoreBundle\Routing\ScopeMatcher'
+    contao.routing.url_generator: '@Contao\CoreBundle\Routing\UrlGenerator'
+    contao.security.frontend_preview_authenticator: '@Contao\CoreBundle\Security\Authentication\FrontendPreviewAuthenticator'
+    contao.security.token_checker: '@Contao\CoreBundle\Security\Authentication\Token\TokenChecker'
+    contao.security.two_factor.authenticator: '@Contao\CoreBundle\Security\TwoFactor\Authenticator'
+    contao.slug: '@Contao\CoreBundle\Slug\Slug'
+    contao.slug.valid_characters: '@Contao\CoreBundle\Slug\ValidCharacters'

--- a/core-bundle/src/Resources/config/listener.yml
+++ b/core-bundle/src/Resources/config/listener.yml
@@ -41,7 +41,7 @@ services:
     contao.listener.bypass_maintenance:
         class: Contao\CoreBundle\EventListener\BypassMaintenanceListener
         arguments:
-            - '@contao.security.token_checker'
+            - '@Contao\CoreBundle\Security\Authentication\Token\TokenChecker'
         tags:
             # The priority must be higher than the one of the Lexik maintenance bundle (defaults to 0)
             - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: 6 }
@@ -113,7 +113,7 @@ services:
         class: Contao\CoreBundle\EventListener\LocaleListener
         arguments:
             - '@translator'
-            - '@contao.routing.scope_matcher'
+            - '@Contao\CoreBundle\Routing\ScopeMatcher'
             - '%contao.locales%'
         tags:
             # The priority must be lower than the one of the Symfony route listener (defaults to 32)
@@ -150,7 +150,7 @@ services:
         class: Contao\CoreBundle\EventListener\RefererIdListener
         arguments:
             - '@contao.token_generator'
-            - '@contao.routing.scope_matcher'
+            - '@Contao\CoreBundle\Routing\ScopeMatcher'
         tags:
             # The priority must be lower than the one of the Symfony route listener (defaults to 32)
             - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: 20 }
@@ -159,7 +159,7 @@ services:
         class: Contao\CoreBundle\EventListener\RequestTokenListener
         arguments:
             - '@contao.framework'
-            - '@contao.routing.scope_matcher'
+            - '@Contao\CoreBundle\Routing\ScopeMatcher'
             - '@contao.csrf.token_manager'
             - '%contao.csrf_token_name%'
             - '%contao.csrf_cookie_prefix%'
@@ -177,7 +177,7 @@ services:
         class: Contao\CoreBundle\EventListener\StoreRefererListener
         arguments:
             - '@security.helper'
-            - '@contao.routing.scope_matcher'
+            - '@Contao\CoreBundle\Routing\ScopeMatcher'
         tags:
             - { name: kernel.event_listener, event: kernel.response, method: onKernelResponse }
 
@@ -193,7 +193,7 @@ services:
         class: Contao\CoreBundle\EventListener\TwoFactorFrontendListener
         arguments:
             - '@contao.framework'
-            - '@contao.routing.scope_matcher'
+            - '@Contao\CoreBundle\Routing\ScopeMatcher'
             - '@security.token_storage'
             - '%scheb_two_factor.security_tokens%'
         tags:
@@ -204,7 +204,7 @@ services:
         arguments:
             - '@database_connection'
             - '@security.helper'
-            - '@contao.routing.scope_matcher'
+            - '@Contao\CoreBundle\Routing\ScopeMatcher'
             - '@event_dispatcher'
         tags:
             - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest }

--- a/core-bundle/src/Resources/config/listener.yml
+++ b/core-bundle/src/Resources/config/listener.yml
@@ -2,7 +2,7 @@ services:
     _instanceof:
         Contao\CoreBundle\Framework\FrameworkAwareInterface:
             calls:
-                - ['setFramework', ['@contao.framework']]
+                - ['setFramework', ['@Contao\CoreBundle\Framework\ContaoFramework']]
 
         Symfony\Component\DependencyInjection\ContainerAwareInterface:
             calls:
@@ -10,14 +10,14 @@ services:
 
     Contao\CoreBundle\EventListener\RobotsTxtListener:
         arguments:
-            - '@contao.framework'
+            - '@Contao\CoreBundle\Framework\ContaoFramework'
         tags:
             - { name: kernel.event_listener, event: contao.robots_txt, method: onRobotsTxt }
 
     contao.listener.add_to_search_index:
         class: Contao\CoreBundle\EventListener\AddToSearchIndexListener
         arguments:
-            - '@contao.framework'
+            - '@Contao\CoreBundle\Framework\ContaoFramework'
             - '%fragment.path%'
         tags:
             - { name: kernel.event_listener, event: kernel.terminate, method: onKernelTerminate }
@@ -55,7 +55,7 @@ services:
     contao.listener.command_scheduler:
         class: Contao\CoreBundle\EventListener\CommandSchedulerListener
         arguments:
-            - '@contao.framework'
+            - '@Contao\CoreBundle\Framework\ContaoFramework'
             - '@database_connection'
             - '%fragment.path%'
         tags:
@@ -130,7 +130,7 @@ services:
     contao.listener.merge_http_headers:
         class: Contao\CoreBundle\EventListener\MergeHttpHeadersListener
         arguments:
-            - '@contao.framework'
+            - '@Contao\CoreBundle\Framework\ContaoFramework'
         tags:
             - { name: kernel.event_listener, event: kernel.response, method: onKernelResponse, priority: 256 }
 
@@ -139,7 +139,7 @@ services:
         arguments:
             - '%contao.pretty_error_screens%'
             - '@twig'
-            - '@contao.framework'
+            - '@Contao\CoreBundle\Framework\ContaoFramework'
             - '@security.helper'
             - '@?logger'
         tags:
@@ -158,7 +158,7 @@ services:
     contao.listener.request_token:
         class: Contao\CoreBundle\EventListener\RequestTokenListener
         arguments:
-            - '@contao.framework'
+            - '@Contao\CoreBundle\Framework\ContaoFramework'
             - '@Contao\CoreBundle\Routing\ScopeMatcher'
             - '@contao.csrf.token_manager'
             - '%contao.csrf_token_name%'
@@ -192,7 +192,7 @@ services:
     contao.listener.two_factor.frontend:
         class: Contao\CoreBundle\EventListener\TwoFactorFrontendListener
         arguments:
-            - '@contao.framework'
+            - '@Contao\CoreBundle\Framework\ContaoFramework'
             - '@Contao\CoreBundle\Routing\ScopeMatcher'
             - '@security.token_storage'
             - '%scheb_two_factor.security_tokens%'

--- a/core-bundle/src/Resources/config/services.yml
+++ b/core-bundle/src/Resources/config/services.yml
@@ -5,7 +5,7 @@ services:
     _instanceof:
         Contao\CoreBundle\Framework\FrameworkAwareInterface:
             calls:
-                - ['setFramework', ['@contao.framework']]
+                - ['setFramework', ['@Contao\CoreBundle\Framework\ContaoFramework']]
 
         Symfony\Component\DependencyInjection\ContainerAwareInterface:
             calls:
@@ -17,7 +17,7 @@ services:
     Contao\CoreBundle\Picker\PickerBuilderInterface: '@contao.picker.builder'
 
     # Backwards compatibility
-    Contao\CoreBundle\Framework\ContaoFrameworkInterface: '@contao.framework'
+    Contao\CoreBundle\Framework\ContaoFrameworkInterface: '@Contao\CoreBundle\Framework\ContaoFramework'
 
     Contao\CoreBundle\Controller\BackendController:
         calls:
@@ -28,7 +28,7 @@ services:
 
     Contao\CoreBundle\Controller\FaviconController:
         arguments:
-            - '@contao.framework'
+            - '@Contao\CoreBundle\Framework\ContaoFramework'
             - '@?fos_http_cache.http.symfony_response_tagger'
         tags:
             - controller.service_arguments
@@ -36,14 +36,14 @@ services:
 
     Contao\CoreBundle\Controller\FrontendController:
         arguments:
-            - '@contao.framework'
+            - '@Contao\CoreBundle\Framework\ContaoFramework'
             - '@contao.csrf.token_manager'
             - '%contao.csrf_token_name%'
         public: true
 
     Contao\CoreBundle\Controller\RobotsTxtController:
         arguments:
-            - '@contao.framework'
+            - '@Contao\CoreBundle\Framework\ContaoFramework'
             - '@event_dispatcher'
         tags:
             - controller.service_arguments
@@ -80,13 +80,13 @@ services:
             - '@contao.resource_locator'
             - '%kernel.project_dir%'
             - '@database_connection'
-            - '@contao.framework'
+            - '@Contao\CoreBundle\Framework\ContaoFramework'
         tags:
             - { name: kernel.cache_warmer }
 
     Contao\CoreBundle\Controller\BackendCsvImportController:
         arguments:
-            - '@contao.framework'
+            - '@Contao\CoreBundle\Framework\ContaoFramework'
             - '@database_connection'
             - '@request_stack'
             - '@translator'
@@ -111,7 +111,7 @@ services:
 
     Contao\CoreBundle\Controller\InsertTagsController:
         arguments:
-            - '@contao.framework'
+            - '@Contao\CoreBundle\Framework\ContaoFramework'
         public: true
 
     contao.controller_resolver:
@@ -146,7 +146,7 @@ services:
     contao.doctrine.schema_provider:
         class: Contao\CoreBundle\Doctrine\Schema\DcaSchemaProvider
         arguments:
-            - '@contao.framework'
+            - '@Contao\CoreBundle\Framework\ContaoFramework'
             - '@doctrine'
 
     contao.fragment.handler:
@@ -225,7 +225,7 @@ services:
             - '@contao.image.imagine'
             - '@contao.image.imagine_svg'
             - '@filesystem'
-            - '@contao.framework'
+            - '@Contao\CoreBundle\Framework\ContaoFramework'
             - '%contao.image.bypass_cache%'
             - '%contao.image.imagine_options%'
             - '%contao.image.valid_extensions%'
@@ -237,7 +237,7 @@ services:
         arguments:
             - '@database_connection'
             - '@event_dispatcher'
-            - '@contao.framework'
+            - '@Contao\CoreBundle\Framework\ContaoFramework'
             - '@contao.translation.translator'
         public: true
 
@@ -251,7 +251,7 @@ services:
         arguments:
             - '@Contao\Image\PictureGenerator'
             - '@Contao\CoreBundle\Image\ImageFactory'
-            - '@contao.framework'
+            - '@Contao\CoreBundle\Framework\ContaoFramework'
             - '%contao.image.bypass_cache%'
             - '%contao.image.imagine_options%'
         public: true
@@ -278,7 +278,7 @@ services:
 
     Contao\CoreBundle\HttpKernel\ModelArgumentResolver:
         arguments:
-            - '@contao.framework'
+            - '@Contao\CoreBundle\Framework\ContaoFramework'
             - '@Contao\CoreBundle\Routing\ScopeMatcher'
         tags:
             # The priority must be higher than the one of the request attribute value resolver (defaults to 100)
@@ -303,7 +303,7 @@ services:
 
     Contao\CoreBundle\OptIn\OptIn:
         arguments:
-            - '@contao.framework'
+            - '@Contao\CoreBundle\Framework\ContaoFramework'
         public: true
 
     Contao\CoreBundle\Picker\PickerBuilder:
@@ -396,7 +396,7 @@ services:
     contao.routing.input_enhancer:
         class: Contao\CoreBundle\Routing\Enhancer\InputEnhancer
         arguments:
-            - '@contao.framework'
+            - '@Contao\CoreBundle\Framework\ContaoFramework'
             - '%contao.prepend_locale%'
 
     contao.routing.language_filter:
@@ -408,7 +408,7 @@ services:
         class: Contao\CoreBundle\Routing\Matcher\LegacyMatcher
         decorates: contao.routing.nested_matcher
         arguments:
-            - '@contao.framework'
+            - '@Contao\CoreBundle\Framework\ContaoFramework'
             - '@contao.routing.legacy_matcher.inner'
             - '%contao.url_suffix%'
             - '%contao.prepend_locale%'
@@ -459,7 +459,7 @@ services:
     contao.routing.route_provider:
         class: Contao\CoreBundle\Routing\RouteProvider
         arguments:
-            - '@contao.framework'
+            - '@Contao\CoreBundle\Framework\ContaoFramework'
             - '@database_connection'
             - '%contao.url_suffix%'
             - '%contao.prepend_locale%'
@@ -473,7 +473,7 @@ services:
     Contao\CoreBundle\Routing\UrlGenerator:
         arguments:
             - '@router'
-            - '@contao.framework'
+            - '@Contao\CoreBundle\Framework\ContaoFramework'
             - '%contao.prepend_locale%'
         public: true
 
@@ -493,19 +493,19 @@ services:
             - ~ # user checker
             - ~ # provider-shared key
             - '@security.encoder_factory'
-            - '@contao.framework'
+            - '@Contao\CoreBundle\Framework\ContaoFramework'
 
     contao.security.authentication_success_handler:
         class: Contao\CoreBundle\Security\Authentication\AuthenticationSuccessHandler
         arguments:
             - '@security.http_utils'
-            - '@contao.framework'
+            - '@Contao\CoreBundle\Framework\ContaoFramework'
             - '@?logger'
 
     contao.security.backend_user_provider:
         class: Contao\CoreBundle\Security\User\ContaoUserProvider
         arguments:
-            - '@contao.framework'
+            - '@Contao\CoreBundle\Framework\ContaoFramework'
             - '@session'
             - 'Contao\BackendUser'
             - '@?logger'
@@ -545,7 +545,7 @@ services:
     contao.security.frontend_user_provider:
         class: Contao\CoreBundle\Security\User\ContaoUserProvider
         arguments:
-            - '@contao.framework'
+            - '@Contao\CoreBundle\Framework\ContaoFramework'
             - '@session'
             - 'Contao\FrontendUser'
             - '@?logger'
@@ -559,7 +559,7 @@ services:
     contao.security.logout_handler:
         class: Contao\CoreBundle\Security\Logout\LogoutHandler
         arguments:
-            - '@contao.framework'
+            - '@Contao\CoreBundle\Framework\ContaoFramework'
             - '@?logger'
 
     Contao\CoreBundle\Security\Authentication\Token\TokenChecker:
@@ -585,7 +585,7 @@ services:
     contao.security.user_checker:
         class: Contao\CoreBundle\Security\User\UserChecker
         arguments:
-            - '@contao.framework'
+            - '@Contao\CoreBundle\Framework\ContaoFramework'
 
     contao.session.contao_backend:
         class: Contao\CoreBundle\Session\Attribute\ArrayAttributeBag
@@ -604,7 +604,7 @@ services:
     Contao\CoreBundle\Slug\Slug:
         arguments:
             - '@contao.slug.generator'
-            - '@contao.framework'
+            - '@Contao\CoreBundle\Framework\ContaoFramework'
         public: true
 
     contao.slug.generator:
@@ -629,7 +629,7 @@ services:
         decorates: translator
         arguments:
             - '@contao.translation.translator.inner'
-            - '@contao.framework'
+            - '@Contao\CoreBundle\Framework\ContaoFramework'
 
     contao.translation.translator.data_collector:
         class: Contao\CoreBundle\Translation\DataCollectorTranslator
@@ -640,7 +640,7 @@ services:
         class: Contao\CoreBundle\Twig\Extension\ContaoTemplateExtension
         arguments:
             - '@request_stack'
-            - '@contao.framework'
+            - '@Contao\CoreBundle\Framework\ContaoFramework'
             - '@Contao\CoreBundle\Routing\ScopeMatcher'
         tags:
             - { name: twig.extension }

--- a/core-bundle/src/Resources/config/services.yml
+++ b/core-bundle/src/Resources/config/services.yml
@@ -1,3 +1,6 @@
+imports:
+    - { resource: legacy_aliases.yml }
+
 services:
     _instanceof:
         Contao\CoreBundle\Framework\FrameworkAwareInterface:
@@ -8,19 +11,14 @@ services:
             calls:
                 - ['setContainer', ['@service_container']]
 
-    Contao\CoreBundle\Framework\ContaoFramework: '@contao.framework'
+    # Autowiring aliases
     Contao\CoreBundle\Image\ImageFactoryInterface: '@contao.image.image_factory'
     Contao\CoreBundle\Image\PictureFactoryInterface: '@contao.image.picture_factory'
     Contao\CoreBundle\Picker\PickerBuilderInterface: '@contao.picker.builder'
-    Contao\CoreBundle\Routing\ScopeMatcher: '@contao.routing.scope_matcher'
-    Contao\CoreBundle\Security\Authentication\Token\TokenChecker: '@contao.security.token_checker'
-    Contao\CoreBundle\Security\TwoFactor\Authenticator: '@contao.security.two_factor.authenticator'
-    Contao\CoreBundle\Slug\Slug: '@contao.slug'
 
     # Backwards compatibility
     Contao\CoreBundle\Framework\ContaoFrameworkInterface: '@contao.framework'
 
-    # Controllers
     Contao\CoreBundle\Controller\BackendController:
         calls:
             - ['setContainer', ['@Psr\Container\ContainerInterface']]
@@ -78,7 +76,7 @@ services:
         class: Contao\CoreBundle\Cache\ContaoCacheWarmer
         arguments:
             - '@filesystem'
-            - '@contao.resource_finder'
+            - '@Contao\CoreBundle\Config\ResourceFinder'
             - '@contao.resource_locator'
             - '%kernel.project_dir%'
             - '@database_connection'
@@ -86,8 +84,7 @@ services:
         tags:
             - { name: kernel.cache_warmer }
 
-    contao.controller.backend_csv_import:
-        class: Contao\CoreBundle\Controller\BackendCsvImportController
+    Contao\CoreBundle\Controller\BackendCsvImportController:
         arguments:
             - '@contao.framework'
             - '@database_connection'
@@ -104,17 +101,15 @@ services:
             - { name: contao.frontend_module, category: user }
             - { name: container.service_subscriber }
 
-    contao.controller.images:
-        class:  Contao\CoreBundle\Controller\ImagesController
+    Contao\CoreBundle\Controller\ImagesController:
         arguments:
-            - '@contao.image.image_factory'
-            - '@contao.image.resizer'
+            - '@Contao\CoreBundle\Image\ImageFactory'
+            - '@Contao\CoreBundle\Image\LegacyResizer'
             - '%contao.image.target_dir%'
             - '@?filesystem'
         public: true
 
-    contao.controller.insert_tags:
-        class: Contao\CoreBundle\Controller\InsertTagsController
+    Contao\CoreBundle\Controller\InsertTagsController:
         arguments:
             - '@contao.framework'
         public: true
@@ -185,12 +180,11 @@ services:
         tags:
             - { name: 'kernel.fragment_renderer', alias: 'forward' }
 
-    contao.framework:
-        class: Contao\CoreBundle\Framework\ContaoFramework
+    Contao\CoreBundle\Framework\ContaoFramework:
         arguments:
             - '@request_stack'
-            - '@contao.routing.scope_matcher'
-            - '@contao.security.token_checker'
+            - '@Contao\CoreBundle\Routing\ScopeMatcher'
+            - '@Contao\CoreBundle\Security\Authentication\Token\TokenChecker'
             - '%kernel.project_dir%'
             - '%contao.error_level%'
         public: true
@@ -217,8 +211,7 @@ services:
     contao.image.resize_calculator:
         class: Contao\Image\ResizeCalculator
 
-    contao.image.resizer:
-        class: Contao\CoreBundle\Image\LegacyResizer
+    Contao\CoreBundle\Image\LegacyResizer:
         arguments:
             - '%contao.image.target_dir%'
             - '@contao.image.resize_calculator'
@@ -226,10 +219,9 @@ services:
             - '@contao.image.deferred_image_storage'
         public: true
 
-    contao.image.image_factory:
-        class: Contao\CoreBundle\Image\ImageFactory
+    Contao\CoreBundle\Image\ImageFactory:
         arguments:
-            - '@contao.image.resizer'
+            - '@Contao\CoreBundle\Image\LegacyResizer'
             - '@contao.image.imagine'
             - '@contao.image.imagine_svg'
             - '@filesystem'
@@ -241,8 +233,7 @@ services:
             - '@?logger'
         public: true
 
-    contao.image.image_sizes:
-        class: Contao\CoreBundle\Image\ImageSizes
+    Contao\CoreBundle\Image\ImageSizes:
         arguments:
             - '@database_connection'
             - '@event_dispatcher'
@@ -250,34 +241,30 @@ services:
             - '@contao.translation.translator'
         public: true
 
-    contao.image.picture_generator:
-        class: Contao\Image\PictureGenerator
+    Contao\Image\PictureGenerator:
         arguments:
-            - '@contao.image.resizer'
+            - '@Contao\CoreBundle\Image\LegacyResizer'
             - '@?contao.image.resize_calculator'
         public: true
 
-    contao.image.picture_factory:
-        class: Contao\CoreBundle\Image\PictureFactory
+    Contao\CoreBundle\Image\PictureFactory:
         arguments:
-            - '@contao.image.picture_generator'
-            - '@contao.image.image_factory'
+            - '@Contao\Image\PictureGenerator'
+            - '@Contao\CoreBundle\Image\ImageFactory'
             - '@contao.framework'
             - '%contao.image.bypass_cache%'
             - '%contao.image.imagine_options%'
         public: true
 
-    contao.menu.backend_menu_renderer:
-        class: Contao\CoreBundle\Menu\BackendMenuRenderer
-        arguments:
-            - '@twig'
-        public: true
-
-    contao.menu.backend_menu_builder:
-        class: Contao\CoreBundle\Menu\BackendMenuBuilder
+    Contao\CoreBundle\Menu\BackendMenuBuilder:
         arguments:
             - '@knp_menu.factory'
             - '@event_dispatcher'
+        public: true
+
+    Contao\CoreBundle\Menu\BackendMenuRenderer:
+        arguments:
+            - '@twig'
         public: true
 
     contao.menu.matcher:
@@ -289,11 +276,10 @@ services:
             - '@contao.menu.matcher'
         public: true
 
-    contao.model_argument_resolver:
-        class: Contao\CoreBundle\HttpKernel\ModelArgumentResolver
+    Contao\CoreBundle\HttpKernel\ModelArgumentResolver:
         arguments:
             - '@contao.framework'
-            - '@contao.routing.scope_matcher'
+            - '@Contao\CoreBundle\Routing\ScopeMatcher'
         tags:
             # The priority must be higher than the one of the request attribute value resolver (defaults to 100)
             - { name: controller.argument_value_resolver, priority: 101 }
@@ -311,18 +297,16 @@ services:
         arguments:
             - '@request_stack'
             - '@security.token_storage'
-            - '@contao.routing.scope_matcher'
+            - '@Contao\CoreBundle\Routing\ScopeMatcher'
         tags:
             - { name: monolog.processor }
 
-    contao.opt-in:
-        class: Contao\CoreBundle\OptIn\OptIn
+    Contao\CoreBundle\OptIn\OptIn:
         arguments:
             - '@contao.framework'
         public: true
 
-    contao.picker.builder:
-        class: Contao\CoreBundle\Picker\PickerBuilder
+    Contao\CoreBundle\Picker\PickerBuilder:
         arguments:
             - '@knp_menu.factory'
             - '@router'
@@ -365,8 +349,7 @@ services:
             - '@doctrine'
             - 'Contao\CoreBundle\Entity\RememberMe'
 
-    contao.resource_finder:
-        class: Contao\CoreBundle\Config\ResourceFinder
+    Contao\CoreBundle\Config\ResourceFinder:
         arguments:
             - '%contao.resources_paths%'
         public: true
@@ -465,7 +448,7 @@ services:
     contao.routing.published_filter:
         class: Contao\CoreBundle\Routing\Matcher\PublishedFilter
         arguments:
-            - '@contao.security.token_checker'
+            - '@Contao\CoreBundle\Security\Authentication\Token\TokenChecker'
 
     contao.routing.route_generator:
         class: Symfony\Cmf\Component\Routing\ProviderBasedGenerator
@@ -481,15 +464,13 @@ services:
             - '%contao.url_suffix%'
             - '%contao.prepend_locale%'
 
-    contao.routing.scope_matcher:
-        class: Contao\CoreBundle\Routing\ScopeMatcher
+    Contao\CoreBundle\Routing\ScopeMatcher:
         arguments:
             - '@contao.routing.backend_matcher'
             - '@contao.routing.frontend_matcher'
         public: true
 
-    contao.routing.url_generator:
-        class: Contao\CoreBundle\Routing\UrlGenerator
+    Contao\CoreBundle\Routing\UrlGenerator:
         arguments:
             - '@router'
             - '@contao.framework'
@@ -553,8 +534,7 @@ services:
         tags:
             - { name: monolog.logger, channel: security }
 
-    contao.security.frontend_preview_authenticator:
-        class: Contao\CoreBundle\Security\Authentication\FrontendPreviewAuthenticator
+    Contao\CoreBundle\Security\Authentication\FrontendPreviewAuthenticator:
         arguments:
             - '@security.helper'
             - '@session'
@@ -574,7 +554,7 @@ services:
         class: Contao\CoreBundle\Security\Logout\LogoutSuccessHandler
         arguments:
             - '@security.http_utils'
-            - '@contao.routing.scope_matcher'
+            - '@Contao\CoreBundle\Routing\ScopeMatcher'
 
     contao.security.logout_handler:
         class: Contao\CoreBundle\Security\Logout\LogoutHandler
@@ -582,8 +562,7 @@ services:
             - '@contao.framework'
             - '@?logger'
 
-    contao.security.token_checker:
-        class: Contao\CoreBundle\Security\Authentication\Token\TokenChecker
+    Contao\CoreBundle\Security\Authentication\Token\TokenChecker:
         arguments:
             - '@request_stack'
             - '@security.firewall.map'
@@ -593,14 +572,13 @@ services:
             - '%contao.preview_script%'
         public: true
 
-    contao.security.two_factor.authenticator:
-        class: Contao\CoreBundle\Security\TwoFactor\Authenticator
+    Contao\CoreBundle\Security\TwoFactor\Authenticator:
         public: true
 
     contao.security.two_factor.provider:
         class: Contao\CoreBundle\Security\TwoFactor\Provider
         arguments:
-            - '@contao.security.two_factor.authenticator'
+            - '@Contao\CoreBundle\Security\TwoFactor\Authenticator'
         tags:
             - { name: 'scheb_two_factor.provider', alias: 'contao' }
 
@@ -623,8 +601,7 @@ services:
         calls:
             - ['setName', ['contao_frontend']]
 
-    contao.slug:
-        class: Contao\CoreBundle\Slug\Slug
+    Contao\CoreBundle\Slug\Slug:
         arguments:
             - '@contao.slug.generator'
             - '@contao.framework'
@@ -636,8 +613,7 @@ services:
             - { validChars: '0-9a-z' }
         public: true
 
-    contao.slug.valid_characters:
-        class: Contao\CoreBundle\Slug\ValidCharacters
+    Contao\CoreBundle\Slug\ValidCharacters:
         arguments:
             - '@event_dispatcher'
             - '@translator'
@@ -665,6 +641,6 @@ services:
         arguments:
             - '@request_stack'
             - '@contao.framework'
-            - '@contao.routing.scope_matcher'
+            - '@Contao\CoreBundle\Routing\ScopeMatcher'
         tags:
             - { name: twig.extension }

--- a/core-bundle/src/Resources/config/services.yml
+++ b/core-bundle/src/Resources/config/services.yml
@@ -1,6 +1,3 @@
-imports:
-    - { resource: legacy_aliases.yml }
-
 services:
     _instanceof:
         Contao\CoreBundle\Framework\FrameworkAwareInterface:

--- a/core-bundle/src/Resources/contao/classes/Backend.php
+++ b/core-bundle/src/Resources/contao/classes/Backend.php
@@ -12,6 +12,7 @@ namespace Contao;
 
 use Contao\CoreBundle\Exception\AccessDeniedException;
 use Contao\CoreBundle\Exception\ResponseException;
+use Contao\CoreBundle\Picker\PickerBuilder;
 use Contao\CoreBundle\Picker\PickerInterface;
 use Contao\Database\Result;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -1101,7 +1102,7 @@ abstract class Backend extends Controller
 			unset($extras['context']);
 		}
 
-		$factory = System::getContainer()->get('contao.picker.builder');
+		$factory = System::getContainer()->get(PickerBuilder::class);
 
 		if (!$factory->supportsContext($context, $providers))
 		{

--- a/core-bundle/src/Resources/contao/classes/BackendUser.php
+++ b/core-bundle/src/Resources/contao/classes/BackendUser.php
@@ -10,6 +10,7 @@
 
 namespace Contao;
 
+use Contao\CoreBundle\Security\Authentication\Token\TokenChecker;
 use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface;
 use Symfony\Component\Routing\RouterInterface;
 
@@ -141,7 +142,7 @@ class BackendUser extends User
 		}
 
 		// Check for an authenticated user in the session
-		$strUser = System::getContainer()->get('contao.security.token_checker')->getBackendUsername();
+		$strUser = System::getContainer()->get(TokenChecker::class)->getBackendUsername();
 
 		if ($strUser !== null)
 		{
@@ -208,7 +209,7 @@ class BackendUser extends User
 	{
 		@trigger_error('Using BackendUser::authenticate() has been deprecated and will no longer work in Contao 5.0. Use Symfony security instead.', E_USER_DEPRECATED);
 
-		return System::getContainer()->get('contao.security.token_checker')->hasBackendUser();
+		return System::getContainer()->get(TokenChecker::class)->hasBackendUser();
 	}
 
 	/**
@@ -223,7 +224,7 @@ class BackendUser extends User
 	{
 		@trigger_error('Using BackendUser::login() has been deprecated and will no longer work in Contao 5.0. Use Symfony security instead.', E_USER_DEPRECATED);
 
-		return System::getContainer()->get('contao.security.token_checker')->hasBackendUser();
+		return System::getContainer()->get(TokenChecker::class)->hasBackendUser();
 	}
 
 	/**

--- a/core-bundle/src/Resources/contao/classes/DataContainer.php
+++ b/core-bundle/src/Resources/contao/classes/DataContainer.php
@@ -12,7 +12,9 @@ namespace Contao;
 
 use Contao\CoreBundle\Exception\AccessDeniedException;
 use Contao\CoreBundle\Exception\ResponseException;
+use Contao\CoreBundle\Image\ImageFactory;
 use Contao\CoreBundle\Picker\DcaPickerProviderInterface;
+use Contao\CoreBundle\Picker\PickerBuilder;
 use Contao\CoreBundle\Picker\PickerInterface;
 use Contao\Image\ResizeConfiguration;
 use FOS\HttpCacheBundle\CacheManager;
@@ -581,7 +583,7 @@ abstract class DataContainer extends Backend
 			list ($file, $type) = explode('|', $arrData['eval']['rte'], 2);
 
 			$fileBrowserTypes = array();
-			$pickerBuilder = System::getContainer()->get('contao.picker.builder');
+			$pickerBuilder = System::getContainer()->get(PickerBuilder::class);
 
 			foreach (array('file' => 'image', 'link' => 'file') as $context => $fileBrowserType)
 			{
@@ -642,7 +644,7 @@ abstract class DataContainer extends Backend
 				{
 					$container = System::getContainer();
 					$rootDir = $container->getParameter('kernel.project_dir');
-					$image = rawurldecode($container->get('contao.image.image_factory')->create($rootDir . '/' . $objFile->path, array(699, 524, ResizeConfiguration::MODE_BOX))->getUrl($rootDir));
+					$image = rawurldecode($container->get(ImageFactory::class)->create($rootDir . '/' . $objFile->path, array(699, 524, ResizeConfiguration::MODE_BOX))->getUrl($rootDir));
 				}
 
 				$objImage = new File($image);

--- a/core-bundle/src/Resources/contao/classes/FileUpload.php
+++ b/core-bundle/src/Resources/contao/classes/FileUpload.php
@@ -10,6 +10,7 @@
 
 namespace Contao;
 
+use Contao\CoreBundle\Image\ImageFactory;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 /**
@@ -339,7 +340,7 @@ class FileUpload extends Backend
 		{
 			$container = System::getContainer();
 			$rootDir = $container->getParameter('kernel.project_dir');
-			$container->get('contao.image.image_factory')->create($rootDir . '/' . $strImage, array($arrImageSize[0], $arrImageSize[1]), $rootDir . '/' . $strImage);
+			$container->get(ImageFactory::class)->create($rootDir . '/' . $strImage, array($arrImageSize[0], $arrImageSize[1]), $rootDir . '/' . $strImage);
 
 			Message::addInfo(sprintf($GLOBALS['TL_LANG']['MSC']['fileResized'], $objFile->basename));
 			$this->log('File "' . $strImage . '" was scaled down to the maximum dimensions', __METHOD__, TL_FILES);

--- a/core-bundle/src/Resources/contao/classes/Frontend.php
+++ b/core-bundle/src/Resources/contao/classes/Frontend.php
@@ -11,6 +11,7 @@
 namespace Contao;
 
 use Contao\CoreBundle\Exception\NoRootPageFoundException;
+use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\CoreBundle\Monolog\ContaoContext;
 use Contao\CoreBundle\Security\Authentication\Token\TokenChecker;
 use Psr\Log\LogLevel;
@@ -144,7 +145,7 @@ abstract class Frontend extends Controller
 			}
 
 			/** @var PageModel $objPageModel */
-			$objPageModel = System::getContainer()->get('contao.framework')->getAdapter(PageModel::class);
+			$objPageModel = System::getContainer()->get(ContaoFramework::class)->getAdapter(PageModel::class);
 
 			// Check if there are pages with a matching alias
 			$objPages = $objPageModel->findByAliases($arrOptions);

--- a/core-bundle/src/Resources/contao/classes/Frontend.php
+++ b/core-bundle/src/Resources/contao/classes/Frontend.php
@@ -12,6 +12,7 @@ namespace Contao;
 
 use Contao\CoreBundle\Exception\NoRootPageFoundException;
 use Contao\CoreBundle\Monolog\ContaoContext;
+use Contao\CoreBundle\Security\Authentication\Token\TokenChecker;
 use Psr\Log\LogLevel;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -512,7 +513,7 @@ abstract class Frontend extends Controller
 	{
 		@trigger_error('Using Frontend::getLoginStatus() has been deprecated and will no longer work in Contao 5.0. Use Symfony security instead.', E_USER_DEPRECATED);
 
-		$objTokenChecker = System::getContainer()->get('contao.security.token_checker');
+		$objTokenChecker = System::getContainer()->get(TokenChecker::class);
 
 		if ($strCookie == 'BE_USER_AUTH' && $objTokenChecker->hasBackendUser())
 		{

--- a/core-bundle/src/Resources/contao/classes/FrontendTemplate.php
+++ b/core-bundle/src/Resources/contao/classes/FrontendTemplate.php
@@ -10,6 +10,7 @@
 
 namespace Contao;
 
+use Contao\CoreBundle\Security\Authentication\Token\TokenChecker;
 use FOS\HttpCache\ResponseTagger;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -259,7 +260,7 @@ class FrontendTemplate extends Template
 	 */
 	public function hasAuthenticatedBackendUser()
 	{
-		return System::getContainer()->get('contao.security.token_checker')->hasBackendUser();
+		return System::getContainer()->get(TokenChecker::class)->hasBackendUser();
 	}
 
 	/**

--- a/core-bundle/src/Resources/contao/classes/FrontendUser.php
+++ b/core-bundle/src/Resources/contao/classes/FrontendUser.php
@@ -10,6 +10,8 @@
 
 namespace Contao;
 
+use Contao\CoreBundle\Security\Authentication\Token\TokenChecker;
+
 /**
  * Provide methods to manage front end users.
  *
@@ -96,7 +98,7 @@ class FrontendUser extends User
 		}
 
 		// Check for an authenticated user in the session
-		$strUser = System::getContainer()->get('contao.security.token_checker')->getFrontendUsername();
+		$strUser = System::getContainer()->get(TokenChecker::class)->getFrontendUsername();
 
 		if ($strUser !== null)
 		{
@@ -161,7 +163,7 @@ class FrontendUser extends User
 	{
 		@trigger_error('Using FrontendUser::authenticate() has been deprecated and will no longer work in Contao 5.0. Use Symfony security instead.', E_USER_DEPRECATED);
 
-		return System::getContainer()->get('contao.security.token_checker')->hasFrontendUser();
+		return System::getContainer()->get(TokenChecker::class)->hasFrontendUser();
 	}
 
 	/**
@@ -176,7 +178,7 @@ class FrontendUser extends User
 	{
 		@trigger_error('Using FrontendUser::login() has been deprecated and will no longer work in Contao 5.0. Use Symfony security instead.', E_USER_DEPRECATED);
 
-		return System::getContainer()->get('contao.security.token_checker')->hasFrontendUser();
+		return System::getContainer()->get(TokenChecker::class)->hasFrontendUser();
 	}
 
 	/**

--- a/core-bundle/src/Resources/contao/classes/RebuildIndex.php
+++ b/core-bundle/src/Resources/contao/classes/RebuildIndex.php
@@ -10,6 +10,7 @@
 
 namespace Contao;
 
+use Contao\CoreBundle\Security\Authentication\FrontendPreviewAuthenticator;
 use Symfony\Component\HttpFoundation\Session\Session;
 
 /**
@@ -115,7 +116,7 @@ class RebuildIndex extends Backend implements \executable
 			$this->import(Automator::class, 'Automator');
 			$this->Automator->purgeSearchTables();
 
-			$objAuthenticator = System::getContainer()->get('contao.security.frontend_preview_authenticator');
+			$objAuthenticator = System::getContainer()->get(FrontendPreviewAuthenticator::class);
 			$strUser = Input::get('user');
 
 			// Log in the front end user

--- a/core-bundle/src/Resources/contao/config/config.php
+++ b/core-bundle/src/Resources/contao/config/config.php
@@ -17,13 +17,13 @@ $GLOBALS['BE_MOD'] = array
 		'article' => array
 		(
 			'tables'      => array('tl_article', 'tl_content'),
-			'table'       => array('contao.controller.backend_csv_import', 'importTableWizardAction'),
-			'list'        => array('contao.controller.backend_csv_import', 'importListWizardAction')
+			'table'       => array('Contao\CoreBundle\Controller\BackendCsvImportController', 'importTableWizardAction'),
+			'list'        => array('Contao\CoreBundle\Controller\BackendCsvImportController', 'importListWizardAction')
 		),
 		'form' => array
 		(
 			'tables'      => array('tl_form', 'tl_form_field'),
-			'option'      => array('contao.controller.backend_csv_import', 'importOptionWizardAction')
+			'option'      => array('Contao\CoreBundle\Controller\BackendCsvImportController', 'importOptionWizardAction')
 		)
 	),
 

--- a/core-bundle/src/Resources/contao/controllers/BackendMain.php
+++ b/core-bundle/src/Resources/contao/controllers/BackendMain.php
@@ -13,6 +13,9 @@ namespace Contao;
 use Contao\CoreBundle\Event\ContaoCoreEvents;
 use Contao\CoreBundle\Event\PreviewUrlCreateEvent;
 use Contao\CoreBundle\Exception\AccessDeniedException;
+use Contao\CoreBundle\Menu\BackendMenuBuilder;
+use Contao\CoreBundle\Menu\BackendMenuRenderer;
+use Contao\CoreBundle\Picker\PickerBuilder;
 use Contao\CoreBundle\Util\PackageUtil;
 use Knp\Bundle\TimeBundle\DateTimeFormatter;
 use Symfony\Component\HttpFoundation\Response;
@@ -148,7 +151,7 @@ class BackendMain extends Backend
 
 			if (isset($_GET['picker']))
 			{
-				$picker = System::getContainer()->get('contao.picker.builder')->createFromData(Input::get('picker', true));
+				$picker = System::getContainer()->get(PickerBuilder::class)->createFromData(Input::get('picker', true));
 
 				if ($picker !== null)
 				{
@@ -272,7 +275,7 @@ class BackendMain extends Backend
 		$this->Template->burger = $GLOBALS['TL_LANG']['MSC']['burgerTitle'];
 		$this->Template->learnMore = sprintf($GLOBALS['TL_LANG']['MSC']['learnMore'], '<a href="https://contao.org" target="_blank" rel="noreferrer noopener">contao.org</a>');
 		$this->Template->ref = $container->get('request_stack')->getCurrentRequest()->attributes->get('_contao_referer_id');
-		$this->Template->menu = $container->get('contao.menu.backend_menu_renderer')->render($container->get('contao.menu.backend_menu_builder')->create());
+		$this->Template->menu = $container->get(BackendMenuRenderer::class)->render($container->get(BackendMenuBuilder::class)->create());
 		$this->Template->headerNavigation = StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['headerNavigation']);
 
 		// TODO: This should be moved the the manager-bundle in Contao 4.9

--- a/core-bundle/src/Resources/contao/controllers/BackendPreview.php
+++ b/core-bundle/src/Resources/contao/controllers/BackendPreview.php
@@ -13,6 +13,8 @@ namespace Contao;
 use Contao\CoreBundle\Event\ContaoCoreEvents;
 use Contao\CoreBundle\Event\PreviewUrlConvertEvent;
 use Contao\CoreBundle\Exception\AccessDeniedException;
+use Contao\CoreBundle\Security\Authentication\FrontendPreviewAuthenticator;
+use Contao\CoreBundle\Security\Authentication\Token\TokenChecker;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -59,7 +61,7 @@ class BackendPreview extends Backend
 		// Switch to a particular member (see #6546)
 		if ($strUser = Input::get('user'))
 		{
-			$objAuthenticator = System::getContainer()->get('contao.security.frontend_preview_authenticator');
+			$objAuthenticator = System::getContainer()->get(FrontendPreviewAuthenticator::class);
 
 			if (!$objAuthenticator->authenticateFrontendUser($strUser, false))
 			{
@@ -89,7 +91,7 @@ class BackendPreview extends Backend
 		$objTemplate->charset = Config::get('characterSet');
 		$objTemplate->site = Input::get('site', true);
 		$objTemplate->switchHref = $objRouter->generate('contao_backend_switch');
-		$objTemplate->user = System::getContainer()->get('contao.security.token_checker')->getFrontendUsername();
+		$objTemplate->user = System::getContainer()->get(TokenChecker::class)->getFrontendUsername();
 
 		$strUrl = null;
 

--- a/core-bundle/src/Resources/contao/controllers/BackendSwitch.php
+++ b/core-bundle/src/Resources/contao/controllers/BackendSwitch.php
@@ -11,6 +11,8 @@
 namespace Contao;
 
 use Contao\CoreBundle\Exception\AccessDeniedException;
+use Contao\CoreBundle\Security\Authentication\FrontendPreviewAuthenticator;
+use Contao\CoreBundle\Security\Authentication\Token\TokenChecker;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -58,7 +60,7 @@ class BackendSwitch extends Backend
 		}
 
 		$blnCanSwitchUser = ($this->User->isAdmin || (!empty($this->User->amg) && \is_array($this->User->amg)));
-		$objTokenChecker = System::getContainer()->get('contao.security.token_checker');
+		$objTokenChecker = System::getContainer()->get(TokenChecker::class);
 		$strUser = $objTokenChecker->getFrontendUsername();
 		$blnShowUnpublished = $objTokenChecker->isPreviewMode();
 		$blnUpdate = false;
@@ -67,7 +69,7 @@ class BackendSwitch extends Backend
 		if (Input::post('FORM_SUBMIT') == 'tl_switch')
 		{
 			$blnUpdate = true;
-			$objAuthenticator = System::getContainer()->get('contao.security.frontend_preview_authenticator');
+			$objAuthenticator = System::getContainer()->get(FrontendPreviewAuthenticator::class);
 			$blnShowUnpublished = Input::post('unpublished') != 'hide';
 
 			// Switch user accounts

--- a/core-bundle/src/Resources/contao/dca/tl_article.php
+++ b/core-bundle/src/Resources/contao/dca/tl_article.php
@@ -576,7 +576,7 @@ class tl_article extends Contao\Backend
 		// Generate an alias if there is none
 		if ($varValue == '')
 		{
-			$varValue = Contao\System::getContainer()->get('contao.slug')->generate($dc->activeRecord->title, $dc->activeRecord->pid, $aliasExists);
+			$varValue = Contao\System::getContainer()->get('Contao\CoreBundle\Slug\Slug')->generate($dc->activeRecord->title, $dc->activeRecord->pid, $aliasExists);
 		}
 		elseif ($aliasExists($varValue))
 		{
@@ -815,7 +815,7 @@ class tl_article extends Contao\Backend
 					continue;
 				}
 
-				$strAlias = Contao\System::getContainer()->get('contao.slug')->generate($objArticle->title, $objArticle->pid);
+				$strAlias = Contao\System::getContainer()->get('Contao\CoreBundle\Slug\Slug')->generate($objArticle->title, $objArticle->pid);
 
 				// The alias has not changed
 				if ($strAlias == $objArticle->alias)

--- a/core-bundle/src/Resources/contao/dca/tl_content.php
+++ b/core-bundle/src/Resources/contao/dca/tl_content.php
@@ -246,7 +246,7 @@ $GLOBALS['TL_DCA']['tl_content'] = array
 			'eval'                    => array('rgxp'=>'natural', 'includeBlankOption'=>true, 'nospace'=>true, 'helpwizard'=>true, 'tl_class'=>'w50'),
 			'options_callback' => static function ()
 			{
-				return Contao\System::getContainer()->get('contao.image.image_sizes')->getOptionsForUser(Contao\BackendUser::getInstance());
+				return Contao\System::getContainer()->get('Contao\CoreBundle\Image\ImageSizes')->getOptionsForUser(Contao\BackendUser::getInstance());
 			},
 			'sql'                     => "varchar(255) NOT NULL default ''"
 		),

--- a/core-bundle/src/Resources/contao/dca/tl_form.php
+++ b/core-bundle/src/Resources/contao/dca/tl_form.php
@@ -476,7 +476,7 @@ class tl_form extends Contao\Backend
 		// Generate an alias if there is none
 		if ($varValue == '')
 		{
-			$varValue = Contao\System::getContainer()->get('contao.slug')->generate($dc->activeRecord->title, Contao\Input::post('jumpTo') ?: $dc->activeRecord->jumpTo, $aliasExists);
+			$varValue = Contao\System::getContainer()->get('Contao\CoreBundle\Slug\Slug')->generate($dc->activeRecord->title, Contao\Input::post('jumpTo') ?: $dc->activeRecord->jumpTo, $aliasExists);
 		}
 		elseif ($aliasExists($varValue))
 		{

--- a/core-bundle/src/Resources/contao/dca/tl_layout.php
+++ b/core-bundle/src/Resources/contao/dca/tl_layout.php
@@ -290,7 +290,7 @@ $GLOBALS['TL_DCA']['tl_layout'] = array
 			'eval'                    => array('rgxp'=>'natural', 'includeBlankOption'=>true, 'nospace'=>true, 'helpwizard'=>true, 'tl_class'=>'w50'),
 			'options_callback' => static function ()
 			{
-				return Contao\System::getContainer()->get('contao.image.image_sizes')->getOptionsForUser(Contao\BackendUser::getInstance());
+				return Contao\System::getContainer()->get('Contao\CoreBundle\Image\ImageSizes')->getOptionsForUser(Contao\BackendUser::getInstance());
 			},
 			'sql'                     => "varchar(255) NOT NULL default ''"
 		),

--- a/core-bundle/src/Resources/contao/dca/tl_module.php
+++ b/core-bundle/src/Resources/contao/dca/tl_module.php
@@ -424,7 +424,7 @@ $GLOBALS['TL_DCA']['tl_module'] = array
 			'eval'                    => array('rgxp'=>'natural', 'includeBlankOption'=>true, 'nospace'=>true, 'helpwizard'=>true, 'tl_class'=>'w50'),
 			'options_callback' => static function ()
 			{
-				return Contao\System::getContainer()->get('contao.image.image_sizes')->getOptionsForUser(Contao\BackendUser::getInstance());
+				return Contao\System::getContainer()->get('Contao\CoreBundle\Image\ImageSizes')->getOptionsForUser(Contao\BackendUser::getInstance());
 			},
 			'sql'                     => "varchar(255) NOT NULL default ''"
 		),

--- a/core-bundle/src/Resources/contao/dca/tl_opt_in.php
+++ b/core-bundle/src/Resources/contao/dca/tl_opt_in.php
@@ -180,7 +180,7 @@ class tl_opt_in extends Contao\Backend
 	{
 		$model = Contao\OptInModel::findByPk($dc->id);
 
-		Contao\System::getContainer()->get('contao.opt-in')->find($model->token)->send();
+		Contao\System::getContainer()->get('Contao\CoreBundle\OptIn\OptIn')->find($model->token)->send();
 		Contao\Message::addConfirmation(sprintf($GLOBALS['TL_LANG']['MSC']['resendToken'], $model->email));
 		Contao\Controller::redirect($this->getReferer());
 	}

--- a/core-bundle/src/Resources/contao/dca/tl_page.php
+++ b/core-bundle/src/Resources/contao/dca/tl_page.php
@@ -416,7 +416,7 @@ $GLOBALS['TL_DCA']['tl_page'] = array
 			'inputType'               => 'select',
 			'options_callback' => static function ()
 			{
-				return Contao\System::getContainer()->get('contao.slug.valid_characters')->getOptions();
+				return Contao\System::getContainer()->get('Contao\CoreBundle\Slug\ValidCharacters')->getOptions();
 			},
 			'eval'                    => array('includeBlankOption'=>true, 'decodeEntities'=>true, 'tl_class'=>'w50'),
 			'sql'                     => "varchar(255) NOT NULL default ''"
@@ -1132,7 +1132,7 @@ class tl_page extends Contao\Backend
 		// Generate an alias if there is none
 		if ($varValue == '')
 		{
-			$varValue = Contao\System::getContainer()->get('contao.slug')->generate
+			$varValue = Contao\System::getContainer()->get('Contao\CoreBundle\Slug\Slug')->generate
 			(
 				$dc->activeRecord->title,
 				$dc->activeRecord->id,
@@ -1301,7 +1301,7 @@ class tl_page extends Contao\Backend
 	{
 		$page = Contao\PageModel::findByPk($dc->activeRecord->id);
 		$url = $page->getAbsoluteUrl();
-		$suffix = substr($dc->inputName, strlen($dc->field));
+		$suffix = substr($dc->inputName, \strlen($dc->field));
 
 		list($baseUrl) = explode($page->alias ?: $page->id, $url);
 

--- a/core-bundle/src/Resources/contao/dca/tl_templates.php
+++ b/core-bundle/src/Resources/contao/dca/tl_templates.php
@@ -237,7 +237,7 @@ class tl_templates extends Contao\Backend
 		$arrAllTemplates = array();
 
 		/** @var SplFileInfo[] $files */
-		$files = Contao\System::getContainer()->get('contao.resource_finder')->findIn('templates')->files()->name('/\.html5$/');
+		$files = Contao\System::getContainer()->get('Contao\CoreBundle\Config\ResourceFinder')->findIn('templates')->files()->name('/\.html5$/');
 
 		foreach ($files as $file)
 		{

--- a/core-bundle/src/Resources/contao/dca/tl_theme.php
+++ b/core-bundle/src/Resources/contao/dca/tl_theme.php
@@ -262,7 +262,7 @@ class tl_theme extends Contao\Backend
 			if ($objFile !== null && file_exists(TL_ROOT . '/' . $objFile->path))
 			{
 				$rootDir = Contao\System::getContainer()->getParameter('kernel.project_dir');
-				$label = Contao\Image::getHtml(Contao\System::getContainer()->get('contao.image.image_factory')->create($rootDir . '/' . $objFile->path, array(75, 50, 'center_top'))->getUrl($rootDir), '', 'class="theme_preview"') . ' ' . $label;
+				$label = Contao\Image::getHtml(Contao\System::getContainer()->get('Contao\CoreBundle\Image\ImageFactory')->create($rootDir . '/' . $objFile->path, array(75, 50, 'center_top'))->getUrl($rootDir), '', 'class="theme_preview"') . ' ' . $label;
 			}
 		}
 

--- a/core-bundle/src/Resources/contao/dca/tl_user.php
+++ b/core-bundle/src/Resources/contao/dca/tl_user.php
@@ -331,7 +331,7 @@ $GLOBALS['TL_DCA']['tl_user'] = array
 			'eval'                    => array('multiple'=>true),
 			'options_callback' => static function ()
 			{
-				return Contao\System::getContainer()->get('contao.image.image_sizes')->getAllOptions();
+				return Contao\System::getContainer()->get('Contao\CoreBundle\Image\ImageSizes')->getAllOptions();
 			},
 			'sql'                     => "blob NULL"
 		),

--- a/core-bundle/src/Resources/contao/dca/tl_user_group.php
+++ b/core-bundle/src/Resources/contao/dca/tl_user_group.php
@@ -181,7 +181,7 @@ $GLOBALS['TL_DCA']['tl_user_group'] = array
 			'eval'                    => array('multiple'=>true),
 			'options_callback' => static function ()
 			{
-				return Contao\System::getContainer()->get('contao.image.image_sizes')->getAllOptions();
+				return Contao\System::getContainer()->get('Contao\CoreBundle\Image\ImageSizes')->getAllOptions();
 			},
 			'sql'                     => "blob NULL"
 		),
@@ -343,7 +343,7 @@ class tl_user_group extends Contao\Backend
 		$processed = array();
 
 		/** @var SplFileInfo[] $files */
-		$files = Contao\System::getContainer()->get('contao.resource_finder')->findIn('dca')->depth(0)->files()->name('*.php');
+		$files = Contao\System::getContainer()->get('Contao\CoreBundle\Config\ResourceFinder')->findIn('dca')->depth(0)->files()->name('*.php');
 
 		foreach ($files as $file)
 		{

--- a/core-bundle/src/Resources/contao/drivers/DC_Folder.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Folder.php
@@ -13,6 +13,7 @@ namespace Contao;
 use Contao\CoreBundle\Exception\AccessDeniedException;
 use Contao\CoreBundle\Exception\InternalServerErrorException;
 use Contao\CoreBundle\Exception\ResponseException;
+use Contao\CoreBundle\Image\ImageFactory;
 use Contao\CoreBundle\Picker\PickerInterface;
 use Contao\CoreBundle\Util\SymlinkUtil;
 use Contao\Image\ResizeConfiguration;
@@ -2774,14 +2775,14 @@ class DC_Folder extends DataContainer implements \listable, \editable
 						}
 						else
 						{
-							$thumbnail .= '<br>' . Image::getHtml(System::getContainer()->get('contao.image.image_factory')->create($this->strRootDir . '/' . rawurldecode($currentEncoded), array(100, 75, ResizeConfiguration::MODE_BOX))->getUrl($this->strRootDir), '', 'class="preview-image"');
+							$thumbnail .= '<br>' . Image::getHtml(System::getContainer()->get(ImageFactory::class)->create($this->strRootDir . '/' . rawurldecode($currentEncoded), array(100, 75, ResizeConfiguration::MODE_BOX))->getUrl($this->strRootDir), '', 'class="preview-image"');
 						}
 
-						$importantPart = System::getContainer()->get('contao.image.image_factory')->create($this->strRootDir . '/' . rawurldecode($currentEncoded))->getImportantPart();
+						$importantPart = System::getContainer()->get(ImageFactory::class)->create($this->strRootDir . '/' . rawurldecode($currentEncoded))->getImportantPart();
 
 						if ($importantPart->getX() > 0 || $importantPart->getY() > 0 || $importantPart->getWidth() < 1 || $importantPart->getHeight() < 1)
 						{
-							$thumbnail .= ' ' . Image::getHtml(System::getContainer()->get('contao.image.image_factory')->create($this->strRootDir . '/' . rawurldecode($currentEncoded), (new ResizeConfiguration())->setWidth(80)->setHeight(60)->setMode(ResizeConfiguration::MODE_BOX)->setZoomLevel(100))->getUrl($this->strRootDir), '', 'class="preview-important"');
+							$thumbnail .= ' ' . Image::getHtml(System::getContainer()->get(ImageFactory::class)->create($this->strRootDir . '/' . rawurldecode($currentEncoded), (new ResizeConfiguration())->setWidth(80)->setHeight(60)->setMode(ResizeConfiguration::MODE_BOX)->setZoomLevel(100))->getUrl($this->strRootDir), '', 'class="preview-important"');
 						}
 					}
 					catch (RuntimeException $e)

--- a/core-bundle/src/Resources/contao/library/Contao/Automator.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Automator.php
@@ -242,7 +242,7 @@ class Automator extends System
 	public function purgeOptInTokens()
 	{
 		/** @var OptIn $optIn */
-		$optIn = System::getContainer()->get('contao.opt-in');
+		$optIn = System::getContainer()->get(OptIn::class);
 		$optIn->purgeTokens();
 
 		// Add a log entry

--- a/core-bundle/src/Resources/contao/library/Contao/Controller.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Controller.php
@@ -15,6 +15,9 @@ use Contao\CoreBundle\Exception\AccessDeniedException;
 use Contao\CoreBundle\Exception\AjaxRedirectResponseException;
 use Contao\CoreBundle\Exception\PageNotFoundException;
 use Contao\CoreBundle\Exception\RedirectResponseException;
+use Contao\CoreBundle\Image\PictureFactory;
+use Contao\CoreBundle\Routing\UrlGenerator;
+use Contao\CoreBundle\Security\Authentication\Token\TokenChecker;
 use Contao\Database\Result;
 use Contao\Image\PictureConfiguration;
 use Contao\Model\Collection;
@@ -805,7 +808,7 @@ abstract class Controller extends System
 		}
 
 		// FE preview support
-		if (System::getContainer()->get('contao.security.token_checker')->hasBackendUser())
+		if (System::getContainer()->get(TokenChecker::class)->hasBackendUser())
 		{
 			$strScripts .= "
 <script>
@@ -1140,11 +1143,11 @@ abstract class Controller extends System
 	 * @return string An URL that can be used in the front end
 	 *
 	 * @deprecated Deprecated since Contao 4.2, to be removed in Contao 5.0.
-	 *             Use the contao.routing.url_generator service or PageModel::getFrontendUrl() instead.
+	 *             Use the Contao\CoreBundle\Routing\UrlGenerator service or PageModel::getFrontendUrl() instead.
 	 */
 	public static function generateFrontendUrl(array $arrRow, $strParams=null, $strForceLang=null, $blnFixDomain=false)
 	{
-		@trigger_error('Using Controller::generateFrontendUrl() has been deprecated and will no longer work in Contao 5.0. Use the contao.routing.url_generator service or PageModel::getFrontendUrl() instead.', E_USER_DEPRECATED);
+		@trigger_error('Using Controller::generateFrontendUrl() has been deprecated and will no longer work in Contao 5.0. Use the Contao\CoreBundle\Routing\UrlGenerator service or PageModel::getFrontendUrl() instead.', E_USER_DEPRECATED);
 
 		if (!isset($arrRow['rootId']))
 		{
@@ -1191,7 +1194,7 @@ abstract class Controller extends System
 			$arrParams['_ssl'] = (bool) $arrRow['rootUseSSL'];
 		}
 
-		$objUrlGenerator = System::getContainer()->get('contao.routing.url_generator');
+		$objUrlGenerator = System::getContainer()->get(UrlGenerator::class);
 		$strUrl = $objUrlGenerator->generate(($arrRow['alias'] ?: $arrRow['id']) . $strParams, $arrParams);
 
 		// Remove path from absolute URLs
@@ -1568,7 +1571,7 @@ abstract class Controller extends System
 		{
 			$rootDir = $container->getParameter('kernel.project_dir');
 			$staticUrl = $container->get('contao.assets.files_context')->getStaticUrl();
-			$picture = $container->get('contao.image.picture_factory')->create($rootDir . '/' . $arrItem['singleSRC'], $size);
+			$picture = $container->get(PictureFactory::class)->create($rootDir . '/' . $arrItem['singleSRC'], $size);
 
 			$picture = array
 			(
@@ -1709,7 +1712,7 @@ abstract class Controller extends System
 						{
 							$rootDir = $container->getParameter('kernel.project_dir');
 							$staticUrl = $container->get('contao.assets.files_context')->getStaticUrl();
-							$picture = $container->get('contao.image.picture_factory')->create($rootDir . '/' . $arrItem['imageUrl'], $lightboxSize);
+							$picture = $container->get(PictureFactory::class)->create($rootDir . '/' . $arrItem['imageUrl'], $lightboxSize);
 
 							$objTemplate->lightboxPicture = array
 							(
@@ -1742,7 +1745,7 @@ abstract class Controller extends System
 			{
 				$rootDir = $container->getParameter('kernel.project_dir');
 				$staticUrl = $container->get('contao.assets.files_context')->getStaticUrl();
-				$picture = $container->get('contao.image.picture_factory')->create($rootDir . '/' . $arrItem['singleSRC'], $lightboxSize);
+				$picture = $container->get(PictureFactory::class)->create($rootDir . '/' . $arrItem['singleSRC'], $lightboxSize);
 
 				$objTemplate->lightboxPicture = array
 				(

--- a/core-bundle/src/Resources/contao/library/Contao/Database/Installer.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Database/Installer.php
@@ -12,6 +12,7 @@ namespace Contao\Database;
 
 use Contao\Config;
 use Contao\Controller;
+use Contao\CoreBundle\Config\ResourceFinder;
 use Contao\Database;
 use Contao\DcaExtractor;
 use Contao\SqlFileParser;
@@ -271,7 +272,7 @@ class Installer extends Controller
 		$processed = array();
 
 		/** @var SplFileInfo[] $files */
-		$files = System::getContainer()->get('contao.resource_finder')->findIn('dca')->depth(0)->files()->name('*.php');
+		$files = System::getContainer()->get(ResourceFinder::class)->findIn('dca')->depth(0)->files()->name('*.php');
 
 		foreach ($files as $file)
 		{
@@ -316,7 +317,7 @@ class Installer extends Controller
 		$return = array();
 
 		/** @var SplFileInfo[] $files */
-		$files = System::getContainer()->get('contao.resource_finder')->findIn('config')->depth(0)->files()->name('database.sql');
+		$files = System::getContainer()->get(ResourceFinder::class)->findIn('config')->depth(0)->files()->name('database.sql');
 
 		foreach ($files as $file)
 		{

--- a/core-bundle/src/Resources/contao/library/Contao/Database/Updater.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Database/Updater.php
@@ -12,6 +12,7 @@ namespace Contao\Database;
 
 use Contao\Config;
 use Contao\Controller;
+use Contao\CoreBundle\Config\ResourceFinder;
 use Contao\Database;
 use Contao\Dbafs;
 use Contao\File;
@@ -739,7 +740,7 @@ class Updater extends Controller
 		$arrFields = array();
 
 		/** @var SplFileInfo[] $files */
-		$files = System::getContainer()->get('contao.resource_finder')->findIn('dca')->depth(0)->files()->name('*.php');
+		$files = System::getContainer()->get(ResourceFinder::class)->findIn('dca')->depth(0)->files()->name('*.php');
 
 		foreach ($files as $file)
 		{

--- a/core-bundle/src/Resources/contao/library/Contao/File.php
+++ b/core-bundle/src/Resources/contao/library/Contao/File.php
@@ -11,6 +11,8 @@
 namespace Contao;
 
 use Contao\CoreBundle\Exception\ResponseException;
+use Contao\CoreBundle\Image\ImageFactory;
+use Contao\CoreBundle\Image\LegacyResizer;
 use Contao\Image\DeferredImageInterface;
 use Contao\Image\ImageDimensions;
 use Patchwork\Utf8;
@@ -270,7 +272,7 @@ class File extends System
 					{
 						try
 						{
-							$dimensions = System::getContainer()->get('contao.image.image_factory')->create($this->strRootDir . '/' . $this->strFile)->getDimensions();
+							$dimensions = System::getContainer()->get(ImageFactory::class)->create($this->strRootDir . '/' . $this->strFile)->getDimensions();
 
 							if (!$dimensions->isRelative() && !$dimensions->isUndefined())
 							{
@@ -609,11 +611,11 @@ class File extends System
 		{
 			try
 			{
-				$image = System::getContainer()->get('contao.image.image_factory')->create($this->strRootDir . '/' . $this->strFile);
+				$image = System::getContainer()->get(ImageFactory::class)->create($this->strRootDir . '/' . $this->strFile);
 
 				if ($image instanceof DeferredImageInterface)
 				{
-					System::getContainer()->get('contao.image.resizer')->resizeDeferredImage($image);
+					System::getContainer()->get(LegacyResizer::class)->resizeDeferredImage($image);
 
 					return true;
 				}
@@ -779,7 +781,7 @@ class File extends System
 		}
 
 		$return = System::getContainer()
-			->get('contao.image.image_factory')
+			->get(ImageFactory::class)
 			->create($this->strRootDir . '/' . $this->strFile, array($width, $height, $mode), $this->strRootDir . '/' . $this->strFile)
 			->getUrl($this->strRootDir)
 		;

--- a/core-bundle/src/Resources/contao/library/Contao/Image.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Image.php
@@ -10,6 +10,8 @@
 
 namespace Contao;
 
+use Contao\CoreBundle\Image\ImageFactory;
+use Contao\CoreBundle\Image\LegacyResizer;
 use Contao\Image\DeferredImageInterface;
 use Contao\Image\Image as NewImage;
 use Contao\Image\ImageDimensions;
@@ -117,11 +119,11 @@ class Image
 	 * @throws \InvalidArgumentException If the file does not exists or cannot be processed
 	 *
 	 * @deprecated Deprecated since Contao 4.3, to be removed in Contao 5.0.
-	 *             Use the contao.image.image_factory service instead.
+	 *             Use the Contao\CoreBundle\Image\ImageFactory service instead.
 	 */
 	public function __construct(File $file)
 	{
-		@trigger_error('Using new Contao\Image() has been deprecated and will no longer work in Contao 5.0. Use the contao.image.image_factory service instead.', E_USER_DEPRECATED);
+		@trigger_error('Using new Contao\Image() has been deprecated and will no longer work in Contao 5.0. Use the Contao\CoreBundle\Image\ImageFactory service instead.', E_USER_DEPRECATED);
 
 		// Check whether the file exists
 		if (!$file->exists())
@@ -448,7 +450,7 @@ class Image
 		}
 
 		$image = System::getContainer()
-			->get('contao.image.resizer')
+			->get(LegacyResizer::class)
 			->resize(
 				$image,
 				$resizeConfig,
@@ -689,7 +691,7 @@ class Image
 		{
 			try
 			{
-				$deferredImage = $container->get('contao.image.image_factory')->create($rootDir . '/' . $src);
+				$deferredImage = $container->get(ImageFactory::class)->create($rootDir . '/' . $src);
 			}
 			catch (\Exception $e)
 			{
@@ -731,11 +733,11 @@ class Image
 	 * @return boolean True if the image could be resized successfully
 	 *
 	 * @deprecated Deprecated since Contao 4.3, to be removed in Contao 5.0.
-	 *             Use the contao.image.image_factory service instead.
+	 *             Use the Contao\CoreBundle\Image\ImageFactory service instead.
 	 */
 	public static function resize($image, $width, $height, $mode='')
 	{
-		@trigger_error('Using Image::resize() has been deprecated and will no longer work in Contao 5.0. Use the contao.image.image_factory service instead.', E_USER_DEPRECATED);
+		@trigger_error('Using Image::resize() has been deprecated and will no longer work in Contao 5.0. Use the Contao\CoreBundle\Image\ImageFactory service instead.', E_USER_DEPRECATED);
 
 		return static::get($image, $width, $height, $mode, $image, true) ? true : false;
 	}
@@ -749,11 +751,11 @@ class Image
 	 * @return static The created image instance
 	 *
 	 * @deprecated Deprecated since Contao 4.3, to be removed in Contao 5.0.
-	 *             Use the contao.image.image_factory service instead.
+	 *             Use the Contao\CoreBundle\Image\ImageFactory service instead.
 	 */
 	public static function create($image, $size=null)
 	{
-		@trigger_error('Using Image::create() has been deprecated and will no longer work in Contao 5.0. Use the contao.image.image_factory service instead.', E_USER_DEPRECATED);
+		@trigger_error('Using Image::create() has been deprecated and will no longer work in Contao 5.0. Use the Contao\CoreBundle\Image\ImageFactory service instead.', E_USER_DEPRECATED);
 
 		if (\is_string($image))
 		{
@@ -822,11 +824,11 @@ class Image
 	 * @return string|null The path of the resized image or null
 	 *
 	 * @deprecated Deprecated since Contao 4.3, to be removed in Contao 5.0.
-	 *             Use the contao.image.image_factory service instead.
+	 *             Use the Contao\CoreBundle\Image\ImageFactory service instead.
 	 */
 	public static function get($image, $width, $height, $mode='', $target=null, $force=false)
 	{
-		@trigger_error('Using Image::get() has been deprecated and will no longer work in Contao 5.0. Use the contao.image.image_factory service instead.', E_USER_DEPRECATED);
+		@trigger_error('Using Image::get() has been deprecated and will no longer work in Contao 5.0. Use the Contao\CoreBundle\Image\ImageFactory service instead.', E_USER_DEPRECATED);
 
 		if ($image == '')
 		{
@@ -860,7 +862,7 @@ class Image
 	 * @return integer The pixel value
 	 *
 	 * @deprecated Deprecated since Contao 4.3, to be removed in Contao 5.0.
-	 *             Use the contao.image.image_factory service instead.
+	 *             Use the Contao\CoreBundle\Image\ImageFactory service instead.
 	 */
 	public static function getPixelValue($size)
 	{

--- a/core-bundle/src/Resources/contao/library/Contao/InsertTags.php
+++ b/core-bundle/src/Resources/contao/library/Contao/InsertTags.php
@@ -10,6 +10,9 @@
 
 namespace Contao;
 
+use Contao\CoreBundle\Controller\InsertTagsController;
+use Contao\CoreBundle\Image\ImageFactory;
+use Contao\CoreBundle\Image\PictureFactory;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Controller\ControllerReference;
 use Symfony\Component\HttpKernel\Fragment\FragmentHandler;
@@ -144,7 +147,7 @@ class InsertTags extends Controller
 
 					$strBuffer .= $fragmentHandler->render(
 						new ControllerReference(
-							'contao.controller.insert_tags:renderAction',
+							InsertTagsController::class.':renderAction',
 							$attributes,
 							array('clientCache' => (int) $objPage->clientCache, 'pageId' => $objPage->id, 'request' => Environment::get('request'))
 						),
@@ -886,7 +889,7 @@ class InsertTags extends Controller
 						if (strtolower($elements[0]) == 'image')
 						{
 							$dimensions = '';
-							$src = $container->get('contao.image.image_factory')->create($container->getParameter('kernel.project_dir') . '/' . rawurldecode($strFile), array($width, $height, $mode))->getUrl($container->getParameter('kernel.project_dir'));
+							$src = $container->get(ImageFactory::class)->create($container->getParameter('kernel.project_dir') . '/' . rawurldecode($strFile), array($width, $height, $mode))->getUrl($container->getParameter('kernel.project_dir'));
 							$objFile = new File(rawurldecode($src));
 
 							// Add the image dimensions
@@ -902,7 +905,7 @@ class InsertTags extends Controller
 						else
 						{
 							$staticUrl = $container->get('contao.assets.files_context')->getStaticUrl();
-							$picture = $container->get('contao.image.picture_factory')->create($container->getParameter('kernel.project_dir') . '/' . $strFile, $size);
+							$picture = $container->get(PictureFactory::class)->create($container->getParameter('kernel.project_dir') . '/' . $strFile, $size);
 
 							$picture = array
 							(

--- a/core-bundle/src/Resources/contao/library/Contao/Picture.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Picture.php
@@ -10,14 +10,16 @@
 
 namespace Contao;
 
+use Contao\CoreBundle\Image\ImageFactory;
 use Contao\Image\ImportantPart;
 use Contao\Image\PictureConfiguration;
 use Contao\Image\PictureConfigurationItem;
+use Contao\Image\PictureGenerator;
 use Contao\Image\ResizeConfiguration;
 use Contao\Image\ResizeOptions;
 use Contao\Model\Collection;
 
-@trigger_error('Using the "Contao\Picture" class has been deprecated and will no longer work in Contao 5.0. Use the "contao.image.picture_factory" service instead.', E_USER_DEPRECATED);
+@trigger_error('Using the "Contao\Picture" class has been deprecated and will no longer work in Contao 5.0. Use the "Contao\CoreBundle\Image\PictureFactory" service instead.', E_USER_DEPRECATED);
 
 /**
  * Resizes images and creates picture data
@@ -43,7 +45,7 @@ use Contao\Model\Collection;
  * @author Yanick Witschi <https://github.com/Toflar>
  *
  * @deprecated Deprecated since Contao 4.3, to be removed in Contao 5.0.
- *             Use the contao.image.picture_factory service instead.
+ *             Use the Contao\CoreBundle\Image\PictureFactory service instead.
  */
 class Picture
 {
@@ -205,7 +207,7 @@ class Picture
 	public function getTemplateData()
 	{
 		$rootDir = System::getContainer()->getParameter('kernel.project_dir');
-		$image = System::getContainer()->get('contao.image.image_factory')->create($rootDir . '/' . $this->image->getOriginalPath());
+		$image = System::getContainer()->get(ImageFactory::class)->create($rootDir . '/' . $this->image->getOriginalPath());
 
 		$config = new PictureConfiguration();
 		$config->setSize($this->getConfigurationItem($this->imageSize));
@@ -235,7 +237,7 @@ class Picture
 		$staticUrl = $container->get('contao.assets.files_context')->getStaticUrl();
 
 		$picture = $container
-			->get('contao.image.picture_generator')
+			->get(PictureGenerator::class)
 			->generate(
 				$image,
 				$config,

--- a/core-bundle/src/Resources/contao/library/Contao/System.php
+++ b/core-bundle/src/Resources/contao/library/Contao/System.php
@@ -12,6 +12,8 @@ namespace Contao;
 
 use Contao\CoreBundle\Config\Loader\PhpFileLoader;
 use Contao\CoreBundle\Config\Loader\XliffFileLoader;
+use Contao\CoreBundle\Config\ResourceFinder;
+use Contao\CoreBundle\Image\ImageSizes;
 use Contao\CoreBundle\Monolog\ContaoContext;
 use Contao\Database\Installer;
 use Contao\Database\Updater;
@@ -413,7 +415,7 @@ abstract class System
 			else
 			{
 				// Find the given filename either as .php or .xlf file
-				$finder = static::getContainer()->get('contao.resource_finder')->findIn('languages/' . $strCreateLang)->name('/^' . $strName . '\.(php|xlf)$/');
+				$finder = static::getContainer()->get(ResourceFinder::class)->findIn('languages/' . $strCreateLang)->name('/^' . $strName . '\.(php|xlf)$/');
 
 				/** @var SplFileInfo $file */
 				foreach ($finder as $file)
@@ -484,7 +486,7 @@ abstract class System
 			else
 			{
 				/** @var SplFileInfo[] $files */
-				$files = static::getContainer()->get('contao.resource_finder')->findIn('languages')->depth(0)->directories()->name($strLanguage);
+				$files = static::getContainer()->get(ResourceFinder::class)->findIn('languages')->depth(0)->directories()->name($strLanguage);
 				static::$arrLanguages[$strLanguage] = \count($files) > 0;
 			}
 		}
@@ -612,13 +614,13 @@ abstract class System
 	 * @return array The available image sizes
 	 *
 	 * @deprecated Deprecated since Contao 4.1, to be removed in Contao 5.
-	 *             Use the contao.image.image_sizes service instead.
+	 *             Use the Contao\CoreBundle\Image\ImageSizes service instead.
 	 */
 	public static function getImageSizes()
 	{
-		@trigger_error('Using System::getImageSizes() has been deprecated and will no longer work in Contao 5.0. Use the contao.image.image_sizes service instead.', E_USER_DEPRECATED);
+		@trigger_error('Using System::getImageSizes() has been deprecated and will no longer work in Contao 5.0. Use the Contao\CoreBundle\Image\ImageSizes service instead.', E_USER_DEPRECATED);
 
-		return static::getContainer()->get('contao.image.image_sizes')->getAllOptions();
+		return static::getContainer()->get(ImageSizes::class)->getAllOptions();
 	}
 
 	/**

--- a/core-bundle/src/Resources/contao/library/Contao/TemplateLoader.php
+++ b/core-bundle/src/Resources/contao/library/Contao/TemplateLoader.php
@@ -10,6 +10,7 @@
 
 namespace Contao;
 
+use Contao\CoreBundle\Config\ResourceFinder;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\SplFileInfo;
 
@@ -144,7 +145,7 @@ class TemplateLoader
 		try
 		{
 			// Search for the template if it is not in the lookup array (last match wins)
-			foreach ($container->get('contao.resource_finder')->findIn('templates')->name($file) as $file)
+			foreach ($container->get(ResourceFinder::class)->findIn('templates')->name($file) as $file)
 			{
 				/** @var SplFileInfo $file */
 				$strPath = $file->getPathname();
@@ -178,7 +179,7 @@ class TemplateLoader
 		{
 			try
 			{
-				foreach (System::getContainer()->get('contao.resource_finder')->findIn('templates')->name('*.html5') as $file)
+				foreach (System::getContainer()->get(ResourceFinder::class)->findIn('templates')->name('*.html5') as $file)
 				{
 					/** @var SplFileInfo $file */
 					self::addFile($file->getBasename('.html5'), rtrim($objFilesystem->makePathRelative($file->getPath(), $container->getParameter('kernel.project_dir')), '/'));

--- a/core-bundle/src/Resources/contao/models/PageModel.php
+++ b/core-bundle/src/Resources/contao/models/PageModel.php
@@ -11,6 +11,7 @@
 namespace Contao;
 
 use Contao\CoreBundle\Exception\NoRootPageFoundException;
+use Contao\CoreBundle\Routing\UrlGenerator;
 use Contao\Model\Collection;
 use Contao\Model\Registry;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -1079,7 +1080,7 @@ class PageModel extends Model
 
 		$this->loadDetails();
 
-		$objUrlGenerator = System::getContainer()->get('contao.routing.url_generator');
+		$objUrlGenerator = System::getContainer()->get(UrlGenerator::class);
 
 		$strUrl = $objUrlGenerator->generate
 		(
@@ -1114,7 +1115,7 @@ class PageModel extends Model
 	{
 		$this->loadDetails();
 
-		$objUrlGenerator = System::getContainer()->get('contao.routing.url_generator');
+		$objUrlGenerator = System::getContainer()->get(UrlGenerator::class);
 
 		$strUrl = $objUrlGenerator->generate
 		(
@@ -1154,7 +1155,7 @@ class PageModel extends Model
 		$context = $router->getContext();
 		$context->setBaseUrl($previewScript);
 
-		$objUrlGenerator = $container->get('contao.routing.url_generator');
+		$objUrlGenerator = $container->get(UrlGenerator::class);
 
 		$strUrl = $objUrlGenerator->generate
 		(

--- a/core-bundle/src/Resources/contao/modules/ModulePassword.php
+++ b/core-bundle/src/Resources/contao/modules/ModulePassword.php
@@ -174,7 +174,7 @@ class ModulePassword extends Module
 	protected function setNewPassword()
 	{
 		/** @var OptIn $optIn */
-		$optIn = System::getContainer()->get('contao.opt-in');
+		$optIn = System::getContainer()->get(OptIn::class);
 
 		// Find an unconfirmed token with only one related record
 		if ((!$optInToken = $optIn->find(Input::get('token'))) || !$optInToken->isValid() || \count($arrRelated = $optInToken->getRelatedRecords()) != 1 || key($arrRelated) != 'tl_member' || \count($arrIds = current($arrRelated)) != 1 || (!$objMember = MemberModel::findByPk($arrIds[0])))
@@ -308,7 +308,7 @@ class ModulePassword extends Module
 	protected function sendPasswordLink($objMember)
 	{
 		/** @var OptIn $optIn */
-		$optIn = System::getContainer()->get('contao.opt-in');
+		$optIn = System::getContainer()->get(OptIn::class);
 		$optInToken = $optIn->create('pw', $objMember->email, array('tl_member'=>array($objMember->id)));
 
 		// Prepare the simple token data

--- a/core-bundle/src/Resources/contao/modules/ModuleRegistration.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleRegistration.php
@@ -465,7 +465,7 @@ class ModuleRegistration extends Module
 	protected function sendActivationMail($arrData)
 	{
 		/** @var OptIn $optIn */
-		$optIn = System::getContainer()->get('contao.opt-in');
+		$optIn = System::getContainer()->get(OptIn::class);
 		$optInToken = $optIn->create('reg', $arrData['email'], array('tl_member'=>array($arrData['id'])));
 
 		// Prepare the simple token data
@@ -520,7 +520,7 @@ class ModuleRegistration extends Module
 		$this->Template = new FrontendTemplate($this->strTemplate);
 
 		/** @var OptIn $optIn */
-		$optIn = System::getContainer()->get('contao.opt-in');
+		$optIn = System::getContainer()->get(OptIn::class);
 
 		// Find an unconfirmed token with only one related record
 		if ((!$optInToken = $optIn->find(Input::get('token'))) || !$optInToken->isValid() || \count($arrRelated = $optInToken->getRelatedRecords()) != 1 || key($arrRelated) != 'tl_member' || \count($arrIds = current($arrRelated)) != 1 || (!$objMember = MemberModel::findByPk($arrIds[0])))
@@ -593,7 +593,7 @@ class ModuleRegistration extends Module
 		$this->Template = new FrontendTemplate($this->strTemplate);
 
 		/** @var OptIn $optIn */
-		$optIn = System::getContainer()->get('contao.opt-in');
+		$optIn = System::getContainer()->get(OptIn::class);
 		$optInToken = null;
 		$models = OptInModel::findByRelatedTableAndIds('tl_member', array($objMember->id));
 

--- a/core-bundle/src/Resources/contao/modules/ModuleTwoFactor.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleTwoFactor.php
@@ -90,7 +90,7 @@ class ModuleTwoFactor extends BackendModule
 		$verifyHelp = $GLOBALS['TL_LANG']['MSC']['twoFactorVerificationHelp'];
 
 		/** @var Authenticator $authenticator */
-		$authenticator = $container->get('contao.security.two_factor.authenticator');
+		$authenticator = $container->get(Authenticator::class);
 
 		// Validate the verification code
 		if (Input::post('FORM_SUBMIT') == 'tl_two_factor')

--- a/core-bundle/src/Resources/contao/pages/PageRegular.php
+++ b/core-bundle/src/Resources/contao/pages/PageRegular.php
@@ -11,6 +11,7 @@
 namespace Contao;
 
 use Contao\CoreBundle\Exception\NoLayoutSpecifiedException;
+use Contao\CoreBundle\Image\PictureFactory;
 use Contao\CoreBundle\Util\PackageUtil;
 use Symfony\Component\Cache\Adapter\AdapterInterface;
 use Symfony\Component\HttpFoundation\Response;
@@ -81,7 +82,7 @@ class PageRegular extends Frontend
 		$objTheme = $objLayout->getRelated('pid');
 
 		// Set the default image densities
-		$container->get('contao.image.picture_factory')->setDefaultDensities($objLayout->defaultImageDensities);
+		$container->get(PictureFactory::class)->setDefaultDensities($objLayout->defaultImageDensities);
 
 		// Store the layout ID
 		$objPage->layoutId = $objLayout->id;

--- a/core-bundle/src/Resources/contao/widgets/FileSelector.php
+++ b/core-bundle/src/Resources/contao/widgets/FileSelector.php
@@ -10,6 +10,7 @@
 
 namespace Contao;
 
+use Contao\CoreBundle\Image\ImageFactory;
 use Contao\Image\ResizeConfiguration;
 use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface;
 
@@ -563,12 +564,12 @@ class FileSelector extends Widget
 				if ($objFile->isImage && $objFile->viewHeight > 0 && Config::get('thumbnails') && ($objFile->isSvgImage || ($objFile->height <= Config::get('gdMaxImgHeight') && $objFile->width <= Config::get('gdMaxImgWidth'))))
 				{
 					$rootDir = System::getContainer()->getParameter('kernel.project_dir');
-					$thumbnail .= '<br>' . Image::getHtml(System::getContainer()->get('contao.image.image_factory')->create($rootDir . '/' . rawurldecode($currentEncoded), array(100, 75, ResizeConfiguration::MODE_BOX))->getUrl($rootDir), '', 'style="margin:0 0 2px -18px"');
-					$importantPart = System::getContainer()->get('contao.image.image_factory')->create($rootDir . '/' . rawurldecode($currentEncoded))->getImportantPart();
+					$thumbnail .= '<br>' . Image::getHtml(System::getContainer()->get(ImageFactory::class)->create($rootDir . '/' . rawurldecode($currentEncoded), array(100, 75, ResizeConfiguration::MODE_BOX))->getUrl($rootDir), '', 'style="margin:0 0 2px -18px"');
+					$importantPart = System::getContainer()->get(ImageFactory::class)->create($rootDir . '/' . rawurldecode($currentEncoded))->getImportantPart();
 
 					if ($importantPart->getX() > 0 || $importantPart->getY() > 0 || $importantPart->getWidth() < 1 || $importantPart->getHeight() < 1)
 					{
-						$thumbnail .= ' ' . Image::getHtml(System::getContainer()->get('contao.image.image_factory')->create($rootDir . '/' . rawurldecode($currentEncoded), (new ResizeConfiguration())->setWidth(80)->setHeight(60)->setMode(ResizeConfiguration::MODE_BOX)->setZoomLevel(100))->getUrl($rootDir), '', 'style="margin:0 0 2px 0;vertical-align:bottom"');
+						$thumbnail .= ' ' . Image::getHtml(System::getContainer()->get(ImageFactory::class)->create($rootDir . '/' . rawurldecode($currentEncoded), (new ResizeConfiguration())->setWidth(80)->setHeight(60)->setMode(ResizeConfiguration::MODE_BOX)->setZoomLevel(100))->getUrl($rootDir), '', 'style="margin:0 0 2px 0;vertical-align:bottom"');
 					}
 				}
 

--- a/core-bundle/src/Resources/contao/widgets/FileTree.php
+++ b/core-bundle/src/Resources/contao/widgets/FileTree.php
@@ -10,6 +10,8 @@
 
 namespace Contao;
 
+use Contao\CoreBundle\Image\ImageFactory;
+use Contao\CoreBundle\Picker\PickerBuilder;
 use Contao\Image\ResizeConfiguration;
 
 /**
@@ -370,7 +372,7 @@ class FileTree extends Widget
 
 		$return .= '</ul>';
 
-		if (!System::getContainer()->get('contao.picker.builder')->supportsContext('file'))
+		if (!System::getContainer()->get(PickerBuilder::class)->supportsContext('file'))
 		{
 			$return .= '
 	<p><button class="tl_submit" disabled>'.$GLOBALS['TL_LANG']['MSC']['changeSelection'].'</button></p>';
@@ -400,7 +402,7 @@ class FileTree extends Widget
 			}
 
 			$return .= '
-    <p><a href="' . ampersand(System::getContainer()->get('contao.picker.builder')->getUrl('file', $extras)) . '" class="tl_submit" id="ft_' . $this->strName . '">'.$GLOBALS['TL_LANG']['MSC']['changeSelection'].'</a></p>
+    <p><a href="' . ampersand(System::getContainer()->get(PickerBuilder::class)->getUrl('file', $extras)) . '" class="tl_submit" id="ft_' . $this->strName . '">'.$GLOBALS['TL_LANG']['MSC']['changeSelection'].'</a></p>
     <script>
       $("ft_' . $this->strName . '").addEvent("click", function(e) {
         e.preventDefault();
@@ -450,7 +452,7 @@ class FileTree extends Widget
 			else
 			{
 				$rootDir = System::getContainer()->getParameter('kernel.project_dir');
-				$image = System::getContainer()->get('contao.image.image_factory')->create($rootDir . '/' . $objFile->path, array(100, 75, ResizeConfiguration::MODE_BOX))->getUrl($rootDir);
+				$image = System::getContainer()->get(ImageFactory::class)->create($rootDir . '/' . $objFile->path, array(100, 75, ResizeConfiguration::MODE_BOX))->getUrl($rootDir);
 			}
 		}
 		else

--- a/core-bundle/src/Resources/contao/widgets/ImageSize.php
+++ b/core-bundle/src/Resources/contao/widgets/ImageSize.php
@@ -10,6 +10,8 @@
 
 namespace Contao;
 
+use Contao\CoreBundle\Image\ImageSizes;
+
 /**
  * Provide methods to handle image size fields.
  *
@@ -108,7 +110,7 @@ class ImageSize extends Widget
 
 		$this->import(BackendUser::class, 'User');
 
-		$imageSizes = System::getContainer()->get('contao.image.image_sizes');
+		$imageSizes = System::getContainer()->get(ImageSizes::class);
 		$this->arrAvailableOptions = $this->User->isAdmin ? $imageSizes->getAllOptions() : $imageSizes->getOptionsForUser($this->User);
 
 		if (!$this->isValidOption($varInput[2]))

--- a/core-bundle/src/Resources/contao/widgets/ListWizard.php
+++ b/core-bundle/src/Resources/contao/widgets/ListWizard.php
@@ -10,6 +10,7 @@
 
 namespace Contao;
 
+use Contao\CoreBundle\Controller\BackendCsvImportController;
 use Contao\CoreBundle\Exception\ResponseException;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 
@@ -117,11 +118,11 @@ class ListWizard extends Widget
 	 * @throws ResponseException
 	 *
 	 * @deprecated Deprecated since Contao 4.3 to be removed in 5.0.
-	 *             Use the contao.controller.backend_csv_import service instead.
+	 *             Use the Contao\CoreBundle\Controller\BackendCsvImportController service instead.
 	 */
 	public function importList(DataContainer $dc)
 	{
-		$response = System::getContainer()->get('contao.controller.backend_csv_import')->importListWizardAction($dc);
+		$response = System::getContainer()->get(BackendCsvImportController::class)->importListWizardAction($dc);
 
 		if ($response instanceof RedirectResponse)
 		{

--- a/core-bundle/src/Resources/contao/widgets/PageTree.php
+++ b/core-bundle/src/Resources/contao/widgets/PageTree.php
@@ -10,6 +10,8 @@
 
 namespace Contao;
 
+use Contao\CoreBundle\Picker\PickerBuilder;
+
 /**
  * Provide methods to handle input field "page tree".
  *
@@ -221,7 +223,7 @@ class PageTree extends Widget
 
 		$return .= '</ul>';
 
-		if (!System::getContainer()->get('contao.picker.builder')->supportsContext('page'))
+		if (!System::getContainer()->get(PickerBuilder::class)->supportsContext('page'))
 		{
 			$return .= '
 	<p><button class="tl_submit" disabled>'.$GLOBALS['TL_LANG']['MSC']['changeSelection'].'</button></p>';
@@ -240,7 +242,7 @@ class PageTree extends Widget
 			}
 
 			$return .= '
-    <p><a href="' . ampersand(System::getContainer()->get('contao.picker.builder')->getUrl('page', $extras)) . '" class="tl_submit" id="pt_' . $this->strName . '">'.$GLOBALS['TL_LANG']['MSC']['changeSelection'].'</a></p>
+    <p><a href="' . ampersand(System::getContainer()->get(PickerBuilder::class)->getUrl('page', $extras)) . '" class="tl_submit" id="pt_' . $this->strName . '">'.$GLOBALS['TL_LANG']['MSC']['changeSelection'].'</a></p>
     <script>
       $("pt_' . $this->strName . '").addEvent("click", function(e) {
         e.preventDefault();

--- a/core-bundle/src/Resources/contao/widgets/TableWizard.php
+++ b/core-bundle/src/Resources/contao/widgets/TableWizard.php
@@ -10,6 +10,7 @@
 
 namespace Contao;
 
+use Contao\CoreBundle\Controller\BackendCsvImportController;
 use Contao\CoreBundle\Exception\ResponseException;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 
@@ -168,11 +169,11 @@ class TableWizard extends Widget
 	 * @throws ResponseException
 	 *
 	 * @deprecated Deprecated since Contao 4.3 to be removed in 5.0.
-	 *             Use the contao.controller.backend_csv_import service instead.
+	 *             Use the Contao\CoreBundle\Controller\BackendCsvImportController service instead.
 	 */
 	public function importTable(DataContainer $dc)
 	{
-		$response = System::getContainer()->get('contao.controller.backend_csv_import')->importTableWizardAction($dc);
+		$response = System::getContainer()->get(BackendCsvImportController::class)->importTableWizardAction($dc);
 
 		if ($response instanceof RedirectResponse)
 		{

--- a/core-bundle/src/Routing/ImagesLoader.php
+++ b/core-bundle/src/Routing/ImagesLoader.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Routing;
 
+use Contao\CoreBundle\Controller\ImagesController;
 use Symfony\Component\Config\Loader\Loader;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Routing\Route;
@@ -37,7 +38,7 @@ class ImagesLoader extends Loader
         $route = new Route(
             '/'.$this->pathPrefix.'/{path}',
             [
-                '_controller' => 'contao.controller.images',
+                '_controller' => ImagesController::class,
                 '_bypass_maintenance' => true,
             ],
             ['path' => '.+']

--- a/core-bundle/tests/Asset/ContaoContextTest.php
+++ b/core-bundle/tests/Asset/ContaoContextTest.php
@@ -163,7 +163,7 @@ class ContaoContextTest extends TestCase
         $finder = new ResourceFinder($this->getFixturesDir().'/vendor/contao/test-bundle/Resources/contao');
 
         $container = $this->getContainerWithContaoConfiguration();
-        $container->set('contao.resource_finder', $finder);
+        $container->set(ResourceFinder::class, $finder);
 
         System::setContainer($container);
 

--- a/core-bundle/tests/Contao/ImageTest.php
+++ b/core-bundle/tests/Contao/ImageTest.php
@@ -1440,11 +1440,11 @@ class ImageTest extends TestCase
 
         /** @var DeferredImageInterface $deferredImage */
         $deferredImage = System::getContainer()
-            ->get('contao.image.image_factory')
+            ->get(ImageFactory::class)
             ->create(System::getContainer()->getParameter('kernel.project_dir').'/'.$imageObj->getResizedPath())
         ;
 
-        System::getContainer()->get('contao.image.resizer')->resizeDeferredImage($deferredImage);
+        System::getContainer()->get(LegacyResizer::class)->resizeDeferredImage($deferredImage);
 
         $GLOBALS['TL_HOOKS'] = [
             'getImage' => [[\get_class($this), 'getImageHookCallback']],
@@ -1556,8 +1556,8 @@ class ImageTest extends TestCase
             $container->getParameter('kernel.project_dir').'/'.$container->getParameter('contao.upload_path')
         );
 
-        $container->set('contao.image.resizer', $resizer);
-        $container->set('contao.image.image_factory', $factory);
+        $container->set(LegacyResizer::class, $resizer);
+        $container->set(ImageFactory::class, $factory);
         $container->set('filesystem', new Filesystem());
         $container->set('monolog.logger.contao', new NullLogger());
 

--- a/core-bundle/tests/Contao/PictureTest.php
+++ b/core-bundle/tests/Contao/PictureTest.php
@@ -342,8 +342,8 @@ class PictureTest extends TestCase
 
         $pictureGenerator = new PictureGenerator($resizer);
 
-        $container->set('contao.image.image_factory', $imageFactory);
-        $container->set('contao.image.picture_generator', $pictureGenerator);
+        $container->set(ImageFactory::class, $imageFactory);
+        $container->set(PictureGenerator::class, $pictureGenerator);
 
         return $container;
     }

--- a/core-bundle/tests/Contao/RoutingTest.php
+++ b/core-bundle/tests/Contao/RoutingTest.php
@@ -177,7 +177,7 @@ class RoutingTest extends ContaoTestCase
 
         $container = new ContainerBuilder();
         $container->set('request_stack', $requestStack);
-        $container->set('contao.framework', $this->mockFrameworkWithPageAdapter());
+        $container->set(ContaoFramework::class, $this->mockFrameworkWithPageAdapter());
 
         System::setContainer($container);
 
@@ -208,7 +208,7 @@ class RoutingTest extends ContaoTestCase
 
         $container = new ContainerBuilder();
         $container->set('request_stack', $requestStack);
-        $container->set('contao.framework', $this->mockFrameworkWithPageAdapter());
+        $container->set(ContaoFramework::class, $this->mockFrameworkWithPageAdapter());
 
         System::setContainer($container);
         Config::set('useAutoItem', true);
@@ -240,7 +240,7 @@ class RoutingTest extends ContaoTestCase
 
         $container = new ContainerBuilder();
         $container->set('request_stack', $requestStack);
-        $container->set('contao.framework', $this->mockFrameworkWithPageAdapter());
+        $container->set(ContaoFramework::class, $this->mockFrameworkWithPageAdapter());
 
         System::setContainer($container);
 
@@ -308,7 +308,7 @@ class RoutingTest extends ContaoTestCase
 
         $container = new ContainerBuilder();
         $container->set('request_stack', $requestStack);
-        $container->set('contao.framework', $this->mockFrameworkWithPageAdapter());
+        $container->set(ContaoFramework::class, $this->mockFrameworkWithPageAdapter());
 
         System::setContainer($container);
         Config::set('useAutoItem', true);
@@ -402,7 +402,7 @@ class RoutingTest extends ContaoTestCase
 
         $container = new ContainerBuilder();
         $container->set('request_stack', $requestStack);
-        $container->set('contao.framework', $this->mockFrameworkWithPageAdapter());
+        $container->set(ContaoFramework::class, $this->mockFrameworkWithPageAdapter());
 
         System::setContainer($container);
         Config::set('addLanguageToUrl', true);
@@ -441,7 +441,7 @@ class RoutingTest extends ContaoTestCase
 
         $container = new ContainerBuilder();
         $container->set('request_stack', $requestStack);
-        $container->set('contao.framework', $this->mockFrameworkWithPageAdapter($pageModel));
+        $container->set(ContaoFramework::class, $this->mockFrameworkWithPageAdapter($pageModel));
 
         System::setContainer($container);
 
@@ -500,7 +500,7 @@ class RoutingTest extends ContaoTestCase
 
         $container = new ContainerBuilder();
         $container->set('request_stack', $requestStack);
-        $container->set('contao.framework', $framework);
+        $container->set(ContaoFramework::class, $framework);
 
         System::setContainer($container);
 
@@ -568,7 +568,7 @@ class RoutingTest extends ContaoTestCase
 
         $container = new ContainerBuilder();
         $container->set('request_stack', $requestStack);
-        $container->set('contao.framework', $framework);
+        $container->set(ContaoFramework::class, $framework);
 
         System::setContainer($container);
         Config::set('addLanguageToUrl', true);
@@ -628,7 +628,7 @@ class RoutingTest extends ContaoTestCase
 
         $container = new ContainerBuilder();
         $container->set('request_stack', $requestStack);
-        $container->set('contao.framework', $framework);
+        $container->set(ContaoFramework::class, $framework);
 
         System::setContainer($container);
 

--- a/core-bundle/tests/Controller/BackendControllerTest.php
+++ b/core-bundle/tests/Controller/BackendControllerTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Tests\Controller;
 
 use Contao\CoreBundle\Controller\BackendController;
+use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\CoreBundle\Picker\PickerBuilderInterface;
 use Contao\CoreBundle\Picker\PickerInterface;
 use Contao\CoreBundle\Tests\TestCase;
@@ -43,7 +44,7 @@ class BackendControllerTest extends TestCase
         ;
 
         $container = $this->getContainerWithContaoConfiguration();
-        $container->set('contao.framework', $this->mockContaoFramework());
+        $container->set(ContaoFramework::class, $this->mockContaoFramework());
         $container->set('security.authorization_checker', $authorizationChecker);
         $container->set('router', $router);
 
@@ -68,7 +69,7 @@ class BackendControllerTest extends TestCase
         ;
 
         $container = $this->getContainerWithContaoConfiguration();
-        $container->set('contao.framework', $this->mockContaoFramework());
+        $container->set(ContaoFramework::class, $this->mockContaoFramework());
         $container->set('router', $router);
 
         $controller = new BackendController();

--- a/core-bundle/tests/Controller/BackendCsvImportControllerTest.php
+++ b/core-bundle/tests/Controller/BackendCsvImportControllerTest.php
@@ -43,7 +43,7 @@ class BackendCsvImportControllerTest extends TestCase
 
         $container = $this->getContainerWithContaoConfiguration();
         $container->set('session', new Session(new MockArraySessionStorage()));
-        $container->set('contao.resource_finder', $finder);
+        $container->set(ResourceFinder::class, $finder);
 
         System::setContainer($container);
     }

--- a/core-bundle/tests/Controller/ContentElement/ContentElementControllerTest.php
+++ b/core-bundle/tests/Controller/ContentElement/ContentElementControllerTest.php
@@ -15,6 +15,7 @@ namespace Contao\CoreBundle\Tests\Controller\ContentElement;
 use Contao\ContentModel;
 use Contao\CoreBundle\Fixtures\Controller\ContentElement\TestController;
 use Contao\CoreBundle\Fixtures\Controller\ContentElement\TestSharedMaxAgeController;
+use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\CoreBundle\Tests\TestCase;
 use Contao\FrontendTemplate;
 use Contao\System;
@@ -217,7 +218,7 @@ class ContentElementControllerTest extends TestCase
         ;
 
         $container = new ContainerBuilder();
-        $container->set('contao.framework', $framework);
+        $container->set(ContaoFramework::class, $framework);
 
         return $container;
     }

--- a/core-bundle/tests/Controller/FrontendModule/FrontendModuleControllerTest.php
+++ b/core-bundle/tests/Controller/FrontendModule/FrontendModuleControllerTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Tests\Controller\FrontendModule;
 
 use Contao\CoreBundle\Fixtures\Controller\FrontendModule\TestController;
+use Contao\CoreBundle\Routing\ScopeMatcher;
 use Contao\CoreBundle\Tests\TestCase;
 use Contao\FrontendTemplate;
 use Contao\ModuleModel;
@@ -156,7 +157,7 @@ class FrontendModuleControllerTest extends TestCase
 
         $container = new ContainerBuilder();
         $container->set('contao.framework', $framework);
-        $container->set('contao.routing.scope_matcher', $this->mockScopeMatcher());
+        $container->set(ScopeMatcher::class, $this->mockScopeMatcher());
 
         return $container;
     }

--- a/core-bundle/tests/Controller/FrontendModule/FrontendModuleControllerTest.php
+++ b/core-bundle/tests/Controller/FrontendModule/FrontendModuleControllerTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Tests\Controller\FrontendModule;
 
 use Contao\CoreBundle\Fixtures\Controller\FrontendModule\TestController;
+use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\CoreBundle\Routing\ScopeMatcher;
 use Contao\CoreBundle\Tests\TestCase;
 use Contao\FrontendTemplate;
@@ -156,7 +157,7 @@ class FrontendModuleControllerTest extends TestCase
         ;
 
         $container = new ContainerBuilder();
-        $container->set('contao.framework', $framework);
+        $container->set(ContaoFramework::class, $framework);
         $container->set(ScopeMatcher::class, $this->mockScopeMatcher());
 
         return $container;

--- a/core-bundle/tests/Controller/FrontendModule/TwoFactorControllerTest.php
+++ b/core-bundle/tests/Controller/FrontendModule/TwoFactorControllerTest.php
@@ -334,8 +334,8 @@ class TwoFactorControllerTest extends TestCase
         $services = TwoFactorController::getSubscribedServices();
 
         $this->assertArrayHasKey('contao.framework', $services);
-        $this->assertArrayHasKey('contao.routing.scope_matcher', $services);
-        $this->assertArrayHasKey('contao.security.two_factor.authenticator', $services);
+        $this->assertArrayHasKey(ScopeMatcher::class, $services);
+        $this->assertArrayHasKey(Authenticator::class, $services);
         $this->assertArrayHasKey('security.authentication_utils', $services);
         $this->assertArrayHasKey('security.token_storage', $services);
         $this->assertArrayHasKey('translator', $services);
@@ -463,10 +463,10 @@ class TwoFactorControllerTest extends TestCase
 
         $container = new ContainerBuilder();
         $container->set('contao.framework', $framework);
-        $container->set('contao.routing.scope_matcher', $scopeMatcher);
+        $container->set(ScopeMatcher::class, $scopeMatcher);
         $container->set('translator', $translator);
         $container->set('security.token_storage', $tokenStorage);
-        $container->set('contao.security.two_factor.authenticator', $authenticator);
+        $container->set(Authenticator::class, $authenticator);
         $container->set('security.authentication_utils', $authenticationUtils);
 
         return $container;

--- a/core-bundle/tests/Controller/FrontendModule/TwoFactorControllerTest.php
+++ b/core-bundle/tests/Controller/FrontendModule/TwoFactorControllerTest.php
@@ -14,6 +14,7 @@ namespace Contao\CoreBundle\Tests\Controller\FrontendModule;
 
 use Contao\BackendUser;
 use Contao\CoreBundle\Controller\FrontendModule\TwoFactorController;
+use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\CoreBundle\Routing\ScopeMatcher;
 use Contao\CoreBundle\Security\TwoFactor\Authenticator;
 use Contao\CoreBundle\Tests\TestCase;
@@ -333,9 +334,6 @@ class TwoFactorControllerTest extends TestCase
     {
         $services = TwoFactorController::getSubscribedServices();
 
-        $this->assertArrayHasKey('contao.framework', $services);
-        $this->assertArrayHasKey(ScopeMatcher::class, $services);
-        $this->assertArrayHasKey(Authenticator::class, $services);
         $this->assertArrayHasKey('security.authentication_utils', $services);
         $this->assertArrayHasKey('security.token_storage', $services);
         $this->assertArrayHasKey('translator', $services);
@@ -462,7 +460,7 @@ class TwoFactorControllerTest extends TestCase
         $translator = $this->createMock(Translator::class);
 
         $container = new ContainerBuilder();
-        $container->set('contao.framework', $framework);
+        $container->set(ContaoFramework::class, $framework);
         $container->set(ScopeMatcher::class, $scopeMatcher);
         $container->set('translator', $translator);
         $container->set('security.token_storage', $tokenStorage);

--- a/core-bundle/tests/DependencyInjection/Compiler/DataContainerCallbackPassTest.php
+++ b/core-bundle/tests/DependencyInjection/Compiler/DataContainerCallbackPassTest.php
@@ -490,7 +490,7 @@ class DataContainerCallbackPassTest extends TestCase
     }
 
     /**
-     * Returns the container builder with a dummy contao.framework definition.
+     * Returns the container builder with a dummy Contao framework definition.
      */
     private function getContainerBuilder(): ContainerBuilder
     {

--- a/core-bundle/tests/DependencyInjection/Compiler/PickerProviderPassTest.php
+++ b/core-bundle/tests/DependencyInjection/Compiler/PickerProviderPassTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Tests\DependencyInjection\Compiler;
 
 use Contao\CoreBundle\DependencyInjection\Compiler\PickerProviderPass;
+use Contao\CoreBundle\Picker\PickerBuilder;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -23,7 +24,7 @@ class PickerProviderPassTest extends TestCase
     public function testAddsTheProvidersToThePickerBuilder(): void
     {
         $container = new ContainerBuilder();
-        $container->setDefinition('contao.picker.builder', new Definition());
+        $container->setDefinition(PickerBuilder::class, new Definition());
 
         $definition = new Definition();
         $definition->addTag('contao.picker_provider');
@@ -33,7 +34,7 @@ class PickerProviderPassTest extends TestCase
         $pass = new PickerProviderPass();
         $pass->process($container);
 
-        $methodCalls = $container->findDefinition('contao.picker.builder')->getMethodCalls();
+        $methodCalls = $container->findDefinition(PickerBuilder::class)->getMethodCalls();
 
         $this->assertCount(1, $methodCalls);
         $this->assertSame('addProvider', $methodCalls[0][0]);

--- a/core-bundle/tests/DependencyInjection/Compiler/RegisterHookListenersPassTest.php
+++ b/core-bundle/tests/DependencyInjection/Compiler/RegisterHookListenersPassTest.php
@@ -254,7 +254,7 @@ class RegisterHookListenersPassTest extends TestCase
         $container = $this->createMock(ContainerBuilder::class);
         $container
             ->method('hasDefinition')
-            ->with('contao.framework')
+            ->with(ContaoFramework::class)
             ->willReturn(false)
         ;
 
@@ -274,7 +274,7 @@ class RegisterHookListenersPassTest extends TestCase
         $pass = new RegisterHookListenersPass();
         $pass->process($container);
 
-        $definition = $container->getDefinition('contao.framework');
+        $definition = $container->getDefinition(ContaoFramework::class);
 
         $this->assertEmpty($definition->getMethodCalls());
     }
@@ -299,9 +299,9 @@ class RegisterHookListenersPassTest extends TestCase
      */
     private function getHookListenersFromDefinition(ContainerBuilder $container): array
     {
-        $this->assertTrue($container->hasDefinition('contao.framework'));
+        $this->assertTrue($container->hasDefinition(ContaoFramework::class));
 
-        $definition = $container->getDefinition('contao.framework');
+        $definition = $container->getDefinition(ContaoFramework::class);
         $methodCalls = $definition->getMethodCalls();
 
         $this->assertIsArray($methodCalls);
@@ -312,12 +312,12 @@ class RegisterHookListenersPassTest extends TestCase
     }
 
     /**
-     * Returns the container builder with a dummy contao.framework definition.
+     * Returns the container builder with a dummy Contao framework definition.
      */
     private function getContainerBuilder(): ContainerBuilder
     {
         $container = new ContainerBuilder();
-        $container->setDefinition('contao.framework', new Definition(ContaoFramework::class, []));
+        $container->setDefinition(ContaoFramework::class, new Definition(ContaoFramework::class, []));
 
         return $container;
     }

--- a/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
+++ b/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
@@ -308,7 +308,7 @@ class ContaoCoreExtensionTest extends TestCase
 
         $this->assertSame(BypassMaintenanceListener::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
-        $this->assertSame('contao.security.token_checker', (string) $definition->getArgument(0));
+        $this->assertSame(TokenChecker::class, (string) $definition->getArgument(0));
 
         $tags = $definition->getTags();
 
@@ -490,7 +490,7 @@ class ContaoCoreExtensionTest extends TestCase
         $this->assertSame(LocaleListener::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
         $this->assertSame('translator', (string) $definition->getArgument(0));
-        $this->assertSame('contao.routing.scope_matcher', (string) $definition->getArgument(1));
+        $this->assertSame(ScopeMatcher::class, (string) $definition->getArgument(1));
         $this->assertSame('%contao.locales%', (string) $definition->getArgument(2));
 
         $tags = $definition->getTags();
@@ -553,7 +553,7 @@ class ContaoCoreExtensionTest extends TestCase
         $this->assertSame(RefererIdListener::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
         $this->assertSame('contao.token_generator', (string) $definition->getArgument(0));
-        $this->assertSame('contao.routing.scope_matcher', (string) $definition->getArgument(1));
+        $this->assertSame(ScopeMatcher::class, (string) $definition->getArgument(1));
 
         $tags = $definition->getTags();
 
@@ -572,7 +572,7 @@ class ContaoCoreExtensionTest extends TestCase
         $this->assertSame(RequestTokenListener::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
         $this->assertSame('contao.framework', (string) $definition->getArgument(0));
-        $this->assertSame('contao.routing.scope_matcher', (string) $definition->getArgument(1));
+        $this->assertSame(ScopeMatcher::class, (string) $definition->getArgument(1));
         $this->assertSame('contao.csrf.token_manager', (string) $definition->getArgument(2));
         $this->assertSame('%contao.csrf_token_name%', (string) $definition->getArgument(3));
         $this->assertSame('%contao.csrf_cookie_prefix%', (string) $definition->getArgument(4));
@@ -611,7 +611,7 @@ class ContaoCoreExtensionTest extends TestCase
         $this->assertSame(StoreRefererListener::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
         $this->assertSame('security.helper', (string) $definition->getArgument(0));
-        $this->assertSame('contao.routing.scope_matcher', (string) $definition->getArgument(1));
+        $this->assertSame(ScopeMatcher::class, (string) $definition->getArgument(1));
 
         $tags = $definition->getTags();
 
@@ -647,7 +647,7 @@ class ContaoCoreExtensionTest extends TestCase
         $this->assertSame(TwoFactorFrontendListener::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
         $this->assertSame('contao.framework', (string) $definition->getArgument(0));
-        $this->assertSame('contao.routing.scope_matcher', (string) $definition->getArgument(1));
+        $this->assertSame(ScopeMatcher::class, (string) $definition->getArgument(1));
         $this->assertSame('security.token_storage', (string) $definition->getArgument(2));
         $this->assertSame('%scheb_two_factor.security_tokens%', (string) $definition->getArgument(3));
 
@@ -668,7 +668,7 @@ class ContaoCoreExtensionTest extends TestCase
         $this->assertTrue($definition->isPrivate());
         $this->assertSame('database_connection', (string) $definition->getArgument(0));
         $this->assertSame('security.helper', (string) $definition->getArgument(1));
-        $this->assertSame('contao.routing.scope_matcher', (string) $definition->getArgument(2));
+        $this->assertSame(ScopeMatcher::class, (string) $definition->getArgument(2));
         $this->assertSame('event_dispatcher', (string) $definition->getArgument(3));
 
         $tags = $definition->getTags();
@@ -728,7 +728,7 @@ class ContaoCoreExtensionTest extends TestCase
         $this->assertSame(ContaoCacheWarmer::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
         $this->assertSame('filesystem', (string) $definition->getArgument(0));
-        $this->assertSame('contao.resource_finder', (string) $definition->getArgument(1));
+        $this->assertSame(ResourceFinder::class, (string) $definition->getArgument(1));
         $this->assertSame('contao.resource_locator', (string) $definition->getArgument(2));
         $this->assertSame('%kernel.project_dir%', (string) $definition->getArgument(3));
         $this->assertSame('database_connection', (string) $definition->getArgument(4));
@@ -741,11 +741,10 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheBackendCsvImportController(): void
     {
-        $this->assertTrue($this->container->has('contao.controller.backend_csv_import'));
+        $this->assertTrue($this->container->has(BackendCsvImportController::class));
 
-        $definition = $this->container->getDefinition('contao.controller.backend_csv_import');
+        $definition = $this->container->getDefinition(BackendCsvImportController::class);
 
-        $this->assertSame(BackendCsvImportController::class, $definition->getClass());
         $this->assertTrue($definition->isPublic());
         $this->assertSame('contao.framework', (string) $definition->getArgument(0));
         $this->assertSame('database_connection', (string) $definition->getArgument(1));
@@ -777,9 +776,9 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function tesRegistersTheInsertTagsController(): void
     {
-        $this->assertTrue($this->container->has('contao.controller.insert_tags'));
+        $this->assertTrue($this->container->has(InsertTagsController::class));
 
-        $definition = $this->container->getDefinition('contao.controller.insert_tags');
+        $definition = $this->container->getDefinition(InsertTagsController::class);
 
         $this->assertSame(InsertTagsController::class, $definition->getClass());
         $this->assertTrue($definition->isPublic());
@@ -938,15 +937,14 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheContaoFramework(): void
     {
-        $this->assertTrue($this->container->has('contao.framework'));
+        $this->assertTrue($this->container->has(ContaoFramework::class));
 
-        $definition = $this->container->getDefinition('contao.framework');
+        $definition = $this->container->getDefinition(ContaoFramework::class);
 
-        $this->assertSame(ContaoFramework::class, $definition->getClass());
         $this->assertTrue($definition->isPublic());
         $this->assertSame('request_stack', (string) $definition->getArgument(0));
-        $this->assertSame('contao.routing.scope_matcher', (string) $definition->getArgument(1));
-        $this->assertSame('contao.security.token_checker', (string) $definition->getArgument(2));
+        $this->assertSame(ScopeMatcher::class, (string) $definition->getArgument(1));
+        $this->assertSame(TokenChecker::class, (string) $definition->getArgument(2));
         $this->assertSame('%kernel.project_dir%', (string) $definition->getArgument(3));
         $this->assertSame('%contao.error_level%', (string) $definition->getArgument(4));
 
@@ -991,11 +989,10 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheImageResizer(): void
     {
-        $this->assertTrue($this->container->has('contao.image.resizer'));
+        $this->assertTrue($this->container->has(LegacyResizer::class));
 
-        $definition = $this->container->getDefinition('contao.image.resizer');
+        $definition = $this->container->getDefinition(LegacyResizer::class);
 
-        $this->assertSame(LegacyResizer::class, $definition->getClass());
         $this->assertTrue($definition->isPublic());
         $this->assertSame('%contao.image.target_dir%', (string) $definition->getArgument(0));
         $this->assertSame('contao.image.resize_calculator', (string) $definition->getArgument(1));
@@ -1013,15 +1010,14 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheImageFactory(): void
     {
-        $this->assertTrue($this->container->has('contao.image.image_factory'));
+        $this->assertTrue($this->container->has(ImageFactory::class));
 
-        $definition = $this->container->getDefinition('contao.image.image_factory');
+        $definition = $this->container->getDefinition(ImageFactory::class);
 
-        $this->assertSame(ImageFactory::class, $definition->getClass());
         $this->assertTrue($definition->isPublic());
-        $this->assertSame('contao.image.resizer', (string) $definition->getArgument(0));
+        $this->assertSame(LegacyResizer::class, (string) $definition->getArgument(0));
         $this->assertSame('contao.image.imagine', (string) $definition->getArgument(1));
-        $this->assertSame('contao.image.imagine_svg', (string) $definition->getArgument(2));
+        $this->assertSame(ImagineSvg::class, (string) $definition->getArgument(2));
         $this->assertSame('filesystem', (string) $definition->getArgument(3));
         $this->assertSame('contao.framework', (string) $definition->getArgument(4));
         $this->assertSame('%contao.image.bypass_cache%', (string) $definition->getArgument(5));
@@ -1031,11 +1027,10 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheImageSizesService(): void
     {
-        $this->assertTrue($this->container->has('contao.image.image_sizes'));
+        $this->assertTrue($this->container->has(ImageSizes::class));
 
-        $definition = $this->container->getDefinition('contao.image.image_sizes');
+        $definition = $this->container->getDefinition(ImageSizes::class);
 
-        $this->assertSame(ImageSizes::class, $definition->getClass());
         $this->assertTrue($definition->isPublic());
         $this->assertSame('database_connection', (string) $definition->getArgument(0));
         $this->assertSame('event_dispatcher', (string) $definition->getArgument(1));
@@ -1044,26 +1039,24 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheImagePictureGenerator(): void
     {
-        $this->assertTrue($this->container->has('contao.image.picture_generator'));
+        $this->assertTrue($this->container->has(PictureGenerator::class));
 
-        $definition = $this->container->getDefinition('contao.image.picture_generator');
+        $definition = $this->container->getDefinition(PictureGenerator::class);
 
-        $this->assertSame(PictureGenerator::class, $definition->getClass());
         $this->assertTrue($definition->isPublic());
-        $this->assertSame('contao.image.resizer', (string) $definition->getArgument(0));
+        $this->assertSame(LegacyResizer::class, (string) $definition->getArgument(0));
         $this->assertSame('contao.image.resize_calculator', (string) $definition->getArgument(1));
     }
 
     public function testRegistersTheImagePictureFactory(): void
     {
-        $this->assertTrue($this->container->has('contao.image.picture_factory'));
+        $this->assertTrue($this->container->has(PictureFactory::class));
 
-        $definition = $this->container->getDefinition('contao.image.picture_factory');
+        $definition = $this->container->getDefinition(PictureFactory::class);
 
-        $this->assertSame(PictureFactory::class, $definition->getClass());
         $this->assertTrue($definition->isPublic());
-        $this->assertSame('contao.image.picture_generator', (string) $definition->getArgument(0));
-        $this->assertSame('contao.image.image_factory', (string) $definition->getArgument(1));
+        $this->assertSame(PictureGenerator::class, (string) $definition->getArgument(0));
+        $this->assertSame(ImageFactory::class, (string) $definition->getArgument(1));
         $this->assertSame('contao.framework', (string) $definition->getArgument(2));
         $this->assertSame('%contao.image.bypass_cache%', (string) $definition->getArgument(3));
         $this->assertSame('%contao.image.imagine_options%', (string) $definition->getArgument(4));
@@ -1071,22 +1064,20 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheBackendMenuRenderer(): void
     {
-        $this->assertTrue($this->container->has('contao.menu.backend_menu_renderer'));
+        $this->assertTrue($this->container->has(BackendMenuRenderer::class));
 
-        $definition = $this->container->getDefinition('contao.menu.backend_menu_renderer');
+        $definition = $this->container->getDefinition(BackendMenuRenderer::class);
 
-        $this->assertSame(BackendMenuRenderer::class, $definition->getClass());
         $this->assertTrue($definition->isPublic());
         $this->assertSame('twig', (string) $definition->getArgument(0));
     }
 
     public function testRegistersTheBackendMenuBuilder(): void
     {
-        $this->assertTrue($this->container->has('contao.menu.backend_menu_builder'));
+        $this->assertTrue($this->container->has(BackendMenuBuilder::class));
 
-        $definition = $this->container->getDefinition('contao.menu.backend_menu_builder');
+        $definition = $this->container->getDefinition(BackendMenuBuilder::class);
 
-        $this->assertSame(BackendMenuBuilder::class, $definition->getClass());
         $this->assertTrue($definition->isPublic());
         $this->assertSame('knp_menu.factory', (string) $definition->getArgument(0));
         $this->assertSame('event_dispatcher', (string) $definition->getArgument(1));
@@ -1115,14 +1106,13 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheModelArgumentResolver(): void
     {
-        $this->assertTrue($this->container->has('contao.model_argument_resolver'));
+        $this->assertTrue($this->container->has(ModelArgumentResolver::class));
 
-        $definition = $this->container->getDefinition('contao.model_argument_resolver');
+        $definition = $this->container->getDefinition(ModelArgumentResolver::class);
 
-        $this->assertSame(ModelArgumentResolver::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
         $this->assertSame('contao.framework', (string) $definition->getArgument(0));
-        $this->assertSame('contao.routing.scope_matcher', (string) $definition->getArgument(1));
+        $this->assertSame(ScopeMatcher::class, (string) $definition->getArgument(1));
 
         $tags = $definition->getTags();
 
@@ -1166,7 +1156,7 @@ class ContaoCoreExtensionTest extends TestCase
         $this->assertTrue($definition->isPrivate());
         $this->assertSame('request_stack', (string) $definition->getArgument(0));
         $this->assertSame('security.token_storage', (string) $definition->getArgument(1));
-        $this->assertSame('contao.routing.scope_matcher', (string) $definition->getArgument(2));
+        $this->assertSame(ScopeMatcher::class, (string) $definition->getArgument(2));
 
         $tags = $definition->getTags();
 
@@ -1175,22 +1165,20 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheOptInService(): void
     {
-        $this->assertTrue($this->container->has('contao.opt-in'));
+        $this->assertTrue($this->container->has(OptIn::class));
 
-        $definition = $this->container->getDefinition('contao.opt-in');
+        $definition = $this->container->getDefinition(OptIn::class);
 
-        $this->assertSame(OptIn::class, $definition->getClass());
         $this->assertTrue($definition->isPublic());
         $this->assertSame('contao.framework', (string) $definition->getArgument(0));
     }
 
     public function testRegistersThePickerBuilder(): void
     {
-        $this->assertTrue($this->container->has('contao.picker.builder'));
+        $this->assertTrue($this->container->has(PickerBuilder::class));
 
-        $definition = $this->container->getDefinition('contao.picker.builder');
+        $definition = $this->container->getDefinition(PickerBuilder::class);
 
-        $this->assertSame(PickerBuilder::class, $definition->getClass());
         $this->assertTrue($definition->isPublic());
         $this->assertSame('knp_menu.factory', (string) $definition->getArgument(0));
         $this->assertSame('router', (string) $definition->getArgument(1));
@@ -1267,11 +1255,10 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheResourceFinder(): void
     {
-        $this->assertTrue($this->container->has('contao.resource_finder'));
+        $this->assertTrue($this->container->has(ResourceFinder::class));
 
-        $definition = $this->container->getDefinition('contao.resource_finder');
+        $definition = $this->container->getDefinition(ResourceFinder::class);
 
-        $this->assertSame(ResourceFinder::class, $definition->getClass());
         $this->assertTrue($definition->isPublic());
         $this->assertSame('%contao.resources_paths%', $definition->getArgument(0));
     }
@@ -1475,7 +1462,7 @@ class ContaoCoreExtensionTest extends TestCase
 
         $this->assertSame(PublishedFilter::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
-        $this->assertSame('contao.security.token_checker', (string) $definition->getArgument(0));
+        $this->assertSame(TokenChecker::class, (string) $definition->getArgument(0));
     }
 
     public function testRegistersTheRoutingRouteGenerator(): void
@@ -1506,11 +1493,10 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheRoutingScopeMatcher(): void
     {
-        $this->assertTrue($this->container->has('contao.routing.scope_matcher'));
+        $this->assertTrue($this->container->has(ScopeMatcher::class));
 
-        $definition = $this->container->getDefinition('contao.routing.scope_matcher');
+        $definition = $this->container->getDefinition(ScopeMatcher::class);
 
-        $this->assertSame(ScopeMatcher::class, $definition->getClass());
         $this->assertTrue($definition->isPublic());
         $this->assertSame('contao.routing.backend_matcher', (string) $definition->getArgument(0));
         $this->assertSame('contao.routing.frontend_matcher', (string) $definition->getArgument(1));
@@ -1518,11 +1504,10 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheRoutingUrlGenerator(): void
     {
-        $this->assertTrue($this->container->has('contao.routing.url_generator'));
+        $this->assertTrue($this->container->has(UrlGenerator::class));
 
-        $definition = $this->container->getDefinition('contao.routing.url_generator');
+        $definition = $this->container->getDefinition(UrlGenerator::class);
 
-        $this->assertSame(UrlGenerator::class, $definition->getClass());
         $this->assertTrue($definition->isPublic());
         $this->assertSame('router', (string) $definition->getArgument(0));
         $this->assertSame('contao.framework', (string) $definition->getArgument(1));
@@ -1634,11 +1619,10 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheSecurityFrontendPreviewAuthenticator(): void
     {
-        $this->assertTrue($this->container->has('contao.security.frontend_preview_authenticator'));
+        $this->assertTrue($this->container->has(FrontendPreviewAuthenticator::class));
 
-        $definition = $this->container->getDefinition('contao.security.frontend_preview_authenticator');
+        $definition = $this->container->getDefinition(FrontendPreviewAuthenticator::class);
 
-        $this->assertSame(FrontendPreviewAuthenticator::class, $definition->getClass());
         $this->assertFalse($definition->isPrivate());
         $this->assertSame('security.helper', (string) $definition->getArgument(0));
         $this->assertSame('session', (string) $definition->getArgument(1));
@@ -1669,7 +1653,7 @@ class ContaoCoreExtensionTest extends TestCase
         $this->assertSame(LogoutSuccessHandler::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
         $this->assertSame('security.http_utils', (string) $definition->getArgument(0));
-        $this->assertSame('contao.routing.scope_matcher', (string) $definition->getArgument(1));
+        $this->assertSame(ScopeMatcher::class, (string) $definition->getArgument(1));
     }
 
     public function testRegistersTheSecurityLogoutHandler(): void
@@ -1686,11 +1670,10 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheSecurityTokenChecker(): void
     {
-        $this->assertTrue($this->container->has('contao.security.token_checker'));
+        $this->assertTrue($this->container->has(TokenChecker::class));
 
-        $definition = $this->container->getDefinition('contao.security.token_checker');
+        $definition = $this->container->getDefinition(TokenChecker::class);
 
-        $this->assertSame(TokenChecker::class, $definition->getClass());
         $this->assertTrue($definition->isPublic());
         $this->assertSame('request_stack', (string) $definition->getArgument(0));
         $this->assertSame('security.firewall.map', (string) $definition->getArgument(1));
@@ -1702,11 +1685,10 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheSecurityTwoFactorAuthenticator(): void
     {
-        $this->assertTrue($this->container->has('contao.security.two_factor.authenticator'));
+        $this->assertTrue($this->container->has(Authenticator::class));
 
-        $definition = $this->container->getDefinition('contao.security.two_factor.authenticator');
+        $definition = $this->container->getDefinition(Authenticator::class);
 
-        $this->assertSame(Authenticator::class, $definition->getClass());
         $this->assertTrue($definition->isPublic());
     }
 
@@ -1718,7 +1700,7 @@ class ContaoCoreExtensionTest extends TestCase
 
         $this->assertSame(Provider::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
-        $this->assertSame('contao.security.two_factor.authenticator', (string) $definition->getArgument(0));
+        $this->assertSame(Authenticator::class, (string) $definition->getArgument(0));
 
         $tags = $definition->getTags();
 
@@ -1781,11 +1763,10 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheSlugService(): void
     {
-        $this->assertTrue($this->container->has('contao.slug'));
+        $this->assertTrue($this->container->has(Slug::class));
 
-        $definition = $this->container->getDefinition('contao.slug');
+        $definition = $this->container->getDefinition(Slug::class);
 
-        $this->assertSame(Slug::class, $definition->getClass());
         $this->assertTrue($definition->isPublic());
         $this->assertSame('contao.slug.generator', (string) $definition->getArgument(0));
         $this->assertSame('contao.framework', (string) $definition->getArgument(1));
@@ -1804,11 +1785,10 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheSlugValidCharactersService(): void
     {
-        $this->assertTrue($this->container->has('contao.slug.valid_characters'));
+        $this->assertTrue($this->container->has(ValidCharacters::class));
 
-        $definition = $this->container->getDefinition('contao.slug.valid_characters');
+        $definition = $this->container->getDefinition(ValidCharacters::class);
 
-        $this->assertSame(ValidCharacters::class, $definition->getClass());
         $this->assertTrue($definition->isPublic());
         $this->assertSame('event_dispatcher', (string) $definition->getArgument(0));
         $this->assertSame('translator', (string) $definition->getArgument(1));
@@ -1849,7 +1829,7 @@ class ContaoCoreExtensionTest extends TestCase
         $this->assertTrue($definition->isPrivate());
         $this->assertSame('request_stack', (string) $definition->getArgument(0));
         $this->assertSame('contao.framework', (string) $definition->getArgument(1));
-        $this->assertSame('contao.routing.scope_matcher', (string) $definition->getArgument(2));
+        $this->assertSame(ScopeMatcher::class, (string) $definition->getArgument(2));
 
         $tags = $definition->getTags();
 
@@ -1858,7 +1838,7 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersThePredefinedImageSizes(): void
     {
-        $services = ['contao.image.image_sizes', 'contao.image.image_factory', 'contao.image.picture_factory'];
+        $services = [ImageSizes::class, ImageFactory::class, PictureFactory::class];
 
         $extension = new ContaoCoreExtension();
         $extension->load([], $this->container);

--- a/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
+++ b/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
@@ -254,7 +254,7 @@ class ContaoCoreExtensionTest extends TestCase
 
         $this->assertSame(AddToSearchIndexListener::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
-        $this->assertSame('contao.framework', (string) $definition->getArgument(0));
+        $this->assertSame(ContaoFramework::class, (string) $definition->getArgument(0));
         $this->assertSame('%fragment.path%', (string) $definition->getArgument(1));
 
         $tags = $definition->getTags();
@@ -368,7 +368,7 @@ class ContaoCoreExtensionTest extends TestCase
 
         $this->assertSame(CommandSchedulerListener::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
-        $this->assertSame('contao.framework', (string) $definition->getArgument(0));
+        $this->assertSame(ContaoFramework::class, (string) $definition->getArgument(0));
         $this->assertSame('database_connection', (string) $definition->getArgument(1));
         $this->assertSame('%fragment.path%', (string) $definition->getArgument(2));
 
@@ -512,7 +512,7 @@ class ContaoCoreExtensionTest extends TestCase
 
         $this->assertSame(MergeHttpHeadersListener::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
-        $this->assertSame('contao.framework', (string) $definition->getArgument(0));
+        $this->assertSame(ContaoFramework::class, (string) $definition->getArgument(0));
 
         $tags = $definition->getTags();
 
@@ -532,7 +532,7 @@ class ContaoCoreExtensionTest extends TestCase
         $this->assertTrue($definition->isPrivate());
         $this->assertSame('%contao.pretty_error_screens%', (string) $definition->getArgument(0));
         $this->assertSame('twig', (string) $definition->getArgument(1));
-        $this->assertSame('contao.framework', (string) $definition->getArgument(2));
+        $this->assertSame(ContaoFramework::class, (string) $definition->getArgument(2));
         $this->assertSame('security.helper', (string) $definition->getArgument(3));
         $this->assertSame('logger', (string) $definition->getArgument(4));
 
@@ -571,7 +571,7 @@ class ContaoCoreExtensionTest extends TestCase
 
         $this->assertSame(RequestTokenListener::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
-        $this->assertSame('contao.framework', (string) $definition->getArgument(0));
+        $this->assertSame(ContaoFramework::class, (string) $definition->getArgument(0));
         $this->assertSame(ScopeMatcher::class, (string) $definition->getArgument(1));
         $this->assertSame('contao.csrf.token_manager', (string) $definition->getArgument(2));
         $this->assertSame('%contao.csrf_token_name%', (string) $definition->getArgument(3));
@@ -646,7 +646,7 @@ class ContaoCoreExtensionTest extends TestCase
 
         $this->assertSame(TwoFactorFrontendListener::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
-        $this->assertSame('contao.framework', (string) $definition->getArgument(0));
+        $this->assertSame(ContaoFramework::class, (string) $definition->getArgument(0));
         $this->assertSame(ScopeMatcher::class, (string) $definition->getArgument(1));
         $this->assertSame('security.token_storage', (string) $definition->getArgument(2));
         $this->assertSame('%scheb_two_factor.security_tokens%', (string) $definition->getArgument(3));
@@ -732,7 +732,7 @@ class ContaoCoreExtensionTest extends TestCase
         $this->assertSame('contao.resource_locator', (string) $definition->getArgument(2));
         $this->assertSame('%kernel.project_dir%', (string) $definition->getArgument(3));
         $this->assertSame('database_connection', (string) $definition->getArgument(4));
-        $this->assertSame('contao.framework', (string) $definition->getArgument(5));
+        $this->assertSame(ContaoFramework::class, (string) $definition->getArgument(5));
 
         $tags = $definition->getTags();
 
@@ -746,7 +746,7 @@ class ContaoCoreExtensionTest extends TestCase
         $definition = $this->container->getDefinition(BackendCsvImportController::class);
 
         $this->assertTrue($definition->isPublic());
-        $this->assertSame('contao.framework', (string) $definition->getArgument(0));
+        $this->assertSame(ContaoFramework::class, (string) $definition->getArgument(0));
         $this->assertSame('database_connection', (string) $definition->getArgument(1));
         $this->assertSame('request_stack', (string) $definition->getArgument(2));
         $this->assertSame('translator', (string) $definition->getArgument(3));
@@ -782,7 +782,7 @@ class ContaoCoreExtensionTest extends TestCase
 
         $this->assertSame(InsertTagsController::class, $definition->getClass());
         $this->assertTrue($definition->isPublic());
-        $this->assertSame('contao.framework', (string) $definition->getArgument(0));
+        $this->assertSame(ContaoFramework::class, (string) $definition->getArgument(0));
     }
 
     public function testRegistersTheControllerResolver(): void
@@ -867,7 +867,7 @@ class ContaoCoreExtensionTest extends TestCase
 
         $this->assertSame(DcaSchemaProvider::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
-        $this->assertSame('contao.framework', (string) $definition->getArgument(0));
+        $this->assertSame(ContaoFramework::class, (string) $definition->getArgument(0));
         $this->assertSame('doctrine', (string) $definition->getArgument(1));
     }
 
@@ -1017,9 +1017,9 @@ class ContaoCoreExtensionTest extends TestCase
         $this->assertTrue($definition->isPublic());
         $this->assertSame(LegacyResizer::class, (string) $definition->getArgument(0));
         $this->assertSame('contao.image.imagine', (string) $definition->getArgument(1));
-        $this->assertSame(ImagineSvg::class, (string) $definition->getArgument(2));
+        $this->assertSame('contao.image.imagine_svg', (string) $definition->getArgument(2));
         $this->assertSame('filesystem', (string) $definition->getArgument(3));
-        $this->assertSame('contao.framework', (string) $definition->getArgument(4));
+        $this->assertSame(ContaoFramework::class, (string) $definition->getArgument(4));
         $this->assertSame('%contao.image.bypass_cache%', (string) $definition->getArgument(5));
         $this->assertSame('%contao.image.imagine_options%', (string) $definition->getArgument(6));
         $this->assertSame('%contao.image.valid_extensions%', (string) $definition->getArgument(7));
@@ -1034,7 +1034,7 @@ class ContaoCoreExtensionTest extends TestCase
         $this->assertTrue($definition->isPublic());
         $this->assertSame('database_connection', (string) $definition->getArgument(0));
         $this->assertSame('event_dispatcher', (string) $definition->getArgument(1));
-        $this->assertSame('contao.framework', (string) $definition->getArgument(2));
+        $this->assertSame(ContaoFramework::class, (string) $definition->getArgument(2));
     }
 
     public function testRegistersTheImagePictureGenerator(): void
@@ -1057,7 +1057,7 @@ class ContaoCoreExtensionTest extends TestCase
         $this->assertTrue($definition->isPublic());
         $this->assertSame(PictureGenerator::class, (string) $definition->getArgument(0));
         $this->assertSame(ImageFactory::class, (string) $definition->getArgument(1));
-        $this->assertSame('contao.framework', (string) $definition->getArgument(2));
+        $this->assertSame(ContaoFramework::class, (string) $definition->getArgument(2));
         $this->assertSame('%contao.image.bypass_cache%', (string) $definition->getArgument(3));
         $this->assertSame('%contao.image.imagine_options%', (string) $definition->getArgument(4));
     }
@@ -1111,7 +1111,7 @@ class ContaoCoreExtensionTest extends TestCase
         $definition = $this->container->getDefinition(ModelArgumentResolver::class);
 
         $this->assertTrue($definition->isPrivate());
-        $this->assertSame('contao.framework', (string) $definition->getArgument(0));
+        $this->assertSame(ContaoFramework::class, (string) $definition->getArgument(0));
         $this->assertSame(ScopeMatcher::class, (string) $definition->getArgument(1));
 
         $tags = $definition->getTags();
@@ -1170,7 +1170,7 @@ class ContaoCoreExtensionTest extends TestCase
         $definition = $this->container->getDefinition(OptIn::class);
 
         $this->assertTrue($definition->isPublic());
-        $this->assertSame('contao.framework', (string) $definition->getArgument(0));
+        $this->assertSame(ContaoFramework::class, (string) $definition->getArgument(0));
     }
 
     public function testRegistersThePickerBuilder(): void
@@ -1365,7 +1365,7 @@ class ContaoCoreExtensionTest extends TestCase
 
         $this->assertSame(InputEnhancer::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
-        $this->assertSame('contao.framework', (string) $definition->getArgument(0));
+        $this->assertSame(ContaoFramework::class, (string) $definition->getArgument(0));
         $this->assertSame('%contao.prepend_locale%', (string) $definition->getArgument(1));
     }
 
@@ -1389,7 +1389,7 @@ class ContaoCoreExtensionTest extends TestCase
         $this->assertSame(LegacyMatcher::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
         $this->assertSame('contao.routing.nested_matcher', $definition->getDecoratedService()[0]);
-        $this->assertSame('contao.framework', (string) $definition->getArgument(0));
+        $this->assertSame(ContaoFramework::class, (string) $definition->getArgument(0));
         $this->assertSame('contao.routing.legacy_matcher.inner', (string) $definition->getArgument(1));
         $this->assertSame('%contao.url_suffix%', (string) $definition->getArgument(2));
         $this->assertSame('%contao.prepend_locale%', (string) $definition->getArgument(3));
@@ -1485,7 +1485,7 @@ class ContaoCoreExtensionTest extends TestCase
 
         $this->assertSame(RouteProvider::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
-        $this->assertSame('contao.framework', (string) $definition->getArgument(0));
+        $this->assertSame(ContaoFramework::class, (string) $definition->getArgument(0));
         $this->assertSame('database_connection', (string) $definition->getArgument(1));
         $this->assertSame('%contao.url_suffix%', (string) $definition->getArgument(2));
         $this->assertSame('%contao.prepend_locale%', (string) $definition->getArgument(3));
@@ -1510,7 +1510,7 @@ class ContaoCoreExtensionTest extends TestCase
 
         $this->assertTrue($definition->isPublic());
         $this->assertSame('router', (string) $definition->getArgument(0));
-        $this->assertSame('contao.framework', (string) $definition->getArgument(1));
+        $this->assertSame(ContaoFramework::class, (string) $definition->getArgument(1));
         $this->assertSame('%contao.prepend_locale%', (string) $definition->getArgument(2));
     }
 
@@ -1540,7 +1540,7 @@ class ContaoCoreExtensionTest extends TestCase
         $this->assertNull($definition->getArgument(1));
         $this->assertNull($definition->getArgument(2));
         $this->assertSame('security.encoder_factory', (string) $definition->getArgument(3));
-        $this->assertSame('contao.framework', (string) $definition->getArgument(4));
+        $this->assertSame(ContaoFramework::class, (string) $definition->getArgument(4));
     }
 
     public function testRegistersTheSecurityAuthenticationSuccessHandler(): void
@@ -1552,7 +1552,7 @@ class ContaoCoreExtensionTest extends TestCase
         $this->assertSame(AuthenticationSuccessHandler::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
         $this->assertSame('security.http_utils', (string) $definition->getArgument(0));
-        $this->assertSame('contao.framework', (string) $definition->getArgument(1));
+        $this->assertSame(ContaoFramework::class, (string) $definition->getArgument(1));
         $this->assertSame('logger', (string) $definition->getArgument(2));
     }
 
@@ -1564,7 +1564,7 @@ class ContaoCoreExtensionTest extends TestCase
 
         $this->assertSame(ContaoUserProvider::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
-        $this->assertSame('contao.framework', (string) $definition->getArgument(0));
+        $this->assertSame(ContaoFramework::class, (string) $definition->getArgument(0));
         $this->assertSame('session', (string) $definition->getArgument(1));
         $this->assertSame(BackendUser::class, (string) $definition->getArgument(2));
         $this->assertSame('logger', (string) $definition->getArgument(3));
@@ -1638,7 +1638,7 @@ class ContaoCoreExtensionTest extends TestCase
 
         $this->assertSame(ContaoUserProvider::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
-        $this->assertSame('contao.framework', (string) $definition->getArgument(0));
+        $this->assertSame(ContaoFramework::class, (string) $definition->getArgument(0));
         $this->assertSame('session', (string) $definition->getArgument(1));
         $this->assertSame(FrontendUser::class, (string) $definition->getArgument(2));
         $this->assertSame('logger', (string) $definition->getArgument(3));
@@ -1664,7 +1664,7 @@ class ContaoCoreExtensionTest extends TestCase
 
         $this->assertSame(LogoutHandler::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
-        $this->assertSame('contao.framework', (string) $definition->getArgument(0));
+        $this->assertSame(ContaoFramework::class, (string) $definition->getArgument(0));
         $this->assertSame('logger', (string) $definition->getArgument(1));
     }
 
@@ -1716,7 +1716,7 @@ class ContaoCoreExtensionTest extends TestCase
 
         $this->assertSame(UserChecker::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
-        $this->assertSame('contao.framework', (string) $definition->getArgument(0));
+        $this->assertSame(ContaoFramework::class, (string) $definition->getArgument(0));
     }
 
     public function testRegistersTheTokenGenerator(): void
@@ -1769,7 +1769,7 @@ class ContaoCoreExtensionTest extends TestCase
 
         $this->assertTrue($definition->isPublic());
         $this->assertSame('contao.slug.generator', (string) $definition->getArgument(0));
-        $this->assertSame('contao.framework', (string) $definition->getArgument(1));
+        $this->assertSame(ContaoFramework::class, (string) $definition->getArgument(1));
     }
 
     public function testRegistersTheSlugGenerator(): void
@@ -1804,7 +1804,7 @@ class ContaoCoreExtensionTest extends TestCase
         $this->assertTrue($definition->isPrivate());
         $this->assertSame('translator', $definition->getDecoratedService()[0]);
         $this->assertSame('contao.translation.translator.inner', (string) $definition->getArgument(0));
-        $this->assertSame('contao.framework', (string) $definition->getArgument(1));
+        $this->assertSame(ContaoFramework::class, (string) $definition->getArgument(1));
     }
 
     public function testRegistersTheContaoTranslatorDataCollector(): void
@@ -1828,7 +1828,7 @@ class ContaoCoreExtensionTest extends TestCase
         $this->assertSame(ContaoTemplateExtension::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
         $this->assertSame('request_stack', (string) $definition->getArgument(0));
-        $this->assertSame('contao.framework', (string) $definition->getArgument(1));
+        $this->assertSame(ContaoFramework::class, (string) $definition->getArgument(1));
         $this->assertSame(ScopeMatcher::class, (string) $definition->getArgument(2));
 
         $tags = $definition->getTags();

--- a/core-bundle/tests/Monolog/ContaoTableHandlerTest.php
+++ b/core-bundle/tests/Monolog/ContaoTableHandlerTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Tests\Monolog;
 
+use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\CoreBundle\Monolog\ContaoContext;
 use Contao\CoreBundle\Monolog\ContaoTableHandler;
 use Contao\CoreBundle\Tests\TestCase;
@@ -63,7 +64,7 @@ class ContaoTableHandlerTest extends TestCase
         $system = $this->mockConfiguredAdapter(['importStatic' => $this]);
 
         $container = $this->getContainerWithContaoConfiguration();
-        $container->set('contao.framework', $this->mockContaoFramework([System::class => $system]));
+        $container->set(ContaoFramework::class, $this->mockContaoFramework([System::class => $system]));
         $container->set('doctrine.dbal.default_connection', $connection);
 
         $GLOBALS['TL_HOOKS']['addLogEntry'][] = [\get_class($this), 'addLogEntry'];

--- a/core-bundle/tests/Routing/ImagesLoaderTest.php
+++ b/core-bundle/tests/Routing/ImagesLoaderTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Tests\Routing;
 
+use Contao\CoreBundle\Controller\ImagesController;
 use Contao\CoreBundle\Routing\ImagesLoader;
 use Contao\CoreBundle\Tests\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
@@ -41,7 +42,7 @@ class ImagesLoaderTest extends TestCase
 
         $this->assertNotNull($route);
         $this->assertSame('/path/to/images/{path}', $route->getPath());
-        $this->assertSame('contao.controller.images', $route->getDefault('_controller'));
+        $this->assertSame(ImagesController::class, $route->getDefault('_controller'));
         $this->assertSame('.+', $route->getRequirement('path'));
     }
 }

--- a/faq-bundle/src/DependencyInjection/ContaoFaqExtension.php
+++ b/faq-bundle/src/DependencyInjection/ContaoFaqExtension.php
@@ -31,5 +31,8 @@ class ContaoFaqExtension extends Extension
 
         $loader->load('listener.yml');
         $loader->load('services.yml');
+
+        // Backwards compatibility
+        $loader->load('legacy_aliases.yml');
     }
 }

--- a/faq-bundle/src/Resources/config/legacy_aliases.yml
+++ b/faq-bundle/src/Resources/config/legacy_aliases.yml
@@ -1,0 +1,5 @@
+services:
+    _defaults:
+        public: true
+
+    contao_faq.listener.insert_tags: '@Contao\FaqBundle\EventListener\InsertTagsListener'

--- a/faq-bundle/src/Resources/config/listener.yml
+++ b/faq-bundle/src/Resources/config/listener.yml
@@ -2,5 +2,5 @@ services:
     contao_faq.listener.insert_tags:
         class: Contao\FaqBundle\EventListener\InsertTagsListener
         arguments:
-            - '@contao.framework'
+            - '@Contao\CoreBundle\Framework\ContaoFramework'
         public: true

--- a/faq-bundle/src/Resources/config/listener.yml
+++ b/faq-bundle/src/Resources/config/listener.yml
@@ -1,6 +1,5 @@
 services:
-    contao_faq.listener.insert_tags:
-        class: Contao\FaqBundle\EventListener\InsertTagsListener
+    Contao\FaqBundle\EventListener\InsertTagsListener:
         arguments:
             - '@Contao\CoreBundle\Framework\ContaoFramework'
         public: true

--- a/faq-bundle/src/Resources/config/services.yml
+++ b/faq-bundle/src/Resources/config/services.yml
@@ -9,6 +9,6 @@ services:
             - '@knp_menu.factory'
             - '@router'
             - '@?translator'
-            - '@Symfony\Component\Security\Core\Security'
+            - '@security.helper'
         tags:
             - { name: contao.picker_provider, priority: 64 }

--- a/faq-bundle/src/Resources/config/services.yml
+++ b/faq-bundle/src/Resources/config/services.yml
@@ -2,7 +2,7 @@ services:
     _instanceof:
         Contao\CoreBundle\Framework\FrameworkAwareInterface:
             calls:
-                - ['setFramework', ['@contao.framework']]
+                - ['setFramework', ['@Contao\CoreBundle\Framework\ContaoFramework']]
 
     contao_faq.picker.faq_provider:
         class: Contao\FaqBundle\Picker\FaqPickerProvider

--- a/faq-bundle/src/Resources/config/services.yml
+++ b/faq-bundle/src/Resources/config/services.yml
@@ -4,12 +4,11 @@ services:
             calls:
                 - ['setFramework', ['@Contao\CoreBundle\Framework\ContaoFramework']]
 
-    contao_faq.picker.faq_provider:
-        class: Contao\FaqBundle\Picker\FaqPickerProvider
+    Contao\FaqBundle\Picker\FaqPickerProvider:
         arguments:
             - '@knp_menu.factory'
             - '@router'
             - '@?translator'
-            - '@security.helper'
+            - '@Symfony\Component\Security\Core\Security'
         tags:
             - { name: contao.picker_provider, priority: 64 }

--- a/faq-bundle/src/Resources/contao/config/config.php
+++ b/faq-bundle/src/Resources/contao/config/config.php
@@ -36,7 +36,7 @@ if (\defined('TL_MODE') && TL_MODE == 'BE')
 
 // Register hooks
 $GLOBALS['TL_HOOKS']['getSearchablePages'][] = array('Contao\ModuleFaq', 'getSearchablePages');
-$GLOBALS['TL_HOOKS']['replaceInsertTags'][] = array('contao_faq.listener.insert_tags', 'onReplaceInsertTags');
+$GLOBALS['TL_HOOKS']['replaceInsertTags'][] = array('Contao\FaqBundle\EventListener\InsertTagsListener', 'onReplaceInsertTags');
 
 // Add permissions
 $GLOBALS['TL_PERMISSIONS'][] = 'faqs';

--- a/faq-bundle/src/Resources/contao/dca/tl_faq.php
+++ b/faq-bundle/src/Resources/contao/dca/tl_faq.php
@@ -226,7 +226,7 @@ $GLOBALS['TL_DCA']['tl_faq'] = array
 			'eval'                    => array('rgxp'=>'natural', 'includeBlankOption'=>true, 'nospace'=>true, 'helpwizard'=>true, 'tl_class'=>'w50'),
 			'options_callback' => static function ()
 			{
-				return Contao\System::getContainer()->get('contao.image.image_sizes')->getOptionsForUser(Contao\BackendUser::getInstance());
+				return Contao\System::getContainer()->get('Contao\CoreBundle\Image\ImageSizes')->getOptionsForUser(Contao\BackendUser::getInstance());
 			},
 			'sql'                     => "varchar(64) NOT NULL default ''"
 		),
@@ -366,7 +366,7 @@ class tl_faq extends Contao\Backend
 		// Generate alias if there is none
 		if ($varValue == '')
 		{
-			$varValue = Contao\System::getContainer()->get('contao.slug')->generate($dc->activeRecord->question, Contao\FaqCategoryModel::findByPk($dc->activeRecord->pid)->jumpTo, $aliasExists);
+			$varValue = Contao\System::getContainer()->get('Contao\CoreBundle\Slug\Slug')->generate($dc->activeRecord->question, Contao\FaqCategoryModel::findByPk($dc->activeRecord->pid)->jumpTo, $aliasExists);
 		}
 		elseif ($aliasExists($varValue))
 		{

--- a/faq-bundle/tests/DependencyInjection/ContaoFaqExtensionTest.php
+++ b/faq-bundle/tests/DependencyInjection/ContaoFaqExtensionTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\FaqBundle\Tests\DependencyInjection;
 
+use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\CoreBundle\Framework\FrameworkAwareInterface;
 use Contao\FaqBundle\DependencyInjection\ContaoFaqExtension;
 use Contao\FaqBundle\EventListener\InsertTagsListener;
@@ -48,7 +49,7 @@ class ContaoFaqExtensionTest extends TestCase
 
         $this->assertSame(InsertTagsListener::class, $definition->getClass());
         $this->assertTrue($definition->isPublic());
-        $this->assertSame('contao.framework', (string) $definition->getArgument(0));
+        $this->assertSame(ContaoFramework::class, (string) $definition->getArgument(0));
     }
 
     public function testRegistersTheEventPickerProvider(): void

--- a/faq-bundle/tests/DependencyInjection/ContaoFaqExtensionTest.php
+++ b/faq-bundle/tests/DependencyInjection/ContaoFaqExtensionTest.php
@@ -20,6 +20,7 @@ use Contao\FaqBundle\Picker\FaqPickerProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+use Symfony\Component\Security\Core\Security;
 
 class ContaoFaqExtensionTest extends TestCase
 {
@@ -43,26 +44,24 @@ class ContaoFaqExtensionTest extends TestCase
 
     public function testRegistersTheInsertTagsListener(): void
     {
-        $this->assertTrue($this->container->has('contao_faq.listener.insert_tags'));
+        $this->assertTrue($this->container->has(InsertTagsListener::class));
 
-        $definition = $this->container->getDefinition('contao_faq.listener.insert_tags');
+        $definition = $this->container->getDefinition(InsertTagsListener::class);
 
-        $this->assertSame(InsertTagsListener::class, $definition->getClass());
         $this->assertTrue($definition->isPublic());
         $this->assertSame(ContaoFramework::class, (string) $definition->getArgument(0));
     }
 
     public function testRegistersTheEventPickerProvider(): void
     {
-        $this->assertTrue($this->container->has('contao_faq.picker.faq_provider'));
+        $this->assertTrue($this->container->has(FaqPickerProvider::class));
 
-        $definition = $this->container->getDefinition('contao_faq.picker.faq_provider');
+        $definition = $this->container->getDefinition(FaqPickerProvider::class);
 
-        $this->assertSame(FaqPickerProvider::class, $definition->getClass());
         $this->assertSame('knp_menu.factory', (string) $definition->getArgument(0));
         $this->assertSame('router', (string) $definition->getArgument(1));
         $this->assertSame('translator', (string) $definition->getArgument(2));
-        $this->assertSame('security.helper', (string) $definition->getArgument(3));
+        $this->assertSame(Security::class, (string) $definition->getArgument(3));
 
         $conditionals = $definition->getInstanceofConditionals();
 

--- a/faq-bundle/tests/DependencyInjection/ContaoFaqExtensionTest.php
+++ b/faq-bundle/tests/DependencyInjection/ContaoFaqExtensionTest.php
@@ -20,7 +20,6 @@ use Contao\FaqBundle\Picker\FaqPickerProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
-use Symfony\Component\Security\Core\Security;
 
 class ContaoFaqExtensionTest extends TestCase
 {
@@ -61,7 +60,7 @@ class ContaoFaqExtensionTest extends TestCase
         $this->assertSame('knp_menu.factory', (string) $definition->getArgument(0));
         $this->assertSame('router', (string) $definition->getArgument(1));
         $this->assertSame('translator', (string) $definition->getArgument(2));
-        $this->assertSame(Security::class, (string) $definition->getArgument(3));
+        $this->assertSame('security.helper', (string) $definition->getArgument(3));
 
         $conditionals = $definition->getInstanceofConditionals();
 

--- a/installation-bundle/src/Controller/InstallationController.php
+++ b/installation-bundle/src/Controller/InstallationController.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\InstallationBundle\Controller;
 
+use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\Environment;
 use Contao\InstallationBundle\Config\ParameterDumper;
 use Contao\InstallationBundle\Database\AbstractVersionUpdate;
@@ -54,8 +55,8 @@ class InstallationController implements ContainerAwareInterface
             return $response;
         }
 
-        if ($this->container->has('contao.framework')) {
-            $this->container->get('contao.framework')->initialize();
+        if ($this->container->has(ContaoFramework::class)) {
+            $this->container->get(ContaoFramework::class)->initialize();
         }
 
         $installTool = $this->container->get('contao.install_tool');
@@ -688,7 +689,7 @@ class InstallationController implements ContainerAwareInterface
 
     private function getUserAgentString(): string
     {
-        if (!$this->container->has('contao.framework') || !$this->container->get('contao.framework')->isInitialized()) {
+        if (!$this->container->has(ContaoFramework::class) || !$this->container->get(ContaoFramework::class)->isInitialized()) {
             return '';
         }
 

--- a/installation-bundle/src/DependencyInjection/ContaoInstallationExtension.php
+++ b/installation-bundle/src/DependencyInjection/ContaoInstallationExtension.php
@@ -32,5 +32,8 @@ class ContaoInstallationExtension extends Extension
         $loader->load('commands.yml');
         $loader->load('listener.yml');
         $loader->load('services.yml');
+
+        // Backwards compatibility
+        $loader->load('legacy_aliases.yml');
     }
 }

--- a/installation-bundle/src/Resources/config/commands.yml
+++ b/installation-bundle/src/Resources/config/commands.yml
@@ -2,12 +2,10 @@ services:
     _defaults:
         autoconfigure: true
 
-    contao.command.lock:
-        class: Contao\InstallationBundle\Command\LockCommand
+    Contao\InstallationBundle\Command\LockCommand:
         arguments:
             - '%kernel.project_dir%/var/install_lock'
 
-    contao.command.unlock:
-        class: Contao\InstallationBundle\Command\UnlockCommand
+    Contao\InstallationBundle\Command\UnlockCommand:
         arguments:
             - '%kernel.project_dir%/var/install_lock'

--- a/installation-bundle/src/Resources/config/legacy_aliases.yml
+++ b/installation-bundle/src/Resources/config/legacy_aliases.yml
@@ -1,0 +1,7 @@
+services:
+    _defaults:
+        public: true
+
+    contao.install_tool: '@Contao\InstallationBundle\InstallTool'
+    contao.install_tool_user: '@Contao\InstallationBundle\InstallToolUser'
+    contao.installer: '@Contao\InstallationBundle\Database\Installer'

--- a/installation-bundle/src/Resources/config/listener.yml
+++ b/installation-bundle/src/Resources/config/listener.yml
@@ -1,6 +1,5 @@
 services:
-    contao.listener.initialize_application:
-        class: Contao\InstallationBundle\EventListener\InitializeApplicationListener
+    Contao\InstallationBundle\EventListener\InitializeApplicationListener:
         calls:
             - ['setContainer', ['@service_container']]
         tags:

--- a/installation-bundle/src/Resources/config/services.yml
+++ b/installation-bundle/src/Resources/config/services.yml
@@ -1,26 +1,23 @@
 services:
-    contao.install_tool:
-        class: Contao\InstallationBundle\InstallTool
+    Contao\InstallationBundle\InstallTool:
         arguments:
             - '@database_connection'
             - '%kernel.project_dir%'
             - '@logger'
         public: true
 
-    contao.install_tool_user:
-        class: Contao\InstallationBundle\InstallToolUser
+    Contao\InstallationBundle\InstallToolUser:
         arguments:
             - '@session'
+        public: true
+
+    Contao\InstallationBundle\Database\Installer:
+        arguments:
+            - '@database_connection'
+            - '@contao.doctrine.schema_provider'
         public: true
 
     contao.install_tool_twig_extension:
         class: SensioLabs\AnsiConverter\Bridge\Twig\AnsiExtension
         tags:
             - { name: twig.extension }
-
-    contao.installer:
-        class: Contao\InstallationBundle\Database\Installer
-        arguments:
-            - '@database_connection'
-            - '@contao.doctrine.schema_provider'
-        public: true

--- a/manager-bundle/src/DependencyInjection/ContaoManagerExtension.php
+++ b/manager-bundle/src/DependencyInjection/ContaoManagerExtension.php
@@ -35,6 +35,9 @@ class ContaoManagerExtension extends Extension
         $loader->load('listener.yml');
         $loader->load('services.yml');
 
+        // Backwards compatibility
+        $loader->load('legacy_aliases.yml');
+
         $container->setParameter('contao_manager.manager_path', $config['manager_path']);
     }
 }

--- a/manager-bundle/src/Resources/config/commands.yml
+++ b/manager-bundle/src/Resources/config/commands.yml
@@ -2,7 +2,6 @@ services:
     _defaults:
         autoconfigure: true
 
-    contao.command.install-web-dir:
-        class: Contao\ManagerBundle\Command\InstallWebDirCommand
+    Contao\ManagerBundle\Command\InstallWebDirCommand:
         arguments:
             - '%kernel.project_dir%'

--- a/manager-bundle/src/Resources/config/legacy_aliases.yml
+++ b/manager-bundle/src/Resources/config/legacy_aliases.yml
@@ -1,0 +1,6 @@
+services:
+    _defaults:
+        public: true
+
+    contao_manager.routing_loader: '@Contao\ManagerBundle\Routing\RouteLoader'
+    contao_manager.listener.debug: '@Contao\ManagerBundle\EventListener\DebugListener'

--- a/manager-bundle/src/Resources/config/listener.yml
+++ b/manager-bundle/src/Resources/config/listener.yml
@@ -1,14 +1,14 @@
 services:
     Contao\ManagerBundle\EventListener\BackendMenuListener:
         arguments:
-            - '@Symfony\Component\Security\Core\Security'
+            - '@security.helper'
             - '%contao_manager.manager_path%'
         tags:
             - { name: kernel.event_listener, event: contao.backend_menu_build, method: onBuild, priority: -10 }
 
     Contao\ManagerBundle\EventListener\DebugListener:
         arguments:
-            - '@Symfony\Component\Security\Core\Security'
+            - '@security.helper'
             - '@request_stack'
             - '@contao_manager.jwt_manager'
         public: true

--- a/manager-bundle/src/Resources/config/listener.yml
+++ b/manager-bundle/src/Resources/config/listener.yml
@@ -1,36 +1,31 @@
 services:
-    contao_manager.listener.backend_menu_listener:
-        class: Contao\ManagerBundle\EventListener\BackendMenuListener
+    Contao\ManagerBundle\EventListener\BackendMenuListener:
         arguments:
-            - '@security.helper'
+            - '@Symfony\Component\Security\Core\Security'
             - '%contao_manager.manager_path%'
         tags:
             - { name: kernel.event_listener, event: contao.backend_menu_build, method: onBuild, priority: -10 }
 
-    contao_manager.listener.debug:
-        class: Contao\ManagerBundle\EventListener\DebugListener
+    Contao\ManagerBundle\EventListener\DebugListener:
         arguments:
-            - '@security.helper'
+            - '@Symfony\Component\Security\Core\Security'
             - '@request_stack'
             - '@contao_manager.jwt_manager'
         public: true
 
-    contao_manager.listener.initialize_application:
-        class: Contao\ManagerBundle\EventListener\InitializeApplicationListener
+    Contao\ManagerBundle\EventListener\InitializeApplicationListener:
         arguments:
             - '%kernel.project_dir%'
         tags:
             - { name: kernel.event_listener, event: contao_installation.initialize_application, method: onInitializeApplication, priority: -128 }
 
-    contao_manager.listener.install_command:
-        class: Contao\ManagerBundle\EventListener\InstallCommandListener
+    Contao\ManagerBundle\EventListener\InstallCommandListener:
         arguments:
             - '%kernel.project_dir%'
         tags:
             - { name: kernel.event_listener, event: console.terminate }
 
-    contao_manager.listener.preview_authentication:
-        class: Contao\ManagerBundle\EventListener\PreviewAuthenticationListener
+    Contao\ManagerBundle\EventListener\PreviewAuthenticationListener:
         arguments:
             - '@Contao\CoreBundle\Routing\ScopeMatcher'
             - '@Contao\CoreBundle\Security\Authentication\Token\TokenChecker'

--- a/manager-bundle/src/Resources/config/listener.yml
+++ b/manager-bundle/src/Resources/config/listener.yml
@@ -32,8 +32,8 @@ services:
     contao_manager.listener.preview_authentication:
         class: Contao\ManagerBundle\EventListener\PreviewAuthenticationListener
         arguments:
-            - '@contao.routing.scope_matcher'
-            - '@contao.security.token_checker'
+            - '@Contao\CoreBundle\Routing\ScopeMatcher'
+            - '@Contao\CoreBundle\Security\Authentication\Token\TokenChecker'
             - '@router'
             - '%contao.preview_script%'
         tags:

--- a/manager-bundle/src/Resources/config/services.yml
+++ b/manager-bundle/src/Resources/config/services.yml
@@ -1,12 +1,24 @@
 services:
     Contao\ManagerBundle\HttpKernel\JwtManager: '@contao_manager.jwt_manager'
 
-    contao_manager.cache.clear_bundle:
+    Contao\ManagerBundle\Cache\BundleCacheClearer:
         class: Contao\ManagerBundle\Cache\BundleCacheClearer
         arguments:
             - '@?filesystem'
         tags:
             - { name: kernel.cache_clearer }
+
+    Contao\ManagerBundle\Routing\RouteLoader:
+        arguments:
+            - '@routing.loader'
+            - '@contao_manager.plugin_loader'
+            - '@kernel'
+            - '%kernel.project_dir%'
+        public: true
+
+    Contao\ManagerBundle\Security\Logout\LogoutHandler:
+        arguments:
+            - '@?contao_manager.jwt_manager'
 
     contao_manager.plugin_loader:
         synthetic: true
@@ -15,17 +27,3 @@ services:
     contao_manager.jwt_manager:
         synthetic: true
         public: true
-
-    contao_manager.routing_loader:
-        class: Contao\ManagerBundle\Routing\RouteLoader
-        arguments:
-            - '@routing.loader'
-            - '@contao_manager.plugin_loader'
-            - '@kernel'
-            - '%kernel.project_dir%'
-        public: true
-
-    contao_manager.security.logout_handler:
-        class: Contao\ManagerBundle\Security\Logout\LogoutHandler
-        arguments:
-            - '@?contao_manager.jwt_manager'

--- a/manager-bundle/src/Resources/contao/config/config.php
+++ b/manager-bundle/src/Resources/contao/config/config.php
@@ -11,8 +11,8 @@
 // Back end modules
 $GLOBALS['BE_MOD']['accounts']['debug'] = array
 (
-	'enable'                  => ['contao_manager.listener.debug', 'onEnable'],
-	'disable'                 => ['contao_manager.listener.debug', 'onDisable'],
+	'enable'                  => ['Contao\ManagerBundle\EventListener\DebugListener', 'onEnable'],
+	'disable'                 => ['Contao\ManagerBundle\EventListener\DebugListener', 'onDisable'],
 	'hideInNavigation'        => true,
 	'disablePermissionChecks' => true
 );

--- a/manager-bundle/src/Resources/skeleton/config/config.yml
+++ b/manager-bundle/src/Resources/skeleton/config/config.yml
@@ -13,7 +13,7 @@ framework:
     translator: { fallbacks: ['%locale%'] }
     secret: '%secret%'
     router:
-        resource: 'contao_manager.routing_loader::loadFromPlugins'
+        resource: 'Contao\ManagerBundle\Routing\RouteLoader::loadFromPlugins'
         type: service
         strict_requirements: '%kernel.debug%'
     csrf_protection: ~

--- a/manager-bundle/src/Resources/skeleton/config/security.yml
+++ b/manager-bundle/src/Resources/skeleton/config/security.yml
@@ -46,7 +46,7 @@ security:
                 path: contao_backend_logout
                 handlers:
                     - contao.security.logout_handler
-                    - contao_manager.security.logout_handler
+                    - Contao\ManagerBundle\Security\Logout\LogoutHandler
                 success_handler: contao.security.logout_success_handler
 
         contao_frontend:

--- a/manager-bundle/tests/DependencyInjection/ContaoManagerExtensionTest.php
+++ b/manager-bundle/tests/DependencyInjection/ContaoManagerExtensionTest.php
@@ -12,13 +12,19 @@ declare(strict_types=1);
 
 namespace Contao\ManagerBundle\Tests\DependencyInjection;
 
+use Contao\CoreBundle\Routing\ScopeMatcher;
+use Contao\CoreBundle\Security\Authentication\Token\TokenChecker;
 use Contao\ManagerBundle\Cache\BundleCacheClearer;
 use Contao\ManagerBundle\DependencyInjection\ContaoManagerExtension;
+use Contao\ManagerBundle\EventListener\BackendMenuListener;
+use Contao\ManagerBundle\EventListener\DebugListener;
 use Contao\ManagerBundle\EventListener\InitializeApplicationListener;
 use Contao\ManagerBundle\EventListener\InstallCommandListener;
+use Contao\ManagerBundle\EventListener\PreviewAuthenticationListener;
 use Contao\ManagerBundle\Routing\RouteLoader;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Security\Core\Security;
 
 class ContaoManagerExtensionTest extends TestCase
 {
@@ -40,13 +46,41 @@ class ContaoManagerExtensionTest extends TestCase
         $extension->load([], $this->container);
     }
 
+    public function testRegistersTheBackendMenuListener(): void
+    {
+        $this->assertTrue($this->container->has(BackendMenuListener::class));
+
+        $definition = $this->container->getDefinition(BackendMenuListener::class);
+
+        $this->assertSame(Security::class, (string) $definition->getArgument(0));
+        $this->assertSame('%contao_manager.manager_path%', (string) $definition->getArgument(1));
+
+        $tags = $definition->getTags();
+
+        $this->assertArrayHasKey('kernel.event_listener', $tags);
+        $this->assertSame('contao.backend_menu_build', $tags['kernel.event_listener'][0]['event']);
+        $this->assertSame('onBuild', $tags['kernel.event_listener'][0]['method']);
+        $this->assertSame(-10, $tags['kernel.event_listener'][0]['priority']);
+    }
+
+    public function testRegistersTheDebugListener(): void
+    {
+        $this->assertTrue($this->container->has(DebugListener::class));
+
+        $definition = $this->container->getDefinition(DebugListener::class);
+
+        $this->assertTrue($definition->isPublic());
+        $this->assertSame(Security::class, (string) $definition->getArgument(0));
+        $this->assertSame('request_stack', (string) $definition->getArgument(1));
+        $this->assertSame('contao_manager.jwt_manager', (string) $definition->getArgument(2));
+    }
+
     public function testRegistersTheInitializeApplicationListener(): void
     {
-        $this->assertTrue($this->container->has('contao_manager.listener.initialize_application'));
+        $this->assertTrue($this->container->has(InitializeApplicationListener::class));
 
-        $definition = $this->container->getDefinition('contao_manager.listener.initialize_application');
+        $definition = $this->container->getDefinition(InitializeApplicationListener::class);
 
-        $this->assertSame(InitializeApplicationListener::class, $definition->getClass());
         $this->assertSame('%kernel.project_dir%', (string) $definition->getArgument(0));
 
         $tags = $definition->getTags();
@@ -59,11 +93,10 @@ class ContaoManagerExtensionTest extends TestCase
 
     public function testRegistersTheInstallCommandListener(): void
     {
-        $this->assertTrue($this->container->has('contao_manager.listener.install_command'));
+        $this->assertTrue($this->container->has(InstallCommandListener::class));
 
-        $definition = $this->container->getDefinition('contao_manager.listener.install_command');
+        $definition = $this->container->getDefinition(InstallCommandListener::class);
 
-        $this->assertSame(InstallCommandListener::class, $definition->getClass());
         $this->assertSame('%kernel.project_dir%', (string) $definition->getArgument(0));
 
         $tags = $definition->getTags();
@@ -72,13 +105,31 @@ class ContaoManagerExtensionTest extends TestCase
         $this->assertSame('console.terminate', $tags['kernel.event_listener'][0]['event']);
     }
 
+    public function testRegistersThePreviewAuthenticationListener(): void
+    {
+        $this->assertTrue($this->container->has(PreviewAuthenticationListener::class));
+
+        $definition = $this->container->getDefinition(PreviewAuthenticationListener::class);
+
+        $this->assertSame(ScopeMatcher::class, (string) $definition->getArgument(0));
+        $this->assertSame(TokenChecker::class, (string) $definition->getArgument(1));
+        $this->assertSame('router', (string) $definition->getArgument(2));
+        $this->assertSame('%contao.preview_script%', (string) $definition->getArgument(3));
+
+        $tags = $definition->getTags();
+
+        $this->assertArrayHasKey('kernel.event_listener', $tags);
+        $this->assertSame('kernel.request', $tags['kernel.event_listener'][0]['event']);
+        $this->assertSame('onKernelRequest', $tags['kernel.event_listener'][0]['method']);
+        $this->assertSame(7, $tags['kernel.event_listener'][0]['priority']);
+    }
+
     public function testRegistersTheBundleCacheClearer(): void
     {
-        $this->assertTrue($this->container->has('contao_manager.cache.clear_bundle'));
+        $this->assertTrue($this->container->has(BundleCacheClearer::class));
 
-        $definition = $this->container->getDefinition('contao_manager.cache.clear_bundle');
+        $definition = $this->container->getDefinition(BundleCacheClearer::class);
 
-        $this->assertSame(BundleCacheClearer::class, $definition->getClass());
         $this->assertSame('filesystem', (string) $definition->getArgument(0));
 
         $tags = $definition->getTags();
@@ -98,11 +149,10 @@ class ContaoManagerExtensionTest extends TestCase
 
     public function testRegistersTheRoutingLoader(): void
     {
-        $this->assertTrue($this->container->has('contao_manager.routing_loader'));
+        $this->assertTrue($this->container->has(RouteLoader::class));
 
-        $definition = $this->container->getDefinition('contao_manager.routing_loader');
+        $definition = $this->container->getDefinition(RouteLoader::class);
 
-        $this->assertSame(RouteLoader::class, $definition->getClass());
         $this->assertTrue($definition->isPublic());
         $this->assertSame('routing.loader', (string) $definition->getArgument(0));
         $this->assertSame('contao_manager.plugin_loader', (string) $definition->getArgument(1));

--- a/manager-bundle/tests/DependencyInjection/ContaoManagerExtensionTest.php
+++ b/manager-bundle/tests/DependencyInjection/ContaoManagerExtensionTest.php
@@ -24,7 +24,6 @@ use Contao\ManagerBundle\EventListener\PreviewAuthenticationListener;
 use Contao\ManagerBundle\Routing\RouteLoader;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\Security\Core\Security;
 
 class ContaoManagerExtensionTest extends TestCase
 {
@@ -52,7 +51,7 @@ class ContaoManagerExtensionTest extends TestCase
 
         $definition = $this->container->getDefinition(BackendMenuListener::class);
 
-        $this->assertSame(Security::class, (string) $definition->getArgument(0));
+        $this->assertSame('security.helper', (string) $definition->getArgument(0));
         $this->assertSame('%contao_manager.manager_path%', (string) $definition->getArgument(1));
 
         $tags = $definition->getTags();
@@ -70,7 +69,7 @@ class ContaoManagerExtensionTest extends TestCase
         $definition = $this->container->getDefinition(DebugListener::class);
 
         $this->assertTrue($definition->isPublic());
-        $this->assertSame(Security::class, (string) $definition->getArgument(0));
+        $this->assertSame('security.helper', (string) $definition->getArgument(0));
         $this->assertSame('request_stack', (string) $definition->getArgument(1));
         $this->assertSame('contao_manager.jwt_manager', (string) $definition->getArgument(2));
     }

--- a/news-bundle/src/DependencyInjection/ContaoNewsExtension.php
+++ b/news-bundle/src/DependencyInjection/ContaoNewsExtension.php
@@ -31,5 +31,8 @@ class ContaoNewsExtension extends Extension
 
         $loader->load('listener.yml');
         $loader->load('services.yml');
+
+        // Backwards compatibility
+        $loader->load('legacy_aliases.yml');
     }
 }

--- a/news-bundle/src/Resources/config/legacy_aliases.yml
+++ b/news-bundle/src/Resources/config/legacy_aliases.yml
@@ -1,0 +1,6 @@
+services:
+    _defaults:
+        public: true
+
+    contao_news.listener.generate_page: '@Contao\NewsBundle\EventListener\GeneratePageListener'
+    contao_news.listener.insert_tags: '@Contao\NewsBundle\EventListener\InsertTagsListener'

--- a/news-bundle/src/Resources/config/listener.yml
+++ b/news-bundle/src/Resources/config/listener.yml
@@ -2,20 +2,20 @@ services:
     contao_news.listener.generate_page:
         class: Contao\NewsBundle\EventListener\GeneratePageListener
         arguments:
-            - '@contao.framework'
+            - '@Contao\CoreBundle\Framework\ContaoFramework'
         public: true
 
     contao_news.listener.insert_tags:
         class: Contao\NewsBundle\EventListener\InsertTagsListener
         arguments:
-            - '@contao.framework'
+            - '@Contao\CoreBundle\Framework\ContaoFramework'
         public: true
 
     contao_news.listener.preview_url_create:
         class: Contao\NewsBundle\EventListener\PreviewUrlCreateListener
         arguments:
             - '@request_stack'
-            - '@contao.framework'
+            - '@Contao\CoreBundle\Framework\ContaoFramework'
         tags:
             - { name: kernel.event_listener, event: contao.preview_url_create, method: onPreviewUrlCreate }
 
@@ -23,6 +23,6 @@ services:
         class: Contao\NewsBundle\EventListener\PreviewUrlConvertListener
         arguments:
             - '@request_stack'
-            - '@contao.framework'
+            - '@Contao\CoreBundle\Framework\ContaoFramework'
         tags:
             - { name: kernel.event_listener, event: contao.preview_url_convert, method: onPreviewUrlConvert }

--- a/news-bundle/src/Resources/config/listener.yml
+++ b/news-bundle/src/Resources/config/listener.yml
@@ -1,26 +1,22 @@
 services:
-    contao_news.listener.generate_page:
-        class: Contao\NewsBundle\EventListener\GeneratePageListener
+    Contao\NewsBundle\EventListener\GeneratePageListener:
         arguments:
             - '@Contao\CoreBundle\Framework\ContaoFramework'
         public: true
 
-    contao_news.listener.insert_tags:
-        class: Contao\NewsBundle\EventListener\InsertTagsListener
+    Contao\NewsBundle\EventListener\InsertTagsListener:
         arguments:
             - '@Contao\CoreBundle\Framework\ContaoFramework'
         public: true
 
-    contao_news.listener.preview_url_create:
-        class: Contao\NewsBundle\EventListener\PreviewUrlCreateListener
+    Contao\NewsBundle\EventListener\PreviewUrlCreateListener:
         arguments:
             - '@request_stack'
             - '@Contao\CoreBundle\Framework\ContaoFramework'
         tags:
             - { name: kernel.event_listener, event: contao.preview_url_create, method: onPreviewUrlCreate }
 
-    contao_news.listener.preview_url_convert:
-        class: Contao\NewsBundle\EventListener\PreviewUrlConvertListener
+    Contao\NewsBundle\EventListener\PreviewUrlConvertListener:
         arguments:
             - '@request_stack'
             - '@Contao\CoreBundle\Framework\ContaoFramework'

--- a/news-bundle/src/Resources/config/services.yml
+++ b/news-bundle/src/Resources/config/services.yml
@@ -2,7 +2,7 @@ services:
     _instanceof:
         Contao\CoreBundle\Framework\FrameworkAwareInterface:
             calls:
-                - ['setFramework', ['@contao.framework']]
+                - ['setFramework', ['@Contao\CoreBundle\Framework\ContaoFramework']]
 
     contao_news.picker.news_provider:
         class: Contao\NewsBundle\Picker\NewsPickerProvider

--- a/news-bundle/src/Resources/config/services.yml
+++ b/news-bundle/src/Resources/config/services.yml
@@ -4,8 +4,7 @@ services:
             calls:
                 - ['setFramework', ['@Contao\CoreBundle\Framework\ContaoFramework']]
 
-    contao_news.picker.news_provider:
-        class: Contao\NewsBundle\Picker\NewsPickerProvider
+    Contao\NewsBundle\Picker\NewsPickerProvider:
         arguments:
             - '@knp_menu.factory'
             - '@router'

--- a/news-bundle/src/Resources/contao/config/config.php
+++ b/news-bundle/src/Resources/contao/config/config.php
@@ -43,9 +43,9 @@ if (\defined('TL_MODE') && TL_MODE == 'BE')
 // Register hooks
 $GLOBALS['TL_HOOKS']['removeOldFeeds'][] = array('Contao\News', 'purgeOldFeeds');
 $GLOBALS['TL_HOOKS']['getSearchablePages'][] = array('Contao\News', 'getSearchablePages');
-$GLOBALS['TL_HOOKS']['generatePage'][] = array('contao_news.listener.generate_page', 'onGeneratePage');
+$GLOBALS['TL_HOOKS']['generatePage'][] = array('Contao\NewsBundle\EventListener\GeneratePageListener', 'onGeneratePage');
 $GLOBALS['TL_HOOKS']['generateXmlFiles'][] = array('Contao\News', 'generateFeeds');
-$GLOBALS['TL_HOOKS']['replaceInsertTags'][] = array('contao_news.listener.insert_tags', 'onReplaceInsertTags');
+$GLOBALS['TL_HOOKS']['replaceInsertTags'][] = array('Contao\NewsBundle\EventListener\InsertTagsListener', 'onReplaceInsertTags');
 
 // Add permissions
 $GLOBALS['TL_PERMISSIONS'][] = 'news';

--- a/news-bundle/src/Resources/contao/dca/tl_news.php
+++ b/news-bundle/src/Resources/contao/dca/tl_news.php
@@ -307,7 +307,7 @@ $GLOBALS['TL_DCA']['tl_news'] = array
 			'eval'                    => array('rgxp'=>'natural', 'includeBlankOption'=>true, 'nospace'=>true, 'helpwizard'=>true, 'tl_class'=>'w50'),
 			'options_callback' => static function ()
 			{
-				return Contao\System::getContainer()->get('contao.image.image_sizes')->getOptionsForUser(Contao\BackendUser::getInstance());
+				return Contao\System::getContainer()->get('Contao\CoreBundle\Image\ImageSizes')->getOptionsForUser(Contao\BackendUser::getInstance());
 			},
 			'sql'                     => "varchar(64) NOT NULL default ''"
 		),
@@ -640,7 +640,7 @@ class tl_news extends Contao\Backend
 		// Generate alias if there is none
 		if ($varValue == '')
 		{
-			$varValue = Contao\System::getContainer()->get('contao.slug')->generate($dc->activeRecord->headline, Contao\NewsArchiveModel::findByPk($dc->activeRecord->pid)->jumpTo, $aliasExists);
+			$varValue = Contao\System::getContainer()->get('Contao\CoreBundle\Slug\Slug')->generate($dc->activeRecord->headline, Contao\NewsArchiveModel::findByPk($dc->activeRecord->pid)->jumpTo, $aliasExists);
 		}
 		elseif ($aliasExists($varValue))
 		{
@@ -748,7 +748,7 @@ class tl_news extends Contao\Backend
 	{
 		$news = Contao\NewsModel::findByPk($dc->activeRecord->id);
 		$url = Contao\News::generateNewsUrl($news, false, true);
-		$suffix = substr($dc->inputName, strlen($dc->field));
+		$suffix = substr($dc->inputName, \strlen($dc->field));
 
 		list($baseUrl) = explode($news->alias ?: $news->id, $url);
 

--- a/news-bundle/tests/DependencyInjection/ContaoNewsExtensionTest.php
+++ b/news-bundle/tests/DependencyInjection/ContaoNewsExtensionTest.php
@@ -46,33 +46,30 @@ class ContaoNewsExtensionTest extends TestCase
 
     public function testRegistersTheGeneratePageListener(): void
     {
-        $this->assertTrue($this->container->has('contao_news.listener.generate_page'));
+        $this->assertTrue($this->container->has(GeneratePageListener::class));
 
-        $definition = $this->container->getDefinition('contao_news.listener.generate_page');
+        $definition = $this->container->getDefinition(GeneratePageListener::class);
 
-        $this->assertSame(GeneratePageListener::class, $definition->getClass());
         $this->assertTrue($definition->isPublic());
         $this->assertSame(ContaoFramework::class, (string) $definition->getArgument(0));
     }
 
     public function testRegistersTheInsertTagsListener(): void
     {
-        $this->assertTrue($this->container->has('contao_news.listener.insert_tags'));
+        $this->assertTrue($this->container->has(InsertTagsListener::class));
 
-        $definition = $this->container->getDefinition('contao_news.listener.insert_tags');
+        $definition = $this->container->getDefinition(InsertTagsListener::class);
 
-        $this->assertSame(InsertTagsListener::class, $definition->getClass());
         $this->assertTrue($definition->isPublic());
         $this->assertSame(ContaoFramework::class, (string) $definition->getArgument(0));
     }
 
     public function testRegistersThePreviewUrlCreateListener(): void
     {
-        $this->assertTrue($this->container->has('contao_news.listener.preview_url_create'));
+        $this->assertTrue($this->container->has(PreviewUrlCreateListener::class));
 
-        $definition = $this->container->getDefinition('contao_news.listener.preview_url_create');
+        $definition = $this->container->getDefinition(PreviewUrlCreateListener::class);
 
-        $this->assertSame(PreviewUrlCreateListener::class, $definition->getClass());
         $this->assertSame('request_stack', (string) $definition->getArgument(0));
         $this->assertSame(ContaoFramework::class, (string) $definition->getArgument(1));
 
@@ -85,11 +82,10 @@ class ContaoNewsExtensionTest extends TestCase
 
     public function testRegistersThePreviewUrlConvertListener(): void
     {
-        $this->assertTrue($this->container->has('contao_news.listener.preview_url_convert'));
+        $this->assertTrue($this->container->has(PreviewUrlConvertListener::class));
 
-        $definition = $this->container->getDefinition('contao_news.listener.preview_url_convert');
+        $definition = $this->container->getDefinition(PreviewUrlConvertListener::class);
 
-        $this->assertSame(PreviewUrlConvertListener::class, $definition->getClass());
         $this->assertSame('request_stack', (string) $definition->getArgument(0));
         $this->assertSame(ContaoFramework::class, (string) $definition->getArgument(1));
 
@@ -102,11 +98,10 @@ class ContaoNewsExtensionTest extends TestCase
 
     public function testRegistersTheNewsPickerProvider(): void
     {
-        $this->assertTrue($this->container->has('contao_news.picker.news_provider'));
+        $this->assertTrue($this->container->has(NewsPickerProvider::class));
 
-        $definition = $this->container->getDefinition('contao_news.picker.news_provider');
+        $definition = $this->container->getDefinition(NewsPickerProvider::class);
 
-        $this->assertSame(NewsPickerProvider::class, $definition->getClass());
         $this->assertSame('knp_menu.factory', (string) $definition->getArgument(0));
         $this->assertSame('router', (string) $definition->getArgument(1));
         $this->assertSame('translator', (string) $definition->getArgument(2));

--- a/news-bundle/tests/DependencyInjection/ContaoNewsExtensionTest.php
+++ b/news-bundle/tests/DependencyInjection/ContaoNewsExtensionTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\NewsBundle\Tests\DependencyInjection;
 
+use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\CoreBundle\Framework\FrameworkAwareInterface;
 use Contao\NewsBundle\DependencyInjection\ContaoNewsExtension;
 use Contao\NewsBundle\EventListener\GeneratePageListener;
@@ -51,7 +52,7 @@ class ContaoNewsExtensionTest extends TestCase
 
         $this->assertSame(GeneratePageListener::class, $definition->getClass());
         $this->assertTrue($definition->isPublic());
-        $this->assertSame('contao.framework', (string) $definition->getArgument(0));
+        $this->assertSame(ContaoFramework::class, (string) $definition->getArgument(0));
     }
 
     public function testRegistersTheInsertTagsListener(): void
@@ -62,7 +63,7 @@ class ContaoNewsExtensionTest extends TestCase
 
         $this->assertSame(InsertTagsListener::class, $definition->getClass());
         $this->assertTrue($definition->isPublic());
-        $this->assertSame('contao.framework', (string) $definition->getArgument(0));
+        $this->assertSame(ContaoFramework::class, (string) $definition->getArgument(0));
     }
 
     public function testRegistersThePreviewUrlCreateListener(): void
@@ -73,7 +74,7 @@ class ContaoNewsExtensionTest extends TestCase
 
         $this->assertSame(PreviewUrlCreateListener::class, $definition->getClass());
         $this->assertSame('request_stack', (string) $definition->getArgument(0));
-        $this->assertSame('contao.framework', (string) $definition->getArgument(1));
+        $this->assertSame(ContaoFramework::class, (string) $definition->getArgument(1));
 
         $tags = $definition->getTags();
 
@@ -90,7 +91,7 @@ class ContaoNewsExtensionTest extends TestCase
 
         $this->assertSame(PreviewUrlConvertListener::class, $definition->getClass());
         $this->assertSame('request_stack', (string) $definition->getArgument(0));
-        $this->assertSame('contao.framework', (string) $definition->getArgument(1));
+        $this->assertSame(ContaoFramework::class, (string) $definition->getArgument(1));
 
         $tags = $definition->getTags();
 

--- a/newsletter-bundle/src/Resources/contao/dca/tl_newsletter.php
+++ b/newsletter-bundle/src/Resources/contao/dca/tl_newsletter.php
@@ -449,7 +449,7 @@ class tl_newsletter extends Contao\Backend
 		// Generate alias if there is none
 		if ($varValue == '')
 		{
-			$varValue = Contao\System::getContainer()->get('contao.slug')->generate($dc->activeRecord->subject, Contao\NewsletterChannelModel::findByPk($dc->activeRecord->pid)->jumpTo, $aliasExists);
+			$varValue = Contao\System::getContainer()->get('Contao\CoreBundle\Slug\Slug')->generate($dc->activeRecord->subject, Contao\NewsletterChannelModel::findByPk($dc->activeRecord->pid)->jumpTo, $aliasExists);
 		}
 		elseif ($aliasExists($varValue))
 		{

--- a/newsletter-bundle/src/Resources/contao/modules/ModuleSubscribe.php
+++ b/newsletter-bundle/src/Resources/contao/modules/ModuleSubscribe.php
@@ -166,7 +166,7 @@ class ModuleSubscribe extends Module
 		$this->Template = new FrontendTemplate('mod_newsletter');
 
 		/** @var OptIn $optIn */
-		$optIn = System::getContainer()->get('contao.opt-in');
+		$optIn = System::getContainer()->get(OptIn::class);
 
 		// Find an unconfirmed token
 		if ((!$optInToken = $optIn->find(Input::get('token'))) || !$optInToken->isValid() || \count($arrRelated = $optInToken->getRelatedRecords()) < 1 || key($arrRelated) != 'tl_newsletter_recipients' || \count($arrIds = current($arrRelated)) < 1)
@@ -359,7 +359,7 @@ class ModuleSubscribe extends Module
 		}
 
 		/** @var OptIn $optIn */
-		$optIn = System::getContainer()->get('contao.opt-in');
+		$optIn = System::getContainer()->get(OptIn::class);
 		$optInToken = $optIn->create('nl', $strEmail, $arrRelated);
 
 		// Get the channels


### PR DESCRIPTION
This PR replaces the `contao.` service IDs with class names as recommended in Symfony 4.

### TODO

- [ ] Also convert the private services
- [ ] Add aliases for the private services
- [ ] Check for `->getDefinition()->getClass()`, which now returns `null`
