### PR TITLE
Fix invalid "array to string conversion" in ScriptHandler exception message

### DIFF
--- a/manager-bundle/src/Composer/ScriptHandler.php
+++ b/manager-bundle/src/Composer/ScriptHandler.php
@@ -92,7 +92,7 @@ class ScriptHandler
         );
 
         if (!$process->isSuccessful()) {
-            throw new \RuntimeException(sprintf('An error occurred while executing the "%s" command: %s', $cmd, $process->getErrorOutput()));
+            throw new \RuntimeException(sprintf('An error occurred while executing the "%s" command: %s', implode(' ', $cmd), $process->getErrorOutput()));
         }
     }
 


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes https://github.com/contao/manager-bundle/issues/88
| Docs PR or issue | -

There is indeed a missing implode at this place. 