### PR TITLE
Check if a template exists when inheriting templates

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/TemplateInheritance.php
+++ b/core-bundle/src/Resources/contao/library/Contao/TemplateInheritance.php
@@ -10,6 +10,9 @@
 
 namespace Contao;
 
+use Contao\CoreBundle\Monolog\ContaoContext;
+use Psr\Log\LogLevel;
+
 /**
  * Provides the template inheritance logic
  *
@@ -92,12 +95,21 @@ trait TemplateInheritance
 
 			try
 			{
-				if (!file_exists($strParent))
+				if (file_exists($strParent))
 				{
-					throw new \Exception('Invalid template path: ' . $strParent); // see #798
+					include $strParent;
 				}
-
-				include $strParent;
+				else
+				{
+					System::getContainer()
+						->get('monolog.logger.contao')
+						->log(
+							LogLevel::ERROR,
+							'Invalid template path: ' . StringUtil::stripRootDir($strParent),
+							array('contao' => new ContaoContext(__METHOD__, ContaoContext::ERROR))
+						)
+					;
+				}
 
 				// Capture the output of the root template
 				if ($this->strParent === null)

--- a/core-bundle/src/Resources/contao/library/Contao/TemplateInheritance.php
+++ b/core-bundle/src/Resources/contao/library/Contao/TemplateInheritance.php
@@ -92,6 +92,11 @@ trait TemplateInheritance
 
 			try
 			{
+				if (!file_exists($strParent))
+				{
+					throw new \Exception('Invalid template path: ' . $strParent); // see #798
+				}
+
 				include $strParent;
 
 				// Capture the output of the root template


### PR DESCRIPTION
Fixes #798 

I am not sure about the performance implications here as the `file_exists()` check is done inside the `while` loop. We could also do

```php
if (!include $strParent)
{
    throw new \Exception('…');
}
```

@contao/developers WDYT?