### PR TITLE
Redirect to FE preview page after login and ensure integrity of target links

### DIFF
--- a/core-bundle/src/Controller/BackendController.php
+++ b/core-bundle/src/Controller/BackendController.php
@@ -59,7 +59,7 @@ class BackendController extends AbstractController
             if ($request->query->has('redirect')) {
                 $uriSigner = $this->get('uri_signer');
 
-                // we cannot use $request->getUri() here as we want to work with the original URI (no query string reordering)
+                // We cannot use $request->getUri() here as we want to work with the original URI (no query string reordering)
                 if ($uriSigner->check($request->getSchemeAndHttpHost().$request->getBaseUrl().$request->getPathInfo().(null !== ($qs = $request->server->get('QUERY_STRING')) ? '?'.$qs : ''))) {
                     return new RedirectResponse($request->query->get('redirect'));
                 }

--- a/core-bundle/src/Controller/BackendController.php
+++ b/core-bundle/src/Controller/BackendController.php
@@ -217,7 +217,7 @@ class BackendController extends AbstractController
         $services = parent::getSubscribedServices();
 
         $services['contao.picker.builder'] = PickerBuilderInterface::class;
-        $services['uri_signer'] = 'uri_signer';
+        $services['uri_signer'] = 'uri_signer'; // FIXME: adjust this once https://github.com/symfony/symfony/pull/35298 has been merged
 
         return $services;
     }

--- a/core-bundle/src/Controller/BackendController.php
+++ b/core-bundle/src/Controller/BackendController.php
@@ -56,13 +56,16 @@ class BackendController extends AbstractController
         $this->initializeContaoFramework();
 
         if ($this->isGranted('IS_AUTHENTICATED_FULLY')) {
-            $queryString = '';
+            if ($request->query->has('redirect')) {
+                $uriSigner = $this->get('uri_signer');
 
-            if ($request->query->has('referer')) {
-                $queryString = '?'.base64_decode($request->query->get('referer'), true);
+                // we cannot use $request->getUri() here as we want to work with the original URI (no query string reordering)
+                if ($uriSigner->check($request->getSchemeAndHttpHost().$request->getBaseUrl().$request->getPathInfo().(null !== ($qs = $request->server->get('QUERY_STRING')) ? '?'.$qs : ''))) {
+                    return new RedirectResponse($request->query->get('redirect'));
+                }
             }
 
-            return new RedirectResponse($this->generateUrl('contao_backend').$queryString);
+            return new RedirectResponse($this->generateUrl('contao_backend'));
         }
 
         $controller = new BackendIndex();
@@ -214,6 +217,7 @@ class BackendController extends AbstractController
         $services = parent::getSubscribedServices();
 
         $services['contao.picker.builder'] = PickerBuilderInterface::class;
+        $services['uri_signer'] = 'uri_signer';
 
         return $services;
     }

--- a/core-bundle/src/Controller/Base64EncodedRedirectController.php
+++ b/core-bundle/src/Controller/Base64EncodedRedirectController.php
@@ -20,7 +20,7 @@ use Symfony\Component\HttpKernel\UriSigner;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
- * @internal Do not use this controller in your code
+ * @internal
  */
 class Base64EncodedRedirectController
 {
@@ -43,7 +43,7 @@ class Base64EncodedRedirectController
             throw new BadRequestHttpException();
         }
 
-        // we cannot use $request->getUri() here as we want to work with the original URI (no query string reordering)
+        // We cannot use $request->getUri() here as we want to work with the original URI (no query string reordering)
         if (!$this->uriSigner->check($request->getSchemeAndHttpHost().$request->getBaseUrl().$request->getPathInfo().(null !== ($qs = $request->server->get('QUERY_STRING')) ? '?'.$qs : ''))) {
             throw new BadRequestHttpException();
         }

