### PR TITLE
Fix the security.yml code in the README file

### DIFF
--- a/core-bundle/README.md
+++ b/core-bundle/README.md
@@ -105,7 +105,7 @@ security:
                 path: contao_backend_logout
                 handlers:
                     - contao.security.logout_handler
-                    - contao_manager.security.logout_handler
+                    # - contao_manager.security.logout_handler # only used when manager-bundle is installed
                 success_handler: contao.security.logout_success_handler
 
         contao_frontend:

--- a/core-bundle/README.md
+++ b/core-bundle/README.md
@@ -105,7 +105,6 @@ security:
                 path: contao_backend_logout
                 handlers:
                     - contao.security.logout_handler
-                    # - contao_manager.security.logout_handler # only used when manager-bundle is installed
                 success_handler: contao.security.logout_success_handler
 
         contao_frontend:


### PR DESCRIPTION
**How to reproduce:**
Just follow the instructions from the [core-bundle README](https://github.com/contao/contao/tree/master/core-bundle).

If you copy paste the `security.yml` configuration from the [core-bundle README #configuration](https://github.com/contao/contao/tree/master/core-bundle#configuration) it will end up in an exception, because the `contao/manager-bundle` is not required to run Contao as a Symfony bundle:

```
...
Executing command (CWD): php bin/console cache:clear --no-warmup

In CheckExceptionOnInvalidReferenceBehaviorPass.php line 86:
                                                                               
  The service "security.firewall.map.context.contao_backend" has a dependency  
   on a non-existent service "contao_manager.security.logout_handler".         
                                                                               

Script php bin/console cache:clear --no-warmup handling the setup-scripts event returned with error code 1
Script @setup-scripts was called via post-install-cmd
...
```

