### PR TITLE
Handle the "no JSON-LD found" case separately from the "noSearch" case

### DIFF
--- a/core-bundle/src/Search/Indexer/DefaultIndexer.php
+++ b/core-bundle/src/Search/Indexer/DefaultIndexer.php
@@ -72,7 +72,6 @@ class DefaultIndexer implements IndexerInterface
             'protected' => false,
             'groups' => [],
             'pageId' => 0,
-            'noSearch' => true, // Causes the indexer to skip this document if there is no json-ld data
         ];
 
         $this->extendMetaFromJsonLdScripts($document, $meta);
@@ -144,7 +143,7 @@ class DefaultIndexer implements IndexerInterface
         $jsonLds = $document->extractJsonLdScripts('https://schema.contao.org/', 'RegularPage');
 
         if (0 === \count($jsonLds)) {
-            return;
+            $this->throwBecause('No JSON-LD found.');
         }
 
         // Merge all entries to one meta array (the latter overrides the former)

--- a/core-bundle/tests/Search/Indexer/DefaultIndexerTest.php
+++ b/core-bundle/tests/Search/Indexer/DefaultIndexerTest.php
@@ -74,10 +74,16 @@ class DefaultIndexerTest extends ContaoTestCase
             'Was explicitly marked "noSearch" in page settings.',
         ];
 
-        yield 'Test does not index if json ld data is not of type "RegularPage"' => [
+        yield 'Test does not index if there is no JSON-LD data' => [
+            new Document(new Uri('https://example.com'), 200, [], '<html><body></body></html>'),
+            null,
+            'No JSON-LD found.',
+        ];
+
+        yield 'Test does not index if JSON-LD data is not of type "RegularPage"' => [
             new Document(new Uri('https://example.com'), 200, [], '<html><body><script type="application/ld+json">{"@context":"https:\/\/schema.contao.org\/","@type":"FoobarType","pageId":2,"noSearch":false,"protected":false,"groups":[],"fePreview":false}</script></body></html>'),
             null,
-            'Was explicitly marked "noSearch" in page settings.',
+            'No JSON-LD found.',
         ];
 
         yield 'Test does not index if protected is set to true' => [


### PR DESCRIPTION
Fixes #1378 