### PR TITLE
Use a strict check to determine whether a label is false

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Widget.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Widget.php
@@ -1262,7 +1262,7 @@ abstract class Widget extends Controller
 		$arrAttributes['name'] = $strName;
 		$arrAttributes['strField'] = $strField;
 		$arrAttributes['strTable'] = $strTable;
-		$arrAttributes['label'] = (($label = \is_array($arrData['label']) ? $arrData['label'][0] : $arrData['label']) != false) ? $label : $strField;
+		$arrAttributes['label'] = (($label = \is_array($arrData['label']) ? $arrData['label'][0] : $arrData['label']) !== false) ? $label : $strField;
 		$arrAttributes['description'] = $arrData['label'][1];
 		$arrAttributes['type'] = $arrData['inputType'];
 		$arrAttributes['dataContainer'] = $objDca;


### PR DESCRIPTION
The current check is also true if `$label` is `null`, `0` or an empty string, which is wrong.