### PR TITLE
Improve the legacy class import performance

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/System.php
+++ b/core-bundle/src/Resources/contao/library/Contao/System.php
@@ -85,6 +85,12 @@ abstract class System
 	protected static $arrStaticObjects = array();
 
 	/**
+	 * Singletons
+	 * @var array
+	 */
+	protected static $arrSingletons = array();
+
+	/**
 	 * Available languages
 	 * @var array
 	 */
@@ -164,6 +170,10 @@ abstract class System
 			{
 				$this->arrObjects[$strKey] = $strClass;
 			}
+			elseif (isset(static::$arrSingletons[$strKey]))
+			{
+				$this->arrObjects[$strKey] = static::$arrSingletons[$strKey];
+			}
 			elseif ($container->has($strClass) && (strpos($strClass, '\\') !== false || !class_exists($strClass)))
 			{
 				$this->arrObjects[$strKey] = $container->get($strClass);
@@ -174,7 +184,7 @@ abstract class System
 			}
 			elseif (\in_array('getInstance', get_class_methods($strClass)))
 			{
-				$this->arrObjects[$strKey] = \call_user_func(array($strClass, 'getInstance'));
+				static::$arrStaticObjects[$strKey] = static::$arrSingletons[$strKey] = $this->arrObjects[$strKey] = \call_user_func(array($strClass, 'getInstance'));
 			}
 			else
 			{
@@ -221,7 +231,7 @@ abstract class System
 			}
 			elseif (\in_array('getInstance', get_class_methods($strClass)))
 			{
-				static::$arrStaticObjects[$strKey] = \call_user_func(array($strClass, 'getInstance'));
+				static::$arrStaticObjects[$strKey] = static::$arrSingletons[$strKey] = \call_user_func(array($strClass, 'getInstance'));
 			}
 			else
 			{


### PR DESCRIPTION
All of our legacy code that still uses `$this->import()` currently causes hundreds of `$container->getRemovedIds()` calls. This is especially true for our legacy singletons.

These calls are slow and e.g. in the file manager where we instantiate hundreds of old `Contao\File` objects that all import the old `Contao\Files` class, things are never shared and the calls to the container happen over and over again.

Another 0.4s shaved off for a rather normal file manager list view call 😊 

4.4 is not directly affected because it never calls the container for removed service IDs so I figured we go 4.9 only here.