### PR TITLE
Let the pretty error screen handle unused argument exceptions

### DIFF
--- a/core-bundle/src/EventListener/ExceptionConverterListener.php
+++ b/core-bundle/src/EventListener/ExceptionConverterListener.php
@@ -51,6 +51,7 @@ class ExceptionConverterListener
         PageNotFoundException::class => 'NotFoundHttpException',
         ServiceUnavailableException::class => 'ServiceUnavailableHttpException',
         ContaoServiceUnavailableException::class => 'ServiceUnavailableHttpException',
+        \UnusedArgumentsException::class => 'NotFoundHttpException',
     ];
 
     /**

--- a/core-bundle/src/Resources/contao/controllers/FrontendIndex.php
+++ b/core-bundle/src/Resources/contao/controllers/FrontendIndex.php
@@ -349,10 +349,7 @@ class FrontendIndex extends Frontend
 			$GLOBALS['TL_MOOTOOLS'] = $arrMootools;
 			$GLOBALS['TL_JQUERY'] = $arrJquery;
 
-			/** @var PageError404 $objHandler */
-			$objHandler = new $GLOBALS['TL_PTY']['error_404']();
-
-			return $objHandler->getResponse();
+			throw $e;
 		}
 	}
 

--- a/core-bundle/tests/EventListener/ExceptionConverterListenerTest.php
+++ b/core-bundle/tests/EventListener/ExceptionConverterListenerTest.php
@@ -192,6 +192,19 @@ class ExceptionConverterListenerTest extends TestCase
         $this->assertInstanceOf(PageNotFoundException::class, $exception->getPrevious());
     }
 
+    public function testConvertsUnusedArgumentsExceptions(): void
+    {
+        $event = $this->getResponseEvent(new \UnusedArgumentsException());
+
+        $listener = new ExceptionConverterListener();
+        $listener($event);
+
+        $exception = $event->getThrowable();
+
+        $this->assertInstanceOf(NotFoundHttpException::class, $exception);
+        $this->assertInstanceOf(\UnusedArgumentsException::class, $exception->getPrevious());
+    }
+
     private function getResponseEvent(\Exception $exception): ExceptionEvent
     {
         $kernel = $this->createMock(KernelInterface::class);


### PR DESCRIPTION
Advantages:
 1. rendering the 404 page is always done by the same component (pretty error screen handler)
 2. in debug mode, the exception is shown so one can see the unused arguments.

I haven't (manually) tested this yet, but I'd like to know your opinion @contao/developers 