### PR TITLE
Clear invalid URLs using the new search indexer abstraction

### DIFF
--- a/core-bundle/src/EventListener/SearchIndexListener.php
+++ b/core-bundle/src/EventListener/SearchIndexListener.php
@@ -54,15 +54,14 @@ class SearchIndexListener
 
         $document = Document::createFromRequestResponse($request, $event->getResponse());
 
-        // Index if successful, clear if not
+        // If there are no json ld scripts at all, this should not be handled by our indexer
+        $lds = $document->extractJsonLdScripts();
+
+        if (0 === \count($lds)) {
+            return;
+        }
+
         if ($event->getResponse()->isSuccessful()) {
-            // If there are no json ld scripts at all, nothing will be indexed
-            $lds = $document->extractJsonLdScripts();
-
-            if (0 === \count($lds)) {
-                return;
-            }
-
             $this->indexer->index($document);
         } else {
             $this->indexer->delete($document);

--- a/core-bundle/src/EventListener/SearchIndexListener.php
+++ b/core-bundle/src/EventListener/SearchIndexListener.php
@@ -47,7 +47,7 @@ class SearchIndexListener
             return;
         }
 
-        // Do handle fragments
+        // Do not handle fragments
         if (preg_match('~(?:^|/)'.preg_quote($this->fragmentPath, '~').'/~', $request->getPathInfo())) {
             return;
         }

--- a/core-bundle/src/EventListener/SearchIndexListener.php
+++ b/core-bundle/src/EventListener/SearchIndexListener.php
@@ -53,10 +53,9 @@ class SearchIndexListener
         }
 
         $document = Document::createFromRequestResponse($request, $event->getResponse());
-
-        // If there are no json ld scripts at all, this should not be handled by our indexer
         $lds = $document->extractJsonLdScripts();
 
+        // If there are no json ld scripts at all, this should not be handled by our indexer
         if (0 === \count($lds)) {
             return;
         }

--- a/core-bundle/src/Resources/config/listener.yml
+++ b/core-bundle/src/Resources/config/listener.yml
@@ -8,14 +8,6 @@ services:
             calls:
                 - ['setContainer', ['@service_container']]
 
-    contao.listener.add_to_search_index:
-        class: Contao\CoreBundle\EventListener\AddToSearchIndexListener
-        arguments:
-            - '@contao.search.indexer'
-            - '%fragment.path%'
-        tags:
-            - { name: kernel.event_listener, event: kernel.terminate, method: onKernelTerminate }
-
     contao.listener.backend_locale:
         class: Contao\CoreBundle\EventListener\BackendLocaleListener
         arguments:
@@ -173,6 +165,14 @@ services:
             - '@contao.framework'
         tags:
             - { name: kernel.event_listener, event: contao.robots_txt, method: onRobotsTxt }
+
+    contao.listener.search_index:
+        class: Contao\CoreBundle\EventListener\SearchIndexListener
+        arguments:
+            - '@contao.search.indexer'
+            - '%fragment.path%'
+        tags:
+            - { name: kernel.event_listener, event: kernel.terminate, method: onKernelTerminate }
 
     contao.listener.store_referer:
         class: Contao\CoreBundle\EventListener\StoreRefererListener

