### PR TITLE
Fix a potential wrong image dimensions being returned from cache

### DIFF
--- a/core-bundle/src/Resources/contao/classes/FileUpload.php
+++ b/core-bundle/src/Resources/contao/classes/FileUpload.php
@@ -321,11 +321,7 @@ class FileUpload extends \Backend
 		// Resized successfully
 		if ($blnResize)
 		{
-			\System::getContainer()
-				->get('contao.image.image_factory')
-				->create(TL_ROOT . '/' . $strImage, array($arrImageSize[0], $arrImageSize[1]), TL_ROOT . '/' . $strImage)
-			;
-
+			$objFile->resizeTo($arrImageSize[0], $arrImageSize[1]);
 			\Message::addInfo(sprintf($GLOBALS['TL_LANG']['MSC']['fileResized'], $objFile->basename));
 			$this->log('File "' . $strImage . '" was scaled down to the maximum dimensions', __METHOD__, TL_FILES);
 			$this->blnHasResized = true;

--- a/core-bundle/src/Resources/contao/library/Contao/File.php
+++ b/core-bundle/src/Resources/contao/library/Contao/File.php
@@ -736,7 +736,6 @@ class File extends \System
 		\System::getContainer()
 			->get('contao.image.image_factory')
 			->create(TL_ROOT . '/' . $this->strFile, array($width, $height, $mode), TL_ROOT . '/' . $this->strFile)
-			->getUrl(TL_ROOT)
 		;
 
 		$this->arrPathinfo = array();

--- a/core-bundle/src/Resources/contao/library/Contao/File.php
+++ b/core-bundle/src/Resources/contao/library/Contao/File.php
@@ -733,19 +733,19 @@ class File extends \System
 			return false;
 		}
 
-		$return = \System::getContainer()
+		\System::getContainer()
 			->get('contao.image.image_factory')
 			->create(TL_ROOT . '/' . $this->strFile, array($width, $height, $mode), TL_ROOT . '/' . $this->strFile)
 			->getUrl(TL_ROOT)
 		;
 
-		if ($return)
-		{
-			$this->arrPathinfo = array();
-			$this->arrImageSize = array();
-		}
+		$this->arrPathinfo = array();
+		$this->arrImageSize = array();
 
-		return $return;
+		// Clear the image size cache as mtime could potentially not change
+		unset(static::$arrImageSizeCache[$this->strFile . '|' . $this->mtime]);
+
+		return true;
 	}
 
 	/**


### PR DESCRIPTION
This PR should fix a potential wrong image dimensions being returned if the image was resized but its mtime not changed. One of our systems has terminal42/contao-fineuploader installed (which internally uses `FileUpload`) and we occasionally have a problem validating image size.

This happens when a user uploads an image that exceeds the maximum dimensions set in the system settings. The image is then being scaled down correctly, but if it all happens fast enough and within the same second, the resized file will keep its `mtime` and thus the `File` image size cache would still contain the old value. Thus our validation in fineuploader extension fails, as we use `$file->width` [there](https://github.com/terminal42/contao-fineuploader/blob/969822159c70bf188986705898b9ac98cd5bc583/src/EventListener/FileUploadListener.php#L107).

Described step by step:

1. User uploads a 2000x2000 image.
2. Contao scales down the image to 1200x1200 (system settings):
2a. Contao [reads the uploaded image size](https://github.com/contao/contao/blob/master/core-bundle/src/Resources/contao/classes/FileUpload.php#L304) and [caches it internally](https://github.com/contao/contao/blob/4.4/core-bundle/src/Resources/contao/library/Contao/File.php#L254).
2b. Contao [resizes the image](https://github.com/contao/contao/blob/master/core-bundle/src/Resources/contao/classes/FileUpload.php#L338-L340).
3. The `$file->width` contains original image size due to cache (2000x2000), provided the `mtime` did not change. Expected value would be 1200x1200.

PS. I have also changed the method to return boolean like it did in the old 3.x days and according to what the docblock says, yet it may be a BC break so feel free to adjust that if necessary.