### PR TITLE
Do not use array_insert to inject modules and menu items

### DIFF
--- a/calendar-bundle/src/Resources/contao/config/config.php
+++ b/calendar-bundle/src/Resources/contao/config/config.php
@@ -9,27 +9,21 @@
  */
 
 // Back end modules
-array_insert($GLOBALS['BE_MOD']['content'], 1, array
+$GLOBALS['BE_MOD']['content']['calendar'] = array
 (
-	'calendar' => array
-	(
-		'tables'      => array('tl_calendar', 'tl_calendar_events', 'tl_calendar_feed', 'tl_content'),
-		'table'       => array('Contao\TableWizard', 'importTable'),
-		'list'        => array('Contao\ListWizard', 'importList')
-	)
-));
+	'tables'      => array('tl_calendar', 'tl_calendar_events', 'tl_calendar_feed', 'tl_content'),
+	'table'       => array('Contao\TableWizard', 'importTable'),
+	'list'        => array('Contao\ListWizard', 'importList')
+);
 
 // Front end modules
-array_insert($GLOBALS['FE_MOD'], 2, array
+$GLOBALS['FE_MOD']['events'] = array
 (
-	'events' => array
-	(
-		'calendar'    => 'Contao\ModuleCalendar',
-		'eventreader' => 'Contao\ModuleEventReader',
-		'eventlist'   => 'Contao\ModuleEventlist',
-		'eventmenu'   => 'Contao\ModuleEventMenu'
-	)
-));
+	'calendar'    => 'Contao\ModuleCalendar',
+	'eventreader' => 'Contao\ModuleEventReader',
+	'eventlist'   => 'Contao\ModuleEventlist',
+	'eventmenu'   => 'Contao\ModuleEventMenu'
+);
 
 // Cron jobs
 $GLOBALS['TL_CRON']['daily']['generateCalendarFeeds'] = array('Contao\Calendar', 'generateFeeds');

--- a/comments-bundle/src/Resources/contao/config/config.php
+++ b/comments-bundle/src/Resources/contao/config/config.php
@@ -15,14 +15,11 @@ $GLOBALS['TL_CTE']['includes']['comments'] = 'Contao\ContentComments';
 $GLOBALS['FE_MOD']['application']['comments'] = 'Contao\ModuleComments';
 
 // Back end modules
-array_insert($GLOBALS['BE_MOD']['content'], 5, array
+$GLOBALS['BE_MOD']['content']['comments'] = array
 (
-	'comments' => array
-	(
-		'tables'     => array('tl_comments'),
-		'stylesheet' => 'bundles/contaocomments/comments.min.css'
-	)
-));
+	'tables'     => array('tl_comments'),
+	'stylesheet' => 'bundles/contaocomments/comments.min.css'
+);
 
 // Cron jobs
 $GLOBALS['TL_CRON']['daily']['purgeCommentSubscriptions'] = array('Contao\Comments', 'purgeSubscriptions');

--- a/faq-bundle/src/Resources/contao/config/config.php
+++ b/faq-bundle/src/Resources/contao/config/config.php
@@ -9,24 +9,18 @@
  */
 
 // Add back end modules
-array_insert($GLOBALS['BE_MOD']['content'], 2, array
+$GLOBALS['BE_MOD']['content']['faq'] = array
 (
-	'faq' => array
-	(
-		'tables' => array('tl_faq_category', 'tl_faq')
-	)
-));
+	'tables' => array('tl_faq_category', 'tl_faq')
+);
 
 // Front end modules
-array_insert($GLOBALS['FE_MOD'], 3, array
+$GLOBALS['FE_MOD']['faq'] = array
 (
-	'faq' => array
-	(
-		'faqlist'   => 'Contao\ModuleFaqList',
-		'faqreader' => 'Contao\ModuleFaqReader',
-		'faqpage'   => 'Contao\ModuleFaqPage'
-	)
-));
+	'faqlist'   => 'Contao\ModuleFaqList',
+	'faqreader' => 'Contao\ModuleFaqReader',
+	'faqpage'   => 'Contao\ModuleFaqPage'
+);
 
 // Style sheet
 if (defined('TL_MODE') && TL_MODE == 'BE')

