### PR TITLE
Add the image_container class to the default figure template

### DIFF
--- a/core-bundle/src/Resources/views/Image/Studio/figure.html.twig
+++ b/core-bundle/src/Resources/views/Image/Studio/figure.html.twig
@@ -1,3 +1,3 @@
 {% import "@ContaoCore/Image/Studio/_macros.html.twig" as studio %}
 
-{{- studio.figure(figure) -}}
+{{- studio.figure(figure, { attr: { class: 'image_container' }}) -}}


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | -
| Docs PR or issue | -

I figured we should probably add the `image_container` class to the core's default `figure.html.twig` template as well so that people can use it as a drop-in-replacement for the `image.html5` template. 

If someone should not want this class to be present in their installation, only a minor template adjustment is needed.