### PR TITLE
Disable the MakeResponsePrivateListener for non-Contao requests

### DIFF
--- a/core-bundle/src/EventListener/MakeResponsePrivateListener.php
+++ b/core-bundle/src/EventListener/MakeResponsePrivateListener.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\EventListener;
 
+use Contao\CoreBundle\Routing\ScopeMatcher;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\EventListener\AbstractSessionListener;
 
@@ -20,6 +21,16 @@ use Symfony\Component\HttpKernel\EventListener\AbstractSessionListener;
  */
 class MakeResponsePrivateListener
 {
+    /**
+     * @var ScopeMatcher
+     */
+    private $scopeMatcher;
+
+    public function __construct(ScopeMatcher $scopeMatcher)
+    {
+        $this->scopeMatcher = $scopeMatcher;
+    }
+
     /**
      * Make sure that the current response becomes a private response if any
      * of the following conditions are true.
@@ -34,7 +45,7 @@ class MakeResponsePrivateListener
      */
     public function __invoke(ResponseEvent $event): void
     {
-        if (!$event->isMasterRequest()) {
+        if (!$this->scopeMatcher->isContaoMasterRequest($event)) {
             return;
         }
 

--- a/core-bundle/src/Resources/config/listener.yml
+++ b/core-bundle/src/Resources/config/listener.yml
@@ -130,6 +130,8 @@ services:
 
     contao.listener.make_response_private:
         class: Contao\CoreBundle\EventListener\MakeResponsePrivateListener
+        arguments:
+            - '@contao.routing.scope_matcher'
         tags:
             # The priority must be lower than the one of MergeHttpHeadersListener (defaults to 256)
             - { name: kernel.event_listener }

--- a/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
+++ b/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
@@ -678,6 +678,13 @@ class ContaoCoreExtensionTest extends TestCase
         $this->assertSame(MakeResponsePrivateListener::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
 
+        $this->assertEquals(
+            [
+                new Reference('contao.routing.scope_matcher'),
+            ],
+            $definition->getArguments()
+        );
+
         $tags = $definition->getTags();
 
         $this->assertSame(


### PR DESCRIPTION
PR for https://github.com/contao/contao/issues/1079

I think it's better to disable it for all non-Contao requests. Not just the FE ones.