### PR TITLE
Deprecate the remaining helper functions

### DIFF
--- a/calendar-bundle/src/Resources/contao/classes/Calendar.php
+++ b/calendar-bundle/src/Resources/contao/classes/Calendar.php
@@ -458,7 +458,7 @@ class Calendar extends Frontend
 				if (($objArticle = ArticleModel::findByPk($objEvent->articleId)) instanceof ArticleModel && ($objPid = $objArticle->getRelated('pid')) instanceof PageModel)
 				{
 					/** @var PageModel $objPid */
-					$link = ampersand($objPid->getAbsoluteUrl('/articles/' . ($objArticle->alias ?: $objArticle->id)));
+					$link = StringUtil::ampersand($objPid->getAbsoluteUrl('/articles/' . ($objArticle->alias ?: $objArticle->id)));
 				}
 				break;
 

--- a/calendar-bundle/src/Resources/contao/classes/Events.php
+++ b/calendar-bundle/src/Resources/contao/classes/Events.php
@@ -442,7 +442,7 @@ abstract class Events extends Module
 				}
 				else
 				{
-					self::$arrUrlCache[$strCacheKey] = ampersand($objEvent->url);
+					self::$arrUrlCache[$strCacheKey] = StringUtil::ampersand($objEvent->url);
 				}
 				break;
 
@@ -451,7 +451,7 @@ abstract class Events extends Module
 				if (($objTarget = $objEvent->getRelated('jumpTo')) instanceof PageModel)
 				{
 					/** @var PageModel $objTarget */
-					self::$arrUrlCache[$strCacheKey] = ampersand($blnAbsolute ? $objTarget->getAbsoluteUrl() : $objTarget->getFrontendUrl());
+					self::$arrUrlCache[$strCacheKey] = StringUtil::ampersand($blnAbsolute ? $objTarget->getAbsoluteUrl() : $objTarget->getFrontendUrl());
 				}
 				break;
 
@@ -462,7 +462,7 @@ abstract class Events extends Module
 					$params = '/articles/' . ($objArticle->alias ?: $objArticle->id);
 
 					/** @var PageModel $objPid */
-					self::$arrUrlCache[$strCacheKey] = ampersand($blnAbsolute ? $objPid->getAbsoluteUrl($params) : $objPid->getFrontendUrl($params));
+					self::$arrUrlCache[$strCacheKey] = StringUtil::ampersand($blnAbsolute ? $objPid->getAbsoluteUrl($params) : $objPid->getFrontendUrl($params));
 				}
 				break;
 		}
@@ -474,13 +474,13 @@ abstract class Events extends Module
 
 			if (!$objPage instanceof PageModel)
 			{
-				self::$arrUrlCache[$strCacheKey] = ampersand(Environment::get('request'));
+				self::$arrUrlCache[$strCacheKey] = StringUtil::ampersand(Environment::get('request'));
 			}
 			else
 			{
 				$params = (Config::get('useAutoItem') ? '/' : '/events/') . ($objEvent->alias ?: $objEvent->id);
 
-				self::$arrUrlCache[$strCacheKey] = ampersand($blnAbsolute ? $objPage->getAbsoluteUrl($params) : $objPage->getFrontendUrl($params));
+				self::$arrUrlCache[$strCacheKey] = StringUtil::ampersand($blnAbsolute ? $objPage->getAbsoluteUrl($params) : $objPage->getFrontendUrl($params));
 			}
 		}
 

--- a/comments-bundle/src/Resources/contao/classes/Comments.php
+++ b/comments-bundle/src/Resources/contao/classes/Comments.php
@@ -501,7 +501,7 @@ class Comments extends Frontend
 	 */
 	public function convertLineFeeds($strComment)
 	{
-		$strComment = nl2br_pre($strComment);
+		$strComment = preg_replace('/\r?\n/', '<br>', $strComment);
 
 		// Use paragraphs to generate new lines
 		if (strncmp('<p>', $strComment, 3) !== 0)

--- a/core-bundle/src/Resources/contao/classes/Backend.php
+++ b/core-bundle/src/Resources/contao/classes/Backend.php
@@ -1118,7 +1118,7 @@ abstract class Backend extends Controller
 			return '';
 		}
 
-		return ' <a href="' . ampersand($factory->getUrl($context, $extras)) . '" title="' . StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['pagepicker']) . '" id="pp_' . $inputName . '">' . Image::getHtml((\is_array($extras) && isset($extras['icon']) ? $extras['icon'] : 'pickpage.svg'), $GLOBALS['TL_LANG']['MSC']['pagepicker']) . '</a>
+		return ' <a href="' . StringUtil::ampersand($factory->getUrl($context, $extras)) . '" title="' . StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['pagepicker']) . '" id="pp_' . $inputName . '">' . Image::getHtml((\is_array($extras) && isset($extras['icon']) ? $extras['icon'] : 'pickpage.svg'), $GLOBALS['TL_LANG']['MSC']['pagepicker']) . '</a>
   <script>
     $("pp_' . $inputName . '").addEvent("click", function(e) {
       e.preventDefault();

--- a/core-bundle/src/Resources/contao/classes/Backend.php
+++ b/core-bundle/src/Resources/contao/classes/Backend.php
@@ -68,7 +68,7 @@ abstract class Backend extends Controller
 	{
 		$arrReturn = array();
 		$rootDir = System::getContainer()->getParameter('kernel.project_dir');
-		$arrThemes = scan($rootDir . '/system/themes');
+		$arrThemes = Folder::scan($rootDir . '/system/themes');
 
 		foreach ($arrThemes as $strTheme)
 		{
@@ -202,7 +202,7 @@ abstract class Backend extends Controller
 		}
 
 		$arrFiles = array();
-		$arrTemplates = scan($rootDir . '/' . $strDir);
+		$arrTemplates = Folder::scan($rootDir . '/' . $strDir);
 
 		foreach ($arrTemplates as $strFile)
 		{
@@ -1345,7 +1345,7 @@ abstract class Backend extends Controller
 		}
 
 		$rootDir = System::getContainer()->getParameter('kernel.project_dir');
-		$arrPages = scan($rootDir . '/' . $strFolder);
+		$arrPages = Folder::scan($rootDir . '/' . $strFolder);
 
 		// Empty folder
 		if (empty($arrPages))

--- a/core-bundle/src/Resources/contao/classes/Frontend.php
+++ b/core-bundle/src/Resources/contao/classes/Frontend.php
@@ -227,7 +227,7 @@ abstract class Frontend extends Controller
 				return false; // see #264
 			}
 
-			array_insert($arrFragments, 1, array('auto_item'));
+			ArrayUtil::arrayInsert($arrFragments, 1, array('auto_item'));
 		}
 
 		// HOOK: add custom logic

--- a/core-bundle/src/Resources/contao/classes/StyleSheets.php
+++ b/core-bundle/src/Resources/contao/classes/StyleSheets.php
@@ -1306,7 +1306,7 @@ class StyleSheets extends Backend
 		// Return form
 		return Message::generate() . '
 <div id="tl_buttons">
-<a href="' . ampersand(str_replace('&key=import', '', Environment::get('request'))) . '" class="header_back" title="' . StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['backBTTitle']) . '" accesskey="b">' . $GLOBALS['TL_LANG']['MSC']['backBT'] . '</a>
+<a href="' . StringUtil::ampersand(str_replace('&key=import', '', Environment::get('request'))) . '" class="header_back" title="' . StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['backBTTitle']) . '" accesskey="b">' . $GLOBALS['TL_LANG']['MSC']['backBT'] . '</a>
 </div>
 <form id="tl_style_sheet_import" class="tl_form tl_edit_form" method="post" enctype="multipart/form-data">
 <div class="tl_formbody_edit">

--- a/core-bundle/src/Resources/contao/classes/StyleSheets.php
+++ b/core-bundle/src/Resources/contao/classes/StyleSheets.php
@@ -165,8 +165,9 @@ class StyleSheets extends Backend
 		}
 
 		// Sort by key length (see #3316)
