### PR TITLE
Fix the news link markup

### DIFF
--- a/news-bundle/src/Resources/contao/modules/ModuleNews.php
+++ b/news-bundle/src/Resources/contao/modules/ModuleNews.php
@@ -362,12 +362,16 @@ abstract class ModuleNews extends Module
 	 */
 	protected function generateLink($strLink, $objArticle, $blnAddArchive=false, $blnIsReadMore=false)
 	{
+		$blnIsInternal = $objArticle->source != 'external';
+		$strReadMore = $blnIsInternal ? $GLOBALS['TL_LANG']['MSC']['readMore'] : $GLOBALS['TL_LANG']['MSC']['open'];
+		$strArticleUrl = News::generateNewsUrl($objArticle, $blnAddArchive);
+
 		return sprintf(
 			'<a href="%s" title="%s" itemprop="url">%s%s</a>',
-			News::generateNewsUrl($objArticle, $blnAddArchive),
-			StringUtil::specialchars(sprintf($GLOBALS['TL_LANG']['MSC']['readMore'], $objArticle->headline), true),
+			$strArticleUrl,
+			StringUtil::specialchars(sprintf($strReadMore, $blnIsInternal ? $objArticle->headline : $strArticleUrl), true),
 			($blnIsReadMore ? $strLink : '<span itemprop="headline">'.$strLink.'</span>'),
-			($blnIsReadMore && $objArticle->source != 'external' ? '<span class="invisible"> ' . $objArticle->headline . '</span>' : '')
+			($blnIsReadMore && $blnIsInternal ? '<span class="invisible"> ' . $objArticle->headline . '</span>' : '')
 		);
 	}
 }

--- a/news-bundle/src/Resources/contao/modules/ModuleNews.php
+++ b/news-bundle/src/Resources/contao/modules/ModuleNews.php
@@ -362,37 +362,12 @@ abstract class ModuleNews extends Module
 	 */
 	protected function generateLink($strLink, $objArticle, $blnAddArchive=false, $blnIsReadMore=false)
 	{
-		// Internal link
-		if ($objArticle->source != 'external')
-		{
-			return sprintf(
-				'<a href="%s" title="%s" itemprop="url"><span itemprop="headline">%s</span>%s</a>',
-				News::generateNewsUrl($objArticle, $blnAddArchive),
-				StringUtil::specialchars(sprintf($GLOBALS['TL_LANG']['MSC']['readMore'], $objArticle->headline), true),
-				$strLink,
-				($blnIsReadMore ? '<span class="invisible"> ' . $objArticle->headline . '</span>' : '')
-			);
-		}
-
-		// Encode e-mail addresses
-		if (0 === strncmp($objArticle->url, 'mailto:', 7))
-		{
-			$strArticleUrl = StringUtil::encodeEmail($objArticle->url);
-		}
-
-		// Ampersand URIs
-		else
-		{
-			$strArticleUrl = ampersand($objArticle->url);
-		}
-
-		// External link
 		return sprintf(
-			'<a href="%s" title="%s"%s itemprop="url"><span itemprop="headline">%s</span></a>',
-			$strArticleUrl,
-			StringUtil::specialchars(sprintf($GLOBALS['TL_LANG']['MSC']['open'], $strArticleUrl)),
-			($objArticle->target ? ' target="_blank" rel="noreferrer noopener"' : ''),
-			$strLink
+			'<a href="%s" title="%s" itemprop="url">%s%s</a>',
+			News::generateNewsUrl($objArticle, $blnAddArchive),
+			StringUtil::specialchars(sprintf($GLOBALS['TL_LANG']['MSC']['readMore'], $objArticle->headline), true),
+			($blnIsReadMore ? $strLink : '<span itemprop="headline">'.$strLink.'</span>'),
+			($blnIsReadMore && $objArticle->source != 'external' ? '<span class="invisible"> ' . $objArticle->headline . '</span>' : '')
 		);
 	}
 }

--- a/news-bundle/src/Resources/contao/modules/ModuleNews.php
+++ b/news-bundle/src/Resources/contao/modules/ModuleNews.php
@@ -370,7 +370,7 @@ abstract class ModuleNews extends Module
 			'<a href="%s" title="%s" itemprop="url">%s%s</a>',
 			$strArticleUrl,
 			StringUtil::specialchars(sprintf($strReadMore, $blnIsInternal ? $objArticle->headline : $strArticleUrl), true),
