### PR TITLE
Port the numeric alias changes to the PageUrlListener class

### DIFF
--- a/core-bundle/src/EventListener/DataContainer/PageUrlListener.php
+++ b/core-bundle/src/EventListener/DataContainer/PageUrlListener.php
@@ -77,6 +77,10 @@ class PageUrlListener implements ResetInterface
         $pageModel = $pageAdapter->findWithDetails($dc->id);
 
         if ('' !== $value) {
+            if (preg_match('/^[1-9]\d*$/', $value)) {
+                throw new \RuntimeException(sprintf($this->translator->trans('ERR.aliasNumeric', [], 'contao_default')));
+            }
+
             try {
                 $this->aliasExists($value, (int) $pageModel->id, $pageModel, true);
             } catch (DuplicateAliasException $exception) {

--- a/core-bundle/src/Routing/AbstractPageRouteProvider.php
+++ b/core-bundle/src/Routing/AbstractPageRouteProvider.php
@@ -53,7 +53,7 @@ abstract class AbstractPageRouteProvider implements RouteProviderInterface
         $aliases = [];
 
         foreach ($candidates as $candidate) {
-            if (is_numeric($candidate)) {
+            if (preg_match('/^[1-9]\d*$/', $candidate)) {
                 $ids[] = (int) $candidate;
             } else {
                 $aliases[] = $candidate;
@@ -96,7 +96,7 @@ abstract class AbstractPageRouteProvider implements RouteProviderInterface
 
             [, $id] = explode('.', $name);
 
-            if (!is_numeric($id)) {
+            if (!preg_match('/^[1-9]\d*$/', $id)) {
                 continue;
             }
 


### PR DESCRIPTION
Originally added to Contao 4.9 in #2361. The changes could not be merged upstream, hence this PR.