### PR TITLE
Use createResult() in the OrderFieldMigration

### DIFF
--- a/core-bundle/src/Migration/Version410/OrderFieldMigration.php
+++ b/core-bundle/src/Migration/Version410/OrderFieldMigration.php
@@ -90,7 +90,7 @@ class OrderFieldMigration extends AbstractMigration
             }
         }
 
-        return new MigrationResult(true, '');
+        return $this->createResult(true);
     }
 
     private function migrateOrderField(string $table, string $orderField, string $field): void


### PR DESCRIPTION
See #1761

I wonder if we should generally disallow empty migration results. It's not a good user experience, if you only see

```
*
```

for the result of a migration.