### PR TITLE
Suppress undefined docblock class errors for the Stringable interface

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -36,5 +36,10 @@
                 <file name="core-bundle/src/Controller/InitializeController.php" />
             </errorLevel>
         </UndefinedConstant>
+        <UndefinedDocblockClass>
+            <errorLevel type="suppress">
+                <referencedClass name="Stringable"/>
+            </errorLevel>
+        </UndefinedDocblockClass>
     </issueHandlers>
 </psalm>


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | -
| Docs PR or issue | -

Symfony uses the `Stringable` interface in the [`TokenInterface`](https://github.com/symfony/symfony/blob/4.4/src/Symfony/Component/Security/Core/Authentication/Token/TokenInterface.php#L57) class in Symfony 4.4, however, they do not require `symfony/polyfill-php80` before Symfony 5.1 (see [composer.json@4.4](https://github.com/symfony/symfony/blob/4.4/src/Symfony/Component/Security/Core/composer.json) and [composer.json@master](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Security/Core/composer.json#L21)), therefore the class is undefined in PHP 7 + Symfony 4.

This PR adds the "undefined docblock class" error to the Psalm ignore list.