### PR TITLE
Support projectDir instead of rootDir for ContaoModuleBundle

### DIFF
--- a/core-bundle/src/HttpKernel/Bundle/ContaoModuleBundle.php
+++ b/core-bundle/src/HttpKernel/Bundle/ContaoModuleBundle.php
@@ -29,7 +29,7 @@ final class ContaoModuleBundle extends Bundle
         $this->name = $name;
         $this->path = $projectDir.'/system/modules/'.$this->name;
 
-        if (\is_dir($this->path)) {
+        if (is_dir($this->path)) {
             return;
         }
 

--- a/core-bundle/src/HttpKernel/Bundle/ContaoModuleBundle.php
+++ b/core-bundle/src/HttpKernel/Bundle/ContaoModuleBundle.php
@@ -24,10 +24,17 @@ final class ContaoModuleBundle extends Bundle
      *
      * @throws \LogicException
      */
-    public function __construct(string $name, string $rootDir)
+    public function __construct(string $name, string $projectDir)
     {
         $this->name = $name;
-        $this->path = \dirname($rootDir).'/system/modules/'.$this->name;
+        $this->path = $projectDir.'/system/modules/'.$this->name;
+
+        if (\is_dir($this->path)) {
+            return;
+        }
+
+        // Backwards compatibility, $projectDir was previously set from kernel $rootDir
+        $this->path = \dirname($projectDir).'/system/modules/'.$this->name;
 
         if (!is_dir($this->path)) {
             throw new \LogicException(sprintf('The module folder "system/modules/%s" does not exist.', $this->name));


### PR DESCRIPTION
As discussed, the changes in https://github.com/contao/contao/pull/1891/files#diff-ea356aa2a9f8e5318aa5a063576cf963R27-R35 should be reverted for Contao 4.9 and this PR should be implemented in 4.10