### PR TITLE
Override the size variable for the ce_player template

### DIFF
--- a/core-bundle/src/Resources/contao/elements/ContentMedia.php
+++ b/core-bundle/src/Resources/contao/elements/ContentMedia.php
@@ -157,6 +157,7 @@ class ContentMedia extends ContentElement
 		}
 		else
 		{
+			// $this->size might contain image size data, therefore unset it (see #2351)
 			$this->Template->size = '';
 		}
 

--- a/core-bundle/src/Resources/contao/elements/ContentMedia.php
+++ b/core-bundle/src/Resources/contao/elements/ContentMedia.php
@@ -155,6 +155,10 @@ class ContentMedia extends ContentElement
 		{
 			$this->Template->size = ' width="' . $size[0] . '" height="' . $size[1] . '"';
 		}
+		else
+		{
+			$this->Template->size = '';
+		}
 
 		$this->Template->files = array_values(array_filter($arrFiles));
 


### PR DESCRIPTION
In https://github.com/contao/contao/pull/2300 we removed the old default player size for the media content element. However, since the template is, by default, always filled with all the fields from `tl_content`, the `$this->size` variable might then contain image size data (for text, image and gallery content elements). 

**Reproduction:**

1. Create a new `text` content element.
2. Enable _Add image_.
3. Save the content element.
4. Change the content element type to `Video/audio player`.
5. Select a video and save.

The front end will then output the following invalid HTML:

```html
<div class="ce_player first block">
  <figure class="video_container">
    <videoa:3:{i:0;s:0:"";i:1;s:0:"";i:2;s:0:"";} controls>
      <source type="video/mp4" src="files/foo/bar.mp4" title="bar.mp4">
    </video>
  </figure>
</div>
```

This PR fixes this by setting the `size` template variable to an empty string, if no size is given.