### PR TITLE
Remove the autoload_files option from the phpstan.neon.dist file

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -11,9 +11,6 @@ rules:
     - TheCodingMachine\PHPStan\Rules\Exceptions\ThrowMustBundlePreviousExceptionRule
 
 parameters:
-    autoload_files:
-        - %currentWorkingDirectory%/vendor/autoload.php
-
     contao:
         services_yml_path: %currentWorkingDirectory%/core-bundle/src/Resources/config/services.yml
 


### PR DESCRIPTION
```
⚠️  You're using a deprecated config option autoload_files. ⚠️️

You might not need it anymore - try removing it from your
configuration file and run PHPStan again.

If the analysis fails, there are now two distinct options
to choose from to replace autoload_files:
1) scanFiles - PHPStan will scan those for classes and functions
   definitions. PHPStan will not execute those files.
2) bootstrapFiles - PHPStan will execute these files to prepare
   the PHP runtime environment for the analysis.
```