### PR TITLE
Correctly check if the search panel is active

### DIFF
--- a/core-bundle/src/Resources/contao/drivers/DC_Folder.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Folder.php
@@ -2903,7 +2903,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 			$this->values[] = $session['search'][$this->strTable]['value'];
 		}
 
-		$active = isset($session['search'][$this->strTable]['value']);
+		$active = isset($session['search'][$this->strTable]['value']) && $session['search'][$this->strTable]['value'] != '';
 
 		return '
     <div class="tl_search tl_subpanel">

--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -5236,7 +5236,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 
 		// Sort by option values
 		$options_sorter = natcaseksort($options_sorter);
-		$active = isset($session['search'][$this->strTable]['value']);
+		$active = isset($session['search'][$this->strTable]['value']) && $session['search'][$this->strTable]['value'] != '';
 
 		return '
 <div class="tl_search tl_subpanel">


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | 
| Docs PR or issue | 

At the moment the search panel is always in an active state if the search panel was used before. The active state is detected by `isset`, but the search is only applied then the value is not empty.

How to reproduce:

1. Use any panel filter (search or filter doesn't matter)
2. Clear the search field
3. The search is still marked as active though it's not used