### PR TITLE
Loosen type constraint for `$rowData['fullsize']`

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Controller.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Controller.php
@@ -1693,7 +1693,7 @@ abstract class Controller extends System
 			->setSize($size)
 			->setLightboxGroupIdentifier($lightboxGroupIdentifier)
 			->setLightboxSize($lightboxSize)
-			->enableLightbox('1' === ($rowData['fullsize'] ?? null))
+			->enableLightbox($rowData['fullsize'] ?? false)
 			->build();
 
 		// Build result and apply it to the template


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes -
| Docs PR or issue | -

We should not force `$rowData['fullsize']` to be exactly `'1'` but also allow other trueish values. 