### PR TITLE
Correctly decode entities in the layout name

### DIFF
--- a/core-bundle/src/DataCollector/ContaoDataCollector.php
+++ b/core-bundle/src/DataCollector/ContaoDataCollector.php
@@ -14,6 +14,7 @@ use Contao\CoreBundle\Framework\FrameworkAwareInterface;
 use Contao\CoreBundle\Framework\FrameworkAwareTrait;
 use Contao\LayoutModel;
 use Contao\Model\Registry;
+use Contao\StringUtil;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\DataCollector\DataCollector;
@@ -222,7 +223,7 @@ class ContaoDataCollector extends DataCollector implements FrameworkAwareInterfa
             return '';
         }
 
-        return sprintf('%s (ID %s)', $layout->name, $layout->id);
+        return sprintf('%s (ID %s)', StringUtil::decodeEntities($layout->name), $layout->id);
     }
 
     /**


### PR DESCRIPTION
If the page layout has special characters (in my case it was a bracket, e.g. `My Layout (with something)`, these are currently encoded in the profiler output.