--- a/core-bundle/src/Resources/contao/pages/PageError404.php
+++ b/core-bundle/src/Resources/contao/pages/PageError404.php
@@ -81,9 +81,6 @@ class PageError404 extends Frontend
 	 */
 	protected function prepare()
 	{
-		// Check the search index (see #3761)
-		Search::removeEntry(Environment::get('base') . Environment::get('relativeRequest'));
-
 		// Find the matching root page
 		$objRootPage = $this->getRootPageFromUrl();
 

--- a/core-bundle/src/Search/Indexer/DefaultIndexer.php
+++ b/core-bundle/src/Search/Indexer/DefaultIndexer.php
@@ -95,6 +95,19 @@ class DefaultIndexer implements IndexerInterface
     /**
      * {@inheritdoc}
      */
+    public function delete(Document $document): void
+    {
+        $this->framework->initialize();
+
+        /** @var Search $search */
+        $search = $this->framework->getAdapter(Search::class);
+
+        $search->removeEntry((string) $document->getUri());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function clear(): void
     {
         $this->connection->exec('TRUNCATE TABLE tl_search');

--- a/core-bundle/src/Search/Indexer/DefaultIndexer.php
+++ b/core-bundle/src/Search/Indexer/DefaultIndexer.php
@@ -101,7 +101,6 @@ class DefaultIndexer implements IndexerInterface
 
         /** @var Search $search */
         $search = $this->framework->getAdapter(Search::class);
-
         $search->removeEntry((string) $document->getUri());
     }
 

--- a/core-bundle/src/Search/Indexer/DelegatingIndexer.php
+++ b/core-bundle/src/Search/Indexer/DelegatingIndexer.php
@@ -41,6 +41,16 @@ class DelegatingIndexer implements IndexerInterface
     /**
      * {@inheritdoc}
      */
+    public function delete(Document $document): void
+    {
+        foreach ($this->indexers as $indexer) {
+            $indexer->delete($document);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function clear(): void
     {
         foreach ($this->indexers as $indexer) {

--- a/core-bundle/src/Search/Indexer/IndexerInterface.php
+++ b/core-bundle/src/Search/Indexer/IndexerInterface.php
@@ -27,7 +27,7 @@ interface IndexerInterface
     public function delete(Document $document): void;
 
     /**
-     * Clears the whole search index.
+     * Clears the search index.
      */
     public function clear(): void;
 }

--- a/core-bundle/src/Search/Indexer/IndexerInterface.php
+++ b/core-bundle/src/Search/Indexer/IndexerInterface.php
@@ -22,7 +22,12 @@ interface IndexerInterface
     public function index(Document $document): void;
 
     /**
-     * Clears the search index.
+     * Deletes a given document.
+     */
+    public function delete(Document $document): void;
+
+    /**
+     * Clears the whole search index.
      */
     public function clear(): void;
 }

--- a/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
+++ b/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
@@ -39,7 +39,6 @@ use Contao\CoreBundle\DataCollector\ContaoDataCollector;
 use Contao\CoreBundle\DependencyInjection\ContaoCoreExtension;
 use Contao\CoreBundle\Doctrine\Schema\DcaSchemaProvider;
 use Contao\CoreBundle\Entity\RememberMe;
-use Contao\CoreBundle\EventListener\AddToSearchIndexListener;
 use Contao\CoreBundle\EventListener\BackendLocaleListener;
 use Contao\CoreBundle\EventListener\BackendMenuListener;
 use Contao\CoreBundle\EventListener\BypassMaintenanceListener;
@@ -60,6 +59,7 @@ use Contao\CoreBundle\EventListener\RefererIdListener;
 use Contao\CoreBundle\EventListener\RequestTokenListener;
 use Contao\CoreBundle\EventListener\ResponseExceptionListener;
 use Contao\CoreBundle\EventListener\RobotsTxtListener;
+use Contao\CoreBundle\EventListener\SearchIndexListener;
 use Contao\CoreBundle\EventListener\StoreRefererListener;
 use Contao\CoreBundle\EventListener\SwitchUserListener;
 use Contao\CoreBundle\EventListener\TwoFactorFrontendListener;
@@ -238,13 +238,13 @@ class ContaoCoreExtensionTest extends TestCase
         yield ['contao.command.version', VersionCommand::class];
     }
 
-    public function testRegistersTheAddToSearchIndexListener(): void
+    public function testRegistersTheSearchIndexListener(): void
     {
-        $this->assertTrue($this->container->has('contao.listener.add_to_search_index'));
+        $this->assertTrue($this->container->has('contao.listener.search_index'));
 
-        $definition = $this->container->getDefinition('contao.listener.add_to_search_index');
+        $definition = $this->container->getDefinition('contao.listener.search_index');
 
-        $this->assertSame(AddToSearchIndexListener::class, $definition->getClass());
+        $this->assertSame(SearchIndexListener::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
         $this->assertSame('contao.search.indexer', (string) $definition->getArgument(0));
         $this->assertSame('%fragment.path%', (string) $definition->getArgument(1));

--- a/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
+++ b/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
@@ -238,24 +238,6 @@ class ContaoCoreExtensionTest extends TestCase
         yield ['contao.command.version', VersionCommand::class];
     }
 
-    public function testRegistersTheSearchIndexListener(): void
-    {
-        $this->assertTrue($this->container->has('contao.listener.search_index'));
-
-        $definition = $this->container->getDefinition('contao.listener.search_index');
-
-        $this->assertSame(SearchIndexListener::class, $definition->getClass());
-        $this->assertTrue($definition->isPrivate());
-        $this->assertSame('contao.search.indexer', (string) $definition->getArgument(0));
-        $this->assertSame('%fragment.path%', (string) $definition->getArgument(1));
-
-        $tags = $definition->getTags();
-
-        $this->assertArrayHasKey('kernel.event_listener', $tags);
-        $this->assertSame('kernel.terminate', $tags['kernel.event_listener'][0]['event']);
-        $this->assertSame('onKernelTerminate', $tags['kernel.event_listener'][0]['method']);
-    }
-
     public function testRegistersTheBackendLocaleListener(): void
     {
         $this->assertTrue($this->container->has('contao.listener.backend_locale'));
@@ -624,6 +606,24 @@ class ContaoCoreExtensionTest extends TestCase
         $this->assertArrayHasKey('kernel.event_listener', $tags);
         $this->assertSame('contao.robots_txt', $tags['kernel.event_listener'][0]['event']);
         $this->assertSame('onRobotsTxt', $tags['kernel.event_listener'][0]['method']);
+    }
+
+    public function testRegistersTheSearchIndexListener(): void
+    {
+        $this->assertTrue($this->container->has('contao.listener.search_index'));
+
+        $definition = $this->container->getDefinition('contao.listener.search_index');
+
+        $this->assertSame(SearchIndexListener::class, $definition->getClass());
+        $this->assertTrue($definition->isPrivate());
+        $this->assertSame('contao.search.indexer', (string) $definition->getArgument(0));
+        $this->assertSame('%fragment.path%', (string) $definition->getArgument(1));
+
+        $tags = $definition->getTags();
+
+        $this->assertArrayHasKey('kernel.event_listener', $tags);
+        $this->assertSame('kernel.terminate', $tags['kernel.event_listener'][0]['event']);
+        $this->assertSame('onKernelTerminate', $tags['kernel.event_listener'][0]['method']);
     }
 
     public function testRegistersTheStoreRefererListener(): void

--- a/core-bundle/tests/EventListener/SearchIndexListenerTest.php
+++ b/core-bundle/tests/EventListener/SearchIndexListenerTest.php
@@ -69,16 +69,23 @@ class SearchIndexListenerTest extends TestCase
             false, // Should not delete
         ];
 
-        yield 'Should be deleted because the response was not successful (404)' => [
+        yield 'Should be ignored because the response was not successful (404) but there was no ld+json data' => [
             Request::create('/foobar', 'GET'),
             new Response('', 404),
+            false, // Should not index
+            false, // Should not delete
+        ];
+
+        yield 'Should be deleted because the response was not successful (404)' => [
+            Request::create('/foobar', 'GET'),
+            new Response('<html><body><script type="application/ld+json">{"@context":"https:\/\/contao.org\/","@type":"PageMetaData","pageId":2,"noSearch":false,"protected":false,"groups":[],"fePreview":false}</script></body></html>', 404),
             false, // Should not index
             true, // Should delete
         ];
 
         yield 'Should be deleted because the response was not successful (403)' => [
             Request::create('/foobar', 'GET'),
-            new Response('', 403),
+            new Response('<html><body><script type="application/ld+json">{"@context":"https:\/\/contao.org\/","@type":"PageMetaData","pageId":2,"noSearch":false,"protected":false,"groups":[],"fePreview":false}</script></body></html>', 403),
             false, // Should not index
             true, // Should delete
         ];

--- a/core-bundle/tests/EventListener/SearchIndexListenerTest.php
+++ b/core-bundle/tests/EventListener/SearchIndexListenerTest.php
@@ -34,6 +34,7 @@ class SearchIndexListenerTest extends TestCase
             ->method('index')
             ->with($this->isInstanceOf(Document::class))
         ;
+
         $indexer
             ->expects($delete ? $this->once() : $this->never())
             ->method('delete')
@@ -51,43 +52,43 @@ class SearchIndexListenerTest extends TestCase
         yield 'Should index because the response was successful and contains ld+json information' => [
             Request::create('/foobar'),
             new Response('<html><body><script type="application/ld+json">{"@context":"https:\/\/contao.org\/","@type":"PageMetaData","pageId":2,"noSearch":false,"protected":false,"groups":[],"fePreview":false}</script></body></html>'),
-            true, // Should index
-            false, // Should not delete
+            true,
+            false,
         ];
 
         yield 'Should be skipped because it is not a GET request' => [
             Request::create('/foobar', 'POST'),
             new Response(),
-            false, // Should not index
-            false, // Should not delete
+            false,
+            false,
         ];
 
         yield 'Should be skipped because it is a fragment request' => [
             Request::create('_fragment/foo/bar'),
             new Response(),
-            false, // Should not index
-            false, // Should not delete
+            false,
+            false,
         ];
 
         yield 'Should be ignored because the response was not successful (404) but there was no ld+json data' => [
             Request::create('/foobar', 'GET'),
             new Response('', 404),
-            false, // Should not index
-            false, // Should not delete
+            false,
+            false,
         ];
 
         yield 'Should be deleted because the response was not successful (404)' => [
             Request::create('/foobar', 'GET'),
             new Response('<html><body><script type="application/ld+json">{"@context":"https:\/\/contao.org\/","@type":"PageMetaData","pageId":2,"noSearch":false,"protected":false,"groups":[],"fePreview":false}</script></body></html>', 404),
-            false, // Should not index
-            true, // Should delete
+            false,
+            true,
         ];
 
         yield 'Should be deleted because the response was not successful (403)' => [
             Request::create('/foobar', 'GET'),
             new Response('<html><body><script type="application/ld+json">{"@context":"https:\/\/contao.org\/","@type":"PageMetaData","pageId":2,"noSearch":false,"protected":false,"groups":[],"fePreview":false}</script></body></html>', 403),
-            false, // Should not index
-            true, // Should delete
+            false,
+            true,
         ];
     }
 }

--- a/core-bundle/tests/Search/Indexer/DefaultIndexerTest.php
+++ b/core-bundle/tests/Search/Indexer/DefaultIndexerTest.php
@@ -104,6 +104,26 @@ class DefaultIndexerTest extends ContaoTestCase
         ];
     }
 
