### PR TITLE
Deprecate the Controller::addImageToTemplate() method

### DIFF
--- a/calendar-bundle/src/Resources/contao/modules/ModuleEventReader.php
+++ b/calendar-bundle/src/Resources/contao/modules/ModuleEventReader.php
@@ -293,7 +293,7 @@ class ModuleEventReader extends Events
 		if ($objEvent->addImage && null !== ($figureBuilder = $this->getFigureBuilderIfResourceExists($objEvent->singleSRC)))
 		{
 			$figureBuilder
-				->setSize($objEvent->size ?: $this->imgSize ?: null)
+				->setSize($this->imgSize ?: $objEvent->size ?: null)
 				->setMetaData($objEvent->getOverwriteMetaData())
 				->enableLightbox($objEvent->fullsize)
 				->build()

--- a/calendar-bundle/src/Resources/contao/modules/ModuleEventReader.php
+++ b/calendar-bundle/src/Resources/contao/modules/ModuleEventReader.php
@@ -13,6 +13,7 @@ namespace Contao;
 use Contao\CoreBundle\Exception\InternalServerErrorException;
 use Contao\CoreBundle\Exception\PageNotFoundException;
 use Contao\CoreBundle\Exception\RedirectResponseException;
+use Contao\CoreBundle\Image\Studio\LegacyFigureBuilderTrait;
 use Patchwork\Utf8;
 
 /**
@@ -27,6 +28,8 @@ use Patchwork\Utf8;
  */
 class ModuleEventReader extends Events
 {
+	use LegacyFigureBuilderTrait;
+
 	/**
 	 * Template
 	 * @var string
@@ -287,29 +290,14 @@ class ModuleEventReader extends Events
 		$objTemplate->addBefore = false;
 
 		// Add an image
-		if ($objEvent->addImage && $objEvent->singleSRC)
+		if ($objEvent->addImage && null !== ($figureBuilder = $this->getFigureBuilderIfResourceExists($objEvent->singleSRC)))
 		{
-			$objModel = FilesModel::findByUuid($objEvent->singleSRC);
-
-			if ($objModel !== null && is_file(System::getContainer()->getParameter('kernel.project_dir') . '/' . $objModel->path))
-			{
-				// Do not override the field now that we have a model registry (see #6303)
-				$arrEvent = $objEvent->row();
-
-				// Override the default image size
-				if ($this->imgSize)
-				{
-					$size = StringUtil::deserialize($this->imgSize);
-
-					if ($size[0] > 0 || $size[1] > 0 || is_numeric($size[2]) || ($size[2][0] ?? null) === '_')
-					{
-						$arrEvent['size'] = $this->imgSize;
-					}
-				}
-
-				$arrEvent['singleSRC'] = $objModel->path;
-				$this->addImageToTemplate($objTemplate, $arrEvent, null, null, $objModel);
-			}
+			$figureBuilder
+				->setSize($objEvent->size ?: $this->imgSize ?: null)
+				->setMetaData($objEvent->getOverwriteMetaData())
+				->enableLightbox($objEvent->fullsize)
+				->build()
+				->applyLegacyTemplateData($objTemplate, $objEvent->imagemargin, $objEvent->floating);
 		}
 
 		$objTemplate->enclosure = array();

--- a/calendar-bundle/src/Resources/contao/modules/ModuleEventReader.php
+++ b/calendar-bundle/src/Resources/contao/modules/ModuleEventReader.php
@@ -307,7 +307,7 @@ class ModuleEventReader extends Events
 
 			$figureBuilder
 				->setSize($imgSize)
-				->setMetaData($objEvent->getOverwriteMetaData())
+				->setMetadata($objEvent->getOverwriteMetadata())
 				->enableLightbox($objEvent->fullsize)
 				->build()
 				->applyLegacyTemplateData($objTemplate, $objEvent->imagemargin, $objEvent->floating);

--- a/calendar-bundle/src/Resources/contao/modules/ModuleEventReader.php
+++ b/calendar-bundle/src/Resources/contao/modules/ModuleEventReader.php
@@ -292,8 +292,21 @@ class ModuleEventReader extends Events
 		// Add an image
 		if ($objEvent->addImage && null !== ($figureBuilder = $this->getFigureBuilderIfResourceExists($objEvent->singleSRC)))
 		{
+			$imgSize = $objEvent->size ?: null;
+
+			// Override the default image size
+			if ($this->imgSize)
+			{
+				$size = StringUtil::deserialize($this->imgSize);
+
+				if ($size[0] > 0 || $size[1] > 0 || is_numeric($size[2]) || ($size[2][0] ?? null) === '_')
+				{
+					$imgSize = $this->imgSize;
+				}
+			}
+
 			$figureBuilder
-				->setSize($this->imgSize ?: $objEvent->size ?: null)
+				->setSize($imgSize)
 				->setMetaData($objEvent->getOverwriteMetaData())
 				->enableLightbox($objEvent->fullsize)
 				->build()

--- a/calendar-bundle/src/Resources/contao/modules/ModuleEventlist.php
+++ b/calendar-bundle/src/Resources/contao/modules/ModuleEventlist.php
@@ -272,20 +272,7 @@ class ModuleEventlist extends Events
 		$dayCount = 0;
 		$eventCount = 0;
 		$headerCount = 0;
-		$imgSize = false;
 
-		// Override the default image size
-		if ($this->imgSize)
-		{
-			$size = StringUtil::deserialize($this->imgSize);
-
-			if ($size[0] > 0 || $size[1] > 0 || is_numeric($size[2]) || ($size[2][0] ?? null) === '_')
-			{
-				$imgSize = $this->imgSize;
-			}
-		}
-
-		$projectDir = System::getContainer()->getParameter('kernel.project_dir');
 		$uuids = array();
 
 		for ($i=$offset; $i<$limit; $i++)
@@ -366,8 +353,21 @@ class ModuleEventlist extends Events
 				/** @var CalendarEventsModel $eventModel */
 				$eventModel = CalendarEventsModel::findByPk($event['id']);
 
+				$imgSize = $eventModel->size ?: null;
+
+				// Override the default image size
+				if ($this->imgSize)
+				{
+					$size = StringUtil::deserialize($this->imgSize);
+
+					if ($size[0] > 0 || $size[1] > 0 || is_numeric($size[2]) || ($size[2][0] ?? null) === '_')
+					{
+						$imgSize = $this->imgSize;
+					}
+				}
+
 				$figure = $figureBuilder
-					->setSize($imgSize ?: $eventModel->size ?: null)
+					->setSize($imgSize)
 					->setMetaData($eventModel->getOverwriteMetaData())
 					->enableLightbox($eventModel->fullsize)
 					->build();

--- a/calendar-bundle/src/Resources/contao/modules/ModuleEventlist.php
+++ b/calendar-bundle/src/Resources/contao/modules/ModuleEventlist.php
@@ -352,7 +352,6 @@ class ModuleEventlist extends Events
 			{
 				/** @var CalendarEventsModel $eventModel */
 				$eventModel = CalendarEventsModel::findByPk($event['id']);
-
 				$imgSize = $eventModel->size ?: null;
 
 				// Override the default image size
@@ -368,7 +367,7 @@ class ModuleEventlist extends Events
 
 				$figure = $figureBuilder
 					->setSize($imgSize)
-					->setMetaData($eventModel->getOverwriteMetaData())
+					->setMetadata($eventModel->getOverwriteMetadata())
 					->enableLightbox($eventModel->fullsize)
 					->build();
 
@@ -378,7 +377,7 @@ class ModuleEventlist extends Events
 					$figure = $figureBuilder
 						->setLinkHref($event['href'])
 						->setLinkAttribute('title', $objTemplate->readMore)
-						->setOptions(array('linkTitle' => $objTemplate->readMore)) // BC
+						->setOptions(array('linkTitle' => $objTemplate->readMore)) // Backwards compatibility
 						->build();
 				}
 

--- a/calendar-bundle/src/Resources/contao/modules/ModuleEventlist.php
+++ b/calendar-bundle/src/Resources/contao/modules/ModuleEventlist.php
@@ -367,7 +367,7 @@ class ModuleEventlist extends Events
 				$eventModel = CalendarEventsModel::findByPk($event['id']);
 
 				$figure = $figureBuilder
-					->setSize($eventModel->size ?: $this->imgSize ?: null)
+					->setSize($this->imgSize ?: $eventModel->size ?: null)
 					->setMetaData($eventModel->getOverwriteMetaData())
 					->enableLightbox($eventModel->fullsize)
 					->build();

--- a/calendar-bundle/src/Resources/contao/modules/ModuleEventlist.php
+++ b/calendar-bundle/src/Resources/contao/modules/ModuleEventlist.php
@@ -367,7 +367,7 @@ class ModuleEventlist extends Events
 				$eventModel = CalendarEventsModel::findByPk($event['id']);
 
 				$figure = $figureBuilder
-					->setSize($this->imgSize ?: $eventModel->size ?: null)
+					->setSize($imgSize ?: $eventModel->size ?: null)
 					->setMetaData($eventModel->getOverwriteMetaData())
 					->enableLightbox($eventModel->fullsize)
 					->build();

--- a/core-bundle/src/Image/Studio/FigureBuilder.php
+++ b/core-bundle/src/Image/Studio/FigureBuilder.php
@@ -163,7 +163,7 @@ class FigureBuilder
     private $options = [];
 
     /**
-     * @internal Use the Contao\Image\Studio\Studio factory to get an instance of this class
+     * @internal Use the Contao\CoreBundle\Image\Studio\Studio factory to get an instance of this class
      */
     public function __construct(ContainerInterface $locator, string $projectDir, string $uploadPath, array $validExtensions)
     {

--- a/core-bundle/src/Image/Studio/ImageResult.php
+++ b/core-bundle/src/Image/Studio/ImageResult.php
@@ -71,7 +71,7 @@ class ImageResult
      * @param string|ImageInterface                      $filePathOrImage
      * @param array|PictureConfiguration|int|string|null $sizeConfiguration
      *
-     * @internal Use the Contao\Image\Studio\Studio factory to get an instance of this class
+     * @internal Use the Contao\CoreBundle\Image\Studio\Studio factory to get an instance of this class
      */
     public function __construct(ContainerInterface $locator, string $projectDir, $filePathOrImage, $sizeConfiguration = null, ResizeOptions $resizeOptions = null)
     {

--- a/core-bundle/src/Image/Studio/LegacyFigureBuilderTrait.php
+++ b/core-bundle/src/Image/Studio/LegacyFigureBuilderTrait.php
@@ -16,9 +16,11 @@ use Contao\CoreBundle\Exception\InvalidResourceException;
 use Contao\System;
 
 /**
- * This trait is intended to be used in legacy content elements and modules
- * where dependency injection isn't available and missing images are silently
- * ignored for BC reasons.
+ * This trait simplifies the FigureBuilder usage in legacy content elements and
+ * modules where dependency injection isn't available and missing images are
+ * silently ignored for BC reasons.
+ *
+ * @internal
  */
 trait LegacyFigureBuilderTrait
 {

--- a/core-bundle/src/Image/Studio/LegacyFigureBuilderTrait.php
+++ b/core-bundle/src/Image/Studio/LegacyFigureBuilderTrait.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Image\Studio;
+
+use Contao\CoreBundle\Exception\InvalidResourceException;
+use Contao\System;
+
+/**
+ * This trait is intended to be used in legacy content elements and modules
+ * where dependency injection isn't available and missing images are silently
+ * ignored for BC reasons.
+ */
+trait LegacyFigureBuilderTrait
+{
+    private function getFigureBuilder(): FigureBuilder
+    {
+        /** @var Studio $studio */
+        $studio = System::getContainer()->get(Studio::class);
+
+        return $studio->createFigureBuilder();
+    }
+
+    /**
+     * Returns a FigureBuilder configured to use the given resource or null if
+     * the resource is invalid.
+     */
+    private function getFigureBuilderIfResourceExists($resource): ?FigureBuilder
+    {
+        if (empty($resource)) {
+            return null;
+        }
+
+        $figureBuilder = $this->getFigureBuilder();
+
+        try {
+            $figureBuilder->from($resource);
+        } catch (InvalidResourceException $e) {
+            return null;
+        }
+
+        return $figureBuilder;
+    }
+}

--- a/core-bundle/src/Image/Studio/LegacyFigureBuilderTrait.php
+++ b/core-bundle/src/Image/Studio/LegacyFigureBuilderTrait.php
@@ -17,8 +17,8 @@ use Contao\System;
 
 /**
  * This trait simplifies the FigureBuilder usage in legacy content elements and
- * modules where dependency injection isn't available and missing images are
- * silently ignored for BC reasons.
+ * front end modules where dependency injection is not available and missing
+ * images are silently ignored to remain backwards compatible.
  *
  * @internal
  */
@@ -26,10 +26,7 @@ trait LegacyFigureBuilderTrait
 {
     private function getFigureBuilder(): FigureBuilder
     {
-        /** @var Studio $studio */
-        $studio = System::getContainer()->get(Studio::class);
-
-        return $studio->createFigureBuilder();
+        return System::getContainer()->get(Studio::class)->createFigureBuilder();
     }
 
     /**

--- a/core-bundle/src/Image/Studio/LightboxResult.php
+++ b/core-bundle/src/Image/Studio/LightboxResult.php
@@ -46,7 +46,7 @@ class LightboxResult
      * @param string|ImageInterface|null                 $filePathOrImage
      * @param array|PictureConfiguration|int|string|null $sizeConfiguration
      *
-     * @internal Use the Contao\Image\Studio\Studio factory to get an instance of this class
+     * @internal Use the Contao\CoreBundle\Image\Studio\Studio factory to get an instance of this class
      */
     public function __construct(ContainerInterface $locator, $filePathOrImage, ?string $url, $sizeConfiguration = null, string $groupIdentifier = null, ResizeOptions $resizeOptions = null)
     {

--- a/core-bundle/src/Resources/contao/elements/ContentAccordion.php
+++ b/core-bundle/src/Resources/contao/elements/ContentAccordion.php
@@ -44,7 +44,7 @@ class ContentAccordion extends ContentElement
 		{
 			$figureBuilder
 				->setSize($this->size)
-				->setMetaData($this->objModel->getOverwriteMetaData())
+				->setMetadata($this->objModel->getOverwriteMetadata())
 				->enableLightbox($this->fullsize)
 				->build()
 				->applyLegacyTemplateData($this->Template, $this->imagemargin, $this->floating);

--- a/core-bundle/src/Resources/contao/elements/ContentAccordion.php
+++ b/core-bundle/src/Resources/contao/elements/ContentAccordion.php
@@ -10,6 +10,8 @@
 
 namespace Contao;
 
+use Contao\CoreBundle\Image\Studio\LegacyFigureBuilderTrait;
+
 /**
  * Front end content element "accordion".
  *
@@ -17,6 +19,8 @@ namespace Contao;
  */
 class ContentAccordion extends ContentElement
 {
+	use LegacyFigureBuilderTrait;
+
 	/**
 	 * Template
 	 * @var string
@@ -36,15 +40,14 @@ class ContentAccordion extends ContentElement
 		$this->Template->addBefore = false;
 
 		// Add an image
-		if ($this->addImage && $this->singleSRC)
+		if ($this->addImage && null !== ($figureBuilder = $this->getFigureBuilderIfResourceExists($this->singleSRC)))
 		{
-			$objModel = FilesModel::findByUuid($this->singleSRC);
-
-			if ($objModel !== null && is_file(System::getContainer()->getParameter('kernel.project_dir') . '/' . $objModel->path))
-			{
-				$this->singleSRC = $objModel->path;
-				$this->addImageToTemplate($this->Template, $this->arrData, null, null, $objModel);
-			}
+			$figureBuilder
+				->setSize($this->size)
+				->setMetaData($this->objModel->getOverwriteMetaData())
+				->enableLightbox($this->fullsize)
+				->build()
+				->applyLegacyTemplateData($this->Template, $this->imagemargin, $this->floating);
 		}
 
 		$classes = StringUtil::deserialize($this->mooClasses);

--- a/core-bundle/src/Resources/contao/elements/ContentGallery.php
+++ b/core-bundle/src/Resources/contao/elements/ContentGallery.php
@@ -217,7 +217,8 @@ class ContentGallery extends ContentElement
 		$colwidth = floor(100/$this->perRow);
 		$body = array();
 
-		$figureBuilder = $this->getFigureBuilder()
+		$figureBuilder = $this
+			->getFigureBuilder()
 			->setSize($this->size)
 			->setLightboxGroupIdentifier('lb' . $this->id)
 			->enableLightbox($this->fullsize);

--- a/core-bundle/src/Resources/contao/elements/ContentGallery.php
+++ b/core-bundle/src/Resources/contao/elements/ContentGallery.php
@@ -11,6 +11,7 @@
 namespace Contao;
 
 use Contao\CoreBundle\Exception\PageNotFoundException;
+use Contao\CoreBundle\Image\Studio\LegacyFigureBuilderTrait;
 use Contao\Model\Collection;
 
 /**
@@ -20,6 +21,8 @@ use Contao\Model\Collection;
  */
 class ContentGallery extends ContentElement
 {
+	use LegacyFigureBuilderTrait;
+
 	/**
 	 * Files object
 	 * @var Collection|FilesModel
@@ -100,15 +103,7 @@ class ContentGallery extends ContentElement
 				}
 
 				// Add the image
-				$images[$objFiles->path] = array
-				(
-					'id'         => $objFiles->id,
-					'uuid'       => $objFiles->uuid,
-					'name'       => $objFile->basename,
-					'singleSRC'  => $objFiles->path,
-					'filesModel' => $objFiles->current()
-				);
-
+				$images[$objFiles->path] = $objFiles->current();
 				$auxDate[] = $objFile->mtime;
 			}
 
@@ -138,15 +133,7 @@ class ContentGallery extends ContentElement
 					}
 
 					// Add the image
-					$images[$objSubfiles->path] = array
-					(
-						'id'         => $objSubfiles->id,
-						'uuid'       => $objSubfiles->uuid,
-						'name'       => $objFile->basename,
-						'singleSRC'  => $objSubfiles->path,
-						'filesModel' => $objSubfiles->current()
-					);
-
+					$images[$objSubfiles->path] = $objSubfiles->current();
 					$auxDate[] = $objFile->mtime;
 				}
 			}
@@ -228,8 +215,12 @@ class ContentGallery extends ContentElement
 
 		$rowcount = 0;
 		$colwidth = floor(100/$this->perRow);
-		$strLightboxId = 'lb' . $this->id;
 		$body = array();
+
+		$figureBuilder = $this->getFigureBuilder()
+			->setSize($this->size)
+			->setLightboxGroupIdentifier('lb' . $this->id)
+			->enableLightbox($this->fullsize);
 
 		// Rows
 		for ($i=$offset; $i<$limit; $i+=$this->perRow)
@@ -263,31 +254,24 @@ class ContentGallery extends ContentElement
 					$class_td .= ' col_last';
 				}
 
-				$objCell = new \stdClass();
-				$key = 'row_' . $rowcount . $class_tr . $class_eo;
-
-				// Empty cell
-				if (($j+$i) >= $limit || !\is_array($images[($i+$j)]))
+				// Image / empty cell
+				if (($j + $i) < $limit && null !== ($image = $images[$i + $j] ?? null))
 				{
-					$objCell->addImage = false;
-					$objCell->colWidth = $colwidth . '%';
-					$objCell->class = 'col_' . $j . $class_td;
+					$cellData = $figureBuilder
+						->fromFilesModel($image)
+						->build()
+						->getLegacyTemplateData($this->imagemargin);
 				}
 				else
 				{
-					// Add size and margin
-					$images[($i+$j)]['size'] = $this->size;
-					$images[($i+$j)]['imagemargin'] = $this->imagemargin;
-					$images[($i+$j)]['fullsize'] = $this->fullsize;
-
-					$this->addImageToTemplate($objCell, $images[($i+$j)], null, $strLightboxId, $images[($i+$j)]['filesModel']);
-
-					// Add column width and class
-					$objCell->colWidth = $colwidth . '%';
-					$objCell->class = 'col_' . $j . $class_td;
+					$cellData = array('addImage' => false);
 				}
 
-				$body[$key][$j] = $objCell;
+				// Add column width and class
+				$cellData['colWidth'] = $colwidth . '%';
+				$cellData['class'] = 'col_' . $j . $class_td;
+
+				$body['row_' . $rowcount . $class_tr . $class_eo][$j] = (object) $cellData;
 			}
 
 			++$rowcount;

--- a/core-bundle/src/Resources/contao/elements/ContentHyperlink.php
+++ b/core-bundle/src/Resources/contao/elements/ContentHyperlink.php
@@ -10,6 +10,8 @@
 
 namespace Contao;
 
+use Contao\CoreBundle\Image\Studio\LegacyFigureBuilderTrait;
+
 /**
  * Front end content element "hyperlink".
  *
@@ -17,6 +19,8 @@ namespace Contao;
  */
 class ContentHyperlink extends ContentElement
 {
+	use LegacyFigureBuilderTrait;
+
 	/**
 	 * Template
 	 * @var string
@@ -40,16 +44,15 @@ class ContentHyperlink extends ContentElement
 		$embed = explode('%s', $this->embed);
 
 		// Use an image instead of the title
-		if ($this->useImage && $this->singleSRC)
+		if ($this->useImage && null !== ($figureBuilder = $this->getFigureBuilderIfResourceExists($this->singleSRC)))
 		{
-			$objModel = FilesModel::findByUuid($this->singleSRC);
+			$figureBuilder
+				->setSize($this->size)
+				->setMetaData($this->objModel->getOverwriteMetaData())
+				->build()
+				->applyLegacyTemplateData($this->Template);
 
-			if ($objModel !== null && is_file(System::getContainer()->getParameter('kernel.project_dir') . '/' . $objModel->path))
-			{
-				$this->singleSRC = $objModel->path;
-				$this->addImageToTemplate($this->Template, $this->arrData, null, null, $objModel);
-				$this->Template->useImage = true;
-			}
+			$this->Template->useImage = true;
 		}
 
 		if ($this->rel)

--- a/core-bundle/src/Resources/contao/elements/ContentHyperlink.php
+++ b/core-bundle/src/Resources/contao/elements/ContentHyperlink.php
@@ -48,7 +48,7 @@ class ContentHyperlink extends ContentElement
 		{
 			$figureBuilder
 				->setSize($this->size)
-				->setMetaData($this->objModel->getOverwriteMetaData())
+				->setMetadata($this->objModel->getOverwriteMetadata())
 				->build()
 				->applyLegacyTemplateData($this->Template);
 

--- a/core-bundle/src/Resources/contao/elements/ContentImage.php
+++ b/core-bundle/src/Resources/contao/elements/ContentImage.php
@@ -72,7 +72,7 @@ class ContentImage extends ContentElement
 
 		$figureBuilder
 			->setSize($this->size)
-			->setMetaData($this->objModel->getOverwriteMetaData())
+			->setMetadata($this->objModel->getOverwriteMetadata())
 			->enableLightbox($this->fullsize)
 			->build()
 			->applyLegacyTemplateData($this->Template, $this->imagemargin);

--- a/core-bundle/src/Resources/contao/elements/ContentImage.php
+++ b/core-bundle/src/Resources/contao/elements/ContentImage.php
@@ -10,6 +10,8 @@
 
 namespace Contao;
 
+use Contao\CoreBundle\Image\Studio\LegacyFigureBuilderTrait;
+
 /**
  * Front end content element "image".
  *
@@ -17,6 +19,8 @@ namespace Contao;
  */
 class ContentImage extends ContentElement
 {
+	use LegacyFigureBuilderTrait;
+
 	/**
 	 * Template
 	 * @var string
@@ -36,6 +40,8 @@ class ContentImage extends ContentElement
 	 */
 	public function generate()
 	{
+		// Note: These file operations are only here for BC reasons and do not
+		//       serve any functional purpose anymore.
 		if (!$this->singleSRC)
 		{
 			return '';
@@ -59,9 +65,19 @@ class ContentImage extends ContentElement
 	 */
 	protected function compile()
 	{
-		$this->arrData['floating'] = '';
+		$figureBuilder = $this->getFigureBuilderIfResourceExists($this->objFilesModel);
 
-		$this->addImageToTemplate($this->Template, $this->arrData, null, null, $this->objFilesModel);
+		if (null === $figureBuilder)
+		{
+			return;
+		}
+
+		$figureBuilder
+			->setSize($this->size)
+			->setMetaData($this->objModel->getOverwriteMetaData())
+			->enableLightbox($this->fullsize)
+			->build()
+			->applyLegacyTemplateData($this->Template, $this->imagemargin);
 	}
 }
 

--- a/core-bundle/src/Resources/contao/elements/ContentImage.php
+++ b/core-bundle/src/Resources/contao/elements/ContentImage.php
@@ -40,8 +40,6 @@ class ContentImage extends ContentElement
 	 */
 	public function generate()
 	{
-		// Note: These file operations are only here for BC reasons and do not
-		//       serve any functional purpose anymore.
 		if (!$this->singleSRC)
 		{
 			return '';

--- a/core-bundle/src/Resources/contao/elements/ContentText.php
+++ b/core-bundle/src/Resources/contao/elements/ContentText.php
@@ -51,7 +51,7 @@ class ContentText extends ContentElement
 			$figureBuilder
 				->setSize($this->size)
 				->setMetaData($this->objModel->getOverwriteMetaData())
-				->enableLightbox()
+				->enableLightbox($this->fullsize)
 				->build()
 				->applyLegacyTemplateData($this->Template, $this->imagemargin, $this->floating);
 		}

--- a/core-bundle/src/Resources/contao/elements/ContentText.php
+++ b/core-bundle/src/Resources/contao/elements/ContentText.php
@@ -50,7 +50,7 @@ class ContentText extends ContentElement
 		{
 			$figureBuilder
 				->setSize($this->size)
-				->setMetaData($this->objModel->getOverwriteMetaData())
+				->setMetadata($this->objModel->getOverwriteMetadata())
 				->enableLightbox($this->fullsize)
 				->build()
 				->applyLegacyTemplateData($this->Template, $this->imagemargin, $this->floating);

--- a/core-bundle/src/Resources/contao/elements/ContentText.php
+++ b/core-bundle/src/Resources/contao/elements/ContentText.php
@@ -10,6 +10,8 @@
 
 namespace Contao;
 
+use Contao\CoreBundle\Image\Studio\LegacyFigureBuilderTrait;
+
 /**
  * Front end content element "text".
  *
@@ -17,6 +19,8 @@ namespace Contao;
  */
 class ContentText extends ContentElement
 {
+	use LegacyFigureBuilderTrait;
+
 	/**
 	 * Template
 	 * @var string
@@ -42,15 +46,14 @@ class ContentText extends ContentElement
 		$this->Template->addBefore = false;
 
 		// Add an image
-		if ($this->addImage && $this->singleSRC)
+		if ($this->addImage && null !== ($figureBuilder = $this->getFigureBuilderIfResourceExists($this->singleSRC)))
 		{
-			$objModel = FilesModel::findByUuid($this->singleSRC);
-
-			if ($objModel !== null && is_file(System::getContainer()->getParameter('kernel.project_dir') . '/' . $objModel->path))
-			{
-				$this->singleSRC = $objModel->path;
-				$this->addImageToTemplate($this->Template, $this->arrData, null, null, $objModel);
-			}
+			$figureBuilder
+				->setSize($this->size)
+				->setMetaData($this->objModel->getOverwriteMetaData())
+				->enableLightbox()
+				->build()
+				->applyLegacyTemplateData($this->Template, $this->imagemargin, $this->floating);
 		}
 	}
 }

--- a/core-bundle/src/Resources/contao/elements/ContentVimeo.php
+++ b/core-bundle/src/Resources/contao/elements/ContentVimeo.php
@@ -10,6 +10,8 @@
 
 namespace Contao;
 
+use Contao\CoreBundle\Image\Studio\LegacyFigureBuilderTrait;
+
 /**
  * Content element "Vimeo".
  *
@@ -17,6 +19,8 @@ namespace Contao;
  */
 class ContentVimeo extends ContentElement
 {
+	use LegacyFigureBuilderTrait;
+
 	/**
 	 * Template
 	 * @var string
@@ -110,18 +114,12 @@ class ContentVimeo extends ContentElement
 		}
 
 		// Add a splash image
-		if ($this->splashImage)
+		if ($this->splashImage && null !== ($figureBuilder = $this->getFigureBuilderIfResourceExists($this->singleSRC)))
 		{
-			$objFile = FilesModel::findByUuid($this->singleSRC);
-
-			if ($objFile !== null && is_file(TL_ROOT . '/' . $objFile->path))
-			{
-				$this->singleSRC = $objFile->path;
-
-				$objSplash = new \stdClass();
-				$this->addImageToTemplate($objSplash, $this->arrData, null, null, $objFile);
-				$this->Template->splashImage = $objSplash;
-			}
+			$this->Template->splashImage = (object) $figureBuilder
+				->setSize($this->size)
+				->build()
+				->getLegacyTemplateData();
 		}
 
 		$this->Template->src = $url;

--- a/core-bundle/src/Resources/contao/elements/ContentYouTube.php
+++ b/core-bundle/src/Resources/contao/elements/ContentYouTube.php
@@ -10,6 +10,8 @@
 
 namespace Contao;
 
+use Contao\CoreBundle\Image\Studio\LegacyFigureBuilderTrait;
+
 /**
  * Content element "YouTube".
  *
@@ -17,6 +19,8 @@ namespace Contao;
  */
 class ContentYouTube extends ContentElement
 {
+	use LegacyFigureBuilderTrait;
+
 	/**
 	 * Template
 	 * @var string
@@ -125,18 +129,12 @@ class ContentYouTube extends ContentElement
 		}
 
 		// Add a splash image
-		if ($this->splashImage)
+		if ($this->splashImage && null !== ($figureBuilder = $this->getFigureBuilderIfResourceExists($this->singleSRC)))
 		{
-			$objFile = FilesModel::findByUuid($this->singleSRC);
-
-			if ($objFile !== null && is_file(TL_ROOT . '/' . $objFile->path))
-			{
-				$this->singleSRC = $objFile->path;
-
-				$objSplash = new \stdClass();
-				$this->addImageToTemplate($objSplash, $this->arrData, null, null, $objFile);
-				$this->Template->splashImage = $objSplash;
-			}
+			$this->Template->splashImage = (object) $figureBuilder
+				->setSize($this->size)
+				->build()
+				->getLegacyTemplateData();
 		}
 
 		$this->Template->src = $url;

--- a/core-bundle/src/Resources/contao/library/Contao/Controller.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Controller.php
@@ -1494,12 +1494,12 @@ abstract class Controller extends System
 	 * @param string|null     $lightboxGroupIdentifier An optional lightbox group identifier
 	 * @param FilesModel|null $filesModel              An optional files model
 	 *
-	 * @deprecated Deprecated since Contao 4.11, to be removed in Contao 5.0.
-	 *             Use the Contao\Image\Studio\FigureBuilder instead.
+	 * @deprecated Deprecated since Contao 4.11, to be removed in Contao 5.0;
+	 *             use the Contao\CoreBundle\Image\Studio\FigureBuilder instead.
 	 */
 	public static function addImageToTemplate($template, array $rowData, $maxWidth = null, $lightboxGroupIdentifier = null, FilesModel $filesModel = null): void
 	{
-		trigger_deprecation('contao/core-bundle', '4.11', 'Using Controller::addImageToTemplate() is deprecated and will no longer work in Contao 5.0. Use the "Contao\Image\Studio\FigureBuilder" instead.');
+		trigger_deprecation('contao/core-bundle', '4.11', 'Using Controller::addImageToTemplate() is deprecated and will no longer work in Contao 5.0. Use the "Contao\CoreBundle\Image\Studio\FigureBuilder" class instead.');
 
 		// Helper: Create metadata from the specified row data
 		$createMetadataOverwriteFromRowData = static function (bool $interpretAsContentModel) use ($rowData)

--- a/core-bundle/src/Resources/contao/library/Contao/Controller.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Controller.php
@@ -1493,9 +1493,14 @@ abstract class Controller extends System
 	 * @param integer|null    $maxWidth                An optional maximum width of the image
 	 * @param string|null     $lightboxGroupIdentifier An optional lightbox group identifier
 	 * @param FilesModel|null $filesModel              An optional files model
+	 *
+	 * @deprecated Deprecated since Contao 4.11, to be removed in Contao 5.0.
+	 *             Use the Contao\Image\Studio\FigureBuilder instead.
 	 */
 	public static function addImageToTemplate($template, array $rowData, $maxWidth = null, $lightboxGroupIdentifier = null, FilesModel $filesModel = null): void
 	{
+		trigger_deprecation('contao/core-bundle', '4.11', 'Using Controller::addImageToTemplate() is deprecated and will no longer work in Contao 5.0. Use the "Contao\Image\Studio\FigureBuilder" instead.');
+
 		// Helper: Create metadata from the specified row data
 		$createMetadataOverwriteFromRowData = static function (bool $interpretAsContentModel) use ($rowData)
 		{

--- a/core-bundle/src/Resources/contao/modules/ModuleRandomImage.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleRandomImage.php
@@ -125,20 +125,19 @@ class ModuleRandomImage extends Module
 			return;
 		}
 
-		$imageData = $this->getFigureBuilder()
+		$imageData = $this
+			->getFigureBuilder()
 			->fromFilesModel($images[array_rand($images)])
 			->setSize($this->imgSize)
 			->enableLightbox($this->fullsize)
 			->build()
 			->getLegacyTemplateData();
 
-		$this->Template->setData(
-			array_merge(
-				$this->Template->getData(),
-				$imageData,
-				array('caption' => $this->useCaption ? $imageData['title'] ?? '' : null)
-			)
-		);
+		$this->Template->setData(array_merge(
+			$this->Template->getData(),
+			$imageData,
+			array('caption' => $this->useCaption ? $imageData['title'] ?? '' : null)
+		));
 	}
 }
 

--- a/core-bundle/src/Resources/contao/modules/ModuleRandomImage.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleRandomImage.php
@@ -10,6 +10,7 @@
 
 namespace Contao;
 
+use Contao\CoreBundle\Image\Studio\LegacyFigureBuilderTrait;
 use Contao\Model\Collection;
 
 /**
@@ -19,6 +20,8 @@ use Contao\Model\Collection;
  */
 class ModuleRandomImage extends Module
 {
+	use LegacyFigureBuilderTrait;
+
 	/**
 	 * Files object
 	 * @var Collection|FilesModel
@@ -83,14 +86,7 @@ class ModuleRandomImage extends Module
 				}
 
 				// Add the image
-				$images[$objFiles->path] = array
-				(
-					'id'         => $objFiles->id,
-					'name'       => $objFile->basename,
-					'singleSRC'  => $objFiles->path,
-					'title'      => StringUtil::specialchars($objFile->basename),
-					'filesModel' => $objFiles->current()
-				);
+				$images[$objFiles->path] = $objFiles->current();
 			}
 
 			// Folders
@@ -119,42 +115,30 @@ class ModuleRandomImage extends Module
 					}
 
 					// Add the image
-					$images[$objSubfiles->path] = array
-					(
-						'id'         => $objSubfiles->id,
-						'name'       => $objFile->basename,
-						'singleSRC'  => $objSubfiles->path,
-						'title'      => StringUtil::specialchars($objFile->basename),
-						'filesModel' => $objSubfiles->current()
-					);
+					$images[$objSubfiles->path] = $objSubfiles->current();
 				}
 			}
 		}
-
-		$images = array_values($images);
 
 		if (empty($images))
 		{
 			return;
 		}
 
-		$i = random_int(0, \count($images)-1);
+		$imageData = $this->getFigureBuilder()
+			->fromFilesModel($images[array_rand($images)])
+			->setSize($this->imgSize)
+			->enableLightbox($this->fullsize)
+			->build()
+			->getLegacyTemplateData();
 
-		$arrImage = $images[$i];
-
-		$arrImage['size'] = $this->imgSize;
-		$arrImage['fullsize'] = $this->fullsize;
-
-		if (!$this->useCaption)
-		{
-			$arrImage['caption'] = null;
-		}
-		elseif (!$arrImage['caption'])
-		{
-			$arrImage['caption'] = $arrImage['title'];
-		}
-
-		$this->addImageToTemplate($this->Template, $arrImage, null, null, $arrImage['filesModel']);
+		$this->Template->setData(
+			array_merge(
+				$this->Template->getData(),
+				$imageData,
+				array('caption' => $this->useCaption ? $imageData['title'] ?? '' : null)
+			)
+		);
 	}
 }
 

--- a/faq-bundle/src/Resources/contao/modules/ModuleFaqPage.php
+++ b/faq-bundle/src/Resources/contao/modules/ModuleFaqPage.php
@@ -112,8 +112,6 @@ class ModuleFaqPage extends Module
 					->enableLightbox($objFaq->fullsize)
 					->build()
 					->applyLegacyTemplateData($objTemp, $objFaq->imagemargin, $objFaq->floating);
-
-				$this->Template->useImage = true;
 			}
 
 			$objTemp->enclosure = array();

--- a/faq-bundle/src/Resources/contao/modules/ModuleFaqPage.php
+++ b/faq-bundle/src/Resources/contao/modules/ModuleFaqPage.php
@@ -107,7 +107,7 @@ class ModuleFaqPage extends Module
 			{
 				$figureBuilder
 					->setSize($objFaq->size)
-					->setMetaData($objFaq->getOverwriteMetaData())
+					->setMetadata($objFaq->getOverwriteMetadata())
 					->setLightboxGroupIdentifier('lightbox[' . substr(md5('mod_faqpage_' . $objFaq->id), 0, 6) . ']')
 					->enableLightbox($objFaq->fullsize)
 					->build()

--- a/faq-bundle/src/Resources/contao/modules/ModuleFaqReader.php
+++ b/faq-bundle/src/Resources/contao/modules/ModuleFaqReader.php
@@ -135,8 +135,6 @@ class ModuleFaqReader extends Module
 				->enableLightbox($objFaq->fullsize)
 				->build()
 				->applyLegacyTemplateData($this->Template, $objFaq->imagemargin, $objFaq->floating);
-
-			$this->Template->useImage = true;
 		}
 
 		$this->Template->enclosure = array();

--- a/faq-bundle/src/Resources/contao/modules/ModuleFaqReader.php
+++ b/faq-bundle/src/Resources/contao/modules/ModuleFaqReader.php
@@ -131,7 +131,7 @@ class ModuleFaqReader extends Module
 		{
 			$figureBuilder
 				->setSize($objFaq->size)
-				->setMetaData($objFaq->getOverwriteMetaData())
+				->setMetadata($objFaq->getOverwriteMetadata())
 				->enableLightbox($objFaq->fullsize)
 				->build()
 				->applyLegacyTemplateData($this->Template, $objFaq->imagemargin, $objFaq->floating);

--- a/news-bundle/src/Resources/contao/modules/ModuleNews.php
+++ b/news-bundle/src/Resources/contao/modules/ModuleNews.php
@@ -162,9 +162,22 @@ abstract class ModuleNews extends Module
 		$objTemplate->addImage = false;
 		$objTemplate->addBefore = false;
 
-		// Add image
+		// Add an image
 		if ($objArticle->addImage && null !== ($figureBuilder = $this->getFigureBuilderIfResourceExists($objArticle->singleSRC)))
 		{
+			$imgSize = $objArticle->size ?: null;
+
+			// Override the default image size
+			if ($this->imgSize)
+			{
+				$size = StringUtil::deserialize($this->imgSize);
+
+				if ($size[0] > 0 || $size[1] > 0 || is_numeric($size[2]) || ($size[2][0] ?? null) === '_')
+				{
+					$imgSize = $this->imgSize;
+				}
+			}
+
 			// If the external link is opened in a new window, open the image link in a new window, too (see #210)
 			if ('external' === $objTemplate->source && $objTemplate->target)
 			{
@@ -172,7 +185,7 @@ abstract class ModuleNews extends Module
 			}
 
 			$figure = $figureBuilder
-				->setSize($objArticle->size)
+				->setSize($imgSize)
 				->setMetaData($objArticle->getOverwriteMetaData())
 				->enableLightbox($objArticle->fullsize)
 				->build();

--- a/news-bundle/src/Resources/contao/modules/ModuleNews.php
+++ b/news-bundle/src/Resources/contao/modules/ModuleNews.php
@@ -10,6 +10,7 @@
 
 namespace Contao;
 
+use Contao\CoreBundle\Image\Studio\LegacyFigureBuilderTrait;
 use Contao\Model\Collection;
 
 /**
@@ -22,6 +23,8 @@ use Contao\Model\Collection;
  */
 abstract class ModuleNews extends Module
 {
+	use LegacyFigureBuilderTrait;
+
 	/**
 	 * Sort out protected archives
 	 *
@@ -159,49 +162,34 @@ abstract class ModuleNews extends Module
 		$objTemplate->addImage = false;
 		$objTemplate->addBefore = false;
 
-		// Add an image
-		if ($objArticle->addImage && $objArticle->singleSRC)
+		// Add image
+		if ($objArticle->addImage && null !== ($figureBuilder = $this->getFigureBuilderIfResourceExists($objArticle->singleSRC)))
 		{
-			$objModel = FilesModel::findByUuid($objArticle->singleSRC);
-
-			if ($objModel !== null && is_file(System::getContainer()->getParameter('kernel.project_dir') . '/' . $objModel->path))
+			// If the external link is opened in a new window, open the image link in a new window, too (see #210)
+			if ('external' === $objTemplate->source && $objTemplate->target)
 			{
-				// Do not override the field now that we have a model registry (see #6303)
-				$arrArticle = $objArticle->row();
-
-				// Override the default image size
-				if ($this->imgSize)
-				{
-					$size = StringUtil::deserialize($this->imgSize);
-
-					if ($size[0] > 0 || $size[1] > 0 || is_numeric($size[2]) || ($size[2][0] ?? null) === '_')
-					{
-						$arrArticle['size'] = $this->imgSize;
-					}
-				}
-
-				$arrArticle['singleSRC'] = $objModel->path;
-				$this->addImageToTemplate($objTemplate, $arrArticle, null, null, $objModel);
-
-				// Link to the news article if no image link has been defined (see #30)
-				if (!$objTemplate->fullsize && !$objTemplate->imageUrl)
-				{
-					// Unset the image title attribute
-					$picture = $objTemplate->picture;
-					unset($picture['title']);
-					$objTemplate->picture = $picture;
-
-					// Link to the news article
-					$objTemplate->href = $objTemplate->link;
-					$objTemplate->linkTitle = StringUtil::specialchars(sprintf($GLOBALS['TL_LANG']['MSC']['readMore'], $objArticle->headline), true);
-
-					// If the external link is opened in a new window, open the image link in a new window, too (see #210)
-					if ($objTemplate->source == 'external' && $objTemplate->target && strpos($objTemplate->attributes, 'target="_blank"') === false)
-					{
-						$objTemplate->attributes .= ' target="_blank"';
-					}
-				}
+				$figureBuilder->setLinkAttribute('target', '_blank');
 			}
+
+			$figure = $figureBuilder
+				->setSize($objArticle->size)
+				->setMetaData($objArticle->getOverwriteMetaData())
+				->enableLightbox($objArticle->fullsize)
+				->build();
+
+			// Rebuild with link to news article if none is set
+			if (!$figure->getLinkHref())
+			{
+				$linkTitle = StringUtil::specialchars(sprintf($GLOBALS['TL_LANG']['MSC']['readMore'], $objArticle->headline), true);
+
+				$figure = $figureBuilder
+					->setLinkHref($objTemplate->link)
+					->setLinkAttribute('title', $linkTitle)
+					->setOptions(array('linkTitle' => $linkTitle)) // BC
+					->build();
+			}
+
+			$figure->applyLegacyTemplateData($objTemplate, $objArticle->imagemargin, $objArticle->floating);
 		}
 
 		$objTemplate->enclosure = array();

--- a/news-bundle/src/Resources/contao/modules/ModuleNews.php
+++ b/news-bundle/src/Resources/contao/modules/ModuleNews.php
@@ -178,7 +178,7 @@ abstract class ModuleNews extends Module
 				}
 			}
 
-			// If the external link is opened in a new window, open the image link in a new window, too (see #210)
+			// If the external link is opened in a new window, open the image link in a new window as well (see #210)
 			if ('external' === $objTemplate->source && $objTemplate->target)
 			{
 				$figureBuilder->setLinkAttribute('target', '_blank');
@@ -186,7 +186,7 @@ abstract class ModuleNews extends Module
 
 			$figure = $figureBuilder
 				->setSize($imgSize)
-				->setMetaData($objArticle->getOverwriteMetaData())
+				->setMetadata($objArticle->getOverwriteMetadata())
 				->enableLightbox($objArticle->fullsize)
 				->build();
 
@@ -198,7 +198,7 @@ abstract class ModuleNews extends Module
 				$figure = $figureBuilder
 					->setLinkHref($objTemplate->link)
 					->setLinkAttribute('title', $linkTitle)
-					->setOptions(array('linkTitle' => $linkTitle)) // BC
+					->setOptions(array('linkTitle' => $linkTitle)) // Backwards compatibility
 					->build();
 			}
 


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | -
| Docs PR or issue | -

This deprecates `Controller::addImageToTemplate` and rewires all usages. What I really like is that you can now see what the element's/module's figure is built from. Like: Is there a resize happening? From what data? Lightbox? Overwritten mtadata? ....

**Example**

before:
```php
// Add an image
if ($this->addImage && $this->singleSRC != '')
{
    $objModel = FilesModel::findByUuid($this->singleSRC);

    if ($objModel !== null && is_file(System::getContainer()->getParameter('kernel.project_dir') . '/' . $objModel->path))
    {
        $this->singleSRC = $objModel->path;
        $this->addImageToTemplate($this->Template, $this->arrData, null, null, $objModel);
    }
}
```

after:
```php
 // Add an image
if ($this->addImage && null !== ($figureBuilder = $this->getFigureBuilderIfResourceExists($this->singleSRC)))
{
    $figureBuilder
        ->setSize($this->size)
        ->setMetaData($this->objModel->getOverwriteMetaData())
        ->enableLightbox($this->fullsize)
        ->build()
        ->applyLegacyTemplateData($this->Template, $this->imagemargin, $this->floating);
}
```

This PR needs to be rebased once #2054 + #2060 are merged upstream and depends on #2071 for BC compatibility.