### PR TITLE
Load all languages for metawizard options

### DIFF
--- a/core-bundle/src/Resources/contao/widgets/MetaWizard.php
+++ b/core-bundle/src/Resources/contao/widgets/MetaWizard.php
@@ -128,7 +128,7 @@ class MetaWizard extends Widget
 			return '<p class="tl_info">' . $GLOBALS['TL_LANG']['MSC']['metaNoLanguages'] . '</p>';
 		}
 
-		$languages = $this->getLanguages(true);
+		$languages = $this->getLanguages();
 
 		// Add the existing entries
 		if (!empty($this->varValue))


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | https://contao.slack.com/archives/CK4J0KNDB/p1600785877095400
| Docs PR or issue | n/a

The metawizard select should display all languages, not just the one available in the backend:

**wrong** 
![Bildschirmfoto 2020-09-22 um 17 05 42](https://user-images.githubusercontent.com/754921/93900663-f40e8200-fcf5-11ea-84ce-c1ade54062c6.png)

**correct**
![Bildschirmfoto 2020-09-22 um 17 05 59](https://user-images.githubusercontent.com/754921/93900697-fe308080-fcf5-11ea-966b-6275f16e1d87.png)

Origin: https://github.com/contao/core-bundle/commit/740ede20eb1dbffe79204cd7f4ea8ff0ed4b62ed