### PR TITLE
Do not use floorToMinute() in the PageModel::loadDetails() method

### DIFF
--- a/core-bundle/src/Resources/contao/models/PageModel.php
+++ b/core-bundle/src/Resources/contao/models/PageModel.php
@@ -896,7 +896,7 @@ class PageModel extends Model
 		$pname = '';
 		$ptitle = '';
 		$trail = array($this->id, $pid);
-		$time = Date::floorToMinute();
+		$time = time();
 
 		// Inherit the settings
 		if ($this->type == 'root')


### PR DESCRIPTION
@ausi It seems I have missed this one. 🙈 