### PR TITLE
Automatically prefix the back end attributes

### DIFF
--- a/core-bundle/src/DependencyInjection/Configuration.php
+++ b/core-bundle/src/DependencyInjection/Configuration.php
@@ -456,7 +456,7 @@ class Configuration implements ConfigurationInterface
             ->children()
                 ->arrayNode('attributes')
                     ->info('Adds HTML attributes to the <body> tag in the back end.')
-                    ->example(['data-app-name' => 'My App', 'data-app-version' => '1.2.3'])
+                    ->example(['app-name' => 'My App', 'app-version' => '1.2.3'])
                     ->validate()
                     ->always(
                         static function (array $attributes): array {

--- a/core-bundle/src/Resources/contao/classes/BackendTemplate.php
+++ b/core-bundle/src/Resources/contao/classes/BackendTemplate.php
@@ -244,7 +244,7 @@ class BackendTemplate extends Template
 		if (!empty($backendConfig['attributes']) && \is_array($backendConfig['attributes']))
 		{
 			$this->attributes = ' ' . implode(' ', array_map(
-				static function ($v, $k) { return sprintf('%s="%s"', $k, $v); },
+				static function ($v, $k) { return sprintf('data-%s="%s"', $k, $v); },
 				$backendConfig['attributes'],
 				array_keys($backendConfig['attributes'])
 			));


### PR DESCRIPTION
Follow-up on #1999

### Currently

```yaml
contao:
    backend:
        attributes:
            data-app-name: Foobar
            data-app-version: 1.2.3
            style: 'background: #f00'
```

Will be converted to `data-app-name="Foobar" data-app-version="1.2.3" style="background: #f00"`.

### New

```yaml
contao:
    backend:
        attributes:
            app-name: Foobar
            app-version: 1.2.3
            style: 'background: #f00'
```

Will be converted to `data-app-name="Foobar" data-app-version="1.2.3" data-style="background: #f00"`.

So by automatically prefixing the attributes with `data-`, we can not only simplify the configuration but also prevent users from accidentally overwriting attributes such as `style`, `class` or `id`.
