### PR TITLE
Do not decode entities in page names

### DIFF
--- a/core-bundle/src/Resources/contao/dca/tl_page.php
+++ b/core-bundle/src/Resources/contao/dca/tl_page.php
@@ -202,7 +202,7 @@ $GLOBALS['TL_DCA']['tl_page'] = array
 			'exclude'                 => true,
 			'search'                  => true,
 			'inputType'               => 'text',
-			'eval'                    => array('mandatory'=>true, 'maxlength'=>255, 'decodeEntities'=>true, 'tl_class'=>'w50'),
+			'eval'                    => array('mandatory'=>true, 'maxlength'=>255, 'tl_class'=>'w50'),
 			'sql'                     => "varchar(255) NOT NULL default ''"
 		),
 		'alias' => array

--- a/core-bundle/src/Resources/contao/pages/PageRegular.php
+++ b/core-bundle/src/Resources/contao/pages/PageRegular.php
@@ -210,7 +210,7 @@ class PageRegular extends Frontend
 		}
 
 		// Assign the title and description
-		$this->Template->title = StringUtil::stripInsertTags($this->replaceInsertTags($objLayout->titleTag)); // see #7097
+		$this->Template->title = $this->replaceInsertTags($objLayout->titleTag);
 		$this->Template->description = str_replace(array("\n", "\r", '"'), array(' ', '', ''), $objPage->description);
 
 		// Body onload and body classes

--- a/core-bundle/src/Resources/contao/pages/PageRegular.php
+++ b/core-bundle/src/Resources/contao/pages/PageRegular.php
@@ -210,7 +210,7 @@ class PageRegular extends Frontend
 		}
 
 		// Assign the title and description
-		$this->Template->title = $this->replaceInsertTags($objLayout->titleTag);
+		$this->Template->title = strip_tags($this->replaceInsertTags($objLayout->titleTag));
 		$this->Template->description = str_replace(array("\n", "\r", '"'), array(' ', '', ''), $objPage->description);
 
 		// Body onload and body classes


### PR DESCRIPTION
Fixes #473 

Since insert tags are now removed recursively, we do not need the `StringUtil::stripInsertTags()` call in the `PageRegular` class anymore.