### PR TITLE
Fix a wrong type hint

### DIFF
--- a/core-bundle/src/EventListener/DataContainerCallbackListener.php
+++ b/core-bundle/src/EventListener/DataContainerCallbackListener.php
@@ -71,7 +71,10 @@ class DataContainerCallbackListener
         return $dcaRef;
     }
 
-    private function updateSingleton(?array &$dcaRef, array $callbacks): void
+    /**
+     * @param array|callable|null $dcaRef
+     */
+    private function updateSingleton(&$dcaRef, array $callbacks): void
     {
         krsort($callbacks, SORT_NUMERIC);
 
@@ -81,7 +84,10 @@ class DataContainerCallbackListener
         }
     }
 
-    private function addCallbacks(?array &$dcaRef, array $callbacks): void
+    /**
+     * @param array|callable|null $dcaRef
+     */
+    private function addCallbacks(&$dcaRef, array $callbacks): void
     {
         if (null === $dcaRef) {
             $dcaRef = [];


### PR DESCRIPTION
`$dcaRef` can be of type `array|callable|null` (see line 61 above, https://github.com/contao/contao/pull/2270/files#diff-26ec4b3e6c5b2ff5898a7c6caa86c1c6L61), so the type hint is wrong and can lead to an error: 
```
Argument 1 passed to Contao\CoreBundle\EventListener\DataContainerCallbackListener::updateSingleton() 
must be of the type array or null, object given, called in 
/vendor/contao/core-bundle/src/EventListener/DataContainerCallbackListener.php on line 53
```

PS: this bug was introduced by myself in https://github.com/contao/contao/pull/1483 🙃 