### PR TITLE
Fix the tl_maintenance_jobs.crawl_queue explanation

### DIFF
--- a/core-bundle/src/Resources/contao/languages/en/tl_maintenance.xlf
+++ b/core-bundle/src/Resources/contao/languages/en/tl_maintenance.xlf
@@ -54,7 +54,7 @@
         <source>Purge the crawl queue</source>
       </trans-unit>
       <trans-unit id="tl_maintenance_jobs.crawl_queue.1">
-        <source>Truncates the &lt;code&gt;tl_crawl_queue&lt;/code&gt; table which stores all the queue information from crawl processes. This job permanently deletes these records.</source>
+        <source>Truncates the &lt;code&gt;tl_crawl_queue&lt;/code&gt; table which stores all the queue information from crawl processes.</source>
       </trans-unit>
       <trans-unit id="tl_maintenance_jobs.images.0">
         <source>Purge the image cache</source>


### PR DESCRIPTION
The note ``This job permanently deletes these records.`` applies to all jobs on an abstract level, but it is only relevant for those that delete irretrievable information. It is also not shown at the jobs to purge caches or the temp folder.