### PR TITLE
Work towards Psalm level 6 (part 2)

### DIFF
--- a/core-bundle/src/Image/PictureFactory.php
+++ b/core-bundle/src/Image/PictureFactory.php
@@ -148,7 +148,8 @@ class PictureFactory implements PictureFactoryInterface
      *
      * @param int|array|null $size
      *
-     * @return array<(PictureConfiguration|array<string, string>|ResizeOptions|null)>
+     * @return array<(PictureConfiguration|array<string, string>|ResizeOptions)>
+     * @psalm-return array{0:PictureConfiguration, 1:array<string, string>, 2:ResizeOptions}
      */
     private function createConfig($size): array
     {

--- a/core-bundle/src/Image/PictureFactory.php
+++ b/core-bundle/src/Image/PictureFactory.php
@@ -148,7 +148,6 @@ class PictureFactory implements PictureFactoryInterface
      *
      * @param int|array|null $size
      *
-     * @return array<(PictureConfiguration|array<string, string>|ResizeOptions)>
      * @psalm-return array{0:PictureConfiguration, 1:array<string, string>, 2:ResizeOptions}
      */
     private function createConfig($size): array

--- a/core-bundle/src/Image/Studio/Figure.php
+++ b/core-bundle/src/Image/Studio/Figure.php
@@ -100,7 +100,7 @@ final class Figure
             throw new \LogicException('This result container does not include a lightbox.');
         }
 
-        // Safely return as Closure will be evaluated at this point
+        /** @var LightboxResult */
         return $this->lightbox;
     }
 
@@ -120,7 +120,7 @@ final class Figure
             throw new \LogicException('This result container does not include metadata.');
         }
 
-        // Safely return as Closure will be evaluated at this point
+        /** @var Metadata */
         return $this->metadata;
     }
 


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | -
| Docs PR or issue | -

This is a follow-up to #2124 that addresses the issues reported in the `Contao/Image` namespace.

After playing around with some solutions for the `Figure` class I think it's best/most readable to just annotate the return types. This way we can keep the `resolveIfClosure` method which imo helps devs to understand what the code is doing and also makes sure we're evaluating each closure with the same argument.