### PR TITLE
Ignore minlength/maxlength/minval/maxval in hidden fields

### DIFF
--- a/core-bundle/src/Resources/contao/forms/FormHidden.php
+++ b/core-bundle/src/Resources/contao/forms/FormHidden.php
@@ -32,6 +32,30 @@ class FormHidden extends Widget
 	protected $strTemplate = 'form_hidden';
 
 	/**
+	 * Add specific attributes
+	 *
+	 * @param string $strKey   The attribute key
+	 * @param mixed  $varValue The attribute value
+	 */
+	public function __set($strKey, $varValue)
+	{
+		switch ($strKey)
+		{
+			case 'rgxp':
+			case 'minlength':
+			case 'maxlength':
+			case 'minval':
+			case 'maxval':
+				// Ignore
+				break;
+
+			default:
+				parent::__set($strKey, $varValue);
+				break;
+		}
+	}
+
+	/**
 	 * Generate the widget and return it as string
 	 *
 	 * @return string The widget markup

--- a/core-bundle/src/Resources/contao/forms/FormHidden.php
+++ b/core-bundle/src/Resources/contao/forms/FormHidden.php
@@ -41,7 +41,6 @@ class FormHidden extends Widget
 	{
 		switch ($strKey)
 		{
-			case 'rgxp':
 			case 'minlength':
 			case 'maxlength':
 			case 'minval':


### PR DESCRIPTION
As a follow-up on #1699. Steps to reproduce the problem:

1. Create a new form field of `text` type in form generator.
2. Add some validation like `minlength/maxlength/minval/maxval`.
3. Switch to the `hidden` type.
4. The form submission can now fail due to "hidden" error for that field.

It **might** be somewhat a BC break for some projects but IMO it's a bug.