### PR TITLE
Fix test order (3) - Reset singletons

### DIFF
--- a/core-bundle/src/Framework/ContaoFramework.php
+++ b/core-bundle/src/Framework/ContaoFramework.php
@@ -19,10 +19,12 @@ use Contao\CoreBundle\Routing\ScopeMatcher;
 use Contao\CoreBundle\Security\Authentication\Token\TokenChecker;
 use Contao\CoreBundle\Session\LazySessionAccess;
 use Contao\Environment;
+use Contao\Files;
 use Contao\Input;
 use Contao\InsertTags;
 use Contao\Model\Registry;
 use Contao\RequestToken;
+use Contao\Session;
 use Contao\System;
 use Contao\TemplateLoader;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
@@ -119,6 +121,9 @@ class ContaoFramework implements ContaoFrameworkInterface, ContainerAwareInterfa
         Input::resetUnusedGet();
         InsertTags::reset();
         Registry::getInstance()->reset();
+        Files::reset();
+        Session::reset();
+        System::reset();
     }
 
     public function isInitialized(): bool

--- a/core-bundle/src/Framework/ContaoFramework.php
+++ b/core-bundle/src/Framework/ContaoFramework.php
@@ -117,11 +117,11 @@ class ContaoFramework implements ContaoFrameworkInterface, ContainerAwareInterfa
         }
 
         Environment::reset();
+        Files::reset();
         Input::resetCache();
         Input::resetUnusedGet();
         InsertTags::reset();
         Registry::getInstance()->reset();
-        Files::reset();
         Session::reset();
         System::reset();
     }

--- a/core-bundle/src/Framework/ContaoFramework.php
+++ b/core-bundle/src/Framework/ContaoFramework.php
@@ -18,6 +18,7 @@ use Contao\CoreBundle\Exception\RedirectResponseException;
 use Contao\CoreBundle\Routing\ScopeMatcher;
 use Contao\CoreBundle\Security\Authentication\Token\TokenChecker;
 use Contao\CoreBundle\Session\LazySessionAccess;
+use Contao\Database;
 use Contao\Environment;
 use Contao\Files;
 use Contao\Input;
@@ -110,13 +111,71 @@ class ContaoFramework implements ContaoFrameworkInterface, ContainerAwareInterfa
     public function reset(): void
     {
         $this->adapterCache = [];
-        $this->isFrontend = false;
+        $this->hookListeners = [];
 
         if (!$this->isInitialized()) {
             return;
         }
 
+        // Reset internal state
+        self::$initialized = false;
+        $this->request = null;
+        $this->isFrontend = false;
+
+        // Reset session
+        if (null !== ($session = $this->getSession())) {
+            $session->getBag('contao_backend')->clear();
+            $session->getBag('contao_frontend')->clear();
+        }
+
+        if (($_SESSION ?? null) instanceof LazySessionAccess) {
+            $_SESSION = [];
+        }
+
+        // Reset globals
+        unset(
+            $GLOBALS['BE_FFL'],
+            $GLOBALS['BE_MOD'],
+            $GLOBALS['FE_MOD'],
+            $GLOBALS['TL_ADMIN_EMAIL'],
+            $GLOBALS['TL_ADMIN_NAME'],
+            $GLOBALS['TL_AUTO_ITEM'],
+            $GLOBALS['TL_BODY'],
+            $GLOBALS['TL_CONFIG'],
+            $GLOBALS['TL_CRON'],
+            $GLOBALS['TL_CROP'],
+            $GLOBALS['TL_CSS'],
+            $GLOBALS['TL_CSS_UNITS'],
+            $GLOBALS['TL_CTE'],
+            $GLOBALS['TL_DCA'],
+            $GLOBALS['TL_DEBUG'],
+            $GLOBALS['TL_FFL'],
+            $GLOBALS['TL_FRAMEWORK_CSS'],
+            $GLOBALS['TL_HEAD'],
+            $GLOBALS['TL_HOOKS'],
+            $GLOBALS['TL_JAVASCRIPT'],
+            $GLOBALS['TL_JQUERY'],
+            $GLOBALS['TL_KEYWORDS'],
+            $GLOBALS['TL_LANG'],
+            $GLOBALS['TL_LANGUAGE'],
+            $GLOBALS['TL_MAINTENANCE'],
+            $GLOBALS['TL_MIME'],
+            $GLOBALS['TL_MODELS'],
+            $GLOBALS['TL_MOOTOOLS'],
+            $GLOBALS['TL_NOINDEX_KEYS'],
+            $GLOBALS['TL_PERMISSIONS'],
+            $GLOBALS['TL_PTY'],
+            $GLOBALS['TL_PURGE'],
+            $GLOBALS['TL_USERNAME'],
+            $GLOBALS['TL_USER_CSS'],
+            $GLOBALS['TL_WRAPPERS'],
+            $GLOBALS['objPage'],
+        );
+
+        // Reset framework classes
+        Config::reset();
         ClassLoader::reset();
+        Database::reset();
         Environment::reset();
         Files::reset();
         Input::resetCache();

--- a/core-bundle/src/Framework/ContaoFramework.php
+++ b/core-bundle/src/Framework/ContaoFramework.php
@@ -116,6 +116,7 @@ class ContaoFramework implements ContaoFrameworkInterface, ContainerAwareInterfa
             return;
         }
 
