### PR TITLE
hide manager link in back end

### DIFF
--- a/manager-bundle/src/DependencyInjection/Compiler/ContaoManagerPass.php
+++ b/manager-bundle/src/DependencyInjection/Compiler/ContaoManagerPass.php
@@ -26,8 +26,7 @@ class ContaoManagerPass implements CompilerPassInterface
         $webDir = $container->getParameter('contao.web_dir');
         $managerPath = $container->getParameter('contao_manager.manager_path');
 
-        if('false' === $managerPath)
-        {
+        if('false' === $managerPath) {
             return;
         }
 

--- a/manager-bundle/src/DependencyInjection/Compiler/ContaoManagerPass.php
+++ b/manager-bundle/src/DependencyInjection/Compiler/ContaoManagerPass.php
@@ -26,6 +26,11 @@ class ContaoManagerPass implements CompilerPassInterface
         $webDir = $container->getParameter('contao.web_dir');
         $managerPath = $container->getParameter('contao_manager.manager_path');
 
+        if('false' === $managerPath)
+        {
+            return;
+        }
+
         if (null === $managerPath) {
             if (is_file(Path::join($webDir, 'contao-manager.phar.php'))) {
                 $managerPath = 'contao-manager.phar.php';

--- a/manager-bundle/src/DependencyInjection/Compiler/ContaoManagerPass.php
+++ b/manager-bundle/src/DependencyInjection/Compiler/ContaoManagerPass.php
@@ -26,7 +26,7 @@ class ContaoManagerPass implements CompilerPassInterface
         $webDir = $container->getParameter('contao.web_dir');
         $managerPath = $container->getParameter('contao_manager.manager_path');
 
-        if('false' === $managerPath) {
+        if ('false' === $managerPath) {
             return;
         }
 

--- a/manager-bundle/tests/DependencyInjection/Compiler/ContaoManagerPassTest.php
+++ b/manager-bundle/tests/DependencyInjection/Compiler/ContaoManagerPassTest.php
@@ -78,4 +78,15 @@ class ContaoManagerPassTest extends ContaoTestCase
 
         $pass->process($container);
     }
+
+    public function testDoesNotAddAManagerLinkIfManagerPathIsSetToFalse(): void
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('contao.web_dir', $this->getTempDir());
+        $container->setParameter('contao_manager.manager_path', 'false');
+
+        $pass = new ContaoManagerPass();
+
+        $pass->process($container);
+    }
 }


### PR DESCRIPTION
## feature

# Question
Is there a parameter for the config to hide the back end link for the manager?

# Solution
Now you can set manager_path to false in parameters.yml and the link will not be added.

```
parameters:
    contao_manager:
        manager_path: false

```

Note: The test should be viewed again by someone who is familiar with it ;)
