### PR TITLE
Use "isSortable" in file and page trees without orderField

### DIFF
--- a/calendar-bundle/src/Resources/contao/dca/tl_calendar_events.php
+++ b/calendar-bundle/src/Resources/contao/dca/tl_calendar_events.php
@@ -424,12 +424,7 @@ $GLOBALS['TL_DCA']['tl_calendar_events'] = array
 		(
 			'exclude'                 => true,
 			'inputType'               => 'fileTree',
-			'eval'                    => array('multiple'=>true, 'fieldType'=>'checkbox', 'filesOnly'=>true, 'isDownloads'=>true, 'extensions'=>Contao\Config::get('allowedDownload'), 'mandatory'=>true, 'orderField'=>'orderEnclosure'),
-			'sql'                     => "blob NULL"
-		),
-		'orderEnclosure' => array
-		(
-			'label'                   => &$GLOBALS['TL_LANG']['MSC']['sortOrder'],
+			'eval'                    => array('multiple'=>true, 'fieldType'=>'checkbox', 'filesOnly'=>true, 'isDownloads'=>true, 'extensions'=>Contao\Config::get('allowedDownload'), 'mandatory'=>true, 'isSortable'=>true),
 			'sql'                     => "blob NULL"
 		),
 		'source' => array

--- a/core-bundle/src/Migration/Version410/OrderFieldMigration.php
+++ b/core-bundle/src/Migration/Version410/OrderFieldMigration.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Migration\Version410;
+
+use Contao\CoreBundle\Migration\AbstractMigration;
+use Contao\CoreBundle\Migration\MigrationResult;
+use Contao\StringUtil;
+use Doctrine\DBAL\Connection;
+
+/**
+ * @internal
+ */
+class OrderFieldMigration extends AbstractMigration
+{
+    private const ORDER_FIELDS = [
+        'tl_calendar_events' => [
+            'orderEnclosure' => 'enclosure',
+        ],
+        'tl_layout' => [
+            'orderExt' => 'external',
+            'orderExtJs' => 'externalJs',
+        ],
+        'tl_module' => [
+            'orderPages' => 'pages',
+        ],
+        'tl_faq' => [
+            'orderEnclosure' => 'enclosure',
+        ],
+        'tl_news' => [
+            'orderEnclosure' => 'enclosure',
+        ],
+    ];
+
+    /**
+     * @var Connection
+     */
+    private $connection;
+
+    public function __construct(Connection $connection)
+    {
+        $this->connection = $connection;
+    }
+
+    public function shouldRun(): bool
+    {
+        $schemaManager = $this->connection->getSchemaManager();
+
+        foreach (self::ORDER_FIELDS as $table => $fields) {
+            if (!$schemaManager->tablesExist($table)) {
+                continue;
+            }
+
+            $columns = $schemaManager->listTableColumns($table);
+
+            foreach ($fields as $orderField => $field) {
+                if (isset($columns[strtolower($orderField)], $columns[strtolower($field)])) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    public function run(): MigrationResult
+    {
+        $schemaManager = $this->connection->getSchemaManager();
+
+        foreach (self::ORDER_FIELDS as $table => $fields) {
+            if (!$schemaManager->tablesExist($table)) {
+                continue;
+            }
+
+            $columns = $schemaManager->listTableColumns($table);
+
+            foreach ($fields as $orderField => $field) {
+                if (isset($columns[strtolower($orderField)], $columns[strtolower($field)])) {
+                    $this->migrateOrderField($table, $orderField, $field);
+                }
+            }
+        }
+
+        return new MigrationResult(true, '');
+    }
+
+    private function migrateOrderField(string $table, string $orderField, string $field): void
+    {
+        $tableQuoted = $this->connection->quoteIdentifier($table);
+        $orderFieldQuoted = $this->connection->quoteIdentifier($orderField);
+        $fieldQuoted = $this->connection->quoteIdentifier($field);
+
+        $stmt = $this->connection->query("
+            SELECT
+                $orderFieldQuoted, $fieldQuoted
+            FROM
+                $tableQuoted
+            WHERE 
+                $orderFieldQuoted IS NOT NULL 
+                AND $orderFieldQuoted != ''
+                AND $fieldQuoted IS NOT NULL 
+                AND $fieldQuoted != ''
+        ");
+
+        while (false !== ($row = $stmt->fetch(\PDO::FETCH_OBJ))) {
+            $items = StringUtil::deserialize($row->$field, true);
+            $order = array_map(static function (): void {}, array_flip(StringUtil::deserialize($row->$orderField, true)));
+
+            foreach ($items as $key => $value) {
+                if (\array_key_exists($value, $order)) {
+                    $order[$value] = $value;
+                    unset($items[$key]);
+                }
+            }
+
+            $items = array_merge(array_values(array_filter($order)), array_values($items));
+
+            $this->connection->prepare("
+                UPDATE
+                    $tableQuoted
+                SET
+                    $fieldQuoted = :items,
+                    $orderFieldQuoted = ''
+            ")->execute([':items' => serialize($items)]);
+        }
+
+        $this->connection->query("
+            ALTER TABLE $tableQuoted DROP $orderFieldQuoted
+        ");
+    }
+}

--- a/core-bundle/src/Migration/Version410/OrderFieldMigration.php
+++ b/core-bundle/src/Migration/Version410/OrderFieldMigration.php
@@ -104,10 +104,10 @@ class OrderFieldMigration extends AbstractMigration
                 $orderFieldQuoted, $fieldQuoted
             FROM
                 $tableQuoted
-            WHERE 
-                $orderFieldQuoted IS NOT NULL 
+            WHERE
+                $orderFieldQuoted IS NOT NULL
                 AND $orderFieldQuoted != ''
-                AND $fieldQuoted IS NOT NULL 
+                AND $fieldQuoted IS NOT NULL
                 AND $fieldQuoted != ''
         ");
 
@@ -124,17 +124,18 @@ class OrderFieldMigration extends AbstractMigration
 
             $items = array_merge(array_values(array_filter($order)), array_values($items));
 
-            $this->connection->prepare("
-                UPDATE
-                    $tableQuoted
-                SET
-                    $fieldQuoted = :items,
-                    $orderFieldQuoted = ''
-            ")->execute([':items' => serialize($items)]);
+            $this->connection
+                ->prepare("
+                    UPDATE
+                        $tableQuoted
+                    SET
+                        $fieldQuoted = :items,
+                        $orderFieldQuoted = ''
+                ")
+                ->execute([':items' => serialize($items)])
+            ;
         }
 
-        $this->connection->query("
-            ALTER TABLE $tableQuoted DROP $orderFieldQuoted
-        ");
+        $this->connection->query("ALTER TABLE $tableQuoted DROP $orderFieldQuoted");
     }
 }

--- a/core-bundle/src/Resources/config/migrations.yml
+++ b/core-bundle/src/Resources/config/migrations.yml
@@ -8,3 +8,7 @@ services:
         arguments:
             - '@database_connection'
             - '@contao.framework'
+
+    Contao\CoreBundle\Migration\Version410\OrderFieldMigration:
+        arguments:
+            - '@database_connection'

--- a/core-bundle/src/Resources/contao/dca/tl_layout.php
+++ b/core-bundle/src/Resources/contao/dca/tl_layout.php
@@ -220,12 +220,7 @@ $GLOBALS['TL_DCA']['tl_layout'] = array
 		(
 			'exclude'                 => true,
 			'inputType'               => 'fileTree',
-			'eval'                    => array('multiple'=>true, 'fieldType'=>'checkbox', 'filesOnly'=>true, 'extensions'=>'css,scss,less', 'orderField'=>'orderExt'),
-			'sql'                     => "blob NULL"
-		),
-		'orderExt' => array
-		(
-			'label'                   => &$GLOBALS['TL_LANG']['MSC']['sortOrder'],
+			'eval'                    => array('multiple'=>true, 'fieldType'=>'checkbox', 'filesOnly'=>true, 'extensions'=>'css,scss,less', 'isSortable'=>true),
 			'sql'                     => "blob NULL"
 		),
 		'loadingOrder' => array
@@ -416,12 +411,7 @@ $GLOBALS['TL_DCA']['tl_layout'] = array
 		(
 			'exclude'                 => true,
 			'inputType'               => 'fileTree',
-			'eval'                    => array('multiple'=>true, 'fieldType'=>'checkbox', 'filesOnly'=>true, 'extensions'=>'js', 'orderField'=>'orderExtJs'),
-			'sql'                     => "blob NULL"
-		),
-		'orderExtJs' => array
-		(
-			'label'                   => &$GLOBALS['TL_LANG']['MSC']['sortOrder'],
+			'eval'                    => array('multiple'=>true, 'fieldType'=>'checkbox', 'filesOnly'=>true, 'extensions'=>'js', 'isSortable'=>true),
 			'sql'                     => "blob NULL"
 		),
 		'scripts' => array

--- a/core-bundle/src/Resources/contao/dca/tl_module.php
+++ b/core-bundle/src/Resources/contao/dca/tl_module.php
@@ -245,18 +245,13 @@ $GLOBALS['TL_DCA']['tl_module'] = array
 			'exclude'                 => true,
 			'inputType'               => 'pageTree',
 			'foreignKey'              => 'tl_page.title',
-			'eval'                    => array('multiple'=>true, 'fieldType'=>'checkbox', 'orderField'=>'orderPages', 'mandatory'=>true),
+			'eval'                    => array('multiple'=>true, 'fieldType'=>'checkbox', 'isSortable'=>true, 'mandatory'=>true),
 			'load_callback' => array
 			(
 				array('tl_module', 'setPagesFlags')
 			),
 			'sql'                     => "blob NULL",
 			'relation'                => array('type'=>'hasMany', 'load'=>'lazy')
-		),
-		'orderPages' => array
-		(
-			'label'                   => &$GLOBALS['TL_LANG']['MSC']['sortOrder'],
-			'sql'                     => "blob NULL"
 		),
 		'showHidden' => array
 		(
@@ -855,7 +850,7 @@ class tl_module extends Contao\Backend
 		if ($dc->activeRecord && $dc->activeRecord->type == 'search')
 		{
 			$GLOBALS['TL_DCA'][$dc->table]['fields'][$dc->field]['eval']['mandatory'] = false;
-			unset($GLOBALS['TL_DCA'][$dc->table]['fields'][$dc->field]['eval']['orderField']);
+			unset($GLOBALS['TL_DCA'][$dc->table]['fields'][$dc->field]['eval']['isSortable']);
 		}
 
 		return $varValue;

--- a/core-bundle/src/Resources/contao/library/Contao/Controller.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Controller.php
@@ -1880,7 +1880,7 @@ abstract class Controller extends System
 		// Order the enclosures
 		if (!empty($arrItem['orderEnclosure']))
 		{
-			@trigger_error('Using orderEnclosure has been deprecated and will no longer work in Contao 5.0. Use the fileTree with isSortable instead.', E_USER_DEPRECATED);
+			@trigger_error('Using "orderEnclosure" has been deprecated and will no longer work in Contao 5.0. Use a file tree with "isSortable" instead.', E_USER_DEPRECATED);
 
 			$arrEnclosures = ArrayUtil::sortByOrderField($arrEnclosures, $arrItem['orderEnclosure']);
 		}

--- a/core-bundle/src/Resources/contao/library/Contao/Controller.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Controller.php
@@ -1880,6 +1880,8 @@ abstract class Controller extends System
 		// Order the enclosures
 		if (!empty($arrItem['orderEnclosure']))
 		{
+			@trigger_error('Using orderEnclosure has been deprecated and will no longer work in Contao 5.0. Use the fileTree with isSortable instead.', E_USER_DEPRECATED);
+
 			$arrEnclosures = ArrayUtil::sortByOrderField($arrEnclosures, $arrItem['orderEnclosure']);
 		}
 

--- a/core-bundle/src/Resources/contao/models/LayoutModel.php
+++ b/core-bundle/src/Resources/contao/models/LayoutModel.php
@@ -29,7 +29,6 @@ use Contao\Model\Collection;
  * @property string  $framework
  * @property string  $stylesheet
  * @property string  $external
- * @property string  $orderExt
  * @property string  $loadingOrder
  * @property boolean $combineScripts
  * @property string  $modules
@@ -51,7 +50,6 @@ use Contao\Model\Collection;
  * @property string  $mootools
  * @property string  $analytics
  * @property string  $externalJs
- * @property string  $orderExtJs
  * @property string  $script
  * @property string  $scripts
  * @property boolean $static
@@ -75,7 +73,6 @@ use Contao\Model\Collection;
  * @method static LayoutModel|null findOneByFramework($val, array $opt=array())
  * @method static LayoutModel|null findOneByStylesheet($val, array $opt=array())
  * @method static LayoutModel|null findOneByExternal($val, array $opt=array())
- * @method static LayoutModel|null findOneByOrderExt($val, array $opt=array())
  * @method static LayoutModel|null findOneByLoadingOrder($val, array $opt=array())
  * @method static LayoutModel|null findOneByCombineScripts($val, array $opt=array())
  * @method static LayoutModel|null findOneByModules($val, array $opt=array())
@@ -97,7 +94,6 @@ use Contao\Model\Collection;
  * @method static LayoutModel|null findOneByMootools($val, array $opt=array())
  * @method static LayoutModel|null findOneByAnalytics($val, array $opt=array())
  * @method static LayoutModel|null findOneByExternalJs($val, array $opt=array())
- * @method static LayoutModel|null findOneByOrderExtJs($val, array $opt=array())
  * @method static LayoutModel|null findOneByScript($val, array $opt=array())
  * @method static LayoutModel|null findOneByScripts($val, array $opt=array())
  * @method static LayoutModel|null findOneByStatic($val, array $opt=array())
@@ -117,7 +113,6 @@ use Contao\Model\Collection;
  * @method static Collection|LayoutModel[]|LayoutModel|null findByFramework($val, array $opt=array())
  * @method static Collection|LayoutModel[]|LayoutModel|null findByStylesheet($val, array $opt=array())
  * @method static Collection|LayoutModel[]|LayoutModel|null findByExternal($val, array $opt=array())
- * @method static Collection|LayoutModel[]|LayoutModel|null findByOrderExt($val, array $opt=array())
  * @method static Collection|LayoutModel[]|LayoutModel|null findByLoadingOrder($val, array $opt=array())
  * @method static Collection|LayoutModel[]|LayoutModel|null findByCombineScripts($val, array $opt=array())
  * @method static Collection|LayoutModel[]|LayoutModel|null findByModules($val, array $opt=array())
@@ -139,7 +134,6 @@ use Contao\Model\Collection;
  * @method static Collection|LayoutModel[]|LayoutModel|null findByMootools($val, array $opt=array())
  * @method static Collection|LayoutModel[]|LayoutModel|null findByAnalytics($val, array $opt=array())
  * @method static Collection|LayoutModel[]|LayoutModel|null findByExternalJs($val, array $opt=array())
- * @method static Collection|LayoutModel[]|LayoutModel|null findByOrderExtJs($val, array $opt=array())
  * @method static Collection|LayoutModel[]|LayoutModel|null findByScript($val, array $opt=array())
  * @method static Collection|LayoutModel[]|LayoutModel|null findByScripts($val, array $opt=array())
  * @method static Collection|LayoutModel[]|LayoutModel|null findByStatic($val, array $opt=array())
@@ -163,7 +157,6 @@ use Contao\Model\Collection;
  * @method static integer countByFramework($val, array $opt=array())
  * @method static integer countByStylesheet($val, array $opt=array())
  * @method static integer countByExternal($val, array $opt=array())
- * @method static integer countByOrderExt($val, array $opt=array())
  * @method static integer countByLoadingOrder($val, array $opt=array())
  * @method static integer countByCombineScripts($val, array $opt=array())
  * @method static integer countByModules($val, array $opt=array())
@@ -185,7 +178,6 @@ use Contao\Model\Collection;
  * @method static integer countByMootools($val, array $opt=array())
  * @method static integer countByAnalytics($val, array $opt=array())
  * @method static integer countByExternalJs($val, array $opt=array())
- * @method static integer countByOrderExtJs($val, array $opt=array())
  * @method static integer countByScript($val, array $opt=array())
  * @method static integer countByScripts($val, array $opt=array())
  * @method static integer countByStatic($val, array $opt=array())

--- a/core-bundle/src/Resources/contao/models/ModuleModel.php
+++ b/core-bundle/src/Resources/contao/models/ModuleModel.php
@@ -30,7 +30,6 @@ use Contao\Model\Collection;
  * @property string  $navigationTpl
  * @property string  $customTpl
  * @property string  $pages
- * @property string  $orderPages
  * @property boolean $showHidden
  * @property string  $customLabel
  * @property boolean $autologin
@@ -98,7 +97,6 @@ use Contao\Model\Collection;
  * @method static ModuleModel|null findOneByNavigationTpl($val, array $opt=array())
  * @method static ModuleModel|null findOneByCustomTpl($val, array $opt=array())
  * @method static ModuleModel|null findOneByPages($val, array $opt=array())
- * @method static ModuleModel|null findOneByOrderPages($val, array $opt=array())
  * @method static ModuleModel|null findOneByShowHidden($val, array $opt=array())
  * @method static ModuleModel|null findOneByCustomLabel($val, array $opt=array())
  * @method static ModuleModel|null findOneByAutologin($val, array $opt=array())
@@ -162,7 +160,6 @@ use Contao\Model\Collection;
  * @method static Collection|ModuleModel[]|ModuleModel|null findByNavigationTpl($val, array $opt=array())
  * @method static Collection|ModuleModel[]|ModuleModel|null findByCustomTpl($val, array $opt=array())
  * @method static Collection|ModuleModel[]|ModuleModel|null findByPages($val, array $opt=array())
- * @method static Collection|ModuleModel[]|ModuleModel|null findByOrderPages($val, array $opt=array())
  * @method static Collection|ModuleModel[]|ModuleModel|null findByShowHidden($val, array $opt=array())
  * @method static Collection|ModuleModel[]|ModuleModel|null findByCustomLabel($val, array $opt=array())
  * @method static Collection|ModuleModel[]|ModuleModel|null findByAutologin($val, array $opt=array())
@@ -230,7 +227,6 @@ use Contao\Model\Collection;
  * @method static integer countByNavigationTpl($val, array $opt=array())
  * @method static integer countByCustomTpl($val, array $opt=array())
  * @method static integer countByPages($val, array $opt=array())
- * @method static integer countByOrderPages($val, array $opt=array())
  * @method static integer countByShowHidden($val, array $opt=array())
  * @method static integer countByCustomLabel($val, array $opt=array())
  * @method static integer countByAutologin($val, array $opt=array())

--- a/core-bundle/src/Resources/contao/modules/Module.php
+++ b/core-bundle/src/Resources/contao/modules/Module.php
@@ -31,7 +31,6 @@ use FOS\HttpCache\ResponseTagger;
  * @property string  $navigationTpl
  * @property string  $customTpl
  * @property array   $pages
- * @property string  $orderPages
  * @property boolean $showHidden
  * @property string  $customLabel
  * @property boolean $autologin

--- a/core-bundle/src/Resources/contao/modules/ModuleCustomnav.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleCustomnav.php
@@ -84,35 +84,14 @@ class ModuleCustomnav extends Module
 			return;
 		}
 
-		$arrPages = array();
-
-		// Sort the array keys according to the given order
-		if ($this->orderPages != '')
-		{
-			$tmp = StringUtil::deserialize($this->orderPages);
-
-			if (!empty($tmp) && \is_array($tmp))
-			{
-				$arrPages = array_map(static function () {}, array_flip($tmp));
-			}
-		}
-
-		// Add the items to the pre-sorted array
-		while ($objPages->next())
-		{
-			$arrPages[$objPages->id] = $objPages->current();
-		}
-
-		$arrPages = array_values(array_filter($arrPages));
-
 		$objTemplate = new FrontendTemplate($this->navigationTpl ?: 'nav_default');
 		$objTemplate->type = static::class;
 		$objTemplate->cssID = $this->cssID; // see #4897 and 6129
 		$objTemplate->level = 'level_1';
 		$objTemplate->module = $this; // see #155
 
-		/** @var PageModel[] $arrPages */
-		foreach ($arrPages as $objModel)
+		/** @var PageModel[] $objPages */
+		foreach ($objPages as $objModel)
 		{
 			$_groups = StringUtil::deserialize($objModel->groups);
 

--- a/core-bundle/src/Resources/contao/modules/ModuleQuicklink.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleQuicklink.php
@@ -78,30 +78,10 @@ class ModuleQuicklink extends Module
 			return;
 		}
 
-		$arrPages = array();
-
-		// Sort the array keys according to the given order
-		if ($this->orderPages != '')
-		{
-			$tmp = StringUtil::deserialize($this->orderPages);
-
-			if (!empty($tmp) && \is_array($tmp))
-			{
-				$arrPages = array_map(static function () {}, array_flip($tmp));
-			}
-		}
-
-		// Add the items to the pre-sorted array
-		while ($objPages->next())
-		{
-			$arrPages[$objPages->id] = $objPages->current();
-		}
-
 		$items = array();
-		$arrPages = array_values(array_filter($arrPages));
 
-		/** @var PageModel[] $arrPages */
-		foreach ($arrPages as $objSubpage)
+		/** @var PageModel[] $objPages */
+		foreach ($objPages as $objSubpage)
 		{
 			$objSubpage->title = StringUtil::stripInsertTags($objSubpage->title);
 			$objSubpage->pageTitle = StringUtil::stripInsertTags($objSubpage->pageTitle);

--- a/core-bundle/src/Resources/contao/pages/PageRegular.php
+++ b/core-bundle/src/Resources/contao/pages/PageRegular.php
@@ -602,38 +602,6 @@ class PageRegular extends Frontend
 		// External style sheets
 		if (!empty($arrExternal) && \is_array($arrExternal))
 		{
-			// Consider the sorting order (see #5038)
-			if ($objLayout->orderExt != '')
-			{
-				$tmp = StringUtil::deserialize($objLayout->orderExt);
-
-				if (!empty($tmp) && \is_array($tmp))
-				{
-					// Remove all values
-					$arrOrder = array_map(static function () {}, array_flip($tmp));
-
-					// Move the matching elements to their position in $arrOrder
-					foreach ($arrExternal as $k=>$v)
-					{
-						if (\array_key_exists($v, $arrOrder))
-						{
-							$arrOrder[$v] = $v;
-							unset($arrExternal[$k]);
-						}
-					}
-
-					// Append the left-over style sheets at the end
-					if (!empty($arrExternal))
-					{
-						$arrOrder = array_merge($arrOrder, array_values($arrExternal));
-					}
-
-					// Remove empty (unreplaced) entries
-					$arrExternal = array_values(array_filter($arrOrder));
-					unset($arrOrder);
-				}
-			}
-
 			// Get the file entries from the database
 			$objFiles = FilesModel::findMultipleByUuids($arrExternal);
 			$rootDir = System::getContainer()->getParameter('kernel.project_dir');
@@ -764,38 +732,6 @@ class PageRegular extends Frontend
 
 		// Add the external JavaScripts
 		$arrExternalJs = StringUtil::deserialize($objLayout->externalJs);
-
-		// Consider the sorting order (see #5038)
-		if (!empty($arrExternalJs) && \is_array($arrExternalJs) && $objLayout->orderExtJs != '')
-		{
-			$tmp = StringUtil::deserialize($objLayout->orderExtJs);
-
-			if (!empty($tmp) && \is_array($tmp))
-			{
-				// Remove all values
-				$arrOrder = array_map(static function () {}, array_flip($tmp));
-
-				// Move the matching elements to their position in $arrOrder
-				foreach ($arrExternalJs as $k=>$v)
-				{
-					if (\array_key_exists($v, $arrOrder))
-					{
-						$arrOrder[$v] = $v;
-						unset($arrExternalJs[$k]);
-					}
-				}
-
-				// Append the left-over JavaScripts at the end
-				if (!empty($arrExternalJs))
-				{
-					$arrOrder = array_merge($arrOrder, array_values($arrExternalJs));
-				}
-
-				// Remove empty (unreplaced) entries
-				$arrExternalJs = array_values(array_filter($arrOrder));
-				unset($arrOrder);
-			}
-		}
 
 		// Get the file entries from the database
 		$objFiles = FilesModel::findMultipleByUuids($arrExternalJs);

--- a/core-bundle/src/Resources/contao/widgets/FileTree.php
+++ b/core-bundle/src/Resources/contao/widgets/FileTree.php
@@ -66,7 +66,7 @@ class FileTree extends Widget
 
 		if ($this->isSortable && !$this->filesOnly && !$this->orderField && ($this->isGallery || $this->isDownloads))
 		{
-			throw new \RuntimeException('File tree in gallery or downloads mode needs a configured orderField to be sortable.');
+			throw new \RuntimeException('A file tree in gallery or downloads mode needs an "orderField" to be sortable');
 		}
 
 		// Prepare the order field

--- a/core-bundle/src/Resources/contao/widgets/FileTree.php
+++ b/core-bundle/src/Resources/contao/widgets/FileTree.php
@@ -16,6 +16,7 @@ use Contao\Image\ResizeConfiguration;
  * Provide methods to handle input field "file tree".
  *
  * @property string  $orderField
+ * @property boolean $isSortable
  * @property boolean $multiple
  * @property boolean $isGallery
  * @property boolean $isDownloads
@@ -62,6 +63,11 @@ class FileTree extends Widget
 	{
 		$this->import(Database::class, 'Database');
 		parent::__construct($arrAttributes);
+
+		if ($this->isSortable && !$this->filesOnly && !$this->orderField && ($this->isGallery || $this->isDownloads))
+		{
+			throw new \RuntimeException('File tree in gallery or downloads mode needs a configured orderField to be sortable.');
+		}
 
 		// Prepare the order field
 		if ($this->orderField != '')
@@ -330,9 +336,9 @@ class FileTree extends Widget
 
 		$return = '<input type="hidden" name="' . $this->strName . '" id="ctrl_' . $this->strId . '" value="' . $strSet . '">' . ($blnHasOrder ? '
   <input type="hidden" name="' . $this->strOrderName . '" id="ctrl_' . $this->strOrderId . '" value="' . $strOrder . '">' : '') . '
-  <div class="selector_container">' . (($blnHasOrder && \count($arrValues) > 1) ? '
+  <div class="selector_container">' . ((($blnHasOrder || $this->isSortable) && \count($arrValues) > 1) ? '
     <p class="sort_hint">' . $GLOBALS['TL_LANG']['MSC']['dragItemsHint'] . '</p>' : '') . '
-    <ul id="sort_' . $this->strId . '" class="' . trim(($blnHasOrder ? 'sortable ' : '') . ($this->isGallery ? 'sgallery' : '')) . '">';
+    <ul id="sort_' . $this->strId . '" class="' . trim(($blnHasOrder || $this->isSortable ? 'sortable ' : '') . ($this->isGallery ? 'sgallery' : '')) . '">';
 
 		foreach ($arrValues as $k=>$v)
 		{
@@ -371,8 +377,8 @@ class FileTree extends Widget
           }
         });
       });
-    </script>' . ($blnHasOrder ? '
-    <script>Backend.makeMultiSrcSortable("sort_' . $this->strId . '", "ctrl_' . $this->strOrderId . '", "ctrl_' . $this->strId . '")</script>' : '');
+    </script>' . ($blnHasOrder || $this->isSortable ? '
+    <script>Backend.makeMultiSrcSortable("sort_' . $this->strId . '", "ctrl_' . ($blnHasOrder ? $this->strOrderId : $this->strId) . '", "ctrl_' . $this->strId . '")</script>' : '');
 		}
 
 		$return = '<div>' . $return . '</div></div>';

--- a/core-bundle/src/Resources/contao/widgets/PageTree.php
+++ b/core-bundle/src/Resources/contao/widgets/PageTree.php
@@ -59,7 +59,7 @@ class PageTree extends Widget
 		// Prepare the order field
 		if ($this->orderField != '')
 		{
-			@trigger_error('Using an orderField for pageTree has been deprecated and will no longer work in Contao 5.0. Use isSortable instead.', E_USER_DEPRECATED);
+			@trigger_error('Using "orderField" for the page tree has been deprecated and will no longer work in Contao 5.0. Use "isSortable" instead.', E_USER_DEPRECATED);
 
 			$this->strOrderId = $this->orderField . str_replace($this->strField, '', $this->strId);
 			$this->strOrderName = $this->orderField . str_replace($this->strField, '', $this->strName);

--- a/core-bundle/src/Resources/contao/widgets/PageTree.php
+++ b/core-bundle/src/Resources/contao/widgets/PageTree.php
@@ -59,6 +59,8 @@ class PageTree extends Widget
 		// Prepare the order field
 		if ($this->orderField != '')
 		{
+			@trigger_error('Using an orderField for pageTree has been deprecated and will no longer work in Contao 5.0. Use isSortable instead.', E_USER_DEPRECATED);
+
 			$this->strOrderId = $this->orderField . str_replace($this->strField, '', $this->strId);
 			$this->strOrderName = $this->orderField . str_replace($this->strField, '', $this->strName);
 
@@ -190,9 +192,9 @@ class PageTree extends Widget
 
 		$return = '<input type="hidden" name="' . $this->strName . '" id="ctrl_' . $this->strId . '" value="' . implode(',', $arrSet) . '">' . ($blnHasOrder ? '
   <input type="hidden" name="' . $this->strOrderName . '" id="ctrl_' . $this->strOrderId . '" value="' . $this->{$this->orderField} . '">' : '') . '
-  <div class="selector_container">' . (($blnHasOrder && \count($arrValues) > 1) ? '
+  <div class="selector_container">' . ((($blnHasOrder || $this->isSortable) && \count($arrValues) > 1) ? '
     <p class="sort_hint">' . $GLOBALS['TL_LANG']['MSC']['dragItemsHint'] . '</p>' : '') . '
-    <ul id="sort_' . $this->strId . '" class="' . ($blnHasOrder ? 'sortable' : '') . '">';
+    <ul id="sort_' . $this->strId . '" class="' . ($blnHasOrder || $this->isSortable ? 'sortable' : '') . '">';
 
 		foreach ($arrValues as $k=>$v)
 		{
@@ -231,8 +233,8 @@ class PageTree extends Widget
           }
         });
       });
-    </script>' . ($blnHasOrder ? '
-    <script>Backend.makeMultiSrcSortable("sort_' . $this->strId . '", "ctrl_' . $this->strOrderId . '", "ctrl_' . $this->strId . '")</script>' : '');
+    </script>' . ($blnHasOrder || $this->isSortable ? '
+    <script>Backend.makeMultiSrcSortable("sort_' . $this->strId . '", "ctrl_' . ($blnHasOrder ? $this->strOrderId : $this->strId) . '", "ctrl_' . $this->strId . '")</script>' : '');
 		}
 
 		$return = '<div>' . $return . '</div></div>';

--- a/core-bundle/src/Resources/contao/widgets/Picker.php
+++ b/core-bundle/src/Resources/contao/widgets/Picker.php
@@ -40,7 +40,7 @@ class Picker extends Widget
 		// Prepare the order field
 		if ($this->orderField != '')
 		{
-			@trigger_error('Using an orderField for the picker has been deprecated and will no longer work in Contao 5.0. Use isSortable instead.', E_USER_DEPRECATED);
+			@trigger_error('Using "orderField" for the picker has been deprecated and will no longer work in Contao 5.0. Use "isSortable" instead.', E_USER_DEPRECATED);
 
 			$this->strOrderId = $this->orderField . str_replace($this->strField, '', $this->strId);
 			$this->strOrderName = $this->orderField . str_replace($this->strField, '', $this->strName);

--- a/core-bundle/src/Resources/contao/widgets/Picker.php
+++ b/core-bundle/src/Resources/contao/widgets/Picker.php
@@ -40,6 +40,8 @@ class Picker extends Widget
 		// Prepare the order field
 		if ($this->orderField != '')
 		{
+			@trigger_error('Using an orderField for the picker has been deprecated and will no longer work in Contao 5.0. Use isSortable instead.', E_USER_DEPRECATED);
+
 			$this->strOrderId = $this->orderField . str_replace($this->strField, '', $this->strId);
 			$this->strOrderName = $this->orderField . str_replace($this->strField, '', $this->strName);
 
@@ -122,9 +124,9 @@ class Picker extends Widget
 
 		$return = '<input type="hidden" name="' . $this->strName . '" id="ctrl_' . $this->strId . '" value="' . implode(',', $arrSet) . '">' . ($blnHasOrder ? '
   <input type="hidden" name="' . $this->strOrderName . '" id="ctrl_' . $this->strOrderId . '" value="' . $this->{$this->orderField} . '">' : '') . '
-  <div class="selector_container">' . (($blnHasOrder && \count($arrValues) > 1) ? '
+  <div class="selector_container">' . ((($blnHasOrder || $this->isSortable) && \count($arrValues) > 1) ? '
     <p class="sort_hint">' . $GLOBALS['TL_LANG']['MSC']['dragItemsHint'] . '</p>' : '') . '
-    <ul id="sort_' . $this->strId . '" class="' . ($blnHasOrder ? 'sortable' : '') . '">';
+    <ul id="sort_' . $this->strId . '" class="' . (($blnHasOrder || $this->isSortable) ? 'sortable' : '') . '">';
 
 		foreach ($arrValues as $k=>$v)
 		{
@@ -163,8 +165,8 @@ class Picker extends Widget
           }
         });
       });
-    </script>' . ($blnHasOrder ? '
-    <script>Backend.makeMultiSrcSortable("sort_' . $this->strId . '", "ctrl_' . $this->strOrderId . '", "ctrl_' . $this->strId . '")</script>' : '');
+    </script>' . ($blnHasOrder || $this->isSortable ? '
+    <script>Backend.makeMultiSrcSortable("sort_' . $this->strId . '", "ctrl_' . ($blnHasOrder ? $this->strOrderId : $this->strId) . '", "ctrl_' . $this->strId . '")</script>' : '');
 		}
 
 		$return = '<div>' . $return . '</div></div>';
