### PR TITLE
Fix tcpdf symlink for monorepo (backport of #158)

### DIFF
--- a/core-bundle/src/Command/InstallCommand.php
+++ b/core-bundle/src/Command/InstallCommand.php
@@ -17,6 +17,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Filesystem\Filesystem;
+use Webmozart\PathUtil\Path;
 
 /**
  * Installs the required Contao directories.
@@ -249,7 +250,7 @@ EOF
         $relPath = $this->fs->makePathRelative($this->bundlesMeta['ContaoCoreBundle']['path'], $this->rootDir);
 
         SymlinkUtil::symlink(
-            $relPath.'Resources/contao/config/tcpdf.php',
+            Path::join($relPath, 'Resources/contao/config/tcpdf.php'),
             'system/config/tcpdf.php',
             $this->rootDir
         );

--- a/core-bundle/src/Command/InstallCommand.php
+++ b/core-bundle/src/Command/InstallCommand.php
@@ -260,7 +260,7 @@ EOF
     /**
      * @return string
      */
-    private function getRelativePath(string $path)
+    private function getRelativePath($path)
     {
         return str_replace(strtr($this->rootDir, '\\', '/').'/', '', strtr($path, '\\', '/'));
     }

--- a/core-bundle/src/Command/InstallCommand.php
+++ b/core-bundle/src/Command/InstallCommand.php
@@ -246,24 +246,14 @@ EOF
      */
     private function symlinkTcpdfConfig()
     {
-        $relPath = $this->getRelativePath($this->bundlesMeta['ContaoCoreBundle']['path']);
+        $relPath = (new Filesystem())->makePathRelative($this->bundlesMeta['ContaoCoreBundle']['path'], $this->rootDir);
 
         SymlinkUtil::symlink(
-            $relPath.'/Resources/contao/config/tcpdf.php',
+            trim($relPath, '/').'/Resources/contao/config/tcpdf.php',
             'system/config/tcpdf.php',
             $this->rootDir
         );
 
         $this->io->writeln('Symlinked the <comment>system/config/tcpdf.php</comment> file.');
-    }
-
-    /**
-     * @param string $path
-     *
-     * @return string
-     */
-    private function getRelativePath($path)
-    {
-        return str_replace(strtr($this->rootDir, '\\', '/').'/', '', strtr($path, '\\', '/'));
     }
 }

--- a/core-bundle/src/Command/InstallCommand.php
+++ b/core-bundle/src/Command/InstallCommand.php
@@ -61,9 +61,9 @@ class InstallCommand extends Command
     private $webDir;
 
     /**
-     * @var array<string,string>
+     * @var array<string,array<string,string>>
      */
-    private $bundles;
+    private $bundlesMeta;
 
     /**
      * @var array
@@ -94,14 +94,14 @@ class InstallCommand extends Command
      * @param string $rootDir
      * @param string $uploadPath
      * @param string $imageDir
-     * @param array  $bundles
+     * @param array  $bundlesMeta
      */
-    public function __construct($rootDir, $uploadPath, $imageDir, $bundles)
+    public function __construct($rootDir, $uploadPath, $imageDir, $bundlesMeta)
     {
         $this->rootDir = $rootDir;
         $this->uploadPath = $uploadPath;
         $this->imageDir = $imageDir;
-        $this->bundles = $bundles;
+        $this->bundlesMeta = $bundlesMeta;
 
         parent::__construct();
     }
