### PR TITLE
Change the default URL suffix

### DIFF
--- a/core-bundle/src/Resources/contao/dca/tl_page.php
+++ b/core-bundle/src/Resources/contao/dca/tl_page.php
@@ -471,7 +471,7 @@ $GLOBALS['TL_DCA']['tl_page'] = array
 			'label'                   => &$GLOBALS['TL_LANG']['tl_page']['urlSuffix'],
 			'inputType'               => 'text',
 			'eval'                    => array('nospace'=>'true', 'maxlength'=>16, 'tl_class'=>'w50'),
-			'sql'                     => "varchar(16) NOT NULL default '.html'"
+			'sql'                     => "varchar(16) NOT NULL default ''"
 		),
 		'useSSL' => array
 		(

--- a/core-bundle/tests/Fixtures/Functional/Routing/domain-without-hostname.yml
+++ b/core-bundle/tests/Fixtures/Functional/Routing/domain-without-hostname.yml
@@ -5,6 +5,7 @@ tl_page:
       tstamp: 1539696285
       title: Domain without hostname
       alias: domain-without-hostname
+      urlSuffix: .html
       type: root
       language: en
       fallback: '1'

--- a/core-bundle/tests/Fixtures/Functional/Routing/issue-2465.yml
+++ b/core-bundle/tests/Fixtures/Functional/Routing/issue-2465.yml
@@ -15,6 +15,7 @@ tl_page:
       tstamp: 1603728012
       title: Domain1 - Deutsch
       alias: de
+      urlSuffix: .html
       type: root
       language: de
       dns: domain1.local
@@ -38,6 +39,7 @@ tl_page:
       tstamp: 1603728012
       title: Domain1 - Français
       alias: fr
+      urlSuffix: .html
       type: root
       language: fr
       dns: domain1.local
@@ -51,6 +53,7 @@ tl_page:
       tstamp: 1603795275
       title: Domain1 - Italiano
       alias: it
+      urlSuffix: .html
       type: root
       language: it
       dns: domain1.local
@@ -64,6 +67,7 @@ tl_page:
       tstamp: 1603728012
       title: Domain1 - English
       alias: en
+      urlSuffix: .html
       type: root
       language: en
       dns: domain1.local
@@ -77,6 +81,7 @@ tl_page:
       tstamp: 1603728012
       title: Domain2 - Deutsch
       alias: de
+      urlSuffix: .html
       type: root
       language: de
       dns: domain2.local
@@ -91,6 +96,7 @@ tl_page:
       tstamp: 1603728012
       title: Domain2 - Français
       alias: fr
+      urlSuffix: .html
       type: root
       language: fr
       dns: domain2.local
@@ -104,6 +110,7 @@ tl_page:
       tstamp: 1603728012
       title: Domain2 - Italiano
       alias: it
+      urlSuffix: .html
       type: root
       language: it
       dns: domain2.local
@@ -171,6 +178,7 @@ tl_page:
       tstamp: 1603728012
       title: Domain3 - Deutsch
       alias: de
+      urlSuffix: .html
       type: root
       language: de
       dns: domain3.local
@@ -185,6 +193,7 @@ tl_page:
       tstamp: 1603728012
       title: Domain3 - Français
       alias: fr
+      urlSuffix: .html
       type: root
       language: fr
       dns: domain3.local
@@ -198,6 +207,7 @@ tl_page:
       tstamp: 1603728012
       title: Domain3 - Italiano
       alias: it
+      urlSuffix: .html
       type: root
       language: it
       dns: domain3.local
@@ -238,6 +248,7 @@ tl_page:
       tstamp: 1603728012
       title: Domain3 - English
       alias: en
+      urlSuffix: .html
       type: root
       language: en
       dns: domain3.local

--- a/core-bundle/tests/Fixtures/Functional/Routing/language-index-mix.yml
+++ b/core-bundle/tests/Fixtures/Functional/Routing/language-index-mix.yml
@@ -5,6 +5,7 @@ tl_page:
       tstamp: 1539679763
       title: English Root
       alias: english-root
+      urlSuffix: .html
       type: root
       language: en
       dns: example.com
@@ -28,6 +29,7 @@ tl_page:
       tstamp: 1539679763
       title: German Root
       alias: german-root
+      urlSuffix: .html
       type: root
       language: de
       dns: example.com

--- a/core-bundle/tests/Fixtures/Functional/Routing/language-sorting.yml
+++ b/core-bundle/tests/Fixtures/Functional/Routing/language-sorting.yml
@@ -5,6 +5,7 @@ tl_page:
       tstamp: 1568196756
       title: Root ZH
       alias: root-zh
+      urlSuffix: .html
       type: root
       language: zh
       dns: root-zh.local
@@ -28,6 +29,7 @@ tl_page:
       tstamp: 1568196339
       title: Root FR
       alias: foot-fr
+      urlSuffix: .html
       type: root
       language: fr
       dns: root-fr.local

--- a/core-bundle/tests/Fixtures/Functional/Routing/localhost.yml
+++ b/core-bundle/tests/Fixtures/Functional/Routing/localhost.yml
@@ -5,6 +5,7 @@ tl_page:
       tstamp: 1539696285
       title: Localhost
       alias: localhost
+      urlSuffix: .html
       type: root
       language: en
       dns: 127.0.0.1

--- a/core-bundle/tests/Fixtures/Functional/Routing/page-without-alias.yml
+++ b/core-bundle/tests/Fixtures/Functional/Routing/page-without-alias.yml
@@ -5,6 +5,7 @@ tl_page:
       tstamp: 1539679767
       title: Page without alias
       alias: page-without-alias
+      urlSuffix: .html
       type: root
       language: en
       fallback: '1'

--- a/core-bundle/tests/Fixtures/Functional/Routing/root-with-folder-urls.yml
+++ b/core-bundle/tests/Fixtures/Functional/Routing/root-with-folder-urls.yml
@@ -5,6 +5,7 @@ tl_page:
       tstamp: 1539680468
       title: Root with folder URLs
       alias: root-with-folder-urls
+      urlSuffix: .html
       type: root
       language: en
       dns: root-with-folder-urls.local

--- a/core-bundle/tests/Fixtures/Functional/Routing/root-with-index.yml
+++ b/core-bundle/tests/Fixtures/Functional/Routing/root-with-index.yml
@@ -5,6 +5,7 @@ tl_page:
       tstamp: 1539679763
       title: Root with index page
       alias: root-with-index-page
+      urlSuffix: .html
       type: root
       language: en
       dns: root-with-index.local

--- a/core-bundle/tests/Fixtures/Functional/Routing/root-with-special-chars.yml
+++ b/core-bundle/tests/Fixtures/Functional/Routing/root-with-special-chars.yml
@@ -5,6 +5,7 @@ tl_page:
       tstamp: 1539680233
       title: Root with special chars
       alias: root-with-special-chars
+      urlSuffix: .html
       type: root
       language: en
       dns: root-with-special-chars.local

--- a/core-bundle/tests/Fixtures/Functional/Routing/root-without-fallback-language.yml
+++ b/core-bundle/tests/Fixtures/Functional/Routing/root-without-fallback-language.yml
@@ -5,6 +5,7 @@ tl_page:
       tstamp: 1539694676
       title: Root without fallback language
       alias: root-without-fallback-language
+      urlSuffix: .html
       type: root
       language: en
       dns: root-without-fallback-language.local

--- a/core-bundle/tests/Fixtures/Functional/Routing/same-domain-root-with-index.yml
+++ b/core-bundle/tests/Fixtures/Functional/Routing/same-domain-root-with-index.yml
@@ -5,6 +5,7 @@ tl_page:
       tstamp: 1550250933
       title: Same domain root English with index
       alias: same-domain-root-english-with-index
+      urlSuffix: .html
       type: root
       language: en
       dns: same-domain-root-with-index.local
@@ -28,6 +29,7 @@ tl_page:
       tstamp: 1539696285
       title: Same domain root German with index
       alias: same-domain-root-german-with-index
+      urlSuffix: .html
       type: root
       language: de
       dns: same-domain-root-with-index.local

--- a/core-bundle/tests/Fixtures/Functional/Routing/same-domain-root.yml
+++ b/core-bundle/tests/Fixtures/Functional/Routing/same-domain-root.yml
@@ -5,6 +5,7 @@ tl_page:
       tstamp: 1550250980
       title: Same domain root English
       alias: same-domain-root-english
+      urlSuffix: .html
       type: root
       language: en
       dns: same-domain-root.local
@@ -28,6 +29,7 @@ tl_page:
       tstamp: 1550250980
       title: Same domain root German
       alias: same-domain-root-german
+      urlSuffix: .html
       type: root
       language: de
       dns: same-domain-root.local


### PR DESCRIPTION
As discussed in yesterday's Mumble call, this PR changes the default URL suffix from `'.html'` to `''`.