### PR TITLE
Improve performance of fuzzy search when having a huge search index

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Search.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Search.php
@@ -248,8 +248,9 @@ class Search
 
 		unset($arrSet);
 
-		// Split words
+		// Split words and create all variants of it
 		$arrWords = self::splitIntoWords(Utf8::strtolower($strText), $arrData['language']);
+		$arrWords = self::createWordVariants($arrWords, $arrData['language']);
 		$arrIndex = array();
 
 		// Index words
@@ -397,6 +398,32 @@ class Search
 	}
 
 	/**
+	 * @return string[]
+	 */
+	private static function createWordVariants(array $arrWords, string $strLocale)
+	{
+		$wordVariants = array();
+		$iterator = \IntlRuleBasedBreakIterator::createCharacterInstance($strLocale);
+
+		foreach ($arrWords as $word) {
+			$iterator->setText($word);
+			$variants = array();
+
+			foreach ($iterator->getPartsIterator() as $character)
+			{
+				$prev = end($variants) ?: '';
+				$variants[] = $prev . $character;
+			}
+
+			$wordVariants = array_merge($wordVariants, $variants);
+		}
+
+		$wordVariants = array_unique($wordVariants);
+
+		return $wordVariants;
+	}
+
+	/**
 	 * Search the index and return the result object
 	 *
 	 * @param string  $strKeywords  The keyword string
@@ -501,7 +528,7 @@ class Search
 		{
 			foreach ($arrKeywords as $strKeyword)
 			{
-				$arrWildcards[] = '%' . $strKeyword . '%';
+				$arrWildcards[] = $strKeyword . '%';
 			}
 
 			$arrKeywords = array();

--- a/core-bundle/src/Resources/contao/library/Contao/Search.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Search.php
@@ -405,7 +405,8 @@ class Search
 		$wordVariants = array();
 		$iterator = \IntlRuleBasedBreakIterator::createCharacterInstance($strLocale);
 
-		foreach ($arrWords as $word) {
+		foreach ($arrWords as $word)
+		{
 			$iterator->setText($word);
 			$variants = array();
 


### PR DESCRIPTION
Based on our latest improvements in the search storage (https://github.com/contao/contao/pull/1679), I tried to improve other edge cases.

By storing all word variants (so for e.g. `foobar` we store `foobar`, `oobar`, `obar`, `bar`, `ar` and `r`), we can omit the leading `%` in the wild card and thus, MySQL can use the `term` index to find the matching terms instead of doing a full table scan.

I did some tests with smaller pages compared to huge indexes:

* Small website (~ 70 URLs):
    * Current master:
        * Number of entries in `tl_search_term`: ~ 1,200
        * Searching for `gati` and `e` takes about the same time: 2.8 ms
    * This PR :
        * Number of entries in `tl_search_term`: ~ 4,100
        * Searching for `gati` and `e` takes about the same time: 2.4 ms

* Bigger website (~ 800 URLs):
    * Current master:
        * Number of entries in `tl_search_term`: ~ 27,000
        * Searching for `gati`: 25.13 ms
        * Searching for  `e`: 491.61 ms
    * This PR :
        * Number of entries in `tl_search_term`: ~ 94,000
        * Searching for `gati`: 31.61 ms
        * Searching for  `e`: 305.59 ms

* Even bigger website: (~ 2,000 URLs):
    * Did not bother comparing the results with the current implementation anymore, I only checked the performance of this PR:
    * Number of entries in `tl_search_term`: ~ 127,000
    * Searching for `gati`: 33.63 ms (this is `gati%`), `%gati%` would be  124.45 ms
    * Searching for `e`: 632.63 ms (this is `e%`), `%e%` would be 5.14 s (! not ms)

So in other words, I guess we can conlude the following statements from my tests:

* There's not much difference in performance for smaller sites. The difference is not noticeable at all. This is true for both, the query perfomance as well as the number of entries in `tl_search_term`. We have about 350% more entries.

* The longer the keyword, the better the performance. This is true for both implementations.

* This PR provides a significant improvement for very short keywords like `e` which turns into `%e%` and thus basically matches everything.

* The number of entries in `tl_search_term` relative to the pages index (`tl_search`) is about 3.5 times higher for small pages but that ratio gets better as the index grows because chances that compound words have already been indexed increases.

I find the number of entries in `tl_search_term` is not really relevant. The bigger page I tested (~2,000 entries) current generates 2.6 million entries in 4.9 so I guess the 127,000 terms should not be a big deal ;)

Long story short: This PR improves performance for really big search indexes when searching for short keywords and it has no negative impact on the regular performance. The only "disadvantage" is an increased number of terms in the database which is still an order of magnitude lower than what we've been working with for years.


