### PR TITLE
ContaoFramework::setConstants()

### DIFF
--- a/core-bundle/src/Framework/ContaoFramework.php
+++ b/core-bundle/src/Framework/ContaoFramework.php
@@ -85,6 +85,11 @@ class ContaoFramework implements ContaoFrameworkInterface, ContainerAwareInterfa
      */
     private $hookListeners = [];
 
+    /**
+     * @var array
+     */
+    private $constants = [];
+
     public function __construct(RequestStack $requestStack, ScopeMatcher $scopeMatcher, TokenChecker $tokenChecker, string $rootDir, int $errorLevel)
     {
         $this->requestStack = $requestStack;
@@ -160,6 +165,12 @@ class ContaoFramework implements ContaoFrameworkInterface, ContainerAwareInterfa
 
     public function setConstant(string $name, $value): void
     {
+        if (\array_key_exists($name, $this->constants)) {
+            return;
+        }
+
+        $this->constants[$name] = $value;
+
         if (!\defined($name)) {
             \define($name, $value);
         }
@@ -167,7 +178,16 @@ class ContaoFramework implements ContaoFrameworkInterface, ContainerAwareInterfa
 
     public function getConstant(string $name)
     {
+        if (\array_key_exists($name, $this->constants)) {
+            return $this->constants[$name];
+        }
+
         return \defined($name) ? \constant($name) : null;
+    }
+
+    public function hasConstant(string $name): bool
+    {
+        return \array_key_exists($name, $this->constants) || \defined($name);
     }
 
     /**

--- a/core-bundle/src/Framework/ContaoFramework.php
+++ b/core-bundle/src/Framework/ContaoFramework.php
@@ -192,7 +192,7 @@ class ContaoFramework implements ContaoFrameworkInterface, ContainerAwareInterfa
     public function getConstant(string $name)
     {
         if (\array_key_exists($name, self::$deprecatedConstants)) {
-            trigger_error(self::$deprecatedConstants[$name], E_USER_DEPRECATED);
+            @trigger_error(self::$deprecatedConstants[$name], E_USER_DEPRECATED);
         }
 
         if (\array_key_exists($name, $this->constants)) {

--- a/core-bundle/src/Framework/ContaoFramework.php
+++ b/core-bundle/src/Framework/ContaoFramework.php
@@ -83,11 +83,6 @@ class ContaoFramework implements ContaoFrameworkInterface, ContainerAwareInterfa
     /**
      * @var array
      */
-    private $constants = [];
-
-    /**
-     * @var array
-     */
     private $hookListeners = [];
 
     public function __construct(RequestStack $requestStack, ScopeMatcher $scopeMatcher, TokenChecker $tokenChecker, string $rootDir, int $errorLevel)
@@ -165,20 +160,14 @@ class ContaoFramework implements ContaoFrameworkInterface, ContainerAwareInterfa
 
     public function setConstant(string $name, $value): void
     {
-        if (isset($this->constants[$name])) {
-            throw new \InvalidArgumentException(sprintf('The constant "%s" has already been defined', $name));
-        }
-
         if (!\defined($name)) {
             \define($name, $value);
         }
-
-        $this->constants[$name] = $value;
     }
 
     public function getConstant(string $name)
     {
-        return $this->constants[$name] ?? null;
+        return \defined($name) ? \constant($name) : null;
     }
 
     /**

--- a/core-bundle/src/Framework/ContaoFramework.php
+++ b/core-bundle/src/Framework/ContaoFramework.php
@@ -41,6 +41,19 @@ class ContaoFramework implements ContaoFrameworkInterface, ContainerAwareInterfa
     private static $initialized = false;
 
     /**
+     * @var array
+     */
+    private static $deprecatedConstants = [
+        'TL_START' => 'The TL_START constant is deprecated and will be removed in a next major version.',
+        'TL_SCRIPT' => 'The TL_SCRIPT constant is deprecated and will be removed in a next major version.',
+        'TL_MODE' => 'The TL_MODE constant is deprecated, use the contao.routing.scope_matcher service instead.',
+        'TL_ROOT' => 'The TL_ROOT constant is deprecated, use the %kernel.project_dir% parameter instead.',
+        'TL_PATH' => 'The TL_PATH constant is deprecated, use the Request::getBasePath() method instead.',
+        'BE_USER_LOGGED_IN' => 'The BE_USER_LOGGED_IN constant is deprecated, use the contao.security.token_checker service instead.',
+        'FE_USER_LOGGED_IN' => 'The BE_USER_LOGGED_IN constant is deprecated, use the contao.security.token_checker service instead.',
+    ];
+
+    /**
      * @var RequestStack
      */
     private $requestStack;
@@ -178,6 +191,10 @@ class ContaoFramework implements ContaoFrameworkInterface, ContainerAwareInterfa
 
     public function getConstant(string $name)
     {
+        if (\array_key_exists($name, self::$deprecatedConstants)) {
+            trigger_error(self::$deprecatedConstants[$name], E_USER_DEPRECATED);
+        }
+
         if (\array_key_exists($name, $this->constants)) {
             return $this->constants[$name];
         }
@@ -188,6 +205,18 @@ class ContaoFramework implements ContaoFrameworkInterface, ContainerAwareInterfa
     public function hasConstant(string $name): bool
     {
         return \array_key_exists($name, $this->constants) || \defined($name);
+    }
+
+    /**
+     * Marks a constant as deprecated and triggers a deprecation warning when accessing it.
+     */
+    public static function setDeprecatedConstant(string $name, string $message)
+    {
+        if (\array_key_exists($name, self::$deprecatedConstants)) {
+            return;
+        }
+
+        self::$deprecatedConstants[$name] = $message;
     }
 
     /**

--- a/core-bundle/src/Resources/contao/classes/Backend.php
+++ b/core-bundle/src/Resources/contao/classes/Backend.php
@@ -328,7 +328,9 @@ abstract class Backend extends Controller
 			$objSession->set('CURRENT_ID', $id);
 		}
 
-		\define('CURRENT_ID', (Input::get('table') ? $id : Input::get('id')));
+		$framework = System::getContainer()->get('contao.framework');
+		$framework->setConstant('CURRENT_ID', (Input::get('table') ? $id : Input::get('id')));
+
 		$this->Template->headline = $GLOBALS['TL_LANG']['MOD'][$module][0];
 
 		// Add the module style sheet

--- a/core-bundle/src/Resources/contao/controllers/BackendFile.php
+++ b/core-bundle/src/Resources/contao/controllers/BackendFile.php
@@ -74,7 +74,8 @@ class BackendFile extends Backend
 		$strField = Input::get('field');
 
 		// Define the current ID
-		\define('CURRENT_ID', (Input::get('table') ? $objSession->get('CURRENT_ID') : Input::get('id')));
+		$framework = System::getContainer()->get('contao.framework');
+		$framework->setConstant('CURRENT_ID', (Input::get('table') ? $objSession->get('CURRENT_ID') : Input::get('id')));
 
 		$this->loadDataContainer($strTable);
 		$strDriver = 'DC_' . $GLOBALS['TL_DCA'][$strTable]['config']['dataContainer'];

--- a/core-bundle/src/Resources/contao/controllers/BackendPage.php
+++ b/core-bundle/src/Resources/contao/controllers/BackendPage.php
@@ -74,7 +74,8 @@ class BackendPage extends Backend
 		$strField = Input::get('field');
 
 		// Define the current ID
-		\define('CURRENT_ID', (Input::get('table') ? $objSession->get('CURRENT_ID') : Input::get('id')));
+		$framework = System::getContainer()->get('contao.framework');
+		$framework->setConstant('CURRENT_ID', (Input::get('table') ? $objSession->get('CURRENT_ID') : Input::get('id')));
 
 		$this->loadDataContainer($strTable);
 		$strDriver = 'DC_' . $GLOBALS['TL_DCA'][$strTable]['config']['dataContainer'];

--- a/core-bundle/src/Resources/contao/library/Contao/Controller.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Controller.php
@@ -1930,6 +1930,7 @@ abstract class Controller extends System
 				$GLOBALS['objPage'] = func_get_arg(0);
 			}
 		}
+
 		$framework = System::getContainer()->get('contao.framework');
 		$framework->setConstant('TL_ASSETS_URL', System::getContainer()->get('contao.assets.assets_context')->getStaticUrl());
 		$framework->setConstant('TL_FILES_URL', System::getContainer()->get('contao.assets.files_context')->getStaticUrl());

--- a/core-bundle/src/Resources/contao/library/Contao/Controller.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Controller.php
@@ -1930,13 +1930,13 @@ abstract class Controller extends System
 				$GLOBALS['objPage'] = func_get_arg(0);
 			}
 		}
-
-		\define('TL_ASSETS_URL', System::getContainer()->get('contao.assets.assets_context')->getStaticUrl());
-		\define('TL_FILES_URL', System::getContainer()->get('contao.assets.files_context')->getStaticUrl());
+		$framework = System::getContainer()->get('contao.framework');
+		$framework->setConstant('TL_ASSETS_URL', System::getContainer()->get('contao.assets.assets_context')->getStaticUrl());
+		$framework->setConstant('TL_FILES_URL', System::getContainer()->get('contao.assets.files_context')->getStaticUrl());
 
 		// Deprecated since Contao 4.0, to be removed in Contao 5.0
-		\define('TL_SCRIPT_URL', TL_ASSETS_URL);
-		\define('TL_PLUGINS_URL', TL_ASSETS_URL);
+		$framework->setConstant('TL_SCRIPT_URL', $framework->getConstant('TL_ASSETS_URL'));
+		$framework->setConstant('TL_PLUGINS_URL', $framework->getConstant('TL_ASSETS_URL'));
 	}
 
 	/**

--- a/core-bundle/tests/Controller/FrontendControllerTest.php
+++ b/core-bundle/tests/Controller/FrontendControllerTest.php
@@ -43,10 +43,6 @@ class FrontendControllerTest extends TestCase
         $controller->loginAction();
     }
 
-    /**
-     * @runInSeparateProcess
-     * @preserveGlobalState disabled
-     */
     public function testRendersTheError401PageUponLogin(): void
     {
         $framework = $this->mockContaoFramework();
@@ -70,10 +66,6 @@ class FrontendControllerTest extends TestCase
         unset($GLOBALS['TL_PTY']);
     }
 
-    /**
-     * @runInSeparateProcess
-     * @preserveGlobalState disabled
-     */
     public function testThrowsAnExceptionUponLoginIfTheError401PageThrowsAnException(): void
     {
         $framework = $this->mockContaoFramework();
@@ -155,10 +147,6 @@ class FrontendControllerTest extends TestCase
         $this->assertSame('document.querySelectorAll("input[name=REQUEST_TOKEN]").forEach(function(i){i.value="tokenValue"})', $response->getContent());
     }
 
-    /**
-     * @runInSeparateProcess
-     * @preserveGlobalState disabled
-     */
     public function testRendersTheError401PageForTwoFactorRoute(): void
     {
         $framework = $this->mockContaoFramework();
@@ -182,10 +170,6 @@ class FrontendControllerTest extends TestCase
         unset($GLOBALS['TL_PTY']);
     }
 
-    /**
-     * @runInSeparateProcess
-     * @preserveGlobalState disabled
-     */
     public function testThrowsUnauthorizedHttpExceptionIfNoError401PageTypeIsAvailableForTwoFactorRoute(): void
     {
         $framework = $this->mockContaoFramework();
@@ -206,10 +190,6 @@ class FrontendControllerTest extends TestCase
         $controller->twoFactorAuthenticationAction();
     }
 
-    /**
-     * @runInSeparateProcess
-     * @preserveGlobalState disabled
-     */
     public function testThrowsAnExceptionUponTwoFactorAuthenticationIfTheError401PageThrowsAnException(): void
     {
         $framework = $this->mockContaoFramework();


### PR DESCRIPTION
This PR is work in progress, but I want to discuss the concept with you before I continue working on it.

As you know, we have a really handy `ContaoFramework::getAdapter()` method, which allows us to mock methods of the Contao 3 framework in unit tests. It always bothered me that we do not have the same for constants and thus have to use `@runInSeparateProcess` extensively.

This PR adds two methods to the `contao.framework` service, which allow us to set and get constants in a backwards compatible way. The advantage should be obvious: We can now mock the `getConstant()` method in our unit tests and remove most of the `@runInSeparateProcess` annotations.

@contao/developers WDYT?