### PR TITLE
Prevent brute force in ModuleCloseAccount

### DIFF
--- a/core-bundle/src/Resources/contao/modules/ModuleCloseAccount.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleCloseAccount.php
@@ -86,6 +86,7 @@ class ModuleCloseAccount extends \Module
 			{
 				$objWidget->value = '';
 				$objWidget->addError($GLOBALS['TL_LANG']['ERR']['invalidPass']);
+				sleep(2); // Wait 2 seconds while brute forcing :)
 			}
 
 			// Close account


### PR DESCRIPTION
Prevent brute force in ``ModuleCloseAccount`` with ``sleep(2)`` as in ``ModuleChangePassword``.

https://github.com/contao/contao/blob/9c0502bc4b41f5208a3f54e0e07e5d509be2654e/core-bundle/src/Resources/contao/modules/ModuleChangePassword.php#L149-L154