### PR TITLE
Always show all errors in the contao-setup binary

### DIFF
--- a/manager-bundle/bin/contao-setup
+++ b/manager-bundle/bin/contao-setup
@@ -16,7 +16,10 @@ use Contao\ManagerBundle\HttpKernel\ContaoKernel;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Filesystem\Filesystem;
 
+error_reporting(-1);
 set_time_limit(0);
+@ini_set('display_startup_errors', '1');
+@ini_set('display_errors', '1');
 @ini_set('zlib.output_compression', '0');
 
 if (file_exists(__DIR__.'/../autoload.php')) {


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #2844
| Docs PR or issue | -

We should IMHO be verbose with errors happening in the `contao-setup` binary. By default. As #2844 nicely demonstrates, this could otherwise quickly lead to a bad debugging experience. 

btw.:This is something else than the errors from the sub processes (from within the command) that we're already delegating.