### PR TITLE
Correctly detect unknown options

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Widget.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Widget.php
@@ -1277,6 +1277,7 @@ abstract class Widget extends \Controller
 		$arrAttributes['description'] = $arrData['label'][1];
 		$arrAttributes['type'] = $arrData['inputType'];
 		$arrAttributes['dataContainer'] = $objDca;
+		$arrAttributes['value'] = \StringUtil::deserialize($varValue);
 
 		// Internet Explorer does not support onchange for checkboxes and radio buttons
 		if ($arrData['eval']['submitOnChange'])
@@ -1354,7 +1355,7 @@ abstract class Widget extends \Controller
 				$arrAttributes['options'][] = array('value'=>'', 'label'=>$strLabel);
 			}
 
-			$isKnownOption = false;
+			$unknown = (array) $arrAttributes['value'];
 
 			foreach ($arrData['options'] as $k=>$v)
 			{
@@ -1362,9 +1363,9 @@ abstract class Widget extends \Controller
 				{
 					$value = $blnIsAssociative ? $k : $v;
 
-					if ($varValue && $varValue == $value)
+					if (($i = array_search($value, $unknown)) !== false)
 					{
-						$isKnownOption = true;
+						unset($unknown[$i]);
 					}
 
 					$arrAttributes['options'][] = array('value'=>$value, 'label'=>($blnUseReference ? ((($ref = (\is_array($arrData['reference'][$v]) ? $arrData['reference'][$v][0] : $arrData['reference'][$v])) != false) ? $ref : $v) : $v));
@@ -1378,21 +1379,23 @@ abstract class Widget extends \Controller
 				{
 					$value = $blnIsAssoc ? $kk : $vv;
 
-					if ($varValue && $varValue == $value)
+					if (($i = array_search($value, $unknown)) !== false)
 					{
-						$isKnownOption = true;
+						unset($unknown[$i]);
 					}
 
 					$arrAttributes['options'][$key][] = array('value'=>$value, 'label'=>($blnUseReference ? ((($ref = (\is_array($arrData['reference'][$vv]) ? $arrData['reference'][$vv][0] : $arrData['reference'][$vv])) != false) ? $ref : $vv) : $vv));
 				}
 			}
 
+			$unknown = array_filter($unknown);
+
 			// If the value is not in the options array, the current user most
 			// likely cannot access it. We add the value as unknown option, so
 			// it does not get lost when saving the record (see #920).
-			if ($varValue && !$isKnownOption)
+			foreach ($unknown as $value)
 			{
-				$arrAttributes['options'][] = array('value'=>$varValue, 'label'=>$GLOBALS['TL_LANG']['MSC']['unknownOption']);
+				$arrAttributes['options'][] = array('value'=>$value, 'label'=>$GLOBALS['TL_LANG']['MSC']['unknownOption']);
 			}
 		}
 
@@ -1408,8 +1411,6 @@ abstract class Widget extends \Controller
 				$arrAttributes['unique'] = $arrAttributes['sql']['customSchemaOptions']['unique'];
 			}
 		}
-
-		$arrAttributes['value'] = \StringUtil::deserialize($varValue);
 
 		// Convert timestamps
 		if ($varValue !== null && $varValue !== '' && \in_array($arrData['eval']['rgxp'], array('date', 'time', 'datim')))

--- a/core-bundle/src/Resources/contao/library/Contao/Widget.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Widget.php
@@ -1388,12 +1388,7 @@ abstract class Widget extends \Controller
 				}
 			}
 
-			$unknown = array_filter($unknown);
-
-			if (!empty($unknown))
-			{
-				$arrAttributes['unknownOption'] = $unknown;
-			}
+			$arrAttributes['unknownOption'] = array_filter($unknown);
 		}
 
 		if (\is_array($arrAttributes['sql']) && !isset($arrAttributes['sql']['columnDefinition']))

--- a/core-bundle/src/Resources/contao/library/Contao/Widget.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Widget.php
@@ -1390,12 +1390,9 @@ abstract class Widget extends \Controller
 
 			$unknown = array_filter($unknown);
 
-			// If the value is not in the options array, the current user most
-			// likely cannot access it. We add the value as unknown option, so
-			// it does not get lost when saving the record (see #920).
-			foreach ($unknown as $value)
+			if (!empty($unknown))
 			{
-				$arrAttributes['options'][] = array('value'=>$value, 'label'=>$GLOBALS['TL_LANG']['MSC']['unknownOption']);
+				$arrAttributes['unknownOption'] = $unknown;
 			}
 		}
 

