### PR TITLE
Fix fixed position of toolbar elements

### DIFF
--- a/core-bundle/src/Resources/views/Frontend/preview_toolbar_base_js.html.twig
+++ b/core-bundle/src/Resources/views/Frontend/preview_toolbar_base_js.html.twig
@@ -19,6 +19,7 @@
         height: 36px;
         position: fixed;
         right: 0;
+        top: 0;
         background: #222;
         border-radius: 0 0 0 4px;
         display: flex;
@@ -41,6 +42,7 @@
         width: 100%;
         background: #f2f2f2;
         position: fixed;
+        left: 0;
         top: 0;
         z-index: 99999;
         border-bottom: 1px solid #ccc;


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | N/A
| Docs PR or issue | N/A

Currently, the toolbar and button look a bit off, if you have a margin on the `body`, e.g. in a testing environment with no CSS (where the browser's default `body` margin applies).

![Annotation 2020-05-08 093738-3](https://user-images.githubusercontent.com/4970961/81388067-a2cb7080-910f-11ea-9d9e-45af5a741f2a.png)

![Annotation 2020-05-08 093738-4](https://user-images.githubusercontent.com/4970961/81388068-a3fc9d80-910f-11ea-9efe-4ec7d52cafa9.png)

This is fixed by adding the missing position directives:

![Annotation 2020-05-08 093654](https://user-images.githubusercontent.com/4970961/81388134-bd054e80-910f-11ea-93c4-2ca7f21f1240.png)

![Annotation 2020-05-08 093654-2](https://user-images.githubusercontent.com/4970961/81388138-bd9de500-910f-11ea-8675-f3ee3f76c2f4.png)

