### PR TITLE
Skip navigation items if their URL can't be generated

### DIFF
--- a/core-bundle/src/Resources/contao/modules/Module.php
+++ b/core-bundle/src/Resources/contao/modules/Module.php
@@ -349,7 +349,7 @@ abstract class Module extends Frontend
 						}
 						catch (ExceptionInterface $exception)
 						{
-							System::log('Unable to generate URL for page ID '.$objNext->id.': '.$exception->getMessage(), __METHOD__, TL_ERROR);
+							System::log('Unable to generate the URL for page ID ' . $objNext->id . ': ' . $exception->getMessage(), __METHOD__, TL_ERROR);
 
 							continue 2;
 						}
@@ -362,7 +362,7 @@ abstract class Module extends Frontend
 						}
 						catch (ExceptionInterface $exception)
 						{
-							System::log('Unable to generate URL for page ID '.$objSubpage->id.': '.$exception->getMessage(), __METHOD__, TL_ERROR);
+							System::log('Unable to generate the URL for page ID ' . $objSubpage->id . ': ' . $exception->getMessage(), __METHOD__, TL_ERROR);
 
 							continue 2;
 						}

--- a/core-bundle/src/Resources/contao/modules/ModuleBreadcrumb.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleBreadcrumb.php
@@ -83,7 +83,7 @@ class ModuleBreadcrumb extends Module
 			(
 				'isRoot'   => true,
 				'isActive' => false,
-				'href'     => (($objFirstPage !== null) ? $this->getPageFrontendUrl($objFirstPage) : Environment::get('base')),
+				'href'     => (($objFirstPage !== null) ? $this->getUrl($objFirstPage) : Environment::get('base')),
 				'title'    => StringUtil::specialchars($objPages->pageTitle ?: $objPages->title, true),
 				'link'     => $objPages->title,
 				'data'     => (($objFirstPage !== null) ? $objFirstPage->row() : array()),
@@ -124,13 +124,13 @@ class ModuleBreadcrumb extends Module
 
 					if ($objNext instanceof PageModel)
 					{
-						$href = $this->getPageFrontendUrl($objNext);
+						$href = $this->getUrl($objNext);
 						break;
 					}
 					// no break
 
 				default:
-					$href = $this->getPageFrontendUrl($pages[$i]);
+					$href = $this->getUrl($pages[$i]);
 					break;
 			}
 
