### PR TITLE
[POC] Shared entities

### DIFF
--- a/core-bundle/src/ContaoCoreBundle.php
+++ b/core-bundle/src/ContaoCoreBundle.php
@@ -17,6 +17,7 @@ use Contao\CoreBundle\DependencyInjection\Compiler\AddPackagesPass;
 use Contao\CoreBundle\DependencyInjection\Compiler\AddResourcesPathsPass;
 use Contao\CoreBundle\DependencyInjection\Compiler\AddSessionBagsPass;
 use Contao\CoreBundle\DependencyInjection\Compiler\DataContainerCallbackPass;
+use Contao\CoreBundle\DependencyInjection\Compiler\ExtendableEntityPass;
 use Contao\CoreBundle\DependencyInjection\Compiler\MakeServicesPublicPass;
 use Contao\CoreBundle\DependencyInjection\Compiler\MapFragmentsToGlobalsPass;
 use Contao\CoreBundle\DependencyInjection\Compiler\PickerProviderPass;
@@ -83,5 +84,6 @@ class ContaoCoreBundle extends Bundle
         $container->addCompilerPass(new TranslationDataCollectorPass());
         $container->addCompilerPass(new RegisterHookListenersPass(), PassConfig::TYPE_OPTIMIZE);
         $container->addCompilerPass(new SearchIndexerPass());
+        $container->addCompilerPass(new ExtendableEntityPass());
     }
 }

--- a/core-bundle/src/DependencyInjection/Compiler/ExtendableEntityPass.php
+++ b/core-bundle/src/DependencyInjection/Compiler/ExtendableEntityPass.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\DependencyInjection\Compiler;
+
+use Contao\CoreBundle\Doctrine\ORM\ExtendableEntity\ExtensionRegistry;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class ExtendableEntityPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$container->has(ExtensionRegistry::class)) {
+            return;
+        }
+
+        $extensions = $this->getExtensions($container);
+
+        if (empty($extensions)) {
+            return;
+        }
+
+        $definition = $container->getDefinition(ExtensionRegistry::class);
+        $definition->addMethodCall('setExtensions', [$extensions]);
+    }
+
+    private function getExtensions(ContainerBuilder $container): array
+    {
+        $extensions = [];
+        $serviceIds = $container->findTaggedServiceIds('contao.extendable_entity');
+
+        foreach ($serviceIds as $serviceId => $tags) {
+            if ($container->hasAlias($serviceId)) {
+                $serviceId = (string) $container->getAlias($serviceId);
+            }
+
+            foreach ($tags as $attributes) {
+                if (!isset($attributes['entity'])) {
+                    throw new InvalidConfigurationException(
+                        sprintf('Missing entity attribute in tagged hook service with service id "%s"', $serviceId)
+                    );
+                }
+
+                $extensions[$attributes['entity']] = $container->getDefinition($serviceId)->getClass();
+            }
+        }
+
+        return $extensions;
+    }
+}

