### PR TITLE
Add support for invokable listeners and method validation

### DIFF
--- a/core-bundle/src/DependencyInjection/Compiler/DataContainerCallbackPass.php
+++ b/core-bundle/src/DependencyInjection/Compiler/DataContainerCallbackPass.php
@@ -99,11 +99,13 @@ class DataContainerCallbackPass implements CompilerPassInterface
         if (isset($attributes['method'])) {
             if (!$ref->hasMethod($attributes['method'])) {
                 $invalid .= sprintf('The class "%s" does not have a method "%s".', $class, $attributes['method']);
+
                 throw new InvalidDefinitionException($invalid);
             }
 
             if (!$ref->getMethod($attributes['method'])->isPublic()) {
                 $invalid .= sprintf('The "%s::%s" method exists but is not public.', $class, $attributes['method']);
+
                 throw new InvalidDefinitionException($invalid);
             }
 

--- a/core-bundle/src/DependencyInjection/Compiler/DataContainerCallbackPass.php
+++ b/core-bundle/src/DependencyInjection/Compiler/DataContainerCallbackPass.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\DependencyInjection\Compiler;
 
-use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+use Symfony\Component\Config\Definition\Exception\InvalidDefinitionException;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -54,24 +54,25 @@ class DataContainerCallbackPass implements CompilerPassInterface
                 $serviceId = (string) $container->getAlias($serviceId);
             }
 
-            foreach ($tags as $attributes) {
-                $this->addCallback($callbacks, $serviceId, $attributes);
-            }
+            $definition = $container->findDefinition($serviceId);
+            $definition->setPublic(true);
 
-            $container->findDefinition($serviceId)->setPublic(true);
+            foreach ($tags as $attributes) {
+                $this->addCallback($callbacks, $serviceId, $definition->getClass(), $attributes);
+            }
         }
 
         return $callbacks;
     }
 
-    private function addCallback(array &$callbacks, string $serviceId, array $attributes): void
+    private function addCallback(array &$callbacks, string $serviceId, string $class, array $attributes): void
     {
         if (!isset($attributes['table'])) {
-            throw new InvalidConfigurationException(sprintf('Missing table attribute in tagged callback service ID "%s"', $serviceId));
+            throw new InvalidDefinitionException(sprintf('Missing table attribute in tagged callback service ID "%s"', $serviceId));
         }
 
         if (!isset($attributes['target'])) {
-            throw new InvalidConfigurationException(sprintf('Missing target attribute in tagged callback service ID "%s"', $serviceId));
+            throw new InvalidDefinitionException(sprintf('Missing target attribute in tagged callback service ID "%s"', $serviceId));
         }
 
         if (
@@ -86,13 +87,26 @@ class DataContainerCallbackPass implements CompilerPassInterface
 
         $callbacks[$attributes['table']][$attributes['target']][$priority][] = [
             $serviceId,
-            $this->getMethod($attributes),
+            $this->getMethod($attributes, $class, $serviceId),
         ];
     }
 
-    private function getMethod(array $attributes): string
+    private function getMethod(array $attributes, string $class, string $serviceId): string
     {
+        $ref = new \ReflectionClass($class);
+        $invalid = sprintf('The contao.callback definition for service "%s" is invalid. ', $serviceId);
+
         if (isset($attributes['method'])) {
+            if (!$ref->hasMethod($attributes['method'])) {
+                $invalid .= sprintf('The class "%s" does not have a method "%s".', $class, $attributes['method']);
+                throw new InvalidDefinitionException($invalid);
+            }
+
+            if (!$ref->getMethod($attributes['method'])->isPublic()) {
+                $invalid .= sprintf('The "%s::%s" method exists but is not public.', $class, $attributes['method']);
+                throw new InvalidDefinitionException($invalid);
+            }
+
             return (string) $attributes['method'];
         }
 
@@ -103,6 +117,27 @@ class DataContainerCallbackPass implements CompilerPassInterface
             $callback = substr($callback, 2);
         }
 
-        return 'on'.Container::camelize($callback);
+        $method = 'on'.Container::camelize($callback);
+        $private = false;
+
+        if ($ref->hasMethod($method)) {
+            if ($ref->getMethod($method)->isPublic()) {
+                return $method;
+            }
+
+            $private = true;
+        }
+
+        if ($ref->hasMethod('__invoke')) {
+            return '__invoke';
+        }
+
+        if ($private) {
+            $invalid .= sprintf('The "%s::%s" method exists but is not public.', $class, $method);
+        } else {
+            $invalid .= sprintf('Either specify a method name or implement the "%s" or __invoke method.', $method);
+        }
+
+        throw new InvalidDefinitionException($invalid);
     }
 }

