### PR TITLE
Make the FigureBuilder more fail tolerant

### DIFF
--- a/core-bundle/src/Image/Studio/FigureRenderer.php
+++ b/core-bundle/src/Image/Studio/FigureRenderer.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Image\Studio;
 
-use Contao\CoreBundle\Exception\InvalidResourceException;
 use Contao\CoreBundle\File\Metadata;
 use Contao\FilesModel;
 use Contao\FrontendTemplate;
@@ -73,16 +72,14 @@ class FigureRenderer
             }
         }
 
-        try {
-            $figure = $this->buildFigure($configuration);
-        } catch (InvalidResourceException $e) {
+        if (null === ($figure = $this->buildFigure($configuration))) {
             return null;
         }
 
         return $this->renderTemplate($figure, $template);
     }
 
-    private function buildFigure(array $configuration): Figure
+    private function buildFigure(array $configuration): ?Figure
     {
         $figureBuilder = $this->studio->createFigureBuilder();
 
@@ -90,7 +87,7 @@ class FigureRenderer
             $this->propertyAccessor->setValue($figureBuilder, $property, $value);
         }
 
-        return $figureBuilder->build();
+        return $figureBuilder->buildIfResourceExists();
     }
 
     private function renderTemplate(Figure $figure, string $template): string

--- a/core-bundle/src/Image/Studio/LegacyFigureBuilderTrait.php
+++ b/core-bundle/src/Image/Studio/LegacyFigureBuilderTrait.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Image\Studio;
 
-use Contao\CoreBundle\Exception\InvalidResourceException;
 use Contao\System;
 
 /**
@@ -39,11 +38,9 @@ trait LegacyFigureBuilderTrait
             return null;
         }
 
-        $figureBuilder = $this->getFigureBuilder();
+        $figureBuilder = $this->getFigureBuilder()->from($resource);
 
-        try {
-            $figureBuilder->from($resource);
-        } catch (InvalidResourceException $e) {
+        if (null !== $figureBuilder->getLastException()) {
             return null;
         }
 

--- a/core-bundle/tests/Image/Studio/FigureBuilderTest.php
+++ b/core-bundle/tests/Image/Studio/FigureBuilderTest.php
@@ -415,8 +415,7 @@ class FigureBuilderTest extends TestCase
 
         $exception = null;
 
-        foreach ($setInvalidResourceOperations as $operation) {
-            [$method, $argument] = $operation;
+        foreach ($setInvalidResourceOperations as [$method, $argument]) {
 
             $figureBuilder->$method($argument);
 

--- a/core-bundle/tests/Image/Studio/FigureBuilderTest.php
+++ b/core-bundle/tests/Image/Studio/FigureBuilderTest.php
@@ -56,12 +56,10 @@ class FigureBuilderTest extends TestCase
         $model->type = 'folder';
 
         $figureBuilder = $this->getFigureBuilder()->fromFilesModel($model);
-
         $exception = $figureBuilder->getLastException();
 
         $this->assertInstanceOf(InvalidResourceException::class, $exception);
         $this->assertSame("DBAFS item 'foo' is not a file.", $exception->getMessage());
-
         $this->assertNull($figureBuilder->buildIfResourceExists());
 
         $this->expectExceptionObject($exception);
@@ -77,12 +75,10 @@ class FigureBuilderTest extends TestCase
         $model->path = 'this/does/not/exist.jpg';
 
         $figureBuilder = $this->getFigureBuilder()->fromFilesModel($model);
-
         $exception = $figureBuilder->getLastException();
 
         $this->assertInstanceOf(InvalidResourceException::class, $exception);
         $this->assertRegExp('/No resource could be located at path .*/', $exception->getMessage());
-
         $this->assertNull($figureBuilder->buildIfResourceExists());
 
         $this->expectExceptionObject($exception);
@@ -119,12 +115,10 @@ class FigureBuilderTest extends TestCase
         $framework = $this->mockContaoFramework([FilesModel::class => $filesModelAdapter]);
 
         $figureBuilder = $this->getFigureBuilder(null, $framework)->fromUuid('invalid-uuid');
-
         $exception = $figureBuilder->getLastException();
 
         $this->assertInstanceOf(InvalidResourceException::class, $exception);
         $this->assertSame("DBAFS item with UUID 'invalid-uuid' could not be found.", $exception->getMessage());
-
         $this->assertNull($figureBuilder->buildIfResourceExists());
 
         $this->expectExceptionObject($exception);
@@ -160,12 +154,10 @@ class FigureBuilderTest extends TestCase
         $framework = $this->mockContaoFramework([FilesModel::class => $filesModelAdapter]);
 
         $figureBuilder = $this->getFigureBuilder(null, $framework)->fromId(99);
-
         $exception = $figureBuilder->getLastException();
 
         $this->assertInstanceOf(InvalidResourceException::class, $exception);
         $this->assertSame("DBAFS item with ID '99' could not be found.", $exception->getMessage());
-
         $this->assertNull($figureBuilder->buildIfResourceExists());
 
         $this->expectExceptionObject($exception);
@@ -222,14 +214,11 @@ class FigureBuilderTest extends TestCase
         [, , $projectDir,] = $this->getTestFilePaths();
 
         $filePath = Path::join($projectDir, 'this/does/not/exist.png');
