### PR TITLE
Use the default template path

### DIFF
--- a/manager-bundle/src/Resources/config/services.yml
+++ b/manager-bundle/src/Resources/config/services.yml
@@ -16,6 +16,11 @@ services:
             - '@contao_manager.jwt_manager'
         public: true
 
+    Contao\ManagerBundle\Twig\FileExtensionFilterIterator:
+        decorates: 'twig.template_iterator'
+        arguments:
+            - '@Contao\ManagerBundle\Twig\FileExtensionFilterIterator.inner'
+
     # Backwards compatibility
     contao_manager.controller.debug:
         alias: Contao\ManagerBundle\Controller\DebugController

--- a/manager-bundle/src/Resources/config/services.yml
+++ b/manager-bundle/src/Resources/config/services.yml
@@ -16,11 +16,6 @@ services:
             - '@contao_manager.jwt_manager'
         public: true
 
-    Contao\ManagerBundle\Twig\FileExtensionFilterIterator:
-        decorates: 'twig.template_iterator'
-        arguments:
-            - '@Contao\ManagerBundle\Twig\FileExtensionFilterIterator.inner'
-
     # Backwards compatibility
     contao_manager.controller.debug:
         alias: Contao\ManagerBundle\Controller\DebugController
@@ -48,3 +43,9 @@ services:
         class: Contao\ManagerBundle\Security\Logout\LogoutHandler
         arguments:
             - '@?contao_manager.jwt_manager'
+
+    contao_manager.twig.file_extension_filter_iterator:
+        class: Contao\ManagerBundle\Twig\FileExtensionFilterIterator
+        decorates: 'twig.template_iterator'
+        arguments:
+            - '@Contao\ManagerBundle\Twig\FileExtensionFilterIterator.inner'

--- a/manager-bundle/src/Resources/config/services.yml
+++ b/manager-bundle/src/Resources/config/services.yml
@@ -48,4 +48,4 @@ services:
         class: Contao\ManagerBundle\Twig\FileExtensionFilterIterator
         decorates: 'twig.template_iterator'
         arguments:
-            - '@Contao\ManagerBundle\Twig\FileExtensionFilterIterator.inner'
+            - '@contao_manager.twig.file_extension_filter_iterator.inner'

--- a/manager-bundle/src/Resources/skeleton/config/config.yml
+++ b/manager-bundle/src/Resources/skeleton/config/config.yml
@@ -31,7 +31,6 @@ contao:
 twig:
     debug: '%kernel.debug%'
     strict_variables: '%kernel.debug%'
-    default_path: '%kernel.project_dir%/app/Resources/views'
 
 # Doctrine configuration
 doctrine:

--- a/manager-bundle/src/Twig/FileExtensionFilterIterator.php
+++ b/manager-bundle/src/Twig/FileExtensionFilterIterator.php
@@ -14,7 +14,9 @@ namespace Contao\ManagerBundle\Twig;
 
 class FileExtensionFilterIterator implements \IteratorAggregate
 {
-    /** @var \Traversable */
+    /**
+     * @var \Traversable
+     */
     private $iterator;
 
     public function __construct(\IteratorAggregate $templateIterator)
@@ -22,11 +24,11 @@ class FileExtensionFilterIterator implements \IteratorAggregate
         $this->iterator = $templateIterator->getIterator();
     }
 
-    public function getIterator()
+    public function getIterator(): \CallbackFilterIterator
     {
         return new \CallbackFilterIterator(
             new \IteratorIterator($this->iterator),
-            function ($path) {
+            function ($path): bool {
                 return $this->acceptsPath($path);
             }
         );

--- a/manager-bundle/src/Twig/FileExtensionFilterIterator.php
+++ b/manager-bundle/src/Twig/FileExtensionFilterIterator.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\ManagerBundle\Twig;
+
+class FileExtensionFilterIterator implements \IteratorAggregate
+{
+    /** @var \Traversable */
+    private $iterator;
+
+    public function __construct(\IteratorAggregate $templateIterator)
+    {
+        $this->iterator = $templateIterator->getIterator();
+    }
+
+    public function getIterator()
+    {
+        return new \CallbackFilterIterator(
+            new \IteratorIterator($this->iterator),
+            function ($path) {
+                return $this->acceptsPath($path);
+            }
+        );
+    }
+
+    /**
+     * Filter files by extension (in the root namespace).
+     */
+    private function acceptsPath(string $path): bool
+    {
+        return 0 === strncmp($path, '@', 1) || '.twig' === substr($path, -5);
+    }
+}

--- a/manager-bundle/src/Twig/FileExtensionFilterIterator.php
+++ b/manager-bundle/src/Twig/FileExtensionFilterIterator.php
@@ -37,6 +37,6 @@ class FileExtensionFilterIterator implements \IteratorAggregate
      */
     private function acceptsPath(string $path): bool
     {
-        return 0 === strncmp($path, '@', 1) || '.twig' === substr($path, -5);
+        return 0 === strncmp($path, '@', 1) || '.sql' !== substr($path, -4);
     }
 }

--- a/manager-bundle/src/Twig/FileExtensionFilterIterator.php
+++ b/manager-bundle/src/Twig/FileExtensionFilterIterator.php
@@ -28,17 +28,9 @@ class FileExtensionFilterIterator implements \IteratorAggregate
     {
         return new \CallbackFilterIterator(
             new \IteratorIterator($this->iterator),
-            function ($path): bool {
-                return $this->acceptsPath($path);
+            static function ($path): bool {
+                return 0 === strncmp($path, '@', 1) || '.twig' === substr($path, -5);
             }
         );
-    }
-
-    /**
-     * Filter files by extension (in the root namespace).
-     */
-    private function acceptsPath(string $path): bool
-    {
-        return 0 === strncmp($path, '@', 1) || '.twig' === substr($path, -5);
     }
 }

--- a/manager-bundle/src/Twig/FileExtensionFilterIterator.php
+++ b/manager-bundle/src/Twig/FileExtensionFilterIterator.php
@@ -37,6 +37,6 @@ class FileExtensionFilterIterator implements \IteratorAggregate
      */
     private function acceptsPath(string $path): bool
     {
-        return 0 === strncmp($path, '@', 1) || '.sql' !== substr($path, -4);
+        return 0 === strncmp($path, '@', 1) || '.twig' === substr($path, -5);
     }
 }

