### PR TITLE
Check the attribute type the BackendAccessVoter::supports() method

### DIFF
--- a/core-bundle/src/Security/Voter/BackendAccessVoter.php
+++ b/core-bundle/src/Security/Voter/BackendAccessVoter.php
@@ -23,7 +23,7 @@ class BackendAccessVoter extends Voter
      */
     protected function supports($attribute, $subject): bool
     {
-        return 0 === strncmp($attribute, 'contao_user.', 12);
+        return is_string($attribute) && 0 === strncmp($attribute, 'contao_user.', 12);
     }
 
     /**

--- a/core-bundle/src/Security/Voter/BackendAccessVoter.php
+++ b/core-bundle/src/Security/Voter/BackendAccessVoter.php
@@ -23,7 +23,7 @@ class BackendAccessVoter extends Voter
      */
     protected function supports($attribute, $subject): bool
     {
-        return is_string($attribute) && 0 === strncmp($attribute, 'contao_user.', 12);
+        return \is_string($attribute) && 0 === strncmp($attribute, 'contao_user.', 12);
     }
 
     /**

--- a/core-bundle/tests/Security/Voter/BackendAccessVoterTest.php
+++ b/core-bundle/tests/Security/Voter/BackendAccessVoterTest.php
@@ -33,11 +33,10 @@ class BackendAccessVoterTest extends TestCase
         $this->voter = new BackendAccessVoter();
     }
 
-    public function testAbstainsIfExpressionLanguageAttribute(): void
+    public function testAbstainsIfTheAttributeIsNotAString(): void
     {
         $token = $this->createMock(TokenInterface::class);
-        $expression = new Expression('!is_granted("ROLE_MEMBER")');
-        $attributes = [$expression];
+        $attributes = [new Expression('!is_granted("ROLE_MEMBER")')];
 
         $this->assertSame(VoterInterface::ACCESS_ABSTAIN, $this->voter->vote($token, 'foo', $attributes));
     }

--- a/core-bundle/tests/Security/Voter/BackendAccessVoterTest.php
+++ b/core-bundle/tests/Security/Voter/BackendAccessVoterTest.php
@@ -36,7 +36,7 @@ class BackendAccessVoterTest extends TestCase
     public function testAbstainsIfExpressionLanguageAttribute(): void
     {
         $token = $this->createMock(TokenInterface::class);
-        $attributes = [new Expression('!is_granted(ROLE_MEMBER)')];
+        $attributes = [new Expression('!is_granted("ROLE_MEMBER")')];
 
         $this->assertSame(VoterInterface::ACCESS_ABSTAIN, $this->voter->vote($token, 'foo', $attributes));
     }

--- a/core-bundle/tests/Security/Voter/BackendAccessVoterTest.php
+++ b/core-bundle/tests/Security/Voter/BackendAccessVoterTest.php
@@ -36,7 +36,8 @@ class BackendAccessVoterTest extends TestCase
     public function testAbstainsIfExpressionLanguageAttribute(): void
     {
         $token = $this->createMock(TokenInterface::class);
-        $attributes = [new Expression('!is_granted("ROLE_MEMBER")')];
+        $expression = new Expression('!is_granted("ROLE_MEMBER")');
+        $attributes = [$expression];
 
         $this->assertSame(VoterInterface::ACCESS_ABSTAIN, $this->voter->vote($token, 'foo', $attributes));
     }

--- a/core-bundle/tests/Security/Voter/BackendAccessVoterTest.php
+++ b/core-bundle/tests/Security/Voter/BackendAccessVoterTest.php
@@ -15,6 +15,7 @@ namespace Contao\CoreBundle\Tests\Security\Voter;
 use Contao\BackendUser;
 use Contao\CoreBundle\Security\Voter\BackendAccessVoter;
 use Contao\CoreBundle\Tests\TestCase;
+use Symfony\Component\ExpressionLanguage\Expression;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
@@ -30,6 +31,14 @@ class BackendAccessVoterTest extends TestCase
         parent::setUp();
 
         $this->voter = new BackendAccessVoter();
+    }
+
+    public function testAbstainsIfExpressionLanguageAttribute(): void
+    {
+        $token = $this->createMock(TokenInterface::class);
+        $attributes = [new Expression('!is_granted(ROLE_MEMBER)')];
+
+        $this->assertSame(VoterInterface::ACCESS_ABSTAIN, $this->voter->vote($token, 'foo', $attributes));
     }
 
     public function testAbstainsIfThereIsNoContaoUserAttribute(): void


### PR DESCRIPTION
Ensure that the e.g. ExpressionLanguage objects are ignored when checking for support in the BackendAccessVoter.

Fixes: contao/core-bundle#1710

See also previous PR (and the discussions) for core-bundle: https://github.com/contao/core-bundle/pull/1711

Even if it is a bug in Symfony in the end, I think we should still add the check (at least until we have to update the Access Voter anyway to include the missing type hinting.