### PR TITLE
Ignore bugfix/* and feature/* branches on push

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,6 +1,12 @@
 name: Coverage
 
-on: [push, pull_request]
+on:
+    push:
+        branches-ignore:
+            - bugfix/*
+            - feature/*
+
+    pull_request: ~
 
 jobs:
     coverage:

--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -1,6 +1,12 @@
 name: PHP CS Fixer
 
-on: [push, pull_request]
+on:
+    push:
+        branches-ignore:
+            - bugfix/*
+            - feature/*
+
+    pull_request: ~
 
 jobs:
     fix:


### PR DESCRIPTION
This will prevent the GitHub action to be run twice for pull requests (one time for the push and one time for the pull request).