### PR TITLE
Add CSV mime type and set Content-Type in File::sendToBrowser

### DIFF
--- a/core-bundle/src/Resources/contao/config/mimetypes.php
+++ b/core-bundle/src/Resources/contao/config/mimetypes.php
@@ -122,6 +122,7 @@ $GLOBALS['TL_MIME'] = array
 	'rtf'   => array('text/rtf', 'iconRTF.svg'),
 	'xml'   => array('text/xml', 'iconXML.svg'),
 	'xsl'   => array('text/xml', 'iconXSL.svg'),
+	'csv'   => array('text/csv', 'iconCSV.svg'),
 
 	// Videos
 	'mp4'   => array('video/mp4', 'iconMP4.svg'),

--- a/core-bundle/src/Resources/contao/library/Contao/File.php
+++ b/core-bundle/src/Resources/contao/library/Contao/File.php
@@ -770,12 +770,7 @@ class File extends \System
 
 		$response->headers->addCacheControlDirective('must-revalidate');
 		$response->headers->set('Connection', 'close');
-
-		// Set Content-Type if mime type info for this file extension is known, otherwise let Symfony guess it.
-		if (isset($GLOBALS['TL_MIME'][$this->extension]))
-		{
-			$response->headers->set('Content-Type', $this->getMimeType());
-		}
+		$response->headers->set('Content-Type', $this->getMimeType());
 
 		throw new ResponseException($response);
 	}

--- a/core-bundle/src/Resources/contao/library/Contao/File.php
+++ b/core-bundle/src/Resources/contao/library/Contao/File.php
@@ -771,6 +771,11 @@ class File extends \System
 		$response->headers->addCacheControlDirective('must-revalidate');
 		$response->headers->set('Connection', 'close');
 
+		// Set Content-Type if mime type info for this file extension is known, otherwise let Symfony guess it.
+		if (isset($GLOBALS['TL_MIME'][$this->extension])) {
+			$response->headers->set('Content-Type', $this->getMimeType());
+		}
+
 		throw new ResponseException($response);
 	}
 

--- a/core-bundle/src/Resources/contao/library/Contao/File.php
+++ b/core-bundle/src/Resources/contao/library/Contao/File.php
@@ -772,7 +772,8 @@ class File extends \System
 		$response->headers->set('Connection', 'close');
 
 		// Set Content-Type if mime type info for this file extension is known, otherwise let Symfony guess it.
-		if (isset($GLOBALS['TL_MIME'][$this->extension])) {
+		if (isset($GLOBALS['TL_MIME'][$this->extension]))
+		{
 			$response->headers->set('Content-Type', $this->getMimeType());
 		}
 


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | https://github.com/terminal42/contao-leads/issues/92
| Docs PR or issue | -

Currently, `File::sendToBrowser` does not set the `Content-Type` itself. Symfony's `ResponseListener` will execute `$response->prepare` which will try to guess the mime type, if the `Content-Type` header is missing in the response object. This uses PHP's _fileinfo_ component, which will guess the mime type based on the _contents_ of the file.

However, in case of CSV files for example, this will be `text/plain` instead of `text/csv`, the latter of which would be the standard according to [RFC 4180](https://tools.ietf.org/html/rfc4180).

So I think within the context of `\Contao\File::sendToBrowser`, the method should set the `Content-Type` according to Contao's own mime type mapping, if present, and otherwise let Symfony guess it as before.

This PR fixes this and adds the missing mime type for `.csv` files.