### PR TITLE
Update the composer run documentation in the README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ composer create-project --no-install contao/managed-edition <directory> <branch>
 Replace `<directory>` with the directory you want to install the Managed
 Edition in (use `.` for the current one). Replace `<branch>` with `dev-master`
 if you want to add a new feature or with `<lts-version>.x-dev` (currently
-`4.4.x-dev`) if you want to fix a bug.
+`4.4.x-dev` and `4.9.x-dev`) if you want to fix a bug.
 
 Then adjust the `require` section in your `composer.json` file so Composer
 loads the monorepo instead of the individual bundles:
@@ -81,9 +81,16 @@ You can use Composer to run the code quality scripts:
 ```bash
 composer run all
 composer run unit-tests
-composer run functional-tests
-composer run php-cs-fixer
+composer run cs-fixer
 composer run phpstan
+```
+
+If you want to pass additional flags to the underlying commands, you can use
+the `--` argument:
+
+```bash
+composer run unit-tests -- --filter CoreBundle
+composer run cs-fixer -- --clear-cache
 ```
 
 ## Functional tests

--- a/composer.json
+++ b/composer.json
@@ -254,9 +254,9 @@
             "@monorepo-tools"
         ],
         "cs-fixer": [
-            "vendor/bin/ecs check *-bundle/bin *-bundle/src *-bundle/tests --config vendor/contao/easy-coding-standard/config/default.yaml --ansi",
-            "vendor/bin/ecs check *-bundle/src/Resources/contao --config vendor/contao/easy-coding-standard/config/legacy.yaml --ansi",
-            "vendor/bin/ecs check *-bundle/src/Resources/contao/templates --config vendor/contao/easy-coding-standard/config/template.yaml --ansi"
+            "vendor/bin/ecs check *-bundle/bin *-bundle/src *-bundle/tests --config vendor/contao/easy-coding-standard/config/default.yaml --fix --ansi",
+            "vendor/bin/ecs check *-bundle/src/Resources/contao --config vendor/contao/easy-coding-standard/config/legacy.yaml --fix --ansi",
+            "vendor/bin/ecs check *-bundle/src/Resources/contao/templates --config vendor/contao/easy-coding-standard/config/template.yaml --fix --ansi"
         ],
         "functional-tests": [
             "vendor/bin/phpunit --testsuite=functional --colors=always"


### PR DESCRIPTION
This PR adds a paragraph about the `--` argument, which you can use when running `composer run` to pass additional flags to the underlying command. It also adds the `--fix` flag to the `cs-fixer` script by default, because I guess that is what you mostly want, isn't it?