### PR TITLE
Throw exception for non-absolute paths in image factory

### DIFF
--- a/core-bundle/src/Image/ImageFactory.php
+++ b/core-bundle/src/Image/ImageFactory.php
@@ -135,6 +135,12 @@ class ImageFactory implements ImageFactoryInterface
                 );
             }
 
+            if (!$this->filesystem->isAbsolutePath($path)) {
+                throw new \InvalidArgumentException(
+                    sprintf('Image path "%s" must be absolute', $path)
+                );
+            }
+
             if (
                 $this->resizer instanceof DeferredResizerInterface
                 && !$this->filesystem->exists($path)

--- a/core-bundle/src/Image/ImageFactory.php
+++ b/core-bundle/src/Image/ImageFactory.php
@@ -136,9 +136,7 @@ class ImageFactory implements ImageFactoryInterface
             }
 
             if (!$this->filesystem->isAbsolutePath($path)) {
-                throw new \InvalidArgumentException(
-                    sprintf('Image path "%s" must be absolute', $path)
-                );
+                throw new \InvalidArgumentException(sprintf('Image path "%s" must be absolute', $path));
             }
 
             if (

--- a/core-bundle/tests/Image/ImageFactoryTest.php
+++ b/core-bundle/tests/Image/ImageFactoryTest.php
@@ -181,6 +181,15 @@ class ImageFactoryTest extends TestCase
         $imageFactory->create($this->getFixturesDir().'/images/dummy.foo');
     }
 
+    public function testFailsToCreateAnImageObjectIfThePathIsNotAbsolute(): void
+    {
+        $imageFactory = $this->getImageFactory();
+
+        $this->expectException('InvalidArgumentException');
+
+        $imageFactory->create('images/dummy.jpg');
+    }
+
     public function testCreatesAnImageObjectFromAnImagePathWithAnImageSize(): void
     {
         $path = $this->getFixturesDir().'/images/dummy.jpg';
@@ -449,7 +458,7 @@ class ImageFactoryTest extends TestCase
         $path = $this->getFixturesDir().'/images/none.jpg';
         $imageMock = $this->createMock(ImageInterface::class);
 
-        $filesystem = $this->createMock(Filesystem::class);
+        $filesystem = $this->getMockBuilder(Filesystem::class)->setMethods(['exists'])->getMock();
         $filesystem
             ->expects($this->once())
             ->method('exists')

--- a/core-bundle/tests/Image/ImageFactoryTest.php
+++ b/core-bundle/tests/Image/ImageFactoryTest.php
@@ -458,7 +458,12 @@ class ImageFactoryTest extends TestCase
         $path = $this->getFixturesDir().'/images/none.jpg';
         $imageMock = $this->createMock(ImageInterface::class);
 
-        $filesystem = $this->getMockBuilder(Filesystem::class)->setMethods(['exists'])->getMock();
+        $filesystem = $this
+            ->getMockBuilder(Filesystem::class)
+            ->setMethods(['exists'])
+            ->getMock()
+        ;
+
         $filesystem
             ->expects($this->once())
             ->method('exists')

--- a/core-bundle/tests/Image/ImageFactoryTest.php
+++ b/core-bundle/tests/Image/ImageFactoryTest.php
@@ -186,6 +186,7 @@ class ImageFactoryTest extends TestCase
         $imageFactory = $this->getImageFactory();
 
         $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('Image path "images/dummy.jpg" must be absolute');
 
         $imageFactory->create('images/dummy.jpg');
     }


### PR DESCRIPTION
Calling `$imageFactory->create()` with a relative path can lead to ambiguous error messages because non-existent files are now possible with deferred images.

I think we should catch this error early to generate a meaningful error exception.