### PR TITLE
Don’t use fetchAll and enable initialization from array

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Database/Result.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Database/Result.php
@@ -51,7 +51,7 @@ class Result
 	 * Result set
 	 * @var array
 	 */
-	protected $resultSet = [];
+	protected $resultSet = array();
 
 	/**
 	 * Current row index
@@ -94,7 +94,8 @@ class Result
 	 */
 	public function __destruct()
 	{
-		if ($this->resResult) {
+		if ($this->resResult)
+		{
 			$this->resResult->closeCursor();
 		}
 	}
@@ -193,7 +194,8 @@ class Result
 	 */
 	public function fetchRow()
 	{
-		if ($row = $this->fetchAssoc()) {
+		if ($row = $this->fetchAssoc())
+		{
 			return array_values($row);
 		}
 
@@ -402,7 +404,7 @@ class Result
 	 */
 	private function preload($index)
 	{
-		while($this->resResult && \count($this->resultSet) <= $index)
+		while ($this->resResult && \count($this->resultSet) <= $index)
 		{
 			$row = $this->resResult->fetch(\PDO::FETCH_ASSOC);
 

--- a/core-bundle/src/Resources/contao/library/Contao/Database/Result.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Database/Result.php
@@ -174,6 +174,7 @@ class Result
 				{
 					return $this->arrModified[$strKey];
 				}
+
 				if (isset($this->resultSet[$this->intIndex][$strKey]))
 				{
 					return $this->resultSet[$this->intIndex][$strKey];
@@ -334,6 +335,7 @@ class Result
 	public function last()
 	{
 		$this->intIndex = $this->count() - 1;
+
 		$this->preload($this->intIndex);
 
 		$this->arrModified = array();

--- a/core-bundle/src/Resources/contao/library/Contao/Database/Result.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Database/Result.php
@@ -205,16 +205,11 @@ class Result
 	 */
 	public function fetchRow()
 	{
-		$this->preload($this->intIndex + 1);
-
-		if ($this->intIndex >= \count($this->resultSet) - 1)
-		{
-			return false;
+		if ($row = $this->fetchAssoc()) {
+			return array_values($row);
 		}
 
-		$this->arrCache = array_values($this->resultSet[++$this->intIndex]);
-
-		return $this->arrCache;
+		return false;
 	}
 
 	/**

--- a/core-bundle/src/Resources/contao/library/Contao/Database/Result.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Database/Result.php
@@ -80,24 +80,12 @@ class Result
 	/**
 	 * Validate the connection resource and store the query string
 	 *
-	 * @param DoctrineStatement|array $statement The database statement
-	 * @param string                  $strQuery  The query string
+	 * @param DoctrineStatement $statement The database statement
+	 * @param string            $strQuery  The query string
 	 */
-	public function __construct($statement, $strQuery)
+	public function __construct(DoctrineStatement $statement, $strQuery)
 	{
-		if ($statement instanceof DoctrineStatement)
-		{
-			$this->resResult = $statement;
-		}
-		elseif (is_array($statement) && \count(array_filter(array_map('is_array', $statement))) === \count($statement))
-		{
-			$this->resultSet = array_values($statement);
-			$this->rowCount = \count($this->resultSet);
-		}
-		else {
-			throw new \InvalidArgumentException(sprintf('$statement must be of type "%s" or an array of rows', DoctrineStatement::class));
-		}
-
+		$this->resResult = $statement;
 		$this->strQuery = $strQuery;
 	}
 

--- a/core-bundle/src/Resources/contao/library/Contao/Database/Result.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Database/Result.php
@@ -408,6 +408,12 @@ class Result
 	 */
 	private function preload($index)
 	{
+		// Optimize memory usage for single row results
+		if ($index === 0 && $this->resResult && $this->resResult->rowCount() === 1)
+		{
+			++$index;
+		}
+
 		while ($this->resResult && \count($this->resultSet) <= $index)
 		{
 			$row = $this->resResult->fetch(\PDO::FETCH_ASSOC);

--- a/core-bundle/tests/Contao/Database/ResultTest.php
+++ b/core-bundle/tests/Contao/Database/ResultTest.php
@@ -25,20 +25,17 @@ class ResultTest extends TestCase
 {
     public function testEmptyResult()
     {
-        $resultStatement = new Result(new DoctrineArrayStatement([]), 'SELECT from test');
-        $resultArray = new Result([], 'SELECT from test');
+        $result = new Result(new DoctrineArrayStatement([]), 'SELECT from test');
 
-        foreach ([$resultStatement, $resultArray] as $result) {
-            $this->assertFalse($result->isModified);
-            $this->assertSame(0, $result->numFields);
-            $this->assertSame(0, $result->numRows);
-            $this->assertSame('SELECT from test', $result->query);
-            $this->assertSame(0, $result->count());
-            $this->assertSame([], $result->fetchAllAssoc());
-            $this->assertFalse($result->fetchAssoc());
-            $this->assertSame([], $result->fetchEach('test'));
-            $this->assertFalse($result->fetchRow());
-        }
+        $this->assertFalse($result->isModified);
+        $this->assertSame(0, $result->numFields);
+        $this->assertSame(0, $result->numRows);
+        $this->assertSame('SELECT from test', $result->query);
+        $this->assertSame(0, $result->count());
+        $this->assertSame([], $result->fetchAllAssoc());
+        $this->assertFalse($result->fetchAssoc());
+        $this->assertSame([], $result->fetchEach('test'));
+        $this->assertFalse($result->fetchRow());
     }
 
     public function testMultipleRows()
@@ -48,33 +45,30 @@ class ResultTest extends TestCase
             ['field' => 'value2'],
         ];
 
-        $resultStatement = new Result(new DoctrineArrayStatement($data), 'SELECT from test');
-        $resultArray = new Result($data, 'SELECT from test');
+        $result = new Result(new DoctrineArrayStatement($data), 'SELECT from test');
 
-        foreach ([$resultStatement, $resultArray] as $result) {
-            $this->assertFalse($result->isModified);
-            $this->assertSame(1, $result->numFields);
-            $this->assertSame(2, $result->numRows);
-            $this->assertSame('SELECT from test', $result->query);
-            $this->assertSame(2, $result->count());
-            $this->assertSame($data, $result->fetchAllAssoc());
-            $this->assertSame($data[0], $result->reset()->fetchAssoc());
-            $this->assertSame($data[1], $result->fetchAssoc());
-            $this->assertSame(['value1', 'value2'], $result->fetchEach('field'));
-            $this->assertSame(array_values($data[0]), $result->reset()->fetchRow());
-            $this->assertSame(array_values($data[1]), $result->fetchRow());
-            $this->assertFalse($result->fetchRow());
+        $this->assertFalse($result->isModified);
+        $this->assertSame(1, $result->numFields);
+        $this->assertSame(2, $result->numRows);
+        $this->assertSame('SELECT from test', $result->query);
+        $this->assertSame(2, $result->count());
+        $this->assertSame($data, $result->fetchAllAssoc());
+        $this->assertSame($data[0], $result->reset()->fetchAssoc());
+        $this->assertSame($data[1], $result->fetchAssoc());
+        $this->assertSame(['value1', 'value2'], $result->fetchEach('field'));
+        $this->assertSame(array_values($data[0]), $result->reset()->fetchRow());
+        $this->assertSame(array_values($data[1]), $result->fetchRow());
+        $this->assertFalse($result->fetchRow());
 
-            $this->assertSame($data[0], $result->reset()->row());
-            $this->assertSame(array_values($data[1]), $result->last()->row(true));
+        $this->assertSame($data[0], $result->reset()->row());
+        $this->assertSame(array_values($data[1]), $result->last()->row(true));
 
-            $this->assertSame('value1', $result->first()->field);
-            $this->assertFalse($result->prev());
-            $this->assertSame('value2', $result->next()->field);
-            $this->assertSame('value1', $result->prev()->field);
-            $this->assertSame('value2', $result->last()->field);
-            $this->assertFalse($result->next());
-        }
+        $this->assertSame('value1', $result->first()->field);
+        $this->assertFalse($result->prev());
+        $this->assertSame('value2', $result->next()->field);
+        $this->assertSame('value1', $result->prev()->field);
+        $this->assertSame('value2', $result->last()->field);
+        $this->assertFalse($result->next());
     }
 
     public function testFetchRowAndAssoc()
@@ -84,41 +78,16 @@ class ResultTest extends TestCase
             ['field' => 'value2'],
         ];
 
-        $resultStatement = new Result(new DoctrineArrayStatement($data), 'SELECT from test');
-        $resultArray = new Result($data, 'SELECT from test');
+        $result = new Result(new DoctrineArrayStatement($data), 'SELECT from test');
 
-        foreach ([$resultStatement, $resultArray] as $result) {
-            $this->assertSame(['field' => 'value1'], $result->fetchAssoc());
-            $this->assertSame(['field' => 'value1'], $result->row());
-            $this->assertSame('value1', $result->field);
-            $this->assertNull($result->{'0'});
+        $this->assertSame(['field' => 'value1'], $result->fetchAssoc());
+        $this->assertSame(['field' => 'value1'], $result->row());
+        $this->assertSame('value1', $result->field);
+        $this->assertNull($result->{'0'});
 
-            $this->assertSame(['value2'], $result->fetchRow());
-            $this->assertSame(['field' => 'value2'], $result->row());
-            $this->assertSame('value2', $result->field);
-            $this->assertNull($result->{'0'});
-        }
-    }
-
-    /**
-     * @dataProvider getInvalidStatements
-     *
-     * @param mixed $statement
-     */
-    public function testInvalidStatements($statement)
-    {
-        $this->expectException(\InvalidArgumentException::class);
-
-        new Result($statement, 'SELECT from test');
-    }
-
-    public function getInvalidStatements()
-    {
-        return [
-            'String' => ['foo'],
-            'Object' => [new \stdClass()],
-            'Single Array' => [['foo' => 'bar']],
-            'Mixed Array' => [[['foo' => 'bar'], 'baz']],
-        ];
+        $this->assertSame(['value2'], $result->fetchRow());
+        $this->assertSame(['field' => 'value2'], $result->row());
+        $this->assertSame('value2', $result->field);
+        $this->assertNull($result->{'0'});
     }
 }

--- a/core-bundle/tests/Contao/Database/ResultTest.php
+++ b/core-bundle/tests/Contao/Database/ResultTest.php
@@ -94,9 +94,9 @@ class ResultTest extends TestCase
             $this->assertNull($result->{'0'});
 
             $this->assertSame(['value2'], $result->fetchRow());
-            $this->assertSame(['value2'], $result->row());
-            $this->assertSame('value2', $result->{'0'});
-            $this->assertNull($result->field);
+            $this->assertSame(['field' => 'value2'], $result->row());
+            $this->assertSame('value2', $result->field);
+            $this->assertNull($result->{'0'});
         }
     }
 

--- a/core-bundle/tests/Contao/Database/ResultTest.php
+++ b/core-bundle/tests/Contao/Database/ResultTest.php
@@ -69,6 +69,11 @@ class ResultTest extends TestCase
         $this->assertSame('value1', $result->prev()->field);
         $this->assertSame('value2', $result->last()->field);
         $this->assertFalse($result->next());
+
+        $result->field = 'new value';
+        $this->assertSame('new value', $result->field);
+        $this->assertSame(['field' => 'new value'], $result->row());
+        $this->assertSame(['new value'], $result->row(true));
     }
 
     public function testFetchRowAndAssoc()

--- a/core-bundle/tests/Contao/Database/ResultTest.php
+++ b/core-bundle/tests/Contao/Database/ResultTest.php
@@ -1,0 +1,124 @@
+<?php
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\Contao\Database;
+
+use Contao\CoreBundle\Tests\Fixtures\Database\DoctrineArrayStatement;
+use Contao\Database\Result;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests the Database Result class.
+ *
+ * @author Leo Feyer <https://github.com/leofeyer>
+ *
+ * @group contao3
+ */
+class ResultTest extends TestCase
+{
+    public function testEmptyResult()
+    {
+        $resultStatement = new Result(new DoctrineArrayStatement([]), 'SELECT from test');
+        $resultArray = new Result([], 'SELECT from test');
+
+        foreach ([$resultStatement, $resultArray] as $result) {
+            $this->assertFalse($result->isModified);
+            $this->assertSame(0, $result->numFields);
+            $this->assertSame(0, $result->numRows);
+            $this->assertSame('SELECT from test', $result->query);
+            $this->assertSame(0, $result->count());
+            $this->assertSame([], $result->fetchAllAssoc());
+            $this->assertFalse($result->fetchAssoc());
+            $this->assertSame([], $result->fetchEach('test'));
+            $this->assertFalse($result->fetchRow());
+        }
+    }
+
+    public function testMultipleRows()
+    {
+        $data = [
+            ['field' => 'value1'],
+            ['field' => 'value2'],
+        ];
+
+        $resultStatement = new Result(new DoctrineArrayStatement($data), 'SELECT from test');
+        $resultArray = new Result($data, 'SELECT from test');
+
+        foreach ([$resultStatement, $resultArray] as $result) {
+            $this->assertFalse($result->isModified);
+            $this->assertSame(1, $result->numFields);
+            $this->assertSame(2, $result->numRows);
+            $this->assertSame('SELECT from test', $result->query);
+            $this->assertSame(2, $result->count());
+            $this->assertSame($data, $result->fetchAllAssoc());
+            $this->assertSame($data[0], $result->reset()->fetchAssoc());
+            $this->assertSame($data[1], $result->fetchAssoc());
+            $this->assertSame(['value1', 'value2'], $result->fetchEach('field'));
+            $this->assertSame(array_values($data[0]), $result->reset()->fetchRow());
+            $this->assertSame(array_values($data[1]), $result->fetchRow());
+            $this->assertFalse($result->fetchRow());
+
+            $this->assertSame($data[0], $result->reset()->row());
+            $this->assertSame(array_values($data[1]), $result->last()->row(true));
+
+            $this->assertSame('value1', $result->first()->field);
+            $this->assertFalse($result->prev());
+            $this->assertSame('value2', $result->next()->field);
+            $this->assertSame('value1', $result->prev()->field);
+            $this->assertSame('value2', $result->last()->field);
+            $this->assertFalse($result->next());
+        }
+    }
+
+    public function testFetchRowAndAssoc()
+    {
+        $data = [
+            ['field' => 'value1'],
+            ['field' => 'value2'],
+        ];
+
+        $resultStatement = new Result(new DoctrineArrayStatement($data), 'SELECT from test');
+        $resultArray = new Result($data, 'SELECT from test');
+
+        foreach ([$resultStatement, $resultArray] as $result) {
+            $this->assertSame(['field' => 'value1'], $result->fetchAssoc());
+            $this->assertSame(['field' => 'value1'], $result->row());
+            $this->assertSame('value1', $result->field);
+            $this->assertNull($result->{'0'});
+
+            $this->assertSame(['value2'], $result->fetchRow());
+            $this->assertSame(['value2'], $result->row());
+            $this->assertSame('value2', $result->{'0'});
+            $this->assertNull($result->field);
+        }
+    }
+
+    /**
+     * @dataProvider getInvalidStatements
+     *
+     * @param mixed $statement
+     */
+    public function testInvalidStatements($statement)
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        new Result($statement, 'SELECT from test');
+    }
+
+    public function getInvalidStatements()
+    {
+        return [
+            'String' => ['foo'],
+            'Object' => [new \stdClass()],
+            'Single Array' => [['foo' => 'bar']],
+            'Mixed Array' => [[['foo' => 'bar'], 'baz']],
+        ];
+    }
+}

--- a/core-bundle/tests/Contao/Database/ResultTest.php
+++ b/core-bundle/tests/Contao/Database/ResultTest.php
@@ -38,6 +38,40 @@ class ResultTest extends TestCase
         $this->assertFalse($result->fetchRow());
     }
 
+    public function testSingleRow()
+    {
+        $data = [
+            ['field' => 'value1'],
+        ];
+
+        $result = new Result(new DoctrineArrayStatement($data), 'SELECT from test');
+
+        $this->assertFalse($result->isModified);
+        $this->assertSame(1, $result->numFields);
+        $this->assertSame(1, $result->numRows);
+        $this->assertSame('SELECT from test', $result->query);
+        $this->assertSame(1, $result->count());
+        $this->assertSame($data, $result->fetchAllAssoc());
+        $this->assertSame($data[0], $result->reset()->fetchAssoc());
+        $this->assertFalse($result->fetchAssoc());
+        $this->assertSame(['value1'], $result->fetchEach('field'));
+        $this->assertSame(array_values($data[0]), $result->reset()->fetchRow());
+        $this->assertFalse($result->fetchRow());
+
+        $this->assertSame($data[0], $result->reset()->row());
+        $this->assertSame(array_values($data[0]), $result->last()->row(true));
+
+        $this->assertSame('value1', $result->first()->field);
+        $this->assertFalse($result->prev());
+        $this->assertSame('value1', $result->last()->field);
+        $this->assertFalse($result->next());
+
+        $result->field = 'new value';
+        $this->assertSame('new value', $result->field);
+        $this->assertSame(['field' => 'new value'], $result->row());
+        $this->assertSame(['new value'], $result->row(true));
+    }
+
     public function testMultipleRows()
     {
         $data = [

--- a/core-bundle/tests/Fixtures/Database/DoctrineArrayStatement.php
+++ b/core-bundle/tests/Fixtures/Database/DoctrineArrayStatement.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\Fixtures\Database;
+
+use Doctrine\DBAL\Cache\ArrayStatement;
+use Doctrine\DBAL\Driver\Statement;
+use Doctrine\DBAL\ParameterType;
+
+class DoctrineArrayStatement extends ArrayStatement implements Statement
+{
+    private $rowCount;
+
+    public function __construct(array $data)
+    {
+        $this->rowCount = \count($data);
+
+        parent::__construct($data);
+    }
+
+    public function rowCount()
+    {
+        return $this->rowCount;
+    }
+
+    public function bindValue($param, $value, $type = ParameterType::STRING)
+    {
+        throw new \RuntimeException('Not implemented');
+    }
+
+    public function bindParam($column, &$variable, $type = ParameterType::STRING, $length = null)
+    {
+        throw new \RuntimeException('Not implemented');
+    }
+
+    public function errorCode()
+    {
+        throw new \RuntimeException('Not implemented');
+    }
+
+    public function errorInfo()
+    {
+        throw new \RuntimeException('Not implemented');
+    }
+
+    public function execute($params = null)
+    {
+        throw new \RuntimeException('Not implemented');
+    }
+}


### PR DESCRIPTION
This is related to https://github.com/contao/contao/pull/1274#issuecomment-581869835 an implementation of the `Result` class that doesn’t use `fetchAll` and only copies the data for used/read rows.

But I think for the use case in #1274 we should enable the initialization from an `array` instead of the `overwrite()` method. I’ve added this already to this PR.