+        ClassLoader::reset();
         Environment::reset();
         Files::reset();
         Input::resetCache();

--- a/core-bundle/src/Resources/contao/library/Contao/ClassLoader.php
+++ b/core-bundle/src/Resources/contao/library/Contao/ClassLoader.php
@@ -232,6 +232,17 @@ class ClassLoader
 	}
 
 	/**
+	 * Unregister the autoloader and reset the internal cache
+	 */
+	public static function reset()
+	{
+		self::$namespaces = array('Contao');
+		self::$classes = array();
+
+		spl_autoload_unregister('ClassLoader::load');
+	}
+
+	/**
 	 * Scan the module directories for config/autoload.php files and then
 	 * register the autoloader on the SPL stack
 	 */

--- a/core-bundle/src/Resources/contao/library/Contao/Config.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Config.php
@@ -120,6 +120,17 @@ class Config
 	}
 
 	/**
+	 * Reset the singleton instance, internal cache and global state
+	 */
+	public static function reset(): void
+	{
+		static::$objInstance = null;
+		static::$blnHasLcf = null;
+
+		unset($GLOBALS['TL_CONFIG']);
+	}
+
+	/**
 	 * Load all configuration files
 	 */
 	protected function initialize()

--- a/core-bundle/src/Resources/contao/library/Contao/Database.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Database.php
@@ -169,6 +169,20 @@ class Database
 	}
 
 	/**
+	 * Reset all instances
+	 */
+	public static function reset(): void
+	{
+		/** @var self $instance */
+		foreach (self::$arrInstances as $instance)
+		{
+			$instance->arrCache = array();
+		}
+
+		static::$arrInstances = array();
+	}
+
+	/**
 	 * Prepare a query and return a Statement object
 	 *
 	 * @param string $strQuery The query string

--- a/core-bundle/src/Resources/contao/library/Contao/Files.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Files.php
@@ -74,7 +74,7 @@ class Files
 	}
 
 	/**
-	 * @internal
+	 * Reset the singleton instance
 	 */
 	public static function reset(): void
 	{

--- a/core-bundle/src/Resources/contao/library/Contao/Files.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Files.php
@@ -74,6 +74,14 @@ class Files
 	}
 
 	/**
+	 * @internal
+	 */
+	public static function reset(): void
+	{
+		self::$objInstance = null;
+	}
+
+	/**
 	 * Create a directory
 	 *
 	 * @param string $strDirectory The directory name

--- a/core-bundle/src/Resources/contao/library/Contao/Session.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Session.php
@@ -99,6 +99,14 @@ class Session
 	}
 
 	/**
+	 * @internal
+	 */
+	public static function reset(): void
+	{
+		static::$objInstance = null;
+	}
+
+	/**
 	 * Return a session variable
 	 *
 	 * @param string $strKey The variable name

--- a/core-bundle/src/Resources/contao/library/Contao/Session.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Session.php
@@ -99,7 +99,7 @@ class Session
 	}
 
 	/**
-	 * @internal
+	 * Reset the singleton instance
 	 */
 	public static function reset(): void
 	{

--- a/core-bundle/src/Resources/contao/library/Contao/System.php
+++ b/core-bundle/src/Resources/contao/library/Contao/System.php
@@ -332,17 +332,6 @@ abstract class System
 		static::$objContainer = $container;
 	}
 
