### PR TITLE
Fix stuff found by PHP Insights

### DIFF
--- a/core-bundle/src/Analyzer/HtaccessAnalyzer.php
+++ b/core-bundle/src/Analyzer/HtaccessAnalyzer.php
@@ -61,7 +61,7 @@ class HtaccessAnalyzer
             return false;
         }
 
-        return (false !== stripos($line, 'Allow from all')) || (false !== stripos($line, 'Require all granted'));
+        return false !== stripos($line, 'Allow from all') || false !== stripos($line, 'Require all granted');
     }
 
     /**

--- a/core-bundle/src/Command/AbstractLockedCommand.php
+++ b/core-bundle/src/Command/AbstractLockedCommand.php
@@ -41,13 +41,12 @@ abstract class AbstractLockedCommand extends ContainerAwareCommand
             return 1;
         }
 
-        if (($errorCode = $this->executeLocked($input, $output)) > 0) {
-            $lock->release();
+        $errorCode = $this->executeLocked($input, $output);
+        $lock->release();
 
+        if ($errorCode > 0) {
             return $errorCode;
         }
-
-        $lock->release();
 
         return 0;
     }

--- a/core-bundle/src/Command/ResizeImagesCommand.php
+++ b/core-bundle/src/Command/ResizeImagesCommand.php
@@ -165,7 +165,8 @@ class ResizeImagesCommand extends Command
                     // Clear the current output line
                     $output->write("\r".str_repeat(' ', $this->terminalWidth)."\r");
                 } else {
-                    $output->writeln(sprintf('done%7.3Fs', $duration = microtime(true) - $startTime));
+                    $duration = microtime(true) - $startTime;
+                    $output->writeln(sprintf('done%7.3Fs', $duration));
 
                     return $duration;
                 }

--- a/core-bundle/src/Composer/ScriptHandler.php
+++ b/core-bundle/src/Composer/ScriptHandler.php
@@ -45,7 +45,7 @@ class ScriptHandler
             self::loadRandomCompat($event);
         }
 
-        putenv(self::RANDOM_SECRET_NAME.'='.bin2hex(random_bytes(32)));
+        putenv(static::RANDOM_SECRET_NAME.'='.bin2hex(random_bytes(32)));
     }
 
     /**

--- a/core-bundle/src/Composer/ScriptHandler.php
+++ b/core-bundle/src/Composer/ScriptHandler.php
@@ -45,7 +45,7 @@ class ScriptHandler
             self::loadRandomCompat($event);
         }
 
-        putenv(static::RANDOM_SECRET_NAME.'='.bin2hex(random_bytes(32)));
+        putenv(self::RANDOM_SECRET_NAME.'='.bin2hex(random_bytes(32)));
     }
 
     /**

--- a/core-bundle/src/Cors/WebsiteRootsConfigProvider.php
+++ b/core-bundle/src/Cors/WebsiteRootsConfigProvider.php
@@ -68,8 +68,7 @@ class WebsiteRootsConfigProvider implements ProviderInterface
      */
     private function isCorsRequest(Request $request): bool
     {
-        return
-            $request->headers->has('Origin')
+        return $request->headers->has('Origin')
             && $request->headers->get('Origin') !== $request->getSchemeAndHttpHost()
         ;
     }

