### PR TITLE
Correcting polish translation - branch 4.4

### DIFF
--- a/calendar-bundle/src/Resources/contao/languages/pl/default.xlf
+++ b/calendar-bundle/src/Resources/contao/languages/pl/default.xlf
@@ -35,7 +35,7 @@
       </trans-unit>
       <trans-unit id="MSC.cal_empty">
         <source>Currently there are no events.</source>
-        <target>Aktualnie mie ma żadnych nadchodzących wydarzeń.</target>
+        <target>Aktualnie nie ma żadnych nadchodzących wydarzeń.</target>
       </trans-unit>
       <trans-unit id="MSC.cal_days">
         <source>This event is repeated every %s. day</source>

--- a/calendar-bundle/src/Resources/contao/languages/pl/modules.xlf
+++ b/calendar-bundle/src/Resources/contao/languages/pl/modules.xlf
@@ -35,7 +35,7 @@
       </trans-unit>
       <trans-unit id="FMD.eventlist.1">
         <source>Adds a list of events to the page</source>
-        <target>Ten moduł pokazuje listę wydarzeń w miesiącu, tygodniu, lub dniu.</target>
+        <target>Ten moduł pokazuje listę wydarzeń w miesiącu, tygodniu lub dniu.</target>
       </trans-unit>
       <trans-unit id="FMD.eventreader.0">
         <source>Event reader</source>

--- a/calendar-bundle/src/Resources/contao/languages/pl/tl_calendar.xlf
+++ b/calendar-bundle/src/Resources/contao/languages/pl/tl_calendar.xlf
@@ -63,11 +63,11 @@
       </trans-unit>
       <trans-unit id="tl_calendar.bbcode.1">
         <source>Allow visitors to format their comments with BBCode.</source>
-        <target>Zezwól odwiedzającym na formatowanie ich komenatrzy za pomocą BBCode.</target>
+        <target>Zezwól odwiedzającym na formatowanie ich komentarzy za pomocą BBCode.</target>
       </trans-unit>
       <trans-unit id="tl_calendar.requireLogin.0">
         <source>Require login to comment</source>
-        <target>Wymagaj zalogowania aby komentować</target>
+        <target>Wymagaj zalogowania, aby komentować</target>
       </trans-unit>
       <trans-unit id="tl_calendar.requireLogin.1">
         <source>Allow only authenticated members to create comments.</source>
@@ -79,7 +79,7 @@
       </trans-unit>
       <trans-unit id="tl_calendar.disableCaptcha.1">
         <source>Use this option only if you have limited comments to authenticated users.</source>
-        <target>Używaj tej opcji tylko jeśli ograniczyłeś komentarze dla zalogowanych użytkowników.</target>
+        <target>Używaj tej opcji tylko, jeśli ograniczyłeś komentarze do zalogowanych użytkowników.</target>
       </trans-unit>
       <trans-unit id="tl_calendar.protected.0">
         <source>Protect calendar</source>
@@ -91,7 +91,7 @@
       </trans-unit>
       <trans-unit id="tl_calendar.groups.0">
         <source>Allowed member groups</source>
-        <target>Zezwolone grupy użytkowników</target>
+        <target>Dozwolone grupy użytkowników</target>
       </trans-unit>
       <trans-unit id="tl_calendar.groups.1">
         <source>These groups will be able to see the events in this calendar.</source>

--- a/calendar-bundle/src/Resources/contao/languages/pl/tl_calendar_events.xlf
+++ b/calendar-bundle/src/Resources/contao/languages/pl/tl_calendar_events.xlf
@@ -15,11 +15,11 @@
       </trans-unit>
       <trans-unit id="tl_calendar_events.alias.1">
         <source>The event alias is a unique reference to the event which can be called instead of its numeric ID.</source>
-        <target>Alias wydarzenia jest unikalnym odwołaniem do wydarzenia, który może być używany zamiast jej ID.</target>
+        <target>Alias wydarzenia jest unikalnym odwołaniem do wydarzenia, który może być używany zamiast jego ID.</target>
       </trans-unit>
       <trans-unit id="tl_calendar_events.author.0">
         <source>Author</source>
-        <target>Imię</target>
+        <target>Autor</target>
       </trans-unit>
       <trans-unit id="tl_calendar_events.author.1">
         <source>Here you can change the author of the event.</source>
@@ -95,11 +95,11 @@
       </trans-unit>
       <trans-unit id="tl_calendar_events.addImage.1">
         <source>Add an image to the event.</source>
-        <target>Jeśli wybierzesz tą opcję, do wydarzenia zostanie dodany obrazek.</target>
+        <target>Jeśli wybierzesz tę opcję, do wydarzenia zostanie dodany obrazek.</target>
       </trans-unit>
       <trans-unit id="tl_calendar_events.recurring.0">
         <source>Repeat event</source>
-        <target>Wydarzeni cykliczne</target>
+        <target>Wydarzenie cykliczne</target>
       </trans-unit>
       <trans-unit id="tl_calendar_events.recurring.1">
         <source>Create a recurring event.</source>
@@ -163,7 +163,7 @@
       </trans-unit>
       <trans-unit id="tl_calendar_events.internal.1">
         <source>By clicking the &quot;read more …&quot; button, visitors will be redirected to an internal page.</source>
-        <target>Po kliknięciu w odnośnik &quot;czytaj więcej...&quot; użytkownik będzie przekierowany na inną stronę naszego serwisu.</target>
+        <target>Po kliknięciu w odnośnik &quot;czytaj więcej...&quot; odwiedzający zostaną przekierowani na inną stronę naszego serwisu.</target>
       </trans-unit>
       <trans-unit id="tl_calendar_events.article.0">
         <source>Article</source>
@@ -187,7 +187,7 @@
       </trans-unit>
       <trans-unit id="tl_calendar_events.jumpTo.1">
         <source>Please choose the page to which visitors will be redirected when clicking the event.</source>
-        <target>Wybierz stronę, na którą użytkownik zostanie przekierowany.</target>
+        <target>Wybierz stronę, na którą odwiedzający zostaną przekierowani.</target>
       </trans-unit>
       <trans-unit id="tl_calendar_events.articleId.0">
         <source>Article</source>
@@ -195,7 +195,7 @@
       </trans-unit>
       <trans-unit id="tl_calendar_events.articleId.1">
         <source>Please choose the article to which visitors will be redirected when clicking the event.</source>
-        <target>Wybierz artykuł na który zostaną przeniesieni użytkownicy kiedy klikną w wydarzenie.</target>
+        <target>Wybierz artykuł, na który zostaną przeniesieni użytkownicy, kiedy klikną w wydarzenie.</target>
       </trans-unit>
       <trans-unit id="tl_calendar_events.cssClass.0">
         <source>CSS class</source>
@@ -211,7 +211,7 @@
       </trans-unit>
       <trans-unit id="tl_calendar_events.noComments.1">
         <source>Do not allow comments for this particular event.</source>
-        <target>Nie zezwalaj komentowania tego wydarzenia.</target>
+        <target>Nie zezwalaj na komentowanie tego wydarzenia.</target>
       </trans-unit>
       <trans-unit id="tl_calendar_events.published.0">
         <source>Publish event</source>
@@ -223,7 +223,7 @@
       </trans-unit>
       <trans-unit id="tl_calendar_events.start.0">
         <source>Show from</source>
-        <target>Wrapper start</target>
+        <target>Pokazuj od</target>
       </trans-unit>
       <trans-unit id="tl_calendar_events.start.1">
         <source>Do not show the event on the website before this day.</source>
@@ -231,7 +231,7 @@
       </trans-unit>
       <trans-unit id="tl_calendar_events.stop.0">
         <source>Show until</source>
-        <target>Wrapper stop</target>
+        <target>Pokazuj do</target>
       </trans-unit>
       <trans-unit id="tl_calendar_events.stop.1">
         <source>Do not show the event on the website on and after this day.</source>
@@ -283,7 +283,7 @@
       </trans-unit>
       <trans-unit id="tl_calendar_events.publish_legend">
         <source>Publish settings</source>
-        <target>Ustawinia publikacji</target>
+        <target>Ustawienia publikacji</target>
       </trans-unit>
       <trans-unit id="tl_calendar_events.days">
         <source>day(s)</source>

--- a/calendar-bundle/src/Resources/contao/languages/pl/tl_module.xlf
+++ b/calendar-bundle/src/Resources/contao/languages/pl/tl_module.xlf
@@ -15,7 +15,7 @@
       </trans-unit>
       <trans-unit id="tl_module.cal_noSpan.1">
         <source>Show events only once even if they span multiple days.</source>
-        <target>Pokaż wydarzenia tylko raz nawet jeśli są to wydarzenia wielodniowe.</target>
+        <target>Pokaż wydarzenia tylko raz, nawet jeśli są to wydarzenia wielodniowe.</target>
       </trans-unit>
       <trans-unit id="tl_module.cal_hideRunning.0">
         <source>Hide running events</source>
@@ -47,7 +47,7 @@
       </trans-unit>
       <trans-unit id="tl_module.cal_ignoreDynamic.1">
         <source>Do not switch the time period based on the date/month/year URL parameters.</source>
-        <target>Nie zmieniaj okresu czasu na podstawie parametrów URL date/month/year.</target>
+        <target>Nie zmieniaj przedziału czasu na podstawie parametrów URL date/month/year.</target>
       </trans-unit>
       <trans-unit id="tl_module.cal_order.0">
         <source>Sort order</source>
@@ -71,7 +71,7 @@
       </trans-unit>
       <trans-unit id="tl_module.cal_limit.1">
         <source>Here you can limit the number of events. Enter 0 to show all.</source>
-        <target>Tu możesz ustalić ilość wydarzeń. Jeśli wpiszesz 0 zostaną pokazane wszystkie wydarzenia.</target>
+        <target>Tu możesz ustalić ilość wydarzeń. Jeśli wpiszesz 0, zostaną pokazane wszystkie wydarzenia.</target>
       </trans-unit>
       <trans-unit id="tl_module.cal_template.0">
         <source>Event template</source>
@@ -79,7 +79,7 @@
       </trans-unit>
       <trans-unit id="tl_module.cal_template.1">
         <source>Here you can select the event template.</source>
-        <target>Wybierz szablon wydarzeń. Możesz dodać własne szablony wydarzeń do katalogu &lt;em&gt;templates&lt;/em&gt;. Pliki szablonów wydarzeń muszą zaczynać się od &lt;em&gt;event_&lt;/em&gt; i muszą mieć rozszerzenie &lt;em&gt;.tpl&lt;/em&gt;.</target>
+        <target>Wybierz szablon wydarzeń. Możesz dodać własne szablony wydarzeń do katalogu &lt;em&gt;templates&lt;/em&gt;. Pliki szablonów wydarzeń muszą zaczynać się od &lt;em&gt;event_&lt;/em&gt; i muszą mieć rozszerzenie &lt;em&gt;.html5&lt;/em&gt;.</target>
       </trans-unit>
       <trans-unit id="tl_module.cal_ctemplate.0">
         <source>Calendar template</source>

--- a/calendar-bundle/src/Resources/contao/languages/pl/tl_user.xlf
+++ b/calendar-bundle/src/Resources/contao/languages/pl/tl_user.xlf
@@ -11,7 +11,7 @@
       </trans-unit>
       <trans-unit id="tl_user.calendarp.0">
         <source>Calendar permissions</source>
-        <target>Uprawnienia kalednarzy</target>
+        <target>Uprawnienia kalendarzy</target>
       </trans-unit>
       <trans-unit id="tl_user.calendarp.1">
         <source>Here you can define the calendar permissions.</source>
@@ -35,7 +35,7 @@
       </trans-unit>
       <trans-unit id="tl_user.calendars_legend">
         <source>Events permissions</source>
-        <target>Uprawnienia wydrazeń</target>
+        <target>Uprawnienia wydarzeń</target>
       </trans-unit>
     </body>
   </file>

--- a/comments-bundle/src/Resources/contao/languages/pl/default.xlf
+++ b/comments-bundle/src/Resources/contao/languages/pl/default.xlf
@@ -75,7 +75,7 @@ Edytuj: %s
       </trans-unit>
       <trans-unit id="MSC.com_moderated">
         <source>This comment has to be published in the back end before it will appear on the website!</source>
-        <target>Ten komentarz musi zostać opublikowany w backendzie zanim pojawi się na stronie!</target>
+        <target>Ten komentarz musi zostać opublikowany w backendzie, zanim pojawi się na stronie!</target>
       </trans-unit>
       <trans-unit id="MSC.com_confirm">
         <source>Your comment has been added and is now pending for approval.</source>
@@ -163,7 +163,7 @@ To cancel your subscription, please click here:
 </source>
         <target>Witaj %s,
 
-została dodana nowa odpowiedź na komentarz na stornie, którą subskrybujesz:
+została dodana nowa odpowiedź na komentarz na stronie, którą subskrybujesz:
 
 %s
 

--- a/comments-bundle/src/Resources/contao/languages/pl/tl_comments.xlf
+++ b/comments-bundle/src/Resources/contao/languages/pl/tl_comments.xlf
@@ -27,7 +27,7 @@
       </trans-unit>
       <trans-unit id="tl_comments.name.0">
         <source>Author</source>
-        <target>Imię</target>
+        <target>Autor</target>
       </trans-unit>
       <trans-unit id="tl_comments.name.1">
         <source>Please enter the author's name.</source>
@@ -67,7 +67,7 @@
       </trans-unit>
       <trans-unit id="tl_comments.author.0">
         <source>Author</source>
-        <target>Imię</target>
+        <target>Autor</target>
       </trans-unit>
       <trans-unit id="tl_comments.author.1">
         <source>Here you can change the author of the reply.</source>
@@ -115,7 +115,7 @@
       </trans-unit>
       <trans-unit id="tl_comments.author_legend">
         <source>Author</source>
-        <target>Imię</target>
+        <target>Autor</target>
       </trans-unit>
       <trans-unit id="tl_comments.comment_legend">
         <source>Comment</source>
@@ -127,7 +127,7 @@
       </trans-unit>
       <trans-unit id="tl_comments.publish_legend">
         <source>Publish settings</source>
-        <target>Ustawinia publikacji</target>
+        <target>Ustawienia publikacji</target>
       </trans-unit>
       <trans-unit id="tl_comments.approved">
         <source>Approved</source>

--- a/comments-bundle/src/Resources/contao/languages/pl/tl_content.xlf
+++ b/comments-bundle/src/Resources/contao/languages/pl/tl_content.xlf
@@ -23,7 +23,7 @@
       </trans-unit>
       <trans-unit id="tl_content.com_moderate.1">
         <source>Approve comments before they are published on the website.</source>
-        <target>Zatwierdzaj komentarze zanim zostaną one opublikowane na stronie.</target>
+        <target>Zatwierdzaj komentarze, zanim zostaną one opublikowane na stronie.</target>
       </trans-unit>
       <trans-unit id="tl_content.com_bbcode.0">
         <source>Allow BBCode</source>
@@ -31,11 +31,11 @@
       </trans-unit>
       <trans-unit id="tl_content.com_bbcode.1">
         <source>Allow visitors to format their comments with BBCode.</source>
-        <target>Zezwól odwiedzającym na formatowanie ich komenatrzy za pomocą BBCode.</target>
+        <target>Zezwól odwiedzającym na formatowanie ich komentarzy za pomocą BBCode.</target>
       </trans-unit>
       <trans-unit id="tl_content.com_requireLogin.0">
         <source>Require login to comment</source>
-        <target>Wymagaj zalogowania aby komentować</target>
+        <target>Wymagaj zalogowania, aby komentować</target>
       </trans-unit>
       <trans-unit id="tl_content.com_requireLogin.1">
         <source>Allow only authenticated members to create comments.</source>
@@ -55,11 +55,11 @@
       </trans-unit>
       <trans-unit id="tl_content.com_template.1">
         <source>Here you can select the comments template.</source>
-        <target>Wybierz szablon komentarzy. Własne szablony komentarzy można zapisać do katalogu &lt;em&gt;templates&lt;/em&gt;. Pliki szablonów komentarzy muszą zaczynać się &lt;em&gt;com_&lt;/em&gt; a kończyć &lt;em&gt;.tpl&lt;/em&gt;.</target>
+        <target>Wybierz szablon komentarzy. Własne szablony komentarzy można zapisać do katalogu &lt;em&gt;templates&lt;/em&gt;. Pliki szablonów komentarzy muszą zaczynać się &lt;em&gt;com_&lt;/em&gt;, a kończyć &lt;em&gt;.html5&lt;/em&gt;.</target>
       </trans-unit>
       <trans-unit id="tl_content.comment_legend">
         <source>Comment settings</source>
-        <target>Ustawienia komantarzy</target>
+        <target>Ustawienia komentarzy</target>
       </trans-unit>
     </body>
   </file>

--- a/comments-bundle/src/Resources/contao/languages/pl/tl_module.xlf
+++ b/comments-bundle/src/Resources/contao/languages/pl/tl_module.xlf
@@ -3,7 +3,7 @@
     <body>
       <trans-unit id="tl_module.comment_legend">
         <source>Comment settings</source>
-        <target>Ustawienia komantarzy</target>
+        <target>Ustawienia komentarzy</target>
       </trans-unit>
     </body>
   </file>

--- a/core-bundle/src/Resources/contao/languages/pl/default.xlf
+++ b/core-bundle/src/Resources/contao/languages/pl/default.xlf
@@ -1203,7 +1203,7 @@
       </trans-unit>
       <trans-unit id="MSC.id.1">
         <source>Note that changing the ID can break data integrity!</source>
-        <target>ID jest unikatowym numerycznym identyfikatorem rekordu tabeli. Numery ID są zwykle przydzielane automatycznie. Jako że numery ID używane są w zależnościach pomiędzy rekordami, zmiana lub ich usunięcie może doprowadzić do utraty integralności danych a co za tym idziedo awarii systemu!</target>
+        <target>ID jest unikatowym numerycznym identyfikatorem rekordu tabeli. Numery ID są zwykle przydzielane automatycznie. Jako że numery ID używane są w zależnościach pomiędzy rekordami, zmiana lub ich usunięcie może doprowadzić do utraty integralności danych, a co za tym idzie, do awarii systemu!</target>
       </trans-unit>
       <trans-unit id="MSC.pid.0">
         <source>Parent ID</source>
@@ -1211,7 +1211,7 @@
       </trans-unit>
       <trans-unit id="MSC.pid.1">
         <source>Note that changing the parent ID can break data integrity!</source>
-        <target>Nadrzędne ID jest identyfikatorem rekordu, który jest nadrzędnym rekordem wobec rekordu aktualnego oraz jest z nim powiązany. Nadrzędne numery ID są zwykle przydzielane automatycznie. Jako że nadrzędne numery ID używane są w zależnościach pomiędzy rekordami, zmiana lub ich usunięcie może doprowadzić do utraty integralności danych a co za tym idzie, do awarii systemu!</target>
+        <target>Nadrzędne ID jest identyfikatorem rekordu, który jest nadrzędnym rekordem wobec rekordu aktualnego oraz jest z nim powiązany. Nadrzędne numery ID są zwykle przydzielane automatycznie. Jako że nadrzędne numery ID używane są w zależnościach pomiędzy rekordami, zmiana lub ich usunięcie może doprowadzić do utraty integralności danych, a co za tym idzie, do awarii systemu!</target>
       </trans-unit>
       <trans-unit id="MSC.sorting.0">
         <source>Sorting value</source>
@@ -1533,27 +1533,27 @@ Ten e-mail został wygenerowane przez Contao. Nie odpowiadaj na niego.
       </trans-unit>
       <trans-unit id="MSC.save">
         <source>Save</source>
-        <target>Zachowaj</target>
+        <target>Zapisz</target>
       </trans-unit>
       <trans-unit id="MSC.saveNclose">
         <source>Save and close</source>
-        <target>Zachowaj i zamknij</target>
+        <target>Zapisz i zamknij</target>
       </trans-unit>
       <trans-unit id="MSC.saveNedit">
         <source>Save and edit</source>
-        <target>Zachowaj i edytuj</target>
+        <target>Zapisz i edytuj</target>
       </trans-unit>
       <trans-unit id="MSC.saveNback">
         <source>Save and go back</source>
-        <target>Zachowaj i wróć</target>
+        <target>Zapisz i wróć</target>
       </trans-unit>
       <trans-unit id="MSC.saveNcreate">
         <source>Save and new</source>
-        <target>Zachowaj i nowy</target>
+        <target>Zapisz i nowy</target>
       </trans-unit>
       <trans-unit id="MSC.saveNduplicate">
         <source>Save and duplicate</source>
-        <target>Zachowaj i duplikuj</target>
+        <target>Zapisz i duplikuj</target>
       </trans-unit>
       <trans-unit id="MSC.continue">
         <source>Continue</source>
@@ -2197,7 +2197,7 @@ Ten e-mail został wygenerowane przez Contao. Nie odpowiadaj na niego.
       </trans-unit>
       <trans-unit id="MSC.saveData">
         <source>Save data</source>
-        <target>Zachowaj dane</target>
+        <target>Zapisz dane</target>
       </trans-unit>
       <trans-unit id="MSC.savedData">
         <source>Your data has been saved.</source>

--- a/core-bundle/src/Resources/contao/languages/pl/default.xlf
+++ b/core-bundle/src/Resources/contao/languages/pl/default.xlf
@@ -75,11 +75,11 @@
       </trans-unit>
       <trans-unit id="ERR.locale">
         <source>Please enter a valid locale such as &quot;en&quot; or &quot;en_US&quot;!</source>
-        <target>Wprowadź poprawny język taki jak &quot;en&quot; lub &quot;en_US&quot;!</target>
+        <target>Wprowadź poprawny język, taki jak &quot;en&quot; lub &quot;en_US&quot;!</target>
       </trans-unit>
       <trans-unit id="ERR.language">
         <source>Please enter a valid language code such as &quot;en&quot; or &quot;en-US&quot;!</source>
-        <target>Wprowadź poprawny kod językowy taki jak &quot;en&quot; lub &quot;en-US&quot;!</target>
+        <target>Wprowadź poprawny kod językowy, taki jak &quot;en&quot; lub &quot;en-US&quot;!</target>
       </trans-unit>
       <trans-unit id="ERR.alias">
         <source>Please enter only alphanumeric characters and the following special characters: .-_</source>
@@ -115,7 +115,7 @@
       </trans-unit>
       <trans-unit id="ERR.filesize">
         <source>The maximum size for file uploads is %s (Contao or php.ini settings)!</source>
-        <target>Maksymalny rozmiar pliku do wysyłki to %s KB (Contao lub ustawienia php.ini)!</target>
+        <target>Maksymalny rozmiar pliku do wysyłki, to %s KB (Contao lub ustawienia php.ini)!</target>
       </trans-unit>
       <trans-unit id="ERR.filetype">
         <source>File type &quot;%s&quot; is not allowed to be uploaded!</source>
@@ -191,7 +191,7 @@
       </trans-unit>
       <trans-unit id="ERR.notWriteable">
         <source>The file &quot;%s&quot; is not writeable and can therefore not be updated!</source>
-        <target>Plik &quot;%s&quot; nie ma prawa do zapisu więc zmiany nie zostaną naniesione.</target>
+        <target>Plik &quot;%s&quot; nie ma prawa do zapisu, więc zmiany nie zostaną naniesione.</target>
       </trans-unit>
       <trans-unit id="ERR.invalidName">
         <source>This file or folder name is invalid!</source>
@@ -255,7 +255,7 @@
       </trans-unit>
       <trans-unit id="ERR.invalidTokenUrl">
         <source>The link you were trying to open could not be verified. If you have clicked the link yourself or have received it by a trustworthy person, you can confirm the process below.</source>
-        <target>Link, który próbowałeś otworzyć, nie mógł zostać zweryfikowany. Jeśli kliknąłeś link sam, lub otrzymałeś go od zaufanej osoby, potwierdź proces poniżej.</target>
+        <target>Link, który próbowałeś otworzyć, nie mógł zostać zweryfikowany. Jeśli kliknąłeś link sam lub otrzymałeś go od zaufanej osoby, potwierdź proces poniżej.</target>
       </trans-unit>
       <trans-unit id="ERR.form">
         <source>The form could not be sent</source>
@@ -555,7 +555,7 @@
       </trans-unit>
       <trans-unit id="PTY.regular.1">
         <source>A regular page contains articles and content elements. It is the default page type.</source>
-        <target>Zwykła strona, która może zawierać artykuły lub inne elementy zawartości. Jest to domyślny typ strony.</target>
+        <target>Zwykła strona, która może zawierać artykuły lub inne elementy treści. Jest to domyślny typ strony.</target>
       </trans-unit>
       <trans-unit id="PTY.redirect.0">
         <source>External redirect</source>
@@ -571,7 +571,7 @@
       </trans-unit>
       <trans-unit id="PTY.forward.1">
         <source>This type of page automatically forwards visitors to another page within the site structure.</source>
-        <target>Ten ty strony automatycznie przeniesie cię na inną stronę tego samego serwisu internetowego. Przeniesienie odbywa się na podstawie ID strony lub aliasu strony.</target>
+        <target>Ten typ strony automatycznie przeniesie cię na inną stronę tego samego serwisu internetowego. Przeniesienie odbywa się na podstawie ID strony lub aliasu strony.</target>
       </trans-unit>
       <trans-unit id="PTY.root.0">
         <source>Website root</source>
@@ -595,7 +595,7 @@
       </trans-unit>
       <trans-unit id="PTY.error_403.1">
         <source>If a user requests a protected page without permission, a 403 error page will be loaded instead.</source>
-        <target>Ta strona pokazuje się w momencie kiedy nieautoryzowany użytkownik próbuje uzyskać dostęp do zabezpieczonych stron. Jeśli ta strona błędu znajduje się w konkretnym punkcie startowym, jej użytkowanie ograniczać się będzie tylko dla stron tego konkretnego punktu startowego.</target>
+        <target>Ta strona pokazuje się w momencie, kiedy nieautoryzowany użytkownik próbuje uzyskać dostęp do zabezpieczonych stron. Jeśli ta strona błędu znajduje się w konkretnym punkcie startowym, jej użytkowanie ograniczać się będzie tylko dla stron tego konkretnego punktu startowego.</target>
       </trans-unit>
       <trans-unit id="PTY.error_404.0">
         <source>404 Page not found</source>
@@ -639,7 +639,7 @@
       </trans-unit>
       <trans-unit id="CHMOD.editpage">
         <source>Edit page</source>
-        <target>Edytuj strone</target>
+        <target>Edytuj stronę</target>
       </trans-unit>
       <trans-unit id="CHMOD.editnavigation">
         <source>Edit page hierarchy</source>
@@ -647,7 +647,7 @@
       </trans-unit>
       <trans-unit id="CHMOD.deletepage">
         <source>Delete page</source>
-        <target>Skasuj strone</target>
+        <target>Skasuj stronę</target>
       </trans-unit>
       <trans-unit id="CHMOD.editarticles">
         <source>Edit articles</source>
@@ -1203,7 +1203,7 @@
       </trans-unit>
       <trans-unit id="MSC.id.1">
         <source>Note that changing the ID can break data integrity!</source>
-        <target>ID jest unikatowym numerycznym identyfikatorem rekordu tabeli. Numery ID są zwykle przydzielane automatycznie. Jako, że numery ID używane są w zależnościach pomiędzy rekordami, zmiana lub ich usunięcie może doprowadzić do utraty integralności danych a co za tym idzie do awarii systemu!!</target>
+        <target>ID jest unikatowym numerycznym identyfikatorem rekordu tabeli. Numery ID są zwykle przydzielane automatycznie. Jako że numery ID używane są w zależnościach pomiędzy rekordami, zmiana lub ich usunięcie może doprowadzić do utraty integralności danych a co za tym idziedo awarii systemu!</target>
       </trans-unit>
       <trans-unit id="MSC.pid.0">
         <source>Parent ID</source>
@@ -1211,7 +1211,7 @@
       </trans-unit>
       <trans-unit id="MSC.pid.1">
         <source>Note that changing the parent ID can break data integrity!</source>
