### PR TITLE
Add useful exception when hook class is invalid/missing

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/System.php
+++ b/core-bundle/src/Resources/contao/library/Contao/System.php
@@ -161,6 +161,10 @@ abstract class System
 			{
 				$this->arrObjects[$strKey] = $container->get($strClass);
 			}
+			elseif (!class_exists($strClass))
+			{
+				throw new \RuntimeException('System::import() failed because class "'.$strClass.'" is not a valid class name or does not exist.');
+			}
 			elseif (\in_array('getInstance', get_class_methods($strClass)))
 			{
 				$this->arrObjects[$strKey] = \call_user_func(array($strClass, 'getInstance'));
@@ -201,6 +205,10 @@ abstract class System
 			elseif ($container->has($strClass) && (strpos($strClass, '\\') !== false || !class_exists($strClass)))
 			{
 				static::$arrStaticObjects[$strKey] = $container->get($strClass);
+			}
+			elseif (!class_exists($strClass))
+			{
+				throw new \RuntimeException('System::importStatic() failed because class "'.$strClass.'" is not a valid class name or does not exist.');
 			}
 			elseif (\in_array('getInstance', get_class_methods($strClass)))
 			{

--- a/core-bundle/src/Resources/contao/library/Contao/System.php
+++ b/core-bundle/src/Resources/contao/library/Contao/System.php
@@ -163,7 +163,7 @@ abstract class System
 			}
 			elseif (!class_exists($strClass))
 			{
-				throw new \RuntimeException('System::import() failed because class "'.$strClass.'" is not a valid class name or does not exist.');
+				throw new \RuntimeException('System::import() failed because class "' . $strClass . '" is not a valid class name or does not exist.');
 			}
 			elseif (\in_array('getInstance', get_class_methods($strClass)))
 			{
@@ -208,7 +208,7 @@ abstract class System
 			}
 			elseif (!class_exists($strClass))
 			{
-				throw new \RuntimeException('System::importStatic() failed because class "'.$strClass.'" is not a valid class name or does not exist.');
+				throw new \RuntimeException('System::importStatic() failed because class "' . $strClass . '" is not a valid class name or does not exist.');
 			}
 			elseif (\in_array('getInstance', get_class_methods($strClass)))
 			{


### PR DESCRIPTION
If an invalid class is imported, we'd always get `Warning: in_array() expects parameter 2 to be array, null given` because `get_class_methods()` returns null instead of an array.