### PR TITLE
Allow to configure the HttpCache trace level using an environment variable

### DIFF
--- a/manager-bundle/src/HttpKernel/ContaoCache.php
+++ b/manager-bundle/src/HttpKernel/ContaoCache.php
@@ -64,8 +64,7 @@ class ContaoCache extends HttpCache implements CacheInvalidation
     {
         $options = parent::getOptions();
 
-        // Only works as of Symfony 4.3+
-        $options['trace_level'] = $this->isDebug ? 'full' : 'short';
+        $options['trace_level'] = $_SERVER['TRACE_LEVEL'] ?? 'short';
         $options['trace_header'] = 'Contao-Cache';
 
         return $options;


### PR DESCRIPTION
While debugging https://github.com/contao/contao/pull/1033 I noticed that we cannot configure the trace level of `HttpCache`. It absolutely makes no sense to bind that to `$this->isDebug` because in our case, this is always the case when we are in `dev` mode which again disables the HttpCache completely.

So here we go, by setting `TRACE_LEVEL=full` the `Contao-Cache` header gives you a lot more insight into the fragment requests.