### PR TITLE
Remove the Content-Length header when modifying the response

### DIFF
--- a/core-bundle/src/EventListener/CsrfTokenCookieSubscriber.php
+++ b/core-bundle/src/EventListener/CsrfTokenCookieSubscriber.php
@@ -139,13 +139,18 @@ class CsrfTokenCookieSubscriber implements EventSubscriberInterface
         }
 
         $content = $response->getContent();
+        $tokens = $this->tokenStorage->getUsedTokens();
 
-        foreach ($this->tokenStorage->getUsedTokens() as $value) {
-            $content = str_replace($value, '', $content);
+        if (!\is_string($content) || empty($tokens)) {
+            return;
         }
 
-        $response->setContent($content);
-        $response->headers->remove('Content-Length');
+        $content = str_replace($tokens, '', $content, $replacedCount);
+
+        if ($replacedCount > 0) {
+            $response->setContent($content);
+            $response->headers->remove('Content-Length');
+        }
     }
 
     private function removeCookies(Request $request, Response $response): void

--- a/core-bundle/src/EventListener/CsrfTokenCookieSubscriber.php
+++ b/core-bundle/src/EventListener/CsrfTokenCookieSubscriber.php
@@ -145,6 +145,7 @@ class CsrfTokenCookieSubscriber implements EventSubscriberInterface
         }
 
         $response->setContent($content);
+        $response->headers->remove('Content-Length');
     }
 
     private function removeCookies(Request $request, Response $response): void

--- a/core-bundle/src/EventListener/CsrfTokenCookieSubscriber.php
+++ b/core-bundle/src/EventListener/CsrfTokenCookieSubscriber.php
@@ -149,6 +149,10 @@ class CsrfTokenCookieSubscriber implements EventSubscriberInterface
 
         if ($replacedCount > 0) {
             $response->setContent($content);
+
+            // Remove the Content-Length header now that we have changed the
+            // content length (see #2416). Do not add the header or adjust an
+            // existing one (see symfony/symfony#1846).
             $response->headers->remove('Content-Length');
         }
     }

--- a/core-bundle/tests/EventListener/CsrfTokenCookieSubscriberTest.php
+++ b/core-bundle/tests/EventListener/CsrfTokenCookieSubscriberTest.php
@@ -19,6 +19,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\Security\Csrf\TokenGenerator\UriSafeTokenGenerator;
@@ -174,6 +175,75 @@ class CsrfTokenCookieSubscriberTest extends TestCase
         $this->assertTrue($cookie->isHttpOnly());
         $this->assertTrue($cookie->isSecure());
         $this->assertNull($cookie->getSameSite());
+    }
+
+    public function testDoesNotChangeTheResponseIfNoTokensArePresent(): void
+    {
+        $bag = new ParameterBag([
+            'csrf_foo' => 'bar',
+        ]);
+
+        $request = Request::create('https://foobar.com');
+        $request->cookies = $bag;
+
+        $tokenStorage = new MemoryTokenStorage();
+        $tokenStorage->initialize([]);
+
+        $response = new Response(
+            '<html><body><form><input name="REQUEST_TOKEN" value="tokenValue"></form></body></html>',
+            200,
+            ['Content-Type' => 'text/html', 'Content-Length' => 1234]
+        );
+
+        $listener = new CsrfTokenCookieSubscriber($tokenStorage);
+        $listener->onKernelResponse($this->getResponseEvent($request, $response));
+
+        $this->assertSame(
+            '<html><body><form><input name="REQUEST_TOKEN" value="tokenValue"></form></body></html>',
+            $response->getContent()
+        );
+
+        $this->assertTrue($response->headers->has('Content-Length'));
+    }
+
+    public function testDoesNotChangeTheResponseIfTokensAreNotFound(): void
+    {
+        $bag = new ParameterBag([
+            'csrf_foo' => 'bar',
+        ]);
+
+        $request = Request::create('https://foobar.com');
+        $request->cookies = $bag;
+
+        $tokenStorage = new MemoryTokenStorage();
+        $tokenStorage->initialize(['tokenName' => 'tokenValue']);
+        $tokenStorage->getToken('tokenName');
+
+        $response = $this->createMock(Response::class);
+
+        $response
+            ->expects($this->once())
+            ->method('isSuccessful')
+            ->willReturn(true)
+        ;
+
+        $response
+            ->expects($this->once())
+            ->method('getContent')
+            ->willReturn(
+                '<html><body><form><input name="REQUEST_TOKEN" value=""></form></body></html>'
+            )
+        ;
+
+        $response
+            ->expects($this->never())
+            ->method('setContent')
+        ;
+
+        $response->headers = new ResponseHeaderBag(['Content-Type' => 'text/html']);
+
+        $listener = new CsrfTokenCookieSubscriber($tokenStorage);
+        $listener->onKernelResponse($this->getResponseEvent($request, $response));
     }
 
     public function testDoesNotAddTheTokenCookiesToTheResponseUponSubrequests(): void

--- a/core-bundle/tests/EventListener/CsrfTokenCookieSubscriberTest.php
+++ b/core-bundle/tests/EventListener/CsrfTokenCookieSubscriberTest.php
@@ -220,7 +220,6 @@ class CsrfTokenCookieSubscriberTest extends TestCase
         $tokenStorage->getToken('tokenName');
 
         $response = $this->createMock(Response::class);
-
         $response
             ->expects($this->once())
             ->method('isSuccessful')

--- a/core-bundle/tests/EventListener/CsrfTokenCookieSubscriberTest.php
+++ b/core-bundle/tests/EventListener/CsrfTokenCookieSubscriberTest.php
@@ -148,7 +148,7 @@ class CsrfTokenCookieSubscriberTest extends TestCase
         $response = new Response(
             '<html><body><form><input name="REQUEST_TOKEN" value="tokenValue"></form></body></html>',
             200,
-            ['Content-Type' => 'text/html']
+            ['Content-Type' => 'text/html', 'Content-Length' => 1234]
         );
 
         $listener = new CsrfTokenCookieSubscriber($tokenStorage);
@@ -158,6 +158,8 @@ class CsrfTokenCookieSubscriberTest extends TestCase
             '<html><body><form><input name="REQUEST_TOKEN" value=""></form></body></html>',
             $response->getContent()
         );
+
+        $this->assertFalse($response->headers->has('Content-Length'));
 
         $cookies = $response->headers->getCookies();
 


### PR DESCRIPTION
After searching for 2.5hrs, I tracked a network error in my browser down to this. The `CsrfTokenCookieSubscriber` modifies the response content. If the response already has a `Content-Length` header, the value will be incorrect and browser cannot correctly handle them (especially in HTTP2 fashion).

While debugging this with @leofeyer we also digged why Symfony does not set/fix that header automatically. Apparently there was some code in Symfony 2.0 (added in https://github.com/symfony/symfony/pull/1551) which caused some issues, and it was removed again in https://github.com/symfony/symfony/issues/1846

In my specific case (Isotope eCommerce), the issue was actually caused by https://github.com/codefog/contao-haste/blob/master/library/Haste/Http/Response/Response.php#L206