### PR TITLE
Optimize importing DB fixtures in the functional tests

### DIFF
--- a/core-bundle/tests/Functional/RoutingTest.php
+++ b/core-bundle/tests/Functional/RoutingTest.php
@@ -19,6 +19,11 @@ use Symfony\Component\HttpFoundation\Response;
 
 class RoutingTest extends FunctionalTestCase
 {
+    /**
+     * @var array
+     */
+    private static $lastImport;
+
     public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
@@ -1043,6 +1048,13 @@ class RoutingTest extends FunctionalTestCase
 
     private function loadFixtureFiles(array $fileNames): void
     {
+        // Do not reload the fixtures if they have not changed
+        if (self::$lastImport && self::$lastImport === $fileNames) {
+            return;
+        }
+
+        self::$lastImport = $fileNames;
+
         static::loadFixtures(array_map(
             static function ($file) {
                 return __DIR__.'/../Fixtures/Functional/Routing/'.$file.'.yml';


### PR DESCRIPTION
This PR ensures that DB fixtures are not reloaded if they have not changed. Since we are heavily using data providers in the functional routing tests, fixtures had been reloaded for every single test. Together with https://github.com/contao/test-case/commit/70e5a1432900ef1139331764a5f9b3173961bb96, I was able to decrease the execution time from 51.41 seconds to 22.05 seconds. 💪 