### PR TITLE
Allow pages/routes to define their target URL

### DIFF
--- a/core-bundle/src/Controller/AbstractController.php
+++ b/core-bundle/src/Controller/AbstractController.php
@@ -15,6 +15,7 @@ namespace Contao\CoreBundle\Controller;
 use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\CoreBundle\Routing\Page\PageRoute;
 use FOS\HttpCacheBundle\Http\SymfonyResponseTagger;
+use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController as SymfonyAbstractController;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -26,6 +27,7 @@ abstract class AbstractController extends SymfonyAbstractController
         $services = parent::getSubscribedServices();
 
         $services['contao.framework'] = ContaoFramework::class;
+        $services['logger'] = '?'.LoggerInterface::class;
         $services['fos_http_cache.http.symfony_response_tagger'] = '?'.SymfonyResponseTagger::class;
 
         return $services;

--- a/core-bundle/src/Controller/Page/ForwardPageController.php
+++ b/core-bundle/src/Controller/Page/ForwardPageController.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Controller\Page;
+
+use Contao\CoreBundle\Controller\AbstractController;
+use Contao\CoreBundle\Exception\ForwardPageNotFoundException;
+use Contao\CoreBundle\Routing\Page\DynamicRouteInterface;
+use Contao\CoreBundle\Routing\Page\PageRoute;
+use Contao\PageModel;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Routing\Route;
+
+class ForwardPageController extends AbstractController implements DynamicRouteInterface
+{
+    public function enhancePageRoute(PageRoute $route): Route
+    {
+        return $route->setTargetUrl($this->getTargetUrl($route->getPageModel()));
+    }
+
+    public function getUrlSuffixes(): array
+    {
+        return [];
+    }
+
+    private function getTargetUrl(PageModel $pageModel): string
+    {
+        /** @var PageModel $pageAdapter */
+        $pageAdapter = $this->get('contao.framework')->getAdapter(PageModel::class);
+
+        if ($pageModel->jumpTo) {
+            $forwardPage = $pageAdapter->findPublishedById($pageModel->jumpTo);
+        } else {
+            $forwardPage = $pageAdapter->findFirstPublishedRegularByPid($pageModel->id);
+        }
+
+        // Forward page does not exist
+        if (!$forwardPage instanceof PageModel) {
+            throw new ForwardPageNotFoundException('Forward page not found');
+        }
+
+        return $this->generateContentUrl($forwardPage, [], UrlGeneratorInterface::ABSOLUTE_URL);
+    }
+}

--- a/core-bundle/src/Controller/Page/RedirectPageController.php
+++ b/core-bundle/src/Controller/Page/RedirectPageController.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Controller\Page;
+
+use Contao\CoreBundle\Controller\AbstractController;
+use Contao\CoreBundle\Routing\Page\DynamicRouteInterface;
+use Contao\CoreBundle\Routing\Page\PageRoute;
+use Contao\InsertTags;
+use Contao\PageModel;
+use Contao\StringUtil;
+use Symfony\Component\Routing\Route;
+
+class RedirectPageController extends AbstractController implements DynamicRouteInterface
+{
+    public function enhancePageRoute(PageRoute $route): Route
+    {
+        return $route->setTargetUrl($this->getTargetUrl($route->getPageModel()));
+    }
+
+    public function getUrlSuffixes(): array
+    {
+        return [];
+    }
+
+    private function getTargetUrl(PageModel $pageModel): string
+    {
+        if (0 === strncasecmp($pageModel->url, 'mailto:', 7)) {
+            return StringUtil::encodeEmail($pageModel->url);
+        }
+
+        /** @var InsertTags $insertTags */
+        $insertTags = $this->get('contao.framework')->createInstance(InsertTags::class);
+
+        return $insertTags->replace($pageModel->url, false);
+    }
+}

--- a/core-bundle/src/Controller/Page/RootPageController.php
+++ b/core-bundle/src/Controller/Page/RootPageController.php
@@ -15,39 +15,54 @@ namespace Contao\CoreBundle\Controller\Page;
 use Contao\CoreBundle\Controller\AbstractController;
 use Contao\CoreBundle\Exception\NoActivePageFoundException;
 use Contao\CoreBundle\Monolog\ContaoContext;
