### PR TITLE
Correctly match page controllers with absolute paths

### DIFF
--- a/core-bundle/src/Routing/AbstractPageRouteProvider.php
+++ b/core-bundle/src/Routing/AbstractPageRouteProvider.php
@@ -13,13 +13,13 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Routing;
 
 use Contao\CoreBundle\Framework\ContaoFramework;
+use Contao\CoreBundle\Routing\Page\PageRoute;
 use Contao\Model\Collection;
 use Contao\PageModel;
 use Symfony\Cmf\Component\Routing\Candidates\CandidatesInterface;
 use Symfony\Cmf\Component\Routing\RouteProviderInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Route;
-use Contao\CoreBundle\Routing\Page\PageRoute;
 
 abstract class AbstractPageRouteProvider implements RouteProviderInterface
 {
@@ -167,8 +167,8 @@ abstract class AbstractPageRouteProvider implements RouteProviderInterface
             return 1;
         }
 
-        $pathA = $a instanceof PageRoute ? substr($a->getPath(), 0, -strlen($a->getUrlSuffix())) : $a->getPath();
-        $pathB = $b instanceof PageRoute ? substr($b->getPath(), 0, -strlen($b->getUrlSuffix())) : $b->getPath();
+        $pathA = $a instanceof PageRoute ? substr($a->getPath(), 0, -\strlen($a->getUrlSuffix())) : $a->getPath();
+        $pathB = $b instanceof PageRoute ? substr($b->getPath(), 0, -\strlen($b->getUrlSuffix())) : $b->getPath();
 
         $countA = \count(explode('/', $pathA));
         $countB = \count(explode('/', $pathB));

--- a/core-bundle/src/Routing/AbstractPageRouteProvider.php
+++ b/core-bundle/src/Routing/AbstractPageRouteProvider.php
@@ -19,6 +19,7 @@ use Symfony\Cmf\Component\Routing\Candidates\CandidatesInterface;
 use Symfony\Cmf\Component\Routing\RouteProviderInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Route;
+use Contao\CoreBundle\Routing\Page\PageRoute;
 
 abstract class AbstractPageRouteProvider implements RouteProviderInterface
 {
@@ -166,7 +167,21 @@ abstract class AbstractPageRouteProvider implements RouteProviderInterface
             return 1;
         }
 
-        return strnatcasecmp($a->getPath(), $b->getPath());
+        $pathA = $a instanceof PageRoute ? substr($a->getPath(), 0, -strlen($a->getUrlSuffix())) : $a->getPath();
+        $pathB = $b instanceof PageRoute ? substr($b->getPath(), 0, -strlen($b->getUrlSuffix())) : $b->getPath();
+
+        $countA = \count(explode('/', $pathA));
+        $countB = \count(explode('/', $pathB));
+
+        if ($countA > $countB) {
+            return -1;
+        }
+
+        if ($countB > $countA) {
+            return 1;
+        }
+
+        return strnatcasecmp($pathA, $pathB);
     }
 
     protected function convertLanguagesForSorting(array $languages): array

--- a/core-bundle/src/Routing/AbstractPageRouteProvider.php
+++ b/core-bundle/src/Routing/AbstractPageRouteProvider.php
@@ -166,7 +166,7 @@ abstract class AbstractPageRouteProvider implements RouteProviderInterface
             return 1;
         }
 
-        return strnatcasecmp((string) $pageB->alias, (string) $pageA->alias);
+        return strnatcasecmp($a->getPath(), $b->getPath());
     }
 
     protected function convertLanguagesForSorting(array $languages): array

