### PR TITLE
Remove the symfony/monolog-bundle dependency from functional tests

### DIFF
--- a/core-bundle/tests/Functional/app/AppKernel.php
+++ b/core-bundle/tests/Functional/app/AppKernel.php
@@ -20,7 +20,6 @@ use Knp\Bundle\TimeBundle\KnpTimeBundle;
 use Psr\Log\NullLogger;
 use Scheb\TwoFactorBundle\SchebTwoFactorBundle;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
-use Symfony\Bundle\MonologBundle\MonologBundle;
 use Symfony\Bundle\SecurityBundle\SecurityBundle;
 use Symfony\Bundle\SwiftmailerBundle\SwiftmailerBundle;
 use Symfony\Bundle\TwigBundle\TwigBundle;
@@ -37,7 +36,6 @@ class AppKernel extends Kernel
             new FrameworkBundle(),
             new SecurityBundle(),
             new TwigBundle(),
-            new MonologBundle(),
             new SwiftmailerBundle(),
             new DoctrineBundle(),
             new SchebTwoFactorBundle(),


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes https://github.com/contao/phpstan/issues/18
| Docs PR or issue | n/a

The `symfony/monolog-bundle` is registered in the kernel for the functional tests and therefore creates a dependency which was removed in `contao/phpstan` in https://github.com/contao/phpstan/commit/be3a20326597f2bf557c2e09be322dcdc00b395f. 

IMO this can be removed.
