### PR TITLE
Add attributes variable to templates

### DIFF
--- a/core-bundle/src/Resources/contao/templates/block/block_searchable.html5
+++ b/core-bundle/src/Resources/contao/templates/block/block_searchable.html5
@@ -1,5 +1,5 @@
 
-<div class="<?= $this->class ?> block"<?= $this->cssID ?><?php if ($this->style): ?> style="<?= $this->style ?>"<?php endif; ?>>
+<div class="<?= $this->class ?> block"<?= $this->cssID ?><?php if ($this->style): ?> style="<?= $this->style ?>"<?php endif; ?><?= $this->attributes ?>>
 
   <?php $this->block('headline'); ?>
     <?php if ($this->headline): ?>

--- a/core-bundle/src/Resources/contao/templates/block/block_unsearchable.html5
+++ b/core-bundle/src/Resources/contao/templates/block/block_unsearchable.html5
@@ -1,6 +1,6 @@
 
 <!-- indexer::stop -->
-<div class="<?= $this->class ?> block"<?= $this->cssID ?><?php if ($this->style): ?> style="<?= $this->style ?>"<?php endif; ?>>
+<div class="<?= $this->class ?> block"<?= $this->cssID ?><?php if ($this->style): ?> style="<?= $this->style ?>"<?php endif; ?><?= $this->attributes ?>>
 
   <?php $this->block('headline'); ?>
     <?php if ($this->headline): ?>

--- a/core-bundle/src/Resources/contao/templates/elements/ce_accordionSingle.html5
+++ b/core-bundle/src/Resources/contao/templates/elements/ce_accordionSingle.html5
@@ -1,5 +1,5 @@
 
-<section class="<?= $this->class ?> ce_accordion ce_text block"<?= $this->cssID ?><?php if ($this->style): ?> style="<?= $this->style ?>"<?php endif; ?>>
+<section class="<?= $this->class ?> ce_accordion ce_text block"<?= $this->cssID ?><?php if ($this->style): ?> style="<?= $this->style ?>"<?php endif; ?><?= $this->attributes ?>>
 
   <div class="<?= $this->toggler ?>"<?php if ($this->headlineStyle): ?> style="<?= $this->headlineStyle ?>"<?php endif; ?>>
     <?= $this->headline ?>

--- a/core-bundle/src/Resources/contao/templates/elements/ce_accordionStart.html5
+++ b/core-bundle/src/Resources/contao/templates/elements/ce_accordionStart.html5
@@ -1,5 +1,5 @@
 
-<section class="<?= $this->class ?> ce_accordion block"<?= $this->cssID ?><?php if ($this->style): ?> style="<?= $this->style ?>"<?php endif; ?>>
+<section class="<?= $this->class ?> ce_accordion block"<?= $this->cssID ?><?php if ($this->style): ?> style="<?= $this->style ?>"<?php endif; ?><?= $this->attributes ?>>
 
   <div class="<?= $this->toggler ?>"<?php if ($this->headlineStyle): ?> style="<?= $this->headlineStyle ?>"<?php endif; ?>>
     <?= $this->headline ?>

--- a/core-bundle/src/Resources/contao/templates/elements/ce_headline.html5
+++ b/core-bundle/src/Resources/contao/templates/elements/ce_headline.html5
@@ -1,4 +1,4 @@
 
-<<?= $this->hl ?> class="<?= $this->class ?>"<?= $this->cssID ?><?php if ($this->style): ?> style="<?= $this->style ?>"<?php endif; ?>>
+<<?= $this->hl ?> class="<?= $this->class ?>"<?= $this->cssID ?><?php if ($this->style): ?> style="<?= $this->style ?>"<?php endif; ?><?= $this->attributes ?>>
   <?= $this->headline ?>
 </<?= $this->hl ?>>

--- a/core-bundle/src/Resources/contao/templates/elements/ce_sliderStart.html5
+++ b/core-bundle/src/Resources/contao/templates/elements/ce_sliderStart.html5
@@ -1,5 +1,5 @@
 
-<div class="<?= $this->class ?> block"<?= $this->cssID ?><?php if ($this->style): ?> style="<?= $this->style ?>"<?php endif; ?>>
+<div class="<?= $this->class ?> block"<?= $this->cssID ?><?php if ($this->style): ?> style="<?= $this->style ?>"<?php endif; ?><?= $this->attributes ?>>
 
   <?php if ($this->headline): ?>
     <<?= $this->hl ?>><?= $this->headline ?></<?= $this->hl ?>>

--- a/core-bundle/src/Resources/contao/templates/elements/ce_teaser.html5
+++ b/core-bundle/src/Resources/contao/templates/elements/ce_teaser.html5
@@ -1,5 +1,5 @@
 
-<div class="<?= $this->class ?> ce_text block"<?= $this->cssID ?><?php if ($this->style): ?> style="<?= $this->style ?>"<?php endif; ?>>
+<div class="<?= $this->class ?> ce_text block"<?= $this->cssID ?><?php if ($this->style): ?> style="<?= $this->style ?>"<?php endif; ?><?= $this->attributes ?>>
 
   <?php if ($this->headline): ?>
     <h1><?= $this->headline ?></h1>

