### PR TITLE
Correctly show the xlabel in the checkbox wizard

### DIFF
--- a/core-bundle/src/Resources/contao/widgets/CheckBox.php
+++ b/core-bundle/src/Resources/contao/widgets/CheckBox.php
@@ -227,7 +227,7 @@ class CheckBox extends Widget
 			($this->mandatory && !$this->multiple ? '<span class="invisible">' . $GLOBALS['TL_LANG']['MSC']['mandatory'] . ' </span>' : ''),
 			$arrOption['label'],
 			($this->mandatory && !$this->multiple ? '<span class="mandatory">*</span>' : ''),
-			$this->xlabel
+			!$this->multiple ? $this->xlabel : ''
 		);
 	}
 }


### PR DESCRIPTION
This is a follow-up PR to #2145 which only applies the xlabel if the checkbox is a single checkbox.

### Before

<img width="552" alt="" src="https://user-images.githubusercontent.com/1192057/95849916-50dae680-0d50-11eb-9b2b-6b7b0efd69d6.png">

### After

<img width="549" alt="" src="https://user-images.githubusercontent.com/1192057/95849940-56d0c780-0d50-11eb-83fc-4d743a035825.png">
