### PR TITLE
Remove an unnecessary loadLanguageFile() call

### DIFF
--- a/core-bundle/src/Resources/contao/modules/ModuleCloseAccount.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleCloseAccount.php
@@ -62,8 +62,6 @@ class ModuleCloseAccount extends Module
 	protected function compile()
 	{
 		$this->import(FrontendUser::class, 'User');
-
-		System::loadLanguageFile('tl_member');
 		$this->loadDataContainer('tl_member');
 
 		// Initialize the password widget


### PR DESCRIPTION
Follow-up on #2497

The label ist taken from `$GLOBALS['TL_LANG']['MSC']`, therefore we do not need to load the `tl_member` language files.