--- a/manager-bundle/tests/Fixtures/IteratorAggregateStub.php
+++ b/manager-bundle/tests/Fixtures/IteratorAggregateStub.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
  * @license LGPL-3.0-or-later
  */
 
-namespace Contao\ManagerBundle\Tests\Twig;
+namespace Contao\ManagerBundle\Tests\Fixtures;
 
 class IteratorAggregateStub implements \IteratorAggregate
 {

--- a/manager-bundle/tests/Fixtures/IteratorAggregateStub.php
+++ b/manager-bundle/tests/Fixtures/IteratorAggregateStub.php
@@ -14,7 +14,9 @@ namespace Contao\ManagerBundle\Tests\Fixtures;
 
 class IteratorAggregateStub implements \IteratorAggregate
 {
-    /** @var array */
+    /**
+     * @var array
+     */
     private $data;
 
     public function __construct(array $data)
@@ -22,7 +24,7 @@ class IteratorAggregateStub implements \IteratorAggregate
         $this->data = $data;
     }
 
-    public function getIterator()
+    public function getIterator(): \ArrayIterator
     {
         return new \ArrayIterator($this->data);
     }

--- a/manager-bundle/tests/Twig/FileExtensionFilterIteratorTest.php
+++ b/manager-bundle/tests/Twig/FileExtensionFilterIteratorTest.php
@@ -14,16 +14,15 @@ namespace Contao\ManagerBundle\Tests\Twig;
 
 use Contao\ManagerBundle\Tests\Fixtures\IteratorAggregateStub;
 use Contao\ManagerBundle\Twig\FileExtensionFilterIterator;
-use Contao\TestCase\ContaoTestCase;
+use PHPUnit\Framework\TestCase;
 
-class FileExtensionFilterIteratorTest extends ContaoTestCase
+class FileExtensionFilterIteratorTest extends TestCase
 {
     public function testRemovesPathsWithoutTwigFileExtension(): void
     {
         $input = ['foo.twig', 'bar.twig', 'foobar.php', 'foo/bar'];
-        $expected = ['foo.twig', 'bar.twig'];
 
-        $this->assertSame($expected, $this->applyFilter($input));
+        $this->assertSame(['foo.twig', 'bar.twig'], $this->applyFilter($input));
     }
 
     public function testDoesNotAlterNamespacedPaths(): void
@@ -35,12 +34,9 @@ class FileExtensionFilterIteratorTest extends ContaoTestCase
 
     private function applyFilter(array $input): array
     {
-        $iteratorAggregate = new IteratorAggregateStub($input);
-        $iteratorAggregate = new FileExtensionFilterIterator($iteratorAggregate);
+        $iterator = new FileExtensionFilterIterator(new IteratorAggregateStub($input));
+        $output = iterator_to_array($iterator->getIterator());
 
-        $output = iterator_to_array($iteratorAggregate->getIterator());
-
-        // normalize keys
         return array_values($output);
     }
 }

--- a/manager-bundle/tests/Twig/FileExtensionFilterIteratorTest.php
+++ b/manager-bundle/tests/Twig/FileExtensionFilterIteratorTest.php
@@ -19,7 +19,7 @@ class FileExtensionFilterIteratorTest extends ContaoTestCase
 {
     public function testRemovesPathsWithoutTwigFileExtension(): void
     {
-        $input = ['foo.twig', 'bar.twig', 'foobar.php', 'foo/bar'];
+        $input = ['foo.twig', 'bar.twig', 'foobar.sql', 'foo/bar.sql'];
         $expected = ['foo.twig', 'bar.twig'];
 
         $this->assertSame($expected, $this->applyFilter($input));
@@ -27,7 +27,7 @@ class FileExtensionFilterIteratorTest extends ContaoTestCase
 
     public function testDoesNotAlterNamespacedPaths(): void
     {
-        $input = ['@FooBundle/foo.twig', '@FooBundle/foo.other'];
+        $input = ['@FooBundle/foo.twig', '@FooBundle/foo.sql'];
 
         $this->assertSame($input, $this->applyFilter($input));
     }

--- a/manager-bundle/tests/Twig/FileExtensionFilterIteratorTest.php
+++ b/manager-bundle/tests/Twig/FileExtensionFilterIteratorTest.php
@@ -19,7 +19,7 @@ class FileExtensionFilterIteratorTest extends ContaoTestCase
 {
     public function testRemovesPathsWithoutTwigFileExtension(): void
     {
-        $input = ['foo.twig', 'bar.twig', 'foobar.sql', 'foo/bar.sql'];
+        $input = ['foo.twig', 'bar.twig', 'foobar.php', 'foo/bar'];
         $expected = ['foo.twig', 'bar.twig'];
 
         $this->assertSame($expected, $this->applyFilter($input));
@@ -27,7 +27,7 @@ class FileExtensionFilterIteratorTest extends ContaoTestCase
 
     public function testDoesNotAlterNamespacedPaths(): void
     {
-        $input = ['@FooBundle/foo.twig', '@FooBundle/foo.sql'];
+        $input = ['@FooBundle/foo.twig', '@FooBundle/foo.other'];
 
         $this->assertSame($input, $this->applyFilter($input));
     }

--- a/manager-bundle/tests/Twig/FileExtensionFilterIteratorTest.php
+++ b/manager-bundle/tests/Twig/FileExtensionFilterIteratorTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\ManagerBundle\Tests\Twig;
 
+use Contao\ManagerBundle\Tests\Fixtures\IteratorAggregateStub;
 use Contao\ManagerBundle\Twig\FileExtensionFilterIterator;
 use Contao\TestCase\ContaoTestCase;
 

--- a/manager-bundle/tests/Twig/FileExtensionFilterIteratorTest.php
+++ b/manager-bundle/tests/Twig/FileExtensionFilterIteratorTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\ManagerBundle\Tests\Twig;
+
+use Contao\ManagerBundle\Twig\FileExtensionFilterIterator;
+use Contao\TestCase\ContaoTestCase;
+
+class FileExtensionFilterIteratorTest extends ContaoTestCase
+{
+    public function testRemovesPathsWithoutTwigFileExtension(): void
+    {
+        $input = ['foo.twig', 'bar.twig', 'foobar.php', 'foo/bar'];
+        $expected = ['foo.twig', 'bar.twig'];
+
+        $this->assertSame($expected, $this->applyFilter($input));
+    }
+
+    public function testDoesNotAlterNamespacedPaths(): void
+    {
+        $input = ['@FooBundle/foo.twig', '@FooBundle/foo.other'];
+
+        $this->assertSame($input, $this->applyFilter($input));
+    }
+
+    private function applyFilter(array $input): array
+    {
+        $iteratorAggregate = new IteratorAggregateStub($input);
+        $iteratorAggregate = new FileExtensionFilterIterator($iteratorAggregate);
+
+        $output = iterator_to_array($iteratorAggregate->getIterator());
+
+        // normalize keys
+        return array_values($output);
+    }
+}

--- a/manager-bundle/tests/Twig/IteratorAggregateStub.php
+++ b/manager-bundle/tests/Twig/IteratorAggregateStub.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\ManagerBundle\Tests\Twig;
+
+class IteratorAggregateStub implements \IteratorAggregate
+{
+    /** @var array */
+    private $data;
+
+    public function __construct(array $data)
+    {
+        $this->data = $data;
+    }
+
+    public function getIterator()
+    {
+        return new \ArrayIterator($this->data);
+    }
+}


### PR DESCRIPTION
In 9a7ae410540b6a946e2c6a25d5fbbe1069049f14 (see #108) we set the default template path to `app/Resources/views`. This however prevents user from getting rid of the `app` folder if they are overwriting templates (e.g. our `service_unavailable.twig`). 

This PR resets the folder to the default (`/templates`) again and decorates the template iterator with one that chains the iterator with a filtering iterator that only allows `.twig` files. This circumvents the issue in #108 

todo: 
- [ ] check https://github.com/symfony/symfony/issues/34142
- [x] wait for response of PCT

Credits: This is a result of a discussion & debugging session together with @fritzmg. Thanks :smile: 