### PR TITLE
Do not pollute the session with a target path

### DIFF
--- a/core-bundle/src/Security/Authentication/AuthenticationSuccessHandler.php
+++ b/core-bundle/src/Security/Authentication/AuthenticationSuccessHandler.php
@@ -81,8 +81,6 @@ class AuthenticationSuccessHandler implements AuthenticationSuccessHandlerInterf
 
             $response = new RedirectResponse($request->getUri());
 
-            $this->saveTargetPath($request->getSession(), $token->getProviderKey(), $response->getTargetUrl());
-
             return $response;
         }
 

--- a/core-bundle/src/Security/Authentication/AuthenticationSuccessHandler.php
+++ b/core-bundle/src/Security/Authentication/AuthenticationSuccessHandler.php
@@ -81,6 +81,11 @@ class AuthenticationSuccessHandler implements AuthenticationSuccessHandlerInterf
 
             $response = new RedirectResponse($request->getUri());
 
+            // Used by the TwoFactorListener to redirect a user back to the authentication page
+            if ($request->hasSession() && $request->isMethodSafe() && !$request->isXmlHttpRequest()) {
+                $this->saveTargetPath($request->getSession(), $token->getProviderKey(), $request->getUri());
+            }
+
             return $response;
         }
 
@@ -101,6 +106,7 @@ class AuthenticationSuccessHandler implements AuthenticationSuccessHandlerInterf
         }
 
         $this->triggerPostLoginHook();
+        $this->removeTargetPath($request->getSession(), $token->getProviderKey());
 
         return $response;
     }

--- a/core-bundle/src/Security/Authentication/AuthenticationSuccessHandler.php
+++ b/core-bundle/src/Security/Authentication/AuthenticationSuccessHandler.php
@@ -107,7 +107,7 @@ class AuthenticationSuccessHandler implements AuthenticationSuccessHandlerInterf
 
         $this->triggerPostLoginHook();
 
-        if ($request->hasSession() && \method_exists($token, 'getProviderKey')) {
+        if ($request->hasSession() && method_exists($token, 'getProviderKey')) {
             $this->removeTargetPath($request->getSession(), $token->getProviderKey());
         }
 

--- a/core-bundle/src/Security/Authentication/AuthenticationSuccessHandler.php
+++ b/core-bundle/src/Security/Authentication/AuthenticationSuccessHandler.php
@@ -106,7 +106,10 @@ class AuthenticationSuccessHandler implements AuthenticationSuccessHandlerInterf
         }
 
         $this->triggerPostLoginHook();
-        $this->removeTargetPath($request->getSession(), $token->getProviderKey());
+
+        if ($request->hasSession() && \method_exists($token, 'getProviderKey')) {
+            $this->removeTargetPath($request->getSession(), $token->getProviderKey());
+        }
 
         return $response;
     }