@@ -153,7 +153,7 @@ class ModuleBreadcrumb extends Module
 			(
 				'isRoot'   => false,
 				'isActive' => false,
-				'href'     => $this->getPageFrontendUrl($pages[0]),
+				'href'     => $this->getUrl($pages[0]),
 				'title'    => StringUtil::specialchars($pages[0]->pageTitle ?: $pages[0]->title, true),
 				'link'     => $pages[0]->title,
 				'data'     => $pages[0]->row(),
@@ -181,7 +181,7 @@ class ModuleBreadcrumb extends Module
 				(
 					'isRoot'   => false,
 					'isActive' => true,
-					'href'     => $this->getPageFrontendUrl($pages[0], '/articles/' . $strAlias),
+					'href'     => $this->getUrl($pages[0], '/articles/' . $strAlias),
 					'title'    => StringUtil::specialchars($objArticle->title, true),
 					'link'     => $objArticle->title,
 					'data'     => $objArticle->row(),
@@ -197,7 +197,7 @@ class ModuleBreadcrumb extends Module
 			(
 				'isRoot'   => false,
 				'isActive' => true,
-				'href'     => $this->getPageFrontendUrl($pages[0]),
+				'href'     => $this->getUrl($pages[0]),
 				'title'    => StringUtil::specialchars($pages[0]->pageTitle ?: $pages[0]->title),
 				'link'     => $pages[0]->title,
 				'data'     => $pages[0]->row(),
@@ -221,7 +221,15 @@ class ModuleBreadcrumb extends Module
 		$this->Template->items = $items;
 	}
 
-	private function getPageFrontendUrl(PageModel $pageModel, $strParams=null)
+	/**
+	 * Generate the front end URL
+	 *
+	 * @param PageModel $pageModel
+	 * @param null      $strParams
+	 *
+	 * @return string
+	 */
+	private function getUrl(PageModel $pageModel, $strParams=null)
 	{
 		try
 		{
@@ -229,7 +237,7 @@ class ModuleBreadcrumb extends Module
 		}
 		catch (ExceptionInterface $exception)
 		{
-			System::log('Unable to generate URL for page ID '.$pageModel->id.': '.$exception->getMessage(), __METHOD__, TL_ERROR);
+			System::log('Unable to generate the URL for page ID ' . $pageModel->id . ': ' . $exception->getMessage(), __METHOD__, TL_ERROR);
 
 			return '';
 		}

--- a/core-bundle/src/Resources/contao/modules/ModuleBreadcrumb.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleBreadcrumb.php
@@ -11,6 +11,7 @@
 namespace Contao;
 
 use Patchwork\Utf8;
+use Symfony\Component\Routing\Exception\ExceptionInterface;
 
 /**
  * Front end module "breadcrumb".
@@ -82,7 +83,7 @@ class ModuleBreadcrumb extends Module
 			(
 				'isRoot'   => true,
 				'isActive' => false,
-				'href'     => (($objFirstPage !== null) ? $objFirstPage->getFrontendUrl() : Environment::get('base')),
+				'href'     => (($objFirstPage !== null) ? $this->getPageFrontendUrl($objFirstPage) : Environment::get('base')),
 				'title'    => StringUtil::specialchars($objPages->pageTitle ?: $objPages->title, true),
 				'link'     => $objPages->title,
 				'data'     => (($objFirstPage !== null) ? $objFirstPage->row() : array()),
@@ -123,13 +124,13 @@ class ModuleBreadcrumb extends Module
 
 					if ($objNext instanceof PageModel)
 					{
-						$href = $objNext->getFrontendUrl();
+						$href = $this->getPageFrontendUrl($objNext);
 						break;
 					}
 					// no break
 
 				default:
-					$href = $pages[$i]->getFrontendUrl();
+					$href = $this->getPageFrontendUrl($pages[$i]);
 					break;
 			}
 
@@ -152,7 +153,7 @@ class ModuleBreadcrumb extends Module
 			(
 				'isRoot'   => false,
 				'isActive' => false,
-				'href'     => $pages[0]->getFrontendUrl(),
+				'href'     => $this->getPageFrontendUrl($pages[0]),
 				'title'    => StringUtil::specialchars($pages[0]->pageTitle ?: $pages[0]->title, true),
 				'link'     => $pages[0]->title,
 				'data'     => $pages[0]->row(),
@@ -180,7 +181,7 @@ class ModuleBreadcrumb extends Module
 				(
 					'isRoot'   => false,
 					'isActive' => true,
-					'href'     => $pages[0]->getFrontendUrl('/articles/' . $strAlias),
+					'href'     => $this->getPageFrontendUrl($pages[0], '/articles/' . $strAlias),
 					'title'    => StringUtil::specialchars($objArticle->title, true),
 					'link'     => $objArticle->title,
 					'data'     => $objArticle->row(),
@@ -196,7 +197,7 @@ class ModuleBreadcrumb extends Module
 			(
 				'isRoot'   => false,
 				'isActive' => true,
-				'href'     => $pages[0]->getFrontendUrl(),
+				'href'     => $this->getPageFrontendUrl($pages[0]),
 				'title'    => StringUtil::specialchars($pages[0]->pageTitle ?: $pages[0]->title),
 				'link'     => $pages[0]->title,
 				'data'     => $pages[0]->row(),
@@ -218,6 +219,18 @@ class ModuleBreadcrumb extends Module
 		}
 
 		$this->Template->items = $items;
+	}
+
+	private function getPageFrontendUrl(PageModel $pageModel, $strParams=null)
+	{
+		try
+		{
+			return $pageModel->getFrontendUrl($strParams);
+		}
+		catch (ExceptionInterface $exception)
+		{
+			return '';
+		}
 	}
 }
 

--- a/core-bundle/src/Resources/contao/modules/ModuleBreadcrumb.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleBreadcrumb.php
@@ -229,6 +229,8 @@ class ModuleBreadcrumb extends Module
 		}
 		catch (ExceptionInterface $exception)
 		{
+			System::log('Unable to generate URL for page ID '.$pageModel->id.': '.$exception->getMessage(), __METHOD__, TL_ERROR);
+
 			return '';
 		}
 	}


### PR DESCRIPTION
If a page has `requireItem` enabled, the URL cannot be generated. If you forget to _hide from navigation_, an error would be shown in the front end.