### PR TITLE
Handle the "toggle nodes" command in the main back end method

### DIFF
--- a/core-bundle/src/Resources/contao/classes/BackendUser.php
+++ b/core-bundle/src/Resources/contao/classes/BackendUser.php
@@ -10,7 +10,6 @@
 
 namespace Contao;
 
-use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 
@@ -485,23 +484,11 @@ class BackendUser extends User
 	 */
 	public function navigation($blnShowAll=false)
 	{
-		/** @var AttributeBagInterface $objSessionBag */
-		$objSessionBag = System::getContainer()->get('session')->getBag('contao_backend');
-
 		/** @var RouterInterface $router */
 		$router = System::getContainer()->get('router');
 
 		$arrModules = array();
-		$session = $objSessionBag->all();
-
-		// Toggle nodes
-		if (Input::get('mtg'))
-		{
-			$session['backend_modules'][Input::get('mtg')] = (isset($session['backend_modules'][Input::get('mtg')]) && $session['backend_modules'][Input::get('mtg')] == 0) ? 1 : 0;
-			$objSessionBag->replace($session);
-			Controller::redirect(preg_replace('/(&(amp;)?|\?)mtg=[^& ]*/i', '', Environment::get('request')));
-		}
-
+		$arrStatus = System::getContainer()->get('session')->getBag('contao_backend')->get('backend_modules');
 		$strRefererId = System::getContainer()->get('request_stack')->getCurrentRequest()->attributes->get('_contao_referer_id');
 
 		foreach ($GLOBALS['BE_MOD'] as $strGroupName=>$arrGroupModules)
@@ -549,7 +536,7 @@ class BackendUser extends User
 			$arrModules[$strGroupName]['isClosed'] = false;
 
 			// Do not show the modules if the group is closed
-			if (!$blnShowAll && isset($session['backend_modules'][$strGroupName]) && $session['backend_modules'][$strGroupName] < 1)
+			if (!$blnShowAll && isset($arrStatus[$strGroupName]) && $arrStatus[$strGroupName] < 1)
 			{
 				$arrModules[$strGroupName]['class'] = str_replace('node-expanded', '', $arrModules[$strGroupName]['class']) . ' node-collapsed';
 				$arrModules[$strGroupName]['title'] = StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['expandNode']);

--- a/core-bundle/src/Resources/contao/controllers/BackendMain.php
+++ b/core-bundle/src/Resources/contao/controllers/BackendMain.php
@@ -14,6 +14,7 @@ use Contao\CoreBundle\Exception\AccessDeniedException;
 use Contao\CoreBundle\Util\PackageUtil;
 use Knp\Bundle\TimeBundle\DateTimeFormatter;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
 /**
@@ -123,8 +124,19 @@ class BackendMain extends Backend
 			$this->objAjax->executePreActions();
 		}
 
+		// Toggle nodes
+		if (Input::get('mtg'))
+		{
+			/** @var AttributeBagInterface $objSessionBag */
+			$objSessionBag = System::getContainer()->get('session')->getBag('contao_backend');
+			$session = $objSessionBag->all();
+			$session['backend_modules'][Input::get('mtg')] = (isset($session['backend_modules'][Input::get('mtg')]) && $session['backend_modules'][Input::get('mtg')] == 0) ? 1 : 0;
+			$objSessionBag->replace($session);
+
+			Controller::redirect(preg_replace('/(&(amp;)?|\?)mtg=[^& ]*/i', '', Environment::get('request')));
+		}
 		// Error
-		if (Input::get('act') == 'error')
+		elseif (Input::get('act') == 'error')
 		{
 			$this->Template->error = $GLOBALS['TL_LANG']['ERR']['general'];
 			$this->Template->title = $GLOBALS['TL_LANG']['ERR']['general'];


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #1565
| Docs PR or issue | -

Instead of throwing a redirect exception while building the back end menu, which cannot be handled by the Twig function `knp_menu_render()`, we now handle the "toggle nodes" redirect in the main back end method before rendering anything.