--- a/core-bundle/src/Doctrine/DBAL/Types/BinaryStringType.php
+++ b/core-bundle/src/Doctrine/DBAL/Types/BinaryStringType.php
@@ -20,9 +20,6 @@ use Doctrine\DBAL\Types\Type;
  */
 class BinaryStringType extends Type
 {
-    /**
-     * @var string
-     */
     public const NAME = 'binary_string';
 
     /**

--- a/core-bundle/src/Event/ContaoCoreEvents.php
+++ b/core-bundle/src/Event/ContaoCoreEvents.php
@@ -17,16 +17,12 @@ final class ContaoCoreEvents
     /**
      * The contao.backend_menu_build event is triggered when the backend menu is built.
      *
-     * @var string
-     *
      * @see MenuEvent
      */
     public const BACKEND_MENU_BUILD = 'contao.backend_menu_build';
 
     /**
      * The contao.generate_symlinks event is triggered when the symlinks are generated.
-     *
-     * @var string
      *
      * @see GenerateSymlinksEvent
      */
@@ -35,16 +31,12 @@ final class ContaoCoreEvents
     /**
      * The contao.image_sizes_all event is triggered when the image sizes are generated.
      *
-     * @var string
-     *
      * @see ImageSizesEvent
      */
     public const IMAGE_SIZES_ALL = 'contao.image_sizes_all';
 
     /**
      * The contao.image_sizes_user event is triggered when the image sizes are generated for a user.
-     *
-     * @var string
      *
      * @see ImageSizesEvent
      */
@@ -53,16 +45,12 @@ final class ContaoCoreEvents
     /**
      * The contao.preview_url_create event is triggered when the front end preview URL is generated.
      *
-     * @var string
-     *
      * @see PreviewUrlCreateEvent
      */
     public const PREVIEW_URL_CREATE = 'contao.preview_url_create';
 
     /**
      * The contao.preview_url_convert event is triggered when the front end preview URL is converted.
-     *
-     * @var string
      *
      * @see PreviewUrlConvertEvent
      */
@@ -71,16 +59,12 @@ final class ContaoCoreEvents
     /**
      * The contao.robots_txt event is triggered when the /robots.txt route is called.
      *
-     * @var string
-     *
      * @see RobotsTxtEvent
      */
     public const ROBOTS_TXT = 'contao.robots_txt';
 
     /**
      * The contao.slug_valid_characters event is triggered when the valid slug characters options are generated.
-     *
-     * @var string
      *
      * @see SlugValidCharactersEvent
      */

--- a/core-bundle/src/Routing/RouteProvider.php
+++ b/core-bundle/src/Routing/RouteProvider.php
@@ -501,7 +501,12 @@ class RouteProvider implements RouteProviderInterface
         $return = [];
         $models = array_filter($models);
 
-        array_walk_recursive($models, static function ($i) use (&$return): void { $return[] = $i; });
+        array_walk_recursive(
+            $models,
+            static function ($i) use (&$return): void {
+                $return[] = $i;
+            }
+        );
 
         return $return;
     }