--- a/core-bundle/src/Controller/Base64EncodedRedirectController.php
+++ b/core-bundle/src/Controller/Base64EncodedRedirectController.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Controller;
+
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\UriSigner;
+use Symfony\Component\Routing\Annotation\Route;
+
+/**
+ * @internal Do not use this controller in your code
+ */
+class Base64EncodedRedirectController
+{
+    /**
+     * @var UriSigner
+     */
+    private $uriSigner;
+
+    public function __construct(UriSigner $uriSigner)
+    {
+        $this->uriSigner = $uriSigner;
+    }
+
+    /**
+     * @Route("/_contao/base64_redirect", name="contao_base64_redirect")
+     */
+    public function renderAction(Request $request): Response
+    {
+        if (!$request->query->has('redirect')) {
+            throw new BadRequestHttpException();
+        }
+
+        // we cannot use $request->getUri() here as we want to work with the original URI (no query string reordering)
+        if (!$this->uriSigner->check($request->getSchemeAndHttpHost().$request->getBaseUrl().$request->getPathInfo().(null !== ($qs = $request->server->get('QUERY_STRING')) ? '?'.$qs : ''))) {
+            throw new BadRequestHttpException();
+        }
+
+        return new RedirectResponse(base64_decode($request->query->get('redirect'), true));
+    }
+}

--- a/core-bundle/src/DependencyInjection/Compiler/MakeServicesPublicPass.php
+++ b/core-bundle/src/DependencyInjection/Compiler/MakeServicesPublicPass.php
@@ -30,6 +30,7 @@ class MakeServicesPublicPass implements CompilerPassInterface
         'security.authentication.trust_resolver',
         'security.firewall.map',
         'security.logout_url_generator',
+        'uri_signer',
     ];
 
     private const ALIASES = [

--- a/core-bundle/src/Resources/config/services.yml
+++ b/core-bundle/src/Resources/config/services.yml
@@ -92,6 +92,12 @@ services:
         tags:
             - controller.service_arguments
 
+    Contao\CoreBundle\Controller\Base64EncodedRedirectController:
+        arguments:
+            - '@uri_signer'
+        tags:
+            - controller.service_arguments
+
     # Backwards compatibility
     contao.controller.backend_csv_import:
         alias: Contao\CoreBundle\Controller\BackendCsvImportController
@@ -607,6 +613,7 @@ services:
         arguments:
             - '@security.http_utils'
             - '@router'
+            - '@uri_signer'
 
     contao.security.expiring_token_based_remember_me_services:
         class: Contao\CoreBundle\Security\Authentication\RememberMe\ExpiringTokenBasedRememberMeServices

--- a/core-bundle/src/Resources/contao/controllers/BackendIndex.php
+++ b/core-bundle/src/Resources/contao/controllers/BackendIndex.php
@@ -14,6 +14,7 @@ use Contao\CoreBundle\Security\Exception\LockedException;
 use Scheb\TwoFactorBundle\Security\Authentication\Exception\InvalidTwoFactorCodeException;
 use Scheb\TwoFactorBundle\Security\Authentication\Token\TwoFactorToken;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\UriSigner;
 use Symfony\Component\Routing\Router;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
@@ -66,17 +67,39 @@ class BackendIndex extends Backend
 			Message::addError($GLOBALS['TL_LANG']['ERR']['invalidLogin']);
 		}
 
-		$queryString = '';
-		$arrParams = array();
-
-		if ($referer = Input::get('referer', true))
-		{
-			// Decode the referer and urlencode insert tags
-			$queryString = '?' . str_replace(array('{', '}'), array('%7B', '%7D'), base64_decode($referer, true));
-			$arrParams['referer'] = $referer;
-		}
-
 		$router = $container->get('router');
