### PR TITLE
Fix a typo in the "no active page found" error message

### DIFF
--- a/core-bundle/src/Resources/contao/pages/PageRoot.php
+++ b/core-bundle/src/Resources/contao/pages/PageRoot.php
@@ -70,7 +70,7 @@ class PageRoot extends \Frontend
 		// No published pages yet
 		if (null === $objNextPage)
 		{
-			$this->log('No active page found under root page "' . $rootPageId . '")', __METHOD__, TL_ERROR);
+			$this->log('No active page found under root page "' . $rootPageId . '"', __METHOD__, TL_ERROR);
 			throw new NoActivePageFoundException('No active page found under root page.');
 		}
 


### PR DESCRIPTION
Fixes #815 