### PR TITLE
Add missing ResizeOptions to the studio classes

### DIFF
--- a/core-bundle/src/Image/Studio/FigureBuilder.php
+++ b/core-bundle/src/Image/Studio/FigureBuilder.php
@@ -17,6 +17,7 @@ use Contao\CoreBundle\File\Metadata;
 use Contao\FilesModel;
 use Contao\Image\ImageInterface;
 use Contao\Image\PictureConfiguration;
+use Contao\Image\ResizeOptions;
 use Contao\PageModel;
 use Contao\Validator;
 use Psr\Container\ContainerInterface;
@@ -79,6 +80,15 @@ class FigureBuilder
      * @var int|string|array|PictureConfiguration|null
      */
     private $sizeConfiguration;
+
+    /**
+     * User defined resize options.
+     *
+     * @phpcsSuppress SlevomatCodingStandard.Classes.UnusedPrivateElements
+     *
+     * @var ResizeOptions|null
+     */
+    private $resizeOptions;
 
     /**
      * User defined custom locale. This will overwrite the default if set.
@@ -281,6 +291,19 @@ class FigureBuilder
     }
 
     /**
+     * Sets resize options.
+     *
+     * By default or if the argument is set to null, resize options are derived
+     * from predefined image sizes.
+     */
+    public function setResizeOptions(?ResizeOptions $resizeOptions): self
+    {
+        $this->resizeOptions = $resizeOptions;
+
+        return $this;
+    }
+
+    /**
      * Sets custom metadata.
      *
      * By default or if the argument is set to null, metadata is trying to be
@@ -448,7 +471,7 @@ class FigureBuilder
 
         $imageResult = $this->locator
             ->get(Studio::class)
-            ->createImage($settings->filePath, $settings->sizeConfiguration)
+            ->createImage($settings->filePath, $settings->sizeConfiguration, $settings->resizeOptions)
         ;
 
         // Define the values via closure to make their evaluation lazy

--- a/core-bundle/src/Image/Studio/FigureBuilder.php
+++ b/core-bundle/src/Image/Studio/FigureBuilder.php
@@ -133,6 +133,13 @@ class FigureBuilder
     private $lightboxSizeConfiguration;
 
     /**
+     * User defined lightbox resize options.
+     *
+     * @var ResizeOptions|null
+     */
+    private $lightboxResizeOptions;
+
+    /**
      * User defined lightbox group identifier. This will overwrite the default if set.
      *
      * @var string|null
@@ -421,6 +428,19 @@ class FigureBuilder
     }
 
     /**
+     * Sets resize options for the lightbox image.
+     *
+     * By default or if the argument is set to null, resize options are derived
+     * from predefined image sizes.
+     */
+    public function setLightboxResizeOptions(?ResizeOptions $resizeOptions): self
+    {
+        $this->lightboxResizeOptions = $resizeOptions;
+
+        return $this;
+    }
+
+    /**
      * Sets a custom lightbox group ID.
      *
      * By default or if the argument is set to null, the ID will be empty. For
@@ -601,7 +621,13 @@ class FigureBuilder
 
         return $this->locator
             ->get(Studio::class)
-            ->createLightboxImage($filePathOrImage, $url, $this->lightboxSizeConfiguration, $this->lightboxGroupIdentifier)
+            ->createLightboxImage(
+                $filePathOrImage,
+                $url,
+                $this->lightboxSizeConfiguration,
+                $this->lightboxGroupIdentifier,
+                $this->lightboxResizeOptions
+            )
         ;
     }
 

--- a/core-bundle/src/Image/Studio/ImageResult.php
+++ b/core-bundle/src/Image/Studio/ImageResult.php
@@ -19,6 +19,7 @@ use Contao\Image\ImageDimensions;
 use Contao\Image\ImageInterface;
 use Contao\Image\PictureConfiguration;
 use Contao\Image\PictureInterface;
+use Contao\Image\ResizeOptions;
 use Psr\Container\ContainerInterface;
 use Webmozart\PathUtil\Path;
 
@@ -38,6 +39,11 @@ class ImageResult
      * @var int|string|array|PictureConfiguration|null
      */
     private $sizeConfiguration;
