### PR TITLE
Fix deprecations in unit tests

### DIFF
--- a/core-bundle/tests/Functional/Migration/RoutingMigrationTest.php
+++ b/core-bundle/tests/Functional/Migration/RoutingMigrationTest.php
@@ -21,6 +21,7 @@ use Doctrine\DBAL\Connection;
 class RoutingMigrationTest extends FunctionalTestCase
 {
     /**
+     * @group legacy
      * @dataProvider shouldRunProvider
      */
     public function testShouldRun(array $dropFields, bool $expected): void
@@ -102,6 +103,7 @@ class RoutingMigrationTest extends FunctionalTestCase
     }
 
     /**
+     * @group legacy
      * @dataProvider migrationDataProvider
      */
     public function testMigratesData(bool $prependLocale, string $urlSuffix, bool $folderUrl): void

--- a/core-bundle/tests/Image/Studio/ImageResultTest.php
+++ b/core-bundle/tests/Image/Studio/ImageResultTest.php
@@ -37,6 +37,18 @@ use Symfony\Component\Filesystem\Filesystem;
 
 class ImageResultTest extends TestCase
 {
+    /**
+     * @group legacy
+     *
+     * @expectedDeprecation %s\PictureFactoryWithoutResizeOptionsStub::create()" method will require a new "ResizeOptions|null $options" argument in the next major version%s
+     */
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        spl_autoload_call(PictureFactoryWithoutResizeOptionsStub::class);
+    }
+
     public function testGetPicture(): void
     {
         $filePathOrImage = '/project/dir/foo/bar/foobar.png';

--- a/core-bundle/tests/Security/Logout/LogoutHandlerTest.php
+++ b/core-bundle/tests/Security/Logout/LogoutHandlerTest.php
@@ -31,6 +31,20 @@ class LogoutHandlerTest extends TestCase
 {
     use ExpectDeprecationTrait;
 
+    /**
+     * @group legacy
+     *
+     * @expectedDeprecation %s class implements "Symfony\Component\Security\Http\Logout\LogoutHandlerInterface" that is deprecated %s
+     * @expectedDeprecation The "Symfony\Component\Security\Http\Logout\DefaultLogoutSuccessHandler" class is deprecated%s
+     * @expectedDeprecation The "Symfony\Component\Security\Http\Logout\LogoutSuccessHandlerInterface" interface is deprecated%s
+     */
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        spl_autoload_call(LogoutHandler::class);
+    }
+
     public function testAddsTheLogEntry(): void
     {
         $framework = $this->mockContaoFramework();

--- a/core-bundle/tests/Security/Logout/LogoutSuccessHandlerTest.php
+++ b/core-bundle/tests/Security/Logout/LogoutSuccessHandlerTest.php
@@ -21,6 +21,18 @@ use Symfony\Component\Security\Http\HttpUtils;
 
 class LogoutSuccessHandlerTest extends TestCase
 {
+    /**
+     * @group legacy
+     *
+     * @expectedDeprecation %s class implements "Symfony\Component\Security\Http\Logout\DefaultLogoutSuccessHandler" that is deprecated %s
+     */
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        spl_autoload_call(LogoutSuccessHandler::class);
+    }
+
     public function testRedirectsToAGivenUrl(): void
     {
         $request = new Request();

--- a/manager-bundle/tests/Security/Logout/LogoutHandlerTest.php
+++ b/manager-bundle/tests/Security/Logout/LogoutHandlerTest.php
@@ -21,6 +21,18 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
 class LogoutHandlerTest extends ContaoTestCase
 {
+    /**
+     * @group legacy
+     *
+     * @expectedDeprecation %s class implements "Symfony\Component\Security\Http\Logout\LogoutHandlerInterface" that is deprecated %s
+     */
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        spl_autoload_call(LogoutHandler::class);
+    }
+
     public function testClearsCookieOnResponse(): void
     {
         $response = $this->createMock(Response::class);


### PR DESCRIPTION
This should fix the CI chain. Not sure if we should add `TODO` comments so that we don’t forget to actually change the code according to the deprecation messages?

Related: https://github.com/contao/contao/pull/2517