### PR TITLE
Keep the sorting of the selected IDs for actions

### DIFF
--- a/core-bundle/src/Resources/contao/dca/tl_content.php
+++ b/core-bundle/src/Resources/contao/dca/tl_content.php
@@ -1136,7 +1136,7 @@ class tl_content extends Contao\Backend
 					$objCes = $this->Database->prepare("SELECT id FROM tl_content WHERE id IN(" . implode(',', array_map('\intval', $session['CURRENT']['IDS'])) . ") AND type IN(" . implode(',', array_fill(0, count($this->User->elements), '?')) . ")")
 											 ->execute(...$this->User->elements);
 
-					$session['CURRENT']['IDS'] = $objCes->fetchEach('id');
+					$session['CURRENT']['IDS'] = array_intersect($session['CURRENT']['IDS'], $objCes->fetchEach('id'));
 				}
 
 				$objSession->replace($session);
@@ -1159,7 +1159,7 @@ class tl_content extends Contao\Backend
 					$objCes = $this->Database->prepare("SELECT id, type FROM tl_content WHERE id IN(" . implode(',', array_map('\intval', $session['CLIPBOARD']['tl_content']['id'])) . ") AND type IN(" . implode(',', array_fill(0, count($this->User->elements), '?')) . ")")
 											 ->execute(...$this->User->elements);
 
-					$session['CLIPBOARD']['tl_content']['id'] = $objCes->fetchEach('id');
+					$session['CLIPBOARD']['tl_content']['id'] = array_intersect($session['CLIPBOARD']['tl_content']['id'], $objCes->fetchEach('id'));
 				}
 
 				$objSession->replace($session);


### PR DESCRIPTION
During copyAll we had the problem that the sorting was lost,
because the CLIPBOARD is filtered according to element permissions.

I'm not sure, if it's also neccesary for actions other than copyAll, but I have seen a similar logic there.