### PR TITLE
Add support for HTTP cache subscribers

### DIFF
--- a/manager-bundle/src/HttpKernel/ContaoKernel.php
+++ b/manager-bundle/src/HttpKernel/ContaoKernel.php
@@ -22,6 +22,7 @@ use Contao\ManagerPlugin\Bundle\Parser\IniParser;
 use Contao\ManagerPlugin\Bundle\Parser\JsonParser;
 use Contao\ManagerPlugin\Config\ConfigPluginInterface;
 use Contao\ManagerPlugin\Config\ContainerBuilder as PluginContainerBuilder;
+use Contao\ManagerPlugin\HttpKernel\HttpCacheSubscriberPluginInterface;
 use Contao\ManagerPlugin\PluginLoader;
 use FOS\HttpCache\SymfonyCache\HttpCacheProvider;
 use ProxyManager\Configuration;
@@ -212,7 +213,18 @@ class ContaoKernel extends Kernel implements HttpCacheProvider
             return $this->httpCache;
         }
 
-        return $this->httpCache = new ContaoCache($this, $this->getProjectDir().'/var/cache/prod/http_cache');
+        $this->httpCache = new ContaoCache($this, $this->getProjectDir().'/var/cache/prod/http_cache');
+
+        /** @var array<HttpCacheSubscriberPluginInterface> $plugins */
+        $plugins = $this->getPluginLoader()->getInstancesOf(HttpCacheSubscriberPluginInterface::class);
+
+        foreach ($plugins as $plugin) {
+            foreach ($plugin->getHttpCacheSubscribers() as $subscriber) {
+                $this->httpCache->addSubscriber($subscriber);
+            }
+        }
+
+        return $this->httpCache;
     }
 
     /**


### PR DESCRIPTION
This adds support for https://github.com/contao/manager-plugin/pull/29 in manager-plugin 2.9.

According to @Toflar this should not be a problem if manager-plugin < 2.9 is installed. The interface name is just a symbol that does not exist, as long as no plugin implement it. If a plugin **does** implement it, it should require the plugin ^2.9.

Thanks to the new interface, it will be possible to add cache subscribers to do special handling that should apply to the http cache (as well). In my case, I need to implement geo localization for visitors and dynamically add _sort-of_ preflight header with the country, so responses can `Vary` on it.

I would love to have this in the LTS release, similar to https://github.com/contao/contao/pull/1982 this should not cause any conflicts with existing code or Contao functionality as it is totally separate.