### PR TITLE
Respect the label field order in the picker

### DIFF
--- a/core-bundle/src/Resources/contao/widgets/Picker.php
+++ b/core-bundle/src/Resources/contao/widgets/Picker.php
@@ -265,7 +265,7 @@ class Picker extends Widget
 		$labelValues = [];
 
 		foreach ($labelConfig['fields'] as $field) {
-			$labelValues[] = $arrRow[$field];
+			$labelValues[] = $arrRow[$field] ?? '';
 		}
 
 		$label = vsprintf($labelConfig['format'], $labelValues);

--- a/core-bundle/src/Resources/contao/widgets/Picker.php
+++ b/core-bundle/src/Resources/contao/widgets/Picker.php
@@ -262,9 +262,10 @@ class Picker extends Widget
 		}
 
 		$labelConfig = &$GLOBALS['TL_DCA'][$dc->table]['list']['label'];
-		$labelValues = [];
+		$labelValues = array();
 
-		foreach ($labelConfig['fields'] as $field) {
+		foreach ($labelConfig['fields'] as $field)
+		{
 			$labelValues[] = $arrRow[$field] ?? '';
 		}
 

--- a/core-bundle/src/Resources/contao/widgets/Picker.php
+++ b/core-bundle/src/Resources/contao/widgets/Picker.php
@@ -262,7 +262,13 @@ class Picker extends Widget
 		}
 
 		$labelConfig = &$GLOBALS['TL_DCA'][$dc->table]['list']['label'];
-		$label = vsprintf($labelConfig['format'], array_intersect_key($arrRow, array_flip($labelConfig['fields'])));
+		$labelValues = [];
+
+		foreach ($labelConfig['fields'] as $field) {
+			$labelValues[] = $arrRow[$field];
+		}
+
+		$label = vsprintf($labelConfig['format'], $labelValues);
 
 		if (\is_array($labelConfig['label_callback']))
 		{


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | #2853
| Docs PR or issue | -

Maintains the order of the keys in the picker label generator function.