### PR TITLE
Simplify news source

### DIFF
--- a/news-bundle/src/DependencyInjection/ContaoNewsExtension.php
+++ b/news-bundle/src/DependencyInjection/ContaoNewsExtension.php
@@ -28,5 +28,6 @@ class ContaoNewsExtension extends Extension
 
         $loader->load('listener.yml');
         $loader->load('services.yml');
+        $loader->load('migrations.yml');
     }
 }

--- a/news-bundle/src/Migration/Version412/UnifyNewsSourceMigration.php
+++ b/news-bundle/src/Migration/Version412/UnifyNewsSourceMigration.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\NewsBundle\Migration\Version412;
+
+use Contao\CoreBundle\Migration\AbstractMigration;
+use Contao\CoreBundle\Migration\MigrationResult;
+use Doctrine\DBAL\Connection;
+
+/**
+ * @internal
+ */
+class UnifyNewsSourceMigration extends AbstractMigration
+{
+    /**
+     * @var Connection
+     */
+    private $connection;
+
+    public function __construct(Connection $connection)
+    {
+        $this->connection = $connection;
+    }
+
+    public function shouldRun(): bool
+    {
+        $schemaManager = $this->connection->getSchemaManager();
+
+        if (!$schemaManager->tablesExist('tl_news')) {
+            return false;
+        }
+
+        $columns = $schemaManager->listTableColumns('tl_news');
+
+        return isset($columns['articleid'], $columns['jumpto']);
+    }
+
+    public function run(): MigrationResult
+    {
+        $news = $this->connection->fetchAllAssociative(
+            "SELECT id, source, articleId, jumpTo FROM tl_news WHERE source IN ('internal', 'article')"
+        );
+
+        foreach ($news as $old) {
+            $update = [
+                'source' => 'external',
+                'target' => '',
+                'url' => 'internal' === $old['source'] ?
+                    sprintf('{{link_url::%d}}', $old['jumpTo']) :
+                    sprintf('{{article_url::%d}}', $old['articleId']),
+            ];
+
+            $this->connection->update('tl_news', $update, ['id' => $old['id']]);
+        }
+
+        $this->connection->executeQuery('ALTER TABLE tl_news DROP COLUMN articleId, DROP COLUMN jumpTo');
+
+        return $this->createResult(true);
+    }
+}

--- a/news-bundle/src/Resources/config/migrations.yml
+++ b/news-bundle/src/Resources/config/migrations.yml
@@ -1,0 +1,7 @@
+services:
+    _defaults:
+        autoconfigure: true
+
+    Contao\NewsBundle\Migration\Version412\UnifyNewsSourceMigration:
+        arguments:
+            - '@database_connection'

--- a/news-bundle/src/Resources/contao/languages/en/tl_news.xlf
+++ b/news-bundle/src/Resources/contao/languages/en/tl_news.xlf
@@ -98,18 +98,6 @@
       <trans-unit id="tl_news.default.1">
         <source>By clicking the "read more …" button, visitors will be redirected to the default page of the news archive.</source>
       </trans-unit>
-      <trans-unit id="tl_news.internal.0">
-        <source>Page</source>
-      </trans-unit>
-      <trans-unit id="tl_news.internal.1">
-        <source>By clicking the "read more …" button, visitors will be redirected to a page.</source>
-      </trans-unit>
-      <trans-unit id="tl_news.article.0">
-        <source>Article</source>
-      </trans-unit>
-      <trans-unit id="tl_news.article.1">
-        <source>By clicking the "read more …" button, visitors will be redirected to an article.</source>
-      </trans-unit>
       <trans-unit id="tl_news.external.0">
         <source>Custom URL</source>
       </trans-unit>

--- a/news-bundle/src/Resources/contao/models/NewsModel.php
+++ b/news-bundle/src/Resources/contao/models/NewsModel.php
@@ -43,8 +43,6 @@ use Contao\Model\Collection;
  * @property string|boolean $addEnclosure
  * @property string|null    $enclosure
  * @property string         $source
