### PR TITLE
Fix the execution order of DCA callbacks registered via annotations or service tags

### DIFF
--- a/core-bundle/src/DependencyInjection/Compiler/DataContainerCallbackPass.php
+++ b/core-bundle/src/DependencyInjection/Compiler/DataContainerCallbackPass.php
@@ -86,6 +86,8 @@ class DataContainerCallbackPass implements CompilerPassInterface
             $serviceId,
             $this->getMethod($attributes, $class, $serviceId),
         ];
+
+        krsort($callbacks[$attributes['table']][$attributes['target']], SORT_NUMERIC);
     }
 
     private function getMethod(array $attributes, string $class, string $serviceId): string

--- a/core-bundle/tests/DependencyInjection/Compiler/DataContainerCallbackPassTest.php
+++ b/core-bundle/tests/DependencyInjection/Compiler/DataContainerCallbackPassTest.php
@@ -405,7 +405,7 @@ class DataContainerCallbackPassTest extends TestCase
             [
                 'table' => 'tl_page',
                 'target' => 'config.onload',
-                'method' => 'onLoadFirst',
+                'method' => 'onLoadSecond',
                 'priority' => 10,
             ]
         );
@@ -415,8 +415,18 @@ class DataContainerCallbackPassTest extends TestCase
             [
                 'table' => 'tl_page',
                 'target' => 'config.onload',
-                'method' => 'onLoadSecond',
+                'method' => 'onLoadFirst',
                 'priority' => 100,
+            ]
+        );
+
+        $definitionB->addTag(
+            'contao.callback',
+            [
+                'table' => 'tl_page',
+                'target' => 'config.onload',
+                'method' => 'onLoadLast',
+                'priority' => -50,
             ]
         );
 
@@ -431,12 +441,15 @@ class DataContainerCallbackPassTest extends TestCase
             [
                 'tl_page' => [
                     'config.onload_callback' => [
-                        10 => [
-                            ['test.callback_listener.a', 'onLoadCallback'],
+                        100 => [
                             ['test.callback_listener.b', 'onLoadFirst'],
                         ],
-                        100 => [
+                        10 => [
+                            ['test.callback_listener.a', 'onLoadCallback'],
                             ['test.callback_listener.b', 'onLoadSecond'],
+                        ],
+                        -50 => [
+                            ['test.callback_listener.b', 'onLoadLast'],
                         ],
                     ],
                 ],

--- a/core-bundle/tests/Fixtures/src/EventListener/TestListener.php
+++ b/core-bundle/tests/Fixtures/src/EventListener/TestListener.php
@@ -54,6 +54,10 @@ class TestListener
     {
     }
 
+    public function onLoadLast(): void
+    {
+    }
+
     public function onArticleWizard(): void
     {
     }


### PR DESCRIPTION
Up until now the priority of DCA callbacks registered via annotations or service tags was irrelevant:

```
tl_page => [
    list.operations.articles.button_callback => [
        0 => […],
        16 => […],
        -16 => […],
    ],    
],
```

This PR should fix it and put in correct order:

```
tl_page => [
    list.operations.articles.button_callback => [
        16 => […],
        0 => […],
        -16 => […],
    ],    
],
```

[According to the documentation](https://docs.contao.org/dev/framework/dca/#using-service-tagging) the callback with highest priority should be executed first.