### PR TITLE
Add the missing ContentModel annotations

### DIFF
--- a/core-bundle/src/Resources/contao/models/ContentModel.php
+++ b/core-bundle/src/Resources/contao/models/ContentModel.php
@@ -71,6 +71,16 @@ use Contao\Model\Collection;
  * @property string  $youtube
  * @property string  $posterSRC
  * @property string  $playerSize
+ * @property string  $playerOptions
+ * @property integer $playerStart
+ * @property integer $playerStop
+ * @property string  $playerCaption
+ * @property string  $playerAspect
+ * @property boolean $splashImage
+ * @property string  $playerPreload
+ * @property string  $playerColor
+ * @property string  $youtubeOptions
+ * @property string  $vimeoOptions
  * @property integer $sliderDelay
  * @property integer $sliderSpeed
  * @property integer $sliderStartSlide
@@ -157,7 +167,16 @@ use Contao\Model\Collection;
  * @method static ContentModel|null findOneByYoutube($val, array $opt=array())
  * @method static ContentModel|null findOneByPosterSRC($val, array $opt=array())
  * @method static ContentModel|null findOneByPlayerSize($val, array $opt=array())
- * @method static ContentModel|null findOneByAutoplay($val, array $opt=array())
+ * @method static ContentModel|null findOneByPlayerOptions($val, array $opt=array())
+ * @method static ContentModel|null findOneByPlayerStart($val, array $opt=array())
+ * @method static ContentModel|null findOneByPlayerStop($val, array $opt=array())
+ * @method static ContentModel|null findOneByPlayerCaption($val, array $opt=array())
+ * @method static ContentModel|null findOneByPlayerAspect($val, array $opt=array())
+ * @method static ContentModel|null findOneBySplashImage($val, array $opt=array())
+ * @method static ContentModel|null findOneByPlayerPreload($val, array $opt=array())
+ * @method static ContentModel|null findOneByPlayerColor($val, array $opt=array())
+ * @method static ContentModel|null findOneByYoutubeOptions($val, array $opt=array())
+ * @method static ContentModel|null findOneByVimeoOptions($val, array $opt=array())
  * @method static ContentModel|null findOneBySliderDelay($val, array $opt=array())
  * @method static ContentModel|null findOneBySliderSpeed($val, array $opt=array())
  * @method static ContentModel|null findOneBySliderStartSlide($val, array $opt=array())
@@ -238,7 +257,16 @@ use Contao\Model\Collection;
  * @method static Collection|ContentModel[]|ContentModel|null findByYoutube($val, array $opt=array())
  * @method static Collection|ContentModel[]|ContentModel|null findByPosterSRC($val, array $opt=array())
  * @method static Collection|ContentModel[]|ContentModel|null findByPlayerSize($val, array $opt=array())
- * @method static Collection|ContentModel[]|ContentModel|null findByAutoplay($val, array $opt=array())
+ * @method static Collection|ContentModel[]|ContentModel|null findByPlayerOptions($val, array $opt=array())
+ * @method static Collection|ContentModel[]|ContentModel|null findByPlayerStart($val, array $opt=array())
+ * @method static Collection|ContentModel[]|ContentModel|null findByPlayerStop($val, array $opt=array())
+ * @method static Collection|ContentModel[]|ContentModel|null findByPlayerCaption($val, array $opt=array())
+ * @method static Collection|ContentModel[]|ContentModel|null findByPlayerAspect($val, array $opt=array())
+ * @method static Collection|ContentModel[]|ContentModel|null findBySplashImage($val, array $opt=array())
+ * @method static Collection|ContentModel[]|ContentModel|null findByPlayerPreload($val, array $opt=array())
+ * @method static Collection|ContentModel[]|ContentModel|null findByPlayerColor($val, array $opt=array())
+ * @method static Collection|ContentModel[]|ContentModel|null findByYoutubeOptions($val, array $opt=array())
+ * @method static Collection|ContentModel[]|ContentModel|null findByVimeoOptions($val, array $opt=array())
  * @method static Collection|ContentModel[]|ContentModel|null findBySliderDelay($val, array $opt=array())
  * @method static Collection|ContentModel[]|ContentModel|null findBySliderSpeed($val, array $opt=array())
  * @method static Collection|ContentModel[]|ContentModel|null findBySliderStartSlide($val, array $opt=array())
@@ -323,7 +351,16 @@ use Contao\Model\Collection;
  * @method static integer countByYoutube($val, array $opt=array())
  * @method static integer countByPosterSRC($val, array $opt=array())
  * @method static integer countByPlayerSize($val, array $opt=array())
- * @method static integer countByAutoplay($val, array $opt=array())
+ * @method static integer countByPlayerOptions($val, array $opt=array())
+ * @method static integer countByPlayerStart($val, array $opt=array())
+ * @method static integer countByPlayerStop($val, array $opt=array())
+ * @method static integer countByPlayerCaption($val, array $opt=array())
+ * @method static integer countByPlayerAspect($val, array $opt=array())
+ * @method static integer countBySplashImage($val, array $opt=array())
+ * @method static integer countByPlayerPreload($val, array $opt=array())
+ * @method static integer countByPlayerColor($val, array $opt=array())
+ * @method static integer countByYoutubeOptions($val, array $opt=array())
+ * @method static integer countByVimeoOptions($val, array $opt=array())
  * @method static integer countBySliderDelay($val, array $opt=array())
  * @method static integer countBySliderSpeed($val, array $opt=array())
  * @method static integer countBySliderStartSlide($val, array $opt=array())


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | -
| Docs PR or issue | -

I recently noticed that many of the changes regarding the media player, youtube and vimeo content element weren't updated in the `ContentModel`'s annotations.

Btw. wouldn't it be feasible to write an automatic check whether a newly added or changed property is present the respective model's annotations?