--- a/core-bundle/src/DependencyInjection/Compiler/RegisterHookListenersPass.php
+++ b/core-bundle/src/DependencyInjection/Compiler/RegisterHookListenersPass.php
@@ -91,11 +91,13 @@ class RegisterHookListenersPass implements CompilerPassInterface
         if (isset($attributes['method'])) {
             if (!$ref->hasMethod($attributes['method'])) {
                 $invalid .= sprintf('The class "%s" does not have a method "%s".', $class, $attributes['method']);
+
                 throw new InvalidDefinitionException($invalid);
             }
 
             if (!$ref->getMethod($attributes['method'])->isPublic()) {
                 $invalid .= sprintf('The "%s::%s" method exists but is not public.', $class, $attributes['method']);
+
                 throw new InvalidDefinitionException($invalid);
             }
 

--- a/core-bundle/src/DependencyInjection/Compiler/RegisterHookListenersPass.php
+++ b/core-bundle/src/DependencyInjection/Compiler/RegisterHookListenersPass.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\DependencyInjection\Compiler;
 
-use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+use Symfony\Component\Config\Definition\Exception\InvalidDefinitionException;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
@@ -58,36 +58,71 @@ class RegisterHookListenersPass implements CompilerPassInterface
                 $serviceId = (string) $container->getAlias($serviceId);
             }
 
-            foreach ($tags as $attributes) {
-                $this->addHookCallback($hooks, $serviceId, $attributes);
-            }
+            $definition = $container->findDefinition($serviceId);
+            $definition->setPublic(true);
 
-            $container->findDefinition($serviceId)->setPublic(true);
+            foreach ($tags as $attributes) {
+                $this->addHookCallback($hooks, $serviceId, $definition->getClass(), $attributes);
+            }
         }
 
         return $hooks;
     }
 
     /**
-     * @throws InvalidConfigurationException
+     * @throws InvalidDefinitionException
      */
-    private function addHookCallback(array &$hooks, string $serviceId, array $attributes): void
+    private function addHookCallback(array &$hooks, string $serviceId, string $class, array $attributes): void
     {
         if (!isset($attributes['hook'])) {
-            throw new InvalidConfigurationException(sprintf('Missing hook attribute in tagged hook service with service id "%s"', $serviceId));
+            throw new InvalidDefinitionException(sprintf('Missing hook attribute in tagged hook service with service id "%s"', $serviceId));
         }
 
         $priority = (int) ($attributes['priority'] ?? 0);
 
-        $hooks[$attributes['hook']][$priority][] = [$serviceId, $this->getMethod($attributes)];
+        $hooks[$attributes['hook']][$priority][] = [$serviceId, $this->getMethod($attributes, $class, $serviceId)];
     }
 
-    private function getMethod(array $attributes): string
+    private function getMethod(array $attributes, string $class, string $serviceId): string
     {
+        $ref = new \ReflectionClass($class);
+        $invalid = sprintf('The contao.hook definition for service "%s" is invalid. ', $serviceId);
+
         if (isset($attributes['method'])) {
+            if (!$ref->hasMethod($attributes['method'])) {
+                $invalid .= sprintf('The class "%s" does not have a method "%s".', $class, $attributes['method']);
+                throw new InvalidDefinitionException($invalid);
+            }
+
+            if (!$ref->getMethod($attributes['method'])->isPublic()) {
+                $invalid .= sprintf('The "%s::%s" method exists but is not public.', $class, $attributes['method']);
+                throw new InvalidDefinitionException($invalid);
+            }
+
             return (string) $attributes['method'];
         }
 
-        return 'on'.ucfirst($attributes['hook']);
+        $method = 'on'.ucfirst($attributes['hook']);
+        $private = false;
+
+        if ($ref->hasMethod($method)) {
+            if ($ref->getMethod($method)->isPublic()) {
+                return $method;
+            }
+
+            $private = true;
+        }
+
+        if ($ref->hasMethod('__invoke')) {
+            return '__invoke';
+        }
+
+        if ($private) {
+            $invalid .= sprintf('The "%s::%s" method exists but is not public.', $class, $method);
+        } else {
+            $invalid .= sprintf('Either specify a method name or implement the "%s" or __invoke method.', $method);
+        }
+
+        throw new InvalidDefinitionException($invalid);
     }
 }

--- a/core-bundle/src/ServiceAnnotation/Callback.php
+++ b/core-bundle/src/ServiceAnnotation/Callback.php
@@ -21,7 +21,7 @@ use Terminal42\ServiceAnnotationBundle\Annotation\ServiceTagInterface;
  * Annotation to register a DCA callback.
  *
  * @Annotation
