### PR TITLE
Use $this->trans() in templates

### DIFF
--- a/core-bundle/src/Resources/contao/classes/Maintenance.php
+++ b/core-bundle/src/Resources/contao/classes/Maintenance.php
@@ -37,7 +37,6 @@ class Maintenance extends Backend implements \executable
 	{
 		$objTemplate = new BackendTemplate('be_maintenance_mode');
 		$objTemplate->action = ampersand(Environment::get('request'));
-		$objTemplate->headline = $GLOBALS['TL_LANG']['tl_maintenance']['maintenanceMode'];
 		$objTemplate->isActive = $this->isActive();
 
 		try
@@ -65,16 +64,11 @@ class Maintenance extends Backend implements \executable
 			$this->reload();
 		}
 
+		$objTemplate->isLocked = $isLocked;
+
 		if ($isLocked)
 		{
 			$objTemplate->class= 'tl_error';
-			$objTemplate->explain = $GLOBALS['TL_LANG']['MSC']['maintenanceEnabled'];
-			$objTemplate->submit = $GLOBALS['TL_LANG']['MSC']['disable'];
-		}
-		else
-		{
-			$objTemplate->class= 'tl_info';
-			$objTemplate->submit = $GLOBALS['TL_LANG']['MSC']['enable'];
 		}
 
 		return $objTemplate->parse();

--- a/core-bundle/src/Resources/contao/classes/PurgeData.php
+++ b/core-bundle/src/Resources/contao/classes/PurgeData.php
@@ -139,11 +139,6 @@ class PurgeData extends Backend implements \executable
 
 		$objTemplate->jobs = $arrJobs;
 		$objTemplate->action = ampersand(Environment::get('request'));
-		$objTemplate->headline = $GLOBALS['TL_LANG']['tl_maintenance']['clearCache'];
-		$objTemplate->job = $GLOBALS['TL_LANG']['tl_maintenance']['job'];
-		$objTemplate->description = $GLOBALS['TL_LANG']['tl_maintenance']['description'];
-		$objTemplate->submit = StringUtil::specialchars($GLOBALS['TL_LANG']['tl_maintenance']['clearCache']);
-		$objTemplate->help = (Config::get('showHelp') && ($GLOBALS['TL_LANG']['tl_maintenance']['cacheTables'][1] != '')) ? $GLOBALS['TL_LANG']['tl_maintenance']['cacheTables'][1] : '';
 
 		return $objTemplate->parse();
 	}

--- a/core-bundle/src/Resources/contao/elements/ContentSliderStop.php
+++ b/core-bundle/src/Resources/contao/elements/ContentSliderStop.php
@@ -35,10 +35,6 @@ class ContentSliderStop extends ContentElement
 
 			$this->Template = new BackendTemplate($this->strTemplate);
 		}
-
-		// Previous and next labels
-		$this->Template->previous = $GLOBALS['TL_LANG']['MSC']['previous'];
-		$this->Template->next = $GLOBALS['TL_LANG']['MSC']['next'];
 	}
 }
 

--- a/core-bundle/src/Resources/contao/modules/ModuleLogin.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleLogin.php
@@ -96,10 +96,7 @@ class ModuleLogin extends Module
 			$this->Template->action = $router->generate('contao_frontend_two_factor');
 			$this->Template->targetPath = $redirectPage instanceof PageModel ? $redirectPage->getAbsoluteUrl() : $objPage->getAbsoluteUrl();
 			$this->Template->twoFactorEnabled = $user->useTwoFactor;
-			$this->Template->authCode = $GLOBALS['TL_LANG']['MSC']['twoFactorVerification'];
 			$this->Template->slabel = StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['continue']);
-			$this->Template->cancel = $GLOBALS['TL_LANG']['MSC']['cancelBT'];
-			$this->Template->twoFactorAuthentication = $GLOBALS['TL_LANG']['MSC']['twoFactorAuthentication'];
 
 			if ($exception instanceof InvalidTwoFactorCodeException)
 			{
@@ -171,14 +168,11 @@ class ModuleLogin extends Module
 			$strRedirect = $objTarget->getAbsoluteUrl();
 		}
 
