### PR TITLE
Do not reindex pages with the same checksum

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Search.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Search.php
@@ -186,8 +186,7 @@ class Search
 			// The new URL is more canonical (shorter and/or less fragments)
 			if (self::compareUrls($arrSet['url'], $objIndex->url) < 0)
 			{
-				$objDatabase->prepare("DELETE FROM tl_search WHERE url=?")
-					->execute($arrSet['url']);
+				self::removeEntry($arrSet['url']);
 
 				$objDatabase->prepare("UPDATE tl_search %s WHERE id=?")
 					->set($arrSet)

--- a/core-bundle/src/Resources/contao/library/Contao/Search.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Search.php
@@ -181,27 +181,20 @@ class Search
 								->execute($arrSet['checksum'], $arrSet['pid']);
 
 		// Update the URL if the new URL is shorter or the current URL is not canonical
-		if ($objIndex->numRows && $objIndex->url != $arrSet['url'])
+		if ($objIndex->numRows)
 		{
-			if (strpos($arrSet['url'], '?') === false && strpos($objIndex->url, '?') !== false)
+			// The new URL is more canonical (shorter and/or less fragments)
+			if (self::compareUrls($arrSet['url'], $objIndex->url) < 0)
 			{
-				// The new URL is more canonical (no query string)
-				$objDatabase->prepare("DELETE FROM tl_search WHERE id=?")
-							->execute($objIndex->id);
+				$objDatabase->prepare("DELETE FROM tl_search WHERE url=?")
+					->execute($arrSet['url']);
 
-				$objDatabase->prepare("DELETE FROM tl_search_index WHERE pid=?")
-							->execute($objIndex->id);
+				$objDatabase->prepare("UPDATE tl_search %s WHERE id=?")
+					->set($arrSet)
+					->execute($objIndex->id);
 			}
-			elseif (substr_count($arrSet['url'], '/') > substr_count($objIndex->url, '/') || (strpos($arrSet['url'], '?') !== false && strpos($objIndex->url, '?') === false) || \strlen($arrSet['url']) > \strlen($objIndex->url))
-			{
-				// The current URL is more canonical (shorter and/or less fragments)
-				$arrSet['url'] = $objIndex->url;
-			}
-			else
-			{
-				// The same page has been indexed under a different URL already (see #8460)
-				return false;
-			}
+
+			return false;
 		}
 
 		$objIndex = $objDatabase->prepare("SELECT id FROM tl_search WHERE url=?")
@@ -571,5 +564,39 @@ class Search
 		}
 
 		return static::$objInstance;
+	}
+
+	/**
+	 * @param string $strUrlA
+	 * @param string $strUrlB
+	 *
+	 * @return int negative if $strUrlA is more canonical, positive if $strUrlB is more canonical
+	 */
+	private static function compareUrls($strUrlA, $strUrlB)
+	{
+		if (strpos($strUrlA, '?') === false && strpos($strUrlB, '?') !== false)
+		{
+			return -1;
+		}
+
+		if (strpos($strUrlA, '?') !== false && strpos($strUrlB, '?') === false)
+		{
+			return 1;
+		}
+
+		$slashCountA = substr_count(explode('?', $strUrlA)[0], '/');
+		$slashCountB = substr_count(explode('?', $strUrlB)[0], '/');
+
+		if ($slashCountA !== $slashCountB)
+		{
+			return $slashCountA - $slashCountB;
+		}
+
+		if (\strlen($strUrlA) !== \strlen($strUrlB))
+		{
+			return \strlen($strUrlA) - \strlen($strUrlB);
+		}
+
+		return strcmp($strUrlA, $strUrlB);
 	}
 }

--- a/core-bundle/src/Resources/contao/library/Contao/Search.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Search.php
@@ -180,7 +180,6 @@ class Search
 								->limit(1)
 								->execute($arrSet['checksum'], $arrSet['pid']);
 
-		// Update the URL if the new URL is shorter or the current URL is not canonical
 		if ($objIndex->numRows)
 		{
 			// The new URL is more canonical (shorter and/or less fragments)
@@ -189,10 +188,11 @@ class Search
 				self::removeEntry($arrSet['url']);
 
 				$objDatabase->prepare("UPDATE tl_search %s WHERE id=?")
-					->set($arrSet)
-					->execute($objIndex->id);
+							->set($arrSet)
+							->execute($objIndex->id);
 			}
 
+			// The same page has been indexed under a different URL already (see #8460)
 			return false;
 		}
 

