### PR TITLE
Correctly highlight phrases in the search results

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Search.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Search.php
@@ -539,7 +539,7 @@ class Search
 			// Highlight the words which matched the wildcard keywords
 			foreach ($arrWildcards as $strKeyword)
 			{
-				if ($matches = preg_grep('/'.str_replace('%', '.*', $strKeyword).'/', $arrMatches))
+				if ($matches = preg_grep('/' . str_replace('%', '.*', $strKeyword) . '/', $arrMatches))
 				{
 					$arrHighlight[$i] = array_merge($arrHighlight[$i], $matches);
 				}

--- a/core-bundle/src/Resources/contao/modules/ModuleSearch.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleSearch.php
@@ -160,8 +160,8 @@ class ModuleSearch extends \Module
 				try
 				{
 					$arrHighlight = array();
-					$objResult = \Search::searchFor($strKeywords, ($strQueryType == 'or'), $arrPages, 0, 0, $blnFuzzy, $arrHighlight);
-					$arrResult = $objResult->fetchAllAssoc();
+					$objSearch = \Search::searchFor($strKeywords, ($strQueryType == 'or'), $arrPages, 0, 0, $blnFuzzy, $arrHighlight);
+					$arrResult = $objSearch->fetchAllAssoc();
 
 					foreach (array_keys($arrResult) as $k)
 					{

--- a/core-bundle/src/Resources/contao/modules/ModuleSearch.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleSearch.php
@@ -159,7 +159,14 @@ class ModuleSearch extends \Module
 			{
 				try
 				{
-					$arrResult = \Search::searchFor($strKeywords, ($strQueryType == 'or'), $arrPages, 0, 0, $blnFuzzy);
+					$arrHighlight = array();
+					$objResult = \Search::searchFor($strKeywords, ($strQueryType == 'or'), $arrPages, 0, 0, $blnFuzzy, $arrHighlight);
+					$arrResult = $objResult->fetchAllAssoc();
+
+					foreach (array_keys($arrResult) as $k)
+					{
+						$arrResult[$k]['matches'] = implode(',', $arrHighlight[$k]);
+					}
 				}
 				catch (\Exception $e)
 				{

--- a/core-bundle/src/Resources/contao/modules/ModuleSearch.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleSearch.php
@@ -159,8 +159,7 @@ class ModuleSearch extends \Module
 			{
 				try
 				{
-					$objSearch = \Search::searchFor($strKeywords, ($strQueryType == 'or'), $arrPages, 0, 0, $blnFuzzy);
-					$arrResult = $objSearch->fetchAllAssoc();
+					$arrResult = \Search::searchFor($strKeywords, ($strQueryType == 'or'), $arrPages, 0, 0, $blnFuzzy);
 				}
 				catch (\Exception $e)
 				{


### PR DESCRIPTION
Fixes #1061 

The PR synchronizes the keywords with the matched words of each result so we can highlight phrases and wildcard matches correctly. However, I had to change the return type of the `Search::searchFor()` method to accomplish this, which is an API change (BC break).

@contao/developers Not sure what is more important in this case – remaining BC or fixing the issue?