### PR TITLE
Fix an illegal array access in DC_Table::reviseTables()

### DIFF
--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -3335,11 +3335,11 @@ class DC_Table extends DataContainer implements \listable, \editable
 				if (\is_array($callback))
 				{
 					$this->import($callback[0]);
-					$status = $this->{$callback[0]}->{$callback[1]}($this->strTable, $new_records[$this->strTable] ?? array(), $ptable, $ctable);
+					$status = $this->{$callback[0]}->{$callback[1]}($this->strTable, $new_records[$this->strTable] ?? null, $ptable, $ctable);
 				}
 				elseif (\is_callable($callback))
 				{
-					$status = $callback($this->strTable, $new_records[$this->strTable] ?? array(), $ptable, $ctable);
+					$status = $callback($this->strTable, $new_records[$this->strTable] ?? null, $ptable, $ctable);
 				}
 
 				if ($status === true)

--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -3335,11 +3335,11 @@ class DC_Table extends DataContainer implements \listable, \editable
 				if (\is_array($callback))
 				{
 					$this->import($callback[0]);
-					$status = $this->{$callback[0]}->{$callback[1]}($this->strTable, $new_records[$this->strTable], $ptable, $ctable);
+					$status = $this->{$callback[0]}->{$callback[1]}($this->strTable, $new_records[$this->strTable] ?? array(), $ptable, $ctable);
 				}
 				elseif (\is_callable($callback))
 				{
-					$status = $callback($this->strTable, $new_records[$this->strTable], $ptable, $ctable);
+					$status = $callback($this->strTable, $new_records[$this->strTable] ?? array(), $ptable, $ctable);
 				}
 
 				if ($status === true)


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | -
| Docs PR or issue | -

This PR prevents another illegal array access in `DCTable#reviseTables()` in case `$new_records` does not contain an entry for `$this->strTable`.