### PR TITLE
Reset the KEY_BLOCK_SIZE when migrating the MySQL engine and row format

### DIFF
--- a/installation-bundle/src/Database/Installer.php
+++ b/installation-bundle/src/Database/Installer.php
@@ -254,7 +254,11 @@ class Installer
 
             if (strtolower($tableOptions->Engine) !== strtolower($engine)) {
                 if ($innodb && $dynamic) {
-                    $command = 'ALTER TABLE '.$tableName.' ENGINE = '.$engine.' ROW_FORMAT = DYNAMIC, KEY_BLOCK_SIZE=0';
+                    $command = 'ALTER TABLE '.$tableName.' ENGINE = '.$engine.' ROW_FORMAT = DYNAMIC';
+
+                    if (false !== stripos($tableOptions->Create_options, 'key_block_size=')) {
+                        $command .= ', KEY_BLOCK_SIZE=0';
+                    }
                 } else {
                     $command = 'ALTER TABLE '.$tableName.' ENGINE = '.$engine;
                 }
@@ -263,7 +267,12 @@ class Installer
                 $alterTables[md5($command)] = $command;
             } elseif ($innodb && $dynamic) {
                 if (false === stripos($tableOptions->Create_options, 'row_format=dynamic')) {
-                    $command = 'ALTER TABLE '.$tableName.' ENGINE = '.$engine.' ROW_FORMAT = DYNAMIC, KEY_BLOCK_SIZE=0';
+                    $command = 'ALTER TABLE '.$tableName.' ENGINE = '.$engine.' ROW_FORMAT = DYNAMIC';
+
+                    if (false !== stripos($tableOptions->Create_options, 'key_block_size=')) {
+                        $command .= ', KEY_BLOCK_SIZE=0';
+                    }
+
                     $alterTables[md5($command)] = $command;
                 }
             }

--- a/installation-bundle/src/Database/Installer.php
+++ b/installation-bundle/src/Database/Installer.php
@@ -254,7 +254,7 @@ class Installer
 
             if (strtolower($tableOptions->Engine) !== strtolower($engine)) {
                 if ($innodb && $dynamic) {
-                    $command = 'ALTER TABLE '.$tableName.' ENGINE = '.$engine.' ROW_FORMAT = DYNAMIC';
+                    $command = 'ALTER TABLE '.$tableName.' ENGINE = '.$engine.' ROW_FORMAT = DYNAMIC, KEY_BLOCK_SIZE=0';
                 } else {
                     $command = 'ALTER TABLE '.$tableName.' ENGINE = '.$engine;
                 }
@@ -263,7 +263,7 @@ class Installer
                 $alterTables[md5($command)] = $command;
             } elseif ($innodb && $dynamic) {
                 if (false === stripos($tableOptions->Create_options, 'row_format=dynamic')) {
-                    $command = 'ALTER TABLE '.$tableName.' ENGINE = '.$engine.' ROW_FORMAT = DYNAMIC';
+                    $command = 'ALTER TABLE '.$tableName.' ENGINE = '.$engine.' ROW_FORMAT = DYNAMIC, KEY_BLOCK_SIZE=0';
                     $alterTables[md5($command)] = $command;
                 }
             }

