### PR TITLE
Allow ContainerBuilder with different configurations

### DIFF
--- a/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
+++ b/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
@@ -166,34 +166,6 @@ use Symfony\Component\Security\Http\Firewall;
 
 class ContaoCoreExtensionTest extends TestCase
 {
-    /**
-     * @var ContainerBuilder
-     */
-    private $container;
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $this->container = new ContainerBuilder(
-            new ParameterBag([
-                'kernel.debug' => false,
-                'kernel.project_dir' => $this->getTempDir(),
-                'kernel.default_locale' => 'en',
-            ])
-        );
-
-        $params = [
-            'contao' => [
-                'encryption_key' => 'foobar',
-                'localconfig' => ['foo' => 'bar'],
-            ],
-        ];
-
-        $extension = new ContaoCoreExtension();
-        $extension->load($params, $this->container);
-    }
-
     public function testReturnsTheCorrectAlias(): void
     {
         $extension = new ContaoCoreExtension();
@@ -234,9 +206,11 @@ class ContaoCoreExtensionTest extends TestCase
      */
     public function testRegistersTheCommands(string $key, string $class, bool $public = false): void
     {
-        $this->assertTrue($this->container->has($key));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition($key);
+        $this->assertTrue($container->has($key));
+
+        $definition = $container->getDefinition($key);
 
         $this->assertSame($class, $definition->getClass());
         $this->assertTrue($definition->isAutoconfigured());
@@ -262,9 +236,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheBackendLocaleListener(): void
     {
-        $this->assertTrue($this->container->has('contao.listener.backend_locale'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.listener.backend_locale');
+        $this->assertTrue($container->has('contao.listener.backend_locale'));
+
+        $definition = $container->getDefinition('contao.listener.backend_locale');
 
         $this->assertSame(BackendLocaleListener::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -291,9 +267,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheBackendMenuListener(): void
     {
-        $this->assertTrue($this->container->has('contao.listener.menu.backend_menu'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.listener.menu.backend_menu');
+        $this->assertTrue($container->has('contao.listener.menu.backend_menu'));
+
+        $definition = $container->getDefinition('contao.listener.menu.backend_menu');
 
         $this->assertSame(BackendMenuListener::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -323,9 +301,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheBackendLogoutListener(): void
     {
-        $this->assertTrue($this->container->has('contao.listener.menu.backend_logout'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.listener.menu.backend_logout');
+        $this->assertTrue($container->has('contao.listener.menu.backend_logout'));
+
+        $definition = $container->getDefinition('contao.listener.menu.backend_logout');
 
         $this->assertSame(BackendLogoutListener::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -352,9 +332,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheBackendPreviewListener(): void
     {
-        $this->assertTrue($this->container->has('contao.listener.menu.backend_preview'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.listener.menu.backend_preview');
+        $this->assertTrue($container->has('contao.listener.menu.backend_preview'));
+
+        $definition = $container->getDefinition('contao.listener.menu.backend_preview');
 
         $this->assertSame(BackendPreviewListener::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -383,9 +365,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheBypassMaintenanceListener(): void
     {
-        $this->assertTrue($this->container->has('contao.listener.bypass_maintenance'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.listener.bypass_maintenance');
+        $this->assertTrue($container->has('contao.listener.bypass_maintenance'));
+
+        $definition = $container->getDefinition('contao.listener.bypass_maintenance');
 
         $this->assertSame(BypassMaintenanceListener::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -411,9 +395,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheClearSessionDataListener(): void
     {
-        $this->assertTrue($this->container->has('contao.listener.clear_session_data'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.listener.clear_session_data');
+        $this->assertTrue($container->has('contao.listener.clear_session_data'));
+
+        $definition = $container->getDefinition('contao.listener.clear_session_data');
 
         $this->assertSame(ClearSessionDataListener::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -432,9 +418,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheCommandSchedulerListener(): void
     {
-        $this->assertTrue($this->container->has('contao.listener.command_scheduler'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.listener.command_scheduler');
+        $this->assertTrue($container->has('contao.listener.command_scheduler'));
+
+        $definition = $container->getDefinition('contao.listener.command_scheduler');
 
         $this->assertSame(CommandSchedulerListener::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -461,9 +449,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheCsrfTokenCookieSubscriber(): void
     {
-        $this->assertTrue($this->container->has('contao.listener.csrf_token_cookie'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.listener.csrf_token_cookie');
+        $this->assertTrue($container->has('contao.listener.csrf_token_cookie'));
+
+        $definition = $container->getDefinition('contao.listener.csrf_token_cookie');
 
         $this->assertSame(CsrfTokenCookieSubscriber::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -496,9 +486,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheDisableAppConfiguredSettingsListener(): void
     {
-        $this->assertTrue($this->container->has(DisableAppConfiguredSettingsListener::class));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition(DisableAppConfiguredSettingsListener::class);
+        $this->assertTrue($container->has(DisableAppConfiguredSettingsListener::class));
+
+        $definition = $container->getDefinition(DisableAppConfiguredSettingsListener::class);
 
         $this->assertNull($definition->getClass());
         $this->assertTrue($definition->isPublic());
@@ -515,9 +507,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheDataContainerCallbackListener(): void
     {
-        $this->assertTrue($this->container->has('contao.listener.data_container_callback'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.listener.data_container_callback');
+        $this->assertTrue($container->has('contao.listener.data_container_callback'));
+
+        $definition = $container->getDefinition('contao.listener.data_container_callback');
 
         $this->assertSame(DataContainerCallbackListener::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -536,9 +530,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheDoctrineSchemaListener(): void
     {
-        $this->assertTrue($this->container->has('contao.listener.doctrine_schema'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.listener.doctrine_schema');
+        $this->assertTrue($container->has('contao.listener.doctrine_schema'));
+
+        $definition = $container->getDefinition('contao.listener.doctrine_schema');
 
         $this->assertSame(DoctrineSchemaListener::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -564,9 +560,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheExceptionConverterListener(): void
     {
-        $this->assertTrue($this->container->has('contao.listener.exception_converter'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.listener.exception_converter');
+        $this->assertTrue($container->has('contao.listener.exception_converter'));
+
+        $definition = $container->getDefinition('contao.listener.exception_converter');
 
         $this->assertSame(ExceptionConverterListener::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -585,9 +583,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheInitializeControllerListener(): void
     {
-        $this->assertTrue($this->container->has('contao.listener.initialize_controller'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.listener.initialize_controller');
+        $this->assertTrue($container->has('contao.listener.initialize_controller'));
+
+        $definition = $container->getDefinition('contao.listener.initialize_controller');
 
         $this->assertSame(InitializeControllerListener::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -606,9 +606,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheInsecureInstallationListener(): void
     {
-        $this->assertTrue($this->container->has('contao.listener.insecure_installation'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.listener.insecure_installation');
+        $this->assertTrue($container->has('contao.listener.insecure_installation'));
+
+        $definition = $container->getDefinition('contao.listener.insecure_installation');
 
         $this->assertSame(InsecureInstallationListener::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -625,9 +627,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheAssetInsertTagListener(): void
     {
-        $this->assertTrue($this->container->has('contao.listener.insert_tags.asset'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.listener.insert_tags.asset');
+        $this->assertTrue($container->has('contao.listener.insert_tags.asset'));
+
+        $definition = $container->getDefinition('contao.listener.insert_tags.asset');
 
         $this->assertSame(AssetListener::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -653,9 +657,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheTranslationInsertTagListener(): void
     {
-        $this->assertTrue($this->container->has('contao.listener.insert_tags.translation'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.listener.insert_tags.translation');
+        $this->assertTrue($container->has('contao.listener.insert_tags.translation'));
+
+        $definition = $container->getDefinition('contao.listener.insert_tags.translation');
 
         $this->assertSame(TranslationListener::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -681,9 +687,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheLocaleSubscriber(): void
     {
-        $this->assertTrue($this->container->has('contao.listener.locale'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.listener.locale');
+        $this->assertTrue($container->has('contao.listener.locale'));
+
+        $definition = $container->getDefinition('contao.listener.locale');
 
         $this->assertSame(LocaleSubscriber::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -719,9 +727,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheMakeResponsePrivateListener(): void
     {
-        $this->assertTrue($this->container->has('contao.listener.make_response_private'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.listener.make_response_private');
+        $this->assertTrue($container->has('contao.listener.make_response_private'));
+
+        $definition = $container->getDefinition('contao.listener.make_response_private');
 
         $this->assertSame(MakeResponsePrivateListener::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -746,7 +756,7 @@ class ContaoCoreExtensionTest extends TestCase
 
         $priority = $tags['kernel.event_listener'][0]['priority'] ?? 0;
 
-        $mergeHeadersListenerDefinition = $this->container->getDefinition('contao.listener.merge_http_headers');
+        $mergeHeadersListenerDefinition = $container->getDefinition('contao.listener.merge_http_headers');
         $mergeHeadersListenerTags = $mergeHeadersListenerDefinition->getTags();
         $mergeHeadersListenerPriority = $mergeHeadersListenerTags['kernel.event_listener'][0]['priority'] ?? 0;
 
@@ -756,9 +766,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheMergeHttpHeadersListener(): void
     {
-        $this->assertTrue($this->container->has('contao.listener.merge_http_headers'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.listener.merge_http_headers');
+        $this->assertTrue($container->has('contao.listener.merge_http_headers'));
+
+        $definition = $container->getDefinition('contao.listener.merge_http_headers');
 
         $this->assertSame(MergeHttpHeadersListener::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -789,9 +801,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersThePrettyErrorScreensListener(): void
     {
-        $this->assertTrue($this->container->has('contao.listener.pretty_error_screens'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.listener.pretty_error_screens');
+        $this->assertTrue($container->has('contao.listener.pretty_error_screens'));
+
+        $definition = $container->getDefinition('contao.listener.pretty_error_screens');
 
         $this->assertSame(PrettyErrorScreenListener::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -820,9 +834,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersThePreviewBarListener(): void
     {
-        $this->assertTrue($this->container->has('contao.listener.preview_bar'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.listener.preview_bar');
+        $this->assertTrue($container->has('contao.listener.preview_bar'));
+
+        $definition = $container->getDefinition('contao.listener.preview_bar');
 
         $this->assertSame(PreviewToolbarListener::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -840,9 +856,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersThePreviewUrlConvertListener(): void
     {
-        $this->assertTrue($this->container->has('contao.listener.preview_url_convert'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.listener.preview_url_convert');
+        $this->assertTrue($container->has('contao.listener.preview_url_convert'));
+
+        $definition = $container->getDefinition('contao.listener.preview_url_convert');
 
         $this->assertSame(PreviewUrlConvertListener::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -857,9 +875,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheBackendPreviewController(): void
     {
-        $this->assertTrue($this->container->has(BackendPreviewController::class));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition(BackendPreviewController::class);
+        $this->assertTrue($container->has(BackendPreviewController::class));
+
+        $definition = $container->getDefinition(BackendPreviewController::class);
 
         $this->assertTrue($definition->isPrivate());
 
@@ -876,9 +896,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheBackendPreviewSwitchController(): void
     {
-        $this->assertTrue($this->container->has(BackendPreviewSwitchController::class));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition(BackendPreviewSwitchController::class);
+        $this->assertTrue($container->has(BackendPreviewSwitchController::class));
+
+        $definition = $container->getDefinition(BackendPreviewSwitchController::class);
 
         $this->assertTrue($definition->isPrivate());
 
@@ -899,9 +921,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheRefererIdListener(): void
     {
-        $this->assertTrue($this->container->has('contao.listener.referer_id'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.listener.referer_id');
+        $this->assertTrue($container->has('contao.listener.referer_id'));
+
+        $definition = $container->getDefinition('contao.listener.referer_id');
 
         $this->assertSame(RefererIdListener::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -928,9 +952,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheRequestTokenListener(): void
     {
-        $this->assertTrue($this->container->has('contao.listener.request_token'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.listener.request_token');
+        $this->assertTrue($container->has('contao.listener.request_token'));
+
+        $definition = $container->getDefinition('contao.listener.request_token');
 
         $this->assertSame(RequestTokenListener::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -960,9 +986,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheResponseExceptionListener(): void
     {
-        $this->assertTrue($this->container->has('contao.listener.response_exception'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.listener.response_exception');
+        $this->assertTrue($container->has('contao.listener.response_exception'));
+
+        $definition = $container->getDefinition('contao.listener.response_exception');
 
         $this->assertSame(ResponseExceptionListener::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -981,9 +1009,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheRobotsTxtListener(): void
     {
-        $this->assertTrue($this->container->has('contao.listener.robots_txt'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.listener.robots_txt');
+        $this->assertTrue($container->has('contao.listener.robots_txt'));
+
+        $definition = $container->getDefinition('contao.listener.robots_txt');
 
         $this->assertSame(RobotsTxtListener::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -1007,9 +1037,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheSearchIndexListener(): void
     {
-        $this->assertTrue($this->container->has('contao.listener.search_index'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.listener.search_index');
+        $this->assertTrue($container->has('contao.listener.search_index'));
+
+        $definition = $container->getDefinition('contao.listener.search_index');
 
         $this->assertSame(SearchIndexListener::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -1035,9 +1067,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheStoreRefererListener(): void
     {
-        $this->assertTrue($this->container->has('contao.listener.store_referer'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.listener.store_referer');
+        $this->assertTrue($container->has('contao.listener.store_referer'));
+
+        $definition = $container->getDefinition('contao.listener.store_referer');
 
         $this->assertSame(StoreRefererListener::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -1062,9 +1096,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheSubrequestCacheSubscriber(): void
     {
-        $this->assertTrue($this->container->has('contao.listener.subrequest_cache'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.listener.subrequest_cache');
+        $this->assertTrue($container->has('contao.listener.subrequest_cache'));
+
+        $definition = $container->getDefinition('contao.listener.subrequest_cache');
 
         $this->assertSame(SubrequestCacheSubscriber::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -1095,9 +1131,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheSwitchUserListener(): void
     {
-        $this->assertTrue($this->container->has('contao.listener.switch_user'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.listener.switch_user');
+        $this->assertTrue($container->has('contao.listener.switch_user'));
+
+        $definition = $container->getDefinition('contao.listener.switch_user');
 
         $this->assertSame(SwitchUserListener::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -1122,9 +1160,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheTwoFactorFrontendListener(): void
     {
-        $this->assertTrue($this->container->has('contao.listener.two_factor.frontend'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.listener.two_factor.frontend');
+        $this->assertTrue($container->has('contao.listener.two_factor.frontend'));
+
+        $definition = $container->getDefinition('contao.listener.two_factor.frontend');
 
         $this->assertSame(TwoFactorFrontendListener::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -1151,9 +1191,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheUserSessionListener(): void
     {
-        $this->assertTrue($this->container->has('contao.listener.user_session'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.listener.user_session');
+        $this->assertTrue($container->has('contao.listener.user_session'));
+
+        $definition = $container->getDefinition('contao.listener.user_session');
 
         $this->assertSame(EventUserSessionListener::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -1180,9 +1222,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheAssetPluginContext(): void
     {
-        $this->assertTrue($this->container->has('contao.assets.assets_context'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.assets.assets_context');
+        $this->assertTrue($container->has('contao.assets.assets_context'));
+
+        $definition = $container->getDefinition('contao.assets.assets_context');
 
         $this->assertSame(ContaoContext::class, $definition->getClass());
         $this->assertTrue($definition->isPublic());
@@ -1199,9 +1243,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheAssetFilesContext(): void
     {
-        $this->assertTrue($this->container->has('contao.assets.files_context'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.assets.files_context');
+        $this->assertTrue($container->has('contao.assets.files_context'));
+
+        $definition = $container->getDefinition('contao.assets.files_context');
 
         $this->assertSame(ContaoContext::class, $definition->getClass());
         $this->assertTrue($definition->isPublic());
@@ -1218,9 +1264,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheContaoCacheClearer(): void
     {
-        $this->assertTrue($this->container->has('contao.cache.clear_internal'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.cache.clear_internal');
+        $this->assertTrue($container->has('contao.cache.clear_internal'));
+
+        $definition = $container->getDefinition('contao.cache.clear_internal');
 
         $this->assertSame(ContaoCacheClearer::class, $definition->getClass());
         $this->assertTrue($definition->isPublic());
@@ -1235,9 +1283,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheContaoCacheWarmer(): void
     {
-        $this->assertTrue($this->container->has('contao.cache.warm_internal'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.cache.warm_internal');
+        $this->assertTrue($container->has('contao.cache.warm_internal'));
+
+        $definition = $container->getDefinition('contao.cache.warm_internal');
 
         $this->assertSame(ContaoCacheWarmer::class, $definition->getClass());
         $this->assertTrue($definition->isPublic());
@@ -1258,18 +1308,22 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheBackendController(): void
     {
-        $this->assertTrue($this->container->has(BackendController::class));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition(BackendController::class);
+        $this->assertTrue($container->has(BackendController::class));
+
+        $definition = $container->getDefinition(BackendController::class);
 
         $this->assertTrue($definition->isPrivate());
     }
 
     public function testRegistersTheBackendCsvImportController(): void
     {
-        $this->assertTrue($this->container->has(BackendCsvImportController::class));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition(BackendCsvImportController::class);
+        $this->assertTrue($container->has(BackendCsvImportController::class));
+
+        $definition = $container->getDefinition(BackendCsvImportController::class);
 
         $this->assertTrue($definition->isPublic());
 
@@ -1287,9 +1341,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheFaviconController(): void
     {
-        $this->assertTrue($this->container->has(FaviconController::class));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition(FaviconController::class);
+        $this->assertTrue($container->has(FaviconController::class));
+
+        $definition = $container->getDefinition(FaviconController::class);
 
         $this->assertTrue($definition->isPrivate());
 
@@ -1313,9 +1369,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheFrontendController(): void
     {
-        $this->assertTrue($this->container->has(FrontendController::class));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition(FrontendController::class);
+        $this->assertTrue($container->has(FrontendController::class));
+
+        $definition = $container->getDefinition(FrontendController::class);
 
         $this->assertTrue($definition->isPrivate());
 
@@ -1334,9 +1392,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheFrontendModuleTwoFactorController(): void
     {
-        $this->assertTrue($this->container->has(TwoFactorController::class));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition(TwoFactorController::class);
+        $this->assertTrue($container->has(TwoFactorController::class));
+
+        $definition = $container->getDefinition(TwoFactorController::class);
 
         $this->assertTrue($definition->isPrivate());
 
@@ -1354,9 +1414,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function tesRegistersTheImagesController(): void
     {
-        $this->assertTrue($this->container->has(ImagesController::class));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition(ImagesController::class);
+        $this->assertTrue($container->has(ImagesController::class));
+
+        $definition = $container->getDefinition(ImagesController::class);
 
         $this->assertTrue($definition->isPublic());
 
@@ -1373,9 +1435,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function tesRegistersTheInsertTagsController(): void
     {
-        $this->assertTrue($this->container->has(InsertTagsController::class));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition(InsertTagsController::class);
+        $this->assertTrue($container->has(InsertTagsController::class));
+
+        $definition = $container->getDefinition(InsertTagsController::class);
 
         $this->assertTrue($definition->isPublic());
 
@@ -1389,9 +1453,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheRobotsTxtController(): void
     {
-        $this->assertTrue($this->container->has(RobotsTxtController::class));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition(RobotsTxtController::class);
+        $this->assertTrue($container->has(RobotsTxtController::class));
+
+        $definition = $container->getDefinition(RobotsTxtController::class);
 
         $this->assertTrue($definition->isPrivate());
 
@@ -1415,9 +1481,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheControllerResolver(): void
     {
-        $this->assertTrue($this->container->has('contao.controller_resolver'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.controller_resolver');
+        $this->assertTrue($container->has('contao.controller_resolver'));
+
+        $definition = $container->getDefinition('contao.controller_resolver');
 
         $this->assertSame(ControllerResolver::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -1433,9 +1501,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheCorsWebsiteRootsConfigProvider(): void
     {
-        $this->assertTrue($this->container->has('contao.cors.website_roots_config_provider'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.cors.website_roots_config_provider');
+        $this->assertTrue($container->has('contao.cors.website_roots_config_provider'));
+
+        $definition = $container->getDefinition('contao.cors.website_roots_config_provider');
 
         $this->assertSame(WebsiteRootsConfigProvider::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -1459,9 +1529,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheEscargotFactory(): void
     {
-        $this->assertTrue($this->container->has('contao.crawl.escargot_factory'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.crawl.escargot_factory');
+        $this->assertTrue($container->has('contao.crawl.escargot_factory'));
+
+        $definition = $container->getDefinition('contao.crawl.escargot_factory');
 
         $this->assertSame(Factory::class, $definition->getClass());
         $this->assertTrue($definition->isPublic());
@@ -1479,9 +1551,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheEscargotBrokenLinkCheckerSubscriber(): void
     {
-        $this->assertTrue($this->container->has('contao.crawl.escargot_subscriber.broken_link_checker'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.crawl.escargot_subscriber.broken_link_checker');
+        $this->assertTrue($container->has('contao.crawl.escargot_subscriber.broken_link_checker'));
+
+        $definition = $container->getDefinition('contao.crawl.escargot_subscriber.broken_link_checker');
 
         $this->assertSame(BrokenLinkCheckerSubscriber::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -1503,9 +1577,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheEscargotSearchIndexSubscriber(): void
     {
-        $this->assertTrue($this->container->has('contao.crawl.escargot_subscriber.search_index'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.crawl.escargot_subscriber.search_index');
+        $this->assertTrue($container->has('contao.crawl.escargot_subscriber.search_index'));
+
+        $definition = $container->getDefinition('contao.crawl.escargot_subscriber.search_index');
 
         $this->assertSame(SearchIndexSubscriber::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -1530,9 +1606,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheCronService(): void
     {
-        $this->assertTrue($this->container->has(Cron::class));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition(Cron::class);
+        $this->assertTrue($container->has(Cron::class));
+
+        $definition = $container->getDefinition(Cron::class);
 
         $this->assertTrue($definition->isPublic());
 
@@ -1548,9 +1626,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheLegacyCronService(): void
     {
-        $this->assertTrue($this->container->has(LegacyCron::class));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition(LegacyCron::class);
+        $this->assertTrue($container->has(LegacyCron::class));
+
+        $definition = $container->getDefinition(LegacyCron::class);
 
         $this->assertTrue($definition->isPublic());
 
@@ -1564,9 +1644,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheCsrfTokenManager(): void
     {
-        $this->assertTrue($this->container->has('contao.csrf.token_manager'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.csrf.token_manager');
+        $this->assertTrue($container->has('contao.csrf.token_manager'));
+
+        $definition = $container->getDefinition('contao.csrf.token_manager');
 
         $this->assertSame(CsrfTokenManager::class, $definition->getClass());
         $this->assertTrue($definition->isPublic());
@@ -1582,9 +1664,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheCsrfTokenStorage(): void
     {
-        $this->assertTrue($this->container->has('contao.csrf.token_storage'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.csrf.token_storage');
+        $this->assertTrue($container->has('contao.csrf.token_storage'));
+
+        $definition = $container->getDefinition('contao.csrf.token_storage');
 
         $this->assertSame(MemoryTokenStorage::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -1603,9 +1687,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheDataCollector(): void
     {
-        $this->assertTrue($this->container->has('contao.data_collector'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.data_collector');
+        $this->assertTrue($container->has('contao.data_collector'));
+
+        $definition = $container->getDefinition('contao.data_collector');
 
         $this->assertSame(ContaoDataCollector::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -1625,9 +1711,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheDoctrineSchemaProvider(): void
     {
-        $this->assertTrue($this->container->has('contao.doctrine.schema_provider'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.doctrine.schema_provider');
+        $this->assertTrue($container->has('contao.doctrine.schema_provider'));
+
+        $definition = $container->getDefinition('contao.doctrine.schema_provider');
 
         $this->assertSame(DcaSchemaProvider::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -1643,9 +1731,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheFragmentHandler(): void
     {
-        $this->assertTrue($this->container->has('contao.fragment.handler'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.fragment.handler');
+        $this->assertTrue($container->has('contao.fragment.handler'));
+
+        $definition = $container->getDefinition('contao.fragment.handler');
 
         $this->assertSame(FragmentHandler::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -1666,9 +1756,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheFragmentPreHandlers(): void
     {
-        $this->assertTrue($this->container->has('contao.fragment.pre_handlers'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.fragment.pre_handlers');
+        $this->assertTrue($container->has('contao.fragment.pre_handlers'));
+
+        $definition = $container->getDefinition('contao.fragment.pre_handlers');
 
         $this->assertSame(ServiceLocator::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -1683,9 +1775,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheFragmentRegistry(): void
     {
-        $this->assertTrue($this->container->has('contao.fragment.registry'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.fragment.registry');
+        $this->assertTrue($container->has('contao.fragment.registry'));
+
+        $definition = $container->getDefinition('contao.fragment.registry');
 
         $this->assertSame(FragmentRegistry::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -1693,9 +1787,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheFragmentRendererForward(): void
     {
-        $this->assertTrue($this->container->has('contao.fragment.renderer.forward'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.fragment.renderer.forward');
+        $this->assertTrue($container->has('contao.fragment.renderer.forward'));
+
+        $definition = $container->getDefinition('contao.fragment.renderer.forward');
 
         $this->assertSame(ForwardFragmentRenderer::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -1732,9 +1828,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheContaoFramework(): void
     {
-        $this->assertTrue($this->container->has('contao.framework'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.framework');
+        $this->assertTrue($container->has('contao.framework'));
+
+        $definition = $container->getDefinition('contao.framework');
 
         $this->assertSame(ContaoFramework::class, $definition->getClass());
         $this->assertTrue($definition->isPublic());
@@ -1765,9 +1863,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheDeferredImageStorage(): void
     {
-        $this->assertTrue($this->container->has('contao.image.deferred_image_storage'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->findDefinition('contao.image.deferred_image_storage');
+        $this->assertTrue($container->has('contao.image.deferred_image_storage'));
+
+        $definition = $container->findDefinition('contao.image.deferred_image_storage');
 
         $this->assertTrue($definition->isPrivate());
 
@@ -1782,18 +1882,22 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheImageImagineService(): void
     {
-        $this->assertTrue($this->container->has('contao.image.imagine'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->findDefinition('contao.image.imagine');
+        $this->assertTrue($container->has('contao.image.imagine'));
+
+        $definition = $container->findDefinition('contao.image.imagine');
 
         $this->assertTrue($definition->isPublic());
     }
 
     public function testRegistersTheImageImagineSvgService(): void
     {
-        $this->assertTrue($this->container->has('contao.image.imagine_svg'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.image.imagine_svg');
+        $this->assertTrue($container->has('contao.image.imagine_svg'));
+
+        $definition = $container->getDefinition('contao.image.imagine_svg');
 
         $this->assertSame(ImagineSvg::class, $definition->getClass());
         $this->assertTrue($definition->isPublic());
@@ -1801,9 +1905,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheImageResizeCalculator(): void
     {
-        $this->assertTrue($this->container->has('contao.image.resize_calculator'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.image.resize_calculator');
+        $this->assertTrue($container->has('contao.image.resize_calculator'));
+
+        $definition = $container->getDefinition('contao.image.resize_calculator');
 
         $this->assertSame(ResizeCalculator::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -1811,9 +1917,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheImageResizer(): void
     {
-        $this->assertTrue($this->container->has('contao.image.resizer'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.image.resizer');
+        $this->assertTrue($container->has('contao.image.resizer'));
+
+        $definition = $container->getDefinition('contao.image.resizer');
 
         $this->assertSame(LegacyResizer::class, $definition->getClass());
         $this->assertTrue($definition->isPublic());
@@ -1831,9 +1939,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheImageFactory(): void
     {
-        $this->assertTrue($this->container->has('contao.image.image_factory'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.image.image_factory');
+        $this->assertTrue($container->has('contao.image.image_factory'));
+
+        $definition = $container->getDefinition('contao.image.image_factory');
 
         $this->assertSame(ImageFactory::class, $definition->getClass());
         $this->assertTrue($definition->isPublic());
@@ -1857,9 +1967,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheImageSizesService(): void
     {
-        $this->assertTrue($this->container->has('contao.image.image_sizes'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.image.image_sizes');
+        $this->assertTrue($container->has('contao.image.image_sizes'));
+
+        $definition = $container->getDefinition('contao.image.image_sizes');
 
         $this->assertSame(ImageSizes::class, $definition->getClass());
         $this->assertTrue($definition->isPublic());
@@ -1888,9 +2000,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheImagePictureFactory(): void
     {
-        $this->assertTrue($this->container->has('contao.image.picture_factory'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.image.picture_factory');
+        $this->assertTrue($container->has('contao.image.picture_factory'));
+
+        $definition = $container->getDefinition('contao.image.picture_factory');
 
         $this->assertSame(PictureFactory::class, $definition->getClass());
         $this->assertTrue($definition->isPublic());
@@ -1909,9 +2023,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheImagePictureGenerator(): void
     {
-        $this->assertTrue($this->container->has('contao.image.picture_generator'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.image.picture_generator');
+        $this->assertTrue($container->has('contao.image.picture_generator'));
+
+        $definition = $container->getDefinition('contao.image.picture_generator');
 
         $this->assertSame(PictureGenerator::class, $definition->getClass());
         $this->assertTrue($definition->isPublic());
@@ -1927,9 +2043,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheBackendMenuBuilder(): void
     {
-        $this->assertTrue($this->container->has('contao.menu.backend_menu_builder'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.menu.backend_menu_builder');
+        $this->assertTrue($container->has('contao.menu.backend_menu_builder'));
+
+        $definition = $container->getDefinition('contao.menu.backend_menu_builder');
 
         $this->assertSame(BackendMenuBuilder::class, $definition->getClass());
         $this->assertTrue($definition->isPublic());
@@ -1945,9 +2063,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheMenuMatcher(): void
     {
-        $this->assertTrue($this->container->has('contao.menu.matcher'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.menu.matcher');
+        $this->assertTrue($container->has('contao.menu.matcher'));
+
+        $definition = $container->getDefinition('contao.menu.matcher');
 
         $this->assertSame(Matcher::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -1955,9 +2075,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheMenuRenderer(): void
     {
-        $this->assertTrue($this->container->has('contao.menu.renderer'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.menu.renderer');
+        $this->assertTrue($container->has('contao.menu.renderer'));
+
+        $definition = $container->getDefinition('contao.menu.renderer');
 
         $this->assertSame(ListRenderer::class, $definition->getClass());
         $this->assertTrue($definition->isPublic());
@@ -1972,9 +2094,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheModelArgumentResolver(): void
     {
-        $this->assertTrue($this->container->has('contao.model_argument_resolver'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.model_argument_resolver');
+        $this->assertTrue($container->has('contao.model_argument_resolver'));
+
+        $definition = $container->getDefinition('contao.model_argument_resolver');
 
         $this->assertSame(ModelArgumentResolver::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -2001,9 +2125,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheMonologHandler(): void
     {
-        $this->assertTrue($this->container->has('contao.monolog.handler'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.monolog.handler');
+        $this->assertTrue($container->has('contao.monolog.handler'));
+
+        $definition = $container->getDefinition('contao.monolog.handler');
 
         $this->assertSame(ContaoTableHandler::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -2030,9 +2156,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheMonologProcessor(): void
     {
-        $this->assertTrue($this->container->has('contao.monolog.processor'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.monolog.processor');
+        $this->assertTrue($container->has('contao.monolog.processor'));
+
+        $definition = $container->getDefinition('contao.monolog.processor');
 
         $this->assertSame(ContaoTableProcessor::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -2049,9 +2177,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheOptInService(): void
     {
-        $this->assertTrue($this->container->has('contao.opt-in'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.opt-in');
+        $this->assertTrue($container->has('contao.opt-in'));
+
+        $definition = $container->getDefinition('contao.opt-in');
 
         $this->assertSame(OptIn::class, $definition->getClass());
         $this->assertTrue($definition->isPublic());
@@ -2066,9 +2196,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheArticlePickerProvider(): void
     {
-        $this->assertTrue($this->container->has('contao.picker.article_provider'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.picker.article_provider');
+        $this->assertTrue($container->has('contao.picker.article_provider'));
+
+        $definition = $container->getDefinition('contao.picker.article_provider');
 
         $this->assertSame(ArticlePickerProvider::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -2086,9 +2218,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersThePickerBuilder(): void
     {
-        $this->assertTrue($this->container->has('contao.picker.builder'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.picker.builder');
+        $this->assertTrue($container->has('contao.picker.builder'));
+
+        $definition = $container->getDefinition('contao.picker.builder');
 
         $this->assertSame(PickerBuilder::class, $definition->getClass());
         $this->assertTrue($definition->isPublic());
@@ -2104,9 +2238,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheFilePickerProvider(): void
     {
-        $this->assertTrue($this->container->has('contao.picker.file_provider'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.picker.file_provider');
+        $this->assertTrue($container->has('contao.picker.file_provider'));
+
+        $definition = $container->getDefinition('contao.picker.file_provider');
 
         $this->assertSame(FilePickerProvider::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -2136,9 +2272,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersThePagePickerProvider(): void
     {
-        $this->assertTrue($this->container->has('contao.picker.page_provider'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.picker.page_provider');
+        $this->assertTrue($container->has('contao.picker.page_provider'));
+
+        $definition = $container->getDefinition('contao.picker.page_provider');
 
         $this->assertSame(PagePickerProvider::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -2167,9 +2305,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheTablePickerProvider(): void
     {
-        $this->assertTrue($this->container->has('contao.picker.table_provider'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.picker.table_provider');
+        $this->assertTrue($container->has('contao.picker.table_provider'));
+
+        $definition = $container->getDefinition('contao.picker.table_provider');
 
         $this->assertSame(TablePickerProvider::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -2197,9 +2337,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheCronJobRepository(): void
     {
-        $this->assertTrue($this->container->has(CronJobRepository::class));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition(CronJobRepository::class);
+        $this->assertTrue($container->has(CronJobRepository::class));
+
+        $definition = $container->getDefinition(CronJobRepository::class);
 
         $this->assertTrue($definition->isPrivate());
 
@@ -2213,9 +2355,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheRememberMeRepository(): void
     {
-        $this->assertTrue($this->container->has('contao.repository.remember_me'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.repository.remember_me');
+        $this->assertTrue($container->has('contao.repository.remember_me'));
+
+        $definition = $container->getDefinition('contao.repository.remember_me');
 
         $this->assertSame(RememberMeRepository::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -2230,9 +2374,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheResourceFinder(): void
     {
-        $this->assertTrue($this->container->has('contao.resource_finder'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.resource_finder');
+        $this->assertTrue($container->has('contao.resource_finder'));
+
+        $definition = $container->getDefinition('contao.resource_finder');
 
         $this->assertSame(ResourceFinder::class, $definition->getClass());
         $this->assertTrue($definition->isPublic());
@@ -2247,9 +2393,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheResourceLocator(): void
     {
-        $this->assertTrue($this->container->has('contao.resource_locator'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.resource_locator');
+        $this->assertTrue($container->has('contao.resource_locator'));
+
+        $definition = $container->getDefinition('contao.resource_locator');
 
         $this->assertSame(FileLocator::class, $definition->getClass());
         $this->assertTrue($definition->isPublic());
@@ -2264,9 +2412,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheRoutingBackendMatcher(): void
     {
-        $this->assertTrue($this->container->has('contao.routing.backend_matcher'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.routing.backend_matcher');
+        $this->assertTrue($container->has('contao.routing.backend_matcher'));
+
+        $definition = $container->getDefinition('contao.routing.backend_matcher');
 
         $this->assertSame(RequestMatcher::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -2284,9 +2434,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheRoutingDomainFilter(): void
     {
-        $this->assertTrue($this->container->has('contao.routing.domain_filter'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.routing.domain_filter');
+        $this->assertTrue($container->has('contao.routing.domain_filter'));
+
+        $definition = $container->getDefinition('contao.routing.domain_filter');
 
         $this->assertSame(DomainFilter::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -2294,9 +2446,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheRoutingFinalMatcher(): void
     {
-        $this->assertTrue($this->container->has('contao.routing.final_matcher'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.routing.final_matcher');
+        $this->assertTrue($container->has('contao.routing.final_matcher'));
+
+        $definition = $container->getDefinition('contao.routing.final_matcher');
 
         $this->assertSame(UrlMatcher::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -2304,9 +2458,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheRoutingFrontendLoader(): void
     {
-        $this->assertTrue($this->container->has('contao.routing.frontend_loader'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.routing.frontend_loader');
+        $this->assertTrue($container->has('contao.routing.frontend_loader'));
+
+        $definition = $container->getDefinition('contao.routing.frontend_loader');
 
         $this->assertSame(FrontendLoader::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -2331,9 +2487,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheRoutingFrontendMatcher(): void
     {
-        $this->assertTrue($this->container->has('contao.routing.frontend_matcher'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.routing.frontend_matcher');
+        $this->assertTrue($container->has('contao.routing.frontend_matcher'));
+
+        $definition = $container->getDefinition('contao.routing.frontend_matcher');
 
         $this->assertSame(RequestMatcher::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -2351,9 +2509,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheRoutingImagesLoader(): void
     {
-        $this->assertTrue($this->container->has('contao.routing.images_loader'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.routing.images_loader');
+        $this->assertTrue($container->has('contao.routing.images_loader'));
+
+        $definition = $container->getDefinition('contao.routing.images_loader');
 
         $this->assertSame(ImagesLoader::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -2379,9 +2539,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheRoutingInputEnhancer(): void
     {
-        $this->assertTrue($this->container->has('contao.routing.input_enhancer'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.routing.input_enhancer');
+        $this->assertTrue($container->has('contao.routing.input_enhancer'));
+
+        $definition = $container->getDefinition('contao.routing.input_enhancer');
 
         $this->assertSame(InputEnhancer::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -2397,9 +2559,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheRoutingLanguageFilter(): void
     {
-        $this->assertTrue($this->container->has('contao.routing.language_filter'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.routing.language_filter');
+        $this->assertTrue($container->has('contao.routing.language_filter'));
+
+        $definition = $container->getDefinition('contao.routing.language_filter');
 
         $this->assertSame(LanguageFilter::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -2414,9 +2578,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheRoutingLegacyMatcher(): void
     {
-        $this->assertTrue($this->container->has('contao.routing.legacy_matcher'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.routing.legacy_matcher');
+        $this->assertTrue($container->has('contao.routing.legacy_matcher'));
+
+        $definition = $container->getDefinition('contao.routing.legacy_matcher');
 
         $this->assertSame(LegacyMatcher::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -2435,9 +2601,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheRoutingLegacyRouteProvider(): void
     {
-        $this->assertTrue($this->container->has('contao.routing.legacy_route_provider'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.routing.legacy_route_provider');
+        $this->assertTrue($container->has('contao.routing.legacy_route_provider'));
+
+        $definition = $container->getDefinition('contao.routing.legacy_route_provider');
 
         $this->assertSame(LegacyRouteProvider::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -2453,9 +2621,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheRoutingNestedMatcher(): void
     {
-        $this->assertTrue($this->container->has('contao.routing.nested_matcher'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.routing.nested_matcher');
+        $this->assertTrue($container->has('contao.routing.nested_matcher'));
+
+        $definition = $container->getDefinition('contao.routing.nested_matcher');
 
         $this->assertSame(NestedMatcher::class, $definition->getClass());
         $this->assertTrue($definition->isPublic());
@@ -2489,9 +2659,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheRoutingNested404Matcher(): void
     {
-        $this->assertTrue($this->container->has('contao.routing.nested_404_matcher'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.routing.nested_404_matcher');
+        $this->assertTrue($container->has('contao.routing.nested_404_matcher'));
+
+        $definition = $container->getDefinition('contao.routing.nested_404_matcher');
 
         $this->assertSame(NestedMatcher::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -2507,9 +2679,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheRoutingPageRouter(): void
     {
-        $this->assertTrue($this->container->has('contao.routing.page_router'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.routing.page_router');
+        $this->assertTrue($container->has('contao.routing.page_router'));
+
+        $definition = $container->getDefinition('contao.routing.page_router');
 
         $this->assertSame(DynamicRouter::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -2550,9 +2724,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheRoutingPage404Router(): void
     {
-        $this->assertTrue($this->container->has('contao.routing.page_404_router'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.routing.page_404_router');
+        $this->assertTrue($container->has('contao.routing.page_404_router'));
+
+        $definition = $container->getDefinition('contao.routing.page_404_router');
 
         $this->assertSame(DynamicRouter::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -2572,9 +2748,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheRoutingPublishedFilter(): void
     {
-        $this->assertTrue($this->container->has('contao.routing.published_filter'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.routing.published_filter');
+        $this->assertTrue($container->has('contao.routing.published_filter'));
+
+        $definition = $container->getDefinition('contao.routing.published_filter');
 
         $this->assertSame(PublishedFilter::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -2589,9 +2767,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheRoutingRouteGenerator(): void
     {
-        $this->assertTrue($this->container->has('contao.routing.route_generator'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.routing.route_generator');
+        $this->assertTrue($container->has('contao.routing.route_generator'));
+
+        $definition = $container->getDefinition('contao.routing.route_generator');
 
         $this->assertSame(ProviderBasedGenerator::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -2607,9 +2787,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheRoutingRouteProvider(): void
     {
-        $this->assertTrue($this->container->has('contao.routing.route_provider'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.routing.route_provider');
+        $this->assertTrue($container->has('contao.routing.route_provider'));
+
+        $definition = $container->getDefinition('contao.routing.route_provider');
 
         $this->assertSame(RouteProvider::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -2627,9 +2809,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheRoutingRoute404Provider(): void
     {
-        $this->assertTrue($this->container->has('contao.routing.route_404_provider'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.routing.route_404_provider');
+        $this->assertTrue($container->has('contao.routing.route_404_provider'));
+
+        $definition = $container->getDefinition('contao.routing.route_404_provider');
 
         $this->assertSame(Route404Provider::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -2645,9 +2829,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheRoutingScopeMatcher(): void
     {
-        $this->assertTrue($this->container->has('contao.routing.scope_matcher'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.routing.scope_matcher');
+        $this->assertTrue($container->has('contao.routing.scope_matcher'));
+
+        $definition = $container->getDefinition('contao.routing.scope_matcher');
 
         $this->assertSame(ScopeMatcher::class, $definition->getClass());
         $this->assertTrue($definition->isPublic());
@@ -2663,9 +2849,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheRoutingUrlGenerator(): void
     {
-        $this->assertTrue($this->container->has('contao.routing.url_generator'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.routing.url_generator');
+        $this->assertTrue($container->has('contao.routing.url_generator'));
+
+        $definition = $container->getDefinition('contao.routing.url_generator');
 
         $this->assertSame(UrlGenerator::class, $definition->getClass());
         $this->assertTrue($definition->isPublic());
@@ -2682,9 +2870,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheSecurityAuthenticationFailureHandler(): void
     {
-        $this->assertTrue($this->container->has('contao.security.authentication_failure_handler'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.security.authentication_failure_handler');
+        $this->assertTrue($container->has('contao.security.authentication_failure_handler'));
+
+        $definition = $container->getDefinition('contao.security.authentication_failure_handler');
 
         $this->assertSame(AuthenticationFailureHandler::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -2699,9 +2889,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheSecurityAuthenticationListener(): void
     {
-        $this->assertTrue($this->container->has('contao.security.authentication_listener'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.security.authentication_listener');
+        $this->assertTrue($container->has('contao.security.authentication_listener'));
+
+        $definition = $container->getDefinition('contao.security.authentication_listener');
 
         $this->assertSame(ContaoLoginAuthenticationListener::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -2737,9 +2929,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheSecurityAuthenticationProvider(): void
     {
-        $this->assertTrue($this->container->has('contao.security.authentication_provider'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.security.authentication_provider');
+        $this->assertTrue($container->has('contao.security.authentication_provider'));
+
+        $definition = $container->getDefinition('contao.security.authentication_provider');
 
         $this->assertSame(AuthenticationProvider::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -2763,9 +2957,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheSecurityAuthenticationSuccessHandler(): void
     {
-        $this->assertTrue($this->container->has('contao.security.authentication_success_handler'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.security.authentication_success_handler');
+        $this->assertTrue($container->has('contao.security.authentication_success_handler'));
+
+        $definition = $container->getDefinition('contao.security.authentication_success_handler');
 
         $this->assertSame(AuthenticationSuccessHandler::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -2783,9 +2979,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheSecurityBackendAccessVoter(): void
     {
-        $this->assertTrue($this->container->has('contao.security.backend_access_voter'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.security.backend_access_voter');
+        $this->assertTrue($container->has('contao.security.backend_access_voter'));
+
+        $definition = $container->getDefinition('contao.security.backend_access_voter');
 
         $this->assertSame(BackendAccessVoter::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -2793,9 +2991,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheSecurityBackendUserProvider(): void
     {
-        $this->assertTrue($this->container->has('contao.security.backend_user_provider'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.security.backend_user_provider');
+        $this->assertTrue($container->has('contao.security.backend_user_provider'));
+
+        $definition = $container->getDefinition('contao.security.backend_user_provider');
 
         $this->assertSame(ContaoUserProvider::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -2813,9 +3013,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheSecurityEntryPoint(): void
     {
-        $this->assertTrue($this->container->has('contao.security.entry_point'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.security.entry_point');
+        $this->assertTrue($container->has('contao.security.entry_point'));
+
+        $definition = $container->getDefinition('contao.security.entry_point');
 
         $this->assertSame(AuthenticationEntryPoint::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -2833,9 +3035,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheSecurityExpiringTokenBasedRemembermeServices(): void
     {
-        $this->assertTrue($this->container->has('contao.security.expiring_token_based_remember_me_services'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.security.expiring_token_based_remember_me_services');
+        $this->assertTrue($container->has('contao.security.expiring_token_based_remember_me_services'));
+
+        $definition = $container->getDefinition('contao.security.expiring_token_based_remember_me_services');
 
         $this->assertSame(ExpiringTokenBasedRememberMeServices::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -2866,9 +3070,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheSecurityFrontendPreviewAuthenticator(): void
     {
-        $this->assertTrue($this->container->has('contao.security.frontend_preview_authenticator'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.security.frontend_preview_authenticator');
+        $this->assertTrue($container->has('contao.security.frontend_preview_authenticator'));
+
+        $definition = $container->getDefinition('contao.security.frontend_preview_authenticator');
 
         $this->assertSame(FrontendPreviewAuthenticator::class, $definition->getClass());
         $this->assertFalse($definition->isPrivate());
@@ -2886,9 +3092,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheSecurityFrontendUserProvider(): void
     {
-        $this->assertTrue($this->container->has('contao.security.frontend_user_provider'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.security.frontend_user_provider');
+        $this->assertTrue($container->has('contao.security.frontend_user_provider'));
+
+        $definition = $container->getDefinition('contao.security.frontend_user_provider');
 
         $this->assertSame(ContaoUserProvider::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -2906,9 +3114,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheSecurityLogoutHandler(): void
     {
-        $this->assertTrue($this->container->has('contao.security.logout_handler'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.security.logout_handler');
+        $this->assertTrue($container->has('contao.security.logout_handler'));
+
+        $definition = $container->getDefinition('contao.security.logout_handler');
 
         $this->assertSame(LogoutHandler::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -2924,9 +3134,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheSecurityLogoutSuccessHandler(): void
     {
-        $this->assertTrue($this->container->has('contao.security.logout_success_handler'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.security.logout_success_handler');
+        $this->assertTrue($container->has('contao.security.logout_success_handler'));
+
+        $definition = $container->getDefinition('contao.security.logout_success_handler');
 
         $this->assertSame(LogoutSuccessHandler::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -2942,9 +3154,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheSecurityTokenCheckerWithSimpleRoleVoter(): void
     {
-        $this->assertTrue($this->container->has('contao.security.token_checker'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.security.token_checker');
+        $this->assertTrue($container->has('contao.security.token_checker'));
+
+        $definition = $container->getDefinition('contao.security.token_checker');
 
         $this->assertSame(TokenChecker::class, $definition->getClass());
         $this->assertTrue($definition->isPublic());
@@ -2965,19 +3179,21 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheSecurityTokenCheckerWithRoleHierarchyVoter(): void
     {
+        $container = $this->getContainerBuilder();
+
         // Populate security configuration
-        $this->container->setParameter('security.role_hierarchy.roles', [
+        $container->setParameter('security.role_hierarchy.roles', [
             'ROLE_ADMIN' => ['ROLE_USER'],
             'ROLE_SUPER_ADMIN' => ['ROLE_ADMIN', 'ROLE_ALLOWED_TO_SWITCH'],
         ]);
 
         // Reload container
         $extension = new ContaoCoreExtension();
-        $extension->load([], $this->container);
+        $extension->load([], $container);
 
-        $this->assertTrue($this->container->has('contao.security.token_checker'));
+        $this->assertTrue($container->has('contao.security.token_checker'));
 
-        $definition = $this->container->getDefinition('contao.security.token_checker');
+        $definition = $container->getDefinition('contao.security.token_checker');
 
         $this->assertSame(TokenChecker::class, $definition->getClass());
         $this->assertTrue($definition->isPublic());
@@ -2998,9 +3214,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheSecurityTwoFactorAuthenticator(): void
     {
-        $this->assertTrue($this->container->has('contao.security.two_factor.authenticator'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.security.two_factor.authenticator');
+        $this->assertTrue($container->has('contao.security.two_factor.authenticator'));
+
+        $definition = $container->getDefinition('contao.security.two_factor.authenticator');
 
         $this->assertSame(Authenticator::class, $definition->getClass());
         $this->assertTrue($definition->isPublic());
@@ -3008,18 +3226,22 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheSecurityTwoFactorBackupCodeManager(): void
     {
-        $this->assertTrue($this->container->has(BackupCodeManager::class));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition(BackupCodeManager::class);
+        $this->assertTrue($container->has(BackupCodeManager::class));
+
+        $definition = $container->getDefinition(BackupCodeManager::class);
 
         $this->assertTrue($definition->isPublic());
     }
 
     public function testRegistersTheSecurityTwoFactorProvider(): void
     {
-        $this->assertTrue($this->container->has('contao.security.two_factor.provider'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.security.two_factor.provider');
+        $this->assertTrue($container->has('contao.security.two_factor.provider'));
+
+        $definition = $container->getDefinition('contao.security.two_factor.provider');
 
         $this->assertSame(Provider::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -3045,9 +3267,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheSecurityTwoFactorTrustedDeviceManager(): void
     {
-        $this->assertTrue($this->container->has('contao.security.two_factor.trusted_device_manager'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.security.two_factor.trusted_device_manager');
+        $this->assertTrue($container->has('contao.security.two_factor.trusted_device_manager'));
+
+        $definition = $container->getDefinition('contao.security.two_factor.trusted_device_manager');
 
         $this->assertSame(TrustedDeviceManager::class, $definition->getClass());
         $this->assertTrue($definition->isPublic());
@@ -3064,9 +3288,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheSecurityUserChecker(): void
     {
-        $this->assertTrue($this->container->has('contao.security.user_checker'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.security.user_checker');
+        $this->assertTrue($container->has('contao.security.user_checker'));
+
+        $definition = $container->getDefinition('contao.security.user_checker');
 
         $this->assertSame(UserChecker::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -3081,9 +3307,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheContaoBackendSession(): void
     {
-        $this->assertTrue($this->container->has('contao.session.contao_backend'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.session.contao_backend');
+        $this->assertTrue($container->has('contao.session.contao_backend'));
+
+        $definition = $container->getDefinition('contao.session.contao_backend');
 
         $this->assertSame(ArrayAttributeBag::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -3108,9 +3336,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheContaoFrontendSession(): void
     {
-        $this->assertTrue($this->container->has('contao.session.contao_frontend'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.session.contao_frontend');
+        $this->assertTrue($container->has('contao.session.contao_frontend'));
+
+        $definition = $container->getDefinition('contao.session.contao_frontend');
 
         $this->assertSame(ArrayAttributeBag::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -3135,9 +3365,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheSlugService(): void
     {
-        $this->assertTrue($this->container->has('contao.slug'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.slug');
+        $this->assertTrue($container->has('contao.slug'));
+
+        $definition = $container->getDefinition('contao.slug');
 
         $this->assertSame(Slug::class, $definition->getClass());
         $this->assertTrue($definition->isPublic());
@@ -3153,9 +3385,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheSlugGenerator(): void
     {
-        $this->assertTrue($this->container->has('contao.slug.generator'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.slug.generator');
+        $this->assertTrue($container->has('contao.slug.generator'));
+
+        $definition = $container->getDefinition('contao.slug.generator');
 
         $this->assertSame(SlugGenerator::class, $definition->getClass());
         $this->assertTrue($definition->isPublic());
@@ -3170,9 +3404,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheSlugValidCharactersService(): void
     {
-        $this->assertTrue($this->container->has('contao.slug.valid_characters'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.slug.valid_characters');
+        $this->assertTrue($container->has('contao.slug.valid_characters'));
+
+        $definition = $container->getDefinition('contao.slug.valid_characters');
 
         $this->assertSame(ValidCharacters::class, $definition->getClass());
         $this->assertTrue($definition->isPublic());
@@ -3188,9 +3424,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheTokenGenerator(): void
     {
-        $this->assertTrue($this->container->has('contao.token_generator'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.token_generator');
+        $this->assertTrue($container->has('contao.token_generator'));
+
+        $definition = $container->getDefinition('contao.token_generator');
 
         $this->assertSame(UriSafeTokenGenerator::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -3205,9 +3443,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheContaoTranslator(): void
     {
-        $this->assertTrue($this->container->has('contao.translation.translator'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.translation.translator');
+        $this->assertTrue($container->has('contao.translation.translator'));
+
+        $definition = $container->getDefinition('contao.translation.translator');
 
         $this->assertSame(Translator::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -3224,9 +3464,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheContaoTranslatorDataCollector(): void
     {
-        $this->assertTrue($this->container->has('contao.translation.translator.data_collector'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.translation.translator.data_collector');
+        $this->assertTrue($container->has('contao.translation.translator.data_collector'));
+
+        $definition = $container->getDefinition('contao.translation.translator.data_collector');
 
         $this->assertSame(DataCollectorTranslator::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -3252,9 +3494,11 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheTwigTemplateExtension(): void
     {
-        $this->assertTrue($this->container->has('contao.twig.template_extension'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.twig.template_extension');
+        $this->assertTrue($container->has('contao.twig.template_extension'));
+
+        $definition = $container->getDefinition('contao.twig.template_extension');
 
         $this->assertSame(ContaoTemplateExtension::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -3271,18 +3515,22 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheMigrationCollection(): void
     {
-        $this->assertTrue($this->container->has(MigrationCollection::class));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition(MigrationCollection::class);
+        $this->assertTrue($container->has(MigrationCollection::class));
+
+        $definition = $container->getDefinition(MigrationCollection::class);
 
         $this->assertTrue($definition->isPrivate());
     }
 
     public function testRegistersTheVersion409CeAccessMigration(): void
     {
-        $this->assertTrue($this->container->has(CeAccessMigration::class));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition(CeAccessMigration::class);
+        $this->assertTrue($container->has(CeAccessMigration::class));
+
+        $definition = $container->getDefinition(CeAccessMigration::class);
 
         $this->assertTrue($definition->isPrivate());
 
@@ -3297,13 +3545,15 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersThePredefinedImageSizes(): void
     {
+        $container = $this->getContainerBuilder();
+
         $services = ['contao.image.image_sizes', 'contao.image.image_factory', 'contao.image.picture_factory'];
 
         $extension = new ContaoCoreExtension();
-        $extension->load([], $this->container);
+        $extension->load([], $container);
 
         foreach ($services as $service) {
-            $this->assertFalse($this->container->getDefinition($service)->hasMethodCall('setPredefinedSizes'));
+            $this->assertFalse($container->getDefinition($service)->hasMethodCall('setPredefinedSizes'));
         }
 
         $extension->load(
@@ -3335,14 +3585,14 @@ class ContaoCoreExtensionTest extends TestCase
                     ],
                 ],
             ],
-            $this->container
+            $container
         );
 
         foreach ($services as $service) {
-            $this->assertTrue($this->container->getDefinition($service)->hasMethodCall('setPredefinedSizes'));
+            $this->assertTrue($container->getDefinition($service)->hasMethodCall('setPredefinedSizes'));
         }
 
-        $methodCalls = $this->container->getDefinition('contao.image.image_sizes')->getMethodCalls();
+        $methodCalls = $container->getDefinition('contao.image.image_sizes')->getMethodCalls();
 
         $this->assertSame('setPredefinedSizes', $methodCalls[0][0]);
 
@@ -3376,12 +3626,14 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testSetsTheCrawlOptionsOnTheEscargotFactory(): void
     {
+        $container = $this->getContainerBuilder();
+
         $extension = new ContaoCoreExtension();
-        $extension->load([], $this->container);
+        $extension->load([], $container);
 
-        $this->assertTrue($this->container->has('contao.crawl.escargot_factory'));
+        $this->assertTrue($container->has('contao.crawl.escargot_factory'));
 
-        $definition = $this->container->getDefinition('contao.crawl.escargot_factory');
+        $definition = $container->getDefinition('contao.crawl.escargot_factory');
 
         $this->assertEquals(
             [
@@ -3406,10 +3658,10 @@ class ContaoCoreExtensionTest extends TestCase
                     ],
                 ],
             ],
-            $this->container
+            $container
         );
 
-        $definition = $this->container->getDefinition('contao.crawl.escargot_factory');
+        $definition = $container->getDefinition('contao.crawl.escargot_factory');
 
         $this->assertEquals(
             [
@@ -3424,8 +3676,10 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheDefaultSearchIndexer(): void
     {
+        $container = $this->getContainerBuilder();
+
         $extension = new ContaoCoreExtension();
-        $extension->load([], $this->container);
+        $extension->load([], $container);
 
         $extension->load(
             [
@@ -3438,13 +3692,13 @@ class ContaoCoreExtensionTest extends TestCase
                     ],
                 ],
             ],
-            $this->container
+            $container
         );
 
-        $this->assertArrayHasKey(IndexerInterface::class, $this->container->getAutoconfiguredInstanceof());
-        $this->assertTrue($this->container->hasDefinition('contao.search.indexer.default'));
+        $this->assertArrayHasKey(IndexerInterface::class, $container->getAutoconfiguredInstanceof());
+        $this->assertTrue($container->hasDefinition('contao.search.indexer.default'));
 
-        $definition = $this->container->getDefinition('contao.search.indexer.default');
+        $definition = $container->getDefinition('contao.search.indexer.default');
 
         $this->assertEquals(
             [
@@ -3458,8 +3712,10 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testDoesNotRegisterTheDefaultSearchIndexerIfItIsDisabled(): void
     {
+        $container = $this->getContainerBuilder();
+
         $extension = new ContaoCoreExtension();
-        $extension->load([], $this->container);
+        $extension->load([], $container);
 
         $extension->load(
             [
@@ -3471,18 +3727,20 @@ class ContaoCoreExtensionTest extends TestCase
                     ],
                 ],
             ],
-            $this->container
+            $container
         );
 
         // Should still have the interface registered for autoconfiguration
-        $this->assertArrayHasKey(IndexerInterface::class, $this->container->getAutoconfiguredInstanceof());
-        $this->assertFalse($this->container->hasDefinition('contao.search.indexer.default'));
+        $this->assertArrayHasKey(IndexerInterface::class, $container->getAutoconfiguredInstanceof());
+        $this->assertFalse($container->hasDefinition('contao.search.indexer.default'));
     }
 
     public function testSetsTheCorrectFeatureFlagOnTheSearchIndexListener(): void
     {
+        $container = $this->getContainerBuilder();
+
         $extension = new ContaoCoreExtension();
-        $extension->load([], $this->container);
+        $extension->load([], $container);
 
         $extension->load(
             [
@@ -3494,10 +3752,10 @@ class ContaoCoreExtensionTest extends TestCase
                     ],
                 ],
             ],
-            $this->container
+            $container
         );
 
-        $definition = $this->container->getDefinition('contao.listener.search_index');
+        $definition = $container->getDefinition('contao.listener.search_index');
 
         $this->assertSame(SearchIndexListener::class, $definition->getClass());
 
@@ -3513,8 +3771,10 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRemovesTheSearchIndexListenerIfItIsDisabled(): void
     {
+        $container = $this->getContainerBuilder();
+
         $extension = new ContaoCoreExtension();
-        $extension->load([], $this->container);
+        $extension->load([], $container);
 
         $extension->load(
             [
@@ -3527,17 +3787,19 @@ class ContaoCoreExtensionTest extends TestCase
                     ],
                 ],
             ],
-            $this->container
+            $container
         );
 
-        $this->assertFalse($this->container->has('contao.listener.search_index'));
+        $this->assertFalse($container->has('contao.listener.search_index'));
     }
 
     public function testRegistersThePreviewAuthenticationListener(): void
     {
-        $this->assertTrue($this->container->has('contao.listener.preview_authentication'));
+        $container = $this->getContainerBuilder();
 
-        $definition = $this->container->getDefinition('contao.listener.preview_authentication');
+        $this->assertTrue($container->has('contao.listener.preview_authentication'));
+
+        $definition = $container->getDefinition('contao.listener.preview_authentication');
 
         $this->assertSame(PreviewAuthenticationListener::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
@@ -3595,5 +3857,30 @@ class ContaoCoreExtensionTest extends TestCase
         $extension->load($params, $container);
 
         $this->assertSame($this->getTempDir().'/my/custom/dir', $container->getParameter('contao.image.target_dir'));
+    }
+
+    private function getContainerBuilder(array $params = null): ContainerBuilder
+    {
+        $container = new ContainerBuilder(
+            new ParameterBag([
+                'kernel.debug' => false,
+                'kernel.project_dir' => $this->getTempDir(),
+                'kernel.default_locale' => 'en',
+            ])
+        );
+
+        if (null === $params) {
+            $params = [
+                'contao' => [
+                    'encryption_key' => 'foobar',
+                    'localconfig' => ['foo' => 'bar'],
+                ],
+            ];
+        }
+
+        $extension = new ContaoCoreExtension();
+        $extension->load($params, $container);
+
+        return $container;
     }
 }


### PR DESCRIPTION
This PR moves building of the container into a separate method instead of `setUp`, because the container will behave differently depending on configuration in https://github.com/contao/contao/pull/1516 (legacy mode on or off).