### PR TITLE
Support Symfony Expression Language in Simple Tokens

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/StringUtil.php
+++ b/core-bundle/src/Resources/contao/library/Contao/StringUtil.php
@@ -596,22 +596,27 @@ class StringUtil
 			}
 		}
 
-		$el = new ExpressionLanguage();
-		$el->register('constant', static function ()
-		{
-			return "throw new \\InvalidArgumentException('Cannot use the constant() function in the expression for security reasons.');";
-		}, static function ()
-		{
-			throw new \InvalidArgumentException('Cannot use the constant() function in the expression for security reasons.');
-		});
+		$expressionLanguage = null;
 
-		$evaluateExpression = static function ($strExpression) use ($arrData, $canUseExpressionLanguage, $el)
+		if ($canUseExpressionLanguage)
 		{
-			if ($canUseExpressionLanguage)
+			$expressionLanguage = new ExpressionLanguage();
+			$expressionLanguage->register('constant', static function ()
+			{
+				return "throw new \\InvalidArgumentException('Cannot use the constant() function in the expression for security reasons.');";
+			}, static function ()
+			{
+				throw new \InvalidArgumentException('Cannot use the constant() function in the expression for security reasons.');
+			});
+		}
+
+		$evaluateExpression = static function ($strExpression) use ($arrData, $expressionLanguage)
+		{
+			if (null !== $expressionLanguage)
 			{
 				try
 				{
-					return $el->evaluate($strExpression, $arrData);
+					return $expressionLanguage->evaluate($strExpression, $arrData);
 				}
 				catch (\Exception $e)
 				{

--- a/core-bundle/src/Resources/contao/library/Contao/StringUtil.php
+++ b/core-bundle/src/Resources/contao/library/Contao/StringUtil.php
@@ -615,7 +615,7 @@ class StringUtil
 				}
 				catch (\Exception $e)
 				{
-					throw new \InvalidArgumentException($e->getMessage());
+					throw new \InvalidArgumentException($e->getMessage(), 0, $e);
 				}
 			}
 

--- a/core-bundle/src/Resources/contao/library/Contao/StringUtil.php
+++ b/core-bundle/src/Resources/contao/library/Contao/StringUtil.php
@@ -590,8 +590,9 @@ class StringUtil
 		{
 			if (!preg_match('/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$/', $token))
 			{
+				@trigger_error('Using tokens that are not valid PHP variables has been deprecated and will no longer work in Contao 5.0. Falling back to legacy token parsing.', E_USER_DEPRECATED);
+
 				$canUseExpressionLanguage = false;
-				@trigger_error('Using tokens that are not valid PHP variables is deprecated. Falling back to legacy token parsing.', E_USER_DEPRECATED);
 				break;
 			}
 		}
@@ -601,13 +602,17 @@ class StringUtil
 		if ($canUseExpressionLanguage)
 		{
 			$expressionLanguage = new ExpressionLanguage();
-			$expressionLanguage->register('constant', static function ()
-			{
-				return "throw new \\InvalidArgumentException('Cannot use the constant() function in the expression for security reasons.');";
-			}, static function ()
-			{
-				throw new \InvalidArgumentException('Cannot use the constant() function in the expression for security reasons.');
-			});
+			$expressionLanguage->register(
+				'constant',
+				static function ()
+				{
+					return "throw new \\InvalidArgumentException('Cannot use the constant() function in the expression for security reasons.');";
+				},
+				static function ()
+				{
+					throw new \InvalidArgumentException('Cannot use the constant() function in the expression for security reasons.');
+				}
+			);
 		}
 
 		$evaluateExpression = static function ($strExpression) use ($arrData, $expressionLanguage)

--- a/core-bundle/src/Resources/contao/library/Contao/StringUtil.php
+++ b/core-bundle/src/Resources/contao/library/Contao/StringUtil.php
@@ -597,6 +597,13 @@ class StringUtil
 		}
 
 		$el = new ExpressionLanguage();
+		$el->register('constant', static function ()
+		{
+			return "throw new \\InvalidArgumentException('Cannot use the constant() function in the expression for security reasons.');";
+		}, static function ()
+		{
+			throw new \InvalidArgumentException('Cannot use the constant() function in the expression for security reasons.');
+		});
 
 		$evaluateExpression = static function ($strExpression) use ($arrData, $canUseExpressionLanguage, $el)
 		{

--- a/core-bundle/tests/Contao/StringUtilTest.php
+++ b/core-bundle/tests/Contao/StringUtilTest.php
@@ -218,6 +218,12 @@ class StringUtilTest extends TestCase
             '{if token=="foo"}',
         ];
 
+        yield 'Test escaping works correctly' => [
+            '{if value=="f\"oo"}match{endif}',
+            ['value' => 'f"oo'],
+            'match',
+        ];
+
         yield 'Test else (match)' => [
             'This is my {if value=="foo"}match{else}else-match{endif}',
             ['value' => 'foo'],

--- a/core-bundle/tests/Contao/StringUtilTest.php
+++ b/core-bundle/tests/Contao/StringUtilTest.php
@@ -507,6 +507,14 @@ class StringUtilTest extends TestCase
         );
     }
 
