### PR TITLE
Do not encode HTML in metadata captions

### DIFF
--- a/core-bundle/src/Image/Studio/Figure.php
+++ b/core-bundle/src/Image/Studio/Figure.php
@@ -221,7 +221,7 @@ final class Figure
             $mapping = $metadata->all();
 
             // Handle special chars
-            foreach ([Metadata::VALUE_ALT, Metadata::VALUE_TITLE, Metadata::VALUE_CAPTION] as $key) {
+            foreach ([Metadata::VALUE_ALT, Metadata::VALUE_TITLE] as $key) {
                 if (isset($mapping[$key])) {
                     $mapping[$key] = StringUtil::specialchars($mapping[$key]);
                 }

--- a/core-bundle/src/Resources/views/Image/Studio/_macros.html.twig
+++ b/core-bundle/src/Resources/views/Image/Studio/_macros.html.twig
@@ -135,7 +135,7 @@
             {% set caption_attributes = figure.options.caption_attr|default({})|merge(options.caption_attr|default({})) %}
             {% set base_attributes = { 'itemprop': 'caption' } %}
             <figcaption{{ _self.html_attributes(base_attributes|merge(caption_attributes)) }}>
-                {{- figure.metadata.caption -}}
+                {{- figure.metadata.caption|raw -}}
             </figcaption>
         {% endif %}
     {% endapply %}

--- a/core-bundle/tests/Image/Studio/FigureTest.php
+++ b/core-bundle/tests/Image/Studio/FigureTest.php
@@ -366,6 +366,11 @@ class FigureTest extends TestCase
             Metadata::VALUE_URL => 'foo://meta',
         ]);
 
+        $metadataWithHtml = new Metadata([
+            Metadata::VALUE_ALT => 'Here <b>is</b> some <i>HTML</i>!',
+            Metadata::VALUE_CAPTION => 'Here <b>is</b> some <i>HTML</i>!',
+        ]);
+
         yield 'with metadata' => [
             [$simpleMetadata, null, null, null],
             [false, null, null],
@@ -396,6 +401,15 @@ class FigureTest extends TestCase
                 $this->assertSame('', $data['attributes']);
 
                 $this->assertArrayNotHasKey('title', $data['picture']);
+            },
+        ];
+
+        yield 'with metadata containing HTML' => [
+            [$metadataWithHtml, null, null, null],
+            [true, null, null],
+            function (array $data): void {
+                $this->assertSame('Here <b>is</b> some <i>HTML</i>!', $data['caption']);
+                $this->assertSame('Here &lt;b&gt;is&lt;/b&gt; some &lt;i&gt;HTML&lt;/i&gt;!', $data['alt']);
             },
         ];
 


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #2197 
| Docs PR or issue | -

This makes Contao 4.10 behave the same as previous versions, again. I'm not sure this is/was a good idea to allow HTML in the caption field, though.