### PR TITLE
Correctly highlight phrases in the search results

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Database/Result.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Database/Result.php
@@ -74,12 +74,25 @@ class Result
 	/**
 	 * Validate the connection resource and store the query string
 	 *
-	 * @param DoctrineStatement $statement The database statement
-	 * @param string            $strQuery  The query string
+	 * @param DoctrineStatement|array $statement The database statement
+	 * @param string                  $strQuery  The query string
 	 */
-	public function __construct(DoctrineStatement $statement, $strQuery)
+	public function __construct($statement, $strQuery)
 	{
-		$this->resResult = $statement;
+		if ($statement instanceof DoctrineStatement)
+		{
+			$this->resResult = $statement;
+		}
+		elseif (\is_array($statement) && \count(array_filter(array_map('is_array', $statement))) === \count($statement))
+		{
+			$this->resultSet = array_values($statement);
+			$this->rowCount = \count($this->resultSet);
+		}
+		else
+		{
+			throw new \InvalidArgumentException('$statement must be a Statement object or an array');
+		}
+
 		$this->strQuery = $strQuery;
 	}
 

--- a/core-bundle/src/Resources/contao/library/Contao/Database/Result.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Database/Result.php
@@ -51,7 +51,7 @@ class Result
 	 * Result set
 	 * @var array
 	 */
-	protected $resultSet;
+	protected $resultSet = array();
 
 	/**
 	 * Current row index
@@ -60,36 +60,27 @@ class Result
 	private $intIndex = -1;
 
 	/**
-	 * End indicator
-	 * @var boolean
+	 * Number of rows
+	 * @var integer
 	 */
-	private $blnDone = false;
+	private $rowCount;
 
 	/**
-	 * Modification indicator
-	 * @var boolean
-	 */
-	private $blnModified = false;
-
-	/**
-	 * Result cache
+	 * Modified values of current row
 	 * @var array
 	 */
-	protected $arrCache = array();
+	private $arrModified = array();
 
 	/**
 	 * Validate the connection resource and store the query string
 	 *
 	 * @param DoctrineStatement $statement The database statement
 	 * @param string            $strQuery  The query string
-	 *
-	 * @todo Try to find a solution that works without fetchAll().
 	 */
 	public function __construct(DoctrineStatement $statement, $strQuery)
 	{
 		$this->resResult = $statement;
 		$this->strQuery = $strQuery;
-		$this->resultSet = $statement->fetchAll(\PDO::FETCH_ASSOC);
 	}
 
 	/**
@@ -97,8 +88,10 @@ class Result
 	 */
 	public function __destruct()
 	{
-		$this->resultSet = null;
-		$this->resResult->closeCursor();
+		if ($this->resResult)
+		{
+			$this->resResult->closeCursor();
+		}
 	}
 
 	/**
@@ -109,13 +102,12 @@ class Result
 	 */
 	public function __set($strKey, $varValue)
 	{
-		if (empty($this->arrCache))
+		if ($this->intIndex === -1)
 		{
 			$this->next();
 		}
 
-		$this->blnModified = true;
-		$this->arrCache[$strKey] = $varValue;
+		$this->arrModified[$strKey] = $varValue;
 	}
 
 	/**
@@ -127,12 +119,12 @@ class Result
 	 */
 	public function __isset($strKey)
 	{
-		if (empty($this->arrCache))
+		if ($this->intIndex === -1)
 		{
 			$this->next();
 		}
 
-		return isset($this->arrCache[$strKey]);
+		return isset($this->resultSet[$this->intIndex][$strKey]) || isset($this->arrModified[$strKey]);
 	}
 
 	/**
@@ -153,22 +145,36 @@ class Result
 				return $this->count();
 
 			case 'numFields':
-				return $this->resResult->columnCount();
+				if ($this->resResult)
+				{
+					return $this->resResult->columnCount();
+				}
+
+				if (isset($this->resultSet[0]))
+				{
+					return \count($this->resultSet[0]);
+				}
+
+				return 0;
 
 			case 'isModified':
-				return $this->blnModified;
+				return \count($this->arrModified) !== 0;
 
 			default:
-				if (empty($this->arrCache))
+				if ($this->intIndex === -1)
 				{
 					$this->next();
 				}
 
-				if (isset($this->arrCache[$strKey]))
+				if (isset($this->arrModified[$strKey]))
 				{
-					return $this->arrCache[$strKey];
+					return $this->arrModified[$strKey];
 				}
-				break;
+
+				if (isset($this->resultSet[$this->intIndex][$strKey]))
+				{
+					return $this->resultSet[$this->intIndex][$strKey];
+				}
 		}
 
 		return null;
@@ -181,14 +187,12 @@ class Result
 	 */
 	public function fetchRow()
 	{
-		if ($this->intIndex >= $this->count() - 1)
+		if ($row = $this->fetchAssoc())
 		{
-			return false;
+			return array_values($row);
 		}
 
-		$this->arrCache = array_values($this->resultSet[++$this->intIndex]);
-
-		return $this->arrCache;
+		return false;
 	}
 
 	/**
@@ -198,14 +202,16 @@ class Result
 	 */
 	public function fetchAssoc()
 	{
-		if ($this->intIndex >= $this->count() - 1)
+		$this->preload($this->intIndex + 1);
+
+		if ($this->intIndex >= \count($this->resultSet) - 1)
 		{
 			return false;
 		}
 
-		$this->arrCache = $this->resultSet[++$this->intIndex];
+		$this->arrModified = array();
 
-		return $this->arrCache;
+		return $this->resultSet[++$this->intIndex];
 	}
 
 	/**
@@ -275,9 +281,9 @@ class Result
 	public function first()
 	{
 		$this->intIndex = 0;
+		$this->preload(0);
 
-		$this->blnDone = false;
-		$this->arrCache = $this->resultSet[$this->intIndex];
+		$this->arrModified = array();
 
 		return $this;
 	}
@@ -294,8 +300,9 @@ class Result
 			return false;
 		}
 
-		$this->blnDone = false;
-		$this->arrCache = $this->resultSet[--$this->intIndex];
+		$this->preload(--$this->intIndex);
+
+		$this->arrModified = array();
 
 		return $this;
 	}
@@ -307,17 +314,10 @@ class Result
 	 */
 	public function next()
 	{
-		if ($this->blnDone)
-		{
-			return false;
-		}
-
 		if ($this->fetchAssoc() !== false)
 		{
 			return $this;
 		}
-
-		$this->blnDone = true;
 
 		return false;
 	}