-		$this->Template->username = $GLOBALS['TL_LANG']['MSC']['username'];
-		$this->Template->password = $GLOBALS['TL_LANG']['MSC']['password'][0];
 		$this->Template->action = $router->generate('contao_frontend_login');
 		$this->Template->slabel = StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['login']);
 		$this->Template->value = StringUtil::specialchars($container->get('security.authentication_utils')->getLastUsername());
 		$this->Template->formId = 'tl_login_' . $this->id;
 		$this->Template->autologin = $this->autologin;
-		$this->Template->autoLabel = $GLOBALS['TL_LANG']['MSC']['autologin'];
 		$this->Template->forceTargetPath = (int) $blnRedirectBack;
 		$this->Template->targetPath = StringUtil::specialchars($strRedirect);
 		$this->Template->failurePath = StringUtil::specialchars(Environment::get('base').Environment::get('request'));

--- a/core-bundle/src/Resources/contao/templates/backend/be_maintenance_mode.html5
+++ b/core-bundle/src/Resources/contao/templates/backend/be_maintenance_mode.html5
@@ -1,7 +1,7 @@
 
 <div id="tl_maintenance_mode" class="maintenance_<?= $this->isActive ? 'active' : 'inactive' ?>">
 
-  <h2 class="sub_headline"><?= $this->headline ?></h2>
+  <h2 class="sub_headline"><?= $this->trans('tl_maintenance.maintenanceMode') ?></h2>
 
   <?php if ($this->message): ?>
     <div class="tl_message">
@@ -13,14 +13,14 @@
     <div class="tl_formbody_edit">
       <input type="hidden" name="FORM_SUBMIT" value="tl_maintenance_mode">
       <input type="hidden" name="REQUEST_TOKEN" value="<?= REQUEST_TOKEN ?>">
-      <?php if ($this->explain): ?>
+      <?php if ($this->isLocked): ?>
         <div class="tl_message">
-          <p class="<?= $this->class ?>"><?= $this->explain ?></p>
+          <p class="<?= $this->class ?>"><?= $this->trans('MSC.maintenanceEnabled') ?></p>
         </div>
       <?php endif; ?>
     </div>
     <div class="tl_submit_container">
-      <button type="submit" name="maintenance" class="tl_submit"><?= $this->submit ?></button>
+      <button type="submit" name="maintenance" class="tl_submit"><?= $this->trans($this->isLocked ? 'MSC.disable' : 'MSC.enable') ?></button>
     </div>
   </form>
 

--- a/core-bundle/src/Resources/contao/templates/backend/be_purge_data.html5
+++ b/core-bundle/src/Resources/contao/templates/backend/be_purge_data.html5
@@ -1,7 +1,7 @@
 
 <div id="tl_maintenance_cache" class="maintenance_<?= $this->isActive ? 'active' : 'inactive' ?>">
 
-  <h2 class="sub_headline sub_headline_purge"><?= $this->headline ?></h2>
+  <h2 class="sub_headline sub_headline_purge"><?= $this->trans('tl_maintenance.clearCache') ?></h2>
 
   <?php if ($this->message): ?>
     <div class="tl_message">
@@ -19,8 +19,8 @@
           <thead>
             <tr>
               <th><input type="checkbox" id="check_all" class="tl_checkbox" onclick="Backend.toggleCheckboxes(this, 'purge')"></th>
-              <th><?= $this->job ?></th>
-              <th><?= $this->description ?></th>
+              <th><?= $this->trans('tl_maintenance.job') ?></th>
+              <th><?= $this->trans('tl_maintenance.description') ?></th>
             </tr>
           </thead>
           <tbody>
@@ -34,13 +34,13 @@
           </tbody>
           </table>
         </fieldset>
