### PR TITLE
Check if the FlattenException::getAsString() method exists

### DIFF
--- a/core-bundle/src/Command/ResizeImagesCommand.php
+++ b/core-bundle/src/Command/ResizeImagesCommand.php
@@ -169,7 +169,8 @@ class ResizeImagesCommand extends Command
                     // Clear the current output line
                     $io->write("\r".str_repeat(' ', $this->terminalWidth)."\r");
                 } else {
-                    $io->writeln(sprintf('done%7.3Fs', $duration = microtime(true) - $startTime));
+                    $duration = microtime(true) - $startTime;
+                    $io->writeln(sprintf('done%7.3Fs', $duration));
 
                     return $duration;
                 }
@@ -180,7 +181,7 @@ class ResizeImagesCommand extends Command
         } catch (\Throwable $exception) {
             $io->writeln('failed');
 
-            if ($io->isVerbose()) {
+            if ($io->isVerbose() && method_exists(FlattenException::class, 'getAsString')) {
                 $io->error(FlattenException::createFromThrowable($exception)->getAsString());
             } else {
                 $io->writeln($exception->getMessage());

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -25,5 +25,9 @@ parameters:
         - '#Class Symfony\\Component\\Config\\Definition\\Builder\\TreeBuilder does not have a constructor and must be instantiated without any parameters\.#'
         - '#Method Symfony\\Contracts\\EventDispatcher\\EventDispatcherInterface::dispatch\(\) invoked with 2 parameters, 1 required\.#'
 
+        # Ignore the FlattenException::getAsString() warning
+        # FIXME: remove again in Contao 4.9
+        - '#Call to an undefined method Symfony\\Component\\Debug\\Exception\\FlattenException::getAsString\(\)\.#'
+
     reportUnmatchedIgnoredErrors: false
     inferPrivatePropertyTypeFromConstructor: true


### PR DESCRIPTION
Fixes #866

The first change regarding the `$duration` variable has been made to avoid conflicts when merging upstream.