### PR TITLE
Allow SVG images in favicons

### DIFF
--- a/core-bundle/src/Resources/contao/dca/tl_page.php
+++ b/core-bundle/src/Resources/contao/dca/tl_page.php
@@ -368,7 +368,7 @@ $GLOBALS['TL_DCA']['tl_page'] = array
 		(
 			'exclude'                 => true,
 			'inputType'               => 'fileTree',
-			'eval'                    => array('filesOnly'=>true, 'fieldType'=>'radio', 'extensions'=>'ico'),
+			'eval'                    => array('filesOnly'=>true, 'fieldType'=>'radio', 'extensions'=>'ico,svg'),
 			'sql'                     => "binary(16) NULL"
 		),
 		'robotsTxt' => array


### PR DESCRIPTION
Fixed restricting favicons to `.ico` only.
See https://caniuse.com/#feat=link-icon-svg