- * @Target({"METHOD"})
+ * @Target({"CLASS", "METHOD"})
  * @Attributes({
  *     @Attribute("table", type="string", required=true),
  *     @Attribute("target", type="string", required=true),

--- a/core-bundle/src/ServiceAnnotation/Hook.php
+++ b/core-bundle/src/ServiceAnnotation/Hook.php
@@ -21,7 +21,7 @@ use Terminal42\ServiceAnnotationBundle\Annotation\ServiceTagInterface;
  * Annotation to register a Contao hook.
  *
  * @Annotation
- * @Target({"METHOD"})
+ * @Target({"CLASS", "METHOD"})
  * @Attributes({
  *     @Attribute("value", type="string", required=true),
  *     @Attribute("priority", type="int"),

--- a/core-bundle/tests/DependencyInjection/Compiler/DataContainerCallbackPassTest.php
+++ b/core-bundle/tests/DependencyInjection/Compiler/DataContainerCallbackPassTest.php
@@ -505,7 +505,7 @@ class DataContainerCallbackPassTest extends TestCase
         $pass->process($container);
     }
 
-    public function testThrowsExceptionIfConfiguredMethodDoesNotExist()
+    public function testThrowsExceptionIfConfiguredMethodDoesNotExist(): void
     {
         $definition = new Definition(TestListener::class);
         $definition->addTag('contao.callback', ['table' => 'tl_page', 'target' => 'tl_page.config.foo', 'method' => 'onFooCallback']);
@@ -521,7 +521,7 @@ class DataContainerCallbackPassTest extends TestCase
         $pass->process($container);
     }
 
-    public function testThrowsExceptionIfConfiguredMethodIsPrivate()
+    public function testThrowsExceptionIfConfiguredMethodIsPrivate(): void
     {
         $definition = new Definition(TestListener::class);
         $definition->addTag('contao.callback', ['table' => 'tl_page', 'target' => 'tl_page.config.foo', 'method' => 'onPrivateCallback']);
@@ -537,7 +537,7 @@ class DataContainerCallbackPassTest extends TestCase
         $pass->process($container);
     }
 
-    public function testThrowsExceptionIfGeneratedMethodIsPrivate()
+    public function testThrowsExceptionIfGeneratedMethodIsPrivate(): void
     {
         $definition = new Definition(TestListener::class);
         $definition->addTag('contao.callback', ['table' => 'tl_page', 'target' => 'tl_page.config.private']);
@@ -553,7 +553,7 @@ class DataContainerCallbackPassTest extends TestCase
         $pass->process($container);
     }
 
-    public function testThrowsExceptionIfNoValidMethodExists()
+    public function testThrowsExceptionIfNoValidMethodExists(): void
     {
         $definition = new Definition(TestListener::class);
         $definition->addTag('contao.callback', ['table' => 'tl_page', 'target' => 'tl_page.config.foo']);

--- a/core-bundle/tests/DependencyInjection/Compiler/DataContainerCallbackPassTest.php
+++ b/core-bundle/tests/DependencyInjection/Compiler/DataContainerCallbackPassTest.php
@@ -14,8 +14,10 @@ namespace Contao\CoreBundle\Tests\DependencyInjection\Compiler;
 
 use Contao\CoreBundle\DependencyInjection\Compiler\DataContainerCallbackPass;
 use Contao\CoreBundle\EventListener\DataContainerCallbackListener;
+use Contao\CoreBundle\Fixtures\EventListener\InvokableListener;
+use Contao\CoreBundle\Fixtures\EventListener\TestListener;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+use Symfony\Component\Config\Definition\Exception\InvalidDefinitionException;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 
@@ -30,7 +32,7 @@ class DataContainerCallbackPassTest extends TestCase
             'priority' => 10,
         ];
 
-        $definition = new Definition('Test\CallbackListener');
+        $definition = new Definition(TestListener::class);
         $definition->addTag('contao.callback', $attributes);
 
         $container = $this->getContainerBuilder();
@@ -62,7 +64,7 @@ class DataContainerCallbackPassTest extends TestCase
             'priority' => 10,
         ];
 
-        $definition = new Definition('Test\CallbackListener');
+        $definition = new Definition(TestListener::class);
         $definition->addTag('contao.callback', $attributes);
         $definition->setPublic(false);
 
@@ -85,7 +87,7 @@ class DataContainerCallbackPassTest extends TestCase
             'priority' => 10,
         ];
 
-        $definition = new Definition('Test\CallbackListener');
+        $definition = new Definition(TestListener::class);
         $definition->addTag('contao.callback', $attributes);
 
         $container = $this->getContainerBuilder();
@@ -108,6 +110,37 @@ class DataContainerCallbackPassTest extends TestCase
         );
     }
 
