### PR TITLE
Change how to count records in RobotsTxtListener

### DIFF
--- a/core-bundle/src/EventListener/RobotsTxtListener.php
+++ b/core-bundle/src/EventListener/RobotsTxtListener.php
@@ -45,7 +45,7 @@ class RobotsTxtListener
         // Get all directives for user-agent: *
         $directiveList = $inspector->getDirectives();
 
-        // If no directive for user-agent: * exists, we add the user-agent directive
+        // If no directive for user-agent: * exists, we add the record
         if (0 === $directiveList->getLength()) {
             $record = new Record();
 

--- a/core-bundle/src/EventListener/RobotsTxtListener.php
+++ b/core-bundle/src/EventListener/RobotsTxtListener.php
@@ -16,6 +16,7 @@ use Contao\CoreBundle\Event\RobotsTxtEvent;
 use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\PageModel;
 use webignition\RobotsTxt\Directive\Directive;
+use webignition\RobotsTxt\Directive\UserAgentDirective;
 use webignition\RobotsTxt\Inspector\Inspector;
 use webignition\RobotsTxt\Record\Record;
 
@@ -39,11 +40,18 @@ class RobotsTxtListener
         $this->contaoFramework->initialize();
 
         $file = $event->getFile();
+        $inspector = new Inspector($file, '*');
 
-        // If no directive for user-agent: * exists, we add the record
-        if (0 === count($file->getRecords())) {
+        // Get all directives for user-agent: *
+        $directiveList = $inspector->getDirectives();
+
+        // If no directive for user-agent: * exists, we add the user-agent directive
+        if (0 === $directiveList->getLength()) {
             $record = new Record();
-            $this->addContaoDisallowDirectivesToRecord($record);
+
+            $userAgentDirectiveList = $record->getUserAgentDirectiveList();
+            $userAgentDirectiveList->add(new UserAgentDirective('*'));
+
             $file->addRecord($record);
         }
 

--- a/core-bundle/src/EventListener/RobotsTxtListener.php
+++ b/core-bundle/src/EventListener/RobotsTxtListener.php
@@ -39,13 +39,9 @@ class RobotsTxtListener
         $this->contaoFramework->initialize();
 
         $file = $event->getFile();
-        $inspector = new Inspector($file);
-
-        // Get all directives for user-agent: *
-        $directiveList = $inspector->getDirectives();
 
         // If no directive for user-agent: * exists, we add the record
-        if (0 === $directiveList->getLength()) {
+        if (0 === count($file->getRecords())) {
             $record = new Record();
             $this->addContaoDisallowDirectivesToRecord($record);
             $file->addRecord($record);

--- a/core-bundle/src/EventListener/RobotsTxtListener.php
+++ b/core-bundle/src/EventListener/RobotsTxtListener.php
@@ -58,7 +58,8 @@ class RobotsTxtListener
         $records = $file->getRecords();
 
         foreach ($records as $record) {
-            $this->addContaoDisallowDirectivesToRecord($record);
+            $directiveList = $record->getDirectiveList();
+            $directiveList->add(new Directive('Disallow', '/contao/'));
         }
 
         /** @var PageModel $pageModel */
@@ -80,11 +81,5 @@ class RobotsTxtListener
 
             $event->getFile()->getNonGroupDirectives()->add(new Directive('Sitemap', $sitemap));
         }
-    }
-
-    private function addContaoDisallowDirectivesToRecord(Record $record): void
-    {
-        $directiveList = $record->getDirectiveList();
-        $directiveList->add(new Directive('Disallow', '/contao/'));
     }
 }

--- a/core-bundle/tests/EventListener/RobotsTxtListenerTest.php
+++ b/core-bundle/tests/EventListener/RobotsTxtListenerTest.php
@@ -43,14 +43,14 @@ class RobotsTxtListenerTest extends TestCase
 
         $pageModelAdapter = $this->mockAdapter(['findPublishedRootPages']);
         $pageModelAdapter
-            ->expects($this->once())
+            ->expects($this->exactly(2))
             ->method('findPublishedRootPages')
             ->willReturn([$rootPage, $otherRootPage])
         ;
 
         $framework = $this->mockContaoFramework([PageModel::class => $pageModelAdapter]);
         $framework
-            ->expects($this->once())
+            ->expects($this->exactly(2))
             ->method('initialize')
         ;
 
@@ -61,6 +61,9 @@ class RobotsTxtListenerTest extends TestCase
         $event = new RobotsTxtEvent($file, new Request(), $rootPage);
 
         $listener = new RobotsTxtListener($framework);
+        $listener($event);
+
+        // Output should be the same, if there is another listener
         $listener($event);
 
         $this->assertSame($expectedRobotsTxt, (string) $event->getFile());


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | -
| Docs PR or issue | Related to https://github.com/contao/docs/pull/322

While working on an example for https://github.com/contao/docs/pull/322 I noticed a possible problem within the current `RobotsTxtListener` of Contao. No matter what I tried, the resulting `robots.txt` was always

```
user-agent:*
disallow:/foo/
disallow:/contao/

user-agent:*
disallow:/contao/
```

instead of

```
user-agent:*
disallow:/foo/
disallow:/contao/
```

when using the following `App\EventListener\RobotsTxtListener`:

```php
// src/EventListener/RobotsTxtListener.php
namespace App\EventListener;

use Contao\CoreBundle\Event\ContaoCoreEvents;
use Contao\CoreBundle\Event\RobotsTxtEvent;
use Terminal42\ServiceAnnotationBundle\Annotation\ServiceTag;
use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
use webignition\RobotsTxt\Directive\Directive;
use webignition\RobotsTxt\Record\Record;

/**
 * @ServiceTag("kernel.event_listener", event=ContaoCoreEvents::ROBOTS_TXT)
 */
class RobotsTxtListener implements ServiceAnnotationInterface
{
    public function __invoke(RobotsTxtEvent $event): void
    {
        $file = $event->getFile();

        // If no directive for user-agent: * exists, we add the record
        if (0 === count($file->getRecords())) {
            $record = new Record();
            $this->addDirectivesToRecord($record);
            $file->addRecord($record);
        }

        foreach ($file->getRecords() as $record) {
            $this->addDirectivesToRecord($record);
        }
    }

    private function addDirectivesToRecord(Record $record): void
    {
        $directiveList = $record->getDirectiveList();
        $directiveList->add(new Directive('Disallow', '/foo/'));
    }
}
```

The `App\EventListener\RobotsTxtListener` is actually executed before the `Contao\CoreBundle\EventListener\RobotsTxtListener` (when using no priority setting). So, even though `App\EventListener\RobotsTxtListener` already added a record, the following check still holds true:

https://github.com/contao/contao/blob/7de5fddec93c9a575166296da06e40a5f3e1c9b9/core-bundle/src/EventListener/RobotsTxtListener.php#L42-L52

This PR simply counts the returned records directly - but may be I am overlooking something here.