### PR TITLE
Remove string type hint as there can be an array value

### DIFF
--- a/core-bundle/src/EventListener/CsrfTokenCookieSubscriber.php
+++ b/core-bundle/src/EventListener/CsrfTokenCookieSubscriber.php
@@ -173,7 +173,7 @@ class CsrfTokenCookieSubscriber implements EventSubscriberInterface
         return $tokens;
     }
 
-    private function isCsrfCookie($key, string $value): bool
+    private function isCsrfCookie($key, $value): bool
     {
         if (!\is_string($key)) {
             return false;


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | n/a
| Docs PR or issue | n/a

Recently this error showed up (via sentry.io) multiple times in a Contao 4.9.1 setup:
```
TypeError
Argument 2 passed to Contao\CoreBundle\EventListener\CsrfTokenCookieSubscriber::isCsrfCookie() must be of the type string, array given, called in /vendor/contao/core-bundle/src/EventListener/CsrfTokenCookieSubscriber.php on line 168
```

I'm afraid I don't have a case to reproduce this behaviour on my local machine.

But the method itself checks if it is a `string` or not:
https://github.com/contao/contao/blob/3f24a7950265cbb925004b004437eb0fe762b404/core-bundle/src/EventListener/CsrfTokenCookieSubscriber.php#L178-L180

Looks like we can remove the type hint of the second argument.
