### PR TITLE
Correctly fix the mailer transport

### DIFF
--- a/manager-bundle/src/ContaoManager/Plugin.php
+++ b/manager-bundle/src/ContaoManager/Plugin.php
@@ -244,11 +244,13 @@ class Plugin implements BundlePluginInterface, ConfigPluginInterface, RoutingPlu
                 return $this->addDefaultServerVersion($extensionConfigs, $container);
 
             case 'swiftmailer':
+                $extensionConfigs = $this->checkMailerTransport($extensionConfigs, $container);
+
                 if (!isset($_SERVER['MAILER_URL'])) {
                     $container->setParameter('env(MAILER_URL)', $this->getMailerUrl($container));
                 }
 
-                return $this->checkMailerTransport($extensionConfigs, $container);
+                return $extensionConfigs;
         }
 
         return $extensionConfigs;

--- a/manager-bundle/tests/ContaoManager/PluginTest.php
+++ b/manager-bundle/tests/ContaoManager/PluginTest.php
@@ -490,6 +490,16 @@ class PluginTest extends ContaoTestCase
     public function getMailerParameters(): \Generator
     {
         yield [
+            'mail',
+            '127.0.0.1',
+            null,
+            null,
+            25,
+            null,
+            'sendmail://localhost',
+        ];
+
+        yield [
             'sendmail',
             '127.0.0.1',
             null,


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | N/A
| Docs PR or issue | N/A

While working on a PR that replaces `symfony/swiftmailer-bundle` with `symfony/mailer` I noticed a small bug: the Contao Manager Plugin of the Manager Bundle currently checks for a `mailer_transport` parameter with the content `mail`, which is supposed to be changed to `sendmail` instead, since Swiftmailer dropped the support of the PHP `mail()` function.

However, this does not work in theory because it is done _after_ the DSN for the mailer was already built. So if you had `mailer_transport: mail` in your `parameters.yml`, it would use `smtp://…` instead of `sendmail://localhost`. It only works because during cache warming, `getExtensionConfig()` is called multiple times. So after the second time, `env(MAILER_URL)` will be correct again.

This PR adds the failing test for that and changes the order of execution to fix it.