### PR TITLE
Set the singleSRC flag for the Youtube/Vimeo splash screen

### DIFF
--- a/core-bundle/src/Resources/contao/dca/tl_content.php
+++ b/core-bundle/src/Resources/contao/dca/tl_content.php
@@ -1849,6 +1849,8 @@ class tl_content extends Contao\Backend
 				case 'hyperlink':
 				case 'image':
 				case 'accordionSingle':
+				case 'youtube':
+				case 'vimeo':
 					$GLOBALS['TL_DCA'][$dc->table]['fields'][$dc->field]['eval']['extensions'] = Contao\Config::get('validImageTypes');
 					break;
 


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | -
| Docs PR or issue | -

The splash screen of the `youtube` and `vimeo` content element is stored in the `singleSRC` field but the `eval.extensions` config key is missing. With this PR it will be restricted to `contao.validImageTypes` like with the other image elements.