### PR TITLE
Validate the composer.json files independently from the monorepo split

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,6 +207,30 @@ jobs:
             - name: Run the unit tests
               run: vendor/bin/phpunit.bat --colors=always
 
+    composer:
+        name: Composer
+        runs-on: ubuntu-latest
+        if: github.event_name != 'push'
+        steps:
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: 7.3
+                  extensions: json, zlib
+                  tools: prestissimo
+                  coverage: none
+
+            - name: Checkout
+              uses: actions/checkout@v1
+
+            - name: Install the dependencies
+              run: |
+                  composer global require contao/monorepo-tools:dev-master
+                  composer install --no-interaction --no-suggest
+
+            - name: Validate the composer.json files
+              run: $HOME/.composer/vendor/bin/monorepo-tools composer-json --validate --ansi
+
     monorepo-split:
         name: Monorepo Split
         runs-on: ubuntu-latest
@@ -230,12 +254,7 @@ jobs:
                   key: dev-${GITHUB_REF##*/}
 
             - name: Install the dependencies
-              run: |
-                  composer global require contao/monorepo-tools:dev-master
-                  composer install --no-interaction --no-suggest
-
-            - name: Validate the composer.json files
-              run: $HOME/.composer/vendor/bin/monorepo-tools composer-json --validate --ansi
+              run: composer global require contao/monorepo-tools:dev-master
 
             - name: Split the monorepo
               run: $HOME/.composer/vendor/bin/monorepo-tools split ${GITHUB_REF##*/}

--- a/core-bundle/composer.json
+++ b/core-bundle/composer.json
@@ -47,7 +47,7 @@
         "contao/image": "^1.0",
         "contao/imagine-svg": "^0.2.3 || ^1.0",
         "doctrine/dbal": "^2.10",
-        "doctrine/doctrine-bundle": "^1.8",
+        "doctrine/doctrine-bundle": "^1.8 || ^2.0",
         "doctrine/doctrine-cache-bundle": "^1.3.1",
         "doctrine/orm": "^2.6.3",
         "dragonmantank/cron-expression": "^2.3",

--- a/manager-bundle/composer.json
+++ b/manager-bundle/composer.json
@@ -21,7 +21,7 @@
         "contao/installation-bundle": "self.version",
         "contao/manager-plugin": "^2.4",
         "doctrine/dbal": "^2.10",
-        "doctrine/doctrine-bundle": "^1.8",
+        "doctrine/doctrine-bundle": "^1.8 || ^2.0",
         "doctrine/doctrine-cache-bundle": "^1.3.1",
         "friendsofsymfony/http-cache": "^2.6",
         "friendsofsymfony/http-cache-bundle": "^2.6",


### PR DESCRIPTION
Otherwise we will not realize that the `composer.json` files are out of sync before we merge a PR.