### PR TITLE
Support captcha input wrapped in DIV

### DIFF
--- a/core-bundle/src/Resources/contao/templates/forms/form_captcha.html5
+++ b/core-bundle/src/Resources/contao/templates/forms/form_captcha.html5
@@ -27,7 +27,7 @@
         var e = document.getElementById('ctrl_<?= $this->id ?>'),
             p = e.parentNode, f = p.parentNode;
 
-        if ('fieldset' === f.nodeName.toLowerCase() && 1 === f.children.length) {
+        if (f.classList.contains('widget-captcha') || 'fieldset' === f.nodeName.toLowerCase() && 1 === f.children.length) {
           p = f;
         }
 


### PR DESCRIPTION
This is just a quick fix for my use case but it can't really harm. On my client's system, the input element was wrapped in a `div`, therefore the script didn't hide the label. I didn't want to rewrite the whole script and implement recursive DOM traversal, but this adjustment might fix some edge cases.