### PR TITLE
Fix a "toggle element" permission check

### DIFF
--- a/core-bundle/src/Resources/contao/dca/tl_content.php
+++ b/core-bundle/src/Resources/contao/dca/tl_content.php
@@ -2031,7 +2031,7 @@ class tl_content extends Contao\Backend
 			{
 				$dc->activeRecord = $objRow;
 
-				if (!$this->User->hasAccess($objRow->type, 'fields'))
+				if (!$this->User->hasAccess($objRow->type, 'elements'))
 				{
 					throw new Contao\CoreBundle\Exception\AccessDeniedException('Not enough permissions to modify content elements of type "' . $objRow->type . '".');
 				}


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #1499 

Fix the permission check for toggle content elements.
I guess this was copy & paste from `tl_form_field`
