### PR TITLE
Stop using the deprecated Doctrine methods

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
               with:
-                  php-version: 7.3
+                  php-version: 7.4
                   extensions: dom, fileinfo, filter, gd, hash, intl, json, mbstring, pcre, pdo, zlib
                   tools: prestissimo, flex
                   coverage: pcov
@@ -47,7 +47,7 @@ jobs:
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
               with:
-                  php-version: 7.3
+                  php-version: 7.4
                   extensions: dom, fileinfo, filter, gd, hash, intl, json, mbstring, pcre, pdo, zlib
                   tools: prestissimo, flex
                   coverage: none
@@ -82,7 +82,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: [7.2, 7.3, 7.4]
+                php: [7.3, 7.4]
         steps:
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
@@ -119,7 +119,7 @@ jobs:
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
               with:
-                  php-version: 7.3
+                  php-version: 7.4
                   extensions: dom, fileinfo, filter, gd, hash, intl, json, mbstring, pcre, pdo_mysql, zlib
                   tools: prestissimo, flex
                   coverage: none
@@ -151,7 +151,7 @@ jobs:
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
               with:
-                  php-version: 7.3
+                  php-version: 7.4
                   extensions: dom, fileinfo, filter, gd, hash, intl, json, mbstring, pcre, pdo, zlib
                   tools: prestissimo, flex
                   coverage: none
@@ -189,7 +189,7 @@ jobs:
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
               with:
-                  php-version: 7.3
+                  php-version: 7.4
                   extensions: dom, fileinfo, filter, gd, hash, intl, json, mbstring, pcre, pdo_mysql, zlib
                   ini-values: memory_limit=1G
                   tools: prestissimo, flex
@@ -215,7 +215,7 @@ jobs:
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
               with:
-                  php-version: 7.3
+                  php-version: 7.4
                   extensions: json, zlib
                   tools: prestissimo
                   coverage: none
@@ -239,7 +239,7 @@ jobs:
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
               with:
-                  php-version: 7.3
+                  php-version: 7.4
                   extensions: json, zlib
                   tools: prestissimo
                   coverage: none

--- a/calendar-bundle/composer.json
+++ b/calendar-bundle/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.3",
         "contao/core-bundle": "self.version",
         "friendsofsymfony/http-cache": "^2.4",
         "patchwork/utf8": "^1.2",

--- a/comments-bundle/composer.json
+++ b/comments-bundle/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.3",
         "contao/core-bundle": "self.version",
         "patchwork/utf8": "^1.2",
         "symfony/http-kernel": "4.4.*"

--- a/composer.json
+++ b/composer.json
@@ -136,6 +136,7 @@
         "contao-community-alliance/composer-plugin": "<3.0",
         "contao/core": "*",
         "contao/manager-plugin": "<2.0 || >=3.0",
+        "doctrine/annotations": "<1.7",
         "doctrine/persistence": "1.3.2",
         "nikic/php-parser": "4.7.0",
         "symfony/config": "<4.4.2",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.3",
         "ext-dom": "*",
         "ext-gd": "*",
         "ext-hash": "*",

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
         "contao/imagine-svg": "^0.2.3 || ^1.0",
         "contao/maintenance-bundle-deprecated": "^2.1.5",
         "contao/manager-plugin": "^2.6.2",
-        "doctrine/dbal": "^2.10",
+        "doctrine/dbal": "^2.11",
         "doctrine/doctrine-bundle": "^1.8 || ^2.0",
         "doctrine/orm": "^2.6.3",
         "doctrine/persistence": "^1.3",

--- a/core-bundle/composer.json
+++ b/core-bundle/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.3",
         "ext-dom": "*",
         "ext-gd": "*",
         "ext-hash": "*",

--- a/core-bundle/composer.json
+++ b/core-bundle/composer.json
@@ -46,7 +46,7 @@
         "contao-components/tinymce4": "^4.7 || ^5.0",
         "contao/image": "^1.0",
         "contao/imagine-svg": "^0.2.3 || ^1.0",
-        "doctrine/dbal": "^2.10",
+        "doctrine/dbal": "^2.11",
         "doctrine/doctrine-bundle": "^1.8 || ^2.0",
         "doctrine/orm": "^2.6.3",
         "doctrine/persistence": "^1.3",

--- a/core-bundle/src/Cache/ContaoCacheWarmer.php
+++ b/core-bundle/src/Cache/ContaoCacheWarmer.php
@@ -235,7 +235,7 @@ class ContaoCacheWarmer implements CacheWarmerInterface
     private function isCompleteInstallation(): bool
     {
         try {
-            $this->connection->query('SELECT COUNT(*) FROM tl_page');
+            $this->connection->executeQuery('SELECT COUNT(*) FROM tl_page');
         } catch (\Exception $e) {
             return false;
         }

--- a/core-bundle/src/Controller/BackendPreviewSwitchController.php
+++ b/core-bundle/src/Controller/BackendPreviewSwitchController.php
@@ -17,7 +17,6 @@ use Contao\CoreBundle\Security\Authentication\FrontendPreviewAuthenticator;
 use Contao\CoreBundle\Security\Authentication\Token\TokenChecker;
 use Contao\Date;
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\FetchMode;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -183,7 +182,7 @@ class BackendPreviewSwitchController
         $time = Date::floorToMinute();
 
         // Get the active front end users
-        $result = $this->connection->executeQuery(
+        return $this->connection->fetchFirstColumn(
             "
                 SELECT
                     username
@@ -200,7 +199,5 @@ class BackendPreviewSwitchController
             ",
             [str_replace('%', '', $request->request->get('value')).'%']
         );
-
-        return $result->fetchAll(FetchMode::COLUMN);
     }
 }

--- a/core-bundle/src/Cors/WebsiteRootsConfigProvider.php
+++ b/core-bundle/src/Cors/WebsiteRootsConfigProvider.php
@@ -52,7 +52,7 @@ class WebsiteRootsConfigProvider implements ProviderInterface
         $stmt->bindValue('dns', preg_replace('@^https?://@', '', $request->headers->get('origin')));
         $stmt->execute();
 
-        if (!$stmt->fetchColumn()) {
+        if (!$stmt->fetchOne()) {
             return [];
         }
 

--- a/core-bundle/src/Doctrine/Schema/DcaSchemaProvider.php
+++ b/core-bundle/src/Doctrine/Schema/DcaSchemaProvider.php
@@ -418,12 +418,7 @@ class DcaSchemaProvider
             return 3072;
         }
 
-        $version = $this->doctrine
-            ->getConnection()
-            ->fetchAssociative('SELECT @@version as Value')
-        ;
-
-        [$ver] = explode('-', $version['Value']);
+        [$ver] = explode('-', $this->doctrine->getConnection()->fetchOne('SELECT @@version'));
 
         // As there is no reliable way to get the vendor (see #84), we are
         // guessing based on the version number. The check will not be run

--- a/core-bundle/src/Doctrine/Schema/DcaSchemaProvider.php
+++ b/core-bundle/src/Doctrine/Schema/DcaSchemaProvider.php
@@ -410,22 +410,20 @@ class DcaSchemaProvider
 
         $largePrefix = $this->doctrine
             ->getConnection()
-            ->query("SHOW VARIABLES LIKE 'innodb_large_prefix'")
-            ->fetch(\PDO::FETCH_OBJ)
+            ->fetchAssociative("SHOW VARIABLES LIKE 'innodb_large_prefix'")
         ;
 
         // The variable no longer exists as of MySQL 8 and MariaDB 10.3
-        if (false === $largePrefix || '' === $largePrefix->Value) {
+        if (false === $largePrefix || '' === $largePrefix['Value']) {
             return 3072;
         }
 
         $version = $this->doctrine
             ->getConnection()
-            ->query('SELECT @@version as Value')
-            ->fetch(\PDO::FETCH_OBJ)
+            ->fetchAssociative('SELECT @@version as Value')
         ;
 
-        [$ver] = explode('-', $version->Value);
+        [$ver] = explode('-', $version['Value']);
 
         // As there is no reliable way to get the vendor (see #84), we are
         // guessing based on the version number. The check will not be run
@@ -438,29 +436,27 @@ class DcaSchemaProvider
         }
 
         // The innodb_large_prefix option is disabled
