### PR TITLE
Do not force the RedirectResponse return type in authentication success handler

### DIFF
--- a/core-bundle/src/Security/Authentication/AuthenticationSuccessHandler.php
+++ b/core-bundle/src/Security/Authentication/AuthenticationSuccessHandler.php
@@ -21,8 +21,8 @@ use Contao\System;
 use Contao\User;
 use Psr\Log\LoggerInterface;
 use Scheb\TwoFactorBundle\Security\Authentication\Token\TwoFactorTokenInterface;
-use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Http\Authentication\DefaultAuthenticationSuccessHandler;
@@ -59,7 +59,7 @@ class AuthenticationSuccessHandler extends DefaultAuthenticationSuccessHandler
     /**
      * Redirects the authenticated user.
      */
-    public function onAuthenticationSuccess(Request $request, TokenInterface $token): RedirectResponse
+    public function onAuthenticationSuccess(Request $request, TokenInterface $token): Response
     {
         if ($token instanceof TwoFactorTokenInterface) {
             $response = $this->httpUtils->createRedirectResponse(


### PR DESCRIPTION
In one of my projects I wanted to make it possible to log in to frontend using AJAX request. The problem I bumped into is that both [AuthenticationSuccessHandler](https://github.com/contao/contao/blob/master/core-bundle/src/Security/Authentication/AuthenticationSuccessHandler.php#L62) and [AuthenticationFailureHandler](https://github.com/contao/contao/blob/master/core-bundle/src/Security/Authentication/AuthenticationFailureHandler.php#L30) return the redirect response and thus it is not possible to distinguish directly in the response if the signing in was successful or not.

To workaround this I override both services to return a proper response (200 or 40x) when it's an AJAX request, otherwise fallback to default behavior. It works just fine, yet I had to create a custom response class that extends `RedirectResponse` but does not in fact redirect. That is because [AuthenticationSuccessHandler](https://github.com/contao/contao/blob/master/core-bundle/src/Security/Authentication/AuthenticationSuccessHandler.php#L62) forces the `RedirectResponse` type which I think should not be the case, especially that [the docblock says](https://github.com/symfony/security/blob/4.4/Http/Authentication/AuthenticationSuccessHandlerInterface.php#L34) it should be just `Response`.