### PR TITLE
Do not use the SQL default for empty values

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Widget.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Widget.php
@@ -1444,11 +1444,6 @@ abstract class Widget extends Controller
 			}
 			else
 			{
-				if (isset($sql['default']))
-				{
-					return $sql['default'];
-				}
-
 				if (isset($sql['notnull']) && !$sql['notnull'])
 				{
 					return null;


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | -
| Docs PR or issue | -

If you have a DCA field with a default value in its `sql` configuration and the field is not mandatory, then saving the field with an empty string is not possible currently (even though it should) because `\Contao\Widget` will currently use the `sql`'s `default` as the empty field value. 

For example:

```php
// contao/dca/tl_news.php
use Contao\CoreBundle\DataContainer\PaletteManipulator;

$GLOBALS['TL_DCA']['tl_news']['fields']['foobar'] = [
    'inputType' => 'text',
    'eval' => ['tl_class' => 'w50'],
    'sql' => ['type' => 'string', 'length' => 255, 'default' => 'foobar']
];

PaletteManipulator::create()
    ->addField('foobar', 'title_legend', PaletteManipulator::POSITION_APPEND)
    ->applyToPalette('default', 'tl_news')
;
```

If you edit a news and remove _foobar_ from the `foobar` field and then save, it will again say _foobar_.

The problem is
https://github.com/contao/contao/blob/29c6a132c62ef93519de13f03f01aba5e4f541ad/core-bundle/src/Resources/contao/library/Contao/Widget.php#L1447-L1450

within `Widget::getEmptyValueByFieldType`. The method is supposed to return the _empty_ value according to the field type. However it currently erroneously uses the `sql`'s `default` value as the empty value, if defined (which will not always be an empty value). If a Widget allows an empty value to be saved (i.e. `mandatory` is false/not defined), then an empty value should always be possible (regardless of the table field's default value in the database).