### PR TITLE
Adjust the composer.json description

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "contao/contao",
     "type": "symfony-bundle",
-    "description": "Contao Open Source CMS Development Package",
+    "description": "Contao Open Source CMS development package",
     "homepage": "https://contao.org",
     "license": "LGPL-3.0-or-later",
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "contao/contao",
     "type": "symfony-bundle",
-    "description": "Contao 4 bundles",
+    "description": "Contao Open Source CMS Development Package",
     "homepage": "https://contao.org",
     "license": "LGPL-3.0-or-later",
     "authors": [

--- a/core-bundle/composer.json
+++ b/core-bundle/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "contao/core-bundle",
     "type": "symfony-bundle",
-    "description": "Provides the Contao core functionality",
+    "description": "Contao Open Source CMS",
     "homepage": "https://contao.org",
     "license": "LGPL-3.0-or-later",
     "authors": [

--- a/manager-bundle/composer.json
+++ b/manager-bundle/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "contao/manager-bundle",
     "type": "symfony-bundle",
-    "description": "Symfony bundle for the Contao Managed Edition",
+    "description": "Provides the Contao Managed Edition",
     "homepage": "https://contao.org",
     "license": "LGPL-3.0-or-later",
     "authors": [


### PR DESCRIPTION
As discussed, Contao does not show up when searching for "CMS" on packagist.org: https://packagist.org/?query=cms