-			($blnIsReadMore ? $strLink : '<span itemprop="headline">'.$strLink.'</span>'),
+			($blnIsReadMore ? $strLink : '<span itemprop="headline">' . $strLink . '</span>'),
 			($blnIsReadMore && $blnIsInternal ? '<span class="invisible"> ' . $objArticle->headline . '</span>' : '')
 		);
 	}


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes https://github.com/contao/contao/issues/2396#issuecomment-703212985
| Docs PR or issue | -

This fixes the issue mentioned [here](https://github.com/contao/contao/issues/2396#issuecomment-703212985).

## Comparisons

### `news_latest`

#### Internal News

##### Before

```html
<div class="layout_latest arc_1 block odd" itemscope="" itemtype="http://schema.org/Article">
  <h2 itemprop="name">
    <a href="en/news/lorem-ipsum-foobar" title="Read the article: Lorem ipsum foobar" itemprop="url">
      <span itemprop="headline">Lorem ipsum foobar</span>
    </a>
  </h2>
  <p class="more">
    <a href="en/news/lorem-ipsum-foobar" title="Read the article: Lorem ipsum foobar" itemprop="url">
      <span itemprop="headline">Read more …</span>
      <span class="invisible"> Lorem ipsum foobar</span>
    </a>
  </p>
</div>
```

##### After

```html
<div class="layout_latest arc_1 block odd" itemscope="" itemtype="http://schema.org/Article">
  <h2 itemprop="name">
    <a href="en/news/lorem-ipsum-foobar" title="Read the article: Lorem ipsum foobar" itemprop="url">
      <span itemprop="headline">Lorem ipsum foobar</span>
    </a>
  </h2>
  <p class="more">
    <a href="en/news/lorem-ipsum-foobar" title="Read the article: Lorem ipsum foobar" itemprop="url">
      Read more …
      <span class="invisible"> Lorem ipsum foobar</span>
    </a>
  </p>
</div>
```

#### External News

##### Before

```html
<div class="layout_latest arc_1 block first even" itemscope="" itemtype="http://schema.org/Article">
  <h2 itemprop="name">
    <a href="https://twitter.com/" title="Read more on https://twitter.com/" itemprop="url">
      <span itemprop="headline">External</span>
    </a>
  </h2>
  <p class="more">
    <a href="https://twitter.com/" title="Read more on https://twitter.com/" itemprop="url">
      <span itemprop="headline">Read more …</span>
    </a>
  </p>
</div>
```

##### After

```html
<div class="layout_latest arc_1 block first even" itemscope="" itemtype="http://schema.org/Article">
  <h2 itemprop="name">
    <a href="https://twitter.com/" title="Read more on https://twitter.com/" itemprop="url">
      <span itemprop="headline">External</span>
    </a>
  </h2>
  <p class="more">
    <a href="https://twitter.com/" title="Read more on https://twitter.com/" itemprop="url">
      Read more …
    </a>
  </p>
</div>
```

### `news_simple`

#### Internal News

##### Before

```html
<div class="layout_simple arc_1 block odd" itemscope="" itemtype="http://schema.org/Article">
  <a href="en/news/lorem-ipsum-foobar" title="Read the article: Lorem ipsum foobar" itemprop="url">
    <span itemprop="headline">Lorem ipsum foobar</span>
  </a>
</div>
```

##### After

```html
<div class="layout_simple arc_1 block odd" itemscope="" itemtype="http://schema.org/Article">
  <a href="en/news/lorem-ipsum-foobar" title="Read the article: Lorem ipsum foobar" itemprop="url">
    <span itemprop="headline">Lorem ipsum foobar</span>
  </a>
</div>
```

(No change)

### External News

#### Before

```html
<div class="layout_simple arc_1 block first even" itemscope="" itemtype="http://schema.org/Article">
  <a href="https://twitter.com/" title="Read more on https://twitter.com/" itemprop="url">
    <span itemprop="headline">External</span>
  </a>
</div>
```

##### After

```html
<div class="layout_simple arc_1 block first even" itemscope="" itemtype="http://schema.org/Article">
  <a href="https://twitter.com/" title="Read more on https://twitter.com/" itemprop="url">
    <span itemprop="headline">External</span>
  </a>
</div>
```

(No change)

## Notes

* This generates a more sensible markup, essentially only replacing `<span itemprop="headline">Read more …</span>` with `Read more …` (as _Read more …_ is not in fact the headline).
* The `ModuleNews::generateLink` function previously also handled e-mail addresses and ampersands for external URLs itself. However, `News::generateNewsUrl` already takes care of that, so I have removed that part.