+
+		$targetPath = $router->generate('contao_backend', array(), Router::ABSOLUTE_URL);
+		$failurePath = $router->generate('contao_backend_login', array(), Router::ABSOLUTE_URL);
+
+		$request = $container->get('request_stack')->getCurrentRequest();
+
+		if ($request && $request->query->has('redirect'))
+		{
+			/** @var UriSigner $uriSigner */
+			$uriSigner = $container->get('uri_signer');
+
+			// we cannot use $request->getUri() here as we want to work with the original URI (no query string reordering)
+			if ($uriSigner->check($request->getSchemeAndHttpHost() . $request->getBaseUrl() . $request->getPathInfo() . (null !== ($qs = $request->server->get('QUERY_STRING')) ? '?' . $qs : '')))
+			{
+				$redirectParams = array('redirect' => base64_encode($request->query->get('redirect')));
+
+				$targetPath =  $uriSigner->sign(
+					$router->generate(
+						'contao_base64_redirect',
+						$redirectParams,
+						Router::ABSOLUTE_URL
+					)
+				);
+				$failurePath = $uriSigner->sign(
+					$router->generate(
+						'contao_base64_redirect',
+						array('redirect' => $router->generate('contao_backend_login', $redirectParams, Router::ABSOLUTE_URL)),
+						Router::ABSOLUTE_URL
+					)
+				);
+			}
+		}
 
 		$objTemplate = new BackendTemplate('be_login');
 		$objTemplate->action = ampersand(Environment::get('request'));
@@ -110,8 +133,8 @@ class BackendIndex extends Backend
 		$objTemplate->feLink = $GLOBALS['TL_LANG']['MSC']['feLink'];
 		$objTemplate->default = $GLOBALS['TL_LANG']['MSC']['default'];
 		$objTemplate->jsDisabled = $GLOBALS['TL_LANG']['MSC']['jsDisabled'];
-		$objTemplate->targetPath = StringUtil::specialchars($router->generate('contao_backend', array(), Router::ABSOLUTE_URL) . $queryString);
-		$objTemplate->failurePath = StringUtil::specialchars($router->generate('contao_backend_login', $arrParams, Router::ABSOLUTE_URL));
+		$objTemplate->targetPath = StringUtil::specialchars($targetPath);
+		$objTemplate->failurePath = StringUtil::specialchars($failurePath);
 
 		return $objTemplate->getResponse();
 	}

--- a/core-bundle/src/Resources/contao/controllers/BackendIndex.php
+++ b/core-bundle/src/Resources/contao/controllers/BackendIndex.php
@@ -68,10 +68,8 @@ class BackendIndex extends Backend
 		}
 
 		$router = $container->get('router');
-
 		$targetPath = $router->generate('contao_backend', array(), Router::ABSOLUTE_URL);
 		$failurePath = $router->generate('contao_backend_login', array(), Router::ABSOLUTE_URL);
-
 		$request = $container->get('request_stack')->getCurrentRequest();
 
 		if ($request && $request->query->has('redirect'))
@@ -79,25 +77,12 @@ class BackendIndex extends Backend
 			/** @var UriSigner $uriSigner */
 			$uriSigner = $container->get('uri_signer');
 
-			// we cannot use $request->getUri() here as we want to work with the original URI (no query string reordering)
+			// We cannot use $request->getUri() here as we want to work with the original URI (no query string reordering)
 			if ($uriSigner->check($request->getSchemeAndHttpHost() . $request->getBaseUrl() . $request->getPathInfo() . (null !== ($qs = $request->server->get('QUERY_STRING')) ? '?' . $qs : '')))
 			{
 				$redirectParams = array('redirect' => base64_encode($request->query->get('redirect')));
-
-				$targetPath =  $uriSigner->sign(
-					$router->generate(
-						'contao_base64_redirect',
-						$redirectParams,
-						Router::ABSOLUTE_URL
-					)
-				);
-				$failurePath = $uriSigner->sign(
-					$router->generate(
-						'contao_base64_redirect',
-						array('redirect' => $router->generate('contao_backend_login', $redirectParams, Router::ABSOLUTE_URL)),
-						Router::ABSOLUTE_URL
-					)
-				);
+				$targetPath = $uriSigner->sign($router->generate('contao_base64_redirect', $redirectParams, Router::ABSOLUTE_URL));
+				$failurePath = $uriSigner->sign($router->generate('contao_base64_redirect', array('redirect' => $router->generate('contao_backend_login', $redirectParams, Router::ABSOLUTE_URL)), Router::ABSOLUTE_URL));
 			}
 		}
 

--- a/core-bundle/src/Resources/contao/modules/ModuleLogin.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleLogin.php
@@ -74,7 +74,7 @@ class ModuleLogin extends Module
 			/** @var UriSigner $uriSigner */
 			$uriSigner = $container->get('uri_signer');
 
