### PR TITLE
Do not use the default player size

### DIFF
--- a/core-bundle/src/Resources/contao/elements/ContentMedia.php
+++ b/core-bundle/src/Resources/contao/elements/ContentMedia.php
@@ -151,18 +151,7 @@ class ContentMedia extends ContentElement
 
 		$size = StringUtil::deserialize($this->playerSize);
 
-		if (!\is_array($size) || empty($size[0]) || empty($size[1]))
-		{
-			if ($this->Template->isVideo)
-			{
-				$this->Template->size = ' width="640" height="360"';
-			}
-			else
-			{
-				$this->Template->size = ' width="400" height="40"';
-			}
-		}
-		else
+		if (\is_array($size) && !empty($size[0]) && !empty($size[1]))
 		{
 			$this->Template->size = ' width="' . $size[0] . '" height="' . $size[1] . '"';
 		}


### PR DESCRIPTION
In the media player content element, Contao currently _always_ outputs a `width` and `height` attribute, even if no size is defined within the content element itself.

However, this prevents the element to be sized and resized responsively via CSS according to its actual size and aspect ratio. 

Thus I think we should simply remove these attributes. May be even as a bug fix in earlier versions?
