### PR TITLE
Revert the "contao_backend_switch" route name change

### DIFF
--- a/core-bundle/src/Controller/BackendPreviewSwitchController.php
+++ b/core-bundle/src/Controller/BackendPreviewSwitchController.php
@@ -93,7 +93,7 @@ class BackendPreviewSwitchController
     }
 
     /**
-     * @Route("/contao/preview_switch", name="contao_backend_preview_switch")
+     * @Route("/contao/preview_switch", name="contao_backend_switch")
      */
     public function __invoke(Request $request): Response
     {
@@ -133,7 +133,7 @@ class BackendPreviewSwitchController
                 '@ContaoCore/Frontend/preview_toolbar_base.html.twig',
                 [
                     'request_token' => $this->tokenManager->getToken($this->csrfTokenName)->getValue(),
-                    'action' => $this->router->generate('contao_backend_preview_switch'),
+                    'action' => $this->router->generate('contao_backend_switch'),
                     'canSwitchUser' => $canSwitchUser,
                     'user' => $frontendUsername,
                     'show' => $showUnpublished,

--- a/core-bundle/src/EventListener/PreviewToolbarListener.php
+++ b/core-bundle/src/EventListener/PreviewToolbarListener.php
@@ -105,7 +105,7 @@ class PreviewToolbarListener
         $toolbar = $this->twig->render(
             '@ContaoCore/Frontend/preview_toolbar_base_js.html.twig',
             [
-                'action' => $this->router->generate('contao_backend_preview_switch'),
+                'action' => $this->router->generate('contao_backend_switch'),
                 'request' => $request,
             ]
         );

--- a/core-bundle/tests/Controller/BackendPreviewSwitchControllerTest.php
+++ b/core-bundle/tests/Controller/BackendPreviewSwitchControllerTest.php
@@ -161,7 +161,7 @@ class BackendPreviewSwitchControllerTest extends TestCase
         $router = $this->createMock(RouterInterface::class);
         $router
             ->method('generate')
-            ->with('contao_backend_preview_switch')
+            ->with('contao_backend_switch')
             ->willReturn('/contao/preview_switch')
         ;
 

--- a/core-bundle/tests/EventListener/PreviewToolbarListenerTest.php
+++ b/core-bundle/tests/EventListener/PreviewToolbarListenerTest.php
@@ -376,7 +376,7 @@ class PreviewToolbarListenerTest extends TestCase
     /**
      * @return RouterInterface&MockObject
      */
-    private function mockRouterWithContext(array $expectedParameters = [], string $expectedRoute = 'contao_backend_preview_switch', int $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH): RouterInterface
+    private function mockRouterWithContext(array $expectedParameters = [], string $expectedRoute = 'contao_backend_switch', int $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH): RouterInterface
     {
         $router = $this->createMock(RouterInterface::class);
         $router


### PR DESCRIPTION
See #1277 