### PR TITLE
Always render the "go to front end" link without preview fragment

### DIFF
--- a/core-bundle/src/Resources/contao/templates/backend/be_login.html5
+++ b/core-bundle/src/Resources/contao/templates/backend/be_login.html5
@@ -58,7 +58,7 @@
             </div>
             <div class="submit_container cf">
               <button type="submit" name="login" id="login" class="tl_submit"><?= $this->loginButton ?></button>
-              <a href="<?= $this->route('contao_root') ?>" class="footer_preview"><?= $this->feLink ?> ›</a>
+              <a href="/" class="footer_preview"><?= $this->feLink ?> ›</a>
             </div>
           </div>
         </form>


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #1796
| Docs PR or issue | -

The change is forward compatible with Contao 4.10.