### PR TITLE
Also add a template block for "content_css"

### DIFF
--- a/core-bundle/src/Resources/contao/templates/backend/be_tinyMCE.html5
+++ b/core-bundle/src/Resources/contao/templates/backend/be_tinyMCE.html5
@@ -40,7 +40,9 @@ window.tinymce && tinymce.init({
     file_picker_types: <?= json_encode($this->fileBrowserTypes) ?>,
   <?php $this->endblock(); ?>
 
-  content_css: 'system/themes/<?= Backend::getTheme() ?>/tinymce.min.css',
+  <?php $this->block('content_css'); ?>
+    content_css: 'system/themes/<?= Backend::getTheme() ?>/tinymce.min.css',
+  <?php $this->endblock(); ?>
 
   <?php $this->block('plugins'); ?>
     plugins: 'autosave charmap code fullscreen image importcss link lists paste searchreplace stripnbsp tabfocus table visualblocks visualchars',


### PR DESCRIPTION
Some options in `be_tinyMCE.html5` are editable with block elements, but not the `content_css`. That's why I add it.
