### PR TITLE
Fix custom response status code in Symfony 3.4

### DIFF
--- a/core-bundle/src/Controller/InitializeController.php
+++ b/core-bundle/src/Controller/InitializeController.php
@@ -106,7 +106,6 @@ class InitializeController extends Controller
             @trigger_error(sprintf('Using the X-Status-Code header is deprecated since Symfony 3.3 and will be removed in 4.0. Use %s::allowCustomResponseCode() instead.', GetResponseForExceptionEvent::class), E_USER_DEPRECATED);
 
             $response->setStatusCode($response->headers->get('X-Status-Code'));
-
             $response->headers->remove('X-Status-Code');
         } elseif (
             !$event->isAllowingCustomResponseCode()

--- a/core-bundle/src/Controller/InitializeController.php
+++ b/core-bundle/src/Controller/InitializeController.php
@@ -102,7 +102,13 @@ class InitializeController extends Controller
         $response = $event->getResponse();
 
         // The developer asked for a specific status code
-        if (
+        if ($response->headers->has('X-Status-Code')) {
+            @trigger_error(sprintf('Using the X-Status-Code header is deprecated since Symfony 3.3 and will be removed in 4.0. Use %s::allowCustomResponseCode() instead.', GetResponseForExceptionEvent::class), E_USER_DEPRECATED);
+
+            $response->setStatusCode($response->headers->get('X-Status-Code'));
+
+            $response->headers->remove('X-Status-Code');
+        } elseif (
             !$event->isAllowingCustomResponseCode()
             && !$response->isClientError()
             && !$response->isServerError()

--- a/core-bundle/src/EventListener/ResponseExceptionListener.php
+++ b/core-bundle/src/EventListener/ResponseExceptionListener.php
@@ -33,6 +33,7 @@ class ResponseExceptionListener
             return;
         }
 
+        $event->allowCustomResponseCode();
         $event->setResponse($exception->getResponse());
     }
 }

--- a/core-bundle/src/Exception/ResponseException.php
+++ b/core-bundle/src/Exception/ResponseException.php
@@ -33,10 +33,6 @@ class ResponseException extends \RuntimeException
      */
     public function __construct(Response $response, \Exception $previous = null)
     {
-        if (!$response->headers->has('X-Status-Code')) {
-            $response->headers->set('X-Status-Code', $response->getStatusCode());
-        }
-
         $this->response = $response;
 
         parent::__construct('This exception has no message. Use $exception->getResponse() instead.', 0, $previous);

--- a/core-bundle/tests/EventListener/ResponseExceptionListenerTest.php
+++ b/core-bundle/tests/EventListener/ResponseExceptionListenerTest.php
@@ -41,6 +41,7 @@ class ResponseExceptionListenerTest extends TestCase
         $listener->onKernelException($event);
 
         $this->assertTrue($event->hasResponse());
+        $this->assertTrue($event->isAllowingCustomResponseCode());
 
         $response = $event->getResponse();
 
@@ -64,5 +65,6 @@ class ResponseExceptionListenerTest extends TestCase
         $listener->onKernelException($event);
 
         $this->assertFalse($event->hasResponse());
+        $this->assertFalse($event->isAllowingCustomResponseCode());
     }
 }


### PR DESCRIPTION
in https://github.com/contao/contao/pull/525 we added *correct* exception handling for custom entry points. Unfortunately, the copied code was only valid for Symfony 4 and not Symfony 3, but Contao 4.4 is still on Symfony 3.4.

The `allowCustomResponseCode()` was already implemented in Contao 4.6 (see https://github.com/contao/contao/commit/e14fcb6fe9abb43e4cf0bf55b8d2ee82d308a305), and `X-Status-Code` has been removed in Symfony 4, so this does not need to be upstream merged.