### PR TITLE
Explanation text tl_page.guests.1

### DIFF
--- a/core-bundle/src/Resources/contao/languages/en/tl_page.xlf
+++ b/core-bundle/src/Resources/contao/languages/en/tl_page.xlf
@@ -222,7 +222,7 @@
         <source>Show to guests only</source>
       </trans-unit>
       <trans-unit id="tl_page.guests.1">
-        <source>Hide the page if there is an authenticated user.</source>
+        <source>Hide the page if a member is logged in.</source>
       </trans-unit>
       <trans-unit id="tl_page.tabindex.0">
         <source>Tab index</source>


### PR DESCRIPTION
Correct user to member and adapt the wording to other elements (e.g. article, content).