### PR TITLE
Increase the undo period

### DIFF
--- a/core-bundle/src/Resources/contao/config/default.php
+++ b/core-bundle/src/Resources/contao/config/default.php
@@ -69,7 +69,7 @@ $GLOBALS['TL_CONFIG']['gdMaxImgWidth']  = 3000;
 $GLOBALS['TL_CONFIG']['gdMaxImgHeight'] = 3000;
 
 // Timeout values
-$GLOBALS['TL_CONFIG']['undoPeriod']     = 86400;
+$GLOBALS['TL_CONFIG']['undoPeriod']     = 2592000;
 $GLOBALS['TL_CONFIG']['versionPeriod']  = 7776000;
 $GLOBALS['TL_CONFIG']['logPeriod']      = 604800;
 $GLOBALS['TL_CONFIG']['sessionTimeout'] = 3600;


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | -
| Docs PR or issue | -

I really think the default undo period of 24h is not a good default (which is why I think it should be changed in 4.9 LTS too).

For me, there are two use cases our current undo system can cover:

1. The immediate "Oh, I deleted something which I shouldn't have" case: 24 hours are enough
2. The customer did something over the weekend and you get a report on Monday that something was deleted: 24 hours are likely not enough.

So 30 days by default seem totally okay to me. It makes no sense to store undo entries that date back a year or so.
