### PR TITLE
Use the token checker instead of FE_USER_LOGGED_IN constant

### DIFF
--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -1,5 +1,14 @@
 # Deprecated features
 
+## FE_USER_LOGGED_IN
+
+The constant `FE_USER_LOGGED_IN` has been deprecated and will be removed in
+Contao 5.0. Use the token checker service instead:
+
+```php
+$hasFrontendUser = System::getContainer()->get('contao.security.token_checker')->hasFrontendUser();
+```
+
 ## kernel.packages
 
 The `kernel.packages` parameter has been deprecated in Contao 4.5 and will be
@@ -292,7 +301,7 @@ $refererId = System::getContainer()->get('request_stack')->getCurrentRequest()->
 
 ## PHP entry points
 
-Contao 4 only uses a single PHP entry point, namely the `index.php` or 
+Contao 4 only uses a single PHP entry point, namely the `index.php` or
 `preview.php` file. The previous PHP entry points have been removed and a route
 has been set up for each one instead (see UPGRADE.md).
 
@@ -363,12 +372,3 @@ Subscribe to one of the Symfony events instead (e.g. `kernel.request`).
 Using the `langconfig.php` file to adjust translations is deprecated in Contao
 4.0 and will no longer be supported in Contao 5.0. Add the language files with
 your modifications to the `contao/languages` folder instead.
-
-## FE_USER_LOGGED_IN
-
-The constant `FE_USER_LOGGED_IN` has been deprecated and will be removed in Contao
-5.0. Use the token checker service instead:
-
-```php
-$hasFrontendUser = System::getContainer()->get('contao.security.token_checker')->hasFrontendUser();
-```

--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -363,3 +363,12 @@ Subscribe to one of the Symfony events instead (e.g. `kernel.request`).
 Using the `langconfig.php` file to adjust translations is deprecated in Contao
 4.0 and will no longer be supported in Contao 5.0. Add the language files with
 your modifications to the `contao/languages` folder instead.
+
+## FE_USER_LOGGED_IN
+
+The constant `FE_USER_LOGGED_IN` has been deprecated and will be removed in Contao
+5.0. Use the token checker service instead:
+
+```php
+$hasFrontendUser = System::getContainer()->get('contao.security.token_checker')->hasFrontendUser();
+```

