### PR TITLE
Prevent type errors in the button callback functions

### DIFF
--- a/core-bundle/src/EventListener/DataContainer/ContentCompositionListener.php
+++ b/core-bundle/src/EventListener/DataContainer/ContentCompositionListener.php
@@ -93,7 +93,7 @@ class ContentCompositionListener implements ServiceAnnotationInterface
     /**
      * @Callback(table="tl_page", target="list.operations.articles.button")
      */
-    public function renderPageArticlesOperation(array $row, string $href, string $label, string $title, string $icon): string
+    public function renderPageArticlesOperation(array $row, ?string $href, string $label, string $title, ?string $icon): string
     {
         if (!$this->security->isGranted(ContaoCorePermissions::USER_CAN_ACCESS_MODULE, 'article')) {
             return '';

--- a/core-bundle/src/Resources/contao/classes/DataContainer.php
+++ b/core-bundle/src/Resources/contao/classes/DataContainer.php
@@ -800,13 +800,13 @@ abstract class DataContainer extends Backend
 			if (\is_array($v['button_callback']))
 			{
 				$this->import($v['button_callback'][0]);
-				$return .= $this->{$v['button_callback'][0]}->{$v['button_callback'][1]}($arrRow, $v['href'] ?? '', $label, $title, $v['icon'] ?? '', $attributes, $strTable, $arrRootIds, $arrChildRecordIds, $blnCircularReference, $strPrevious, $strNext, $this);
+				$return .= $this->{$v['button_callback'][0]}->{$v['button_callback'][1]}($arrRow, $v['href'], $label, $title, $v['icon'], $attributes, $strTable, $arrRootIds, $arrChildRecordIds, $blnCircularReference, $strPrevious, $strNext, $this);
 				continue;
 			}
 
 			if (\is_callable($v['button_callback']))
 			{
-				$return .= $v['button_callback']($arrRow, $v['href'] ?? '', $label, $title, $v['icon'] ?? '', $attributes, $strTable, $arrRootIds, $arrChildRecordIds, $blnCircularReference, $strPrevious, $strNext, $this);
+				$return .= $v['button_callback']($arrRow, $v['href'], $label, $title, $v['icon'], $attributes, $strTable, $arrRootIds, $arrChildRecordIds, $blnCircularReference, $strPrevious, $strNext, $this);
 				continue;
 			}
 

--- a/core-bundle/src/Resources/contao/classes/DataContainer.php
+++ b/core-bundle/src/Resources/contao/classes/DataContainer.php
@@ -800,13 +800,13 @@ abstract class DataContainer extends Backend
 			if (\is_array($v['button_callback']))
 			{
 				$this->import($v['button_callback'][0]);
-				$return .= $this->{$v['button_callback'][0]}->{$v['button_callback'][1]}($arrRow, $v['href'], $label, $title, $v['icon'], $attributes, $strTable, $arrRootIds, $arrChildRecordIds, $blnCircularReference, $strPrevious, $strNext, $this);
+				$return .= $this->{$v['button_callback'][0]}->{$v['button_callback'][1]}($arrRow, $v['href'] ?? '', $label, $title, $v['icon'] ?? '', $attributes, $strTable, $arrRootIds, $arrChildRecordIds, $blnCircularReference, $strPrevious, $strNext, $this);
 				continue;
 			}
 
 			if (\is_callable($v['button_callback']))
 			{
-				$return .= $v['button_callback']($arrRow, $v['href'], $label, $title, $v['icon'], $attributes, $strTable, $arrRootIds, $arrChildRecordIds, $blnCircularReference, $strPrevious, $strNext, $this);
+				$return .= $v['button_callback']($arrRow, $v['href'] ?? '', $label, $title, $v['icon'] ?? '', $attributes, $strTable, $arrRootIds, $arrChildRecordIds, $blnCircularReference, $strPrevious, $strNext, $this);
 				continue;
 			}
 


### PR DESCRIPTION
When we moved the `tl_article` and `tl_page` button callbacks into the `ContentCompositionListener`, we have also added type-hints that are now causing problems:

`Argument 2 passed to Contao\CoreBundle\EventListener\DataContainer\ContentCompositionListener::renderPageArticlesOperation() must be of the type string, null given, called in contao/managed-edition/vendor/contao/contao/core-bundle/src/Resources/contao/classes/DataContainer.php on line 803`

**How to reproduce**

Add a custom navigation menu and try to select some pages.