### PR TITLE
Allow stripping query parameters in the reverse proxy

### DIFF
--- a/core-bundle/tests/EventListener/HttpCache/StripCookiesSubscriberTest.php
+++ b/core-bundle/tests/EventListener/HttpCache/StripCookiesSubscriberTest.php
@@ -31,12 +31,13 @@ class StripCookiesSubscriberTest extends TestCase
     /**
      * @dataProvider cookiesProvider
      */
-    public function testCookiesAreStrippedCorrectly(array $cookies, array $expectedCookies, array $whitelist = []): void
+    public function testCookiesAreStrippedCorrectly(array $cookies, array $expectedCookies, array $whitelist = [], array $disabledFromBlacklist = []): void
     {
         $request = Request::create('/', 'GET', [], $cookies);
         $event = new CacheEvent($this->createMock(CacheInvalidation::class), $request);
 
         $subscriber = new StripCookiesSubscriber($whitelist);
+        $subscriber->disableFromBlacklist($disabledFromBlacklist);
         $subscriber->preHandle($event);
 
         $this->assertSame($expectedCookies, $request->cookies->all());
@@ -63,6 +64,13 @@ class StripCookiesSubscriberTest extends TestCase
             ['PHPSESSID' => 'foobar', '_gac_58168352' => 'value'],
             ['PHPSESSID' => 'foobar'],
             ['PHPSESSID'],
+        ];
+
+        yield [
+            ['PHPSESSID' => 'foobar', '_ga' => 'value', '_pk_ref' => 'value', '_pk_hsr' => 'value'],
+            ['PHPSESSID' => 'foobar', '_ga' => 'value'],
+            [],
+            ['_ga'],
         ];
     }
 }

--- a/core-bundle/tests/EventListener/HttpCache/StripQueryParametersSubscriberTest.php
+++ b/core-bundle/tests/EventListener/HttpCache/StripQueryParametersSubscriberTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\EventListener\HttpCache;
+
+use Contao\CoreBundle\EventListener\HttpCache\StripQueryParametersSubscriber;
+use FOS\HttpCache\SymfonyCache\CacheEvent;
+use FOS\HttpCache\SymfonyCache\CacheInvalidation;
+use FOS\HttpCache\SymfonyCache\Events;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+class StripQueryParametersSubscriberTest extends TestCase
+{
+    public function testSubscribedEvents(): void
+    {
+        $subscriber = new StripQueryParametersSubscriber();
+
+        $this->assertSame([Events::PRE_HANDLE => 'preHandle'], $subscriber::getSubscribedEvents());
+    }
+
+    /**
+     * @dataProvider queryParametersProvider
+     */
+    public function testQueryParametersAreStrippedCorrectly(array $parameters, array $expectedParameters, array $whitelist = [], array $disabledFromBlacklist = []): void
+    {
+        $request = Request::create('/', 'GET', $parameters);
+        $event = new CacheEvent($this->createMock(CacheInvalidation::class), $request);
+
+        $subscriber = new StripQueryParametersSubscriber($whitelist);
+        $subscriber->disableFromBlacklist($disabledFromBlacklist);
+        $subscriber->preHandle($event);
+
+        $this->assertSame($expectedParameters, $request->query->all());
+    }
+
+    public function queryParametersProvider(): \Generator
+    {
+        yield [
+            ['page' => 42, 'query' => 'foobar'],
+            ['page' => 42, 'query' => 'foobar'],
+        ];
+
+        yield [
+            ['page' => 42, 'query' => 'foobar', 'gclid' => 'EAIaIQobChMIgrbRrZLH6AIVl6F7Ch2NMQCxEAEYASAAEgLjlPD_BwE'],
+            ['page' => 42, 'query' => 'foobar'],
+        ];
+
+        yield [
+            ['page' => 42, 'query' => 'foobar', 'utm_source' => 'twitter'],
+            ['page' => 42, 'query' => 'foobar'],
+        ];
+
+        yield [
+            ['page' => 42, 'query' => 'foobar', 'utm_source' => 'twitter'],
+            ['page' => 42],
+            ['page'],
+        ];
+
+        yield [
+            ['page' => 42, 'gclid' => 'EAIaIQobChMIgrbRrZLH6AIVl6F7Ch2NMQCxEAEYASAAEgLjlPD_BwE', 'utm_source' => 'twitter'],
+            ['page' => 42, 'utm_source' => 'twitter'],
+            [],
+            ['utm_[a-z]+'],
+        ];
+    }
+}


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | -
| Docs PR or issue | TODO once merged

This PR will allow to strip query parameters that are not required for the application but only for e.g. some tracking tools in the front end. It increases the cache hit rate and prevents these parameters from flooding the cache.

While implementing this I thought there's also the use case where people trust the Contao developers to maintain a proper blacklist but only need one exception to that. Like e.g. you need the `utm_*` parameters in PHP but you don't want to whitelist all of the allowed query parameters.
Same might apply for cookies so I unified that :) 