### PR TITLE
Fix the rgxp=>httpurl implementation

### DIFF
--- a/calendar-bundle/src/Resources/contao/dca/tl_calendar_feed.php
+++ b/calendar-bundle/src/Resources/contao/dca/tl_calendar_feed.php
@@ -13,6 +13,7 @@ use Contao\Backend;
 use Contao\BackendUser;
 use Contao\Calendar;
 use Contao\CalendarModel;
+use Contao\CoreBundle\EventListener\Widget\HttpUrlListener;
 use Contao\CoreBundle\Exception\AccessDeniedException;
 use Contao\DataContainer;
 use Contao\Environment;
@@ -196,7 +197,7 @@ $GLOBALS['TL_DCA']['tl_calendar_feed'] = array
 			'exclude'                 => true,
 			'search'                  => true,
 			'inputType'               => 'text',
-			'eval'                    => array('trailingSlash'=>true, 'rgxp'=>'url', 'decodeEntities'=>true, 'maxlength'=>255, 'tl_class'=>'w50'),
+			'eval'                    => array('trailingSlash'=>true, 'rgxp'=>HttpUrlListener::RGXP_NAME, 'decodeEntities'=>true, 'maxlength'=>255, 'tl_class'=>'w50'),
 			'load_callback' => array
 			(
 				array('tl_calendar_feed', 'addFeedBase')

--- a/comments-bundle/src/Resources/contao/classes/Comments.php
+++ b/comments-bundle/src/Resources/contao/classes/Comments.php
@@ -10,6 +10,7 @@
 
 namespace Contao;
 
+use Contao\CoreBundle\EventListener\Widget\HttpUrlListener;
 use Contao\CoreBundle\Exception\PageNotFoundException;
 use Contao\CoreBundle\OptIn\OptIn;
 
@@ -205,7 +206,7 @@ class Comments extends Frontend
 				'name'      => 'website',
 				'label'     => $GLOBALS['TL_LANG']['MSC']['com_website'],
 				'inputType' => 'text',
-				'eval'      => array('rgxp'=>'url', 'maxlength'=>128, 'decodeEntities'=>true)
+				'eval'      => array('rgxp'=>HttpUrlListener::RGXP_NAME, 'maxlength'=>128, 'decodeEntities'=>true)
 			)
 		);
 

--- a/comments-bundle/src/Resources/contao/dca/tl_comments.php
+++ b/comments-bundle/src/Resources/contao/dca/tl_comments.php
@@ -16,6 +16,7 @@ use Contao\CommentsModel;
 use Contao\CommentsNotifyModel;
 use Contao\Config;
 use Contao\Controller;
+use Contao\CoreBundle\EventListener\Widget\HttpUrlListener;
 use Contao\CoreBundle\Exception\AccessDeniedException;
 use Contao\DataContainer;
 use Contao\Date;
@@ -180,7 +181,7 @@ $GLOBALS['TL_DCA']['tl_comments'] = array
 			'exclude'                 => true,
 			'search'                  => true,
 			'inputType'               => 'text',
-			'eval'                    => array('maxlength'=>128, 'rgxp'=>'url', 'decodeEntities'=>true, 'tl_class'=>'w50'),
+			'eval'                    => array('maxlength'=>128, 'rgxp'=>HttpUrlListener::RGXP_NAME, 'decodeEntities'=>true, 'tl_class'=>'w50'),
 			'sql'                     => "varchar(128) NOT NULL default ''"
 		),
 		'member' => array

--- a/core-bundle/src/Resources/contao/dca/tl_member.php
+++ b/core-bundle/src/Resources/contao/dca/tl_member.php
@@ -11,6 +11,7 @@
 use Contao\Backend;
 use Contao\BackendUser;
 use Contao\Config;
+use Contao\CoreBundle\EventListener\Widget\HttpUrlListener;
 use Contao\CoreBundle\Exception\AccessDeniedException;
 use Contao\DataContainer;
 use Contao\FrontendUser;
@@ -262,7 +263,7 @@ $GLOBALS['TL_DCA']['tl_member'] = array
 			'exclude'                 => true,
 			'search'                  => true,
 			'inputType'               => 'text',
-			'eval'                    => array('rgxp'=>'url', 'maxlength'=>255, 'feEditable'=>true, 'feViewable'=>true, 'feGroup'=>'contact', 'tl_class'=>'w50'),
+			'eval'                    => array('rgxp'=>HttpUrlListener::RGXP_NAME, 'maxlength'=>255, 'feEditable'=>true, 'feViewable'=>true, 'feGroup'=>'contact', 'tl_class'=>'w50'),
 			'sql'                     => "varchar(255) NOT NULL default ''"
 		),
 		'language' => array

--- a/core-bundle/src/Resources/contao/dca/tl_page.php
+++ b/core-bundle/src/Resources/contao/dca/tl_page.php
@@ -15,6 +15,7 @@ use Contao\Config;
 use Contao\CoreBundle\EventListener\DataContainer\ContentCompositionListener;
 use Contao\CoreBundle\EventListener\DataContainer\PageTypeOptionsListener;
 use Contao\CoreBundle\EventListener\DataContainer\PageUrlListener;
+use Contao\CoreBundle\EventListener\Widget\HttpUrlListener;
 use Contao\CoreBundle\Exception\AccessDeniedException;
 use Contao\DataContainer;
 use Contao\Idna;
@@ -350,7 +351,7 @@ $GLOBALS['TL_DCA']['tl_page'] = array
 			'exclude'                 => true,
 			'search'                  => true,
 			'inputType'               => 'text',
