### PR TITLE
Do not add empty CSS classes to the template

### DIFF
--- a/core-bundle/src/Controller/AbstractFragmentController.php
+++ b/core-bundle/src/Controller/AbstractFragmentController.php
@@ -69,7 +69,7 @@ abstract class AbstractFragmentController extends AbstractController implements 
         $template->class = trim($templateName.' '.($data[1] ?? ''));
         $template->cssID = !empty($data[0]) ? ' id="'.$data[0].'"' : '';
 
-        if (\is_array($classes)) {
+        if (\is_array($classes) && !empty($classes)) {
             $template->class .= ' '.implode(' ', $classes);
         }
     }

--- a/core-bundle/src/Controller/AbstractFragmentController.php
+++ b/core-bundle/src/Controller/AbstractFragmentController.php
@@ -69,7 +69,7 @@ abstract class AbstractFragmentController extends AbstractController implements 
         $template->class = trim($templateName.' '.($data[1] ?? ''));
         $template->cssID = !empty($data[0]) ? ' id="'.$data[0].'"' : '';
 
-        if (\is_array($classes) && !empty($classes)) {
+        if (!empty($classes)) {
             $template->class .= ' '.implode(' ', $classes);
         }
     }


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | -
| Docs PR or issue | -

Currently `$classes` will always be an array, passed down from `ModuleArticle::compile`. The array could contain `first` or `last` for example, but otherwise will be empty. In that case an empty string is added to the `class` template variable, resulting in HTML markup like this:

```html
<div class="ce_example_element ">
  …
</div>
```

This PR adds a check for whether the `$classes` array is empty, to prevent the superfluous space.