-			// we cannot use $request->getUri() here as we want to work with the original URI (no query string reordering)
+			// We cannot use $request->getUri() here as we want to work with the original URI (no query string reordering)
 			if ($uriSigner->check($request->getSchemeAndHttpHost() . $request->getBaseUrl() . $request->getPathInfo() . (null !== ($qs = $request->server->get('QUERY_STRING')) ? '?' . $qs : '')))
 			{
 				$this->targetPath = base64_decode($request->query->get('redirect'));
@@ -188,20 +188,8 @@ class ModuleLogin extends Module
 		}
 
 		// Ensure we do not output any possible dangerous data (redirect back to previous URL allows for URL param injection)
-		$targetPath = $uriSigner->sign(
-			$router->generate(
-				'contao_base64_redirect',
-				array('redirect' => base64_encode($strRedirect)),
-				Router::ABSOLUTE_URL
-			)
-		);
-		$failurePath = $uriSigner->sign(
-			$router->generate(
-				'contao_base64_redirect',
-				array('redirect' => base64_encode($objPage->getAbsoluteUrl())),
-				Router::ABSOLUTE_URL
-			)
-		);
+		$targetPath = $uriSigner->sign($router->generate('contao_base64_redirect', array('redirect' => base64_encode($strRedirect)), Router::ABSOLUTE_URL));
+		$failurePath = $uriSigner->sign($router->generate('contao_base64_redirect', array('redirect' => base64_encode($objPage->getAbsoluteUrl())), Router::ABSOLUTE_URL));
 
 		$this->Template->username = $GLOBALS['TL_LANG']['MSC']['username'];
 		$this->Template->password = $GLOBALS['TL_LANG']['MSC']['password'][0];

--- a/core-bundle/src/Resources/contao/modules/ModuleLogin.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleLogin.php
@@ -187,9 +187,11 @@ class ModuleLogin extends Module
 			$strRedirect = $objTarget->getAbsoluteUrl();
 		}
 
+		$request = $container->get('request_stack')->getCurrentRequest();
+
 		// Ensure we do not output any possible dangerous data (redirect back to previous URL allows for URL param injection)
 		$targetPath = $uriSigner->sign($router->generate('contao_base64_redirect', array('redirect' => base64_encode($strRedirect)), Router::ABSOLUTE_URL));
-		$failurePath = $uriSigner->sign($router->generate('contao_base64_redirect', array('redirect' => base64_encode($objPage->getAbsoluteUrl())), Router::ABSOLUTE_URL));
+		$failurePath = $uriSigner->sign($router->generate('contao_base64_redirect', array('redirect' => base64_encode($request->getUri())), Router::ABSOLUTE_URL));
 
 		$this->Template->username = $GLOBALS['TL_LANG']['MSC']['username'];
 		$this->Template->password = $GLOBALS['TL_LANG']['MSC']['password'][0];

--- a/core-bundle/src/Resources/contao/modules/ModuleLogin.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleLogin.php
@@ -13,6 +13,7 @@ namespace Contao;
 use Contao\CoreBundle\Security\Exception\LockedException;
 use Patchwork\Utf8;
 use Scheb\TwoFactorBundle\Security\Authentication\Exception\InvalidTwoFactorCodeException;
+use Symfony\Component\HttpKernel\UriSigner;
 use Symfony\Component\Routing\Router;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 
@@ -59,14 +60,25 @@ class ModuleLogin extends Module
 			return $objTemplate->parse();
 		}
 
+		$container = System::getContainer();
+		$request = $container->get('request_stack')->getCurrentRequest();
+
+		// If the form was submitted and the credentials were wrong, take the target path from the submitted data
+		// as otherwise it would take the current page
 		if ($_POST)
 		{
 			$this->targetPath = (string) Input::post('_target_path');
 		}
