### PR TITLE
Do not log 503 exceptions

### DIFF
--- a/manager-bundle/src/Resources/skeleton/config/config_prod.yml
+++ b/manager-bundle/src/Resources/skeleton/config/config_prod.yml
@@ -15,7 +15,7 @@ monolog:
             type: fingers_crossed
             action_level: error
             handler: nested
-            excluded_http_codes: [400, 401, 403, 404]
+            excluded_http_codes: [400, 401, 403, 404, 503]
         nested:
             type: rotating_file
             max_files: 10


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | -
| Docs PR or issue | -

If you enable the maintenance mode in the back end, then any request in the front end yields the following log entry:

```
[2020-09-06 14:25:57] request.CRITICAL: Uncaught PHP Exception Symfony\Component\HttpKernel\Exception\ServiceUnavailableHttpException: "Service Temporarily Unavailable" at …/vendor/contao/contao/core-bundle/src/EventListener/ExceptionConverterListener.php line 100 {"exception":"[object] (Symfony/Component/HttpKernel/Exception/ServiceUnavailableHttpException(code: 0): Service Temporarily Unavailable at …/vendor/contao/contao/core-bundle/src/EventListener/ExceptionConverterListener.php:100, Lexik/Bundle/MaintenanceBundle/Exception/ServiceUnavailableException(code: 0): Service Temporarily Unavailable at …/vendor/lexik/maintenance-bundle/Listener/MaintenanceListener.php:206)"} []
```

However, this isn't really a critical error. We know that we put the application into a maintenance mode and thus the application responds with a `503` status for any front end request.

I think any request to the application that generates a `503 Service Unavailable` response does not need to get logged as a `request.CRITICAL` entry. Just as we do not log any request, that generated a `404 Not Found` (anymore).
