### PR TITLE
Add associative array keys for label callback

### DIFF
--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -4997,7 +4997,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 				if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['label_callback']) || \is_callable($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['label_callback']))
 				{
 					// add the associative keys 
-					$args = array_combine($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['fields'], $args);
+					$argsWithKeys = array_combine($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['fields'], $args);
 					
 					if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['label_callback']))
 					{
@@ -5005,11 +5005,11 @@ class DC_Table extends DataContainer implements \listable, \editable
 						$strMethod = $GLOBALS['TL_DCA'][$this->strTable]['list']['label']['label_callback'][1];
 
 						$this->import($strClass);
-						$args = $this->$strClass->$strMethod($row, $label, $this, $args);
+						$args = $this->$strClass->$strMethod($row, $label, $this, $args, $argsWithKeys);
 					}
 					elseif (\is_callable($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['label_callback']))
 					{
-						$args = $GLOBALS['TL_DCA'][$this->strTable]['list']['label']['label_callback']($row, $label, $this, $args);
+						$args = $GLOBALS['TL_DCA'][$this->strTable]['list']['label']['label_callback']($row, $label, $this, $args, $argsWithKeys);
 					}
 
 					// Handle strings and arrays

--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -4996,6 +4996,9 @@ class DC_Table extends DataContainer implements \listable, \editable
 				// Call the label_callback ($row, $label, $this)
 				if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['label_callback']) || \is_callable($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['label_callback']))
 				{
+					// add the associative keys 
+					$args = array_combine($GLOBALS['TL_DCA'][$this->table]['list']['label']['fields'], $args);
+					
 					if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['label_callback']))
 					{
 						$strClass = $GLOBALS['TL_DCA'][$this->strTable]['list']['label']['label_callback'][0];

--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -4997,7 +4997,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 				if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['label_callback']) || \is_callable($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['label_callback']))
 				{
 					// add the associative keys 
-					$args = array_combine($GLOBALS['TL_DCA'][$this->table]['list']['label']['fields'], $args);
+					$args = array_combine($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['fields'], $args);
 					
 					if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['label_callback']))
 					{


### PR DESCRIPTION
If you use `$GLOBALS['TL_DCA']['some_table']['list']['label']['showColumns'] = true` and then want to change multiple fields individually in label_callback it is tricky. If you then change the order in `$GLOBALS['TL_DCA']['some_table']['list']['label']['fields']` it will go crazy because the key number changes.

Similar to this: https://github.com/contao/contao/blob/master/core-bundle/src/Resources/contao/dca/tl_member.php#L461

Instead of `$args[0]` it should be `$args['icon']`

~This is not BC breaking.~