-	public static function reset()
-	{
-		self::$objContainer = null;
-		self::$removedServiceIds = null;
-		self::$arrStaticObjects = array();
-		self::$arrSingletons = array();
-		self::$arrLanguages = array();
-		self::$arrLanguageFiles = array();
-		self::$arrImageSizes = array();
-	}
-
 	/**
 	 * Add a log entry to the database
 	 *
@@ -1267,6 +1256,20 @@ abstract class System
 	public static function disableModule()
 	{
 		@trigger_error('Using System::disableModule() has been deprecated and will no longer work in Contao 5.0. Use Composer to add or remove modules.', E_USER_DEPRECATED);
+	}
+
+	/**
+	 * Reset the internal cache
+	 */
+	public static function reset()
+	{
+		self::$objContainer = null;
+		self::$removedServiceIds = null;
+		self::$arrStaticObjects = array();
+		self::$arrSingletons = array();
+		self::$arrLanguages = array();
+		self::$arrLanguageFiles = array();
+		self::$arrImageSizes = array();
 	}
 }
 

--- a/core-bundle/src/Resources/contao/library/Contao/System.php
+++ b/core-bundle/src/Resources/contao/library/Contao/System.php
@@ -329,6 +329,25 @@ abstract class System
 	 */
 	public static function setContainer(ContainerInterface $container)
 	{
+		// Reset state if a container was previously set
+		if (null !== static::$objContainer)
+		{
+			foreach (self::$arrSingletons as $singleton)
+			{
+				if (\in_array('reset', get_class_methods($singleton), true))
+				{
+					$singleton::reset();
+				}
+			}
+
+			self::$removedServiceIds = null;
+			self::$arrStaticObjects = array();
+			self::$arrSingletons = array();
+			self::$arrLanguages = array();
+			self::$arrLanguageFiles = array();
+			self::$arrImageSizes = array();
+		}
+
 		static::$objContainer = $container;
 	}
 

