### PR TITLE
Support indexed tokens in the SimpleTokenParser

### DIFF
--- a/core-bundle/src/Util/SimpleTokenParser.php
+++ b/core-bundle/src/Util/SimpleTokenParser.php
@@ -114,7 +114,7 @@ class SimpleTokenParser implements LoggerAwareInterface
     private function canUseExpressionLanguage(array $data): bool
     {
         foreach (array_keys($data) as $token) {
-            if (!preg_match('/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$/', $token)) {
+            if (!preg_match('/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$/', (string) $token)) {
                 trigger_deprecation('contao/core-bundle', '4.10', 'Using tokens that are not valid PHP variables has been deprecated and will no longer work in Contao 5.0. Falling back to legacy token parsing.');
 
                 return false;

--- a/core-bundle/tests/Util/SimpleTokenParserTest.php
+++ b/core-bundle/tests/Util/SimpleTokenParserTest.php
@@ -344,6 +344,12 @@ class SimpleTokenParserTest extends TestCase
             ['val&#ue' => 9],
             'This is my ',
         ];
+
+        yield 'Test indexed token replacement' => [
+            'This is my ##0##,##1##',
+            ['test@foobar.com', 'foo@test.com'],
+            'This is my test@foobar.com,foo@test.com',
+        ];
     }
 
     /**


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | -
| Docs PR or issue | -

In Contao 4.9, technically the following was possible:

```php
// returns 'custom'
StringUtil::parseSimpleTokens('##0##', ['custom'])
```

In Contao 4.10 however, the following error will occur:

```
Uncaught PHP Exception TypeError: "preg_match() expects parameter 2 to be string, int given" at vendor/contao/core-bundle/src/Util/SimpleTokenParser.php line 117
```

The unmaintained `terminal42/contao-inserttags` extension uses it this way [here](https://github.com/terminal42/contao-inserttags/blob/14286f1a0670a65877e1401d681dff7459a57a72/InsertTagsHelper.php#L82).

At the very least it would be better to have a more descriptive error, if you pass a non-associative array to the simple token parser. However, I don't think it's worth checking for whether an array is associative or not, as it would probably be more expensive than simply casting the token key to string.

This PR does the latter and adds the failing test.