+
+    /**
+     * @var ResizeOptions|null
+     */
+    private $resizeOptions;
 
     /**
      * Cached picture.
@@ -64,12 +70,13 @@ class ImageResult
      *
      * @internal Use the Contao\Image\Studio\Studio factory to get an instance of this class
      */
-    public function __construct(ContainerInterface $locator, string $projectDir, $filePathOrImage, $sizeConfiguration = null)
+    public function __construct(ContainerInterface $locator, string $projectDir, $filePathOrImage, $sizeConfiguration = null, ResizeOptions $resizeOptions = null)
     {
         $this->locator = $locator;
         $this->projectDir = $projectDir;
         $this->filePathOrImageInterface = $filePathOrImage;
         $this->sizeConfiguration = $sizeConfiguration;
+        $this->resizeOptions = $resizeOptions;
     }
 
     /**
@@ -77,11 +84,32 @@ class ImageResult
      */
     public function getPicture(): PictureInterface
     {
-        if (null === $this->picture) {
-            $this->picture = $this->pictureFactory()->create($this->filePathOrImageInterface, $this->sizeConfiguration);
+        if (null !== $this->picture) {
+            return $this->picture;
         }
 
-        return $this->picture;
+        // Unlike the Contao\Image\PictureFactory the PictureFactoryInterface
+        // does not know about ResizeOptions. We therefore check if the third
+        // argument of the 'create' method allows setting them.
+        $canHandleResizeOptions = static function (PictureFactoryInterface $factory): bool {
+            $createParameters = (new \ReflectionClass($factory))
+                ->getMethod('create')
+                ->getParameters()
+            ;
+
+            return isset($createParameters[2]) &&
+                null !== ($type = $createParameters[2]->getType()) &&
+                ResizeOptions::class === $type->getName();
+        };
+
+        $factory = $this->pictureFactory();
+        $arguments = [$this->filePathOrImageInterface, $this->sizeConfiguration];
+
+        if (null !== $this->resizeOptions && $canHandleResizeOptions($factory)) {
+            $arguments[] = $this->resizeOptions;
+        }
+
+        return $this->picture = $this->pictureFactory()->create(...$arguments);
     }
 
     /**

--- a/core-bundle/src/Image/Studio/ImageResult.php
+++ b/core-bundle/src/Image/Studio/ImageResult.php
@@ -108,8 +108,7 @@ class ImageResult
 
             $type = $createParameters[2]->getType();
 
-            return $type instanceof \ReflectionNamedType &&
-                ResizeOptions::class === $type->getName();
+            return $type instanceof \ReflectionNamedType && ResizeOptions::class === $type->getName();
         };
 
         $factory = $this->pictureFactory();

--- a/core-bundle/src/Image/Studio/ImageResult.php
+++ b/core-bundle/src/Image/Studio/ImageResult.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Image\Studio;
 
 use Contao\CoreBundle\Image\ImageFactoryInterface;
+use Contao\CoreBundle\Image\PictureFactory;
 use Contao\CoreBundle\Image\PictureFactoryInterface;
 use Contao\Image\Image;
 use Contao\Image\ImageDimensions;
@@ -92,6 +93,10 @@ class ImageResult
         // does not know about ResizeOptions. We therefore check if the third
         // argument of the 'create' method allows setting them.
         $canHandleResizeOptions = static function (PictureFactoryInterface $factory): bool {
+            if ($factory instanceof PictureFactory) {
+                return true;
+            }
+
             $createParameters = (new \ReflectionClass($factory))
                 ->getMethod('create')
                 ->getParameters()

--- a/core-bundle/src/Image/Studio/ImageResult.php
+++ b/core-bundle/src/Image/Studio/ImageResult.php
@@ -97,8 +97,13 @@ class ImageResult
                 ->getParameters()
             ;
 
-            return isset($createParameters[2]) &&
-                null !== ($type = $createParameters[2]->getType()) &&
+            if (!isset($createParameters[2])) {
+                return false;
+            }
+
+            $type = $createParameters[2]->getType();
+
+            return $type instanceof \ReflectionNamedType &&
                 ResizeOptions::class === $type->getName();
         };
 

--- a/core-bundle/src/Image/Studio/LightboxResult.php
+++ b/core-bundle/src/Image/Studio/LightboxResult.php
@@ -14,6 +14,7 @@ namespace Contao\CoreBundle\Image\Studio;
 
 use Contao\Image\ImageInterface;
 use Contao\Image\PictureConfiguration;
+use Contao\Image\ResizeOptions;
 use Contao\LayoutModel;
 use Contao\PageModel;
 use Contao\StringUtil;
@@ -47,7 +48,7 @@ class LightboxResult
      *
      * @internal Use the Contao\Image\Studio\Studio factory to get an instance of this class
      */
-    public function __construct(ContainerInterface $locator, $filePathOrImage, ?string $url, $sizeConfiguration = null, string $groupIdentifier = null)
+    public function __construct(ContainerInterface $locator, $filePathOrImage, ?string $url, $sizeConfiguration = null, string $groupIdentifier = null, ResizeOptions $resizeOptions = null)
     {
         if (1 !== \count(array_filter([$filePathOrImage, $url]))) {
             throw new \InvalidArgumentException('A lightbox must be either constructed with a resource or an URL.');
@@ -60,7 +61,11 @@ class LightboxResult
         if (null !== $filePathOrImage) {
             $this->image = $locator
                 ->get(Studio::class)
-                ->createImage($filePathOrImage, $sizeConfiguration ?? $this->getDefaultLightboxSizeConfiguration())
+                ->createImage(
+                    $filePathOrImage,
+                    $sizeConfiguration ?? $this->getDefaultLightboxSizeConfiguration(),
+                    $resizeOptions
+                )
             ;
         }
     }

--- a/core-bundle/src/Image/Studio/Studio.php
+++ b/core-bundle/src/Image/Studio/Studio.php
@@ -18,6 +18,7 @@ use Contao\CoreBundle\Image\ImageFactoryInterface;
 use Contao\CoreBundle\Image\PictureFactoryInterface;
 use Contao\Image\ImageInterface;
 use Contao\Image\PictureConfiguration;
+use Contao\Image\ResizeOptions;
 use Psr\Container\ContainerInterface;
 use Symfony\Contracts\Service\ServiceSubscriberInterface;
 
@@ -59,9 +60,9 @@ class Studio implements ServiceSubscriberInterface
     /**
      * @param string|ImageInterface $filePathOrImage
      */
-    public function createImage($filePathOrImage, $sizeConfiguration): ImageResult
+    public function createImage($filePathOrImage, $sizeConfiguration, ResizeOptions $resizeOptions = null): ImageResult
     {
-        return new ImageResult($this->locator, $this->projectDir, $filePathOrImage, $sizeConfiguration);
+        return new ImageResult($this->locator, $this->projectDir, $filePathOrImage, $sizeConfiguration, $resizeOptions);
     }
 
     /**

--- a/core-bundle/src/Image/Studio/Studio.php
+++ b/core-bundle/src/Image/Studio/Studio.php
@@ -69,9 +69,9 @@ class Studio implements ServiceSubscriberInterface
      * @param string|ImageInterface|null                 $filePathOrImage
      * @param array|PictureConfiguration|int|string|null $sizeConfiguration
      */
-    public function createLightboxImage($filePathOrImage, string $url = null, $sizeConfiguration = null, string $groupIdentifier = null): LightboxResult
+    public function createLightboxImage($filePathOrImage, string $url = null, $sizeConfiguration = null, string $groupIdentifier = null, ResizeOptions $resizeOptions = null): LightboxResult
     {
-        return new LightboxResult($this->locator, $filePathOrImage, $url, $sizeConfiguration, $groupIdentifier);
+        return new LightboxResult($this->locator, $filePathOrImage, $url, $sizeConfiguration, $groupIdentifier, $resizeOptions);
     }
 
     public static function getSubscribedServices(): array

--- a/core-bundle/tests/Fixtures/Image/PictureFactoryWithRandomArgumentStub.php
+++ b/core-bundle/tests/Fixtures/Image/PictureFactoryWithRandomArgumentStub.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\Fixtures\Image;
+
+use Contao\CoreBundle\Image\PictureFactoryInterface;
+use Contao\Image\PictureInterface;
+
+class PictureFactoryWithRandomArgumentStub implements PictureFactoryInterface
+{
+    public function setDefaultDensities($densities): void
+    {
+        throw new \RuntimeException('not implemented');
+    }
+
+    public function create($path, $size = null, array $options = null): PictureInterface
+    {
+        throw new \RuntimeException('not implemented');
+    }
+}

--- a/core-bundle/tests/Fixtures/Image/PictureFactoryWithResizeOptionsStub.php
+++ b/core-bundle/tests/Fixtures/Image/PictureFactoryWithResizeOptionsStub.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\Fixtures\Image;
+
+use Contao\CoreBundle\Image\PictureFactoryInterface;
+use Contao\Image\PictureInterface;
+use Contao\Image\ResizeOptions;
+
+class PictureFactoryWithResizeOptionsStub implements PictureFactoryInterface
+{
+    public function setDefaultDensities($densities): void
+    {
+        throw new \RuntimeException('not implemented');
+    }
+
+    public function create($path, $size = null, ResizeOptions $options = null): PictureInterface
+    {
+        throw new \RuntimeException('not implemented');
+    }
+}

--- a/core-bundle/tests/Fixtures/Image/PictureFactoryWithoutResizeOptionsStub.php
+++ b/core-bundle/tests/Fixtures/Image/PictureFactoryWithoutResizeOptionsStub.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\Fixtures\Image;
+
+use Contao\CoreBundle\Image\PictureFactoryInterface;
+use Contao\Image\PictureInterface;
+
+class PictureFactoryWithoutResizeOptionsStub implements PictureFactoryInterface
+{
+    public function setDefaultDensities($densities): void
+    {
+        throw new \RuntimeException('not implemented');
+    }
+
+    public function create($path, $size = null): PictureInterface
+    {
+        throw new \RuntimeException('not implemented');
+    }
+}

--- a/core-bundle/tests/Image/Studio/FigureBuilderTest.php
+++ b/core-bundle/tests/Image/Studio/FigureBuilderTest.php
@@ -23,6 +23,7 @@ use Contao\CoreBundle\Image\Studio\Studio;
 use Contao\CoreBundle\Tests\TestCase;
 use Contao\FilesModel;
 use Contao\Image\ImageInterface;
+use Contao\Image\ResizeOptions;
 use Contao\PageModel;
 use Contao\System;
 use Contao\Validator;
@@ -340,6 +341,20 @@ class FigureBuilderTest extends TestCase
         $this->getFigureBuilder($studio)
             ->fromPath($absoluteFilePath, false)
             ->setSize($size)
+            ->build()
+        ;
+    }
+
+    public function testSetResizeOptions(): void
+    {
+        [$absoluteFilePath] = $this->getTestFilePaths();
+
+        $resizeOptions = new ResizeOptions();
+        $studio = $this->getStudioMockForImage($absoluteFilePath, null, $resizeOptions);
+
+        $this->getFigureBuilder($studio)
+            ->fromPath($absoluteFilePath, false)
+            ->setResizeOptions($resizeOptions)
             ->build()
         ;
     }
@@ -773,6 +788,27 @@ class FigureBuilderTest extends TestCase
         $this->assertTrue($figure->hasLightbox());
     }
 
