### PR TITLE
Auto-configure doctrine.orm.mappings for app entities

### DIFF
--- a/manager-bundle/src/ContaoManager/Plugin.php
+++ b/manager-bundle/src/ContaoManager/Plugin.php
@@ -371,7 +371,7 @@ class Plugin implements BundlePluginInterface, ConfigPluginInterface, RoutingPlu
     }
 
     /**
-     * Adds a default orm mapping for the App namespace if none was configured.
+     * Adds a default ORM mapping for the App namespace if none is configured.
      *
      * @return array<string,array<string,array<string,array<string,mixed>>>>
      */
@@ -395,27 +395,28 @@ class Plugin implements BundlePluginInterface, ConfigPluginInterface, RoutingPlu
                 $mappings[] = $em['mappings'] ?? [];
             }
 
-            $autoMappingEnabled |= ($config['orm']['auto_mapping'] ?? false) ||
-                ($config['orm']['entity_managers'][$defaultEntityManager]['auto_mapping'] ?? false);
+            $autoMappingEnabled |= ($config['orm']['auto_mapping'] ?? false)
+                || ($config['orm']['entity_managers'][$defaultEntityManager]['auto_mapping'] ?? false);
         }
 
-        // Skip if auto mapping isn't enabled for the default entity manager.
+        // Skip if auto mapping is not enabled for the default entity manager.
         if (!$autoMappingEnabled) {
             return $extensionConfigs;
         }
 
-        // Skip if a mapping with name or alias 'App' already exists or any
-        // mapping already targets '%kernel.project_dir%/src/Entity'.
+        // Skip if a mapping with the name or alias "App" already exists or any
+        // mapping already targets "%kernel.project_dir%/src/Entity".
         foreach (array_replace(...$mappings) as $name => $values) {
             if (
-                'App' === $name || 'App' === ($values['alias'] ?? '') ||
-                '%kernel.project_dir%/src/Entity' === ($values['dir'] ?? '')
+                'App' === $name
+                || 'App' === ($values['alias'] ?? '')
+                || '%kernel.project_dir%/src/Entity' === ($values['dir'] ?? '')
             ) {
                 return $extensionConfigs;
             }
         }
 
-        // Skip if the '%kernel.project_dir%/src/Entity' directory does not exists.
+        // Skip if the "%kernel.project_dir%/src/Entity" directory does not exist.
         if (!$container->fileExists(Path::join($container->getParameter('kernel.project_dir'), 'src/Entity'))) {
             return $extensionConfigs;
         }

--- a/manager-bundle/src/ContaoManager/Plugin.php
+++ b/manager-bundle/src/ContaoManager/Plugin.php
@@ -138,6 +138,10 @@ class Plugin implements BundlePluginInterface, ConfigPluginInterface, RoutingPlu
                     $loader->load('@ContaoManagerBundle/Resources/skeleton/config/config_prod.yml');
                 }
 
+                if ($container->fileExists(Path::join($container->getParameter('kernel.project_dir'), 'src/Entity'))) {
+                    $loader->load('@ContaoManagerBundle/Resources/skeleton/config/config_orm_mapping.yml');
+                }
+
                 $container->setParameter('container.dumper.inline_class_loader', true);
             }
         );

--- a/manager-bundle/src/Resources/skeleton/config/config_orm_mapping.yml
+++ b/manager-bundle/src/Resources/skeleton/config/config_orm_mapping.yml
@@ -1,0 +1,9 @@
+doctrine:
+    orm:
+        mappings:
+            App:
+                type: annotation
+                dir: '%kernel.project_dir%/src/Entity'
+                is_bundle: false
+                prefix: App\Entity
+                alias: App

--- a/manager-bundle/src/Resources/skeleton/config/config_orm_mapping.yml
+++ b/manager-bundle/src/Resources/skeleton/config/config_orm_mapping.yml
@@ -1,9 +1,0 @@
-doctrine:
-    orm:
-        mappings:
-            App:
-                type: annotation
-                dir: '%kernel.project_dir%/src/Entity'
-                is_bundle: false
-                prefix: App\Entity
-                alias: App

