### PR TITLE
Revert the document.write() changes

### DIFF
--- a/core-bundle/src/Resources/contao/templates/backend/be_ace.html5
+++ b/core-bundle/src/Resources/contao/templates/backend/be_ace.html5
@@ -4,9 +4,8 @@ namespace Contao;
 
 if ($GLOBALS['TL_CONFIG']['useCE']):
 
-$GLOBALS['TL_JAVASCRIPT'][] = $this->asset('js/ace.js', 'contao-components/ace');
-
 ?>
+<script>window.ace || document.write('<script src="<?= $this->asset('js/ace.js', 'contao-components/ace') ?>" charset="utf-8">\x3C/script>')</script>
 <script>
 window.ace && window.addEvent('domready', function() {
   var ta = document.getElementById('<?= $this->selector ?>'),

--- a/core-bundle/src/Resources/contao/templates/backend/be_tinyMCE.html5
+++ b/core-bundle/src/Resources/contao/templates/backend/be_tinyMCE.html5
@@ -4,9 +4,8 @@ namespace Contao;
 
 if ($GLOBALS['TL_CONFIG']['useRTE']):
 
-$GLOBALS['TL_JAVASCRIPT'][] = $this->asset('js/tinymce.min.js', 'contao-components/tinymce4');
-
 ?>
+<script>window.tinymce || document.write('<script src="<?= $this->asset('js/tinymce.min.js', 'contao-components/tinymce4') ?>">\x3C/script>')</script>
 <script>
 window.tinymce && tinymce.init({
   skin: 'contao',

--- a/core-bundle/src/Resources/contao/templates/backend/be_tinyNews.html5
+++ b/core-bundle/src/Resources/contao/templates/backend/be_tinyNews.html5
@@ -4,9 +4,8 @@ namespace Contao;
 
 if ($GLOBALS['TL_CONFIG']['useRTE']):
 
-$GLOBALS['TL_JAVASCRIPT'][] = $this->asset('js/tinymce.min.js', 'contao-components/tinymce4');
-
 ?>
+<script>window.tinymce || document.write('<script src="<?= $this->asset('js/tinymce.min.js', 'contao-components/tinymce4') ?>">\x3C/script>')</script>
 <script>
 window.tinymce && tinymce.init({
   skin: 'contao',


### PR DESCRIPTION
This reverts the changes from #1332 so TinyMCE is initialized correctly when loaded in a sub-palette (see https://github.com/contao/contao/issues/1313#issuecomment-591931996).