--- a/core-bundle/tests/Contao/ImageTest.php
+++ b/core-bundle/tests/Contao/ImageTest.php
@@ -1365,7 +1365,7 @@ class ImageTest extends TestCase
     public function testExecutesTheResizeHook(): void
     {
         $GLOBALS['TL_HOOKS'] = [
-            'executeResize' => [[\get_class($this), 'executeResizeHookCallback']],
+            'executeResize' => [[static::class, 'executeResizeHookCallback']],
         ];
 
         $file = new File('dummy.jpg');
@@ -1447,7 +1447,7 @@ class ImageTest extends TestCase
         System::getContainer()->get('contao.image.resizer')->resizeDeferredImage($deferredImage);
 
         $GLOBALS['TL_HOOKS'] = [
-            'getImage' => [[\get_class($this), 'getImageHookCallback']],
+            'getImage' => [[static::class, 'getImageHookCallback']],
         ];
 
         $imageObj = new Image($file);

--- a/core-bundle/tests/ContaoManager/PluginTest.php
+++ b/core-bundle/tests/ContaoManager/PluginTest.php
@@ -42,7 +42,7 @@ class PluginTest extends TestCase
     {
         $plugin = new Plugin();
 
-        /** @var BundleConfig[]|array $bundles */
+        /** @var BundleConfig[] $bundles */
         $bundles = $plugin->getBundles(new DelegatingParser());
 
         $this->assertCount(6, $bundles);

--- a/core-bundle/tests/Image/ImageFactoryTest.php
+++ b/core-bundle/tests/Image/ImageFactoryTest.php
@@ -630,7 +630,7 @@ class ImageFactoryTest extends TestCase
         $imageFactory = $this->getImageFactory($resizer, $imagine, $imagine, null, $framework);
 
         $GLOBALS['TL_HOOKS'] = [
-            'executeResize' => [[\get_class($this), 'executeResizeHookCallback']],
+            'executeResize' => [[static::class, 'executeResizeHookCallback']],
         ];
 
         $image = $imageFactory->create($path, [100, 100, ResizeConfiguration::MODE_CROP]);
@@ -708,14 +708,14 @@ class ImageFactoryTest extends TestCase
         $imageFactory = $this->getImageFactory($resizer, $imagine, $imagine, null, $framework);
 
         $GLOBALS['TL_HOOKS'] = [
-            'executeResize' => [[\get_class($this), 'executeResizeHookCallback']],
+            'executeResize' => [[static::class, 'executeResizeHookCallback']],
         ];
 
         // Build cache before adding the hook
         $imageFactory->create($path, [50, 50, ResizeConfiguration::MODE_CROP]);
 
         $GLOBALS['TL_HOOKS'] = [
-            'getImage' => [[\get_class($this), 'getImageHookCallback']],
+            'getImage' => [[static::class, 'getImageHookCallback']],
         ];
 
         $image = $imageFactory->create($path, [100, 100, ResizeConfiguration::MODE_CROP]);
@@ -801,7 +801,7 @@ class ImageFactoryTest extends TestCase
         $imageFactory = $this->getImageFactory($resizer, $imagine, $imagine, null, $framework);
 
         $GLOBALS['TL_HOOKS'] = [
-            'getImage' => [[\get_class($this), 'emptyHookCallback']],
+            'getImage' => [[static::class, 'emptyHookCallback']],
         ];
 
         $image = $imageFactory->create($path, [100, 100, ResizeConfiguration::MODE_CROP]);

--- a/core-bundle/tests/Monolog/ContaoTableHandlerTest.php
+++ b/core-bundle/tests/Monolog/ContaoTableHandlerTest.php
@@ -66,7 +66,7 @@ class ContaoTableHandlerTest extends TestCase
         $container->set('contao.framework', $this->mockContaoFramework([System::class => $system]));
         $container->set('doctrine.dbal.default_connection', $connection);
 
-        $GLOBALS['TL_HOOKS']['addLogEntry'][] = [\get_class($this), 'addLogEntry'];
+        $GLOBALS['TL_HOOKS']['addLogEntry'][] = [static::class, 'addLogEntry'];
 
         $handler = new ContaoTableHandler();
         $handler->setContainer($container);

--- a/installation-bundle/src/Database/Version410Update.php
+++ b/installation-bundle/src/Database/Version410Update.php
@@ -43,7 +43,7 @@ class Version410Update extends AbstractVersionUpdate
 
         $options = [];
 
-        foreach ($crop as $group => $modes) {
+        foreach ($crop as $modes) {
             $options[] = array_values($modes);
         }
 

--- a/installation-bundle/src/Event/ContaoInstallationEvents.php
+++ b/installation-bundle/src/Event/ContaoInstallationEvents.php
@@ -17,8 +17,6 @@ final class ContaoInstallationEvents
     /**
      * The contao_installation.initialize_application event is triggered in the install tool.
      *
-     * @var string
-     *
      * @see InitializeApplicationEvent
      */
     public const INITIALIZE_APPLICATION = 'contao_installation.initialize_application';

--- a/manager-bundle/tests/ContaoManager/PluginTest.php
+++ b/manager-bundle/tests/ContaoManager/PluginTest.php
@@ -52,7 +52,7 @@ class PluginTest extends ContaoTestCase
     {
         $plugin = new Plugin();
 
-        /** @var BundleConfig[]|array $bundles */
+        /** @var BundleConfig[] $bundles */
         $bundles = $plugin->getBundles(new DelegatingParser());
 
         $this->assertCount(14, $bundles);
@@ -248,7 +248,7 @@ class PluginTest extends ContaoTestCase
         $plugin = new Plugin();
         $collection = $plugin->getRouteCollection($resolver, $kernel);
 
-        /** @var Route[]|array $routes */
+        /** @var Route[] $routes */
         $routes = array_values($collection->all());
 
         $this->assertCount(3, $routes);


### PR DESCRIPTION
As discussed in today's Mumble call, I have been trying out PHP Insights. It is an impressive tool for sure, however, I do not think that it is the right one for us. As the authors state themselves, "PHP Insights is opinionated", and their opinions differ a lot from the Symfony ones.

This is the configuration I ended up using: 

```php
return [
    'preset' => 'symfony',
    'exclude' => [
        'src/Resources',
    ],
    'add' => [
        RequireYodaComparisonSniff::class,
    ],
    'remove' => [
        AssignmentInConditionSniff::class,
        ClassTraitAndInterfaceLengthSniff::class,
        ComposerLockMustBeFresh::class,
        CyclomaticComplexityIsHigh::class,
        DisallowShortTernaryOperatorSniff::class,
        DisallowYodaComparisonSniff::class,
        ElementNameMinimalLengthSniff::class,
        EmptyStatementSniff::class,
        ForbiddenGlobals::class,
        ForbiddenNormalClasses::class,
        ForbiddenSetterSniff::class,
        ForbiddenTraits::class,
        FunctionLengthSniff::class,
        LineLengthSniff::class,
        MaxNestingLevelSniff::class,
        MethodPerClassLimitSniff::class,
        NoSilencedErrorsSniff::class,
        PropertyPerClassLimitSniff::class,
        SideEffectsSniff::class,
        SpaceAfterNotSniff::class,
        SuperfluousAbstractClassNamingSniff::class,
        SuperfluousExceptionNamingSniff::class,
        SuperfluousInterfaceNamingSniff::class,
        SuperfluousTraitNamingSniff::class,
    ],
    'config' => [
        NamespaceSpacingSniff::class => [
            'linesCountBeforeNamespace' => 2,
        ],
    ],
];
```

What bothers me most, is that there are no explanations why certain fixers are enabled. Disallow short ternary operators – why? Disallow setter injection – why?  No silenced errors – that is not gonna work with Symfony deprecations.

Still I think it is worth to discuss the other findings.

**Forbidden public property**

`core-bundle/src/ServiceAnnotation/Hook.php:35`: Do not use public properties. Use method access instead.

Why do we have public properties there?

**Nullable type for null default value**

`manager-bundle/src/HttpKernel/JwtManager.php:48`: Parameter $filesystem has null default value, but is not marked as nullable.

Technically, using `method(Filesystem $filesystem = null)` is fine. But I wonder if we should still change this to `method(?Filesystem $filesystem = null)`?

**Disallow empty**

`manager-bundle/src/ContaoManager/Plugin.php:290`: Use of empty() is disallowed.

No explanation given, therefore I assume that PHP Insights wants us to replace all `empty($array)` with `0 === \count($array)`?

**Disallow array type hint syntax**

`manager-bundle/src/ContaoManager/Plugin.php:104`: Usage of array type hint syntax in "SplFileInfo[]" is disallowed, use generic type hint syntax instead.

I would indeed prefer using generic type hints (`array<SplFileInfo>`) instead of array type hints. WDYT?

**Useless inherit doc comment**

`news-bundle/src/Picker/NewsPickerProvider.php:59`: Useless documentation comment with @inheritDoc

I do not really understand why the phpDoc is useless here – again, an explanation would help. Do you think so, too? I would happily remove the phpDocs then.
