### PR TITLE
Cast numeric identifiers to int in the FigureBuilder

### DIFF
--- a/core-bundle/src/Image/Studio/FigureBuilder.php
+++ b/core-bundle/src/Image/Studio/FigureBuilder.php
@@ -279,7 +279,7 @@ class FigureBuilder
         }
 
         if (is_numeric($identifier)) {
-            return $this->fromId($identifier);
+            return $this->fromId((int) $identifier);
         }
 
         return $this->fromPath($identifier);

--- a/core-bundle/tests/Image/Studio/FigureBuilderTest.php
+++ b/core-bundle/tests/Image/Studio/FigureBuilderTest.php
@@ -315,7 +315,9 @@ class FigureBuilderTest extends TestCase
 
         yield 'uuid' => ['1d902bf1-2683-406e-b004-f0b59095e5a1'];
 
-        yield 'id' => [5];
+        yield 'id as integer' => [5];
+
+        yield 'id as string' => ['5'];
 
         yield 'relative path' => [$relativeFilePath];
 


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes -
| Docs PR or issue | -

When auto detecting the resource type in the `FigureBuilder` a numeric identifier should always be cast to an integer. Otherwise `fromId()` will fail with a `TypeError` when called with a numeric string.