### PR TITLE
Use a temporary status code to redirect to the language root

### DIFF
--- a/core-bundle/src/Resources/contao/pages/PageError404.php
+++ b/core-bundle/src/Resources/contao/pages/PageError404.php
@@ -109,7 +109,7 @@ class PageError404 extends Frontend
 						$strRequest = Environment::get('script') . '/' . $objRootPage->language . '/' . $strRequest;
 					}
 
-					$this->redirect($strRequest, 301);
+					$this->redirect($strRequest);
 				}
 			}
 		}

--- a/core-bundle/src/Routing/Route404Provider.php
+++ b/core-bundle/src/Routing/Route404Provider.php
@@ -238,7 +238,7 @@ class Route404Provider extends AbstractPageRouteProvider
         $redirect->addDefaults([
             '_controller' => RedirectController::class,
             'path' => $path,
-            'permanent' => true,
+            'permanent' => false,
         ]);
 
         $routes['tl_page.'.$route->getPageModel()->id.'.locale'] = $redirect;

--- a/core-bundle/src/Routing/RouteProvider.php
+++ b/core-bundle/src/Routing/RouteProvider.php
@@ -230,7 +230,7 @@ class RouteProvider extends AbstractPageRouteProvider
                 [
                     '_controller' => 'Symfony\Bundle\FrameworkBundle\Controller\RedirectController::urlRedirectAction',
                     'path' => '/'.$urlPrefix.'/',
-                    'permanent' => true,
+                    'permanent' => false,
                 ]
             ),
             [],

--- a/core-bundle/tests/Functional/RoutingTest.php
+++ b/core-bundle/tests/Functional/RoutingTest.php
@@ -433,7 +433,7 @@ class RoutingTest extends FunctionalTestCase
         yield 'Redirects to the language root if the request is empty' => [
             ['theme', 'root-with-index'],
             '/',
-            301,
+            302,
             'Redirecting to http://root-with-index.local/en/',
             ['language' => 'en'],
             'root-with-index.local',
@@ -463,7 +463,7 @@ class RoutingTest extends FunctionalTestCase
         yield 'Redirects if the alias matches but no language is given' => [
             ['theme', 'root-with-home'],
             '/home.html',
-            301,
+            302,
             'Redirecting to http://root-with-home.local/en/home.html',
             [],
             'root-with-home.local',
@@ -1108,7 +1108,7 @@ class RoutingTest extends FunctionalTestCase
         yield 'Redirects to the language root if one of the accept languages matches' => [
             ['theme', 'same-domain-root'],
             '/',
-            301,
+            302,
             'Redirecting to http://same-domain-root.local/de/',
             'de,en',
             'same-domain-root.local',
@@ -1117,7 +1117,7 @@ class RoutingTest extends FunctionalTestCase
         yield 'Redirects to the language fallback if one of the accept languages matches' => [
             ['theme', 'same-domain-root'],
             '/',
-            301,
+            302,
             'Redirecting to http://same-domain-root.local/en/',
             'en,de',
             'same-domain-root.local',
@@ -1126,7 +1126,7 @@ class RoutingTest extends FunctionalTestCase
         yield 'Redirects to the language fallback if none of the accept languages matches' => [
             ['theme', 'same-domain-root'],
             '/',
-            301,
+            302,
             'Redirecting to http://same-domain-root.local/en/',
             'fr,es',
             'same-domain-root.local',
@@ -1135,7 +1135,7 @@ class RoutingTest extends FunctionalTestCase
         yield 'Redirects to "de" if "de-CH" is accepted and "de" is not' => [
             ['theme', 'same-domain-root'],
             '/',
-            301,
+            302,
             'Redirecting to http://same-domain-root.local/de/',
             'de-CH',
             'same-domain-root.local',
@@ -1144,7 +1144,7 @@ class RoutingTest extends FunctionalTestCase
         yield 'Ignores the case of the language code' => [
             ['theme', 'same-domain-root'],
             '/',
-            301,
+            302,
             'Redirecting to http://same-domain-root.local/de/',
             'dE-at',
             'same-domain-root.local',
@@ -1153,7 +1153,7 @@ class RoutingTest extends FunctionalTestCase
         yield 'Redirects to "en" if "de-CH" and "en" are accepted and "de" is not' => [
             ['theme', 'same-domain-root'],
             '/',
-            301,
+            302,
             'Redirecting to http://same-domain-root.local/en/',
             'de-CH,en',
             'same-domain-root.local',
@@ -1225,7 +1225,7 @@ class RoutingTest extends FunctionalTestCase
         yield 'Redirects to the correct language if first page does not have index alias' => [
             ['theme', 'language-index-mix'],
             '/',
-            301,
+            302,
             'Redirecting to http://example.com/de/',
             'de,en',
             'example.com',

--- a/core-bundle/tests/Routing/Route404ProviderTest.php
+++ b/core-bundle/tests/Routing/Route404ProviderTest.php
@@ -134,7 +134,7 @@ class Route404ProviderTest extends TestCase
         $this->assertInstanceOf(Route::class, $route);
         $this->assertSame(RedirectController::class, $route->getDefault('_controller'));
         $this->assertSame('/en/foo.html', $route->getDefault('path'));
-        $this->assertTrue($route->getDefault('permanent'));
+        $this->assertFalse($route->getDefault('permanent'));
     }
 
     public function testDoesNotCheckCandidatesForEmptyPath(): void


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #2084
| Docs PR or issue | -
