### PR TITLE
Set the row format in the default table options

### DIFF
--- a/core-bundle/src/Doctrine/Schema/DcaSchemaProvider.php
+++ b/core-bundle/src/Doctrine/Schema/DcaSchemaProvider.php
@@ -80,11 +80,6 @@ class DcaSchemaProvider
                 }
             }
 
-            // The default InnoDB row format before MySQL 5.7.9 is "Compact" but innodb_large_prefix requires "DYNAMIC"
-            if ($table->hasOption('engine') && 'InnoDB' === $table->getOption('engine')) {
-                $table->addOption('row_format', 'DYNAMIC');
-            }
-
             if (isset($definitions['SCHEMA_FIELDS'])) {
                 foreach ($definitions['SCHEMA_FIELDS'] as $fieldName => $config) {
                     $options = $config;

--- a/core-bundle/tests/Doctrine/Schema/DcaSchemaProviderTest.php
+++ b/core-bundle/tests/Doctrine/Schema/DcaSchemaProviderTest.php
@@ -235,7 +235,6 @@ class DcaSchemaProviderTest extends DoctrineTestCase
         $this->assertSame('InnoDB', $table->getOption('engine'));
         $this->assertSame('utf8', $table->getOption('charset'));
         $this->assertSame('utf8_unicode_ci', $table->getOption('collate'));
-        $this->assertSame('DYNAMIC', $table->getOption('row_format'));
 
         $provider = $this->getProvider(
             [],
@@ -256,7 +255,6 @@ class DcaSchemaProviderTest extends DoctrineTestCase
         $this->assertSame('InnoDB', $table->getOption('engine'));
         $this->assertSame('utf8mb4', $table->getOption('charset'));
         $this->assertSame('utf8mb4_unicode_ci', $table->getOption('collate'));
-        $this->assertSame('DYNAMIC', $table->getOption('row_format'));
 
         $provider = $this->getProvider(
             [

--- a/installation-bundle/src/Resources/views/configuration_error.html.twig
+++ b/installation-bundle/src/Resources/views/configuration_error.html.twig
@@ -28,7 +28,8 @@
         connections:
             default:
                 default_table_options:
-                    engine: MyISAM</pre>
+                    engine: MyISAM
+                    row_format: ~</pre>
       </div>
     {% elseif errorCode == 4 %}
       <p class="tl_error">{{ 'engine_mismatch'|trans }}</p>

--- a/manager-bundle/src/Resources/skeleton/config/config.yml
+++ b/manager-bundle/src/Resources/skeleton/config/config.yml
@@ -45,6 +45,7 @@ doctrine:
                     charset: utf8mb4
                     collate: utf8mb4_unicode_ci
                     engine: InnoDB
+                    row_format: DYNAMIC
                 options:
                     !php/const PDO::MYSQL_ATTR_MULTI_STATEMENTS: false
         types:


### PR DESCRIPTION
InnoDB large prefixes require the row format to be `DYNAMIC`. Older MySQL and MariaDB versions set the row format to `COMPACT` by default, which is why we dynamically change it in the `DcaSchemaProvider::appendToSchema()` method.

https://github.com/contao/contao/blob/7f092db0b74fe289da64c8153bb4de0ca87edaab/core-bundle/src/Doctrine/Schema/DcaSchemaProvider.php#L83-L86

The problem with this workaround is that it does not work for ORM entities, from which we now have four. This causes an error during DB migration:

`An exception occurred while executing 'CREATE TABLE tl_cron_job (id INT UNSIGNED AUTO_INCREMENT NOT NULL, name VARCHAR(255) NOT NULL, lastRun DATETIME NOT   
  NULL, INDEX name (name), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB': SQLSTATE[HY000]: General error: 1709 Index column size too large. The maximum column size is 767 bytes. `

This PR removes the hacky workaround and adds a configuration check in the install tool instead:

<img width="793" alt="" src="https://user-images.githubusercontent.com/1192057/72716114-f7071080-3b71-11ea-97e4-cde3d0cc5c7d.png">

If the row format is properly configured in the default table options, it works with both ORM entities and DCA tables.