### PR TITLE
Always include the default value in the generated URL

### DIFF
--- a/core-bundle/src/Routing/RouteFactory.php
+++ b/core-bundle/src/Routing/RouteFactory.php
@@ -53,7 +53,7 @@ class RouteFactory
         $requirements = $config->getRequirements();
 
         if (null === $path) {
-            $path = '/'.($pageModel->alias ?: $pageModel->id).'{parameters}';
+            $path = '/'.($pageModel->alias ?: $pageModel->id).'{!parameters}';
             $defaults['parameters'] = $defaultParameters;
             $requirements['parameters'] = $pageModel->requireItem ? '/.+' : '(/.+)?';
         }

--- a/core-bundle/tests/Routing/RouteFactoryTest.php
+++ b/core-bundle/tests/Routing/RouteFactoryTest.php
@@ -79,7 +79,7 @@ class RouteFactoryTest extends TestCase
 
         $route = $this->factory->createRouteForPage($pageModel, '/items/news');
 
-        $this->assertSame('/foo/bar{parameters}.baz', $route->getPath());
+        $this->assertSame('/foo/bar{!parameters}.baz', $route->getPath());
         $this->assertSame('/items/news', $route->getDefault('parameters'));
         $this->assertSame('(/.+)?', $route->getRequirement('parameters'));
     }
@@ -110,7 +110,7 @@ class RouteFactoryTest extends TestCase
 
         $route = $this->factory->createRouteForPage($pageModel, '/items/news');
 
-        $this->assertSame('/foo/bar{parameters}.baz', $route->getPath());
+        $this->assertSame('/foo/bar{!parameters}.baz', $route->getPath());
         $this->assertSame('/items/news', $route->getDefault('parameters'));
         $this->assertSame('/.+', $route->getRequirement('parameters'));
     }


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | n/a
| Docs PR or issue | n/a

Mark `{parameters}` as important so the url generator will add the defaults to the generated urls.
See https://symfony.com/doc/current/routing.html#optional-parameters
> If you want to always include some default value in the generated URL (for example to force the generation of /blog/1 instead of /blog in the previous example) add the ! character before the parameter name: /blog/{!page}
