### PR TITLE
Fix a memory leak in the resize images command

### DIFF
--- a/core-bundle/src/Command/ResizeImagesCommand.php
+++ b/core-bundle/src/Command/ResizeImagesCommand.php
@@ -17,15 +17,17 @@ use Contao\Image\DeferredImageInterface;
 use Contao\Image\DeferredImageStorageInterface;
 use Contao\Image\DeferredResizerInterface;
 use Contao\Image\ResizerInterface;
-use Patchwork\Utf8;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Exception\InvalidArgumentException;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
+use Symfony\Component\Console\Output\ConsoleSectionOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Console\Terminal;
-use Symfony\Component\Debug\Exception\FlattenException;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Process\PhpExecutableFinder;
 use Symfony\Component\Process\Process;
@@ -70,6 +72,21 @@ class ResizeImagesCommand extends Command
      */
     private $terminalWidth;
 
+    /**
+     * @var SymfonyStyle
+     */
+    private $io;
+
+    /**
+     * @var ConsoleSectionOutput
+     */
+    private $tableOutput;
+
+    /**
+     * @var Table
+     */
+    private $table;
+
     public function __construct(ImageFactoryInterface $imageFactory, ResizerInterface $resizer, string $targetDir, DeferredImageStorageInterface $storage, Filesystem $filesystem = null)
     {
         $this->imageFactory = $imageFactory;
@@ -86,8 +103,10 @@ class ResizeImagesCommand extends Command
     {
         $this
             ->addOption('time-limit', 'l', InputOption::VALUE_OPTIONAL, 'Time limit in seconds', '0')
-            ->addOption('concurrent', 'c', InputOption::VALUE_OPTIONAL, 'Run multiple processes concurrently', '1')
-            ->addOption('throttle', 't', InputOption::VALUE_OPTIONAL, 'Pause between resizes to limit CPU utilization, 0.1 relates to 10% CPU usage', '1')
+            ->addOption('concurrent', 'c', InputOption::VALUE_OPTIONAL, 'Run multiple processes concurrently with a value larger than 1 or pause between resizes to limit CPU utilization with values lower than 1.0', '1')
+            ->addOption('throttle', 't', InputOption::VALUE_OPTIONAL, '(Deprecated) Use the concurrent option instead', false)
+            ->addOption('image', null, InputArgument::OPTIONAL, 'Image name to resize a single image')
+            ->addOption('no-sub-process', null, InputOption::VALUE_NONE, 'Do not start a sub process per resize')
             ->setDescription('Resizes deferred images that have not been processed yet.')
         ;
     }
@@ -98,166 +117,242 @@ class ResizeImagesCommand extends Command
             throw new \RuntimeException('Deferred resizer not available');
         }
 
+        if (!$output instanceof ConsoleOutputInterface) {
+            throw new \InvalidArgumentException(sprintf('Output must be an instance of "%s"', ConsoleOutputInterface::class));
+        }
+
+        $this->io = new SymfonyStyle($input, $output->section());
+
+        if (null !== $image = $input->getOption('image')) {
+            return $this->resizeImage($image);
+        }
+
         $timeLimit = (float) $input->getOption('time-limit');
-        $throttle = (float) $input->getOption('throttle');
-        $concurrent = (int) $input->getOption('concurrent');
+        $concurrent = (float) $input->getOption('concurrent');
+
+        if (false !== $input->getOption('throttle')) {
+            @trigger_error('Using the throttle option is deprecated and will no longer work in Contao 5.0. Use the concurrent option instead.', E_USER_DEPRECATED);
+            $this->io->warning('Using the throttle option is deprecated, use the concurrent option instead.');
+
+            $throttle = (float) $input->getOption('throttle');
+
+            if ($throttle < 0.001 || $throttle > 1) {
+                throw new InvalidArgumentException(sprintf('Throttle value "%s" is invalid.', $throttle));
+            }
+
+            $concurrent *= $throttle;
+        }
 
         if ($timeLimit < 0) {
             throw new InvalidArgumentException(sprintf('Time-limit value "%s" is invalid.', $timeLimit));
         }
 