+    public function testSetLightboxResizeOptions(): void
+    {
+        /** @var ImageInterface&MockObject $image */
+        $image = $this->createMock(ImageInterface::class);
+        $resizeOptions = new ResizeOptions();
+        $studio = $this->getStudioMockForLightbox($image, null, null, null, $resizeOptions);
+
+        $figure = $this->getFigure(
+            static function (FigureBuilder $builder) use ($image, $resizeOptions): void {
+                $builder
+                    ->setLightboxResourceOrUrl($image)
+                    ->setLightboxResizeOptions($resizeOptions)
+                    ->enableLightbox()
+                ;
+            },
+            $studio
+        );
+
+        $this->assertTrue($figure->hasLightbox());
+    }
+
     public function testSetLightboxGroupIdentifier(): void
     {
         /** @var ImageInterface&MockObject $image */
@@ -891,7 +927,7 @@ class FigureBuilderTest extends TestCase
     /**
      * @return MockObject&Studio
      */
-    private function getStudioMockForImage(string $expectedFilePath, $expectedSizeConfiguration = null)
+    private function getStudioMockForImage(string $expectedFilePath, $expectedSizeConfiguration = null, ResizeOptions $resizeOptions = null)
     {
         /** @var ImageResult&MockObject $image */
         $image = $this->createMock(ImageResult::class);
@@ -901,7 +937,7 @@ class FigureBuilderTest extends TestCase
         $studio
             ->expects($this->once())
             ->method('createImage')
-            ->with($expectedFilePath, $expectedSizeConfiguration)
+            ->with($expectedFilePath, $expectedSizeConfiguration, $resizeOptions)
             ->willReturn($image)
         ;
 
@@ -911,7 +947,7 @@ class FigureBuilderTest extends TestCase
     /**
      * @return MockObject&Studio
      */
-    private function getStudioMockForLightbox($expectedResource, ?string $expectedUrl, $expectedSizeConfiguration = null, string $expectedGroupIdentifier = null)
+    private function getStudioMockForLightbox($expectedResource, ?string $expectedUrl, $expectedSizeConfiguration = null, string $expectedGroupIdentifier = null, ResizeOptions $resizeOptions = null)
     {
         /** @var LightboxResult&MockObject $lightbox */
         $lightbox = $this->createMock(LightboxResult::class);
@@ -921,7 +957,7 @@ class FigureBuilderTest extends TestCase
         $studio
             ->expects($this->once())
             ->method('createLightboxImage')
-            ->with($expectedResource, $expectedUrl, $expectedSizeConfiguration, $expectedGroupIdentifier)
+            ->with($expectedResource, $expectedUrl, $expectedSizeConfiguration, $expectedGroupIdentifier, $resizeOptions)
             ->willReturn($lightbox)
         ;
 

--- a/core-bundle/tests/Image/Studio/FigureBuilderTest.php
+++ b/core-bundle/tests/Image/Studio/FigureBuilderTest.php
@@ -830,8 +830,8 @@ class FigureBuilderTest extends TestCase
             ->expects($this->exactly(2))
             ->method('createImage')
             ->willReturnMap([
-                [$filePath1, null, $imageResult1],
-                [$filePath2, null, $imageResult2],
+                [$filePath1, null, null, $imageResult1],
+                [$filePath2, null, null, $imageResult2],
             ])
         ;
 

--- a/core-bundle/tests/Image/Studio/ImageResultTest.php
+++ b/core-bundle/tests/Image/Studio/ImageResultTest.php
@@ -25,8 +25,8 @@ use Contao\Image\Image;
 use Contao\Image\ImageDimensions;
 use Contao\Image\ImageInterface;
 use Contao\Image\PictureInterface;
-use Imagine\Image\ImagineInterface;
 use Contao\Image\ResizeOptions;
+use Imagine\Image\ImagineInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\Filesystem\Filesystem;
@@ -92,17 +92,17 @@ class ImageResultTest extends TestCase
             true,
         ];
 
-        yield 'custom picture factory with resize options' => [
+        yield 'Custom picture factory with resize options' => [
             PictureFactoryWithResizeOptionsStub::class,
             true,
         ];
 
-        yield 'custom picture factory without resize options' => [
+        yield 'Custom picture factory without resize options' => [
             PictureFactoryWithoutResizeOptionsStub::class,
             false,
         ];
 
-        yield 'custom picture factory with random options' => [
+        yield 'Custom picture factory with random options' => [
             PictureFactoryWithRandomArgumentStub::class,
             false,
         ];

--- a/core-bundle/tests/Image/Studio/ImageResultTest.php
+++ b/core-bundle/tests/Image/Studio/ImageResultTest.php
@@ -14,14 +14,19 @@ namespace Contao\CoreBundle\Tests\Image\Studio;
 
 use Contao\CoreBundle\Asset\ContaoContext;
 use Contao\CoreBundle\Image\ImageFactoryInterface;
+use Contao\CoreBundle\Image\PictureFactory;
 use Contao\CoreBundle\Image\PictureFactoryInterface;
 use Contao\CoreBundle\Image\Studio\ImageResult;
+use Contao\CoreBundle\Tests\Fixtures\Image\PictureFactoryWithoutResizeOptionsStub;
+use Contao\CoreBundle\Tests\Fixtures\Image\PictureFactoryWithRandomArgumentStub;
+use Contao\CoreBundle\Tests\Fixtures\Image\PictureFactoryWithResizeOptionsStub;
 use Contao\CoreBundle\Tests\TestCase;
 use Contao\Image\Image;
 use Contao\Image\ImageDimensions;
 use Contao\Image\ImageInterface;
 use Contao\Image\PictureInterface;
 use Imagine\Image\ImagineInterface;
+use Contao\Image\ResizeOptions;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\Filesystem\Filesystem;
@@ -40,6 +45,67 @@ class ImageResultTest extends TestCase
         $imageResult = new ImageResult($locator, '/project/dir', $filePathOrImage, $sizeConfiguration);
 
         $this->assertSame($picture, $imageResult->getPicture());
+    }
+
+    /**
+     * @dataProvider providePictureFactories
+     */
+    public function testGetPictureWithResizeMode(string $pictureFactory, bool $supportsResizeOptions): void
+    {
+        $resizeOptions = new ResizeOptions();
+
+        /** @var PictureFactoryInterface&MockObject $pictureFactory */
+        $pictureFactory = $this->createMock($pictureFactory);
+        $pictureFactory
+            ->expects($this->once())
+            ->method('create')
+            ->willReturnCallback(
+                function () use ($supportsResizeOptions, $resizeOptions) {
+                    // Expect factories with a compatible 'create' method signature
+                    // to be called with $resizeOptions as 3rd argument.
+                    if ($supportsResizeOptions) {
+                        $this->assertSame($resizeOptions, func_get_arg(2));
+                    } else {
+                        $this->assertNull(\func_get_args()[2] ?? null);
+                    }
+
+                    return $this->createMock(PictureInterface::class);
+                }
+            )
+        ;
+
+        $imageResult = new ImageResult(
+            $this->getLocatorMock($pictureFactory),
+            'any/project/dir',
+            'foo/bar/foobar.png',
+            [100, 200, 'crop'],
+            $resizeOptions
+        );
+
+        $imageResult->getPicture();
+    }
+
+    public function providePictureFactories(): \Generator
+    {
+        yield 'Contao default picture factory' => [
+            PictureFactory::class,
+            true,
+        ];
+
+        yield 'custom picture factory with resize options' => [
+            PictureFactoryWithResizeOptionsStub::class,
+            true,
+        ];
+
+        yield 'custom picture factory without resize options' => [
+            PictureFactoryWithoutResizeOptionsStub::class,
+            false,
+        ];
+
+        yield 'custom picture factory with random options' => [
+            PictureFactoryWithRandomArgumentStub::class,
+            false,
+        ];
     }
 
     public function testGetSourcesAndImg(): void

--- a/core-bundle/tests/Image/Studio/LightboxResultTest.php
+++ b/core-bundle/tests/Image/Studio/LightboxResultTest.php
@@ -16,6 +16,7 @@ use Contao\CoreBundle\Image\Studio\ImageResult;
 use Contao\CoreBundle\Image\Studio\LightboxResult;
 use Contao\CoreBundle\Image\Studio\Studio;
 use Contao\CoreBundle\Tests\TestCase;
+use Contao\Image\ResizeOptions;
 use Contao\LayoutModel;
 use Contao\PageModel;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -323,5 +324,37 @@ class LightboxResultTest extends TestCase
         $lightboxResult = new LightboxResult($locator, null, 'foo://bar');
 
         $this->assertSame('', $lightboxResult->getGroupIdentifier());
+    }
+
+    public function testPassesOnResizeOptions(): void
+    {
+        $resource = 'foo/bar.png';
+        $size = [100, 200, 'crop'];
+        $resizeOptions = new ResizeOptions();
+
+        /** @var MockObject&ImageResult $image */
+        $image = $this->createMock(ImageResult::class);
+
+        /** @var MockObject&Studio $studio */
+        $studio = $this->createMock(Studio::class);
+        $studio
+            ->expects($this->once())
+            ->method('createImage')
+            ->with($resource, $size, $resizeOptions)
+            ->willReturn($image)
+        ;
+
+        /** @var MockObject&ContainerInterface $locator */
+        $locator = $this->createMock(ContainerInterface::class);
+        $locator
+            ->expects($this->once())
+            ->method('get')
+            ->with(Studio::class)
+            ->willReturn($studio)
+        ;
+
+        $lightboxResult = new LightboxResult($locator, $resource, null, $size, null, $resizeOptions);
+
+        $this->assertSame($image, $lightboxResult->getImage());
     }
 }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -34,6 +34,9 @@ parameters:
         # Ignore the wrong return type hint of the UrlGeneratorInterface::generate() method
         - '#Method Contao\\CoreBundle\\Picker\\AbstractPickerProvider::generateUrl\(\) never returns null so it can be removed from the return typehint\.#'
 
+        # Ignore missing documentation of the ReflectionType::getName() method
+        - '#Call to an undefined method ReflectionType::getName\(\)\.#'
+
     treatPhpDocTypesAsCertain: false
     checkGenericClassInNonGenericObjectType: false
     inferPrivatePropertyTypeFromConstructor: true

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -34,9 +34,6 @@ parameters:
         # Ignore the wrong return type hint of the UrlGeneratorInterface::generate() method
         - '#Method Contao\\CoreBundle\\Picker\\AbstractPickerProvider::generateUrl\(\) never returns null so it can be removed from the return typehint\.#'
 
-        # Ignore missing documentation of the ReflectionType::getName() method
-        - '#Call to an undefined method ReflectionType::getName\(\)\.#'
-
     treatPhpDocTypesAsCertain: false
     checkGenericClassInNonGenericObjectType: false
     inferPrivatePropertyTypeFromConstructor: true


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes -
| Docs PR or issue | Todo

The studio classes are currently lacking a way to set resize options. This however is needed if you e.g. want to control `skipIfDimensionsMatch` without a predefined image config.  This PR fixes this issue by allowing to define them in the `ImageResult`/`LightboxResultResult` as well as in the `FigureBuilder` (`setResizeOptions()` + `setLightboxResizeOptions()`).

Note that we need to feature detect if the app's picture factory supports this as the `ResizeOptions` were added [later on](94813e3182ed550bbfa4608457d840912cda172b ) and the interface unfortunately doesn't contain them. 

Todo:
- [x] adjust existing tests
- [x] add tests
- [x] decide if we want to trigger a warning when trying to use resize options with a factory that doesn't support them
- [x] rebase/drop [commit](81f72ea86534ff445fd39e1f67996cd2d339e9d0) once #2313 is merged