### PR TITLE
Use the ROOT_COMPOSER_VERSION in the split builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -155,6 +155,6 @@ before_install:
         }
         file_put_contents(__DIR__."/composer.json", json_encode($data, JSON_UNESCAPED_SLASHES));
       '
-      composer update --no-interaction --no-suggest
+      ROOT_COMPOSER_VERSION=dev-$TRAVIS_COMMIT composer update --no-interaction --no-suggest
       php vendor/bin/phpunit --colors=always
     }

--- a/.travis.yml
+++ b/.travis.yml
@@ -155,6 +155,6 @@ before_install:
         }
         file_put_contents(__DIR__."/composer.json", json_encode($data, JSON_UNESCAPED_SLASHES));
       '
-      ROOT_COMPOSER_VERSION=dev-$TRAVIS_COMMIT composer update --no-interaction --no-suggest
+      COMPOSER_ROOT_VERSION=dev-$TRAVIS_COMMIT composer update --no-interaction --no-suggest
       php vendor/bin/phpunit --colors=always
     }


### PR DESCRIPTION
This will fix running the split tests in pull request builds on Travis.

**What is the problem?**

See https://travis-ci.com/contao/contao/jobs/250138857

```
$ git clone --depth=50 https://github.com/contao/contao.git contao/contao
Cloning into 'contao/contao'...
$ cd contao/contao
$ git fetch origin +refs/pull/814/merge:
From https://github.com/contao/contao
 * branch            refs/pull/814/merge -> FETCH_HEAD
$ git checkout -qf FETCH_HEAD
```

Now the Composer version guesser guesses `dev-master`, which is wrong. Therefore we need to provide the commit hash explicitly.
