### PR TITLE
Use HTTP status code 303 instead of 307 for redirects

### DIFF
--- a/core-bundle/src/Controller/BackendController.php
+++ b/core-bundle/src/Controller/BackendController.php
@@ -246,6 +246,6 @@ class BackendController extends Controller
             throw new BadRequestHttpException('Unsupported picker context');
         }
 
-        return new RedirectResponse($picker->getCurrentUrl(), Response::HTTP_SEE_OTHER);
+        return new RedirectResponse($picker->getCurrentUrl());
     }
 }

--- a/core-bundle/src/Controller/BackendController.php
+++ b/core-bundle/src/Controller/BackendController.php
@@ -246,6 +246,6 @@ class BackendController extends Controller
             throw new BadRequestHttpException('Unsupported picker context');
         }
 
-        return new RedirectResponse($picker->getCurrentUrl(), Response::HTTP_TEMPORARY_REDIRECT);
+        return new RedirectResponse($picker->getCurrentUrl(), Response::HTTP_SEE_OTHER);
     }
 }

--- a/core-bundle/src/Controller/BackendCsvImportController.php
+++ b/core-bundle/src/Controller/BackendCsvImportController.php
@@ -181,7 +181,7 @@ class BackendCsvImportController
             } catch (\RuntimeException $e) {
                 Message::addError($e->getMessage());
 
-                return new RedirectResponse($request->getUri(), Response::HTTP_TEMPORARY_REDIRECT);
+                return new RedirectResponse($request->getUri(), Response::HTTP_SEE_OTHER);
             }
 
             $this->connection->update(
@@ -190,7 +190,7 @@ class BackendCsvImportController
                 ['id' => $id]
             );
 
-            $response = new RedirectResponse($this->getBackUrl($request), Response::HTTP_TEMPORARY_REDIRECT);
+            $response = new RedirectResponse($this->getBackUrl($request), Response::HTTP_SEE_OTHER);
             $response->headers->setCookie(new Cookie('BE_PAGE_OFFSET', 0, 0, $request->getBasePath(), null, false, false));
 
             return $response;

--- a/core-bundle/src/Controller/BackendCsvImportController.php
+++ b/core-bundle/src/Controller/BackendCsvImportController.php
@@ -181,7 +181,7 @@ class BackendCsvImportController
             } catch (\RuntimeException $e) {
                 Message::addError($e->getMessage());
 
-                return new RedirectResponse($request->getUri(), Response::HTTP_SEE_OTHER);
+                return new RedirectResponse($request->getUri());
             }
 
             $this->connection->update(
@@ -190,7 +190,7 @@ class BackendCsvImportController
                 ['id' => $id]
             );
 
-            $response = new RedirectResponse($this->getBackUrl($request), Response::HTTP_SEE_OTHER);
+            $response = new RedirectResponse($this->getBackUrl($request));
             $response->headers->setCookie(new Cookie('BE_PAGE_OFFSET', 0, 0, $request->getBasePath(), null, false, false));
 
             return $response;

--- a/core-bundle/src/EventListener/ToggleViewListener.php
+++ b/core-bundle/src/EventListener/ToggleViewListener.php
@@ -15,7 +15,6 @@ use Contao\CoreBundle\Routing\ScopeMatcher;
 use Contao\System;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\RedirectResponse;
-use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 
 /**
@@ -63,7 +62,7 @@ class ToggleViewListener
 
         $this->framework->initialize();
 
-        $response = new RedirectResponse(System::getReferer(), Response::HTTP_SEE_OTHER);
+        $response = new RedirectResponse(System::getReferer());
         $response->headers->setCookie($this->getCookie($request->query->get('toggle_view'), $request->getBasePath()));
 
         $event->setResponse($response);

--- a/core-bundle/src/EventListener/ToggleViewListener.php
+++ b/core-bundle/src/EventListener/ToggleViewListener.php
@@ -63,7 +63,7 @@ class ToggleViewListener
 
         $this->framework->initialize();
 
-        $response = new RedirectResponse(System::getReferer(), Response::HTTP_TEMPORARY_REDIRECT);
+        $response = new RedirectResponse(System::getReferer(), Response::HTTP_SEE_OTHER);
         $response->headers->setCookie($this->getCookie($request->query->get('toggle_view'), $request->getBasePath()));
 
         $event->setResponse($response);

--- a/core-bundle/src/Exception/AjaxRedirectResponseException.php
+++ b/core-bundle/src/Exception/AjaxRedirectResponseException.php
@@ -27,7 +27,7 @@ class AjaxRedirectResponseException extends ResponseException
      * @param int             $status
      * @param \Exception|null $previous
      */
