### PR TITLE
Do not use a relative font for the preview bar

### DIFF
--- a/core-bundle/src/Resources/views/Frontend/preview_toolbar_base_js.html.twig
+++ b/core-bundle/src/Resources/views/Frontend/preview_toolbar_base_js.html.twig
@@ -2,7 +2,7 @@
     .cto-toolbar {
         font-family: -apple-system,system-ui,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
         font-weight: 400;
-        font-size: .875rem;
+        font-size: 14px;
         line-height: 1;
         color: #444;
         background: #f2f2f2;


### PR DESCRIPTION
Because using a relative font size can have unintended side effects, e.g. on contao.org:

<img width="533" alt="" src="https://user-images.githubusercontent.com/1192057/73198714-cc99f200-4133-11ea-97d8-e7180b943e2b.png">
