### PR TITLE
Explicitly register the model classes

### DIFF
--- a/calendar-bundle/src/Resources/contao/config/config.php
+++ b/calendar-bundle/src/Resources/contao/config/config.php
@@ -9,6 +9,9 @@
  */
 
 use Contao\Calendar;
+use Contao\CalendarEventsModel;
+use Contao\CalendarFeedModel;
+use Contao\CalendarModel;
 use Contao\ListWizard;
 use Contao\ModuleCalendar;
 use Contao\ModuleEventlist;
@@ -52,3 +55,10 @@ $GLOBALS['TL_PERMISSIONS'][] = 'calendars';
 $GLOBALS['TL_PERMISSIONS'][] = 'calendarp';
 $GLOBALS['TL_PERMISSIONS'][] = 'calendarfeeds';
 $GLOBALS['TL_PERMISSIONS'][] = 'calendarfeedp';
+
+// Models
+$GLOBALS['TL_MODELS'] = array(
+	'tl_calendar_events' => CalendarEventsModel::class,
+	'tl_calendar_feed' => CalendarFeedModel::class,
+	'tl_calendar' => CalendarModel::class
+);

--- a/calendar-bundle/src/Resources/contao/config/config.php
+++ b/calendar-bundle/src/Resources/contao/config/config.php
@@ -57,8 +57,6 @@ $GLOBALS['TL_PERMISSIONS'][] = 'calendarfeeds';
 $GLOBALS['TL_PERMISSIONS'][] = 'calendarfeedp';
 
 // Models
-$GLOBALS['TL_MODELS'] = array(
-	'tl_calendar_events' => CalendarEventsModel::class,
-	'tl_calendar_feed' => CalendarFeedModel::class,
-	'tl_calendar' => CalendarModel::class
-);
+$GLOBALS['TL_MODELS']['tl_calendar_events'] = CalendarEventsModel::class;
+$GLOBALS['TL_MODELS']['tl_calendar_feed'] = CalendarFeedModel::class;
+$GLOBALS['TL_MODELS']['tl_calendar'] = CalendarModel::class;

--- a/comments-bundle/src/Resources/contao/config/config.php
+++ b/comments-bundle/src/Resources/contao/config/config.php
@@ -31,7 +31,5 @@ $GLOBALS['BE_MOD']['content']['comments'] = array
 $GLOBALS['TL_CRON']['daily']['purgeCommentSubscriptions'] = array(Comments::class, 'purgeSubscriptions');
 
 // Models
-$GLOBALS['TL_MODELS'] = array(
-	'tl_comments' => CommentsModel::class,
-	'tl_comments_notify' => CommentsNotifyModel::class
-);
+$GLOBALS['TL_MODELS']['tl_comments'] = CommentsModel::class;
+$GLOBALS['TL_MODELS']['tl_comments_notify'] = CommentsNotifyModel::class;

--- a/comments-bundle/src/Resources/contao/config/config.php
+++ b/comments-bundle/src/Resources/contao/config/config.php
@@ -9,6 +9,8 @@
  */
 
 use Contao\Comments;
+use Contao\CommentsModel;
+use Contao\CommentsNotifyModel;
 use Contao\ContentComments;
 use Contao\ModuleComments;
 
@@ -27,3 +29,9 @@ $GLOBALS['BE_MOD']['content']['comments'] = array
 
 // Cron jobs
 $GLOBALS['TL_CRON']['daily']['purgeCommentSubscriptions'] = array(Comments::class, 'purgeSubscriptions');
+
+// Models
+$GLOBALS['TL_MODELS'] = array(
+	'tl_comments' => CommentsModel::class,
+	'tl_comments_notify' => CommentsNotifyModel::class
+);

--- a/core-bundle/src/Resources/contao/config/config.php
+++ b/core-bundle/src/Resources/contao/config/config.php
@@ -8,6 +8,7 @@
  * @license LGPL-3.0-or-later
  */
 