--- a/installation-bundle/src/Database/Installer.php
+++ b/installation-bundle/src/Database/Installer.php
@@ -257,7 +257,7 @@ class Installer
                     $command = 'ALTER TABLE '.$tableName.' ENGINE = '.$engine.' ROW_FORMAT = DYNAMIC';
 
                     if (false !== stripos($tableOptions->Create_options, 'key_block_size=')) {
-                        $command .= ', KEY_BLOCK_SIZE = 0';
+                        $command .= ' KEY_BLOCK_SIZE = 0';
                     }
                 } else {
                     $command = 'ALTER TABLE '.$tableName.' ENGINE = '.$engine;
@@ -270,7 +270,7 @@ class Installer
                     $command = 'ALTER TABLE '.$tableName.' ENGINE = '.$engine.' ROW_FORMAT = DYNAMIC';
 
                     if (false !== stripos($tableOptions->Create_options, 'key_block_size=')) {
-                        $command .= ', KEY_BLOCK_SIZE = 0';
+                        $command .= ' KEY_BLOCK_SIZE = 0';
                     }
 
                     $alterTables[md5($command)] = $command;

--- a/installation-bundle/src/Database/Installer.php
+++ b/installation-bundle/src/Database/Installer.php
@@ -257,7 +257,7 @@ class Installer
                     $command = 'ALTER TABLE '.$tableName.' ENGINE = '.$engine.' ROW_FORMAT = DYNAMIC';
 
                     if (false !== stripos($tableOptions->Create_options, 'key_block_size=')) {
-                        $command .= ', KEY_BLOCK_SIZE=0';
+                        $command .= ', KEY_BLOCK_SIZE = 0';
                     }
                 } else {
                     $command = 'ALTER TABLE '.$tableName.' ENGINE = '.$engine;
@@ -270,7 +270,7 @@ class Installer
                     $command = 'ALTER TABLE '.$tableName.' ENGINE = '.$engine.' ROW_FORMAT = DYNAMIC';
 
                     if (false !== stripos($tableOptions->Create_options, 'key_block_size=')) {
-                        $command .= ', KEY_BLOCK_SIZE=0';
+                        $command .= ', KEY_BLOCK_SIZE = 0';
                     }
 
                     $alterTables[md5($command)] = $command;

--- a/installation-bundle/tests/Database/InstallerTest.php
+++ b/installation-bundle/tests/Database/InstallerTest.php
@@ -30,6 +30,9 @@ class InstallerTest extends TestCase
         $fromSchema = new Schema();
         $fromSchema
             ->createTable('tl_foo')
+            ->addOption('engine', 'MyISAM')
+            ->addOption('charset', 'utf8')
+            ->addOption('collate', 'utf8_unicode_ci')
             ->addColumn('foo', 'string')
         ;
 
@@ -49,12 +52,83 @@ class InstallerTest extends TestCase
 
         $this->assertHasStatement(
             $commands['ALTER_TABLE'],
-            'ALTER TABLE tl_foo ENGINE = InnoDB ROW_FORMAT = DYNAMIC, KEY_BLOCK_SIZE=0'
+            'ALTER TABLE tl_foo ENGINE = InnoDB ROW_FORMAT = DYNAMIC'
         );
         $this->assertHasStatement(
             $commands['ALTER_TABLE'],
             'ALTER TABLE tl_foo CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci'
         );
+    }
+
+    public function testChangesTheDatabaseEngine(): void
+    {
+        $fromSchema = new Schema();
+        $fromSchema
+            ->createTable('tl_foo')
+            ->addOption('engine', 'MyISAM')
+            ->addOption('charset', 'utf8')
+            ->addOption('collate', 'utf8_unicode_ci')
+        ;
+
+        $fromSchema->getTable('tl_foo')->addColumn('foo', 'string');
+        $fromSchema->getTable('tl_foo')->addIndex(['foo'], 'foo_idx');
+
+        $toSchema = new Schema();
+        $toSchema
+            ->createTable('tl_foo')
+            ->addOption('engine', 'InnoDB')
+        ;
+
+        $toSchema
+            ->getTable('tl_foo')
+            ->addColumn('foo', 'string')
+        ;
+
+        $toSchema
+            ->getTable('tl_foo')
+            ->addIndex(['foo'], 'foo_idx')
+        ;
+
+        $installer = $this->getInstaller($fromSchema, $toSchema, ['tl_foo']);
+        $commands = $installer->getCommands();
+
+        $this->assertHasStatement($commands['ALTER_TABLE'], 'ALTER TABLE tl_foo ENGINE = InnoDB ROW_FORMAT = DYNAMIC');
+    }
+
+    public function testResetsTheKeyBlockSizeWhenChangingTheDatabaseEngine(): void
+    {
+        $fromSchema = new Schema();
+        $fromSchema
+            ->createTable('tl_foo')
+            ->addOption('engine', 'MyISAM')
+            ->addOption('create_options', ['KEY_BLOCK_SIZE=16'])
+            ->addOption('charset', 'utf8')
+            ->addOption('collate', 'utf8_unicode_ci')
+        ;
+
+        $fromSchema->getTable('tl_foo')->addColumn('foo', 'string');
+        $fromSchema->getTable('tl_foo')->addIndex(['foo'], 'foo_idx');
+
+        $toSchema = new Schema();
+        $toSchema
+            ->createTable('tl_foo')
+            ->addOption('engine', 'InnoDB')
+        ;
+
+        $toSchema
+            ->getTable('tl_foo')
+            ->addColumn('foo', 'string')
+        ;
+
+        $toSchema
+            ->getTable('tl_foo')
+            ->addIndex(['foo'], 'foo_idx')
+        ;
+
+        $installer = $this->getInstaller($fromSchema, $toSchema, ['tl_foo']);
+        $commands = $installer->getCommands();
+
+        $this->assertHasStatement($commands['ALTER_TABLE'], 'ALTER TABLE tl_foo ENGINE = InnoDB ROW_FORMAT = DYNAMIC, KEY_BLOCK_SIZE=0');
     }
 
     public function testDeletesTheIndexesWhenChangingTheDatabaseEngine(): void
