### PR TITLE
Fix the wrong CSRF token storage being wired

### DIFF
--- a/core-bundle/src/Resources/config/services.yml
+++ b/core-bundle/src/Resources/config/services.yml
@@ -110,6 +110,7 @@ services:
     Contao\CoreBundle\Controller\FrontendController:
         tags:
             - controller.service_arguments
+            - { name: 'container.service_subscriber', id: 'contao.csrf.token_manager' }
 
     Contao\CoreBundle\Controller\FrontendModule\TwoFactorController:
         tags:

--- a/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
+++ b/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
@@ -1305,6 +1305,9 @@ class ContaoCoreExtensionTest extends TestCase
                 'controller.service_arguments' => [
                     [],
                 ],
+                'container.service_subscriber' => [
+                    ['id' => 'contao.csrf.token_manager'],
+                ],
             ],
             $definition->getTags()
         );


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes https://github.com/contao/contao/issues/1491
| Docs PR or issue | -

If not specified explicitly, Symfony will autowire to the default CSRF token storage which is the session one :) 