+use Contao\ArticleModel;
 use Contao\Automator;
 use Contao\CheckBox;
 use Contao\CheckBoxWizard;
@@ -28,6 +29,7 @@ use Contao\ContentImage;
 use Contao\ContentList;
 use Contao\ContentMarkdown;
 use Contao\ContentMedia;
+use Contao\ContentModel;
 use Contao\ContentModule;
 use Contao\ContentSliderStart;
 use Contao\ContentSliderStop;
@@ -40,16 +42,19 @@ use Contao\ContentYouTube;
 use Contao\CoreBundle\Controller\BackendCsvImportController;
 use Contao\Crawl;
 use Contao\FileSelector;
+use Contao\FilesModel;
 use Contao\FileTree;
 use Contao\Form;
 use Contao\FormCaptcha;
 use Contao\FormCheckBox;
 use Contao\FormExplanation;
+use Contao\FormFieldModel;
 use Contao\FormFieldsetStart;
 use Contao\FormFieldsetStop;
 use Contao\FormFileUpload;
 use Contao\FormHidden;
 use Contao\FormHtml;
+use Contao\FormModel;
 use Contao\FormPassword;
 use Contao\FormRadioButton;
 use Contao\FormRange;
@@ -58,10 +63,15 @@ use Contao\FormSubmit;
 use Contao\FormTextArea;
 use Contao\FormTextField;
 use Contao\ImageSize;
+use Contao\ImageSizeItemModel;
+use Contao\ImageSizeModel;
 use Contao\InputUnit;
 use Contao\KeyValueWizard;
+use Contao\LayoutModel;
 use Contao\ListWizard;
 use Contao\Maintenance;
+use Contao\MemberGroupModel;
+use Contao\MemberModel;
 use Contao\Messages;
 use Contao\MetaWizard;
 use Contao\ModuleArticleList;
@@ -75,6 +85,7 @@ use Contao\ModuleHtml;
 use Contao\ModuleLogin;
 use Contao\ModuleLogout;
 use Contao\ModuleMaintenance;
+use Contao\ModuleModel;
 use Contao\ModuleNavigation;
 use Contao\ModulePassword;
 use Contao\ModulePersonalData;
@@ -87,12 +98,14 @@ use Contao\ModuleSearch;
 use Contao\ModuleSitemap;
 use Contao\ModuleTwoFactor;
 use Contao\ModuleWizard;
+use Contao\OptInModel;
 use Contao\OptionWizard;
 use Contao\PageError401;
 use Contao\PageError403;
 use Contao\PageError404;
 use Contao\PageForward;
 use Contao\PageLogout;
+use Contao\PageModel;
 use Contao\PageRedirect;
 use Contao\PageRegular;
 use Contao\PageRoot;
@@ -107,6 +120,8 @@ use Contao\SectionWizard;
 use Contao\SelectMenu;
 use Contao\SerpPreview;
 use Contao\StringUtil;
+use Contao\StyleModel;
+use Contao\StyleSheetModel;
 use Contao\StyleSheets;
 use Contao\System;
 use Contao\TableWizard;
@@ -114,9 +129,12 @@ use Contao\TextArea;
 use Contao\TextField;
 use Contao\TextStore;
 use Contao\Theme;
+use Contao\ThemeModel;
 use Contao\TimePeriod;
 use Contao\TrblField;
 use Contao\Upload;
+use Contao\UserGroupModel;
+use Contao\UserModel;
 
 // Back end modules
 $GLOBALS['BE_MOD'] = array
@@ -537,6 +555,27 @@ $GLOBALS['TL_WRAPPERS'] = array
 	'separator' => array()
 );
 
