### PR TITLE
[POC] Refactored TrustedDeviceManager to fix issue with current trusted device

### DIFF
--- a/core-bundle/src/Controller/FrontendModule/TwoFactorController.php
+++ b/core-bundle/src/Controller/FrontendModule/TwoFactorController.php
@@ -86,6 +86,9 @@ class TwoFactorController extends AbstractFrontendModuleController
         /** @var PageModel $adapter */
         $adapter = $this->get('contao.framework')->getAdapter(PageModel::class);
 
+        /** @var TrustedDeviceManager $trustedDeviceManager */
+        $trustedDeviceManager = $this->get('contao.security.two_factor.trusted_device_manager');
+
         $redirectPage = $model->jumpTo > 0 ? $adapter->findByPk($model->jumpTo) : null;
         $return = $redirectPage instanceof PageModel ? $redirectPage->getAbsoluteUrl() : $this->page->getAbsoluteUrl();
 
@@ -130,14 +133,14 @@ class TwoFactorController extends AbstractFrontendModuleController
         }
 
         if ('tl_two_factor_clear_trusted_devices' === $request->request->get('FORM_SUBMIT')) {
-            $this->get('contao.security.two_factor.trusted_device_manager')->clearTrustedDevices($user);
+            $trustedDeviceManager->clearTrustedDevices($user);
         }
 
         $template->isEnabled = (bool) $user->useTwoFactor;
         $template->href = $this->page->getAbsoluteUrl().'?2fa=enable';
         $template->backupCodes = json_decode((string) $user->backupCodes, true) ?? [];
-        $template->trustedDevices = $this->get('contao.security.two_factor.trusted_device_manager')->getTrustedDevices($user);
-        $template->currentDevice = $request->cookies->get($this->getParameter('scheb_two_factor.trusted_device.cookie_name'));
+        $template->trustedDevices = $trustedDeviceManager->getTrustedDevices($user);
+        $template->currentDevice = $trustedDeviceManager->getCurrentTrustedDevice($user);
 
         return new Response($template->parse());
     }

--- a/core-bundle/src/Entity/TrustedDevice.php
+++ b/core-bundle/src/Entity/TrustedDevice.php
@@ -52,9 +52,9 @@ class TrustedDevice
     protected $userId;
 
     /**
-     * @var string
+     * @var string|null
      *
-     * @ORM\Column(type="text", name="cookie_value")
+     * @ORM\Column(type="text", name="cookie_value", nullable=true)
      */
     protected $cookieValue;
 
@@ -135,7 +135,7 @@ class TrustedDevice
         return $this->cookieValue;
     }
 
