### PR TITLE
Adjust the JSON-LD data in the default indexer test

### DIFF
--- a/core-bundle/src/Search/Document.php
+++ b/core-bundle/src/Search/Document.php
@@ -181,7 +181,7 @@ class Document
         if (\is_array($data['@context'])) {
             foreach ($data['@context'] as $prefix => $context) {
                 if (isset($data['@type']) && 0 === strncmp($data['@type'], $prefix.':', \strlen($prefix) + 1)) {
-                    $data['@type'] = substr($data['@type'], \strlen($prefix) + 1);
+                    $data['@type'] = $context.substr($data['@type'], \strlen($prefix) + 1);
                 }
 
                 foreach ($data as $key => $value) {

--- a/core-bundle/tests/Search/Indexer/DefaultIndexerTest.php
+++ b/core-bundle/tests/Search/Indexer/DefaultIndexerTest.php
@@ -79,7 +79,7 @@ class DefaultIndexerTest extends ContaoTestCase
         ];
 
         yield 'Test does not index if noSearch is set to true' => [
-            new Document(new Uri('https://example.com'), 200, [], '<html><body><script type="application/ld+json">{"@context":"https:\/\/schema.contao.org\/","@type":"RegularPage","noSearch":true,"protected":false,"groups":[],"fePreview":false}</script></body></html>'),
+            new Document(new Uri('https://example.com'), 200, [], '<html><body><script type="application/ld+json">{"@context":{"contao":"https:\/\/schema.contao.org\/"},"@type":"contao:RegularPage","contao:noSearch":true,"contao:protected":false,"contao:groups":[],"contao:fePreview":false}</script></body></html>'),
             null,
             'Was explicitly marked "noSearch" in page settings.',
         ];
@@ -90,23 +90,23 @@ class DefaultIndexerTest extends ContaoTestCase
             'No JSON-LD found.',
         ];
 
-        yield 'Test does not index if JSON-LD data is not of type "RegularPage"' => [
-            new Document(new Uri('https://example.com'), 200, [], '<html><body><script type="application/ld+json">{"@context":"https:\/\/schema.contao.org\/","@type":"FoobarType","noSearch":false,"protected":false,"groups":[],"fePreview":false}</script></body></html>'),
+        yield 'Test does not index if JSON-LD data is not of type "contao:RegularPage"' => [
+            new Document(new Uri('https://example.com'), 200, [], '<html><body><script type="application/ld+json">{"@context":{"contao":"https:\/\/schema.contao.org\/"},"@type":"contao:FoobarType","contao:noSearch":false,"contao:protected":false,"contao:groups":[],"contao:fePreview":false}</script></body></html>'),
             null,
             'No JSON-LD found.',
         ];
 
         yield 'Test does not index if protected is set to true' => [
-            new Document(new Uri('https://example.com'), 200, [], '<html><body><script type="application/ld+json">{"@context":"https:\/\/schema.contao.org\/","@type":"RegularPage","noSearch":false,"protected":true,"groups":[],"fePreview":false}</script></body></html>'),
+            new Document(new Uri('https://example.com'), 200, [], '<html><body><script type="application/ld+json">{"@context":{"contao":"https:\/\/schema.contao.org\/"},"@type":"contao:RegularPage","contao:noSearch":false,"contao:protected":true,"contao:groups":[],"contao:fePreview":false}</script></body></html>'),
             null,
             'Indexing protected pages is disabled.',
         ];
 
         yield 'Test valid index when not protected' => [
-            new Document(new Uri('https://example.com/valid'), 200, [], '<html><body><script type="application/ld+json">{"@context":"https:\/\/schema.contao.org\/","@type":"RegularPage","noSearch":false,"protected":false,"groups":[],"fePreview":false}</script></body></html>'),
+            new Document(new Uri('https://example.com/valid'), 200, [], '<html><body><script type="application/ld+json">{"@context":{"contao":"https:\/\/schema.contao.org\/"},"@type":"contao:RegularPage","contao:noSearch":false,"contao:protected":false,"contao:groups":[],"contao:fePreview":false}</script></body></html>'),
             [
                 'url' => 'https://example.com/valid',
-                'content' => '<html><body><script type="application/ld+json">{"@context":"https:\/\/schema.contao.org\/","@type":"RegularPage","noSearch":false,"protected":false,"groups":[],"fePreview":false}</script></body></html>',
+                'content' => '<html><body><script type="application/ld+json">{"@context":{"contao":"https:\/\/schema.contao.org\/"},"@type":"contao:RegularPage","contao:noSearch":false,"contao:protected":false,"contao:groups":[],"contao:fePreview":false}</script></body></html>',
                 'protected' => '',
                 'groups' => [],
                 'pid' => 2,
@@ -116,10 +116,10 @@ class DefaultIndexerTest extends ContaoTestCase
         ];
 
         yield 'Test valid index when protected and index protected is enabled' => [
-            new Document(new Uri('https://example.com/valid'), 200, [], '<html lang="de"><head><title>Foo title</title></head><body><script type="application/ld+json">{"@context":"https:\/\/schema.contao.org\/","@type":"RegularPage","noSearch":false,"protected":true,"groups":[42],"fePreview":false}</script></body></html>'),
+            new Document(new Uri('https://example.com/valid'), 200, [], '<html lang="de"><head><title>Foo title</title></head><body><script type="application/ld+json">{"@context":{"contao":"https:\/\/schema.contao.org\/"},"@type":"contao:RegularPage","contao:noSearch":false,"contao:protected":true,"contao:groups":[42],"contao:fePreview":false}</script></body></html>'),
             [
                 'url' => 'https://example.com/valid',
-                'content' => '<html lang="de"><head><title>Foo title</title></head><body><script type="application/ld+json">{"@context":"https:\/\/schema.contao.org\/","@type":"RegularPage","noSearch":false,"protected":true,"groups":[42],"fePreview":false}</script></body></html>',
+                'content' => '<html lang="de"><head><title>Foo title</title></head><body><script type="application/ld+json">{"@context":{"contao":"https:\/\/schema.contao.org\/"},"@type":"contao:RegularPage","contao:noSearch":false,"contao:protected":true,"contao:groups":[42],"contao:fePreview":false}</script></body></html>',
                 'protected' => '1',
                 'groups' => [42],
                 'pid' => 2,


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | -
| Docs PR or issue | -

After adding the context prefixes to the JSON-LD keys in #1457, we did not adjust the HTML markup in the `DefaultIndexerTest` class. Unfortunately, the unit tests now fail.