-        <target>Nadrzędne ID jest identyfikatorem rekordu, który jest nadrzędnym rekordem wobec rekordu aktualnego oraz jest z nim powiązany. Nadrzędne numery ID są zwykle przydzielane automatycznie. Jako, że nadrzędne numery ID używane są w zależnościach pomiędzy rekordami, zmiana lub ich usunięcie może doprowadzić do utraty integralności danych a co za tym idzie do awarii systemu!</target>
+        <target>Nadrzędne ID jest identyfikatorem rekordu, który jest nadrzędnym rekordem wobec rekordu aktualnego oraz jest z nim powiązany. Nadrzędne numery ID są zwykle przydzielane automatycznie. Jako że nadrzędne numery ID używane są w zależnościach pomiędzy rekordami, zmiana lub ich usunięcie może doprowadzić do utraty integralności danych a co za tym idzie, do awarii systemu!</target>
       </trans-unit>
       <trans-unit id="MSC.sorting.0">
         <source>Sorting value</source>
@@ -1299,7 +1299,7 @@
       </trans-unit>
       <trans-unit id="MSC.move">
         <source>Move the item via drag and drop or the up and down keys</source>
-        <target>Przenieś element za pomocą przeciągnij i upuść lub klawiszów góra i dół.</target>
+        <target>Przenieś element za pomocą przeciągnij i upuść lub klawiszy góra i dół.</target>
       </trans-unit>
       <trans-unit id="MSC.move_up.0">
         <source>Move up</source>
@@ -1351,7 +1351,7 @@
       </trans-unit>
       <trans-unit id="MSC.lockedAccount.0">
         <source>A Contao account has been locked</source>
-        <target>Kontao Contao zostało zablokowane</target>
+        <target>Konto Contao zostało zablokowane</target>
       </trans-unit>
       <trans-unit id="MSC.lockedAccount.1">
         <source>The following Contao account has been locked for security reasons.
@@ -1370,7 +1370,7 @@ Użytkownik: %s
 Prawdziwe imię: %s
 Strona WWW: %s
 
-Konto zostało zablokowane na okres %d minut, pownieważ użytkownik wprowadził nieprawidłowe hasło trzy razy pod rząd. Po tym czasie, konto zostanie odblokowane automatycznie.
+Konto zostało zablokowane na okres %d minut, pownieważ użytkownik wprowadził nieprawidłowe hasło trzy razy pod rząd. Po tym czasie konto zostanie odblokowane automatycznie.
 
 Ten e-mail został wygenerowane przez Contao. Nie odpowiadaj na niego.
 </target>
@@ -1421,7 +1421,7 @@ Ten e-mail został wygenerowane przez Contao. Nie odpowiadaj na niego.
       </trans-unit>
       <trans-unit id="MSC.backToTopTitle">
         <source>Go to the top of the page</source>
-        <target>Idź do góry</target>
+        <target>Idź do góry strony</target>
       </trans-unit>
       <trans-unit id="MSC.home">
         <source>Home</source>
@@ -1497,7 +1497,7 @@ Ten e-mail został wygenerowane przez Contao. Nie odpowiadaj na niego.
       </trans-unit>
       <trans-unit id="MSC.showRecord">
         <source>Show the details of record %s</source>
-        <target>Pokaż szczegóły of record %s</target>
+        <target>Pokaż szczegóły rekordu %s</target>
       </trans-unit>
       <trans-unit id="MSC.editRecord">
         <source>Edit record %s</source>
@@ -1533,7 +1533,7 @@ Ten e-mail został wygenerowane przez Contao. Nie odpowiadaj na niego.
       </trans-unit>
       <trans-unit id="MSC.save">
         <source>Save</source>
-        <target>Zapisz</target>
+        <target>Zachowaj</target>
       </trans-unit>
       <trans-unit id="MSC.saveNclose">
         <source>Save and close</source>
@@ -1553,7 +1553,7 @@ Ten e-mail został wygenerowane przez Contao. Nie odpowiadaj na niego.
       </trans-unit>
       <trans-unit id="MSC.saveNduplicate">
         <source>Save and duplicate</source>
-        <target>Zapisz i duplikuj</target>
+        <target>Zachowaj i duplikuj</target>
       </trans-unit>
       <trans-unit id="MSC.continue">
         <source>Continue</source>
@@ -1565,7 +1565,7 @@ Ten e-mail został wygenerowane przez Contao. Nie odpowiadaj na niego.
       </trans-unit>
       <trans-unit id="MSC.skipNavigation">
         <source>Skip navigation</source>
-        <target>Pomiń nawigacje</target>
+        <target>Pomiń nawigację</target>
       </trans-unit>
       <trans-unit id="MSC.selectAll">
         <source>Select all</source>
@@ -1865,7 +1865,7 @@ Ten e-mail został wygenerowane przez Contao. Nie odpowiadaj na niego.
       </trans-unit>
       <trans-unit id="MSC.applyTitle">
         <source>Apply the changes</source>
-        <target>Zachowaj zmiany</target>
+        <target>Zastosuj zmiany</target>
       </trans-unit>
       <trans-unit id="MSC.reset">
         <source>Reset</source>
@@ -1909,7 +1909,7 @@ Ten e-mail został wygenerowane przez Contao. Nie odpowiadaj na niego.
       </trans-unit>
       <trans-unit id="MSC.updateReplace">
         <source>Replace the existing entries</source>
-        <target>Zastąp istniejący wpis</target>
+        <target>Zastąp istniejące wpisy</target>
       </trans-unit>
       <trans-unit id="MSC.ascending">
         <source>ascending</source>
@@ -1973,7 +1973,7 @@ Ten e-mail został wygenerowane przez Contao. Nie odpowiadaj na niego.
       </trans-unit>
       <trans-unit id="MSC.adminText">
         <source>A new member (ID %s) has registered at your website.%sIf you did not allow e-mail activation, you have to enable the account manually in the back end.</source>
-        <target>Nowy użytkownik (ID %s) zarejestrował się na twojej stronie internetowej. %s Jeżeli nie używasz automatycznego aktywowania nowych uzytkownikow przez email, musisz uaktywnić konto ręcznie w panelu.</target>
+        <target>Nowy użytkownik (ID %s) zarejestrował się na twojej stronie internetowej.%sJeżeli nie używasz automatycznego aktywowania nowych uzytkownikow przez email, musisz uaktywnić konto ręcznie w panelu.</target>
       </trans-unit>
       <trans-unit id="MSC.requestPassword">
         <source>Request password</source>
@@ -1989,7 +1989,7 @@ Ten e-mail został wygenerowane przez Contao. Nie odpowiadaj na niego.
       </trans-unit>
       <trans-unit id="MSC.passwordSubject">
         <source>Your password request for %s</source>
-        <target>Twoje zapytanie o haslo dla %s</target>
+        <target>Twoje zapytanie o hasło dla %s</target>
       </trans-unit>
       <trans-unit id="MSC.accountNotFound">
         <source>No matching account found</source>
@@ -2073,7 +2073,7 @@ Ten e-mail został wygenerowane przez Contao. Nie odpowiadaj na niego.
       </trans-unit>
       <trans-unit id="MSC.selectNewPosition">
         <source>Next, please choose the (new) position of the element</source>
-        <target>Następnie, wybierz (nową) pozycję elementu</target>
+        <target>Następnie wybierz (nową) pozycję elementu</target>
       </trans-unit>
       <trans-unit id="MSC.go">
         <source>Go</source>
@@ -2293,7 +2293,7 @@ Ten e-mail został wygenerowane przez Contao. Nie odpowiadaj na niego.
       </trans-unit>
       <trans-unit id="MSC.versionConflict1">
         <source>Another user has created version %s while you were editing version %s of this record.</source>
-        <target>Inny użytkownik utworzył wersję %s podczas gdy ty edytowałeś wersję %s tego rekordu.</target>
+        <target>Inny użytkownik utworzył wersję %s, podczas gdy ty edytowałeś wersję %s tego rekordu.</target>
       </trans-unit>
       <trans-unit id="MSC.versionConflict2">
         <source>Your changes have been now been saved as version %s and have potentially overwritten the changes of version %s, therefore please compare the versions below:</source>
@@ -2309,7 +2309,7 @@ Ten e-mail został wygenerowane przez Contao. Nie odpowiadaj na niego.
       </trans-unit>
       <trans-unit id="MSC.location">
         <source>Location</source>
-        <target>Lokacja</target>
+        <target>Lokalizacja</target>
       </trans-unit>
       <trans-unit id="MSC.download">
         <source>Download %s</source>
@@ -2321,7 +2321,7 @@ Ten e-mail został wygenerowane przez Contao. Nie odpowiadaj na niego.
       </trans-unit>
       <trans-unit id="UNITS.0">
         <source>Byte</source>
-        <target>Bitów</target>
+        <target>Bajtów</target>
       </trans-unit>
       <trans-unit id="UNITS.1">
         <source>KiB</source>

--- a/core-bundle/src/Resources/contao/languages/pl/exception.xlf
+++ b/core-bundle/src/Resources/contao/languages/pl/exception.xlf
@@ -19,7 +19,7 @@
       </trans-unit>
       <trans-unit id="XPT.hint">
         <source>To customize this notice, create a custom Twig template overriding &lt;em&gt;%s&lt;/em&gt;.</source>
-        <target>Aby zmienić to powiadomienie, utwórz własną templatkę Twig nadpisującą &lt;em&gt;%s&lt;/em&gt;.</target>
+        <target>Aby zmienić to powiadomienie, utwórz własny szablon Twig nadpisujący &lt;em&gt;%s&lt;/em&gt;.</target>
       </trans-unit>
       <trans-unit id="XPT.errorOccurred">
         <source>An error occurred while executing this script. Something does not work properly.</source>
@@ -35,11 +35,11 @@
       </trans-unit>
       <trans-unit id="XPT.requestToken">
         <source>Invalid request token</source>
-        <target>Nieprawidłowy request token</target>
+        <target>Nieprawidłowy token żądania</target>
       </trans-unit>
       <trans-unit id="XPT.invalidToken">
         <source>The request token could not be verified.</source>
-        <target>Request token nie został zweryfikowany.</target>
+        <target>Token żadania nie został zweryfikowany.</target>
       </trans-unit>
       <trans-unit id="XPT.tokenRetry">
         <source>Please &lt;a href=&quot;javascript:window.location.href=window.location.href&quot;&gt;click this link&lt;/a&gt; and try again. Do not use the back button of your browser.</source>
@@ -99,7 +99,7 @@
       </trans-unit>
       <trans-unit id="XPT.noLayoutSpecified">
         <source>The page you have requested has not yet been associated with a page layout.</source>
-        <target>Strona, którą chcesz wyświetlić nie ma przypisanego układu strony.</target>
+        <target>Strona, którą chcesz wyświetlić, nie ma przypisanego układu strony.</target>
       </trans-unit>
       <trans-unit id="XPT.noLayoutFix">
         <source>Make sure that you have assigned a page layout to each website root page in the site structure.</source>
@@ -119,7 +119,7 @@
       </trans-unit>
       <trans-unit id="XPT.noActiveFix">
         <source>Most likely, the website is still under development and will be online in a few days. If you still think that there is something wrong, &lt;a href=&quot;%s&quot;&gt;contact the webmaster&lt;/a&gt; and let him know.</source>
-        <target>Prawdopodobnie strona jest ciągle w fazie produkcji i będzie online za kilka dni. Jeśli myślisz, że jest coś nie tak, &lt;a href=&quot;%s&quot;&gt;skontaktuj się z administratorem&lt;/a&gt; i powiadom go o problemie.</target>
+        <target>Prawdopodobnie strona jest ciągle w fazie rozwoju i będzie online za kilka dni. Jeśli myślisz, że jest coś nie tak, &lt;a href=&quot;%s&quot;&gt;skontaktuj się z administratorem&lt;/a&gt; i powiadom go o problemie.</target>
       </trans-unit>
       <trans-unit id="XPT.unavailable">
         <source>Service unavailable</source>
@@ -143,7 +143,7 @@
       </trans-unit>
       <trans-unit id="XPT.insecureExplain">
         <source>Contao 4 no longer relies on &lt;code&gt;.htaccess&lt;/code&gt; files to protect folders and instead uses a public subfolder as document root. Anything above the document root must not be accessible via HTTP, otherwise anyone could download non-public resources including sensitive data such as configuration files.</source>
-        <target>Contao 4 nie polega już na plikach &lt;code&gt;.htaccess&lt;/code&gt; w celu ochrony plików, a zamiast tego używa publicznego podkatalogu jako document root. Wszystko powyżej document root nie może być dostępne przez HTTP. W przeciwnym wypadku każdy mógłby pobrać niepubliczne pliki zawierające wrażliwe dane, takie jak pliki konfiguracji.</target>
+        <target>Contao 4 nie polega już na plikach &lt;code&gt;.htaccess&lt;/code&gt; w celu ochrony katalogów, a zamiast tego używa publicznego podkatalogu jako document root. Wszystko powyżej document root nie może być dostępne przez HTTP. W przeciwnym wypadku każdy mógłby pobrać niepubliczne pliki zawierające wrażliwe dane, takie jak pliki konfiguracji.</target>
       </trans-unit>
     </body>
   </file>

--- a/core-bundle/src/Resources/contao/languages/pl/exception.xlf
+++ b/core-bundle/src/Resources/contao/languages/pl/exception.xlf
@@ -39,7 +39,7 @@
       </trans-unit>
       <trans-unit id="XPT.invalidToken">
         <source>The request token could not be verified.</source>
-        <target>Token żadania nie został zweryfikowany.</target>
+        <target>Token żądania nie został zweryfikowany.</target>
       </trans-unit>
       <trans-unit id="XPT.tokenRetry">
         <source>Please &lt;a href=&quot;javascript:window.location.href=window.location.href&quot;&gt;click this link&lt;/a&gt; and try again. Do not use the back button of your browser.</source>
@@ -47,7 +47,7 @@
       </trans-unit>
       <trans-unit id="XPT.tokenExplainOne">
         <source>This error occurs if there is a POST request without a valid authentication token. In Contao 2.10, the referer check has been replaced with a request token system. If the problem persists, you may be using an incompatible third-party extension or have not correctly updated your Contao installation.</source>
-        <target>Ten problem pojawia się, gdy występuje zapytanie POST bez prawidłowego tokena autoryzyjącego. W Contao 2.10, sprawdzanie referer został zastąpione przez system request token. Jeśli ten problem się utrzymuje, być może używasz niekompatyblinych rozszerzeń trzecich lub nieprawidłowo aktualizowałeś Contao.</target>
+        <target>Ten problem pojawia się, gdy występuje zapytanie POST bez prawidłowego tokena autoryzyjącego. W Contao 2.10, sprawdzanie referer został zastąpione przez system token żądania. Jeśli ten problem się utrzymuje, być może używasz niekompatyblinych rozszerzeń trzecich lub nieprawidłowo aktualizowałeś Contao.</target>
       </trans-unit>
       <trans-unit id="XPT.tokenExplainTwo">
         <source>For more information, search the &lt;a href=&quot;https://contao.org/en/frequently-asked.html&quot; target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot;&gt;Contao FAQs&lt;/a&gt; or visit the &lt;a href=&quot;https://contao.org/en/support.html&quot; target=&quot;_blank&quot; rel=&quot;noreferrer noopener&quot;&gt;Contao support page&lt;/a&gt;.</source>

--- a/core-bundle/src/Resources/contao/languages/pl/explain.xlf
+++ b/core-bundle/src/Resources/contao/languages/pl/explain.xlf
@@ -31,7 +31,7 @@
       </trans-unit>
       <trans-unit id="XPL.dateFormat.0.1">
         <source>Contao supports all date and time formats that can be parsed with the PHP date() function. However, to ensure that any input can be transformed into a UNIX timestamp, you can only use numeric date and time formats (j, d, m, n, y, Y, g, G, h, H, i, s) in the back end.&lt;br&gt;&lt;br&gt;&lt;strong&gt;You can enter variant front end formats in the site structure (website root pages).&lt;/strong&gt;&lt;br&gt;&lt;br&gt;&lt;em&gt;Here are some examples of valid date and time formats&lt;/em&gt;:</source>
-        <target>Contao wspiera kilka różnych formatów daty i czasu, których podstawą jest funkcja PHP date(). Jednakże, by być pewnym, że wszelkie dane wprowadzane przez użytkownika da się przekonwertować na UNIXowy znacznik czasu (timestamp), można używać jedynie numerycznych formatów daty i czasu (j, d, m, n, y, Y, g, G, h, H, i, s) z dodatkowymi pojedynczymi znakami rozdzielające jednostki daty lub czasu, odpowiednie dla danej specyfikacji formatu.&lt;br /&gt;&lt;br /&gt;&lt;em&gt;Oto kilka przykładów, poprawnego stosowania formatów daty i czasu&lt;/em&gt;:</target>
+        <target>Contao wspiera kilka różnych formatów daty i czasu, których podstawą jest funkcja PHP date(). Jednakże, aby być pewnym, że wszelkie dane wprowadzane przez użytkownika da się przekonwertować na UNIXowy znacznik czasu (timestamp), można używać jedynie numerycznych formatów daty i czasu (j, d, m, n, y, Y, g, G, h, H, i, s) z dodatkowymi pojedynczymi znakami rozdzielające jednostki daty lub czasu, odpowiednie dla danej specyfikacji formatu.&lt;br /&gt;&lt;br /&gt;&lt;em&gt;Oto kilka przykładów, poprawnego stosowania formatów daty i czasu&lt;/em&gt;:</target>
       </trans-unit>
       <trans-unit id="XPL.dateFormat.1.0">
         <source>Y-m-d</source>
@@ -39,7 +39,7 @@
       </trans-unit>
       <trans-unit id="XPL.dateFormat.1.1">
         <source>YYYY-MM-DD, international ISO-8601, e.g. 2005-01-28</source>
-        <target>YYYY-MM-DD, format międzynarodowy ISO 8601 np. 2005-01-28</target>
+        <target>YYYY-MM-DD, format międzynarodowy ISO 8601, np. 2005-01-28</target>
       </trans-unit>
       <trans-unit id="XPL.dateFormat.2.0">
         <source>m/d/Y</source>
@@ -63,7 +63,7 @@
       </trans-unit>
       <trans-unit id="XPL.dateFormat.4.1">
         <source>YY-M-D, without leading zeros, e.g. 05-1-28</source>
-        <target>YY-M-D, czyli rok, miesiąc (bez zera na początku w przypadku miesięcy od 1 do 9), dzień np. 05-1-28</target>
+        <target>YY-M-D, czyli rok, miesiąc (bez zera na początku w przypadku miesięcy od 1 do 9), dzień, np. 05-1-28</target>
       </trans-unit>
       <trans-unit id="XPL.dateFormat.5.0">
         <source>Ymd</source>
@@ -71,7 +71,7 @@
       </trans-unit>
       <trans-unit id="XPL.dateFormat.5.1">
         <source>YYYYMMDD, timestamp, e.g. 20050128</source>
-        <target>YYYYMMDD, tzw. znacznik czasu (timestamp) np. 20050128</target>
+        <target>YYYYMMDD, tzw. znacznik czasu (timestamp), np. 20050128</target>
       </trans-unit>
       <trans-unit id="XPL.dateFormat.6.0">
         <source>H:i:s</source>
@@ -79,7 +79,7 @@
       </trans-unit>
       <trans-unit id="XPL.dateFormat.6.1">
         <source>24 hours, minutes and seconds, e.g. 20:36:59</source>
-        <target>24 godziny, minuty i sekundy np. 20:36:59</target>
+        <target>24 godziny, minuty i sekundy, np. 20:36:59</target>
       </trans-unit>
       <trans-unit id="XPL.dateFormat.7.0">
         <source>g:i</source>
@@ -87,7 +87,7 @@
       </trans-unit>
       <trans-unit id="XPL.dateFormat.7.1">
         <source>12 hours without leading zeros and minutes, e.g. 8:36</source>
-        <target>12 godziny (bez zera na początku w przypadku godzin od 0 do 1) oraz minuty np. 8:36</target>
+        <target>12 godziny (bez zera na początku w przypadku godzin od 0 do 1) oraz minuty, np. 8:36</target>
       </trans-unit>
       <trans-unit id="XPL.imageSizeDensities.0.0">
         <source>Sizes attribute</source>

--- a/core-bundle/src/Resources/contao/languages/pl/modules.xlf
+++ b/core-bundle/src/Resources/contao/languages/pl/modules.xlf
@@ -19,7 +19,7 @@
       </trans-unit>
       <trans-unit id="MOD.form.1">
         <source>Create custom forms and store or send the submitted data</source>
-        <target>Ten moduł pozwala ci na stworzenie każdego rodzaju formularz.</target>
+        <target>Ten moduł pozwala ci na stworzenie każdego rodzaju formularzy.</target>
       </trans-unit>
       <trans-unit id="MOD.design">
         <source>Layout</source>
@@ -27,7 +27,7 @@
       </trans-unit>
       <trans-unit id="MOD.themes.0">
         <source>Themes</source>
-        <target>Themes</target>
+        <target>Motywy</target>
       </trans-unit>
       <trans-unit id="MOD.themes.1">
         <source>Manage front end modules, style sheets, page layouts and templates</source>
@@ -59,7 +59,7 @@
       </trans-unit>
       <trans-unit id="MOD.member.1">
         <source>Manage member accounts (front end users)</source>
-        <target>Użytkownicy są zarejestrowanymi odwiedzającymi twojej strony (np. klienci sklepu online, odbiorcy newslettera lub członkowie strefy chronionej hasłem). Ten moduł pozwala na zarządzanie użytkownikami.</target>
+        <target>Użytkownicy są zarejestrowanymi odwiedzającymi twoją stronę (np. klienci sklepu online, odbiorcy newslettera lub członkowie strefy chronionej hasłem). Ten moduł pozwala na zarządzanie użytkownikami.</target>
       </trans-unit>
       <trans-unit id="MOD.mgroup.0">
         <source>Member groups</source>
@@ -75,7 +75,7 @@
       </trans-unit>
       <trans-unit id="MOD.user.1">
         <source>Manage user accounts (back end users)</source>
-        <target>Ten moduł pozwala ci na ustawienie nowych redaktorów i zarządzać ich kontami.</target>
+        <target>Ten moduł pozwala ci na ustawienie nowych redaktorów i zarządzanie ich kontami.</target>
       </trans-unit>
       <trans-unit id="MOD.group.0">
         <source>User groups</source>
@@ -111,7 +111,7 @@
       </trans-unit>
       <trans-unit id="MOD.settings.1">
         <source>Check and optimize the Contao configuration</source>
-        <target>Ten moduł pozwala ci na zmodyfikowanie lokalnej instalacji i do zmiany podstawowych parametrów takich jak format daty czy czcionkę.</target>
+        <target>Ten moduł pozwala ci na zmodyfikowanie lokalnej instalacji i zmianę podstawowych parametrów, takich jak format daty czy czcionka.</target>
       </trans-unit>
       <trans-unit id="MOD.maintenance.0">
         <source>Maintenance</source>
@@ -119,7 +119,7 @@
       </trans-unit>
       <trans-unit id="MOD.maintenance.1">
         <source>Maintain or update Contao</source>
-        <target>Ten moduł pozwala ci zachować aktualną instalację Contao.</target>
+        <target>Ten moduł pozwala ci utrzymać aktualną instalację Contao.</target>
       </trans-unit>
       <trans-unit id="MOD.undo.0">
         <source>Restore</source>
@@ -127,7 +127,7 @@
       </trans-unit>
       <trans-unit id="MOD.undo.1">
         <source>Restore deleted records</source>
-        <target>Jeśli przez przypadek usunąłeś jakiś rekord w bazie danych ten moduł pozwoli ci go przywrócić. Nie dotyczy plików ani katalogów.</target>
+        <target>Jeśli przez przypadek usunąłeś jakiś rekord w bazie danych, ten moduł pozwoli ci go przywrócić. Nie dotyczy plików ani katalogów.</target>
       </trans-unit>
       <trans-unit id="MOD.login.0">
         <source>User profile</source>
@@ -135,7 +135,7 @@
       </trans-unit>
       <trans-unit id="MOD.login.1">
         <source>Change your personal data or set a new password</source>
-        <target>Ten moduł pozwala ci na zmienienie danych osobistych takich jak imię, e-mail czy hasło.</target>
+        <target>Ten moduł pozwala ci na zmienianie danych osobistych, takich jak imię, e-mail czy hasło.</target>
       </trans-unit>
       <trans-unit id="MOD.tl_content">
         <source>Content elements</source>
@@ -167,11 +167,11 @@
       </trans-unit>
       <trans-unit id="MOD.tl_style_sheet">
         <source>Style sheets</source>
-        <target>Arkusze styli</target>
+        <target>Arkusze stylów</target>
       </trans-unit>
       <trans-unit id="MOD.css">
         <source>Style sheets</source>
-        <target>Arkusze styli</target>
+        <target>Arkusze stylów</target>
       </trans-unit>
       <trans-unit id="MOD.modules">
         <source>Front end modules</source>
@@ -219,7 +219,7 @@
       </trans-unit>
       <trans-unit id="FMD.breadcrumb.1">
         <source>Generates a breadcrumb navigation menu</source>
-        <target>Ten moduł generuje ścieżkę nawigacji, czyli miejsce gdzie aktualnie użytkownik znajduje się w serwisie (np. jeśli znajdujesz się na stronie o akademikach, ścieżka nawigacji będzie wyglądać mniej więcej tak: Strona główna -&gt; Studenci -&gt; Akademiki).</target>
+        <target>Ten moduł generuje ścieżkę nawigacji, czyli miejsce, gdzie aktualnie użytkownik znajduje się w serwisie (np. jeśli znajdujesz się na stronie o akademikach, ścieżka nawigacji będzie wyglądać mniej więcej tak: Strona główna -&gt; Studenci -&gt; Akademiki).</target>
       </trans-unit>
       <trans-unit id="FMD.quicknav.0">
         <source>Quick navigation</source>
@@ -227,7 +227,7 @@
       </trans-unit>
       <trans-unit id="FMD.quicknav.1">
         <source>Generates a drop-down menu from the site structure</source>
-        <target>Ten moduł generuje rozwijane menu z z linkami do wszystkich stron, które pozwolą ci przejść do konkretnej strony.</target>
+        <target>Ten moduł generuje rozwijane menu z linkami do wszystkich stron, które pozwolą ci przejść do konkretnej strony.</target>
       </trans-unit>
       <trans-unit id="FMD.quicklink.0">
         <source>Quick link</source>
@@ -259,7 +259,7 @@
       </trans-unit>
       <trans-unit id="FMD.sitemap.1">
         <source>Generates a list of all pages in the site structure</source>
-        <target>Spis wszystkich stron jakie znajdują się w twoim serwisie.</target>
+        <target>Spis wszystkich stron, jakie znajdują się w twoim serwisie.</target>
       </trans-unit>
       <trans-unit id="FMD.user">
         <source>User</source>
@@ -271,7 +271,7 @@
       </trans-unit>
       <trans-unit id="FMD.login.1">
         <source>Generates a login form</source>
-        <target>Ten moduł osadza na stronie formularz, poprzez który użytkownik może się zalogować. Podczas gdy użytkownik jest zalogowany posiada dostęp do stron chronionych hasłem (jeśli oczywiście posiada nadane odpowiednie uprawnienia).</target>
+        <target>Ten moduł osadza na stronie formularz, poprzez który użytkownik może się zalogować. Podczas gdy użytkownik jest zalogowany, posiada dostęp do stron chronionych hasłem (jeśli oczywiście posiada nadane odpowiednie uprawnienia).</target>
       </trans-unit>
       <trans-unit id="FMD.logout.0">
         <source>Automatic logout</source>
@@ -303,7 +303,7 @@
       </trans-unit>
       <trans-unit id="FMD.changePassword.1">
         <source>Generates a form to change the password</source>
-        <target>Generuje formularz to zmiany hasła</target>
+        <target>Generuje formularz do zmiany hasła</target>
       </trans-unit>
       <trans-unit id="FMD.lostPassword.0">
         <source>Lost password</source>
@@ -311,7 +311,7 @@
       </trans-unit>
       <trans-unit id="FMD.lostPassword.1">
         <source>Generates a form to request a new password</source>
-        <target>Ten moduł tworzy formularz który pozwala użytkownikom zmieniać swoje hasła.</target>
+        <target>Ten moduł tworzy formularz, który pozwala użytkownikom zmieniać swoje hasła.</target>
       </trans-unit>
       <trans-unit id="FMD.closeAccount.0">
         <source>Close account</source>

