### PR TITLE
Ignore the logout URL if no user is present

### DIFF
--- a/core-bundle/src/Resources/contao/pages/PageLogout.php
+++ b/core-bundle/src/Resources/contao/pages/PageLogout.php
@@ -31,7 +31,6 @@ class PageLogout extends Frontend
 	 */
 	public function getResponse($objPage)
 	{
-		$strLogoutUrl = System::getContainer()->get('security.logout_url_generator')->getLogoutUrl();
 		$strRedirect = Environment::get('base');
 
 		// Redirect to last page visited
@@ -47,6 +46,15 @@ class PageLogout extends Frontend
 			$strRedirect = $objTarget->getAbsoluteUrl();
 		}
 
+		$container = System::getContainer();
+
+		// Redirect immediately, if there is no logged in user
+		if (null === $container->get('security.helper')->getUser())
+		{
+			return new RedirectResponse($strRedirect);
+		}
+
+		$strLogoutUrl = $container->get('security.logout_url_generator')->getLogoutUrl();
 		$uri = Http::createFromString($strLogoutUrl);
 
 		// Add the redirect= parameter to the logout URL

--- a/core-bundle/src/Resources/contao/pages/PageLogout.php
+++ b/core-bundle/src/Resources/contao/pages/PageLogout.php
@@ -48,11 +48,10 @@ class PageLogout extends Frontend
 		}
 
 		$container = System::getContainer();
-
-		// Redirect immediately if there is no logged in user (see #2388)
 		$token = $container->get('security.helper')->getToken();
 
-		if (null === $token || $token instanceof AnonymousToken)
+		// Redirect immediately if there is no logged in user (see #2388)
+		if ($token === null || $token instanceof AnonymousToken)
 		{
 			return new RedirectResponse($strRedirect);
 		}

--- a/core-bundle/src/Resources/contao/pages/PageLogout.php
+++ b/core-bundle/src/Resources/contao/pages/PageLogout.php
@@ -14,6 +14,7 @@ use League\Uri\Components\Query;
 use League\Uri\Http;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
 
 /**
  * Provide methods to handle a logout page.
@@ -49,7 +50,8 @@ class PageLogout extends Frontend
 		$container = System::getContainer();
 
 		// Redirect immediately if there is no logged in user (see #2388)
-		if (!$container->get('security.helper')->getUser())
+		$token = $container->get('security.helper')->getToken();
+		if (null === $token || $token instanceof AnonymousToken)
 		{
 			return new RedirectResponse($strRedirect);
 		}

--- a/core-bundle/src/Resources/contao/pages/PageLogout.php
+++ b/core-bundle/src/Resources/contao/pages/PageLogout.php
@@ -48,10 +48,10 @@ class PageLogout extends Frontend
 
 		$container = System::getContainer();
 
-		// Redirect immediately, if there is no logged in user
+		// Redirect immediately, if there is no logged in user (see #2388)
 		if (null === $container->get('security.helper')->getUser())
 		{
-			return new RedirectResponse($strRedirect);
+			//return new RedirectResponse($strRedirect);
 		}
 
 		$strLogoutUrl = $container->get('security.logout_url_generator')->getLogoutUrl();

--- a/core-bundle/src/Resources/contao/pages/PageLogout.php
+++ b/core-bundle/src/Resources/contao/pages/PageLogout.php
@@ -51,6 +51,7 @@ class PageLogout extends Frontend
 
 		// Redirect immediately if there is no logged in user (see #2388)
 		$token = $container->get('security.helper')->getToken();
+
 		if (null === $token || $token instanceof AnonymousToken)
 		{
 			return new RedirectResponse($strRedirect);

--- a/core-bundle/src/Resources/contao/pages/PageLogout.php
+++ b/core-bundle/src/Resources/contao/pages/PageLogout.php
@@ -48,8 +48,8 @@ class PageLogout extends Frontend
 
 		$container = System::getContainer();
 
-		// Redirect immediately, if there is no logged in user (see #2388)
-		if (null === $container->get('security.helper')->getUser())
+		// Redirect immediately if there is no logged in user (see #2388)
+		if (!$container->get('security.helper')->getUser())
 		{
 			return new RedirectResponse($strRedirect);
 		}

--- a/core-bundle/src/Resources/contao/pages/PageLogout.php
+++ b/core-bundle/src/Resources/contao/pages/PageLogout.php
@@ -51,7 +51,7 @@ class PageLogout extends Frontend
 		// Redirect immediately, if there is no logged in user (see #2388)
 		if (null === $container->get('security.helper')->getUser())
 		{
-			//return new RedirectResponse($strRedirect);
+			return new RedirectResponse($strRedirect);
 		}
 
 		$strLogoutUrl = $container->get('security.logout_url_generator')->getLogoutUrl();


### PR DESCRIPTION
If you access the URL of a logout page while not being logged in, the following error will occur:

```
InvalidArgumentException:
Unable to generate a logout url for an anonymous token.

  at vendor/symfony/security-http/Logout/LogoutUrlGenerator.php:144
  at Symfony\Component\Security\Http\Logout\LogoutUrlGenerator->getListener(null)
     (vendor/symfony/security-http/Logout/LogoutUrlGenerator.php:95)
  at Symfony\Component\Security\Http\Logout\LogoutUrlGenerator->generateLogoutUrl(null, 0)
     (vendor/symfony/security-http/Logout/LogoutUrlGenerator.php:76)
  at Symfony\Component\Security\Http\Logout\LogoutUrlGenerator->getLogoutUrl()
     (vendor/contao/contao/core-bundle/src/Resources/contao/pages/PageLogout.php:57)
  at Contao\PageLogout->getResponse(object(PageModel), true)
     (vendor/contao/contao/core-bundle/src/Resources/contao/controllers/FrontendIndex.php:339)
  at Contao\FrontendIndex->renderPage(object(PageModel))
     (vendor/symfony/http-kernel/HttpKernel.php:158)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw(object(Request), 1)
     (vendor/symfony/http-kernel/HttpKernel.php:80)
  at Symfony\Component\HttpKernel\HttpKernel->handle(object(Request), 1, true)
     (vendor/symfony/http-kernel/Kernel.php:201)
  at Symfony\Component\HttpKernel\Kernel->handle(object(Request))
     (web/index.php:31)
  at require('web/index.php')
     (web/app.php:4)
```

This can happen if the front end user happens to click twice on the logout link for example, causing two requests and the second click happens before the response of the first request arrives - thus the user will already be logged out for the second request.

This PR checks whether a user is actually logged in and if not simply redirects to the redirect target directly, without redirecting to the logout URL first.

One might say: "but Fritz, you obviously should protect the logout page 🙃 ". Well, I don't necessarily agree with that. In my case, the logout page isn't actually available anywhere in a regular navigation module, but rather is only used in either a custom navigation or a direct link, _within protected pages_. Thus there was no actual need to protect the logout page itself. Also, if you have defined a `401` page in your site structure (which you should) the 401 page would simply be shown in that case (or its redirect will be executed) - which typically means a login page will be shown. I would not expect the log**out** URL to show me a log**in**. I would expect the logout URL to always redirect to the defined redirect page, no matter what.