### PR TITLE
Add csv_excel format to form generator

### DIFF
--- a/core-bundle/src/Resources/contao/dca/tl_form.php
+++ b/core-bundle/src/Resources/contao/dca/tl_form.php
@@ -191,7 +191,7 @@ $GLOBALS['TL_DCA']['tl_form'] = array
 		(
 			'exclude'                 => true,
 			'inputType'               => 'select',
-			'options'                 => array('raw', 'xml', 'csv', 'email'),
+			'options'                 => array('raw', 'xml', 'csv', 'csv_excel', 'email'),
 			'reference'               => &$GLOBALS['TL_LANG']['tl_form'],
 			'eval'                    => array('helpwizard'=>true, 'tl_class'=>'w50'),
 			'sql'                     => "varchar(12) NOT NULL default 'raw'"

--- a/core-bundle/src/Resources/contao/forms/Form.php
+++ b/core-bundle/src/Resources/contao/forms/Form.php
@@ -345,7 +345,7 @@ class Form extends Hybrid
 				}
 
 				// Prepare CSV file
-				if ($this->format == 'csv')
+				if ($this->format == 'csv' || $this->format == 'csv_excel')
 				{
 					$keys[] = $k;
 					$values[] = (\is_array($v) ? implode(',', $v) : $v);
@@ -418,6 +418,10 @@ class Form extends Hybrid
 			if ($this->format == 'csv')
 			{
 				$email->attachFileFromString(StringUtil::decodeEntities('"' . implode('";"', $keys) . '"' . "\n" . '"' . implode('";"', $values) . '"'), 'form.csv', 'text/comma-separated-values');
+			}
+			elseif ($this->format == 'csv_excel')
+			{
+				$email->attachFileFromString(mb_convert_encoding("\u{FEFF}sep=;\n" . StringUtil::decodeEntities('"' . implode('";"', $keys) . '"' . "\n" . '"' . implode('";"', $values) . '"'), 'UTF-16LE', 'UTF-8'), 'form.csv', 'text/comma-separated-values');
 			}
 
 			$uploaded = '';

--- a/core-bundle/src/Resources/contao/languages/en/tl_form.xlf
+++ b/core-bundle/src/Resources/contao/languages/en/tl_form.xlf
@@ -62,6 +62,12 @@
       <trans-unit id="tl_form.csv.1">
         <source>The form data will be attached to the e-mail as a CSV file.</source>
       </trans-unit>
+      <trans-unit id="tl_form.csv_excel.0">
+        <source>CSV file (Microsoft Excel)</source>
+      </trans-unit>
+      <trans-unit id="tl_form.csv_excel.1">
+        <source>The form data will be attached to the e-mail as a CSV file readable by Microsoft Excel.</source>
+      </trans-unit>
       <trans-unit id="tl_form.skipEmpty.0">
         <source>Skip empty fields</source>
       </trans-unit>


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #1866

This adds a new “CSV file (Microsoft Excel)” format to the form generator. The generated file seems to work fine with Excel on Windows and in the online version of Excel. In macOS it doesn’t seem to work.