### PR TITLE
Handle non-existing resources in the FigureRenderer

### DIFF
--- a/core-bundle/src/Image/Studio/FigureRenderer.php
+++ b/core-bundle/src/Image/Studio/FigureRenderer.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Image\Studio;
 
+use Contao\CoreBundle\Exception\InvalidResourceException;
 use Contao\CoreBundle\File\Metadata;
 use Contao\FilesModel;
 use Contao\FrontendTemplate;
@@ -47,7 +48,7 @@ class FigureRenderer
     }
 
     /**
-     * Renders a figure.
+     * Renders a figure. Returns null if the resource is invalid.
      *
      * The provided configuration array is used to configure a FigureBuilder
      * object. If not explicitly set, the default figure template will be used
@@ -58,7 +59,7 @@ class FigureRenderer
      * @param array<string, mixed>                       $configuration Configuration for the FigureBuilder
      * @param string                                     $template      A Contao or Twig template
      */
-    public function render($from, $size, array $configuration = [], string $template = '@ContaoCore/Image/Studio/figure.html.twig'): string
+    public function render($from, $size, array $configuration = [], string $template = '@ContaoCore/Image/Studio/figure.html.twig'): ?string
     {
         $configuration['from'] = $from;
         $configuration['size'] = $size;
@@ -70,7 +71,11 @@ class FigureRenderer
             }
         }
 
-        $figure = $this->buildFigure($configuration);
+        try {
+            $figure = $this->buildFigure($configuration);
+        } catch (InvalidResourceException $e) {
+            return null;
+        }
 
         return $this->renderTemplate($figure, $template);
     }

--- a/core-bundle/src/Image/Studio/FigureRenderer.php
+++ b/core-bundle/src/Image/Studio/FigureRenderer.php
@@ -48,11 +48,13 @@ class FigureRenderer
     }
 
     /**
-     * Renders a figure. Returns null if the resource is invalid.
+     * Renders a figure.
      *
      * The provided configuration array is used to configure a FigureBuilder
      * object. If not explicitly set, the default figure template will be used
      * to render the results.
+     *
+     * Returns null if the resource is invalid.
      *
      * @param int|string|FilesModel|ImageInterface       $from          Can be a FilesModel, an ImageInterface, a tl_files UUID/ID/path or a file system path
      * @param int|string|array|PictureConfiguration|null $size          A picture size configuration or reference

--- a/core-bundle/src/Resources/contao/library/Contao/InsertTags.php
+++ b/core-bundle/src/Resources/contao/library/Contao/InsertTags.php
@@ -786,7 +786,7 @@ class InsertTags extends Controller
 
 					try
 					{
-						$arrCache[$strTag] = $figureRenderer->render($from, $size, $configuration, $template);
+						$arrCache[$strTag] = $figureRenderer->render($from, $size, $configuration, $template) ?? '';
 					}
 					catch (\Throwable $e)
 					{

--- a/core-bundle/src/Resources/contao/library/Contao/Template.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Template.php
@@ -393,7 +393,7 @@ abstract class Template extends Controller
 	}
 
 	/**
-	 * Renders a figure. Returns null if the resource is invalid.
+	 * Render a figure
 	 *
 	 * The provided configuration array is used to configure a FigureBuilder.
 	 * If not explicitly set, the default template "image.html5" will be used
@@ -405,7 +405,7 @@ abstract class Template extends Controller
 	 * @param array<string, mixed>                       $configuration Configuration for the FigureBuilder
 	 * @param string                                     $template      A Contao or Twig template
 	 *
-	 * @return string|null
+	 * @return string|null Returns null if the resource is invalid
 	 */
 	public function figure($from, $size, $configuration = array(), $template = 'image')
 	{

--- a/core-bundle/src/Resources/contao/library/Contao/Template.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Template.php
@@ -393,7 +393,7 @@ abstract class Template extends Controller
 	}
 
 	/**
-	 * Render a figure
+	 * Renders a figure. Returns null if the resource is invalid.
 	 *
 	 * The provided configuration array is used to configure a FigureBuilder.
 	 * If not explicitly set, the default template "image.html5" will be used
@@ -405,7 +405,7 @@ abstract class Template extends Controller
 	 * @param array<string, mixed>                       $configuration Configuration for the FigureBuilder
 	 * @param string                                     $template      A Contao or Twig template
 	 *
-	 * @return string
+	 * @return string|null
 	 */
 	public function figure($from, $size, $configuration = array(), $template = 'image')
 	{

--- a/core-bundle/src/Twig/Runtime/FigureRendererRuntime.php
+++ b/core-bundle/src/Twig/Runtime/FigureRendererRuntime.php
@@ -34,11 +34,13 @@ final class FigureRendererRuntime implements RuntimeExtensionInterface
     }
 
     /**
-     * Renders a figure. Returns null if the resource is invalid.
+     * Renders a figure.
      *
      * The provided configuration array is used to configure a FigureBuilder
      * object. If not explicitly set, the default figure template will be used
      * to render the results.
+     *
+     * Returns null if the resource is invalid.
      *
      * @param int|string|FilesModel|ImageInterface       $from          Can be a FilesModel, an ImageInterface, a tl_files UUID/ID/path or a file system path
      * @param int|string|array|PictureConfiguration|null $size          A picture size configuration or reference

--- a/core-bundle/src/Twig/Runtime/FigureRendererRuntime.php
+++ b/core-bundle/src/Twig/Runtime/FigureRendererRuntime.php
@@ -34,7 +34,7 @@ final class FigureRendererRuntime implements RuntimeExtensionInterface
     }
 
     /**
-     * Renders a figure.
+     * Renders a figure. Returns null if the resource is invalid.
      *
      * The provided configuration array is used to configure a FigureBuilder
      * object. If not explicitly set, the default figure template will be used
@@ -44,7 +44,7 @@ final class FigureRendererRuntime implements RuntimeExtensionInterface
      * @param int|string|array|PictureConfiguration|null $size          A picture size configuration or reference
      * @param array<string, mixed>                       $configuration Configuration for the FigureBuilder
      */