-		elseif ($this->redirectBack && ($referer = Input::get('referer', true)))
+		elseif ($this->redirectBack && $request && $request->query->has('redirect'))
 		{
-			// Decode the referer and urlencode insert tags
-			$this->targetPath = Environment::get('base') . str_replace(array('{', '}'), array('%7B', '%7D'), base64_decode($referer, true));
+			/** @var UriSigner $uriSigner */
+			$uriSigner = $container->get('uri_signer');
+
+			// we cannot use $request->getUri() here as we want to work with the original URI (no query string reordering)
+			if ($uriSigner->check($request->getSchemeAndHttpHost() . $request->getBaseUrl() . $request->getPathInfo() . (null !== ($qs = $request->server->get('QUERY_STRING')) ? '?' . $qs : '')))
+			{
+				$this->targetPath = base64_decode($request->query->get('redirect'));
+			}
 		}
 
 		return parent::generate();
@@ -84,6 +96,9 @@ class ModuleLogin extends Module
 
 		/** @var Router $router */
 		$router = $container->get('router');
+
+		/** @var UriSigner $uriSigner */
+		$uriSigner = $container->get('uri_signer');
 
 		/** @var AuthenticationException|null $exception */
 		$exception = $container->get('security.authentication_utils')->getLastAuthenticationError();
@@ -172,6 +187,22 @@ class ModuleLogin extends Module
 			$strRedirect = $objTarget->getAbsoluteUrl();
 		}
 
+		// Ensure we do not output any possible dangerous data (redirect back to previous URL allows for URL param injection)
+		$targetPath = $uriSigner->sign(
+			$router->generate(
+				'contao_base64_redirect',
+				array('redirect' => base64_encode($strRedirect)),
+				Router::ABSOLUTE_URL
+			)
+		);
+		$failurePath = $uriSigner->sign(
+			$router->generate(
+				'contao_base64_redirect',
+				array('redirect' => base64_encode($objPage->getAbsoluteUrl())),
+				Router::ABSOLUTE_URL
+			)
+		);
+
 		$this->Template->username = $GLOBALS['TL_LANG']['MSC']['username'];
 		$this->Template->password = $GLOBALS['TL_LANG']['MSC']['password'][0];
 		$this->Template->action = $router->generate('contao_frontend_login');
@@ -181,8 +212,8 @@ class ModuleLogin extends Module
 		$this->Template->autologin = $this->autologin;
 		$this->Template->autoLabel = $GLOBALS['TL_LANG']['MSC']['autologin'];
 		$this->Template->forceTargetPath = (int) $blnRedirectBack;
-		$this->Template->targetPath = StringUtil::specialchars($strRedirect);
-		$this->Template->failurePath = StringUtil::specialchars(Environment::get('base') . Environment::get('request'));
+		$this->Template->targetPath = StringUtil::specialchars($targetPath);
+		$this->Template->failurePath = StringUtil::specialchars($failurePath);
 	}
 }
 

--- a/core-bundle/src/Resources/contao/pages/PageError401.php
+++ b/core-bundle/src/Resources/contao/pages/PageError401.php
@@ -127,9 +127,7 @@ class PageError401 extends Frontend
 			/** @var UriSigner $uriSigner */
 			$uriSigner = System::getContainer()->get('uri_signer');
 
-			$url = $uriSigner->sign($url);
-
-			$this->redirect($url, (($obj401->redirect == 'temporary') ? 302 : 301));
+			$this->redirect($uriSigner->sign($url), (($obj401->redirect == 'temporary') ? 302 : 301));
 		}
 
 		return $obj401;

--- a/core-bundle/src/Resources/contao/pages/PageError401.php
+++ b/core-bundle/src/Resources/contao/pages/PageError401.php
@@ -13,6 +13,7 @@ namespace Contao;
 use Contao\CoreBundle\Exception\ForwardPageNotFoundException;
 use Contao\CoreBundle\Exception\InsufficientAuthenticationException;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\UriSigner;
 
 /**
  * Provide methods to handle an error 401 page.
@@ -121,9 +122,14 @@ class PageError401 extends Frontend
 			}
 
 			// Add the referer so the login module can redirect back
-			$referer = base64_encode(Environment::get('request'));
+			$url = $objNextPage->getAbsoluteUrl() . '?redirect=' . base64_encode(Environment::get('base') . Environment::get('request'));
 
-			$this->redirect($objNextPage->getFrontendUrl() . '?referer=' . $referer, (($obj401->redirect == 'temporary') ? 302 : 301));
+			/** @var UriSigner $uriSigner */
+			$uriSigner = System::getContainer()->get('uri_signer');
+
+			$url = $uriSigner->sign($url);
+
+			$this->redirect($url, (($obj401->redirect == 'temporary') ? 302 : 301));
 		}
 
 		return $obj401;

