### PR TITLE
Correctly store the referer for front end pages

### DIFF
--- a/core-bundle/src/EventListener/StoreRefererListener.php
+++ b/core-bundle/src/EventListener/StoreRefererListener.php
@@ -162,12 +162,14 @@ class StoreRefererListener
 
     private function canModifyFrontendSession(Request $request, array $referer = null): bool
     {
+        $route = $request->attributes->get('_route');
+
         return null !== $referer
             && !$request->query->has('pdf')
             && !$request->query->has('file')
             && !$request->query->has('id')
             && isset($referer['current'])
-            && 'contao_frontend' === $request->attributes->get('_route')
+            && ('contao_frontend' === $route || 0 === strncmp($route, 'tl_page.', 8))
             && $this->getRelativeRequestUri($request) !== $referer['current']
             && !$request->isXmlHttpRequest();
     }

--- a/core-bundle/tests/EventListener/StoreRefererListenerTest.php
+++ b/core-bundle/tests/EventListener/StoreRefererListenerTest.php
@@ -67,6 +67,9 @@ class StoreRefererListenerTest extends TestCase
         $requestWithRefInUrlFrontend->attributes->set('_route', 'contao_frontend');
         $requestWithRefInUrlFrontend->attributes->set('_scope', ContaoCoreBundle::SCOPE_FRONTEND);
 
+        $requestFrontendPage = clone $requestWithRefInUrlFrontend;
+        $requestFrontendPage->attributes->set('_route', 'tl_page.19');
+
         yield 'Test current referer null returns correct new referer for back end scope' => [
             $request,
             null,
@@ -100,18 +103,6 @@ class StoreRefererListenerTest extends TestCase
             null,
         ];
 
-        yield 'Test referer returns correct new referer for front end scope' => [
-            $requestWithRefInUrlFrontend,
-            [
-                'last' => '',
-                'current' => 'hi/I/am/your_current_referer.html',
-            ],
-            [
-                'last' => 'hi/I/am/your_current_referer.html',
-                'current' => 'path/of/contao?having&query&string=1',
-            ],
-        ];
-
         yield 'Test referers are correctly added to the referers array (see #143)' => [
             $requestWithRefInUrl,
             [
@@ -133,6 +124,30 @@ class StoreRefererListenerTest extends TestCase
                     'last' => '',
                     'current' => 'hi/I/am/your_current_referer.html',
                 ],
+            ],
+        ];
+
+        yield 'Test referer returns correct new referer for front end scope' => [
+            $requestWithRefInUrlFrontend,
+            [
+                'last' => '',
+                'current' => 'hi/I/am/your_current_referer.html',
+            ],
+            [
+                'last' => 'hi/I/am/your_current_referer.html',
+                'current' => 'path/of/contao?having&query&string=1',
+            ],
+        ];
+
+        yield 'Test referer also handles tl_page.* routes in the front end' => [
+            $requestFrontendPage,
+            [
+                'last' => '',
+                'current' => 'hi/I/am/your_current_referer.html',
+            ],
+            [
+                'last' => 'hi/I/am/your_current_referer.html',
+                'current' => 'path/of/contao?having&query&string=1',
             ],
         ];
     }


### PR DESCRIPTION
While working on #1516 I stubled upon this route use case. Unfortunately, the unit tests did not make sense at all to me, I couldn't update them.

On a side not, I couldn't understand how the class works, as it only stores the referrer if it's not empty. But isn't it always empty initially…?