-        <?php if ($this->help): ?>
-          <p class="tl_help tl_tip"><?= $this->help ?></p>
+        <?php if (Contao\Config::get('showHelp')): ?>
+          <p class="tl_help tl_tip"><?= $this->trans('tl_maintenance.cacheTables.1') ?></p>
         <?php endif; ?>
       </div>
     </div>
     <div class="tl_submit_container">
-      <button type="submit" name="clear" class="tl_submit"><?= $this->submit ?></button>
+      <button type="submit" name="clear" class="tl_submit"><?= $this->trans('tl_maintenance.clearCache') ?></button>
     </div>
   </form>
 

--- a/core-bundle/src/Resources/contao/templates/elements/ce_sliderStop.html5
+++ b/core-bundle/src/Resources/contao/templates/elements/ce_sliderStop.html5
@@ -3,9 +3,9 @@
   </div>
 
   <nav class="slider-control">
-    <a href="#" class="slider-prev"><?= $this->previous ?></a>
+    <a href="#" class="slider-prev"><?= $this->trans('MSC.previous') ?></a>
     <span class="slider-menu"></span>
-    <a href="#" class="slider-next"><?= $this->next ?></a>
+    <a href="#" class="slider-next"><?= $this->trans('MSC.next') ?></a>
   </nav>
 
 </div>

--- a/core-bundle/src/Resources/contao/templates/modules/mod_login.html5
+++ b/core-bundle/src/Resources/contao/templates/modules/mod_login.html5
@@ -17,26 +17,26 @@
       <?php if ($this->logout): ?>
         <p class="login_info"><?= $this->loggedInAs ?><br><?= $this->lastLogin ?></p>
       <?php elseif ($this->twoFactorEnabled): ?>
-        <h3><?= $this->twoFactorAuthentication ?></h3>
+        <h3><?= $this->trans('MSC.twoFactorAuthentication') ?></h3>
         <div class="widget widget-text">
-          <label for="verify"><?= $this->authCode ?></label>
+          <label for="verify"><?= $this->trans('MSC.twoFactorVerification') ?></label>
           <input type="text" name="verify" id="verify" class="text" value="" autocapitalize="off" autocomplete="off" required>
         </div>
       <?php else: ?>
         <input type="hidden" name="_failure_path" value="<?= $this->failurePath ?>">
         <input type="hidden" name="_always_use_target_path" value="<?= $this->forceTargetPath ?>">
         <div class="widget widget-text">
-          <label for="username"><?= $this->username ?></label>
+          <label for="username"><?= $this->trans('MSC.username') ?></label>
           <input type="text" name="username" id="username" class="text" value="<?= $this->value ?>" required>
         </div>
         <div class="widget widget-password">
-          <label for="password"><?= $this->password ?></label>
+          <label for="password"><?= $this->trans('MSC.password.0') ?></label>
           <input type="password" name="password" id="password" class="text password" value="" required>
         </div>
         <?php if ($this->autologin): ?>
           <div class="widget widget-checkbox">
             <fieldset class="checkbox_container">
-              <span><input type="checkbox" name="autologin" id="autologin" value="1" class="checkbox"> <label for="autologin"><?= $this->autoLabel ?></label></span>
+              <span><input type="checkbox" name="autologin" id="autologin" value="1" class="checkbox"> <label for="autologin"><?= $this->trans('MSC.autologin') ?></label></span>
             </fieldset>
           </div>
         <?php endif; ?>
@@ -44,7 +44,7 @@
       <div class="widget widget-submit">
         <button type="submit" class="submit"><?= $this->slabel ?></button>
         <?php if ($this->twoFactorEnabled): ?>
-          <a href="<?= $this->route('contao_frontend_logout') ?>"><?= $this->cancel ?> ›</a>
+          <a href="<?= $this->route('contao_frontend_logout') ?>"><?= $this->trans('MSC.cancelBT') ?> ›</a>
         <?php endif; ?>
       </div>
     </div>


### PR DESCRIPTION
By using `$this->trans()` in templates, we could greatly reduce the number of template properties (see the [files changed](https://github.com/contao/contao/pull/766/files)). This PR is just a proof of concept so we can decide if this is something we want to go for.

@contao/developers WDYT?