### PR TITLE
Fix an illegal array access in DC_Table when expanding the tree

### DIFF
--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -3843,21 +3843,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 
 		for ($i=0, $c=\count($arrIds); $i<$c; $i++)
 		{
-			$return .= ' ' . trim(
-				$this->generateTree(
-					$table,
-					$arrIds[$i],
-					array('p'=>($arrIds[$i-1] ?? null), 'n'=>($arrIds[$i+1] ?? null)),
-					$hasSorting,
-					$margin,
-					($blnClipboard ? $arrClipboard : false),
-					$arrClipboard !== null && (
-						$id == $arrClipboard['id'] ||
-						(\is_array($arrClipboard['id']) && \in_array($id, $arrClipboard['id'])) ||
-						(!$blnPtable && !\is_array($arrClipboard['id']) && \in_array($id, $this->Database->getChildRecords($arrClipboard['id'], $table)))
-					),
-					$blnProtected
-				));
+			$return .= ' ' . trim($this->generateTree($table, $arrIds[$i], array('p'=>($arrIds[$i-1] ?? null), 'n'=>($arrIds[$i+1] ?? null)), $hasSorting, $margin, ($blnClipboard ? $arrClipboard : false), $arrClipboard !== null && ($id == $arrClipboard['id'] || (\is_array($arrClipboard['id']) && \in_array($id, $arrClipboard['id'])) || (!$blnPtable && !\is_array($arrClipboard['id']) && \in_array($id, $this->Database->getChildRecords($arrClipboard['id'], $table)))), $blnProtected));
 		}
 
 		return $return;

--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -3843,7 +3843,21 @@ class DC_Table extends DataContainer implements \listable, \editable
 
 		for ($i=0, $c=\count($arrIds); $i<$c; $i++)
 		{
-			$return .= ' ' . trim($this->generateTree($table, $arrIds[$i], array('p'=>$arrIds[($i-1)], 'n'=>$arrIds[($i+1)]), $hasSorting, $margin, ($blnClipboard ? $arrClipboard : false), ($id == $arrClipboard['id'] || (\is_array($arrClipboard['id']) && \in_array($id, $arrClipboard['id'])) || (!$blnPtable && !\is_array($arrClipboard['id']) && \in_array($id, $this->Database->getChildRecords($arrClipboard['id'], $table)))), $blnProtected));
+			$return .= ' ' . trim(
+				$this->generateTree(
+					$table,
+					$arrIds[$i],
+					array('p'=>$arrIds[($i-1)], 'n'=>$arrIds[($i+1)]),
+					$hasSorting,
+					$margin,
+					($blnClipboard ? $arrClipboard : false),
+					(
+						$id == $arrClipboard['id'] ||
+						(\is_array($arrClipboard['id']) && \in_array($id, $arrClipboard['id'])) ||
+						(!$blnPtable && !\is_array($arrClipboard['id']) && \in_array($id, $this->Database->getChildRecords($arrClipboard['id'], $table)))
+					),
+					$blnProtected
+				));
 		}
 
 		return $return;

--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -3847,11 +3847,11 @@ class DC_Table extends DataContainer implements \listable, \editable
 				$this->generateTree(
 					$table,
 					$arrIds[$i],
-					array('p'=>$arrIds[($i-1)], 'n'=>$arrIds[($i+1)]),
+					array('p'=>($arrIds[$i-1] ?? null), 'n'=>($arrIds[$i+1] ?? null)),
 					$hasSorting,
 					$margin,
 					($blnClipboard ? $arrClipboard : false),
-					(
+					$arrClipboard !== null && (
 						$id == $arrClipboard['id'] ||
 						(\is_array($arrClipboard['id']) && \in_array($id, $arrClipboard['id'])) ||
 						(!$blnPtable && !\is_array($arrClipboard['id']) && \in_array($id, $this->Database->getChildRecords($arrClipboard['id'], $table)))


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #2797 
| Docs PR or issue | -

I split the PR in two commits:
* one that *only* formats the code so that there is any chance of reviewing this:
https://github.com/contao/contao/commit/a1a16fea1c1cae125f129f03e38db1a3abf5a59e
* one that applies the fixes:
https://github.com/contao/contao/commit/9bcedb793b74062b4e4cfddc7a30765694ffd5fe

(If you want to, I can collapse the whole thing into a oneline-mega-expression again in a third one…)