### PR TITLE
Consider symlink when saving localconfig.php

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Config.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Config.php
@@ -270,7 +270,7 @@ class Config
 		// Create the destination path of the localconfig.php
 		$strDestination = Path::join(TL_ROOT, 'system/config/localconfig.php');
 
-		// Get the realpath in case it is a symlink
+		// Get the realpath in case it is a symlink (see #2209)
 		$strDestination = realpath($strDestination) ?: $strDestination;
 
 		// Then move the file to its final destination

--- a/core-bundle/src/Resources/contao/library/Contao/Config.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Config.php
@@ -257,7 +257,7 @@ class Config
 		// Make sure the file has been written (see #4483)
 		if (!filesize($strTemp))
 		{
-			\System::log('The local configuration file could not be written. Have your reached your quota limit?', __METHOD__, TL_ERROR);
+			\System::log('The local configuration file could not be written. Have you reached your quota limit?', __METHOD__, TL_ERROR);
 
 			return;
 		}

--- a/core-bundle/src/Resources/contao/library/Contao/Config.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Config.php
@@ -271,10 +271,7 @@ class Config
 		$strDestination = Path::join(TL_ROOT, 'system/config/localconfig.php');
 
 		// Get the realpath in case it is a symlink
-		if ($fs->exists($strDestination))
-		{
-			$strDestination = realpath($strDestination);
-		}
+		$strDestination = realpath($strDestination) ?: $strDestination;
 
 		// Then move the file to its final destination
 		$fs->rename($strTemp, $strDestination, true);

--- a/core-bundle/src/Resources/contao/library/Contao/Config.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Config.php
@@ -11,7 +11,6 @@
 namespace Contao;
 
 use Symfony\Component\Filesystem\Filesystem;
-use Webmozart\PathUtil\Path;
 
 /**
  * Loads and writes the local configuration file
@@ -247,7 +246,7 @@ class Config
 			$strFile .= "\n" . $this->strBottom . "\n";
 		}
 
-		$strTemp = Path::join(TL_ROOT, 'system/tmp', md5(uniqid(mt_rand(), true)));
+		$strTemp = TL_ROOT . '/system/tmp/' . md5(uniqid(mt_rand(), true));
 
 		// Write to a temp file first
 		$objFile = fopen($strTemp, 'w');
@@ -267,11 +266,13 @@ class Config
 		// Adjust the file permissions (see #8178)
 		$fs->chmod($strTemp, self::get('defaultFileChmod'));
 
-		// Create the destination path of the localconfig.php
-		$strDestination = Path::join(TL_ROOT, 'system/config/localconfig.php');
+		$strDestination = TL_ROOT . '/system/config/localconfig.php';
 
 		// Get the realpath in case it is a symlink (see #2209)
-		$strDestination = realpath($strDestination) ?: $strDestination;
+		if ($realpath = realpath($strDestination))
+		{
+			$strDestination = $realpath;
+		}
 
 		// Then move the file to its final destination
 		$fs->rename($strTemp, $strDestination, true);

--- a/core-bundle/src/Resources/contao/library/Contao/Config.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Config.php
@@ -11,6 +11,7 @@
 namespace Contao;
 
 use Symfony\Component\Filesystem\Filesystem;
+use Webmozart\PathUtil\Path;
 
 /**
  * Loads and writes the local configuration file
@@ -246,7 +247,7 @@ class Config
 			$strFile .= "\n" . $this->strBottom . "\n";
 		}
 
-		$strTemp = TL_ROOT . '/system/tmp/' . md5(uniqid(mt_rand(), true));
+		$strTemp = Path::join(TL_ROOT, 'system/tmp', md5(uniqid(mt_rand(), true)));
 
 		// Write to a temp file first
 		$objFile = fopen($strTemp, 'w');
@@ -266,7 +267,7 @@ class Config
 		// Adjust the file permissions (see #8178)
 		$fs->chmod($strTemp, self::get('defaultFileChmod'));
 
-		$strDestination = TL_ROOT . '/system/config/localconfig.php';
+		$strDestination = Path::join(TL_ROOT, 'system/config/localconfig.php');
 
 		// Get the realpath in case it is a symlink (see #2209)
 		if ($realpath = realpath($strDestination))

--- a/core-bundle/src/Resources/contao/library/Contao/Config.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Config.php
@@ -10,6 +10,9 @@
 
 namespace Contao;
 
+use Symfony\Component\Filesystem\Filesystem;
+use Webmozart\PathUtil\Path;
+
 /**
  * Loads and writes the local configuration file
  *
@@ -244,37 +247,48 @@ class Config
 			$strFile .= "\n" . $this->strBottom . "\n";
 		}
 
-		$strTemp = md5(uniqid(mt_rand(), true));
+		$strTemp = Path::join(TL_ROOT, 'system/tmp', md5(uniqid(mt_rand(), true)));
 
 		// Write to a temp file first
-		$objFile = fopen(TL_ROOT . '/system/tmp/' . $strTemp, 'w');
+		$objFile = fopen($strTemp, 'w');
 		fwrite($objFile, $strFile);
 		fclose($objFile);
 
 		// Make sure the file has been written (see #4483)
-		if (!filesize(TL_ROOT . '/system/tmp/' . $strTemp))
+		if (!filesize($strTemp))
 		{
 			\System::log('The local configuration file could not be written. Have your reached your quota limit?', __METHOD__, TL_ERROR);
 
 			return;
 		}
 
+		$fs = new Filesystem();
+
 		// Adjust the file permissions (see #8178)
-		$this->Files->chmod('system/tmp/' . $strTemp, \Config::get('defaultFileChmod'));
+		$fs->chmod($strTemp, self::get('defaultFileChmod'));
+
+		// Create the destination path of the localconfig.php
+		$strDestination = Path::join(TL_ROOT, 'system/config/localconfig.php');
+
+		// Get the realpath in case it is a symlink
+		if ($fs->exists($strDestination))
+		{
+			$strDestination = realpath($strDestination);
+		}
 
 		// Then move the file to its final destination
-		$this->Files->rename('system/tmp/' . $strTemp, 'system/config/localconfig.php');
+		$fs->rename($strTemp, $strDestination, true);
 
 		// Reset the Zend OPcache
 		if (\function_exists('opcache_invalidate'))
 		{
-			opcache_invalidate(TL_ROOT . '/system/config/localconfig.php', true);
+			opcache_invalidate($strDestination, true);
 		}
 
 		// Recompile the APC file (thanks to Trenker)
 		if (\function_exists('apc_compile_file') && !ini_get('apc.stat'))
 		{
-			apc_compile_file(TL_ROOT . '/system/config/localconfig.php');
+			apc_compile_file($strDestination);
 		}
 
 		$this->blnIsModified = false;


### PR DESCRIPTION
We are using [Deployer](https://deployer.org/) to deploy our Contao 4 instances. In the config, we have added

```
system/config/localconfig.php
``` 

to the `shared_files` so that any changes to the system config in the back end do not get lost after the next deployment. However, this does not actually work as Contao simply overwrites the symlink with a regular `localconfig.php` file when saving.

This PR changes that: it evaluates the `realpath` of an existing `localconfig.php` and uses that path as the new destination.