-    public function setCookieValue(string $cookieValue): self
+    public function setCookieValue(?string $cookieValue): self
     {
         $this->cookieValue = $cookieValue;
 

--- a/core-bundle/src/Resources/config/services.yml
+++ b/core-bundle/src/Resources/config/services.yml
@@ -722,6 +722,8 @@ services:
             - '@request_stack'
             - '@scheb_two_factor.trusted_token_storage'
             - '@doctrine.orm.entity_manager'
+            - '@scheb_two_factor.trusted_jwt_encoder'
+            - '@security.firewall.map'
         public: true
 
     contao.security.user_checker:

--- a/core-bundle/src/Resources/contao/library/Contao/Template.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Template.php
@@ -56,7 +56,7 @@ use Symfony\Component\VarDumper\VarDumper;
  * @property array        $backupCodes
  * @property boolean      $trustedDevicesEnabled
  * @property array        $trustedDevices
- * @property string       $currentDevice
+ * @property object       $currentDevice
  *
  * @author Leo Feyer <https://github.com/leofeyer>
  */

--- a/core-bundle/src/Resources/contao/templates/backend/be_two_factor.html5
+++ b/core-bundle/src/Resources/contao/templates/backend/be_two_factor.html5
@@ -88,7 +88,7 @@
             </tr>
             <?php foreach ($this->trustedDevices as $index => $trustedDevice): ?>
               <tr class="<?= $index % 2 ? 'odd' : 'even' ?> hover-row">
-                <td class="tl_file_list"><?= $trustedDevice->getDeviceFamily() ?><?php if ($this->currentDevice === $trustedDevice->getCookieValue()): ?> (<?= $this->trans('MSC.thisDevice') ?>)<?php endif; ?></td>
+                <td class="tl_file_list"><?= $trustedDevice->getDeviceFamily() ?><?php if ($this->currentDevice === $trustedDevice): ?> (<?= $this->trans('MSC.thisDevice') ?>)<?php endif; ?></td>
                 <td class="tl_file_list"><?= $trustedDevice->getUaFamily() ?></td>
                 <td class="tl_file_list"><?= $trustedDevice->getOsFamily() ?></td>
                 <td class="tl_file_list"><?= $trustedDevice->getCreated()->format(Contao\Config::get('datimFormat')) ?></td>

--- a/core-bundle/src/Resources/contao/templates/modules/mod_two_factor.html5
+++ b/core-bundle/src/Resources/contao/templates/modules/mod_two_factor.html5
@@ -92,7 +92,7 @@
             </tr>
             <?php foreach ($this->trustedDevices as $trustedDevice): ?>
               <tr>
-                <td><?= $trustedDevice->getDeviceFamily() ?><?php if ($this->currentDevice === $trustedDevice->getCookieValue()): ?> (<?= $this->trans('MSC.thisDevice') ?>)<?php endif; ?></td>
+                <td><?= $trustedDevice->getDeviceFamily() ?><?php if ($this->currentDevice === $trustedDevice): ?> (<?= $this->trans('MSC.thisDevice') ?>)<?php endif; ?></td>
                 <td><?= $trustedDevice->getUaFamily() ?></td>
                 <td><?= $trustedDevice->getOsFamily() ?></td>
                 <td><?= $trustedDevice->getCreated()->format(Contao\Config::get('datimFormat')) ?></td>

--- a/core-bundle/tests/Security/TwoFactor/TrustedDeviceManagerTest.php
+++ b/core-bundle/tests/Security/TwoFactor/TrustedDeviceManagerTest.php
@@ -16,7 +16,9 @@ use Contao\BackendUser;
 use Contao\CoreBundle\Security\TwoFactor\TrustedDeviceManager;
 use Contao\CoreBundle\Tests\TestCase;
 use Doctrine\ORM\EntityManagerInterface;
+use Scheb\TwoFactorBundle\Security\TwoFactor\Trusted\JwtTokenEncoder;
 use Scheb\TwoFactorBundle\Security\TwoFactor\Trusted\TrustedDeviceTokenStorage;
+use Symfony\Bundle\SecurityBundle\Security\FirewallMap;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Security\Core\User\UserInterface;
 
@@ -40,7 +42,9 @@ class TrustedDeviceManagerTest extends TestCase
         $manager = new TrustedDeviceManager(
             $this->createMock(RequestStack::class),
             $tokenStorage,
-            $this->createMock(EntityManagerInterface::class)
+            $this->createMock(EntityManagerInterface::class),
+            $this->createMock(JwtTokenEncoder::class),
+            $this->createMock(FirewallMap::class)
         );
 
         $this->assertTrue($manager->isTrustedDevice($user, 'contao_backend'));
@@ -57,7 +61,9 @@ class TrustedDeviceManagerTest extends TestCase
         $manager = new TrustedDeviceManager(
             $this->createMock(RequestStack::class),
             $tokenStorage,
-            $this->createMock(EntityManagerInterface::class)
+            $this->createMock(EntityManagerInterface::class),
+            $this->createMock(JwtTokenEncoder::class),
+            $this->createMock(FirewallMap::class)
         );
 
         $this->assertFalse($manager->isTrustedDevice($this->createMock(UserInterface::class), 'contao_backend'));


### PR DESCRIPTION
This would be the ugly fix for #1285.

It actually tries to store only the serialized token value in the database and not the whole cookie from the `TrustedDeviceTokenStorage`.