### PR TITLE
Error Messages responsive

### DIFF
--- a/core-bundle/src/Resources/views/Error/layout.html.twig
+++ b/core-bundle/src/Resources/views/Error/layout.html.twig
@@ -92,18 +92,32 @@
                     background-color: #fff;
                     border: 1px solid #dfdfdf;
                     border-radius: 16px;
-                    padding: 15px 30px 24px;
+                    padding: 15px 15px 24px;
                     word-wrap: break-word;
                     overflow: hidden;
                 }
                 .block-error:before {
                     float: left;
                     content: "</";
-                    font-size: 5em;
+                    font-size: 2.5em;
+                    line-height: 1.6em;
                     color: #ccc;
                 }
                 .block-error .inner {
-                    padding-left: 7em;
+                    padding-left: 3em;
+                }
+                @media (min-width:767px)
+                {
+                    .block-error {
+                        padding: 15px 30px 24px;
+                    }
+                    .block-error:before {
+                        font-size: 5em;
+                        line-height: normal;
+                    }
+                    .block-error .inner {
+                        padding-left: 7em;
+                    }
                 }
             </style>
        {% endblock %}

--- a/core-bundle/src/Resources/views/Error/layout.html.twig
+++ b/core-bundle/src/Resources/views/Error/layout.html.twig
@@ -79,7 +79,7 @@
                     color: #808080;
                 }
                 .wrap {
-                    width: 60%;
+                    max-width: 800px;
                     margin: 0 auto;
                     padding: 1em;
                     overflow: hidden;


### PR DESCRIPTION
at the moment the error messages are too small on mobile (60% - some padding)
Changing width: 60%; to max-width: 800px makes this responsive.
The error message fits into mobile devices.

| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #...
| Docs PR or issue | contao/docs#...

<!--
Bugfixes should be based on the 4.4 or 4.9 branch and features on the master
branch. Select the correct branch in the "base:" drop-down menu above.

Replace this notice with a short README for your feature/bugfix. This will help
people to understand your PR and can be used as a start for the documentation.
-->
