### PR TITLE
Improve the deprecation message of the AbstractLockedCommand

### DIFF
--- a/core-bundle/src/Command/AbstractLockedCommand.php
+++ b/core-bundle/src/Command/AbstractLockedCommand.php
@@ -26,7 +26,7 @@ abstract class AbstractLockedCommand extends ContainerAwareCommand
 {
     final protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        @trigger_error('Using the "AbstractLockedCommand" has been deprecated and will no longer work in Contao 5.0. Use the lock service instead.', E_USER_DEPRECATED);
+        @trigger_error('Using the "AbstractLockedCommand" has been deprecated and will no longer work in Contao 5.0. Use the Symfony Lock component instead.', E_USER_DEPRECATED);
 
         $store = new FlockStore($this->getTempDir());
         $factory = new Factory($store);

--- a/core-bundle/src/Command/AbstractLockedCommand.php
+++ b/core-bundle/src/Command/AbstractLockedCommand.php
@@ -19,8 +19,8 @@ use Symfony\Component\Lock\Factory;
 use Symfony\Component\Lock\Store\FlockStore;
 
 /**
- * @deprecated Deprecated since Contao 4.7, to be removed in Contao 5.0; Use
- *             the Symfony Lock component instead.
+ * @deprecated Deprecated since Contao 4.7, to be removed in Contao 5.0; use
+ *             the Symfony Lock component instead
  */
 abstract class AbstractLockedCommand extends ContainerAwareCommand
 {

--- a/core-bundle/src/Command/AbstractLockedCommand.php
+++ b/core-bundle/src/Command/AbstractLockedCommand.php
@@ -19,8 +19,8 @@ use Symfony\Component\Lock\Factory;
 use Symfony\Component\Lock\Store\FlockStore;
 
 /**
- * @deprecated Deprecated since Contao 4.7, to be removed in Contao 5.0; use
- *             the lock service instead
+ * @deprecated Deprecated since Contao 4.7, to be removed in Contao 5.0; Use
+ *             the Symfony Lock component instead.
  */
 abstract class AbstractLockedCommand extends ContainerAwareCommand
 {


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Misleading deprecated message     | added a hint to the Symfony

After a quick talk on slack, the deprecated message for AbstractLockedCommand could be misleading (which "lock service"?). I suggest to change it to a more clearer message with the direct hint to the Symfony Lock component. 