### PR TITLE
Remove the "doNotRedirectEmpty" option

### DIFF
--- a/core-bundle/src/Resources/contao/classes/Frontend.php
+++ b/core-bundle/src/Resources/contao/classes/Frontend.php
@@ -322,12 +322,6 @@ abstract class Frontend extends Controller
 		// No language given
 		else
 		{
-			// Always load the language fall back root if "doNotRedirectEmpty" is enabled
-			if (Config::get('addLanguageToUrl') && Config::get('doNotRedirectEmpty'))
-			{
-				$accept_language = '-';
-			}
-
 			$strUri = Environment::get('url') . '/';
 			$strError = 'No root page found (host "' . Environment::get('host') . '", languages "' . implode(', ', Environment::get('httpAcceptLanguage')) . '")';
 		}
@@ -355,7 +349,7 @@ abstract class Frontend extends Controller
 		// Redirect to the website root or language root (e.g. en/)
 		if (Environment::get('relativeRequest') == '')
 		{
-			if (Config::get('addLanguageToUrl') && !Config::get('doNotRedirectEmpty'))
+			if (Config::get('addLanguageToUrl'))
 			{
 				$arrParams = array('_locale' => $objRootPage->language);
 

--- a/core-bundle/src/Resources/contao/config/default.php
+++ b/core-bundle/src/Resources/contao/config/default.php
@@ -103,7 +103,6 @@ $GLOBALS['TL_CONFIG']['exampleWebsite']       = '';
 $GLOBALS['TL_CONFIG']['minPasswordLength']    = 8;
 $GLOBALS['TL_CONFIG']['disableCron']          = false;
 $GLOBALS['TL_CONFIG']['coreOnlyMode']         = false;
-$GLOBALS['TL_CONFIG']['doNotRedirectEmpty']   = false;
 $GLOBALS['TL_CONFIG']['useAutoItem']          = true;
 $GLOBALS['TL_CONFIG']['privacyAnonymizeIp']   = true;
 $GLOBALS['TL_CONFIG']['privacyAnonymizeGA']   = true;

--- a/core-bundle/src/Resources/contao/dca/tl_settings.php
+++ b/core-bundle/src/Resources/contao/dca/tl_settings.php
@@ -20,7 +20,7 @@ $GLOBALS['TL_DCA']['tl_settings'] = array
 	// Palettes
 	'palettes' => array
 	(
-		'default'                     => '{global_legend},adminEmail;{date_legend},dateFormat,timeFormat,datimFormat,timeZone;{backend_legend:hide},doNotCollapse,resultsPerPage,maxResultsPerPage;{frontend_legend},folderUrl,doNotRedirectEmpty;{security_legend:hide},disableRefererCheck,allowedTags;{files_legend:hide},allowedDownload,gdMaxImgWidth,gdMaxImgHeight;{uploads_legend:hide},uploadTypes,maxFileSize,imageWidth,imageHeight;{cron_legend:hide},disableCron;{chmod_legend},defaultUser,defaultGroup,defaultChmod'
+		'default'                     => '{global_legend},adminEmail;{date_legend},dateFormat,timeFormat,datimFormat,timeZone;{backend_legend:hide},doNotCollapse,resultsPerPage,maxResultsPerPage;{frontend_legend},folderUrl;{security_legend:hide},disableRefererCheck,allowedTags;{files_legend:hide},allowedDownload,gdMaxImgWidth,gdMaxImgHeight;{uploads_legend:hide},uploadTypes,maxFileSize,imageWidth,imageHeight;{cron_legend:hide},disableCron;{chmod_legend},defaultUser,defaultGroup,defaultChmod'
 	),
 
 	// Fields
@@ -72,11 +72,6 @@ $GLOBALS['TL_DCA']['tl_settings'] = array
 			'eval'                    => array('mandatory'=>true, 'rgxp'=>'natural', 'nospace'=>true, 'tl_class'=>'w50')
 		),
 		'doNotCollapse' => array
-		(
-			'inputType'               => 'checkbox',
-			'eval'                    => array('tl_class'=>'w50')
-		),
-		'doNotRedirectEmpty' => array
 		(
 			'inputType'               => 'checkbox',
 			'eval'                    => array('tl_class'=>'w50')

--- a/core-bundle/src/Resources/contao/languages/en/tl_settings.xlf
+++ b/core-bundle/src/Resources/contao/languages/en/tl_settings.xlf
@@ -56,12 +56,6 @@
       <trans-unit id="tl_settings.doNotCollapse.1">
         <source>Do not collapse elements in the back end preview.</source>
       </trans-unit>
-      <trans-unit id="tl_settings.doNotRedirectEmpty.0">
-        <source>Do not redirect empty URLs</source>
-      </trans-unit>
-      <trans-unit id="tl_settings.doNotRedirectEmpty.1">
-        <source>For an empty URL display the website instead of redirecting to the language root page (not recommended).</source>
-      </trans-unit>
       <trans-unit id="tl_settings.folderUrl.0">
         <source>Enable folder URLs</source>
       </trans-unit>

--- a/core-bundle/src/Resources/contao/languages/en/tl_settings.xlf
+++ b/core-bundle/src/Resources/contao/languages/en/tl_settings.xlf
@@ -138,9 +138,6 @@
       <trans-unit id="tl_settings.backend_legend">
         <source>Back end configuration</source>
       </trans-unit>
-      <trans-unit id="tl_settings.frontend_legend">
-        <source>Front end configuration</source>
-      </trans-unit>
       <trans-unit id="tl_settings.security_legend">
         <source>Security settings</source>
       </trans-unit>

--- a/core-bundle/src/Routing/RouteProvider.php
+++ b/core-bundle/src/Routing/RouteProvider.php
@@ -303,14 +303,9 @@ class RouteProvider implements RouteProviderInterface
             []
         );
 
-        /** @var Config $config */
-        $config = $this->framework->getAdapter(Config::class);
-
-        if (!$config->get('doNotRedirectEmpty')) {
-            $defaults['_controller'] = 'Symfony\Bundle\FrameworkBundle\Controller\RedirectController::urlRedirectAction';
-            $defaults['path'] = '/'.$page->language.'/';
-            $defaults['permanent'] = true;
-        }
+        $defaults['_controller'] = 'Symfony\Bundle\FrameworkBundle\Controller\RedirectController::urlRedirectAction';
+        $defaults['path'] = '/'.$page->language.'/';
+        $defaults['permanent'] = true;
 
         $routes['tl_page.'.$page->id.'.fallback'] = new Route(
             '/',

--- a/core-bundle/src/Routing/RouteProvider.php
+++ b/core-bundle/src/Routing/RouteProvider.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Routing;
 
-use Contao\Config;
 use Contao\CoreBundle\ContaoCoreBundle;
 use Contao\CoreBundle\Exception\NoRootPageFoundException;
 use Contao\CoreBundle\Framework\ContaoFramework;


### PR DESCRIPTION
`doNotRedirectEmpty` should be removed for two reasons:
 1. it breaks the reverse proxy cache (different content for same URL)
 2. it will become obsolete by a follow-up PR for 4.10 that allows per-root setting of a locale prefix.