### PR TITLE
Do not flush the template output buffer

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Template.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Template.php
@@ -283,9 +283,6 @@ abstract class Template extends \Controller
 		header('Content-Type: ' . $this->strContentType . '; charset=' . \Config::get('characterSet'));
 
 		echo $this->strBuffer;
-
-		// Flush the output buffers (see #6962)
-		$this->flushAllData();
 	}
 
 	/**


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | https://github.com/isotope/core/issues/2131, https://github.com/isotope/core/issues/2140


As discussed on Slack, `fastcgi_finish_request` (and other output buffer methods) break our logic of simulating a kernel request/response behavior. As @ausi suggested, we're not removing the `Template::flushAllData()` method (because it is public), but we shouldn't flush the data anymore on `Template::output()`.
