### PR TITLE
Show the correct error message if a wrong 2FA token is entered

### DIFF
--- a/core-bundle/src/Security/Authentication/Provider/AuthenticationProvider.php
+++ b/core-bundle/src/Security/Authentication/Provider/AuthenticationProvider.php
@@ -169,7 +169,7 @@ class AuthenticationProvider extends DaoAuthenticationProvider
                 throw $exception;
             }
 
-            $exception = new BadCredentialsException(
+            $exception = new InvalidTwoFactorCodeException(
                 sprintf('Invalid two-factor code submitted for username "%s"', $user->username),
                 $exception->getCode(),
                 $exception

--- a/core-bundle/tests/Security/Authentication/Provider/AuthenticationProviderTest.php
+++ b/core-bundle/tests/Security/Authentication/Provider/AuthenticationProviderTest.php
@@ -125,7 +125,7 @@ class AuthenticationProviderTest extends TestCase
                 $this->assertInstanceOf(LockedException::class, $e);
                 $this->assertSame($user, $e->getUser());
             } else {
-                $this->assertInstanceOf(BadCredentialsException::class, $e);
+                $this->assertInstanceOf(InvalidTwoFactorCodeException::class, $e);
             }
 
             $hasException = true;


### PR DESCRIPTION
This fixes #1186.