+    public function testConstantFunctionOfExpressionLanguageIsDisabled(): void
+    {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('Cannot use the constant() function in the expression for security reasons.');
+
+        StringUtil::parseSimpleTokens('{if constant("PHP_VERSION") > 7}match{else}no-match{endif}', []);
+    }
+
     /**
      * @dataProvider parseSimpleTokensInvalidComparison
      */

--- a/core-bundle/tests/Contao/StringUtilTest.php
+++ b/core-bundle/tests/Contao/StringUtilTest.php
@@ -318,7 +318,8 @@ class StringUtilTest extends TestCase
     /**
      * @group legacy
      * @dataProvider parseSimpleTokensLegacyProvider
-     * @expectedDeprecation Using tokens that are not valid PHP variables is deprecated. Falling back to legacy token parsing.
+     *
+     * @expectedDeprecation Using tokens that are not valid PHP variables has been deprecated %s.
      */
     public function testParsesSimpleTokensLegacy(string $string, array $tokens, string $expected): void
     {

--- a/core-bundle/tests/Contao/StringUtilTest.php
+++ b/core-bundle/tests/Contao/StringUtilTest.php
@@ -307,6 +307,12 @@ class StringUtilTest extends TestCase
             ['name' => 'myname mylastname', 'firstname' => 'myname'],
             'match',
         ];
+
+        yield 'Test ignores unknown tokens' => [
+            "This is my ##token## that ##remains##",
+            ['token' => 'value'],
+            'This is my value that ##remains##',
+        ];
     }
 
     /**

--- a/core-bundle/tests/Contao/StringUtilTest.php
+++ b/core-bundle/tests/Contao/StringUtilTest.php
@@ -309,7 +309,7 @@ class StringUtilTest extends TestCase
         ];
 
         yield 'Test ignores unknown tokens' => [
-            "This is my ##token## that ##remains##",
+            'This is my ##token## that ##remains##',
             ['token' => 'value'],
             'This is my value that ##remains##',
         ];

--- a/core-bundle/tests/Contao/StringUtilTest.php
+++ b/core-bundle/tests/Contao/StringUtilTest.php
@@ -68,30 +68,6 @@ class StringUtilTest extends TestCase
             'This is my test@foobar.com,foo@test.com',
         ];
 
-        yield 'Test token replacement with special characters (-)' => [
-            'This is my ##e-mail##',
-            ['e-mail' => 'test@foobar.com'],
-            'This is my test@foobar.com',
-        ];
-
-        yield 'Test token replacement with special characters (&)' => [
-            'This is my ##e&mail##',
-            ['e&mail' => 'test@foobar.com'],
-            'This is my test@foobar.com',
-        ];
-
-        yield 'Test token replacement with special characters (#)' => [
-            'This is my ##e#mail##',
-            ['e#mail' => 'test@foobar.com'],
-            'This is my test@foobar.com',
-        ];
-
-        yield 'Test token replacement with token delimiter (##)' => [
-            'This is my ##e##mail##',
-            ['e##mail' => 'test@foobar.com'],
-            'This is my ##e##mail##',
-        ];
-
         yield 'Test comparisons (==) with regular characters (match)' => [
             'This is my {if email==""}match{endif}',
             ['email' => ''],
@@ -164,18 +140,6 @@ class StringUtilTest extends TestCase
             'This is my ',
         ];
 
-        yield 'Test comparisons (<) with special characters (match)' => [
-            'This is my {if val&#ue<0}match{endif}',
-            ['val&#ue' => -5],
-            'This is my match',
-        ];
-
-        yield 'Test comparisons (<) with special characters (no match)' => [
-            'This is my {if val&#ue<0}match{endif}',
-            ['val&#ue' => 9],
-            'This is my ',
-        ];
-
         yield 'Test comparisons (===) with regular characters (match)' => [
             'This is my {if value===5}match{endif}',
             ['value' => 5],
@@ -198,12 +162,6 @@ class StringUtilTest extends TestCase
             'This is my {if value!==5.0}match{endif}',
             ['value' => 5.0],
             'This is my ',
-        ];
-
-        yield 'Test whitespace in tokens not allowed and ignored' => [
-            'This is my ##dumb token## you know',
-            ['dumb token' => 'foobar'],
-            'This is my ##dumb token## you know',
         ];
 
         yield 'Test if-tags insertion not evaluated' => [
@@ -342,6 +300,67 @@ class StringUtilTest extends TestCase
             '{if value == "irrelevant" && value matches "/whatever/"}match{else}no-match{endif}',
             ['value' => 'irrelevant'],
             'no-match',
+        ];
+
+        yield 'Test tokens in tokens are handled correctly' => [
+            '{if firstname == "myname"}match{else}no-match{endif}',
+            ['name' => 'myname mylastname', 'firstname' => 'myname'],
+            'match',
+        ];
+    }
+
+    /**
+     * @group legacy
+     * @dataProvider parseSimpleTokensLegacyProvider
+     * @expectedDeprecation Using tokens that are not valid PHP variables is deprecated. Falling back to legacy token parsing.
+     */
+    public function testParsesSimpleTokensLegacy(string $string, array $tokens, string $expected): void
+    {
+        $this->assertSame($expected, StringUtil::parseSimpleTokens($string, $tokens));
+    }
+
+    public function parseSimpleTokensLegacyProvider(): \Generator
+    {
+        yield 'Test token replacement with token delimiter (##)' => [
+            'This is my ##e##mail##',
+            ['e##mail' => 'test@foobar.com'],
+            'This is my ##e##mail##',
+        ];
+
+        yield 'Test whitespace in tokens not allowed and ignored' => [
+            'This is my ##dumb token## you know',
+            ['dumb token' => 'foobar'],
+            'This is my ##dumb token## you know',
+        ];
+
+        yield 'Test token replacement with special characters (-)' => [
+            'This is my ##e-mail##',
+            ['e-mail' => 'test@foobar.com'],
+            'This is my test@foobar.com',
+        ];
+
+        yield 'Test token replacement with special characters (&)' => [
+            'This is my ##e&mail##',
+            ['e&mail' => 'test@foobar.com'],
+            'This is my test@foobar.com',
+        ];
+
+        yield 'Test token replacement with special characters (#)' => [
+            'This is my ##e#mail##',
+            ['e#mail' => 'test@foobar.com'],
+            'This is my test@foobar.com',
+        ];
+
+        yield 'Test comparisons (<) with special characters (match)' => [
+            'This is my {if val&#ue<0}match{endif}',
+            ['val&#ue' => -5],
+            'This is my match',
+        ];
+
+        yield 'Test comparisons (<) with special characters (no match)' => [
+            'This is my {if val&#ue<0}match{endif}',
+            ['val&#ue' => 9],
+            'This is my ',
         ];
     }
 

