### PR TITLE
Update CrawlCsvLogHandler.php to avoid line break in message

### DIFF
--- a/core-bundle/src/Crawl/Monolog/CrawlCsvLogHandler.php
+++ b/core-bundle/src/Crawl/Monolog/CrawlCsvLogHandler.php
@@ -46,7 +46,7 @@ class CrawlCsvLogHandler extends StreamHandler
             null === $crawlUri ? '---' : (string) $crawlUri->getFoundOn(),
             null === $crawlUri ? '---' : $crawlUri->getLevel(),
             null === $crawlUri ? '---' : implode(', ', $crawlUri->getTags()),
-            str_replace(["\n", "\r\n", "\r"], ' ', $record['message']),
+            str_replace(["\r\n", "\n", "\r"], ' ', $record['message']),
         ];
 
         fputcsv($resource, $columns);

--- a/core-bundle/src/Crawl/Monolog/CrawlCsvLogHandler.php
+++ b/core-bundle/src/Crawl/Monolog/CrawlCsvLogHandler.php
@@ -46,7 +46,7 @@ class CrawlCsvLogHandler extends StreamHandler
             null === $crawlUri ? '---' : (string) $crawlUri->getFoundOn(),
             null === $crawlUri ? '---' : $crawlUri->getLevel(),
             null === $crawlUri ? '---' : implode(', ', $crawlUri->getTags()),
-            $record['message'],
+            str_replace(["\n", "\r\n", "\r"], ' ', $record['message']),
         ];
 
         fputcsv($resource, $columns);


### PR DESCRIPTION
Replace line break in message with space to comply with the CSV format.

Fixes #1390 