--- a/calendar-bundle/src/Resources/contao/classes/Events.php
+++ b/calendar-bundle/src/Resources/contao/classes/Events.php
@@ -69,11 +69,13 @@ abstract class Events extends Module
 
 		if ($objCalendar !== null)
 		{
+			$blnFeUserLoggedIn = System::getContainer()->get('contao.security.token_checker')->hasFrontendUser();
+
 			while ($objCalendar->next())
 			{
 				if ($objCalendar->protected)
 				{
-					if (!FE_USER_LOGGED_IN || !\is_array($this->User->groups))
+					if (!$blnFeUserLoggedIn || !\is_array($this->User->groups))
 					{
 						continue;
 					}

--- a/comments-bundle/src/Resources/contao/classes/Comments.php
+++ b/comments-bundle/src/Resources/contao/classes/Comments.php
@@ -172,7 +172,7 @@ class Comments extends Frontend
 		$this->import(FrontendUser::class, 'User');
 
 		// Access control
-		if ($objConfig->requireLogin && !FE_USER_LOGGED_IN)
+		if ($objConfig->requireLogin && !System::getContainer()->get('contao.security.token_checker')->hasFrontendUser())
 		{
 			$objTemplate->requireLogin = true;
 			$objTemplate->login = $GLOBALS['TL_LANG']['MSC']['com_login'];

--- a/core-bundle/src/Resources/contao/elements/ContentDownloads.php
+++ b/core-bundle/src/Resources/contao/elements/ContentDownloads.php
@@ -40,7 +40,7 @@ class ContentDownloads extends ContentElement
 	public function generate()
 	{
 		// Use the home directory of the current user as file source
-		if ($this->useHomeDir && FE_USER_LOGGED_IN)
+		if ($this->useHomeDir && System::getContainer()->get('contao.security.token_checker')->hasFrontendUser())
 		{
 			$this->import(FrontendUser::class, 'User');
 

--- a/core-bundle/src/Resources/contao/elements/ContentGallery.php
+++ b/core-bundle/src/Resources/contao/elements/ContentGallery.php
@@ -40,7 +40,7 @@ class ContentGallery extends ContentElement
 	public function generate()
 	{
 		// Use the home directory of the current user as file source
-		if ($this->useHomeDir && FE_USER_LOGGED_IN)
+		if ($this->useHomeDir && System::getContainer()->get('contao.security.token_checker')->hasFrontendUser())
 		{
 			$this->import(FrontendUser::class, 'User');
 

--- a/core-bundle/src/Resources/contao/forms/Form.php
+++ b/core-bundle/src/Resources/contao/forms/Form.php
@@ -539,7 +539,7 @@ class Form extends Hybrid
 		$_SESSION['FILES'] = array(); // DO NOT CHANGE
 
 		// Add a log entry
-		if (FE_USER_LOGGED_IN)
+		if (System::getContainer()->get('contao.security.token_checker')->hasFrontendUser())
 		{
 			$this->import(FrontendUser::class, 'User');
 			$this->log('Form "' . $this->title . '" has been submitted by "' . $this->User->username . '".', __METHOD__, TL_FORMS);

--- a/core-bundle/src/Resources/contao/forms/FormFileUpload.php
+++ b/core-bundle/src/Resources/contao/forms/FormFileUpload.php
@@ -212,7 +212,7 @@ class FormFileUpload extends Widget implements \uploadable
 				$intUploadFolder = $this->uploadFolder;
 
 				// Overwrite the upload folder with user's home directory
-				if ($this->useHomeDir && FE_USER_LOGGED_IN)
+				if ($this->useHomeDir && System::getContainer()->get('contao.security.token_checker')->hasFrontendUser())
 				{
 					$this->import(FrontendUser::class, 'User');
 

--- a/core-bundle/src/Resources/contao/library/Contao/Controller.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Controller.php
@@ -738,10 +738,12 @@ abstract class Controller extends System
 		// Only apply the restrictions in the front end
 		if (TL_MODE == 'FE')
 		{
+			$blnFeUserLoggedIn = System::getContainer()->get('contao.security.token_checker')->hasFrontendUser();
+
 			// Protected element
 			if ($objElement->protected)
 			{
-				if (!FE_USER_LOGGED_IN)
+				if (!$blnFeUserLoggedIn)
 				{
 					$blnReturn = false;
 				}
@@ -766,7 +768,7 @@ abstract class Controller extends System
 			}
 
 			// Show to guests only
-			elseif ($objElement->guests && FE_USER_LOGGED_IN)
+			elseif ($objElement->guests && $blnFeUserLoggedIn)
 			{
 				$blnReturn = false;
 			}

--- a/core-bundle/src/Resources/contao/library/Contao/InsertTags.php
+++ b/core-bundle/src/Resources/contao/library/Contao/InsertTags.php
@@ -98,6 +98,7 @@ class InsertTags extends Controller
 
 		$strBuffer = '';
 		$container = System::getContainer();
+		$blnFeUserLoggedIn = $container->get('contao.security.token_checker')->hasFrontendUser();
 
 		// Create one cache per cache setting (see #7700)
 		$arrCache = &static::$arrItCache[$blnCache];
@@ -295,7 +296,7 @@ class InsertTags extends Controller
 
 				// Front end user
 				case 'user':
-					if (FE_USER_LOGGED_IN)
+					if ($blnFeUserLoggedIn)
 					{
 						$this->import(FrontendUser::class, 'User');
 						$value = $this->User->{$elements[1]};
@@ -399,7 +400,7 @@ class InsertTags extends Controller
 						// User login page
 						if ($elements[1] == 'login')
 						{
-							if (!FE_USER_LOGGED_IN)
+							if (!$blnFeUserLoggedIn)
 							{
 								break;
 							}

--- a/core-bundle/src/Resources/contao/models/PageModel.php
+++ b/core-bundle/src/Resources/contao/models/PageModel.php
@@ -599,8 +599,9 @@ class PageModel extends Model
 	public static function findPublishedSubpagesWithoutGuestsByPid($intPid, $blnShowHidden=false, $blnIsSitemap=false)
 	{
 		$time = Date::floorToMinute();
+		$blnFeUserLoggedIn = System::getContainer()->get('contao.security.token_checker')->hasFrontendUser();
 
-		$objSubpages = Database::getInstance()->prepare("SELECT p1.*, (SELECT COUNT(*) FROM tl_page p2 WHERE p2.pid=p1.id AND p2.type!='root' AND p2.type!='error_401' AND p2.type!='error_403' AND p2.type!='error_404'" . (!$blnShowHidden ? ($blnIsSitemap ? " AND (p2.hide='' OR sitemap='map_always')" : " AND p2.hide=''") : "") . (FE_USER_LOGGED_IN ? " AND p2.guests=''" : "") . (!BE_USER_LOGGED_IN ? " AND p2.published='1' AND (p2.start='' OR p2.start<='$time') AND (p2.stop='' OR p2.stop>'$time')" : "") . ") AS subpages FROM tl_page p1 WHERE p1.pid=? AND p1.type!='root' AND p1.type!='error_401' AND p1.type!='error_403' AND p1.type!='error_404'" . (!$blnShowHidden ? ($blnIsSitemap ? " AND (p1.hide='' OR sitemap='map_always')" : " AND p1.hide=''") : "") . (FE_USER_LOGGED_IN ? " AND p1.guests=''" : "") . (!BE_USER_LOGGED_IN ? " AND p1.published='1' AND (p1.start='' OR p1.start<='$time') AND (p1.stop='' OR p1.stop>'$time')" : "") . " ORDER BY p1.sorting")
+		$objSubpages = Database::getInstance()->prepare("SELECT p1.*, (SELECT COUNT(*) FROM tl_page p2 WHERE p2.pid=p1.id AND p2.type!='root' AND p2.type!='error_401' AND p2.type!='error_403' AND p2.type!='error_404'" . (!$blnShowHidden ? ($blnIsSitemap ? " AND (p2.hide='' OR sitemap='map_always')" : " AND p2.hide=''") : "") . ($blnFeUserLoggedIn ? " AND p2.guests=''" : "") . (!BE_USER_LOGGED_IN ? " AND p2.published='1' AND (p2.start='' OR p2.start<='$time') AND (p2.stop='' OR p2.stop>'$time')" : "") . ") AS subpages FROM tl_page p1 WHERE p1.pid=? AND p1.type!='root' AND p1.type!='error_401' AND p1.type!='error_403' AND p1.type!='error_404'" . (!$blnShowHidden ? ($blnIsSitemap ? " AND (p1.hide='' OR sitemap='map_always')" : " AND p1.hide=''") : "") . ($blnFeUserLoggedIn ? " AND p1.guests=''" : "") . (!BE_USER_LOGGED_IN ? " AND p1.published='1' AND (p1.start='' OR p1.start<='$time') AND (p1.stop='' OR p1.stop>'$time')" : "") . " ORDER BY p1.sorting")
 											  ->execute($intPid);
 
 		if ($objSubpages->numRows < 1)
@@ -634,7 +635,7 @@ class PageModel extends Model
 			$arrColumns[] = "$t.type!='root'";
 		}
 
-		if (FE_USER_LOGGED_IN)
+		if (System::getContainer()->get('contao.security.token_checker')->hasFrontendUser())
 		{
 			$arrColumns[] = "$t.guests=''";
 		}
@@ -666,7 +667,7 @@ class PageModel extends Model
 		$t = static::$strTable;
 		$arrColumns = array("$t.pid=? AND $t.type!='root' AND $t.type!='error_401' AND $t.type!='error_403' AND $t.type!='error_404'");
 
-		if (FE_USER_LOGGED_IN)
+		if (System::getContainer()->get('contao.security.token_checker')->hasFrontendUser())
 		{
 			$arrColumns[] = "$t.guests=''";
 		}

--- a/core-bundle/src/Resources/contao/modules/Module.php
+++ b/core-bundle/src/Resources/contao/modules/Module.php
@@ -274,7 +274,7 @@ abstract class Module extends Frontend
 		$groups = array();
 
 		// Get all groups of the current front end user
-		if (FE_USER_LOGGED_IN)
+		if (System::getContainer()->get('contao.security.token_checker')->hasFrontendUser())
 		{
 			$this->import(FrontendUser::class, 'User');
 			$groups = $this->User->groups;

--- a/core-bundle/src/Resources/contao/modules/ModuleBooknav.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleBooknav.php
@@ -77,7 +77,7 @@ class ModuleBooknav extends Module
 		$groups = array();
 
 		// Get all groups of the current front end user
-		if (FE_USER_LOGGED_IN)
+		if (System::getContainer()->get('contao.security.token_checker')->hasFrontendUser())
 		{
 			$this->import(FrontendUser::class, 'User');
 			$groups = $this->User->groups;

--- a/core-bundle/src/Resources/contao/modules/ModuleChangePassword.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleChangePassword.php
@@ -32,9 +32,11 @@ class ModuleChangePassword extends Module
 	 */
 	public function generate()
 	{
-		$request = System::getContainer()->get('request_stack')->getCurrentRequest();
+		$container = System::getContainer();
 
-		if ($request && System::getContainer()->get('contao.routing.scope_matcher')->isBackendRequest($request))
+		$request = $container->get('request_stack')->getCurrentRequest();
+
+		if ($request && $container->get('contao.routing.scope_matcher')->isBackendRequest($request))
 		{
 			$objTemplate = new BackendTemplate('be_wildcard');
 			$objTemplate->wildcard = '### ' . Utf8::strtoupper($GLOBALS['TL_LANG']['FMD']['changePassword'][0]) . ' ###';
@@ -47,7 +49,7 @@ class ModuleChangePassword extends Module
 		}
 
 		// Return if there is no logged in user
-		if (!FE_USER_LOGGED_IN)
+		if (!$container->get('contao.security.token_checker')->hasFrontendUser())
 		{
 			return '';
 		}

--- a/core-bundle/src/Resources/contao/modules/ModuleChangePassword.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleChangePassword.php
@@ -33,7 +33,6 @@ class ModuleChangePassword extends Module
 	public function generate()
 	{
 		$container = System::getContainer();
-
 		$request = $container->get('request_stack')->getCurrentRequest();
 
 		if ($request && $container->get('contao.routing.scope_matcher')->isBackendRequest($request))

--- a/core-bundle/src/Resources/contao/modules/ModuleCloseAccount.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleCloseAccount.php
@@ -33,7 +33,6 @@ class ModuleCloseAccount extends Module
 	public function generate()
 	{
 		$container = System::getContainer();
-
 		$request = $container->get('request_stack')->getCurrentRequest();
 
 		if ($request && $container->get('contao.routing.scope_matcher')->isBackendRequest($request))

--- a/core-bundle/src/Resources/contao/modules/ModuleCloseAccount.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleCloseAccount.php
@@ -32,9 +32,11 @@ class ModuleCloseAccount extends Module
 	 */
 	public function generate()
 	{
-		$request = System::getContainer()->get('request_stack')->getCurrentRequest();
+		$container = System::getContainer();
 
-		if ($request && System::getContainer()->get('contao.routing.scope_matcher')->isBackendRequest($request))
+		$request = $container->get('request_stack')->getCurrentRequest();
+
+		if ($request && $container->get('contao.routing.scope_matcher')->isBackendRequest($request))
 		{
 			$objTemplate = new BackendTemplate('be_wildcard');
 			$objTemplate->wildcard = '### ' . Utf8::strtoupper($GLOBALS['TL_LANG']['FMD']['closeAccount'][0]) . ' ###';
@@ -47,7 +49,7 @@ class ModuleCloseAccount extends Module
 		}
 
 		// Return if there is no logged in user
-		if (!FE_USER_LOGGED_IN)
+		if (!$container->get('contao.security.token_checker')->hasFrontendUser())
 		{
 			return '';
 		}

--- a/core-bundle/src/Resources/contao/modules/ModuleCustomnav.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleCustomnav.php
@@ -71,7 +71,7 @@ class ModuleCustomnav extends Module
 		$groups = array();
 
 		// Get all groups of the current front end user
-		if (FE_USER_LOGGED_IN)
+		if (System::getContainer()->get('contao.security.token_checker')->hasFrontendUser())
 		{
 			$this->import(FrontendUser::class, 'User');
 			$groups = $this->User->groups;

--- a/core-bundle/src/Resources/contao/modules/ModulePersonalData.php
+++ b/core-bundle/src/Resources/contao/modules/ModulePersonalData.php
@@ -36,7 +36,6 @@ class ModulePersonalData extends Module
 	public function generate()
 	{
 		$container = System::getContainer();
-
 		$request = $container->get('request_stack')->getCurrentRequest();
 
 		if ($request && $container->get('contao.routing.scope_matcher')->isBackendRequest($request))

--- a/core-bundle/src/Resources/contao/modules/ModulePersonalData.php
+++ b/core-bundle/src/Resources/contao/modules/ModulePersonalData.php
@@ -35,9 +35,11 @@ class ModulePersonalData extends Module
 	 */
 	public function generate()
 	{
-		$request = System::getContainer()->get('request_stack')->getCurrentRequest();
+		$container = System::getContainer();
 
-		if ($request && System::getContainer()->get('contao.routing.scope_matcher')->isBackendRequest($request))
+		$request = $container->get('request_stack')->getCurrentRequest();
+
+		if ($request && $container->get('contao.routing.scope_matcher')->isBackendRequest($request))
 		{
 			$objTemplate = new BackendTemplate('be_wildcard');
 			$objTemplate->wildcard = '### ' . Utf8::strtoupper($GLOBALS['TL_LANG']['FMD']['personalData'][0]) . ' ###';
@@ -52,7 +54,7 @@ class ModulePersonalData extends Module
 		$this->editable = StringUtil::deserialize($this->editable);
 
 		// Return if there are not editable fields or if there is no logged in user
-		if (empty($this->editable) || !\is_array($this->editable) || !FE_USER_LOGGED_IN)
+		if (empty($this->editable) || !\is_array($this->editable) || !$container->get('contao.security.token_checker')->hasFrontendUser())
 		{
 			return '';
 		}

--- a/core-bundle/src/Resources/contao/modules/ModuleQuicknav.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleQuicknav.php
@@ -108,7 +108,7 @@ class ModuleQuicknav extends Module
 		$arrPages = array();
 
 		// Get all groups of the current front end user
-		if (FE_USER_LOGGED_IN)
+		if (System::getContainer()->get('contao.security.token_checker')->hasFrontendUser())
 		{
 			$this->import(FrontendUser::class, 'User');
 			$groups = $this->User->groups;

--- a/core-bundle/src/Resources/contao/modules/ModuleSearch.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleSearch.php
@@ -188,12 +188,13 @@ class ModuleSearch extends Module
 			if (Config::get('indexProtected'))
 			{
 				$this->import(FrontendUser::class, 'User');
+				$blnFeUserLoggedIn = System::getContainer()->get('contao.security.token_checker')->hasFrontendUser();
 
 				foreach ($arrResult as $k=>$v)
 				{
 					if ($v['protected'])
 					{
-						if (!FE_USER_LOGGED_IN || !\is_array($this->User->groups))
+						if (!$blnFeUserLoggedIn || !\is_array($this->User->groups))
 						{
 							unset($arrResult[$k]);
 						}

--- a/news-bundle/src/Resources/contao/modules/ModuleNews.php
+++ b/news-bundle/src/Resources/contao/modules/ModuleNews.php
@@ -42,11 +42,13 @@ abstract class ModuleNews extends Module
 
 		if ($objArchive !== null)
 		{
+			$blnFeUserLoggedIn = System::getContainer()->get('contao.security.token_checker')->hasFrontendUser();
+
 			while ($objArchive->next())
 			{
 				if ($objArchive->protected)
 				{
-					if (!FE_USER_LOGGED_IN || !\is_array($this->User->groups))
+					if (!$blnFeUserLoggedIn || !\is_array($this->User->groups))
 					{
 						continue;
 					}


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #2576
| Docs PR or issue | -

This replaces the usage of the `FE_USER_LOGGED_IN` constant with the `contao.security.token_checker` service as discussed.
