### PR TITLE
Correctly validate min and max values in text fields

### DIFF
--- a/core-bundle/src/Resources/contao/forms/FormTextField.php
+++ b/core-bundle/src/Resources/contao/forms/FormTextField.php
@@ -202,8 +202,8 @@ class FormTextField extends Widget
 				{
 					return $this->arrAttributes['min'];
 				}
-				return parent::__get($strKey);
 
+				return parent::__get($strKey);
 
 			case 'max':
 			case 'maxval':
@@ -211,6 +211,7 @@ class FormTextField extends Widget
 				{
 					return $this->arrAttributes['max'];
 				}
+
 				return parent::__get($strKey);
 
 			default:

--- a/core-bundle/src/Resources/contao/forms/FormTextField.php
+++ b/core-bundle/src/Resources/contao/forms/FormTextField.php
@@ -99,7 +99,6 @@ class FormTextField extends Widget
 			case 'minval':
 				if ($this->rgxp == 'digit')
 				{
-					$this->arrConfiguration['minval'] = $varValue;
 					$this->arrAttributes['min'] = $varValue;
 				}
 				break;
@@ -108,7 +107,6 @@ class FormTextField extends Widget
 			case 'maxval':
 				if ($this->rgxp == 'digit')
 				{
-					$this->arrConfiguration['maxval'] = $varValue;
 					$this->arrAttributes['max'] = $varValue;
 				}
 				break;
@@ -197,6 +195,23 @@ class FormTextField extends Widget
 				}
 
 				return 'text';
+
+			case 'min':
+			case 'minval':
+				if ($this->rgxp == 'digit')
+				{
+					return $this->arrAttributes['min'];
+				}
+				return parent::__get($strKey);
+
+
+			case 'max':
+			case 'maxval':
+				if ($this->rgxp == 'digit')
+				{
+					return $this->arrAttributes['max'];
+				}
+				return parent::__get($strKey);
 
 			default:
 				return parent::__get($strKey);

--- a/core-bundle/src/Resources/contao/forms/FormTextField.php
+++ b/core-bundle/src/Resources/contao/forms/FormTextField.php
@@ -99,6 +99,7 @@ class FormTextField extends Widget
 			case 'minval':
 				if ($this->rgxp == 'digit')
 				{
+					$this->arrConfiguration['minval'] = $varValue;
 					$this->arrAttributes['min'] = $varValue;
 				}
 				break;
@@ -107,6 +108,7 @@ class FormTextField extends Widget
 			case 'maxval':
 				if ($this->rgxp == 'digit')
 				{
+					$this->arrConfiguration['maxval'] = $varValue;
 					$this->arrAttributes['max'] = $varValue;
 				}
 				break;


### PR DESCRIPTION
Without the config value, the input is not validated on the server (e.g. if browser side validation is disabled): https://github.com/contao/contao/blob/master/core-bundle/src/Resources/contao/library/Contao/Widget.php#L840