--- a/core-bundle/src/Security/Logout/LogoutHandler.php
+++ b/core-bundle/src/Security/Logout/LogoutHandler.php
@@ -52,7 +52,7 @@ class LogoutHandler implements LogoutHandlerInterface
      */
     public function logout(Request $request, Response $response, TokenInterface $token): void
     {
-        if ($request->hasSession() && \method_exists($token, 'getProviderKey')) {
+        if ($request->hasSession() && method_exists($token, 'getProviderKey')) {
             $this->removeTargetPath($request->getSession(), $token->getProviderKey());
         }
 

--- a/core-bundle/src/Security/Logout/LogoutHandler.php
+++ b/core-bundle/src/Security/Logout/LogoutHandler.php
@@ -52,6 +52,10 @@ class LogoutHandler implements LogoutHandlerInterface
      */
     public function logout(Request $request, Response $response, TokenInterface $token): void
     {
+        if ($request->hasSession() && \method_exists($token, 'getProviderKey')) {
+            $this->removeTargetPath($request->getSession(), $token->getProviderKey());
+        }
+
         $user = $token->getUser();
 
         if (!$user instanceof User || $token instanceof TwoFactorTokenInterface) {
@@ -66,7 +70,6 @@ class LogoutHandler implements LogoutHandlerInterface
         }
 
         $this->triggerPostLogoutHook($user);
-        $this->removeTargetPath($request->getSession(), $token->getProviderKey());
     }
 
     private function triggerPostLogoutHook(User $user): void

--- a/core-bundle/src/Security/Logout/LogoutHandler.php
+++ b/core-bundle/src/Security/Logout/LogoutHandler.php
@@ -22,9 +22,12 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Http\Logout\LogoutHandlerInterface;
+use Symfony\Component\Security\Http\Util\TargetPathTrait;
 
 class LogoutHandler implements LogoutHandlerInterface
 {
+    use TargetPathTrait;
+
     /**
      * @var ContaoFramework
      */
@@ -63,6 +66,7 @@ class LogoutHandler implements LogoutHandlerInterface
         }
 
         $this->triggerPostLogoutHook($user);
+        $this->removeTargetPath($request->getSession(), $token->getProviderKey());
     }
 
     private function triggerPostLogoutHook(User $user): void

--- a/core-bundle/tests/Security/Authentication/AuthenticationSuccessHandlerTest.php
+++ b/core-bundle/tests/Security/Authentication/AuthenticationSuccessHandlerTest.php
@@ -375,7 +375,7 @@ class AuthenticationSuccessHandlerTest extends TestCase
         $this->assertSame('http://localhost/failure', $response->getTargetUrl());
     }
 
-    public function testRemovesTheTargetPathInTheSessionOnLogin()
+    public function testRemovesTheTargetPathInTheSessionOnLogin(): void
     {
         $session = $this->createMock(SessionInterface::class);
         $session

--- a/core-bundle/tests/Security/Authentication/AuthenticationSuccessHandlerTest.php
+++ b/core-bundle/tests/Security/Authentication/AuthenticationSuccessHandlerTest.php
@@ -45,20 +45,8 @@ class AuthenticationSuccessHandlerTest extends TestCase
             '_target_path' => base64_encode('http://localhost/target'),
         ];
 
-        $session = $this->createMock(SessionInterface::class);
-        $session
-            ->expects($this->once())
-            ->method('remove')
-            ->with('_security.contao_frontend.target_path')
-        ;
-
         $request = $this->createMock(Request::class);
         $request->request = new ParameterBag($parameters);
-
-        $request
-            ->method('getSession')
-            ->willReturn($session)
-        ;
 
         /** @var BackendUser&MockObject $user */
         $user = $this->createPartialMock(BackendUser::class, ['save']);
@@ -71,17 +59,11 @@ class AuthenticationSuccessHandlerTest extends TestCase
             ->method('save')
         ;
 
-        $token = $this->createMock(UsernamePasswordToken::class);
+        $token = $this->createMock(TokenInterface::class);
         $token
             ->expects($this->once())
             ->method('getUser')
             ->willReturn($user)
-        ;
-
-        $token
-            ->expects($this->once())
-            ->method('getProviderKey')
-            ->willReturn('contao_frontend')
         ;
 
         $handler = $this->getHandler(null, $logger);
@@ -132,20 +114,8 @@ class AuthenticationSuccessHandlerTest extends TestCase
             '_target_path' => base64_encode('http://localhost/target'),
         ];
 
-        $session = $this->createMock(SessionInterface::class);
-        $session
-            ->expects($this->once())
-            ->method('remove')
-            ->with('_security.contao_frontend.target_path')
-        ;
-
         $request = $this->createMock(Request::class);
         $request->request = new ParameterBag($parameters);
-
-        $request
-            ->method('getSession')
-            ->willReturn($session)
-        ;
 
         /** @var BackendUser&MockObject $user */
         $user = $this->createPartialMock(BackendUser::class, ['save']);
@@ -158,17 +128,11 @@ class AuthenticationSuccessHandlerTest extends TestCase
             ->method('save')
         ;
 
