### PR TITLE
Do not use Kernel::$rootDir anymore

### DIFF
--- a/manager-bundle/src/HttpKernel/ContaoKernel.php
+++ b/manager-bundle/src/HttpKernel/ContaoKernel.php
@@ -91,11 +91,7 @@ class ContaoKernel extends Kernel implements HttpCacheProvider
      */
     public function getRootDir(): string
     {
-        if (null === $this->rootDir) {
-            $this->rootDir = Path::join($this->getProjectDir(), 'app');
-        }
-
-        return $this->rootDir;
+        return Path::join($this->getProjectDir(), 'app');
     }
 
     public function getCacheDir(): string


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #2773
| Docs PR or issue | -

Implements option 2 from https://github.com/contao/contao/issues/2773 in order to fix the

```
Undefined property: Contao\ManagerBundle\HttpKernel\ContaoKernel::$rootDir
```

error when using `ModuleConfig::getBundleInstance`.