--- a/core-bundle/src/Resources/contao/languages/pl/tl_article.xlf
+++ b/core-bundle/src/Resources/contao/languages/pl/tl_article.xlf
@@ -19,7 +19,7 @@
       </trans-unit>
       <trans-unit id="tl_article.author.0">
         <source>Author</source>
-        <target>Imię</target>
+        <target>Autor</target>
       </trans-unit>
       <trans-unit id="tl_article.author.1">
         <source>Here you can change the author of the article.</source>
@@ -47,7 +47,7 @@
       </trans-unit>
       <trans-unit id="tl_article.teaserCssID.1">
         <source>Here you can set an ID and one or more classes for the teaser element.</source>
-        <target>Jeśli potrzebujesz osobnej definicji do formatowania tej zajawki w stylach CSS, możesz tu wprowadzić ID. To ID będzie przypisane do tej zajawki i można je modyfikować w arkuszu CSS.</target>
+        <target>Jeśli potrzebujesz osobnej definicji do formatowania tej zajawki w stylach CSS, możesz tu wprowadzić ID. To ID będzie przypisane do tej zajawki i można je opisywać w arkuszu CSS.</target>
       </trans-unit>
       <trans-unit id="tl_article.showTeaser.0">
         <source>Show teaser</source>
@@ -55,7 +55,7 @@
       </trans-unit>
       <trans-unit id="tl_article.showTeaser.1">
         <source>Show the article teaser if there are multiple articles.</source>
-        <target>Pokaż zajawkę zamiast artykułu jeśli jest tam więcej niż jeden artykuł.</target>
+        <target>Pokaż zajawkę zamiast artykułu, jeśli jest tam więcej niż jeden artykuł.</target>
       </trans-unit>
       <trans-unit id="tl_article.teaser.0">
         <source>Article teaser</source>
@@ -99,7 +99,7 @@
       </trans-unit>
       <trans-unit id="tl_article.groups.0">
         <source>Allowed member groups</source>
-        <target>Zezwolone grupy użytkowników</target>
+        <target>Dozwolone grupy użytkowników</target>
       </trans-unit>
       <trans-unit id="tl_article.groups.1">
         <source>These groups will be able to see the article.</source>
@@ -111,7 +111,7 @@
       </trans-unit>
       <trans-unit id="tl_article.cssID.1">
         <source>Here you can set an ID and one or more classes.</source>
-        <target>Jeśli potrzebujesz osobnej definicji do formatowania tego modułu w stylach CSS, możesz tu wprowadzić ID. To ID będzie przypisane do tego modułu i można je modyfikować w arkuszu CSS.</target>
+        <target>Jeśli potrzebujesz osobnej definicji do formatowania tego modułu w stylach CSS, możesz tu wprowadzić ID. To ID będzie przypisane do tego modułu i można je opisywać w arkuszu CSS.</target>
       </trans-unit>
       <trans-unit id="tl_article.published.0">
         <source>Publish article</source>
@@ -119,23 +119,23 @@
       </trans-unit>
       <trans-unit id="tl_article.published.1">
         <source>Make the article publicly visible on the website.</source>
-        <target>Dopóki nie zaznaczysz tej opcji artykuł nie będzie widoczny dla odwiedzających twoją stronę.</target>
+        <target>Dopóki nie zaznaczysz tej opcji, artykuł nie będzie widoczny dla odwiedzających twoją stronę.</target>
       </trans-unit>
       <trans-unit id="tl_article.start.0">
         <source>Show from</source>
-        <target>Wrapper start</target>
+        <target>Pokazuj od</target>
       </trans-unit>
       <trans-unit id="tl_article.start.1">
         <source>Do not show the article on the website before this day.</source>
-        <target>Jeśli wprowadzisz tu datę to artykuł nie będzie widoczny na twojej stronie przed tą datą.</target>
+        <target>Jeśli wprowadzisz tu datę, to artykuł nie będzie widoczny na twojej stronie przed tą datą.</target>
       </trans-unit>
       <trans-unit id="tl_article.stop.0">
         <source>Show until</source>
-        <target>Wrapper stop</target>
+        <target>Pokazuj do</target>
       </trans-unit>
       <trans-unit id="tl_article.stop.1">
         <source>Do not show the article on the website on and after this day.</source>
-        <target>Jeśli wprowadzisz tu datę to artykuł przestanie być widoczny na twojej stronie po tej dacie.</target>
+        <target>Jeśli wprowadzisz tu datę, to artykuł przestanie być widoczny na twojej stronie po tej dacie.</target>
       </trans-unit>
       <trans-unit id="tl_article.tstamp.0">
         <source>Revision date</source>
@@ -175,7 +175,7 @@
       </trans-unit>
       <trans-unit id="tl_article.publish_legend">
         <source>Publish settings</source>
-        <target>Ustawinia publikacji</target>
+        <target>Ustawienia publikacji</target>
       </trans-unit>
       <trans-unit id="tl_article.print">
         <source>Print the page</source>
@@ -263,7 +263,7 @@
       </trans-unit>
       <trans-unit id="tl_article.pasteafter.0">
         <source>Paste after</source>
-        <target>Wklej z</target>
+        <target>Wklej za</target>
       </trans-unit>
       <trans-unit id="tl_article.pasteafter.1">
         <source>Paste after article ID %s</source>

--- a/core-bundle/src/Resources/contao/languages/pl/tl_article.xlf
+++ b/core-bundle/src/Resources/contao/languages/pl/tl_article.xlf
@@ -47,7 +47,7 @@
       </trans-unit>
       <trans-unit id="tl_article.teaserCssID.1">
         <source>Here you can set an ID and one or more classes for the teaser element.</source>
-        <target>Jeśli potrzebujesz osobnej definicji do formatowania tej zajawki w stylach CSS, możesz tu wprowadzić ID. To ID będzie przypisane do tej zajawki i można je opisywać w arkuszu CSS.</target>
+        <target>Jeśli potrzebujesz osobnej definicji do formatowania tej zajawki w stylach CSS, możesz tu wprowadzić ID. To ID będzie przypisane do tej zajawki i można je używać w arkuszu CSS.</target>
       </trans-unit>
       <trans-unit id="tl_article.showTeaser.0">
         <source>Show teaser</source>
@@ -111,7 +111,7 @@
       </trans-unit>
       <trans-unit id="tl_article.cssID.1">
         <source>Here you can set an ID and one or more classes.</source>
-        <target>Jeśli potrzebujesz osobnej definicji do formatowania tego modułu w stylach CSS, możesz tu wprowadzić ID. To ID będzie przypisane do tego modułu i można je opisywać w arkuszu CSS.</target>
+        <target>Jeśli potrzebujesz osobnej definicji do formatowania tego modułu w stylach CSS, możesz tu wprowadzić ID. To ID będzie przypisane do tego modułu i można je używać w arkuszu CSS.</target>
       </trans-unit>
       <trans-unit id="tl_article.published.0">
         <source>Publish article</source>

--- a/core-bundle/src/Resources/contao/languages/pl/tl_content.xlf
+++ b/core-bundle/src/Resources/contao/languages/pl/tl_content.xlf
@@ -35,7 +35,7 @@
       </trans-unit>
       <trans-unit id="tl_content.overwriteMeta.0">
         <source>Overwrite meta data</source>
-        <target>Napisz meta dane</target>
+        <target>Nadpisz meta dane</target>
       </trans-unit>
       <trans-unit id="tl_content.overwriteMeta.1">
         <source>Overwrite the image meta data from the file manager.</source>
@@ -103,7 +103,7 @@
       </trans-unit>
       <trans-unit id="tl_content.floating.1">
         <source>Please specify how to align the image.</source>
-        <target>Wybierz wyrównanie obrazka. Obrazek może być wyświetlany nad lub pod tekstem lub po lewej lub prawej stronie tekstu.</target>
+        <target>Wybierz wyrównanie obrazka. Obrazek może być wyświetlany nad lub pod tekstem, lub po lewej, lub prawej stronie tekstu.</target>
       </trans-unit>
       <trans-unit id="tl_content.caption.0">
         <source>Image caption</source>
@@ -119,7 +119,7 @@
       </trans-unit>
       <trans-unit id="tl_content.html.1">
         <source>You can modify the list of allowed HTML tags in the back end settings.</source>
-        <target>Wprowadź twój kod HTML.</target>
+        <target>Wprowadź twój kod HTML. Możesz modyfikować listę dozwolonych tagów HTML w Ustawieniach.</target>
       </trans-unit>
       <trans-unit id="tl_content.listtype.0">
         <source>List type</source>
@@ -135,7 +135,7 @@
       </trans-unit>
       <trans-unit id="tl_content.listitems.1">
         <source>If JavaScript is disabled, make sure to save your changes before modifying the order.</source>
-        <target>Przyporządkuj moduł do elementu strony. Używaj przycisków po prawej stronie by dodać, przesunąć (w górę albo w dół) lub skasować moduł. Jeśli pracujesz z przeglądarką, która ma wyłączoną obsługę Javascript, powinieneś zapisać swoje zmiany przed zmianą kolejności modułów!</target>
+        <target>Przyporządkuj moduł do elementu strony. Używaj przycisków po prawej stronie, aby dodać, przesunąć (w górę albo w dół) lub skasować moduł. Jeśli pracujesz z przeglądarką, która ma wyłączoną obsługę Javascript, powinieneś zapisać swoje zmiany przed zmianą kolejności modułów!</target>
       </trans-unit>
       <trans-unit id="tl_content.tableitems.0">
         <source>Table items</source>
@@ -143,7 +143,7 @@
       </trans-unit>
       <trans-unit id="tl_content.tableitems.1">
         <source>If JavaScript is disabled, make sure to save your changes before modifying the order.</source>
-        <target>Przyporządkuj moduł do elementu strony. Używaj przycisków po prawej stronie by dodać, przesunąć (w górę albo w dół) lub skasować moduł. Jeśli pracujesz z przeglądarką, która ma wyłączoną obsługę Javascript, powinieneś zapisać swoje zmiany przed zmianą kolejności modułów!</target>
+        <target>Przyporządkuj moduł do elementu strony. Używaj przycisków po prawej stronie, aby dodać, przesunąć (w górę albo w dół) lub skasować moduł. Jeśli pracujesz z przeglądarką, która ma wyłączoną obsługę Javascript, powinieneś zapisać swoje zmiany przed zmianą kolejności modułów!</target>
       </trans-unit>
       <trans-unit id="tl_content.summary.0">
         <source>Table summary</source>
@@ -151,7 +151,7 @@
       </trans-unit>
       <trans-unit id="tl_content.summary.1">
         <source>Please enter a short summary of the table and describe its purpose or structure.</source>
-        <target>By uczynić tabelę bardziej dostępną, powinieneś zawsze wprowadzić krótkie podsumowanie jej zawartości.</target>
+        <target>Aby uczynić tabelę bardziej dostępną, powinieneś zawsze wprowadzić krótkie podsumowanie jej zawartości.</target>
       </trans-unit>
       <trans-unit id="tl_content.thead.0">
         <source>Add table header</source>
@@ -247,7 +247,7 @@
       </trans-unit>
       <trans-unit id="tl_content.mooStyle.1">
         <source>Here you can format the section headline using CSS code.</source>
-        <target>Możesz tu wprowadzić opcjonalną składnie CSS do formatowanie nagłówka.</target>
+        <target>Możesz tu wprowadzić opcjonalną składnię CSS do formatowania nagłówka.</target>
       </trans-unit>
       <trans-unit id="tl_content.mooClasses.0">
         <source>Element classes</source>
@@ -279,7 +279,7 @@
       </trans-unit>
       <trans-unit id="tl_content.code.1">
         <source>Note that the code will not be executed. Use F11 to toggle the fullscreen mode if you are using the code editor.</source>
-        <target>Zuważ, że kod nie zostanie wykonany. Użyj F11 by włączyć tryb pełnoekranowy, jeśli używasz edytora kodu.</target>
+        <target>Zauważ, że kod nie zostanie wykonany. Użyj F11, aby włączyć tryb pełnoekranowy, jeśli używasz edytora kodu.</target>
       </trans-unit>
       <trans-unit id="tl_content.linkTitle.0">
         <source>Link text</source>
@@ -367,7 +367,7 @@
       </trans-unit>
       <trans-unit id="tl_content.numberOfItems.1">
         <source>Here you can limit the total number of images. Set to 0 to show all.</source>
-        <target>Tutaj możesz ograniczyć liczbę obrazków. Ustaw 0, by pokazać wszystkie.</target>
+        <target>Tutaj możesz ograniczyć liczbę obrazków. Ustaw 0, aby pokazać wszystkie.</target>
       </trans-unit>
       <trans-unit id="tl_content.sortBy.0">
         <source>Order by</source>
@@ -455,7 +455,7 @@
       </trans-unit>
       <trans-unit id="tl_content.sliderDelay.1">
         <source>The time in milliseconds between slides (1000 = 1s). Set to 0 to disable auto sliding.</source>
-        <target>Czas w milisekundach między slajdami (1000 = 1s). Ustaw 0, by wyłączyć automatyczne przewijanie.</target>
+        <target>Czas w milisekundach między slajdami (1000 = 1s). Ustaw 0, aby wyłączyć automatyczne przewijanie.</target>
       </trans-unit>
       <trans-unit id="tl_content.sliderSpeed.0">
         <source>Transition speed</source>
@@ -467,7 +467,7 @@
       </trans-unit>
       <trans-unit id="tl_content.sliderStartSlide.0">
         <source>Slide offset</source>
-        <target>Offset slajdu</target>
+        <target>Slajd początkowy</target>
       </trans-unit>
       <trans-unit id="tl_content.sliderStartSlide.1">
         <source>Here you can make the slider start with a particular slide (counting starts at 0).</source>
@@ -479,7 +479,7 @@
       </trans-unit>
       <trans-unit id="tl_content.sliderContinuous.1">
         <source>Make the slider continuous (start all over when reaching the end).</source>
-        <target>Zaznacz, jeśli slider ma być ciągły (zaczyna od początku, jeśli dojdzie do końca).</target>
+        <target>Zaznacz, jeśli slider ma być ciągły (zaczynać od początku, gdy dojdzie do końca).</target>
       </trans-unit>
       <trans-unit id="tl_content.cteAlias.0">
         <source>Referenced element</source>
@@ -531,7 +531,7 @@
       </trans-unit>
       <trans-unit id="tl_content.groups.0">
         <source>Allowed member groups</source>
-        <target>Zezwolone grupy użytkowników</target>
+        <target>Dozwolone grupy użytkowników</target>
       </trans-unit>
       <trans-unit id="tl_content.groups.1">
         <source>These groups will be able to see the content element.</source>
@@ -543,7 +543,7 @@
       </trans-unit>
       <trans-unit id="tl_content.guests.1">
         <source>Hide the content element if a member is logged in.</source>
-        <target>Ukryj ten element jeśli użytkownik jest zalogowany.</target>
+        <target>Ukryj ten element, jeśli użytkownik jest zalogowany.</target>
       </trans-unit>
       <trans-unit id="tl_content.cssID.0">
         <source>CSS ID/class</source>
@@ -563,19 +563,19 @@
       </trans-unit>
       <trans-unit id="tl_content.start.0">
         <source>Show from</source>
-        <target>Wrapper start</target>
+        <target>Pokaż od</target>
       </trans-unit>
       <trans-unit id="tl_content.start.1">
         <source>Do not show the element on the website before this day.</source>
-        <target>Ten tryb pozwala wyświetlić w pojedynczym rozwijanym panelu, różne elementy zawartości (tekst, zdjęcia, formularz). Musimy te elementy zawrzeć pomiędzy elementem &lt;em&gt;wrapper start&lt;/em&gt; a elementem &lt;em&gt;wrapper stop&lt;/em&gt;.</target>
+        <target>Jeśli wprowadzisz tu datę, to element nie będzie widoczny na twojej stronie przed tą datą.</target>
       </trans-unit>
       <trans-unit id="tl_content.stop.0">
         <source>Show until</source>
-        <target>Wrapper stop</target>
+        <target>Pokaż do</target>
       </trans-unit>
       <trans-unit id="tl_content.stop.1">
         <source>Do not show the element on the website on and after this day.</source>
-        <target>Zakończenie dla elementu &lt;em&gt;wrapper start&lt;/em&gt;.</target>
+        <target>Jeśli wprowadzisz tu datę, to element przestanie być widoczny na twojej stronie po tej dacie.</target>
       </trans-unit>
       <trans-unit id="tl_content.type_legend">
         <source>Element type</source>
@@ -755,7 +755,7 @@
       </trans-unit>
       <trans-unit id="tl_content.pasteafter.0">
         <source>Paste at the top</source>
-        <target>Wstaw na początku</target>
+        <target>Wklej na początku</target>
       </trans-unit>
       <trans-unit id="tl_content.pasteafter.1">
         <source>Paste after content element ID %s</source>

--- a/core-bundle/src/Resources/contao/languages/pl/tl_content.xlf
+++ b/core-bundle/src/Resources/contao/languages/pl/tl_content.xlf
@@ -551,7 +551,7 @@
       </trans-unit>
       <trans-unit id="tl_content.cssID.1">
         <source>Here you can set an ID and one or more classes.</source>
-        <target>Jeśli potrzebujesz osobnej definicji do formatowania tego modułu w stylach CSS, możesz tu wprowadzić ID. To ID będzie przypisane do tego modułu i można je modyfikować w arkuszu CSS.</target>
+        <target>Jeśli potrzebujesz osobnej definicji do formatowania tego modułu w stylach CSS, możesz tu wprowadzić ID. To ID będzie przypisane do tego modułu i można je używać w arkuszu CSS.</target>
       </trans-unit>
       <trans-unit id="tl_content.invisible.0">
         <source>Invisible</source>

--- a/core-bundle/src/Resources/contao/languages/pl/tl_files.xlf
+++ b/core-bundle/src/Resources/contao/languages/pl/tl_files.xlf
@@ -123,11 +123,11 @@
       </trans-unit>
       <trans-unit id="tl_files.dropzone">
         <source>Click or drop files here to upload</source>
-        <target>Kliknij lub upuść pliki tutaj aby je wysłać</target>
+        <target>Kliknij lub upuść pliki tutaj, aby je wysłać</target>
       </trans-unit>
       <trans-unit id="tl_files.fileLocation">
         <source>File location: %s</source>
-        <target>Lokacja pliku: %s</target>
+        <target>Lokalizacja pliku: %s</target>
       </trans-unit>
       <trans-unit id="tl_files.syncAdded">
         <source>Added the file or folder &quot;%s&quot;</source>
@@ -135,7 +135,7 @@
       </trans-unit>
       <trans-unit id="tl_files.syncChanged">
         <source>Updated the hash of the file or folder &quot;%s&quot;</source>
-        <target>Zaktualizowano hasha pliku lub folderu &quot;%s&quot;</target>
+        <target>Zaktualizowano hash pliku lub folderu &quot;%s&quot;</target>
       </trans-unit>
       <trans-unit id="tl_files.syncUnchanged">
         <source>Found the file or folder &quot;%s&quot;</source>
@@ -175,7 +175,7 @@
       </trans-unit>
       <trans-unit id="tl_files.cut.1">
         <source>Move file or folder &quot;%s&quot;</source>
-        <target>Przenieś ten plik lub katalog</target>
+        <target>Przenieś plik lub katalog &quot;%s&quot;</target>
       </trans-unit>
       <trans-unit id="tl_files.copy.0">
         <source>Duplicate file or folder</source>
@@ -183,7 +183,7 @@
       </trans-unit>
       <trans-unit id="tl_files.copy.1">
         <source>Duplicate file or folder &quot;%s&quot;</source>
-        <target>Kopiuj ten plik lub katalog</target>
+        <target>Kopiuj plik lub katalog &quot;%s&quot;</target>
       </trans-unit>
       <trans-unit id="tl_files.edit.0">
         <source>Edit file or folder</source>
@@ -199,7 +199,7 @@
       </trans-unit>
       <trans-unit id="tl_files.delete.1">
         <source>Delete file or folder &quot;%s&quot;</source>
-        <target>Skasuj ten plik lub katalog</target>
+        <target>Skasuj plik lub katalog &quot;%s&quot;</target>
       </trans-unit>
       <trans-unit id="tl_files.show.0">
         <source>File or folder details</source>
@@ -215,7 +215,7 @@
       </trans-unit>
       <trans-unit id="tl_files.source.1">
         <source>Edit file &quot;%s&quot;</source>
-        <target>Edytuj zawartość pliku</target>
+        <target>Edytuj zawartość pliku &quot;%s&quot;</target>
       </trans-unit>
       <trans-unit id="tl_files.protect.0">
         <source>Protect folder</source>

--- a/core-bundle/src/Resources/contao/languages/pl/tl_form.xlf
+++ b/core-bundle/src/Resources/contao/languages/pl/tl_form.xlf
@@ -143,7 +143,7 @@
       </trans-unit>
       <trans-unit id="tl_form.attributes.1">
         <source>Here you can set an ID and one or more classes.</source>
-        <target>Jeśli potrzebujesz osobnej definicji do formatowania tego modułu w stylach CSS, możesz tu wprowadzić ID. To ID będzie przypisane do tego modułu i można je modyfikować w arkuszu CSS.</target>
+        <target>Jeśli potrzebujesz osobnej definicji do formatowania tego modułu w stylach CSS, możesz tu wprowadzić ID. To ID będzie przypisane do tego modułu i można je używać w arkuszu CSS.</target>
       </trans-unit>
       <trans-unit id="tl_form.formID.0">
         <source>Form ID</source>

--- a/core-bundle/src/Resources/contao/languages/pl/tl_form.xlf
+++ b/core-bundle/src/Resources/contao/languages/pl/tl_form.xlf
@@ -23,7 +23,7 @@
       </trans-unit>
       <trans-unit id="tl_form.jumpTo.1">
         <source>Please choose the page to which visitors will be redirected after submitting the form.</source>
-        <target>Formularz zwykle przenosi wypełniającego do osobnej strony gdzie następuje zakończenie wysyłania danych, np. w formie wyświetlenia tekstu &quot;Dziękujemy za wypełnienie formularza&quot;. Tutaj możesz wybrać tę stronę.</target>
+        <target>Formularz zwykle przenosi wypełniającego do osobnej strony, gdzie następuje zakończenie wysyłania danych, np. w formie wyświetlenia tekstu &quot;Dziękujemy za wypełnienie formularza&quot;. Tutaj możesz wybrać tę stronę.</target>
       </trans-unit>
       <trans-unit id="tl_form.sendViaEmail.0">
         <source>Send form data via e-mail</source>
@@ -47,7 +47,7 @@
       </trans-unit>
       <trans-unit id="tl_form.subject.1">
         <source>Please enter the e-mail subject.</source>
-        <target>Wprowadź temat e-maila. Jeśli nie wpiszesz tematu istnieje wielkie prawdopodobieństwo, że twój e-mail zostanie zakwalifikowany jako SPAM.</target>
+        <target>Wprowadź temat e-maila. Jeśli nie wpiszesz tematu, istnieje duże prawdopodobieństwo, że twój e-mail zostanie zakwalifikowany jako SPAM.</target>
       </trans-unit>
       <trans-unit id="tl_form.format.0">
         <source>Data format</source>
@@ -99,11 +99,11 @@
       </trans-unit>
       <trans-unit id="tl_form.storeValues.0">
         <source>Store data</source>
-        <target>Przetrzymuj zawartość</target>
+        <target>Przechowuj zawartość</target>
       </trans-unit>
       <trans-unit id="tl_form.storeValues.1">
         <source>Store the submitted data in the database.</source>
-        <target>Przetrzymuj dane z formularza w bazie danych.</target>
+        <target>Przechowuj dane z formularza w bazie danych.</target>
       </trans-unit>
       <trans-unit id="tl_form.customTpl.0">
         <source>Form template</source>
@@ -111,7 +111,7 @@
       </trans-unit>
       <trans-unit id="tl_form.customTpl.1">
         <source>Here you can select the form template.</source>
-        <target>Wybierz szablon formularza. Domyślnym szablonem jest &lt;em&gt;member_default&lt;/em&gt;. Jeśli chcesz dodać własny szablon, wgraj go do katalogu &lt;em&gt;templates&lt;/em&gt; (rozszerzenie pliku musi być &lt;em&gt;tpl&lt;/em&gt;).</target>
+        <target>Wybierz szablon formularza. Domyślnym szablonem jest &lt;em&gt;form_wrapper&lt;/em&gt;. Jeśli chcesz dodać własny szablon, wgraj go do katalogu &lt;em&gt;templates&lt;/em&gt; (rozszerzenie pliku musi być &lt;em&gt;html5&lt;/em&gt;).</target>
       </trans-unit>
       <trans-unit id="tl_form.targetTable.0">
         <source>Target table</source>
@@ -159,7 +159,7 @@
       </trans-unit>
       <trans-unit id="tl_form.allowTags.1">
         <source>Allow HTML tags in form fields.</source>
-        <target>Domyślnie, z przyczyn bezpieczeństwa, wszystkie tagi HTML są usuwane z danych wprowadzanych przez użytkowników. Jednakże, jeśli zaznaczysz tę opcję, pewne taki HTML nie będą usuwane.</target>
+        <target>Domyślnie, z przyczyn bezpieczeństwa, wszystkie tagi HTML są usuwane z danych wprowadzanych przez użytkowników. Jednakże, jeśli zaznaczysz tę opcję, pewne tagi HTML nie będą usuwane.</target>
       </trans-unit>
       <trans-unit id="tl_form.tstamp.0">
         <source>Revision date</source>
@@ -179,7 +179,7 @@
       </trans-unit>
       <trans-unit id="tl_form.store_legend">
         <source>Store form data</source>
-        <target>Przetrzymuj dane formularza</target>
+        <target>Przechowuj dane formularza</target>
       </trans-unit>
       <trans-unit id="tl_form.expert_legend">
         <source>Expert settings</source>

--- a/core-bundle/src/Resources/contao/languages/pl/tl_form_field.xlf
+++ b/core-bundle/src/Resources/contao/languages/pl/tl_form_field.xlf
@@ -7,7 +7,7 @@
       </trans-unit>
       <trans-unit id="FFL.explanation.1">
         <source>A custom field to insert an explanation text.</source>
-        <target>Opis pola może np. zawierać wyjaśnienia co do tego jak mają być wypełnione pola lub zawierać pytanie, na które trzeba odpowiedzieć poprzez formularz. Tagi HTML dozwolone.</target>
+        <target>Opis pola może np. zawierać wyjaśnienia co do tego, jak mają być wypełnione pola lub zawierać pytanie, na które trzeba odpowiedzieć poprzez formularz. Tagi HTML dozwolone.</target>
       </trans-unit>
       <trans-unit id="FFL.html.0">
         <source>HTML code</source>
@@ -19,7 +19,7 @@
       </trans-unit>
       <trans-unit id="FFL.fieldset.0">
         <source>Fieldset</source>
-        <target>Fieldset</target>
+        <target>Zbiór pól</target>
       </trans-unit>
       <trans-unit id="FFL.fieldset.1">
         <source>A container for form fields with an optional legend.</source>
@@ -31,7 +31,7 @@
       </trans-unit>
       <trans-unit id="FFL.text.1">
         <source>A single-line input field for a short or medium text.</source>
-        <target>Jedno liniowe pole do wprowadzania tekstu, stosuje się je przy krótkich tekstach.</target>
+        <target>Jednolinijkowe pole do wprowadzania tekstu; stosuje się je przy krótkich tekstach.</target>
       </trans-unit>
       <trans-unit id="FFL.password.0">
         <source>Password field</source>
@@ -39,7 +39,7 @@
       </trans-unit>
       <trans-unit id="FFL.password.1">
         <source>A single-line input field for a password. Contao automatically adds a confirmation field.</source>
-        <target>Jedno liniowe pole do wprowadzania hasła.</target>
+        <target>Jednolinijkowe pole do wprowadzania hasła.</target>
       </trans-unit>
       <trans-unit id="FFL.textarea.0">
         <source>Textarea</source>
@@ -55,7 +55,7 @@
       </trans-unit>
       <trans-unit id="FFL.select.1">
         <source>A single- or multi-line drop-down menu.</source>
