### PR TITLE
Automatically upgrade new password hashes

### DIFF
--- a/core-bundle/src/Security/User/ContaoUserProvider.php
+++ b/core-bundle/src/Security/User/ContaoUserProvider.php
@@ -108,6 +108,19 @@ class ContaoUserProvider implements UserProviderInterface, PasswordUpgraderInter
     }
 
     /**
+     * @param User $user
+     */
+    public function upgradePassword(UserInterface $user, string $newEncodedPassword): void
+    {
+        if (!is_a($user, $this->userClass)) {
+            throw new UnsupportedUserException(sprintf('Unsupported class "%s".', \get_class($user)));
+        }
+
+        $user->password = $newEncodedPassword;
+        $user->save();
+    }
+
+    /**
      * Validates the session lifetime and logs the user out if the session has expired.
      *
      * @throws UsernameNotFoundException
@@ -152,13 +165,5 @@ class ContaoUserProvider implements UserProviderInterface, PasswordUpgraderInter
         foreach ($GLOBALS['TL_HOOKS']['postAuthenticate'] as $callback) {
             $system->importStatic($callback[0])->{$callback[1]}($user);
         }
-    }
-
-    public function upgradePassword(UserInterface $user, string $newEncodedPassword): void
-    {
-        /** @var User $user */
-        $user->password = $newEncodedPassword;
-
-        $user->save();
     }
 }

--- a/core-bundle/src/Security/User/ContaoUserProvider.php
+++ b/core-bundle/src/Security/User/ContaoUserProvider.php
@@ -23,10 +23,11 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
 use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
+use Symfony\Component\Security\Core\User\PasswordUpgraderInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 
-class ContaoUserProvider implements UserProviderInterface
+class ContaoUserProvider implements UserProviderInterface, PasswordUpgraderInterface
 {
     /**
      * @var ContaoFramework
@@ -151,5 +152,13 @@ class ContaoUserProvider implements UserProviderInterface
         foreach ($GLOBALS['TL_HOOKS']['postAuthenticate'] as $callback) {
             $system->importStatic($callback[0])->{$callback[1]}($user);
         }
+    }
+
+    public function upgradePassword(UserInterface $user, string $newEncodedPassword): void
+    {
+        /** @var User $user */
+        $user->password = $newEncodedPassword;
+
+        $user->save();
     }
 }

--- a/core-bundle/tests/Security/User/ContaoUserProviderTest.php
+++ b/core-bundle/tests/Security/User/ContaoUserProviderTest.php
@@ -207,6 +207,24 @@ class ContaoUserProviderTest extends TestCase
         $this->getProvider(null, 'LdapUser');
     }
 
+    public function testStoresUpgradedPasswords(): void
+    {
+        $user = $this->mockClassWithProperties(BackendUser::class);
+        $user->expects($this->once())->method('save');
+        $user->username = 'foobar';
+        $user->password = 'superhash';
+
+        $userProvider = new ContaoUserProvider(
+            $this->mockContaoFramework(),
+            $this->createMock(SessionInterface::class),
+            BackendUser::class
+        );
+
+        $userProvider->upgradePassword($user, 'newsuperhash');
+
+        $this->assertSame('newsuperhash', $user->password);
+    }
+
     /**
      * @group legacy
      *


### PR DESCRIPTION
This will automatically upgrade bcrypt passwords to argon2 passwords when users log in (or whatever we will have in the future). Symfony FTW :)

Implements https://github.com/contao/contao/issues/538.