### PR TITLE
Fix warning in SearchIndexSubscriberTest

### DIFF
--- a/core-bundle/tests/Crawl/Escargot/Subscriber/SearchIndexSubscriberTest.php
+++ b/core-bundle/tests/Crawl/Escargot/Subscriber/SearchIndexSubscriberTest.php
@@ -470,6 +470,12 @@ class SearchIndexSubscriberTest extends TestCase
             ->willReturn($statusCode)
         ;
 
+        $response
+            ->method('getInfo')
+            ->with('response_headers')
+            ->willReturn([])
+        ;
+
         return $response;
     }
 


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | -
| Docs PR or issue | -

Fixes the following warning that currently appears when running any test:

```
Warning: array_reverse() expects parameter 1 to be array, null given in vendor\contao\contao\vendor\symfony\http-client\Exception\HttpExceptionTrait.php on line 34
```