### PR TITLE
Make sure we have the correct type when a search document is created

### DIFF
--- a/core-bundle/src/Search/Document.php
+++ b/core-bundle/src/Search/Document.php
@@ -121,7 +121,7 @@ class Document
             new Uri($request->getUri()),
             $response->getStatusCode(),
             $response->headers->all(),
-            $response->getContent()
+            (string) $response->getContent()
         );
     }
 


### PR DESCRIPTION
According to the phpdoc comment, `Response::getContent()` may also return `false`.