### PR TITLE
Do not use the contao_root route

### DIFF
--- a/core-bundle/README.md
+++ b/core-bundle/README.md
@@ -123,7 +123,6 @@ security:
 
             logout:
                 path: contao_frontend_logout
-                target: contao_root
                 handlers:
                     - contao.security.logout_handler
                 success_handler: contao.security.logout_success_handler

--- a/core-bundle/src/Controller/BackendPreviewController.php
+++ b/core-bundle/src/Controller/BackendPreviewController.php
@@ -20,8 +20,6 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
-use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
 /**
@@ -49,21 +47,15 @@ class BackendPreviewController
     private $dispatcher;
 
     /**
-     * @var RouterInterface
-     */
-    private $router;
-
-    /**
      * @var AuthorizationCheckerInterface
      */
     private $authorizationChecker;
 
-    public function __construct(string $previewScript, FrontendPreviewAuthenticator $previewAuthenticator, EventDispatcherInterface $dispatcher, RouterInterface $router, AuthorizationCheckerInterface $authorizationChecker)
+    public function __construct(string $previewScript, FrontendPreviewAuthenticator $previewAuthenticator, EventDispatcherInterface $dispatcher, AuthorizationCheckerInterface $authorizationChecker)
     {
         $this->previewScript = $previewScript;
         $this->previewAuthenticator = $previewAuthenticator;
         $this->dispatcher = $dispatcher;
-        $this->router = $router;
         $this->authorizationChecker = $authorizationChecker;
     }
 
@@ -98,6 +90,6 @@ class BackendPreviewController
             return new RedirectResponse($targetUrl);
         }
 
-        return new RedirectResponse($this->router->generate('contao_root', [], UrlGeneratorInterface::ABSOLUTE_URL));
+        return new RedirectResponse('/');
     }
 }

--- a/core-bundle/src/Resources/config/services.yml
+++ b/core-bundle/src/Resources/config/services.yml
@@ -76,7 +76,6 @@ services:
             - '%contao.preview_script%'
             - '@contao.security.frontend_preview_authenticator'
             - '@event_dispatcher'
-            - '@router'
             - '@security.authorization_checker'
         tags:
             - controller.service_arguments

--- a/core-bundle/src/Resources/contao/templates/backend/be_login.html5
+++ b/core-bundle/src/Resources/contao/templates/backend/be_login.html5
@@ -58,7 +58,7 @@
             </div>
             <div class="submit_container cf">
               <button type="submit" name="login" id="login" class="tl_submit"><?= $this->loginButton ?></button>
-              <a href="<?= $this->route('contao_root') ?>" class="footer_preview"><?= $this->feLink ?> ›</a>
+              <a href="/" class="footer_preview"><?= $this->feLink ?> ›</a>
             </div>
           </div>
         </form>

--- a/core-bundle/tests/Controller/BackendPreviewControllerTest.php
+++ b/core-bundle/tests/Controller/BackendPreviewControllerTest.php
@@ -22,7 +22,6 @@ use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
 class BackendPreviewControllerTest extends TestCase
@@ -33,7 +32,6 @@ class BackendPreviewControllerTest extends TestCase
             'preview.php',
             $this->createMock(FrontendPreviewAuthenticator::class),
             new EventDispatcher(),
-            $this->mockRouter(),
             $this->mockAuthorizationChecker()
         );
 
@@ -50,7 +48,6 @@ class BackendPreviewControllerTest extends TestCase
             'preview.php',
             $this->createMock(FrontendPreviewAuthenticator::class),
             new EventDispatcher(),
-            $this->mockRouter(),
             $this->mockAuthorizationChecker(false)
         );
 
@@ -75,7 +72,6 @@ class BackendPreviewControllerTest extends TestCase
             'preview.php',
             $previewAuthenticator,
             new EventDispatcher(),
-            $this->mockRouter(),
             $this->mockAuthorizationChecker()
         );
 
@@ -97,7 +93,6 @@ class BackendPreviewControllerTest extends TestCase
             'preview.php',
             $this->createMock(FrontendPreviewAuthenticator::class),
             $dispatcher,
-            $this->mockRouter(),
             $this->mockAuthorizationChecker()
         );
 
@@ -113,7 +108,6 @@ class BackendPreviewControllerTest extends TestCase
             'preview.php',
             $this->createMock(FrontendPreviewAuthenticator::class),
             new EventDispatcher(),
-            $this->mockRouter(),
             $this->mockAuthorizationChecker()
         );
 
@@ -121,7 +115,7 @@ class BackendPreviewControllerTest extends TestCase
         $response = $controller($this->mockRequest());
 
         $this->assertInstanceOf(RedirectResponse::class, $response);
-        $this->assertSame('/index.html', $response->getTargetUrl());
+        $this->assertSame('/', $response->getTargetUrl());
     }
 
     /**
@@ -138,21 +132,6 @@ class BackendPreviewControllerTest extends TestCase
         ;
 
         return $request;
-    }
-
-    /**
-     * @return RouterInterface&MockObject
-     */
-    private function mockRouter(): RouterInterface
-    {
-        $router = $this->createMock(RouterInterface::class);
-        $router
-            ->method('generate')
-            ->with('contao_root')
-            ->willReturn('/index.html')
-        ;
-
-        return $router;
     }
 
     /**

--- a/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
+++ b/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
@@ -848,7 +848,6 @@ class ContaoCoreExtensionTest extends TestCase
                 new Reference('%contao.preview_script%'),
                 new Reference('contao.security.frontend_preview_authenticator'),
                 new Reference('event_dispatcher'),
-                new Reference('router'),
                 new Reference('security.authorization_checker'),
             ],
             $definition->getArguments()

--- a/core-bundle/tests/Functional/app/config/security.yml
+++ b/core-bundle/tests/Functional/app/config/security.yml
@@ -51,7 +51,6 @@ security:
 
             logout:
                 path: contao_frontend_logout
-                target: contao_root
                 handlers:
                     - contao.security.logout_handler
                 success_handler: contao.security.logout_success_handler

--- a/manager-bundle/src/Resources/skeleton/config/security.yml
+++ b/manager-bundle/src/Resources/skeleton/config/security.yml
@@ -52,7 +52,6 @@ security:
 
             logout:
                 path: contao_frontend_logout
-                target: contao_root
                 handlers:
                     - contao.security.logout_handler
                 success_handler: contao.security.logout_success_handler


### PR DESCRIPTION
The `contao_root` route simply points to the `/` path of the website. There's no need to generate such a route. There are only limited uses of it anyway in the core, and some actually cause issues. Removing the use of `contao_root` in the core will also aid in implementing #1516

1. This will actually fix the back end login link to the front end when in `preview.php`, because it will (correctly) remove the entry point script
2. Regarding the firewall configuration, the default value for `target` is `/` so this should have no effect (see https://github.com/symfony/symfony/blob/4.4/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php#L214)