-        if ($throttle < 0.001 || $throttle > 1) {
-            throw new InvalidArgumentException(sprintf('Throttle value "%s" is invalid.', $throttle));
-        }
-
-        if ($concurrent < 1) {
+        if ($concurrent <= 0) {
             throw new InvalidArgumentException(sprintf('Concurrent value "%s" is invalid.', $concurrent));
         }
 
-        $io = new SymfonyStyle($input, $output);
+        $this->tableOutput = $output->section();
 
-        if ($concurrent > 1) {
-            return $this->executeConcurrent($concurrent, $io);
-        }
+        $this->table = new Table($this->tableOutput);
+        $this->table->setHeaders(['Process ID', 'Count', 'Image']);
+        $this->table->setColumnWidth(2, $this->terminalWidth - 25);
+        $this->table->setColumnMaxWidth(2, $this->terminalWidth - 25);
 
-        $startTime = microtime(true);
-
-        $maxDuration = 0;
-        $lastDuration = 0;
-
-        foreach ($this->storage->listPaths() as $path) {
-            $sleep = (1 - $throttle) / $throttle * $lastDuration;
-
-            if ($timeLimit && microtime(true) - $startTime + $maxDuration + $sleep > $timeLimit) {
-                $io->writeln("\n".'Time limit of '.$timeLimit.' seconds reached.');
-
-                return 0;
-            }
-
-            usleep((int) ($sleep * 1000000));
-
-            $maxDuration = max($maxDuration, $lastDuration = $this->resizeImage($path, $io));
-        }
-
-        $io->writeln("\n".'All images resized.');
-
-        return 0;
+        return $this->resizeImages($timeLimit, $concurrent, $input->getOption('no-sub-process'));
     }
 
