### PR TITLE
Fix the picker in the meta wizard

### DIFF
--- a/core-bundle/src/Resources/contao/widgets/MetaWizard.php
+++ b/core-bundle/src/Resources/contao/widgets/MetaWizard.php
@@ -20,6 +20,11 @@ namespace Contao;
 class MetaWizard extends Widget
 {
 	/**
+	 * @var int
+	 */
+	private static $rowCount = 0;
+
+	/**
 	 * Submit user input
 	 * @var boolean
 	 */
@@ -139,19 +144,17 @@ class MetaWizard extends Widget
 			foreach ($this->varValue as $lang=>$meta)
 			{
 				$return .= '
-    <li class="' . (($count % 2 == 0) ? 'even' : 'odd') . '" data-language="' . $lang . '">';
-
-				$return .= '<span class="lang">' . ($languages[$lang] ?? $lang) . ' ' . Image::getHtml('delete.svg', '', 'class="tl_metawizard_img" title="' . $GLOBALS['TL_LANG']['MSC']['delete'] . '" onclick="Backend.metaDelete(this)"') . '</span>';
+    <li class="' . (($count % 2 == 0) ? 'even' : 'odd') . '" data-language="' . $lang . '"><span class="lang">' . ($languages[$lang] ?? $lang) . ' ' . Image::getHtml('delete.svg', '', 'class="tl_metawizard_img" title="' . $GLOBALS['TL_LANG']['MSC']['delete'] . '" onclick="Backend.metaDelete(this)"') . '</span>';
 
 				// Take the fields from the DCA (see #4327)
 				foreach ($this->metaFields as $field=>$fieldConfig)
 				{
-					$return .= '<label for="ctrl_' . $field . '_' . $count . '">' . $GLOBALS['TL_LANG']['MSC']['aw_' . $field] . '</label> <input type="text" name="' . $this->strId . '[' . $lang . '][' . $field . ']" id="ctrl_' . $field . '_' . $count . '" class="tl_text" value="' . StringUtil::specialchars($meta[$field]) . '"' . (!empty($fieldConfig['attributes']) ? ' ' . $fieldConfig['attributes'] : '') . '>';
+					$return .= '<label for="ctrl_' . $field . '_' . self::$rowCount . '">' . $GLOBALS['TL_LANG']['MSC']['aw_' . $field] . '</label> <input type="text" name="' . $this->strId . '[' . $lang . '][' . $field . ']" id="ctrl_' . $field . '_' . self::$rowCount . '" class="tl_text" value="' . StringUtil::specialchars($meta[$field]) . '"' . (!empty($fieldConfig['attributes']) ? ' ' . $fieldConfig['attributes'] : '') . '>';
 
 					// DCA picker
 					if (isset($fieldConfig['dcaPicker']) && (\is_array($fieldConfig['dcaPicker']) || $fieldConfig['dcaPicker'] === true))
 					{
-						$return .= Backend::getDcaPickerWizard($fieldConfig['dcaPicker'], $this->strTable, $this->strField, $field . '_' . $count);
+						$return .= Backend::getDcaPickerWizard($fieldConfig['dcaPicker'], $this->strTable, $this->strField, $field . '_' . self::$rowCount);
 					}
 
 					$return .= '<br>';
@@ -161,6 +164,7 @@ class MetaWizard extends Widget
     </li>';
 
 				++$count;
+				++self::$rowCount;
 			}
 
 			$return .= '

--- a/core-bundle/src/Resources/contao/widgets/MetaWizard.php
+++ b/core-bundle/src/Resources/contao/widgets/MetaWizard.php
@@ -20,11 +20,6 @@ namespace Contao;
 class MetaWizard extends Widget
 {
 	/**
-	 * @var int
-	 */
-	private static $rowCount = 0;
-
-	/**
 	 * Submit user input
 	 * @var boolean
 	 */
@@ -149,12 +144,12 @@ class MetaWizard extends Widget
 				// Take the fields from the DCA (see #4327)
 				foreach ($this->metaFields as $field=>$fieldConfig)
 				{
-					$return .= '<label for="ctrl_' . $field . '_' . self::$rowCount . '">' . $GLOBALS['TL_LANG']['MSC']['aw_' . $field] . '</label> <input type="text" name="' . $this->strId . '[' . $lang . '][' . $field . ']" id="ctrl_' . $field . '_' . self::$rowCount . '" class="tl_text" value="' . StringUtil::specialchars($meta[$field]) . '"' . (!empty($fieldConfig['attributes']) ? ' ' . $fieldConfig['attributes'] : '') . '>';
+					$return .= '<label for="ctrl_' . $this->strId . '_' . $field . '_' . $count . '">' . $GLOBALS['TL_LANG']['MSC']['aw_' . $field] . '</label> <input type="text" name="' . $this->strId . '[' . $lang . '][' . $field . ']" id="ctrl_' . $this->strId . '_' . $field . '_' . $count . '" class="tl_text" value="' . StringUtil::specialchars($meta[$field]) . '"' . (!empty($fieldConfig['attributes']) ? ' ' . $fieldConfig['attributes'] : '') . '>';
 
 					// DCA picker
 					if (isset($fieldConfig['dcaPicker']) && (\is_array($fieldConfig['dcaPicker']) || $fieldConfig['dcaPicker'] === true))
 					{
-						$return .= Backend::getDcaPickerWizard($fieldConfig['dcaPicker'], $this->strTable, $this->strField, $field . '_' . self::$rowCount);
+						$return .= Backend::getDcaPickerWizard($fieldConfig['dcaPicker'], $this->strTable, $this->strField,  $this->strId . '_' . $field . '_' . $count);
 					}
 
 					$return .= '<br>';
@@ -164,7 +159,6 @@ class MetaWizard extends Widget
     </li>';
 
 				++$count;
-				++self::$rowCount;
 			}
 
 			$return .= '

--- a/core-bundle/src/Resources/contao/widgets/MetaWizard.php
+++ b/core-bundle/src/Resources/contao/widgets/MetaWizard.php
@@ -149,7 +149,7 @@ class MetaWizard extends Widget
 					// DCA picker
 					if (isset($fieldConfig['dcaPicker']) && (\is_array($fieldConfig['dcaPicker']) || $fieldConfig['dcaPicker'] === true))
 					{
-						$return .= Backend::getDcaPickerWizard($fieldConfig['dcaPicker'], $this->strTable, $this->strField,  $this->strId . '_' . $field . '_' . $count);
+						$return .= Backend::getDcaPickerWizard($fieldConfig['dcaPicker'], $this->strTable, $this->strField, $this->strId . '_' . $field . '_' . $count);
 					}
 
 					$return .= '<br>';


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #1403
| Docs PR or issue | -

Use a static row count in the meta wizard so the link picker works in "edit multiple" mode and there are no duplicate ID attributes such as `link_0`.