@@ -187,7 +189,8 @@ class Picker extends Widget
 
 		if (!empty($this->varValue))
 		{
-			$objRows = $this->Database->execute("SELECT * FROM $strRelatedTable WHERE id IN (" . implode(',', array_map('intval', (array) $this->varValue)) . ")");
+			$strIdList = implode(',', array_map('intval', (array) $this->varValue));
+			$objRows = $this->Database->execute("SELECT * FROM $strRelatedTable WHERE id IN ($strIdList) ORDER BY FIND_IN_SET(id, '$strIdList')");
 
 			if ($objRows->numRows)
 			{

--- a/faq-bundle/src/Resources/contao/dca/tl_faq.php
+++ b/faq-bundle/src/Resources/contao/dca/tl_faq.php
@@ -286,12 +286,7 @@ $GLOBALS['TL_DCA']['tl_faq'] = array
 		(
 			'exclude'                 => true,
 			'inputType'               => 'fileTree',
-			'eval'                    => array('multiple'=>true, 'fieldType'=>'checkbox', 'filesOnly'=>true, 'isDownloads'=>true, 'extensions'=>Contao\Config::get('allowedDownload'), 'mandatory'=>true, 'orderField'=>'orderEnclosure'),
-			'sql'                     => "blob NULL"
-		),
-		'orderEnclosure' => array
-		(
-			'label'                   => &$GLOBALS['TL_LANG']['MSC']['sortOrder'],
+			'eval'                    => array('multiple'=>true, 'fieldType'=>'checkbox', 'filesOnly'=>true, 'isDownloads'=>true, 'extensions'=>Contao\Config::get('allowedDownload'), 'mandatory'=>true, 'isSortable'=>true),
 			'sql'                     => "blob NULL"
 		),
 		'noComments' => array

--- a/news-bundle/src/Resources/contao/dca/tl_news.php
+++ b/news-bundle/src/Resources/contao/dca/tl_news.php
@@ -368,12 +368,7 @@ $GLOBALS['TL_DCA']['tl_news'] = array
 		(
 			'exclude'                 => true,
 			'inputType'               => 'fileTree',
-			'eval'                    => array('multiple'=>true, 'fieldType'=>'checkbox', 'filesOnly'=>true, 'isDownloads'=>true, 'extensions'=>Contao\Config::get('allowedDownload'), 'mandatory'=>true, 'orderField'=>'orderEnclosure'),
-			'sql'                     => "blob NULL"
-		),
-		'orderEnclosure' => array
-		(
-			'label'                   => &$GLOBALS['TL_LANG']['MSC']['sortOrder'],
+			'eval'                    => array('multiple'=>true, 'fieldType'=>'checkbox', 'filesOnly'=>true, 'isDownloads'=>true, 'extensions'=>Contao\Config::get('allowedDownload'), 'mandatory'=>true),
 			'sql'                     => "blob NULL"
 		),
 		'source' => array


### PR DESCRIPTION
Instead of `'orderField' => 'orderSrc'` we can now use `'isSortable' => true`.

In cases where folders are selectable and the files can be sorted (`isGallery` and `isDownloads`) `orderField` is still required.