### PR TITLE
Ignore the Litespeed HTTP2 Smart Push cookie

### DIFF
--- a/core-bundle/src/EventListener/HttpCache/StripCookiesSubscriber.php
+++ b/core-bundle/src/EventListener/HttpCache/StripCookiesSubscriber.php
@@ -56,6 +56,9 @@ class StripCookiesSubscriber implements EventSubscriberInterface
 
         // Blackfire
         '__blackfire',
+        
+        // Litespeed HTTP2 Smart Push
+        'ls_smartpush',
     ];
 
     /**

--- a/core-bundle/src/EventListener/HttpCache/StripCookiesSubscriber.php
+++ b/core-bundle/src/EventListener/HttpCache/StripCookiesSubscriber.php
@@ -56,7 +56,7 @@ class StripCookiesSubscriber implements EventSubscriberInterface
 
         // Blackfire
         '__blackfire',
-        
+
         // Litespeed HTTP2 Smart Push
         'ls_smartpush',
     ];


### PR DESCRIPTION
Litespeed sends an `ls_smartpush` cookie to remember which files it has already pushed to the client (not sure that's the best way to go as of 2020 but anyway, it's not something we can change :)).