### PR TITLE
Add a "title" attribute to the debug mode menu item

### DIFF
--- a/manager-bundle/src/EventListener/BackendMenuListener.php
+++ b/manager-bundle/src/EventListener/BackendMenuListener.php
@@ -111,7 +111,7 @@ class BackendMenuListener
             ->setLabel('debug_mode')
             ->setUri($this->router->generate('contao_backend', $params))
             ->setLinkAttribute('class', 'icon-debug')
-            ->setLinkAttribute('title', $this->translator->trans('MSC.debugMode', [], 'contao_default'))
+            ->setLinkAttribute('title', $this->translator->trans('debug_mode', [], 'ContaoManagerBundle'))
             ->setExtra('translation_domain', 'ContaoManagerBundle')
         ;
 

--- a/manager-bundle/src/EventListener/BackendMenuListener.php
+++ b/manager-bundle/src/EventListener/BackendMenuListener.php
@@ -17,6 +17,7 @@ use Contao\ManagerBundle\HttpKernel\JwtManager;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Security;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * @internal
@@ -39,6 +40,11 @@ class BackendMenuListener
     private $requestStack;
 
     /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    /**
      * @var bool
      */
     private $debug;
@@ -53,11 +59,12 @@ class BackendMenuListener
      */
     private $jwtManager;
 
-    public function __construct(Security $security, RouterInterface $router, RequestStack $requestStack, bool $debug, ?string $managerPath, ?JwtManager $jwtManager)
+    public function __construct(Security $security, RouterInterface $router, RequestStack $requestStack, TranslatorInterface $translator, bool $debug, ?string $managerPath, ?JwtManager $jwtManager)
     {
         $this->security = $security;
         $this->router = $router;
         $this->requestStack = $requestStack;
+        $this->translator = $translator;
         $this->debug = $debug;
         $this->managerPath = $managerPath;
         $this->jwtManager = $jwtManager;
@@ -104,6 +111,7 @@ class BackendMenuListener
             ->setLabel('debug_mode')
             ->setUri($this->router->generate('contao_backend', $params))
             ->setLinkAttribute('class', 'icon-debug')
+            ->setLinkAttribute('title', $this->translator->trans('MSC.debugMode', [], 'contao_default'))
             ->setExtra('translation_domain', 'ContaoManagerBundle')
         ;
 

--- a/manager-bundle/src/Resources/config/listener.yml
+++ b/manager-bundle/src/Resources/config/listener.yml
@@ -5,6 +5,7 @@ services:
             - '@security.helper'
             - '@router'
             - '@request_stack'
+            - '@translator'
             - '%kernel.debug%'
             - '%contao_manager.manager_path%'
             - '@?contao_manager.jwt_manager'

--- a/manager-bundle/tests/DependencyInjection/ContaoManagerExtensionTest.php
+++ b/manager-bundle/tests/DependencyInjection/ContaoManagerExtensionTest.php
@@ -60,6 +60,7 @@ class ContaoManagerExtensionTest extends TestCase
                 new Reference('security.helper'),
                 new Reference('router'),
                 new Reference('request_stack'),
+                new Reference('translator'),
                 new Reference('%kernel.debug%'),
                 new Reference('%contao_manager.manager_path%'),
                 new Reference('contao_manager.jwt_manager', ContainerInterface::IGNORE_ON_INVALID_REFERENCE),

--- a/manager-bundle/tests/EventListener/BackendMenuListenerTest.php
+++ b/manager-bundle/tests/EventListener/BackendMenuListenerTest.php
@@ -35,9 +35,10 @@ class BackendMenuListenerTest extends ContaoTestCase
 
         $security = $this->getSecurity(false);
         $router = $this->createMock(RouterInterface::class);
+        $requestStack = new RequestStack();
         $translator = $this->getTranslator();
 
-        $listener = new BackendMenuListener($security, $router, new RequestStack(), $translator, false, null, null);
+        $listener = new BackendMenuListener($security, $router, $requestStack, $translator, false, null, null);
         $listener($event);
     }
 
