### PR TITLE
Set Samesite=LAX on unsecured connections avoid browser warnings

### DIFF
--- a/core-bundle/src/EventListener/CsrfTokenCookieSubscriber.php
+++ b/core-bundle/src/EventListener/CsrfTokenCookieSubscriber.php
@@ -153,7 +153,8 @@ class CsrfTokenCookieSubscriber implements EventSubscriberInterface
 
         foreach ($request->cookies as $key => $value) {
             if ($this->isCsrfCookie($key, $value)) {
-                $response->headers->clearCookie($key, $basePath, null, $isSecure);
+                $sameSite = $isSecure ? Cookie::SAMESITE_NONE : Cookie::SAMESITE_LAX;
+                $response->headers->clearCookie($key, $basePath, null, $isSecure, true, $sameSite);
             }
         }
     }


### PR DESCRIPTION

| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #2185 

this Fix needs to merged in Master and lts-Versions too.