+use Contao\CoreBundle\Routing\Page\DynamicRouteInterface;
+use Contao\CoreBundle\Routing\Page\PageRoute;
 use Contao\PageModel;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Route;
 
-class RootPageController extends AbstractController
+class RootPageController extends AbstractController implements DynamicRouteInterface
 {
     public function __invoke(PageModel $pageModel): Response
     {
-        if ('root' !== $pageModel->type) {
-            throw new \InvalidArgumentException('Invalid page type');
+        try {
+            $nextPage = $this->getNextPage($pageModel);
+        } catch (NoActivePageFoundException $exception) {
+            if (null !== ($logger = $this->get('logger'))) {
+                $logger->error(
+                    $exception->getMessage(),
+                    ['contao' => new ContaoContext(__METHOD__, ContaoContext::ERROR)]
+                );
+            }
+
+            throw $exception;
         }
 
-        return $this->redirectToContent($this->getNextPage((int) $pageModel->id));
+        return $this->redirectToContent($nextPage);
     }
 
-    private function getNextPage(int $rootPageId): PageModel
+    public function enhancePageRoute(PageRoute $route): Route
+    {
+        return $route->setTargetUrl($this->generateContentUrl($this->getNextPage($route->getPageModel())));
+    }
+
+    public function getUrlSuffixes(): array
+    {
+        return [];
+    }
+
+    private function getNextPage(PageModel $rootPageModel): PageModel
     {
         $this->initializeContaoFramework();
 
         /** @var PageModel $pageAdapter */
         $pageAdapter = $this->get('contao.framework')->getAdapter(PageModel::class);
-        $nextPage = $pageAdapter->findFirstPublishedByPid($rootPageId);
+        $nextPageModel = $pageAdapter->findFirstPublishedByPid($rootPageModel->id);
 
-        if (null !== $nextPage) {
-            return $nextPage;
+        if (null !== $nextPageModel) {
+            return $nextPageModel;
         }
 
-        if (null !== ($logger = $this->get('logger'))) {
-            $logger->error(
-                'No active page found under root page "'.$rootPageId.'"',
-                ['contao' => new ContaoContext(__METHOD__, ContaoContext::ERROR)]
-            );
-        }
-
-        throw new NoActivePageFoundException('No active page found under root page.');
+        throw new NoActivePageFoundException('No active page found under root page ID '.$rootPageModel->id);
     }
 }

--- a/core-bundle/src/Exception/ForwardPageNotFoundException.php
+++ b/core-bundle/src/Exception/ForwardPageNotFoundException.php
@@ -12,6 +12,8 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Exception;
 
-class ForwardPageNotFoundException extends \RuntimeException
+use Symfony\Component\Routing\Exception\ResourceNotFoundException;
+
+class ForwardPageNotFoundException extends ResourceNotFoundException
 {
 }

--- a/core-bundle/src/Exception/NoActivePageFoundException.php
+++ b/core-bundle/src/Exception/NoActivePageFoundException.php
@@ -12,6 +12,8 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Exception;
 
-class NoActivePageFoundException extends \RuntimeException
+use Symfony\Component\Routing\Exception\ResourceNotFoundException;
+
+class NoActivePageFoundException extends ResourceNotFoundException
 {
 }

--- a/core-bundle/src/Resources/config/controller.yml
+++ b/core-bundle/src/Resources/config/controller.yml
@@ -3,6 +3,21 @@ services:
         autoconfigure: true
         public: true
 
+    _instanceof:
+        Symfony\Bundle\FrameworkBundle\Controller\AbstractController:
+            calls:
+                - [setContainer, ['@Psr\Container\ContainerInterface']]
+
+    Contao\CoreBundle\Controller\Page\ForwardPageController:
+        tags:
+            - { name: contao.page, contentComposition: false }
+            - { name: monolog.logger, channel: contao }
+
+    Contao\CoreBundle\Controller\Page\RedirectPageController:
+        tags:
+            - { name: contao.page, contentComposition: false }
+            - { name: monolog.logger, channel: contao }
+
     Contao\CoreBundle\Controller\Page\RootPageController:
         tags:
             - { name: contao.page, contentComposition: false }

--- a/core-bundle/src/Resources/contao/modules/Module.php
+++ b/core-bundle/src/Resources/contao/modules/Module.php
@@ -319,7 +319,7 @@ abstract class Module extends Frontend
 				}
 				catch (ExceptionInterface $exception)
 				{
-					System::log('Unable to generate URL for page ID '.$objSubpage->id.': '.$exception->getMessage(), __METHOD__, TL_ERROR);
+					System::log('Unable to generate URL for page ID ' . $objSubpage->id . ': ' . $exception->getMessage(), __METHOD__, TL_ERROR);
 
 					continue;
 				}

--- a/core-bundle/src/Resources/contao/modules/ModuleBreadcrumb.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleBreadcrumb.php
@@ -195,7 +195,7 @@ class ModuleBreadcrumb extends Module
 		}
 		catch (ExceptionInterface $exception)
 		{
-			System::log('Unable to generate URL for page ID '.$pageModel->id.': '.$exception->getMessage(), __METHOD__, TL_ERROR);
+			System::log('Unable to generate URL for page ID ' . $pageModel->id . ': ' . $exception->getMessage(), __METHOD__, TL_ERROR);
 
 			return '';
 		}

