### PR TITLE
Load the CSS framework after the style sheets

### DIFF
--- a/core-bundle/src/Resources/contao/templates/frontend/fe_page.html5
+++ b/core-bundle/src/Resources/contao/templates/frontend/fe_page.html5
@@ -14,8 +14,8 @@
     <?php $this->endblock(); ?>
 
     <?= $this->viewport ?>
-    <?= $this->framework ?>
     <?= $this->stylesheets ?>
+    <?= $this->framework ?>
     <?= $this->mooScripts ?>
     <?= $this->head ?>
   <?php $this->endblock(); ?>


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #1314
| Docs PR or issue | -

The fact that no one noticed this for such a long time shows that most people do not use the layout builder anymore (which is good, because it is old and deprecated in favor of a yet to be developed grid/flex solution).
