### PR TITLE
Run PHPStan on level 4 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
                   vendor/bin/ecs check *-bundle/src/Resources/contao/templates --config vendor/contao/easy-coding-standard/config/template.yaml --no-progress-bar --ansi
 
             - name: Analyze the code
-              run: vendor/bin/phpstan analyse core-bundle/src core-bundle/tests --level=3 --no-progress
+              run: vendor/bin/phpstan analyse core-bundle/src core-bundle/tests --level=4 --no-progress
 
     tests:
         name: PHP ${{ matrix.php }}


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | n/a
| Docs PR or issue | n/a

Run PHPStan on level 4 in CI. Missed this in #1476.
