### PR TITLE
Fix the CI chain

### DIFF
--- a/core-bundle/src/ServiceAnnotation/Callback.php
+++ b/core-bundle/src/ServiceAnnotation/Callback.php
@@ -41,7 +41,7 @@ final class Callback implements ServiceTagInterface
     public $target;
 
     /**
-     * @var int
+     * @var int|null
      */
     public $priority;
 

--- a/core-bundle/src/ServiceAnnotation/Hook.php
+++ b/core-bundle/src/ServiceAnnotation/Hook.php
@@ -35,7 +35,7 @@ final class Hook implements ServiceTagInterface
     public $value;
 
     /**
-     * @var int
+     * @var int|null
      */
     public $priority;
 

--- a/core-bundle/src/ServiceAnnotation/PickerProvider.php
+++ b/core-bundle/src/ServiceAnnotation/PickerProvider.php
@@ -29,7 +29,7 @@ use Terminal42\ServiceAnnotationBundle\Annotation\ServiceTagInterface;
 final class PickerProvider implements ServiceTagInterface
 {
     /**
-     * @var int
+     * @var int|null
      */
     public $priority;
 


### PR DESCRIPTION
Latest PhpStan update fails otherwise:

```
 ------ ----------------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   tests/EventListener/InsertTags/DateListenerTest.php                                                                                                        
 ------ ----------------------------------------------------------------------------------------------------------------------------------------------------------- 
  35     Call to method PHPUnit\Framework\Assert::assertSame() with array('value' => 'replaceInsertTags', 'priority' => null) and array()|array('value' => string,  
         'priority' => int) will always evaluate to false.                                                                                                          
 ------ ----------------------------------------------------------------------------------------------------------------------------------------------------------- 
```