### PR TITLE
Warn if the crawler runs without a domain name

### DIFF
--- a/core-bundle/src/Command/CrawlCommand.php
+++ b/core-bundle/src/Command/CrawlCommand.php
@@ -90,6 +90,10 @@ class CrawlCommand extends Command
         $queue = new InMemoryQueue();
         $baseUris = $this->escargotFactory->getCrawlUriCollection();
 
+        if ($baseUris->containsHost('localhost')) {
+            $io->warning('You are going to crawl localhost URIs. This is likely not desired and due to a missing domain configuration in your root page settings. You may also configure a fallback request context using "router.request_context.*" if you want to execute all CLI commands with the same request context.');
+        }
+
         try {
             if ($jobId = $input->getArgument('job')) {
                 $this->escargot = $this->escargotFactory->createFromJobId($jobId, $queue, $subscribers);


### PR DESCRIPTION
Fixes https://github.com/contao/contao/issues/1344