### PR TITLE
4.9 Fix require-dev and re-enable require-dev merging in monorepo tools

### DIFF
--- a/core-bundle/composer.json
+++ b/core-bundle/composer.json
@@ -114,7 +114,7 @@
     },
     "require-dev": {
         "ext-fileinfo": "*",
-        "composer/composer": "^1.0",
+        "composer/composer": "^1.0 || ^2.0",
         "contao/manager-plugin": "^2.3.1",
         "contao/test-case": "^4.2",
         "lexik/maintenance-bundle": "^2.1.5",

--- a/monorepo.yml
+++ b/monorepo.yml
@@ -4,6 +4,8 @@ branch_filter: /^(master|\d+\.\d+)$/
 composer:
     require:
         contao/manager-plugin: ^2.6.2
+    require-dev:
+        bamarni/composer-bin-plugin: ^1.4
     conflict:
         doctrine/persistence: 1.3.2
         zendframework/zend-code: <3.3.1


### PR DESCRIPTION
Backport of #2586 for Contao 4.9