+    public function testUsesInvokeMethodIfNoneGiven(): void
+    {
+        $attributes = [
+            'table' => 'tl_page',
+            'target' => 'config.onload_callback',
+            'priority' => 10,
+        ];
+
+        $definition = new Definition(InvokableListener::class);
+        $definition->addTag('contao.callback', $attributes);
+
+        $container = $this->getContainerBuilder();
+        $container->setDefinition('test.callback_listener', $definition);
+
+        $pass = new DataContainerCallbackPass();
+        $pass->process($container);
+
+        $this->assertSame(
+            [
+                'tl_page' => [
+                    'config.onload_callback' => [
+                        10 => [
+                            ['test.callback_listener', '__invoke'],
+                        ],
+                    ],
+                ],
+            ],
+            $this->getCallbacksFromDefinition($container)[0]
+        );
+    }
+
     public function testSetsTheDefaultPriorityIfNoPriorityGiven(): void
     {
         $attributes = [
@@ -116,7 +149,7 @@ class DataContainerCallbackPassTest extends TestCase
             'method' => 'onLoadPage',
         ];
 
-        $definition = new Definition('Test\CallbackListener');
+        $definition = new Definition(TestListener::class);
         $definition->addTag('contao.callback', $attributes);
 
         $container = $this->getContainerBuilder();
@@ -148,7 +181,7 @@ class DataContainerCallbackPassTest extends TestCase
             'method' => 'onLoadPage',
         ];
 
-        $definition = new Definition('Test\CallbackListener');
+        $definition = new Definition(TestListener::class);
         $definition->addTag('contao.callback', $attributes);
 
         $container = $this->getContainerBuilder();
@@ -180,7 +213,7 @@ class DataContainerCallbackPassTest extends TestCase
             'method' => 'onArticleWizard',
         ];
 
-        $definition = new Definition('Test\CallbackListener');
+        $definition = new Definition(TestListener::class);
         $definition->addTag('contao.callback', $attributes);
 
         $container = $this->getContainerBuilder();
@@ -212,7 +245,7 @@ class DataContainerCallbackPassTest extends TestCase
             'method' => 'onListitemsXlabel',
         ];
 
-        $definition = new Definition('Test\CallbackListener');
+        $definition = new Definition(TestListener::class);
         $definition->addTag('contao.callback', $attributes);
 
         $container = $this->getContainerBuilder();
@@ -243,7 +276,7 @@ class DataContainerCallbackPassTest extends TestCase
             'method' => 'onFoobarCallback',
         ];
 
-        $definition = new Definition('Test\CallbackListener');
+        $definition = new Definition(TestListener::class);
         $definition->addTag('contao.callback', $attributes);
 
         $container = $this->getContainerBuilder();