--- a/news-bundle/src/Resources/contao/config/config.php
+++ b/news-bundle/src/Resources/contao/config/config.php
@@ -9,27 +9,21 @@
  */
 
 // Back end modules
-array_insert($GLOBALS['BE_MOD']['content'], 1, array
+$GLOBALS['BE_MOD']['content']['news'] = array
 (
-	'news' => array
-	(
-		'tables'      => array('tl_news_archive', 'tl_news', 'tl_news_feed', 'tl_content'),
-		'table'       => array('Contao\TableWizard', 'importTable'),
-		'list'        => array('Contao\ListWizard', 'importList')
-	)
-));
+	'tables'      => array('tl_news_archive', 'tl_news', 'tl_news_feed', 'tl_content'),
+	'table'       => array('Contao\TableWizard', 'importTable'),
+	'list'        => array('Contao\ListWizard', 'importList')
+);
 
 // Front end modules
-array_insert($GLOBALS['FE_MOD'], 2, array
+$GLOBALS['FE_MOD']['news'] = array
 (
-	'news' => array
-	(
-		'newslist'    => 'Contao\ModuleNewsList',
-		'newsreader'  => 'Contao\ModuleNewsReader',
-		'newsarchive' => 'Contao\ModuleNewsArchive',
-		'newsmenu'    => 'Contao\ModuleNewsMenu'
-	)
-));
+	'newslist'    => 'Contao\ModuleNewsList',
+	'newsreader'  => 'Contao\ModuleNewsReader',
+	'newsarchive' => 'Contao\ModuleNewsArchive',
+	'newsmenu'    => 'Contao\ModuleNewsMenu'
+);
 
 // Cron jobs
 $GLOBALS['TL_CRON']['daily']['generateNewsFeeds'] = array('Contao\News', 'generateFeeds');

--- a/newsletter-bundle/src/Resources/contao/config/config.php
+++ b/newsletter-bundle/src/Resources/contao/config/config.php
@@ -9,28 +9,22 @@
  */
 
 // Back end modules
-array_insert($GLOBALS['BE_MOD']['content'], 4, array
+$GLOBALS['BE_MOD']['content']['newsletter'] = array
 (
-	'newsletter' => array
-	(
-		'tables'     => array('tl_newsletter_channel', 'tl_newsletter', 'tl_newsletter_recipients'),
-		'send'       => array('Contao\Newsletter', 'send'),
-		'import'     => array('Contao\Newsletter', 'importRecipients'),
-		'stylesheet' => 'bundles/contaonewsletter/newsletter.min.css'
-	)
-));
+	'tables'     => array('tl_newsletter_channel', 'tl_newsletter', 'tl_newsletter_recipients'),
+	'send'       => array('Contao\Newsletter', 'send'),
+	'import'     => array('Contao\Newsletter', 'importRecipients'),
+	'stylesheet' => 'bundles/contaonewsletter/newsletter.min.css'
+);
 
 // Front end modules
-array_insert($GLOBALS['FE_MOD'], 4, array
+$GLOBALS['FE_MOD']['newsletter'] = array
 (
-	'newsletter' => array
-	(
-		'subscribe'        => 'Contao\ModuleSubscribe',
-		'unsubscribe'      => 'Contao\ModuleUnsubscribe',
-		'newsletterlist'   => 'Contao\ModuleNewsletterList',
-		'newsletterreader' => 'Contao\ModuleNewsletterReader'
-	)
-));
+	'subscribe'        => 'Contao\ModuleSubscribe',
+	'unsubscribe'      => 'Contao\ModuleUnsubscribe',
+	'newsletterlist'   => 'Contao\ModuleNewsletterList',
+	'newsletterreader' => 'Contao\ModuleNewsletterReader'
+);
 
 // Register hooks
 $GLOBALS['TL_HOOKS']['createNewUser'][] = array('Contao\Newsletter', 'createNewUser');


### PR DESCRIPTION
Since the order of back end modules is no longer predictable (see #970), it does not make sense to use `array_insert()` to inject a menu item at a certain position. Most likely, it will not end up at this position anyway.