### PR TITLE
Fix parse method call for SimpleTokenParser

### DIFF
--- a/newsletter-bundle/src/Resources/contao/modules/ModuleNewsletterReader.php
+++ b/newsletter-bundle/src/Resources/contao/modules/ModuleNewsletterReader.php
@@ -128,7 +128,7 @@ class ModuleNewsletterReader extends Module
 
 		// Parse simple tokens and insert tags
 		$strContent = $this->replaceInsertTags($strContent);
-		$strContent = System::getContainer()->get(SimpleTokenParser::class)->parse($strContent, array());
+		$strContent = System::getContainer()->get(SimpleTokenParser::class)->parseTokens($strContent, array());
 
 		// Encode e-mail addresses
 		$strContent = StringUtil::encodeEmail($strContent);

--- a/newsletter-bundle/src/Resources/contao/modules/ModuleUnsubscribe.php
+++ b/newsletter-bundle/src/Resources/contao/modules/ModuleUnsubscribe.php
@@ -281,7 +281,7 @@ class ModuleUnsubscribe extends Module
 		$objEmail->from = $GLOBALS['TL_ADMIN_EMAIL'];
 		$objEmail->fromName = $GLOBALS['TL_ADMIN_NAME'];
 		$objEmail->subject = sprintf($GLOBALS['TL_LANG']['MSC']['nl_subject'], Idna::decode(Environment::get('host')));
-		$objEmail->text = System::getContainer()->get(SimpleTokenParser::class)->parse($this->nl_unsubscribe, $arrData);
+		$objEmail->text = System::getContainer()->get(SimpleTokenParser::class)->parseTokens($this->nl_unsubscribe, $arrData);
 		$objEmail->sendTo($strEmail);
 
 		// Redirect to the jumpTo page


### PR DESCRIPTION
`ModuleNewsletterReader` and `ModuleUnsubscribe` erroneously call a `parse` method of the `SimpleTokenParser` - but the method is actually called `parseTokens`.