-		uksort($vars, static function($a, $b): int {
-			return strlen($b) - strlen($a);
+		uksort($vars, static function ($a, $b): int
+		{
+			return \strlen($b) - \strlen($a);
 		});
 
 		// Create the file
@@ -1376,8 +1377,9 @@ class StyleSheets extends Backend
 		}
 
 		// Sort by key length (see #3316)
-		uksort($vars, static function($a, $b): int {
-			return strlen($b) - strlen($a);
+		uksort($vars, static function ($a, $b): int
+		{
+			return \strlen($b) - \strlen($a);
 		});
 
 		// Create the file

--- a/core-bundle/src/Resources/contao/classes/StyleSheets.php
+++ b/core-bundle/src/Resources/contao/classes/StyleSheets.php
@@ -79,7 +79,7 @@ class StyleSheets extends Backend
 		}
 
 		// Delete old style sheets
-		foreach (scan($this->strRootDir . '/assets/css', true) as $file)
+		foreach (Folder::scan($this->strRootDir . '/assets/css', true) as $file)
 		{
 			// Skip directories
 			if (is_dir($this->strRootDir . '/assets/css/' . $file))
@@ -165,7 +165,9 @@ class StyleSheets extends Backend
 		}
 
 		// Sort by key length (see #3316)
-		uksort($vars, 'length_sort_desc');
+		uksort($vars, static function($a, $b): int {
+			return strlen($b) - strlen($a);
+		});
 
 		// Create the file
 		$objFile = new File('assets/css/' . $row['name'] . '.css');
@@ -1374,7 +1376,9 @@ class StyleSheets extends Backend
 		}
 
 		// Sort by key length (see #3316)
-		uksort($vars, 'length_sort_desc');
+		uksort($vars, static function($a, $b): int {
+			return strlen($b) - strlen($a);
+		});
 
 		// Create the file
 		$objFile = new File('system/tmp/' . md5(uniqid(mt_rand(), true)));

--- a/core-bundle/src/Resources/contao/classes/Theme.php
+++ b/core-bundle/src/Resources/contao/classes/Theme.php
@@ -124,7 +124,7 @@ class Theme extends Backend
 		// Return the form
 		return Message::generate() . '
 <div id="tl_buttons">
-<a href="' . ampersand(str_replace('&key=importTheme', '', Environment::get('request'))) . '" class="header_back" title="' . StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['backBTTitle']) . '" accesskey="b">' . $GLOBALS['TL_LANG']['MSC']['backBT'] . '</a>
+<a href="' . StringUtil::ampersand(str_replace('&key=importTheme', '', Environment::get('request'))) . '" class="header_back" title="' . StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['backBTTitle']) . '" accesskey="b">' . $GLOBALS['TL_LANG']['MSC']['backBT'] . '</a>
 </div>
 <form id="tl_theme_import" class="tl_form tl_edit_form" method="post" enctype="multipart/form-data">
 <div class="tl_formbody_edit">
@@ -163,7 +163,7 @@ class Theme extends Backend
 	{
 		$return = Message::generate() . '
 <div id="tl_buttons">
-<a href="' . ampersand(str_replace('&key=importTheme', '', Environment::get('request'))) . '" class="header_back" title="' . StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['backBTTitle']) . '" accesskey="b">' . $GLOBALS['TL_LANG']['MSC']['backBT'] . '</a>
+<a href="' . StringUtil::ampersand(str_replace('&key=importTheme', '', Environment::get('request'))) . '" class="header_back" title="' . StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['backBTTitle']) . '" accesskey="b">' . $GLOBALS['TL_LANG']['MSC']['backBT'] . '</a>
 </div>
 <form id="tl_theme_import" class="tl_form tl_edit_form" method="post">
 <div class="tl_formbody_edit">

--- a/core-bundle/src/Resources/contao/classes/Theme.php
+++ b/core-bundle/src/Resources/contao/classes/Theme.php
@@ -1110,7 +1110,7 @@ class Theme extends Backend
 		}
 
 		// Recursively add the files and subfolders
-		foreach (scan($this->strRootDir . '/' . $strFolder) as $strFile)
+		foreach (Folder::scan($this->strRootDir . '/' . $strFolder) as $strFile)
 		{
 			// Skip hidden resources
 			if (strncmp($strFile, '.', 1) === 0)
@@ -1184,7 +1184,7 @@ class Theme extends Backend
 		}
 
 		// Add all template files to the archive (see #7048)
-		foreach (scan($this->strRootDir . '/' . $strFolder) as $strFile)
+		foreach (Folder::scan($this->strRootDir . '/' . $strFolder) as $strFile)
 		{
 			if (preg_match('/\.(html5|sql)$/', $strFile) && strncmp($strFile, 'be_', 3) !== 0 && strncmp($strFile, 'nl_', 3) !== 0)
 			{

--- a/core-bundle/src/Resources/contao/classes/Versions.php
+++ b/core-bundle/src/Resources/contao/classes/Versions.php
@@ -708,7 +708,7 @@ class Versions extends Controller
 					$arrRow['editUrl'] = preg_replace('/id=[^&]+/', 'id=' . $filesModel->path, $arrRow['editUrl']);
 				}
 
-				$arrRow['editUrl'] = preg_replace(array('/&(amp;)?popup=1/', '/&(amp;)?rt=[^&]+/'), array('', '&amp;rt=' . REQUEST_TOKEN), ampersand($arrRow['editUrl']));
+				$arrRow['editUrl'] = preg_replace(array('/&(amp;)?popup=1/', '/&(amp;)?rt=[^&]+/'), array('', '&amp;rt=' . REQUEST_TOKEN), StringUtil::ampersand($arrRow['editUrl']));
 			}
 
 			$arrVersions[] = $arrRow;

--- a/core-bundle/src/Resources/contao/controllers/BackendConfirm.php
+++ b/core-bundle/src/Resources/contao/controllers/BackendConfirm.php
@@ -65,7 +65,7 @@ class BackendConfirm extends Backend
 
 		// Prepare the URL
 		$url = preg_replace('/[?&]rt=[^&]*/', '', $objSession->get('INVALID_TOKEN_URL'));
-		$objTemplate->href = ampersand($url . ((strpos($url, '?') !== false) ? '&rt=' : '?rt=') . REQUEST_TOKEN);
+		$objTemplate->href = StringUtil::ampersand($url . ((strpos($url, '?') !== false) ? '&rt=' : '?rt=') . REQUEST_TOKEN);
 
 		$vars = array();
 		list(, $request) = explode('?', $url, 2);

--- a/core-bundle/src/Resources/contao/controllers/BackendFile.php
+++ b/core-bundle/src/Resources/contao/controllers/BackendFile.php
@@ -165,7 +165,7 @@ class BackendFile extends Backend
 		if (Input::get('switch') && $this->User->hasAccess('page', 'modules'))
 		{
 			$objTemplate->switch = $GLOBALS['TL_LANG']['MSC']['pagePicker'];
-			$objTemplate->switchHref = str_replace('contao/file?', 'contao/page?', ampersand(Environment::get('request')));
+			$objTemplate->switchHref = str_replace('contao/file?', 'contao/page?', StringUtil::ampersand(Environment::get('request')));
 		}
 
 		return $objTemplate->getResponse();

--- a/core-bundle/src/Resources/contao/controllers/BackendMain.php
+++ b/core-bundle/src/Resources/contao/controllers/BackendMain.php
@@ -222,7 +222,7 @@ class BackendMain extends Backend
 		// File picker reference (backwards compatibility)
 		if (Input::get('popup') && Input::get('act') != 'show' && $objSession->get('filePickerRef') && ((Input::get('do') == 'page' && $this->User->hasAccess('page', 'modules')) || (Input::get('do') == 'files' && $this->User->hasAccess('files', 'modules'))))
 		{
-			$this->Template->managerHref = ampersand($objSession->get('filePickerRef'));
+			$this->Template->managerHref = StringUtil::ampersand($objSession->get('filePickerRef'));
 			$this->Template->manager = (strpos($objSession->get('filePickerRef'), 'contao/page?') !== false) ? $GLOBALS['TL_LANG']['MSC']['pagePickerHome'] : $GLOBALS['TL_LANG']['MSC']['filePickerHome'];
 		}
 

--- a/core-bundle/src/Resources/contao/controllers/BackendPage.php
+++ b/core-bundle/src/Resources/contao/controllers/BackendPage.php
@@ -154,7 +154,7 @@ class BackendPage extends Backend
 		if (Input::get('switch') && $this->User->hasAccess('files', 'modules'))
 		{
 			$objTemplate->switch = $GLOBALS['TL_LANG']['MSC']['filePicker'];
-			$objTemplate->switchHref = str_replace('contao/page?', 'contao/file?', ampersand(Environment::get('request')));
+			$objTemplate->switchHref = str_replace('contao/page?', 'contao/file?', StringUtil::ampersand(Environment::get('request')));
 		}
 
 		return $objTemplate->getResponse();

--- a/core-bundle/src/Resources/contao/controllers/BackendPopup.php
+++ b/core-bundle/src/Resources/contao/controllers/BackendPopup.php
@@ -146,7 +146,7 @@ class BackendPopup extends Backend
 				}
 			}
 
-			$objTemplate->href = ampersand(Environment::get('request')) . '&amp;download=1';
+			$objTemplate->href = StringUtil::ampersand(Environment::get('request')) . '&amp;download=1';
 			$objTemplate->filesize = $this->getReadableSize($objFile->filesize) . ' (' . number_format($objFile->filesize, 0, $GLOBALS['TL_LANG']['MSC']['decimalSeparator'], $GLOBALS['TL_LANG']['MSC']['thousandsSeparator']) . ' Byte)';
 		}
 

