### PR TITLE
Fetch tables to check the database connection

### DIFF
--- a/manager-bundle/src/ContaoManager/Plugin.php
+++ b/manager-bundle/src/ContaoManager/Plugin.php
@@ -169,6 +169,7 @@ class Plugin implements BundlePluginInterface, ConfigPluginInterface, RoutingPlu
         try {
             $connection = DriverManager::getConnection($params);
             $connection->connect();
+            $connection->query('SHOW TABLES');
             $connection->close();
         } catch (DriverException $e) {
             $extensionConfigs[] = [


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #1631


If the database server allows anonymous connections, the current DB check does not fail as it should. The added `SHOW TABLES` is actually the same procedure already used by the install tool, I have also locally reproduced the problem and this fixes it.

Even though #1631 says the issue only appears in Contao 4.9 (which I can confirm), I think we should also fix/change this in 4.4, as it might be related to a change in Doctrine or Symfony that _could_ somewhen apply to 4.4 as well.