### PR TITLE
Show "-" if the device family is "Other"

### DIFF
--- a/core-bundle/src/Entity/TrustedDevice.php
+++ b/core-bundle/src/Entity/TrustedDevice.php
@@ -148,6 +148,10 @@ class TrustedDevice
 
     public function getDeviceFamily(): ?string
     {
+        if ('Other' === $this->deviceFamily) {
+            return '-';
+        }
+
         return $this->deviceFamily;
     }
 


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #1363
| Docs PR or issue | -

Not sure if that is the best place to "fix" this though. We could also change it in the templates only.