### PR TITLE
Check if DBAL connection is available from .env configuration

### DIFF
--- a/installation-bundle/src/Controller/InstallationController.php
+++ b/installation-bundle/src/Controller/InstallationController.php
@@ -17,7 +17,6 @@ use Contao\InstallationBundle\Database\ConnectionFactory;
 use Contao\InstallationBundle\Event\ContaoInstallationEvents;
 use Contao\InstallationBundle\Event\InitializeApplicationEvent;
 use Contao\Validator;
-use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DBALException;
 use Patchwork\Utf8;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
@@ -88,11 +87,7 @@ class InstallationController implements ContainerAwareInterface
             return $this->login();
         }
 
-        $connection = $this->container->get('database_connection');
-
-        if ($connection instanceof Connection) {
-            $installTool->setConnection($connection);
-        } elseif (!$installTool->canConnectToDatabase($this->getContainerParameter('database_name'))) {
+        if (!$installTool->canConnectToDatabase($this->getContainerParameter('database_name'))) {
             return $this->setUpDatabaseConnection();
         }
 

--- a/installation-bundle/src/Controller/InstallationController.php
+++ b/installation-bundle/src/Controller/InstallationController.php
@@ -312,6 +312,11 @@ class InstallationController implements ContainerAwareInterface
             return $this->render('database.html.twig', $parameters);
         }
 
+        // Only warn the user if the connection fails and the env component is used
+        if (false !== getenv('DATABASE_URL')) {
+            return $this->render('misconfigured_database_url.html.twig');
+        }
+
         $parameters['parameters'] = [
             'database_host' => $request->request->get('dbHost'),
             'database_port' => $request->request->get('dbPort'),

--- a/installation-bundle/src/Controller/InstallationController.php
+++ b/installation-bundle/src/Controller/InstallationController.php
@@ -17,6 +17,7 @@ use Contao\InstallationBundle\Database\ConnectionFactory;
 use Contao\InstallationBundle\Event\ContaoInstallationEvents;
 use Contao\InstallationBundle\Event\InitializeApplicationEvent;
 use Contao\Validator;
+use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DBALException;
 use Patchwork\Utf8;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
@@ -87,7 +88,11 @@ class InstallationController implements ContainerAwareInterface
             return $this->login();
         }
 
-        if (!$installTool->canConnectToDatabase($this->getContainerParameter('database_name'))) {
+        $connection = $this->container->get('database_connection');
+
+        if ($connection instanceof Connection) {
+            $installTool->setConnection($connection);
+        } elseif (!$installTool->canConnectToDatabase($this->getContainerParameter('database_name'))) {
             return $this->setUpDatabaseConnection();
         }
 

--- a/installation-bundle/src/InstallTool.php
+++ b/installation-bundle/src/InstallTool.php
@@ -136,6 +136,15 @@ class InstallTool
      */
     public function canConnectToDatabase($name)
     {
+        // Return if there is a working database connection already
+        try {
+            $this->connection->connect();
+            $this->connection->query('SHOW TABLES');
+
+            return true;
+        } catch (\Exception $e) {
+        }
+
         if (null === $name || null === $this->connection) {
             return false;
         }

--- a/installation-bundle/src/Resources/translations/messages.en.xlf
+++ b/installation-bundle/src/Resources/translations/messages.en.xlf
@@ -302,6 +302,10 @@
         <source>duplicate_subscriptions_end</source>
         <target>The duplicate entries have been purged automatically. A backup of the original subscriptions has been stored in &lt;code&gt;tl_newsletter_recipients_backup&lt;/code&gt;.</target>
       </trans-unit>
+      <trans-unit id="76">
+        <source>misconfigured_database_url_explain</source>
+        <target>Could not connect to the database using the connection URL found in the &lt;code&gt;DATABASE_URL&lt;/code&gt; environment variable.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/installation-bundle/src/Resources/views/misconfigured_database_url.html.twig
+++ b/installation-bundle/src/Resources/views/misconfigured_database_url.html.twig
@@ -1,0 +1,9 @@
+{% extends "@ContaoInstallation/layout.html.twig" %}
+
+{% block main %}
+    <fieldset class="tl_tbox nolegend">
+        <h3>{{ 'an_error_occurred'|trans }}</h3>
+        <p class="tl_error">{{ 'database_could_not_connect'|trans }}</p>
+        <p>{{ 'misconfigured_database_url_explain'|trans|raw }}</p>
+    </fieldset>
+{% endblock %}


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | n/a
| Docs PR or issue | https://github.com/contao/docs/pull/307

During my work for contao/docs#300 I stumbled over this.
The installation tool asks for the database connection, even if there is a connection set up via the `DATABASE_URL` variable in `.env`.

This happens if you have `symfony/website-skeleton ^3.4` as a base application and Contao 4.4.* installed on top as a bundle.

_Edit:_
It works in Contao 4.9, see https://github.com/contao/contao/commit/a2c25b4163ceecb0dfdf6db5fc7a9c47da1a3b4d.
