### PR TITLE
Remove the legacy encryption logic

### DIFF
--- a/LIMITATIONS.md
+++ b/LIMITATIONS.md
@@ -23,11 +23,3 @@ types, e.g. from an article to a news item or from a news item to an event.
 They can only copy or move elements from e.g. one article to another article.
 
 More information: https://github.com/contao/core/issues/5234
-
-## Unique checks on encrypted data
-
-The DCA option `'encrypt'=>true` cannot be used together with `'unique'=>true`,
-because there is no effective way to check the unencrypted values for
-duplicate entries.
-
-More information: https://github.com/contao/core/issues/8144

--- a/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
+++ b/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
@@ -66,7 +66,6 @@ class ContaoCoreExtension extends Extension
         $loader->load('migrations.yml');
 
         $container->setParameter('contao.web_dir', $config['web_dir']);
-        $container->setParameter('contao.encryption_key', $config['encryption_key']);
         $container->setParameter('contao.upload_path', $config['upload_path']);
         $container->setParameter('contao.editable_files', $config['editable_files']);
         $container->setParameter('contao.preview_script', $config['preview_script']);

--- a/core-bundle/src/Resources/contao/library/Contao/Config.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Config.php
@@ -485,7 +485,6 @@ class Config
 			'smtpPort'         => 'mailer_port',
 			'smtpEnc'          => 'mailer_encryption',
 			'addLanguageToUrl' => 'contao.prepend_locale',
-			'encryptionKey'    => 'contao.encryption_key',
 			'urlSuffix'        => 'contao.url_suffix',
 			'uploadPath'       => 'contao.upload_path',
 			'editableFiles'    => 'contao.editable_files',

--- a/core-bundle/src/Resources/contao/library/Contao/Encryption.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Encryption.php
@@ -43,19 +43,19 @@ class Encryption
 	protected static $resTd;
 
 	/**
-	 * @deprecated Use a third-party library such as OpenSSL or phpseclib instead.
+	 * @deprecated Use a third-party library such as OpenSSL or phpseclib instead
 	 */
 	public static function encrypt($varValue, $strKey=null)
 	{
-		throw new \BadMethodCallException('This method is not supported anymore since PHP 7.2 removed the mycrpyt extension.');
+		throw new \BadMethodCallException('This method is not supported anymore, because the PHP mcrypt extension has been removed in PHP 7.2.');
 	}
 
 	/**
-	 * @deprecated Use a third-party library such as OpenSSL or phpseclib instead.
+	 * @deprecated Use a third-party library such as OpenSSL or phpseclib instead
 	 */
 	public static function decrypt($varValue, $strKey=null)
 	{
-		throw new \BadMethodCallException('This method is not supported anymore since PHP 7.2 removed the mycrpyt extension.');
+		throw new \BadMethodCallException('This method is not supported anymore, because the PHP mcrypt extension has been removed in PHP 7.2.');
 	}
 
 	/**
@@ -120,7 +120,6 @@ class Encryption
 
 		return $encoder->isPasswordValid($strHash, $strPassword, null);
 	}
-
 
 	/**
 	 * Prevent cloning of the object (Singleton)

--- a/core-bundle/src/Resources/contao/library/Contao/Encryption.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Encryption.php
@@ -43,121 +43,19 @@ class Encryption
 	protected static $resTd;
 
 	/**
-	 * Encrypt a value
-	 *
-	 * @param mixed  $varValue The value to encrypt
-	 * @param string $strKey   An optional encryption key
-	 *
-	 * @return string The encrypted value
+	 * @deprecated Use a third-party library such as OpenSSL or phpseclib instead.
 	 */
 	public static function encrypt($varValue, $strKey=null)
 	{
-		// Recursively encrypt arrays
-		if (\is_array($varValue))
-		{
-			foreach ($varValue as $k=>$v)
-			{
-				$varValue[$k] = static::encrypt($v);
-			}
-
-			return $varValue;
-		}
-
-		if (!$varValue)
-		{
-			return '';
-		}
-
-		// Initialize the module
-		if (static::$resTd === null)
-		{
-			static::initialize();
-		}
-
-		if (!$strKey)
-		{
-			$strKey = System::getContainer()->getParameter('contao.encryption_key');
-		}
-
-		$iv = mcrypt_create_iv(mcrypt_enc_get_iv_size(static::$resTd));
-		mcrypt_generic_init(static::$resTd, md5($strKey), $iv);
-		$strEncrypted = mcrypt_generic(static::$resTd, $varValue);
-		$strEncrypted = base64_encode($iv . $strEncrypted);
-		mcrypt_generic_deinit(static::$resTd);
-
-		return $strEncrypted;
+		throw new \BadMethodCallException('This method is not supported anymore since PHP 7.2 removed the mycrpyt extension.');
 	}
 
 	/**
-	 * Decrypt a value
-	 *
-	 * @param mixed  $varValue The value to decrypt
-	 * @param string $strKey   An optional encryption key
-	 *
-	 * @return string The decrypted value
+	 * @deprecated Use a third-party library such as OpenSSL or phpseclib instead.
 	 */
 	public static function decrypt($varValue, $strKey=null)
 	{
-		// Recursively decrypt arrays
-		if (\is_array($varValue))
-		{
-			foreach ($varValue as $k=>$v)
-			{
-				$varValue[$k] = static::decrypt($v);
-			}
-
-			return $varValue;
-		}
-
-		if (!$varValue)
-		{
-			return '';
-		}
-
-		// Initialize the module
-		if (static::$resTd === null)
-		{
-			static::initialize();
-		}
-
-		$varValue = base64_decode($varValue);
-		$ivsize = mcrypt_enc_get_iv_size(static::$resTd);
-		$iv = substr($varValue, 0, $ivsize);
-		$varValue = substr($varValue, $ivsize);
-
-		if (!$varValue)
-		{
-			return '';
-		}
-
-		if (!$strKey)
-		{
-			$strKey = System::getContainer()->getParameter('contao.encryption_key');
-		}
-
-		mcrypt_generic_init(static::$resTd, md5($strKey), $iv);
-		$strDecrypted = mdecrypt_generic(static::$resTd, $varValue);
-		mcrypt_generic_deinit(static::$resTd);
-
-		return $strDecrypted;
-	}
-
-	/**
-	 * Initialize the encryption module
-	 *
-	 * @throws \Exception If the encryption module cannot be initialized
-	 */
-	protected static function initialize()
-	{
-		if (!\in_array('mcrypt', get_loaded_extensions()))
-		{
-			throw new \Exception('The PHP mcrypt extension is not installed');
-		}
-
-		if (!self::$resTd = mcrypt_module_open(Config::get('encryptionCipher'), '', Config::get('encryptionMode'), ''))
-		{
-			throw new \Exception('Error initializing encryption module');
-		}
+		throw new \BadMethodCallException('This method is not supported anymore since PHP 7.2 removed the mycrpyt extension.');
 	}
 
 	/**
@@ -223,13 +121,6 @@ class Encryption
 		return $encoder->isPasswordValid($strHash, $strPassword, null);
 	}
 
-	/**
-	 * Initialize the encryption module
-	 */
-	protected function __construct()
-	{
-		static::initialize();
-	}
 
 	/**
 	 * Prevent cloning of the object (Singleton)


### PR DESCRIPTION
We've deprecated it a while ago but that doesn't really help us much because it will break as of PHP 7.2 and we're now at a minimum required version of 7.3 for 4.11.

The deprecation message and all the code that still resides in the class somewhat still implies that it works. Which is does absolutely not. So I prefer to remove it completely from the core.