### PR TITLE
Use a listener to reset custom templates

### DIFF
--- a/core-bundle/src/EventListener/DataContainer/ResetCustomTemplateListener.php
+++ b/core-bundle/src/EventListener/DataContainer/ResetCustomTemplateListener.php
@@ -12,15 +12,15 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\EventListener\DataContainer;
 
+use Contao\CoreBundle\ServiceAnnotation\Callback;
 use Contao\DataContainer;
 use Doctrine\DBAL\Connection;
-use Contao\CoreBundle\ServiceAnnotation\Callback;
 
 /**
  * @internal
  *
- * @Callback(table="tl_content", target="fields.customTpl.save")
- * @Callback(table="tl_module", target="fields.customTpl.save"
+ * @Callback(table="tl_content", target="fields.type.save")
+ * @Callback(table="tl_module", target="fields.type.save")
  */
 class ResetCustomTemplateListener
 {
@@ -35,7 +35,7 @@ class ResetCustomTemplateListener
     }
 
     /**
-     * Check if we need to reset the template
+     * Checks if we need to reset the template.
      *
      * @param mixed $varValue
      *
@@ -44,7 +44,7 @@ class ResetCustomTemplateListener
     public function __invoke($varValue, DataContainer $dc)
     {
         if ($dc->activeRecord->type !== $varValue) {
-            $GLOBALS['TL_DCA'][$dc->table]['onsubmit_callback'][] = function (DataContainer $dc) {
+            $GLOBALS['TL_DCA'][$dc->table]['onsubmit_callback'][] = function (DataContainer $dc): void {
                 $this->resetTemplate($dc);
             };
         }
@@ -53,7 +53,7 @@ class ResetCustomTemplateListener
     }
 
     /**
-     * Reset the template if the element type has changed
+     * Resets the template if the element type has changed.
      */
     private function resetTemplate(DataContainer $dc): void
     {
@@ -61,10 +61,6 @@ class ResetCustomTemplateListener
             return;
         }
 
-        $this->connection->update(
-            $dc->table,
-            ['customTpl' => ''],
-            ['id' => $dc->id]
-        );
+        $this->connection->update($dc->table, ['customTpl' => ''], ['id' => $dc->id]);
     }
 }

--- a/core-bundle/src/EventListener/DataContainer/ResetCustomTemplateListener.php
+++ b/core-bundle/src/EventListener/DataContainer/ResetCustomTemplateListener.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\EventListener\DataContainer;
+
+use Contao\DataContainer;
+use Doctrine\DBAL\Connection;
+use Contao\CoreBundle\ServiceAnnotation\Callback;
+
+/**
+ * @internal
+ *
+ * @Callback(table="tl_content", target="fields.customTpl.save")
+ * @Callback(table="tl_module", target="fields.customTpl.save"
+ */
+class ResetCustomTemplateListener
+{
+    /**
+     * @var Connection
+     */
+    private $connection;
+
+    public function __construct(Connection $connection)
+    {
+        $this->connection = $connection;
+    }
+
+    /**
+     * Check if we need to reset the template
+     *
+     * @param mixed $varValue
+     *
+     * @return mixed
+     */
+    public function __invoke($varValue, DataContainer $dc)
+    {
+        if ($dc->activeRecord->type !== $varValue) {
+            $GLOBALS['TL_DCA'][$dc->table]['onsubmit_callback'][] = function (DataContainer $dc) {
+                $this->resetTemplate($dc);
+            };
+        }
+
+        return $varValue;
+    }
+
+    /**
+     * Reset the template if the element type has changed
+     */
+    private function resetTemplate(DataContainer $dc): void
+    {
+        if (!$dc->id) {
+            return;
+        }
+
+        $this->connection->update(
+            $dc->table,
+            ['customTpl' => ''],
+            ['id' => $dc->id]
+        );
+    }
+}

--- a/core-bundle/src/EventListener/DataContainer/ResetCustomTemplateListener.php
+++ b/core-bundle/src/EventListener/DataContainer/ResetCustomTemplateListener.php
@@ -35,32 +35,22 @@ class ResetCustomTemplateListener
     }
 
     /**
-     * Checks if we need to reset the template.
-     *
-     * @param mixed $varValue
-     *
-     * @return mixed
+     * Resets the custom template if the element type changes.
      */
     public function __invoke($varValue, DataContainer $dc)
     {
-        if ($dc->activeRecord->type !== $varValue) {
-            $GLOBALS['TL_DCA'][$dc->table]['onsubmit_callback'][] = function (DataContainer $dc): void {
-                $this->resetTemplate($dc);
-            };
+        if ($dc->activeRecord->type === $varValue) {
+            return $varValue;
         }
+
+        $GLOBALS['TL_DCA'][$dc->table]['config']['onsubmit_callback'][] = function (DataContainer $dc): void {
+            if (!$dc->id) {
+                return;
+            }
+
+            $this->connection->update($dc->table, ['customTpl' => ''], ['id' => $dc->id]);
+        };
 
         return $varValue;
-    }
-
-    /**
-     * Resets the template if the element type has changed.
-     */
-    private function resetTemplate(DataContainer $dc): void
-    {
-        if (!$dc->id) {
-            return;
-        }
-
-        $this->connection->update($dc->table, ['customTpl' => ''], ['id' => $dc->id]);
     }
 }

--- a/core-bundle/src/Resources/config/listener.yml
+++ b/core-bundle/src/Resources/config/listener.yml
@@ -8,6 +8,10 @@ services:
             calls:
                 - [setContainer, ['@service_container']]
 
