### PR TITLE
Automatically use the configured sendmail_path

### DIFF
--- a/manager-bundle/composer.json
+++ b/manager-bundle/composer.json
@@ -50,7 +50,7 @@
         "symfony/routing": "4.4.*",
         "symfony/security-bundle": "4.4.*",
         "symfony/stopwatch": "4.4.*",
-        "symfony/swiftmailer-bundle": "^2.6.2 || ^3.1.5",
+        "symfony/swiftmailer-bundle": "^3.1.5",
         "symfony/twig-bundle": "4.4.*",
         "symfony/web-profiler-bundle": "4.4.*",
         "symfony/yaml": "4.4.*",

--- a/manager-bundle/composer.json
+++ b/manager-bundle/composer.json
@@ -50,7 +50,7 @@
         "symfony/routing": "4.4.*",
         "symfony/security-bundle": "4.4.*",
         "symfony/stopwatch": "4.4.*",
-        "symfony/swiftmailer-bundle": "^3.1.5",
+        "symfony/swiftmailer-bundle": "^3.2.8",
         "symfony/twig-bundle": "4.4.*",
         "symfony/web-profiler-bundle": "4.4.*",
         "symfony/yaml": "4.4.*",

--- a/manager-bundle/tests/ContaoManager/PluginTest.php
+++ b/manager-bundle/tests/ContaoManager/PluginTest.php
@@ -570,6 +570,48 @@ class PluginTest extends ContaoTestCase
         ];
     }
 
+    public function testSetsTheSendmailCommand(): void
+    {
+        ini_set('sendmail_path', '/foobar/sendmail -t');
+
+        $container = $this->getContainer();
+
+        $extensionConfig = (new Plugin())->getExtensionConfig('swiftmailer', [], $container);
+
+        $this->assertTrue(isset($extensionConfig[0]['command']));
+    }
+
+    public function testDoesNotSetTheSendmailCommandIfAlreadyDefined(): void
+    {
+        $container = $this->getContainer();
+
+        $extensionConfigs = [[
+            'command' => '/foobar/sendmail -t',
+        ]];
+
+        $expect = $extensionConfigs;
+
+        $extensionConfig = (new Plugin())->getExtensionConfig('swiftmailer', $extensionConfigs, $container);
+
+        $this->assertSame($expect, $extensionConfig);
+
+        $extensionConfigs = [
+            [
+                'mailers' => [
+                    'default' => [
+                        'command' => '/foobar/sendmail -t',
+                    ],
+                ],
+            ],
+        ];
+
+        $expect = $extensionConfigs;
+
+        $extensionConfig = (new Plugin())->getExtensionConfig('swiftmailer', $extensionConfigs, $container);
+
+        $this->assertSame($expect, $extensionConfig);
+    }
+
     public function testRetrievesTheConnectionParametersFromTheConfiguration(): void
     {
         $pluginLoader = $this->createMock(PluginLoader::class);

--- a/manager-bundle/tests/ContaoManager/PluginTest.php
+++ b/manager-bundle/tests/ContaoManager/PluginTest.php
@@ -572,13 +572,11 @@ class PluginTest extends ContaoTestCase
 
     public function testSetsTheSendmailCommand(): void
     {
-        ini_set('sendmail_path', '/foobar/sendmail -t');
-
         $container = $this->getContainer();
 
         $extensionConfig = (new Plugin())->getExtensionConfig('swiftmailer', [], $container);
 
-        $this->assertTrue(isset($extensionConfig[0]['command']));
+        $this->assertTrue(!ini_get('sendmail_path') || isset($extensionConfig[0]['command']));
     }
 
     public function testDoesNotSetTheSendmailCommandIfAlreadyDefined(): void


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #1261, may be #64, may be even https://github.com/contao/core-bundle/issues/1613 
| Docs PR or issue | -

A long time ago, Swiftmailer dropped support for the PHP `mail` function for security reasons and thus forcing you to use either `sendmail` or `smtp`. However, when using `sendmail`, Swiftmailer only uses a hard coded command by default, which might not work on all hosting environments. The PHP `mail` function on the other hand uses the configured `sendmail_path` of the PHP configuration, which most likely will work in the respective hosting environment. Since then, there were a lot of cases within the community where emails suddenly did not work anymore, _and still did not work with sendmail_. 

```
Uncaught PHP Exception Swift_TransportException: "Expected response code 220 but got an empty response
``` 

Only recently I learned (and began to understand the implications) that this is because some hosting environments require either a specific `sendmail` path or specific parameters for the command - which would be appropriately defined in the `sendmail_path` PHP setting.

This PR automatically injects the `sendmail_path` into the `swiftmailer` configuration. Therefore emails should work again out of the box, just like it was before when Swiftmailer still supported PHP `mail`.

Contao **4.10** is (currently) out of luck here, since Symfony Mailer only supports setting the command (see https://github.com/symfony/symfony/pull/37432) and a native transport that uses the `sendmail_path` (see https://github.com/symfony/symfony/pull/36131) in the upcoming Symfony **5.2** version (see also https://github.com/contao/contao/issues/2164).

**Note:** this PR drops support for `swiftmailer/swiftmailer-bundle` in version `2.x` and increases the version requirement to `^3.2.8`, since the feature to set the command is only really available since `3.2.8` (see https://github.com/symfony/swiftmailer-bundle/pull/286). But only for the `contao/manager-bundle`, since automatically using the `sendmail_path` is only happening there and thus, if you have a regular Symfony application requiring `contao/core-bundle` you can still choose to use `swiftmailer/swiftmailer-bundle` in version `2.x`. For the same reason we cannot fix this in Contao **4.4**, because there `swiftmailer/swiftmailer-bundle` can only be installed in a maximum version of `3.2.6`, due to other version conflicts.

**Note:** the unit tests for this are a bit lacking as `sendmail_path` cannot be changed at runtime.

## Testing Needed ❗ 

As a Windows user 🎖️ I don't have access to the native `sendmail` binary, only to a "fake sendmail" binary for Windows. However, for some reason this binary (which is also not maintained any more by the original author, afaik) is not working any more (though it did work for me in the past). While I was able to test whether the command is set to the correct value, and the command is also executed without prior errors, I was not able to test whether an email is actually sent.

So to be sure someone on a UNIX based system please test this ;)

1. Make sure that no `mailer_*` parameters are set in your `parameters.yml`.
2. Make sure that no `swiftmailer` configuration is set in your `config.yml`.
3. Make sure that no `MAILER_URL` environment variable is used.
4. Make sure that your `sendmail_path` PHP setting is correct.
5. Also verify the `sendmail_path` setting on the command line first.
6. Test with `swiftmailer:email:send --from=foo@example.com --to=foo@example.com --subject=Test --body=Test`.