### PR TITLE
Quote the "group" field in the UserCreateCommand statement

### DIFF
--- a/core-bundle/src/Command/UserCreateCommand.php
+++ b/core-bundle/src/Command/UserCreateCommand.php
@@ -277,21 +277,23 @@ class UserCreateCommand extends Command
         $time = time();
         $hash = $this->encoderFactory->getEncoder(BackendUser::class)->encodePassword($password, null);
 
-        $this->connection->insert(
-            'tl_user',
-            [
-                'tstamp' => $time,
-                'name' => $name,
-                'email' => $email,
-                'username' => $username,
-                'password' => $hash,
-                'language' => $language,
-                'backendTheme' => 'flexible',
-                'admin' => $isAdmin,
-                'pwChange' => $pwChange,
-                'dateAdded' => $time,
-                'groups' => !$isAdmin && !empty($groups) ? serialize(array_map('strval', $groups)) : '',
-            ]
-        );
+        $data = [
+            'tstamp' => $time,
+            'name' => $name,
+            'email' => $email,
+            'username' => $username,
+            'password' => $hash,
+            'language' => $language,
+            'backendTheme' => 'flexible',
+            'admin' => $isAdmin,
+            'pwChange' => $pwChange,
+            'dateAdded' => $time,
+        ];
+
+        if (!$isAdmin && !empty($groups)) {
+            $data[$this->connection->quoteIdentifier('groups')] = serialize(array_map('strval', $groups));
+        }
+
+        $this->connection->insert('tl_user', $data);
     }
 }


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #2849
| Docs PR or issue | 

Fixes a SQL error caused by missing parameter quoting.

The source code of DBAL demonstrates that DBAL is not performing any quoting in this case: https://github.com/doctrine/dbal/blob/7da29b1c5b6ec4fe8636c0a022d98d68058a9053/src/Connection.php#L732

Also see doctrine/dbal#4357 (don't know how relevant this issue is)