### PR TITLE
Show preview toolbar on error pages

### DIFF
--- a/core-bundle/src/EventListener/PreviewToolbarListener.php
+++ b/core-bundle/src/EventListener/PreviewToolbarListener.php
@@ -74,7 +74,7 @@ class PreviewToolbarListener
         $response = $event->getResponse();
 
         // Do not capture redirects, errors, or modify XML HTTP Requests
-        if (!$response->isOk() || $request->isXmlHttpRequest()) {
+        if ($response->isRedirection() || $response->isServerError() || $request->isXmlHttpRequest()) {
             return;
         }
 


### PR DESCRIPTION
The preview toolbar is not present on any error page.

So in case you have a restricted webpage and the first page is a login form with HTTP code 401, not having the preview toolbar is an issue.

The preview toolbar should explicitly be available on pages with error code
- 401
- 403
- 404

I decided to allow any HTTP codes expect 300-399 (redirects) and 500-599 (server errors).