--- a/core-bundle/src/Security/Authentication/AuthenticationEntryPoint.php
+++ b/core-bundle/src/Security/Authentication/AuthenticationEntryPoint.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Security\Authentication;
 
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\UriSigner;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
@@ -32,12 +33,18 @@ class AuthenticationEntryPoint implements AuthenticationEntryPointInterface
     private $router;
 
     /**
+     * @var UriSigner
+     */
+    private $uriSigner;
+
+    /**
      * @internal Do not inherit from this class; decorate the "contao.security.entry_point" service instead
      */
-    public function __construct(HttpUtils $httpUtils, RouterInterface $router)
+    public function __construct(HttpUtils $httpUtils, RouterInterface $router, UriSigner $uriSigner)
     {
         $this->httpUtils = $httpUtils;
         $this->router = $router;
+        $this->uriSigner = $uriSigner;
     }
 
     /**
@@ -49,11 +56,11 @@ class AuthenticationEntryPoint implements AuthenticationEntryPointInterface
             return $this->httpUtils->createRedirectResponse($request, 'contao_backend_login');
         }
 
-        $url = $this->router->generate(
+        $url = $this->uriSigner->sign($this->router->generate(
             'contao_backend_login',
-            ['referer' => base64_encode($request->getQueryString())],
+            ['redirect' => $request->getUri()],
             UrlGeneratorInterface::ABSOLUTE_URL
-        );
+        ));
 
         return $this->httpUtils->createRedirectResponse($request, $url);
     }

--- a/core-bundle/src/Security/Authentication/AuthenticationEntryPoint.php
+++ b/core-bundle/src/Security/Authentication/AuthenticationEntryPoint.php
@@ -56,12 +56,12 @@ class AuthenticationEntryPoint implements AuthenticationEntryPointInterface
             return $this->httpUtils->createRedirectResponse($request, 'contao_backend_login');
         }
 
-        $url = $this->uriSigner->sign($this->router->generate(
+        $url = $this->router->generate(
             'contao_backend_login',
             ['redirect' => $request->getUri()],
             UrlGeneratorInterface::ABSOLUTE_URL
-        ));
+        );
 
-        return $this->httpUtils->createRedirectResponse($request, $url);
+        return $this->httpUtils->createRedirectResponse($request, $this->uriSigner->sign($url));
     }
 }

--- a/core-bundle/tests/Controller/Base64EncodedRedirectControllerTest.php
+++ b/core-bundle/tests/Controller/Base64EncodedRedirectControllerTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\Controller;
+
+use Contao\CoreBundle\Controller\Base64EncodedRedirectController;
+use Contao\CoreBundle\Tests\TestCase;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\UriSigner;
+
+class Base64EncodedRedirectControllerTest extends TestCase
+{
+    public function testReturnsBadRequestIfNoRedirectQueryParameterWasProvided(): void
+    {
+        $this->expectException(BadRequestHttpException::class);
+
+        $request = Request::create('https://contao.org/_contao/base64_redirect?foobar=nonsense');
+
+        $controller = new Base64EncodedRedirectController(new UriSigner('secret'));
+        $controller->renderAction($request);
+    }
+
+    public function testReturnsBadRequestIfUrlSigningWasIncorrect(): void
+    {
+        $this->expectException(BadRequestHttpException::class);
+
+        $redirect = base64_encode('https://contao.org/preview.php/about-contao.html');
+        $request = Request::create('https://contao.org/_contao/base64_redirect?_hash=nonsense&redirect='.$redirect);
+
+        $controller = new Base64EncodedRedirectController(new UriSigner('secret'));
+        $controller->renderAction($request);
+    }
+
+    public function testRedirectsToCorrectUrlSigningMatches(): void
+    {
+        $uriSigner = new UriSigner('secret');
+        $redirectUrl = 'https://contao.org/preview.php/about-contao.html';
+        $signedUri = $uriSigner->sign('https://contao.org/_contao/base64_redirect?redirect='.base64_encode($redirectUrl));
+
+        $request = Request::create($signedUri);
+
+        $controller = new Base64EncodedRedirectController($uriSigner);
+        $response = $controller->renderAction($request);
+
+        $this->assertInstanceOf(RedirectResponse::class, $response);
+        $this->assertSame($redirectUrl, $response->getTargetUrl());
+    }
+}

--- a/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
+++ b/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
@@ -2617,6 +2617,7 @@ class ContaoCoreExtensionTest extends TestCase
             [
                 new Reference('security.http_utils'),
                 new Reference('router'),
+                new Reference('uri_signer'),
             ],
             $definition->getArguments()
         );

--- a/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
+++ b/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
@@ -30,6 +30,7 @@ use Contao\CoreBundle\Controller\BackendController;
 use Contao\CoreBundle\Controller\BackendCsvImportController;
 use Contao\CoreBundle\Controller\BackendPreviewController;
 use Contao\CoreBundle\Controller\BackendPreviewSwitchController;
+use Contao\CoreBundle\Controller\Base64EncodedRedirectController;
 use Contao\CoreBundle\Controller\FaviconController;
 use Contao\CoreBundle\Controller\FrontendController;
 use Contao\CoreBundle\Controller\FrontendModule\TwoFactorController;
@@ -839,6 +840,31 @@ class ContaoCoreExtensionTest extends TestCase
                 new Reference('%contao.csrf_token_name%'),
             ],
             $definition->getArguments()
+        );
+    }
+
+    public function testRegistersTheBase64EncodedRedirectController(): void
+    {
+        $this->assertTrue($this->container->has(Base64EncodedRedirectController::class));
+
+        $definition = $this->container->getDefinition(Base64EncodedRedirectController::class);
+
+        $this->assertTrue($definition->isPrivate());
+
+        $this->assertEquals(
+            [
+                new Reference('uri_signer'),
+            ],
+            $definition->getArguments()
+        );
+
+        $this->assertSame(
+            [
+                'controller.service_arguments' => [
+                    [],
+                ],
+            ],
+            $definition->getTags()
         );
     }
 

--- a/manager-bundle/src/EventListener/PreviewAuthenticationListener.php
+++ b/manager-bundle/src/EventListener/PreviewAuthenticationListener.php
@@ -71,10 +71,12 @@ class PreviewAuthenticationListener
             return;
         }
 
-        $event->setResponse(
-            new RedirectResponse($this->uriSigner->sign($this->router->generate('contao_backend_login', [
-                'redirect' => $request->getUri(),
-            ], UrlGeneratorInterface::ABSOLUTE_URL)))
+        $url = $this->router->generate(
+            'contao_backend_login',
+            ['redirect' => $request->getUri()],
+            UrlGeneratorInterface::ABSOLUTE_URL
         );
+
+        $event->setResponse(new RedirectResponse($this->uriSigner->sign($url)));
     }
 }

--- a/manager-bundle/src/EventListener/PreviewAuthenticationListener.php
+++ b/manager-bundle/src/EventListener/PreviewAuthenticationListener.php
@@ -16,6 +16,7 @@ use Contao\CoreBundle\Routing\ScopeMatcher;
 use Contao\CoreBundle\Security\Authentication\Token\TokenChecker;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\UriSigner;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
@@ -39,15 +40,21 @@ class PreviewAuthenticationListener
     private $router;
 
     /**
+     * @var UriSigner
+     */
+    private $uriSigner;
+
+    /**
      * @var string
      */
     private $previewScript;
 
