### PR TITLE
Fix annotation definition

### DIFF
--- a/core-bundle/src/ServiceAnnotation/Callback.php
+++ b/core-bundle/src/ServiceAnnotation/Callback.php
@@ -41,7 +41,7 @@ final class Callback implements ServiceTagInterface
     public $target;
 
     /**
-     * @var int|null
+     * @var int
      */
     public $priority;
 

--- a/core-bundle/src/ServiceAnnotation/Hook.php
+++ b/core-bundle/src/ServiceAnnotation/Hook.php
@@ -35,7 +35,7 @@ final class Hook implements ServiceTagInterface
     public $value;
 
     /**
-     * @var int|null
+     * @var int
      */
     public $priority;
 

--- a/core-bundle/src/ServiceAnnotation/PickerProvider.php
+++ b/core-bundle/src/ServiceAnnotation/PickerProvider.php
@@ -29,7 +29,7 @@ use Terminal42\ServiceAnnotationBundle\Annotation\ServiceTagInterface;
 final class PickerProvider implements ServiceTagInterface
 {
     /**
-     * @var int|null
+     * @var int
      */
     public $priority;
 


### PR DESCRIPTION
As shown to @aschempp at the developer meeting, the current type definitions within the annotations can cause the following error:
```
  [RuntimeException]
  An error occurred while executing the "contao:install-web-dir" command:
  In AnnotationException.php line 83:

    [Type Error] Attribute "priority" of @Hook declared on method App\EventListener\ParseTemplateListener::onParseTemplate() expects a(n) int|null, but got integer.
```
The error only occurs if you actually use the attribute in your annotation, like `priority` in this case:
```
/**
 * @Hook("parseTemplate", priority=-10)
 */
```