### PR TITLE
Widen typehint of argument

### DIFF
--- a/installation-bundle/src/EventListener/InitializeApplicationListener.php
+++ b/installation-bundle/src/EventListener/InitializeApplicationListener.php
@@ -14,6 +14,7 @@ use Contao\InstallationBundle\Event\InitializeApplicationEvent;
 use Symfony\Bundle\FrameworkBundle\Command\AssetsInstallCommand;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\BufferedOutput;
@@ -120,14 +121,16 @@ class InitializeApplicationListener implements ContainerAwareInterface
     /**
      * Runs a command and returns the error (if any).
      *
-     * @param ContainerAwareCommand $command
-     * @param InputInterface        $input
+     * @param Command        $command
+     * @param InputInterface $input
      *
      * @return string|null
      */
-    private function runCommand(ContainerAwareCommand $command, InputInterface $input)
+    private function runCommand(Command $command, InputInterface $input)
     {
-        $command->setContainer($this->container);
+        if ($command instanceof ContainerAwareCommand) {
+            $command->setContainer($this->container);
+        }
 
         $output = new BufferedOutput(OutputInterface::VERBOSITY_NORMAL, true);
         $status = $command->run($input, $output);


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | n/a
| Docs PR or issue | https://github.com/contao/docs/pull/307

During my work for https://github.com/contao/docs/issues/300 I stumbled over this:
```
Type error: Argument 1 passed to Contao\InstallationBundle\EventListener\InitializeApplicationListener::runCommand() must be an instance of Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand, instance of Contao\CoreBundle\Command\SymlinksCommand given, called in /vendor/contao/installation-bundle/src/EventListener/InitializeApplicationListener.php on line 113
```

This is probably related to this change: https://github.com/contao/core-bundle/commit/2a2e6176f3e8da423a1d527b0ea8b82810049f9d

Widen the typehint to `Command` instead of `ContainerAwareCommand` and set the container if it's an instance of the latter will solve this issue.