### PR TITLE
Check if catalogue has translation

### DIFF
--- a/core-bundle/src/Translation/DataCollectorTranslator.php
+++ b/core-bundle/src/Translation/DataCollectorTranslator.php
@@ -47,9 +47,10 @@ class DataCollectorTranslator extends SymfonyDataCollectorTranslator implements 
     public function trans($id, array $parameters = [], $domain = null, $locale = null): string
     {
         $translated = $this->translator->trans($id, $parameters, $domain, $locale);
+        $catalogue = $this->translator->getCatalogue();
 
         // Forward to the default translator
-        if (null === $domain || 0 !== strncmp($domain, 'contao_', 7) || $this->translator->getCatalogue()->has($id, $domain)) {
+        if (null === $domain || 0 !== strncmp($domain, 'contao_', 7) || null !== $catalogue && $catalogue->has($id, $domain)) {
             return $translated;
         }
 

--- a/core-bundle/src/Translation/DataCollectorTranslator.php
+++ b/core-bundle/src/Translation/DataCollectorTranslator.php
@@ -49,7 +49,7 @@ class DataCollectorTranslator extends SymfonyDataCollectorTranslator implements 
         $translated = $this->translator->trans($id, $parameters, $domain, $locale);
 
         // Forward to the default translator
-        if (null === $domain || 0 !== strncmp($domain, 'contao_', 7)) {
+        if (null === $domain || 0 !== strncmp($domain, 'contao_', 7) || $this->translator->getCatalogue()->has($id, $domain)) {
             return $translated;
         }
 

--- a/core-bundle/src/Translation/DataCollectorTranslator.php
+++ b/core-bundle/src/Translation/DataCollectorTranslator.php
@@ -47,7 +47,7 @@ class DataCollectorTranslator extends SymfonyDataCollectorTranslator implements 
     public function trans($id, array $parameters = [], $domain = null, $locale = null): string
     {
         $translated = $this->translator->trans($id, $parameters, $domain, $locale);
-        $catalogue = $this->translator->getCatalogue();
+        $catalogue = $this->translator->getCatalogue($locale);
 
         // Forward to the default translator
         if (null === $domain || 0 !== strncmp($domain, 'contao_', 7) || null !== $catalogue && $catalogue->has($id, $domain)) {

--- a/core-bundle/src/Translation/Translator.php
+++ b/core-bundle/src/Translation/Translator.php
@@ -49,8 +49,10 @@ class Translator implements TranslatorInterface, TranslatorBagInterface, LocaleA
      */
     public function trans($id, array $parameters = [], $domain = null, $locale = null): string
     {
+        $catalogue = $this->translator->getCatalogue();
+
         // Forward to the default translator
-        if (null === $domain || 0 !== strncmp($domain, 'contao_', 7) || $this->translator->getCatalogue()->has($id, $domain)) {
+        if (null === $domain || 0 !== strncmp($domain, 'contao_', 7) || null !== $catalogue && $catalogue->has($id, $domain)) {
             return $this->translator->trans($id, $parameters, $domain, $locale);
         }
 

--- a/core-bundle/src/Translation/Translator.php
+++ b/core-bundle/src/Translation/Translator.php
@@ -49,7 +49,7 @@ class Translator implements TranslatorInterface, TranslatorBagInterface, LocaleA
      */
     public function trans($id, array $parameters = [], $domain = null, $locale = null): string
     {
-        $catalogue = $this->translator->getCatalogue();
+        $catalogue = $this->translator->getCatalogue($locale);
 
         // Forward to the default translator
         if (null === $domain || 0 !== strncmp($domain, 'contao_', 7) || null !== $catalogue && $catalogue->has($id, $domain)) {

--- a/core-bundle/src/Translation/Translator.php
+++ b/core-bundle/src/Translation/Translator.php
@@ -50,7 +50,7 @@ class Translator implements TranslatorInterface, TranslatorBagInterface, LocaleA
     public function trans($id, array $parameters = [], $domain = null, $locale = null): string
     {
         // Forward to the default translator
-        if (null === $domain || 0 !== strncmp($domain, 'contao_', 7)) {
+        if (null === $domain || 0 !== strncmp($domain, 'contao_', 7) || $this->translator->getCatalogue()->has($id, $domain)) {
             return $this->translator->trans($id, $parameters, $domain, $locale);
         }
 


### PR DESCRIPTION
When creating a new extension for Contao 4.9 and up, I preferably want to use Symfony translations in YAML format, as they are easier to handle. For aesthetic  reasons I want the translation domain to consist of the `contao_` prefix plus the extension name. So for example if my extension's name is `Contao Example` and the package name is `inspiredminds/contao-example` and the extension's namespace is `InspiredMinds\ContaoExample\` I want the translation domain to be `contao_example`, with the translation files under `src/Resources/translations/contao_example.en.yaml` within the package, which you can then override in your application with `translations/contao_example.en.yaml` etc.

However - this does not work currently as any translation with a translation domain beginning with `contao_` is forced to be taken from `$GLOBALS['TL_LANG']`. Thus I would be forced to change the translation name to something else, i.e. `inspiredminds_contao_example`.

The question is: should any translation domain beginning with `contao_` really be only reserved to the `$GLOBALS['TL_LANG']` translations? It can be fixed by checking whether the catalogue has an actual entry for the requested translation id and translation domain combination, as I did in this PR. However I am not sure about performance penalties.

_Note:_ can someone explain what the `DataCollectorTranslator` is used for? I couldn't figure it out, but I did the same change there anyway.