### PR TITLE
Allow forcing a password change upon login in the contao:user:password command

### DIFF
--- a/core-bundle/src/Command/UserPasswordCommand.php
+++ b/core-bundle/src/Command/UserPasswordCommand.php
@@ -66,7 +66,7 @@ class UserPasswordCommand extends Command
             ->setName('contao:user:password')
             ->addArgument('username', InputArgument::REQUIRED, 'The username of the back end user')
             ->addOption('password', 'p', InputOption::VALUE_REQUIRED, 'The new password (using this option is not recommended for security reasons)')
-            ->addOption('require-change', 'r', InputOption::VALUE_NONE, 'Require the user to change the password on next login.')
+            ->addOption('require-change', 'r', InputOption::VALUE_NONE, 'Require the user to change the password on their next login.')
             ->setDescription('Changes the password of a Contao back end user.')
         ;
     }

--- a/core-bundle/src/Command/UserPasswordCommand.php
+++ b/core-bundle/src/Command/UserPasswordCommand.php
@@ -116,7 +116,7 @@ class UserPasswordCommand extends Command
                 'password' => $hash,
                 'locked' => 0,
                 'loginAttempts' => 0,
-                'pwChange' => $input->getOption('require-change'),
+                'pwChange' => $input->getOption('require-change') ? '1' : '',
             ],
             ['username' => $input->getArgument('username')]
         );

--- a/core-bundle/src/Command/UserPasswordCommand.php
+++ b/core-bundle/src/Command/UserPasswordCommand.php
@@ -66,6 +66,7 @@ class UserPasswordCommand extends Command
             ->setName('contao:user:password')
             ->addArgument('username', InputArgument::REQUIRED, 'The username of the back end user')
             ->addOption('password', 'p', InputOption::VALUE_REQUIRED, 'The new password (using this option is not recommended for security reasons)')
+            ->addOption('require-change', 'r', InputOption::VALUE_NONE, 'Require the user to change the password on next login.')
             ->setDescription('Changes the password of a Contao back end user.')
         ;
     }
@@ -111,7 +112,12 @@ class UserPasswordCommand extends Command
 
         $affected = $this->connection->update(
             'tl_user',
-            ['password' => $hash, 'locked' => 0, 'loginAttempts' => $config->get('loginAttempts')],
+            [
+                'password' => $hash,
+                'locked' => 0,
+                'loginAttempts' => 0,
+                'pwChange' => $input->getOption('require-change'),
+            ],
             ['username' => $input->getArgument('username')]
         );
 

--- a/core-bundle/tests/Command/UserPasswordCommandTest.php
+++ b/core-bundle/tests/Command/UserPasswordCommandTest.php
@@ -166,7 +166,7 @@ class UserPasswordCommandTest extends TestCase
     /**
      * @dataProvider usernamePasswordProvider
      */
-    public function testUpdatesTheDatabaseOnSuccess(string $username, string $password): void
+    public function testResetsPassword(string $username, string $password): void
     {
         /** @var Connection&MockObject $connection */
         $connection = $this->createMock(Connection::class);
@@ -179,7 +179,7 @@ class UserPasswordCommandTest extends TestCase
                     'password' => '$argon2id$v=19$m=65536,t=6,p=1$T+WK0xPOk21CQ2dX9AFplw$2uCrfvt7Tby81Dhc8Y7wHQQGP1HnPC3nDEb4FtXsfrQ',
                     'locked' => 0,
                     'loginAttempts' => 0,
-                    'pwChange' => false,
+                    'pwChange' => '',
                 ],
                 ['username' => $username]
             )
@@ -200,6 +200,40 @@ class UserPasswordCommandTest extends TestCase
     {
         yield ['foobar', '12345678'];
         yield ['k.jones', 'kevinjones'];
+    }
+
+    public function testResetsPasswordWithRequiredChangeOnNextLogin(): void
+    {
+        $username = 'foobar';
+        $password = '12345678';
+
+        /** @var Connection&MockObject $connection */
+        $connection = $this->createMock(Connection::class);
+        $connection
+            ->expects($this->once())
+            ->method('update')
+            ->with(
+                'tl_user',
+                [
+                    'password' => '$argon2id$v=19$m=65536,t=6,p=1$T+WK0xPOk21CQ2dX9AFplw$2uCrfvt7Tby81Dhc8Y7wHQQGP1HnPC3nDEb4FtXsfrQ',
+                    'locked' => 0,
+                    'loginAttempts' => 0,
+                    'pwChange' => '1',
+                ],
+                ['username' => $username]
+            )
+            ->willReturn(1)
+        ;
+
+        $input = [
+            'username' => $username,
+            '--password' => $password,
+            '--require-change' => null,
+        ];
+
+        $command = $this->getCommand($connection, $password);
+
+        (new CommandTester($command))->execute($input, ['interactive' => false]);
     }
 
     /**

--- a/core-bundle/tests/Command/UserPasswordCommandTest.php
+++ b/core-bundle/tests/Command/UserPasswordCommandTest.php
@@ -179,6 +179,7 @@ class UserPasswordCommandTest extends TestCase
                     'password' => '$argon2id$v=19$m=65536,t=6,p=1$T+WK0xPOk21CQ2dX9AFplw$2uCrfvt7Tby81Dhc8Y7wHQQGP1HnPC3nDEb4FtXsfrQ',
                     'locked' => 0,
                     'loginAttempts' => 0,
+                    'pwChange' => false,
                 ],
                 ['username' => $username]
             )

--- a/core-bundle/tests/Command/UserPasswordCommandTest.php
+++ b/core-bundle/tests/Command/UserPasswordCommandTest.php
@@ -207,7 +207,6 @@ class UserPasswordCommandTest extends TestCase
         $username = 'foobar';
         $password = '12345678';
 
-        /** @var Connection&MockObject $connection */
         $connection = $this->createMock(Connection::class);
         $connection
             ->expects($this->once())


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes none
| Docs PR or issue | -

see https://github.com/contao/contao/pull/1724#issuecomment-629143761

This also includes the changes from #1724. Should probably be another PR against the 4.9 branch, right?

I wonder If we would also like to have a function to generate passwords. This would come in handy with this option.