### PR TITLE
Always sort root pages by language first

### DIFF
--- a/core-bundle/src/Routing/RouteProvider.php
+++ b/core-bundle/src/Routing/RouteProvider.php
@@ -417,43 +417,46 @@ class RouteProvider implements RouteProviderInterface
                     return 0;
                 }
 
+                $langA = null;
+                $langB = null;
+
+                if (null !== $languages && $pageA->rootLanguage !== $pageB->rootLanguage) {
+                    $langA = $languages[$pageA->rootLanguage] ?? null;
+                    $langB = $languages[$pageB->rootLanguage] ?? null;
+                }
+
+                if (null === $langA && null === $langB) {
+                    if ($pageA->rootIsFallback && !$pageB->rootIsFallback) {
+                        return -1;
+                    }
+
+                    if ($pageB->rootIsFallback && !$pageA->rootIsFallback) {
+                        return 1;
+                    }
+                } else {
+                    if (null === $langA && null !== $langB) {
+                        return 1;
+                    }
+
+                    if (null !== $langA && null === $langB) {
+                        return -1;
+                    }
+
+                    if ($langA < $langB) {
+                        return -1;
+                    }
+
+                    if ($langA > $langB) {
+                        return 1;
+                    }
+                }
+
                 if ('root' !== $pageA->type && 'root' === $pageB->type) {
                     return -1;
                 }
 
                 if ('root' === $pageA->type && 'root' !== $pageB->type) {
                     return 1;
-                }
-
-                if (null !== $languages && $pageA->rootLanguage !== $pageB->rootLanguage) {
-                    $langA = $languages[$pageA->rootLanguage] ?? null;
-                    $langB = $languages[$pageB->rootLanguage] ?? null;
-
-                    if (null === $langA && null === $langB) {
-                        if ($pageA->rootIsFallback && !$pageB->rootIsFallback) {
-                            return -1;
-                        }
-
-                        if ($pageB->rootIsFallback && !$pageA->rootIsFallback) {
-                            return 1;
-                        }
-                    } else {
-                        if (null === $langA && null !== $langB) {
-                            return 1;
-                        }
-
-                        if (null !== $langA && null === $langB) {
-                            return -1;
-                        }
-
-                        if ($langA < $langB) {
-                            return -1;
-                        }
-
-                        if ($langA > $langB) {
-                            return 1;
-                        }
-                    }
                 }
 
                 return strnatcasecmp((string) $pageB->alias, (string) $pageA->alias);


### PR DESCRIPTION
The fix in #2819 was not correct. Luckily, merging the changes in Contao 4.11 showed the problem.

**Example case:**
 - Root page `de`
 - No `index` page in `de`
 - Root Page `en`
 - `index` page in `en`

The changes in #2819 would sort the english `index` page before any root pages. This means even if a user requests `de` as preferred language, she would not land on the german home page. This means the changes in #2819 need to be reverted.

While debugging the routing through `route:match` (thanks @dmolineus) I noticed the fallback page is not preferred if no language is given. Applying the fallback sorting fixes the initial issue in #2819 as well, most likely because bubblesort now correctly compares the necessary pages.