### PR TITLE
Start the session to check for a user token

### DIFF
--- a/core-bundle/src/Security/Authentication/Token/TokenChecker.php
+++ b/core-bundle/src/Security/Authentication/Token/TokenChecker.php
@@ -174,7 +174,16 @@ class TokenChecker
 
     private function getTokenFromSession(string $sessionKey): ?TokenInterface
     {
-        if (!$this->session->isStarted() || !$this->session->has($sessionKey)) {
+        if (!$this->session->isStarted()) {
+            $request = $this->requestStack->getMasterRequest();
+
+            if (!$request || !$request->hasPreviousSession()) {
+                return null;
+            }
+        }
+
+        // This will start the session if Request::hasPreviousSession() was true
+        if (!$this->session->has($sessionKey)) {
             return null;
         }
 


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #2810


Explicitly bypassing the `_wdt` route as suggested in https://github.com/contao/contao/issues/2810#issuecomment-786569685 is not the correct solution. The back end user is always available from the session, but we need to start the session if no other service has done that before the `TokenChecker`.
