### PR TITLE
Allow passing an array of IDs to User::isMemberOf()

### DIFF
--- a/calendar-bundle/src/Resources/contao/classes/Events.php
+++ b/calendar-bundle/src/Resources/contao/classes/Events.php
@@ -63,29 +63,23 @@ abstract class Events extends Module
 			return $arrCalendars;
 		}
 
-		$this->import(FrontendUser::class, 'User');
 		$objCalendar = CalendarModel::findMultipleByIds($arrCalendars);
 		$arrCalendars = array();
 
 		if ($objCalendar !== null)
 		{
-			$blnFeUserLoggedIn = System::getContainer()->get('contao.security.token_checker')->hasFrontendUser();
+			$user = null;
+
+			if (System::getContainer()->get('contao.security.token_checker')->hasFrontendUser())
+			{
+				$user = FrontendUser::getInstance();
+			}
 
 			while ($objCalendar->next())
 			{
-				if ($objCalendar->protected)
+				if ($objCalendar->protected && (!$user || !$user->isMemberOf(StringUtil::deserialize($objCalendar->groups))))
 				{
-					if (!$blnFeUserLoggedIn || !\is_array($this->User->groups))
-					{
-						continue;
-					}
-
-					$groups = StringUtil::deserialize($objCalendar->groups);
-
-					if (empty($groups) || !\is_array($groups) || \count(array_intersect($groups, $this->User->groups)) < 1)
-					{
-						continue;
-					}
+					continue;
 				}
 
 				$arrCalendars[] = $objCalendar->id;

--- a/core-bundle/src/Resources/contao/controllers/FrontendIndex.php
+++ b/core-bundle/src/Resources/contao/controllers/FrontendIndex.php
@@ -276,10 +276,8 @@ class FrontendIndex extends Frontend
 				throw new AccessDeniedException('Access denied: ' . Environment::get('uri'));
 			}
 
-			$arrGroups = $objPage->groups; // required for empty()
-
 			// Check the user groups
-			if (empty($arrGroups) || !\is_array($arrGroups) || !\is_array($this->User->groups) || !\count(array_intersect($arrGroups, $this->User->groups)))
+			if (!$this->User->isMemberOf($objPage->groups))
 			{
 				$this->log('Page ID "' . $objPage->id . '" can only be accessed by groups "' . implode(', ', (array) $objPage->groups) . '" (current user groups: ' . implode(', ', $this->User->groups) . ')', __METHOD__, TL_ERROR);
 

--- a/core-bundle/src/Resources/contao/library/Contao/Controller.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Controller.php
@@ -726,27 +726,9 @@ abstract class Controller extends System
 			// Protected element
 			if ($objElement->protected)
 			{
-				if (!$blnFeUserLoggedIn)
+				if (!$blnFeUserLoggedIn || !FrontendUser::getInstance()->isMemberOf(StringUtil::deserialize($objElement->groups)))
 				{
 					$blnReturn = false;
-				}
-				else
-				{
-					$objUser = FrontendUser::getInstance();
-
-					if (!\is_array($objUser->groups))
-					{
-						$blnReturn = false;
-					}
-					else
-					{
-						$groups = StringUtil::deserialize($objElement->groups);
-
-						if (empty($groups) || !\is_array($groups) || !\count(array_intersect($groups, $objUser->groups)))
-						{
-							$blnReturn = false;
-						}
-					}
 				}
 			}
 

--- a/core-bundle/src/Resources/contao/library/Contao/User.php
+++ b/core-bundle/src/Resources/contao/library/Contao/User.php
@@ -411,14 +411,21 @@ abstract class User extends System implements UserInterface, EquatableInterface,
 	/**
 	 * Return true if the user is member of a particular group
 	 *
-	 * @param integer $id The group ID
+	 * @param mixed $ids A single group ID or an array of group IDs
 	 *
 	 * @return boolean True if the user is a member of the group
 	 */
-	public function isMemberOf($id)
+	public function isMemberOf($ids)
 	{
-		// ID not numeric
-		if (!is_numeric($id))
+		if (!\is_array($ids))
+		{
+			$ids = array($ids);
+		}
+
+		// Filter non-numeric values
+		$ids = array_values(array_filter($ids, static function ($val) { return is_numeric($val); }));
+
+		if (empty($ids))
 		{
 			return false;
 		}
@@ -431,13 +438,7 @@ abstract class User extends System implements UserInterface, EquatableInterface,
 			return false;
 		}
 
-		// Group ID found
-		if (\in_array($id, $groups))
-		{
-			return true;
-		}
-
-		return false;
+		return \count(array_intersect($ids, $groups)) > 0;
 	}
 
 	/**

--- a/core-bundle/src/Resources/contao/modules/Module.php
+++ b/core-bundle/src/Resources/contao/modules/Module.php
@@ -271,13 +271,11 @@ abstract class Module extends Frontend
 		}
 
 		$items = array();
-		$groups = array();
+		$user = null;
 
-		// Get all groups of the current front end user
 		if (System::getContainer()->get('contao.security.token_checker')->hasFrontendUser())
 		{
-			$this->import(FrontendUser::class, 'User');
-			$groups = $this->User->groups;
+			$user = FrontendUser::getInstance();
 		}
 
 		$objTemplate = new FrontendTemplate($this->navigationTpl ?: 'nav_default');
@@ -300,7 +298,6 @@ abstract class Module extends Frontend
 			}
 
 			$subitems = '';
-			$_groups = StringUtil::deserialize($objSubpage->groups);
 
 			// Override the domain (see #3765)
 			if ($host !== null)
@@ -309,7 +306,7 @@ abstract class Module extends Frontend
 			}
 
 			// Do not show protected pages unless a front end user is logged in
-			if (!$objSubpage->protected || $this->showProtected || ($this instanceof ModuleSitemap && $objSubpage->sitemap == 'map_always') || (\is_array($_groups) && \is_array($groups) && \count(array_intersect($_groups, $groups))))
+			if (!$objSubpage->protected || $this->showProtected || ($this instanceof ModuleSitemap && $objSubpage->sitemap == 'map_always') || ($user && $user->isMemberOf(StringUtil::deserialize($objSubpage->groups))))
 			{
 				// Check whether there will be subpages
 				if ($objSubpage->subpages > 0 && (!$this->showLevel || $this->showLevel >= $level || (!$this->hardLimit && ($objPage->id == $objSubpage->id || \in_array($objPage->id, $this->Database->getChildRecords($objSubpage->id, 'tl_page'))))))

--- a/core-bundle/src/Resources/contao/modules/ModuleCustomnav.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleCustomnav.php
@@ -68,13 +68,11 @@ class ModuleCustomnav extends Module
 		global $objPage;
 
 		$items = array();
-		$groups = array();
+		$user = null;
 
-		// Get all groups of the current front end user
 		if (System::getContainer()->get('contao.security.token_checker')->hasFrontendUser())
 		{
-			$this->import(FrontendUser::class, 'User');
-			$groups = $this->User->groups;
+			$user = FrontendUser::getInstance();
 		}
 
 		// Get all active pages and also include root pages if the language is added to the URL (see #72)
@@ -95,10 +93,8 @@ class ModuleCustomnav extends Module
 		/** @var PageModel[] $objPages */
 		foreach ($objPages as $objModel)
 		{
-			$_groups = StringUtil::deserialize($objModel->groups);
-
 			// Do not show protected pages unless a front end user is logged in
-			if (!$objModel->protected || $this->showProtected || (\is_array($_groups) && \is_array($groups) && \count(array_intersect($_groups, $groups))))
+			if (!$objModel->protected || $this->showProtected || ($user && $user->isMemberOf(StringUtil::deserialize($objModel->groups))))
 			{
 				// Get href
 				switch ($objModel->type)

--- a/core-bundle/src/Resources/contao/modules/ModuleSearch.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleSearch.php
@@ -187,26 +187,18 @@ class ModuleSearch extends Module
 			// Sort out protected pages
 			if (Config::get('indexProtected'))
 			{
-				$this->import(FrontendUser::class, 'User');
-				$blnFeUserLoggedIn = System::getContainer()->get('contao.security.token_checker')->hasFrontendUser();
+				$user = null;
+
+				if (System::getContainer()->get('contao.security.token_checker')->hasFrontendUser())
+				{
+					$user = FrontendUser::getInstance();
+				}
 
 				foreach ($arrResult as $k=>$v)
 				{
-					if ($v['protected'] ?? null)
+					if (($v['protected'] ?? null) && (!$user || !$user->isMemberOf(StringUtil::deserialize($v['groups'] ?? null))))
 					{
-						if (!$blnFeUserLoggedIn || !\is_array($this->User->groups))
-						{
-							unset($arrResult[$k]);
-						}
-						else
-						{
-							$groups = StringUtil::deserialize($v['groups']);
-
-							if (empty($groups) || !\is_array($groups) || !\count(array_intersect($groups, $this->User->groups)))
-							{
-								unset($arrResult[$k]);
-							}
-						}
+						unset($arrResult[$k]);
 					}
 				}
 

--- a/news-bundle/src/Resources/contao/modules/ModuleNews.php
+++ b/news-bundle/src/Resources/contao/modules/ModuleNews.php
@@ -39,29 +39,23 @@ abstract class ModuleNews extends Module
 			return $arrArchives;
 		}
 
-		$this->import(FrontendUser::class, 'User');
 		$objArchive = NewsArchiveModel::findMultipleByIds($arrArchives);
 		$arrArchives = array();
 
 		if ($objArchive !== null)
 		{
-			$blnFeUserLoggedIn = System::getContainer()->get('contao.security.token_checker')->hasFrontendUser();
+			$user = null;
+
+			if (System::getContainer()->get('contao.security.token_checker')->hasFrontendUser())
+			{
+				$user = FrontendUser::getInstance();
+			}
 
 			while ($objArchive->next())
 			{
-				if ($objArchive->protected)
+				if ($objArchive->protected && (!$user || !$user->isMemberOf(StringUtil::deserialize($objArchive->groups))))
 				{
-					if (!$blnFeUserLoggedIn || !\is_array($this->User->groups))
-					{
-						continue;
-					}
-
-					$groups = StringUtil::deserialize($objArchive->groups);
-
-					if (empty($groups) || !\is_array($groups) || !\count(array_intersect($groups, $this->User->groups)))
-					{
-						continue;
-					}
+					continue;
 				}
 
 				$arrArchives[] = $objArchive->id;


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #2753
| Docs PR or issue | -

To fix #2753 (do not show protected pages in the sitemap if there is no front end user or the user groups do not match), I have adjusted the `User::isMemberOf()` method to also accept an array of group IDs. This allows us to greatly simplify other checks as well:

### Current

```php
$blnFeUserLoggedIn = System::getContainer()->get('contao.security.token_checker')->hasFrontendUser();

while ($objCalendar->next())
{
	if ($objCalendar->protected)
	{
		if (!$blnFeUserLoggedIn || !\is_array($this->User->groups))
		{
			continue;
		}

		$groups = StringUtil::deserialize($objCalendar->groups);

		if (empty($groups) || !\is_array($groups) || \count(array_intersect($groups, $this->User->groups)) < 1)
		{
			continue;
		}
	}

	// …
}
```

### New

```php
$user = null;

if (System::getContainer()->get('contao.security.token_checker')->hasFrontendUser())
{
	$user = FrontendUser::getInstance();
}

while ($objCalendar->next())
{
	if ($objCalendar->protected && (!$user || !$user->isMemberOf(StringUtil::deserialize($objCalendar->groups))))
	{
		continue;
	}

	// …
}
```
