### PR TITLE
Do not reorder existing DROP INDEX queries to the end

### DIFF
--- a/installation-bundle/src/Database/Installer.php
+++ b/installation-bundle/src/Database/Installer.php
@@ -295,17 +295,10 @@ class Installer
                     $indexCommand = $platform->getDropIndexSQL($indexName, $tableName);
                     $strKey = md5($indexCommand);
 
-                    if (isset($sql['ALTER_CHANGE'][$strKey])) {
-                        unset(
-                            $sql['ALTER_CHANGE'][$strKey],
-                            $order[array_search($strKey, $order, true)]
-                        );
-
-                        $order = array_values($order);
+                    if (!isset($sql['ALTER_CHANGE'][$strKey])) {
+                        $sql['ALTER_TABLE'][$strKey] = $indexCommand;
+                        $order[] = $strKey;
                     }
-
-                    $sql['ALTER_TABLE'][$strKey] = $indexCommand;
-                    $order[] = $strKey;
                 }
             }
 


### PR DESCRIPTION
Followup to #1651

If a `DROP INDEX` that `checkEngineAndCollation()` wants to add already exits we should not reorder it to the end but keep the order as is.