### PR TITLE
Add the GitHub issue templates

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,38 @@
+# Contributing to Contao
+
+The following is a set of guidelines for contributing to Contao and its
+packages, which are hosted in the [Contao organization][1] on GitHub. These
+are just guidelines, not rules, use your best judgement and feel free to
+propose changes to this document in a pull request.
+
+## Issues
+
+ * Use the search function to see if a similar issue has already been
+   submitted.
+ * Describe the issue in detail and include all the steps to follow in order to
+   reproduce the bug in the [online demo][2].
+ * Include the version of Contao and PHP you are using.
+ * Include screenshots if possible; they are immensely helpful.
+ * If you are reporting a bug, please include any related error message you are
+   seeing and also check the `var/logs/` directory for related log files.
+
+## Pull requests
+
+ * Follow the Contao coding standards.
+ * For new features, create your pull request against the `master` branch.
+ * For bug fixes, create your pull request against the lowest affected branch,
+   e.g. `4.4` if the bug is in Contao 4.4 or `4.7` if the bug is in Contao 4.7.
+ * Include screenshots in your pull request whenever possible.
+ * If you want to add a new feature, we recommend that you discuss your ideas
+   with us before your start writing code; either on GitHub or in one of our
+   [monthly calls][3].
+
+## Git commit messages
+
+ * Use the present tense ("Add feature" not "Added feature").
+ * Use the imperative mood ("Move cursor to …" not "Moves cursor to …").
+ * Reference issues and pull requests liberally.
+
+[1]: https://github.com/contao
+[2]: https://demo.contao.org/contao
+[3]: https://contao.org/en/mumble-calls.html

--- a/.github/ISSUE_TEMPLATE/1_Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/1_Bug_report.md
@@ -1,0 +1,10 @@
+---
+name: 🐞 Report a bug
+about: Report errors and problems
+---
+
+**Affected version(s)**
+
+**Description**
+
+**How to reproduce**

--- a/.github/ISSUE_TEMPLATE/2_Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/2_Feature_request.md
@@ -1,0 +1,8 @@
+---
+name: 🚀 Request a feature
+about: RFC and ideas for new features and improvements
+---
+
+**Description**
+
+**Example**

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,6 @@
+contact_links:
+    - name: Get support
+      url: https://contao.org/en/support.html
+      about: If you need help using Contao, pick a support option on contao.org
+
+blank_issues_enabled: false

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,43 @@
+# Security policy
+
+Security is a top priority for Contao. Please help us make the system more
+secure!
+
+## Reporting a security issue
+
+If you think that you have found a security issue in Contao, please write an
+e-mail to **security [at] contao.org**. E-mails sent to this address are
+forwarded to a private channel of the Contao core team.
+
+Never disclose any information about a vulnerability in the public web (blog
+posts, tweets, GitHub issues, etc.) before the vulnerability has been
+acknowledged and fixed in a new Contao release!
+
+## Resolving process
+
+For each report, we first try to confirm the vulnerability. When it is
+confirmed, the core team works on a solution following these steps:
+
+1. Send an acknowledgement to the reporter;
+2. Work on a patch;
+3. Get a CVE identifier from mitre.org;
+4. Publish a security announcement on contao.org;
+5. Send the patch to the reporter for review;
+6. Apply the patch to all maintained versions of Contao;
+7. Release new versions for all affected versions;
+8. Announce the new versions and the vulnerability on contao.org;
+9. Update the public [security advisories database][1].
+
+## Bug bounty
+
+The [Contao Association][2] rewards reporters of confirmed vulnerabilities with
+a security bounty of 100 Euros.
+
+## Security advisories
+
+Check the [security advisories database][3] for a list of all security
+vulnerabilities that were already found and fixed in Contao.
+
+[1]: https://github.com/FriendsOfPHP/security-advisories
+[2]: https://association.contao.org
+[3]: https://contao.org/en/security-advisories.html

--- a/core-bundle/.github/ISSUE_TEMPLATE/config.yml
+++ b/core-bundle/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,6 @@
+contact_links:
+    - name: Go to contao/contao
+      url: https://github.com/contao/contao
+      about: This is a read-only split repository; go to contao/contao instead
+
+blank_issues_enabled: false


### PR DESCRIPTION
These are the templates from contao/.github which we have to get rid of so the issue templates do not show up at the contao/docs repository.