@@ -331,8 +331,9 @@ class Result
 	{
 		$this->intIndex = $this->count() - 1;
 
-		$this->blnDone = true;
-		$this->arrCache = $this->resultSet[$this->intIndex];
+		$this->preload($this->intIndex);
+
+		$this->arrModified = array();
 
 		return $this;
 	}
@@ -344,7 +345,19 @@ class Result
 	 */
 	public function count()
 	{
-		return \count($this->resultSet);
+		if ($this->rowCount === null)
+		{
+			$this->rowCount = $this->resResult->rowCount();
+
+			// rowCount() might incorrectly return 0 for some platforms
+			if ($this->rowCount < 1)
+			{
+				$this->preload(PHP_INT_MAX);
+				$this->rowCount = \count($this->resultSet);
+			}
+		}
+
+		return $this->rowCount;
 	}
 
 	/**
@@ -356,12 +369,19 @@ class Result
 	 */
 	public function row($blnEnumerated=false)
 	{
-		if (empty($this->arrCache))
+		if ($this->intIndex === -1)
 		{
 			$this->next();
 		}
 
-		return $blnEnumerated ? array_values($this->arrCache) : $this->arrCache;
+		if (!$this->isModified)
+		{
+			return $blnEnumerated ? array_values($this->resultSet[$this->intIndex]) : $this->resultSet[$this->intIndex];
+		}
+
+		$row = array_merge($this->resultSet[$this->intIndex], $this->arrModified);
+
+		return $blnEnumerated ? array_values($row) : $row;
 	}
 
 	/**
@@ -372,10 +392,39 @@ class Result
 	public function reset()
 	{
 		$this->intIndex = -1;
-		$this->blnDone = false;
-		$this->arrCache = array();
+		$this->arrModified = array();
 
 		return $this;
+	}
+
+	/**
+	 * Preload all rows up to the specified index from the underlying statement
+	 * and store them in the resultSet array.
+	 *
+	 * @param int $index
+	 */
+	private function preload($index)
+	{
+		// Optimize memory usage for single row results
+		if ($index === 0 && $this->resResult && $this->resResult->rowCount() === 1)
+		{
+			++$index;
+		}
+
+		while ($this->resResult && \count($this->resultSet) <= $index)
+		{
+			$row = $this->resResult->fetch(\PDO::FETCH_ASSOC);
+
+			if ($row === false)
+			{
+				$this->rowCount = \count($this->resultSet);
+				$this->resResult->closeCursor();
+				$this->resResult = null;
+				break;
+			}
+
+			$this->resultSet[] = $row;
+		}
 	}
 }
 

