### PR TITLE
Revert #2476 + work around for PHPStan

### DIFF
--- a/core-bundle/src/ServiceAnnotation/Callback.php
+++ b/core-bundle/src/ServiceAnnotation/Callback.php
@@ -41,7 +41,7 @@ final class Callback implements ServiceTagInterface
     public $target;
 
     /**
-     * @var int|null
+     * @var int
      */
     public $priority;
 

--- a/core-bundle/src/ServiceAnnotation/Hook.php
+++ b/core-bundle/src/ServiceAnnotation/Hook.php
@@ -35,7 +35,7 @@ final class Hook implements ServiceTagInterface
     public $value;
 
     /**
-     * @var int|null
+     * @var int
      */
     public $priority;
 

--- a/core-bundle/src/ServiceAnnotation/PickerProvider.php
+++ b/core-bundle/src/ServiceAnnotation/PickerProvider.php
@@ -29,7 +29,7 @@ use Terminal42\ServiceAnnotationBundle\Annotation\ServiceTagInterface;
 final class PickerProvider implements ServiceTagInterface
 {
     /**
-     * @var int|null
+     * @var int
      */
     public $priority;
 

--- a/core-bundle/tests/EventListener/DataContainer/DisableAppConfiguredSettingsListenerTest.php
+++ b/core-bundle/tests/EventListener/DataContainer/DisableAppConfiguredSettingsListenerTest.php
@@ -24,10 +24,9 @@ class DisableAppConfiguredSettingsListenerTest extends TestCase
     public function testAnnotatedCallbacks(): void
     {
         $listener = $this->createListener();
-
         $annotationReader = new AnnotationReader();
 
-        /** @var callback $annotation */
+        /** @var Callback $annotation */
         $annotation = $annotationReader->getClassAnnotation(new \ReflectionClass($listener), Callback::class);
 
         $this->assertSame('tl_settings', $annotation->table);

--- a/core-bundle/tests/EventListener/DataContainer/DisableAppConfiguredSettingsListenerTest.php
+++ b/core-bundle/tests/EventListener/DataContainer/DisableAppConfiguredSettingsListenerTest.php
@@ -26,16 +26,12 @@ class DisableAppConfiguredSettingsListenerTest extends TestCase
         $listener = $this->createListener();
 
         $annotationReader = new AnnotationReader();
+
+        /** @var callback $annotation */
         $annotation = $annotationReader->getClassAnnotation(new \ReflectionClass($listener), Callback::class);
 
-        $this->assertSame(
-            [
-                'table' => 'tl_settings',
-                'target' => 'config.onload',
-                'priority' => null,
-            ],
-            (array) $annotation
-        );
+        $this->assertSame('tl_settings', $annotation->table);
+        $this->assertSame('config.onload', $annotation->target);
     }
 
     public function testLoadCallbackExitsOnMissingLocalconfigParameter(): void

--- a/core-bundle/tests/EventListener/InsertTags/DateListenerTest.php
+++ b/core-bundle/tests/EventListener/InsertTags/DateListenerTest.php
@@ -30,15 +30,11 @@ class DateListenerTest extends TestCase
         $listener = new DateListener($this->getFramework(), new RequestStack());
 
         $annotationReader = new AnnotationReader();
+
+        /** @var Hook $annotation */
         $annotation = $annotationReader->getClassAnnotation(new \ReflectionClass($listener), Hook::class);
 
-        $this->assertSame(
-            [
-                'value' => 'replaceInsertTags',
-                'priority' => null,
-            ],
-            (array) $annotation
-        );
+        $this->assertSame('replaceInsertTags', $annotation->value);
     }
 
     /**

--- a/core-bundle/tests/EventListener/InsertTags/DateListenerTest.php
+++ b/core-bundle/tests/EventListener/InsertTags/DateListenerTest.php
@@ -28,7 +28,6 @@ class DateListenerTest extends TestCase
     public function testAnnotatedCallbacks(): void
     {
         $listener = new DateListener($this->getFramework(), new RequestStack());
-
         $annotationReader = new AnnotationReader();
 
         /** @var Hook $annotation */


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #2570
| Docs PR or issue | -

This works around the issue in #2570. Besides that we should probably investigate if `doctrine/annotations` has a bug and/or check  our default values.