### PR TITLE
Start the MySQL service before running the functional tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,9 @@ jobs:
               run: vendor/bin/phpunit --colors=always
 
             - name: Run the functional tests
-              run: vendor/bin/phpunit --testsuite=functional --colors=always
+              run: |
+                  sudo /etc/init.d/mysql start
+                  vendor/bin/phpunit --testsuite=functional --colors=always
               env:
                   DATABASE_URL: mysql://root:root@localhost:3306/contao_test
 
@@ -154,7 +156,9 @@ jobs:
               run: vendor/bin/phpunit --colors=always
 
             - name: Run the functional tests
-              run: vendor/bin/phpunit --testsuite=functional --colors=always
+              run: |
+                  sudo /etc/init.d/mysql start
+                  vendor/bin/phpunit --testsuite=functional --colors=always
               env:
                   DATABASE_URL: mysql://root:root@localhost:3306/contao_test
 


### PR DESCRIPTION
Otherwise the functional tests will fail as of March, 3rd (see https://github.blog/changelog/2020-02-21-github-actions-breaking-change-ubuntu-virtual-environments-will-no-longer-start-the-mysql-service-automatically/).