### PR TITLE
Correctly trigger kernel response events when handling exceptions

### DIFF
--- a/core-bundle/src/Controller/InitializeController.php
+++ b/core-bundle/src/Controller/InitializeController.php
@@ -13,6 +13,8 @@ namespace Contao\CoreBundle\Controller;
 use Contao\CoreBundle\Response\InitializeControllerResponse;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\Event\FinishRequestEvent;
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
 use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 use Symfony\Component\HttpKernel\HttpKernel;
@@ -121,7 +123,11 @@ class InitializeController extends Controller
             $this->get('event_dispatcher')->dispatch(KernelEvents::RESPONSE, $event);
             $response = $event->getResponse();
 
-            $this->get('event_dispatcher')->dispatch(KernelEvents::FINISH_REQUEST, new FinishRequestEvent($this->get('http_kernel'), $request, $type));
+            $this->get('event_dispatcher')->dispatch(
+                KernelEvents::FINISH_REQUEST,
+                new FinishRequestEvent($this->get('http_kernel'), $request, $type)
+            );
+
             $this->get('request_stack')->pop();
         } catch (\Exception $e) {
             // ignore and continue with original response

--- a/core-bundle/src/Controller/InitializeController.php
+++ b/core-bundle/src/Controller/InitializeController.php
@@ -116,6 +116,17 @@ class InitializeController extends Controller
             }
         }
 
+        try {
+            $event = new FilterResponseEvent($this->get('http_kernel'), $request, $type, $response);
+            $this->get('event_dispatcher')->dispatch(KernelEvents::RESPONSE, $event);
+            $response = $event->getResponse();
+
+            $this->get('event_dispatcher')->dispatch(KernelEvents::FINISH_REQUEST, new FinishRequestEvent($this->get('http_kernel'), $request, $type));
+            $this->get('request_stack')->pop();
+        } catch (\Exception $e) {
+            // ignore and continue with original response
+        }
+
         $response->send();
         $this->get('kernel')->terminate($request, $response);
         exit;


### PR DESCRIPTION
In #525 we added our own exception handling for legacy entry points. To correctly behave like a kernel, we also need to trigger all respective events. Without it, somehow the session does not get stored correctly.

The code is copied and simplified from `HttpKernel`. As this is Symfony 3.4, we have to use the old event names and order. Maybe this should be updated when merging into master.

fixes https://github.com/isotope/core/issues/2087