-			'eval'                    => array('rgxp'=>'url', 'trailingSlash'=>false, 'tl_class'=>'w50'),
+			'eval'                    => array('rgxp'=>HttpUrlListener::RGXP_NAME, 'trailingSlash'=>false, 'tl_class'=>'w50'),
 			'save_callback' => array
 			(
 				array('tl_page', 'checkStaticUrl')
@@ -362,7 +363,7 @@ $GLOBALS['TL_DCA']['tl_page'] = array
 			'exclude'                 => true,
 			'search'                  => true,
 			'inputType'               => 'text',
-			'eval'                    => array('rgxp'=>'url', 'trailingSlash'=>false, 'tl_class'=>'w50'),
+			'eval'                    => array('rgxp'=>HttpUrlListener::RGXP_NAME, 'trailingSlash'=>false, 'tl_class'=>'w50'),
 			'save_callback' => array
 			(
 				array('tl_page', 'checkStaticUrl')

--- a/core-bundle/src/Resources/contao/forms/FormTextField.php
+++ b/core-bundle/src/Resources/contao/forms/FormTextField.php
@@ -10,6 +10,8 @@
 
 namespace Contao;
 
+use Contao\CoreBundle\EventListener\Widget\HttpUrlListener;
+
 /**
  * Class FormTextField
  *
@@ -145,7 +147,7 @@ class FormTextField extends Widget
 		{
 			case 'value':
 				// Hide the Punycode format (see #2750)
-				if ($this->rgxp == 'url')
+				if ($this->rgxp == 'url' || $this->rgxp == HttpUrlListener::RGXP_NAME)
 				{
 					try
 					{
@@ -191,7 +193,7 @@ class FormTextField extends Widget
 						return 'email';
 
 					case 'url':
-					case 'httpurl':
+					case HttpUrlListener::RGXP_NAME:
 						return 'url';
 				}
 
@@ -235,7 +237,7 @@ class FormTextField extends Widget
 		}
 
 		// Convert to Punycode format (see #5571)
-		if ($this->rgxp == 'url')
+		if ($this->rgxp == 'url' || $this->rgxp == HttpUrlListener::RGXP_NAME)
 		{
 			try
 			{

--- a/core-bundle/src/Resources/contao/widgets/TextField.php
+++ b/core-bundle/src/Resources/contao/widgets/TextField.php
@@ -10,6 +10,8 @@
 
 namespace Contao;
 
+use Contao\CoreBundle\EventListener\Widget\HttpUrlListener;
+
 /**
  * Provide methods to handle text fields.
  *
@@ -113,7 +115,7 @@ class TextField extends Widget
 		if (!$this->multiple)
 		{
 			// Convert to Punycode format (see #5571)
-			if ($this->rgxp == 'url')
+			if ($this->rgxp == 'url' || $this->rgxp == HttpUrlListener::RGXP_NAME)
 			{
 				try
 				{
@@ -144,7 +146,7 @@ class TextField extends Widget
 		if (!$this->multiple)
 		{
 			// Hide the Punycode format (see #2750)
-			if ($this->rgxp == 'url')
+			if ($this->rgxp == 'url' || $this->rgxp == HttpUrlListener::RGXP_NAME)
 			{
 				try
 				{

--- a/listing-bundle/src/Resources/contao/modules/ModuleListing.php
+++ b/listing-bundle/src/Resources/contao/modules/ModuleListing.php
@@ -10,6 +10,7 @@
 
 namespace Contao;
 
+use Contao\CoreBundle\EventListener\Widget\HttpUrlListener;
 use Contao\CoreBundle\Exception\PageNotFoundException;
 use Patchwork\Utf8;
 
@@ -451,7 +452,7 @@ class ModuleListing extends Module
 		}
 
 		// URLs
-		elseif (($GLOBALS['TL_DCA'][$this->list_table]['fields'][$k]['eval']['rgxp'] ?? null) == 'url' && preg_match('@^(https?://|ftp://)@i', $value))
+		elseif (\in_array($GLOBALS['TL_DCA'][$this->list_table]['fields'][$k]['eval']['rgxp'] ?? null, array('url', HttpUrlListener::RGXP_NAME)) && preg_match('@^(https?://|ftp://)@i', $value))
 		{
 			$value = Idna::decode($value); // see #5946
 			$value = '<a href="' . $value . '" target="_blank" rel="noreferrer noopener">' . $value . '</a>';

--- a/news-bundle/src/Resources/contao/dca/tl_news_feed.php
+++ b/news-bundle/src/Resources/contao/dca/tl_news_feed.php
@@ -11,6 +11,7 @@
 use Contao\Automator;
 use Contao\Backend;
 use Contao\BackendUser;
+use Contao\CoreBundle\EventListener\Widget\HttpUrlListener;
 use Contao\CoreBundle\Exception\AccessDeniedException;
 use Contao\DataContainer;
 use Contao\Environment;
@@ -196,7 +197,7 @@ $GLOBALS['TL_DCA']['tl_news_feed'] = array
 			'exclude'                 => true,
 			'search'                  => true,
 			'inputType'               => 'text',
-			'eval'                    => array('trailingSlash'=>true, 'rgxp'=>'url', 'decodeEntities'=>true, 'maxlength'=>255, 'tl_class'=>'w50'),
+			'eval'                    => array('trailingSlash'=>true, 'rgxp'=>HttpUrlListener::RGXP_NAME, 'decodeEntities'=>true, 'maxlength'=>255, 'tl_class'=>'w50'),
 			'load_callback' => array
 			(
 				array('tl_news_feed', 'addFeedBase')


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #2629
| Docs PR or issue | -

This PR fixes the rgxp=>httpurl implementation, which was missing a couple of checks. It also uses the new rgxp for all fields that expect an absolute URL (see #2629).

I am not a big fan of having class constants for 2 of 10 rgxp options, though. Either all or none. @contao/developers WDYT?