### PR TITLE
Fix the SERP preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
  * Support using `.env` and `.env.local.php` files (see #768).
  * Do not install the tests with "prefer-dist" (see #762).
  * Simplify registering custom fragment types (see #776).
- * Add a SERP preview wherever page meta data can be edited.
+ * Add a Google search results preview wherever page meta data can be edited.
  * Dynamically add the robots.txt and favicon.ico files per root page (see #717).
  * Moved folderUrl setting to the root page (see #706).
  * Do not generate request tokens via ESI if not needed (see #710).

--- a/calendar-bundle/src/Resources/contao/dca/tl_calendar_events.php
+++ b/calendar-bundle/src/Resources/contao/dca/tl_calendar_events.php
@@ -259,7 +259,7 @@ $GLOBALS['TL_DCA']['tl_calendar_events'] = array
 			'label'                   => &$GLOBALS['TL_LANG']['MSC']['serpPreview'],
 			'exclude'                 => true,
 			'inputType'               => 'serpPreview',
-			'eval'                    => array('serpPreview'=>array('url'=>array('tl_calendar_events', 'getSerpUrl'), 'title'=>array('pageTitle', 'title'), 'description'=>array('description', 'teaser'))),
+			'eval'                    => array('serpUrl'=>array('tl_calendar_events', 'getSerpUrl'), 'serpTitle'=>array('pageTitle', 'title'), 'serpDescription'=>array('description', 'teaser')),
 			'sql'                     => null
 		),
 		'location' => array

--- a/calendar-bundle/src/Resources/contao/dca/tl_calendar_events.php
+++ b/calendar-bundle/src/Resources/contao/dca/tl_calendar_events.php
@@ -259,7 +259,18 @@ $GLOBALS['TL_DCA']['tl_calendar_events'] = array
 			'label'                   => &$GLOBALS['TL_LANG']['MSC']['serpPreview'],
 			'exclude'                 => true,
 			'inputType'               => 'serpPreview',
-			'eval'                    => array('serpPreview'=>array('title'=>array('pageTitle', 'title'), 'description'=>array('description', 'teaser'))),
+			'eval'                    => array
+			(
+				'serpPreview' => array
+				(
+					'url' => static function (Contao\CalendarEventsModel $model)
+					{
+						return Contao\Events::generateEventUrl($model, true);
+					},
+					'title' => array('pageTitle', 'title'),
+					'description' => array('description', 'teaser')
+				)
+			),
 			'sql'                     => null
 		),
 		'location' => array

--- a/calendar-bundle/src/Resources/contao/dca/tl_calendar_events.php
+++ b/calendar-bundle/src/Resources/contao/dca/tl_calendar_events.php
@@ -259,7 +259,7 @@ $GLOBALS['TL_DCA']['tl_calendar_events'] = array
 			'label'                   => &$GLOBALS['TL_LANG']['MSC']['serpPreview'],
 			'exclude'                 => true,
 			'inputType'               => 'serpPreview',
-			'eval'                    => array('serpUrl'=>array('tl_calendar_events', 'getSerpUrl'), 'serpTitle'=>array('pageTitle', 'title'), 'serpDescription'=>array('description', 'teaser')),
+			'eval'                    => array('url_callback'=>array('tl_calendar_events', 'getSerpUrl'), 'titleFields'=>array('pageTitle', 'title'), 'descriptionFields'=>array('description', 'teaser')),
 			'sql'                     => null
 		),
 		'location' => array

--- a/calendar-bundle/src/Resources/contao/dca/tl_calendar_events.php
+++ b/calendar-bundle/src/Resources/contao/dca/tl_calendar_events.php
@@ -259,18 +259,7 @@ $GLOBALS['TL_DCA']['tl_calendar_events'] = array
 			'label'                   => &$GLOBALS['TL_LANG']['MSC']['serpPreview'],
 			'exclude'                 => true,
 			'inputType'               => 'serpPreview',
-			'eval'                    => array
-			(
-				'serpPreview' => array
-				(
-					'url' => static function (Contao\CalendarEventsModel $model)
-					{
-						return Contao\Events::generateEventUrl($model, true);
-					},
-					'title' => array('pageTitle', 'title'),
-					'description' => array('description', 'teaser')
-				)
-			),
+			'eval'                    => array('serpPreview'=>array('url'=>array('tl_calendar_events', 'getSerpUrl'), 'title'=>array('pageTitle', 'title'), 'description'=>array('description', 'teaser'))),
 			'sql'                     => null
 		),
 		'location' => array
@@ -746,6 +735,18 @@ class tl_calendar_events extends Contao\Backend
 		}
 
 		return $varValue;
+	}
+
+	/**
+	 * Return the SERP URL
+	 *
+	 * @param Contao\CalendarEventsModel $model
+	 *
+	 * @return string
+	 */
+	public function getSerpUrl(Contao\CalendarEventsModel $model)
+	{
+		return Contao\Events::generateEventUrl($model, true);
 	}
 
 	/**

--- a/core-bundle/src/Resources/contao/dca/tl_page.php
+++ b/core-bundle/src/Resources/contao/dca/tl_page.php
@@ -269,7 +269,17 @@ $GLOBALS['TL_DCA']['tl_page'] = array
 			'label'                   => &$GLOBALS['TL_LANG']['MSC']['serpPreview'],
 			'exclude'                 => true,
 			'inputType'               => 'serpPreview',
-			'eval'                    => array('serpPreview'=>array('title'=>array('pageTitle', 'title'))),
+			'eval'                    => array
+			(
+				'serpPreview' => array
+				(
+					'url' => static function (Contao\PageModel $model)
+					{
+						return $model->getAbsoluteUrl();
+					},
+					'title' => array('pageTitle', 'title'),
+				)
+			),
 			'sql'                     => null
 		),
 		'redirect' => array

--- a/core-bundle/src/Resources/contao/dca/tl_page.php
+++ b/core-bundle/src/Resources/contao/dca/tl_page.php
@@ -269,7 +269,7 @@ $GLOBALS['TL_DCA']['tl_page'] = array
 			'label'                   => &$GLOBALS['TL_LANG']['MSC']['serpPreview'],
 			'exclude'                 => true,
 			'inputType'               => 'serpPreview',
-			'eval'                    => array('serpPreview'=>array('url'=>array('tl_page', 'getSerpUrl'), 'title'=>array('pageTitle', 'title'))),
+			'eval'                    => array('serpUrl'=>array('tl_page', 'getSerpUrl'), 'serpTitle'=>array('pageTitle', 'title')),
 			'sql'                     => null
 		),
 		'redirect' => array

--- a/core-bundle/src/Resources/contao/dca/tl_page.php
+++ b/core-bundle/src/Resources/contao/dca/tl_page.php
@@ -269,7 +269,7 @@ $GLOBALS['TL_DCA']['tl_page'] = array
 			'label'                   => &$GLOBALS['TL_LANG']['MSC']['serpPreview'],
 			'exclude'                 => true,
 			'inputType'               => 'serpPreview',
-			'eval'                    => array('serpUrl'=>array('tl_page', 'getSerpUrl'), 'serpTitle'=>array('pageTitle', 'title')),
+			'eval'                    => array('url_callback'=>array('tl_page', 'getSerpUrl'), 'titleFields'=>array('pageTitle', 'title')),
 			'sql'                     => null
 		),
 		'redirect' => array

--- a/core-bundle/src/Resources/contao/dca/tl_page.php
+++ b/core-bundle/src/Resources/contao/dca/tl_page.php
@@ -269,17 +269,7 @@ $GLOBALS['TL_DCA']['tl_page'] = array
 			'label'                   => &$GLOBALS['TL_LANG']['MSC']['serpPreview'],
 			'exclude'                 => true,
 			'inputType'               => 'serpPreview',
-			'eval'                    => array
-			(
-				'serpPreview' => array
-				(
-					'url' => static function (Contao\PageModel $model)
-					{
-						return $model->getAbsoluteUrl();
-					},
-					'title' => array('pageTitle', 'title'),
-				)
-			),
+			'eval'                    => array('serpPreview'=>array('url'=>array('tl_page', 'getSerpUrl'), 'title'=>array('pageTitle', 'title'))),
 			'sql'                     => null
 		),
 		'redirect' => array
@@ -997,6 +987,18 @@ class tl_page extends Contao\Backend
 		}
 
 		return $varValue;
+	}
+
+	/**
+	 * Return the SERP URL
+	 *
+	 * @param Contao\PageModel $model
+	 *
+	 * @return string
+	 */
+	public function getSerpUrl(Contao\PageModel $model)
+	{
+		return $model->getAbsoluteUrl();
 	}
 
 	/**

--- a/core-bundle/src/Resources/contao/languages/en/default.xlf
+++ b/core-bundle/src/Resources/contao/languages/en/default.xlf
@@ -1848,10 +1848,10 @@
         <source>The internal CSS editor has been deprecated and will be removed in one of the next Contao versions! Please consider exporting your existing style sheets and re-adding them to the page layout as external style sheets.</source>
       </trans-unit>
       <trans-unit id="MSC.serpPreview.0">
-        <source>SERP preview</source>
+        <source>Google search results preview</source>
       </trans-unit>
       <trans-unit id="MSC.serpPreview.1">
-        <source>Here you can preview the meta data in the search results. Some search engines might show longer texts or crop at a different position.</source>
+        <source>Here you can preview the meta data in the Google search results. Other search engines might show longer texts or crop at a different position.</source>
       </trans-unit>
       <trans-unit id="UNITS.0">
         <source>Byte</source>

--- a/core-bundle/src/Resources/contao/widgets/SerpPreview.php
+++ b/core-bundle/src/Resources/contao/widgets/SerpPreview.php
@@ -11,11 +11,10 @@
 namespace Contao;
 
 /**
- * @property string          $serpClass
- * @property string|array    $serpTitle
- * @property string|array    $serpDescription
- * @property string|callable $serpUrl
- * @property string|array    $serpAlias
+ * @property array    $titleFields
+ * @property array    $descriptionFields
+ * @property string   $aliasField
+ * @property callable $url_callback
  */
 class SerpPreview extends Widget
 {
@@ -30,7 +29,7 @@ class SerpPreview extends Widget
 	public function generate()
 	{
 		/** @var Model $class */
-		$class = $this->serpClass ?? Model::getClassFromTable($this->strTable);
+		$class = Model::getClassFromTable($this->strTable);
 		$model = $class::findByPk($this->activeRecord->id);
 
 		if (!$model instanceof Model)
@@ -41,11 +40,21 @@ class SerpPreview extends Widget
 		$id = $model->id;
 		$title = StringUtil::substr($this->getTitle($model), 64);
 		$description = StringUtil::substr($this->getDescription($model), 160);
+		$alias = $this->getAlias($model);
 
 		// Get the URL with a %s placeholder for the alias or ID
 		$url = $this->getUrl($model);
 		list($baseUrl, $urlSuffix) = explode('%s', $url);
-		$url = $model->alias == 'index' ? $baseUrl : sprintf($url, $model->alias ?: $model->id);
+
+		// Use the base URL for the index page
+		if ($model instanceof PageModel && $alias == 'index')
+		{
+			$url = $baseUrl;
+		}
+		else
+		{
+			$url = sprintf($url, $alias ?: $model->id);
+		}
 
 		// Get the input field suffix (edit multiple mode)
 		$suffix = substr($this->objDca->inputName, \strlen($this->objDca->field));
@@ -81,32 +90,32 @@ EOT;
 
 	private function getTitle(Model $model)
 	{
-		if (!isset($this->serpTitle))
+		if (!isset($this->titleFields))
 		{
 			return $model->title;
 		}
 
-		if (\is_array($this->serpTitle))
-		{
-			return $model->{$this->serpTitle[0]} ?: $model->{$this->serpTitle[1]};
-		}
-
-		return $model->{$this->serpTitle};
+		return $model->{$this->titleFields[0]} ?: $model->{$this->titleFields[1]};
 	}
 
 	private function getDescription(Model $model)
 	{
-		if (!isset($this->serpDescription))
+		if (!isset($this->descriptionFields))
 		{
 			return $model->description;
 		}
 
-		if (\is_array($this->serpDescription))
+		return $model->{$this->descriptionFields[0]} ?: $model->{$this->descriptionFields[1]};
+	}
+
+	private function getAlias(Model $model)
+	{
+		if (!isset($this->aliasField))
 		{
-			return $model->{$this->serpDescription[0]} ?: $model->{$this->serpDescription[1]};
+			return $model->alias;
 		}
 
-		return $model->{$this->serpDescription};
+		return $model->{$this->aliasField};
 	}
 
 	/**
@@ -114,14 +123,9 @@ EOT;
 	 */
 	private function getUrl(Model $model)
 	{
-		if (!isset($this->serpUrl))
+		if (!isset($this->url_callback))
 		{
-			throw new \Exception('No SERP widget URL given');
-		}
-
-		if (\is_string($this->serpUrl))
-		{
-			return $this->serpUrl;
+			throw new \LogicException('No url_callback given');
 		}
 
 		$placeholder = bin2hex(random_bytes(10));
@@ -132,18 +136,18 @@ EOT;
 		$tempModel->alias = $placeholder;
 		$tempModel->preventSaving(false);
 
-		if (\is_array($this->serpUrl))
+		if (\is_array($this->url_callback))
 		{
-			$this->import($this->serpUrl[0]);
-			$url = $this->{$this->serpUrl[0]}->{$this->serpUrl[1]}($tempModel);
+			$this->import($this->url_callback[0]);
+			$url = $this->{$this->url_callback[0]}->{$this->url_callback[1]}($tempModel);
 		}
-		elseif (\is_callable($this->serpUrl))
+		elseif (\is_callable($this->url_callback))
 		{
-			$url = \call_user_func($this->serpUrl, $tempModel);
+			$url = \call_user_func($this->url_callback, $tempModel);
 		}
 		else
 		{
-			throw new \Exception('Please provide the SERP widget URL as string or callable');
+			throw new \LogicException('Please provide the url_callback as callable');
 		}
 
 		return str_replace($placeholder, '%s', $url);
@@ -151,61 +155,51 @@ EOT;
 
 	private function getTitleField($suffix)
 	{
-		if (!isset($this->serpTitle))
+		if (!isset($this->titleFields))
 		{
 			return 'ctrl_title' . $suffix;
 		}
 
-		if (\is_array($this->serpTitle))
-		{
-			return 'ctrl_' . $this->serpTitle[0] . $suffix;
-		}
-
-		return 'ctrl_' . $this->serpTitle . $suffix;
+		return 'ctrl_' . $this->titleFields[0] . $suffix;
 	}
 
 	private function getTitleFallbackField($suffix)
 	{
-		if (!isset($this->serpTitle) || !\is_array($this->serpTitle))
+		if (!isset($this->titleFields))
 		{
 			return '';
 		}
 
-		return 'ctrl_' . $this->serpTitle[1] . $suffix;
-	}
-
-	private function getAliasField($suffix)
-	{
-		if (!isset($this->serpAlias))
-		{
-			return 'ctrl_alias' . $suffix;
-		}
-
-		return 'ctrl_' . $this->serpAlias . $suffix;
+		return 'ctrl_' . $this->titleFields[1] . $suffix;
 	}
 
 	private function getDescriptionField($suffix)
 	{
-		if (!isset($this->serpDescription))
+		if (!isset($this->descriptionFields))
 		{
 			return 'ctrl_description' . $suffix;
 		}
 
-		if (\is_array($this->serpDescription))
-		{
-			return 'ctrl_' . $this->serpDescription[0] . $suffix;
-		}
-
-		return 'ctrl_' . $this->serpDescription . $suffix;
+		return 'ctrl_' . $this->descriptionFields[0] . $suffix;
 	}
 
 	private function getDescriptionFallbackField($suffix)
 	{
-		if (!isset($this->serpDescription) || !\is_array($this->serpDescription))
+		if (!isset($this->descriptionFields))
 		{
 			return '';
 		}
 
-		return 'ctrl_' . $this->serpDescription[1] . $suffix;
+		return 'ctrl_' . $this->descriptionFields[1] . $suffix;
+	}
+
+	private function getAliasField($suffix)
+	{
+		if (!isset($this->aliasField))
+		{
+			return 'ctrl_alias' . $suffix;
+		}
+
+		return 'ctrl_' . $this->aliasField . $suffix;
 	}
 }

--- a/core-bundle/src/Resources/contao/widgets/SerpPreview.php
+++ b/core-bundle/src/Resources/contao/widgets/SerpPreview.php
@@ -40,7 +40,7 @@ class SerpPreview extends Widget
 
 		// Get the URL with a %s placeholder for the alias or ID
 		$url = $this->getUrl($model);
-		list($baseUrl) = explode('%s', $url);
+		list($baseUrl, $urlSuffix) = explode('%s', $url);
 		$url = sprintf($url, $model->alias ?: $model->id);
 
 		// Get the input field suffix (edit multiple mode)
@@ -51,7 +51,6 @@ class SerpPreview extends Widget
 		$aliasField = $this->getAliasField($suffix);
 		$descriptionField = $this->getDescriptionField($suffix);
 		$descriptionFallbackField = $this->getDescriptionFallbackField($suffix);
-		$urlSuffix = System::getContainer()->getParameter('contao.url_suffix');
 
 		return <<<EOT
 <div class="serp-preview">

--- a/core-bundle/src/Resources/contao/widgets/SerpPreview.php
+++ b/core-bundle/src/Resources/contao/widgets/SerpPreview.php
@@ -11,7 +11,11 @@
 namespace Contao;
 
 /**
- * @property array $serpPreview
+ * @property string          $serpClass
+ * @property string|array    $serpTitle
+ * @property string|array    $serpDescription
+ * @property string|callable $serpUrl
+ * @property string|array    $serpAlias
  */
 class SerpPreview extends Widget
 {
@@ -26,7 +30,7 @@ class SerpPreview extends Widget
 	public function generate()
 	{
 		/** @var Model $class */
-		$class = $this->serpPreview['class'] ?? Model::getClassFromTable($this->strTable);
+		$class = $this->serpClass ?? Model::getClassFromTable($this->strTable);
 		$model = $class::findByPk($this->activeRecord->id);
 
 		if (!$model instanceof Model)
@@ -77,32 +81,32 @@ EOT;
 
 	private function getTitle(Model $model)
 	{
-		if (!isset($this->serpPreview['title']))
+		if (!isset($this->serpTitle))
 		{
 			return $model->title;
 		}
 
-		if (\is_array($this->serpPreview['title']))
+		if (\is_array($this->serpTitle))
 		{
-			return $model->{$this->serpPreview['title'][0]} ?: $model->{$this->serpPreview['title'][1]};
+			return $model->{$this->serpTitle[0]} ?: $model->{$this->serpTitle[1]};
 		}
 
-		return $model->{$this->serpPreview['title']};
+		return $model->{$this->serpTitle};
 	}
 
 	private function getDescription(Model $model)
 	{
-		if (!isset($this->serpPreview['description']))
+		if (!isset($this->serpDescription))
 		{
 			return $model->description;
 		}
 
-		if (\is_array($this->serpPreview['description']))
+		if (\is_array($this->serpDescription))
 		{
-			return $model->{$this->serpPreview['description'][0]} ?: $model->{$this->serpPreview['description'][1]};
+			return $model->{$this->serpDescription[0]} ?: $model->{$this->serpDescription[1]};
 		}
 
-		return $model->{$this->serpPreview['description']};
+		return $model->{$this->serpDescription};
 	}
 
 	/**
@@ -110,14 +114,14 @@ EOT;
 	 */
 	private function getUrl(Model $model)
 	{
-		if (!isset($this->serpPreview['url']))
+		if (!isset($this->serpUrl))
 		{
 			throw new \Exception('No SERP widget URL given');
 		}
 
-		if (\is_string($this->serpPreview['url']))
+		if (\is_string($this->serpUrl))
 		{
-			return $this->serpPreview['url'];
+			return $this->serpUrl;
 		}
 
 		$placeholder = bin2hex(random_bytes(10));
@@ -128,14 +132,14 @@ EOT;
 		$tempModel->alias = $placeholder;
 		$tempModel->preventSaving(false);
 
-		if (\is_array($this->serpPreview['url']))
+		if (\is_array($this->serpUrl))
 		{
-			$this->import($this->serpPreview['url'][0]);
-			$url = $this->{$this->serpPreview['url'][0]}->{$this->serpPreview['url'][1]}($tempModel);
+			$this->import($this->serpUrl[0]);
+			$url = $this->{$this->serpUrl[0]}->{$this->serpUrl[1]}($tempModel);
 		}
-		elseif (\is_callable($this->serpPreview['url']))
+		elseif (\is_callable($this->serpUrl))
 		{
-			$url = $this->serpPreview['url']($tempModel);
+			$url = \call_user_func($this->serpUrl, $tempModel);
 		}
 		else
 		{
@@ -147,61 +151,61 @@ EOT;
 
 	private function getTitleField($suffix)
 	{
-		if (!isset($this->serpPreview['title']))
+		if (!isset($this->serpTitle))
 		{
 			return 'ctrl_title' . $suffix;
 		}
 
-		if (\is_array($this->serpPreview['title']))
+		if (\is_array($this->serpTitle))
 		{
-			return 'ctrl_' . $this->serpPreview['title'][0] . $suffix;
+			return 'ctrl_' . $this->serpTitle[0] . $suffix;
 		}
 
-		return 'ctrl_' . $this->serpPreview['title'] . $suffix;
+		return 'ctrl_' . $this->serpTitle . $suffix;
 	}
 
 	private function getTitleFallbackField($suffix)
 	{
-		if (!isset($this->serpPreview['title']) || !\is_array($this->serpPreview['title']))
+		if (!isset($this->serpTitle) || !\is_array($this->serpTitle))
 		{
 			return '';
 		}
 
-		return 'ctrl_' . $this->serpPreview['title'][1] . $suffix;
+		return 'ctrl_' . $this->serpTitle[1] . $suffix;
 	}
 
 	private function getAliasField($suffix)
 	{
-		if (!isset($this->serpPreview['alias']))
+		if (!isset($this->serpAlias))
 		{
 			return 'ctrl_alias' . $suffix;
 		}
 
-		return 'ctrl_' . $this->serpPreview['alias'] . $suffix;
+		return 'ctrl_' . $this->serpAlias . $suffix;
 	}
 
 	private function getDescriptionField($suffix)
 	{
-		if (!isset($this->serpPreview['description']))
+		if (!isset($this->serpDescription))
 		{
 			return 'ctrl_description' . $suffix;
 		}
 
-		if (\is_array($this->serpPreview['description']))
+		if (\is_array($this->serpDescription))
 		{
-			return 'ctrl_' . $this->serpPreview['description'][0] . $suffix;
+			return 'ctrl_' . $this->serpDescription[0] . $suffix;
 		}
 
-		return 'ctrl_' . $this->serpPreview['description'] . $suffix;
+		return 'ctrl_' . $this->serpDescription . $suffix;
 	}
 
 	private function getDescriptionFallbackField($suffix)
 	{
-		if (!isset($this->serpPreview['description']) || !\is_array($this->serpPreview['description']))
+		if (!isset($this->serpDescription) || !\is_array($this->serpDescription))
 		{
 			return '';
 		}
 
-		return 'ctrl_' . $this->serpPreview['description'][1] . $suffix;
+		return 'ctrl_' . $this->serpDescription[1] . $suffix;
 	}
 }

--- a/core-bundle/src/Resources/contao/widgets/SerpPreview.php
+++ b/core-bundle/src/Resources/contao/widgets/SerpPreview.php
@@ -128,12 +128,13 @@ EOT;
 			throw new \LogicException('No url_callback given');
 		}
 
+		$alias = $this->getAlias($model);
 		$placeholder = bin2hex(random_bytes(10));
 
 		// Pass a detached clone with the alias set to the placeholder
 		$tempModel = clone $model;
-		$tempModel->origAlias = $tempModel->alias;
-		$tempModel->alias = $placeholder;
+		$tempModel->origAlias = $tempModel->$alias;
+		$tempModel->$alias = $placeholder;
 		$tempModel->preventSaving(false);
 
 		if (\is_array($this->url_callback))
@@ -155,7 +156,7 @@ EOT;
 
 	private function getTitleField($suffix)
 	{
-		if (!isset($this->titleFields))
+		if (!isset($this->titleFields[0]))
 		{
 			return 'ctrl_title' . $suffix;
 		}
@@ -165,7 +166,7 @@ EOT;
 
 	private function getTitleFallbackField($suffix)
 	{
-		if (!isset($this->titleFields))
+		if (!isset($this->titleFields[1]))
 		{
 			return '';
 		}
@@ -175,7 +176,7 @@ EOT;
 
 	private function getDescriptionField($suffix)
 	{
-		if (!isset($this->descriptionFields))
+		if (!isset($this->descriptionFields[0]))
 		{
 			return 'ctrl_description' . $suffix;
 		}
@@ -185,7 +186,7 @@ EOT;
 
 	private function getDescriptionFallbackField($suffix)
 	{
-		if (!isset($this->descriptionFields))
+		if (!isset($this->descriptionFields[1]))
 		{
 			return '';
 		}

--- a/core-bundle/src/Resources/contao/widgets/SerpPreview.php
+++ b/core-bundle/src/Resources/contao/widgets/SerpPreview.php
@@ -139,8 +139,7 @@ EOT;
 
 		if (\is_array($this->url_callback))
 		{
-			$this->import($this->url_callback[0]);
-			$url = $this->{$this->url_callback[0]}->{$this->url_callback[1]}($tempModel);
+			$url = System::importStatic($this->url_callback[0])->{$this->url_callback[1]}($tempModel);
 		}
 		elseif (\is_callable($this->url_callback))
 		{

--- a/news-bundle/src/Resources/contao/dca/tl_news.php
+++ b/news-bundle/src/Resources/contao/dca/tl_news.php
@@ -239,7 +239,7 @@ $GLOBALS['TL_DCA']['tl_news'] = array
 			'label'                   => &$GLOBALS['TL_LANG']['MSC']['serpPreview'],
 			'exclude'                 => true,
 			'inputType'               => 'serpPreview',
-			'eval'                    => array('serpUrl'=>array('tl_news', 'getSerpUrl'), 'serpTitle'=>array('pageTitle', 'headline'), 'serpDescription'=>array('description', 'teaser')),
+			'eval'                    => array('url_callback'=>array('tl_news', 'getSerpUrl'), 'titleFields'=>array('pageTitle', 'headline'), 'descriptionFields'=>array('description', 'teaser')),
 			'sql'                     => null
 		),
 		'subheadline' => array

--- a/news-bundle/src/Resources/contao/dca/tl_news.php
+++ b/news-bundle/src/Resources/contao/dca/tl_news.php
@@ -239,7 +239,7 @@ $GLOBALS['TL_DCA']['tl_news'] = array
 			'label'                   => &$GLOBALS['TL_LANG']['MSC']['serpPreview'],
 			'exclude'                 => true,
 			'inputType'               => 'serpPreview',
-			'eval'                    => array('serpPreview'=>array('url'=>array('tl_news', 'getSerpUrl'), 'title'=>array('pageTitle', 'headline'), 'description'=>array('description', 'teaser'))),
+			'eval'                    => array('serpUrl'=>array('tl_news', 'getSerpUrl'), 'serpTitle'=>array('pageTitle', 'headline'), 'serpDescription'=>array('description', 'teaser')),
 			'sql'                     => null
 		),
 		'subheadline' => array

--- a/news-bundle/src/Resources/contao/dca/tl_news.php
+++ b/news-bundle/src/Resources/contao/dca/tl_news.php
@@ -239,7 +239,18 @@ $GLOBALS['TL_DCA']['tl_news'] = array
 			'label'                   => &$GLOBALS['TL_LANG']['MSC']['serpPreview'],
 			'exclude'                 => true,
 			'inputType'               => 'serpPreview',
-			'eval'                    => array('serpPreview'=>array('title'=>array('pageTitle', 'headline'), 'description'=>array('description', 'teaser'))),
+			'eval'                    => array
+			(
+				'serpPreview' => array
+				(
+					'url' => static function (Contao\NewsModel $model)
+					{
+						return Contao\News::generateNewsUrl($model, false, true);
+					},
+					'title' => array('pageTitle', 'headline'),
+					'description' => array('description', 'teaser')
+				)
+			),
 			'sql'                     => null
 		),
 		'subheadline' => array

--- a/news-bundle/src/Resources/contao/dca/tl_news.php
+++ b/news-bundle/src/Resources/contao/dca/tl_news.php
@@ -239,18 +239,7 @@ $GLOBALS['TL_DCA']['tl_news'] = array
 			'label'                   => &$GLOBALS['TL_LANG']['MSC']['serpPreview'],
 			'exclude'                 => true,
 			'inputType'               => 'serpPreview',
-			'eval'                    => array
-			(
-				'serpPreview' => array
-				(
-					'url' => static function (Contao\NewsModel $model)
-					{
-						return Contao\News::generateNewsUrl($model, false, true);
-					},
-					'title' => array('pageTitle', 'headline'),
-					'description' => array('description', 'teaser')
-				)
-			),
+			'eval'                    => array('serpPreview'=>array('url'=>array('tl_news', 'getSerpUrl'), 'title'=>array('pageTitle', 'headline'), 'description'=>array('description', 'teaser'))),
 			'sql'                     => null
 		),
 		'subheadline' => array
@@ -684,6 +673,18 @@ class tl_news extends Contao\Backend
 	public function loadTime($value)
 	{
 		return strtotime('1970-01-01 ' . date('H:i:s', $value));
+	}
+
+	/**
+	 * Return the SERP URL
+	 *
+	 * @param Contao\NewsModel $model
+	 *
+	 * @return string
+	 */
+	public function getSerpUrl(Contao\NewsModel $model)
+	{
+		return Contao\News::generateNewsUrl($model, false, true);
 	}
 
 	/**


### PR DESCRIPTION
Since #831 has not made it into Contao 4.9, we need a different solution to retrieve the URL from the model. This PR does the following:

* Support callables as URL (`'serpPreview' => array('url' => function () {})`)
* Only add the input field suffix if the field name is not empty
