### PR TITLE
Fix test order (2) - Handle file scoped deprecations 

### DIFF
--- a/core-bundle/tests/Contao/GdImageTest.php
+++ b/core-bundle/tests/Contao/GdImageTest.php
@@ -19,6 +19,18 @@ use Contao\System;
 
 class GdImageTest extends TestCase
 {
+    /**
+     * @group legacy
+     *
+     * @expectedDeprecation Using the "Contao\GdImage" class has been deprecated %s.
+     */
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        spl_autoload_call(GdImage::class);
+    }
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -26,11 +38,6 @@ class GdImageTest extends TestCase
         System::setContainer($this->getContainerWithContaoConfiguration($this->getTempDir()));
     }
 
-    /**
-     * @group legacy
-     *
-     * @expectedDeprecation Using the "Contao\GdImage" class has been deprecated %s.
-     */
     public function testCreatesImagesFromResources(): void
     {
         $resource = imagecreate(1, 1);

--- a/core-bundle/tests/Controller/FrontendModule/TwoFactorControllerTest.php
+++ b/core-bundle/tests/Controller/FrontendModule/TwoFactorControllerTest.php
@@ -42,6 +42,18 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class TwoFactorControllerTest extends TestCase
 {
+    /**
+     * @group legacy
+     *
+     * @expectedDeprecation %sserialize%sInvalidTwoFactorCodeException%s
+     */
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        spl_autoload_call(InvalidTwoFactorCodeException::class);
+    }
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -227,11 +239,6 @@ class TwoFactorControllerTest extends TestCase
         $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
     }
 
-    /**
-     * @group legacy
-     *
-     * @expectedDeprecation %sserialize%sInvalidTwoFactorCodeException%s
-     */
     public function testFailsIfTheTwoFactorCodeIsInvalid(): void
     {
         /** @var FrontendUser&MockObject $user */

--- a/core-bundle/tests/DataContainer/PaletteManipulatorTest.php
+++ b/core-bundle/tests/DataContainer/PaletteManipulatorTest.php
@@ -19,6 +19,20 @@ use PHPUnit\Framework\TestCase;
 
 class PaletteManipulatorTest extends TestCase
 {
+    /**
+     * @group legacy
+     *
+     * @expectedDeprecation Using the "Contao\CoreBundle\Exception\PaletteNotFoundException" class has been deprecated %s.
+     * @expectedDeprecation Using the "Contao\CoreBundle\Exception\PalettePositionException" class has been deprecated %s.
+     */
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        spl_autoload_call(PaletteNotFoundException::class);
+        spl_autoload_call(PalettePositionException::class);
+    }
+
     public function testPrependsAFieldToAPalette(): void
     {
         $pm = PaletteManipulator::create()
@@ -330,10 +344,6 @@ class PaletteManipulatorTest extends TestCase
         $this->assertTrue($closureCalled);
     }
 
-    /**
-     * @group legacy
-     * @expectedDeprecation Using the "Contao\CoreBundle\Exception\PaletteNotFoundException" class has been deprecated %s.
-     */
     public function testFailsIfTheDcaPaletteDoesNotExist(): void
     {
         $pm = PaletteManipulator::create()
@@ -363,10 +373,6 @@ class PaletteManipulatorTest extends TestCase
         $pm->applyToSubpalette('name', 'tl_test');
     }
 
-    /**
-     * @group legacy
-     * @expectedDeprecation Using the "Contao\CoreBundle\Exception\PalettePositionException" class has been deprecated %s.
-     */
     public function testFailsIfThePositionIsInvalid(): void
     {
         $this->expectException(PalettePositionException::class);

--- a/core-bundle/tests/Translation/TranslatorTest.php
+++ b/core-bundle/tests/Translation/TranslatorTest.php
@@ -26,6 +26,13 @@ class TranslatorTest extends TestCase
      *
      * @expectedDeprecation %simplements "Symfony\Component\Translation\TranslatorInterface" that is deprecated%s
      */
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        spl_autoload_call(Translator::class);
+    }
+
     public function testTranslatorImplementsDeprecatedInterface(): void
     {
         $translator = new Translator($this->createMock(BaseTranslator::class), $this->mockContaoFramework());


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | partly solves #2316 
| Docs PR or issue | -

I'm working on test isolation. This part makes sure file scoped deprecations (= `trigger_error` outside the class definition) are only encountered in the static `setupBeforeClass` method while autoloading the file.