### PR TITLE
Added index to tl_form_field.invisible

### DIFF
--- a/core-bundle/src/Resources/contao/dca/tl_form_field.php
+++ b/core-bundle/src/Resources/contao/dca/tl_form_field.php
@@ -25,7 +25,8 @@ $GLOBALS['TL_DCA']['tl_form_field'] = array
 			'keys' => array
 			(
 				'id' => 'primary',
-				'pid' => 'index'
+				'pid' => 'index',
+				'invisible' => 'index'
 			)
 		)
 	),


### PR DESCRIPTION
Should improve performance of `FormFieldModel::findPublishedByPid()` for huge forms (which I have and does not end up in a mess thanks to mp-forms ;)).
