### PR TITLE
Enable accessing Figure in all templates

### DIFF
--- a/core-bundle/src/Image/Studio/Figure.php
+++ b/core-bundle/src/Image/Studio/Figure.php
@@ -355,6 +355,9 @@ final class Figure
             unset($new['href']);
         }
 
+        // Allow accessing Figure methods in a legacy template context
+        $new['figure'] = $this;
+
         // Apply data
         if ($template instanceof Template) {
             $template->setData(array_replace($existing, $new));

--- a/core-bundle/src/Resources/contao/elements/ContentGallery.php
+++ b/core-bundle/src/Resources/contao/elements/ContentGallery.php
@@ -263,7 +263,7 @@ class ContentGallery extends ContentElement
 						->build();
 
 					$cellData = $figure->getLegacyTemplateData($this->imagemargin);
-					$cellData['figure'] = $this;
+					$cellData['figure'] = $figure;
 				}
 				else
 				{

--- a/core-bundle/src/Resources/contao/elements/ContentGallery.php
+++ b/core-bundle/src/Resources/contao/elements/ContentGallery.php
@@ -258,10 +258,12 @@ class ContentGallery extends ContentElement
 				// Image / empty cell
 				if (($j + $i) < $limit && null !== ($image = $images[$i + $j] ?? null))
 				{
-					$cellData = $figureBuilder
+					$figure = $figureBuilder
 						->fromFilesModel($image)
-						->build()
-						->getLegacyTemplateData($this->imagemargin);
+						->build();
+
+					$cellData = $figure->getLegacyTemplateData($this->imagemargin);
+					$cellData['figure'] = $this;
 				}
 				else
 				{

--- a/core-bundle/src/Resources/contao/elements/ContentVimeo.php
+++ b/core-bundle/src/Resources/contao/elements/ContentVimeo.php
@@ -116,10 +116,12 @@ class ContentVimeo extends ContentElement
 		// Add a splash image
 		if ($this->splashImage && null !== ($figureBuilder = $this->getFigureBuilderIfResourceExists($this->singleSRC)))
 		{
-			$this->Template->splashImage = (object) $figureBuilder
+			$figure = $figureBuilder
 				->setSize($this->size)
-				->build()
-				->getLegacyTemplateData();
+				->build();
+
+			$this->Template->splashImage = (object) $figure->getLegacyTemplateData();
+			$this->Template->splashImage->figure = $figure;
 		}
 
 		$this->Template->src = $url;

--- a/core-bundle/src/Resources/contao/elements/ContentYouTube.php
+++ b/core-bundle/src/Resources/contao/elements/ContentYouTube.php
@@ -131,10 +131,12 @@ class ContentYouTube extends ContentElement
 		// Add a splash image
 		if ($this->splashImage && null !== ($figureBuilder = $this->getFigureBuilderIfResourceExists($this->singleSRC)))
 		{
-			$this->Template->splashImage = (object) $figureBuilder
+			$figure = $figureBuilder
 				->setSize($this->size)
-				->build()
-				->getLegacyTemplateData();
+				->build();
+
+			$this->Template->splashImage = (object) $figure->getLegacyTemplateData();
+			$this->Template->splashImage->figure = $figure;
 		}
 
 		$this->Template->src = $url;

--- a/core-bundle/src/Resources/contao/modules/ModuleRandomImage.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleRandomImage.php
@@ -125,13 +125,15 @@ class ModuleRandomImage extends Module
 			return;
 		}
 
-		$imageData = $this
+		$figure = $this
 			->getFigureBuilder()
 			->fromFilesModel($images[array_rand($images)])
 			->setSize($this->imgSize)
 			->enableLightbox((bool) $this->fullsize)
-			->build()
-			->getLegacyTemplateData();
+			->build();
+
+		$imageData = $figure->getLegacyTemplateData();
+		$imageData['figure'] = $figure;
 
 		$this->Template->setData(array_merge(
 			$this->Template->getData(),

--- a/core-bundle/tests/Image/Studio/FigureBuilderIntegrationTest.php
+++ b/core-bundle/tests/Image/Studio/FigureBuilderIntegrationTest.php
@@ -18,6 +18,7 @@ use Contao\CoreBundle\Framework\Adapter;
 use Contao\CoreBundle\Image\ImageFactory;
 use Contao\CoreBundle\Image\LegacyResizer;
 use Contao\CoreBundle\Image\PictureFactory;
+use Contao\CoreBundle\Image\Studio\Figure;
 use Contao\CoreBundle\Image\Studio\Studio;
 use Contao\CoreBundle\Security\Authentication\Token\TokenChecker;
 use Contao\CoreBundle\Tests\TestCase;
@@ -1672,6 +1673,9 @@ class FigureBuilderIntegrationTest extends TestCase
         $templateData = $template instanceof Template
             ? $template->getData()
             : get_object_vars($template);
+
+        // Do not compare Figure reference
+        unset($templateData['figure']);
 
         $sortByKeyRecursive = static function (array &$array) use (&$sortByKeyRecursive): void {
             foreach ($array as &$value) {

--- a/core-bundle/tests/Image/Studio/FigureTest.php
+++ b/core-bundle/tests/Image/Studio/FigureTest.php
@@ -571,11 +571,13 @@ class FigureTest extends TestCase
         $figure->applyLegacyTemplateData($template);
 
         $this->assertSame(['img foo'], $template->getData()['picture']['img']);
+        $this->assertSame($figure, $template->getData()['figure']);
 
         $template = new \stdClass();
         $figure->applyLegacyTemplateData($template);
 
         $this->assertSame(['img foo'], $template->picture['img']);
+        $this->assertSame($figure, $template->figure);
     }
 
     public function testApplyLegacyTemplateDataDoesNotOverwriteHref(): void


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Partly solves #2709
| Docs PR or issue | todo

Addresses https://github.com/contao/contao/issues/2709#issuecomment-777626885 (last bit).

With this PR the `Figure` can be accessed in all custom templates. I added a reference to `applyLegacyTemplateData` and also manually added references where `getLegacyTemplateData` was used directly in our content elements/modules.