### PR TITLE
Starting to migrate permissions to proper Symfony Security Voters

### DIFF
--- a/core-bundle/src/Resources/config/services.yml
+++ b/core-bundle/src/Resources/config/services.yml
@@ -609,6 +609,11 @@ services:
     contao.search.indexer.delegating:
         class: Contao\CoreBundle\Search\Indexer\DelegatingIndexer
 
+    contao.security.access_decision_manager:
+        class: Contao\CoreBundle\Security\Authorization\AccessDecisionManager
+        arguments: [!tagged security.voter]
+        public: true
+
     contao.security.authentication_failure_handler:
         class: Contao\CoreBundle\Security\Authentication\AuthenticationFailureHandler
         arguments:

--- a/core-bundle/src/Resources/config/services.yml
+++ b/core-bundle/src/Resources/config/services.yml
@@ -609,6 +609,14 @@ services:
     contao.search.indexer.delegating:
         class: Contao\CoreBundle\Search\Indexer\DelegatingIndexer
 
+    contao.security.authorization_checker:
+        class: Symfony\Component\Security\Core\Authorization\AuthorizationChecker
+        arguments:
+            - '@security.token_storage'
+            - '@security.authentication.manager'
+            - '@contao.security.access_decision_manager'
+        public: true
+
     contao.security.access_decision_manager:
         class: Contao\CoreBundle\Security\Authorization\AccessDecisionManager
         arguments: [!tagged security.voter]

--- a/core-bundle/src/Resources/contao/classes/Backend.php
+++ b/core-bundle/src/Resources/contao/classes/Backend.php
@@ -21,8 +21,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface;
 use Symfony\Component\HttpFoundation\Session\Session;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
-use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
 /**
  * Provide methods to manage back end controllers.
@@ -697,21 +696,12 @@ abstract class Backend extends Controller
 		return $arrPages;
 	}
 
-	protected function hasAccess(array $attributes, $object = null): bool
+	protected function hasAccess(array $attributes, $subject = null): bool
 	{
-		/** @var AccessDecisionManagerInterface $accessDecisionManager */
-		$accessDecisionManager = System::getContainer()->get('contao.security.access_decision_manager');
+		/** @var AuthorizationCheckerInterface $authorizationChecker */
+		$authorizationChecker = System::getContainer()->get('contao.security.authorization_checker');
 
