### PR TITLE
Add a conflict with nikic/php-parser

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -137,6 +137,7 @@
         "contao/core": "*",
         "contao/manager-plugin": "<2.0 || >=3.0",
         "doctrine/persistence": "1.3.2",
+        "nikic/php-parser": "4.7.0",
         "symfony/config": "<4.4.2",
         "symfony/mime": "4.4.* <4.4.10 || 5.0.* <5.0.10 || 5.1.0",
         "symfony/security-bundle": "4.4.* <4.4.5",

--- a/monorepo.yml
+++ b/monorepo.yml
@@ -6,6 +6,7 @@ composer:
         contao/manager-plugin: ^2.6.2
     conflict:
         doctrine/persistence: 1.3.2
+        nikic/php-parser: 4.7.0
         zendframework/zend-code: <3.3.1
     require-dev:
         contao/easy-coding-standard: ^2.0


### PR DESCRIPTION
As of version 4.7, the PHP parser supports PHP 8 match expressions, which unfortunately [breaks PHPUnit](https://github.com/nikic/PHP-Parser/pull/672#issuecomment-659343331) under PHP 7.4.

```
ERROR: ParseError - vendor/phpunit/phpunit/src/Framework/MockObject/Builder/ParametersMatch.php:15:35 - Syntax error, unexpected T_MATCH on line 15 (see https://psalm.dev/173)
interface ParametersMatch extends Match


ERROR: ParseError - vendor/phpunit/phpunit/src/Framework/MockObject/Builder/ParametersMatch.php:34:40 - Syntax error, unexpected ';', expecting '{' on line 34 (see https://psalm.dev/173)
    public function with(...$arguments);


ERROR: ParseError - vendor/phpunit/phpunit/src/Framework/MockObject/Builder/ParametersMatch.php:47:40 - Syntax error, unexpected ';', expecting '{' on line 47 (see https://psalm.dev/173)
    public function withAnyParameters();
```

The issue has been reported in https://github.com/nikic/PHP-Parser/issues/690, so I hope it will be fixed in version 4.7.1.