### PR TITLE
Move the static analysis to the "checks" workflow

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -42,4 +42,4 @@ install:
 
 test_script:
     - cd %APPVEYOR_BUILD_FOLDER%
-    - vendor\bin\simple-phpunit.bat
+    - vendor\bin\phpunit.bat

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -9,12 +9,12 @@ on:
     pull_request: ~
 
 jobs:
-    php-cs-fixer:
-        name: PHP CS Fixer
+    checks:
+        name: Checks
         runs-on: ubuntu-latest
         steps:
             - name: Setup PHP
-              uses: shivammathur/setup-php@1.4.4
+              uses: shivammathur/setup-php@1.5.1
               with:
                   php-version: 7.3
                   extension-csv: intl
@@ -28,8 +28,14 @@ jobs:
             - name: Install dependencies
               run: composer install --no-interaction --no-suggest
 
-            - name: Run the CS fixer
+            - name: Check the coding style
               run: |
-                  vendor/bin/php-cs-fixer fix --diff --diff-format=udiff --dry-run
+                  PHP_CS_CONFIG=default vendor/bin/php-cs-fixer fix --diff --diff-format=udiff --dry-run
                   PHP_CS_CONFIG=legacy vendor/bin/php-cs-fixer fix --diff --diff-format=udiff --dry-run
                   PHP_CS_CONFIG=template vendor/bin/php-cs-fixer fix --diff --diff-format=udiff --dry-run
+
+            - name: Analyze the code
+              run: vendor/bin/phpstan analyse core-bundle/src core-bundle/tests --level=3 --no-progress
+
+            - name: Validate the composer.json files
+              run: vendor/bin/monorepo-tools composer-json --validate

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,12 +9,12 @@ on:
     pull_request: ~
 
 jobs:
-    codecov:
-        name: Codecov
+    coverage:
+        name: Coverage
         runs-on: ubuntu-latest
         steps:
             - name: Setup PHP
-              uses: shivammathur/setup-php@1.4.4
+              uses: shivammathur/setup-php@1.5.1
               with:
                   php-version: 7.3
                   extension-csv: intl
@@ -29,10 +29,9 @@ jobs:
               run: composer install --no-interaction --no-suggest
 
             - name: Generate the coverage report
-              run: phpdbg -qrr -dmemory_limit=1G vendor/bin/simple-phpunit --testsuite=coverage --coverage-clover=clover.xml
+              run: phpdbg -qrr -dmemory_limit=1G vendor/bin/phpunit --testsuite=coverage --coverage-clover=clover.xml
 
