### PR TITLE
Fix padding with mb strings in ResizeImagesCommand

### DIFF
--- a/core-bundle/src/Command/ResizeImagesCommand.php
+++ b/core-bundle/src/Command/ResizeImagesCommand.php
@@ -152,7 +152,7 @@ class ResizeImagesCommand extends Command
             return 0;
         }
 
-        $output->write(str_pad($path, $this->terminalWidth + strlen($path) - mb_strlen($path, 'UTF-8') - 14, '.').' ');
+        $output->write(str_pad($path, $this->terminalWidth + strlen($path) - mb_strlen($path, 'UTF-8') - 13, '.').' ');
 
         try {
             $image = $this->imageFactory->create($this->targetDir.'/'.$path);

--- a/core-bundle/src/Command/ResizeImagesCommand.php
+++ b/core-bundle/src/Command/ResizeImagesCommand.php
@@ -152,7 +152,7 @@ class ResizeImagesCommand extends Command
             return 0;
         }
 
-        $output->write(str_pad($path, $this->terminalWidth - 14, '.').' ');
+        $output->write(str_pad($path, $this->terminalWidth + strlen($path) - mb_strlen($path, 'UTF-8') - 14, '.').' ');
 
         try {
             $image = $this->imageFactory->create($this->targetDir.'/'.$path);


### PR DESCRIPTION
This is just a cosmetic issue: The padding (adding dots to the filenames) misses a character if something like `ß` is in the pathname. Adding the difference between `strlen` and `mb_strlen` solves this issue (unfortunately there is no such thing as `mb_str_pad`).