--- a/manager-bundle/tests/ContaoManager/PluginTest.php
+++ b/manager-bundle/tests/ContaoManager/PluginTest.php
@@ -837,8 +837,7 @@ class PluginTest extends ContaoTestCase
 
     public function testRetrievesTheConnectionParametersFromTheConfiguration(): void
     {
-        $pluginLoader = $this->createMock(PluginLoader::class);
-        $container = new PluginContainerBuilder($pluginLoader, []);
+        $container = new PluginContainerBuilder($this->createMock(PluginLoader::class), []);
         $container->setParameter('kernel.project_dir', __DIR__.'/../Fixtures/app');
 
         $extensionConfigs = [
@@ -896,7 +895,7 @@ class PluginTest extends ContaoTestCase
 
         $extensionConfig = $plugin->getExtensionConfig('doctrine', [], $this->getContainer());
 
-        // Ignore dbal entry
+        // Ignore the DBAL entry
         unset($extensionConfig[0]['dbal']);
 
         $this->assertCount(1, $extensionConfig);
@@ -906,7 +905,7 @@ class PluginTest extends ContaoTestCase
     /**
      * @dataProvider getOrmMappingConfigurations
      */
-    public function testOnlyAddsDefaultDoctrineMappingIfAutoMappingEnabledAndNotAlreadyExisting(array $ormConfig, string $defaultEntityManager, bool $shouldAdd): void
+    public function testOnlyAddsTheDefaultDoctrineMappingIfAutoMappingIsEnabledAndNotAlreadyConfigured(array $ormConfig, string $defaultEntityManager, bool $shouldAdd): void
     {
         $extensionConfigs = [
             [
@@ -933,6 +932,8 @@ class PluginTest extends ContaoTestCase
             ],
         ];
 
+        $expect = $extensionConfigs;
+
         if ($shouldAdd) {
             $expect = array_merge(
                 $extensionConfigs,
@@ -954,8 +955,6 @@ class PluginTest extends ContaoTestCase
                     ],
                 ]]
             );
-        } else {
-            $expect = $extensionConfigs;
         }
 
         $plugin = new Plugin(
@@ -967,16 +966,12 @@ class PluginTest extends ContaoTestCase
         $container = $this->getContainer();
         $container->setParameter('kernel.project_dir', __DIR__.'/../Fixtures/app-with-entities');
 
-        $this->assertSame(
-            $expect,
-            $plugin->getExtensionConfig('doctrine', $extensionConfigs, $container)
-        );
+        $this->assertSame($expect, $plugin->getExtensionConfig('doctrine', $extensionConfigs, $container));
     }
 
     public function getOrmMappingConfigurations(): \Generator
     {
-        // positive configurations
-
+        // Positive configurations
         yield 'with global auto_mapping enabled' => [
             [
                 'auto_mapping' => true,
@@ -1010,8 +1005,7 @@ class PluginTest extends ContaoTestCase
             true,
         ];
 
-        // skip, because auto_mapping is not set
-
+        // Skip, because auto_mapping is not set
         yield 'with auto_mapping not set' => [
             [
             ],
@@ -1052,8 +1046,7 @@ class PluginTest extends ContaoTestCase
             false,
         ];
 
-        // skip, because conflicting mapping already exists (global)
-
+        // Skip, because conflicting mapping already exists (global)
         yield 'with existing global mapping "App"' => [
             [
                 'auto_mapping' => true,
@@ -1093,8 +1086,7 @@ class PluginTest extends ContaoTestCase
             false,
         ];
 
-        // skip, because conflicting mapping already exists (in any entity manager)
-
+        // Skip, because conflicting mapping already exists (in any entity manager)
         yield 'with existing mapping "App" in any entity manager' => [
             [
                 'auto_mapping' => true,

--- a/manager-bundle/tests/ContaoManager/PluginTest.php
+++ b/manager-bundle/tests/ContaoManager/PluginTest.php
@@ -896,7 +896,11 @@ class PluginTest extends ContaoTestCase
 
         $extensionConfig = $plugin->getExtensionConfig('doctrine', [], $this->getContainer());
 
-        $this->assertEmpty($extensionConfig);
+        // Ignore dbal entry
+        unset($extensionConfig[0]['dbal']);
+
+        $this->assertCount(1, $extensionConfig);
+        $this->assertEmpty($extensionConfig[0]);
     }
 
     /**
@@ -915,6 +919,17 @@ class PluginTest extends ContaoTestCase
                     ],
                 ],
                 'orm' => $ormConfig,
+            ],
+            [
+                'dbal' => [
+                    'connections' => [
+                        'default' => [
+                            'options' => [
+                                \PDO::MYSQL_ATTR_MULTI_STATEMENTS => false,
+                            ],
+                        ],
+                    ],
+                ],
             ],
         ];
 


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Closes #1434 
| Docs PR or issue | -

As discussed in our last call but inside the manager-bundle's `ManagerPlugin` instad of `CompilerPass`.

This effectively loads the following config by default if the `src/Entity` folder exists:

```yml
doctrine:
    orm:
        mappings:
            App:
                type: annotation
                dir: '%kernel.project_dir%/src/Entity'
                is_bundle: false
                prefix: App\Entity
                alias: App
```

This now works no matter if the folder exists and the respective config can be omitted in the application. I'm not sure about side effects though. :thinking: 