--- a/core-bundle/src/Resources/contao/templates/elements/ce_toplink.html5
+++ b/core-bundle/src/Resources/contao/templates/elements/ce_toplink.html5
@@ -1,6 +1,6 @@
 
 <!-- indexer::stop -->
-<div class="<?= $this->class ?> block"<?= $this->cssID ?><?php if ($this->style): ?> style="<?= $this->style ?>"<?php endif; ?>>
+<div class="<?= $this->class ?> block"<?= $this->cssID ?><?php if ($this->style): ?> style="<?= $this->style ?>"<?php endif; ?><?= $this->attributes ?>>
   <a href="<?= $this->request ?>#top" title="<?= $this->title ?>"><?= $this->label ?></a>
 </div>
 <!-- indexer::continue -->

--- a/core-bundle/src/Resources/contao/templates/frontend/fe_page.html5
+++ b/core-bundle/src/Resources/contao/templates/frontend/fe_page.html5
@@ -21,7 +21,7 @@
   <?php $this->endblock(); ?>
 
 </head>
-<body id="top"<?php if ($this->class): ?> class="<?= $this->class ?>"<?php endif; ?><?php if ($this->onload): ?> onload="<?= $this->onload ?>"<?php endif; ?> itemscope itemtype="http://schema.org/WebPage">
+<body id="top"<?php if ($this->class): ?> class="<?= $this->class ?>"<?php endif; ?><?php if ($this->onload): ?> onload="<?= $this->onload ?>"<?php endif; ?> itemscope itemtype="http://schema.org/WebPage"<?php if ($this->attributes): ?> <?= $this->attributes ?><?php endif;?>>
 
   <?php $this->block('body'); ?>
     <?php $this->sections('top'); ?>

--- a/core-bundle/src/Resources/contao/templates/frontend/fe_page.html5
+++ b/core-bundle/src/Resources/contao/templates/frontend/fe_page.html5
@@ -21,7 +21,7 @@
   <?php $this->endblock(); ?>
 
 </head>
-<body id="top"<?php if ($this->class): ?> class="<?= $this->class ?>"<?php endif; ?><?php if ($this->onload): ?> onload="<?= $this->onload ?>"<?php endif; ?> itemscope itemtype="http://schema.org/WebPage"<?php if ($this->attributes): ?> <?= $this->attributes ?><?php endif; ?>>
+<body id="top"<?php if ($this->class): ?> class="<?= $this->class ?>"<?php endif; ?><?php if ($this->onload): ?> onload="<?= $this->onload ?>"<?php endif; ?> itemscope itemtype="http://schema.org/WebPage"<?= $this->attributes ?>>
 
   <?php $this->block('body'); ?>
     <?php $this->sections('top'); ?>

--- a/core-bundle/src/Resources/contao/templates/frontend/fe_page.html5
+++ b/core-bundle/src/Resources/contao/templates/frontend/fe_page.html5
@@ -21,7 +21,7 @@
   <?php $this->endblock(); ?>
 
 </head>
-<body id="top"<?php if ($this->class): ?> class="<?= $this->class ?>"<?php endif; ?><?php if ($this->onload): ?> onload="<?= $this->onload ?>"<?php endif; ?> itemscope itemtype="http://schema.org/WebPage"<?php if ($this->attributes): ?> <?= $this->attributes ?><?php endif;?>>
+<body id="top"<?php if ($this->class): ?> class="<?= $this->class ?>"<?php endif; ?><?php if ($this->onload): ?> onload="<?= $this->onload ?>"<?php endif; ?> itemscope itemtype="http://schema.org/WebPage"<?php if ($this->attributes): ?> <?= $this->attributes ?><?php endif; ?>>
 
   <?php $this->block('body'); ?>
     <?php $this->sections('top'); ?>

--- a/core-bundle/src/Resources/contao/templates/modules/mod_article.html5
+++ b/core-bundle/src/Resources/contao/templates/modules/mod_article.html5
@@ -21,7 +21,7 @@
 
 <?php else: ?>
 
-  <div class="<?= $this->class ?> block"<?= $this->cssID ?><?php if ($this->style): ?> style="<?= $this->style ?>"<?php endif; ?>>
+  <div class="<?= $this->class ?> block"<?= $this->cssID ?><?php if ($this->style): ?> style="<?= $this->style ?>"<?php endif; ?><?= $this->attributes ?>>
     <?php if ($this->printable): ?>
       <?php $this->block('syndication'); ?>
         <!-- indexer::stop -->

--- a/core-bundle/src/Resources/contao/templates/modules/mod_articlenav.html5
+++ b/core-bundle/src/Resources/contao/templates/modules/mod_articlenav.html5
@@ -1,6 +1,6 @@
 
 <!-- indexer::stop -->
-<div class="<?= $this->class ?> pagination block"<?= $this->cssID ?><?php if ($this->style): ?> style="<?= $this->style ?>"<?php endif; ?>>
+<div class="<?= $this->class ?> pagination block"<?= $this->cssID ?><?php if ($this->style): ?> style="<?= $this->style ?>"<?php endif; ?><?= $this->attributes ?>>
 
   <?php if ($this->headline): ?>
     <<?= $this->hl ?>><?= $this->headline ?></<?= $this->hl ?>>

