### PR TITLE
Re-use tl_member DCA password field in ModuleCloseAccount

### DIFF
--- a/core-bundle/src/Resources/contao/modules/ModuleCloseAccount.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleCloseAccount.php
@@ -62,14 +62,11 @@ class ModuleCloseAccount extends Module
 	{
 		$this->import(FrontendUser::class, 'User');
 
+		System::loadLanguageFile('tl_member');
+		$this->loadDataContainer('tl_member');
+
 		// Initialize the password widget
-		$arrField = array
-		(
-			'name' => 'password',
-			'inputType' => 'text',
-			'label' => $GLOBALS['TL_LANG']['MSC']['password'][0],
-			'eval' => array('hideInput'=>true, 'preserveTags'=>true, 'mandatory'=>true, 'required'=>true)
-		);
+		$arrField = $GLOBALS['TL_DCA']['tl_member']['fields']['password'];
 
 		$objWidget = new FormTextField(FormTextField::getAttributesFromDca($arrField, $arrField['name']));
 		$objWidget->rowClass = 'row_0 row_first even';


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #2492 

This PR re-uses the password field from tl_member DCA like instead of creating a new one. This way it's possible to modify the properties of the field like it's already the case with all other member related modules.