### PR TITLE
Make the contao.search.indexer service public

### DIFF
--- a/core-bundle/src/DependencyInjection/Compiler/SearchIndexerPass.php
+++ b/core-bundle/src/DependencyInjection/Compiler/SearchIndexerPass.php
@@ -59,6 +59,6 @@ class SearchIndexerPass implements CompilerPassInterface
         }
 
         // Add an alias for the delegating service
-        $container->setAlias('contao.search.indexer', self::DELEGATING_SERVICE_ID);
+        $container->setAlias('contao.search.indexer', self::DELEGATING_SERVICE_ID)->setPublic(true);
     }
 }

--- a/core-bundle/tests/DependencyInjection/Compiler/SearchIndexerPassTest.php
+++ b/core-bundle/tests/DependencyInjection/Compiler/SearchIndexerPassTest.php
@@ -47,6 +47,7 @@ class SearchIndexerPassTest extends TestCase
         $this->assertTrue($container->hasDefinition('contao.listener.search_index'));
         $this->assertTrue($container->hasDefinition('contao.crawl.escargot_subscriber.search_index'));
         $this->assertTrue($container->hasAlias('contao.search.indexer'));
+        $this->assertTrue($container->getAlias('contao.search.indexer')->isPublic());
     }
 
     public function testRemovesTheDelegatingIndexerAndDisablesTheListenerAndCrawlSubscriberIfNoIndexersWereGiven(): void


### PR DESCRIPTION
Because the service is fetched via `$container->get()` in the `Automator` class (Back end -> Maintenance -> Purge the search index).