@@ -179,8 +180,9 @@ class BackendMenuListenerTest extends ContaoTestCase
         $router = $this->createMock(RouterInterface::class);
         $requestStack = new RequestStack();
         $translator = $this->getTranslator();
+        $managerPath = 'contao-manager.phar.php';
 
-        $listener = new BackendMenuListener($security, $router, $requestStack, $translator, false, 'contao-manager.phar.php', null);
+        $listener = new BackendMenuListener($security, $router, $requestStack, $translator, false, $managerPath, null);
         $listener($event);
 
         $children = $event->getTree()->getChild('system')->getChildren();
@@ -228,8 +230,9 @@ class BackendMenuListenerTest extends ContaoTestCase
         $router = $this->createMock(RouterInterface::class);
         $requestStack = new RequestStack();
         $translator = $this->getTranslator();
+        $managerPath = 'contao-manager.phar.php';
 
-        $listener = new BackendMenuListener($security, $router, $requestStack, $translator, false, 'contao-manager.phar.php', null);
+        $listener = new BackendMenuListener($security, $router, $requestStack, $translator, false, $managerPath, null);
         $listener($event);
 
         $this->assertNull($event->getTree()->getChild('system'));

--- a/manager-bundle/tests/EventListener/BackendMenuListenerTest.php
+++ b/manager-bundle/tests/EventListener/BackendMenuListenerTest.php
@@ -92,7 +92,7 @@ class BackendMenuListenerTest extends ContaoTestCase
 
         $this->assertSame('debug_mode', $debug->getLabel());
         $this->assertSame('/contao?do=debug&key=enable&referer=ZG89cGFnZQ==&ref=foo', $debug->getUri());
-        $this->assertSame(['class' => 'icon-debug'], $debug->getLinkAttributes());
+        $this->assertSame(['class' => 'icon-debug', 'title' => 'debug_mode'], $debug->getLinkAttributes());
         $this->assertSame(['translation_domain' => 'ContaoManagerBundle'], $debug->getExtras());
     }
 

--- a/manager-bundle/tests/EventListener/BackendMenuListenerTest.php
+++ b/manager-bundle/tests/EventListener/BackendMenuListenerTest.php
@@ -21,6 +21,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Security;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 class BackendMenuListenerTest extends ContaoTestCase
 {
@@ -34,8 +35,9 @@ class BackendMenuListenerTest extends ContaoTestCase
 
         $security = $this->getSecurity(false);
         $router = $this->createMock(RouterInterface::class);
+        $translator = $this->getTranslator();
 
-        $listener = new BackendMenuListener($security, $router, new RequestStack(), false, null, null);
+        $listener = new BackendMenuListener($security, $router, new RequestStack(), $translator, false, null, null);
         $listener($event);
     }
 
@@ -50,6 +52,8 @@ class BackendMenuListenerTest extends ContaoTestCase
 
         $requestStack = new RequestStack();
         $requestStack->push($request);
+
+        $translator = $this->getTranslator();
 
         $params = [
             'do' => 'debug',
@@ -76,7 +80,7 @@ class BackendMenuListenerTest extends ContaoTestCase
         $jwtManager = $this->createMock(JwtManager::class);
         $security = $this->getSecurity();
 
-        $listener = new BackendMenuListener($security, $router, $requestStack, false, null, $jwtManager);
+        $listener = new BackendMenuListener($security, $router, $requestStack, $translator, false, null, $jwtManager);
         $listener($event);
 
         $children = $event->getTree()->getChildren();
@@ -109,8 +113,9 @@ class BackendMenuListenerTest extends ContaoTestCase
         $security = $this->getSecurity();
         $router = $this->createMock(RouterInterface::class);
         $requestStack = new RequestStack();
+        $translator = $this->getTranslator();
 
-        $listener = new BackendMenuListener($security, $router, $requestStack, false, null, null);
+        $listener = new BackendMenuListener($security, $router, $requestStack, $translator, false, null, null);
         $listener($event);
     }
 