-        if (!\in_array(strtolower((string) $largePrefix->Value), ['1', 'on'], true)) {
+        if (!\in_array(strtolower((string) $largePrefix['Value']), ['1', 'on'], true)) {
             return 767;
         }
 
         $filePerTable = $this->doctrine
             ->getConnection()
-            ->query("SHOW VARIABLES LIKE 'innodb_file_per_table'")
-            ->fetch(\PDO::FETCH_OBJ)
+            ->fetchAssociative("SHOW VARIABLES LIKE 'innodb_file_per_table'")
         ;
 
         // The innodb_file_per_table option is disabled
-        if (!\in_array(strtolower((string) $filePerTable->Value), ['1', 'on'], true)) {
+        if (!\in_array(strtolower((string) $filePerTable['Value']), ['1', 'on'], true)) {
             return 767;
         }
 
         $fileFormat = $this->doctrine
             ->getConnection()
-            ->query("SHOW VARIABLES LIKE 'innodb_file_format'")
-            ->fetch(\PDO::FETCH_OBJ)
+            ->fetchAssociative("SHOW VARIABLES LIKE 'innodb_file_format'")
         ;
 
         // The InnoDB file format is not Barracuda
-        if ('' !== $fileFormat->Value && 'barracuda' !== strtolower((string) $fileFormat->Value)) {
+        if ('' !== $fileFormat['Value'] && 'barracuda' !== strtolower((string) $fileFormat['Value'])) {
             return 767;
         }
 

--- a/core-bundle/src/EventListener/DataContainer/ContentCompositionListener.php
+++ b/core-bundle/src/EventListener/DataContainer/ContentCompositionListener.php
@@ -156,13 +156,10 @@ class ContentCompositionListener
         }
 
         // Check whether there are articles (e.g. on copied pages)
-        $total = $this->connection
-            ->executeQuery(
-                'SELECT COUNT(*) FROM tl_article WHERE pid=:pid',
-                ['pid' => $dc->id]
-            )
-            ->fetchColumn()
-        ;
+        $total = $this->connection->fetchOne(
+            'SELECT COUNT(*) FROM tl_article WHERE pid=:pid',
+            ['pid' => $dc->id]
+        );
 
         if ($total > 0) {
             return;

--- a/core-bundle/src/EventListener/DataContainer/PageUrlListener.php
+++ b/core-bundle/src/EventListener/DataContainer/PageUrlListener.php
@@ -21,7 +21,6 @@ use Contao\Input;
 use Contao\PageModel;
 use Contao\Search;
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\FetchMode;
 use Symfony\Contracts\Service\ResetInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
@@ -143,17 +142,14 @@ class PageUrlListener implements ResetInterface
         }
 
         // First check if another root page uses the same url prefix and domain
-        $count = $this->connection
-            ->executeQuery(
-                "SELECT COUNT(*) FROM tl_page WHERE urlPrefix=:urlPrefix AND dns=:dns AND id!=:rootId AND type='root'",
-                [
-                    'urlPrefix' => $value,
-                    'dns' => $dc->activeRecord->dns,
-                    'rootId' => $dc->id,
-                ]
-            )
-            ->fetchColumn()
-        ;
+        $count = $this->connection->fetchOne(
+            "SELECT COUNT(*) FROM tl_page WHERE urlPrefix=:urlPrefix AND dns=:dns AND id!=:rootId AND type='root'",
+            [
+                'urlPrefix' => $value,
+                'dns' => $dc->activeRecord->dns,
+                'rootId' => $dc->id,
+            ]
+        );
 
         if ($count > 0) {
             throw new \RuntimeException($this->translator->trans('ERR.urlPrefixExists', [$value], 'contao_default'));
@@ -210,13 +206,10 @@ class PageUrlListener implements ResetInterface
 
     public function purgeSearchIndex(int $pageId): void
     {
-        $urls = $this->connection
-            ->executeQuery(
-                'SELECT url FROM tl_search WHERE pid=:pageId',
-                ['pageId' => $pageId]
-            )
-            ->fetchAll(FetchMode::COLUMN)
-        ;
+        $urls = $this->connection->fetchFirstColumn(
+            'SELECT url FROM tl_search WHERE pid=:pageId',
+            ['pageId' => $pageId]
+        );
 
         /** @var Search $search */
         $search = $this->framework->getAdapter(Search::class);
@@ -274,16 +267,13 @@ class PageUrlListener implements ResetInterface
             }
         }
 
-        $aliasIds = $this->connection
-            ->executeQuery(
-                'SELECT id FROM tl_page WHERE alias LIKE :alias AND id!=:id',
-                [
-                    'alias' => '%'.$this->stripPrefixesAndSuffixes($currentAlias, $currentPrefix, $currentSuffix).'%',
-                    'id' => $currentId,
-                ]
-            )
-            ->fetchAll(FetchMode::COLUMN)
-        ;
+        $aliasIds = $this->connection->fetchFirstColumn(
+            'SELECT id FROM tl_page WHERE alias LIKE :alias AND id!=:id',
+            [
+                'alias' => '%'.$this->stripPrefixesAndSuffixes($currentAlias, $currentPrefix, $currentSuffix).'%',
+                'id' => $currentId,
+            ]
+        );
 
         if (0 === \count($aliasIds)) {
             return false;
@@ -344,10 +334,7 @@ class PageUrlListener implements ResetInterface
             $this->prefixes = [];
             $this->suffixes = [];
 
-            $rows = $this->connection
-                ->executeQuery("SELECT urlPrefix, urlSuffix FROM tl_page WHERE type='root'")
-                ->fetchAll()
-            ;
+            $rows = $this->connection->fetchAllAssociative("SELECT urlPrefix, urlSuffix FROM tl_page WHERE type='root'");
 
             if (0 === ($prefixLength = \strlen($urlPrefix))) {
                 $this->prefixes = array_column($rows, 'urlPrefix');

--- a/core-bundle/src/EventListener/FilterPageTypeListener.php
+++ b/core-bundle/src/EventListener/FilterPageTypeListener.php
@@ -14,7 +14,6 @@ namespace Contao\CoreBundle\EventListener;
 
 use Contao\CoreBundle\Event\FilterPageTypeEvent;
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\FetchMode;
 
 /**
  * @internal
@@ -48,7 +47,7 @@ class FilterPageTypeListener
 
         $event->removeOption('root');
 
-        $parentType = $this->connection->fetchColumn('SELECT type FROM tl_page WHERE id=?', [$dc->activeRecord->pid]);
+        $parentType = $this->connection->fetchOne('SELECT type FROM tl_page WHERE id=?', [$dc->activeRecord->pid]);
 
         // Error pages can only be placed directly inside root pages
         if ('root' !== $parentType) {
@@ -59,10 +58,10 @@ class FilterPageTypeListener
             return;
         }
 
-        $siblingTypes = $this->connection
-            ->executeQuery('SELECT DISTINCT(type) FROM tl_page WHERE pid=?', [$dc->activeRecord->pid])
-            ->fetchAll(FetchMode::COLUMN)
-        ;
+        $siblingTypes = $this->connection->fetchFirstColumn(
+            'SELECT DISTINCT(type) FROM tl_page WHERE pid=?',
+            [$dc->activeRecord->pid]
+        );
 
         foreach (array_intersect(['error_401', 'error_403', 'error_404'], $siblingTypes) as $type) {
             $event->removeOption($type);

--- a/core-bundle/src/Image/ImageSizes.php
+++ b/core-bundle/src/Image/ImageSizes.php
@@ -135,7 +135,7 @@ class ImageSizes implements ResetInterface
 
         $this->options = $GLOBALS['TL_CROP'];
 
-        $rows = $this->connection->fetchAll(
+        $rows = $this->connection->fetchAllAssociative(
             'SELECT
                 s.id, s.name, s.width, s.height, t.name as theme
             FROM

--- a/core-bundle/src/Migration/Version409/CeAccessMigration.php
+++ b/core-bundle/src/Migration/Version409/CeAccessMigration.php
@@ -55,7 +55,7 @@ class CeAccessMigration extends AbstractMigration
     {
         $this->framework->initialize();
 
-        $this->connection->query('
+        $this->connection->executeStatement('
             ALTER TABLE
                 tl_user_group
             ADD

--- a/core-bundle/src/Migration/Version410/DropSearchMigration.php
+++ b/core-bundle/src/Migration/Version410/DropSearchMigration.php
@@ -53,8 +53,8 @@ class DropSearchMigration extends AbstractMigration
 
     public function run(): MigrationResult
     {
-        $this->connection->query('DROP TABLE IF EXISTS tl_search_index');
-        $this->connection->query('DROP TABLE IF EXISTS tl_search');
+        $this->connection->executeStatement('DROP TABLE IF EXISTS tl_search_index');
+        $this->connection->executeStatement('DROP TABLE IF EXISTS tl_search');
 
         return $this->createResult(true);
     }

--- a/core-bundle/src/Migration/Version410/RoutingMigration.php
+++ b/core-bundle/src/Migration/Version410/RoutingMigration.php
@@ -82,7 +82,7 @@ class RoutingMigration extends AbstractMigration
         $sql = $this->connection->getDatabasePlatform()->getAlterTableSQL($diff);
 
         foreach ($sql as $statement) {
-            $this->connection->exec($statement);
+            $this->connection->executeStatement($statement);
         }
 
         $prefix = $this->prependLocale ? 'language' : "''";

--- a/core-bundle/src/Picker/AbstractTablePickerProvider.php
+++ b/core-bundle/src/Picker/AbstractTablePickerProvider.php
@@ -15,6 +15,7 @@ namespace Contao\CoreBundle\Picker;
 use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\DcaLoader;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver\Result;
 use Knp\Menu\FactoryInterface;
 use Knp\Menu\ItemInterface;
 use Symfony\Component\Routing\RouterInterface;
@@ -248,7 +249,9 @@ abstract class AbstractTablePickerProvider implements PickerProviderInterface, D
             $qb->addSelect('ptable');
         }
 
-        $data = $qb->execute()->fetch();
+        /** @var Result $result */
+        $result = $qb->execute();
+        $data = $result->fetchAssociative();
 
         if (false === $data) {
             return [null, null];

--- a/core-bundle/src/Repository/CronJobRepository.php
+++ b/core-bundle/src/Repository/CronJobRepository.php
@@ -40,11 +40,11 @@ class CronJobRepository extends ServiceEntityRepository
     {
         $table = $this->getClassMetadata()->getTableName();
 
-        $this->connection->exec("LOCK TABLES $table WRITE, $table AS t0 WRITE, $table AS t0_ WRITE");
+        $this->connection->executeStatement("LOCK TABLES $table WRITE, $table AS t0 WRITE, $table AS t0_ WRITE");
     }
 
     public function unlockTable(): void
     {
-        $this->connection->exec('UNLOCK TABLES');
+        $this->connection->executeStatement('UNLOCK TABLES');
     }
 }

--- a/core-bundle/src/Repository/RememberMeRepository.php
+++ b/core-bundle/src/Repository/RememberMeRepository.php
@@ -38,12 +38,12 @@ class RememberMeRepository extends ServiceEntityRepository
     {
         $table = $this->getClassMetadata()->getTableName();
 
-        $this->connection->exec("LOCK TABLES $table WRITE, $table AS t0_ WRITE");
+        $this->connection->executeStatement("LOCK TABLES $table WRITE, $table AS t0_ WRITE");
     }
 
     public function unlockTable(): void
     {
-        $this->connection->exec('UNLOCK TABLES');
+        $this->connection->executeStatement('UNLOCK TABLES');
     }
 
     /**

--- a/core-bundle/src/Resources/contao/library/Contao/Database.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Database.php
@@ -585,7 +585,7 @@ class Database
 	 */
 	public function setDatabase($strDatabase)
 	{
-		$this->resConnection->exec("USE $strDatabase");
+		$this->resConnection->executeStatement("USE $strDatabase");
 	}
 
 	/**
@@ -626,7 +626,7 @@ class Database
 			$arrLocks[] = $this->resConnection->quoteIdentifier($table) . ' ' . $mode;
 		}
 
-		$this->resConnection->exec('LOCK TABLES ' . implode(', ', $arrLocks) . ';');
+		$this->resConnection->executeStatement('LOCK TABLES ' . implode(', ', $arrLocks) . ';');
 	}
 
 	/**
@@ -634,7 +634,7 @@ class Database
 	 */
 	public function unlockTables()
 	{
-		$this->resConnection->exec('UNLOCK TABLES;');
+		$this->resConnection->executeStatement('UNLOCK TABLES;');
 	}
 
 	/**
@@ -649,14 +649,13 @@ class Database
 		try
 		{
 			// MySQL 8 compatibility
-			$this->resConnection->executeQuery('SET @@SESSION.information_schema_stats_expiry = 0');
+			$this->resConnection->executeStatement('SET @@SESSION.information_schema_stats_expiry = 0');
 		}
 		catch (DriverException $e)
 		{
 		}
 
-		$statement = $this->resConnection->executeQuery('SHOW TABLE STATUS LIKE ' . $this->resConnection->quote($strTable));
-		$status = $statement->fetch(\PDO::FETCH_ASSOC);
+		$status = $this->resConnection->fetchAssociative('SHOW TABLE STATUS LIKE ' . $this->resConnection->quote($strTable));
 
 		return $status['Data_length'] + $status['Index_length'];
 	}
@@ -673,14 +672,13 @@ class Database
 		try
 		{
 			// MySQL 8 compatibility
-			$this->resConnection->executeQuery('SET @@SESSION.information_schema_stats_expiry = 0');
+			$this->resConnection->executeStatement('SET @@SESSION.information_schema_stats_expiry = 0');
 		}
 		catch (DriverException $e)
 		{
 		}
 
-		$statement = $this->resConnection->executeQuery('SHOW TABLE STATUS LIKE ' . $this->resConnection->quote($strTable));
-		$status = $statement->fetch(\PDO::FETCH_ASSOC);
+		$status = $this->resConnection->fetchAssociative('SHOW TABLE STATUS LIKE ' . $this->resConnection->quote($strTable));
 
 		return $status['Auto_increment'];
 	}
@@ -696,8 +694,7 @@ class Database
 
 		if (empty($ids))
 		{
-			$statement = $this->resConnection->executeQuery(implode(' UNION ALL ', array_fill(0, 10, "SELECT UNHEX(REPLACE(UUID(), '-', '')) AS uuid")));
-			$ids = $statement->fetchAll(\PDO::FETCH_COLUMN);
+			$ids = $this->resConnection->fetchFirstColumn(implode(' UNION ALL ', array_fill(0, 10, "SELECT UNHEX(REPLACE(UUID(), '-', '')) AS uuid")));
 		}
 
 		return array_pop($ids);

--- a/core-bundle/src/Resources/contao/library/Contao/Database/Result.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Database/Result.php
@@ -103,7 +103,7 @@ class Result
 	{
 		if ($this->resResult)
 		{
-			$this->resResult->closeCursor();
+			$this->resResult->free();
 		}
 	}
 
@@ -434,12 +434,12 @@ class Result
 
 		while ($this->resResult && \count($this->resultSet) <= $index)
 		{
-			$row = $this->resResult->fetch(\PDO::FETCH_ASSOC);
+			$row = $this->resResult->fetchAssociative();
 
 			if ($row === false)
 			{
 				$this->rowCount = \count($this->resultSet);
-				$this->resResult->closeCursor();
+				$this->resResult->free();
 				$this->resResult = null;
 				break;
 			}

--- a/core-bundle/src/Resources/contao/library/Contao/Database/Statement.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Database/Statement.php
@@ -344,7 +344,7 @@ class Statement
 	 */
 	public function explain()
 	{
-		return $this->resConnection->executeQuery('EXPLAIN ' . $this->strQuery)->fetch();
+		return $this->resConnection->fetchAssociative('EXPLAIN ' . $this->strQuery);
 	}
 
 	/**

--- a/core-bundle/src/Resources/contao/library/Contao/Widget.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Widget.php
@@ -11,7 +11,7 @@
 namespace Contao;
 
 use Contao\Database\Result;
-use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
 use Patchwork\Utf8;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -1454,7 +1454,7 @@ abstract class Widget extends Controller
 					return null;
 				}
 
-				if (\in_array($sql['type'], array(Type::BIGINT, Type::DECIMAL, Type::INTEGER, Type::SMALLINT, Type::FLOAT)))
+				if (\in_array($sql['type'], array(Types::BIGINT, Types::DECIMAL, Types::INTEGER, Types::SMALLINT, Types::FLOAT)))
 				{
 					return 0;
 				}

--- a/core-bundle/src/Routing/Candidates/PageCandidates.php
+++ b/core-bundle/src/Routing/Candidates/PageCandidates.php
@@ -14,7 +14,7 @@ namespace Contao\CoreBundle\Routing\Candidates;
 
 use Contao\CoreBundle\Routing\Page\PageRegistry;
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\FetchMode;
+use Doctrine\DBAL\Driver\Result;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -56,7 +56,10 @@ class PageCandidates extends AbstractCandidates
         $hasRegex = $this->addRegexQuery($qb, $request->getPathInfo());
 
         if ($hasRoot || $hasRegex) {
-            return array_unique(array_merge($candidates, $qb->execute()->fetchAll(FetchMode::COLUMN)));
+            /** @var Result $result */
+            $result = $qb->execute();
+
+            return array_unique(array_merge($candidates, $result->fetchFirstColumn()));
         }
 
         return $candidates;

--- a/core-bundle/src/Routing/Page/PageRegistry.php
+++ b/core-bundle/src/Routing/Page/PageRegistry.php
@@ -187,10 +187,7 @@ class PageRegistry
             return;
         }
 
-        $results = $this->connection
-            ->query("SELECT urlPrefix, urlSuffix FROM tl_page WHERE type='root'")
-            ->fetchAll()
-        ;
+        $results = $this->connection->fetchAllAssociative("SELECT urlPrefix, urlSuffix FROM tl_page WHERE type='root'");
 
         $urlSuffixes = [
             array_column($results, 'urlSuffix'),

--- a/core-bundle/src/Search/Indexer/DefaultIndexer.php
+++ b/core-bundle/src/Search/Indexer/DefaultIndexer.php
@@ -15,7 +15,7 @@ namespace Contao\CoreBundle\Search\Indexer;
 use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\CoreBundle\Search\Document;
 use Contao\Search;
-use Doctrine\DBAL\Driver\Connection;
+use Doctrine\DBAL\Connection;
 
 class DefaultIndexer implements IndexerInterface
 {
@@ -125,9 +125,9 @@ class DefaultIndexer implements IndexerInterface
 
     public function clear(): void
     {
-        $this->connection->exec('TRUNCATE TABLE tl_search');
-        $this->connection->exec('TRUNCATE TABLE tl_search_index');
-        $this->connection->exec('TRUNCATE TABLE tl_search_term');
+        $this->connection->executeStatement('TRUNCATE TABLE tl_search');
+        $this->connection->executeStatement('TRUNCATE TABLE tl_search_index');
+        $this->connection->executeStatement('TRUNCATE TABLE tl_search_term');
     }
 
     /**

--- a/core-bundle/tests/Cache/ContaoCacheWarmerTest.php
+++ b/core-bundle/tests/Cache/ContaoCacheWarmerTest.php
@@ -109,7 +109,7 @@ class ContaoCacheWarmerTest extends TestCase
     {
         $connection = $this->createMock(Connection::class);
         $connection
-            ->method('query')
+            ->method('executeQuery')
             ->willThrowException(new \Exception())
         ;
 

--- a/core-bundle/tests/Controller/BackendPreviewSwitchControllerTest.php
+++ b/core-bundle/tests/Controller/BackendPreviewSwitchControllerTest.php
@@ -18,7 +18,6 @@ use Contao\CoreBundle\Security\Authentication\FrontendPreviewAuthenticator;
 use Contao\CoreBundle\Security\Authentication\Token\TokenChecker;
 use Contao\CoreBundle\Tests\TestCase;
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\Driver\ResultStatement;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\ParameterBag;
@@ -37,7 +36,7 @@ class BackendPreviewSwitchControllerTest extends TestCase
         $controller = new BackendPreviewSwitchController(
             $this->createMock(FrontendPreviewAuthenticator::class),
             $this->mockTokenChecker(),
-            $this->mockConnection(),
+            $this->createMock(Connection::class),
             $this->mockSecurity(),
             $this->getTwigMock(),
             $this->mockRouter(),
@@ -61,7 +60,7 @@ class BackendPreviewSwitchControllerTest extends TestCase
         $controller = new BackendPreviewSwitchController(
             $this->createMock(FrontendPreviewAuthenticator::class),
             $this->mockTokenChecker(),
-            $this->mockConnection(),
+            $this->createMock(Connection::class),
             $this->mockSecurity(),
             $this->getTwigMock(),
             $this->mockRouter(),
@@ -92,7 +91,7 @@ class BackendPreviewSwitchControllerTest extends TestCase
         $controller = new BackendPreviewSwitchController(
             $this->createMock(FrontendPreviewAuthenticator::class),
             $this->mockTokenChecker(),
-            $this->mockConnection(),
+            $this->createMock(Connection::class),
             $this->mockSecurity(),
             $this->getTwigMock(),
             $this->mockRouter(),
@@ -124,7 +123,7 @@ class BackendPreviewSwitchControllerTest extends TestCase
         $controller = new BackendPreviewSwitchController(
             $this->createMock(FrontendPreviewAuthenticator::class),
             $this->mockTokenChecker(),
-            $this->mockConnection([]),
+            $this->createMock(Connection::class),
             $this->mockSecurity(),
             $this->getTwigMock(),
             $this->mockRouter(),
@@ -229,24 +228,5 @@ class BackendPreviewSwitchControllerTest extends TestCase
         ;
 
         return $twig;
-    }
-
-    /**
-     * @return Connection&MockObject
-     */
-    private function mockConnection(array $return = []): Connection
-    {
-        $resultStatement = $this->createMock(ResultStatement::class)
-            ->method('fetchAll')
-            ->willReturn($return)
-        ;
-
-        $connection = $this->createMock(Connection::class);
-        $connection
-            ->method('executeQuery')
-            ->willReturn($resultStatement)
-        ;
-
-        return $connection;
     }
 }

--- a/core-bundle/tests/Cors/WebsiteRootsConfigProviderTest.php
+++ b/core-bundle/tests/Cors/WebsiteRootsConfigProviderTest.php
@@ -14,8 +14,8 @@ namespace Contao\CoreBundle\Tests\Cors;
 
 use Contao\CoreBundle\Cors\WebsiteRootsConfigProvider;
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\Driver\Statement;
 use Doctrine\DBAL\Schema\MySqlSchemaManager;
+use Doctrine\DBAL\Statement;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
@@ -35,7 +35,7 @@ class WebsiteRootsConfigProviderTest extends TestCase
 
         $statement
             ->expects($this->once())
-            ->method('fetchColumn')
+            ->method('fetchOne')
             ->willReturn('1')
         ;
 
@@ -67,7 +67,7 @@ class WebsiteRootsConfigProviderTest extends TestCase
 
         $statement
             ->expects($this->once())
-            ->method('fetchColumn')
+            ->method('fetchOne')
             ->willReturn('0')
         ;
 

--- a/core-bundle/tests/Doctrine/Schema/DcaSchemaProviderTest.php
+++ b/core-bundle/tests/Doctrine/Schema/DcaSchemaProviderTest.php
@@ -14,10 +14,11 @@ namespace Contao\CoreBundle\Tests\Doctrine\Schema;
 
 use Contao\CoreBundle\Doctrine\Schema\DcaSchemaProvider;
 use Contao\CoreBundle\Tests\Doctrine\DoctrineTestCase;
+use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\MySqlPlatform;
-use Doctrine\DBAL\Statement;
 use Doctrine\ORM\Mapping\ClassMetadata;
+use PHPUnit\Framework\MockObject\MockObject;
 
 class DcaSchemaProviderTest extends DoctrineTestCase
 {
@@ -292,12 +293,6 @@ class DcaSchemaProviderTest extends DoctrineTestCase
 
     public function testCreatesTheTableDefinitions(): void
     {
-        $statement = $this->createMock(Statement::class);
-        $statement
-            ->method('fetch')
-            ->willReturn((object) ['Collation' => null])
-        ;
-
         $provider = $this->getProvider(
             [
                 'tl_member' => [
@@ -315,9 +310,7 @@ class DcaSchemaProviderTest extends DoctrineTestCase
                         'name' => 'KEY `name` (`firstname`, `lastname`)',
                     ],
                 ],
-            ],
-            [],
-            $statement
+            ]
         );
 
         $schema = $provider->createSchema();
@@ -351,14 +344,14 @@ class DcaSchemaProviderTest extends DoctrineTestCase
      */
     public function testAddsTheIndexLength(?int $expected, string $tableOptions, $largePrefixes = null, string $version = null, string $filePerTable = null, string $fileFormat = null): void
     {
-        $statement = $this->createMock(Statement::class);
-        $statement
-            ->method('fetch')
+        $connection = $this->createMock(Connection::class);
+        $connection
+            ->method('fetchAssociative')
             ->willReturnOnConsecutiveCalls(
-                (object) ['Value' => $largePrefixes],
-                (object) ['Value' => $version],
-                (object) ['Value' => $filePerTable],
-                (object) ['Value' => $fileFormat]
+                ['Value' => $largePrefixes],
+                ['Value' => $version],
+                ['Value' => $filePerTable],
+                ['Value' => $fileFormat]
             )
         ;
 
@@ -375,7 +368,7 @@ class DcaSchemaProviderTest extends DoctrineTestCase
                 ],
             ],
             [],
-            $statement
+            $connection
         );
 
         $schema = $provider->createSchema();
@@ -596,10 +589,10 @@ class DcaSchemaProviderTest extends DoctrineTestCase
 
     public function testHandlesFulltextIndexes(): void
     {
-        $statement = $this->createMock(Statement::class);
-        $statement
-            ->method('fetch')
-            ->willReturn((object) ['Value' => 'On'])
+        $connection = $this->createMock(Connection::class);
+        $connection
+            ->method('fetchAssociative')
+            ->willReturn(['Value' => 'On'])
         ;
 
         $provider = $this->getProvider(
@@ -615,7 +608,7 @@ class DcaSchemaProviderTest extends DoctrineTestCase
                 ],
             ],
             [],
-            $statement
+            $connection
         );
 
         $schema = $provider->createSchema();
