### PR TITLE
Retrieve the PageModel from the current request

### DIFF
--- a/core-bundle/src/Asset/ContaoContext.php
+++ b/core-bundle/src/Asset/ContaoContext.php
@@ -12,10 +12,10 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Asset;
 
+use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\PageModel;
 use Symfony\Component\Asset\Context\ContextInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
-use Contao\CoreBundle\Framework\ContaoFramework;
 
 /**
  * @internal Do not use this class in your code; use the "contao.assets.assets_context" or "contao.assets.files_context" service instead
@@ -102,6 +102,10 @@ class ContaoContext implements ContextInterface
         $request = $this->requestStack->getCurrentRequest();
 
         if (null === $request || !$request->attributes->has('pageModel')) {
+            if (isset($GLOBALS['objPage']) && $GLOBALS['objPage'] instanceof PageModel) {
+                return $GLOBALS['objPage'];
+            }
+
             return null;
         }
 

--- a/core-bundle/src/Asset/ContaoContext.php
+++ b/core-bundle/src/Asset/ContaoContext.php
@@ -15,13 +15,22 @@ namespace Contao\CoreBundle\Asset;
 use Contao\PageModel;
 use Symfony\Component\Asset\Context\ContextInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Contao\CoreBundle\Framework\ContaoFramework;
 
+/**
+ * @internal Do not use this class in your code; use the "contao.assets.assets_context" or "contao.assets.files_context" service instead
+ */
 class ContaoContext implements ContextInterface
 {
     /**
      * @var RequestStack
      */
     private $requestStack;
+
+    /**
+     * @var ContaoFramework
+     */
+    private $framework;
 
     /**
      * @var string
@@ -33,9 +42,10 @@ class ContaoContext implements ContextInterface
      */
     private $debug;
 
-    public function __construct(RequestStack $requestStack, string $field, bool $debug = false)
+    public function __construct(RequestStack $requestStack, ContaoFramework $framework, string $field, bool $debug = false)
     {
         $this->requestStack = $requestStack;
+        $this->framework = $framework;
         $this->field = $field;
         $this->debug = $debug;
     }
@@ -89,11 +99,32 @@ class ContaoContext implements ContextInterface
 
     private function getPageModel(): ?PageModel
     {
-        if (isset($GLOBALS['objPage']) && $GLOBALS['objPage'] instanceof PageModel) {
+        $request = $this->requestStack->getCurrentRequest();
+
+        if (null === $request || !$request->attributes->has('pageModel')) {
+            return null;
+        }
+
+        $pageModel = $request->attributes->get('pageModel');
+
+        if ($pageModel instanceof PageModel) {
+            return $pageModel;
+        }
+
+        if (
+            isset($GLOBALS['objPage'])
+            && $GLOBALS['objPage'] instanceof PageModel
+            && (int) $GLOBALS['objPage']->id === (int) $pageModel
+        ) {
             return $GLOBALS['objPage'];
         }
 
-        return null;
+        $this->framework->initialize();
+
+        /** @var PageModel $pageAdapter */
+        $pageAdapter = $this->framework->getAdapter(PageModel::class);
+
+        return $pageAdapter->findByPk((int) $pageModel);
     }
 
     /**

--- a/core-bundle/src/Controller/ContentElement/AbstractContentElementController.php
+++ b/core-bundle/src/Controller/ContentElement/AbstractContentElementController.php
@@ -14,17 +14,14 @@ namespace Contao\CoreBundle\Controller\ContentElement;
 
 use Contao\ContentModel;
 use Contao\CoreBundle\Controller\AbstractFragmentController;
-use Contao\PageModel;
 use Contao\Template;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 abstract class AbstractContentElementController extends AbstractFragmentController
 {
-    public function __invoke(Request $request, ContentModel $model, string $section, array $classes = null, PageModel $pageModel = null): Response
+    public function __invoke(Request $request, ContentModel $model, string $section, array $classes = null): Response
     {
-        $this->setPageModel($pageModel);
-
         $type = $this->getType();
         $template = $this->createTemplate($model, 'ce_'.$type);
 

--- a/core-bundle/src/Controller/FrontendModule/AbstractFrontendModuleController.php
+++ b/core-bundle/src/Controller/FrontendModule/AbstractFrontendModuleController.php
@@ -16,7 +16,6 @@ use Contao\BackendTemplate;
 use Contao\CoreBundle\Controller\AbstractFragmentController;
 use Contao\CoreBundle\Routing\ScopeMatcher;
 use Contao\ModuleModel;
-use Contao\PageModel;
 use Contao\Template;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -24,13 +23,11 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 abstract class AbstractFrontendModuleController extends AbstractFragmentController
 {
-    public function __invoke(Request $request, ModuleModel $model, string $section, array $classes = null, PageModel $pageModel = null): Response
+    public function __invoke(Request $request, ModuleModel $model, string $section, array $classes = null): Response
     {
         if ($this->get('contao.routing.scope_matcher')->isBackendRequest($request)) {
             return $this->getBackendWildcard($model);
         }
-
-        $this->setPageModel($pageModel);
 
         $type = $this->getType();
         $template = $this->createTemplate($model, 'mod_'.$type);

--- a/core-bundle/src/Resources/config/services.yml
+++ b/core-bundle/src/Resources/config/services.yml
@@ -33,6 +33,7 @@ services:
         class: Contao\CoreBundle\Asset\ContaoContext
         arguments:
             - '@request_stack'
+            - '@contao.framework'
             - staticPlugins
             - '%kernel.debug%'
         public: true
@@ -41,6 +42,7 @@ services:
         class: Contao\CoreBundle\Asset\ContaoContext
         arguments:
             - '@request_stack'
+            - '@contao.framework'
             - staticFiles
             - '%kernel.debug%'
         public: true

--- a/core-bundle/tests/Asset/ContaoContextTest.php
+++ b/core-bundle/tests/Asset/ContaoContextTest.php
@@ -61,6 +61,7 @@ class ContaoContextTest extends TestCase
             ->method('getBasePath')
             ->willReturn($basePath)
         ;
+
         $request->attributes = $this->createMock(ParameterBag::class);
 
         $requestStack = new RequestStack();
@@ -159,6 +160,7 @@ class ContaoContextTest extends TestCase
             ->method('getBasePath')
             ->willReturn($basePath)
         ;
+
         $request->attributes = new ParameterBag(['pageModel' => 42]);
 
         $requestStack = new RequestStack();
@@ -207,6 +209,7 @@ class ContaoContextTest extends TestCase
             ->method('getBasePath')
             ->willReturn('/foo')
         ;
+
         $request->attributes = $this->createMock(ParameterBag::class);
 
         $requestStack = new RequestStack();
@@ -299,7 +302,6 @@ class ContaoContextTest extends TestCase
         }
 
         $framework = $this->mockContaoFramework();
-
         $framework
             ->expects($this->never())
             ->method('initialize')

--- a/core-bundle/tests/Asset/ContaoContextTest.php
+++ b/core-bundle/tests/Asset/ContaoContextTest.php
@@ -17,6 +17,7 @@ use Contao\CoreBundle\Config\ResourceFinder;
 use Contao\CoreBundle\Tests\TestCase;
 use Contao\PageModel;
 use Contao\System;
+use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
@@ -24,7 +25,7 @@ class ContaoContextTest extends TestCase
 {
     public function testReturnsAnEmptyBasePathInDebugMode(): void
     {
-        $context = new ContaoContext(new RequestStack(), 'staticPlugins', true);
+        $context = new ContaoContext(new RequestStack(), $this->mockContaoFramework(), 'staticPlugins', true);
 
         $this->assertSame('', $context->getBasePath());
     }
@@ -60,6 +61,7 @@ class ContaoContextTest extends TestCase
             ->method('getBasePath')
             ->willReturn($basePath)
         ;
+        $request->attributes = $this->createMock(ParameterBag::class);
 
         $requestStack = new RequestStack();
         $requestStack->push($request);
@@ -71,6 +73,117 @@ class ContaoContextTest extends TestCase
         $GLOBALS['objPage'] = $page;
 
         $context = $this->getContaoContext('staticPlugins', $requestStack);
+
+        $this->assertSame($expected, $context->getBasePath());
+
+        unset($GLOBALS['objPage']);
+    }
+
+    /**
+     * @dataProvider getBasePaths
+     */
+    public function testUsesThePageModelFromRequestAttributes(string $domain, bool $useSSL, string $basePath, string $expected): void
+    {
+        $request = $this->createMock(Request::class);
+        $request
+            ->expects($this->once())
+            ->method('getBasePath')
+            ->willReturn($basePath)
+        ;
+
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
+        $page = $this->getPageWithDetails();
+        $page->rootUseSSL = $useSSL;
+        $page->staticPlugins = $domain;
+
+        $request->attributes = new ParameterBag(['pageModel' => $page]);
+        unset($GLOBALS['objPage']);
+
+        $context = $this->getContaoContext('staticPlugins', $requestStack);
+
+        $this->assertSame($expected, $context->getBasePath());
+    }
+
+    /**
+     * @dataProvider getBasePaths
+     */
+    public function testGetsPageModelFromIdInRequestAttributes(string $domain, bool $useSSL, string $basePath, string $expected): void
+    {
+        $request = $this->createMock(Request::class);
+        $request
+            ->expects($this->once())
+            ->method('getBasePath')
+            ->willReturn($basePath)
+        ;
+
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
+        $page = $this->getPageWithDetails();
+        $page->id = 42;
+        $page->rootUseSSL = $useSSL;
+        $page->staticPlugins = $domain;
+
+        $request->attributes = new ParameterBag(['pageModel' => 42]);
+        unset($GLOBALS['objPage']);
+
+        $pageAdapter = $this->mockAdapter(['findByPk']);
+        $pageAdapter
+            ->expects($this->atLeastOnce())
+            ->method('findByPk')
+            ->with(42)
+            ->willReturn($page)
+        ;
+
+        $framework = $this->mockContaoFramework([PageModel::class => $pageAdapter]);
+        $framework
+            ->expects($this->atLeastOnce())
+            ->method('initialize')
+        ;
+
+        $context = new ContaoContext($requestStack, $framework, 'staticPlugins');
+
+        $this->assertSame($expected, $context->getBasePath());
+    }
+
+    /**
+     * @dataProvider getBasePaths
+     */
+    public function testUsesTheGlobalPageModelWithSameIdInRequestAttributes(string $domain, bool $useSSL, string $basePath, string $expected): void
+    {
+        $request = $this->createMock(Request::class);
+        $request
+            ->expects($this->once())
+            ->method('getBasePath')
+            ->willReturn($basePath)
+        ;
+        $request->attributes = new ParameterBag(['pageModel' => 42]);
+
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
+        $page = $this->getPageWithDetails();
+        $page->id = 42;
+        $page->rootUseSSL = $useSSL;
+        $page->staticPlugins = $domain;
+
+        $GLOBALS['objPage'] = $page;
+
+        $pageAdapter = $this->mockAdapter(['findByPk']);
+        $pageAdapter
+            ->expects($this->never())
+            ->method('findByPk')
+        ;
+
+        $framework = $this->mockContaoFramework([PageModel::class => $pageAdapter]);
+        $framework
+            ->expects($this->never())
+            ->method('initialize')
+        ;
+
+        $context = new ContaoContext($requestStack, $framework, 'staticPlugins');
 
         $this->assertSame($expected, $context->getBasePath());
 
@@ -94,6 +207,7 @@ class ContaoContextTest extends TestCase
             ->method('getBasePath')
             ->willReturn('/foo')
         ;
+        $request->attributes = $this->createMock(ParameterBag::class);
 
         $requestStack = new RequestStack();
         $requestStack->push($request);
@@ -111,7 +225,7 @@ class ContaoContextTest extends TestCase
 
     public function testReturnsAnEmptyStaticUrlIfTheBasePathIsEmpty(): void
     {
-        $context = new ContaoContext(new RequestStack(), 'staticPlugins');
+        $context = new ContaoContext(new RequestStack(), $this->mockContaoFramework(), 'staticPlugins');
 
         $this->assertSame('', $context->getStaticUrl());
     }
@@ -135,7 +249,10 @@ class ContaoContextTest extends TestCase
 
     public function testReadsTheSslConfigurationFromTheRequest(): void
     {
+        unset($GLOBALS['objPage']);
+
         $request = new Request();
+        $request->attributes = $this->createMock(ParameterBag::class);
 
         $requestStack = new RequestStack();
         $requestStack->push($request);
@@ -181,6 +298,13 @@ class ContaoContextTest extends TestCase
             $requestStack = new RequestStack();
         }
 
-        return new ContaoContext($requestStack, $field);
+        $framework = $this->mockContaoFramework();
+
+        $framework
+            ->expects($this->never())
+            ->method('initialize')
+        ;
+
+        return new ContaoContext($requestStack, $framework, $field);
     }
 }

--- a/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
+++ b/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
@@ -1190,6 +1190,7 @@ class ContaoCoreExtensionTest extends TestCase
         $this->assertEquals(
             [
                 new Reference('request_stack'),
+                new Reference('contao.framework'),
                 new Reference('staticPlugins'),
                 new Reference('%kernel.debug%'),
             ],
@@ -1209,6 +1210,7 @@ class ContaoCoreExtensionTest extends TestCase
         $this->assertEquals(
             [
                 new Reference('request_stack'),
+                new Reference('contao.framework'),
                 new Reference('staticFiles'),
                 new Reference('%kernel.debug%'),
             ],


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #2506
| Docs PR or issue | https://github.com/contao/docs/pull/629

The changes introduced in #2506 cause the following warning if the `__invoke` method is extended.

`
Warning: Declaration of App\Controller\FrontendModule\MyController::__invoke(Symfony\Component\HttpFoundation\Request $request, Contao\ModuleModel $model, string $section, ?array $classes = NULL): Symfony\Component\HttpFoundation\Response should be compatible with Contao\CoreBundle\Controller\FrontendModule\AbstractFrontendModuleController::__invoke(Symfony\Component\HttpFoundation\Request $request, Contao\ModuleModel $model, string $section, ?array $classes = NULL, ?Contao\PageModel $pageModel = NULL): Symfony\Component\HttpFoundation\Response  
`

This PR fixes that by not relying on the argument resolver but duplicate the functionality inside the abstract controller. While implementing it, I notices the asset context would not behave correctly in a fragment case either.

I think we should introduce a service in Contao 4.1x to get the page model, and possibly also set the page title etc. But this would certainly be a feature we can't have in 4.9 just yet.