### PR TITLE
Show SQL import error message

### DIFF
--- a/installation-bundle/src/Controller/InstallationController.php
+++ b/installation-bundle/src/Controller/InstallationController.php
@@ -459,9 +459,9 @@ class InstallationController implements ContainerAwareInterface
             $installTool->persistConfig('exampleWebsite', null);
             $installTool->logException($e);
 
-            for($rootException = $e; null !== $rootException->getPrevious(); $rootException = $rootException->getPrevious());
+            for ($rootException = $e; null !== $rootException->getPrevious(); $rootException = $rootException->getPrevious());
 
-            $this->context['import_error'] = $this->trans('import_exception') . "\n" . $rootException->getMessage();
+            $this->context['import_error'] = $this->trans('import_exception')."\n".$rootException->getMessage();
 
             return null;
         }

--- a/installation-bundle/src/Controller/InstallationController.php
+++ b/installation-bundle/src/Controller/InstallationController.php
@@ -459,7 +459,9 @@ class InstallationController implements ContainerAwareInterface
             $installTool->persistConfig('exampleWebsite', null);
             $installTool->logException($e);
 
-            $this->context['import_error'] = $this->trans('import_exception');
+            for($rootException = $e; null !== $rootException->getPrevious(); $rootException = $rootException->getPrevious());
+
+            $this->context['import_error'] = $this->trans('import_exception') . "\n" . $rootException->getMessage();
 
             return null;
         }

--- a/installation-bundle/src/Resources/views/main.html.twig
+++ b/installation-bundle/src/Resources/views/main.html.twig
@@ -53,7 +53,7 @@
     <div>
       <h3>{{ 'template_import'|trans }}</h3>
       {% if import_error is defined %}
-        <p class="tl_error">{{ import_error }}</p>
+        <p class="tl_error">{{ import_error|nl2br }}</p>
       {% elseif import_date is defined %}
         <p class="tl_confirm">{{ 'imported_on'|trans|format(import_date) }}</p>
       {% else %}


### PR DESCRIPTION
The SQL error message when importing an SQL website template would be very helpful to see what table or column is missing.