### PR TITLE
Require at least jQuery 3.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "contao-components/datepicker": "^2.3",
         "contao-components/dropzone": "^5.0.1",
         "contao-components/highlight": "^9.0",
-        "contao-components/jquery": "^1.12 || ^2.0 || ^3.0",
+        "contao-components/jquery": "^1.12 || ^2.0 || ^3.5",
         "contao-components/jquery-ui": "^1.11.4",
         "contao-components/mediabox": "^1.5",
         "contao-components/mootools": "^1.6.0.1",

--- a/core-bundle/composer.json
+++ b/core-bundle/composer.json
@@ -35,7 +35,7 @@
         "contao-components/datepicker": "^2.3",
         "contao-components/dropzone": "^5.0.1",
         "contao-components/highlight": "^9.0",
-        "contao-components/jquery": "^1.12 || ^2.0 || ^3.0",
+        "contao-components/jquery": "^1.12 || ^2.0 || ^3.5",
         "contao-components/jquery-ui": "^1.11.4",
         "contao-components/mediabox": "^1.5",
         "contao-components/mootools": "^1.6.0.1",


### PR DESCRIPTION
jQuery <3.5 has a [potential XSS vulnerability](https://github.com/jquery/jquery/security/advisories/GHSA-gxr4-xjj5-5px2) that has been fixed in version 3.5.0, therefore this PR adjusts the version constraint accordingly. As there might be people out there who still use jQuery 1, @ausi, @fritzmg and I have decided against removing these version constraints in Contao 4.9 LTS. We will remove them in Contao 4.10 though.