-
         $figureBuilder = $this->getFigureBuilder()->fromPath($filePath, false);
-
         $exception = $figureBuilder->getLastException();
 
         $this->assertInstanceOf(InvalidResourceException::class, $exception);
         $this->assertRegExp('/No resource could be located at path .*/', $exception->getMessage());
-
         $this->assertNull($figureBuilder->buildIfResourceExists());
 
         $this->expectExceptionObject($exception);
@@ -268,12 +257,10 @@ class FigureBuilderTest extends TestCase
         ;
 
         $figureBuilder = $this->getFigureBuilder()->fromImage($image);
-
         $exception = $figureBuilder->getLastException();
 
         $this->assertInstanceOf(InvalidResourceException::class, $exception);
         $this->assertRegExp('/No resource could be located at path .*/', $exception->getMessage());
-
         $this->assertNull($figureBuilder->buildIfResourceExists());
 
         $this->expectExceptionObject($exception);
@@ -384,7 +371,6 @@ class FigureBuilderTest extends TestCase
         $invalidModel->type = 'folder';
 
         $filesModelAdapter = $this->mockAdapter(['findByUuid', 'findByPk', 'findByPath']);
-
         $filesModelAdapter
             ->method('findByUuid')
             ->willReturnMap([
@@ -411,7 +397,6 @@ class FigureBuilderTest extends TestCase
 
         $framework = $this->mockContaoFramework([FilesModel::class => $filesModelAdapter]);
         $studio = $this->getStudioMockForImage($absoluteFilePath);
-
         $figureBuilder = $this->getFigureBuilder($studio, $framework);
 
         $setValidResourceOperations = [
@@ -536,6 +521,7 @@ class FigureBuilderTest extends TestCase
     {
         $container = $this->getContainerWithContaoConfiguration();
         $container->set('request_stack', $this->createMock(RequestStack::class));
+
         System::setContainer($container);
 
         $GLOBALS['TL_DCA']['tl_files']['fields']['meta']['eval']['metaFields'] = [

--- a/core-bundle/tests/Image/Studio/FigureBuilderTest.php
+++ b/core-bundle/tests/Image/Studio/FigureBuilderTest.php
@@ -430,8 +430,7 @@ class FigureBuilderTest extends TestCase
             $this->assertInstanceOf(InvalidResourceException::class, $exception);
         }
 
-        foreach ($setValidResourceOperations as $operation) {
-            [$method, $argument] = $operation;
+        foreach ($setValidResourceOperations as [$method, $argument]) {
 
             $figureBuilder->from($invalidModel);
 

--- a/core-bundle/tests/Image/Studio/FigureBuilderTest.php
+++ b/core-bundle/tests/Image/Studio/FigureBuilderTest.php
@@ -416,7 +416,6 @@ class FigureBuilderTest extends TestCase
         $exception = null;
 
         foreach ($setInvalidResourceOperations as [$method, $argument]) {
-
             $figureBuilder->$method($argument);
 
             $this->assertNotSame(
@@ -431,7 +430,6 @@ class FigureBuilderTest extends TestCase
         }
 
         foreach ($setValidResourceOperations as [$method, $argument]) {
-
             $figureBuilder->from($invalidModel);
 
             $this->assertInstanceOf(InvalidResourceException::class, $exception);

--- a/core-bundle/tests/Image/Studio/FigureRendererTest.php
+++ b/core-bundle/tests/Image/Studio/FigureRendererTest.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Tests\Image\Studio;
 
-use Contao\CoreBundle\Exception\InvalidResourceException;
 use Contao\CoreBundle\File\Metadata;
 use Contao\CoreBundle\Image\Studio\Figure;
 use Contao\CoreBundle\Image\Studio\FigureBuilder;
@@ -101,7 +100,7 @@ class FigureRendererTest extends TestCase
 
         $figureBuilder = $this->createMock(FigureBuilder::class);
         $figureBuilder
-            ->method('build')
+            ->method('buildIfResourceExists')
             ->willReturn(new Figure($image))
         ;
 
@@ -153,9 +152,8 @@ class FigureRendererTest extends TestCase
     {
         $figureBuilder = $this->createMock(FigureBuilder::class);
         $figureBuilder
-            ->method('from')
-            ->with('invalid-resource')
-            ->willThrowException(new InvalidResourceException())
+            ->method('buildIfResourceExists')
+            ->willReturn(null)
         ;
 
         $studio = $this->createMock(Studio::class);
@@ -176,7 +174,7 @@ class FigureRendererTest extends TestCase
 
         $figureBuilder = $this->createMock(FigureBuilder::class);
         $figureBuilder
-            ->method('build')
+            ->method('buildIfResourceExists')
             ->willReturn($figure)
         ;
 


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Partly solves #2709 
| Docs PR or issue | todo

This PR addresses https://github.com/contao/contao/issues/2709#issuecomment-777626885 (1.). There now is an alternative `buildIfResourceExists()` and throwing of `InvalidResourceExceptions` is deferred to the `build()` method.

**Todo:**
 - [x] Adjust usage after #2732 is merged upstream