### PR TITLE
Fix ArgumentCountError

### DIFF
--- a/core-bundle/src/Resources/contao/modules/ModulePersonalData.php
+++ b/core-bundle/src/Resources/contao/modules/ModulePersonalData.php
@@ -85,7 +85,7 @@ class ModulePersonalData extends Module
 				if (\is_array($callback))
 				{
 					$this->import($callback[0]);
-					$this->{$callback[0]}->{$callback[1]}();
+					$this->{$callback[0]}->{$callback[1]}(new DC_Table('tl_member'));
 				}
 				elseif (\is_callable($callback))
 				{

--- a/core-bundle/src/Resources/contao/modules/ModulePersonalData.php
+++ b/core-bundle/src/Resources/contao/modules/ModulePersonalData.php
@@ -89,7 +89,7 @@ class ModulePersonalData extends Module
 				}
 				elseif (\is_callable($callback))
 				{
-					$callback();
+					$callback(new DC_Table('tl_member'));
 				}
 			}
 		}


### PR DESCRIPTION
Make code compatible with backend and frontend (ModulePersonalData)
 if you have an `onload_callback` with `DataContainer` parameter in Backend you get an ArgumentCountError in Frontend.

see https://docs.contao.org/dev/reference/dca/callbacks/#config-onload