### PR TITLE
Remove two left-over requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,6 @@
     "require": {
         "php": "^7.2",
         "ext-dom": "*",
-        "ext-filter": "*",
         "ext-gd": "*",
         "ext-hash": "*",
         "ext-intl": "*",
@@ -76,7 +75,6 @@
         "ramsey/uuid": "^3.8",
         "scheb/two-factor-bundle": "^4.11",
         "scssphp/scssphp": "^1.0",
-        "sensiolabs/ansi-to-html": "^1.1",
         "simplepie/simplepie": "^1.3",
         "spomky-labs/otphp": "^9.1",
         "symfony-cmf/routing-bundle": "^2.1",

--- a/installation-bundle/composer.json
+++ b/installation-bundle/composer.json
@@ -16,12 +16,10 @@
     ],
     "require": {
         "php": "^7.2",
-        "ext-filter": "*",
         "contao/core-bundle": "self.version",
         "doctrine/dbal": "^2.10",
         "patchwork/utf8": "^1.2",
         "psr/log": "^1.0",
-        "sensiolabs/ansi-to-html": "^1.1",
         "symfony/config": "4.4.*",
         "symfony/console": "4.4.*",
         "symfony/dependency-injection": "4.4.*",


### PR DESCRIPTION
We used `sensiolabs/ansi-to-html` to render the console output in the install tool before we had the Contao Manager. And we used the PHP filter* functions in some ancient version to avoid booting the Contao framework.