### PR TITLE
Fix PhpStan

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -153,6 +153,7 @@
         "doctrine/event-manager": "^1.0",
         "monolog/monolog": "^1.24",
         "phpunit/phpunit": "^8.4",
+        "psr/event-dispatcher": "^1.0",
         "slam/phpstan-extensions": "^5.0",
         "symfony/browser-kit": "4.4.*",
         "symfony/phpunit-bridge": "4.4.*"

--- a/core-bundle/composer.json
+++ b/core-bundle/composer.json
@@ -123,6 +123,7 @@
         "lexik/maintenance-bundle": "^2.1.5",
         "monolog/monolog": "^1.24",
         "phpunit/phpunit": "^8.4",
+        "psr/event-dispatcher": "^1.0",
         "symfony/browser-kit": "4.4.*",
         "symfony/http-client": "4.4.*",
         "symfony/phpunit-bridge": "4.4.*"

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -11,9 +11,6 @@ rules:
     - TheCodingMachine\PHPStan\Rules\Exceptions\ThrowMustBundlePreviousExceptionRule
 
 parameters:
-    autoload_files:
-        - %currentWorkingDirectory%/vendor/autoload.php
-
     contao:
         services_yml_path: %currentWorkingDirectory%/core-bundle/src/Resources/config/services.yml
 


### PR DESCRIPTION
I have fixed the PhpStan error

```
Reflection error: Psr\EventDispatcher\StoppableEventInterface not   
found.                                                              
💡 Learn more at https://phpstan.org/user-guide/discovering-symbols
```

by adding `"psr/event-dispatcher": "^1.0"` to the dev requirements. However, it seems odd that I have to do this although we are already requiring `"symfony/event-dispatcher"`. @Toflar Can this be correct?