@@ -268,7 +301,7 @@ class DataContainerCallbackPassTest extends TestCase
 
     public function testHandlesMultipleCallbacks(): void
     {
-        $definition = new Definition('Test\CallbackListener');
+        $definition = new Definition(TestListener::class);
 
         $definition->addTag(
             'contao.callback',
@@ -354,7 +387,7 @@ class DataContainerCallbackPassTest extends TestCase
 
     public function testAddsTheCallbacksByPriority(): void
     {
-        $definitionA = new Definition('Test\CallbackListenerA');
+        $definitionA = new Definition(TestListener::class);
 
         $definitionA->addTag(
             'contao.callback',
@@ -365,7 +398,7 @@ class DataContainerCallbackPassTest extends TestCase
             ]
         );
 
-        $definitionB = new Definition('Test\CallbackListenerB');
+        $definitionB = new Definition(TestListener::class);
 
         $definitionB->addTag(
             'contao.callback',
@@ -444,7 +477,7 @@ class DataContainerCallbackPassTest extends TestCase
 
     public function testFailsIfTheTableAttributeIsMissing(): void
     {
-        $definition = new Definition('Test\CallbackListener');
+        $definition = new Definition(TestListener::class);
         $definition->addTag('contao.callback', ['target' => 'config.onload']);
 
         $container = $this->getContainerBuilder();
@@ -452,14 +485,14 @@ class DataContainerCallbackPassTest extends TestCase
 
         $pass = new DataContainerCallbackPass();
 
-        $this->expectException(InvalidConfigurationException::class);
+        $this->expectException(InvalidDefinitionException::class);
 
         $pass->process($container);
     }
 
     public function testFailsIfTheTargetAttributeIsMissing(): void
     {
-        $definition = new Definition('Test\CallbackListener');
+        $definition = new Definition(TestListener::class);
         $definition->addTag('contao.callback', ['table' => 'tl_page']);
 
         $container = $this->getContainerBuilder();
@@ -467,7 +500,71 @@ class DataContainerCallbackPassTest extends TestCase
 
         $pass = new DataContainerCallbackPass();
 
-        $this->expectException(InvalidConfigurationException::class);
+        $this->expectException(InvalidDefinitionException::class);
+
+        $pass->process($container);
+    }
+
+    public function testThrowsExceptionIfConfiguredMethodDoesNotExist()
+    {
+        $definition = new Definition(TestListener::class);
+        $definition->addTag('contao.callback', ['table' => 'tl_page', 'target' => 'tl_page.config.foo', 'method' => 'onFooCallback']);
+
+        $container = $this->getContainerBuilder();
+        $container->setDefinition('test.callback_listener', $definition);
+
+        $pass = new DataContainerCallbackPass();
+
+        $this->expectException(InvalidDefinitionException::class);
+        $this->expectDeprecationMessage('The class "Contao\CoreBundle\Fixtures\EventListener\TestListener" does not have a method "onFooCallback".');
+
+        $pass->process($container);
+    }
+
+    public function testThrowsExceptionIfConfiguredMethodIsPrivate()
+    {
+        $definition = new Definition(TestListener::class);
+        $definition->addTag('contao.callback', ['table' => 'tl_page', 'target' => 'tl_page.config.foo', 'method' => 'onPrivateCallback']);
+
+        $container = $this->getContainerBuilder();
+        $container->setDefinition('test.callback_listener', $definition);
+
+        $pass = new DataContainerCallbackPass();
+
+        $this->expectException(InvalidDefinitionException::class);
+        $this->expectDeprecationMessage('The "Contao\CoreBundle\Fixtures\EventListener\TestListener::onPrivateCallback" method exists but is not public.');
+
+        $pass->process($container);
+    }
+
+    public function testThrowsExceptionIfGeneratedMethodIsPrivate()
+    {
+        $definition = new Definition(TestListener::class);
+        $definition->addTag('contao.callback', ['table' => 'tl_page', 'target' => 'tl_page.config.private']);
+
+        $container = $this->getContainerBuilder();
+        $container->setDefinition('test.callback_listener', $definition);
+
+        $pass = new DataContainerCallbackPass();
+
+        $this->expectException(InvalidDefinitionException::class);
+        $this->expectDeprecationMessage('The "Contao\CoreBundle\Fixtures\EventListener\TestListener::onPrivateCallback" method exists but is not public.');
+
+        $pass->process($container);
+    }
+
+    public function testThrowsExceptionIfNoValidMethodExists()
+    {
+        $definition = new Definition(TestListener::class);
+        $definition->addTag('contao.callback', ['table' => 'tl_page', 'target' => 'tl_page.config.foo']);
+
+        $container = $this->getContainerBuilder();
+        $container->setDefinition('test.callback_listener', $definition);
+
+        $pass = new DataContainerCallbackPass();
+
+        $this->expectException(InvalidDefinitionException::class);
+        $this->expectDeprecationMessage('Either specify a method name or implement the "onFooCallback" or __invoke method.');
 
         $pass->process($container);
     }

--- a/core-bundle/tests/DependencyInjection/Compiler/DataContainerCallbackPassTest.php
+++ b/core-bundle/tests/DependencyInjection/Compiler/DataContainerCallbackPassTest.php
@@ -508,7 +508,15 @@ class DataContainerCallbackPassTest extends TestCase
     public function testThrowsExceptionIfConfiguredMethodDoesNotExist(): void
     {
         $definition = new Definition(TestListener::class);
-        $definition->addTag('contao.callback', ['table' => 'tl_page', 'target' => 'tl_page.config.foo', 'method' => 'onFooCallback']);
+
+        $definition->addTag(
+            'contao.callback',
+            [
+                'table' => 'tl_page',
+                'target' => 'tl_page.config.foo',
+                'method' => 'onFooCallback',
+            ]
+        );
 
         $container = $this->getContainerBuilder();
         $container->setDefinition('test.callback_listener', $definition);
@@ -524,7 +532,15 @@ class DataContainerCallbackPassTest extends TestCase
     public function testThrowsExceptionIfConfiguredMethodIsPrivate(): void
     {
         $definition = new Definition(TestListener::class);
-        $definition->addTag('contao.callback', ['table' => 'tl_page', 'target' => 'tl_page.config.foo', 'method' => 'onPrivateCallback']);
+
+        $definition->addTag(
+            'contao.callback',
+            [
+                'table' => 'tl_page',
+                'target' => 'tl_page.config.foo',
+                'method' => 'onPrivateCallback',
+            ]
+        );
 
         $container = $this->getContainerBuilder();
         $container->setDefinition('test.callback_listener', $definition);

--- a/core-bundle/tests/DependencyInjection/Compiler/RegisterHookListenersPassTest.php
+++ b/core-bundle/tests/DependencyInjection/Compiler/RegisterHookListenersPassTest.php
@@ -13,9 +13,11 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Tests\DependencyInjection\Compiler;
 
 use Contao\CoreBundle\DependencyInjection\Compiler\RegisterHookListenersPass;
+use Contao\CoreBundle\Fixtures\EventListener\InvokableListener;
+use Contao\CoreBundle\Fixtures\EventListener\TestListener;
 use Contao\CoreBundle\Framework\ContaoFramework;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+use Symfony\Component\Config\Definition\Exception\InvalidDefinitionException;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 
@@ -30,7 +32,7 @@ class RegisterHookListenersPassTest extends TestCase
             'private' => false,
         ];
 
-        $definition = new Definition('Test\HookListener');
+        $definition = new Definition(TestListener::class);
         $definition->addTag('contao.hook', $attributes);
 
         $container = $this->getContainerBuilder();
@@ -58,7 +60,7 @@ class RegisterHookListenersPassTest extends TestCase
             'method' => 'onInitializeSystem',
         ];
 
-        $definition = new Definition('Test\HookListener');
+        $definition = new Definition(TestListener::class);
         $definition->addTag('contao.hook', $attributes);
         $definition->setPublic(false);
 
@@ -79,7 +81,7 @@ class RegisterHookListenersPassTest extends TestCase
             'hook' => 'generatePage',
         ];
 
-        $definition = new Definition('Test\HookListener');
+        $definition = new Definition(TestListener::class);
         $definition->addTag('contao.hook', $attributes);
 
         $container = $this->getContainerBuilder();
@@ -100,6 +102,33 @@ class RegisterHookListenersPassTest extends TestCase
         );
     }
 