--- a/core-bundle/src/Doctrine/ORM/ExtendableEntity/DelegatingAnnotationReader.php
+++ b/core-bundle/src/Doctrine/ORM/ExtendableEntity/DelegatingAnnotationReader.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Doctrine\ORM\ExtendableEntity;
+
+use Doctrine\Common\Annotations\Reader;
+use Doctrine\ORM\Mapping\DiscriminatorMap;
+
+class DelegatingAnnotationReader implements Reader
+{
+    /** @var Reader */
+    private $reader;
+
+    /** @var ExtensionRegistry */
+    private $registry;
+
+    public function __construct(Reader $reader, ExtensionRegistry $registry)
+    {
+        $this->reader = $reader;
+        $this->registry = $registry;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * Add registered mappings of extending classes to the DiscriminatorMap.
+     */
+    public function getClassAnnotations(\ReflectionClass $class): array
+    {
+        $annotations = $this->reader->getClassAnnotations($class);
+
+        if (!$class->implementsInterface(ExtendableEntity::class)) {
+            return $annotations;
+        }
+
+        $extensions = $this->registry->getExtensions($class->getName());
+
+        if (empty($extensions)) {
+            return $annotations;
+        }
+
+        // extend the discriminator map
+        foreach ($annotations as $annotation) {
+            if ($annotation instanceof DiscriminatorMap) {
+                $annotation->value = array_merge($annotation->value, $extensions);
+
+                return $annotations;
+            }
+        }
+
+        // add a discriminator map if not present
+        $discriminatorMap = new DiscriminatorMap();
+        $discriminatorMap->value = $extensions;
+
+        $annotations[] = $discriminatorMap;
+
+        return $annotations;
+    }
+
+    public function getClassAnnotation(\ReflectionClass $class, $annotationName)
+    {
+        // delegate call
+        return $this->reader->getClassAnnotation($class, $annotationName);
+    }
+
+    public function getMethodAnnotations(\ReflectionMethod $method): array
+    {
+        // delegate call
+        return $this->reader->getMethodAnnotations($method);
+    }
+
+    public function getMethodAnnotation(\ReflectionMethod $method, $annotationName)
+    {
+        // delegate call
+        return $this->reader->getMethodAnnotation($method, $annotationName);
+    }
+
+    public function getPropertyAnnotations(\ReflectionProperty $property): array
+    {
+        // delegate call
+        return $this->reader->getPropertyAnnotations($property);
+    }
+
+    public function getPropertyAnnotation(\ReflectionProperty $property, $annotationName)
+    {
+        // delegate call
+        return $this->reader->getPropertyAnnotation($property, $annotationName);
+    }
+}

--- a/core-bundle/src/Doctrine/ORM/ExtendableEntity/ExtendableEntity.php
+++ b/core-bundle/src/Doctrine/ORM/ExtendableEntity/ExtendableEntity.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Doctrine\ORM\ExtendableEntity;
+
+/**
+ * This interface acts as a tag for doctrine entities with single table
+ * inheritance configured that should be able to be extended by 3rd party
+ * entities. Make sure to specify a DiscriminatorColumn.
+ */
+interface ExtendableEntity
+{
+}

--- a/core-bundle/src/Doctrine/ORM/ExtendableEntity/ExtensionRegistry.php
+++ b/core-bundle/src/Doctrine/ORM/ExtendableEntity/ExtensionRegistry.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Doctrine\ORM\ExtendableEntity;
+
+use Doctrine\ORM\EntityNotFoundException;
+
+class ExtensionRegistry
+{
+    /** @var array */
+    private $extensionMapping = [];
+
+    public function setExtensions(array $extensions): void
+    {
+        foreach ($extensions as $name => $class) {
+            $targetClass = $this->getSharedParentClass($class);
+
+            if (!\array_key_exists($targetClass, $this->extensionMapping)) {
+                $this->extensionMapping[$targetClass] = [];
+            }
+
+            $this->extensionMapping[$targetClass][$name] = $class;
+        }
+    }
+
+    public function getExtensions(string $className): array
+    {
+        return $this->extensionMapping[$className] ?? [];
+    }
+
+    /**
+     * Find parent class that implements ExtendableEntity.
+     */
+    private function getSharedParentClass(string $className): string
+    {
+        $class = new \ReflectionClass($className);
+
+        do {
+            $parentClass = $class->getParentClass();
+
+            if (false === $parentClass) {
+                throw new EntityNotFoundException(
+                    sprintf('%s must extend from a class implementing %s.', $className, ExtendableEntity::class)
+                );
+            }
+        } while (!$parentClass->implementsInterface(ExtendableEntity::class));
+
+        return $parentClass->getName();
+    }
+}

--- a/core-bundle/src/Doctrine/Schema/DcaSchemaProvider.php
+++ b/core-bundle/src/Doctrine/Schema/DcaSchemaProvider.php
@@ -59,7 +59,9 @@ class DcaSchemaProvider
         $config = $this->getSqlDefinitions();
 
         foreach ($config as $tableName => $definitions) {
-            $table = $schema->createTable($tableName);
+            $table = $schema->hasTable($tableName) ?
+                $schema->getTable($tableName) :
+                $schema->createTable($tableName);
 
             // Parse the table options first
             if (isset($definitions['TABLE_OPTIONS'])) {

--- a/core-bundle/src/Entity/Component/DcaDefault.php
+++ b/core-bundle/src/Entity/Component/DcaDefault.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Entity\Component;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\MappedSuperclass()
+ * @ORM\HasLifecycleCallbacks()
+ */
+abstract class DcaDefault
+{
+    /**
+     * @ORM\Column(name="id", type="integer", options={"unsigned": true})
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="AUTO")
+     *
+     * @var int
+     */
+    protected $id;
+
+    /**
+     * @ORM\Column(name="tstamp", type="integer", options={"unsigned": true, "default": 0})
+     *
+     * @var int
+     */
+    protected $timestamp;
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    /**
+     * Update the entry's timestamp.
+     *
+     * @ORM\PrePersist()
+     * @ORM\PreUpdate()
+     */
+    public function touch(): void
+    {
+        $this->timestamp = time();
+    }
+}

--- a/core-bundle/src/Entity/Component/ParentIdReferenceTrait.php
+++ b/core-bundle/src/Entity/Component/ParentIdReferenceTrait.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Entity\Component;
+
+trait ParentIdReferenceTrait
+{
+    /**
+     * @ORM\Column(name="pid", type="integer", options={"unsigned": true})
+     *
+     * @var int
+     */
+    protected $parentId;
+
+    public function getParentId(): ?int
+    {
+        return 0 !== $this->parentId ? $this->parentId : null;
+    }
+}

--- a/core-bundle/src/Entity/Module.php
+++ b/core-bundle/src/Entity/Module.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Entity;
+
+use Contao\CoreBundle\Doctrine\ORM\ExtendableEntity\ExtendableEntity;
+use Contao\CoreBundle\Entity\Component\DcaDefault;
+use Contao\CoreBundle\Entity\Component\ParentIdReferenceTrait;
+use Contao\StringUtil;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Table(name="tl_module")
+ * @ORM\Entity()
+ *
+ * @ORM\InheritanceType("SINGLE_TABLE")
+ * @ORM\DiscriminatorColumn(name="type", type="string")
+ * @ORM\DiscriminatorMap({
+ *   "form" = "Contao\CoreBundle\Entity\Module\FormModule",
+ *   "html" = "Contao\CoreBundle\Entity\Module\HtmlModule"
+ * })
+ */
+abstract class Module extends DcaDefault implements ExtendableEntity
+{
+    use ParentIdReferenceTrait;
+
+    /**
+     * @ORM\Column(name="name", options={"default": ""})
+     *
+     * @var string
+     */
+    protected $name = '';
+
+    /**
+     * @ORM\Column(name="headline", options={"default": "a:2:{s:5:\""value\"";s:0:\""\"";s:4:\""unit\"";s:2:\""h2\"";}"})
+     *
+     * @var string
+     */
+    protected $headline = '';
+
+    /**
+     * @ORM\Column(name="protected", length=1, options={"fixed": true, "default": ""})
+     *
+     * @var string
+     */
+    protected $isProtected = '';
+
+    /**
+     * @ORM\Column(name="groups", type="blob", length=Doctrine\DBAL\Platforms\MySqlPlatform::LENGTH_LIMIT_BLOB, nullable=true)
+     *
+     * @var string
+     */
+    protected $allowedGroups = '';
+
+    /**
+     * @ORM\Column(name="guests", length=1, options={"fixed": true, "default": ""})
+     *
+     * @var string
+     */
+    protected $isOnlyVisibleToGuests = '';
+
+    /**
+     * @ORM\Column(name="customTpl", length=64, options={"default": ""})
+     *
+     * @var string
+     */
+    protected $customTemplate;
+
+    /**
+     * @ORM\Column(name="cssID", options={"default": ""})
+     *
+     * @var string
+     */
+    protected $cssId = '';
+
+    public function getType(): string
+    {
+        return (static::class)::TYPE;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function isProtected(): bool
+    {
+        return '1' === $this->isProtected;
+    }
+
+    public function isOnlyVisibleToGuests(): bool
+    {
+        return '1' === $this->isOnlyVisibleToGuests;
+    }
+
+    /**
+     * @return int[]
+     */
+    public function getAllowedGroups(): array
+    {
+        return StringUtil::deserialize($this->allowedGroups, true);
+    }
+
+    public function getCssId(): string
+    {
+        return $this->cssId;
+    }
+}

--- a/core-bundle/src/Entity/Module/FormModule.php
+++ b/core-bundle/src/Entity/Module/FormModule.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Entity\Module;
+
+use Contao\CoreBundle\Entity\Module;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity()
+ */
+class FormModule extends Module
+{
+    /**
+     * @ORM\Column(name="form", type="integer", options={"unsigned": true, "default": 0})
+     *
+     * @var int
+     */
+    protected $form;
+
+    public function getForm(): ?int
+    {
+        return 0 !== $this->form ? $this->form : null;
+    }
+}

--- a/core-bundle/src/Entity/Module/HtmlModule.php
+++ b/core-bundle/src/Entity/Module/HtmlModule.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Entity\Module;
+
+use Contao\CoreBundle\Entity\Module;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity()
+ */
+class HtmlModule extends Module
+{
+    /**
+     * @ORM\Column(name="html", type="text", length=Doctrine\DBAL\Platforms\MySqlPlatform::LENGTH_LIMIT_TEXT, options={"default": ""})
+     *
+     * @var string
+     */
+    protected $html = '';
+
+    public function getHtml(): string
+    {
+        return $this->html;
+    }
+
+    public function getCustomTemplate(): string
+    {
+        return $this->customTemplate;
+    }
+}

--- a/core-bundle/src/Resources/config/services.yml
+++ b/core-bundle/src/Resources/config/services.yml
@@ -677,3 +677,11 @@ services:
             - '@request_stack'
             - '@contao.framework'
             - '@contao.routing.scope_matcher'
+
+    Contao\CoreBundle\Doctrine\ORM\ExtendableEntity\ExtensionRegistry:
+
+    Contao\CoreBundle\Doctrine\ORM\ExtendableEntity\DelegatingAnnotationReader:
+        decorates: 'annotation_reader'
+        arguments:
+            - '@Contao\CoreBundle\Doctrine\ORM\ExtendableEntity\DelegatingAnnotationReader.inner'
+            - '@Contao\CoreBundle\Doctrine\ORM\ExtendableEntity\ExtensionRegistry'

--- a/core-bundle/src/Resources/contao/dca/tl_module.php
+++ b/core-bundle/src/Resources/contao/dca/tl_module.php
@@ -22,13 +22,6 @@ $GLOBALS['TL_DCA']['tl_module'] = array
 			array('tl_module', 'checkPermission'),
 			array('tl_module', 'addCustomLayoutSectionReferences')
 		),
-		'sql' => array
-		(
-			'keys' => array
-			(
-				'id' => 'primary'
-			)
-		)
 	),
 
 	// List
@@ -131,17 +124,14 @@ $GLOBALS['TL_DCA']['tl_module'] = array
 	(
 		'id' => array
 		(
-			'sql'                     => "int(10) unsigned NOT NULL auto_increment"
 		),
 		'pid' => array
 		(
 			'foreignKey'              => 'tl_theme.name',
-			'sql'                     => "int(10) unsigned NOT NULL default 0",
 			'relation'                => array('type'=>'belongsTo', 'load'=>'lazy')
 		),
 		'tstamp' => array
 		(
-			'sql'                     => "int(10) unsigned NOT NULL default 0"
 		),
 		'name' => array
 		(
@@ -151,7 +141,6 @@ $GLOBALS['TL_DCA']['tl_module'] = array
 			'search'                  => true,
 			'inputType'               => 'text',
 			'eval'                    => array('mandatory'=>true, 'maxlength'=>255, 'tl_class'=>'w50'),
-			'sql'                     => "varchar(255) NOT NULL default ''"
 		),
 		'headline' => array
 		(
@@ -160,7 +149,6 @@ $GLOBALS['TL_DCA']['tl_module'] = array
 			'inputType'               => 'inputUnit',
 			'options'                 => array('h1', 'h2', 'h3', 'h4', 'h5', 'h6'),
 			'eval'                    => array('maxlength'=>200, 'tl_class'=>'w50 clr'),
-			'sql'                     => "varchar(255) NOT NULL default 'a:2:{s:5:\"value\";s:0:\"\";s:4:\"unit\";s:2:\"h2\";}'"
 		),
 		'type' => array
 		(
@@ -172,7 +160,7 @@ $GLOBALS['TL_DCA']['tl_module'] = array
 			'options_callback'        => array('tl_module', 'getModules'),
 			'reference'               => &$GLOBALS['TL_LANG']['FMD'],
 			'eval'                    => array('helpwizard'=>true, 'chosen'=>true, 'submitOnChange'=>true, 'tl_class'=>'w50'),
-			'sql'                     => "varchar(64) NOT NULL default 'navigation'"
+			'default'			      => 'navigation'
 		),
 		'levelOffset' => array
 		(
@@ -238,7 +226,6 @@ $GLOBALS['TL_DCA']['tl_module'] = array
 				return Contao\Controller::getTemplateGroup('mod_' . $dc->activeRecord->type . '_');
 			},
 			'eval'                    => array('includeBlankOption'=>true, 'chosen'=>true, 'tl_class'=>'w50'),
-			'sql'                     => "varchar(64) NOT NULL default ''"
 		),
 		'pages' => array
 		(
@@ -319,7 +306,6 @@ $GLOBALS['TL_DCA']['tl_module'] = array
 			'foreignKey'              => 'tl_form.title',
 			'options_callback'        => array('tl_module', 'getForms'),
 			'eval'                    => array('chosen'=>true, 'tl_class'=>'w50 wizard'),
-			'sql'                     => "int(10) unsigned NOT NULL default 0",
 			'relation'                => array('type'=>'hasOne', 'load'=>'lazy')
 		),
 		'queryType' => array
@@ -464,7 +450,6 @@ $GLOBALS['TL_DCA']['tl_module'] = array
 			'inputType'               => 'textarea',
 			'eval'                    => array('allowHtml'=>true, 'class'=>'monospace', 'rte'=>'ace|html', 'helpwizard'=>true),
 			'explanation'             => 'insertTags',
-			'sql'                     => "text NULL"
 		),
 		'rss_cache' => array
 		(
@@ -594,7 +579,6 @@ $GLOBALS['TL_DCA']['tl_module'] = array
 			'filter'                  => true,
 			'inputType'               => 'checkbox',
 			'eval'                    => array('submitOnChange'=>true),
-			'sql'                     => "char(1) NOT NULL default ''"
 		),
 		'groups' => array
 		(
@@ -602,7 +586,6 @@ $GLOBALS['TL_DCA']['tl_module'] = array
 			'inputType'               => 'checkbox',
 			'foreignKey'              => 'tl_member_group.name',
 			'eval'                    => array('mandatory'=>true, 'multiple'=>true),
-			'sql'                     => "blob NULL",
 			'relation'                => array('type'=>'hasMany', 'load'=>'lazy')
 		),
 		'guests' => array
@@ -610,14 +593,12 @@ $GLOBALS['TL_DCA']['tl_module'] = array
 			'exclude'                 => true,
 			'filter'                  => true,
 			'inputType'               => 'checkbox',
-			'sql'                     => "char(1) NOT NULL default ''"
 		),
 		'cssID' => array
 		(
 			'exclude'                 => true,
 			'inputType'               => 'text',
 			'eval'                    => array('multiple'=>true, 'size'=>2, 'tl_class'=>'w50'),
-			'sql'                     => "varchar(255) NOT NULL default ''"
 		)
 	)
 );

