### PR TITLE
Fix constructing Form from FormModel

### DIFF
--- a/core-bundle/src/Resources/contao/forms/Form.php
+++ b/core-bundle/src/Resources/contao/forms/Form.php
@@ -66,7 +66,14 @@ class Form extends \Hybrid
 	public function __construct($objElement, $strColumn = 'main')
 	{
 		if ($objElement instanceof FormModel) {
-			$this->strKey = 'id';
+			if (!$objElement->form)
+			{
+				$objElement->form = $objElement->id;
+			}
+			if (!$objElement->typePrefix)
+			{
+				$objElement->typePrefix = 'ce_';
+			}
 		}
 
 		parent::__construct($objElement, $strColumn);

--- a/core-bundle/src/Resources/contao/forms/Form.php
+++ b/core-bundle/src/Resources/contao/forms/Form.php
@@ -61,6 +61,18 @@ class Form extends \Hybrid
 	protected $strTemplate = 'form_wrapper';
 
 	/**
+	 * {@inheritdoc}
+	 */
+	public function __construct($objElement, $strColumn = 'main')
+	{
+		if ($objElement instanceof FormModel) {
+			$this->strKey = 'id';
+		}
+
+		parent::__construct($objElement, $strColumn);
+	}
+
+	/**
 	 * Remove name attributes in the back end so the form is not validated
 	 *
 	 * @return string


### PR DESCRIPTION
When creating a new `Form` object, its constructor (or rather `Hybrid`'s constructor) allows passing an instance of `FormModel`.

https://github.com/contao/contao/blob/34be236168f2e1cccaaf1b62394d1bac74949bda/core-bundle/src/Resources/contao/classes/Hybrid.php#L75-L81

However the resulting object does not contain the model's data, because the constructor tries to load the model again, using a dynamically defined property of the passed object as PK.

https://github.com/contao/contao/blob/34be236168f2e1cccaaf1b62394d1bac74949bda/core-bundle/src/Resources/contao/classes/Hybrid.php#L110-L115

When constructing a `Form`, `$this->strKey` is set to `form`, which is correct if the passed object is an instance of `ContentModel` or `ModuleModel`, both of which store the form's PK in the `form` property. Instances of `FormModel` however do not have a `form` property, they store the PK in the `id` property. Thus loading the model fails and the constructor returns early.

This PR fixes this bug by setting `$this->strKey` to `id`, if an instance of `FormModel` is passed to the (newly created) constructor of `Form`.

I also considered modifying the model loading logic in `Hybrid`s constructor in case a `FormModel` is passed, but this approach feels way cleaner, as it keeps `Hybrid` agnostic of the passed parameters.