--- a/core-bundle/src/Routing/Page/PageRoute.php
+++ b/core-bundle/src/Routing/Page/PageRoute.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Routing\Page;
 
 use Contao\CoreBundle\ContaoCoreBundle;
+use Contao\CoreBundle\Routing\RedirectRoute;
 use Contao\PageModel;
 use Symfony\Component\Routing\Route;
 
@@ -141,5 +142,12 @@ class PageRoute extends Route
     public function getContent()
     {
         return $this->content;
+    }
+
+    public function setTargetUrl(string $targetUrl): self
+    {
+        $this->setOption(RedirectRoute::TARGET_URL, $targetUrl);
+
+        return $this;
     }
 }

--- a/core-bundle/src/Routing/RedirectRoute.php
+++ b/core-bundle/src/Routing/RedirectRoute.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Routing;
+
+use Symfony\Component\Routing\Route;
+
+class RedirectRoute extends Route
+{
+    public const TARGET_URL = 'target_url';
+
+    public function __construct(string $targetUrl)
+    {
+        $options[self::TARGET_URL] = $targetUrl;
+
+        parent::__construct('', [], [], $options);
+    }
+}

--- a/core-bundle/src/Routing/RouteFactory.php
+++ b/core-bundle/src/Routing/RouteFactory.php
@@ -74,6 +74,7 @@ class RouteFactory
             return $content;
         }
 
