### PR TITLE
Update terminal42/service-annotation-bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -111,7 +111,7 @@
         "symfony/web-profiler-bundle": "4.4.*",
         "symfony/yaml": "4.4.*",
         "terminal42/escargot": "^0.6.0",
-        "terminal42/service-annotation-bundle": "^1.0",
+        "terminal42/service-annotation-bundle": "^1.1",
         "toflar/psr6-symfony-http-cache-store": "^2.1",
         "true/punycode": "^2.1",
         "twig/twig": "^2.7",

--- a/core-bundle/composer.json
+++ b/core-bundle/composer.json
@@ -98,7 +98,7 @@
         "symfony/var-dumper": "4.4.*",
         "symfony/yaml": "4.4.*",
         "terminal42/escargot": "^0.6.0",
-        "terminal42/service-annotation-bundle": "^1.0",
+        "terminal42/service-annotation-bundle": "^1.1",
         "true/punycode": "^2.1",
         "twig/twig": "^2.7",
         "ua-parser/uap-php": "^3.9",

--- a/core-bundle/src/Controller/AbstractController.php
+++ b/core-bundle/src/Controller/AbstractController.php
@@ -15,9 +15,8 @@ namespace Contao\CoreBundle\Controller;
 use Contao\CoreBundle\Framework\ContaoFramework;
 use FOS\HttpCacheBundle\Http\SymfonyResponseTagger;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController as SymfonyAbstractController;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-abstract class AbstractController extends SymfonyAbstractController implements ServiceAnnotationInterface
+abstract class AbstractController extends SymfonyAbstractController
 {
     public static function getSubscribedServices()
     {

--- a/core-bundle/src/Cron/LegacyCron.php
+++ b/core-bundle/src/Cron/LegacyCron.php
@@ -15,9 +15,8 @@ namespace Contao\CoreBundle\Cron;
 use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\CoreBundle\ServiceAnnotation\CronJob;
 use Contao\System;
-use Terminal42\ServiceAnnotationBundle\ServiceAnnotationInterface;
 
-class LegacyCron implements ServiceAnnotationInterface
+class LegacyCron
 {
     /**
      * @var ContaoFramework


### PR DESCRIPTION
Requires `terminal42/service-annotation-bundle` 1.1 which no longer requires the marker interface or tag.

see https://github.com/contao/contao/pull/1985