### PR TITLE
Fix require-dev and re-enable require-dev merging in monorepo tools

### DIFF
--- a/core-bundle/composer.json
+++ b/core-bundle/composer.json
@@ -117,7 +117,7 @@
     },
     "require-dev": {
         "ext-fileinfo": "*",
-        "composer/composer": "^1.0",
+        "composer/composer": "^1.0 || ^2.0",
         "contao/maintenance-bundle-deprecated": "^2.1.5",
         "contao/manager-plugin": "^2.3.1",
         "contao/test-case": "^4.2",

--- a/monorepo.yml
+++ b/monorepo.yml
@@ -4,6 +4,8 @@ branch_filter: /^(master|\d+\.\d+)$/
 composer:
     require:
         contao/manager-plugin: ^2.6.2
+    require-dev:
+        bamarni/composer-bin-plugin: ^1.4
     conflict:
         doctrine/annotations: <1.7
         nikic/php-parser: 4.7.0

--- a/tools/monorepo/composer.json
+++ b/tools/monorepo/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "contao/monorepo-tools": "dev-master#608d7dee82a1dba95be989b0b843634e9a2da085"
+        "contao/monorepo-tools": "dev-master"
     }
 }

--- a/tools/monorepo/composer.json
+++ b/tools/monorepo/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "contao/monorepo-tools": "dev-master"
+        "contao/monorepo-tools": "dev-master#608d7dee82a1dba95be989b0b843634e9a2da085"
     }
 }


### PR DESCRIPTION
Follow up to #2582

I think we should revert https://github.com/contao/monorepo-tools/commit/a4ff52a5b125c50e22d43b22ccdcb7a5a9801095 as this helps us spot issues like the one (`"composer/composer": "^1.0 || ^2.0"`) from this PR.