@@ -63,6 +137,8 @@ class InstallerTest extends TestCase
         $fromSchema
             ->createTable('tl_foo')
             ->addOption('engine', 'MyISAM')
+            ->addOption('charset', 'utf8')
+            ->addOption('collate', 'utf8_unicode_ci')
         ;
 
         $fromSchema
@@ -102,6 +178,8 @@ class InstallerTest extends TestCase
         $fromSchema = new Schema();
         $fromSchema
             ->createTable('tl_foo')
+            ->addOption('engine', 'MyISAM')
+            ->addOption('charset', 'utf8')
             ->addOption('collate', 'utf8_unicode_ci')
         ;
 
@@ -142,6 +220,43 @@ class InstallerTest extends TestCase
         $fromSchema = new Schema();
         $fromSchema
             ->createTable('tl_bar')
+            ->addOption('engine', 'InnoDB')
+            ->addOption('charset', 'utf8mb4')
+            ->addOption('collate', 'utf8mb4_unicode_ci')
+            ->addOption('Create_options', 'row_format=COMPACT')
+            ->addColumn('foo', 'string')
+        ;
+
+        $toSchema = new Schema();
+        $toSchema
+            ->createTable('tl_bar')
+            ->addOption('engine', 'InnoDB')
+            ->addOption('row_format', 'DYNAMIC')
+            ->addOption('charset', 'utf8mb4')
+            ->addOption('collate', 'utf8mb4_unicode_ci')
+            ->addColumn('foo', 'string')
+        ;
+
+        $installer = $this->getInstaller($fromSchema, $toSchema, ['tl_foo']);
+        $commands = $installer->getCommands();
+
+        $this->assertArrayHasKey('ALTER_TABLE', $commands);
+
+        $this->assertHasStatement(
+            $commands['ALTER_TABLE'],
+            'ALTER TABLE tl_bar ENGINE = InnoDB ROW_FORMAT = DYNAMIC'
+        );
+    }
+
+    public function testResetsTheKeyBlockSizeIfInnodbIsUsed(): void
+    {
+        $fromSchema = new Schema();
+        $fromSchema
+            ->createTable('tl_bar')
+            ->addOption('engine', 'InnoDB')
+            ->addOption('charset', 'utf8mb4')
+            ->addOption('collate', 'utf8mb4_unicode_ci')
+            ->addOption('create_options', ['row_format=COMPACT', 'KEY_BLOCK_SIZE=16'])
             ->addColumn('foo', 'string')
         ;
 
@@ -171,6 +286,9 @@ class InstallerTest extends TestCase
         $fromSchema = new Schema();
         $fromSchema
             ->createTable('tl_foo')
+            ->addOption('engine', 'MyISAM')
+            ->addOption('charset', 'utf8')
+            ->addOption('collate', 'utf8_unicode_ci')
             ->addColumn('foo', 'string')
         ;
 
@@ -221,6 +339,9 @@ class InstallerTest extends TestCase
         $fromSchema = new Schema();
         $fromSchema
             ->createTable('tl_foo')
+            ->addOption('engine', 'MyISAM')
+            ->addOption('charset', 'utf8')
+            ->addOption('collate', 'utf8_unicode_ci')
             ->addColumn('foo', 'string')
         ;
 
@@ -247,6 +368,9 @@ class InstallerTest extends TestCase
         $fromSchema = new Schema();
         $fromSchema
             ->createTable('tl_foo')
+            ->addOption('engine', 'MyISAM')
+            ->addOption('charset', 'utf8')
+            ->addOption('collate', 'utf8_unicode_ci')
             ->addColumn('foo', 'string')
         ;
 
@@ -274,7 +398,12 @@ class InstallerTest extends TestCase
     public function testHandlesDecimalsInTheAddColumnCommands(): void
     {
         $fromSchema = new Schema();
-        $fromSchema->createTable('tl_foo');
+        $fromSchema
+            ->createTable('tl_foo')
+            ->addOption('engine', 'MyISAM')
+            ->addOption('charset', 'utf8')
+            ->addOption('collate', 'utf8_unicode_ci')
+        ;
 
         $toSchema = new Schema();
         $toSchema
@@ -295,7 +424,12 @@ class InstallerTest extends TestCase
     public function testHandlesDefaultsInTheAddColumnCommands(): void
     {
         $fromSchema = new Schema();
-        $fromSchema->createTable('tl_foo');
+        $fromSchema
+            ->createTable('tl_foo')
+            ->addOption('engine', 'MyISAM')
+            ->addOption('charset', 'utf8')
+            ->addOption('collate', 'utf8_unicode_ci')
+        ;
 
         $toSchema = new Schema();
         $toSchema
@@ -316,7 +450,12 @@ class InstallerTest extends TestCase
     public function testHandlesMixedColumnsInTheAddColumnCommands(): void
     {
         $fromSchema = new Schema();
-        $fromSchema->createTable('tl_foo');
+        $fromSchema
+            ->createTable('tl_foo')
+            ->addOption('engine', 'MyISAM')
+            ->addOption('charset', 'utf8')
+            ->addOption('collate', 'utf8_unicode_ci')
+        ;
 
         $toSchema = new Schema();
         $toSchema
@@ -354,6 +493,9 @@ class InstallerTest extends TestCase
         $fromSchema = new Schema();
         $fromSchema
             ->createTable('tl_foo')
+            ->addOption('engine', 'MyISAM')
+            ->addOption('charset', 'utf8')
+            ->addOption('collate', 'utf8_unicode_ci')
             ->addColumn('foo', 'string')
         ;
 
@@ -440,48 +582,31 @@ class InstallerTest extends TestCase
         $connection
             ->method('executeQuery')
             ->willReturnCallback(
-                function (string $query, array $parameters): ?MockObject {
+                function (string $query, array $parameters) use ($fromSchema): ?MockObject {
                     if ('SHOW TABLE STATUS WHERE Name = ? AND Engine IS NOT NULL AND Create_options IS NOT NULL AND Collation IS NOT NULL' !== $query) {
                         return null;
                     }
 
-                    switch ($parameters[0]) {
-                        case 'tl_foo':
-                            $statement = $this->createMock(Statement::class);
-                            $statement
-                                ->method('fetch')
-                                ->willReturn((object) [
-                                    'Engine' => 'MyISAM',
-                                    'Collation' => 'utf8_unicode_ci',
-                                ])
-                            ;
+                    $table = $fromSchema->getTable($parameters[0]);
+                    $statement = $this->createMock(Statement::class);
 
-                            return $statement;
-
-                        case 'tl_bar':
-                            $statement = $this->createMock(Statement::class);
-                            $statement
-                                ->method('fetch')
-                                ->willReturn((object) [
-                                    'Engine' => 'InnoDB',
-                                    'Create_options' => 'row_format=COMPACT',
-                                    'Collation' => 'utf8mb4_unicode_ci',
-                                ])
-                            ;
-
-                            return $statement;
-
-                        case 'tl_foo_view':
-                            $statement = $this->createMock(Statement::class);
-                            $statement
-                                ->method('fetch')
-                                ->willReturn(false)
-                            ;
-
-                            return $statement;
+                    if ($table->hasOption('engine')) {
+                        $statement
+                            ->method('fetch')
+                            ->willReturn((object) [
+                                'Engine' => $table->getOption('engine'),
+                                'Create_options' => implode(', ', $table->getOption('create_options')),
+                                'Collation' => $table->hasOption('collate') ? $table->getOption('collate') : '',
+                            ])
+                        ;
+                    } else {
+                        $statement
+                            ->method('fetch')
+                            ->willReturn(false)
+                        ;
                     }
 
-                    return null;
+                    return $statement;
                 }
             )
         ;

--- a/installation-bundle/tests/Database/InstallerTest.php
+++ b/installation-bundle/tests/Database/InstallerTest.php
@@ -128,7 +128,7 @@ class InstallerTest extends TestCase
         $installer = $this->getInstaller($fromSchema, $toSchema, ['tl_foo']);
         $commands = $installer->getCommands();
 
-        $this->assertHasStatement($commands['ALTER_TABLE'], 'ALTER TABLE tl_foo ENGINE = InnoDB ROW_FORMAT = DYNAMIC, KEY_BLOCK_SIZE = 0');
+        $this->assertHasStatement($commands['ALTER_TABLE'], 'ALTER TABLE tl_foo ENGINE = InnoDB ROW_FORMAT = DYNAMIC KEY_BLOCK_SIZE = 0');
     }
 
     public function testDeletesTheIndexesWhenChangingTheDatabaseEngine(): void
@@ -277,7 +277,7 @@ class InstallerTest extends TestCase
 
         $this->assertHasStatement(
             $commands['ALTER_TABLE'],
-            'ALTER TABLE tl_bar ENGINE = InnoDB ROW_FORMAT = DYNAMIC, KEY_BLOCK_SIZE = 0'
+            'ALTER TABLE tl_bar ENGINE = InnoDB ROW_FORMAT = DYNAMIC KEY_BLOCK_SIZE = 0'
         );
     }
 

--- a/installation-bundle/tests/Database/InstallerTest.php
+++ b/installation-bundle/tests/Database/InstallerTest.php
@@ -46,18 +46,17 @@ class InstallerTest extends TestCase
         $commands = $installer->getCommands();
 
         $this->assertArrayHasKey('ALTER_TABLE', $commands);
-        $this->assertArrayHasKey('d21451588bc7442c256f8a0be02c3430', $commands['ALTER_TABLE']);
-        $this->assertArrayHasKey('fb9f8dee53c39b7be92194908d98731e', $commands['ALTER_TABLE']);
 
-        $this->assertSame(
-            'ALTER TABLE tl_foo ENGINE = InnoDB ROW_FORMAT = DYNAMIC',
-            $commands['ALTER_TABLE']['d21451588bc7442c256f8a0be02c3430']
-        );
+        $expected = [
+            'ALTER TABLE tl_foo ENGINE = InnoDB ROW_FORMAT = DYNAMIC, KEY_BLOCK_SIZE=0',
+            'ALTER TABLE tl_foo CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci'
+        ];
 
-        $this->assertSame(
-            'ALTER TABLE tl_foo CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci',
-            $commands['ALTER_TABLE']['fb9f8dee53c39b7be92194908d98731e']
-        );
+        foreach ($expected as $statement) {
+            $key = md5($statement);
+            $this->assertArrayHasKey($key, $commands['ALTER_TABLE']);
+            $this->assertSame($statement, $commands['ALTER_TABLE'][$key]);
+        }
     }
 
     public function testDeletesTheIndexesWhenChangingTheDatabaseEngine(): void

--- a/installation-bundle/tests/Database/InstallerTest.php
+++ b/installation-bundle/tests/Database/InstallerTest.php
@@ -128,7 +128,7 @@ class InstallerTest extends TestCase
         $installer = $this->getInstaller($fromSchema, $toSchema, ['tl_foo']);
         $commands = $installer->getCommands();
 
-        $this->assertHasStatement($commands['ALTER_TABLE'], 'ALTER TABLE tl_foo ENGINE = InnoDB ROW_FORMAT = DYNAMIC, KEY_BLOCK_SIZE=0');
+        $this->assertHasStatement($commands['ALTER_TABLE'], 'ALTER TABLE tl_foo ENGINE = InnoDB ROW_FORMAT = DYNAMIC, KEY_BLOCK_SIZE = 0');
     }
 
     public function testDeletesTheIndexesWhenChangingTheDatabaseEngine(): void
@@ -277,7 +277,7 @@ class InstallerTest extends TestCase
 
         $this->assertHasStatement(
             $commands['ALTER_TABLE'],
-            'ALTER TABLE tl_bar ENGINE = InnoDB ROW_FORMAT = DYNAMIC, KEY_BLOCK_SIZE=0'
+            'ALTER TABLE tl_bar ENGINE = InnoDB ROW_FORMAT = DYNAMIC, KEY_BLOCK_SIZE = 0'
         );
     }
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -37,12 +37,14 @@
             <directory>./calendar-bundle/src</directory>
             <directory>./core-bundle/src</directory>
             <directory>./faq-bundle/src</directory>
+            <directory>./installation-bundle/src</directory>
             <directory>./manager-bundle/src</directory>
             <directory>./news-bundle/src</directory>
             <exclude>
                 <directory>./calendar-bundle/src/Resources</directory>
                 <directory>./core-bundle/src/Resources</directory>
                 <directory>./faq-bundle/src/Resources</directory>
+                <directory>./installation-bundle/src/Resources</directory>
                 <directory>./manager-bundle/src/Resources</directory>
                 <directory>./news-bundle/src/Resources</directory>
                 <!-- exclude files with symbols and side-effects -->

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -37,14 +37,12 @@
             <directory>./calendar-bundle/src</directory>
             <directory>./core-bundle/src</directory>
             <directory>./faq-bundle/src</directory>
-            <directory>./installation-bundle/src</directory>
             <directory>./manager-bundle/src</directory>
             <directory>./news-bundle/src</directory>
             <exclude>
                 <directory>./calendar-bundle/src/Resources</directory>
                 <directory>./core-bundle/src/Resources</directory>
                 <directory>./faq-bundle/src/Resources</directory>
-                <directory>./installation-bundle/src/Resources</directory>
                 <directory>./manager-bundle/src/Resources</directory>
                 <directory>./news-bundle/src/Resources</directory>
                 <!-- exclude files with symbols and side-effects -->


### PR DESCRIPTION
I have a Contao 4.6 setup on a server that did not support InnoDB. Therefore, I configured the DBAL like so which worked for about 2 years now.

```yaml
doctrine:
    dbal:
        connections:
            default:
                charset: utf8
                default_table_options:
                    charset: utf8
                    collate: utf8_unicode_ci
                    engine: MyISAM
```

I could finally convince the client to move to a good hoster and also do an update to Contao 4.9. First step was to move the existing installation to the new hoster, on Contao 4.6 and with this DBAL configuration. Then I updated to Contao 4.9 and did run `contao:migrate`, which fails at migrating the `tl_files` table:

>ALTER TABLE tl_files ENGINE = InnoDB ROW_FORMAT = DYNAMIC......FAILED
>[ERROR] An exception occurred while executing 'ALTER TABLE tl_files ENGINE = InnoDB ROW_FORMAT = DYNAMIC':                                                                                                                                  
        SQLSTATE[HY000]: General error: 1031 Table storage engine for '#sql-10b9_2e20d0a' doesn't have this option    

After a suggestion from @ausi I tried to set `ROW_FORMAT=DEFAULT` before changing the engine. Changing the row format worked, but I got a new error after that (this time in german due to phpMyAdmin).

> error 1478 - Speicher-Engine 'InnoDB' der Tabelle unterstützt die Option 'KEY_BLOCK_SIZE' nicht

I did some digging on the internet and found the following to MySQL issues:
 - https://bugs.mysql.com/bug.php?id=88843
 - https://bugs.mysql.com/bug.php?id=56628

Apparently, my database table has a `KEY_BLOCK_SIZE` defined, but that's not supported by an DYNAMIC (uncompressed) row format. According to the second bug report, setting `KEY_BLOCK_SIZE=0` is the correct way to remove that setting since MySQL 5.5.9