### PR TITLE
Rename "light box" to "lightbox"

### DIFF
--- a/core-bundle/src/Image/Studio/Figure.php
+++ b/core-bundle/src/Image/Studio/Figure.php
@@ -43,9 +43,9 @@ final class Figure
     private $linkAttributes;
 
     /**
-     * @var LightBoxResult|(\Closure(self):LightBoxResult|null)|null
+     * @var LightboxResult|(\Closure(self):LightboxResult|null)|null
      */
-    private $lightBox;
+    private $lightbox;
 
     /**
      * @var array<string, mixed>|(\Closure(self):array<string, mixed>)|null
@@ -61,15 +61,15 @@ final class Figure
      * @param ImageResult                                                                 $image          Main image
      * @param MetaData|(\Closure(self):MetaData|null)|null                                $metaData       Meta data container
      * @param array<string, string|null>|(\Closure(self):array<string, string|null>)|null $linkAttributes Link attributes
-     * @param LightBoxResult|(\Closure(self):LightBoxResult|null)|null                    $lightBox       Light box
+     * @param LightboxResult|(\Closure(self):LightboxResult|null)|null                    $lightbox       Lightbox
      * @param array<string, mixed>|(\Closure(self):array<string, mixed>)|null             $options        Template options
      */
-    public function __construct(ImageResult $image, $metaData = null, $linkAttributes = null, $lightBox = null, $options = null)
+    public function __construct(ImageResult $image, $metaData = null, $linkAttributes = null, $lightbox = null, $options = null)
     {
         $this->image = $image;
         $this->metaData = $metaData;
         $this->linkAttributes = $linkAttributes;
-        $this->lightBox = $lightBox;
+        $this->lightbox = $lightbox;
         $this->options = $options;
     }
 
@@ -82,26 +82,26 @@ final class Figure
     }
 
     /**
-     * Returns true if a light box result can be obtained.
+     * Returns true if a lightbox result can be obtained.
      */
-    public function hasLightBox(): bool
+    public function hasLightbox(): bool
     {
-        $this->resolveIfClosure($this->lightBox);
+        $this->resolveIfClosure($this->lightbox);
 
-        return $this->lightBox instanceof LightBoxResult;
+        return $this->lightbox instanceof LightboxResult;
     }
 
     /**
-     * Returns the light box result (if available).
+     * Returns the lightbox result (if available).
      */
