### PR TITLE
Use the request attribute to determine preview mode

### DIFF
--- a/core-bundle/src/EventListener/PreviewAuthenticationListener.php
+++ b/core-bundle/src/EventListener/PreviewAuthenticationListener.php
@@ -58,6 +58,7 @@ class PreviewAuthenticationListener
 
         if (
             !$request->attributes->get('_preview', false)
+            || $this->scopeMatcher->isBackendRequest($request)
             || $this->tokenChecker->hasBackendUser()
         ) {
             return;

--- a/core-bundle/src/EventListener/PreviewAuthenticationListener.php
+++ b/core-bundle/src/EventListener/PreviewAuthenticationListener.php
@@ -44,18 +44,12 @@ class PreviewAuthenticationListener
      */
     private $uriSigner;
 
-    /**
-     * @var string
-     */
-    private $previewScript;
-
-    public function __construct(ScopeMatcher $scopeMatcher, TokenChecker $tokenChecker, UrlGeneratorInterface $router, UriSigner $uriSigner, string $previewScript)
+    public function __construct(ScopeMatcher $scopeMatcher, TokenChecker $tokenChecker, UrlGeneratorInterface $router, UriSigner $uriSigner)
     {
         $this->scopeMatcher = $scopeMatcher;
         $this->tokenChecker = $tokenChecker;
         $this->router = $router;
         $this->uriSigner = $uriSigner;
-        $this->previewScript = $previewScript;
     }
 
     public function __invoke(RequestEvent $event): void
@@ -63,9 +57,7 @@ class PreviewAuthenticationListener
         $request = $event->getRequest();
 
         if (
-            '' === $this->previewScript
-            || $request->getScriptName() !== $this->previewScript
-            || !$this->scopeMatcher->isFrontendRequest($request)
+            !$request->attributes->get('_preview', false)
             || $this->tokenChecker->hasBackendUser()
         ) {
             return;

--- a/core-bundle/src/EventListener/PreviewToolbarListener.php
+++ b/core-bundle/src/EventListener/PreviewToolbarListener.php
@@ -28,6 +28,8 @@ use Twig\Error\Error as TwigError;
  *
  * The toolbar is only injected on well-formed HTML with a proper </body> tag,
  * so is never included in sub-requests or ESI requests.
+ *
+ * @internal
  */
 class PreviewToolbarListener
 {
@@ -35,11 +37,6 @@ class PreviewToolbarListener
      * @var ScopeMatcher
      */
     private $scopeMatcher;
-
-    /**
-     * @var string
-     */
-    private $previewScript;
 
     /**
      * @var TwigEnvironment
@@ -51,9 +48,8 @@ class PreviewToolbarListener
      */
     private $router;
 
-    public function __construct(string $previewScript, ScopeMatcher $scopeMatcher, TwigEnvironment $twig, RouterInterface $router)
+    public function __construct(ScopeMatcher $scopeMatcher, TwigEnvironment $twig, RouterInterface $router)
     {
-        $this->previewScript = $previewScript;
         $this->scopeMatcher = $scopeMatcher;
         $this->twig = $twig;
         $this->router = $router;
@@ -61,20 +57,19 @@ class PreviewToolbarListener
 
     public function __invoke(ResponseEvent $event): void
     {
-        if (!$this->scopeMatcher->isFrontendMasterRequest($event)) {
+        if ($this->scopeMatcher->isBackendMasterRequest($event)) {
             return;
         }
 
         $request = $event->getRequest();
-
-        if ('' === $this->previewScript || $request->getScriptName() !== $this->previewScript) {
-            return;
-        }
-
         $response = $event->getResponse();
 
         // Do not capture redirects, errors, or modify XML HTTP Requests
-        if ($request->isXmlHttpRequest() || !($response->isSuccessful() || $response->isClientError())) {
+        if (
+            !$request->attributes->get('_preview', false)
+            || $request->isXmlHttpRequest()
+            || !($response->isSuccessful() || $response->isClientError())
+        ) {
             return;
         }
 

--- a/core-bundle/src/Resources/config/listener.yml
+++ b/core-bundle/src/Resources/config/listener.yml
@@ -170,7 +170,6 @@ services:
     contao.listener.preview_bar:
         class: Contao\CoreBundle\EventListener\PreviewToolbarListener
         arguments:
-            - '%contao.preview_script%'
             - '@contao.routing.scope_matcher'
             - '@twig'
             - '@router'
@@ -191,7 +190,6 @@ services:
             - '@contao.security.token_checker'
             - '@router'
             - '@uri_signer'
-            - '%contao.preview_script%'
         tags:
             # The priority must be lower than the one of the firewall listener (defaults to 8)
             - { name: kernel.event_listener, priority: 7 }

--- a/core-bundle/src/Resources/config/services.yml
+++ b/core-bundle/src/Resources/config/services.yml
@@ -728,7 +728,6 @@ services:
             - '@session'
             - '@security.authentication.trust_resolver'
             - ~ # Simple or Role Hierarchy Voter
-            - '%contao.preview_script%'
         public: true
 
     contao.security.two_factor.authenticator:

--- a/core-bundle/src/Security/Authentication/Token/TokenChecker.php
+++ b/core-bundle/src/Security/Authentication/Token/TokenChecker.php
@@ -60,14 +60,9 @@ class TokenChecker
     private $roleVoter;
 
     /**
-     * @var string
-     */
-    private $previewScript;
-
-    /**
      * @internal Do not inherit from this class; decorate the "contao.security.token_checker" service instead
      */
-    public function __construct(RequestStack $requestStack, FirewallMapInterface $firewallMap, TokenStorageInterface $tokenStorage, SessionInterface $session, AuthenticationTrustResolverInterface $trustResolver, VoterInterface $roleVoter, string $previewScript = '')
+    public function __construct(RequestStack $requestStack, FirewallMapInterface $firewallMap, TokenStorageInterface $tokenStorage, SessionInterface $session, AuthenticationTrustResolverInterface $trustResolver, VoterInterface $roleVoter)
     {
         $this->requestStack = $requestStack;
         $this->firewallMap = $firewallMap;
@@ -75,7 +70,6 @@ class TokenChecker
         $this->session = $session;
         $this->trustResolver = $trustResolver;
         $this->roleVoter = $roleVoter;
-        $this->previewScript = $previewScript;
     }
 
     /**
@@ -133,7 +127,7 @@ class TokenChecker
     {
         $request = $this->requestStack->getMasterRequest();
 
-        if (null === $request || $request->getScriptName() !== $this->previewScript) {
+        if (null === $request || !$request->attributes->get('_preview', false)) {
             return false;
         }
 

--- a/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
+++ b/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
@@ -828,7 +828,6 @@ class ContaoCoreExtensionTest extends TestCase
 
         $this->assertEquals(
             [
-                new Reference('%contao.preview_script%'),
                 new Reference('contao.routing.scope_matcher'),
                 new Reference('twig'),
                 new Reference('router'),
@@ -2957,7 +2956,6 @@ class ContaoCoreExtensionTest extends TestCase
                 new Reference('session'),
                 new Reference('security.authentication.trust_resolver'),
                 new Reference('security.access.simple_role_voter'),
-                new Reference('%contao.preview_script%'),
             ],
             $definition->getArguments()
         );
@@ -2990,7 +2988,6 @@ class ContaoCoreExtensionTest extends TestCase
                 new Reference('session'),
                 new Reference('security.authentication.trust_resolver'),
                 new Reference('security.access.role_hierarchy_voter'),
-                new Reference('%contao.preview_script%'),
             ],
             $definition->getArguments()
         );
@@ -3548,7 +3545,6 @@ class ContaoCoreExtensionTest extends TestCase
                 new Reference('contao.security.token_checker'),
                 new Reference('router'),
                 new Reference('uri_signer'),
-                new Reference('%contao.preview_script%'),
             ],
             $definition->getArguments()
         );

--- a/core-bundle/tests/EventListener/PreviewAuthenticationListenerTest.php
+++ b/core-bundle/tests/EventListener/PreviewAuthenticationListenerTest.php
@@ -26,17 +26,16 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class PreviewAuthenticationListenerTest extends TestCase
 {
-    public function testReturnsIfNoPreviewScriptIsSet(): void
+    public function testDoesNothingIfPreviewAttributeIsNotSet(): void
     {
         $scopeMatcher = $this->createMock(ScopeMatcher::class);
         $tokenChecker = $this->createMock(TokenChecker::class);
         $router = $this->createMock(UrlGeneratorInterface::class);
         $uriSigner = $this->createMock(UriSigner::class);
-        $previewScript = '';
 
         $requestEvent = $this->getRequestEvent();
 
-        $listener = new PreviewAuthenticationListener($scopeMatcher, $tokenChecker, $router, $uriSigner, $previewScript);
+        $listener = new PreviewAuthenticationListener($scopeMatcher, $tokenChecker, $router, $uriSigner);
         $listener($requestEvent);
 
         $this->assertNull($requestEvent->getResponse());
@@ -47,8 +46,8 @@ class PreviewAuthenticationListenerTest extends TestCase
         $scopeMatcher = $this->createMock(ScopeMatcher::class);
         $scopeMatcher
             ->expects($this->once())
-            ->method('isFrontendRequest')
-            ->willReturn(true)
+            ->method('isBackendRequest')
+            ->willReturn(false)
         ;
 
         $tokenChecker = $this->createMock(TokenChecker::class);
@@ -73,13 +72,12 @@ class PreviewAuthenticationListenerTest extends TestCase
             ->willReturn('/contao/login')
         ;
 
-        $previewScript = '/preview.php';
-
         $request = new Request([], [], [], [], [], ['SCRIPT_NAME' => '/preview.php']);
+        $request->attributes->set('_preview', true);
 
         $requestEvent = $this->getRequestEvent($request);
 
-        $listener = new PreviewAuthenticationListener($scopeMatcher, $tokenChecker, $router, $uriSigner, $previewScript);
+        $listener = new PreviewAuthenticationListener($scopeMatcher, $tokenChecker, $router, $uriSigner);
         $listener($requestEvent);
 
         $this->assertInstanceOf(RedirectResponse::class, $requestEvent->getResponse());

--- a/core-bundle/tests/EventListener/PreviewToolbarListenerTest.php
+++ b/core-bundle/tests/EventListener/PreviewToolbarListenerTest.php
@@ -17,6 +17,7 @@ use Contao\CoreBundle\Routing\ScopeMatcher;
 use Contao\CoreBundle\Tests\TestCase;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\HttpFoundation\HeaderBag;
+use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\Session;
@@ -26,7 +27,6 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Routing\RouterInterface;
 use Twig\Environment;
-use Symfony\Component\HttpFoundation\ParameterBag;
 
 class PreviewToolbarListenerTest extends TestCase
 {

--- a/core-bundle/tests/EventListener/PreviewToolbarListenerTest.php
+++ b/core-bundle/tests/EventListener/PreviewToolbarListenerTest.php
@@ -26,6 +26,7 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Routing\RouterInterface;
 use Twig\Environment;
+use Symfony\Component\HttpFoundation\ParameterBag;
 
 class PreviewToolbarListenerTest extends TestCase
 {
@@ -35,7 +36,6 @@ class PreviewToolbarListenerTest extends TestCase
     public function testInjectsTheToolbarBeforeTheClosingBodyTag($content, $expected): void
     {
         $listener = new PreviewToolbarListener(
-            'preview.php',
             $this->mockScopeMatcher(),
             $this->getTwigMock(),
             $this->mockRouterWithContext()
@@ -77,7 +77,6 @@ class PreviewToolbarListenerTest extends TestCase
         );
 
         $listener = new PreviewToolbarListener(
-            'preview.php',
             $this->mockScopeMatcher(),
             $this->getTwigMock(),
             $this->mockRouterWithContext()
@@ -88,20 +87,19 @@ class PreviewToolbarListenerTest extends TestCase
         $this->assertSame("<html><head></head><body>\nCONTAO\n</body></html>", $response->getContent());
     }
 
-    public function testDoesNotInjectTheToolbarIfThereIsNoPreviewEntrypoint(): void
+    public function testDoesNotInjectTheToolbarIfPreviewAttributeIsNotSet(): void
     {
         $response = new Response('<html><head></head><body></body></html>');
         $response->headers->set('Content-Type', 'text/html; charset=utf-8');
 
         $event = new ResponseEvent(
             $this->createMock(HttpKernelInterface::class),
-            $this->getRequestMock(),
+            $this->getRequestMock(false),
             HttpKernelInterface::MASTER_REQUEST,
             $response
         );
 
         $listener = new PreviewToolbarListener(
-            '',
             $this->mockScopeMatcher(),
             $this->getTwigMock(),
             $this->mockRouterWithContext()
@@ -125,7 +123,6 @@ class PreviewToolbarListenerTest extends TestCase
         );
 
         $listener = new PreviewToolbarListener(
-            'preview.php',
             $this->mockScopeMatcher(),
             $this->getTwigMock(),
             $this->mockRouterWithContext()
@@ -149,7 +146,6 @@ class PreviewToolbarListenerTest extends TestCase
         );
 
         $listener = new PreviewToolbarListener(
-            'preview.php',
             $this->mockScopeMatcher(),
             $this->getTwigMock(),
             $this->mockRouterWithContext()
@@ -170,13 +166,12 @@ class PreviewToolbarListenerTest extends TestCase
 
         $event = new ResponseEvent(
             $this->createMock(HttpKernelInterface::class),
-            $this->getRequestMock(false, 'html', $hasSession),
+            $this->getRequestMock(true, false, 'html', $hasSession),
             HttpKernelInterface::MASTER_REQUEST,
             $response
         );
 
         $listener = new PreviewToolbarListener(
-            'preview.php',
             $this->mockScopeMatcher(),
             $this->getTwigMock(),
             $this->mockRouterWithContext()
@@ -210,13 +205,12 @@ class PreviewToolbarListenerTest extends TestCase
 
         $event = new ResponseEvent(
             $this->createMock(HttpKernelInterface::class),
-            $this->getRequestMock(false, 'html', $hasSession),
+            $this->getRequestMock(true, false, 'html', $hasSession),
             HttpKernelInterface::MASTER_REQUEST,
             $response
         );
 
         $listener = new PreviewToolbarListener(
-            'preview.php',
             $this->mockScopeMatcher(),
             $this->getTwigMock(),
             $this->mockRouterWithContext()
@@ -256,7 +250,6 @@ class PreviewToolbarListenerTest extends TestCase
         );
 
         $listener = new PreviewToolbarListener(
-            'preview.php',
             $this->mockScopeMatcher(),
             $this->getTwigMock(),
             $this->mockRouterWithContext()
@@ -274,13 +267,12 @@ class PreviewToolbarListenerTest extends TestCase
 
         $event = new ResponseEvent(
             $this->createMock(HttpKernelInterface::class),
-            $this->getRequestMock(true),
+            $this->getRequestMock(true, true),
             HttpKernelInterface::MASTER_REQUEST,
             $response
         );
 
         $listener = new PreviewToolbarListener(
-            'preview.php',
             $this->mockScopeMatcher(),
             $this->getTwigMock(),
             $this->mockRouterWithContext()
@@ -298,13 +290,12 @@ class PreviewToolbarListenerTest extends TestCase
 
         $event = new ResponseEvent(
             $this->createMock(HttpKernelInterface::class),
-            $this->getRequestMock(false, 'json'),
+            $this->getRequestMock(true, false, 'json'),
             HttpKernelInterface::MASTER_REQUEST,
             $response
         );
 
         $listener = new PreviewToolbarListener(
-            'preview.php',
             $this->mockScopeMatcher(),
             $this->getTwigMock(),
             $this->mockRouterWithContext()
@@ -318,10 +309,15 @@ class PreviewToolbarListenerTest extends TestCase
     /**
      * @return Request&MockObject
      */
-    protected function getRequestMock(bool $isXmlHttpRequest = false, string $requestFormat = 'html', bool $hasSession = true): Request
+    protected function getRequestMock(bool $isPreview = true, bool $isXmlHttpRequest = false, string $requestFormat = 'html', bool $hasSession = true): Request
     {
         $request = $this->createMock(Request::class);
         $request->headers = new HeaderBag();
+        $request->attributes = new ParameterBag();
+
+        if ($isPreview) {
+            $request->attributes->set('_preview', true);
+        }
 
         $request
             ->method('isXmlHttpRequest')

--- a/core-bundle/tests/Security/Authentication/Token/TokenCheckerTest.php
+++ b/core-bundle/tests/Security/Authentication/Token/TokenCheckerTest.php
@@ -173,13 +173,13 @@ class TokenCheckerTest extends TestCase
     /**
      * @dataProvider getPreviewModeData
      */
-    public function testChecksIfThePreviewModeIsActive(TokenInterface $token, string $script, bool $expect): void
+    public function testChecksIfThePreviewModeIsActive(TokenInterface $token, bool $isPreview, bool $expect): void
     {
         $request = new Request();
-        $request->server->set('SCRIPT_NAME', $script);
 
-        if ('' !== $script) {
+        if ($isPreview) {
             $session = $this->mockSessionWithToken($token);
+            $request->attributes->set('_preview', $isPreview);
         } else {
             $session = $this->createMock(SessionInterface::class);
             $session
@@ -194,8 +194,7 @@ class TokenCheckerTest extends TestCase
             $this->mockTokenStorage(BackendUser::class),
             $session,
             $this->trustResolver,
-            $this->getRoleVoter(),
-            '/preview.php'
+            $this->getRoleVoter()
         );
 
         $this->assertSame($expect, $tokenChecker->isPreviewMode());
@@ -203,10 +202,10 @@ class TokenCheckerTest extends TestCase
 
     public function getPreviewModeData(): \Generator
     {
-        yield [new FrontendPreviewToken(null, true), '', false];
-        yield [new FrontendPreviewToken(null, true), '/preview.php', true];
-        yield [new FrontendPreviewToken(null, false), '/preview.php', false];
-        yield [new UsernamePasswordToken('user', 'password', 'provider'), '/preview.php', false];
+        yield [new FrontendPreviewToken(null, true), false, false];
+        yield [new FrontendPreviewToken(null, true), true, true];
+        yield [new FrontendPreviewToken(null, false), true, false];
+        yield [new UsernamePasswordToken('user', 'password', 'provider'), true, false];
     }
 
     public function testDoesNotReturnATokenIfTheSessionIsNotStarted(): void

--- a/manager-bundle/src/Resources/skeleton/web/preview.php
+++ b/manager-bundle/src/Resources/skeleton/web/preview.php
@@ -19,7 +19,7 @@ use Symfony\Component\HttpKernel\TerminableInterface;
 @ini_set('display_errors', '0');
 
 // Disable the phar stream wrapper for security reasons (see #105)
-if (\in_array('phar', stream_get_wrappers(), true)) {
+if (in_array('phar', stream_get_wrappers(), true)) {
     stream_wrapper_unregister('phar');
 }
 
@@ -27,7 +27,9 @@ if (\in_array('phar', stream_get_wrappers(), true)) {
 $loader = require __DIR__.'/../vendor/autoload.php';
 
 $request = Request::createFromGlobals();
-$kernel = ContaoKernel::fromRequest(\dirname(__DIR__), $request);
+$request->attributes->set('_preview', true);
+
+$kernel = ContaoKernel::fromRequest(dirname(__DIR__), $request);
 $response = $kernel->handle($request);
 
 // Prevent preview URLs from being indexed


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #2460


This fixes #2460 because of https://github.com/contao/contao/pull/2685/files#diff-d8b64ca1e6f2e35530ef0c68a0f1dd2c5978bad268025a592d6c194883026b44R60
It adds the preview toolbar on every html response that is not a back end request. I'm not sure that's what we really want, but why would anyone use the `preview.php` to get a non-Contao page?