### PR TITLE
Fail the Codecov action if the upload failed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         if: github.event_name != 'schedule'
         steps:
             - name: Setup PHP
-              uses: shivammathur/setup-php@master
+              uses: shivammathur/setup-php@v1
               with:
                   php-version: 7.3
                   extension-csv: dom, fileinfo, filter, gd, hash, intl, json, mbstring, pcre, pdo, zlib
@@ -40,6 +40,7 @@ jobs:
               with:
                   token: ${{ secrets.CODECOV_TOKEN }}
                   file: ./clover.xml
+                  fail_ci_if_error: true
 
     coding-style:
         name: Coding Style
@@ -47,7 +48,7 @@ jobs:
         if: github.event_name == 'pull_request'
         steps:
             - name: Setup PHP
-              uses: shivammathur/setup-php@master
+              uses: shivammathur/setup-php@v1
               with:
                   php-version: 7.3
                   extension-csv: dom, fileinfo, filter, gd, hash, intl, json, mbstring, pcre, pdo, zlib
@@ -82,7 +83,7 @@ jobs:
                 php: [7.2, 7.3, 7.4]
         steps:
             - name: Setup PHP
-              uses: shivammathur/setup-php@master
+              uses: shivammathur/setup-php@v1
               with:
                   php-version: ${{ matrix.php }}
                   extension-csv: dom, fileinfo, filter, gd, hash, intl, json, mbstring, mysql, pcre, pdo, zlib
@@ -115,7 +116,7 @@ jobs:
         if: github.event_name != 'push'
         steps:
             - name: Setup PHP
-              uses: shivammathur/setup-php@master
+              uses: shivammathur/setup-php@v1
               with:
                   php-version: 7.3
                   extension-csv: dom, fileinfo, filter, gd, hash, intl, json, mbstring, mysql, pcre, pdo, zlib
@@ -148,7 +149,7 @@ jobs:
         if: github.event_name != 'push'
         steps:
             - name: Setup PHP
-              uses: shivammathur/setup-php@master
+              uses: shivammathur/setup-php@v1
               with:
                   php-version: 7.3
                   extension-csv: dom, fileinfo, filter, gd, hash, intl, json, mbstring, pcre, pdo, zlib
@@ -188,7 +189,7 @@ jobs:
         if: github.event_name != 'push'
         steps:
             - name: Setup PHP
-              uses: shivammathur/setup-php@master
+              uses: shivammathur/setup-php@v1
               with:
                   php-version: 7.3
                   extension-csv: dom, fileinfo, filter, gd, hash, intl, json, mbstring, mysql, pcre, pdo, zlib
@@ -216,7 +217,7 @@ jobs:
         if: github.event_name == 'push'
         steps:
             - name: Setup PHP
-              uses: shivammathur/setup-php@master
+              uses: shivammathur/setup-php@v1
               with:
                   php-version: 7.3
                   extension-csv: json, zlib


### PR DESCRIPTION
This does not yet fix the problem that the Codecov token is not available for third-party repos, but at least the build no longer completes successfully in this case.