### PR TITLE
Fix the SERP preview with mandatory route parameters

### DIFF
--- a/core-bundle/src/Resources/contao/languages/en/default.xlf
+++ b/core-bundle/src/Resources/contao/languages/en/default.xlf
@@ -2013,7 +2013,7 @@
         <source>Close the Contao toolbar</source>
       </trans-unit>
       <trans-unit id="MSC.noSerpPreview">
-        <source>As this page is configured to require an item (trigger a 404 when the item alias is missing in the URL, see expert settings), a search result preview can't be generated.</source>
+        <source>The preview URL cannot be generated, because the route has mandatory parameters.</source>
       </trans-unit>
       <trans-unit id="UNITS.0">
         <source>Byte</source>

--- a/core-bundle/src/Resources/contao/languages/en/default.xlf
+++ b/core-bundle/src/Resources/contao/languages/en/default.xlf
@@ -2012,6 +2012,9 @@
       <trans-unit id="MSC.closeToolbar">
         <source>Close the Contao toolbar</source>
       </trans-unit>
+      <trans-unit id="MSC.noSerpPreview">
+        <source>As this page is configured to require an item (trigger a 404 when the item alias is missing in the URL, see expert settings), a search result preview can't be generated.</source>
+      </trans-unit>
       <trans-unit id="UNITS.0">
         <source>Byte</source>
       </trans-unit>

--- a/core-bundle/src/Resources/contao/widgets/SerpPreview.php
+++ b/core-bundle/src/Resources/contao/widgets/SerpPreview.php
@@ -51,10 +51,7 @@ class SerpPreview extends Widget
 		}
 		catch (ExceptionInterface $routingException)
 		{
-			if ($model->requireItem)
-			{
-				return '<div class="serp-preview"><p class="tl_info">' . $GLOBALS['TL_LANG']['MSC']['noResult'] . '</p></div>';
-			}
+			return '<div class="serp-preview"><p class="tl_info">' . $GLOBALS['TL_LANG']['MSC']['noResult'] . '</p></div>';
 		}
 
 		list($baseUrl) = explode('%s', $url);

--- a/core-bundle/src/Resources/contao/widgets/SerpPreview.php
+++ b/core-bundle/src/Resources/contao/widgets/SerpPreview.php
@@ -10,6 +10,8 @@
 
 namespace Contao;
 
+use Symfony\Component\Routing\Exception\InvalidParameterException;
+
 /**
  * @property array    $titleFields
  * @property array    $descriptionFields
@@ -42,8 +44,18 @@ class SerpPreview extends Widget
 		$description = StringUtil::substr($this->getDescription($model), 160);
 		$alias = $this->getAlias($model);
 
-		// Get the URL with a %s placeholder for the alias or ID
-		$url = $this->getUrl($model);
+		try
+		{
+			// Get the URL with a %s placeholder for the alias or ID
+			$url = $this->getUrl($model);
+		}
+		catch (InvalidParameterException $exception)
+		{
+			if ($model->requireItem)
+			{
+				return '<div class="serp-preview"><p class="tl_info">' . $GLOBALS['TL_LANG']['MSC']['noResult'] . '</p></div>';
+			}
+		}
 
 		list($baseUrl) = explode('%s', $url);
 		$trail = implode(' › ', $this->convertUrlToItems($baseUrl));

--- a/core-bundle/src/Resources/contao/widgets/SerpPreview.php
+++ b/core-bundle/src/Resources/contao/widgets/SerpPreview.php
@@ -51,7 +51,7 @@ class SerpPreview extends Widget
 		}
 		catch (ExceptionInterface $routingException)
 		{
-			return '<div class="serp-preview"><p class="tl_info">' . $GLOBALS['TL_LANG']['MSC']['noResult'] . '</p></div>';
+			return '<div class="serp-preview"><p class="tl_info">' . $GLOBALS['TL_LANG']['MSC']['noSerpPreview'] . '</p></div>';
 		}
 
 		list($baseUrl) = explode('%s', $url);

--- a/core-bundle/src/Resources/contao/widgets/SerpPreview.php
+++ b/core-bundle/src/Resources/contao/widgets/SerpPreview.php
@@ -10,7 +10,7 @@
 
 namespace Contao;
 
-use Symfony\Component\Routing\Exception\InvalidParameterException;
+use Symfony\Component\Routing\Exception\ExceptionInterface;
 
 /**
  * @property array    $titleFields
@@ -49,7 +49,7 @@ class SerpPreview extends Widget
 			// Get the URL with a %s placeholder for the alias or ID
 			$url = $this->getUrl($model);
 		}
-		catch (InvalidParameterException $exception)
+		catch (ExceptionInterface $routingException)
 		{
 			if ($model->requireItem)
 			{


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | n/a
| Docs PR or issue | n/a

With #1975 merged the url generating for SERP preview will fail, when `requireItem` is set on the page:
```
Parameter "parameters" for route "contao_routing_object" must match "/.+" ("" given) to generate a corresponding URL
```

This PR will disable the SERP preview for this cases:
<img width="1052" alt="Bildschirmfoto 2020-07-24 um 13 27 22" src="https://user-images.githubusercontent.com/754921/88387982-e8651480-cdb3-11ea-8e01-ef9676c0a2c2.png">

@contao/developers WDYT?