### PR TITLE
Remove an incorrect BC layer

### DIFF
--- a/manager-bundle/src/HttpKernel/ContaoCache.php
+++ b/manager-bundle/src/HttpKernel/ContaoCache.php
@@ -36,7 +36,7 @@ class ContaoCache extends HttpCache implements CacheInvalidation
         parent::__construct($kernel, $cacheDir);
 
         $stripCookies = new StripCookiesSubscriber($this->readEnvCsv('COOKIE_ALLOW_LIST', 'COOKIE_WHITELIST'));
-        $stripCookies->removeFromDenyList($this->readEnvCsv('COOKIE_REMOVE_FROM_DENY_LIST', 'COOKIE_DISABLE_FROM_BLACKLIST'));
+        $stripCookies->removeFromDenyList($this->readEnvCsv('COOKIE_REMOVE_FROM_DENY_LIST'));
 
         $stripQueryParams = new StripQueryParametersSubscriber($this->readEnvCsv('QUERY_PARAMS_ALLOW_LIST'));
         $stripQueryParams->removeFromDenyList($this->readEnvCsv('QUERY_PARAMS_REMOVE_FROM_DENY_LIST'));


### PR DESCRIPTION
This env var was only introduced in master and has never been released stable. So we don't need BC here.