### PR TITLE
Only replace file insert tags for meta data

### DIFF
--- a/core-bundle/src/Resources/contao/models/FilesModel.php
+++ b/core-bundle/src/Resources/contao/models/FilesModel.php
@@ -423,7 +423,7 @@ class FilesModel extends Model
 			}
 
 			// Make sure we resolve insert tags pointing to files
-			if (isset($data[Metadata::VALUE_URL]))
+			if (isset($data[Metadata::VALUE_URL]) && 0 === stripos($data[Metadata::VALUE_URL], '{{file'))
 			{
 				$data[Metadata::VALUE_URL] = Controller::replaceInsertTags($data[Metadata::VALUE_URL]);
 			}


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #2394
| Docs PR or issue | -

The reason for the bug is that `{{link_url::*}}` will return an empty string for the `index` page (if no prefix is defined in the website root) - and thus the whole meta data array is considered empty and no link will be generated. In this PR I limit replacing the Insert Tags to `{{file::*}}`, since the comment above says "Make sure we resolve insert tags pointing to files".

However: what is the reason for replacing the insert tags here early in the first place? I'd just not replace any insert tags at this point at all.

/cc @m-vo 
