### PR TITLE
Revert the $rootDir changes in the ContaoModuleBundle class

### DIFF
--- a/core-bundle/src/HttpKernel/Bundle/ContaoModuleBundle.php
+++ b/core-bundle/src/HttpKernel/Bundle/ContaoModuleBundle.php
@@ -24,15 +24,10 @@ final class ContaoModuleBundle extends Bundle
      *
      * @throws \LogicException
      */
-    public function __construct(string $name, string $projectDir)
+    public function __construct(string $name, string $rootDir)
     {
         $this->name = $name;
-        $this->path = $projectDir.'/system/modules/'.$this->name;
-
-        // Backwards compatibility, $projectDir was previously set from kernel $rootDir
-        if (!is_dir($this->path)) {
-            $this->path = \dirname($projectDir).'/system/modules/'.$this->name;
-        }
+        $this->path = \dirname($rootDir).'/system/modules/'.$this->name;
 
         if (!is_dir($this->path)) {
             throw new \LogicException(sprintf('The module folder "system/modules/%s" does not exist.', $this->name));


### PR DESCRIPTION
As discussed in Mumble on July 2nd, this needs to be reverted for Contao 4.9 and re-applied in Contao 4.10.