### PR TITLE
Restore compatibility with E_WARNING

### DIFF
--- a/calendar-bundle/src/Resources/contao/dca/tl_calendar.php
+++ b/calendar-bundle/src/Resources/contao/dca/tl_calendar.php
@@ -115,7 +115,7 @@ $GLOBALS['TL_DCA']['tl_calendar'] = array
 			(
 				'href'                => 'act=delete',
 				'icon'                => 'delete.svg',
-				'attributes'          => 'onclick="if(!confirm(\'' . $GLOBALS['TL_LANG']['MSC']['deleteConfirm'] . '\'))return false;Backend.getScrollOffset()"',
+				'attributes'          => 'onclick="if(!confirm(\'' . ($GLOBALS['TL_LANG']['MSC']['deleteConfirm'] ?? null) . '\'))return false;Backend.getScrollOffset()"',
 				'button_callback'     => array('tl_calendar', 'deleteCalendar')
 			),
 			'show' => array

--- a/calendar-bundle/src/Resources/contao/dca/tl_calendar_events.php
+++ b/calendar-bundle/src/Resources/contao/dca/tl_calendar_events.php
@@ -119,7 +119,7 @@ $GLOBALS['TL_DCA']['tl_calendar_events'] = array
 			(
 				'href'                => 'act=delete',
 				'icon'                => 'delete.svg',
-				'attributes'          => 'onclick="if(!confirm(\'' . $GLOBALS['TL_LANG']['MSC']['deleteConfirm'] . '\'))return false;Backend.getScrollOffset()"'
+				'attributes'          => 'onclick="if(!confirm(\'' . ($GLOBALS['TL_LANG']['MSC']['deleteConfirm'] ?? null) . '\'))return false;Backend.getScrollOffset()"'
 			),
 			'toggle' => array
 			(

--- a/calendar-bundle/src/Resources/contao/dca/tl_calendar_events.php
+++ b/calendar-bundle/src/Resources/contao/dca/tl_calendar_events.php
@@ -589,7 +589,7 @@ class tl_calendar_events extends Backend
 		// HOOK: comments extension required
 		if (!isset($bundles['ContaoCommentsBundle']))
 		{
-			$key = array_search('allowComments', $GLOBALS['TL_DCA']['tl_calendar_events']['list']['sorting']['headerFields']);
+			$key = array_search('allowComments', $GLOBALS['TL_DCA']['tl_calendar_events']['list']['sorting']['headerFields'] ?? array());
 			unset($GLOBALS['TL_DCA']['tl_calendar_events']['list']['sorting']['headerFields'][$key]);
 		}
 
@@ -1148,7 +1148,7 @@ class tl_calendar_events extends Backend
 		}
 
 		// Trigger the onload_callback
-		if (is_array($GLOBALS['TL_DCA']['tl_calendar_events']['config']['onload_callback']))
+		if (is_array($GLOBALS['TL_DCA']['tl_calendar_events']['config']['onload_callback'] ?? null))
 		{
 			foreach ($GLOBALS['TL_DCA']['tl_calendar_events']['config']['onload_callback'] as $callback)
 			{
@@ -1189,7 +1189,7 @@ class tl_calendar_events extends Backend
 		$objVersions->initialize();
 
 		// Trigger the save_callback
-		if (is_array($GLOBALS['TL_DCA']['tl_calendar_events']['fields']['featured']['save_callback']))
+		if (is_array($GLOBALS['TL_DCA']['tl_calendar_events']['fields']['featured']['save_callback'] ?? null))
 		{
 			foreach ($GLOBALS['TL_DCA']['tl_calendar_events']['fields']['featured']['save_callback'] as $callback)
 			{
@@ -1218,7 +1218,7 @@ class tl_calendar_events extends Backend
 		}
 
 		// Trigger the onsubmit_callback
-		if (is_array($GLOBALS['TL_DCA']['tl_calendar_events']['config']['onsubmit_callback']))
+		if (is_array($GLOBALS['TL_DCA']['tl_calendar_events']['config']['onsubmit_callback'] ?? null))
 		{
 			foreach ($GLOBALS['TL_DCA']['tl_calendar_events']['config']['onsubmit_callback'] as $callback)
 			{
@@ -1299,7 +1299,7 @@ class tl_calendar_events extends Backend
 		}
 
 		// Trigger the onload_callback
-		if (is_array($GLOBALS['TL_DCA']['tl_calendar_events']['config']['onload_callback']))
+		if (is_array($GLOBALS['TL_DCA']['tl_calendar_events']['config']['onload_callback'] ?? null))
 		{
 			foreach ($GLOBALS['TL_DCA']['tl_calendar_events']['config']['onload_callback'] as $callback)
 			{
@@ -1340,7 +1340,7 @@ class tl_calendar_events extends Backend
 		$objVersions->initialize();
 
 		// Trigger the save_callback
-		if (is_array($GLOBALS['TL_DCA']['tl_calendar_events']['fields']['published']['save_callback']))
+		if (is_array($GLOBALS['TL_DCA']['tl_calendar_events']['fields']['published']['save_callback'] ?? null))
 		{
 			foreach ($GLOBALS['TL_DCA']['tl_calendar_events']['fields']['published']['save_callback'] as $callback)
 			{
@@ -1369,7 +1369,7 @@ class tl_calendar_events extends Backend
 		}
 
 		// Trigger the onsubmit_callback
-		if (is_array($GLOBALS['TL_DCA']['tl_calendar_events']['config']['onsubmit_callback']))
+		if (is_array($GLOBALS['TL_DCA']['tl_calendar_events']['config']['onsubmit_callback'] ?? null))
 		{
 			foreach ($GLOBALS['TL_DCA']['tl_calendar_events']['config']['onsubmit_callback'] as $callback)
 			{

--- a/calendar-bundle/src/Resources/contao/dca/tl_calendar_feed.php
+++ b/calendar-bundle/src/Resources/contao/dca/tl_calendar_feed.php
@@ -100,7 +100,7 @@ $GLOBALS['TL_DCA']['tl_calendar_feed'] = array
 			(
 				'href'                => 'act=delete',
 				'icon'                => 'delete.svg',
-				'attributes'          => 'onclick="if(!confirm(\'' . $GLOBALS['TL_LANG']['MSC']['deleteConfirm'] . '\'))return false;Backend.getScrollOffset()"',
+				'attributes'          => 'onclick="if(!confirm(\'' . ($GLOBALS['TL_LANG']['MSC']['deleteConfirm'] ?? null) . '\'))return false;Backend.getScrollOffset()"',
 				'button_callback'     => array('tl_calendar_feed', 'deleteFeed')
 			),
 			'show' => array
@@ -193,11 +193,14 @@ $GLOBALS['TL_DCA']['tl_calendar_feed'] = array
 		),
 		'feedBase' => array
 		(
-			'default'                 => Environment::get('base'),
 			'exclude'                 => true,
 			'search'                  => true,
 			'inputType'               => 'text',
 			'eval'                    => array('trailingSlash'=>true, 'rgxp'=>'url', 'decodeEntities'=>true, 'maxlength'=>255, 'tl_class'=>'w50'),
+			'load_callback' => array
+			(
+				array('tl_calendar_feed', 'addFeedBase')
+			),
 			'sql'                     => "varchar(255) NOT NULL default ''"
 		),
 		'description' => array
@@ -559,6 +562,23 @@ class tl_calendar_feed extends Backend
 		if (in_array($varValue, $arrFeeds))
 		{
 			throw new Exception(sprintf($GLOBALS['TL_LANG']['ERR']['aliasExists'], $varValue));
+		}
+
+		return $varValue;
+	}
+
+	/**
+	 * Add the RSS-feed base URL
+	 *
+	 * @param mixed $varValue
+	 *
+	 * @return string
+	 */
+	public function addFeedBase($varValue)
+	{
+		if (!$varValue)
+		{
+			$varValue = Environment::get('base');
 		}
 
 		return $varValue;

--- a/calendar-bundle/src/Resources/contao/modules/ModuleEventMenu.php
+++ b/calendar-bundle/src/Resources/contao/modules/ModuleEventMenu.php
@@ -106,6 +106,11 @@ class ModuleEventMenu extends ModuleCalendar
 		{
 			foreach ($arrDay as $arrEvents)
 			{
+				if (!isset($arrData[substr($intDay, 0, 4)]))
+				{
+					$arrData[substr($intDay, 0, 4)] = 0;
+				}
+
 				$arrData[substr($intDay, 0, 4)] += \count($arrEvents);
 			}
 		}
@@ -161,6 +166,11 @@ class ModuleEventMenu extends ModuleCalendar
 		{
 			foreach ($arrDay as $arrEvents)
 			{
+				if (!isset($arrData[substr($intDay, 0, 4)][substr($intDay, 4, 2)]))
+				{
+					$arrData[substr($intDay, 0, 4)][substr($intDay, 4, 2)] = 0;
+				}
+
 				$arrData[substr($intDay, 0, 4)][substr($intDay, 4, 2)] += \count($arrEvents);
 			}
 		}

--- a/calendar-bundle/src/Resources/contao/modules/ModuleEventReader.php
+++ b/calendar-bundle/src/Resources/contao/modules/ModuleEventReader.php
@@ -284,6 +284,7 @@ class ModuleEventReader extends Events
 		}
 
 		$objTemplate->addImage = false;
+		$objTemplate->addBefore = false;
 
 		// Add an image
 		if ($objEvent->addImage && $objEvent->singleSRC)

--- a/calendar-bundle/src/Resources/contao/modules/ModuleEventlist.php
+++ b/calendar-bundle/src/Resources/contao/modules/ModuleEventlist.php
@@ -355,6 +355,7 @@ class ModuleEventlist extends Events
 			}
 
 			$objTemplate->addImage = false;
+			$objTemplate->addBefore = false;
 
 			// Add an image
 			if ($event['addImage'] && $event['singleSRC'])

--- a/comments-bundle/src/Resources/contao/classes/Comments.php
+++ b/comments-bundle/src/Resources/contao/classes/Comments.php
@@ -254,7 +254,7 @@ class Comments extends Frontend
 		foreach ($arrFields as $arrField)
 		{
 			/** @var Widget $strClass */
-			$strClass = $GLOBALS['TL_FFL'][$arrField['inputType']];
+			$strClass = $GLOBALS['TL_FFL'][$arrField['inputType']] ?? null;
 
 			// Continue if the class is not defined
 			if (!class_exists($strClass))
@@ -262,10 +262,10 @@ class Comments extends Frontend
 				continue;
 			}
 
-			$arrField['eval']['required'] = $arrField['eval']['mandatory'];
+			$arrField['eval']['required'] = $arrField['eval']['mandatory'] ?? null;
 
 			/** @var Widget $objWidget */
-			$objWidget = new $strClass($strClass::getAttributesFromDca($arrField, $arrField['name'], $arrField['value']));
+			$objWidget = new $strClass($strClass::getAttributesFromDca($arrField, $arrField['name'], $arrField['value'] ?? null));
 
 			// Append the parent ID to prevent duplicate IDs (see #1493)
 			$objWidget->id .= '_' . $intParent;

--- a/comments-bundle/src/Resources/contao/dca/tl_comments.php
+++ b/comments-bundle/src/Resources/contao/dca/tl_comments.php
@@ -96,7 +96,7 @@ $GLOBALS['TL_DCA']['tl_comments'] = array
 			(
 				'href'                => 'act=delete',
 				'icon'                => 'delete.svg',
-				'attributes'          => 'onclick="if(!confirm(\'' . $GLOBALS['TL_LANG']['MSC']['deleteConfirm'] . '\'))return false;Backend.getScrollOffset()"',
+				'attributes'          => 'onclick="if(!confirm(\'' . ($GLOBALS['TL_LANG']['MSC']['deleteConfirm'] ?? null) . '\'))return false;Backend.getScrollOffset()"',
 				'button_callback'     => array('tl_comments', 'deleteComment')
 			),
 			'toggle' => array

--- a/comments-bundle/src/Resources/contao/dca/tl_comments.php
+++ b/comments-bundle/src/Resources/contao/dca/tl_comments.php
@@ -677,7 +677,7 @@ class tl_comments extends Backend
 		}
 
 		// Trigger the onload_callback
-		if (is_array($GLOBALS['TL_DCA']['tl_comments']['config']['onload_callback']))
+		if (is_array($GLOBALS['TL_DCA']['tl_comments']['config']['onload_callback'] ?? null))
 		{
 			foreach ($GLOBALS['TL_DCA']['tl_comments']['config']['onload_callback'] as $callback)
 			{
@@ -718,7 +718,7 @@ class tl_comments extends Backend
 		$objVersions->initialize();
 
 		// Trigger the save_callback
-		if (is_array($GLOBALS['TL_DCA']['tl_comments']['fields']['published']['save_callback']))
+		if (is_array($GLOBALS['TL_DCA']['tl_comments']['fields']['published']['save_callback'] ?? null))
 		{
 			foreach ($GLOBALS['TL_DCA']['tl_comments']['fields']['published']['save_callback'] as $callback)
 			{
@@ -747,7 +747,7 @@ class tl_comments extends Backend
 		}
 
 		// Trigger the onsubmit_callback
-		if (is_array($GLOBALS['TL_DCA']['tl_comments']['config']['onsubmit_callback']))
+		if (is_array($GLOBALS['TL_DCA']['tl_comments']['config']['onsubmit_callback'] ?? null))
 		{
 			foreach ($GLOBALS['TL_DCA']['tl_comments']['config']['onsubmit_callback'] as $callback)
 			{

--- a/core-bundle/src/Command/DebugDcaCommand.php
+++ b/core-bundle/src/Command/DebugDcaCommand.php
@@ -15,6 +15,7 @@ namespace Contao\CoreBundle\Command;
 use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\DcaLoader;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Exception\InvalidArgumentException;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -57,6 +58,10 @@ class DebugDcaCommand extends Command
         $this->framework->initialize();
         $dcaLoader = $this->framework->createInstance(DcaLoader::class, [$table]);
         $dcaLoader->load();
+
+        if (!isset($GLOBALS['TL_DCA'][$table])) {
+            throw new InvalidArgumentException('Invalid table name: '.$table);
+        }
 
         $cloner = new VarCloner();
         $dumper = new CliDumper();

--- a/core-bundle/src/DependencyInjection/Configuration.php
+++ b/core-bundle/src/DependencyInjection/Configuration.php
@@ -58,10 +58,10 @@ class Configuration implements ConfigurationInterface
                     ->defaultValue('%kernel.secret%')
                 ->end()
                 ->integerNode('error_level')
-                    ->info('The error reporting level set when the framework is initialized.')
+                    ->info('The error reporting level set when the framework is initialized. Defaults to E_ALL & ~E_NOTICE & ~E_DEPRECATED & ~E_USER_DEPRECATED.')
                     ->min(-1)
                     ->max(32767)
-                    ->defaultValue($this->getErrorLevel())
+                    ->defaultValue(E_ALL & ~E_NOTICE & ~E_DEPRECATED & ~E_USER_DEPRECATED)
                 ->end()
                 ->booleanNode('legacy_routing')
                     ->defaultTrue()
@@ -445,19 +445,6 @@ class Configuration implements ConfigurationInterface
                 ->end()
             ->end()
         ;
-    }
-
-    private function getErrorLevel(): int
-    {
-        if (PHP_MAJOR_VERSION < 8) {
-            return E_ALL & ~E_NOTICE & ~E_DEPRECATED & ~E_USER_DEPRECATED;
-        }
-
-        // Disable E_WARNING in PHP 8, because a number of notices have been
-        // converted into warnings and now cause a lot of issues with undefined
-        // array keys and undefined properties.
-        // @see https://www.php.net/manual/de/migration80.incompatible.php
-        return E_ALL & ~E_WARNING & ~E_NOTICE & ~E_DEPRECATED & ~E_USER_DEPRECATED;
     }
 
     /**

--- a/core-bundle/src/EventListener/DataContainer/ContentCompositionListener.php
+++ b/core-bundle/src/EventListener/DataContainer/ContentCompositionListener.php
@@ -185,7 +185,7 @@ class ContentCompositionListener
      */
     public function renderArticlePasteButton(DataContainer $dc, array $row, string $table, bool $cr, array $clipboard = null): string
     {
-        if ($table === $GLOBALS['TL_DCA'][$dc->table]['config']['ptable']) {
+        if ($table === ($GLOBALS['TL_DCA'][$dc->table]['config']['ptable'] ?? null)) {
             return $this->renderArticlePasteIntoButton($dc, $row, $cr, $clipboard);
         }
 

--- a/core-bundle/src/Image/ImageSizes.php
+++ b/core-bundle/src/Image/ImageSizes.php
@@ -133,7 +133,7 @@ class ImageSizes implements ResetInterface
         // The framework is required to have the TL_CROP options available
         $this->framework->initialize();
 
-        $this->options = $GLOBALS['TL_CROP'] ?? array();
+        $this->options = $GLOBALS['TL_CROP'] ?? [];
 
         $rows = $this->connection->fetchAllAssociative(
             'SELECT

--- a/core-bundle/src/Image/ImageSizes.php
+++ b/core-bundle/src/Image/ImageSizes.php
@@ -133,7 +133,7 @@ class ImageSizes implements ResetInterface
         // The framework is required to have the TL_CROP options available
         $this->framework->initialize();
 
-        $this->options = $GLOBALS['TL_CROP'];
+        $this->options = $GLOBALS['TL_CROP'] ?? array();
 
         $rows = $this->connection->fetchAllAssociative(
             'SELECT

--- a/core-bundle/src/Image/Studio/Figure.php
+++ b/core-bundle/src/Image/Studio/Figure.php
@@ -322,7 +322,7 @@ final class Figure
         }
 
         // Other
-        if (null !== $floating) {
+        if ($floating) {
             $templateData['floatClass'] = " float_$floating";
         }
 

--- a/core-bundle/src/Migration/Version401/Version410Update.php
+++ b/core-bundle/src/Migration/Version401/Version410Update.php
@@ -60,7 +60,7 @@ class Version410Update extends AbstractMigration
     {
         $this->framework->initialize();
 
-        $crop = $GLOBALS['TL_CROP'];
+        $crop = $GLOBALS['TL_CROP'] ?? array();
 
         if (empty($crop)) {
             return $this->createResult(true);

--- a/core-bundle/src/Migration/Version401/Version410Update.php
+++ b/core-bundle/src/Migration/Version401/Version410Update.php
@@ -60,7 +60,7 @@ class Version410Update extends AbstractMigration
     {
         $this->framework->initialize();
 
-        $crop = $GLOBALS['TL_CROP'] ?? array();
+        $crop = $GLOBALS['TL_CROP'] ?? [];
 
         if (empty($crop)) {
             return $this->createResult(true);

--- a/core-bundle/src/Picker/AbstractTablePickerProvider.php
+++ b/core-bundle/src/Picker/AbstractTablePickerProvider.php
@@ -132,7 +132,8 @@ abstract class AbstractTablePickerProvider implements PickerProviderInterface, D
         $this->framework->initialize();
         $this->framework->createInstance(DcaLoader::class, [$table])->load();
 
-        return $this->getDataContainer() === $GLOBALS['TL_DCA'][$table]['config']['dataContainer']
+        return isset($GLOBALS['TL_DCA'][$table]['config']['dataContainer'])
+            && $this->getDataContainer() === $GLOBALS['TL_DCA'][$table]['config']['dataContainer']
             && 0 !== \count($this->getModulesForTable($table));
     }
 

--- a/core-bundle/src/Resources/contao/classes/Ajax.php
+++ b/core-bundle/src/Resources/contao/classes/Ajax.php
@@ -203,8 +203,13 @@ class Ajax extends Backend
 				$varValue = null;
 				$strField = $dc->field = Input::post('name');
 
+				if (!isset($GLOBALS['TL_DCA'][$dc->table]['fields'][$strField]))
+				{
+					throw new BadRequestHttpException('Invalid field name: ' . $strField);
+				}
+
 				// Call the load_callback
-				if (\is_array($GLOBALS['TL_DCA'][$dc->table]['fields'][$strField]['load_callback']))
+				if (\is_array($GLOBALS['TL_DCA'][$dc->table]['fields'][$strField]['load_callback'] ?? null))
 				{
 					foreach ($GLOBALS['TL_DCA'][$dc->table]['fields'][$strField]['load_callback'] as $callback)
 					{
@@ -233,8 +238,13 @@ class Ajax extends Backend
 				$varValue = null;
 				$strField = $dc->field = Input::post('name');
 
+				if (!isset($GLOBALS['TL_DCA'][$dc->table]['fields'][$strField]))
+				{
+					throw new BadRequestHttpException('Invalid field name: ' . $strField);
+				}
+
 				// Call the load_callback
-				if (\is_array($GLOBALS['TL_DCA'][$dc->table]['fields'][$strField]['load_callback']))
+				if (\is_array($GLOBALS['TL_DCA'][$dc->table]['fields'][$strField]['load_callback'] ?? null))
 				{
 					foreach ($GLOBALS['TL_DCA'][$dc->table]['fields'][$strField]['load_callback'] as $callback)
 					{
@@ -283,9 +293,7 @@ class Ajax extends Backend
 				// The field does not exist
 				if (!isset($GLOBALS['TL_DCA'][$dc->table]['fields'][$strField]))
 				{
-					$this->log('Field "' . $strField . '" does not exist in DCA "' . $dc->table . '"', __METHOD__, TL_ERROR);
-
-					throw new BadRequestHttpException('Bad request');
+					throw new BadRequestHttpException('Invalid field name: ' . $strField);
 				}
 
 				$objRow = null;
@@ -294,7 +302,7 @@ class Ajax extends Backend
 				// Load the value
 				if (Input::get('act') != 'overrideAll')
 				{
-					if ($GLOBALS['TL_DCA'][$dc->table]['config']['dataContainer'] == 'File')
+					if (($GLOBALS['TL_DCA'][$dc->table]['config']['dataContainer'] ?? null) == 'File')
 					{
 						$varValue = Config::get($strField);
 					}
@@ -317,7 +325,7 @@ class Ajax extends Backend
 				}
 
 				// Call the load_callback
-				if (\is_array($GLOBALS['TL_DCA'][$dc->table]['fields'][$strField]['load_callback']))
+				if (\is_array($GLOBALS['TL_DCA'][$dc->table]['fields'][$strField]['load_callback'] ?? null))
 				{
 					foreach ($GLOBALS['TL_DCA'][$dc->table]['fields'][$strField]['load_callback'] as $callback)
 					{
@@ -409,7 +417,7 @@ class Ajax extends Backend
 				$this->import(BackendUser::class, 'User');
 
 				// Check whether the field is a selector field and allowed for regular users (thanks to Fabian Mihailowitsch) (see #4427)
-				if (!\is_array($GLOBALS['TL_DCA'][$dc->table]['palettes']['__selector__']) || !\in_array(Input::post('field'), $GLOBALS['TL_DCA'][$dc->table]['palettes']['__selector__']) || ($GLOBALS['TL_DCA'][$dc->table]['fields'][Input::post('field')]['exclude'] && !$this->User->hasAccess($dc->table . '::' . Input::post('field'), 'alexf')))
+				if (!\is_array($GLOBALS['TL_DCA'][$dc->table]['palettes']['__selector__'] ?? null) || !\in_array(Input::post('field'), $GLOBALS['TL_DCA'][$dc->table]['palettes']['__selector__']) || (($GLOBALS['TL_DCA'][$dc->table]['fields'][Input::post('field')]['exclude'] ?? null) && !$this->User->hasAccess($dc->table . '::' . Input::post('field'), 'alexf')))
 				{
 					$this->log('Field "' . Input::post('field') . '" is not an allowed selector field (possible SQL injection attempt)', __METHOD__, TL_ERROR);
 

--- a/core-bundle/src/Resources/contao/classes/Ajax.php
+++ b/core-bundle/src/Resources/contao/classes/Ajax.php
@@ -226,7 +226,7 @@ class Ajax extends Backend
 				}
 
 				/** @var PageSelector $strClass */
-				$strClass = $GLOBALS['BE_FFL']['pageSelector'];
+				$strClass = $GLOBALS['BE_FFL']['pageSelector'] ?? null;
 
 				/** @var PageSelector $objWidget */
 				$objWidget = new $strClass($strClass::getAttributesFromDca($GLOBALS['TL_DCA'][$dc->table]['fields'][$strField], $dc->field, $varValue, $strField, $dc->table, $dc));
@@ -261,7 +261,7 @@ class Ajax extends Backend
 				}
 
 				/** @var FileSelector $strClass */
-				$strClass = $GLOBALS['BE_FFL']['fileSelector'];
+				$strClass = $GLOBALS['BE_FFL']['fileSelector'] ?? null;
 
 				/** @var FileSelector $objWidget */
 				$objWidget = new $strClass($strClass::getAttributesFromDca($GLOBALS['TL_DCA'][$dc->table]['fields'][$strField], $dc->field, $varValue, $strField, $dc->table, $dc));
@@ -391,7 +391,7 @@ class Ajax extends Backend
 				}
 
 				/** @var FileTree|PageTree|Picker $strClass */
-				$strClass = $GLOBALS['BE_FFL'][$strKey];
+				$strClass = $GLOBALS['BE_FFL'][$strKey] ?? null;
 
 				/** @var FileTree|PageTree|Picker $objWidget */
 				$objWidget = new $strClass($strClass::getAttributesFromDca($GLOBALS['TL_DCA'][$dc->table]['fields'][$strField], $dc->inputName, $varValue, $strField, $dc->table, $dc));

--- a/core-bundle/src/Resources/contao/classes/Backend.php
+++ b/core-bundle/src/Resources/contao/classes/Backend.php
@@ -382,11 +382,11 @@ abstract class Backend extends Controller
 			$this->loadDataContainer($strTable);
 
 			// Include all excluded fields which are allowed for the current user
-			if ($GLOBALS['TL_DCA'][$strTable]['fields'])
+			if (\is_array($GLOBALS['TL_DCA'][$strTable]['fields'] ?? null))
 			{
 				foreach ($GLOBALS['TL_DCA'][$strTable]['fields'] as $k=>$v)
 				{
-					if ($v['exclude'] && $this->User->hasAccess($strTable . '::' . $k, 'alexf'))
+					if (($v['exclude'] ?? null) && $this->User->hasAccess($strTable . '::' . $k, 'alexf'))
 					{
 						if ($strTable == 'tl_user_group')
 						{
@@ -399,7 +399,7 @@ abstract class Backend extends Controller
 			}
 
 			// Fabricate a new data container object
-			if (!$GLOBALS['TL_DCA'][$strTable]['config']['dataContainer'])
+			if (!($GLOBALS['TL_DCA'][$strTable]['config']['dataContainer'] ?? null))
 			{
 				$this->log('Missing data container for table "' . $strTable . '"', __METHOD__, TL_ERROR);
 				trigger_error('Could not create a data container object', E_USER_ERROR);
@@ -518,9 +518,9 @@ abstract class Backend extends Controller
 
 				$pid = $dc->id;
 				$table = $strTable;
-				$ptable = ($act != 'edit') ? $GLOBALS['TL_DCA'][$strTable]['config']['ptable'] : $strTable;
+				$ptable = ($act != 'edit') ? ($GLOBALS['TL_DCA'][$strTable]['config']['ptable'] ?? null) : $strTable;
 
-				while ($ptable && !\in_array($GLOBALS['TL_DCA'][$table]['list']['sorting']['mode'], array(5, 6)))
+				while ($ptable && !\in_array($GLOBALS['TL_DCA'][$table]['list']['sorting']['mode'] ?? null, array(5, 6)))
 				{
 					$objRow = $this->Database->prepare("SELECT * FROM " . $ptable . " WHERE id=?")
 											 ->limit(1)
@@ -556,7 +556,7 @@ abstract class Backend extends Controller
 					// Next parent table
 					$pid = $objRow->pid;
 					$table = $ptable;
-					$ptable = ($GLOBALS['TL_DCA'][$ptable]['config']['dynamicPtable']) ? $objRow->ptable : $GLOBALS['TL_DCA'][$ptable]['config']['ptable'];
+					$ptable = ($GLOBALS['TL_DCA'][$ptable]['config']['dynamicPtable'] ?? null) ? $objRow->ptable : ($GLOBALS['TL_DCA'][$ptable]['config']['ptable'] ?? null);
 				}
 
 				// Add the last parent table

--- a/core-bundle/src/Resources/contao/classes/Backend.php
+++ b/core-bundle/src/Resources/contao/classes/Backend.php
@@ -337,7 +337,7 @@ abstract class Backend extends Controller
 		$objSession = System::getContainer()->get('session');
 
 		$arrTables = $arrModule['tables'] ?? array();
-		$strTable = Input::get('table') ?? $arrTables[0] ?? null;
+		$strTable = Input::get('table') ?: ($arrTables[0] ?? null);
 		$id = (!Input::get('act') && Input::get('id')) ? Input::get('id') : $objSession->get('CURRENT_ID');
 
 		// Store the current ID in the current session

--- a/core-bundle/src/Resources/contao/classes/Backend.php
+++ b/core-bundle/src/Resources/contao/classes/Backend.php
@@ -399,7 +399,7 @@ abstract class Backend extends Controller
 			}
 
 			// Fabricate a new data container object
-			if (!($GLOBALS['TL_DCA'][$strTable]['config']['dataContainer'] ?? null))
+			if (!isset($GLOBALS['TL_DCA'][$strTable]['config']['dataContainer']))
 			{
 				$this->log('Missing data container for table "' . $strTable . '"', __METHOD__, TL_ERROR);
 				trigger_error('Could not create a data container object', E_USER_ERROR);
@@ -518,7 +518,7 @@ abstract class Backend extends Controller
 
 				$pid = $dc->id;
 				$table = $strTable;
-				$ptable = ($act != 'edit') ? ($GLOBALS['TL_DCA'][$strTable]['config']['ptable'] ?? null) : $strTable;
+				$ptable = $act != 'edit' ? ($GLOBALS['TL_DCA'][$strTable]['config']['ptable'] ?? null) : $strTable;
 
 				while ($ptable && !\in_array($GLOBALS['TL_DCA'][$table]['list']['sorting']['mode'] ?? null, array(5, 6)))
 				{

--- a/core-bundle/src/Resources/contao/classes/Backend.php
+++ b/core-bundle/src/Resources/contao/classes/Backend.php
@@ -426,7 +426,7 @@ abstract class Backend extends Controller
 		}
 
 		// Trigger the module callback
-		elseif (class_exists($arrModule['callback']))
+		elseif (class_exists($arrModule['callback'] ?? null))
 		{
 			/** @var Module $objCallback */
 			$objCallback = new $arrModule['callback']($dc);

--- a/core-bundle/src/Resources/contao/classes/Backend.php
+++ b/core-bundle/src/Resources/contao/classes/Backend.php
@@ -336,7 +336,7 @@ abstract class Backend extends Controller
 		/** @var Session $objSession */
 		$objSession = System::getContainer()->get('session');
 
-		$arrTables = $arrModule['tables'] ?? array();
+		$arrTables = (array) ($arrModule['tables'] ?? array());
 		$strTable = Input::get('table') ?: ($arrTables[0] ?? null);
 		$id = (!Input::get('act') && Input::get('id')) ? Input::get('id') : $objSession->get('CURRENT_ID');
 

--- a/core-bundle/src/Resources/contao/classes/Backend.php
+++ b/core-bundle/src/Resources/contao/classes/Backend.php
@@ -336,8 +336,8 @@ abstract class Backend extends Controller
 		/** @var Session $objSession */
 		$objSession = System::getContainer()->get('session');
 
-		$arrTables = (array) $arrModule['tables'];
-		$strTable = Input::get('table') ?: $arrTables[0];
+		$arrTables = $arrModule['tables'] ?? array();
+		$strTable = Input::get('table') ?? $arrTables[0] ?? null;
 		$id = (!Input::get('act') && Input::get('id')) ? Input::get('id') : $objSession->get('CURRENT_ID');
 
 		// Store the current ID in the current session

--- a/core-bundle/src/Resources/contao/classes/BackendUser.php
+++ b/core-bundle/src/Resources/contao/classes/BackendUser.php
@@ -519,7 +519,7 @@ class BackendUser extends User
 			{
 				$arrModules[$strGroupName]['class'] = 'group-' . $strGroupName . ' node-expanded';
 				$arrModules[$strGroupName]['title'] = StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['collapseNode']);
-				$arrModules[$strGroupName]['label'] = (($label = \is_array($GLOBALS['TL_LANG']['MOD'][$strGroupName]) ? $GLOBALS['TL_LANG']['MOD'][$strGroupName][0] : $GLOBALS['TL_LANG']['MOD'][$strGroupName]) != false) ? $label : $strGroupName;
+				$arrModules[$strGroupName]['label'] = ($label = \is_array($GLOBALS['TL_LANG']['MOD'][$strGroupName] ?? null) ? $GLOBALS['TL_LANG']['MOD'][$strGroupName][0] : ($GLOBALS['TL_LANG']['MOD'][$strGroupName] ?? null)) ? $label : $strGroupName;
 				$arrModules[$strGroupName]['href'] = $router->generate('contao_backend', array('do'=>Input::get('do'), 'mtg'=>$strGroupName, 'ref'=>$strRefererId));
 				$arrModules[$strGroupName]['ajaxUrl'] = $router->generate('contao_backend');
 				$arrModules[$strGroupName]['icon'] = 'modPlus.gif'; // backwards compatibility with e.g. EasyThemes
@@ -534,7 +534,7 @@ class BackendUser extends User
 					{
 						$arrModules[$strGroupName]['modules'][$strModuleName] = $arrModuleConfig;
 						$arrModules[$strGroupName]['modules'][$strModuleName]['title'] = StringUtil::specialchars($GLOBALS['TL_LANG']['MOD'][$strModuleName][1]);
-						$arrModules[$strGroupName]['modules'][$strModuleName]['label'] = (($label = \is_array($GLOBALS['TL_LANG']['MOD'][$strModuleName]) ? $GLOBALS['TL_LANG']['MOD'][$strModuleName][0] : $GLOBALS['TL_LANG']['MOD'][$strModuleName]) != false) ? $label : $strModuleName;
+						$arrModules[$strGroupName]['modules'][$strModuleName]['label'] = ($label = \is_array($GLOBALS['TL_LANG']['MOD'][$strModuleName] ?? null) ? $GLOBALS['TL_LANG']['MOD'][$strModuleName][0] : ($GLOBALS['TL_LANG']['MOD'][$strModuleName] ?? null)) ? $label : $strModuleName;
 						$arrModules[$strGroupName]['modules'][$strModuleName]['class'] = 'navigation ' . $strModuleName;
 						$arrModules[$strGroupName]['modules'][$strModuleName]['href'] = $router->generate('contao_backend', array('do'=>$strModuleName, 'ref'=>$strRefererId));
 						$arrModules[$strGroupName]['modules'][$strModuleName]['isActive'] = false;

--- a/core-bundle/src/Resources/contao/classes/DataContainer.php
+++ b/core-bundle/src/Resources/contao/classes/DataContainer.php
@@ -225,7 +225,7 @@ abstract class DataContainer extends Backend
 		$arrData = $GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField];
 
 		// Check if the field is excluded
-		if ($arrData['exclude'])
+		if ($arrData['exclude'] ?? null)
 		{
 			throw new AccessDeniedException('Field "' . $this->strTable . '.' . $this->strField . '" is excluded from being edited.');
 		}
@@ -233,19 +233,19 @@ abstract class DataContainer extends Backend
 		$xlabel = '';
 
 		// Toggle line wrap (textarea)
-		if ($arrData['inputType'] == 'textarea' && !isset($arrData['eval']['rte']))
+		if (($arrData['inputType'] ?? null) == 'textarea' && !isset($arrData['eval']['rte']))
 		{
 			$xlabel .= ' ' . Image::getHtml('wrap.svg', $GLOBALS['TL_LANG']['MSC']['wordWrap'], 'title="' . StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['wordWrap']) . '" class="toggleWrap" onclick="Backend.toggleWrap(\'ctrl_' . $this->strInputName . '\')"');
 		}
 
 		// Add the help wizard
-		if ($arrData['eval']['helpwizard'])
+		if ($arrData['eval']['helpwizard'] ?? null)
 		{
 			$xlabel .= ' <a href="contao/help.php?table=' . $this->strTable . '&amp;field=' . $this->strField . '" title="' . StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['helpWizard']) . '" onclick="Backend.openModalIframe({\'title\':\'' . StringUtil::specialchars(str_replace("'", "\\'", $arrData['label'][0])) . '\',\'url\':this.href});return false">' . Image::getHtml('about.svg', $GLOBALS['TL_LANG']['MSC']['helpWizard']) . '</a>';
 		}
 
 		// Add a custom xlabel
-		if (\is_array($arrData['xlabel']))
+		if (\is_array($arrData['xlabel'] ?? null))
 		{
 			foreach ($arrData['xlabel'] as $callback)
 			{
@@ -262,20 +262,20 @@ abstract class DataContainer extends Backend
 		}
 
 		// Input field callback
-		if (\is_array($arrData['input_field_callback']))
+		if (\is_array($arrData['input_field_callback'] ?? null))
 		{
 			$this->import($arrData['input_field_callback'][0]);
 
 			return $this->{$arrData['input_field_callback'][0]}->{$arrData['input_field_callback'][1]}($this, $xlabel);
 		}
 
-		if (\is_callable($arrData['input_field_callback']))
+		if (\is_callable($arrData['input_field_callback'] ?? null))
 		{
 			return $arrData['input_field_callback']($this, $xlabel);
 		}
 
 		/** @var Widget $strClass */
-		$strClass = $GLOBALS['BE_FFL'][$arrData['inputType']];
+		$strClass = $GLOBALS['BE_FFL'][$arrData['inputType']] ?? null;
 
 		// Return if the widget class does not exists
 		if (!class_exists($strClass))
@@ -285,7 +285,7 @@ abstract class DataContainer extends Backend
 
 		$arrData['eval']['required'] = false;
 
-		if ($arrData['eval']['mandatory'])
+		if ($arrData['eval']['mandatory'] ?? null)
 		{
 			if (\is_array($this->varValue))
 			{
@@ -425,9 +425,9 @@ abstract class DataContainer extends Backend
 		$strHelpClass = '';
 
 		// Date picker
-		if ($arrData['eval']['datepicker'])
+		if ($arrData['eval']['datepicker'] ?? null)
 		{
-			$rgxp = $arrData['eval']['rgxp'];
+			$rgxp = $arrData['eval']['rgxp'] ?? 'date';
 			$format = Date::formatToJs(Config::get($rgxp . 'Format'));
 
 			switch ($rgxp)
@@ -448,7 +448,7 @@ abstract class DataContainer extends Backend
 			$strOnSelect = '';
 
 			// Trigger the auto-submit function (see #8603)
-			if ($arrData['eval']['submitOnChange'])
+			if ($arrData['eval']['submitOnChange'] ?? null)
 			{
 				$strOnSelect = ",\n        onSelect: function() { Backend.autoSubmit(\"" . $this->strTable . "\"); }";
 			}
@@ -471,10 +471,10 @@ abstract class DataContainer extends Backend
 		}
 
 		// Color picker
-		if ($arrData['eval']['colorpicker'])
+		if ($arrData['eval']['colorpicker'] ?? null)
 		{
 			// Support single fields as well (see #5240)
-			$strKey = $arrData['eval']['multiple'] ? $this->strField . '_0' : $this->strField;
+			$strKey = ($arrData['eval']['multiple'] ?? null) ? $this->strField . '_0' : $this->strField;
 
 			$wizard .= ' ' . Image::getHtml('pickcolor.svg', $GLOBALS['TL_LANG']['MSC']['colorpicker'], 'title="' . StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['colorpicker']) . '" id="moo_' . $this->strField . '" style="cursor:pointer"') . '
   <script>
@@ -492,7 +492,7 @@ abstract class DataContainer extends Backend
   </script>';
 		}
 
-		$arrClasses = StringUtil::trimsplit(' ', (string) $arrData['eval']['tl_class']);
+		$arrClasses = StringUtil::trimsplit(' ', $arrData['eval']['tl_class'] ?? '');
 
 		// DCA picker
 		if (isset($arrData['eval']['dcaPicker']) && (\is_array($arrData['eval']['dcaPicker']) || $arrData['eval']['dcaPicker'] === true))
@@ -502,7 +502,7 @@ abstract class DataContainer extends Backend
 		}
 
 		// Add a custom wizard
-		if (\is_array($arrData['wizard']))
+		if (\is_array($arrData['wizard'] ?? null))
 		{
 			foreach ($arrData['wizard'] as $callback)
 			{
@@ -522,7 +522,7 @@ abstract class DataContainer extends Backend
 		{
 			$objWidget->wizard = $wizard;
 
-			if ($arrData['eval']['addWizardClass'] !== false && !\in_array('wizard', $arrClasses))
+			if (($arrData['eval']['addWizardClass'] ?? null) !== false && !\in_array('wizard', $arrClasses))
 			{
 				$arrClasses[] = 'wizard';
 			}
@@ -538,17 +538,17 @@ abstract class DataContainer extends Backend
 			$this->blnUploadable = true;
 		}
 
-		if ($arrData['inputType'] != 'password')
+		if (($arrData['inputType'] ?? null) != 'password')
 		{
 			$arrClasses[] = 'widget';
 		}
 
 		// Mark floated single checkboxes
-		if ($arrData['inputType'] == 'checkbox' && !$arrData['eval']['multiple'] && \in_array('w50', $arrClasses))
+		if (($arrData['inputType'] ?? null) == 'checkbox' && !($arrData['eval']['multiple'] ?? null) && \in_array('w50', $arrClasses))
 		{
 			$arrClasses[] = 'cbx';
 		}
-		elseif ($arrData['inputType'] == 'text' && $arrData['eval']['multiple'] && \in_array('wizard', $arrClasses))
+		elseif (($arrData['inputType'] ?? null) == 'text' && ($arrData['eval']['multiple'] ?? null) && \in_array('wizard', $arrClasses))
 		{
 			$arrClasses[] = 'inline';
 		}
@@ -591,7 +591,7 @@ abstract class DataContainer extends Backend
 		}
 
 		// Handle multi-select fields in "override all" mode
-		elseif (($arrData['inputType'] == 'checkbox' || $arrData['inputType'] == 'checkboxWizard') && $arrData['eval']['multiple'] && Input::get('act') == 'overrideAll')
+		elseif ((($arrData['inputType'] ?? null) == 'checkbox' || ($arrData['inputType'] ?? null) == 'checkboxWizard') && ($arrData['eval']['multiple'] ?? null) && Input::get('act') == 'overrideAll')
 		{
 			$updateMode = '
 </div>
@@ -667,7 +667,7 @@ abstract class DataContainer extends Backend
 		}
 
 		return $strPreview . '
-<div' . ($arrData['eval']['tl_class'] ? ' class="' . trim($arrData['eval']['tl_class']) . '"' : '') . '>' . $objWidget->parse() . $updateMode . (!$objWidget->hasErrors() ? $this->help($strHelpClass) : '') . '
+<div' . (!empty($arrData['eval']['tl_class']) ? ' class="' . trim($arrData['eval']['tl_class']) . '"' : '') . '>' . $objWidget->parse() . $updateMode . (!$objWidget->hasErrors() ? $this->help($strHelpClass) : '') . '
 </div>';
 	}
 
@@ -682,7 +682,7 @@ abstract class DataContainer extends Backend
 	{
 		$return = $GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['label'][1];
 
-		if (!$return || $GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['inputType'] == 'password' || !Config::get('showHelp'))
+		if (!$return || ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['inputType'] ?? null) == 'password' || !Config::get('showHelp'))
 		{
 			return '';
 		}
@@ -759,7 +759,7 @@ abstract class DataContainer extends Backend
 	 */
 	protected function generateButtons($arrRow, $strTable, $arrRootIds=array(), $blnCircularReference=false, $arrChildRecordIds=null, $strPrevious=null, $strNext=null)
 	{
-		if (empty($GLOBALS['TL_DCA'][$strTable]['list']['operations']) || !\is_array($GLOBALS['TL_DCA'][$strTable]['list']['operations']))
+		if (!\is_array($GLOBALS['TL_DCA'][$strTable]['list']['operations'] ?? null))
 		{
 			return '';
 		}
@@ -876,7 +876,7 @@ abstract class DataContainer extends Backend
 	 */
 	protected function generateGlobalButtons()
 	{
-		if (empty($GLOBALS['TL_DCA'][$this->strTable]['list']['global_operations']) || !\is_array($GLOBALS['TL_DCA'][$this->strTable]['list']['global_operations']))
+		if (!\is_array($GLOBALS['TL_DCA'][$this->strTable]['list']['global_operations'] ?? null))
 		{
 			return '';
 		}
@@ -958,7 +958,7 @@ abstract class DataContainer extends Backend
 	 */
 	protected function generateHeaderButtons($arrRow, $strPtable)
 	{
-		if (empty($GLOBALS['TL_DCA'][$strPtable]['list']['operations']) || !\is_array($GLOBALS['TL_DCA'][$strPtable]['list']['operations']))
+		if (!\is_array($GLOBALS['TL_DCA'][$strPtable]['list']['operations'] ?? null))
 		{
 			return '';
 		}
@@ -967,7 +967,7 @@ abstract class DataContainer extends Backend
 
 		foreach ($GLOBALS['TL_DCA'][$strPtable]['list']['operations'] as $k=> $v)
 		{
-			if (empty($v['showInHeader']) || (Input::get('act') == 'select' && !$v['showOnSelect']))
+			if (empty($v['showInHeader']) || (Input::get('act') == 'select' && !($v['showOnSelect'] ?? null)))
 			{
 				continue;
 			}
@@ -1142,7 +1142,7 @@ abstract class DataContainer extends Backend
 	 */
 	protected function panel()
 	{
-		if (!$GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['panelLayout'])
+		if (!($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['panelLayout'] ?? null))
 		{
 			return '';
 		}
@@ -1169,7 +1169,7 @@ abstract class DataContainer extends Backend
 
 		$intFilterPanel = 0;
 		$arrPanels = array();
-		$arrPanes = StringUtil::trimsplit(';', $GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['panelLayout']);
+		$arrPanes = StringUtil::trimsplit(';', $GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['panelLayout'] ?? '');
 
 		foreach ($arrPanes as $strPanel)
 		{
@@ -1195,7 +1195,7 @@ abstract class DataContainer extends Backend
 				// Call the panel_callback
 				else
 				{
-					$arrCallback = $GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['panel_callback'][$strSubPanel];
+					$arrCallback = $GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['panel_callback'][$strSubPanel] ?? null;
 
 					if (\is_array($arrCallback))
 					{
@@ -1285,7 +1285,7 @@ abstract class DataContainer extends Backend
 		$this->addCtableTags($this->table, $this->id, $tags);
 
 		// Trigger the oninvalidate_cache_tags_callback
-		if (\is_array($GLOBALS['TL_DCA'][$this->table]['config']['oninvalidate_cache_tags_callback']))
+		if (\is_array($GLOBALS['TL_DCA'][$this->table]['config']['oninvalidate_cache_tags_callback'] ?? null))
 		{
 			foreach ($GLOBALS['TL_DCA'][$this->table]['config']['oninvalidate_cache_tags_callback'] as $callback)
 			{
@@ -1346,7 +1346,7 @@ abstract class DataContainer extends Backend
 		{
 			Controller::loadDataContainer($ctable);
 
-			if ($GLOBALS['TL_DCA'][$ctable]['config']['dynamicPtable'])
+			if ($GLOBALS['TL_DCA'][$ctable]['config']['dynamicPtable'] ?? null)
 			{
 				$objIds = $this->Database->prepare('SELECT id FROM ' . Database::quoteIdentifier($ctable) . ' WHERE pid=? AND ptable=?')
 										 ->execute($intId, $strTable);

--- a/core-bundle/src/Resources/contao/classes/DataContainer.php
+++ b/core-bundle/src/Resources/contao/classes/DataContainer.php
@@ -222,7 +222,7 @@ abstract class DataContainer extends Backend
 	 */
 	protected function row($strPalette=null)
 	{
-		$arrData = $GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField];
+		$arrData = $GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField] ?? array();
 
 		// Check if the field is excluded
 		if ($arrData['exclude'] ?? null)
@@ -241,7 +241,7 @@ abstract class DataContainer extends Backend
 		// Add the help wizard
 		if ($arrData['eval']['helpwizard'] ?? null)
 		{
-			$xlabel .= ' <a href="contao/help.php?table=' . $this->strTable . '&amp;field=' . $this->strField . '" title="' . StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['helpWizard']) . '" onclick="Backend.openModalIframe({\'title\':\'' . StringUtil::specialchars(str_replace("'", "\\'", $arrData['label'][0])) . '\',\'url\':this.href});return false">' . Image::getHtml('about.svg', $GLOBALS['TL_LANG']['MSC']['helpWizard']) . '</a>';
+			$xlabel .= ' <a href="contao/help.php?table=' . $this->strTable . '&amp;field=' . $this->strField . '" title="' . StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['helpWizard']) . '" onclick="Backend.openModalIframe({\'title\':\'' . StringUtil::specialchars(str_replace("'", "\\'", $arrData['label'][0] ?? '')) . '\',\'url\':this.href});return false">' . Image::getHtml('about.svg', $GLOBALS['TL_LANG']['MSC']['helpWizard']) . '</a>';
 		}
 
 		// Add a custom xlabel
@@ -563,7 +563,9 @@ abstract class DataContainer extends Backend
 		// Replace the textarea with an RTE instance
 		if (!empty($arrData['eval']['rte']))
 		{
-			list ($file, $type) = explode('|', $arrData['eval']['rte'], 2);
+			$chunks = explode('|', $arrData['eval']['rte'], 2);
+			$file = $chunks[0] ?? null;
+			$type = $chunks[1] ?? null;
 
 			$fileBrowserTypes = array();
 			$pickerBuilder = System::getContainer()->get('contao.picker.builder');
@@ -680,7 +682,7 @@ abstract class DataContainer extends Backend
 	 */
 	public function help($strClass='')
 	{
-		$return = $GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['label'][1];
+		$return = $GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['label'][1] ?? null;
 
 		if (!$return || ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['inputType'] ?? null) == 'password' || !Config::get('showHelp'))
 		{
@@ -798,16 +800,16 @@ abstract class DataContainer extends Backend
 			}
 
 			// Call a custom function instead of using the default button
-			if (\is_array($v['button_callback']))
+			if (\is_array($v['button_callback'] ?? null))
 			{
 				$this->import($v['button_callback'][0]);
-				$return .= $this->{$v['button_callback'][0]}->{$v['button_callback'][1]}($arrRow, $v['href'], $label, $title, $v['icon'], $attributes, $strTable, $arrRootIds, $arrChildRecordIds, $blnCircularReference, $strPrevious, $strNext, $this);
+				$return .= $this->{$v['button_callback'][0]}->{$v['button_callback'][1]}($arrRow, $v['href'] ?? null, $label, $title, $v['icon'] ?? null, $attributes, $strTable, $arrRootIds, $arrChildRecordIds, $blnCircularReference, $strPrevious, $strNext, $this);
 				continue;
 			}
 
-			if (\is_callable($v['button_callback']))
+			if (\is_callable($v['button_callback'] ?? null))
 			{
-				$return .= $v['button_callback']($arrRow, $v['href'], $label, $title, $v['icon'], $attributes, $strTable, $arrRootIds, $arrChildRecordIds, $blnCircularReference, $strPrevious, $strNext, $this);
+				$return .= $v['button_callback']($arrRow, $v['href'] ?? null, $label, $title, $v['icon'] ?? null, $attributes, $strTable, $arrRootIds, $arrChildRecordIds, $blnCircularReference, $strPrevious, $strNext, $this);
 				continue;
 			}
 
@@ -849,11 +851,11 @@ abstract class DataContainer extends Backend
 
 			foreach ($arrDirections as $dir)
 			{
-				$label = $GLOBALS['TL_LANG'][$strTable][$dir][0] ?: $dir;
-				$title = $GLOBALS['TL_LANG'][$strTable][$dir][1] ?: $dir;
+				$label = $GLOBALS['TL_LANG'][$strTable][$dir][0] ?? $dir;
+				$title = $GLOBALS['TL_LANG'][$strTable][$dir][1] ?? $dir;
 
 				$label = Image::getHtml($dir . '.svg', $label);
-				$href = $v['href'] ?: '&amp;act=move';
+				$href = $v['href'] ?? '&amp;act=move';
 
 				if ($dir == 'up')
 				{
@@ -885,7 +887,7 @@ abstract class DataContainer extends Backend
 
 		foreach ($GLOBALS['TL_DCA'][$this->strTable]['list']['global_operations'] as $k=>$v)
 		{
-			if (!$v['showOnSelect'] && Input::get('act') == 'select')
+			if (!($v['showOnSelect'] ?? null) && Input::get('act') == 'select')
 			{
 				continue;
 			}
@@ -896,7 +898,7 @@ abstract class DataContainer extends Backend
 			$attributes = !empty($v['attributes']) ? ' ' . ltrim($v['attributes']) : '';
 
 			// Custom icon (see #5541)
-			if ($v['icon'])
+			if ($v['icon'] ?? null)
 			{
 				$v['class'] = trim($v['class'] . ' header_icon');
 
@@ -920,14 +922,14 @@ abstract class DataContainer extends Backend
 			}
 
 			// Call a custom function instead of using the default button
-			if (\is_array($v['button_callback']))
+			if (\is_array($v['button_callback'] ?? null))
 			{
 				$this->import($v['button_callback'][0]);
 				$return .= $this->{$v['button_callback'][0]}->{$v['button_callback'][1]}($v['href'], $label, $title, $v['class'], $attributes, $this->strTable, $this->root);
 				continue;
 			}
 
-			if (\is_callable($v['button_callback']))
+			if (\is_callable($v['button_callback'] ?? null))
 			{
 				$return .= $v['button_callback']($v['href'], $label, $title, $v['class'], $attributes, $this->strTable, $this->root);
 				continue;
@@ -1012,14 +1014,14 @@ abstract class DataContainer extends Backend
 			}
 
 			// Call a custom function instead of using the default button
-			if (\is_array($v['button_callback']))
+			if (\is_array($v['button_callback'] ?? null))
 			{
 				$this->import($v['button_callback'][0]);
 				$return .= $this->{$v['button_callback'][0]}->{$v['button_callback'][1]}($arrRow, $v['href'], $label, $title, $v['icon'], $attributes, $strPtable, array(), null, false, null, null, $this);
 				continue;
 			}
 
-			if (\is_callable($v['button_callback']))
+			if (\is_callable($v['button_callback'] ?? null))
 			{
 				$return .= $v['button_callback']($arrRow, $v['href'], $label, $title, $v['icon'], $attributes, $strPtable, array(), null, false, null, null, $this);
 				continue;
@@ -1036,7 +1038,7 @@ abstract class DataContainer extends Backend
 					$href = $this->addToUrl($v['href'] . '&amp;id=' . $arrRow['id'] . '&amp;popup=1');
 				}
 
-				$return .= '<a href="' . $href . '" title="' . StringUtil::specialchars($title) . '" onclick="Backend.openModalIframe({\'title\':\'' . StringUtil::specialchars(str_replace("'", "\\'", sprintf(\is_array($GLOBALS['TL_LANG'][$strPtable]['show']) ? $GLOBALS['TL_LANG'][$strPtable]['show'][1] : $GLOBALS['TL_LANG'][$strPtable]['show'], $arrRow['id']))) . '\',\'url\':this.href});return false"' . $attributes . '>' . Image::getHtml($v['icon'], $label) . '</a> ';
+				$return .= '<a href="' . $href . '" title="' . StringUtil::specialchars($title) . '" onclick="Backend.openModalIframe({\'title\':\'' . StringUtil::specialchars(str_replace("'", "\\'", sprintf(\is_array($GLOBALS['TL_LANG'][$strPtable]['show'] ?? null) ? $GLOBALS['TL_LANG'][$strPtable]['show'][1] : ($GLOBALS['TL_LANG'][$strPtable]['show'] ?? ''), $arrRow['id']))) . '\',\'url\':this.href});return false"' . $attributes . '>' . Image::getHtml($v['icon'], $label) . '</a> ';
 			}
 			else
 			{

--- a/core-bundle/src/Resources/contao/classes/DataContainer.php
+++ b/core-bundle/src/Resources/contao/classes/DataContainer.php
@@ -856,11 +856,11 @@ abstract class DataContainer extends Backend
 
 			foreach ($arrDirections as $dir)
 			{
-				$label = $GLOBALS['TL_LANG'][$strTable][$dir][0] ?? $dir;
-				$title = $GLOBALS['TL_LANG'][$strTable][$dir][1] ?? $dir;
+				$label = !empty($GLOBALS['TL_LANG'][$strTable][$dir][0]) ? $GLOBALS['TL_LANG'][$strTable][$dir][0] : $dir;
+				$title = !empty($GLOBALS['TL_LANG'][$strTable][$dir][1]) ? $GLOBALS['TL_LANG'][$strTable][$dir][1] : $dir;
 
 				$label = Image::getHtml($dir . '.svg', $label);
-				$href = $v['href'] ?? '&amp;act=move';
+				$href = !empty($v['href']) ? $v['href'] : '&amp;act=move';
 
 				if ($dir == 'up')
 				{

--- a/core-bundle/src/Resources/contao/classes/DataContainer.php
+++ b/core-bundle/src/Resources/contao/classes/DataContainer.php
@@ -224,6 +224,11 @@ abstract class DataContainer extends Backend
 	{
 		$arrData = $GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField] ?? array();
 
+		if (!isset($arrData['inputType']))
+		{
+			return '';
+		}
+
 		// Check if the field is excluded
 		if ($arrData['exclude'] ?? null)
 		{
@@ -233,7 +238,7 @@ abstract class DataContainer extends Backend
 		$xlabel = '';
 
 		// Toggle line wrap (textarea)
-		if (($arrData['inputType'] ?? null) == 'textarea' && !isset($arrData['eval']['rte']))
+		if ($arrData['inputType'] == 'textarea' && !isset($arrData['eval']['rte']))
 		{
 			$xlabel .= ' ' . Image::getHtml('wrap.svg', $GLOBALS['TL_LANG']['MSC']['wordWrap'], 'title="' . StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['wordWrap']) . '" class="toggleWrap" onclick="Backend.toggleWrap(\'ctrl_' . $this->strInputName . '\')"');
 		}
@@ -538,17 +543,17 @@ abstract class DataContainer extends Backend
 			$this->blnUploadable = true;
 		}
 
-		if (($arrData['inputType'] ?? null) != 'password')
+		if ($arrData['inputType'] != 'password')
 		{
 			$arrClasses[] = 'widget';
 		}
 
 		// Mark floated single checkboxes
-		if (($arrData['inputType'] ?? null) == 'checkbox' && !($arrData['eval']['multiple'] ?? null) && \in_array('w50', $arrClasses))
+		if ($arrData['inputType'] == 'checkbox' && !($arrData['eval']['multiple'] ?? null) && \in_array('w50', $arrClasses))
 		{
 			$arrClasses[] = 'cbx';
 		}
-		elseif (($arrData['inputType'] ?? null) == 'text' && ($arrData['eval']['multiple'] ?? null) && \in_array('wizard', $arrClasses))
+		elseif ($arrData['inputType'] == 'text' && ($arrData['eval']['multiple'] ?? null) && \in_array('wizard', $arrClasses))
 		{
 			$arrClasses[] = 'inline';
 		}
@@ -593,7 +598,7 @@ abstract class DataContainer extends Backend
 		}
 
 		// Handle multi-select fields in "override all" mode
-		elseif ((($arrData['inputType'] ?? null) == 'checkbox' || ($arrData['inputType'] ?? null) == 'checkboxWizard') && ($arrData['eval']['multiple'] ?? null) && Input::get('act') == 'overrideAll')
+		elseif (($arrData['inputType'] == 'checkbox' || $arrData['inputType'] == 'checkboxWizard') && ($arrData['eval']['multiple'] ?? null) && Input::get('act') == 'overrideAll')
 		{
 			$updateMode = '
 </div>

--- a/core-bundle/src/Resources/contao/classes/Hybrid.php
+++ b/core-bundle/src/Resources/contao/classes/Hybrid.php
@@ -232,8 +232,8 @@ abstract class Hybrid extends Frontend
 		$this->compile();
 
 		$this->Template->style = !empty($this->arrStyle) ? implode(' ', $this->arrStyle) : '';
+		$this->Template->class = trim($this->typePrefix . $this->strKey . ' ' . ($this->cssID[1] ?? ''));
 		$this->Template->cssID = !empty($this->cssID[0]) ? ' id="' . $this->cssID[0] . '"' : '';
-		$this->Template->class = trim($this->typePrefix . $this->strKey . ' ' . ($this->cssID[1] ?? null));
 
 		$this->Template->inColumn = $this->strColumn;
 

--- a/core-bundle/src/Resources/contao/classes/Hybrid.php
+++ b/core-bundle/src/Resources/contao/classes/Hybrid.php
@@ -147,7 +147,7 @@ abstract class Hybrid extends Frontend
 		// Merge the CSS classes (see #6011)
 		if (!empty($this->cssID[1]))
 		{
-			$cssID[1] = trim($cssID[1] . ' ' . $this->cssID[1]);
+			$cssID[1] = trim(($cssID[1] ?? '') . ' ' . $this->cssID[1]);
 		}
 
 		$this->cssID = $cssID;
@@ -233,7 +233,7 @@ abstract class Hybrid extends Frontend
 
 		$this->Template->style = !empty($this->arrStyle) ? implode(' ', $this->arrStyle) : '';
 		$this->Template->cssID = !empty($this->cssID[0]) ? ' id="' . $this->cssID[0] . '"' : '';
-		$this->Template->class = trim($this->typePrefix . $this->strKey . ' ' . $this->cssID[1]);
+		$this->Template->class = trim($this->typePrefix . $this->strKey . ' ' . ($this->cssID[1] ?? null));
 
 		$this->Template->inColumn = $this->strColumn;
 

--- a/core-bundle/src/Resources/contao/classes/PurgeData.php
+++ b/core-bundle/src/Resources/contao/classes/PurgeData.php
@@ -132,7 +132,8 @@ class PurgeData extends Backend implements \executable
 				'id' => 'purge_' . $key,
 				'title' => $GLOBALS['TL_LANG']['tl_maintenance_jobs'][$key][0],
 				'description' => $GLOBALS['TL_LANG']['tl_maintenance_jobs'][$key][1],
-				'group' => 'custom'
+				'group' => 'custom',
+				'affected' => ''
 			);
 		}
 

--- a/core-bundle/src/Resources/contao/classes/StyleSheets.php
+++ b/core-bundle/src/Resources/contao/classes/StyleSheets.php
@@ -156,7 +156,7 @@ class StyleSheets extends Backend
 		}
 
 		// Merge the global style sheet variables
-		if ($row['vars'] != '' && \is_array($tmp = StringUtil::deserialize($row['vars'])))
+		if (!empty($row['vars']) && \is_array($tmp = StringUtil::deserialize($row['vars'])))
 		{
 			foreach ($tmp as $v)
 			{

--- a/core-bundle/src/Resources/contao/classes/Theme.php
+++ b/core-bundle/src/Resources/contao/classes/Theme.php
@@ -584,7 +584,7 @@ class Theme extends Backend
 						}
 
 						// Replace the file paths in singleSRC fields with their tl_files ID
-						elseif ($GLOBALS['TL_DCA'][$table]['fields'][$name]['inputType'] == 'fileTree' && !$GLOBALS['TL_DCA'][$table]['fields'][$name]['eval']['multiple'])
+						elseif (($GLOBALS['TL_DCA'][$table]['fields'][$name]['inputType'] ?? null) == 'fileTree' && !($GLOBALS['TL_DCA'][$table]['fields'][$name]['eval']['multiple'] ?? null))
 						{
 							if (!$value)
 							{
@@ -602,7 +602,7 @@ class Theme extends Backend
 						}
 
 						// Replace the file paths in multiSRC fields with their tl_files ID
-						elseif ($GLOBALS['TL_DCA'][$table]['fields'][$name]['inputType'] == 'fileTree' || \in_array($name, $arrOrder))
+						elseif (($GLOBALS['TL_DCA'][$table]['fields'][$name]['inputType'] ?? null) == 'fileTree' || \in_array($name, $arrOrder))
 						{
 							$tmp = StringUtil::deserialize($value);
 
@@ -623,7 +623,7 @@ class Theme extends Backend
 						}
 
 						// Adjust the imageSize widget data
-						elseif ($GLOBALS['TL_DCA'][$table]['fields'][$name]['inputType'] == 'imageSize')
+						elseif (($GLOBALS['TL_DCA'][$table]['fields'][$name]['inputType'] ?? null) == 'imageSize')
 						{
 							$imageSizes = StringUtil::deserialize($value, true);
 
@@ -1019,7 +1019,7 @@ class Theme extends Backend
 			}
 
 			// Replace the IDs of singleSRC fields with their path (see #4952)
-			elseif ($GLOBALS['TL_DCA'][$t]['fields'][$k]['inputType'] == 'fileTree' && !$GLOBALS['TL_DCA'][$t]['fields'][$k]['eval']['multiple'])
+			elseif (($GLOBALS['TL_DCA'][$t]['fields'][$k]['inputType'] ?? null) == 'fileTree' && !($GLOBALS['TL_DCA'][$t]['fields'][$k]['eval']['multiple'] ?? null))
 			{
 				$objFile = FilesModel::findByUuid($v);
 
@@ -1034,7 +1034,7 @@ class Theme extends Backend
 			}
 
 			// Replace the IDs of multiSRC fields with their paths (see #4952)
-			elseif ($GLOBALS['TL_DCA'][$t]['fields'][$k]['inputType'] == 'fileTree' || \in_array($k, $arrOrder))
+			elseif (($GLOBALS['TL_DCA'][$t]['fields'][$k]['inputType'] ?? null) == 'fileTree' || \in_array($k, $arrOrder))
 			{
 				$arrFiles = StringUtil::deserialize($v);
 

--- a/core-bundle/src/Resources/contao/classes/Versions.php
+++ b/core-bundle/src/Resources/contao/classes/Versions.php
@@ -112,7 +112,7 @@ class Versions extends Controller
 	 */
 	public function getLatestVersion()
 	{
-		if (!$GLOBALS['TL_DCA'][$this->strTable]['config']['enableVersioning'])
+		if (!($GLOBALS['TL_DCA'][$this->strTable]['config']['enableVersioning'] ?? null))
 		{
 			return null;
 		}
@@ -129,7 +129,7 @@ class Versions extends Controller
 	 */
 	public function initialize()
 	{
-		if (!$GLOBALS['TL_DCA'][$this->strTable]['config']['enableVersioning'])
+		if (!($GLOBALS['TL_DCA'][$this->strTable]['config']['enableVersioning'] ?? null))
 		{
 			return;
 		}
@@ -153,7 +153,7 @@ class Versions extends Controller
 	 */
 	public function create($blnHideUser=false)
 	{
-		if (!$GLOBALS['TL_DCA'][$this->strTable]['config']['enableVersioning'])
+		if (!($GLOBALS['TL_DCA'][$this->strTable]['config']['enableVersioning'] ?? null))
 		{
 			return;
 		}
@@ -177,7 +177,7 @@ class Versions extends Controller
 		// Remove fields that are excluded from versioning
 		foreach (array_keys($data) as $k)
 		{
-			if (isset($GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['eval']['versionize']) && $GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['eval']['versionize'] === false)
+			if (($GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['eval']['versionize'] ?? null) === false)
 			{
 				unset($data[$k]);
 			}
@@ -231,7 +231,7 @@ class Versions extends Controller
 									 ->version;
 
 		// Trigger the oncreate_version_callback
-		if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['config']['oncreate_version_callback']))
+		if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['config']['oncreate_version_callback'] ?? null))
 		{
 			foreach ($GLOBALS['TL_DCA'][$this->strTable]['config']['oncreate_version_callback'] as $callback)
 			{
@@ -257,7 +257,7 @@ class Versions extends Controller
 	 */
 	public function restore($intVersion)
 	{
-		if (!$GLOBALS['TL_DCA'][$this->strTable]['config']['enableVersioning'])
+		if (!($GLOBALS['TL_DCA'][$this->strTable]['config']['enableVersioning'] ?? null))
 		{
 			return;
 		}
@@ -287,27 +287,27 @@ class Versions extends Controller
 		// Reset fields added after storing the version to their default value (see #7755)
 		foreach (array_diff_key($arrFields, $data) as $k=>$v)
 		{
-			$data[$k] = Widget::getEmptyValueByFieldType($GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['sql']);
+			$data[$k] = Widget::getEmptyValueByFieldType($GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['sql'] ?? array());
 		}
 
 		foreach ($data as $k=>$v)
 		{
 			// Remove fields that are excluded from versioning
-			if (isset($GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['eval']['versionize']) && $GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['eval']['versionize'] === false)
+			if (($GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['eval']['versionize'] ?? null) === false)
 			{
 				unset($data[$k]);
 				continue;
 			}
 
 			// Reset unique fields if the restored value already exists (see #698)
-			if (isset($GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['eval']['unique']) && $GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['eval']['unique'] === true)
+			if (($GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['eval']['unique'] ?? null) === true)
 			{
 				$objResult = $this->Database->prepare("SELECT COUNT(*) AS cnt FROM " . $this->strTable . " WHERE " . Database::quoteIdentifier($k) . "=? AND id!=?")
 											->execute($v, $this->intPid);
 
 				if ($objResult->cnt > 0)
 				{
-					$data[$k] = Widget::getEmptyValueByFieldType($GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['sql']);
+					$data[$k] = Widget::getEmptyValueByFieldType($GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['sql'] ?? array());
 				}
 			}
 		}
@@ -323,7 +323,7 @@ class Versions extends Controller
 					   ->execute($this->strTable, $this->intPid, $intVersion);
 
 		// Trigger the onrestore_version_callback
-		if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['config']['onrestore_version_callback']))
+		if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['config']['onrestore_version_callback'] ?? null))
 		{
 			foreach ($GLOBALS['TL_DCA'][$this->strTable]['config']['onrestore_version_callback'] as $callback)
 			{
@@ -340,7 +340,7 @@ class Versions extends Controller
 		}
 
 		// Trigger the deprecated onrestore_callback
-		if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['config']['onrestore_callback']))
+		if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['config']['onrestore_callback'] ?? null))
 		{
 			trigger_deprecation('contao/core-bundle', '4.0', 'Using the "onrestore_callback" has been deprecated and will no longer work in Contao 5.0. Use the "onrestore_version_callback" instead.');
 
@@ -455,7 +455,7 @@ class Versions extends Controller
 				{
 					if ($from[$k] != $to[$k])
 					{
-						if ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['eval']['doNotShow'] || $GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['eval']['hideInput'])
+						if (($GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['eval']['doNotShow'] ?? null) || ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['eval']['hideInput'] ?? null))
 						{
 							continue;
 						}
@@ -470,13 +470,13 @@ class Versions extends Controller
 						}
 
 						// Decrypt the values
-						if ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['eval']['encrypt'])
+						if ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['eval']['encrypt'] ?? null)
 						{
 							$to[$k] = Encryption::decrypt($to[$k]);
 							$from[$k] = Encryption::decrypt($from[$k]);
 						}
 
-						if ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['eval']['multiple'] || \in_array($k, $arrOrderFields))
+						if (($GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['eval']['multiple'] ?? null) || \in_array($k, $arrOrderFields))
 						{
 							if (isset($GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['eval']['csv']))
 							{
@@ -524,17 +524,17 @@ class Versions extends Controller
 						}
 
 						// Convert date fields
-						if ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['eval']['rgxp'] == 'date')
+						if (($GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['eval']['rgxp'] ?? null) == 'date')
 						{
 							$to[$k] = Date::parse(Config::get('dateFormat'), $to[$k] ?: '');
 							$from[$k] = Date::parse(Config::get('dateFormat'), $from[$k] ?: '');
 						}
-						elseif ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['eval']['rgxp'] == 'time')
+						elseif (($GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['eval']['rgxp'] ?? null) == 'time')
 						{
 							$to[$k] = Date::parse(Config::get('timeFormat'), $to[$k] ?: '');
 							$from[$k] = Date::parse(Config::get('timeFormat'), $from[$k] ?: '');
 						}
-						elseif ($k == 'tstamp' || $GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['eval']['rgxp'] == 'datim')
+						elseif ($k == 'tstamp' || ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['eval']['rgxp'] ?? null) == 'datim')
 						{
 							$to[$k] = Date::parse(Config::get('datimFormat'), $to[$k] ?: '');
 							$from[$k] = Date::parse(Config::get('datimFormat'), $from[$k] ?: '');

--- a/core-bundle/src/Resources/contao/classes/Versions.php
+++ b/core-bundle/src/Resources/contao/classes/Versions.php
@@ -733,7 +733,7 @@ class Versions extends Controller
 			}
 
 			// Skip deleted files (see #8480)
-			if ($v['fromTable'] == 'tl_files' && $arrVersions[$k]['deleted'])
+			if (($v['fromTable'] ?? null) == 'tl_files' && ($arrVersions[$k]['deleted'] ?? null))
 			{
 				--$intCount;
 				unset($arrVersions[$k]);

--- a/core-bundle/src/Resources/contao/controllers/BackendConfirm.php
+++ b/core-bundle/src/Resources/contao/controllers/BackendConfirm.php
@@ -131,7 +131,7 @@ class BackendConfirm extends Backend
 		}
 		else
 		{
-			$arrInfo['act'] = \is_array($GLOBALS['TL_LANG'][$arrInfo['table']][$arrInfo['act']]) ? $GLOBALS['TL_LANG'][$arrInfo['table']][$arrInfo['act']][0] : $GLOBALS['TL_LANG'][$arrInfo['table']][$arrInfo['act']];
+			$arrInfo['act'] = \is_array($GLOBALS['TL_LANG'][$arrInfo['table']][$arrInfo['act']] ?? null) ? $GLOBALS['TL_LANG'][$arrInfo['table']][$arrInfo['act']][0] : ($GLOBALS['TL_LANG'][$arrInfo['table']][$arrInfo['act']] ?? null);
 		}
 
 		// Replace the ID wildcard

--- a/core-bundle/src/Resources/contao/controllers/BackendFile.php
+++ b/core-bundle/src/Resources/contao/controllers/BackendFile.php
@@ -135,7 +135,7 @@ class BackendFile extends Backend
 		}
 
 		/** @var FileSelector $strClass */
-		$strClass = $GLOBALS['BE_FFL']['fileSelector'];
+		$strClass = $GLOBALS['BE_FFL']['fileSelector'] ?? null;
 
 		/** @var FileSelector $objFileTree */
 		$objFileTree = new $strClass($strClass::getAttributesFromDca($GLOBALS['TL_DCA'][$strTable]['fields'][$strField], $strField, $arrValues, $strField, $strTable, $objDca));

--- a/core-bundle/src/Resources/contao/controllers/BackendFile.php
+++ b/core-bundle/src/Resources/contao/controllers/BackendFile.php
@@ -118,7 +118,7 @@ class BackendFile extends Backend
 		}
 
 		// Call the load_callback
-		if (\is_array($GLOBALS['TL_DCA'][$strTable]['fields'][$strField]['load_callback']))
+		if (\is_array($GLOBALS['TL_DCA'][$strTable]['fields'][$strField]['load_callback'] ?? null))
 		{
 			foreach ($GLOBALS['TL_DCA'][$strTable]['fields'][$strField]['load_callback'] as $callback)
 			{
@@ -154,7 +154,7 @@ class BackendFile extends Backend
 		$objTemplate->search = $GLOBALS['TL_LANG']['MSC']['search'];
 		$objTemplate->searchExclude = $GLOBALS['TL_LANG']['MSC']['searchExclude'];
 		$objTemplate->value = $objSessionBag->get('file_selector_search');
-		$objTemplate->breadcrumb = $GLOBALS['TL_DCA']['tl_files']['list']['sorting']['breadcrumb'];
+		$objTemplate->breadcrumb = $GLOBALS['TL_DCA']['tl_files']['list']['sorting']['breadcrumb'] ?? null;
 
 		if ($this->User->hasAccess('files', 'modules'))
 		{

--- a/core-bundle/src/Resources/contao/controllers/BackendHelp.php
+++ b/core-bundle/src/Resources/contao/controllers/BackendHelp.php
@@ -147,7 +147,7 @@ class BackendHelp extends Backend
 		$objTemplate->title = StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['helpWizardTitle']);
 		$objTemplate->host = Backend::getDecodedHostname();
 		$objTemplate->charset = Config::get('characterSet');
-		$objTemplate->headline = $arrData['label'][0] ?? $field;
+		$objTemplate->headline = $arrData['label'][0] ?: $field;
 		$objTemplate->helpWizard = $GLOBALS['TL_LANG']['MSC']['helpWizard'];
 
 		return $objTemplate->getResponse();

--- a/core-bundle/src/Resources/contao/controllers/BackendHelp.php
+++ b/core-bundle/src/Resources/contao/controllers/BackendHelp.php
@@ -60,23 +60,23 @@ class BackendHelp extends Backend
 		$objTemplate->rows = array();
 		$objTemplate->explanation = '';
 
-		$arrData = $GLOBALS['TL_DCA'][$table]['fields'][$field];
+		$arrData = $GLOBALS['TL_DCA'][$table]['fields'][$field] ?? array();
 
 		// Add the reference
 		if (!empty($arrData['reference']))
 		{
 			$rows = array();
 
-			if (\is_array($arrData['options']))
+			if (\is_array($arrData['options'] ?? null))
 			{
 				$options = $arrData['options'];
 			}
-			elseif (\is_array($arrData['options_callback']))
+			elseif (\is_array($arrData['options_callback'] ?? null))
 			{
 				$this->import($arrData['options_callback'][0]);
 				$options = $this->{$arrData['options_callback'][0]}->{$arrData['options_callback'][1]}(new DC_Table($table));
 			}
-			elseif (\is_callable($arrData['options_callback']))
+			elseif (\is_callable($arrData['options_callback'] ?? null))
 			{
 				$options = $arrData['options_callback']();
 			}
@@ -105,20 +105,20 @@ class BackendHelp extends Backend
 
 					foreach ($option as $opt)
 					{
-						$rows[] = $arrData['reference'][$opt];
+						$rows[] = $arrData['reference'][$opt] ?? null;
 					}
 				}
 				elseif (isset($arrData['reference'][$key]))
 				{
 					$rows[] = $arrData['reference'][$key];
 				}
-				elseif (\is_array($arrData['reference'][$option]))
+				elseif (\is_array($arrData['reference'][$option] ?? null))
 				{
 					$rows[] = $arrData['reference'][$option];
 				}
 				else
 				{
-					$rows[] = array('headspan', $arrData['reference'][$option]);
+					$rows[] = array('headspan', $arrData['reference'][$option] ?? null);
 				}
 			}
 
@@ -147,7 +147,7 @@ class BackendHelp extends Backend
 		$objTemplate->title = StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['helpWizardTitle']);
 		$objTemplate->host = Backend::getDecodedHostname();
 		$objTemplate->charset = Config::get('characterSet');
-		$objTemplate->headline = $arrData['label'][0] ?: $field;
+		$objTemplate->headline = $arrData['label'][0] ?? $field;
 		$objTemplate->helpWizard = $GLOBALS['TL_LANG']['MSC']['helpWizard'];
 
 		return $objTemplate->getResponse();

--- a/core-bundle/src/Resources/contao/controllers/BackendHelp.php
+++ b/core-bundle/src/Resources/contao/controllers/BackendHelp.php
@@ -131,13 +131,16 @@ class BackendHelp extends Backend
 			System::loadLanguageFile('explain');
 			$key = $arrData['explanation'];
 
-			if (!\is_array($GLOBALS['TL_LANG']['XPL'][$key]))
+			if (isset($GLOBALS['TL_LANG']['XPL'][$key]))
 			{
-				$objTemplate->explanation = trim($GLOBALS['TL_LANG']['XPL'][$key]);
-			}
-			else
-			{
-				$objTemplate->rows = $GLOBALS['TL_LANG']['XPL'][$key];
+				if (\is_array($GLOBALS['TL_LANG']['XPL'][$key]))
+				{
+					$objTemplate->rows = $GLOBALS['TL_LANG']['XPL'][$key];
+				}
+				else
+				{
+					$objTemplate->explanation = trim($GLOBALS['TL_LANG']['XPL'][$key]);
+				}
 			}
 		}
 

--- a/core-bundle/src/Resources/contao/controllers/BackendPage.php
+++ b/core-bundle/src/Resources/contao/controllers/BackendPage.php
@@ -125,7 +125,7 @@ class BackendPage extends Backend
 		}
 
 		/** @var PageSelector $strClass */
-		$strClass = $GLOBALS['BE_FFL']['pageSelector'];
+		$strClass = $GLOBALS['BE_FFL']['pageSelector'] ?? null;
 
 		/** @var PageSelector $objPageTree */
 		$objPageTree = new $strClass($strClass::getAttributesFromDca($GLOBALS['TL_DCA'][$strTable]['fields'][$strField], $strField, $arrValues, $strField, $strTable, $objDca));

--- a/core-bundle/src/Resources/contao/controllers/BackendPage.php
+++ b/core-bundle/src/Resources/contao/controllers/BackendPage.php
@@ -108,7 +108,7 @@ class BackendPage extends Backend
 		$arrValues = array_filter(explode(',', Input::get('value')));
 
 		// Call the load_callback
-		if (\is_array($GLOBALS['TL_DCA'][$strTable]['fields'][$strField]['load_callback']))
+		if (\is_array($GLOBALS['TL_DCA'][$strTable]['fields'][$strField]['load_callback'] ?? null))
 		{
 			foreach ($GLOBALS['TL_DCA'][$strTable]['fields'][$strField]['load_callback'] as $callback)
 			{
@@ -143,7 +143,7 @@ class BackendPage extends Backend
 		$objTemplate->addSearch = true;
 		$objTemplate->search = $GLOBALS['TL_LANG']['MSC']['search'];
 		$objTemplate->value = $objSessionBag->get('page_selector_search');
-		$objTemplate->breadcrumb = $GLOBALS['TL_DCA']['tl_page']['list']['sorting']['breadcrumb'];
+		$objTemplate->breadcrumb = $GLOBALS['TL_DCA']['tl_page']['list']['sorting']['breadcrumb'] ?? null;
 
 		if ($this->User->hasAccess('page', 'modules'))
 		{

--- a/core-bundle/src/Resources/contao/controllers/BackendPassword.php
+++ b/core-bundle/src/Resources/contao/controllers/BackendPassword.php
@@ -92,7 +92,7 @@ class BackendPassword extends Backend
 					$this->loadDataContainer('tl_user');
 
 					// Trigger the save_callback
-					if (\is_array($GLOBALS['TL_DCA']['tl_user']['fields']['password']['save_callback']))
+					if (\is_array($GLOBALS['TL_DCA']['tl_user']['fields']['password']['save_callback'] ?? null))
 					{
 						$dc = new DC_Table('tl_user');
 						$dc->id = $this->User->id;

--- a/core-bundle/src/Resources/contao/controllers/FrontendIndex.php
+++ b/core-bundle/src/Resources/contao/controllers/FrontendIndex.php
@@ -288,10 +288,10 @@ class FrontendIndex extends Frontend
 		}
 
 		// Backup some globals (see #7659)
-		$arrHead = $GLOBALS['TL_HEAD'];
-		$arrBody = $GLOBALS['TL_BODY'];
-		$arrMootools = $GLOBALS['TL_MOOTOOLS'];
-		$arrJquery = $GLOBALS['TL_JQUERY'];
+		$arrHead = $GLOBALS['TL_HEAD'] ?? null;
+		$arrBody = $GLOBALS['TL_BODY'] ?? null;
+		$arrMootools = $GLOBALS['TL_MOOTOOLS'] ?? null;
+		$arrJquery = $GLOBALS['TL_JQUERY'] ?? null;
 
 		try
 		{

--- a/core-bundle/src/Resources/contao/dca/tl_article.php
+++ b/core-bundle/src/Resources/contao/dca/tl_article.php
@@ -116,7 +116,7 @@ $GLOBALS['TL_DCA']['tl_article'] = array
 			(
 				'href'                => 'act=delete',
 				'icon'                => 'delete.svg',
-				'attributes'          => 'onclick="if(!confirm(\'' . $GLOBALS['TL_LANG']['MSC']['deleteConfirm'] . '\'))return false;Backend.getScrollOffset()"',
+				'attributes'          => 'onclick="if(!confirm(\'' . ($GLOBALS['TL_LANG']['MSC']['deleteConfirm'] ?? null) . '\'))return false;Backend.getScrollOffset()"',
 				'button_callback'     => array('tl_article', 'deleteArticle')
 			),
 			'toggle' => array
@@ -614,7 +614,7 @@ class tl_article extends Backend
 	public function getActiveLayoutSections(DataContainer $dc)
 	{
 		// Show only active sections
-		if ($dc->activeRecord->pid)
+		if ($dc->activeRecord->pid ?? null)
 		{
 			$arrSections = array();
 			$objPage = PageModel::findWithDetails($dc->activeRecord->pid);

--- a/core-bundle/src/Resources/contao/dca/tl_article.php
+++ b/core-bundle/src/Resources/contao/dca/tl_article.php
@@ -732,7 +732,7 @@ class tl_article extends Backend
 	 */
 	public function copyArticle($row, $href, $label, $title, $icon, $attributes, $table)
 	{
-		if ($GLOBALS['TL_DCA'][$table]['config']['closed'])
+		if ($GLOBALS['TL_DCA'][$table]['config']['closed'] ?? null)
 		{
 			return '';
 		}
@@ -933,7 +933,7 @@ class tl_article extends Backend
 		}
 
 		// Trigger the onload_callback
-		if (is_array($GLOBALS['TL_DCA']['tl_article']['config']['onload_callback']))
+		if (is_array($GLOBALS['TL_DCA']['tl_article']['config']['onload_callback'] ?? null))
 		{
 			foreach ($GLOBALS['TL_DCA']['tl_article']['config']['onload_callback'] as $callback)
 			{
@@ -974,7 +974,7 @@ class tl_article extends Backend
 		$objVersions->initialize();
 
 		// Trigger the save_callback
-		if (is_array($GLOBALS['TL_DCA']['tl_article']['fields']['published']['save_callback']))
+		if (is_array($GLOBALS['TL_DCA']['tl_article']['fields']['published']['save_callback'] ?? null))
 		{
 			foreach ($GLOBALS['TL_DCA']['tl_article']['fields']['published']['save_callback'] as $callback)
 			{
@@ -1003,7 +1003,7 @@ class tl_article extends Backend
 		}
 
 		// Trigger the onsubmit_callback
-		if (is_array($GLOBALS['TL_DCA']['tl_article']['config']['onsubmit_callback']))
+		if (is_array($GLOBALS['TL_DCA']['tl_article']['config']['onsubmit_callback'] ?? null))
 		{
 			foreach ($GLOBALS['TL_DCA']['tl_article']['config']['onsubmit_callback'] as $callback)
 			{

--- a/core-bundle/src/Resources/contao/dca/tl_article.php
+++ b/core-bundle/src/Resources/contao/dca/tl_article.php
@@ -824,7 +824,7 @@ class tl_article extends Backend
 			$objSession = System::getContainer()->get('session');
 
 			$session = $objSession->all();
-			$ids = $session['CURRENT']['IDS'];
+			$ids = $session['CURRENT']['IDS'] ?? array();
 
 			foreach ($ids as $id)
 			{

--- a/core-bundle/src/Resources/contao/dca/tl_content.php
+++ b/core-bundle/src/Resources/contao/dca/tl_content.php
@@ -97,7 +97,7 @@ $GLOBALS['TL_DCA']['tl_content'] = array
 			(
 				'href'                => 'act=delete',
 				'icon'                => 'delete.svg',
-				'attributes'          => 'onclick="if(!confirm(\'' . $GLOBALS['TL_LANG']['MSC']['deleteConfirm'] . '\'))return false;Backend.getScrollOffset()"',
+				'attributes'          => 'onclick="if(!confirm(\'' . ($GLOBALS['TL_LANG']['MSC']['deleteConfirm'] ?? null) . '\'))return false;Backend.getScrollOffset()"',
 				'button_callback'     => array('tl_content', 'deleteElement')
 			),
 			'toggle' => array

--- a/core-bundle/src/Resources/contao/dca/tl_content.php
+++ b/core-bundle/src/Resources/contao/dca/tl_content.php
@@ -1117,7 +1117,7 @@ class tl_content extends Backend
 			$GLOBALS['TL_DCA']['tl_content']['config']['closed'] = true;
 			$GLOBALS['TL_DCA']['tl_content']['config']['notEditable'] = true;
 		}
-		elseif (!in_array($GLOBALS['TL_DCA']['tl_content']['fields']['type']['sql']['default'], $this->User->elements))
+		elseif (!in_array($GLOBALS['TL_DCA']['tl_content']['fields']['type']['sql']['default'] ?? null, $this->User->elements))
 		{
 			$GLOBALS['TL_DCA']['tl_content']['fields']['type']['default'] = $this->User->elements[0];
 		}
@@ -2017,7 +2017,7 @@ class tl_content extends Backend
 		}
 
 		// Trigger the onload_callback
-		if (is_array($GLOBALS['TL_DCA']['tl_content']['config']['onload_callback']))
+		if (is_array($GLOBALS['TL_DCA']['tl_content']['config']['onload_callback'] ?? null))
 		{
 			foreach ($GLOBALS['TL_DCA']['tl_content']['config']['onload_callback'] as $callback)
 			{
@@ -2066,7 +2066,7 @@ class tl_content extends Backend
 		$blnVisible = !$blnVisible;
 
 		// Trigger the save_callback
-		if (is_array($GLOBALS['TL_DCA']['tl_content']['fields']['invisible']['save_callback']))
+		if (is_array($GLOBALS['TL_DCA']['tl_content']['fields']['invisible']['save_callback'] ?? null))
 		{
 			foreach ($GLOBALS['TL_DCA']['tl_content']['fields']['invisible']['save_callback'] as $callback)
 			{
@@ -2095,7 +2095,7 @@ class tl_content extends Backend
 		}
 
 		// Trigger the onsubmit_callback
-		if (is_array($GLOBALS['TL_DCA']['tl_content']['config']['onsubmit_callback']))
+		if (is_array($GLOBALS['TL_DCA']['tl_content']['config']['onsubmit_callback'] ?? null))
 		{
 			foreach ($GLOBALS['TL_DCA']['tl_content']['config']['onsubmit_callback'] as $callback)
 			{

--- a/core-bundle/src/Resources/contao/dca/tl_files.php
+++ b/core-bundle/src/Resources/contao/dca/tl_files.php
@@ -603,16 +603,19 @@ class tl_files extends Backend
 		// Check the length without the file extension
 		if ($dc->activeRecord && $varValue)
 		{
-			$intMaxlength = $GLOBALS['TL_DCA'][$dc->table]['fields'][$dc->field]['eval']['maxlength'];
+			$intMaxlength = $GLOBALS['TL_DCA'][$dc->table]['fields'][$dc->field]['eval']['maxlength'] ?? null;
 
-			if ($dc->activeRecord->type == 'file')
+			if ($intMaxlength)
 			{
-				$intMaxlength -= (strlen($dc->activeRecord->extension) + 1);
-			}
+				if ($dc->activeRecord->type == 'file')
+				{
+					$intMaxlength -= (strlen($dc->activeRecord->extension) + 1);
+				}
 
-			if ($intMaxlength && Utf8::strlen($varValue) > $intMaxlength)
-			{
-				throw new Exception(sprintf($GLOBALS['TL_LANG']['ERR']['maxlength'], $GLOBALS['TL_DCA'][$dc->table]['fields'][$dc->field]['label'][0], $intMaxlength));
+				if (Utf8::strlen($varValue) > $intMaxlength)
+				{
+					throw new Exception(sprintf($GLOBALS['TL_LANG']['ERR']['maxlength'], $GLOBALS['TL_DCA'][$dc->table]['fields'][$dc->field]['label'][0], $intMaxlength));
+				}
 			}
 		}
 
@@ -717,7 +720,7 @@ class tl_files extends Backend
 	 */
 	public function uploadFile($row, $href, $label, $title, $icon, $attributes)
 	{
-		if (isset($row['type']) && $row['type'] == 'folder' && !$GLOBALS['TL_DCA']['tl_files']['config']['closed'] && !$GLOBALS['TL_DCA']['tl_files']['config']['notCreatable'] && Input::get('act') != 'select')
+		if (($row['type'] ?? null) == 'folder' && !($GLOBALS['TL_DCA']['tl_files']['config']['closed'] ?? null) && !($GLOBALS['TL_DCA']['tl_files']['config']['notCreatable'] ?? null) && Input::get('act') != 'select')
 		{
 			return '<a href="' . $this->addToUrl($href . '&amp;pid=' . $row['id']) . '" title="' . StringUtil::specialchars($title) . '" ' . $attributes . '>' . Image::getHtml($icon, $label) . '</a> ';
 		}

--- a/core-bundle/src/Resources/contao/dca/tl_files.php
+++ b/core-bundle/src/Resources/contao/dca/tl_files.php
@@ -547,7 +547,7 @@ class tl_files extends Backend
 
 		$arrData = StringUtil::deserialize($objData->data);
 
-		if (!is_array($arrData))
+		if (!is_array($arrData) || !isset($arrData['content']))
 		{
 			return;
 		}
@@ -875,7 +875,7 @@ class tl_files extends Backend
 			}
 		}
 
-		$class = $GLOBALS['TL_DCA'][$dc->table]['fields'][$dc->field]['eval']['tl_class'] . ' cbx';
+		$class = ($GLOBALS['TL_DCA'][$dc->table]['fields'][$dc->field]['eval']['tl_class'] ?? '') . ' cbx';
 
 		if (in_array(Input::get('act'), array('editAll', 'overrideAll')))
 		{
@@ -960,7 +960,7 @@ class tl_files extends Backend
 			}
 		}
 
-		$class = $GLOBALS['TL_DCA'][$dc->table]['fields'][$dc->field]['eval']['tl_class'] . ' cbx';
+		$class = ($GLOBALS['TL_DCA'][$dc->table]['fields'][$dc->field]['eval']['tl_class'] ?? '') . ' cbx';
 
 		if (in_array(Input::get('act'), array('editAll', 'overrideAll')))
 		{

--- a/core-bundle/src/Resources/contao/dca/tl_form.php
+++ b/core-bundle/src/Resources/contao/dca/tl_form.php
@@ -99,7 +99,7 @@ $GLOBALS['TL_DCA']['tl_form'] = array
 			(
 				'href'                => 'act=delete',
 				'icon'                => 'delete.svg',
-				'attributes'          => 'onclick="if(!confirm(\'' . $GLOBALS['TL_LANG']['MSC']['deleteConfirm'] . '\'))return false;Backend.getScrollOffset()"',
+				'attributes'          => 'onclick="if(!confirm(\'' . ($GLOBALS['TL_LANG']['MSC']['deleteConfirm'] ?? null) . '\'))return false;Backend.getScrollOffset()"',
 				'button_callback'     => array('tl_form', 'deleteForm')
 			),
 			'show' => array

--- a/core-bundle/src/Resources/contao/dca/tl_form_field.php
+++ b/core-bundle/src/Resources/contao/dca/tl_form_field.php
@@ -562,7 +562,7 @@ class tl_form_field extends Backend
 			$GLOBALS['TL_DCA']['tl_form_field']['config']['closed'] = true;
 			$GLOBALS['TL_DCA']['tl_form_field']['config']['notEditable'] = true;
 		}
-		elseif (!in_array($GLOBALS['TL_DCA']['tl_form_field']['fields']['type']['sql']['default'], $this->User->fields))
+		elseif (!in_array($GLOBALS['TL_DCA']['tl_form_field']['fields']['type']['sql']['default'] ?? null, $this->User->fields))
 		{
 			$GLOBALS['TL_DCA']['tl_form_field']['fields']['type']['default'] = $this->User->fields[0];
 		}
@@ -833,7 +833,7 @@ class tl_form_field extends Backend
 		}
 
 		// Trigger the onload_callback
-		if (is_array($GLOBALS['TL_DCA']['tl_form_field']['config']['onload_callback']))
+		if (is_array($GLOBALS['TL_DCA']['tl_form_field']['config']['onload_callback'] ?? null))
 		{
 			foreach ($GLOBALS['TL_DCA']['tl_form_field']['config']['onload_callback'] as $callback)
 			{
@@ -882,7 +882,7 @@ class tl_form_field extends Backend
 		$blnVisible = !$blnVisible;
 
 		// Trigger the save_callback
-		if (is_array($GLOBALS['TL_DCA']['tl_form_field']['fields']['invisible']['save_callback']))
+		if (is_array($GLOBALS['TL_DCA']['tl_form_field']['fields']['invisible']['save_callback'] ?? null))
 		{
 			foreach ($GLOBALS['TL_DCA']['tl_form_field']['fields']['invisible']['save_callback'] as $callback)
 			{
@@ -911,7 +911,7 @@ class tl_form_field extends Backend
 		}
 
 		// Trigger the onsubmit_callback
-		if (is_array($GLOBALS['TL_DCA']['tl_form_field']['config']['onsubmit_callback']))
+		if (is_array($GLOBALS['TL_DCA']['tl_form_field']['config']['onsubmit_callback'] ?? null))
 		{
 			foreach ($GLOBALS['TL_DCA']['tl_form_field']['config']['onsubmit_callback'] as $callback)
 			{

--- a/core-bundle/src/Resources/contao/dca/tl_form_field.php
+++ b/core-bundle/src/Resources/contao/dca/tl_form_field.php
@@ -645,7 +645,7 @@ class tl_form_field extends Backend
 <div class="cte_type ' . $key . '">' . $GLOBALS['TL_LANG']['FFL'][$arrRow['type']][0] . ($arrRow['name'] ? ' (' . $arrRow['name'] . ')' : '') . '</div>
 <div class="limit_height' . (!Config::get('doNotCollapse') ? ' h32' : '') . '">';
 
-		$strClass = $GLOBALS['TL_FFL'][$arrRow['type']];
+		$strClass = $GLOBALS['TL_FFL'][$arrRow['type']] ?? null;
 
 		if (!class_exists($strClass))
 		{

--- a/core-bundle/src/Resources/contao/dca/tl_form_field.php
+++ b/core-bundle/src/Resources/contao/dca/tl_form_field.php
@@ -90,7 +90,7 @@ $GLOBALS['TL_DCA']['tl_form_field'] = array
 			(
 				'href'                => 'act=delete',
 				'icon'                => 'delete.svg',
-				'attributes'          => 'onclick="if(!confirm(\'' . $GLOBALS['TL_LANG']['MSC']['deleteConfirm'] . '\'))return false;Backend.getScrollOffset()"',
+				'attributes'          => 'onclick="if(!confirm(\'' . ($GLOBALS['TL_LANG']['MSC']['deleteConfirm'] ?? null) . '\'))return false;Backend.getScrollOffset()"',
 				'button_callback'     => array('tl_form_field', 'disableButton')
 			),
 			'toggle' => array

--- a/core-bundle/src/Resources/contao/dca/tl_image_size.php
+++ b/core-bundle/src/Resources/contao/dca/tl_image_size.php
@@ -102,7 +102,7 @@ $GLOBALS['TL_DCA']['tl_image_size'] = array
 			(
 				'href'                => 'act=delete',
 				'icon'                => 'delete.svg',
-				'attributes'          => 'onclick="if(!confirm(\'' . $GLOBALS['TL_LANG']['MSC']['deleteConfirm'] . '\'))return false;Backend.getScrollOffset()"'
+				'attributes'          => 'onclick="if(!confirm(\'' . ($GLOBALS['TL_LANG']['MSC']['deleteConfirm'] ?? null) . '\'))return false;Backend.getScrollOffset()"'
 			),
 			'show' => array
 			(

--- a/core-bundle/src/Resources/contao/dca/tl_image_size_item.php
+++ b/core-bundle/src/Resources/contao/dca/tl_image_size_item.php
@@ -313,7 +313,7 @@ class tl_image_size_item extends Backend
 		}
 
 		// Trigger the onload_callback
-		if (is_array($GLOBALS['TL_DCA']['tl_image_size_item']['config']['onload_callback']))
+		if (is_array($GLOBALS['TL_DCA']['tl_image_size_item']['config']['onload_callback'] ?? null))
 		{
 			foreach ($GLOBALS['TL_DCA']['tl_image_size_item']['config']['onload_callback'] as $callback)
 			{
@@ -357,7 +357,7 @@ class tl_image_size_item extends Backend
 		$blnVisible = !$blnVisible;
 
 		// Trigger the save_callback
-		if (is_array($GLOBALS['TL_DCA']['tl_image_size_item']['fields']['invisible']['save_callback']))
+		if (is_array($GLOBALS['TL_DCA']['tl_image_size_item']['fields']['invisible']['save_callback'] ?? null))
 		{
 			foreach ($GLOBALS['TL_DCA']['tl_image_size_item']['fields']['invisible']['save_callback'] as $callback)
 			{
@@ -386,7 +386,7 @@ class tl_image_size_item extends Backend
 		}
 
 		// Trigger the onsubmit_callback
-		if (is_array($GLOBALS['TL_DCA']['tl_image_size_item']['config']['onsubmit_callback']))
+		if (is_array($GLOBALS['TL_DCA']['tl_image_size_item']['config']['onsubmit_callback'] ?? null))
 		{
 			foreach ($GLOBALS['TL_DCA']['tl_image_size_item']['config']['onsubmit_callback'] as $callback)
 			{

--- a/core-bundle/src/Resources/contao/dca/tl_image_size_item.php
+++ b/core-bundle/src/Resources/contao/dca/tl_image_size_item.php
@@ -85,7 +85,7 @@ $GLOBALS['TL_DCA']['tl_image_size_item'] = array
 			(
 				'href'                => 'act=delete',
 				'icon'                => 'delete.svg',
-				'attributes'          => 'onclick="if(!confirm(\'' . $GLOBALS['TL_LANG']['MSC']['deleteConfirm'] . '\'))return false;Backend.getScrollOffset()"'
+				'attributes'          => 'onclick="if(!confirm(\'' . ($GLOBALS['TL_LANG']['MSC']['deleteConfirm'] ?? null) . '\'))return false;Backend.getScrollOffset()"'
 			),
 			'toggle' => array
 			(

--- a/core-bundle/src/Resources/contao/dca/tl_layout.php
+++ b/core-bundle/src/Resources/contao/dca/tl_layout.php
@@ -84,7 +84,7 @@ $GLOBALS['TL_DCA']['tl_layout'] = array
 			(
 				'href'                => 'act=delete',
 				'icon'                => 'delete.svg',
-				'attributes'          => 'onclick="if(!confirm(\'' . $GLOBALS['TL_LANG']['MSC']['deleteConfirm'] . '\'))return false;Backend.getScrollOffset()"'
+				'attributes'          => 'onclick="if(!confirm(\'' . ($GLOBALS['TL_LANG']['MSC']['deleteConfirm'] ?? null) . '\'))return false;Backend.getScrollOffset()"'
 			),
 			'show' => array
 			(

--- a/core-bundle/src/Resources/contao/dca/tl_log.php
+++ b/core-bundle/src/Resources/contao/dca/tl_log.php
@@ -58,7 +58,7 @@ $GLOBALS['TL_DCA']['tl_log'] = array
 			(
 				'href'                => 'act=delete',
 				'icon'                => 'delete.svg',
-				'attributes'          => 'onclick="if(!confirm(\'' . $GLOBALS['TL_LANG']['MSC']['deleteConfirm'] . '\'))return false;Backend.getScrollOffset()"'
+				'attributes'          => 'onclick="if(!confirm(\'' . ($GLOBALS['TL_LANG']['MSC']['deleteConfirm'] ?? null) . '\'))return false;Backend.getScrollOffset()"'
 			),
 			'show' => array
 			(

--- a/core-bundle/src/Resources/contao/dca/tl_member.php
+++ b/core-bundle/src/Resources/contao/dca/tl_member.php
@@ -85,7 +85,7 @@ $GLOBALS['TL_DCA']['tl_member'] = array
 			(
 				'href'                => 'act=delete',
 				'icon'                => 'delete.svg',
-				'attributes'          => 'onclick="if(!confirm(\'' . $GLOBALS['TL_LANG']['MSC']['deleteConfirm'] . '\'))return false;Backend.getScrollOffset()"'
+				'attributes'          => 'onclick="if(!confirm(\'' . ($GLOBALS['TL_LANG']['MSC']['deleteConfirm'] ?? null) . '\'))return false;Backend.getScrollOffset()"'
 			),
 			'toggle' => array
 			(

--- a/core-bundle/src/Resources/contao/dca/tl_member.php
+++ b/core-bundle/src/Resources/contao/dca/tl_member.php
@@ -637,7 +637,7 @@ class tl_member extends Backend
 		}
 
 		// Trigger the onload_callback
-		if (is_array($GLOBALS['TL_DCA']['tl_member']['config']['onload_callback']))
+		if (is_array($GLOBALS['TL_DCA']['tl_member']['config']['onload_callback'] ?? null))
 		{
 			foreach ($GLOBALS['TL_DCA']['tl_member']['config']['onload_callback'] as $callback)
 			{
@@ -681,7 +681,7 @@ class tl_member extends Backend
 		$blnVisible = !$blnVisible;
 
 		// Trigger the save_callback
-		if (is_array($GLOBALS['TL_DCA']['tl_member']['fields']['disable']['save_callback']))
+		if (is_array($GLOBALS['TL_DCA']['tl_member']['fields']['disable']['save_callback'] ?? null))
 		{
 			foreach ($GLOBALS['TL_DCA']['tl_member']['fields']['disable']['save_callback'] as $callback)
 			{
@@ -710,7 +710,7 @@ class tl_member extends Backend
 		}
 
 		// Trigger the onsubmit_callback
-		if (is_array($GLOBALS['TL_DCA']['tl_member']['config']['onsubmit_callback']))
+		if (is_array($GLOBALS['TL_DCA']['tl_member']['config']['onsubmit_callback'] ?? null))
 		{
 			foreach ($GLOBALS['TL_DCA']['tl_member']['config']['onsubmit_callback'] as $callback)
 			{

--- a/core-bundle/src/Resources/contao/dca/tl_member_group.php
+++ b/core-bundle/src/Resources/contao/dca/tl_member_group.php
@@ -259,7 +259,7 @@ class tl_member_group extends Backend
 		}
 
 		// Trigger the onload_callback
-		if (is_array($GLOBALS['TL_DCA']['tl_member_group']['config']['onload_callback']))
+		if (is_array($GLOBALS['TL_DCA']['tl_member_group']['config']['onload_callback'] ?? null))
 		{
 			foreach ($GLOBALS['TL_DCA']['tl_member_group']['config']['onload_callback'] as $callback)
 			{
@@ -303,7 +303,7 @@ class tl_member_group extends Backend
 		$blnVisible = !$blnVisible;
 
 		// Trigger the save_callback
-		if (is_array($GLOBALS['TL_DCA']['tl_member_group']['fields']['disable']['save_callback']))
+		if (is_array($GLOBALS['TL_DCA']['tl_member_group']['fields']['disable']['save_callback'] ?? null))
 		{
 			foreach ($GLOBALS['TL_DCA']['tl_member_group']['fields']['disable']['save_callback'] as $callback)
 			{
@@ -332,7 +332,7 @@ class tl_member_group extends Backend
 		}
 
 		// Trigger the onsubmit_callback
-		if (is_array($GLOBALS['TL_DCA']['tl_member_group']['config']['onsubmit_callback']))
+		if (is_array($GLOBALS['TL_DCA']['tl_member_group']['config']['onsubmit_callback'] ?? null))
 		{
 			foreach ($GLOBALS['TL_DCA']['tl_member_group']['config']['onsubmit_callback'] as $callback)
 			{

--- a/core-bundle/src/Resources/contao/dca/tl_member_group.php
+++ b/core-bundle/src/Resources/contao/dca/tl_member_group.php
@@ -76,7 +76,7 @@ $GLOBALS['TL_DCA']['tl_member_group'] = array
 			(
 				'href'                => 'act=delete',
 				'icon'                => 'delete.svg',
-				'attributes'          => 'onclick="if(!confirm(\'' . $GLOBALS['TL_LANG']['MSC']['deleteConfirm'] . '\'))return false;Backend.getScrollOffset()"'
+				'attributes'          => 'onclick="if(!confirm(\'' . ($GLOBALS['TL_LANG']['MSC']['deleteConfirm'] ?? null) . '\'))return false;Backend.getScrollOffset()"'
 			),
 			'toggle' => array
 			(

--- a/core-bundle/src/Resources/contao/dca/tl_module.php
+++ b/core-bundle/src/Resources/contao/dca/tl_module.php
@@ -87,7 +87,7 @@ $GLOBALS['TL_DCA']['tl_module'] = array
 			(
 				'href'                => 'act=delete',
 				'icon'                => 'delete.svg',
-				'attributes'          => 'onclick="if(!confirm(\'' . $GLOBALS['TL_LANG']['MSC']['deleteConfirm'] . '\'))return false;Backend.getScrollOffset()"'
+				'attributes'          => 'onclick="if(!confirm(\'' . ($GLOBALS['TL_LANG']['MSC']['deleteConfirm'] ?? null) . '\'))return false;Backend.getScrollOffset()"'
 			),
 			'show' => array
 			(

--- a/core-bundle/src/Resources/contao/dca/tl_module.php
+++ b/core-bundle/src/Resources/contao/dca/tl_module.php
@@ -793,7 +793,7 @@ class tl_module extends Backend
 	{
 		if (trim($varValue) === '')
 		{
-			$varValue = (is_array($GLOBALS['TL_LANG']['tl_module']['emailText']) ? $GLOBALS['TL_LANG']['tl_module']['emailText'][1] : $GLOBALS['TL_LANG']['tl_module']['emailText']);
+			$varValue = (is_array($GLOBALS['TL_LANG']['tl_module']['emailText'] ?? null) ? $GLOBALS['TL_LANG']['tl_module']['emailText'][1] : ($GLOBALS['TL_LANG']['tl_module']['emailText'] ?? null));
 		}
 
 		return $varValue;
@@ -810,7 +810,7 @@ class tl_module extends Backend
 	{
 		if (trim($varValue) === '')
 		{
-			$varValue = (is_array($GLOBALS['TL_LANG']['tl_module']['passwordText']) ? $GLOBALS['TL_LANG']['tl_module']['passwordText'][1] : $GLOBALS['TL_LANG']['tl_module']['passwordText']);
+			$varValue = (is_array($GLOBALS['TL_LANG']['tl_module']['passwordText'] ?? null) ? $GLOBALS['TL_LANG']['tl_module']['passwordText'][1] : ($GLOBALS['TL_LANG']['tl_module']['passwordText'] ?? null));
 		}
 
 		return $varValue;

--- a/core-bundle/src/Resources/contao/dca/tl_module.php
+++ b/core-bundle/src/Resources/contao/dca/tl_module.php
@@ -695,7 +695,7 @@ class tl_module extends Backend
 
 		foreach ($GLOBALS['TL_DCA']['tl_member']['fields'] as $k=>$v)
 		{
-			if ($v['eval']['feEditable'])
+			if ($v['eval']['feEditable'] ?? null)
 			{
 				$return[$k] = $GLOBALS['TL_DCA']['tl_member']['fields'][$k]['label'][0];
 			}

--- a/core-bundle/src/Resources/contao/dca/tl_opt_in.php
+++ b/core-bundle/src/Resources/contao/dca/tl_opt_in.php
@@ -167,7 +167,7 @@ class tl_opt_in extends Backend
 
 			foreach ($arrRow as $k=>$v)
 			{
-				$label = is_array($GLOBALS['TL_DCA']['tl_opt_in_related']['fields'][$k]['label']) ? $GLOBALS['TL_DCA']['tl_opt_in_related']['fields'][$k]['label'][0] : $GLOBALS['TL_DCA']['tl_opt_in_related']['fields'][$k]['label'];
+				$label = is_array($GLOBALS['TL_DCA']['tl_opt_in_related']['fields'][$k]['label'] ?? null) ? $GLOBALS['TL_DCA']['tl_opt_in_related']['fields'][$k]['label'][0] : ($GLOBALS['TL_DCA']['tl_opt_in_related']['fields'][$k]['label'] ?? null);
 
 				$arrAdd[$label] = $v;
 			}

--- a/core-bundle/src/Resources/contao/dca/tl_page.php
+++ b/core-bundle/src/Resources/contao/dca/tl_page.php
@@ -139,7 +139,7 @@ $GLOBALS['TL_DCA']['tl_page'] = array
 			(
 				'href'                => 'act=delete',
 				'icon'                => 'delete.svg',
-				'attributes'          => 'onclick="if(!confirm(\'' . $GLOBALS['TL_LANG']['MSC']['deleteConfirm'] . '\'))return false;Backend.getScrollOffset()"',
+				'attributes'          => 'onclick="if(!confirm(\'' . ($GLOBALS['TL_LANG']['MSC']['deleteConfirm'] ?? null) . '\'))return false;Backend.getScrollOffset()"',
 				'button_callback'     => array('tl_page', 'deletePage')
 			),
 			'toggle' => array

--- a/core-bundle/src/Resources/contao/dca/tl_page.php
+++ b/core-bundle/src/Resources/contao/dca/tl_page.php
@@ -1386,7 +1386,7 @@ class tl_page extends Backend
 	 */
 	public function copyPage($row, $href, $label, $title, $icon, $attributes, $table)
 	{
-		if ($GLOBALS['TL_DCA'][$table]['config']['closed'])
+		if ($GLOBALS['TL_DCA'][$table]['config']['closed'] ?? null)
 		{
 			return '';
 		}
@@ -1409,7 +1409,7 @@ class tl_page extends Backend
 	 */
 	public function copyPageWithSubpages($row, $href, $label, $title, $icon, $attributes, $table)
 	{
-		if ($GLOBALS['TL_DCA'][$table]['config']['closed'])
+		if ($GLOBALS['TL_DCA'][$table]['config']['closed'] ?? null)
 		{
 			return '';
 		}
@@ -1603,16 +1603,19 @@ class tl_page extends Backend
 				$strAlias = '';
 
 				// Generate new alias through save callbacks
-				foreach ($GLOBALS['TL_DCA'][$dc->table]['fields']['alias']['save_callback'] as $callback)
+				if (is_array($GLOBALS['TL_DCA'][$dc->table]['fields']['alias']['save_callback'] ?? null))
 				{
-					if (is_array($callback))
+					foreach ($GLOBALS['TL_DCA'][$dc->table]['fields']['alias']['save_callback'] as $callback)
 					{
-						$this->import($callback[0]);
-						$strAlias = $this->{$callback[0]}->{$callback[1]}($strAlias, $dc);
-					}
-					elseif (is_callable($callback))
-					{
-						$strAlias = $callback($strAlias, $dc);
+						if (is_array($callback))
+						{
+							$this->import($callback[0]);
+							$strAlias = $this->{$callback[0]}->{$callback[1]}($strAlias, $dc);
+						}
+						elseif (is_callable($callback))
+						{
+							$strAlias = $callback($strAlias, $dc);
+						}
 					}
 				}
 
@@ -1705,7 +1708,7 @@ class tl_page extends Backend
 		}
 
 		// Trigger the onload_callback
-		if (is_array($GLOBALS['TL_DCA']['tl_page']['config']['onload_callback']))
+		if (is_array($GLOBALS['TL_DCA']['tl_page']['config']['onload_callback'] ?? null))
 		{
 			foreach ($GLOBALS['TL_DCA']['tl_page']['config']['onload_callback'] as $callback)
 			{
@@ -1746,7 +1749,7 @@ class tl_page extends Backend
 		$objVersions->initialize();
 
 		// Trigger the save_callback
-		if (is_array($GLOBALS['TL_DCA']['tl_page']['fields']['published']['save_callback']))
+		if (is_array($GLOBALS['TL_DCA']['tl_page']['fields']['published']['save_callback'] ?? null))
 		{
 			foreach ($GLOBALS['TL_DCA']['tl_page']['fields']['published']['save_callback'] as $callback)
 			{
@@ -1775,7 +1778,7 @@ class tl_page extends Backend
 		}
 
 		// Trigger the onsubmit_callback
-		if (is_array($GLOBALS['TL_DCA']['tl_page']['config']['onsubmit_callback']))
+		if (is_array($GLOBALS['TL_DCA']['tl_page']['config']['onsubmit_callback'] ?? null))
 		{
 			foreach ($GLOBALS['TL_DCA']['tl_page']['config']['onsubmit_callback'] as $callback)
 			{

--- a/core-bundle/src/Resources/contao/dca/tl_page.php
+++ b/core-bundle/src/Resources/contao/dca/tl_page.php
@@ -1586,7 +1586,7 @@ class tl_page extends Backend
 			$objSession = System::getContainer()->get('session');
 
 			$session = $objSession->all();
-			$ids = $session['CURRENT']['IDS'];
+			$ids = $session['CURRENT']['IDS'] ?? array();
 
 			foreach ($ids as $id)
 			{

--- a/core-bundle/src/Resources/contao/dca/tl_style.php
+++ b/core-bundle/src/Resources/contao/dca/tl_style.php
@@ -728,7 +728,7 @@ class tl_style extends Backend
 		}
 
 		// Trigger the onload_callback
-		if (is_array($GLOBALS['TL_DCA']['tl_style']['config']['onload_callback']))
+		if (is_array($GLOBALS['TL_DCA']['tl_style']['config']['onload_callback'] ?? null))
 		{
 			foreach ($GLOBALS['TL_DCA']['tl_style']['config']['onload_callback'] as $callback)
 			{
@@ -766,7 +766,7 @@ class tl_style extends Backend
 		$blnVisible = !$blnVisible;
 
 		// Trigger the save_callback
-		if (is_array($GLOBALS['TL_DCA']['tl_style']['fields']['invisible']['save_callback']))
+		if (is_array($GLOBALS['TL_DCA']['tl_style']['fields']['invisible']['save_callback'] ?? null))
 		{
 			foreach ($GLOBALS['TL_DCA']['tl_style']['fields']['invisible']['save_callback'] as $callback)
 			{
@@ -795,7 +795,7 @@ class tl_style extends Backend
 		}
 
 		// Trigger the onsubmit_callback
-		if (is_array($GLOBALS['TL_DCA']['tl_style']['config']['onsubmit_callback']))
+		if (is_array($GLOBALS['TL_DCA']['tl_style']['config']['onsubmit_callback'] ?? null))
 		{
 			foreach ($GLOBALS['TL_DCA']['tl_style']['config']['onsubmit_callback'] as $callback)
 			{

--- a/core-bundle/src/Resources/contao/dca/tl_style.php
+++ b/core-bundle/src/Resources/contao/dca/tl_style.php
@@ -109,7 +109,7 @@ $GLOBALS['TL_DCA']['tl_style'] = array
 			(
 				'href'                => 'act=delete',
 				'icon'                => 'delete.svg',
-				'attributes'          => 'onclick="if(!confirm(\'' . $GLOBALS['TL_LANG']['MSC']['deleteConfirm'] . '\'))return false;Backend.getScrollOffset()"'
+				'attributes'          => 'onclick="if(!confirm(\'' . ($GLOBALS['TL_LANG']['MSC']['deleteConfirm'] ?? null) . '\'))return false;Backend.getScrollOffset()"'
 			),
 			'toggle' => array
 			(

--- a/core-bundle/src/Resources/contao/dca/tl_style_sheet.php
+++ b/core-bundle/src/Resources/contao/dca/tl_style_sheet.php
@@ -107,7 +107,7 @@ $GLOBALS['TL_DCA']['tl_style_sheet'] = array
 			(
 				'href'                => 'act=delete',
 				'icon'                => 'delete.svg',
-				'attributes'          => 'onclick="if(!confirm(\'' . $GLOBALS['TL_LANG']['MSC']['deleteConfirm'] . '\'))return false;Backend.getScrollOffset()"'
+				'attributes'          => 'onclick="if(!confirm(\'' . ($GLOBALS['TL_LANG']['MSC']['deleteConfirm'] ?? null) . '\'))return false;Backend.getScrollOffset()"'
 			),
 			'show' => array
 			(

--- a/core-bundle/src/Resources/contao/dca/tl_theme.php
+++ b/core-bundle/src/Resources/contao/dca/tl_theme.php
@@ -100,7 +100,7 @@ $GLOBALS['TL_DCA']['tl_theme'] = array
 			(
 				'href'                => 'act=delete',
 				'icon'                => 'delete.svg',
-				'attributes'          => 'onclick="if(!confirm(\'' . $GLOBALS['TL_LANG']['MSC']['deleteConfirm'] . '\'))return false;Backend.getScrollOffset()"'
+				'attributes'          => 'onclick="if(!confirm(\'' . ($GLOBALS['TL_LANG']['MSC']['deleteConfirm'] ?? null) . '\'))return false;Backend.getScrollOffset()"'
 			),
 			'show' => array
 			(

--- a/core-bundle/src/Resources/contao/dca/tl_undo.php
+++ b/core-bundle/src/Resources/contao/dca/tl_undo.php
@@ -148,7 +148,7 @@ class tl_undo extends Backend
 		$GLOBALS['TL_DCA']['tl_undo']['list']['sorting']['root'] = $objSteps->numRows ? $objSteps->fetchEach('id') : array(0);
 
 		// Redirect if there is an error
-		if (Input::get('act') && !in_array(Input::get('id'), $GLOBALS['TL_DCA']['tl_undo']['list']['sorting']['root']))
+		if (Input::get('act') && !in_array(Input::get('id'), $GLOBALS['TL_DCA']['tl_undo']['list']['sorting']['root'] ?? array()))
 		{
 			throw new AccessDeniedException('Not enough permissions to ' . Input::get('act') . ' undo step ID ' . Input::get('id') . '.');
 		}

--- a/core-bundle/src/Resources/contao/dca/tl_undo.php
+++ b/core-bundle/src/Resources/contao/dca/tl_undo.php
@@ -187,14 +187,16 @@ class tl_undo extends Backend
 						}
 					}
 
+					$label = null;
+
 					// Get the field label
 					if (isset($GLOBALS['TL_DCA'][$strTable]['fields'][$i]['label']))
 					{
 						$label = is_array($GLOBALS['TL_DCA'][$strTable]['fields'][$i]['label']) ? $GLOBALS['TL_DCA'][$strTable]['fields'][$i]['label'][0] : $GLOBALS['TL_DCA'][$strTable]['fields'][$i]['label'];
 					}
-					else
+					elseif (isset($GLOBALS['TL_LANG']['MSC'][$i]))
 					{
-						$label = is_array($GLOBALS['TL_LANG']['MSC'][$i] ?? null) ? $GLOBALS['TL_LANG']['MSC'][$i][0] : ($GLOBALS['TL_LANG']['MSC'][$i] ?? null);
+						$label = is_array($GLOBALS['TL_LANG']['MSC'][$i]) ? $GLOBALS['TL_LANG']['MSC'][$i][0] : $GLOBALS['TL_LANG']['MSC'][$i];
 					}
 
 					if (!$label)

--- a/core-bundle/src/Resources/contao/dca/tl_undo.php
+++ b/core-bundle/src/Resources/contao/dca/tl_undo.php
@@ -194,7 +194,7 @@ class tl_undo extends Backend
 					}
 					else
 					{
-						$label = is_array($GLOBALS['TL_LANG']['MSC'][$i]) ? $GLOBALS['TL_LANG']['MSC'][$i][0] : $GLOBALS['TL_LANG']['MSC'][$i];
+						$label = is_array($GLOBALS['TL_LANG']['MSC'][$i] ?? null) ? $GLOBALS['TL_LANG']['MSC'][$i][0] : ($GLOBALS['TL_LANG']['MSC'][$i] ?? null);
 					}
 
 					if (!$label)

--- a/core-bundle/src/Resources/contao/dca/tl_user.php
+++ b/core-bundle/src/Resources/contao/dca/tl_user.php
@@ -586,7 +586,7 @@ class tl_user extends Backend
 			'default' => $GLOBALS['TL_DCA'][$dc->table]['palettes']['login']
 		);
 
-		$arrFields = StringUtil::trimsplit('[,;]', $GLOBALS['TL_DCA'][$dc->table]['palettes']['default']);
+		$arrFields = StringUtil::trimsplit('[,;]', $GLOBALS['TL_DCA'][$dc->table]['palettes']['default'] ?? '');
 
 		foreach ($arrFields as $strField)
 		{
@@ -679,7 +679,7 @@ class tl_user extends Backend
 	 */
 	public function copyUser($row, $href, $label, $title, $icon, $attributes, $table)
 	{
-		if ($GLOBALS['TL_DCA'][$table]['config']['closed'])
+		if ($GLOBALS['TL_DCA'][$table]['config']['closed'] ?? null)
 		{
 			return '';
 		}
@@ -1013,7 +1013,7 @@ class tl_user extends Backend
 		}
 
 		// Trigger the onload_callback
-		if (is_array($GLOBALS['TL_DCA']['tl_user']['config']['onload_callback']))
+		if (is_array($GLOBALS['TL_DCA']['tl_user']['config']['onload_callback'] ?? null))
 		{
 			foreach ($GLOBALS['TL_DCA']['tl_user']['config']['onload_callback'] as $callback)
 			{
@@ -1057,7 +1057,7 @@ class tl_user extends Backend
 		$blnVisible = !$blnVisible;
 
 		// Trigger the save_callback
-		if (is_array($GLOBALS['TL_DCA']['tl_user']['fields']['disable']['save_callback']))
+		if (is_array($GLOBALS['TL_DCA']['tl_user']['fields']['disable']['save_callback'] ?? null))
 		{
 			foreach ($GLOBALS['TL_DCA']['tl_user']['fields']['disable']['save_callback'] as $callback)
 			{
@@ -1086,7 +1086,7 @@ class tl_user extends Backend
 		}
 
 		// Trigger the onsubmit_callback
-		if (is_array($GLOBALS['TL_DCA']['tl_user']['config']['onsubmit_callback']))
+		if (is_array($GLOBALS['TL_DCA']['tl_user']['config']['onsubmit_callback'] ?? null))
 		{
 			foreach ($GLOBALS['TL_DCA']['tl_user']['config']['onsubmit_callback'] as $callback)
 			{

--- a/core-bundle/src/Resources/contao/dca/tl_user.php
+++ b/core-bundle/src/Resources/contao/dca/tl_user.php
@@ -96,7 +96,7 @@ $GLOBALS['TL_DCA']['tl_user'] = array
 			(
 				'href'                => 'act=delete',
 				'icon'                => 'delete.svg',
-				'attributes'          => 'onclick="if(!confirm(\'' . $GLOBALS['TL_LANG']['MSC']['deleteConfirm'] . '\'))return false;Backend.getScrollOffset()"',
+				'attributes'          => 'onclick="if(!confirm(\'' . ($GLOBALS['TL_LANG']['MSC']['deleteConfirm'] ?? null) . '\'))return false;Backend.getScrollOffset()"',
 				'button_callback'     => array('tl_user', 'deleteUser')
 			),
 			'toggle' => array

--- a/core-bundle/src/Resources/contao/dca/tl_user_group.php
+++ b/core-bundle/src/Resources/contao/dca/tl_user_group.php
@@ -82,7 +82,7 @@ $GLOBALS['TL_DCA']['tl_user_group'] = array
 			(
 				'href'                => 'act=delete',
 				'icon'                => 'delete.svg',
-				'attributes'          => 'onclick="if(!confirm(\'' . $GLOBALS['TL_LANG']['MSC']['deleteConfirm'] . '\'))return false;Backend.getScrollOffset()"'
+				'attributes'          => 'onclick="if(!confirm(\'' . ($GLOBALS['TL_LANG']['MSC']['deleteConfirm'] ?? null) . '\'))return false;Backend.getScrollOffset()"'
 			),
 			'toggle' => array
 			(

--- a/core-bundle/src/Resources/contao/dca/tl_user_group.php
+++ b/core-bundle/src/Resources/contao/dca/tl_user_group.php
@@ -433,7 +433,7 @@ class tl_user_group extends Backend
 						continue;
 					}
 
-					if ($vv['exclude'] || $vv['orig_exclude'])
+					if (($vv['exclude'] ?? null) || ($vv['orig_exclude'] ?? null))
 					{
 						$arrReturn[$k][StringUtil::specialchars($k . '::' . $kk)] = isset($vv['label'][0]) ? $vv['label'][0] . ' <span style="color:#999;padding-left:3px">[' . $kk . ']</span>' : $kk;
 					}

--- a/core-bundle/src/Resources/contao/dca/tl_user_group.php
+++ b/core-bundle/src/Resources/contao/dca/tl_user_group.php
@@ -503,7 +503,7 @@ class tl_user_group extends Backend
 		}
 
 		// Trigger the onload_callback
-		if (is_array($GLOBALS['TL_DCA']['tl_user_group']['config']['onload_callback']))
+		if (is_array($GLOBALS['TL_DCA']['tl_user_group']['config']['onload_callback'] ?? null))
 		{
 			foreach ($GLOBALS['TL_DCA']['tl_user_group']['config']['onload_callback'] as $callback)
 			{
@@ -547,7 +547,7 @@ class tl_user_group extends Backend
 		$blnVisible = !$blnVisible;
 
 		// Trigger the save_callback
-		if (is_array($GLOBALS['TL_DCA']['tl_user_group']['fields']['disable']['save_callback']))
+		if (is_array($GLOBALS['TL_DCA']['tl_user_group']['fields']['disable']['save_callback'] ?? null))
 		{
 			foreach ($GLOBALS['TL_DCA']['tl_user_group']['fields']['disable']['save_callback'] as $callback)
 			{
@@ -564,7 +564,7 @@ class tl_user_group extends Backend
 		}
 
 		// Trigger the onsubmit_callback
-		if (is_array($GLOBALS['TL_DCA']['tl_user_group']['config']['onsubmit_callback']))
+		if (is_array($GLOBALS['TL_DCA']['tl_user_group']['config']['onsubmit_callback'] ?? null))
 		{
 			foreach ($GLOBALS['TL_DCA']['tl_user_group']['config']['onsubmit_callback'] as $callback)
 			{

--- a/core-bundle/src/Resources/contao/drivers/DC_File.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_File.php
@@ -41,7 +41,7 @@ class DC_File extends DataContainer implements \editable
 		$this->strTable = $strTable;
 
 		// Call onload_callback (e.g. to check permissions)
-		if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['config']['onload_callback']))
+		if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['config']['onload_callback'] ?? null))
 		{
 			foreach ($GLOBALS['TL_DCA'][$this->strTable]['config']['onload_callback'] as $callback)
 			{
@@ -136,7 +136,7 @@ class DC_File extends DataContainer implements \editable
 						$legends[$k] = substr($vv, 1, -1);
 						unset($boxes[$k][$kk]);
 					}
-					elseif (!\is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$vv]) || $GLOBALS['TL_DCA'][$this->strTable]['fields'][$vv]['exclude'])
+					elseif (!\is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$vv] ?? null) || ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$vv]['exclude'] ?? null))
 					{
 						unset($boxes[$k][$kk]);
 					}
@@ -211,9 +211,9 @@ class DC_File extends DataContainer implements \editable
 					$this->varValue = Config::get($this->strField);
 
 					// Handle entities
-					if ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['inputType'] == 'text' || $GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['inputType'] == 'textarea')
+					if (($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['inputType'] ?? null) == 'text' || ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['inputType'] ?? null) == 'textarea')
 					{
-						if ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['eval']['multiple'])
+						if ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['eval']['multiple'] ?? null)
 						{
 							$this->varValue = StringUtil::deserialize($this->varValue);
 						}
@@ -232,7 +232,7 @@ class DC_File extends DataContainer implements \editable
 					}
 
 					// Call load_callback
-					if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['load_callback']))
+					if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['load_callback'] ?? null))
 					{
 						foreach ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['load_callback'] as $callback)
 						{
@@ -271,7 +271,7 @@ class DC_File extends DataContainer implements \editable
 		$arrButtons['saveNclose'] = '<button type="submit" name="saveNclose" id="saveNclose" class="tl_submit" accesskey="c">' . $GLOBALS['TL_LANG']['MSC']['saveNclose'] . '</button>';
 
 		// Call the buttons_callback (see #4691)
-		if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['edit']['buttons_callback']))
+		if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['edit']['buttons_callback'] ?? null))
 		{
 			foreach ($GLOBALS['TL_DCA'][$this->strTable]['edit']['buttons_callback'] as $callback)
 			{
@@ -313,7 +313,7 @@ class DC_File extends DataContainer implements \editable
 		if (!$this->noReload && Input::post('FORM_SUBMIT') == $this->strTable)
 		{
 			// Call onsubmit_callback
-			if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['config']['onsubmit_callback']))
+			if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['config']['onsubmit_callback'] ?? null))
 			{
 				foreach ($GLOBALS['TL_DCA'][$this->strTable]['config']['onsubmit_callback'] as $callback)
 				{
@@ -368,7 +368,7 @@ class DC_File extends DataContainer implements \editable
 		$arrData = $GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField];
 
 		// Make sure that checkbox values are boolean
-		if ($arrData['inputType'] == 'checkbox' && !$arrData['eval']['multiple'])
+		if (($arrData['inputType'] ?? null) == 'checkbox' && !($arrData['eval']['multiple'] ?? null))
 		{
 			$varValue = $varValue ? true : false;
 		}
@@ -376,7 +376,7 @@ class DC_File extends DataContainer implements \editable
 		if ($varValue)
 		{
 			// Convert binary UUIDs (see #6893)
-			if ($arrData['inputType'] == 'fileTree')
+			if (($arrData['inputType'] ?? null) == 'fileTree')
 			{
 				$varValue = StringUtil::deserialize($varValue);
 
@@ -391,14 +391,14 @@ class DC_File extends DataContainer implements \editable
 			}
 
 			// Convert date formats into timestamps
-			if ($varValue !== null && $varValue !== '' && \in_array($arrData['eval']['rgxp'], array('date', 'time', 'datim')))
+			if ($varValue !== null && $varValue !== '' && \in_array($arrData['eval']['rgxp'] ?? null, array('date', 'time', 'datim')))
 			{
 				$objDate = new Date($varValue, Date::getFormatFromRgxp($arrData['eval']['rgxp']));
 				$varValue = $objDate->tstamp;
 			}
 
 			// Handle entities
-			if ($arrData['inputType'] == 'text' || $arrData['inputType'] == 'textarea')
+			if (($arrData['inputType'] ?? null) == 'text' || ($arrData['inputType'] ?? null) == 'textarea')
 			{
 				$varValue = StringUtil::deserialize($varValue);
 
@@ -414,7 +414,7 @@ class DC_File extends DataContainer implements \editable
 		}
 
 		// Trigger the save_callback
-		if (\is_array($arrData['save_callback']))
+		if (\is_array($arrData['save_callback'] ?? null))
 		{
 			foreach ($arrData['save_callback'] as $callback)
 			{
@@ -443,7 +443,7 @@ class DC_File extends DataContainer implements \editable
 		}
 
 		// Save the value if there was no error
-		if ($strCurrent != $varValue && (\strlen($varValue) || !$arrData['eval']['doNotSaveEmpty']))
+		if ($strCurrent != $varValue && (\strlen($varValue) || !($arrData['eval']['doNotSaveEmpty'] ?? null)))
 		{
 			Config::persist($this->strField, $varValue);
 
@@ -453,7 +453,7 @@ class DC_File extends DataContainer implements \editable
 			// Add a log entry
 			if (!\is_array($deserialize) && !\is_array(StringUtil::deserialize($prior)))
 			{
-				if ($arrData['inputType'] == 'password' || $arrData['inputType'] == 'textStore')
+				if (($arrData['inputType'] ?? null) == 'password' || ($arrData['inputType'] ?? null) == 'textStore')
 				{
 					$this->log('The global configuration variable "' . $this->strField . '" has been changed', __METHOD__, TL_CONFIGURATION);
 				}
@@ -476,8 +476,7 @@ class DC_File extends DataContainer implements \editable
 	 */
 	public function getPalette()
 	{
-		$palette = 'default';
-		$strPalette = $GLOBALS['TL_DCA'][$this->strTable]['palettes'][$palette];
+		$strPalette = $GLOBALS['TL_DCA'][$this->strTable]['palettes']['default'] ?? '';
 
 		// Check whether there are selector fields
 		if (!empty($GLOBALS['TL_DCA'][$this->strTable]['palettes']['__selector__']))
@@ -494,7 +493,7 @@ class DC_File extends DataContainer implements \editable
 				{
 					$key = (Input::get('act') == 'editAll') ? $name . '_' . $this->intId : $name;
 
-					if (!$GLOBALS['TL_DCA'][$this->strTable]['fields'][$name]['eval']['submitOnChange'])
+					if (!($GLOBALS['TL_DCA'][$this->strTable]['fields'][$name]['eval']['submitOnChange'] ?? null))
 					{
 						$trigger = Input::post($key);
 					}
@@ -502,7 +501,7 @@ class DC_File extends DataContainer implements \editable
 
 				if ($trigger)
 				{
-					if ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$name]['inputType'] == 'checkbox' && !$GLOBALS['TL_DCA'][$this->strTable]['fields'][$name]['eval']['multiple'])
+					if (($GLOBALS['TL_DCA'][$this->strTable]['fields'][$name]['inputType'] ?? null) == 'checkbox' && !($GLOBALS['TL_DCA'][$this->strTable]['fields'][$name]['eval']['multiple'] ?? null))
 					{
 						$sValues[] = $name;
 

--- a/core-bundle/src/Resources/contao/drivers/DC_File.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_File.php
@@ -166,7 +166,10 @@ class DC_File extends DataContainer implements \editable
 
 				if (isset($legends[$k]))
 				{
-					list($key, $cls) = explode(':', $legends[$k]);
+					$chunks = explode(':', $legends[$k]);
+					$key = $chunks[0] ?? null;
+					$cls = $chunks[1] ?? null;
+
 					$legend = "\n" . '<legend onclick="AjaxRequest.toggleFieldset(this, \'' . $key . '\', \'' . $this->strTable . '\')">' . ($GLOBALS['TL_LANG'][$this->strTable][$key] ?? $key) . '</legend>';
 				}
 
@@ -365,7 +368,7 @@ class DC_File extends DataContainer implements \editable
 			return;
 		}
 
-		$arrData = $GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField];
+		$arrData = $GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField] ?? array();
 
 		// Make sure that checkbox values are boolean
 		if (($arrData['inputType'] ?? null) == 'checkbox' && !($arrData['eval']['multiple'] ?? null))

--- a/core-bundle/src/Resources/contao/drivers/DC_Folder.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Folder.php
@@ -186,13 +186,13 @@ class DC_Folder extends DataContainer implements \listable, \editable
 		$this->strRootDir = System::getContainer()->getParameter('kernel.project_dir');
 
 		// Check for valid file types
-		if ($GLOBALS['TL_DCA'][$this->strTable]['config']['validFileTypes'])
+		if ($GLOBALS['TL_DCA'][$this->strTable]['config']['validFileTypes'] ?? null)
 		{
 			$this->arrValidFileTypes = StringUtil::trimsplit(',', strtolower($GLOBALS['TL_DCA'][$this->strTable]['config']['validFileTypes']));
 		}
 
 		// Call onload_callback (e.g. to check permissions)
-		if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['config']['onload_callback']))
+		if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['config']['onload_callback'] ?? null))
 		{
 			foreach ($GLOBALS['TL_DCA'][$this->strTable]['config']['onload_callback'] as $callback)
 			{
@@ -209,7 +209,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 		}
 
 		// Get all filemounts (root folders)
-		if (\is_array($GLOBALS['TL_DCA'][$strTable]['list']['sorting']['root']))
+		if (\is_array($GLOBALS['TL_DCA'][$strTable]['list']['sorting']['root'] ?? null))
 		{
 			$this->arrFilemounts = $this->eliminateNestedPaths($GLOBALS['TL_DCA'][$strTable]['list']['sorting']['root']);
 		}
@@ -347,7 +347,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 					$arrRoot = array();
 
 					// Respect existing limitations (root IDs)
-					if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['root']))
+					if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['root'] ?? null))
 					{
 						while ($objRoot->next())
 						{
@@ -392,7 +392,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 		{
 			// Show an empty tree if there are no search results
 		}
-		elseif (empty($this->arrFilemounts) && !\is_array($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['root']) && $GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['root'] !== false)
+		elseif (empty($this->arrFilemounts) && !\is_array($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['root'] ?? null) && ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['root'] ?? null) !== false)
 		{
 			$return .= $this->generateTree($this->strRootDir . '/' . Config::get('uploadPath'), 0, false, true, ($blnClipboard ? $arrClipboard : false), $arrFound);
 		}
@@ -448,7 +448,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 		// Build the tree
 		$return = $this->panel() . Message::generate() . '
 <div id="tl_buttons">' . ((Input::get('act') == 'select') ? '
-<a href="' . $this->getReferer(true) . '" class="header_back" title="' . StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['backBTTitle']) . '" accesskey="b" onclick="Backend.getScrollOffset()">' . $GLOBALS['TL_LANG']['MSC']['backBT'] . '</a> ' : '') . ((Input::get('act') != 'select' && !$blnClipboard && !$GLOBALS['TL_DCA'][$this->strTable]['config']['closed'] && !$GLOBALS['TL_DCA'][$this->strTable]['config']['notCreatable']) ? '
+<a href="' . $this->getReferer(true) . '" class="header_back" title="' . StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['backBTTitle']) . '" accesskey="b" onclick="Backend.getScrollOffset()">' . $GLOBALS['TL_LANG']['MSC']['backBT'] . '</a> ' : '') . ((Input::get('act') != 'select' && !$blnClipboard && !($GLOBALS['TL_DCA'][$this->strTable]['config']['closed'] ?? null) && !($GLOBALS['TL_DCA'][$this->strTable]['config']['notCreatable'] ?? null)) ? '
 <a href="' . $this->addToUrl($hrfNew) . '" class="' . $clsNew . '" title="' . StringUtil::specialchars($ttlNew) . '" accesskey="n" onclick="Backend.getScrollOffset()">' . $lblNew . '</a>
 <a href="' . $this->addToUrl('&amp;act=paste&amp;mode=move') . '" class="header_new" title="' . StringUtil::specialchars($GLOBALS['TL_LANG'][$this->strTable]['move'][1]) . '" onclick="Backend.getScrollOffset()">' . $GLOBALS['TL_LANG'][$this->strTable]['move'][0] . '</a>  ' : '') . ($blnClipboard ? '
 <a href="' . $this->addToUrl('clipboard=1') . '" class="header_clipboard" title="' . StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['clearClipboard']) . '" accesskey="x">' . $GLOBALS['TL_LANG']['MSC']['clearClipboard'] . '</a> ' : $this->generateGlobalButtons()) . '
@@ -465,7 +465,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 <label for="tl_select_trigger" class="tl_select_label">' . $GLOBALS['TL_LANG']['MSC']['selectAll'] . '</label> <input type="checkbox" id="tl_select_trigger" onclick="Backend.toggleCheckboxes(this)" class="tl_tree_checkbox">
 </div>' : '') . '
 <ul class="tl_listing tl_file_manager' . ($this->strPickerFieldType ? ' picker unselectable' : '') . '">
-  <li class="tl_folder_top cf"><div class="tl_left">' . $label . '</div> <div class="tl_right">' . (($blnClipboard && empty($this->arrFilemounts) && !\is_array($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['root']) && $GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['root'] !== false) ? '<a href="' . $this->addToUrl('&amp;act=' . $arrClipboard['mode'] . '&amp;mode=2&amp;pid=' . Config::get('uploadPath') . (!\is_array($arrClipboard['id']) ? '&amp;id=' . $arrClipboard['id'] : '')) . '" title="' . StringUtil::specialchars($labelPasteInto[0]) . '" onclick="Backend.getScrollOffset()">' . $imagePasteInto . '</a>' : '&nbsp;') . '</div></li>' . $return . '
+  <li class="tl_folder_top cf"><div class="tl_left">' . $label . '</div> <div class="tl_right">' . (($blnClipboard && empty($this->arrFilemounts) && !\is_array($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['root'] ?? null) && ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['root'] ?? null) !== false) ? '<a href="' . $this->addToUrl('&amp;act=' . $arrClipboard['mode'] . '&amp;mode=2&amp;pid=' . Config::get('uploadPath') . (!\is_array($arrClipboard['id'] ?? null) ? '&amp;id=' . $arrClipboard['id'] : '')) . '" title="' . StringUtil::specialchars($labelPasteInto[0]) . '" onclick="Backend.getScrollOffset()">' . $imagePasteInto . '</a>' : '&nbsp;') . '</div></li>' . $return . '
 </ul>' . ($this->strPickerFieldType == 'radio' ? '
 <div class="tl_radio_reset">
 <label for="tl_radio_reset" class="tl_radio_label">' . $GLOBALS['TL_LANG']['MSC']['resetSelected'] . '</label> <input type="radio" name="picker" id="tl_radio_reset" value="" class="tl_tree_radio">
@@ -478,28 +478,28 @@ class DC_Folder extends DataContainer implements \listable, \editable
 			// Submit buttons
 			$arrButtons = array();
 
-			if (!$GLOBALS['TL_DCA'][$this->strTable]['config']['notEditable'])
+			if (!($GLOBALS['TL_DCA'][$this->strTable]['config']['notEditable'] ?? null))
 			{
 				$arrButtons['edit'] = '<button type="submit" name="edit" id="edit" class="tl_submit" accesskey="s">' . $GLOBALS['TL_LANG']['MSC']['editSelected'] . '</button>';
 			}
 
-			if (!$GLOBALS['TL_DCA'][$this->strTable]['config']['notDeletable'])
+			if (!($GLOBALS['TL_DCA'][$this->strTable]['config']['notDeletable'] ?? null))
 			{
 				$arrButtons['delete'] = '<button type="submit" name="delete" id="delete" class="tl_submit" accesskey="d" onclick="return confirm(\'' . $GLOBALS['TL_LANG']['MSC']['delAllConfirmFile'] . '\')">' . $GLOBALS['TL_LANG']['MSC']['deleteSelected'] . '</button>';
 			}
 
-			if (!$GLOBALS['TL_DCA'][$this->strTable]['config']['notSortable'])
+			if (!($GLOBALS['TL_DCA'][$this->strTable]['config']['notSortable'] ?? null))
 			{
 				$arrButtons['cut'] = '<button type="submit" name="cut" id="cut" class="tl_submit" accesskey="x">' . $GLOBALS['TL_LANG']['MSC']['moveSelected'] . '</button>';
 			}
 
-			if (!$GLOBALS['TL_DCA'][$this->strTable]['config']['notCopyable'])
+			if (!($GLOBALS['TL_DCA'][$this->strTable]['config']['notCopyable'] ?? null))
 			{
 				$arrButtons['copy'] = '<button type="submit" name="copy" id="copy" class="tl_submit" accesskey="c">' . $GLOBALS['TL_LANG']['MSC']['copySelected'] . '</button>';
 			}
 
 			// Call the buttons_callback (see #4691)
-			if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['select']['buttons_callback']))
+			if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['select']['buttons_callback'] ?? null))
 			{
 				foreach ($GLOBALS['TL_DCA'][$this->strTable]['select']['buttons_callback'] as $callback)
 				{
@@ -543,7 +543,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 </form>';
 		}
 
-		if (!$GLOBALS['TL_DCA'][$this->strTable]['config']['closed'] && !$GLOBALS['TL_DCA'][$this->strTable]['config']['notCreatable'] && Input::get('act') != 'select')
+		if (!($GLOBALS['TL_DCA'][$this->strTable]['config']['closed'] ?? null) && !($GLOBALS['TL_DCA'][$this->strTable]['config']['notCreatable'] ?? null) && Input::get('act') != 'select')
 		{
 			$GLOBALS['TL_CSS'][] = 'assets/dropzone/css/dropzone.min.css';
 			$GLOBALS['TL_JAVASCRIPT'][] = 'assets/dropzone/js/dropzone.min.js';
@@ -593,7 +593,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 	 */
 	public function create()
 	{
-		if ($GLOBALS['TL_DCA'][$this->strTable]['config']['notCreatable'])
+		if ($GLOBALS['TL_DCA'][$this->strTable]['config']['notCreatable'] ?? null)
 		{
 			throw new InternalServerErrorException('Table "' . $this->strTable . '" is not creatable.');
 		}
@@ -628,7 +628,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 	 */
 	public function cut($source=null)
 	{
-		if ($GLOBALS['TL_DCA'][$this->strTable]['config']['notSortable'])
+		if ($GLOBALS['TL_DCA'][$this->strTable]['config']['notSortable'] ?? null)
 		{
 			throw new InternalServerErrorException('Table "' . $this->strTable . '" is not sortable.');
 		}
@@ -702,7 +702,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 			}
 
 			// Call the oncut_callback
-			if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['config']['oncut_callback']))
+			if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['config']['oncut_callback'] ?? null))
 			{
 				foreach ($GLOBALS['TL_DCA'][$this->strTable]['config']['oncut_callback'] as $callback)
 				{
@@ -736,7 +736,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 	 */
 	public function cutAll()
 	{
-		if ($GLOBALS['TL_DCA'][$this->strTable]['config']['notSortable'])
+		if ($GLOBALS['TL_DCA'][$this->strTable]['config']['notSortable'] ?? null)
 		{
 			throw new InternalServerErrorException('Table "' . $this->strTable . '" is not sortable.');
 		}
@@ -774,7 +774,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 	 */
 	public function copy($source=null, $destination=null)
 	{
-		if ($GLOBALS['TL_DCA'][$this->strTable]['config']['notCopyable'])
+		if ($GLOBALS['TL_DCA'][$this->strTable]['config']['notCopyable'] ?? null)
 		{
 			throw new InternalServerErrorException('Table "' . $this->strTable . '" is not copyable.');
 		}
@@ -871,7 +871,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 		}
 
 		// Call the oncopy_callback
-		if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['config']['oncopy_callback']))
+		if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['config']['oncopy_callback'] ?? null))
 		{
 			foreach ($GLOBALS['TL_DCA'][$this->strTable]['config']['oncopy_callback'] as $callback)
 			{
@@ -910,7 +910,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 	 */
 	public function copyAll()
 	{
-		if ($GLOBALS['TL_DCA'][$this->strTable]['config']['notCopyable'])
+		if ($GLOBALS['TL_DCA'][$this->strTable]['config']['notCopyable'] ?? null)
 		{
 			throw new InternalServerErrorException('Table "' . $this->strTable . '" is not copyable.');
 		}
@@ -947,7 +947,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 	 */
 	public function delete($source=null)
 	{
-		if ($GLOBALS['TL_DCA'][$this->strTable]['config']['notDeletable'])
+		if ($GLOBALS['TL_DCA'][$this->strTable]['config']['notDeletable'] ?? null)
 		{
 			throw new InternalServerErrorException('Table "' . $this->strTable . '" is not deletable.');
 		}
@@ -968,7 +968,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 		}
 
 		// Call the ondelete_callback
-		if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['config']['ondelete_callback']))
+		if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['config']['ondelete_callback'] ?? null))
 		{
 			foreach ($GLOBALS['TL_DCA'][$this->strTable]['config']['ondelete_callback'] as $callback)
 			{
@@ -1027,7 +1027,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 	 */
 	public function deleteAll()
 	{
-		if ($GLOBALS['TL_DCA'][$this->strTable]['config']['notDeletable'])
+		if ($GLOBALS['TL_DCA'][$this->strTable]['config']['notDeletable'] ?? null)
 		{
 			throw new InternalServerErrorException('Table "' . $this->strTable . '" is not deletable.');
 		}
@@ -1206,7 +1206,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 		$arrButtons['uploadNback'] = '<button type="submit" name="uploadNback" class="tl_submit" accesskey="c">' . $GLOBALS['TL_LANG'][$this->strTable]['uploadNback'] . '</button>';
 
 		// Call the buttons_callback (see #4691)
-		if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['edit']['buttons_callback']))
+		if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['edit']['buttons_callback'] ?? null))
 		{
 			foreach ($GLOBALS['TL_DCA'][$this->strTable]['edit']['buttons_callback'] as $callback)
 			{
@@ -1305,7 +1305,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 			/** @var FilesModel $objModel */
 			$objVersions = new Versions($this->strTable, $objModel->id);
 
-			if (!$GLOBALS['TL_DCA'][$this->strTable]['config']['hideVersionMenu'])
+			if (!($GLOBALS['TL_DCA'][$this->strTable]['config']['hideVersionMenu'] ?? null))
 			{
 				// Compare versions
 				if (Input::get('versions'))
@@ -1326,7 +1326,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 		else
 		{
 			// Unset the database fields
-			$GLOBALS['TL_DCA'][$this->strTable]['fields'] = array_intersect_key($GLOBALS['TL_DCA'][$this->strTable]['fields'], array('name' => true, 'protected' => true, 'syncExclude' => true));
+			$GLOBALS['TL_DCA'][$this->strTable]['fields'] = array_intersect_key($GLOBALS['TL_DCA'][$this->strTable]['fields'] ?? array(), array('name' => true, 'protected' => true, 'syncExclude' => true));
 		}
 
 		// Build an array from boxes and rows (do not show excluded fields)
@@ -1342,7 +1342,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 
 				foreach ($boxes[$k] as $kk=>$vv)
 				{
-					if (!isset($GLOBALS['TL_DCA'][$this->strTable]['fields'][$vv]) || $GLOBALS['TL_DCA'][$this->strTable]['fields'][$vv]['exclude'])
+					if (!isset($GLOBALS['TL_DCA'][$this->strTable]['fields'][$vv]) || ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$vv]['exclude'] ?? null))
 					{
 						unset($boxes[$k][$kk]);
 					}
@@ -1396,7 +1396,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 					}
 
 					// Call load_callback
-					if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['load_callback']))
+					if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['load_callback'] ?? null))
 					{
 						foreach ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['load_callback'] as $callback)
 						{
@@ -1425,7 +1425,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 		}
 
 		// Versions overview
-		if ($objVersions && $this->blnIsDbAssisted && $GLOBALS['TL_DCA'][$this->strTable]['config']['enableVersioning'] && !$GLOBALS['TL_DCA'][$this->strTable]['config']['hideVersionMenu'] && Dbafs::shouldBeSynchronized($this->intId))
+		if ($objVersions && $this->blnIsDbAssisted && ($GLOBALS['TL_DCA'][$this->strTable]['config']['enableVersioning'] ?? null) && !($GLOBALS['TL_DCA'][$this->strTable]['config']['hideVersionMenu'] ?? null) && Dbafs::shouldBeSynchronized($this->intId))
 		{
 			$version = $objVersions->renderDropdown();
 		}
@@ -1444,7 +1444,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 		}
 
 		// Call the buttons_callback (see #4691)
-		if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['edit']['buttons_callback']))
+		if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['edit']['buttons_callback'] ?? null))
 		{
 			foreach ($GLOBALS['TL_DCA'][$this->strTable]['edit']['buttons_callback'] as $callback)
 			{
@@ -1509,7 +1509,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 		if (!$this->noReload && Input::post('FORM_SUBMIT') == $this->strTable)
 		{
 			// Trigger the onsubmit_callback
-			if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['config']['onsubmit_callback']))
+			if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['config']['onsubmit_callback'] ?? null))
 			{
 				foreach ($GLOBALS['TL_DCA'][$this->strTable]['config']['onsubmit_callback'] as $callback)
 				{
@@ -1538,7 +1538,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 				$objVersions->create();
 
 				// Call the onversion_callback
-				if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['config']['onversion_callback']))
+				if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['config']['onversion_callback'] ?? null))
 				{
 					trigger_deprecation('contao/core-bundle', '4.0', 'Using the "onversion_callback" has been deprecated and will no longer work in Contao 5.0. Use the "oncreate_version_callback" instead.');
 
@@ -1600,7 +1600,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 	{
 		$return = '';
 
-		if ($GLOBALS['TL_DCA'][$this->strTable]['config']['notEditable'])
+		if ($GLOBALS['TL_DCA'][$this->strTable]['config']['notEditable'] ?? null)
 		{
 			throw new InternalServerErrorException('Table "' . $this->strTable . '" is not editable.');
 		}
@@ -1668,7 +1668,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 				foreach ($this->strPalette as $v)
 				{
 					// Check whether field is excluded
-					if ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['exclude'])
+					if ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['exclude'] ?? null)
 					{
 						continue;
 					}
@@ -1703,7 +1703,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 					}
 
 					// Call load_callback
-					if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['load_callback']))
+					if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['load_callback'] ?? null))
 					{
 						foreach ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['load_callback'] as $callback)
 						{
@@ -1738,7 +1738,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 				if (!$this->noReload && Input::post('FORM_SUBMIT') == $this->strTable)
 				{
 					// Call onsubmit_callback
-					if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['config']['onsubmit_callback']))
+					if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['config']['onsubmit_callback'] ?? null))
 					{
 						foreach ($GLOBALS['TL_DCA'][$this->strTable]['config']['onsubmit_callback'] as $callback)
 						{
@@ -1767,7 +1767,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 						$objVersions->create();
 
 						// Call the onversion_callback
-						if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['config']['onversion_callback']))
+						if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['config']['onversion_callback'] ?? null))
 						{
 							trigger_deprecation('contao/core-bundle', '4.0', 'Using the "onversion_callback" has been deprecated and will no longer work in Contao 5.0. Use the "oncreate_version_callback" instead.');
 
@@ -1794,7 +1794,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 			$arrButtons['saveNclose'] = '<button type="submit" name="saveNclose" id="saveNclose" class="tl_submit" accesskey="c">' . $GLOBALS['TL_LANG']['MSC']['saveNclose'] . '</button>';
 
 			// Call the buttons_callback (see #4691)
-			if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['edit']['buttons_callback']))
+			if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['edit']['buttons_callback'] ?? null))
 			{
 				foreach ($GLOBALS['TL_DCA'][$this->strTable]['edit']['buttons_callback'] as $callback)
 				{
@@ -1873,12 +1873,12 @@ class DC_Folder extends DataContainer implements \listable, \editable
 			$fields = array();
 
 			// Add fields of the current table
-			$fields = array_merge($fields, array_keys($GLOBALS['TL_DCA'][$this->strTable]['fields']));
+			$fields = array_merge($fields, array_keys($GLOBALS['TL_DCA'][$this->strTable]['fields'] ?? array()));
 
 			// Show all non-excluded fields
 			foreach ($fields as $field)
 			{
-				if (!$GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['exclude'] && !$GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['eval']['doNotShow'] && (isset($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['inputType']) || \is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['input_field_callback'])))
+				if (!($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['exclude'] ?? null) && !($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['eval']['doNotShow'] ?? null) && (isset($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['inputType']) || \is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['input_field_callback'] ?? null)))
 				{
 					$options .= '
   <input type="checkbox" name="all_fields[]" id="all_' . $field . '" class="tl_checkbox" value="' . StringUtil::specialchars($field) . '"> <label for="all_' . $field . '" class="tl_checkbox_label">' . (($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['label'][0] ?: ($GLOBALS['TL_LANG']['MSC'][$field][0] ?: $field)) . ' <span style="color:#999;padding-left:3px">[' . $field . ']</span>') . '</label><br>';
@@ -1964,7 +1964,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 
 			$objVersions = new Versions($this->strTable, $objMeta->id);
 
-			if (!$GLOBALS['TL_DCA'][$this->strTable]['config']['hideVersionMenu'])
+			if (!($GLOBALS['TL_DCA'][$this->strTable]['config']['hideVersionMenu'] ?? null))
 			{
 				// Compare versions
 				if (Input::get('versions'))
@@ -2045,7 +2045,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 		}
 
 		// Versions overview
-		if ($this->blnIsDbAssisted && $objVersions !== null && $GLOBALS['TL_DCA'][$this->strTable]['config']['enableVersioning'] && !$GLOBALS['TL_DCA'][$this->strTable]['config']['hideVersionMenu'])
+		if ($this->blnIsDbAssisted && $objVersions !== null && ($GLOBALS['TL_DCA'][$this->strTable]['config']['enableVersioning'] ?? null) && !($GLOBALS['TL_DCA'][$this->strTable]['config']['hideVersionMenu'] ?? null))
 		{
 			$version = $objVersions->renderDropdown();
 		}
@@ -2060,7 +2060,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 		$arrButtons['saveNclose'] = '<button type="submit" name="saveNclose" id="saveNclose" class="tl_submit" accesskey="c">' . $GLOBALS['TL_LANG']['MSC']['saveNclose'] . '</button>';
 
 		// Call the buttons_callback (see #4691)
-		if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['edit']['buttons_callback']))
+		if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['edit']['buttons_callback'] ?? null))
 		{
 			foreach ($GLOBALS['TL_DCA'][$this->strTable]['edit']['buttons_callback'] as $callback)
 			{
@@ -2399,7 +2399,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 				// Set the correct empty value (see #6284, #6373)
 				if ((string) $varValue === '')
 				{
-					$varValue = Widget::getEmptyValueByFieldType($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['sql']);
+					$varValue = Widget::getEmptyValueByFieldType($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['sql'] ?? array());
 				}
 
 				$this->objActiveRecord->{$this->strField} = $varValue;
@@ -2742,7 +2742,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 				}
 
 				// Add upload button if it is missing for backwards compatibility
-				if (!isset($GLOBALS['TL_DCA'][$this->strTable]['list']['operations']['upload']) && !$GLOBALS['TL_DCA'][$this->strTable]['config']['closed'] && !$GLOBALS['TL_DCA'][$this->strTable]['config']['notCreatable'] && Input::get('act') != 'select')
+				if (!isset($GLOBALS['TL_DCA'][$this->strTable]['list']['operations']['upload']) && !($GLOBALS['TL_DCA'][$this->strTable]['config']['closed'] ?? null) && !($GLOBALS['TL_DCA'][$this->strTable]['config']['notCreatable'] ?? null) && Input::get('act') != 'select')
 				{
 					$return .= $uploadButton;
 				}

--- a/core-bundle/src/Resources/contao/drivers/DC_Folder.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Folder.php
@@ -182,7 +182,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 		}
 
 		$this->strTable = $strTable;
-		$this->blnIsDbAssisted = $GLOBALS['TL_DCA'][$strTable]['config']['databaseAssisted'];
+		$this->blnIsDbAssisted = $GLOBALS['TL_DCA'][$strTable]['config']['databaseAssisted'] ?? false;
 		$this->strRootDir = System::getContainer()->getParameter('kernel.project_dir');
 
 		// Check for valid file types
@@ -310,7 +310,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 		$this->import(BackendUser::class, 'User');
 
 		$arrFound = array();
-		$for = $session['search'][$this->strTable]['value'];
+		$for = $session['search'][$this->strTable]['value'] ?? null;
 
 		// Limit the results by modifying $this->arrFilemounts
 		if ((string) $for !== '')
@@ -442,7 +442,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 			$label = $GLOBALS['TL_LANG']['MOD']['files'][0];
 		}
 
-		$icon = $GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['icon'] ?: 'filemounts.svg';
+		$icon = $GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['icon'] ?? 'filemounts.svg';
 		$label = Image::getHtml($icon) . ' <label>' . $label . '</label>';
 
 		// Build the tree
@@ -1036,7 +1036,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 		$objSession = System::getContainer()->get('session');
 
 		$session = $objSession->all();
-		$ids = $session['CURRENT']['IDS'];
+		$ids = $session['CURRENT']['IDS'] ?? array();
 
 		if (!empty($ids) && \is_array($ids))
 		{
@@ -1610,7 +1610,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 
 		// Get current IDs from session
 		$session = $objSession->all();
-		$ids = $session['CURRENT']['IDS'];
+		$ids = $session['CURRENT']['IDS'] ?? array();
 
 		// Save field selection in session
 		if (Input::post('FORM_SUBMIT') == $this->strTable . '_all' && Input::get('fields'))
@@ -1619,7 +1619,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 			$objSession->replace($session);
 		}
 
-		$fields = $session['CURRENT'][$this->strTable];
+		$fields = $session['CURRENT'][$this->strTable] ?? array();
 
 		// Add fields
 		if (!empty($fields) && \is_array($fields) && Input::get('fields'))
@@ -1881,7 +1881,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 				if (!($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['exclude'] ?? null) && !($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['eval']['doNotShow'] ?? null) && (isset($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['inputType']) || \is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['input_field_callback'] ?? null)))
 				{
 					$options .= '
-  <input type="checkbox" name="all_fields[]" id="all_' . $field . '" class="tl_checkbox" value="' . StringUtil::specialchars($field) . '"> <label for="all_' . $field . '" class="tl_checkbox_label">' . (($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['label'][0] ?: ($GLOBALS['TL_LANG']['MSC'][$field][0] ?: $field)) . ' <span style="color:#999;padding-left:3px">[' . $field . ']</span>') . '</label><br>';
+  <input type="checkbox" name="all_fields[]" id="all_' . $field . '" class="tl_checkbox" value="' . StringUtil::specialchars($field) . '"> <label for="all_' . $field . '" class="tl_checkbox_label">' . (($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['label'][0] ?? $GLOBALS['TL_LANG']['MSC'][$field][0] ?? $field) . ' <span style="color:#999;padding-left:3px">[' . $field . ']</span>') . '</label><br>';
 				}
 			}
 
@@ -2202,7 +2202,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 			return;
 		}
 
-		$arrData = $GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField];
+		$arrData = $GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField] ?? array();
 
 		// File names
 		if ($this->strField == 'name')
@@ -2215,7 +2215,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 			$this->import(Files::class, 'Files');
 
 			// Trigger the save_callback
-			if (\is_array($arrData['save_callback']))
+			if (\is_array($arrData['save_callback'] ?? null))
 			{
 				foreach ($arrData['save_callback'] as $callback)
 				{
@@ -2317,20 +2317,20 @@ class DC_Folder extends DataContainer implements \listable, \editable
 		elseif ($this->blnIsDbAssisted && $this->objActiveRecord !== null)
 		{
 			// Convert date formats into timestamps
-			if ($varValue !== null && $varValue !== '' && \in_array($arrData['eval']['rgxp'], array('date', 'time', 'datim')))
+			if ($varValue !== null && $varValue !== '' && \in_array($arrData['eval']['rgxp'] ?? null, array('date', 'time', 'datim')))
 			{
 				$objDate = new Date($varValue, Date::getFormatFromRgxp($arrData['eval']['rgxp']));
 				$varValue = $objDate->tstamp;
 			}
 
 			// Make sure unique fields are unique
-			if ((string) $varValue !== '' && $arrData['eval']['unique'] && !$this->Database->isUniqueValue($this->strTable, $this->strField, $varValue, $this->objActiveRecord->id))
+			if ((string) $varValue !== '' && ($arrData['eval']['unique'] ?? null) && !$this->Database->isUniqueValue($this->strTable, $this->strField, $varValue, $this->objActiveRecord->id))
 			{
 				throw new \Exception(sprintf($GLOBALS['TL_LANG']['ERR']['unique'], $arrData['label'][0] ?: $this->strField));
 			}
 
 			// Handle multi-select fields in "override all" mode
-			if ($this->objActiveRecord !== null && ($arrData['inputType'] == 'checkbox' || $arrData['inputType'] == 'checkboxWizard') && $arrData['eval']['multiple'] && Input::get('act') == 'overrideAll')
+			if ($this->objActiveRecord !== null && (($arrData['inputType'] ?? null) == 'checkbox' || ($arrData['inputType'] ?? null) == 'checkboxWizard') && ($arrData['eval']['multiple'] ?? null) && Input::get('act') == 'overrideAll')
 			{
 				$new = StringUtil::deserialize($varValue, true);
 				$old = StringUtil::deserialize($this->objActiveRecord->{$this->strField}, true);
@@ -2365,13 +2365,13 @@ class DC_Folder extends DataContainer implements \listable, \editable
 			}
 
 			// Convert arrays (see #2890)
-			if ($arrData['eval']['multiple'] && isset($arrData['eval']['csv']))
+			if (($arrData['eval']['multiple'] ?? null) && isset($arrData['eval']['csv']))
 			{
 				$varValue = implode($arrData['eval']['csv'], StringUtil::deserialize($varValue, true));
 			}
 
 			// Trigger the save_callback
-			if (\is_array($arrData['save_callback']))
+			if (\is_array($arrData['save_callback'] ?? null))
 			{
 				foreach ($arrData['save_callback'] as $callback)
 				{
@@ -2388,10 +2388,10 @@ class DC_Folder extends DataContainer implements \listable, \editable
 			}
 
 			// Save the value if there was no error
-			if (((string) $varValue !== '' || !$arrData['eval']['doNotSaveEmpty']) && ($this->varValue != $varValue || $arrData['eval']['alwaysSave']))
+			if (((string) $varValue !== '' || !($arrData['eval']['doNotSaveEmpty'] ?? null)) && ($this->varValue != $varValue || ($arrData['eval']['alwaysSave'] ?? null)))
 			{
 				// If the field is a fallback field, empty all other columns
-				if ($varValue && $arrData['eval']['fallback'])
+				if ($varValue && ($arrData['eval']['fallback'] ?? null))
 				{
 					$this->Database->execute("UPDATE " . $this->strTable . " SET " . $this->strField . "=''");
 				}
@@ -2571,7 +2571,6 @@ class DC_Folder extends DataContainer implements \listable, \editable
 	{
 		/** @var AttributeBagInterface $objSessionBag */
 		$objSessionBag = System::getContainer()->get('session')->getBag('contao_backend');
-
 		$session = $objSessionBag->all();
 
 		// Get the session data and toggle the nodes
@@ -2644,7 +2643,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 
 			$md5 = substr(md5($folders[$f]), 0, 8);
 			$content = Folder::scan($folders[$f]);
-			$session['filetree'][$md5] = is_numeric($session['filetree'][$md5]) ? $session['filetree'][$md5] : 0;
+			$session['filetree'][$md5] = is_numeric($session['filetree'][$md5] ?? null) ? $session['filetree'][$md5] : 0;
 			$currentEncoded = $this->urlEncode($currentFolder);
 			$countFiles = \count($content);
 
@@ -2729,7 +2728,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 			// Default buttons
 			else
 			{
-				$uploadButton = ' <a href="' . $this->addToUrl('&amp;act=move&amp;mode=2&amp;pid=' . $currentEncoded) . '" title="' . StringUtil::specialchars(sprintf($GLOBALS['TL_LANG']['tl_files']['uploadFF'], $currentEncoded)) . '">' . Image::getHtml('new.svg', $GLOBALS['TL_LANG'][$this->strTable]['move'][0]) . '</a>';
+				$uploadButton = ' <a href="' . $this->addToUrl('&amp;act=move&amp;mode=2&amp;pid=' . $currentEncoded) . '" title="' . StringUtil::specialchars(sprintf($GLOBALS['TL_LANG']['tl_files']['uploadFF'], $currentEncoded)) . '">' . Image::getHtml('new.svg', $GLOBALS['TL_LANG']['tl_files']['move'][0]) . '</a>';
 
 				// Only show the upload button for mounted folders
 				if (!$this->User->isAdmin && \in_array($currentFolder, $this->User->filemounts))
@@ -2909,7 +2908,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 		}
 
 		// Set the search value from the session
-		elseif ((string) $session['search'][$this->strTable]['value'] !== '')
+		elseif (isset($session['search'][$this->strTable]['value']) && (string) $session['search'][$this->strTable]['value'] !== '')
 		{
 			$strPattern = "CAST(name AS CHAR) REGEXP ?";
 
@@ -2922,14 +2921,14 @@ class DC_Folder extends DataContainer implements \listable, \editable
 			{
 				list($t, $f) = explode('.', $GLOBALS['TL_DCA'][$this->strTable]['fields']['name']['foreignKey']);
 				$this->procedure[] = "(" . $strPattern . " OR " . sprintf($strPattern, "(SELECT " . Database::quoteIdentifier($f) . " FROM $t WHERE $t.id=" . $this->strTable . ".name)") . ")";
-				$this->values[] = $session['search'][$this->strTable]['value'];
+				$this->values[] = $session['search'][$this->strTable]['value'] ?? null;
 			}
 			else
 			{
 				$this->procedure[] = $strPattern;
 			}
 
-			$this->values[] = $session['search'][$this->strTable]['value'];
+			$this->values[] = $session['search'][$this->strTable]['value'] ?? null;
 		}
 
 		$active = isset($session['search'][$this->strTable]['value']) && (string) $session['search'][$this->strTable]['value'] !== '';
@@ -2938,10 +2937,10 @@ class DC_Folder extends DataContainer implements \listable, \editable
     <div class="tl_search tl_subpanel">
       <strong>' . $GLOBALS['TL_LANG']['MSC']['search'] . ':</strong>
       <select name="tl_field" class="tl_select' . ($active ? ' active' : '') . '">
-        <option value="name">' . ($GLOBALS['TL_DCA'][$this->strTable]['fields']['name']['label'][0] ?: (\is_array($GLOBALS['TL_LANG']['MSC']['name']) ? $GLOBALS['TL_LANG']['MSC']['name'][0] : $GLOBALS['TL_LANG']['MSC']['name'])) . '</option>
+        <option value="name">' . ($GLOBALS['TL_DCA'][$this->strTable]['fields']['name']['label'][0] ?? (\is_array($GLOBALS['TL_LANG']['MSC']['name'] ?? null) ? $GLOBALS['TL_LANG']['MSC']['name'][0] : ($GLOBALS['TL_LANG']['MSC']['name'] ?? null))) . '</option>
       </select>
       <span>=</span>
-      <input type="search" name="tl_value" class="tl_text' . ($active ? ' active' : '') . '" value="' . StringUtil::specialchars($session['search'][$this->strTable]['value']) . '">
+      <input type="search" name="tl_value" class="tl_text' . ($active ? ' active' : '') . '" value="' . StringUtil::specialchars($session['search'][$this->strTable]['value'] ?? '') . '">
     </div>';
 	}
 

--- a/core-bundle/src/Resources/contao/drivers/DC_Folder.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Folder.php
@@ -442,7 +442,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 			$label = $GLOBALS['TL_LANG']['MOD']['files'][0];
 		}
 
-		$icon = $GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['icon'] ?: 'filemounts.svg';
+		$icon = $GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['icon'] ?? 'filemounts.svg';
 		$label = Image::getHtml($icon) . ' <label>' . $label . '</label>';
 
 		// Build the tree
@@ -1881,7 +1881,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 				if (!($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['exclude'] ?? null) && !($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['eval']['doNotShow'] ?? null) && (isset($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['inputType']) || \is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['input_field_callback'] ?? null)))
 				{
 					$options .= '
-  <input type="checkbox" name="all_fields[]" id="all_' . $field . '" class="tl_checkbox" value="' . StringUtil::specialchars($field) . '"> <label for="all_' . $field . '" class="tl_checkbox_label">' . (($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['label'][0] ?: ($GLOBALS['TL_LANG']['MSC'][$field][0] ?: $field)) . ' <span style="color:#999;padding-left:3px">[' . $field . ']</span>') . '</label><br>';
+  <input type="checkbox" name="all_fields[]" id="all_' . $field . '" class="tl_checkbox" value="' . StringUtil::specialchars($field) . '"> <label for="all_' . $field . '" class="tl_checkbox_label">' . (($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['label'][0] ?? (\is_array($GLOBALS['TL_LANG']['MSC'][$field] ?? null) ? $GLOBALS['TL_LANG']['MSC'][$field][0] : ($GLOBALS['TL_LANG']['MSC'][$field] ?? null) ?? $field)) . ' <span style="color:#999;padding-left:3px">[' . $field . ']</span>') . '</label><br>';
 				}
 			}
 

--- a/core-bundle/src/Resources/contao/drivers/DC_Folder.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Folder.php
@@ -442,7 +442,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 			$label = $GLOBALS['TL_LANG']['MOD']['files'][0];
 		}
 
-		$icon = $GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['icon'] ?? 'filemounts.svg';
+		$icon = $GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['icon'] ?: 'filemounts.svg';
 		$label = Image::getHtml($icon) . ' <label>' . $label . '</label>';
 
 		// Build the tree
@@ -1881,7 +1881,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 				if (!($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['exclude'] ?? null) && !($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['eval']['doNotShow'] ?? null) && (isset($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['inputType']) || \is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['input_field_callback'] ?? null)))
 				{
 					$options .= '
-  <input type="checkbox" name="all_fields[]" id="all_' . $field . '" class="tl_checkbox" value="' . StringUtil::specialchars($field) . '"> <label for="all_' . $field . '" class="tl_checkbox_label">' . (($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['label'][0] ?? $GLOBALS['TL_LANG']['MSC'][$field][0] ?? $field) . ' <span style="color:#999;padding-left:3px">[' . $field . ']</span>') . '</label><br>';
+  <input type="checkbox" name="all_fields[]" id="all_' . $field . '" class="tl_checkbox" value="' . StringUtil::specialchars($field) . '"> <label for="all_' . $field . '" class="tl_checkbox_label">' . (($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['label'][0] ?: ($GLOBALS['TL_LANG']['MSC'][$field][0] ?: $field)) . ' <span style="color:#999;padding-left:3px">[' . $field . ']</span>') . '</label><br>';
 				}
 			}
 
@@ -2937,7 +2937,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
     <div class="tl_search tl_subpanel">
       <strong>' . $GLOBALS['TL_LANG']['MSC']['search'] . ':</strong>
       <select name="tl_field" class="tl_select' . ($active ? ' active' : '') . '">
-        <option value="name">' . ($GLOBALS['TL_DCA'][$this->strTable]['fields']['name']['label'][0] ?? (\is_array($GLOBALS['TL_LANG']['MSC']['name'] ?? null) ? $GLOBALS['TL_LANG']['MSC']['name'][0] : ($GLOBALS['TL_LANG']['MSC']['name'] ?? null))) . '</option>
+        <option value="name">' . ($GLOBALS['TL_DCA'][$this->strTable]['fields']['name']['label'][0] ?: (\is_array($GLOBALS['TL_LANG']['MSC']['name'] ?? null) ? $GLOBALS['TL_LANG']['MSC']['name'][0] : ($GLOBALS['TL_LANG']['MSC']['name'] ?? null))) . '</option>
       </select>
       <span>=</span>
       <input type="search" name="tl_value" class="tl_text' . ($active ? ' active' : '') . '" value="' . StringUtil::specialchars($session['search'][$this->strTable]['value'] ?? '') . '">

--- a/core-bundle/src/Resources/contao/drivers/DC_Folder.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Folder.php
@@ -442,7 +442,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 			$label = $GLOBALS['TL_LANG']['MOD']['files'][0];
 		}
 
-		$icon = $GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['icon'] ?? 'filemounts.svg';
+		$icon = !empty($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['icon']) ? $GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['icon'] : 'filemounts.svg';
 		$label = Image::getHtml($icon) . ' <label>' . $label . '</label>';
 
 		// Build the tree

--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -4461,8 +4461,8 @@ class DC_Table extends DataContainer implements \listable, \editable
 				for ($i=0, $c=\count($row); $i<$c; $i++)
 				{
 					$this->current[] = $row[$i]['id'];
-					$imagePasteAfter = Image::getHtml('pasteafter.svg', sprintf($labelPasteAfter[1], $row[$i]['id']));
-					$imagePasteNew = Image::getHtml('new.svg', sprintf($labelPasteNew[1], $row[$i]['id']));
+					$imagePasteAfter = Image::getHtml('pasteafter.svg', sprintf($labelPasteAfter[1] ?? $labelPasteAfter[0], $row[$i]['id']));
+					$imagePasteNew = Image::getHtml('new.svg', sprintf($labelPasteNew[1] ?? $labelPasteNew[0], $row[$i]['id']));
 
 					// Decrypt encrypted value
 					foreach ($row[$i] as $k=>$v)
@@ -4494,9 +4494,9 @@ class DC_Table extends DataContainer implements \listable, \editable
 						}
 					}
 
-					$blnWrapperStart = \in_array($row[$i]['type'], $GLOBALS['TL_WRAPPERS']['start']);
-					$blnWrapperSeparator = \in_array($row[$i]['type'], $GLOBALS['TL_WRAPPERS']['separator']);
-					$blnWrapperStop = \in_array($row[$i]['type'], $GLOBALS['TL_WRAPPERS']['stop']);
+					$blnWrapperStart = isset($row[$i]['type']) && \in_array($row[$i]['type'], $GLOBALS['TL_WRAPPERS']['start']);
+					$blnWrapperSeparator = isset($row[$i]['type']) && \in_array($row[$i]['type'], $GLOBALS['TL_WRAPPERS']['separator']);
+					$blnWrapperStop = isset($row[$i]['type']) && \in_array($row[$i]['type'], $GLOBALS['TL_WRAPPERS']['stop']);
 					$blnIndentFirst = isset($row[$i - 1]['type']) && \in_array($row[$i - 1]['type'], $GLOBALS['TL_WRAPPERS']['start']);
 					$blnIndentLast = isset($row[$i + 1]['type']) && \in_array($row[$i + 1]['type'], $GLOBALS['TL_WRAPPERS']['stop']);
 

--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -2688,7 +2688,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 				if ($field == 'pid' || $field == 'sorting' || (!($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['exclude'] ?? null) && !($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['eval']['doNotShow'] ?? null) && (isset($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['inputType']) || \is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['input_field_callback'] ?? null) || \is_callable($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['input_field_callback'] ?? null))))
 				{
 					$options .= '
-  <input type="checkbox" name="all_fields[]" id="all_' . $field . '" class="tl_checkbox" value="' . StringUtil::specialchars($field) . '"> <label for="all_' . $field . '" class="tl_checkbox_label">' . (($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['label'][0] ?? $GLOBALS['TL_LANG']['MSC'][$field][0] ?? $field) . ' <span style="color:#999;padding-left:3px">[' . $field . ']</span>') . '</label><br>';
+  <input type="checkbox" name="all_fields[]" id="all_' . $field . '" class="tl_checkbox" value="' . StringUtil::specialchars($field) . '"> <label for="all_' . $field . '" class="tl_checkbox_label">' . (($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['label'][0] ?: ($GLOBALS['TL_LANG']['MSC'][$field][0] ?: $field)) . ' <span style="color:#999;padding-left:3px">[' . $field . ']</span>') . '</label><br>';
 				}
 			}
 
@@ -3014,7 +3014,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 				if ($field == 'pid' || $field == 'sorting' || (!($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['exclude'] ?? null) && !($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['eval']['doNotShow'] ?? null) && (isset($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['inputType']) || \is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['input_field_callback'] ?? null) || \is_callable($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['input_field_callback'] ?? null))))
 				{
 					$options .= '
-  <input type="checkbox" name="all_fields[]" id="all_' . $field . '" class="tl_checkbox" value="' . StringUtil::specialchars($field) . '"> <label for="all_' . $field . '" class="tl_checkbox_label">' . (($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['label'][0] ?? $GLOBALS['TL_LANG']['MSC'][$field][0] ?? $field) . ' <span style="color:#999;padding-left:3px">[' . $field . ']</span>') . '</label><br>';
+  <input type="checkbox" name="all_fields[]" id="all_' . $field . '" class="tl_checkbox" value="' . StringUtil::specialchars($field) . '"> <label for="all_' . $field . '" class="tl_checkbox_label">' . (($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['label'][0] ?: ($GLOBALS['TL_LANG']['MSC'][$field][0] ?: $field)) . ' <span style="color:#999;padding-left:3px">[' . $field . ']</span>') . '</label><br>';
 				}
 			}
 
@@ -3079,7 +3079,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 		// Make sure unique fields are unique
 		if ((string) $varValue !== '' && ($arrData['eval']['unique'] ?? null) && !$this->Database->isUniqueValue($this->strTable, $this->strField, $varValue, $this->objActiveRecord->id))
 		{
-			throw new \Exception(sprintf($GLOBALS['TL_LANG']['ERR']['unique'], $arrData['label'][0] ?? $this->strField));
+			throw new \Exception(sprintf($GLOBALS['TL_LANG']['ERR']['unique'], $arrData['label'][0] ?: $this->strField));
 		}
 
 		// Handle multi-select fields in "override all" mode
@@ -3559,7 +3559,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 			$label = $GLOBALS['TL_LANG']['MOD']['page'][0];
 		}
 
-		$icon = $GLOBALS['TL_DCA'][$table]['list']['sorting']['icon'] ?? 'pagemounts.svg';
+		$icon = $GLOBALS['TL_DCA'][$table]['list']['sorting']['icon'] ?: 'pagemounts.svg';
 		$label = Image::getHtml($icon) . ' <label>' . $label . '</label>';
 
 		// Check the default labels (see #509)
@@ -3990,7 +3990,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 			}
 			else
 			{
-				$args[$k] = $GLOBALS['TL_DCA'][$table]['fields'][$v]['reference'][$objRow->$v] ?? $objRow->$v;
+				$args[$k] = $GLOBALS['TL_DCA'][$table]['fields'][$v]['reference'][$objRow->$v] ?: $objRow->$v;
 			}
 		}
 
@@ -4950,7 +4950,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 
 							foreach ($row_v as $option)
 							{
-								$args_k[] = $GLOBALS['TL_DCA'][$table]['fields'][$v]['reference'][$option] ?? $option;
+								$args_k[] = $GLOBALS['TL_DCA'][$table]['fields'][$v]['reference'][$option] ?: $option;
 							}
 
 							$args[$k] = implode(', ', $args_k);
@@ -4975,7 +4975,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 				}
 
 				// Shorten the label it if it is too long
-				$label = vsprintf($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['format'] ?? '%s', $args);
+				$label = vsprintf($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['format'] ?: '%s', $args);
 
 				if (($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['maxCharacters'] ?? null) > 0 && $GLOBALS['TL_DCA'][$this->strTable]['list']['label']['maxCharacters'] < \strlen(strip_tags($label)))
 				{

--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -185,8 +185,8 @@ class DC_Table extends DataContainer implements \listable, \editable
 		}
 
 		$this->strTable = $strTable;
-		$this->ptable = $GLOBALS['TL_DCA'][$this->strTable]['config']['ptable'];
-		$this->ctable = $GLOBALS['TL_DCA'][$this->strTable]['config']['ctable'];
+		$this->ptable = $GLOBALS['TL_DCA'][$this->strTable]['config']['ptable'] ?? null;
+		$this->ctable = $GLOBALS['TL_DCA'][$this->strTable]['config']['ctable'] ?? null;
 		$this->treeView = \in_array($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] ?? null, array(5, 6));
 		$this->root = null;
 		$this->arrModule = $arrModule;
@@ -536,23 +536,25 @@ class DC_Table extends DataContainer implements \listable, \editable
 			}
 			elseif (\is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$i]['reference'] ?? null))
 			{
-				$row[$i] = isset($GLOBALS['TL_DCA'][$this->strTable]['fields'][$i]['reference'][$row[$i]]) ? ((\is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$i]['reference'][$row[$i]])) ? $GLOBALS['TL_DCA'][$this->strTable]['fields'][$i]['reference'][$row[$i]][0] : $GLOBALS['TL_DCA'][$this->strTable]['fields'][$i]['reference'][$row[$i]]) : $row[$i];
+				$row[$i] = isset($GLOBALS['TL_DCA'][$this->strTable]['fields'][$i]['reference'][$row[$i]]) ? (\is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$i]['reference'][$row[$i]]) ? $GLOBALS['TL_DCA'][$this->strTable]['fields'][$i]['reference'][$row[$i]][0] : $GLOBALS['TL_DCA'][$this->strTable]['fields'][$i]['reference'][$row[$i]]) : $row[$i];
 			}
-			elseif (($GLOBALS['TL_DCA'][$this->strTable]['fields'][$i]['eval']['isAssociative'] ?? null) || ArrayUtil::isAssoc($GLOBALS['TL_DCA'][$this->strTable]['fields'][$i]['options'] ?? array()))
+			elseif (($GLOBALS['TL_DCA'][$this->strTable]['fields'][$i]['eval']['isAssociative'] ?? null) || ArrayUtil::isAssoc($GLOBALS['TL_DCA'][$this->strTable]['fields'][$i]['options'] ?? null))
 			{
-				$row[$i] = $GLOBALS['TL_DCA'][$this->strTable]['fields'][$i]['options'][$row[$i]];
+				$row[$i] = $GLOBALS['TL_DCA'][$this->strTable]['fields'][$i]['options'][$row[$i]] ?? null;
 			}
 			else
 			{
 				$row[$i] = $value;
 			}
 
+			$label = null;
+
 			// Label
 			if (isset($GLOBALS['TL_DCA'][$this->strTable]['fields'][$i]['label']))
 			{
 				$label = \is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$i]['label']) ? $GLOBALS['TL_DCA'][$this->strTable]['fields'][$i]['label'][0] : $GLOBALS['TL_DCA'][$this->strTable]['fields'][$i]['label'];
 			}
-			else
+			elseif (isset($GLOBALS['TL_LANG']['MSC'][$i]))
 			{
 				$label = \is_array($GLOBALS['TL_LANG']['MSC'][$i]) ? $GLOBALS['TL_LANG']['MSC'][$i][0] : $GLOBALS['TL_LANG']['MSC'][$i];
 			}
@@ -691,7 +693,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 
 			if ($objInsertStmt->affectedRows)
 			{
-				$s2e = $GLOBALS['TL_DCA'][$this->strTable]['config']['switchToEdit'] ? '&s2e=1' : '';
+				$s2e = ($GLOBALS['TL_DCA'][$this->strTable]['config']['switchToEdit'] ?? null) ? '&s2e=1' : '';
 				$insertID = $objInsertStmt->insertId;
 
 				/** @var AttributeBagInterface $objSessionBag */
@@ -1050,14 +1052,14 @@ class DC_Table extends DataContainer implements \listable, \editable
 		$time = time();
 		$copy = array();
 		$cctable = array();
-		$ctable = $GLOBALS['TL_DCA'][$table]['config']['ctable'];
+		$ctable = $GLOBALS['TL_DCA'][$table]['config']['ctable'] ?? array();
 
 		if (!($GLOBALS['TL_DCA'][$table]['config']['ptable'] ?? null) && Input::get('childs') && $this->Database->fieldExists('pid', $table) && $this->Database->fieldExists('sorting', $table))
 		{
 			$ctable[] = $table;
 		}
 
-		if (!\is_array($ctable))
+		if (empty($ctable) || !\is_array($ctable))
 		{
 			return;
 		}
@@ -1066,7 +1068,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 		foreach ($ctable as $v)
 		{
 			$this->loadDataContainer($v);
-			$cctable[$v] = $GLOBALS['TL_DCA'][$v]['config']['ctable'];
+			$cctable[$v] = $GLOBALS['TL_DCA'][$v]['config']['ctable'] ?? null;
 
 			if (!($GLOBALS['TL_DCA'][$v]['config']['doNotCopyRecords'] ?? null) && \strlen($v))
 			{
@@ -1610,7 +1612,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 		$objSession = System::getContainer()->get('session');
 
 		$session = $objSession->all();
-		$ids = $session['CURRENT']['IDS'];
+		$ids = $session['CURRENT']['IDS'] ?? array();
 
 		if (\is_array($ids) && \strlen($ids[0]))
 		{
@@ -1634,9 +1636,9 @@ class DC_Table extends DataContainer implements \listable, \editable
 	public function deleteChilds($table, $id, &$delete)
 	{
 		$cctable = array();
-		$ctable = $GLOBALS['TL_DCA'][$table]['config']['ctable'];
+		$ctable = $GLOBALS['TL_DCA'][$table]['config']['ctable'] ?? array();
 
-		if (!\is_array($ctable))
+		if (empty($ctable) || !\is_array($ctable))
 		{
 			return;
 		}
@@ -1645,7 +1647,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 		foreach ($ctable as $v)
 		{
 			$this->loadDataContainer($v);
-			$cctable[$v] = $GLOBALS['TL_DCA'][$v]['config']['ctable'];
+			$cctable[$v] = $GLOBALS['TL_DCA'][$v]['config']['ctable'] ?? null;
 
 			// Consider the dynamic parent table (see #4867)
 			if ($GLOBALS['TL_DCA'][$v]['config']['dynamicPtable'] ?? null)
@@ -1912,7 +1914,10 @@ class DC_Table extends DataContainer implements \listable, \editable
 
 				if (isset($legends[$k]))
 				{
-					list($key, $cls) = explode(':', $legends[$k]);
+					$chunks = explode(':', $legends[$k]);
+					$key = $chunks[0] ?? null;
+					$cls = $chunks[1] ?? null;
+
 					$legend = "\n" . '<legend onclick="AjaxRequest.toggleFieldset(this,\'' . $key . '\',\'' . $this->strTable . '\')">' . ($GLOBALS['TL_LANG'][$this->strTable][$key] ?? $key) . '</legend>';
 				}
 
@@ -2335,7 +2340,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 
 		// Get current IDs from session
 		$session = $objSession->all();
-		$ids = $session['CURRENT']['IDS'];
+		$ids = $session['CURRENT']['IDS'] ?? array();
 
 		if ($intId && Environment::get('isAjaxRequest'))
 		{
@@ -2350,7 +2355,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 		}
 
 		// Add fields
-		$fields = $session['CURRENT'][$this->strTable];
+		$fields = $session['CURRENT'][$this->strTable] ?? array();
 
 		if (!empty($fields) && \is_array($fields) && Input::get('fields'))
 		{
@@ -2683,7 +2688,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 				if ($field == 'pid' || $field == 'sorting' || (!($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['exclude'] ?? null) && !($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['eval']['doNotShow'] ?? null) && (isset($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['inputType']) || \is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['input_field_callback'] ?? null) || \is_callable($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['input_field_callback'] ?? null))))
 				{
 					$options .= '
-  <input type="checkbox" name="all_fields[]" id="all_' . $field . '" class="tl_checkbox" value="' . StringUtil::specialchars($field) . '"> <label for="all_' . $field . '" class="tl_checkbox_label">' . (($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['label'][0] ?: ($GLOBALS['TL_LANG']['MSC'][$field][0] ?: $field)) . ' <span style="color:#999;padding-left:3px">[' . $field . ']</span>') . '</label><br>';
+  <input type="checkbox" name="all_fields[]" id="all_' . $field . '" class="tl_checkbox" value="' . StringUtil::specialchars($field) . '"> <label for="all_' . $field . '" class="tl_checkbox_label">' . (($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['label'][0] ?? $GLOBALS['TL_LANG']['MSC'][$field][0] ?? $field) . ' <span style="color:#999;padding-left:3px">[' . $field . ']</span>') . '</label><br>';
 				}
 			}
 
@@ -2745,7 +2750,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 
 		// Get current IDs from session
 		$session = $objSession->all();
-		$ids = $session['CURRENT']['IDS'];
+		$ids = $session['CURRENT']['IDS'] ?? array();
 
 		// Save field selection in session
 		if (Input::post('FORM_SUBMIT') == $this->strTable . '_all' && Input::get('fields'))
@@ -2755,7 +2760,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 		}
 
 		// Add fields
-		$fields = $session['CURRENT'][$this->strTable];
+		$fields = $session['CURRENT'][$this->strTable] ?? array();
 
 		if (!empty($fields) && \is_array($fields) && Input::get('fields'))
 		{
@@ -3009,7 +3014,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 				if ($field == 'pid' || $field == 'sorting' || (!($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['exclude'] ?? null) && !($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['eval']['doNotShow'] ?? null) && (isset($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['inputType']) || \is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['input_field_callback'] ?? null) || \is_callable($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['input_field_callback'] ?? null))))
 				{
 					$options .= '
-  <input type="checkbox" name="all_fields[]" id="all_' . $field . '" class="tl_checkbox" value="' . StringUtil::specialchars($field) . '"> <label for="all_' . $field . '" class="tl_checkbox_label">' . (($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['label'][0] ?: ($GLOBALS['TL_LANG']['MSC'][$field][0] ?: $field)) . ' <span style="color:#999;padding-left:3px">[' . $field . ']</span>') . '</label><br>';
+  <input type="checkbox" name="all_fields[]" id="all_' . $field . '" class="tl_checkbox" value="' . StringUtil::specialchars($field) . '"> <label for="all_' . $field . '" class="tl_checkbox_label">' . (($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['label'][0] ?? $GLOBALS['TL_LANG']['MSC'][$field][0] ?? $field) . ' <span style="color:#999;padding-left:3px">[' . $field . ']</span>') . '</label><br>';
 				}
 			}
 
@@ -3062,23 +3067,23 @@ class DC_Table extends DataContainer implements \listable, \editable
 			return;
 		}
 
-		$arrData = $GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField];
+		$arrData = $GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField] ?? array();
 
 		// Convert date formats into timestamps
-		if ($varValue !== null && $varValue !== '' && \in_array($arrData['eval']['rgxp'], array('date', 'time', 'datim')))
+		if ($varValue !== null && $varValue !== '' && \in_array($arrData['eval']['rgxp'] ?? null, array('date', 'time', 'datim')))
 		{
 			$objDate = new Date($varValue, Date::getFormatFromRgxp($arrData['eval']['rgxp']));
 			$varValue = $objDate->tstamp;
 		}
 
 		// Make sure unique fields are unique
-		if ((string) $varValue !== '' && $arrData['eval']['unique'] && !$this->Database->isUniqueValue($this->strTable, $this->strField, $varValue, $this->objActiveRecord->id))
+		if ((string) $varValue !== '' && ($arrData['eval']['unique'] ?? null) && !$this->Database->isUniqueValue($this->strTable, $this->strField, $varValue, $this->objActiveRecord->id))
 		{
-			throw new \Exception(sprintf($GLOBALS['TL_LANG']['ERR']['unique'], $arrData['label'][0] ?: $this->strField));
+			throw new \Exception(sprintf($GLOBALS['TL_LANG']['ERR']['unique'], $arrData['label'][0] ?? $this->strField));
 		}
 
 		// Handle multi-select fields in "override all" mode
-		if ($this->objActiveRecord !== null && ($arrData['inputType'] == 'checkbox' || $arrData['inputType'] == 'checkboxWizard') && $arrData['eval']['multiple'] && Input::get('act') == 'overrideAll')
+		if ($this->objActiveRecord !== null && (($arrData['inputType'] ?? null) == 'checkbox' || ($arrData['inputType'] ?? null) == 'checkboxWizard') && ($arrData['eval']['multiple'] ?? null) && Input::get('act') == 'overrideAll')
 		{
 			$new = StringUtil::deserialize($varValue, true);
 			$old = StringUtil::deserialize($this->objActiveRecord->{$this->strField}, true);
@@ -3117,7 +3122,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 
 			if (empty($varValue) || !\is_array($varValue))
 			{
-				$varValue = Widget::getEmptyStringOrNullByFieldType($arrData['sql']);
+				$varValue = Widget::getEmptyStringOrNullByFieldType($arrData['sql'] ?? array());
 			}
 			elseif (isset($arrData['eval']['csv']))
 			{
@@ -3130,13 +3135,13 @@ class DC_Table extends DataContainer implements \listable, \editable
 		}
 
 		// Convert arrays (see #2890)
-		if ($arrData['eval']['multiple'] && isset($arrData['eval']['csv']))
+		if (($arrData['eval']['multiple'] ?? null) && isset($arrData['eval']['csv']))
 		{
 			$varValue = implode($arrData['eval']['csv'], StringUtil::deserialize($varValue, true));
 		}
 
 		// Trigger the save_callback
-		if (\is_array($arrData['save_callback']))
+		if (\is_array($arrData['save_callback'] ?? null))
 		{
 			foreach ($arrData['save_callback'] as $callback)
 			{
@@ -3153,10 +3158,10 @@ class DC_Table extends DataContainer implements \listable, \editable
 		}
 
 		// Save the value if there was no error
-		if (((string) $varValue !== '' || !$arrData['eval']['doNotSaveEmpty']) && ($this->varValue !== $varValue || $arrData['eval']['alwaysSave']))
+		if (((string) $varValue !== '' || !($arrData['eval']['doNotSaveEmpty'] ?? null)) && ($this->varValue !== $varValue || ($arrData['eval']['alwaysSave'] ?? null)))
 		{
 			// If the field is a fallback field, empty all other columns (see #6498)
-			if ($varValue && $arrData['eval']['fallback'])
+			if ($varValue && ($arrData['eval']['fallback'] ?? null))
 			{
 				if (($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] ?? null) == 4)
 				{
@@ -3312,8 +3317,8 @@ class DC_Table extends DataContainer implements \listable, \editable
 	protected function reviseTable()
 	{
 		$reload = false;
-		$ptable = $GLOBALS['TL_DCA'][$this->strTable]['config']['ptable'];
-		$ctable = $GLOBALS['TL_DCA'][$this->strTable]['config']['ctable'];
+		$ptable = $GLOBALS['TL_DCA'][$this->strTable]['config']['ptable'] ?? null;
+		$ctable = $GLOBALS['TL_DCA'][$this->strTable]['config']['ctable'] ?? null;
 
 		/** @var AttributeBagInterface $objSessionBag */
 		$objSessionBag = System::getContainer()->get('session')->getBag('contao_backend');
@@ -3554,7 +3559,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 			$label = $GLOBALS['TL_LANG']['MOD']['page'][0];
 		}
 
-		$icon = $GLOBALS['TL_DCA'][$table]['list']['sorting']['icon'] ?: 'pagemounts.svg';
+		$icon = $GLOBALS['TL_DCA'][$table]['list']['sorting']['icon'] ?? 'pagemounts.svg';
 		$label = Image::getHtml($icon) . ' <label>' . $label . '</label>';
 
 		// Check the default labels (see #509)
@@ -3921,7 +3926,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 			$blnProtected = ($objRow->protected || $protectedPage);
 		}
 
-		$session[$node][$id] = (\is_int($session[$node][$id])) ? $session[$node][$id] : 0;
+		$session[$node][$id] = (\is_int($session[$node][$id] ?? null)) ? $session[$node][$id] : 0;
 		$mouseover = (($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] ?? null) == 5 || $table == $this->strTable) ? ' toggle_select hover-div' : '';
 
 		$return .= "\n  " . '<li class="' . (((($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] ?? null) == 5 && $objRow->type == 'root') || $table != $this->strTable) ? 'tl_folder' : 'tl_file') . ' click2edit' . $mouseover . ' cf"><div class="tl_left" style="padding-left:' . ($intMargin + $intSpacing + (empty($childs) ? 20 : 0)) . 'px">';
@@ -3985,7 +3990,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 			}
 			else
 			{
-				$args[$k] = $GLOBALS['TL_DCA'][$table]['fields'][$v]['reference'][$objRow->$v] ?: $objRow->$v;
+				$args[$k] = $GLOBALS['TL_DCA'][$table]['fields'][$v]['reference'][$objRow->$v] ?? $objRow->$v;
 			}
 		}
 
@@ -4018,8 +4023,8 @@ class DC_Table extends DataContainer implements \listable, \editable
 		}
 
 		$return .= '</div> <div class="tl_right">';
-		$previous = ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] ?? null) == 6 ? $arrPrevNext['pp'] : $arrPrevNext['p'];
-		$next = ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] ?? null) == 6 ? $arrPrevNext['nn'] : $arrPrevNext['n'];
+		$previous = ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] ?? null) == 6 ? ($arrPrevNext['pp'] ?? null) : ($arrPrevNext['p'] ?? null);
+		$next = ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] ?? null) == 6 ? ($arrPrevNext['nn'] ?? null) : ($arrPrevNext['n'] ?? null);
 		$_buttons = '';
 
 		// Regular buttons ($row, $table, $root, $blnCircularReference, $childs, $previous, $next)
@@ -4101,7 +4106,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 
 				for ($j=0, $c=\count($ids); $j<$c; $j++)
 				{
-					$return .= $this->generateTree($this->strTable, $ids[$j], array('pp'=>$ids[($j-1)], 'nn'=>$ids[($j+1)]), $blnHasSorting, ($intMargin + $intSpacing), $arrClipboard, false, ($j<(\count($ids)-1) || !empty($childs)), $blnNoRecursion, $arrFound);
+					$return .= $this->generateTree($this->strTable, $ids[$j], array('pp'=>($ids[($j-1)] ?? null), 'nn'=>($ids[($j+1)] ?? null)), $blnHasSorting, ($intMargin + $intSpacing), $arrClipboard, false, ($j<(\count($ids)-1) || !empty($childs)), $blnNoRecursion, $arrFound);
 				}
 			}
 		}
@@ -4121,7 +4126,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 			{
 				for ($k=0, $c=\count($childs); $k<$c; $k++)
 				{
-					$return .= $this->generateTree($table, $childs[$k], array('p'=>($childs[($k-1)] ?? null), 'n'=>($childs[($k+1)] ?? null)), $blnHasSorting, ($intMargin + $intSpacing), $arrClipboard, ((($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] ?? null) == 5 && $childs[$k] == $arrClipboard['id']) || $blnCircularReference), ($blnProtected || $protectedPage), $blnNoRecursion, $arrFound);
+					$return .= $this->generateTree($table, $childs[$k], array('p'=>($childs[($k-1)] ?? null), 'n'=>($childs[($k+1)] ?? null)), $blnHasSorting, ($intMargin + $intSpacing), $arrClipboard, ((($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] ?? null) == 5 && \is_array($arrClipboard) && $childs[$k] == $arrClipboard['id']) || $blnCircularReference), ($blnProtected || $protectedPage), $blnNoRecursion, $arrFound);
 				}
 			}
 
@@ -4285,9 +4290,9 @@ class DC_Table extends DataContainer implements \listable, \editable
 				{
 					$_v = $GLOBALS['TL_DCA'][$this->ptable]['fields'][$v]['reference'][$_v];
 				}
-				elseif (($GLOBALS['TL_DCA'][$this->ptable]['fields'][$v]['eval']['isAssociative'] ?? null) || ArrayUtil::isAssoc($GLOBALS['TL_DCA'][$this->ptable]['fields'][$v]['options'] ?? array()))
+				elseif (($GLOBALS['TL_DCA'][$this->ptable]['fields'][$v]['eval']['isAssociative'] ?? null) || ArrayUtil::isAssoc($GLOBALS['TL_DCA'][$this->ptable]['fields'][$v]['options'] ?? null))
 				{
-					$_v = $GLOBALS['TL_DCA'][$this->ptable]['fields'][$v]['options'][$_v];
+					$_v = $GLOBALS['TL_DCA'][$this->ptable]['fields'][$v]['options'][$_v] ?? null;
 				}
 				elseif (\is_array($GLOBALS['TL_DCA'][$this->ptable]['fields'][$v]['options_callback'] ?? null))
 				{
@@ -4520,7 +4525,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 					// Regular buttons
 					else
 					{
-						$return .= $this->generateButtons($row[$i], $this->strTable, $this->root, false, null, $row[($i-1)]['id'], $row[($i+1)]['id']);
+						$return .= $this->generateButtons($row[$i], $this->strTable, $this->root, false, null, ($row[($i-1)]['id'] ?? null), ($row[($i+1)]['id'] ?? null));
 
 						// Sortable table
 						if ($blnHasSorting)
@@ -4692,7 +4697,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 		$orderBy = $GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['fields'] ?? array();
 		$firstOrderBy = preg_replace('/\s+.*$/', '', $orderBy[0]);
 
-		if (\is_array($this->orderBy) && $this->orderBy[0])
+		if (\is_array($this->orderBy) && !empty($this->orderBy[0]))
 		{
 			$orderBy = $this->orderBy;
 			$firstOrderBy = $this->firstOrderBy;
@@ -4717,7 +4722,9 @@ class DC_Table extends DataContainer implements \listable, \editable
 		{
 			foreach ($orderBy as $k=>$v)
 			{
-				list($key, $direction) = explode(' ', $v, 2);
+				$chunks = explode(' ', $v, 2);
+				$key = $chunks[0] ?? null;
+				$direction = $chunks[1] ?? null;
 
 				// If there is no direction, check the global flag in sorting mode 1 or the field flag in all other sorting modes
 				if (!$direction)
@@ -4750,7 +4757,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 					}
 					else
 					{
-						$keys = $GLOBALS['TL_DCA'][$this->strTable]['fields'][$key]['options'];
+						$keys = $GLOBALS['TL_DCA'][$this->strTable]['fields'][$key]['options'] ?? array();
 					}
 
 					if (($GLOBALS['TL_DCA'][$this->strTable]['fields'][$key]['eval']['isAssociative'] ?? null) || ArrayUtil::isAssoc($keys))
@@ -4875,7 +4882,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 					}
 
 					$return .= '
-    <th class="tl_folder_tlist col_' . $f . (($f == $firstOrderBy) ? ' ordered_by' : '') . '">' . (\is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$f]['label']) ? $GLOBALS['TL_DCA'][$this->strTable]['fields'][$f]['label'][0] : $GLOBALS['TL_DCA'][$this->strTable]['fields'][$f]['label']) . '</th>';
+    <th class="tl_folder_tlist col_' . $f . (($f == $firstOrderBy) ? ' ordered_by' : '') . '">' . (\is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$f]['label'] ?? null) ? $GLOBALS['TL_DCA'][$this->strTable]['fields'][$f]['label'][0] : ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$f]['label'] ?? null)) . '</th>';
 				}
 
 				$return .= '
@@ -4933,7 +4940,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 					{
 						$args[$k] = $row[$v] ? $GLOBALS['TL_LANG']['MSC']['yes'] : $GLOBALS['TL_LANG']['MSC']['no'];
 					}
-					else
+					elseif (isset($row[$v]))
 					{
 						$row_v = StringUtil::deserialize($row[$v]);
 
@@ -4943,7 +4950,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 
 							foreach ($row_v as $option)
 							{
-								$args_k[] = $GLOBALS['TL_DCA'][$table]['fields'][$v]['reference'][$option] ?: $option;
+								$args_k[] = $GLOBALS['TL_DCA'][$table]['fields'][$v]['reference'][$option] ?? $option;
 							}
 
 							$args[$k] = implode(', ', $args_k);
@@ -4952,19 +4959,23 @@ class DC_Table extends DataContainer implements \listable, \editable
 						{
 							$args[$k] = \is_array($GLOBALS['TL_DCA'][$table]['fields'][$v]['reference'][$row[$v]]) ? $GLOBALS['TL_DCA'][$table]['fields'][$v]['reference'][$row[$v]][0] : $GLOBALS['TL_DCA'][$table]['fields'][$v]['reference'][$row[$v]];
 						}
-						elseif ((($GLOBALS['TL_DCA'][$table]['fields'][$v]['eval']['isAssociative'] ?? null) || ArrayUtil::isAssoc($GLOBALS['TL_DCA'][$table]['fields'][$v]['options'] ?? array())) && isset($GLOBALS['TL_DCA'][$table]['fields'][$v]['options'][$row[$v]]))
+						elseif ((($GLOBALS['TL_DCA'][$table]['fields'][$v]['eval']['isAssociative'] ?? null) || ArrayUtil::isAssoc($GLOBALS['TL_DCA'][$table]['fields'][$v]['options'] ?? null)) && isset($GLOBALS['TL_DCA'][$table]['fields'][$v]['options'][$row[$v]]))
 						{
-							$args[$k] = $GLOBALS['TL_DCA'][$table]['fields'][$v]['options'][$row[$v]];
+							$args[$k] = $GLOBALS['TL_DCA'][$table]['fields'][$v]['options'][$row[$v]] ?? null;
 						}
 						else
 						{
 							$args[$k] = $row[$v];
 						}
 					}
+					else
+					{
+						$args[$k] = null;
+					}
 				}
 
 				// Shorten the label it if it is too long
-				$label = vsprintf($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['format'] ?: '%s', $args);
+				$label = vsprintf($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['format'] ?? '%s', $args);
 
 				if (($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['maxCharacters'] ?? null) > 0 && $GLOBALS['TL_DCA'][$this->strTable]['list']['label']['maxCharacters'] < \strlen(strip_tags($label)))
 				{
@@ -4979,7 +4990,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 				if (($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] ?? null) > 0)
 				{
 					$current = $row[$firstOrderBy];
-					$orderBy = $GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['fields'];
+					$orderBy = $GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['fields'] ?? array();
 					$sortingMode = (\count($orderBy) == 1 && $firstOrderBy == $orderBy[0] && ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['flag'] ?? null) && !($GLOBALS['TL_DCA'][$this->strTable]['fields'][$firstOrderBy]['flag'] ?? null)) ? $GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['flag'] : $GLOBALS['TL_DCA'][$this->strTable]['fields'][$firstOrderBy]['flag'];
 					$remoteNew = $this->formatCurrentValue($firstOrderBy, $current, $sortingMode);
 
@@ -5152,7 +5163,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 		// Get search fields
 		foreach ($GLOBALS['TL_DCA'][$this->strTable]['fields'] as $k=>$v)
 		{
-			if ($v['search'])
+			if ($v['search'] ?? null)
 			{
 				$searchFields[] = $k;
 			}
@@ -5198,7 +5209,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 		}
 
 		// Set the search value from the session
-		elseif ((string) $session['search'][$this->strTable]['value'] !== '')
+		elseif (isset($session['search'][$this->strTable]['value']) && (string) $session['search'][$this->strTable]['value'] !== '')
 		{
 			$strPattern = "CAST(%s AS CHAR) REGEXP ?";
 
@@ -5207,20 +5218,20 @@ class DC_Table extends DataContainer implements \listable, \editable
 				$strPattern = "LOWER(CAST(%s AS CHAR)) REGEXP LOWER(?)";
 			}
 
-			$fld = $session['search'][$this->strTable]['field'];
+			$fld = $session['search'][$this->strTable]['field'] ?? array();
 
 			if (isset($GLOBALS['TL_DCA'][$this->strTable]['fields'][$fld]['foreignKey']))
 			{
 				list($t, $f) = explode('.', $GLOBALS['TL_DCA'][$this->strTable]['fields'][$fld]['foreignKey'], 2);
 				$this->procedure[] = "(" . sprintf($strPattern, Database::quoteIdentifier($fld)) . " OR " . sprintf($strPattern, "(SELECT " . Database::quoteIdentifier($f) . " FROM $t WHERE $t.id=" . $this->strTable . "." . Database::quoteIdentifier($fld) . ")") . ")";
-				$this->values[] = $session['search'][$this->strTable]['value'];
+				$this->values[] = $session['search'][$this->strTable]['value'] ?? null;
 			}
 			else
 			{
 				$this->procedure[] = sprintf($strPattern, Database::quoteIdentifier($fld));
 			}
 
-			$this->values[] = $session['search'][$this->strTable]['value'];
+			$this->values[] = $session['search'][$this->strTable]['value'] ?? null;
 		}
 
 		$options_sorter = array();
@@ -5238,7 +5249,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 				$option_label = \is_array($GLOBALS['TL_LANG']['MSC'][$field]) ? $GLOBALS['TL_LANG']['MSC'][$field][0] : $GLOBALS['TL_LANG']['MSC'][$field];
 			}
 
-			$options_sorter[Utf8::toAscii($option_label) . '_' . $field] = '  <option value="' . StringUtil::specialchars($field) . '"' . (($field == $session['search'][$this->strTable]['field']) ? ' selected="selected"' : '') . '>' . $option_label . '</option>';
+			$options_sorter[Utf8::toAscii($option_label) . '_' . $field] = '  <option value="' . StringUtil::specialchars($field) . '"' . ((isset($session['search'][$this->strTable]['field']) && $session['search'][$this->strTable]['field'] == $field) ? ' selected="selected"' : '') . '>' . $option_label . '</option>';
 		}
 
 		// Sort by option values
@@ -5252,7 +5263,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 ' . implode("\n", $options_sorter) . '
 </select>
 <span>=</span>
-<input type="search" name="tl_value" class="tl_text' . ($active ? ' active' : '') . '" value="' . StringUtil::specialchars($session['search'][$this->strTable]['value']) . '">
+<input type="search" name="tl_value" class="tl_text' . ($active ? ' active' : '') . '" value="' . StringUtil::specialchars($session['search'][$this->strTable]['value'] ?? '') . '">
 </div>';
 	}
 
@@ -5273,7 +5284,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 		// Get sorting fields
 		foreach ($GLOBALS['TL_DCA'][$this->strTable]['fields'] as $k=>$v)
 		{
-			if ($v['sorting'])
+			if ($v['sorting'] ?? null)
 			{
 				$sortingFields[] = $k;
 			}
@@ -5289,7 +5300,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 		$objSessionBag = System::getContainer()->get('session')->getBag('contao_backend');
 
 		$session = $objSessionBag->all();
-		$orderBy = $GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['fields'];
+		$orderBy = $GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['fields'] ?? array();
 		$firstOrderBy = preg_replace('/\s+.*$/', '', $orderBy[0]);
 
 		// Add PID to order fields
@@ -5328,14 +5339,14 @@ class DC_Table extends DataContainer implements \listable, \editable
 		// Sorting fields
 		foreach ($sortingFields as $field)
 		{
-			$options_label = ($lbl = \is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['label']) ? $GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['label'][0] : $GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['label']) ? $lbl : $GLOBALS['TL_LANG']['MSC'][$field];
+			$options_label = ($lbl = \is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['label'] ?? null) ? $GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['label'][0] : ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['label'] ?? null)) ? $lbl : $GLOBALS['TL_LANG']['MSC'][$field];
 
 			if (\is_array($options_label))
 			{
 				$options_label = $options_label[0];
 			}
 
-			$options_sorter[$options_label] = '  <option value="' . StringUtil::specialchars($field) . '"' . (((!isset($session['sorting'][$this->strTable]) && $field == $firstOrderBy) || $field == str_replace(' DESC', '', $session['sorting'][$this->strTable])) ? ' selected="selected"' : '') . '>' . $options_label . '</option>';
+			$options_sorter[$options_label] = '  <option value="' . StringUtil::specialchars($field) . '"' . (((!isset($session['sorting'][$this->strTable]) && $field == $firstOrderBy) || $field == str_replace(' DESC', '', $session['sorting'][$this->strTable] ?? '')) ? ' selected="selected"' : '') . '>' . $options_label . '</option>';
 		}
 
 		// Sort by option values
@@ -5392,7 +5403,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 		// Set limit from table configuration
 		else
 		{
-			$this->limit = $session['filter'][$filter]['limit'] ? (($session['filter'][$filter]['limit'] == 'all') ? null : $session['filter'][$filter]['limit']) : '0,' . Config::get('resultsPerPage');
+			$this->limit = isset($session['filter'][$filter]['limit']) ? (($session['filter'][$filter]['limit'] == 'all') ? null : $session['filter'][$filter]['limit']) : '0,' . Config::get('resultsPerPage');
 
 			$arrProcedure = $this->procedure;
 			$arrValues = $this->values;
@@ -5477,7 +5488,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 			}
 
 			$fields = '
-<select name="tl_limit" class="tl_select' . (($session['filter'][$filter]['limit'] != 'all' && $this->total > Config::get('resultsPerPage')) ? ' active' : '') . '" onchange="this.form.submit()">
+<select name="tl_limit" class="tl_select' . (($session['filter'][$filter]['limit'] ?? null) != 'all' && $this->total > Config::get('resultsPerPage') ? ' active' : '') . '" onchange="this.form.submit()">
   <option value="tl_limit">' . $GLOBALS['TL_LANG']['MSC']['filterRecords'] . '</option>' . $options . '
 </select> ';
 		}
@@ -5602,7 +5613,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 						if (isset($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['eval']['csv']))
 						{
 							$this->procedure[] = $this->Database->findInSet('?', $field, true);
-							$this->values[] = $session['filter'][$filter][$field];
+							$this->values[] = $session['filter'][$filter][$field] ?? null;
 						}
 						else
 						{
@@ -5615,7 +5626,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 					else
 					{
 						$this->procedure[] = $what . '=?';
-						$this->values[] = $session['filter'][$filter][$field];
+						$this->values[] = $session['filter'][$filter][$field] ?? null;
 					}
 				}
 			}
@@ -5715,7 +5726,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 			// Begin select menu
 			$fields .= '
 <select name="' . $field . '" id="' . $field . '" class="tl_select' . (isset($session['filter'][$filter][$field]) ? ' active' : '') . '">
-  <option value="tl_' . $field . '">' . (\is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['label']) ? $GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['label'][0] : $GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['label']) . '</option>
+  <option value="tl_' . $field . '">' . (\is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['label'] ?? null) ? $GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['label'][0] : ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['label'] ?? null)) . '</option>
   <option value="tl_' . $field . '">---</option>';
 
 			if ($objFields->numRows)
@@ -5877,9 +5888,9 @@ class DC_Table extends DataContainer implements \listable, \editable
 					elseif ($field == 'pid')
 					{
 						$this->loadDataContainer($this->ptable);
-						$showFields = $GLOBALS['TL_DCA'][$this->ptable]['list']['label']['fields'];
+						$showFields = $GLOBALS['TL_DCA'][$this->ptable]['list']['label']['fields'] ?? array();
 
-						if (!$showFields[0])
+						if (!($showFields[0] ?? null))
 						{
 							$showFields[0] = 'id';
 						}
@@ -5899,13 +5910,13 @@ class DC_Table extends DataContainer implements \listable, \editable
 					// Use reference array
 					if (isset($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['reference']))
 					{
-						$option_label = \is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['reference'][$vv]) ? $GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['reference'][$vv][0] : $GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['reference'][$vv];
+						$option_label = \is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['reference'][$vv] ?? null) ? $GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['reference'][$vv][0] : ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['reference'][$vv] ?? null);
 					}
 
 					// Associative array
-					elseif (($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['eval']['isAssociative'] ?? null) || ArrayUtil::isAssoc($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['options'] ?? array()))
+					elseif (($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['eval']['isAssociative'] ?? null) || ArrayUtil::isAssoc($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['options'] ?? null))
 					{
-						$option_label = $GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['options'][$vv];
+						$option_label = $GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['options'][$vv] ?? '-';
 					}
 
 					// No empty options allowed
@@ -5914,7 +5925,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 						$option_label = $vv ?: '-';
 					}
 
-					$options_sorter['  <option value="' . StringUtil::specialchars($value) . '"' . ((isset($session['filter'][$filter][$field]) && $value == $session['filter'][$filter][$field]) ? ' selected="selected"' : '') . '>' . $option_label . '</option>'] = Utf8::toAscii($option_label);
+					$options_sorter['  <option value="' . StringUtil::specialchars($value) . '"' . ((isset($session['filter'][$filter][$field]) && $session['filter'][$filter][$field] == $value) ? ' selected="selected"' : '') . '>' . $option_label . '</option>'] = Utf8::toAscii($option_label);
 				}
 
 				// Sort by option values
@@ -6056,11 +6067,11 @@ class DC_Table extends DataContainer implements \listable, \editable
 			}
 			elseif (\is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['reference'] ?? null))
 			{
-				$remoteNew = $GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['reference'][$value];
+				$remoteNew = $GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['reference'][$value] ?? null;
 			}
-			elseif (($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['eval']['isAssociative'] ?? null) || ArrayUtil::isAssoc($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['options'] ?? array()))
+			elseif (($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['eval']['isAssociative'] ?? null) || ArrayUtil::isAssoc($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['options'] ?? null))
 			{
-				$remoteNew = $GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['options'][$value];
+				$remoteNew = $GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['options'][$value] ?? null;
 			}
 			else
 			{
@@ -6095,9 +6106,9 @@ class DC_Table extends DataContainer implements \listable, \editable
 	{
 		static $lookup = array();
 
-		if (($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['eval']['isAssociative'] ?? null) || ArrayUtil::isAssoc($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['options'] ?? array()))
+		if (($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['eval']['isAssociative'] ?? null) || ArrayUtil::isAssoc($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['options'] ?? null))
 		{
-			$group = $GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['options'][$value];
+			$group = $GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['options'][$value] ?? null;
 		}
 		elseif (\is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['options_callback'] ?? null))
 		{
@@ -6114,12 +6125,12 @@ class DC_Table extends DataContainer implements \listable, \editable
 		}
 		else
 		{
-			$group = \is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['reference'][$value]) ? $GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['reference'][$value][0] : $GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['reference'][$value];
+			$group = \is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['reference'][$value] ?? null) ? $GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['reference'][$value][0] : ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['reference'][$value] ?? null);
 		}
 
 		if (empty($group))
 		{
-			$group = \is_array($GLOBALS['TL_LANG'][$this->strTable][$value]) ? $GLOBALS['TL_LANG'][$this->strTable][$value][0] : $GLOBALS['TL_LANG'][$this->strTable][$value];
+			$group = \is_array($GLOBALS['TL_LANG'][$this->strTable][$value] ?? null) ? $GLOBALS['TL_LANG'][$this->strTable][$value][0] : ($GLOBALS['TL_LANG'][$this->strTable][$value] ?? null);
 		}
 
 		if (empty($group))
@@ -6128,7 +6139,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 
 			if ($value != '-' && ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['eval']['isBoolean'] ?? null))
 			{
-				$group = \is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['label']) ? $GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['label'][0] : $GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['label'];
+				$group = \is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['label'] ?? null) ? $GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['label'][0] : ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['label'] ?? null);
 			}
 		}
 

--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -3559,7 +3559,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 			$label = $GLOBALS['TL_LANG']['MOD']['page'][0];
 		}
 
-		$icon = $GLOBALS['TL_DCA'][$table]['list']['sorting']['icon'] ?? 'pagemounts.svg';
+		$icon = !empty($GLOBALS['TL_DCA'][$table]['list']['sorting']['icon']) ? $GLOBALS['TL_DCA'][$table]['list']['sorting']['icon'] : 'pagemounts.svg';
 		$label = Image::getHtml($icon) . ' <label>' . $label . '</label>';
 
 		// Check the default labels (see #509)
@@ -4975,7 +4975,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 				}
 
 				// Shorten the label it if it is too long
-				$label = vsprintf($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['format'] ?? '%s', $args);
+				$label = vsprintf(!empty($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['format']) ? $GLOBALS['TL_DCA'][$this->strTable]['list']['label']['format'] : '%s', $args);
 
 				if (($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['maxCharacters'] ?? null) > 0 && $GLOBALS['TL_DCA'][$this->strTable]['list']['label']['maxCharacters'] < \strlen(strip_tags($label)))
 				{
@@ -5916,7 +5916,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 					// Associative array
 					elseif (($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['eval']['isAssociative'] ?? null) || ArrayUtil::isAssoc($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['options'] ?? null))
 					{
-						$option_label = $GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['options'][$vv] ?? '-';
+						$option_label = $GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['options'][$vv] ?? null;
 					}
 
 					// No empty options allowed

--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -2688,7 +2688,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 				if ($field == 'pid' || $field == 'sorting' || (!($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['exclude'] ?? null) && !($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['eval']['doNotShow'] ?? null) && (isset($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['inputType']) || \is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['input_field_callback'] ?? null) || \is_callable($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['input_field_callback'] ?? null))))
 				{
 					$options .= '
-  <input type="checkbox" name="all_fields[]" id="all_' . $field . '" class="tl_checkbox" value="' . StringUtil::specialchars($field) . '"> <label for="all_' . $field . '" class="tl_checkbox_label">' . (($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['label'][0] ?: ($GLOBALS['TL_LANG']['MSC'][$field][0] ?: $field)) . ' <span style="color:#999;padding-left:3px">[' . $field . ']</span>') . '</label><br>';
+  <input type="checkbox" name="all_fields[]" id="all_' . $field . '" class="tl_checkbox" value="' . StringUtil::specialchars($field) . '"> <label for="all_' . $field . '" class="tl_checkbox_label">' . (($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['label'][0] ?? (\is_array($GLOBALS['TL_LANG']['MSC'][$field] ?? null) ? $GLOBALS['TL_LANG']['MSC'][$field][0] : ($GLOBALS['TL_LANG']['MSC'][$field] ?? null)) ?? $field) . ' <span style="color:#999;padding-left:3px">[' . $field . ']</span>') . '</label><br>';
 				}
 			}
 
@@ -3014,7 +3014,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 				if ($field == 'pid' || $field == 'sorting' || (!($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['exclude'] ?? null) && !($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['eval']['doNotShow'] ?? null) && (isset($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['inputType']) || \is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['input_field_callback'] ?? null) || \is_callable($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['input_field_callback'] ?? null))))
 				{
 					$options .= '
-  <input type="checkbox" name="all_fields[]" id="all_' . $field . '" class="tl_checkbox" value="' . StringUtil::specialchars($field) . '"> <label for="all_' . $field . '" class="tl_checkbox_label">' . (($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['label'][0] ?: ($GLOBALS['TL_LANG']['MSC'][$field][0] ?: $field)) . ' <span style="color:#999;padding-left:3px">[' . $field . ']</span>') . '</label><br>';
+  <input type="checkbox" name="all_fields[]" id="all_' . $field . '" class="tl_checkbox" value="' . StringUtil::specialchars($field) . '"> <label for="all_' . $field . '" class="tl_checkbox_label">' . (($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['label'][0] ?? (\is_array($GLOBALS['TL_LANG']['MSC'][$field] ?? null) ? $GLOBALS['TL_LANG']['MSC'][$field][0] : ($GLOBALS['TL_LANG']['MSC'][$field] ?? null)) ?? $field) . ' <span style="color:#999;padding-left:3px">[' . $field . ']</span>') . '</label><br>';
 				}
 			}
 
@@ -3559,7 +3559,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 			$label = $GLOBALS['TL_LANG']['MOD']['page'][0];
 		}
 
-		$icon = $GLOBALS['TL_DCA'][$table]['list']['sorting']['icon'] ?: 'pagemounts.svg';
+		$icon = $GLOBALS['TL_DCA'][$table]['list']['sorting']['icon'] ?? 'pagemounts.svg';
 		$label = Image::getHtml($icon) . ' <label>' . $label . '</label>';
 
 		// Check the default labels (see #509)
@@ -3990,7 +3990,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 			}
 			else
 			{
-				$args[$k] = $GLOBALS['TL_DCA'][$table]['fields'][$v]['reference'][$objRow->$v] ?: $objRow->$v;
+				$args[$k] = !empty($GLOBALS['TL_DCA'][$table]['fields'][$v]['reference'][$objRow->$v]) ? $GLOBALS['TL_DCA'][$table]['fields'][$v]['reference'][$objRow->$v] : $objRow->$v;
 			}
 		}
 
@@ -4975,7 +4975,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 				}
 
 				// Shorten the label it if it is too long
-				$label = vsprintf($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['format'] ?: '%s', $args);
+				$label = vsprintf($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['format'] ?? '%s', $args);
 
 				if (($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['maxCharacters'] ?? null) > 0 && $GLOBALS['TL_DCA'][$this->strTable]['list']['label']['maxCharacters'] < \strlen(strip_tags($label)))
 				{

--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -175,7 +175,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 				$objSession->set('CLIPBOARD', $arrClipboard);
 
 				// Support copyAll in the list view (see #7499)
-				if (isset($_POST['copy']) && $GLOBALS['TL_DCA'][$strTable]['list']['sorting']['mode'] < 4)
+				if (isset($_POST['copy']) && ($GLOBALS['TL_DCA'][$strTable]['list']['sorting']['mode'] ?? 0) < 4)
 				{
 					$this->redirect(str_replace('act=select', 'act=copyAll', Environment::get('request')));
 				}
@@ -187,12 +187,12 @@ class DC_Table extends DataContainer implements \listable, \editable
 		$this->strTable = $strTable;
 		$this->ptable = $GLOBALS['TL_DCA'][$this->strTable]['config']['ptable'];
 		$this->ctable = $GLOBALS['TL_DCA'][$this->strTable]['config']['ctable'];
-		$this->treeView = \in_array($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'], array(5, 6));
+		$this->treeView = \in_array($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] ?? null, array(5, 6));
 		$this->root = null;
 		$this->arrModule = $arrModule;
 
 		// Call onload_callback (e.g. to check permissions)
-		if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['config']['onload_callback']))
+		if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['config']['onload_callback'] ?? null))
 		{
 			foreach ($GLOBALS['TL_DCA'][$this->strTable]['config']['onload_callback'] as $callback)
 			{
@@ -211,7 +211,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 		// Get the IDs of all root records (tree view)
 		if ($this->treeView)
 		{
-			$table = ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] == 6) ? $this->ptable : $this->strTable;
+			$table = ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] ?? null) == 6 ? $this->ptable : $this->strTable;
 
 			// Unless there are any root records specified, use all records with parent ID 0
 			if (!isset($GLOBALS['TL_DCA'][$table]['list']['sorting']['root']) || $GLOBALS['TL_DCA'][$table]['list']['sorting']['root'] === false)
@@ -226,7 +226,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 			}
 
 			// Get root records from global configuration file
-			elseif (\is_array($GLOBALS['TL_DCA'][$table]['list']['sorting']['root']))
+			elseif (\is_array($GLOBALS['TL_DCA'][$table]['list']['sorting']['root'] ?? null))
 			{
 				if ($GLOBALS['TL_DCA'][$table]['list']['sorting']['root'] == array(0))
 				{
@@ -240,7 +240,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 		}
 
 		// Get the IDs of all root records (list view or parent view)
-		elseif (\is_array($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['root']))
+		elseif (\is_array($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['root'] ?? null))
 		{
 			$this->root = array_unique($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['root']);
 		}
@@ -361,10 +361,10 @@ class DC_Table extends DataContainer implements \listable, \editable
 			}
 
 			$return .= $this->panel();
-			$return .= ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] == 4) ? $this->parentView() : $this->listView();
+			$return .= ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] ?? null) == 4 ? $this->parentView() : $this->listView();
 
 			// Add another panel at the end of the page
-			if (strpos($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['panelLayout'], 'limit') !== false)
+			if (strpos($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['panelLayout'] ?? '', 'limit') !== false)
 			{
 				$return .= $this->paginationMenu();
 			}
@@ -405,7 +405,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 		$fields = array_keys($row);
 		$allowedFields = array('id', 'pid', 'sorting', 'tstamp');
 
-		if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['fields']))
+		if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'] ?? null))
 		{
 			$allowedFields = array_unique(array_merge($allowedFields, array_keys($GLOBALS['TL_DCA'][$this->strTable]['fields'])));
 		}
@@ -416,7 +416,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 		// Show all allowed fields
 		foreach ($fields as $i)
 		{
-			if ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$i]['inputType'] == 'password' || $GLOBALS['TL_DCA'][$this->strTable]['fields'][$i]['eval']['doNotShow'] || $GLOBALS['TL_DCA'][$this->strTable]['fields'][$i]['eval']['hideInput'] || !\in_array($i, $allowedFields))
+			if (($GLOBALS['TL_DCA'][$this->strTable]['fields'][$i]['inputType'] ?? null) == 'password' || ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$i]['eval']['doNotShow'] ?? null) || ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$i]['eval']['hideInput'] ?? null) || !\in_array($i, $allowedFields))
 			{
 				continue;
 			}
@@ -430,7 +430,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 			$value = StringUtil::deserialize($row[$i]);
 
 			// Decrypt the value
-			if ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$i]['eval']['encrypt'])
+			if ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$i]['eval']['encrypt'] ?? null)
 			{
 				$value = Encryption::decrypt($value);
 			}
@@ -455,7 +455,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 
 				$row[$i] = implode(', ', $temp);
 			}
-			elseif ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$i]['inputType'] == 'fileTree' || \in_array($i, $arrOrder))
+			elseif (($GLOBALS['TL_DCA'][$this->strTable]['fields'][$i]['inputType'] ?? null) == 'fileTree' || \in_array($i, $arrOrder))
 			{
 				if (\is_array($value))
 				{
@@ -510,35 +510,35 @@ class DC_Table extends DataContainer implements \listable, \editable
 					$row[$i] = implode(', ', $value);
 				}
 			}
-			elseif ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$i]['eval']['rgxp'] == 'date')
+			elseif (($GLOBALS['TL_DCA'][$this->strTable]['fields'][$i]['eval']['rgxp'] ?? null) == 'date')
 			{
 				$row[$i] = $value ? Date::parse(Config::get('dateFormat'), $value) : '-';
 			}
-			elseif ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$i]['eval']['rgxp'] == 'time')
+			elseif (($GLOBALS['TL_DCA'][$this->strTable]['fields'][$i]['eval']['rgxp'] ?? null) == 'time')
 			{
 				$row[$i] = $value ? Date::parse(Config::get('timeFormat'), $value) : '-';
 			}
-			elseif ($i == 'tstamp' || $GLOBALS['TL_DCA'][$this->strTable]['fields'][$i]['eval']['rgxp'] == 'datim' || \in_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$i]['flag'], array(5, 6, 7, 8, 9, 10)))
+			elseif ($i == 'tstamp' || ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$i]['eval']['rgxp'] ?? null) == 'datim' || \in_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$i]['flag'] ?? null, array(5, 6, 7, 8, 9, 10)))
 			{
 				$row[$i] = $value ? Date::parse(Config::get('datimFormat'), $value) : '-';
 			}
-			elseif ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$i]['eval']['isBoolean'] || ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$i]['inputType'] == 'checkbox' && !$GLOBALS['TL_DCA'][$this->strTable]['fields'][$i]['eval']['multiple']))
+			elseif (($GLOBALS['TL_DCA'][$this->strTable]['fields'][$i]['eval']['isBoolean'] ?? null) || (($GLOBALS['TL_DCA'][$this->strTable]['fields'][$i]['inputType'] ?? null) == 'checkbox' && !($GLOBALS['TL_DCA'][$this->strTable]['fields'][$i]['eval']['multiple'] ?? null)))
 			{
 				$row[$i] = $value ? $GLOBALS['TL_LANG']['MSC']['yes'] : $GLOBALS['TL_LANG']['MSC']['no'];
 			}
-			elseif ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$i]['eval']['rgxp'] == 'email')
+			elseif (($GLOBALS['TL_DCA'][$this->strTable]['fields'][$i]['eval']['rgxp'] ?? null) == 'email')
 			{
 				$row[$i] = Idna::decodeEmail($value);
 			}
-			elseif ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$i]['inputType'] == 'textarea' && ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$i]['eval']['allowHtml'] || $GLOBALS['TL_DCA'][$this->strTable]['fields'][$i]['eval']['preserveTags']))
+			elseif (($GLOBALS['TL_DCA'][$this->strTable]['fields'][$i]['inputType'] ?? null) == 'textarea' && (($GLOBALS['TL_DCA'][$this->strTable]['fields'][$i]['eval']['allowHtml'] ?? null) || ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$i]['eval']['preserveTags'] ?? null)))
 			{
 				$row[$i] = StringUtil::specialchars($value);
 			}
-			elseif (\is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$i]['reference']))
+			elseif (\is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$i]['reference'] ?? null))
 			{
 				$row[$i] = isset($GLOBALS['TL_DCA'][$this->strTable]['fields'][$i]['reference'][$row[$i]]) ? ((\is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$i]['reference'][$row[$i]])) ? $GLOBALS['TL_DCA'][$this->strTable]['fields'][$i]['reference'][$row[$i]][0] : $GLOBALS['TL_DCA'][$this->strTable]['fields'][$i]['reference'][$row[$i]]) : $row[$i];
 			}
-			elseif ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$i]['eval']['isAssociative'] || ArrayUtil::isAssoc($GLOBALS['TL_DCA'][$this->strTable]['fields'][$i]['options']))
+			elseif (($GLOBALS['TL_DCA'][$this->strTable]['fields'][$i]['eval']['isAssociative'] ?? null) || ArrayUtil::isAssoc($GLOBALS['TL_DCA'][$this->strTable]['fields'][$i]['options'] ?? array()))
 			{
 				$row[$i] = $GLOBALS['TL_DCA'][$this->strTable]['fields'][$i]['options'][$row[$i]];
 			}
@@ -568,7 +568,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 		}
 
 		// Call onshow_callback
-		if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['config']['onshow_callback']))
+		if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['config']['onshow_callback'] ?? null))
 		{
 			foreach ($GLOBALS['TL_DCA'][$this->strTable]['config']['onshow_callback'] as $callback)
 			{
@@ -636,7 +636,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 	 */
 	public function create($set=array())
 	{
-		if ($GLOBALS['TL_DCA'][$this->strTable]['config']['notCreatable'])
+		if ($GLOBALS['TL_DCA'][$this->strTable]['config']['notCreatable'] ?? null)
 		{
 			throw new InternalServerErrorException('Table "' . $this->strTable . '" is not creatable.');
 		}
@@ -650,7 +650,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 				$this->set[$k] = \is_array($v['default']) ? serialize($v['default']) : $v['default'];
 
 				// Encrypt the default value (see #3740)
-				if ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['eval']['encrypt'])
+				if ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['eval']['encrypt'] ?? null)
 				{
 					$this->set[$k] = Encryption::encrypt($this->set[$k]);
 				}
@@ -667,7 +667,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 		$this->getNewPosition('new', Input::get('pid'), Input::get('mode') == '2');
 
 		// Dynamically set the parent table
-		if ($GLOBALS['TL_DCA'][$this->strTable]['config']['dynamicPtable'])
+		if ($GLOBALS['TL_DCA'][$this->strTable]['config']['dynamicPtable'] ?? null)
 		{
 			$this->set['ptable'] = $this->ptable;
 		}
@@ -681,7 +681,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 		$objSession->set('CLIPBOARD', $arrClipboard);
 
 		// Insert the record if the table is not closed and switch to edit mode
-		if (!$GLOBALS['TL_DCA'][$this->strTable]['config']['closed'])
+		if (!($GLOBALS['TL_DCA'][$this->strTable]['config']['closed'] ?? null))
 		{
 			$this->set['tstamp'] = 0;
 
@@ -703,7 +703,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 				$objSessionBag->set('new_records', $new_records);
 
 				// Call the oncreate_callback
-				if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['config']['oncreate_callback']))
+				if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['config']['oncreate_callback'] ?? null))
 				{
 					foreach ($GLOBALS['TL_DCA'][$this->strTable]['config']['oncreate_callback'] as $callback)
 					{
@@ -737,7 +737,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 	 */
 	public function cut($blnDoNotRedirect=false)
 	{
-		if ($GLOBALS['TL_DCA'][$this->strTable]['config']['notSortable'])
+		if ($GLOBALS['TL_DCA'][$this->strTable]['config']['notSortable'] ?? null)
 		{
 			throw new InternalServerErrorException('Table "' . $this->strTable . '" is not sortable.');
 		}
@@ -792,7 +792,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 		}
 
 		// Dynamically set the parent table of tl_content
-		if ($GLOBALS['TL_DCA'][$this->strTable]['config']['dynamicPtable'])
+		if ($GLOBALS['TL_DCA'][$this->strTable]['config']['dynamicPtable'] ?? null)
 		{
 			$this->set['ptable'] = $this->ptable;
 		}
@@ -802,7 +802,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 					   ->execute($this->intId);
 
 		// Call the oncut_callback
-		if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['config']['oncut_callback']))
+		if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['config']['oncut_callback'] ?? null))
 		{
 			foreach ($GLOBALS['TL_DCA'][$this->strTable]['config']['oncut_callback'] as $callback)
 			{
@@ -831,7 +831,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 	 */
 	public function cutAll()
 	{
-		if ($GLOBALS['TL_DCA'][$this->strTable]['config']['notSortable'])
+		if ($GLOBALS['TL_DCA'][$this->strTable]['config']['notSortable'] ?? null)
 		{
 			throw new InternalServerErrorException('Table "' . $this->strTable . '" is not sortable.');
 		}
@@ -866,7 +866,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 	 */
 	public function copy($blnDoNotRedirect=false)
 	{
-		if ($GLOBALS['TL_DCA'][$this->strTable]['config']['notCopyable'])
+		if ($GLOBALS['TL_DCA'][$this->strTable]['config']['notCopyable'] ?? null)
 		{
 			throw new InternalServerErrorException('Table "' . $this->strTable . '" is not copyable.');
 		}
@@ -891,33 +891,33 @@ class DC_Table extends DataContainer implements \listable, \editable
 		{
 			foreach ($objRow->row() as $k=>$v)
 			{
-				if (\array_key_exists($k, $GLOBALS['TL_DCA'][$this->strTable]['fields']))
+				if (\array_key_exists($k, $GLOBALS['TL_DCA'][$this->strTable]['fields'] ?? array()))
 				{
 					// Never copy passwords
-					if ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['inputType'] == 'password')
+					if (($GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['inputType'] ?? null) == 'password')
 					{
-						$v = Widget::getEmptyValueByFieldType($GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['sql']);
+						$v = Widget::getEmptyValueByFieldType($GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['sql'] ?? array());
 					}
 
 					// Empty unique fields or add a unique identifier in copyAll mode
-					elseif ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['eval']['unique'])
+					elseif ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['eval']['unique'] ?? null)
 					{
-						$v = (Input::get('act') == 'copyAll' && !$GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['eval']['doNotCopy']) ? $v . '-' . substr(md5(uniqid(mt_rand(), true)), 0, 8) : Widget::getEmptyValueByFieldType($GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['sql']);
+						$v = (Input::get('act') == 'copyAll' && !($GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['eval']['doNotCopy'] ?? null)) ? $v . '-' . substr(md5(uniqid(mt_rand(), true)), 0, 8) : Widget::getEmptyValueByFieldType($GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['sql'] ?? array());
 					}
 
 					// Reset doNotCopy and fallback fields to their default value
-					elseif ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['eval']['doNotCopy'] || $GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['eval']['fallback'])
+					elseif (($GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['eval']['doNotCopy'] ?? null) || ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['eval']['fallback'] ?? null))
 					{
-						$v = Widget::getEmptyValueByFieldType($GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['sql']);
+						$v = Widget::getEmptyValueByFieldType($GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['sql'] ?? array());
 
 						// Use array_key_exists to allow NULL (see #5252)
-						if (\array_key_exists('default', $GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]))
+						if (\array_key_exists('default', $GLOBALS['TL_DCA'][$this->strTable]['fields'][$k] ?? array()))
 						{
 							$v = \is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['default']) ? serialize($GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['default']) : $GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['default'];
 						}
 
 						// Encrypt the default value (see #3740)
-						if ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['eval']['encrypt'])
+						if ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['eval']['encrypt'] ?? null)
 						{
 							$v = Encryption::encrypt($v);
 						}
@@ -944,7 +944,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 		$this->getNewPosition('copy', Input::get('pid'), Input::get('mode') == '2');
 
 		// Dynamically set the parent table of tl_content
-		if ($GLOBALS['TL_DCA'][$this->strTable]['config']['dynamicPtable'])
+		if ($GLOBALS['TL_DCA'][$this->strTable]['config']['dynamicPtable'] ?? null)
 		{
 			$this->set['ptable'] = $this->ptable;
 		}
@@ -955,7 +955,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 		$objSession->set('CLIPBOARD', $arrClipboard);
 
 		// Insert the record if the table is not closed and switch to edit mode
-		if (!$GLOBALS['TL_DCA'][$this->strTable]['config']['closed'])
+		if (!($GLOBALS['TL_DCA'][$this->strTable]['config']['closed'] ?? null))
 		{
 			$this->set['tstamp'] = ($blnDoNotRedirect ? time() : 0);
 
@@ -964,7 +964,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 			{
 				$strKey = $GLOBALS['TL_DCA'][$this->strTable]['config']['markAsCopy'];
 
-				if ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$strKey]['inputType'] == 'inputUnit')
+				if (($GLOBALS['TL_DCA'][$this->strTable]['fields'][$strKey]['inputType'] ?? null) == 'inputUnit')
 				{
 					$value = StringUtil::deserialize($this->set[$strKey]);
 
@@ -1000,7 +1000,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 				$this->copyChilds($this->strTable, $insertID, $this->intId, $insertID);
 
 				// Call the oncopy_callback after all new records have been created
-				if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['config']['oncopy_callback']))
+				if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['config']['oncopy_callback'] ?? null))
 				{
 					foreach ($GLOBALS['TL_DCA'][$this->strTable]['config']['oncopy_callback'] as $callback)
 					{
@@ -1052,7 +1052,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 		$cctable = array();
 		$ctable = $GLOBALS['TL_DCA'][$table]['config']['ctable'];
 
-		if (!$GLOBALS['TL_DCA'][$table]['config']['ptable'] && Input::get('childs') && $this->Database->fieldExists('pid', $table) && $this->Database->fieldExists('sorting', $table))
+		if (!($GLOBALS['TL_DCA'][$table]['config']['ptable'] ?? null) && Input::get('childs') && $this->Database->fieldExists('pid', $table) && $this->Database->fieldExists('sorting', $table))
 		{
 			$ctable[] = $table;
 		}
@@ -1068,10 +1068,10 @@ class DC_Table extends DataContainer implements \listable, \editable
 			$this->loadDataContainer($v);
 			$cctable[$v] = $GLOBALS['TL_DCA'][$v]['config']['ctable'];
 
-			if (!$GLOBALS['TL_DCA'][$v]['config']['doNotCopyRecords'] && \strlen($v))
+			if (!($GLOBALS['TL_DCA'][$v]['config']['doNotCopyRecords'] ?? null) && \strlen($v))
 			{
 				// Consider the dynamic parent table (see #4867)
-				if ($GLOBALS['TL_DCA'][$v]['config']['dynamicPtable'])
+				if ($GLOBALS['TL_DCA'][$v]['config']['dynamicPtable'] ?? null)
 				{
 					$ptable = $GLOBALS['TL_DCA'][$v]['config']['ptable'];
 					$cond = ($ptable == 'tl_article') ? "(ptable=? OR ptable='')" : "ptable=?";
@@ -1101,30 +1101,30 @@ class DC_Table extends DataContainer implements \listable, \editable
 						}
 
 						// Never copy passwords
-						if ($GLOBALS['TL_DCA'][$v]['fields'][$kk]['inputType'] == 'password')
+						if (($GLOBALS['TL_DCA'][$v]['fields'][$kk]['inputType'] ?? null) == 'password')
 						{
-							$vv = Widget::getEmptyValueByFieldType($GLOBALS['TL_DCA'][$v]['fields'][$kk]['sql']);
+							$vv = Widget::getEmptyValueByFieldType($GLOBALS['TL_DCA'][$v]['fields'][$kk]['sql'] ?? array());
 						}
 
 						// Empty unique fields or add a unique identifier in copyAll mode
-						elseif ($GLOBALS['TL_DCA'][$v]['fields'][$kk]['eval']['unique'])
+						elseif ($GLOBALS['TL_DCA'][$v]['fields'][$kk]['eval']['unique'] ?? null)
 						{
-							$vv = (Input::get('act') == 'copyAll') ? $vv . '-' . substr(md5(uniqid(mt_rand(), true)), 0, 8) : Widget::getEmptyValueByFieldType($GLOBALS['TL_DCA'][$v]['fields'][$kk]['sql']);
+							$vv = (Input::get('act') == 'copyAll') ? $vv . '-' . substr(md5(uniqid(mt_rand(), true)), 0, 8) : Widget::getEmptyValueByFieldType($GLOBALS['TL_DCA'][$v]['fields'][$kk]['sql'] ?? array());
 						}
 
 						// Reset doNotCopy and fallback fields to their default value
-						elseif ($GLOBALS['TL_DCA'][$v]['fields'][$kk]['eval']['doNotCopy'] || $GLOBALS['TL_DCA'][$v]['fields'][$kk]['eval']['fallback'])
+						elseif (($GLOBALS['TL_DCA'][$v]['fields'][$kk]['eval']['doNotCopy'] ?? null) || ($GLOBALS['TL_DCA'][$v]['fields'][$kk]['eval']['fallback'] ?? null))
 						{
-							$vv = Widget::getEmptyValueByFieldType($GLOBALS['TL_DCA'][$v]['fields'][$kk]['sql']);
+							$vv = Widget::getEmptyValueByFieldType($GLOBALS['TL_DCA'][$v]['fields'][$kk]['sql'] ?? array());
 
 							// Use array_key_exists to allow NULL (see #5252)
-							if (\array_key_exists('default', $GLOBALS['TL_DCA'][$v]['fields'][$kk]))
+							if (\array_key_exists('default', $GLOBALS['TL_DCA'][$v]['fields'][$kk] ?? array()))
 							{
 								$vv = \is_array($GLOBALS['TL_DCA'][$v]['fields'][$kk]['default']) ? serialize($GLOBALS['TL_DCA'][$v]['fields'][$kk]['default']) : $GLOBALS['TL_DCA'][$v]['fields'][$kk]['default'];
 							}
 
 							// Encrypt the default value (see #3740)
-							if ($GLOBALS['TL_DCA'][$v]['fields'][$kk]['eval']['encrypt'])
+							if ($GLOBALS['TL_DCA'][$v]['fields'][$kk]['eval']['encrypt'] ?? null)
 							{
 								$vv = Encryption::encrypt($vv);
 							}
@@ -1154,7 +1154,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 					{
 						$insertID = $objInsertStmt->insertId;
 
-						if ($kk != $parentId && (!empty($cctable[$k]) || $GLOBALS['TL_DCA'][$k]['list']['sorting']['mode'] == 5))
+						if ($kk != $parentId && (!empty($cctable[$k]) || ($GLOBALS['TL_DCA'][$k]['list']['sorting']['mode'] ?? null) == 5))
 						{
 							$this->copyChilds($k, $insertID, $kk, $parentId);
 						}
@@ -1171,7 +1171,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 	 */
 	public function copyAll()
 	{
-		if ($GLOBALS['TL_DCA'][$this->strTable]['config']['notCopyable'])
+		if ($GLOBALS['TL_DCA'][$this->strTable]['config']['notCopyable'] ?? null)
 		{
 			throw new InternalServerErrorException('Table "' . $this->strTable . '" is not copyable.');
 		}
@@ -1218,7 +1218,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 			{
 				$newPID = null;
 				$newSorting = null;
-				$filter = ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] == 4) ? $this->strTable . '_' . CURRENT_ID : $this->strTable;
+				$filter = ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] ?? null) == 4 ? $this->strTable . '_' . CURRENT_ID : $this->strTable;
 
 				/** @var Session $objSession */
 				$objSession = System::getContainer()->get('session');
@@ -1471,7 +1471,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 	 */
 	public function delete($blnDoNotRedirect=false)
 	{
-		if ($GLOBALS['TL_DCA'][$this->strTable]['config']['notDeletable'])
+		if ($GLOBALS['TL_DCA'][$this->strTable]['config']['notDeletable'] ?? null)
 		{
 			throw new InternalServerErrorException('Table "' . $this->strTable . '" is not deletable.');
 		}
@@ -1551,7 +1551,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 			$undoId = $objUndoStmt->insertId;
 
 			// Call ondelete_callback
-			if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['config']['ondelete_callback']))
+			if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['config']['ondelete_callback'] ?? null))
 			{
 				foreach ($GLOBALS['TL_DCA'][$this->strTable]['config']['ondelete_callback'] as $callback)
 				{
@@ -1601,7 +1601,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 	 */
 	public function deleteAll()
 	{
-		if ($GLOBALS['TL_DCA'][$this->strTable]['config']['notDeletable'])
+		if ($GLOBALS['TL_DCA'][$this->strTable]['config']['notDeletable'] ?? null)
 		{
 			throw new InternalServerErrorException('Table "' . $this->strTable . '" is not deletable.');
 		}
@@ -1648,7 +1648,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 			$cctable[$v] = $GLOBALS['TL_DCA'][$v]['config']['ctable'];
 
 			// Consider the dynamic parent table (see #4867)
-			if ($GLOBALS['TL_DCA'][$v]['config']['dynamicPtable'])
+			if ($GLOBALS['TL_DCA'][$v]['config']['dynamicPtable'] ?? null)
 			{
 				$ptable = $GLOBALS['TL_DCA'][$v]['config']['ptable'];
 				$cond = ($ptable == 'tl_article') ? "(ptable=? OR ptable='')" : "ptable=?";
@@ -1662,7 +1662,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 											->execute($id);
 			}
 
-			if ($objDelete->numRows && !$GLOBALS['TL_DCA'][$v]['config']['doNotDeleteRecords'] && \strlen($v))
+			if ($objDelete->numRows && !($GLOBALS['TL_DCA'][$v]['config']['doNotDeleteRecords'] ?? null) && \strlen($v))
 			{
 				foreach ($objDelete->fetchAllAssoc() as $row)
 				{
@@ -1731,7 +1731,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 				}
 
 				// Trigger the undo_callback
-				if (\is_array($GLOBALS['TL_DCA'][$table]['config']['onundo_callback']))
+				if (\is_array($GLOBALS['TL_DCA'][$table]['config']['onundo_callback'] ?? null))
 				{
 					foreach ($GLOBALS['TL_DCA'][$table]['config']['onundo_callback'] as $callback)
 					{
@@ -1770,7 +1770,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 	public function move()
 	{
 		// Proceed only if all mandatory variables are set
-		if ($this->intId && Input::get('sid') && (!$GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['root'] || !\in_array($this->intId, $this->root)))
+		if ($this->intId && Input::get('sid') && (!($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['root'] ?? null) || !\in_array($this->intId, $this->root)))
 		{
 			$objRow = $this->Database->prepare("SELECT * FROM " . $this->strTable . " WHERE id=? OR id=?")
 									 ->limit(2)
@@ -1806,7 +1806,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 	 */
 	public function edit($intId=null, $ajaxId=null)
 	{
-		if ($GLOBALS['TL_DCA'][$this->strTable]['config']['notEditable'])
+		if ($GLOBALS['TL_DCA'][$this->strTable]['config']['notEditable'] ?? null)
 		{
 			throw new InternalServerErrorException('Table "' . $this->strTable . '" is not editable.');
 		}
@@ -1836,7 +1836,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 		$this->blnCreateNewVersion = false;
 		$objVersions = new Versions($this->strTable, $this->intId);
 
-		if (!$GLOBALS['TL_DCA'][$this->strTable]['config']['hideVersionMenu'])
+		if (!($GLOBALS['TL_DCA'][$this->strTable]['config']['hideVersionMenu'] ?? null))
 		{
 			// Compare versions
 			if (Input::get('versions'))
@@ -1882,7 +1882,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 						$legends[$k] = substr($vv, 1, -1);
 						unset($boxes[$k][$kk]);
 					}
-					elseif (!\is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$vv]) || $GLOBALS['TL_DCA'][$this->strTable]['fields'][$vv]['exclude'])
+					elseif (!\is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$vv] ?? null) || ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$vv]['exclude'] ?? null))
 					{
 						unset($boxes[$k][$kk]);
 					}
@@ -1970,13 +1970,13 @@ class DC_Table extends DataContainer implements \listable, \editable
 					$this->varValue = $objRow->$vv;
 
 					// Convert CSV fields (see #2890)
-					if ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['eval']['multiple'] && isset($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['eval']['csv']))
+					if (($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['eval']['multiple'] ?? null) && isset($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['eval']['csv']))
 					{
 						$this->varValue = StringUtil::trimsplit($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['eval']['csv'], $this->varValue);
 					}
 
 					// Call load_callback
-					if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['load_callback']))
+					if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['load_callback'] ?? null))
 					{
 						foreach ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['load_callback'] as $callback)
 						{
@@ -2005,7 +2005,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 		}
 
 		// Versions overview
-		if ($GLOBALS['TL_DCA'][$this->strTable]['config']['enableVersioning'] && !$GLOBALS['TL_DCA'][$this->strTable]['config']['hideVersionMenu'])
+		if (($GLOBALS['TL_DCA'][$this->strTable]['config']['enableVersioning'] ?? null) && !($GLOBALS['TL_DCA'][$this->strTable]['config']['hideVersionMenu'] ?? null))
 		{
 			$version = $objVersions->renderDropdown();
 		}
@@ -2024,22 +2024,22 @@ class DC_Table extends DataContainer implements \listable, \editable
 
 			if (!Input::get('nc'))
 			{
-				if (!$GLOBALS['TL_DCA'][$this->strTable]['config']['closed'] && !$GLOBALS['TL_DCA'][$this->strTable]['config']['notCreatable'])
+				if (!($GLOBALS['TL_DCA'][$this->strTable]['config']['closed'] ?? null) && !($GLOBALS['TL_DCA'][$this->strTable]['config']['notCreatable'] ?? null))
 				{
 					$arrButtons['saveNcreate'] = '<button type="submit" name="saveNcreate" id="saveNcreate" class="tl_submit" accesskey="n">' . $GLOBALS['TL_LANG']['MSC']['saveNcreate'] . '</button>';
 
-					if (!$GLOBALS['TL_DCA'][$this->strTable]['config']['notCopyable'])
+					if (!($GLOBALS['TL_DCA'][$this->strTable]['config']['notCopyable'] ?? null))
 					{
 						$arrButtons['saveNduplicate'] = '<button type="submit" name="saveNduplicate" id="saveNduplicate" class="tl_submit" accesskey="d">' . $GLOBALS['TL_LANG']['MSC']['saveNduplicate'] . '</button>';
 					}
 				}
 
-				if ($GLOBALS['TL_DCA'][$this->strTable]['config']['switchToEdit'])
+				if ($GLOBALS['TL_DCA'][$this->strTable]['config']['switchToEdit'] ?? null)
 				{
 					$arrButtons['saveNedit'] = '<button type="submit" name="saveNedit" id="saveNedit" class="tl_submit" accesskey="e">' . $GLOBALS['TL_LANG']['MSC']['saveNedit'] . '</button>';
 				}
 
-				if ($this->ptable || $GLOBALS['TL_DCA'][$this->strTable]['config']['switchToEdit'] || $GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] == 4)
+				if ($this->ptable || ($GLOBALS['TL_DCA'][$this->strTable]['config']['switchToEdit'] ?? null) || ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] ?? null) == 4)
 				{
 					$arrButtons['saveNback'] = '<button type="submit" name="saveNback" id="saveNback" class="tl_submit" accesskey="g">' . $GLOBALS['TL_LANG']['MSC']['saveNback'] . '</button>';
 				}
@@ -2047,7 +2047,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 		}
 
 		// Call the buttons_callback (see #4691)
-		if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['edit']['buttons_callback']))
+		if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['edit']['buttons_callback'] ?? null))
 		{
 			foreach ($GLOBALS['TL_DCA'][$this->strTable]['edit']['buttons_callback'] as $callback)
 			{
@@ -2125,7 +2125,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 			array_unshift($arrValues, time());
 
 			// Trigger the onsubmit_callback
-			if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['config']['onsubmit_callback']))
+			if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['config']['onsubmit_callback'] ?? null))
 			{
 				foreach ($GLOBALS['TL_DCA'][$this->strTable]['config']['onsubmit_callback'] as $callback)
 				{
@@ -2142,7 +2142,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 			}
 
 			// Set the current timestamp before adding a new version
-			if ($GLOBALS['TL_DCA'][$this->strTable]['config']['dynamicPtable'])
+			if ($GLOBALS['TL_DCA'][$this->strTable]['config']['dynamicPtable'] ?? null)
 			{
 				$this->Database->prepare("UPDATE " . $this->strTable . " SET ptable=?, tstamp=? WHERE id=?")
 							   ->execute($this->ptable, time(), $this->intId);
@@ -2159,7 +2159,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 				$objVersions->create();
 
 				// Call the onversion_callback
-				if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['config']['onversion_callback']))
+				if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['config']['onversion_callback'] ?? null))
 				{
 					trigger_deprecation('contao/core-bundle', '4.0', 'Using the "onversion_callback" has been deprecated and will no longer work in Contao 5.0. Use the "oncreate_version_callback" instead.');
 
@@ -2210,7 +2210,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 			{
 				Message::reset();
 
-				$this->redirect($this->addToUrl($GLOBALS['TL_DCA'][$this->strTable]['list']['operations']['edit']['href'], false, array('s2e', 'act', 'mode', 'pid')));
+				$this->redirect($this->addToUrl($GLOBALS['TL_DCA'][$this->strTable]['list']['operations']['edit']['href'] ?? '', false, array('s2e', 'act', 'mode', 'pid')));
 			}
 			elseif (isset($_POST['saveNback']))
 			{
@@ -2248,7 +2248,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 				}
 
 				// Parent view
-				elseif ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] == 4)
+				elseif (($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] ?? null) == 4)
 				{
 					$strUrl .= $this->Database->fieldExists('sorting', $this->strTable) ? '&amp;act=create&amp;mode=1&amp;pid=' . $this->intId : '&amp;act=create&amp;mode=2&amp;pid=' . $this->activeRecord->pid;
 				}
@@ -2279,7 +2279,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 				}
 
 				// Parent view
-				elseif ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] == 4)
+				elseif (($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] ?? null) == 4)
 				{
 					$strUrl .= $this->Database->fieldExists('sorting', $this->strTable) ? '&amp;act=copy&amp;mode=1&amp;pid=' . $this->intId . '&amp;id=' . $this->intId : '&amp;act=copy&amp;mode=2&amp;pid=' . CURRENT_ID . '&amp;id=' . $this->intId;
 				}
@@ -2322,7 +2322,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 	 */
 	public function editAll($intId=null, $ajaxId=null)
 	{
-		if ($GLOBALS['TL_DCA'][$this->strTable]['config']['notEditable'])
+		if ($GLOBALS['TL_DCA'][$this->strTable]['config']['notEditable'] ?? null)
 		{
 			throw new InternalServerErrorException('Table "' . $this->strTable . '" is not editable.');
 		}
@@ -2426,7 +2426,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 				foreach ($this->strPalette as $v)
 				{
 					// Check whether field is excluded
-					if ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$v]['exclude'])
+					if ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$v]['exclude'] ?? null)
 					{
 						continue;
 					}
@@ -2463,7 +2463,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 					$formFields[] = $v . '_' . $this->intId;
 
 					// Set the default value and try to load the current value from DB (see #5252)
-					if (\array_key_exists('default', $GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]))
+					if (\array_key_exists('default', $GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField] ?? array()))
 					{
 						$this->varValue = \is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['default']) ? serialize($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['default']) : $GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['default'];
 					}
@@ -2474,13 +2474,13 @@ class DC_Table extends DataContainer implements \listable, \editable
 					}
 
 					// Convert CSV fields (see #2890)
-					if ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['eval']['multiple'] && isset($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['eval']['csv']))
+					if (($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['eval']['multiple'] ?? null) && isset($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['eval']['csv']))
 					{
 						$this->varValue = StringUtil::trimsplit($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['eval']['csv'], $this->varValue);
 					}
 
 					// Call load_callback
-					if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['load_callback']))
+					if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['load_callback'] ?? null))
 					{
 						foreach ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['load_callback'] as $callback)
 						{
@@ -2518,7 +2518,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 				if (!$this->noReload && Input::post('FORM_SUBMIT') == $this->strTable)
 				{
 					// Call the onsubmit_callback
-					if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['config']['onsubmit_callback']))
+					if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['config']['onsubmit_callback'] ?? null))
 					{
 						foreach ($GLOBALS['TL_DCA'][$this->strTable]['config']['onsubmit_callback'] as $callback)
 						{
@@ -2535,7 +2535,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 					}
 
 					// Set the current timestamp before adding a new version
-					if ($GLOBALS['TL_DCA'][$this->strTable]['config']['dynamicPtable'])
+					if ($GLOBALS['TL_DCA'][$this->strTable]['config']['dynamicPtable'] ?? null)
 					{
 						$this->Database->prepare("UPDATE " . $this->strTable . " SET ptable=?, tstamp=? WHERE id=?")
 									   ->execute($this->ptable, time(), $this->intId);
@@ -2552,7 +2552,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 						$objVersions->create();
 
 						// Call the onversion_callback
-						if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['config']['onversion_callback']))
+						if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['config']['onversion_callback'] ?? null))
 						{
 							trigger_deprecation('contao/core-bundle', '4.0', 'Using the "onversion_callback" has been deprecated and will no longer work in Contao 5.0. Use the "oncreate_version_callback" instead.');
 
@@ -2581,7 +2581,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 			$arrButtons['saveNclose'] = '<button type="submit" name="saveNclose" id="saveNclose" class="tl_submit" accesskey="c">' . $GLOBALS['TL_LANG']['MSC']['saveNclose'] . '</button>';
 
 			// Call the buttons_callback (see #4691)
-			if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['edit']['buttons_callback']))
+			if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['edit']['buttons_callback'] ?? null))
 			{
 				foreach ($GLOBALS['TL_DCA'][$this->strTable]['edit']['buttons_callback'] as $callback)
 				{
@@ -2661,7 +2661,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 			$fields = array();
 
 			// Add fields of the current table
-			$fields = array_merge($fields, array_keys($GLOBALS['TL_DCA'][$this->strTable]['fields']));
+			$fields = array_merge($fields, array_keys($GLOBALS['TL_DCA'][$this->strTable]['fields'] ?? array()));
 
 			// Add meta fields if the current user is an administrator
 			if ($this->User->isAdmin)
@@ -2680,7 +2680,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 			// Show all non-excluded fields
 			foreach ($fields as $field)
 			{
-				if ($field == 'pid' || $field == 'sorting' || (!$GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['exclude'] && !$GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['eval']['doNotShow'] && (isset($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['inputType']) || \is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['input_field_callback']) || \is_callable($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['input_field_callback']))))
+				if ($field == 'pid' || $field == 'sorting' || (!($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['exclude'] ?? null) && !($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['eval']['doNotShow'] ?? null) && (isset($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['inputType']) || \is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['input_field_callback'] ?? null) || \is_callable($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['input_field_callback'] ?? null))))
 				{
 					$options .= '
   <input type="checkbox" name="all_fields[]" id="all_' . $field . '" class="tl_checkbox" value="' . StringUtil::specialchars($field) . '"> <label for="all_' . $field . '" class="tl_checkbox_label">' . (($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['label'][0] ?: ($GLOBALS['TL_LANG']['MSC'][$field][0] ?: $field)) . ' <span style="color:#999;padding-left:3px">[' . $field . ']</span>') . '</label><br>';
@@ -2732,7 +2732,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 	 */
 	public function overrideAll()
 	{
-		if ($GLOBALS['TL_DCA'][$this->strTable]['config']['notEditable'])
+		if ($GLOBALS['TL_DCA'][$this->strTable]['config']['notEditable'] ?? null)
 		{
 			throw new InternalServerErrorException('Table "' . $this->strTable . '" is not editable.');
 		}
@@ -2787,7 +2787,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 					foreach ($fields as $v)
 					{
 						// Check whether field is excluded
-						if ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$v]['exclude'])
+						if ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$v]['exclude'] ?? null)
 						{
 							continue;
 						}
@@ -2813,7 +2813,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 					if (!$this->noReload)
 					{
 						// Call the onsubmit_callback
-						if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['config']['onsubmit_callback']))
+						if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['config']['onsubmit_callback'] ?? null))
 						{
 							foreach ($GLOBALS['TL_DCA'][$this->strTable]['config']['onsubmit_callback'] as $callback)
 							{
@@ -2832,7 +2832,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 						$this->invalidateCacheTags();
 
 						// Set the current timestamp before adding a new version
-						if ($GLOBALS['TL_DCA'][$this->strTable]['config']['dynamicPtable'])
+						if ($GLOBALS['TL_DCA'][$this->strTable]['config']['dynamicPtable'] ?? null)
 						{
 							$this->Database->prepare("UPDATE " . $this->strTable . " SET ptable=?, tstamp=? WHERE id=?")
 										   ->execute($this->ptable, time(), $this->intId);
@@ -2849,7 +2849,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 							$objVersions->create();
 
 							// Call the onversion_callback
-							if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['config']['onversion_callback']))
+							if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['config']['onversion_callback'] ?? null))
 							{
 								trigger_deprecation('contao/core-bundle', '4.0', 'Using the "onversion_callback" has been deprecated and will no longer work in Contao 5.0. Use the "oncreate_version_callback" instead.');
 
@@ -2878,7 +2878,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 			foreach ($fields as $v)
 			{
 				// Check whether field is excluded
-				if ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$v]['exclude'])
+				if ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$v]['exclude'] ?? null)
 				{
 					continue;
 				}
@@ -2908,7 +2908,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 			$arrButtons['saveNclose'] = '<button type="submit" name="saveNclose" id="saveNclose" class="tl_submit" accesskey="c">' . $GLOBALS['TL_LANG']['MSC']['saveNclose'] . '</button>';
 
 			// Call the buttons_callback (see #4691)
-			if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['edit']['buttons_callback']))
+			if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['edit']['buttons_callback'] ?? null))
 			{
 				foreach ($GLOBALS['TL_DCA'][$this->strTable]['edit']['buttons_callback'] as $callback)
 				{
@@ -2987,7 +2987,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 			$fields = array();
 
 			// Add fields of the current table
-			$fields = array_merge($fields, array_keys($GLOBALS['TL_DCA'][$this->strTable]['fields']));
+			$fields = array_merge($fields, array_keys($GLOBALS['TL_DCA'][$this->strTable]['fields'] ?? array()));
 
 			// Add meta fields if the current user is an administrator
 			if ($this->User->isAdmin)
@@ -3006,7 +3006,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 			// Show all non-excluded fields
 			foreach ($fields as $field)
 			{
-				if ($field == 'pid' || $field == 'sorting' || (!$GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['exclude'] && !$GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['eval']['doNotShow'] && (isset($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['inputType']) || \is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['input_field_callback']) || \is_callable($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['input_field_callback']))))
+				if ($field == 'pid' || $field == 'sorting' || (!($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['exclude'] ?? null) && !($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['eval']['doNotShow'] ?? null) && (isset($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['inputType']) || \is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['input_field_callback'] ?? null) || \is_callable($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['input_field_callback'] ?? null))))
 				{
 					$options .= '
   <input type="checkbox" name="all_fields[]" id="all_' . $field . '" class="tl_checkbox" value="' . StringUtil::specialchars($field) . '"> <label for="all_' . $field . '" class="tl_checkbox_label">' . (($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['label'][0] ?: ($GLOBALS['TL_LANG']['MSC'][$field][0] ?: $field)) . ' <span style="color:#999;padding-left:3px">[' . $field . ']</span>') . '</label><br>';
@@ -3084,7 +3084,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 			$old = StringUtil::deserialize($this->objActiveRecord->{$this->strField}, true);
 
 			// Call load_callback
-			if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['load_callback']))
+			if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['load_callback'] ?? null))
 			{
 				foreach ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['load_callback'] as $callback)
 				{
@@ -3158,7 +3158,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 			// If the field is a fallback field, empty all other columns (see #6498)
 			if ($varValue && $arrData['eval']['fallback'])
 			{
-				if ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] == 4)
+				if (($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] ?? null) == 4)
 				{
 					$this->Database->prepare("UPDATE " . $this->strTable . " SET " . Database::quoteIdentifier($this->strField) . "='' WHERE pid=?")
 								   ->execute($this->activeRecord->pid);
@@ -3172,7 +3172,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 			// Set the correct empty value (see #6284, #6373)
 			if ((string) $varValue === '')
 			{
-				$varValue = Widget::getEmptyValueByFieldType($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['sql']);
+				$varValue = Widget::getEmptyValueByFieldType($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['sql'] ?? array());
 			}
 
 			$arrValues = $this->values;
@@ -3238,7 +3238,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 
 					if ($trigger)
 					{
-						if ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$name]['inputType'] == 'checkbox' && !$GLOBALS['TL_DCA'][$this->strTable]['fields'][$name]['eval']['multiple'])
+						if (($GLOBALS['TL_DCA'][$this->strTable]['fields'][$name]['inputType'] ?? null) == 'checkbox' && !($GLOBALS['TL_DCA'][$this->strTable]['fields'][$name]['eval']['multiple'] ?? null))
 						{
 							$sValues[] = $name;
 
@@ -3404,7 +3404,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 		// Delete all records of the current table that are not related to the parent table
 		if ($ptable)
 		{
-			if ($GLOBALS['TL_DCA'][$this->strTable]['config']['dynamicPtable'])
+			if ($GLOBALS['TL_DCA'][$this->strTable]['config']['dynamicPtable'] ?? null)
 			{
 				$objIds = $this->Database->execute("SELECT c.id FROM " . $this->strTable . " c LEFT JOIN " . $ptable . " p ON c.pid=p.id WHERE c.ptable='" . $ptable . "' AND p.id IS NULL");
 			}
@@ -3434,7 +3434,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 					// Load the DCA configuration so we can check for "dynamicPtable"
 					$this->loadDataContainer($v);
 
-					if ($GLOBALS['TL_DCA'][$v]['config']['dynamicPtable'])
+					if ($GLOBALS['TL_DCA'][$v]['config']['dynamicPtable'] ?? null)
 					{
 						$objIds = $this->Database->execute("SELECT c.id FROM " . $v . " c LEFT JOIN " . $this->strTable . " p ON c.pid=p.id WHERE c.ptable='" . $this->strTable . "' AND p.id IS NULL");
 					}
@@ -3473,7 +3473,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 		$table = $this->strTable;
 		$treeClass = 'tl_tree';
 
-		if ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] == 6)
+		if (($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] ?? null) == 6)
 		{
 			$table = $this->ptable;
 			$treeClass = 'tl_tree_xtnd';
@@ -3493,7 +3493,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 		// Toggle the nodes
 		if (Input::get('ptg') == 'all')
 		{
-			$node = ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] == 6) ? $this->strTable . '_' . $table . '_tree' : $this->strTable . '_tree';
+			$node = ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] ?? null) == 6 ? $this->strTable . '_' . $table . '_tree' : $this->strTable . '_tree';
 
 			// Expand tree
 			if (empty($session[$node]) || !\is_array($session[$node]) || current($session[$node]) != 1)
@@ -3518,14 +3518,14 @@ class DC_Table extends DataContainer implements \listable, \editable
 		}
 
 		// Return if a mandatory field (id, pid, sorting) is missing
-		if ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] == 5 && (!$this->Database->fieldExists('id', $table) || !$this->Database->fieldExists('pid', $table) || !$this->Database->fieldExists('sorting', $table)))
+		if (($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] ?? null) == 5 && (!$this->Database->fieldExists('id', $table) || !$this->Database->fieldExists('pid', $table) || !$this->Database->fieldExists('sorting', $table)))
 		{
 			return '
 <p class="tl_empty">Table "' . $table . '" can not be shown as tree, because the "id", "pid" or "sorting" field is missing!</p>';
 		}
 
 		// Return if there is no parent table
-		if (!$this->ptable && $GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] == 6)
+		if (!$this->ptable && ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] ?? null) == 6)
 		{
 			return '
 <p class="tl_empty">Table "' . $table . '" can not be shown as extended tree, because there is no parent table!</p>';
@@ -3564,7 +3564,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 		$return = Message::generate() . '
 <div id="tl_buttons">' . ((Input::get('act') == 'select') ? '
 <a href="' . $this->getReferer(true) . '" class="header_back" title="' . StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['backBTTitle']) . '" accesskey="b" onclick="Backend.getScrollOffset()">' . $GLOBALS['TL_LANG']['MSC']['backBT'] . '</a> ' : (isset($GLOBALS['TL_DCA'][$this->strTable]['config']['backlink']) ? '
-<a href="contao/main.php?' . $GLOBALS['TL_DCA'][$this->strTable]['config']['backlink'] . '" class="header_back" title="' . StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['backBTTitle']) . '" accesskey="b" onclick="Backend.getScrollOffset()">' . $GLOBALS['TL_LANG']['MSC']['backBT'] . '</a> ' : '')) . ((Input::get('act') != 'select' && !$blnClipboard && !$GLOBALS['TL_DCA'][$this->strTable]['config']['closed'] && !$GLOBALS['TL_DCA'][$this->strTable]['config']['notCreatable']) ? '
+<a href="contao/main.php?' . $GLOBALS['TL_DCA'][$this->strTable]['config']['backlink'] . '" class="header_back" title="' . StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['backBTTitle']) . '" accesskey="b" onclick="Backend.getScrollOffset()">' . $GLOBALS['TL_LANG']['MSC']['backBT'] . '</a> ' : '')) . ((Input::get('act') != 'select' && !$blnClipboard && !($GLOBALS['TL_DCA'][$this->strTable]['config']['closed'] ?? null) && !($GLOBALS['TL_DCA'][$this->strTable]['config']['notCreatable'] ?? null)) ? '
 <a href="' . $this->addToUrl('act=paste&amp;mode=create') . '" class="header_new" title="' . StringUtil::specialchars($labelNew[1]) . '" accesskey="n" onclick="Backend.getScrollOffset()">' . $labelNew[0] . '</a> ' : '') . ($blnClipboard ? '
 <a href="' . $this->addToUrl('clipboard=1') . '" class="header_clipboard" title="' . StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['clearClipboard']) . '" accesskey="x">' . $GLOBALS['TL_LANG']['MSC']['clearClipboard'] . '</a> ' : $this->generateGlobalButtons()) . '
 </div>';
@@ -3575,7 +3575,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 
 		if (!empty($this->procedure))
 		{
-			$fld = ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] == 6) ? 'pid' : 'id';
+			$fld = ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] ?? null) == 6 ? 'pid' : 'id';
 
 			if ($fld == 'id')
 			{
@@ -3625,11 +3625,11 @@ class DC_Table extends DataContainer implements \listable, \editable
 		{
 			for ($i=0, $c=\count($this->root); $i<$c; $i++)
 			{
-				$tree .= $this->generateTree($table, $this->root[$i], array('p'=>$this->root[($i-1)], 'n'=>$this->root[($i+1)]), $blnHasSorting, -20, ($blnClipboard ? $arrClipboard : false), ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] == 5 && $blnClipboard && $this->root[$i] == $arrClipboard['id']), false, false, $arrFound);
+				$tree .= $this->generateTree($table, $this->root[$i], array('p'=>($this->root[($i-1)] ?? null), 'n'=>($this->root[($i+1)] ?? null)), $blnHasSorting, -20, ($blnClipboard ? $arrClipboard : false), (($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] ?? null) == 5 && $blnClipboard && $this->root[$i] == $arrClipboard['id']), false, false, $arrFound);
 			}
 		}
 
-		$breadcrumb = ($GLOBALS['TL_DCA'][$table]['list']['sorting']['breadcrumb'] ?? '');
+		$breadcrumb = $GLOBALS['TL_DCA'][$table]['list']['sorting']['breadcrumb'] ?? '';
 
 		// Return if there are no records
 		if (!$tree && Input::get('act') != 'paste')
@@ -3661,10 +3661,10 @@ class DC_Table extends DataContainer implements \listable, \editable
 		$_buttons = '&nbsp;';
 
 		// Show paste button only if there are no root records specified
-		if ($blnClipboard && $GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] == 5 && ((empty($GLOBALS['TL_DCA'][$table]['list']['sorting']['root']) && $GLOBALS['TL_DCA'][$table]['list']['sorting']['root'] !== false) || $GLOBALS['TL_DCA'][$table]['list']['sorting']['rootPaste']) && Input::get('act') != 'select')
+		if ($blnClipboard && ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] ?? null) == 5 && ((empty($GLOBALS['TL_DCA'][$table]['list']['sorting']['root']) && $GLOBALS['TL_DCA'][$table]['list']['sorting']['root'] !== false) || ($GLOBALS['TL_DCA'][$table]['list']['sorting']['rootPaste'] ?? null)) && Input::get('act') != 'select')
 		{
 			// Call paste_button_callback (&$dc, $row, $table, $cr, $childs, $previous, $next)
-			if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['paste_button_callback']))
+			if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['paste_button_callback'] ?? null))
 			{
 				$strClass = $GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['paste_button_callback'][0];
 				$strMethod = $GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['paste_button_callback'][1];
@@ -3672,7 +3672,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 				$this->import($strClass);
 				$_buttons = $this->$strClass->$strMethod($this, array('id'=>0), $table, false, $arrClipboard);
 			}
-			elseif (\is_callable($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['paste_button_callback']))
+			elseif (\is_callable($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['paste_button_callback'] ?? null))
 			{
 				$_buttons = $GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['paste_button_callback']($this, array('id'=>0), $table, false, $arrClipboard);
 			}
@@ -3698,33 +3698,33 @@ class DC_Table extends DataContainer implements \listable, \editable
 			// Submit buttons
 			$arrButtons = array();
 
-			if (!$GLOBALS['TL_DCA'][$this->strTable]['config']['notEditable'])
+			if (!($GLOBALS['TL_DCA'][$this->strTable]['config']['notEditable'] ?? null))
 			{
 				$arrButtons['edit'] = '<button type="submit" name="edit" id="edit" class="tl_submit" accesskey="s">' . $GLOBALS['TL_LANG']['MSC']['editSelected'] . '</button>';
 			}
 
-			if (!$GLOBALS['TL_DCA'][$this->strTable]['config']['notDeletable'])
+			if (!($GLOBALS['TL_DCA'][$this->strTable]['config']['notDeletable'] ?? null))
 			{
 				$arrButtons['delete'] = '<button type="submit" name="delete" id="delete" class="tl_submit" accesskey="d" onclick="return confirm(\'' . $GLOBALS['TL_LANG']['MSC']['delAllConfirm'] . '\')">' . $GLOBALS['TL_LANG']['MSC']['deleteSelected'] . '</button>';
 			}
 
-			if (!$GLOBALS['TL_DCA'][$this->strTable]['config']['notCopyable'])
+			if (!($GLOBALS['TL_DCA'][$this->strTable]['config']['notCopyable'] ?? null))
 			{
 				$arrButtons['copy'] = '<button type="submit" name="copy" id="copy" class="tl_submit" accesskey="c">' . $GLOBALS['TL_LANG']['MSC']['copySelected'] . '</button>';
 			}
 
-			if (!$GLOBALS['TL_DCA'][$this->strTable]['config']['notSortable'])
+			if (!($GLOBALS['TL_DCA'][$this->strTable]['config']['notSortable'] ?? null))
 			{
 				$arrButtons['cut'] = '<button type="submit" name="cut" id="cut" class="tl_submit" accesskey="x">' . $GLOBALS['TL_LANG']['MSC']['moveSelected'] . '</button>';
 			}
 
-			if (!$GLOBALS['TL_DCA'][$this->strTable]['config']['notEditable'])
+			if (!($GLOBALS['TL_DCA'][$this->strTable]['config']['notEditable'] ?? null))
 			{
 				$arrButtons['override'] = '<button type="submit" name="override" id="override" class="tl_submit" accesskey="v">' . $GLOBALS['TL_LANG']['MSC']['overrideSelected'] . '</button>';
 			}
 
 			// Call the buttons_callback (see #4691)
-			if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['select']['buttons_callback']))
+			if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['select']['buttons_callback'] ?? null))
 			{
 				foreach ($GLOBALS['TL_DCA'][$this->strTable]['select']['buttons_callback'] as $callback)
 				{
@@ -3791,7 +3791,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 		$blnPtable = false;
 
 		// Load parent table
-		if ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] == 6)
+		if (($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] ?? null) == 6)
 		{
 			$table = $this->ptable;
 
@@ -3866,7 +3866,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 		$objSessionBag = System::getContainer()->get('session')->getBag('contao_backend');
 
 		$session = $objSessionBag->all();
-		$node = ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] == 6) ? $this->strTable . '_' . $table . '_tree' : $this->strTable . '_tree';
+		$node = ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] ?? null) == 6 ? $this->strTable . '_' . $table . '_tree' : $this->strTable . '_tree';
 
 		// Toggle nodes
 		if (Input::get('ptg'))
@@ -3901,7 +3901,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 		// Check whether there are child records
 		if (!$blnNoRecursion)
 		{
-			if ($this->strTable != $table || $GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] == 5)
+			if ($this->strTable != $table || ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] ?? null) == 5)
 			{
 				$objChilds = $this->Database->prepare("SELECT id FROM " . $table . " WHERE pid=?" . (!empty($arrFound) ? " AND id IN(" . implode(',', array_map('\intval', $arrFound)) . ")" : '') . ($blnHasSorting ? " ORDER BY sorting" : ''))
 											->execute($id);
@@ -3922,9 +3922,9 @@ class DC_Table extends DataContainer implements \listable, \editable
 		}
 
 		$session[$node][$id] = (\is_int($session[$node][$id])) ? $session[$node][$id] : 0;
-		$mouseover = ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] == 5 || $table == $this->strTable) ? ' toggle_select hover-div' : '';
+		$mouseover = (($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] ?? null) == 5 || $table == $this->strTable) ? ' toggle_select hover-div' : '';
 
-		$return .= "\n  " . '<li class="' . ((($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] == 5 && $objRow->type == 'root') || $table != $this->strTable) ? 'tl_folder' : 'tl_file') . ' click2edit' . $mouseover . ' cf"><div class="tl_left" style="padding-left:' . ($intMargin + $intSpacing + (empty($childs) ? 20 : 0)) . 'px">';
+		$return .= "\n  " . '<li class="' . (((($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] ?? null) == 5 && $objRow->type == 'root') || $table != $this->strTable) ? 'tl_folder' : 'tl_file') . ' click2edit' . $mouseover . ' cf"><div class="tl_left" style="padding-left:' . ($intMargin + $intSpacing + (empty($childs) ? 20 : 0)) . 'px">';
 
 		// Calculate label and add a toggle button
 		$args = array();
@@ -3933,11 +3933,11 @@ class DC_Table extends DataContainer implements \listable, \editable
 		$blnIsOpen = (!empty($arrFound) || $session[$node][$id] == 1);
 
 		// Always show selected nodes
-		if (!$blnIsOpen && !empty($this->arrPickerValue) && ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] == 5 || $table !== $this->strTable))
+		if (!$blnIsOpen && !empty($this->arrPickerValue) && (($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] ?? null) == 5 || $table !== $this->strTable))
 		{
 			$selected = $this->arrPickerValue;
 
-			if ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] == 6)
+			if (($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] ?? null) == 6)
 			{
 				$selected = $this->Database->execute("SELECT pid FROM {$this->strTable} WHERE id IN (" . implode(',', array_map('\intval', $this->arrPickerValue)) . ')')
 										   ->fetchEach('pid');
@@ -3953,13 +3953,13 @@ class DC_Table extends DataContainer implements \listable, \editable
 		{
 			$img = $blnIsOpen ? 'folMinus.svg' : 'folPlus.svg';
 			$alt = $blnIsOpen ? $GLOBALS['TL_LANG']['MSC']['collapseNode'] : $GLOBALS['TL_LANG']['MSC']['expandNode'];
-			$return .= '<a href="' . $this->addToUrl('ptg=' . $id) . '" title="' . StringUtil::specialchars($alt) . '" onclick="Backend.getScrollOffset();return AjaxRequest.toggleStructure(this,\'' . $node . '_' . $id . '\',' . $level . ',' . $GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] . ')">' . Image::getHtml($img, '', 'style="margin-right:2px"') . '</a>';
+			$return .= '<a href="' . $this->addToUrl('ptg=' . $id) . '" title="' . StringUtil::specialchars($alt) . '" onclick="Backend.getScrollOffset();return AjaxRequest.toggleStructure(this,\'' . $node . '_' . $id . '\',' . $level . ',' . ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] ?? '') . ')">' . Image::getHtml($img, '', 'style="margin-right:2px"') . '</a>';
 		}
 
 		foreach ($showFields as $k=>$v)
 		{
 			// Decrypt the value
-			if ($GLOBALS['TL_DCA'][$table]['fields'][$v]['eval']['encrypt'])
+			if ($GLOBALS['TL_DCA'][$table]['fields'][$v]['eval']['encrypt'] ?? null)
 			{
 				$objRow->$v = Encryption::decrypt(StringUtil::deserialize($objRow->$v));
 			}
@@ -3975,11 +3975,11 @@ class DC_Table extends DataContainer implements \listable, \editable
 
 				$args[$k] = $objRef->numRows ? $objRef->$strField : '';
 			}
-			elseif (\in_array($GLOBALS['TL_DCA'][$table]['fields'][$v]['flag'], array(5, 6, 7, 8, 9, 10)))
+			elseif (\in_array($GLOBALS['TL_DCA'][$table]['fields'][$v]['flag'] ?? null, array(5, 6, 7, 8, 9, 10)))
 			{
 				$args[$k] = Date::parse(Config::get('datimFormat'), $objRow->$v);
 			}
-			elseif ($GLOBALS['TL_DCA'][$table]['fields'][$v]['inputType'] == 'checkbox' && !$GLOBALS['TL_DCA'][$table]['fields'][$v]['eval']['multiple'])
+			elseif (($GLOBALS['TL_DCA'][$table]['fields'][$v]['inputType'] ?? null) == 'checkbox' && !($GLOBALS['TL_DCA'][$table]['fields'][$v]['eval']['multiple'] ?? null))
 			{
 				$args[$k] = $objRow->$v ? ($GLOBALS['TL_DCA'][$table]['fields'][$v]['label'][0] ?? $v) : '';
 			}
@@ -3992,7 +3992,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 		$label = vsprintf($GLOBALS['TL_DCA'][$table]['list']['label']['format'] ?? '%s', $args);
 
 		// Shorten the label if it is too long
-		if ($GLOBALS['TL_DCA'][$table]['list']['label']['maxCharacters'] > 0 && $GLOBALS['TL_DCA'][$table]['list']['label']['maxCharacters'] < Utf8::strlen(strip_tags($label)))
+		if (($GLOBALS['TL_DCA'][$table]['list']['label']['maxCharacters'] ?? null) > 0 && $GLOBALS['TL_DCA'][$table]['list']['label']['maxCharacters'] < Utf8::strlen(strip_tags($label)))
 		{
 			$label = trim(StringUtil::substrHtml($label, $GLOBALS['TL_DCA'][$table]['list']['label']['maxCharacters'])) . ' …';
 		}
@@ -4000,7 +4000,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 		$label = preg_replace('/\(\) ?|\[] ?|{} ?|<> ?/', '', $label);
 
 		// Call the label_callback ($row, $label, $this)
-		if (\is_array($GLOBALS['TL_DCA'][$table]['list']['label']['label_callback']))
+		if (\is_array($GLOBALS['TL_DCA'][$table]['list']['label']['label_callback'] ?? null))
 		{
 			$strClass = $GLOBALS['TL_DCA'][$table]['list']['label']['label_callback'][0];
 			$strMethod = $GLOBALS['TL_DCA'][$table]['list']['label']['label_callback'][1];
@@ -4008,7 +4008,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 			$this->import($strClass);
 			$return .= $this->$strClass->$strMethod($objRow->row(), $label, $this, '', false, $blnProtected);
 		}
-		elseif (\is_callable($GLOBALS['TL_DCA'][$table]['list']['label']['label_callback']))
+		elseif (\is_callable($GLOBALS['TL_DCA'][$table]['list']['label']['label_callback'] ?? null))
 		{
 			$return .= $GLOBALS['TL_DCA'][$table]['list']['label']['label_callback']($objRow->row(), $label, $this, '', false, $blnProtected);
 		}
@@ -4018,8 +4018,8 @@ class DC_Table extends DataContainer implements \listable, \editable
 		}
 
 		$return .= '</div> <div class="tl_right">';
-		$previous = ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] == 6) ? $arrPrevNext['pp'] : $arrPrevNext['p'];
-		$next = ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] == 6) ? $arrPrevNext['nn'] : $arrPrevNext['n'];
+		$previous = ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] ?? null) == 6 ? $arrPrevNext['pp'] : $arrPrevNext['p'];
+		$next = ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] ?? null) == 6 ? $arrPrevNext['nn'] : $arrPrevNext['n'];
 		$_buttons = '';
 
 		// Regular buttons ($row, $table, $root, $blnCircularReference, $childs, $previous, $next)
@@ -4039,7 +4039,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 			$_buttons .= ' ';
 
 			// Call paste_button_callback(&$dc, $row, $table, $blnCircularReference, $arrClipboard, $childs, $previous, $next)
-			if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['paste_button_callback']))
+			if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['paste_button_callback'] ?? null))
 			{
 				$strClass = $GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['paste_button_callback'][0];
 				$strMethod = $GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['paste_button_callback'][1];
@@ -4047,7 +4047,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 				$this->import($strClass);
 				$_buttons .= $this->$strClass->$strMethod($this, $objRow->row(), $table, $blnCircularReference, $arrClipboard, $childs, $previous, $next);
 			}
-			elseif (\is_callable($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['paste_button_callback']))
+			elseif (\is_callable($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['paste_button_callback'] ?? null))
 			{
 				$_buttons .= $GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['paste_button_callback']($this, $objRow->row(), $table, $blnCircularReference, $arrClipboard, $childs, $previous, $next);
 			}
@@ -4060,7 +4060,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 				$imagePasteInto = Image::getHtml('pasteinto.svg', sprintf($labelPasteInto[1], $id));
 
 				// Regular tree (on cut: disable buttons of the page and all its childs to avoid circular references)
-				if ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] == 5)
+				if (($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] ?? null) == 5)
 				{
 					$_buttons .= (($arrClipboard['mode'] == 'cut' && ($blnCircularReference || $arrClipboard['id'] == $id)) || ($arrClipboard['mode'] == 'cutAll' && ($blnCircularReference || \in_array($id, $arrClipboard['id']))) || (!empty($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['root']) && !$GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['rootPaste'] && \in_array($id, $this->root))) ? Image::getHtml('pasteafter_.svg') . ' ' : '<a href="' . $this->addToUrl('act=' . $arrClipboard['mode'] . '&amp;mode=1&amp;pid=' . $id . (!\is_array($arrClipboard['id']) ? '&amp;id=' . $arrClipboard['id'] : '')) . '" title="' . StringUtil::specialchars(sprintf($labelPasteAfter[1], $id)) . '" onclick="Backend.getScrollOffset()">' . $imagePasteAfter . '</a> ';
 					$_buttons .= (($arrClipboard['mode'] == 'cut' && ($blnCircularReference || $arrClipboard['id'] == $id)) || ($arrClipboard['mode'] == 'cutAll' && ($blnCircularReference || \in_array($id, $arrClipboard['id'])))) ? Image::getHtml('pasteinto_.svg') . ' ' : '<a href="' . $this->addToUrl('act=' . $arrClipboard['mode'] . '&amp;mode=2&amp;pid=' . $id . (!\is_array($arrClipboard['id']) ? '&amp;id=' . $arrClipboard['id'] : '')) . '" title="' . StringUtil::specialchars(sprintf($labelPasteInto[1], $id)) . '" onclick="Backend.getScrollOffset()">' . $imagePasteInto . '</a> ';
@@ -4081,7 +4081,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 		if ($table != $this->strTable)
 		{
 			// Also apply the filter settings to the child table (see #716)
-			if (!empty($this->procedure) && $GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] == 6)
+			if (!empty($this->procedure) && ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] ?? null) == 6)
 			{
 				$arrValues = $this->values;
 				array_unshift($arrValues, $id);
@@ -4121,7 +4121,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 			{
 				for ($k=0, $c=\count($childs); $k<$c; $k++)
 				{
-					$return .= $this->generateTree($table, $childs[$k], array('p'=>$childs[($k-1)], 'n'=>$childs[($k+1)]), $blnHasSorting, ($intMargin + $intSpacing), $arrClipboard, (($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] == 5 && $childs[$k] == $arrClipboard['id']) || $blnCircularReference), ($blnProtected || $protectedPage), $blnNoRecursion, $arrFound);
+					$return .= $this->generateTree($table, $childs[$k], array('p'=>($childs[($k-1)] ?? null), 'n'=>($childs[($k+1)] ?? null)), $blnHasSorting, ($intMargin + $intSpacing), $arrClipboard, ((($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] ?? null) == 5 && $childs[$k] == $arrClipboard['id']) || $blnCircularReference), ($blnProtected || $protectedPage), $blnNoRecursion, $arrFound);
 				}
 			}
 
@@ -4149,8 +4149,8 @@ class DC_Table extends DataContainer implements \listable, \editable
 
 		$blnClipboard = false;
 		$arrClipboard = $objSession->get('CLIPBOARD');
-		$table = ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] == 6) ? $this->ptable : $this->strTable;
-		$blnHasSorting = $GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['fields'][0] == 'sorting';
+		$table = ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] ?? null) == 6 ? $this->ptable : $this->strTable;
+		$blnHasSorting = ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['fields'][0] ?? null) == 'sorting';
 		$blnMultiboard = false;
 
 		// Check clipboard
@@ -4179,7 +4179,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 		$return = Message::generate() . '
 <div id="tl_buttons">' . (Input::get('nb') ? '&nbsp;' : ($this->ptable ? '
 <a href="' . $this->getReferer(true, $this->ptable) . '" class="header_back" title="' . StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['backBTTitle']) . '" accesskey="b" onclick="Backend.getScrollOffset()">' . $GLOBALS['TL_LANG']['MSC']['backBT'] . '</a>' : (isset($GLOBALS['TL_DCA'][$this->strTable]['config']['backlink']) ? '
-<a href="contao/main.php?' . $GLOBALS['TL_DCA'][$this->strTable]['config']['backlink'] . '" class="header_back" title="' . StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['backBTTitle']) . '" accesskey="b" onclick="Backend.getScrollOffset()">' . $GLOBALS['TL_LANG']['MSC']['backBT'] . '</a>' : ''))) . ' ' . ((Input::get('act') != 'select' && !$blnClipboard && !$GLOBALS['TL_DCA'][$this->strTable]['config']['closed'] && !$GLOBALS['TL_DCA'][$this->strTable]['config']['notCreatable']) ? '
+<a href="contao/main.php?' . $GLOBALS['TL_DCA'][$this->strTable]['config']['backlink'] . '" class="header_back" title="' . StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['backBTTitle']) . '" accesskey="b" onclick="Backend.getScrollOffset()">' . $GLOBALS['TL_LANG']['MSC']['backBT'] . '</a>' : ''))) . ' ' . ((Input::get('act') != 'select' && !$blnClipboard && !($GLOBALS['TL_DCA'][$this->strTable]['config']['closed'] ?? null) && !($GLOBALS['TL_DCA'][$this->strTable]['config']['notCreatable'] ?? null)) ? '
 <a href="' . $this->addToUrl(($blnHasSorting ? 'act=paste&amp;mode=create' : 'act=create&amp;mode=2&amp;pid=' . $this->intId)) . '" class="header_new" title="' . StringUtil::specialchars($labelNew[1]) . '" accesskey="n" onclick="Backend.getScrollOffset()">' . $labelNew[0] . '</a> ' : '') . ($blnClipboard ? '
 <a href="' . $this->addToUrl('clipboard=1') . '" class="header_clipboard" title="' . StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['clearClipboard']) . '" accesskey="x">' . $GLOBALS['TL_LANG']['MSC']['clearClipboard'] . '</a> ' : $this->generateGlobalButtons()) . '
 </div>';
@@ -4219,8 +4219,8 @@ class DC_Table extends DataContainer implements \listable, \editable
 			$return .= '
 <div class="tl_content_right">' . ((Input::get('act') == 'select' || $this->strPickerFieldType == 'checkbox') ? '
 <label for="tl_select_trigger" class="tl_select_label">' . $GLOBALS['TL_LANG']['MSC']['selectAll'] . '</label> <input type="checkbox" id="tl_select_trigger" onclick="Backend.toggleCheckboxes(this)" class="tl_tree_checkbox">' : ($blnClipboard ? '
-<a href="' . $this->addToUrl('act=' . $arrClipboard['mode'] . '&amp;mode=2&amp;pid=' . $objParent->id . (!$blnMultiboard ? '&amp;id=' . $arrClipboard['id'] : '')) . '" title="' . StringUtil::specialchars($labelPasteAfter[0]) . '" onclick="Backend.getScrollOffset()">' . $imagePasteAfter . '</a>' : ((!$GLOBALS['TL_DCA'][$this->ptable]['config']['notEditable'] && $this->User->canEditFieldsOf($this->ptable)) ? '
-<a href="' . preg_replace('/&(amp;)?table=[^& ]*/i', ($this->ptable ? '&amp;table=' . $this->ptable : ''), $this->addToUrl('act=edit' . (Input::get('nb') ? '&amp;nc=1' : ''))) . '" class="edit" title="' . StringUtil::specialchars(sprintf(\is_array($labelEditHeader) ? $labelEditHeader[1] : $labelEditHeader, $objParent->id)) . '">' . $imageEditHeader . '</a> ' . $this->generateHeaderButtons($objParent->row(), $this->ptable) : '') . (($blnHasSorting && !$GLOBALS['TL_DCA'][$this->strTable]['config']['closed'] && !$GLOBALS['TL_DCA'][$this->strTable]['config']['notCreatable']) ? '
+<a href="' . $this->addToUrl('act=' . $arrClipboard['mode'] . '&amp;mode=2&amp;pid=' . $objParent->id . (!$blnMultiboard ? '&amp;id=' . $arrClipboard['id'] : '')) . '" title="' . StringUtil::specialchars($labelPasteAfter[0]) . '" onclick="Backend.getScrollOffset()">' . $imagePasteAfter . '</a>' : ((!($GLOBALS['TL_DCA'][$this->ptable]['config']['notEditable'] ?? null) && $this->User->canEditFieldsOf($this->ptable)) ? '
+<a href="' . preg_replace('/&(amp;)?table=[^& ]*/i', ($this->ptable ? '&amp;table=' . $this->ptable : ''), $this->addToUrl('act=edit' . (Input::get('nb') ? '&amp;nc=1' : ''))) . '" class="edit" title="' . StringUtil::specialchars(sprintf(\is_array($labelEditHeader) ? $labelEditHeader[1] : $labelEditHeader, $objParent->id)) . '">' . $imageEditHeader . '</a> ' . $this->generateHeaderButtons($objParent->row(), $this->ptable) : '') . (($blnHasSorting && !($GLOBALS['TL_DCA'][$this->strTable]['config']['closed'] ?? null) && !($GLOBALS['TL_DCA'][$this->strTable]['config']['notCreatable'] ?? null)) ? '
 <a href="' . $this->addToUrl('act=create&amp;mode=2&amp;pid=' . $objParent->id . '&amp;id=' . $this->intId) . '" title="' . StringUtil::specialchars($labelPasteNew[0]) . '">' . $imagePasteNew . '</a>' : ''))) . '
 </div>';
 
@@ -4233,7 +4233,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 				$_v = StringUtil::deserialize($objParent->$v);
 
 				// Translate UUIDs to paths
-				if ($GLOBALS['TL_DCA'][$this->ptable]['fields'][$v]['inputType'] == 'fileTree')
+				if (($GLOBALS['TL_DCA'][$this->ptable]['fields'][$v]['inputType'] ?? null) == 'fileTree')
 				{
 					$objFiles = FilesModel::findMultipleByUuids((array) $_v);
 
@@ -4247,19 +4247,19 @@ class DC_Table extends DataContainer implements \listable, \editable
 				{
 					$_v = implode(', ', $_v);
 				}
-				elseif ($GLOBALS['TL_DCA'][$this->ptable]['fields'][$v]['eval']['isBoolean'] || ($GLOBALS['TL_DCA'][$this->ptable]['fields'][$v]['inputType'] == 'checkbox' && !$GLOBALS['TL_DCA'][$this->ptable]['fields'][$v]['eval']['multiple']))
+				elseif (($GLOBALS['TL_DCA'][$this->ptable]['fields'][$v]['eval']['isBoolean'] ?? null) || (($GLOBALS['TL_DCA'][$this->ptable]['fields'][$v]['inputType'] ?? null) == 'checkbox' && !($GLOBALS['TL_DCA'][$this->ptable]['fields'][$v]['eval']['multiple'] ?? null)))
 				{
 					$_v = $_v ? $GLOBALS['TL_LANG']['MSC']['yes'] : $GLOBALS['TL_LANG']['MSC']['no'];
 				}
-				elseif ($GLOBALS['TL_DCA'][$this->ptable]['fields'][$v]['eval']['rgxp'] == 'date')
+				elseif (($GLOBALS['TL_DCA'][$this->ptable]['fields'][$v]['eval']['rgxp'] ?? null) == 'date')
 				{
 					$_v = $_v ? Date::parse(Config::get('dateFormat'), $_v) : '-';
 				}
-				elseif ($GLOBALS['TL_DCA'][$this->ptable]['fields'][$v]['eval']['rgxp'] == 'time')
+				elseif (($GLOBALS['TL_DCA'][$this->ptable]['fields'][$v]['eval']['rgxp'] ?? null) == 'time')
 				{
 					$_v = $_v ? Date::parse(Config::get('timeFormat'), $_v) : '-';
 				}
-				elseif ($GLOBALS['TL_DCA'][$this->ptable]['fields'][$v]['eval']['rgxp'] == 'datim')
+				elseif (($GLOBALS['TL_DCA'][$this->ptable]['fields'][$v]['eval']['rgxp'] ?? null) == 'datim')
 				{
 					$_v = $_v ? Date::parse(Config::get('datimFormat'), $_v) : '-';
 				}
@@ -4277,7 +4277,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 
 					$_v = $objLabel->numRows ? $objLabel->value : '-';
 				}
-				elseif (\is_array($GLOBALS['TL_DCA'][$this->ptable]['fields'][$v]['reference'][$_v]))
+				elseif (\is_array($GLOBALS['TL_DCA'][$this->ptable]['fields'][$v]['reference'][$_v] ?? null))
 				{
 					$_v = $GLOBALS['TL_DCA'][$this->ptable]['fields'][$v]['reference'][$_v][0];
 				}
@@ -4285,11 +4285,11 @@ class DC_Table extends DataContainer implements \listable, \editable
 				{
 					$_v = $GLOBALS['TL_DCA'][$this->ptable]['fields'][$v]['reference'][$_v];
 				}
-				elseif ($GLOBALS['TL_DCA'][$this->ptable]['fields'][$v]['eval']['isAssociative'] || ArrayUtil::isAssoc($GLOBALS['TL_DCA'][$this->ptable]['fields'][$v]['options']))
+				elseif (($GLOBALS['TL_DCA'][$this->ptable]['fields'][$v]['eval']['isAssociative'] ?? null) || ArrayUtil::isAssoc($GLOBALS['TL_DCA'][$this->ptable]['fields'][$v]['options'] ?? array()))
 				{
 					$_v = $GLOBALS['TL_DCA'][$this->ptable]['fields'][$v]['options'][$_v];
 				}
-				elseif (\is_array($GLOBALS['TL_DCA'][$this->ptable]['fields'][$v]['options_callback']))
+				elseif (\is_array($GLOBALS['TL_DCA'][$this->ptable]['fields'][$v]['options_callback'] ?? null))
 				{
 					$strClass = $GLOBALS['TL_DCA'][$this->ptable]['fields'][$v]['options_callback'][0];
 					$strMethod = $GLOBALS['TL_DCA'][$this->ptable]['fields'][$v]['options_callback'][1];
@@ -4299,7 +4299,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 
 					$_v = $options_callback[$_v];
 				}
-				elseif (\is_callable($GLOBALS['TL_DCA'][$this->ptable]['fields'][$v]['options_callback']))
+				elseif (\is_callable($GLOBALS['TL_DCA'][$this->ptable]['fields'][$v]['options_callback'] ?? null))
 				{
 					$options_callback = $GLOBALS['TL_DCA'][$this->ptable]['fields'][$v]['options_callback']($this);
 
@@ -4323,7 +4323,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 			}
 
 			// Trigger the header_callback (see #3417)
-			if (\is_array($GLOBALS['TL_DCA'][$table]['list']['sorting']['header_callback']))
+			if (\is_array($GLOBALS['TL_DCA'][$table]['list']['sorting']['header_callback'] ?? null))
 			{
 				$strClass = $GLOBALS['TL_DCA'][$table]['list']['sorting']['header_callback'][0];
 				$strMethod = $GLOBALS['TL_DCA'][$table]['list']['sorting']['header_callback'][1];
@@ -4331,7 +4331,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 				$this->import($strClass);
 				$add = $this->$strClass->$strMethod($add, $this);
 			}
-			elseif (\is_callable($GLOBALS['TL_DCA'][$table]['list']['sorting']['header_callback']))
+			elseif (\is_callable($GLOBALS['TL_DCA'][$table]['list']['sorting']['header_callback'] ?? null))
 			{
 				$add = $GLOBALS['TL_DCA'][$table]['list']['sorting']['header_callback']($add, $this);
 			}
@@ -4378,7 +4378,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 					$orderBy[0] = 'foreignKey';
 				}
 			}
-			elseif (\is_array($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['fields']))
+			elseif (\is_array($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['fields'] ?? null))
 			{
 				$orderBy = $GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['fields'];
 				$firstOrderBy = preg_replace('/\s+.*$/', '', $orderBy[0]);
@@ -4388,7 +4388,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 			$arrValues = $this->values;
 
 			// Support empty ptable fields
-			if ($GLOBALS['TL_DCA'][$this->strTable]['config']['dynamicPtable'])
+			if ($GLOBALS['TL_DCA'][$this->strTable]['config']['dynamicPtable'] ?? null)
 			{
 				$arrProcedure[] = ($this->ptable == 'tl_article') ? "(ptable=? OR ptable='')" : "ptable=?";
 				$arrValues[] = $this->ptable;
@@ -4438,7 +4438,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 			}
 
 			// Call the child_record_callback
-			if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['child_record_callback']) || \is_callable($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['child_record_callback']))
+			if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['child_record_callback'] ?? null) || \is_callable($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['child_record_callback'] ?? null))
 			{
 				$strGroup = '';
 				$blnIndent = false;
@@ -4462,7 +4462,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 					// Decrypt encrypted value
 					foreach ($row[$i] as $k=>$v)
 					{
-						if ($GLOBALS['TL_DCA'][$table]['fields'][$k]['eval']['encrypt'])
+						if ($GLOBALS['TL_DCA'][$table]['fields'][$k]['eval']['encrypt'] ?? null)
 						{
 							$row[$i][$k] = Encryption::decrypt(StringUtil::deserialize($v));
 						}
@@ -4476,9 +4476,9 @@ class DC_Table extends DataContainer implements \listable, \editable
 					}
 
 					// Add the group header
-					if ($firstOrderBy != 'sorting' && !$GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['disableGrouping'])
+					if ($firstOrderBy != 'sorting' && !($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['disableGrouping'] ?? null))
 					{
-						$sortingMode = (\count($orderBy) == 1 && $firstOrderBy == $orderBy[0] && $GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['flag'] && !$GLOBALS['TL_DCA'][$this->strTable]['fields'][$firstOrderBy]['flag']) ? $GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['flag'] : $GLOBALS['TL_DCA'][$this->strTable]['fields'][$firstOrderBy]['flag'];
+						$sortingMode = (\count($orderBy) == 1 && $firstOrderBy == $orderBy[0] && ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['flag'] ?? null) && !($GLOBALS['TL_DCA'][$this->strTable]['fields'][$firstOrderBy]['flag'] ?? null)) ? $GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['flag'] : $GLOBALS['TL_DCA'][$this->strTable]['fields'][$firstOrderBy]['flag'];
 						$remoteNew = $this->formatCurrentValue($firstOrderBy, $row[$i][$firstOrderBy], $sortingMode);
 						$group = $this->formatGroupHeader($firstOrderBy, $remoteNew, $sortingMode, $row[$i]);
 
@@ -4526,7 +4526,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 						if ($blnHasSorting)
 						{
 							// Create new button
-							if (!$GLOBALS['TL_DCA'][$this->strTable]['config']['closed'] && !$GLOBALS['TL_DCA'][$this->strTable]['config']['notCreatable'])
+							if (!($GLOBALS['TL_DCA'][$this->strTable]['config']['closed'] ?? null) && !($GLOBALS['TL_DCA'][$this->strTable]['config']['notCreatable'] ?? null))
 							{
 								$return .= ' <a href="' . $this->addToUrl('act=create&amp;mode=1&amp;pid=' . $row[$i]['id'] . '&amp;id=' . $objParent->id . (Input::get('nb') ? '&amp;nc=1' : '')) . '" title="' . StringUtil::specialchars(sprintf($labelPasteNew[1], $row[$i]['id'])) . '">' . $imagePasteNew . '</a>';
 							}
@@ -4550,7 +4550,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 							}
 
 							// Drag handle
-							if (!$GLOBALS['TL_DCA'][$this->strTable]['config']['notSortable'])
+							if (!($GLOBALS['TL_DCA'][$this->strTable]['config']['notSortable'] ?? null))
 							{
 								$return .= ' <button type="button" class="drag-handle" title="' . StringUtil::specialchars(sprintf(\is_array($labelCut) ? $labelCut[1] : $labelCut, $row[$i]['id'])) . '" aria-hidden="true">' . Image::getHtml('drag.svg') . '</button>';
 							}
@@ -4563,7 +4563,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 						}
 					}
 
-					if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['child_record_callback']))
+					if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['child_record_callback'] ?? null))
 					{
 						$strClass = $GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['child_record_callback'][0];
 						$strMethod = $GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['child_record_callback'][1];
@@ -4571,7 +4571,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 						$this->import($strClass);
 						$return .= '</div>' . $this->$strClass->$strMethod($row[$i]) . '</div>';
 					}
-					elseif (\is_callable($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['child_record_callback']))
+					elseif (\is_callable($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['child_record_callback'] ?? null))
 					{
 						$return .= '</div>' . $GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['child_record_callback']($row[$i]) . '</div>';
 					}
@@ -4587,7 +4587,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 		}
 
 		// Make items sortable
-		if ($blnHasSorting && !$GLOBALS['TL_DCA'][$this->strTable]['config']['notSortable'] && Input::get('act') != 'select')
+		if ($blnHasSorting && !($GLOBALS['TL_DCA'][$this->strTable]['config']['notSortable'] ?? null) && Input::get('act') != 'select')
 		{
 			$return .= '
 </ul>
@@ -4608,33 +4608,33 @@ class DC_Table extends DataContainer implements \listable, \editable
 			// Submit buttons
 			$arrButtons = array();
 
-			if (!$GLOBALS['TL_DCA'][$this->strTable]['config']['notEditable'])
+			if (!($GLOBALS['TL_DCA'][$this->strTable]['config']['notEditable'] ?? null))
 			{
 				$arrButtons['edit'] = '<button type="submit" name="edit" id="edit" class="tl_submit" accesskey="s">' . $GLOBALS['TL_LANG']['MSC']['editSelected'] . '</button>';
 			}
 
-			if (!$GLOBALS['TL_DCA'][$this->strTable]['config']['notDeletable'])
+			if (!($GLOBALS['TL_DCA'][$this->strTable]['config']['notDeletable'] ?? null))
 			{
 				$arrButtons['delete'] = '<button type="submit" name="delete" id="delete" class="tl_submit" accesskey="d" onclick="return confirm(\'' . $GLOBALS['TL_LANG']['MSC']['delAllConfirm'] . '\')">' . $GLOBALS['TL_LANG']['MSC']['deleteSelected'] . '</button>';
 			}
 
-			if (!$GLOBALS['TL_DCA'][$this->strTable]['config']['notCopyable'])
+			if (!($GLOBALS['TL_DCA'][$this->strTable]['config']['notCopyable'] ?? null))
 			{
 				$arrButtons['copy'] = '<button type="submit" name="copy" id="copy" class="tl_submit" accesskey="c">' . $GLOBALS['TL_LANG']['MSC']['copySelected'] . '</button>';
 			}
 
-			if (!$GLOBALS['TL_DCA'][$this->strTable]['config']['notSortable'])
+			if (!($GLOBALS['TL_DCA'][$this->strTable]['config']['notSortable'] ?? null))
 			{
 				$arrButtons['cut'] = '<button type="submit" name="cut" id="cut" class="tl_submit" accesskey="x">' . $GLOBALS['TL_LANG']['MSC']['moveSelected'] . '</button>';
 			}
 
-			if (!$GLOBALS['TL_DCA'][$this->strTable]['config']['notEditable'])
+			if (!($GLOBALS['TL_DCA'][$this->strTable]['config']['notEditable'] ?? null))
 			{
 				$arrButtons['override'] = '<button type="submit" name="override" id="override" class="tl_submit" accesskey="v">' . $GLOBALS['TL_LANG']['MSC']['overrideSelected'] . '</button>';
 			}
 
 			// Call the buttons_callback (see #4691)
-			if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['select']['buttons_callback']))
+			if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['select']['buttons_callback'] ?? null))
 			{
 				foreach ($GLOBALS['TL_DCA'][$this->strTable]['select']['buttons_callback'] as $callback)
 				{
@@ -4688,8 +4688,8 @@ class DC_Table extends DataContainer implements \listable, \editable
 	 */
 	protected function listView()
 	{
-		$table = ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] == 6) ? $this->ptable : $this->strTable;
-		$orderBy = $GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['fields'];
+		$table = ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] ?? null) == 6 ? $this->ptable : $this->strTable;
+		$orderBy = $GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['fields'] ?? array();
 		$firstOrderBy = preg_replace('/\s+.*$/', '', $orderBy[0]);
 
 		if (\is_array($this->orderBy) && $this->orderBy[0])
@@ -4722,7 +4722,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 				// If there is no direction, check the global flag in sorting mode 1 or the field flag in all other sorting modes
 				if (!$direction)
 				{
-					if ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] == 1 && isset($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['flag']) && ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['flag'] % 2) == 0)
+					if (($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] ?? null) == 1 && isset($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['flag']) && ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['flag'] % 2) == 0)
 					{
 						$direction = 'DESC';
 					}
@@ -4732,11 +4732,11 @@ class DC_Table extends DataContainer implements \listable, \editable
 					}
 				}
 
-				if ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$key]['eval']['findInSet'])
+				if ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$key]['eval']['findInSet'] ?? null)
 				{
 					$direction = null;
 
-					if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$key]['options_callback']))
+					if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$key]['options_callback'] ?? null))
 					{
 						$strClass = $GLOBALS['TL_DCA'][$this->strTable]['fields'][$key]['options_callback'][0];
 						$strMethod = $GLOBALS['TL_DCA'][$this->strTable]['fields'][$key]['options_callback'][1];
@@ -4744,7 +4744,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 						$this->import($strClass);
 						$keys = $this->$strClass->$strMethod($this);
 					}
-					elseif (\is_callable($GLOBALS['TL_DCA'][$this->strTable]['fields'][$key]['options_callback']))
+					elseif (\is_callable($GLOBALS['TL_DCA'][$this->strTable]['fields'][$key]['options_callback'] ?? null))
 					{
 						$keys = $GLOBALS['TL_DCA'][$this->strTable]['fields'][$key]['options_callback']($this);
 					}
@@ -4753,14 +4753,14 @@ class DC_Table extends DataContainer implements \listable, \editable
 						$keys = $GLOBALS['TL_DCA'][$this->strTable]['fields'][$key]['options'];
 					}
 
-					if ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$key]['eval']['isAssociative'] || ArrayUtil::isAssoc($keys))
+					if (($GLOBALS['TL_DCA'][$this->strTable]['fields'][$key]['eval']['isAssociative'] ?? null) || ArrayUtil::isAssoc($keys))
 					{
 						$keys = array_keys($keys);
 					}
 
 					$orderBy[$k] = $this->Database->findInSet($v, $keys);
 				}
-				elseif (\in_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$key]['flag'], array(5, 6, 7, 8, 9, 10)))
+				elseif (\in_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$key]['flag'] ?? null, array(5, 6, 7, 8, 9, 10)))
 				{
 					$orderBy[$k] = "CAST($key AS SIGNED)"; // see #5503
 				}
@@ -4771,7 +4771,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 				}
 			}
 
-			if ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] == 3)
+			if (($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] ?? null) == 3)
 			{
 				$firstOrderBy = 'pid';
 				$showFields = $GLOBALS['TL_DCA'][$table]['list']['label']['fields'];
@@ -4779,7 +4779,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 				$query .= " ORDER BY (SELECT " . Database::quoteIdentifier($showFields[0]) . " FROM " . $this->ptable . " WHERE " . $this->ptable . ".id=" . $this->strTable . ".pid), " . implode(', ', $orderBy);
 
 				// Set the foreignKey so that the label is translated
-				if (!$GLOBALS['TL_DCA'][$table]['fields']['pid']['foreignKey'])
+				if (!($GLOBALS['TL_DCA'][$table]['fields']['pid']['foreignKey'] ?? null))
 				{
 					$GLOBALS['TL_DCA'][$table]['fields']['pid']['foreignKey'] = $this->ptable . '.' . $showFields[0];
 				}
@@ -4808,8 +4808,8 @@ class DC_Table extends DataContainer implements \listable, \editable
 		$return = Message::generate() . '
 <div id="tl_buttons">' . ((Input::get('act') == 'select' || $this->ptable) ? '
 <a href="' . $this->getReferer(true, $this->ptable) . '" class="header_back" title="' . StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['backBTTitle']) . '" accesskey="b" onclick="Backend.getScrollOffset()">' . $GLOBALS['TL_LANG']['MSC']['backBT'] . '</a> ' : (isset($GLOBALS['TL_DCA'][$this->strTable]['config']['backlink']) ? '
-<a href="contao/main.php?' . $GLOBALS['TL_DCA'][$this->strTable]['config']['backlink'] . '" class="header_back" title="' . StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['backBTTitle']) . '" accesskey="b" onclick="Backend.getScrollOffset()">' . $GLOBALS['TL_LANG']['MSC']['backBT'] . '</a> ' : '')) . ((Input::get('act') != 'select' && !$GLOBALS['TL_DCA'][$this->strTable]['config']['closed'] && !$GLOBALS['TL_DCA'][$this->strTable]['config']['notCreatable']) ? '
-<a href="' . ($this->ptable ? $this->addToUrl('act=create' . (($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] < 4) ? '&amp;mode=2' : '') . '&amp;pid=' . $this->intId) : $this->addToUrl('act=create')) . '" class="header_new" title="' . StringUtil::specialchars($labelNew[1]) . '" accesskey="n" onclick="Backend.getScrollOffset()">' . $labelNew[0] . '</a> ' : '') . $this->generateGlobalButtons() . '
+<a href="contao/main.php?' . $GLOBALS['TL_DCA'][$this->strTable]['config']['backlink'] . '" class="header_back" title="' . StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['backBTTitle']) . '" accesskey="b" onclick="Backend.getScrollOffset()">' . $GLOBALS['TL_LANG']['MSC']['backBT'] . '</a> ' : '')) . ((Input::get('act') != 'select' && !($GLOBALS['TL_DCA'][$this->strTable]['config']['closed'] ?? null) && !($GLOBALS['TL_DCA'][$this->strTable]['config']['notCreatable'] ?? null)) ? '
+<a href="' . ($this->ptable ? $this->addToUrl('act=create' . ((($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] ?? null) < 4) ? '&amp;mode=2' : '') . '&amp;pid=' . $this->intId) : $this->addToUrl('act=create')) . '" class="header_new" title="' . StringUtil::specialchars($labelNew[1]) . '" accesskey="n" onclick="Backend.getScrollOffset()">' . $labelNew[0] . '</a> ' : '') . $this->generateGlobalButtons() . '
 </div>';
 
 		// Return "no records found" message
@@ -4833,10 +4833,10 @@ class DC_Table extends DataContainer implements \listable, \editable
 <div class="tl_select_trigger">
 <label for="tl_select_trigger" class="tl_select_label">' . $GLOBALS['TL_LANG']['MSC']['selectAll'] . '</label> <input type="checkbox" id="tl_select_trigger" onclick="Backend.toggleCheckboxes(this)" class="tl_tree_checkbox">
 </div>' : '') . '
-<table class="tl_listing' . ($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['showColumns'] ? ' showColumns' : '') . ($this->strPickerFieldType ? ' picker unselectable' : '') . '">';
+<table class="tl_listing' . (($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['showColumns'] ?? null) ? ' showColumns' : '') . ($this->strPickerFieldType ? ' picker unselectable' : '') . '">';
 
 			// Automatically add the "order by" field as last column if we do not have group headers
-			if ($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['showColumns'])
+			if ($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['showColumns'] ?? null)
 			{
 				$blnFound = false;
 
@@ -4862,7 +4862,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 			}
 
 			// Generate the table header if the "show columns" option is active
-			if ($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['showColumns'])
+			if ($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['showColumns'] ?? null)
 			{
 				$return .= '
   <tr>';
@@ -4898,7 +4898,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 				foreach ($showFields as $k=>$v)
 				{
 					// Decrypt the value
-					if ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$v]['eval']['encrypt'])
+					if ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$v]['eval']['encrypt'] ?? null)
 					{
 						$row[$v] = Encryption::decrypt(StringUtil::deserialize($row[$v]));
 					}
@@ -4914,13 +4914,13 @@ class DC_Table extends DataContainer implements \listable, \editable
 
 						$args[$k] = $objRef->numRows ? $objRef->$strField : '';
 					}
-					elseif (\in_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$v]['flag'], array(5, 6, 7, 8, 9, 10)))
+					elseif (\in_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$v]['flag'] ?? null, array(5, 6, 7, 8, 9, 10)))
 					{
-						if ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$v]['eval']['rgxp'] == 'date')
+						if (($GLOBALS['TL_DCA'][$this->strTable]['fields'][$v]['eval']['rgxp'] ?? null) == 'date')
 						{
 							$args[$k] = $row[$v] ? Date::parse(Config::get('dateFormat'), $row[$v]) : '-';
 						}
-						elseif ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$v]['eval']['rgxp'] == 'time')
+						elseif (($GLOBALS['TL_DCA'][$this->strTable]['fields'][$v]['eval']['rgxp'] ?? null) == 'time')
 						{
 							$args[$k] = $row[$v] ? Date::parse(Config::get('timeFormat'), $row[$v]) : '-';
 						}
@@ -4929,7 +4929,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 							$args[$k] = $row[$v] ? Date::parse(Config::get('datimFormat'), $row[$v]) : '-';
 						}
 					}
-					elseif ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$v]['eval']['isBoolean'] || ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$v]['inputType'] == 'checkbox' && !$GLOBALS['TL_DCA'][$this->strTable]['fields'][$v]['eval']['multiple']))
+					elseif (($GLOBALS['TL_DCA'][$this->strTable]['fields'][$v]['eval']['isBoolean'] ?? null) || (($GLOBALS['TL_DCA'][$this->strTable]['fields'][$v]['inputType'] ?? null) == 'checkbox' && !($GLOBALS['TL_DCA'][$this->strTable]['fields'][$v]['eval']['multiple'] ?? null)))
 					{
 						$args[$k] = $row[$v] ? $GLOBALS['TL_LANG']['MSC']['yes'] : $GLOBALS['TL_LANG']['MSC']['no'];
 					}
@@ -4952,7 +4952,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 						{
 							$args[$k] = \is_array($GLOBALS['TL_DCA'][$table]['fields'][$v]['reference'][$row[$v]]) ? $GLOBALS['TL_DCA'][$table]['fields'][$v]['reference'][$row[$v]][0] : $GLOBALS['TL_DCA'][$table]['fields'][$v]['reference'][$row[$v]];
 						}
-						elseif (($GLOBALS['TL_DCA'][$table]['fields'][$v]['eval']['isAssociative'] || ArrayUtil::isAssoc($GLOBALS['TL_DCA'][$table]['fields'][$v]['options'])) && isset($GLOBALS['TL_DCA'][$table]['fields'][$v]['options'][$row[$v]]))
+						elseif ((($GLOBALS['TL_DCA'][$table]['fields'][$v]['eval']['isAssociative'] ?? null) || ArrayUtil::isAssoc($GLOBALS['TL_DCA'][$table]['fields'][$v]['options'] ?? array())) && isset($GLOBALS['TL_DCA'][$table]['fields'][$v]['options'][$row[$v]]))
 						{
 							$args[$k] = $GLOBALS['TL_DCA'][$table]['fields'][$v]['options'][$row[$v]];
 						}
@@ -4966,7 +4966,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 				// Shorten the label it if it is too long
 				$label = vsprintf($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['format'] ?: '%s', $args);
 
-				if ($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['maxCharacters'] > 0 && $GLOBALS['TL_DCA'][$this->strTable]['list']['label']['maxCharacters'] < \strlen(strip_tags($label)))
+				if (($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['maxCharacters'] ?? null) > 0 && $GLOBALS['TL_DCA'][$this->strTable]['list']['label']['maxCharacters'] < \strlen(strip_tags($label)))
 				{
 					$label = trim(StringUtil::substrHtml($label, $GLOBALS['TL_DCA'][$this->strTable]['list']['label']['maxCharacters'])) . ' …';
 				}
@@ -4976,15 +4976,15 @@ class DC_Table extends DataContainer implements \listable, \editable
 				$label = preg_replace('/<[^>]+>\s*<\/[^>]+>/', '', $label);
 
 				// Build the sorting groups
-				if ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] > 0)
+				if (($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] ?? null) > 0)
 				{
 					$current = $row[$firstOrderBy];
 					$orderBy = $GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['fields'];
-					$sortingMode = (\count($orderBy) == 1 && $firstOrderBy == $orderBy[0] && $GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['flag'] && !$GLOBALS['TL_DCA'][$this->strTable]['fields'][$firstOrderBy]['flag']) ? $GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['flag'] : $GLOBALS['TL_DCA'][$this->strTable]['fields'][$firstOrderBy]['flag'];
+					$sortingMode = (\count($orderBy) == 1 && $firstOrderBy == $orderBy[0] && ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['flag'] ?? null) && !($GLOBALS['TL_DCA'][$this->strTable]['fields'][$firstOrderBy]['flag'] ?? null)) ? $GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['flag'] : $GLOBALS['TL_DCA'][$this->strTable]['fields'][$firstOrderBy]['flag'];
 					$remoteNew = $this->formatCurrentValue($firstOrderBy, $current, $sortingMode);
 
 					// Add the group header
-					if (($remoteNew != $remoteCur || $remoteCur === false) && !$GLOBALS['TL_DCA'][$this->strTable]['list']['label']['showColumns'] && !$GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['disableGrouping'])
+					if (($remoteNew != $remoteCur || $remoteCur === false) && !($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['showColumns'] ?? null) && !($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['disableGrouping'] ?? null))
 					{
 						$eoCount = -1;
 						$group = $this->formatGroupHeader($firstOrderBy, $remoteNew, $sortingMode, $row);
@@ -5005,9 +5005,9 @@ class DC_Table extends DataContainer implements \listable, \editable
 				$colspan = 1;
 
 				// Call the label_callback ($row, $label, $this)
-				if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['label_callback']) || \is_callable($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['label_callback']))
+				if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['label_callback'] ?? null) || \is_callable($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['label_callback'] ?? null))
 				{
-					if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['label_callback']))
+					if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['label_callback'] ?? null))
 					{
 						$strClass = $GLOBALS['TL_DCA'][$this->strTable]['list']['label']['label_callback'][0];
 						$strMethod = $GLOBALS['TL_DCA'][$this->strTable]['list']['label']['label_callback'][1];
@@ -5015,29 +5015,29 @@ class DC_Table extends DataContainer implements \listable, \editable
 						$this->import($strClass);
 						$args = $this->$strClass->$strMethod($row, $label, $this, $args);
 					}
-					elseif (\is_callable($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['label_callback']))
+					elseif (\is_callable($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['label_callback'] ?? null))
 					{
 						$args = $GLOBALS['TL_DCA'][$this->strTable]['list']['label']['label_callback']($row, $label, $this, $args);
 					}
 
 					// Handle strings and arrays
-					if (!$GLOBALS['TL_DCA'][$this->strTable]['list']['label']['showColumns'])
+					if (!($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['showColumns'] ?? null))
 					{
 						$label = \is_array($args) ? implode(' ', $args) : $args;
 					}
 					elseif (!\is_array($args))
 					{
 						$args = array($args);
-						$colspan = \count($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['fields']);
+						$colspan = \count($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['fields'] ?? array());
 					}
 				}
 
 				// Show columns
-				if ($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['showColumns'])
+				if ($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['showColumns'] ?? null)
 				{
 					foreach ($args as $j=>$arg)
 					{
-						$return .= '<td colspan="' . $colspan . '" class="tl_file_list col_' . $GLOBALS['TL_DCA'][$this->strTable]['list']['label']['fields'][$j] . (($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['fields'][$j] == $firstOrderBy) ? ' ordered_by' : '') . '">' . ($arg ?: '-') . '</td>';
+						$return .= '<td colspan="' . $colspan . '" class="tl_file_list col_' . $GLOBALS['TL_DCA'][$this->strTable]['list']['label']['fields'][$j] . ((($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['fields'][$j] ?? null) == $firstOrderBy) ? ' ordered_by' : '') . '">' . ($arg ?: '-') . '</td>';
 					}
 				}
 				else
@@ -5066,28 +5066,28 @@ class DC_Table extends DataContainer implements \listable, \editable
 				// Submit buttons
 				$arrButtons = array();
 
-				if (!$GLOBALS['TL_DCA'][$this->strTable]['config']['notEditable'])
+				if (!($GLOBALS['TL_DCA'][$this->strTable]['config']['notEditable'] ?? null))
 				{
 					$arrButtons['edit'] = '<button type="submit" name="edit" id="edit" class="tl_submit" accesskey="s">' . $GLOBALS['TL_LANG']['MSC']['editSelected'] . '</button>';
 				}
 
-				if (!$GLOBALS['TL_DCA'][$this->strTable]['config']['notDeletable'])
+				if (!($GLOBALS['TL_DCA'][$this->strTable]['config']['notDeletable'] ?? null))
 				{
 					$arrButtons['delete'] = '<button type="submit" name="delete" id="delete" class="tl_submit" accesskey="d" onclick="return confirm(\'' . $GLOBALS['TL_LANG']['MSC']['delAllConfirm'] . '\')">' . $GLOBALS['TL_LANG']['MSC']['deleteSelected'] . '</button>';
 				}
 
-				if (!$GLOBALS['TL_DCA'][$this->strTable]['config']['notCopyable'])
+				if (!($GLOBALS['TL_DCA'][$this->strTable]['config']['notCopyable'] ?? null))
 				{
 					$arrButtons['copy'] = '<button type="submit" name="copy" id="copy" class="tl_submit" accesskey="c">' . $GLOBALS['TL_LANG']['MSC']['copySelected'] . '</button>';
 				}
 
-				if (!$GLOBALS['TL_DCA'][$this->strTable]['config']['notEditable'])
+				if (!($GLOBALS['TL_DCA'][$this->strTable]['config']['notEditable'] ?? null))
 				{
 					$arrButtons['override'] = '<button type="submit" name="override" id="override" class="tl_submit" accesskey="v">' . $GLOBALS['TL_LANG']['MSC']['overrideSelected'] . '</button>';
 				}
 
 				// Call the buttons_callback (see #4691)
-				if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['select']['buttons_callback']))
+				if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['select']['buttons_callback'] ?? null))
 				{
 					foreach ($GLOBALS['TL_DCA'][$this->strTable]['select']['buttons_callback'] as $callback)
 					{
@@ -5263,7 +5263,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 	 */
 	protected function sortMenu()
 	{
-		if ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] != 2 && $GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] != 4)
+		if (($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] ?? null) != 2 && ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] ?? null) != 4)
 		{
 			return '';
 		}
@@ -5293,7 +5293,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 		$firstOrderBy = preg_replace('/\s+.*$/', '', $orderBy[0]);
 
 		// Add PID to order fields
-		if ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] == 3 && $this->Database->fieldExists('pid', $this->strTable))
+		if (($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] ?? null) == 3 && $this->Database->fieldExists('pid', $this->strTable))
 		{
 			array_unshift($orderBy, 'pid');
 		}
@@ -5306,7 +5306,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 			// Validate the user input (thanks to aulmn) (see #4971)
 			if (\in_array($strSort, $sortingFields, true))
 			{
-				$session['sorting'][$this->strTable] = \in_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$strSort]['flag'], array(2, 4, 6, 8, 10, 12)) ? "$strSort DESC" : $strSort;
+				$session['sorting'][$this->strTable] = \in_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$strSort]['flag'] ?? null, array(2, 4, 6, 8, 10, 12)) ? "$strSort DESC" : $strSort;
 				$objSessionBag->replace($session);
 			}
 		}
@@ -5363,7 +5363,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 		$objSessionBag = System::getContainer()->get('session')->getBag('contao_backend');
 
 		$session = $objSessionBag->all();
-		$filter = ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] == 4) ? $this->strTable . '_' . CURRENT_ID : $this->strTable;
+		$filter = ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] ?? null) == 4 ? $this->strTable . '_' . CURRENT_ID : $this->strTable;
 		$fields = '';
 
 		// Set limit from user input
@@ -5404,7 +5404,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 			}
 
 			// Support empty ptable fields
-			if ($GLOBALS['TL_DCA'][$this->strTable]['config']['dynamicPtable'])
+			if ($GLOBALS['TL_DCA'][$this->strTable]['config']['dynamicPtable'] ?? null)
 			{
 				$arrProcedure[] = ($this->ptable == 'tl_article') ? "(ptable=? OR ptable='')" : "ptable=?";
 				$arrValues[] = $this->ptable;
@@ -5503,12 +5503,12 @@ class DC_Table extends DataContainer implements \listable, \editable
 		$fields = '';
 		$sortingFields = array();
 		$session = $objSessionBag->all();
-		$filter = ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] == 4) ? $this->strTable . '_' . CURRENT_ID : $this->strTable;
+		$filter = ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] ?? null) == 4 ? $this->strTable . '_' . CURRENT_ID : $this->strTable;
 
 		// Get the sorting fields
 		foreach ($GLOBALS['TL_DCA'][$this->strTable]['fields'] as $k=>$v)
 		{
-			if ((int) $v['filter'] == $intFilterPanel)
+			if (($v['filter'] ?? null) == $intFilterPanel)
 			{
 				$sortingFields[] = $k;
 			}
@@ -5548,7 +5548,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 				if (isset($session['filter'][$filter][$field]))
 				{
 					// Sort by day
-					if (\in_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['flag'], array(5, 6)))
+					if (\in_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['flag'] ?? null, array(5, 6)))
 					{
 						if (!$session['filter'][$filter][$field])
 						{
@@ -5564,7 +5564,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 					}
 
 					// Sort by month
-					elseif (\in_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['flag'], array(7, 8)))
+					elseif (\in_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['flag'] ?? null, array(7, 8)))
 					{
 						if (!$session['filter'][$filter][$field])
 						{
@@ -5580,7 +5580,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 					}
 
 					// Sort by year
-					elseif (\in_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['flag'], array(9, 10)))
+					elseif (\in_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['flag'] ?? null, array(9, 10)))
 					{
 						if (!$session['filter'][$filter][$field])
 						{
@@ -5596,7 +5596,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 					}
 
 					// Manual filter
-					elseif ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['eval']['multiple'])
+					elseif ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['eval']['multiple'] ?? null)
 					{
 						// CSV lists (see #2890)
 						if (isset($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['eval']['csv']))
@@ -5627,7 +5627,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 			$arrValues = array();
 			$arrProcedure = array();
 
-			if ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] == 4)
+			if (($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] ?? null) == 4)
 			{
 				$arrProcedure[] = 'pid=?';
 				$arrValues[] = CURRENT_ID;
@@ -5639,7 +5639,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 			}
 
 			// Check for a static filter (see #4719)
-			if (!empty($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['filter']) && \is_array($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['filter']))
+			if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['filter'] ?? null))
 			{
 				foreach ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['filter'] as $fltr)
 				{
@@ -5656,7 +5656,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 			}
 
 			// Support empty ptable fields
-			if ($GLOBALS['TL_DCA'][$this->strTable]['config']['dynamicPtable'])
+			if ($GLOBALS['TL_DCA'][$this->strTable]['config']['dynamicPtable'] ?? null)
 			{
 				$arrProcedure[] = ($this->ptable == 'tl_article') ? "(ptable=? OR ptable='')" : "ptable=?";
 				$arrValues[] = $this->ptable;
@@ -5686,7 +5686,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 				}
 			}
 
-			$table = ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] == 6) ? $this->ptable : $this->strTable;
+			$table = ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] ?? null) == 6 ? $this->ptable : $this->strTable;
 
 			// Limit the options if there are root records
 			if (isset($GLOBALS['TL_DCA'][$table]['list']['sorting']['root']) && $GLOBALS['TL_DCA'][$table]['list']['sorting']['root'] !== false)
@@ -5694,12 +5694,12 @@ class DC_Table extends DataContainer implements \listable, \editable
 				$rootIds = array_map('\intval', $GLOBALS['TL_DCA'][$table]['list']['sorting']['root']);
 
 				// Also add the child records of the table (see #1811)
-				if ($GLOBALS['TL_DCA'][$table]['list']['sorting']['mode'] == 5)
+				if (($GLOBALS['TL_DCA'][$table]['list']['sorting']['mode'] ?? null) == 5)
 				{
 					$rootIds = array_merge($rootIds, $this->Database->getChildRecords($rootIds, $table));
 				}
 
-				if ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] == 6)
+				if (($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] ?? null) == 6)
 				{
 					$arrProcedure[] = "pid IN(" . implode(',', $rootIds) . ")";
 				}
@@ -5723,9 +5723,9 @@ class DC_Table extends DataContainer implements \listable, \editable
 				$options = $objFields->fetchEach($field);
 
 				// Sort by day
-				if (\in_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['flag'], array(5, 6)))
+				if (\in_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['flag'] ?? null, array(5, 6)))
 				{
-					($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['flag'] == 6) ? rsort($options) : sort($options);
+					($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['flag'] ?? null) == 6 ? rsort($options) : sort($options);
 
 					foreach ($options as $k=>$v)
 					{
@@ -5743,9 +5743,9 @@ class DC_Table extends DataContainer implements \listable, \editable
 				}
 
 				// Sort by month
-				elseif (\in_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['flag'], array(7, 8)))
+				elseif (\in_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['flag'] ?? null, array(7, 8)))
 				{
-					($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['flag'] == 8) ? rsort($options) : sort($options);
+					($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['flag'] ?? null) == 8 ? rsort($options) : sort($options);
 
 					foreach ($options as $k=>$v)
 					{
@@ -5769,9 +5769,9 @@ class DC_Table extends DataContainer implements \listable, \editable
 				}
 
 				// Sort by year
-				elseif (\in_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['flag'], array(9, 10)))
+				elseif (\in_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['flag'] ?? null, array(9, 10)))
 				{
-					($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['flag'] == 10) ? rsort($options) : sort($options);
+					($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['flag'] ?? null) == 10 ? rsort($options) : sort($options);
 
 					foreach ($options as $k=>$v)
 					{
@@ -5789,7 +5789,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 				}
 
 				// Manual filter
-				if ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['eval']['multiple'])
+				if ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['eval']['multiple'] ?? null)
 				{
 					$moptions = array();
 
@@ -5819,9 +5819,9 @@ class DC_Table extends DataContainer implements \listable, \editable
 				$options_callback = array();
 
 				// Call the options_callback
-				if (!$GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['reference'] && (\is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['options_callback']) || \is_callable($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['options_callback'])))
+				if (!($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['reference'] ?? null) && (\is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['options_callback'] ?? null) || \is_callable($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['options_callback'] ?? null)))
 				{
-					if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['options_callback']))
+					if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['options_callback'] ?? null))
 					{
 						$strClass = $GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['options_callback'][0];
 						$strMethod = $GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['options_callback'][1];
@@ -5829,7 +5829,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 						$this->import($strClass);
 						$options_callback = $this->$strClass->$strMethod($this);
 					}
-					elseif (\is_callable($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['options_callback']))
+					elseif (\is_callable($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['options_callback'] ?? null))
 					{
 						$options_callback = $GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['options_callback']($this);
 					}
@@ -5839,7 +5839,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 				}
 
 				$options_sorter = array();
-				$blnDate = \in_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['flag'], array(5, 6, 7, 8, 9, 10));
+				$blnDate = \in_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['flag'] ?? null, array(5, 6, 7, 8, 9, 10));
 
 				// Options
 				foreach ($options as $kk=>$vv)
@@ -5868,7 +5868,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 					}
 
 					// Replace boolean checkbox value with "yes" and "no"
-					elseif ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['eval']['isBoolean'] || ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['inputType'] == 'checkbox' && !$GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['eval']['multiple']))
+					elseif (($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['eval']['isBoolean'] ?? null) || (($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['inputType'] ?? null) == 'checkbox' && !($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['eval']['multiple'] ?? null)))
 					{
 						$vv = $vv ? $GLOBALS['TL_LANG']['MSC']['yes'] : $GLOBALS['TL_LANG']['MSC']['no'];
 					}
@@ -5903,7 +5903,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 					}
 
 					// Associative array
-					elseif ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['eval']['isAssociative'] || ArrayUtil::isAssoc($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['options']))
+					elseif (($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['eval']['isAssociative'] ?? null) || ArrayUtil::isAssoc($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['options'] ?? array()))
 					{
 						$option_label = $GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['options'][$vv];
 					}
@@ -5922,7 +5922,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 				{
 					natcasesort($options_sorter);
 
-					if (\in_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['flag'], array(2, 4, 12)))
+					if (\in_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['flag'] ?? null, array(2, 4, 12)))
 					{
 						$options_sorter = array_reverse($options_sorter, true);
 					}
@@ -5959,7 +5959,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 		$objSessionBag = System::getContainer()->get('session')->getBag('contao_backend');
 
 		$session = $objSessionBag->all();
-		$filter = ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] == 4) ? $this->strTable . '_' . CURRENT_ID : $this->strTable;
+		$filter = ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] ?? null) == 4 ? $this->strTable . '_' . CURRENT_ID : $this->strTable;
 
 		list($offset, $limit) = explode(',', $this->limit);
 
@@ -6000,7 +6000,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 	{
 		$remoteNew = $value; // see #3861
 
-		if ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['eval']['isBoolean'] || ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['inputType'] == 'checkbox' && !$GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['eval']['multiple']))
+		if (($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['eval']['isBoolean'] ?? null) || (($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['inputType'] ?? null) == 'checkbox' && !($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['eval']['multiple'] ?? null)))
 		{
 			$remoteNew = $value ? ucfirst($GLOBALS['TL_LANG']['MSC']['yes']) : ucfirst($GLOBALS['TL_LANG']['MSC']['no']);
 		}
@@ -6050,15 +6050,15 @@ class DC_Table extends DataContainer implements \listable, \editable
 		}
 		else
 		{
-			if ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['inputType'] == 'checkbox' && !$GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['eval']['multiple'])
+			if (($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['inputType'] ?? null) == 'checkbox' && !($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['eval']['multiple'] ?? null))
 			{
 				$remoteNew = $value ? $field : '';
 			}
-			elseif (\is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['reference']))
+			elseif (\is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['reference'] ?? null))
 			{
 				$remoteNew = $GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['reference'][$value];
 			}
-			elseif ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['eval']['isAssociative'] || ArrayUtil::isAssoc($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['options']))
+			elseif (($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['eval']['isAssociative'] ?? null) || ArrayUtil::isAssoc($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['options'] ?? array()))
 			{
 				$remoteNew = $GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['options'][$value];
 			}
@@ -6095,11 +6095,11 @@ class DC_Table extends DataContainer implements \listable, \editable
 	{
 		static $lookup = array();
 
-		if ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['eval']['isAssociative'] || ArrayUtil::isAssoc($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['options']))
+		if (($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['eval']['isAssociative'] ?? null) || ArrayUtil::isAssoc($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['options'] ?? array()))
 		{
 			$group = $GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['options'][$value];
 		}
-		elseif (\is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['options_callback']))
+		elseif (\is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['options_callback'] ?? null))
 		{
 			if (!isset($lookup[$field]))
 			{
@@ -6126,14 +6126,14 @@ class DC_Table extends DataContainer implements \listable, \editable
 		{
 			$group = $value;
 
-			if ($value != '-' && $GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['eval']['isBoolean'])
+			if ($value != '-' && ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['eval']['isBoolean'] ?? null))
 			{
 				$group = \is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['label']) ? $GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['label'][0] : $GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['label'];
 			}
 		}
 
 		// Call the group callback ($group, $sortingMode, $firstOrderBy, $row, $this)
-		if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['group_callback']))
+		if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['group_callback'] ?? null))
 		{
 			$strClass = $GLOBALS['TL_DCA'][$this->strTable]['list']['label']['group_callback'][0];
 			$strMethod = $GLOBALS['TL_DCA'][$this->strTable]['list']['label']['group_callback'][1];
@@ -6141,7 +6141,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 			$this->import($strClass);
 			$group = $this->$strClass->$strMethod($group, $mode, $field, $row, $this);
 		}
-		elseif (\is_callable($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['group_callback']))
+		elseif (\is_callable($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['group_callback'] ?? null))
 		{
 			$group = $GLOBALS['TL_DCA'][$this->strTable]['list']['label']['group_callback']($group, $mode, $field, $row, $this);
 		}

--- a/core-bundle/src/Resources/contao/elements/ContentAccordion.php
+++ b/core-bundle/src/Resources/contao/elements/ContentAccordion.php
@@ -33,6 +33,7 @@ class ContentAccordion extends ContentElement
 
 		$this->Template->text = StringUtil::encodeEmail($this->text);
 		$this->Template->addImage = false;
+		$this->Template->addBefore = false;
 
 		// Add an image
 		if ($this->addImage && $this->singleSRC)

--- a/core-bundle/src/Resources/contao/elements/ContentAccordion.php
+++ b/core-bundle/src/Resources/contao/elements/ContentAccordion.php
@@ -48,8 +48,8 @@ class ContentAccordion extends ContentElement
 
 		$classes = StringUtil::deserialize($this->mooClasses);
 
-		$this->Template->toggler = $classes[0] ?? 'toggler';
-		$this->Template->accordion = $classes[1] ?? 'accordion';
+		$this->Template->toggler = $classes[0] ?: 'toggler';
+		$this->Template->accordion = $classes[1] ?: 'accordion';
 		$this->Template->headlineStyle = $this->mooStyle;
 		$this->Template->headline = $this->mooHeadline;
 	}

--- a/core-bundle/src/Resources/contao/elements/ContentAccordion.php
+++ b/core-bundle/src/Resources/contao/elements/ContentAccordion.php
@@ -48,8 +48,8 @@ class ContentAccordion extends ContentElement
 
 		$classes = StringUtil::deserialize($this->mooClasses);
 
-		$this->Template->toggler = $classes[0] ?: 'toggler';
-		$this->Template->accordion = $classes[1] ?: 'accordion';
+		$this->Template->toggler = $classes[0] ?? 'toggler';
+		$this->Template->accordion = $classes[1] ?? 'accordion';
 		$this->Template->headlineStyle = $this->mooStyle;
 		$this->Template->headline = $this->mooHeadline;
 	}

--- a/core-bundle/src/Resources/contao/elements/ContentAccordionStart.php
+++ b/core-bundle/src/Resources/contao/elements/ContentAccordionStart.php
@@ -40,8 +40,8 @@ class ContentAccordionStart extends ContentElement
 
 		$classes = StringUtil::deserialize($this->mooClasses);
 
-		$this->Template->toggler = $classes[0] ?: 'toggler';
-		$this->Template->accordion = $classes[1] ?: 'accordion';
+		$this->Template->toggler = $classes[0] ?? 'toggler';
+		$this->Template->accordion = $classes[1] ?? 'accordion';
 		$this->Template->headlineStyle = $this->mooStyle;
 		$this->Template->headline = $this->mooHeadline;
 	}

--- a/core-bundle/src/Resources/contao/elements/ContentAccordionStart.php
+++ b/core-bundle/src/Resources/contao/elements/ContentAccordionStart.php
@@ -40,8 +40,8 @@ class ContentAccordionStart extends ContentElement
 
 		$classes = StringUtil::deserialize($this->mooClasses);
 
-		$this->Template->toggler = $classes[0] ?? 'toggler';
-		$this->Template->accordion = $classes[1] ?? 'accordion';
+		$this->Template->toggler = $classes[0] ?: 'toggler';
+		$this->Template->accordion = $classes[1] ?: 'accordion';
 		$this->Template->headlineStyle = $this->mooStyle;
 		$this->Template->headline = $this->mooHeadline;
 	}

--- a/core-bundle/src/Resources/contao/elements/ContentAlias.php
+++ b/core-bundle/src/Resources/contao/elements/ContentAlias.php
@@ -56,7 +56,7 @@ class ContentAlias extends ContentElement
 		// Merge the CSS classes (see #6011)
 		if (!empty($this->cssID[1]))
 		{
-			$cssID[1] = trim($cssID[1] . ' ' . $this->cssID[1]);
+			$cssID[1] = trim(($cssID[1] ?? '') . ' ' . $this->cssID[1]);
 		}
 
 		$objElement->cssID = $cssID;

--- a/core-bundle/src/Resources/contao/elements/ContentDownloads.php
+++ b/core-bundle/src/Resources/contao/elements/ContentDownloads.php
@@ -141,7 +141,7 @@ class ContentDownloads extends ContentElement
 				}
 
 				// Use the file name as title if none is given
-				if (!$arrMeta['title'])
+				if (empty($arrMeta['title']))
 				{
 					$arrMeta['title'] = StringUtil::specialchars($objFile->basename);
 				}
@@ -168,8 +168,8 @@ class ContentDownloads extends ContentElement
 					'uuid'      => $objFiles->uuid,
 					'name'      => $objFile->basename,
 					'title'     => StringUtil::specialchars(sprintf($GLOBALS['TL_LANG']['MSC']['download'], $objFile->basename)),
-					'link'      => $arrMeta['title'],
-					'caption'   => $arrMeta['caption'],
+					'link'      => $arrMeta['title'] ?? null,
+					'caption'   => $arrMeta['caption'] ?? null,
 					'href'      => $strHref,
 					'filesize'  => $this->getReadableSize($objFile->filesize),
 					'icon'      => Image::getPath($objFile->icon),

--- a/core-bundle/src/Resources/contao/elements/ContentElement.php
+++ b/core-bundle/src/Resources/contao/elements/ContentElement.php
@@ -253,7 +253,7 @@ abstract class ContentElement extends Frontend
 
 		// Do not change this order (see #6191)
 		$this->Template->style = !empty($this->arrStyle) ? implode(' ', $this->arrStyle) : '';
-		$this->Template->class = !empty($this->cssID[1]) ? trim('ce_' . $this->type . ' ' . $this->cssID[1]) : '';
+		$this->Template->class = trim('ce_' . $this->type . ' ' . ($this->cssID[1] ?? ''));
 		$this->Template->cssID = !empty($this->cssID[0]) ? ' id="' . $this->cssID[0] . '"' : '';
 
 		$this->Template->inColumn = $this->strColumn;

--- a/core-bundle/src/Resources/contao/elements/ContentElement.php
+++ b/core-bundle/src/Resources/contao/elements/ContentElement.php
@@ -253,7 +253,7 @@ abstract class ContentElement extends Frontend
 
 		// Do not change this order (see #6191)
 		$this->Template->style = !empty($this->arrStyle) ? implode(' ', $this->arrStyle) : '';
-		$this->Template->class = trim('ce_' . $this->type . ' ' . $this->cssID[1]);
+		$this->Template->class = !empty($this->cssID[1]) ? trim('ce_' . $this->type . ' ' . $this->cssID[1]) : '';
 		$this->Template->cssID = !empty($this->cssID[0]) ? ' id="' . $this->cssID[0] . '"' : '';
 
 		$this->Template->inColumn = $this->strColumn;

--- a/core-bundle/src/Resources/contao/elements/ContentGallery.php
+++ b/core-bundle/src/Resources/contao/elements/ContentGallery.php
@@ -269,6 +269,7 @@ class ContentGallery extends ContentElement
 				// Empty cell
 				if (($j+$i) >= $limit || !\is_array($images[($i+$j)]))
 				{
+					$objCell->addImage = false;
 					$objCell->colWidth = $colwidth . '%';
 					$objCell->class = 'col_' . $j . $class_td;
 				}

--- a/core-bundle/src/Resources/contao/elements/ContentHyperlink.php
+++ b/core-bundle/src/Resources/contao/elements/ContentHyperlink.php
@@ -63,8 +63,8 @@ class ContentHyperlink extends ContentElement
 		}
 
 		$this->Template->href = $this->url;
-		$this->Template->embed_pre = $embed[0];
-		$this->Template->embed_post = $embed[1];
+		$this->Template->embed_pre = $embed[0] ?? null;
+		$this->Template->embed_post = $embed[1] ?? null;
 		$this->Template->link = $this->linkTitle;
 		$this->Template->target = '';
 		$this->Template->rel = '';

--- a/core-bundle/src/Resources/contao/elements/ContentModule.php
+++ b/core-bundle/src/Resources/contao/elements/ContentModule.php
@@ -54,7 +54,7 @@ class ContentModule extends ContentElement
 		// Merge the CSS classes (see #6011)
 		if (!empty($this->cssID[1]))
 		{
-			$cssID[1] = trim($cssID[1] . ' ' . $this->cssID[1]);
+			$cssID[1] = trim(($cssID[1] ?? '') . ' ' . $this->cssID[1]);
 		}
 
 		// Clone the model so we do not modify the shared model in the registry

--- a/core-bundle/src/Resources/contao/elements/ContentText.php
+++ b/core-bundle/src/Resources/contao/elements/ContentText.php
@@ -39,6 +39,7 @@ class ContentText extends ContentElement
 
 		$this->Template->text = StringUtil::encodeEmail($this->text);
 		$this->Template->addImage = false;
+		$this->Template->addBefore = false;
 
 		// Add an image
 		if ($this->addImage && $this->singleSRC)

--- a/core-bundle/src/Resources/contao/forms/Form.php
+++ b/core-bundle/src/Resources/contao/forms/Form.php
@@ -153,7 +153,7 @@ class Form extends Hybrid
 			foreach ($arrFields as $objField)
 			{
 				/** @var FormFieldModel $objField */
-				$strClass = $GLOBALS['TL_FFL'][$objField->type];
+				$strClass = $GLOBALS['TL_FFL'][$objField->type] ?? null;
 
 				// Continue if the class is not defined
 				if (!class_exists($strClass))
@@ -495,7 +495,7 @@ class Form extends Hybrid
 			{
 				foreach ($_SESSION['FILES'] as $k=>$v)
 				{
-					if ($v['uploaded'])
+					if ($v['uploaded'] ?? null)
 					{
 						$arrSet[$k] = StringUtil::stripRootDir($v['tmp_name']);
 					}

--- a/core-bundle/src/Resources/contao/forms/Form.php
+++ b/core-bundle/src/Resources/contao/forms/Form.php
@@ -183,7 +183,7 @@ class Form extends Hybrid
 				}
 
 				// Unset the default value depending on the field type (see #4722)
-				if (!empty($arrData['value']) && !\in_array('value', StringUtil::trimsplit('[,;]', $GLOBALS['TL_DCA']['tl_form_field']['palettes'][$objField->type])))
+				if (!empty($arrData['value']) && !\in_array('value', StringUtil::trimsplit('[,;]', $GLOBALS['TL_DCA']['tl_form_field']['palettes'][$objField->type] ?? '')))
 				{
 					$arrData['value'] = '';
 				}
@@ -517,7 +517,7 @@ class Form extends Hybrid
 			{
 				if ($v === '')
 				{
-					$arrSet[$k] = Widget::getEmptyValueByFieldType($GLOBALS['TL_DCA'][$this->targetTable]['fields'][$k]['sql']);
+					$arrSet[$k] = Widget::getEmptyValueByFieldType($GLOBALS['TL_DCA'][$this->targetTable]['fields'][$k]['sql'] ?? array());
 				}
 			}
 

--- a/core-bundle/src/Resources/contao/forms/Form.php
+++ b/core-bundle/src/Resources/contao/forms/Form.php
@@ -596,11 +596,11 @@ class Form extends Hybrid
 		}
 
 		$arrMessageBox = array('TL_ERROR', 'TL_CONFIRM', 'TL_INFO');
-		$_SESSION['FORM_DATA'] = \is_array($_SESSION['FORM_DATA']) ? $_SESSION['FORM_DATA'] : array();
+		$_SESSION['FORM_DATA'] = \is_array($_SESSION['FORM_DATA'] ?? null) ? $_SESSION['FORM_DATA'] : array();
 
 		foreach ($arrMessageBox as $tl)
 		{
-			if (\is_array($_SESSION[$formId][$tl]))
+			if (\is_array($_SESSION[$formId][$tl] ?? null))
 			{
 				$_SESSION[$formId][$tl] = array_unique($_SESSION[$formId][$tl]);
 

--- a/core-bundle/src/Resources/contao/forms/FormCheckBox.php
+++ b/core-bundle/src/Resources/contao/forms/FormCheckBox.php
@@ -170,7 +170,7 @@ class FormCheckBox extends Widget
 
 		foreach ($this->arrOptions as $i=>$arrOption)
 		{
-			if ($arrOption['group'])
+			if ($arrOption['group'] ?? null)
 			{
 				if ($blnHasGroups)
 				{
@@ -183,7 +183,7 @@ class FormCheckBox extends Widget
 				$arrOptions[] = array
 				(
 					'type'  => 'group_start',
-					'label' => StringUtil::specialchars($arrOption['label'])
+					'label' => StringUtil::specialchars($arrOption['label'] ?? '')
 				);
 
 				$blnHasGroups = true;
@@ -198,10 +198,10 @@ class FormCheckBox extends Widget
 						'type'       => 'option',
 						'name'       => $this->strName . ((\count($this->arrOptions) > 1) ? '[]' : ''),
 						'id'         => $this->strId . '_' . $i,
-						'value'      => $arrOption['value'],
+						'value'      => $arrOption['value'] ?? null,
 						'checked'    => $this->isChecked($arrOption),
 						'attributes' => $this->getAttributes(),
-						'label'      => $arrOption['label']
+						'label'      => $arrOption['label'] ?? null
 					)
 				);
 			}
@@ -247,13 +247,13 @@ class FormCheckBox extends Widget
 				'<span><input type="checkbox" name="%s" id="opt_%s" class="checkbox" value="%s"%s%s%s <label id="lbl_%s" for="opt_%s">%s</label></span> ',
 				$this->strName . ((\count($this->arrOptions) > 1) ? '[]' : ''),
 				$this->strId . '_' . $i,
-				$arrOption['value'],
+				$arrOption['value'] ?? null,
 				$this->isChecked($arrOption),
 				$this->getAttributes(),
 				$this->strTagEnding,
 				$this->strId . '_' . $i,
 				$this->strId . '_' . $i,
-				$arrOption['label']
+				$arrOption['label'] ?? null
 			);
 		}
 

--- a/core-bundle/src/Resources/contao/forms/FormRadioButton.php
+++ b/core-bundle/src/Resources/contao/forms/FormRadioButton.php
@@ -134,7 +134,7 @@ class FormRadioButton extends Widget
 
 		foreach ($this->arrOptions as $i=>$arrOption)
 		{
-			if ($arrOption['group'])
+			if ($arrOption['group'] ?? null)
 			{
 				if ($blnHasGroups)
 				{
@@ -147,7 +147,7 @@ class FormRadioButton extends Widget
 				$arrOptions[] = array
 				(
 					'type'  => 'group_start',
-					'label' => StringUtil::specialchars($arrOption['label'])
+					'label' => StringUtil::specialchars($arrOption['label'] ?? '')
 				);
 
 				$blnHasGroups = true;
@@ -162,10 +162,10 @@ class FormRadioButton extends Widget
 						'type'       => 'option',
 						'name'       => $this->strName,
 						'id'         => $this->strId . '_' . $i,
-						'value'      => $arrOption['value'],
+						'value'      => $arrOption['value'] ?? null,
 						'checked'    => $this->isChecked($arrOption),
 						'attributes' => $this->getAttributes(),
-						'label'      => $arrOption['label']
+						'label'      => $arrOption['label'] ?? null
 					)
 				);
 			}
@@ -211,13 +211,13 @@ class FormRadioButton extends Widget
 				'<span><input type="radio" name="%s" id="opt_%s" class="radio" value="%s"%s%s%s <label id="lbl_%s" for="opt_%s">%s</label></span> ',
 				$this->strName,
 				$this->strId . '_' . $i,
-				$arrOption['value'],
+				$arrOption['value'] ?? null,
 				$this->isChecked($arrOption),
 				$this->getAttributes(),
 				$this->strTagEnding,
 				$this->strId . '_' . $i,
 				$this->strId . '_' . $i,
-				$arrOption['label']
+				$arrOption['label'] ?? null
 			);
 		}
 

--- a/core-bundle/src/Resources/contao/forms/FormSelectMenu.php
+++ b/core-bundle/src/Resources/contao/forms/FormSelectMenu.php
@@ -229,7 +229,7 @@ class FormSelectMenu extends Widget
 		// Generate options
 		foreach ($this->arrOptions as $arrOption)
 		{
-			if ($arrOption['group'])
+			if ($arrOption['group'] ?? null)
 			{
 				if ($blnHasGroups)
 				{
@@ -242,7 +242,7 @@ class FormSelectMenu extends Widget
 				$arrOptions[] = array
 				(
 					'type'  => 'group_start',
-					'label' => StringUtil::specialchars($arrOption['label'])
+					'label' => StringUtil::specialchars($arrOption['label'] ?? '')
 				);
 
 				$blnHasGroups = true;
@@ -255,9 +255,9 @@ class FormSelectMenu extends Widget
 					array
 					(
 						'type'     => 'option',
-						'value'    => $arrOption['value'],
+						'value'    => $arrOption['value'] ?? null,
 						'selected' => $this->isSelected($arrOption),
-						'label'    => $arrOption['label'],
+						'label'    => $arrOption['label'] ?? null
 					)
 				);
 			}
@@ -303,23 +303,23 @@ class FormSelectMenu extends Widget
 
 		foreach ($this->arrOptions as $arrOption)
 		{
-			if ($arrOption['group'])
+			if ($arrOption['group'] ?? null)
 			{
 				if ($blnHasGroups)
 				{
 					$strOptions .= '</optgroup>';
 				}
 
-				$strOptions .= sprintf('<optgroup label="%s">', StringUtil::specialchars($arrOption['label']));
+				$strOptions .= sprintf('<optgroup label="%s">', StringUtil::specialchars($arrOption['label'] ?? ''));
 				$blnHasGroups = true;
 				continue;
 			}
 
 			$strOptions .= sprintf(
 				'<option value="%s"%s>%s</option>',
-				$arrOption['value'],
+				$arrOption['value'] ?? null,
 				$this->isSelected($arrOption),
-				$arrOption['label']
+				$arrOption['label'] ?? null
 			);
 		}
 

--- a/core-bundle/src/Resources/contao/library/Contao/ArrayUtil.php
+++ b/core-bundle/src/Resources/contao/library/Contao/ArrayUtil.php
@@ -47,7 +47,7 @@ class ArrayUtil
 	/**
 	 * Return true if an array is associative
 	 *
-	 * @param array $arrArray
+	 * @param mixed $arrArray
 	 *
 	 * @return boolean
 	 */

--- a/core-bundle/src/Resources/contao/library/Contao/Controller.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Controller.php
@@ -1697,7 +1697,7 @@ abstract class Controller extends System
 			->build();
 
 		// Build result and apply it to the template
-		$figure->applyLegacyTemplateData($template, $margin, $rowData['floating'] ?: null, $includeFullMetadata);
+		$figure->applyLegacyTemplateData($template, $margin, $rowData['floating'] ?? null, $includeFullMetadata);
 
 		// Fall back to manually specified link title or empty string if not set (backwards compatibility)
 		$template->linkTitle = $template->linkTitle ?? StringUtil::specialchars($rowData['title'] ?? '');

--- a/core-bundle/src/Resources/contao/library/Contao/Controller.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Controller.php
@@ -1513,7 +1513,7 @@ abstract class Controller extends System
 				Metadata::VALUE_ALT => $rowData['alt'] ?? '',
 				Metadata::VALUE_TITLE => $rowData['imageTitle'] ?? '',
 				Metadata::VALUE_URL => self::replaceInsertTags($rowData['imageUrl'] ?? ''),
-				'linkTitle' => $rowData['linkTitle'] ?: '',
+				'linkTitle' => $rowData['linkTitle'] ?? '',
 			));
 		};
 
@@ -1697,7 +1697,7 @@ abstract class Controller extends System
 			->build();
 
 		// Build result and apply it to the template
-		$figure->applyLegacyTemplateData($template, $margin, $rowData['floating'] ?: null, $includeFullMetadata);
+		$figure->applyLegacyTemplateData($template, $margin, $rowData['floating'] ?? null, $includeFullMetadata);
 
 		// Fall back to manually specified link title or empty string if not set (backwards compatibility)
 		$template->linkTitle = $template->linkTitle ?? StringUtil::specialchars($rowData['title'] ?? '');

--- a/core-bundle/src/Resources/contao/library/Contao/Controller.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Controller.php
@@ -1513,7 +1513,7 @@ abstract class Controller extends System
 				Metadata::VALUE_ALT => $rowData['alt'] ?? '',
 				Metadata::VALUE_TITLE => $rowData['imageTitle'] ?? '',
 				Metadata::VALUE_URL => self::replaceInsertTags($rowData['imageUrl'] ?? ''),
-				'linkTitle' => $rowData['linkTitle'] ?? '',
+				'linkTitle' => $rowData['linkTitle'] ?: '',
 			));
 		};
 
@@ -1697,7 +1697,7 @@ abstract class Controller extends System
 			->build();
 
 		// Build result and apply it to the template
-		$figure->applyLegacyTemplateData($template, $margin, $rowData['floating'] ?? null, $includeFullMetadata);
+		$figure->applyLegacyTemplateData($template, $margin, $rowData['floating'] ?: null, $includeFullMetadata);
 
 		// Fall back to manually specified link title or empty string if not set (backwards compatibility)
 		$template->linkTitle = $template->linkTitle ?? StringUtil::specialchars($rowData['title'] ?? '');

--- a/core-bundle/src/Resources/contao/library/Contao/Database/Updater.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Database/Updater.php
@@ -691,7 +691,7 @@ class Updater extends Controller
 			// Handle meta.txt files
 			if (preg_match('/^meta(_([a-z]{2}))?\.txt$/', basename($strFile), $matches))
 			{
-				$key = $matches[2] ?? 'en';
+				$key = $matches[2] ?: 'en';
 				$arrData = file($projectDir . '/' . $strFile, FILE_IGNORE_NEW_LINES);
 
 				foreach ($arrData as $line)

--- a/core-bundle/src/Resources/contao/library/Contao/Database/Updater.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Database/Updater.php
@@ -691,7 +691,7 @@ class Updater extends Controller
 			// Handle meta.txt files
 			if (preg_match('/^meta(_([a-z]{2}))?\.txt$/', basename($strFile), $matches))
 			{
-				$key = $matches[2] ?: 'en';
+				$key = $matches[2] ?? 'en';
 				$arrData = file($projectDir . '/' . $strFile, FILE_IGNORE_NEW_LINES);
 
 				foreach ($arrData as $line)
@@ -782,7 +782,7 @@ class Updater extends Controller
 					{
 						if ($this->Database->fieldExists($strField, $strTable, true))
 						{
-							$key = $arrField['eval']['multiple'] ? 'multiple' : 'single';
+							$key = ($arrField['eval']['multiple'] ?? null) ? 'multiple' : 'single';
 							$arrFields[$key][] = $strTable . '.' . $strField;
 						}
 

--- a/core-bundle/src/Resources/contao/library/Contao/Database/Updater.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Database/Updater.php
@@ -774,7 +774,7 @@ class Updater extends Controller
 			}
 
 			// Make sure there are fields (see #6437)
-			if (\is_array($GLOBALS['TL_DCA'][$strTable]['fields']))
+			if (\is_array($GLOBALS['TL_DCA'][$strTable]['fields'] ?? null))
 			{
 				foreach ($GLOBALS['TL_DCA'][$strTable]['fields'] as $strField=>$arrField)
 				{

--- a/core-bundle/src/Resources/contao/library/Contao/DcaExtractor.php
+++ b/core-bundle/src/Resources/contao/library/Contao/DcaExtractor.php
@@ -378,13 +378,13 @@ class DcaExtractor extends Controller
 		}
 
 		// Return if the DC type is "File"
-		if ($GLOBALS['TL_DCA'][$this->strTable]['config']['dataContainer'] == 'File')
+		if (($GLOBALS['TL_DCA'][$this->strTable]['config']['dataContainer'] ?? null) == 'File')
 		{
 			return;
 		}
 
 		// Return if the DC type is "Folder" and the DC is not database assisted
-		if ($GLOBALS['TL_DCA'][$this->strTable]['config']['dataContainer'] == 'Folder' && empty($GLOBALS['TL_DCA'][$this->strTable]['config']['databaseAssisted']))
+		if (($GLOBALS['TL_DCA'][$this->strTable]['config']['dataContainer'] ?? null) == 'Folder' && empty($GLOBALS['TL_DCA'][$this->strTable]['config']['databaseAssisted']))
 		{
 			return;
 		}

--- a/core-bundle/src/Resources/contao/library/Contao/DcaLoader.php
+++ b/core-bundle/src/Resources/contao/library/Contao/DcaLoader.php
@@ -191,7 +191,7 @@ class DcaLoader extends Controller
 	 */
 	private function setDynamicPTable(): void
 	{
-		if (!($GLOBALS['TL_DCA'][$this->strTable]['config']['dynamicPtable'] ?? false) || !isset($GLOBALS['BE_MOD']))
+		if (!($GLOBALS['TL_DCA'][$this->strTable]['config']['dynamicPtable'] ?? null) || !isset($GLOBALS['BE_MOD']))
 		{
 			return;
 		}

--- a/core-bundle/src/Resources/contao/library/Contao/File.php
+++ b/core-bundle/src/Resources/contao/library/Contao/File.php
@@ -301,10 +301,10 @@ class File extends System
 				return $this->arrImageSize;
 
 			case 'width':
-				return $this->imageSize[0];
+				return $this->imageSize[0] ?? null;
 
 			case 'height':
-				return $this->imageSize[1];
+				return $this->imageSize[1] ?? null;
 
 			case 'imageViewSize':
 				if (empty($this->arrImageViewSize))

--- a/core-bundle/src/Resources/contao/library/Contao/GdImage.php
+++ b/core-bundle/src/Resources/contao/library/Contao/GdImage.php
@@ -187,7 +187,7 @@ class GdImage
 			case 'jpg':
 			case 'jpeg':
 				imageinterlace($this->gdResource, 1); // see #6529
-				imagejpeg($this->gdResource, $path, (System::getContainer()->getParameter('contao.image.imagine_options')['jpeg_quality'] ?: 80));
+				imagejpeg($this->gdResource, $path, (System::getContainer()->getParameter('contao.image.imagine_options')['jpeg_quality'] ?? 80));
 				break;
 
 			case 'png':

--- a/core-bundle/src/Resources/contao/library/Contao/GdImage.php
+++ b/core-bundle/src/Resources/contao/library/Contao/GdImage.php
@@ -187,7 +187,7 @@ class GdImage
 			case 'jpg':
 			case 'jpeg':
 				imageinterlace($this->gdResource, 1); // see #6529
-				imagejpeg($this->gdResource, $path, (System::getContainer()->getParameter('contao.image.imagine_options')['jpeg_quality'] ?? 80));
+				imagejpeg($this->gdResource, $path, (System::getContainer()->getParameter('contao.image.imagine_options')['jpeg_quality'] ?: 80));
 				break;
 
 			case 'png':

--- a/core-bundle/src/Resources/contao/library/Contao/InsertTags.php
+++ b/core-bundle/src/Resources/contao/library/Contao/InsertTags.php
@@ -127,7 +127,7 @@ class InsertTags extends Controller
 			// Skip certain elements if the output will be cached
 			if ($blnCache)
 			{
-				if ($elements[0] == 'date' || $elements[0] == 'ua' || $elements[0] == 'post' || $elements[1] == 'back' || $elements[1] == 'referer' || \in_array('uncached', $flags) || strncmp($elements[0], 'cache_', 6) === 0)
+				if ($elements[0] == 'date' || $elements[0] == 'ua' || $elements[0] == 'post' || ($elements[1] ?? null) == 'back' || ($elements[1] ?? null) == 'referer' || \in_array('uncached', $flags) || strncmp($elements[0], 'cache_', 6) === 0)
 				{
 					/** @var FragmentHandler $fragmentHandler */
 					$fragmentHandler = $container->get('fragment.handler');
@@ -163,7 +163,7 @@ class InsertTags extends Controller
 			{
 				// Date
 				case 'date':
-					$arrCache[$strTag] = Date::parse($elements[1] ?: Config::get('dateFormat'));
+					$arrCache[$strTag] = Date::parse($elements[1] ?? Config::get('dateFormat'));
 					break;
 
 				// Accessibility tags
@@ -316,9 +316,9 @@ class InsertTags extends Controller
 							$value = Encryption::decrypt($value);
 						}
 
-						$rgxp = $GLOBALS['TL_DCA']['tl_member']['fields'][$elements[1]]['eval']['rgxp'];
-						$opts = $GLOBALS['TL_DCA']['tl_member']['fields'][$elements[1]]['options'];
-						$rfrc = $GLOBALS['TL_DCA']['tl_member']['fields'][$elements[1]]['reference'];
+						$rgxp = $GLOBALS['TL_DCA']['tl_member']['fields'][$elements[1]]['eval']['rgxp'] ?? null;
+						$opts = $GLOBALS['TL_DCA']['tl_member']['fields'][$elements[1]]['options'] ?? null;
+						$rfrc = $GLOBALS['TL_DCA']['tl_member']['fields'][$elements[1]]['reference'] ?? null;
 
 						if ($rgxp == 'date')
 						{

--- a/core-bundle/src/Resources/contao/library/Contao/InsertTags.php
+++ b/core-bundle/src/Resources/contao/library/Contao/InsertTags.php
@@ -163,7 +163,7 @@ class InsertTags extends Controller
 			{
 				// Date
 				case 'date':
-					$arrCache[$strTag] = Date::parse($elements[1] ?? Config::get('dateFormat'));
+					$arrCache[$strTag] = Date::parse($elements[1] ?: Config::get('dateFormat'));
 					break;
 
 				// Accessibility tags

--- a/core-bundle/src/Resources/contao/library/Contao/InsertTags.php
+++ b/core-bundle/src/Resources/contao/library/Contao/InsertTags.php
@@ -302,7 +302,7 @@ class InsertTags extends Controller
 
 						$this->loadDataContainer('tl_member');
 
-						if ($GLOBALS['TL_DCA']['tl_member']['fields'][$elements[1]]['inputType'] == 'password')
+						if (($GLOBALS['TL_DCA']['tl_member']['fields'][$elements[1]]['inputType'] ?? null) == 'password')
 						{
 							$arrCache[$strTag] = '';
 							break;
@@ -311,7 +311,7 @@ class InsertTags extends Controller
 						$value = StringUtil::deserialize($value);
 
 						// Decrypt the value
-						if ($GLOBALS['TL_DCA']['tl_member']['fields'][$elements[1]]['eval']['encrypt'])
+						if ($GLOBALS['TL_DCA']['tl_member']['fields'][$elements[1]]['eval']['encrypt'] ?? null)
 						{
 							$value = Encryption::decrypt($value);
 						}

--- a/core-bundle/src/Resources/contao/library/Contao/Model.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Model.php
@@ -1027,7 +1027,7 @@ abstract class Model
 		}
 
 		// Try to load from the registry
-		if ($arrOptions['return'] == 'Model')
+		if (($arrOptions['return'] ?? null) == 'Model')
 		{
 			$arrColumn = (array) $arrOptions['column'];
 
@@ -1072,17 +1072,17 @@ abstract class Model
 		}
 
 		$objStatement = static::preFind($objStatement);
-		$objResult = $objStatement->execute($arrOptions['value']);
+		$objResult = $objStatement->execute($arrOptions['value'] ?? null);
 
 		if ($objResult->numRows < 1)
 		{
-			return $arrOptions['return'] == 'Array' ? array() : null;
+			return ($arrOptions['return'] ?? null) == 'Array' ? array() : null;
 		}
 
 		$objResult = static::postFind($objResult);
 
 		// Try to load from the registry
-		if ($arrOptions['return'] == 'Model')
+		if (($arrOptions['return'] ?? null) == 'Model')
 		{
 			$objModel = Registry::getInstance()->fetch(static::$strTable, $objResult->{static::$strPk});
 
@@ -1094,7 +1094,7 @@ abstract class Model
 			return static::createModelFromDbResult($objResult);
 		}
 
-		if ($arrOptions['return'] == 'Array')
+		if (($arrOptions['return'] ?? null) == 'Array')
 		{
 			return static::createCollectionFromDbResult($objResult, static::$strTable)->getModels();
 		}

--- a/core-bundle/src/Resources/contao/library/Contao/Model/QueryBuilder.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Model/QueryBuilder.php
@@ -45,7 +45,7 @@ class QueryBuilder
 			foreach ($objBase->getRelations() as $strKey=>$arrConfig)
 			{
 				// Automatically join the single-relation records
-				if ($arrConfig['load'] == 'eager' || $arrOptions['eager'])
+				if ($arrConfig['load'] == 'eager' || ($arrOptions['eager'] ?? null))
 				{
 					if ($arrConfig['type'] == 'hasOne' || $arrConfig['type'] == 'belongsTo')
 					{
@@ -105,7 +105,7 @@ class QueryBuilder
 	{
 		$strQuery = "SELECT COUNT(*) AS count FROM " . $arrOptions['table'];
 
-		if ($arrOptions['column'] !== null)
+		if (isset($arrOptions['column']))
 		{
 			$strQuery .= " WHERE " . (\is_array($arrOptions['column']) ? implode(" AND ", $arrOptions['column']) : $arrOptions['table'] . '.' . Database::quoteIdentifier($arrOptions['column']) . "=?");
 		}

--- a/core-bundle/src/Resources/contao/library/Contao/Widget.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Widget.php
@@ -233,7 +233,7 @@ abstract class Widget extends Controller
 				$this->varValue = StringUtil::deserialize($varValue);
 
 				// Decrypt the value if it is encrypted
-				if ($this->arrConfiguration['encrypt'])
+				if ($this->arrConfiguration['encrypt'] ?? null)
 				{
 					$this->varValue = Encryption::decrypt($this->varValue);
 				}
@@ -1113,12 +1113,12 @@ abstract class Widget extends Controller
 	 */
 	protected function isChecked($arrOption)
 	{
-		if (empty($this->varValue) && empty($_POST) && $arrOption['default'])
+		if (empty($this->varValue) && empty($_POST) && ($arrOption['default'] ?? null))
 		{
 			return static::optionChecked(1, 1);
 		}
 
-		return static::optionChecked($arrOption['value'], $this->varValue);
+		return static::optionChecked($arrOption['value'] ?? null, $this->varValue);
 	}
 
 	/**
@@ -1130,12 +1130,12 @@ abstract class Widget extends Controller
 	 */
 	protected function isSelected($arrOption)
 	{
-		if (empty($this->varValue) && empty($_POST) && $arrOption['default'])
+		if (empty($this->varValue) && empty($_POST) && ($arrOption['default'] ?? null))
 		{
 			return static::optionSelected(1, 1);
 		}
 
-		return static::optionSelected($arrOption['value'], $this->varValue);
+		return static::optionSelected($arrOption['value'] ?? null, $this->varValue);
 	}
 
 	/**
@@ -1256,11 +1256,11 @@ abstract class Widget extends Controller
 		{
 			if (($arrData['inputType'] ?? null) == 'checkbox' || ($arrData['inputType'] ?? null) == 'checkboxWizard' || ($arrData['inputType'] ?? null) == 'radio' || ($arrData['inputType'] ?? null) == 'radioTable')
 			{
-				$arrAttributes['onclick'] = trim($arrAttributes['onclick'] . " Backend.autoSubmit('" . $strTable . "')");
+				$arrAttributes['onclick'] = trim(($arrAttributes['onclick'] ?? '') . " Backend.autoSubmit('" . $strTable . "')");
 			}
 			else
 			{
-				$arrAttributes['onchange'] = trim($arrAttributes['onchange'] . " Backend.autoSubmit('" . $strTable . "')");
+				$arrAttributes['onchange'] = trim(($arrAttributes['onchange'] ?? '') . " Backend.autoSubmit('" . $strTable . "')");
 			}
 		}
 
@@ -1318,7 +1318,7 @@ abstract class Widget extends Controller
 		// Add options
 		if (\is_array($arrData['options'] ?? null))
 		{
-			$blnIsAssociative = ($arrData['eval']['isAssociative'] ?? null) || ArrayUtil::isAssoc($arrData['options'] ?? array());
+			$blnIsAssociative = ($arrData['eval']['isAssociative'] ?? null) || ArrayUtil::isAssoc($arrData['options'] ?? null);
 			$blnUseReference = isset($arrData['reference']);
 
 			if (($arrData['eval']['includeBlankOption'] ?? null) && !($arrData['eval']['multiple'] ?? null))
@@ -1340,11 +1340,11 @@ abstract class Widget extends Controller
 						unset($unknown[$i]);
 					}
 
-					$arrAttributes['options'][] = array('value'=>$value, 'label'=>($blnUseReference ? ((($ref = (\is_array($arrData['reference'][$v]) ? $arrData['reference'][$v][0] : $arrData['reference'][$v])) != false) ? $ref : $v) : $v));
+					$arrAttributes['options'][] = array('value'=>$value, 'label'=>($blnUseReference && isset($arrData['reference'][$v]) ? ((($ref = (\is_array($arrData['reference'][$v]) ? $arrData['reference'][$v][0] : $arrData['reference'][$v])) != false) ? $ref : $v) : $v));
 					continue;
 				}
 
-				$key = $blnUseReference ? ((($ref = (\is_array($arrData['reference'][$k]) ? $arrData['reference'][$k][0] : $arrData['reference'][$k])) != false) ? $ref : $k) : $k;
+				$key = $blnUseReference && isset($arrData['reference'][$k]) ? ((($ref = (\is_array($arrData['reference'][$k]) ? $arrData['reference'][$k][0] : $arrData['reference'][$k])) != false) ? $ref : $k) : $k;
 				$blnIsAssoc = ArrayUtil::isAssoc($v);
 
 				foreach ($v as $kk=>$vv)
@@ -1356,14 +1356,14 @@ abstract class Widget extends Controller
 						unset($unknown[$i]);
 					}
 
-					$arrAttributes['options'][$key][] = array('value'=>$value, 'label'=>($blnUseReference ? ((($ref = (\is_array($arrData['reference'][$vv]) ? $arrData['reference'][$vv][0] : $arrData['reference'][$vv])) != false) ? $ref : $vv) : $vv));
+					$arrAttributes['options'][$key][] = array('value'=>$value, 'label'=>($blnUseReference && isset($arrData['reference'][$vv]) ? ((($ref = (\is_array($arrData['reference'][$vv]) ? $arrData['reference'][$vv][0] : $arrData['reference'][$vv])) != false) ? $ref : $vv) : $vv));
 				}
 			}
 
 			$arrAttributes['unknownOption'] = array_filter($unknown);
 		}
 
-		if (\is_array($arrAttributes['sql']) && !isset($arrAttributes['sql']['columnDefinition']))
+		if (\is_array($arrAttributes['sql'] ?? null) && !isset($arrAttributes['sql']['columnDefinition']))
 		{
 			if (!isset($arrAttributes['maxlength']) && isset($arrAttributes['sql']['length']))
 			{

--- a/core-bundle/src/Resources/contao/library/Contao/Widget.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Widget.php
@@ -1239,22 +1239,22 @@ abstract class Widget extends Controller
 	 */
 	public static function getAttributesFromDca($arrData, $strName, $varValue=null, $strField='', $strTable='', $objDca=null)
 	{
-		$arrAttributes = $arrData['eval'];
+		$arrAttributes = $arrData['eval'] ?? array();
 
 		$arrAttributes['id'] = $strName;
 		$arrAttributes['name'] = $strName;
 		$arrAttributes['strField'] = $strField;
 		$arrAttributes['strTable'] = $strTable;
 		$arrAttributes['label'] = (($label = \is_array($arrData['label']) ? $arrData['label'][0] : $arrData['label']) !== null) ? $label : $strField;
-		$arrAttributes['description'] = $arrData['label'][1];
-		$arrAttributes['type'] = $arrData['inputType'];
+		$arrAttributes['description'] = $arrData['label'][1] ?? null;
+		$arrAttributes['type'] = $arrData['inputType'] ?? null;
 		$arrAttributes['dataContainer'] = $objDca;
 		$arrAttributes['value'] = StringUtil::deserialize($varValue);
 
 		// Internet Explorer does not support onchange for checkboxes and radio buttons
-		if ($arrData['eval']['submitOnChange'])
+		if ($arrData['eval']['submitOnChange'] ?? null)
 		{
-			if ($arrData['inputType'] == 'checkbox' || $arrData['inputType'] == 'checkboxWizard' || $arrData['inputType'] == 'radio' || $arrData['inputType'] == 'radioTable')
+			if (($arrData['inputType'] ?? null) == 'checkbox' || ($arrData['inputType'] ?? null) == 'checkboxWizard' || ($arrData['inputType'] ?? null) == 'radio' || ($arrData['inputType'] ?? null) == 'radioTable')
 			{
 				$arrAttributes['onclick'] = trim($arrAttributes['onclick'] . " Backend.autoSubmit('" . $strTable . "')");
 			}
@@ -1264,27 +1264,27 @@ abstract class Widget extends Controller
 			}
 		}
 
-		$arrAttributes['allowHtml'] = ($arrData['eval']['allowHtml'] || $arrData['eval']['rte'] || $arrData['eval']['preserveTags']);
+		$arrAttributes['allowHtml'] = (($arrData['eval']['allowHtml'] ?? null) || ($arrData['eval']['rte'] ?? null) || ($arrData['eval']['preserveTags'] ?? null));
 
 		// Decode entities if HTML is allowed
-		if ($arrAttributes['allowHtml'] || $arrData['inputType'] == 'fileTree')
+		if ($arrAttributes['allowHtml'] || ($arrData['inputType'] ?? null) == 'fileTree')
 		{
 			$arrAttributes['decodeEntities'] = true;
 		}
 
 		// Add Ajax event
-		if ($arrData['inputType'] == 'checkbox' && $arrData['eval']['submitOnChange'] && \is_array($GLOBALS['TL_DCA'][$strTable]['subpalettes']) && \array_key_exists($strField, $GLOBALS['TL_DCA'][$strTable]['subpalettes']))
+		if (($arrData['inputType'] ?? null) == 'checkbox' && ($arrData['eval']['submitOnChange'] ?? null) && \is_array($GLOBALS['TL_DCA'][$strTable]['subpalettes'] ?? null) && \array_key_exists($strField, $GLOBALS['TL_DCA'][$strTable]['subpalettes']))
 		{
 			$arrAttributes['onclick'] = "AjaxRequest.toggleSubpalette(this, 'sub_" . $strName . "', '" . $strField . "')";
 		}
 
 		// Options callback
-		if (\is_array($arrData['options_callback']))
+		if (\is_array($arrData['options_callback'] ?? null))
 		{
 			$arrCallback = $arrData['options_callback'];
 			$arrData['options'] = static::importStatic($arrCallback[0])->{$arrCallback[1]}($objDca);
 		}
-		elseif (\is_callable($arrData['options_callback']))
+		elseif (\is_callable($arrData['options_callback'] ?? null))
 		{
 			$arrData['options'] = $arrData['options_callback']($objDca);
 		}
@@ -1303,7 +1303,7 @@ abstract class Widget extends Controller
 		}
 
 		// Add default option to single checkbox
-		if ($arrData['inputType'] == 'checkbox' && !isset($arrData['options']) && !isset($arrData['options_callback']) && !isset($arrData['foreignKey']))
+		if (($arrData['inputType'] ?? null) == 'checkbox' && !isset($arrData['options']) && !isset($arrData['options_callback']) && !isset($arrData['foreignKey']))
 		{
 			if (TL_MODE == 'FE' && isset($arrAttributes['description']))
 			{
@@ -1316,12 +1316,12 @@ abstract class Widget extends Controller
 		}
 
 		// Add options
-		if (\is_array($arrData['options']))
+		if (\is_array($arrData['options'] ?? null))
 		{
-			$blnIsAssociative = ($arrData['eval']['isAssociative'] || ArrayUtil::isAssoc($arrData['options']));
+			$blnIsAssociative = ($arrData['eval']['isAssociative'] ?? null) || ArrayUtil::isAssoc($arrData['options'] ?? array());
 			$blnUseReference = isset($arrData['reference']);
 
-			if ($arrData['eval']['includeBlankOption'] && !$arrData['eval']['multiple'])
+			if (($arrData['eval']['includeBlankOption'] ?? null) && !($arrData['eval']['multiple'] ?? null))
 			{
 				$strLabel = $arrData['eval']['blankOptionLabel'] ?? '-';
 				$arrAttributes['options'][] = array('value'=>'', 'label'=>$strLabel);
@@ -1377,7 +1377,7 @@ abstract class Widget extends Controller
 		}
 
 		// Convert timestamps
-		if ($varValue !== null && $varValue !== '' && \in_array($arrData['eval']['rgxp'], array('date', 'time', 'datim')))
+		if ($varValue !== null && $varValue !== '' && \in_array($arrData['eval']['rgxp'] ?? null, array('date', 'time', 'datim')))
 		{
 			$objDate = new Date($varValue, Date::getFormatFromRgxp($arrData['eval']['rgxp']));
 			$arrAttributes['value'] = $objDate->{$arrData['eval']['rgxp']};

--- a/core-bundle/src/Resources/contao/modules/Module.php
+++ b/core-bundle/src/Resources/contao/modules/Module.php
@@ -215,7 +215,7 @@ abstract class Module extends Frontend
 
 		// Do not change this order (see #6191)
 		$this->Template->style = !empty($this->arrStyle) ? implode(' ', $this->arrStyle) : '';
-		$this->Template->class = trim('mod_' . $this->type . ' ' . $this->cssID[1]);
+		$this->Template->class = !empty($this->cssID[1]) ? trim('mod_' . $this->type . ' ' . $this->cssID[1]) : '';
 		$this->Template->cssID = !empty($this->cssID[0]) ? ' id="' . $this->cssID[0] . '"' : '';
 
 		$this->Template->inColumn = $this->strColumn;

--- a/core-bundle/src/Resources/contao/modules/Module.php
+++ b/core-bundle/src/Resources/contao/modules/Module.php
@@ -215,7 +215,7 @@ abstract class Module extends Frontend
 
 		// Do not change this order (see #6191)
 		$this->Template->style = !empty($this->arrStyle) ? implode(' ', $this->arrStyle) : '';
-		$this->Template->class = !empty($this->cssID[1]) ? trim('mod_' . $this->type . ' ' . $this->cssID[1]) : '';
+		$this->Template->class = trim('mod_' . $this->type . ' ' . ($this->cssID[1] ?? ''));
 		$this->Template->cssID = !empty($this->cssID[0]) ? ' id="' . $this->cssID[0] . '"' : '';
 
 		$this->Template->inColumn = $this->strColumn;

--- a/core-bundle/src/Resources/contao/modules/ModuleArticle.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleArticle.php
@@ -113,7 +113,7 @@ class ModuleArticle extends Module
 		// Generate the CSS ID if it is not set
 		if (empty($this->cssID[0]))
 		{
-			$this->cssID = array($id, $this->cssID[1]);
+			$this->cssID = array($id, $this->cssID[1] ?? null);
 		}
 
 		$this->Template->column = $this->inColumn;
@@ -157,12 +157,9 @@ class ModuleArticle extends Module
 		}
 
 		// Get section and article alias
-		list($strSection, $strArticle) = explode(':', Input::get('articles'));
-
-		if ($strArticle === null)
-		{
-			$strArticle = $strSection;
-		}
+		$chunks = explode(':', Input::get('articles'));
+		$strSection = $chunks[0] ?? null;
+		$strArticle = $chunks[1] ?? $strSection;
 
 		// Overwrite the page title (see #2853 and #4955)
 		if (!$this->blnNoMarkup && $strArticle && ($strArticle == $this->id || $strArticle == $this->alias) && $this->title)

--- a/core-bundle/src/Resources/contao/modules/ModuleArticleList.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleArticleList.php
@@ -106,7 +106,7 @@ class ModuleArticleList extends Module
 			(
 				'link' => $objArticles->title,
 				'title' => StringUtil::specialchars($objArticles->title),
-				'id' => $cssID[0] ?? 'article-' . $objArticles->id,
+				'id' => $cssID[0] ?: 'article-' . $objArticles->id,
 				'articleId' => $objArticles->id,
 				'href' => $objHelper->getFrontendUrl('/articles/' . ($objArticles->alias ?: $objArticles->id))
 			);

--- a/core-bundle/src/Resources/contao/modules/ModuleArticleList.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleArticleList.php
@@ -106,7 +106,7 @@ class ModuleArticleList extends Module
 			(
 				'link' => $objArticles->title,
 				'title' => StringUtil::specialchars($objArticles->title),
-				'id' => $cssID[0] ?: 'article-' . $objArticles->id,
+				'id' => $cssID[0] ?? 'article-' . $objArticles->id,
 				'articleId' => $objArticles->id,
 				'href' => $objHelper->getFrontendUrl('/articles/' . ($objArticles->alias ?: $objArticles->id))
 			);

--- a/core-bundle/src/Resources/contao/modules/ModuleChangePassword.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleChangePassword.php
@@ -71,7 +71,7 @@ class ModuleChangePassword extends Module
 		$this->loadDataContainer('tl_member');
 
 		// Call onload_callback (e.g. to check permissions)
-		if (\is_array($GLOBALS['TL_DCA']['tl_member']['config']['onload_callback']))
+		if (\is_array($GLOBALS['TL_DCA']['tl_member']['config']['onload_callback'] ?? null))
 		{
 			foreach ($GLOBALS['TL_DCA']['tl_member']['config']['onload_callback'] as $callback)
 			{
@@ -192,7 +192,7 @@ class ModuleChangePassword extends Module
 			$objMember->save();
 
 			// Create a new version
-			if ($GLOBALS['TL_DCA'][$strTable]['config']['enableVersioning'])
+			if ($GLOBALS['TL_DCA'][$strTable]['config']['enableVersioning'] ?? null)
 			{
 				$objVersions->create();
 			}

--- a/core-bundle/src/Resources/contao/modules/ModuleChangePassword.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleChangePassword.php
@@ -127,7 +127,7 @@ class ModuleChangePassword extends Module
 		foreach ($arrFields as $strKey=>$arrField)
 		{
 			/** @var Widget $strClass */
-			$strClass = $GLOBALS['TL_FFL'][$arrField['inputType']];
+			$strClass = $GLOBALS['TL_FFL'][$arrField['inputType']] ?? null;
 
 			// Continue if the class is not defined
 			if (!class_exists($strClass))
@@ -135,7 +135,7 @@ class ModuleChangePassword extends Module
 				continue;
 			}
 
-			$arrField['eval']['required'] = $arrField['eval']['mandatory'];
+			$arrField['eval']['required'] = $arrField['eval']['mandatory'] ?? null;
 
 			/** @var Widget $objWidget */
 			$objWidget = new $strClass($strClass::getAttributesFromDca($arrField, $arrField['name']));

--- a/core-bundle/src/Resources/contao/modules/ModulePassword.php
+++ b/core-bundle/src/Resources/contao/modules/ModulePassword.php
@@ -68,7 +68,7 @@ class ModulePassword extends Module
 		$this->loadDataContainer('tl_member');
 
 		// Call onload_callback (e.g. to check permissions)
-		if (\is_array($GLOBALS['TL_DCA']['tl_member']['config']['onload_callback']))
+		if (\is_array($GLOBALS['TL_DCA']['tl_member']['config']['onload_callback'] ?? null))
 		{
 			foreach ($GLOBALS['TL_DCA']['tl_member']['config']['onload_callback'] as $callback)
 			{
@@ -277,7 +277,7 @@ class ModulePassword extends Module
 				$optInToken->confirm();
 
 				// Create a new version
-				if ($GLOBALS['TL_DCA']['tl_member']['config']['enableVersioning'])
+				if ($GLOBALS['TL_DCA']['tl_member']['config']['enableVersioning'] ?? null)
 				{
 					$objVersions->create();
 				}

--- a/core-bundle/src/Resources/contao/modules/ModulePassword.php
+++ b/core-bundle/src/Resources/contao/modules/ModulePassword.php
@@ -124,7 +124,7 @@ class ModulePassword extends Module
 		foreach ($arrFields as $arrField)
 		{
 			/** @var Widget $strClass */
-			$strClass = $GLOBALS['TL_FFL'][$arrField['inputType']];
+			$strClass = $GLOBALS['TL_FFL'][$arrField['inputType']] ?? null;
 
 			// Continue if the class is not defined
 			if (!class_exists($strClass))
@@ -132,7 +132,7 @@ class ModulePassword extends Module
 				continue;
 			}
 
-			$arrField['eval']['required'] = $arrField['eval']['mandatory'];
+			$arrField['eval']['required'] = $arrField['eval']['mandatory'] ?? null;
 
 			/** @var Widget $objWidget */
 			$objWidget = new $strClass($strClass::getAttributesFromDca($arrField, $arrField['name']));
@@ -240,7 +240,7 @@ class ModulePassword extends Module
 		$arrField = $GLOBALS['TL_DCA']['tl_member']['fields']['password'];
 
 		/** @var Widget $strClass */
-		$strClass = $GLOBALS['TL_FFL']['password'];
+		$strClass = $GLOBALS['TL_FFL']['password'] ?? null;
 
 		// Fallback to default if the class is not defined
 		if (!class_exists($strClass))

--- a/core-bundle/src/Resources/contao/modules/ModulePersonalData.php
+++ b/core-bundle/src/Resources/contao/modules/ModulePersonalData.php
@@ -131,34 +131,34 @@ class ModulePersonalData extends Module
 		// Build the form
 		foreach ($this->editable as $field)
 		{
-			$arrData = &$GLOBALS['TL_DCA']['tl_member']['fields'][$field];
+			$arrData = $GLOBALS['TL_DCA']['tl_member']['fields'][$field] ?? array();
 
 			// Map checkboxWizards to regular checkbox widgets
-			if ($arrData['inputType'] == 'checkboxWizard')
+			if (($arrData['inputType'] ?? null) == 'checkboxWizard')
 			{
 				$arrData['inputType'] = 'checkbox';
 			}
 
 			// Map fileTrees to upload widgets (see #8091)
-			if ($arrData['inputType'] == 'fileTree')
+			if (($arrData['inputType'] ?? null) == 'fileTree')
 			{
 				$arrData['inputType'] = 'upload';
 			}
 
 			/** @var Widget $strClass */
-			$strClass = $GLOBALS['TL_FFL'][$arrData['inputType']];
+			$strClass = $GLOBALS['TL_FFL'][$arrData['inputType']] ?? null;
 
 			// Continue if the class does not exist
-			if (!$arrData['eval']['feEditable'] || !class_exists($strClass))
+			if (!($arrData['eval']['feEditable'] ?? null) || !class_exists($strClass))
 			{
 				continue;
 			}
 
-			$strGroup = $arrData['eval']['feGroup'];
+			$strGroup = $arrData['eval']['feGroup'] ?? null;
 
 			$arrData['eval']['required'] = false;
 
-			if ($arrData['eval']['mandatory'])
+			if ($arrData['eval']['mandatory'] ?? null)
 			{
 				if (\is_array($this->User->$field))
 				{
@@ -177,7 +177,7 @@ class ModulePersonalData extends Module
 			$varValue = $this->User->$field;
 
 			// Call the load_callback
-			if (isset($arrData['load_callback']) && \is_array($arrData['load_callback']))
+			if (\is_array($arrData['load_callback'] ?? null))
 			{
 				foreach ($arrData['load_callback'] as $callback)
 				{
@@ -218,7 +218,7 @@ class ModulePersonalData extends Module
 				$objWidget->validate();
 				$varValue = $objWidget->value;
 
-				$rgxp = $arrData['eval']['rgxp'];
+				$rgxp = $arrData['eval']['rgxp'] ?? null;
 
 				// Convert date formats into timestamps (check the eval setting first -> #3063)
 				if ($varValue !== null && $varValue !== '' && \in_array($rgxp, array('date', 'time', 'datim')))
@@ -235,13 +235,13 @@ class ModulePersonalData extends Module
 				}
 
 				// Make sure that unique fields are unique (check the eval setting first -> #3063)
-				if ((string) $varValue !== '' && $arrData['eval']['unique'] && !$this->Database->isUniqueValue('tl_member', $field, $varValue, $this->User->id))
+				if ((string) $varValue !== '' && ($arrData['eval']['unique'] ?? null) && !$this->Database->isUniqueValue('tl_member', $field, $varValue, $this->User->id))
 				{
-					$objWidget->addError(sprintf($GLOBALS['TL_LANG']['ERR']['unique'], $arrData['label'][0] ?: $field));
+					$objWidget->addError(sprintf($GLOBALS['TL_LANG']['ERR']['unique'], $arrData['label'][0] ?? $field));
 				}
 
 				// Trigger the save_callback (see #5247)
-				if (\is_array($arrData['save_callback']) && $objWidget->submitInput() && !$objWidget->hasErrors())
+				if (\is_array($arrData['save_callback'] ?? null) && $objWidget->submitInput() && !$objWidget->hasErrors())
 				{
 					foreach ($arrData['save_callback'] as $callback)
 					{
@@ -286,7 +286,7 @@ class ModulePersonalData extends Module
 					}
 
 					// Encrypt the value (see #7815)
-					if ($arrData['eval']['encrypt'])
+					if ($arrData['eval']['encrypt'] ?? null)
 					{
 						$varValue = Encryption::encrypt($varValue);
 					}

--- a/core-bundle/src/Resources/contao/modules/ModulePersonalData.php
+++ b/core-bundle/src/Resources/contao/modules/ModulePersonalData.php
@@ -81,7 +81,7 @@ class ModulePersonalData extends Module
 		$this->loadDataContainer('tl_member');
 
 		// Call onload_callback (e.g. to check permissions)
-		if (\is_array($GLOBALS['TL_DCA']['tl_member']['config']['onload_callback']))
+		if (\is_array($GLOBALS['TL_DCA']['tl_member']['config']['onload_callback'] ?? null))
 		{
 			foreach ($GLOBALS['TL_DCA']['tl_member']['config']['onload_callback'] as $callback)
 			{
@@ -322,7 +322,7 @@ class ModulePersonalData extends Module
 			$objMember->save();
 
 			// Create a new version
-			if ($GLOBALS['TL_DCA'][$strTable]['config']['enableVersioning'])
+			if ($GLOBALS['TL_DCA'][$strTable]['config']['enableVersioning'] ?? null)
 			{
 				$objVersions->create();
 			}
@@ -344,7 +344,7 @@ class ModulePersonalData extends Module
 			}
 
 			// Call the onsubmit_callback
-			if (\is_array($GLOBALS['TL_DCA']['tl_member']['config']['onsubmit_callback']))
+			if (\is_array($GLOBALS['TL_DCA']['tl_member']['config']['onsubmit_callback'] ?? null))
 			{
 				foreach ($GLOBALS['TL_DCA']['tl_member']['config']['onsubmit_callback'] as $callback)
 				{

--- a/core-bundle/src/Resources/contao/modules/ModulePersonalData.php
+++ b/core-bundle/src/Resources/contao/modules/ModulePersonalData.php
@@ -237,7 +237,7 @@ class ModulePersonalData extends Module
 				// Make sure that unique fields are unique (check the eval setting first -> #3063)
 				if ((string) $varValue !== '' && ($arrData['eval']['unique'] ?? null) && !$this->Database->isUniqueValue('tl_member', $field, $varValue, $this->User->id))
 				{
-					$objWidget->addError(sprintf($GLOBALS['TL_LANG']['ERR']['unique'], $arrData['label'][0] ?? $field));
+					$objWidget->addError(sprintf($GLOBALS['TL_LANG']['ERR']['unique'], $arrData['label'][0] ?: $field));
 				}
 
 				// Trigger the save_callback (see #5247)

--- a/core-bundle/src/Resources/contao/modules/ModulePersonalData.php
+++ b/core-bundle/src/Resources/contao/modules/ModulePersonalData.php
@@ -311,7 +311,14 @@ class ModulePersonalData extends Module
 			$temp = $objWidget->parse();
 
 			$this->Template->fields .= $temp;
+
+			if (!isset($arrFields[$strGroup][$field]))
+			{
+				$arrFields[$strGroup][$field] = '';
+			}
+
 			$arrFields[$strGroup][$field] .= $temp;
+
 			++$row;
 		}
 

--- a/core-bundle/src/Resources/contao/modules/ModuleRegistration.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleRegistration.php
@@ -250,7 +250,7 @@ class ModuleRegistration extends Module
 				// Make sure that unique fields are unique (check the eval setting first -> #3063)
 				if ((string) $varValue !== '' && ($arrData['eval']['unique'] ?? null) && !$this->Database->isUniqueValue('tl_member', $field, $varValue))
 				{
-					$objWidget->addError(sprintf($GLOBALS['TL_LANG']['ERR']['unique'], $arrData['label'][0] ?? $field));
+					$objWidget->addError(sprintf($GLOBALS['TL_LANG']['ERR']['unique'], $arrData['label'][0] ?: $field));
 				}
 
 				// Save callback

--- a/core-bundle/src/Resources/contao/modules/ModuleRegistration.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleRegistration.php
@@ -133,7 +133,7 @@ class ModuleRegistration extends Module
 			);
 
 			/** @var FormCaptcha $strClass */
-			$strClass = $GLOBALS['TL_FFL']['captcha'];
+			$strClass = $GLOBALS['TL_FFL']['captcha'] ?? null;
 
 			// Fallback to default if the class is not defined
 			if (!class_exists($strClass))
@@ -173,22 +173,22 @@ class ModuleRegistration extends Module
 		// Build the form
 		foreach ($this->editable as $field)
 		{
-			$arrData = $GLOBALS['TL_DCA']['tl_member']['fields'][$field];
+			$arrData = $GLOBALS['TL_DCA']['tl_member']['fields'][$field] ?? array();
 
 			// Map checkboxWizards to regular checkbox widgets
-			if ($arrData['inputType'] == 'checkboxWizard')
+			if (($arrData['inputType'] ?? null) == 'checkboxWizard')
 			{
 				$arrData['inputType'] = 'checkbox';
 			}
 
 			// Map fileTrees to upload widgets (see #8091)
-			if ($arrData['inputType'] == 'fileTree')
+			if (($arrData['inputType'] ?? null) == 'fileTree')
 			{
 				$arrData['inputType'] = 'upload';
 			}
 
 			/** @var Widget $strClass */
-			$strClass = $GLOBALS['TL_FFL'][$arrData['inputType']];
+			$strClass = $GLOBALS['TL_FFL'][$arrData['inputType']] ?? null;
 
 			// Continue if the class is not defined
 			if (!class_exists($strClass))
@@ -196,15 +196,15 @@ class ModuleRegistration extends Module
 				continue;
 			}
 
-			$arrData['eval']['required'] = $arrData['eval']['mandatory'];
+			$arrData['eval']['required'] = $arrData['eval']['mandatory'] ?? null;
 
 			// Unset the unique field check upon follow-up registrations
-			if ($objMember !== null && $arrData['eval']['unique'] && Input::post($field) == $objMember->$field)
+			if ($objMember !== null && ($arrData['eval']['unique'] ?? null) && Input::post($field) == $objMember->$field)
 			{
 				$arrData['eval']['unique'] = false;
 			}
 
-			$objWidget = new $strClass($strClass::getAttributesFromDca($arrData, $field, $arrData['default'], '', '', $this));
+			$objWidget = new $strClass($strClass::getAttributesFromDca($arrData, $field, $arrData['default'] ?? null, '', '', $this));
 
 			// Append the module ID to prevent duplicate IDs (see #1493)
 			$objWidget->id .= '_' . $this->id;
@@ -231,7 +231,7 @@ class ModuleRegistration extends Module
 					$objWidget->addError($GLOBALS['TL_LANG']['ERR']['passwordName']);
 				}
 
-				$rgxp = $arrData['eval']['rgxp'];
+				$rgxp = $arrData['eval']['rgxp'] ?? null;
 
 				// Convert date formats into timestamps (check the eval setting first -> #3063)
 				if ($varValue !== null && $varValue !== '' && \in_array($rgxp, array('date', 'time', 'datim')))
@@ -248,13 +248,13 @@ class ModuleRegistration extends Module
 				}
 
 				// Make sure that unique fields are unique (check the eval setting first -> #3063)
-				if ((string) $varValue !== '' && $arrData['eval']['unique'] && !$this->Database->isUniqueValue('tl_member', $field, $varValue))
+				if ((string) $varValue !== '' && ($arrData['eval']['unique'] ?? null) && !$this->Database->isUniqueValue('tl_member', $field, $varValue))
 				{
-					$objWidget->addError(sprintf($GLOBALS['TL_LANG']['ERR']['unique'], $arrData['label'][0] ?: $field));
+					$objWidget->addError(sprintf($GLOBALS['TL_LANG']['ERR']['unique'], $arrData['label'][0] ?? $field));
 				}
 
 				// Save callback
-				if (\is_array($arrData['save_callback']) && $objWidget->submitInput() && !$objWidget->hasErrors())
+				if (\is_array($arrData['save_callback'] ?? null) && $objWidget->submitInput() && !$objWidget->hasErrors())
 				{
 					foreach ($arrData['save_callback'] as $callback)
 					{
@@ -296,7 +296,7 @@ class ModuleRegistration extends Module
 					}
 
 					// Encrypt the value (see #7815)
-					if ($arrData['eval']['encrypt'])
+					if ($arrData['eval']['encrypt'] ?? null)
 					{
 						$varValue = Encryption::encrypt($varValue);
 					}
@@ -314,6 +314,12 @@ class ModuleRegistration extends Module
 			$temp = $objWidget->parse();
 
 			$this->Template->fields .= $temp;
+
+			if (!isset($arrFields[$arrData['eval']['feGroup']][$field]))
+			{
+				$arrFields[$arrData['eval']['feGroup']][$field] = '';
+			}
+
 			$arrFields[$arrData['eval']['feGroup']][$field] .= $temp;
 
 			++$i;
@@ -486,7 +492,7 @@ class ModuleRegistration extends Module
 		if (isset($bundles['ContaoNewsletterBundle']))
 		{
 			// Make sure newsletter is an array
-			if (!\is_array($arrData['newsletter']))
+			if (!\is_array($arrData['newsletter'] ?? null))
 			{
 				if ($arrData['newsletter'])
 				{

--- a/core-bundle/src/Resources/contao/modules/ModuleRegistration.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleRegistration.php
@@ -74,7 +74,7 @@ class ModuleRegistration extends Module
 		$this->loadDataContainer('tl_member');
 
 		// Call onload_callback (e.g. to check permissions)
-		if (\is_array($GLOBALS['TL_DCA']['tl_member']['config']['onload_callback']))
+		if (\is_array($GLOBALS['TL_DCA']['tl_member']['config']['onload_callback'] ?? null))
 		{
 			foreach ($GLOBALS['TL_DCA']['tl_member']['config']['onload_callback'] as $callback)
 			{

--- a/core-bundle/src/Resources/contao/modules/ModuleSearch.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleSearch.php
@@ -191,7 +191,7 @@ class ModuleSearch extends Module
 
 				foreach ($arrResult as $k=>$v)
 				{
-					if ($v['protected'])
+					if ($v['protected'] ?? null)
 					{
 						if (!FE_USER_LOGGED_IN || !\is_array($this->User->groups))
 						{

--- a/core-bundle/src/Resources/contao/pages/PageRegular.php
+++ b/core-bundle/src/Resources/contao/pages/PageRegular.php
@@ -529,7 +529,7 @@ class PageRegular extends Frontend
 		}
 
 		// Make sure TL_USER_CSS is set
-		if (!\is_array($GLOBALS['TL_USER_CSS'] ?? null))
+		if (!isset($GLOBALS['TL_USER_CSS']) || !\is_array($GLOBALS['TL_USER_CSS']))
 		{
 			$GLOBALS['TL_USER_CSS'] = array();
 		}

--- a/core-bundle/src/Resources/contao/pages/PageRegular.php
+++ b/core-bundle/src/Resources/contao/pages/PageRegular.php
@@ -99,13 +99,12 @@ class PageRegular extends Frontend
 		$arrCustomSections = array();
 		$arrSections = array('header', 'left', 'right', 'main', 'footer');
 		$arrModules = StringUtil::deserialize($objLayout->modules);
-
 		$arrModuleIds = array();
 
 		// Filter the disabled modules
 		foreach ($arrModules as $module)
 		{
-			if ($module['enable'])
+			if ($module['enable'] ?? null)
 			{
 				$arrModuleIds[] = (int) $module['mod'];
 			}
@@ -130,7 +129,7 @@ class PageRegular extends Frontend
 			foreach ($arrModules as $arrModule)
 			{
 				// Disabled module
-				if (!BE_USER_LOGGED_IN && !$arrModule['enable'])
+				if (!BE_USER_LOGGED_IN && !($arrModule['enable'] ?? null))
 				{
 					continue;
 				}
@@ -169,6 +168,11 @@ class PageRegular extends Frontend
 				}
 				else
 				{
+					if (!isset($arrCustomSections[$arrModule['col']]))
+					{
+						$arrCustomSections[$arrModule['col']] = '';
+					}
+
 					$arrCustomSections[$arrModule['col']] .= $this->getFrontendModule($arrModule['mod'], $arrModule['col']);
 				}
 			}
@@ -177,7 +181,7 @@ class PageRegular extends Frontend
 		$this->Template->sections = $arrCustomSections;
 
 		// Mark RTL languages (see #7171)
-		if ($GLOBALS['TL_LANG']['MSC']['textDirection'] == 'rtl')
+		if (($GLOBALS['TL_LANG']['MSC']['textDirection'] ?? null) == 'rtl')
 		{
 			$this->Template->isRTL = true;
 		}
@@ -525,7 +529,7 @@ class PageRegular extends Frontend
 		}
 
 		// Make sure TL_USER_CSS is set
-		if (!\is_array($GLOBALS['TL_USER_CSS']))
+		if (!\is_array($GLOBALS['TL_USER_CSS'] ?? null))
 		{
 			$GLOBALS['TL_USER_CSS'] = array();
 		}

--- a/core-bundle/src/Resources/contao/pages/PageRegular.php
+++ b/core-bundle/src/Resources/contao/pages/PageRegular.php
@@ -87,7 +87,7 @@ class PageRegular extends Frontend
 
 		// Set the layout template and template group
 		$objPage->template = $objLayout->template ?: 'fe_page';
-		$objPage->templateGroup = $objTheme->templates;
+		$objPage->templateGroup = $objTheme->templates ?? null;
 
 		// Minify the markup
 		$objPage->minifyMarkup = $objLayout->minifyMarkup;

--- a/core-bundle/src/Resources/contao/widgets/CheckBox.php
+++ b/core-bundle/src/Resources/contao/widgets/CheckBox.php
@@ -225,7 +225,7 @@ class CheckBox extends Widget
 			$this->getAttributes(),
 			$this->strId . '_' . $i,
 			($this->mandatory && !$this->multiple ? '<span class="invisible">' . $GLOBALS['TL_LANG']['MSC']['mandatory'] . ' </span>' : ''),
-			$arrOption['label'],
+			$arrOption['label'] ?? null,
 			($this->mandatory && !$this->multiple ? '<span class="mandatory">*</span>' : ''),
 			!$this->multiple ? $this->xlabel : ''
 		);

--- a/core-bundle/src/Resources/contao/widgets/CheckBoxWizard.php
+++ b/core-bundle/src/Resources/contao/widgets/CheckBoxWizard.php
@@ -113,7 +113,7 @@ class CheckBoxWizard extends Widget
 			// Move selected and sorted options to the top
 			foreach ($this->arrOptions as $i=>$arrOption)
 			{
-				if (($intPos = array_search($arrOption['value'], $this->varValue)) !== false)
+				if (($intPos = array_search($arrOption['value'] ?? null, $this->varValue)) !== false)
 				{
 					$arrOptions[$intPos] = $arrOption;
 					unset($arrTemp[$i]);
@@ -181,12 +181,12 @@ class CheckBoxWizard extends Widget
 			'<span><input type="checkbox" name="%s" id="opt_%s" class="tl_checkbox" value="%s"%s%s onfocus="Backend.getScrollOffset()"> %s<label for="opt_%s">%s</label></span>',
 			$this->strName . ($this->multiple ? '[]' : ''),
 			$this->strId . '_' . $i,
-			($this->multiple ? StringUtil::specialchars($arrOption['value']) : 1),
-			(((\is_array($this->varValue) && \in_array($arrOption['value'], $this->varValue)) || $this->varValue == $arrOption['value']) ? ' checked="checked"' : ''),
+			($this->multiple ? StringUtil::specialchars($arrOption['value'] ?? '') : 1),
+			(((\is_array($this->varValue) && \in_array($arrOption['value'] ?? null, $this->varValue)) || $this->varValue == ($arrOption['value'] ?? null)) ? ' checked="checked"' : ''),
 			$this->getAttributes(),
 			$strButtons,
 			$this->strId . '_' . $i,
-			$arrOption['label']
+			$arrOption['label'] ?? null
 		);
 	}
 }

--- a/core-bundle/src/Resources/contao/widgets/FileSelector.php
+++ b/core-bundle/src/Resources/contao/widgets/FileSelector.php
@@ -283,7 +283,7 @@ class FileSelector extends Widget
 
 		// Return the tree
 		return '<ul class="tl_listing tree_view picker_selector' . ($this->strClass ? ' ' . $this->strClass : '') . '" id="' . $this->strId . '" data-callback="reloadFiletree">
-    <li class="tl_folder_top"><div class="tl_left">' . Image::getHtml($GLOBALS['TL_DCA']['tl_files']['list']['sorting']['icon'] ?: 'filemounts.svg') . ' ' . $GLOBALS['TL_LANG']['MOD']['files'][0] . '</div> <div class="tl_right">&nbsp;</div><div style="clear:both"></div></li><li class="parent" id="' . $this->strId . '_parent"><ul>' . $tree . $strReset . '
+    <li class="tl_folder_top"><div class="tl_left">' . Image::getHtml($GLOBALS['TL_DCA']['tl_files']['list']['sorting']['icon'] ?? 'filemounts.svg') . ' ' . $GLOBALS['TL_LANG']['MOD']['files'][0] . '</div> <div class="tl_right">&nbsp;</div><div style="clear:both"></div></li><li class="parent" id="' . $this->strId . '_parent"><ul>' . $tree . $strReset . '
   </ul></li></ul>';
 	}
 
@@ -308,7 +308,7 @@ class FileSelector extends Widget
 		$this->loadDataContainer($this->strTable);
 
 		// Load the current values
-		switch ($GLOBALS['TL_DCA'][$this->strTable]['config']['dataContainer'])
+		switch ($GLOBALS['TL_DCA'][$this->strTable]['config']['dataContainer'] ?? null)
 		{
 			case 'File':
 				if (Config::get($this->strField))

--- a/core-bundle/src/Resources/contao/widgets/FileSelector.php
+++ b/core-bundle/src/Resources/contao/widgets/FileSelector.php
@@ -283,7 +283,7 @@ class FileSelector extends Widget
 
 		// Return the tree
 		return '<ul class="tl_listing tree_view picker_selector' . ($this->strClass ? ' ' . $this->strClass : '') . '" id="' . $this->strId . '" data-callback="reloadFiletree">
-    <li class="tl_folder_top"><div class="tl_left">' . Image::getHtml($GLOBALS['TL_DCA']['tl_files']['list']['sorting']['icon'] ?? 'filemounts.svg') . ' ' . $GLOBALS['TL_LANG']['MOD']['files'][0] . '</div> <div class="tl_right">&nbsp;</div><div style="clear:both"></div></li><li class="parent" id="' . $this->strId . '_parent"><ul>' . $tree . $strReset . '
+    <li class="tl_folder_top"><div class="tl_left">' . Image::getHtml($GLOBALS['TL_DCA']['tl_files']['list']['sorting']['icon'] ?: 'filemounts.svg') . ' ' . $GLOBALS['TL_LANG']['MOD']['files'][0] . '</div> <div class="tl_right">&nbsp;</div><div style="clear:both"></div></li><li class="parent" id="' . $this->strId . '_parent"><ul>' . $tree . $strReset . '
   </ul></li></ul>';
 	}
 

--- a/core-bundle/src/Resources/contao/widgets/ImageSize.php
+++ b/core-bundle/src/Resources/contao/widgets/ImageSize.php
@@ -190,9 +190,9 @@ class ImageSize extends Widget
 			{
 				$arrOptions[] = sprintf(
 					'<option value="%s"%s>%s</option>',
-					StringUtil::specialchars($arrOption['value']),
-					$this->optionSelected($arrOption['value'], $this->varValue[2]),
-					$arrOption['label']
+					StringUtil::specialchars($arrOption['value'] ?? ''),
+					$this->optionSelected($arrOption['value'] ?? null, $this->varValue[2]),
+					$arrOption['label'] ?? null
 				);
 			}
 			else
@@ -203,9 +203,9 @@ class ImageSize extends Widget
 				{
 					$arrOptgroups[] = sprintf(
 						'<option value="%s"%s>%s</option>',
-						StringUtil::specialchars($arrOptgroup['value']),
-						$this->optionSelected($arrOptgroup['value'], $this->varValue[2]),
-						$arrOptgroup['label']
+						StringUtil::specialchars($arrOptgroup['value'] ?? ''),
+						$this->optionSelected($arrOptgroup['value'] ?? null, $this->varValue[2]),
+						$arrOptgroup['label'] ?? null
 					);
 				}
 

--- a/core-bundle/src/Resources/contao/widgets/ImageSize.php
+++ b/core-bundle/src/Resources/contao/widgets/ImageSize.php
@@ -191,7 +191,7 @@ class ImageSize extends Widget
 				$arrOptions[] = sprintf(
 					'<option value="%s"%s>%s</option>',
 					StringUtil::specialchars($arrOption['value'] ?? ''),
-					$this->optionSelected($arrOption['value'] ?? null, $this->varValue[2]),
+					$this->optionSelected($arrOption['value'] ?? null, $this->varValue[2] ?? null),
 					$arrOption['label'] ?? null
 				);
 			}
@@ -204,7 +204,7 @@ class ImageSize extends Widget
 					$arrOptgroups[] = sprintf(
 						'<option value="%s"%s>%s</option>',
 						StringUtil::specialchars($arrOptgroup['value'] ?? ''),
-						$this->optionSelected($arrOptgroup['value'] ?? null, $this->varValue[2]),
+						$this->optionSelected($arrOptgroup['value'] ?? null, $this->varValue[2] ?? null),
 						$arrOptgroup['label'] ?? null
 					);
 				}

--- a/core-bundle/src/Resources/contao/widgets/InputUnit.php
+++ b/core-bundle/src/Resources/contao/widgets/InputUnit.php
@@ -112,7 +112,7 @@ class InputUnit extends Widget
 	 */
 	protected function isSelected($arrOption)
 	{
-		if (empty($this->varValue) && empty($_POST) && $arrOption['default'])
+		if (empty($this->varValue) && empty($_POST) && ($arrOption['default'] ?? null))
 		{
 			return $this->optionSelected(1, 1);
 		}
@@ -122,7 +122,7 @@ class InputUnit extends Widget
 			return '';
 		}
 
-		return $this->optionSelected($arrOption['value'], $this->varValue['unit']);
+		return $this->optionSelected($arrOption['value'] ?? null, $this->varValue['unit'] ?? null);
 	}
 
 	/**

--- a/core-bundle/src/Resources/contao/widgets/KeyValueWizard.php
+++ b/core-bundle/src/Resources/contao/widgets/KeyValueWizard.php
@@ -107,7 +107,7 @@ class KeyValueWizard extends Widget
 		$arrButtons = array('copy', 'delete', 'drag');
 
 		// Make sure there is at least an empty array
-		if (!\is_array($this->varValue) || !$this->varValue[0])
+		if (!\is_array($this->varValue) || empty($this->varValue[0]))
 		{
 			$this->varValue = array(array(''));
 		}
@@ -128,8 +128,8 @@ class KeyValueWizard extends Widget
 		{
 			$return .= '
     <tr>
-      <td><input type="text" name="' . $this->strId . '[' . $i . '][key]" id="' . $this->strId . '_key_' . $i . '" class="tl_text" value="' . StringUtil::specialchars($this->varValue[$i]['key']) . '"' . $this->getAttributes() . '></td>
-      <td><input type="text" name="' . $this->strId . '[' . $i . '][value]" id="' . $this->strId . '_value_' . $i . '" class="tl_text" value="' . StringUtil::specialchars($this->varValue[$i]['value']) . '"' . $this->getAttributes() . '></td>';
+      <td><input type="text" name="' . $this->strId . '[' . $i . '][key]" id="' . $this->strId . '_key_' . $i . '" class="tl_text" value="' . StringUtil::specialchars($this->varValue[$i]['key'] ?? '') . '"' . $this->getAttributes() . '></td>
+      <td><input type="text" name="' . $this->strId . '[' . $i . '][value]" id="' . $this->strId . '_value_' . $i . '" class="tl_text" value="' . StringUtil::specialchars($this->varValue[$i]['value'] ?? '') . '"' . $this->getAttributes() . '></td>';
 
 			// Add row buttons
 			$return .= '

--- a/core-bundle/src/Resources/contao/widgets/OptionWizard.php
+++ b/core-bundle/src/Resources/contao/widgets/OptionWizard.php
@@ -113,10 +113,10 @@ class OptionWizard extends Widget
 		{
 			$return .= '
     <tr>
-      <td><input type="text" name="' . $this->strId . '[' . $i . '][value]" id="' . $this->strId . '_value_' . $i . '" class="tl_text" value="' . StringUtil::specialchars($this->varValue[$i]['value']) . '"></td>
-      <td><input type="text" name="' . $this->strId . '[' . $i . '][label]" id="' . $this->strId . '_label_' . $i . '" class="tl_text" value="' . StringUtil::specialchars($this->varValue[$i]['label']) . '"></td>
-      <td><input type="checkbox" name="' . $this->strId . '[' . $i . '][default]" id="' . $this->strId . '_default_' . $i . '" class="fw_checkbox" value="1"' . ($this->varValue[$i]['default'] ? ' checked="checked"' : '') . '> <label for="' . $this->strId . '_default_' . $i . '">' . $GLOBALS['TL_LANG']['MSC']['ow_default'] . '</label></td>
-      <td><input type="checkbox" name="' . $this->strId . '[' . $i . '][group]" id="' . $this->strId . '_group_' . $i . '" class="fw_checkbox" value="1"' . ($this->varValue[$i]['group'] ? ' checked="checked"' : '') . '> <label for="' . $this->strId . '_group_' . $i . '">' . $GLOBALS['TL_LANG']['MSC']['ow_group'] . '</label></td>';
+      <td><input type="text" name="' . $this->strId . '[' . $i . '][value]" id="' . $this->strId . '_value_' . $i . '" class="tl_text" value="' . StringUtil::specialchars($this->varValue[$i]['value'] ?? '') . '"></td>
+      <td><input type="text" name="' . $this->strId . '[' . $i . '][label]" id="' . $this->strId . '_label_' . $i . '" class="tl_text" value="' . StringUtil::specialchars($this->varValue[$i]['label'] ?? '') . '"></td>
+      <td><input type="checkbox" name="' . $this->strId . '[' . $i . '][default]" id="' . $this->strId . '_default_' . $i . '" class="fw_checkbox" value="1"' . (($this->varValue[$i]['default'] ?? null) ? ' checked="checked"' : '') . '> <label for="' . $this->strId . '_default_' . $i . '">' . $GLOBALS['TL_LANG']['MSC']['ow_default'] . '</label></td>
+      <td><input type="checkbox" name="' . $this->strId . '[' . $i . '][group]" id="' . $this->strId . '_group_' . $i . '" class="fw_checkbox" value="1"' . (($this->varValue[$i]['group'] ?? null) ? ' checked="checked"' : '') . '> <label for="' . $this->strId . '_group_' . $i . '">' . $GLOBALS['TL_LANG']['MSC']['ow_group'] . '</label></td>';
 
 			// Add row buttons
 			$return .= '

--- a/core-bundle/src/Resources/contao/widgets/OptionWizard.php
+++ b/core-bundle/src/Resources/contao/widgets/OptionWizard.php
@@ -90,7 +90,7 @@ class OptionWizard extends Widget
 		$arrButtons = array('copy', 'delete', 'drag');
 
 		// Make sure there is at least an empty array
-		if (!\is_array($this->varValue) || !$this->varValue[0])
+		if (!\is_array($this->varValue) || empty($this->varValue[0]))
 		{
 			$this->varValue = array(array(''));
 		}

--- a/core-bundle/src/Resources/contao/widgets/PageSelector.php
+++ b/core-bundle/src/Resources/contao/widgets/PageSelector.php
@@ -247,7 +247,7 @@ class PageSelector extends Widget
 
 		// Return the tree
 		return '<ul class="tl_listing tree_view picker_selector' . ($this->strClass ? ' ' . $this->strClass : '') . '" id="' . $this->strId . '" data-callback="reloadPagetree" data-inserttag="link_url">
-    <li class="tl_folder_top"><div class="tl_left">' . Image::getHtml($GLOBALS['TL_DCA']['tl_page']['list']['sorting']['icon'] ?? 'pagemounts.svg') . ' ' . $GLOBALS['TL_LANG']['MOD']['page'][0] . '</div> <div class="tl_right">&nbsp;</div><div style="clear:both"></div></li><li class="parent" id="' . $this->strId . '_parent"><ul>' . $tree . $strReset . '
+    <li class="tl_folder_top"><div class="tl_left">' . Image::getHtml($GLOBALS['TL_DCA']['tl_page']['list']['sorting']['icon'] ?: 'pagemounts.svg') . ' ' . $GLOBALS['TL_LANG']['MOD']['page'][0] . '</div> <div class="tl_right">&nbsp;</div><div style="clear:both"></div></li><li class="parent" id="' . $this->strId . '_parent"><ul>' . $tree . $strReset . '
   </ul></li></ul>';
 	}
 

--- a/core-bundle/src/Resources/contao/widgets/PageSelector.php
+++ b/core-bundle/src/Resources/contao/widgets/PageSelector.php
@@ -247,7 +247,7 @@ class PageSelector extends Widget
 
 		// Return the tree
 		return '<ul class="tl_listing tree_view picker_selector' . ($this->strClass ? ' ' . $this->strClass : '') . '" id="' . $this->strId . '" data-callback="reloadPagetree" data-inserttag="link_url">
-    <li class="tl_folder_top"><div class="tl_left">' . Image::getHtml($GLOBALS['TL_DCA']['tl_page']['list']['sorting']['icon'] ?: 'pagemounts.svg') . ' ' . $GLOBALS['TL_LANG']['MOD']['page'][0] . '</div> <div class="tl_right">&nbsp;</div><div style="clear:both"></div></li><li class="parent" id="' . $this->strId . '_parent"><ul>' . $tree . $strReset . '
+    <li class="tl_folder_top"><div class="tl_left">' . Image::getHtml($GLOBALS['TL_DCA']['tl_page']['list']['sorting']['icon'] ?? 'pagemounts.svg') . ' ' . $GLOBALS['TL_LANG']['MOD']['page'][0] . '</div> <div class="tl_right">&nbsp;</div><div style="clear:both"></div></li><li class="parent" id="' . $this->strId . '_parent"><ul>' . $tree . $strReset . '
   </ul></li></ul>';
 	}
 
@@ -271,7 +271,7 @@ class PageSelector extends Widget
 		$this->loadDataContainer($this->strTable);
 
 		// Load current values
-		switch ($GLOBALS['TL_DCA'][$this->strTable]['config']['dataContainer'])
+		switch ($GLOBALS['TL_DCA'][$this->strTable]['config']['dataContainer'] ?? null)
 		{
 			case 'File':
 				if (Config::get($this->strField))

--- a/core-bundle/src/Resources/contao/widgets/Password.php
+++ b/core-bundle/src/Resources/contao/widgets/Password.php
@@ -122,7 +122,7 @@ class Password extends Widget
 			$this->addError($GLOBALS['TL_LANG']['ERR']['passwordMatch']);
 		}
 
-		if ($varInput == $GLOBALS['TL_USERNAME'])
+		if (isset($GLOBALS['TL_USERNAME']) && $varInput == $GLOBALS['TL_USERNAME'])
 		{
 			$this->addError($GLOBALS['TL_LANG']['ERR']['passwordName']);
 		}

--- a/core-bundle/src/Resources/contao/widgets/Picker.php
+++ b/core-bundle/src/Resources/contao/widgets/Picker.php
@@ -229,7 +229,7 @@ class Picker extends Widget
 
 		if ($mode === 4)
 		{
-			$callback = $GLOBALS['TL_DCA'][$dc->table]['list']['sorting']['child_record_callback'];
+			$callback = $GLOBALS['TL_DCA'][$dc->table]['list']['sorting']['child_record_callback'] ?? null;
 
 			if (\is_array($callback))
 			{
@@ -247,14 +247,14 @@ class Picker extends Widget
 		$labelConfig = &$GLOBALS['TL_DCA'][$dc->table]['list']['label'];
 		$label = vsprintf($labelConfig['format'], array_intersect_key($arrRow, array_flip($labelConfig['fields'])));
 
-		if (\is_array($labelConfig['label_callback']))
+		if (\is_array($labelConfig['label_callback'] ?? null))
 		{
 			$this->import($labelConfig['label_callback'][0]);
 
 			return $this->{$labelConfig['label_callback'][0]}->{$labelConfig['label_callback'][1]}($arrRow, $label, $dc, $arrRow);
 		}
 
-		if (\is_callable($labelConfig['label_callback']))
+		if (\is_callable($labelConfig['label_callback'] ?? null))
 		{
 			return $labelConfig['label_callback']($arrRow, $label, $dc, $arrRow);
 		}

--- a/core-bundle/src/Resources/contao/widgets/RadioButton.php
+++ b/core-bundle/src/Resources/contao/widgets/RadioButton.php
@@ -124,11 +124,11 @@ class RadioButton extends Widget
 				'<input type="radio" name="%s" id="opt_%s" class="tl_radio" value="%s"%s%s onfocus="Backend.getScrollOffset()"> <label for="opt_%s">%s</label>',
 				$this->strName,
 				$this->strId . '_' . $i,
-				StringUtil::specialchars($arrOption['value']),
+				StringUtil::specialchars($arrOption['value'] ?? ''),
 				$this->isChecked($arrOption),
 				$this->getAttributes(),
 				$this->strId . '_' . $i,
-				$arrOption['label']
+				$arrOption['label'] ?? null
 			);
 		}
 

--- a/core-bundle/src/Resources/contao/widgets/SelectMenu.php
+++ b/core-bundle/src/Resources/contao/widgets/SelectMenu.php
@@ -157,7 +157,7 @@ class SelectMenu extends Widget
 					'<option value="%s"%s>%s</option>',
 					StringUtil::specialchars($arrOption['value']),
 					$this->isSelected($arrOption),
-					$arrOption['label']
+					$arrOption['label'] ?? null
 				);
 			}
 			else
@@ -168,9 +168,9 @@ class SelectMenu extends Widget
 				{
 					$arrOptgroups[] = sprintf(
 						'<option value="%s"%s>%s</option>',
-						StringUtil::specialchars($arrOptgroup['value']),
+						StringUtil::specialchars($arrOptgroup['value'] ?? ''),
 						$this->isSelected($arrOptgroup),
-						$arrOptgroup['label']
+						$arrOptgroup['label'] ?? null
 					);
 				}
 

--- a/core-bundle/src/Resources/contao/widgets/TimePeriod.php
+++ b/core-bundle/src/Resources/contao/widgets/TimePeriod.php
@@ -107,7 +107,7 @@ class TimePeriod extends Widget
 	 */
 	protected function isSelected($arrOption)
 	{
-		if (empty($this->varValue) && empty($_POST) && $arrOption['default'])
+		if (empty($this->varValue) && empty($_POST) && ($arrOption['default'] ?? null))
 		{
 			return $this->optionSelected(1, 1);
 		}
@@ -117,7 +117,7 @@ class TimePeriod extends Widget
 			return '';
 		}
 
-		return $this->optionSelected($arrOption['value'], $this->varValue['unit']);
+		return $this->optionSelected($arrOption['value'] ?? null, $this->varValue['unit'] ?? null);
 	}
 
 	/**

--- a/core-bundle/src/Resources/contao/widgets/TrblField.php
+++ b/core-bundle/src/Resources/contao/widgets/TrblField.php
@@ -94,7 +94,7 @@ class TrblField extends Widget
 	 */
 	protected function isSelected($arrOption)
 	{
-		if (empty($this->varValue) && empty($_POST) && $arrOption['default'])
+		if (empty($this->varValue) && empty($_POST) && ($arrOption['default'] ?? null))
 		{
 			return $this->optionSelected(1, 1);
 		}
@@ -104,7 +104,7 @@ class TrblField extends Widget
 			return '';
 		}
 
-		return $this->optionSelected($arrOption['value'], $this->varValue['unit']);
+		return $this->optionSelected($arrOption['value'] ?? null, $this->varValue['unit'] ?? null);
 	}
 
 	/**

--- a/faq-bundle/src/Resources/contao/dca/tl_faq.php
+++ b/faq-bundle/src/Resources/contao/dca/tl_faq.php
@@ -88,7 +88,7 @@ $GLOBALS['TL_DCA']['tl_faq'] = array
 			(
 				'href'                => 'act=delete',
 				'icon'                => 'delete.svg',
-				'attributes'          => 'onclick="if(!confirm(\'' . $GLOBALS['TL_LANG']['MSC']['deleteConfirm'] . '\'))return false;Backend.getScrollOffset()"'
+				'attributes'          => 'onclick="if(!confirm(\'' . ($GLOBALS['TL_LANG']['MSC']['deleteConfirm'] ?? null) . '\'))return false;Backend.getScrollOffset()"'
 			),
 			'toggle' => array
 			(

--- a/faq-bundle/src/Resources/contao/dca/tl_faq.php
+++ b/faq-bundle/src/Resources/contao/dca/tl_faq.php
@@ -348,7 +348,7 @@ class tl_faq extends Backend
 		// HOOK: comments extension required
 		if (!isset($bundles['ContaoCommentsBundle']))
 		{
-			$key = array_search('allowComments', $GLOBALS['TL_DCA']['tl_faq']['list']['sorting']['headerFields']);
+			$key = array_search('allowComments', $GLOBALS['TL_DCA']['tl_faq']['list']['sorting']['headerFields'] ?? array());
 			unset($GLOBALS['TL_DCA']['tl_faq']['list']['sorting']['headerFields'][$key]);
 		}
 
@@ -597,7 +597,7 @@ class tl_faq extends Backend
 		}
 
 		// Trigger the onload_callback
-		if (is_array($GLOBALS['TL_DCA']['tl_faq']['config']['onload_callback']))
+		if (is_array($GLOBALS['TL_DCA']['tl_faq']['config']['onload_callback'] ?? null))
 		{
 			foreach ($GLOBALS['TL_DCA']['tl_faq']['config']['onload_callback'] as $callback)
 			{
@@ -638,7 +638,7 @@ class tl_faq extends Backend
 		$objVersions->initialize();
 
 		// Trigger the save_callback
-		if (is_array($GLOBALS['TL_DCA']['tl_faq']['fields']['published']['save_callback']))
+		if (is_array($GLOBALS['TL_DCA']['tl_faq']['fields']['published']['save_callback'] ?? null))
 		{
 			foreach ($GLOBALS['TL_DCA']['tl_faq']['fields']['published']['save_callback'] as $callback)
 			{
@@ -667,7 +667,7 @@ class tl_faq extends Backend
 		}
 
 		// Trigger the onsubmit_callback
-		if (is_array($GLOBALS['TL_DCA']['tl_faq']['config']['onsubmit_callback']))
+		if (is_array($GLOBALS['TL_DCA']['tl_faq']['config']['onsubmit_callback'] ?? null))
 		{
 			foreach ($GLOBALS['TL_DCA']['tl_faq']['config']['onsubmit_callback'] as $callback)
 			{

--- a/faq-bundle/src/Resources/contao/dca/tl_faq_category.php
+++ b/faq-bundle/src/Resources/contao/dca/tl_faq_category.php
@@ -96,7 +96,7 @@ $GLOBALS['TL_DCA']['tl_faq_category'] = array
 			(
 				'href'                => 'act=delete',
 				'icon'                => 'delete.svg',
-				'attributes'          => 'onclick="if(!confirm(\'' . $GLOBALS['TL_LANG']['tl_faq_category']['deleteConfirm'] . '\'))return false;Backend.getScrollOffset()"',
+				'attributes'          => 'onclick="if(!confirm(\'' . ($GLOBALS['TL_LANG']['MSC']['deleteConfirm'] ?? null) . '\'))return false;Backend.getScrollOffset()"',
 				'button_callback'     => array('tl_faq_category', 'deleteCategory')
 			),
 			'show' => array

--- a/faq-bundle/src/Resources/contao/languages/en/tl_faq_category.xlf
+++ b/faq-bundle/src/Resources/contao/languages/en/tl_faq_category.xlf
@@ -89,9 +89,6 @@
       <trans-unit id="tl_faq_category.notify_both">
         <source>Author and system administrator</source>
       </trans-unit>
-      <trans-unit id="tl_faq_category.deleteConfirm">
-        <source>Deleting category ID %s will also delete all its FAQs! Continue?</source>
-      </trans-unit>
       <trans-unit id="tl_faq_category.new.0">
         <source>New</source>
       </trans-unit>

--- a/faq-bundle/src/Resources/contao/modules/ModuleFaqPage.php
+++ b/faq-bundle/src/Resources/contao/modules/ModuleFaqPage.php
@@ -95,9 +95,10 @@ class ModuleFaqPage extends Module
 
 			// Clean the RTE output
 			$objTemp->answer = StringUtil::toHtml5($objFaq->answer);
-
 			$objTemp->answer = StringUtil::encodeEmail($objTemp->answer);
+
 			$objTemp->addImage = false;
+			$objTemp->addBefore = false;
 
 			// Add an image
 			if ($objFaq->addImage && $objFaq->singleSRC)

--- a/faq-bundle/src/Resources/contao/modules/ModuleFaqReader.php
+++ b/faq-bundle/src/Resources/contao/modules/ModuleFaqReader.php
@@ -121,6 +121,7 @@ class ModuleFaqReader extends Module
 
 		$this->Template->answer = StringUtil::encodeEmail($objFaq->answer);
 		$this->Template->addImage = false;
+		$this->Template->before = false;
 
 		// Add image
 		if ($objFaq->addImage && $objFaq->singleSRC)

--- a/listing-bundle/src/Resources/contao/modules/ModuleListing.php
+++ b/listing-bundle/src/Resources/contao/modules/ModuleListing.php
@@ -128,7 +128,7 @@ class ModuleListing extends Module
 
 			foreach ($arrSearchFields as $field)
 			{
-				$strOptions .= '  <option value="' . $field . '"' . (($field == $strSearch) ? ' selected="selected"' : '') . '>' . ($GLOBALS['TL_DCA'][$this->list_table]['fields'][$field]['label'][0] ?? $field) . '</option>' . "\n";
+				$strOptions .= '  <option value="' . $field . '"' . ($field == $strSearch ? ' selected="selected"' : '') . '>' . ($GLOBALS['TL_DCA'][$this->list_table]['fields'][$field]['label'][0] ?? $field) . '</option>' . "\n";
 			}
 		}
 
@@ -255,7 +255,7 @@ class ModuleListing extends Module
 		for ($i=0, $c=\count($arrFields); $i<$c; $i++)
 		{
 			// Never show passwords
-			if ($GLOBALS['TL_DCA'][$this->list_table]['fields'][$arrFields[$i]]['inputType'] == 'password')
+			if (($GLOBALS['TL_DCA'][$this->list_table]['fields'][$arrFields[$i]]['inputType'] ?? null) == 'password')
 			{
 				continue;
 			}
@@ -309,7 +309,7 @@ class ModuleListing extends Module
 				}
 
 				// Never show passwords
-				if ($GLOBALS['TL_DCA'][$this->list_table]['fields'][$k]['inputType'] == 'password')
+				if (($GLOBALS['TL_DCA'][$this->list_table]['fields'][$k]['inputType'] ?? null) == 'password')
 				{
 					continue;
 				}
@@ -384,7 +384,7 @@ class ModuleListing extends Module
 		foreach ($arrRow as $k=>$v)
 		{
 			// Never show passwords
-			if ($GLOBALS['TL_DCA'][$this->list_table]['fields'][$k]['inputType'] == 'password')
+			if (($GLOBALS['TL_DCA'][$this->list_table]['fields'][$k]['inputType'] ?? null) == 'password')
 			{
 				--$limit;
 				continue;
@@ -433,45 +433,45 @@ class ModuleListing extends Module
 		}
 
 		// Date
-		elseif ($GLOBALS['TL_DCA'][$this->list_table]['fields'][$k]['eval']['rgxp'] == 'date')
+		elseif (($GLOBALS['TL_DCA'][$this->list_table]['fields'][$k]['eval']['rgxp'] ?? null) == 'date')
 		{
 			$value = Date::parse($objPage->dateFormat, $value);
 		}
 
 		// Time
-		elseif ($GLOBALS['TL_DCA'][$this->list_table]['fields'][$k]['eval']['rgxp'] == 'time')
+		elseif (($GLOBALS['TL_DCA'][$this->list_table]['fields'][$k]['eval']['rgxp'] ?? null) == 'time')
 		{
 			$value = Date::parse($objPage->timeFormat, $value);
 		}
 
 		// Date and time
-		elseif ($GLOBALS['TL_DCA'][$this->list_table]['fields'][$k]['eval']['rgxp'] == 'datim')
+		elseif (($GLOBALS['TL_DCA'][$this->list_table]['fields'][$k]['eval']['rgxp'] ?? null) == 'datim')
 		{
 			$value = Date::parse($objPage->datimFormat, $value);
 		}
 
 		// URLs
-		elseif ($GLOBALS['TL_DCA'][$this->list_table]['fields'][$k]['eval']['rgxp'] == 'url' && preg_match('@^(https?://|ftp://)@i', $value))
+		elseif (($GLOBALS['TL_DCA'][$this->list_table]['fields'][$k]['eval']['rgxp'] ?? null) == 'url' && preg_match('@^(https?://|ftp://)@i', $value))
 		{
 			$value = Idna::decode($value); // see #5946
 			$value = '<a href="' . $value . '" target="_blank" rel="noreferrer noopener">' . $value . '</a>';
 		}
 
 		// E-mail addresses
-		elseif ($GLOBALS['TL_DCA'][$this->list_table]['fields'][$k]['eval']['rgxp'] == 'email')
+		elseif (($GLOBALS['TL_DCA'][$this->list_table]['fields'][$k]['eval']['rgxp'] ?? null) == 'email')
 		{
 			$value = StringUtil::encodeEmail(Idna::decode($value)); // see #5946
 			$value = '<a href="&#109;&#97;&#105;&#108;&#116;&#111;&#58;' . $value . '">' . $value . '</a>';
 		}
 
 		// Reference
-		elseif (\is_array($GLOBALS['TL_DCA'][$this->list_table]['fields'][$k]['reference']))
+		elseif (\is_array($GLOBALS['TL_DCA'][$this->list_table]['fields'][$k]['reference'] ?? null))
 		{
 			$value = $GLOBALS['TL_DCA'][$this->list_table]['fields'][$k]['reference'][$value];
 		}
 
 		// Associative array
-		elseif ($GLOBALS['TL_DCA'][$this->list_table]['fields'][$k]['eval']['isAssociative'] || ArrayUtil::isAssoc($GLOBALS['TL_DCA'][$this->list_table]['fields'][$k]['options']))
+		elseif (($GLOBALS['TL_DCA'][$this->list_table]['fields'][$k]['eval']['isAssociative'] ?? null) || ArrayUtil::isAssoc($GLOBALS['TL_DCA'][$this->list_table]['fields'][$k]['options'] ?? array()))
 		{
 			if ($blnListSingle)
 			{

--- a/listing-bundle/src/Resources/contao/modules/ModuleListing.php
+++ b/listing-bundle/src/Resources/contao/modules/ModuleListing.php
@@ -176,7 +176,7 @@ class ModuleListing extends Module
 		// Cast date fields to int (see #5609)
 		$isInt = function ($field)
 		{
-			return $GLOBALS['TL_DCA'][$this->list_table]['fields'][$field]['eval']['rgxp'] == 'date' || $GLOBALS['TL_DCA'][$this->list_table]['fields'][$field]['eval']['rgxp'] == 'time' || $GLOBALS['TL_DCA'][$this->list_table]['fields'][$field]['eval']['rgxp'] == 'datim';
+			return ($GLOBALS['TL_DCA'][$this->list_table]['fields'][$field]['eval']['rgxp'] ?? null) == 'date' || ($GLOBALS['TL_DCA'][$this->list_table]['fields'][$field]['eval']['rgxp'] ?? null) == 'time' || ($GLOBALS['TL_DCA'][$this->list_table]['fields'][$field]['eval']['rgxp'] ?? null) == 'datim';
 		};
 
 		$order_by = Input::get('order_by');
@@ -467,19 +467,19 @@ class ModuleListing extends Module
 		// Reference
 		elseif (\is_array($GLOBALS['TL_DCA'][$this->list_table]['fields'][$k]['reference'] ?? null))
 		{
-			$value = $GLOBALS['TL_DCA'][$this->list_table]['fields'][$k]['reference'][$value];
+			$value = $GLOBALS['TL_DCA'][$this->list_table]['fields'][$k]['reference'][$value] ?? null;
 		}
 
 		// Associative array
-		elseif (($GLOBALS['TL_DCA'][$this->list_table]['fields'][$k]['eval']['isAssociative'] ?? null) || ArrayUtil::isAssoc($GLOBALS['TL_DCA'][$this->list_table]['fields'][$k]['options'] ?? array()))
+		elseif (($GLOBALS['TL_DCA'][$this->list_table]['fields'][$k]['eval']['isAssociative'] ?? null) || ArrayUtil::isAssoc($GLOBALS['TL_DCA'][$this->list_table]['fields'][$k]['options'] ?? null))
 		{
 			if ($blnListSingle)
 			{
-				$value = $GLOBALS['TL_DCA'][$this->list_table]['fields'][$k]['options'][$value];
+				$value = $GLOBALS['TL_DCA'][$this->list_table]['fields'][$k]['options'][$value] ?? null;
 			}
 			else
 			{
-				$value = '<span class="value">[' . $value . ']</span> ' . $GLOBALS['TL_DCA'][$this->list_table]['fields'][$k]['options'][$value];
+				$value = '<span class="value">[' . $value . ']</span> ' . ($GLOBALS['TL_DCA'][$this->list_table]['fields'][$k]['options'][$value] ?? null);
 			}
 		}
 

--- a/news-bundle/src/Resources/contao/dca/tl_news.php
+++ b/news-bundle/src/Resources/contao/dca/tl_news.php
@@ -119,7 +119,7 @@ $GLOBALS['TL_DCA']['tl_news'] = array
 			(
 				'href'                => 'act=delete',
 				'icon'                => 'delete.svg',
-				'attributes'          => 'onclick="if(!confirm(\'' . $GLOBALS['TL_LANG']['MSC']['deleteConfirm'] . '\'))return false;Backend.getScrollOffset()"'
+				'attributes'          => 'onclick="if(!confirm(\'' . ($GLOBALS['TL_LANG']['MSC']['deleteConfirm'] ?? null) . '\'))return false;Backend.getScrollOffset()"'
 			),
 			'toggle' => array
 			(

--- a/news-bundle/src/Resources/contao/dca/tl_news.php
+++ b/news-bundle/src/Resources/contao/dca/tl_news.php
@@ -526,7 +526,7 @@ class tl_news extends Backend
 		// HOOK: comments extension required
 		if (!isset($bundles['ContaoCommentsBundle']))
 		{
-			$key = array_search('allowComments', $GLOBALS['TL_DCA']['tl_news']['list']['sorting']['headerFields']);
+			$key = array_search('allowComments', $GLOBALS['TL_DCA']['tl_news']['list']['sorting']['headerFields'] ?? array());
 			unset($GLOBALS['TL_DCA']['tl_news']['list']['sorting']['headerFields'][$key]);
 		}
 
@@ -1002,7 +1002,7 @@ class tl_news extends Backend
 		}
 
 		// Trigger the onload_callback
-		if (is_array($GLOBALS['TL_DCA']['tl_news']['config']['onload_callback']))
+		if (is_array($GLOBALS['TL_DCA']['tl_news']['config']['onload_callback'] ?? null))
 		{
 			foreach ($GLOBALS['TL_DCA']['tl_news']['config']['onload_callback'] as $callback)
 			{
@@ -1043,7 +1043,7 @@ class tl_news extends Backend
 		$objVersions->initialize();
 
 		// Trigger the save_callback
-		if (is_array($GLOBALS['TL_DCA']['tl_news']['fields']['featured']['save_callback']))
+		if (is_array($GLOBALS['TL_DCA']['tl_news']['fields']['featured']['save_callback'] ?? null))
 		{
 			foreach ($GLOBALS['TL_DCA']['tl_news']['fields']['featured']['save_callback'] as $callback)
 			{
@@ -1072,7 +1072,7 @@ class tl_news extends Backend
 		}
 
 		// Trigger the onsubmit_callback
-		if (is_array($GLOBALS['TL_DCA']['tl_news']['config']['onsubmit_callback']))
+		if (is_array($GLOBALS['TL_DCA']['tl_news']['config']['onsubmit_callback'] ?? null))
 		{
 			foreach ($GLOBALS['TL_DCA']['tl_news']['config']['onsubmit_callback'] as $callback)
 			{
@@ -1151,7 +1151,7 @@ class tl_news extends Backend
 		}
 
 		// Trigger the onload_callback
-		if (is_array($GLOBALS['TL_DCA']['tl_news']['config']['onload_callback']))
+		if (is_array($GLOBALS['TL_DCA']['tl_news']['config']['onload_callback'] ?? null))
 		{
 			foreach ($GLOBALS['TL_DCA']['tl_news']['config']['onload_callback'] as $callback)
 			{
@@ -1192,7 +1192,7 @@ class tl_news extends Backend
 		$objVersions->initialize();
 
 		// Trigger the save_callback
-		if (is_array($GLOBALS['TL_DCA']['tl_news']['fields']['published']['save_callback']))
+		if (is_array($GLOBALS['TL_DCA']['tl_news']['fields']['published']['save_callback'] ?? null))
 		{
 			foreach ($GLOBALS['TL_DCA']['tl_news']['fields']['published']['save_callback'] as $callback)
 			{
@@ -1221,7 +1221,7 @@ class tl_news extends Backend
 		}
 
 		// Trigger the onsubmit_callback
-		if (is_array($GLOBALS['TL_DCA']['tl_news']['config']['onsubmit_callback']))
+		if (is_array($GLOBALS['TL_DCA']['tl_news']['config']['onsubmit_callback'] ?? null))
 		{
 			foreach ($GLOBALS['TL_DCA']['tl_news']['config']['onsubmit_callback'] as $callback)
 			{

--- a/news-bundle/src/Resources/contao/dca/tl_news_archive.php
+++ b/news-bundle/src/Resources/contao/dca/tl_news_archive.php
@@ -115,7 +115,7 @@ $GLOBALS['TL_DCA']['tl_news_archive'] = array
 			(
 				'href'                => 'act=delete',
 				'icon'                => 'delete.svg',
-				'attributes'          => 'onclick="if(!confirm(\'' . $GLOBALS['TL_LANG']['MSC']['deleteConfirm'] . '\'))return false;Backend.getScrollOffset()"',
+				'attributes'          => 'onclick="if(!confirm(\'' . ($GLOBALS['TL_LANG']['MSC']['deleteConfirm'] ?? null) . '\'))return false;Backend.getScrollOffset()"',
 				'button_callback'     => array('tl_news_archive', 'deleteArchive')
 			),
 			'show' => array

--- a/news-bundle/src/Resources/contao/dca/tl_news_feed.php
+++ b/news-bundle/src/Resources/contao/dca/tl_news_feed.php
@@ -100,7 +100,7 @@ $GLOBALS['TL_DCA']['tl_news_feed'] = array
 			(
 				'href'                => 'act=delete',
 				'icon'                => 'delete.svg',
-				'attributes'          => 'onclick="if(!confirm(\'' . $GLOBALS['TL_LANG']['MSC']['deleteConfirm'] . '\'))return false;Backend.getScrollOffset()"',
+				'attributes'          => 'onclick="if(!confirm(\'' . ($GLOBALS['TL_LANG']['MSC']['deleteConfirm'] ?? null) . '\'))return false;Backend.getScrollOffset()"',
 				'button_callback'     => array('tl_news_feed', 'deleteFeed')
 			),
 			'show' => array
@@ -193,11 +193,14 @@ $GLOBALS['TL_DCA']['tl_news_feed'] = array
 		),
 		'feedBase' => array
 		(
-			'default'                 => Environment::get('base'),
 			'exclude'                 => true,
 			'search'                  => true,
 			'inputType'               => 'text',
 			'eval'                    => array('trailingSlash'=>true, 'rgxp'=>'url', 'decodeEntities'=>true, 'maxlength'=>255, 'tl_class'=>'w50'),
+			'load_callback' => array
+			(
+				array('tl_news_feed', 'addFeedBase')
+			),
 			'sql'                     => "varchar(255) NOT NULL default ''"
 		),
 		'description' => array
@@ -559,6 +562,23 @@ class tl_news_feed extends Backend
 		if (in_array($varValue, $arrFeeds))
 		{
 			throw new Exception(sprintf($GLOBALS['TL_LANG']['ERR']['aliasExists'], $varValue));
+		}
+
+		return $varValue;
+	}
+
+	/**
+	 * Add the RSS-feed base URL
+	 *
+	 * @param mixed $varValue
+	 *
+	 * @return string
+	 */
+	public function addFeedBase($varValue)
+	{
+		if (!$varValue)
+		{
+			$varValue = Environment::get('base');
 		}
 
 		return $varValue;

--- a/news-bundle/src/Resources/contao/modules/ModuleNews.php
+++ b/news-bundle/src/Resources/contao/modules/ModuleNews.php
@@ -151,8 +151,8 @@ abstract class ModuleNews extends Module
 		// Add the meta information
 		$objTemplate->date = $arrMeta['date'];
 		$objTemplate->hasMetaFields = !empty($arrMeta);
-		$objTemplate->numberOfComments = $arrMeta['ccount'];
-		$objTemplate->commentCount = $arrMeta['comments'];
+		$objTemplate->numberOfComments = $arrMeta['ccount'] ?? null;
+		$objTemplate->commentCount = $arrMeta['comments'] ?? null;
 		$objTemplate->timestamp = $objArticle->date;
 		$objTemplate->author = $arrMeta['author'];
 		$objTemplate->datetime = date('Y-m-d\TH:i:sP', $objArticle->date);

--- a/news-bundle/src/Resources/contao/modules/ModuleNews.php
+++ b/news-bundle/src/Resources/contao/modules/ModuleNews.php
@@ -156,8 +156,8 @@ abstract class ModuleNews extends Module
 		$objTemplate->timestamp = $objArticle->date;
 		$objTemplate->author = $arrMeta['author'];
 		$objTemplate->datetime = date('Y-m-d\TH:i:sP', $objArticle->date);
-
 		$objTemplate->addImage = false;
+		$objTemplate->addBefore = false;
 
 		// Add an image
 		if ($objArticle->addImage && $objArticle->singleSRC)

--- a/newsletter-bundle/src/Resources/contao/classes/Newsletter.php
+++ b/newsletter-bundle/src/Resources/contao/classes/Newsletter.php
@@ -621,10 +621,10 @@ class Newsletter extends Backend
 	 */
 	public function createNewUser($intUser, $arrData)
 	{
-		$arrNewsletters = StringUtil::deserialize($arrData['newsletter'], true);
+		$arrNewsletters = StringUtil::deserialize($arrData['newsletter'] ?? '', true);
 
 		// Return if there are no newsletters
-		if (!\is_array($arrNewsletters))
+		if (empty($arrNewsletters) || !\is_array($arrNewsletters))
 		{
 			return;
 		}

--- a/newsletter-bundle/src/Resources/contao/dca/tl_newsletter.php
+++ b/newsletter-bundle/src/Resources/contao/dca/tl_newsletter.php
@@ -87,7 +87,7 @@ $GLOBALS['TL_DCA']['tl_newsletter'] = array
 			(
 				'href'                => 'act=delete',
 				'icon'                => 'delete.svg',
-				'attributes'          => 'onclick="if(!confirm(\'' . $GLOBALS['TL_LANG']['MSC']['deleteConfirm'] . '\'))return false;Backend.getScrollOffset()"'
+				'attributes'          => 'onclick="if(!confirm(\'' . ($GLOBALS['TL_LANG']['MSC']['deleteConfirm'] ?? null) . '\'))return false;Backend.getScrollOffset()"'
 			),
 			'show' => array
 			(

--- a/newsletter-bundle/src/Resources/contao/dca/tl_newsletter_channel.php
+++ b/newsletter-bundle/src/Resources/contao/dca/tl_newsletter_channel.php
@@ -98,7 +98,7 @@ $GLOBALS['TL_DCA']['tl_newsletter_channel'] = array
 			(
 				'href'                => 'act=delete',
 				'icon'                => 'delete.svg',
-				'attributes'          => 'onclick="if(!confirm(\'' . $GLOBALS['TL_LANG']['MSC']['deleteConfirm'] . '\'))return false;Backend.getScrollOffset()"',
+				'attributes'          => 'onclick="if(!confirm(\'' . ($GLOBALS['TL_LANG']['MSC']['deleteConfirm'] ?? null) . '\'))return false;Backend.getScrollOffset()"',
 				'button_callback'     => array('tl_newsletter_channel', 'deleteChannel')
 			),
 			'show' => array

--- a/newsletter-bundle/src/Resources/contao/dca/tl_newsletter_recipients.php
+++ b/newsletter-bundle/src/Resources/contao/dca/tl_newsletter_recipients.php
@@ -428,7 +428,7 @@ class tl_newsletter_recipients extends Backend
 		}
 
 		// Trigger the onload_callback
-		if (is_array($GLOBALS['TL_DCA']['tl_newsletter_recipients']['config']['onload_callback']))
+		if (is_array($GLOBALS['TL_DCA']['tl_newsletter_recipients']['config']['onload_callback'] ?? null))
 		{
 			foreach ($GLOBALS['TL_DCA']['tl_newsletter_recipients']['config']['onload_callback'] as $callback)
 			{
@@ -469,7 +469,7 @@ class tl_newsletter_recipients extends Backend
 		$objVersions->initialize();
 
 		// Trigger the save_callback
-		if (is_array($GLOBALS['TL_DCA']['tl_newsletter_recipients']['fields']['active']['save_callback']))
+		if (is_array($GLOBALS['TL_DCA']['tl_newsletter_recipients']['fields']['active']['save_callback'] ?? null))
 		{
 			foreach ($GLOBALS['TL_DCA']['tl_newsletter_recipients']['fields']['active']['save_callback'] as $callback)
 			{
@@ -498,7 +498,7 @@ class tl_newsletter_recipients extends Backend
 		}
 
 		// Trigger the onsubmit_callback
-		if (is_array($GLOBALS['TL_DCA']['tl_newsletter_recipients']['config']['onsubmit_callback']))
+		if (is_array($GLOBALS['TL_DCA']['tl_newsletter_recipients']['config']['onsubmit_callback'] ?? null))
 		{
 			foreach ($GLOBALS['TL_DCA']['tl_newsletter_recipients']['config']['onsubmit_callback'] as $callback)
 			{

--- a/newsletter-bundle/src/Resources/contao/dca/tl_newsletter_recipients.php
+++ b/newsletter-bundle/src/Resources/contao/dca/tl_newsletter_recipients.php
@@ -97,7 +97,7 @@ $GLOBALS['TL_DCA']['tl_newsletter_recipients'] = array
 			(
 				'href'                => 'act=delete',
 				'icon'                => 'delete.svg',
-				'attributes'          => 'onclick="if(!confirm(\'' . $GLOBALS['TL_LANG']['MSC']['deleteConfirm'] . '\'))return false;Backend.getScrollOffset()"'
+				'attributes'          => 'onclick="if(!confirm(\'' . ($GLOBALS['TL_LANG']['MSC']['deleteConfirm'] ?? null) . '\'))return false;Backend.getScrollOffset()"'
 			),
 			'toggle' => array
 			(


### PR DESCRIPTION
This PR aims to revert the PHP error_level changes we had to make in #2535 to be compatible with PHP 8.

@ausi and I have also discussed making the code compatible with `E_ALL`, however, that is a lot of work and I am not sure if the Contao ecosystem will ever be compatible given that we have been ignoring `E_NOTICE` ever since. But let us see how this PR develops and maybe we can create another PR for `E_ALL`.
