### PR TITLE
Remove a superfluous argument in the RememberMeRepository class

### DIFF
--- a/core-bundle/src/Resources/config/services.yml
+++ b/core-bundle/src/Resources/config/services.yml
@@ -420,7 +420,6 @@ services:
         class: Contao\CoreBundle\Repository\RememberMeRepository
         arguments:
             - '@doctrine'
-            - 'Contao\CoreBundle\Entity\RememberMe'
 
     contao.resource_finder:
         class: Contao\CoreBundle\Config\ResourceFinder

--- a/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
+++ b/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
@@ -2130,7 +2130,6 @@ class ContaoCoreExtensionTest extends TestCase
         $this->assertEquals(
             [
                 new Reference('doctrine'),
-                new Reference(RememberMe::class),
             ],
             $definition->getArguments()
         );

--- a/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
+++ b/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
@@ -44,7 +44,6 @@ use Contao\CoreBundle\Csrf\MemoryTokenStorage;
 use Contao\CoreBundle\DataCollector\ContaoDataCollector;
 use Contao\CoreBundle\DependencyInjection\ContaoCoreExtension;
 use Contao\CoreBundle\Doctrine\Schema\DcaSchemaProvider;
-use Contao\CoreBundle\Entity\RememberMe;
 use Contao\CoreBundle\EventListener\BackendLocaleListener;
 use Contao\CoreBundle\EventListener\BypassMaintenanceListener;
 use Contao\CoreBundle\EventListener\ClearSessionDataListener;


### PR DESCRIPTION
While working on #1098, another discrepancy with the `RememberMeRepository` that I found was, that the `services.yml` defines two service constructor for the `RememberMeRepository` - even though it just takes one. The second parameter would only be necessary, if the `RememberMeRepository` did not define its own constructor. However it does define its own constructor, hardcoding the entity class within PHP.