+// Models
+$GLOBALS['TL_MODELS'] = array(
+	'tl_article' => ArticleModel::class,
+	'tl_content' => ContentModel::class,
+	'tl_files' => FilesModel::class,
+	'tl_form_field' => FormFieldModel::class,
+	'tl_form' => FormModel::class,
+	'tl_image_size_item' => ImageSizeItemModel::class,
+	'tl_image_size' => ImageSizeModel::class,
+	'tl_layout' => LayoutModel::class,
+	'tl_member_group' => MemberGroupModel::class,
+	'tl_member' => MemberModel::class,
+	'tl_module' => ModuleModel::class,
+	'tl_opt_in' => OptInModel::class,
+	'tl_page' => PageModel::class,
+	'tl_style' => StyleModel::class,
+	'tl_style_sheet' => StyleSheetModel::class,
+	'tl_theme' => ThemeModel::class,
+	'tl_user_group' => UserGroupModel::class,
+	'tl_user' => UserModel::class
+);
+
 // Other global arrays
-$GLOBALS['TL_MODELS'] = array();
 $GLOBALS['TL_PERMISSIONS'] = array();

--- a/core-bundle/src/Resources/contao/library/Contao/Model.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Model.php
@@ -1189,6 +1189,8 @@ abstract class Model
 			return static::$arrClassNames[$strTable];
 		}
 
+		trigger_deprecation('contao/core-bundle', '4.10', sprintf('Not registering table "%s" in $GLOBALS[\'TL_MODELS\'] has been deprecated and will no longer work in Contao 5.0.', $strTable));
+
 		$arrChunks = explode('_', $strTable);
 
 		if ($arrChunks[0] == 'tl')

--- a/faq-bundle/src/Resources/contao/config/config.php
+++ b/faq-bundle/src/Resources/contao/config/config.php
@@ -8,6 +8,8 @@
  * @license LGPL-3.0-or-later
  */
 
+use Contao\FaqCategoryModel;
+use Contao\FaqModel;
 use Contao\ModuleFaq;
 use Contao\ModuleFaqList;
 use Contao\ModuleFaqPage;
