### PR TITLE
Allow DCA filter definitions without placeholder values

### DIFF
--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -334,8 +334,15 @@ class DC_Table extends DataContainer implements \listable, \editable
 		{
 			foreach ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['filter'] as $filter)
 			{
-				$this->procedure[] = $filter[0];
-				$this->values[] = $filter[1];
+				if (\is_string($filter))
+				{
+					$this->procedure[] = $filter;
+				}
+				else
+				{
+					$this->procedure[] = $filter[0];
+					$this->values[] = $filter[1];
+				}
 			}
 		}
 
@@ -5632,8 +5639,15 @@ class DC_Table extends DataContainer implements \listable, \editable
 			{
 				foreach ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['filter'] as $fltr)
 				{
-					$arrProcedure[] = $fltr[0];
-					$arrValues[] = $fltr[1];
+					if (\is_string($fltr))
+					{
+						$arrProcedure[] = $fltr;
+					}
+					else
+					{
+						$arrProcedure[] = $fltr[0];
+						$arrValues[] = $fltr[1];
+					}
 				}
 			}
 


### PR DESCRIPTION
In a project of ours we dynamically injected a DCA filter into

```php
$GLOBALS['TL_DCA']['tl_foo']['list']['sorting']['filter']
```

via an `onload_callback`. However, in our case we wanted to add a query like this:

```sql
foo NOT IN (…)
```

Initially we added the filter like this:

```php
$GLOBALS['TL_DCA']['tl_foo']['list']['sorting']['filter'][] = ['foo NOT IN ('.implode(',', $ids).')'];
```

However, since Contao assumes that these filters are _always_ a placeholder/value pair, the placeholders and values will mismatch in the final query and thus it results in a wrong SQL query, when user defined filter is selected for example.

As a workaround we implemented it like this:

```php
$GLOBALS['TL_DCA']['tl_foo']['list']['sorting']['filter'][] = ['(foo NOT IN ('.implode(',', $ids).') AND 1=?)', 1];
```

so that there is no placeholder/value mismatch anymore. But it would be convenient (and would save some debugging time …) if one could simply define a filter without a placeholder like this:

```php
$GLOBALS['TL_DCA']['tl_foo']['list']['sorting']['filter'][] = 'foo NOT IN ('.implode(',', $ids).')';
```

This PR would allow that.