### PR TITLE
Use the image template everywhere

### DIFF
--- a/core-bundle/src/Resources/contao/templates/gallery/gallery_default.html5
+++ b/core-bundle/src/Resources/contao/templates/gallery/gallery_default.html5
@@ -4,16 +4,7 @@
     <?php foreach ($row as $col): ?>
       <?php if ($col->addImage): ?>
         <li class="<?= $class ?> <?= $col->class ?>">
-          <figure class="image_container"<?php if ($col->margin): ?> style="<?= $col->margin ?>"<?php endif; ?>>
-            <?php if ($col->href): ?>
-              <a href="<?= $col->href ?>"<?= $col->attributes ?><?php if ($col->linkTitle): ?> title="<?= $col->linkTitle ?>"<?php endif; ?>><?php $this->insert('picture_default', $col->picture); ?></a>
-            <?php else: ?>
-              <?php $this->insert('picture_default', $col->picture); ?>
-            <?php endif; ?>
-            <?php if ($col->caption): ?>
-              <figcaption class="caption"><?= $col->caption ?></figcaption>
-            <?php endif; ?>
-          </figure>
+          <?php $this->insert('image', (array) $col); ?>
         </li>
       <?php endif; ?>
     <?php endforeach; ?>

--- a/core-bundle/src/Resources/contao/templates/modules/mod_randomImage.html5
+++ b/core-bundle/src/Resources/contao/templates/modules/mod_randomImage.html5
@@ -2,20 +2,6 @@
 
 <?php $this->block('content'); ?>
 
-  <figure class="image_container"<?php if ($this->margin): ?> style="<?= $this->margin ?>"<?php endif; ?>>
-    <?php if ($this->href): ?>
-      <a href="<?= $this->href ?>"<?php if ($this->linkTitle): ?> title="<?= $this->linkTitle ?>"<?php endif; ?><?= $this->attributes ?>>
-    <?php endif; ?>
-
-    <?php $this->insert('picture_default', $this->picture); ?>
-
-    <?php if ($this->href): ?>
-      </a>
-    <?php endif; ?>
-
-    <?php if ($this->caption): ?>
-      <figcaption class="caption"><?= $this->caption ?></figcaption>
-    <?php endif; ?>
-  </figure>
+  <?php $this->insert('image', $this->arrData); ?>
 
 <?php $this->endblock(); ?>


### PR DESCRIPTION
The `gallery_default` and `mod_randomImage` templates still do not use the `image` template and instead output

```
<figure><a>…</a><figcaption></figcaption></figure>
```

themselves. There does not seem to be any reason for it as the HTML structure is exactly the same as with the `image` template.

In order to reduce the complexity of these templates and make the HTML output of images more consistent (in cases where you may want to alter the `image` template for example) this PR also uses the `image` template for these templates instead.

The only exception left is `ce_hyperlink` - which needs `embed_pre` and `embed_post` before/after the image itself. Honestly though I have never used the image feature in the hyperlink element and I consider it somewhat of a frankenstein thing anyway 😁 

I have based this against the `4.9` branch as I consider it a bug that if you create a custom `image` template these changes are not automatically reflected in the `gallery` content element or the `randomImage` module. But that's up for discussion of course.