### PR TITLE
Execute schema diff queries in the correct order

### DIFF
--- a/core-bundle/src/Command/MigrateCommand.php
+++ b/core-bundle/src/Command/MigrateCommand.php
@@ -206,13 +206,13 @@ class MigrateCommand extends Command
         while (true) {
             $this->installer->compileCommands();
 
-            if (!$commands = $this->installer->getCommands()) {
+            if (!$commands = $this->installer->getCommands(false)) {
                 return true;
             }
 
             $hasNewCommands = \count(
                 array_filter(
-                    array_keys(array_merge(...array_values($commands))),
+                    array_keys($commands),
                     static function ($hash) use ($commandsByHash) {
                         return !isset($commandsByHash[$hash]);
                     }
@@ -225,7 +225,7 @@ class MigrateCommand extends Command
 
             $this->io->section('Pending database migrations');
 
-            $commandsByHash = array_merge(...array_values($commands));
+            $commandsByHash = $commands;
 
             $this->io->listing($commandsByHash);
 
@@ -285,17 +285,16 @@ class MigrateCommand extends Command
     private function getCommandHashes(array $commands, bool $withDrops): array
     {
         if (!$withDrops) {
-            unset($commands['ALTER_DROP']);
-
-            foreach ($commands as $category => $commandsByHash) {
-                foreach ($commandsByHash as $hash => $command) {
-                    if ('DROP' === $category && false === strpos($command, 'DROP INDEX')) {
-                        unset($commands[$category][$hash]);
-                    }
+            foreach ($commands as $hash => $command) {
+                if (
+                    (0 === strncmp($command, 'DROP ', 5) && 0 !== strncmp($command, 'DROP INDEX', 10))
+                    || preg_match('/^ALTER TABLE [^ ]+ DROP /', $command, $matches)
+                ) {
+                    unset($commands[$hash]);
                 }
             }
         }
 
-        return \count($commands) ? array_keys(array_merge(...array_values($commands))) : [];
+        return array_keys($commands);
     }
 }

--- a/core-bundle/tests/Command/MigrateCommandTest.php
+++ b/core-bundle/tests/Command/MigrateCommandTest.php
@@ -96,13 +96,16 @@ class MigrateCommandTest extends TestCase
         $installer
             ->expects($this->atLeastOnce())
             ->method('getCommands')
+            ->with(false)
             ->willReturn(
                 [
-                    'CREATE' => ['hash1' => 'First call QUERY 1', 'hash2' => 'First call QUERY 2'],
+                    'hash1' => 'First call QUERY 1',
+                    'hash2' => 'First call QUERY 2',
                 ],
                 [
-                    'CREATE' => ['hash3' => 'Second call QUERY 1', 'hash4' => 'Second call QUERY 2'],
-                    'DROP' => ['hash5' => 'DROP QUERY'],
+                    'hash3' => 'Second call QUERY 1',
+                    'hash4' => 'Second call QUERY 2',
+                    'hash5' => 'DROP QUERY',
                 ],
                 []
             )

--- a/installation-bundle/src/Database/Installer.php
+++ b/installation-bundle/src/Database/Installer.php
@@ -177,18 +177,18 @@ class Installer
                         switch (true) {
                             case 0 === strncmp($part, 'DROP ', 5):
                                 $return['ALTER_DROP'][md5($command)] = $command;
-                                $order[] = md5($sql);
+                                $order[] = md5($command);
                                 break;
 
                             case 0 === strncmp($part, 'ADD ', 4):
                                 $return['ALTER_ADD'][md5($command)] = $command;
-                                $order[] = md5($sql);
+                                $order[] = md5($command);
                                 break;
 
                             case 0 === strncmp($part, 'CHANGE ', 7):
                             case 0 === strncmp($part, 'RENAME ', 7):
                                 $return['ALTER_CHANGE'][md5($command)] = $command;
-                                $order[] = md5($sql);
+                                $order[] = md5($command);
                                 break;
 
                             default:

--- a/installation-bundle/src/Database/Installer.php
+++ b/installation-bundle/src/Database/Installer.php
@@ -118,6 +118,7 @@ class Installer
             'DROP' => [],
             'ALTER_DROP' => [],
         ];
+
         $order = [];
 
         // The schema assets filter is a callable as of Doctrine DBAL 2.9

--- a/installation-bundle/src/Database/Installer.php
+++ b/installation-bundle/src/Database/Installer.php
@@ -31,6 +31,11 @@ class Installer
     private $commands;
 
     /**
+     * @var array
+     */
+    private $commandOrder;
+
+    /**
      * @var DcaSchemaProvider
      */
     private $schemaProvider;
@@ -47,13 +52,37 @@ class Installer
     /**
      * @return array<string>
      */
-    public function getCommands(): array
+    public function getCommands(bool $byGroup = true): array
     {
         if (null === $this->commands) {
             $this->compileCommands();
         }
 
-        return $this->commands;
+        if ($byGroup || !$this->commands) {
+            return $this->commands;
+        }
+
+        $commandsByHash = array_merge(...array_values($this->commands));
+
+        uksort(
+            $commandsByHash,
+            function ($a, $b) {
+                $indexA = array_search($a, $this->commandOrder, true);
+                $indexB = array_search($b, $this->commandOrder, true);
+
+                if (false === $indexA) {
+                    $indexA = \count($this->commandOrder);
+                }
+
+                if (false === $indexB) {
+                    $indexB = \count($this->commandOrder);
+                }
+
+                return $indexA - $indexB;
+            }
+        );
+
+        return $commandsByHash;
     }
 
     /**
@@ -89,6 +118,7 @@ class Installer
             'DROP' => [],
             'ALTER_DROP' => [],
         ];
+        $order = [];
 
         // The schema assets filter is a callable as of Doctrine DBAL 2.9
         $filter = static function (string $assetName): bool {
@@ -114,20 +144,24 @@ class Installer
             switch (true) {
                 case 0 === strncmp($sql, 'CREATE TABLE ', 13):
                     $return['CREATE'][md5($sql)] = $sql;
+                    $order[] = md5($sql);
                     break;
 
                 case 0 === strncmp($sql, 'DROP TABLE ', 11):
                     $return['DROP'][md5($sql)] = $sql;
+                    $order[] = md5($sql);
                     break;
 
                 case 0 === strncmp($sql, 'CREATE INDEX ', 13):
                 case 0 === strncmp($sql, 'CREATE UNIQUE INDEX ', 20):
                 case 0 === strncmp($sql, 'CREATE FULLTEXT INDEX ', 22):
                     $return['ALTER_ADD'][md5($sql)] = $sql;
+                    $order[] = md5($sql);
                     break;
 
                 case 0 === strncmp($sql, 'DROP INDEX', 10):
                     $return['ALTER_CHANGE'][md5($sql)] = $sql;
+                    $order[] = md5($sql);
                     break;
 
                 case preg_match('/^(ALTER TABLE [^ ]+) /', $sql, $matches):
@@ -142,15 +176,18 @@ class Installer
                         switch (true) {
                             case 0 === strncmp($part, 'DROP ', 5):
                                 $return['ALTER_DROP'][md5($command)] = $command;
+                                $order[] = md5($sql);
                                 break;
 
                             case 0 === strncmp($part, 'ADD ', 4):
                                 $return['ALTER_ADD'][md5($command)] = $command;
+                                $order[] = md5($sql);
                                 break;
 
                             case 0 === strncmp($part, 'CHANGE ', 7):
                             case 0 === strncmp($part, 'RENAME ', 7):
                                 $return['ALTER_CHANGE'][md5($command)] = $command;
+                                $order[] = md5($sql);
                                 break;
 
                             default:
@@ -165,7 +202,7 @@ class Installer
             }
         }
 
-        $this->checkEngineAndCollation($return, $fromSchema, $toSchema);
+        $this->checkEngineAndCollation($return, $order, $fromSchema, $toSchema);
 
         $return = array_filter($return);
 
@@ -177,12 +214,13 @@ class Installer
         }
 
         $this->commands = $return;
+        $this->commandOrder = $order;
     }
 
     /**
      * Checks engine and collation and adds the ALTER TABLE queries.
      */
-    private function checkEngineAndCollation(array &$sql, Schema $fromSchema, Schema $toSchema): void
+    private function checkEngineAndCollation(array &$sql, array &$order, Schema $fromSchema, Schema $toSchema): void
     {
         $tables = $toSchema->getTables();
         $dynamic = $this->hasDynamicRowFormat();
@@ -257,15 +295,22 @@ class Installer
                     $strKey = md5($indexCommand);
 
                     if (isset($sql['ALTER_CHANGE'][$strKey])) {
-                        unset($sql['ALTER_CHANGE'][$strKey]);
+                        unset(
+                            $sql['ALTER_CHANGE'][$strKey],
+                            $order[array_search($strKey, $order, true)]
+                        );
+
+                        $order = array_values($order);
                     }
 
                     $sql['ALTER_TABLE'][$strKey] = $indexCommand;
+                    $order[] = $strKey;
                 }
             }
 
             foreach ($alterTables as $k => $alterTable) {
                 $sql['ALTER_TABLE'][$k] = $alterTable;
+                $order[] = $k;
             }
         }
     }


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #1507
| Docs PR or issue | N/A

This executes the schema diff SQL queries in the correct order. Similar to #169 but only for the migrate command, not the install tool.

@m-vo Can you verify that this code works correctly with your foreign key use cases?