### PR TITLE
Only check the request token for master requests

### DIFF
--- a/core-bundle/src/EventListener/RequestTokenListener.php
+++ b/core-bundle/src/EventListener/RequestTokenListener.php
@@ -70,14 +70,15 @@ class RequestTokenListener
 
         // Only check the request token if a) the request is a POST request, b)
         // the request is not an Ajax request, c) the _token_check attribute is
-        // not false, d) the _token_check attribute is set or the request is a
-        // Contao request and e) the request has cookies, an authenticated user
-        // or the session has been started
+        // not false, d) the request is a Contao master request, e) the _token_check 
+        // attribute is set or the request is a Contao request and f) the request 
+        // has cookies, an authenticated user or the session has been started
         if (
             'POST' !== $request->getRealMethod()
             || $request->isXmlHttpRequest()
             || false === $request->attributes->get('_token_check')
             || (!$request->attributes->has('_token_check') && !$this->scopeMatcher->isContaoRequest($request))
+            || !$this->scopeMatcher->isContaoMasterRequest($event)
             || (
                 (0 === $request->cookies->count() || [$this->csrfCookiePrefix.$this->csrfTokenName] === $request->cookies->keys())
                 && !$request->getUserInfo()

--- a/core-bundle/src/EventListener/RequestTokenListener.php
+++ b/core-bundle/src/EventListener/RequestTokenListener.php
@@ -66,19 +66,23 @@ class RequestTokenListener
      */
     public function __invoke(RequestEvent $event): void
     {
+        // Don't do anything if it's not the master request
+        if (!$event->isMasterRequest()) {
+            return;
+        }
+
         $request = $event->getRequest();
 
         // Only check the request token if a) the request is a POST request, b)
         // the request is not an Ajax request, c) the _token_check attribute is
-        // not false, d) the request is a Contao master request, e) the _token_check 
-        // attribute is set or the request is a Contao request and f) the request 
-        // has cookies, an authenticated user or the session has been started
+        // not false, d) the _token_check attribute is set or the request is a
+        // Contao request and e) the request has cookies, an authenticated user
+        // or the session has been started
         if (
             'POST' !== $request->getRealMethod()
             || $request->isXmlHttpRequest()
             || false === $request->attributes->get('_token_check')
             || (!$request->attributes->has('_token_check') && !$this->scopeMatcher->isContaoRequest($request))
-            || !$this->scopeMatcher->isContaoMasterRequest($event)
             || (
                 (0 === $request->cookies->count() || [$this->csrfCookiePrefix.$this->csrfTokenName] === $request->cookies->keys())
                 && !$request->getUserInfo()

--- a/core-bundle/tests/EventListener/RequestTokenListenerTest.php
+++ b/core-bundle/tests/EventListener/RequestTokenListenerTest.php
@@ -92,12 +92,6 @@ class RequestTokenListenerTest extends TestCase
             ->willReturn(true)
         ;
 
-        $scopeMatcher
-            ->expects($this->once())
-            ->method('isContaoMasterRequest')
-            ->willReturn(true)
-        ;
-
         $csrfTokenManager = $this->createMock(CsrfTokenManagerInterface::class);
         $csrfTokenManager
             ->expects($this->once())
@@ -116,6 +110,12 @@ class RequestTokenListenerTest extends TestCase
             ->willReturn($request)
         ;
 
+        $event
+            ->expects($this->once())
+            ->method('isMasterRequest')
+            ->willReturn(true)
+        ;
+
         $listener = new RequestTokenListener($framework, $scopeMatcher, $csrfTokenManager, 'contao_csrf_token');
         $listener($event);
     }
@@ -125,12 +125,6 @@ class RequestTokenListenerTest extends TestCase
         $config = $this->mockConfiguredAdapter(['get' => false]);
         $framework = $this->mockContaoFramework([Config::class => $config]);
         $scopeMatcher = $this->createMock(ScopeMatcher::class);
-
-        $scopeMatcher
-            ->expects($this->once())
-            ->method('isContaoMasterRequest')
-            ->willReturn(true)
-        ;
 
         $csrfTokenManager = $this->createMock(CsrfTokenManagerInterface::class);
         $csrfTokenManager
@@ -149,6 +143,12 @@ class RequestTokenListenerTest extends TestCase
             ->expects($this->once())
             ->method('getRequest')
             ->willReturn($request)
+        ;
+
+        $event
+            ->expects($this->once())
+            ->method('isMasterRequest')
+            ->willReturn(true)
         ;
 
         $listener = new RequestTokenListener($framework, $scopeMatcher, $csrfTokenManager, 'contao_csrf_token');
@@ -181,6 +181,12 @@ class RequestTokenListenerTest extends TestCase
             ->willReturn($request)
         ;
 
+        $event
+            ->expects($this->once())
+            ->method('isMasterRequest')
+            ->willReturn(true)
+        ;
+
         $listener = new RequestTokenListener($framework, $scopeMatcher, $csrfTokenManager, 'contao_csrf_token');
         $listener($event);
     }
@@ -209,6 +215,12 @@ class RequestTokenListenerTest extends TestCase
             ->willReturn($request)
         ;
 
+        $event
+            ->expects($this->once())
+            ->method('isMasterRequest')
+            ->willReturn(true)
+        ;
+
         $listener = new RequestTokenListener($framework, $scopeMatcher, $csrfTokenManager, 'contao_csrf_token');
         $listener($event);
     }
@@ -234,6 +246,12 @@ class RequestTokenListenerTest extends TestCase
             ->expects($this->once())
             ->method('getRequest')
             ->willReturn($request)
+        ;
+
+        $event
+            ->expects($this->once())
+            ->method('isMasterRequest')
+            ->willReturn(true)
         ;
 
         $listener = new RequestTokenListener($framework, $scopeMatcher, $csrfTokenManager, 'contao_csrf_token');
@@ -268,11 +286,17 @@ class RequestTokenListenerTest extends TestCase
             ->willReturn($request)
         ;
 
+        $event
+            ->expects($this->once())
+            ->method('isMasterRequest')
+            ->willReturn(true)
+        ;
+
         $listener = new RequestTokenListener($framework, $scopeMatcher, $csrfTokenManager, 'contao_csrf_token');
         $listener($event);
     }
 
-    public function testDoesNotValidateTheRequestTokenIfNotAContaoMasterRequest(): void
+    public function testDoesNotValidateTheRequestTokenIfNotAMasterRequest(): void
     {
         $framework = $this->mockContaoFramework();
         $framework
@@ -281,29 +305,18 @@ class RequestTokenListenerTest extends TestCase
         ;
 
         $scopeMatcher = $this->createMock(ScopeMatcher::class);
-        $scopeMatcher
-            ->expects($this->once())
-            ->method('isContaoRequest')
-            ->willReturn(true)
-        ;
-
-        $scopeMatcher
-            ->expects($this->once())
-            ->method('isContaoMasterRequest')
-            ->willReturn(false)
-        ;
-
         $csrfTokenManager = $this->createMock(CsrfTokenManagerInterface::class);
-
-        $request = Request::create('/account.html');
-        $request->setMethod('POST');
-        $request->cookies = new ParameterBag(['unrelated-cookie' => 'to-activate-csrf']);
 
         $event = $this->createMock(RequestEvent::class);
         $event
-            ->expects($this->once())
+            ->expects($this->never())
             ->method('getRequest')
-            ->willReturn($request)
+        ;
+
+        $event
+            ->expects($this->once())
+            ->method('isMasterRequest')
+            ->willReturn(false)
         ;
 
         $listener = new RequestTokenListener($framework, $scopeMatcher, $csrfTokenManager, 'contao_csrf_token');
@@ -315,12 +328,6 @@ class RequestTokenListenerTest extends TestCase
         $config = $this->mockConfiguredAdapter(['get' => false]);
         $framework = $this->mockContaoFramework([Config::class => $config]);
         $scopeMatcher = $this->createMock(ScopeMatcher::class);
-
-        $scopeMatcher
-            ->expects($this->once())
-            ->method('isContaoMasterRequest')
-            ->willReturn(true)
-        ;
 
         $csrfTokenManager = $this->createMock(CsrfTokenManagerInterface::class);
         $csrfTokenManager
@@ -334,6 +341,12 @@ class RequestTokenListenerTest extends TestCase
             ->expects($this->once())
             ->method('getRequest')
             ->willReturn($request)
+        ;
+
+        $event
+            ->expects($this->once())
+            ->method('isMasterRequest')
+            ->willReturn(true)
         ;
 
         $listener = new RequestTokenListener($framework, $scopeMatcher, $csrfTokenManager, 'contao_csrf_token');


### PR DESCRIPTION
## Summary

If you have a form on a page and a fragment element after the form, and if, during the POST request, the form does not validate, hence the form does not throw a `RedirectException` and rendering of the page continues, the `RequestTokenListener` will be executed for the subsequent sub-requests for fragments, where the session will be set (due to the failing form before), but no CSRF Token will be present and thus the listener will throw the `InvalidRequestTokenException`.

## Reproduction

### 1. Create a form

1.1. Create a form and _disable its HTML5 validation_.
1.2. Create a single text field _and make it mandatory_.
1.3. Create a submit button.
1.4. Insert the form on a page via a form include content element.

### 2. Create a fragment content element

```php
// src/Controller/ContentElement/ExampleElementController.php
namespace App\Controller\ContentElement;

use Contao\CoreBundle\Controller\AbstractFragmentController;
use Contao\CoreBundle\ServiceAnnotation\ContentElement;
use Symfony\Component\HttpFoundation\Response;

/**
 * @ContentElement(category="texts")
 */
class ExampleElementController extends AbstractFragmentController
{
    public function __invoke(): Response
    {
        return new Response('<p>Hello World!</p>');
    }
}
```

Create a content element of type `example_element` _after_ (❗) the form include element.

### 3. Execute the POST request

3.1. Open a private browsing window, or clear all cookies for the domain of your Contao installation.
3.2. Open the page in the front end where the form and fragment is included.
3.3. Submit the form _without any input in the text element_.

This will show the _invalid request token_ error in the front end.

## Cause

Usually `\Contao\Form` will either _reload_ the current page or redirect to a new page, thus halting execution. However, when a form field does not validate, the `POST` request continues and the remaining fragments are rendered. Since the fragments are rendered via sub-requests, the `kernel.request` event is dispatched for each sub-request, thus also triggering the `RequestTokenListener` again. But by this point, `\Contao\Form` has initiated a session and therefore fulfilling all of the conditions for the request to require a valid request token - **if** the fragment is rendered with the `forward` renderer (which Contao Content Element fragments are by default), because those fragments get a full duplicate of the original request. Of course no request token will be present in the request, since no request token was necessary yet before the `POST` request was initiated.

## Solution

As discussed with @Toflar in Slack, the `RequestTokenListener` should probably check whether the request is actually a master request. Thus in this PR I have added this in the beginning of the listener.