### PR TITLE
Correctly sort if both root pages are fallback

### DIFF
--- a/core-bundle/src/Routing/RouteProvider.php
+++ b/core-bundle/src/Routing/RouteProvider.php
@@ -437,11 +437,11 @@ class RouteProvider implements RouteProviderInterface
                     $langB = $languages[$pageB->rootLanguage] ?? null;
 
                     if (null === $langA && null === $langB) {
-                        if ($pageA->rootIsFallback) {
+                        if ($pageA->rootIsFallback && !$pageB->rootIsFallback) {
                             return -1;
                         }
 
-                        if ($pageB->rootIsFallback) {
+                        if ($pageB->rootIsFallback && !$pageA->rootIsFallback) {
                             return 1;
                         }
 
@@ -465,23 +465,18 @@ class RouteProvider implements RouteProviderInterface
     }
 
     /**
-     * Finds the page models keeping the candidates order.
-     *
      * @return array<Model>
      */
     private function findPages(array $candidates): array
     {
         $ids = [];
         $aliases = [];
-        $models = [];
 
         foreach ($candidates as $candidate) {
             if (is_numeric($candidate)) {
                 $ids[] = (int) $candidate;
-                $models['id|'.$candidate] = false;
             } else {
                 $aliases[] = $this->database->quote($candidate);
-                $models['alias|'.$candidate] = [];
             }
         }
 
@@ -503,25 +498,7 @@ class RouteProvider implements RouteProviderInterface
             return [];
         }
 
-        foreach ($pages as $page) {
-            if (isset($models['id|'.$page->id])) {
-                $models['id|'.$page->id] = $page;
-            } elseif (isset($models['alias|'.$page->alias])) {
-                $models['alias|'.$page->alias][] = $page;
-            }
-        }
-
-        $return = [];
-        $models = array_filter($models);
-
-        array_walk_recursive(
-            $models,
-            static function ($i) use (&$return): void {
-                $return[] = $i;
-            }
-        );
-
-        return $return;
+        return $pages->getModels();
     }
 
     /**

--- a/core-bundle/tests/Routing/RouteProviderTest.php
+++ b/core-bundle/tests/Routing/RouteProviderTest.php
@@ -348,7 +348,15 @@ class RouteProviderTest extends TestCase
 
             $this->assertInstanceOf(PageModel::class, $routedPage);
             $this->assertSame('tl_page.'.$routedPage->id, $name);
-            $this->assertSame($pages[$i++], $routedPage);
+            $this->assertSame($pages[$i], $routedPage, sprintf(
+                'Position %s should be %s/%s but is %s/%s',
+                $i,
+                $pages[$i]->rootLanguage,
+                $pages[$i]->alias,
+                $routedPage->rootLanguage,
+                $routedPage->alias
+            ));
+            $i++;
         }
     }
 
@@ -428,6 +436,17 @@ class RouteProviderTest extends TestCase
                 3 => $this->createPage('en', 'foo/bar', false),
             ],
             ['de', 'fr'],
+        ];
+
+        // createPage() generates a rootSorting value from the language, so the test order is by language
+        yield 'Sorts by root page sorting if all of the languages are fallback' => [
+            [
+                1 => $this->createPage('en', 'foo', true),
+                3 => $this->createPage('ru', 'foo', true),
+                2 => $this->createPage('fr', 'foo', true),
+                0 => $this->createPage('en', 'foo/bar', true),
+            ],
+            ['de'],
         ];
 
         // createPage() generates a rootSorting value from the language, so the test order is by language

--- a/core-bundle/tests/Routing/RouteProviderTest.php
+++ b/core-bundle/tests/Routing/RouteProviderTest.php
@@ -356,7 +356,7 @@ class RouteProviderTest extends TestCase
                 $routedPage->rootLanguage,
                 $routedPage->alias
             ));
-            $i++;
+            ++$i;
         }
     }
 

--- a/core-bundle/tests/Routing/RouteProviderTest.php
+++ b/core-bundle/tests/Routing/RouteProviderTest.php
@@ -348,14 +348,20 @@ class RouteProviderTest extends TestCase
 
             $this->assertInstanceOf(PageModel::class, $routedPage);
             $this->assertSame('tl_page.'.$routedPage->id, $name);
-            $this->assertSame($pages[$i], $routedPage, sprintf(
-                'Position %s should be %s/%s but is %s/%s',
-                $i,
-                $pages[$i]->rootLanguage,
-                $pages[$i]->alias,
-                $routedPage->rootLanguage,
-                $routedPage->alias
-            ));
+
+            $this->assertSame(
+                $pages[$i],
+                $routedPage,
+                sprintf(
+                    'Position %s should be %s/%s but is %s/%s',
+                    $i,
+                    $pages[$i]->rootLanguage,
+                    $pages[$i]->alias,
+                    $routedPage->rootLanguage,
+                    $routedPage->alias
+                )
+            );
+
             ++$i;
         }
     }


### PR DESCRIPTION
While working on #1516 I discovered a bug in the route sorting algorithm. In the current functional tests, we have the following case:

- page 1  with alias `main` in domain `A` (which is fallback)
- page 2 with alias `main` in domain `B` (which is fallback)
- page 3 with alias `main/sub` in domain `B` (which is fallback)

Fetching a route for `main/sub` did not correctly return page 3, because page 2 was sorted (and matched) before it.
Because the database/candidates algorithm sorted the database results by length of alias, the tests didn't fail yet. But that sorting shouldn't be necessary. If the database items are not fetched by that order, the sorting algorithm must sort accordingly.