### PR TITLE
Also add z-index to the .cto-toolbar__open element

### DIFF
--- a/core-bundle/src/Resources/views/Frontend/preview_toolbar_base_js.html.twig
+++ b/core-bundle/src/Resources/views/Frontend/preview_toolbar_base_js.html.twig
@@ -24,6 +24,7 @@
         display: flex;
         align-items: center;
         justify-content: center;
+        z-index: 99999;
     }
 
     .cto-toolbar--visible .cto-toolbar__open {


### PR DESCRIPTION
Otherwise the "open" button will disappear if the front end has a fixed or absolute positioned header. `.cto-toolbar__inside` already has `z-index: 99999`.