### PR TITLE
Fix notices for empty database result sets

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Database/Result.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Database/Result.php
@@ -187,7 +187,7 @@ class Result
 				}
 
 				// Use array_key_exists() instead of isset(), because the value might be null
-				if (\array_key_exists($strKey, $this->resultSet[$this->intIndex]))
+				if (isset($this->resultSet[$this->intIndex]) && \array_key_exists($strKey, $this->resultSet[$this->intIndex]))
 				{
 					return $this->resultSet[$this->intIndex][$strKey];
 				}
@@ -392,10 +392,15 @@ class Result
 
 		if (!$this->isModified)
 		{
+			if (!isset($this->resultSet[$this->intIndex]))
+			{
+				return array();
+			}
+
 			return $blnEnumerated ? array_values($this->resultSet[$this->intIndex]) : $this->resultSet[$this->intIndex];
 		}
 
-		$row = array_merge($this->resultSet[$this->intIndex], $this->arrModified);
+		$row = array_merge(isset($this->resultSet[$this->intIndex]) ? $this->resultSet[$this->intIndex] : array(), $this->arrModified);
 
 		return $blnEnumerated ? array_values($row) : $row;
 	}

--- a/core-bundle/tests/Contao/Database/ResultTest.php
+++ b/core-bundle/tests/Contao/Database/ResultTest.php
@@ -14,6 +14,7 @@ namespace Contao\CoreBundle\Tests\Contao\Database;
 
 use Contao\CoreBundle\Tests\Fixtures\Database\DoctrineArrayStatement;
 use Contao\Database\Result;
+use PHPUnit\Framework\Error\Notice;
 use PHPUnit\Framework\TestCase;
 
 class ResultTest extends TestCase
@@ -25,16 +26,34 @@ class ResultTest extends TestCase
 
         /** @var Result|object $result */
         foreach ([$resultStatement, $resultArray] as $result) {
-            $this->assertFalse($result->isModified);
-            $this->assertSame(0, $result->numFields);
-            $this->assertSame(0, $result->numRows);
-            $this->assertSame('SELECT * FROM test', $result->query);
-            $this->assertSame(0, $result->count());
-            $this->assertSame([], $result->fetchAllAssoc());
-            $this->assertFalse($result->fetchAssoc());
-            $this->assertSame([], $result->fetchEach('test'));
-            $this->assertFalse($result->fetchRow());
+            foreach ([null, 'first', 'last', 'reset'] as $methodName) {
+                if ($methodName) {
+                    $this->assertSame($result, $result->$methodName());
+                }
+                $this->assertFalse($result->isModified);
+                $this->assertSame(0, $result->numFields);
+                $this->assertSame(0, $result->numRows);
+                $this->assertSame('SELECT * FROM test', $result->query);
+                $this->assertSame(0, $result->count());
+                $this->assertSame([], $result->fetchAllAssoc());
+                $this->assertFalse($result->fetchAssoc());
+                $this->assertSame([], $result->fetchEach('test'));
+                $this->assertFalse($result->fetchRow());
+                $this->assertSame([], $result->row());
+                $this->assertSame([], $result->row(true));
+                $this->assertFalse(isset($result->modifiedKey));
+                $this->assertNull($result->modifiedKey);
+                $result->modifiedKey = 'value';
+                $this->assertSame(['modifiedKey' => 'value'], $result->row());
+                $this->assertSame(['modifiedKey' => 'value'], $result->row(false));
+                $this->assertSame(['value'], $result->row(true));
+                $this->assertTrue(isset($result->modifiedKey));
+                $this->assertSame('value', $result->modifiedKey);
+            }
         }
+
+        $this->expectException(Notice::class);
+        $result->fetchField();
     }
 
     public function testSingleRow(): void
@@ -72,7 +91,12 @@ class ResultTest extends TestCase
             $this->assertSame('new value', $result->field);
             $this->assertSame(['field' => 'new value'], $result->row());
             $this->assertSame(['new value'], $result->row(true));
+            $this->assertSame('value1', $result->fetchField());
+            $this->assertSame('value1', $result->fetchField(0));
         }
+
+        $this->expectException(Notice::class);
+        $result->fetchField(1);
     }
 
     public function testMultipleRows(): void
@@ -115,7 +139,12 @@ class ResultTest extends TestCase
             $this->assertSame('new value', $result->field);
             $this->assertSame(['field' => 'new value'], $result->row());
             $this->assertSame(['new value'], $result->row(true));
+            $this->assertSame('value2', $result->fetchField());
+            $this->assertSame('value2', $result->fetchField(0));
         }
+
+        $this->expectException(Notice::class);
+        $result->fetchField(1);
     }
 
     public function testFetchRowAndAssoc(): void

--- a/core-bundle/tests/Contao/Database/ResultTest.php
+++ b/core-bundle/tests/Contao/Database/ResultTest.php
@@ -53,7 +53,7 @@ class ResultTest extends TestCase
         }
 
         $this->expectException(Notice::class);
-        $result->fetchField();
+        $resultStatement->fetchField();
     }
 
     public function testSingleRow(): void


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #1739 

Same as #1741 for the 4.9 branch