### PR TITLE
Add compatibility with terminal42/escargot 1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -110,7 +110,7 @@
         "symfony/var-dumper": "4.4.*",
         "symfony/web-profiler-bundle": "4.4.*",
         "symfony/yaml": "4.4.*",
-        "terminal42/escargot": "^0.6.0",
+        "terminal42/escargot": "^0.6.0 || ^1.0",
         "terminal42/service-annotation-bundle": "^1.1",
         "toflar/psr6-symfony-http-cache-store": "^2.1",
         "true/punycode": "^2.1",

--- a/core-bundle/composer.json
+++ b/core-bundle/composer.json
@@ -97,7 +97,7 @@
         "symfony/twig-bundle": "4.4.*",
         "symfony/var-dumper": "4.4.*",
         "symfony/yaml": "4.4.*",
-        "terminal42/escargot": "^0.6.0",
+        "terminal42/escargot": "^0.6.0 || ^1.0",
         "terminal42/service-annotation-bundle": "^1.1",
         "true/punycode": "^2.1",
         "twig/twig": "^2.7",


### PR DESCRIPTION
@Toflar anything more to do here or should version 1.0 be completely backwards compatible?

Related: #2263