### PR TITLE
Fix the lightbox group identifier description

### DIFF
--- a/core-bundle/src/Image/Studio/FigureBuilder.php
+++ b/core-bundle/src/Image/Studio/FigureBuilder.php
@@ -400,9 +400,9 @@ class FigureBuilder
     /**
      * Sets a custom light box group ID.
      *
-     * By default or if the argument is set to null, an ID will be generated.
-     * For this setting to take effect, make sure you have enabled the creation
-     * of a light box by calling enableLightBox().
+     * By default or if the argument is set to null, the ID will be empty. For
+     * this setting to take effect, make sure you have enabled the creation of
+     * a light box by calling enableLightBox().
      */
     public function setLightBoxGroupIdentifier(?string $identifier): self
     {


### PR DESCRIPTION
Just a minor fix. We dropped the auto generation of light box ids but the current description is still mentioning it.