--- a/core-bundle/tests/Contao/SearchTest.php
+++ b/core-bundle/tests/Contao/SearchTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\Contao;
+
+use Contao\CoreBundle\Tests\TestCase;
+use Contao\Search;
+
+/**
+ * Tests the Search class.
+ *
+ * @author Martin Auswöger <martin@auswoeger.com>
+ *
+ * @group contao3
+ */
+class SearchTest extends TestCase
+{
+    /**
+     * @dataProvider compareUrlsProvider
+     *
+     * @param int $expected
+     */
+    public function testCompareUrls(array $args, $expected)
+    {
+        $search = new \ReflectionClass(Search::class);
+        $compareUrls = $search->getMethod('compareUrls');
+        $compareUrls->setAccessible(true);
+
+        if ($expected < 0) {
+            $this->assertLessThan(0, $compareUrls->invokeArgs(null, $args));
+            $this->assertGreaterThan(0, $compareUrls->invokeArgs(null, array_reverse($args)));
+        } elseif ($expected > 0) {
+            $this->assertGreaterThan(0, $compareUrls->invokeArgs(null, $args));
+            $this->assertLessThan(0, $compareUrls->invokeArgs(null, array_reverse($args)));
+        } else {
+            $this->assertSame(0, $compareUrls->invokeArgs(null, $args));
+            $this->assertSame(0, $compareUrls->invokeArgs(null, array_reverse($args)));
+        }
+    }
+
+    /**
+     * Provides the data for the testCompareUrls() method.
+     *
+     * @return array
+     */
+    public function compareUrlsProvider()
+    {
+        return [
+            [['foo/bar.html', 'foo/bar.html?query'], -1],
+            [['foo/bar.html', 'foo/bar/baz.html'], -1],
+            [['foo/bar.html', 'foo/bar-baz.html'], -1],
+            [['foo/bar.html', 'foo/barr.html'], -1],
+            [['foo/bar.html', 'foo/baz.html'], -1],
+            [['foo/bar.html', 'foo/bar.html'], 0],
+            [['foo/bar-longer-url-but-no-query.html', 'foo/bar.html?query'], -1],
+            [['foo/bar-longer-url-but-less-slashes.html', 'foo/bar/baz.html'], -1],
+            [['foo.html?query/with/many/slashes/', 'foo/bar.html?query-without-slashes'], -1],
+        ];
+    }
+}

--- a/core-bundle/tests/Contao/SearchTest.php
+++ b/core-bundle/tests/Contao/SearchTest.php
@@ -23,9 +23,9 @@ use Contao\Search;
 class SearchTest extends TestCase
 {
     /**
-     * @dataProvider compareUrlsProvider
-     *
      * @param int $expected
+     *
+     * @dataProvider compareUrlsProvider
      */
     public function testCompareUrls(array $args, $expected)
     {

--- a/core-bundle/tests/Contao/SearchTest.php
+++ b/core-bundle/tests/Contao/SearchTest.php
@@ -23,26 +23,21 @@ use Contao\Search;
 class SearchTest extends TestCase
 {
     /**
-     * @param int $expected
+     * @param string $moreCanonicalUrl
+     * @param string $lessCanonicalUrl
      *
      * @dataProvider compareUrlsProvider
      */
-    public function testCompareUrls(array $args, $expected)
+    public function testCompareUrls($moreCanonicalUrl, $lessCanonicalUrl)
     {
         $search = new \ReflectionClass(Search::class);
         $compareUrls = $search->getMethod('compareUrls');
         $compareUrls->setAccessible(true);
 
-        if ($expected < 0) {
-            $this->assertLessThan(0, $compareUrls->invokeArgs(null, $args));
-            $this->assertGreaterThan(0, $compareUrls->invokeArgs(null, array_reverse($args)));
-        } elseif ($expected > 0) {
-            $this->assertGreaterThan(0, $compareUrls->invokeArgs(null, $args));
-            $this->assertLessThan(0, $compareUrls->invokeArgs(null, array_reverse($args)));
-        } else {
-            $this->assertSame(0, $compareUrls->invokeArgs(null, $args));
-            $this->assertSame(0, $compareUrls->invokeArgs(null, array_reverse($args)));
-        }
+        $this->assertLessThan(0, $compareUrls->invokeArgs(null, [$moreCanonicalUrl, $lessCanonicalUrl]));
+        $this->assertGreaterThan(0, $compareUrls->invokeArgs(null, [$lessCanonicalUrl, $moreCanonicalUrl]));
+        $this->assertSame(0, $compareUrls->invokeArgs(null, [$moreCanonicalUrl, $moreCanonicalUrl]));
+        $this->assertSame(0, $compareUrls->invokeArgs(null, [$lessCanonicalUrl, $lessCanonicalUrl]));
     }
 
     /**
@@ -53,15 +48,14 @@ class SearchTest extends TestCase
     public function compareUrlsProvider()
     {
         return [
-            [['foo/bar.html', 'foo/bar.html?query'], -1],
-            [['foo/bar.html', 'foo/bar/baz.html'], -1],
-            [['foo/bar.html', 'foo/bar-baz.html'], -1],
-            [['foo/bar.html', 'foo/barr.html'], -1],
-            [['foo/bar.html', 'foo/baz.html'], -1],
-            [['foo/bar.html', 'foo/bar.html'], 0],
-            [['foo/bar-longer-url-but-no-query.html', 'foo/bar.html?query'], -1],
-            [['foo/bar-longer-url-but-less-slashes.html', 'foo/bar/baz.html'], -1],
-            [['foo.html?query/with/many/slashes/', 'foo/bar.html?query-without-slashes'], -1],
+            ['foo/bar.html', 'foo/bar.html?query'],
+            ['foo/bar.html', 'foo/bar/baz.html'],
+            ['foo/bar.html', 'foo/bar-baz.html'],
+            ['foo/bar.html', 'foo/barr.html'],
+            ['foo/bar.html', 'foo/baz.html'],
+            ['foo/bar-longer-url-but-no-query.html', 'foo/bar.html?query'],
+            ['foo/bar-longer-url-but-less-slashes.html', 'foo/bar/baz.html'],
+            ['foo.html?query/with/many/slashes/', 'foo/bar.html?query-without-slashes'],
         ];
     }
 }


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes https://github.com/contao/contao/issues/2235#issuecomment-689569882

The new behavior now is, if there is already an entry for the same page ID with the exact same content (checksum):

1. If the new URL is less canonical (query string, more slashes or just longer) => Do nothing.
2. If the new URL is more canonical => update the existing `tl_search` row but skip the other steps as the content of the page didn’t change.