### PR TITLE
Ignore pages without alias when checking for duplicates

### DIFF
--- a/core-bundle/src/EventListener/DataContainer/PageUrlListener.php
+++ b/core-bundle/src/EventListener/DataContainer/PageUrlListener.php
@@ -240,6 +240,10 @@ class PageUrlListener implements ServiceAnnotationInterface, ResetInterface
 
         /** @var PageModel $page */
         foreach ($pages as $page) {
+            if (!$page->alias) {
+                continue;
+            }
+
             $this->aliasExists($page->alias, (int) $page->id, $rootPage, true);
             $this->recursiveValidatePages((int) $page->id, $rootPage);
         }

--- a/core-bundle/src/EventListener/DataContainer/PageUrlListener.php
+++ b/core-bundle/src/EventListener/DataContainer/PageUrlListener.php
@@ -240,11 +240,10 @@ class PageUrlListener implements ServiceAnnotationInterface, ResetInterface
 
         /** @var PageModel $page */
         foreach ($pages as $page) {
-            if (!$page->alias) {
-                continue;
+            if ($page->alias) {
+                $this->aliasExists($page->alias, (int) $page->id, $rootPage, true);
             }
 
-            $this->aliasExists($page->alias, (int) $page->id, $rootPage, true);
             $this->recursiveValidatePages((int) $page->id, $rootPage);
         }
     }

--- a/core-bundle/tests/EventListener/DataContainer/PageUrlListenerTest.php
+++ b/core-bundle/tests/EventListener/DataContainer/PageUrlListenerTest.php
@@ -1139,6 +1139,7 @@ class PageUrlListenerTest extends TestCase
             ]
         );
 
+        // Expects exception
         $translator = $this->mockTranslator('ERR.pageUrlPrefix', '/de/bar/foo.html');
 
         $connection = $this->mockConnection(
@@ -1153,6 +1154,87 @@ class PageUrlListenerTest extends TestCase
             $framework,
             $this->createMock(Slug::class),
             $translator,
+            $connection,
+            $this->createMock(IndexerInterface::class)
+        );
+
+        /** @var MockObject&DataContainer $dc */
+        $dc = $this->mockClassWithProperties(
+            DataContainer::class,
+            [
+                'id' => 1,
+                'activeRecord' => (object) ['type' => 'root', 'dns' => '', 'urlPrefix' => 'de', 'urlSuffix' => ''],
+            ]
+        );
+
+        $listener->validateUrlPrefix('en', $dc);
+    }
+
+    public function testIgnoresPagesWithoutAliasWhenValidatingUrlPrefix(): void
+    {
+        $framework = $this->mockFrameworkWithPages(
+            [
+                'dns' => '',
+                'urlPrefix' => 'de',
+                'urlSuffix' => '.html',
+            ],
+            [
+                'id' => 1,
+                'pid' => 0,
+                'type' => 'root',
+                'alias' => 'root',
+                'urlPrefix' => '',
+                'urlSuffix' => '.html',
+            ],
+            [
+                'id' => 2,
+                'pid' => 1,
+                'alias' => 'foo',
+                'urlPrefix' => '',
+                'urlSuffix' => '.html',
+            ],
+            [
+                'id' => 3,
+                'pid' => 1,
+                'alias' => 'bar',
+                'urlPrefix' => '',
+                'urlSuffix' => '.html',
+            ],
+            [
+                'id' => 4,
+                'pid' => 3,
+                'alias' => '',
+                'urlPrefix' => '',
+                'urlSuffix' => '.html',
+            ],
+            [
+                'id' => 5,
+                'pid' => 0,
+                'type' => 'root',
+                'urlPrefix' => 'de',
+                'urlSuffix' => '.html',
+            ],
+            [
+                'id' => 6,
+                'pid' => 5,
+                'alias' => '',
+                'urlPrefix' => 'de',
+                'urlSuffix' => '.html',
+            ]
+        );
+
+        $connection = $this->mockConnection(
+            [['urlPrefix' => 'de', 'urlSuffix' => '.html']],
+            [2, 3],
+            ['foo', 'bar'],
+            [[], [], [6]],
+            true
+        );
+
+        $listener = new PageUrlListener(
+            $framework,
+            $this->createMock(Slug::class),
+            $this->createMock(TranslatorInterface::class),
             $connection,
             $this->createMock(IndexerInterface::class)
         );

--- a/core-bundle/tests/EventListener/DataContainer/PageUrlListenerTest.php
+++ b/core-bundle/tests/EventListener/DataContainer/PageUrlListenerTest.php
@@ -1196,14 +1196,14 @@ class PageUrlListenerTest extends TestCase
             [
                 'id' => 3,
                 'pid' => 1,
-                'alias' => 'bar',
+                'alias' => '',
                 'urlPrefix' => '',
                 'urlSuffix' => '.html',
             ],
             [
                 'id' => 4,
                 'pid' => 3,
-                'alias' => '',
+                'alias' => 'foo/bar',
                 'urlPrefix' => '',
                 'urlSuffix' => '.html',
             ],
@@ -1225,8 +1225,8 @@ class PageUrlListenerTest extends TestCase
 
         $connection = $this->mockConnection(
             [['urlPrefix' => 'de', 'urlSuffix' => '.html']],
-            [2, 3],
-            ['foo', 'bar'],
+            [2, 3, 4],
+            [0 => 'foo', 2 => 'foo/bar'],
             [[], [], [6]],
             true
         );
@@ -1622,6 +1622,10 @@ class PageUrlListenerTest extends TestCase
         $statements[] = $statement;
 
         foreach ($ids as $k => $id) {
+            if (!isset($aliases[$k])) {
+                continue;
+            }
+
             $args[] = [
                 'SELECT id FROM tl_page WHERE alias LIKE :alias AND id!=:id',
                 [


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #1965

