### PR TITLE
Fix empty value for boolean type

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Widget.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Widget.php
@@ -1454,6 +1454,11 @@ abstract class Widget extends Controller
 					return 0;
 				}
 
+				if ($sql['type'] === Type::BOOLEAN)
+				{
+					return false;
+				}
+
 				return '';
 			}
 		}


### PR DESCRIPTION
See https://github.com/contao/contao/issues/2637#issuecomment-763886537

If you use `'sql' => ['type' => 'boolean', 'default' => false]` for your checkbox widget in `4.9.x-dev` or `4.11.0-RC1`, the unchecked value cannot be saved, because `Widget::getEmptyValueByFieldType()` would default to an empty string now.

This PR adds support for boolean field types.