### PR TITLE
Disable auto cache control of the Symfony SessionListener

### DIFF
--- a/core-bundle/src/EventListener/MakeResponsePrivateListener.php
+++ b/core-bundle/src/EventListener/MakeResponsePrivateListener.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\EventListener;
 
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\EventListener\AbstractSessionListener;
 
 class MakeResponsePrivateListener
 {
@@ -36,6 +37,9 @@ class MakeResponsePrivateListener
 
         $request = $event->getRequest();
         $response = $event->getResponse();
+
+        // Disable the default Symfony auto cache control
+        $response->headers->set(AbstractSessionListener::NO_AUTO_CACHE_CONTROL_HEADER, true);
 
         // If the response is not cacheable for a reverse proxy, we don't have to do anything anyway
         if (!$response->isCacheable()) {

--- a/core-bundle/tests/EventListener/MakeResponsePrivateListenerTest.php
+++ b/core-bundle/tests/EventListener/MakeResponsePrivateListenerTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\EventListener\AbstractSessionListener;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
 
@@ -62,6 +63,7 @@ class MakeResponsePrivateListenerTest extends TestCase
         $listener->onKernelResponse($event);
 
         $this->assertTrue($response->headers->getCacheControlDirective('public'));
+        $this->assertTrue($response->headers->has(AbstractSessionListener::NO_AUTO_CACHE_CONTROL_HEADER));
         $this->assertSame('600', $response->headers->getCacheControlDirective('max-age'));
     }
 
@@ -84,6 +86,7 @@ class MakeResponsePrivateListenerTest extends TestCase
         $listener = new MakeResponsePrivateListener();
         $listener->onKernelResponse($event);
 
+        $this->assertTrue($response->headers->has(AbstractSessionListener::NO_AUTO_CACHE_CONTROL_HEADER));
         $this->assertTrue($response->headers->getCacheControlDirective('private'));
     }
 
@@ -113,6 +116,7 @@ class MakeResponsePrivateListenerTest extends TestCase
         $listener = new MakeResponsePrivateListener();
         $listener->onKernelResponse($event);
 
+        $this->assertTrue($response->headers->has(AbstractSessionListener::NO_AUTO_CACHE_CONTROL_HEADER));
         $this->assertTrue($response->headers->getCacheControlDirective('private'));
     }
 
@@ -133,6 +137,7 @@ class MakeResponsePrivateListenerTest extends TestCase
         $listener = new MakeResponsePrivateListener();
         $listener->onKernelResponse($event);
 
+        $this->assertTrue($response->headers->has(AbstractSessionListener::NO_AUTO_CACHE_CONTROL_HEADER));
         $this->assertTrue($response->headers->getCacheControlDirective('private'));
     }
 
@@ -153,6 +158,7 @@ class MakeResponsePrivateListenerTest extends TestCase
         $listener = new MakeResponsePrivateListener();
         $listener->onKernelResponse($event);
 
+        $this->assertTrue($response->headers->has(AbstractSessionListener::NO_AUTO_CACHE_CONTROL_HEADER));
         $this->assertTrue($response->headers->getCacheControlDirective('private'));
     }
 
@@ -173,6 +179,7 @@ class MakeResponsePrivateListenerTest extends TestCase
         $listener = new MakeResponsePrivateListener();
         $listener->onKernelResponse($event);
 
+        $this->assertTrue($response->headers->has(AbstractSessionListener::NO_AUTO_CACHE_CONTROL_HEADER));
         $this->assertTrue($response->headers->getCacheControlDirective('public'));
     }
 }


### PR DESCRIPTION
Fixes https://github.com/contao/contao/issues/1028.

In fact, we don't need the default behaviour of Symfony because we qualify for "advanced usage" and our listener already correctly handles making responses private if needed.
I thought we need session stacking but that's not required because the SessionListener of SF correctly closes the session during `kernel.finish_request` which will cause our listener to correctly determine that the session was not started yet during the next `kernel.response`.