### PR TITLE
Rename all occurrences of rootDir to projectDir

### DIFF
--- a/calendar-bundle/src/Resources/contao/modules/ModuleEventlist.php
+++ b/calendar-bundle/src/Resources/contao/modules/ModuleEventlist.php
@@ -259,7 +259,7 @@ class ModuleEventlist extends Events
 			}
 		}
 
-		$rootDir = System::getContainer()->getParameter('kernel.project_dir');
+		$projectDir = System::getContainer()->getParameter('kernel.project_dir');
 		$uuids = array();
 
 		for ($i=$offset; $i<$limit; $i++)
@@ -338,7 +338,7 @@ class ModuleEventlist extends Events
 			{
 				$objModel = FilesModel::findByUuid($event['singleSRC']);
 
-				if ($objModel !== null && is_file($rootDir . '/' . $objModel->path))
+				if ($objModel !== null && is_file($projectDir . '/' . $objModel->path))
 				{
 					if ($imgSize)
 					{

--- a/core-bundle/src/Cache/ContaoCacheWarmer.php
+++ b/core-bundle/src/Cache/ContaoCacheWarmer.php
@@ -47,7 +47,7 @@ class ContaoCacheWarmer implements CacheWarmerInterface
     /**
      * @var string
      */
-    private $rootDir;
+    private $projectDir;
 
     /**
      * @var Connection
@@ -67,12 +67,12 @@ class ContaoCacheWarmer implements CacheWarmerInterface
     /**
      * @internal Do not inherit from this class; decorate the "contao.cache.warm_internal" service instead
      */
-    public function __construct(Filesystem $filesystem, ResourceFinderInterface $finder, FileLocator $locator, string $rootDir, Connection $connection, ContaoFramework $framework, array $locales)
+    public function __construct(Filesystem $filesystem, ResourceFinderInterface $finder, FileLocator $locator, string $projectDir, Connection $connection, ContaoFramework $framework, array $locales)
     {
         $this->filesystem = $filesystem;
         $this->finder = $finder;
         $this->locator = $locator;
-        $this->rootDir = $rootDir;
+        $this->projectDir = $projectDir;
         $this->connection = $connection;
         $this->framework = $framework;
         $this->locales = $locales;
@@ -136,7 +136,7 @@ class ContaoCacheWarmer implements CacheWarmerInterface
     {
         $dumper = new CombinedFileDumper(
             $this->filesystem,
-            new DelegatingLoader(new LoaderResolver([new PhpFileLoader(), new XliffFileLoader($this->rootDir)])),
+            new DelegatingLoader(new LoaderResolver([new PhpFileLoader(), new XliffFileLoader($this->projectDir)])),
             $cacheDir.'/contao'
         );
 
@@ -216,7 +216,7 @@ class ContaoCacheWarmer implements CacheWarmerInterface
 
         foreach ($files as $file) {
             $mapper[$file->getBasename('.html5')] = rtrim(
-                $this->filesystem->makePathRelative($file->getPath(), $this->rootDir),
+                $this->filesystem->makePathRelative($file->getPath(), $this->projectDir),
                 '/'
             );
         }

--- a/core-bundle/src/Command/InstallCommand.php
+++ b/core-bundle/src/Command/InstallCommand.php
@@ -46,7 +46,7 @@ class InstallCommand extends Command
     /**
      * @var string
      */
-    private $rootDir;
+    private $projectDir;
 
     /**
      * @var string
@@ -63,9 +63,9 @@ class InstallCommand extends Command
      */
     private $webDir;
 
-    public function __construct(string $rootDir, string $uploadPath, string $imageDir)
+    public function __construct(string $projectDir, string $uploadPath, string $imageDir)
     {
-        $this->rootDir = $rootDir;
+        $this->projectDir = $projectDir;
         $this->uploadPath = $uploadPath;
         $this->imageDir = $imageDir;
 
@@ -113,11 +113,11 @@ class InstallCommand extends Command
         ];
 
         foreach ($emptyDirs as $path) {
-            $this->addEmptyDir($this->rootDir.'/'.sprintf($path, $this->webDir));
+            $this->addEmptyDir($this->projectDir.'/'.sprintf($path, $this->webDir));
         }
 
         $this->addEmptyDir($this->imageDir);
-        $this->addEmptyDir($this->rootDir.'/'.$this->uploadPath);
+        $this->addEmptyDir($this->projectDir.'/'.$this->uploadPath);
     }
 
     private function addEmptyDir(string $path): void
@@ -128,6 +128,6 @@ class InstallCommand extends Command
 
         $this->fs->mkdir($path);
 
-        $this->rows[] = str_replace($this->rootDir.'/', '', $path);
+        $this->rows[] = str_replace($this->projectDir.'/', '', $path);
     }
 }

--- a/core-bundle/src/Command/SymlinksCommand.php
+++ b/core-bundle/src/Command/SymlinksCommand.php
@@ -49,7 +49,7 @@ class SymlinksCommand extends Command
     /**
      * @var string
      */
-    private $rootDir;
+    private $projectDir;
 
     /**
      * @var string
@@ -81,9 +81,9 @@ class SymlinksCommand extends Command
      */
     private $statusCode = 0;
 
-    public function __construct(string $rootDir, string $uploadPath, string $logsDir, ResourceFinderInterface $resourceFinder, EventDispatcherInterface $eventDispatcher)
+    public function __construct(string $projectDir, string $uploadPath, string $logsDir, ResourceFinderInterface $resourceFinder, EventDispatcherInterface $eventDispatcher)
     {
-        $this->rootDir = $rootDir;
+        $this->projectDir = $projectDir;
         $this->uploadPath = $uploadPath;
         $this->logsDir = $logsDir;
         $this->resourceFinder = $resourceFinder;
@@ -123,9 +123,9 @@ class SymlinksCommand extends Command
         $fs = new Filesystem();
 
         // Remove the base folders in the document root
-        $fs->remove($this->rootDir.'/'.$this->webDir.'/'.$this->uploadPath);
-        $fs->remove($this->rootDir.'/'.$this->webDir.'/system/modules');
-        $fs->remove($this->rootDir.'/'.$this->webDir.'/vendor');
+        $fs->remove($this->projectDir.'/'.$this->webDir.'/'.$this->uploadPath);
+        $fs->remove($this->projectDir.'/'.$this->webDir.'/system/modules');
+        $fs->remove($this->projectDir.'/'.$this->webDir.'/vendor');
 
         $this->symlinkFiles($this->uploadPath);
         $this->symlinkModules();
@@ -144,7 +144,7 @@ class SymlinksCommand extends Command
     private function symlinkFiles(string $uploadPath): void
     {
         $this->createSymlinksFromFinder(
-            $this->findIn($this->rootDir.'/'.$uploadPath)->files()->depth('> 0')->name('.public'),
+            $this->findIn($this->projectDir.'/'.$uploadPath)->files()->depth('> 0')->name('.public'),
             $uploadPath
         );
     }
@@ -156,7 +156,7 @@ class SymlinksCommand extends Command
         };
 
         $this->createSymlinksFromFinder(
-            $this->findIn($this->rootDir.'/system/modules')->files()->filter($filter)->name('.htaccess'),
+            $this->findIn($this->projectDir.'/system/modules')->files()->filter($filter)->name('.htaccess'),
             'system/modules'
         );
     }
@@ -208,7 +208,7 @@ class SymlinksCommand extends Command
         $link = strtr($link, '\\', '/');
 
         try {
-            SymlinkUtil::symlink($target, $link, $this->rootDir);
+            SymlinkUtil::symlink($target, $link, $this->projectDir);
 
             $this->rows[] = [
                 sprintf(
@@ -295,6 +295,6 @@ class SymlinksCommand extends Command
 
     private function getRelativePath(string $path): string
     {
-        return str_replace(strtr($this->rootDir, '\\', '/').'/', '', strtr($path, '\\', '/'));
+        return str_replace(strtr($this->projectDir, '\\', '/').'/', '', strtr($path, '\\', '/'));
     }
 }

--- a/core-bundle/src/Config/Loader/XliffFileLoader.php
+++ b/core-bundle/src/Config/Loader/XliffFileLoader.php
@@ -22,16 +22,16 @@ class XliffFileLoader extends Loader
     /**
      * @var string
      */
-    private $rootDir;
+    private $projectDir;
 
     /**
      * @var bool
      */
     private $addToGlobals;
 
-    public function __construct(string $rootDir, bool $addToGlobals = false)
+    public function __construct(string $projectDir, bool $addToGlobals = false)
     {
-        $this->rootDir = $rootDir;
+        $this->projectDir = $projectDir;
         $this->addToGlobals = $addToGlobals;
     }
 
@@ -49,7 +49,7 @@ class XliffFileLoader extends Loader
     {
         $xml = $this->getDomDocumentFromFile($name);
 
-        $return = "\n// ".str_replace(strtr($this->rootDir, '\\', '/').'/', '', strtr($name, '\\', '/'))."\n";
+        $return = "\n// ".str_replace(strtr($this->projectDir, '\\', '/').'/', '', strtr($name, '\\', '/'))."\n";
         $fileNodes = $xml->getElementsByTagName('file');
         $language = strtolower($language);
 

--- a/core-bundle/src/DependencyInjection/Compiler/AddResourcesPathsPass.php
+++ b/core-bundle/src/DependencyInjection/Compiler/AddResourcesPathsPass.php
@@ -32,7 +32,7 @@ class AddResourcesPathsPass implements CompilerPassInterface
     private function getResourcesPaths(ContainerBuilder $container): array
     {
         $paths = [];
-        $rootDir = $container->getParameter('kernel.project_dir');
+        $projectDir = $container->getParameter('kernel.project_dir');
 
         $bundles = $container->getParameter('kernel.bundles');
         $meta = $container->getParameter('kernel.bundles_metadata');
@@ -47,18 +47,18 @@ class AddResourcesPathsPass implements CompilerPassInterface
             }
         }
 
-        if (is_dir($rootDir.'/contao')) {
-            $paths[] = $rootDir.'/contao';
+        if (is_dir($projectDir.'/contao')) {
+            $paths[] = $projectDir.'/contao';
         }
 
-        if (is_dir($rootDir.'/app/Resources/contao')) {
+        if (is_dir($projectDir.'/app/Resources/contao')) {
             @trigger_error('Using "app/Resources/contao" has been deprecated and will no longer work in Contao 5.0. Use the "contao" folder instead.', E_USER_DEPRECATED);
-            $paths[] = $rootDir.'/app/Resources/contao';
+            $paths[] = $projectDir.'/app/Resources/contao';
         }
 
-        if (is_dir($rootDir.'/src/Resources/contao')) {
+        if (is_dir($projectDir.'/src/Resources/contao')) {
             @trigger_error('Using "src/Resources/contao" has been deprecated and will no longer work in Contao 5.0. Use the "contao" folder instead.', E_USER_DEPRECATED);
-            $paths[] = $rootDir.'/src/Resources/contao';
+            $paths[] = $projectDir.'/src/Resources/contao';
         }
 
         return $paths;

--- a/core-bundle/src/Framework/ContaoFramework.php
+++ b/core-bundle/src/Framework/ContaoFramework.php
@@ -68,7 +68,7 @@ class ContaoFramework implements ContaoFrameworkInterface, ContainerAwareInterfa
     /**
      * @var string
      */
-    private $rootDir;
+    private $projectDir;
 
     /**
      * @var int
@@ -95,13 +95,13 @@ class ContaoFramework implements ContaoFrameworkInterface, ContainerAwareInterfa
      */
     private $hookListeners = [];
 
-    public function __construct(RequestStack $requestStack, ScopeMatcher $scopeMatcher, TokenChecker $tokenChecker, Filesystem $filesystem, string $rootDir, int $errorLevel)
+    public function __construct(RequestStack $requestStack, ScopeMatcher $scopeMatcher, TokenChecker $tokenChecker, Filesystem $filesystem, string $projectDir, int $errorLevel)
     {
         $this->requestStack = $requestStack;
         $this->scopeMatcher = $scopeMatcher;
         $this->tokenChecker = $tokenChecker;
         $this->filesystem = $filesystem;
-        $this->rootDir = $rootDir;
+        $this->projectDir = $projectDir;
         $this->errorLevel = $errorLevel;
     }
 
@@ -184,7 +184,7 @@ class ContaoFramework implements ContaoFrameworkInterface, ContainerAwareInterfa
         }
 
         \define('TL_START', microtime(true));
-        \define('TL_ROOT', $this->rootDir);
+        \define('TL_ROOT', $this->projectDir);
         \define('TL_REFERER_ID', $this->getRefererId());
 
         if (!\defined('TL_SCRIPT')) {
@@ -386,16 +386,16 @@ class ContaoFramework implements ContaoFrameworkInterface, ContainerAwareInterfa
         if (
             !empty($GLOBALS['TL_HOOKS']['initializeSystem'])
             && \is_array($GLOBALS['TL_HOOKS']['initializeSystem'])
-            && is_dir($this->rootDir.'/system/tmp')
+            && is_dir($this->projectDir.'/system/tmp')
         ) {
             foreach ($GLOBALS['TL_HOOKS']['initializeSystem'] as $callback) {
                 System::importStatic($callback[0])->{$callback[1]}();
             }
         }
 
-        if ($this->filesystem->exists($this->rootDir.'/system/config/initconfig.php')) {
+        if ($this->filesystem->exists($this->projectDir.'/system/config/initconfig.php')) {
             @trigger_error('Using the "initconfig.php" file has been deprecated and will no longer work in Contao 5.0.', E_USER_DEPRECATED);
-            include $this->rootDir.'/system/config/initconfig.php';
+            include $this->projectDir.'/system/config/initconfig.php';
         }
     }
 

--- a/core-bundle/src/HttpKernel/Bundle/ContaoModuleBundle.php
+++ b/core-bundle/src/HttpKernel/Bundle/ContaoModuleBundle.php
@@ -24,10 +24,15 @@ final class ContaoModuleBundle extends Bundle
      *
      * @throws \LogicException
      */
-    public function __construct(string $name, string $rootDir)
+    public function __construct(string $name, string $projectDir)
     {
         $this->name = $name;
-        $this->path = \dirname($rootDir).'/system/modules/'.$this->name;
+        $this->path = $projectDir.'/system/modules/'.$this->name;
+
+        // Backwards compatibility, $projectDir was previously set from kernel $rootDir
+        if (!is_dir($this->path)) {
+            $this->path = \dirname($projectDir).'/system/modules/'.$this->name;
+        }
 
         if (!is_dir($this->path)) {
             throw new \LogicException(sprintf('The module folder "system/modules/%s" does not exist.', $this->name));

--- a/core-bundle/src/Image/LegacyResizer.php
+++ b/core-bundle/src/Image/LegacyResizer.php
@@ -41,7 +41,7 @@ class LegacyResizer extends ImageResizer implements FrameworkAwareInterface
     {
         $this->framework->initialize(true);
 
-        $rootDir = System::getContainer()->getParameter('kernel.project_dir');
+        $projectDir = System::getContainer()->getParameter('kernel.project_dir');
 
         if ($this->hasExecuteResizeHook() || $this->hasGetImageHook()) {
             @trigger_error('Using the "executeResize" and "getImage" hooks has been deprecated and will no longer work in Contao 5.0. Replace the "contao.image.resizer" service instead.', E_USER_DEPRECATED);
@@ -49,8 +49,8 @@ class LegacyResizer extends ImageResizer implements FrameworkAwareInterface
             $this->legacyImage = null;
             $legacyPath = $image->getPath();
 
-            if (0 === strpos($legacyPath, $rootDir.'/') || 0 === strpos($legacyPath, $rootDir.'\\')) {
-                $legacyPath = substr($legacyPath, \strlen($rootDir) + 1);
+            if (0 === strpos($legacyPath, $projectDir.'/') || 0 === strpos($legacyPath, $projectDir.'\\')) {
+                $legacyPath = substr($legacyPath, \strlen($projectDir) + 1);
                 $this->legacyImage = new LegacyImage(new File($legacyPath));
                 $this->legacyImage->setTargetWidth($config->getWidth());
                 $this->legacyImage->setTargetHeight($config->getHeight());
@@ -59,9 +59,9 @@ class LegacyResizer extends ImageResizer implements FrameworkAwareInterface
 
                 if (
                     ($targetPath = $options->getTargetPath())
-                    && (0 === strpos($targetPath, $rootDir.'/') || 0 === strpos($targetPath, $rootDir.'\\'))
+                    && (0 === strpos($targetPath, $projectDir.'/') || 0 === strpos($targetPath, $projectDir.'\\'))
                 ) {
-                    $this->legacyImage->setTargetPath(substr($targetPath, \strlen($rootDir) + 1));
+                    $this->legacyImage->setTargetPath(substr($targetPath, \strlen($projectDir) + 1));
                 }
 
                 $importantPart = $image->getImportantPart();
@@ -81,7 +81,7 @@ class LegacyResizer extends ImageResizer implements FrameworkAwareInterface
                 $return = System::importStatic($callback[0])->{$callback[1]}($this->legacyImage);
 
                 if (\is_string($return)) {
-                    return $this->createImage($image, $rootDir.'/'.$return);
+                    return $this->createImage($image, $projectDir.'/'.$return);
                 }
             }
         }
@@ -92,7 +92,7 @@ class LegacyResizer extends ImageResizer implements FrameworkAwareInterface
     protected function executeResize(ImageInterface $image, ResizeCoordinates $coordinates, string $path, ResizeOptions $options): ImageInterface
     {
         if ($this->legacyImage && $this->hasGetImageHook()) {
-            $rootDir = System::getContainer()->getParameter('kernel.project_dir');
+            $projectDir = System::getContainer()->getParameter('kernel.project_dir');
 
             foreach ($GLOBALS['TL_HOOKS']['getImage'] as $callback) {
                 $return = System::importStatic($callback[0])->{$callback[1]}(
@@ -107,7 +107,7 @@ class LegacyResizer extends ImageResizer implements FrameworkAwareInterface
                 );
 
                 if (\is_string($return)) {
-                    return $this->createImage($image, $rootDir.'/'.$return);
+                    return $this->createImage($image, $projectDir.'/'.$return);
                 }
             }
         }

--- a/core-bundle/src/Resources/contao/classes/Backend.php
+++ b/core-bundle/src/Resources/contao/classes/Backend.php
@@ -49,9 +49,9 @@ abstract class Backend extends Controller
 	public static function getTheme()
 	{
 		$theme = Config::get('backendTheme');
-		$rootDir = System::getContainer()->getParameter('kernel.project_dir');
+		$projectDir = System::getContainer()->getParameter('kernel.project_dir');
 
-		if ($theme != '' && $theme != 'flexible' && is_dir($rootDir . '/system/themes/' . $theme))
+		if ($theme != '' && $theme != 'flexible' && is_dir($projectDir . '/system/themes/' . $theme))
 		{
 			return $theme;
 		}
@@ -67,12 +67,12 @@ abstract class Backend extends Controller
 	public static function getThemes()
 	{
 		$arrReturn = array();
-		$rootDir = System::getContainer()->getParameter('kernel.project_dir');
-		$arrThemes = scan($rootDir . '/system/themes');
+		$projectDir = System::getContainer()->getParameter('kernel.project_dir');
+		$arrThemes = scan($projectDir . '/system/themes');
 
 		foreach ($arrThemes as $strTheme)
 		{
-			if (strncmp($strTheme, '.', 1) === 0 || !is_dir($rootDir . '/system/themes/' . $strTheme))
+			if (strncmp($strTheme, '.', 1) === 0 || !is_dir($projectDir . '/system/themes/' . $strTheme))
 			{
 				continue;
 			}
@@ -98,10 +98,10 @@ abstract class Backend extends Controller
 		}
 
 		$lang = str_replace('-', '_', $lang);
-		$rootDir = System::getContainer()->getParameter('kernel.project_dir');
+		$projectDir = System::getContainer()->getParameter('kernel.project_dir');
 
 		// The translation exists
-		if (file_exists($rootDir . '/assets/tinymce4/js/langs/' . $lang . '.js'))
+		if (file_exists($projectDir . '/assets/tinymce4/js/langs/' . $lang . '.js'))
 		{
 			return $lang;
 		}
@@ -109,7 +109,7 @@ abstract class Backend extends Controller
 		if (($short = substr($GLOBALS['TL_LANGUAGE'], 0, 2)) != $lang)
 		{
 			// Try the short tag, e.g. "de" instead of "de_CH"
-			if (file_exists($rootDir . '/assets/tinymce4/js/langs/' . $short . '.js'))
+			if (file_exists($projectDir . '/assets/tinymce4/js/langs/' . $short . '.js'))
 			{
 				return $short;
 			}
@@ -117,7 +117,7 @@ abstract class Backend extends Controller
 		elseif (($long = $short . '_' . strtoupper($short)) != $lang)
 		{
 			// Try the long tag, e.g. "fr_FR" instead of "fr" (see #6952)
-			if (file_exists($rootDir . '/assets/tinymce4/js/langs/' . $long . '.js'))
+			if (file_exists($projectDir . '/assets/tinymce4/js/langs/' . $long . '.js'))
 			{
 				return $long;
 			}
@@ -194,19 +194,19 @@ abstract class Backend extends Controller
 	public static function getTinyTemplates()
 	{
 		$strDir = Config::get('uploadPath') . '/tiny_templates';
-		$rootDir = System::getContainer()->getParameter('kernel.project_dir');
+		$projectDir = System::getContainer()->getParameter('kernel.project_dir');
 
-		if (!is_dir($rootDir . '/' . $strDir))
+		if (!is_dir($projectDir . '/' . $strDir))
 		{
 			return '';
 		}
 
 		$arrFiles = array();
-		$arrTemplates = scan($rootDir . '/' . $strDir);
+		$arrTemplates = scan($projectDir . '/' . $strDir);
 
 		foreach ($arrTemplates as $strFile)
 		{
-			if (strncmp('.', $strFile, 1) !== 0 && is_file($rootDir . '/' . $strDir . '/' . $strFile))
+			if (strncmp('.', $strFile, 1) !== 0 && is_file($projectDir . '/' . $strDir . '/' . $strFile))
 			{
 				$arrFiles[] = '{ title: "' . $strFile . '", url: "' . $strDir . '/' . $strFile . '" }';
 			}
@@ -1007,10 +1007,10 @@ abstract class Backend extends Controller
 			throw new \RuntimeException('Insecure path ' . $strNode);
 		}
 
-		$rootDir = System::getContainer()->getParameter('kernel.project_dir');
+		$projectDir = System::getContainer()->getParameter('kernel.project_dir');
 
 		// Currently selected folder does not exist
-		if (!is_dir($rootDir . '/' . $strNode))
+		if (!is_dir($projectDir . '/' . $strNode))
 		{
 			$objSession->set($strKey, '');
 
@@ -1344,8 +1344,8 @@ abstract class Backend extends Controller
 			$strFilter = 'gif,jpg,jpeg,png';
 		}
 
-		$rootDir = System::getContainer()->getParameter('kernel.project_dir');
-		$arrPages = scan($rootDir . '/' . $strFolder);
+		$projectDir = System::getContainer()->getParameter('kernel.project_dir');
+		$arrPages = scan($projectDir . '/' . $strFolder);
 
 		// Empty folder
 		if (empty($arrPages))
@@ -1372,7 +1372,7 @@ abstract class Backend extends Controller
 			}
 
 			// Folders
-			if (is_dir($rootDir . '/' . $strFolder . '/' . $strFile))
+			if (is_dir($projectDir . '/' . $strFolder . '/' . $strFile))
 			{
 				$strFolders .=  $this->doCreateFileList($strFolder . '/' . $strFile, $level, $strFilter);
 			}

--- a/core-bundle/src/Resources/contao/classes/DataContainer.php
+++ b/core-bundle/src/Resources/contao/classes/DataContainer.php
@@ -634,8 +634,8 @@ abstract class DataContainer extends Backend
 				if ($blnCanResize)
 				{
 					$container = System::getContainer();
-					$rootDir = $container->getParameter('kernel.project_dir');
-					$image = rawurldecode($container->get('contao.image.image_factory')->create($rootDir . '/' . $objFile->path, array(699, 524, ResizeConfiguration::MODE_BOX))->getUrl($rootDir));
+					$projectDir = $container->getParameter('kernel.project_dir');
+					$image = rawurldecode($container->get('contao.image.image_factory')->create($projectDir . '/' . $objFile->path, array(699, 524, ResizeConfiguration::MODE_BOX))->getUrl($projectDir));
 				}
 				else
 				{

--- a/core-bundle/src/Resources/contao/classes/FileUpload.php
+++ b/core-bundle/src/Resources/contao/classes/FileUpload.php
@@ -336,8 +336,8 @@ class FileUpload extends Backend
 		if ($blnResize)
 		{
 			$container = System::getContainer();
-			$rootDir = $container->getParameter('kernel.project_dir');
-			$container->get('contao.image.image_factory')->create($rootDir . '/' . $strImage, array($arrImageSize[0], $arrImageSize[1]), $rootDir . '/' . $strImage);
+			$projectDir = $container->getParameter('kernel.project_dir');
+			$container->get('contao.image.image_factory')->create($projectDir . '/' . $strImage, array($arrImageSize[0], $arrImageSize[1]), $projectDir . '/' . $strImage);
 
 			Message::addInfo(sprintf($GLOBALS['TL_LANG']['MSC']['fileResized'], $objFile->basename));
 			$this->log('File "' . $strImage . '" was scaled down to the maximum dimensions', __METHOD__, TL_FILES);

--- a/core-bundle/src/Resources/contao/classes/PurgeData.php
+++ b/core-bundle/src/Resources/contao/classes/PurgeData.php
@@ -85,7 +85,7 @@ class PurgeData extends Backend implements \executable
 		}
 
 		$container = System::getContainer();
-		$rootDir = $container->getParameter('kernel.project_dir');
+		$projectDir = $container->getParameter('kernel.project_dir');
 		$strCachePath = StringUtil::stripRootDir($container->getParameter('kernel.cache_dir'));
 
 		// Folders
@@ -107,9 +107,9 @@ class PurgeData extends Backend implements \executable
 				$folder = sprintf($folder, $strCachePath);
 
 				// Only check existing folders
-				if (is_dir($rootDir . '/' . $folder))
+				if (is_dir($projectDir . '/' . $folder))
 				{
-					$objFiles = Finder::create()->in($rootDir . '/' . $folder)->files();
+					$objFiles = Finder::create()->in($projectDir . '/' . $folder)->files();
 
 					// Do not count the deferred images JSON files
 					if ($key == 'images')

--- a/core-bundle/src/Resources/contao/controllers/BackendPopup.php
+++ b/core-bundle/src/Resources/contao/controllers/BackendPopup.php
@@ -78,10 +78,10 @@ class BackendPopup extends Backend
 			die('Invalid path');
 		}
 
-		$rootDir = System::getContainer()->getParameter('kernel.project_dir');
+		$projectDir = System::getContainer()->getParameter('kernel.project_dir');
 
 		// Check whether the file exists
-		if (!file_exists($rootDir . '/' . $this->strFile))
+		if (!file_exists($projectDir . '/' . $this->strFile))
 		{
 			die('File not found');
 		}
@@ -113,7 +113,7 @@ class BackendPopup extends Backend
 		}
 
 		// Add the file info
-		if (is_dir($rootDir . '/' . $this->strFile))
+		if (is_dir($projectDir . '/' . $this->strFile))
 		{
 			$objFile = new Folder($this->strFile);
 			$objTemplate->filesize = $this->getReadableSize($objFile->size) . ' (' . number_format($objFile->size, 0, $GLOBALS['TL_LANG']['MSC']['decimalSeparator'], $GLOBALS['TL_LANG']['MSC']['thousandsSeparator']) . ' Byte)';

--- a/core-bundle/src/Resources/contao/dca/tl_files.php
+++ b/core-bundle/src/Resources/contao/dca/tl_files.php
@@ -302,7 +302,7 @@ class tl_files extends Contao\Backend
 		}
 
 		$container = Contao\System::getContainer();
-		$rootDir = $container->getParameter('kernel.project_dir');
+		$projectDir = $container->getParameter('kernel.project_dir');
 		$objSession = $container->get('session');
 
 		$session = $objSession->all();
@@ -326,11 +326,11 @@ class tl_files extends Contao\Backend
 
 				foreach ($session['CURRENT']['IDS'] as $id)
 				{
-					if (is_dir($rootDir . '/' . $id))
+					if (is_dir($projectDir . '/' . $id))
 					{
 						$folders[] = $id;
 
-						if ($canDeleteRecursive || ($canDeleteOne && count(scan($rootDir . '/' . $id)) < 1))
+						if ($canDeleteRecursive || ($canDeleteOne && count(scan($projectDir . '/' . $id)) < 1))
 						{
 							$delete_all[] = $id;
 						}
@@ -381,9 +381,9 @@ class tl_files extends Contao\Backend
 				case 'delete':
 					$strFile = Contao\Input::get('id', true);
 
-					if (is_dir($rootDir . '/' . $strFile))
+					if (is_dir($projectDir . '/' . $strFile))
 					{
-						$finder = Symfony\Component\Finder\Finder::create()->in($rootDir . '/' . $strFile);
+						$finder = Symfony\Component\Finder\Finder::create()->in($projectDir . '/' . $strFile);
 
 						if (!$canDeleteRecursive && $finder->hasResults())
 						{
@@ -445,8 +445,8 @@ class tl_files extends Contao\Backend
 			return;
 		}
 
-		$rootDir = Contao\System::getContainer()->getParameter('kernel.project_dir');
-		$blnIsFolder = is_dir($rootDir . '/' . $dc->id);
+		$projectDir = Contao\System::getContainer()->getParameter('kernel.project_dir');
+		$blnIsFolder = is_dir($projectDir . '/' . $dc->id);
 
 		// Remove the meta data when editing folders
 		if ($blnIsFolder)
@@ -720,8 +720,8 @@ class tl_files extends Contao\Backend
 	 */
 	public function deleteFile($row, $href, $label, $title, $icon, $attributes)
 	{
-		$rootDir = Contao\System::getContainer()->getParameter('kernel.project_dir');
-		$path = $rootDir . '/' . urldecode($row['id']);
+		$projectDir = Contao\System::getContainer()->getParameter('kernel.project_dir');
+		$path = $projectDir . '/' . urldecode($row['id']);
 
 		if (!is_dir($path))
 		{
@@ -758,9 +758,9 @@ class tl_files extends Contao\Backend
 		}
 
 		$strDecoded = rawurldecode($row['id']);
-		$rootDir = Contao\System::getContainer()->getParameter('kernel.project_dir');
+		$projectDir = Contao\System::getContainer()->getParameter('kernel.project_dir');
 
-		if (is_dir($rootDir . '/' . $strDecoded))
+		if (is_dir($projectDir . '/' . $strDecoded))
 		{
 			return '';
 		}
@@ -809,10 +809,10 @@ class tl_files extends Contao\Backend
 	public function protectFolder(Contao\DataContainer $dc)
 	{
 		$strPath = $dc->id;
-		$rootDir = Contao\System::getContainer()->getParameter('kernel.project_dir');
+		$projectDir = Contao\System::getContainer()->getParameter('kernel.project_dir');
 
 		// Check if the folder has been renamed (see #6432, #934)
-		if (Contao\Input::post('name') && !is_dir($rootDir . '/' . $strPath))
+		if (Contao\Input::post('name') && !is_dir($projectDir . '/' . $strPath))
 		{
 			if (Contao\Validator::isInsecurePath(Contao\Input::post('name')))
 			{
@@ -823,14 +823,14 @@ class tl_files extends Contao\Backend
 			$strName = basename($strPath);
 			$strNewPath = str_replace($strName, Contao\Input::post('name'), $strPath, $count);
 
-			if ($strNewPath && $count > 0 && is_dir($rootDir . '/' . $strNewPath))
+			if ($strNewPath && $count > 0 && is_dir($projectDir . '/' . $strNewPath))
 			{
 				$strPath = $strNewPath;
 			}
 		}
 
 		// Only show for folders (see #5660)
-		if (!is_dir($rootDir . '/' . $strPath))
+		if (!is_dir($projectDir . '/' . $strPath))
 		{
 			return '';
 		}
@@ -841,7 +841,7 @@ class tl_files extends Contao\Backend
 		$blnUnprotected = $objFolder->isUnprotected();
 
 		// Disable the checkbox if a parent folder is public (see #712)
-		$blnDisable = $blnUnprotected && !file_exists($rootDir . '/' . $strPath . '/.public');
+		$blnDisable = $blnUnprotected && !file_exists($projectDir . '/' . $strPath . '/.public');
 
 		// Protect or unprotect the folder
 		if (!$blnDisable && Contao\Input::post('FORM_SUBMIT') == 'tl_files')
@@ -901,7 +901,7 @@ class tl_files extends Contao\Backend
 	public function excludeFolder(Contao\DataContainer $dc)
 	{
 		$strPath = $dc->id;
-		$rootDir = Contao\System::getContainer()->getParameter('kernel.project_dir');
+		$projectDir = Contao\System::getContainer()->getParameter('kernel.project_dir');
 
 		// Check if the folder has been renamed (see #6432, #934)
 		if (Contao\Input::post('name'))
@@ -914,14 +914,14 @@ class tl_files extends Contao\Backend
 			$count = 0;
 			$strName = basename($strPath);
 
-			if ($count > 0 && ($strNewPath = str_replace($strName, Contao\Input::post('name'), $strPath, $count)) && is_dir($rootDir . '/' . $strNewPath))
+			if ($count > 0 && ($strNewPath = str_replace($strName, Contao\Input::post('name'), $strPath, $count)) && is_dir($projectDir . '/' . $strNewPath))
 			{
 				$strPath = $strNewPath;
 			}
 		}
 
 		// Only show for folders (see #5660)
-		if (!is_dir($rootDir . '/' . $strPath))
+		if (!is_dir($projectDir . '/' . $strPath))
 		{
 			return '';
 		}
@@ -932,7 +932,7 @@ class tl_files extends Contao\Backend
 		$blnUnsynchronized = $objFolder->isUnsynchronized();
 
 		// Disable the checkbox if a parent folder is unsynchronized
-		$blnDisable = $blnUnsynchronized && !file_exists($rootDir . '/' . $strPath . '/.nosync');
+		$blnDisable = $blnUnsynchronized && !file_exists($projectDir . '/' . $strPath . '/.nosync');
 
 		// Synchronize or unsynchronize the folder
 		if (!$blnDisable && Contao\Input::post('FORM_SUBMIT') == 'tl_files')

--- a/core-bundle/src/Resources/contao/dca/tl_templates.php
+++ b/core-bundle/src/Resources/contao/dca/tl_templates.php
@@ -178,10 +178,10 @@ class tl_templates extends Contao\Backend
 			throw new RuntimeException('Insecure path ' . $strNode);
 		}
 
-		$rootDir = Contao\System::getContainer()->getParameter('kernel.project_dir');
+		$projectDir = Contao\System::getContainer()->getParameter('kernel.project_dir');
 
 		// Currently selected folder does not exist
-		if (!is_dir($rootDir . '/' . $strNode))
+		if (!is_dir($projectDir . '/' . $strNode))
 		{
 			$objSessionBag->set('tl_templates_node', '');
 
@@ -262,10 +262,10 @@ class tl_templates extends Contao\Backend
 				throw new RuntimeException('Invalid path ' . $strTarget);
 			}
 
-			$rootDir = Contao\System::getContainer()->getParameter('kernel.project_dir');
+			$projectDir = Contao\System::getContainer()->getParameter('kernel.project_dir');
 
 			// Validate the target path
-			if (strncmp($strTarget, 'templates', 9) !== 0 || !is_dir($rootDir . '/' . $strTarget))
+			if (strncmp($strTarget, 'templates', 9) !== 0 || !is_dir($projectDir . '/' . $strTarget))
 			{
 				$strError = sprintf($GLOBALS['TL_LANG']['tl_templates']['invalid'], $strTarget);
 			}
@@ -292,7 +292,7 @@ class tl_templates extends Contao\Backend
 					$strTarget .= '/' . basename($strOriginal);
 
 					// Check whether the target file exists
-					if (file_exists($rootDir . '/' . $strTarget))
+					if (file_exists($projectDir . '/' . $strTarget))
 					{
 						$strError = sprintf($GLOBALS['TL_LANG']['tl_templates']['exists'], $strTarget);
 					}

--- a/core-bundle/src/Resources/contao/dca/tl_theme.php
+++ b/core-bundle/src/Resources/contao/dca/tl_theme.php
@@ -259,8 +259,8 @@ class tl_theme extends Contao\Backend
 
 			if ($objFile !== null && file_exists(TL_ROOT . '/' . $objFile->path))
 			{
-				$rootDir = Contao\System::getContainer()->getParameter('kernel.project_dir');
-				$label = Contao\Image::getHtml(Contao\System::getContainer()->get('contao.image.image_factory')->create($rootDir . '/' . $objFile->path, array(75, 50, 'center_top'))->getUrl($rootDir), '', 'class="theme_preview"') . ' ' . $label;
+				$projectDir = Contao\System::getContainer()->getParameter('kernel.project_dir');
+				$label = Contao\Image::getHtml(Contao\System::getContainer()->get('contao.image.image_factory')->create($projectDir . '/' . $objFile->path, array(75, 50, 'center_top'))->getUrl($projectDir), '', 'class="theme_preview"') . ' ' . $label;
 			}
 		}
 
@@ -319,11 +319,11 @@ class tl_theme extends Contao\Backend
 	protected function doGetTemplateFolders($path, $level=0)
 	{
 		$return = array();
-		$rootDir = Contao\System::getContainer()->getParameter('kernel.project_dir');
+		$projectDir = Contao\System::getContainer()->getParameter('kernel.project_dir');
 
-		foreach (scan($rootDir . '/' . $path) as $file)
+		foreach (scan($projectDir . '/' . $path) as $file)
 		{
-			if (is_dir($rootDir . '/' . $path . '/' . $file))
+			if (is_dir($projectDir . '/' . $path . '/' . $file))
 			{
 				$return[$path . '/' . $file] = str_repeat(' &nbsp; &nbsp; ', $level) . $file;
 				$return = array_merge($return, $this->doGetTemplateFolders($path . '/' . $file, $level+1));

--- a/core-bundle/src/Resources/contao/forms/FormFileUpload.php
+++ b/core-bundle/src/Resources/contao/forms/FormFileUpload.php
@@ -231,19 +231,19 @@ class FormFileUpload extends Widget implements \uploadable
 				}
 
 				$strUploadFolder = $objUploadFolder->path;
-				$rootDir = System::getContainer()->getParameter('kernel.project_dir');
+				$projectDir = System::getContainer()->getParameter('kernel.project_dir');
 
 				// Store the file if the upload folder exists
-				if ($strUploadFolder != '' && is_dir($rootDir . '/' . $strUploadFolder))
+				if ($strUploadFolder != '' && is_dir($projectDir . '/' . $strUploadFolder))
 				{
 					$this->import(Files::class, 'Files');
 
 					// Do not overwrite existing files
-					if ($this->doNotOverwrite && file_exists($rootDir . '/' . $strUploadFolder . '/' . $file['name']))
+					if ($this->doNotOverwrite && file_exists($projectDir . '/' . $strUploadFolder . '/' . $file['name']))
 					{
 						$offset = 1;
 
-						$arrAll = scan($rootDir . '/' . $strUploadFolder);
+						$arrAll = scan($projectDir . '/' . $strUploadFolder);
 						$arrFiles = preg_grep('/^' . preg_quote($objFile->filename, '/') . '.*\.' . preg_quote($objFile->extension, '/') . '/', $arrAll);
 
 						foreach ($arrFiles as $strFile)
@@ -288,7 +288,7 @@ class FormFileUpload extends Widget implements \uploadable
 					(
 						'name'     => $file['name'],
 						'type'     => $file['type'],
-						'tmp_name' => $rootDir . '/' . $strFile,
+						'tmp_name' => $projectDir . '/' . $strFile,
 						'error'    => $file['error'],
 						'size'     => $file['size'],
 						'uploaded' => true,

--- a/core-bundle/src/Resources/contao/library/Contao/Automator.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Automator.php
@@ -459,8 +459,8 @@ class Automator extends System
 	{
 		@trigger_error('Using Automator::rotateLogs() has been deprecated and will no longer work in Contao 5.0. Use the logger service instead, which rotates its log files automatically.', E_USER_DEPRECATED);
 
-		$rootDir = System::getContainer()->getParameter('kernel.project_dir');
-		$arrFiles = preg_grep('/\.log$/', scan($rootDir . '/system/logs'));
+		$projectDir = System::getContainer()->getParameter('kernel.project_dir');
+		$arrFiles = preg_grep('/\.log$/', scan($projectDir . '/system/logs'));
 
 		foreach ($arrFiles as $strFile)
 		{
@@ -477,7 +477,7 @@ class Automator extends System
 			{
 				$strGzName = 'system/logs/' . $strFile . '.' . $i;
 
-				if (file_exists($rootDir . '/' . $strGzName))
+				if (file_exists($projectDir . '/' . $strGzName))
 				{
 					$objFile = new File($strGzName);
 					$objFile->renameTo('system/logs/' . $strFile . '.' . ($i+1));

--- a/core-bundle/src/Resources/contao/library/Contao/ClassLoader.php
+++ b/core-bundle/src/Resources/contao/library/Contao/ClassLoader.php
@@ -152,7 +152,7 @@ class ClassLoader
 			return;
 		}
 
-		$rootDir = System::getContainer()->getParameter('kernel.project_dir');
+		$projectDir = System::getContainer()->getParameter('kernel.project_dir');
 
 		// The class file is set in the mapper
 		if (isset(self::$classes[$class]))
@@ -162,7 +162,7 @@ class ClassLoader
 				$GLOBALS['TL_DEBUG']['classes_set'][$class] = $class;
 			}
 
-			include $rootDir . '/' . self::$classes[$class];
+			include $projectDir . '/' . self::$classes[$class];
 		}
 
 		// Find the class in the registered namespaces
@@ -175,7 +175,7 @@ class ClassLoader
 					$GLOBALS['TL_DEBUG']['classes_aliased'][$class] = $namespaced;
 				}
 
-				include $rootDir . '/' . self::$classes[$namespaced];
+				include $projectDir . '/' . self::$classes[$namespaced];
 			}
 
 			class_alias($namespaced, $class);

--- a/core-bundle/src/Resources/contao/library/Contao/Config.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Config.php
@@ -426,12 +426,12 @@ class Config
 		include __DIR__ . '/../../config/agents.php';
 		include __DIR__ . '/../../config/mimetypes.php';
 
-		$rootDir = System::getContainer()->getParameter('kernel.project_dir');
+		$projectDir = System::getContainer()->getParameter('kernel.project_dir');
 
 		// Include the local configuration file
-		if (($blnHasLcf = file_exists($rootDir . '/system/config/localconfig.php')) === true)
+		if (($blnHasLcf = file_exists($projectDir . '/system/config/localconfig.php')) === true)
 		{
-			include $rootDir . '/system/config/localconfig.php';
+			include $projectDir . '/system/config/localconfig.php';
 		}
 
 		static::loadParameters();

--- a/core-bundle/src/Resources/contao/library/Contao/Controller.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Controller.php
@@ -141,8 +141,8 @@ abstract class Controller extends System
 			$strGlobPrefix = substr($strGlobPrefix, 0, -1) . '[_-]';
 		}
 
-		$rootDir = System::getContainer()->getParameter('kernel.project_dir');
-		$arrCustomized = self::braceGlob($rootDir . '/templates/' . $strGlobPrefix . '*.html5');
+		$projectDir = System::getContainer()->getParameter('kernel.project_dir');
+		$arrCustomized = self::braceGlob($projectDir . '/templates/' . $strGlobPrefix . '*.html5');
 
 		// Add the customized templates
 		if (!empty($arrCustomized) && \is_array($arrCustomized))
@@ -183,7 +183,7 @@ abstract class Controller extends System
 
 		$arrDefaultPlaces = array();
 
-		if ($strDefaultTemplate && file_exists($rootDir . '/templates/' . $strDefaultTemplate . '.html5'))
+		if ($strDefaultTemplate && file_exists($projectDir . '/templates/' . $strDefaultTemplate . '.html5'))
 		{
 			$arrDefaultPlaces[] = $GLOBALS['TL_LANG']['MSC']['global'];
 		}
@@ -211,12 +211,12 @@ abstract class Controller extends System
 						continue;
 					}
 
-					if ($strDefaultTemplate && file_exists($rootDir . '/' . $objTheme->templates . '/' . $strDefaultTemplate . '.html5'))
+					if ($strDefaultTemplate && file_exists($projectDir . '/' . $objTheme->templates . '/' . $strDefaultTemplate . '.html5'))
 					{
 						$arrDefaultPlaces[] = $objTheme->name;
 					}
 
-					$arrThemeTemplates = self::braceGlob($rootDir . '/' . $objTheme->templates . '/' . $strGlobPrefix . '*.html5');
+					$arrThemeTemplates = self::braceGlob($projectDir . '/' . $objTheme->templates . '/' . $strGlobPrefix . '*.html5');
 
 					if (!empty($arrThemeTemplates) && \is_array($arrThemeTemplates))
 					{
@@ -1319,10 +1319,10 @@ abstract class Controller extends System
 			throw new PageNotFoundException('Invalid path');
 		}
 
-		$rootDir = System::getContainer()->getParameter('kernel.project_dir');
+		$projectDir = System::getContainer()->getParameter('kernel.project_dir');
 
 		// Check whether the file exists
-		if (!file_exists($rootDir . '/' . $strFile))
+		if (!file_exists($projectDir . '/' . $strFile))
 		{
 			throw new PageNotFoundException('File not found');
 		}
@@ -1595,14 +1595,14 @@ abstract class Controller extends System
 
 		try
 		{
-			$rootDir = $container->getParameter('kernel.project_dir');
+			$projectDir = $container->getParameter('kernel.project_dir');
 			$staticUrl = $container->get('contao.assets.files_context')->getStaticUrl();
-			$picture = $container->get('contao.image.picture_factory')->create($rootDir . '/' . $arrItem['singleSRC'], $size);
+			$picture = $container->get('contao.image.picture_factory')->create($projectDir . '/' . $arrItem['singleSRC'], $size);
 
 			$picture = array
 			(
-				'img' => $picture->getImg($rootDir, $staticUrl),
-				'sources' => $picture->getSources($rootDir, $staticUrl)
+				'img' => $picture->getImg($projectDir, $staticUrl),
+				'sources' => $picture->getSources($projectDir, $staticUrl)
 			);
 
 			$src = $picture['img']['src'];
@@ -1738,14 +1738,14 @@ abstract class Controller extends System
 					{
 						try
 						{
-							$rootDir = $container->getParameter('kernel.project_dir');
+							$projectDir = $container->getParameter('kernel.project_dir');
 							$staticUrl = $container->get('contao.assets.files_context')->getStaticUrl();
-							$picture = $container->get('contao.image.picture_factory')->create($rootDir . '/' . $arrItem['imageUrl'], $lightboxSize);
+							$picture = $container->get('contao.image.picture_factory')->create($projectDir . '/' . $arrItem['imageUrl'], $lightboxSize);
 
 							$objTemplate->lightboxPicture = array
 							(
-								'img' => $picture->getImg($rootDir, $staticUrl),
-								'sources' => $picture->getSources($rootDir, $staticUrl)
+								'img' => $picture->getImg($projectDir, $staticUrl),
+								'sources' => $picture->getSources($projectDir, $staticUrl)
 							);
 
 							$objTemplate->$strHrefKey = $objTemplate->lightboxPicture['img']['src'];
@@ -1776,14 +1776,14 @@ abstract class Controller extends System
 		{
 			try
 			{
-				$rootDir = $container->getParameter('kernel.project_dir');
+				$projectDir = $container->getParameter('kernel.project_dir');
 				$staticUrl = $container->get('contao.assets.files_context')->getStaticUrl();
-				$picture = $container->get('contao.image.picture_factory')->create($rootDir . '/' . $arrItem['singleSRC'], $lightboxSize);
+				$picture = $container->get('contao.image.picture_factory')->create($projectDir . '/' . $arrItem['singleSRC'], $lightboxSize);
 
 				$objTemplate->lightboxPicture = array
 				(
-					'img' => $picture->getImg($rootDir, $staticUrl),
-					'sources' => $picture->getSources($rootDir, $staticUrl)
+					'img' => $picture->getImg($projectDir, $staticUrl),
+					'sources' => $picture->getSources($projectDir, $staticUrl)
 				);
 
 				$objTemplate->$strHrefKey = $objTemplate->lightboxPicture['img']['src'];
@@ -1863,9 +1863,9 @@ abstract class Controller extends System
 		{
 			if ($objFiles->type == 'file')
 			{
-				$rootDir = System::getContainer()->getParameter('kernel.project_dir');
+				$projectDir = System::getContainer()->getParameter('kernel.project_dir');
 
-				if (!\in_array($objFiles->extension, $allowedDownload) || !is_file($rootDir . '/' . $objFiles->path))
+				if (!\in_array($objFiles->extension, $allowedDownload) || !is_file($projectDir . '/' . $objFiles->path))
 				{
 					continue;
 				}

--- a/core-bundle/src/Resources/contao/library/Contao/Database/Updater.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Database/Updater.php
@@ -89,10 +89,10 @@ class Updater extends Controller
 						   ->execute(serialize($mootools), $objLayout->id);
 		}
 
-		$rootDir = System::getContainer()->getParameter('kernel.project_dir');
+		$projectDir = System::getContainer()->getParameter('kernel.project_dir');
 
 		// Update event reader
-		if (!file_exists($rootDir . '/templates/event_default.tpl'))
+		if (!file_exists($projectDir . '/templates/event_default.tpl'))
 		{
 			$this->Database->execute("UPDATE tl_module SET cal_template='event_full' WHERE cal_template='event_default'");
 		}
@@ -649,8 +649,8 @@ class Updater extends Controller
 		$arrMapper = array();
 		$arrFolders = array();
 		$arrFiles = array();
-		$rootDir = System::getContainer()->getParameter('kernel.project_dir');
-		$arrScan = scan($rootDir . '/' . $strPath);
+		$projectDir = System::getContainer()->getParameter('kernel.project_dir');
+		$arrScan = scan($projectDir . '/' . $strPath);
 
 		foreach ($arrScan as $strFile)
 		{
@@ -659,7 +659,7 @@ class Updater extends Controller
 				continue;
 			}
 
-			if (is_dir($rootDir . '/' . $strPath . '/' . $strFile))
+			if (is_dir($projectDir . '/' . $strPath . '/' . $strFile))
 			{
 				$arrFolders[] = $strPath . '/' . $strFile;
 			}
@@ -689,7 +689,7 @@ class Updater extends Controller
 			if (preg_match('/^meta(_([a-z]{2}))?\.txt$/', basename($strFile), $matches))
 			{
 				$key = $matches[2] ?: 'en';
-				$arrData = file($rootDir . '/' . $strFile, FILE_IGNORE_NEW_LINES);
+				$arrData = file($projectDir . '/' . $strFile, FILE_IGNORE_NEW_LINES);
 
 				foreach ($arrData as $line)
 				{

--- a/core-bundle/src/Resources/contao/library/Contao/Dbafs.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Dbafs.php
@@ -49,7 +49,7 @@ class Dbafs
 		self::validateUtf8Path($strResource);
 
 		$strUploadPath = Config::get('uploadPath') . '/';
-		$rootDir = System::getContainer()->getParameter('kernel.project_dir');
+		$projectDir = System::getContainer()->getParameter('kernel.project_dir');
 
 		// Remove trailing slashes (see #5707)
 		if (substr($strResource, -1) == '/')
@@ -61,7 +61,7 @@ class Dbafs
 		$strResource = str_replace(array('\\', '//'), '/', $strResource);
 
 		// The resource does not exist or lies outside the upload directory
-		if ($strResource == '' || !file_exists($rootDir . '/' . $strResource) || strncmp($strResource, $strUploadPath, \strlen($strUploadPath)) !== 0)
+		if ($strResource == '' || !file_exists($projectDir . '/' . $strResource) || strncmp($strResource, $strUploadPath, \strlen($strUploadPath)) !== 0)
 		{
 			throw new \InvalidArgumentException("Invalid resource $strResource");
 		}
@@ -118,13 +118,13 @@ class Dbafs
 		$arrPaths = array_values($arrPaths);
 
 		// If the resource is a folder, also add its contents
-		if (is_dir($rootDir . '/' . $strResource))
+		if (is_dir($projectDir . '/' . $strResource))
 		{
 			/** @var \SplFileInfo[] $objFiles */
 			$objFiles = new \RecursiveIteratorIterator(
 				new SyncExclude(
 					new \RecursiveDirectoryIterator(
-						$rootDir . '/' . $strResource,
+						$projectDir . '/' . $strResource,
 						\FilesystemIterator::UNIX_PATHS|\FilesystemIterator::FOLLOW_SYMLINKS|\FilesystemIterator::SKIP_DOTS
 					)
 				),
@@ -169,7 +169,7 @@ class Dbafs
 			}
 
 			// Create the file or folder
-			if (is_file($rootDir . '/' . $strPath))
+			if (is_file($projectDir . '/' . $strPath))
 			{
 				$objFile = new File($strPath);
 
@@ -213,7 +213,7 @@ class Dbafs
 		// Update the folder hashes from bottom up after all file hashes are set
 		foreach (array_reverse($arrPaths) as $strPath)
 		{
-			if (is_dir($rootDir . '/' . $strPath))
+			if (is_dir($projectDir . '/' . $strPath))
 			{
 				$objModel = FilesModel::findByPath($strPath);
 				$objModel->hash = static::getFolderHash($strPath);
@@ -438,7 +438,7 @@ class Dbafs
 			$varResource = array($varResource);
 		}
 
-		$rootDir = System::getContainer()->getParameter('kernel.project_dir');
+		$projectDir = System::getContainer()->getParameter('kernel.project_dir');
 
 		foreach ($varResource as $strResource)
 		{
@@ -448,7 +448,7 @@ class Dbafs
 			$strPath   = array_shift($arrChunks);
 
 			// Do not check files
-			if (is_file($rootDir . '/' . $strResource))
+			if (is_file($projectDir . '/' . $strResource))
 			{
 				array_pop($arrChunks);
 			}
@@ -514,13 +514,13 @@ class Dbafs
 		// Reset the "found" flag
 		$objDatabase->query("UPDATE tl_files SET found=''");
 
-		$rootDir = System::getContainer()->getParameter('kernel.project_dir');
+		$projectDir = System::getContainer()->getParameter('kernel.project_dir');
 
 		/** @var \SplFileInfo[] $objFiles */
 		$objFiles = new \RecursiveIteratorIterator(
 			new SyncExclude(
 				new \RecursiveDirectoryIterator(
-					$rootDir . '/' . Config::get('uploadPath'),
+					$projectDir . '/' . Config::get('uploadPath'),
 					\FilesystemIterator::UNIX_PATHS|\FilesystemIterator::FOLLOW_SYMLINKS|\FilesystemIterator::SKIP_DOTS
 				)
 			),
@@ -591,7 +591,7 @@ class Dbafs
 				}
 
 				// Create the file or folder
-				if (is_file($rootDir . '/' . $strRelpath))
+				if (is_file($projectDir . '/' . $strRelpath))
 				{
 					$objFile = new File($strRelpath);
 
@@ -836,10 +836,10 @@ class Dbafs
 
 		self::validateUtf8Path($strPath);
 
-		$rootDir = System::getContainer()->getParameter('kernel.project_dir');
+		$projectDir = System::getContainer()->getParameter('kernel.project_dir');
 
 		// Look for an existing parent folder (see #410)
-		while ($strPath != '.' && !is_dir($rootDir . '/' . $strPath))
+		while ($strPath != '.' && !is_dir($projectDir . '/' . $strPath))
 		{
 			$strPath = \dirname($strPath);
 		}

--- a/core-bundle/src/Resources/contao/library/Contao/DcaLoader.php
+++ b/core-bundle/src/Resources/contao/library/Contao/DcaLoader.php
@@ -120,13 +120,13 @@ class DcaLoader extends Controller
 			}
 		}
 
-		$rootDir = System::getContainer()->getParameter('kernel.project_dir');
+		$projectDir = System::getContainer()->getParameter('kernel.project_dir');
 
 		// Local configuration file
-		if (file_exists($rootDir . '/system/config/dcaconfig.php'))
+		if (file_exists($projectDir . '/system/config/dcaconfig.php'))
 		{
 			@trigger_error('Using the "dcaconfig.php" file has been deprecated and will no longer work in Contao 5.0. Create custom DCA files in the "contao/dca" folder instead.', E_USER_DEPRECATED);
-			include $rootDir . '/system/config/dcaconfig.php';
+			include $projectDir . '/system/config/dcaconfig.php';
 		}
 	}
 

--- a/core-bundle/src/Resources/contao/library/Contao/Image.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Image.php
@@ -624,7 +624,7 @@ class Image
 			return $src;
 		}
 
-		$rootDir = System::getContainer()->getParameter('kernel.project_dir');
+		$projectDir = System::getContainer()->getParameter('kernel.project_dir');
 
 		if (strncmp($src, 'icon', 4) === 0)
 		{
@@ -636,7 +636,7 @@ class Image
 			$filename = pathinfo($src, PATHINFO_FILENAME);
 
 			// Prefer SVG icons
-			if (file_exists($rootDir . '/assets/contao/images/' . $filename . '.svg'))
+			if (file_exists($projectDir . '/assets/contao/images/' . $filename . '.svg'))
 			{
 				return 'assets/contao/images/' . $filename . '.svg';
 			}
@@ -654,7 +654,7 @@ class Image
 		$filename = pathinfo($src, PATHINFO_FILENAME);
 
 		// Prefer SVG icons
-		if (file_exists($rootDir . '/system/themes/' . $theme . '/icons/' . $filename . '.svg'))
+		if (file_exists($projectDir . '/system/themes/' . $theme . '/icons/' . $filename . '.svg'))
 		{
 			return 'system/themes/' . $theme . '/icons/' . $filename . '.svg';
 		}
@@ -681,14 +681,14 @@ class Image
 		}
 
 		$container = System::getContainer();
-		$rootDir = $container->getParameter('kernel.project_dir');
+		$projectDir = $container->getParameter('kernel.project_dir');
 		$webDir = StringUtil::stripRootDir($container->getParameter('contao.web_dir'));
 
-		if (!is_file($rootDir . '/' . $src))
+		if (!is_file($projectDir . '/' . $src))
 		{
 			try
 			{
-				$deferredImage = $container->get('contao.image.image_factory')->create($rootDir . '/' . $src);
+				$deferredImage = $container->get('contao.image.image_factory')->create($projectDir . '/' . $src);
 			}
 			catch (\Exception $e)
 			{
@@ -696,7 +696,7 @@ class Image
 			}
 
 			// Handle public bundle resources
-			if (file_exists($rootDir . '/' . $webDir . '/' . $src))
+			if (file_exists($projectDir . '/' . $webDir . '/' . $src))
 			{
 				$src = $webDir . '/' . $src;
 			}

--- a/core-bundle/src/Resources/contao/library/Contao/Picture.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Picture.php
@@ -217,8 +217,8 @@ class Picture
 	 */
 	public function getTemplateData()
 	{
-		$rootDir = System::getContainer()->getParameter('kernel.project_dir');
-		$image = System::getContainer()->get('contao.image.image_factory')->create($rootDir . '/' . $this->image->getOriginalPath());
+		$projectDir = System::getContainer()->getParameter('kernel.project_dir');
+		$image = System::getContainer()->get('contao.image.image_factory')->create($projectDir . '/' . $this->image->getOriginalPath());
 
 		if (\is_string($this->imageSize) && $this->imageSize[0] === '_')
 		{
@@ -268,8 +268,8 @@ class Picture
 
 		return array
 		(
-			'img' => $picture->getImg($rootDir, $staticUrl),
-			'sources' => $picture->getSources($rootDir, $staticUrl),
+			'img' => $picture->getImg($projectDir, $staticUrl),
+			'sources' => $picture->getSources($projectDir, $staticUrl),
 		);
 	}
 

--- a/core-bundle/src/Resources/contao/library/Contao/StringUtil.php
+++ b/core-bundle/src/Resources/contao/library/Contao/StringUtil.php
@@ -1110,12 +1110,12 @@ class StringUtil
 	 */
 	public static function stripRootDir($path)
 	{
-		$rootDir = System::getContainer()->getParameter('kernel.project_dir');
-		$length = \strlen($rootDir);
+		$projectDir = System::getContainer()->getParameter('kernel.project_dir');
+		$length = \strlen($projectDir);
 
-		if (strncmp($path, $rootDir, $length) !== 0 || \strlen($path) <= $length || ($path[$length] !== '/' && $path[$length] !== '\\'))
+		if (strncmp($path, $projectDir, $length) !== 0 || \strlen($path) <= $length || ($path[$length] !== '/' && $path[$length] !== '\\'))
 		{
-			throw new \InvalidArgumentException(sprintf('Path "%s" is not inside the Contao root dir "%s"', $path, $rootDir));
+			throw new \InvalidArgumentException(sprintf('Path "%s" is not inside the Contao root dir "%s"', $path, $projectDir));
 		}
 
 		return (string) substr($path, $length + 1);

--- a/core-bundle/src/Resources/contao/library/Contao/System.php
+++ b/core-bundle/src/Resources/contao/library/Contao/System.php
@@ -468,13 +468,13 @@ abstract class System
 			$GLOBALS['TL_LANG']['MSC']['deleteConfirm'] = str_replace("'", "\\'", $GLOBALS['TL_LANG']['MSC']['deleteConfirm']);
 		}
 
-		$rootDir = self::getContainer()->getParameter('kernel.project_dir');
+		$projectDir = self::getContainer()->getParameter('kernel.project_dir');
 
 		// Local configuration file
-		if (file_exists($rootDir . '/system/config/langconfig.php'))
+		if (file_exists($projectDir . '/system/config/langconfig.php'))
 		{
 			@trigger_error('Using the "langconfig.php" file has been deprecated and will no longer work in Contao 5.0. Create custom language files in the "contao/languages" folder instead.', E_USER_DEPRECATED);
-			include $rootDir . '/system/config/langconfig.php';
+			include $projectDir . '/system/config/langconfig.php';
 		}
 	}
 
@@ -489,9 +489,9 @@ abstract class System
 	{
 		if (!isset(static::$arrLanguages[$strLanguage]))
 		{
-			$rootDir = self::getContainer()->getParameter('kernel.project_dir');
+			$projectDir = self::getContainer()->getParameter('kernel.project_dir');
 
-			if (is_dir($rootDir . '/vendor/contao/core-bundle/src/Resources/contao/languages/' . $strLanguage))
+			if (is_dir($projectDir . '/vendor/contao/core-bundle/src/Resources/contao/languages/' . $strLanguage))
 			{
 				static::$arrLanguages[$strLanguage] = true;
 			}
@@ -785,12 +785,12 @@ abstract class System
 	{
 		@trigger_error('Using System::readPhpFileWithoutTags() has been deprecated and will no longer work in Contao 5.0. Use the Contao\CoreBundle\Config\Loader\PhpFileLoader instead.', E_USER_DEPRECATED);
 
-		$rootDir = self::getContainer()->getParameter('kernel.project_dir');
+		$projectDir = self::getContainer()->getParameter('kernel.project_dir');
 
 		// Convert to absolute path
-		if (strpos($strName, $rootDir . '/') === false)
+		if (strpos($strName, $projectDir . '/') === false)
 		{
-			$strName = $rootDir . '/' . $strName;
+			$strName = $projectDir . '/' . $strName;
 		}
 
 		$loader = new PhpFileLoader();
@@ -814,12 +814,12 @@ abstract class System
 	{
 		@trigger_error('Using System::convertXlfToPhp() has been deprecated and will no longer work in Contao 5.0. Use the Contao\CoreBundle\Config\Loader\XliffFileLoader instead.', E_USER_DEPRECATED);
 
-		$rootDir = self::getContainer()->getParameter('kernel.project_dir');
+		$projectDir = self::getContainer()->getParameter('kernel.project_dir');
 
 		// Convert to absolute path
-		if (strpos($strName, $rootDir . '/') === false)
+		if (strpos($strName, $projectDir . '/') === false)
 		{
-			$strName = $rootDir . '/' . $strName;
+			$strName = $projectDir . '/' . $strName;
 		}
 
 		$loader = new XliffFileLoader(static::getContainer()->getParameter('kernel.project_dir'), $blnLoad);

--- a/core-bundle/src/Resources/contao/library/Contao/Template.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Template.php
@@ -553,20 +553,20 @@ abstract class Template extends Controller
 		if ($mtime === null && !preg_match('@^https?://@', $href))
 		{
 			$container = System::getContainer();
-			$rootDir = $container->getParameter('kernel.project_dir');
+			$projectDir = $container->getParameter('kernel.project_dir');
 
-			if (file_exists($rootDir . '/' . $href))
+			if (file_exists($projectDir . '/' . $href))
 			{
-				$mtime = filemtime($rootDir . '/' . $href);
+				$mtime = filemtime($projectDir . '/' . $href);
 			}
 			else
 			{
 				$webDir = StringUtil::stripRootDir($container->getParameter('contao.web_dir'));
 
 				// Handle public bundle resources in web/
-				if (file_exists($rootDir . '/' . $webDir . '/' . $href))
+				if (file_exists($projectDir . '/' . $webDir . '/' . $href))
 				{
-					$mtime = filemtime($rootDir . '/' . $webDir . '/' . $href);
+					$mtime = filemtime($projectDir . '/' . $webDir . '/' . $href);
 				}
 			}
 		}
@@ -609,20 +609,20 @@ abstract class Template extends Controller
 		if ($mtime === null && !preg_match('@^https?://@', $src))
 		{
 			$container = System::getContainer();
-			$rootDir = $container->getParameter('kernel.project_dir');
+			$projectDir = $container->getParameter('kernel.project_dir');
 
-			if (file_exists($rootDir . '/' . $src))
+			if (file_exists($projectDir . '/' . $src))
 			{
-				$mtime = filemtime($rootDir . '/' . $src);
+				$mtime = filemtime($projectDir . '/' . $src);
 			}
 			else
 			{
 				$webDir = StringUtil::stripRootDir($container->getParameter('contao.web_dir'));
 
 				// Handle public bundle resources in web/
-				if (file_exists($rootDir . '/' . $webDir . '/' . $src))
+				if (file_exists($projectDir . '/' . $webDir . '/' . $src))
 				{
-					$mtime = filemtime($rootDir . '/' . $webDir . '/' . $src);
+					$mtime = filemtime($projectDir . '/' . $webDir . '/' . $src);
 				}
 			}
 		}

--- a/core-bundle/src/Resources/contao/library/Contao/TemplateLoader.php
+++ b/core-bundle/src/Resources/contao/library/Contao/TemplateLoader.php
@@ -97,18 +97,18 @@ class TemplateLoader
 	public static function getPath($template, $format, $custom='templates')
 	{
 		$file = $template . '.' . $format;
-		$rootDir = System::getContainer()->getParameter('kernel.project_dir');
+		$projectDir = System::getContainer()->getParameter('kernel.project_dir');
 
 		// Check the theme folder first
-		if (file_exists($rootDir . '/' . $custom . '/' . $file))
+		if (file_exists($projectDir . '/' . $custom . '/' . $file))
 		{
-			return $rootDir . '/' . $custom . '/' . $file;
+			return $projectDir . '/' . $custom . '/' . $file;
 		}
 
 		// Then check the global templates directory (see #5547)
-		if ($custom != 'templates' && file_exists($rootDir . '/templates/' . $file))
+		if ($custom != 'templates' && file_exists($projectDir . '/templates/' . $file))
 		{
-			return $rootDir . '/templates/' . $file;
+			return $projectDir . '/templates/' . $file;
 		}
 
 		return static::getDefaultPath($template, $format);
@@ -128,11 +128,11 @@ class TemplateLoader
 	{
 		$file = $template . '.' . $format;
 		$container = System::getContainer();
-		$rootDir = $container->getParameter('kernel.project_dir');
+		$projectDir = $container->getParameter('kernel.project_dir');
 
 		if (isset(self::$files[$template]))
 		{
-			return $rootDir . '/' . self::$files[$template] . '/' . $file;
+			return $projectDir . '/' . self::$files[$template] . '/' . $file;
 		}
 
 		$strPath = null;

--- a/core-bundle/src/Resources/contao/models/FilesModel.php
+++ b/core-bundle/src/Resources/contao/models/FilesModel.php
@@ -253,12 +253,12 @@ class FilesModel extends Model
 	 */
 	public static function findByPath($path, array $arrOptions=array())
 	{
-		$rootDir = System::getContainer()->getParameter('kernel.project_dir');
+		$projectDir = System::getContainer()->getParameter('kernel.project_dir');
 		$uploadPath = System::getContainer()->getParameter('contao.upload_path');
 
-		if (strncmp($path, $rootDir . '/', \strlen($rootDir) + 1) === 0)
+		if (strncmp($path, $projectDir . '/', \strlen($projectDir) + 1) === 0)
 		{
-			$path = substr($path, \strlen($rootDir) + 1);
+			$path = substr($path, \strlen($projectDir) + 1);
 		}
 
 		if (strncmp($path, $uploadPath . '/', \strlen($uploadPath) + 1) !== 0)

--- a/core-bundle/src/Resources/contao/pages/PageRegular.php
+++ b/core-bundle/src/Resources/contao/pages/PageRegular.php
@@ -375,7 +375,7 @@ class PageRegular extends Frontend
 		}
 
 		$container = System::getContainer();
-		$rootDir = $container->getParameter('kernel.project_dir');
+		$projectDir = $container->getParameter('kernel.project_dir');
 
 		// jQuery scripts
 		if ($objLayout->addJQuery)
@@ -390,7 +390,7 @@ class PageRegular extends Frontend
 
 					if (!$hash->isHit())
 					{
-						$hash->set('sha256-' . base64_encode(hash_file('sha256', $rootDir . '/assets/jquery/js/jquery.min.js', true)));
+						$hash->set('sha256-' . base64_encode(hash_file('sha256', $projectDir . '/assets/jquery/js/jquery.min.js', true)));
 						$cache->save($hash);
 					}
 
@@ -636,7 +636,7 @@ class PageRegular extends Frontend
 
 			// Get the file entries from the database
 			$objFiles = FilesModel::findMultipleByUuids($arrExternal);
-			$rootDir = System::getContainer()->getParameter('kernel.project_dir');
+			$projectDir = System::getContainer()->getParameter('kernel.project_dir');
 
 			if ($objFiles !== null)
 			{
@@ -644,7 +644,7 @@ class PageRegular extends Frontend
 
 				while ($objFiles->next())
 				{
-					if (file_exists($rootDir . '/' . $objFiles->path))
+					if (file_exists($projectDir . '/' . $objFiles->path))
 					{
 						$arrFiles[] = $objFiles->path . '|static';
 					}
@@ -799,13 +799,13 @@ class PageRegular extends Frontend
 
 		// Get the file entries from the database
 		$objFiles = FilesModel::findMultipleByUuids($arrExternalJs);
-		$rootDir = System::getContainer()->getParameter('kernel.project_dir');
+		$projectDir = System::getContainer()->getParameter('kernel.project_dir');
 
 		if ($objFiles !== null)
 		{
 			while ($objFiles->next())
 			{
-				if (file_exists($rootDir . '/' . $objFiles->path))
+				if (file_exists($projectDir . '/' . $objFiles->path))
 				{
 					$strScripts .= Template::generateScriptTag($objFiles->path, false, null);
 				}

--- a/core-bundle/src/Resources/contao/widgets/FileSelector.php
+++ b/core-bundle/src/Resources/contao/widgets/FileSelector.php
@@ -217,7 +217,7 @@ class FileSelector extends Widget
 			Backend::addFilesBreadcrumb('tl_files_picker');
 		}
 
-		$rootDir = System::getContainer()->getParameter('kernel.project_dir');
+		$projectDir = System::getContainer()->getParameter('kernel.project_dir');
 
 		// Root nodes (breadcrumb menu)
 		if (!empty($GLOBALS['TL_DCA']['tl_files']['list']['sorting']['root']))
@@ -232,7 +232,7 @@ class FileSelector extends Widget
 				if (empty($root))
 				{
 					// Set all folders inside the custom path as root nodes
-					$root = array_map(function ($el) { return $this->path . '/' . $el; }, scan($rootDir . '/' . $this->path));
+					$root = array_map(function ($el) { return $this->path . '/' . $el; }, scan($projectDir . '/' . $this->path));
 
 					// Hide the breadcrumb
 					$GLOBALS['TL_DCA']['tl_file']['list']['sorting']['breadcrumb'] = '';
@@ -243,20 +243,20 @@ class FileSelector extends Widget
 
 			foreach ($nodes as $node)
 			{
-				$tree .= $this->renderFiletree($rootDir . '/' . $node, 0, true, true, $arrFound);
+				$tree .= $this->renderFiletree($projectDir . '/' . $node, 0, true, true, $arrFound);
 			}
 		}
 
 		// Show a custom path (see #4926)
 		elseif ($this->path != '')
 		{
-			$tree .= $this->renderFiletree($rootDir . '/' . $this->path, 0, false, $this->isProtectedPath($this->path), $arrFound);
+			$tree .= $this->renderFiletree($projectDir . '/' . $this->path, 0, false, $this->isProtectedPath($this->path), $arrFound);
 		}
 
 		// Start from root
 		elseif ($this->User->isAdmin)
 		{
-			$tree .= $this->renderFiletree($rootDir . '/' . Config::get('uploadPath'), 0, false, true, $arrFound);
+			$tree .= $this->renderFiletree($projectDir . '/' . Config::get('uploadPath'), 0, false, true, $arrFound);
 		}
 
 		// Show mounted files to regular users
@@ -266,7 +266,7 @@ class FileSelector extends Widget
 
 			foreach ($nodes as $node)
 			{
-				$tree .= $this->renderFiletree($rootDir . '/' . $node, 0, true, true, $arrFound);
+				$tree .= $this->renderFiletree($projectDir . '/' . $node, 0, true, true, $arrFound);
 			}
 		}
 
@@ -557,13 +557,13 @@ class FileSelector extends Widget
 				// Generate thumbnail
 				if ($objFile->isImage && $objFile->viewHeight > 0 && Config::get('thumbnails') && ($objFile->isSvgImage || ($objFile->height <= Config::get('gdMaxImgHeight') && $objFile->width <= Config::get('gdMaxImgWidth'))))
 				{
-					$rootDir = System::getContainer()->getParameter('kernel.project_dir');
-					$thumbnail .= '<br>' . Image::getHtml(System::getContainer()->get('contao.image.image_factory')->create($rootDir . '/' . rawurldecode($currentEncoded), array(100, 75, ResizeConfiguration::MODE_BOX))->getUrl($rootDir), '', 'style="margin:0 0 2px -18px"');
-					$importantPart = System::getContainer()->get('contao.image.image_factory')->create($rootDir . '/' . rawurldecode($currentEncoded))->getImportantPart();
+					$projectDir = System::getContainer()->getParameter('kernel.project_dir');
+					$thumbnail .= '<br>' . Image::getHtml(System::getContainer()->get('contao.image.image_factory')->create($projectDir . '/' . rawurldecode($currentEncoded), array(100, 75, ResizeConfiguration::MODE_BOX))->getUrl($projectDir), '', 'style="margin:0 0 2px -18px"');
+					$importantPart = System::getContainer()->get('contao.image.image_factory')->create($projectDir . '/' . rawurldecode($currentEncoded))->getImportantPart();
 
 					if ($importantPart->getX() > 0 || $importantPart->getY() > 0 || $importantPart->getWidth() < 1 || $importantPart->getHeight() < 1)
 					{
-						$thumbnail .= ' ' . Image::getHtml(System::getContainer()->get('contao.image.image_factory')->create($rootDir . '/' . rawurldecode($currentEncoded), (new ResizeConfiguration())->setWidth(80)->setHeight(60)->setMode(ResizeConfiguration::MODE_BOX)->setZoomLevel(100))->getUrl($rootDir), '', 'style="margin:0 0 2px 0;vertical-align:bottom"');
+						$thumbnail .= ' ' . Image::getHtml(System::getContainer()->get('contao.image.image_factory')->create($projectDir . '/' . rawurldecode($currentEncoded), (new ResizeConfiguration())->setWidth(80)->setHeight(60)->setMode(ResizeConfiguration::MODE_BOX)->setZoomLevel(100))->getUrl($projectDir), '', 'style="margin:0 0 2px 0;vertical-align:bottom"');
 					}
 				}
 
@@ -648,11 +648,11 @@ class FileSelector extends Widget
 	 */
 	protected function isProtectedPath($path)
 	{
-		$rootDir = System::getContainer()->getParameter('kernel.project_dir');
+		$projectDir = System::getContainer()->getParameter('kernel.project_dir');
 
 		do
 		{
-			if (file_exists($rootDir . '/' . $path . '/.public'))
+			if (file_exists($projectDir . '/' . $path . '/.public'))
 			{
 				return false;
 			}

--- a/core-bundle/src/Resources/contao/widgets/FileTree.php
+++ b/core-bundle/src/Resources/contao/widgets/FileTree.php
@@ -166,19 +166,19 @@ class FileTree extends Widget
 			return;
 		}
 
-		$rootDir = System::getContainer()->getParameter('kernel.project_dir');
+		$projectDir = System::getContainer()->getParameter('kernel.project_dir');
 
 		foreach ($objFiles as $objFile)
 		{
 			// Only files can be selected
-			if ($this->filesOnly && is_dir($rootDir . '/' . $objFile->path))
+			if ($this->filesOnly && is_dir($projectDir . '/' . $objFile->path))
 			{
 				$this->addError($GLOBALS['TL_LANG']['ERR']['filesOnly']);
 				break;
 			}
 
 			// Only folders can be selected
-			if ($this->files === false && !is_dir($rootDir . '/' . $objFile->path))
+			if ($this->files === false && !is_dir($projectDir . '/' . $objFile->path))
 			{
 				$this->addError($GLOBALS['TL_LANG']['ERR']['foldersOnly']);
 				break;
@@ -192,7 +192,7 @@ class FileTree extends Widget
 			}
 
 			// Only certain file types can be selected
-			if ($this->extensions && !is_dir($rootDir . '/' . $objFile->path))
+			if ($this->extensions && !is_dir($projectDir . '/' . $objFile->path))
 			{
 				$objFile = new File($objFile->path);
 				$extensions = StringUtil::trimsplit(',', $this->extensions);
@@ -222,14 +222,14 @@ class FileTree extends Widget
 		{
 			$objFiles = FilesModel::findMultipleByUuids((array) $this->varValue);
 			$allowedDownload = StringUtil::trimsplit(',', strtolower(Config::get('allowedDownload')));
-			$rootDir = System::getContainer()->getParameter('kernel.project_dir');
+			$projectDir = System::getContainer()->getParameter('kernel.project_dir');
 
 			if ($objFiles !== null)
 			{
 				while ($objFiles->next())
 				{
 					// File system and database seem not in sync
-					if (!file_exists($rootDir . '/' . $objFiles->path))
+					if (!file_exists($projectDir . '/' . $objFiles->path))
 					{
 						continue;
 					}
@@ -455,8 +455,8 @@ class FileTree extends Widget
 			}
 			else
 			{
-				$rootDir = System::getContainer()->getParameter('kernel.project_dir');
-				$image = System::getContainer()->get('contao.image.image_factory')->create($rootDir . '/' . $objFile->path, array(100, 75, ResizeConfiguration::MODE_BOX))->getUrl($rootDir);
+				$projectDir = System::getContainer()->getParameter('kernel.project_dir');
+				$image = System::getContainer()->get('contao.image.image_factory')->create($projectDir . '/' . $objFile->path, array(100, 75, ResizeConfiguration::MODE_BOX))->getUrl($projectDir);
 			}
 		}
 		else

--- a/core-bundle/src/Util/SymlinkUtil.php
+++ b/core-bundle/src/Util/SymlinkUtil.php
@@ -22,18 +22,18 @@ class SymlinkUtil
      * The method will try to generate relative symlinks and fall back to generating
      * absolute symlinks if relative symlinks are not supported (see #208).
      */
-    public static function symlink(string $target, string $link, string $rootDir): void
+    public static function symlink(string $target, string $link, string $projectDir): void
     {
-        static::validateSymlink($target, $link, $rootDir);
+        static::validateSymlink($target, $link, $projectDir);
 
         $fs = new Filesystem();
 
         if (!$fs->isAbsolutePath($target)) {
-            $target = $rootDir.'/'.$target;
+            $target = $projectDir.'/'.$target;
         }
 
         if (!$fs->isAbsolutePath($link)) {
-            $link = $rootDir.'/'.$link;
+            $link = $projectDir.'/'.$link;
         }
 
         if ('\\' === \DIRECTORY_SEPARATOR) {
@@ -49,7 +49,7 @@ class SymlinkUtil
      * @throws \InvalidArgumentException
      * @throws \LogicException
      */
-    public static function validateSymlink(string $target, string $link, string $rootDir): void
+    public static function validateSymlink(string $target, string $link, string $projectDir): void
     {
         if ('' === $target) {
             throw new \InvalidArgumentException('The symlink target must not be empty.');
@@ -65,7 +65,7 @@ class SymlinkUtil
 
         $fs = new Filesystem();
 
-        if ($fs->exists($rootDir.'/'.$link) && !is_link($rootDir.'/'.$link)) {
+        if ($fs->exists($projectDir.'/'.$link) && !is_link($projectDir.'/'.$link)) {
             throw new \LogicException(sprintf('The path "%s" exists and is not a symlink.', $link));
         }
     }

--- a/core-bundle/tests/Command/SymlinksCommandTest.php
+++ b/core-bundle/tests/Command/SymlinksCommandTest.php
@@ -61,10 +61,10 @@ class SymlinksCommandTest extends TestCase
     {
         $command = (new \ReflectionClass(SymlinksCommand::class))->newInstanceWithoutConstructor();
 
-        // Use \ as directory separator in $rootDir
-        $rootDir = new \ReflectionProperty(SymlinksCommand::class, 'rootDir');
-        $rootDir->setAccessible(true);
-        $rootDir->setValue($command, strtr($this->getFixturesDir(), '/', '\\'));
+        // Use \ as directory separator in $projectDir
+        $projectDir = new \ReflectionProperty(SymlinksCommand::class, 'projectDir');
+        $projectDir->setAccessible(true);
+        $projectDir->setValue($command, strtr($this->getFixturesDir(), '/', '\\'));
 
         // Use / as directory separator in $path
         $method = new \ReflectionMethod(SymlinksCommand::class, 'getRelativePath');

--- a/core-bundle/tests/Contao/EnvironmentTest.php
+++ b/core-bundle/tests/Contao/EnvironmentTest.php
@@ -24,13 +24,13 @@ class EnvironmentTest extends TestCase
     /**
      * @var string
      */
-    public $rootDir;
+    public $projectDir;
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->rootDir = strtr($this->getFixturesDir(), '\\', '/');
+        $this->projectDir = strtr($this->getFixturesDir(), '\\', '/');
 
         Environment::reset();
         Environment::set('path', '/core');
@@ -67,8 +67,8 @@ class EnvironmentTest extends TestCase
         $_SERVER['HTTPS'] = 'on';
         $_SERVER['SERVER_NAME'] = 'localhost';
         $_SERVER['SERVER_ADDR'] = '127.0.0.1';
-        $_SERVER['DOCUMENT_ROOT'] = $this->rootDir;
-        $_SERVER['SCRIPT_FILENAME'] = $this->rootDir.'/core/index.php';
+        $_SERVER['DOCUMENT_ROOT'] = $this->projectDir;
+        $_SERVER['SCRIPT_FILENAME'] = $this->projectDir.'/core/index.php';
         $_SERVER['SERVER_PROTOCOL'] = 'HTTP/1.1';
         $_SERVER['QUERY_STRING'] = 'do=test';
         $_SERVER['REQUEST_URI'] = '/core/en/academy.html?do=test';
@@ -93,8 +93,8 @@ class EnvironmentTest extends TestCase
         $_SERVER['HTTPS'] = 'on';
         $_SERVER['SERVER_NAME'] = 'localhost';
         $_SERVER['SERVER_ADDR'] = '127.0.0.1';
-        $_SERVER['DOCUMENT_ROOT'] = $this->rootDir;
-        $_SERVER['SCRIPT_FILENAME'] = $this->rootDir.'/core/index.php';
+        $_SERVER['DOCUMENT_ROOT'] = $this->projectDir;
+        $_SERVER['SCRIPT_FILENAME'] = $this->projectDir.'/core/index.php';
         $_SERVER['SERVER_PROTOCOL'] = 'HTTP/1.1';
         $_SERVER['QUERY_STRING'] = 'do=test';
         $_SERVER['REQUEST_URI'] = '/core/en/academy.html?do=test';
@@ -123,8 +123,8 @@ class EnvironmentTest extends TestCase
         $_SERVER['HTTPS'] = 'on';
         $_SERVER['SERVER_NAME'] = 'localhost';
         $_SERVER['SERVER_ADDR'] = '127.0.0.1';
-        $_SERVER['DOCUMENT_ROOT'] = $this->rootDir;
-        $_SERVER['SCRIPT_FILENAME'] = $this->rootDir.'/core/index.php';
+        $_SERVER['DOCUMENT_ROOT'] = $this->projectDir;
+        $_SERVER['SCRIPT_FILENAME'] = $this->projectDir.'/core/index.php';
         $_SERVER['SERVER_PROTOCOL'] = 'HTTP/1.1';
         $_SERVER['QUERY_STRING'] = 'do=test';
         $_SERVER['REQUEST_URI'] = 'http://localhost/core/en/academy.html?do=test'; // see #8661
@@ -150,9 +150,9 @@ class EnvironmentTest extends TestCase
         $this->assertFalse($agent->mobile);
 
         $this->assertSame('HTTP/1.1', Environment::get('serverProtocol'));
-        $this->assertSame($this->rootDir.'/core/index.php', Environment::get('scriptFilename'));
+        $this->assertSame($this->projectDir.'/core/index.php', Environment::get('scriptFilename'));
         $this->assertSame('/core/index.php', Environment::get('scriptName'));
-        $this->assertSame($this->rootDir, Environment::get('documentRoot'));
+        $this->assertSame($this->projectDir, Environment::get('documentRoot'));
         $this->assertSame('/core/en/academy.html?do=test', Environment::get('requestUri'));
         $this->assertSame(['de-DE', 'de', 'en-GB', 'en'], Environment::get('httpAcceptLanguage'));
         $this->assertSame(['gzip', 'deflate', 'sdch'], Environment::get('httpAcceptEncoding'));

--- a/core-bundle/tests/Image/ImageFactoryTest.php
+++ b/core-bundle/tests/Image/ImageFactoryTest.php
@@ -695,13 +695,13 @@ class ImageFactoryTest extends TestCase
             .'.jpg';
 
         $fs = new Filesystem();
-        $rootDir = System::getContainer()->getParameter('kernel.project_dir');
+        $projectDir = System::getContainer()->getParameter('kernel.project_dir');
 
-        if (!$fs->exists(\dirname($rootDir.'/'.$path))) {
-            $fs->mkdir(\dirname($rootDir.'/'.$path), 0777);
+        if (!$fs->exists(\dirname($projectDir.'/'.$path))) {
+            $fs->mkdir(\dirname($projectDir.'/'.$path), 0777);
         }
 
-        $fs->dumpFile($rootDir.'/'.$path, '');
+        $fs->dumpFile($projectDir.'/'.$path, '');
 
         return $path;
     }
@@ -783,13 +783,13 @@ class ImageFactoryTest extends TestCase
             .'.jpg';
 
         $fs = new Filesystem();
-        $rootDir = System::getContainer()->getParameter('kernel.project_dir');
+        $projectDir = System::getContainer()->getParameter('kernel.project_dir');
 
-        if (!$fs->exists(\dirname($rootDir.'/'.$path))) {
-            $fs->mkdir(\dirname($rootDir.'/'.$path), 0777);
+        if (!$fs->exists(\dirname($projectDir.'/'.$path))) {
+            $fs->mkdir(\dirname($projectDir.'/'.$path), 0777);
         }
 
-        $fs->dumpFile($rootDir.'/'.$path, '');
+        $fs->dumpFile($projectDir.'/'.$path, '');
 
         return $path;
     }

--- a/faq-bundle/src/Resources/contao/modules/ModuleFaqPage.php
+++ b/faq-bundle/src/Resources/contao/modules/ModuleFaqPage.php
@@ -75,7 +75,7 @@ class ModuleFaqPage extends Module
 		global $objPage;
 
 		$arrFaqs = array_fill_keys($this->faq_categories, array());
-		$rootDir = System::getContainer()->getParameter('kernel.project_dir');
+		$projectDir = System::getContainer()->getParameter('kernel.project_dir');
 
 		// Add FAQs
 		while ($objFaq->next())
@@ -94,7 +94,7 @@ class ModuleFaqPage extends Module
 			{
 				$objModel = FilesModel::findByUuid($objFaq->singleSRC);
 
-				if ($objModel !== null && is_file($rootDir . '/' . $objModel->path))
+				if ($objModel !== null && is_file($projectDir . '/' . $objModel->path))
 				{
 					// Do not override the field now that we have a model registry (see #6303)
 					$arrFaq = $objFaq->row();

--- a/installation-bundle/src/Config/ParameterDumper.php
+++ b/installation-bundle/src/Config/ParameterDumper.php
@@ -32,14 +32,14 @@ class ParameterDumper
      */
     private $parameters = ['parameters' => []];
 
-    public function __construct(string $rootDir, Filesystem $filesystem = null)
+    public function __construct(string $projectDir, Filesystem $filesystem = null)
     {
-        $this->configFile = $rootDir.'/config/parameters.yml';
+        $this->configFile = $projectDir.'/config/parameters.yml';
         $this->filesystem = $filesystem ?: new Filesystem();
 
         // Fallback to the legacy config file (see #566)
-        if (file_exists($rootDir.'/app/config/parameters.yml') && !file_exists($rootDir.'/config/parameters.yml')) {
-            $this->configFile = $rootDir.'/app/config/parameters.yml';
+        if (file_exists($projectDir.'/app/config/parameters.yml') && !file_exists($projectDir.'/config/parameters.yml')) {
+            $this->configFile = $projectDir.'/app/config/parameters.yml';
         } elseif (!file_exists($this->configFile)) {
             return;
         }

--- a/installation-bundle/src/InstallTool.php
+++ b/installation-bundle/src/InstallTool.php
@@ -34,7 +34,7 @@ class InstallTool
     /**
      * @var string
      */
-    private $rootDir;
+    private $projectDir;
 
     /**
      * @var LoggerInterface
@@ -49,23 +49,23 @@ class InstallTool
     /**
      * @internal Do not inherit from this class; decorate the "contao.install_tool" service instead
      */
-    public function __construct(Connection $connection, string $rootDir, LoggerInterface $logger, MigrationCollection $migrations)
+    public function __construct(Connection $connection, string $projectDir, LoggerInterface $logger, MigrationCollection $migrations)
     {
         $this->connection = $connection;
-        $this->rootDir = $rootDir;
+        $this->projectDir = $projectDir;
         $this->logger = $logger;
         $this->migrations = $migrations;
     }
 
     public function isLocked(): bool
     {
-        $file = $this->rootDir.'/var/install_lock';
+        $file = $this->projectDir.'/var/install_lock';
 
         if (!file_exists($file)) {
             return false;
         }
 
-        $count = file_get_contents($this->rootDir.'/var/install_lock');
+        $count = file_get_contents($this->projectDir.'/var/install_lock');
 
         return (int) $count >= 3;
     }
@@ -83,10 +83,10 @@ class InstallTool
     public function increaseLoginCount(): void
     {
         $count = 0;
-        $file = $this->rootDir.'/var/install_lock';
+        $file = $this->projectDir.'/var/install_lock';
 
         if (file_exists($file)) {
-            $count = file_get_contents($this->rootDir.'/var/install_lock');
+            $count = file_get_contents($this->projectDir.'/var/install_lock');
         }
 
         $fs = new Filesystem();
@@ -326,7 +326,7 @@ class InstallTool
         $finder = Finder::create()
             ->files()
             ->name('*.sql')
-            ->in($this->rootDir.'/templates')
+            ->in($this->projectDir.'/templates')
         ;
 
         $templates = [];
@@ -350,7 +350,7 @@ class InstallTool
             }
         }
 
-        $data = file($this->rootDir.'/templates/'.$template);
+        $data = file($this->projectDir.'/templates/'.$template);
 
         foreach (preg_grep('/^INSERT /', $data) as $query) {
             $this->connection->query($query);

--- a/manager-bundle/src/Command/InstallWebDirCommand.php
+++ b/manager-bundle/src/Command/InstallWebDirCommand.php
@@ -39,11 +39,11 @@ class InstallWebDirCommand extends Command
     /**
      * @var string
      */
-    private $rootDir;
+    private $projectDir;
 
-    public function __construct(string $rootDir)
+    public function __construct(string $projectDir)
     {
-        $this->rootDir = $rootDir;
+        $this->projectDir = $projectDir;
 
         parent::__construct();
     }
@@ -62,7 +62,7 @@ class InstallWebDirCommand extends Command
         $this->fs = new Filesystem();
         $this->io = new SymfonyStyle($input, $output);
 
-        $webDir = $this->rootDir.'/'.rtrim($input->getArgument('target'), '/');
+        $webDir = $this->projectDir.'/'.rtrim($input->getArgument('target'), '/');
 
         $this->addHtaccess($webDir);
         $this->addFiles($webDir);

--- a/manager-bundle/src/HttpKernel/ContaoKernel.php
+++ b/manager-bundle/src/HttpKernel/ContaoKernel.php
@@ -316,20 +316,20 @@ class ContaoKernel extends Kernel implements HttpCacheProvider
 
     private function getConfigFile(string $file): ?string
     {
-        $rootDir = $this->getProjectDir();
+        $projectDir = $this->getProjectDir();
 
         foreach (['.yaml', '.yml'] as $ext) {
-            if (file_exists($rootDir.'/config/'.$file.$ext)) {
-                return $rootDir.'/config/'.$file.$ext;
+            if (file_exists($projectDir.'/config/'.$file.$ext)) {
+                return $projectDir.'/config/'.$file.$ext;
             }
         }
 
         // Fallback to the legacy config file (see #566)
         foreach (['.yaml', '.yml'] as $ext) {
-            if (file_exists($rootDir.'/app/config/'.$file.$ext)) {
+            if (file_exists($projectDir.'/app/config/'.$file.$ext)) {
                 @trigger_error(sprintf('Storing the "%s" file in the "app/config" folder has been deprecated and will no longer work in Contao 5.0. Move it to the "config" folder instead.', $file.$ext), E_USER_DEPRECATED);
 
-                return $rootDir.'/app/config/'.$file.$ext;
+                return $projectDir.'/app/config/'.$file.$ext;
             }
         }
 

--- a/manager-bundle/src/Routing/RouteLoader.php
+++ b/manager-bundle/src/Routing/RouteLoader.php
@@ -38,17 +38,17 @@ class RouteLoader
     /**
      * @var string
      */
-    private $rootDir;
+    private $projectDir;
 
     /**
      * @internal Do not inherit from this class; decorate the "contao_manager.routing_loader" service instead
      */
-    public function __construct(LoaderInterface $loader, PluginLoader $pluginLoader, KernelInterface $kernel, string $rootDir)
+    public function __construct(LoaderInterface $loader, PluginLoader $pluginLoader, KernelInterface $kernel, string $projectDir)
     {
         $this->loader = $loader;
         $this->pluginLoader = $pluginLoader;
         $this->kernel = $kernel;
-        $this->rootDir = $rootDir;
+        $this->projectDir = $projectDir;
     }
 
     /**
@@ -92,21 +92,21 @@ class RouteLoader
     private function getConfigFile(): ?string
     {
         foreach (['routes.yaml', 'routes.yml', 'routing.yaml', 'routing.yml'] as $file) {
-            if (file_exists($this->rootDir.'/config/'.$file)) {
+            if (file_exists($this->projectDir.'/config/'.$file)) {
                 if (0 === strncmp($file, 'routing.', 8)) {
                     @trigger_error(sprintf('Using a "%s" file has been deprecated and will no longer work in Contao 5.0. Rename it to "routes.yaml" instead.', $file), E_USER_DEPRECATED);
                 }
 
-                return $this->rootDir.'/config/'.$file;
+                return $this->projectDir.'/config/'.$file;
             }
         }
 
         // Fallback to the legacy config file (see #566)
         foreach (['routes.yaml', 'routes.yml', 'routing.yaml', 'routing.yml'] as $file) {
-            if (file_exists($this->rootDir.'/app/config/'.$file)) {
+            if (file_exists($this->projectDir.'/app/config/'.$file)) {
                 @trigger_error(sprintf('Storing the "%s" file in the "app/config" folder has been deprecated and will no longer work in Contao 5.0. Move it to the "config" folder instead.', $file), E_USER_DEPRECATED);
 
-                return $this->rootDir.'/app/config/'.$file;
+                return $this->projectDir.'/app/config/'.$file;
             }
         }
 

--- a/newsletter-bundle/src/Resources/contao/classes/Newsletter.php
+++ b/newsletter-bundle/src/Resources/contao/classes/Newsletter.php
@@ -79,11 +79,11 @@ class Newsletter extends Backend
 
 				if ($objFiles !== null)
 				{
-					$rootDir = System::getContainer()->getParameter('kernel.project_dir');
+					$projectDir = System::getContainer()->getParameter('kernel.project_dir');
 
 					while ($objFiles->next())
 					{
-						if (is_file($rootDir . '/' . $objFiles->path))
+						if (is_file($projectDir . '/' . $objFiles->path))
 						{
 							$arrAttachments[] = $objFiles->path;
 						}
@@ -340,11 +340,11 @@ class Newsletter extends Backend
 		// Attachments
 		if (!empty($arrAttachments) && \is_array($arrAttachments))
 		{
-			$rootDir = System::getContainer()->getParameter('kernel.project_dir');
+			$projectDir = System::getContainer()->getParameter('kernel.project_dir');
 
 			foreach ($arrAttachments as $strAttachment)
 			{
-				$objEmail->attachFile($rootDir . '/' . $strAttachment);
+				$objEmail->attachFile($projectDir . '/' . $strAttachment);
 			}
 		}
 


### PR DESCRIPTION
The `Kernel::getRootDir()` method and `kernel.root_dir` parameter are deprecated since Symfony 4.2 and have been removed in Symfony 5. The only place Contao still uses the actual `rootDir` was in the `ContaoModuleBundle` class, which has been fixed here to [allow either version](https://github.com/contao/contao/pull/1891/files#diff-ea356aa2a9f8e5318aa5a063576cf963R32). I have also renamed all uses of `$rootDir` to be consistent across the code base.

**Road to Symfony 5:** https://github.com/contao/contao/issues/1889