### PR TITLE
Do not index preview URLs for searching

### DIFF
--- a/core-bundle/tests/EventListener/SearchIndexListenerTest.php
+++ b/core-bundle/tests/EventListener/SearchIndexListenerTest.php
@@ -121,5 +121,24 @@ class SearchIndexListenerTest extends TestCase
             false,
             false,
         ];
+
+        $response = new Response('<html><body><script type="application/ld+json">{"@context":"https:\/\/contao.org\/","@type":"Page","pageId":2,"noSearch":false,"protected":false,"groups":[],"fePreview":false}</script></body></html>', 403);
+        $response->headers->set('X-Robots-Tag', 'noindex');
+
+        yield 'Should not be handled because the X-Robots-Tag header contains "noindex" ' => [
+            Request::create('/foobar'),
+            $response,
+            SearchIndexListener::FEATURE_DELETE | SearchIndexListener::FEATURE_INDEX,
+            false,
+            false,
+        ];
+
+        yield 'Should not be handled because the meta robots tag contains "noindex" ' => [
+            Request::create('/foobar'),
+            new Response('<html><head><meta name="robots" content="noindex,nofollow"/></head><body><script type="application/ld+json">{"@context":"https:\/\/contao.org\/","@type":"Page","pageId":2,"noSearch":false,"protected":false,"groups":[],"fePreview":false}</script></body></html>', 403),
+            SearchIndexListener::FEATURE_DELETE | SearchIndexListener::FEATURE_INDEX,
+            false,
+            false,
+        ];
     }
 }

--- a/manager-bundle/src/Resources/skeleton/web/preview.php
+++ b/manager-bundle/src/Resources/skeleton/web/preview.php
@@ -30,6 +30,9 @@ $request = Request::createFromGlobals();
 $kernel = ContaoKernel::fromRequest(\dirname(__DIR__), $request);
 $response = $kernel->handle($request);
 
+// Prevent preview URLs from being indexed
+$response->headers->set('X-Robots-Tag', 'noindex');
+
 // Force no-cache on all responses in the preview front controller
 $response->headers->set('Cache-Control', 'no-store');
 


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #2507
| Docs PR or issue | -

@Toflar: If the `X-Robots-Tag` header or the meta robots tag contains `noindex`, the listener will not pass the document to the indexer at all. This means that potentially existing entries will not be deleted. Is this OK?
