### PR TITLE
Fix the resize options priority in the PictureFactory class

### DIFF
--- a/core-bundle/src/Image/PictureFactory.php
+++ b/core-bundle/src/Image/PictureFactory.php
@@ -120,12 +120,11 @@ class PictureFactory implements PictureFactoryInterface
         if ($size instanceof PictureConfiguration) {
             $config = $size;
         } else {
-            [$config, $attributes, $options] = $this->createConfig($size);
+            [$config, $attributes, $configOptions] = $this->createConfig($size);
         }
 
-        if (null === $options) {
-            $options = new ResizeOptions();
-        }
+        // Always prefer options passed to this function
+        $options = $options ?? $configOptions ?? new ResizeOptions();
 
         if (!$options->getImagineOptions()) {
             $options->setImagineOptions($this->imagineOptions);

--- a/core-bundle/tests/Image/PictureFactoryTest.php
+++ b/core-bundle/tests/Image/PictureFactoryTest.php
@@ -612,49 +612,49 @@ class PictureFactoryTest extends TestCase
 
     public function getResizeOptionsScenarios(): \Generator
     {
-        yield 'prefer skipIfDimensionsMatch from explicitly set options (1)' => [
+        yield 'Prefer skipIfDimensionsMatch from explicitly set options (1)' => [
             (new ResizeOptions())->setSkipIfDimensionsMatch(true),
             'size_skip',
             true,
         ];
 
-        yield 'prefer skipIfDimensionsMatch from explicitly set options (2)' => [
+        yield 'Prefer skipIfDimensionsMatch from explicitly set options (2)' => [
             (new ResizeOptions())->setSkipIfDimensionsMatch(true),
             'size_noskip',
             true,
         ];
 
-        yield 'prefer skipIfDimensionsMatch from explicitly set options (3)' => [
+        yield 'Prefer skipIfDimensionsMatch from explicitly set options (3)' => [
             (new ResizeOptions())->setSkipIfDimensionsMatch(false),
             'size_skip',
             false,
         ];
 
-        yield 'prefer skipIfDimensionsMatch from explicitly set options (4)' => [
+        yield 'Prefer skipIfDimensionsMatch from explicitly set options (4)' => [
             (new ResizeOptions())->setSkipIfDimensionsMatch(false),
             'size_noskip',
             false,
         ];
 
-        yield 'use skipIfDimensionsMatch from predefined size (1)' => [
+        yield 'Use skipIfDimensionsMatch from predefined size (1)' => [
             null,
             'size_skip',
             true,
         ];
 
-        yield 'use skipIfDimensionsMatch from predefined size (2)' => [
+        yield 'Use skipIfDimensionsMatch from predefined size (2)' => [
             null,
             'size_noskip',
             false,
         ];
 
-        yield 'fallback to default resize option when passing a picture configuration' => [
+        yield 'Fallback to default resize option when passing a picture configuration' => [
             null,
             new PictureConfiguration(),
             false,
         ];
 
-        yield 'fallback to default predefined size' => [
+        yield 'Fallback to default predefined size' => [
             null,
             null,
             true, // !

--- a/core-bundle/tests/Image/PictureFactoryTest.php
+++ b/core-bundle/tests/Image/PictureFactoryTest.php
@@ -657,7 +657,7 @@ class PictureFactoryTest extends TestCase
         yield 'Fallback to default predefined size' => [
             null,
             null,
-            true, // !
+            true,
         ];
     }
 

--- a/core-bundle/tests/Image/PictureFactoryTest.php
+++ b/core-bundle/tests/Image/PictureFactoryTest.php
@@ -568,6 +568,100 @@ class PictureFactoryTest extends TestCase
     }
 
     /**
+     * @dataProvider getResizeOptionsScenarios
+     */
+    public function testCreatesAPictureWithResizeOptions(?ResizeOptions $resizeOptions, $size, bool $expected): void
+    {
+        $path = $this->getTempDir().'/images/dummy.jpg';
+        $imageMock = $this->createMock(ImageInterface::class);
+
+        $pictureGenerator = $this->createMock(PictureGeneratorInterface::class);
+        $pictureGenerator
+            ->method('generate')
+            ->willReturnCallback(
+                function (ImageInterface $image, PictureConfiguration $config, ResizeOptions $options) use ($imageMock, $expected) {
+                    $this->assertSame($expected, $options->getSkipIfDimensionsMatch());
+
+                    return new Picture(['src' => $imageMock, 'srcset' => []], []);
+                }
+            )
+        ;
+
+        $imageFactory = $this->createMock(ImageFactoryInterface::class);
+        $imageFactory
+            ->method('create')
+            ->willReturn($imageMock)
+        ;
+
+        $pictureFactory = $this->getPictureFactory($pictureGenerator, $imageFactory);
+        $pictureFactory->setPredefinedSizes([
+            'size_skip' => [
+                'resizeMode' => ResizeConfiguration::MODE_BOX,
+                'skipIfDimensionsMatch' => true,
+                'items' => [],
+            ],
+            'size_noskip' => [
+                'resizeMode' => ResizeConfiguration::MODE_BOX,
+                'skipIfDimensionsMatch' => false,
+                'items' => [],
+            ],
+        ]);
+
+        $pictureFactory->create($path, $size, $resizeOptions);
+    }
+
+    public function getResizeOptionsScenarios(): \Generator
+    {
+        yield 'prefer skipIfDimensionsMatch from explicitly set options (1)' => [
+            (new ResizeOptions())->setSkipIfDimensionsMatch(true),
+            'size_skip',
+            true,
+        ];
+
+        yield 'prefer skipIfDimensionsMatch from explicitly set options (2)' => [
+            (new ResizeOptions())->setSkipIfDimensionsMatch(true),
+            'size_noskip',
+            true,
+        ];
+
+        yield 'prefer skipIfDimensionsMatch from explicitly set options (3)' => [
+            (new ResizeOptions())->setSkipIfDimensionsMatch(false),
+            'size_skip',
+            false,
+        ];
+
+        yield 'prefer skipIfDimensionsMatch from explicitly set options (4)' => [
+            (new ResizeOptions())->setSkipIfDimensionsMatch(false),
+            'size_noskip',
+            false,
+        ];
+
+        yield 'use skipIfDimensionsMatch from predefined size (1)' => [
+            null,
+            'size_skip',
+            true,
+        ];
+
+        yield 'use skipIfDimensionsMatch from predefined size (2)' => [
+            null,
+            'size_noskip',
+            false,
+        ];
+
+        yield 'fallback to default resize option when passing a picture configuration' => [
+            null,
+            new PictureConfiguration(),
+            false,
+        ];
+
+        yield 'fallback to default predefined size' => [
+            null,
+            null,
+            true, // !
+        ];
+    }
+
+    /**
      * @dataProvider getAspectRatios
      */
     public function testSetHasSingleAspectRatioAttribute(bool $expected, int $imgWidth, int $imgHeight, int $sourceWidth, int $sourceHeight): void


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes -
| Docs PR or issue | -

Options that are passed to the `PictureFactory#create` method were previously ignored in case the given `$size` was anything else than a `PictureConfiguration`. Now explicitly set options will always have precedence which allows you to overwrite those generated from predefined config.

/cc @ausi 