### PR TITLE
Get rid of a massive amount of is_dir() checks that are not necessary

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/File.php
+++ b/core-bundle/src/Resources/contao/library/Contao/File.php
@@ -125,11 +125,12 @@ class File extends System
 	/**
 	 * Instantiate a new file object
 	 *
-	 * @param string $strFile The file path
+	 * @param string $strFile 		 The file path
+	 * @param bool   $blnValidateDir Ensures that the provided file path is not a directory
 	 *
 	 * @throws \Exception If $strFile is a directory
 	 */
-	public function __construct($strFile)
+	public function __construct($strFile, $blnValidateDir = true)
 	{
 		// Handle open_basedir restrictions
 		if ($strFile == '.')
@@ -140,7 +141,7 @@ class File extends System
 		$this->strRootDir = System::getContainer()->getParameter('kernel.project_dir');
 
 		// Make sure we are not pointing to a directory
-		if (is_dir($this->strRootDir . '/' . $strFile))
+		if ($blnValidateDir && is_dir($this->strRootDir . '/' . $strFile))
 		{
 			throw new \Exception(sprintf('Directory "%s" is not a file', $strFile));
 		}

--- a/core-bundle/src/Resources/contao/library/Contao/Image.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Image.php
@@ -706,7 +706,8 @@ class Image
 			}
 		}
 
-		$objFile = new File($src);
+		// We know it's a file here so we can disable the directory check for performance reasons
+		$objFile = new File($src, false);
 
 		// Strip the web/ prefix (see #337)
 		if (strncmp($src, $webDir . '/', \strlen($webDir) + 1) === 0)


### PR DESCRIPTION
The file manager currently executes hundreds of unnecessary `is_dir()` calls although we already know it cannot be a directory.