-    public function __construct($location, $status = 307, \Exception $previous = null)
+    public function __construct($location, $status = 303, \Exception $previous = null)
     {
         parent::__construct(new Response($location, $status, ['X-Ajax-Location' => $location]), $previous);
     }

--- a/core-bundle/src/Exception/RedirectResponseException.php
+++ b/core-bundle/src/Exception/RedirectResponseException.php
@@ -27,7 +27,7 @@ class RedirectResponseException extends ResponseException
      * @param int             $status
      * @param \Exception|null $previous
      */
-    public function __construct($location, $status = 307, \Exception $previous = null)
+    public function __construct($location, $status = 303, \Exception $previous = null)
     {
         parent::__construct(new RedirectResponse($location, $status), $previous);
     }

--- a/core-bundle/src/Resources/contao/controllers/FrontendShare.php
+++ b/core-bundle/src/Resources/contao/controllers/FrontendShare.php
@@ -33,7 +33,7 @@ class FrontendShare extends \Frontend
 				return new RedirectResponse(
 					'https://www.facebook.com/sharer/sharer.php'
 						. '?u=' . rawurlencode(\Input::get('u', true)),
-					Response::HTTP_TEMPORARY_REDIRECT
+					Response::HTTP_SEE_OTHER
 				);
 
 			case 'twitter':
@@ -41,17 +41,17 @@ class FrontendShare extends \Frontend
 					'https://twitter.com/intent/tweet'
 						. '?url=' . rawurlencode(\Input::get('u', true))
 						. '&text=' . rawurlencode(\Input::get('t', true)),
-					Response::HTTP_TEMPORARY_REDIRECT
+					Response::HTTP_SEE_OTHER
 				);
 
 			case 'gplus':
 				return new RedirectResponse(
 					'https://plus.google.com/share'
 						. '?url=' . rawurlencode(\Input::get('u', true)),
-					Response::HTTP_TEMPORARY_REDIRECT
+					Response::HTTP_SEE_OTHER
 				);
 		}
 
-		return new RedirectResponse('../', Response::HTTP_TEMPORARY_REDIRECT);
+		return new RedirectResponse('../', Response::HTTP_SEE_OTHER);
 	}
 }

--- a/core-bundle/src/Resources/contao/controllers/FrontendShare.php
+++ b/core-bundle/src/Resources/contao/controllers/FrontendShare.php
@@ -11,7 +11,6 @@
 namespace Contao;
 
 use Symfony\Component\HttpFoundation\RedirectResponse;
-use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Share a page via a social network.
@@ -32,26 +31,23 @@ class FrontendShare extends \Frontend
 			case 'facebook':
 				return new RedirectResponse(
 					'https://www.facebook.com/sharer/sharer.php'
-						. '?u=' . rawurlencode(\Input::get('u', true)),
-					Response::HTTP_SEE_OTHER
+						. '?u=' . rawurlencode(\Input::get('u', true))
 				);
 
 			case 'twitter':
 				return new RedirectResponse(
 					'https://twitter.com/intent/tweet'
 						. '?url=' . rawurlencode(\Input::get('u', true))
-						. '&text=' . rawurlencode(\Input::get('t', true)),
-					Response::HTTP_SEE_OTHER
+						. '&text=' . rawurlencode(\Input::get('t', true))
 				);
 
 			case 'gplus':
 				return new RedirectResponse(
 					'https://plus.google.com/share'
-						. '?url=' . rawurlencode(\Input::get('u', true)),
-					Response::HTTP_SEE_OTHER
+						. '?url=' . rawurlencode(\Input::get('u', true))
 				);
 		}
 
-		return new RedirectResponse('../', Response::HTTP_SEE_OTHER);
+		return new RedirectResponse('../');
 	}
 }

--- a/core-bundle/src/Resources/contao/library/Contao/Controller.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Controller.php
@@ -1002,9 +1002,9 @@ abstract class Controller extends \System
 	 * Redirect to another page
 	 *
 	 * @param string  $strLocation The target URL
-	 * @param integer $intStatus   The HTTP status code (defaults to 307)
+	 * @param integer $intStatus   The HTTP status code (defaults to 303)
 	 */
