### PR TITLE
Load the default labels in the loadDcaFiles() method

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/DcaLoader.php
+++ b/core-bundle/src/Resources/contao/library/Contao/DcaLoader.php
@@ -68,7 +68,6 @@ class DcaLoader extends Controller
 	public function load($blnNoCache=false)
 	{
 		$this->loadDcaFiles($blnNoCache);
-		$this->addDefaultLabels($blnNoCache);
 	}
 
 	/**
@@ -128,6 +127,8 @@ class DcaLoader extends Controller
 			@trigger_error('Using the "dcaconfig.php" file has been deprecated and will no longer work in Contao 5.0. Create custom DCA files in the "contao/dca" folder instead.', E_USER_DEPRECATED);
 			include $projectDir . '/system/config/dcaconfig.php';
 		}
+
+		$this->addDefaultLabels($blnNoCache);
 	}
 
 	/**


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | -
| Docs PR or issue | -

In Contao **4.9** we do not have to specify

```php
'label' => &$GLOBALS['TL_LANG']['tl_module']['foo'],
```

any more in our DCAs, if the name of the translation is equal to the name of the field, because the default labels are automatically loaded from `$GLOBALS['TL_LANG']` within `\Contao\DcaLoader`.

However, this breaks under certain circumstances. For instance, if you install `codefog/contao-news_categories`, then any custom fields you add via `contao/dca/tl_content.php` or `contao/dca/tl_module.php` will not use the translation from `contao/languages/` automatically.

The reason is the following (example with a new field in `tl_module`):

1. The Contao Backend will first call `Controller::loadDataContainer('tl_module')`.
2. This loads all the `tl_module.php` files of all extensions in the defined order, with `contao/dca/tl_module.php` being last.
3. When `vendor/codefog/contao-news_categories/…/dca/tl_module.php` is called, it contains another call to `Controller::loadDataContainer('tl_content')` (because it depends on some data from that data container).
4. This loads all the `tl_content.php` files of all extensions in the defined order.
5. When `vendor/codefog/contao-news_categories/…/dca/tl_contao.php` is called, it contains another call to `Controller::loadDataContainer('tl_module')` (because it depends on some data from that data container).
6. In _that_ call, within `\Contao\DcaLoader::load`, `$this->loadDcaFiles();` is skipped, because it was already executed, however, `$this->addDefaultLabels();` is **not** skipped, because it was not yet executed at this point.
7. `\Contao\DcaLoader::addDefaultLabels` will then load the default labels for `tl_module`, but only for fields that are known at this point. i.e. any fields from DCA files that came _after_ `codefog/contao-news_categories` are not included.

You can also replicate the problem this way:

```php
// contao/dca/tl_module.php
use Contao\Controller;
use Contao\CoreBundle\DataContainer\PaletteManipulator;

Controller::loadDataContainer('tl_content');

$GLOBALS['TL_DCA']['tl_module']['fields']['foo'] = [
    'inputType' => 'text',
    'eval' => ['tl_class' => 'w50'],
];

PaletteManipulator::create()
    ->addField('foo', 'title_legend', PaletteManipulator::POSITION_APPEND)
    ->applyToPalette('navigation', 'tl_module')
;
```
```php
// contao/languages/en/tl_module.php
$GLOBALS['TL_LANG']['tl_module']['foo'] = ['Foo label', 'Foo description'];
```
```php
// contao/dca/tl_content.php
use Contao\Controller;

Controller::loadDataContainer('tl_module');
```

When creating/editing a navigation module, you will see that the `foo` field will have no label and description. Once the fix from this PR is applied, the label will be correctly loaded.

This PR simply moves the call to `addDefaultLabels` to within `loadDcaFiles`, which ensures that the default labels from _all_ fields will be loaded, even if `\Contao\DcaLoader::load` was called recursively.