+    Contao\CoreBundle\EventListener\DataContainer\ResetCustomTemplateListener:
+        arguments:
+            - '@database_connection'
+
     contao.listener.backend_locale:
         class: Contao\CoreBundle\EventListener\BackendLocaleListener
         arguments:

--- a/core-bundle/src/Resources/contao/dca/tl_content.php
+++ b/core-bundle/src/Resources/contao/dca/tl_content.php
@@ -25,10 +25,6 @@ $GLOBALS['TL_DCA']['tl_content'] = array
 			array('tl_content', 'filterContentElements'),
 			array('tl_content', 'preserveReferenced')
 		),
-		'onsubmit_callback'             => array
-		(
-			array('tl_content', 'resetTemplate')
-		),
 		'sql' => array
 		(
 			'keys' => array
@@ -177,10 +173,6 @@ $GLOBALS['TL_DCA']['tl_content'] = array
 			'options_callback'        => array('tl_content', 'getContentElements'),
 			'reference'               => &$GLOBALS['TL_LANG']['CTE'],
 			'eval'                    => array('helpwizard'=>true, 'chosen'=>true, 'submitOnChange'=>true, 'tl_class'=>'w50'),
-			'save_callback' => array
-			(
-				array('tl_content', 'checkTemplate')
-			),
 			'sql'                     => array('name'=>'type', 'type'=>'string', 'length'=>64, 'default'=>'text')
 		),
 		'headline' => array
@@ -868,11 +860,6 @@ if (in_array(Contao\Input::get('do'), array('article', 'page')))
  */
 class tl_content extends Contao\Backend
 {
-	/**
-	 * @var bool
-	 */
-	private $resetTemplate = false;
-
 	/**
 	 * Import the back end user object
 	 */
@@ -1903,40 +1890,6 @@ class tl_content extends Contao\Backend
 		}
 
 		return $varValue;
-	}
-
-	/**
-	 * Check if we need to reset the template
-	 *
-	 * @param mixed                $varValue
-	 * @param Contao\DataContainer $dc
-	 *
-	 * @return mixed
-	 */
-	public function checkTemplate($varValue, Contao\DataContainer $dc)
-	{
-		if ($dc->activeRecord->type != $varValue)
-		{
-			$this->resetTemplate = true;
-		}
-
-		return $varValue;
-	}
-
-	/**
-	 * Reset the template if the element type has changed
-	 *
-	 * @param Contao\DataContainer $dc
-	 */
-	public function resetTemplate(Contao\DataContainer $dc)
-	{
-		if (!$dc->id || !$this->resetTemplate)
-		{
-			return;
-		}
-
-		$this->Database->prepare("UPDATE tl_content SET customTpl='' WHERE id=?")
-					   ->execute($dc->id);
 	}
 
 	/**

--- a/core-bundle/src/Resources/contao/dca/tl_module.php
+++ b/core-bundle/src/Resources/contao/dca/tl_module.php
@@ -22,10 +22,6 @@ $GLOBALS['TL_DCA']['tl_module'] = array
 			array('tl_module', 'checkPermission'),
 			array('tl_module', 'addCustomLayoutSectionReferences')
 		),
-		'onsubmit_callback'             => array
-		(
-			array('tl_module', 'resetTemplate')
-		),
 		'sql' => array
 		(
 			'keys' => array
@@ -176,10 +172,6 @@ $GLOBALS['TL_DCA']['tl_module'] = array
 			'options_callback'        => array('tl_module', 'getModules'),
 			'reference'               => &$GLOBALS['TL_LANG']['FMD'],
 			'eval'                    => array('helpwizard'=>true, 'chosen'=>true, 'submitOnChange'=>true, 'tl_class'=>'w50'),
-			'save_callback' => array
-			(
-				array('tl_module', 'checkTemplate')
-			),
 			'sql'                     => "varchar(64) NOT NULL default 'navigation'"
 		),
 		'levelOffset' => array
@@ -638,11 +630,6 @@ $GLOBALS['TL_DCA']['tl_module'] = array
 class tl_module extends Contao\Backend
 {
 	/**
-	 * @var bool
-	 */
-	private $resetTemplate = false;
-
-	/**
 	 * Import the back end user object
 	 */
 	public function __construct()
@@ -872,39 +859,5 @@ class tl_module extends Contao\Backend
 		}
 
 		return $varValue;
-	}
-
-	/**
-	 * Check if we need to reset the template
-	 *
-	 * @param mixed                $varValue
-	 * @param Contao\DataContainer $dc
-	 *
-	 * @return mixed
-	 */
-	public function checkTemplate($varValue, Contao\DataContainer $dc)
-	{
-		if ($dc->activeRecord->type != $varValue)
-		{
-			$this->resetTemplate = true;
-		}
-
-		return $varValue;
-	}
-
-	/**
-	 * Reset the template if the element type has changed
-	 *
-	 * @param Contao\DataContainer $dc
-	 */
-	public function resetTemplate(Contao\DataContainer $dc)
-	{
-		if (!$dc->id || !$this->resetTemplate)
-		{
-			return;
-		}
-
-		$this->Database->prepare("UPDATE tl_module SET customTpl='' WHERE id=?")
-					   ->execute($dc->id);
 	}
 }


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #2666

I'm sorry for the late response about #2666, @fritzmg is right there. The behaviour of adding new methods to `tl_` classes is discouraged and something we agreed not to do. Doing the same in a listener is much easier and more universal, see this PR changes. It also means we don't need to duplicate the code in multiple places.