### PR TITLE
Add debugging information to the MakeResponsePrivateListener

### DIFF
--- a/core-bundle/src/EventListener/MakeResponsePrivateListener.php
+++ b/core-bundle/src/EventListener/MakeResponsePrivateListener.php
@@ -23,7 +23,7 @@ use Symfony\Component\HttpKernel\EventListener\AbstractSessionListener;
  */
 class MakeResponsePrivateListener
 {
-    public const DEBUG_HEADER = 'Contao-Response-Private-Reason';
+    public const DEBUG_HEADER = 'Contao-Private-Response-Reason';
 
     /**
      * @var ScopeMatcher

--- a/core-bundle/src/EventListener/MakeResponsePrivateListener.php
+++ b/core-bundle/src/EventListener/MakeResponsePrivateListener.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\EventListener;
 
 use Contao\CoreBundle\Routing\ScopeMatcher;
+use Symfony\Component\HttpFoundation\Cookie;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\EventListener\AbstractSessionListener;
 
@@ -21,6 +23,8 @@ use Symfony\Component\HttpKernel\EventListener\AbstractSessionListener;
  */
 class MakeResponsePrivateListener
 {
+    public const DEBUG_HEADER = 'Contao-Response-Private-Reason';
+
     /**
      * @var ScopeMatcher
      */
@@ -62,28 +66,47 @@ class MakeResponsePrivateListener
 
         // 1) An Authorization header is present
         if ($request->headers->has('Authorization')) {
-            $response->setPrivate();
+            $this->makePrivate($response, 'authorization');
 
             return;
         }
 
         // 2) The session was started
         if ($request->hasSession() && $request->getSession()->isStarted()) {
-            $response->setPrivate();
+            $this->makePrivate($response, 'session-cookie');
 
             return;
         }
 
         // 3) The response sets a cookie (same reason as 2 but for other cookies than the session cookie)
-        if (0 !== \count($response->headers->getCookies())) {
-            $response->setPrivate();
+        $cookies = $response->headers->getCookies();
+
+        if (0 !== \count($cookies)) {
+            $this->makePrivate(
+                $response,
+                sprintf('response-cookies (%s)', implode(', ', array_map(
+                    static function (Cookie $cookie) {
+                        return $cookie->getName();
+                    },
+                    $cookies
+                )))
+            );
 
             return;
         }
 
         // 4) The response has a "Vary: Cookie" header and the request provides at least one cookie
         if ($request->cookies->count() && \in_array('cookie', array_map('strtolower', $response->getVary()), true)) {
-            $response->setPrivate();
+            $this->makePrivate(
+                $response,
+                sprintf('request-cookies (%s)', implode(', ', array_keys($request->cookies->all())))
+            );
         }
+    }
+
+    private function makePrivate(Response $response, string $reason): void
+    {
+        $response->setPrivate();
+        $response->headers->set(self::DEBUG_HEADER, $reason);
     }
 }

--- a/core-bundle/tests/EventListener/MakeResponsePrivateListenerTest.php
+++ b/core-bundle/tests/EventListener/MakeResponsePrivateListenerTest.php
@@ -45,6 +45,7 @@ class MakeResponsePrivateListenerTest extends TestCase
         $listener($event);
 
         $this->assertTrue($response->headers->getCacheControlDirective('public'));
+        $this->assertFalse($response->headers->has(MakeResponsePrivateListener::DEBUG_HEADER));
     }
 
     public function testIgnoresRequestsThatMatchNoCondition(): void
@@ -66,6 +67,7 @@ class MakeResponsePrivateListenerTest extends TestCase
         $this->assertTrue($response->headers->getCacheControlDirective('public'));
         $this->assertTrue($response->headers->has(AbstractSessionListener::NO_AUTO_CACHE_CONTROL_HEADER));
         $this->assertSame('600', $response->headers->getCacheControlDirective('max-age'));
+        $this->assertFalse($response->headers->has(MakeResponsePrivateListener::DEBUG_HEADER));
     }
 
     public function testMakesResponsePrivateWhenAnAuthorizationHeaderIsPresent(): void
@@ -89,6 +91,7 @@ class MakeResponsePrivateListenerTest extends TestCase
 
         $this->assertTrue($response->headers->has(AbstractSessionListener::NO_AUTO_CACHE_CONTROL_HEADER));
         $this->assertTrue($response->headers->getCacheControlDirective('private'));
+        $this->assertSame('authorization', $response->headers->get(MakeResponsePrivateListener::DEBUG_HEADER));
     }
 
     public function testMakesResponsePrivateWhenTheSessionWasStarted(): void
@@ -119,6 +122,7 @@ class MakeResponsePrivateListenerTest extends TestCase
 
         $this->assertTrue($response->headers->has(AbstractSessionListener::NO_AUTO_CACHE_CONTROL_HEADER));
         $this->assertTrue($response->headers->getCacheControlDirective('private'));
+        $this->assertSame('session-cookie', $response->headers->get(MakeResponsePrivateListener::DEBUG_HEADER));
     }
 
     public function testMakesResponsePrivateWhenTheResponseContainsACookie(): void
@@ -127,6 +131,7 @@ class MakeResponsePrivateListenerTest extends TestCase
         $response->setPublic();
         $response->setMaxAge(600);
         $response->headers->setCookie(Cookie::create('foobar', 'foobar'));
+        $response->headers->setCookie(Cookie::create('foobar2', 'foobar'));
 
         $event = new ResponseEvent(
             $this->createMock(KernelInterface::class),
@@ -140,6 +145,7 @@ class MakeResponsePrivateListenerTest extends TestCase
 
         $this->assertTrue($response->headers->has(AbstractSessionListener::NO_AUTO_CACHE_CONTROL_HEADER));
         $this->assertTrue($response->headers->getCacheControlDirective('private'));
+        $this->assertSame('response-cookies (foobar, foobar2)', $response->headers->get(MakeResponsePrivateListener::DEBUG_HEADER));
     }
 
     public function testMakesResponsePrivateWhenItContainsVaryCookieAndTheRequestProvidesAtLeastOne(): void
@@ -161,6 +167,7 @@ class MakeResponsePrivateListenerTest extends TestCase
 
         $this->assertTrue($response->headers->has(AbstractSessionListener::NO_AUTO_CACHE_CONTROL_HEADER));
         $this->assertTrue($response->headers->getCacheControlDirective('private'));
+        $this->assertSame('request-cookies (super-cookie)', $response->headers->get(MakeResponsePrivateListener::DEBUG_HEADER));
     }
 
     public function testIgnoresTheResponseWhenItContainsVaryCookieButTheRequestDoesNotSendAnyCookie(): void
@@ -182,6 +189,7 @@ class MakeResponsePrivateListenerTest extends TestCase
 
         $this->assertTrue($response->headers->has(AbstractSessionListener::NO_AUTO_CACHE_CONTROL_HEADER));
         $this->assertTrue($response->headers->getCacheControlDirective('public'));
+        $this->assertFalse($response->headers->has(MakeResponsePrivateListener::DEBUG_HEADER));
     }
 
     private function createScopeMatcher(bool $isContaoMasterRequest): ScopeMatcher


### PR DESCRIPTION
Fixes missing debug information on the `MakeResponsePrivateListener` which bascially leaves you in the dark about why your response was turned into a `private` response. We should fix that, as people will configure caching in 4.9 for years to come.
