### PR TITLE
Use custom routers to generate URLs from models

### DIFF
--- a/core-bundle/src/Resources/config/services.yml
+++ b/core-bundle/src/Resources/config/services.yml
@@ -445,6 +445,14 @@ services:
             - ['addRouteFilter', ['@contao.routing.language_filter']]
         public: true
 
+    contao.routing.page_model_router:
+        class: Contao\CoreBundle\Routing\PageModelRouter
+        arguments:
+            - '@contao.routing.url_generator'
+            - '@request_stack'
+        tags:
+            - { name: router }
+
     contao.routing.page_router:
         class: Symfony\Cmf\Component\Routing\DynamicRouter
         arguments:

--- a/core-bundle/src/Resources/contao/widgets/SerpPreview.php
+++ b/core-bundle/src/Resources/contao/widgets/SerpPreview.php
@@ -10,6 +10,8 @@
 
 namespace Contao;
 
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
 /**
  * @property array $serpPreview
  */
@@ -107,24 +109,7 @@ EOT;
 			return $this->serpPreview['url'];
 		}
 
-		// FIXME: use the router to generate the URL (see #831)
-		switch (true)
-		{
-			case $model instanceof PageModel:
-				return $model->getAbsoluteUrl();
-				break;
-
-			case $model instanceof NewsModel:
-				return News::generateNewsUrl($model, false, true);
-				break;
-
-			case $model instanceof CalendarEventsModel:
-				return Events::generateEventUrl($model, true);
-				break;
-
-			default:
-				throw new \RuntimeException(sprintf('Unsupported model class "%s"', \get_class($model)));
-		}
+		return System::getContainer()->get('router')->generate($model, array(), UrlGeneratorInterface::ABSOLUTE_URL);
 	}
 
 	private function getTitleField()

--- a/core-bundle/src/Routing/PageModelRouter.php
+++ b/core-bundle/src/Routing/PageModelRouter.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Routing;
+
+use Contao\PageModel;
+use Symfony\Cmf\Component\Routing\ChainedRouterInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Routing\RequestContext;
+
+class PageModelRouter implements ChainedRouterInterface
+{
+    /**
+     * @var UrlGenerator
+     */
+    private $urlGenerator;
+
+    /**
+     * @var RequestStack
+     */
+    private $requestStack;
+
+    /**
+     * @var RequestContext
+     */
+    private $context;
+
+    public function __construct(UrlGenerator $urlGenerator, RequestStack $requestStack)
+    {
+        $this->urlGenerator = $urlGenerator;
+        $this->requestStack = $requestStack;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setContext(RequestContext $context): void
+    {
+        $this->context = $context;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getContext(): RequestContext
+    {
+        return $this->context;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param PageModel $pageModel
+     * @param array     $parameters
+     * @param string    $referenceType
+     */
+    public function generate($pageModel, $parameters = [], $referenceType = self::ABSOLUTE_PATH): string
+    {
+        $pageModel->loadDetails();
+
+        $parameters['_locale'] = $pageModel->rootLanguage;
+        $parameters['_domain'] = $pageModel->domain;
+        $parameters['_ssl'] = (bool) $pageModel->rootUseSSL;
+
+        $strUrl = $this->urlGenerator->generate(($pageModel->alias ?: $pageModel->id), $parameters, $referenceType);
+
+        // Make the URL relative to the base path
+        if (0 === strncmp($strUrl, '/', 1))
+        {
+            if (!$request = $this->requestStack->getCurrentRequest()) {
+                throw new \RuntimeException('The request stack did not contain a request.');
+            }
+
+            $strUrl = substr($strUrl, \strlen($request->getBasePath()) + 1);
+        }
+
+        return $strUrl;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports($name): bool
+    {
+        return $name instanceof PageModel;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param PageModel $pageModel
+     */
+    public function getRouteDebugMessage($pageModel, array $parameters = []): string
+    {
+        return 'Page ID '.$pageModel->id;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRouteCollection()
+    {
+        throw new \LogicException('Not implemented');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function match($pathinfo)
+    {
+        throw new \LogicException('Not implemented');
+    }
+}


### PR DESCRIPTION
This PR allows us to do the following:

```php
$pageModel = PageModel::findById(2);
echo $router->generate($pageModel); // will output en/foo.html
```

### TODO

* [ ] Agree on the implementation
* [ ] Check the priority
* [ ] Add a NewsModelRouter and CalendarEventsModelRouter
* [ ] Unit tests