--- a/core-bundle/src/Resources/contao/library/Contao/DcaExtractor.php
+++ b/core-bundle/src/Resources/contao/library/Contao/DcaExtractor.php
@@ -497,7 +497,7 @@ class DcaExtractor extends Controller
 		}
 
 		// Not a database table or no field information
-		if (empty($sql) || empty($fields))
+		if (empty($sql) && empty($fields))
 		{
 			return;
 		}

--- a/faq-bundle/src/Entity/FaqModule.php
+++ b/faq-bundle/src/Entity/FaqModule.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\FaqBundle\Entity;
+
+use Contao\CoreBundle\Entity\Module;
+use Contao\StringUtil;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity()
+ */
+class FaqModule extends Module
+{
+    /**
+     * @ORM\Column(name="faq_categories", type="blob", length=Doctrine\DBAL\Platforms\MySqlPlatform::LENGTH_LIMIT_BLOB, nullable=true)
+     *
+     * @var string
+     */
+    protected $categories = '';
+
+    /**
+     * @ORM\Column(name="faq_readerModule", type="integer", options={"unsigned": true, "default": 0})
+     *
+     * @var int
+     */
+    protected $readerModule;
+
+    /**
+     * @return int[]
+     */
+    public function getCategories(): array
+    {
+        return StringUtil::deserialize($this->categories, true);
+    }
+
+    public function getReaderModule(): int
+    {
+        return $this->readerModule;
+    }
+}