-        <target>Rozwijane menu, zwane także rozwijanym polem wyboru, zawiera kilka opcji do wyboru, każda opcja znajduje się w osobnej linii i tylko jedna może zostać wybrana.</target>
+        <target>Rozwijane menu, zwane także rozwijanym polem wyboru, zawiera kilka opcji do wyboru - każda opcja znajduje się w osobnej linii i tylko jedna może zostać wybrana.</target>
       </trans-unit>
       <trans-unit id="FFL.radio.0">
         <source>Radio button menu</source>
@@ -79,7 +79,7 @@
       </trans-unit>
       <trans-unit id="FFL.upload.1">
         <source>A single-line input field to upload a local file to the server.</source>
-        <target>Wysyłanie pliku to pole, które umożliwia wysłanie na serwer pliku z naszego dysku twardego.</target>
+        <target>Wysyłanie pliku, to pole, które umożliwia wysłanie na serwer pliku z komputera osobistego.</target>
       </trans-unit>
       <trans-unit id="FFL.hidden.0">
         <source>Hidden field</source>
@@ -95,7 +95,7 @@
       </trans-unit>
       <trans-unit id="FFL.captcha.1">
         <source>A simple math question to verify that the form is being submitted by a human (CAPTCHA).</source>
-        <target>To pole zawiera proste zadanie matematyczne, na które musisz odpowiedzieć by wysłać formularz.</target>
+        <target>To pole zawiera proste zadanie matematyczne, na które musisz odpowiedzieć, aby wysłać formularz.</target>
       </trans-unit>
       <trans-unit id="FFL.submit.0">
         <source>Submit field</source>
@@ -119,7 +119,7 @@
       </trans-unit>
       <trans-unit id="tl_form_field.name.1">
         <source>The field name is a unique name to identify the field.</source>
-        <target>Wprowadź nazwę pola. Nazwa pola będzie widoczna na stronach twjego serwisu.</target>
+        <target>Wprowadź nazwę pola. Nazwa pola będzie widoczna na stronach twojego serwisu.</target>
       </trans-unit>
       <trans-unit id="tl_form_field.label.0">
         <source>Field label</source>
@@ -151,7 +151,7 @@
       </trans-unit>
       <trans-unit id="tl_form_field.options.1">
         <source>If JavaScript is disabled, make sure to save your changes before modifying the order.</source>
-        <target>Przyporządkuj moduł do elementu strony. Używaj przycisków po prawej stronie by dodać, przesunąć (w górę albo w dół) lub skasować moduł. Jeśli pracujesz z przeglądarką, która ma wyłączoną obsługę Javascript, powinieneś zapisać swoje zmiany przed zmianą kolejności modułów!</target>
+        <target>Przyporządkuj moduł do elementu strony. Używaj przycisków po prawej stronie, aby dodać, przesunąć (w górę albo w dół) lub skasować moduł. Jeśli pracujesz z przeglądarką, która ma wyłączoną obsługę Javascript, powinieneś zapisać swoje zmiany przed zmianą kolejności modułów!</target>
       </trans-unit>
       <trans-unit id="tl_form_field.mandatory.0">
         <source>Mandatory field</source>
@@ -167,7 +167,7 @@
       </trans-unit>
       <trans-unit id="tl_form_field.rgxp.1">
         <source>Validate the input against a regular expression.</source>
-        <target>Jeśli wybierzesz tę opcję, wprowadzone przez użytkownika dane będą sprawdzone czy odpowiadają odpowiedniemu wzorcowi. Jeśli dany ciąg znaków w polu nie odpowiada założeniom wzorca zostanie on odrzucony.</target>
+        <target>Jeśli wybierzesz tę opcję, wprowadzone przez użytkownika dane będą sprawdzone czy odpowiadają zadanemu wzorcowi. Jeśli wprowadzony ciąg znaków w polu nie odpowiada założeniom wzorca, zostanie on odrzucony.</target>
       </trans-unit>
       <trans-unit id="tl_form_field.digit.0">
         <source>Numeric characters</source>
@@ -223,7 +223,7 @@
       </trans-unit>
       <trans-unit id="tl_form_field.datim.1">
         <source>Checks whether the input matches the global date and time format.</source>
-        <target>sprawdza czy wprowadzona data i czas ma odpowiedni format, ustalony w ustawieniach systemu.</target>
+        <target>sprawdza czy wprowadzona data i czas mają odpowiedni format, ustalony w ustawieniach systemu.</target>
       </trans-unit>
       <trans-unit id="tl_form_field.phone.0">
         <source>Phone number</source>
@@ -271,7 +271,7 @@
       </trans-unit>
       <trans-unit id="tl_form_field.maxlength.1">
         <source>Limit the field length to a certain number of characters (text) or bytes (file uploads).</source>
-        <target>Jeśli wprowadzisz numeryczną wartość, wprowadzana długość tekstu będzie ograniczone do podanej wartości. Jeśli jest to pole do wysyłania plików, możesz tu wprowadzić, w bajtach, maksymalny rozmiar pliku jaki będzie mógł być przesłany (np. 1 MB = 1024 KB = 1024000 bajtów).</target>
+        <target>Jeśli wprowadzisz numeryczną wartość, wprowadzana długość tekstu będzie ograniczona do podanej wartości. Jeśli jest to pole do wysyłania plików, możesz tu wprowadzić, w bajtach, maksymalny rozmiar pliku, jaki będzie mógł być przesłany (np. 1 MB = 1024 KB = 1024000 bajtów).</target>
       </trans-unit>
       <trans-unit id="tl_form_field.size.0">
         <source>Rows and columns</source>
@@ -311,7 +311,7 @@
       </trans-unit>
       <trans-unit id="tl_form_field.storeFile.1">
         <source>Move the uploaded files to a folder on the server.</source>
-        <target>Jeśli wybierzesz tę opcję, wysyłane pliki będą przechowywane w katalogu na serwerze. Nie wybieraj tej opcji jeśli wysyłane pliki są przesyłane e-mailem jako załączniki i nie chcesz ich przechowywać.</target>
+        <target>Jeśli wybierzesz tę opcję, wysyłane pliki będą przechowywane w katalogu na serwerze. Nie wybieraj tej opcji, jeśli wysyłane pliki są przesyłane e-mailem jako załączniki i nie chcesz ich przechowywać.</target>
       </trans-unit>
       <trans-unit id="tl_form_field.uploadFolder.0">
         <source>Target folder</source>
@@ -319,7 +319,7 @@
       </trans-unit>
       <trans-unit id="tl_form_field.uploadFolder.1">
         <source>Please select the target folder from the files directory.</source>
-        <target>Wybierz katalog gdzie przechowywane będą wysyłane pliki.</target>
+        <target>Wybierz katalog, gdzie przechowywane będą wysyłane pliki.</target>
       </trans-unit>
       <trans-unit id="tl_form_field.useHomeDir.0">
         <source>Use home directory</source>
@@ -343,7 +343,7 @@
       </trans-unit>
       <trans-unit id="tl_form_field.fsType.1">
         <source>Please select the operation mode of the fieldset element.</source>
-        <target>Zaznacz tryb pracy elementu fieldset.</target>
+        <target>Zaznacz tryb pracy elementu &quot;zbiór pól&quot;.</target>
       </trans-unit>
       <trans-unit id="tl_form_field.fsStart.0">
         <source>Wrapper start</source>
@@ -351,7 +351,7 @@
       </trans-unit>
       <trans-unit id="tl_form_field.fsStart.1">
         <source>Marks the beginning of a fieldset and can contain a legend.</source>
-        <target>Zaznacz początek fieldset, może zawierać legendę.</target>
+        <target>Zaznacz początek zbioru pól; może zawierać legendę.</target>
       </trans-unit>
       <trans-unit id="tl_form_field.fsStop.0">
         <source>Wrapper stop</source>
@@ -359,15 +359,15 @@
       </trans-unit>
       <trans-unit id="tl_form_field.fsStop.1">
         <source>Marks the end of a fieldset.</source>
-        <target>Zaznacz koniec fieldset.</target>
+        <target>Zaznacz koniec zbioru pól.</target>
       </trans-unit>
       <trans-unit id="tl_form_field.value.0">
         <source>Default value</source>
-        <target>Zawartość</target>
+        <target>Domyślna wartość</target>
       </trans-unit>
       <trans-unit id="tl_form_field.value.1">
         <source>Here you can enter a default value for the field.</source>
-        <target>Jeśli wprowadzisz tu zawartość zostanie ona użyta jako domyślne wypełnienie aktualnego pola.</target>
+        <target>Jeśli wprowadzisz tu zawartość, zostanie ona użyta jako domyślne wypełnienie aktualnego pola.</target>
       </trans-unit>
       <trans-unit id="tl_form_field.class.0">
         <source>CSS class</source>
@@ -383,7 +383,7 @@
       </trans-unit>
       <trans-unit id="tl_form_field.accesskey.1">
         <source>A form field can be focused by pressing the [ALT] or [CTRL] key and the access key simultaneously.</source>
-        <target>Klawisz dostępu jest pojedynczym znakiem, który jest przyporządkowany polu w formularzu. Jeśli użytkownik jednocześnie naciśnie klawisz [ALT] i klawisz dostępu, do przypisanego mu pola jest wstawiany kursor i możemy np. wprowadzać tekst.</target>
+        <target>Klawisz dostępu jest pojedynczym znakiem, który jest przyporządkowany polu w formularzu. Jeśli użytkownik jednocześnie naciśnie klawisz [ALT] i klawisz dostępu, przypisane pole staje się aktywne.</target>
       </trans-unit>
       <trans-unit id="tl_form_field.tabindex.0">
         <source>Tab index</source>
@@ -423,7 +423,7 @@
       </trans-unit>
       <trans-unit id="tl_form_field.imageSubmit.1">
         <source>Use an image submit button instead of the default one.</source>
-        <target>Użyj obrazka jako przycisku zamiast domyślnego przycisku z tekstem.</target>
+        <target>Użyj obrazka jako przycisku, zamiast domyślnego przycisku z tekstem.</target>
       </trans-unit>
       <trans-unit id="tl_form_field.singleSRC.0">
         <source>Source file</source>
@@ -459,7 +459,7 @@
       </trans-unit>
       <trans-unit id="tl_form_field.store_legend">
         <source>Store file</source>
-        <target>Przetrzymuj plik</target>
+        <target>Przechowuj plik</target>
       </trans-unit>
       <trans-unit id="tl_form_field.expert_legend">
         <source>Expert settings</source>
@@ -543,7 +543,7 @@
       </trans-unit>
       <trans-unit id="tl_form_field.pasteafter.0">
         <source>Paste at the top</source>
-        <target>Wstaw na początku</target>
+        <target>Wklej na początku</target>
       </trans-unit>
       <trans-unit id="tl_form_field.pasteafter.1">
         <source>Paste after field ID %s</source>
@@ -551,19 +551,19 @@
       </trans-unit>
       <trans-unit id="tl_form_field.pastenew.0">
         <source>Add new at the top</source>
-        <target>Utwórz nowy element arkusza na początku</target>
+        <target>Utwórz nowy pole formularza na górze</target>
       </trans-unit>
       <trans-unit id="tl_form_field.pastenew.1">
         <source>Add new after field ID %s</source>
-        <target>Utwórz nowe pole po polu ID %s</target>
+        <target>Utwórz nowe pole formularza po polu formularza ID %s</target>
       </trans-unit>
       <trans-unit id="tl_form_field.toggle.0">
         <source>Toggle visibility</source>
-        <target>Włącz lub wyłącz widoczność elementu</target>
+        <target>Ukryj/pokaż pole formularza</target>
       </trans-unit>
       <trans-unit id="tl_form_field.toggle.1">
         <source>Toggle the visibility of field ID %s</source>
-        <target>Włącz widoczność pola ID %s</target>
+        <target>Ukryj/pokaż pole formularza ID %s</target>
       </trans-unit>
       <trans-unit id="tl_form_field.option.1">
         <source>Import options from a CSV file</source>

--- a/core-bundle/src/Resources/contao/languages/pl/tl_form_field.xlf
+++ b/core-bundle/src/Resources/contao/languages/pl/tl_form_field.xlf
@@ -551,7 +551,7 @@
       </trans-unit>
       <trans-unit id="tl_form_field.pastenew.0">
         <source>Add new at the top</source>
-        <target>Utwórz nowy pole formularza na górze</target>
+        <target>Utwórz nowe pole formularza na górze</target>
       </trans-unit>
       <trans-unit id="tl_form_field.pastenew.1">
         <source>Add new after field ID %s</source>

--- a/core-bundle/src/Resources/contao/languages/pl/tl_image_size.xlf
+++ b/core-bundle/src/Resources/contao/languages/pl/tl_image_size.xlf
@@ -3,7 +3,7 @@
     <body>
       <trans-unit id="tl_image_size.name.0">
         <source>Name</source>
-        <target>Imię i nazwisko</target>
+        <target>Nazwa wyświetlana</target>
       </trans-unit>
       <trans-unit id="tl_image_size.name.1">
         <source>Please enter the image size name.</source>
@@ -63,7 +63,7 @@
       </trans-unit>
       <trans-unit id="tl_image_size.cssClass.1">
         <source>The CSS classes will be applied to the image tag.</source>
-        <target>Klasy CSS zostaną zaaplikowane do tagu obrazka.</target>
+        <target>Klasy CSS zostaną dodane do tagu obrazka.</target>
       </trans-unit>
       <trans-unit id="tl_image_size.tstamp.0">
         <source>Revision date</source>

--- a/core-bundle/src/Resources/contao/languages/pl/tl_image_size.xlf
+++ b/core-bundle/src/Resources/contao/languages/pl/tl_image_size.xlf
@@ -3,7 +3,7 @@
     <body>
       <trans-unit id="tl_image_size.name.0">
         <source>Name</source>
-        <target>Nazwa wyświetlana</target>
+        <target>Nazwa</target>
       </trans-unit>
       <trans-unit id="tl_image_size.name.1">
         <source>Please enter the image size name.</source>

--- a/core-bundle/src/Resources/contao/languages/pl/tl_image_size_item.xlf
+++ b/core-bundle/src/Resources/contao/languages/pl/tl_image_size_item.xlf
@@ -7,7 +7,7 @@
       </trans-unit>
       <trans-unit id="tl_image_size_item.media.1">
         <source>Here you can define when to use the image size, e.g. &lt;em&gt;(max-width: 600px)&lt;/em&gt;.</source>
-        <target>Tutaj możesz określić kiedy użyć rozmiaru obrazka, np. &lt;em&gt;(max-width: 600px)&lt;/em&gt;.</target>
+        <target>Tutaj możesz określić, kiedy użyć rozmiaru obrazka, np. &lt;em&gt;(max-width: 600px)&lt;/em&gt;.</target>
       </trans-unit>
       <trans-unit id="tl_image_size_item.invisible.0">
         <source>Invisible</source>
@@ -95,7 +95,7 @@
       </trans-unit>
       <trans-unit id="tl_image_size_item.pasteafter.0">
         <source>Paste at the top</source>
-        <target>Wstaw na początku</target>
+        <target>Wklej na początku</target>
       </trans-unit>
       <trans-unit id="tl_image_size_item.pasteafter.1">
         <source>Paste after media query ID %s</source>
@@ -103,19 +103,19 @@
       </trans-unit>
       <trans-unit id="tl_image_size_item.pastenew.0">
         <source>Add new at the top</source>
-        <target>Utwórz nowy element arkusza na początku</target>
+        <target>Utwórz nowe media query na górze</target>
       </trans-unit>
       <trans-unit id="tl_image_size_item.pastenew.1">
         <source>Add new after media query ID %s</source>
-        <target>Dodaj nowy po media query ID %s</target>
+        <target>Utwórz nowe media query pod media query ID %s</target>
       </trans-unit>
       <trans-unit id="tl_image_size_item.toggle.0">
         <source>Toggle visibility</source>
-        <target>Włącz lub wyłącz widoczność elementu</target>
+        <target>Ukryj/pokaż media query</target>
       </trans-unit>
       <trans-unit id="tl_image_size_item.toggle.1">
         <source>Toggle the visibility of media query ID %s</source>
-        <target>Włącz lub wyłącz widoczność media query ID %s</target>
+        <target>Ukryj/pokaż media query ID %s</target>
       </trans-unit>
     </body>
   </file>

--- a/core-bundle/src/Resources/contao/languages/pl/tl_layout.xlf
+++ b/core-bundle/src/Resources/contao/languages/pl/tl_layout.xlf
@@ -95,7 +95,7 @@
       </trans-unit>
       <trans-unit id="tl_layout.2cll.1">
         <source>Show two columns with the main column on the right side.</source>
-        <target>zostaną wyświetlone dwie kolumny a kolumna główna będzie po prawej stronie.</target>
+        <target>zostaną wyświetlone dwie kolumny, a kolumna główna będzie po prawej stronie.</target>
       </trans-unit>
       <trans-unit id="tl_layout.2clr.0">
         <source>Main and right column</source>
@@ -103,15 +103,15 @@
       </trans-unit>
       <trans-unit id="tl_layout.2clr.1">
         <source>Show two columns with the main column on the left side.</source>
-        <target>zostaną wyświetlone dwie kolumny a kolumna główna będzie po lewej stronie.</target>
+        <target>zostaną wyświetlone dwie kolumny, a kolumna główna będzie po lewej stronie.</target>
       </trans-unit>
       <trans-unit id="tl_layout.3cl.0">
         <source>Main, left and right column</source>
-        <target>Trzy kolumny w główną kolumną po środku</target>
+        <target>Trzy kolumny z główną kolumną po środku</target>
       </trans-unit>
       <trans-unit id="tl_layout.3cl.1">
         <source>Show three columns with the main column in the middle.</source>
-        <target>zostaną wyświetlone trzy kolumny a główna kolumna będzie w środku.</target>
+        <target>zostaną wyświetlone trzy kolumny, a główna kolumna będzie w środku.</target>
       </trans-unit>
       <trans-unit id="tl_layout.widthLeft.0">
         <source>Left column width</source>
@@ -155,19 +155,19 @@
       </trans-unit>
       <trans-unit id="tl_layout.layout.css.0">
         <source>Layout builder</source>
-        <target>Budowa layoutu</target>
+        <target>Budowa układu</target>
       </trans-unit>
       <trans-unit id="tl_layout.layout.css.1">
         <source>Generates a CSS layout based on the page layout settings. This component is required for the page layout generator to work!</source>
-        <target>Generuje CSS layoutu opierając się na ustawieniach układu strony. Ten komponent jest wymagany do działania generatora układu strony!</target>
+        <target>Generuje CSS układu opierając się na ustawieniach układu strony. Ten komponent jest wymagany do działania generatora układu strony!</target>
       </trans-unit>
       <trans-unit id="tl_layout.responsive.css.0">
         <source>Responsive layout</source>
-        <target>Responsywny layout</target>
+        <target>Responsywny układ</target>
       </trans-unit>
       <trans-unit id="tl_layout.responsive.css.1">
         <source>Adds a meta viewport tag to the page header and scales the CSS layout based on the device width.</source>
-        <target>Dodaje do nagłówka strony tag z meta portem przeglądarki i skaluje layout CSS, używając jako punkt odniesienia szerokość urządzenia.</target>
+        <target>Dodaje do nagłówka strony tag z meta portem przeglądarki i skaluje układ CSS, używając jako punkt odniesienia szerokość urządzenia.</target>
       </trans-unit>
       <trans-unit id="tl_layout.grid.css.0">
         <source>12-column grid</source>
@@ -175,7 +175,7 @@
       </trans-unit>
       <trans-unit id="tl_layout.grid.css.1">
         <source>Adds a responsive 12-column grid that is triggered by the CSS classes &quot;grid1&quot; to &quot;grid12&quot; and &quot;offset1&quot; to &quot;offset12&quot;.</source>
-        <target>Dodaje responsywną 12-kolumnową siatkę, która może być użyta za pomocą klass CSS począwszy od &quot;grid1&quot; do &quot;grid12&quot; i &quot;offset1&quot; do &quot;offset12&quot;.</target>
+        <target>Dodaje responsywną 12-kolumnową siatkę, która może być użyta za pomocą klass CSS, począwszy od &quot;grid1&quot; do &quot;grid12&quot; i &quot;offset1&quot; do &quot;offset12&quot;.</target>
       </trans-unit>
       <trans-unit id="tl_layout.reset.css.0">
         <source>CSS reset</source>
@@ -235,11 +235,11 @@
       </trans-unit>
       <trans-unit id="tl_layout.external_first">
         <source>Load external style sheets first</source>
-        <target>Załaduj zewnętrzne arkusze styli najpierw</target>
+        <target>Załaduj zewnętrzne arkusze stylów najpierw</target>
       </trans-unit>
       <trans-unit id="tl_layout.internal_first">
         <source>Load internal style sheets first</source>
-        <target>Załaduj wewnętrzne arkusze styli najpierw</target>
+        <target>Załaduj wewnętrzne arkusze stylów najpierw</target>
       </trans-unit>
       <trans-unit id="tl_layout.webfonts.0">
         <source>Google web fonts</source>
@@ -255,7 +255,7 @@
       </trans-unit>
       <trans-unit id="tl_layout.modules.1">
         <source>If JavaScript is disabled, make sure to save your changes before modifying the order.</source>
-        <target>Przyporządkuj moduł do elementu strony. Używaj przycisków po prawej stronie by dodać, przesunąć (w górę albo w dół) lub skasować moduł. Jeśli pracujesz z przeglądarką, która ma wyłączoną obsługę Javascript, powinieneś zapisać swoje zmiany przed zmianą kolejności modułów!</target>
+        <target>Przyporządkuj moduł do elementu strony. Używaj przycisków po prawej stronie, aby dodać, przesunąć (w górę albo w dół) lub skasować moduł. Jeśli pracujesz z przeglądarką, która ma wyłączoną obsługę Javascript, powinieneś zapisać swoje zmiany przed zmianą kolejności modułów!</target>
       </trans-unit>
       <trans-unit id="tl_layout.template.0">
         <source>Page template</source>
@@ -263,7 +263,7 @@
       </trans-unit>
       <trans-unit id="tl_layout.template.1">
         <source>Here you can select the page template.</source>
-        <target>Wybierz szablon układu. Domyślnym szablonem jest &lt;em&gt;fe_page&lt;/em&gt;. Jeśli chcesz dodać własny szablon, wgraj go do katalogu &lt;em&gt;templates&lt;/em&gt; (rozszerzenie pliku musi być &lt;em&gt;tpl&lt;/em&gt;).</target>
+        <target>Wybierz szablon układu. Domyślnym szablonem jest &lt;em&gt;fe_page&lt;/em&gt;. Jeśli chcesz dodać własny szablon, wgraj go do katalogu &lt;em&gt;templates&lt;/em&gt; (rozszerzenie pliku musi być &lt;em&gt;html5&lt;/em&gt;).</target>
       </trans-unit>
       <trans-unit id="tl_layout.doctype.0">
         <source>Output format</source>
@@ -319,7 +319,7 @@
       </trans-unit>
       <trans-unit id="tl_layout.addJQuery.1">
         <source>Include the jQuery library in the layout.</source>
-        <target>Załącz bibliotekę jQuery do layoutu.</target>
+        <target>Załącz bibliotekę jQuery do układu.</target>
       </trans-unit>
       <trans-unit id="tl_layout.jSource.0">
         <source>jQuery source</source>
@@ -327,7 +327,7 @@
       </trans-unit>
       <trans-unit id="tl_layout.jSource.1">
         <source>Here you can select from where to load the jQuery script.</source>
-        <target>Tutaj możesz wybrać skąd załadować skrypt jQuery.</target>
+        <target>Tutaj możesz wybrać, skąd załadować skrypt jQuery.</target>
       </trans-unit>
       <trans-unit id="tl_layout.jquery.0">
         <source>jQuery templates</source>
@@ -343,7 +343,7 @@
       </trans-unit>
       <trans-unit id="tl_layout.addMooTools.1">
         <source>Include the MooTools library in the layout.</source>
-        <target>Załącz bibliotekę MooTools do layoutu.</target>
+        <target>Załącz bibliotekę MooTools do układu.</target>
       </trans-unit>
       <trans-unit id="tl_layout.mooSource.0">
         <source>MooTools source</source>
@@ -359,7 +359,7 @@
       </trans-unit>
       <trans-unit id="tl_layout.mootools.1">
         <source>Here you can select one or more MooTools templates.</source>
-        <target>Jeśli chcesz umieścić na swojej stronie rozwijane panele (mootools accordion), musisz dodać szablon JavaScript, który uruchomi ten efekt. Szablon JavaScript możesz wybrać tutaj. Szablon mootools zaczyna się od &lt;em&gt;moo_&lt;/em&gt; (rozszerzenie pliku &lt;em&gt;tpl&lt;/em&gt;).</target>
+        <target>Jeśli chcesz umieścić na swojej stronie rozwijane panele (mootools accordion), musisz dodać szablon JavaScript, który uruchomi ten efekt. Szablon JavaScript możesz wybrać tutaj. Szablon mootools zaczyna się od &lt;em&gt;moo_&lt;/em&gt; (rozszerzenie pliku &lt;em&gt;html5&lt;/em&gt;).</target>
       </trans-unit>
       <trans-unit id="tl_layout.picturefill.0">
         <source>Load the image polyfill</source>
@@ -371,7 +371,7 @@
       </trans-unit>
       <trans-unit id="tl_layout.scripts.0">
         <source>JavaScript templates</source>
-        <target>Templatki JavaScript</target>
+        <target>Szablony JavaScript</target>
       </trans-unit>
       <trans-unit id="tl_layout.scripts.1">
         <source>Here you can select one or more JavaScript templates.</source>
@@ -395,7 +395,7 @@
       </trans-unit>
       <trans-unit id="tl_layout.static.0">
         <source>Static layout</source>
-        <target>Szablon statyczny</target>
+        <target>Układ statyczny</target>
       </trans-unit>
       <trans-unit id="tl_layout.static.1">
         <source>Create a static layout with a fixed width and alignment.</source>
@@ -439,7 +439,7 @@
       </trans-unit>
       <trans-unit id="tl_layout.style_legend">
         <source>Style sheets</source>
-        <target>Arkusze styli</target>
+        <target>Arkusze stylów</target>
       </trans-unit>
       <trans-unit id="tl_layout.picturefill_legend">
         <source>Responsive images</source>
@@ -459,7 +459,7 @@
       </trans-unit>
       <trans-unit id="tl_layout.static_legend">
         <source>Static layout</source>
-        <target>Szablon statyczny</target>
+        <target>Układ statyczny</target>
       </trans-unit>
       <trans-unit id="tl_layout.jquery_legend">
         <source>jQuery</source>
@@ -475,7 +475,7 @@
       </trans-unit>
       <trans-unit id="tl_layout.j_fallback">
         <source>CDN with local fallback</source>
-        <target>CDN z lokalnym wsparciem fallback</target>
+        <target>CDN z lokalnym wsparciem (fallback)</target>
       </trans-unit>
       <trans-unit id="tl_layout.mootools_legend">
         <source>MooTools</source>
@@ -491,7 +491,7 @@
       </trans-unit>
       <trans-unit id="tl_layout.moo_fallback">
         <source>CDN with local fallback</source>
-        <target>CDN z lokalnym wsparciem fallback</target>
+        <target>CDN z lokalnym wsparciem (fallback)</target>
       </trans-unit>
       <trans-unit id="tl_layout.html5">
         <source>HTML</source>
@@ -531,7 +531,7 @@
       </trans-unit>
       <trans-unit id="tl_layout.edit.0">
         <source>Edit layout</source>
-        <target>Edytuj układ layout</target>
+        <target>Edytuj układ</target>
       </trans-unit>
       <trans-unit id="tl_layout.edit.1">
         <source>Edit layout ID %s</source>

--- a/core-bundle/src/Resources/contao/languages/pl/tl_log.xlf
+++ b/core-bundle/src/Resources/contao/languages/pl/tl_log.xlf
@@ -19,7 +19,7 @@
       </trans-unit>
       <trans-unit id="tl_log.action.0">
         <source>Category</source>
-        <target>Kategorie</target>
+        <target>Kategoria</target>
       </trans-unit>
       <trans-unit id="tl_log.action.1">
         <source>Category of the action</source>

--- a/core-bundle/src/Resources/contao/languages/pl/tl_maintenance.xlf
+++ b/core-bundle/src/Resources/contao/languages/pl/tl_maintenance.xlf
@@ -3,7 +3,7 @@
     <body>
       <trans-unit id="tl_maintenance.cacheTables.0">
         <source>Purge data</source>
