### PR TITLE
Clean up the routing changes

### DIFF
--- a/core-bundle/src/Resources/config/services.yml
+++ b/core-bundle/src/Resources/config/services.yml
@@ -211,7 +211,10 @@ services:
     contao.data_collector:
         class: Contao\CoreBundle\DataCollector\ContaoDataCollector
         arguments:
-            - '@parameter_bag'
+            - '%contao.legacy_routing%'
+            - '%kernel.project_dir%'
+            - '%contao.prepend_locale%'
+            - '%contao.url_suffix%'
         tags:
             - { name: data_collector, template: '@ContaoCore/Collector/contao.html.twig', id: contao }
 

--- a/core-bundle/src/Resources/contao/classes/Frontend.php
+++ b/core-bundle/src/Resources/contao/classes/Frontend.php
@@ -411,6 +411,7 @@ abstract class Frontend extends Controller
 	 */
 	public static function addToUrl($strRequest, $blnIgnoreParams=false, $arrUnset=array())
 	{
+		/** @var PageModel $objPage */
 		global $objPage;
 
 		$arrGet = $blnIgnoreParams ? array() : $_GET;

--- a/core-bundle/src/Resources/contao/controllers/FrontendIndex.php
+++ b/core-bundle/src/Resources/contao/controllers/FrontendIndex.php
@@ -87,6 +87,7 @@ class FrontendIndex extends Frontend
 	 */
 	public function renderPage($pageModel)
 	{
+		/** @var PageModel $objPage */
 		global $objPage;
 
 		$objPage = $pageModel;

--- a/core-bundle/src/Resources/contao/elements/ContentDownload.php
+++ b/core-bundle/src/Resources/contao/elements/ContentDownload.php
@@ -89,6 +89,7 @@ class ContentDownload extends ContentElement
 
 		if (TL_MODE == 'FE')
 		{
+			/** @var PageModel $objPage */
 			global $objPage;
 
 			$arrMeta = Frontend::getMetaData($this->objFile->meta, $objPage->language);

--- a/core-bundle/src/Resources/contao/library/Contao/Controller.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Controller.php
@@ -863,6 +863,7 @@ abstract class Controller extends System
 			}
 		}
 
+		/** @var PageModel $objPage */
 		global $objPage;
 
 		$objLayout = LayoutModel::findByPk($objPage->layoutId);

--- a/core-bundle/tests/Controller/Page/RootPageControllerTest.php
+++ b/core-bundle/tests/Controller/Page/RootPageControllerTest.php
@@ -71,7 +71,7 @@ class RootPageControllerTest extends TestCase
 
         $this->expectException(\InvalidArgumentException::class);
 
-        $this->controller->__invoke($page);
+        ($this->controller)($page);
     }
 
     public function testThrowsExceptionIfFirstPageOfRootIsNotFound(): void
@@ -88,7 +88,7 @@ class RootPageControllerTest extends TestCase
 
         $this->expectException(NoActivePageFoundException::class);
 
-        $this->controller->__invoke($page);
+        ($this->controller)($page);
     }
 
     public function testCreatesRedirectResponseToFirstPage(): void
@@ -114,7 +114,7 @@ class RootPageControllerTest extends TestCase
         ;
 
         /** @var RedirectResponse $response */
-        $response = $this->controller->__invoke($page);
+        $response = ($this->controller)($page);
 
         $this->assertInstanceOf(RedirectResponse::class, $response);
         $this->assertSame('https://www.example.org/en/foobar.html', $response->getTargetUrl());

--- a/core-bundle/tests/DataCollector/ContaoDataCollectorTest.php
+++ b/core-bundle/tests/DataCollector/ContaoDataCollectorTest.php
@@ -23,8 +23,6 @@ use Contao\LayoutModel;
 use Contao\PageModel;
 use Contao\System;
 use PHPUnit\Framework\MockObject\MockObject;
-use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
-use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -39,7 +37,7 @@ class ContaoDataCollectorTest extends TestCase
             'additional_data' => 'data',
         ];
 
-        $collector = new ContaoDataCollector($this->createParameterBag());
+        $collector = $this->getDataCollector();
         $collector->collect(new Request(), new Response());
 
         $this->assertSame(['ContentText' => ContentText::class], $collector->getClassesAliased());
