### PR TITLE
Decorate mailer.mailer instead of mailer

### DIFF
--- a/core-bundle/src/Resources/config/services.yml
+++ b/core-bundle/src/Resources/config/services.yml
@@ -357,7 +357,7 @@ services:
             - '@?translator'
 
     Contao\CoreBundle\Mailer\ContaoMailer:
-        decorates: mailer
+        decorates: mailer.mailer
         arguments:
             - '@Contao\CoreBundle\Mailer\ContaoMailer.inner'
             - '@Contao\CoreBundle\Mailer\AvailableTransports'

--- a/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
+++ b/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
@@ -2120,7 +2120,7 @@ class ContaoCoreExtensionTest extends TestCase
         $definition = $container->getDefinition(ContaoMailer::class);
 
         $this->assertTrue($definition->isPrivate());
-        $this->assertSame('mailer', $definition->getDecoratedService()[0]);
+        $this->assertSame('mailer.mailer', $definition->getDecoratedService()[0]);
 
         $this->assertEquals(
             [


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | n/a
| Docs PR or issue | n/a

Decorate `mailer.mailer` instead of `mailer`, as `mailer` could be an instance of `Swift_Mailer`:

```
Argument 1 passed to Contao\CoreBundle\Mailer\ContaoMailer::__construct() must implement interface 
Symfony\Component\Mailer\MailerInterface, instance of Swift_Mailer given, 
called in /var/cache/dev/ContainerAczZpjT/getMailerService.php on line 12
```

See also https://github.com/symfony/swiftmailer-bundle/blob/master/DependencyInjection/SwiftmailerExtension.php#L71