### PR TITLE
Do not change the CSRF token cookie if the response is not successful

### DIFF
--- a/core-bundle/src/EventListener/CsrfTokenCookieSubscriber.php
+++ b/core-bundle/src/EventListener/CsrfTokenCookieSubscriber.php
@@ -71,7 +71,7 @@ class CsrfTokenCookieSubscriber implements EventSubscriberInterface
         if ($this->requiresCsrf($request, $response)) {
             $this->setCookies($request, $response);
         } elseif ($response->isSuccessful()) {
-            // Only delete CSRF token cookie, if response is successful (#2252)
+            // Only delete the CSRF token cookie if the response is successful (#2252)
             $this->removeCookies($request, $response);
             $this->replaceTokenOccurrences($response);
         }

--- a/core-bundle/src/EventListener/CsrfTokenCookieSubscriber.php
+++ b/core-bundle/src/EventListener/CsrfTokenCookieSubscriber.php
@@ -70,12 +70,8 @@ class CsrfTokenCookieSubscriber implements EventSubscriberInterface
 
         if ($this->requiresCsrf($request, $response)) {
             $this->setCookies($request, $response);
-        } else {
-            // Do not delete CSRF token cookie, if response is not successful (#2252)
-            if (!$response->isSuccessful()) {
-                return;
-            }
-
+        } elseif ($response->isSuccessful()) {
+            // Only delete CSRF token cookie, if response is successful (#2252)
             $this->removeCookies($request, $response);
             $this->replaceTokenOccurrences($response);
         }

--- a/core-bundle/src/EventListener/CsrfTokenCookieSubscriber.php
+++ b/core-bundle/src/EventListener/CsrfTokenCookieSubscriber.php
@@ -68,14 +68,14 @@ class CsrfTokenCookieSubscriber implements EventSubscriberInterface
         $request = $event->getRequest();
         $response = $event->getResponse();
 
-        // Do not set or delete CSRF token cookie, if response is not successful (#2246)
-        if (!$response->isSuccessful()) {
-            return;
-        }
-
         if ($this->requiresCsrf($request, $response)) {
             $this->setCookies($request, $response);
         } else {
+            // Do not delete CSRF token cookie, if response is not successful (#2252)
+            if (!$response->isSuccessful()) {
+                return;
+            }
+
             $this->removeCookies($request, $response);
             $this->replaceTokenOccurrences($response);
         }

--- a/core-bundle/src/EventListener/CsrfTokenCookieSubscriber.php
+++ b/core-bundle/src/EventListener/CsrfTokenCookieSubscriber.php
@@ -68,6 +68,11 @@ class CsrfTokenCookieSubscriber implements EventSubscriberInterface
         $request = $event->getRequest();
         $response = $event->getResponse();
 
+        // Do not set or delete CSRF token cookie, if response is not successful (#2246)
+        if (!$response->isSuccessful()) {
+            return;
+        }
+
         if ($this->requiresCsrf($request, $response)) {
             $this->setCookies($request, $response);
         } else {


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #2246
| Docs PR or issue | -

I am not sure if this is the right approach to fix #2246, but I think it makes sense to never change the CSRF token cookie, if the response is not within the `>= 200, < 300` status code range. Implementing this check would fix #2246 as far as I tested.

The problem is, that an AJAX request on the same page that requires the presence of a CSRF token cookie can invalidate said CSRF token cookie, if the generated response in turn requires a new CSRF token cookie (e.g., if the 404 page redirects to another Contao page which in turn requires a CSRF token cookie).

The problem does not occur in Contao 4.4, at least not with the reproduction I posted.