### PR TITLE
Do not mark copied image size items as copied

### DIFF
--- a/core-bundle/src/Resources/contao/dca/tl_image_size_item.php
+++ b/core-bundle/src/Resources/contao/dca/tl_image_size_item.php
@@ -18,7 +18,6 @@ $GLOBALS['TL_DCA']['tl_image_size_item'] = array
 		'dataContainer'               => 'Table',
 		'ptable'                      => 'tl_image_size',
 		'enableVersioning'            => true,
-		'markAsCopy'                  => 'media',
 		'onload_callback' => array
 		(
 			array('tl_image_size_item', 'checkPermission')


### PR DESCRIPTION
Fixes #969 