--- a/core-bundle/src/Resources/contao/widgets/CheckBox.php
+++ b/core-bundle/src/Resources/contao/widgets/CheckBox.php
@@ -81,9 +81,12 @@ class CheckBox extends \Widget
 	{
 		$arrOptions = $this->arrOptions;
 
-		foreach ($this->unknownOption as $v)
+		if (\is_array($this->unknownOption))
 		{
-			$this->arrOptions[] = array('value'=>$v);
+			foreach ($this->unknownOption as $v)
+			{
+				$this->arrOptions[] = array('value'=>$v);
+			}
 		}
 
 		$blnIsValid = parent::isValidOption($varInput);
@@ -130,9 +133,12 @@ class CheckBox extends \Widget
 		$arrAllOptions = $this->arrOptions;
 
 		// Add unknown options, so they are not lost when saving the record (see #920)
-		foreach ($this->unknownOption as $val)
+		if (\is_array($this->unknownOption))
 		{
-			$arrAllOptions[] = array('value' => $val, 'label' => $GLOBALS['TL_LANG']['MSC']['unknownOption']);
+			foreach ($this->unknownOption as $val)
+			{
+				$arrAllOptions[] = array('value' => $val, 'label' => $GLOBALS['TL_LANG']['MSC']['unknownOption']);
+			}
 		}
 
 		foreach ($arrAllOptions as $i=>$arrOption)

--- a/core-bundle/src/Resources/contao/widgets/CheckBox.php
+++ b/core-bundle/src/Resources/contao/widgets/CheckBox.php
@@ -16,6 +16,7 @@ use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface;
  * Provide methods to handle check boxes.
  *
  * @property array   $options
+ * @property array   $unknownOption
  * @property boolean $multiple
  *
  * @author Leo Feyer <https://github.com/leofeyer>
@@ -70,6 +71,28 @@ class CheckBox extends \Widget
 	}
 
 	/**
+	 * Check whether an input is one of the given options
+	 *
+	 * @param mixed $varInput The input string or array
+	 *
+	 * @return boolean True if the selected option exists
+	 */
+	protected function isValidOption($varInput)
+	{
+		$arrOptions = $this->arrOptions;
+
+		foreach ($this->unknownOption as $v)
+		{
+			$this->arrOptions[] = array('value'=>$v);
+		}
+
+		$blnIsValid = parent::isValidOption($varInput);
+		$this->arrOptions = $arrOptions;
+
+		return $blnIsValid;
+	}
+
+	/**
 	 * Generate the widget and return it as string
 	 *
 	 * @return string
@@ -104,8 +127,15 @@ class CheckBox extends \Widget
 
 		$blnFirst = true;
 		$blnCheckAll = true;
+		$arrAllOptions = $this->arrOptions;
 
-		foreach ($this->arrOptions as $i=>$arrOption)
+		// Add unknown options, so they are not lost when saving the record (see #920)
+		foreach ($this->unknownOption as $val)
+		{
+			$arrAllOptions[] = array('value' => $val, 'label' => $GLOBALS['TL_LANG']['MSC']['unknownOption']);
+		}
+
+		foreach ($arrAllOptions as $i=>$arrOption)
 		{
 			// Single dimension array
 			if (is_numeric($i))
@@ -130,7 +160,7 @@ class CheckBox extends \Widget
 			// Multidimensional array
 			foreach ($arrOption as $k=>$v)
 			{
-				$arrOptions[] = $this->generateCheckbox($v, standardize($i) . '_' . $k);
+				$arrOptions[] = $this->generateCheckbox($v, StringUtil::standardize($i) . '_' . $k);
 			}
 
 			$arrOptions[] = '</fieldset>';

--- a/core-bundle/src/Resources/contao/widgets/CheckBoxWizard.php
+++ b/core-bundle/src/Resources/contao/widgets/CheckBoxWizard.php
@@ -14,6 +14,7 @@ namespace Contao;
  * Provide methods to handle sortable checkboxes.
  *
  * @property array   $options
+ * @property array   $unknownOption
  * @property boolean $multiple
  *
  * @author John Brand <http://www.thyon.com>
@@ -69,6 +70,28 @@ class CheckBoxWizard extends \Widget
 	}
 
 	/**
+	 * Check whether an input is one of the given options
+	 *
+	 * @param mixed $varInput The input string or array
+	 *
+	 * @return boolean True if the selected option exists
+	 */
+	protected function isValidOption($varInput)
+	{
+		$arrOptions = $this->arrOptions;
+
+		foreach ($this->unknownOption as $v)
+		{
+			$this->arrOptions[] = array('value'=>$v);
+		}
+
+		$blnIsValid = parent::isValidOption($varInput);
+		$this->arrOptions = $arrOptions;
+
+		return $blnIsValid;
+	}
+
+	/**
 	 * Generate the widget and return it as string
 	 *
 	 * @return string
@@ -102,9 +125,16 @@ class CheckBoxWizard extends \Widget
 
 		$blnCheckAll = true;
 		$arrOptions = array();
+		$arrAllOptions = $this->arrOptions;
+
+		// Add unknown options, so they are not lost when saving the record (see #920)
+		foreach ($this->unknownOption as $val)
+		{
+			$arrAllOptions[] = array('value' => $val, 'label' => $GLOBALS['TL_LANG']['MSC']['unknownOption']);
+		}
 
 		// Generate options and add buttons
-		foreach ($this->arrOptions as $i=>$arrOption)
+		foreach ($arrAllOptions as $i=>$arrOption)
 		{
 			$arrOptions[] = $this->generateCheckbox($arrOption, $i, '<button type="button" class="drag-handle" title="' . \StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['move']) . '" aria-hidden="true">' . \Image::getHtml('drag.svg') . '</button> ');
 		}

--- a/core-bundle/src/Resources/contao/widgets/CheckBoxWizard.php
+++ b/core-bundle/src/Resources/contao/widgets/CheckBoxWizard.php
@@ -80,9 +80,12 @@ class CheckBoxWizard extends \Widget
 	{
 		$arrOptions = $this->arrOptions;
 
-		foreach ($this->unknownOption as $v)
+		if (\is_array($this->unknownOption))
 		{
-			$this->arrOptions[] = array('value'=>$v);
+			foreach ($this->unknownOption as $v)
+			{
+				$this->arrOptions[] = array('value'=>$v);
+			}
 		}
 
 		$blnIsValid = parent::isValidOption($varInput);
@@ -128,9 +131,12 @@ class CheckBoxWizard extends \Widget
 		$arrAllOptions = $this->arrOptions;
 
 		// Add unknown options, so they are not lost when saving the record (see #920)
-		foreach ($this->unknownOption as $val)
+		if (\is_array($this->unknownOption))
 		{
-			$arrAllOptions[] = array('value' => $val, 'label' => $GLOBALS['TL_LANG']['MSC']['unknownOption']);
+			foreach ($this->unknownOption as $val)
+			{
+				$arrAllOptions[] = array('value' => $val, 'label' => $GLOBALS['TL_LANG']['MSC']['unknownOption']);
+			}
 		}
 
 		// Generate options and add buttons

--- a/core-bundle/src/Resources/contao/widgets/ImageSize.php
+++ b/core-bundle/src/Resources/contao/widgets/ImageSize.php
@@ -15,6 +15,7 @@ namespace Contao;
  *
  * @property integer $maxlength
  * @property array   $options
+ * @property array   $unknownOption
  *
  * @author Leo Feyer <https://github.com/leofeyer>
  */
