### PR TITLE
Fix the SERP preview alias field and missing primary key

### DIFF
--- a/core-bundle/src/Resources/contao/widgets/SerpPreview.php
+++ b/core-bundle/src/Resources/contao/widgets/SerpPreview.php
@@ -128,13 +128,14 @@ EOT;
 			throw new \LogicException('No url_callback given');
 		}
 
-		$alias = $this->getAlias($model);
+		$aliasField = $this->aliasField ?: 'alias';
 		$placeholder = bin2hex(random_bytes(10));
 
 		// Pass a detached clone with the alias set to the placeholder
 		$tempModel = clone $model;
-		$tempModel->origAlias = $tempModel->$alias;
-		$tempModel->$alias = $placeholder;
+		$tempModel->{$tempModel::getPk()} = $model->{$model::getPk()};
+		$tempModel->origAlias = $tempModel->$aliasField;
+		$tempModel->$aliasField = $placeholder;
 		$tempModel->preventSaving(false);
 
 		if (\is_array($this->url_callback))

--- a/core-bundle/src/Resources/contao/widgets/SerpPreview.php
+++ b/core-bundle/src/Resources/contao/widgets/SerpPreview.php
@@ -132,8 +132,7 @@ EOT;
 		$placeholder = bin2hex(random_bytes(10));
 
 		// Pass a detached clone with the alias set to the placeholder
-		$tempModel = clone $model;
-		$tempModel->{$tempModel::getPk()} = $model->{$model::getPk()};
+		$tempModel = $model->cloneOriginal();
 		$tempModel->origAlias = $tempModel->$aliasField;
 		$tempModel->$aliasField = $placeholder;
 		$tempModel->preventSaving(false);


### PR DESCRIPTION
This fixes two SERP issues:

1. Because of the cloned model, the primary key is missing. So if the alias is empty, we try to generate an URL for an empty ID, which results in exception `Parameter "alias" for route "contao_frontend" must match ".+" ("" given) to generate a corresponding URL`

2. Das temporäre Alias muss natürlich auf dem Feld `alias` und nicht auf dem Wert des Feldes gesetzt werden 😆 