### PR TITLE
Improve the "purge search results cache" label

### DIFF
--- a/core-bundle/src/Resources/contao/languages/en/tl_maintenance.xlf
+++ b/core-bundle/src/Resources/contao/languages/en/tl_maintenance.xlf
@@ -93,7 +93,7 @@
         <source>Removes the cached versions of the front end pages.</source>
       </trans-unit>
       <trans-unit id="tl_maintenance_jobs.search.0">
-        <source>Purge the search cache</source>
+        <source>Purge the search results cache</source>
       </trans-unit>
       <trans-unit id="tl_maintenance_jobs.search.1">
         <source>Removes the cached versions of the search results.</source>


### PR DESCRIPTION
Fixed incorrect maintenance information now that we have a search indexer abstraction.