-    public function getLightBox(): LightBoxResult
+    public function getLightbox(): LightboxResult
     {
-        if (!$this->hasLightBox()) {
-            throw new \LogicException('This result container does not include a light box.');
+        if (!$this->hasLightbox()) {
+            throw new \LogicException('This result container does not include a lightbox.');
         }
 
         // Safely return as Closure will be evaluated at this point
-        return $this->lightBox;
+        return $this->lightbox;
     }
 
     public function hasMetaData(): bool
@@ -140,8 +140,8 @@ final class Figure
         if (!\array_key_exists('href', $this->linkAttributes)) {
             $this->linkAttributes['href'] = (
                 function () {
-                    if ($this->hasLightBox()) {
-                        return $this->getLightBox()->getLinkHref();
+                    if ($this->hasLightbox()) {
+                        return $this->getLightbox()->getLinkHref();
                     }
 
                     if ($this->hasMetaData()) {
@@ -162,10 +162,10 @@ final class Figure
             $this->linkAttributes['rel'] = 'noreferrer noopener';
         }
 
-        // Add light box attributes
-        if (!\array_key_exists('data-lightbox', $this->linkAttributes) && $this->hasLightBox()) {
-            $lightBox = $this->getLightBox();
-            $this->linkAttributes['data-lightbox'] = $lightBox->getGroupIdentifier();
+        // Add lightbox attributes
+        if (!\array_key_exists('data-lightbox', $this->linkAttributes) && $this->hasLightbox()) {
+            $lightbox = $this->getLightbox();
+            $this->linkAttributes['data-lightbox'] = $lightbox->getGroupIdentifier();
         }
 
         // Allow removing attributes by setting them to null
@@ -276,7 +276,7 @@ final class Figure
                 'imgSize' => sprintf(' width="%d" height="%d"', $fileInfoImageSize[0], $fileInfoImageSize[1]),
                 'singleSRC' => $image->getFilePath(),
                 'src' => $image->getImageSrc(),
-                'fullsize' => ('_blank' === ($linkAttributes['target'] ?? null)) || $this->hasLightBox(),
+                'fullsize' => ('_blank' === ($linkAttributes['target'] ?? null)) || $this->hasLightbox(),
                 'margin' => $createMargin($margin),
                 'addBefore' => 'below' !== $floating,
                 'addImage' => true,
@@ -307,16 +307,16 @@ final class Figure
             $templateData['attributes'] = ' '.implode(' ', $htmlAttributes);
         }
 
-        // Light box
-        if ($this->hasLightBox()) {
-            $lightBox = $this->getLightBox();
+        // Lightbox
+        if ($this->hasLightbox()) {
+            $lightbox = $this->getLightbox();
 
-            if ($lightBox->hasImage()) {
-                $lightBoxImage = $lightBox->getImage();
+            if ($lightbox->hasImage()) {
+                $lightboxImage = $lightbox->getImage();
 
                 $templateData['lightboxPicture'] = [
-                    'img' => $lightBoxImage->getImg(),
-                    'sources' => $lightBoxImage->getSources(),
+                    'img' => $lightboxImage->getImg(),
+                    'sources' => $lightboxImage->getSources(),
                 ];
             }
         }

--- a/core-bundle/src/Image/Studio/FigureBuilder.php
+++ b/core-bundle/src/Image/Studio/FigureBuilder.php
@@ -109,32 +109,32 @@ class FigureBuilder
     private $additionalLinkAttributes = [];
 
     /**
-     * User defined light box resource or url. This will overwrite the default if set.
+     * User defined lightbox resource or url. This will overwrite the default if set.
      *
      * @var string|ImageInterface|null
      */
-    private $lightBoxResourceOrUrl;
+    private $lightboxResourceOrUrl;
 
     /**
-     * User defined light box size configuration. This will overwrite the default if set.
+     * User defined lightbox size configuration. This will overwrite the default if set.
      *
      * @var mixed|null
      */
-    private $lightBoxSizeConfiguration;
+    private $lightboxSizeConfiguration;
 
     /**
-     * User defined light box group identifier. This will overwrite the default if set.
+     * User defined lightbox group identifier. This will overwrite the default if set.
      *
      * @var string|null
      */
-    private $lightBoxGroupIdentifier;
+    private $lightboxGroupIdentifier;
 
     /**
-     * Determines if a light box (or "fullsize") image should be created.
+     * Determines if a lightbox (or "fullsize") image should be created.
      *
      * @var bool
      */
-    private $enableLightBox;
+    private $enableLightbox;
 
     /**
      * User defined template options.
@@ -366,60 +366,60 @@ class FigureBuilder
     }
 
     /**
-     * Sets a custom light box resource (file path or ImageInterface) or URL.
+     * Sets a custom lightbox resource (file path or ImageInterface) or URL.
      *
      * By default or if the argument is set to null, the image/target will be
      * automatically determined from the meta data or base resource. For this
      * setting to take effect, make sure you have enabled the creation of a
-     * light box by calling enableLightBox().
+     * lightbox by calling enableLightbox().
      *
      * @param string|ImageInterface|null $resourceOrUrl
      */
-    public function setLightBoxResourceOrUrl($resourceOrUrl): self
+    public function setLightboxResourceOrUrl($resourceOrUrl): self
     {
-        $this->lightBoxResourceOrUrl = $resourceOrUrl;
+        $this->lightboxResourceOrUrl = $resourceOrUrl;
 
         return $this;
     }
 
     /**
-     * Sets a size configuration that will be applied to the light box image.
+     * Sets a size configuration that will be applied to the lightbox image.
      *
      * For this setting to take effect, make sure you have enabled the creation
-     * of a light box by calling enableLightBox().
+     * of a lightbox by calling enableLightbox().
      *
      * @param int|string|array|PictureConfiguration $size A picture size configuration or reference
      */
-    public function setLightBoxSize($size): self
+    public function setLightboxSize($size): self
     {
-        $this->lightBoxSizeConfiguration = $size;
+        $this->lightboxSizeConfiguration = $size;
 
         return $this;
     }
 
     /**
-     * Sets a custom light box group ID.
+     * Sets a custom lightbox group ID.
      *
      * By default or if the argument is set to null, the ID will be empty. For
      * this setting to take effect, make sure you have enabled the creation of
-     * a light box by calling enableLightBox().
+     * a lightbox by calling enableLightbox().
      */
-    public function setLightBoxGroupIdentifier(?string $identifier): self
+    public function setLightboxGroupIdentifier(?string $identifier): self
     {
-        $this->lightBoxGroupIdentifier = $identifier;
+        $this->lightboxGroupIdentifier = $identifier;
 
         return $this;
     }
 
     /**
-     * Enables the creation of a light box image (if possible) and/or
+     * Enables the creation of a lightbox image (if possible) and/or
      * outputting the respective link attributes.
      *
      * This setting is disabled by default.
      */
-    public function enableLightBox(bool $enable = true): self
+    public function enableLightbox(bool $enable = true): self
     {
-        $this->enableLightBox = $enable;
+        $this->enableLightbox = $enable;
 
         return $this;
     }
@@ -467,8 +467,8 @@ class FigureBuilder
                 $settings
             ),
             \Closure::bind(
-                function (Figure $figure): ?LightBoxResult {
-                    return $this->onDefineLightBoxResult($figure);
+                function (Figure $figure): ?LightboxResult {
+                    return $this->onDefineLightboxResult($figure);
                 },
                 $settings
             ),
@@ -515,8 +515,8 @@ class FigureBuilder
     {
         $linkAttributes = [];
 
-        // Open in a new window if light box was requested but is invalid (fullsize)
-        if ($this->enableLightBox && !$result->hasLightBox()) {
+        // Open in a new window if lightbox was requested but is invalid (fullsize)
+        if ($this->enableLightbox && !$result->hasLightbox()) {
             $linkAttributes['target'] = '_blank';
         }
 
@@ -524,11 +524,11 @@ class FigureBuilder
     }
 
     /**
-     * Defines the light box result (if enabled) on demand.
+     * Defines the lightbox result (if enabled) on demand.
      */
-    private function onDefineLightBoxResult(Figure $result): ?LightBoxResult
+    private function onDefineLightboxResult(Figure $result): ?LightboxResult
     {
-        if (!$this->enableLightBox) {
+        if (!$this->enableLightbox) {
             return null;
         }
 
@@ -568,9 +568,9 @@ class FigureBuilder
         };
 
         // Use explicitly set data (1), fall back to using meta data (2) or use the base resource (3) if empty
-        $lightBoxResourceOrUrl = $this->lightBoxResourceOrUrl ?? $getMetaDataUrl() ?? $this->filePath;
+        $lightboxResourceOrUrl = $this->lightboxResourceOrUrl ?? $getMetaDataUrl() ?? $this->filePath;
 
-        [$filePathOrImage, $url] = $getResourceOrUrl($lightBoxResourceOrUrl);
+        [$filePathOrImage, $url] = $getResourceOrUrl($lightboxResourceOrUrl);
 
         if (null === $filePathOrImage && null === $url) {
             return null;
@@ -578,7 +578,7 @@ class FigureBuilder
 
         return $this->locator
             ->get(Studio::class)
-            ->createLightBoxImage($filePathOrImage, $url, $this->lightBoxSizeConfiguration, $this->lightBoxGroupIdentifier)
+            ->createLightboxImage($filePathOrImage, $url, $this->lightboxSizeConfiguration, $this->lightboxGroupIdentifier)
         ;
     }
 

--- a/core-bundle/src/Image/Studio/LightboxResult.php
+++ b/core-bundle/src/Image/Studio/LightboxResult.php
@@ -19,7 +19,7 @@ use Contao\PageModel;
 use Contao\StringUtil;
 use Psr\Container\ContainerInterface;
 
-class LightBoxResult
+class LightboxResult
 {
     /**
      * @var ContainerInterface
@@ -60,13 +60,13 @@ class LightBoxResult
         if (null !== $filePathOrImage) {
             $this->image = $locator
                 ->get(Studio::class)
-                ->createImage($filePathOrImage, $sizeConfiguration ?? $this->getDefaultLightBoxSizeConfiguration())
+                ->createImage($filePathOrImage, $sizeConfiguration ?? $this->getDefaultLightboxSizeConfiguration())
             ;
         }
     }
 
     /**
-     * Returns true if this light box result contains an image.
+     * Returns true if this lightbox result contains an image.
      */
     public function hasImage(): bool
     {
@@ -79,7 +79,7 @@ class LightBoxResult
     public function getImage(): ImageResult
     {
         if (!$this->hasImage()) {
-            throw new \RuntimeException('This light box result does not contain an image.');
+            throw new \RuntimeException('This lightbox result does not contain an image.');
         }
 
         return $this->image;
@@ -94,7 +94,7 @@ class LightBoxResult
     }
 
     /**
-     * Returns the light box group identifier.
+     * Returns the lightbox group identifier.
      */
     public function getGroupIdentifier(): string
     {
@@ -102,12 +102,12 @@ class LightBoxResult
     }
 
     /**
-     * Returns the light box size configuration from the associated page layout.
+     * Returns the lightbox size configuration from the associated page layout.
      *
-     * Will return null if there is no light box size configuration or if not
+     * Will return null if there is no lightbox size configuration or if not
      * in a request context.
      */
-    private function getDefaultLightBoxSizeConfiguration(): ?array
+    private function getDefaultLightboxSizeConfiguration(): ?array
     {
         $framework = $this->locator->get('contao.framework');
         $page = $GLOBALS['objPage'] ?? null;

--- a/core-bundle/src/Image/Studio/Studio.php
+++ b/core-bundle/src/Image/Studio/Studio.php
@@ -68,9 +68,9 @@ class Studio implements ServiceSubscriberInterface
      * @param string|ImageInterface|null                 $filePathOrImage
      * @param array|PictureConfiguration|int|string|null $sizeConfiguration
      */
-    public function createLightBoxImage($filePathOrImage, string $url = null, $sizeConfiguration = null, string $groupIdentifier = null): LightBoxResult
+    public function createLightboxImage($filePathOrImage, string $url = null, $sizeConfiguration = null, string $groupIdentifier = null): LightboxResult
     {
-        return new LightBoxResult($this->locator, $filePathOrImage, $url, $sizeConfiguration, $groupIdentifier);
+        return new LightboxResult($this->locator, $filePathOrImage, $url, $sizeConfiguration, $groupIdentifier);
     }
 
     public static function getSubscribedServices(): array

--- a/core-bundle/src/Resources/contao/library/Contao/Controller.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Controller.php
@@ -1517,10 +1517,10 @@ abstract class Controller extends System
 	 * @param object          $template                The template object to add the image to
 	 * @param array           $rowData                 The element or module as array
 	 * @param integer|null    $maxWidth                An optional maximum width of the image
-	 * @param string|null     $lightBoxGroupIdentifier An optional lightbox group identifier
+	 * @param string|null     $lightboxGroupIdentifier An optional lightbox group identifier
 	 * @param FilesModel|null $filesModel              An optional files model
 	 */
-	public static function addImageToTemplate($template, array $rowData, $maxWidth = null, $lightBoxGroupIdentifier = null, FilesModel $filesModel = null): void
+	public static function addImageToTemplate($template, array $rowData, $maxWidth = null, $lightboxGroupIdentifier = null, FilesModel $filesModel = null): void
 	{
 		// Helper: Create MetaData from the specified row data
 		$createMetaDataOverwriteFromRowData = static function (bool $interpretAsContentModel) use ($rowData)
@@ -1710,16 +1710,16 @@ abstract class Controller extends System
 			return;
 		}
 
-		// Set size and light box configuration
+		// Set size and lightbox configuration
 		list($size, $margin) = $getSizeAndMargin();
 
-		$lightBoxSize = StringUtil::deserialize($rowData['lightboxSize'] ?? null) ?: null;
+		$lightboxSize = StringUtil::deserialize($rowData['lightboxSize'] ?? null) ?: null;
 
 		$figure = $figureBuilder
 			->setSize($size)
-			->setLightBoxGroupIdentifier($lightBoxGroupIdentifier)
-			->setLightBoxSize($lightBoxSize)
-			->enableLightBox('1' === ($rowData['fullsize'] ?? null))
+			->setLightboxGroupIdentifier($lightboxGroupIdentifier)
+			->setLightboxSize($lightboxSize)
+			->enableLightbox('1' === ($rowData['fullsize'] ?? null))
 			->build();
 
 		// Build result and apply it to the template

--- a/core-bundle/src/Resources/views/Image/Studio/_macros.html.twig
+++ b/core-bundle/src/Resources/views/Image/Studio/_macros.html.twig
@@ -57,7 +57,7 @@
         {% if figure.linkHref -%}
             {%- set base_attributes = {
                 'href': figure.linkHref,
-                'title': figure.hasLightBox and figure.hasMetaData ? figure.metaData.title : null,
+                'title': figure.hasLightbox and figure.hasMetaData ? figure.metaData.title : null,
             }|merge(figure.linkAttributes) -%}
             <a{{ _self.html_attributes(base_attributes|merge(link_attributes)) }}>
                {{~ _self.picture(figure, options) }}

--- a/core-bundle/tests/Image/Studio/FigureBuilderIntegrationTest.php
+++ b/core-bundle/tests/Image/Studio/FigureBuilderIntegrationTest.php
@@ -71,9 +71,9 @@ class FigureBuilderIntegrationTest extends TestCase
      */
     public function testControllerAddImageToTemplate(\Closure $testCase, array $expectedTemplateData): void
     {
-        [$template, $dataRow, $maxWidth, $lightBoxGroupIdentifier, $filesModel] = $this->setUpTestCase($testCase);
+        [$template, $dataRow, $maxWidth, $lightboxGroupIdentifier, $filesModel] = $this->setUpTestCase($testCase);
 
-        Controller::addImageToTemplate($template, $dataRow, $maxWidth, $lightBoxGroupIdentifier, $filesModel);
+        Controller::addImageToTemplate($template, $dataRow, $maxWidth, $lightboxGroupIdentifier, $filesModel);
 
         $this->assertSameTemplateData($expectedTemplateData, $template);
     }
@@ -91,7 +91,7 @@ class FigureBuilderIntegrationTest extends TestCase
      *  <TestCase Closure> itself must return the following preconditions and arguments:
      *   [
      *     <FilesAdapter>|<Setup Closure>|[<FilesAdapter>, <Setup Closure>]|null,
-     *     [ $template, $dataRow, $maxWidth, $lightBoxGroupIdentifier, $filesModel ]
+     *     [ $template, $dataRow, $maxWidth, $lightboxGroupIdentifier, $filesModel ]
      *   ]
      */
     public function provideControllerAddImageToTemplateTestCases(): \Generator

--- a/core-bundle/tests/Image/Studio/FigureBuilderTest.php
+++ b/core-bundle/tests/Image/Studio/FigureBuilderTest.php
@@ -18,7 +18,7 @@ use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\CoreBundle\Image\Studio\Figure;
 use Contao\CoreBundle\Image\Studio\FigureBuilder;
 use Contao\CoreBundle\Image\Studio\ImageResult;
-use Contao\CoreBundle\Image\Studio\LightBoxResult;
+use Contao\CoreBundle\Image\Studio\LightboxResult;
 use Contao\CoreBundle\Image\Studio\Studio;
 use Contao\CoreBundle\Tests\TestCase;
 use Contao\FilesModel;
@@ -617,13 +617,13 @@ class FigureBuilderTest extends TestCase
         $this->assertSame('https://example.com', $figure->getLinkHref());
     }
 
-    public function testSetsTargetAttributeIfFullsizeWithoutLightBox(): void
+    public function testSetsTargetAttributeIfFullsizeWithoutLightbox(): void
     {
         $figure = $this->getFigure(
             static function (FigureBuilder $builder): void {
                 $builder
-                    ->setLightBoxResourceOrUrl('https://exampe.com/this-is-no-image')
-                    ->enableLightBox()
+                    ->setLightboxResourceOrUrl('https://exampe.com/this-is-no-image')
+                    ->enableLightbox()
                 ;
             }
         );
@@ -631,20 +631,20 @@ class FigureBuilderTest extends TestCase
         $this->assertSame('_blank', $figure->getLinkAttributes()['target']);
     }
 
-    public function testLightBoxIsDisabledByDefault(): void
+    public function testLightboxIsDisabledByDefault(): void
     {
         $figure = $this->getFigure();
 
-        $this->assertFalse($figure->hasLightBox());
+        $this->assertFalse($figure->hasLightbox());
     }
 
     /**
-     * @dataProvider provideLightBoxResourcesOrUrls
+     * @dataProvider provideLightboxResourcesOrUrls
      */
-    public function testSetLightBoxResourceOrUrl($resource, array $expectedArguments, bool $hasLightBox = true): void
+    public function testSetLightboxResourceOrUrl($resource, array $expectedArguments, bool $hasLightbox = true): void
     {
-        if ($hasLightBox) {
-            $studio = $this->getStudioMockForLightBox(...$expectedArguments);
+        if ($hasLightbox) {
+            $studio = $this->getStudioMockForLightbox(...$expectedArguments);
         } else {
             /** @var Studio&MockObject $studio */
             $studio = $this->createMock(Studio::class);
@@ -653,17 +653,17 @@ class FigureBuilderTest extends TestCase
         $figure = $this->getFigure(
             static function (FigureBuilder $builder) use ($resource): void {
                 $builder
-                    ->setLightBoxResourceOrUrl($resource)
-                    ->enableLightBox()
+                    ->setLightboxResourceOrUrl($resource)
+                    ->enableLightbox()
                 ;
             },
             $studio
         );
 
-        $this->assertSame($hasLightBox, $figure->hasLightBox());
+        $this->assertSame($hasLightbox, $figure->hasLightbox());
     }
 
-    public function provideLightBoxResourcesOrUrls(): \Generator
+    public function provideLightboxResourcesOrUrls(): \Generator
     {
         [$absoluteFilePath, $relativeFilePath, ,] = $this->getTestFilePaths();
 
@@ -707,26 +707,26 @@ class FigureBuilderTest extends TestCase
     }
 
     /**
-     * @dataProvider provideLightBoxFallbackResources
+     * @dataProvider provideLightboxFallbackResources
      */
-    public function testLightBoxResourceFallback(?MetaData $metaData, ?string $expectedFilePath, ?string $expectedUrl): void
+    public function testLightboxResourceFallback(?MetaData $metaData, ?string $expectedFilePath, ?string $expectedUrl): void
     {
-        $studio = $this->getStudioMockForLightBox($expectedFilePath, $expectedUrl);
+        $studio = $this->getStudioMockForLightbox($expectedFilePath, $expectedUrl);
 
         $figure = $this->getFigure(
             static function (FigureBuilder $builder) use ($metaData): void {
                 $builder
                     ->setMetaData($metaData)
-                    ->enableLightBox()
+                    ->enableLightbox()
                 ;
             },
             $studio
         );
 
-        $this->assertTrue($figure->hasLightBox());
+        $this->assertTrue($figure->hasLightbox());
     }
 
-    public function provideLightBoxFallbackResources(): \Generator
+    public function provideLightboxFallbackResources(): \Generator
     {
         [$absoluteFilePath, , ,] = $this->getTestFilePaths();
 
@@ -745,46 +745,46 @@ class FigureBuilderTest extends TestCase
         ];
     }
 
-    public function testSetLightBoxSize(): void
+    public function testSetLightboxSize(): void
     {
         /** @var ImageInterface&MockObject $image */
         $image = $this->createMock(ImageInterface::class);
         $size = '_custom_size_configuration';
-        $studio = $this->getStudioMockForLightBox($image, null, $size);
+        $studio = $this->getStudioMockForLightbox($image, null, $size);
 
         $figure = $this->getFigure(
             static function (FigureBuilder $builder) use ($image, $size): void {
                 $builder
-                    ->setLightBoxResourceOrUrl($image)
-                    ->setLightBoxSize($size)
-                    ->enableLightBox()
+                    ->setLightboxResourceOrUrl($image)
+                    ->setLightboxSize($size)
+                    ->enableLightbox()
                 ;
             },
             $studio
         );
 
-        $this->assertTrue($figure->hasLightBox());
+        $this->assertTrue($figure->hasLightbox());
     }
 
-    public function testSetLightBoxGroupIdentifier(): void
+    public function testSetLightboxGroupIdentifier(): void
     {
         /** @var ImageInterface&MockObject $image */
         $image = $this->createMock(ImageInterface::class);
         $groupIdentifier = '12345';
-        $studio = $this->getStudioMockForLightBox($image, null, null, $groupIdentifier);
+        $studio = $this->getStudioMockForLightbox($image, null, null, $groupIdentifier);
 
         $figure = $this->getFigure(
             static function (FigureBuilder $builder) use ($image, $groupIdentifier): void {
                 $builder
-                    ->setLightBoxResourceOrUrl($image)
-                    ->setLightBoxGroupIdentifier($groupIdentifier)
-                    ->enableLightBox()
+                    ->setLightboxResourceOrUrl($image)
+                    ->setLightboxGroupIdentifier($groupIdentifier)
+                    ->enableLightbox()
                 ;
             },
             $studio
         );
 
-        $this->assertTrue($figure->hasLightBox());
+        $this->assertTrue($figure->hasLightbox());
     }
 
     public function testSetTemplateOptions(): void
@@ -811,11 +811,11 @@ class FigureBuilderTest extends TestCase
         /** @var ImageResult&MockObject $imageResult2 */
         $imageResult2 = $this->createMock(ImageResult::class);
 
-        /** @var ImageInterface&MockObject $lightBoxResource */
-        $lightBoxResource = $this->createMock(ImageInterface::class);
+        /** @var ImageInterface&MockObject $lightboxResource */
+        $lightboxResource = $this->createMock(ImageInterface::class);
 
-        /** @var LightBoxResult&MockObject $lightBoxImageResult */
-        $lightBoxImageResult = $this->createMock(LightBoxResult::class);
+        /** @var LightboxResult&MockObject $lightboxImageResult */
+        $lightboxImageResult = $this->createMock(LightboxResult::class);
 
         /** @var Studio&MockObject $studio */
         $studio = $this->createMock(Studio::class);
@@ -830,9 +830,9 @@ class FigureBuilderTest extends TestCase
 
         $studio
             ->expects($this->once())
-            ->method('createLightBoxImage')
-            ->with($lightBoxResource)
-            ->willReturn($lightBoxImageResult)
+            ->method('createLightboxImage')
+            ->with($lightboxResource)
+            ->willReturn($lightboxImageResult)
         ;
 
         $builder = $this->getFigureBuilder($studio);
@@ -847,8 +847,8 @@ class FigureBuilderTest extends TestCase
         $builder
             ->fromPath($filePath2, false)
             ->setLinkAttribute('custom', 'bar')
-            ->setLightBoxResourceOrUrl($lightBoxResource)
-            ->enableLightBox()
+            ->setLightboxResourceOrUrl($lightboxResource)
+            ->enableLightbox()
         ;
 
         $figure2 = $builder->build();
@@ -856,12 +856,12 @@ class FigureBuilderTest extends TestCase
         $this->assertSame($imageResult1, $figure1->getImage());
         $this->assertSame('foo', $figure1->getLinkAttributes()['custom']); // not affected by reconfiguring
         $this->assertSame($metaData, $figure1->getMetaData());
-        $this->assertFalse($figure1->hasLightBox());
+        $this->assertFalse($figure1->hasLightbox());
 
         $this->assertSame($imageResult2, $figure2->getImage()); // other image
         $this->assertSame('bar', $figure2->getLinkAttributes()['custom']); // other link attribute
         $this->assertSame($metaData, $figure2->getMetaData()); // same meta data
-        $this->assertSame($lightBoxImageResult, $figure2->getLightBox());
+        $this->assertSame($lightboxImageResult, $figure2->getLightbox());
     }
 
     private function getFigure(\Closure $configureBuilderCallback = null, Studio $studio = null): Figure
@@ -904,18 +904,18 @@ class FigureBuilderTest extends TestCase
     /**
      * @return MockObject&Studio
      */
-    private function getStudioMockForLightBox($expectedResource, ?string $expectedUrl, $expectedSizeConfiguration = null, string $expectedGroupIdentifier = null)
+    private function getStudioMockForLightbox($expectedResource, ?string $expectedUrl, $expectedSizeConfiguration = null, string $expectedGroupIdentifier = null)
     {
-        /** @var LightBoxResult&MockObject $lightBox */
-        $lightBox = $this->createMock(LightBoxResult::class);
+        /** @var LightboxResult&MockObject $lightbox */
+        $lightbox = $this->createMock(LightboxResult::class);
 
         /** @var Studio&MockObject $studio */
         $studio = $this->createMock(Studio::class);
         $studio
             ->expects($this->once())
-            ->method('createLightBoxImage')
+            ->method('createLightboxImage')
             ->with($expectedResource, $expectedUrl, $expectedSizeConfiguration, $expectedGroupIdentifier)
-            ->willReturn($lightBox)
+            ->willReturn($lightbox)
         ;
 
         return $studio;

--- a/core-bundle/tests/Image/Studio/FigureTest.php
+++ b/core-bundle/tests/Image/Studio/FigureTest.php
@@ -15,7 +15,7 @@ namespace Contao\CoreBundle\Tests\Image\Studio;
 use Contao\CoreBundle\File\MetaData;
 use Contao\CoreBundle\Image\Studio\Figure;
 use Contao\CoreBundle\Image\Studio\ImageResult;
-use Contao\CoreBundle\Image\Studio\LightBoxResult;
+use Contao\CoreBundle\Image\Studio\LightboxResult;
 use Contao\CoreBundle\Tests\TestCase;
 use Contao\FrontendTemplate;
 use Contao\Image\ImageDimensions;
@@ -35,55 +35,55 @@ class FigureTest extends TestCase
         $this->assertSame($image, $figure->getImage());
     }
 
-    public function testHasNoLightBoxOrMetaDataByDefault(): void
+    public function testHasNoLightboxOrMetaDataByDefault(): void
     {
         /** @var ImageResult&MockObject $image */
         $image = $this->createMock(ImageResult::class);
         $figure = new Figure($image);
 
-        $this->assertFalse($figure->hasLightBox());
+        $this->assertFalse($figure->hasLightbox());
         $this->assertFalse($figure->hasMetaData());
     }
 
-    public function testGetLightBox(): void
+    public function testGetLightbox(): void
     {
         /** @var ImageResult&MockObject $image */
         $image = $this->createMock(ImageResult::class);
 
-        /** @var LightBoxResult&MockObject $lightBox */
-        $lightBox = $this->createMock(LightBoxResult::class);
-        $figure = new Figure($image, null, null, $lightBox);
+        /** @var LightboxResult&MockObject $lightbox */
+        $lightbox = $this->createMock(LightboxResult::class);
+        $figure = new Figure($image, null, null, $lightbox);
 
-        $this->assertTrue($figure->hasLightBox());
-        $this->assertSame($lightBox, $figure->getLightBox());
+        $this->assertTrue($figure->hasLightbox());
+        $this->assertSame($lightbox, $figure->getLightbox());
     }
 
-    public function testGetLightBoxSetViaCallback(): void
+    public function testGetLightboxSetViaCallback(): void
     {
         /** @var ImageResult&MockObject $image */
         $image = $this->createMock(ImageResult::class);
 
-        /** @var LightBoxResult&MockObject $lightBox */
-        $lightBox = $this->createMock(LightBoxResult::class);
+        /** @var LightboxResult&MockObject $lightbox */
+        $lightbox = $this->createMock(LightboxResult::class);
         $called = 0;
 
-        $lightBoxClosure = function (Figure $figure) use (&$called, $lightBox): LightBoxResult {
+        $lightboxClosure = function (Figure $figure) use (&$called, $lightbox): LightboxResult {
             $this->assertInstanceOf(Figure::class, $figure);
             ++$called;
 
-            return $lightBox;
+            return $lightbox;
         };
 
-        $figure = new Figure($image, null, null, $lightBoxClosure);
+        $figure = new Figure($image, null, null, $lightboxClosure);
 
-        $this->assertTrue($figure->hasLightBox());
-        $this->assertSame($lightBox, $figure->getLightBox());
+        $this->assertTrue($figure->hasLightbox());
+        $this->assertSame($lightbox, $figure->getLightbox());
 
-        $figure->getLightBox(); // second call should be cached
+        $figure->getLightbox(); // second call should be cached
         $this->assertSame(1, $called);
     }
 
-    public function testGetLightBoxFailsIfNotSet(): void
+    public function testGetLightboxFailsIfNotSet(): void
     {
         /** @var ImageResult&MockObject $image */
         $image = $this->createMock(ImageResult::class);
@@ -91,7 +91,7 @@ class FigureTest extends TestCase
 
         $this->expectException(\LogicException::class);
 
-        $figure->getLightBox();
+        $figure->getLightbox();
     }
 
     public function testGetMetaData(): void
@@ -147,9 +147,9 @@ class FigureTest extends TestCase
         /** @var ImageResult&MockObject $image */
         $image = $this->createMock(ImageResult::class);
 
-        [$attributes, $metaData, $lightBox] = $argumentsAndPreconditions;
+        [$attributes, $metaData, $lightbox] = $argumentsAndPreconditions;
 
-        $figure = new Figure($image, $metaData, $attributes, $lightBox);
+        $figure = new Figure($image, $metaData, $attributes, $lightbox);
 
         $this->assertSame($expectedAttributes, $figure->getLinkAttributes());
         $this->assertSame($expectedHref ?? '', $figure->getLinkHref());
@@ -158,14 +158,14 @@ class FigureTest extends TestCase
 
     public function provideLinkAttributesAndPreconditions(): \Generator
     {
-        /** @var LightBoxResult&MockObject $lightBox */
-        $lightBox = $this->createMock(LightBoxResult::class);
-        $lightBox
+        /** @var LightboxResult&MockObject $lightbox */
+        $lightbox = $this->createMock(LightboxResult::class);
+        $lightbox
             ->method('getLinkHref')
             ->willReturn('path/from/lightbox')
         ;
 
-        $lightBox
+        $lightbox
             ->method('getGroupIdentifier')
             ->willReturn('12345')
         ;
@@ -235,9 +235,9 @@ class FigureTest extends TestCase
             'this-will-win',
         ];
 
-        yield 'custom attributes and light box' => [
+        yield 'custom attributes and lightbox' => [
             [
-                ['foo' => 'a'], null, $lightBox,
+                ['foo' => 'a'], null, $lightbox,
             ],
             [
                 'foo' => 'a',
@@ -246,9 +246,9 @@ class FigureTest extends TestCase
             'path/from/lightbox',
         ];
 
-        yield 'custom attributes, meta data containing link and light box' => [
+        yield 'custom attributes, meta data containing link and lightbox' => [
             [
-                ['foo' => 'a'], new MetaData([MetaData::VALUE_URL => 'will-be-ignored']), $lightBox,
+                ['foo' => 'a'], new MetaData([MetaData::VALUE_URL => 'will-be-ignored']), $lightbox,
             ],
             [
                 'foo' => 'a',
@@ -267,7 +267,7 @@ class FigureTest extends TestCase
 
         yield 'custom attributes, force-set data-lightbox attribute and light-box' => [
             [
-                ['foo' => 'a', 'data-lightbox' => 'abcde'], new MetaData([MetaData::VALUE_URL => 'https://example.com']), $lightBox,
+                ['foo' => 'a', 'data-lightbox' => 'abcde'], new MetaData([MetaData::VALUE_URL => 'https://example.com']), $lightbox,
             ],
             [
                 'foo' => 'a',
@@ -324,12 +324,12 @@ class FigureTest extends TestCase
      */
     public function testGetLegacyTemplateData(array $preconditions, array $buildAttributes, \Closure $assert): void
     {
-        [$metaData, $linkAttributes, $lightBox] = $preconditions;
+        [$metaData, $linkAttributes, $lightbox] = $preconditions;
         [$includeFullMetaData, $floatingProperty, $marginProperty] = $buildAttributes;
 
         System::setContainer($this->getContainerWithContaoConfiguration());
 
-        $figure = new Figure($this->getImageMock(), $metaData, $linkAttributes, $lightBox);
+        $figure = new Figure($this->getImageMock(), $metaData, $linkAttributes, $lightbox);
         $data = $figure->getLegacyTemplateData($marginProperty, $floatingProperty, $includeFullMetaData);
 
         $assert($data);
@@ -439,46 +439,46 @@ class FigureTest extends TestCase
             },
         ];
 
-        /** @var ImageResult&MockObject $lightBoxImage */
-        $lightBoxImage = $this->createMock(ImageResult::class);
-        $lightBoxImage
+        /** @var ImageResult&MockObject $lightboxImage */
+        $lightboxImage = $this->createMock(ImageResult::class);
+        $lightboxImage
             ->method('getImg')
-            ->willReturn(['light box img'])
+            ->willReturn(['lightbox img'])
         ;
 
-        $lightBoxImage
+        $lightboxImage
             ->method('getSources')
-            ->willReturn(['light box sources'])
+            ->willReturn(['lightbox sources'])
         ;
 
-        /** @var LightBoxResult&MockObject $lightBox */
-        $lightBox = $this->createMock(LightBoxResult::class);
-        $lightBox
+        /** @var LightboxResult&MockObject $lightbox */
+        $lightbox = $this->createMock(LightboxResult::class);
+        $lightbox
             ->method('hasImage')
             ->willReturn(true)
         ;
 
-        $lightBox
+        $lightbox
             ->method('getImage')
-            ->willReturn($lightBoxImage)
+            ->willReturn($lightboxImage)
         ;
 
-        $lightBox
+        $lightbox
             ->method('getGroupIdentifier')
             ->willReturn('12345')
         ;
 
-        $lightBox
+        $lightbox
             ->method('getLinkHref')
             ->willReturn('foo://bar')
         ;
 
-        yield 'with light box' => [
-            [null, null, $lightBox],
+        yield 'with lightbox' => [
+            [null, null, $lightbox],
             [false, null, null],
             function (array $data): void {
-                $this->assertSame(['light box img'], $data['lightboxPicture']['img']);
-                $this->assertSame(['light box sources'], $data['lightboxPicture']['sources']);
+                $this->assertSame(['lightbox img'], $data['lightboxPicture']['img']);
+                $this->assertSame(['lightbox sources'], $data['lightboxPicture']['sources']);
 
                 $this->assertSame('foo://bar', $data['href']);
                 $this->assertSame(' data-lightbox="12345"', $data['attributes']);

--- a/core-bundle/tests/Image/Studio/LightboxResultTest.php
+++ b/core-bundle/tests/Image/Studio/LightboxResultTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Tests\Image\Studio;
 
 use Contao\CoreBundle\Image\Studio\ImageResult;
-use Contao\CoreBundle\Image\Studio\LightBoxResult;
+use Contao\CoreBundle\Image\Studio\LightboxResult;
 use Contao\CoreBundle\Image\Studio\Studio;
 use Contao\CoreBundle\Tests\TestCase;
 use Contao\LayoutModel;
@@ -21,7 +21,7 @@ use Contao\PageModel;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Container\ContainerInterface;
 
-class LightBoxResultTest extends TestCase
+class LightboxResultTest extends TestCase
 {
     /**
      * @dataProvider provideInvalidConfigurations
@@ -33,7 +33,7 @@ class LightBoxResultTest extends TestCase
 
         $this->expectException(\InvalidArgumentException::class);
 
-        new LightBoxResult($locator, $resource, $url);
+        new LightboxResult($locator, $resource, $url);
     }
 
     public function provideInvalidConfigurations(): \Generator
@@ -43,7 +43,7 @@ class LightBoxResultTest extends TestCase
         yield 'both set' => ['foo', 'bar'];
     }
 
-    public function testUsesFallBackLightBoxSizeConfiguration(): void
+    public function testUsesFallBackLightboxSizeConfiguration(): void
     {
         $resource = 'foo/bar.png';
         $size = [100, 200, 'crop'];
@@ -91,12 +91,12 @@ class LightBoxResultTest extends TestCase
             ])
         ;
 
-        new LightBoxResult($locator, $resource, null);
+        new LightboxResult($locator, $resource, null);
 
         unset($GLOBALS['objPage']);
     }
 
-    public function testFallBackLightBoxSizeConfigurationFailsIfNoLightBoxSizeSet(): void
+    public function testFallBackLightboxSizeConfigurationFailsIfNoLightboxSizeSet(): void
     {
         $resource = 'foo/bar.png';
         $layoutId = '1';
@@ -143,12 +143,12 @@ class LightBoxResultTest extends TestCase
             ])
         ;
 
-        new LightBoxResult($locator, $resource, null);
+        new LightboxResult($locator, $resource, null);
 
         unset($GLOBALS['objPage']);
     }
 
-    public function testFallBackLightBoxSizeConfigurationFailsIfNoPage(): void
+    public function testFallBackLightboxSizeConfigurationFailsIfNoPage(): void
     {
         $resource = 'foo/bar.png';
         $framework = $this->mockContaoFramework();
@@ -177,7 +177,7 @@ class LightBoxResultTest extends TestCase
         ;
 
         // Note: $GLOBALS['objPage'] is not set at this point
-        new LightBoxResult($locator, $resource, null);
+        new LightboxResult($locator, $resource, null);
     }
 
     public function testHasImage(): void
@@ -206,18 +206,18 @@ class LightBoxResultTest extends TestCase
             ->willReturn($studio)
         ;
 
-        $lightBoxResult = new LightBoxResult($locator, $resource, null, $size);
+        $lightboxResult = new LightboxResult($locator, $resource, null, $size);
 
-        $this->assertTrue($lightBoxResult->hasImage());
+        $this->assertTrue($lightboxResult->hasImage());
     }
 
     public function testHasNoImage(): void
     {
         /** @var MockObject&ContainerInterface $locator */
         $locator = $this->createMock(ContainerInterface::class);
-        $lightBoxResult = new LightBoxResult($locator, null, 'foo://bar');
+        $lightboxResult = new LightboxResult($locator, null, 'foo://bar');
 
-        $this->assertFalse($lightBoxResult->hasImage());
+        $this->assertFalse($lightboxResult->hasImage());
     }
 
     public function testGetImage(): void
@@ -246,20 +246,20 @@ class LightBoxResultTest extends TestCase
             ->willReturn($studio)
         ;
 
-        $lightBoxResult = new LightBoxResult($locator, $resource, null, $size);
+        $lightboxResult = new LightboxResult($locator, $resource, null, $size);
 
-        $this->assertSame($image, $lightBoxResult->getImage());
+        $this->assertSame($image, $lightboxResult->getImage());
     }
 
     public function testGetImageThrowsIfNoImageWasSet(): void
     {
         /** @var MockObject&ContainerInterface $locator */
         $locator = $this->createMock(ContainerInterface::class);
-        $lightBoxResult = new LightBoxResult($locator, null, 'foo://bar');
+        $lightboxResult = new LightboxResult($locator, null, 'foo://bar');
 
         $this->expectException(\RuntimeException::class);
 
-        $lightBoxResult->getImage();
+        $lightboxResult->getImage();
     }
 
     public function testGetLinkHrefForImageResource(): void
@@ -293,35 +293,35 @@ class LightBoxResultTest extends TestCase
             ->willReturn($studio)
         ;
 
-        $lightBoxResult = new LightBoxResult($locator, $resource, null, $size);
+        $lightboxResult = new LightboxResult($locator, $resource, null, $size);
 
-        $this->assertSame('foobar.png', $lightBoxResult->getLinkHref());
+        $this->assertSame('foobar.png', $lightboxResult->getLinkHref());
     }
 
     public function testGetLinkHrefForUrl(): void
     {
         /** @var MockObject&ContainerInterface $locator */
         $locator = $this->createMock(ContainerInterface::class);
-        $lightBoxResult = new LightBoxResult($locator, null, 'foo://bar');
+        $lightboxResult = new LightboxResult($locator, null, 'foo://bar');
 
-        $this->assertSame('foo://bar', $lightBoxResult->getLinkHref());
+        $this->assertSame('foo://bar', $lightboxResult->getLinkHref());
     }
 
     public function testGetGroupIdentifierIfExplicitlySet(): void
     {
         /** @var MockObject&ContainerInterface $locator */
         $locator = $this->createMock(ContainerInterface::class);
-        $lightBoxResult = new LightBoxResult($locator, null, 'foo://bar', null, '12345');
+        $lightboxResult = new LightboxResult($locator, null, 'foo://bar', null, '12345');
 
-        $this->assertSame('12345', $lightBoxResult->getGroupIdentifier());
+        $this->assertSame('12345', $lightboxResult->getGroupIdentifier());
     }
 
     public function testGroupIdentifierIsEmptyIfNotExplicitlySet(): void
     {
         /** @var MockObject&ContainerInterface $locator */
         $locator = $this->createMock(ContainerInterface::class);
-        $lightBoxResult = new LightBoxResult($locator, null, 'foo://bar');
+        $lightboxResult = new LightboxResult($locator, null, 'foo://bar');
 
-        $this->assertSame('', $lightBoxResult->getGroupIdentifier());
+        $this->assertSame('', $lightboxResult->getGroupIdentifier());
     }
 }

--- a/core-bundle/tests/Twig/Runtime/FigureRendererRuntimeTest.php
+++ b/core-bundle/tests/Twig/Runtime/FigureRendererRuntimeTest.php
@@ -34,10 +34,10 @@ class FigureRendererRuntimeTest extends TestCase
             'locale' => 'de',
             'linkAttributes' => ['foo' => 'bar'],
             'linkHref' => 'foo',
-            'lightBoxResourceOrUrl' => 'foobar',
-            'lightBoxSize' => '_lightbox_size',
-            'lightBoxGroupIdentifier' => '123',
-            'enableLightBox' => true,
+            'lightboxResourceOrUrl' => 'foobar',
+            'lightboxSize' => '_lightbox_size',
+            'lightboxGroupIdentifier' => '123',
+            'enableLightbox' => true,
             'options' => ['foo' => 'bar'],
         ];
 
@@ -49,10 +49,10 @@ class FigureRendererRuntimeTest extends TestCase
             'setLocale' => 'de',
             'setLinkAttributes' => ['foo' => 'bar'],
             'setLinkHref' => 'foo',
-            'setLightBoxResourceOrUrl' => 'foobar',
-            'setLightBoxSize' => '_lightbox_size',
-            'setLightBoxGroupIdentifier' => '123',
-            'enableLightBox' => true,
+            'setLightboxResourceOrUrl' => 'foobar',
+            'setLightboxSize' => '_lightbox_size',
+            'setLightboxGroupIdentifier' => '123',
+            'enableLightbox' => true,
             'setOptions' => ['foo' => 'bar'],
         ];
 


### PR DESCRIPTION
"Lightbox" should be a single word. 

see https://en.wikipedia.org/wiki/Lightbox_(JavaScript)

Thanks @ausi for pointing this out.