### PR TITLE
Revert the document.write() changes

### DIFF
--- a/core-bundle/src/Resources/contao/templates/backend/be_ace.html5
+++ b/core-bundle/src/Resources/contao/templates/backend/be_ace.html5
@@ -4,6 +4,7 @@ namespace Contao;
 
 if ($GLOBALS['TL_CONFIG']['useCE']):
 
+// Use document.write() here in case ACE is loaded in a subpalette (see #1424)
 ?>
 <script>window.ace || document.write('<script src="<?= TL_ASSETS_URL ?>assets/ace/js/ace.js" charset="utf-8">\x3C/script>')</script>
 <script>

--- a/core-bundle/src/Resources/contao/templates/backend/be_ace.html5
+++ b/core-bundle/src/Resources/contao/templates/backend/be_ace.html5
@@ -4,9 +4,8 @@ namespace Contao;
 
 if ($GLOBALS['TL_CONFIG']['useCE']):
 
-$GLOBALS['TL_JAVASCRIPT'][] = 'assets/ace/js/ace.js';
-
 ?>
+<script>window.ace || document.write('<script src="<?= TL_ASSETS_URL ?>assets/ace/js/ace.js" charset="utf-8">\x3C/script>')</script>
 <script>
 window.ace && window.addEvent('domready', function() {
   var ta = document.getElementById('<?= $this->selector ?>'),

--- a/core-bundle/src/Resources/contao/templates/backend/be_tinyFlash.html5
+++ b/core-bundle/src/Resources/contao/templates/backend/be_tinyFlash.html5
@@ -4,6 +4,7 @@ namespace Contao;
 
 if ($GLOBALS['TL_CONFIG']['useRTE']):
 
+// Use document.write() here in case TinyMCE is loaded in a subpalette (see #1424)
 ?>
 <script>window.tinymce || document.write('<script src="<?= TL_ASSETS_URL ?>assets/tinymce4/js/tinymce.min.js">\x3C/script>')</script>
 <script>

--- a/core-bundle/src/Resources/contao/templates/backend/be_tinyFlash.html5
+++ b/core-bundle/src/Resources/contao/templates/backend/be_tinyFlash.html5
@@ -4,9 +4,8 @@ namespace Contao;
 
 if ($GLOBALS['TL_CONFIG']['useRTE']):
 
-$GLOBALS['TL_JAVASCRIPT'][] = 'assets/tinymce4/js/tinymce.min.js';
-
 ?>
+<script>window.tinymce || document.write('<script src="<?= TL_ASSETS_URL ?>assets/tinymce4/js/tinymce.min.js">\x3C/script>')</script>
 <script>
 window.tinymce && tinymce.init({
   skin: 'contao',

--- a/core-bundle/src/Resources/contao/templates/backend/be_tinyMCE.html5
+++ b/core-bundle/src/Resources/contao/templates/backend/be_tinyMCE.html5
@@ -4,6 +4,7 @@ namespace Contao;
 
 if ($GLOBALS['TL_CONFIG']['useRTE']):
 
+// Use document.write() here in case TinyMCE is loaded in a subpalette (see #1424)
 ?>
 <script>window.tinymce || document.write('<script src="<?= TL_ASSETS_URL ?>assets/tinymce4/js/tinymce.min.js">\x3C/script>')</script>
 <script>

--- a/core-bundle/src/Resources/contao/templates/backend/be_tinyMCE.html5
+++ b/core-bundle/src/Resources/contao/templates/backend/be_tinyMCE.html5
@@ -4,9 +4,8 @@ namespace Contao;
 
 if ($GLOBALS['TL_CONFIG']['useRTE']):
 
-$GLOBALS['TL_JAVASCRIPT'][] = 'assets/tinymce4/js/tinymce.min.js';
-
 ?>
+<script>window.tinymce || document.write('<script src="<?= TL_ASSETS_URL ?>assets/tinymce4/js/tinymce.min.js">\x3C/script>')</script>
 <script>
 window.tinymce && tinymce.init({
   skin: 'contao',

--- a/core-bundle/src/Resources/contao/templates/backend/be_tinyNews.html5
+++ b/core-bundle/src/Resources/contao/templates/backend/be_tinyNews.html5
@@ -4,6 +4,7 @@ namespace Contao;
 
 if ($GLOBALS['TL_CONFIG']['useRTE']):
 
+// Use document.write() here in case TinyMCE is loaded in a subpalette (see #1424)
 ?>
 <script>window.tinymce || document.write('<script src="<?= TL_ASSETS_URL ?>assets/tinymce4/js/tinymce.min.js">\x3C/script>')</script>
 <script>

--- a/core-bundle/src/Resources/contao/templates/backend/be_tinyNews.html5
+++ b/core-bundle/src/Resources/contao/templates/backend/be_tinyNews.html5
@@ -4,9 +4,8 @@ namespace Contao;
 
 if ($GLOBALS['TL_CONFIG']['useRTE']):
 
-$GLOBALS['TL_JAVASCRIPT'][] = 'assets/tinymce4/js/tinymce.min.js';
-
 ?>
+<script>window.tinymce || document.write('<script src="<?= TL_ASSETS_URL ?>assets/tinymce4/js/tinymce.min.js">\x3C/script>')</script>
 <script>
 window.tinymce && tinymce.init({
   skin: 'contao',


### PR DESCRIPTION
This reverts the changes from #1332 so TinyMCE is initialized correctly when loaded in a sub-palette (see https://github.com/contao/contao/issues/1313#issuecomment-591931996).