### PR TITLE
Improve search query performance

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Search.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Search.php
@@ -403,7 +403,7 @@ class Search
 		$arrValues = array();
 
 		// Remember found words so we can highlight them later
-		$strQuery = "SELECT * FROM (SELECT tl_search_index.pid AS sid, GROUP_CONCAT(word) AS matches";
+		$strQuery = "SELECT * FROM (SELECT tl_search_index.pid AS sid, GROUP_CONCAT(tl_search_index.word) AS matches";
 
 		// Get the number of wildcard matches
 		if (!$blnOrSearch && $intWildcards)
@@ -456,7 +456,7 @@ class Search
 			$arrValues = array_merge($arrValues, $arrWildcards);
 		}
 
-		$strQuery .= " FROM tl_search_index WHERE (" . implode(' OR ', $arrAllKeywords) . ")";
+		$strQuery .= " FROM (SELECT word FROM tl_search_index WHERE (" . implode(' OR ', $arrAllKeywords) . ") GROUP BY word) words JOIN tl_search_index ON tl_search_index.word = words.word WHERE 1";
 
 		// Get phrases
 		if ($intPhrases)

--- a/core-bundle/src/Resources/contao/library/Contao/Search.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Search.php
@@ -405,8 +405,8 @@ class Search
 		// Remember found words so we can highlight them later
 		$strQuery = "SELECT * FROM (SELECT tl_search_index.pid AS sid, GROUP_CONCAT(tl_search_index.word) AS matches";
 
-		// Get the number of wildcard matches
-		if (!$blnOrSearch && $intWildcards)
+		// Get the number of wildcard matches if wildcards and keywords are mixed
+		if (!$blnOrSearch && $intWildcards && (\count($arrKeywords) || $intIncluded || $intPhrases))
 		{
 			$strQuery .= ", (SELECT COUNT(*) FROM tl_search_index WHERE (" . implode(' OR ', array_fill(0, $intWildcards, 'word LIKE ?')) . ") AND pid=sid) AS wildcards";
 			$arrValues = array_merge($arrValues, $arrWildcards);
@@ -499,7 +499,14 @@ class Search
 			// Dynamically add the number of wildcard matches
 			if ($intWildcards)
 			{
-				$strQuery .= " + IF(matches.wildcards>" . $intWildcards . ", matches.wildcards, " . $intWildcards . ")";
+				if ($intKeywords)
+				{
+					$strQuery .= " + IF(matches.wildcards>" . $intWildcards . ", matches.wildcards, " . $intWildcards . ")";
+				}
+				else
+				{
+					$strQuery .= " + " . $intWildcards;
+				}
 			}
 		}
 


### PR DESCRIPTION
This pull request improves the search query performance.

1. 792499a moves the word matching into a subselect which seems to help MySQL make better use of the indexes.
2. a2ce8e8 removes the extra counting of wildcards if it is a wildcard-only search because the count is not needed in this case.

In my tests with a `tl_search_index` table with about 1.5 million rows it took down a search like `*foo*` from 10 seconds to 1 second, and `*foo* *bar*` from 12 to 1.3 seconds.