### PR TITLE
Restore compatibility with scheb/2fa-bundle v5.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -73,7 +73,7 @@
         "psr/log": "^1.0",
         "ramsey/uuid": "^3.8",
         "scheb/2fa-backup-code": "^5.0",
-        "scheb/2fa-bundle": "^5.0",
+        "scheb/2fa-bundle": "^5.4.0",
         "scheb/2fa-trusted-device": "^5.0",
         "scssphp/scssphp": "^1.0",
         "simplepie/simplepie": "^1.3",

--- a/core-bundle/composer.json
+++ b/core-bundle/composer.json
@@ -69,7 +69,7 @@
         "psr/log": "^1.0",
         "ramsey/uuid": "^3.8",
         "scheb/2fa-backup-code": "^5.0",
-        "scheb/2fa-bundle": "^5.0",
+        "scheb/2fa-bundle": "^5.4.0",
         "scheb/2fa-trusted-device": "^5.0",
         "scssphp/scssphp": "^1.0",
         "simplepie/simplepie": "^1.3",

--- a/core-bundle/src/DependencyInjection/Security/ContaoLoginFactory.php
+++ b/core-bundle/src/DependencyInjection/Security/ContaoLoginFactory.php
@@ -53,11 +53,12 @@ class ContaoLoginFactory extends AbstractFactory
     {
         $twoFactorProviderId = TwoFactorFactory::PROVIDER_ID_PREFIX.$id;
         $twoFactorFirewallConfigId = 'contao.security.two_factor_firewall_config.'.$id;
-        $twoFactorFirewallConfig = new Definition(TwoFactorFirewallConfig::class, [$config, $id, null]);
+        $twoFactorFirewallConfig = new Definition(TwoFactorFirewallConfig::class, [$config, $id, null, null]);
 
         $container
             ->setDefinition($twoFactorFirewallConfigId, $twoFactorFirewallConfig)
             ->replaceArgument(2, new Reference('security.http_utils'))
+            ->replaceArgument(3, new Reference('scheb_two_factor.security.request_data_reader'))
         ;
 
         $container

--- a/core-bundle/tests/DependencyInjection/Security/ContaoLoginFactoryTest.php
+++ b/core-bundle/tests/DependencyInjection/Security/ContaoLoginFactoryTest.php
@@ -63,10 +63,11 @@ class ContaoLoginFactoryTest extends TestCase
         $arguments = $container->getDefinition($twoFactorFirewallConfigId)->getArguments();
 
         $this->assertIsArray($arguments);
-        $this->assertCount(3, $arguments);
+        $this->assertCount(4, $arguments);
         $this->assertSame(['remember_me' => true], $arguments[0]);
         $this->assertSame('contao_frontend', $arguments[1]);
         $this->assertEquals(new Reference('security.http_utils'), $arguments[2]);
+        $this->assertEquals(new Reference('scheb_two_factor.security.request_data_reader'), $arguments[3]);
 
         $this->assertTrue($container->hasDefinition($twoFactorProviderId));
 


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | -
| Related PR | #2617 
| Docs PR or issue | -

There was a change in scheb/2fa-bundle two hours ago: https://github.com/scheb/2fa-bundle/commit/05e7669088a02199e3f81abddb363f426ca0bbc1#diff-4fb3d6310ed5bd23d9a85bd9ad9e9d2447afae2152f76e98901fbf5da988b026R114

This results in the following error:

```
ArgumentCountError:
Too few arguments to function Scheb\TwoFactorBundle\Security\TwoFactor\TwoFactorFirewallConfig::__construct(), 3 passed in /Users/richard/Sites/zzzzz/var/cache/dev/ContainerN7uFMb5/getContao_Security_AuthenticationProvider_ContaoBackend_TwoFactorDecoratorService.php on line 36 and exactly 4 expected

  at vendor/scheb/2fa-bundle/Security/TwoFactor/TwoFactorFirewallConfig.php:37
  at Scheb\TwoFactorBundle\Security\TwoFactor\TwoFactorFirewallConfig->__construct(array('remember_me' => false, 'require_previous_session' => false), 'contao_backend', object(HttpUtils))
     (var/cache/dev/ContainerN7uFMb5/getContao_Security_AuthenticationProvider_ContaoBackend_TwoFactorDecoratorService.php:36)
  at ContainerN7uFMb5\getContao_Security_AuthenticationProvider_ContaoBackend_TwoFactorDecoratorService::do(object(Contao_ManagerBundle_HttpKernel_ContaoKernelDevDebugContainer), true)
     (var/cache/dev/ContainerN7uFMb5/Contao_ManagerBundle_HttpKernel_ContaoKernelDevDebugContainer.php:638)
  at ContainerN7uFMb5\Contao_ManagerBundle_HttpKernel_ContaoKernelDevDebugContainer->load('getContao_Security_AuthenticationProvider_ContaoBackend_TwoFactorDecoratorService.php')
     (var/cache/dev/ContainerN7uFMb5/Contao_ManagerBundle_HttpKernel_ContaoKernelDevDebugContainer.php:2481)
  at ContainerN7uFMb5\Contao_ManagerBundle_HttpKernel_ContaoKernelDevDebugContainer->ContainerN7uFMb5\{closure}()
     (vendor/symfony/security-core/Authentication/AuthenticationProviderManager.php:71)
  at Symfony\Component\Security\Core\Authentication\AuthenticationProviderManager->authenticate(object(AnonymousToken))
     (vendor/symfony/security-http/Firewall/AnonymousAuthenticationListener.php:68)
  at Symfony\Component\Security\Http\Firewall\AnonymousAuthenticationListener->authenticate(object(RequestEvent))
     (vendor/symfony/security-bundle/Debug/WrappedLazyListener.php:49)
  at Symfony\Bundle\SecurityBundle\Debug\WrappedLazyListener->authenticate(object(RequestEvent))
     (vendor/symfony/security-http/Firewall/AbstractListener.php:26)
  at Symfony\Component\Security\Http\Firewall\AbstractListener->__invoke(object(RequestEvent))
     (vendor/symfony/security-bundle/Debug/TraceableFirewallListener.php:62)
  at Symfony\Bundle\SecurityBundle\Debug\TraceableFirewallListener->callListeners(object(RequestEvent), object(Generator))
     (vendor/symfony/security-http/Firewall.php:86)
  at Symfony\Component\Security\Http\Firewall->onKernelRequest(object(RequestEvent), 'kernel.request', object(TraceableEventDispatcher))
     (vendor/symfony/event-dispatcher/Debug/WrappedListener.php:117)
  at Symfony\Component\EventDispatcher\Debug\WrappedListener->__invoke(object(RequestEvent), 'kernel.request', object(TraceableEventDispatcher))
     (vendor/symfony/event-dispatcher/EventDispatcher.php:230)
  at Symfony\Component\EventDispatcher\EventDispatcher->callListeners(array(object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener)), 'kernel.request', object(RequestEvent))
     (vendor/symfony/event-dispatcher/EventDispatcher.php:59)
  at Symfony\Component\EventDispatcher\EventDispatcher->dispatch(object(RequestEvent), 'kernel.request')
     (vendor/symfony/event-dispatcher/Debug/TraceableEventDispatcher.php:151)
  at Symfony\Component\EventDispatcher\Debug\TraceableEventDispatcher->dispatch(object(RequestEvent), 'kernel.request')
     (vendor/symfony/http-kernel/HttpKernel.php:133)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw(object(Request), 1)
     (vendor/symfony/http-kernel/HttpKernel.php:79)
  at Symfony\Component\HttpKernel\HttpKernel->handle(object(Request), 1, true)
     (vendor/symfony/http-kernel/Kernel.php:195)
  at Symfony\Component\HttpKernel\Kernel->handle(object(Request))
     (web/index.php:31)             
```


cc @bytehead 