--- a/core-bundle/src/Resources/contao/library/Contao/System.php
+++ b/core-bundle/src/Resources/contao/library/Contao/System.php
@@ -334,6 +334,7 @@ abstract class System
 
 	public static function reset()
 	{
+		self::$objContainer = null;
 		self::$removedServiceIds = null;
 		self::$arrStaticObjects = array();
 		self::$arrSingletons = array();

--- a/core-bundle/src/Resources/contao/library/Contao/System.php
+++ b/core-bundle/src/Resources/contao/library/Contao/System.php
@@ -329,26 +329,17 @@ abstract class System
 	 */
 	public static function setContainer(ContainerInterface $container)
 	{
-		// Reset state if a container was previously set
-		if (null !== static::$objContainer)
-		{
-			foreach (self::$arrSingletons as $singleton)
-			{
-				if (\in_array('reset', get_class_methods($singleton), true))
-				{
-					$singleton::reset();
-				}
-			}
-
-			self::$removedServiceIds = null;
-			self::$arrStaticObjects = array();
-			self::$arrSingletons = array();
-			self::$arrLanguages = array();
-			self::$arrLanguageFiles = array();
-			self::$arrImageSizes = array();
-		}
-
 		static::$objContainer = $container;
+	}
+
+	public static function reset()
+	{
+		self::$removedServiceIds = null;
+		self::$arrStaticObjects = array();
+		self::$arrSingletons = array();
+		self::$arrLanguages = array();
+		self::$arrLanguageFiles = array();
+		self::$arrImageSizes = array();
 	}
 
 	/**

--- a/core-bundle/tests/Controller/ContentElement/ContentElementControllerTest.php
+++ b/core-bundle/tests/Controller/ContentElement/ContentElementControllerTest.php
@@ -19,6 +19,7 @@ use Contao\CoreBundle\Tests\TestCase;
 use Contao\FrontendTemplate;
 use Contao\System;
 use FOS\HttpCache\ResponseTagger;
+use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -37,7 +38,7 @@ class ContentElementControllerTest extends TestCase
         $controller = new TestController();
         $controller->setContainer($this->mockContainerWithFrameworkTemplate('ce_test'));
 
-        $controller(new Request(), new ContentModel(), 'main');
+        $controller(new Request(), $this->createMock(ContentModel::class), 'main');
     }
 
     public function testCreatesTheTemplateFromTheTypeFragmentOptions(): void
@@ -46,7 +47,7 @@ class ContentElementControllerTest extends TestCase
         $controller->setContainer($this->mockContainerWithFrameworkTemplate('ce_foo'));
         $controller->setFragmentOptions(['type' => 'foo']);
 
-        $controller(new Request(), new ContentModel(), 'main');
+        $controller(new Request(), $this->createMock(ContentModel::class), 'main');
     }
 
     public function testCreatesTheTemplateFromTheTemplateFragmentOption(): void
@@ -55,12 +56,13 @@ class ContentElementControllerTest extends TestCase
         $controller->setContainer($this->mockContainerWithFrameworkTemplate('ce_bar'));
         $controller->setFragmentOptions(['template' => 'ce_bar']);
 
-        $controller(new Request(), new ContentModel(), 'main');
+        $controller(new Request(), $this->createMock(ContentModel::class), 'main');
     }
 
     public function testCreatesTheTemplateFromACustomTpl(): void
     {
-        $model = new ContentModel();
+        /** @var ContentModel&MockObject $model */
+        $model = $this->mockClassWithProperties(ContentModel::class);
         $model->customTpl = 'ce_bar';
 
         $container = $this->mockContainerWithFrameworkTemplate('ce_bar');
@@ -103,7 +105,7 @@ class ContentElementControllerTest extends TestCase
         $controller = new TestController();
         $controller->setContainer($this->mockContainerWithFrameworkTemplate('ce_test'));
 
-        $response = $controller(new Request(), new ContentModel(), 'main');
+        $response = $controller(new Request(), $this->createMock(ContentModel::class), 'main');
         $template = json_decode($response->getContent(), true);
 
         $this->assertSame('', $template['cssID']);
@@ -112,7 +114,8 @@ class ContentElementControllerTest extends TestCase
 
     public function testSetsTheHeadlineFromTheModel(): void
     {
-        $model = new ContentModel();
+        /** @var ContentModel&MockObject $model */
+        $model = $this->mockClassWithProperties(ContentModel::class);
         $model->headline = serialize(['unit' => 'h6', 'value' => 'foobar']);
 
         $controller = new TestController();
@@ -127,7 +130,8 @@ class ContentElementControllerTest extends TestCase
 
     public function testSetsTheCssIdAndClassFromTheModel(): void
     {
-        $model = new ContentModel();
+        /** @var ContentModel&MockObject $model */
+        $model = $this->mockClassWithProperties(ContentModel::class);
         $model->cssID = serialize(['foo', 'bar']);
 
         $controller = new TestController();
@@ -145,7 +149,7 @@ class ContentElementControllerTest extends TestCase
         $controller = new TestController();
         $controller->setContainer($this->mockContainerWithFrameworkTemplate('ce_test'));
 
-        $response = $controller(new Request(), new ContentModel(), 'left');
+        $response = $controller(new Request(), $this->createMock(ContentModel::class), 'left');
         $template = json_decode($response->getContent(), true);
 
         $this->assertSame('left', $template['inColumn']);
@@ -156,7 +160,7 @@ class ContentElementControllerTest extends TestCase
         $controller = new TestController();
         $controller->setContainer($this->mockContainerWithFrameworkTemplate('ce_test'));
 
-        $response = $controller(new Request(), new ContentModel(), 'main', ['first', 'last']);
+        $response = $controller(new Request(), $this->createMock(ContentModel::class), 'main', ['first', 'last']);
         $template = json_decode($response->getContent(), true);
 
         $this->assertSame('ce_test first last', $template['class']);
@@ -164,7 +168,8 @@ class ContentElementControllerTest extends TestCase
 
     public function testAddsTheCacheTags(): void
     {
-        $model = new ContentModel();
+        /** @var ContentModel&MockObject $model */
+        $model = $this->mockClassWithProperties(ContentModel::class);
         $model->id = 42;
 
         $responseTagger = $this->createMock(ResponseTagger::class);
@@ -189,7 +194,8 @@ class ContentElementControllerTest extends TestCase
         $start = strtotime('+2 weeks', $time);
         $expires = $start - $time;
 
-        $model = new ContentModel();
+        /** @var ContentModel&MockObject $model */
+        $model = $this->mockClassWithProperties(ContentModel::class);
         $model->start = (string) $start;
 
         $container = $this->mockContainerWithFrameworkTemplate('ce_test_shared_max_age');
@@ -208,7 +214,8 @@ class ContentElementControllerTest extends TestCase
         $stop = strtotime('+2 weeks', $time);
         $expires = $stop - $time;
 
-        $model = new ContentModel();
+        /** @var ContentModel&MockObject $model */
+        $model = $this->mockClassWithProperties(ContentModel::class);
         $model->stop = (string) $stop;
 
         $container = $this->mockContainerWithFrameworkTemplate('ce_test_shared_max_age');
@@ -228,7 +235,7 @@ class ContentElementControllerTest extends TestCase
         $controller = new TestSharedMaxAgeController();
         $controller->setContainer($container);
 
-        $response = $controller(new Request(), new ContentModel(), 'main');
+        $response = $controller(new Request(), $this->createMock(ContentModel::class), 'main');
 
         $this->assertNull($response->getMaxAge());
     }

--- a/core-bundle/tests/Controller/FrontendModule/FrontendModuleControllerTest.php
+++ b/core-bundle/tests/Controller/FrontendModule/FrontendModuleControllerTest.php
@@ -18,6 +18,7 @@ use Contao\FrontendTemplate;
 use Contao\ModuleModel;
 use Contao\System;
 use FOS\HttpCache\ResponseTagger;
+use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -36,7 +37,7 @@ class FrontendModuleControllerTest extends TestCase
         $controller = new TestController();
         $controller->setContainer($this->mockContainerWithFrameworkTemplate('mod_test'));
 
-        $controller(new Request([], [], ['_scope' => 'frontend']), new ModuleModel(), 'main');
+        $controller(new Request([], [], ['_scope' => 'frontend']), $this->createMock(ModuleModel::class), 'main');
     }
 
     public function testCreatesTheTemplateFromTheTypeFragmentOption(): void
@@ -45,7 +46,7 @@ class FrontendModuleControllerTest extends TestCase
         $controller->setContainer($this->mockContainerWithFrameworkTemplate('mod_foo'));
         $controller->setFragmentOptions(['type' => 'foo']);
 
-        $controller(new Request(), new ModuleModel(), 'main');
+        $controller(new Request(), $this->createMock(ModuleModel::class), 'main');
     }
 
     public function testCreatesTheTemplateFromTheTemplateFragmentOption(): void
@@ -54,12 +55,13 @@ class FrontendModuleControllerTest extends TestCase
         $controller->setContainer($this->mockContainerWithFrameworkTemplate('mod_bar'));
         $controller->setFragmentOptions(['template' => 'mod_bar']);
 
-        $controller(new Request(), new ModuleModel(), 'main');
+        $controller(new Request(), $this->createMock(ModuleModel::class), 'main');
     }
 
     public function testCreatesTheTemplateFromACustomTpl(): void
     {
-        $model = new ModuleModel();
+        /** @var ModuleModel&MockObject $model */
+        $model = $this->mockClassWithProperties(ModuleModel::class);
         $model->customTpl = 'mod_bar';
 
         $container = $this->mockContainerWithFrameworkTemplate('mod_bar');
@@ -79,7 +81,7 @@ class FrontendModuleControllerTest extends TestCase
         $controller = new TestController();
         $controller->setContainer($this->mockContainerWithFrameworkTemplate('mod_test'));
 
-        $response = $controller(new Request(), new ModuleModel(), 'main');
+        $response = $controller(new Request(), $this->createMock(ModuleModel::class), 'main');
         $template = json_decode($response->getContent(), true);
 
         $this->assertSame('', $template['cssID']);
@@ -88,7 +90,8 @@ class FrontendModuleControllerTest extends TestCase
 
     public function testSetsTheHeadlineFromTheModel(): void
     {
-        $model = new ModuleModel();
+        /** @var ModuleModel&MockObject $model */
+        $model = $this->mockClassWithProperties(ModuleModel::class);
         $model->headline = serialize(['unit' => 'h6', 'value' => 'foobar']);
 
         $controller = new TestController();
@@ -103,7 +106,8 @@ class FrontendModuleControllerTest extends TestCase
 
     public function testSetsTheCssIdAndClassFromTheModel(): void
     {
-        $model = new ModuleModel();
+        /** @var ModuleModel&MockObject $model */
+        $model = $this->mockClassWithProperties(ModuleModel::class);
         $model->cssID = serialize(['foo', 'bar']);
 
         $controller = new TestController();
@@ -121,7 +125,7 @@ class FrontendModuleControllerTest extends TestCase
         $controller = new TestController();
         $controller->setContainer($this->mockContainerWithFrameworkTemplate('mod_test'));
 
-        $response = $controller(new Request(), new ModuleModel(), 'left');
+        $response = $controller(new Request(), $this->createMock(ModuleModel::class), 'left');
         $template = json_decode($response->getContent(), true);
 
         $this->assertSame('left', $template['inColumn']);
@@ -129,7 +133,8 @@ class FrontendModuleControllerTest extends TestCase
 
     public function testAddsTheCacheTags(): void
     {
-        $model = new ModuleModel();
+        /** @var ModuleModel&MockObject $model */
+        $model = $this->mockClassWithProperties(ModuleModel::class);
         $model->id = 42;
 
         $responseTagger = $this->createMock(ResponseTagger::class);

--- a/core-bundle/tests/Fragment/FragmentHandlerTest.php
+++ b/core-bundle/tests/Fragment/FragmentHandlerTest.php
@@ -117,7 +117,7 @@ class FragmentHandlerTest extends TestCase
 
         $renderers = $this->mockServiceLocatorWithRenderer('inline', [$callback]);
 
-        $GLOBALS['objPage'] = new PageModel();
+        $GLOBALS['objPage'] = $this->mockClassWithProperties(PageModel::class);
         $GLOBALS['objPage']->id = 42;
 
         $fragmentHandler = $this->getFragmentHandler($fragmentRegistry, $renderers);
@@ -139,7 +139,7 @@ class FragmentHandlerTest extends TestCase
 
         $renderers = $this->mockServiceLocatorWithRenderer('inline', [$callback]);
 
-        $GLOBALS['objPage'] = new PageModel();
+        $GLOBALS['objPage'] = $this->mockClassWithProperties(PageModel::class);
         $GLOBALS['objPage']->id = 42;
 
         $fragmentHandler = $this->getFragmentHandler($fragmentRegistry, $renderers);

--- a/core-bundle/tests/Fragment/Reference/ContentElementReferenceTest.php
+++ b/core-bundle/tests/Fragment/Reference/ContentElementReferenceTest.php
@@ -15,12 +15,14 @@ namespace Contao\CoreBundle\Tests\Fragment\Reference;
 use Contao\ContentModel;
 use Contao\CoreBundle\Fragment\Reference\ContentElementReference;
 use Contao\CoreBundle\Tests\TestCase;
+use PHPUnit\Framework\MockObject\MockObject;
 
 class ContentElementReferenceTest extends TestCase
 {
     public function testCreatesTheControllerNameFromTheModelType(): void
     {
-        $model = new ContentModel();
+        /** @var ContentModel&MockObject $model */
+        $model = $this->mockClassWithProperties(ContentModel::class);
         $model->type = 'foobar';
 
         $reference = new ContentElementReference($model);
@@ -30,8 +32,7 @@ class ContentElementReferenceTest extends TestCase
 
     public function testAddsTheSectionAttribute(): void
     {
-        $model = new ContentModel();
-        $model->type = 'foobar';
+        $model = $this->createMock(ContentModel::class);
 
         $reference = new ContentElementReference($model);
         $this->assertSame('main', $reference->attributes['section']);

--- a/core-bundle/tests/Fragment/Reference/FrontendModuleReferenceTest.php
+++ b/core-bundle/tests/Fragment/Reference/FrontendModuleReferenceTest.php
@@ -15,12 +15,14 @@ namespace Contao\CoreBundle\Tests\Fragment\Reference;
 use Contao\CoreBundle\Fragment\Reference\FrontendModuleReference;
 use Contao\CoreBundle\Tests\TestCase;
 use Contao\ModuleModel;
+use PHPUnit\Framework\MockObject\MockObject;
 
 class FrontendModuleReferenceTest extends TestCase
 {
     public function testCreatesTheControllerNameFromTheModelType(): void
     {
-        $model = new ModuleModel();
+        /** @var ModuleModel&MockObject $model */
+        $model = $this->mockClassWithProperties(ModuleModel::class);
         $model->type = 'foobar';
 
         $reference = new FrontendModuleReference($model);
@@ -30,8 +32,7 @@ class FrontendModuleReferenceTest extends TestCase
 
     public function testAddsTheSectionAttribute(): void
     {
-        $model = new ModuleModel();
-        $model->type = 'foobar';
+        $model = $this->createMock(ModuleModel::class);
 
         $reference = new FrontendModuleReference($model);
         $this->assertSame('main', $reference->attributes['section']);

--- a/core-bundle/tests/Framework/ContaoFrameworkTest.php
+++ b/core-bundle/tests/Framework/ContaoFrameworkTest.php
@@ -639,7 +639,7 @@ class ContaoFrameworkTest extends TestCase
         );
     }
 
-    public function testServiceIsResetable(): void
+    public function testServiceIsResettable(): void
     {
         $this->assertInstanceOf(ResetInterface::class, $this->mockFramework());
 

--- a/core-bundle/tests/Functional/RoutingTest.php
+++ b/core-bundle/tests/Functional/RoutingTest.php
@@ -13,9 +13,6 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Tests\Functional;
 
 use Contao\Config;
-use Contao\Environment;
-use Contao\Input;
-use Contao\InsertTags;
 use Contao\System;
 use Contao\TestCase\ContaoDatabaseTrait;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
@@ -44,16 +41,16 @@ class RoutingTest extends WebTestCase
     {
         parent::setUp();
 
-        $_GET = [];
-
-        Input::resetCache();
-        Input::resetUnusedGet();
-        Environment::reset();
-        InsertTags::reset();
-
         Config::set('debugMode', false);
         Config::set('useAutoItem', true);
         Config::set('addLanguageToUrl', false);
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        $_GET = [];
     }
 
     /**


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | partly solves #2316 
| Docs PR or issue | -

I'm working on test isolation. This part adds the ability to reset the singleton instances. 

Without this the `Files` class would for instance store the `$projectDir` property and keep it forever although another test might have called `System::setContainer()` with another path in the meantime.

The following changes needed for #2316 are also part of this PR in order for the canonical order to pass:

1) Mocking models instead of real instances in the `Tests/Controller` namespace.
1) Mocking models instead of real instances in the `Tests/Fragment` namespace.
