### PR TITLE
Use the Codecov GitHub action to upload reports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,9 +36,10 @@ jobs:
               run: php -d pcov.enabled=1 vendor/bin/phpunit --testsuite=coverage --coverage-clover=clover.xml --colors=always
 
             - name: Upload the coverage report
-              run: bash <(curl -s https://codecov.io/bash) -f clover.xml
-              env:
-                  CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+              uses: codecov/codecov-action@v1
+              with:
+                  token: ${{ secrets.CODECOV_TOKEN }}
+                  file: ./clover.xml
 
     coding-style:
         name: Coding Style


### PR DESCRIPTION
Hopefully this will fix some issues with reports not getting uploaded for pull requests from external repos. Also, it hopefully makes the build fail if the HTTP status of the response is 400. 🙈 