--- a/core-bundle/tests/Contao/StringUtilTest.php
+++ b/core-bundle/tests/Contao/StringUtilTest.php
@@ -218,12 +218,6 @@ class StringUtilTest extends TestCase
             '{if token=="foo"}',
         ];
 
-        yield 'Test nested if-tag with " in value (match)' => [
-            '{if value=="f"oo"}1{endif}{if value=="f\"oo"}2{endif}',
-            ['value' => 'f"oo'],
-            '12',
-        ];
-
         yield 'Test else (match)' => [
             'This is my {if value=="foo"}match{else}else-match{endif}',
             ['value' => 'foo'],
@@ -308,16 +302,40 @@ class StringUtilTest extends TestCase
             'This is my match',
         ];
 
-        yield 'Test does not support tabs in expressions' => [
-            "This is my {if number\t>\t5}match{endif}",
-            ['number' => 6],
-            'This is my ',
+        yield 'Test if value in array' => [
+            '{if value in ["foobar", "test", "other-value"]}match{else}no-match{endif}',
+            ['value' => 'foobar'],
+            'match',
         ];
 
-        yield 'Test does not support line breaks in expressions' => [
-            "This is my {if number\n>\n5}match{endif}",
-            ['number' => 6],
-            'This is my ',
+        yield 'Test if value not in array' => [
+            '{if value not in ["foobar", "test", "other-value"]}match{else}no-match{endif}',
+            ['value' => 'whatever'],
+            'match',
+        ];
+
+        yield 'Test OR operator (match)' => [
+            '{if value == "whatever" || value == "foobar"}match{else}no-match{endif}',
+            ['value' => 'whatever'],
+            'match',
+        ];
+
+        yield 'Test OR operator (no-match)' => [
+            '{if value == "whatever" || value == "foobar"}match{else}no-match{endif}',
+            ['value' => 'irrelevant'],
+            'no-match',
+        ];
+
+        yield 'Test AND operator (match)' => [
+            '{if value == "whatever" && value matches "/whatever/"}match{else}no-match{endif}',
+            ['value' => 'whatever'],
+            'match',
+        ];
+
+        yield 'Test AND operator (no-match)' => [
+            '{if value == "irrelevant" && value matches "/whatever/"}match{else}no-match{endif}',
+            ['value' => 'irrelevant'],
+            'no-match',
         ];
     }
 


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | none
| Docs PR or issue | TODO

I've replaced our own parser for our "Simple Tokens" with the Symfony Expression Language which unlocks a whole new range of functions you can use within Simple Tokens. E.g.

* Array functionality (just use `{if value in ["foo", "bar"]}` instead of 400 if comparisons)
* Object functionality (you can pass objects as values and operate on them)
* You can now expand on the condition and use AND and OR (e.g.  `{if value == "foo" || value == "bar"}`
* You can use regular expressions using `matches`

There's more! See https://symfony.com/doc/current/components/expression_language/syntax.html