--- a/core-bundle/src/Resources/contao/library/Contao/Search.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Search.php
@@ -526,49 +526,49 @@ class Search
 
 		foreach ($arrResult as $k=>$v)
 		{
- 			$arrHighlight = array();
- 			$arrMatches = explode(',', $v['matches']);
+			$arrHighlight = array();
+			$arrMatches = explode(',', $v['matches']);
 
- 			foreach ($arrKeywords as $strKeyword)
- 			{
- 				if (\in_array($strKeyword, $arrMatches))
- 				{
- 					$arrHighlight[] = $strKeyword;
- 				}
- 			}
+			foreach ($arrKeywords as $strKeyword)
+			{
+				if (\in_array($strKeyword, $arrMatches))
+				{
+					$arrHighlight[] = $strKeyword;
+				}
+			}
 
- 			foreach ($arrIncluded as $strKeyword)
- 			{
- 				if (\in_array($strKeyword, $arrMatches))
- 				{
- 					$arrHighlight[] = $strKeyword;
- 				}
- 			}
+			foreach ($arrIncluded as $strKeyword)
+			{
+				if (\in_array($strKeyword, $arrMatches))
+				{
+					$arrHighlight[] = $strKeyword;
+				}
+			}
 
- 			// Highlight the words which matched the wildcard keywords
- 			foreach ($arrWildcards as $strKeyword)
- 			{
- 				if ($matches = preg_grep('/' . str_replace('%', '.*', $strKeyword) . '/', $arrMatches))
- 				{
- 					$arrHighlight = array_merge($arrHighlight, $matches);
- 				}
- 			}
+			// Highlight the words which matched the wildcard keywords
+			foreach ($arrWildcards as $strKeyword)
+			{
+				if ($matches = preg_grep('/' . str_replace('%', '.*', $strKeyword) . '/', $arrMatches))
+				{
+					$arrHighlight = array_merge($arrHighlight, $matches);
+				}
+			}
 
- 			// Highlight phrases if all their words have matched
- 			foreach ($arrPhrases as $strPhrase)
- 			{
- 				$strPhrase = str_replace('[^[:alnum:]]+', ' ', $strPhrase);
+			// Highlight phrases if all their words have matched
+			foreach ($arrPhrases as $strPhrase)
+			{
+				$strPhrase = str_replace('[^[:alnum:]]+', ' ', $strPhrase);
 
- 				if (!array_diff(explode(' ', $strPhrase), $arrMatches))
- 				{
- 					$arrHighlight[] = $strPhrase;
- 				}
- 			}
+				if (!array_diff(explode(' ', $strPhrase), $arrMatches))
+				{
+					$arrHighlight[] = $strPhrase;
+				}
+			}
 
- 			$arrResult[$k]['matches'] = implode(',', $arrHighlight);
+			$arrResult[$k]['matches'] = implode(',', $arrHighlight);
 		}
 
