### PR TITLE
Allow underscores in the hostname in the Environment class

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Environment.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Environment.php
@@ -296,7 +296,7 @@ class Environment
 			}
 		}
 
-		return preg_replace('/[^A-Za-z0-9[\].:-]/', '', $host);
+		return preg_replace('/[^A-Za-z0-9[\].:_-]/', '', $host);
 	}
 
 	/**


### PR DESCRIPTION
Fixes #1220 