### PR TITLE
Do not allow slashes at the beginning and end of a folder alias

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Validator.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Validator.php
@@ -188,7 +188,7 @@ class Validator
 	 */
 	public static function isFolderAlias($varValue)
 	{
-		return preg_match('/^[\w\/.-]+$/u', $varValue);
+		return preg_match('(^(?!/)[\w/.-]+(?<!/)$)u', $varValue);
 	}
 
 	/**


### PR DESCRIPTION
This fix is required for the routing changes @aschempp is working on (no PR available yet).