-        $token = $this->createMock(UsernamePasswordToken::class);
+        $token = $this->createMock(TokenInterface::class);
         $token
             ->expects($this->once())
             ->method('getUser')
             ->willReturn($user)
-        ;
-
-        $token
-            ->expects($this->once())
-            ->method('getProviderKey')
-            ->willReturn('contao_frontend')
         ;
 
         $systemAdapter = $this->mockAdapter(['importStatic']);
@@ -228,35 +192,14 @@ class AuthenticationSuccessHandlerTest extends TestCase
             ->method('save')
         ;
 
-        $session = $this->createMock(SessionInterface::class);
-        $session
-            ->expects($this->once())
-            ->method('remove')
-            ->with('_security.contao_frontend.target_path')
-        ;
-
-        $request = $this->createMock(Request::class);
-        $request->request = new ParameterBag();
-
-        $request
-            ->method('getSession')
-            ->willReturn($session)
-        ;
-
-        $token = $this->createMock(UsernamePasswordToken::class);
+        $token = $this->createMock(TokenInterface::class);
         $token
             ->method('getUser')
             ->willReturn($user)
         ;
 
-        $token
-            ->expects($this->once())
-            ->method('getProviderKey')
-            ->willReturn('contao_frontend')
-        ;
-
         $handler = $this->getHandler($framework);
-        $response = $handler->onAuthenticationSuccess($request, $token);
+        $response = $handler->onAuthenticationSuccess(new Request(), $token);
 
         $this->assertSame('http://localhost/page', $response->getTargetUrl());
     }
@@ -278,20 +221,8 @@ class AuthenticationSuccessHandlerTest extends TestCase
             '_target_path' => base64_encode('http://localhost/target'),
         ];
 
-        $session = $this->createMock(SessionInterface::class);
-        $session
-            ->expects($this->once())
-            ->method('remove')
-            ->with('_security.contao_frontend.target_path')
-        ;
-
         $request = $this->createMock(Request::class);
         $request->request = new ParameterBag($parameters);
-
-        $request
-            ->method('getSession')
-            ->willReturn($session)
-        ;
 
         /** @var FrontendUser&MockObject $user */
         $user = $this->createPartialMock(FrontendUser::class, ['save']);
@@ -304,16 +235,10 @@ class AuthenticationSuccessHandlerTest extends TestCase
             ->method('save')
         ;
 
-        $token = $this->createMock(UsernamePasswordToken::class);
+        $token = $this->createMock(TokenInterface::class);
         $token
             ->method('getUser')
             ->willReturn($user)
-        ;
-
-        $token
-            ->expects($this->once())
-            ->method('getProviderKey')
-            ->willReturn('contao_frontend')
         ;
 
         $handler = $this->getHandler($framework);
@@ -322,7 +247,7 @@ class AuthenticationSuccessHandlerTest extends TestCase
         $this->assertSame('http://localhost/target', $response->getTargetUrl());
     }
 
-    public function testUsesThePostTargetPath(): void
+    public function testUsesTheTargetPath(): void
     {
         $adapter = $this->mockAdapter(['findFirstActiveByMemberGroups']);
         $adapter
@@ -337,20 +262,8 @@ class AuthenticationSuccessHandlerTest extends TestCase
             '_target_path' => base64_encode('http://localhost/target'),
         ];
 
-        $session = $this->createMock(SessionInterface::class);
-        $session
-            ->expects($this->once())
-            ->method('remove')
-            ->with('_security.contao_frontend.target_path')
-        ;
-
         $request = $this->createMock(Request::class);
         $request->request = new ParameterBag($parameters);
-
-        $request
-            ->method('getSession')
-            ->willReturn($session)
-        ;
 
         /** @var FrontendUser&MockObject $user */
         $user = $this->createPartialMock(FrontendUser::class, ['save']);
@@ -363,16 +276,10 @@ class AuthenticationSuccessHandlerTest extends TestCase
             ->method('save')
         ;
 
