### PR TITLE
Add a Twig helper for rendering figures

### DIFF
--- a/core-bundle/src/Image/Studio/FigureBuilder.php
+++ b/core-bundle/src/Image/Studio/FigureBuilder.php
@@ -76,7 +76,7 @@ class FigureBuilder
      *
      * @phpcsSuppress SlevomatCodingStandard.Classes.UnusedPrivateElements
      *
-     * @var mixed|null
+     * @var int|string|array|PictureConfiguration|null
      */
     private $sizeConfiguration;
 

--- a/core-bundle/src/Image/Studio/FigureBuilder.php
+++ b/core-bundle/src/Image/Studio/FigureBuilder.php
@@ -271,7 +271,7 @@ class FigureBuilder
     /**
      * Sets a size configuration that will be applied to the resource.
      *
-     * @param int|string|array|PictureConfiguration $size A picture size configuration or reference
+     * @param int|string|array|PictureConfiguration|null $size A picture size configuration or reference
      */
     public function setSize($size): self
     {

--- a/core-bundle/src/Resources/config/services.yml
+++ b/core-bundle/src/Resources/config/services.yml
@@ -817,6 +817,18 @@ services:
         tags:
             - { name: kernel.reset, method: reset }
 
+    contao.twig.image_extension:
+        class: Contao\CoreBundle\Twig\Extension\ImageExtension
+
+    contao.twig.runtime.figure_renderer:
+        class: Contao\CoreBundle\Twig\Runtime\FigureRendererRuntime
+        arguments:
+            - '@Contao\CoreBundle\Image\Studio\Studio'
+            - '@twig'
+
+    contao.twig.runtime.picture_configuration:
+        class: Contao\CoreBundle\Twig\Runtime\PictureConfigurationRuntime
+
     contao.twig.template_extension:
         class: Contao\CoreBundle\Twig\Extension\ContaoTemplateExtension
         arguments:

--- a/core-bundle/src/Resources/config/services.yml
+++ b/core-bundle/src/Resources/config/services.yml
@@ -817,17 +817,14 @@ services:
         tags:
             - { name: kernel.reset, method: reset }
 
-    contao.twig.image_extension:
-        class: Contao\CoreBundle\Twig\Extension\ImageExtension
+    Contao\CoreBundle\Twig\Extension\ImageExtension: ~
 
-    contao.twig.runtime.figure_renderer:
-        class: Contao\CoreBundle\Twig\Runtime\FigureRendererRuntime
+    Contao\CoreBundle\Twig\Runtime\FigureRendererRuntime:
         arguments:
             - '@Contao\CoreBundle\Image\Studio\Studio'
             - '@twig'
 
-    contao.twig.runtime.picture_configuration:
-        class: Contao\CoreBundle\Twig\Runtime\PictureConfigurationRuntime
+    Contao\CoreBundle\Twig\Runtime\PictureConfigurationRuntime: ~
 
     contao.twig.template_extension:
         class: Contao\CoreBundle\Twig\Extension\ContaoTemplateExtension

--- a/core-bundle/src/Resources/views/Image/Studio/_macros.html.twig
+++ b/core-bundle/src/Resources/views/Image/Studio/_macros.html.twig
@@ -44,10 +44,15 @@
 
     If a link is defined the picture will be wrapped in an `<a>` tag.
 #}
-{% macro figure(figure, options = {}) %}
-    {% set figure_attributes = figure.options.attr|default({})|merge(options.attr|default({})) %}
-    {% set link_attributes = figure.options.link_attr|default({})|merge(options.link_attr|default({})) ~%}
-    <figure{{ _self.html_attributes(figure_attributes) }}>
+{%- macro figure(figure, options = {}) -%}
+    {%- set figure_attributes = figure.options.attr|default({})|merge(options.attr|default({})) %}
+    {%- set link_attributes = figure.options.link_attr|default({})|merge(options.link_attr|default({})) ~%}
+
+    {%- set base_attributes = {
+        'itemscope': '',
+        'itemtype': 'http://schema.org/ImageObject'
+    } %}
+    <figure{{ _self.html_attributes(base_attributes|merge(figure_attributes)) }}>
         {% if figure.linkHref -%}
             {%- set base_attributes = {
                 'href': figure.linkHref,
@@ -62,7 +67,7 @@
 
         {{ _self.caption(figure, options) }}
     </figure>
-{% endmacro %}
+{%- endmacro -%}
 
 {#
     Build a `<picture>` from `Studio\Figure` data.
@@ -127,7 +132,11 @@
     {% apply spaceless %}
         {% if figure.hasMetaData and figure.metaData.caption %}
             {% set caption_attributes = figure.options.caption_attr|default({})|merge(options.caption_attr|default({})) %}
-            <figcaption{{ _self.html_attributes(caption_attributes) }}>
+
+            {% set base_attributes = {
+                'itemprop': 'caption'
+            } %}
+            <figcaption{{ _self.html_attributes(base_attributes|merge(caption_attributes)) }}>
                 {{- figure.metaData.caption -}}
             </figcaption>
         {% endif %}
@@ -146,6 +155,6 @@
 #}
 {%- macro html_attributes(attributes) -%}
     {%- for attr, value in attributes|filter(v => v is not null) -%}
-        {{ ' ' ~ attr }}="{{ value }}"
+        {{ ' ' ~ attr }}{% if value %}="{{ value }}"{% endif %}
     {%- endfor -%}
 {%- endmacro -%}

--- a/core-bundle/src/Resources/views/Image/Studio/_macros.html.twig
+++ b/core-bundle/src/Resources/views/Image/Studio/_macros.html.twig
@@ -1,0 +1,151 @@
+{#
+    Studio Macros
+    -------------
+    This collection of twig macros is intended to help you render figure/image
+    markup directly from a Studio\Figure. You can use these macros as building
+    blocks for your own figure template or render the whole thing and pass some
+    options.
+
+
+    Options
+    -------
+    By setting options, the default output can be altered: There are two places
+    where this can be done:
+      1) by constructing Studio\Figure with `$options`
+      2) by passing the `options` argument to the macros
+
+     If the same keys are defined in both 1) and 2) the template options
+     will have precedence.
+
+     Currently, options allow you to extend/overwrite HTML attributes for all
+     tags that are output. Attributes defined under the `attr` key will be
+     placed inside the <figure> tag while those defined under the `%tag%_attr`
+     key will end up inside the `<%tag%>` tag.
+
+     Example:
+        {{ _self.figure(figure, {
+         attr: { data-foo: 'a' },
+         figcaption_attr: { class: 'bar' }
+        } }}
+
+        :  <figure data-foo="a">
+        :    ...
+        :    <figcaption class="bar">
+        :      ...
+        :    </figcaption>
+        :  </figure>
+
+#}
+
+
+{#
+    Build a `<figure>` including a picture and - if available - a caption from
+    `Studio\Figure` data.
+
+    If a link is defined the picture will be wrapped in an `<a>` tag.
+#}
+{% macro figure(figure, options = {}) %}
+    {% set figure_attributes = figure.options.attr|default({})|merge(options.attr|default({})) %}
+    {% set link_attributes = figure.options.link_attr|default({})|merge(options.link_attr|default({})) ~%}
+    <figure{{ _self.html_attributes(figure_attributes) }}>
+        {% if figure.linkHref -%}
+            {%- set base_attributes = {
+                'href': figure.linkHref,
+                'title': figure.hasLightBox and figure.hasMetaData ? figure.metaData.title : null,
+            }|merge(figure.linkAttributes) -%}
+            <a{{ _self.html_attributes(base_attributes|merge(link_attributes)) }}>
+               {{~ _self.picture(figure, options) }}
+            </a>
+        {%- else %}
+            {{- _self.picture(figure, options) -}}
+        {% endif %}
+
+        {{ _self.caption(figure, options) }}
+    </figure>
+{% endmacro %}
+
+{#
+    Build a `<picture>` from `Studio\Figure` data.
+    This falls back to only creating a single `<img>` if no sources are present.
+#}
+{% macro picture(figure, options = {}) %}
+    {%- set picture_attributes = figure.options.picture_attr|default({})|merge(options.picture_attr|default({})) %}
+    {%- set source_attributes = figure.options.source_attr|default({})|merge(options.source_attr|default({})) %}
+
+    {%- if figure.image.sources %}
+        <picture{{ _self.html_attributes(picture_attributes) }}>
+            {% for source in figure.image.sources %}
+                {%- set base_attributes = {
+                    'srcset': source.srcset,
+                    'sizes': source.sizes|default(null),
+                    'media': source.media|default(null),
+                    'type': source.type|default(null),
+                } -%}
+                <source{{ _self.html_attributes(base_attributes|merge(source_attributes)) }}>
+            {%- endfor %}
+
+            {{ _self.img(figure, options) }}
+        </picture>
+    {%- else %}
+        {{ _self.img(figure, options) }}
+    {%- endif %}
+{% endmacro %}
+
+
+{#
+    Build an `<img>` from `Studio\Figure` data.
+#}
+{%- macro img(figure, options = {}) -%}
+    {% apply spaceless %}
+        {% set img_attributes = figure.options.img_attr|default({})|merge(options.img_attr|default({})) %}
+
+        {% set img = figure.image.img %}
+        {% set defineProportions = img.hasSingleAspectRatio|default(false) and img.width|default(false) and img.height|default(false) %}
+
+        {% set base_attributes = {
+            'src': img.src,
+            'alt': figure.hasMetaData ? figure.metaData.alt : '',
+            'title': figure.hasMetaData ? figure.metaData.title : null,
+            'srcset': img.srcset is defined and img.srcset != img.src ? img.srcset : null,
+            'sizes': img.sizes|default(null),
+            'width': defineProportions ? img.width : null,
+            'height': defineProportions ? img.height : null,
+            'loading': img.loading|default(null),
+            'class': img.class|default(null),
+            'itemprop': 'image',
+        } %}
+        <img{{ _self.html_attributes(base_attributes|merge(img_attributes)) }}>
+    {% endapply %}
+{%- endmacro -%}
+
+
+{#
+    Build a `<figcaption>` from `Studio\Figure` data.
+    If no meta data is present, nothing will be output.
+#}
+{%- macro caption(figure, options = {}) -%}
+    {% apply spaceless %}
+        {% if figure.hasMetaData and figure.metaData.caption %}
+            {% set caption_attributes = figure.options.caption_attr|default({})|merge(options.caption_attr|default({})) %}
+            <figcaption{{ _self.html_attributes(caption_attributes) }}>
+                {{- figure.metaData.caption -}}
+            </figcaption>
+        {% endif %}
+    {% endapply %}
+{%- endmacro -%}
+
+
+{#
+    Helper: Expand an associative mapping into HTML attributes.
+
+     - Values that are null won't be included.
+     - The output will contain a leading space.
+
+    Example:
+        { 'foo': 'a', 'bar': 'b, 'foobar': null } --> ' foo="a" bar="b"'
+#}
+{%- macro html_attributes(attributes) -%}
+    {%- for attr, value in attributes|filter(v => v is not null) -%}
+        {{ ' ' ~ attr }}="{{ value }}"
+    {%- endfor -%}
+{%- endmacro -%}

--- a/core-bundle/src/Resources/views/Image/Studio/_macros.html.twig
+++ b/core-bundle/src/Resources/views/Image/Studio/_macros.html.twig
@@ -1,20 +1,21 @@
 {#
     Studio Macros
     -------------
-    This collection of twig macros is intended to help you render figure/image
+    This collection of Twig macros is intended to help you render figure/image
     markup directly from a Studio\Figure. You can use these macros as building
-    blocks for your own figure template or render the whole thing and pass some
-    options.
+    blocks for your own figure template or to render the whole thing and pass
+    some options.
 
 
     Options
     -------
-    By setting options, the default output can be altered: There are two places
+    By setting options, the default output can be altered. There are two places
     where this can be done:
-      1) by constructing Studio\Figure with `$options`
-      2) by passing the `options` argument to the macros
 
-     If the same keys are defined in both 1) and 2) the template options
+      1) By constructing a Studio\Figure object with `$options`
+      2) By passing the `$options` argument to the macros
+
+     If the same keys are defined in both 1) and 2), the template options
      will have precedence.
 
      Currently, options allow you to extend/overwrite HTML attributes for all
@@ -23,9 +24,10 @@
      key will end up inside the `<%tag%>` tag.
 
      Example:
+
         {{ _self.figure(figure, {
-         attr: { data-foo: 'a' },
-         figcaption_attr: { class: 'bar' }
+            attr: { data-foo: 'a' },
+            figcaption_attr: { class: 'bar' }
         } }}
 
         :  <figure data-foo="a">
@@ -34,7 +36,6 @@
         :      ...
         :    </figcaption>
         :  </figure>
-
 #}
 
 
@@ -71,6 +72,7 @@
 
 {#
     Build a `<picture>` from `Studio\Figure` data.
+
     This falls back to only creating a single `<img>` if no sources are present.
 #}
 {% macro picture(figure, options = {}) %}
@@ -95,7 +97,6 @@
         {{ _self.img(figure, options) }}
     {%- endif %}
 {% endmacro %}
-
 
 {#
     Build an `<img>` from `Studio\Figure` data.
@@ -123,19 +124,16 @@
     {% endapply %}
 {%- endmacro -%}
 
-
 {#
     Build a `<figcaption>` from `Studio\Figure` data.
+
     If no meta data is present, nothing will be output.
 #}
 {%- macro caption(figure, options = {}) -%}
     {% apply spaceless %}
         {% if figure.hasMetaData and figure.metaData.caption %}
             {% set caption_attributes = figure.options.caption_attr|default({})|merge(options.caption_attr|default({})) %}
-
-            {% set base_attributes = {
-                'itemprop': 'caption'
-            } %}
+            {% set base_attributes = { 'itemprop': 'caption' } %}
             <figcaption{{ _self.html_attributes(base_attributes|merge(caption_attributes)) }}>
                 {{- figure.metaData.caption -}}
             </figcaption>
@@ -143,14 +141,14 @@
     {% endapply %}
 {%- endmacro -%}
 
-
 {#
     Helper: Expand an associative mapping into HTML attributes.
 
-     - Values that are null won't be included.
-     - The output will contain a leading space.
+     - Values that are null won't be included
+     - The output will contain a leading space
 
     Example:
+
         { 'foo': 'a', 'bar': 'b, 'foobar': null } --> ' foo="a" bar="b"'
 #}
 {%- macro html_attributes(attributes) -%}

--- a/core-bundle/src/Resources/views/Image/Studio/_macros.html.twig
+++ b/core-bundle/src/Resources/views/Image/Studio/_macros.html.twig
@@ -12,16 +12,16 @@
     By setting options, the default output can be altered. There are two places
     where this can be done:
 
-      1) By constructing a Studio\Figure object with `$options`
-      2) By passing the `$options` argument to the macros
+      1) By constructing a Studio\Figure object with $options
+      2) By passing the $options argument to the macros
 
      If the same keys are defined in both 1) and 2), the template options
      will have precedence.
 
      Currently, options allow you to extend/overwrite HTML attributes for all
-     tags that are output. Attributes defined under the `attr` key will be
-     placed inside the <figure> tag while those defined under the `%tag%_attr`
-     key will end up inside the `<%tag%>` tag.
+     tags that are output. Attributes defined under the 'attr' key will be
+     placed inside the <figure> tag while those defined under the '%tag%_attr'
+     key will end up inside the <%tag%> tag.
 
      Example:
 
@@ -40,10 +40,10 @@
 
 
 {#
-    Build a `<figure>` including a picture and - if available - a caption from
-    `Studio\Figure` data.
+    Build a <figure> including a picture and - if available - a caption from
+    Studio\Figure data.
 
-    If a link is defined the picture will be wrapped in an `<a>` tag.
+    If a link is defined the picture will be wrapped in an <a> tag.
 #}
 {%- macro figure(figure, options = {}) -%}
     {%- set figure_attributes = figure.options.attr|default({})|merge(options.attr|default({})) %}
@@ -71,9 +71,9 @@
 {%- endmacro -%}
 
 {#
-    Build a `<picture>` from `Studio\Figure` data.
+    Build a <picture> from Studio\Figure data.
 
-    This falls back to only creating a single `<img>` if no sources are present.
+    This falls back to only creating a single <img> if no sources are present.
 #}
 {% macro picture(figure, options = {}) %}
     {%- set picture_attributes = figure.options.picture_attr|default({})|merge(options.picture_attr|default({})) %}
@@ -99,7 +99,7 @@
 {% endmacro %}
 
 {#
-    Build an `<img>` from `Studio\Figure` data.
+    Build an <img> from Studio\Figure data.
 #}
 {%- macro img(figure, options = {}) -%}
     {% apply spaceless %}
@@ -125,7 +125,7 @@
 {%- endmacro -%}
 
 {#
-    Build a `<figcaption>` from `Studio\Figure` data.
+    Build a <figcaption> from Studio\Figure data.
 
     If no meta data is present, nothing will be output.
 #}

--- a/core-bundle/src/Resources/views/Image/Studio/figure.html.twig
+++ b/core-bundle/src/Resources/views/Image/Studio/figure.html.twig
@@ -1,0 +1,3 @@
+{% import "@ContaoCore/Image/Studio/_macros.html.twig" as studio %}
+
+{{ studio.figure(figure) }}

--- a/core-bundle/src/Resources/views/Image/Studio/figure.html.twig
+++ b/core-bundle/src/Resources/views/Image/Studio/figure.html.twig
@@ -1,3 +1,3 @@
 {% import "@ContaoCore/Image/Studio/_macros.html.twig" as studio %}
 
-{{ studio.figure(figure) }}
+{{- studio.figure(figure) -}}

--- a/core-bundle/src/Twig/Extension/ImageExtension.php
+++ b/core-bundle/src/Twig/Extension/ImageExtension.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Twig\Extension;
+
+use Contao\CoreBundle\Twig\Runtime\FigureRendererRuntime;
+use Contao\CoreBundle\Twig\Runtime\PictureConfigurationRuntime;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+class ImageExtension extends AbstractExtension
+{
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction(
+                'contao_figure',
+                [FigureRendererRuntime::class, 'render'],
+                ['is_safe' => ['html']]
+            ),
+            new TwigFunction(
+                'picture_configuration',
+                [PictureConfigurationRuntime::class, 'fromArray']
+            ),
+        ];
+    }
+}

--- a/core-bundle/src/Twig/Extension/ImageExtension.php
+++ b/core-bundle/src/Twig/Extension/ImageExtension.php
@@ -28,7 +28,7 @@ class ImageExtension extends AbstractExtension
                 ['is_safe' => ['html']]
             ),
             new TwigFunction(
-                'picture_configuration',
+                'picture_config',
                 [PictureConfigurationRuntime::class, 'fromArray']
             ),
         ];

--- a/core-bundle/src/Twig/Runtime/FigureRendererRuntime.php
+++ b/core-bundle/src/Twig/Runtime/FigureRendererRuntime.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Twig\Runtime;
+
+use Contao\CoreBundle\Image\Studio\Figure;
+use Contao\CoreBundle\Image\Studio\Studio;
+use Symfony\Component\PropertyAccess\PropertyAccess;
+use Twig\Environment;
+use Twig\Extension\RuntimeExtensionInterface;
+
+final class FigureRendererRuntime implements RuntimeExtensionInterface
+{
+    /**
+     * @var Studio
+     */
+    private $studio;
+
+    /**
+     * @var Environment
+     */
+    private $twig;
+
+    /**
+     * @internal
+     */
+    public function __construct(Studio $studio, Environment $twig)
+    {
+        $this->studio = $studio;
+        $this->twig = $twig;
+    }
+
+    /**
+     * Render a figure. The provided options are used to configure a
+     * FigureBuilder. By default.
+     */
+    public function render($from, array $options = [], $template = '@ContaoCore/Image/Studio/figure.html.twig'): string
+    {
+        $options['from'] = $from;
+
+        $figure = $this->buildFigure($options);
+
+        return $this->twig->render($template, ['figure' => $figure]);
+    }
+
+    private function buildFigure(array $options): Figure
+    {
+        $figureBuilder = $this->studio->createFigureBuilder();
+        $propertyAccessor = PropertyAccess::createPropertyAccessor();
+
+        foreach ($options as $property => $value) {
+            $propertyAccessor->setValue($figureBuilder, $property, $value);
+        }
+
+        return $figureBuilder->build();
+    }
+}

--- a/core-bundle/src/Twig/Runtime/FigureRendererRuntime.php
+++ b/core-bundle/src/Twig/Runtime/FigureRendererRuntime.php
@@ -15,6 +15,7 @@ namespace Contao\CoreBundle\Twig\Runtime;
 use Contao\CoreBundle\Image\Studio\Figure;
 use Contao\CoreBundle\Image\Studio\Studio;
 use Symfony\Component\PropertyAccess\PropertyAccess;
+use Symfony\Component\PropertyAccess\PropertyAccessor;
 use Twig\Environment;
 use Twig\Extension\RuntimeExtensionInterface;
 
@@ -31,12 +32,19 @@ final class FigureRendererRuntime implements RuntimeExtensionInterface
     private $twig;
 
     /**
+     * @var PropertyAccessor
+     */
+    private $propertyAccessor;
+
+    /**
      * @internal
      */
     public function __construct(Studio $studio, Environment $twig)
     {
         $this->studio = $studio;
         $this->twig = $twig;
+
+        $this->propertyAccessor = PropertyAccess::createPropertyAccessor();
     }
 
     /**
@@ -56,10 +64,9 @@ final class FigureRendererRuntime implements RuntimeExtensionInterface
     private function buildFigure(array $options): Figure
     {
         $figureBuilder = $this->studio->createFigureBuilder();
-        $propertyAccessor = PropertyAccess::createPropertyAccessor();
 
         foreach ($options as $property => $value) {
-            $propertyAccessor->setValue($figureBuilder, $property, $value);
+            $this->propertyAccessor->setValue($figureBuilder, $property, $value);
         }
 
         return $figureBuilder->build();

--- a/core-bundle/src/Twig/Runtime/FigureRendererRuntime.php
+++ b/core-bundle/src/Twig/Runtime/FigureRendererRuntime.php
@@ -52,9 +52,11 @@ final class FigureRendererRuntime implements RuntimeExtensionInterface
     }
 
     /**
-     * Render a figure. The provided configuration array is used to configure
-     * a FigureBuilder. If not explicitly set the default figure template will
-     * be used to render the results.
+     * Renders a figure.
+     *
+     * The provided configuration array is used to configure a FigureBuilder
+     * object. If not explicitly set, the default figure template will be used
+     * to render the results.
      *
      * @param int|string|FilesModel|ImageInterface  $from          Can be a FilesModel, an ImageInterface, a tl_files UUID/ID/path or a file system path
      * @param int|string|array|PictureConfiguration $size          A picture size configuration or reference

--- a/core-bundle/src/Twig/Runtime/FigureRendererRuntime.php
+++ b/core-bundle/src/Twig/Runtime/FigureRendererRuntime.php
@@ -40,14 +40,15 @@ final class FigureRendererRuntime implements RuntimeExtensionInterface
     }
 
     /**
-     * Render a figure. The provided options are used to configure a
-     * FigureBuilder. By default.
+     * Render a figure. The provided configuration array is used to configure
+     * a FigureBuilder. If not explicitly set the default figure template will
+     * be used to render the results.
      */
-    public function render($from, array $options = [], $template = '@ContaoCore/Image/Studio/figure.html.twig'): string
+    public function render($from, array $configuration = [], $template = '@ContaoCore/Image/Studio/figure.html.twig'): string
     {
-        $options['from'] = $from;
+        $configuration['from'] = $from;
 
-        $figure = $this->buildFigure($options);
+        $figure = $this->buildFigure($configuration);
 
         return $this->twig->render($template, ['figure' => $figure]);
     }

--- a/core-bundle/src/Twig/Runtime/FigureRendererRuntime.php
+++ b/core-bundle/src/Twig/Runtime/FigureRendererRuntime.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Twig\Runtime;
 
+use Contao\CoreBundle\File\MetaData;
 use Contao\CoreBundle\Image\Studio\Figure;
 use Contao\CoreBundle\Image\Studio\Studio;
 use Symfony\Component\PropertyAccess\PropertyAccess;
@@ -55,6 +56,13 @@ final class FigureRendererRuntime implements RuntimeExtensionInterface
     public function render($from, array $configuration = [], $template = '@ContaoCore/Image/Studio/figure.html.twig'): string
     {
         $configuration['from'] = $from;
+
+        // Allow overwriting meta data on the fly
+        foreach (['metaData', 'setMetaData'] as $key) {
+            if (\is_array($configuration[$key] ?? null)) {
+                $configuration[$key] = new MetaData($configuration[$key]);
+            }
+        }
 
         $figure = $this->buildFigure($configuration);
 

--- a/core-bundle/src/Twig/Runtime/FigureRendererRuntime.php
+++ b/core-bundle/src/Twig/Runtime/FigureRendererRuntime.php
@@ -58,9 +58,9 @@ final class FigureRendererRuntime implements RuntimeExtensionInterface
      * object. If not explicitly set, the default figure template will be used
      * to render the results.
      *
-     * @param int|string|FilesModel|ImageInterface  $from          Can be a FilesModel, an ImageInterface, a tl_files UUID/ID/path or a file system path
-     * @param int|string|array|PictureConfiguration $size          A picture size configuration or reference
-     * @param array<string, mixed>                  $configuration Configuration for the FigureBuilder
+     * @param int|string|FilesModel|ImageInterface       $from          Can be a FilesModel, an ImageInterface, a tl_files UUID/ID/path or a file system path
+     * @param int|string|array|PictureConfiguration|null $size          A picture size configuration or reference
+     * @param array<string, mixed>                       $configuration Configuration for the FigureBuilder
      */
     public function render($from, $size, array $configuration = [], string $template = '@ContaoCore/Image/Studio/figure.html.twig'): string
     {

--- a/core-bundle/src/Twig/Runtime/FigureRendererRuntime.php
+++ b/core-bundle/src/Twig/Runtime/FigureRendererRuntime.php
@@ -15,6 +15,9 @@ namespace Contao\CoreBundle\Twig\Runtime;
 use Contao\CoreBundle\File\MetaData;
 use Contao\CoreBundle\Image\Studio\Figure;
 use Contao\CoreBundle\Image\Studio\Studio;
+use Contao\FilesModel;
+use Contao\Image\ImageInterface;
+use Contao\Image\PictureConfiguration;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
 use Twig\Environment;
@@ -52,10 +55,15 @@ final class FigureRendererRuntime implements RuntimeExtensionInterface
      * Render a figure. The provided configuration array is used to configure
      * a FigureBuilder. If not explicitly set the default figure template will
      * be used to render the results.
+     *
+     * @param int|string|FilesModel|ImageInterface  $from          Can be a FilesModel, an ImageInterface, a tl_files UUID/ID/path or a file system path
+     * @param int|string|array|PictureConfiguration $size          A picture size configuration or reference
+     * @param array<string, mixed>                  $configuration Configuration for the FigureBuilder
      */
-    public function render($from, array $configuration = [], $template = '@ContaoCore/Image/Studio/figure.html.twig'): string
+    public function render($from, $size, array $configuration = [], string $template = '@ContaoCore/Image/Studio/figure.html.twig'): string
     {
         $configuration['from'] = $from;
+        $configuration['size'] = $size;
 
         // Allow overwriting meta data on the fly
         foreach (['metaData', 'setMetaData'] as $key) {
@@ -69,11 +77,11 @@ final class FigureRendererRuntime implements RuntimeExtensionInterface
         return $this->twig->render($template, ['figure' => $figure]);
     }
 
-    private function buildFigure(array $options): Figure
+    private function buildFigure(array $configuration): Figure
     {
         $figureBuilder = $this->studio->createFigureBuilder();
 
-        foreach ($options as $property => $value) {
+        foreach ($configuration as $property => $value) {
             $this->propertyAccessor->setValue($figureBuilder, $property, $value);
         }
 

--- a/core-bundle/src/Twig/Runtime/PictureConfigurationRuntime.php
+++ b/core-bundle/src/Twig/Runtime/PictureConfigurationRuntime.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Twig\Runtime;
+
+use Contao\Image\PictureConfiguration;
+use Contao\Image\PictureConfigurationItem;
+use Contao\Image\ResizeConfiguration;
+use Twig\Extension\RuntimeExtensionInterface;
+
+final class PictureConfigurationRuntime implements RuntimeExtensionInterface
+{
+    /**
+     * Create a picture configuration from an array. This is intended to be
+     * used from within templates where programmatic building isn't available.
+     */
+    public function fromArray(array $configArray): PictureConfiguration
+    {
+        $config = new PictureConfiguration();
+
+        $config->setSize($this->createConfigItem($configArray));
+        $config->setFormats($configArray['formats'] ?? []);
+
+        $config->setSizeItems(
+            array_map(
+                function (array $imageSizeItem): PictureConfigurationItem {
+                    return $this->createConfigItem($imageSizeItem);
+                },
+                $configArray['items'] ?? []
+            )
+        );
+
+        return $config;
+    }
+
+    private function createConfigItem(array $imageSize): PictureConfigurationItem
+    {
+        $configItem = new PictureConfigurationItem();
+
+        if (isset($imageSize['sizes'])) {
+            $configItem->setSizes((string) $imageSize['sizes']);
+        }
+
+        if (isset($imageSize['densities'])) {
+            $configItem->setDensities((string) $imageSize['densities']);
+        }
+
+        if (isset($imageSize['media'])) {
+            $configItem->setMedia((string) $imageSize['media']);
+        }
+
+        $resizeConfig = new ResizeConfiguration();
+
+        if (isset($imageSize['width'])) {
+            $resizeConfig->setWidth((int) $imageSize['width']);
+        }
+
+        if (isset($imageSize['height'])) {
+            $resizeConfig->setHeight((int) $imageSize['height']);
+        }
+
+        if (isset($imageSize['zoom'])) {
+            $resizeConfig->setZoomLevel((int) $imageSize['zoom']);
+        }
+
+        if (isset($imageSize['resizeMode'])) {
+            $resizeConfig->setMode((string) $imageSize['resizeMode']);
+        }
+
+        $configItem->setResizeConfig($resizeConfig);
+
+        return $configItem;
+    }
+}

--- a/core-bundle/src/Twig/Runtime/PictureConfigurationRuntime.php
+++ b/core-bundle/src/Twig/Runtime/PictureConfigurationRuntime.php
@@ -32,8 +32,10 @@ final class PictureConfigurationRuntime implements RuntimeExtensionInterface
     }
 
     /**
-     * Create a picture configuration from an array. This is intended to be
-     * used from within templates where programmatic building isn't available.
+     * Creates a picture configuration from an array.
+     *
+     * This is intended to be used from within templates where programmatic
+     * building is not available.
      */
     public function fromArray(array $config): PictureConfiguration
     {
@@ -55,6 +57,7 @@ final class PictureConfigurationRuntime implements RuntimeExtensionInterface
             },
             $config['items'] ?? []
         );
+
         unset($config['items']);
 
         // Apply remaining data to root config
@@ -80,6 +83,7 @@ final class PictureConfigurationRuntime implements RuntimeExtensionInterface
         if (isset($config['resizeMode'])) {
             $config['mode'] = $config['resizeMode'];
         }
+
         unset($config['zoom'], $config['resizeMode']);
 
         $this->applyConfiguration($pictureConfigurationItem, $config);

--- a/core-bundle/src/Twig/Runtime/PictureConfigurationRuntime.php
+++ b/core-bundle/src/Twig/Runtime/PictureConfigurationRuntime.php
@@ -42,38 +42,38 @@ final class PictureConfigurationRuntime implements RuntimeExtensionInterface
         return $config;
     }
 
-    private function createConfigItem(array $imageSize): PictureConfigurationItem
+    private function createConfigItem(array $config): PictureConfigurationItem
     {
         $configItem = new PictureConfigurationItem();
 
-        if (isset($imageSize['sizes'])) {
-            $configItem->setSizes((string) $imageSize['sizes']);
+        if (isset($config['sizes'])) {
+            $configItem->setSizes((string) $config['sizes']);
         }
 
-        if (isset($imageSize['densities'])) {
-            $configItem->setDensities((string) $imageSize['densities']);
+        if (isset($config['densities'])) {
+            $configItem->setDensities((string) $config['densities']);
         }
 
-        if (isset($imageSize['media'])) {
-            $configItem->setMedia((string) $imageSize['media']);
+        if (isset($config['media'])) {
+            $configItem->setMedia((string) $config['media']);
         }
 
         $resizeConfig = new ResizeConfiguration();
 
-        if (isset($imageSize['width'])) {
-            $resizeConfig->setWidth((int) $imageSize['width']);
+        if (isset($config['width'])) {
+            $resizeConfig->setWidth((int) $config['width']);
         }
 
-        if (isset($imageSize['height'])) {
-            $resizeConfig->setHeight((int) $imageSize['height']);
+        if (isset($config['height'])) {
+            $resizeConfig->setHeight((int) $config['height']);
         }
 
-        if (isset($imageSize['zoom'])) {
-            $resizeConfig->setZoomLevel((int) $imageSize['zoom']);
+        if (isset($config['zoom'])) {
+            $resizeConfig->setZoomLevel((int) $config['zoom']);
         }
 
-        if (isset($imageSize['resizeMode'])) {
-            $resizeConfig->setMode((string) $imageSize['resizeMode']);
+        if (isset($config['resizeMode'])) {
+            $resizeConfig->setMode((string) $config['resizeMode']);
         }
 
         $configItem->setResizeConfig($resizeConfig);

--- a/core-bundle/tests/Twig/Extension/ImageExtensionTest.php
+++ b/core-bundle/tests/Twig/Extension/ImageExtensionTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\Twig\Extension;
+
+use Contao\CoreBundle\Tests\TestCase;
+use Contao\CoreBundle\Twig\Extension\ImageExtension;
+use Contao\CoreBundle\Twig\Runtime\FigureRendererRuntime;
+use Contao\CoreBundle\Twig\Runtime\PictureConfigurationRuntime;
+use Twig\Node\Node;
+
+class ImageExtensionTest extends TestCase
+{
+    public function testAddsTheContaoFigureAndPictureConfigurationFunctions(): void
+    {
+        $functions = (new ImageExtension())->getFunctions();
+
+        $this->assertCount(2, $functions);
+        [$contaoFigureFn, $pictureConfigurationFn] = $functions;
+
+        $node = $this->createMock(Node::class);
+
+        $this->assertSame('contao_figure', $contaoFigureFn->getName());
+        $this->assertSame([FigureRendererRuntime::class, 'render'], $contaoFigureFn->getCallable());
+        $this->assertSame(['html'], $contaoFigureFn->getSafe($node));
+
+        $this->assertSame('picture_configuration', $pictureConfigurationFn->getName());
+        $this->assertSame([PictureConfigurationRuntime::class, 'fromArray'], $pictureConfigurationFn->getCallable());
+        $this->assertSame([], $pictureConfigurationFn->getSafe($node));
+    }
+}

--- a/core-bundle/tests/Twig/Extension/ImageExtensionTest.php
+++ b/core-bundle/tests/Twig/Extension/ImageExtensionTest.php
@@ -25,6 +25,7 @@ class ImageExtensionTest extends TestCase
         $functions = (new ImageExtension())->getFunctions();
 
         $this->assertCount(2, $functions);
+
         [$contaoFigureFn, $pictureConfigurationFn] = $functions;
 
         $node = $this->createMock(Node::class);

--- a/core-bundle/tests/Twig/Extension/ImageExtensionTest.php
+++ b/core-bundle/tests/Twig/Extension/ImageExtensionTest.php
@@ -33,7 +33,7 @@ class ImageExtensionTest extends TestCase
         $this->assertSame([FigureRendererRuntime::class, 'render'], $contaoFigureFn->getCallable());
         $this->assertSame(['html'], $contaoFigureFn->getSafe($node));
 
-        $this->assertSame('picture_configuration', $pictureConfigurationFn->getName());
+        $this->assertSame('picture_config', $pictureConfigurationFn->getName());
         $this->assertSame([PictureConfigurationRuntime::class, 'fromArray'], $pictureConfigurationFn->getCallable());
         $this->assertSame([], $pictureConfigurationFn->getSafe($node));
     }

--- a/core-bundle/tests/Twig/Runtime/FigureRendererRuntimeTest.php
+++ b/core-bundle/tests/Twig/Runtime/FigureRendererRuntimeTest.php
@@ -29,7 +29,6 @@ class FigureRendererRuntimeTest extends TestCase
         $metaData = new MetaData([]);
 
         $configuration = [
-            'size' => '_size',
             'metaData' => $metaData,
             'disableMetaData' => true,
             'locale' => 'de',
@@ -59,7 +58,7 @@ class FigureRendererRuntimeTest extends TestCase
 
         $runtime = $this->getRuntime($expectedFigureBuilderCalls);
 
-        $this->assertSame('<result>', $runtime->render('resource', $configuration));
+        $this->assertSame('<result>', $runtime->render('resource', '_size', $configuration));
     }
 
     /**
@@ -71,14 +70,14 @@ class FigureRendererRuntimeTest extends TestCase
 
         $runtime = $this->getRuntime(['setMetaData' => new MetaData($metaData)]);
 
-        $this->assertSame('<result>', $runtime->render('resource', [$key => [MetaData::VALUE_ALT => 'foo']]));
+        $this->assertSame('<result>', $runtime->render('resource', null, [$key => [MetaData::VALUE_ALT => 'foo']]));
     }
 
     public function testUsesCustomTemplate(): void
     {
         $runtime = $this->getRuntime([], '@App/custom_figure.html.twig');
 
-        $this->assertSame('<result>', $runtime->render(1, [], '@App/custom_figure.html.twig'));
+        $this->assertSame('<result>', $runtime->render(1, null, [], '@App/custom_figure.html.twig'));
     }
 
     public function testFailsWithInvalidConfiguration(): void
@@ -89,7 +88,7 @@ class FigureRendererRuntimeTest extends TestCase
             'invalid' => 'foobar',
         ];
 
-        $this->getRuntime()->render(1, $configuration);
+        $this->getRuntime()->render(1, null, $configuration);
     }
 
     private function getRuntime(array $figureBuilderCalls = [], string $expectedTemplate = '@ContaoCore/Image/Studio/figure.html.twig'): FigureRendererRuntime

--- a/core-bundle/tests/Twig/Runtime/FigureRendererRuntimeTest.php
+++ b/core-bundle/tests/Twig/Runtime/FigureRendererRuntimeTest.php
@@ -81,13 +81,11 @@ class FigureRendererRuntimeTest extends TestCase
 
     public function testFailsWithInvalidConfiguration(): void
     {
+        $runtime = $this->getRuntime();
+
         $this->expectException(NoSuchPropertyException::class);
 
-        $configuration = [
-            'invalid' => 'foobar',
-        ];
-
-        $this->getRuntime()->render(1, null, $configuration);
+        $runtime->render(1, null, ['invalid' => 'foobar']);
     }
 
     private function getRuntime(array $figureBuilderCalls = [], string $expectedTemplate = '@ContaoCore/Image/Studio/figure.html.twig'): FigureRendererRuntime

--- a/core-bundle/tests/Twig/Runtime/FigureRendererRuntimeTest.php
+++ b/core-bundle/tests/Twig/Runtime/FigureRendererRuntimeTest.php
@@ -67,7 +67,6 @@ class FigureRendererRuntimeTest extends TestCase
     public function testAllowsDefiningMetaDataAsArray(string $key): void
     {
         $metaData = [MetaData::VALUE_ALT => 'foo'];
-
         $runtime = $this->getRuntime(['setMetaData' => new MetaData($metaData)]);
 
         $this->assertSame('<result>', $runtime->render('resource', null, [$key => [MetaData::VALUE_ALT => 'foo']]));
@@ -96,7 +95,6 @@ class FigureRendererRuntimeTest extends TestCase
         $figure = new Figure($this->createMock(ImageResult::class));
 
         $figureBuilder = $this->createMock(FigureBuilder::class);
-
         $figureBuilder
             ->method('build')
             ->willReturn($figure)
@@ -112,14 +110,12 @@ class FigureRendererRuntimeTest extends TestCase
         }
 
         $studio = $this->createMock(Studio::class);
-
         $studio
             ->method('createFigureBuilder')
             ->willReturn($figureBuilder)
         ;
 
         $twig = $this->createMock(Environment::class);
-
         $twig
             ->method('render')
             ->with($expectedTemplate, ['figure' => $figure])

--- a/core-bundle/tests/Twig/Runtime/FigureRendererRuntimeTest.php
+++ b/core-bundle/tests/Twig/Runtime/FigureRendererRuntimeTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\Twig\Runtime;
+
+use Contao\CoreBundle\File\MetaData;
+use Contao\CoreBundle\Image\Studio\Figure;
+use Contao\CoreBundle\Image\Studio\FigureBuilder;
+use Contao\CoreBundle\Image\Studio\ImageResult;
+use Contao\CoreBundle\Image\Studio\Studio;
+use Contao\CoreBundle\Tests\TestCase;
+use Contao\CoreBundle\Twig\Runtime\FigureRendererRuntime;
+use Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException;
+use Twig\Environment;
+
+class FigureRendererRuntimeTest extends TestCase
+{
+    public function testConfiguresBuilder(): void
+    {
+        $metaData = new MetaData([]);
+
+        $configuration = [
+            'size' => '_size',
+            'metadata' => $metaData,
+            'disableMetaData' => true,
+            'locale' => 'de',
+            'linkAttributes' => ['foo' => 'bar'],
+            'linkHref' => 'foo',
+            'lightBoxResourceOrUrl' => 'foobar',
+            'lightBoxSize' => '_lightbox_size',
+            'lightBoxGroupIdentifier' => '123',
+            'enableLightBox' => true,
+            'options' => ['foo' => 'bar'],
+        ];
+
+        $expectedFigureBuilderCalls = [
+            'from' => 'resource',
+            'setSize' => '_size',
+            'setMetaData' => $metaData,
+            'disableMetaData' => true,
+            'setLocale' => 'de',
+            'setLinkAttributes' => ['foo' => 'bar'],
+            'setLinkHref' => 'foo',
+            'setLightBoxResourceOrUrl' => 'foobar',
+            'setLightBoxSize' => '_lightbox_size',
+            'setLightBoxGroupIdentifier' => '123',
+            'enableLightBox' => true,
+            'setOptions' => ['foo' => 'bar'],
+        ];
+
+        $runtime = $this->getRuntime($expectedFigureBuilderCalls);
+
+        $this->assertSame('<result>', $runtime->render('resource', $configuration));
+    }
+
+    public function testUsesCustomTemplate(): void
+    {
+        $runtime = $this->getRuntime([], '@App/custom_figure.html.twig');
+
+        $this->assertSame('<result>', $runtime->render(1, [], '@App/custom_figure.html.twig'));
+    }
+
+    public function testFailsWithInvalidConfiguration(): void
+    {
+        $this->expectException(NoSuchPropertyException::class);
+
+        $configuration = [
+            'invalid' => 'foobar',
+        ];
+
+        $this->getRuntime()->render(1, $configuration);
+    }
+
+    private function getRuntime(array $figureBuilderCalls = [], string $expectedTemplate = '@ContaoCore/Image/Studio/figure.html.twig'): FigureRendererRuntime
+    {
+        $figure = new Figure($this->createMock(ImageResult::class));
+
+        $figureBuilder = $this->createMock(FigureBuilder::class);
+
+        $figureBuilder
+            ->method('build')
+            ->willReturn($figure)
+        ;
+
+        foreach ($figureBuilderCalls as $method => $value) {
+            $figureBuilder
+                ->expects($this->once())
+                ->method($method)
+                ->with($value)
+                ->willReturn($figureBuilder)
+            ;
+        }
+
+        $studio = $this->createMock(Studio::class);
+
+        $studio
+            ->method('createFigureBuilder')
+            ->willReturn($figureBuilder)
+        ;
+
+        $twig = $this->createMock(Environment::class);
+
+        $twig
+            ->method('render')
+            ->with($expectedTemplate, ['figure' => $figure])
+            ->willReturn('<result>')
+        ;
+
+        return new FigureRendererRuntime($studio, $twig);
+    }
+}

--- a/core-bundle/tests/Twig/Runtime/FigureRendererRuntimeTest.php
+++ b/core-bundle/tests/Twig/Runtime/FigureRendererRuntimeTest.php
@@ -30,7 +30,7 @@ class FigureRendererRuntimeTest extends TestCase
 
         $configuration = [
             'size' => '_size',
-            'metadata' => $metaData,
+            'metaData' => $metaData,
             'disableMetaData' => true,
             'locale' => 'de',
             'linkAttributes' => ['foo' => 'bar'],
@@ -60,6 +60,18 @@ class FigureRendererRuntimeTest extends TestCase
         $runtime = $this->getRuntime($expectedFigureBuilderCalls);
 
         $this->assertSame('<result>', $runtime->render('resource', $configuration));
+    }
+
+    /**
+     * @testWith ["metaData", "setMetaData"]
+     */
+    public function testAllowsDefiningMetaDataAsArray(string $key): void
+    {
+        $metaData = [MetaData::VALUE_ALT => 'foo'];
+
+        $runtime = $this->getRuntime(['setMetaData' => new MetaData($metaData)]);
+
+        $this->assertSame('<result>', $runtime->render('resource', [$key => [MetaData::VALUE_ALT => 'foo']]));
     }
 
     public function testUsesCustomTemplate(): void

--- a/core-bundle/tests/Twig/Runtime/PictureConfigurationRuntimeTest.php
+++ b/core-bundle/tests/Twig/Runtime/PictureConfigurationRuntimeTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\Twig\Runtime;
+
+use Contao\CoreBundle\Tests\TestCase;
+use Contao\CoreBundle\Twig\Runtime\PictureConfigurationRuntime;
+
+class PictureConfigurationRuntimeTest extends TestCase
+{
+    public function testGeneratesEmptyPictureConfiguration(): void
+    {
+        $runtime = new PictureConfigurationRuntime();
+
+        $configuration = $runtime->fromArray([]);
+
+        $this->assertSame('', $configuration->getSize()->getDensities());
+        $this->assertSame('', $configuration->getSize()->getSizes());
+        $this->assertSame(0, $configuration->getSize()->getResizeConfig()->getWidth());
+        $this->assertSame(0, $configuration->getSize()->getResizeConfig()->getHeight());
+        $this->assertSame(0, $configuration->getSize()->getResizeConfig()->getZoomLevel());
+        $this->assertSame('crop', $configuration->getSize()->getResizeConfig()->getMode());
+        $this->assertSame(['.default' => ['.default']], $configuration->getFormats());
+        $this->assertSame([], $configuration->getSizeItems());
+    }
+
+    public function testGeneratesPictureConfigurationWithoutItems(): void
+    {
+        $runtime = new PictureConfigurationRuntime();
+
+        $configuration = $runtime->fromArray([
+            'densities' => '1x, 2x',
+            'sizes' => '100vw',
+            'width' => '200',
+            'height' => '100',
+            'zoom' => '75',
+            'resizeMode' => 'proportional',
+            'formats' => ['jpg' => ['jpg', 'webp']],
+        ]);
+
+        $this->assertSame('1x, 2x', $configuration->getSize()->getDensities());
+        $this->assertSame('100vw', $configuration->getSize()->getSizes());
+        $this->assertSame(200, $configuration->getSize()->getResizeConfig()->getWidth());
+        $this->assertSame(100, $configuration->getSize()->getResizeConfig()->getHeight());
+        $this->assertSame(75, $configuration->getSize()->getResizeConfig()->getZoomLevel());
+        $this->assertSame('proportional', $configuration->getSize()->getResizeConfig()->getMode());
+        $this->assertSame(['jpg' => ['jpg', 'webp'], '.default' => ['.default']], $configuration->getFormats());
+        $this->assertSame([], $configuration->getSizeItems());
+    }
+
+    public function testGeneratesPictureConfigurationWithItems(): void
+    {
+        $runtime = new PictureConfigurationRuntime();
+
+        $configuration = $runtime->fromArray([
+            'items' => [
+                [
+                ],
+                [
+                    'densities' => '1x, 2x',
+                    'sizes' => '100vw',
+                    'width' => '200',
+                    'height' => '100',
+                    'zoom' => '75',
+                    'resizeMode' => 'proportional',
+                    'media' => '(max-width: 640px)',
+                ],
+            ],
+        ]);
+
+        $this->assertCount(2, $configuration->getSizeItems());
+        [$item1, $item2] = $configuration->getSizeItems();
+
+        $this->assertSame('', $item1->getDensities());
+        $this->assertSame('', $item1->getSizes());
+        $this->assertSame(0, $item1->getResizeConfig()->getWidth());
+        $this->assertSame(0, $item1->getResizeConfig()->getHeight());
+        $this->assertSame(0, $item1->getResizeConfig()->getZoomLevel());
+        $this->assertSame('crop', $item1->getResizeConfig()->getMode());
+        $this->assertSame('', $item1->getMedia());
+
+        $this->assertSame('1x, 2x', $item2->getDensities());
+        $this->assertSame('100vw', $item2->getSizes());
+        $this->assertSame(200, $item2->getResizeConfig()->getWidth());
+        $this->assertSame(100, $item2->getResizeConfig()->getHeight());
+        $this->assertSame(75, $item2->getResizeConfig()->getZoomLevel());
+        $this->assertSame('proportional', $item2->getResizeConfig()->getMode());
+        $this->assertSame('(max-width: 640px)', $item2->getMedia());
+    }
+}

--- a/core-bundle/tests/Twig/Runtime/PictureConfigurationRuntimeTest.php
+++ b/core-bundle/tests/Twig/Runtime/PictureConfigurationRuntimeTest.php
@@ -96,4 +96,36 @@ class PictureConfigurationRuntimeTest extends TestCase
         $this->assertSame('proportional', $item2->getResizeConfig()->getMode());
         $this->assertSame('(max-width: 640px)', $item2->getMedia());
     }
+
+    public function testFailsWithInvalidConfiguration(): void
+    {
+        $runtime = new PictureConfigurationRuntime();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Could not map picture configuration key(s) "foo", "bar".');
+
+        $runtime->fromArray([
+            'foo' => 'value',
+            'bar' => 'value',
+            'sizes' => '100vw',
+        ]);
+    }
+
+    public function testFailsWithInvalidItemConfiguration(): void
+    {
+        $runtime = new PictureConfigurationRuntime();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Could not map picture configuration key(s) "items.foo", "items.bar".');
+
+        $runtime->fromArray([
+            'items' => [
+                [
+                    'width' => '100',
+                    'foo' => 'value',
+                    'bar' => 'value',
+                ],
+            ],
+        ]);
+    }
 }

--- a/core-bundle/tests/Twig/Runtime/PictureConfigurationRuntimeTest.php
+++ b/core-bundle/tests/Twig/Runtime/PictureConfigurationRuntimeTest.php
@@ -20,7 +20,6 @@ class PictureConfigurationRuntimeTest extends TestCase
     public function testGeneratesEmptyPictureConfiguration(): void
     {
         $runtime = new PictureConfigurationRuntime();
-
         $configuration = $runtime->fromArray([]);
 
         $this->assertSame('', $configuration->getSize()->getDensities());
@@ -78,6 +77,7 @@ class PictureConfigurationRuntimeTest extends TestCase
         ]);
 
         $this->assertCount(2, $configuration->getSizeItems());
+
         [$item1, $item2] = $configuration->getSizeItems();
 
         $this->assertSame('', $item1->getDensities());


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | #1508 
| Docs PR or issue | https://github.com/contao/docs/pull/468

*Updated description (20/07/08)*

---

### What's inside
This PR ships&hellip;
* &hellip; a Twig template + some helper functions (macros) to render a `Image\Studio\Figure` as a `<figure>` tag. This includes a picture + caption and is comparable to the `image.html5` template.
* &hellip; a Twig function to directly render figures from within templates. The function accepts an optional custom template and a set of options that used to configure the `FigureBuilder`.
* &hellip; as a bonus (idea &copy; by @ausi :slightly_smiling_face: ) a function to create `PictureConfiguration`s from within templates. This enables building figures with custom size configurations per template.

#### It enables the following scenarios:
1) Rendering the default template (from a Controller):
```php
$figure = $studio->createFigureBuilder->from($uuid)->setSize(5)->build();

$twig->render('@ContaoCore/Image/Studio/figure.html.twig', ['figure' => $figure]);
```

2) Rendering a custom template with a figure (using the 'figure' macro):
```php
$twig->render('my_template.html.twig', [
  'headline' => $headline,
  'my_figure' => $figure,
]);
```
```twig
{% import "@ContaoCore/Image/Studio/_macros.html.twig" as studio %}

<h1>{{ headline }}</h1>
<div class="container">
  {{ studio.figure(my_figure) }}
</div>
```

3) Rendering a figure from within a template :star2:  (&rarr; uses the default figure template):
```twig
{{ contao_figure(uuid, [200, 200, 'crop'], {
    enableLightBox: true,
    lightBoxGroupIdentifier: 'foo',
}) }}
```

4) Rendering a figure from within a template using a custom figure template:
```html
{{ contao_figure('path/to/an/image.png', '_mySize', {
    disableMetaData,
}, '@App\my_custom_template.html.twig') }}
```

5) Building a picture configuration on the fly (syntax equals definition from config):
```twig
{% set special_config = picture_config({
    width: 400,
    height: 400,
    resize_mode: 'crop',
    sizes: '0.75,1,1.5,2',
    items: [{
        width: 200,
        height: 100,
        media: '(max-width: 140px)',
    }]
}) %}

{{ contao_figure(id, special_config) }}
```

6) Building a figure template from building blocks:
```twig
{% import "@ContaoCore/Image/Studio/_macros.html.twig" as studio %}

<h3>Now look</h3>
<figure class="my_custom_stuff">
  <div class="caption-container">
    {{ studio.caption(figure) }}
  </div>
  {{ studio.picture(figure) }}
</div>
```

7) Overwriting options inside the template:
```twig
{% import "@ContaoCore/Image/Studio/_macros.html.twig" as studio %}

{{ studio.figure(uuid, {}, { 
    attr: { class: 'image-container' },
    caption_attr: { class: 'caption', data-foo: 'bar' }
} }}
```
This principle is borrowed from `symfony/form`. You can define options when creating a `Figure` but you can also specify them when building the template (overwriting the set ones). This makes the whole thing very flexible. Currently you can only define HTML attributes for the various tags but this can easily be extended by either the core or devs creating their own templates. Have a look in the macro file for a more detailed explanation how it is set up.

### Dependencies
Note: This PR is currently based on #1753. The relevant changes are in the following folders:
* `core-bundle\src\Twig\*`
* `core-bundle\views\Image\*`
* `core-bundle\Resources\config\services.yml`
* `core-bundle\tests\Twig\*`

(Commits starting from e76bf63295b6f5d2ff09fc17e74e463139bbb4ab)

### Todo
* [x] Finish templates
* [x] Tests
* [x] Rebase once #1753 is merged
