### PR TITLE
Fix unknown option when creating or editing error pages

### DIFF
--- a/core-bundle/src/EventListener/FilterPageTypeListener.php
+++ b/core-bundle/src/EventListener/FilterPageTypeListener.php
@@ -60,7 +60,7 @@ class FilterPageTypeListener
         }
 
         $siblingTypes = $this->connection
-            ->executeQuery('SELECT DISTINCT(type) FROM tl_page WHERE pid=?', [$dc->activeRecord->pid])
+            ->executeQuery('SELECT DISTINCT(type) FROM tl_page WHERE pid=? AND id !=?', [$dc->activeRecord->pid, $dc->activeRecord->id])
             ->fetchAll(FetchMode::COLUMN)
         ;
 

--- a/core-bundle/src/EventListener/FilterPageTypeListener.php
+++ b/core-bundle/src/EventListener/FilterPageTypeListener.php
@@ -60,7 +60,7 @@ class FilterPageTypeListener
         }
 
         $siblingTypes = $this->connection
-            ->executeQuery('SELECT DISTINCT(type) FROM tl_page WHERE pid=? AND id !=?', [$dc->activeRecord->pid, $dc->activeRecord->id])
+            ->executeQuery('SELECT DISTINCT(type) FROM tl_page WHERE pid=? AND id!=?', [$dc->activeRecord->pid, $dc->activeRecord->id])
             ->fetchAll(FetchMode::COLUMN)
         ;
 

--- a/core-bundle/tests/EventListener/FilterPageTypeListenerTest.php
+++ b/core-bundle/tests/EventListener/FilterPageTypeListenerTest.php
@@ -114,13 +114,13 @@ class FilterPageTypeListenerTest extends TestCase
         $connection
             ->expects($this->once())
             ->method('executeQuery')
-            ->with('SELECT DISTINCT(type) FROM tl_page WHERE pid=?', [1])
+            ->with('SELECT DISTINCT(type) FROM tl_page WHERE pid=? AND id!=?', [1, 2])
             ->willReturn($statement)
         ;
 
         $event = new FilterPageTypeEvent(
             ['foo', 'root', 'error_401', 'error_403', 'error_404'],
-            $this->mockDataContainer(1)
+            $this->mockDataContainer(1, 2)
         );
 
         $listener = new FilterPageTypeListener($connection);
@@ -132,12 +132,22 @@ class FilterPageTypeListenerTest extends TestCase
     /**
      * @return DataContainer&MockObject
      */
-    private function mockDataContainer(?int $pid): DataContainer
+    private function mockDataContainer(?int $pid, int $id = null): DataContainer
     {
+        $activeRecord = array_filter(
+            [
+                'id' => $id,
+                'pid' => $pid,
+            ],
+            static function ($v) {
+                return null !== $v;
+            }
+        );
+        dump($activeRecord);
         /** @var DataContainer&MockObject */
         return $this->mockClassWithProperties(
             DataContainer::class,
-            ['activeRecord' => null === $pid ? null : (object) ['pid' => $pid]]
+            ['activeRecord' => empty($activeRecord) ? null : (object) $activeRecord]
         );
     }
 }

--- a/core-bundle/tests/EventListener/FilterPageTypeListenerTest.php
+++ b/core-bundle/tests/EventListener/FilterPageTypeListenerTest.php
@@ -139,11 +139,11 @@ class FilterPageTypeListenerTest extends TestCase
                 'id' => $id,
                 'pid' => $pid,
             ],
-            static function ($v) {
+            static function ($v): bool {
                 return null !== $v;
             }
         );
-        dump($activeRecord);
+
         /** @var DataContainer&MockObject */
         return $this->mockClassWithProperties(
             DataContainer::class,


### PR DESCRIPTION
This fixes a bug introduced in #2397. If you create a 401, 403 or 404 page, it will be shown as an "unknown option" in the type selection.

This is because the `FilterPageTypeListener` is supposed to remove any error pages that are already present within the same website root. However, it also removes the page type of the page being currently edited.

This PR adds an additional query condition to prevent that.