-        <target>Usuń dane sesji</target>
+        <target>Usuń dane</target>
       </trans-unit>
       <trans-unit id="tl_maintenance.cacheTables.1">
         <source>Please select the data you want to purge or rebuild.</source>
@@ -15,7 +15,7 @@
       </trans-unit>
       <trans-unit id="tl_maintenance.frontendUser.1">
         <source>Automatically log in a front end user to index protected pages.</source>
-        <target>Automatycznie zaloguj użytkownika by zaindeksować strony chronione.</target>
+        <target>Automatycznie zaloguj użytkownika, aby zaindeksować strony chronione.</target>
       </trans-unit>
       <trans-unit id="tl_maintenance.job">
         <source>Job</source>
@@ -39,7 +39,7 @@
       </trans-unit>
       <trans-unit id="tl_maintenance.clearCache">
         <source>Purge data</source>
-        <target>Usuń dane sesji</target>
+        <target>Usuń dane</target>
       </trans-unit>
       <trans-unit id="tl_maintenance.cacheCleared">
         <source>The data has been purged</source>
@@ -119,7 +119,7 @@
       </trans-unit>
       <trans-unit id="tl_maintenance_jobs.scripts.1">
         <source>Removes the automatically generated &lt;code&gt;.css&lt;/code&gt; and &lt;code&gt;.js&lt;/code&gt; files, recreates the internal style sheets and then purges the page cache.</source>
-        <target>Usuwa automatycznie wygenerowane pliki .css i .js, odtwarza wewnętrzne style i wtedy czyści cache stron.</target>
+        <target>Usuwa automatycznie wygenerowane pliki &lt;code&gt;.css&lt;/code&gt; i &lt;code&gt;.js&lt;/code&gt;, odtwarza wewnętrzne style i wtedy czyści cache stron.</target>
       </trans-unit>
       <trans-unit id="tl_maintenance_jobs.pages.0">
         <source>Purge the page cache</source>

--- a/core-bundle/src/Resources/contao/languages/pl/tl_member.xlf
+++ b/core-bundle/src/Resources/contao/languages/pl/tl_member.xlf
@@ -291,7 +291,7 @@
       </trans-unit>
       <trans-unit id="tl_member.su.1">
         <source>Preview the front end as member ID %s</source>
-        <target>Podgląd front end jako użytkownik ID %s</target>
+        <target>Podgląd serwisu jako użytkownik ID %s</target>
       </trans-unit>
     </body>
   </file>

--- a/core-bundle/src/Resources/contao/languages/pl/tl_member_group.xlf
+++ b/core-bundle/src/Resources/contao/languages/pl/tl_member_group.xlf
@@ -3,7 +3,7 @@
     <body>
       <trans-unit id="tl_member_group.name.0">
         <source>Title</source>
-        <target>Nagłówek</target>
+        <target>Nazwa</target>
       </trans-unit>
       <trans-unit id="tl_member_group.name.1">
         <source>Please enter the group title.</source>
@@ -15,7 +15,7 @@
       </trans-unit>
       <trans-unit id="tl_member_group.redirect.1">
         <source>Redirect group members to a custom page when they log in.</source>
-        <target>Jeśli wybierzesz tą opcję, użytkownicy grupy będą przekierowani na specjalnie przygotowaną stronę kiedy się zalogują.</target>
+        <target>Jeśli wybierzesz tę opcję, użytkownicy grupy będą przekierowani na specjalnie przygotowaną stronę, kiedy się zalogują.</target>
       </trans-unit>
       <trans-unit id="tl_member_group.jumpTo.0">
         <source>Redirect page</source>
@@ -23,7 +23,7 @@
       </trans-unit>
       <trans-unit id="tl_member_group.jumpTo.1">
         <source>Please choose the page to which the group members will be redirected.</source>
-        <target>Wybierz stronę na którą będą przekierowani użytkownicy grupy.</target>
+        <target>Wybierz stronę, na którą będą przekierowani użytkownicy grupy.</target>
       </trans-unit>
       <trans-unit id="tl_member_group.disable.0">
         <source>Deactivate</source>
@@ -51,7 +51,7 @@
       </trans-unit>
       <trans-unit id="tl_member_group.title_legend">
         <source>Title</source>
-        <target>Nagłówek</target>
+        <target>Nazwa</target>
       </trans-unit>
       <trans-unit id="tl_member_group.redirect_legend">
         <source>Auto-redirect</source>
@@ -103,11 +103,11 @@
       </trans-unit>
       <trans-unit id="tl_member_group.toggle.0">
         <source>Activate/deactivate group</source>
-        <target>Aktywuj/nie aktywuj grupę</target>
+        <target>Aktywuj/deaktywuj grupę</target>
       </trans-unit>
       <trans-unit id="tl_member_group.toggle.1">
         <source>Activate/deactivate group ID %s</source>
-        <target>Aktywuj/nie aktywuj grupę ID %s</target>
+        <target>Aktywuj/deaktywuj grupę ID %s</target>
       </trans-unit>
     </body>
   </file>

--- a/core-bundle/src/Resources/contao/languages/pl/tl_module.xlf
+++ b/core-bundle/src/Resources/contao/languages/pl/tl_module.xlf
@@ -495,7 +495,7 @@
       </trans-unit>
       <trans-unit id="tl_module.cssID.1">
         <source>Here you can set an ID and one or more classes.</source>
-        <target>Jeśli potrzebujesz osobnej definicji do formatowania tego modułu w stylach CSS, możesz tu wprowadzić ID. To ID będzie przypisane do tego modułu i można je modyfikować w arkuszu CSS.</target>
+        <target>Jeśli potrzebujesz osobnej definicji do formatowania tego modułu w stylach CSS, możesz tu wprowadzić ID. To ID będzie przypisane do tego modułu i można je używać w arkuszu CSS.</target>
       </trans-unit>
       <trans-unit id="tl_module.disableCaptcha.0">
         <source>Disable the security question</source>

--- a/core-bundle/src/Resources/contao/languages/pl/tl_module.xlf
+++ b/core-bundle/src/Resources/contao/languages/pl/tl_module.xlf
@@ -3,7 +3,7 @@
     <body>
       <trans-unit id="tl_module.name.0">
         <source>Title</source>
-        <target>Nagłówek</target>
+        <target>Nazwa</target>
       </trans-unit>
       <trans-unit id="tl_module.name.1">
         <source>Please enter the module title.</source>
@@ -31,7 +31,7 @@
       </trans-unit>
       <trans-unit id="tl_module.levelOffset.1">
         <source>Enter a value greater than 0 to show only submenu items.</source>
-        <target>Zdefiniuj, od którego poziomu, pozycje w menu powinny być widoczne. Wybierz 0 lub zostaw puste aby zacząć od najwyższego poziomu.</target>
+        <target>Zdefiniuj, od którego poziomu pozycje w menu powinny być widoczne. Wybierz 0 lub zostaw puste, aby zacząć od najwyższego poziomu.</target>
       </trans-unit>
       <trans-unit id="tl_module.showLevel.0">
         <source>Stop level</source>
@@ -39,7 +39,7 @@
       </trans-unit>
       <trans-unit id="tl_module.showLevel.1">
         <source>Enter a value greater than 0 to limit the nesting level of the menu.</source>
-        <target>Zdefiniuj jaki poziom menu powinien być widoczny. Np. wybierając 1 wyświetlą się tylko główne elementy menu oraz podelementy aktualnej strony. Wybierając 0 wyświetlą się wszystkie główne elementy i ich podelementy.</target>
+        <target>Zdefiniuj jaki poziom menu powinien być widoczny. Np. gdy wpisane 1, wyświetlą się tylko główne elementy menu oraz podelementy aktualnej strony. Gdy wpisane 0, wyświetlą się wszystkie główne elementy i ich podelementy.</target>
       </trans-unit>
       <trans-unit id="tl_module.hardLimit.0">
         <source>Hard limit</source>
@@ -55,7 +55,7 @@
       </trans-unit>
       <trans-unit id="tl_module.showProtected.1">
         <source>Show items that are usually only visible to authenticated members.</source>
-        <target>Pokaż rzeczy, które są widoczne tylko dla zalogowanych użytkowników.</target>
+        <target>Pokaż elementy, które są widoczne tylko dla zalogowanych użytkowników.</target>
       </trans-unit>
       <trans-unit id="tl_module.defineRoot.0">
         <source>Set a reference page</source>
@@ -71,7 +71,7 @@
       </trans-unit>
       <trans-unit id="tl_module.rootPage.1">
         <source>Please choose the reference page from the site structure.</source>
-        <target>Tutaj możesz wybrać inny punk startowy do wygenerowania mapy serwisu.</target>
+        <target>Tutaj możesz wybrać inny punkt startowy do wygenerowania mapy serwisu.</target>
       </trans-unit>
       <trans-unit id="tl_module.navigationTpl.0">
         <source>Navigation template</source>
@@ -79,7 +79,7 @@
       </trans-unit>
       <trans-unit id="tl_module.navigationTpl.1">
         <source>Here you can select the navigation template.</source>
-        <target>Wybierz szablon menu. Możesz dodać własne szablony wydarzeń do katalogu templates. Pliki szablonów wydarzeń muszą zaczynać się od nav_ i muszą mieć rozszerzenie .tpl.</target>
+        <target>Wybierz szablon menu. Możesz dodać własne szablony nawigacji do katalogu templates. Pliki szablonów nawigacji muszą zaczynać się od nav_ i muszą mieć rozszerzenie &lt;code&gt;html5&lt;/code&gt;.</target>
       </trans-unit>
       <trans-unit id="tl_module.customTpl.0">
         <source>Custom module template</source>
@@ -107,11 +107,11 @@
       </trans-unit>
       <trans-unit id="tl_module.customLabel.0">
         <source>Custom label</source>
-        <target>Własna etykietka</target>
+        <target>Własna etykieta</target>
       </trans-unit>
       <trans-unit id="tl_module.customLabel.1">
         <source>Here you can enter a custom label for the drop-down menu.</source>
-        <target>Tu możesz wprowadzić nazwę własnej etykietki w zastępstwie &lt;em&gt;Szybkiego odnośnika&lt;/em&gt; lub &lt;em&gt;Szybkiej nawigacji&lt;/em&gt;.</target>
+        <target>Tu możesz wprowadzić nazwę własnej etykiety w zastępstwie &lt;em&gt;Szybkiego odnośnika&lt;/em&gt; lub &lt;em&gt;Szybkiej nawigacji&lt;/em&gt;.</target>
       </trans-unit>
       <trans-unit id="tl_module.autologin.0">
         <source>Allow auto login</source>
@@ -119,7 +119,7 @@
       </trans-unit>
       <trans-unit id="tl_module.autologin.1">
         <source>Allow members to log into the front end automatically.</source>
-        <target>Zezwól użytkownikom serwisu na automatyczne logowanie do serwisu</target>
+        <target>Zezwól użytkownikom na automatyczne logowanie do serwisu</target>
       </trans-unit>
       <trans-unit id="tl_module.jumpTo.0">
         <source>Redirect page</source>
@@ -127,7 +127,7 @@
       </trans-unit>
       <trans-unit id="tl_module.jumpTo.1">
         <source>Please choose the page to which visitors will be redirected when clicking a link or submitting a form.</source>
-        <target>Te ustawienia definiują, na którą stronę zostanie przekierowany użytkownik po jakiejś operacji. (np. kliknięcie na link lub przesłanie formularza).</target>
+        <target>Te ustawienia definiują, na którą stronę zostanie przekierowany użytkownik po jakiejś operacji (np. kliknięcie na link lub przesłanie formularza).</target>
       </trans-unit>
       <trans-unit id="tl_module.redirectBack.0">
         <source>Redirect to last page visited</source>
@@ -135,7 +135,7 @@
       </trans-unit>
       <trans-unit id="tl_module.redirectBack.1">
         <source>Redirect the member back to the last page visited instead of the redirect page.</source>
-        <target>Przekieruj użytkownika z powrotem do ostatnio odwiedzanej strony zamiast do określonej strony docelowej.</target>
+        <target>Przekieruj użytkownika z powrotem do ostatnio odwiedzanej strony, zamiast do określonej strony docelowej.</target>
       </trans-unit>
       <trans-unit id="tl_module.cols.0">
         <source>Number of columns</source>
@@ -175,7 +175,7 @@
       </trans-unit>
       <trans-unit id="tl_module.memberTpl.1">
         <source>Here you can select the form template.</source>
-        <target>Wybierz szablon formularza. Domyślnym szablonem jest &lt;em&gt;member_default&lt;/em&gt;. Jeśli chcesz dodać własny szablon, wgraj go do katalogu &lt;em&gt;templates&lt;/em&gt; (rozszerzenie pliku musi być &lt;em&gt;tpl&lt;/em&gt;).</target>
+        <target>Wybierz szablon formularza. Domyślnym szablonem jest &lt;em&gt;member_default&lt;/em&gt;. Jeśli chcesz dodać własny szablon, wgraj go do katalogu &lt;em&gt;templates&lt;/em&gt; (rozszerzenie pliku musi być &lt;em&gt;html5&lt;/em&gt;).</target>
       </trans-unit>
       <trans-unit id="tl_module.form.0">
         <source>Form</source>
@@ -199,7 +199,7 @@
       </trans-unit>
       <trans-unit id="tl_module.and.1">
         <source>Returns only pages that contain all keywords.</source>
-        <target>Wyszukiwarka odnajdzie strony gdzie występują wszystkie podane słowa kluczowe.</target>
+        <target>Wyszukiwarka odnajdzie strony, gdzie występują wszystkie podane słowa kluczowe.</target>
       </trans-unit>
       <trans-unit id="tl_module.or.0">
         <source>Find any word</source>
@@ -207,7 +207,7 @@
       </trans-unit>
       <trans-unit id="tl_module.or.1">
         <source>Returns all pages that contain any of the keywords.</source>
-        <target>Wyszukiwarka odnajdzie strony gdzie występuje przynajmniej jedno z podanych słów kluczowych.</target>
+        <target>Wyszukiwarka odnajdzie strony, gdzie występuje przynajmniej jedno z podanych słów kluczowych.</target>
       </trans-unit>
       <trans-unit id="tl_module.fuzzy.0">
         <source>Fuzzy search</source>
@@ -231,7 +231,7 @@
       </trans-unit>
       <trans-unit id="tl_module.advanced.1">
         <source>Contains an input field and a radio button menu to choose the query type.</source>
-        <target>W zaawansowanym szukaniu możesz wybrać rodzaj zapytania jaki będzie używać wyszukiwarka.</target>
+        <target>W zaawansowanym szukaniu możesz wybrać rodzaj zapytania, jaki będzie używać wyszukiwarka.</target>
       </trans-unit>
       <trans-unit id="tl_module.contextLength.0">
         <source>Context range</source>
@@ -239,7 +239,7 @@
       </trans-unit>
       <trans-unit id="tl_module.contextLength.1">
         <source>The number of characters on the left and right side of each keyword that are used as context.</source>
-        <target>Wpisz ilość znaków jaka ma się pojawić po obu stronach każdego wyszukiwanego słowa. Pomaga to zrozumieć kontekst wyszukiwanej frazy.</target>
+        <target>Wpisz ilość znaków, jaka ma się pojawić po obu stronach każdego wyszukiwanego słowa. Pomaga to zrozumieć kontekst wyszukiwanej frazy.</target>
       </trans-unit>
       <trans-unit id="tl_module.totalLength.0">
         <source>Maximum context length</source>
@@ -271,7 +271,7 @@
       </trans-unit>
       <trans-unit id="tl_module.searchTpl.1">
         <source>Here you can select the search results template.</source>
-        <target>Wybierz szablon wyników wyszukiwania. Domyślnym szablonem jest &lt;em&gt;search_default&lt;/em&gt;. Jeśli chcesz dodać własny szablon, wgraj go do katalogu &lt;em&gt;templates&lt;/em&gt; (rozszerzenie pliku musi być &lt;em&gt;tpl&lt;/em&gt;).</target>
+        <target>Wybierz szablon wyników wyszukiwania. Domyślnym szablonem jest &lt;em&gt;search_default&lt;/em&gt;. Jeśli chcesz dodać własny szablon, wgraj go do katalogu &lt;em&gt;templates&lt;/em&gt; (rozszerzenie pliku musi być &lt;em&gt;html5&lt;/em&gt;).</target>
       </trans-unit>
       <trans-unit id="tl_module.inColumn.0">
         <source>Column</source>
@@ -283,11 +283,11 @@
       </trans-unit>
       <trans-unit id="tl_module.skipFirst.0">
         <source>Skip items</source>
-        <target>Pomiń pierwszy artykuł</target>
+        <target>Pomiń artykuły</target>
       </trans-unit>
       <trans-unit id="tl_module.skipFirst.1">
         <source>Here you can define how many items will be skipped.</source>
-        <target>Po wybieraniu tej opcji wykluczony z listy zostanie pierwszy artykuł.</target>
+        <target>Określ, ile artykułów ma zostać wykluczonych z listy.</target>
       </trans-unit>
       <trans-unit id="tl_module.loadFirst.0">
         <source>Load the first item</source>
@@ -295,7 +295,7 @@
       </trans-unit>
       <trans-unit id="tl_module.loadFirst.1">
         <source>Automatically redirect to the first item if none is selected.</source>
-        <target>Automatycznie przekieruj do pierwszego artykułu jeśli żaden nie został wybrany.</target>
+        <target>Automatycznie przekieruj do pierwszego artykułu, jeśli żaden nie został wybrany.</target>
       </trans-unit>
       <trans-unit id="tl_module.size.0">
         <source>Width and height</source>
@@ -311,7 +311,7 @@
       </trans-unit>
       <trans-unit id="tl_module.transparent.1">
         <source>Make the Flash movie transparent (wmode = transparent).</source>
-        <target>Wybierz tę opcję by wprowadzić przezroczystość do klipu Flash (wmode = transparent). Pamiętaj, że przyciski i pola tekstowe, w klipie Flash z włączoną przezroczystością, w niektórych przeglądarkach internetowych mogą nie działać poprawnie.</target>
+        <target>Wybierz tę opcję, aby wprowadzić przezroczystość do klipu Flash (wmode = transparent). Pamiętaj, że przyciski i pola tekstowe w klipie Flash z włączoną przezroczystością, w niektórych przeglądarkach internetowych mogą nie działać poprawnie.</target>
       </trans-unit>
       <trans-unit id="tl_module.flashvars.0">
         <source>FlashVars</source>
@@ -335,7 +335,7 @@
       </trans-unit>
       <trans-unit id="tl_module.altContent.1">
         <source>The alternate content will be shown if the movie cannot be loaded. HTML tags are allowed.</source>
-        <target>Wprowadź zastępczą zawartość, która zostanie wyświetlona jeśli z jakichś powodów klip Flash nie będzie mógł być załadowany. Tagi HTML są dozwolone.</target>
+        <target>Wprowadź zastępczą zawartość, która zostanie wyświetlona, jeśli z jakichś powodów klip Flash nie będzie mógł być załadowany. Tagi HTML są dozwolone.</target>
       </trans-unit>
       <trans-unit id="tl_module.source.0">
         <source>Source</source>
@@ -367,7 +367,7 @@
       </trans-unit>
       <trans-unit id="tl_module.interactive.1">
         <source>Make the Flash movie interact with the browser (requires JavaScript).</source>
-        <target>Wybierz tę opcję jeśli twój klip Flash wchodzi w interakcję z przeglądarką za pomocą JavaScript i funkcji Flash &lt;em&gt;fscommand()&lt;/em&gt;.</target>
+        <target>Wybierz tę opcję, jeśli twój klip Flash wchodzi w interakcję z przeglądarką za pomocą JavaScript i funkcji Flash &lt;em&gt;fscommand()&lt;/em&gt;.</target>
       </trans-unit>
       <trans-unit id="tl_module.flashID.0">
         <source>Flash movie ID</source>
@@ -383,7 +383,7 @@
       </trans-unit>
       <trans-unit id="tl_module.flashJS.1">
         <source>Please enter the JavaScript code.</source>
-        <target>Wprowadź zawartość funkcji JavaScript &lt;em&gt;_DoFSCommand()&lt;/em&gt;. Zmienna zawiera komendę &lt;em&gt;command&lt;/em&gt;, oraz argument &lt;em&gt;args&lt;/em&gt;.</target>
+        <target>Wprowadź zawartość funkcji JavaScript &lt;em&gt;_DoFSCommand()&lt;/em&gt;. Zmienna zawiera komendę &lt;em&gt;command&lt;/em&gt; oraz argument &lt;em&gt;args&lt;/em&gt;.</target>
       </trans-unit>
       <trans-unit id="tl_module.fullsize.0">
         <source>Full-size view/new window</source>
@@ -423,7 +423,7 @@
       </trans-unit>
       <trans-unit id="tl_module.orderSRC.1">
         <source>The sort order of the items.</source>
-        <target>Kolejność sortowania pozycji</target>
+        <target>Kolejność sortowania elementów</target>
       </trans-unit>
       <trans-unit id="tl_module.html.0">
         <source>HTML code</source>
@@ -439,7 +439,7 @@
       </trans-unit>
       <trans-unit id="tl_module.rss_cache.1">
         <source>Here you can define how long the RSS feed is being cached.</source>
-        <target>Tutaj możesz zdefiniować okres czasu przez jaki kanał RSS będzie przechowywany w pamięci podręcznej.</target>
+        <target>Tutaj możesz zdefiniować czas, przez jaki kanał RSS będzie przechowywany w pamięci podręcznej.</target>
       </trans-unit>
       <trans-unit id="tl_module.rss_feed.0">
         <source>Feed URLs</source>
@@ -455,7 +455,7 @@
       </trans-unit>
       <trans-unit id="tl_module.rss_template.1">
         <source>Here you can select the feed template.</source>
-        <target>Wybierz szablon układ graficznego. Własne szablony można zapisać do katalogu &lt;em&gt;templates&lt;/em&gt;. Pliki szablonów muszą zaczynać się &lt;em&gt;rss_&lt;/em&gt; a kończyć &lt;em&gt;.tpl&lt;/em&gt;.</target>
+        <target>Wybierz szablon układ graficznego. Własne szablony można zapisać do katalogu &lt;em&gt;templates&lt;/em&gt;. Pliki szablonów muszą zaczynać się &lt;em&gt;rss_&lt;/em&gt; a kończyć &lt;em&gt;.html5&lt;/em&gt;.</target>
       </trans-unit>
       <trans-unit id="tl_module.numberOfItems.0">
         <source>Number of items</source>
@@ -475,7 +475,7 @@
       </trans-unit>
       <trans-unit id="tl_module.groups.0">
         <source>Allowed member groups</source>
-        <target>Zezwolone grupy użytkowników</target>
+        <target>Dozwolone grupy użytkowników</target>
       </trans-unit>
       <trans-unit id="tl_module.groups.1">
         <source>These groups will be able to see the module.</source>
@@ -487,7 +487,7 @@
       </trans-unit>
       <trans-unit id="tl_module.guests.1">
         <source>Hide the module if a member is logged in.</source>
-        <target>Ukryj ten moduł jeśli użytkownik jest zalogowany.</target>
+        <target>Ukryj ten moduł, jeśli użytkownik jest zalogowany.</target>
       </trans-unit>
       <trans-unit id="tl_module.cssID.0">
         <source>CSS ID/class</source>
@@ -527,7 +527,7 @@
       </trans-unit>
       <trans-unit id="tl_module.reg_skipName.1">
         <source>Do not require the username to request a new password.</source>
-        <target>Nie wymagaj nazwy użytkownika podczas zgłoszenia o nowe hasło.</target>
+        <target>Nie wymagaj nazwy użytkownika podczas żądania nowego hasła.</target>
       </trans-unit>
       <trans-unit id="tl_module.reg_close.0">
         <source>Mode</source>
@@ -543,7 +543,7 @@
       </trans-unit>
       <trans-unit id="tl_module.reg_assignDir.1">
         <source>Create a home directory from the registered username.</source>
-        <target>Wybierz tę opcję aby automatycznie założyć katalog użytkownika.</target>
+        <target>Wybierz tę opcję, aby automatycznie założyć katalog użytkownika.</target>
       </trans-unit>
       <trans-unit id="tl_module.reg_homeDir.0">
         <source>Home directory path</source>
@@ -559,7 +559,7 @@
       </trans-unit>
       <trans-unit id="tl_module.reg_activate.1">
         <source>Send an activation e-mail to the registered e-mail address.</source>
-        <target>Wybierz tę opcję aby wysłać do rejestrującego się użytkownika e-maila z aktywacją konta.</target>
+        <target>Wybierz tę opcję, aby wysłać do rejestrującego się użytkownika e-maila z aktywacją konta.</target>
       </trans-unit>
       <trans-unit id="tl_module.reg_jumpTo.0">
         <source>Confirmation page</source>
@@ -654,7 +654,7 @@
 
 Please click ##link## to complete your registration and to activate your account. If you did not request an account, please ignore this e-mail.
 </source>
-        <target>Dziękujemy za rejestrację w serwisie ##domain##. Kliknij na ten link: ##link## aby dokończyć procedurę rejestracji i aktywować swoje konto. Jeśli nie zakładałeś konta w naszym serwisie, prosimy o zignorowanie tego maila.</target>
+        <target>Dziękujemy za rejestrację w serwisie ##domain##. Kliknij na ten link ##link##, aby dokończyć procedurę rejestracji i aktywować swoje konto. Jeśli nie zakładałeś konta w naszym serwisie, prosimy o zignorowanie tego maila.</target>
       </trans-unit>
       <trans-unit id="tl_module.passwordText.0">
         <source>Your password request on %s</source>
@@ -665,15 +665,15 @@ Please click ##link## to complete your registration and to activate your account
 
 Please click ##link## to set the new password. If you did not request this e-mail, please contact the website administrator.
 </source>
-        <target>Zgłaszałeś prośbę o nowe hasło do serwisu ##domain##. Kliknij ten link: ##link## i wpisz nowe hasło. Jeśli nie wysyłałeś takiej prośby, prosimy skontaktować sie z administratorem serwisu.</target>
+        <target>Zgłaszałeś prośbę o nowe hasło do serwisu ##domain##. Kliknij ten link ##link## i wpisz nowe hasło. Jeśli nie wysyłałeś takiej prośby, prosimy skontaktować sie z administratorem serwisu.</target>
       </trans-unit>
       <trans-unit id="tl_module.internal">
         <source>Internal file</source>
-        <target>wewnętrzny plik</target>
+        <target>Wewnętrzny plik</target>
       </trans-unit>
       <trans-unit id="tl_module.external">
         <source>External URL</source>
-        <target>zewnętrzny URL</target>
+        <target>Zewnętrzny URL</target>
       </trans-unit>
       <trans-unit id="tl_module.close_deactivate">
         <source>Deactivate account</source>

--- a/core-bundle/src/Resources/contao/languages/pl/tl_page.xlf
+++ b/core-bundle/src/Resources/contao/languages/pl/tl_page.xlf
@@ -7,7 +7,7 @@
       </trans-unit>
       <trans-unit id="tl_page.title.1">
         <source>Please enter the page name.</source>
-        <target>Nazwa strony wyświetla się w nawigacji. Nie powinien zawierać więcej niż 65 znaków.</target>
+        <target>Nazwa strony wyświetla się w nawigacji. Nie powinna zawierać więcej niż 65 znaków.</target>
       </trans-unit>
       <trans-unit id="tl_page.alias.0">
         <source>Page alias</source>
@@ -23,7 +23,7 @@
       </trans-unit>
       <trans-unit id="tl_page.type.1">
         <source>Please choose the page type.</source>
-        <target>Wybierz typ strony zależnie od jej przeznaczenia.</target>
+        <target>Wybierz typ strony, zależnie od jej przeznaczenia.</target>
       </trans-unit>
       <trans-unit id="tl_page.pageTitle.0">
         <source>Page title</source>
@@ -47,7 +47,7 @@
       </trans-unit>
       <trans-unit id="tl_page.robots.1">
         <source>Here you can define how search engines handle the page.</source>
