### PR TITLE
Let the user disable 2FA if it is enforced

### DIFF
--- a/core-bundle/src/Controller/FrontendModule/TwoFactorController.php
+++ b/core-bundle/src/Controller/FrontendModule/TwoFactorController.php
@@ -107,7 +107,7 @@ class TwoFactorController extends AbstractFrontendModuleController
             }
         }
 
-        if (!$this->page->enforceTwoFactor && 'tl_two_factor_disable' === $request->request->get('FORM_SUBMIT')) {
+        if ('tl_two_factor_disable' === $request->request->get('FORM_SUBMIT')) {
             $response = $this->disableTwoFactor($user);
 
             if (null !== $response) {

--- a/core-bundle/src/Resources/contao/templates/modules/mod_two_factor.html5
+++ b/core-bundle/src/Resources/contao/templates/modules/mod_two_factor.html5
@@ -36,7 +36,6 @@
     <div class="message">
       <p class="confirm"><?= $this->trans('MSC.twoFactorActive') ?></p>
     </div>
-    <?php if (!$this->enforceTwoFactor): ?>
       <form class="tl_two_factor_form" id="<?= $this->formId ?>" method="post">
         <div class="formbody">
           <input type="hidden" name="FORM_SUBMIT" value="tl_two_factor_disable">
@@ -46,7 +45,6 @@
           </div>
         </div>
       </form>
-    <?php endif; ?>
     <div class="recovery_codes">
       <h3><?= $this->trans('MSC.twoFactorBackupCodesLabel') ?></h3>
       <p><?= $this->trans('MSC.twoFactorBackupCodesExplain') ?></p>

--- a/core-bundle/src/Resources/contao/templates/modules/mod_two_factor.html5
+++ b/core-bundle/src/Resources/contao/templates/modules/mod_two_factor.html5
@@ -36,15 +36,15 @@
     <div class="message">
       <p class="confirm"><?= $this->trans('MSC.twoFactorActive') ?></p>
     </div>
-      <form class="tl_two_factor_form" id="<?= $this->formId ?>" method="post">
-        <div class="formbody">
-          <input type="hidden" name="FORM_SUBMIT" value="tl_two_factor_disable">
-          <input type="hidden" name="REQUEST_TOKEN" value="<?= REQUEST_TOKEN ?>">
-          <div class="submit_container">
-            <button type="submit" class="submit"><?= $this->trans('MSC.disable') ?></button>
-          </div>
+    <form class="tl_two_factor_form" id="<?= $this->formId ?>" method="post">
+      <div class="formbody">
+        <input type="hidden" name="FORM_SUBMIT" value="tl_two_factor_disable">
+        <input type="hidden" name="REQUEST_TOKEN" value="<?= REQUEST_TOKEN ?>">
+        <div class="submit_container">
+          <button type="submit" class="submit"><?= $this->trans('MSC.disable') ?></button>
         </div>
-      </form>
+      </div>
+    </form>
     <div class="recovery_codes">
       <h3><?= $this->trans('MSC.twoFactorBackupCodesLabel') ?></h3>
       <p><?= $this->trans('MSC.twoFactorBackupCodesExplain') ?></p>


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #1851
| Docs PR or issue | n/a

Allow disable 2FA even if it is enforced. User is forced to set it up again anyway. 
See #1851 for more information.