--- a/faq-bundle/src/Resources/config/services.yml
+++ b/faq-bundle/src/Resources/config/services.yml
@@ -13,3 +13,7 @@ services:
             - '@security.helper'
         tags:
             - { name: contao.picker_provider, priority: 64 }
+
+    Contao\FaqBundle\Entity\FaqModule:
+        tags:
+            - { name: contao.extendable_entity, entity: 'faq' }

--- a/faq-bundle/src/Resources/contao/dca/tl_module.php
+++ b/faq-bundle/src/Resources/contao/dca/tl_module.php
@@ -20,7 +20,6 @@ $GLOBALS['TL_DCA']['tl_module']['fields']['faq_categories'] = array
 	'inputType'               => 'checkboxWizard',
 	'foreignKey'              => 'tl_faq_category.title',
 	'eval'                    => array('multiple'=>true, 'mandatory'=>true),
-	'sql'                     => "blob NULL"
 );
 
 $GLOBALS['TL_DCA']['tl_module']['fields']['faq_readerModule'] = array
@@ -30,7 +29,6 @@ $GLOBALS['TL_DCA']['tl_module']['fields']['faq_readerModule'] = array
 	'options_callback'        => array('tl_module_faq', 'getReaderModules'),
 	'reference'               => &$GLOBALS['TL_LANG']['tl_module'],
 	'eval'                    => array('includeBlankOption'=>true, 'tl_class'=>'w50'),
