### PR TITLE
Simplify the tl_content header fields

### DIFF
--- a/core-bundle/src/Resources/contao/dca/tl_content.php
+++ b/core-bundle/src/Resources/contao/dca/tl_content.php
@@ -43,7 +43,7 @@ $GLOBALS['TL_DCA']['tl_content'] = array
 			'mode'                    => 4,
 			'fields'                  => array('sorting'),
 			'panelLayout'             => 'filter;search,limit',
-			'headerFields'            => array('title', 'headline', 'author', 'inColumn', 'tstamp', 'showTeaser', 'published', 'start', 'stop'),
+			'headerFields'            => array('title', 'headline', 'author', 'tstamp', 'start', 'stop'),
 			'child_record_callback'   => array('tl_content', 'addCteType')
 		),
 		'global_operations' => array


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #2157
| Docs PR or issue | -

This PR fixes #2157 and also removes header fields that are specific to `tl_article` and do not exist in e.g. `tl_news`.
