### PR TITLE
Add more cases to the functional routing test

### DIFF
--- a/core-bundle/tests/Functional/RoutingTest.php
+++ b/core-bundle/tests/Functional/RoutingTest.php
@@ -59,7 +59,7 @@ class RoutingTest extends FunctionalTestCase
 
         $this->loadFixtureFiles($fixtures);
 
-        $crawler = $client->request('GET', $request);
+        $crawler = $client->request('GET', "http://$host$request");
         $title = trim($crawler->filterXPath('//head/title')->text());
 
         /** @var Response $response */
@@ -88,7 +88,7 @@ class RoutingTest extends FunctionalTestCase
 
         $this->loadFixtureFiles($fixtures);
 
-        $crawler = $client->request('GET', $request);
+        $crawler = $client->request('GET', "http://$host$request");
         $title = trim($crawler->filterXPath('//head/title')->text());
 
         /** @var Response $response */
@@ -126,6 +126,16 @@ class RoutingTest extends FunctionalTestCase
             '/home.html',
             200,
             'Home - Root with home page',
+            [],
+            'root-with-home.local',
+            false,
+        ];
+
+        yield 'Renders the 404 page if the request string is a double-slash' => [
+            ['theme', 'root-with-home'],
+            '//',
+            404,
+            '(404 Not Found)',
             [],
             'root-with-home.local',
             false,
@@ -373,7 +383,7 @@ class RoutingTest extends FunctionalTestCase
             ->exec('UPDATE tl_page SET urlPrefix=language')
         ;
 
-        $crawler = $client->request('GET', $request);
+        $crawler = $client->request('GET', "http://$host$request");
         $title = trim($crawler->filterXPath('//head/title')->text());
 
         /** @var Response $response */
@@ -403,7 +413,7 @@ class RoutingTest extends FunctionalTestCase
 
         $this->loadFixtureFiles($fixtures);
 
-        $crawler = $client->request('GET', $request);
+        $crawler = $client->request('GET', "http://$host$request");
         $title = trim($crawler->filterXPath('//head/title')->text());
 
         /** @var Response $response */
@@ -463,6 +473,16 @@ class RoutingTest extends FunctionalTestCase
         yield 'Renders the 404 page if the URL suffix does not match' => [
             ['theme', 'root-with-home'],
             '/en/home.xml',
+            404,
+            '(404 Not Found)',
+            [],
+            'root-with-home.local',
+            false,
+        ];
+
+        yield 'Renders the 404 page if the path ends with a double-slash' => [
+            ['theme', 'root-with-home'],
+            '/en//',
             404,
             '(404 Not Found)',
             [],
@@ -692,7 +712,7 @@ class RoutingTest extends FunctionalTestCase
             ->exec("UPDATE tl_page SET urlSuffix=''")
         ;
 
-        $crawler = $client->request('GET', $request);
+        $crawler = $client->request('GET', "http://$host$request");
         $title = trim($crawler->filterXPath('//head/title')->text());
 
         /** @var Response $response */
@@ -721,7 +741,7 @@ class RoutingTest extends FunctionalTestCase
 
         $this->loadFixtureFiles($fixtures);
 
-        $crawler = $client->request('GET', $request);
+        $crawler = $client->request('GET', "http://$host$request");
         $title = trim($crawler->filterXPath('//head/title')->text());
 
         /** @var Response $response */
@@ -939,7 +959,7 @@ class RoutingTest extends FunctionalTestCase
 
         $this->loadFixtureFiles($fixtures);
 
-        $crawler = $client->request('GET', $request);
+        $crawler = $client->request('GET', "http://$host$request");
         $title = trim($crawler->filterXPath('//head/title')->text());
 
         /** @var Response $response */
@@ -1044,7 +1064,7 @@ class RoutingTest extends FunctionalTestCase
             ->exec('UPDATE tl_page SET urlPrefix=language')
         ;
 
-        $crawler = $client->request('GET', $request);
+        $crawler = $client->request('GET', "http://$host$request");
         $title = trim($crawler->filterXPath('//head/title')->text());
 
         /** @var Response $response */
@@ -1073,7 +1093,7 @@ class RoutingTest extends FunctionalTestCase
 
         $this->loadFixtureFiles($fixtures);
 
-        $crawler = $client->request('GET', $request);
+        $crawler = $client->request('GET', "http://$host$request");
         $title = trim($crawler->filterXPath('//head/title')->text());
 
         /** @var Response $response */


### PR DESCRIPTION
The PR adds functional tests for #2144. We should actually also test the `//en/` case, however, this one is handled differently in legacy mode and in non-legacy mode (purposefully), therefore I could not add it easily.