### PR TITLE
Use a multicolumn index for the tl_form_field table

### DIFF
--- a/core-bundle/src/Resources/contao/dca/tl_form_field.php
+++ b/core-bundle/src/Resources/contao/dca/tl_form_field.php
@@ -25,8 +25,7 @@ $GLOBALS['TL_DCA']['tl_form_field'] = array
 			'keys' => array
 			(
 				'id' => 'primary',
-				'pid' => 'index',
-				'invisible' => 'index'
+				'pid,invisible,sorting' => 'index'
 			)
 		)
 	),


### PR DESCRIPTION
I think we have merged #2192 a little too quickly. 🙈 We should use a multicolumn index instead, as we already do for all other tables (`tl_content`, `tl_article`, `tl_page`, `tl_news`, `tl_faq` and so on).

@Toflar Can you please check if my changes work for you as well?
