### PR TITLE
Fix the legacy entry points not working in Contao 4.11

### DIFF
--- a/core-bundle/src/Controller/InitializeController.php
+++ b/core-bundle/src/Controller/InitializeController.php
@@ -12,7 +12,9 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Controller;
 
+use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\CoreBundle\Response\InitializeControllerResponse;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
@@ -121,6 +123,16 @@ class InitializeController extends AbstractController
         );
 
         return new InitializeControllerResponse('', 204);
+    }
+
+    public static function getSubscribedServices()
+    {
+        $services = parent::getSubscribedServices();
+
+        $services['contao.framework'] = ContaoFramework::class;
+        $services['kernel'] = KernelInterface::class;
+
+        return $services;
     }
 
     /**

--- a/core-bundle/src/Controller/InitializeController.php
+++ b/core-bundle/src/Controller/InitializeController.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Controller;
 
 use Contao\CoreBundle\Response\InitializeControllerResponse;
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;

--- a/core-bundle/src/Resources/config/services.yml
+++ b/core-bundle/src/Resources/config/services.yml
@@ -134,6 +134,9 @@ services:
             - controller.service_arguments
 
     # Backwards compatibility
+    Contao\CoreBundle\Controller\InitializeController: ~
+
+    # Backwards compatibility
     contao.controller.images:
         alias: Contao\CoreBundle\Controller\ImagesController
         # TODO: re-enable this as soon as we are on Symfony 5 only


### PR DESCRIPTION
The first error I have encountered when trying to open a script that uses a legacy entry point was:

```
"Contao\CoreBundle\Controller\InitializeController" has no container set, did you forget to define it as a service subscriber?
```

Apparently in Contao 4.11 that controller is no longer considered by Symfony as a service and thus the container is not injected. Thus my adjustments to the `services.yml` file.

Then another error popped up:

```
Service "contao.framework" not found: even though it exists in the app's container, the container inside "Contao\CoreBundle\Controller\InitializeController" is a smaller service locator that only knows about the "doctrine", "http_kernel", "parameter_bag", "request_stack", "router", "security.authorization_checker", "security.csrf.token_manager", "security.token_storage", "session" and "twig" services. Try using dependency injection instead.
```

It seems that other legacy Contao controllers (such as `BackendController`) do extend the Contao's `AbstractController`, whereas the `InitializeController` extends the Symfony's one. I am not sure if it's intended or not, but having the class extend the Contao's controller does the job.

Please double check this PR as I am not 100% sure if it has any negative impacts on other stuff.

/cc @aschempp 