### PR TITLE
Use expectExceptionMessage() for non-deprecations

### DIFF
--- a/core-bundle/tests/DependencyInjection/Compiler/DataContainerCallbackPassTest.php
+++ b/core-bundle/tests/DependencyInjection/Compiler/DataContainerCallbackPassTest.php
@@ -524,7 +524,7 @@ class DataContainerCallbackPassTest extends TestCase
         $pass = new DataContainerCallbackPass();
 
         $this->expectException(InvalidDefinitionException::class);
-        $this->expectDeprecationMessage('The class "Contao\CoreBundle\Fixtures\EventListener\TestListener" does not have a method "onFooCallback".');
+        $this->expectExceptionMessage('The class "Contao\CoreBundle\Fixtures\EventListener\TestListener" does not have a method "onFooCallback".');
 
         $pass->process($container);
     }
@@ -548,7 +548,7 @@ class DataContainerCallbackPassTest extends TestCase
         $pass = new DataContainerCallbackPass();
 
         $this->expectException(InvalidDefinitionException::class);
-        $this->expectDeprecationMessage('The "Contao\CoreBundle\Fixtures\EventListener\TestListener::onPrivateCallback" method exists but is not public.');
+        $this->expectExceptionMessage('The "Contao\CoreBundle\Fixtures\EventListener\TestListener::onPrivateCallback" method exists but is not public.');
 
         $pass->process($container);
     }
@@ -564,7 +564,7 @@ class DataContainerCallbackPassTest extends TestCase
         $pass = new DataContainerCallbackPass();
 
         $this->expectException(InvalidDefinitionException::class);
-        $this->expectDeprecationMessage('The "Contao\CoreBundle\Fixtures\EventListener\TestListener::onPrivateCallback" method exists but is not public.');
+        $this->expectExceptionMessage('The "Contao\CoreBundle\Fixtures\EventListener\TestListener::onPrivateCallback" method exists but is not public.');
 
         $pass->process($container);
     }
@@ -580,7 +580,7 @@ class DataContainerCallbackPassTest extends TestCase
         $pass = new DataContainerCallbackPass();
 
         $this->expectException(InvalidDefinitionException::class);
-        $this->expectDeprecationMessage('Either specify a method name or implement the "onFooCallback" or __invoke method.');
+        $this->expectExceptionMessage('Either specify a method name or implement the "onFooCallback" or __invoke method.');
 
         $pass->process($container);
     }

--- a/core-bundle/tests/DependencyInjection/Compiler/RegisterHookListenersPassTest.php
+++ b/core-bundle/tests/DependencyInjection/Compiler/RegisterHookListenersPassTest.php
@@ -334,7 +334,7 @@ class RegisterHookListenersPassTest extends TestCase
         $pass = new RegisterHookListenersPass();
 
         $this->expectException(InvalidDefinitionException::class);
-        $this->expectDeprecationMessage('The class "Contao\CoreBundle\Fixtures\EventListener\TestListener" does not have a method "onFoo".');
+        $this->expectExceptionMessage('The class "Contao\CoreBundle\Fixtures\EventListener\TestListener" does not have a method "onFoo".');
 
         $pass->process($container);
     }
@@ -350,7 +350,7 @@ class RegisterHookListenersPassTest extends TestCase
         $pass = new RegisterHookListenersPass();
 
         $this->expectException(InvalidDefinitionException::class);
-        $this->expectDeprecationMessage('The "Contao\CoreBundle\Fixtures\EventListener\TestListener::onPrivateCallback" method exists but is not public.');
+        $this->expectExceptionMessage('The "Contao\CoreBundle\Fixtures\EventListener\TestListener::onPrivateCallback" method exists but is not public.');
 
         $pass->process($container);
     }
@@ -366,7 +366,7 @@ class RegisterHookListenersPassTest extends TestCase
         $pass = new RegisterHookListenersPass();
 
         $this->expectException(InvalidDefinitionException::class);
-        $this->expectDeprecationMessage('The "Contao\CoreBundle\Fixtures\EventListener\TestListener::onPrivateCallback" method exists but is not public.');
+        $this->expectExceptionMessage('The "Contao\CoreBundle\Fixtures\EventListener\TestListener::onPrivateCallback" method exists but is not public.');
 
         $pass->process($container);
     }
@@ -382,7 +382,7 @@ class RegisterHookListenersPassTest extends TestCase
         $pass = new RegisterHookListenersPass();
 
         $this->expectException(InvalidDefinitionException::class);
-        $this->expectDeprecationMessage('Either specify a method name or implement the "onFooBar" or __invoke method.');
+        $this->expectExceptionMessage('Either specify a method name or implement the "onFooBar" or __invoke method.');
 
         $pass->process($container);
     }


### PR DESCRIPTION
`expectDeprecationMessage()` is an alias for `expectExceptionMessage()`, but since they are not used for deprecations in this case this should be changed I think.