+        /** @var ContentRouteProviderInterface $provider */
         foreach ($this->routeProviders as $provider) {
             if ($provider->supportsContent($content)) {
                 return $provider->getRouteForContent($content);

--- a/core-bundle/tests/Controller/Page/RedirectPageControllerTest.php
+++ b/core-bundle/tests/Controller/Page/RedirectPageControllerTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\Controller\Page;
+
+use Contao\CoreBundle\Controller\Page\RedirectPageController;
+use Contao\CoreBundle\Routing\Page\PageRoute;
+use Contao\CoreBundle\Routing\RedirectRoute;
+use Contao\CoreBundle\Tests\TestCase;
+use Contao\InsertTags;
+use Contao\PageModel;
+use Contao\StringUtil;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Container\ContainerInterface;
+
+class RedirectPageControllerTest extends TestCase
+{
+    public function testAddsTheTargetUrlToThePageRoute(): void
+    {
+        $insertTags = $this->createMock(InsertTags::class);
+        $insertTags
+            ->method('replace')
+            ->willReturnArgument(0)
+        ;
+
+        $framework = $this->mockContaoFramework();
+        $framework
+            ->expects($this->once())
+            ->method('createInstance')
+            ->with(InsertTags::class)
+            ->willReturn($insertTags)
+        ;
+
+        $container = $this->createMock(ContainerInterface::class);
+        $container
+            ->method('get')
+            ->willReturnMap(
+                [
+                    ['contao.framework', $framework],
+                ]
+            )
+        ;
+
+        /** @var PageModel&MockObject $pageModel */
+        $pageModel = $this->mockClassWithProperties(PageModel::class, ['url' => 'https://example.com']);
+
+        $controller = new RedirectPageController();
+        $controller->setContainer($container);
+
+        $route = $controller->enhancePageRoute(new PageRoute($pageModel));
+
+        $this->assertTrue($route->hasOption(RedirectRoute::TARGET_URL));
+        $this->assertSame('https://example.com', $route->getOption(RedirectRoute::TARGET_URL));
+    }
+
+    public function testReplacesInsertTagsOnTargetUrl(): void
+    {
+        $insertTags = $this->createMock(InsertTags::class);
+        $insertTags
+            ->expects($this->once())
+            ->method('replace')
+            ->with('{some-insert-tag}')
+            ->willReturn('https://example.com')
+        ;
+
+        $framework = $this->mockContaoFramework();
+        $framework
+            ->expects($this->once())
+            ->method('createInstance')
+            ->with(InsertTags::class)
+            ->willReturn($insertTags)
+        ;
+
+        $container = $this->createMock(ContainerInterface::class);
+        $container
+            ->method('get')
+            ->willReturnMap(
+                [
+                    ['contao.framework', $framework],
+                ]
+            )
+        ;
+
+        /** @var PageModel&MockObject $pageModel */
+        $pageModel = $this->mockClassWithProperties(PageModel::class, ['url' => '{some-insert-tag}']);
+
+        $controller = new RedirectPageController();
+        $controller->setContainer($container);
+
+        $route = $controller->enhancePageRoute(new PageRoute($pageModel));
+
+        $this->assertTrue($route->hasOption(RedirectRoute::TARGET_URL));
+        $this->assertSame('https://example.com', $route->getOption(RedirectRoute::TARGET_URL));
+    }
+
+    public function testEncodesEmailOnTargetUrl(): void
+    {
+        $framework = $this->mockContaoFramework();
+        $framework
+            ->expects($this->never())
+            ->method($this->anything())
+        ;
+
+        $container = $this->createMock(ContainerInterface::class);
+        $container
+            ->method('get')
+            ->willReturnMap(
+                [
+                    ['contao.framework', $framework],
+                ]
+            )
+        ;
+
+        /** @var PageModel&MockObject $pageModel */
+        $pageModel = $this->mockClassWithProperties(PageModel::class, ['url' => 'mailto:test@example.org']);
+
+        $controller = new RedirectPageController();
+        $controller->setContainer($container);
+
+        $route = $controller->enhancePageRoute(new PageRoute($pageModel));
+
+        $this->assertTrue($route->hasOption(RedirectRoute::TARGET_URL));
+        $this->assertSame(StringUtil::encodeEmail('mailto:test@example.org'), $route->getOption(RedirectRoute::TARGET_URL));
+    }
+
+    public function testDoesNotAddUrlSuffixes(): void
+    {
+        $controller = new RedirectPageController();
+
+        $this->assertSame([], $controller->getUrlSuffixes());
+    }
+}

--- a/core-bundle/tests/Routing/ContentResolvingGeneratorTest.php
+++ b/core-bundle/tests/Routing/ContentResolvingGeneratorTest.php
@@ -14,6 +14,7 @@ namespace Contao\CoreBundle\Tests\Routing;
 
 use Contao\CoreBundle\Routing\ContentResolvingGenerator;
 use Contao\CoreBundle\Routing\Page\PageRoute;
+use Contao\CoreBundle\Routing\RedirectRoute;
 use Contao\CoreBundle\Routing\RouteFactory;
 use Contao\CoreBundle\Tests\TestCase;
 use Contao\PageModel;
@@ -53,6 +54,27 @@ class ContentResolvingGeneratorTest extends TestCase
         $this->expectExceptionMessage('Missing parameter "_content" for content route (contao_routing_object).');
 
         $this->generator->generate(PageRoute::ROUTE_NAME);
+    }
+
+    public function testReturnsTheTargetUrlOptionIfPresent(): void
+    {
+        $content = (object) ['foo' => 'bar'];
+        $route = new RedirectRoute('https://www.example.org/foobar.html');
+
+        $this->routeFactory
+            ->expects($this->once())
+            ->method('createRouteForContent')
+            ->with($content)
+            ->willReturn($route)
+        ;
+
+        $url = $this->generator->generate(
+            PageRoute::ROUTE_NAME,
+            [PageRoute::CONTENT_PARAMETER => $content],
+            UrlGeneratorInterface::ABSOLUTE_URL
+        );
+
+        $this->assertSame('https://www.example.org/foobar.html', $url);
     }
 
     public function testGeneratesTheContentRoute(): void

--- a/core-bundle/tests/Routing/Page/PageRouteTest.php
+++ b/core-bundle/tests/Routing/Page/PageRouteTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Tests\Routing\Page;
 
 use Contao\CoreBundle\Routing\Page\PageRoute;
+use Contao\CoreBundle\Routing\RedirectRoute;
 use Contao\CoreBundle\Tests\TestCase;
 use Contao\PageModel;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -41,6 +42,30 @@ class PageRouteTest extends TestCase
         $route->setPath('/path/{pattern}');
 
         $this->assertSame('/prefix/path/{pattern}.suffix', $route->getPath());
+    }
+
+    public function testIgnoresPageAliasForAbsolutePath(): void
+    {
+        $route = new PageRoute($this->mockPageModel(), '/bar/{baz}');
+
+        $this->assertSame('/foo/bar/{baz}.baz', $route->getPath());
+
+        $route->setUrlPrefix('');
+        $route->setUrlSuffix('.html');
+
+        $this->assertSame('/bar/{baz}.html', $route->getPath());
+    }
+
+    public function testAppendsRelativePathToPageAlias(): void
+    {
+        $route = new PageRoute($this->mockPageModel(), '{foo}/{bar}');
+
+        $this->assertSame('/foo/bar/{foo}/{bar}.baz', $route->getPath());
+
+        $route->setUrlPrefix('');
+        $route->setUrlSuffix('.html');
+
+        $this->assertSame('/bar/{foo}/{bar}.html', $route->getPath());
     }
 
     public function testReturnsTheUrlPrefix(): void
