### PR TITLE
Revert 'Remove symfony/monolog-bundle dependency from functional tests'

### DIFF
--- a/core-bundle/composer.json
+++ b/core-bundle/composer.json
@@ -126,6 +126,7 @@
         "psr/event-dispatcher": "^1.0",
         "symfony/browser-kit": "4.4.*",
         "symfony/http-client": "4.4.*",
+        "symfony/monolog-bundle": "^3.1",
         "symfony/phpunit-bridge": "4.4.*"
     },
     "suggest": {

--- a/core-bundle/tests/Functional/app/AppKernel.php
+++ b/core-bundle/tests/Functional/app/AppKernel.php
@@ -20,6 +20,7 @@ use Knp\Bundle\TimeBundle\KnpTimeBundle;
 use Psr\Log\NullLogger;
 use Scheb\TwoFactorBundle\SchebTwoFactorBundle;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\MonologBundle\MonologBundle;
 use Symfony\Bundle\SecurityBundle\SecurityBundle;
 use Symfony\Bundle\SwiftmailerBundle\SwiftmailerBundle;
 use Symfony\Bundle\TwigBundle\TwigBundle;
@@ -36,6 +37,7 @@ class AppKernel extends Kernel
             new FrameworkBundle(),
             new SecurityBundle(),
             new TwigBundle(),
+            new MonologBundle(),
             new SwiftmailerBundle(),
             new DoctrineBundle(),
             new SchebTwoFactorBundle(),

--- a/core-bundle/tests/Functional/app/AppKernel.php
+++ b/core-bundle/tests/Functional/app/AppKernel.php
@@ -37,7 +37,7 @@ class AppKernel extends Kernel
             new FrameworkBundle(),
             new SecurityBundle(),
             new TwigBundle(),
-            new MonologBundle(),
+            new MonologBundle(), // prevents a lot of [debug] lines in the console output (see #1927)
             new SwiftmailerBundle(),
             new DoctrineBundle(),
             new SchebTwoFactorBundle(),


### PR DESCRIPTION
This reverts the changes from #1914 (see #1927).