### PR TITLE
Fix picker for providers with insert tags

### DIFF
--- a/core-bundle/src/Resources/contao/classes/DataContainer.php
+++ b/core-bundle/src/Resources/contao/classes/DataContainer.php
@@ -969,24 +969,24 @@ abstract class DataContainer extends \Backend
 	}
 
 	/**
-	 * Returns a data-picker-value attribute with the currently selected picker values (#1816).
-	 * 
+	 * Returns a data-picker-value attribute with the currently selected picker values (#1816)
+	 *
 	 * @return string
 	 */
 	protected function getPickerValueAttribute()
 	{
-		$attribute = '';
-
-		if ($this->strPickerFieldType)
+		// Only load the previously selected values for the checkbox field type (#2346)
+		if ('checkbox' !== $this->strPickerFieldType)
 		{
-			$values = array_map($this->objPickerCallback, $this->arrPickerValue);
-			$values = array_map('strval', $values);
-			$values = json_encode($values);
-			$values = htmlspecialchars($values);
-			$attribute = ' data-picker-value="' . $values . '"';
+			return '';
 		}
 
-		return $attribute;
+		$values = array_map($this->objPickerCallback, $this->arrPickerValue);
+		$values = array_map('strval', $values);
+		$values = json_encode($values);
+		$values = htmlspecialchars($values);
+
+		return ' data-picker-value="' . $values . '"';
 	}
 
 	/**

--- a/core-bundle/src/Resources/contao/classes/DataContainer.php
+++ b/core-bundle/src/Resources/contao/classes/DataContainer.php
@@ -969,14 +969,14 @@ abstract class DataContainer extends \Backend
 	}
 
 	/**
-	 * Returns a data-picker-value attribute with the currently selected picker values (#1816)
+	 * Return the data-picker-value attribute with the currently selected picker values (see #1816)
 	 *
 	 * @return string
 	 */
 	protected function getPickerValueAttribute()
 	{
-		// Only load the previously selected values for the checkbox field type (#2346)
-		if ('checkbox' !== $this->strPickerFieldType)
+		// Only load the previously selected values for the checkbox field type (see #2346)
+		if ($this->strPickerFieldType != 'checkbox')
 		{
 			return '';
 		}

--- a/core-bundle/src/Resources/contao/classes/DataContainer.php
+++ b/core-bundle/src/Resources/contao/classes/DataContainer.php
@@ -969,6 +969,27 @@ abstract class DataContainer extends \Backend
 	}
 
 	/**
+	 * Returns a data-picker-value attribute with the currently selected picker values (#1816).
+	 * 
+	 * @return string
+	 */
+	protected function getPickerValueAttribute()
+	{
+		$attribute = '';
+
+		if ($this->strPickerFieldType)
+		{
+			$values = array_map($this->objPickerCallback, $this->arrPickerValue);
+			$values = array_map('strval', $values);
+			$values = json_encode($values);
+			$values = htmlspecialchars($values);
+			$attribute = ' data-picker-value="' . $values . '"';
+		}
+
+		return $attribute;
+	}
+
+	/**
 	 * Build the sort panel and return it as string
 	 *
 	 * @return string

--- a/core-bundle/src/Resources/contao/drivers/DC_Folder.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Folder.php
@@ -417,14 +417,6 @@ class DC_Folder extends \DataContainer implements \listable, \editable
 			\Message::addInfo($GLOBALS['TL_LANG']['MSC']['searchExclude']);
 		}
 
-		// Pass previously selected values to picker (#1816)
-		$prevPickerValue = '';
-
-		if ($this->strPickerFieldType)
-		{
-			$prevPickerValue = ' data-picker-value="' . htmlspecialchars(json_encode(array_map('strval', $this->arrPickerValue))) . '"';
-		}
-
 		// Build the tree
 		$return = $this->panel() . \Message::generate() . '
 <div id="tl_buttons">' . ((\Input::get('act') == 'select') ? '
@@ -440,7 +432,7 @@ class DC_Folder extends \DataContainer implements \listable, \editable
 <div id="paste_hint">
   <p>' . $GLOBALS['TL_LANG']['MSC']['selectNewPosition'] . '</p>
 </div>' : '') . '
-<div class="tl_listing_container tree_view" id="tl_listing"' . $prevPickerValue . '>' . (isset($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['breadcrumb']) ? $GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['breadcrumb'] : '') . ((\Input::get('act') == 'select' || $this->strPickerFieldType == 'checkbox') ? '
+<div class="tl_listing_container tree_view" id="tl_listing"' . $this->getPickerValueAttribute() . '>' . (isset($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['breadcrumb']) ? $GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['breadcrumb'] : '') . ((\Input::get('act') == 'select' || $this->strPickerFieldType == 'checkbox') ? '
 <div class="tl_select_trigger">
 <label for="tl_select_trigger" class="tl_select_label">' . $GLOBALS['TL_LANG']['MSC']['selectAll'] . '</label> <input type="checkbox" id="tl_select_trigger" onclick="Backend.toggleCheckboxes(this)" class="tl_tree_checkbox">
 </div>' : '') . '

--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -3597,14 +3597,6 @@ class DC_Table extends \DataContainer implements \listable, \editable
 <p class="tl_empty">' . $GLOBALS['TL_LANG']['MSC']['noResult'] . '</p>';
 		}
 
-		// Pass previously selected values to picker (#1816)
-		$prevPickerValue = '';
-
-		if ($this->strPickerFieldType)
-		{
-			$prevPickerValue = ' data-picker-value="' . htmlspecialchars(json_encode(array_map('strval', $this->arrPickerValue))) . '"';
-		}
-
 		$return .= ((\Input::get('act') == 'select') ? '
 <form action="' . ampersand(\Environment::get('request'), true) . '" id="tl_select" class="tl_form' . ((\Input::get('act') == 'select') ? ' unselectable' : '') . '" method="post" novalidate>
 <div class="tl_formbody_edit">
@@ -3613,7 +3605,7 @@ class DC_Table extends \DataContainer implements \listable, \editable
 <div id="paste_hint">
   <p>' . $GLOBALS['TL_LANG']['MSC']['selectNewPosition'] . '</p>
 </div>' : '') . '
-<div class="tl_listing_container tree_view" id="tl_listing"' . $prevPickerValue . '>' . $breadcrumb . ((\Input::get('act') == 'select' || ($this->strPickerFieldType == 'checkbox')) ? '
+<div class="tl_listing_container tree_view" id="tl_listing"' . $this->getPickerValueAttribute() . '>' . $breadcrumb . ((\Input::get('act') == 'select' || ($this->strPickerFieldType == 'checkbox')) ? '
 <div class="tl_select_trigger">
 <label for="tl_select_trigger" class="tl_select_label">' . $GLOBALS['TL_LANG']['MSC']['selectAll'] . '</label> <input type="checkbox" id="tl_select_trigger" onclick="Backend.toggleCheckboxes(this)" class="tl_tree_checkbox">
 </div>' : '') . '
@@ -4136,14 +4128,6 @@ class DC_Table extends \DataContainer implements \listable, \editable
 			return $return;
 		}
 
-		// Pass previously selected values to picker (#1816)
-		$prevPickerValue = '';
-
-		if ($this->strPickerFieldType)
-		{
-			$prevPickerValue = ' data-picker-value="' . htmlspecialchars(json_encode(array_map('strval', $this->arrPickerValue))) . '"';
-		}
-
 		$return .= ((\Input::get('act') == 'select') ? '
 
 <form action="' . ampersand(\Environment::get('request'), true) . '" id="tl_select" class="tl_form' . ((\Input::get('act') == 'select') ? ' unselectable' : '') . '" method="post" novalidate>
@@ -4153,7 +4137,7 @@ class DC_Table extends \DataContainer implements \listable, \editable
 <div id="paste_hint">
   <p>' . $GLOBALS['TL_LANG']['MSC']['selectNewPosition'] . '</p>
 </div>' : '') . '
-<div class="tl_listing_container parent_view' . ($this->strPickerFieldType ? ' picker unselectable' : '') . '" id="tl_listing"' . $prevPickerValue . '>
+<div class="tl_listing_container parent_view' . ($this->strPickerFieldType ? ' picker unselectable' : '') . '" id="tl_listing"' . $this->getPickerValueAttribute() . '>
 <div class="tl_header click2edit toggle_select hover-div">';
 
 		// List all records of the child table
@@ -4773,20 +4757,12 @@ class DC_Table extends \DataContainer implements \listable, \editable
 		{
 			$result = $objRow->fetchAllAssoc();
 
-			// Pass previously selected values to picker (#1816)
-			$prevPickerValue = '';
-
-			if ($this->strPickerFieldType)
-			{
-				$prevPickerValue = ' data-picker-value="' . htmlspecialchars(json_encode(array_map('strval', $this->arrPickerValue))) . '"';
-			}
-
 			$return .= ((\Input::get('act') == 'select') ? '
 <form action="' . ampersand(\Environment::get('request'), true) . '" id="tl_select" class="tl_form' . ((\Input::get('act') == 'select') ? ' unselectable' : '') . '" method="post" novalidate>
 <div class="tl_formbody_edit">
 <input type="hidden" name="FORM_SUBMIT" value="tl_select">
 <input type="hidden" name="REQUEST_TOKEN" value="' . REQUEST_TOKEN . '">' : '') . '
-<div class="tl_listing_container list_view" id="tl_listing"' . $prevPickerValue . '>' . ((\Input::get('act') == 'select' || $this->strPickerFieldType == 'checkbox') ? '
+<div class="tl_listing_container list_view" id="tl_listing"' . $this->getPickerValueAttribute() . '>' . ((\Input::get('act') == 'select' || $this->strPickerFieldType == 'checkbox') ? '
 <div class="tl_select_trigger">
 <label for="tl_select_trigger" class="tl_select_label">' . $GLOBALS['TL_LANG']['MSC']['selectAll'] . '</label> <input type="checkbox" id="tl_select_trigger" onclick="Backend.toggleCheckboxes(this)" class="tl_tree_checkbox">
 </div>' : '') . '


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #2346
| Docs PR or issue | -

This fixes the picker for picker providers that return insert tags (see #2346). It uses the picker callback to transform the DCA values back to the appropriate picker values and also checks whether it is actually necessary to load the previous values - which it only should be for the `checkbox` picker type.

I've tested this solution with:

* single `fileTree` and `pageTree` widgets
* `fileTree` and `pageTree` widgets that allow multiple selections
* pickers that allow the selection of files, articles, news, events, pages (e.g. the `url` field of `tl_content`)