### PR TITLE
Support root language with region in language filter 

### DIFF
--- a/core-bundle/src/Routing/Matcher/LanguageFilter.php
+++ b/core-bundle/src/Routing/Matcher/LanguageFilter.php
@@ -37,7 +37,7 @@ class LanguageFilter implements RouteFilterInterface
      */
     public function filter(RouteCollection $collection, Request $request): RouteCollection
     {
-        $languages = str_replace('_', '-', $request->getLanguages());
+        $languages = $request->getLanguages();
 
         foreach ($collection->all() as $name => $route) {
             if ('.fallback' !== substr($name, -9) && ($this->prependLocale || '.root' !== substr($name, -5))) {
@@ -51,7 +51,8 @@ class LanguageFilter implements RouteFilterInterface
                 !$pageModel instanceof PageModel
                 || $pageModel->rootIsFallback
                 || \in_array($pageModel->rootLanguage, $languages, true)
-                || preg_grep('/'.preg_quote($pageModel->rootLanguage, '/').'-[A-Z]{2}/', $languages)
+                || \in_array(str_replace('-', '_', $pageModel->rootLanguage), $languages, true)
+                || preg_grep('/'.preg_quote($pageModel->rootLanguage, '/').'_[A-Z]{2}/', $languages)
             ) {
                 continue;
             }

--- a/core-bundle/src/Routing/Matcher/LanguageFilter.php
+++ b/core-bundle/src/Routing/Matcher/LanguageFilter.php
@@ -37,7 +37,7 @@ class LanguageFilter implements RouteFilterInterface
      */
     public function filter(RouteCollection $collection, Request $request): RouteCollection
     {
-        $languages = $request->getLanguages();
+        $languages = str_replace('_', '-', $request->getLanguages());
 
         foreach ($collection->all() as $name => $route) {
             if ('.fallback' !== substr($name, -9) && ($this->prependLocale || '.root' !== substr($name, -5))) {
@@ -51,7 +51,7 @@ class LanguageFilter implements RouteFilterInterface
                 !$pageModel instanceof PageModel
                 || $pageModel->rootIsFallback
                 || \in_array($pageModel->rootLanguage, $languages, true)
-                || preg_grep('/'.preg_quote($pageModel->rootLanguage, '/').'_[A-Z]{2}/', $languages)
+                || preg_grep('/'.preg_quote($pageModel->rootLanguage, '/').'-[A-Z]{2}/', $languages)
             ) {
                 continue;
             }

--- a/core-bundle/src/Routing/Matcher/LanguageFilter.php
+++ b/core-bundle/src/Routing/Matcher/LanguageFilter.php
@@ -50,7 +50,6 @@ class LanguageFilter implements RouteFilterInterface
             if (
                 !$pageModel instanceof PageModel
                 || $pageModel->rootIsFallback
-                || \in_array($pageModel->rootLanguage, $languages, true)
                 || \in_array(str_replace('-', '_', $pageModel->rootLanguage), $languages, true)
                 || preg_grep('/'.preg_quote($pageModel->rootLanguage, '/').'_[A-Z]{2}/', $languages)
             ) {

--- a/core-bundle/tests/Routing/Matcher/LanguageFilterTest.php
+++ b/core-bundle/tests/Routing/Matcher/LanguageFilterTest.php
@@ -114,5 +114,13 @@ class LanguageFilterTest extends TestCase
             true,
             false,
         ];
+
+        yield 'Does not remove a route if the root page language with region code is equal accepted language' => [
+            'tl_page.2.root',
+            $this->mockClassWithProperties(PageModel::class, ['rootIsFallback' => false, 'rootLanguage' => 'de-CH']),
+            'de-CH',
+            true,
+            false
+        ];
     }
 }

--- a/core-bundle/tests/Routing/Matcher/LanguageFilterTest.php
+++ b/core-bundle/tests/Routing/Matcher/LanguageFilterTest.php
@@ -115,7 +115,7 @@ class LanguageFilterTest extends TestCase
             false,
         ];
 
-        yield 'Does not remove a route if the root page language with region code is equal accepted language' => [
+        yield 'Does not remove a route if the root page language with region code equals the accepted language' => [
             'tl_page.2.root',
             $this->mockClassWithProperties(PageModel::class, ['rootIsFallback' => false, 'rootLanguage' => 'de-CH']),
             'de-CH',


### PR DESCRIPTION
If you set a language with region (e.g. 'de-CH') as language for a root page, the routing language filter will remove that route, because the languages of the request are Locale IDs (with underscore) instead of Language Tags (with dash).