### PR TITLE
Ignore empty authorization headers in the MakeResponsePrivateListener

### DIFF
--- a/core-bundle/src/EventListener/MakeResponsePrivateListener.php
+++ b/core-bundle/src/EventListener/MakeResponsePrivateListener.php
@@ -39,7 +39,7 @@ class MakeResponsePrivateListener
      * Make sure that the current response becomes a private response if any
      * of the following conditions are true.
      *
-     *   1. An Authorization header is present
+     *   1. An Authorization header is present and not empty
      *   2. The session was started
      *   3. The response sets a cookie (same reason as 2 but for other cookies than the session cookie)
      *   4. The response has a "Vary: Cookie" header and the request provides at least one cookie
@@ -64,8 +64,8 @@ class MakeResponsePrivateListener
             return;
         }
 
-        // 1) An Authorization header is present
-        if ($request->headers->has('Authorization')) {
+        // 1) An Authorization header is present and not empty
+        if ($request->headers->has('Authorization') && '' !== $request->headers->get('Authorization')) {
             $this->makePrivate($response, 'authorization');
 
             return;

--- a/core-bundle/src/EventListener/MakeResponsePrivateListener.php
+++ b/core-bundle/src/EventListener/MakeResponsePrivateListener.php
@@ -65,7 +65,7 @@ class MakeResponsePrivateListener
         }
 
         // 1) An Authorization header is present and not empty
-        if ($request->headers->has('Authorization') && '' !== $request->headers->get('Authorization')) {
+        if ('' !== (string) $request->headers->get('Authorization')) {
             $this->makePrivate($response, 'authorization');
 
             return;

--- a/core-bundle/tests/EventListener/MakeResponsePrivateListenerTest.php
+++ b/core-bundle/tests/EventListener/MakeResponsePrivateListenerTest.php
@@ -94,6 +94,30 @@ class MakeResponsePrivateListenerTest extends TestCase
         $this->assertSame('authorization', $response->headers->get(MakeResponsePrivateListener::DEBUG_HEADER));
     }
 
+    public function testIgnoresTheResponseWhenAnAuthorizationHeaderIsEmpty(): void
+    {
+        $response = new Response();
+        $response->setPublic();
+        $response->setMaxAge(600);
+
+        $request = new Request();
+        $request->headers->set('Authorization', '');
+
+        $event = new ResponseEvent(
+            $this->createMock(KernelInterface::class),
+            $request,
+            HttpKernelInterface::MASTER_REQUEST,
+            $response
+        );
+
+        $listener = new MakeResponsePrivateListener($this->createScopeMatcher(true));
+        $listener($event);
+
+        $this->assertTrue($response->headers->has(AbstractSessionListener::NO_AUTO_CACHE_CONTROL_HEADER));
+        $this->assertTrue($response->headers->getCacheControlDirective('public'));
+        $this->assertFalse($response->headers->has(MakeResponsePrivateListener::DEBUG_HEADER));
+    }
+
     public function testMakesResponsePrivateWhenTheSessionWasStarted(): void
     {
         $session = $this->createMock(SessionInterface::class);

--- a/core-bundle/tests/EventListener/MakeResponsePrivateListenerTest.php
+++ b/core-bundle/tests/EventListener/MakeResponsePrivateListenerTest.php
@@ -118,6 +118,30 @@ class MakeResponsePrivateListenerTest extends TestCase
         $this->assertFalse($response->headers->has(MakeResponsePrivateListener::DEBUG_HEADER));
     }
 
+    public function testIgnoresTheResponseWhenAnAuthorizationHeaderIsNull(): void
+    {
+        $response = new Response();
+        $response->setPublic();
+        $response->setMaxAge(600);
+
+        $request = new Request();
+        $request->headers->set('Authorization', null);
+
+        $event = new ResponseEvent(
+            $this->createMock(KernelInterface::class),
+            $request,
+            HttpKernelInterface::MASTER_REQUEST,
+            $response
+        );
+
+        $listener = new MakeResponsePrivateListener($this->createScopeMatcher(true));
+        $listener($event);
+
+        $this->assertTrue($response->headers->has(AbstractSessionListener::NO_AUTO_CACHE_CONTROL_HEADER));
+        $this->assertTrue($response->headers->getCacheControlDirective('public'));
+        $this->assertFalse($response->headers->has(MakeResponsePrivateListener::DEBUG_HEADER));
+    }
+
     public function testMakesResponsePrivateWhenTheSessionWasStarted(): void
     {
         $session = $this->createMock(SessionInterface::class);


### PR DESCRIPTION
After debugging a non-working cache on a Contao website I noticed that I always got the following headers in the response:

```
contao-cache: miss
contao-private-response-reason: authorization
```

After debugging I found out that `$_SERVER['HTTP_AUTHORIZATION']` is set to an empty string. So I guess we should ignore empty authorization headers in the `MakeResponsePrivateListener`.