-	public static function redirect($strLocation, $intStatus=307)
+	public static function redirect($strLocation, $intStatus=303)
 	{
 		if (headers_sent())
 		{

--- a/core-bundle/src/Resources/contao/library/Contao/System.php
+++ b/core-bundle/src/Resources/contao/library/Contao/System.php
@@ -853,12 +853,12 @@ abstract class System
 	 * Redirect to another page
 	 *
 	 * @param string  $strLocation The target URL
-	 * @param integer $intStatus   The HTTP status code (defaults to 307)
+	 * @param integer $intStatus   The HTTP status code (defaults to 303)
 	 *
 	 * @deprecated Deprecated since Contao 4.0, to be removed in Contao 5.0.
 	 *             Use Controller::redirect() instead.
 	 */
-	public static function redirect($strLocation, $intStatus=307)
+	public static function redirect($strLocation, $intStatus=303)
 	{
 		@trigger_error('Using System::redirect() has been deprecated and will no longer work in Contao 5.0. Use Controller::redirect() instead.', E_USER_DEPRECATED);
 

--- a/core-bundle/src/Resources/contao/pages/PageForward.php
+++ b/core-bundle/src/Resources/contao/pages/PageForward.php
@@ -133,6 +133,6 @@ class PageForward extends \Frontend
 	 */
 	protected function getRedirectStatusCode($objPage)
 	{
-		return ($objPage->redirect == 'temporary') ? 307 : 301;
+		return ($objPage->redirect == 'temporary') ? 303 : 301;
 	}
 }

--- a/core-bundle/src/Resources/contao/pages/PageRedirect.php
+++ b/core-bundle/src/Resources/contao/pages/PageRedirect.php
@@ -51,6 +51,6 @@ class PageRedirect extends \Frontend
 	 */
 	protected function getRedirectStatusCode($objPage)
 	{
-		return ($objPage->redirect == 'temporary') ? 307 : 301;
+		return ($objPage->redirect == 'temporary') ? 303 : 301;
 	}
 }

--- a/core-bundle/src/Resources/contao/pages/PageRoot.php
+++ b/core-bundle/src/Resources/contao/pages/PageRoot.php
@@ -12,7 +12,6 @@ namespace Contao;
 
 use Contao\CoreBundle\Exception\NoActivePageFoundException;
 use Symfony\Component\HttpFoundation\RedirectResponse;
-use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Provide methods to handle a website root page.
@@ -52,7 +51,7 @@ class PageRoot extends \Frontend
 	 */
 	public function getResponse($rootPageId)
 	{
-		return new RedirectResponse($this->getRedirectUrl($rootPageId), Response::HTTP_SEE_OTHER);
+		return new RedirectResponse($this->getRedirectUrl($rootPageId));
 	}
 
 	/**

--- a/core-bundle/src/Resources/contao/pages/PageRoot.php
+++ b/core-bundle/src/Resources/contao/pages/PageRoot.php
@@ -52,7 +52,7 @@ class PageRoot extends \Frontend
 	 */
 	public function getResponse($rootPageId)
 	{
-		return new RedirectResponse($this->getRedirectUrl($rootPageId), Response::HTTP_TEMPORARY_REDIRECT);
+		return new RedirectResponse($this->getRedirectUrl($rootPageId), Response::HTTP_SEE_OTHER);
 	}
 
 	/**

--- a/core-bundle/tests/Controller/BackendControllerTest.php
+++ b/core-bundle/tests/Controller/BackendControllerTest.php
@@ -63,7 +63,7 @@ class BackendControllerTest extends TestCase
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $response);
         $this->assertSame('/foobar', $response->getTargetUrl());
-        $this->assertSame(307, $response->getStatusCode());
+        $this->assertSame(303, $response->getStatusCode());
     }
 
     /**

--- a/core-bundle/tests/Controller/BackendControllerTest.php
+++ b/core-bundle/tests/Controller/BackendControllerTest.php
@@ -63,7 +63,7 @@ class BackendControllerTest extends TestCase
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $response);
         $this->assertSame('/foobar', $response->getTargetUrl());
-        $this->assertSame(303, $response->getStatusCode());
+        $this->assertSame(302, $response->getStatusCode());
     }
 
     /**

--- a/core-bundle/tests/Controller/BackendCsvImportControllerTest.php
+++ b/core-bundle/tests/Controller/BackendCsvImportControllerTest.php
@@ -135,7 +135,7 @@ EOF;
         $response = $controller->importListWizard($dc);
 
         $this->assertInstanceOf(RedirectResponse::class, $response);
-        $this->assertSame(303, $response->getStatusCode());
+        $this->assertSame(302, $response->getStatusCode());
     }
 
     /**
@@ -224,7 +224,7 @@ EOF;
         $response = $controller->importTableWizard($dc);
 
         $this->assertInstanceOf(RedirectResponse::class, $response);
-        $this->assertSame(303, $response->getStatusCode());
+        $this->assertSame(302, $response->getStatusCode());
     }
 
     /**
@@ -317,7 +317,7 @@ EOF;
         $response = $controller->importOptionWizard($dc);
 
         $this->assertInstanceOf(RedirectResponse::class, $response);
-        $this->assertSame(303, $response->getStatusCode());
+        $this->assertSame(302, $response->getStatusCode());
     }
 
     /**
@@ -350,7 +350,7 @@ EOF;
         $response = $this->getController($request)->importListWizard($dc);
 
         $this->assertInstanceOf(RedirectResponse::class, $response);
-        $this->assertSame(303, $response->getStatusCode());
+        $this->assertSame(302, $response->getStatusCode());
     }
 
     /**

--- a/core-bundle/tests/Controller/BackendCsvImportControllerTest.php
+++ b/core-bundle/tests/Controller/BackendCsvImportControllerTest.php
@@ -135,7 +135,7 @@ EOF;
         $response = $controller->importListWizard($dc);
 
         $this->assertInstanceOf(RedirectResponse::class, $response);
-        $this->assertSame(307, $response->getStatusCode());
+        $this->assertSame(303, $response->getStatusCode());
     }
 
     /**
@@ -224,7 +224,7 @@ EOF;
         $response = $controller->importTableWizard($dc);
 
         $this->assertInstanceOf(RedirectResponse::class, $response);
-        $this->assertSame(307, $response->getStatusCode());
+        $this->assertSame(303, $response->getStatusCode());
     }
 
     /**
@@ -317,7 +317,7 @@ EOF;
         $response = $controller->importOptionWizard($dc);
 
         $this->assertInstanceOf(RedirectResponse::class, $response);
-        $this->assertSame(307, $response->getStatusCode());
+        $this->assertSame(303, $response->getStatusCode());
     }
 
     /**
@@ -350,7 +350,7 @@ EOF;
         $response = $this->getController($request)->importListWizard($dc);
 
         $this->assertInstanceOf(RedirectResponse::class, $response);
-        $this->assertSame(307, $response->getStatusCode());
+        $this->assertSame(303, $response->getStatusCode());
     }
 
     /**

--- a/core-bundle/tests/Exception/AjaxRedirectResponseExceptionTest.php
+++ b/core-bundle/tests/Exception/AjaxRedirectResponseExceptionTest.php
@@ -30,7 +30,7 @@ class AjaxRedirectResponseExceptionTest extends TestCase
         $response = $exception->getResponse();
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $response);
-        $this->assertSame(307, $response->getStatusCode());
+        $this->assertSame(303, $response->getStatusCode());
         $this->assertSame('http://example.org', $response->headers->get('X-Ajax-Location'));
     }
 }

--- a/core-bundle/tests/Exception/RedirectResponseExceptionTest.php
+++ b/core-bundle/tests/Exception/RedirectResponseExceptionTest.php
@@ -28,7 +28,7 @@ class RedirectResponseExceptionTest extends TestCase
         $exception = new RedirectResponseException('http://example.org');
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $exception->getResponse());
-        $this->assertSame(307, $exception->getResponse()->getStatusCode());
+        $this->assertSame(303, $exception->getResponse()->getStatusCode());
         $this->assertSame('http://example.org', $exception->getResponse()->headers->get('Location'));
     }
 }

--- a/installation-bundle/src/Controller/InstallationController.php
+++ b/installation-bundle/src/Controller/InstallationController.php
@@ -609,10 +609,7 @@ class InstallationController implements ContainerAwareInterface
      */
     private function getRedirectResponse()
     {
-        return new RedirectResponse(
-            $this->container->get('request_stack')->getCurrentRequest()->getRequestUri(),
-            Response::HTTP_SEE_OTHER
-        );
+        return new RedirectResponse($this->container->get('request_stack')->getCurrentRequest()->getRequestUri());
     }
 
     /**

--- a/installation-bundle/src/Controller/InstallationController.php
+++ b/installation-bundle/src/Controller/InstallationController.php
@@ -611,7 +611,7 @@ class InstallationController implements ContainerAwareInterface
     {
         return new RedirectResponse(
             $this->container->get('request_stack')->getCurrentRequest()->getRequestUri(),
-            Response::HTTP_TEMPORARY_REDIRECT
+            Response::HTTP_SEE_OTHER
         );
     }
 


### PR DESCRIPTION
A 307 redirect does not change the request method and therefore breaks the Contao login (and other routines that are triggered with a POST request and expect the following redirect to be a GET request).

The PR reverts the changes from #2037 but replaces 302 with 303 where applicable.