-        <target>Tutaj możesz zdefiniować jak wyszukiwarki mają interpretować Twoją stronę.</target>
+        <target>Tutaj możesz zdefiniować, jak wyszukiwarki mają interpretować Twoją stronę.</target>
       </trans-unit>
       <trans-unit id="tl_page.description.0">
         <source>Page description</source>
@@ -79,7 +79,7 @@
       </trans-unit>
       <trans-unit id="tl_page.redirectBack.1">
         <source>Redirect the member back to the last page visited instead of the redirect page.</source>
-        <target>Przekieruj użytkownika z powrotem do ostatnio odwiedzanej strony zamiast do określonej strony docelowej.</target>
+        <target>Przekieruj użytkownika z powrotem do ostatnio odwiedzanej strony, zamiast do określonej strony docelowej.</target>
       </trans-unit>
       <trans-unit id="tl_page.fallback.0">
         <source>Language fallback</source>
@@ -95,7 +95,7 @@
       </trans-unit>
       <trans-unit id="tl_page.dns.1">
         <source>Here you can restrict the access to the website to a certain domain name.</source>
-        <target>Jeśli przypiszesz nazwę domenę do punktu startowego, odwiedzający będą przekierowani do tej strony dopiero wtedy kiedy wpiszą odpowiedni adres domeny (np. &lt;em&gt;twojadomena.pl&lt;/em&gt; lub &lt;em&gt;subdomena.twojadomena.pl&lt;/em&gt;).</target>
+        <target>Jeśli przypiszesz nazwę domenę do punktu startowego, odwiedzający będą przekierowani do tej strony dopiero wtedy, kiedy wpiszą odpowiedni adres domeny (np. &lt;em&gt;twojadomena.pl&lt;/em&gt; lub &lt;em&gt;subdomena.twojadomena.pl&lt;/em&gt;).</target>
       </trans-unit>
       <trans-unit id="tl_page.adminEmail.0">
         <source>E-mail address of the website administrator</source>
@@ -103,6 +103,7 @@
       </trans-unit>
       <trans-unit id="tl_page.adminEmail.1">
         <source>This e-mail address will be used to send and receive system messages.</source>
+        <target>Ten adres e-mail zostanie użyty do wysyłania i odbierania wiadomości systemowych.</target>
       </trans-unit>
       <trans-unit id="tl_page.dateFormat.0">
         <source>Date format</source>
@@ -110,7 +111,7 @@
       </trans-unit>
       <trans-unit id="tl_page.dateFormat.1">
         <source>The date format string will be parsed with the PHP date() function.</source>
-        <target>Wprowadź format daty obsługiwany przez funkcję PHP function date().</target>
+        <target>Wprowadź format daty obsługiwany przez funkcję PHP date().</target>
       </trans-unit>
       <trans-unit id="tl_page.timeFormat.0">
         <source>Time format</source>
@@ -118,7 +119,7 @@
       </trans-unit>
       <trans-unit id="tl_page.timeFormat.1">
         <source>The time format string will be parsed with the PHP date() function.</source>
-        <target>Wprowadź format czasu obsługiwany przez funkcję PHP function date().</target>
+        <target>Wprowadź format czasu obsługiwany przez funkcję PHP date().</target>
       </trans-unit>
       <trans-unit id="tl_page.datimFormat.0">
         <source>Date and time format</source>
@@ -126,7 +127,7 @@
       </trans-unit>
       <trans-unit id="tl_page.datimFormat.1">
         <source>The date and time format string will be parsed with the PHP date() function.</source>
-        <target>Wprowadź format daty i czasu obsługiwany przez funkcję PHP function date().</target>
+        <target>Wprowadź format daty i czasu obsługiwany przez funkcję PHP date().</target>
       </trans-unit>
       <trans-unit id="tl_page.createSitemap.0">
         <source>Create an XML sitemap</source>
@@ -158,7 +159,7 @@
       </trans-unit>
       <trans-unit id="tl_page.autoforward.1">
         <source>Redirect visitors to another page (e.g. a login page).</source>
-        <target>Jeśli wybierzesz tą opcję, odwiedzający będą przekierowywani do innej strony (np. strony logowania lub strony powitalnej).</target>
+        <target>Jeśli wybierzesz tę opcję, odwiedzający będą przekierowywani do innej strony (np. strony logowania lub strony powitalnej).</target>
       </trans-unit>
       <trans-unit id="tl_page.protected.0">
         <source>Protect page</source>
@@ -166,11 +167,11 @@
       </trans-unit>
       <trans-unit id="tl_page.protected.1">
         <source>Restrict page access to certain member groups.</source>
-        <target>Jeśli wybierzesz tą opcję możesz ograniczyć dostęp do strony dla pewnych grup.</target>
+        <target>Jeśli wybierzesz tę opcję, możesz ograniczyć dostęp do strony dla pewnych grup.</target>
       </trans-unit>
       <trans-unit id="tl_page.groups.0">
         <source>Allowed member groups</source>
-        <target>Zezwolone grupy użytkowników</target>
+        <target>Dozwolone grupy użytkowników</target>
       </trans-unit>
       <trans-unit id="tl_page.groups.1">
         <source>These groups will be able to access the page.</source>
@@ -178,19 +179,19 @@
       </trans-unit>
       <trans-unit id="tl_page.includeLayout.0">
         <source>Assign a layout</source>
-        <target>Ustal szablon</target>
+        <target>Ustal układ</target>
       </trans-unit>
       <trans-unit id="tl_page.includeLayout.1">
         <source>Assign a page layout to the page and its subpages.</source>
-        <target>Domyślnie strona używa takiego samego szablonu jak strona nadrzędna. Jeśli wybierzesz tą opcję, możesz ustalić nowy szablon dla tej strony jak i jej podstron.</target>
+        <target>Domyślnie strona używa takiego samego układu jak strona nadrzędna. Jeśli wybierzesz tę opcję, możesz ustalić nowy układ dla tej strony jak i jej podstron.</target>
       </trans-unit>
       <trans-unit id="tl_page.layout.0">
         <source>Page layout</source>
-        <target>Szablon strony</target>
+        <target>Układ strony</target>
       </trans-unit>
       <trans-unit id="tl_page.layout.1">
         <source>You can manage page layouts with the &quot;themes&quot; module.</source>
-        <target>Wybierz szablon strony. Możesz edytować lub tworzyć szablony używając modułu &lt;em&gt;szablony strony&lt;/em&gt;.</target>
+        <target>Wybierz układ strony. Możesz edytować lub tworzyć układy używając modułu &lt;em&gt;Układy stron&lt;/em&gt;.</target>
       </trans-unit>
       <trans-unit id="tl_page.mobileLayout.0">
         <source>Mobile page layout</source>
@@ -214,7 +215,7 @@
       </trans-unit>
       <trans-unit id="tl_page.cache.1">
         <source>The number of seconds after which the page should no longer be considered fresh by shared caches.</source>
-        <target>Liczba sekund, po której strona przestanie być uznawana jako &quot;świeża&quot; przez pamięć podręczną.</target>
+        <target>Liczba sekund, po których strona przestanie być uznawana jako &quot;świeża&quot; przez pamięć podręczną.</target>
       </trans-unit>
       <trans-unit id="tl_page.clientCache.0">
         <source>Client cache timeout</source>
@@ -222,7 +223,7 @@
       </trans-unit>
       <trans-unit id="tl_page.clientCache.1">
         <source>The number of seconds after which the page should no longer be considered fresh by the browser.</source>
-        <target>Liczba sekund, po której strona przestanie być uznawana jako &quot;świeża&quot; przez przeglądarkę.</target>
+        <target>Liczba sekund, po których strona przestanie być uznawana jako &quot;świeża&quot; przez przeglądarkę.</target>
       </trans-unit>
       <trans-unit id="tl_page.includeChmod.0">
         <source>Assign access rights</source>
@@ -230,11 +231,11 @@
       </trans-unit>
       <trans-unit id="tl_page.includeChmod.1">
         <source>Access rights determine what back end users can do with the page.</source>
-        <target>Zezwolenia pozwalają określić do jakiego obrębu użytkownik może modyfikować stronę i jej artykuły. Jeśli nie wybierzesz tej opcji, strona używa tych samych zezwoleń co strona .</target>
+        <target>Zezwolenia pozwalają określić, jak użytkownik może modyfikować stronę i jej artykuły. Jeśli nie wybierzesz tej opcji, strona będzie używać tych samych zezwoleń co strona nadrzędna.</target>
       </trans-unit>
       <trans-unit id="tl_page.cuser.0">
         <source>Owner</source>
-        <target>Użytkownik</target>
+        <target>Właściciel</target>
       </trans-unit>
       <trans-unit id="tl_page.cuser.1">
         <source>Please select a user as the owner of the page.</source>
@@ -254,7 +255,7 @@
       </trans-unit>
       <trans-unit id="tl_page.chmod.1">
         <source>Please assign the access rights for the page and its subpages.</source>
-        <target>Każda strona ma 3 poziomy dostępu: jeden dla użytkownika, jeden dla grupy i jeden dla kogokolwiek innego. Możesz ustalić różne zezwolenia dla każdego poziomu.</target>
+        <target>Każda strona ma 3 poziomy dostępu: jeden dla użytkownika, jeden dla grupy i jeden dla wszystkich pozostałych. Możesz ustalić różne zezwolenia dla każdego poziomu.</target>
       </trans-unit>
       <trans-unit id="tl_page.noSearch.0">
         <source>Do not search</source>
@@ -310,7 +311,7 @@
       </trans-unit>
       <trans-unit id="tl_page.accesskey.1">
         <source>A navigation item can be focused by pressing the [ALT] or [CTRL] key and the access key simultaneously.</source>
-        <target>Klawisz dostępu jest pojedynczym znakiem, który może być przypisany to elementu nawigacji. Jeśli odwiedzający jednocześnie wciśnie klawisz ALT i klucz dostępu (np. literę A), element nawigacji uaktywni się tak samo jak po kliknięciu.</target>
+        <target>Klawisz dostępu jest pojedynczym znakiem, który może być przypisany to elementu nawigacji. Jeśli odwiedzający jednocześnie wciśnie klawisz ALT i klawisz dostępu (np. literę A), element nawigacji uaktywni się tak samo jak po kliknięciu.</target>
       </trans-unit>
       <trans-unit id="tl_page.published.0">
         <source>Publish page</source>
@@ -322,7 +323,7 @@
       </trans-unit>
       <trans-unit id="tl_page.start.0">
         <source>Show from</source>
-        <target>Wrapper start</target>
+        <target>Pokaż od</target>
       </trans-unit>
       <trans-unit id="tl_page.start.1">
         <source>Do not show the page on the website before this day.</source>
@@ -330,7 +331,7 @@
       </trans-unit>
       <trans-unit id="tl_page.stop.0">
         <source>Show until</source>
-        <target>Wrapper stop</target>
+        <target>Pokaż do</target>
       </trans-unit>
       <trans-unit id="tl_page.stop.1">
         <source>Do not show the page on the website on and after this day.</source>
@@ -402,7 +403,7 @@
       </trans-unit>
       <trans-unit id="tl_page.publish_legend">
         <source>Publish settings</source>
-        <target>Ustawinia publikacji</target>
+        <target>Ustawienia publikacji</target>
       </trans-unit>
       <trans-unit id="tl_page.permanent">
         <source>301 Permanent redirect</source>
@@ -442,7 +443,7 @@
       </trans-unit>
       <trans-unit id="tl_page.edit.0">
         <source>Edit page</source>
-        <target>Edytuj strone</target>
+        <target>Edytuj stronę</target>
       </trans-unit>
       <trans-unit id="tl_page.edit.1">
         <source>Edit page ID %s</source>
@@ -474,7 +475,7 @@
       </trans-unit>
       <trans-unit id="tl_page.delete.0">
         <source>Delete page</source>
-        <target>Skasuj strone</target>
+        <target>Skasuj stronę</target>
       </trans-unit>
       <trans-unit id="tl_page.delete.1">
         <source>Delete page ID %s</source>
@@ -490,7 +491,7 @@
       </trans-unit>
       <trans-unit id="tl_page.pasteafter.0">
         <source>Paste after</source>
-        <target>Wklej z</target>
+        <target>Wklej po</target>
       </trans-unit>
       <trans-unit id="tl_page.pasteafter.1">
         <source>Paste after page ID %s</source>

--- a/core-bundle/src/Resources/contao/languages/pl/tl_settings.xlf
+++ b/core-bundle/src/Resources/contao/languages/pl/tl_settings.xlf
@@ -15,6 +15,7 @@
       </trans-unit>
       <trans-unit id="tl_settings.adminEmail.1">
         <source>This e-mail address will be used to send and receive system messages.</source>
+        <target>Ten adres e-mail zostanie użyty do wysyłania i odbierania wiadomości systemowych.</target>
       </trans-unit>
       <trans-unit id="tl_settings.dateFormat.0">
         <source>Date format</source>
@@ -22,7 +23,7 @@
       </trans-unit>
       <trans-unit id="tl_settings.dateFormat.1">
         <source>The date format string will be parsed with the PHP date() function.</source>
-        <target>Wprowadź format daty obsługiwany przez funkcję PHP function date().</target>
+        <target>Wprowadź format daty obsługiwany przez funkcję PHP date().</target>
       </trans-unit>
       <trans-unit id="tl_settings.timeFormat.0">
         <source>Time format</source>
@@ -30,7 +31,7 @@
       </trans-unit>
       <trans-unit id="tl_settings.timeFormat.1">
         <source>The time format string will be parsed with the PHP date() function.</source>
-        <target>Wprowadź format czasu obsługiwany przez funkcję PHP function date().</target>
+        <target>Wprowadź format czasu obsługiwany przez funkcję PHP date().</target>
       </trans-unit>
       <trans-unit id="tl_settings.datimFormat.0">
         <source>Date and time format</source>
@@ -38,7 +39,7 @@
       </trans-unit>
       <trans-unit id="tl_settings.datimFormat.1">
         <source>The date and time format string will be parsed with the PHP date() function.</source>
-        <target>Wprowadź format daty i czasu obsługiwany przez funkcję PHP function date().</target>
+        <target>Wprowadź format daty i czasu obsługiwany przez funkcję PHP date().</target>
       </trans-unit>
       <trans-unit id="tl_settings.timeZone.0">
         <source>Time zone</source>
@@ -50,11 +51,11 @@
       </trans-unit>
       <trans-unit id="tl_settings.characterSet.0">
         <source>Character set</source>
-        <target>Kodowania znaków dla Contao</target>
+        <target>Kodowanie znaków dla Contao</target>
       </trans-unit>
       <trans-unit id="tl_settings.characterSet.1">
         <source>It is recommended to use UTF-8, so special characters are displayed correctly.</source>
-        <target>Wpisz rodzaj kodowania znaków. Rekomendowane jest używanie UTF-8, zapewnia to poprawne wyświetlanie znaków specjalnych np. diakrytycznych.</target>
+        <target>Wpisz rodzaj kodowania znaków. Rekomendowane jest używanie UTF-8, zapewnia to poprawne wyświetlanie znaków specjalnych, np. diakrytycznych.</target>
       </trans-unit>
       <trans-unit id="tl_settings.disableCron.0">
         <source>Disable the command scheduler</source>
@@ -70,7 +71,7 @@
       </trans-unit>
       <trans-unit id="tl_settings.minifyMarkup.1">
         <source>Minify the HTML markup before it is sent to the browser.</source>
-        <target>Minimalizuj kod źródłowy HTML zanim zostanie wysłany do przeglądarki.</target>
+        <target>Minimalizuj kod źródłowy HTML, zanim zostanie wysłany do przeglądarki.</target>
       </trans-unit>
       <trans-unit id="tl_settings.gzipScripts.0">
         <source>Compress scripts</source>
@@ -86,7 +87,7 @@
       </trans-unit>
       <trans-unit id="tl_settings.resultsPerPage.1">
         <source>Here you can define the number of items per page in the back end.</source>
-        <target>Ilość wyników na stronie jest używana do ograniczenia wyników zapytań w admin panelu, nie dotyczy to wyszukiwarki.</target>
+        <target>Ilość wyników na stronie jest używana do ograniczenia wyników zapytań w admin panelu; nie dotyczy to wyszukiwarki.</target>
       </trans-unit>
       <trans-unit id="tl_settings.maxResultsPerPage.0">
         <source>Maximum items per page</source>
@@ -94,7 +95,7 @@
       </trans-unit>
       <trans-unit id="tl_settings.maxResultsPerPage.1">
         <source>This overall limit takes effect if a user chooses the &quot;show all records&quot; option.</source>
-        <target>Ta opcja ustala maksymalną ilość wyświetlanych rekordów w panelu jeśli użytkownik wybierze opcję &quot;Pokaż wszystkie rekordy&quot;.</target>
+        <target>Ta opcja ustala maksymalną ilość wyświetlanych rekordów w panelu, jeśli użytkownik wybierze opcję &quot;Pokaż wszystkie rekordy&quot;.</target>
       </trans-unit>
       <trans-unit id="tl_settings.fileSyncExclude.0">
         <source>Exclude folders from synchronization</source>
@@ -126,7 +127,7 @@
       </trans-unit>
       <trans-unit id="tl_settings.privacyAnonymizeIp.1">
         <source>Anonymize any IP address that is stored in the database, except in the &lt;em&gt;tl_session&lt;/em&gt; table (the IP address is bound to the session for security reasons).</source>
-        <target>Anonimizuj każdy adres IP, który jest przechowywane w bazie danych, z wyjątkiem tych w tabeli &lt;em&gt;tl_session&lt;/em&gt; (adres IP jest przypisany do sesji ze względów bezpieczeństwa).</target>
+        <target>Anonimizuj każdy adres IP, który jest przechowywany w bazie danych, z wyjątkiem tych w tabeli &lt;em&gt;tl_session&lt;/em&gt; (adres IP jest przypisany do sesji ze względów bezpieczeństwa).</target>
       </trans-unit>
       <trans-unit id="tl_settings.privacyAnonymizeGA.0">
         <source>Anonymize Google Analytics</source>
@@ -158,7 +159,7 @@
       </trans-unit>
       <trans-unit id="tl_settings.folderUrl.1">
         <source>Here you can enable folder-style page aliases like &lt;em&gt;docs/install/download.html&lt;/em&gt; instead of &lt;em&gt;docs-install-download.html&lt;/em&gt;.</source>
-        <target>Tutaj możesz włączyć folderowy styl aliasów stron jak na przykład &lt;em&gt;docs/install/downloads.html&lt;/em&gt; zamiast &lt;em&gt;docs-install-download.html&lt;/em&gt;.</target>
+        <target>Tutaj możesz włączyć folderowy styl aliasów stron, np. &lt;em&gt;docs/install/downloads.html&lt;/em&gt; zamiast &lt;em&gt;docs-install-download.html&lt;/em&gt;.</target>
       </trans-unit>
       <trans-unit id="tl_settings.allowedTags.0">
         <source>Allowed HTML tags</source>
@@ -214,7 +215,7 @@
       </trans-unit>
       <trans-unit id="tl_settings.maxImageWidth.1">
         <source>If the width of an image or movie exceeds this value, it will be adjusted automatically. Set to 0 to disable the limit.</source>
-        <target>Jeśli szerokość obrazka lub filmu przekroczy tą wartość, element zostanie automatycznie dostosowany. Wprowadź 0, aby wyłączyć limit.</target>
+        <target>Jeśli szerokość obrazka lub filmu przekroczy tę wartość, element zostanie automatycznie dostosowany. Wprowadź 0, aby wyłączyć limit.</target>
       </trans-unit>
       <trans-unit id="tl_settings.gdMaxImgWidth.0">
         <source>Maximum GD image width</source>
@@ -222,7 +223,7 @@
       </trans-unit>
       <trans-unit id="tl_settings.gdMaxImgWidth.1">
         <source>Here you can enter the maximum image width that the GD library shall try to handle.</source>
-        <target>Wprowadź maksymalną długość dla obrazka, którą biblioteka GD postara się ujarzmić.</target>
+        <target>Wprowadź maksymalną długość dla obrazka, którą biblioteka GD powinna przetworzyć.</target>
       </trans-unit>
       <trans-unit id="tl_settings.gdMaxImgHeight.0">
         <source>Maximum GD image height</source>
@@ -230,7 +231,7 @@
       </trans-unit>
       <trans-unit id="tl_settings.gdMaxImgHeight.1">
         <source>Here you can enter the maximum image height that the GD library shall try to handle.</source>
-        <target>Wprowadź maksymalną wysokość dla obrazka, którą biblioteka GD postara się ujarzmić.</target>
+        <target>Wprowadź maksymalną wysokość dla obrazka, którą biblioteka GD powinna przetworzyć.</target>
       </trans-unit>
       <trans-unit id="tl_settings.uploadTypes.0">
         <source>Upload file types</source>
@@ -238,7 +239,7 @@
       </trans-unit>
       <trans-unit id="tl_settings.uploadTypes.1">
         <source>Here you can enter a comma separated list of uploadable file types.</source>
-        <target>Wprowadź oddzielone przecinkami rozszerzenia plików, które mogą być wysyłane na serwer. Z przyczyn bezpieczeństwa pobieranie plików ograniczone jest do katalogu &quot;tl_files&quot; i jego podkatalogów.</target>
+        <target>Wprowadź oddzielone przecinkami rozszerzenia plików, które mogą być wysyłane na serwer. Z przyczyn bezpieczeństwa wysyłanie plików ograniczone jest do katalogu &quot;tl_files&quot; i jego podkatalogów.</target>
       </trans-unit>
       <trans-unit id="tl_settings.maxFileSize.0">
         <source>Maximum upload file size</source>
@@ -254,7 +255,7 @@
       </trans-unit>
       <trans-unit id="tl_settings.imageWidth.1">
         <source>Here you can enter the maximum width for image uploads in pixels.</source>
-        <target>Wprowadź maksymalną szerokość wysyłanego obrazka w pikslach.</target>
+        <target>Wprowadź maksymalną szerokość wysyłanego obrazka w pikselach.</target>
       </trans-unit>
       <trans-unit id="tl_settings.imageHeight.0">
         <source>Maximum image height</source>
@@ -262,7 +263,7 @@
       </trans-unit>
       <trans-unit id="tl_settings.imageHeight.1">
         <source>Here you can enter the maximum height for image uploads in pixels.</source>
-        <target>Wprowadź maksymalną wysokość wysyłanego obrazka w pikslach.</target>
+        <target>Wprowadź maksymalną wysokość wysyłanego obrazka w pikselach.</target>
       </trans-unit>
       <trans-unit id="tl_settings.enableSearch.0">
         <source>Enable searching</source>
@@ -278,7 +279,7 @@
       </trans-unit>
       <trans-unit id="tl_settings.indexProtected.1">
         <source>Use this option carefully and always exclude personalized pages from being indexed!</source>
-        <target>Używaj tej opcji z rozwagą i zawsze wykluczaj strony spersonalizowane lub prywatne z indeksowania!</target>
+        <target>Używaj tej opcji z rozwagą i zawsze wykluczaj z indeksowania strony spersonalizowane lub prywatne!</target>
       </trans-unit>
       <trans-unit id="tl_settings.undoPeriod.0">
         <source>Storage time for undo steps</source>
@@ -302,7 +303,7 @@
       </trans-unit>
       <trans-unit id="tl_settings.logPeriod.1">
         <source>Here you can enter the storage time for log entries in seconds (14 days = 1209600 seconds).</source>
-        <target>Wprowadź czas (w sekundach) przez jaki przechowywane będą logi systemowe (domyślnie: 14 dni = 1209600 sekund).</target>
+        <target>Wprowadź czas (w sekundach), przez jaki przechowywane będą logi systemowe (domyślnie: 14 dni = 1209600 sekund).</target>
       </trans-unit>
       <trans-unit id="tl_settings.sessionTimeout.0">
         <source>Session timeout</source>

--- a/core-bundle/src/Resources/contao/languages/pl/tl_style.xlf
+++ b/core-bundle/src/Resources/contao/languages/pl/tl_style.xlf
@@ -15,7 +15,7 @@
       </trans-unit>
       <trans-unit id="tl_style.selector.1">
         <source>The selector defines to which element(s) the format definition applies.</source>
-        <target>Selektor definiuje do jakiego elementu HTML lub to jakiej grupy elementów stosuje się format definicji. Możesz wprowadzić jeden lub więcej - oddzielonych przecinkami - selektorów.</target>
+        <target>Selektor definiuje, do jakiego elementu HTML lub do jakiej grupy elementów stosuje się definicja formatu. Możesz wprowadzić jeden lub więcej - oddzielonych przecinkami - selektorów.</target>
       </trans-unit>
       <trans-unit id="tl_style.category.0">
         <source>Category</source>
@@ -23,7 +23,7 @@
       </trans-unit>
       <trans-unit id="tl_style.category.1">
         <source>Categories can be used to group format definitions in the back end.</source>
-        <target>Np. wybierasz &quot;nawigacja&quot; a system pokazuje ci tylko te klasy css, które obsługują nawigację.</target>
+        <target>Np. wybierasz &quot;nawigacja&quot;, a system pokazuje ci tylko te klasy css, które obsługują nawigację.</target>
       </trans-unit>
       <trans-unit id="tl_style.comment.0">
         <source>Comment</source>
@@ -31,7 +31,7 @@
       </trans-unit>
       <trans-unit id="tl_style.comment.1">
         <source>Here you can add a comment.</source>
-        <target>Komentarze będą pokazywane powyżej przekazaniu formatu definicji.</target>
+        <target>Komentarze będą pokazywane powyżej definicji formatu.</target>
       </trans-unit>
       <trans-unit id="tl_style.size.0">
         <source>Size</source>
@@ -167,7 +167,7 @@
       </trans-unit>
       <trans-unit id="tl_style.padding.1">
         <source>Here you can enter the top, right, bottom and left padding.</source>
-        <target>Wprowadź dopełnienie kolejno od: góry, prawej strony, dołu, lewej strony; oraz wybierz jednostkę. Dopełnienie to dystans pomiędzy zawartością elementu i jego obramowaniem.</target>
+        <target>Wprowadź dopełnienie kolejno od: góry, prawej strony, dołu, lewej strony; oraz wybierz jednostkę. Dopełnienie, to dystans pomiędzy zawartością elementu i jego obramowaniem.</target>
       </trans-unit>
       <trans-unit id="tl_style.align.0">
         <source>Element alignment</source>
@@ -175,7 +175,7 @@
       </trans-unit>
       <trans-unit id="tl_style.align.1">
         <source>To align an element, its left and right margin will be overwritten.</source>
-        <target>Podczas wyrównywania elementu jego ustawienia marginesów zostaną zmienione.</target>
+        <target>Podczas wyrównywania elementu, jego ustawienia marginesów zostaną zmienione.</target>
       </trans-unit>
       <trans-unit id="tl_style.verticalalign.0">
         <source>Vertical alignment</source>
@@ -211,7 +211,7 @@
       </trans-unit>
       <trans-unit id="tl_style.bgcolor.0">
         <source>Background color and opacity</source>
-        <target>Kolor tła</target>
+        <target>Kolor tła i przezroczystość</target>
       </trans-unit>
       <trans-unit id="tl_style.bgcolor.1">
         <source>Here you can enter a hexadecimal background color (e.g. ff0000 for red) and an optional opacity in percent (e.g. 75).</source>
@@ -319,7 +319,7 @@
       </trans-unit>
       <trans-unit id="tl_style.bordercollapse.1">
         <source>Here you can choose the border handling.</source>
-        <target>Określ czy obramowanie sąsiadujących komórek tabeli ma być wyświetlane jako jedno obramowanie czy jako dwa oddzielne.</target>
+        <target>Określ czy obramowanie sąsiadujących komórek tabeli ma być wyświetlane, jako jedno obramowanie czy jako dwa oddzielne.</target>
       </trans-unit>
       <trans-unit id="tl_style.borderspacing.0">
         <source>Border spacing</source>
@@ -343,7 +343,7 @@
       </trans-unit>
       <trans-unit id="tl_style.fontfamily.1">
         <source>Here you can enter a comma separated list of font types.</source>
