### PR TITLE
Hide the 2FA fields in the back end info modal

### DIFF
--- a/core-bundle/src/Resources/contao/dca/tl_member.php
+++ b/core-bundle/src/Resources/contao/dca/tl_member.php
@@ -387,12 +387,12 @@ $GLOBALS['TL_DCA']['tl_member'] = array
 		),
 		'backupCodes' => array
 		(
-			'eval'                    => array('doNotCopy'=>true),
+			'eval'                    => array('doNotCopy'=>true, 'doNotShow'=>true),
 			'sql'                     => "text NULL"
 		),
 		'trustedTokenVersion' => array
 		(
-			'eval'                    => array('doNotCopy'=>true),
+			'eval'                    => array('doNotCopy'=>true, 'doNotShow'=>true),
 			'sql'                     => "int(10) unsigned NOT NULL default 0"
 		)
 	)

--- a/core-bundle/src/Resources/contao/dca/tl_user.php
+++ b/core-bundle/src/Resources/contao/dca/tl_user.php
@@ -452,12 +452,12 @@ $GLOBALS['TL_DCA']['tl_user'] = array
 		),
 		'backupCodes' => array
 		(
-			'eval'                    => array('doNotCopy'=>true),
+			'eval'                    => array('doNotCopy'=>true, 'doNotShow'=>true),
 			'sql'                     => "text NULL"
 		),
 		'trustedTokenVersion' => array
 		(
-			'eval'                    => array('doNotCopy'=>true),
+			'eval'                    => array('doNotCopy'=>true, 'doNotShow'=>true),
 			'sql'                     => "int(10) unsigned NOT NULL default 0"
 		)
 	)


### PR DESCRIPTION
Hide the fields `backupCodes` and `trustedTokenVersion` in the info modal.