-    public function render($from, $size, array $configuration = [], string $template = '@ContaoCore/Image/Studio/figure.html.twig'): string
+    public function render($from, $size, array $configuration = [], string $template = '@ContaoCore/Image/Studio/figure.html.twig'): ?string
     {
         return $this->figureRenderer->render($from, $size, $configuration, $template);
     }

--- a/core-bundle/tests/Image/Studio/FigureRendererTest.php
+++ b/core-bundle/tests/Image/Studio/FigureRendererTest.php
@@ -149,7 +149,7 @@ class FigureRendererTest extends TestCase
         $figureRenderer->render(1, null, ['invalid' => 'foobar']);
     }
 
-    public function testReturnsNullForInvalidResources(): void
+    public function testReturnsNullIfTheResourceDoesNotExist(): void
     {
         $figureBuilder = $this->createMock(FigureBuilder::class);
         $figureBuilder
@@ -165,7 +165,6 @@ class FigureRendererTest extends TestCase
         ;
 
         $twig = $this->createMock(Environment::class);
-
         $figureRenderer = new FigureRenderer($studio, $twig);
 
         $this->assertNull($figureRenderer->render('invalid-resource', null));

--- a/core-bundle/tests/Image/Studio/FigureRendererTest.php
+++ b/core-bundle/tests/Image/Studio/FigureRendererTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Tests\Image\Studio;
 
+use Contao\CoreBundle\Exception\InvalidResourceException;
 use Contao\CoreBundle\File\Metadata;
 use Contao\CoreBundle\Image\Studio\Figure;
 use Contao\CoreBundle\Image\Studio\FigureBuilder;
@@ -146,6 +147,28 @@ class FigureRendererTest extends TestCase
         $this->expectException(NoSuchPropertyException::class);
 
         $figureRenderer->render(1, null, ['invalid' => 'foobar']);
+    }
+
+    public function testReturnsNullForInvalidResources(): void
+    {
+        $figureBuilder = $this->createMock(FigureBuilder::class);
+        $figureBuilder
+            ->method('from')
+            ->with('invalid-resource')
+            ->willThrowException(new InvalidResourceException())
+        ;
+
+        $studio = $this->createMock(Studio::class);
+        $studio
+            ->method('createFigureBuilder')
+            ->willReturn($figureBuilder)
+        ;
+
+        $twig = $this->createMock(Environment::class);
+
+        $figureRenderer = new FigureRenderer($studio, $twig);
+
+        $this->assertNull($figureRenderer->render('invalid-resource', null));
     }
 
     private function getFigureRenderer(array $figureBuilderCalls = [], string $expectedTemplate = '@ContaoCore/Image/Studio/figure.html.twig'): FigureRenderer


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Partly solves #2709 
| Docs PR or issue | -

This PR addresses https://github.com/contao/contao/issues/2709#issuecomment-777626885 (2.)  by making the `FigureRenderer` handle invalid resources gracefully. Now, a `InvalidResourceException` will be catched and null returned. 

In Contao 4.12 this will be adjusted to call `FigureBuilder#buildIfResourceExists()` that returns `null` immediately.