### PR TITLE
Change the JSON-LD type "RegularPage" to "Page"

### DIFF
--- a/core-bundle/src/Resources/contao/pages/PageRegular.php
+++ b/core-bundle/src/Resources/contao/pages/PageRegular.php
@@ -826,7 +826,7 @@ class PageRegular extends Frontend
 			$meta = array
 			(
 				'@context' => array('contao' => 'https://schema.contao.org/'),
-				'@type' => 'contao:RegularPage',
+				'@type' => 'contao:Page',
 				'contao:pageId' => (int) $objPage->id,
 				'contao:noSearch' => $noSearch,
 				'contao:protected' => (bool) $objPage->protected,

--- a/core-bundle/src/Search/Indexer/DefaultIndexer.php
+++ b/core-bundle/src/Search/Indexer/DefaultIndexer.php
@@ -143,10 +143,16 @@ class DefaultIndexer implements IndexerInterface
 
     private function extendMetaFromJsonLdScripts(Document $document, array &$meta): void
     {
-        $jsonLds = $document->extractJsonLdScripts('https://schema.contao.org/', 'RegularPage');
+        $jsonLds = $document->extractJsonLdScripts('https://schema.contao.org/', 'Page');
 
         if (0 === \count($jsonLds)) {
-            $this->throwBecause('No JSON-LD found.');
+            $jsonLds = $document->extractJsonLdScripts('https://schema.contao.org/', 'RegularPage');
+
+            if (0 === \count($jsonLds)) {
+                $this->throwBecause('No JSON-LD found.');
+            }
+
+            @trigger_error('JSON-LD type "RegularPage" is deprecated and will no longer work in Contao 5.0. Use "Page" instead.', E_USER_DEPRECATED);
         }
 
         // Merge all entries to one meta array (the latter overrides the former)

--- a/core-bundle/src/Search/Indexer/DefaultIndexer.php
+++ b/core-bundle/src/Search/Indexer/DefaultIndexer.php
@@ -152,7 +152,7 @@ class DefaultIndexer implements IndexerInterface
                 $this->throwBecause('No JSON-LD found.');
             }
 
-            @trigger_error('JSON-LD type "RegularPage" is deprecated and will no longer work in Contao 5.0. Use "Page" instead.', E_USER_DEPRECATED);
+            @trigger_error('Using the JSON-LD type "RegularPage" has been deprecated and will no longer work in Contao 5.0. Use "Page" instead.', E_USER_DEPRECATED);
         }
 
         // Merge all entries to one meta array (the latter overrides the former)

