### PR TITLE
Lazy-load commands

### DIFF
--- a/core-bundle/src/Command/AutomatorCommand.php
+++ b/core-bundle/src/Command/AutomatorCommand.php
@@ -28,6 +28,8 @@ use Symfony\Component\Console\Question\ChoiceQuestion;
  */
 class AutomatorCommand extends Command
 {
+    protected static $defaultName = 'contao:automator';
+
     /**
      * @var array
      */
@@ -48,8 +50,7 @@ class AutomatorCommand extends Command
     protected function configure(): void
     {
         $this
-            ->setName('contao:automator')
-            ->addArgument('task', InputArgument::OPTIONAL, 'The name of the task')
+            ->addArgument('task', InputArgument::OPTIONAL, "The name of the task:\n  - ".implode("\n  - ", $this->getCommands()))
             ->setDescription('Runs automator tasks on the command line.')
         ;
     }

--- a/core-bundle/src/Command/AutomatorCommand.php
+++ b/core-bundle/src/Command/AutomatorCommand.php
@@ -49,7 +49,7 @@ class AutomatorCommand extends Command
     {
         $this
             ->setName('contao:automator')
-            ->addArgument('task', InputArgument::OPTIONAL, "The name of the task:\n  - ".implode("\n  - ", $this->getCommands()))
+            ->addArgument('task', InputArgument::OPTIONAL, 'The name of the task')
             ->setDescription('Runs automator tasks on the command line.')
         ;
     }

--- a/core-bundle/src/Command/CrawlCommand.php
+++ b/core-bundle/src/Command/CrawlCommand.php
@@ -42,6 +42,8 @@ use Terminal42\Escargot\Subscriber\SubscriberInterface;
 
 class CrawlCommand extends Command
 {
+    protected static $defaultName = 'contao:crawl';
+
     /**
      * @var Factory
      */
@@ -73,7 +75,6 @@ class CrawlCommand extends Command
     protected function configure(): void
     {
         $this
-            ->setName('contao:crawl')
             ->addArgument('job', InputArgument::OPTIONAL, 'An optional existing job ID')
             ->addOption('subscribers', 's', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'A list of subscribers to enable', $this->escargotFactory->getSubscriberNames())
             ->addOption('concurrency', 'c', InputOption::VALUE_REQUIRED, 'The number of concurrent requests that are going to be executed', 10)

--- a/core-bundle/src/Command/CronCommand.php
+++ b/core-bundle/src/Command/CronCommand.php
@@ -19,6 +19,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class CronCommand extends Command
 {
+    protected static $defaultName = 'contao:cron';
+
     /**
      * @var Cron
      */
@@ -34,7 +36,6 @@ class CronCommand extends Command
     protected function configure(): void
     {
         $this
-            ->setName('contao:cron')
             ->setDescription('Runs all registered cron jobs on the command line.')
         ;
     }

--- a/core-bundle/src/Command/DebugDcaCommand.php
+++ b/core-bundle/src/Command/DebugDcaCommand.php
@@ -28,6 +28,8 @@ use Symfony\Component\VarDumper\Dumper\CliDumper;
  */
 class DebugDcaCommand extends Command
 {
+    protected static $defaultName = 'debug:dca';
+
     /**
      * @var ContaoFramework
      */
@@ -43,7 +45,6 @@ class DebugDcaCommand extends Command
     protected function configure(): void
     {
         $this
-            ->setName('debug:dca')
             ->addArgument('table', InputArgument::REQUIRED, 'The table name')
             ->setDescription('Dumps the DCA configuration for a table.')
         ;

--- a/core-bundle/src/Command/DebugDcaCommand.php
+++ b/core-bundle/src/Command/DebugDcaCommand.php
@@ -53,6 +53,7 @@ class DebugDcaCommand extends Command
     {
         $table = $input->getArgument('table');
 
+        $this->framework->initialize();
         $dcaLoader = $this->framework->createInstance(DcaLoader::class, [$table]);
         $dcaLoader->load();
 

--- a/core-bundle/src/Command/FilesyncCommand.php
+++ b/core-bundle/src/Command/FilesyncCommand.php
@@ -28,10 +28,11 @@ class FilesyncCommand extends Command implements FrameworkAwareInterface
 {
     use FrameworkAwareTrait;
 
+    protected static $defaultName = 'contao:filesync';
+
     protected function configure(): void
     {
         $this
-            ->setName('contao:filesync')
             ->setDescription('Synchronizes the file system with the database.')
         ;
     }

--- a/core-bundle/src/Command/InstallCommand.php
+++ b/core-bundle/src/Command/InstallCommand.php
@@ -26,6 +26,8 @@ use Symfony\Component\Filesystem\Filesystem;
  */
 class InstallCommand extends Command
 {
+    protected static $defaultName = 'contao:install';
+
     /**
      * @var Filesystem
      */
@@ -73,7 +75,6 @@ class InstallCommand extends Command
     protected function configure(): void
     {
         $this
-            ->setName('contao:install')
             ->addArgument('target', InputArgument::OPTIONAL, 'The target directory', 'web')
             ->setDescription('Installs the required Contao directories')
         ;

--- a/core-bundle/src/Command/MigrateCommand.php
+++ b/core-bundle/src/Command/MigrateCommand.php
@@ -27,6 +27,8 @@ use Symfony\Component\Filesystem\Filesystem;
 
 class MigrateCommand extends Command
 {
+    protected static $defaultName = 'contao:migrate';
+
     /**
      * @var MigrationCollection
      */
@@ -71,7 +73,6 @@ class MigrateCommand extends Command
     protected function configure(): void
     {
         $this
-            ->setName('contao:migrate')
             ->addOption('with-deletes', null, InputOption::VALUE_NONE, 'Execute all database migrations including DROP queries. Can be used together with --no-interaction.')
             ->addOption('schema-only', null, InputOption::VALUE_NONE, 'Execute database schema migration only.')
             ->setDescription('Executes migrations and the database schema diff.')

--- a/core-bundle/src/Command/ResizeImagesCommand.php
+++ b/core-bundle/src/Command/ResizeImagesCommand.php
@@ -37,6 +37,8 @@ use Symfony\Component\Process\Process;
  */
 class ResizeImagesCommand extends Command
 {
+    protected static $defaultName = 'contao:resize-images';
+
     /**
      * @var ImageFactoryInterface
      */
@@ -82,7 +84,6 @@ class ResizeImagesCommand extends Command
     protected function configure(): void
     {
         $this
-            ->setName('contao:resize-images')
             ->addOption('time-limit', 'l', InputOption::VALUE_OPTIONAL, 'Time limit in seconds', '0')
             ->addOption('concurrent', 'c', InputOption::VALUE_OPTIONAL, 'Run multiple processes concurrently', '1')
             ->addOption('throttle', 't', InputOption::VALUE_OPTIONAL, 'Pause between resizes to limit CPU utilization, 0.1 relates to 10% CPU usage', '1')

--- a/core-bundle/src/Command/SymlinksCommand.php
+++ b/core-bundle/src/Command/SymlinksCommand.php
@@ -34,6 +34,8 @@ use Symfony\Component\Finder\SplFileInfo;
  */
 class SymlinksCommand extends Command
 {
+    protected static $defaultName = 'contao:symlinks';
+
     /**
      * @var SymfonyStyle
      */
@@ -93,7 +95,6 @@ class SymlinksCommand extends Command
     protected function configure(): void
     {
         $this
-            ->setName('contao:symlinks')
             ->addArgument('target', InputArgument::OPTIONAL, 'The target directory', 'web')
             ->setDescription('Symlinks the public resources into the web directory.')
         ;

--- a/core-bundle/src/Command/UserPasswordCommand.php
+++ b/core-bundle/src/Command/UserPasswordCommand.php
@@ -36,6 +36,8 @@ use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
  */
 class UserPasswordCommand extends Command
 {
+    protected static $defaultName = 'contao:user:password';
+
     /**
      * @var ContaoFramework
      */
@@ -63,7 +65,6 @@ class UserPasswordCommand extends Command
     protected function configure(): void
     {
         $this
-            ->setName('contao:user:password')
             ->addArgument('username', InputArgument::REQUIRED, 'The username of the back end user')
             ->addOption('password', 'p', InputOption::VALUE_REQUIRED, 'The new password (using this option is not recommended for security reasons)')
             ->setDescription('Changes the password of a Contao back end user.')

--- a/core-bundle/src/Command/VersionCommand.php
+++ b/core-bundle/src/Command/VersionCommand.php
@@ -25,10 +25,11 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class VersionCommand extends Command
 {
+    protected static $defaultName = 'contao:version';
+
     protected function configure(): void
     {
         $this
-            ->setName('contao:version')
             ->setDescription('Outputs the contao/core-bundle version (deprecated).')
         ;
     }

--- a/core-bundle/src/Resources/contao/library/Contao/System.php
+++ b/core-bundle/src/Resources/contao/library/Contao/System.php
@@ -160,6 +160,11 @@ abstract class System
 		{
 			$container = static::getContainer();
 
+			if (null === $container)
+			{
+				throw new \RuntimeException('The Symfony container is not available, did you initialize the ContaoFramework?');
+			}
+
 			if (\is_object($strClass))
 			{
 				$this->arrObjects[$strKey] = $strClass;
@@ -206,6 +211,11 @@ abstract class System
 		if ($blnForce || !isset(static::$arrStaticObjects[$strKey]))
 		{
 			$container = static::getContainer();
+
+			if (null === $container)
+			{
+				throw new \RuntimeException('The Symfony container is not available, did you initialize the ContaoFramework?');
+			}
 
 			if (\is_object($strClass))
 			{

--- a/core-bundle/src/Resources/contao/library/Contao/System.php
+++ b/core-bundle/src/Resources/contao/library/Contao/System.php
@@ -162,7 +162,7 @@ abstract class System
 
 			if (null === $container)
 			{
-				throw new \RuntimeException('The Symfony container is not available, did you initialize the ContaoFramework?');
+				throw new \RuntimeException('The Symfony container is not available, did you initialize the Contao framework?');
 			}
 
 			if (\is_object($strClass))
@@ -214,7 +214,7 @@ abstract class System
 
 			if (null === $container)
 			{
-				throw new \RuntimeException('The Symfony container is not available, did you initialize the ContaoFramework?');
+				throw new \RuntimeException('The Symfony container is not available, did you initialize the Contao framework?');
 			}
 
 			if (\is_object($strClass))


### PR DESCRIPTION
Listing the `Automator` methods in the command description causes the `ContaoFramework` to be initialized on **every call to the Symfony console**. That's unacceptable to me, and I think we can live with the helper options just fine …