### PR TITLE
Fix the unit tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
         "contao/maintenance-bundle-deprecated": "^2.1.5",
         "contao/manager-plugin": "^2.6.2",
         "doctrine/dbal": "^2.10",
-        "doctrine/doctrine-bundle": "^1.8 || ^2.0",
+        "doctrine/doctrine-bundle": "^2.0",
         "doctrine/orm": "^2.6.3",
         "dragonmantank/cron-expression": "^2.3",
         "friendsofsymfony/http-cache": "^2.6",

--- a/composer.json
+++ b/composer.json
@@ -50,8 +50,9 @@
         "contao/maintenance-bundle-deprecated": "^2.1.5",
         "contao/manager-plugin": "^2.6.2",
         "doctrine/dbal": "^2.10",
-        "doctrine/doctrine-bundle": "^2.0",
+        "doctrine/doctrine-bundle": "^1.8 || ^2.0",
         "doctrine/orm": "^2.6.3",
+        "doctrine/persistence": "^1.3",
         "dragonmantank/cron-expression": "^2.3",
         "friendsofsymfony/http-cache": "^2.6",
         "friendsofsymfony/http-cache-bundle": "^2.6",
@@ -176,7 +177,7 @@
             "contao/newsletter-bundle": "Contao\\NewsletterBundle\\ContaoManager\\Plugin"
         },
         "symfony": {
-            "require": "^4.4"
+            "require": "4.4.*"
         }
     },
     "autoload": {

--- a/core-bundle/composer.json
+++ b/core-bundle/composer.json
@@ -47,8 +47,9 @@
         "contao/image": "^1.0",
         "contao/imagine-svg": "^0.2.3 || ^1.0",
         "doctrine/dbal": "^2.10",
-        "doctrine/doctrine-bundle": "^2.0",
+        "doctrine/doctrine-bundle": "^1.8 || ^2.0",
         "doctrine/orm": "^2.6.3",
+        "doctrine/persistence": "^1.3",
         "dragonmantank/cron-expression": "^2.3",
         "friendsofsymfony/http-cache": "^2.6",
         "friendsofsymfony/http-cache-bundle": "^2.6",
@@ -136,7 +137,7 @@
     "extra": {
         "contao-manager-plugin": "Contao\\CoreBundle\\ContaoManager\\Plugin",
         "symfony": {
-            "require": "^4.4"
+            "require": "4.4.*"
         }
     },
     "autoload": {

--- a/core-bundle/composer.json
+++ b/core-bundle/composer.json
@@ -47,7 +47,7 @@
         "contao/image": "^1.0",
         "contao/imagine-svg": "^0.2.3 || ^1.0",
         "doctrine/dbal": "^2.10",
-        "doctrine/doctrine-bundle": "^1.8 || ^2.0",
+        "doctrine/doctrine-bundle": "^2.0",
         "doctrine/orm": "^2.6.3",
         "dragonmantank/cron-expression": "^2.3",
         "friendsofsymfony/http-cache": "^2.6",

--- a/core-bundle/src/Repository/CronJobRepository.php
+++ b/core-bundle/src/Repository/CronJobRepository.php
@@ -14,8 +14,8 @@ namespace Contao\CoreBundle\Repository;
 
 use Contao\CoreBundle\Entity\CronJob;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
-use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\DBAL\Connection;
+use Doctrine\Persistence\ManagerRegistry;
 
 /**
  * @internal

--- a/core-bundle/src/Repository/RememberMeRepository.php
+++ b/core-bundle/src/Repository/RememberMeRepository.php
@@ -14,8 +14,8 @@ namespace Contao\CoreBundle\Repository;
 
 use Contao\CoreBundle\Entity\RememberMe;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
-use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\DBAL\Connection;
+use Doctrine\Persistence\ManagerRegistry;
 
 /**
  * @internal

--- a/manager-bundle/composer.json
+++ b/manager-bundle/composer.json
@@ -22,7 +22,7 @@
         "contao/maintenance-bundle-deprecated": "^2.1.5",
         "contao/manager-plugin": "^2.4",
         "doctrine/dbal": "^2.10",
-        "doctrine/doctrine-bundle": "^1.8 || ^2.0",
+        "doctrine/doctrine-bundle": "^2.0",
         "friendsofsymfony/http-cache": "^2.6",
         "friendsofsymfony/http-cache-bundle": "^2.6",
         "nelmio/cors-bundle": "^1.5.3 || ^2.0.1",

--- a/manager-bundle/composer.json
+++ b/manager-bundle/composer.json
@@ -22,7 +22,8 @@
         "contao/maintenance-bundle-deprecated": "^2.1.5",
         "contao/manager-plugin": "^2.4",
         "doctrine/dbal": "^2.10",
-        "doctrine/doctrine-bundle": "^2.0",
+        "doctrine/doctrine-bundle": "^1.8 || ^2.0",
+        "doctrine/persistence": "^1.3",
         "friendsofsymfony/http-cache": "^2.6",
         "friendsofsymfony/http-cache-bundle": "^2.6",
         "nelmio/cors-bundle": "^1.5.3 || ^2.0.1",
@@ -74,7 +75,7 @@
     "extra": {
         "contao-manager-plugin": "Contao\\ManagerBundle\\ContaoManager\\Plugin",
         "symfony": {
-            "require": "^4.4"
+            "require": "4.4.*"
         }
     },
     "autoload": {


### PR DESCRIPTION
This will fix all the `Error: Class 'Doctrine\Common\Persistence\Mapping\Driver\MappingDriverChain' not found` errors occurring in our CI chain since yesterday.

<del>The problem arises because we try to be compatible with two different major versions of `doctrine/doctrine-bundle`. There have been a lot of deprecations and BC breaks in Doctrine (e.g. see [doctrine/persistence@2.0.0](https://github.com/doctrine/persistence/releases/tag/2.0.0) or [doctrine/common@3.0.0](https://github.com/doctrine/common/releases/tag/3.0.0)) and it seems that you currently cannot be compatible with both version 1 and 2. Fortunately, we do not have to. 😊</del>

That was not it, I'm afraid. 😞 