### PR TITLE
Fix the unit tests

### DIFF
--- a/core-bundle/composer.json
+++ b/core-bundle/composer.json
@@ -125,6 +125,7 @@
         "psr/event-dispatcher": "^1.0",
         "symfony/browser-kit": "4.4.*",
         "symfony/http-client": "4.4.*",
+        "symfony/monolog-bundle": "^3.1",
         "symfony/phpunit-bridge": "4.4.*"
     },
     "suggest": {

--- a/core-bundle/tests/Functional/app/AppKernel.php
+++ b/core-bundle/tests/Functional/app/AppKernel.php
@@ -20,7 +20,6 @@ use Knp\Bundle\TimeBundle\KnpTimeBundle;
 use Psr\Log\NullLogger;
 use Scheb\TwoFactorBundle\SchebTwoFactorBundle;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
-use Symfony\Bundle\MonologBundle\MonologBundle;
 use Symfony\Bundle\SecurityBundle\SecurityBundle;
 use Symfony\Bundle\TwigBundle\TwigBundle;
 use Symfony\Cmf\Bundle\RoutingBundle\CmfRoutingBundle;
@@ -36,7 +35,6 @@ class AppKernel extends Kernel
             new FrameworkBundle(),
             new SecurityBundle(),
             new TwigBundle(),
-            new MonologBundle(),
             new DoctrineBundle(),
             new SchebTwoFactorBundle(),
             new KnpTimeBundle(),

--- a/core-bundle/tests/Functional/app/AppKernel.php
+++ b/core-bundle/tests/Functional/app/AppKernel.php
@@ -20,6 +20,7 @@ use Knp\Bundle\TimeBundle\KnpTimeBundle;
 use Psr\Log\NullLogger;
 use Scheb\TwoFactorBundle\SchebTwoFactorBundle;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\MonologBundle\MonologBundle;
 use Symfony\Bundle\SecurityBundle\SecurityBundle;
 use Symfony\Bundle\TwigBundle\TwigBundle;
 use Symfony\Cmf\Bundle\RoutingBundle\CmfRoutingBundle;
@@ -35,6 +36,7 @@ class AppKernel extends Kernel
             new FrameworkBundle(),
             new SecurityBundle(),
             new TwigBundle(),
+            new MonologBundle(),
             new DoctrineBundle(),
             new SchebTwoFactorBundle(),
             new KnpTimeBundle(),

--- a/core-bundle/tests/Functional/app/AppKernel.php
+++ b/core-bundle/tests/Functional/app/AppKernel.php
@@ -75,6 +75,6 @@ class AppKernel extends Kernel
 
     protected function build(ContainerBuilder $container): void
     {
-        $container->register('monolog.logger.contao', NullLogger::class);
+        $container->register('logger', NullLogger::class);
     }
 }

--- a/core-bundle/tests/Functional/app/AppKernel.php
+++ b/core-bundle/tests/Functional/app/AppKernel.php
@@ -20,6 +20,7 @@ use Knp\Bundle\TimeBundle\KnpTimeBundle;
 use Psr\Log\NullLogger;
 use Scheb\TwoFactorBundle\SchebTwoFactorBundle;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\MonologBundle\MonologBundle;
 use Symfony\Bundle\SecurityBundle\SecurityBundle;
 use Symfony\Bundle\TwigBundle\TwigBundle;
 use Symfony\Cmf\Bundle\RoutingBundle\CmfRoutingBundle;
@@ -35,6 +36,7 @@ class AppKernel extends Kernel
             new FrameworkBundle(),
             new SecurityBundle(),
             new TwigBundle(),
+            new MonologBundle(),
             new DoctrineBundle(),
             new SchebTwoFactorBundle(),
             new KnpTimeBundle(),
@@ -75,6 +77,6 @@ class AppKernel extends Kernel
 
     protected function build(ContainerBuilder $container): void
     {
-        $container->register('logger', NullLogger::class);
+        $container->register('monolog.logger.contao', NullLogger::class);
     }
 }

--- a/core-bundle/tests/Picker/TablePickerProviderTest.php
+++ b/core-bundle/tests/Picker/TablePickerProviderTest.php
@@ -468,6 +468,8 @@ class TablePickerProviderTest extends ContaoTestCase
 
         if ($menu) {
             $expectedItems[] = ['picker'];
+        } else {
+            $menu = $this->createMock(ItemInterface::class);
         }
 
         foreach ($modules as $module) {


### PR DESCRIPTION
This fixes the `Method createItem may not return value of type NULL, its return declaration is ": Knp\Menu\ItemInterface"` error and the output of the functional tests.