### PR TITLE
Initial concept for new accordion

### DIFF
--- a/core-bundle/src/Resources/contao/elements/ContentAccordionStart.php
+++ b/core-bundle/src/Resources/contao/elements/ContentAccordionStart.php
@@ -38,19 +38,20 @@ class ContentAccordionStart extends ContentElement
 			$this->Template->title = $this->mooHeadline;
 		}
 
+		$this->Template->headline = $this->mooHeadline;
 		$this->Template->addWrapper = true;
 
-		$prev = ContentModel::findOneBy([
-            'ptable = ?',
-            'pid = ?',
+		$prev = ContentModel::findOneBy(array(
+			'ptable = ?',
+			'pid = ?',
 			'sorting < ?',
-        ], [
-            $this->ptable,
-            $this->pid,
-            $this->sorting,
-        ], [
-            'order' => 'sorting DESC',
-		]);
+		), array(
+			$this->ptable,
+			$this->pid,
+			$this->sorting,
+		), array(
+			'order' => 'sorting DESC',
+		));
 
 		if (null !== $prev && 'accordionStop' !== $prev->type)
 		{

--- a/core-bundle/src/Resources/contao/elements/ContentAccordionStart.php
+++ b/core-bundle/src/Resources/contao/elements/ContentAccordionStart.php
@@ -38,12 +38,24 @@ class ContentAccordionStart extends ContentElement
 			$this->Template->title = $this->mooHeadline;
 		}
 
-		$classes = StringUtil::deserialize($this->mooClasses);
+		$this->Template->addWrapper = true;
 
-		$this->Template->toggler = $classes[0] ?: 'toggler';
-		$this->Template->accordion = $classes[1] ?: 'accordion';
-		$this->Template->headlineStyle = $this->mooStyle;
-		$this->Template->headline = $this->mooHeadline;
+		$prev = ContentModel::findOneBy([
+            'ptable = ?',
+            'pid = ?',
+			'sorting < ?',
+        ], [
+            $this->ptable,
+            $this->pid,
+            $this->sorting,
+        ], [
+            'order' => 'sorting DESC',
+		]);
+
+		if (null !== $prev && 'accordionStop' !== $prev->type)
+		{
+			$this->Template->addWrapper = false;
+		}
 	}
 }
 

--- a/core-bundle/src/Resources/contao/elements/ContentAccordionStop.php
+++ b/core-bundle/src/Resources/contao/elements/ContentAccordionStop.php
@@ -38,17 +38,17 @@ class ContentAccordionStop extends ContentElement
 
 		$this->Template->addWrapper = true;
 
-		$next = ContentModel::findOneBy([
-            'ptable = ?',
-            'pid = ?',
+		$next = ContentModel::findOneBy(array(
+			'ptable = ?',
+			'pid = ?',
 			'sorting > ?',
-        ], [
-            $this->ptable,
-            $this->pid,
-            $this->sorting,
-        ], [
-            'order' => 'sorting ASC',
-		]);
+		), array(
+			$this->ptable,
+			$this->pid,
+			$this->sorting,
+		), array(
+			'order' => 'sorting ASC',
+		));
 
 		if (null !== $next && 'accordionStart' !== $next->type)
 		{

--- a/core-bundle/src/Resources/contao/elements/ContentAccordionStop.php
+++ b/core-bundle/src/Resources/contao/elements/ContentAccordionStop.php
@@ -35,6 +35,25 @@ class ContentAccordionStop extends ContentElement
 			$this->strTemplate = 'be_wildcard';
 			$this->Template = new BackendTemplate($this->strTemplate);
 		}
+
+		$this->Template->addWrapper = true;
+
+		$next = ContentModel::findOneBy([
+            'ptable = ?',
+            'pid = ?',
+			'sorting > ?',
+        ], [
+            $this->ptable,
+            $this->pid,
+            $this->sorting,
+        ], [
+            'order' => 'sorting ASC',
+		]);
+
+		if (null !== $next && 'accordionStart' !== $next->type)
+		{
+			$this->Template->addWrapper = false;
+		}
 	}
 }
 

--- a/core-bundle/src/Resources/contao/templates/elements/ce_accordionStart.html5
+++ b/core-bundle/src/Resources/contao/templates/elements/ce_accordionStart.html5
@@ -1,9 +1,13 @@
 
-<section class="<?= $this->class ?> ce_accordion block"<?= $this->cssID ?><?php if ($this->style): ?> style="<?= $this->style ?>"<?php endif; ?>>
+<?php if ($this->addWrapper): ?>
+  <section class="<?= $this->class ?> ce_accordion block"<?= $this->cssID ?><?php if ($this->style): ?> style="<?= $this->style ?>"<?php endif; ?>>
+<?php endif; ?>
 
-  <div class="<?= $this->toggler ?>"<?php if ($this->headlineStyle): ?> style="<?= $this->headlineStyle ?>"<?php endif; ?>>
-    <?= $this->headline ?>
+  <div class="handorgel__headline">
+    <button class="handorgel__header__button">
+      <?= $this->headline ?>
+    </button>
   </div>
 
-  <div class="<?= $this->accordion ?>">
-    <div>
+  <div class="handorgel__content">
+    <div class="handorgel__content__inner">

--- a/core-bundle/src/Resources/contao/templates/elements/ce_accordionStop.html5
+++ b/core-bundle/src/Resources/contao/templates/elements/ce_accordionStop.html5
@@ -2,4 +2,6 @@
     </div>
   </div>
 
-</section>
+<?php if ($this->addWrapper): ?>
+  </section>
+<?php endif; ?>

--- a/core-bundle/src/Resources/contao/templates/js/js_accordion.html5
+++ b/core-bundle/src/Resources/contao/templates/js/js_accordion.html5
@@ -1,0 +1,9 @@
+<?php $GLOBALS['TL_CSS'][] = 'handorgel/handorgel.min.css'; ?>
+<?= \Contao\Template::generateScriptTag('handorgel/handorgel.min.js', false, null) ?>
+<script>
+  document.querySelectorAll('.ce_accordion').forEach(function(element) {
+    new handorgel(element, {
+      multiSelectable: false
+    });
+  })
+</script>


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #1703 
| Docs PR or issue | -

This is a draft PR showing how we could implement different accordion libraries, which require a wrapper around all accordion elements (which the current jQuery UI solution does not). The start and stop content elements simply make another database query checking whether they are preceded or followed by  a stop or start element respectively and thus only add the wrapper accordingly.