### PR TITLE
Allow to define a default ptable

### DIFF
--- a/calendar-bundle/src/Resources/contao/dca/tl_content.php
+++ b/calendar-bundle/src/Resources/contao/dca/tl_content.php
@@ -21,10 +21,9 @@ use Contao\System;
 use Contao\Versions;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
-// Dynamically add the permission check and parent table
+// Dynamically add the permission check and other callbacks
 if (Input::get('do') == 'calendar')
 {
-	$GLOBALS['TL_DCA']['tl_content']['config']['ptable'] = 'tl_calendar_events';
 	array_unshift($GLOBALS['TL_DCA']['tl_content']['config']['onload_callback'], array('tl_content_calendar', 'checkPermission'));
 	$GLOBALS['TL_DCA']['tl_content']['config']['onload_callback'][] = array('tl_content_calendar', 'generateFeed');
 	$GLOBALS['TL_DCA']['tl_content']['list']['operations']['toggle']['button_callback'] = array('tl_content_calendar', 'toggleIcon');

--- a/core-bundle/src/Resources/contao/dca/tl_content.php
+++ b/core-bundle/src/Resources/contao/dca/tl_content.php
@@ -32,7 +32,7 @@ $GLOBALS['TL_DCA']['tl_content'] = array
 	(
 		'dataContainer'               => 'Table',
 		'enableVersioning'            => true,
-		'ptable'                      => '',
+		'ptable'                      => 'tl_article',
 		'dynamicPtable'               => true,
 		'markAsCopy'                  => 'headline',
 		'onload_callback'             => array
@@ -863,10 +863,9 @@ $GLOBALS['TL_DCA']['tl_content'] = array
 	)
 );
 
-// Dynamically add the permission check and parent table (see #5241)
-if (in_array(Input::get('do'), array('article', 'page')))
+// Dynamically add the permission check
+if (Input::get('do') == 'article')
 {
-	$GLOBALS['TL_DCA']['tl_content']['config']['ptable'] = 'tl_article';
 	array_unshift($GLOBALS['TL_DCA']['tl_content']['config']['onload_callback'], array('tl_content', 'checkPermission'));
 }
 

--- a/core-bundle/src/Resources/contao/library/Contao/DcaLoader.php
+++ b/core-bundle/src/Resources/contao/library/Contao/DcaLoader.php
@@ -207,7 +207,7 @@ class DcaLoader extends Controller
 	 */
 	private function setDynamicPTable(): void
 	{
-		if (!($GLOBALS['TL_DCA'][$this->strTable]['config']['dynamicPtable'] ?? false) || !empty($GLOBALS['TL_DCA'][$this->strTable]['config']['ptable']) || !isset($GLOBALS['BE_MOD']))
+		if (!($GLOBALS['TL_DCA'][$this->strTable]['config']['dynamicPtable'] ?? false) || !isset($GLOBALS['BE_MOD']))
 		{
 			return;
 		}

--- a/core-bundle/tests/Picker/TablePickerProviderTest.php
+++ b/core-bundle/tests/Picker/TablePickerProviderTest.php
@@ -347,8 +347,8 @@ class TablePickerProviderTest extends ContaoTestCase
             'config' => [
                 'dataContainer' => 'Table',
                 'ptable' => 'tl_article',
-                'dynamicPtable' => true
-            ]
+                'dynamicPtable' => true,
+            ],
         ];
 
         $params = [

--- a/core-bundle/tests/Picker/TablePickerProviderTest.php
+++ b/core-bundle/tests/Picker/TablePickerProviderTest.php
@@ -342,7 +342,14 @@ class TablePickerProviderTest extends ContaoTestCase
     {
         $GLOBALS['BE_MOD']['foo']['article'] = ['tables' => ['tl_article', 'tl_content']];
         $GLOBALS['BE_MOD']['foo']['news'] = ['tables' => ['tl_news', 'tl_content']];
-        $GLOBALS['TL_DCA']['tl_content'] = ['config' => ['dataContainer' => 'Table', 'dynamicPtable' => true]];
+
+        $GLOBALS['TL_DCA']['tl_content'] = [
+            'config' => [
+                'dataContainer' => 'Table',
+                'ptable' => 'tl_article',
+                'dynamicPtable' => true
+            ]
+        ];
 
         $params = [
             'do' => 'news',

--- a/news-bundle/src/Resources/contao/dca/tl_content.php
+++ b/news-bundle/src/Resources/contao/dca/tl_content.php
@@ -21,10 +21,9 @@ use Contao\System;
 use Contao\Versions;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
-// Dynamically add the permission check and parent table
+// Dynamically add the permission check and other callbacks
 if (Input::get('do') == 'news')
 {
-	$GLOBALS['TL_DCA']['tl_content']['config']['ptable'] = 'tl_news';
 	array_unshift($GLOBALS['TL_DCA']['tl_content']['config']['onload_callback'], array('tl_content_news', 'checkPermission'));
 	$GLOBALS['TL_DCA']['tl_content']['config']['onload_callback'][] = array('tl_content_news', 'generateFeed');
 	$GLOBALS['TL_DCA']['tl_content']['list']['operations']['toggle']['button_callback'] = array('tl_content_news', 'toggleIcon');


### PR DESCRIPTION
This is a follow-up PR to #1446. It removes some code that has become unnecessary and it adds support for defining a default ptable.

```php
'ptable'        => '',
'dynamicPtable' => true,
```

New:

```php
'ptable'        => 'tl_article', // default ptable if no other is determined
'dynamicPtable' => true,
```

This allows us to get rid of a nasty workaround that we have implemented to fix https://github.com/contao/core/issues/5241.