### PR TITLE
Remove the codecov token again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,25 +36,6 @@ jobs:
             - name: Upload the coverage report
               uses: codecov/codecov-action@v1
               with:
-                  # Yes, this is our upload token in plain text and yes, we should
-                  # set it as a secret instead. However, this is currently the
-                  # only way to allow coverage uploads from fork repository PRs:
-                  #
-                  # https://github.com/codecov/codecov-node/issues/118
-                  # https://github.community/t5/GitHub-Actions/Make-secrets-available-to-builds-of-forks/m-p/33885#M1696
-                  #
-                  # If you stumble across this, here is what you should do:
-                  #
-                  # * If the problems mentioned above have been solved and we did
-                  #   not notice, please give us a heads-up.
-                  #
-                  # * If you think about doing the same, make sure to be aware of
-                  #   the implications. This is a trial and error shot on our end
-                  #   and the odds are that the outcome is error.
-                  #
-                  # * If you have an idea how to solve this in a better way, please
-                  #   let us know.
-                  token: e129b38e-acf2-484c-97bc-1cde6b4a0693
                   file: ./clover.xml
                   fail_ci_if_error: true
 


### PR DESCRIPTION
This is finally happening. 🎉 

https://github.com/codecov/codecov-action/releases/tag/v1.0.6