### PR TITLE
Return the request argument if it has the correct type

### DIFF
--- a/core-bundle/src/HttpKernel/ModelArgumentResolver.php
+++ b/core-bundle/src/HttpKernel/ModelArgumentResolver.php
@@ -72,10 +72,17 @@ class ModelArgumentResolver implements ArgumentValueResolverInterface
             return null;
         }
 
+        $value = $request->attributes->get($name);
+        $type = $argument->getType();
+
+        if ($value instanceof $type) {
+            return $value;
+        }
+
         /** @var Model $model */
         $model = $this->framework->getAdapter($argument->getType());
 
-        return $model->findByPk($request->attributes->getInt($name));
+        return $model->findByPk((int) $value);
     }
 
     /**

--- a/core-bundle/src/HttpKernel/ModelArgumentResolver.php
+++ b/core-bundle/src/HttpKernel/ModelArgumentResolver.php
@@ -75,7 +75,7 @@ class ModelArgumentResolver implements ArgumentValueResolverInterface
         $value = $request->attributes->get($name);
         $type = $argument->getType();
 
-        if ($value instanceof $type) {
+        if ($type && $value instanceof $type) {
             return $value;
         }
 

--- a/core-bundle/tests/HttpKernel/ModelArgumentResolverTest.php
+++ b/core-bundle/tests/HttpKernel/ModelArgumentResolverTest.php
@@ -55,7 +55,7 @@ class ModelArgumentResolverTest extends TestCase
         yield ['foobar', 'PageModel'];
     }
 
-    public function testResolvesAttributeInstances()
+    public function testResolvesAttributeInstances(): void
     {
         System::setContainer($this->getContainerWithContaoConfiguration());
 

--- a/core-bundle/tests/HttpKernel/ModelArgumentResolverTest.php
+++ b/core-bundle/tests/HttpKernel/ModelArgumentResolverTest.php
@@ -29,8 +29,7 @@ class ModelArgumentResolverTest extends TestCase
     {
         System::setContainer($this->getContainerWithContaoConfiguration());
 
-        $pageModel = new PageModel();
-        $pageModel->setRow(['id' => 42]);
+        $pageModel = $this->createMock(PageModel::class);
 
         $adapter = $this->mockConfiguredAdapter(['findByPk' => $pageModel]);
         $framework = $this->mockContaoFramework([$class => $adapter]);
@@ -54,6 +53,27 @@ class ModelArgumentResolverTest extends TestCase
         yield ['pageModel', PageModel::class];
         yield ['foobar', PageModel::class];
         yield ['foobar', 'PageModel'];
+    }
+
+    public function testResolvesAttributeInstances()
+    {
+        System::setContainer($this->getContainerWithContaoConfiguration());
+
+        $pageModel = $this->createMock(PageModel::class);
+        $framework = $this->mockContaoFramework();
+
+        $request = Request::create('/foobar');
+        $request->attributes->set('pageModel', $pageModel);
+        $request->attributes->set('_scope', ContaoCoreBundle::SCOPE_FRONTEND);
+
+        $metadata = new ArgumentMetadata('pageModel', PageModel::class, false, false, '');
+
+        $resolver = new ModelArgumentResolver($framework, $this->mockScopeMatcher());
+        $generator = $resolver->resolve($request, $metadata);
+
+        foreach ($generator as $resolved) {
+            $this->assertSame($pageModel, $resolved);
+        }
     }
 
     public function testDoesNothingIfOutsideTheContaoScope(): void


### PR DESCRIPTION
We've added the `ModelArgumentResolver` for our fragments, where the `pageModel` request attribute is the ID of the origin page model.

Since CMF routing, the `pageModel` is also in the master request attribute, but there it's the actual page model instance. If the page is routed to a Symfony controller, injecting that attribute into the action (normally done by https://github.com/symfony/symfony/blob/master/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestAttributeValueResolver.php) fails because of our resolver.