@@ -131,9 +136,10 @@ class BackendMenuListenerTest extends ContaoTestCase
         $security = $this->getSecurity();
         $router = $this->createMock(RouterInterface::class);
         $requestStack = new RequestStack();
+        $translator = $this->getTranslator();
         $jwtManager = $this->createMock(JwtManager::class);
 
-        $listener = new BackendMenuListener($security, $router, $requestStack, false, null, $jwtManager);
+        $listener = new BackendMenuListener($security, $router, $requestStack, $translator, false, null, $jwtManager);
         $listener($event);
     }
 
@@ -149,9 +155,10 @@ class BackendMenuListenerTest extends ContaoTestCase
         $security = $this->getSecurity();
         $router = $this->createMock(RouterInterface::class);
         $requestStack = new RequestStack();
+        $translator = $this->getTranslator();
         $jwtManager = $this->createMock(JwtManager::class);
 
-        $listener = new BackendMenuListener($security, $router, $requestStack, false, null, $jwtManager);
+        $listener = new BackendMenuListener($security, $router, $requestStack, $translator, false, null, $jwtManager);
 
         $this->expectException('RuntimeException');
         $this->expectExceptionMessage('The request stack did not contain a request');
@@ -171,8 +178,9 @@ class BackendMenuListenerTest extends ContaoTestCase
         $security = $this->getSecurity();
         $router = $this->createMock(RouterInterface::class);
         $requestStack = new RequestStack();
+        $translator = $this->getTranslator();
 
-        $listener = new BackendMenuListener($security, $router, $requestStack, false, 'contao-manager.phar.php', null);
+        $listener = new BackendMenuListener($security, $router, $requestStack, $translator, false, 'contao-manager.phar.php', null);
         $listener($event);
 
         $children = $event->getTree()->getChild('system')->getChildren();
@@ -199,8 +207,9 @@ class BackendMenuListenerTest extends ContaoTestCase
         $security = $this->getSecurity();
         $router = $this->createMock(RouterInterface::class);
         $requestStack = new RequestStack();
+        $translator = $this->getTranslator();
 
-        $listener = new BackendMenuListener($security, $router, $requestStack, false, null, null);
+        $listener = new BackendMenuListener($security, $router, $requestStack, $translator, false, null, null);
         $listener($event);
 
         $this->assertCount(0, $event->getTree()->getChild('system')->getChildren());
@@ -218,8 +227,9 @@ class BackendMenuListenerTest extends ContaoTestCase
         $security = $this->getSecurity();
         $router = $this->createMock(RouterInterface::class);
         $requestStack = new RequestStack();
+        $translator = $this->getTranslator();
 
-        $listener = new BackendMenuListener($security, $router, $requestStack, false, 'contao-manager.phar.php', null);
+        $listener = new BackendMenuListener($security, $router, $requestStack, $translator, false, 'contao-manager.phar.php', null);
         $listener($event);
 
         $this->assertNull($event->getTree()->getChild('system'));
@@ -236,5 +246,20 @@ class BackendMenuListenerTest extends ContaoTestCase
         ;
 
         return $security;
+    }
+
+    private function getTranslator(): TranslatorInterface
+    {
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator
+            ->method('trans')
+            ->willReturnCallback(
+                static function (string $id): string {
+                    return $id;
+                }
+            )
+        ;
+
+        return $translator;
     }
 }


### PR DESCRIPTION
This adds the missing `title` attribute for the debug mode menu item.

Unit tests are failing because my [test file](https://github.com/contao/contao/pull/1230/commits/63cf466c08bbb90f0d5f7c4db1b81dacaf5987e7) needs to be revised. Could someone help me with this?