### PR TITLE
Fix the initial table sorting in the "table" content element

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "contao-components/respimage": "^1.4",
         "contao-components/simplemodal": "^2.0.3",
         "contao-components/swipe": "^2.0.3",
-        "contao-components/tablesort": "^3.4.5",
+        "contao-components/tablesort": "^4.0",
         "contao-components/tablesorter": "^2.0.5.3",
         "contao-components/tinymce4": "4.6.*",
         "contao/image": "^0.3.1",

--- a/core-bundle/composer.json
+++ b/core-bundle/composer.json
@@ -36,7 +36,7 @@
         "contao-components/respimage": "^1.4",
         "contao-components/simplemodal": "^2.0.3",
         "contao-components/swipe": "^2.0.3",
-        "contao-components/tablesort": "^3.4.5",
+        "contao-components/tablesort": "^4.0",
         "contao-components/tablesorter": "^2.0.5.3",
         "contao-components/tinymce4": "4.6.*",
         "contao/image": "^0.3.1",

--- a/core-bundle/src/Resources/contao/elements/ContentTable.php
+++ b/core-bundle/src/Resources/contao/elements/ContentTable.php
@@ -37,6 +37,11 @@ class ContentTable extends \ContentElement
 		$this->Template->useLeftTh = $this->tleft ? true : false;
 		$this->Template->sortable = $this->sortable ? true : false;
 
+		if ($this->sortable)
+		{
+			$this->Template->sortDefault = $this->sortIndex . '|' . ($this->sortOrder == 'descending' ? 'desc' : 'asc');
+		}
+
 		$arrHeader = array();
 		$arrBody = array();
 		$arrFooter = array();
@@ -46,19 +51,6 @@ class ContentTable extends \ContentElement
 		{
 			foreach ($rows[0] as $i=>$v)
 			{
-				// Set table sort cookie
-				if ($this->sortable && $i == $this->sortIndex)
-				{
-					$co = 'TS_TABLE_' . $this->id;
-					$so = ($this->sortOrder == 'descending') ? 'desc' : 'asc';
-
-					if (\Input::cookie($co) == '')
-					{
-						\System::setCookie($co, $i . '|' . $so, 0);
-					}
-				}
-
-				// Add cell
 				$arrHeader[] = array
 				(
 					'class' => 'head_' . $i . (($i == 0) ? ' col_first' : '') . (($i == (\count($rows[0]) - 1)) ? ' col_last' : '') . (($i == 0 && $this->tleft) ? ' unsortable' : ''),

--- a/core-bundle/src/Resources/contao/templates/elements/ce_table.html5
+++ b/core-bundle/src/Resources/contao/templates/elements/ce_table.html5
@@ -2,9 +2,9 @@
 
 <?php $this->block('content'); ?>
 
-  <table id="<?= $this->id ?>"<?php if ($this->sortable): ?> class="sortable"<?php endif; ?>>
+  <table id="<?= $this->id ?>"<?php if ($this->sortable): ?> class="sortable" data-sort-default="<?= $this->sortDefault ?>"<?php endif; ?>>
 
-    <?php if ($this->summary != ''): ?>
+    <?php if ($this->summary): ?>
       <caption><?= $this->summary ?></caption>
     <?php endif; ?>
 

--- a/core-bundle/src/Resources/contao/templates/jquery/j_tablesort.html5
+++ b/core-bundle/src/Resources/contao/templates/jquery/j_tablesort.html5
@@ -9,7 +9,15 @@ $GLOBALS['TL_CSS'][] = 'assets/tablesorter/css/tablesorter.min.css|static';
 <script>
   jQuery(function($) {
     $('.ce_table .sortable').each(function(i, table) {
-      $(table).tablesorter();
+      var attr = $(table).attr('data-sort-default'),
+          opts = {}, s;
+
+      if (attr) {
+        s = attr.split('|');
+        opts = { sortList: [[s[0], s[1] == 'desc' | 0]] };
+      }
+
+      $(table).tablesorter(opts);
     });
   });
 </script>


### PR DESCRIPTION
Fixes #1278 

The PR backports the changes from 4a8be779e885f51ae95d49b0d477a22b19c0f440 and adjusts the `j_tablesort.html5` template accordingly.