@@ -246,8 +246,7 @@ EOF
      */
     private function symlinkTcpdfConfig()
     {
-        $coreBundle = new \ReflectionClass($this->bundles['ContaoCoreBundle']);
-        $relPath = $this->getRelativePath(\dirname($coreBundle->getFileName()));
+        $relPath = $this->getRelativePath($this->bundlesMeta['ContaoCoreBundle']['path']);
 
         SymlinkUtil::symlink(
             $relPath.'/Resources/contao/config/tcpdf.php',

--- a/core-bundle/src/Command/InstallCommand.php
+++ b/core-bundle/src/Command/InstallCommand.php
@@ -246,7 +246,7 @@ EOF
      */
     private function symlinkTcpdfConfig()
     {
-        $relPath = (new Filesystem())->makePathRelative($this->bundlesMeta['ContaoCoreBundle']['path'], $this->rootDir);
+        $relPath = $this->fs->makePathRelative($this->bundlesMeta['ContaoCoreBundle']['path'], $this->rootDir);
 
         SymlinkUtil::symlink(
             trim($relPath, '/').'/Resources/contao/config/tcpdf.php',

--- a/core-bundle/src/Command/InstallCommand.php
+++ b/core-bundle/src/Command/InstallCommand.php
@@ -17,7 +17,6 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Filesystem\Filesystem;
-use Webmozart\PathUtil\Path;
 
 /**
  * Installs the required Contao directories.
@@ -247,10 +246,10 @@ EOF
      */
     private function symlinkTcpdfConfig()
     {
-        $relPath = $this->fs->makePathRelative($this->bundlesMeta['ContaoCoreBundle']['path'], $this->rootDir);
+        $relPath = rtrim($this->fs->makePathRelative($this->bundlesMeta['ContaoCoreBundle']['path'], $this->rootDir), '/');
 
         SymlinkUtil::symlink(
-            Path::join($relPath, 'Resources/contao/config/tcpdf.php'),
+            $relPath.'/Resources/contao/config/tcpdf.php',
             'system/config/tcpdf.php',
             $this->rootDir
         );

--- a/core-bundle/src/Command/InstallCommand.php
+++ b/core-bundle/src/Command/InstallCommand.php
@@ -96,7 +96,7 @@ class InstallCommand extends Command
      * @param string $imageDir
      * @param array  $bundlesMeta
      */
-    public function __construct($rootDir, $uploadPath, $imageDir, $bundlesMeta)
+    public function __construct($rootDir, $uploadPath, $imageDir, array $bundlesMeta)
     {
         $this->rootDir = $rootDir;
         $this->uploadPath = $uploadPath;
@@ -246,10 +246,10 @@ EOF
      */
     private function symlinkTcpdfConfig()
     {
-        $relPath = rtrim($this->fs->makePathRelative($this->bundlesMeta['ContaoCoreBundle']['path'], $this->rootDir), '/');
+        $relPath = $this->fs->makePathRelative($this->bundlesMeta['ContaoCoreBundle']['path'], $this->rootDir);
 
         SymlinkUtil::symlink(
-            $relPath.'/Resources/contao/config/tcpdf.php',
+            rtrim($relPath, '/').'/Resources/contao/config/tcpdf.php',
             'system/config/tcpdf.php',
             $this->rootDir
         );

--- a/core-bundle/src/Command/InstallCommand.php
+++ b/core-bundle/src/Command/InstallCommand.php
@@ -257,7 +257,10 @@ EOF
         $this->io->writeln('Symlinked the <comment>system/config/tcpdf.php</comment> file.');
     }
 
-    private function getRelativePath(string $path): string
+    /**
+     * @return string
+     */
+    private function getRelativePath(string $path)
     {
         return str_replace(strtr($this->rootDir, '\\', '/').'/', '', strtr($path, '\\', '/'));
     }

--- a/core-bundle/src/Command/InstallCommand.php
+++ b/core-bundle/src/Command/InstallCommand.php
@@ -61,7 +61,7 @@ class InstallCommand extends Command
     private $webDir;
 
     /**
-     * @var array
+     * @var array<string,string>
      */
     private $bundles;
 

--- a/core-bundle/src/Command/InstallCommand.php
+++ b/core-bundle/src/Command/InstallCommand.php
@@ -63,6 +63,11 @@ class InstallCommand extends Command
     /**
      * @var array
      */
+    private $bundles;
+
+    /**
+     * @var array
+     */
     private $emptyDirs = [
         'system',
         'system/config',
@@ -90,11 +95,12 @@ class InstallCommand extends Command
      * @param string $uploadPath
      * @param string $imageDir
      */
-    public function __construct($rootDir, $uploadPath, $imageDir)
+    public function __construct($rootDir, $uploadPath, $imageDir, $bundles)
     {
         $this->rootDir = $rootDir;
         $this->uploadPath = $uploadPath;
         $this->imageDir = $imageDir;
+        $this->bundles = $bundles;
 
         parent::__construct();
     }
@@ -239,12 +245,20 @@ EOF
      */
     private function symlinkTcpdfConfig()
     {
+        $coreBundle = new \ReflectionClass($this->bundles['ContaoCoreBundle']);
+        $relPath = $this->getRelativePath(\dirname($coreBundle->getFileName()));
+
         SymlinkUtil::symlink(
-            'vendor/contao/core-bundle/src/Resources/contao/config/tcpdf.php',
+            $relPath.'/Resources/contao/config/tcpdf.php', 
             'system/config/tcpdf.php',
             $this->rootDir
         );
 
         $this->io->writeln('Symlinked the <comment>system/config/tcpdf.php</comment> file.');
+    }
+
+    private function getRelativePath(string $path): string
+    {
+        return str_replace(strtr($this->rootDir, '\\', '/').'/', '', strtr($path, '\\', '/'));
     }
 }

--- a/core-bundle/src/Command/InstallCommand.php
+++ b/core-bundle/src/Command/InstallCommand.php
@@ -249,7 +249,7 @@ EOF
         $relPath = $this->fs->makePathRelative($this->bundlesMeta['ContaoCoreBundle']['path'], $this->rootDir);
 
         SymlinkUtil::symlink(
-            trim($relPath, '/').'/Resources/contao/config/tcpdf.php',
+            $relPath.'Resources/contao/config/tcpdf.php',
             'system/config/tcpdf.php',
             $this->rootDir
         );

--- a/core-bundle/src/Command/InstallCommand.php
+++ b/core-bundle/src/Command/InstallCommand.php
@@ -94,6 +94,7 @@ class InstallCommand extends Command
      * @param string $rootDir
      * @param string $uploadPath
      * @param string $imageDir
+     * @param array  $bundles
      */
     public function __construct($rootDir, $uploadPath, $imageDir, $bundles)
     {
@@ -249,7 +250,7 @@ EOF
         $relPath = $this->getRelativePath(\dirname($coreBundle->getFileName()));
 
         SymlinkUtil::symlink(
-            $relPath.'/Resources/contao/config/tcpdf.php', 
+            $relPath.'/Resources/contao/config/tcpdf.php',
             'system/config/tcpdf.php',
             $this->rootDir
         );
@@ -258,6 +259,8 @@ EOF
     }
 
     /**
+     * @param string $path
+     *
      * @return string
      */
     private function getRelativePath($path)

--- a/core-bundle/src/Resources/config/commands.yml
+++ b/core-bundle/src/Resources/config/commands.yml
@@ -19,7 +19,7 @@ services:
             - '%kernel.project_dir%'
             - '%contao.upload_path%'
             - '%contao.image.target_dir%'
-            - '%kernel.bundles%'
+            - '%kernel.bundles_metadata%'
 
     contao.command.symlinks:
         class: Contao\CoreBundle\Command\SymlinksCommand

--- a/core-bundle/src/Resources/config/commands.yml
+++ b/core-bundle/src/Resources/config/commands.yml
@@ -19,6 +19,7 @@ services:
             - '%kernel.project_dir%'
             - '%contao.upload_path%'
             - '%contao.image.target_dir%'
+            - '%kernel.bundles%'
 
     contao.command.symlinks:
         class: Contao\CoreBundle\Command\SymlinksCommand

--- a/core-bundle/tests/Command/InstallCommandTest.php
+++ b/core-bundle/tests/Command/InstallCommandTest.php
@@ -67,7 +67,13 @@ class InstallCommandTest extends TestCase
      */
     public function testCreatesTheContaoFolders()
     {
-        $command = new InstallCommand($this->getRootDir(), 'files', $this->getRootDir().'/assets/images', $this->getBundlesMetadata());
+        $command = new InstallCommand(
+            $this->getRootDir(),
+            'files',
+            $this->getRootDir().'/assets/images',
+            $this->getBundlesMetadata()
+        );
+
         $tester = new CommandTester($command);
         $code = $tester->execute([]);
         $output = $tester->getDisplay();
@@ -88,7 +94,13 @@ class InstallCommandTest extends TestCase
      */
     public function testHandlesCustomFilesAndImagesPaths()
     {
-        $command = new InstallCommand($this->getRootDir(), 'files_test', $this->getRootDir().'/assets/images_test', $this->getBundlesMetadata());
+        $command = new InstallCommand(
+            $this->getRootDir(),
+            'files_test',
+            $this->getRootDir().'/assets/images_test',
+            $this->getBundlesMetadata()
+        );
+
         $tester = new CommandTester($command);
         $code = $tester->execute([]);
         $display = $tester->getDisplay();
@@ -103,13 +115,18 @@ class InstallCommandTest extends TestCase
      */
     public function testCreatesInitializeFileAndTcpdfSymlink()
     {
-        $command = new InstallCommand($this->getRootDir(), 'files_test', $this->getRootDir().'/assets/images_test', $this->getBundlesMetadata());
+        $command = new InstallCommand(
+            $this->getRootDir(),
+            'files_test',
+            $this->getRootDir().'/assets/images_test',
+            $this->getBundlesMetadata()
+        );
+
         $tester = new CommandTester($command);
         $tester->execute([]);
 
         $this->assertFileExists($this->getRootDir().'/system/initialize.php');
         $this->assertTrue(is_link($this->getRootDir().'/system/config/tcpdf.php'));
-        $this->assertFileExists($this->getRootDir().'/system/config/tcpdf.php');
     }
 
     /**

--- a/core-bundle/tests/Command/InstallCommandTest.php
+++ b/core-bundle/tests/Command/InstallCommandTest.php
@@ -11,7 +11,6 @@
 namespace Contao\CoreBundle\Tests\Command;
 
 use Contao\CoreBundle\Command\InstallCommand;
-use Contao\CoreBundle\ContaoCoreBundle;
 use Contao\CoreBundle\Tests\TestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Filesystem\Filesystem;
@@ -68,7 +67,7 @@ class InstallCommandTest extends TestCase
      */
     public function testCreatesTheContaoFolders()
     {
-        $command = new InstallCommand($this->getRootDir(), 'files', $this->getRootDir().'/assets/images', ['ContaoCoreBundle' => ContaoCoreBundle::class]);
+        $command = new InstallCommand($this->getRootDir(), 'files', $this->getRootDir().'/assets/images', $this->getBundlesMetadata());
         $tester = new CommandTester($command);
         $code = $tester->execute([]);
         $output = $tester->getDisplay();
@@ -89,7 +88,7 @@ class InstallCommandTest extends TestCase
      */
     public function testHandlesCustomFilesAndImagesPaths()
     {
-        $command = new InstallCommand($this->getRootDir(), 'files_test', $this->getRootDir().'/assets/images_test', ['ContaoCoreBundle' => ContaoCoreBundle::class]);
+        $command = new InstallCommand($this->getRootDir(), 'files_test', $this->getRootDir().'/assets/images_test', $this->getBundlesMetadata());
         $tester = new CommandTester($command);
         $code = $tester->execute([]);
         $display = $tester->getDisplay();
@@ -97,5 +96,17 @@ class InstallCommandTest extends TestCase
         $this->assertSame(0, $code);
         $this->assertContains(' * files_test', $display);
         $this->assertContains(' * assets/images_test', $display);
+    }
+
+    /**
+     * @return array<string,array<string,string>>
+     */
+    private function getBundlesMetadata()
+    {
+        return [
+            'ContaoCoreBundle' => [
+                'path' => $this->getRootDir().'/vendor/contao/core-bundle/src',
+            ],
+        ];
     }
 }

--- a/core-bundle/tests/Command/InstallCommandTest.php
+++ b/core-bundle/tests/Command/InstallCommandTest.php
@@ -127,11 +127,7 @@ class InstallCommandTest extends TestCase
 
         $this->assertFileExists($this->getRootDir().'/system/initialize.php');
 
-        /*
-         * We need to check both if the tcpdf.php is a symlink and is in fact a file,
-         * because is_link() returns true, even if the symlink is invalid and
-         * file_exists() returns false, if the symlink is invalid.
-         */
+        // is_link() returns true even if the symlink target does not exist, therefore also check file_exists()
         $this->assertTrue(is_link($this->getRootDir().'/system/config/tcpdf.php'));
         $this->assertFileExists($this->getRootDir().'/system/config/tcpdf.php');
     }

--- a/core-bundle/tests/Command/InstallCommandTest.php
+++ b/core-bundle/tests/Command/InstallCommandTest.php
@@ -126,7 +126,14 @@ class InstallCommandTest extends TestCase
         $tester->execute([]);
 
         $this->assertFileExists($this->getRootDir().'/system/initialize.php');
+
+        /*
+         * We need to check both if the tcpdf.php is a symlink and is in fact a file,
+         * because is_link() returns true, even if the symlink is invalid and
+         * file_exists() returns false, if the symlink is invalid.
+         */
         $this->assertTrue(is_link($this->getRootDir().'/system/config/tcpdf.php'));
+        $this->assertFileExists($this->getRootDir().'/system/config/tcpdf.php');
     }
 
     /**

--- a/core-bundle/tests/Command/InstallCommandTest.php
+++ b/core-bundle/tests/Command/InstallCommandTest.php
@@ -11,6 +11,7 @@
 namespace Contao\CoreBundle\Tests\Command;
 
 use Contao\CoreBundle\Command\InstallCommand;
+use Contao\CoreBundle\ContaoCoreBundle;
 use Contao\CoreBundle\Tests\TestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Filesystem\Filesystem;
@@ -67,7 +68,7 @@ class InstallCommandTest extends TestCase
      */
     public function testCreatesTheContaoFolders()
     {
-        $command = new InstallCommand($this->getRootDir(), 'files', $this->getRootDir().'/assets/images');
+        $command = new InstallCommand($this->getRootDir(), 'files', $this->getRootDir().'/assets/images', ['ContaoCoreBundle' => ContaoCoreBundle::class]);
         $tester = new CommandTester($command);
         $code = $tester->execute([]);
         $output = $tester->getDisplay();
@@ -88,7 +89,7 @@ class InstallCommandTest extends TestCase
      */
     public function testHandlesCustomFilesAndImagesPaths()
     {
-        $command = new InstallCommand($this->getRootDir(), 'files_test', $this->getRootDir().'/assets/images_test');
+        $command = new InstallCommand($this->getRootDir(), 'files_test', $this->getRootDir().'/assets/images_test', ['ContaoCoreBundle' => ContaoCoreBundle::class]);
         $tester = new CommandTester($command);
         $code = $tester->execute([]);
         $display = $tester->getDisplay();

--- a/core-bundle/tests/Command/InstallCommandTest.php
+++ b/core-bundle/tests/Command/InstallCommandTest.php
@@ -99,6 +99,20 @@ class InstallCommandTest extends TestCase
     }
 
     /**
+     * Tests adding the initialize.php file and tcpdf.php symlink.
+     */
+    public function testCreatesInitializeFileAndTcpdfSymlink()
+    {
+        $command = new InstallCommand($this->getRootDir(), 'files_test', $this->getRootDir().'/assets/images_test', $this->getBundlesMetadata());
+        $tester = new CommandTester($command);
+        $tester->execute([]);
+
+        $this->assertFileExists($this->getRootDir().'/system/initialize.php');
+        $this->assertTrue(is_link($this->getRootDir().'/system/config/tcpdf.php'));
+        $this->assertFileExists($this->getRootDir().'/system/config/tcpdf.php');
+    }
+
+    /**
      * @return array<string,array<string,string>>
      */
     private function getBundlesMetadata()


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | N/A
| Docs PR or issue | N/A

When installing/checking out the monorepo for the 4.4 branch, `ScriptHandler::initializeApplication` will fail because of the `tcpdf.php` path. This PR is actually a backport of #158, in order to fix it for the 4.4 branch.