-    public function __construct(ScopeMatcher $scopeMatcher, TokenChecker $tokenChecker, UrlGeneratorInterface $router, string $previewScript)
+    public function __construct(ScopeMatcher $scopeMatcher, TokenChecker $tokenChecker, UrlGeneratorInterface $router, UriSigner $uriSigner, string $previewScript)
     {
         $this->scopeMatcher = $scopeMatcher;
         $this->tokenChecker = $tokenChecker;
         $this->router = $router;
+        $this->uriSigner = $uriSigner;
         $this->previewScript = $previewScript;
     }
 
@@ -64,6 +71,10 @@ class PreviewAuthenticationListener
             return;
         }
 
-        $event->setResponse(new RedirectResponse($this->router->generate('contao_backend_login')));
+        $event->setResponse(
+            new RedirectResponse($this->uriSigner->sign($this->router->generate('contao_backend_login', [
+                'redirect' => $request->getUri(),
+            ], UrlGeneratorInterface::ABSOLUTE_URL)))
+        );
     }
 }

--- a/manager-bundle/src/Resources/config/listener.yml
+++ b/manager-bundle/src/Resources/config/listener.yml
@@ -31,6 +31,7 @@ services:
             - '@contao.routing.scope_matcher'
             - '@contao.security.token_checker'
             - '@router'