-        $token = $this->createMock(UsernamePasswordToken::class);
+        $token = $this->createMock(TokenInterface::class);
         $token
             ->method('getUser')
             ->willReturn($user)
-        ;
-
-        $token
-            ->expects($this->once())
-            ->method('getProviderKey')
-            ->willReturn('contao_frontend')
         ;
 
         $handler = $this->getHandler($framework);
@@ -466,6 +373,44 @@ class AuthenticationSuccessHandlerTest extends TestCase
         $response = $this->getHandler()->onAuthenticationSuccess($request, $token);
 
         $this->assertSame('http://localhost/failure', $response->getTargetUrl());
+    }
+
+    public function testRemovesTheTargetPathInTheSessionOnLogin()
+    {
+        $session = $this->createMock(SessionInterface::class);
+        $session
+            ->expects($this->once())
+            ->method('remove')
+            ->with('_security.contao_frontend.target_path')
+        ;
+
+        $request = $this->createMock(Request::class);
+        $request->request = new ParameterBag(['_target_path' => base64_encode('/')]);
+
+        $request
+            ->method('getSession')
+            ->willReturn($session)
+        ;
+
+        $request
+            ->method('hasSession')
+            ->willReturn(true)
+        ;
+
+        $token = $this->createMock(UsernamePasswordToken::class);
+        $token
+            ->expects($this->once())
+            ->method('getUser')
+            ->willReturn($this->createPartialMock(BackendUser::class, ['save']))
+        ;
+
+        $token
+            ->expects($this->once())
+            ->method('getProviderKey')
+            ->willReturn('contao_frontend')
+        ;
+
+        $this->getHandler()->onAuthenticationSuccess($request, $token);
     }
 
     /**

--- a/core-bundle/tests/Security/Authentication/AuthenticationSuccessHandlerTest.php
+++ b/core-bundle/tests/Security/Authentication/AuthenticationSuccessHandlerTest.php
@@ -26,6 +26,7 @@ use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\User\UserInterface;
 
 class AuthenticationSuccessHandlerTest extends TestCase
@@ -44,8 +45,20 @@ class AuthenticationSuccessHandlerTest extends TestCase
             '_target_path' => base64_encode('http://localhost/target'),
         ];
 
+        $session = $this->createMock(SessionInterface::class);
+        $session
+            ->expects($this->once())
+            ->method('remove')
+            ->with('_security.contao_frontend.target_path')
+        ;
+
         $request = $this->createMock(Request::class);
         $request->request = new ParameterBag($parameters);
+
+        $request
+            ->method('getSession')
+            ->willReturn($session)
+        ;
 
         /** @var BackendUser&MockObject $user */
         $user = $this->createPartialMock(BackendUser::class, ['save']);
@@ -58,11 +71,17 @@ class AuthenticationSuccessHandlerTest extends TestCase
             ->method('save')
         ;
 
-        $token = $this->createMock(TokenInterface::class);
+        $token = $this->createMock(UsernamePasswordToken::class);
         $token
             ->expects($this->once())
             ->method('getUser')
             ->willReturn($user)
+        ;
+
+        $token
+            ->expects($this->once())
+            ->method('getProviderKey')
+            ->willReturn('contao_frontend')
         ;
 
         $handler = $this->getHandler(null, $logger);
@@ -113,8 +132,20 @@ class AuthenticationSuccessHandlerTest extends TestCase
             '_target_path' => base64_encode('http://localhost/target'),
         ];
 
+        $session = $this->createMock(SessionInterface::class);
+        $session
+            ->expects($this->once())
+            ->method('remove')
+            ->with('_security.contao_frontend.target_path')
+        ;
+
         $request = $this->createMock(Request::class);
         $request->request = new ParameterBag($parameters);
+
+        $request
+            ->method('getSession')
+            ->willReturn($session)
+        ;
 
         /** @var BackendUser&MockObject $user */
         $user = $this->createPartialMock(BackendUser::class, ['save']);
