### PR TITLE
Allow 0 as default value for range sliders

### DIFF
--- a/core-bundle/src/Resources/contao/templates/forms/form_range.html5
+++ b/core-bundle/src/Resources/contao/templates/forms/form_range.html5
@@ -1,4 +1,8 @@
-<?php $this->extend('form_row'); ?>
+<?php
+
+use Contao\FormRange;
+
+$this->extend('form_row'); ?>
 
 <?php $this->block('label'); ?>
   <?php if ($this->label): ?>
@@ -17,5 +21,5 @@
     <p class="error"><?= $this->getErrorAsString() ?></p>
   <?php endif; ?>
 
-  <input type="<?= $this->type ?>" name="<?= $this->name ?>" id="ctrl_<?= $this->id ?>" class="range<?php if ($this->class): ?> <?= $this->class ?><?php endif; ?>"<?php if ($this->value != ''): ?> value="<?= (float) $this->value ?>"<?php endif; ?><?= $this->getAttributes() ?>>
+  <input type="<?= $this->type ?>" name="<?= $this->name ?>" id="ctrl_<?= $this->id ?>" class="range<?php if ($this->class): ?> <?= $this->class ?><?php endif; ?>"<?php if ('' != $this->value): ?> value="<?= (float) $this->value ?>"<?php endif; ?><?= $this->getAttributes() ?>>
 <?php $this->endblock(); ?>

--- a/core-bundle/src/Resources/contao/templates/forms/form_range.html5
+++ b/core-bundle/src/Resources/contao/templates/forms/form_range.html5
@@ -1,8 +1,4 @@
-<?php
-
-use Contao\FormRange;
-
-$this->extend('form_row'); ?>
+<?php $this->extend('form_row'); ?>
 
 <?php $this->block('label'); ?>
   <?php if ($this->label): ?>

--- a/core-bundle/src/Resources/contao/templates/forms/form_range.html5
+++ b/core-bundle/src/Resources/contao/templates/forms/form_range.html5
@@ -17,5 +17,5 @@
     <p class="error"><?= $this->getErrorAsString() ?></p>
   <?php endif; ?>
 
-  <input type="<?= $this->type ?>" name="<?= $this->name ?>" id="ctrl_<?= $this->id ?>" class="range<?php if ($this->class): ?> <?= $this->class ?><?php endif; ?>"<?php if ('' != $this->value): ?> value="<?= (float) $this->value ?>"<?php endif; ?><?= $this->getAttributes() ?>>
+  <input type="<?= $this->type ?>" name="<?= $this->name ?>" id="ctrl_<?= $this->id ?>" class="range<?php if ($this->class): ?> <?= $this->class ?><?php endif; ?>"<?php if ('' !== $this->value && null !== $this->value): ?> value="<?= (float) $this->value ?>"<?php endif; ?><?= $this->getAttributes() ?>>
 <?php $this->endblock(); ?>

--- a/core-bundle/src/Resources/contao/templates/forms/form_range.html5
+++ b/core-bundle/src/Resources/contao/templates/forms/form_range.html5
@@ -17,5 +17,5 @@
     <p class="error"><?= $this->getErrorAsString() ?></p>
   <?php endif; ?>
 
-  <input type="<?= $this->type ?>" name="<?= $this->name ?>" id="ctrl_<?= $this->id ?>" class="range<?php if ($this->class): ?> <?= $this->class ?><?php endif; ?>"<?php if ('' !== $this->value && null !== $this->value): ?> value="<?= (float) $this->value ?>"<?php endif; ?><?= $this->getAttributes() ?>>
+  <input type="<?= $this->type ?>" name="<?= $this->name ?>" id="ctrl_<?= $this->id ?>" class="range<?php if ($this->class): ?> <?= $this->class ?><?php endif; ?>"<?php if ('' !== (string) $this->value): ?> value="<?= (float) $this->value ?>"<?php endif; ?><?= $this->getAttributes() ?>>
 <?php $this->endblock(); ?>

--- a/core-bundle/src/Resources/contao/templates/forms/form_range.html5
+++ b/core-bundle/src/Resources/contao/templates/forms/form_range.html5
@@ -17,5 +17,5 @@
     <p class="error"><?= $this->getErrorAsString() ?></p>
   <?php endif; ?>
 
-  <input type="<?= $this->type ?>" name="<?= $this->name ?>" id="ctrl_<?= $this->id ?>" class="range<?php if ($this->class): ?> <?= $this->class ?><?php endif; ?>"<?php if ($this->value): ?> value="<?= (float) $this->value ?>"<?php endif; ?><?= $this->getAttributes() ?>>
+  <input type="<?= $this->type ?>" name="<?= $this->name ?>" id="ctrl_<?= $this->id ?>" class="range<?php if ($this->class): ?> <?= $this->class ?><?php endif; ?>"<?php if ($this->value != ''): ?> value="<?= (float) $this->value ?>"<?php endif; ?><?= $this->getAttributes() ?>>
 <?php $this->endblock(); ?>


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #2778
| Docs PR or issue | -

In order to be able to set a **Default value** of `0` for a _Range slider_ form field in the form generator, we need to check for an empty string.