### PR TITLE
Only check fragment registry if controller name is a string

### DIFF
--- a/core-bundle/src/HttpKernel/ControllerResolver.php
+++ b/core-bundle/src/HttpKernel/ControllerResolver.php
@@ -39,8 +39,10 @@ class ControllerResolver implements ControllerResolverInterface
      */
     public function getController(Request $request)
     {
-        if ($request->attributes->has('_controller')) {
-            $fragmentConfig = $this->registry->get($request->attributes->get('_controller'));
+        if ($request->attributes->has('_controller')
+            && \is_string($controller = $request->attributes->get('_controller'))
+        ) {
+            $fragmentConfig = $this->registry->get($controller);
 
             if (null !== $fragmentConfig) {
                 $request->attributes->set('_controller', $fragmentConfig->getController());

--- a/core-bundle/tests/HttpKernel/ControllerResolverTest.php
+++ b/core-bundle/tests/HttpKernel/ControllerResolverTest.php
@@ -17,6 +17,7 @@ use Contao\CoreBundle\Fragment\FragmentRegistry;
 use Contao\CoreBundle\HttpKernel\ControllerResolver;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Controller\ControllerReference;
 use Symfony\Component\HttpKernel\Controller\ControllerResolverInterface;
 use Symfony\Component\HttpKernel\Kernel;
 
@@ -72,5 +73,20 @@ class ControllerResolverTest extends TestCase
 
         $resolver = new ControllerResolver($decorated, new FragmentRegistry());
         $resolver->getArguments(new Request(), '');
+    }
+
+    public function testIgnoresControllersThatAreNotString()
+    {
+        $registry = $this->createMock(FragmentRegistry::class);
+        $registry
+            ->expects($this->never())
+            ->method('get')
+        ;
+
+        $request = new Request();
+        $request->attributes->set('_controller', new ControllerReference('foo'));
+
+        $resolver = new ControllerResolver($this->createMock(ControllerResolverInterface::class), $registry);
+        $resolver->getController($request);
     }
 }


### PR DESCRIPTION
fixes https://github.com/contao/contao/issues/1070