### PR TITLE
Fix table content element not showing zeros

### DIFF
--- a/core-bundle/src/Resources/contao/elements/ContentTable.php
+++ b/core-bundle/src/Resources/contao/elements/ContentTable.php
@@ -54,7 +54,7 @@ class ContentTable extends ContentElement
 				$arrHeader[] = array
 				(
 					'class' => 'head_' . $i . (($i == 0) ? ' col_first' : '') . (($i == (\count($rows[0]) - 1)) ? ' col_last' : '') . (($i == 0 && $this->tleft) ? ' unsortable' : ''),
-					'content' => ($v ? $this->nl2br($v) : '&nbsp;')
+					'content' => ((string) $v !== '' ? $this->nl2br($v) : '&nbsp;')
 				);
 			}
 
@@ -98,7 +98,7 @@ class ContentTable extends ContentElement
 				$arrBody['row_' . $j . $class_tr . $class_eo][] = array
 				(
 					'class' => 'col_' . $i . $class_td,
-					'content' => ($v ? $this->nl2br($v) : '&nbsp;')
+					'content' => ((string) $v !== '' ? $this->nl2br($v) : '&nbsp;')
 				);
 			}
 		}
@@ -113,7 +113,7 @@ class ContentTable extends ContentElement
 				$arrFooter[] = array
 				(
 					'class' => 'foot_' . $i . (($i == 0) ? ' col_first' : '') . (($i == (\count($rows[(\count($rows)-1)]) - 1)) ? ' col_last' : ''),
-					'content' => ($v ? $this->nl2br($v) : '&nbsp;')
+					'content' => ((string) $v !== '' ? $this->nl2br($v) : '&nbsp;')
 				);
 			}
 		}


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #2860
| Docs PR or issue | -

This change will output `&nbsp;` for `null`, `false` and an empty string and will otherwise output the content, even if it is `0`.

_Note:_ the `(string)` typecast isn't strictly necessary, as the content of `$rows` should always be a string anyway (otherwise it would throw an error in PHP 8 at least, since the content would be passed to `preg_match`).