### PR TITLE
Rename the SimpleTokenParser::parseTokens() method

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Controller.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Controller.php
@@ -2150,7 +2150,7 @@ abstract class Controller extends System
 	{
 		trigger_deprecation('contao/core-bundle', '4.10', 'Using "Contao\Controller::parseSimpleTokens()" has been deprecated and will no longer work in Contao 5.0. Use the "SimpleTokenParser::class" service instead.');
 
-		return System::getContainer()->get(SimpleTokenParser::class)->parseTokens($strBuffer, $arrData);
+		return System::getContainer()->get(SimpleTokenParser::class)->parse($strBuffer, $arrData);
 	}
 
 	/**

--- a/core-bundle/src/Resources/contao/library/Contao/StringUtil.php
+++ b/core-bundle/src/Resources/contao/library/Contao/StringUtil.php
@@ -562,7 +562,7 @@ class StringUtil
 	{
 		trigger_deprecation('contao/core-bundle', '4.10', 'Using "Contao\StringUtil::parseSimpleTokens()" has been deprecated and will no longer work in Contao 5.0. Use the "SimpleTokenParser::class" service instead.');
 
-		return System::getContainer()->get(SimpleTokenParser::class)->parseTokens($strString, $arrData);
+		return System::getContainer()->get(SimpleTokenParser::class)->parse($strString, $arrData);
 	}
 
 	/**

--- a/core-bundle/src/Resources/contao/modules/ModulePassword.php
+++ b/core-bundle/src/Resources/contao/modules/ModulePassword.php
@@ -321,7 +321,7 @@ class ModulePassword extends Module
 		// Send the token
 		$optInToken->send(
 			sprintf($GLOBALS['TL_LANG']['MSC']['passwordSubject'], Idna::decode(Environment::get('host'))),
-			System::getContainer()->get(SimpleTokenParser::class)->parseTokens($this->reg_password, $arrData)
+			System::getContainer()->get(SimpleTokenParser::class)->parse($this->reg_password, $arrData)
 		);
 
 		$this->log('A new password has been requested for user ID ' . $objMember->id . ' (' . Idna::decodeEmail($objMember->email) . ')', __METHOD__, TL_ACCESS);

--- a/core-bundle/src/Resources/contao/modules/ModuleRegistration.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleRegistration.php
@@ -511,7 +511,7 @@ class ModuleRegistration extends Module
 		// Send the token
 		$optInToken->send(
 			sprintf($GLOBALS['TL_LANG']['MSC']['emailSubject'], Idna::decode(Environment::get('host'))),
-			System::getContainer()->get(SimpleTokenParser::class)->parseTokens($this->reg_text, $arrTokenData)
+			System::getContainer()->get(SimpleTokenParser::class)->parse($this->reg_text, $arrTokenData)
 		);
 	}
 

--- a/core-bundle/src/Util/SimpleTokenParser.php
+++ b/core-bundle/src/Util/SimpleTokenParser.php
@@ -39,7 +39,7 @@ class SimpleTokenParser implements LoggerAwareInterface
      * @throws \RuntimeException         If $subject cannot be parsed
      * @throws \InvalidArgumentException If there are incorrectly formatted if-tags
      */
-    public function parseTokens(string $subject, array $tokens): string
+    public function parse(string $subject, array $tokens): string
     {
         // Check if we can use the expression language or if legacy tokens have been used
         $canUseExpressionLanguage = $this->canUseExpressionLanguage($tokens);
@@ -89,6 +89,17 @@ class SimpleTokenParser implements LoggerAwareInterface
         }
 
         return $return;
+    }
+
+    /**
+     * @deprecated Deprecated since Contao 4.10, to be removed in Contao 5.0;
+     *             use the parse() method instead
+     */
+    public function parseTokens(string $subject, array $tokens): string
+    {
+        trigger_deprecation('contao/core-bundle', '4.10', 'Using the parseTokens() method has been deprecated and will no longer work in Contao 5.0. Use the parse() method instead.');
+
+        return $this->parse($subject, $tokens);
     }
 
     private function replaceTokens(string $subject, array $data): string

--- a/core-bundle/tests/Util/SimpleTokenParserTest.php
+++ b/core-bundle/tests/Util/SimpleTokenParserTest.php
@@ -26,7 +26,7 @@ class SimpleTokenParserTest extends TestCase
      */
     public function testParsesSimpleTokens(string $string, array $tokens, string $expected): void
     {
-        $this->assertSame($expected, $this->getParser()->parseTokens($string, $tokens));
+        $this->assertSame($expected, $this->getParser()->parse($string, $tokens));
     }
 
     public function parseSimpleTokensProvider(): \Generator
@@ -298,7 +298,7 @@ class SimpleTokenParserTest extends TestCase
      */
     public function testParsesSimpleTokensLegacy(string $string, array $tokens, string $expected): void
     {
-        $this->assertSame($expected, $this->getParser()->parseTokens($string, $tokens));
+        $this->assertSame($expected, $this->getParser()->parse($string, $tokens));
     }
 
     public function parseSimpleTokensLegacyProvider(): \Generator
