### PR TITLE
Symlink highlight.php as highlight_php

### DIFF
--- a/core-bundle/src/Command/SymlinksCommand.php
+++ b/core-bundle/src/Command/SymlinksCommand.php
@@ -129,7 +129,7 @@ class SymlinksCommand extends Command
 
         $this->symlink(
             'vendor/scrivo/highlight.php/styles',
-            Path::join($this->webDir, 'vendor/scrivo/highlight.php/styles')
+            Path::join($this->webDir, 'vendor/scrivo/highlight_php/styles')
         );
 
         // Symlink the assets and themes directory

--- a/core-bundle/src/Resources/contao/templates/elements/ce_code.html5
+++ b/core-bundle/src/Resources/contao/templates/elements/ce_code.html5
@@ -2,8 +2,8 @@
 
 <?php
 
-// Add the highlight.php style sheet
-$GLOBALS['TL_CSS'][] = 'vendor/scrivo/highlight.php/styles/foundation.css';
+// Add the style sheet
+$GLOBALS['TL_CSS'][] = 'vendor/scrivo/highlight_php/styles/foundation.css';
 
 ?>
 


### PR DESCRIPTION
This will save us a lot of headaches with servers interpreting `https://domain.tld/vendor/scrivo/highlight.php/styles/foundation.css` as request for `vendor/scrivo/highlight.php`. 🙈 