### PR TITLE
Handle another illegal array access in the tl_page DCA

### DIFF
--- a/core-bundle/src/Resources/contao/dca/tl_page.php
+++ b/core-bundle/src/Resources/contao/dca/tl_page.php
@@ -1461,7 +1461,7 @@ class tl_page extends Backend
 		}
 
 		// Prevent adding non-root pages on top-level
-		if ($row['pid'] == 0 && Input::get('mode') != 'create')
+		if (($row['pid'] ?? null) == 0 && Input::get('mode') != 'create')
 		{
 			$objPage = $this->Database->prepare("SELECT * FROM " . $table . " WHERE id=?")
 									  ->limit(1)

--- a/core-bundle/src/Resources/contao/dca/tl_page.php
+++ b/core-bundle/src/Resources/contao/dca/tl_page.php
@@ -1461,7 +1461,7 @@ class tl_page extends Backend
 		}
 
 		// Prevent adding non-root pages on top-level
-		if (($row['pid'] ?? null) == 0 && Input::get('mode') != 'create')
+		if (empty($row['pid']) && Input::get('mode') != 'create')
 		{
 			$objPage = $this->Database->prepare("SELECT * FROM " . $table . " WHERE id=?")
 									  ->limit(1)

--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -3666,7 +3666,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 		$_buttons = '&nbsp;';
 
 		// Show paste button only if there are no root records specified
-		if ($blnClipboard && ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] ?? null) == 5 && ((empty($GLOBALS['TL_DCA'][$table]['list']['sorting']['root']) && $GLOBALS['TL_DCA'][$table]['list']['sorting']['root'] !== false) || ($GLOBALS['TL_DCA'][$table]['list']['sorting']['rootPaste'] ?? null)) && Input::get('act') != 'select')
+		if ($blnClipboard && ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] ?? null) == 5 && ((empty($GLOBALS['TL_DCA'][$table]['list']['sorting']['root']) && ($GLOBALS['TL_DCA'][$table]['list']['sorting']['root'] ?? null) !== false) || ($GLOBALS['TL_DCA'][$table]['list']['sorting']['rootPaste'] ?? null)) && Input::get('act') != 'select')
 		{
 			// Call paste_button_callback (&$dc, $row, $table, $cr, $childs, $previous, $next)
 			if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['paste_button_callback'] ?? null))


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes -
| Docs PR or issue | -

This fixes `Warning: Undefined array key "root"` coming from `DCTable` line 3669. This also hardens `tl_page#pastePage()` that will receive an incomplete `$row` by the call in line 3678 and would otherwise produce `Warning: Undefined array key "pid"`.

https://github.com/contao/contao/blob/1873bcc9ea728a08ca8755f6e7251d999d7b316b/core-bundle/src/Resources/contao/drivers/DC_Table.php#L3669-L3690