### PR TITLE
Correctly highlight phrases in the search results (alternative)

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Database/Result.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Database/Result.php
@@ -179,6 +179,22 @@ class Result
 	}
 
 	/**
+	 * Overwrite a value in the result set
+	 *
+	 * @param string $strKey
+	 * @param mixed  $varValue
+	 */
+	public function overwrite($strKey, $varValue)
+	{
+		if (empty($this->arrCache))
+		{
+			$this->next();
+		}
+
+		$this->resultSet[$this->intIndex][$strKey] = $varValue;
+	}
+
+	/**
 	 * Fetch the current row as enumerated array
 	 *
 	 * @return array|false The row as enumerated array or false if there is no row

--- a/core-bundle/src/Resources/contao/library/Contao/Search.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Search.php
@@ -511,7 +511,53 @@ class Search
 			$objResultStmt->limit($intRows, $intOffset);
 		}
 
-		return $objResultStmt->execute($arrValues);
+		$objResult = $objResultStmt->execute($arrValues);
+
+		while ($objResult->next())
+		{
+			$arrHighlight = array();
+			$arrMatches = explode(',', $objResult->matches);
+
+			foreach ($arrKeywords as $strKeyword)
+			{
+				if (\in_array($strKeyword, $arrMatches))
+				{
+					$arrHighlight[] = $strKeyword;
+				}
+			}
+
+			foreach ($arrIncluded as $strKeyword)
+			{
+				if (\in_array($strKeyword, $arrMatches))
+				{
+					$arrHighlight[] = $strKeyword;
+				}
+			}
+
+			// Highlight the words which matched the wildcard keywords
+			foreach ($arrWildcards as $strKeyword)
+			{
+				if ($matches = preg_grep('/' . str_replace('%', '.*', $strKeyword) . '/', $arrMatches))
+				{
+					$arrHighlight = array_merge($arrHighlight, $matches);
+				}
+			}
+
+			// Highlight phrases if all their words have matched
+			foreach ($arrPhrases as $strPhrase)
+			{
+				$strPhrase = str_replace('[^[:alnum:]]+', ' ', Utf8::substr($strPhrase, 7, -7));
+
+				if (!array_diff(explode(' ', $strPhrase), $arrMatches))
+				{
+					$arrHighlight[] = $strPhrase;
+				}
+			}
+
+			$objResult->overwrite('matches', implode(',', $arrHighlight));
+		}
+
+		return $objResult;
 	}
 
 	/**


### PR DESCRIPTION
This is an alternative approach to #1270 which does not require to pass a seventh argument via reference. It adds a public `overwrite()` method to the `Contao\Database\Result` class though.

@contao/developers Please let me know which variant you prefer.