### PR TITLE
Support getOverwriteMetadata() in more models

### DIFF
--- a/calendar-bundle/src/Resources/contao/models/CalendarEventsModel.php
+++ b/calendar-bundle/src/Resources/contao/models/CalendarEventsModel.php
@@ -10,6 +10,7 @@
 
 namespace Contao;
 
+use Contao\CoreBundle\File\ModelMetadataTrait;
 use Contao\Model\Collection;
 
 /**
@@ -200,6 +201,8 @@ use Contao\Model\Collection;
  */
 class CalendarEventsModel extends Model
 {
+	use ModelMetadataTrait;
+
 	/**
 	 * Table name
 	 * @var string

--- a/core-bundle/src/File/ModelMetadataTrait.php
+++ b/core-bundle/src/File/ModelMetadataTrait.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\File;
+
+use Contao\Controller;
+use Contao\FilesModel;
+
+/**
+ * @property string $overwriteMeta
+ *
+ * @method array row()
+ */
+trait ModelMetadataTrait
+{
+    /**
+     * Get the default meta data or null if not applicable.
+     */
+    public function getOverwriteMetadata(): ?Metadata
+    {
+        // Ignore if "overwriteMeta" is not set
+        if (!$this->overwriteMeta) {
+            return null;
+        }
+
+        $data = $this->row();
+
+        // Normalize keys
+        if (isset($data['imageTitle'])) {
+            $data[Metadata::VALUE_TITLE] = $data['imageTitle'];
+        }
+
+        if (isset($data['imageUrl'])) {
+            $data[Metadata::VALUE_URL] = $data['imageUrl'];
+        }
+
+        unset($data['imageTitle'], $data['imageUrl']);
+
+        // Make sure we resolve insert tags pointing to files.
+        if (isset($data[Metadata::VALUE_URL])) {
+            $data[Metadata::VALUE_URL] = Controller::replaceInsertTags($data[Metadata::VALUE_URL]);
+        }
+
+        // Strip superfluous fields by intersecting with tl_files.meta.eval.metaFields
+        return new Metadata(array_intersect_key($data, array_flip(FilesModel::getMetaFields())));
+    }
+}

--- a/core-bundle/src/Resources/contao/models/ContentModel.php
+++ b/core-bundle/src/Resources/contao/models/ContentModel.php
@@ -10,7 +10,7 @@
 
 namespace Contao;
 
-use Contao\CoreBundle\File\Metadata;
+use Contao\CoreBundle\File\ModelMetadataTrait;
 use Contao\Model\Collection;
 
 /**
@@ -391,6 +391,8 @@ use Contao\Model\Collection;
  */
 class ContentModel extends Model
 {
+	use ModelMetadataTrait;
+
 	/**
 	 * Table name
 	 * @var string
@@ -469,42 +471,6 @@ class ContentModel extends Model
 		}
 
 		return static::countBy($arrColumns, array($intPid, $strParentTable), $arrOptions);
-	}
-
-	/**
-	 * Get the default metadata or null if not applicable.
-	 */
-	public function getOverwriteMetadata(): ?Metadata
-	{
-		// Ignore if "overwriteMeta" is not set
-		if (!$this->overwriteMeta)
-		{
-			return null;
-		}
-
-		$data = $this->row();
-
-		// Normalize keys
-		if (isset($data['imageTitle']))
-		{
-			$data[Metadata::VALUE_TITLE] = $data['imageTitle'];
-		}
-
-		if (isset($data['imageUrl']))
-		{
-			$data[Metadata::VALUE_URL] = $data['imageUrl'];
-		}
-
-		unset($data['imageTitle'], $data['imageUrl']);
-
-		// Make sure we resolve insert tags pointing to files.
-		if (isset($data[Metadata::VALUE_URL]))
-		{
-			$data[Metadata::VALUE_URL] = Controller::replaceInsertTags($data[Metadata::VALUE_URL]);
-		}
-
-		// Strip superfluous fields by intersecting with tl_files.meta.eval.metaFields
-		return new Metadata(array_intersect_key($data, array_flip(FilesModel::getMetaFields())));
 	}
 }
 

--- a/core-bundle/tests/File/MetadataTest.php
+++ b/core-bundle/tests/File/MetadataTest.php
@@ -12,16 +12,11 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Tests\File;
 
-use Contao\CalendarEventsModel;
 use Contao\ContentModel;
 use Contao\CoreBundle\File\Metadata;
 use Contao\CoreBundle\Tests\TestCase;
-use Contao\FaqModel;
 use Contao\FilesModel;
-use Contao\NewsModel;
 use Contao\System;
-use Symfony\Component\DependencyInjection\Definition;
-use Symfony\Component\HttpFoundation\RequestStack;
 
 class MetadataTest extends TestCase
 {
@@ -29,9 +24,7 @@ class MetadataTest extends TestCase
     {
         parent::setUp();
 
-        $container = $this->getContainerWithContaoConfiguration();
-        $container->setDefinition('request_stack', new Definition(RequestStack::class));
-        System::setContainer($container);
+        System::setContainer($this->getContainerWithContaoConfiguration());
 
         $GLOBALS['TL_DCA']['tl_files']['fields']['meta']['eval']['metaFields'] = [
             'title' => '', 'alt' => '', 'link' => '', 'caption' => '',
@@ -99,13 +92,10 @@ class MetadataTest extends TestCase
         $this->assertFalse($metadata->has('bar'));
     }
 
-    /**
-     * @dataProvider provideModelsThatContainMetadata
-     */
-    public function testCreatesMetadataContainerFromModel(string $modelClass): void
+    public function testCreatesMetadataContainerFromContentModel(): void
     {
-        /** @var ContentModel|CalendarEventsModel|NewsModel|FaqModel $model */
-        $model = (new \ReflectionClass($modelClass))->newInstanceWithoutConstructor();
+        /** @var ContentModel $model */
+        $model = (new \ReflectionClass(ContentModel::class))->newInstanceWithoutConstructor();
 
         $model->setRow([
             'id' => 100,
@@ -126,14 +116,6 @@ class MetadataTest extends TestCase
             ],
             $model->getOverwriteMetadata()->all()
         );
-    }
-
-    public function provideModelsThatContainMetadata(): \Generator
-    {
-        yield [ContentModel::class];
-        yield [CalendarEventsModel::class];
-        yield [NewsModel::class];
-        yield [FaqModel::class];
     }
 
     public function testDoesNotCreateMetadataContainerFromContentModelIfOverwriteIsDisabled(): void

--- a/faq-bundle/src/Resources/contao/models/FaqModel.php
+++ b/faq-bundle/src/Resources/contao/models/FaqModel.php
@@ -10,6 +10,7 @@
 
 namespace Contao;
 
+use Contao\CoreBundle\File\ModelMetadataTrait;
 use Contao\Model\Collection;
 
 /**
@@ -112,6 +113,8 @@ use Contao\Model\Collection;
  */
 class FaqModel extends Model
 {
+	use ModelMetadataTrait;
+
 	/**
 	 * Table name
 	 * @var string

--- a/news-bundle/src/Resources/contao/models/NewsModel.php
+++ b/news-bundle/src/Resources/contao/models/NewsModel.php
@@ -10,6 +10,7 @@
 
 namespace Contao;
 
+use Contao\CoreBundle\File\ModelMetadataTrait;
 use Contao\Model\Collection;
 
 /**
@@ -168,6 +169,8 @@ use Contao\Model\Collection;
  */
 class NewsModel extends Model
 {
+	use ModelMetadataTrait;
+
 	/**
 	 * Table name
 	 * @var string


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | -
| Docs PR or issue | -

While working on a PR to deprecate `Controller::addImageToTemplate` in 4.11, I noticed that we are still missing some places where you can overwrite metadata.

This PR adds the possibility to call `getOverwriteMetaData()` on not only the `ContentModel` but also the `CalendarEventsModel`, `FaqModel` and `NewsModel`. I introduced a `ModelMetadataTrait` to minimize code duplication that devs could also use in their own models if they adhere to the same field names.