### PR TITLE
Ignore the /var folder in the core bundle

### DIFF
--- a/core-bundle/.gitignore
+++ b/core-bundle/.gitignore
@@ -4,3 +4,6 @@
 
 # PhpUnit
 /phpunit.xml
+
+# Upstream compatibility
+/var/


### PR DESCRIPTION
To be upstream compatible with Contao 4.9+.