### PR TITLE
Revert 'Check if reset method exists on DeferredImageStorageFilesystem'

### DIFF
--- a/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
+++ b/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
@@ -97,7 +97,6 @@ class ContaoCoreExtension extends Extension
         $this->setPredefinedImageSizes($config, $container);
         $this->setImagineService($config, $container);
         $this->overwriteImageTargetDir($config, $container);
-        $this->resetDeferredImageStorage($container);
 
         $container
             ->registerForAutoconfiguration(PickerProviderInterface::class)
@@ -264,18 +263,5 @@ class ContaoCoreExtension extends Extension
         );
 
         @trigger_error('Using the "contao.image.target_path" parameter has been deprecated and will no longer work in Contao 5.0. Use the "contao.image.target_dir" parameter instead.', E_USER_DEPRECATED);
-    }
-
-    private function resetDeferredImageStorage(ContainerBuilder $container): void
-    {
-        if (!$container->hasDefinition('contao.image.deferred_image_storage')) {
-            return;
-        }
-
-        $definition = $container->findDefinition('contao.image.deferred_image_storage');
-
-        if (method_exists($definition->getClass(), 'reset')) {
-            $definition->addTag('kernel.reset', ['method' => 'reset']);
-        }
     }
 }

--- a/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
+++ b/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
@@ -1733,21 +1733,6 @@ class ContaoCoreExtensionTest extends TestCase
             ],
             $definition->getArguments()
         );
-
-        if (method_exists($definition->getClass(), 'reset')) {
-            $this->assertSame(
-                [
-                    'kernel.reset' => [
-                        [
-                            'method' => 'reset',
-                        ],
-                    ],
-                ],
-                $definition->getTags()
-            );
-        } else {
-            $this->assertSame([], $definition->getTags());
-        }
     }
 
     public function testRegistersTheImageImagineService(): void


### PR DESCRIPTION
As discussed in Mumble on January 16th, we have to revert the changes from #1105 because https://github.com/contao/image/pull/66 will not be merged.