### PR TITLE
Add priority to migrations

### DIFF
--- a/core-bundle/src/Resources/config/migrations.yml
+++ b/core-bundle/src/Resources/config/migrations.yml
@@ -8,3 +8,5 @@ services:
         arguments:
             - '@database_connection'
             - '@contao.framework'
+        tags:
+            - { name: contao.migration, priority: 25 }

--- a/installation-bundle/src/Resources/config/migrations.yml
+++ b/installation-bundle/src/Resources/config/migrations.yml
@@ -5,39 +5,57 @@ services:
     Contao\InstallationBundle\Database\Version330Update:
         arguments:
             - '@database_connection'
+        tags:
+            - { name: contao.migration, priority: 50 }
 
     Contao\InstallationBundle\Database\Version350Update:
         arguments:
             - '@database_connection'
+        tags:
+            - { name: contao.migration, priority: 50 }
 
     Contao\InstallationBundle\Database\Version400Update:
         arguments:
             - '@database_connection'
+        tags:
+            - { name: contao.migration, priority: 50 }
 
     Contao\InstallationBundle\Database\Version410Update:
         arguments:
             - '@database_connection'
+        tags:
+            - { name: contao.migration, priority: 50 }
 
     Contao\InstallationBundle\Database\Version430Update:
         arguments:
             - '@database_connection'
+        tags:
+            - { name: contao.migration, priority: 50 }
 
     Contao\InstallationBundle\Database\Version440Update:
         arguments:
             - '@database_connection'
+        tags:
+            - { name: contao.migration, priority: 50 }
 
     Contao\InstallationBundle\Database\Version447Update:
         arguments:
             - '@database_connection'
             - '@translator'
+        tags:
+            - { name: contao.migration, priority: 50 }
 
     Contao\InstallationBundle\Database\Version450Update:
         arguments:
             - '@database_connection'
+        tags:
+            - { name: contao.migration, priority: 50 }
 
     Contao\InstallationBundle\Database\Version460Update:
         arguments:
             - '@database_connection'
+        tags:
+            - { name: contao.migration, priority: 50 }
 
     Contao\InstallationBundle\Database\Version470Update:
         arguments:
@@ -45,8 +63,12 @@ services:
             - '@filesystem'
             - '%contao.upload_path%'
             - '%kernel.project_dir%'
+        tags:
+            - { name: contao.migration, priority: 50 }
 
     Contao\InstallationBundle\Database\Version480Update:
         arguments:
             - '@database_connection'
             - '%kernel.project_dir%'
+        tags:
+            - { name: contao.migration, priority: 50 }


### PR DESCRIPTION
Without this priority, the core migrations will (potentially) be executed before migrations from the application or bundles without migration priority.