### PR TITLE
Correctly handle empty manager config files

### DIFF
--- a/manager-bundle/src/Api/ManagerConfig.php
+++ b/manager-bundle/src/Api/ManagerConfig.php
@@ -62,10 +62,14 @@ class ManagerConfig
      */
     public function read(): array
     {
-        if (!is_file($this->configFile)) {
-            $this->config = [];
-        } else {
-            $this->config = Yaml::parse(file_get_contents($this->configFile));
+        $this->config = [];
+
+        if (is_file($this->configFile)) {
+            $config = Yaml::parse(file_get_contents($this->configFile));
+
+            if (\is_array($config)) {
+                $this->config = $config;
+            }
         }
 
         return $this->config;

--- a/manager-bundle/tests/Api/ManagerConfigTest.php
+++ b/manager-bundle/tests/Api/ManagerConfigTest.php
@@ -86,6 +86,13 @@ class ManagerConfigTest extends ContaoTestCase
         $this->assertSame(['bar' => 'foo'], $this->config->all());
     }
 
+    public function testIgnoresEmptyConfigFile()
+    {
+        $this->filesystem->dumpFile($this->tempfile, '');
+
+        $this->assertSame([], $this->config->all());
+    }
+
     private function dumpTestdata(array $data): void
     {
         $this->filesystem->dumpFile($this->tempfile, Yaml::dump($data));

--- a/manager-bundle/tests/Api/ManagerConfigTest.php
+++ b/manager-bundle/tests/Api/ManagerConfigTest.php
@@ -86,7 +86,7 @@ class ManagerConfigTest extends ContaoTestCase
         $this->assertSame(['bar' => 'foo'], $this->config->all());
     }
 
-    public function testIgnoresEmptyConfigFile()
+    public function testIgnoresEmptyConfigFile(): void
     {
         $this->filesystem->dumpFile($this->tempfile, '');
 


### PR DESCRIPTION
I noticed by accident that an error is thrown it the manager config file is empty, because the `ManagerConfig` would return `null` instead of an array.