### PR TITLE
Fix test order (4) - Set/reset globals

### DIFF
--- a/core-bundle/tests/Asset/ContaoContextTest.php
+++ b/core-bundle/tests/Asset/ContaoContextTest.php
@@ -224,6 +224,8 @@ class ContaoContextTest extends TestCase
         $context = $this->getContaoContext('staticPlugins', $requestStack);
 
         $this->assertSame('https://example.com/foo/', $context->getStaticUrl());
+
+        unset($GLOBALS['objPage']);
     }
 
     public function testReturnsAnEmptyStaticUrlIfTheBasePathIsEmpty(): void

--- a/core-bundle/tests/Contao/TemplateTest.php
+++ b/core-bundle/tests/Contao/TemplateTest.php
@@ -36,6 +36,8 @@ class TemplateTest extends TestCase
         $this->filesystem->mkdir($this->getFixturesDir().'/templates');
 
         System::setContainer($this->getContainerWithContaoConfiguration($this->getFixturesDir()));
+
+        Config::set('debugMode', false);
     }
 
     protected function tearDown(): void
@@ -47,8 +49,6 @@ class TemplateTest extends TestCase
 
     public function testReplacesTheVariables(): void
     {
-        Config::set('debugMode', false);
-
         $this->filesystem->dumpFile(
             $this->getFixturesDir().'/templates/test_template.html5',
             '<?= $this->value ?>'

--- a/core-bundle/tests/Contao/TemplateTest.php
+++ b/core-bundle/tests/Contao/TemplateTest.php
@@ -36,7 +36,6 @@ class TemplateTest extends TestCase
         $this->filesystem->mkdir($this->getFixturesDir().'/templates');
 
         System::setContainer($this->getContainerWithContaoConfiguration($this->getFixturesDir()));
-
         Config::set('debugMode', false);
     }
 

--- a/core-bundle/tests/Controller/BackendCsvImportControllerTest.php
+++ b/core-bundle/tests/Controller/BackendCsvImportControllerTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Tests\Controller;
 
+use Contao\Config;
 use Contao\CoreBundle\Config\ResourceFinder;
 use Contao\CoreBundle\Controller\BackendCsvImportController;
 use Contao\CoreBundle\Exception\InternalServerErrorException;
@@ -43,6 +44,8 @@ class BackendCsvImportControllerTest extends TestCase
         $container->set('contao.resource_finder', $finder);
 
         System::setContainer($container);
+
+        Config::set('debugMode', false);
     }
 
     public function testRendersTheListWizardMarkup(): void

--- a/core-bundle/tests/Controller/BackendCsvImportControllerTest.php
+++ b/core-bundle/tests/Controller/BackendCsvImportControllerTest.php
@@ -44,7 +44,6 @@ class BackendCsvImportControllerTest extends TestCase
         $container->set('contao.resource_finder', $finder);
 
         System::setContainer($container);
-
         Config::set('debugMode', false);
     }
 

--- a/manager-bundle/tests/ContaoManager/PluginTest.php
+++ b/manager-bundle/tests/ContaoManager/PluginTest.php
@@ -53,11 +53,7 @@ class PluginTest extends ContaoTestCase
     {
         parent::setUp();
 
-        unset(
-            $_SERVER['DATABASE_URL'],
-            $_SERVER['APP_SECRET'],
-            $_ENV['DATABASE_URL']
-        );
+        unset($_SERVER['DATABASE_URL'], $_SERVER['APP_SECRET'], $_ENV['DATABASE_URL']);
     }
 
     public function testReturnsTheBundles(): void

--- a/manager-bundle/tests/ContaoManager/PluginTest.php
+++ b/manager-bundle/tests/ContaoManager/PluginTest.php
@@ -44,36 +44,20 @@ use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
 
