### PR TITLE
Improve the performance of the file manager

### DIFF
--- a/core-bundle/src/Resources/contao/dca/tl_files.php
+++ b/core-bundle/src/Resources/contao/dca/tl_files.php
@@ -385,7 +385,7 @@ class tl_files extends Contao\Backend
 					{
 						$finder = Symfony\Component\Finder\Finder::create()->in($rootDir . '/' . $strFile);
 
-						if (!$canDeleteRecursive && $finder->count() > 0)
+						if (!$canDeleteRecursive && $finder->hasResults())
 						{
 							throw new Contao\CoreBundle\Exception\AccessDeniedException('No permission to delete folder "' . $strFile . '" recursively.');
 						}
@@ -730,7 +730,7 @@ class tl_files extends Contao\Backend
 
 		$finder = Symfony\Component\Finder\Finder::create()->in($path);
 
-		if ($finder->count() > 0)
+		if ($finder->hasResults())
 		{
 			return $this->User->hasAccess('f4', 'fop') ? '<a href="' . $this->addToUrl($href . '&amp;id=' . $row['id']) . '" title="' . Contao\StringUtil::specialchars($title) . '"' . $attributes . '>' . Contao\Image::getHtml($icon, $label) . '</a> ' : Contao\Image::getHtml(preg_replace('/\.svg$/i', '_.svg', $icon)) . ' ';
 		}


### PR DESCRIPTION
I found a huge performance bottleneck in the file manager.

To check for permissions, we count all the files for every single delete button callback recursively. However, we only need to know if there is at least something so the actual number is completely irrelevant to us and we can early return.

Saved 2 seconds of loading time for my use case :) 