- 		return new Result($arrResult, $objResult->query);
+		return new Result($arrResult, $objResult->query);
 	}
 
 	/**

--- a/core-bundle/src/Resources/contao/library/Contao/Search.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Search.php
@@ -521,7 +521,54 @@ class Search
 			$objResultStmt->limit($intRows, $intOffset);
 		}
 
-		return $objResultStmt->execute($arrValues);
+		$objResult = $objResultStmt->execute($arrValues);
+		$arrResult = $objResult->fetchAllAssoc();
+
+		foreach ($arrResult as $k=>$v)
+		{
+ 			$arrHighlight = array();
+ 			$arrMatches = explode(',', $v['matches']);
+
+ 			foreach ($arrKeywords as $strKeyword)
+ 			{
+ 				if (\in_array($strKeyword, $arrMatches))
+ 				{
+ 					$arrHighlight[] = $strKeyword;
+ 				}
+ 			}
+
+ 			foreach ($arrIncluded as $strKeyword)
+ 			{
+ 				if (\in_array($strKeyword, $arrMatches))
+ 				{
+ 					$arrHighlight[] = $strKeyword;
+ 				}
+ 			}
+
+ 			// Highlight the words which matched the wildcard keywords
+ 			foreach ($arrWildcards as $strKeyword)
+ 			{
+ 				if ($matches = preg_grep('/' . str_replace('%', '.*', $strKeyword) . '/', $arrMatches))
+ 				{
+ 					$arrHighlight = array_merge($arrHighlight, $matches);
+ 				}
+ 			}
+
+ 			// Highlight phrases if all their words have matched
+ 			foreach ($arrPhrases as $strPhrase)
+ 			{
+ 				$strPhrase = str_replace('[^[:alnum:]]+', ' ', $strPhrase);
+
+ 				if (!array_diff(explode(' ', $strPhrase), $arrMatches))
+ 				{
+ 					$arrHighlight[] = $strPhrase;
+ 				}
+ 			}
+
+ 			$arrResult[$k]['matches'] = implode(',', $arrHighlight);
+		}
+
+ 		return new Result($arrResult, $objResult->query);
 	}
 
 	/**

--- a/core-bundle/tests/Contao/Database/ResultTest.php
+++ b/core-bundle/tests/Contao/Database/ResultTest.php
@@ -1,0 +1,132 @@
+<?php
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\Contao\Database;
+
+use Contao\CoreBundle\Tests\Fixtures\Database\DoctrineArrayStatement;
+use Contao\Database\Result;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests the Database Result class.
+ *
+ * @author Leo Feyer <https://github.com/leofeyer>
+ *
+ * @group contao3
+ */
+class ResultTest extends TestCase
+{
+    public function testEmptyResult()
+    {
+        $result = new Result(new DoctrineArrayStatement([]), 'SELECT from test');
+
+        $this->assertFalse($result->isModified);
+        $this->assertSame(0, $result->numFields);
+        $this->assertSame(0, $result->numRows);
+        $this->assertSame('SELECT from test', $result->query);
+        $this->assertSame(0, $result->count());
+        $this->assertSame([], $result->fetchAllAssoc());
+        $this->assertFalse($result->fetchAssoc());
+        $this->assertSame([], $result->fetchEach('test'));
+        $this->assertFalse($result->fetchRow());
+    }
+
+    public function testSingleRow()
+    {
+        $data = [
+            ['field' => 'value1'],
+        ];
+
+        $result = new Result(new DoctrineArrayStatement($data), 'SELECT from test');
+
+        $this->assertFalse($result->isModified);
+        $this->assertSame(1, $result->numFields);
+        $this->assertSame(1, $result->numRows);
+        $this->assertSame('SELECT from test', $result->query);
+        $this->assertSame(1, $result->count());
+        $this->assertSame($data, $result->fetchAllAssoc());
+        $this->assertSame($data[0], $result->reset()->fetchAssoc());
+        $this->assertFalse($result->fetchAssoc());
+        $this->assertSame(['value1'], $result->fetchEach('field'));
+        $this->assertSame(array_values($data[0]), $result->reset()->fetchRow());
+        $this->assertFalse($result->fetchRow());
+
+        $this->assertSame($data[0], $result->reset()->row());
+        $this->assertSame(array_values($data[0]), $result->last()->row(true));
+
+        $this->assertSame('value1', $result->first()->field);
+        $this->assertFalse($result->prev());
+        $this->assertSame('value1', $result->last()->field);
+        $this->assertFalse($result->next());
+
+        $result->field = 'new value';
+        $this->assertSame('new value', $result->field);
+        $this->assertSame(['field' => 'new value'], $result->row());
+        $this->assertSame(['new value'], $result->row(true));
+    }
+
+    public function testMultipleRows()
+    {
+        $data = [
+            ['field' => 'value1'],
+            ['field' => 'value2'],
+        ];
+
+        $result = new Result(new DoctrineArrayStatement($data), 'SELECT from test');
+
+        $this->assertFalse($result->isModified);
+        $this->assertSame(1, $result->numFields);
+        $this->assertSame(2, $result->numRows);
+        $this->assertSame('SELECT from test', $result->query);
+        $this->assertSame(2, $result->count());
+        $this->assertSame($data, $result->fetchAllAssoc());
+        $this->assertSame($data[0], $result->reset()->fetchAssoc());
+        $this->assertSame($data[1], $result->fetchAssoc());
+        $this->assertSame(['value1', 'value2'], $result->fetchEach('field'));
+        $this->assertSame(array_values($data[0]), $result->reset()->fetchRow());
+        $this->assertSame(array_values($data[1]), $result->fetchRow());
+        $this->assertFalse($result->fetchRow());
+
+        $this->assertSame($data[0], $result->reset()->row());
+        $this->assertSame(array_values($data[1]), $result->last()->row(true));
+
+        $this->assertSame('value1', $result->first()->field);
+        $this->assertFalse($result->prev());
+        $this->assertSame('value2', $result->next()->field);
+        $this->assertSame('value1', $result->prev()->field);
+        $this->assertSame('value2', $result->last()->field);
+        $this->assertFalse($result->next());
+
+        $result->field = 'new value';
+        $this->assertSame('new value', $result->field);
+        $this->assertSame(['field' => 'new value'], $result->row());
+        $this->assertSame(['new value'], $result->row(true));
+    }
+
+    public function testFetchRowAndAssoc()
+    {
+        $data = [
+            ['field' => 'value1'],
+            ['field' => 'value2'],
+        ];
+
+        $result = new Result(new DoctrineArrayStatement($data), 'SELECT from test');
+
+        $this->assertSame(['field' => 'value1'], $result->fetchAssoc());
+        $this->assertSame(['field' => 'value1'], $result->row());
+        $this->assertSame('value1', $result->field);
+        $this->assertNull($result->{'0'});
+
+        $this->assertSame(['value2'], $result->fetchRow());
+        $this->assertSame(['field' => 'value2'], $result->row());
+        $this->assertSame('value2', $result->field);
+        $this->assertNull($result->{'0'});
+    }
+}

