### PR TITLE
Remove sleep() from the password modules

### DIFF
--- a/core-bundle/src/Resources/contao/modules/ModuleChangePassword.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleChangePassword.php
@@ -150,7 +150,6 @@ class ModuleChangePassword extends Module
 					{
 						$objWidget->value = '';
 						$objWidget->addError($GLOBALS['TL_LANG']['MSC']['oldPasswordWrong']);
-						sleep(2); // Wait 2 seconds while brute forcing :)
 					}
 				}
 

--- a/core-bundle/src/Resources/contao/modules/ModulePassword.php
+++ b/core-bundle/src/Resources/contao/modules/ModulePassword.php
@@ -152,7 +152,6 @@ class ModulePassword extends Module
 
 			if ($objMember === null)
 			{
-				sleep(2); // Wait 2 seconds while brute forcing :)
 				$this->Template->error = $GLOBALS['TL_LANG']['MSC']['accountNotFound'];
 			}
 			else


### PR DESCRIPTION
Because

1. the effect is marginal and can even encourage timing attacks,
2. we already have real brute force protection for logins,
3. it will mislead people to believe that `sleep(2)` is an appropriate means to mitigate brute force attacks (see #1769), which it is definitely not!