--- a/core-bundle/tests/EventListener/SearchIndexListenerTest.php
+++ b/core-bundle/tests/EventListener/SearchIndexListenerTest.php
@@ -52,7 +52,7 @@ class SearchIndexListenerTest extends TestCase
     {
         yield 'Should index because the response was successful and contains ld+json information' => [
             Request::create('/foobar'),
-            new Response('<html><body><script type="application/ld+json">{"@context":"https:\/\/contao.org\/","@type":"PageMetaData","pageId":2,"noSearch":false,"protected":false,"groups":[],"fePreview":false}</script></body></html>'),
+            new Response('<html><body><script type="application/ld+json">{"@context":"https:\/\/contao.org\/","@type":"Page","pageId":2,"noSearch":false,"protected":false,"groups":[],"fePreview":false}</script></body></html>'),
             SearchIndexListener::FEATURE_DELETE | SearchIndexListener::FEATURE_INDEX,
             true,
             false,
@@ -60,7 +60,7 @@ class SearchIndexListenerTest extends TestCase
 
         yield 'Should not index because even though the response was successful and contains ld+json information, it was disabled by the feature flag' => [
             Request::create('/foobar'),
-            new Response('<html><body><script type="application/ld+json">{"@context":"https:\/\/contao.org\/","@type":"PageMetaData","pageId":2,"noSearch":false,"protected":false,"groups":[],"fePreview":false}</script></body></html>'),
+            new Response('<html><body><script type="application/ld+json">{"@context":"https:\/\/contao.org\/","@type":"Page","pageId":2,"noSearch":false,"protected":false,"groups":[],"fePreview":false}</script></body></html>'),
             SearchIndexListener::FEATURE_DELETE,
             false,
             false,
@@ -100,7 +100,7 @@ class SearchIndexListenerTest extends TestCase
 
         yield 'Should be deleted because the response was not successful (404)' => [
             Request::create('/foobar', 'GET'),
-            new Response('<html><body><script type="application/ld+json">{"@context":"https:\/\/contao.org\/","@type":"PageMetaData","pageId":2,"noSearch":false,"protected":false,"groups":[],"fePreview":false}</script></body></html>', 404),
+            new Response('<html><body><script type="application/ld+json">{"@context":"https:\/\/contao.org\/","@type":"Page","pageId":2,"noSearch":false,"protected":false,"groups":[],"fePreview":false}</script></body></html>', 404),
             SearchIndexListener::FEATURE_DELETE | SearchIndexListener::FEATURE_INDEX,
             false,
             true,
@@ -108,7 +108,7 @@ class SearchIndexListenerTest extends TestCase
 
         yield 'Should be deleted because the response was not successful (403)' => [
             Request::create('/foobar', 'GET'),
-            new Response('<html><body><script type="application/ld+json">{"@context":"https:\/\/contao.org\/","@type":"PageMetaData","pageId":2,"noSearch":false,"protected":false,"groups":[],"fePreview":false}</script></body></html>', 403),
+            new Response('<html><body><script type="application/ld+json">{"@context":"https:\/\/contao.org\/","@type":"Page","pageId":2,"noSearch":false,"protected":false,"groups":[],"fePreview":false}</script></body></html>', 403),
             SearchIndexListener::FEATURE_DELETE | SearchIndexListener::FEATURE_INDEX,
             false,
             true,
@@ -116,7 +116,7 @@ class SearchIndexListenerTest extends TestCase
 
         yield 'Should not be deleted because even though the response was not successful (403), it was disabled by the feature flag ' => [
             Request::create('/foobar', 'GET'),
-            new Response('<html><body><script type="application/ld+json">{"@context":"https:\/\/contao.org\/","@type":"PageMetaData","pageId":2,"noSearch":false,"protected":false,"groups":[],"fePreview":false}</script></body></html>', 403),
+            new Response('<html><body><script type="application/ld+json">{"@context":"https:\/\/contao.org\/","@type":"Page","pageId":2,"noSearch":false,"protected":false,"groups":[],"fePreview":false}</script></body></html>', 403),
             SearchIndexListener::FEATURE_INDEX,
             false,
             false,

--- a/core-bundle/tests/Search/DocumentTest.php
+++ b/core-bundle/tests/Search/DocumentTest.php
@@ -61,54 +61,54 @@ class DocumentTest extends TestCase
         ];
 
         yield 'Test with one valid json ld element' => [
-            '<html><body><script type="application/ld+json">{"@context":"https:\/\/contao.org\/","@type":"PageMetaData","foobar":true}</script></body></html>',
+            '<html><body><script type="application/ld+json">{"@context":"https:\/\/contao.org\/","@type":"Page","foobar":true}</script></body></html>',
             [
                 [
-                    '@type' => 'PageMetaData',
+                    '@type' => 'Page',
                     'foobar' => true,
                 ],
             ],
         ];
 
         yield 'Test with one valid json ld element without context' => [
-            '<html><body><script type="application/ld+json">{"@type":"https:\/\/contao.org\/PageMetaData","https:\/\/contao.org\/foobar":true}</script></body></html>',
+            '<html><body><script type="application/ld+json">{"@type":"https:\/\/contao.org\/Page","https:\/\/contao.org\/foobar":true}</script></body></html>',
             [
                 [
-                    '@type' => 'PageMetaData',
+                    '@type' => 'Page',
                     'foobar' => true,
                 ],
             ],
         ];
 
         yield 'Test with one valid json ld element with context prefix' => [
-            '<html><body><script type="application/ld+json">{"@context":{"contao":"https:\/\/contao.org\/"},"@type":"contao:PageMetaData","contao:foobar":true}</script></body></html>',
+            '<html><body><script type="application/ld+json">{"@context":{"contao":"https:\/\/contao.org\/"},"@type":"contao:Page","contao:foobar":true}</script></body></html>',
             [
                 [
-                    '@type' => 'PageMetaData',
+                    '@type' => 'Page',
                     'foobar' => true,
                 ],
             ],
         ];
 
         yield 'Test with two valid json ld elements' => [
-            '<html><body><script type="application/ld+json">{"@context":"https:\/\/contao.org\/","@type":"PageMetaData","foobar":true}</script><script type="application/ld+json">{"@context":"https:\/\/contao.org\/","@type":"PageMetaData","foobar":false}</script></body></html>',
+            '<html><body><script type="application/ld+json">{"@context":"https:\/\/contao.org\/","@type":"Page","foobar":true}</script><script type="application/ld+json">{"@context":"https:\/\/contao.org\/","@type":"Page","foobar":false}</script></body></html>',
             [
                 [
-                    '@type' => 'PageMetaData',
+                    '@type' => 'Page',
                     'foobar' => true,
                 ],
                 [
-                    '@type' => 'PageMetaData',
+                    '@type' => 'Page',
                     'foobar' => false,
                 ],
             ],
         ];
 
         yield 'Test with one valid and one invalid json ld element' => [
-            '<html><body><script type="application/ld+json">{"@context":"https:\/\/contao.org\/","@type":"PageMetaData","foobar":true}</script><script type="application/ld+json">{"@context":"https:\/\/contao.org\/", ...</script></body></html>',
+            '<html><body><script type="application/ld+json">{"@context":"https:\/\/contao.org\/","@type":"Page","foobar":true}</script><script type="application/ld+json">{"@context":"https:\/\/contao.org\/", ...</script></body></html>',
             [
                 [
-                    '@type' => 'PageMetaData',
+                    '@type' => 'Page',
                     'foobar' => true,
                 ],
             ],
@@ -121,7 +121,7 @@ class DocumentTest extends TestCase
             new Uri('https://example.com'),
             200,
             ['Content-Type' => ['text/html']],
-            '<html><body><script type="application/ld+json">{"@context":"https:\/\/contao.org\/","@type":"PageMetaData","foobar":true}</script></body></html>'
+            '<html><body><script type="application/ld+json">{"@context":"https:\/\/contao.org\/","@type":"Page","foobar":true}</script></body></html>'
         );
 
         $this->assertSame([], $document->extractJsonLdScripts('https://example.com/'));

--- a/core-bundle/tests/Search/Indexer/DefaultIndexerTest.php
+++ b/core-bundle/tests/Search/Indexer/DefaultIndexerTest.php
@@ -67,7 +67,7 @@ class DefaultIndexerTest extends ContaoTestCase
      */
     public function testIndexesADocumentDeprecated(): void
     {
-        $this->testIndexesADocument(...func_get_args());
+        $this->testIndexesADocument(...\func_get_args());
     }
 
     public function indexProvider(): \Generator

--- a/core-bundle/tests/Search/Indexer/DefaultIndexerTest.php
+++ b/core-bundle/tests/Search/Indexer/DefaultIndexerTest.php
@@ -60,16 +60,6 @@ class DefaultIndexerTest extends ContaoTestCase
         $indexer->index($document);
     }
 
-    /**
-     * @dataProvider indexProviderDeprecated
-     * @group legacy
-     * @expectedDeprecation JSON-LD type "RegularPage" is deprecated and will no longer work in Contao 5.0. Use "Page" instead.
-     */
-    public function testIndexesADocumentDeprecated(): void
-    {
-        $this->testIndexesADocument(...\func_get_args());
-    }
-
     public function indexProvider(): \Generator
     {
         yield 'Test does not index on empty content' => [
@@ -135,6 +125,17 @@ class DefaultIndexerTest extends ContaoTestCase
             null,
             true,
         ];
+    }
+
+    /**
+     * @group legacy
+     * @dataProvider indexProviderDeprecated
+     *
+     * @expectedDeprecation Using the JSON-LD type "RegularPage" has been deprecated and will no longer work in Contao 5.0. Use "Page" instead.
+     */
+    public function testIndexesADocumentWithDeprecatedJsonLd(Document $document, ?array $expectedIndexParams, string $expectedMessage = null, bool $indexProtected = false): void
+    {
+        $this->testIndexesADocument($document, $expectedIndexParams, $expectedMessage, $indexProtected);
     }
 
     public function indexProviderDeprecated(): \Generator


### PR DESCRIPTION
While reviewing #2054 I noticed that the JSON-LD `@type` we are currently using is inconsistent.

1. The “official” type from schema.contao.org is `Page`, see https://schema.contao.org/Page
2. Contao currently only indexes pages with the type `RegularPage`
3. Some tests still use the (old) type `PageMetaData`

This PR changes this now to `Page` everywhere and supports the type `RegularPage` for BC.