--- a/core-bundle/tests/Contao/Database/ResultTest.php
+++ b/core-bundle/tests/Contao/Database/ResultTest.php
@@ -45,6 +45,7 @@ class ResultTest extends TestCase
         $resultStatement = new Result(new DoctrineArrayStatement($data), 'SELECT * FROM test');
         $resultArray = new Result($data, 'SELECT * FROM test');
 
+        /** @var Result|object $result */
         foreach ([$resultStatement, $resultArray] as $result) {
             $this->assertFalse($result->isModified);
             $this->assertSame(1, $result->numFields);
@@ -83,6 +84,7 @@ class ResultTest extends TestCase
         $resultStatement = new Result(new DoctrineArrayStatement($data), 'SELECT * FROM test');
         $resultArray = new Result($data, 'SELECT * FROM test');
 
+        /** @var Result|object $result */
         foreach ([$resultStatement, $resultArray] as $result) {
             $this->assertFalse($result->isModified);
             $this->assertSame(1, $result->numFields);
@@ -103,7 +105,8 @@ class ResultTest extends TestCase
             $this->assertSame('value1', $result->first()->field);
             $this->assertFalse($result->prev());
             $this->assertSame('value2', $result->next()->field);
-            $this->assertSame('value1', $result->prev()->field);
+            $this->assertInstanceOf(Result::class, $result->prev());
+            $this->assertSame('value1', $result->field);
             $this->assertSame('value2', $result->last()->field);
             $this->assertFalse($result->next());
 
@@ -124,6 +127,7 @@ class ResultTest extends TestCase
         $resultStatement = new Result(new DoctrineArrayStatement($data), 'SELECT * FROM test');
         $resultArray = new Result($data, 'SELECT * FROM test');
 
+        /** @var Result|object $result */
         foreach ([$resultStatement, $resultArray] as $result) {
             $this->assertSame(['field' => 'value1'], $result->fetchAssoc());
             $this->assertSame(['field' => 'value1'], $result->row());

--- a/core-bundle/tests/Contao/Database/ResultTest.php
+++ b/core-bundle/tests/Contao/Database/ResultTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of Contao.
  *
@@ -14,119 +16,142 @@ use Contao\CoreBundle\Tests\Fixtures\Database\DoctrineArrayStatement;
 use Contao\Database\Result;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests the Database Result class.
- *
- * @author Leo Feyer <https://github.com/leofeyer>
- *
- * @group contao3
- */
 class ResultTest extends TestCase
 {
-    public function testEmptyResult()
+    public function testEmptyResult(): void
     {
-        $result = new Result(new DoctrineArrayStatement([]), 'SELECT from test');
+        $resultStatement = new Result(new DoctrineArrayStatement([]), 'SELECT * FROM test');
+        $resultArray = new Result([], 'SELECT * FROM test');
 
-        $this->assertFalse($result->isModified);
-        $this->assertSame(0, $result->numFields);
-        $this->assertSame(0, $result->numRows);
-        $this->assertSame('SELECT from test', $result->query);
-        $this->assertSame(0, $result->count());
-        $this->assertSame([], $result->fetchAllAssoc());
-        $this->assertFalse($result->fetchAssoc());
-        $this->assertSame([], $result->fetchEach('test'));
-        $this->assertFalse($result->fetchRow());
+        foreach ([$resultStatement, $resultArray] as $result) {
+            $this->assertFalse($result->isModified);
+            $this->assertSame(0, $result->numFields);
+            $this->assertSame(0, $result->numRows);
+            $this->assertSame('SELECT * FROM test', $result->query);
+            $this->assertSame(0, $result->count());
+            $this->assertSame([], $result->fetchAllAssoc());
+            $this->assertFalse($result->fetchAssoc());
+            $this->assertSame([], $result->fetchEach('test'));
+            $this->assertFalse($result->fetchRow());
+        }
     }
 
-    public function testSingleRow()
+    public function testSingleRow(): void
     {
         $data = [
             ['field' => 'value1'],
         ];
 
-        $result = new Result(new DoctrineArrayStatement($data), 'SELECT from test');
+        $resultStatement = new Result(new DoctrineArrayStatement($data), 'SELECT * FROM test');
+        $resultArray = new Result($data, 'SELECT * FROM test');
 
-        $this->assertFalse($result->isModified);
-        $this->assertSame(1, $result->numFields);
-        $this->assertSame(1, $result->numRows);
-        $this->assertSame('SELECT from test', $result->query);
-        $this->assertSame(1, $result->count());
-        $this->assertSame($data, $result->fetchAllAssoc());
-        $this->assertSame($data[0], $result->reset()->fetchAssoc());
-        $this->assertFalse($result->fetchAssoc());
-        $this->assertSame(['value1'], $result->fetchEach('field'));
-        $this->assertSame(array_values($data[0]), $result->reset()->fetchRow());
-        $this->assertFalse($result->fetchRow());
+        foreach ([$resultStatement, $resultArray] as $result) {
+            $this->assertFalse($result->isModified);
+            $this->assertSame(1, $result->numFields);
+            $this->assertSame(1, $result->numRows);
+            $this->assertSame('SELECT * FROM test', $result->query);
+            $this->assertSame(1, $result->count());
+            $this->assertSame($data, $result->fetchAllAssoc());
+            $this->assertSame($data[0], $result->reset()->fetchAssoc());
+            $this->assertFalse($result->fetchAssoc());
+            $this->assertSame(['value1'], $result->fetchEach('field'));
+            $this->assertSame(array_values($data[0]), $result->reset()->fetchRow());
+            $this->assertFalse($result->fetchRow());
 
-        $this->assertSame($data[0], $result->reset()->row());
-        $this->assertSame(array_values($data[0]), $result->last()->row(true));
+            $this->assertSame($data[0], $result->reset()->row());
+            $this->assertSame(array_values($data[0]), $result->last()->row(true));
 
-        $this->assertSame('value1', $result->first()->field);
-        $this->assertFalse($result->prev());
-        $this->assertSame('value1', $result->last()->field);
-        $this->assertFalse($result->next());
+            $this->assertSame('value1', $result->first()->field);
+            $this->assertFalse($result->prev());
+            $this->assertSame('value1', $result->last()->field);
+            $this->assertFalse($result->next());
 
-        $result->field = 'new value';
-        $this->assertSame('new value', $result->field);
-        $this->assertSame(['field' => 'new value'], $result->row());
-        $this->assertSame(['new value'], $result->row(true));
+            $result->field = 'new value';
+            $this->assertSame('new value', $result->field);
+            $this->assertSame(['field' => 'new value'], $result->row());
+            $this->assertSame(['new value'], $result->row(true));
+        }
     }
 
-    public function testMultipleRows()
-    {
-        $data = [
-            ['field' => 'value1'],
-            ['field' => 'value2'],
-        ];
-
-        $result = new Result(new DoctrineArrayStatement($data), 'SELECT from test');
-
-        $this->assertFalse($result->isModified);
-        $this->assertSame(1, $result->numFields);
-        $this->assertSame(2, $result->numRows);
-        $this->assertSame('SELECT from test', $result->query);
-        $this->assertSame(2, $result->count());
-        $this->assertSame($data, $result->fetchAllAssoc());
-        $this->assertSame($data[0], $result->reset()->fetchAssoc());
-        $this->assertSame($data[1], $result->fetchAssoc());
-        $this->assertSame(['value1', 'value2'], $result->fetchEach('field'));
-        $this->assertSame(array_values($data[0]), $result->reset()->fetchRow());
-        $this->assertSame(array_values($data[1]), $result->fetchRow());
-        $this->assertFalse($result->fetchRow());
-
-        $this->assertSame($data[0], $result->reset()->row());
-        $this->assertSame(array_values($data[1]), $result->last()->row(true));
-
-        $this->assertSame('value1', $result->first()->field);
-        $this->assertFalse($result->prev());
-        $this->assertSame('value2', $result->next()->field);
-        $this->assertSame('value1', $result->prev()->field);
-        $this->assertSame('value2', $result->last()->field);
-        $this->assertFalse($result->next());
-
-        $result->field = 'new value';
-        $this->assertSame('new value', $result->field);
-        $this->assertSame(['field' => 'new value'], $result->row());
-        $this->assertSame(['new value'], $result->row(true));
-    }
-
-    public function testFetchRowAndAssoc()
+    public function testMultipleRows(): void
     {
         $data = [
             ['field' => 'value1'],
             ['field' => 'value2'],
         ];
 
-        $result = new Result(new DoctrineArrayStatement($data), 'SELECT from test');
+        $resultStatement = new Result(new DoctrineArrayStatement($data), 'SELECT * FROM test');
+        $resultArray = new Result($data, 'SELECT * FROM test');
 
-        $this->assertSame(['field' => 'value1'], $result->fetchAssoc());
-        $this->assertSame(['field' => 'value1'], $result->row());
-        $this->assertSame('value1', $result->field);
-        $this->assertNull($result->{'0'});
+        foreach ([$resultStatement, $resultArray] as $result) {
+            $this->assertFalse($result->isModified);
+            $this->assertSame(1, $result->numFields);
+            $this->assertSame(2, $result->numRows);
+            $this->assertSame('SELECT * FROM test', $result->query);
+            $this->assertSame(2, $result->count());
+            $this->assertSame($data, $result->fetchAllAssoc());
+            $this->assertSame($data[0], $result->reset()->fetchAssoc());
+            $this->assertSame($data[1], $result->fetchAssoc());
+            $this->assertSame(['value1', 'value2'], $result->fetchEach('field'));
+            $this->assertSame(array_values($data[0]), $result->reset()->fetchRow());
+            $this->assertSame(array_values($data[1]), $result->fetchRow());
+            $this->assertFalse($result->fetchRow());
 
-        $this->assertSame(['value2'], $result->fetchRow());
-        $this->assertSame(['field' => 'value2'], $result->row());
-        $this->assertSame('value2', $result->field);
-        $this->assertNull($result->{'0'});
+            $this->assertSame($data[0], $result->reset()->row());
+            $this->assertSame(array_values($data[1]), $result->last()->row(true));
+
+            $this->assertSame('value1', $result->first()->field);
+            $this->assertFalse($result->prev());
+            $this->assertSame('value2', $result->next()->field);
+            $this->assertSame('value1', $result->prev()->field);
+            $this->assertSame('value2', $result->last()->field);
+            $this->assertFalse($result->next());
+
+            $result->field = 'new value';
+            $this->assertSame('new value', $result->field);
+            $this->assertSame(['field' => 'new value'], $result->row());
+            $this->assertSame(['new value'], $result->row(true));
+        }
+    }
+
+    public function testFetchRowAndAssoc(): void
+    {
+        $data = [
+            ['field' => 'value1'],
+            ['field' => 'value2'],
+        ];
+
+        $resultStatement = new Result(new DoctrineArrayStatement($data), 'SELECT * FROM test');
+        $resultArray = new Result($data, 'SELECT * FROM test');
+
+        foreach ([$resultStatement, $resultArray] as $result) {
+            $this->assertSame(['field' => 'value1'], $result->fetchAssoc());
+            $this->assertSame(['field' => 'value1'], $result->row());
+            $this->assertSame('value1', $result->field);
+            $this->assertNull($result->{'0'});
+
+            $this->assertSame(['value2'], $result->fetchRow());
+            $this->assertSame(['field' => 'value2'], $result->row());
+            $this->assertSame('value2', $result->field);
+            $this->assertNull($result->{'0'});
+        }
+    }
+
+    /**
+     * @dataProvider getInvalidStatements
+     */
+    public function testInvalidStatements($statement): void
+    {
+        $this->expectException('InvalidArgumentException');
+
+        new Result($statement, 'SELECT * FROM test');
+    }
+
+    public function getInvalidStatements(): \Generator
+    {
+        yield 'String' => ['foo'];
+        yield 'Object' => [new \stdClass()];
+        yield 'Single Array' => [['foo' => 'bar']];
+        yield 'Mixed Array' => [[['foo' => 'bar'], 'baz']];
     }
 }

--- a/core-bundle/tests/Fixtures/Database/DoctrineArrayStatement.php
+++ b/core-bundle/tests/Fixtures/Database/DoctrineArrayStatement.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\Fixtures\Database;
+
+use Doctrine\DBAL\Cache\ArrayStatement;
+use Doctrine\DBAL\Driver\Statement;
+use Doctrine\DBAL\ParameterType;
+
+class DoctrineArrayStatement extends ArrayStatement implements Statement
+{
+    private $rowCount;
+
+    public function __construct(array $data)
+    {
+        $this->rowCount = \count($data);
+
+        parent::__construct($data);
+    }
+
+    public function rowCount()
+    {
+        return $this->rowCount;
+    }
+
+    public function bindValue($param, $value, $type = ParameterType::STRING)
+    {
+        throw new \RuntimeException('Not implemented');
+    }
+
+    public function bindParam($column, &$variable, $type = ParameterType::STRING, $length = null)
+    {
+        throw new \RuntimeException('Not implemented');
+    }
+
+    public function errorCode()
+    {
+        throw new \RuntimeException('Not implemented');
+    }
+
+    public function errorInfo()
+    {
+        throw new \RuntimeException('Not implemented');
+    }
+
+    public function execute($params = null)
+    {
+        throw new \RuntimeException('Not implemented');
+    }
+}

--- a/core-bundle/tests/Fixtures/Database/DoctrineArrayStatement.php
+++ b/core-bundle/tests/Fixtures/Database/DoctrineArrayStatement.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of Contao.
  *
@@ -30,27 +32,27 @@ class DoctrineArrayStatement extends ArrayStatement implements Statement
         return $this->rowCount;
     }
 
-    public function bindValue($param, $value, $type = ParameterType::STRING)
+    public function bindValue($param, $value, $type = ParameterType::STRING): void
     {
         throw new \RuntimeException('Not implemented');
     }
 
-    public function bindParam($column, &$variable, $type = ParameterType::STRING, $length = null)
+    public function bindParam($column, &$variable, $type = ParameterType::STRING, $length = null): void
     {
         throw new \RuntimeException('Not implemented');
     }
 
-    public function errorCode()
+    public function errorCode(): void
     {
         throw new \RuntimeException('Not implemented');
     }
 
-    public function errorInfo()
+    public function errorInfo(): void
     {
         throw new \RuntimeException('Not implemented');
     }
 
-    public function execute($params = null)
+    public function execute($params = null): void
     {
         throw new \RuntimeException('Not implemented');
     }


### PR DESCRIPTION
Fixes #1061 

@ausi I have split up the PR into multiple commits. The first one cherry-picks the `Result` changes from Contao 4.4, the second one re-adds array initialization and the third one adds the fix to the `Search` class.