### PR TITLE
Stop using the deprecated Doctrine DBAL methods

### DIFF
--- a/core-bundle/src/Doctrine/Schema/DcaSchemaProvider.php
+++ b/core-bundle/src/Doctrine/Schema/DcaSchemaProvider.php
@@ -15,6 +15,7 @@ namespace Contao\CoreBundle\Doctrine\Schema;
 use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\Database\Installer;
 use Doctrine\Bundle\DoctrineBundle\Registry;
+use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\MySqlPlatform;
 use Doctrine\DBAL\Schema\Schema;
@@ -118,10 +119,13 @@ class DcaSchemaProvider
         /** @var ClassMetadata[] $metadata */
         $metadata = $manager->getMetadataFactory()->getAllMetadata();
 
+        /** @var Connection $connection */
+        $connection = $this->doctrine->getConnection();
+
         // Apply the schema filter
-        if ($filter = $this->doctrine->getConnection()->getConfiguration()->getFilterSchemaAssetsExpression()) {
+        if ($filter = $connection->getConfiguration()->getSchemaAssetsFilter()) {
             foreach ($metadata as $key => $data) {
-                if (!preg_match($filter, $data->getTableName())) {
+                if (!$filter($data->getTableName())) {
                     unset($metadata[$key]);
                 }
             }
@@ -362,10 +366,13 @@ class DcaSchemaProvider
             }
         }
 
+        /** @var Connection $connection */
+        $connection = $this->doctrine->getConnection();
+
         // Apply the schema filter (see contao/installation-bundle#78)
-        if ($filter = $this->doctrine->getConnection()->getConfiguration()->getFilterSchemaAssetsExpression()) {
+        if ($filter = $connection->getConfiguration()->getSchemaAssetsFilter()) {
             foreach (array_keys($sqlTarget) as $key) {
-                if (!preg_match($filter, $key)) {
+                if (!$filter($key)) {
                     unset($sqlTarget[$key]);
                 }
             }

--- a/core-bundle/tests/Doctrine/DoctrineTestCase.php
+++ b/core-bundle/tests/Doctrine/DoctrineTestCase.php
@@ -46,8 +46,8 @@ abstract class DoctrineTestCase extends TestCase
 
         $config = $this->createMock(Configuration::class);
         $config
-            ->method('getFilterSchemaAssetsExpression')
-            ->willReturn($filter)
+            ->method('getSchemaAssetsFilter')
+            ->willReturn($this->getSchemaAssetsFilter($filter))
         ;
 
         $connection = $this->createMock(Connection::class);
@@ -111,8 +111,8 @@ abstract class DoctrineTestCase extends TestCase
     {
         $config = $this->createMock(Configuration::class);
         $config
-            ->method('getFilterSchemaAssetsExpression')
-            ->willReturn($filter)
+            ->method('getSchemaAssetsFilter')
+            ->willReturn($this->getSchemaAssetsFilter($filter))
         ;
 
         $connection = $this->createMock(Connection::class);
@@ -228,5 +228,16 @@ abstract class DoctrineTestCase extends TestCase
             $this->mockContaoFrameworkWithInstaller($dca, $file),
             $this->mockDoctrineRegistry($statement, $filter)
         );
+    }
+
+    protected function getSchemaAssetsFilter(string $filter = null): ?callable
+    {
+        if (null === $filter) {
+            return null;
+        }
+
+        return static function (string $assetName) use ($filter): bool {
+            return (bool) preg_match($filter, $assetName);
+        };
     }
 }

--- a/installation-bundle/src/Database/Installer.php
+++ b/installation-bundle/src/Database/Installer.php
@@ -87,18 +87,23 @@ class Installer
             'ALTER_DROP' => [],
         ];
 
+        // The schema assets filter is a callable as of Doctrine DBAL 2.9
+        $filter = static function (string $assetName): bool {
+            return 0 === strncmp($assetName, 'tl_', 3);
+        };
+
         $config = $this->connection->getConfiguration();
 
         // Overwrite the schema filter (see #78)
-        $previousFilter = $config->getFilterSchemaAssetsExpression();
-        $config->setFilterSchemaAssetsExpression('/^tl_/');
+        $previousFilter = $config->getSchemaAssetsFilter();
+        $config->setSchemaAssetsFilter($filter);
 
         // Create the from and to schema
         $fromSchema = $this->connection->getSchemaManager()->createSchema();
         $toSchema = $this->schemaProvider->createSchema();
 
         // Reset the schema filter
-        $config->setFilterSchemaAssetsExpression($previousFilter);
+        $config->setSchemaAssetsFilter($previousFilter);
 
         $diff = $fromSchema->getMigrateToSql($toSchema, $this->connection->getDatabasePlatform());
 


### PR DESCRIPTION
Using a regex as schema assets filter is deprecated as of Doctrine DBAL 2.9.