### PR TITLE
Dynamically configure the TokenChecker service

### DIFF
--- a/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
+++ b/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
@@ -24,6 +24,7 @@ use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 class ContaoCoreExtension extends Extension
@@ -88,6 +89,7 @@ class ContaoCoreExtension extends Extension
         $this->setPredefinedImageSizes($config, $container);
         $this->setImagineService($config, $container);
         $this->overwriteImageTargetDir($config, $container);
+        $this->handleTokenCheckerConfig($config, $container);
 
         $container
             ->registerForAutoconfiguration(PickerProviderInterface::class)
@@ -254,5 +256,19 @@ class ContaoCoreExtension extends Extension
         );
 
         @trigger_error('Using the "contao.image.target_path" parameter has been deprecated and will no longer work in Contao 5.0. Use the "contao.image.target_dir" parameter instead.', E_USER_DEPRECATED);
+    }
+
+    private function handleTokenCheckerConfig(array $config, ContainerBuilder $container): void
+    {
+        if (!$container->hasDefinition('contao.security.token_checker')) {
+            return;
+        }
+
+        $tokenChecker = $container->getDefinition('contao.security.token_checker');
+        $tokenChecker->replaceArgument(5, new Reference('security.access.simple_role_voter'));
+
+        if ($container->hasParameter('security.role_hierarchy.roles') && 0 < \count($container->getParameter('security.role_hierarchy.roles'))) {
+            $tokenChecker->replaceArgument(5, new Reference('security.access.role_hierarchy_voter'));
+        }
     }
 }

--- a/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
+++ b/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
@@ -267,7 +267,7 @@ class ContaoCoreExtension extends Extension
         $tokenChecker = $container->getDefinition('contao.security.token_checker');
         $tokenChecker->replaceArgument(5, new Reference('security.access.simple_role_voter'));
 
-        if ($container->hasParameter('security.role_hierarchy.roles') && 0 < \count($container->getParameter('security.role_hierarchy.roles'))) {
+        if ($container->hasParameter('security.role_hierarchy.roles') && \count($container->getParameter('security.role_hierarchy.roles')) > 0) {
             $tokenChecker->replaceArgument(5, new Reference('security.access.role_hierarchy_voter'));
         }
     }

--- a/core-bundle/src/Resources/config/services.yml
+++ b/core-bundle/src/Resources/config/services.yml
@@ -723,7 +723,7 @@ services:
             - '@security.token_storage'
             - '@session'
             - '@security.authentication.trust_resolver'
-            - '@security.access.simple_role_voter'
+            - ~ # Simple or Role Hierarchy Voter
             - '%contao.preview_script%'
         public: true
 


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | #1548
| Docs PR or issue | https://github.com/contao/docs/pull/307

With `role_hierarchy` configured in Symfony security `config/packages/security.yaml`, the `security.access.simple_role_voter` gets removed:

```                                                                                           
The service "contao.security.token_checker" has a dependency 
on a non-existent service "security.access.simple_role_voter".
```

See here:
https://github.com/symfony/symfony/blob/8397eb79e003c52b93339c34d9bcafe4848e82c2/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php#L165-L175