@@ -357,7 +357,7 @@ class SimpleTokenParserTest extends TestCase
      */
     public function testHandlesLineBreaksWhenParsingSimpleTokens(string $string, array $tokens, string $expected): void
     {
-        $this->assertSame($expected, $this->getParser()->parseTokens($string, $tokens));
+        $this->assertSame($expected, $this->getParser()->parse($string, $tokens));
     }
 
     public function parseSimpleTokensCorrectNewlines(): \Generator
@@ -404,7 +404,7 @@ class SimpleTokenParserTest extends TestCase
      */
     public function testDoesNotExecutePhpCode(string $string): void
     {
-        $this->assertSame($string, $this->getParser()->parseTokens($string, []));
+        $this->assertSame($string, $this->getParser()->parse($string, []));
     }
 
     public function parseSimpleTokensDoesntExecutePhp(): \Generator
@@ -445,7 +445,7 @@ class SimpleTokenParserTest extends TestCase
      */
     public function testDoesNotExecutePhpCodeInTokens(array $tokens): void
     {
-        $this->assertSame($tokens['foo'], $this->getParser()->parseTokens('##foo##', $tokens));
+        $this->assertSame($tokens['foo'], $this->getParser()->parse('##foo##', $tokens));
     }
 
     public function parseSimpleTokensDoesntExecutePhpInToken(): \Generator
@@ -491,7 +491,7 @@ class SimpleTokenParserTest extends TestCase
 
         $this->assertSame(
             'This is <?php echo "I am evil";?> evil',
-            $this->getParser()->parseTokens('This is ##open####open2####close## evil', $data)
+            $this->getParser()->parse('This is ##open####open2####close## evil', $data)
         );
     }
 
@@ -500,7 +500,7 @@ class SimpleTokenParserTest extends TestCase
         $this->expectException('InvalidArgumentException');
         $this->expectExceptionMessage('Cannot use the constant() function in the expression for security reasons.');
 
-        $this->getParser()->parseTokens('{if constant("PHP_VERSION") > 7}match{else}no-match{endif}', []);
+        $this->getParser()->parse('{if constant("PHP_VERSION") > 7}match{else}no-match{endif}', []);
     }
 
     /**
@@ -510,7 +510,7 @@ class SimpleTokenParserTest extends TestCase
     {
         $this->expectException('InvalidArgumentException');
 
-        $this->getParser()->parseTokens($string, ['foo' => 'bar']);
+        $this->getParser()->parse($string, ['foo' => 'bar']);
     }
 
     public function parseSimpleTokensInvalidComparison(): \Generator
@@ -542,7 +542,7 @@ class SimpleTokenParserTest extends TestCase
 
         $this->assertSame(
             'Custom function evaluated!',
-            $simpleTokenParser->parseTokens("Custom function {if strtoupper(token) === 'FOO'}evaluated!{endif}", ['token' => 'foo'])
+            $simpleTokenParser->parse("Custom function {if strtoupper(token) === 'FOO'}evaluated!{endif}", ['token' => 'foo'])
         );
     }
 

--- a/newsletter-bundle/src/Resources/contao/classes/Newsletter.php
+++ b/newsletter-bundle/src/Resources/contao/classes/Newsletter.php
@@ -378,14 +378,14 @@ class Newsletter extends Backend
 		$simpleTokenParser = System::getContainer()->get(SimpleTokenParser::class);
 
 		// Prepare the text content
-		$objEmail->text = $simpleTokenParser->parseTokens($text, $arrRecipient);
+		$objEmail->text = $simpleTokenParser->parse($text, $arrRecipient);
 
 		if (!$objNewsletter->sendText)
 		{
 			$objTemplate = new BackendTemplate($objNewsletter->template ?: 'mail_default');
 			$objTemplate->setData($objNewsletter->row());
 			$objTemplate->title = $objNewsletter->subject;
-			$objTemplate->body = $simpleTokenParser->parseTokens($html, $arrRecipient);
+			$objTemplate->body = $simpleTokenParser->parse($html, $arrRecipient);
 			$objTemplate->charset = Config::get('characterSet');
 			$objTemplate->recipient = $arrRecipient['email'];
 

--- a/newsletter-bundle/src/Resources/contao/modules/ModuleSubscribe.php
+++ b/newsletter-bundle/src/Resources/contao/modules/ModuleSubscribe.php
@@ -379,7 +379,7 @@ class ModuleSubscribe extends Module
 		// Send the token
 		$optInToken->send(
 			sprintf($GLOBALS['TL_LANG']['MSC']['nl_subject'], Idna::decode(Environment::get('host'))),
-			System::getContainer()->get(SimpleTokenParser::class)->parseTokens($this->nl_subscribe, $arrData)
+			System::getContainer()->get(SimpleTokenParser::class)->parse($this->nl_subscribe, $arrData)
 		);
 
 		// Redirect to the jumpTo page


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #2233
| Docs PR or issue | -