--- a/core-bundle/src/Resources/contao/dca/tl_files.php
+++ b/core-bundle/src/Resources/contao/dca/tl_files.php
@@ -330,7 +330,7 @@ class tl_files extends Contao\Backend
 					{
 						$folders[] = $id;
 
-						if ($canDeleteRecursive || ($canDeleteOne && count(scan($rootDir . '/' . $id)) < 1))
+						if ($canDeleteRecursive || ($canDeleteOne && count(Contao\Folder::scan($rootDir . '/' . $id)) < 1))
 						{
 							$delete_all[] = $id;
 						}

--- a/core-bundle/src/Resources/contao/dca/tl_layout.php
+++ b/core-bundle/src/Resources/contao/dca/tl_layout.php
@@ -586,7 +586,7 @@ class tl_layout extends Contao\Backend
 
 		if (($i = array_search('responsive.css', $array)) !== false && !in_array('layout.css', $array))
 		{
-			array_insert($array, $i, 'layout.css');
+			Contao\ArrayUtil::arrayInsert($array, $i, 'layout.css');
 		}
 
 		return $array;

--- a/core-bundle/src/Resources/contao/dca/tl_templates.php
+++ b/core-bundle/src/Resources/contao/dca/tl_templates.php
@@ -528,7 +528,7 @@ class tl_templates extends Contao\Backend
 		$strFolders = '';
 		$strPath = Contao\System::getContainer()->getParameter('kernel.project_dir') . '/' . $strFolder;
 
-		foreach (scan($strPath) as $strFile)
+		foreach (Contao\Folder::scan($strPath) as $strFile)
 		{
 			if (!is_dir($strPath . '/' . $strFile) || strncmp($strFile, '.', 1) === 0)
 			{

--- a/core-bundle/src/Resources/contao/dca/tl_theme.php
+++ b/core-bundle/src/Resources/contao/dca/tl_theme.php
@@ -321,7 +321,7 @@ class tl_theme extends Contao\Backend
 		$return = array();
 		$rootDir = Contao\System::getContainer()->getParameter('kernel.project_dir');
 
-		foreach (scan($rootDir . '/' . $path) as $file)
+		foreach (Contao\Folder::scan($rootDir . '/' . $path) as $file)
 		{
 			if (is_dir($rootDir . '/' . $path . '/' . $file))
 			{

--- a/core-bundle/src/Resources/contao/drivers/DC_Folder.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Folder.php
@@ -1888,7 +1888,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 
 			// Return the select menu
 			$return .= '
-<form action="' . ampersand(Environment::get('request')) . '&amp;fields=1" id="' . $this->strTable . '_all" class="tl_form tl_edit_form" method="post">
+<form action="' . StringUtil::ampersand(Environment::get('request')) . '&amp;fields=1" id="' . $this->strTable . '_all" class="tl_form tl_edit_form" method="post">
 <div class="tl_formbody_edit">
 <input type="hidden" name="FORM_SUBMIT" value="' . $this->strTable . '_all">
 <input type="hidden" name="REQUEST_TOKEN" value="' . REQUEST_TOKEN . '">' . ($blnIsError ? '

--- a/core-bundle/src/Resources/contao/drivers/DC_Folder.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Folder.php
@@ -2574,7 +2574,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 		// Scan directory and sort the result
 		else
 		{
-			foreach (scan($path) as $v)
+			foreach (Folder::scan($path) as $v)
 			{
 				if (strncmp($v, '.', 1) === 0)
 				{
@@ -2606,7 +2606,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 		for ($f=0, $c=\count($folders); $f<$c; $f++)
 		{
 			$md5 = substr(md5($folders[$f]), 0, 8);
-			$content = scan($folders[$f]);
+			$content = Folder::scan($folders[$f]);
 			$currentFolder = StringUtil::stripRootDir($folders[$f]);
 			$session['filetree'][$md5] = is_numeric($session['filetree'][$md5]) ? $session['filetree'][$md5] : 0;
 			$currentEncoded = $this->urlEncode($currentFolder);
@@ -3015,7 +3015,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 	{
 		$arrFiles = array();
 
-		foreach (scan($this->strRootDir . '/' . $strPath) as $strFile)
+		foreach (Folder::scan($this->strRootDir . '/' . $strPath) as $strFile)
 		{
 			if (!is_dir($this->strRootDir . '/' . $strPath . '/' . $strFile))
 			{

--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -2687,7 +2687,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 			// Return the select menu
 			$return .= '
 
-<form action="' . ampersand(Environment::get('request')) . '&amp;fields=1" id="' . $this->strTable . '_all" class="tl_form tl_edit_form" method="post">
+<form action="' . StringUtil::ampersand(Environment::get('request')) . '&amp;fields=1" id="' . $this->strTable . '_all" class="tl_form tl_edit_form" method="post">
 <div class="tl_formbody_edit">
 <input type="hidden" name="FORM_SUBMIT" value="' . $this->strTable . '_all">
 <input type="hidden" name="REQUEST_TOKEN" value="' . REQUEST_TOKEN . '">' . ($blnIsError ? '
@@ -3010,7 +3010,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 
 			// Return the select menu
 			$return .= '
-<form action="' . ampersand(Environment::get('request')) . '&amp;fields=1" id="' . $this->strTable . '_all" class="tl_form tl_edit_form" method="post">
+<form action="' . StringUtil::ampersand(Environment::get('request')) . '&amp;fields=1" id="' . $this->strTable . '_all" class="tl_form tl_edit_form" method="post">
 <div class="tl_formbody_edit">
 <input type="hidden" name="FORM_SUBMIT" value="' . $this->strTable . '_all">
 <input type="hidden" name="REQUEST_TOKEN" value="' . REQUEST_TOKEN . '">' . ($blnIsError ? '

--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -5238,7 +5238,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 		}
 
 		// Sort by option values
-		$options_sorter = natcaseksort($options_sorter);
+		uksort($options_sorter, 'strnatcasecmp');
 		$active = isset($session['search'][$this->strTable]['value']);
 
 		return '

--- a/core-bundle/src/Resources/contao/elements/ContentDownloads.php
+++ b/core-bundle/src/Resources/contao/elements/ContentDownloads.php
@@ -266,11 +266,15 @@ class ContentDownloads extends ContentElement
 		{
 			default:
 			case 'name_asc':
-				uksort($files, 'basename_natcasecmp');
+				uksort($files, static function(): int {
+					return strnatcasecmp(basename($a), basename($b));
+				});
 				break;
 
 			case 'name_desc':
-				uksort($files, 'basename_natcasercmp');
+				uksort($files, static function(): int {
+					return -strnatcasecmp(basename($a), basename($b));
+				});
 				break;
 
 			case 'date_asc':

--- a/core-bundle/src/Resources/contao/elements/ContentDownloads.php
+++ b/core-bundle/src/Resources/contao/elements/ContentDownloads.php
@@ -266,13 +266,15 @@ class ContentDownloads extends ContentElement
 		{
 			default:
 			case 'name_asc':
-				uksort($files, static function(): int {
+				uksort($files, static function (): int
+				{
 					return strnatcasecmp(basename($a), basename($b));
 				});
 				break;
 
 			case 'name_desc':
-				uksort($files, static function(): int {
+				uksort($files, static function (): int
+				{
 					return -strnatcasecmp(basename($a), basename($b));
 				});
 				break;

--- a/core-bundle/src/Resources/contao/elements/ContentDownloads.php
+++ b/core-bundle/src/Resources/contao/elements/ContentDownloads.php
@@ -293,36 +293,7 @@ class ContentDownloads extends ContentElement
 				// no break
 
 			case 'custom':
-				if ($this->orderSRC != '')
-				{
-					$tmp = StringUtil::deserialize($this->orderSRC);
-
-					if (!empty($tmp) && \is_array($tmp))
-					{
-						// Remove all values
-						$arrOrder = array_map(static function () {}, array_flip($tmp));
-
-						// Move the matching elements to their position in $arrOrder
-						foreach ($files as $k=>$v)
-						{
-							if (\array_key_exists($v['uuid'], $arrOrder))
-							{
-								$arrOrder[$v['uuid']] = $v;
-								unset($files[$k]);
-							}
-						}
-
-						// Append the left-over files at the end
-						if (!empty($files))
-						{
-							$arrOrder = array_merge($arrOrder, array_values($files));
-						}
-
-						// Remove empty (unreplaced) entries
-						$files = array_values(array_filter($arrOrder));
-						unset($arrOrder);
-					}
-				}
+				$files = ArrayUtil::sortByOrderField($files, $this->orderSRC);
 				break;
 
 			case 'random':

--- a/core-bundle/src/Resources/contao/elements/ContentGallery.php
+++ b/core-bundle/src/Resources/contao/elements/ContentGallery.php
@@ -157,13 +157,15 @@ class ContentGallery extends ContentElement
 		{
 			default:
 			case 'name_asc':
-				uksort($images, static function($a, $b): int {
+				uksort($images, static function ($a, $b): int
+				{
 					return strnatcasecmp(basename($a), basename($b));
 				});
 				break;
 
 			case 'name_desc':
-				uksort($images, static function($a, $b): int {
+				uksort($images, static function ($a, $b): int
+				{
 					return -strnatcasecmp(basename($a), basename($b));
 				});
 				break;

--- a/core-bundle/src/Resources/contao/elements/ContentGallery.php
+++ b/core-bundle/src/Resources/contao/elements/ContentGallery.php
@@ -157,11 +157,15 @@ class ContentGallery extends ContentElement
 		{
 			default:
 			case 'name_asc':
-				uksort($images, 'basename_natcasecmp');
+				uksort($images, static function($a, $b): int {
+					return strnatcasecmp(basename($a), basename($b));
+				});
 				break;
 
 			case 'name_desc':
-				uksort($images, 'basename_natcasercmp');
+				uksort($images, static function($a, $b): int {
+					return -strnatcasecmp(basename($a), basename($b));
+				});
 				break;
 
 			case 'date_asc':

--- a/core-bundle/src/Resources/contao/elements/ContentGallery.php
+++ b/core-bundle/src/Resources/contao/elements/ContentGallery.php
@@ -184,36 +184,7 @@ class ContentGallery extends ContentElement
 				// no break
 
 			case 'custom':
-				if ($this->orderSRC != '')
-				{
-					$tmp = StringUtil::deserialize($this->orderSRC);
-
-					if (!empty($tmp) && \is_array($tmp))
-					{
-						// Remove all values
-						$arrOrder = array_map(static function () {}, array_flip($tmp));
-
-						// Move the matching elements to their position in $arrOrder
-						foreach ($images as $k=>$v)
-						{
-							if (\array_key_exists($v['uuid'], $arrOrder))
-							{
-								$arrOrder[$v['uuid']] = $v;
-								unset($images[$k]);
-							}
-						}
-
-						// Append the left-over images at the end
-						if (!empty($images))
-						{
-							$arrOrder = array_merge($arrOrder, array_values($images));
-						}
-
-						// Remove empty (unreplaced) entries
-						$images = array_values(array_filter($arrOrder));
-						unset($arrOrder);
-					}
-				}
+				$images = ArrayUtil::sortByOrderField($images, $this->orderSRC);
 				break;
 
 			case 'random':

--- a/core-bundle/src/Resources/contao/elements/ContentHyperlink.php
+++ b/core-bundle/src/Resources/contao/elements/ContentHyperlink.php
@@ -34,7 +34,7 @@ class ContentHyperlink extends ContentElement
 		}
 		else
 		{
-			$this->url = ampersand($this->url);
+			$this->url = StringUtil::ampersand($this->url);
 		}
 
 		$embed = explode('%s', $this->embed);

--- a/core-bundle/src/Resources/contao/elements/ContentToplink.php
+++ b/core-bundle/src/Resources/contao/elements/ContentToplink.php
@@ -35,7 +35,7 @@ class ContentToplink extends ContentElement
 
 		$this->Template->label = $this->linkTitle;
 		$this->Template->title = StringUtil::specialchars($this->linkTitle);
-		$this->Template->request = ampersand(Environment::get('request'));
+		$this->Template->request = StringUtil::ampersand(Environment::get('request'));
 	}
 }
 

--- a/core-bundle/src/Resources/contao/forms/FormFileUpload.php
+++ b/core-bundle/src/Resources/contao/forms/FormFileUpload.php
@@ -243,7 +243,7 @@ class FormFileUpload extends Widget implements \uploadable
 					{
 						$offset = 1;
 
-						$arrAll = scan($rootDir . '/' . $strUploadFolder);
+						$arrAll = Folder::scan($rootDir . '/' . $strUploadFolder);
 						$arrFiles = preg_grep('/^' . preg_quote($objFile->filename, '/') . '.*\.' . preg_quote($objFile->extension, '/') . '/', $arrAll);
 
 						foreach ($arrFiles as $strFile)

--- a/core-bundle/src/Resources/contao/helper/functions.php
+++ b/core-bundle/src/Resources/contao/helper/functions.php
@@ -247,10 +247,14 @@ function trimsplit($strPattern, $strString)
  * @param boolean $blnEncode
  *
  * @return string
+ *
+ * @deprecated Deprecated since Contao 4.10, to be removed in Contao 5.0.
  */
 function ampersand($strString, $blnEncode=true)
 {
-	return preg_replace('/&(amp;)?/i', ($blnEncode ? '&amp;' : '&'), $strString);
+	@trigger_error('Using ampersand() has been deprecated and will no longer work in Contao 5.0. Use StringUtil::ampersand() instead.', E_USER_DEPRECATED);
+
+	return Contao\StringUtil::ampersand($strString, $blnEncode);
 }
 
 /**

--- a/core-bundle/src/Resources/contao/helper/functions.php
+++ b/core-bundle/src/Resources/contao/helper/functions.php
@@ -51,43 +51,14 @@ function log_message($strMessage, $strLog=null)
  * @param boolean $blnUncached
  *
  * @return array
+ *
+ * @deprecated Deprecated since Contao 4.10, to be removed in Contao 5.0.
  */
 function scan($strFolder, $blnUncached=false)
 {
-	global $arrScanCache;
+	@trigger_error('Using scan() has been deprecated and will no longer work in Contao 5.0. Use Folder::scan() instead.', E_USER_DEPRECATED);
 
-	// Add a trailing slash
-	if (substr($strFolder, -1, 1) != '/')
-	{
-		$strFolder .= '/';
-	}
-
-	// Load from cache
-	if (!$blnUncached && isset($arrScanCache[$strFolder]))
-	{
-		return $arrScanCache[$strFolder];
-	}
-
-	$arrReturn = array();
-
-	// Scan directory
-	foreach (scandir($strFolder, SCANDIR_SORT_ASCENDING) as $strFile)
-	{
-		if ($strFile == '.' || $strFile == '..')
-		{
-			continue;
-		}
-
-		$arrReturn[] = $strFile;
-	}
-
-	// Cache the result
-	if (!$blnUncached)
-	{
-		$arrScanCache[$strFolder] = $arrReturn;
-	}
-
-	return $arrReturn;
+	return Contao\Folder::scan($strFolder, $blnUncached);
 }
 
 /**
@@ -289,9 +260,13 @@ function ampersand($strString, $blnEncode=true)
  * @param boolean $xhtml
  *
  * @return string
+ *
+ * @deprecated Deprecated since Contao 4.10, to be removed in Contao 5.0.
  */
 function nl2br_html5($str, $xhtml=false)
 {
+	@trigger_error('Using nl2br_html5() has been deprecated and will no longer work in Contao 5.0.', E_USER_DEPRECATED);
+
 	return nl2br($str, $xhtml);
 }
 
@@ -301,9 +276,13 @@ function nl2br_html5($str, $xhtml=false)
  * @param string $str
  *
  * @return string
+ *
+ * @deprecated Deprecated since Contao 4.10, to be removed in Contao 5.0.
  */
 function nl2br_xhtml($str)
 {
+	@trigger_error('Using nl2br_xhtml() has been deprecated and will no longer work in Contao 5.0.', E_USER_DEPRECATED);
+
 	return nl2br($str);
 }
 
@@ -314,9 +293,13 @@ function nl2br_xhtml($str)
  * @param boolean $xhtml
  *
  * @return string
+ *
+ * @deprecated Deprecated since Contao 4.10, to be removed in Contao 5.0.
  */
 function nl2br_pre($str, $xhtml=false)
 {
+	@trigger_error('Using nl2br_pre() has been deprecated and will no longer work in Contao 5.0.', E_USER_DEPRECATED);
+
 	$str = $xhtml ? nl2br_xhtml($str) : nl2br_html5($str);
 
 	if (stripos($str, '<pre') === false)
@@ -342,9 +325,13 @@ function nl2br_pre($str, $xhtml=false)
  * @param string $b
  *
  * @return integer
+ *
+ * @deprecated Deprecated since Contao 4.10, to be removed in Contao 5.0.
  */
 function basename_natcasecmp($a, $b)
 {
+	@trigger_error('Using basename_natcasecmp() has been deprecated and will no longer work in Contao 5.0.', E_USER_DEPRECATED);
+
 	return strnatcasecmp(basename($a), basename($b));
 }
 
@@ -355,9 +342,13 @@ function basename_natcasecmp($a, $b)
  * @param string $b
  *
  * @return integer
+ *
+ * @deprecated Deprecated since Contao 4.10, to be removed in Contao 5.0.
  */
 function basename_natcasercmp($a, $b)
 {
+	@trigger_error('Using basename_natcasercmp() has been deprecated and will no longer work in Contao 5.0.', E_USER_DEPRECATED);
+
 	return -strnatcasecmp(basename($a), basename($b));
 }
 
@@ -367,14 +358,16 @@ function basename_natcasercmp($a, $b)
  * @param array $arrArray
  *
  * @return array
+ *
+ * @deprecated Deprecated since Contao 4.10, to be removed in Contao 5.0.
  */
 function natcaseksort($arrArray)
 {
-	$arrBuffer = array_flip($arrArray);
-	natcasesort($arrBuffer);
-	$arrBuffer = array_flip($arrBuffer);
+	@trigger_error('Using natcaseksort() has been deprecated and will no longer work in Contao 5.0. Use uksort(…, \'strnatcasecmp\') instead.', E_USER_DEPRECATED);
 
-	return $arrBuffer;
+	uksort($arrArray, 'strnatcasecmp');
+
+	return $arrArray;
 }
 
 /**
@@ -384,9 +377,13 @@ function natcaseksort($arrArray)
  * @param integer $b
  *
  * @return integer
+ *
+ * @deprecated Deprecated since Contao 4.10, to be removed in Contao 5.0.
  */
 function length_sort_asc($a, $b)
 {
+	@trigger_error('Using length_sort_asc() has been deprecated and will no longer work in Contao 5.0. Use a closure instead.', E_USER_DEPRECATED);
+
 	return strlen($a) - strlen($b);
 }
 
@@ -397,9 +394,13 @@ function length_sort_asc($a, $b)
  * @param integer $b
  *
  * @return integer
+ *
+ * @deprecated Deprecated since Contao 4.10, to be removed in Contao 5.0.
  */
 function length_sort_desc($a, $b)
 {
+	@trigger_error('Using length_sort_desc() has been deprecated and will no longer work in Contao 5.0. Use a closure instead.', E_USER_DEPRECATED);
+
 	return strlen($b) - strlen($a);
 }
 
@@ -409,25 +410,14 @@ function length_sort_desc($a, $b)
  * @param array   $arrCurrent
  * @param integer $intIndex
  * @param mixed   $arrNew
+ *
+ * @deprecated Deprecated since Contao 4.10, to be removed in Contao 5.0.
  */
 function array_insert(&$arrCurrent, $intIndex, $arrNew)
 {
-	if (!is_array($arrCurrent))
-	{
-		$arrCurrent = $arrNew;
+	@trigger_error('Using array_insert() has been deprecated and will no longer work in Contao 5.0. Use ArrayUtil::arrayInsert() instead.', E_USER_DEPRECATED);
 
-		return;
-	}
-
-	if (is_array($arrNew))
-	{
-		$arrBuffer = array_splice($arrCurrent, 0, $intIndex);
-		$arrCurrent = array_merge_recursive($arrBuffer, $arrNew, $arrCurrent);
-
-		return;
-	}
-
-	array_splice($arrCurrent, $intIndex, 0, $arrNew);
+	Contao\ArrayUtil::arrayInsert($arrCurrent, $intIndex, $arrNew);
 }
 
 /**
@@ -543,10 +533,14 @@ function array_delete($arrStack, $intIndex)
  * @param array $arrArray
  *
  * @return boolean
+ *
+ * @deprecated Deprecated since Contao 4.10, to be removed in Contao 5.0.
  */
 function array_is_assoc($arrArray)
 {
-	return is_array($arrArray) && array_keys($arrArray) !== range(0, count($arrArray) - 1);
+	@trigger_error('Using array_is_assoc() has been deprecated and will no longer work in Contao 5.0. Use ArrayUtil::isAssoc() instead.', E_USER_DEPRECATED);
+
+	return Contao\ArrayUtil::isAssoc($arrArray);
 }
 
 /**

--- a/core-bundle/src/Resources/contao/helper/functions.php
+++ b/core-bundle/src/Resources/contao/helper/functions.php
@@ -304,22 +304,7 @@ function nl2br_pre($str, $xhtml=false)
 {
 	@trigger_error('Using nl2br_pre() has been deprecated and will no longer work in Contao 5.0.', E_USER_DEPRECATED);
 
-	$str = $xhtml ? nl2br_xhtml($str) : nl2br_html5($str);
-
-	if (stripos($str, '<pre') === false)
-	{
-		return $str;
-	}
-
-	$chunks = array();
-	preg_match_all('/<pre[^>]*>.*<\/pre>/Uis', $str, $chunks);
-
-	foreach ($chunks as $chunk)
-	{
-		$str = str_replace($chunk, str_ireplace(array('<br>', '<br />'), '', $chunk), $str);
-	}
-
-	return $str;
+	return preg_replace('/\r?\n/', $xhtml ? '<br />' : '<br>', $str);
 }
 
 /**

--- a/core-bundle/src/Resources/contao/library/Contao/ArrayUtil.php
+++ b/core-bundle/src/Resources/contao/library/Contao/ArrayUtil.php
@@ -59,11 +59,12 @@ class ArrayUtil
 	/**
 	 * @param array        $arrItems   Items array that should ge sorted
 	 * @param string|array $strOrder   Serialized order field or array
-	 * @param string       $strIdField Name of the id field to be used for
+	 * @param string|null  $strIdField Name of the id field to be used for
 	 *                                 sorting if the items are objects
+	 * @param boolean      $blnByKey   If true the keys of the $arrItems are used
 	 * @return array
 	 */
-	public static function sortByOrderField(array $arrItems, $strOrder, string $strIdField = 'uuid'): array
+	public static function sortByOrderField(array $arrItems, $strOrder, ?string $strIdField = 'uuid', bool $blnByKey = false): array
 	{
 		// Remove all values
 		$arrOrder = array_map(static function () {}, array_flip(StringUtil::deserialize($strOrder, true)));
@@ -71,10 +72,16 @@ class ArrayUtil
 		// Move the matching elements to their position in $arrOrder
 		foreach ($arrItems as $key=>$item)
 		{
-			if (\is_string($item)) {
+			if ($blnByKey)
+			{
+				$strKey = $key;
+			}
+			elseif (\is_string($item))
+			{
 				$strKey = $item;
 			}
-			else {
+			else
+			{
 				$strKey = is_object($item) ? $item->$strIdField : $item[$strIdField];
 			}
 
@@ -85,7 +92,15 @@ class ArrayUtil
 			}
 		}
 
-		// Remove empty (unreplaced) entries and append the left-over images at the end
-		return array_merge(array_values(array_filter($arrOrder)), array_values($images));
+		// Remove empty (unreplaced) entries
+		$arrOrder = array_filter($arrOrder);
+
+		if ($blnByKey) {
+			// Append the left-over images at the end
+			return $arrOrder + $arrItems;
+		}
+
+		// Append the left-over images at the end
+		return array_merge(array_values($arrOrder), array_values($arrItems));
 	}
 }

--- a/core-bundle/src/Resources/contao/library/Contao/ArrayUtil.php
+++ b/core-bundle/src/Resources/contao/library/Contao/ArrayUtil.php
@@ -55,6 +55,39 @@ class ArrayUtil
 	{
 		return \is_array($arrArray) && array_keys($arrArray) !== range(0, \count($arrArray) - 1);
 	}
+
+	/**
+	 * @param array        $arrItems   Items array that should ge sorted
+	 * @param string|array $strOrder   Serialized order field or array
+	 * @param string       $strIdField Name of the id field to be used for
+	 *                                 sorting if the items are objects
+	 * @return array
+	 */
+	public static function sortByOrderField(array $arrItems, $strOrder, string $strIdField = 'uuid'): array
+	{
+		// Remove all values
+		$arrOrder = array_map(static function () {}, array_flip(StringUtil::deserialize($strOrder, true)));
+
+		// Move the matching elements to their position in $arrOrder
+		foreach ($arrItems as $key=>$item)
+		{
+			if (\is_string($item)) {
+				$strKey = $item;
+			}
+			else {
+				$strKey = is_object($item) ? $item->$strIdField : $item[$strIdField];
+			}
+
+			if (\array_key_exists($strKey, $arrOrder))
+			{
+				$arrOrder[$strKey] = $item;
+				unset($arrItems[$key]);
+			}
+		}
+
+		// Remove empty (unreplaced) entries and append the left-over images at the end
+		return array_merge(array_values(array_filter($arrOrder)), array_values($images));
+	}
 }
 
 class_alias(ArrayUtil::class, 'ArrayUtil');

--- a/core-bundle/src/Resources/contao/library/Contao/ArrayUtil.php
+++ b/core-bundle/src/Resources/contao/library/Contao/ArrayUtil.php
@@ -89,5 +89,3 @@ class ArrayUtil
 		return array_merge(array_values(array_filter($arrOrder)), array_values($images));
 	}
 }
-
-class_alias(ArrayUtil::class, 'ArrayUtil');

--- a/core-bundle/src/Resources/contao/library/Contao/ArrayUtil.php
+++ b/core-bundle/src/Resources/contao/library/Contao/ArrayUtil.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao;
+
+/**
+ * Provides array manipulation methods
+ *
+ * @author Leo Feyer <https://github.com/leofeyer>
+ */
+class ArrayUtil
+{
+	/**
+	 * Insert a parameter or array into an existing array at a particular index
+	 *
+	 * @param array   $arrCurrent
+	 * @param integer $intIndex
+	 * @param mixed   $arrNew
+	 */
+	public static function arrayInsert(&$arrCurrent, $intIndex, $arrNew): void
+	{
+		if (!is_array($arrCurrent))
+		{
+			$arrCurrent = $arrNew;
+
+			return;
+		}
+
+		if (is_array($arrNew))
+		{
+			$arrBuffer = array_splice($arrCurrent, 0, $intIndex);
+			$arrCurrent = array_merge_recursive($arrBuffer, $arrNew, $arrCurrent);
+
+			return;
+		}
+
+		array_splice($arrCurrent, $intIndex, 0, $arrNew);
+	}
+
+	/**
+	 * Return true if an array is associative
+	 *
+	 * @param array $arrArray
+	 *
+	 * @return boolean
+	 */
+	public static function isAssoc($arrArray): bool
+	{
+		return is_array($arrArray) && array_keys($arrArray) !== range(0, count($arrArray) - 1);
+	}
+}
+
+class_alias(ArrayUtil::class, 'ArrayUtil');

--- a/core-bundle/src/Resources/contao/library/Contao/ArrayUtil.php
+++ b/core-bundle/src/Resources/contao/library/Contao/ArrayUtil.php
@@ -26,14 +26,14 @@ class ArrayUtil
 	 */
 	public static function arrayInsert(&$arrCurrent, $intIndex, $arrNew): void
 	{
-		if (!is_array($arrCurrent))
+		if (!\is_array($arrCurrent))
 		{
 			$arrCurrent = $arrNew;
 
 			return;
 		}
 
-		if (is_array($arrNew))
+		if (\is_array($arrNew))
 		{
 			$arrBuffer = array_splice($arrCurrent, 0, $intIndex);
 			$arrCurrent = array_merge_recursive($arrBuffer, $arrNew, $arrCurrent);
@@ -53,7 +53,7 @@ class ArrayUtil
 	 */
 	public static function isAssoc($arrArray): bool
 	{
-		return is_array($arrArray) && array_keys($arrArray) !== range(0, count($arrArray) - 1);
+		return \is_array($arrArray) && array_keys($arrArray) !== range(0, \count($arrArray) - 1);
 	}
 }
 

--- a/core-bundle/src/Resources/contao/library/Contao/ArrayUtil.php
+++ b/core-bundle/src/Resources/contao/library/Contao/ArrayUtil.php
@@ -57,11 +57,11 @@ class ArrayUtil
 	}
 
 	/**
-	 * @param array        $arrItems   Items array that should ge sorted
-	 * @param string|array $strOrder   Serialized order field or array
-	 * @param string|null  $strIdField Name of the id field to be used for
-	 *                                 sorting if the items are objects
-	 * @param boolean      $blnByKey   If true the keys of the $arrItems are used
+	 * @param  array        $arrItems   Items array that should ge sorted
+	 * @param  string|array $strOrder   Serialized order field or array
+	 * @param  string|null  $strIdField Name of the id field to be used for
+	 *                                  sorting if the items are objects
+	 * @param  boolean      $blnByKey   If true the keys of the $arrItems are used
 	 * @return array
 	 */
 	public static function sortByOrderField(array $arrItems, $strOrder, ?string $strIdField = 'uuid', bool $blnByKey = false): array
@@ -76,13 +76,17 @@ class ArrayUtil
 			{
 				$strKey = $key;
 			}
-			elseif (\is_string($item))
+			elseif (\is_object($item))
 			{
-				$strKey = $item;
+				$strKey = $item->$strIdField;
+			}
+			elseif (\is_array($item))
+			{
+				$strKey = $item[$strIdField];
 			}
 			else
 			{
-				$strKey = is_object($item) ? $item->$strIdField : $item[$strIdField];
+				$strKey = $item;
 			}
 
 			if (\array_key_exists($strKey, $arrOrder))
@@ -93,9 +97,13 @@ class ArrayUtil
 		}
 
 		// Remove empty (unreplaced) entries
-		$arrOrder = array_filter($arrOrder);
+		$arrOrder = array_filter($arrOrder, static function ($item)
+		{
+			return $item !== null;
+		});
 
-		if ($blnByKey) {
+		if ($blnByKey)
+		{
 			// Append the left-over images at the end
 			return $arrOrder + $arrItems;
 		}

--- a/core-bundle/src/Resources/contao/library/Contao/Automator.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Automator.php
@@ -115,7 +115,7 @@ class Automator extends System
 		$strRootDir = $container->getParameter('kernel.project_dir');
 
 		// Walk through the subfolders
-		foreach (scan($strRootDir . '/' . $strTargetPath) as $dir)
+		foreach (Folder::scan($strRootDir . '/' . $strTargetPath) as $dir)
 		{
 			if (strncmp($dir, '.', 1) !== 0)
 			{
@@ -295,7 +295,7 @@ class Automator extends System
 		{
 			$shareDir = System::getContainer()->getParameter('contao.web_dir') . '/share';
 
-			foreach (scan($shareDir) as $file)
+			foreach (Folder::scan($shareDir) as $file)
 			{
 				if (is_dir($shareDir . '/' . $file))
 				{
@@ -460,7 +460,7 @@ class Automator extends System
 		@trigger_error('Using Automator::rotateLogs() has been deprecated and will no longer work in Contao 5.0. Use the logger service instead, which rotates its log files automatically.', E_USER_DEPRECATED);
 
 		$rootDir = System::getContainer()->getParameter('kernel.project_dir');
-		$arrFiles = preg_grep('/\.log$/', scan($rootDir . '/system/logs'));
+		$arrFiles = preg_grep('/\.log$/', Folder::scan($rootDir . '/system/logs'));
 
 		foreach ($arrFiles as $strFile)
 		{

--- a/core-bundle/src/Resources/contao/library/Contao/Automator.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Automator.php
@@ -376,7 +376,7 @@ class Automator extends System
 				}
 
 				$strUrl = implode('/', $strUrl);
-				$strUrl = ampersand($strUrl);
+				$strUrl = StringUtil::ampersand($strUrl);
 
 				$objFile->append('  <url><loc>' . $strUrl . '</loc></url>');
 			}

--- a/core-bundle/src/Resources/contao/library/Contao/Controller.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Controller.php
@@ -1060,7 +1060,7 @@ abstract class Controller extends System
 			$uri = str_replace('+', '%2B', $uri);
 		}
 
-		return TL_SCRIPT . ampersand($uri);
+		return TL_SCRIPT . StringUtil::ampersand($uri);
 	}
 
 	/**

--- a/core-bundle/src/Resources/contao/library/Contao/Controller.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Controller.php
@@ -630,7 +630,7 @@ abstract class Controller extends System
 		System::loadLanguageFile('languages');
 
 		$return = array();
-		$langs = scan(__DIR__ . '/../../languages');
+		$langs = Folder::scan(__DIR__ . '/../../languages');
 		array_unshift($langs, $GLOBALS['TL_LANGUAGE']);
 
 		foreach ($langs as $lang)

--- a/core-bundle/src/Resources/contao/library/Contao/Controller.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Controller.php
@@ -1880,33 +1880,7 @@ abstract class Controller extends System
 		// Order the enclosures
 		if (!empty($arrItem['orderEnclosure']))
 		{
-			$tmp = StringUtil::deserialize($arrItem['orderEnclosure']);
-
-			if (!empty($tmp) && \is_array($tmp))
-			{
-				// Remove all values
-				$arrOrder = array_map(static function () {}, array_flip($tmp));
-
-				// Move the matching elements to their position in $arrOrder
-				foreach ($arrEnclosures as $k=>$v)
-				{
-					if (\array_key_exists($v['uuid'], $arrOrder))
-					{
-						$arrOrder[$v['uuid']] = $v;
-						unset($arrEnclosures[$k]);
-					}
-				}
-
-				// Append the left-over enclosures at the end
-				if (!empty($arrEnclosures))
-				{
-					$arrOrder = array_merge($arrOrder, array_values($arrEnclosures));
-				}
-
-				// Remove empty (unreplaced) entries
-				$arrEnclosures = array_values(array_filter($arrOrder));
-				unset($arrOrder);
-			}
+			$arrEnclosures = ArrayUtil::sortByOrderField($arrEnclosures, $arrItem['orderEnclosure']);
 		}
 
 		$objTemplate->enclosure = $arrEnclosures;

--- a/core-bundle/src/Resources/contao/library/Contao/Database.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Database.php
@@ -538,7 +538,7 @@ class Database
 				foreach (array_reverse(array_keys($arrOrdered)) as $pid)
 				{
 					$pos = (int) array_search($pid, $arrReturn);
-					array_insert($arrReturn, $pos+1, $arrOrdered[$pid]);
+					ArrayUtil::arrayInsert($arrReturn, $pos+1, $arrOrdered[$pid]);
 				}
 
 				$arrReturn = $this->getChildRecords($arrChilds, $strTable, $blnSorting, $arrReturn, $strWhere);

--- a/core-bundle/src/Resources/contao/library/Contao/Database/Updater.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Database/Updater.php
@@ -10,6 +10,7 @@
 
 namespace Contao\Database;
 
+use Contao\ArrayUtil;
 use Contao\Config;
 use Contao\Controller;
 use Contao\Database;
@@ -17,6 +18,7 @@ use Contao\Dbafs;
 use Contao\File;
 use Contao\Files;
 use Contao\FilesModel;
+use Contao\Folder;
 use Contao\StringUtil;
 use Contao\System;
 use Symfony\Component\Finder\SplFileInfo;
@@ -556,7 +558,7 @@ class Updater extends Controller
 			{
 				if (($key = array_search('layout.css', $tmp)) !== false)
 				{
-					array_insert($tmp, $key + 1, 'responsive.css');
+					ArrayUtil::arrayInsert($tmp, $key + 1, 'responsive.css');
 				}
 
 				$strFramework = serialize(array_values(array_unique($tmp)));
@@ -650,7 +652,7 @@ class Updater extends Controller
 		$arrFolders = array();
 		$arrFiles = array();
 		$rootDir = System::getContainer()->getParameter('kernel.project_dir');
-		$arrScan = scan($rootDir . '/' . $strPath);
+		$arrScan = Folder::scan($rootDir . '/' . $strPath);
 
 		foreach ($arrScan as $strFile)
 		{

--- a/core-bundle/src/Resources/contao/library/Contao/Files.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Files.php
@@ -120,7 +120,7 @@ class Files
 	public function rrdir($strFolder, $blnPreserveRoot=false)
 	{
 		$this->validate($strFolder);
-		$arrFiles = scan($this->strRootDir . '/' . $strFolder, true);
+		$arrFiles = Folder::scan($this->strRootDir . '/' . $strFolder, true);
 
 		foreach ($arrFiles as $strFile)
 		{
@@ -242,7 +242,7 @@ class Files
 		$this->validate($strSource, $strDestination);
 
 		$this->mkdir($strDestination);
-		$arrFiles = scan($this->strRootDir . '/' . $strSource, true);
+		$arrFiles = Folder::scan($this->strRootDir . '/' . $strSource, true);
 
 		foreach ($arrFiles as $strFile)
 		{

--- a/core-bundle/src/Resources/contao/library/Contao/Folder.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Folder.php
@@ -60,6 +60,12 @@ class Folder extends System
 	protected $arrPathinfo = array();
 
 	/**
+	 * Scan cache
+	 * @var array
+	 */
+	private static $arrScanCache = array();
+
+	/**
 	 * Check whether the folder exists
 	 *
 	 * @param string $strFolder The folder path
@@ -166,7 +172,7 @@ class Folder extends System
 	 */
 	public function isEmpty()
 	{
-		return \count(scan($this->strRootDir . '/' . $this->strFolder, true)) < 1;
+		return \count(static::scan($this->strRootDir . '/' . $this->strFolder, true)) < 1;
 	}
 
 	/**
@@ -478,7 +484,7 @@ class Folder extends System
 	{
 		$intSize = 0;
 
-		foreach (scan($this->strRootDir . '/' . $this->strFolder, true) as $strFile)
+		foreach (static::scan($this->strRootDir . '/' . $this->strFolder, true) as $strFile)
 		{
 			if (strncmp($strFile, '.', 1) === 0)
 			{
@@ -538,6 +544,52 @@ class Folder extends System
 		}
 
 		return $return;
+	}
+
+	/**
+	 * Scan a directory and return its files and folders as array
+	 *
+	 * @param string  $strFolder
+	 * @param boolean $blnUncached
+	 *
+	 * @return array
+	 */
+	public static function scan($strFolder, $blnUncached=false): array
+	{
+		static::$arrScanCache;
+
+		// Add a trailing slash
+		if (substr($strFolder, -1, 1) != '/')
+		{
+			$strFolder .= '/';
+		}
+
+		// Load from cache
+		if (!$blnUncached && isset($arrScanCache[$strFolder]))
+		{
+			return $arrScanCache[$strFolder];
+		}
+
+		$arrReturn = array();
+
+		// Scan directory
+		foreach (scandir($strFolder, SCANDIR_SORT_ASCENDING) as $strFile)
+		{
+			if ($strFile == '.' || $strFile == '..')
+			{
+				continue;
+			}
+
+			$arrReturn[] = $strFile;
+		}
+
+		// Cache the result
+		if (!$blnUncached)
+		{
+			$arrScanCache[$strFolder] = $arrReturn;
+		}
+
+		return $arrReturn;
 	}
 }
 

--- a/core-bundle/src/Resources/contao/library/Contao/InsertTags.php
+++ b/core-bundle/src/Resources/contao/library/Contao/InsertTags.php
@@ -1023,8 +1023,6 @@ class InsertTags extends Controller
 						case 'standardize':
 						case 'ampersand':
 						case 'specialchars':
-						case 'nl2br':
-						case 'nl2br_pre':
 						case 'strtolower':
 						case 'utf8_strtolower':
 						case 'strtoupper':
@@ -1039,6 +1037,14 @@ class InsertTags extends Controller
 						case 'urlencode':
 						case 'rawurlencode':
 							$arrCache[$strTag] = $flag($arrCache[$strTag]);
+							break;
+
+						case 'nl2br_pre':
+							@trigger_error('Using nl2br_pre() has been deprecated and will no longer work in Contao 5.0.', E_USER_DEPRECATED);
+							// no break
+
+						case 'nl2br':
+							$arrCache[$strTag] = preg_replace('/\r?\n/', '<br>', $arrCache[$strTag]);
 							break;
 
 						case 'encodeEmail':

--- a/core-bundle/src/Resources/contao/library/Contao/Pagination.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Pagination.php
@@ -395,10 +395,10 @@ class Pagination
 	{
 		if ($intPage <= 1 && !$this->blnForceParam)
 		{
-			return ampersand($this->strUrl);
+			return StringUtil::ampersand($this->strUrl);
 		}
 
-		return ampersand($this->strUrl) . $this->strVarConnector . $this->strParameter . '=' . $intPage;
+		return StringUtil::ampersand($this->strUrl) . $this->strVarConnector . $this->strParameter . '=' . $intPage;
 	}
 }
 

--- a/core-bundle/src/Resources/contao/library/Contao/StringUtil.php
+++ b/core-bundle/src/Resources/contao/library/Contao/StringUtil.php
@@ -1120,6 +1120,19 @@ class StringUtil
 
 		return (string) substr($path, $length + 1);
 	}
+
+	/**
+	 * Convert all ampersands into their HTML entity (default) or unencoded value
+	 *
+	 * @param string  $strString
+	 * @param boolean $blnEncode
+	 *
+	 * @return string
+	 */
+	public static function ampersand($strString, $blnEncode=true): string
+	{
+		return preg_replace('/&(amp;)?/i', ($blnEncode ? '&amp;' : '&'), $strString);
+	}
 }
 
 class_alias(StringUtil::class, 'StringUtil');

--- a/core-bundle/src/Resources/contao/library/Contao/System.php
+++ b/core-bundle/src/Resources/contao/library/Contao/System.php
@@ -1123,7 +1123,7 @@ abstract class System
 	{
 		@trigger_error('Using System::getIndexFreeRequest() has been deprecated and will no longer work in Contao 5.0. Use Environment::get("indexFreeRequest") instead.', E_USER_DEPRECATED);
 
-		return ampersand(Environment::get('indexFreeRequest'), $blnAmpersand);
+		return StringUtil::ampersand(Environment::get('indexFreeRequest'), $blnAmpersand);
 	}
 
 	/**

--- a/core-bundle/src/Resources/contao/library/Contao/Template.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Template.php
@@ -344,7 +344,7 @@ abstract class Template extends Controller
 		$strUrl = System::getContainer()->get('router')->generate($strName, $arrParams);
 		$strUrl = substr($strUrl, \strlen(Environment::get('path')) + 1);
 
-		return ampersand($strUrl);
+		return StringUtil::ampersand($strUrl);
 	}
 
 	/**
@@ -374,7 +374,7 @@ abstract class Template extends Controller
 
 		$context->setBaseUrl('');
 
-		return ampersand($strUrl);
+		return StringUtil::ampersand($strUrl);
 	}
 
 	/**

--- a/core-bundle/src/Resources/contao/modules/ModuleNavigation.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleNavigation.php
@@ -81,7 +81,7 @@ class ModuleNavigation extends Module
 			$host = $objRootPage->domain;
 		}
 
-		$this->Template->request = ampersand(Environment::get('indexFreeRequest'));
+		$this->Template->request = StringUtil::ampersand(Environment::get('indexFreeRequest'));
 		$this->Template->skipId = 'skipNavigation' . $this->id;
 		$this->Template->skipNavigation = StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['skipNavigation']);
 		$this->Template->items = $this->renderNavigation($trail[$level], 1, $host, $lang);

--- a/core-bundle/src/Resources/contao/modules/ModuleQuicklink.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleQuicklink.php
@@ -146,7 +146,7 @@ class ModuleQuicklink extends Module
 
 		$this->Template->items = $items;
 		$this->Template->formId = 'tl_quicklink_' . $this->id;
-		$this->Template->request = ampersand(Environment::get('request'));
+		$this->Template->request = StringUtil::ampersand(Environment::get('request'));
 		$this->Template->title = $this->customLabel ?: $GLOBALS['TL_LANG']['MSC']['quicklink'];
 		$this->Template->button = StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['go']);
 	}

--- a/core-bundle/src/Resources/contao/templates/backend/be_csv_import.html5
+++ b/core-bundle/src/Resources/contao/templates/backend/be_csv_import.html5
@@ -2,7 +2,7 @@
 <?= Contao\Message::generate() ?>
 
 <div id="tl_buttons">
-  <a href="<?= ampersand($this->backUrl) ?>" class="header_back" title="<?= Contao\StringUtil::specialchars($this->backBTTitle) ?>" accesskey="b"><?= $this->backBT ?></a>
+  <a href="<?= Contao\StringUtil::ampersand($this->backUrl) ?>" class="header_back" title="<?= Contao\StringUtil::specialchars($this->backBTTitle) ?>" accesskey="b"><?= $this->backBT ?></a>
 </div>
 
 <form id="<?= $this->formId ?>" class="tl_form tl_edit_form" method="post" enctype="multipart/form-data">

--- a/core-bundle/src/Resources/contao/widgets/FileSelector.php
+++ b/core-bundle/src/Resources/contao/widgets/FileSelector.php
@@ -232,7 +232,7 @@ class FileSelector extends Widget
 				if (empty($root))
 				{
 					// Set all folders inside the custom path as root nodes
-					$root = array_map(function ($el) { return $this->path . '/' . $el; }, scan($rootDir . '/' . $this->path));
+					$root = array_map(function ($el) { return $this->path . '/' . $el; }, Folder::scan($rootDir . '/' . $this->path));
 
 					// Hide the breadcrumb
 					$GLOBALS['TL_DCA']['tl_file']['list']['sorting']['breadcrumb'] = '';
@@ -403,7 +403,7 @@ class FileSelector extends Widget
 		// Scan directory and sort the result
 		else
 		{
-			foreach (scan($path) as $v)
+			foreach (Folder::scan($path) as $v)
 			{
 				if (strncmp($v, '.', 1) === 0)
 				{
@@ -439,7 +439,7 @@ class FileSelector extends Widget
 		// Process folders
 		for ($f=0, $c=\count($folders); $f<$c; $f++)
 		{
-			$content = scan($folders[$f]);
+			$content = Folder::scan($folders[$f]);
 			$currentFolder = StringUtil::stripRootDir($folders[$f]);
 			$countFiles = \count($content);
 

--- a/core-bundle/src/Resources/contao/widgets/FileTree.php
+++ b/core-bundle/src/Resources/contao/widgets/FileTree.php
@@ -320,27 +320,7 @@ class FileTree extends Widget
 			// Apply a custom sort order
 			if ($blnHasOrder)
 			{
-				$arrNew = array();
-
-				foreach ((array) $this->{$this->orderField} as $i)
-				{
-					if (isset($arrValues[$i]))
-					{
-						$arrNew[$i] = $arrValues[$i];
-						unset($arrValues[$i]);
-					}
-				}
-
-				if (!empty($arrValues))
-				{
-					foreach ($arrValues as $k=>$v)
-					{
-						$arrNew[$k] = $v;
-					}
-				}
-
-				$arrValues = $arrNew;
-				unset($arrNew);
+				$arrValues = ArrayUtil::sortByOrderField($arrValues, $this->{$this->orderField}, null, true);
 			}
 		}
 

--- a/core-bundle/src/Resources/contao/widgets/FileTree.php
+++ b/core-bundle/src/Resources/contao/widgets/FileTree.php
@@ -371,7 +371,7 @@ class FileTree extends Widget
 			$extras = $this->getPickerUrlExtras($arrValues);
 
 			$return .= '
-    <p><a href="' . ampersand(System::getContainer()->get('contao.picker.builder')->getUrl('file', $extras)) . '" class="tl_submit" id="ft_' . $this->strName . '">' . $GLOBALS['TL_LANG']['MSC']['changeSelection'] . '</a></p>
+    <p><a href="' . StringUtil::ampersand(System::getContainer()->get('contao.picker.builder')->getUrl('file', $extras)) . '" class="tl_submit" id="ft_' . $this->strName . '">' . $GLOBALS['TL_LANG']['MSC']['changeSelection'] . '</a></p>
     <script>
       $("ft_' . $this->strName . '").addEvent("click", function(e) {
         e.preventDefault();

--- a/core-bundle/src/Resources/contao/widgets/PageTree.php
+++ b/core-bundle/src/Resources/contao/widgets/PageTree.php
@@ -231,7 +231,7 @@ class PageTree extends Widget
 			$extras = $this->getPickerUrlExtras($arrValues);
 
 			$return .= '
-    <p><a href="' . ampersand(System::getContainer()->get('contao.picker.builder')->getUrl('page', $extras)) . '" class="tl_submit" id="pt_' . $this->strName . '">' . $GLOBALS['TL_LANG']['MSC']['changeSelection'] . '</a></p>
+    <p><a href="' . StringUtil::ampersand(System::getContainer()->get('contao.picker.builder')->getUrl('page', $extras)) . '" class="tl_submit" id="pt_' . $this->strName . '">' . $GLOBALS['TL_LANG']['MSC']['changeSelection'] . '</a></p>
     <script>
       $("pt_' . $this->strName . '").addEvent("click", function(e) {
         e.preventDefault();

--- a/core-bundle/src/Resources/contao/widgets/PageTree.php
+++ b/core-bundle/src/Resources/contao/widgets/PageTree.php
@@ -184,27 +184,7 @@ class PageTree extends Widget
 			// Apply a custom sort order
 			if ($blnHasOrder)
 			{
-				$arrNew = array();
-
-				foreach ((array) $this->{$this->orderField} as $i)
-				{
-					if (isset($arrValues[$i]))
-					{
-						$arrNew[$i] = $arrValues[$i];
-						unset($arrValues[$i]);
-					}
-				}
-
-				if (!empty($arrValues))
-				{
-					foreach ($arrValues as $k=>$v)
-					{
-						$arrNew[$k] = $v;
-					}
-				}
-
-				$arrValues = $arrNew;
-				unset($arrNew);
+				$arrValues = ArrayUtil::sortByOrderField($arrValues, $this->{$this->orderField}, null, true);
 			}
 		}
 

--- a/core-bundle/src/Resources/contao/widgets/Picker.php
+++ b/core-bundle/src/Resources/contao/widgets/Picker.php
@@ -213,27 +213,7 @@ class Picker extends Widget
 			// Apply a custom sort order
 			if ($blnHasOrder)
 			{
-				$arrNew = array();
-
-				foreach ((array) $this->{$this->orderField} as $i)
-				{
-					if (isset($arrValues[$i]))
-					{
-						$arrNew[$i] = $arrValues[$i];
-						unset($arrValues[$i]);
-					}
-				}
-
-				if (!empty($arrValues))
-				{
-					foreach ($arrValues as $k=>$v)
-					{
-						$arrNew[$k] = $v;
-					}
-				}
-
-				$arrValues = $arrNew;
-				unset($arrNew);
+				$arrValues = ArrayUtil::sortByOrderField($arrValues, $this->{$this->orderField}, null, true);
 			}
 		}
 

--- a/core-bundle/src/Resources/contao/widgets/Picker.php
+++ b/core-bundle/src/Resources/contao/widgets/Picker.php
@@ -143,7 +143,7 @@ class Picker extends Widget
 			$extras = $this->getPickerUrlExtras($arrValues);
 
 			$return .= '
-    <p><a href="' . ampersand(System::getContainer()->get('contao.picker.builder')->getUrl($strContext, $extras)) . '" class="tl_submit" id="picker_' . $this->strName . '">' . $GLOBALS['TL_LANG']['MSC']['changeSelection'] . '</a></p>
+    <p><a href="' . StringUtil::ampersand(System::getContainer()->get('contao.picker.builder')->getUrl($strContext, $extras)) . '" class="tl_submit" id="picker_' . $this->strName . '">' . $GLOBALS['TL_LANG']['MSC']['changeSelection'] . '</a></p>
     <script>
       $("picker_' . $this->strName . '").addEvent("click", function(e) {
         e.preventDefault();

--- a/core-bundle/tests/Contao/ArrayUtilTest.php
+++ b/core-bundle/tests/Contao/ArrayUtilTest.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\Contao;
+
+use Contao\ArrayUtil;
+use Contao\CoreBundle\Tests\TestCase;
+
+class ArrayUtilTest extends TestCase
+{
+    /**
+     * @dataProvider sortByOrderFieldProvider
+     */
+    public function testSortsByOrderField(array $items, array $order, array $expected): void
+    {
+        $this->assertSame($expected, ArrayUtil::sortByOrderField($items, $order));
+
+        $itemArrays = array_map(
+            static function ($item): array {
+                return ['uuid' => $item];
+            },
+            $items
+        );
+        $expectedArrays = array_map(
+            static function ($item): array {
+                return ['uuid' => $item];
+            },
+            $expected
+        );
+
+        $this->assertSame($expectedArrays, ArrayUtil::sortByOrderField($itemArrays, $order));
+
+        $itemArrays = array_map(
+            static function ($item): array {
+                return ['id' => $item];
+            },
+            $items
+        );
+        $expectedArrays = array_map(
+            static function ($item): array {
+                return ['id' => $item];
+            },
+            $expected
+        );
+
+        $this->assertSame($expectedArrays, ArrayUtil::sortByOrderField($itemArrays, $order, 'id'));
+
+        $itemObjects = array_map(
+            static function ($item): \stdClass {
+                return (object) ['uuid' => $item];
+            },
+            $items
+        );
+        $expectedObjects = array_map(
+            static function ($item): \stdClass {
+                return (object) ['uuid' => $item];
+            },
+            $expected
+        );
+
+        $this->assertSame(array_map('get_object_vars', $expectedObjects), array_map('get_object_vars', ArrayUtil::sortByOrderField($itemObjects, $order)));
+
+        $itemObjects = array_map(
+            static function ($item): \stdClass {
+                return (object) ['id' => $item];
+            },
+            $items
+        );
+        $expectedObjects = array_map(
+            static function ($item): \stdClass {
+                return (object) ['id' => $item];
+            },
+            $expected
+        );
+
+        $this->assertSame(array_map('get_object_vars', $expectedObjects), array_map('get_object_vars', ArrayUtil::sortByOrderField($itemObjects, $order, 'id')));
+
+        $itemFlipped = array_map(static function () { return 'X'; }, array_flip($items));
+        $expectedFlipped = array_map(static function () { return 'X'; }, array_flip($expected));
+
+        $this->assertSame($expectedFlipped, ArrayUtil::sortByOrderField($itemFlipped, $order, null, true));
+    }
+
+    public function sortByOrderFieldProvider(): \Generator
+    {
+        yield [
+            ['a', 'b', 'c'],
+            [],
+            ['a', 'b', 'c'],
+        ];
+
+        yield [
+            ['a', 'b', 'c'],
+            ['b', 'c', 'a'],
+            ['b', 'c', 'a'],
+        ];
+
+        yield [
+            ['a', 'b', 'c'],
+            ['b'],
+            ['b', 'a', 'c'],
+        ];
+
+        yield [
+            ['a', 'b', 'c'],
+            ['X'],
+            ['a', 'b', 'c'],
+        ];
+
+        yield [
+            [0, 1, 2],
+            [],
+            [0, 1, 2],
+        ];
+
+        yield [
+            [0, 1, 2],
+            [1, 2, 0],
+            [1, 2, 0],
+        ];
+
+        yield [
+            [0, 1, 2],
+            [1],
+            [1, 0, 2],
+        ];
+
+        yield [
+            [0, 1, 2],
+            [99],
+            [0, 1, 2],
+        ];
+    }
+}

--- a/core-bundle/tests/Contao/ArrayUtilTest.php
+++ b/core-bundle/tests/Contao/ArrayUtilTest.php
@@ -38,6 +38,7 @@ class ArrayUtilTest extends TestCase
         );
 
         $this->assertSame($expectedArrays, ArrayUtil::sortByOrderField($itemArrays, $order));
+        $this->assertSame($expectedArrays, ArrayUtil::sortByOrderField($itemArrays, serialize($order)));
 
         $itemArrays = array_map(
             static function ($item): array {
@@ -53,6 +54,7 @@ class ArrayUtilTest extends TestCase
         );
 
         $this->assertSame($expectedArrays, ArrayUtil::sortByOrderField($itemArrays, $order, 'id'));
+        $this->assertSame($expectedArrays, ArrayUtil::sortByOrderField($itemArrays, serialize($order), 'id'));
 
         $itemObjects = array_map(
             static function ($item): \stdClass {
@@ -68,6 +70,7 @@ class ArrayUtilTest extends TestCase
         );
 
         $this->assertSame(array_map('get_object_vars', $expectedObjects), array_map('get_object_vars', ArrayUtil::sortByOrderField($itemObjects, $order)));
+        $this->assertSame(array_map('get_object_vars', $expectedObjects), array_map('get_object_vars', ArrayUtil::sortByOrderField($itemObjects, serialize($order))));
 
         $itemObjects = array_map(
             static function ($item): \stdClass {
@@ -83,11 +86,13 @@ class ArrayUtilTest extends TestCase
         );
 
         $this->assertSame(array_map('get_object_vars', $expectedObjects), array_map('get_object_vars', ArrayUtil::sortByOrderField($itemObjects, $order, 'id')));
+        $this->assertSame(array_map('get_object_vars', $expectedObjects), array_map('get_object_vars', ArrayUtil::sortByOrderField($itemObjects, serialize($order), 'id')));
 
         $itemFlipped = array_map(static function () { return 'X'; }, array_flip($items));
         $expectedFlipped = array_map(static function () { return 'X'; }, array_flip($expected));
 
         $this->assertSame($expectedFlipped, ArrayUtil::sortByOrderField($itemFlipped, $order, null, true));
+        $this->assertSame($expectedFlipped, ArrayUtil::sortByOrderField($itemFlipped, serialize($order), null, true));
     }
 
     public function sortByOrderFieldProvider(): \Generator

--- a/faq-bundle/src/Resources/contao/modules/ModuleFaqList.php
+++ b/faq-bundle/src/Resources/contao/modules/ModuleFaqList.php
@@ -147,12 +147,12 @@ class ModuleFaqList extends Module
 		// Get the URL from the jumpTo page of the category
 		if (!isset($this->arrTargets[$jumpTo]))
 		{
-			$this->arrTargets[$jumpTo] = ampersand(Environment::get('request'));
+			$this->arrTargets[$jumpTo] = StringUtil::ampersand(Environment::get('request'));
 
 			if ($jumpTo > 0 && ($objTarget = PageModel::findByPk($jumpTo)) !== null)
 			{
 				/** @var PageModel $objTarget */
-				$this->arrTargets[$jumpTo] = ampersand($objTarget->getFrontendUrl(Config::get('useAutoItem') ? '/%s' : '/items/%s'));
+				$this->arrTargets[$jumpTo] = StringUtil::ampersand($objTarget->getFrontendUrl(Config::get('useAutoItem') ? '/%s' : '/items/%s'));
 			}
 		}
 

--- a/installation-bundle/src/Database/Version330Update.php
+++ b/installation-bundle/src/Database/Version330Update.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\InstallationBundle\Database;
 
+use Contao\ArrayUtil;
 use Contao\CoreBundle\Migration\AbstractMigration;
 use Contao\CoreBundle\Migration\MigrationResult;
 use Contao\StringUtil;
@@ -67,7 +68,7 @@ class Version330Update extends AbstractMigration
 
             if (!empty($tmp) && \is_array($tmp)) {
                 if (false !== ($key = array_search('layout.css', $tmp, true))) {
-                    array_insert($tmp, $key + 1, 'responsive.css');
+                    ArrayUtil::arrayInsert($tmp, $key + 1, 'responsive.css');
                 }
 
                 $framework = serialize(array_values(array_unique($tmp)));

--- a/listing-bundle/src/Resources/contao/modules/ModuleListing.php
+++ b/listing-bundle/src/Resources/contao/modules/ModuleListing.php
@@ -278,7 +278,7 @@ class ModuleListing extends Module
 			$arrTh[] = array
 			(
 				'link' => $strField,
-				'href' => (ampersand($strUrl) . $strVarConnector . 'order_by=' . $arrFields[$i]) . '&amp;sort=' . $sort,
+				'href' => (StringUtil::ampersand($strUrl) . $strVarConnector . 'order_by=' . $arrFields[$i]) . '&amp;sort=' . $sort,
 				'title' => StringUtil::specialchars(sprintf($GLOBALS['TL_LANG']['MSC']['list_orderBy'], $strField)),
 				'class' => $class . (($i == 0) ? ' col_first' : '') . ((($i + 1) == \count($arrFields)) ? ' col_last' : '')
 			);

--- a/news-bundle/src/Resources/contao/classes/News.php
+++ b/news-bundle/src/Resources/contao/classes/News.php
@@ -377,7 +377,7 @@ class News extends Frontend
 				}
 				else
 				{
-					self::$arrUrlCache[$strCacheKey] = ampersand($objItem->url);
+					self::$arrUrlCache[$strCacheKey] = StringUtil::ampersand($objItem->url);
 				}
 				break;
 
@@ -386,7 +386,7 @@ class News extends Frontend
 				if (($objTarget = $objItem->getRelated('jumpTo')) instanceof PageModel)
 				{
 					/** @var PageModel $objTarget */
-					self::$arrUrlCache[$strCacheKey] = ampersand($blnAbsolute ? $objTarget->getAbsoluteUrl() : $objTarget->getFrontendUrl());
+					self::$arrUrlCache[$strCacheKey] = StringUtil::ampersand($blnAbsolute ? $objTarget->getAbsoluteUrl() : $objTarget->getFrontendUrl());
 				}
 				break;
 
@@ -397,7 +397,7 @@ class News extends Frontend
 					$params = '/articles/' . ($objArticle->alias ?: $objArticle->id);
 
 					/** @var PageModel $objPid */
-					self::$arrUrlCache[$strCacheKey] = ampersand($blnAbsolute ? $objPid->getAbsoluteUrl($params) : $objPid->getFrontendUrl($params));
+					self::$arrUrlCache[$strCacheKey] = StringUtil::ampersand($blnAbsolute ? $objPid->getAbsoluteUrl($params) : $objPid->getFrontendUrl($params));
 				}
 				break;
 		}
@@ -409,13 +409,13 @@ class News extends Frontend
 
 			if (!$objPage instanceof PageModel)
 			{
-				self::$arrUrlCache[$strCacheKey] = ampersand(Environment::get('request'));
+				self::$arrUrlCache[$strCacheKey] = StringUtil::ampersand(Environment::get('request'));
 			}
 			else
 			{
 				$params = (Config::get('useAutoItem') ? '/' : '/items/') . ($objItem->alias ?: $objItem->id);
 
-				self::$arrUrlCache[$strCacheKey] = ampersand($blnAbsolute ? $objPage->getAbsoluteUrl($params) : $objPage->getFrontendUrl($params));
+				self::$arrUrlCache[$strCacheKey] = StringUtil::ampersand($blnAbsolute ? $objPage->getAbsoluteUrl($params) : $objPage->getFrontendUrl($params));
 			}
 
 			// Add the current archive parameter (news archive)
@@ -459,7 +459,7 @@ class News extends Frontend
 				if (($objArticle = ArticleModel::findByPk($objItem->articleId)) instanceof ArticleModel && ($objPid = $objArticle->getRelated('pid')) instanceof PageModel)
 				{
 					/** @var PageModel $objPid */
-					return ampersand($objPid->getAbsoluteUrl('/articles/' . ($objArticle->alias ?: $objArticle->id)));
+					return StringUtil::ampersand($objPid->getAbsoluteUrl('/articles/' . ($objArticle->alias ?: $objArticle->id)));
 				}
 				break;
 		}

--- a/news-bundle/src/Resources/contao/modules/ModuleNews.php
+++ b/news-bundle/src/Resources/contao/modules/ModuleNews.php
@@ -377,7 +377,7 @@ abstract class ModuleNews extends Module
 		// Ampersand URIs
 		else
 		{
-			$strArticleUrl = ampersand($objArticle->url);
+			$strArticleUrl = StringUtil::ampersand($objArticle->url);
 		}
 
 		// External link

--- a/newsletter-bundle/src/Resources/contao/classes/Newsletter.php
+++ b/newsletter-bundle/src/Resources/contao/classes/Newsletter.php
@@ -534,7 +534,7 @@ class Newsletter extends Backend
 		// Return form
 		return '
 <div id="tl_buttons">
-<a href="' . ampersand(str_replace('&key=import', '', Environment::get('request'))) . '" class="header_back" title="' . StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['backBTTitle']) . '" accesskey="b">' . $GLOBALS['TL_LANG']['MSC']['backBT'] . '</a>
+<a href="' . StringUtil::ampersand(str_replace('&key=import', '', Environment::get('request'))) . '" class="header_back" title="' . StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['backBTTitle']) . '" accesskey="b">' . $GLOBALS['TL_LANG']['MSC']['backBT'] . '</a>
 </div>
 ' . Message::generate() . '
 <form id="tl_recipients_import" class="tl_form tl_edit_form" method="post" enctype="multipart/form-data">

--- a/newsletter-bundle/src/Resources/contao/modules/ModuleNewsletterList.php
+++ b/newsletter-bundle/src/Resources/contao/modules/ModuleNewsletterList.php
@@ -68,7 +68,7 @@ class ModuleNewsletterList extends Module
 		$arrJumpTo = array();
 		$arrNewsletter = array();
 
-		$strRequest = ampersand(Environment::get('request'));
+		$strRequest = StringUtil::ampersand(Environment::get('request'));
 		$objNewsletter = NewsletterModel::findSentByPids($this->nl_channels);
 
 		if ($objNewsletter !== null)

--- a/newsletter-bundle/src/Resources/contao/modules/ModuleNewsletterReader.php
+++ b/newsletter-bundle/src/Resources/contao/modules/ModuleNewsletterReader.php
@@ -116,7 +116,7 @@ class ModuleNewsletterReader extends Module
 		// Support plain text newsletters (thanks to Hagen Klemp)
 		if ($objNewsletter->sendText)
 		{
-			$strContent = nl2br_html5($objNewsletter->text);
+			$strContent = nl2br($objNewsletter->text, false);
 		}
 		else
 		{


### PR DESCRIPTION
Moved functions:

- `scan()` to `Folder::scan()` 
- `ampersand()` to `StringUtil::ampersand()`
- `array_insert()` to `ArrayUtil::arrayInsert()`
- `array_is_assoc()` to `ArrayUtil::isAssoc()`

Without replacement:

- `nl2br_html5()`
- `nl2br_xhtml()`
- `nl2br_pre()`
- `basename_natcasecmp()`
- `basename_natcasercmp()`
- `natcaseksort()`
- `length_sort_asc()`
- `length_sort_desc()`