### PR TITLE
Use the native font stack in the layout.html.twig template

### DIFF
--- a/core-bundle/src/Resources/views/Error/layout.html.twig
+++ b/core-bundle/src/Resources/views/Error/layout.html.twig
@@ -16,13 +16,21 @@
                 body {
                     margin: 0;
                     padding: 0;
-                    font: 1rem/1.25 Lato,sans-serif;
-                    font-weight: 300;
-                    color: #222;
+                    font-family: -apple-system,system-ui,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+                    font-weight: 400;
+                    font-size: .875rem;
+                    color: #444;
                 }
-                @media (-webkit-min-device-pixel-ratio:2),(min-resolution:192dpi) {
+                h1, h2, h3 {
+                    font-weight: 600;
+                }
+                @media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
                     body {
-                        font-family: "Lato Retina", Lato, sans-serif;
+                        color: #222;
+                        font-weight: 300;
+                    }
+                    h1, h2, h3, strong, b, th {
+                        font-weight: 500;
                     }
                 }
                 a, a:visited {
@@ -31,9 +39,6 @@
                 }
                 a:hover {
                     text-decoration: underline;
-                }
-                h1, h2, h3 {
-                    font-weight: 300;
                 }
                 h1 {
                     margin: 0;
@@ -84,7 +89,7 @@
                     color: #ccc;
                 }
                 .block-error .inner {
-                    padding-left: 13%;
+                    padding-left: 7em;
                 }
             </style>
        {% endblock %}


### PR DESCRIPTION
As mentioned in https://github.com/contao/contao/issues/1442, the pretty error screens (i.e. the base `layout.html.twig`) still use the `Lato` font - without actually including the `Lato` font. This PR brings the CSS in line with the current back end style, using a native font stack and different font colors and weights depending on the device pixel ratio.

![Screenshot_2020-03-02 Service unavailable](https://user-images.githubusercontent.com/4970961/75670713-8cbbb280-5c7d-11ea-8085-620e1ad406e0.png)

![Screenshot_2020-03-02 Service unavailable(1)](https://user-images.githubusercontent.com/4970961/75670826-c42a5f00-5c7d-11ea-90b1-869b2cf718f7.png)

This PR also improves the padding on `.block-error .inner` for different zoom levels:

*Before:*

![Screenshot_2020-03-02 Service unavailable(2)](https://user-images.githubusercontent.com/4970961/75670778-b1b02580-5c7d-11ea-99d6-969813ee3d2c.png)

![Screenshot_2020-03-02 Service unavailable(3)](https://user-images.githubusercontent.com/4970961/75670780-b2e15280-5c7d-11ea-81bb-efbbc98d5fa3.png)

*After:*

![Screenshot_2020-03-02 Service unavailable(4)](https://user-images.githubusercontent.com/4970961/75670796-b96fca00-5c7d-11ea-8ad1-70b9d2ad86c0.png)

![Screenshot_2020-03-02 Service unavailable(5)](https://user-images.githubusercontent.com/4970961/75670800-baa0f700-5c7d-11ea-8aa9-c551220aef2d.png)


