### PR TITLE
Reset the preview toolbar styles

### DIFF
--- a/core-bundle/src/Resources/views/Frontend/preview_toolbar_base_js.html.twig
+++ b/core-bundle/src/Resources/views/Frontend/preview_toolbar_base_js.html.twig
@@ -1,4 +1,9 @@
 <style>
+    .cto-toolbar,
+    .cto-toolbar * {
+        all: unset;
+    }
+
     .cto-toolbar {
         font-family: -apple-system,system-ui,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
         font-weight: 400;
@@ -26,6 +31,10 @@
         align-items: center;
         justify-content: center;
         z-index: 99999;
+    }
+
+    .cto-toolbar__open svg {
+        fill: #fff;
     }
 
     .cto-toolbar--visible .cto-toolbar__open {

--- a/core-bundle/src/Resources/views/Frontend/preview_toolbar_base_js.html.twig
+++ b/core-bundle/src/Resources/views/Frontend/preview_toolbar_base_js.html.twig
@@ -1,6 +1,5 @@
 <style>
-    .cto-toolbar,
-    .cto-toolbar * {
+    .cto-toolbar, .cto-toolbar * {
         all: unset;
     }
 


### PR DESCRIPTION
Currently, the styling of the preview tool bar in the front end is affected by the page styling. 

For example, my toolbar is affected by a default margin on the `.formbody` class:
<img width="1440" alt="Bildschirmfoto 2020-07-24 um 05 46 10" src="https://user-images.githubusercontent.com/1073273/88358886-06f5ec00-cd71-11ea-89bf-69ca43ba491e.png">
