### PR TITLE
Require context length

### DIFF
--- a/core-bundle/src/Resources/contao/dca/tl_module.php
+++ b/core-bundle/src/Resources/contao/dca/tl_module.php
@@ -334,8 +334,8 @@ $GLOBALS['TL_DCA']['tl_module'] = array
 		(
 			'exclude'                 => true,
 			'inputType'               => 'text',
-			'eval'                    => array('multiple'=>true, 'size'=>2, 'rgxp'=>'natural', 'tl_class'=>'w50', 'mandatory'=>true),
-			'sql'                     => "varchar(64) NOT NULL default ''"
+			'eval'                    => array('multiple'=>true, 'size'=>2, 'rgxp'=>'natural', 'mandatory'=>true, 'tl_class'=>'w50'),
+			'sql'                     => "varchar(64) NOT NULL default 'a:2:{i:0;i:48;i:1;i:1000;}'"
 		),
 		'minKeywordLength' => array
 		(

--- a/core-bundle/src/Resources/contao/dca/tl_module.php
+++ b/core-bundle/src/Resources/contao/dca/tl_module.php
@@ -334,7 +334,7 @@ $GLOBALS['TL_DCA']['tl_module'] = array
 		(
 			'exclude'                 => true,
 			'inputType'               => 'text',
-			'eval'                    => array('multiple'=>true, 'size'=>2, 'rgxp'=>'natural', 'tl_class'=>'w50'),
+			'eval'                    => array('multiple'=>true, 'size'=>2, 'rgxp'=>'natural', 'tl_class'=>'w50', 'mandatory'=>true),
 			'sql'                     => "varchar(64) NOT NULL default ''"
 		),
 		'minKeywordLength' => array


### PR DESCRIPTION
**Affected version(s)**
4.8 (checked on PHP 7.3.9)

**Description**  
Require values for `contextLength` in `ModuleSearch`.

**How to reproduce**  
Setup a search module in the backend and save module without providing values for context length. 

A warning will follow if you search for a value that provides some results:
```
ErrorException:
Warning: A non-numeric value encountered

  at vendor/contao/core-bundle/src/Resources/contao/library/Contao/StringUtil.php:133
  at Contao\StringUtil::substrHtml('this is my search string', '')
     (vendor/contao/core-bundle/src/Resources/contao/modules/ModuleSearch.php:297)
  at Contao\ModuleSearch->compile()
     (vendor/contao/core-bundle/src/Resources/contao/modules/Module.php:210)
  at Contao\Module->generate()
     (vendor/contao/core-bundle/src/Resources/contao/modules/ModuleSearch.php:51)
  at Contao\ModuleSearch->generate()
     (vendor/contao/core-bundle/src/Resources/contao/elements/ContentModule.php:78)
  at Contao\ContentModule->generate()
     (vendor/contao/core-bundle/src/Resources/contao/library/Contao/Controller.php:513)
  at Contao\Controller::getContentElement(object(ContentModel), 'main')
     (vendor/contao/core-bundle/src/Resources/contao/modules/ModuleArticle.php:193)
  at Contao\ModuleArticle->compile()
     (vendor/contao/core-bundle/src/Resources/contao/modules/Module.php:210)
  at Contao\Module->generate()
     (vendor/contao/core-bundle/src/Resources/contao/modules/ModuleArticle.php:75)
  at Contao\ModuleArticle->generate(false)
     (vendor/contao/core-bundle/src/Resources/contao/library/Contao/Controller.php:453)
  at Contao\Controller::getArticle(object(ArticleModel), false, false, 'main')
     (vendor/contao/core-bundle/src/Resources/contao/library/Contao/Controller.php:315)
  at Contao\Controller::getFrontendModule('0', 'main')
     (vendor/contao/core-bundle/src/Resources/contao/pages/PageRegular.php:166)
  at Contao\PageRegular->prepare(object(PageModel))
     (vendor/contao/core-bundle/src/Resources/contao/pages/PageRegular.php:49)
  at Contao\PageRegular->getResponse(object(PageModel), true)
     (vendor/contao/core-bundle/src/Resources/contao/controllers/FrontendIndex.php:344)
  at Contao\FrontendIndex->renderPage(object(PageModel))
     (vendor/symfony/http-kernel/HttpKernel.php:151)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw(object(Request), 1)
     (vendor/symfony/http-kernel/HttpKernel.php:68)
  at Symfony\Component\HttpKernel\HttpKernel->handle(object(Request), 1, true)
     (vendor/symfony/http-kernel/Kernel.php:198)
  at Symfony\Component\HttpKernel\Kernel->handle(object(Request))
     (public/index.php:42)
```