### PR TITLE
Always use absolute paths

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Controller.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Controller.php
@@ -1198,12 +1198,6 @@ abstract class Controller extends System
 		$objRouter = System::getContainer()->get('router');
 		$strUrl = $objRouter->generate(RouteObjectInterface::OBJECT_BASED_ROUTE_NAME, array(RouteObjectInterface::CONTENT_OBJECT => $page, 'parameters' => $strParams));
 
-		// Remove path from absolute URLs
-		if (0 === strncmp($strUrl, '/', 1))
-		{
-			$strUrl = substr($strUrl, \strlen(Environment::get('path')) + 1);
-		}
-
 		// Decode sprintf placeholders
 		if (strpos($strParams, '%') !== false)
 		{

--- a/core-bundle/src/Resources/contao/models/PageModel.php
+++ b/core-bundle/src/Resources/contao/models/PageModel.php
@@ -1133,12 +1133,6 @@ class PageModel extends Model
 		$objRouter = System::getContainer()->get('router');
 		$strUrl = $objRouter->generate(RouteObjectInterface::OBJECT_BASED_ROUTE_NAME, array(RouteObjectInterface::CONTENT_OBJECT => $this, 'parameters' => $strParams));
 
-		// Make the URL relative to the base path
-		if (0 === strncmp($strUrl, '/', 1))
-		{
-			$strUrl = substr($strUrl, \strlen(Environment::get('path')) + 1);
-		}
-
 		return $this->applyLegacyLogic($strUrl, $strParams);
 	}
 


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #2171

In Contao 4.10, we switched to using the current page model in routing. If a page's host does not match the current host, Symfony automatically adds the host name by using `NETWORK_PATH` (see https://github.com/symfony/symfony/blob/4.4/src/Symfony/Component/Routing/Generator/UrlGenerator.php#L264-L269).

Our current attempt at making paths relative breaks the `NETWORK_PATH`, and I don't think it's necessary. I know we used to need that for some browser quirks regarding the base tag, but according to [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base) the base tag should only be applied _for all relative URLs in a document_.

I think we should adhere to the Symfony standard and always use absolute paths (or absolute URLs).