-            - name: Upload the report to Codecov
-              uses: codecov/codecov-action@v1.0.3
-              with:
-                  token: ${{secrets.CODECOV_TOKEN}}
-                  file: ./clover.xml
+            - name: Upload the report
+              run: bash <(curl -s https://codecov.io/bash) -f clover.xml
+              env:
+                  CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,30 +37,24 @@ jobs:
           install:
               - composer update --prefer-lowest --prefer-stable --no-interaction --no-suggest
           script:
-              - php vendor/bin/simple-phpunit
-              - php vendor/bin/simple-phpunit --testsuite=functional
-              - php vendor/bin/phpstan analyse core-bundle/src core-bundle/tests --level=3 --no-progress
-              - php vendor/bin/monorepo-tools composer-json --validate
+              - php vendor/bin/phpunit
+              - php vendor/bin/phpunit --testsuite=functional
 
         - stage: test
           php: 7.2
           install:
               - composer update --no-interaction --no-suggest
           script:
-              - php vendor/bin/simple-phpunit
-              - php vendor/bin/simple-phpunit --testsuite=functional
-              - php vendor/bin/phpstan analyse core-bundle/src core-bundle/tests --level=3 --no-progress
-              - php vendor/bin/monorepo-tools composer-json --validate
+              - php vendor/bin/phpunit
+              - php vendor/bin/phpunit --testsuite=functional
 
         - stage: test
           php: 7.3
           install:
               - composer update --no-interaction --no-suggest
           script:
-              - php vendor/bin/simple-phpunit
-              - php vendor/bin/simple-phpunit --testsuite=functional
-              - php vendor/bin/phpstan analyse core-bundle/src core-bundle/tests --level=3 --no-progress
-              - php vendor/bin/monorepo-tools composer-json --validate
+              - php vendor/bin/phpunit
+              - php vendor/bin/phpunit --testsuite=functional
 
         - stage: test
           if: 'type = cron'
@@ -68,10 +62,8 @@ jobs:
           install:
               - composer update --no-interaction --no-suggest
           script:
-              - php vendor/bin/simple-phpunit
-              - php vendor/bin/simple-phpunit --testsuite=functional
-              - php vendor/bin/phpstan analyse core-bundle/src core-bundle/tests --level=3 --no-progress
-              - php vendor/bin/monorepo-tools composer-json --validate
+              - php vendor/bin/phpunit
+              - php vendor/bin/phpunit --testsuite=functional
 
         # Ignore the platform requirements for the upcoming PHP version
         - stage: test
@@ -80,10 +72,8 @@ jobs:
           install:
               - composer update --ignore-platform-reqs --no-interaction --no-suggest
           script:
-              - php vendor/bin/simple-phpunit
-              - php vendor/bin/simple-phpunit --testsuite=functional
-              - php vendor/bin/phpstan analyse core-bundle/src core-bundle/tests --level=3 --no-progress
-              - php vendor/bin/monorepo-tools composer-json --validate
+              - php vendor/bin/phpunit
+              - php vendor/bin/phpunit --testsuite=functional
 
         # Split the monorepo
         - stage: split
@@ -117,7 +107,7 @@ before_install:
           file_put_contents(__DIR__."/composer.json", json_encode($data, JSON_UNESCAPED_SLASHES));
         '
         COMPOSER_ROOT_VERSION=dev-$TRAVIS_COMMIT composer update --no-interaction --no-suggest
-        php vendor/bin/simple-phpunit --colors=always
+        php vendor/bin/phpunit --colors=always
       }
       update_composer_json () {
         php -r '

--- a/calendar-bundle/composer.json
+++ b/calendar-bundle/composer.json
@@ -33,6 +33,7 @@
         "contao/manager-plugin": "^2.3.1",
         "contao/test-case": "^4.0",
         "php-http/guzzle6-adapter": "^1.1",
+        "phpunit/phpunit": "^8.4",
         "symfony/phpunit-bridge": "^4.3.4"
     },
     "extra": {

--- a/calendar-bundle/phpunit.xml.dist
+++ b/calendar-bundle/phpunit.xml.dist
@@ -8,7 +8,6 @@
     <php>
         <ini name="error_reporting" value="-1" />
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0" />
-        <env name="SYMFONY_PHPUNIT_VERSION" value="8.4" />
     </php>
 
     <testsuites>

--- a/composer.json
+++ b/composer.json
@@ -152,6 +152,7 @@
         "phpstan/phpstan": "^0.11",
         "phpstan/phpstan-phpunit": "^0.11.2",
         "phpstan/phpstan-symfony": "^0.11.6",
+        "phpunit/phpunit": "^8.4",
         "symfony/browser-kit": "4.2.* || 4.3.*",
         "symfony/phpunit-bridge": "^4.3.4"
     },
@@ -255,7 +256,7 @@
             "@monorepo-tools"
         ],
         "functional-tests": [
-            "vendor/bin/simple-phpunit --testsuite=functional"
+            "vendor/bin/phpunit --testsuite=functional --colors=always"
         ],
         "monorepo-tools": [
             "vendor/bin/monorepo-tools composer --validate"
@@ -269,7 +270,7 @@
             "vendor/bin/phpstan analyze core-bundle/src core-bundle/tests --level=3 --no-progress --ansi"
         ],
         "unit-tests": [
-            "vendor/bin/simple-phpunit"
+            "vendor/bin/phpunit --colors=always"
         ]
     },
     "support": {

--- a/core-bundle/composer.json
+++ b/core-bundle/composer.json
@@ -123,6 +123,7 @@
         "lexik/maintenance-bundle": "^2.1.3",
         "monolog/monolog": "^1.24",
         "php-http/guzzle6-adapter": "^1.1",
+        "phpunit/phpunit": "^8.4",
         "symfony/browser-kit": "4.2.* || 4.3.*",
         "symfony/phpunit-bridge": "^4.3.4"
     },

