### PR TITLE
Do not show the current URI in the progress bar title when crawling

### DIFF
--- a/core-bundle/src/Command/CrawlCommand.php
+++ b/core-bundle/src/Command/CrawlCommand.php
@@ -181,7 +181,7 @@ class CrawlCommand extends Command
 
         $progressBar = new ProgressBar($processOutput);
         $progressBar->setFormat("%title%\n%current%/%max% [%bar%] %percent:3s%%");
-        $progressBar->setMessage('Starting to crawl...', 'title');
+        $progressBar->setMessage('Crawling…', 'title');
         $progressBar->start();
 
         $this->escargot->addSubscriber($this->getProgressSubscriber($progressBar));
@@ -218,8 +218,7 @@ class CrawlCommand extends Command
 
             public function onLastChunk(CrawlUri $crawlUri, ResponseInterface $response, ChunkInterface $chunk): void
             {
-                // We only update the message here, otherwise too many nonsense URIs will be shown
-                $this->progressBar->setMessage((string) $crawlUri->getUri(), 'title');
+                // noop
             }
 
             public function finishedCrawling(): void


### PR DESCRIPTION
It was confusing and it does not provide any added value.
Also, it just slows down CLI rendering.

Also see https://github.com/contao/contao/issues/1356.