### PR TITLE
Fix the PictureFactoryInterface::create() type hint

### DIFF
--- a/core-bundle/src/Image/PictureFactoryInterface.php
+++ b/core-bundle/src/Image/PictureFactoryInterface.php
@@ -30,8 +30,8 @@ interface PictureFactoryInterface
     /**
      * Creates a Picture object.
      *
-     * @param string|ImageInterface               $path
-     * @param int|array|PictureConfiguration|null $size
+     * @param string|ImageInterface                      $path
+     * @param int|string|array|PictureConfiguration|null $size
      *
      * @return PictureInterface
      */


### PR DESCRIPTION
My PHPStan level=7 in my projects complains about this when using preconfigured image size values from config like `_my_image_size`.