### PR TITLE
Do not query for PIDs when building the breadcrumb of a File data container

### DIFF
--- a/core-bundle/src/Resources/contao/classes/Backend.php
+++ b/core-bundle/src/Resources/contao/classes/Backend.php
@@ -520,7 +520,7 @@ abstract class Backend extends Controller
 				$table = $strTable;
 				$ptable = ($act != 'edit') ? $GLOBALS['TL_DCA'][$strTable]['config']['ptable'] : $strTable;
 
-				while ($ptable && !\in_array($GLOBALS['TL_DCA'][$table]['list']['sorting']['mode'], array(5, 6)))
+				while ($ptable && !\in_array($GLOBALS['TL_DCA'][$table]['list']['sorting']['mode'], array(5, 6)) && ($GLOBALS['TL_DCA'][$ptable]['config']['dataContainer'] ?? null) === 'Table')
 				{
 					$objRow = $this->Database->prepare("SELECT * FROM " . $ptable . " WHERE id=?")
 											 ->limit(1)


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #2317

Looks like I was already affected by that bug, but instead of fixing it I used a workaround in https://github.com/madeyourday/contao-rocksolid-slider/commit/ae2dd521f0890dab33ad2e07d95b79e474190e43 🙈