### PR TITLE
Correctly match the language URL if there is no trailing slash

### DIFF
--- a/core-bundle/src/Routing/Candidates/AbstractCandidates.php
+++ b/core-bundle/src/Routing/Candidates/AbstractCandidates.php
@@ -93,7 +93,8 @@ class AbstractCandidates implements CandidatesInterface
 
         foreach ($this->urlPrefixes as $prefix) {
             // Language prefix only (e.g. URL = /en/)
-            if ($url === $prefix.'/') {
+            // Includes "/en" to redirect to language prefix with slash
+            if ($url === $prefix.'/' || $url === $prefix) {
                 $candidates[] = 'index';
                 continue;
             }

--- a/core-bundle/tests/Routing/Candidates/CandidatesTest.php
+++ b/core-bundle/tests/Routing/Candidates/CandidatesTest.php
@@ -244,6 +244,17 @@ class CandidatesTest extends TestCase
         ];
 
         yield [
+            '/en',
+            ['.html'],
+            ['en'],
+            [
+                'default' => ['index', '/', 15],
+                'legacy' => [],
+                'locale' => [],
+            ],
+        ];
+
+        yield [
             '/bar.php',
             ['.php'],
             [''],


### PR DESCRIPTION
If legacy mode is disabled, Contao 4.10 does currently not correctly redirect `https://example.org/de` to `https://example.org/de/`. Symfony actually performs a redirect automatically if the slash is missing, but we need to make sure to find the respective root/index page through our route candidates.