### PR TITLE
Correctly redirect to the preferred language if there is no index alias

### DIFF
--- a/core-bundle/src/Routing/RouteProvider.php
+++ b/core-bundle/src/Routing/RouteProvider.php
@@ -424,14 +424,6 @@ class RouteProvider implements RouteProviderInterface
                     return 0;
                 }
 
-                if ('root' !== $pageA->type && 'root' === $pageB->type) {
-                    return -1;
-                }
-
-                if ('root' === $pageA->type && 'root' !== $pageB->type) {
-                    return 1;
-                }
-
                 if (null !== $languages && $pageA->rootLanguage !== $pageB->rootLanguage) {
                     $langA = $languages[$pageA->rootLanguage] ?? null;
                     $langB = $languages[$pageB->rootLanguage] ?? null;
@@ -456,7 +448,21 @@ class RouteProvider implements RouteProviderInterface
                         return -1;
                     }
 
-                    return $langA < $langB ? -1 : 1;
+                    if ($langA < $langB) {
+                        return -1;
+                    }
+
+                    if ($langA > $langB) {
+                        return 1;
+                    }
+                }
+
+                if ('root' !== $pageA->type && 'root' === $pageB->type) {
+                    return -1;
+                }
+
+                if ('root' === $pageA->type && 'root' !== $pageB->type) {
+                    return 1;
                 }
 
                 return strnatcasecmp((string) $pageB->alias, (string) $pageA->alias);
@@ -533,7 +539,7 @@ class RouteProvider implements RouteProviderInterface
             $rootPages = $pages->getModels();
         }
 
-        $pages = $pageModel->findBy(["tl_page.alias='index' OR tl_page.alias='/'"], null);
+        $pages = $pageModel->findBy(["tl_page.alias IN ('index', '/')"], null);
 
         if ($pages instanceof Collection) {
             $indexPages = $pages->getModels();

--- a/core-bundle/src/Routing/RouteProvider.php
+++ b/core-bundle/src/Routing/RouteProvider.php
@@ -539,7 +539,7 @@ class RouteProvider implements RouteProviderInterface
             $rootPages = $pages->getModels();
         }
 
-        $pages = $pageModel->findBy(["tl_page.alias IN ('index', '/')"], null);
+        $pages = $pageModel->findBy(["tl_page.alias='index' OR tl_page.alias='/'"], null);
 
         if ($pages instanceof Collection) {
             $indexPages = $pages->getModels();


### PR DESCRIPTION
The current implementation always sorts pages with "index" alias before the root page. However, this can cause an issue in the following example:

- root page "en"
- root page "de"
- "en" page with alias "index"
- no "index" page in the german page tree

even if the user has preferred language "de", the english page will be served because the english tree has an "index" page.