- * @property string|integer $jumpTo
- * @property string|integer $articleId
  * @property string         $url
  * @property string|boolean $target
  * @property string         $cssClass
@@ -84,8 +82,6 @@ use Contao\Model\Collection;
  * @method static NewsModel|null findOneByAddEnclosure($val, array $opt=array())
  * @method static NewsModel|null findOneByEnclosure($val, array $opt=array())
  * @method static NewsModel|null findOneBySource($val, array $opt=array())
- * @method static NewsModel|null findOneByJumpTo($val, array $opt=array())
- * @method static NewsModel|null findOneByArticleId($val, array $opt=array())
  * @method static NewsModel|null findOneByUrl($val, array $opt=array())
  * @method static NewsModel|null findOneByTarget($val, array $opt=array())
  * @method static NewsModel|null findOneByCssClass($val, array $opt=array())
@@ -121,8 +117,6 @@ use Contao\Model\Collection;
  * @method static Collection|NewsModel[]|NewsModel|null findByAddEnclosure($val, array $opt=array())
  * @method static Collection|NewsModel[]|NewsModel|null findByEnclosure($val, array $opt=array())
  * @method static Collection|NewsModel[]|NewsModel|null findBySource($val, array $opt=array())
- * @method static Collection|NewsModel[]|NewsModel|null findByJumpTo($val, array $opt=array())
- * @method static Collection|NewsModel[]|NewsModel|null findByArticleId($val, array $opt=array())
  * @method static Collection|NewsModel[]|NewsModel|null findByUrl($val, array $opt=array())
  * @method static Collection|NewsModel[]|NewsModel|null findByTarget($val, array $opt=array())
  * @method static Collection|NewsModel[]|NewsModel|null findByCssClass($val, array $opt=array())
@@ -162,8 +156,6 @@ use Contao\Model\Collection;
  * @method static integer countByAddEnclosure($val, array $opt=array())
  * @method static integer countByEnclosure($val, array $opt=array())
  * @method static integer countBySource($val, array $opt=array())
- * @method static integer countByJumpTo($val, array $opt=array())
- * @method static integer countByArticleId($val, array $opt=array())
  * @method static integer countByUrl($val, array $opt=array())
  * @method static integer countByTarget($val, array $opt=array())
  * @method static integer countByCssClass($val, array $opt=array())

--- a/news-bundle/src/Resources/contao/modules/ModuleNewsReader.php
+++ b/news-bundle/src/Resources/contao/modules/ModuleNewsReader.php
@@ -100,31 +100,14 @@ class ModuleNewsReader extends ModuleNews
 			throw new PageNotFoundException('Page not found: ' . Environment::get('uri'));
 		}
 
