### PR TITLE
Add a command to debug fragments

### DIFF
--- a/core-bundle/src/Command/DebugFragmentsCommand.php
+++ b/core-bundle/src/Command/DebugFragmentsCommand.php
@@ -88,13 +88,17 @@ class DebugFragmentsCommand extends Command
 
     private function generateArray(array $values): string
     {
+        $length = array_reduce(
+            array_keys($values),
+            static function ($carry, $item) {
+                $length = \strlen($item);
+
+                return $carry > $length ? $carry : $length;
+            },
+            0
+        );
+
         $return = [];
-
-        $length = array_reduce(array_keys($values), static function ($carry, $item) {
-            $length = \strlen($item);
-
-            return $carry > $length ? $carry : $length;
-        }, 0);
 
         foreach ($values as $k => $v) {
             if (\is_bool($v)) {

--- a/core-bundle/src/Command/DebugFragmentsCommand.php
+++ b/core-bundle/src/Command/DebugFragmentsCommand.php
@@ -14,9 +14,7 @@ namespace Contao\CoreBundle\Command;
 
 use Contao\CoreBundle\Fragment\FragmentConfig;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
@@ -44,11 +42,6 @@ class DebugFragmentsCommand extends Command
      */
     private $io;
 
-    public function __construct()
-    {
-        parent::__construct();
-    }
-
     public function add(string $identifier, FragmentConfig $config, array $attributes)
     {
         $this->identifiers[] = $identifier;
@@ -62,11 +55,7 @@ class DebugFragmentsCommand extends Command
     protected function configure(): void
     {
         $this
-            ->setDefinition([
-                new InputArgument('name', InputArgument::OPTIONAL, 'The plugin class or package name'),
-            ])
-            ->addOption('bundles', null, InputOption::VALUE_NONE, 'List all bundles or bundles config of the specified plugin')
-            ->setDescription('Displays the configuration of Contao Manager plugins.')
+            ->setDescription('Displays the fragment controller configuration.')
         ;
     }
 
@@ -91,10 +80,8 @@ class DebugFragmentsCommand extends Command
             ];
         }
 
-
         $this->io->title('Contao Fragments');
         $this->io->table(['Identifier', 'Controller', 'Renderer', 'Render Options', 'Fragment Options'], $rows);
-
 
         return 0;
     }

--- a/core-bundle/src/Command/DebugFragmentsCommand.php
+++ b/core-bundle/src/Command/DebugFragmentsCommand.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Command;
+
+use Contao\CoreBundle\Fragment\FragmentConfig;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+class DebugFragmentsCommand extends Command
+{
+    protected static $defaultName = 'debug:fragments';
+
+    /**
+     * @var array
+     */
+    private $identifiers = [];
+
+    /**
+     * @var FragmentConfig[]
+     */
+    private $configs = [];
+
+    /**
+     * @var array
+     */
+    private $attributes = [];
+
+    /**
+     * @var SymfonyStyle
+     */
+    private $io;
+
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    public function add(string $identifier, FragmentConfig $config, array $attributes)
+    {
+        $this->identifiers[] = $identifier;
+        $this->configs[$identifier] = $config;
+        $this->attributes[$identifier] = $attributes;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure(): void
+    {
+        $this
+            ->setDefinition([
+                new InputArgument('name', InputArgument::OPTIONAL, 'The plugin class or package name'),
+            ])
+            ->addOption('bundles', null, InputOption::VALUE_NONE, 'List all bundles or bundles config of the specified plugin')
+            ->setDescription('Displays the configuration of Contao Manager plugins.')
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $this->io = new SymfonyStyle($input, $output);
+
+        $rows = [];
+        $identifiers = $this->identifiers;
+        natsort($identifiers);
+
+        foreach ($identifiers as $identifier) {
+            $rows[] = [
+                $identifier,
+                $this->configs[$identifier]->getController(),
+                $this->configs[$identifier]->getRenderer(),
+                $this->generateArray($this->configs[$identifier]->getOptions()),
+                $this->generateArray($this->attributes[$identifier]),
+            ];
+        }
+
+
+        $this->io->title('Contao Fragments');
+        $this->io->table(['Identifier', 'Controller', 'Renderer', 'Render Options', 'Fragment Options'], $rows);
+
+
+        return 0;
+    }
+
+    private function generateArray(array $values): string
+    {
+        $return = [];
+
+        $length = array_reduce(array_keys($values), function($carry, $item) {
+            $length = strlen($item);
+            return $carry > $length ? $carry : $length;
+        }, 0);
+
+        foreach ($values as $k => $v) {
+            if (is_bool($v)) {
+                $v = $v ? 'true' : 'false';
+            }
+
+            $return[] = sprintf('%s : %s', str_pad($k, $length, ' ', STR_PAD_RIGHT), (string) $v);
+        }
+
+        return implode("\n", $return);
+    }
+}

--- a/core-bundle/src/Command/DebugFragmentsCommand.php
+++ b/core-bundle/src/Command/DebugFragmentsCommand.php
@@ -42,7 +42,7 @@ class DebugFragmentsCommand extends Command
      */
     private $io;
 
-    public function add(string $identifier, FragmentConfig $config, array $attributes)
+    public function add(string $identifier, FragmentConfig $config, array $attributes): void
     {
         $this->identifiers[] = $identifier;
         $this->configs[$identifier] = $config;
@@ -90,13 +90,14 @@ class DebugFragmentsCommand extends Command
     {
         $return = [];
 
-        $length = array_reduce(array_keys($values), function($carry, $item) {
-            $length = strlen($item);
+        $length = array_reduce(array_keys($values), static function ($carry, $item) {
+            $length = \strlen($item);
+
             return $carry > $length ? $carry : $length;
         }, 0);
 
         foreach ($values as $k => $v) {
-            if (is_bool($v)) {
+            if (\is_bool($v)) {
                 $v = $v ? 'true' : 'false';
             }
 

--- a/core-bundle/src/Command/DebugFragmentsCommand.php
+++ b/core-bundle/src/Command/DebugFragmentsCommand.php
@@ -90,7 +90,7 @@ class DebugFragmentsCommand extends Command
     {
         $length = array_reduce(
             array_keys($values),
-            static function ($carry, $item) {
+            static function ($carry, $item): int {
                 $length = \strlen($item);
 
                 return $carry > $length ? $carry : $length;

--- a/core-bundle/src/DependencyInjection/Compiler/RegisterFragmentsPass.php
+++ b/core-bundle/src/DependencyInjection/Compiler/RegisterFragmentsPass.php
@@ -65,6 +65,7 @@ class RegisterFragmentsPass implements CompilerPassInterface
     {
         $preHandlers = [];
         $registry = $container->findDefinition('contao.fragment.registry');
+        $command = $container->findDefinition('contao.command.debug_fragments');
 
         foreach ($this->findAndSortTaggedServices($tag, $container) as $priority => $reference) {
             $definition = $container->findDefinition($reference);
@@ -88,6 +89,7 @@ class RegisterFragmentsPass implements CompilerPassInterface
                 }
 
                 $registry->addMethodCall('add', [$identifier, $config]);
+                $command->addMethodCall('add', [$identifier, $config, $attributes]);
                 $definition->addTag($tag, $attributes);
             }
         }

--- a/core-bundle/src/Resources/config/commands.yml
+++ b/core-bundle/src/Resources/config/commands.yml
@@ -17,6 +17,9 @@ services:
         arguments:
             - '@contao.framework'
 
+    contao.command.debug_fragments:
+        class: Contao\CoreBundle\Command\DebugFragmentsCommand
+
     contao.command.filesync:
         class: Contao\CoreBundle\Command\FilesyncCommand
 

--- a/core-bundle/tests/Command/DebugFragmentsCommandTest.php
+++ b/core-bundle/tests/Command/DebugFragmentsCommandTest.php
@@ -66,7 +66,6 @@ Contao Fragments
 
 
 OUTPUT
-
         ];
 
         yield 'Multiple fragments' => [
@@ -88,7 +87,6 @@ Contao Fragments
 
 
 OUTPUT
-
         ];
 
         yield 'ESI fragment' => [
@@ -109,7 +107,6 @@ Contao Fragments
 
 
 OUTPUT
-
         ];
     }
 }

--- a/core-bundle/tests/Command/DebugFragmentsCommandTest.php
+++ b/core-bundle/tests/Command/DebugFragmentsCommandTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\Command;
+
+use Contao\CoreBundle\Command\DebugFragmentsCommand;
+use Contao\CoreBundle\Controller\FrontendModule\TwoFactorController;
+use Contao\CoreBundle\Fragment\FragmentConfig;
+use Contao\TestCase\ContaoTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\HttpKernel\Tests\DependencyInjection\ControllerDummy;
+
+class DebugFragmentsCommandTest extends ContaoTestCase
+{
+    public function testNameAndArguments(): void
+    {
+        $command = new DebugFragmentsCommand();
+
+        $this->assertSame('debug:fragments', $command->getName());
+        $this->assertSame(0, $command->getDefinition()->getArgumentCount());
+        $this->assertEmpty($command->getDefinition()->getOptions());
+    }
+
+    /**
+     * @dataProvider commandOutputProvider
+     */
+    public function testCommandOutput(array $fragments, string $expectedOutput): void
+    {
+        $command = new DebugFragmentsCommand();
+
+        foreach ($fragments as $fragment) {
+            $command->add($fragment[0], $fragment[1], $fragment[2]);
+        }
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute([]);
+
+        $this->assertSame($expectedOutput, $commandTester->getDisplay(true));
+    }
+
+    public function commandOutputProvider(): \Generator
+    {
+        yield 'Basic fragment list' => [
+            [
+                ['contao.foo.bar', new FragmentConfig(TwoFactorController::class), []],
+            ],
+            <<<'OUTPUT'
+
+Contao Fragments
+================
+
+ ---------------- ----------------------------------------------------------------- ---------- ---------------- ------------------ 
+  Identifier       Controller                                                        Renderer   Render Options   Fragment Options  
+ ---------------- ----------------------------------------------------------------- ---------- ---------------- ------------------ 
+  contao.foo.bar   Contao\CoreBundle\Controller\FrontendModule\TwoFactorController   forward                                       
+ ---------------- ----------------------------------------------------------------- ---------- ---------------- ------------------ 
+
+
+OUTPUT
+
+        ];
+
+        yield 'Multiple fragments' => [
+            [
+                ['contao.foo.bar', new FragmentConfig(TwoFactorController::class), ['category' => 'application']],
+                ['contao.foo.baz', new FragmentConfig(ControllerDummy::class), ['category' => 'foobar']],
+            ],
+            <<<'OUTPUT'
+
+Contao Fragments
+================
+
+ ---------------- ------------------------------------------------------------------------ ---------- ---------------- ------------------------ 
+  Identifier       Controller                                                               Renderer   Render Options   Fragment Options        
+ ---------------- ------------------------------------------------------------------------ ---------- ---------------- ------------------------ 
+  contao.foo.bar   Contao\CoreBundle\Controller\FrontendModule\TwoFactorController          forward                     category : application  
+  contao.foo.baz   Symfony\Component\HttpKernel\Tests\DependencyInjection\ControllerDummy   forward                     category : foobar       
+ ---------------- ------------------------------------------------------------------------ ---------- ---------------- ------------------------ 
+
+
+OUTPUT
+
+        ];
+
+        yield 'ESI fragment' => [
+            [
+                ['contao.foo.bar', new FragmentConfig(ControllerDummy::class, 'esi', ['ignore_errors' => false]), ['category' => 'esi', 'foo' => 'bar']],
+            ],
+            <<<'OUTPUT'
+
+Contao Fragments
+================
+
+ ---------------- ------------------------------------------------------------------------ ---------- ----------------------- ------------------ 
+  Identifier       Controller                                                               Renderer   Render Options          Fragment Options  
+ ---------------- ------------------------------------------------------------------------ ---------- ----------------------- ------------------ 
+  contao.foo.bar   Symfony\Component\HttpKernel\Tests\DependencyInjection\ControllerDummy   esi        ignore_errors : false   category : esi    
+                                                                                                                               foo      : bar    
+ ---------------- ------------------------------------------------------------------------ ---------- ----------------------- ------------------ 
+
+
+OUTPUT
+
+        ];
+    }
+}

--- a/core-bundle/tests/Command/DebugFragmentsCommandTest.php
+++ b/core-bundle/tests/Command/DebugFragmentsCommandTest.php
@@ -14,10 +14,10 @@ namespace Contao\CoreBundle\Tests\Command;
 
 use Contao\CoreBundle\Command\DebugFragmentsCommand;
 use Contao\CoreBundle\Controller\FrontendModule\TwoFactorController;
+use Contao\CoreBundle\Fixtures\Controller\FrontendModule\TestController;
 use Contao\CoreBundle\Fragment\FragmentConfig;
 use Contao\TestCase\ContaoTestCase;
 use Symfony\Component\Console\Tester\CommandTester;
-use Symfony\Component\HttpKernel\Tests\DependencyInjection\ControllerDummy;
 
 class DebugFragmentsCommandTest extends ContaoTestCase
 {
@@ -71,19 +71,19 @@ OUTPUT
         yield 'Multiple fragments' => [
             [
                 ['contao.foo.bar', new FragmentConfig(TwoFactorController::class), ['category' => 'application']],
-                ['contao.foo.baz', new FragmentConfig(ControllerDummy::class), ['category' => 'foobar']],
+                ['contao.foo.baz', new FragmentConfig(TestController::class), ['category' => 'foobar']],
             ],
             <<<'OUTPUT'
 
 Contao Fragments
 ================
 
- ---------------- ------------------------------------------------------------------------ ---------- ---------------- ------------------------ 
-  Identifier       Controller                                                               Renderer   Render Options   Fragment Options        
- ---------------- ------------------------------------------------------------------------ ---------- ---------------- ------------------------ 
-  contao.foo.bar   Contao\CoreBundle\Controller\FrontendModule\TwoFactorController          forward                     category : application  
-  contao.foo.baz   Symfony\Component\HttpKernel\Tests\DependencyInjection\ControllerDummy   forward                     category : foobar       
- ---------------- ------------------------------------------------------------------------ ---------- ---------------- ------------------------ 
+ ---------------- --------------------------------------------------------------------- ---------- ---------------- ------------------------ 
+  Identifier       Controller                                                            Renderer   Render Options   Fragment Options        
+ ---------------- --------------------------------------------------------------------- ---------- ---------------- ------------------------ 
+  contao.foo.bar   Contao\CoreBundle\Controller\FrontendModule\TwoFactorController       forward                     category : application  
+  contao.foo.baz   Contao\CoreBundle\Fixtures\Controller\FrontendModule\TestController   forward                     category : foobar       
+ ---------------- --------------------------------------------------------------------- ---------- ---------------- ------------------------ 
 
 
 OUTPUT
@@ -91,19 +91,19 @@ OUTPUT
 
         yield 'ESI fragment' => [
             [
-                ['contao.foo.bar', new FragmentConfig(ControllerDummy::class, 'esi', ['ignore_errors' => false]), ['category' => 'esi', 'foo' => 'bar']],
+                ['contao.foo.bar', new FragmentConfig(TestController::class, 'esi', ['ignore_errors' => false]), ['category' => 'esi', 'foo' => 'bar']],
             ],
             <<<'OUTPUT'
 
 Contao Fragments
 ================
 
- ---------------- ------------------------------------------------------------------------ ---------- ----------------------- ------------------ 
-  Identifier       Controller                                                               Renderer   Render Options          Fragment Options  
- ---------------- ------------------------------------------------------------------------ ---------- ----------------------- ------------------ 
-  contao.foo.bar   Symfony\Component\HttpKernel\Tests\DependencyInjection\ControllerDummy   esi        ignore_errors : false   category : esi    
-                                                                                                                               foo      : bar    
- ---------------- ------------------------------------------------------------------------ ---------- ----------------------- ------------------ 
+ ---------------- --------------------------------------------------------------------- ---------- ----------------------- ------------------ 
+  Identifier       Controller                                                            Renderer   Render Options          Fragment Options  
+ ---------------- --------------------------------------------------------------------- ---------- ----------------------- ------------------ 
+  contao.foo.bar   Contao\CoreBundle\Fixtures\Controller\FrontendModule\TestController   esi        ignore_errors : false   category : esi    
+                                                                                                                            foo      : bar    
+ ---------------- --------------------------------------------------------------------- ---------- ----------------------- ------------------ 
 
 
 OUTPUT

--- a/core-bundle/tests/DependencyInjection/Compiler/RegisterFragmentsPassTest.php
+++ b/core-bundle/tests/DependencyInjection/Compiler/RegisterFragmentsPassTest.php
@@ -148,6 +148,7 @@ class RegisterFragmentsPassTest extends TestCase
 
         $container = new ContainerBuilder();
         $container->setDefinition('contao.fragment.registry', new Definition());
+        $container->setDefinition('contao.command.debug_fragments', new Definition());
         $container->setDefinition('app.fragments.content_controller', $contentController);
 
         (new ResolveClassPass())->process($container);


### PR DESCRIPTION
This provides a new `debug:fragments` command in Contao to debug the controller fragments. Here's what it looks like in a default 4.8 installation.

```
Contao Fragments
================

 ----------------------------------- ----------------------------------------------------------------- ---------- ----------------------- ----------------------- 
  Identifier                          Controller                                                        Renderer   Render Options          Fragment Options       
 ----------------------------------- ----------------------------------------------------------------- ---------- ----------------------- ----------------------- 
  contao.frontend_module.two_factor   Contao\CoreBundle\Controller\FrontendModule\TwoFactorController   forward    ignore_errors : false   category : user        
                                                                                                                                           type     : two_factor  
 ----------------------------------- ----------------------------------------------------------------- ---------- ----------------------- ----------------------- 
```