### PR TITLE
Correctly handle URL suffix when redirecting page IDs

### DIFF
--- a/core-bundle/src/Resources/contao/controllers/FrontendIndex.php
+++ b/core-bundle/src/Resources/contao/controllers/FrontendIndex.php
@@ -183,7 +183,7 @@ class FrontendIndex extends \Frontend
 			$language = \Config::get('addLanguageToUrl') ? '[a-z]{2}(-[A-Z]{2})?/' : '';
 			$suffix = \Config::get('urlSuffix') ? preg_quote(\Config::get('urlSuffix'), '#') : '';
 
-			if (preg_match('#^' . $language . $objPage->id . '(' . $suffix . '$|/)#', \Environment::get('relativeRequest')))
+			if (preg_match('#^' . $language . $objPage->id . '(' . $suffix . '|/)#', \Environment::get('relativeRequest')))
 			{
 				throw new PageNotFoundException('Page not found: ' . \Environment::get('uri'));
 			}

--- a/core-bundle/src/Resources/contao/controllers/FrontendIndex.php
+++ b/core-bundle/src/Resources/contao/controllers/FrontendIndex.php
@@ -183,7 +183,7 @@ class FrontendIndex extends \Frontend
 			$language = \Config::get('addLanguageToUrl') ? '[a-z]{2}(-[A-Z]{2})?/' : '';
 			$suffix = \Config::get('urlSuffix') ? preg_quote(\Config::get('urlSuffix'), '#') : '';
 
-			if (preg_match('#^' . $language . $objPage->id . '(' . $suffix . '|/)#', \Environment::get('relativeRequest')))
+			if (preg_match('#^' . $language . $objPage->id . '(' . $suffix . '($|\?)|/)#', \Environment::get('relativeRequest')))
 			{
 				throw new PageNotFoundException('Page not found: ' . \Environment::get('uri'));
 			}

--- a/core-bundle/src/Resources/contao/controllers/FrontendIndex.php
+++ b/core-bundle/src/Resources/contao/controllers/FrontendIndex.php
@@ -181,9 +181,9 @@ class FrontendIndex extends \Frontend
 		if ($objPage->alias != '')
 		{
 			$language = \Config::get('addLanguageToUrl') ? '[a-z]{2}(-[A-Z]{2})?/' : '';
-			$suffix = \Config::get('urlSuffix') ? preg_quote(\Config::get('urlSuffix'), '#') : '$';
+			$suffix = \Config::get('urlSuffix') ? preg_quote(\Config::get('urlSuffix'), '#') : '';
 
-			if (preg_match('#^' . $language . $objPage->id . '(' . $suffix . '|/)#', \Environment::get('relativeRequest')))
+			if (preg_match('#^' . $language . $objPage->id . '(' . $suffix . '$|/)#', \Environment::get('relativeRequest')))
 			{
 				throw new PageNotFoundException('Page not found: ' . \Environment::get('uri'));
 			}

--- a/core-bundle/src/Resources/contao/controllers/FrontendIndex.php
+++ b/core-bundle/src/Resources/contao/controllers/FrontendIndex.php
@@ -181,7 +181,7 @@ class FrontendIndex extends \Frontend
 		if ($objPage->alias != '')
 		{
 			$language = \Config::get('addLanguageToUrl') ? '[a-z]{2}(-[A-Z]{2})?/' : '';
-			$suffix = \Config::get('urlSuffix') ? preg_quote(\Config::get('urlSuffix'), '#') : '';
+			$suffix = preg_quote(\Config::get('urlSuffix'), '#');
 
 			if (preg_match('#^' . $language . $objPage->id . '(' . $suffix . '($|\?)|/)#', \Environment::get('relativeRequest')))
 			{


### PR DESCRIPTION
I'm not entirely sure this patch is correct. Does `Environment::get('relativeRequest')` contain the query parameter, or does it not? Depending on that, the `$` should be added on line 186, but it sure should be removed on line 184 imho.