### PR TITLE
Remove @param Something&MockObject annotations

### DIFF
--- a/core-bundle/tests/Cache/ContaoCacheWarmerTest.php
+++ b/core-bundle/tests/Cache/ContaoCacheWarmerTest.php
@@ -18,7 +18,6 @@ use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\CoreBundle\Tests\TestCase;
 use Contao\System;
 use Doctrine\DBAL\Connection;
-use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Filesystem\Filesystem;
 
@@ -126,10 +125,6 @@ class ContaoCacheWarmerTest extends TestCase
         $this->assertFileNotExists($this->getFixturesDir().'/var/cache/contao');
     }
 
-    /**
-     * @param Connection&MockObject      $connection
-     * @param ContaoFramework&MockObject $framework
-     */
     private function getCacheWarmer(Connection $connection = null, ContaoFramework $framework = null, string $bundle = 'test-bundle'): ContaoCacheWarmer
     {
         if (null === $connection) {

--- a/core-bundle/tests/Command/MigrateCommandTest.php
+++ b/core-bundle/tests/Command/MigrateCommandTest.php
@@ -18,7 +18,6 @@ use Contao\CoreBundle\Migration\MigrationCollection;
 use Contao\CoreBundle\Migration\MigrationResult;
 use Contao\CoreBundle\Tests\TestCase;
 use Contao\InstallationBundle\Database\Installer;
-use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Filesystem\Filesystem;
@@ -177,7 +176,6 @@ class MigrateCommandTest extends TestCase
      * @param array<array<string>>          $pendingMigrations
      * @param array<array<MigrationResult>> $migrationResults
      * @param array<array<string>>          $runonceFiles
-     * @param Installer&MockObject          $installer
      */
     private function getCommand(array $pendingMigrations = [], array $migrationResults = [], array $runonceFiles = [], Installer $installer = null): MigrateCommand
     {

--- a/core-bundle/tests/Command/ResizeImagesCommandTest.php
+++ b/core-bundle/tests/Command/ResizeImagesCommandTest.php
@@ -19,7 +19,6 @@ use Contao\Image\DeferredImageInterface;
 use Contao\Image\DeferredImageStorageInterface;
 use Contao\Image\DeferredResizerInterface;
 use Contao\Image\ImageInterface;
-use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Bridge\PhpUnit\ClockMock;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Filesystem\Filesystem;
@@ -133,11 +132,6 @@ class ResizeImagesCommandTest extends TestCase
         $this->assertNotRegExp('/All images resized/', $display);
     }
 
-    /**
-     * @param ImageFactoryInterface&MockObject         $factory
-     * @param DeferredResizerInterface&MockObject      $resizer
-     * @param DeferredImageStorageInterface&MockObject $storage
-     */
     private function getCommand(ImageFactoryInterface $factory = null, DeferredResizerInterface $resizer = null, DeferredImageStorageInterface $storage = null): ResizeImagesCommand
     {
         return new ResizeImagesCommand(

--- a/core-bundle/tests/Command/UserPasswordCommandTest.php
+++ b/core-bundle/tests/Command/UserPasswordCommandTest.php
@@ -235,9 +235,6 @@ class UserPasswordCommandTest extends TestCase
         (new CommandTester($command))->execute($input, ['interactive' => false]);
     }
 
-    /**
-     * @param Connection&MockObject $connection
-     */
     private function getCommand(Connection $connection = null, string $password = null): UserPasswordCommand
     {
         if (null === $connection) {

--- a/core-bundle/tests/Contao/Database/ResultTest.php
+++ b/core-bundle/tests/Contao/Database/ResultTest.php
@@ -14,7 +14,6 @@ namespace Contao\CoreBundle\Tests\Contao\Database;
 
 use Contao\CoreBundle\Tests\Fixtures\Database\DoctrineArrayStatement;
 use Contao\Database\Result;
-use PHPUnit\Framework\Error\Notice;
 use PHPUnit\Framework\TestCase;
 
 class ResultTest extends TestCase
@@ -52,7 +51,8 @@ class ResultTest extends TestCase
             }
         }
 
-        $this->expectException(Notice::class);
+        $this->expectNotice();
+
         $resultStatement->fetchField();
     }
 
@@ -95,7 +95,8 @@ class ResultTest extends TestCase
             $this->assertSame('value1', $result->fetchField(0));
         }
 
-        $this->expectException(Notice::class);
+        $this->expectNotice();
+
         $result->fetchField(1);
     }
 