@@ -127,11 +158,17 @@ class AuthenticationSuccessHandlerTest extends TestCase
             ->method('save')
         ;
 
-        $token = $this->createMock(TokenInterface::class);
+        $token = $this->createMock(UsernamePasswordToken::class);
         $token
             ->expects($this->once())
             ->method('getUser')
             ->willReturn($user)
+        ;
+
+        $token
+            ->expects($this->once())
+            ->method('getProviderKey')
+            ->willReturn('contao_frontend')
         ;
 
         $systemAdapter = $this->mockAdapter(['importStatic']);
@@ -191,14 +228,35 @@ class AuthenticationSuccessHandlerTest extends TestCase
             ->method('save')
         ;
 
-        $token = $this->createMock(TokenInterface::class);
+        $session = $this->createMock(SessionInterface::class);
+        $session
+            ->expects($this->once())
+            ->method('remove')
+            ->with('_security.contao_frontend.target_path')
+        ;
+
+        $request = $this->createMock(Request::class);
+        $request->request = new ParameterBag();
+
+        $request
+            ->method('getSession')
+            ->willReturn($session)
+        ;
+
+        $token = $this->createMock(UsernamePasswordToken::class);
         $token
             ->method('getUser')
             ->willReturn($user)
         ;
 
+        $token
+            ->expects($this->once())
+            ->method('getProviderKey')
+            ->willReturn('contao_frontend')
+        ;
+
         $handler = $this->getHandler($framework);
-        $response = $handler->onAuthenticationSuccess(new Request(), $token);
+        $response = $handler->onAuthenticationSuccess($request, $token);
 
         $this->assertSame('http://localhost/page', $response->getTargetUrl());
     }
@@ -220,8 +278,20 @@ class AuthenticationSuccessHandlerTest extends TestCase
             '_target_path' => base64_encode('http://localhost/target'),
         ];
 
+        $session = $this->createMock(SessionInterface::class);
+        $session
+            ->expects($this->once())
+            ->method('remove')
+            ->with('_security.contao_frontend.target_path')
+        ;
+
         $request = $this->createMock(Request::class);
         $request->request = new ParameterBag($parameters);
+
+        $request
+            ->method('getSession')
+            ->willReturn($session)
+        ;
 
         /** @var FrontendUser&MockObject $user */
         $user = $this->createPartialMock(FrontendUser::class, ['save']);
@@ -234,10 +304,16 @@ class AuthenticationSuccessHandlerTest extends TestCase
             ->method('save')
         ;
 
-        $token = $this->createMock(TokenInterface::class);
+        $token = $this->createMock(UsernamePasswordToken::class);
         $token
             ->method('getUser')
             ->willReturn($user)
+        ;
+
+        $token
+            ->expects($this->once())
+            ->method('getProviderKey')
+            ->willReturn('contao_frontend')
         ;
 
         $handler = $this->getHandler($framework);
@@ -246,7 +322,7 @@ class AuthenticationSuccessHandlerTest extends TestCase
         $this->assertSame('http://localhost/target', $response->getTargetUrl());
     }
 
-    public function testUsesTheTargetPath(): void
+    public function testUsesThePostTargetPath(): void
     {
         $adapter = $this->mockAdapter(['findFirstActiveByMemberGroups']);
         $adapter
@@ -261,8 +337,20 @@ class AuthenticationSuccessHandlerTest extends TestCase
             '_target_path' => base64_encode('http://localhost/target'),
         ];
 
+        $session = $this->createMock(SessionInterface::class);
+        $session
+            ->expects($this->once())
+            ->method('remove')
+            ->with('_security.contao_frontend.target_path')
+        ;
+
         $request = $this->createMock(Request::class);
         $request->request = new ParameterBag($parameters);
+
+        $request
+            ->method('getSession')
+            ->willReturn($session)
+        ;
 
         /** @var FrontendUser&MockObject $user */
         $user = $this->createPartialMock(FrontendUser::class, ['save']);
