### PR TITLE
Fix the search index subscriber test

### DIFF
--- a/core-bundle/tests/Crawl/Escargot/Subscriber/SearchIndexSubscriberTest.php
+++ b/core-bundle/tests/Crawl/Escargot/Subscriber/SearchIndexSubscriberTest.php
@@ -472,8 +472,20 @@ class SearchIndexSubscriberTest extends TestCase
 
         $response
             ->method('getInfo')
-            ->with('response_headers')
-            ->willReturn([])
+            ->willReturnCallback(
+                static function (string $key) use ($statusCode) {
+                    switch ($key) {
+                        case 'http_code':
+                            return $statusCode;
+
+                        case 'response_headers':
+                            return [];
+
+                        default:
+                            return null;
+                    }
+                }
+            )
         ;
 
         return $response;


### PR DESCRIPTION
See https://github.com/contao/contao/pull/1991#issuecomment-664003473. Needs to be backported to Contao 4.9.