### PR TITLE
Correctly encode the DATABASE_URL parameter

### DIFF
--- a/installation-bundle/src/Config/ParameterDumper.php
+++ b/installation-bundle/src/Config/ParameterDumper.php
@@ -97,14 +97,8 @@ class ParameterDumper
         $parameters = [];
 
         foreach ($this->parameters['parameters'] as $key => $value) {
-            if (\is_string($value)) {
-                if (0 === strncmp($value, '@', 1)) {
-                    $value = '@'.$value;
-                }
-
-                if (false !== strpos($value, '%')) {
-                    $value = str_replace('%', '%%', $value);
-                }
+            if (\is_string($value) && 0 === strncmp($value, '@', 1)) {
+                $value = '@'.$value;
             }
 
             $parameters[$key] = $value;

--- a/manager-bundle/src/ContaoManager/Plugin.php
+++ b/manager-bundle/src/ContaoManager/Plugin.php
@@ -399,15 +399,15 @@ class Plugin implements BundlePluginInterface, ConfigPluginInterface, RoutingPlu
         $parameters = [];
 
         if ($user = $container->getParameter('mailer_user')) {
-            $parameters[] = 'username='.rawurlencode($user);
+            $parameters[] = 'username='.$this->encodeUrlParameter($user);
 
             if ($password = $container->getParameter('mailer_password')) {
-                $parameters[] = 'password='.rawurlencode($password);
+                $parameters[] = 'password='.$this->encodeUrlParameter($password);
             }
         }
 
         if ($encryption = $container->getParameter('mailer_encryption')) {
-            $parameters[] = 'encryption='.rawurlencode($encryption);
+            $parameters[] = 'encryption='.$this->encodeUrlParameter($encryption);
         }
 
         $qs = '';
@@ -418,7 +418,7 @@ class Plugin implements BundlePluginInterface, ConfigPluginInterface, RoutingPlu
 
         return sprintf(
             'smtp://%s:%s%s',
-            rawurlencode($container->getParameter('mailer_host')),
+            $container->getParameter('mailer_host'),
             (int) $container->getParameter('mailer_port'),
             $qs
         );

--- a/manager-bundle/src/ContaoManager/Plugin.php
+++ b/manager-bundle/src/ContaoManager/Plugin.php
@@ -385,7 +385,7 @@ class Plugin implements BundlePluginInterface, ConfigPluginInterface, RoutingPlu
             'mysql://%s%s:%s%s',
             $userPassword,
             $container->getParameter('database_host'),
-            $container->getParameter('database_port'),
+            (int) $container->getParameter('database_port'),
             $dbName
         );
     }

--- a/manager-bundle/src/ContaoManager/Plugin.php
+++ b/manager-bundle/src/ContaoManager/Plugin.php
@@ -366,10 +366,10 @@ class Plugin implements BundlePluginInterface, ConfigPluginInterface, RoutingPlu
         $userPassword = '';
 
         if ($user = $container->getParameter('database_user')) {
-            $userPassword = $user;
+            $userPassword = $this->encodeUrlParameter($user);
 
             if ($password = $container->getParameter('database_password')) {
-                $userPassword .= ':'.$password;
+                $userPassword .= ':'.$this->encodeUrlParameter($password);
             }
 
             $userPassword .= '@';
@@ -378,13 +378,13 @@ class Plugin implements BundlePluginInterface, ConfigPluginInterface, RoutingPlu
         $dbName = '';
 
         if ($name = $container->getParameter('database_name')) {
-            $dbName = '/'.$name;
+            $dbName = '/'.$this->encodeUrlParameter($name);
         }
 
         return sprintf(
             'mysql://%s%s:%s%s',
             $userPassword,
-            $container->getParameter('database_host'),
+            $this->encodeUrlParameter($container->getParameter('database_host')),
             $container->getParameter('database_port'),
             $dbName
         );
@@ -422,5 +422,10 @@ class Plugin implements BundlePluginInterface, ConfigPluginInterface, RoutingPlu
             (int) $container->getParameter('mailer_port'),
             $qs
         );
+    }
+
+    private function encodeUrlParameter(string $parameter): string
+    {
+        return str_replace('%', '%%', rawurlencode($parameter));
     }
 }

