### PR TITLE
Correctly track if container config files exist

### DIFF
--- a/manager-bundle/src/HttpKernel/ContaoKernel.php
+++ b/manager-bundle/src/HttpKernel/ContaoKernel.php
@@ -152,9 +152,11 @@ class ContaoKernel extends Kernel
      */
     public function registerContainerConfiguration(LoaderInterface $loader)
     {
-        if (file_exists($this->getRootDir().'/config/parameters.yml')) {
-            $loader->load($this->getRootDir().'/config/parameters.yml');
-        }
+        $loader->load(function (ContainerBuilder $container) use ($loader) {
+            if ($container->fileExists($this->getRootDir().'/config/parameters.yml')) {
+                $loader->load($this->getRootDir().'/config/parameters.yml');
+            }
+        });
 
         /** @var ConfigPluginInterface[] $plugins */
         $plugins = $this->getPluginLoader()->getInstancesOf(PluginLoader::CONFIG_PLUGINS);
@@ -163,16 +165,16 @@ class ContaoKernel extends Kernel
             $plugin->registerContainerConfiguration($loader, []);
         }
 
-        if (file_exists($this->getRootDir().'/config/parameters.yml')) {
-            $loader->load($this->getRootDir().'/config/parameters.yml');
-        }
-
         $loader->load(function (ContainerBuilder $container) use ($loader) {
+            if ($container->fileExists($this->getRootDir().'/config/parameters.yml')) {
+                $loader->load($this->getRootDir().'/config/parameters.yml');
+            }
+
             $environment = $container->getParameter('kernel.environment');
 
-            if (file_exists($this->getRootDir().'/config/config_'.$environment.'.yml')) {
+            if ($container->fileExists($this->getRootDir().'/config/config_'.$environment.'.yml')) {
                 $loader->load($this->getRootDir().'/config/config_'.$environment.'.yml');
-            } elseif (file_exists($this->getRootDir().'/config/config.yml')) {
+            } elseif ($container->fileExists($this->getRootDir().'/config/config.yml')) {
                 $loader->load($this->getRootDir().'/config/config.yml');
             }
         });


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #1766

The container tracks files for changes or existence in debug mode, to automatically rebuild in that case. This PR fixes the mentioned issue for Contao 4.4, I assume a separate PR is needed after this is merged upstream.
