### PR TITLE
Fallback to the regular icon if a page type has no icon

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Controller.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Controller.php
@@ -656,7 +656,8 @@ abstract class Controller extends System
 	public static function getPageStatusIcon($objPage)
 	{
 		$sub = 0;
-		$image = $objPage->type . '.svg';
+		$type = \in_array($objPage->type, array('regular', 'root', 'forward', 'redirect', 'error_401', 'error_403', 'error_404'), true) ? $objPage->type : 'regular';
+		$image = $type . '.svg';
 
 		// Page not published or not active
 		if (!$objPage->published || ($objPage->start != '' && $objPage->start > time()) || ($objPage->stop != '' && $objPage->stop < time()))
@@ -665,13 +666,13 @@ abstract class Controller extends System
 		}
 
 		// Page hidden from menu
-		if ($objPage->hide && !\in_array($objPage->type, array('root', 'error_401', 'error_403', 'error_404')))
+		if ($objPage->hide && !\in_array($type, array('root', 'error_401', 'error_403', 'error_404')))
 		{
 			$sub += 2;
 		}
 
 		// Page protected
-		if ($objPage->protected && !\in_array($objPage->type, array('root', 'error_401', 'error_403', 'error_404')))
+		if ($objPage->protected && !\in_array($type, array('root', 'error_401', 'error_403', 'error_404')))
 		{
 			$sub += 4;
 		}
@@ -679,7 +680,7 @@ abstract class Controller extends System
 		// Get the image name
 		if ($sub > 0)
 		{
-			$image = $objPage->type . '_' . $sub . '.svg';
+			$image = $type . '_' . $sub . '.svg';
 		}
 
 		// HOOK: add custom logic


### PR DESCRIPTION
Preparing for https://github.com/contao/contao/pull/1516: I very much doubt every developer wants to provide a custom icon for a custom page type.

Currently, extensions (most likely) copy their images into the core's theme folder (e.g. [folderpage](https://github.com/terminal42/contao-folderpage) does that). But that shouldn't be used, people should use the hook to override the icon and provide their own path.