-        <target>Wporwadź typy czcionek oddzielone od siebie przecinkami (np. Arial,Helvetica). Użyj znaków cudzysłowia jeśli nazwa czcionki zawiera puste pola (spacje) i dostarcza co najmniej jednej ogólnej czcionki rodzinnej (font family), np. &lt;em&gt;sans-serif&lt;/em&gt;.</target>
+        <target>Wporwadź typy czcionek oddzielone od siebie przecinkami (np. Arial,Helvetica). Użyj znaków cudzysłowu, jeśli nazwa czcionki zawiera puste pola (spacje) i dostarcza co najmniej jedną ogólną rodzinę czcionek (font family), np. &lt;em&gt;sans-serif&lt;/em&gt;.</target>
       </trans-unit>
       <trans-unit id="tl_style.fontsize.0">
         <source>Font size</source>
@@ -455,7 +455,7 @@
       </trans-unit>
       <trans-unit id="tl_style.align_legend">
         <source>Margin and alignment</source>
-        <target>margines i wyrównanie</target>
+        <target>Margines i wyrównanie</target>
       </trans-unit>
       <trans-unit id="tl_style.background_legend">
         <source>Background settings</source>
@@ -615,11 +615,11 @@
       </trans-unit>
       <trans-unit id="tl_style.pasteafter.0">
         <source>Paste at the top</source>
-        <target>Wstaw na początku</target>
+        <target>Wklej na początku</target>
       </trans-unit>
       <trans-unit id="tl_style.pasteafter.1">
         <source>Paste after format definition ID %s</source>
-        <target>Wstaw pod elementem arkusza ID %s</target>
+        <target>Wklej pod elementem arkusza ID %s</target>
       </trans-unit>
       <trans-unit id="tl_style.pastenew.0">
         <source>Add new at the top</source>

--- a/core-bundle/src/Resources/contao/languages/pl/tl_style_sheet.xlf
+++ b/core-bundle/src/Resources/contao/languages/pl/tl_style_sheet.xlf
@@ -3,7 +3,7 @@
     <body>
       <trans-unit id="tl_style_sheet.name.0">
         <source>Name</source>
-        <target>Nazwa wyświetlana</target>
+        <target>Nazwa</target>
       </trans-unit>
       <trans-unit id="tl_style_sheet.name.1">
         <source>Please enter the style sheet name.</source>
@@ -67,7 +67,7 @@
       </trans-unit>
       <trans-unit id="tl_style_sheet.title_legend">
         <source>Name</source>
-        <target>Nazwa wyświetlana</target>
+        <target>Nazwa</target>
       </trans-unit>
       <trans-unit id="tl_style_sheet.expert_legend">
         <source>Expert settings</source>

--- a/core-bundle/src/Resources/contao/languages/pl/tl_style_sheet.xlf
+++ b/core-bundle/src/Resources/contao/languages/pl/tl_style_sheet.xlf
@@ -3,7 +3,7 @@
     <body>
       <trans-unit id="tl_style_sheet.name.0">
         <source>Name</source>
-        <target>Imię i nazwisko</target>
+        <target>Nazwa wyświetlana</target>
       </trans-unit>
       <trans-unit id="tl_style_sheet.name.1">
         <source>Please enter the style sheet name.</source>
@@ -23,7 +23,7 @@
       </trans-unit>
       <trans-unit id="tl_style_sheet.cc.1">
         <source>Conditional comments allow you to create Internet Explorer specific style sheets (e.g. &lt;em&gt;if lt IE 9&lt;/em&gt;).</source>
-        <target>Komentarze warunkowe pozwalają utworzyć specyficzne arkusze stylów np. dla Internet Explorera.</target>
+        <target>Komentarze warunkowe pozwalają utworzyć specyficzne arkusze stylów, np. dla Internet Explorera.</target>
       </trans-unit>
       <trans-unit id="tl_style_sheet.media.0">
         <source>Media types</source>
@@ -67,7 +67,7 @@
       </trans-unit>
       <trans-unit id="tl_style_sheet.title_legend">
         <source>Name</source>
-        <target>Imię i nazwisko</target>
+        <target>Nazwa wyświetlana</target>
       </trans-unit>
       <trans-unit id="tl_style_sheet.expert_legend">
         <source>Expert settings</source>
@@ -103,7 +103,7 @@
       </trans-unit>
       <trans-unit id="tl_style_sheet.show.1">
         <source>Show the details of style sheet ID %s</source>
-        <target>Pokarz informacje o arkuszu stylów ID %s</target>
+        <target>Pokaż informacje o arkuszu stylów ID %s</target>
       </trans-unit>
       <trans-unit id="tl_style_sheet.edit.0">
         <source>Edit style sheet</source>
@@ -155,7 +155,7 @@
       </trans-unit>
       <trans-unit id="tl_style_sheet.export.0">
         <source>Export style sheet</source>
-        <target>Eksportuj arkusz styli</target>
+        <target>Eksportuj arkusz stylów</target>
       </trans-unit>
       <trans-unit id="tl_style_sheet.export.1">
         <source>Export style sheet ID %s</source>

--- a/core-bundle/src/Resources/contao/languages/pl/tl_templates.xlf
+++ b/core-bundle/src/Resources/contao/languages/pl/tl_templates.xlf
@@ -3,7 +3,7 @@
     <body>
       <trans-unit id="tl_templates.original.0">
         <source>Original template</source>
-        <target>Oryginalne szablony</target>
+        <target>Oryginalny szablon</target>
       </trans-unit>
       <trans-unit id="tl_templates.original.1">
         <source>Here you can select the template that you want to customize.</source>
@@ -15,7 +15,7 @@
       </trans-unit>
       <trans-unit id="tl_templates.target.1">
         <source>A copy of the selected template will be stored in the target folder.</source>
-        <target>Kopia zaznaczonych szablonów będzie przetrzymywana w tym katalogu.</target>
+        <target>Kopia wybranego szablonu będzie przetrzymywana w tym katalogu.</target>
       </trans-unit>
       <trans-unit id="tl_templates.headline">
         <source>Add a new template</source>
@@ -27,7 +27,7 @@
       </trans-unit>
       <trans-unit id="tl_templates.exists">
         <source>Template &quot;%s&quot; exists already!</source>
-        <target>Nazwa własnego szablonu &quot;%s&quot; już istnieje!</target>
+        <target>Nazwa szablonu &quot;%s&quot; już istnieje!</target>
       </trans-unit>
       <trans-unit id="tl_templates.invalid">
         <source>Invalid source or target directory &quot;%s&quot;!</source>
@@ -43,11 +43,11 @@
       </trans-unit>
       <trans-unit id="tl_templates.new.0">
         <source>New folder</source>
-        <target>Nowy szablon</target>
+        <target>Nowy katalog</target>
       </trans-unit>
       <trans-unit id="tl_templates.new.1">
         <source>Create a new folder</source>
-        <target>Utwórz nowy szablon</target>
+        <target>Utwórz nowy katalog</target>
       </trans-unit>
       <trans-unit id="tl_templates.pasteinto.0">
         <source>Paste into</source>

--- a/core-bundle/src/Resources/contao/languages/pl/tl_theme.xlf
+++ b/core-bundle/src/Resources/contao/languages/pl/tl_theme.xlf
@@ -11,7 +11,7 @@
       </trans-unit>
       <trans-unit id="tl_theme.author.0">
         <source>Author</source>
-        <target>Imię</target>
+        <target>Autor</target>
       </trans-unit>
       <trans-unit id="tl_theme.author.1">
         <source>Please enter the name of the theme designer.</source>
@@ -47,15 +47,15 @@
       </trans-unit>
       <trans-unit id="tl_theme.vars.1">
         <source>Here you can define global variables for the style sheets of the theme (e.g. &lt;em&gt;$red&lt;/em&gt; -&gt; &lt;em&gt;c00&lt;/em&gt; or &lt;em&gt;$margin&lt;/em&gt; -&gt; &lt;em&gt;12px&lt;/em&gt;).</source>
-        <target>Tutaj możesz zdefiniować zmienne globalne dla arkuszy styli tego motywu (np. &lt;em&gt;$red&lt;/em&gt; -&gt; &lt;em&gt;c00&lt;/em&gt; lub &lt;em&gt;$margin&lt;/em&gt; -&gt; &lt;em&gt;12px&lt;/em&gt;).</target>
+        <target>Tutaj możesz zdefiniować zmienne globalne dla arkuszy stylów tego motywu (np. &lt;em&gt;$red&lt;/em&gt; -&gt; &lt;em&gt;c00&lt;/em&gt; lub &lt;em&gt;$margin&lt;/em&gt; -&gt; &lt;em&gt;12px&lt;/em&gt;).</target>
       </trans-unit>
       <trans-unit id="tl_theme.defaultImageDensities.0">
         <source>Default image pixel densities</source>
-        <target>Domyślne gęstości pikselu obrazka</target>
+        <target>Domyślne gęstości pikseli obrazka</target>
       </trans-unit>
       <trans-unit id="tl_theme.defaultImageDensities.1">
         <source>Here you can define the default pixel densities, e.g. &lt;em&gt;1x, 1.5x, 2x&lt;/em&gt;.</source>
-        <target>Domyślne gęstości pikselu obrazka, np. &lt;em&gt;1x, 1.5x, 2x&lt;/em&gt;.</target>
+        <target>Domyślne gęstości pikseli obrazka, np. &lt;em&gt;1x, 1.5x, 2x&lt;/em&gt;.</target>
       </trans-unit>
       <trans-unit id="tl_theme.source.0">
         <source>Source files</source>
@@ -119,7 +119,7 @@
       </trans-unit>
       <trans-unit id="tl_theme.template_exists">
         <source>The template &lt;strong&gt;&quot;%s&quot;&lt;/strong&gt; exists and will be overwritten.</source>
-        <target>Szablon &lt;strong&gt;&quot;%s&quot;&lt;/strong&gt; istnieje i zostanie nadpisany..</target>
+        <target>Szablon &lt;strong&gt;&quot;%s&quot;&lt;/strong&gt; istnieje i zostanie nadpisany.</target>
       </trans-unit>
       <trans-unit id="tl_theme.templates_ok">
         <source>No conflicts detected.</source>
@@ -167,11 +167,11 @@
       </trans-unit>
       <trans-unit id="tl_theme.css.0">
         <source>Style sheets</source>
-        <target>Arkusze styli</target>
+        <target>Arkusze stylów</target>
       </trans-unit>
       <trans-unit id="tl_theme.css.1">
         <source>Edit the style sheets of theme ID %s</source>
-        <target>Edytuj arkusze styli motywu ID %s</target>
+        <target>Edytuj arkusze stylów motywu ID %s</target>
       </trans-unit>
       <trans-unit id="tl_theme.modules.0">
         <source>Modules</source>
@@ -183,11 +183,11 @@
       </trans-unit>
       <trans-unit id="tl_theme.layout.0">
         <source>Layouts</source>
-        <target>Szablony</target>
+        <target>Układy</target>
       </trans-unit>
       <trans-unit id="tl_theme.layout.1">
         <source>Edit the page layouts of theme ID %s</source>
-        <target>Edytuj szablony stron motywu ID %s</target>
+        <target>Edytuj układy stron motywu ID %s</target>
       </trans-unit>
       <trans-unit id="tl_theme.imageSizes.0">
         <source>Image sizes</source>

--- a/core-bundle/src/Resources/contao/languages/pl/tl_user.xlf
+++ b/core-bundle/src/Resources/contao/languages/pl/tl_user.xlf
@@ -7,7 +7,7 @@
       </trans-unit>
       <trans-unit id="tl_user.username.1">
         <source>Please enter a unique username.</source>
-        <target>Wprowadź nazwę redaktora.</target>
+        <target>Wprowadź unikalny login redaktora.</target>
       </trans-unit>
       <trans-unit id="tl_user.name.0">
         <source>Name</source>
@@ -31,7 +31,7 @@
       </trans-unit>
       <trans-unit id="tl_user.language.1">
         <source>Here you can choose the back end language.</source>
-        <target>Wybierz domyślny język strony.</target>
+        <target>Wybierz język panelu.</target>
       </trans-unit>
       <trans-unit id="tl_user.backendTheme.0">
         <source>Back end theme</source>
@@ -63,15 +63,15 @@
       </trans-unit>
       <trans-unit id="tl_user.showHelp.1">
         <source>Show a short explanation text below each input field.</source>
-        <target>Jeśli wybierzesz tą opcję, będzie wyświetlane krótkie wyjaśnienie po wpisaniu w polu tekstowym.</target>
+        <target>Jeśli wybierzesz tę opcję, będzie wyświetlane krótkie wyjaśnienie po wpisaniu w polu tekstowym.</target>
       </trans-unit>
       <trans-unit id="tl_user.thumbnails.0">
         <source>Show thumbnail images</source>
-        <target>Pokazuj miniaturki obrazków</target>
+        <target>Pokazuj miniatury obrazków</target>
       </trans-unit>
       <trans-unit id="tl_user.thumbnails.1">
         <source>Show thumbnail images in the file manager.</source>
-        <target>Jeśli wybierzesz tą opcję, w menadżerze plików zostaną wyśwwietlone miniaturki obrazków.</target>
+        <target>Jeśli wybierzesz tę opcję, w menadżerze plików zostaną wyśwwietlone miniatury obrazków.</target>
       </trans-unit>
       <trans-unit id="tl_user.useRTE.0">
         <source>Enable the rich text editor</source>
@@ -111,7 +111,7 @@
       </trans-unit>
       <trans-unit id="tl_user.groups.1">
         <source>Here you can assign the user to one or more groups.</source>
-        <target>Każdy redaktor, który nie jest administratorem dziedziczy zezwolenia po grupie, w której się znajduje. Dlatego każdy redaktor musi być członkiem co najmniej jednej grupy! Jeśli redaktor jest w więcej niż jednej grupie, zezwolenia się łączą.</target>
+        <target>Każdy redaktor, który nie jest administratorem, dziedziczy zezwolenia po grupie, w której się znajduje. Dlatego każdy redaktor musi być członkiem co najmniej jednej grupy! Jeśli redaktor jest w więcej niż jednej grupie, zezwolenia się łączą.</target>
       </trans-unit>
       <trans-unit id="tl_user.inherit.0">
         <source>Permission inheritance</source>
@@ -119,7 +119,7 @@
       </trans-unit>
       <trans-unit id="tl_user.inherit.1">
         <source>Here you can define which group permissions the user inherits.</source>
-        <target>Określ do jakiego obszaru redaktor dziedziczy zezwolenia.</target>
+        <target>Określ, do jakiego obszaru redaktor dziedziczy zezwolenia.</target>
       </trans-unit>
       <trans-unit id="tl_user.group.0">
         <source>Use group settings only</source>
@@ -127,7 +127,7 @@
       </trans-unit>
       <trans-unit id="tl_user.group.1">
         <source>The user inherits only group permissions.</source>
-        <target>Redaktor dziedziczy zezwolenia od grup wyłącznie niezależnych indywidualnymi ustawieniami.</target>
+        <target>Redaktor dziedziczy zezwolenia wyłącznie od grup.</target>
       </trans-unit>
       <trans-unit id="tl_user.extend.0">
         <source>Extend group settings</source>
@@ -143,11 +143,11 @@
       </trans-unit>
       <trans-unit id="tl_user.custom.1">
         <source>Only individual permissions are applied.</source>
-        <target>Tylko zezwolenia aktualnego redaktora są potwierdzone niezależnie przez każde zezwolenie grupy.</target>
+        <target>Tylko zezwolenia aktualnego redaktora są stosowane.</target>
       </trans-unit>
       <trans-unit id="tl_user.modules.0">
         <source>Back end modules</source>
-        <target>Moduły admin panelu</target>
+        <target>Moduły panelu admina</target>
       </trans-unit>
       <trans-unit id="tl_user.modules.1">
         <source>Here you can grant access to one or more back end modules.</source>
@@ -211,7 +211,7 @@
       </trans-unit>
       <trans-unit id="tl_user.amg.0">
         <source>Allowed member groups</source>
-        <target>Zezwolone grupy użytkowników</target>
+        <target>Dozwolone grupy użytkowników</target>
       </trans-unit>
       <trans-unit id="tl_user.amg.1">
         <source>Members of these groups can be used in the front end preview.</source>
@@ -231,7 +231,7 @@
       </trans-unit>
       <trans-unit id="tl_user.start.1">
         <source>Automatically activate the account on this day.</source>
-        <target>Wpisz datę, kiedy konto redaktora zostanie aktywowany.</target>
+        <target>Wpisz datę, kiedy konto redaktora zostanie aktywowane.</target>
       </trans-unit>
       <trans-unit id="tl_user.stop.0">
         <source>Deactivate on</source>
@@ -247,7 +247,7 @@
       </trans-unit>
       <trans-unit id="tl_user.session.1">
         <source>Please select the data you want to purge.</source>
-        <target>Po wybraniu tej opcji, dane tej sesji zostaną usunięte.</target>
+        <target>Zaznacz dane, które chcesz wyczyścić.</target>
       </trans-unit>
       <trans-unit id="tl_user.name_legend">
         <source>Name and e-mail</source>
@@ -295,7 +295,7 @@
       </trans-unit>
       <trans-unit id="tl_user.amg_legend">
         <source>Allowed member groups</source>
-        <target>Zezwolone grupy użytkowników</target>
+        <target>Dozwolone grupy użytkowników</target>
       </trans-unit>
       <trans-unit id="tl_user.account_legend">
         <source>Account settings</source>
@@ -315,7 +315,7 @@
       </trans-unit>
       <trans-unit id="tl_user.tempLabel">
         <source>Page cache</source>
-        <target>Katalog tymczasowy</target>
+        <target>Pamięć podręczna stron</target>
       </trans-unit>
       <trans-unit id="tl_user.sessionPurged">
         <source>The session data has been purged</source>
@@ -327,7 +327,7 @@
       </trans-unit>
       <trans-unit id="tl_user.tempPurged">
         <source>The page cache has been purged</source>
-        <target>Katalog tymczasowy został wyczyszczony</target>
+        <target>Pamięć podręczna stron została wyczyszczona</target>
       </trans-unit>
       <trans-unit id="tl_user.FileUpload">
         <source>Default uploader</source>

--- a/core-bundle/src/Resources/contao/languages/pl/tl_user_group.xlf
+++ b/core-bundle/src/Resources/contao/languages/pl/tl_user_group.xlf
@@ -3,7 +3,7 @@
     <body>
       <trans-unit id="tl_user_group.name.0">
         <source>Title</source>
-        <target>Nagłówek</target>
+        <target>Nazwa</target>
       </trans-unit>
       <trans-unit id="tl_user_group.name.1">
         <source>Please enter the group title.</source>
@@ -15,7 +15,7 @@
       </trans-unit>
       <trans-unit id="tl_user_group.alexf.1">
         <source>Here you can choose which fields will be editable.</source>
-        <target>Kilka tabel zawiera pola, które są wykluczone z domyślnego edytowania. Tutaj masz możliwość odblokowania tych pól dla tej grupy. Przytrzymaj klawisz CTRL podczas zaznaczania obiektów.</target>
+        <target>Kilka tabel zawiera pola, które są wykluczone z domyślnego edytowania. Tutaj masz możliwość odblokowania tych pól dla grupy.</target>
       </trans-unit>
       <trans-unit id="tl_user_group.disable.0">
         <source>Deactivate</source>
@@ -43,7 +43,7 @@
       </trans-unit>
       <trans-unit id="tl_user_group.title_legend">
         <source>Title</source>
-        <target>Nagłówek</target>
+        <target>Nazwa</target>
       </trans-unit>
       <trans-unit id="tl_user_group.modules_legend">
         <source>Allowed modules</source>
@@ -67,7 +67,7 @@
       </trans-unit>
       <trans-unit id="tl_user_group.amg_legend">
         <source>Allowed member groups</source>
-        <target>Zezwolone grupy użytkowników</target>
+        <target>Dozwolone grupy użytkowników</target>
       </trans-unit>
       <trans-unit id="tl_user_group.alexf_legend">
         <source>Allowed fields</source>

--- a/faq-bundle/src/Resources/contao/languages/pl/tl_faq.xlf
+++ b/faq-bundle/src/Resources/contao/languages/pl/tl_faq.xlf
@@ -95,7 +95,7 @@
       </trans-unit>
       <trans-unit id="tl_faq.publish_legend">
         <source>Publish settings</source>
-        <target>Ustawinia publikacji</target>
+        <target>Ustawienia publikacji</target>
       </trans-unit>
       <trans-unit id="tl_faq.new.0">
         <source>New question</source>

--- a/faq-bundle/src/Resources/contao/languages/pl/tl_faq.xlf
+++ b/faq-bundle/src/Resources/contao/languages/pl/tl_faq.xlf
@@ -19,7 +19,7 @@
       </trans-unit>
       <trans-unit id="tl_faq.author.0">
         <source>Author</source>
-        <target>Imię</target>
+        <target>Autor</target>
       </trans-unit>
       <trans-unit id="tl_faq.author.1">
         <source>Here you can change the author of the FAQ.</source>
@@ -159,7 +159,7 @@
       </trans-unit>
       <trans-unit id="tl_faq.editheader.1">
         <source>Edit the category settings</source>
-        <target>Edytuj tą kategorię</target>
+        <target>Edytuj tę kategorię</target>
       </trans-unit>
       <trans-unit id="tl_faq.pasteafter.0">
         <source>Paste at the top</source>

--- a/faq-bundle/src/Resources/contao/languages/pl/tl_faq_category.xlf
+++ b/faq-bundle/src/Resources/contao/languages/pl/tl_faq_category.xlf
@@ -23,7 +23,7 @@
       </trans-unit>
       <trans-unit id="tl_faq_category.jumpTo.1">
         <source>Please choose the FAQ reader page to which visitors will be redirected when clicking a FAQ.</source>
-        <target>Wybierz stronę, na którą zostaną przekierowani odwiedzający kiedy klikną na pytanie.</target>
+        <target>Wybierz stronę, na którą zostaną przekierowani odwiedzający, kiedy klikną na pytanie.</target>
       </trans-unit>
       <trans-unit id="tl_faq_category.allowComments.0">
         <source>Enable comments</source>
@@ -39,7 +39,7 @@
       </trans-unit>
       <trans-unit id="tl_faq_category.notify.1">
         <source>Please choose who to notify when comments are added.</source>
-        <target>Wybierz kogo powiadomić kiedy komentarz zostanie dodany.</target>
+        <target>Wybierz kogo powiadomić, kiedy komentarz zostanie dodany.</target>
       </trans-unit>
       <trans-unit id="tl_faq_category.sortOrder.0">
         <source>Sort order</source>
@@ -63,7 +63,7 @@
       </trans-unit>
       <trans-unit id="tl_faq_category.moderate.1">
         <source>Approve comments before they are published on the website.</source>
-        <target>Zatwierdzaj komentarze zanim zostaną one opublikowane na stronie.</target>
+        <target>Zatwierdzaj komentarze, zanim zostaną one opublikowane na stronie.</target>
       </trans-unit>
       <trans-unit id="tl_faq_category.bbcode.0">
         <source>Allow BBCode</source>
@@ -71,11 +71,11 @@
       </trans-unit>
       <trans-unit id="tl_faq_category.bbcode.1">
         <source>Allow visitors to format their comments with BBCode.</source>
-        <target>Zezwól odwiedzającym na formatowanie ich komenatrzy za pomocą BBCode.</target>
+        <target>Zezwól odwiedzającym na formatowanie ich komentarzy za pomocą BBCode.</target>
       </trans-unit>
       <trans-unit id="tl_faq_category.requireLogin.0">
         <source>Require login to comment</source>
-        <target>Wymagaj zalogowania aby komentować</target>
+        <target>Wymagaj zalogowania, aby komentować</target>
       </trans-unit>
       <trans-unit id="tl_faq_category.requireLogin.1">
         <source>Allow only authenticated members to create comments.</source>
@@ -87,7 +87,7 @@
       </trans-unit>
       <trans-unit id="tl_faq_category.disableCaptcha.1">
         <source>Use this option only if you have limited comments to authenticated users.</source>
-        <target>Używaj tej opcji tylko jeśli ograniczyłeś komentarze dla zalogowanych użytkowników.</target>
+        <target>Używaj tej opcji tylko, jeśli ograniczyłeś komentarze do zalogowanych użytkowników.</target>
       </trans-unit>
       <trans-unit id="tl_faq_category.tstamp.0">
         <source>Revision date</source>
@@ -151,7 +151,7 @@
       </trans-unit>
       <trans-unit id="tl_faq_category.editheader.1">
         <source>Edit the category settings</source>
-        <target>Edytuj tą kategorię</target>
+        <target>Edytuj tę kategorię</target>
       </trans-unit>
       <trans-unit id="tl_faq_category.copy.0">
         <source>Duplicate category</source>

--- a/installation-bundle/src/Resources/translations/messages.pl.xlf
+++ b/installation-bundle/src/Resources/translations/messages.pl.xlf
@@ -18,6 +18,7 @@
       </trans-unit>
       <trans-unit id="4">
         <source>locked_explanation</source>
+        <target>Ze względów bezpieczeństwa, instalator został zablokowany po tym, jak hasło zostało wpisane niepoprawnie więcej niż trzy razy z rzędu. Możesz to odblokować w Contao Manager lub w konsoli Contao wykonując polecenie &lt;code&gt;contao:install:unlock&lt;/code&gt;.</target>
         
       </trans-unit>
       <trans-unit id="5">
@@ -87,7 +88,7 @@
       </trans-unit>
       <trans-unit id="18">
         <source>allow_cookies</source>
-        <target>Musisz zaakceptować cisteczka (cookies) aby używać Contao.</target>
+        <target>Musisz zaakceptować cisteczka (cookies), aby używać Contao.</target>
         
       </trans-unit>
       <trans-unit id="19">
@@ -217,7 +218,7 @@
       </trans-unit>
       <trans-unit id="44">
         <source>import_exception</source>
-        <target>Import się nie powiódł! Czy baza danych jest aktualna a pliki szablonów kompatybilne z twoją wersją Conto?</target>
+        <target>Import się nie powiódł! Czy baza danych jest aktualna a pliki szablonów kompatybilne z twoją wersją Contao?</target>
         
       </trans-unit>
       <trans-unit id="45">
@@ -317,7 +318,7 @@
       </trans-unit>
       <trans-unit id="64">
         <source>admin_error</source>
-        <target>Prosimy wypełnić wszystkie pola aby utworzyć administratora!</target>
+        <target>Prosimy wypełnić wszystkie pola, aby utworzyć administratora!</target>
         
       </trans-unit>
       <trans-unit id="65">
@@ -362,6 +363,7 @@
       </trans-unit>
       <trans-unit id="73">
         <source>duplicate_subscriptions</source>
+        <target>Zduplikowane subskrypcje:</target>
         
       </trans-unit>
       <trans-unit id="74">

--- a/listing-bundle/src/Resources/contao/languages/pl/tl_module.xlf
+++ b/listing-bundle/src/Resources/contao/languages/pl/tl_module.xlf
@@ -15,7 +15,7 @@
       </trans-unit>
       <trans-unit id="tl_module.list_fields.1">
         <source>Please enter a comma separated list of the fields you want to list.</source>
-        <target>Wprowadź rozdzieloną przecinkami listę pól, którą chcesz wylistować.</target>
+        <target>Wprowadź rozdzieloną przecinkami listę pól, które chcesz wylistować.</target>
       </trans-unit>
       <trans-unit id="tl_module.list_where.0">
         <source>Condition</source>
@@ -31,7 +31,7 @@
       </trans-unit>
       <trans-unit id="tl_module.list_search.1">
         <source>Here you can enter a comma seperated list of fields that you want to be searchable.</source>
-        <target>Wprowadź rozdzieloną przecinkami listę pól, które chcesz aby były przeszukiwane.</target>
+        <target>Wprowadź rozdzieloną przecinkami listę pól, które chcesz, aby były przeszukiwane.</target>
       </trans-unit>
       <trans-unit id="tl_module.list_sort.0">
         <source>Order by</source>
@@ -39,7 +39,7 @@
       </trans-unit>
       <trans-unit id="tl_module.list_sort.1">
         <source>Here you can enter a comma seperated list of fields to sort the results by.</source>
-        <target>Wprowadź rozdzieloną przecinkami listę pól, które będą użyte do ustawienia domyślnej kolejności wyników. Dodaj &lt;em&gt;DESC&lt;/em&gt; po nazwie pola by uporządkować malejąco (np. &lt;em&gt;name, date DESC&lt;/em&gt;).</target>
+        <target>Wprowadź rozdzieloną przecinkami listę pól, które będą użyte do ustawienia domyślnej kolejności wyników. Dodaj &lt;em&gt;DESC&lt;/em&gt; po nazwie pola, aby uporządkować malejąco (np. &lt;em&gt;name, date DESC&lt;/em&gt;).</target>
       </trans-unit>
       <trans-unit id="tl_module.list_info.0">
         <source>Details page fields</source>
