### PR TITLE
Fix phpstan (ThrowMustBundlePreviousExceptionRule not found)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -159,6 +159,7 @@
         "slam/phpstan-extensions": "^5.0",
         "symfony/browser-kit": "4.4.*",
         "symfony/phpunit-bridge": "4.4.*",
+        "thecodingmachine/phpstan-strict-rules": "^0.12",
         "weirdan/doctrine-psalm-plugin": "^0.11"
     },
     "extra": {

--- a/monorepo.yml
+++ b/monorepo.yml
@@ -15,6 +15,7 @@ composer:
         psalm/plugin-phpunit: ^0.10
         psalm/plugin-symfony: ^1.0
         slam/phpstan-extensions: ^5.0
+        thecodingmachine/phpstan-strict-rules: ^0.12
         weirdan/doctrine-psalm-plugin: ^0.11
 
 repositories:


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | -
| Docs PR or issue | -

The `thecodingmachine/phpstan-strict-rules` dev dependency is missing in `4.10` and `master`, which is required for

https://github.com/contao/contao/blob/90caa2a8e8cd3f7e066628f7a84f5c12c32e15f3/phpstan.neon.dist#L10
