### PR TITLE
Include table views in the listing module drop-down menu

### DIFF
--- a/listing-bundle/src/Resources/contao/dca/tl_module.php
+++ b/listing-bundle/src/Resources/contao/dca/tl_module.php
@@ -107,6 +107,15 @@ class tl_module_listing extends Contao\Backend
 	 */
 	public function getAllTables()
 	{
-		return $this->Database->listTables();
+		$arrTables = $this->Database->listTables();
+		$arrViews = Contao\System::getContainer()->get('database_connection')->getSchemaManager()->listViews();
+
+		if (!empty($arrViews))
+		{
+			$arrTables = array_merge($arrTables, array_keys($arrViews));
+			natsort($arrTables);
+		}
+
+		return array_values($arrTables);
 	}
 }


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #2795
| Docs PR or issue | -

In Contao 3 you were able to also select table views for the **Table** in a `listing` module. However this functionality was lost somewhere along the way in Contao 4. It is however still present for `tl_form.targetTable`.

This PR fixes that and simply copies over the [same code from `tl_form`](https://github.com/contao/contao/blob/712de2476dc6100cad1876da1f22b809f7558d5c/core-bundle/src/Resources/contao/dca/tl_form.php#L497-L509). I can make this fix also more elaborate and implement a proper service for the callback, but I am not sure if it is worth the effort.