### PR TITLE
Fixed some Piwik/Matomo cookie regex

### DIFF
--- a/core-bundle/src/EventListener/HttpCache/StripCookiesSubscriber.php
+++ b/core-bundle/src/EventListener/HttpCache/StripCookiesSubscriber.php
@@ -34,11 +34,11 @@ class StripCookiesSubscriber implements EventSubscriberInterface
         '_gac_.+',
 
         // Matomo (https://matomo.org/faq/general/faq_146/)
-        '_pk_id',
-        '_pk_ref',
-        '_pk_ses',
-        '_pk_cvar',
-        '_pk_hsr',
+        '_pk_id.*',
+        '_pk_ref.*',
+        '_pk_ses.*',
+        '_pk_cvar.*',
+        '_pk_hsr.*',
 
         // Cloudflare
         '__cfduid',


### PR DESCRIPTION
According to the manual mentioned above these lines, the cookies **start with** the mentioned names, and that's exactly what I've discovered on a @Pellinger's website.

> To track visitors, Matomo (Piwik) by default uses 1st party cookies, set on the domain of your website. Cookies created by Matomo **start with**: _pk_ref, _pk_cvar, _pk_id, _pk_ses. When you use the Heatmap & Session Recording plugin, a cookie _pk_hsr will be created.