### PR TITLE
Consistently use "news feed" and "calendar feed" instead of "RSS feed"

### DIFF
--- a/calendar-bundle/src/Resources/contao/languages/en/tl_calendar.xlf
+++ b/calendar-bundle/src/Resources/contao/languages/en/tl_calendar.xlf
@@ -144,10 +144,10 @@
         <source>Delete calendar ID %s</source>
       </trans-unit>
       <trans-unit id="tl_calendar.feeds.0">
-        <source>RSS feeds</source>
+        <source>Calendar feeds</source>
       </trans-unit>
       <trans-unit id="tl_calendar.feeds.1">
-        <source>Manage RSS feeds</source>
+        <source>Manage calendar feeds</source>
       </trans-unit>
     </body>
   </file>

--- a/calendar-bundle/src/Resources/contao/languages/en/tl_user.xlf
+++ b/calendar-bundle/src/Resources/contao/languages/en/tl_user.xlf
@@ -15,13 +15,13 @@
         <source>Here you can define the calendar permissions.</source>
       </trans-unit>
       <trans-unit id="tl_user.calendarfeeds.0">
-        <source>Allowed RSS feeds</source>
+        <source>Allowed calendar feeds</source>
       </trans-unit>
       <trans-unit id="tl_user.calendarfeeds.1">
         <source>Here you can grant access to one or more calendar feeds.</source>
       </trans-unit>
       <trans-unit id="tl_user.calendarfeedp.0">
-        <source>RSS feed permissions</source>
+        <source>Calendar feed permissions</source>
       </trans-unit>
       <trans-unit id="tl_user.calendarfeedp.1">
         <source>Here you can define the calendar feed permissions.</source>

--- a/news-bundle/src/Resources/contao/languages/en/tl_news_archive.xlf
+++ b/news-bundle/src/Resources/contao/languages/en/tl_news_archive.xlf
@@ -144,10 +144,10 @@
         <source>Show comments of archive ID %s</source>
       </trans-unit>
       <trans-unit id="tl_news_archive.feeds.0">
-        <source>RSS feeds</source>
+        <source>News feeds</source>
       </trans-unit>
       <trans-unit id="tl_news_archive.feeds.1">
-        <source>Manage RSS feeds</source>
+        <source>Manage news feeds</source>
       </trans-unit>
     </body>
   </file>

--- a/news-bundle/src/Resources/contao/languages/en/tl_user.xlf
+++ b/news-bundle/src/Resources/contao/languages/en/tl_user.xlf
@@ -15,13 +15,13 @@
         <source>Here you can define the news permissions.</source>
       </trans-unit>
       <trans-unit id="tl_user.newsfeeds.0">
-        <source>Allowed RSS feeds</source>
+        <source>Allowed news feeds</source>
       </trans-unit>
       <trans-unit id="tl_user.newsfeeds.1">
         <source>Here you can grant access to one or more news feeds.</source>
       </trans-unit>
       <trans-unit id="tl_user.newsfeedp.0">
-        <source>RSS feed permissions</source>
+        <source>News feed permissions</source>
       </trans-unit>
       <trans-unit id="tl_user.newsfeedp.1">
         <source>Here you can define the news feed permissions.</source>


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #1474
| Docs PR or issue | -
