### PR TITLE
Improve the error message for unsupported image formats

### DIFF
--- a/core-bundle/src/Image/LegacyResizer.php
+++ b/core-bundle/src/Image/LegacyResizer.php
@@ -17,13 +17,18 @@ use Contao\CoreBundle\Framework\FrameworkAwareInterface;
 use Contao\CoreBundle\Framework\FrameworkAwareTrait;
 use Contao\File;
 use Contao\Image as LegacyImage;
+use Contao\Image\DeferredImageInterface;
 use Contao\Image\DeferredResizer as ImageResizer;
 use Contao\Image\ImageInterface;
 use Contao\Image\ResizeConfiguration;
 use Contao\Image\ResizeCoordinates;
 use Contao\Image\ResizeOptions;
 use Contao\System;
+use Imagine\Exception\Exception as ImagineException;
 use Imagine\Gd\Imagine as GdImagine;
+use Imagine\Image\Box;
+use Imagine\Image\ImagineInterface;
+use Webmozart\PathUtil\Path;
 
 /**
  * Resizes image objects and executes the legacy hooks.
@@ -86,7 +91,20 @@ class LegacyResizer extends ImageResizer implements FrameworkAwareInterface
             }
         }
 
-        return parent::resize($image, $config, $options);
+        try {
+            return parent::resize($image, $config, $options);
+        } catch (ImagineException $exception) {
+            throw $this->enhanceImagineException($exception, $image);
+        }
+    }
+
+    public function resizeDeferredImage(DeferredImageInterface $image, bool $blocking = true): ?ImageInterface
+    {
+        try {
+            return parent::resizeDeferredImage($image, $blocking);
+        } catch (ImagineException $exception) {
+            throw $this->enhanceImagineException($exception, $image);
+        }
     }
 
     protected function executeResize(ImageInterface $image, ResizeCoordinates $coordinates, string $path, ResizeOptions $options): ImageInterface
@@ -142,5 +160,31 @@ class LegacyResizer extends ImageResizer implements FrameworkAwareInterface
     private function hasGetImageHook(): bool
     {
         return !empty($GLOBALS['TL_HOOKS']['getImage']) && \is_array($GLOBALS['TL_HOOKS']['getImage']);
+    }
+
+    private function enhanceImagineException(\Throwable $exception, ImageInterface $image): \Throwable
+    {
+        $format = Path::getExtension($image->getPath());
+
+        if (!$this->formatIsSupported($format, $image->getImagine())) {
+            return new \RuntimeException(sprintf('Image format "%s" is not supported in %s on this environment. Consider removing this format from contao.image.valid_extensions or switch the contao.image.imagine_service to an implementation that supports it.', $format, \get_class($image->getImagine())), $exception->getCode(), $exception);
+        }
+
+        return $exception;
+    }
+
+    private function formatIsSupported(string $format, ImagineInterface $imagine): bool
+    {
+        if ('' === $format) {
+            return false;
+        }
+
+        try {
+            $imagine->create(new Box(1, 1))->get($format);
+        } catch (\Throwable $e) {
+            return false;
+        }
+
+        return true;
     }
 }


### PR DESCRIPTION
#1913 was another case where the `contao.image.valid_extensions` caused confusion. I think especially because the IMagick error message is not very descriptive. We tried triggering a warning at container build time in https://github.com/contao/contao/pull/1815#issuecomment-642889481 but concluded that it might not be a good idea.

How about improving the error message of the exception?

Before:
<img width="856" alt="Bildschirmfoto 2020-07-12 um 10 51 56" src="https://user-images.githubusercontent.com/367169/87242551-fcad2700-c42d-11ea-9269-979670e8762b.png">

After:
<img width="857" alt="Bildschirmfoto 2020-07-12 um 10 51 27" src="https://user-images.githubusercontent.com/367169/87242555-033b9e80-c42e-11ea-8128-b622364ee43a.png">