@@ -86,7 +84,7 @@ class ContaoDataCollectorTest extends TestCase
 
         $GLOBALS['objPage'] = $page;
 
-        $collector = new ContaoDataCollector($this->createParameterBag());
+        $collector = $this->getDataCollector();
         $collector->setFramework($framework);
         $collector->collect(new Request(), new Response());
 
@@ -113,7 +111,7 @@ class ContaoDataCollectorTest extends TestCase
 
     public function testStoresTheLegacyRoutingData(bool $legacyRouting = false, bool $prependLocale = false, string $urlSuffix = '.html'): void
     {
-        $collector = new ContaoDataCollector($this->createParameterBag($legacyRouting, $prependLocale, $urlSuffix));
+        $collector = $this->getDataCollector($legacyRouting, $prependLocale, $urlSuffix);
         $collector->collect(new Request(), new Response());
 
         $this->assertSame(
@@ -159,10 +157,7 @@ class ContaoDataCollectorTest extends TestCase
 
         $framework = $this->mockContaoFramework([System::class => $systemAdapter]);
 
-        $parameterBag = $this->createParameterBag(true);
-        $parameterBag->set('kernel.project_dir', \dirname(__DIR__).'/Fixtures/DataCollector');
-
-        $collector = new ContaoDataCollector($parameterBag);
+        $collector = $this->getDataCollector(true);
         $collector->setFramework($framework);
         $collector->collect(new Request(), new Response());
 
@@ -179,7 +174,7 @@ class ContaoDataCollectorTest extends TestCase
 
     public function testReturnsAnEmptyArrayIfTheKeyIsUnknown(): void
     {
-        $collector = new ContaoDataCollector($this->createParameterBag());
+        $collector = $this->getDataCollector();
 
         $method = new \ReflectionMethod($collector, 'getData');
         $method->setAccessible(true);
@@ -187,12 +182,8 @@ class ContaoDataCollectorTest extends TestCase
         $this->assertSame([], $method->invokeArgs($collector, ['foo']));
     }
 
-    private function createParameterBag(bool $legacyRouting = false, bool $prependLocale = false, string $urlSuffix = '.html'): ParameterBagInterface
+    private function getDataCollector(bool $legacyRouting = false, bool $prependLocale = false, string $urlSuffix = '.html'): ContaoDataCollector
     {
-        return new ParameterBag([
-            'contao.legacy_routing' => $legacyRouting,
-            'contao.prepend_locale' => $prependLocale,
-            'contao.url_suffix' => $urlSuffix,
-        ]);
+        return new ContaoDataCollector($legacyRouting, \dirname(__DIR__).'/Fixtures/DataCollector', $prependLocale, $urlSuffix);
     }
 }

--- a/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
+++ b/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
@@ -1722,6 +1722,16 @@ class ContaoCoreExtensionTest extends TestCase
         $this->assertSame(ContaoDataCollector::class, $definition->getClass());
         $this->assertTrue($definition->isPrivate());
 
+        $this->assertEquals(
+            [
+                new Reference('%contao.legacy_routing%'),
+                new Reference('%kernel.project_dir%'),
+                new Reference('%contao.prepend_locale%'),
+                new Reference('%contao.url_suffix%'),
+            ],
+            $definition->getArguments()
+        );
+
         $this->assertSame(
             [
                 'data_collector' => [
@@ -2552,6 +2562,12 @@ class ContaoCoreExtensionTest extends TestCase
         $this->assertTrue($definition->isPrivate());
     }
 
+    /**
+     * @group legacy
+     *
+     * @expectedDeprecation The language prefix is configured per root page since Contao 4.10. Enabling this option will activate legacy routing.
+     * @expectedDeprecation The URL suffix is configured per root page since Contao 4.10. Enabling this option will activate legacy routing.
+     */
     public function testRegistersTheRoutingFrontendLoaderInLegacyMode(): void
     {
         $container = $this->getContainerBuilder();
@@ -2685,6 +2701,12 @@ class ContaoCoreExtensionTest extends TestCase
         $this->assertSame([], $definition->getArguments());
     }
 
+    /**
+     * @group legacy
+     *
+     * @expectedDeprecation The language prefix is configured per root page since Contao 4.10. Enabling this option will activate legacy routing.
+     * @expectedDeprecation The URL suffix is configured per root page since Contao 4.10. Enabling this option will activate legacy routing.
+     */
     public function testRegistersTheRoutingLegacyMatcher(): void
     {
         $container = $this->getContainerBuilder();
@@ -2728,6 +2750,11 @@ class ContaoCoreExtensionTest extends TestCase
         );
     }
 
+    /**
+     * @group legacy
+     *
+     * @expectedDeprecation The URL suffix is configured per root page since Contao 4.10. Enabling this option will activate legacy routing.
+     */
     public function testRegistersTheRoutingLegacyRouteProvider(): void
     {
         $container = $this->getContainerBuilder();
@@ -2991,6 +3018,11 @@ class ContaoCoreExtensionTest extends TestCase
         );
     }
 
+    /**
+     * @group legacy
+     *
+     * @expectedDeprecation The URL suffix is configured per root page since Contao 4.10. Enabling this option will activate legacy routing.
+     */
     public function testRegistersTheRoutingUrlGeneratorInLegacyMode(): void
     {
         $container = $this->getContainerBuilder();

--- a/core-bundle/tests/Functional/Migration/RoutingMigrationTest.php
+++ b/core-bundle/tests/Functional/Migration/RoutingMigrationTest.php
@@ -18,16 +18,12 @@ use Doctrine\DBAL\Connection;
 
 class RoutingMigrationTest extends FunctionalTestCase
 {
-    protected function setUp(): void
-    {
-        static::bootKernel();
-    }
-
     /**
      * @dataProvider shouldRunProvider
      */
     public function testShouldRun(array $dropFields, bool $expected): void
     {
+        static::bootKernel();
         static::resetDatabaseSchema();
 
         /** @var Connection $connection */
@@ -67,6 +63,7 @@ class RoutingMigrationTest extends FunctionalTestCase
 
     public function testMigratesSchema(): void
     {
+        static::bootKernel();
         static::resetDatabaseSchema();
 
         /** @var Connection $connection */
@@ -94,6 +91,7 @@ class RoutingMigrationTest extends FunctionalTestCase
      */
     public function testMigratesData(bool $prependLocale, string $urlSuffix): void
     {
+        static::bootKernel();
         static::resetDatabaseSchema();
         static::loadFixtures([__DIR__.'/../../Fixtures/Functional/Migration/routing.yml'], false);
 

--- a/core-bundle/tests/Functional/RoutingTest.php
+++ b/core-bundle/tests/Functional/RoutingTest.php
@@ -36,7 +36,6 @@ class RoutingTest extends FunctionalTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        static::bootKernel();
 
         $_GET = [];
 
@@ -79,8 +78,6 @@ class RoutingTest extends FunctionalTestCase
      */
     public function testResolvesAliasesInLegacyMode(array $fixtures, string $request, int $statusCode, string $pageTitle, array $query, string $host, bool $autoItem): void
     {
-        $this->loadFixtureFiles($fixtures);
-
         Config::set('useAutoItem', $autoItem);
 
         $_SERVER['REQUEST_URI'] = $request;
@@ -88,6 +85,8 @@ class RoutingTest extends FunctionalTestCase
 
         $client = $this->createClient(['environment' => 'legacy'], $_SERVER);
         System::setContainer($client->getContainer());
+
+        $this->loadFixtureFiles($fixtures);
 
         $crawler = $client->request('GET', $request);
         $title = trim($crawler->filterXPath('//head/title')->text());
@@ -358,14 +357,6 @@ class RoutingTest extends FunctionalTestCase
      */
     public function testResolvesAliasesWithLocale(array $fixtures, string $request, int $statusCode, string $pageTitle, array $query, string $host, bool $autoItem): void
     {
-        $this->loadFixtureFiles($fixtures);
-
-        self::$container
-            ->get('doctrine')
-            ->getConnection()
-            ->exec('UPDATE tl_page SET urlPrefix=language')
-        ;
-
         Config::set('useAutoItem', $autoItem);
 
         $_SERVER['REQUEST_URI'] = $request;
@@ -373,6 +364,14 @@ class RoutingTest extends FunctionalTestCase
 
         $client = $this->createClient([], $_SERVER);
         System::setContainer($client->getContainer());
+
+        $this->loadFixtureFiles($fixtures);
+
+        self::$container
+            ->get('doctrine')
+            ->getConnection()
+            ->exec('UPDATE tl_page SET urlPrefix=language')
+        ;
 
         $crawler = $client->request('GET', $request);
         $title = trim($crawler->filterXPath('//head/title')->text());
@@ -393,8 +392,6 @@ class RoutingTest extends FunctionalTestCase
      */
     public function testResolvesAliasesWithLocaleInLegacyMode(array $fixtures, string $request, int $statusCode, string $pageTitle, array $query, string $host, bool $autoItem): void
     {
-        $this->loadFixtureFiles($fixtures);
-
         Config::set('useAutoItem', $autoItem);
         Config::set('addLanguageToUrl', true);
 
@@ -679,14 +676,6 @@ class RoutingTest extends FunctionalTestCase
      */
     public function testResolvesAliasesWithoutUrlSuffix(array $fixtures, string $request, int $statusCode, string $pageTitle, array $query, string $host, bool $autoItem): void
     {
-        $this->loadFixtureFiles($fixtures);
-
-        self::$container
-            ->get('doctrine')
-            ->getConnection()
-            ->exec("UPDATE tl_page SET urlSuffix=''")
-        ;
-
         Config::set('useAutoItem', $autoItem);
 
         $_SERVER['REQUEST_URI'] = $request;
@@ -694,6 +683,14 @@ class RoutingTest extends FunctionalTestCase
 
         $client = $this->createClient([], $_SERVER);
         System::setContainer($client->getContainer());
+
+        $this->loadFixtureFiles($fixtures);
+
+        self::$container
+            ->get('doctrine')
+            ->getConnection()
+            ->exec("UPDATE tl_page SET urlSuffix=''")
+        ;
 
         $crawler = $client->request('GET', $request);
         $title = trim($crawler->filterXPath('//head/title')->text());
@@ -714,8 +711,6 @@ class RoutingTest extends FunctionalTestCase
      */
     public function testResolvesAliasesWithoutUrlSuffixInLegacyMode(array $fixtures, string $request, int $statusCode, string $pageTitle, array $query, string $host, bool $autoItem): void
     {
-        $this->loadFixtureFiles($fixtures);
-
         Config::set('useAutoItem', $autoItem);
 
         $_SERVER['REQUEST_URI'] = $request;
@@ -1034,6 +1029,13 @@ class RoutingTest extends FunctionalTestCase
      */
     public function testResolvesTheRootPageWithLocale(array $fixtures, string $request, int $statusCode, string $pageTitle, string $acceptLanguages, string $host): void
     {
+        $_SERVER['REQUEST_URI'] = $request;
+        $_SERVER['HTTP_HOST'] = $host;
+        $_SERVER['HTTP_ACCEPT_LANGUAGE'] = $acceptLanguages;
+
+        $client = $this->createClient([], $_SERVER);
+        System::setContainer($client->getContainer());
+
         $this->loadFixtureFiles($fixtures);
 
         self::$container
@@ -1041,13 +1043,6 @@ class RoutingTest extends FunctionalTestCase
             ->getConnection()
             ->exec('UPDATE tl_page SET urlPrefix=language')
         ;
-
-        $_SERVER['REQUEST_URI'] = $request;
-        $_SERVER['HTTP_HOST'] = $host;
-        $_SERVER['HTTP_ACCEPT_LANGUAGE'] = $acceptLanguages;
-
-        $client = $this->createClient([], $_SERVER);
-        System::setContainer($client->getContainer());
 
         $crawler = $client->request('GET', $request);
         $title = trim($crawler->filterXPath('//head/title')->text());
@@ -1067,8 +1062,6 @@ class RoutingTest extends FunctionalTestCase
      */
     public function testResolvesTheRootPageWithLocaleInLegacyMode(array $fixtures, string $request, int $statusCode, string $pageTitle, string $acceptLanguages, string $host): void
     {
-        $this->loadFixtureFiles($fixtures);
-
         Config::set('addLanguageToUrl', true);
 
         $_SERVER['REQUEST_URI'] = $request;


### PR DESCRIPTION
This is a follow-up PR to #1516, which

- injects the parameters instead of the parameter bag into the data collector;
- adds the missing inline `@var` declarations for `global $objPage`;
- invokes the controllers without explicitly calling the `__invoke()` method;
- adds the missing `@expectedDeprecation` tags to the core extension tests;
- does not boot the kernel twice in the functional tests (forward compatibility with Symfony 5).