### PR TITLE
Automatically load the services.yml file if it exists

### DIFF
--- a/manager-bundle/src/HttpKernel/ContaoKernel.php
+++ b/manager-bundle/src/HttpKernel/ContaoKernel.php
@@ -211,6 +211,11 @@ class ContaoKernel extends Kernel implements HttpCacheProvider
         } elseif ($configFile = $this->getConfigFile('config.yml')) {
             $loader->load($configFile);
         }
+
+        // Automatically load the services.yml file if it exists
+        if ($servicesFile = $this->getConfigFile('services.yml')) {
+            $loader->load($servicesFile);
+        }
     }
 
     /**

--- a/manager-bundle/tests/HttpKernel/ContaoKernelTest.php
+++ b/manager-bundle/tests/HttpKernel/ContaoKernelTest.php
@@ -197,7 +197,7 @@ class ContaoKernelTest extends ContaoTestCase
         yield [
             __DIR__.'/../Fixtures/HttpKernel/WithConfigsYml',
             'prod',
-            ['config_prod.yml'],
+            ['config_prod.yml', 'services.yml'],
         ];
 
         yield [


### PR DESCRIPTION
In Symfony 4, the `services.yml` file will be loaded automatically, therefore we should do it, too.