### PR TITLE
Fix includeBlankOption with value 0 - issue 1022

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Widget.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Widget.php
@@ -1153,7 +1153,7 @@ abstract class Widget extends Controller
 			return '';
 		}
 
-		return (\is_array($varValues) ? \in_array($strOption, $varValues) : $strOption == $varValues) ? ' selected' : '';
+		return \in_array((string) $strOption, array_map('strval', (array) $varValues), true) ? ' selected' : '';
 	}
 
 	/**


### PR DESCRIPTION
Fix includeBlankOption with value 0

implement https://github.com/contao/contao/issues/1022#issuecomment-575210705 with cast option values to string if values int - see https://github.com/menatwork/contao-multicolumnwizard-bundle/issues/63

| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #1022