--- a/manager-bundle/src/ContaoManager/Plugin.php
+++ b/manager-bundle/src/ContaoManager/Plugin.php
@@ -384,7 +384,7 @@ class Plugin implements BundlePluginInterface, ConfigPluginInterface, RoutingPlu
         return sprintf(
             'mysql://%s%s:%s%s',
             $userPassword,
-            $this->encodeUrlParameter($container->getParameter('database_host')),
+            $container->getParameter('database_host'),
             $container->getParameter('database_port'),
             $dbName
         );

--- a/manager-bundle/tests/ContaoManager/PluginTest.php
+++ b/manager-bundle/tests/ContaoManager/PluginTest.php
@@ -571,7 +571,7 @@ class PluginTest extends ContaoTestCase
                     'connections' => [
                         'default' => [
                             'url' => '%env(DATABASE_URL)%',
-                            'password' => 'foo%%bar',
+                            'password' => '@foobar',
                         ],
                     ],
                 ],
@@ -592,8 +592,8 @@ class PluginTest extends ContaoTestCase
         $dbalConnectionFactory = function ($params) use ($connection) {
             $this->assertSame(
                 [
-                    'url' => 'mysql://root:foo%bar@localhost:3306/database',
-                    'password' => 'foo%bar',
+                    'url' => 'mysql://root:%%40foobar@localhost:3306/database',
+                    'password' => '@foobar',
                 ],
                 $params
             );
@@ -602,7 +602,7 @@ class PluginTest extends ContaoTestCase
         };
 
         $url = $_ENV['DATABASE_URL'] ?? null;
-        $_SERVER['DATABASE_URL'] = $_ENV['DATABASE_URL'] = 'mysql://root:foo%bar@localhost:3306/database';
+        $_SERVER['DATABASE_URL'] = $_ENV['DATABASE_URL'] = 'mysql://root:%%40foobar@localhost:3306/database';
 
         $plugin = new Plugin($dbalConnectionFactory);
         $plugin->getExtensionConfig('doctrine', $extensionConfigs, $container);

--- a/manager-bundle/tests/ContaoManager/PluginTest.php
+++ b/manager-bundle/tests/ContaoManager/PluginTest.php
@@ -415,6 +415,13 @@ class PluginTest extends ContaoTestCase
             'contao_test',
             'mysql://root:foobar@localhost:3306/contao_test',
         ];
+
+        yield [
+            'root',
+            'aA&3yuA?123-2ABC',
+            'contao_test',
+            'mysql://root:aA%%263yuA%%3F123-2ABC@localhost:3306/contao_test',
+        ];
     }
 
     public function testAddsTheDefaultServerVersion(): void

--- a/manager-bundle/tests/ContaoManager/PluginTest.php
+++ b/manager-bundle/tests/ContaoManager/PluginTest.php
@@ -526,7 +526,7 @@ class PluginTest extends ContaoTestCase
             null,
             25,
             null,
-            'smtp://127.0.0.1:25?username=foo%40bar.com',
+            'smtp://127.0.0.1:25?username=foo%%40bar.com',
         ];
 
         yield [
@@ -536,7 +536,7 @@ class PluginTest extends ContaoTestCase
             'foobar',
             25,
             null,
-            'smtp://127.0.0.1:25?username=foo%40bar.com&password=foobar',
+            'smtp://127.0.0.1:25?username=foo%%40bar.com&password=foobar',
         ];
 
         yield [
@@ -556,7 +556,7 @@ class PluginTest extends ContaoTestCase
             'foobar',
             587,
             'tls',
-            'smtp://127.0.0.1:587?username=foo%40bar.com&password=foobar&encryption=tls',
+            'smtp://127.0.0.1:587?username=foo%%40bar.com&password=foobar&encryption=tls',
         ];
     }
 


### PR DESCRIPTION
The install procedure fails with a special character in the database password or username.

<img width="318" alt="Screen Shot 2020-01-19 at 18 08 16" src="https://user-images.githubusercontent.com/1284725/72686048-b0bd9d00-3af0-11ea-971a-54a44a1a30a5.png">

The [Symfony docs](https://symfony.com/doc/current/doctrine.html#configuring-the-database) state:
> If the username, password, host or database name contain any character considered special in a URI (such as +, @, $, #, /, :, *, !), you must encode them. See RFC 3986 for the full list of reserved characters or use the urlencode function to encode them. In this case you need to remove the resolve: prefix in config/packages/doctrine.yaml to avoid errors: url: '%env(resolve:DATABASE_URL)%'

This PR is this issue by encoding those parameters when building the DATABASE_URL.
I am not sure if this is the correct approach though.

TODO:
- [x] tests