+            - '@uri_signer'
             - '%contao.preview_script%'
         tags:
             # The priority must be lower than the one of the firewall listener (defaults to 8)

--- a/manager-bundle/tests/DependencyInjection/ContaoManagerExtensionTest.php
+++ b/manager-bundle/tests/DependencyInjection/ContaoManagerExtensionTest.php
@@ -145,6 +145,7 @@ class ContaoManagerExtensionTest extends TestCase
                 new Reference('contao.routing.scope_matcher'),
                 new Reference('contao.security.token_checker'),
                 new Reference('router'),
+                new Reference('uri_signer'),
                 new Reference('%contao.preview_script%'),
             ],
             $definition->getArguments()


### PR DESCRIPTION
This PR addresses two issues:

* Currently we only handle insert tags to be potentially dangerous when outputting the `_target_path` in the login forms (both, back end and front end). Although it seems to solve the most obvious potential vulnerability, I'd like to use URI signing to make sure these URIs were not tampered with.

* The new preview bar does not support automated redirect after login. So if I send `https://contao.org/prevew.php/about-us.html` to a user, they are redirected to the back end login and aren't redirected back automatically after successful login.

This PR solves both of these issues by doing the following:

Both, the `ModuleLogin` (for the front end) as well as the `BackendIndex` (for the back end) accepted a `referer` query parameter which is used to redirect you back to the pages you were coming from after successful login. We have two potential security issues here:

1. We must not allow any absolute URI as this would be an OWASP "Unvalidated redirects and forwards" security vulnerability.

2. We must ensure the URIs do not contain mailicious query parameters (such as containing an insert tag) as we output the redirect URI as `<form input="hidden" name="_target_path" value="<target-uri-here>">`. The insert tags would be interpreted and protected content might be revealed.

This PR addresses 1) by only accepting `redirect` (I renamed `referer` to `redirect` to make sure I don't miss anything) parameters that are properly signed using the `UriSigner`. So both, the `ModuleLogin` as well as `BackendIndex` validate the URIs.

That means, nobody can do something like `?redirect=https://www.google.com.....`. However, we still have the problem that the "redirect to where you were coming from" is essentially user input. It will always be the URI you were visiting before so I could do some `?evil={{insert_tag....`.
This is issue 2) and is addressed by a new controller named `Base64EncodedRedirectController`. So instead of exposing the provided value directly in HTML (`<form input="hidden" name="_target_path" value="https://contao.org?evil={{insert_tag...">` we do a double redirect. So the actual target is protected behind our own route: `<form input="hidden" name="_target_path" value="https://contao_org/_contao/base64_redirect?redirect=<base64encoded-which-ensures-security>&_hash=<again-uri-signed-hash-to-prevent-from-random-redirect-targets">`.
Again, those target URIs also have to be signed, otherwise anyone can abuse our `/_contao/base64_redirect` route to redirect people anywhere (which would be a 1) vulnerability again).