-		/** @var TokenStorageInterface $tokenStorage */
-		$tokenStorage = System::getContainer()->get('security.token_storage');
-		$token = $tokenStorage->getToken();
-
-		if (null === $token)
-		{
-			return false;
-		}
-
-		return $accessDecisionManager->decide($token, $attributes, $object);
+		return $authorizationChecker->isGranted($attributes, $subject);
 	}
 
 	/**

--- a/core-bundle/src/Resources/contao/classes/Backend.php
+++ b/core-bundle/src/Resources/contao/classes/Backend.php
@@ -440,9 +440,6 @@ abstract class Backend extends Controller
 		// Custom action (if key is not defined in config.php the default action will be called)
 		elseif (Input::get('key') && isset($arrModule[Input::get('key')]))
 		{
-			// Check permissions
-			$this->denyAccessUnlessGranted(Input::get('key'), new DcaPermission($dc->table, (string) $dc->id));
-
 			$objCallback = System::importStatic($arrModule[Input::get('key')][0]);
 			$response = $objCallback->{$arrModule[Input::get('key')][1]}($dc);
 
@@ -646,9 +643,6 @@ abstract class Backend extends Controller
 					}
 				}
 			}
-
-			// Check permissions
-			$this->denyAccessUnlessGranted($act, new DcaPermission($dc->table, (string) $dc->id));
 
 			return $dc->$act();
 		}

--- a/core-bundle/src/Resources/contao/classes/Backend.php
+++ b/core-bundle/src/Resources/contao/classes/Backend.php
@@ -13,7 +13,6 @@ namespace Contao;
 use Contao\CoreBundle\Exception\AccessDeniedException;
 use Contao\CoreBundle\Exception\ResponseException;
 use Contao\CoreBundle\Picker\PickerInterface;
-use Contao\CoreBundle\Security\Authorization\DcaPermission;
 use Contao\Database\Result;
 use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;

--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -391,6 +391,9 @@ class DC_Table extends DataContainer implements \listable, \editable
 			return '';
 		}
 
+		// Check permissions
+		$this->denyAccessUnlessGranted(AbstractDcaVoter::OPERATION_SHOW, new RecordSubject($this->strTable, (string) $this->intId));
+
 		$objRow = $this->Database->prepare("SELECT * FROM " . $this->strTable . " WHERE id=?")
 								 ->limit(1)
 								 ->execute($this->intId);
@@ -642,6 +645,10 @@ class DC_Table extends DataContainer implements \listable, \editable
 	 */
 	public function create($set=array())
 	{
+		// Check permissions
+		$this->denyAccessUnlessGranted(AbstractDcaVoter::OPERATION_CREATE, new RootSubject($this->strTable));
+
+		// TODO: Move to voter
 		if ($GLOBALS['TL_DCA'][$this->strTable]['config']['notCreatable'])
 		{
 			throw new InternalServerErrorException('Table "' . $this->strTable . '" is not creatable.');
@@ -743,6 +750,10 @@ class DC_Table extends DataContainer implements \listable, \editable
 	 */
 	public function cut($blnDoNotRedirect=false)
 	{
+		// Check permissions
+		$this->denyAccessUnlessGranted(AbstractDcaVoter::OPERATION_CUT, new RootSubject($this->strTable));
+
+		// TODO: move to voter
 		if ($GLOBALS['TL_DCA'][$this->strTable]['config']['notSortable'])
 		{
 			throw new InternalServerErrorException('Table "' . $this->strTable . '" is not sortable.');
@@ -851,6 +862,9 @@ class DC_Table extends DataContainer implements \listable, \editable
 		{
 			foreach ($arrClipboard[$this->strTable]['id'] as $id)
 			{
+				// Check permissions
+				$this->denyAccessUnlessGranted(AbstractDcaVoter::OPERATION_CUT, new RecordSubject($this->strTable, (string) $id));
+
 				$this->intId = $id;
 				$this->cut(true);
 				Input::setGet('pid', $id);
@@ -872,6 +886,10 @@ class DC_Table extends DataContainer implements \listable, \editable
 	 */
 	public function copy($blnDoNotRedirect=false)
 	{
+		// Check permissions
+		$this->denyAccessUnlessGranted(AbstractDcaVoter::OPERATION_COPY, new RootSubject($this->strTable));
+
+		// TODO: move to voter
 		if ($GLOBALS['TL_DCA'][$this->strTable]['config']['notCopyable'])
 		{
 			throw new InternalServerErrorException('Table "' . $this->strTable . '" is not copyable.');
@@ -1145,6 +1163,8 @@ class DC_Table extends DataContainer implements \listable, \editable
 			}
 		}
 
+		// TODO: permission check
+
 		// Duplicate the child records
 		foreach ($copy as $k=>$v)
 		{
@@ -1177,6 +1197,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 	 */
 	public function copyAll()
 	{
+		// TODO: migrate to voter
 		if ($GLOBALS['TL_DCA'][$this->strTable]['config']['notCopyable'])
 		{
 			throw new InternalServerErrorException('Table "' . $this->strTable . '" is not copyable.');
@@ -1191,6 +1212,9 @@ class DC_Table extends DataContainer implements \listable, \editable
 		{
 			foreach ($arrClipboard[$this->strTable]['id'] as $id)
 			{
+				// Check permissions
+				$this->denyAccessUnlessGranted(AbstractDcaVoter::OPERATION_COPY, new RecordSubject($this->strTable, (string) $id));
+
 				$this->intId = $id;
 				$id = $this->copy(true);
 				Input::setGet('pid', $id);
@@ -1477,6 +1501,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 	 */
 	public function delete($blnDoNotRedirect=false)
 	{
+		// TODO: move to voter
 		if ($GLOBALS['TL_DCA'][$this->strTable]['config']['notDeletable'])
 		{
 			throw new InternalServerErrorException('Table "' . $this->strTable . '" is not deletable.');
@@ -1486,6 +1511,9 @@ class DC_Table extends DataContainer implements \listable, \editable
 		{
 			$this->redirect($this->getReferer());
 		}
+
+		// Check permissions
+		$this->denyAccessUnlessGranted(AbstractDcaVoter::OPERATION_DELETE, new RecordSubject($this->strTable, (string) $this->intId));
 
 		$delete = array();
 
@@ -1607,6 +1635,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 	 */
 	public function deleteAll()
 	{
+		// TODO: move to voter
 		if ($GLOBALS['TL_DCA'][$this->strTable]['config']['notDeletable'])
 		{
 			throw new InternalServerErrorException('Table "' . $this->strTable . '" is not deletable.');
@@ -1622,6 +1651,9 @@ class DC_Table extends DataContainer implements \listable, \editable
 		{
 			foreach ($ids as $id)
 			{
+				// Check permissions
+				$this->denyAccessUnlessGranted(AbstractDcaVoter::OPERATION_DELETE, new RecordSubject($this->strTable, (string) $id));
+
 				$this->intId = $id;
 				$this->delete(true);
 			}
@@ -1672,6 +1704,9 @@ class DC_Table extends DataContainer implements \listable, \editable
 			{
 				foreach ($objDelete->fetchAllAssoc() as $row)
 				{
+					// Check permissions
+					$this->denyAccessUnlessGranted(AbstractDcaVoter::OPERATION_DELETE, new RecordSubject($v, (string) $row['id']));
+
 					$delete[$v][] = $row['id'];
 
 					if (!empty($cctable[$v]))
@@ -1811,6 +1846,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 	 */
 	public function edit($intId=null, $ajaxId=null)
 	{
+		// TODO: move to vote
 		if ($GLOBALS['TL_DCA'][$this->strTable]['config']['notEditable'])
 		{
 			throw new InternalServerErrorException('Table "' . $this->strTable . '" is not editable.');
@@ -1820,6 +1856,9 @@ class DC_Table extends DataContainer implements \listable, \editable
 		{
 			$this->intId = $intId;
 		}
+
+		// Check permissions
+		$this->denyAccessUnlessGranted(AbstractDcaVoter::OPERATION_EDIT, new RecordSubject($this->strTable, (string) $this->intId));
 
 		// Get the current record
 		$objRow = $this->Database->prepare("SELECT * FROM " . $this->strTable . " WHERE id=?")
@@ -2325,6 +2364,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 	 */
 	public function editAll($intId=null, $ajaxId=null)
 	{
+		// TODO: move to voter
 		if ($GLOBALS['TL_DCA'][$this->strTable]['config']['notEditable'])
 		{
 			throw new InternalServerErrorException('Table "' . $this->strTable . '" is not editable.');
@@ -2362,6 +2402,9 @@ class DC_Table extends DataContainer implements \listable, \editable
 			// Walk through each record
 			foreach ($ids as $id)
 			{
+				// Check permissions
+				$this->denyAccessUnlessGranted(AbstractDcaVoter::OPERATION_EDIT, new RecordSubject($this->strTable, (string) $id));
+
 				$this->intId = $id;
 				$this->procedure = array('id=?');
 				$this->values = array($this->intId);
@@ -2733,6 +2776,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 	 */
 	public function overrideAll()
 	{
+		// TODO: move to voter
 		if ($GLOBALS['TL_DCA'][$this->strTable]['config']['notEditable'])
 		{
 			throw new InternalServerErrorException('Table "' . $this->strTable . '" is not editable.');
@@ -2768,6 +2812,9 @@ class DC_Table extends DataContainer implements \listable, \editable
 			{
 				foreach ($ids as $id)
 				{
+					// Check permissions
+					$this->denyAccessUnlessGranted(AbstractDcaVoter::OPERATION_EDIT, new RecordSubject($this->strTable, (string) $id));
+
 					$this->intId = $id;
 					$this->procedure = array('id=?');
 					$this->values = array($this->intId);
@@ -3784,6 +3831,9 @@ class DC_Table extends DataContainer implements \listable, \editable
 		{
 			return '';
 		}
+
+		// Check permissions
+		$this->denyAccessUnlessGranted(AbstractDcaVoter::OPERATION_SHOW, new RecordSubject($this->strTable, (string) $id));
 
 		$return = '';
 		$table = $this->strTable;

--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -14,6 +14,9 @@ use Contao\CoreBundle\Exception\AccessDeniedException;
 use Contao\CoreBundle\Exception\InternalServerErrorException;
 use Contao\CoreBundle\Exception\ResponseException;
 use Contao\CoreBundle\Picker\PickerInterface;
+use Contao\CoreBundle\Security\Authorization\DcaSubject\RecordSubject;
+use Contao\CoreBundle\Security\Authorization\DcaSubject\RootSubject;
+use Contao\CoreBundle\Security\Voter\AbstractDcaVoter;
 use Patchwork\Utf8;
 use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface;
 use Symfony\Component\HttpFoundation\Session\Session;
@@ -291,6 +294,9 @@ class DC_Table extends DataContainer implements \listable, \editable
 	 */
 	public function showAll()
 	{
+		// Check permissions
+		$this->denyAccessUnlessGranted(AbstractDcaVoter::OPERATION_LIST, new RootSubject($this->strTable));
+
 		$return = '';
 		$this->limit = '';
 
@@ -4451,6 +4457,9 @@ class DC_Table extends DataContainer implements \listable, \editable
 
 				for ($i=0, $c=\count($row); $i<$c; $i++)
 				{
+					// Check permissions
+					$this->denyAccessUnlessGranted(AbstractDcaVoter::OPERATION_SHOW, new RecordSubject($this->strTable, (string) $row[$i]['id']));
+
 					$this->current[] = $row[$i]['id'];
 					$imagePasteAfter = Image::getHtml('pasteafter.svg', sprintf($labelPasteAfter[1], $row[$i]['id']));
 					$imagePasteNew = Image::getHtml('new.svg', sprintf($labelPasteNew[1], $row[$i]['id']));
@@ -4886,6 +4895,9 @@ class DC_Table extends DataContainer implements \listable, \editable
 
 			foreach ($result as $row)
 			{
+				// Check permissions
+				$this->denyAccessUnlessGranted(AbstractDcaVoter::OPERATION_SHOW, new RecordSubject($this->strTable, (string) $row['id']));
+
 				$args = array();
 				$this->current[] = $row['id'];
 				$showFields = $GLOBALS['TL_DCA'][$table]['list']['label']['fields'];

--- a/core-bundle/src/Security/Authorization/AccessDecisionManager.php
+++ b/core-bundle/src/Security/Authorization/AccessDecisionManager.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Security\Authorization;
 
-use Contao\BackendUser;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
@@ -34,11 +33,6 @@ class AccessDecisionManager implements AccessDecisionManagerInterface
 
     public function decide(TokenInterface $token, array $attributes, $subject = null): bool
     {
-        // In Contao, a back end admin user always has access to everything, there's no need to ask any voter
-        if ($token->getUser() instanceof BackendUser && $token->getUser()->isAdmin) {
-            return true;
-        }
-
         foreach ($this->voters as $voter) {
             $result = $voter->vote($token, $subject, $attributes);
 

--- a/core-bundle/src/Security/Authorization/AccessDecisionManager.php
+++ b/core-bundle/src/Security/Authorization/AccessDecisionManager.php
@@ -33,6 +33,10 @@ class AccessDecisionManager implements AccessDecisionManagerInterface
 
     public function decide(TokenInterface $token, array $attributes, $subject = null): bool
     {
+        if (1 !== \count($attributes)) {
+            throw new \InvalidArgumentException('You cannot decide on more than one attribute!');
+        }
+
         foreach ($this->voters as $voter) {
             $result = $voter->vote($token, $subject, $attributes);
 

--- a/core-bundle/src/Security/Authorization/AccessDecisionManager.php
+++ b/core-bundle/src/Security/Authorization/AccessDecisionManager.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Security\Authorization;
+
+use Contao\BackendUser;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+
+class AccessDecisionManager implements AccessDecisionManagerInterface
+{
+    /**
+     * @var iterable<VoterInterface>
+     */
+    private $voters;
+
+    /**
+     * @param iterable<VoterInterface> $voters
+     */
+    public function __construct(iterable $voters = [])
+    {
+        $this->voters = $voters;
+    }
+
+    public function decide(TokenInterface $token, array $attributes, $subject = null): bool
+    {
+        // In Contao, a back end admin user always has access to everything, there's no need to ask any voter
+        if ($token->getUser() instanceof BackendUser && $token->getUser()->isAdmin) {
+            return true;
+        }
+
+        foreach ($this->voters as $voter) {
+            $result = $voter->vote($token, $subject, $attributes);
+
+            if (VoterInterface::ACCESS_GRANTED === $result) {
+                return true;
+            }
+
+            if (VoterInterface::ACCESS_DENIED === $result) {
+                return false;
+            }
+        }
+
+        // In Contao, by default users do have access to everything unless any voter explicitly
+        // disallowed access
+        return true;
+    }
+}

--- a/core-bundle/src/Security/Authorization/DcaPermission.php
+++ b/core-bundle/src/Security/Authorization/DcaPermission.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Security\Authorization;
+
+class DcaPermission
+{
+    /**
+     * @var string
+     */
+    private $table;
+
+    /**
+     * @var string|null
+     */
+    private $id;
+
+    public function __construct(string $table, string $id = null)
+    {
+        $this->table = $table;
+        $this->id = $id;
+    }
+
+    public function getTable(): string
+    {
+        return $this->table;
+    }
+
+    public function getId(): ?string
+    {
+        return $this->id;
+    }
+}

--- a/core-bundle/src/Security/Authorization/DcaSubject/ParentSubject.php
+++ b/core-bundle/src/Security/Authorization/DcaSubject/ParentSubject.php
@@ -17,28 +17,28 @@ class ParentSubject extends RootSubject
     /**
      * @var string
      */
-    private $pid;
+    private $parentId;
 
     /**
      * @var string
      */
-    private $ptable;
+    private $parentTable;
 
-    public function __construct(string $table, string $pid, string $ptable)
+    public function __construct(string $table, string $parentId, string $parentTable)
     {
         parent::__construct($table);
 
-        $this->pid = $pid;
-        $this->ptable = $ptable;
+        $this->parentId = $parentId;
+        $this->parentTable = $parentTable;
     }
 
-    public function getPid(): string
+    public function getParentId(): string
     {
-        return $this->pid;
+        return $this->parentId;
     }
 
-    public function getPtable(): string
+    public function getParentTable(): string
     {
-        return $this->ptable;
+        return $this->parentTable;
     }
 }

--- a/core-bundle/src/Security/Authorization/DcaSubject/ParentSubject.php
+++ b/core-bundle/src/Security/Authorization/DcaSubject/ParentSubject.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Security\Authorization\DcaSubject;
+
+class ParentSubject extends RootSubject
+{
+    /**
+     * @var string
+     */
+    private $pid;
+
+    /**
+     * @var string
+     */
+    private $ptable;
+
+    public function __construct(string $table, string $pid, string $ptable)
+    {
+        parent::__construct($table);
+
+        $this->pid = $pid;
+        $this->ptable = $ptable;
+    }
+
+    public function getPid(): string
+    {
+        return $this->pid;
+    }
+
+    public function getPtable(): string
+    {
+        return $this->ptable;
+    }
+}

--- a/core-bundle/src/Security/Authorization/DcaSubject/RecordSubject.php
+++ b/core-bundle/src/Security/Authorization/DcaSubject/RecordSubject.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Security\Authorization\DcaSubject;
+
+class RecordSubject extends RootSubject
+{
+    /**
+     * @var string
+     */
+    private $id;
+
+    /**
+     * RootSubject constructor.
+     */
+    public function __construct(string $table, string $id)
+    {
+        parent::__construct($table);
+        $this->id = $id;
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+}

--- a/core-bundle/src/Security/Authorization/DcaSubject/RootSubject.php
+++ b/core-bundle/src/Security/Authorization/DcaSubject/RootSubject.php
@@ -10,9 +10,9 @@ declare(strict_types=1);
  * @license LGPL-3.0-or-later
  */
 
-namespace Contao\CoreBundle\Security\Authorization;
+namespace Contao\CoreBundle\Security\Authorization\DcaSubject;
 
-class DcaPermission
+class RootSubject
 {
     /**
      * @var string
@@ -20,23 +20,15 @@ class DcaPermission
     private $table;
 
     /**
-     * @var string|null
+     * RootSubject constructor.
      */
-    private $id;
-
-    public function __construct(string $table, string $id = null)
+    public function __construct(string $table)
     {
         $this->table = $table;
-        $this->id = $id;
     }
 
     public function getTable(): string
     {
         return $this->table;
-    }
-
-    public function getId(): ?string
-    {
-        return $this->id;
     }
 }

--- a/core-bundle/src/Security/Voter/AbstractDcaVoter.php
+++ b/core-bundle/src/Security/Voter/AbstractDcaVoter.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Security\Voter;
+
+use Contao\BackendUser;
+use Contao\CoreBundle\Security\Authorization\DcaPermission;
+use Contao\FrontendUser;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+
+abstract class AbstractDcaVoter extends Voter
+{
+    public function getFrontendUser(TokenInterface $token): ?FrontendUser
+    {
+        return $token->getUser() instanceof FrontendUser ? $token->getUser() : null;
+    }
+
+    public function getBackendUser(TokenInterface $token): ?BackendUser
+    {
+        return $token->getUser() instanceof BackendUser ? $token->getUser() : null;
+    }
+
+    abstract protected function getTable(): string;
+
+    protected function supports($attribute, $subject): bool
+    {
+        if (!$subject instanceof DcaPermission) {
+            return false;
+        }
+
+        return $this->getTable() === $subject->getTable() && \in_array($attribute, $this->getValidOperations(), true);
+    }
+
+    protected function isCollectionOperation(string $operation): bool
+    {
+        return \in_array($operation, $this->getCollectionOperations(), true);
+    }
+
+    protected function getCollectionOperations(): array
+    {
+        return [
+            'paste',
+            'select',
+            'editAll',
+            'deleteAll',
+            'overrideAll',
+            'cutAll',
+            'copyAll',
+            'showAll',
+        ];
+    }
+
+    protected function getItemOperations(): array
+    {
+        return [
+            'create',
+            'edit',
+            'copy',
+            'delete',
+            'show',
+        ];
+    }
+
+    private function getValidOperations(): array
+    {
+        return array_unique(array_merge($this->getCollectionOperations(), $this->getItemOperations()));
+    }
+}

--- a/core-bundle/src/Security/Voter/AbstractDcaVoter.php
+++ b/core-bundle/src/Security/Voter/AbstractDcaVoter.php
@@ -55,13 +55,10 @@ abstract class AbstractDcaVoter implements VoterInterface
             if ($user->isAdmin) {
                 return self::ACCESS_GRANTED;
             }
-            
-            // as soon as at least one attribute is supported, default is to deny access
-            $vote = self::ACCESS_DENIED;
 
-            if ($this->voteOnAttribute($attribute, $subject, $user, $token)) {
+            if (!$this->voteOnAttribute($attribute, $subject, $user, $token)) {
                 // grant access as soon as at least one attribute returns a positive response
-                return self::ACCESS_GRANTED;
+                return self::ACCESS_DENIED;
             }
         }
 

--- a/core-bundle/src/Security/Voter/AbstractDcaVoter.php
+++ b/core-bundle/src/Security/Voter/AbstractDcaVoter.php
@@ -14,11 +14,11 @@ namespace Contao\CoreBundle\Security\Voter;
 
 use Contao\BackendUser;
 use Contao\CoreBundle\Security\Authorization\DcaSubject\ParentSubject;
-use Contao\FrontendUser;
+use Contao\CoreBundle\Security\Authorization\DcaSubject\RootSubject;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
-use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
-abstract class AbstractDcaVoter extends Voter
+abstract class AbstractDcaVoter implements VoterInterface
 {
     public const OPERATION_CREATE = 'create';
     public const OPERATION_EDIT = 'edit';
@@ -28,21 +28,48 @@ abstract class AbstractDcaVoter extends Voter
     public const OPERATION_SHOW = 'show';
     public const OPERATION_PASTE = 'paste';
 
-    public function getFrontendUser(TokenInterface $token): ?FrontendUser
+    public function vote(TokenInterface $token, $subject, array $attributes)
     {
-        return $token->getUser() instanceof FrontendUser ? $token->getUser() : null;
-    }
+        // abstain vote by default in case none of the attributes are supported
+        $vote = self::ACCESS_ABSTAIN;
 
-    public function getBackendUser(TokenInterface $token): ?BackendUser
-    {
-        return $token->getUser() instanceof BackendUser ? $token->getUser() : null;
+        foreach ($attributes as $attribute) {
+            // Only DCA subjects are supported
+            if (!$subject instanceof RootSubject) {
+                continue;
+            }
+
+            // If it is not a back end user, it's not supported
+            $user = $token->getUser();
+
+            if (!$user instanceof BackendUser) {
+                continue;
+            }
+
+            // Let's still call supports() here so it can be easily extended in a child class
+            if (!$this->supports($attribute, $subject)) {
+                continue;
+            }
+
+            // as soon as at least one attribute is supported, default is to deny access
+            $vote = self::ACCESS_DENIED;
+
+            if ($this->voteOnAttribute($attribute, $subject, $user)) {
+                // grant access as soon as at least one attribute returns a positive response
+                return self::ACCESS_GRANTED;
+            }
+        }
+
+        return $vote;
     }
 
     abstract protected function getTable(): string;
 
+    abstract protected function voteOnAttribute(string $attribute, RootSubject $subject, BackendUser $user): bool;
+
     abstract protected function getSubjectByAttributes(): array;
 
-    protected function isSubjectOfDesiredType(string $attribute, $subject)
+    protected function isSubjectOfDesiredType(string $attribute, RootSubject $subject)
     {
         $supportedSubjects = $this->getSubjectByAttributes();
 
@@ -57,7 +84,7 @@ abstract class AbstractDcaVoter extends Voter
         return true;
     }
 
-    protected function supports($attribute, $subject): bool
+    protected function supports($attribute, RootSubject $subject, TokenInterface $token): bool
     {
         if (!$this->isSubjectOfDesiredType($attribute, $subject)) {
             return false;

--- a/core-bundle/src/Security/Voter/AbstractDcaVoter.php
+++ b/core-bundle/src/Security/Voter/AbstractDcaVoter.php
@@ -13,13 +13,13 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Security\Voter;
 
 use Contao\BackendUser;
-use Contao\CoreBundle\Security\Authorization\DcaSubject\ParentSubject;
 use Contao\CoreBundle\Security\Authorization\DcaSubject\RootSubject;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
 abstract class AbstractDcaVoter implements VoterInterface
 {
+    public const OPERATION_LIST = 'list';
     public const OPERATION_CREATE = 'create';
     public const OPERATION_EDIT = 'edit';
     public const OPERATION_DELETE = 'delete';
@@ -54,7 +54,7 @@ abstract class AbstractDcaVoter implements VoterInterface
             // as soon as at least one attribute is supported, default is to deny access
             $vote = self::ACCESS_DENIED;
 
-            if ($this->voteOnAttribute($attribute, $subject, $user)) {
+            if ($this->voteOnAttribute($attribute, $subject, $user, $token)) {
                 // grant access as soon as at least one attribute returns a positive response
                 return self::ACCESS_GRANTED;
             }
@@ -65,7 +65,7 @@ abstract class AbstractDcaVoter implements VoterInterface
 
     abstract protected function getTable(): string;
 
-    abstract protected function voteOnAttribute(string $attribute, RootSubject $subject, BackendUser $user): bool;
+    abstract protected function voteOnAttribute(string $attribute, RootSubject $subject, BackendUser $user, TokenInterface $token): bool;
 
     abstract protected function getSubjectByAttributes(): array;
 
@@ -84,16 +84,12 @@ abstract class AbstractDcaVoter implements VoterInterface
         return true;
     }
 
-    protected function supports($attribute, RootSubject $subject, TokenInterface $token): bool
+    protected function supports($attribute, RootSubject $subject): bool
     {
         if (!$this->isSubjectOfDesiredType($attribute, $subject)) {
             return false;
         }
 
-        if ($subject instanceof ParentSubject) {
-            return $this->getTable() === $subject->getTable();
-        }
-
-        return false;
+        return $this->getTable() === $subject->getTable();
     }
 }

--- a/core-bundle/src/Security/Voter/AbstractDcaVoter.php
+++ b/core-bundle/src/Security/Voter/AbstractDcaVoter.php
@@ -51,6 +51,11 @@ abstract class AbstractDcaVoter implements VoterInterface
                 continue;
             }
 
+            // If user is admin, we allow access
+            if ($user->isAdmin) {
+                return self::ACCESS_GRANTED;
+            }
+            
             // as soon as at least one attribute is supported, default is to deny access
             $vote = self::ACCESS_DENIED;
 

--- a/news-bundle/src/Resources/config/services.yml
+++ b/news-bundle/src/Resources/config/services.yml
@@ -13,3 +13,16 @@ services:
             - '@security.helper'
         tags:
             - { name: contao.picker_provider, priority: 128 }
+
+    contao_news.security.news_archive_voter:
+        class: Contao\NewsBundle\Security\NewsArchiveAccessVoter
+        tags:
+            - { name: 'security.voter' }
+
+    contao_news.security.news_voter:
+        class: Contao\NewsBundle\Security\NewsAccessVoter
+        arguments:
+            - '@contao.security.access_decision_manager'
+            - '@contao.framework'
+        tags:
+            - { name: 'security.voter' }

--- a/news-bundle/src/Security/NewsAccessVoter.php
+++ b/news-bundle/src/Security/NewsAccessVoter.php
@@ -40,9 +40,9 @@ class NewsAccessVoter extends AbstractDcaVoter
         $this->contaoFramework = $contaoFramework;
     }
 
-    protected function getTable(): string
+    protected function supportsTable(string $table): string
     {
-        return 'tl_news';
+        return 'tl_news' === $table;
     }
 
     protected function voteOnAttribute(string $attribute, RootSubject $subject, BackendUser $user, TokenInterface $token): bool

--- a/news-bundle/src/Security/NewsAccessVoter.php
+++ b/news-bundle/src/Security/NewsAccessVoter.php
@@ -12,12 +12,13 @@ declare(strict_types=1);
 
 namespace Contao\NewsBundle\Security;
 
+use Contao\BackendUser;
 use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\CoreBundle\Security\Authorization\DcaSubject\ParentSubject;
 use Contao\CoreBundle\Security\Authorization\DcaSubject\RecordSubject;
+use Contao\CoreBundle\Security\Authorization\DcaSubject\RootSubject;
 use Contao\CoreBundle\Security\Voter\AbstractDcaVoter;
 use Contao\NewsModel;
-use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
 
 class NewsAccessVoter extends AbstractDcaVoter
@@ -43,14 +44,8 @@ class NewsAccessVoter extends AbstractDcaVoter
         return 'tl_news';
     }
 
-    protected function voteOnAttribute($attribute, $subject, TokenInterface $token): bool
+    protected function voteOnAttribute(string $attribute, RootSubject $subject, BackendUser $user): bool
     {
-        $user = $this->getBackendUser($token);
-
-        if (null === $user) {
-            return false;
-        }
-
         if ($subject instanceof ParentSubject) {
             $newsArchiveId = (int) $subject->getPid();
         } elseif ($subject instanceof RecordSubject) {

--- a/news-bundle/src/Security/NewsAccessVoter.php
+++ b/news-bundle/src/Security/NewsAccessVoter.php
@@ -40,7 +40,7 @@ class NewsAccessVoter extends AbstractDcaVoter
         $this->contaoFramework = $contaoFramework;
     }
 
-    protected function supportsTable(string $table): string
+    protected function supportsTable(string $table): bool
     {
         return 'tl_news' === $table;
     }

--- a/news-bundle/src/Security/NewsAccessVoter.php
+++ b/news-bundle/src/Security/NewsAccessVoter.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\NewsBundle\Security;
+
+use Contao\CoreBundle\Framework\ContaoFramework;
+use Contao\CoreBundle\Security\Authorization\DcaPermission;
+use Contao\CoreBundle\Security\Voter\AbstractDcaVoter;
+use Contao\NewsModel;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
+
+class NewsAccessVoter extends AbstractDcaVoter
+{
+    /**
+     * @var AccessDecisionManagerInterface
+     */
+    private $accessDecisionManager;
+
+    /**
+     * @var ContaoFramework
+     */
+    private $framework;
+
+    /**
+     * NewsAccessVoter constructor.
+     */
+    public function __construct(AccessDecisionManagerInterface $accessDecisionManager, ContaoFramework $framework)
+    {
+        $this->accessDecisionManager = $accessDecisionManager;
+        $this->framework = $framework;
+    }
+
+    protected function getTable(): string
+    {
+        return 'tl_news';
+    }
+
+    /**
+     * @param DcaPermission $subject
+     */
+    protected function voteOnAttribute($attribute, $subject, TokenInterface $token): bool
+    {
+        $user = $this->getBackendUser($token);
+
+        if (null === $user) {
+            return false;
+        }
+
+        $allowedNewsArchives = array_map('intval', (array) $user->news);
+
+        if (0 === \count($allowedNewsArchives)) {
+            return true;
+        }
+
+        $newsId = (int) $subject->getId();
+
+        if (0 === $newsId) {
+            return true;
+        }
+
+        if ($this->isCollectionOperation($attribute)) {
+            return $this->accessDecisionManager->decide($token, [$attribute], new DcaPermission('tl_news_archive', $subject->getId()));
+        }
+
+        $news = $this->framework->getAdapter(NewsModel::class)->findById($newsId);
+
+        if (null === $news) {
+            return false;
+        }
+
+        return $this->accessDecisionManager->decide($token, [$attribute], new DcaPermission('tl_news_archive', $news->pid));
+    }
+
+    protected function getItemOperations(): array
+    {
+        return array_merge(parent::getItemOperations(), ['toggle', 'feature']);
+    }
+}

--- a/news-bundle/src/Security/NewsAccessVoter.php
+++ b/news-bundle/src/Security/NewsAccessVoter.php
@@ -57,7 +57,7 @@ class NewsAccessVoter extends AbstractDcaVoter
         }
 
         if ($subject instanceof ParentSubject) {
-            $newsArchiveId = (int) $subject->getPid();
+            $newsArchiveId = (int) $subject->getParentId();
         } elseif ($subject instanceof RecordSubject) {
             $news = $this->contaoFramework->getAdapter(NewsModel::class)->findById((int) $subject->getId());
 

--- a/news-bundle/src/Security/NewsArchiveAccessVoter.php
+++ b/news-bundle/src/Security/NewsArchiveAccessVoter.php
@@ -20,7 +20,7 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
 class NewsArchiveAccessVoter extends AbstractDcaVoter
 {
-    protected function supportsTable(string $table): string
+    protected function supportsTable(string $table): bool
     {
         return 'tl_news_archive' === $table;
     }

--- a/news-bundle/src/Security/NewsArchiveAccessVoter.php
+++ b/news-bundle/src/Security/NewsArchiveAccessVoter.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 namespace Contao\NewsBundle\Security;
 
 use Contao\CoreBundle\Security\Authorization\DcaPermission;
+use Contao\CoreBundle\Security\Authorization\DcaSubject\ParentSubject;
+use Contao\CoreBundle\Security\Authorization\DcaSubject\RecordSubject;
+use Contao\CoreBundle\Security\Authorization\DcaSubject\RootSubject;
 use Contao\CoreBundle\Security\Voter\AbstractDcaVoter;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
@@ -28,7 +31,6 @@ class NewsArchiveAccessVoter extends AbstractDcaVoter
      */
     protected function voteOnAttribute($attribute, $subject, TokenInterface $token): bool
     {
-        // TODO: implement newsp settings
         $user = $this->getBackendUser($token);
 
         if (null === $user) {
@@ -37,34 +39,37 @@ class NewsArchiveAccessVoter extends AbstractDcaVoter
 
         $allowedNewsArchives = array_map('intval', (array) $user->news);
 
-        if (0 === \count($allowedNewsArchives)) {
-            return true;
+        switch ($attribute) {
+            case AbstractDcaVoter::OPERATION_CREATE:
+            case AbstractDcaVoter::OPERATION_PASTE:
+
+                return $user->hasAccess('create', 'newp');
+
+            case AbstractDcaVoter::OPERATION_DELETE:
+                if (!$user->hasAccess('delete', 'newp')) {
+                    return false;
+                }
+
+                return \in_array($newsArchiveId, $allowedNewsArchives, true);
+
+            case AbstractDcaVoter::OPERATION_EDIT:
+            case AbstractDcaVoter::OPERATION_COPY:
+            case AbstractDcaVoter::OPERATION_CUT:
+            case AbstractDcaVoter::OPERATION_SHOW:
+                return \in_array($newsArchiveId, $allowedNewsArchives, true);
         }
+    }
 
-        if ($this->isCollectionOperation($attribute)) {
-            $newsArchiveId = (int) $subject->getId();
-
-            if (0 === $newsArchiveId) {
-                return true;
-            }
-
-            return \in_array($newsArchiveId, $allowedNewsArchives, true);
-        }
-
-        $newsArchiveId = (int) $subject->getId();
-
-        if (0 === $newsArchiveId) {
-            return false;
-        }
-
-        if ('create' === $attribute) {
-            return $user->hasAccess('create', 'newp');
-        }
-
-        if ('delete' === $attribute || 'deleteAll' === $attribute) {
-            return $user->hasAccess('delete', 'newp');
-        }
-
-        return \in_array($newsArchiveId, $allowedNewsArchives, true);
+    protected function getSubjectByAttributes(): array
+    {
+        return [
+            AbstractDcaVoter::OPERATION_CREATE => RootSubject::class,
+            AbstractDcaVoter::OPERATION_EDIT => RecordSubject::class,
+            AbstractDcaVoter::OPERATION_DELETE => RecordSubject::class,
+            AbstractDcaVoter::OPERATION_COPY => RecordSubject::class,
+            AbstractDcaVoter::OPERATION_CUT => RecordSubject::class,
+            AbstractDcaVoter::OPERATION_SHOW => RecordSubject::class,
+            AbstractDcaVoter::OPERATION_PASTE => RootSubject::class,
+        ];
     }
 }

--- a/news-bundle/src/Security/NewsArchiveAccessVoter.php
+++ b/news-bundle/src/Security/NewsArchiveAccessVoter.php
@@ -12,8 +12,6 @@ declare(strict_types=1);
 
 namespace Contao\NewsBundle\Security;
 
-use Contao\CoreBundle\Security\Authorization\DcaPermission;
-use Contao\CoreBundle\Security\Authorization\DcaSubject\ParentSubject;
 use Contao\CoreBundle\Security\Authorization\DcaSubject\RecordSubject;
 use Contao\CoreBundle\Security\Authorization\DcaSubject\RootSubject;
 use Contao\CoreBundle\Security\Voter\AbstractDcaVoter;
@@ -26,9 +24,6 @@ class NewsArchiveAccessVoter extends AbstractDcaVoter
         return 'tl_news_archive';
     }
 
-    /**
-     * @param DcaPermission $subject
-     */
     protected function voteOnAttribute($attribute, $subject, TokenInterface $token): bool
     {
         $user = $this->getBackendUser($token);

--- a/news-bundle/src/Security/NewsArchiveAccessVoter.php
+++ b/news-bundle/src/Security/NewsArchiveAccessVoter.php
@@ -12,10 +12,10 @@ declare(strict_types=1);
 
 namespace Contao\NewsBundle\Security;
 
+use Contao\BackendUser;
 use Contao\CoreBundle\Security\Authorization\DcaSubject\RecordSubject;
 use Contao\CoreBundle\Security\Authorization\DcaSubject\RootSubject;
 use Contao\CoreBundle\Security\Voter\AbstractDcaVoter;
-use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
 class NewsArchiveAccessVoter extends AbstractDcaVoter
 {
@@ -24,14 +24,8 @@ class NewsArchiveAccessVoter extends AbstractDcaVoter
         return 'tl_news_archive';
     }
 
-    protected function voteOnAttribute($attribute, $subject, TokenInterface $token): bool
+    protected function voteOnAttribute(string $attribute, RootSubject $subject, BackendUser $user): bool
     {
-        $user = $this->getBackendUser($token);
-
-        if (null === $user) {
-            return false;
-        }
-
         $allowedNewsArchives = array_map('intval', (array) $user->news);
 
         switch ($attribute) {

--- a/news-bundle/src/Security/NewsArchiveAccessVoter.php
+++ b/news-bundle/src/Security/NewsArchiveAccessVoter.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\NewsBundle\Security;
+
+use Contao\CoreBundle\Security\Authorization\DcaPermission;
+use Contao\CoreBundle\Security\Voter\AbstractDcaVoter;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+
+class NewsArchiveAccessVoter extends AbstractDcaVoter
+{
+    protected function getTable(): string
+    {
+        return 'tl_news_archive';
+    }
+
+    /**
+     * @param DcaPermission $subject
+     */
+    protected function voteOnAttribute($attribute, $subject, TokenInterface $token): bool
+    {
+        // TODO: implement newsp settings
+        $user = $this->getBackendUser($token);
+
+        if (null === $user) {
+            return false;
+        }
+
+        $allowedNewsArchives = array_map('intval', (array) $user->news);
+
+        if (0 === \count($allowedNewsArchives)) {
+            return true;
+        }
+
+        if ($this->isCollectionOperation($attribute)) {
+            $newsArchiveId = (int) $subject->getId();
+
+            if (0 === $newsArchiveId) {
+                return true;
+            }
+
+            return \in_array($newsArchiveId, $allowedNewsArchives, true);
+        }
+
+        $newsArchiveId = (int) $subject->getId();
+
+        if (0 === $newsArchiveId) {
+            return false;
+        }
+
+        if ('create' === $attribute) {
+            return $user->hasAccess('create', 'newp');
+        }
+
+        if ('delete' === $attribute || 'deleteAll' === $attribute) {
+            return $user->hasAccess('delete', 'newp');
+        }
+
+        return \in_array($newsArchiveId, $allowedNewsArchives, true);
+    }
+}

--- a/news-bundle/src/Security/NewsArchiveAccessVoter.php
+++ b/news-bundle/src/Security/NewsArchiveAccessVoter.php
@@ -20,9 +20,9 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
 class NewsArchiveAccessVoter extends AbstractDcaVoter
 {
-    protected function getTable(): string
+    protected function supportsTable(string $table): string
     {
-        return 'tl_news_archive';
+        return 'tl_news_archive' === $table;
     }
 
     protected function voteOnAttribute(string $attribute, RootSubject $subject, BackendUser $user, TokenInterface $token): bool


### PR DESCRIPTION
After hours of discussions at the first core developer's meeting 2020, here's the concept we came up with:

* The checks themselves have to be executed in the respecitve `DC_*` classes. It's not correct from DI perspective but it's the only way we can currently deal with those as e.g. the `DC_Table` needs to check different permissions based on the `mode` etc. and we don't want `mode` to be part of our permissions system.

* We'll need the following permission operations for now:

    * `list`
    * `create`
    * `edit`
    * `delete`
    * `copy`
    * `cut`
    * `show`
    * `paste`





* The `*All` permissions (e.g.`editAll`) need to map to the single permissions.

We outlined the following permission subjects for which we should be able to cover all the use cases:

* `RootSubject` (contains only the table)
* `RecordSubject` (extends `RootSubject` and contains the ID on top)
* `ParentSubject` (extends `RootSubject` and contains the `pid` and `ptable` on top)

That should also help developers to understand which attributes they need to provide to the voters/decision manager.