### PR TITLE
Remove the obsolete container.autowiring.strict_mode parameter

### DIFF
--- a/manager-bundle/src/ContaoManager/Plugin.php
+++ b/manager-bundle/src/ContaoManager/Plugin.php
@@ -149,9 +149,6 @@ class Plugin implements BundlePluginInterface, ConfigPluginInterface, RoutingPlu
                 } else {
                     $loader->load('@ContaoManagerBundle/Resources/skeleton/config/config_prod.yml');
                 }
-
-                $container->setParameter('container.autowiring.strict_mode', true);
-                $container->setParameter('container.dumper.inline_class_loader', true);
             }
         );
     }

--- a/manager-bundle/src/ContaoManager/Plugin.php
+++ b/manager-bundle/src/ContaoManager/Plugin.php
@@ -149,6 +149,8 @@ class Plugin implements BundlePluginInterface, ConfigPluginInterface, RoutingPlu
                 } else {
                     $loader->load('@ContaoManagerBundle/Resources/skeleton/config/config_prod.yml');
                 }
+
+                $container->setParameter('container.dumper.inline_class_loader', true);
             }
         );
     }


### PR DESCRIPTION
These parameters are on by default since Symfony 3.3
https://github.com/symfony/recipes/pull/241