### PR TITLE
Use type="url" for httpurl text fields

### DIFF
--- a/core-bundle/src/Resources/contao/forms/FormTextField.php
+++ b/core-bundle/src/Resources/contao/forms/FormTextField.php
@@ -191,6 +191,7 @@ class FormTextField extends Widget
 						return 'email';
 
 					case 'url':
+					case 'httpurl':
 						return 'url';
 				}
 


### PR DESCRIPTION
When using `rgxp => httpurl` the form field type in the front end will be `type="text"` instead of `type="url"` currently. This PR fixes that.