--- a/core-bundle/phpunit.xml.dist
+++ b/core-bundle/phpunit.xml.dist
@@ -9,7 +9,6 @@
     <php>
         <ini name="error_reporting" value="-1" />
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0" />
-        <env name="SYMFONY_PHPUNIT_VERSION" value="8.4" />
         <env name="KERNEL_CLASS" value="Contao\CoreBundle\Tests\Functional\app\AppKernel" />
         <env name="APP_SECRET" value="foobar" />
         <env name="DATABASE_URL" value="mysql://root@localhost:3306/contao_test" />

--- a/faq-bundle/composer.json
+++ b/faq-bundle/composer.json
@@ -31,6 +31,7 @@
         "contao/manager-plugin": "^2.3.1",
         "contao/test-case": "^4.0",
         "php-http/guzzle6-adapter": "^1.1",
+        "phpunit/phpunit": "^8.4",
         "symfony/phpunit-bridge": "^4.3.4"
     },
     "extra": {

--- a/faq-bundle/phpunit.xml.dist
+++ b/faq-bundle/phpunit.xml.dist
@@ -8,7 +8,6 @@
     <php>
         <ini name="error_reporting" value="-1" />
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0" />
-        <env name="SYMFONY_PHPUNIT_VERSION" value="8.4" />
     </php>
 
     <testsuites>

--- a/installation-bundle/composer.json
+++ b/installation-bundle/composer.json
@@ -40,6 +40,7 @@
     "require-dev": {
         "contao/manager-plugin": "^2.3.1",
         "php-http/guzzle6-adapter": "^1.1",
+        "phpunit/phpunit": "^8.4",
         "symfony/phpunit-bridge": "^4.3.4"
     },
     "extra": {

--- a/installation-bundle/phpunit.xml.dist
+++ b/installation-bundle/phpunit.xml.dist
@@ -8,7 +8,6 @@
     <php>
         <ini name="error_reporting" value="-1" />
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0" />
-        <env name="SYMFONY_PHPUNIT_VERSION" value="8.4" />
     </php>
 
     <testsuites>

--- a/manager-bundle/composer.json
+++ b/manager-bundle/composer.json
@@ -56,6 +56,7 @@
     "require-dev": {
         "composer/composer": "^1.0",
         "contao/test-case": "^4.0",
+        "phpunit/phpunit": "^8.4",
         "symfony/phpunit-bridge": "^4.3.4"
     },
     "suggest": {

--- a/manager-bundle/phpunit.xml.dist
+++ b/manager-bundle/phpunit.xml.dist
@@ -8,7 +8,6 @@
     <php>
         <ini name="error_reporting" value="-1" />
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0" />
-        <env name="SYMFONY_PHPUNIT_VERSION" value="8.4" />
     </php>
 
     <testsuites>

--- a/news-bundle/composer.json
+++ b/news-bundle/composer.json
@@ -33,6 +33,7 @@
         "contao/manager-plugin": "^2.3.1",
         "contao/test-case": "^4.0",
         "php-http/guzzle6-adapter": "^1.1",
+        "phpunit/phpunit": "^8.4",
         "symfony/phpunit-bridge": "^4.3.4"
     },
     "extra": {

--- a/news-bundle/phpunit.xml.dist
+++ b/news-bundle/phpunit.xml.dist
@@ -8,7 +8,6 @@
     <php>
         <ini name="error_reporting" value="-1" />
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0" />
-        <env name="SYMFONY_PHPUNIT_VERSION" value="8.4" />
     </php>
 
     <testsuites>

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,7 +1,6 @@
 parameters:
     autoload_files:
         - %currentWorkingDirectory%/vendor/autoload.php
-        - %currentWorkingDirectory%/vendor/bin/.phpunit/phpunit-8.4/vendor/autoload.php
 
     contao:
         services_yml_path: %currentWorkingDirectory%/core-bundle/src/Resources/config/services.yml

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,7 +9,6 @@
     <php>
         <ini name="error_reporting" value="-1" />
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0" />
-        <env name="SYMFONY_PHPUNIT_VERSION" value="8.4" />
         <env name="KERNEL_CLASS" value="Contao\CoreBundle\Tests\Functional\app\AppKernel" />
         <env name="APP_SECRET" value="foobar" />
         <env name="DATABASE_URL" value="mysql://root@localhost:3306/contao_test" />


### PR DESCRIPTION
The PR effectively reverts the simple-phpunit changes, because PHPStan will not run without the PHPUnit classes. This is not a problem, though, because we require PHP 7.2+ and thus do not need different PHPUnit versions anyway.