### PR TITLE
Add a missing type-hint in the PageRoute constructor

### DIFF
--- a/core-bundle/src/Routing/Page/PageRoute.php
+++ b/core-bundle/src/Routing/Page/PageRoute.php
@@ -43,7 +43,7 @@ class PageRoute extends Route
      */
     private $content;
 
-    public function __construct(PageModel $pageModel, string $path = '', array $defaults = [], array $requirements = [], array $options = [], $methods = [])
+    public function __construct(PageModel $pageModel, string $path = '', array $defaults = [], array $requirements = [], array $options = [], array $methods = [])
     {
         $pageModel->loadDetails();
 


### PR DESCRIPTION
IIRC the argument is always an array, because the return value of `$config->getMethods()` is always an array.