### PR TITLE
Always warm the English language cache

### DIFF
--- a/core-bundle/src/Cache/ContaoCacheWarmer.php
+++ b/core-bundle/src/Cache/ContaoCacheWarmer.php
@@ -291,7 +291,7 @@ class ContaoCacheWarmer implements CacheWarmerInterface
 
         $statement->execute();
 
-        $languages = [];
+        $languages = ['en'];
 
         while (false !== ($language = $statement->fetch(\PDO::FETCH_OBJ))) {
             if ('' === $language->language) {

--- a/core-bundle/src/Cache/ContaoCacheWarmer.php
+++ b/core-bundle/src/Cache/ContaoCacheWarmer.php
@@ -291,6 +291,7 @@ class ContaoCacheWarmer implements CacheWarmerInterface
 
         $statement->execute();
 
+        // Always load the English language (see #1040)
         $languages = ['en'];
 
         while (false !== ($language = $statement->fetch(\PDO::FETCH_OBJ))) {


### PR DESCRIPTION
During profiling for https://github.com/contao/contao/issues/809, @Toflar noticed, that `Contao\CoreBundle\Config\Loader\XliffFileLoader::getPhpFromFileNode` is getting called, even though it shouldn't be called in production mode, since the internal language cache should already contain the compiled languages.

I then noticed, that in fact only `de` was present in the internal cache of Contao, but not `en` - and `en` will then later on always be loaded as the fall back (in case any translations are missing for the current language, but may be present in the English language).

The root cause is `Contao\CoreBundle\Cache\ContaoCacheWarmer::getLanguagesInUse` which combines the used languages from:

* the website roots
* the language of all back end users
* the language of all front end users

So, if you only have back end users with a language setting of "German" for example and you only have non-English website roots and no English members... then English would never be considered during the cache warming process.

This affects Contao 4.4.45 and 4.8.5