### PR TITLE
Use spl_object_id() instead of spl_object_hash()

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Model/Registry.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Model/Registry.php
@@ -143,7 +143,7 @@ class Registry implements \Countable
 	 */
 	public function register(Model $objModel)
 	{
-		$intObjectId = spl_object_hash($objModel);
+		$intObjectId = spl_object_id($objModel);
 
 		// The model has been registered already
 		if (isset($this->arrIdentities[$intObjectId]))
@@ -191,7 +191,7 @@ class Registry implements \Countable
 	 */
 	public function unregister(Model $objModel)
 	{
-		$intObjectId = spl_object_hash($objModel);
+		$intObjectId = spl_object_id($objModel);
 
 		// The model is not registered
 		if (!isset($this->arrIdentities[$intObjectId]))
@@ -218,7 +218,7 @@ class Registry implements \Countable
 	 */
 	public function isRegistered(Model $objModel)
 	{
-		$intObjectId = spl_object_hash($objModel);
+		$intObjectId = spl_object_id($objModel);
 
 		return isset($this->arrIdentities[$intObjectId]);
 	}


### PR DESCRIPTION
Now that we require at least PHP 7.2 we can use `spl_object_id()` instead of `spl_object_hash()` which is faster and requires a lot less memory.

https://3v4l.org/WCYb8/perf#output
https://3v4l.org/I4mEg/perf#output