### PR TITLE
Remove the ID column from the search index table

### DIFF
--- a/core-bundle/src/Resources/contao/dca/tl_search_index.php
+++ b/core-bundle/src/Resources/contao/dca/tl_search_index.php
@@ -17,9 +17,8 @@ $GLOBALS['TL_DCA']['tl_search_index'] = array
 		(
 			'keys' => array
 			(
-				'id' => 'primary',
-				'pid' => 'index',
-				'termId,pid' => 'unique'
+				'termId,pid' => 'primary',
+				'pid' => 'index'
 			)
 		)
 	),
@@ -27,10 +26,6 @@ $GLOBALS['TL_DCA']['tl_search_index'] = array
 	// Fields
 	'fields' => array
 	(
-		'id' => array
-		(
-			'sql'                     => "int(10) unsigned NOT NULL auto_increment"
-		),
 		'pid' => array
 		(
 			'sql'                     => "int(10) unsigned NOT NULL"


### PR DESCRIPTION
Follow up to #1679

With this optimization we get a 1.5x to 2x speed increase for wildcard-heavy searches like `*e*` or `*a* *b* *c* *d* *e*`.

Idea © by @m-vo 🙃