@@ -47,7 +47,7 @@
       </trans-unit>
       <trans-unit id="tl_module.list_info.1">
         <source>Enter a comma separated list of the fields you want to show on the details page. Leave blank to disable the feature.</source>
-        <target>Wprowadź rozdzieloną przecinkami listę pól, które chcesz aby znajdowały się na stronie ze szczegółami. Pozostaw to pole puste aby wyłączyć funkcje strony ze szczegółami.</target>
+        <target>Wprowadź rozdzieloną przecinkami listę pól, które chcesz, aby znajdowały się na stronie ze szczegółami. Pozostaw to pole puste, aby wyłączyć funkcje strony ze szczegółami.</target>
       </trans-unit>
       <trans-unit id="tl_module.list_info_where.0">
         <source>Details page condition</source>
@@ -63,7 +63,7 @@
       </trans-unit>
       <trans-unit id="tl_module.list_layout.1">
         <source>Here you can select the list template.</source>
-        <target>Wybierz szablon listy. Możesz dodać dowolny szablon do folderu &lt;em&gt;templates&lt;/em&gt;. Pliki szablonów zaczynają się z &lt;em&gt;list_&lt;/em&gt; i muszą mieć rozszerzenie &lt;em&gt;.tpl&lt;/em&gt;.</target>
+        <target>Wybierz szablon listy. Możesz dodać dowolny szablon do folderu &lt;em&gt;templates&lt;/em&gt;. Pliki szablonów zaczynają się od &lt;em&gt;list_&lt;/em&gt; i muszą mieć rozszerzenie &lt;em&gt;.html5&lt;/em&gt;.</target>
       </trans-unit>
       <trans-unit id="tl_module.list_info_layout.0">
         <source>Details page template</source>
@@ -71,7 +71,7 @@
       </trans-unit>
       <trans-unit id="tl_module.list_info_layout.1">
         <source>Here you can select the details page template.</source>
-        <target>Wybierz szablon strony szczegółów. Możesz dodać dowolny szablon do folderu &lt;em&gt;templates&lt;/em&gt;. Pliki szablonów zaczynają się z &lt;em&gt;info_&lt;/em&gt; i muszą mieć rozszerzenie &lt;em&gt;.tpl&lt;/em&gt;.</target>
+        <target>Wybierz szablon strony szczegółów. Możesz dodać dowolny szablon do folderu &lt;em&gt;templates&lt;/em&gt;. Pliki szablonów zaczynają się od &lt;em&gt;info_&lt;/em&gt; i muszą mieć rozszerzenie &lt;em&gt;.html5&lt;/em&gt;.</target>
       </trans-unit>
     </body>
   </file>

--- a/news-bundle/src/Resources/contao/languages/pl/default.xlf
+++ b/news-bundle/src/Resources/contao/languages/pl/default.xlf
@@ -7,7 +7,7 @@
       </trans-unit>
       <trans-unit id="MSC.author">
         <source>Author</source>
-        <target>Imię</target>
+        <target>Autor</target>
       </trans-unit>
       <trans-unit id="MSC.by">
         <source>by</source>
@@ -35,7 +35,7 @@
       </trans-unit>
       <trans-unit id="MSC.news_previous">
         <source>&amp;lt;</source>
-        <target>&gt;</target>
+        <target>&lt;</target>
       </trans-unit>
       <trans-unit id="MSC.news_next">
         <source>&amp;gt;</source>

--- a/news-bundle/src/Resources/contao/languages/pl/modules.xlf
+++ b/news-bundle/src/Resources/contao/languages/pl/modules.xlf
@@ -27,7 +27,7 @@
       </trans-unit>
       <trans-unit id="FMD.newslist.1">
         <source>Adds a list of news items to the page</source>
-        <target>Ten moduł wyświetla listę pewnych liczb aktualności danego archiwum.</target>
+        <target>Ten moduł wyświetla listę aktualności danego archiwum.</target>
       </trans-unit>
       <trans-unit id="FMD.newsreader.0">
         <source>Newsreader</source>

--- a/news-bundle/src/Resources/contao/languages/pl/tl_module.xlf
+++ b/news-bundle/src/Resources/contao/languages/pl/tl_module.xlf
@@ -23,11 +23,11 @@
       </trans-unit>
       <trans-unit id="tl_module.news_jumpToCurrent.1">
         <source>Here you can define what to display if no period is selected.</source>
-        <target>Jeśli wybierzesz tą opcję, Contao automatycznie przeskoczy do archiwum aktualności obecnego miesiąca, gdy poszczególne archiwum zostało określone.</target>
+        <target>Jeśli wybierzesz tę opcję, Contao automatycznie przeskoczy do archiwum aktualności obecnego miesiąca, gdy poszczególne archiwum zostało określone.</target>
       </trans-unit>
       <trans-unit id="tl_module.news_readerModule.0">
         <source>News reader module</source>
-        <target>Moduł czytinka aktualności</target>
+        <target>Moduł czytnika aktualności</target>
       </trans-unit>
       <trans-unit id="tl_module.news_readerModule.1">
         <source>Automatically switch to the news reader if an item has been selected.</source>
@@ -39,7 +39,7 @@
       </trans-unit>
       <trans-unit id="tl_module.news_metaFields.1">
         <source>Here you can select the meta fields.</source>
-        <target>Wybierz pola, które chcesz by zawierały w aktualnościach nagłówek.</target>
+        <target>Wybierz pola, które mają zostać wyświetlone.</target>
       </trans-unit>
       <trans-unit id="tl_module.news_template.0">
         <source>News template</source>
@@ -47,7 +47,7 @@
       </trans-unit>
       <trans-unit id="tl_module.news_template.1">
         <source>Here you can select the news template.</source>
-        <target>Wybierz szablon aktualności. Możesz dodać dowolny szablon do folderu &lt;em&gt;templates&lt;/em&gt;. Pliki szablonów zaczynają się z &lt;em&gt;news_&lt;/em&gt; i muszą mieć rozszerzenie &lt;em&gt;.tpl&lt;/em&gt;.</target>
+        <target>Wybierz szablon aktualności. Możesz dodać dowolny szablon do folderu &lt;em&gt;templates&lt;/em&gt;. Pliki szablonów zaczynają się od &lt;em&gt;news_&lt;/em&gt; i muszą mieć rozszerzenie &lt;em&gt;.html5&lt;/em&gt;.</target>
       </trans-unit>
       <trans-unit id="tl_module.news_format.0">
         <source>Archive format</source>
@@ -79,7 +79,7 @@
       </trans-unit>
       <trans-unit id="tl_module.news_showQuantity.1">
         <source>Show the number of news items of each month.</source>
-        <target>Jeśli wybierzesz tą opcję, liczba aktualności w miesiącu będzie wyświetlana w menu archiwum.</target>
+        <target>Jeśli wybierzesz tę opcję, ilość aktualności w miesiącu będzie wyświetlana w menu archiwum.</target>
       </trans-unit>
       <trans-unit id="tl_module.news_day">
         <source>Day</source>

--- a/news-bundle/src/Resources/contao/languages/pl/tl_news.xlf
+++ b/news-bundle/src/Resources/contao/languages/pl/tl_news.xlf
@@ -15,11 +15,11 @@
       </trans-unit>
       <trans-unit id="tl_news.alias.1">
         <source>The news alias is a unique reference to the news item which can be called instead of its numeric ID.</source>
-        <target>Alias aktualności jest unikalnym odwołaniem do strony gdzie będzie ona wyświetlana, który może być używany zamiast jej ID.</target>
+        <target>Alias aktualności jest unikalnym odwołaniem do strony, gdzie będzie ona wyświetlana, który może być używany zamiast jej ID.</target>
       </trans-unit>
       <trans-unit id="tl_news.author.0">
         <source>Author</source>
-        <target>Imię</target>
+        <target>Autor</target>
       </trans-unit>
       <trans-unit id="tl_news.author.1">
         <source>Here you can change the author of the news item.</source>
@@ -55,7 +55,7 @@
       </trans-unit>
       <trans-unit id="tl_news.teaser.1">
         <source>The news teaser can be shown in a news list instead of the full story. A &quot;read more …&quot; link will be added automatically.</source>
-        <target>Zajawka jest tekstem wstępnym do pełnej treści i jest zazwyczaj pokazywany zamiast pełnej treści aktualności. Jest on zakończony odnośnikiem &quot;Więcej...&quot;.</target>
+        <target>Zajawka jest tekstem wstępnym do pełnej treści i jest zazwyczaj pokazywana zamiast pełnej treści aktualności. Jest ona zakończona odnośnikiem &quot;Więcej...&quot;.</target>
       </trans-unit>
       <trans-unit id="tl_news.text.0">
         <source>News text</source>
@@ -71,7 +71,7 @@
       </trans-unit>
       <trans-unit id="tl_news.addImage.1">
         <source>Add an image to the news item.</source>
-        <target>Jeśli wybierzesz tą opcję, do aktualności zostanie dodany obrazek.</target>
+        <target>Jeśli wybierzesz tę opcję, do aktualności zostanie dodany obrazek.</target>
       </trans-unit>
       <trans-unit id="tl_news.addEnclosure.0">
         <source>Add enclosures</source>
@@ -87,7 +87,7 @@
       </trans-unit>
       <trans-unit id="tl_news.enclosure.1">
         <source>Please choose the files you want to attach.</source>
-        <target>Wybierz plik, który chcesz załączyć do odpowiedzi.</target>
+        <target>Wybierz pliki, które chcesz załączyć do aktualności.</target>
       </trans-unit>
       <trans-unit id="tl_news.source.0">
         <source>Redirect target</source>
@@ -119,7 +119,7 @@
       </trans-unit>
       <trans-unit id="tl_news.article.1">
         <source>By clicking the &quot;read more …&quot; button, visitors will be redirected to an article.</source>
-        <target>Kliknięcie w przycisk &quot;czytaj więcej...&quot;, przekieruje do artykułu</target>
+        <target>Klikając w przycisk &quot;czytaj więcej...&quot; odwiedzający zostaną przekierowani do artykułu</target>
       </trans-unit>
       <trans-unit id="tl_news.external.0">
         <source>External URL</source>
@@ -135,7 +135,7 @@
       </trans-unit>
       <trans-unit id="tl_news.jumpTo.1">
         <source>Please choose the page to which visitors will be redirected when clicking the news item.</source>
-        <target>Wybierz stronę, na którą zostaną przekierowani odwiedzający. Zauważ, że strona docelowa powinna zawierać moduł &quot;Czytnik aktualności&quot; w kolejności wyświetlania aktualności.</target>
+        <target>Wybierz stronę, na którą zostaną przekierowani odwiedzający. Zauważ, że strona docelowa powinna zawierać moduł &quot;Czytnik aktualności&quot;.</target>
       </trans-unit>
       <trans-unit id="tl_news.articleId.0">
         <source>Article</source>
@@ -143,7 +143,7 @@
       </trans-unit>
       <trans-unit id="tl_news.articleId.1">
         <source>Please choose the article to which visitors will be redirected when clicking the news item.</source>
-        <target>Wybierz artykuł, do którego czytelnicy będą przekierowani kiedy klikną w aktualność.</target>
+        <target>Wybierz artykuł, do którego czytelnicy będą przekierowani, kiedy klikną w aktualność.</target>
       </trans-unit>
       <trans-unit id="tl_news.cssClass.0">
         <source>CSS class</source>
@@ -179,7 +179,7 @@
       </trans-unit>
       <trans-unit id="tl_news.start.0">
         <source>Show from</source>
-        <target>Wrapper start</target>
+        <target>Pokazuj od</target>
       </trans-unit>
       <trans-unit id="tl_news.start.1">
         <source>Do not show the news item on the website before this day.</source>
@@ -187,7 +187,7 @@
       </trans-unit>
       <trans-unit id="tl_news.stop.0">
         <source>Show until</source>
-        <target>Wrapper stop</target>
+        <target>Pokazuj do</target>
       </trans-unit>
       <trans-unit id="tl_news.stop.1">
         <source>Do not show the news item on the website on and after this day.</source>
@@ -235,7 +235,7 @@
       </trans-unit>
       <trans-unit id="tl_news.publish_legend">
         <source>Publish settings</source>
-        <target>Ustawinia publikacji</target>
+        <target>Ustawienia publikacji</target>
       </trans-unit>
       <trans-unit id="tl_news.new.0">
         <source>New item</source>
@@ -247,7 +247,7 @@
       </trans-unit>
       <trans-unit id="tl_news.show.0">
         <source>Item details</source>
-        <target>Szczegółyaktualności</target>
+        <target>Szczegóły aktualności</target>
       </trans-unit>
       <trans-unit id="tl_news.show.1">
         <source>Show the details of news item ID %s</source>

--- a/news-bundle/src/Resources/contao/languages/pl/tl_news_archive.xlf
+++ b/news-bundle/src/Resources/contao/languages/pl/tl_news_archive.xlf
@@ -15,7 +15,7 @@
       </trans-unit>
       <trans-unit id="tl_news_archive.jumpTo.1">
         <source>Please choose the news reader page to which visitors will be redirected when clicking a news item.</source>
-        <target>Wybierz stronę, do której odwiedzający będą przekierowani kiedy klikną w niusa.</target>
+        <target>Wybierz stronę, do której odwiedzający będą przekierowani, kiedy klikną w aktualność.</target>
       </trans-unit>
       <trans-unit id="tl_news_archive.allowComments.0">
         <source>Enable comments</source>
@@ -31,7 +31,7 @@
       </trans-unit>
       <trans-unit id="tl_news_archive.notify.1">
         <source>Please choose who to notify when comments are added.</source>
-        <target>Wybierz kogo powiadomić kiedy komentarz zostanie dodany.</target>
+        <target>Wybierz kogo powiadomić, kiedy komentarz zostanie dodany.</target>
       </trans-unit>
       <trans-unit id="tl_news_archive.sortOrder.0">
         <source>Sort order</source>
@@ -55,7 +55,7 @@
       </trans-unit>
       <trans-unit id="tl_news_archive.moderate.1">
         <source>Approve comments before they are published on the website.</source>
-        <target>Zatwierdzaj komentarze zanim zostaną one opublikowane na stronie.</target>
+        <target>Zatwierdzaj komentarze, zanim zostaną one opublikowane na stronie.</target>
       </trans-unit>
       <trans-unit id="tl_news_archive.bbcode.0">
         <source>Allow BBCode</source>
@@ -63,11 +63,11 @@
       </trans-unit>
       <trans-unit id="tl_news_archive.bbcode.1">
         <source>Allow visitors to format their comments with BBCode.</source>
-        <target>Zezwól odwiedzającym na formatowanie ich komenatrzy za pomocą BBCode.</target>
+        <target>Zezwól odwiedzającym na formatowanie ich komentarzy za pomocą BBCode.</target>
       </trans-unit>
       <trans-unit id="tl_news_archive.requireLogin.0">
         <source>Require login to comment</source>
-        <target>Wymagaj zalogowania aby komentować</target>
+        <target>Wymagaj zalogowania, aby komentować</target>
       </trans-unit>
       <trans-unit id="tl_news_archive.requireLogin.1">
         <source>Allow only authenticated members to create comments.</source>
@@ -79,7 +79,7 @@
       </trans-unit>
       <trans-unit id="tl_news_archive.disableCaptcha.1">
         <source>Use this option only if you have limited comments to authenticated users.</source>
-        <target>Używaj tej opcji tylko jeśli ograniczyłeś komentarze dla zalogowanych użytkowników.</target>
+        <target>Używaj tej opcji tylko, jeśli ograniczyłeś komentarze do zalogowanych użytkowników.</target>
       </trans-unit>
       <trans-unit id="tl_news_archive.protected.0">
         <source>Protect archive</source>
@@ -91,11 +91,11 @@
       </trans-unit>
       <trans-unit id="tl_news_archive.groups.0">
         <source>Allowed member groups</source>
-        <target>Zezwolone grupy użytkowników</target>
+        <target>Dozwolone grupy użytkowników</target>
       </trans-unit>
       <trans-unit id="tl_news_archive.groups.1">
         <source>These groups will be able to see the news items in this archive.</source>
-        <target>Tutaj możesz ustalić, która grupa użytkowników będzie mogła przeglądać te aktualności.</target>
+        <target>Tutaj możesz ustalić, które grupy użytkowników będą mogły przeglądać te aktualności.</target>
       </trans-unit>
       <trans-unit id="tl_news_archive.tstamp.0">
         <source>Revision date</source>

--- a/newsletter-bundle/src/Resources/contao/languages/pl/default.xlf
+++ b/newsletter-bundle/src/Resources/contao/languages/pl/default.xlf
@@ -3,11 +3,11 @@
     <body>
       <trans-unit id="ERR.subscribed">
         <source>You are subscribed to the selected channels already.</source>
-        <target>Jesteś już zapisany do tego newslettera.</target>
+        <target>Jesteś już zapisany do tego kanału newslettera.</target>
       </trans-unit>
       <trans-unit id="ERR.unsubscribed">
         <source>You are not subscribed to the selected channels.</source>
-        <target>Nie jesteś zapisany do tego newslettera.</target>
+        <target>Nie jesteś zapisany do tego kanału newslettera.</target>
       </trans-unit>
       <trans-unit id="ERR.invalidToken">
         <source>The activation link is invalid or outdated.</source>
@@ -15,7 +15,7 @@
       </trans-unit>
       <trans-unit id="ERR.noChannels">
         <source>Please select at least one channel.</source>
-        <target>Wybierz conajmniej jeden kanał.</target>
+        <target>Wybierz co najmniej jeden kanał.</target>
       </trans-unit>
       <trans-unit id="ERR.blacklisted">
         <source>The e-mail address has been unsubscribed from the channel.</source>

--- a/newsletter-bundle/src/Resources/contao/languages/pl/tl_module.xlf
+++ b/newsletter-bundle/src/Resources/contao/languages/pl/tl_module.xlf
@@ -7,7 +7,7 @@
       </trans-unit>
       <trans-unit id="tl_module.newsletters.1">
         <source>Show these channels in the front end form.</source>
-        <target>Wybierz newslettery, do których użytkownik może się zapisać podczas procesu rejestracji.</target>
+        <target>Wybierz kanały, do których użytkownik może się zapisać podczas procesu rejestracji.</target>
       </trans-unit>
       <trans-unit id="tl_module.nl_channels.0">
         <source>Channels</source>
@@ -39,7 +39,7 @@
       </trans-unit>
       <trans-unit id="tl_module.nl_unsubscribe.1">
         <source>You can use the wildcards &lt;em&gt;##channels##&lt;/em&gt; (channel names) and &lt;em&gt;##domain##&lt;/em&gt; (domain name).</source>
-        <target>Wpisz treść e-maila z anulowaniem subskrypcji. Możesz używać tagów &lt;em&gt;##channel##&lt;/em&gt; (channel name) and &lt;em&gt;##domain##&lt;/em&gt; (aktualna domena).</target>
+        <target>Wpisz treść e-maila z anulowaniem subskrypcji. Możesz używać tagów &lt;em&gt;##channel##&lt;/em&gt; (nazwa kanału) and &lt;em&gt;##domain##&lt;/em&gt; (aktualna domena).</target>
       </trans-unit>
       <trans-unit id="tl_module.nl_template.0">
         <source>Newsletter template</source>
@@ -47,7 +47,7 @@
       </trans-unit>
       <trans-unit id="tl_module.nl_template.1">
         <source>Here you can select the newsletter template.</source>
-        <target>Wybierz szablon modułu. Możesz dodać własne szablony do katalogu &lt;em&gt;templates&lt;/em&gt;. Pliki szablonów newslettera muszą zaczynać się od &lt;em&gt;nl_&lt;/em&gt; i muszą mieć rozszerzenie &lt;em&gt;.tpl&lt;/em&gt;.</target>
+        <target>Wybierz szablon modułu. Możesz dodać własne szablony do katalogu &lt;em&gt;templates&lt;/em&gt;. Pliki szablonów newslettera muszą zaczynać się od &lt;em&gt;nl_&lt;/em&gt; i muszą mieć rozszerzenie &lt;em&gt;.html5&lt;/em&gt;.</target>
       </trans-unit>
       <trans-unit id="tl_module.text_subscribe.0">
         <source>Your subscription on %s</source>
@@ -64,7 +64,7 @@ Please click ##link## to activate your subscription. If you did not subscribe yo
 
 Dziękujemy za subskrypcję newslettera ##channel## na ##domain##.
 
-Prosimy kliknąć w poniższy link aby dokończyć proces subskrypcji
+Prosimy kliknąć w poniższy link, aby dokończyć proces subskrypcji
 ##link##
 Jeśli powyższy link nie działa, musisz skopiować go i wkleić do swojej przeglądarki internetowej lub samemu go wpisać.
 

--- a/newsletter-bundle/src/Resources/contao/languages/pl/tl_newsletter.xlf
+++ b/newsletter-bundle/src/Resources/contao/languages/pl/tl_newsletter.xlf
@@ -7,7 +7,7 @@
       </trans-unit>
       <trans-unit id="tl_newsletter.subject.1">
         <source>Please enter the newsletter subject.</source>
-        <target>Wpisz temat newlettera.</target>
+        <target>Wpisz temat newslettera.</target>
       </trans-unit>
       <trans-unit id="tl_newsletter.alias.0">
         <source>Newsletter alias</source>
@@ -19,19 +19,19 @@
       </trans-unit>
       <trans-unit id="tl_newsletter.content.0">
         <source>HTML content</source>
-        <target>Treść</target>
+        <target>Treść HTML</target>
       </trans-unit>
       <trans-unit id="tl_newsletter.content.1">
         <source>Here you can enter the HTML content of the newsletter. Use the wildcard &lt;em&gt;##email##&lt;/em&gt; to insert the recipient's e-mail address.</source>
-        <target>Wprowadź treść newslettera. Użyj tagu &lt;em&gt;##email##&lt;/em&gt; do umieszczenia adresu e-mail odbiorcy. Link do anulowania subskrypcji &lt;em&gt;http://www.domena.com/unsubscribe-page.html?email=##email##&lt;/em&gt;.</target>
+        <target>Wprowadź treść HTML newslettera. Użyj tagu &lt;em&gt;##email##&lt;/em&gt; do umieszczenia adresu e-mail odbiorcy. Link do anulowania subskrypcji &lt;em&gt;http://www.domena.com/unsubscribe-page.html?email=##email##&lt;/em&gt;.</target>
       </trans-unit>
       <trans-unit id="tl_newsletter.text.0">
         <source>Text content</source>
-        <target>Treść</target>
+        <target>Treść tekstowa</target>
       </trans-unit>
       <trans-unit id="tl_newsletter.text.1">
         <source>Here you can enter the text content of the newsletter. Use the wildcard &lt;em&gt;##email##&lt;/em&gt; to insert the recipient's e-mail address.</source>
-        <target>Wprowadź treść newslettera. Użyj tagu &lt;em&gt;##email##&lt;/em&gt; do umieszczenia adresu e-mail odbiorcy. Link do anulowania subskrypcji &lt;em&gt;http://www.domena.com/unsubscribe-page.html?email=##email##&lt;/em&gt;.</target>
+        <target>Wprowadź treść tekstową newslettera. Użyj tagu &lt;em&gt;##email##&lt;/em&gt; do umieszczenia adresu e-mail odbiorcy. Link do anulowania subskrypcji &lt;em&gt;http://www.domena.com/unsubscribe-page.html?email=##email##&lt;/em&gt;.</target>
       </trans-unit>
       <trans-unit id="tl_newsletter.addFile.0">
         <source>Add attachments</source>
@@ -95,7 +95,7 @@
       </trans-unit>
       <trans-unit id="tl_newsletter.mailsPerCycle.1">
         <source>The sending process is split into several cycles to prevent the script from timing out.</source>
-        <target>By uniemożliwić skryptowi przekroczenia dozwolonego czasu wykonania, proces wysyłania został podzielony na kilka cykli. Tutaj możesz zdefiniować ilość wysyłanych maili w ciągu jednego cyklu, jest to uzależnione od zdefiniowanego w pliku php.ini maksymalnego czasu wykonywania jednego skryptu.</target>
+        <target>By uniemożliwić skryptowi przekroczenia dozwolonego czasu wykonania, proces wysyłania został podzielony na kilka cykli. Tutaj możesz zdefiniować ilość wysyłanych maili w ciągu jednego cyklu. Jest to uzależnione od zdefiniowanego w pliku php.ini maksymalnego czasu wykonywania jednego skryptu.</target>
       </trans-unit>
       <trans-unit id="tl_newsletter.timeout.0">
         <source>Timeout in seconds</source>
@@ -103,11 +103,11 @@
       </trans-unit>
       <trans-unit id="tl_newsletter.timeout.1">
         <source>Here you can modify the waiting time between each cycle to control the number of e-mails per minute.</source>
-        <target>Niektóre mail serwery mają limit maili, które mogą wysłać w ciągu jednej minuty. Tutaj możesz ustawić przerwę w sekundach pomiędzy każdym cyklem w celu większej kontroli operacji w ramach danego czasu.</target>
+        <target>Niektóre serwery poczty mają limit maili, które mogą wysłać w ciągu jednej minuty. Tutaj możesz ustawić przerwę w sekundach pomiędzy każdym cyklem w celu większej kontroli operacji w ramach danego czasu.</target>
       </trans-unit>
       <trans-unit id="tl_newsletter.start.0">
         <source>Offset</source>
-        <target>Offset</target>
+        <target>Przesunięcie</target>
       </trans-unit>
       <trans-unit id="tl_newsletter.start.1">
         <source>In case the sending process is interrupted, you can enter a numeric offset here to continue with a particular recipient. You can check how many mails have been sent by selecting the category &lt;code&gt;NEWSLETTER_%s&lt;/code&gt; in the system log. If there are 120 entries, enter &quot;120&quot; to continue with the 121st recipient (counting starts at 0).</source>
@@ -127,11 +127,11 @@
       </trans-unit>
       <trans-unit id="tl_newsletter.html_legend">
         <source>HTML content</source>
-        <target>Treść</target>
+        <target>Treść HTML</target>
       </trans-unit>
       <trans-unit id="tl_newsletter.text_legend">
         <source>Text content</source>
-        <target>Treść</target>
+        <target>Treść tekstowa</target>
       </trans-unit>
       <trans-unit id="tl_newsletter.attachment_legend">
         <source>Attachments</source>

--- a/newsletter-bundle/src/Resources/contao/languages/pl/tl_newsletter_channel.xlf
+++ b/newsletter-bundle/src/Resources/contao/languages/pl/tl_newsletter_channel.xlf
@@ -15,7 +15,7 @@
       </trans-unit>
       <trans-unit id="tl_newsletter_channel.jumpTo.1">
         <source>Please choose the newsletter reader page to which visitors will be redirected when clicking a newsletter.</source>
-        <target>Wybierz stronę, na którą będą przekierowani użytkownicy kiedy klikną w newsletter.</target>
+        <target>Wybierz stronę, na którą będą przekierowani użytkownicy, kiedy klikną w newsletter.</target>
       </trans-unit>
       <trans-unit id="tl_newsletter_channel.template.0">
         <source>E-mail template</source>

--- a/newsletter-bundle/src/Resources/contao/languages/pl/tl_user.xlf
+++ b/newsletter-bundle/src/Resources/contao/languages/pl/tl_user.xlf
@@ -3,11 +3,11 @@
     <body>
       <trans-unit id="tl_user.newsletters.0">
         <source>Allowed channels</source>
-        <target>Newslettery</target>
+        <target>Dozwolone kanały</target>
       </trans-unit>
       <trans-unit id="tl_user.newsletters.1">
         <source>Here you can grant access to one or more channels.</source>
-        <target>Zaznacz newslettery, które mają być dostępne dla redaktora.</target>
+        <target>Zaznacz kanały, które mają być dostępne dla redaktora.</target>
       </trans-unit>
       <trans-unit id="tl_user.newsletterp.0">
         <source>Channel permissions</source>


### PR DESCRIPTION
General correction of polish translation. Mainly misspelings, but also punctation and factual corrections.