### PR TITLE
Fix the preview bar alignment

### DIFF
--- a/core-bundle/src/Resources/views/Frontend/preview_toolbar_base.html.twig
+++ b/core-bundle/src/Resources/views/Frontend/preview_toolbar_base.html.twig
@@ -28,3 +28,4 @@
     </form>
     <div class="cto-toolbar__close"><a href="#" title="{{ 'MSC.close'|trans }}">&times;</a></div>
 </div>
+<div class="cto-toolbar__clear"></div>

--- a/core-bundle/src/Resources/views/Frontend/preview_toolbar_base_js.html.twig
+++ b/core-bundle/src/Resources/views/Frontend/preview_toolbar_base_js.html.twig
@@ -5,41 +5,81 @@
         font-size: 14px;
         line-height: 1;
         color: #444;
+    }
+
+    @media (-webkit-min-device-pixel-ratio:2),(min-resolution:192dpi) {
+        .cto-toolbar {
+            font-weight: 300;
+            color: #222;
+        }
+    }
+
+    .cto-toolbar__open {
+        width: 36px;
+        height: 36px;
+        position: fixed;
+        right: 0;
+        background: #222;
+        border-radius: 0 0 0 4px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+
+    .cto-toolbar--visible .cto-toolbar__open {
+        display: none;
+    }
+
+    .cto-toolbar__open a {
+        opacity: .7;
+    }
+
+    .cto-toolbar__inside {
+        display: grid;
+        grid-template: auto / 1fr auto;
+        width: 100%;
         background: #f2f2f2;
-        overflow: hidden;
-        position: -webkit-sticky;
-        position: sticky;
+        position: fixed;
         top: 0;
         z-index: 99999;
         border-bottom: 1px solid #ccc;
     }
 
-    @media (-webkit-min-device-pixel-ratio:2),(min-resolution:192dpi) {
-        .cto-toolbar {
-            color: #222;
-            font-weight: 300;
-        }
+    .cto-toolbar--hidden .cto-toolbar__inside {
+        display: none;
+    }
+
+    .cto-toolbar__close {
+        border-left: 1px solid #ccc;
+    }
+
+    .cto-toolbar__close a {
+        font-weight: 600;
+        font-size: 29px;
+        color: #444;
+        text-decoration: none;
+        display: block;
+        padding: 3px 8px 7px 9px;
+    }
+
+    .cto-toolbar__close a:hover {
+        color: #666;
+        background: rgba(0, 0, 0, 0.03);
+    }
+
+    .cto-toolbar__clear {
+        height: 40px;
+        display: none;
+    }
+
+    .cto-toolbar--visible .cto-toolbar__clear {
+        display: block;
     }
 
     .cto-toolbar input, .cto-toolbar select, .cto-toolbar button {
         font: inherit;
         color: inherit;
         line-height: 18px;
-    }
-
-    .cto-toolbar__inside {
-        display: grid;
-        grid-template: auto / 1fr auto;
-    }
-
-    .cto-toolbar--hidden {
-        position: fixed;
-        right: 0;
-        border: none;
-    }
-
-    .cto-toolbar--hidden .cto-toolbar__inside {
-        display: none;
     }
 
     .cto-toolbar.ajax-loading .formbody {
@@ -132,47 +172,6 @@
 
     .cto-toolbar .tl_submit:active {
         color: #aaa;
-    }
-
-    .cto-toolbar__open {
-        display: none;
-        width: 36px;
-        height: 36px;
-        background: #222;
-    }
-
-    .cto-toolbar__open a {
-        display: flex;
-        height: 100%;
-        align-items: center;
-        justify-content: center;
-        opacity: .7;
-    }
-
-    .cto-toolbar--hidden {
-        border-radius: 0 0 0 4px;
-    }
-
-    .cto-toolbar--hidden .cto-toolbar__open {
-        display: block;
-    }
-
-    .cto-toolbar__close {
-        border-left: 1px solid #ccc;
-    }
-
-    .cto-toolbar__close a {
-        font-weight: 600;
-        font-size: 29px;
-        color: #444;
-        text-decoration: none;
-        display: block;
-        padding: 3px 8px 7px 9px;
-    }
-
-    .cto-toolbar__close a:hover {
-        color: #666;
-        background: rgba(0, 0, 0, 0.03);
     }
 </style>
 <script>


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #1428
| Docs PR or issue | -

As discussed in #1428, this PR uses `position: fixed` instead of `position: sticky` and a `.cto-toolbar__clear` element that provides the necessary space on top of the page.