### PR TITLE
Convert non existing $_POST fields to an empty string

### DIFF
--- a/core-bundle/src/EventListener/DataContainer/PageUrlListener.php
+++ b/core-bundle/src/EventListener/DataContainer/PageUrlListener.php
@@ -261,9 +261,9 @@ class PageUrlListener implements ServiceAnnotationInterface, ResetInterface
             $input = $this->framework->getAdapter(Input::class);
 
             // TODO: this won't work in edit-all, in legacy mode or if user does not have access to these fields
-            $currentDomain = $input->post('dns');
-            $currentPrefix = $input->post('urlPrefix');
-            $currentSuffix = $input->post('urlSuffix');
+            $currentDomain = $input->post('dns') ?: '';
+            $currentPrefix = $input->post('urlPrefix') ?: '';
+            $currentSuffix = $input->post('urlSuffix') ?: '';
         }
 
         $aliasIds = $this->connection


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #1958
| Docs PR or issue | -

Until we have discussed the code (see #1955), this PR will fix the issue mentioned in #1958.