### PR TITLE
Support predefined image sizes in {{picture::}} tag

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/InsertTags.php
+++ b/core-bundle/src/Resources/contao/library/Contao/InsertTags.php
@@ -771,7 +771,6 @@ class InsertTags extends Controller
 					$strFile = $elements[1];
 					$mode = '';
 					$size = null;
-					$config = null;
 					$strTemplate = 'picture_default';
 
 					// Take arguments
@@ -813,11 +812,7 @@ class InsertTags extends Controller
 									break;
 
 								case 'size':
-									$size = (int) $value;
-									break;
-
-								case 'config':
-									$config = $value;
+									$size = is_numeric($value) ? (int) $value : $value;
 									break;
 
 								case 'template':
@@ -907,7 +902,7 @@ class InsertTags extends Controller
 						else
 						{
 							$staticUrl = $container->get('contao.assets.files_context')->getStaticUrl();
-							$picture = $container->get('contao.image.picture_factory')->create($container->getParameter('kernel.project_dir') . '/' . $strFile, $size ?? $config);
+							$picture = $container->get('contao.image.picture_factory')->create($container->getParameter('kernel.project_dir') . '/' . $strFile, $size);
 
 							$picture = array
 							(

--- a/core-bundle/src/Resources/contao/library/Contao/InsertTags.php
+++ b/core-bundle/src/Resources/contao/library/Contao/InsertTags.php
@@ -771,6 +771,7 @@ class InsertTags extends Controller
 					$strFile = $elements[1];
 					$mode = '';
 					$size = null;
+					$config = null;
 					$strTemplate = 'picture_default';
 
 					// Take arguments
@@ -813,6 +814,10 @@ class InsertTags extends Controller
 
 								case 'size':
 									$size = (int) $value;
+									break;
+
+								case 'config':
+									$config = $value;
 									break;
 
 								case 'template':
@@ -902,7 +907,7 @@ class InsertTags extends Controller
 						else
 						{
 							$staticUrl = $container->get('contao.assets.files_context')->getStaticUrl();
-							$picture = $container->get('contao.image.picture_factory')->create($container->getParameter('kernel.project_dir') . '/' . $strFile, $size);
+							$picture = $container->get('contao.image.picture_factory')->create($container->getParameter('kernel.project_dir') . '/' . $strFile, $size ?? $config);
 
 							$picture = array
 							(


### PR DESCRIPTION
Example: 

### Template
```
{{picture::files/foo.jpg?size=_foobar}}
```

### config.yml
```yml
contao:
    image:
        sizes:
            foobar:
                width: 100
                height: 200
                resizeMode: 'box'
                zoom: 100
                cssClass: 'foobar-image'
                densities: '1x, 2x'
                sizes: '100vw'
                items:
                    -
                        width: 50
                        height: 50
                        resizeMode: 'box'
                        zoom: 100
                        cssClass: 'foobar-image'
                        densities: '0.5x, 2x'
                        sizes: '50vw'
                        media: '(max-width: 900px)'
```