+    public function testUsesInvokeMethodIfNoneGiven(): void
+    {
+        $attributes = [
+            'hook' => 'generatePage',
+        ];
+
+        $definition = new Definition(InvokableListener::class);
+        $definition->addTag('contao.hook', $attributes);
+
+        $container = $this->getContainerBuilder();
+        $container->setDefinition('test.hook_listener', $definition);
+
+        $pass = new RegisterHookListenersPass();
+        $pass->process($container);
+
+        $this->assertSame(
+            [
+                'generatePage' => [
+                    0 => [
+                        ['test.hook_listener', '__invoke'],
+                    ],
+                ],
+            ],
+            $this->getHookListenersFromDefinition($container)[0]
+        );
+    }
+
     public function testSetsTheDefaultPriorityIfNoPriorityGiven(): void
     {
         $attributes = [
@@ -107,7 +136,7 @@ class RegisterHookListenersPassTest extends TestCase
             'method' => 'onInitializeSystem',
         ];
 
-        $definition = new Definition('Test\HookListener');
+        $definition = new Definition(TestListener::class);
         $definition->addTag('contao.hook', $attributes);
 
         $container = $this->getContainerBuilder();
@@ -130,7 +159,7 @@ class RegisterHookListenersPassTest extends TestCase
 
     public function testHandlesMultipleTags(): void
     {
-        $definition = new Definition('Test\HookListener');
+        $definition = new Definition(TestListener::class);
 
         $definition->addTag(
             'contao.hook',
@@ -195,7 +224,7 @@ class RegisterHookListenersPassTest extends TestCase
 
     public function testSortsTheHooksByPriority(): void
     {
-        $definitionA = new Definition('Test\HookListenerA');
+        $definitionA = new Definition(TestListener::class);
 
         $definitionA->addTag(
             'contao.hook',
@@ -206,7 +235,7 @@ class RegisterHookListenersPassTest extends TestCase
             ]
         );
 
-        $definitionB = new Definition('Test\HookListenerB');
+        $definitionB = new Definition(TestListener::class);
 
         $definitionB->addTag(
             'contao.hook',
@@ -281,7 +310,7 @@ class RegisterHookListenersPassTest extends TestCase
 
     public function testFailsIfTheHookAttributeIsMissing(): void
     {
-        $definition = new Definition('Test\HookListener');
+        $definition = new Definition(TestListener::class);
         $definition->addTag('contao.hook', ['method' => 'onInitializeSystemAfter']);
 
         $container = $this->getContainerBuilder();
@@ -289,7 +318,71 @@ class RegisterHookListenersPassTest extends TestCase
 
         $pass = new RegisterHookListenersPass();
 
-        $this->expectException(InvalidConfigurationException::class);
+        $this->expectException(InvalidDefinitionException::class);
+
+        $pass->process($container);
+    }
+
+    public function testThrowsExceptionIfConfiguredMethodDoesNotExist()
+    {
+        $definition = new Definition(TestListener::class);
+        $definition->addTag('contao.hook', ['hook' => 'onInitializeSystem', 'method' => 'onFoo']);
+
+        $container = $this->getContainerBuilder();
+        $container->setDefinition('test.hook_listener', $definition);
+
+        $pass = new RegisterHookListenersPass();
+
+        $this->expectException(InvalidDefinitionException::class);
+        $this->expectDeprecationMessage('The class "Contao\CoreBundle\Fixtures\EventListener\TestListener" does not have a method "onFoo".');
+
+        $pass->process($container);
+    }
+
+    public function testThrowsExceptionIfConfiguredMethodIsPrivate()
+    {
+        $definition = new Definition(TestListener::class);
+        $definition->addTag('contao.hook', ['hook' => 'onInitializeSystem', 'method' => 'onPrivateCallback']);
+
+        $container = $this->getContainerBuilder();
+        $container->setDefinition('test.hook_listener', $definition);
+
+        $pass = new RegisterHookListenersPass();
+
+        $this->expectException(InvalidDefinitionException::class);
+        $this->expectDeprecationMessage('The "Contao\CoreBundle\Fixtures\EventListener\TestListener::onPrivateCallback" method exists but is not public.');
+
+        $pass->process($container);
+    }
+
+    public function testThrowsExceptionIfGeneratedMethodIsPrivate()
+    {
+        $definition = new Definition(TestListener::class);
+        $definition->addTag('contao.hook', ['hook' => 'privateCallback']);
+
+        $container = $this->getContainerBuilder();
+        $container->setDefinition('test.hook_listener', $definition);
+
+        $pass = new RegisterHookListenersPass();
+
+        $this->expectException(InvalidDefinitionException::class);
+        $this->expectDeprecationMessage('The "Contao\CoreBundle\Fixtures\EventListener\TestListener::onPrivateCallback" method exists but is not public.');
+
+        $pass->process($container);
+    }
+
+    public function testThrowsExceptionIfNoValidMethodExists()
+    {
+        $definition = new Definition(TestListener::class);
+        $definition->addTag('contao.hook', ['hook' => 'fooBar']);
+
+        $container = $this->getContainerBuilder();
+        $container->setDefinition('test.hook_listener', $definition);
+
+        $pass = new RegisterHookListenersPass();
+
+        $this->expectException(InvalidDefinitionException::class);
+        $this->expectDeprecationMessage('Either specify a method name or implement the "onFooBar" or __invoke method.');
 
         $pass->process($container);
     }

--- a/core-bundle/tests/DependencyInjection/Compiler/RegisterHookListenersPassTest.php
+++ b/core-bundle/tests/DependencyInjection/Compiler/RegisterHookListenersPassTest.php
@@ -323,7 +323,7 @@ class RegisterHookListenersPassTest extends TestCase
         $pass->process($container);
     }
 
-    public function testThrowsExceptionIfConfiguredMethodDoesNotExist()
+    public function testThrowsExceptionIfConfiguredMethodDoesNotExist(): void
     {
         $definition = new Definition(TestListener::class);
         $definition->addTag('contao.hook', ['hook' => 'onInitializeSystem', 'method' => 'onFoo']);
@@ -339,7 +339,7 @@ class RegisterHookListenersPassTest extends TestCase
         $pass->process($container);
     }
 
-    public function testThrowsExceptionIfConfiguredMethodIsPrivate()
+    public function testThrowsExceptionIfConfiguredMethodIsPrivate(): void
     {
         $definition = new Definition(TestListener::class);
         $definition->addTag('contao.hook', ['hook' => 'onInitializeSystem', 'method' => 'onPrivateCallback']);
@@ -355,7 +355,7 @@ class RegisterHookListenersPassTest extends TestCase
         $pass->process($container);
     }
 
-    public function testThrowsExceptionIfGeneratedMethodIsPrivate()
+    public function testThrowsExceptionIfGeneratedMethodIsPrivate(): void
     {
         $definition = new Definition(TestListener::class);
         $definition->addTag('contao.hook', ['hook' => 'privateCallback']);
@@ -371,7 +371,7 @@ class RegisterHookListenersPassTest extends TestCase
         $pass->process($container);
     }
 
-    public function testThrowsExceptionIfNoValidMethodExists()
+    public function testThrowsExceptionIfNoValidMethodExists(): void
     {
         $definition = new Definition(TestListener::class);
         $definition->addTag('contao.hook', ['hook' => 'fooBar']);

--- a/core-bundle/tests/Fixtures/src/EventListener/InvokableListener.php
+++ b/core-bundle/tests/Fixtures/src/EventListener/InvokableListener.php
@@ -1,12 +1,20 @@
 <?php
 
-namespace Contao\CoreBundle\Fixtures\EventListener;
+declare(strict_types=1);
 
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Fixtures\EventListener;
 
 class InvokableListener
 {
-    public function __invoke()
+    public function __invoke(): void
     {
-
     }
 }

--- a/core-bundle/tests/Fixtures/src/EventListener/InvokableListener.php
+++ b/core-bundle/tests/Fixtures/src/EventListener/InvokableListener.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Contao\CoreBundle\Fixtures\EventListener;
+
+
+class InvokableListener
+{
+    public function __invoke()
+    {
+
+    }
+}

--- a/core-bundle/tests/Fixtures/src/EventListener/TestListener.php
+++ b/core-bundle/tests/Fixtures/src/EventListener/TestListener.php
@@ -1,87 +1,96 @@
 <?php
 
-namespace Contao\CoreBundle\Fixtures\EventListener;
+declare(strict_types=1);
 
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Fixtures\EventListener;
 
 class TestListener
 {
-    private function onPrivateCallback()
+    public function onLoadPage(): void
     {
     }
 
-    public function onLoadPage()
+    public function onLoadCallback(): void
     {
     }
 
-    public function onLoadCallback()
+    public function onListitemsXlabel(): void
     {
     }
 
-    public function onListitemsXlabel()
+    public function onFoobarCallback(): void
     {
     }
 
-    public function onFoobarCallback()
+    public function loadFirst(): void
     {
     }
 
-    public function loadFirst()
+    public function loadSecond(): void
     {
     }
 
-    public function loadSecond()
+    public function onSaveCallback(): void
     {
     }
 
-    public function onSaveCallback()
+    public function onLabelCallback(): void
     {
     }
 
-    public function onLabelCallback()
+    public function onLoadFirst(): void
     {
     }
 
-    public function onLoadFirst()
+    public function onLoadSecond(): void
     {
     }
 
-    public function onLoadSecond()
+    public function onArticleWizard(): void
     {
     }
 
-    public function onArticleWizard()
+    public function onInitializeSystem(): void
     {
     }
 
-    public function onInitializeSystem()
+    public function onGeneratePage(): void
     {
     }
 
-    public function onGeneratePage()
+    public function onInitializeSystemFirst(): void
     {
     }
 
-    public function onInitializeSystemFirst()
+    public function onInitializeSystemSecond(): void
     {
     }
 
-    public function onInitializeSystemSecond()
+    public function onParseTemplate(): void
     {
     }
 
-    public function onParseTemplate()
+    public function onInitializeSystemLow(): void
     {
     }
 
-    public function onInitializeSystemLow()
+    public function onInitializeSystemHigh(): void
     {
     }
 
-    public function onInitializeSystemHigh()
+    public function onInitializeSystemAfter(): void
     {
     }
 
-    public function onInitializeSystemAfter()
+    private function onPrivateCallback(): void
     {
     }
 }

--- a/core-bundle/tests/Fixtures/src/EventListener/TestListener.php
+++ b/core-bundle/tests/Fixtures/src/EventListener/TestListener.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Contao\CoreBundle\Fixtures\EventListener;
+
+
+class TestListener
+{
+    private function onPrivateCallback()
+    {
+    }
+
+    public function onLoadPage()
+    {
+    }
+
+    public function onLoadCallback()
+    {
+    }
+
+    public function onListitemsXlabel()
+    {
+    }
+
+    public function onFoobarCallback()
+    {
+    }
+
+    public function loadFirst()
+    {
+    }
+
+    public function loadSecond()
+    {
+    }
+
+    public function onSaveCallback()
+    {
+    }
+
+    public function onLabelCallback()
+    {
+    }
+
+    public function onLoadFirst()
+    {
+    }
+
+    public function onLoadSecond()
+    {
+    }
+
+    public function onArticleWizard()
+    {
+    }
+
+    public function onInitializeSystem()
+    {
+    }
+
+    public function onGeneratePage()
+    {
+    }
+
+    public function onInitializeSystemFirst()
+    {
+    }
+
+    public function onInitializeSystemSecond()
+    {
+    }
+
+    public function onParseTemplate()
+    {
+    }
+
+    public function onInitializeSystemLow()
+    {
+    }
+
+    public function onInitializeSystemHigh()
+    {
+    }
+
+    public function onInitializeSystemAfter()
+    {
+    }
+}


### PR DESCRIPTION
This implementation has three features:

1. You can now have a `__invoke` method on a tagged hook or DCA callback listener. For BC reasons, we still prefer the generated method name (hook `initializeSystem` will use method `onInitializedSystem` if it exists). But if that method does not exist, we'll try to use `__invoke`.

2. Thanks to support for `__invoke`, we can now also support the service annotations on the class

3. While implementing it, I also added full validation for the method during container build time, so the developer will get an error message *on build* instead of *at runtime*. 😎 