### PR TITLE
DCA validation via symfony/validator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -108,6 +108,7 @@
         "symfony/swiftmailer-bundle": "^2.6.2 || ^3.1.5",
         "symfony/translation": "4.4.*",
         "symfony/twig-bundle": "4.4.*",
+        "symfony/validator": "4.4.*",
         "symfony/var-dumper": "4.4.*",
         "symfony/web-profiler-bundle": "4.4.*",
         "symfony/yaml": "4.4.*",

--- a/core-bundle/composer.json
+++ b/core-bundle/composer.json
@@ -95,6 +95,7 @@
         "symfony/translation": "4.4.*",
         "symfony/twig-bundle": "4.4.*",
         "symfony/var-dumper": "4.4.*",
+        "symfony/validator": "4.4.*",
         "symfony/yaml": "4.4.*",
         "terminal42/escargot": "^0.1",
         "terminal42/service-annotation-bundle": "^1.0",

--- a/core-bundle/src/Resources/contao/dca/tl_content.php
+++ b/core-bundle/src/Resources/contao/dca/tl_content.php
@@ -832,14 +832,33 @@ $GLOBALS['TL_DCA']['tl_content'] = array
 		(
 			'exclude'                 => true,
 			'inputType'               => 'text',
-			'eval'                    => array('rgxp'=>'datim', 'datepicker'=>true, 'tl_class'=>'w50 wizard'),
+			'eval'                    => array(
+				'rgxp' 						=> 'datim',
+				'datepicker' 				=> true,
+				'tl_class'					=> 'w50 wizard',
+				'expression_validation'		=> 'value === "" or "" === dc.activeRecord.stop or value <= dc.activeRecord.stop',
+				'expression_validation_msg' => 'The start date must be before the stop date.',
+			),
 			'sql'                     => "varchar(10) NOT NULL default ''"
 		),
 		'stop' => array
 		(
 			'exclude'                 => true,
 			'inputType'               => 'text',
-			'eval'                    => array('rgxp'=>'datim', 'datepicker'=>true, 'tl_class'=>'w50 wizard'),
+			'eval'                    => array(
+				'rgxp'					=> 'datim',
+				'datepicker'			=> true,
+				'tl_class'				=> 'w50 wizard',
+				'constraints_callback' 	=> array(
+					function($varValue, $dc) {
+						return new \Symfony\Component\Validator\Constraints\Expression(array(
+							'expression' => 'value === "" or "" ===  dc.activeRecord.start or value >= dc.activeRecord.start',
+							'values' => array('dc' => $dc),
+							'message' => 'The stop date must be after the start date.'
+						));
+					}
+				)
+			),
 			'sql'                     => "varchar(10) NOT NULL default ''"
 		)
 	)


### PR DESCRIPTION
This is a draft for an alternative to https://github.com/contao/contao/pull/896.
Instead of inventing some custom evaluation language it not only reuses the Symfony Expression language but provides integration for the complete Symfony validation framework which means we could reuse not only the Expression language but also all the other validation components.

This PR implements 3 ways to define constraints:

1. Using `eval->constraints` for the simple use cases like.`new NotBlank()`.
2. Using `eval->constraints_callback` for the use cases that need acceess to the `$dc` like e.g. the `Expression` if you want to write something like `dc.activeRecord.foo == "foo"`.
3. An abbreviation for 2 which is `eval->expression_validation` so you don't have to write the callback all the time.

I added examples for both, 2 and 3 so you can see how it would work in practice.