### PR TITLE
Ensure language files are loaded when adding default labels

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/DcaLoader.php
+++ b/core-bundle/src/Resources/contao/library/Contao/DcaLoader.php
@@ -138,6 +138,8 @@ class DcaLoader extends Controller
 	 */
 	private function addDefaultLabels($blnNoCache)
 	{
+		$this->loadLanguageFile($this->strTable, null, $blnNoCache);
+
 		// Return if there are no labels
 		if (!isset(static::$arrLanguageFiles[$this->strTable]))
 		{


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | -
| Docs PR or issue | -

In Contao 4.9 you do not have to provide a dedicated `label` key for each field of your data container in the data container array, as `DcaLoader::loadDcaFiles` will automatically add the labels from `$GLOBALS['TL_LANG']` when present.

However, this will fail if `Controller::loadDataContainer` or `DcaLoader::load` is executed for a DCA _before_ its language files have been loaded. Thus `DcaLoader::addDefaultLabels` also needs to ensure that the language files have already been loaded.

This might happen in unexpected circumstances. Suppose you have a `tl_foo` DCA with a `FooModel`. If you now execute the following somewhere:

```
$fooModel = new FooModel();

System::loadLanguageFile('tl_foo');
Controller::loadDataContainer('tl_foo');
```
then the labels within `$GLOBALS['TL_DCA']['tl_foo']['fields']` will be empty, because `\Contao\Model::__construct()` already loads the DCA of `tl_foo`, but before the language files of `tl_foo` have been loaded in this case.