+/**
+ * @backupGlobals enabled
+ */
 class PluginTest extends ContaoTestCase
 {
-    public static function setUpBeforeClass(): void
+    protected function setUp(): void
     {
-        parent::setUpBeforeClass();
+        parent::setUp();
 
-        if (isset($_SERVER['APP_SECRET'])) {
-            $_SERVER['APP_SECRET_ORIG'] = $_SERVER['APP_SECRET'];
-            unset($_SERVER['APP_SECRET']);
-        }
-
-        if (isset($_SERVER['DATABASE_URL'])) {
-            $_SERVER['DATABASE_URL_ORIG'] = $_SERVER['DATABASE_URL'];
-            unset($_SERVER['DATABASE_URL']);
-        }
-    }
-
-    public static function tearDownAfterClass(): void
-    {
-        parent::tearDownAfterClass();
-
-        if (isset($_SERVER['APP_SECRET_ORIG'])) {
-            $_SERVER['APP_SECRET'] = $_SERVER['APP_SECRET_ORIG'];
-            unset($_SERVER['APP_SECRET_ORIG']);
-        }
-
-        if (isset($_SERVER['DATABASE_URL_ORIG'])) {
-            $_SERVER['DATABASE_URL'] = $_SERVER['DATABASE_URL_ORIG'];
-            unset($_SERVER['DATABASE_URL_ORIG']);
-        }
+        unset(
+            $_SERVER['DATABASE_URL'],
+            $_SERVER['APP_SECRET'],
+            $_ENV['DATABASE_URL']
+        );
     }
 
     public function testReturnsTheBundles(): void
@@ -684,13 +668,10 @@ class PluginTest extends ContaoTestCase
             return $connection;
         };
 
-        $url = $_ENV['DATABASE_URL'] ?? null;
         $_SERVER['DATABASE_URL'] = $_ENV['DATABASE_URL'] = 'mysql://root:%%40foobar@localhost:3306/database';
 
         $plugin = new Plugin($dbalConnectionFactory);
         $plugin->getExtensionConfig('doctrine', $extensionConfigs, $container);
-
-        $_ENV['DATABASE_URL'] = $url;
     }
 
     private function getContainer(): PluginContainerBuilder

--- a/manager-bundle/tests/HttpKernel/ContaoKernelTest.php
+++ b/manager-bundle/tests/HttpKernel/ContaoKernelTest.php
@@ -102,6 +102,9 @@ class ContaoKernelTest extends ContaoTestCase
         $this->assertArrayNotHasKey(AppBundle::class, $bundles);
     }
 
+    /**
+     * @runInSeparateProcess
+     */
     public function testRegistersAppBundle(): void
     {
         $bundleLoader = $this->createMock(BundleLoader::class);

--- a/manager-bundle/tests/HttpKernel/ContaoKernelTest.php
+++ b/manager-bundle/tests/HttpKernel/ContaoKernelTest.php
@@ -272,6 +272,8 @@ class ContaoKernelTest extends ContaoTestCase
 
         $this->assertSame(['1.1.1.1', '2.2.2.2'], Request::getTrustedProxies());
         $this->assertSame(Request::HEADER_X_FORWARDED_ALL ^ Request::HEADER_X_FORWARDED_HOST, Request::getTrustedHeaderSet());
+
+        unset($_SERVER['TRUSTED_PROXIES']);
     }
 
     public function testSetsRequestTrustedHostsFromEnvVars(): void
@@ -283,6 +285,8 @@ class ContaoKernelTest extends ContaoTestCase
         ContaoKernel::fromRequest($this->getTempDir(), Request::create('/'));
 
         $this->assertSame(['{1.1.1.1}i', '{2.2.2.2}i'], Request::getTrustedHosts());
+
+        unset($_SERVER['TRUSTED_HOSTS']);
     }
 
     public function testEnablesRequestHttpMethodParameterOverride(): void


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | partly solves #2316 
| Docs PR or issue | -

I'm working on test isolation. This part is about handling global variables.

This PR adds/sets...
1) missing `unset()` statements for global variables,
2) process isolation where needed,
3) debug mode to `false` when comparing templates.
