### PR TITLE
Recreate sitemap xml, when regenerating news RSS

### DIFF
--- a/news-bundle/src/Resources/contao/classes/News.php
+++ b/news-bundle/src/Resources/contao/classes/News.php
@@ -61,7 +61,8 @@ class News extends Frontend
 	{
 		$this->import(Automator::class, 'Automator');
 		$this->Automator->purgeXmlFiles();
-
+		$this->Automator->generateSitemap();
+		
 		$objFeed = NewsFeedModel::findAll();
 
 		if ($objFeed !== null)


### PR DESCRIPTION
When regenerating RSS feeds using function `generateFeeds()`. It also removes all XML files including sitemaps xml files.
