### PR TITLE
Port the 'handle URL suffix when redirecting page IDs' changes

### DIFF
--- a/core-bundle/src/Resources/contao/controllers/FrontendIndex.php
+++ b/core-bundle/src/Resources/contao/controllers/FrontendIndex.php
@@ -174,9 +174,9 @@ class FrontendIndex extends Frontend
 		if ($objPage->alias != '')
 		{
 			$language = Config::get('addLanguageToUrl') ? '[a-z]{2}(-[A-Z]{2})?/' : '';
-			$suffix = Config::get('urlSuffix') ? preg_quote(Config::get('urlSuffix'), '#') : '$';
+			$suffix = preg_quote(Config::get('urlSuffix'), '#');
 
-			if (preg_match('#^' . $language . $objPage->id . '(' . $suffix . '|/)#', Environment::get('relativeRequest')))
+			if (preg_match('#^' . $language . $objPage->id . '(' . $suffix . '($|\?)|/)#', Environment::get('relativeRequest')))
 			{
 				throw new PageNotFoundException('Page not found: ' . Environment::get('uri'));
 			}


### PR DESCRIPTION
This PR ports the changes from #1503 to Contao 4.9.