+    public function testDeletesADocument(): void
+    {
+        $searchAdapter = $this->mockAdapter(['removeEntry']);
+        $searchAdapter
+            ->expects($this->once())
+            ->method('removeEntry')
+            ->with('https://example.com')
+        ;
+
+        $framework = $this->mockContaoFramework([Search::class => $searchAdapter]);
+
+        $framework
+            ->expects($this->once())
+            ->method('initialize')
+        ;
+
+        $indexer = new DefaultIndexer($framework, $this->createMock(Connection::class));
+        $indexer->delete(new Document(new Uri('https://example.com'), 200, [], ''));
+    }
+
     public function testClearsTheSearchIndex(): void
     {
         $framework = $this->mockContaoFramework();

--- a/core-bundle/tests/Search/Indexer/DefaultIndexerTest.php
+++ b/core-bundle/tests/Search/Indexer/DefaultIndexerTest.php
@@ -114,7 +114,6 @@ class DefaultIndexerTest extends ContaoTestCase
         ;
 
         $framework = $this->mockContaoFramework([Search::class => $searchAdapter]);
-
         $framework
             ->expects($this->once())
             ->method('initialize')

--- a/core-bundle/tests/Search/Indexer/DelegatingIndexerTest.php
+++ b/core-bundle/tests/Search/Indexer/DelegatingIndexerTest.php
@@ -30,6 +30,12 @@ class DelegatingIndexerTest extends TestCase
 
         $indexer1
             ->expects($this->once())
+            ->method('delete')
+            ->with($this->isInstanceOf(Document::class))
+        ;
+
+        $indexer1
+            ->expects($this->once())
             ->method('clear')
         ;
 
@@ -42,6 +48,12 @@ class DelegatingIndexerTest extends TestCase
 
         $indexer2
             ->expects($this->once())
+            ->method('delete')
+            ->with($this->isInstanceOf(Document::class))
+        ;
+
+        $indexer2
+            ->expects($this->once())
             ->method('clear')
         ;
 
@@ -49,6 +61,7 @@ class DelegatingIndexerTest extends TestCase
         $delegating->addIndexer($indexer1);
         $delegating->addIndexer($indexer2);
         $delegating->index($this->createMock(Document::class));
+        $delegating->delete($this->createMock(Document::class));
         $delegating->clear();
     }
 }


### PR DESCRIPTION
This is a follow-up PR for https://github.com/contao/contao/pull/730.
I've introduced a search indexer abstraction there but clearing a single URI was not part of it.
I've extended the interface which now also contains a `clearDocument()` method (no BC break, 4.9 is still in development) and I've extracted the logic into its own listener so that it doesn't just work for our own `PageError404` but for any exception.