### PR TITLE
Fix the order of the CSRF and the private response listener

### DIFF
--- a/core-bundle/src/EventListener/CsrfTokenCookieSubscriber.php
+++ b/core-bundle/src/EventListener/CsrfTokenCookieSubscriber.php
@@ -81,8 +81,8 @@ class CsrfTokenCookieSubscriber implements EventSubscriberInterface
         return [
             // The priority must be higher than the one of the Symfony route listener (defaults to 32)
             KernelEvents::REQUEST => ['onKernelRequest', 36],
-            // The priority must be higher than the one of the make-response-private listener (defaults to -99)
-            KernelEvents::RESPONSE => ['onKernelResponse', -98],
+            // The priority must be higher than the one of the make-response-private listener (defaults to -896)
+            KernelEvents::RESPONSE => ['onKernelResponse', -832],
         ];
     }
 

--- a/core-bundle/src/EventListener/CsrfTokenCookieSubscriber.php
+++ b/core-bundle/src/EventListener/CsrfTokenCookieSubscriber.php
@@ -81,6 +81,7 @@ class CsrfTokenCookieSubscriber implements EventSubscriberInterface
         return [
             // The priority must be higher than the one of the Symfony route listener (defaults to 32)
             KernelEvents::REQUEST => ['onKernelRequest', 36],
+            // The priority must be higher than the one of the make-response-private listener (defaults to -99)
             KernelEvents::RESPONSE => ['onKernelResponse', -98],
         ];
     }

--- a/core-bundle/src/EventListener/CsrfTokenCookieSubscriber.php
+++ b/core-bundle/src/EventListener/CsrfTokenCookieSubscriber.php
@@ -81,7 +81,7 @@ class CsrfTokenCookieSubscriber implements EventSubscriberInterface
         return [
             // The priority must be higher than the one of the Symfony route listener (defaults to 32)
             KernelEvents::REQUEST => ['onKernelRequest', 36],
-            KernelEvents::RESPONSE => 'onKernelResponse',
+            KernelEvents::RESPONSE => ['onKernelResponse', -98],
         ];
     }
 

--- a/core-bundle/src/Resources/config/listener.yml
+++ b/core-bundle/src/Resources/config/listener.yml
@@ -140,6 +140,7 @@ services:
             - '@contao.routing.scope_matcher'
         tags:
             # The priority must be lower than the one of MergeHttpHeadersListener (defaults to 256)
+            # and must be lower than the one of the make-response-private listener (defaults to -98)
             - { name: kernel.event_listener, priority: -99 }
 
     contao.listener.merge_http_headers:

--- a/core-bundle/src/Resources/config/listener.yml
+++ b/core-bundle/src/Resources/config/listener.yml
@@ -140,8 +140,9 @@ services:
             - '@contao.routing.scope_matcher'
         tags:
             # The priority must be lower than the one of MergeHttpHeadersListener (defaults to 256)
-            # and must be lower than the one of the make-response-private listener (defaults to -98)
-            - { name: kernel.event_listener, priority: -99 }
+            # and must be lower than the one of the ClearSessionDataListener listener (defaults to -768)
+            # and must be lower than the one of the CsrfTokenCookieSubscriber listener (defaults to -832)
+            - { name: kernel.event_listener, priority: -896 }
 
     contao.listener.merge_http_headers:
         class: Contao\CoreBundle\EventListener\MergeHttpHeadersListener

--- a/core-bundle/src/Resources/config/listener.yml
+++ b/core-bundle/src/Resources/config/listener.yml
@@ -140,7 +140,7 @@ services:
             - '@contao.routing.scope_matcher'
         tags:
             # The priority must be lower than the one of MergeHttpHeadersListener (defaults to 256)
-            - kernel.event_listener
+            - { name: kernel.event_listener, priority: -99 }
 
     contao.listener.merge_http_headers:
         class: Contao\CoreBundle\EventListener\MergeHttpHeadersListener