@@ -145,10 +146,11 @@ class ImageSize extends \Widget
 			{
 				return true;
 			}
-			elseif (parent::isValidOption($varInput))
-			{
-				return true;
-			}
+		}
+
+		if ($varInput == $this->unknownOption[2])
+		{
+			return true;
 		}
 
 		return false;
@@ -202,6 +204,17 @@ class ImageSize extends \Widget
 
 				$arrOptions[] = sprintf('<optgroup label="&nbsp;%s">%s</optgroup>', \StringUtil::specialchars($strKey), implode('', $arrOptgroups));
 			}
+		}
+
+		// If the user cannot select the current value, add it as unknown option,
+		// so it does not get lost when saving the record (see #920)
+		if (isset($this->unknownOption))
+		{
+			$arrOptions[] = sprintf(
+				'<option value="%s" selected>%s</option>',
+				StringUtil::specialchars($this->unknownOption[2]),
+				$GLOBALS['TL_LANG']['MSC']['unknownOption']
+			);
 		}
 
 		$arrFields[] = sprintf(

--- a/core-bundle/src/Resources/contao/widgets/ImageSize.php
+++ b/core-bundle/src/Resources/contao/widgets/ImageSize.php
@@ -145,6 +145,10 @@ class ImageSize extends \Widget
 			{
 				return true;
 			}
+			elseif (parent::isValidOption($varInput))
+			{
+				return true;
+			}
 		}
 
 		return false;