-		// Redirect if the news item has a target URL (see #1498)
-		switch ($objArticle->source) {
-			case 'internal':
-				if ($page = PageModel::findPublishedById($objArticle->jumpTo))
-				{
-					throw new RedirectResponseException($page->getAbsoluteUrl(), 301);
-				}
+		if ('external' === $objArticle->source)
+		{
+			if ($url = News::generateNewsUrl($objArticle, false, true))
+			{
+				throw new RedirectResponseException($url, 301);
+			}
 
-				throw new InternalServerErrorException('Invalid "jumpTo" value or target page not public');
-
-			case 'article':
-				if (($article = ArticleModel::findByPk($objArticle->articleId)) && ($page = PageModel::findPublishedById($article->pid)))
-				{
-					throw new RedirectResponseException($page->getAbsoluteUrl('/articles/' . ($article->alias ?: $article->id)), 301);
-				}
-
-				throw new InternalServerErrorException('Invalid "articleId" value or target page not public');
-
-			case 'external':
-				if ($objArticle->url)
-				{
-					throw new RedirectResponseException($objArticle->url, 301);
-				}
-
-				throw new InternalServerErrorException('Empty target URL');
+			throw new InternalServerErrorException('Empty target URL');
 		}
 
 		// Set the default template

--- a/news-bundle/tests/Migration/Version412/UnifyNewsSourceMigrationTest.php
+++ b/news-bundle/tests/Migration/Version412/UnifyNewsSourceMigrationTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\NewsBundle\Tests\Migration\Version412;
+
+use Contao\NewsBundle\Migration\Version412\UnifyNewsSourceMigration;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Schema\AbstractSchemaManager;
+use Doctrine\DBAL\Schema\Column;
+use PHPUnit\Framework\TestCase;
+
+class UnifyNewsSourceMigrationTest extends TestCase
+{
+    /**
+     * @dataProvider providePreconditions
+     */
+    public function testRunsIfOldFieldsExist(bool $tableExist, array $columns, bool $shouldRun): void
+    {
+        $schemaManager = $this->createMock(AbstractSchemaManager::class);
+
+        $schemaManager
+            ->expects($this->once())
+            ->method('tablesExist')
+            ->with('tl_news')
+            ->willReturn($tableExist)
+        ;
+
+        $schemaManager
+            ->method('listTableColumns')
+            ->with('tl_news')
+            ->willReturn($columns)
+        ;
+
+        $connection = $this->createMock(Connection::class);
+        $connection
+            ->method('getSchemaManager')
+            ->willReturn($schemaManager)
+        ;
+
+        $this->assertSame($shouldRun, (new UnifyNewsSourceMigration($connection))->shouldRun());
+    }
+
+    public function providePreconditions(): \Generator
+    {
+        yield 'tl_news does not exist' => [
+            false, [], false,
+        ];
+
+        $column = $this->createMock(Column::class);
+
+        yield 'already migrated (no articleid/jumpto columns)' => [
+            true, ['id' => $column, 'foo' => $column], false,
+        ];
+
+        yield 'should migrate' => [
+            true, ['id' => $column, 'articleid' => $column, 'jumpto' => $column], true,
+        ];
+    }
+
+    /**
+     * @dataProvider provideTransformations
+     */
+    public function testMigratesAndDropsColumns(array $from, array $expectedUpdate): void
+    {
+        [$source, $jumpTo, $articleId] = $from;
+
+        $connection = $this->createMock(Connection::class);
+
+        $connection
+            ->method('fetchAllAssociative')
+            ->with("SELECT id, source, articleId, jumpTo FROM tl_news WHERE source IN ('internal', 'article')")
+            ->willReturn([
+                [
+                    'id' => 123,
+                    'source' => $source,
+                    'articleId' => $articleId,
+                    'jumpTo' => $jumpTo,
+                ],
+            ])
+        ;
+
+        $connection
+            ->expects($this->once())
+            ->method('update')
+            ->with('tl_news', $expectedUpdate, ['id' => 123])
+        ;
+
+        $connection
+            ->expects($this->once())
+            ->method('executeQuery')
+            ->with('ALTER TABLE tl_news DROP COLUMN articleId, DROP COLUMN jumpTo')
+        ;
+
+        (new UnifyNewsSourceMigration($connection))->run();
+    }
+
+    public function provideTransformations(): \Generator
+    {
+        yield 'transform "internal"' => [
+            ['internal', '5', '0'],
+            ['source' => 'external', 'url' => '{{link_url::5}}', 'target' => ''],
+        ];
+
+        yield 'transform "article"' => [
+            ['article', '0', '3'],
+            ['source' => 'external', 'url' => '{{article_url::3}}', 'target' => ''],
+        ];
+    }
+}


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Closes #2196 
| Docs PR or issue | Todo

This removes the redundant news source options 'Article' and 'Page' that are also available in the picker for the url. This also allows us to get rid of two database columns.

![image](https://user-images.githubusercontent.com/5305677/93332969-ef902800-f822-11ea-8196-037feb574524.png)

I kept the radio selection even though there are only two variants (default / custom) now. Imo this makes it easier for long term users to still recognize the options and it still works if someone added their own options.

Todo:
- [x] DCA
- [ ] News class / rendering in frontend
- [x] Migration for source
- [ ] ~~Migration for allowed fields~~
- [x] Tests