### PR TITLE
Catch exceptions to prevent the resize images command from failing

### DIFF
--- a/core-bundle/src/Command/ResizeImagesCommand.php
+++ b/core-bundle/src/Command/ResizeImagesCommand.php
@@ -194,15 +194,15 @@ class ResizeImagesCommand extends Command
     private function resizeImages(float $timeLimit, float $concurrent, bool $noSubProcess)
     {
         if (!$noSubProcess && $this->supportsSubProcesses()) {
-            $this->executeConcurrent($timeLimit, $concurrent);
-        } else {
-            $this->io->warning(
-                "Running this command without sub processes.\n"
-                .'This can lead to memory leaks and eventually let the execution fail.'
-            );
-
-            $this->executeInCurrentProcess($timeLimit, $concurrent);
+            return $this->executeConcurrent($timeLimit, $concurrent);
         }
+
+        $this->io->warning(
+            "Running this command without sub processes.\n"
+            .'This can lead to memory leaks and eventually let the execution fail.'
+        );
+
+        $this->executeInCurrentProcess($timeLimit, $concurrent);
 
         return 0;
     }
@@ -267,6 +267,7 @@ class ResizeImagesCommand extends Command
         $phpFinder = new PhpExecutableFinder();
         $phpPath = $phpFinder->find();
 
+        $failedCount = 0;
         $processes = array_fill(0, (int) $concurrent ?: 1, null);
         $paths = array_fill(0, \count($processes), '');
         $counts = array_fill(0, \count($processes), 0);
@@ -284,7 +285,9 @@ class ResizeImagesCommand extends Command
                             continue;
                         }
 
-                        $this->finishSubProcess($process, $paths[$index]);
+                        if (!$this->finishSubProcess($process, $paths[$index])) {
+                            ++$failedCount;
+                        }
 
                         if ($concurrent < 1) {
                             usleep((int) (
@@ -326,14 +329,30 @@ class ResizeImagesCommand extends Command
             if (null === $process) {
                 continue;
             }
-            $this->finishSubProcess($process, $paths[$index]);
+
+            if (!$this->finishSubProcess($process, $paths[$index])) {
+                ++$failedCount;
+            }
+
             unset($processes[$index]);
             $this->updateOutput($processes, $counts, $paths);
         }
 
         $this->tableOutput->clear();
 
-        $this->io->writeln('Resized '.array_sum($counts).' Images.');
+        $count = array_sum($counts);
+
+        $this->io->writeln('Resized '.($count - $failedCount).' Images successfully.');
+
+        if ($failedCount > 0) {
+            $this->io->writeln('Resizing of '.$failedCount.' images failed.');
+        }
+
+        if (0 !== $failedCount && $count - $failedCount <= 0) {
+            $this->io->error('No image could be resized successfully.');
+
+            return 1;
+        }
 
         return 0;
     }
@@ -351,18 +370,22 @@ class ResizeImagesCommand extends Command
         $this->table->render();
     }
 
-    private function finishSubProcess(Process $process, string $path): void
+    private function finishSubProcess(Process $process, string $path): bool
     {
         try {
             $process->wait();
         } catch (ProcessSignaledException $exception) {
             $this->io->writeln($path.' failed: '.$exception->getMessage());
 
-            return;
+            return false;
         }
 
-        if (!$process->isSuccessful()) {
-            $this->io->writeln($path.' failed');
+        if ($process->isSuccessful()) {
+            return true;
         }
+
+        $this->io->writeln($path.' failed');
+
+        return false;
     }
 }

--- a/core-bundle/src/Command/ResizeImagesCommand.php
+++ b/core-bundle/src/Command/ResizeImagesCommand.php
@@ -255,7 +255,7 @@ class ResizeImagesCommand extends Command
             }
         } finally {
             $this->tableOutput->clear();
-            $this->io->writeln('Resized '.$count.' Images.');
+            $this->io->writeln('Resized '.$count.' images.');
         }
     }
 

--- a/core-bundle/src/Command/ResizeImagesCommand.php
+++ b/core-bundle/src/Command/ResizeImagesCommand.php
@@ -29,6 +29,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Console\Terminal;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Process\Exception\ProcessSignaledException;
 use Symfony\Component\Process\PhpExecutableFinder;
 use Symfony\Component\Process\Process;
 
@@ -352,7 +353,13 @@ class ResizeImagesCommand extends Command
 
     private function finishSubProcess(Process $process, string $path): void
     {
-        $process->wait();
+        try {
+            $process->wait();
+        } catch (ProcessSignaledException $exception) {
+            $this->io->writeln($path.' failed: '.$exception->getMessage());
+
+            return;
+        }
 
         if (!$process->isSuccessful()) {
             $this->io->writeln($path.' failed');

--- a/core-bundle/src/Command/ResizeImagesCommand.php
+++ b/core-bundle/src/Command/ResizeImagesCommand.php
@@ -342,7 +342,7 @@ class ResizeImagesCommand extends Command
 
         $count = array_sum($counts);
 
-        $this->io->writeln('Resized '.($count - $failedCount).' Images successfully.');
+        $this->io->writeln('Resized '.($count - $failedCount).' images successfully.');
 
         if ($failedCount > 0) {
             $this->io->writeln('Resizing of '.$failedCount.' images failed.');

--- a/core-bundle/tests/Command/ResizeImagesCommandTest.php
+++ b/core-bundle/tests/Command/ResizeImagesCommandTest.php
@@ -51,7 +51,7 @@ class ResizeImagesCommandTest extends TestCase
         $display = $tester->getDisplay();
 
         $this->assertSame(0, $code);
-        $this->assertRegExp('/Resized 0 Images/', $display);
+        $this->assertRegExp('/Resized 0 images/', $display);
     }
 
     public function testResizesImages(): void
@@ -85,7 +85,7 @@ class ResizeImagesCommandTest extends TestCase
         $this->assertSame(0, $code);
         $this->assertRegExp('/image1.jpg/', $display);
         $this->assertRegExp('/image2.jpg/', $display);
-        $this->assertRegExp('/Resized 2 Images/', $display);
+        $this->assertRegExp('/Resized 2 images/', $display);
     }
 
     public function testTimeLimit(): void
@@ -129,7 +129,7 @@ class ResizeImagesCommandTest extends TestCase
         $this->assertSame(0, $code);
         $this->assertRegExp('/image1.jpg/', $display);
         $this->assertRegExp('/Time limit of 0.5 seconds reached/', $display);
-        $this->assertRegExp('/Resized 1 Images/', $display);
+        $this->assertRegExp('/Resized 1 images/', $display);
         $this->assertNotRegExp('/image2.jpg/', $display);
     }
 


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #2176

