### PR TITLE
Do not try to generate fragments for generated fragments

### DIFF
--- a/core-bundle/src/DependencyInjection/Compiler/RegisterFragmentsPass.php
+++ b/core-bundle/src/DependencyInjection/Compiler/RegisterFragmentsPass.php
@@ -83,10 +83,10 @@ class RegisterFragmentsPass implements CompilerPassInterface
         $command = $container->hasDefinition('contao.command.debug_fragments') ? $container->findDefinition('contao.command.debug_fragments') : null;
 
         foreach ($this->findAndSortTaggedServices($tag, $container) as $reference) {
-            // If a controller has multiple methods for different fragment type (e.g. a content element
-            // and a front end module), the first RegisterFragmentsPass creates a child definition that
-            // inherits all tags from the original. On the next run, the RegisterFragmentsPass would
-            // pick up the child definition and try to create duplicate fragments.
+            // If a controller has multiple methods for different fragment types (e.g. a content
+            // element and a front end module), the first pass creates a child definition that
+            // inherits all tags from the original. On the next run, the pass would pick up the
+            // child definition and try to create duplicate fragments.
             if (0 === strpos((string) $reference, 'contao.fragment._')) {
                 continue;
             }

--- a/core-bundle/src/DependencyInjection/Compiler/RegisterFragmentsPass.php
+++ b/core-bundle/src/DependencyInjection/Compiler/RegisterFragmentsPass.php
@@ -83,6 +83,14 @@ class RegisterFragmentsPass implements CompilerPassInterface
         $command = $container->hasDefinition('contao.command.debug_fragments') ? $container->findDefinition('contao.command.debug_fragments') : null;
 
         foreach ($this->findAndSortTaggedServices($tag, $container) as $reference) {
+            // If a controller has multiple methods for different fragment type (e.g. a content element
+            // and a front end module), the first RegisterFragmentsPass creates a child definition that
+            // inherits all tags from the original. On the next run, the RegisterFragmentsPass would
+            // pick up the child definition and try to create duplicate fragments.
+            if (0 === strpos((string) $reference, 'contao.fragment._')) {
+                continue;
+            }
+
             $definition = $container->findDefinition($reference);
 
             $tags = $definition->getTag($tag);


### PR DESCRIPTION
If a fragment has multiple methods with different fragment type (e.g. a content element and a front end module), the first RegisterFragmentsPass creates a child definition that inherits all tags from the original. On the next run, the RegisterFragmentsPass would pick up the child definition and try to create duplicate fragments.