### PR TITLE
Use filesize units translation in search results

### DIFF
--- a/core-bundle/src/Resources/contao/modules/ModuleSearch.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleSearch.php
@@ -258,6 +258,7 @@ class ModuleSearch extends \Module
 				$objTemplate->class = (($i == ($from - 1)) ? 'first ' : '') . (($i == ($to - 1) || $i == ($count - 1)) ? 'last ' : '') . (($i % 2 == 0) ? 'even' : 'odd');
 				$objTemplate->relevance = sprintf($GLOBALS['TL_LANG']['MSC']['relevance'], number_format($arrResult[$i]['relevance'] / $arrResult[0]['relevance'] * 100, 2) . '%');
 				$objTemplate->filesize = $arrResult[$i]['filesize'];
+				$objTemplate->unit = $GLOBALS['TL_LANG']['UNITS'][1];
 				$objTemplate->matches = $arrResult[$i]['matches'];
 
 				$arrContext = array();

--- a/core-bundle/src/Resources/contao/templates/search/search_default.html5
+++ b/core-bundle/src/Resources/contao/templates/search/search_default.html5
@@ -7,6 +7,6 @@
     <p class="context"><?= $this->context ?></p>
   <?php endif; ?>
 
-  <p class="url"><?= $this->url ?><span class="filesize"> - <?= $this->filesize ?> kB</span></p>
+  <p class="url"><?= $this->url ?><span class="filesize"> - <?= $this->filesize ?> <?= $this->unit ?></span></p>
 
 </div>


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | -
| Docs PR or issue | -

Currently the filesize unit is hardcoded as `kB` in the `search_default` template, instead of using the `UNITS` translation as everywhere else. Thus any changes to `$GLOBALS['TL_LANG']['UNITS'][1]` would unexpectedly have no effect on the search result and you have inconsistent usage of filesize units in your front end.

Needs to be merged upstream as well.
