### PR TITLE
Separate Fehlermeldung bei fehlendem JSON-LD

### DIFF
--- a/core-bundle/src/Search/Indexer/DefaultIndexer.php
+++ b/core-bundle/src/Search/Indexer/DefaultIndexer.php
@@ -71,11 +71,15 @@ class DefaultIndexer implements IndexerInterface
             'language' => $language,
             'protected' => false,
             'groups' => [],
-            'pageId' => 0,
-            'noSearch' => true, // Causes the indexer to skip this document if there is no json-ld data
+            'pageId' => 0
         ];
 
         $this->extendMetaFromJsonLdScripts($document, $meta);
+
+        // Causes the indexer to skip this document if there is no json-ld data
+        if (!isset($meta['noSearch'])) {
+            $this->throwBecause('JSONLD is missing');
+        }
 
         // If search was disabled in the page settings, we do not index
         if (isset($meta['noSearch']) && true === $meta['noSearch']) {


### PR DESCRIPTION
Wenn de JSON-LD Daten in der Ausgabe fehlen, z.B. wenn man Änderungen an der fe_page vorgenommen hatte, bricht der Indexer bisher mit der Fehlermeldung ab, das ausdrücklich die Indexierung unterbunden wurde. Das ist aber falsch da nur die JSON-LD Daten fehlten.
Durch die Entfernung des vorbelegten Wertes und Prüfen auf die Existenz des Schlüssels kann nun eine spearate Fehlermeldung auf das Fehlen der JSON-LD Daten hinweisen.
