### PR TITLE
Fix a potential problem with backend module permissions for regular users

### DIFF
--- a/core-bundle/src/Resources/contao/dca/tl_user.php
+++ b/core-bundle/src/Resources/contao/dca/tl_user.php
@@ -761,7 +761,8 @@ class tl_user extends Backend
 			unset($arrModules['design'][$key]);
 		}
 
-		return $arrModules;
+		// Reset the module indexes and return modules
+		return array_map('array_values', $arrModules);
 	}
 
 	/**

--- a/core-bundle/src/Resources/contao/dca/tl_user_group.php
+++ b/core-bundle/src/Resources/contao/dca/tl_user_group.php
@@ -323,7 +323,8 @@ class tl_user_group extends Backend
 			unset($arrModules['design'][$key]);
 		}
 
-		return $arrModules;
+		// Reset the module indexes and return modules
+		return array_map('array_values', $arrModules);
 	}
 
 	/**


### PR DESCRIPTION
If one of the backend modules "in the middle" is unset, then the module permissions checkbox list will get incorrect values because the modules array will no longer be numeric. For example if we have the following system backend modules:

```
[system] => Array
(
    [0] => files
    [1] => log
    [2] => maintenance
    [3] => undo
    [4] => url_rewrites
)
```

The "undo" module is [unset automatically](https://github.com/contao/contao/blob/4.4/core-bundle/src/Resources/contao/dca/tl_user_group.php#L315) for the backend module permissions field which results in an array:

```
[system] => Array
(
    [0] => files
    [1] => log
    [2] => maintenance
    [4] => url_rewrites
)
```

Thus the array is no longer numeric but associative and checkbox values in the field are being generated incorrectly (e.g. value="2" instead of value="maintenance").

![2019-10-25 at 17 08](https://user-images.githubusercontent.com/193483/67583778-8906a500-f74c-11e9-8957-a9ac5b7077ae.png)

/cc @Toflar