@@ -111,6 +136,18 @@ class PageRouteTest extends TestCase
         $route = new PageRoute($this->mockPageModel(['rootUseSSL' => true]));
 
         $this->assertSame(['https'], $route->getSchemes());
+    }
+
+    public function testSetsTargetUrlInOptions(): void
+    {
+        $route = new PageRoute($this->mockPageModel());
+
+        $this->assertFalse($route->hasOption(RedirectRoute::TARGET_URL));
+
+        $route->setTargetUrl('https://example.com');
+
+        $this->assertTrue($route->hasOption(RedirectRoute::TARGET_URL));
+        $this->assertSame('https://example.com', $route->getOption(RedirectRoute::TARGET_URL));
     }
 
     /**


### PR DESCRIPTION
While trying to write unit tests for https://github.com/contao/contao/pull/2012 I realized that a route cannot be "any URL". It has a protocol, host and path, but it's unnecessarily hard or even impossible to create a route for e.g. an email link.

The redirect route / `target_url` option allows a route to tell the target URL without affecting routing. As you might remember, it's a bit complicate because a route – by default – is responsible for matching (check if host, path etc. matches the current request) as well as generating the URL.

What's even better is that this also allows the `forward` and `redirect` pages to **match it's alias "path"** as well as tell its target URL independently. This means we don't need "special" handling anymore (e.g. in navigation and breadcrumb).