-    private function resizeImage(string $path, SymfonyStyle $io): float
+    private function resizeImage(string $path, bool $quiet = false): int
     {
-        $startTime = microtime(true);
-
-        if ($this->filesystem->exists($path)) {
+        if ($this->filesystem->exists($this->targetDir.'/'.$path)) {
             return 0;
         }
-
-        $io->write(str_pad($path, $this->terminalWidth + \strlen($path) - Utf8::strlen($path) - 13, '.').' ');
 
         try {
             $image = $this->imageFactory->create(Path::join($this->targetDir, $path));
             $resizer = $this->resizer;
 
             if ($image instanceof DeferredImageInterface) {
-                $resizedImage = $resizer->resizeDeferredImage($image, false);
-
-                if (null === $resizedImage) {
-                    // Clear the current output line
-                    $io->write("\r".str_repeat(' ', $this->terminalWidth)."\r");
-                } else {
-                    $duration = microtime(true) - $startTime;
-                    $io->writeln(sprintf('done%7.3Fs', $duration));
-
-                    return $duration;
-                }
-            } else {
-                // Clear the current output line
-                $io->write("\r".str_repeat(' ', $this->terminalWidth)."\r");
+                $resizer->resizeDeferredImage($image, false);
             }
         } catch (\Throwable $exception) {
-            $io->writeln('failed');
-
-            if ($io->isVerbose()) {
-                $io->error(FlattenException::createFromThrowable($exception)->getAsString());
+            if ($this->io->isVerbose()) {
+                $this->getApplication()->renderThrowable($exception, $this->io);
             } else {
-                $io->writeln($exception->getMessage());
+                $this->io->writeln($exception->getMessage());
             }
+
+            return 1;
+        }
+
+        if (!$quiet) {
+            $this->io->writeln('Image "'.$path.'" resized successfully');
         }
 
         return 0;
     }
 
-    private function executeConcurrent(int $count, SymfonyStyle $io): int
+    private function resizeImages(float $timeLimit, float $concurrent, bool $noSubProcess): int
+    {
+        if (!$noSubProcess && $this->supportsSubProcesses()) {
+            $this->executeConcurrent($timeLimit, $concurrent);
+        } else {
+            $this->io->warning(
+                "Running this command without sub processes.\n"
+                .'This can lead to memory leaks and eventually let the execution fail.'
+            );
+
+            $this->executeInCurrentProcess($timeLimit, $concurrent);
+        }
+
+        return 0;
+    }
+
+    private function supportsSubProcesses(): bool
     {
         $phpFinder = new PhpExecutableFinder();
 
-        $io->writeln('Starting '.$count.' concurrent processes...');
-
         if (false === ($phpPath = $phpFinder->find())) {
-            throw new \RuntimeException('The php executable could not be found.');
+            return false;
         }
 
-        $processes = [];
-        $buffers = [];
+        $process = new Process(array_merge([$phpPath], $_SERVER['argv'], ['--help']));
 
-        for ($i = 0; $i < $count; ++$i) {
-            $process = new Process(array_merge(
-                [$phpPath],
-                $_SERVER['argv'],
-                ['--concurrent=1', $io->isDecorated() ? '--ansi' : '--no-ansi']
-            ));
+        return 0 === $process->run();
+    }
 
-            $process->setTimeout(null);
-            $process->setEnv(['LINES' => getenv('LINES'), 'COLUMNS' => getenv('COLUMNS') - 4]);
-            $process->start();
+    private function executeInCurrentProcess(float $timeLimit, float $concurrent): void
+    {
+        $startTime = microtime(true);
 
-            $processes[] = $process;
-            $buffers[] = '';
-        }
+        $count = 0;
+        $lastDuration = 0;
 
-        do {
-            $isRunning = false;
+        try {
+            foreach ($this->storage->listPaths() as $path) {
+                $sleep = $concurrent < 1 ? (1 - $concurrent) / $concurrent * $lastDuration : 0;
 
-            foreach ($processes as $index => $process) {
-                if ($process->isRunning()) {
-                    $isRunning = true;
+                if ($timeLimit && microtime(true) - $startTime + $sleep > $timeLimit) {
+                    $this->io->writeln('Time limit of '.$timeLimit.' seconds reached.');
+
+                    return;
                 }
 
-                // Append new output to remaining buffer from previous loop run
-                $buffers[$index] .= $process->getIncrementalOutput();
+                usleep((int) ($sleep * 1000000));
 
-                // Split output into rows
-                $rows = explode("\n", $buffers[$index]);
+                $this->table->setRows([[getmypid(), ++$count, $path]]);
+                $this->tableOutput->clear();
+                $this->table->render();
 
-                // Buffer and remove last line of output, as it might be incomplete
-                $buffers[$index] = array_pop($rows);
+                $resizeStart = microtime(true);
 
-                // Write remaining rows to the output with thread prefix
-                $io->write(array_map(
-                    static function ($row) use ($index) {
-                        return sprintf('%02d: ', $index + 1).preg_replace('/^.*\r/s', '', $row)."\n";
-                    },
-                    $rows
-                ));
+                $this->resizeImage($path, true);
+
+                $lastDuration = microtime(true) - $resizeStart;
             }
+        } finally {
+            $this->tableOutput->clear();
+            $this->io->writeln('Resized '.$count.' Images.');
+        }
+    }
 
-            usleep(15000);
-        } while ($isRunning);
+    private function executeConcurrent(float $timeLimit, float $concurrent): int
+    {
+        $startTime = microtime(true);
+        $processStartTime = 0;
 
-        $io->write($buffers);
+        $phpFinder = new PhpExecutableFinder();
+        $phpPath = $phpFinder->find();
 
-        $io->write(array_map(
-            static function (Process $process): string {
-                return $process->getErrorOutput();
-            },
-            $processes
-        ));
+        $processes = array_fill(0, (int) $concurrent ?: 1, null);
+        $paths = array_fill(0, \count($processes), '');
+        $counts = array_fill(0, \count($processes), 0);
 
-        return max(...array_map(
-            static function (Process $process): int {
-                return (int) $process->getExitCode();
-            },
-            $processes
-        ));
+        foreach ($this->storage->listPaths() as $path) {
+            while (true) {
+                if ($timeLimit && microtime(true) - $startTime > $timeLimit) {
+                    $this->io->writeln('Time limit of '.$timeLimit.' seconds reached.');
+                    break 2;
+                }
+
+                foreach ($processes as $index => $process) {
+                    if (null !== $process) {
+                        if ($process->isRunning()) {
+                            continue;
+                        }
+
+                        $this->finishSubProcess($process, $paths[$index]);
+
+                        if ($concurrent < 1) {
+                            usleep((int) (
+                                (1 - $concurrent)
+                                / $concurrent
+                                * (microtime(true) - $processStartTime)
+                                * 1000000
+                            ));
+                        }
+                    }
+
+                    $process = new Process(array_merge(
+                        [$phpPath],
+                        $_SERVER['argv'],
+                        ['--image='.$path]
+                    ));
+
+                    $process->setTimeout(null);
+                    $process->start();
+
+                    if ($concurrent < 1) {
+                        $processStartTime = microtime(true);
+                    }
+
+                    $processes[$index] = $process;
+                    $paths[$index] = $path;
+                    ++$counts[$index];
+
+                    $this->updateOutput($processes, $counts, $paths);
+
+                    continue 3;
+                }
+
+                usleep(15000);
+            }
+        }
+
+        foreach ($processes as $index => $process) {
+            if (null === $process) {
+                continue;
+            }
+            $this->finishSubProcess($process, $paths[$index]);
+            unset($processes[$index]);
+            $this->updateOutput($processes, $counts, $paths);
+        }
+
+        $this->tableOutput->clear();
+
+        $this->io->writeln('Resized '.array_sum($counts).' Images.');
+
+        return 0;
+    }
+
+    private function updateOutput(array $processes, array $counts, array $paths): void
+    {
+        $rows = [];
+
+        foreach ($processes as $index => $process) {
+            $rows[] = [$process ? $process->getPid() : '', $counts[$index], $paths[$index]];
+        }
+
+        $this->table->setRows($rows);
+        $this->tableOutput->clear();
+        $this->table->render();
+    }
+
+    private function finishSubProcess(Process $process, string $path): void
+    {
+        $process->wait();
+
+        if (!$process->isSuccessful()) {
+            $this->io->writeln($path.' failed');
+        }
     }
 }

--- a/core-bundle/src/Command/ResizeImagesCommand.php
+++ b/core-bundle/src/Command/ResizeImagesCommand.php
@@ -131,7 +131,7 @@ class ResizeImagesCommand extends Command
         $concurrent = (float) $input->getOption('concurrent');
 
         if (false !== $input->getOption('throttle')) {
-            trigger_deprecation('contao/core-bundle', '4.10', 'Using the throttle option is deprecated and will no longer work in Contao 5.0. Use the concurrent option instead.', E_USER_DEPRECATED);
+            trigger_deprecation('contao/core-bundle', '4.9', 'Using the throttle option is deprecated and will no longer work in Contao 5.0. Use the concurrent option instead.', E_USER_DEPRECATED);
             $this->io->warning('Using the throttle option is deprecated, use the concurrent option instead.');
 
             $throttle = (float) $input->getOption('throttle');

--- a/core-bundle/src/Command/ResizeImagesCommand.php
+++ b/core-bundle/src/Command/ResizeImagesCommand.php
@@ -132,7 +132,6 @@ class ResizeImagesCommand extends Command
 
         if (false !== $input->getOption('throttle')) {
             trigger_deprecation('contao/core-bundle', '4.10', 'Using the throttle option is deprecated and will no longer work in Contao 5.0. Use the concurrent option instead.', E_USER_DEPRECATED);
-
             $this->io->warning('Using the throttle option is deprecated, use the concurrent option instead.');
 
             $throttle = (float) $input->getOption('throttle');
@@ -293,12 +292,7 @@ class ResizeImagesCommand extends Command
                         }
                     }
 
-                    $process = new Process(array_merge(
-                        [$phpPath],
-                        $_SERVER['argv'],
-                        ['--image='.$path]
-                    ));
-
+                    $process = new Process(array_merge([$phpPath], $_SERVER['argv'], ['--image='.$path]));
                     $process->setTimeout(null);
                     $process->start();
 
@@ -323,6 +317,7 @@ class ResizeImagesCommand extends Command
             if (null === $process) {
                 continue;
             }
+
             $this->finishSubProcess($process, $paths[$index]);
             unset($processes[$index]);
             $this->updateOutput($processes, $counts, $paths);

--- a/core-bundle/src/Command/ResizeImagesCommand.php
+++ b/core-bundle/src/Command/ResizeImagesCommand.php
@@ -131,7 +131,8 @@ class ResizeImagesCommand extends Command
         $concurrent = (float) $input->getOption('concurrent');
 
         if (false !== $input->getOption('throttle')) {
-            @trigger_error('Using the throttle option is deprecated and will no longer work in Contao 5.0. Use the concurrent option instead.', E_USER_DEPRECATED);
+            trigger_deprecation('contao/core-bundle', '4.10', 'Using the throttle option is deprecated and will no longer work in Contao 5.0. Use the concurrent option instead.', E_USER_DEPRECATED);
+
             $this->io->warning('Using the throttle option is deprecated, use the concurrent option instead.');
 
             $throttle = (float) $input->getOption('throttle');
@@ -163,7 +164,7 @@ class ResizeImagesCommand extends Command
 
     private function resizeImage(string $path, bool $quiet = false): int
     {
-        if ($this->filesystem->exists($this->targetDir.'/'.$path)) {
+        if ($this->filesystem->exists(Path::join($this->targetDir, $path))) {
             return 0;
         }
 

--- a/core-bundle/tests/Command/ResizeImagesCommandTest.php
+++ b/core-bundle/tests/Command/ResizeImagesCommandTest.php
@@ -46,11 +46,11 @@ class ResizeImagesCommandTest extends TestCase
 
         $command = $this->getCommand(null, null, $storage);
         $tester = new CommandTester($command);
-        $code = $tester->execute([]);
+        $code = $tester->execute([], ['capture_stderr_separately' => true]);
         $display = $tester->getDisplay();
 
         $this->assertSame(0, $code);
-        $this->assertRegExp('/All images resized/', $display);
+        $this->assertRegExp('/Resized 0 Images/', $display);
     }
 
     public function testResizesImages(): void
@@ -78,13 +78,13 @@ class ResizeImagesCommandTest extends TestCase
 
         $command = $this->getCommand($factory, $resizer, $storage);
         $tester = new CommandTester($command);
-        $code = $tester->execute([]);
+        $code = $tester->execute(['--no-sub-process' => true], ['capture_stderr_separately' => true]);
         $display = $tester->getDisplay();
 
         $this->assertSame(0, $code);
-        $this->assertRegExp('/image1.jpg.+done/', $display);
-        $this->assertRegExp('/image2.jpg.+done/', $display);
-        $this->assertRegExp('/All images resized/', $display);
+        $this->assertRegExp('/image1.jpg/', $display);
+        $this->assertRegExp('/image2.jpg/', $display);
+        $this->assertRegExp('/Resized 2 Images/', $display);
     }
 
     public function testTimeLimit(): void
@@ -120,16 +120,16 @@ class ResizeImagesCommandTest extends TestCase
 
         $command = $this->getCommand($factory, $resizer, $storage);
         $tester = new CommandTester($command);
-        $code = $tester->execute(['--time-limit' => 0.5]);
+        $code = $tester->execute(['--no-sub-process' => true, '--time-limit' => 0.5], ['capture_stderr_separately' => true]);
         $display = $tester->getDisplay();
 
         ClockMock::withClockMock(false);
 
         $this->assertSame(0, $code);
-        $this->assertRegExp('/image1.jpg.+done/', $display);
+        $this->assertRegExp('/image1.jpg/', $display);
         $this->assertRegExp('/Time limit of 0.5 seconds reached/', $display);
-        $this->assertNotRegExp('/image2.jpg.+done/', $display);
-        $this->assertNotRegExp('/All images resized/', $display);
+        $this->assertRegExp('/Resized 1 Images/', $display);
+        $this->assertNotRegExp('/image2.jpg/', $display);
     }
 
     private function getCommand(ImageFactoryInterface $factory = null, DeferredResizerInterface $resizer = null, DeferredImageStorageInterface $storage = null): ResizeImagesCommand


### PR DESCRIPTION
This is a port of #1486 with the Contao 4.10-specific additions (`trigger_deprecation()` and `Path::join()`).