### PR TITLE
Always show the default template in the drop-down menu

### DIFF
--- a/calendar-bundle/src/Resources/contao/languages/en/tl_module.xlf
+++ b/calendar-bundle/src/Resources/contao/languages/en/tl_module.xlf
@@ -60,13 +60,13 @@
         <source>Event template</source>
       </trans-unit>
       <trans-unit id="tl_module.cal_template.1">
-        <source>Here you can select the event template.</source>
+        <source>Here you can select an event template.</source>
       </trans-unit>
       <trans-unit id="tl_module.cal_ctemplate.0">
         <source>Calendar template</source>
       </trans-unit>
       <trans-unit id="tl_module.cal_ctemplate.1">
-        <source>Here you can select the calendar template.</source>
+        <source>Here you can select a calendar template.</source>
       </trans-unit>
       <trans-unit id="tl_module.cal_showQuantity.0">
         <source>Show number of events</source>

--- a/comments-bundle/src/Resources/contao/languages/en/tl_content.xlf
+++ b/comments-bundle/src/Resources/contao/languages/en/tl_content.xlf
@@ -42,7 +42,7 @@
         <source>Comments template</source>
       </trans-unit>
       <trans-unit id="tl_content.com_template.1">
-        <source>Here you can select the comments template.</source>
+        <source>Here you can select a comments template.</source>
       </trans-unit>
       <trans-unit id="tl_content.comment_legend">
         <source>Comment settings</source>

--- a/core-bundle/src/Resources/contao/dca/tl_article.php
+++ b/core-bundle/src/Resources/contao/dca/tl_article.php
@@ -250,9 +250,9 @@ $GLOBALS['TL_DCA']['tl_article'] = array
 			'inputType'               => 'select',
 			'options_callback' => static function ()
 			{
-				return Contao\Controller::getTemplateGroup('mod_article_');
+				return Contao\Controller::getTemplateGroup('mod_article_', array(), 'mod_article');
 			},
-			'eval'                    => array('includeBlankOption'=>true, 'chosen'=>true, 'tl_class'=>'w50'),
+			'eval'                    => array('chosen'=>true, 'tl_class'=>'w50'),
 			'sql'                     => "varchar(64) NOT NULL default ''"
 		),
 		'protected' => array

--- a/core-bundle/src/Resources/contao/dca/tl_content.php
+++ b/core-bundle/src/Resources/contao/dca/tl_content.php
@@ -568,9 +568,9 @@ $GLOBALS['TL_DCA']['tl_content'] = array
 			'inputType'               => 'select',
 			'options_callback' => static function (Contao\DataContainer $dc)
 			{
-				return Contao\Controller::getTemplateGroup('ce_' . $dc->activeRecord->type . '_');
+				return Contao\Controller::getTemplateGroup('ce_' . $dc->activeRecord->type . '_', array(), 'ce_' . $dc->activeRecord->type);
 			},
-			'eval'                    => array('includeBlankOption'=>true, 'chosen'=>true, 'tl_class'=>'w50'),
+			'eval'                    => array('chosen'=>true, 'tl_class'=>'w50'),
 			'sql'                     => "varchar(64) NOT NULL default ''"
 		),
 		'playerSRC' => array

--- a/core-bundle/src/Resources/contao/dca/tl_form.php
+++ b/core-bundle/src/Resources/contao/dca/tl_form.php
@@ -215,9 +215,9 @@ $GLOBALS['TL_DCA']['tl_form'] = array
 			'inputType'               => 'select',
 			'options_callback' => static function ()
 			{
-				return Contao\Controller::getTemplateGroup('form_wrapper_');
+				return Contao\Controller::getTemplateGroup('form_wrapper_', array(), 'form_wrapper');
 			},
-			'eval'                    => array('includeBlankOption'=>true, 'chosen'=>true, 'tl_class'=>'w50'),
+			'eval'                    => array('chosen'=>true, 'tl_class'=>'w50'),
 			'sql'                     => "varchar(64) NOT NULL default ''"
 		),
 		'method' => array

--- a/core-bundle/src/Resources/contao/dca/tl_form_field.php
+++ b/core-bundle/src/Resources/contao/dca/tl_form_field.php
@@ -363,7 +363,7 @@ $GLOBALS['TL_DCA']['tl_form_field'] = array
 			'exclude'                 => true,
 			'inputType'               => 'select',
 			'options_callback'        => array('tl_form_field', 'getFormFieldTemplates'),
-			'eval'                    => array('includeBlankOption'=>true, 'chosen'=>true, 'tl_class'=>'w50'),
+			'eval'                    => array('chosen'=>true, 'tl_class'=>'w50'),
 			'sql'                     => "varchar(64) NOT NULL default ''"
 		),
 		'slabel' => array
