### PR TITLE
Allow global page model access in fragments

### DIFF
--- a/core-bundle/src/Fragment/FragmentHandler.php
+++ b/core-bundle/src/Fragment/FragmentHandler.php
@@ -99,7 +99,7 @@ class FragmentHandler extends BaseFragmentHandler
     private function preHandleFragment(FragmentReference $uri, FragmentConfig $config): void
     {
         if (!isset($uri->attributes['pageModel']) && $this->hasGlobalPageObject()) {
-            $uri->attributes['pageModel'] = $GLOBALS['objPage']->id;
+            $uri->attributes['pageModel'] = 'esi' === $config->getRenderer() ? $GLOBALS['objPage']->id : $GLOBALS['objPage'];
         }
 
         if ($this->preHandlers->has($uri->controller)) {


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | -
| Docs PR or issue | -

Currently fragment controllers for content elements and front end modules only receive the _ID_ of the page model of the current page in their `pageModel` request attribute, whereas everywhere else the `pageModel` request attribute is actually the global page model object itself.

This means that fragments are not able to access the global page model object at all, if they do not want to use `global $objPage` or `$GLOBALS['objPage']`, since the global page object is detached from the model registry. Thus you couldn't implement something like `ModuleNewsreader` as a fragment, without resorting to accessing the global variable, since the module needs to be able to modify the current global page object.

As far as I understand it, the `pageModel` only needs to be an ID for `esi` rendered fragments, but not really for `inline` or `forward` rendered fragments. Therefore this PR would change this behaviour.

However - why does this distinction need to be made at all? Isn't the global page object missing anyway (and thus also the `pageModel` request attribute), when rendering an `esi` fragment?