### PR TITLE
Always set host and language when generating the navigation menu

### DIFF
--- a/core-bundle/src/Resources/contao/modules/ModuleNavigation.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleNavigation.php
@@ -77,17 +77,8 @@ class ModuleNavigation extends Module
 		{
 			$objRootPage = PageModel::findWithDetails($this->rootPage);
 
-			// Set the language
-			if ($objRootPage->rootLanguage != $objPage->rootLanguage && Config::get('addLanguageToUrl'))
-			{
-				$lang = $objRootPage->rootLanguage;
-			}
-
-			// Set the domain
-			if ($objRootPage->rootId != $objPage->rootId && $objRootPage->domain != '' && $objRootPage->domain != $objPage->domain)
-			{
-				$host = $objRootPage->domain;
-			}
+			$lang = $objRootPage->rootLanguage;
+			$host = $objRootPage->domain;
 		}
 
 		$this->Template->request = ampersand(Environment::get('indexFreeRequest'));

--- a/core-bundle/src/Resources/contao/modules/ModuleSitemap.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleSitemap.php
@@ -69,17 +69,8 @@ class ModuleSitemap extends Module
 		{
 			$objRootPage = PageModel::findWithDetails($this->rootPage);
 
-			// Set the language
-			if ($objRootPage->rootLanguage != $objPage->rootLanguage && Config::get('addLanguageToUrl'))
-			{
-				$lang = $objRootPage->rootLanguage;
-			}
-
-			// Set the domain
-			if ($objRootPage->rootId != $objPage->rootId && $objRootPage->domain != '' && $objRootPage->domain != $objPage->domain)
-			{
-				$host = $objRootPage->domain;
-			}
+			$lang = $objRootPage->rootLanguage;
+			$host = $objRootPage->domain;
 		}
 
 		$this->showLevel = 0;


### PR DESCRIPTION
Currently, the host and language is only forwarded to the `renderNavigation` method if it's different than the current one. But I don't really see a point in that, why would it not always be passed on? 

Also, the `$language` property isn't used at all anymore, it seems. Removing this condition is helpful to _get rid of_ `addLanguageToUrl` stuff.