--- a/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
+++ b/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
@@ -487,7 +487,7 @@ class ContaoCoreExtensionTest extends TestCase
         $this->assertSame(
             [
                 'kernel.request' => ['onKernelRequest', 36],
-                'kernel.response' => 'onKernelResponse',
+                'kernel.response' => ['onKernelResponse', -98],
             ],
             CsrfTokenCookieSubscriber::getSubscribedEvents()
         );
@@ -718,7 +718,9 @@ class ContaoCoreExtensionTest extends TestCase
         $this->assertSame(
             [
                 'kernel.event_listener' => [
-                    [],
+                    [
+                        'priority' => -99
+                    ],
                 ],
             ],
             $tags

--- a/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
+++ b/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
@@ -734,6 +734,11 @@ class ContaoCoreExtensionTest extends TestCase
 
         // Ensure that the listener is registered after the MergeHeaderListener
         $this->assertTrue($priority < $mergeHeadersListenerPriority);
+
+        $csrfCookieListenerPriority = CsrfTokenCookieSubscriber::getSubscribedEvents()['kernel.response'][1] ?? 0;
+
+        // Ensure that the listener is registered after the CsrfTokenCookieSubscriber
+        $this->assertTrue($priority < $csrfCookieListenerPriority);
     }
 
     public function testRegistersTheMergeHttpHeadersListener(): void

--- a/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
+++ b/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
@@ -738,7 +738,7 @@ class ContaoCoreExtensionTest extends TestCase
         $csrfCookieListenerPriority = CsrfTokenCookieSubscriber::getSubscribedEvents()['kernel.response'][1] ?? 0;
 
         // Ensure that the listener is registered after the CsrfTokenCookieSubscriber
-        $this->assertTrue($priority < $csrfCookieListenerPriority);
+        $this->assertTrue($priority < (int) $csrfCookieListenerPriority);
     }
 
     public function testRegistersTheMergeHttpHeadersListener(): void

--- a/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
+++ b/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
@@ -487,7 +487,7 @@ class ContaoCoreExtensionTest extends TestCase
         $this->assertSame(
             [
                 'kernel.request' => ['onKernelRequest', 36],
-                'kernel.response' => ['onKernelResponse', -98],
+                'kernel.response' => ['onKernelResponse', -832],
             ],
             CsrfTokenCookieSubscriber::getSubscribedEvents()
         );
@@ -719,7 +719,7 @@ class ContaoCoreExtensionTest extends TestCase
             [
                 'kernel.event_listener' => [
                     [
-                        'priority' => -99,
+                        'priority' => -896,
                     ],
                 ],
             ],
@@ -734,6 +734,13 @@ class ContaoCoreExtensionTest extends TestCase
 
         // Ensure that the listener is registered after the MergeHeaderListener
         $this->assertTrue($priority < $mergeHeadersListenerPriority);
+
+        $clearSessionDataListenerDefinition = $this->container->getDefinition('contao.listener.clear_session_data');
+        $clearSessionDataListenerTags = $clearSessionDataListenerDefinition->getTags();
+        $clearSessionDataListenerPriority = $clearSessionDataListenerTags['kernel.event_listener'][0]['priority'] ?? 0;
+
+        // Ensure that the listener is registered after the ClearSessionDataListener
+        $this->assertTrue($priority < $clearSessionDataListenerPriority);
 
         $csrfCookieListenerPriority = CsrfTokenCookieSubscriber::getSubscribedEvents()['kernel.response'][1] ?? 0;
 

--- a/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
+++ b/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
@@ -719,7 +719,7 @@ class ContaoCoreExtensionTest extends TestCase
             [
                 'kernel.event_listener' => [
                     [
-                        'priority' => -99
+                        'priority' => -99,
                     ],
                 ],
             ],


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #2067

The problem in #2067 was the order of the CSRF and make-response-private listeners: First, the make-response-private listener kept the response public, then the CSRF listener added a cookie-header to remove the CSRF cookie. This “cookie deletion” was then stored in the HTTP cache and every subsequent access to this resource always resulted in the CSRF cookie to get removed.

I’m not sure what the “correct” priorities for them are, but I think both listeners should come very late. /cc @Toflar 

### ToDo

- [x] Unit test to make sure the relative order is kept in the future.