### PR TITLE
Use Throwable instead of Exception in the exception and error listeners

### DIFF
--- a/core-bundle/src/EventListener/ExceptionConverterListener.php
+++ b/core-bundle/src/EventListener/ExceptionConverterListener.php
@@ -67,7 +67,7 @@ class ExceptionConverterListener
         }
     }
 
-    private function getTargetClass(\Exception $exception): ?string
+    private function getTargetClass(\Throwable $exception): ?string
     {
         foreach (self::MAPPER as $source => $target) {
             if ($exception instanceof $source) {
@@ -78,7 +78,7 @@ class ExceptionConverterListener
         return null;
     }
 
-    private function convertToHttpException(\Exception $exception, string $target): ?HttpException
+    private function convertToHttpException(\Throwable $exception, string $target): ?HttpException
     {
         switch ($target) {
             case 'AccessDeniedHttpException':

--- a/core-bundle/src/EventListener/PrettyErrorScreenListener.php
+++ b/core-bundle/src/EventListener/PrettyErrorScreenListener.php
@@ -231,7 +231,7 @@ class PrettyErrorScreenListener
         ];
     }
 
-    private function logException(\Exception $exception): void
+    private function logException(\Throwable $exception): void
     {
         if (Kernel::VERSION_ID >= 40100 || null === $this->logger || !$this->isLoggable($exception)) {
             return;
@@ -240,7 +240,7 @@ class PrettyErrorScreenListener
         $this->logger->critical('An exception occurred.', ['exception' => $exception]);
     }
 
-    private function isLoggable(\Exception $exception): bool
+    private function isLoggable(\Throwable $exception): bool
     {
         do {
             if ($exception instanceof InvalidRequestTokenException) {
@@ -251,7 +251,7 @@ class PrettyErrorScreenListener
         return true;
     }
 
-    private function getStatusCodeForException(\Exception $exception): int
+    private function getStatusCodeForException(\Throwable $exception): int
     {
         if ($exception instanceof HttpException) {
             return (int) $exception->getStatusCode();


### PR DESCRIPTION
The PR fixes problems like this:

`
Argument 1 passed to Contao\CoreBundle\EventListener\ExceptionConverterListener::getTargetClass() must be an instance of Exception, instance of Symfony\Component\ErrorHandler\Error\UndefinedFunctionError given, called in vendor/contao/contao/core-bundle/src/EventListener/ExceptionConverterListener.php on line 59
`