### PR TITLE
Rename "security question" to "spam protection"

### DIFF
--- a/calendar-bundle/src/Resources/contao/languages/en/tl_calendar.xlf
+++ b/calendar-bundle/src/Resources/contao/languages/en/tl_calendar.xlf
@@ -57,7 +57,7 @@
         <source>Allow only authenticated users to create comments.</source>
       </trans-unit>
       <trans-unit id="tl_calendar.disableCaptcha.0">
-        <source>Disable the security question</source>
+        <source>Disable spam protection</source>
       </trans-unit>
       <trans-unit id="tl_calendar.disableCaptcha.1">
         <source>Use this option only if you have limited comments to authenticated users.</source>

--- a/comments-bundle/src/Resources/contao/languages/en/tl_content.xlf
+++ b/comments-bundle/src/Resources/contao/languages/en/tl_content.xlf
@@ -33,10 +33,10 @@
         <source>Allow only authenticated users to create comments.</source>
       </trans-unit>
       <trans-unit id="tl_content.com_disableCaptcha.0">
-        <source>Disable the security question</source>
+        <source>Disable spam protection</source>
       </trans-unit>
       <trans-unit id="tl_content.com_disableCaptcha.1">
-        <source>Here you can disable the security question (not recommended).</source>
+        <source>Here you can disable the spam protection (not recommended).</source>
       </trans-unit>
       <trans-unit id="tl_content.com_template.0">
         <source>Comments template</source>

--- a/core-bundle/src/Resources/contao/languages/en/tl_module.xlf
+++ b/core-bundle/src/Resources/contao/languages/en/tl_module.xlf
@@ -309,10 +309,10 @@
         <source>Here you can set an ID and one or more classes.</source>
       </trans-unit>
       <trans-unit id="tl_module.disableCaptcha.0">
-        <source>Disable the security question</source>
+        <source>Disable spam protection</source>
       </trans-unit>
       <trans-unit id="tl_module.disableCaptcha.1">
-        <source>Here you can disable the security question (not recommended).</source>
+        <source>Here you can disable the spam protection (not recommended).</source>
       </trans-unit>
       <trans-unit id="tl_module.reg_groups.0">
         <source>Member groups</source>

--- a/faq-bundle/src/Resources/contao/languages/en/tl_faq_category.xlf
+++ b/faq-bundle/src/Resources/contao/languages/en/tl_faq_category.xlf
@@ -63,7 +63,7 @@
         <source>Allow only authenticated users to create comments.</source>
       </trans-unit>
       <trans-unit id="tl_faq_category.disableCaptcha.0">
-        <source>Disable the security question</source>
+        <source>Disable spam protection</source>
       </trans-unit>
       <trans-unit id="tl_faq_category.disableCaptcha.1">
         <source>Use this option only if you have limited comments to authenticated users.</source>

--- a/news-bundle/src/Resources/contao/languages/en/tl_news_archive.xlf
+++ b/news-bundle/src/Resources/contao/languages/en/tl_news_archive.xlf
@@ -57,7 +57,7 @@
         <source>Allow only authenticated users to create comments.</source>
       </trans-unit>
       <trans-unit id="tl_news_archive.disableCaptcha.0">
-        <source>Disable the security question</source>
+        <source>Disable spam protection</source>
       </trans-unit>
       <trans-unit id="tl_news_archive.disableCaptcha.1">
         <source>Use this option only if you have limited comments to authenticated users.</source>


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #1718
| Docs PR or issue | contao/docs#359

Note that this PR only renames the "Disable the security question" option to "Disable spam protection" as suggested in #1718. The form field is still called "security question" and the error message is still "please answer the security question".
