### PR TITLE
Add a crawl queue maintenance job

### DIFF
--- a/core-bundle/src/Resources/contao/config/config.php
+++ b/core-bundle/src/Resources/contao/config/config.php
@@ -303,6 +303,11 @@ $GLOBALS['TL_PURGE'] = array
 		(
 			'callback' => array('Contao\Automator', 'purgeSystemLog'),
 			'affected' => array('tl_log')
+		),
+		'crawl_queue' => array
+		(
+			'callback' => array('Contao\Automator', 'purgeCrawlQueue'),
+			'affected' => array('tl_crawl_queue')
 		)
 	),
 	'folders' => array

--- a/core-bundle/src/Resources/contao/languages/en/tl_maintenance.xlf
+++ b/core-bundle/src/Resources/contao/languages/en/tl_maintenance.xlf
@@ -50,6 +50,12 @@
       <trans-unit id="tl_maintenance_jobs.log.1">
         <source>Truncates the &lt;code&gt;tl_log&lt;/code&gt; table which stores all the system log entries. This job permanently deletes these records.</source>
       </trans-unit>
+      <trans-unit id="tl_maintenance_jobs.crawl_queue.0">
+        <source>Purge the crawl queue</source>
+      </trans-unit>
+      <trans-unit id="tl_maintenance_jobs.crawl_queue.1">
+        <source>Truncates the &lt;code&gt;tl_crawl_queue&lt;/code&gt; table which stores all the queue information from crawl processes. This job permanently deletes these records.</source>
+      </trans-unit>
       <trans-unit id="tl_maintenance_jobs.images.0">
         <source>Purge the image cache</source>
       </trans-unit>

--- a/core-bundle/src/Resources/contao/library/Contao/Automator.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Automator.php
@@ -92,6 +92,20 @@ class Automator extends System
 	}
 
 	/**
+	 * Purge the crawl queue
+	 */
+	public function purgeCrawlQueue()
+	{
+		$objDatabase = Database::getInstance();
+
+		// Truncate the table
+		$objDatabase->execute("TRUNCATE TABLE tl_crawl_queue");
+
+		// Add a log entry
+		$this->log('Purged the crawl queue', __METHOD__, TL_CRON);
+	}
+
+	/**
 	 * Purge the image cache
 	 */
 	public function purgeImageCache()


### PR DESCRIPTION
I noticed that the crawl queue will grow forever. I'm not sure we should also automatically delete the data once the job is finished because that would mean reloading doesn't work?

At least with the maintenance job you can clean up things easily.