### PR TITLE
Check allowed page types

### DIFF
--- a/core-bundle/src/EventListener/FilterPageTypeListener.php
+++ b/core-bundle/src/EventListener/FilterPageTypeListener.php
@@ -59,10 +59,10 @@ class FilterPageTypeListener
             return;
         }
 
-        $siblingTypes = $this->connection->executeQuery(
-            'SELECT DISTINCT(type) FROM tl_page WHERE pid=?',
-            [$dc->activeRecord->pid]
-        )->fetchAll(FetchMode::COLUMN);
+        $siblingTypes = $this->connection
+            ->executeQuery('SELECT DISTINCT(type) FROM tl_page WHERE pid=?', [$dc->activeRecord->pid])
+            ->fetchAll(FetchMode::COLUMN)
+        ;
 
         foreach (array_intersect(['error_401', 'error_403', 'error_404'], $siblingTypes) as $type) {
             $event->removeOption($type);

--- a/core-bundle/src/EventListener/FilterPageTypeListener.php
+++ b/core-bundle/src/EventListener/FilterPageTypeListener.php
@@ -13,12 +13,24 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\EventListener;
 
 use Contao\CoreBundle\Event\FilterPageTypeEvent;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\FetchMode;
 
 /**
  * @internal
  */
 class FilterPageTypeListener
 {
+    /**
+     * @var Connection
+     */
+    private $connection;
+
+    public function __construct(Connection $connection)
+    {
+        $this->connection = $connection;
+    }
+
     public function __invoke(FilterPageTypeEvent $event): void
     {
         $dc = $event->getDataContainer();
@@ -27,11 +39,33 @@ class FilterPageTypeListener
             return;
         }
 
-        // Root pages are allowed on the first level only (see #6360)
-        if ($dc->activeRecord->pid > 0) {
-            $event->removeOption('root');
-        } else {
+        // The first level can only have root pages (see #6360)
+        if (!$dc->activeRecord->pid) {
             $event->setOptions(['root']);
+
+            return;
+        }
+
+        $event->removeOption('root');
+
+        $parentType = $this->connection->fetchColumn('SELECT type FROM tl_page WHERE id=?', [$dc->activeRecord->pid]);
+
+        // Error pages can only be placed directly inside root pages
+        if ('root' !== $parentType) {
+            $event->removeOption('error_401');
+            $event->removeOption('error_403');
+            $event->removeOption('error_404');
+
+            return;
+        }
+
+        $siblingTypes = $this->connection->executeQuery(
+            'SELECT DISTINCT(type) FROM tl_page WHERE pid=?',
+            [$dc->activeRecord->pid]
+        )->fetchAll(FetchMode::COLUMN);
+
+        foreach (array_intersect(['error_401', 'error_403', 'error_404'], $siblingTypes) as $type) {
+            $event->removeOption($type);
         }
     }
 }

--- a/core-bundle/src/Resources/config/listener.yml
+++ b/core-bundle/src/Resources/config/listener.yml
@@ -38,6 +38,8 @@ services:
         public: true
 
     Contao\CoreBundle\EventListener\FilterPageTypeListener:
+        arguments:
+            - '@database_connection'
         tags:
             - { name: kernel.event_listener }
 

--- a/core-bundle/tests/EventListener/FilterPageTypeListenerTest.php
+++ b/core-bundle/tests/EventListener/FilterPageTypeListenerTest.php
@@ -104,7 +104,6 @@ class FilterPageTypeListenerTest extends TestCase
         ;
 
         $connection = $this->createMock(Connection::class);
-
         $connection
             ->expects($this->once())
             ->method('fetchColumn')
@@ -135,12 +134,10 @@ class FilterPageTypeListenerTest extends TestCase
      */
     private function mockDataContainer(?int $pid): DataContainer
     {
-        /** @var DataContainer&MockObject $dataContainer */
-        $dataContainer = $this->mockClassWithProperties(
+        /** @var DataContainer&MockObject */
+        return $this->mockClassWithProperties(
             DataContainer::class,
             ['activeRecord' => null === $pid ? null : (object) ['pid' => $pid]]
         );
-
-        return $dataContainer;
     }
 }

--- a/core-bundle/tests/EventListener/FilterPageTypeListenerTest.php
+++ b/core-bundle/tests/EventListener/FilterPageTypeListenerTest.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\EventListener;
+
+use Contao\CoreBundle\Event\FilterPageTypeEvent;
+use Contao\CoreBundle\EventListener\FilterPageTypeListener;
+use Contao\CoreBundle\Tests\TestCase;
+use Contao\DataContainer;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\FetchMode;
+use Doctrine\DBAL\Statement;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class FilterPageTypeListenerTest extends TestCase
+{
+    public function testDoesNothingWithoutActiveRecord(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection
+            ->expects($this->never())
+            ->method($this->anything())
+        ;
+
+        $event = new FilterPageTypeEvent(['foo', 'bar'], $this->mockDataContainer(null));
+
+        $listener = new FilterPageTypeListener($connection);
+        $listener($event);
+
+        $this->assertSame(['foo', 'bar'], $event->getOptions());
+    }
+
+    public function testOnlyAllowsRootTypeWithoutPid(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection
+            ->expects($this->never())
+            ->method($this->anything())
+        ;
+
+        $event = new FilterPageTypeEvent(['foo', 'bar', 'root'], $this->mockDataContainer(0));
+
+        $listener = new FilterPageTypeListener($connection);
+        $listener($event);
+
+        $this->assertSame(['root'], $event->getOptions());
+    }
+
+    public function testRemovesRootTypeIfHasParentPage(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection
+            ->expects($this->once())
+            ->method('fetchColumn')
+            ->willReturn('foo')
+        ;
+
+        $event = new FilterPageTypeEvent(['foo', 'root'], $this->mockDataContainer(17));
+
+        $listener = new FilterPageTypeListener($connection);
+        $listener($event);
+
+        $this->assertSame(['foo'], $event->getOptions());
+    }
+
+    public function testRemovesErrorTypesIfParentIsNotRoot(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection
+            ->expects($this->once())
+            ->method('fetchColumn')
+            ->with('SELECT type FROM tl_page WHERE id=?', [17])
+            ->willReturn('foo')
+        ;
+
+        $event = new FilterPageTypeEvent(
+            ['foo', 'root', 'error_401', 'error_403', 'error_404'],
+            $this->mockDataContainer(17)
+        );
+
+        $listener = new FilterPageTypeListener($connection);
+        $listener($event);
+
+        $this->assertSame(['foo'], $event->getOptions());
+    }
+
+    public function testRemovesErrorTypesAlreadyPresentInTheRootPage(): void
+    {
+        $statement = $this->createMock(Statement::class);
+        $statement
+            ->expects($this->once())
+            ->method('fetchAll')
+            ->with(FetchMode::COLUMN)
+            ->willReturn(['foo', 'error_401', 'error_403'])
+        ;
+
+        $connection = $this->createMock(Connection::class);
+
+        $connection
+            ->expects($this->once())
+            ->method('fetchColumn')
+            ->with('SELECT type FROM tl_page WHERE id=?', [1])
+            ->willReturn('root')
+        ;
+
+        $connection
+            ->expects($this->once())
+            ->method('executeQuery')
+            ->with('SELECT DISTINCT(type) FROM tl_page WHERE pid=?', [1])
+            ->willReturn($statement)
+        ;
+
+        $event = new FilterPageTypeEvent(
+            ['foo', 'root', 'error_401', 'error_403', 'error_404'],
+            $this->mockDataContainer(1)
+        );
+
+        $listener = new FilterPageTypeListener($connection);
+        $listener($event);
+
+        $this->assertSame(['foo', 'error_404'], $event->getOptions());
+    }
+
+    /**
+     * @return DataContainer&MockObject
+     */
+    private function mockDataContainer(?int $pid): DataContainer
+    {
+        /** @var DataContainer&MockObject $dataContainer */
+        $dataContainer = $this->mockClassWithProperties(
+            DataContainer::class,
+            ['activeRecord' => null === $pid ? null : (object) ['pid' => $pid]]
+        );
+
+        return $dataContainer;
+    }
+}


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #1521


With this PR Contao only allows acceptable page type options in the respective place:

1. The root node can only contain `root` (already present)
2. `root` is not allowed with a parent page
3. `error_401`, `error_403` and `error_404` are only allowed as direct descendents of type `root`
4. `error_401`, `error_403` and `error_404` can only exist once per root page

This PR is against Contao 4.10, because it added the feature to limit the page type options. I don't think we should invest into fixing this in Contao 4.9, also because it might introduce a slightly different behavior for people.

I'm not 100% sure if the error pages can only exist once per root page? What about permissions or unpublished pages? Also, this is not 100%, it does not prevent copying the page type etc., but I don't think it should.