### PR TITLE
Harden the table options lookup in the Installer class

### DIFF
--- a/installation-bundle/src/Database/Installer.php
+++ b/installation-bundle/src/Database/Installer.php
@@ -238,11 +238,13 @@ class Installer
             $this->setLegacyOptions($table);
 
             $tableOptions = $this->connection
-                ->query("SHOW TABLE STATUS LIKE '".$tableName."'")
+                ->executeQuery(
+                    'SHOW TABLE STATUS WHERE Name = ? AND Engine IS NOT NULL AND Create_options IS NOT NULL AND Collation IS NOT NULL',
+                    [$tableName]
+                )
                 ->fetch(\PDO::FETCH_OBJ)
             ;
 
-            // The table does not yet exist
             if (false === $tableOptions) {
                 continue;
             }


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Closes #1934
| Docs PR or issue | -

This makes sure that the table options we're using in the `Installer` are actually available. This will now skip views for instance.

We labeled the original issue as feature. Imo this could also be considered a bugfix and would then need to target 4.9 instead.