### PR TITLE
Load the security bundle after the framework bundle

### DIFF
--- a/manager-bundle/src/ContaoManager/Plugin.php
+++ b/manager-bundle/src/ContaoManager/Plugin.php
@@ -91,7 +91,7 @@ class Plugin implements BundlePluginInterface, ConfigPluginInterface, RoutingPlu
     {
         $configs = [
             BundleConfig::create(FrameworkBundle::class),
-            BundleConfig::create(SecurityBundle::class),
+            BundleConfig::create(SecurityBundle::class)->setLoadAfter([FrameworkBundle::class]),
             BundleConfig::create(TwigBundle::class),
             BundleConfig::create(MonologBundle::class),
             BundleConfig::create(SwiftmailerBundle::class),

--- a/manager-bundle/tests/ContaoManager/PluginTest.php
+++ b/manager-bundle/tests/ContaoManager/PluginTest.php
@@ -92,7 +92,7 @@ class PluginTest extends ContaoTestCase
 
         $this->assertSame(SecurityBundle::class, $bundles[1]->getName());
         $this->assertSame([], $bundles[1]->getReplace());
-        $this->assertSame([], $bundles[1]->getLoadAfter());
+        $this->assertSame([FrameworkBundle::class], $bundles[1]->getLoadAfter());
 
         $this->assertSame(TwigBundle::class, $bundles[2]->getName());
         $this->assertSame([], $bundles[2]->getReplace());


### PR DESCRIPTION
In the extension of the security bundle, the parameter `%kernel.secret%` is used. This provides the framework bundle. If it is not set, an error will occur after running composer (install|update).

This has changed in version 4.4.1 of the security bundle.
https://github.com/symfony/security-bundle/blob/v4.4.1/DependencyInjection/SecurityExtension.php#L66

The Contao 4.4 LTS is not affected by this.

The error can be reproduced in the method `buildLoadingOrder` of the `ConfigResolver` which shuffle the loading order.
https://github.com/contao/manager-plugin/blob/442c3b1360b2caa784cd38aa8b2997545f20f3e1/src/Bundle/Config/ConfigResolver.php#L95

```php
uksort($loadingOrder, function() { return rand() > rand() ? 1 : -1; });

return $loadingOrder;
````

And additionally in the manager bundle plugin the order of the security bundle and framework bundle is changed.
https://github.com/contao/contao/blob/863701051e1acdc6391ef8233d445c3d352c8698/manager-bundle/src/ContaoManager/Plugin.php#L93-L94