### PR TITLE
Use array_key_exists() in the Database\Result class

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Database/Result.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Database/Result.php
@@ -124,7 +124,8 @@ class Result
 			$this->next();
 		}
 
-		return isset($this->resultSet[$this->intIndex][$strKey]) || isset($this->arrModified[$strKey]);
+		// Use array_key_exists() instead of isset(), because the value might be null
+		return \array_key_exists($strKey, $this->resultSet[$this->intIndex]) || \array_key_exists($strKey, $this->arrModified);
 	}
 
 	/**
@@ -170,12 +171,14 @@ class Result
 					$this->next();
 				}
 
-				if (isset($this->arrModified[$strKey]))
+				// Use array_key_exists() instead of isset(), because the value might be null
+				if (\array_key_exists($strKey, $this->arrModified))
 				{
 					return $this->arrModified[$strKey];
 				}
 
-				if (isset($this->resultSet[$this->intIndex][$strKey]))
+				// Use array_key_exists() instead of isset(), because the value might be null
+				if (\array_key_exists($strKey, $this->resultSet[$this->intIndex]))
 				{
 					return $this->resultSet[$this->intIndex][$strKey];
 				}

--- a/core-bundle/src/Resources/contao/library/Contao/Database/Result.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Database/Result.php
@@ -124,7 +124,7 @@ class Result
 			$this->next();
 		}
 
-		// Use array_key_exists() instead of isset(), because the value might be null
+		// If the modified value is null, return false even if the original value is not null (see #1689)
 		return \array_key_exists($strKey, $this->arrModified) ? isset($this->arrModified[$strKey]) : isset($this->resultSet[$this->intIndex][$strKey]);
 	}
 

--- a/core-bundle/src/Resources/contao/library/Contao/Database/Result.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Database/Result.php
@@ -125,7 +125,7 @@ class Result
 		}
 
 		// Use array_key_exists() instead of isset(), because the value might be null
-		return \array_key_exists($strKey, $this->resultSet[$this->intIndex]) || \array_key_exists($strKey, $this->arrModified);
+		return \array_key_exists($strKey, $this->arrModified) ? isset($this->arrModified[$strKey]) : isset($this->resultSet[$this->intIndex][$strKey]);
 	}
 
 	/**


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #1587
| Docs PR or issue | -

Now that @ausi has improved the `Result` class in #1287, we have to use `array_key_exists()` instead of `isset()`, because the values can be `null`.

This causes the problem described in #1587:

```php
$this->arrModified['endDate'] = null; // new value
$this->resultSet[$this->intIndex] = 123456; // old value

// This condition never evaluates to true, therefore the new value is never used
if (isset($this->arrModified[$strKey])) {
    return $this->arrModified[$strKey]; 
}
```
