### PR TITLE
Remove the app folder if there are no more files in it

### DIFF
--- a/core-bundle/src/Resources/contao/classes/Backend.php
+++ b/core-bundle/src/Resources/contao/classes/Backend.php
@@ -286,7 +286,7 @@ abstract class Backend extends Controller
 		$finder = Finder::create()->files()->in($appDir);
 
 		// Remove the app folder if there are no more files in it
-		if (0 === \count($finder))
+		if (!$finder->hasResults())
 		{
 			(new Filesystem())->remove($appDir);
 		}

--- a/core-bundle/src/Resources/contao/classes/Backend.php
+++ b/core-bundle/src/Resources/contao/classes/Backend.php
@@ -14,6 +14,7 @@ use Contao\CoreBundle\Exception\AccessDeniedException;
 use Contao\CoreBundle\Exception\ResponseException;
 use Contao\CoreBundle\Picker\PickerInterface;
 use Contao\Database\Result;
+use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -285,10 +286,19 @@ abstract class Backend extends Controller
 
 		$finder = Finder::create()->files()->in($appDir);
 
-		// Remove the app folder if there are no more files in it
-		if (!$finder->hasResults())
+		// Do not remove the app folder if there are still files in it
+		if ($finder->hasResults())
+		{
+			return;
+		}
+
+		try
 		{
 			(new Filesystem())->remove($appDir);
+		}
+		catch (IOException $e)
+		{
+			// ignore
 		}
 	}
 

--- a/core-bundle/src/Resources/contao/classes/Backend.php
+++ b/core-bundle/src/Resources/contao/classes/Backend.php
@@ -14,6 +14,8 @@ use Contao\CoreBundle\Exception\AccessDeniedException;
 use Contao\CoreBundle\Exception\ResponseException;
 use Contao\CoreBundle\Picker\PickerInterface;
 use Contao\Database\Result;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Finder\Finder;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface;
@@ -272,6 +274,21 @@ abstract class Backend extends Controller
 			}
 
 			System::log("File $strRelpath ran once and has then been removed successfully", __METHOD__, TL_GENERAL);
+		}
+
+		$appDir = System::getContainer()->getParameter('kernel.project_dir') . '/app';
+
+		if (!is_dir($appDir))
+		{
+			return;
+		}
+
+		$finder = Finder::create()->files()->in($appDir);
+
+		// Remove the app folder if there are no more files in it
+		if (0 === \count($finder))
+		{
+			(new Filesystem())->remove($appDir);
 		}
 	}
 


### PR DESCRIPTION
As discussed in our last Mumble call, this PR will delete the `app/` folder if there are no more files in it after executing the runonce files.