### PR TITLE
Correctly fix the domain when generating URLs from a page array

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Controller.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Controller.php
@@ -1175,6 +1175,10 @@ abstract class Controller extends System
 				{
 					$page->$key = $arrRow[$key];
 				}
+				else
+				{
+					$arrRow[$key] = $page->$key;
+				}
 			}
 		}
 


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #2573


