### PR TITLE
Allow defining default values for the contao.image.sizes config

### DIFF
--- a/core-bundle/src/DependencyInjection/Configuration.php
+++ b/core-bundle/src/DependencyInjection/Configuration.php
@@ -181,7 +181,7 @@ class Configuration implements ConfigurationInterface
                     ->defaultValue(false)
                 ->end()
                 ->arrayNode('sizes')
-                    ->info('Allows to define image sizes in the configuration file in addition to in the Contao back end.')
+                    ->info('Allows to define image sizes in the configuration file in addition to in the Contao back end. Use the special name "_defaults" to preset values for all sizes of the configuration file.')
                     ->useAttributeAsKey('name')
                     ->validate()
                         ->always(

--- a/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
+++ b/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
@@ -179,7 +179,11 @@ class ContaoCoreExtension extends Extension
         $imageSizes = [];
 
         // Do not add a size with the special name '_default' but merge its values into all other definitions instead.
-        foreach (array_diff_key($config['image']['sizes'], ['_defaults' => null]) as $name => $value) {
+        foreach ($config['image']['sizes'] as $name => $value) {
+            if ('_defaults' === $name) {
+                continue;
+            }
+
             $imageSizes['_'.$name] = $this->camelizeKeys(
                 array_merge($config['image']['sizes']['_defaults'] ?? [], $value)
             );

--- a/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
+++ b/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
@@ -178,8 +178,11 @@ class ContaoCoreExtension extends Extension
 
         $imageSizes = [];
 
-        foreach ($config['image']['sizes'] as $name => $value) {
-            $imageSizes['_'.$name] = $this->camelizeKeys($value);
+        // Do not add a size with the special name '_default' but merge its values into all other definitions instead.
+        foreach (array_diff_key($config['image']['sizes'], ['_defaults' => null]) as $name => $value) {
+            $imageSizes['_'.$name] = $this->camelizeKeys(
+                array_merge($config['image']['sizes']['_defaults'] ?? [], $value)
+            );
         }
 
         $services = ['contao.image.image_sizes', 'contao.image.image_factory', 'contao.image.picture_factory'];

--- a/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
+++ b/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
@@ -178,15 +178,17 @@ class ContaoCoreExtension extends Extension
 
         $imageSizes = [];
 
-        // Do not add a size with the special name '_default' but merge its values into all other definitions instead.
+        // Do not add a size with the special name '_defaults' but merge its values into all other definitions instead.
         foreach ($config['image']['sizes'] as $name => $value) {
             if ('_defaults' === $name) {
                 continue;
             }
 
-            $imageSizes['_'.$name] = $this->camelizeKeys(
-                array_merge($config['image']['sizes']['_defaults'] ?? [], $value)
-            );
+            if (isset($config['image']['sizes']['_defaults'])) {
+                $value = array_merge($config['image']['sizes']['_defaults'], $value);
+            }
+
+            $imageSizes['_'.$name] = $this->camelizeKeys($value);
         }
 
         $services = ['contao.image.image_sizes', 'contao.image.image_factory', 'contao.image.picture_factory'];

--- a/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
+++ b/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
@@ -3842,14 +3842,14 @@ class ContaoCoreExtensionTest extends TestCase
 
         $sizes = $methodCalls[0][1];
 
-        $sortByKeyRecursive = static function (array &$array) use (&$sortByKeyRecursive) {
+        $sortByKeyRecursive = static function (array &$array) use (&$sortByKeyRecursive): void {
             foreach ($array as &$value) {
                 if (\is_array($value)) {
                     $sortByKeyRecursive($value);
                 }
             }
 
-            return ksort($array);
+            ksort($array);
         };
 
         $sortByKeyRecursive($expectedSizes);

--- a/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
+++ b/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
@@ -3762,6 +3762,14 @@ class ContaoCoreExtensionTest extends TestCase
                 'contao' => [
                     'image' => [
                         'sizes' => [
+                            '_defaults' => [
+                                'width' => 150,
+                            ],
+                            'foo' => [
+                                'height' => 250,
+                            ],
+                            'bar' => [
+                            ],
                             'foobar' => [
                                 'width' => 100,
                                 'height' => 200,
@@ -3797,32 +3805,57 @@ class ContaoCoreExtensionTest extends TestCase
 
         $this->assertSame('setPredefinedSizes', $methodCalls[0][0]);
 
-        $this->assertSame(
-            [[
-                '_foobar' => [
-                    'width' => 100,
-                    'height' => 200,
+        $expectedSizes = [[
+            '_foo' => [
+                'width' => 150,
+                'height' => 250,
+                'items' => [],
+                'formats' => [],
+            ],
+            '_bar' => [
+                'width' => 150,
+                'items' => [],
+                'formats' => [],
+            ],
+            '_foobar' => [
+                'width' => 100,
+                'height' => 200,
+                'resizeMode' => 'box',
+                'zoom' => 100,
+                'cssClass' => 'foobar-image',
+                'lazyLoading' => true,
+                'densities' => '1x, 2x',
+                'sizes' => '100vw',
+                'skipIfDimensionsMatch' => false,
+                'items' => [[
+                    'width' => 50,
+                    'height' => 50,
                     'resizeMode' => 'box',
                     'zoom' => 100,
-                    'cssClass' => 'foobar-image',
-                    'lazyLoading' => true,
-                    'densities' => '1x, 2x',
-                    'sizes' => '100vw',
-                    'skipIfDimensionsMatch' => false,
-                    'items' => [[
-                        'width' => 50,
-                        'height' => 50,
-                        'resizeMode' => 'box',
-                        'zoom' => 100,
-                        'densities' => '0.5x, 2x',
-                        'sizes' => '50vw',
-                        'media' => '(max-width: 900px)',
-                    ]],
-                    'formats' => [],
-                ],
-            ]],
-            $methodCalls[0][1]
-        );
+                    'densities' => '0.5x, 2x',
+                    'sizes' => '50vw',
+                    'media' => '(max-width: 900px)',
+                ]],
+                'formats' => [],
+            ],
+        ]];
+
+        $sizes = $methodCalls[0][1];
+
+        $sortByKeyRecursive = static function (array &$array) use (&$sortByKeyRecursive) {
+            foreach ($array as &$value) {
+                if (\is_array($value)) {
+                    $sortByKeyRecursive($value);
+                }
+            }
+
+            return ksort($array);
+        };
+
+        $sortByKeyRecursive($expectedSizes);
+        $sortByKeyRecursive($sizes);
+
+        $this->assertSame($expectedSizes, $sizes);
     }
 
     public function testSetsTheCrawlOptionsOnTheEscargotFactory(): void

--- a/core-bundle/tests/Image/Studio/FigureBuilderIntegrationTest.php
+++ b/core-bundle/tests/Image/Studio/FigureBuilderIntegrationTest.php
@@ -1624,14 +1624,14 @@ class FigureBuilderIntegrationTest extends TestCase
             ? $template->getData()
             : get_object_vars($template);
 
-        $sortByKeyRecursive = static function (array &$array) use (&$sortByKeyRecursive) {
+        $sortByKeyRecursive = static function (array &$array) use (&$sortByKeyRecursive): void {
             foreach ($array as &$value) {
                 if (\is_array($value)) {
                     $sortByKeyRecursive($value);
                 }
             }
 
-            return ksort($array);
+            ksort($array);
         };
 
         $sortByKeyRecursive($expected);


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Closes #2198
| Docs PR or issue | Todo

This allows defining default values for the `contao.image.sizes` config as described in #2198. 

Note, that the values won't be merged recursively, so defining `items` in a concrete config will overwrite any possibly set defaults (and not be merged with them).
