### PR TITLE
Only use $dc->id in the protectFolder() method

### DIFF
--- a/core-bundle/src/Resources/contao/dca/tl_files.php
+++ b/core-bundle/src/Resources/contao/dca/tl_files.php
@@ -808,13 +808,7 @@ class tl_files extends Contao\Backend
 	 */
 	public function protectFolder(Contao\DataContainer $dc)
 	{
-		if (!$dc->activeRecord || !$dc->activeRecord->path)
-		{
-			// This should never happen, because DC_Folder does not support "override all"
-			throw new \InvalidArgumentException('The DataContainer object does not contain a valid active record');
-		}
-
-		$strPath = $dc->activeRecord->path;
+		$strPath = $dc->id;
 		$projectDir = Contao\System::getContainer()->getParameter('kernel.project_dir');
 
 		// Only show for folders (see #5660)


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #2338
| Docs PR or issue | -

As discussed in Mumble on September 24th, we should not have to use the active record at all, because of:

https://github.com/contao/contao/blob/59dd103ad9c1e054fd19737306ab94bcdc87d03f/core-bundle/src/Resources/contao/drivers/DC_Folder.php#L2304
