### PR TITLE
Add SCSS source maps in debug mode

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Combiner.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Combiner.php
@@ -402,7 +402,7 @@ class Combiner extends System
 			$objCompiler->setImportPaths($this->strRootDir . '/' . \dirname($arrFile['name']));
 			$objCompiler->setFormatter((Config::get('debugMode') ? Expanded::class : Compressed::class));
 			
-			if(Config::get('debugMode'))
+			if (Config::get('debugMode'))
 			{
 				$objCompiler->setSourceMap(Compiler::SOURCE_MAP_INLINE);
 			}

--- a/core-bundle/src/Resources/contao/library/Contao/Combiner.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Combiner.php
@@ -401,6 +401,11 @@ class Combiner extends System
 			$objCompiler = new Compiler();
 			$objCompiler->setImportPaths($this->strRootDir . '/' . \dirname($arrFile['name']));
 			$objCompiler->setFormatter((Config::get('debugMode') ? Expanded::class : Compressed::class));
+			
+			if(Config::get('debugMode'))
+			{
+				$objCompiler->setSourceMap(Compiler::SOURCE_MAP_INLINE);
+			}
 
 			return $this->fixPaths($objCompiler->compile($content), $arrFile);
 		}

--- a/core-bundle/src/Resources/contao/library/Contao/Combiner.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Combiner.php
@@ -401,7 +401,7 @@ class Combiner extends System
 			$objCompiler = new Compiler();
 			$objCompiler->setImportPaths($this->strRootDir . '/' . \dirname($arrFile['name']));
 			$objCompiler->setFormatter((Config::get('debugMode') ? Expanded::class : Compressed::class));
-			
+
 			if (Config::get('debugMode'))
 			{
 				$objCompiler->setSourceMap(Compiler::SOURCE_MAP_INLINE);


### PR DESCRIPTION
The SCSS-Compiler has an option to generate Source Maps for generated CSS files, see https://scssphp.github.io/scssphp/docs/#source-maps

It would be nice to have Source Maps activated, when Contao Debug Mode is activated, too. A basic solution could be adding an inline source map, but there are also options to generate a separate file.

What do you think?