@@ -723,13 +723,15 @@ class tl_form_field extends Contao\Backend
 			return $this->getTemplateGroup('form_');
 		}
 
+		$arrTemplates = $this->getTemplateGroup('form_' . $dc->activeRecord->type . '_', array(), 'form_' . $dc->activeRecord->type);
+
 		// Backwards compatibility
 		if ($dc->activeRecord->type == 'text')
 		{
-			return array_merge($this->getTemplateGroup('form_text_'), $this->getTemplateGroup('form_textfield_'));
+			$arrTemplates += $this->getTemplateGroup('form_textfield_');
 		}
 
-		return $this->getTemplateGroup('form_' . $dc->activeRecord->type . '_');
+		return $arrTemplates;
 	}
 
 	/**

--- a/core-bundle/src/Resources/contao/dca/tl_module.php
+++ b/core-bundle/src/Resources/contao/dca/tl_module.php
@@ -235,9 +235,9 @@ $GLOBALS['TL_DCA']['tl_module'] = array
 			'inputType'               => 'select',
 			'options_callback' => static function (Contao\DataContainer $dc)
 			{
-				return Contao\Controller::getTemplateGroup('mod_' . $dc->activeRecord->type . '_');
+				return Contao\Controller::getTemplateGroup('mod_' . $dc->activeRecord->type . '_', array(), 'mod_' . $dc->activeRecord->type);
 			},
-			'eval'                    => array('includeBlankOption'=>true, 'chosen'=>true, 'tl_class'=>'w50'),
+			'eval'                    => array('chosen'=>true, 'tl_class'=>'w50'),
 			'sql'                     => "varchar(64) NOT NULL default ''"
 		),
 		'pages' => array

--- a/core-bundle/src/Resources/contao/languages/en/tl_article.xlf
+++ b/core-bundle/src/Resources/contao/languages/en/tl_article.xlf
@@ -63,10 +63,10 @@
         <source>Hide the article if a member is logged in.</source>
       </trans-unit>
       <trans-unit id="tl_article.customTpl.0">
-        <source>Custom article template</source>
+        <source>Article template</source>
       </trans-unit>
       <trans-unit id="tl_article.customTpl.1">
-        <source>Here you can overwrite the default article template.</source>
+        <source>Here you can select the article template.</source>
       </trans-unit>
       <trans-unit id="tl_article.protected.0">
         <source>Protect article</source>

--- a/core-bundle/src/Resources/contao/languages/en/tl_content.xlf
+++ b/core-bundle/src/Resources/contao/languages/en/tl_content.xlf
@@ -294,13 +294,13 @@
         <source>Gallery template</source>
       </trans-unit>
       <trans-unit id="tl_content.galleryTpl.1">
-        <source>Here you can select the gallery template.</source>
+        <source>Here you can select a gallery template.</source>
       </trans-unit>
       <trans-unit id="tl_content.customTpl.0">
-        <source>Custom element template</source>
+        <source>Content element template</source>
       </trans-unit>
       <trans-unit id="tl_content.customTpl.1">
-        <source>Here you can overwrite the default element template.</source>
+        <source>Here you can select the content element template.</source>
       </trans-unit>
       <trans-unit id="tl_content.playerSRC.0">
         <source>Video/audio files</source>

--- a/core-bundle/src/Resources/contao/languages/en/tl_form.xlf
+++ b/core-bundle/src/Resources/contao/languages/en/tl_form.xlf
@@ -87,10 +87,10 @@
         <source>Store the submitted data in the database.</source>
       </trans-unit>
       <trans-unit id="tl_form.customTpl.0">
-        <source>Custom form template</source>
+        <source>Form template</source>
       </trans-unit>
       <trans-unit id="tl_form.customTpl.1">
-        <source>Here you can overwrite the default form template.</source>
+        <source>Here you can select the form template.</source>
       </trans-unit>
       <trans-unit id="tl_form.targetTable.0">
         <source>Target table</source>

--- a/core-bundle/src/Resources/contao/languages/en/tl_form_field.xlf
+++ b/core-bundle/src/Resources/contao/languages/en/tl_form_field.xlf
@@ -225,10 +225,10 @@
         <source>Here you can enter the size of the upload field (&lt;em&gt;size&lt;/em&gt; attribute).</source>
       </trans-unit>
       <trans-unit id="tl_form_field.customTpl.0">
-        <source>Custom form field template</source>
+        <source>Form field template</source>
       </trans-unit>
       <trans-unit id="tl_form_field.customTpl.1">
-        <source>Here you can overwrite the default form field template.</source>
+        <source>Here you can select the form field template.</source>
       </trans-unit>
       <trans-unit id="tl_form_field.slabel.0">
         <source>Submit button label</source>

--- a/core-bundle/src/Resources/contao/languages/en/tl_module.xlf
+++ b/core-bundle/src/Resources/contao/languages/en/tl_module.xlf
@@ -63,10 +63,10 @@
         <source>Here you can select the navigation template.</source>
       </trans-unit>
       <trans-unit id="tl_module.customTpl.0">
-        <source>Custom module template</source>
+        <source>Module template</source>
       </trans-unit>
       <trans-unit id="tl_module.customTpl.1">
-        <source>Here you can overwrite the default module template.</source>
+        <source>Here you can select the module template.</source>
       </trans-unit>
       <trans-unit id="tl_module.pages.0">
         <source>Pages</source>

--- a/listing-bundle/src/Resources/contao/languages/en/tl_module.xlf
+++ b/listing-bundle/src/Resources/contao/languages/en/tl_module.xlf
@@ -48,13 +48,13 @@
         <source>List template</source>
       </trans-unit>
       <trans-unit id="tl_module.list_layout.1">
-        <source>Here you can select the list template.</source>
+        <source>Here you can select a list template.</source>
       </trans-unit>
       <trans-unit id="tl_module.list_info_layout.0">
         <source>Details page template</source>
       </trans-unit>
       <trans-unit id="tl_module.list_info_layout.1">
-        <source>Here you can select the details page template.</source>
+        <source>Here you can select a details page template.</source>
       </trans-unit>
     </body>
   </file>

--- a/news-bundle/src/Resources/contao/languages/en/tl_module.xlf
+++ b/news-bundle/src/Resources/contao/languages/en/tl_module.xlf
@@ -36,7 +36,7 @@
         <source>News template</source>
       </trans-unit>
       <trans-unit id="tl_module.news_template.1">
-        <source>Here you can select the news template.</source>
+        <source>Here you can select a news template.</source>
       </trans-unit>
       <trans-unit id="tl_module.news_format.0">
         <source>Archive format</source>

--- a/newsletter-bundle/src/Resources/contao/languages/en/tl_module.xlf
+++ b/newsletter-bundle/src/Resources/contao/languages/en/tl_module.xlf
@@ -42,7 +42,7 @@
         <source>Newsletter template</source>
       </trans-unit>
       <trans-unit id="tl_module.nl_template.1">
-        <source>Here you can select the newsletter template.</source>
+        <source>Here you can select a newsletter template.</source>
       </trans-unit>
       <trans-unit id="tl_module.text_legend">
         <source>Custom text</source>

--- a/newsletter-bundle/src/Resources/contao/languages/en/tl_newsletter.xlf
+++ b/newsletter-bundle/src/Resources/contao/languages/en/tl_newsletter.xlf
@@ -39,10 +39,10 @@
         <source>Please choose the files to be attached from the files directory.</source>
       </trans-unit>
       <trans-unit id="tl_newsletter.template.0">
-        <source>Custom e-mail template</source>
+        <source>E-mail template</source>
       </trans-unit>
       <trans-unit id="tl_newsletter.template.1">
-        <source>Here you can override the default e-mail template of the channel.</source>
+        <source>Here you can override the e-mail template of the channel.</source>
       </trans-unit>
       <trans-unit id="tl_newsletter.sendText.0">
         <source>Send as plain text</source>

--- a/newsletter-bundle/src/Resources/contao/languages/en/tl_newsletter_channel.xlf
+++ b/newsletter-bundle/src/Resources/contao/languages/en/tl_newsletter_channel.xlf
@@ -18,7 +18,7 @@
         <source>E-mail template</source>
       </trans-unit>
       <trans-unit id="tl_newsletter_channel.template.1">
-        <source>Here you can choose the e-mail template.</source>
+        <source>Here you can select an e-mail template.</source>
       </trans-unit>
       <trans-unit id="tl_newsletter_channel.sender.0">
         <source>Sender e-mail address</source>


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #1060
| Docs PR or issue | -

Although this mostly works as discussed, there are edge cases like this:

<img width="628" alt="" src="https://user-images.githubusercontent.com/1192057/81574650-62d1eb00-93a6-11ea-9066-099ea620edca.png">

The screenshot shows that there is a custom `ce_text` template in the "Theme 2" theme. However, if the content element is used within "Theme 1", the default template will be used instead of the one of Theme 2, but the drop-down does not "say" so.

Not sure how to improve this, though.