--- a/core-bundle/src/Routing/Candidates/PageCandidates.php
+++ b/core-bundle/src/Routing/Candidates/PageCandidates.php
@@ -87,7 +87,14 @@ class PageCandidates extends AbstractCandidates
         $paths = [];
 
         foreach ($pathMap as $type => $pathRegex) {
-            $paths[] = '(?P<'.$type.'>'.substr($pathRegex, 2, strrpos($pathRegex, '$') - 2).')';
+            $path = '(?P<'.$type.'>'.substr($pathRegex, 2, strrpos($pathRegex, '$') - 2).')';
+
+            $lastParam = strrpos($path, '[^/]++');
+            if (false !== $lastParam) {
+                $path = substr_replace($path, '[^/]+?', $lastParam, 6);
+            }
+
+            $paths[] = $path;
         }
 
         $prefixes = array_map(

--- a/core-bundle/src/Routing/Candidates/PageCandidates.php
+++ b/core-bundle/src/Routing/Candidates/PageCandidates.php
@@ -88,7 +88,6 @@ class PageCandidates extends AbstractCandidates
 
         foreach ($pathMap as $type => $pathRegex) {
             $path = '(?P<'.$type.'>'.substr($pathRegex, 2, strrpos($pathRegex, '$') - 2).')';
-
             $lastParam = strrpos($path, '[^/]++');
 
             if (false !== $lastParam) {

--- a/core-bundle/src/Routing/Candidates/PageCandidates.php
+++ b/core-bundle/src/Routing/Candidates/PageCandidates.php
@@ -90,6 +90,7 @@ class PageCandidates extends AbstractCandidates
             $path = '(?P<'.$type.'>'.substr($pathRegex, 2, strrpos($pathRegex, '$') - 2).')';
 
             $lastParam = strrpos($path, '[^/]++');
+
             if (false !== $lastParam) {
                 $path = substr_replace($path, '[^/]+?', $lastParam, 6);
             }

--- a/core-bundle/tests/Routing/RouteProviderTest.php
+++ b/core-bundle/tests/Routing/RouteProviderTest.php
@@ -94,12 +94,14 @@ class RouteProviderTest extends TestCase
         $page1->id = 17;
         $page1->rootId = 1;
         $page1->urlPrefix = '';
+        $page1->urlSuffix = '';
 
         /** @var PageModel&MockObject $page2 */
         $page2 = $this->mockClassWithProperties(PageModel::class);
         $page2->id = 21;
         $page2->rootId = 1;
         $page2->urlPrefix = '';
+        $page2->urlSuffix = '';
 
         $pageAdapter = $this->mockAdapter(['findBy']);
         $pageAdapter
@@ -420,6 +422,24 @@ class RouteProviderTest extends TestCase
                 2 => $this->createPage('it', 'foo'),
             ],
             ['de_CH', 'en'],
+        ];
+
+        yield 'Sorts with parameters' => [
+            [
+                1 => $this->createPage('de', 'foo/bar{!parameters}'),
+                0 => $this->createPage('de', 'foo/bar/baz{!parameters}'),
+                2 => $this->createPage('de', 'foo{!parameters}'),
+            ],
+            ['en'],
+        ];
+
+        yield 'Sorts with absolute path' => [
+            [
+                1 => $this->createPage('de', 'foo/bar{!parameters}'),
+                0 => $this->createPage('de', 'foo/{category}/{alias}'),
+                2 => $this->createPage('de', 'foo{!parameters}'),
+            ],
+            ['en'],
         ];
     }
 


### PR DESCRIPTION
Thanks to @qzminski we finally had a first use case for page controllers with a `path` attribute. We found several issues in the handling for page controllers:

1. The regular expression to check if a page controller's path matches the current URL does not work with URL suffixes. This is because we modify Symfony's regex and append the suffixes on the fly
    
    - Actual path: `/blog/foo/bar.html`
    - Path path: `/blog/{category}/{article}`
    - Symfony Route regex: `^/blog/(?P<category>[^/]++)/(?P<alias>[^/]++)$`
    - Our modification: `^()((?P<page_type>/blog/(?P<category>[^/]++)/(?P<alias>[^/]++)))(\.html)$`

    The problematic part is `(?P<alias>[^/]++)`, because `++` asks to match as far as possible, wich in this case includes `.html`. Therefore the whole regex does not match anymore, because the suffix "is not present".

    This issue is pretty similar to https://github.com/contao/contao/pull/2690 and is fixed by modifying the regex in `PageCandidates`.

2. For page controllers with an absolute path, the alias in the page tree is irrelevant. Sorting the pages by alias does not make sense for them. Sorting by route path also fixes the order problem of custom attributes. Example

    - Page 1: Alias = `blog`, Route Path = `/blog{!parameters}.html`, Actual URL = `/blog.html`
    - Page 2: Alias = _empty_, Route Path = `/blog/{category}/{alias}.html`, Actual URL = `blog/foo/bar.html`

    In route sorting, you want Page 2 to match before Page 1, but the Route Path for Page 1 would match the actual URL of Page 2 as well. Sorting by alias would not necessarily order correctly, but sorting by route path does, because `/` comes before `{`.

3. I also notices that absolute path matching will not work in legacy routing mode. We might need to backport the logic from `PageCandidates` to `LegacyCandidates`, but that's a topic for another PR.
        