### PR TITLE
Close the cursor of the statement object after the result set has been read

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Database/Result.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Database/Result.php
@@ -36,12 +36,6 @@ use Doctrine\DBAL\Driver\Statement as DoctrineStatement;
 class Result
 {
 	/**
-	 * Database result
-	 * @var DoctrineStatement
-	 */
-	protected $resResult;
-
-	/**
 	 * Query string
 	 * @var string
 	 */
@@ -87,18 +81,10 @@ class Result
 	 */
 	public function __construct(DoctrineStatement $statement, $strQuery)
 	{
-		$this->resResult = $statement;
 		$this->strQuery = $strQuery;
 		$this->resultSet = $statement->fetchAll(\PDO::FETCH_ASSOC);
-	}
 
-	/**
-	 * Automatically free the result
-	 */
-	public function __destruct()
-	{
-		$this->resultSet = null;
-		$this->resResult->closeCursor();
+		$statement->closeCursor();
 	}
 
 	/**
@@ -155,7 +141,7 @@ class Result
 				break;
 
 			case 'numFields':
-				return $this->resResult->columnCount();
+				return \count($this->resultSet[0]);
 				break;
 
 			case 'isModified':


### PR DESCRIPTION
Since we are no longer working with the PHP resource object in the `Result` class (see https://github.com/contao/contao/pull/1274#issuecomment-581869835), it does not make sense to keep the cursor of the statement object open until the `__destruct()` method is called. We can close it right after we have read in the result set.