--- a/core-bundle/src/Resources/contao/widgets/ImageSize.php
+++ b/core-bundle/src/Resources/contao/widgets/ImageSize.php
@@ -148,7 +148,7 @@ class ImageSize extends \Widget
 			}
 		}
 
-		if ($varInput == $this->unknownOption[2])
+		if (isset($this->unknownOption[2]) && $varInput == $this->unknownOption[2])
 		{
 			return true;
 		}
@@ -176,8 +176,15 @@ class ImageSize extends \Widget
 
 		$arrFields = array();
 		$arrOptions = array();
+		$arrAllOptions = $this->arrOptions;
 
-		foreach ($this->arrOptions as $strKey=>$arrOption)
+		// Add an unknown option, so it is not lost when saving the record (see #920)
+		if (isset($this->unknownOption[2]))
+		{
+			$arrAllOptions[] = array('value'=>$this->unknownOption[2], 'label'=>$GLOBALS['TL_LANG']['MSC']['unknownOption']);
+		}
+
+		foreach ($arrAllOptions as $strKey=>$arrOption)
 		{
 			if (isset($arrOption['value']))
 			{
@@ -204,17 +211,6 @@ class ImageSize extends \Widget
 
 				$arrOptions[] = sprintf('<optgroup label="&nbsp;%s">%s</optgroup>', \StringUtil::specialchars($strKey), implode('', $arrOptgroups));
 			}
-		}
-
-		// If the user cannot select the current value, add it as unknown option,
-		// so it does not get lost when saving the record (see #920)
-		if (isset($this->unknownOption))
-		{
-			$arrOptions[] = sprintf(
-				'<option value="%s" selected>%s</option>',
-				StringUtil::specialchars($this->unknownOption[2]),
-				$GLOBALS['TL_LANG']['MSC']['unknownOption']
-			);
 		}
 
 		$arrFields[] = sprintf(

--- a/core-bundle/src/Resources/contao/widgets/RadioButton.php
+++ b/core-bundle/src/Resources/contao/widgets/RadioButton.php
@@ -15,6 +15,7 @@ namespace Contao;
  *
  * @property boolean $mandatory
  * @property array   $options
+ * @property array   $unknownOption
  *
  * @author Leo Feyer <https://github.com/leofeyer>
  */
@@ -80,6 +81,28 @@ class RadioButton extends \Widget
 	}
 
 	/**
+	 * Check whether an input is one of the given options
+	 *
+	 * @param mixed $varInput The input string or array
+	 *
+	 * @return boolean True if the selected option exists
+	 */
+	protected function isValidOption($varInput)
+	{
+		$arrOptions = $this->arrOptions;
+
+		if (isset($this->unknownOption[0]))
+		{
+			$this->arrOptions[] = array('value'=>$this->unknownOption[0]);
+		}
+
+		$blnIsValid = parent::isValidOption($varInput);
+		$this->arrOptions = $arrOptions;
+
+		return $blnIsValid;
+	}
+
+	/**
 	 * Generate the widget and return it as string
 	 *
 	 * @return string
@@ -87,8 +110,15 @@ class RadioButton extends \Widget
 	public function generate()
 	{
 		$arrOptions = array();
+		$arrAllOptions = $this->arrOptions;
 
-		foreach ($this->arrOptions as $i=>$arrOption)
+		// Add an unknown option, so it is not lost when saving the record (see #920)
+		if (isset($this->unknownOption[0]))
+		{
+			$arrAllOptions[] = array('value'=>$this->unknownOption[0], 'label'=>$GLOBALS['TL_LANG']['MSC']['unknownOption']);
+		}
+
+		foreach ($arrAllOptions as $i=>$arrOption)
 		{
 			$arrOptions[] = sprintf(
 				'<input type="radio" name="%s" id="opt_%s" class="tl_radio" value="%s"%s%s onfocus="Backend.getScrollOffset()"> <label for="opt_%s">%s</label>',

--- a/core-bundle/src/Resources/contao/widgets/SelectMenu.php
+++ b/core-bundle/src/Resources/contao/widgets/SelectMenu.php
@@ -106,17 +106,17 @@ class SelectMenu extends \Widget
 	 */
 	protected function isValidOption($varInput)
 	{
-		if (parent::isValidOption($varInput))
+		$arrOptions = $this->arrOptions;
+
+		if (isset($this->unknownOption[0]))
 		{
-			return true;
+			$this->arrOptions['unknown'][] = array('value'=>$this->unknownOption[0]);
 		}
 
-		if ($varInput == $this->unknownOption[0])
-		{
-			return true;
-		}
+		$blnIsValid = parent::isValidOption($varInput);
+		$this->arrOptions = $arrOptions;
 
-		return false;
+		return $blnIsValid;
 	}
 
 	/**
@@ -141,7 +141,15 @@ class SelectMenu extends \Widget
 			$this->arrOptions = array(array('value'=>'', 'label'=>'-'));
 		}
 
-		foreach ($this->arrOptions as $strKey=>$arrOption)
+		$arrAllOptions = $this->arrOptions;
+
+		// Add an unknown option, so it is not lost when saving the record (see #920)
+		if (isset($this->unknownOption[0]))
+		{
+			$arrAllOptions[] = array('value'=>$this->unknownOption[0], 'label'=>$GLOBALS['TL_LANG']['MSC']['unknownOption']);
+		}
+
+		foreach ($arrAllOptions as $strKey=>$arrOption)
 		{
 			if (isset($arrOption['value']))
 			{
@@ -168,17 +176,6 @@ class SelectMenu extends \Widget
 
 				$arrOptions[] = sprintf('<optgroup label="&nbsp;%s">%s</optgroup>', \StringUtil::specialchars($strKey), implode('', $arrOptgroups));
 			}
-		}
-
-		// If the user cannot select the current value, add it as unknown option,
-		// so it does not get lost when saving the record (see #920)
-		if (isset($this->unknownOption))
-		{
-			$arrOptions[] = sprintf(
-				'<option value="%s" selected>%s</option>',
-				StringUtil::specialchars($this->unknownOption[0]),
-				$GLOBALS['TL_LANG']['MSC']['unknownOption']
-			);
 		}
 
 		// Chosen

--- a/core-bundle/src/Resources/contao/widgets/SelectMenu.php
+++ b/core-bundle/src/Resources/contao/widgets/SelectMenu.php
@@ -17,6 +17,7 @@ namespace Contao;
  * @property integer $size
  * @property boolean $multiple
  * @property array   $options
+ * @property array   $unknownOption
  * @property boolean $chosen
  *
  * @author Leo Feyer <https://github.com/leofeyer>
@@ -97,6 +98,28 @@ class SelectMenu extends \Widget
 	}
 
 	/**
+	 * Check whether an input is one of the given options
+	 *
+	 * @param mixed $varInput The input string or array
+	 *
+	 * @return boolean True if the selected option exists
+	 */
+	protected function isValidOption($varInput)
+	{
+		if (parent::isValidOption($varInput))
+		{
+			return true;
+		}
+
+		if ($varInput == $this->unknownOption[0])
+		{
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
 	 * Generate the widget and return it as string
 	 *
 	 * @return string
@@ -145,6 +168,17 @@ class SelectMenu extends \Widget
 
 				$arrOptions[] = sprintf('<optgroup label="&nbsp;%s">%s</optgroup>', \StringUtil::specialchars($strKey), implode('', $arrOptgroups));
 			}
+		}
+
+		// If the user cannot select the current value, add it as unknown option,
+		// so it does not get lost when saving the record (see #920)
+		if (isset($this->unknownOption))
+		{
+			$arrOptions[] = sprintf(
+				'<option value="%s" selected>%s</option>',
+				StringUtil::specialchars($this->unknownOption[0]),
+				$GLOBALS['TL_LANG']['MSC']['unknownOption']
+			);
 		}
 
 		// Chosen


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #2349
| Docs PR or issue | -

This fixes all the issues mentioned in #2349. However, there is still a problem that I could not yet solve:

<img width="598" alt="" src="https://user-images.githubusercontent.com/1192057/94276257-45ae4b00-ff48-11ea-87e6-a35083150ec9.png">

This is because the value of the `ImageSize` widget can be an array with three items (e.g. `[300, 300, 'crop']`) and all of the values are added as unknown options. The `Widget` class does not know that only the third value needs to be checked.

@contao/developers Any idea how to fix this without a protected method that can be overwritten in each widget class?