### PR TITLE
Add missing where condition for url prefix check

### DIFF
--- a/core-bundle/src/EventListener/DataContainer/PageUrlListener.php
+++ b/core-bundle/src/EventListener/DataContainer/PageUrlListener.php
@@ -149,7 +149,7 @@ class PageUrlListener implements ResetInterface
         // First check if another root page uses the same url prefix and domain
         $count = $this->connection
             ->executeQuery(
-                'SELECT COUNT(*) FROM tl_page WHERE urlPrefix=:urlPrefix AND dns=:dns AND id!=:rootId',
+                "SELECT COUNT(*) FROM tl_page WHERE urlPrefix=:urlPrefix AND dns=:dns AND id!=:rootId AND type='root'",
                 [
                     'urlPrefix' => $value,
                     'dns' => $dc->activeRecord->dns,

--- a/core-bundle/tests/EventListener/DataContainer/PageUrlListenerTest.php
+++ b/core-bundle/tests/EventListener/DataContainer/PageUrlListenerTest.php
@@ -1055,7 +1055,7 @@ class PageUrlListenerTest extends TestCase
             ->expects($this->once())
             ->method('executeQuery')
             ->with(
-                'SELECT COUNT(*) FROM tl_page WHERE urlPrefix=:urlPrefix AND dns=:dns AND id!=:rootId',
+                "SELECT COUNT(*) FROM tl_page WHERE urlPrefix=:urlPrefix AND dns=:dns AND id!=:rootId AND type='root'",
                 ['urlPrefix' => 'en', 'dns' => 'www.example.com', 'rootId' => 1]
             )
             ->willReturn($statement)
@@ -1598,7 +1598,7 @@ class PageUrlListenerTest extends TestCase
         $statements = [];
 
         if ($prefixCheck) {
-            $args[] = ['SELECT COUNT(*) FROM tl_page WHERE urlPrefix=:urlPrefix AND dns=:dns AND id!=:rootId'];
+            $args[] = ["SELECT COUNT(*) FROM tl_page WHERE urlPrefix=:urlPrefix AND dns=:dns AND id!=:rootId AND type='root'"];
 
             $statement = $this->createMock(Statement::class);
             $statement


### PR DESCRIPTION
Currently it is not possible to remove the URL prefix because of this missing condition.