### PR TITLE
Reduce the file queries by preloading image models

### DIFF
--- a/calendar-bundle/src/Resources/contao/modules/ModuleEventlist.php
+++ b/calendar-bundle/src/Resources/contao/modules/ModuleEventlist.php
@@ -260,6 +260,18 @@ class ModuleEventlist extends Events
 		}
 
 		$rootDir = System::getContainer()->getParameter('kernel.project_dir');
+		$uuids = array();
+
+		for ($i=$offset; $i<$limit; $i++)
+		{
+			if ($arrEvents[$i]['addImage'] && $arrEvents[$i]['singleSRC'] != '')
+			{
+				$uuids[] = $arrEvents[$i]['singleSRC'];
+			}
+		}
+
+		// Preload all images in one query so they are loaded into the model registry
+		FilesModel::findMultipleByUuids($uuids);
 
 		// Parse events
 		for ($i=$offset; $i<$limit; $i++)

--- a/news-bundle/src/Resources/contao/modules/ModuleNews.php
+++ b/news-bundle/src/Resources/contao/modules/ModuleNews.php
@@ -254,8 +254,6 @@ abstract class ModuleNews extends Module
 
 		$count = 0;
 		$arrArticles = array();
-
-		// Performance: Preload all images in one query so they are loaded into the model registry before actually rendering them
 		$uuids = array();
 
 		foreach ($objArticles as $objArticle)
@@ -266,9 +264,9 @@ abstract class ModuleNews extends Module
 			}
 		}
 
+		// Preload all images in one query so they are loaded into the model registry
 		FilesModel::findMultipleByUuids($uuids);
 
-		// Actually render the articles
 		foreach ($objArticles as $objArticle)
 		{
 			$arrArticles[] = $this->parseArticle($objArticle, $blnAddArchive, ((++$count == 1) ? ' first' : '') . (($count == $limit) ? ' last' : '') . ((($count % 2) == 0) ? ' odd' : ' even'), $count);

--- a/news-bundle/src/Resources/contao/modules/ModuleNews.php
+++ b/news-bundle/src/Resources/contao/modules/ModuleNews.php
@@ -255,11 +255,22 @@ abstract class ModuleNews extends Module
 		$count = 0;
 		$arrArticles = array();
 
-		while ($objArticles->next())
-		{
-			/** @var NewsModel $objArticle */
-			$objArticle = $objArticles->current();
+		// Performance: Preload all images in one query so they are loaded into the model registry before actually rendering them
+		$uuids = array();
 
+		foreach ($objArticles as $objArticle)
+		{
+			if ($objArticle->addImage && $objArticle->singleSRC != '')
+			{
+				$uuids[] = $objArticle->singleSRC;
+			}
+		}
+
+		FilesModel::findMultipleByUuids($uuids);
+
+		// Actually render the articles
+		foreach ($objArticles as $objArticle)
+		{
 			$arrArticles[] = $this->parseArticle($objArticle, $blnAddArchive, ((++$count == 1) ? ' first' : '') . (($count == $limit) ? ' last' : '') . ((($count % 2) == 0) ? ' odd' : ' even'), $count);
 		}
 


### PR DESCRIPTION
I've noticed another small performance bottleneck in the news list module.
Every image is loaded in a single query which - if you do not have a low value for pagination - can be quite a few.

Let's just preload them into the registry. Another 20ms saved in my case :)