@@ -143,7 +144,8 @@ class ResultTest extends TestCase
             $this->assertSame('value2', $result->fetchField(0));
         }
 
-        $this->expectException(Notice::class);
+        $this->expectNotice();
+
         $result->fetchField(1);
     }
 

--- a/core-bundle/tests/EventListener/PrettyErrorScreenListenerTest.php
+++ b/core-bundle/tests/EventListener/PrettyErrorScreenListenerTest.php
@@ -23,7 +23,6 @@ use Contao\CoreBundle\Exception\PageNotFoundException;
 use Contao\CoreBundle\Fixtures\Exception\PageErrorResponseException;
 use Contao\CoreBundle\Tests\TestCase;
 use Lexik\Bundle\MaintenanceBundle\Exception\ServiceUnavailableException;
-use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
@@ -308,9 +307,6 @@ class PrettyErrorScreenListenerTest extends TestCase
         $this->assertSame(500, $event->getResponse()->getStatusCode());
     }
 
-    /**
-     * @param Environment&MockObject $twig
-     */
     private function getListener(bool $isBackendUser = false, bool $expectLogging = false, Environment $twig = null): PrettyErrorScreenListener
     {
         if (null === $twig) {

--- a/core-bundle/tests/EventListener/UserSessionListenerTest.php
+++ b/core-bundle/tests/EventListener/UserSessionListenerTest.php
@@ -335,13 +335,6 @@ class UserSessionListenerTest extends TestCase
         $listener->write($this->getResponseEvent($request));
     }
 
-    /**
-     * Mocks a session listener.
-     *
-     * @param Connection&MockObject               $connection
-     * @param Security&MockObject                 $security
-     * @param EventDispatcherInterface&MockObject $eventDispatcher
-     */
     private function getListener(Connection $connection = null, Security $security = null, EventDispatcherInterface $eventDispatcher = null): UserSessionListener
     {
         if (null === $connection) {

--- a/core-bundle/tests/Fragment/FragmentHandlerTest.php
+++ b/core-bundle/tests/Fragment/FragmentHandlerTest.php
@@ -206,9 +206,6 @@ class FragmentHandlerTest extends TestCase
         $fragmentHandler->render($uri);
     }
 
-    /**
-     * @param BaseFragmentHandler&MockObject $fragmentHandler
-     */
     private function getFragmentHandler(FragmentRegistry $registry = null, ServiceLocator $renderers = null, ServiceLocator $preHandlers = null, Request $request = null, BaseFragmentHandler $fragmentHandler = null): FragmentHandler
     {
         if (null === $registry) {

--- a/core-bundle/tests/Framework/ContaoFrameworkTest.php
+++ b/core-bundle/tests/Framework/ContaoFrameworkTest.php
@@ -693,9 +693,6 @@ class ContaoFrameworkTest extends TestCase
         $this->assertCount(0, $registry);
     }
 
-    /**
-     * @param TokenChecker&MockObject $tokenChecker
-     */
     private function mockFramework(Request $request = null, ScopeMatcher $scopeMatcher = null, TokenChecker $tokenChecker = null): ContaoFramework
     {
         $requestStack = new RequestStack();

--- a/core-bundle/tests/Image/ImageFactoryTest.php
+++ b/core-bundle/tests/Image/ImageFactoryTest.php
@@ -838,12 +838,6 @@ class ImageFactoryTest extends TestCase
     {
     }
 
-    /**
-     * @param ResizerInterface&MockObject $resizer
-     * @param ImagineInterface&MockObject $imagine
-     * @param ImagineInterface&MockObject $imagineSvg
-     * @param ContaoFramework&MockObject  $framework
-     */
     private function getImageFactory(ResizerInterface $resizer = null, ImagineInterface $imagine = null, ImagineInterface $imagineSvg = null, Filesystem $filesystem = null, ContaoFramework $framework = null, bool $bypassCache = null, array $imagineOptions = null, array $validExtensions = null, string $uploadDir = null): ImageFactory
     {
         if (null === $resizer) {

--- a/core-bundle/tests/Image/PictureFactoryTest.php
+++ b/core-bundle/tests/Image/PictureFactoryTest.php
@@ -628,11 +628,6 @@ class PictureFactoryTest extends TestCase
         yield [false, 20, 100, 22, 100];
     }
 
-    /**
-     * @param PictureGeneratorInterface&MockObject $pictureGenerator
-     * @param ImageFactoryInterface&MockObject     $imageFactory
-     * @param ContaoFramework&MockObject           $framework
-     */
     private function getPictureFactory(PictureGeneratorInterface $pictureGenerator = null, ImageFactoryInterface $imageFactory = null, ContaoFramework $framework = null, bool $bypassCache = null, array $imagineOptions = null): PictureFactory
     {
         if (null === $pictureGenerator) {

--- a/core-bundle/tests/Monolog/ContaoTableProcessorTest.php
+++ b/core-bundle/tests/Monolog/ContaoTableProcessorTest.php
@@ -17,7 +17,6 @@ use Contao\CoreBundle\Monolog\ContaoContext;
 use Contao\CoreBundle\Monolog\ContaoTableProcessor;
 use Contao\CoreBundle\Tests\TestCase;
 use Monolog\Logger;
-use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
@@ -232,10 +231,6 @@ class ContaoTableProcessorTest extends TestCase
         yield [ContaoCoreBundle::SCOPE_BACKEND, null, 'BE'];
     }
 
-    /**
-     * @param RequestStack&MockObject          $requestStack
-     * @param TokenStorageInterface&MockObject $tokenStorage
-     */
     private function getContaoTableProcessor(RequestStack $requestStack = null, TokenStorageInterface $tokenStorage = null): ContaoTableProcessor
     {
         if (null === $requestStack) {

--- a/core-bundle/tests/OptIn/OptInTokenTest.php
+++ b/core-bundle/tests/OptIn/OptInTokenTest.php
@@ -320,9 +320,6 @@ class OptInTokenTest extends ContaoTestCase
         $this->assertTrue($token->hasBeenSent());
     }
 
-    /**
-     * @param ContaoFramework&MockObject $framework
-     */
     private function getToken(OptInModel $model, ContaoFramework $framework = null): OptInTokenInterface
     {
         if (null === $framework) {

--- a/core-bundle/tests/Routing/Matcher/LanguageFilterTest.php
+++ b/core-bundle/tests/Routing/Matcher/LanguageFilterTest.php
@@ -15,7 +15,6 @@ namespace Contao\CoreBundle\Tests\Routing\Matcher;
 use Contao\CoreBundle\Routing\Matcher\LanguageFilter;
 use Contao\CoreBundle\Tests\TestCase;
 use Contao\PageModel;
-use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
@@ -23,8 +22,6 @@ use Symfony\Component\Routing\RouteCollection;
 class LanguageFilterTest extends TestCase
 {
     /**
-     * @param PageModel&MockObject $page
-     *
      * @dataProvider getRoutesAndLanguages
      */
     public function testRemovesARouteIfTheAcceptedLanguagesDoNotMatch(string $name, ?PageModel $page, string $acceptLanguage, bool $expectPageModel, bool $expectRemoval, bool $prependLocale = false): void

--- a/core-bundle/tests/Routing/RouteProviderTest.php
+++ b/core-bundle/tests/Routing/RouteProviderTest.php
@@ -749,9 +749,6 @@ class RouteProviderTest extends TestCase
         return $page;
     }
 
-    /**
-     * @param ContaoFramework&MockObject $framework
-     */
     private function getRouteProvider(ContaoFramework $framework = null, string $urlSuffix = '.html', bool $prependLocale = false): RouteProvider
     {
         if (null === $framework) {

--- a/core-bundle/tests/Security/Authentication/AuthenticationSuccessHandlerTest.php
+++ b/core-bundle/tests/Security/Authentication/AuthenticationSuccessHandlerTest.php
@@ -449,10 +449,6 @@ class AuthenticationSuccessHandlerTest extends TestCase
         $this->getHandler()->onAuthenticationSuccess($request, $token);
     }
 
-    /**
-     * @param ContaoFramework&MockObject $framework
-     * @param LoggerInterface&MockObject $logger
-     */
     private function getHandler(ContaoFramework $framework = null, LoggerInterface $logger = null): AuthenticationSuccessHandler
     {
         if (null === $framework) {

--- a/core-bundle/tests/Security/Authentication/FrontendPreviewAuthenticatorTest.php
+++ b/core-bundle/tests/Security/Authentication/FrontendPreviewAuthenticatorTest.php
@@ -250,12 +250,6 @@ class FrontendPreviewAuthenticatorTest extends TestCase
         $this->assertFalse($authenticator->removeFrontendAuthentication());
     }
 
-    /**
-     * @param Security&MockObject              $security
-     * @param SessionInterface&MockObject      $session
-     * @param UserProviderInterface&MockObject $userProvider
-     * @param LoggerInterface&MockObject       $logger
-     */
     private function getAuthenticator(Security $security = null, SessionInterface $session = null, UserProviderInterface $userProvider = null, LoggerInterface $logger = null): FrontendPreviewAuthenticator
     {
         if (null === $security) {

--- a/core-bundle/tests/Security/Authentication/Provider/AuthenticationProviderTest.php
+++ b/core-bundle/tests/Security/Authentication/Provider/AuthenticationProviderTest.php
@@ -522,11 +522,6 @@ class AuthenticationProviderTest extends TestCase
         return false;
     }
 
-    /**
-     * @param ContaoFramework&MockObject                $framework
-     * @param AuthenticationHandlerInterface&MockObject $twoFactorHandler
-     * @param TrustedDeviceManagerInterface&MockObject  $trustedDeviceManager
-     */
     private function createUsernamePasswordProvider(ContaoFramework $framework = null, AuthenticationHandlerInterface $twoFactorHandler = null, TrustedDeviceManagerInterface $trustedDeviceManager = null): AuthenticationProvider
     {
         $userProvider = $this->createMock(UserProviderInterface::class);

--- a/core-bundle/tests/Security/Authentication/Token/TokenCheckerTest.php
+++ b/core-bundle/tests/Security/Authentication/Token/TokenCheckerTest.php
@@ -340,8 +340,6 @@ class TokenCheckerTest extends TestCase
     }
 
     /**
-     * @param Request&MockObject $request
-     *
      * @return RequestStack&MockObject
      */
     private function mockRequestStack(Request $request = null): RequestStack

--- a/core-bundle/tests/Security/User/ContaoUserProviderTest.php
+++ b/core-bundle/tests/Security/User/ContaoUserProviderTest.php
@@ -279,9 +279,6 @@ class ContaoUserProviderTest extends TestCase
         // Dummy method to test the postAuthenticate hook
     }
 
-    /**
-     * @param ContaoFramework&MockObject $framework
-     */
     private function getProvider(ContaoFramework $framework = null, string $userClass = BackendUser::class): ContaoUserProvider
     {
         if (null === $framework) {

--- a/core-bundle/tests/Twig/Extension/ContaoTemplateExtensionTest.php
+++ b/core-bundle/tests/Twig/Extension/ContaoTemplateExtensionTest.php
@@ -16,7 +16,6 @@ use Contao\BackendCustom;
 use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\CoreBundle\Tests\TestCase;
 use Contao\CoreBundle\Twig\Extension\ContaoTemplateExtension;
-use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
@@ -75,9 +74,6 @@ class ContaoTemplateExtensionTest extends TestCase
         $this->assertEmpty($this->getExtension(null, 'frontend')->renderContaoBackendTemplate());
     }
 
-    /**
-     * @param ContaoFramework&MockObject $framework
-     */
     private function getExtension(ContaoFramework $framework = null, string $scope = 'backend'): ContaoTemplateExtension
     {
         $request = new Request();

--- a/core-bundle/tests/Util/SimpleTokenParserTest.php
+++ b/core-bundle/tests/Util/SimpleTokenParserTest.php
@@ -524,11 +524,9 @@ class SimpleTokenParserTest extends TestCase
     public function testParseSimpleTokenWithCustomExtensionProvider(): void
     {
         $stringExtensionProvider = new class() implements ExpressionFunctionProviderInterface {
-            public function getFunctions()
+            public function getFunctions(): array
             {
-                return [
-                    ExpressionFunction::fromPhp('strtoupper'),
-                ];
+                return [ExpressionFunction::fromPhp('strtoupper')];
             }
         };
 


### PR DESCRIPTION
Because they will no longer trigger `type MockObject is not within the annotated types` warnings in PhpStorm (see https://github.com/contao/contao/pull/1924#discussion_r452954478).