### PR TITLE
Set "information_schema_stats_expiry=0" in MySQL 8

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Database.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Database.php
@@ -12,6 +12,7 @@ namespace Contao;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\Exception\DriverException;
 
 /**
  * Handle the database communication
@@ -643,6 +644,15 @@ class Database
 	 */
 	public function getSizeOf($strTable)
 	{
+		try
+		{
+			// MySQL 8 compatibility
+			$this->resConnection->executeQuery('SET @@SESSION.information_schema_stats_expiry = 0');
+		}
+		catch (DriverException $e)
+		{
+		}
+
 		$statement = $this->resConnection->executeQuery('SHOW TABLE STATUS LIKE ' . $this->resConnection->quote($strTable));
 		$status = $statement->fetch(\PDO::FETCH_ASSOC);
 
@@ -658,6 +668,15 @@ class Database
 	 */
 	public function getNextId($strTable)
 	{
+		try
+		{
+			// MySQL 8 compatibility
+			$this->resConnection->executeQuery('SET @@SESSION.information_schema_stats_expiry = 0');
+		}
+		catch (DriverException $e)
+		{
+		}
+
 		$statement = $this->resConnection->executeQuery('SHOW TABLE STATUS LIKE ' . $this->resConnection->quote($strTable));
 		$status = $statement->fetch(\PDO::FETCH_ASSOC);
 


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #958
| Docs PR or issue | -

<!--
Bugfixes should be based on the 4.4 or 4.9 branch and features on the master
branch. Select the correct branch in the "base:" drop-down menu above.

Replace this notice with a short README for your feature/bugfix. This will help
people to understand your PR and can be used as a start for the documentation.
-->
