### PR TITLE
Use eval.context in the picker if set

### DIFF
--- a/core-bundle/src/Resources/contao/widgets/Picker.php
+++ b/core-bundle/src/Resources/contao/widgets/Picker.php
@@ -174,11 +174,18 @@ class Picker extends Widget
 
 	protected function generateValues($blnHasOrder): array
 	{
-		$strRelatedTable = $this->getRelatedTable();
+		if (substr($this->context ?? '', 0, 3) === 'dc.')
+		{
+			$strRelatedTable = substr($this->context, 3);
+		}
+		else
+		{
+			$strRelatedTable = $this->getRelatedTable();
+		}
 
 		if (!$strRelatedTable)
 		{
-			return (array) $this->varValue;
+			return array_combine((array) $this->varValue, (array) $this->varValue);
 		}
 
 		Controller::loadDataContainer($strRelatedTable);


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes https://github.com/madeyourday/contao-rocksolid-custom-elements/issues/129

For dynamic DCA fields (like in multicolumn wizard, custom elements and so on) there is no relation information stored in the DCA extractor. The picker widget supports setting `eval.context` to something like `dc.tl_content`, but when rendering the values this `context` is ignored. This PR changes that so that `context` is always used and the relation data as fallback.