### PR TITLE
Remove the registerCommands() methods

### DIFF
--- a/core-bundle/src/ContaoCoreBundle.php
+++ b/core-bundle/src/ContaoCoreBundle.php
@@ -31,7 +31,6 @@ use Contao\CoreBundle\DependencyInjection\Security\ContaoLoginFactory;
 use Contao\CoreBundle\Fragment\Reference\ContentElementReference;
 use Contao\CoreBundle\Fragment\Reference\FrontendModuleReference;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\SecurityExtension;
-use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -48,14 +47,6 @@ class ContaoCoreBundle extends Bundle
     public function getContainerExtension(): ContaoCoreExtension
     {
         return new ContaoCoreExtension();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function registerCommands(Application $application): void
-    {
-        // disable automatic command registration
     }
 
     /**

--- a/core-bundle/tests/ContaoCoreBundleTest.php
+++ b/core-bundle/tests/ContaoCoreBundleTest.php
@@ -29,23 +29,11 @@ use Contao\CoreBundle\DependencyInjection\Compiler\SearchIndexerPass;
 use Contao\CoreBundle\DependencyInjection\Compiler\TranslationDataCollectorPass;
 use Contao\CoreBundle\DependencyInjection\Security\ContaoLoginFactory;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\SecurityExtension;
-use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\DependencyInjection\FragmentRendererPass;
 
 class ContaoCoreBundleTest extends TestCase
 {
-    public function testDoesNotRegisterAnyCommands(): void
-    {
-        $application = new Application();
-        $commands = $application->all();
-
-        $bundle = new ContaoCoreBundle();
-        $bundle->registerCommands($application);
-
-        $this->assertSame($commands, $application->all());
-    }
-
     public function testAddsTheCompilerPaths(): void
     {
         $passes = [

--- a/manager-bundle/src/ContaoManagerBundle.php
+++ b/manager-bundle/src/ContaoManagerBundle.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 namespace Contao\ManagerBundle;
 
 use Contao\ManagerBundle\DependencyInjection\Compiler\ContaoManagerPass;
-use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -27,13 +26,5 @@ class ContaoManagerBundle extends Bundle
         parent::build($container);
 
         $container->addCompilerPass(new ContaoManagerPass());
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function registerCommands(Application $application): void
-    {
-        // disable automatic command registration
     }
 }


### PR DESCRIPTION
Symfony 4.4 no longer auto-registers commands, therefore we do not have to override the method anymore.
