### PR TITLE
Prevent password spraying in ModuleLogin

### DIFF
--- a/core-bundle/src/Resources/contao/modules/ModuleLogin.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleLogin.php
@@ -117,6 +117,8 @@ class ModuleLogin extends \Module
 				$this->redirect($strRedirect);
 			}
 
+			sleep(2); // Wait 2 seconds while brute forcing to prevent password spraying :)
+
 			$this->reload();
 		}
 


### PR DESCRIPTION
Prevent password spraying in ``ModuleLogin`` with ``sleep(2)``.