### PR TITLE
Limit the template choices to the theme in tl_module

### DIFF
--- a/calendar-bundle/src/Resources/contao/dca/tl_module.php
+++ b/calendar-bundle/src/Resources/contao/dca/tl_module.php
@@ -267,9 +267,9 @@ class tl_module_calendar extends Backend
 	 *
 	 * @return array
 	 */
-	public function getEventTemplates()
+	public function getEventTemplates(Contao\DataContainer $dc)
 	{
-		return $this->getTemplateGroup('event_');
+		return $this->getTemplateGroup('event_', $dc->activeRecord->pid);
 	}
 
 	/**
@@ -277,8 +277,8 @@ class tl_module_calendar extends Backend
 	 *
 	 * @return array
 	 */
-	public function getCalendarTemplates()
+	public function getCalendarTemplates(Contao\DataContainer $dc)
 	{
-		return $this->getTemplateGroup('cal_');
+		return $this->getTemplateGroup('cal_', $dc->activeRecord->pid);
 	}
 }

--- a/comments-bundle/src/Resources/contao/dca/tl_module.php
+++ b/comments-bundle/src/Resources/contao/dca/tl_module.php
@@ -81,12 +81,12 @@ $GLOBALS['TL_DCA']['tl_module']['fields']['com_template'] = array
 class tl_module_comments extends Backend
 {
 	/**
-	 * Return all navigation templates as array
+	 * Return all comment templates as array
 	 *
 	 * @return array
 	 */
-	public function getCommentTemplates()
+	public function getCommentTemplates(Contao\DataContainer $dc)
 	{
-		return $this->getTemplateGroup('com_');
+		return $this->getTemplateGroup('com_', $dc->activeRecord->pid);
 	}
 }

--- a/core-bundle/src/Resources/contao/dca/tl_module.php
+++ b/core-bundle/src/Resources/contao/dca/tl_module.php
@@ -896,21 +896,19 @@ class tl_module extends Backend
 	 *
 	 * @return array
 	 */
-	public function getNavigationTemplates()
+	public function getNavigationTemplates(Contao\DataContainer $dc)
 	{
-		return $this->getTemplateGroup('nav_');
+		return $this->getTemplateGroup('nav_', $dc->activeRecord->pid);
 	}
 
 	/**
 	 * Return all module templates as array
 	 *
-	 * @param DataContainer $dc
-	 *
 	 * @return array
 	 */
-	public function getModuleTemplates(DataContainer $dc)
+	public function getModuleTemplates(Contao\DataContainer $dc)
 	{
-		return $this->getTemplateGroup('mod_' . $dc->activeRecord->type);
+		return $this->getTemplateGroup('mod_' . $dc->activeRecord->type, $dc->activeRecord->pid);
 	}
 
 	/**
@@ -918,9 +916,9 @@ class tl_module extends Backend
 	 *
 	 * @return array
 	 */
-	public function getMemberTemplates()
+	public function getMemberTemplates(Contao\DataContainer $dc)
 	{
-		return $this->getTemplateGroup('member_');
+		return $this->getTemplateGroup('member_', $dc->activeRecord->pid);
 	}
 
 	/**
@@ -928,9 +926,9 @@ class tl_module extends Backend
 	 *
 	 * @return array
 	 */
-	public function getSearchTemplates()
+	public function getSearchTemplates(Contao\DataContainer $dc)
 	{
-		return $this->getTemplateGroup('search_');
+		return $this->getTemplateGroup('search_', $dc->activeRecord->pid);
 	}
 
 	/**
@@ -938,9 +936,9 @@ class tl_module extends Backend
 	 *
 	 * @return array
 	 */
-	public function getRssTemplates()
+	public function getRssTemplates(Contao\DataContainer $dc)
 	{
-		return $this->getTemplateGroup('rss_');
+		return $this->getTemplateGroup('rss_', $dc->activeRecord->pid);
 	}
 
 	/**

--- a/core-bundle/src/Resources/contao/library/Contao/Controller.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Controller.php
@@ -85,11 +85,12 @@ abstract class Controller extends \System
 	/**
 	 * Return all template files of a particular group as array
 	 *
-	 * @param string $strPrefix The template name prefix (e.g. "ce_")
+	 * @param string  $strPrefix The template name prefix (e.g. "ce_")
+	 * @param integer $intTheme  An optional theme ID
 	 *
 	 * @return array An array of template names
 	 */
-	public static function getTemplateGroup($strPrefix)
+	public static function getTemplateGroup($strPrefix, $intTheme=0)
 	{
 		$arrTemplates = array();
 
@@ -118,7 +119,14 @@ abstract class Controller extends \System
 			// Try to select the themes (see #5210)
 			try
 			{
-				$objTheme = \ThemeModel::findAll(array('order'=>'name'));
+				if ($intTheme > 0)
+				{
+					$objTheme = ThemeModel::findByPk($intTheme, array('return'=>'Collection'));
+				}
+				else
+				{
+					$objTheme = ThemeModel::findAll(array('order'=>'name'));
+				}
 			}
 			catch (\Exception $e)
 			{

--- a/listing-bundle/src/Resources/contao/dca/tl_module.php
+++ b/listing-bundle/src/Resources/contao/dca/tl_module.php
@@ -120,9 +120,9 @@ class tl_module_listing extends Backend
 	 *
 	 * @return array
 	 */
-	public function getListTemplates()
+	public function getListTemplates(Contao\DataContainer $dc)
 	{
-		return $this->getTemplateGroup('list_');
+		return $this->getTemplateGroup('list_', $dc->activeRecord->pid);
 	}
 
 	/**
@@ -130,8 +130,8 @@ class tl_module_listing extends Backend
 	 *
 	 * @return array
 	 */
-	public function getInfoTemplates()
+	public function getInfoTemplates(Contao\DataContainer $dc)
 	{
-		return $this->getTemplateGroup('info_');
+		return $this->getTemplateGroup('info_', $dc->activeRecord->pid);
 	}
 }

--- a/news-bundle/src/Resources/contao/dca/tl_module.php
+++ b/news-bundle/src/Resources/contao/dca/tl_module.php
@@ -232,8 +232,8 @@ class tl_module_news extends Backend
 	 *
 	 * @return array
 	 */
-	public function getNewsTemplates()
+	public function getNewsTemplates(Contao\DataContainer $dc)
 	{
-		return $this->getTemplateGroup('news_');
+		return $this->getTemplateGroup('news_', $dc->activeRecord->pid);
 	}
 }

--- a/newsletter-bundle/src/Resources/contao/dca/tl_module.php
+++ b/newsletter-bundle/src/Resources/contao/dca/tl_module.php
@@ -172,8 +172,8 @@ class tl_module_newsletter extends Backend
 	 *
 	 * @return array
 	 */
-	public function getNewsletterTemplates()
+	public function getNewsletterTemplates(Contao\DataContainer $dc)
 	{
-		return $this->getTemplateGroup('nl_');
+		return $this->getTemplateGroup('nl_', $dc->activeRecord->pid);
 	}
 }


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #737
| Docs PR or issue | -

Since `tl_theme` is the parent table of `tl_module`, we can limit the templates returned by the `getTemplateGroup()` method to the respective theme.

We could probably do the same for content elements in articles, news etc., although this would involve a lot more DB queries (CE -> news -> news archive -> jumpTo -> page -> layout -> theme). I am not sure whether it is worth the effort though. @contao/developers WDYT?