### PR TITLE
Do not run the push builds for pull requests

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,5 +1,6 @@
 build: off
 clone_depth: 50
+skip_branch_with_pr: true
 
 environment:
   # This sets the PHP version (from Chocolatey)

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,11 @@ env:
     - COMPOSER_ALLOW_XDEBUG=0
     - COMPOSER_MEMORY_LIMIT=-1
 
+branches:
+  only:
+    - master
+    - /^\d+\.\d+$/
+
 jobs:
   include:
     - stage: test


### PR DESCRIPTION
This will prevent double builds for pull requests on Travis and Appveyor.
