### PR TITLE
Verify TOTP with a window of 1 for better UX

### DIFF
--- a/core-bundle/src/Security/TwoFactor/Authenticator.php
+++ b/core-bundle/src/Security/TwoFactor/Authenticator.php
@@ -26,11 +26,11 @@ class Authenticator
     /**
      * Validates the code which was entered by the user.
      */
-    public function validateCode(User $user, string $code): bool
+    public function validateCode(User $user, string $code, ?int $timestamp = null): bool
     {
         $totp = TOTP::create($this->getUpperUnpaddedSecretForUser($user));
 
-        return $totp->verify($code);
+        return $totp->verify($code, $timestamp, 1);
     }
 
     /**

--- a/core-bundle/tests/Security/TwoFactor/AuthenticatorTest.php
+++ b/core-bundle/tests/Security/TwoFactor/AuthenticatorTest.php
@@ -37,6 +37,25 @@ class AuthenticatorTest extends TestCase
         $this->assertFalse($authenticator->validateCode($user, 'foobar'));
     }
 
+    public function testValidatesTheCodeOfPreviousWindow(): void
+    {
+        $secret = random_bytes(128);
+        $now = 1586161036;
+        $fourtySecondsAgo = $now - 40;
+
+        $totp = TOTP::create(Base32::encodeUpperUnpadded($secret));
+
+        /** @var BackendUser&MockObject $user */
+        $user = $this->mockClassWithProperties(BackendUser::class);
+        $user->secret = $secret;
+
+        $authenticator = new Authenticator();
+
+        $this->assertTrue($authenticator->validateCode($user, $totp->at($now), $now));
+        $this->assertTrue($authenticator->validateCode($user, $totp->at($fourtySecondsAgo), $now));
+        $this->assertFalse($authenticator->validateCode($user, 'foobar', $now));
+    }
+
     public function testGeneratesTheProvisionUri(): void
     {
         $secret = random_bytes(128);


### PR DESCRIPTION
I think we should allow for a TOTP window of 1 when checking the validity of a code.
I often find myself not being able to log in because the time the code was copied into my clipboard by my password manager, the token was only valid for another second or two. Until I hit enter, the code has already become invalid and I cannot log in.
By allowing a window of 1, the previous code remains valid. So the time a code is considered valid increases from 30 seconds to 60 seconds (at max) but it increases UX considerably and is thus done in many applications (Google authenticator does this too for example).