-	'sql'                     => "int(10) unsigned NOT NULL default 0"
 );
 
 $bundles = Contao\System::getContainer()->getParameter('kernel.bundles');


### PR DESCRIPTION
Here is a proof of concept for shared entities with [single table inheritance](https://www.doctrine-project.org/projects/doctrine-orm/en/2.6/reference/inheritance-mapping.html#single-table-inheritance). 

**Concept**
Doctrine already allows extending entities multiple times if they are annotated with
`@InheritanceType("SINGLE_TABLE")`. In this case a discriminator column and mapping can be specified. 

For `tl_module` this would be the column `type`. Each type would then become its own entity (`HtmlModule`, `FormModule`, ...) resulting in an anotation like this: 
```php
/**
 * @ORM\Table(name="tl_module")
 * @ORM\Entity()
 *
 * @ORM\InheritanceType("SINGLE_TABLE")
 * @ORM\DiscriminatorColumn(name="type", type="string")
 * @ORM\DiscriminatorMap({
 *   "form" = "Contao\CoreBundle\Entity\Module\FormModule",
 *   "html" = "Contao\CoreBundle\Entity\Module\HtmlModule",
 *    ...
 * })
 */
```
The only problem with this approach: The discriminator map must be specified at the base entity - which will not work out of the box for 3rd party bundles. 

The solution in this PR works like this:
* base entities that should be extendable implement a tag interface `ExtendableEntity`
* child entities are tagged with `contao.extendable_entity` (and a discriminator name)
* there is a compiler pass that registers the discriminator mapping based on the above

In order to get things going (BC) I needed to slightly adjust the `DCASchemaProvider` & `DCAExtractor` so that SQL definitions can be defined in both DCAs and entities (for the same table). 

**How to use**
To create a simple custom module you would create something like this:
```php
namespace App\Entity;

use Contao\CoreBundle\Entity\Module;
use Doctrine\ORM\Mapping as ORM;
use Terminal42\ServiceAnnotationBundle\Annotation\ServiceTag;
use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;

/**
 * @ServiceTag("contao.extendable_entity", entity="my_custom_module")
 * @ORM\Entity()
 */
class MyCustomModule extends Module implements ServiceAnnotationInterface
{
    /**
     * @ORM\Column(name="special_field", type="integer", options={"default": 0})
     * @var int
     */
    private $specialField;

    // special logic
}
```

**What to expect**
This PR is only a brief showcase. Look at 7eccdf6 for some demo implementations. Good ideas might include:
* use `loadClassMetadata` event instead of decorating annotation reader
* extract the concept of extending entities to it's own bundle
* add a way to get the specific entities in the controllers
* add repositories
* add a custom service annotation class for the tag
* fully refactor the core so that it gets extendable
* tests :smile: 
* ...