--- a/core-bundle/src/Resources/contao/templates/modules/mod_changePassword.html5
+++ b/core-bundle/src/Resources/contao/templates/modules/mod_changePassword.html5
@@ -1,6 +1,6 @@
 
 <!-- indexer::stop -->
-<div class="<?= $this->class ?> block"<?= $this->cssID ?><?php if ($this->style): ?> style="<?= $this->style ?>"<?php endif; ?>>
+<div class="<?= $this->class ?> block"<?= $this->cssID ?><?php if ($this->style): ?> style="<?= $this->style ?>"<?php endif; ?><?= $this->attributes ?>>
 
   <?php if ($this->headline): ?>
     <<?= $this->hl ?>><?= $this->headline ?></<?= $this->hl ?>>

--- a/core-bundle/src/Resources/contao/templates/modules/mod_login.html5
+++ b/core-bundle/src/Resources/contao/templates/modules/mod_login.html5
@@ -1,6 +1,6 @@
 
 <!-- indexer::stop -->
-<div class="<?= $this->class ?> <?= $this->logout ? 'logout' : 'login' ?> block"<?= $this->cssID ?><?php if ($this->style): ?> style="<?= $this->style ?>"<?php endif; ?>>
+<div class="<?= $this->class ?> <?= $this->logout ? 'logout' : 'login' ?> block"<?= $this->cssID ?><?php if ($this->style): ?> style="<?= $this->style ?>"<?php endif; ?><?= $this->attributes ?>>
 
   <?php if ($this->headline): ?>
     <<?= $this->hl ?>><?= $this->headline ?></<?= $this->hl ?>>

--- a/core-bundle/src/Resources/contao/templates/modules/mod_navigation.html5
+++ b/core-bundle/src/Resources/contao/templates/modules/mod_navigation.html5
@@ -1,6 +1,6 @@
 
 <!-- indexer::stop -->
-<nav class="<?= $this->class ?> block"<?= $this->cssID ?><?php if ($this->style): ?> style="<?= $this->style ?>"<?php endif; ?> itemscope itemtype="http://schema.org/SiteNavigationElement">
+<nav class="<?= $this->class ?> block"<?= $this->cssID ?><?php if ($this->style): ?> style="<?= $this->style ?>"<?php endif; ?> itemscope itemtype="http://schema.org/SiteNavigationElement"<?= $this->attributes ?>>
 
   <?php if ($this->headline): ?>
     <<?= $this->hl ?>><?= $this->headline ?></<?= $this->hl ?>>

--- a/core-bundle/src/Resources/contao/templates/modules/mod_password.html5
+++ b/core-bundle/src/Resources/contao/templates/modules/mod_password.html5
@@ -1,6 +1,6 @@
 
 <!-- indexer::stop -->
-<div class="<?= $this->class ?> block"<?= $this->cssID ?><?php if ($this->style): ?> style="<?= $this->style ?>"<?php endif; ?>>
+<div class="<?= $this->class ?> block"<?= $this->cssID ?><?php if ($this->style): ?> style="<?= $this->style ?>"<?php endif; ?><?= $this->attributes ?>>
 
   <?php if ($this->headline): ?>
     <<?= $this->hl ?>><?= $this->headline ?></<?= $this->hl ?>>

--- a/core-bundle/src/Resources/contao/templates/modules/mod_two_factor.html5
+++ b/core-bundle/src/Resources/contao/templates/modules/mod_two_factor.html5
@@ -1,6 +1,6 @@
 
 <!-- indexer::stop -->
-<div class="<?= $this->class ?> two-factor block"<?= $this->cssID ?><?php if ($this->style): ?> style="<?= $this->style ?>"<?php endif; ?>>
+<div class="<?= $this->class ?> two-factor block"<?= $this->cssID ?><?php if ($this->style): ?> style="<?= $this->style ?>"<?php endif; ?><?= $this->attributes ?>>
 
   <?php if ($this->headline): ?>
     <<?= $this->hl ?>><?= $this->headline ?></<?= $this->hl ?>>


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Address    | https://contao.slack.com/archives/CK4J0KNDB/p1599547582289200

This litte PR adds an attributes variable to the body tag to add custom (data) attributes to the body tag without the need to complete  override the fe_page template. As this is a very small addition, I would love to see this also merged in the contao 4.9 and 4.4 branch. 

Usage example:
```
/**
 * @Hook("generatePage")
 */
class GeneratePageListener
{
    public function __invoke(PageModel $pageModel, LayoutModel $layout, PageRegular $pageRegular): void
    {

        $pageRegular->Template->attributes = $pageRegular->Template->attributes
            ? $pageRegular->Template->attributes .' data-custom-attribute="myCustomAttribute"'
            : 'data-custom-attribute="myCustomAttribute"';
    }
}
```

**Update:**
After discussion this pull request also adds the attributes variable to block templates and all module and element template not inheriting from block templates.