### PR TITLE
Do not redirect to the language URL

### DIFF
--- a/core-bundle/src/Resources/contao/pages/PageError404.php
+++ b/core-bundle/src/Resources/contao/pages/PageError404.php
@@ -84,36 +84,6 @@ class PageError404 extends Frontend
 		// Find the matching root page
 		$objRootPage = $this->getRootPageFromUrl();
 
-		// Forward if the language should be but is not set (see #4028)
-		if (Config::get('addLanguageToUrl'))
-		{
-			// Get the request string without the script name
-			$strRequest = Environment::get('relativeRequest');
-
-			// Only redirect if there is no language fragment (see #4669)
-			if ($strRequest != '' && !preg_match('@^[a-z]{2}(-[A-Z]{2})?/@', $strRequest))
-			{
-				// Handle language fragments without trailing slash (see #7666)
-				if (preg_match('@^[a-z]{2}(-[A-Z]{2})?$@', $strRequest))
-				{
-					$this->redirect(Environment::get('request') . '/', 301);
-				}
-				else
-				{
-					if ($strRequest == Environment::get('request'))
-					{
-						$strRequest = $objRootPage->language . '/' . $strRequest;
-					}
-					else
-					{
-						$strRequest = Environment::get('script') . '/' . $objRootPage->language . '/' . $strRequest;
-					}
-
-					$this->redirect($strRequest, 301);
-				}
-			}
-		}
-
 		// Look for a 404 page
 		$obj404 = PageModel::find404ByPid($objRootPage->id);
 

--- a/core-bundle/src/Routing/RouteProvider.php
+++ b/core-bundle/src/Routing/RouteProvider.php
@@ -253,7 +253,7 @@ class RouteProvider implements RouteProviderInterface
         $path = sprintf('/%s{parameters}%s', $page->alias ?: $page->id, $this->urlSuffix);
 
         if ($this->prependLocale) {
-            $this->addLocaleRedirect($page, $pathInfo, $routes);
+            $this->addLocaleRedirect($page, $path, $requirements, $pathInfo, $routes);
 
             $path = '/{_locale}'.$path;
             $requirements['_locale'] = $page->rootLanguage;
@@ -271,18 +271,18 @@ class RouteProvider implements RouteProviderInterface
         $this->addRoutesForRootPage($page, $routes);
     }
 
-    private function addLocaleRedirect(PageModel $page, ?string $path, array &$routes)
+    private function addLocaleRedirect(PageModel $page, string $path, array $requirements, ?string $pathInfo, array &$routes)
     {
         $defaults = [
             '_controller' => 'Symfony\Bundle\FrameworkBundle\Controller\RedirectController::urlRedirectAction',
-            'path' => '/'.$page->rootLanguage.($path ?: ('/'.$page->alias.$this->urlSuffix)),
+            'path' => '/'.$page->rootLanguage.($pathInfo ?: ('/'.$page->alias.$this->urlSuffix)),
             'permanent' => true,
         ];
 
         $routes['tl_page.'.$page->id.'.locale'] = new Route(
             $path,
             $defaults,
-            [],
+            $requirements,
             ['utf8' => true],
             $page->domain
         );

--- a/core-bundle/src/Routing/RouteProvider.php
+++ b/core-bundle/src/Routing/RouteProvider.php
@@ -253,7 +253,7 @@ class RouteProvider implements RouteProviderInterface
         $path = sprintf('/%s{parameters}%s', $page->alias ?: $page->id, $this->urlSuffix);
 
         if ($this->prependLocale) {
-            $this->addLocaleRedirect($page, $pathInfo, $defaults, $routes);
+            $this->addLocaleRedirect($page, $pathInfo, $routes);
 
             $path = '/{_locale}'.$path;
             $requirements['_locale'] = $page->rootLanguage;


### PR DESCRIPTION
Since Contao 3.0 (https://github.com/contao/core/issues/4028) it is possible to enable `addLanguageToUrl`/`prepend_locale` and have Contao add the language automatically.

If a user opens `https://example.org/foobar.html` they are redirected to `https://example.org/{language}/foobar.html`, where the language depends on the best match of the root pages.

This PR removes that feature, as it seems incorrect. @contao/reviewers what's your opinion, have you ever used this feature?