### PR TITLE
Added traits to implement legacy modules as controller

### DIFF
--- a/core-bundle/src/Resources/contao/elements/ContentControllerTrait.php
+++ b/core-bundle/src/Resources/contao/elements/ContentControllerTrait.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao;
+
+use Symfony\Component\HttpFoundation\Response;
+
+trait ContentControllerTrait
+{
+	public function __invoke(Request $request, ModuleModel $model, string $section, array $classes = null): Response
+	{
+		/* @var ContentElement $class */
+		$class = $GLOBALS['TL_CTE'][$model->type];
+
+		/* @var ContentElement $element */
+		$element = new $class($model, $section);
+
+		return new Response($element->generate());
+	}
+}

--- a/core-bundle/src/Resources/contao/elements/ContentControllerTrait.php
+++ b/core-bundle/src/Resources/contao/elements/ContentControllerTrait.php
@@ -10,18 +10,20 @@
 
 namespace Contao;
 
+use \Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 trait ContentControllerTrait
 {
+	public function __construct()
+	{
+		// Do not call parent
+	}
+
 	public function __invoke(Request $request, ModuleModel $model, string $section, array $classes = null): Response
 	{
-		/* @var ContentElement $class */
-		$class = $GLOBALS['TL_CTE'][$model->type];
+		parent::__construct($model, $section);
 
-		/* @var ContentElement $element */
-		$element = new $class($model, $section);
-
-		return new Response($element->generate());
+		return new Response($this->generate());
 	}
 }

--- a/core-bundle/src/Resources/contao/modules/ModuleControllerTrait.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleControllerTrait.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao;
+
+use Symfony\Component\HttpFoundation\Response;
+
+trait ModuleControllerTrait
+{
+	public function __invoke(Request $request, ModuleModel $model, string $section, array $classes = null): Response
+	{
+		/* @var Module $class */
+		$class = $GLOBALS['FE_MOD'][$model->type];
+
+		/* @var Module $module */
+		$module = new $class($model, $section);
+
+		return new Response($module->generate());
+	}
+}

--- a/core-bundle/src/Resources/contao/modules/ModuleControllerTrait.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleControllerTrait.php
@@ -10,18 +10,20 @@
 
 namespace Contao;
 
+use \Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 trait ModuleControllerTrait
 {
-	public function __invoke(Request $request, ModuleModel $model, string $section, array $classes = null): Response
+	public function __construct()
 	{
-		/* @var Module $class */
-		$class = $GLOBALS['FE_MOD'][$model->type];
+		// Do not call parent
+	}
 
-		/* @var Module $module */
-		$module = new $class($model, $section);
+	public function __invoke(Request $request, ModuleModel $model, string $section): Response
+	{
+		parent::__construct($model, $section);
 
-		return new Response($module->generate());
+		return new Response($this->generate());
 	}
 }


### PR DESCRIPTION
These very simple traits allow to extend Contao 3 modules/elements inside a Contao 4 fragment controller. My use case was to extend the Contao news module:

```php
/**
 * @FrontendModule(category="news")
 */
class CustomNewsController extends ModuleNewsList
{
    use ModuleControllerTrait;

    public function fetchItems(/* ... */)
    {
        // override which news models should be fetched
    }
}