### PR TITLE
Add legacy routing pretty error screen

### DIFF
--- a/core-bundle/src/Exception/LegacyRoutingException.php
+++ b/core-bundle/src/Exception/LegacyRoutingException.php
@@ -12,6 +12,49 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Exception;
 
+use Contao\CoreBundle\Framework\Adapter;
+use Contao\System;
+use Webmozart\PathUtil\Path;
+
 class LegacyRoutingException extends \LogicException
 {
+    /**
+     * @param System&Adapter $systemAdapter
+     */
+    public static function getHooks(Adapter $systemAdapter, string $projectDir): array
+    {
+        $hooks = [];
+
+        foreach (['getPageIdFromUrl', 'getRootPageFromUrl'] as $name) {
+            if (empty($GLOBALS['TL_HOOKS'][$name]) || !\is_array($GLOBALS['TL_HOOKS'][$name])) {
+                continue;
+            }
+
+            foreach ($GLOBALS['TL_HOOKS'][$name] as $callback) {
+                $class = $systemAdapter->importStatic($callback[0]);
+                $file = (new \ReflectionClass($class))->getFileName();
+                $vendorDir = $projectDir.'/vendor/';
+                $modulesDir = $projectDir.'/system/modules/';
+
+                $hook = [
+                    'name' => $name,
+                    'class' => \get_class($class),
+                    'method' => $callback[1],
+                    'extension' => '',
+                ];
+
+                if (Path::isBasePath($vendorDir, $file)) {
+                    [$vendor, $package] = explode('/', Path::makeRelative($file, $vendorDir), 3);
+                    $hook['extension'] = $vendor.'/'.$package;
+                } elseif (Path::isBasePath($modulesDir, $file)) {
+                    [$module] = explode('/', Path::makeRelative($file, $modulesDir), 2);
+                    $hook['extension'] = 'system/modules/'.$module;
+                }
+
+                $hooks[] = $hook;
+            }
+        }
+
+        return $hooks;
+    }
 }

--- a/core-bundle/src/Resources/config/listener.yml
+++ b/core-bundle/src/Resources/config/listener.yml
@@ -202,6 +202,7 @@ services:
             - '@twig'
             - '@contao.framework'
             - '@security.helper'
+            - '%kernel.project_dir%'
         tags:
             # The priority must be higher than the one of the Twig exception listener (defaults to -128)
             - { name: kernel.event_listener, priority: -96 }

--- a/core-bundle/src/Resources/contao/languages/en/exception.xlf
+++ b/core-bundle/src/Resources/contao/languages/en/exception.xlf
@@ -47,6 +47,21 @@
       <trans-unit id="XPT.maintenance">
         <source>The website is currently not available. Please come back later.</source>
       </trans-unit>
+      <trans-unit id="XPT.legacyRoutingTitle">
+        <source>Legacy routing required</source>
+      </trans-unit>
+      <trans-unit id="XPT.legacyRoutingMatter">
+        <source>At least one extension requires legacy routing to work correctly, because it has not been updated to support the new routing system introduced in Contao 4.10.</source>
+      </trans-unit>
+      <trans-unit id="XPT.legacyRoutingFix1">
+        <source>Legacy routing can be activated by setting &lt;code&gt;prepend_locale&lt;/code&gt; and/or &lt;code&gt;url_suffix&lt;/code&gt; in the Contao configuration. &lt;strong&gt;Be aware that you can no longer set the URL prefix and suffix in the root page and existing configuration will be ignored!&lt;/strong&gt;</source>
+      </trans-unit>
+      <trans-unit id="XPT.legacyRoutingFix2">
+        <source>To enable legacy routing, add the following to your &lt;code&gt;config.yml&lt;/code&gt; and adapt it to your needs. Please refer to the &lt;a href="https://docs.contao.org" target="_blank"&gt;Contao Documentation&lt;/a&gt; if you are unsure how to adjust the container configuration.</source>
+      </trans-unit>
+      <trans-unit id="XPT.legacyRoutingHooks">
+        <source>The following hooks are incompatible with legacy routing.</source>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/core-bundle/src/Resources/views/Collector/contao.html.twig
+++ b/core-bundle/src/Resources/views/Collector/contao.html.twig
@@ -114,7 +114,7 @@
                         <th>Hook</th>
                         <th>Class</th>
                         <th>Method</th>
-                        <th>Composer Package</th>
+                        <th>Extension</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -123,7 +123,7 @@
                             <td><code>{{ hook.name }}</code></td>
                             <td><code>{{ hook.class }}</code></td>
                             <td><code>{{ hook.method }}</code></td>
-                            <td><code>{{ hook.package }}</code></td>
+                            <td><code>{{ hook.extension }}</code></td>
                         </tr>
                     {% endfor %}
                 </tbody>

--- a/core-bundle/src/Resources/views/Error/legacy_routing.html.twig
+++ b/core-bundle/src/Resources/views/Error/legacy_routing.html.twig
@@ -1,0 +1,40 @@
+{% trans_default_domain 'contao_exception' %}
+{% extends "@ContaoCore/Error/layout.html.twig" %}
+{% block title %}
+    {{ 'XPT.legacyRoutingTitle'|trans }}
+{% endblock %}
+{% block matter %}
+    <p>{{ 'XPT.legacyRoutingMatter'|trans }}</p>
+{% endblock %}
+{% block howToFix %}
+    <p>{{ 'XPT.legacyRoutingFix1'|trans|raw }}</p>
+    <p>{{ 'XPT.legacyRoutingFix2'|trans|raw }}</p>
+    <pre>
+contao:
+    prepend_locale: false
+    url_suffix: '.html'
+    </pre>
+{% endblock %}
+{% block explain %}
+    <p>{{ 'XPT.legacyRoutingHooks'|trans|raw }}</p>
+    <table>
+        <thead>
+        <tr>
+            <th style="text-align:left; padding-right:10px">Hook</th>
+            <th style="text-align:left; padding-right:10px">Class</th>
+            <th style="text-align:left; padding-right:10px">Method</th>
+            <th style="text-align:left; padding-right:10px">Extension</th>
+        </tr>
+        </thead>
+        <tbody>
+        {% for hook in hooks %}
+            <tr>
+                <td style="padding-right:10px"><code>{{ hook.name }}</code></td>
+                <td style="padding-right:10px"><code>{{ hook.class }}</code></td>
+                <td style="padding-right:10px"><code>{{ hook.method }}</code></td>
+                <td style="padding-right:10px"><code>{{ hook.extension }}</code></td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+{% endblock %}


### PR DESCRIPTION
This adds a custom pretty error screen to tell what to do if the system experiences a `LegacyRoutingException`.

<img width="1353" alt="Bildschirmfoto 2020-07-28 um 06 06 17" src="https://user-images.githubusercontent.com/1073273/88618119-99133280-d098-11ea-900b-8cf70057b4e7.png">

I think this is a great addition, because most people will be confused with the new option. By default, they will only get a 500 error page and nothing more to see what happens. If there are hooks registered, they can't even log in to the back end.

However, the only issue with this is that the exception _might_ be shown in the front end, uncontrollably by the admin. If an extension is not using the hooks, but e.g. calling `Controller::getPageIdFromUrl()` the exception is thrown, which can "randomly" happen at runtime if the admin does not check all pages.

Opinions @contao/developers ?