@@ -732,5 +725,16 @@ class DcaSchemaProviderTest extends DoctrineTestCase
         $schema = $provider->createSchema();
 
         $this->assertCount(0, $schema->getTables());
+    }
+
+    /**
+     * @param Connection&MockObject $connection
+     */
+    private function getProvider(array $dca = [], array $file = [], Connection $connection = null, string $filter = null): DcaSchemaProvider
+    {
+        return new DcaSchemaProvider(
+            $this->mockContaoFrameworkWithInstaller($dca, $file),
+            $this->mockDoctrineRegistryWithConnection($connection, $filter)
+        );
     }
 }

--- a/core-bundle/tests/Doctrine/Schema/DcaSchemaProviderTest.php
+++ b/core-bundle/tests/Doctrine/Schema/DcaSchemaProviderTest.php
@@ -346,10 +346,14 @@ class DcaSchemaProviderTest extends DoctrineTestCase
     {
         $connection = $this->createMock(Connection::class);
         $connection
+            ->method('fetchOne')
+            ->willReturn($version)
+        ;
+
+        $connection
             ->method('fetchAssociative')
             ->willReturnOnConsecutiveCalls(
                 ['Value' => $largePrefixes],
-                ['Value' => $version],
                 ['Value' => $filePerTable],
                 ['Value' => $fileFormat]
             )
@@ -593,6 +597,11 @@ class DcaSchemaProviderTest extends DoctrineTestCase
         $connection
             ->method('fetchAssociative')
             ->willReturn(['Value' => 'On'])
+        ;
+
+        $connection
+            ->method('fetchOne')
+            ->willReturn('8.0.13')
         ;
 
         $provider = $this->getProvider(

--- a/core-bundle/tests/EventListener/DataContainer/ContentCompositionListenerTest.php
+++ b/core-bundle/tests/EventListener/DataContainer/ContentCompositionListenerTest.php
@@ -26,7 +26,6 @@ use Contao\Image;
 use Contao\LayoutModel;
 use Contao\PageModel;
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\Statement;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -1119,18 +1118,11 @@ class ContentCompositionListenerTest extends TestCase
 
     private function expectArticleCount(int $count): void
     {
-        $statement = $this->createMock(Statement::class);
-        $statement
-            ->expects($this->once())
-            ->method('fetchColumn')
-            ->willReturn($count)
-        ;
-
         $this->connection
             ->expects($this->once())
-            ->method('executeQuery')
+            ->method('fetchOne')
             ->with('SELECT COUNT(*) FROM tl_article WHERE pid=:pid')
-            ->willReturn($statement)
+            ->willReturn($count)
         ;
     }
 }

--- a/core-bundle/tests/Functional/Migration/RoutingMigrationTest.php
+++ b/core-bundle/tests/Functional/Migration/RoutingMigrationTest.php
@@ -32,7 +32,7 @@ class RoutingMigrationTest extends FunctionalTestCase
         $connection = static::$container->get('database_connection');
 
         foreach ($dropFields as $field) {
-            $connection->exec('ALTER TABLE tl_page DROP '.$field);
+            $connection->executeStatement('ALTER TABLE tl_page DROP '.$field);
         }
 
         /** @var ContaoFramework $framework */
@@ -78,7 +78,7 @@ class RoutingMigrationTest extends FunctionalTestCase
 
         /** @var Connection $connection */
         $connection = static::$container->get('database_connection');
-        $connection->exec('ALTER TABLE tl_page DROP urlPrefix, DROP urlSuffix, DROP useFolderUrl');
+        $connection->executeStatement('ALTER TABLE tl_page DROP urlPrefix, DROP urlSuffix, DROP useFolderUrl');
 
         $columns = $connection->getSchemaManager()->listTableColumns('tl_page');
 
@@ -112,7 +112,7 @@ class RoutingMigrationTest extends FunctionalTestCase
 
         /** @var Connection $connection */
         $connection = static::$container->get('database_connection');
-        $connection->exec('ALTER TABLE tl_page DROP urlPrefix, DROP urlSuffix, DROP useFolderUrl');
+        $connection->executeStatement('ALTER TABLE tl_page DROP urlPrefix, DROP urlSuffix, DROP useFolderUrl');
 
         /** @var ContaoFramework $framework */
         $framework = static::$container->get('contao.framework');
@@ -124,7 +124,7 @@ class RoutingMigrationTest extends FunctionalTestCase
         $migration = new RoutingMigration($connection, $framework, $urlSuffix, $prependLocale);
         $migration->run();
 
-        $rows = $connection->fetchAll('SELECT type, language, urlPrefix, urlSuffix, useFolderUrl FROM tl_page');
+        $rows = $connection->fetchAllAssociative('SELECT type, language, urlPrefix, urlSuffix, useFolderUrl FROM tl_page');
 
         foreach ($rows as $row) {
             if ('root' !== $row['type']) {

--- a/core-bundle/tests/Functional/RoutingTest.php
+++ b/core-bundle/tests/Functional/RoutingTest.php
@@ -380,7 +380,7 @@ class RoutingTest extends FunctionalTestCase
         self::$container
             ->get('doctrine')
             ->getConnection()
-            ->exec('UPDATE tl_page SET urlPrefix=language')
+            ->executeStatement('UPDATE tl_page SET urlPrefix=language')
         ;
 
         $crawler = $client->request('GET', "http://$host$request");
@@ -709,7 +709,7 @@ class RoutingTest extends FunctionalTestCase
         self::$container
             ->get('doctrine')
             ->getConnection()
-            ->exec("UPDATE tl_page SET urlSuffix=''")
+            ->executeStatement("UPDATE tl_page SET urlSuffix=''")
         ;
 
         $crawler = $client->request('GET', "http://$host$request");
@@ -1061,7 +1061,7 @@ class RoutingTest extends FunctionalTestCase
         self::$container
             ->get('doctrine')
             ->getConnection()
-            ->exec('UPDATE tl_page SET urlPrefix=language')
+            ->executeStatement('UPDATE tl_page SET urlPrefix=language')
         ;
 
         $crawler = $client->request('GET', "http://$host$request");

--- a/core-bundle/tests/Image/ImageSizesTest.php
+++ b/core-bundle/tests/Image/ImageSizesTest.php
@@ -167,11 +167,11 @@ class ImageSizesTest extends TestCase
 
         $this->connection
             ->expects($this->exactly(2))
-            ->method('fetchAll')
+            ->method('fetchAllAssociative')
             ->willReturn([])
         ;
 
-        // Test that fetchAll() is only called once
+        // Test that fetchAllAssociative() is only called once
         $this->imageSizes->getAllOptions();
         $this->imageSizes->getAllOptions();
 
@@ -198,7 +198,7 @@ class ImageSizesTest extends TestCase
     {
         $this->connection
             ->expects($this->atLeastOnce())
-            ->method('fetchAll')
+            ->method('fetchAllAssociative')
             ->willReturn($imageSizes)
         ;
     }

--- a/core-bundle/tests/Migration/Version409/CeAccessMigrationTest.php
+++ b/core-bundle/tests/Migration/Version409/CeAccessMigrationTest.php
@@ -78,7 +78,7 @@ class CeAccessMigrationTest extends TestCase
 
         $connection
             ->expects($this->once())
-            ->method('query')
+            ->method('executeStatement')
         ;
 
         $connection

--- a/core-bundle/tests/Picker/TablePickerProviderTest.php
+++ b/core-bundle/tests/Picker/TablePickerProviderTest.php
@@ -624,7 +624,7 @@ class TablePickerProviderTest extends ContaoTestCase
         $statement = $this->createMock(Statement::class);
         $statement
             ->expects($this->once())
-            ->method('fetch')
+            ->method('fetchAssociative')
             ->willReturn($data)
         ;
 

--- a/core-bundle/tests/Routing/Candidates/PageCandidatesTest.php
+++ b/core-bundle/tests/Routing/Candidates/PageCandidatesTest.php
@@ -18,13 +18,12 @@ use Contao\CoreBundle\Routing\Candidates\PageCandidates;
 use Contao\CoreBundle\Routing\Page\PageRegistry;
 use Contao\CoreBundle\Tests\TestCase;
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\FetchMode;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Doctrine\DBAL\Statement;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\HttpFoundation\Request;
 
-class CandidatesTest extends TestCase
+class PageCandidatesTest extends TestCase
 {
     /**
      * @dataProvider getCandidatesProvider
@@ -512,8 +511,7 @@ class CandidatesTest extends TestCase
     {
         $statement = $this->createMock(Statement::class);
         $statement
-            ->method('fetchAll')
-            ->with(FetchMode::COLUMN)
+            ->method('fetchFirstColumn')
             ->willReturn([15])
         ;
 

--- a/core-bundle/tests/Routing/Page/PageRegistryTest.php
+++ b/core-bundle/tests/Routing/Page/PageRegistryTest.php
@@ -20,7 +20,6 @@ use Contao\CoreBundle\Routing\Page\RouteConfig;
 use Contao\CoreBundle\Tests\TestCase;
 use Contao\PageModel;
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\Statement;
 use PHPUnit\Framework\MockObject\MockObject;
 
 class PageRegistryTest extends TestCase
@@ -363,19 +362,12 @@ class PageRegistryTest extends TestCase
 
     private function mockConnectionWithPrefixAndSuffix(string $urlPrefix = '', string $urlSuffix = '.html'): Connection
     {
-        $statement = $this->createMock(Statement::class);
-        $statement
-            ->expects($this->once())
-            ->method('fetchAll')
-            ->willReturn([compact('urlPrefix', 'urlSuffix')])
-        ;
-
         $connection = $this->createMock(Connection::class);
         $connection
             ->expects($this->once())
-            ->method('query')
+            ->method('fetchAllAssociative')
             ->with("SELECT urlPrefix, urlSuffix FROM tl_page WHERE type='root'")
-            ->willReturn($statement)
+            ->willReturn([compact('urlPrefix', 'urlSuffix')])
         ;
 
         return $connection;

--- a/core-bundle/tests/Search/Indexer/DefaultIndexerTest.php
+++ b/core-bundle/tests/Search/Indexer/DefaultIndexerTest.php
@@ -17,7 +17,7 @@ use Contao\CoreBundle\Search\Indexer\DefaultIndexer;
 use Contao\CoreBundle\Search\Indexer\IndexerException;
 use Contao\Search;
 use Contao\TestCase\ContaoTestCase;
-use Doctrine\DBAL\Driver\Connection;
+use Doctrine\DBAL\Connection;
 use Nyholm\Psr7\Uri;
 
 class DefaultIndexerTest extends ContaoTestCase
@@ -182,7 +182,7 @@ class DefaultIndexerTest extends ContaoTestCase
         $connection = $this->createMock(Connection::class);
         $connection
             ->expects($this->exactly(3))
-            ->method('exec')
+            ->method('executeStatement')
             ->withConsecutive(
                 ['TRUNCATE TABLE tl_search'],
                 ['TRUNCATE TABLE tl_search_index'],

--- a/faq-bundle/composer.json
+++ b/faq-bundle/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.3",
         "contao/core-bundle": "self.version",
         "patchwork/utf8": "^1.2",
         "symfony/config": "4.4.*",

--- a/installation-bundle/composer.json
+++ b/installation-bundle/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.3",
         "contao/core-bundle": "self.version",
         "doctrine/dbal": "^2.11",
         "patchwork/utf8": "^1.2",

--- a/installation-bundle/composer.json
+++ b/installation-bundle/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": "^7.2",
         "contao/core-bundle": "self.version",
-        "doctrine/dbal": "^2.10",
+        "doctrine/dbal": "^2.11",
         "patchwork/utf8": "^1.2",
         "psr/log": "^1.0",
         "symfony/config": "4.4.*",

--- a/installation-bundle/src/Database/Installer.php
+++ b/installation-bundle/src/Database/Installer.php
@@ -96,7 +96,7 @@ class Installer
 
         foreach ($this->commands as $commands) {
             if (isset($commands[$hash])) {
-                $this->connection->query($commands[$hash]);
+                $this->connection->executeStatement($commands[$hash]);
 
                 return;
             }
@@ -237,13 +237,10 @@ class Installer
 
             $this->setLegacyOptions($table);
 
-            $tableOptions = $this->connection
-                ->executeQuery(
-                    'SHOW TABLE STATUS WHERE Name = ? AND Engine IS NOT NULL AND Create_options IS NOT NULL AND Collation IS NOT NULL',
-                    [$tableName]
-                )
-                ->fetch(\PDO::FETCH_OBJ)
-            ;
+            $tableOptions = $this->connection->fetchAssociative(
+                'SHOW TABLE STATUS WHERE Name = ? AND Engine IS NOT NULL AND Create_options IS NOT NULL AND Collation IS NOT NULL',
+                [$tableName]
+            );
 
             if (false === $tableOptions) {
                 continue;
@@ -252,11 +249,11 @@ class Installer
             $engine = $table->getOption('engine');
             $innodb = 'innodb' === strtolower($engine);
 
-            if (strtolower($tableOptions->Engine) !== strtolower($engine)) {
+            if (strtolower($tableOptions['Engine']) !== strtolower($engine)) {
                 if ($innodb && $dynamic) {
                     $command = 'ALTER TABLE '.$tableName.' ENGINE = '.$engine.' ROW_FORMAT = DYNAMIC';
 
-                    if (false !== stripos($tableOptions->Create_options, 'key_block_size=')) {
+                    if (false !== stripos($tableOptions['Create_options'], 'key_block_size=')) {
                         $command .= ' KEY_BLOCK_SIZE = 0';
                     }
                 } else {
@@ -266,10 +263,10 @@ class Installer
                 $deleteIndexes = true;
                 $alterTables[md5($command)] = $command;
             } elseif ($innodb && $dynamic) {
-                if (false === stripos($tableOptions->Create_options, 'row_format=dynamic')) {
+                if (false === stripos($tableOptions['Create_options'], 'row_format=dynamic')) {
                     $command = 'ALTER TABLE '.$tableName.' ENGINE = '.$engine.' ROW_FORMAT = DYNAMIC';
 
-                    if (false !== stripos($tableOptions->Create_options, 'key_block_size=')) {
+                    if (false !== stripos($tableOptions['Create_options'], 'key_block_size=')) {
                         $command .= ' KEY_BLOCK_SIZE = 0';
                     }
 
@@ -279,7 +276,7 @@ class Installer
 
             $collate = $table->getOption('collate');
 
-            if ($tableOptions->Collation !== $collate) {
+            if ($tableOptions['Collation'] !== $collate) {
                 $charset = $table->getOption('charset');
                 $command = 'ALTER TABLE '.$tableName.' CONVERT TO CHARACTER SET '.$charset.' COLLATE '.$collate;
                 $deleteIndexes = true;
@@ -322,28 +319,22 @@ class Installer
 
     private function hasDynamicRowFormat(): bool
     {
-        $filePerTable = $this->connection
-            ->query("SHOW VARIABLES LIKE 'innodb_file_per_table'")
-            ->fetch(\PDO::FETCH_OBJ)
-        ;
+        $filePerTable = $this->connection->fetchAssociative("SHOW VARIABLES LIKE 'innodb_file_per_table'");
 
         // Dynamic rows require innodb_file_per_table to be enabled
-        if (!\in_array(strtolower((string) $filePerTable->Value), ['1', 'on'], true)) {
+        if (!\in_array(strtolower((string) $filePerTable['Value']), ['1', 'on'], true)) {
             return false;
         }
 
-        $fileFormat = $this->connection
-            ->query("SHOW VARIABLES LIKE 'innodb_file_format'")
-            ->fetch(\PDO::FETCH_OBJ)
-        ;
+        $fileFormat = $this->connection->fetchAssociative("SHOW VARIABLES LIKE 'innodb_file_format'");
 
         // MySQL 8 and MariaDB 10.3 no longer have the "innodb_file_format" setting
-        if (false === $fileFormat || '' === $fileFormat->Value) {
+        if (false === $fileFormat || '' === $fileFormat['Value']) {
             return true;
         }
 
         // Dynamic rows require the Barracuda file format in MySQL <8 and MariaDB <10.3
-        return 'barracuda' === strtolower((string) $fileFormat->Value);
+        return 'barracuda' === strtolower((string) $fileFormat['Value']);
     }
 
     /**

--- a/installation-bundle/src/Database/Version330Update.php
+++ b/installation-bundle/src/Database/Version330Update.php
@@ -53,7 +53,7 @@ class Version330Update extends AbstractMigration
 
     public function run(): MigrationResult
     {
-        $statement = $this->connection->query("
+        $layouts = $this->connection->fetchAllAssociative("
             SELECT
                 id, framework
             FROM
@@ -62,9 +62,9 @@ class Version330Update extends AbstractMigration
                 framework != ''
         ");
 
-        while (false !== ($layout = $statement->fetch(\PDO::FETCH_OBJ))) {
+        foreach ($layouts as $layout) {
             $framework = '';
-            $tmp = StringUtil::deserialize($layout->framework);
+            $tmp = StringUtil::deserialize($layout['framework']);
 
             if (!empty($tmp) && \is_array($tmp)) {
                 if (false !== ($key = array_search('layout.css', $tmp, true))) {
@@ -83,11 +83,11 @@ class Version330Update extends AbstractMigration
                     id = :id
             ');
 
-            $stmt->execute([':framework' => $framework, ':id' => $layout->id]);
+            $stmt->execute([':framework' => $framework, ':id' => $layout['id']]);
         }
 
         // Add the "viewport" field (triggers the version 3.3 update)
-        $this->connection->query("
+        $this->connection->executeStatement("
             ALTER TABLE
                 tl_layout
             ADD

--- a/installation-bundle/src/Database/Version350Update.php
+++ b/installation-bundle/src/Database/Version350Update.php
@@ -51,14 +51,14 @@ class Version350Update extends AbstractMigration
 
     public function run(): MigrationResult
     {
-        $this->connection->query('
+        $this->connection->executeStatement('
             ALTER TABLE
                 tl_member
             CHANGE
                 username username varchar(64) COLLATE utf8_bin NULL
         ');
 
-        $this->connection->query("
+        $this->connection->executeStatement("
             UPDATE
                 tl_member
             SET
@@ -67,7 +67,7 @@ class Version350Update extends AbstractMigration
                 username = ''
         ");
 
-        $this->connection->query('
+        $this->connection->executeStatement('
             ALTER TABLE
                 tl_member
             DROP INDEX

--- a/installation-bundle/src/Database/Version400Update.php
+++ b/installation-bundle/src/Database/Version400Update.php
@@ -52,7 +52,7 @@ class Version400Update extends AbstractMigration
 
     public function run(): MigrationResult
     {
-        $this->connection->query('
+        $this->connection->executeStatement('
             ALTER TABLE
                 tl_layout
             ADD
@@ -60,7 +60,7 @@ class Version400Update extends AbstractMigration
         ');
 
         // Adjust the framework agnostic scripts
-        $statement = $this->connection->query("
+        $layouts = $this->connection->fetchAllAssociative("
             SELECT
                 id, addJQuery, jquery, addMooTools, mootools
             FROM
@@ -69,12 +69,12 @@ class Version400Update extends AbstractMigration
                 framework != ''
         ");
 
-        while (false !== ($layout = $statement->fetch(\PDO::FETCH_OBJ))) {
+        foreach ($layouts as $layout) {
             $scripts = [];
 
             // Check if j_slider is enabled
-            if ($layout->addJQuery) {
-                $jquery = StringUtil::deserialize($layout->jquery);
+            if ($layout['addJQuery']) {
+                $jquery = StringUtil::deserialize($layout['jquery']);
 
                 if (!empty($jquery) && \is_array($jquery)) {
                     $key = array_search('j_slider', $jquery, true);
@@ -92,14 +92,14 @@ class Version400Update extends AbstractMigration
                                 id = :id
                         ');
 
-                        $stmt->execute([':jquery' => serialize(array_values($jquery)), ':id' => $layout->id]);
+                        $stmt->execute([':jquery' => serialize(array_values($jquery)), ':id' => $layout['id']]);
                     }
                 }
             }
 
             // Check if moo_slider is enabled
-            if ($layout->addMooTools) {
-                $mootools = StringUtil::deserialize($layout->mootools);
+            if ($layout['addMooTools']) {
+                $mootools = StringUtil::deserialize($layout['mootools']);
 
                 if (!empty($mootools) && \is_array($mootools)) {
                     $key = array_search('moo_slider', $mootools, true);
@@ -117,7 +117,7 @@ class Version400Update extends AbstractMigration
                                 id = :id
                         ');
 
-                        $stmt->execute([':mootools' => serialize(array_values($mootools)), ':id' => $layout->id]);
+                        $stmt->execute([':mootools' => serialize(array_values($mootools)), ':id' => $layout['id']]);
                     }
                 }
             }
@@ -133,12 +133,12 @@ class Version400Update extends AbstractMigration
                         id = :id
                 ');
 
-                $stmt->execute([':scripts' => serialize(array_values($scripts)), ':id' => $layout->id]);
+                $stmt->execute([':scripts' => serialize(array_values($scripts)), ':id' => $layout['id']]);
             }
         }
 
         // Replace moo_slimbox with moo_mediabox
-        $statement = $this->connection->query("
+        $layouts = $this->connection->fetchAllAssociative("
             SELECT
                 id, mootools
             FROM
@@ -147,8 +147,8 @@ class Version400Update extends AbstractMigration
                 framework != ''
         ");
 
-        while (false !== ($layout = $statement->fetch(\PDO::FETCH_OBJ))) {
-            $mootools = StringUtil::deserialize($layout->mootools);
+        foreach ($layouts as $layout) {
+            $mootools = StringUtil::deserialize($layout['mootools']);
 
             if (!empty($mootools) && \is_array($mootools)) {
                 $key = array_search('moo_slimbox', $mootools, true);
@@ -166,13 +166,13 @@ class Version400Update extends AbstractMigration
                             id = :id
                     ');
 
-                    $stmt->execute([':mootools' => serialize(array_values($mootools)), ':id' => $layout->id]);
+                    $stmt->execute([':mootools' => serialize(array_values($mootools)), ':id' => $layout['id']]);
                 }
             }
         }
 
         // Adjust the list of framework style sheets
-        $statement = $this->connection->query("
+        $layouts = $this->connection->fetchAllAssociative("
             SELECT
                 id, framework
             FROM
@@ -181,8 +181,8 @@ class Version400Update extends AbstractMigration
                 framework != ''
         ");
 
-        while (false !== ($layout = $statement->fetch(\PDO::FETCH_OBJ))) {
-            $framework = StringUtil::deserialize($layout->framework);
+        foreach ($layouts as $layout) {
+            $framework = StringUtil::deserialize($layout['framework']);
 
             if (!empty($framework) && \is_array($framework)) {
                 $key = array_search('tinymce.css', $framework, true);
@@ -199,13 +199,13 @@ class Version400Update extends AbstractMigration
                             id = :id
                     ');
 
-                    $stmt->execute([':framework' => serialize(array_values($framework)), ':id' => $layout->id]);
+                    $stmt->execute([':framework' => serialize(array_values($framework)), ':id' => $layout['id']]);
                 }
             }
         }
 
         // Adjust the module types
-        $this->connection->query("
+        $this->connection->executeStatement("
             UPDATE
                 tl_module
             SET
@@ -214,7 +214,7 @@ class Version400Update extends AbstractMigration
                 type = 'articleList'
         ");
 
-        $this->connection->query("
+        $this->connection->executeStatement("
             UPDATE
                 tl_module
             SET
@@ -223,7 +223,7 @@ class Version400Update extends AbstractMigration
                 type = 'rss_reader'
         ");
 
-        $this->connection->query("
+        $this->connection->executeStatement("
             UPDATE
                 tl_form_field
             SET

--- a/installation-bundle/src/Database/Version410Update.php
+++ b/installation-bundle/src/Database/Version410Update.php
@@ -67,7 +67,7 @@ class Version410Update extends AbstractMigration
             $options = array_merge(...$options);
         }
 
-        $rows = $this->connection->fetchAll('
+        $rows = $this->connection->fetchAllAssociative('
             SELECT
                 id
             FROM
@@ -79,14 +79,14 @@ class Version410Update extends AbstractMigration
         }
 
         // Add the database fields
-        $this->connection->query('
+        $this->connection->executeStatement('
             ALTER TABLE
                 tl_user
             ADD
                 imageSizes blob NULL
         ');
 
-        $this->connection->query('
+        $this->connection->executeStatement('
             ALTER TABLE
                 tl_user_group
             ADD

--- a/installation-bundle/src/Database/Version440Update.php
+++ b/installation-bundle/src/Database/Version440Update.php
@@ -53,15 +53,15 @@ class Version440Update extends AbstractMigration
     public function run(): MigrationResult
     {
         // Add the js_autofocus.html5 template
-        $statement = $this->connection->query('
+        $layouts = $this->connection->fetchAllAssociative('
             SELECT
                 id, scripts
             FROM
                 tl_layout
         ');
 
-        while (false !== ($layout = $statement->fetch(\PDO::FETCH_OBJ))) {
-            $scripts = StringUtil::deserialize($layout->scripts);
+        foreach ($layouts as $layout) {
+            $scripts = StringUtil::deserialize($layout['scripts']);
 
             if (!empty($scripts) && \is_array($scripts)) {
                 $scripts[] = 'js_autofocus';
@@ -75,7 +75,7 @@ class Version440Update extends AbstractMigration
                         id = :id
                 ');
 
-                $stmt->execute([':scripts' => serialize(array_values(array_unique($scripts))), ':id' => $layout->id]);
+                $stmt->execute([':scripts' => serialize(array_values(array_unique($scripts))), ':id' => $layout['id']]);
             }
         }
 
@@ -93,21 +93,21 @@ class Version440Update extends AbstractMigration
             $this->enableOverwriteMeta('tl_news');
         }
 
-        $this->connection->query("
+        $this->connection->executeStatement("
             ALTER TABLE
                 tl_content
             CHANGE
                 title imageTitle varchar(255) NOT NULL DEFAULT ''
         ");
 
-        $this->connection->query("
+        $this->connection->executeStatement("
             ALTER TABLE
                 tl_content
             ADD
                 overwriteMeta CHAR(1) DEFAULT '' NOT NULL
         ");
 
-        $this->connection->query("
+        $this->connection->executeStatement("
             UPDATE
                 tl_content
             SET
@@ -121,14 +121,14 @@ class Version440Update extends AbstractMigration
 
     private function enableOverwriteMeta(string $table): void
     {
-        $this->connection->query("
+        $this->connection->executeStatement("
             ALTER TABLE
                 $table
             ADD
                 overwriteMeta CHAR(1) DEFAULT '' NOT NULL
         ");
 
-        $this->connection->query("
+        $this->connection->executeStatement("
             UPDATE
                 $table
             SET

--- a/installation-bundle/src/Database/Version450Update.php
+++ b/installation-bundle/src/Database/Version450Update.php
@@ -51,28 +51,28 @@ class Version450Update extends AbstractMigration
 
     public function run(): MigrationResult
     {
-        $this->connection->query('
+        $this->connection->executeStatement('
             ALTER TABLE
                 tl_content
             ADD
                 youtubeOptions text NULL
         ');
 
-        $this->connection->query('
+        $this->connection->executeStatement('
             ALTER TABLE
                 tl_content
             ADD
                 youtubeStart int(10) unsigned NOT NULL default 0
         ');
 
-        $this->connection->query('
+        $this->connection->executeStatement('
             ALTER TABLE
                 tl_content
             ADD
                 youtubeStop int(10) unsigned NOT NULL default 0
         ');
 
-        $this->connection->query("
+        $this->connection->executeStatement("
             UPDATE
                 tl_form_field
             SET
@@ -81,7 +81,7 @@ class Version450Update extends AbstractMigration
                 type = 'fieldset' AND fsType = 'fsStart'
         ");
 
-        $this->connection->query("
+        $this->connection->executeStatement("
             UPDATE
                 tl_form_field
             SET
@@ -96,7 +96,7 @@ class Version450Update extends AbstractMigration
         ;
 
         if (isset($columns['news_order'])) {
-            $this->connection->query("
+            $this->connection->executeStatement("
                 UPDATE
                     tl_module
                 SET
@@ -105,7 +105,7 @@ class Version450Update extends AbstractMigration
                     news_order = 'ascending'
             ");
 
-            $this->connection->query("
+            $this->connection->executeStatement("
                 UPDATE
                     tl_module
                 SET
@@ -115,7 +115,7 @@ class Version450Update extends AbstractMigration
             ");
         }
 
-        $this->connection->query('
+        $this->connection->executeStatement('
             ALTER TABLE
                 tl_layout
             ADD

--- a/installation-bundle/src/Database/Version470Update.php
+++ b/installation-bundle/src/Database/Version470Update.php
@@ -71,7 +71,7 @@ class Version470Update extends AbstractMigration
 
     public function run(): MigrationResult
     {
-        $this->connection->query("
+        $this->connection->executeStatement("
             ALTER TABLE
                 tl_layout
             ADD
@@ -80,7 +80,7 @@ class Version470Update extends AbstractMigration
 
         // Enable the "minifyMarkup" option if it was enabled before
         if (isset($GLOBALS['TL_CONFIG']['minifyMarkup']) && $GLOBALS['TL_CONFIG']['minifyMarkup']) {
-            $this->connection->query("
+            $this->connection->executeStatement("
                 UPDATE
                     tl_layout
                 SET
@@ -102,14 +102,14 @@ class Version470Update extends AbstractMigration
         $schemaManager = $this->connection->getSchemaManager();
 
         if ($schemaManager->tablesExist(['tl_comments_notify'])) {
-            $this->connection->query("
+            $this->connection->executeStatement("
                 ALTER TABLE
                     tl_comments_notify
                 ADD
                     active CHAR(1) DEFAULT '' NOT NULL
             ");
 
-            $this->connection->query("
+            $this->connection->executeStatement("
                 UPDATE
                     tl_comments_notify
                 SET

--- a/installation-bundle/src/InstallTool.php
+++ b/installation-bundle/src/InstallTool.php
@@ -109,7 +109,7 @@ class InstallTool
         // Return if there is a working database connection already
         try {
             $this->connection->connect();
-            $this->connection->query('SHOW TABLES');
+            $this->connection->executeQuery('SHOW TABLES');
 
             return true;
         } catch (\Exception $e) {
@@ -130,7 +130,7 @@ class InstallTool
         $quotedName = $this->connection->quoteIdentifier($name);
 
         try {
-            $this->connection->query('use '.$quotedName);
+            $this->connection->executeStatement('USE '.$quotedName);
         } catch (DBALException $e) {
             $this->logException($e);
 
@@ -151,14 +151,7 @@ class InstallTool
             return true;
         }
 
-        $statement = $this->connection->query('
-            SELECT
-                COUNT(*) AS count
-            FROM
-                tl_page
-        ');
-
-        return $statement->fetch(\PDO::FETCH_OBJ)->count < 1;
+        return $this->connection->fetchOne('SELECT COUNT(*) AS count FROM tl_page') < 1;
     }
 
     /**
@@ -175,7 +168,7 @@ class InstallTool
             ->getListTableColumnsSQL('tl_layout', $this->connection->getDatabase())
         ;
 
-        $columns = $this->connection->fetchAll($sql);
+        $columns = $this->connection->fetchAllAssociative($sql);
 
         foreach ($columns as $column) {
             if ('sections' === $column['Field']) {
@@ -191,12 +184,9 @@ class InstallTool
      */
     public function hasConfigurationError(array &$context): bool
     {
-        $row = $this->connection
-            ->query('SELECT @@version as Version')
-            ->fetch(\PDO::FETCH_OBJ)
-        ;
+        $row = $this->connection->fetchAssociative('SELECT @@version as Version');
 
-        [$version] = explode('-', $row->Version);
+        [$version] = explode('-', $row['Version']);
 
         // The database version is too old
         if (version_compare($version, '5.1.0', '<')) {
@@ -210,10 +200,10 @@ class InstallTool
 
         // Check the collation if the user has configured it
         if (isset($options['collate'])) {
-            $statement = $this->connection->query("SHOW COLLATION LIKE '".$options['collate']."'");
+            $row = $this->connection->fetchAssociative("SHOW COLLATION LIKE '".$options['collate']."'");
 
             // The configured collation is not installed
-            if (false === ($row = $statement->fetch(\PDO::FETCH_OBJ))) {
+            if (false === $row) {
                 $context['errorCode'] = 2;
                 $context['collation'] = $options['collate'];
 
@@ -224,10 +214,10 @@ class InstallTool
         // Check the engine if the user has configured it
         if (isset($options['engine'])) {
             $engineFound = false;
-            $statement = $this->connection->query('SHOW ENGINES');
+            $rows = $this->connection->fetchAllAssociative('SHOW ENGINES');
 
-            while (false !== ($row = $statement->fetch(\PDO::FETCH_OBJ))) {
-                if ($options['engine'] === $row->Engine) {
+            foreach ($rows as $row) {
+                if ($options['engine'] === $row['Engine']) {
                     $engineFound = true;
                     break;
                 }
@@ -251,13 +241,10 @@ class InstallTool
                 return true;
             }
 
-            $row = $this->connection
-                ->query("SHOW VARIABLES LIKE 'innodb_large_prefix'")
-                ->fetch(\PDO::FETCH_OBJ)
-            ;
+            $row = $this->connection->fetchAssociative("SHOW VARIABLES LIKE 'innodb_large_prefix'");
 
             // The variable no longer exists as of MySQL 8 and MariaDB 10.3
-            if (false === $row || '' === $row->Value) {
+            if (false === $row || '' === $row['Value']) {
                 return false;
             }
 
@@ -272,31 +259,25 @@ class InstallTool
             }
 
             // The innodb_large_prefix option is disabled
-            if (!\in_array(strtolower((string) $row->Value), ['1', 'on'], true)) {
+            if (!\in_array(strtolower((string) $row['Value']), ['1', 'on'], true)) {
                 $context['errorCode'] = 5;
 
                 return true;
             }
 
-            $row = $this->connection
-                ->query("SHOW VARIABLES LIKE 'innodb_file_per_table'")
-                ->fetch(\PDO::FETCH_OBJ)
-            ;
+            $row = $this->connection->fetchAssociative("SHOW VARIABLES LIKE 'innodb_file_per_table'");
 
             // The innodb_file_per_table option is disabled
-            if (!\in_array(strtolower((string) $row->Value), ['1', 'on'], true)) {
+            if (!\in_array(strtolower((string) $row['Value']), ['1', 'on'], true)) {
                 $context['errorCode'] = 6;
 
                 return true;
             }
 
-            $row = $this->connection
-                ->query("SHOW VARIABLES LIKE 'innodb_file_format'")
-                ->fetch(\PDO::FETCH_OBJ)
-            ;
+            $row = $this->connection->fetchAssociative("SHOW VARIABLES LIKE 'innodb_file_format'");
 
             // The InnoDB file format is not Barracuda
-            if ('' !== $row->Value && 'barracuda' !== strtolower((string) $row->Value)) {
+            if ('' !== $row['Value'] && 'barracuda' !== strtolower((string) $row['Value'])) {
                 $context['errorCode'] = 6;
 
                 return true;
@@ -346,7 +327,7 @@ class InstallTool
 
             foreach ($tables as $table) {
                 if (0 === strncmp($table, 'tl_', 3)) {
-                    $this->connection->query('TRUNCATE TABLE '.$this->connection->quoteIdentifier($table));
+                    $this->connection->executeStatement('TRUNCATE TABLE '.$this->connection->quoteIdentifier($table));
                 }
             }
         }
@@ -354,14 +335,14 @@ class InstallTool
         $data = file(Path::join($this->projectDir, 'templates', $template));
 
         foreach (preg_grep('/^INSERT /', $data) as $query) {
-            $this->connection->query($query);
+            $this->connection->executeStatement($query);
         }
     }
 
     public function hasAdminUser(): bool
     {
         try {
-            $statement = $this->connection->query("
+            $count = $this->connection->fetchOne("
                 SELECT
                     COUNT(*) AS count
                 FROM
@@ -370,7 +351,7 @@ class InstallTool
                     `admin` = '1'
             ");
 
-            if ($statement->fetch(\PDO::FETCH_OBJ)->count > 0) {
+            if ($count > 0) {
                 return true;
             }
         } catch (DBALException $e) {

--- a/installation-bundle/src/InstallTool.php
+++ b/installation-bundle/src/InstallTool.php
@@ -151,7 +151,7 @@ class InstallTool
             return true;
         }
 
-        return $this->connection->fetchOne('SELECT COUNT(*) AS count FROM tl_page') < 1;
+        return $this->connection->fetchOne('SELECT COUNT(*) FROM tl_page') < 1;
     }
 
     /**
@@ -184,9 +184,7 @@ class InstallTool
      */
     public function hasConfigurationError(array &$context): bool
     {
-        $row = $this->connection->fetchAssociative('SELECT @@version as Version');
-
-        [$version] = explode('-', $row['Version']);
+        [$version] = explode('-', $this->connection->fetchOne('SELECT @@version'));
 
         // The database version is too old
         if (version_compare($version, '5.1.0', '<')) {
@@ -342,16 +340,7 @@ class InstallTool
     public function hasAdminUser(): bool
     {
         try {
-            $count = $this->connection->fetchOne("
-                SELECT
-                    COUNT(*) AS count
-                FROM
-                    tl_user
-                WHERE
-                    `admin` = '1'
-            ");
-
-            if ($count > 0) {
+            if ($this->connection->fetchOne("SELECT COUNT(*) FROM tl_user WHERE `admin` = '1'") > 0) {
                 return true;
             }
         } catch (DBALException $e) {

--- a/listing-bundle/composer.json
+++ b/listing-bundle/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.3",
         "contao/core-bundle": "self.version",
         "patchwork/utf8": "^1.2",
         "symfony/http-kernel": "4.4.*"

--- a/manager-bundle/composer.json
+++ b/manager-bundle/composer.json
@@ -21,7 +21,7 @@
         "contao/installation-bundle": "self.version",
         "contao/maintenance-bundle-deprecated": "^2.1.5",
         "contao/manager-plugin": "^2.4",
-        "doctrine/dbal": "^2.10",
+        "doctrine/dbal": "^2.11",
         "doctrine/doctrine-bundle": "^1.8 || ^2.0",
         "doctrine/persistence": "^1.3",
         "friendsofsymfony/http-cache": "^2.6",

--- a/manager-bundle/composer.json
+++ b/manager-bundle/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.3",
         "ext-json": "*",
         "contao/core-bundle": "self.version",
         "contao/installation-bundle": "self.version",

--- a/manager-bundle/src/ContaoManager/Plugin.php
+++ b/manager-bundle/src/ContaoManager/Plugin.php
@@ -311,7 +311,7 @@ class Plugin implements BundlePluginInterface, ConfigPluginInterface, RoutingPlu
         try {
             $connection = \call_user_func($this->dbalConnectionFactory, $params);
             $connection->connect();
-            $connection->query('SHOW TABLES');
+            $connection->executeQuery('SHOW TABLES');
             $connection->close();
         } catch (DriverException $e) {
             $extensionConfigs[] = [

--- a/manager-bundle/tests/EventListener/DoctrineAlterTableListenerTest.php
+++ b/manager-bundle/tests/EventListener/DoctrineAlterTableListenerTest.php
@@ -19,6 +19,7 @@ use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
 use PHPUnit\Framework\TestCase;
 
 class DoctrineAlterTableListenerTest extends TestCase
@@ -26,9 +27,9 @@ class DoctrineAlterTableListenerTest extends TestCase
     public function testConvertsRenameToDropAndAdd(): void
     {
         $table = new Table('tl_member');
-        $table->addColumn('bar', Type::INTEGER);
+        $table->addColumn('bar', Types::INTEGER);
 
-        $column = new Column('foo', Type::getType(Type::INTEGER));
+        $column = new Column('foo', Type::getType(Types::INTEGER));
 
         $tableDiff = new TableDiff('tl_member');
         $tableDiff->renamedColumns['bar'] = $column;

--- a/monorepo.yml
+++ b/monorepo.yml
@@ -5,6 +5,7 @@ composer:
     require:
         contao/manager-plugin: ^2.6.2
     conflict:
+        doctrine/annotations: <1.7
         doctrine/persistence: 1.3.2
         nikic/php-parser: 4.7.0
         zendframework/zend-code: <3.3.1

--- a/news-bundle/composer.json
+++ b/news-bundle/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.3",
         "contao/core-bundle": "self.version",
         "friendsofsymfony/http-cache": "^2.4",
         "patchwork/utf8": "^1.2",

--- a/newsletter-bundle/composer.json
+++ b/newsletter-bundle/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.3",
         "contao/core-bundle": "self.version",
         "patchwork/utf8": "^1.2",
         "symfony/deprecation-contracts": "^2.1",


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | -
| Docs PR or issue | #580

This PR raises the minimum doctrine/dbal version to 2.11 and uses the new, forward compatible API.

```php
// OLD
$stmt = $connection->executeQuery($query);
$result = $stmt->fetch(\PDO::FETCH_ASSOC);

// NEW
$result = $connection->fetchAssociative($query);
```