### PR TITLE
Correctly check for duplicate input parameters

### DIFF
--- a/core-bundle/src/Routing/Enhancer/InputEnhancer.php
+++ b/core-bundle/src/Routing/Enhancer/InputEnhancer.php
@@ -81,7 +81,7 @@ class InputEnhancer implements RouteEnhancerInterface
             }
 
             // Abort if there is a duplicate parameter (duplicate content) (see #4277)
-            if ($request->query->has($fragments[$i]) || \in_array($fragments[$i], $inputKeys)) {
+            if ($request->query->has($fragments[$i]) || \in_array($fragments[$i], $inputKeys, true)) {
                 throw new ResourceNotFoundException(sprintf('Duplicate parameter "%s" in path', $fragments[$i]));
             }
 

--- a/core-bundle/src/Routing/Enhancer/InputEnhancer.php
+++ b/core-bundle/src/Routing/Enhancer/InputEnhancer.php
@@ -63,6 +63,7 @@ class InputEnhancer implements RouteEnhancerInterface
         /** @var Config $config */
         $config = $this->framework->getAdapter(Config::class);
         $fragments = explode('/', substr($defaults['parameters'], 1));
+        $inputKeys = [];
 
         // Add the second fragment as auto_item if the number of fragments is even
         if (0 !== \count($fragments) % 2) {
@@ -80,8 +81,7 @@ class InputEnhancer implements RouteEnhancerInterface
             }
 
             // Abort if there is a duplicate parameter (duplicate content) (see #4277)
-            // Do not use the request here, as we only need to make sure not to overwrite globals with Input::setGet()
-            if (isset($_GET[$fragments[$i]])) {
+            if ($request->query->has($fragments[$i]) || \in_array($fragments[$i], $inputKeys)) {
                 throw new ResourceNotFoundException(sprintf('Duplicate parameter "%s" in path', $fragments[$i]));
             }
 
@@ -94,6 +94,7 @@ class InputEnhancer implements RouteEnhancerInterface
                 throw new ResourceNotFoundException(sprintf('"%s" is an auto_item keyword (duplicate content)', $fragments[$i]));
             }
 
+            $inputKeys[] = $fragments[$i];
             $input->setGet($fragments[$i], $fragments[$i + 1], true);
         }
 

--- a/core-bundle/tests/Routing/Enhancer/InputEnhancerTest.php
+++ b/core-bundle/tests/Routing/Enhancer/InputEnhancerTest.php
@@ -139,6 +139,29 @@ class InputEnhancerTest extends TestCase
     {
         $input = $this->mockAdapter(['setGet']);
         $input
+            ->expects($this->once())
+            ->method('setGet')
+        ;
+
+        $framework = $this->mockContaoFramework([Input::class => $input]);
+
+        $defaults = [
+            'pageModel' => $this->createMock(PageModel::class),
+            'parameters' => '/foo/bar/foo/bar',
+        ];
+
+        $enhancer = new InputEnhancer($framework, false);
+
+        $this->expectException(ResourceNotFoundException::class);
+        $this->expectExceptionMessage('Duplicate parameter "foo" in path');
+
+        $enhancer->enhance($defaults, Request::create('/'));
+    }
+
+    public function testThrowsAnExceptionUponParametersInQuery(): void
+    {
+        $input = $this->mockAdapter(['setGet']);
+        $input
             ->expects($this->never())
             ->method('setGet')
         ;
@@ -150,14 +173,12 @@ class InputEnhancerTest extends TestCase
             'parameters' => '/foo/bar',
         ];
 
-        $_GET = ['foo' => 'baz'];
-
         $enhancer = new InputEnhancer($framework, false);
 
         $this->expectException(ResourceNotFoundException::class);
         $this->expectExceptionMessage('Duplicate parameter "foo" in path');
 
-        $enhancer->enhance($defaults, Request::create('/'));
+        $enhancer->enhance($defaults, Request::create('/?foo=bar'));
     }
 
     public function testThrowsAnExceptionIfAnAutoItemKeywordIsPresent(): void


### PR DESCRIPTION
This fixes issue when manually matching requests, e.g. for the search indexer.

The mentioned issue (contao/core#4277) describes multiple cases, and it is where we added the _unused argument_ stuff. These lines were previously added to prevent duplicate parameters in the URL.
 1. For `http://example.com/foo/bar/foo/baz.html`, Contao (previously) correctly rendered the page with `foo` being set to `baz`. This also allowed for duplicate page URLs (e.g. `http://example.com/foo/bar/foo/bar/foo/bar/foo/baz.html` and the _unused argument_ handling wouldn't kick in.
 2. It should also not be possible to repeat a parameter that is already present in query parameters (e.g. `http://example.com/foo/bar.html?foo=baz`).

In Contao 3, this meant checking the `$_GET` array for duplicate data. In Symfony, this should only match on the current request.

**Warning:** what this PR cannot solve (and wasn't solved before) is actually running multiple requests that change the `$_GET` parameters 🤷 