@@ -39,3 +41,9 @@ $GLOBALS['TL_HOOKS']['getSearchablePages'][] = array(ModuleFaq::class, 'getSearc
 // Add permissions
 $GLOBALS['TL_PERMISSIONS'][] = 'faqs';
 $GLOBALS['TL_PERMISSIONS'][] = 'faqp';
+
+// Models
+$GLOBALS['TL_MODELS'] = array(
+	'tl_faq_category' => FaqCategoryModel::class,
+	'tl_faq' => FaqModel::class
+);

--- a/faq-bundle/src/Resources/contao/config/config.php
+++ b/faq-bundle/src/Resources/contao/config/config.php
@@ -43,7 +43,5 @@ $GLOBALS['TL_PERMISSIONS'][] = 'faqs';
 $GLOBALS['TL_PERMISSIONS'][] = 'faqp';
 
 // Models
-$GLOBALS['TL_MODELS'] = array(
-	'tl_faq_category' => FaqCategoryModel::class,
-	'tl_faq' => FaqModel::class
-);
+$GLOBALS['TL_MODELS']['tl_faq_category'] = FaqCategoryModel::class;
+$GLOBALS['TL_MODELS']['tl_faq'] = FaqModel::class;

--- a/news-bundle/src/Resources/contao/config/config.php
+++ b/news-bundle/src/Resources/contao/config/config.php
@@ -14,6 +14,9 @@ use Contao\ModuleNewsList;
 use Contao\ModuleNewsMenu;
 use Contao\ModuleNewsReader;
 use Contao\News;
+use Contao\NewsArchiveModel;
+use Contao\NewsFeedModel;
+use Contao\NewsModel;
 use Contao\TableWizard;
 
 // Back end modules
@@ -52,3 +55,10 @@ $GLOBALS['TL_PERMISSIONS'][] = 'news';
 $GLOBALS['TL_PERMISSIONS'][] = 'newp';
 $GLOBALS['TL_PERMISSIONS'][] = 'newsfeeds';
 $GLOBALS['TL_PERMISSIONS'][] = 'newsfeedp';
+
+// Models
+$GLOBALS['TL_MODELS'] = array(
+	'tl_news_archive' => NewsArchiveModel::class,
+	'tl_news_feed' => NewsFeedModel::class,
+	'tl_news' => NewsModel::class
+);

--- a/news-bundle/src/Resources/contao/config/config.php
+++ b/news-bundle/src/Resources/contao/config/config.php
@@ -57,8 +57,6 @@ $GLOBALS['TL_PERMISSIONS'][] = 'newsfeeds';
 $GLOBALS['TL_PERMISSIONS'][] = 'newsfeedp';
 
 // Models
-$GLOBALS['TL_MODELS'] = array(
-	'tl_news_archive' => NewsArchiveModel::class,
-	'tl_news_feed' => NewsFeedModel::class,
-	'tl_news' => NewsModel::class
-);
+$GLOBALS['TL_MODELS']['tl_news_archive'] = NewsArchiveModel::class;
+$GLOBALS['TL_MODELS']['tl_news_feed'] = NewsFeedModel::class;
+$GLOBALS['TL_MODELS']['tl_news'] = NewsModel::class;

--- a/newsletter-bundle/src/Resources/contao/config/config.php
+++ b/newsletter-bundle/src/Resources/contao/config/config.php
@@ -50,9 +50,7 @@ $GLOBALS['TL_PERMISSIONS'][] = 'newsletterp';
 $GLOBALS['TL_CRON']['daily']['purgeNewsletterSubscriptions'] = array(Newsletter::class, 'purgeSubscriptions');
 
 // Models
-$GLOBALS['TL_MODELS'] = array(
-	'tl_newsletter_channel' => NewsletterChannelModel::class,
-	'tl_newsletter_deny_list' => NewsletterDenyListModel::class,
-	'tl_newsletter' => NewsletterModel::class,
-	'tl_newsletter_recipients' => NewsletterRecipientsModel::class
-);
+$GLOBALS['TL_MODELS']['tl_newsletter_channel'] = NewsletterChannelModel::class;
+$GLOBALS['TL_MODELS']['tl_newsletter_deny_list'] = NewsletterDenyListModel::class;
+$GLOBALS['TL_MODELS']['tl_newsletter'] = NewsletterModel::class;
+$GLOBALS['TL_MODELS']['tl_newsletter_recipients'] = NewsletterRecipientsModel::class;

--- a/newsletter-bundle/src/Resources/contao/config/config.php
+++ b/newsletter-bundle/src/Resources/contao/config/config.php
@@ -13,6 +13,10 @@ use Contao\ModuleNewsletterReader;
 use Contao\ModuleSubscribe;
 use Contao\ModuleUnsubscribe;
 use Contao\Newsletter;
+use Contao\NewsletterChannelModel;
+use Contao\NewsletterDenyListModel;
+use Contao\NewsletterModel;
+use Contao\NewsletterRecipientsModel;
 
 // Back end modules
 $GLOBALS['BE_MOD']['content']['newsletter'] = array
@@ -44,3 +48,11 @@ $GLOBALS['TL_PERMISSIONS'][] = 'newsletterp';
 
 // Cron jobs
 $GLOBALS['TL_CRON']['daily']['purgeNewsletterSubscriptions'] = array(Newsletter::class, 'purgeSubscriptions');
+
+// Models
+$GLOBALS['TL_MODELS'] = array(
+	'tl_newsletter_channel' => NewsletterChannelModel::class,
+	'tl_newsletter_deny_list' => NewsletterDenyListModel::class,
+	'tl_newsletter' => NewsletterModel::class,
+	'tl_newsletter_recipients' => NewsletterRecipientsModel::class
+);


### PR DESCRIPTION
I have realized that using `Model::getRelated()` still relies on the old Contao 3 class autoloader to find the related model class. This is because `Model::getClassFromTable()` only converts `tl_page` to `PageModel` and not to `Contao\PageModel` and therefore we still have "composerized" classes in Contao 4.10 when we really should not anymore. 😄 

<img width="724" alt="" src="https://user-images.githubusercontent.com/1192057/88038330-5c9a8080-cb46-11ea-9976-6441d9ab906a.png">

This PR explicitly registers the fully qualified model class names.