@@ -275,10 +363,16 @@ class AuthenticationSuccessHandlerTest extends TestCase
             ->method('save')
         ;
 
-        $token = $this->createMock(TokenInterface::class);
+        $token = $this->createMock(UsernamePasswordToken::class);
         $token
             ->method('getUser')
             ->willReturn($user)
+        ;
+
+        $token
+            ->expects($this->once())
+            ->method('getProviderKey')
+            ->willReturn('contao_frontend')
         ;
 
         $handler = $this->getHandler($framework);
@@ -289,22 +383,11 @@ class AuthenticationSuccessHandlerTest extends TestCase
 
     public function testReloadsIfTwoFactorAuthenticationIsEnabled(): void
     {
-        $session = $this->createMock(SessionInterface::class);
-        $session
-            ->expects($this->never())
-            ->method('set')
-        ;
-
         $request = $this->createMock(Request::class);
         $request
             ->expects($this->once())
             ->method('getUri')
             ->willReturn('http://localhost/failure')
-        ;
-
-        $request
-            ->method('getSession')
-            ->willReturn($session)
         ;
 
         /** @var FrontendUser&MockObject $user */
@@ -317,14 +400,67 @@ class AuthenticationSuccessHandlerTest extends TestCase
         /** @var TwoFactorTokenInterface&MockObject $token */
         $token = $this->createMock(TwoFactorTokenInterface::class);
         $token
-            ->method('getProviderKey')
-            ->willReturn('contao_frontend')
+            ->expects($this->once())
+            ->method('getUser')
+            ->willReturn($user)
         ;
 
+        $response = $this->getHandler()->onAuthenticationSuccess($request, $token);
+
+        $this->assertSame('http://localhost/failure', $response->getTargetUrl());
+    }
+
+    public function testStoresTheTargetPathInSessionOnTwoFactorAuthentication(): void
+    {
+        $session = $this->createMock(SessionInterface::class);
+        $session
+            ->expects($this->once())
+            ->method('set')
+            ->with('_security.contao_frontend.target_path')
+        ;
+
+        $request = $this->createMock(Request::class);
+        $request
+            ->expects($this->atLeastOnce())
+            ->method('getUri')
+            ->willReturn('http://localhost/failure')
+        ;
+
+        $request
+            ->method('getSession')
+            ->willReturn($session)
+        ;
+
+        $request
+            ->method('hasSession')
+            ->willReturn(true)
+        ;
+
+        $request
+            ->method('isMethodSafe')
+            ->willReturn(true)
+        ;
+
+        $request
+            ->method('isXmlHttpRequest')
+            ->willReturn(false)
+        ;
+
+        /** @var FrontendUser&MockObject $user */
+        $user = $this->createPartialMock(FrontendUser::class, ['save']);
+
+        /** @var TwoFactorTokenInterface&MockObject $token */
+        $token = $this->createMock(TwoFactorTokenInterface::class);
         $token
             ->expects($this->once())
             ->method('getUser')
             ->willReturn($user)
+        ;
+
+        $token
+            ->expects($this->once())
+            ->method('getProviderKey')
+            ->willReturn('contao_frontend')
         ;
 
         $response = $this->getHandler()->onAuthenticationSuccess($request, $token);

--- a/core-bundle/tests/Security/Authentication/AuthenticationSuccessHandlerTest.php
+++ b/core-bundle/tests/Security/Authentication/AuthenticationSuccessHandlerTest.php
@@ -291,9 +291,8 @@ class AuthenticationSuccessHandlerTest extends TestCase
     {
         $session = $this->createMock(SessionInterface::class);
         $session
-            ->expects($this->once())
+            ->expects($this->never())
             ->method('set')
-            ->with('_security.contao_frontend.target_path', 'http://localhost/failure')
         ;
 
         $request = $this->createMock(Request::class);
@@ -318,7 +317,6 @@ class AuthenticationSuccessHandlerTest extends TestCase
         /** @var TwoFactorTokenInterface&MockObject $token */
         $token = $this->createMock(TwoFactorTokenInterface::class);
         $token
-            ->expects($this->once())
             ->method('getProviderKey')
             ->willReturn('contao_frontend')
         ;

--- a/core-bundle/tests/Security/Logout/LogoutHandlerTest.php
+++ b/core-bundle/tests/Security/Logout/LogoutHandlerTest.php
@@ -18,9 +18,12 @@ use Contao\CoreBundle\Tests\TestCase;
 use Contao\System;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
+use Scheb\TwoFactorBundle\Security\Authentication\Token\TwoFactorTokenInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\User\UserInterface;
 
 class LogoutHandlerTest extends TestCase
@@ -122,5 +125,70 @@ class LogoutHandlerTest extends TestCase
     public function onPostLogout(): void
     {
         // Dummy method to test the postLogout hook
+    }
+
+    public function testRemovesTargetPathFromSessionWithUsernamePasswordToken()
+    {
+        $session = $this->createMock(SessionInterface::class);
+        $session
+            ->expects($this->once())
+            ->method('remove')
+            ->with('_security.contao_frontend.target_path')
+        ;
+
+        $request = $this->createMock(Request::class);
+        $request
+            ->expects($this->once())
+            ->method('getSession')
+            ->willReturn($session)
+        ;
+
+        $request
+            ->method('hasSession')
+            ->willReturn(true)
+        ;
+
+        $token = $this->createMock(UsernamePasswordToken::class);
+        $token
+            ->expects($this->once())
+            ->method('getProviderKey')
+            ->willReturn('contao_frontend')
+        ;
+
+        $handler = new LogoutHandler($this->mockContaoFramework());
+        $handler->logout($request, $this->createMock(Response::class), $token);
+    }
+
+    public function testRemovesTargetPathFromSessionWithTwoFactorToken()
+    {
+        $session = $this->createMock(SessionInterface::class);
+        $session
+            ->expects($this->once())
+            ->method('remove')
+            ->with('_security.contao_frontend.target_path')
+        ;
+
+        $request = $this->createMock(Request::class);
+        $request
+            ->expects($this->once())
+            ->method('getSession')
+            ->willReturn($session)
+        ;
+
+        $request
+            ->method('hasSession')
+            ->willReturn(true)
+        ;
+
+        /** @var TwoFactorTokenInterface&MockObject $token */
+        $token = $this->createMock(TwoFactorTokenInterface::class);
+        $token
+            ->expects($this->once())
+            ->method('getProviderKey')
+            ->willReturn('contao_frontend')
+        ;
+
+        $handler = new LogoutHandler($this->mockContaoFramework());
+        $handler->logout($request, $this->createMock(Response::class), $token);
     }
 }

--- a/core-bundle/tests/Security/Logout/LogoutHandlerTest.php
+++ b/core-bundle/tests/Security/Logout/LogoutHandlerTest.php
@@ -127,7 +127,7 @@ class LogoutHandlerTest extends TestCase
         // Dummy method to test the postLogout hook
     }
 
-    public function testRemovesTargetPathFromSessionWithUsernamePasswordToken()
+    public function testRemovesTargetPathFromSessionWithUsernamePasswordToken(): void
     {
         $session = $this->createMock(SessionInterface::class);
         $session
@@ -159,7 +159,7 @@ class LogoutHandlerTest extends TestCase
         $handler->logout($request, $this->createMock(Response::class), $token);
     }
 
-    public function testRemovesTargetPathFromSessionWithTwoFactorToken()
+    public function testRemovesTargetPathFromSessionWithTwoFactorToken(): void
     {
         $session = $this->createMock(SessionInterface::class);
         $session


### PR DESCRIPTION
The target path is stored in the session, so the front end has a fallback place to redirect the user, if he tries to navigate away in 2FA process, and no 2FA page is configured in the root page.

We need to remove the session value after successful login or if the user cancels the 2FA process (logout).