### PR TITLE
Remove hard dependency on PDO (4.4)

### DIFF
--- a/manager-bundle/src/ContaoManager/Plugin.php
+++ b/manager-bundle/src/ContaoManager/Plugin.php
@@ -151,9 +151,9 @@ class Plugin implements BundlePluginInterface, ConfigPluginInterface, RoutingPlu
             return $extensionConfigs;
         }
 
-        $extensionConfigs = $this->setDatabaseServerVersion($extensionConfigs, $container);
+        $extensionConfigs = $this->addDefaultServerVersion($extensionConfigs, $container);
 
-        return $this->setPdoDriverOptions($extensionConfigs, $container);
+        return $this->addDefaultPdoDriverOptions($extensionConfigs, $container);
     }
 
     /**
@@ -171,7 +171,7 @@ class Plugin implements BundlePluginInterface, ConfigPluginInterface, RoutingPlu
      *
      * @return array
      */
-    private function setDatabaseServerVersion(array $extensionConfigs, PluginContainerBuilder $container)
+    private function addDefaultServerVersion(array $extensionConfigs, PluginContainerBuilder $container)
     {
         $params = [];
 
@@ -214,7 +214,7 @@ class Plugin implements BundlePluginInterface, ConfigPluginInterface, RoutingPlu
      *
      * @return array
      */
-    private function setPdoDriverOptions(array $extensionConfigs, PluginContainerBuilder $container)
+    private function addDefaultPdoDriverOptions(array $extensionConfigs, PluginContainerBuilder $container)
     {
         // Do not add PDO options, if constant does not exist
         if (!\defined('PDO::MYSQL_ATTR_MULTI_STATEMENTS')) {

--- a/manager-bundle/src/ContaoManager/Plugin.php
+++ b/manager-bundle/src/ContaoManager/Plugin.php
@@ -19,7 +19,6 @@ use Contao\ManagerPlugin\Dependency\DependentPluginInterface;
 use Contao\ManagerPlugin\Routing\RoutingPluginInterface;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Exception\DriverException;
-use PDO;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\Config\Loader\LoaderResolverInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -210,24 +209,24 @@ class Plugin implements BundlePluginInterface, ConfigPluginInterface, RoutingPlu
     }
 
     /**
-     * Sets the PDO driver options, if applicable (#2459).
+     * Sets the PDO driver options if applicable (see #2459).
      *
      * @return array
      */
     private function addDefaultPdoDriverOptions(array $extensionConfigs)
     {
-        // Do not add PDO options, if constant does not exist
+        // Do not add PDO options if the constant does not exist
         if (!\defined('PDO::MYSQL_ATTR_MULTI_STATEMENTS')) {
             return $extensionConfigs;
         }
 
         foreach ($extensionConfigs as $extensionConfig) {
-            // Do not add PDO options, if selected driver is not pdo_mysql
+            // Do not add PDO options if the selected driver is not pdo_mysql
             if (isset($extensionConfig['dbal']['connections']['default']['driver']) && 'pdo_mysql' !== $extensionConfig['dbal']['connections']['default']['driver']) {
                 return $extensionConfigs;
             }
 
-            // Do not add PDO options, if custom options have been defined
+            // Do not add PDO options if custom options have been defined
             if (isset($extensionConfig['dbal']['connections']['default']) && \array_key_exists('options', $extensionConfig['dbal']['connections']['default'])) {
                 return $extensionConfigs;
             }
@@ -238,7 +237,7 @@ class Plugin implements BundlePluginInterface, ConfigPluginInterface, RoutingPlu
                 'connections' => [
                     'default' => [
                         'options' => [
-                            PDO::MYSQL_ATTR_MULTI_STATEMENTS => false,
+                            \PDO::MYSQL_ATTR_MULTI_STATEMENTS => false,
                         ],
                     ],
                 ],

--- a/manager-bundle/src/ContaoManager/Plugin.php
+++ b/manager-bundle/src/ContaoManager/Plugin.php
@@ -153,7 +153,7 @@ class Plugin implements BundlePluginInterface, ConfigPluginInterface, RoutingPlu
 
         $extensionConfigs = $this->addDefaultServerVersion($extensionConfigs, $container);
 
-        return $this->addDefaultPdoDriverOptions($extensionConfigs, $container);
+        return $this->addDefaultPdoDriverOptions($extensionConfigs);
     }
 
     /**
@@ -214,7 +214,7 @@ class Plugin implements BundlePluginInterface, ConfigPluginInterface, RoutingPlu
      *
      * @return array
      */
-    private function addDefaultPdoDriverOptions(array $extensionConfigs, PluginContainerBuilder $container)
+    private function addDefaultPdoDriverOptions(array $extensionConfigs)
     {
         // Do not add PDO options, if constant does not exist
         if (!\defined('PDO::MYSQL_ATTR_MULTI_STATEMENTS')) {

--- a/manager-bundle/src/ContaoManager/Plugin.php
+++ b/manager-bundle/src/ContaoManager/Plugin.php
@@ -216,6 +216,11 @@ class Plugin implements BundlePluginInterface, ConfigPluginInterface, RoutingPlu
      */
     private function setPdoDriverOptions(array $extensionConfigs, PluginContainerBuilder $container)
     {
+        // Do not add PDO options, if constant does not exist
+        if (!\defined('PDO::MYSQL_ATTR_MULTI_STATEMENTS')) {
+            return $extensionConfigs;
+        }
+
         foreach ($extensionConfigs as $extensionConfig) {
             // Do not add PDO options, if selected driver is not pdo_mysql
             if (isset($extensionConfig['dbal']['connections']['default']['driver']) && 'pdo_mysql' !== $extensionConfig['dbal']['connections']['default']['driver']) {
@@ -228,20 +233,17 @@ class Plugin implements BundlePluginInterface, ConfigPluginInterface, RoutingPlu
             }
         }
 
-        // Add PDO driver options dynamically, if defined
-        if (\defined('PDO::MYSQL_ATTR_MULTI_STATEMENTS')) {
-            $extensionConfigs[] = [
-                'dbal' => [
-                    'connections' => [
-                        'default' => [
-                            'options' => [
-                                PDO::MYSQL_ATTR_MULTI_STATEMENTS => false,
-                            ],
+        $extensionConfigs[] = [
+            'dbal' => [
+                'connections' => [
+                    'default' => [
+                        'options' => [
+                            PDO::MYSQL_ATTR_MULTI_STATEMENTS => false,
                         ],
                     ],
                 ],
-            ];
-        }
+            ],
+        ];
 
         return $extensionConfigs;
     }

--- a/manager-bundle/src/ContaoManager/Plugin.php
+++ b/manager-bundle/src/ContaoManager/Plugin.php
@@ -223,7 +223,7 @@ class Plugin implements BundlePluginInterface, ConfigPluginInterface, RoutingPlu
             }
 
             // Do not add PDO options, if custom options have been defined
-            if (isset($extensionConfig['dbal']['connections']['default']['options'])) {
+            if (isset($extensionConfig['dbal']['connections']['default']) && \array_key_exists('options', $extensionConfig['dbal']['connections']['default'])) {
                 return $extensionConfigs;
             }
         }

--- a/manager-bundle/src/Resources/contao-manager/doctrine.yml
+++ b/manager-bundle/src/Resources/contao-manager/doctrine.yml
@@ -18,8 +18,6 @@ doctrine:
                 password: "%database_password%"
                 dbname: "%database_name%"
                 charset: UTF8
-                options:
-                    !php/const:PDO::MYSQL_ATTR_MULTI_STATEMENTS: false
         types:
             binary_string:
                 class: "Contao\\CoreBundle\\Doctrine\\DBAL\\Types\\BinaryStringType"

--- a/manager-bundle/tests/ContaoManager/PluginTest.php
+++ b/manager-bundle/tests/ContaoManager/PluginTest.php
@@ -14,6 +14,7 @@ use Contao\ManagerBundle\ContaoManager\Plugin;
 use Contao\ManagerPlugin\Bundle\Parser\ParserInterface;
 use Contao\ManagerPlugin\Config\ContainerBuilder as PluginContainerBuilder;
 use Contao\ManagerPlugin\PluginLoader;
+use PDO;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\Config\Loader\LoaderResolverInterface;
@@ -298,6 +299,52 @@ class PluginTest extends TestCase
                     'connections' => [
                         'default' => [
                             'server_version' => '5.1',
+                        ],
+                    ],
+                ],
+            ],
+        ], $result);
+
+        $extensionConfigs = [
+            [
+                'dbal' => [
+                    'connections' => [
+                        'default' => [
+                            'driver' => 'pdo_mysql',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $result = $this->plugin->getExtensionConfig('doctrine', $extensionConfigs, $container);
+
+        $this->assertSame([
+            [
+                'dbal' => [
+                    'connections' => [
+                        'default' => [
+                            'driver' => 'pdo_mysql',
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'dbal' => [
+                    'connections' => [
+                        'default' => [
+                            'server_version' => '5.1',
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'dbal' => [
+                    'connections' => [
+                        'default' => [
+                            'options' => [
+                                PDO::MYSQL_ATTR_MULTI_STATEMENTS => false,
+                            ],
                         ],
                     ],
                 ],

--- a/manager-bundle/tests/ContaoManager/PluginTest.php
+++ b/manager-bundle/tests/ContaoManager/PluginTest.php
@@ -12,6 +12,8 @@ namespace Contao\ManagerBundle\Tests\ContaoManager;
 
 use Contao\ManagerBundle\ContaoManager\Plugin;
 use Contao\ManagerPlugin\Bundle\Parser\ParserInterface;
+use Contao\ManagerPlugin\Config\ContainerBuilder as PluginContainerBuilder;
+use Contao\ManagerPlugin\PluginLoader;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\Config\Loader\LoaderResolverInterface;
@@ -221,5 +223,85 @@ class PluginTest extends TestCase
         $this->assertCount(3, $routes);
         $this->assertSame('/_wdt/foobar', $routes[0]->getPath());
         $this->assertSame('/_profiler/foobar', $routes[1]->getPath());
+    }
+
+    /**
+     * Tests the getExtensionConfig() method.
+     */
+    public function testGetExtensionConfig()
+    {
+        $container = new PluginContainerBuilder(new PluginLoader(), []);
+
+        $extensionConfigs = [
+            [
+                'dbal' => [
+                    'connections' => [
+                        'default' => [
+                            'driver' => 'mysqli',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $result = $this->plugin->getExtensionConfig('doctrine', $extensionConfigs, $container);
+
+        $this->assertSame([
+            [
+                'dbal' => [
+                    'connections' => [
+                        'default' => [
+                            'driver' => 'mysqli',
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'dbal' => [
+                    'connections' => [
+                        'default' => [
+                            'server_version' => '5.1',
+                        ],
+                    ],
+                ],
+            ],
+        ], $result);
+
+        $extensionConfigs = [
+            [
+                'dbal' => [
+                    'connections' => [
+                        'default' => [
+                            'driver' => 'pdo_mysql',
+                            'options' => null,
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $result = $this->plugin->getExtensionConfig('doctrine', $extensionConfigs, $container);
+
+        $this->assertSame([
+            [
+                'dbal' => [
+                    'connections' => [
+                        'default' => [
+                            'driver' => 'pdo_mysql',
+                            'options' => null,
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'dbal' => [
+                    'connections' => [
+                        'default' => [
+                            'server_version' => '5.1',
+                        ],
+                    ],
+                ],
+            ],
+        ], $result);
     }
 }

--- a/manager-bundle/tests/ContaoManager/PluginTest.php
+++ b/manager-bundle/tests/ContaoManager/PluginTest.php
@@ -14,7 +14,6 @@ use Contao\ManagerBundle\ContaoManager\Plugin;
 use Contao\ManagerPlugin\Bundle\Parser\ParserInterface;
 use Contao\ManagerPlugin\Config\ContainerBuilder as PluginContainerBuilder;
 use Contao\ManagerPlugin\PluginLoader;
-use PDO;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\Config\Loader\LoaderResolverInterface;
@@ -247,108 +246,117 @@ class PluginTest extends TestCase
 
         $result = $this->plugin->getExtensionConfig('doctrine', $extensionConfigs, $container);
 
-        $this->assertSame([
+        $this->assertSame(
             [
-                'dbal' => [
-                    'connections' => [
-                        'default' => [
-                            'driver' => 'mysqli',
+                [
+                    'dbal' => [
+                        'connections' => [
+                            'default' => [
+                                'driver' => 'mysqli',
+                            ],
                         ],
                     ],
                 ],
-            ],
-            [
-                'dbal' => [
-                    'connections' => [
-                        'default' => [
-                            'server_version' => '5.1',
-                        ],
-                    ],
-                ],
-            ],
-        ], $result);
-
-        $extensionConfigs = [
-            [
-                'dbal' => [
-                    'connections' => [
-                        'default' => [
-                            'driver' => 'pdo_mysql',
-                            'options' => null,
-                        ],
-                    ],
-                ],
-            ],
-        ];
-
-        $result = $this->plugin->getExtensionConfig('doctrine', $extensionConfigs, $container);
-
-        $this->assertSame([
-            [
-                'dbal' => [
-                    'connections' => [
-                        'default' => [
-                            'driver' => 'pdo_mysql',
-                            'options' => null,
-                        ],
-                    ],
-                ],
-            ],
-            [
-                'dbal' => [
-                    'connections' => [
-                        'default' => [
-                            'server_version' => '5.1',
-                        ],
-                    ],
-                ],
-            ],
-        ], $result);
-
-        $extensionConfigs = [
-            [
-                'dbal' => [
-                    'connections' => [
-                        'default' => [
-                            'driver' => 'pdo_mysql',
-                        ],
-                    ],
-                ],
-            ],
-        ];
-
-        $result = $this->plugin->getExtensionConfig('doctrine', $extensionConfigs, $container);
-
-        $this->assertSame([
-            [
-                'dbal' => [
-                    'connections' => [
-                        'default' => [
-                            'driver' => 'pdo_mysql',
-                        ],
-                    ],
-                ],
-            ],
-            [
-                'dbal' => [
-                    'connections' => [
-                        'default' => [
-                            'server_version' => '5.1',
-                        ],
-                    ],
-                ],
-            ],
-            [
-                'dbal' => [
-                    'connections' => [
-                        'default' => [
-                            'options' => [
-                                PDO::MYSQL_ATTR_MULTI_STATEMENTS => false,
+                [
+                    'dbal' => [
+                        'connections' => [
+                            'default' => [
+                                'server_version' => '5.1',
                             ],
                         ],
                     ],
                 ],
             ],
-        ], $result);
+            $result
+        );
+
+        $extensionConfigs = [
+            [
+                'dbal' => [
+                    'connections' => [
+                        'default' => [
+                            'driver' => 'pdo_mysql',
+                            'options' => null,
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $result = $this->plugin->getExtensionConfig('doctrine', $extensionConfigs, $container);
+
+        $this->assertSame(
+            [
+                [
+                    'dbal' => [
+                        'connections' => [
+                            'default' => [
+                                'driver' => 'pdo_mysql',
+                                'options' => null,
+                            ],
+                        ],
+                    ],
+                ],
+                [
+                    'dbal' => [
+                        'connections' => [
+                            'default' => [
+                                'server_version' => '5.1',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            $result
+        );
+
+        $extensionConfigs = [
+            [
+                'dbal' => [
+                    'connections' => [
+                        'default' => [
+                            'driver' => 'pdo_mysql',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $result = $this->plugin->getExtensionConfig('doctrine', $extensionConfigs, $container);
+
+        $this->assertSame(
+            [
+                [
+                    'dbal' => [
+                        'connections' => [
+                            'default' => [
+                                'driver' => 'pdo_mysql',
+                            ],
+                        ],
+                    ],
+                ],
+                [
+                    'dbal' => [
+                        'connections' => [
+                            'default' => [
+                                'server_version' => '5.1',
+                            ],
+                        ],
+                    ],
+                ],
+                [
+                    'dbal' => [
+                        'connections' => [
+                            'default' => [
+                                'options' => [
+                                    \PDO::MYSQL_ATTR_MULTI_STATEMENTS => false,
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            $result
+        );
     }
 }

--- a/manager-bundle/tests/ContaoManager/PluginTest.php
+++ b/manager-bundle/tests/ContaoManager/PluginTest.php
@@ -230,7 +230,7 @@ class PluginTest extends TestCase
      */
     public function testGetExtensionConfig()
     {
-        $container = new PluginContainerBuilder(new PluginLoader(), []);
+        $container = new PluginContainerBuilder(new PluginLoader(''), []);
 
         $extensionConfigs = [
             [


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #2459
| Docs PR or issue | -

This would add the PDO options dynamically via the Manager Plugin of the Manager Bundle. It will not add anything if a driver other than `pdo_mysql` is used, or custom `options` have already been set.
