### PR TITLE
Support "submitOnChange" in the FileTree widget

### DIFF
--- a/core-bundle/src/Resources/contao/widgets/FileTree.php
+++ b/core-bundle/src/Resources/contao/widgets/FileTree.php
@@ -348,7 +348,7 @@ class FileTree extends Widget
 		$strSet = implode(',', array_map('StringUtil::binToUuid', $arrSet));
 		$strOrder = $blnHasOrder ? implode(',', array_map('StringUtil::binToUuid', $this->{$this->orderField})) : '';
 
-		$return = '<input type="hidden" name="' . $this->strName . '" id="ctrl_' . $this->strId . '" value="' . $strSet . '">' . ($blnHasOrder ? '
+		$return = '<input type="hidden" name="' . $this->strName . '" id="ctrl_' . $this->strId . '" value="' . $strSet . '" onchange="' . $this->onchange . '">' . ($blnHasOrder ? '
   <input type="hidden" name="' . $this->strOrderName . '" id="ctrl_' . $this->strOrderId . '" value="' . $strOrder . '">' : '') . '
   <div class="selector_container">' . (($blnHasOrder && \count($arrValues) > 1) ? '
     <p class="sort_hint">' . $GLOBALS['TL_LANG']['MSC']['dragItemsHint'] . '</p>' : '') . '
@@ -385,7 +385,7 @@ class FileTree extends Widget
               onSuccess: function(txt, json) {
                 $("ctrl_' . $this->strId . '").getParent("div").set("html", json.content);
                 json.javascript && Browser.exec(json.javascript);
-                $("ctrl_' . $this->strId . '").fireEvent("change");' . ($this->arrConfiguration['submitOnChange']) ? ' Backend.autoSubmit("' . $this->strTable . '");' : '' . '
+                $("ctrl_' . $this->strId . '").fireEvent("change");' . ($this->arrConfiguration['submitOnChange'] ? ' Backend.autoSubmit("' . $this->strTable . '");' : '') . '
               }
             }).post({"action":"reloadFiletree", "name":"' . $this->strName . '", "value":value.join("\t"), "REQUEST_TOKEN":"' . REQUEST_TOKEN . '"});
           }

--- a/core-bundle/src/Resources/contao/widgets/FileTree.php
+++ b/core-bundle/src/Resources/contao/widgets/FileTree.php
@@ -385,7 +385,7 @@ class FileTree extends Widget
               onSuccess: function(txt, json) {
                 $("ctrl_' . $this->strId . '").getParent("div").set("html", json.content);
                 json.javascript && Browser.exec(json.javascript);
-                $("ctrl_' . $this->strId . '").fireEvent("change");
+                $("ctrl_' . $this->strId . '").fireEvent("change");' . ($this->arrConfiguration['submitOnChange']) ? ' Backend.autoSubmit("' . $this->strTable . '");' : '' . '
               }
             }).post({"action":"reloadFiletree", "name":"' . $this->strName . '", "value":value.join("\t"), "REQUEST_TOKEN":"' . REQUEST_TOKEN . '"});
           }

--- a/core-bundle/src/Resources/contao/widgets/FileTree.php
+++ b/core-bundle/src/Resources/contao/widgets/FileTree.php
@@ -348,7 +348,7 @@ class FileTree extends Widget
 		$strSet = implode(',', array_map('StringUtil::binToUuid', $arrSet));
 		$strOrder = $blnHasOrder ? implode(',', array_map('StringUtil::binToUuid', $this->{$this->orderField})) : '';
 
-		$return = '<input type="hidden" name="' . $this->strName . '" id="ctrl_' . $this->strId . '" value="' . $strSet . '" onchange="' . $this->onchange . '">' . ($blnHasOrder ? '
+		$return = '<input type="hidden" name="' . $this->strName . '" id="ctrl_' . $this->strId . '" value="' . $strSet . '"' . ($this->onchange ? ' onchange="' . $this->onchange . '"' : '') .'>' . ($blnHasOrder ? '
   <input type="hidden" name="' . $this->strOrderName . '" id="ctrl_' . $this->strOrderId . '" value="' . $strOrder . '">' : '') . '
   <div class="selector_container">' . (($blnHasOrder && \count($arrValues) > 1) ? '
     <p class="sort_hint">' . $GLOBALS['TL_LANG']['MSC']['dragItemsHint'] . '</p>' : '') . '
@@ -385,7 +385,9 @@ class FileTree extends Widget
               onSuccess: function(txt, json) {
                 $("ctrl_' . $this->strId . '").getParent("div").set("html", json.content);
                 json.javascript && Browser.exec(json.javascript);
-                $("ctrl_' . $this->strId . '").fireEvent("change");' . ($this->arrConfiguration['submitOnChange'] ? ' Backend.autoSubmit("' . $this->strTable . '");' : '') . '
+                var evt = document.createEvent("HTMLEvents");
+                evt.initEvent("change", true, true);
+                $("ctrl_' . $this->strId . '").dispatchEvent(evt);
               }
             }).post({"action":"reloadFiletree", "name":"' . $this->strName . '", "value":value.join("\t"), "REQUEST_TOKEN":"' . REQUEST_TOKEN . '"});
           }

--- a/core-bundle/src/Resources/contao/widgets/FileTree.php
+++ b/core-bundle/src/Resources/contao/widgets/FileTree.php
@@ -348,7 +348,7 @@ class FileTree extends Widget
 		$strSet = implode(',', array_map('StringUtil::binToUuid', $arrSet));
 		$strOrder = $blnHasOrder ? implode(',', array_map('StringUtil::binToUuid', $this->{$this->orderField})) : '';
 
-		$return = '<input type="hidden" name="' . $this->strName . '" id="ctrl_' . $this->strId . '" value="' . $strSet . '"' . ($this->onchange ? ' onchange="' . $this->onchange . '"' : '') .'>' . ($blnHasOrder ? '
+		$return = '<input type="hidden" name="' . $this->strName . '" id="ctrl_' . $this->strId . '" value="' . $strSet . '"' . ($this->onchange ? ' onchange="' . $this->onchange . '"' : '') . '>' . ($blnHasOrder ? '
   <input type="hidden" name="' . $this->strOrderName . '" id="ctrl_' . $this->strOrderId . '" value="' . $strOrder . '">' : '') . '
   <div class="selector_container">' . (($blnHasOrder && \count($arrValues) > 1) ? '
     <p class="sort_hint">' . $GLOBALS['TL_LANG']['MSC']['dragItemsHint'] . '</p>' : '') . '


### PR DESCRIPTION
This PR adds submitOnChange to FileTree Widget after selecting a file from the filesystem.

Recreated for #1436
