### PR TITLE
Correctly handle trailing slashes in URLs

### DIFF
--- a/core-bundle/src/Routing/Page/PageRegistry.php
+++ b/core-bundle/src/Routing/Page/PageRegistry.php
@@ -71,7 +71,7 @@ class PageRegistry
         if (null === $path) {
             $path = '/'.($pageModel->alias ?: $pageModel->id).'{!parameters}';
             $defaults['parameters'] = '';
-            $requirements['parameters'] = $pageModel->requireItem ? '/.+' : '(/.+)?';
+            $requirements['parameters'] = $pageModel->requireItem ? '/.+' : '(/.+?)?';
         }
 
         $route = new PageRoute($pageModel, $path, $defaults, $requirements, $config->getOptions(), $config->getMethods());

--- a/core-bundle/tests/Routing/Page/PageRegistryTest.php
+++ b/core-bundle/tests/Routing/Page/PageRegistryTest.php
@@ -41,7 +41,7 @@ class PageRegistryTest extends TestCase
 
         $this->assertSame('/foo/bar{!parameters}.baz', $route->getPath());
         $this->assertSame('', $route->getDefault('parameters'));
-        $this->assertSame('(/.+)?', $route->getRequirement('parameters'));
+        $this->assertSame('(/.+?)?', $route->getRequirement('parameters'));
     }
 
     public function testReturnsParameteredPageRouteIfPathIsNullWithRequireItem(): void


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #2493

Symfony has a special handling for trailing slashes in URLs.

If the request [matcher implements RedirectableUrlMatcherInterface](https://github.com/symfony/symfony/blob/5.x/src/Symfony/Component/Routing/Matcher/UrlMatcher.php#L135), the regex to match [the URL is modified](https://github.com/symfony/symfony/blob/5.x/src/Symfony/Component/Routing/Matcher/UrlMatcher.php#L151) to allow for URLs with or without trailing slashes.

This is intentional, as the `RedirectableUrlMatcher` will redirect to URLs with slash if one is missing. We use the `RedirectableUrlMatcher` to redirect https to http (and vice versa) as well.

The modification makes the parameter lazy, so trailing slashes are matched even if optional. When matching `/en/news-detail/new-contao-versions-in-short-intervalls/`, parameters must be matched as `new-contao-versions-in-short-intervalls` instead of `new-contao-versions-in-short-intervalls/`