### PR TITLE
Fix an "undefined index: filesize" error in the indexer

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Search.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Search.php
@@ -55,7 +55,7 @@ class Search
 		$arrSet['url'] = $arrData['url'];
 		$arrSet['title'] = $arrData['title'];
 		$arrSet['protected'] = $arrData['protected'];
-		$arrSet['filesize'] = $arrData['filesize'];
+		$arrSet['filesize'] = $arrData['filesize'] ?? null;
 		$arrSet['groups'] = $arrData['groups'];
 		$arrSet['pid'] = $arrData['pid'];
 		$arrSet['language'] = $arrData['language'];


### PR DESCRIPTION
The following error occurs when running the crawler:

```
[Contao\CoreBundle\Crawl\Escargot\Subscriber\SearchIndexSubscriber] [[object] (Terminal42\Escargot\CrawlUri: URI: http://c49.local/en/page/subpage (Level: 4, Processed: 
yes, Found on: http://c49.local/en/foobar, Tags: rel-nofollow, noindex, nofollow))] Forwarded to the search indexer. Did not index because of the following reason: Could not add a search index entry: Undefined index: filesize (0)
```

The `DefaultIndexer` currently does not provide `filesize` here:

https://github.com/contao/contao/blob/d0c813f4e0f84980942e0463688c2970606bb2c6/core-bundle/src/Search/Indexer/DefaultIndexer.php#L103-L111

but `filesize` is accessed here:

https://github.com/contao/contao/blob/d0c813f4e0f84980942e0463688c2970606bb2c6/core-bundle/src/Resources/contao/library/Contao/Search.php#L54-L61

It is valid to not provide the `filesize`, as `Search` would automatically calculate it from `content`. We could also add an exception if neither `content` nor `filesize` was provided?