### PR TITLE
Fix a normalize whitespace error in the DomCrawler

### DIFF
--- a/core-bundle/src/Search/Document.php
+++ b/core-bundle/src/Search/Document.php
@@ -110,7 +110,7 @@ class Document
             ->filterXPath('descendant-or-self::script[@type = "application/ld+json"]')
             ->each(
                 static function (Crawler $node) {
-                    $data = json_decode($node->text(), true);
+                    $data = json_decode($node->text(null, true), true);
 
                     if (JSON_ERROR_NONE !== json_last_error()) {
                         return null;

--- a/core-bundle/src/Search/Indexer/DefaultIndexer.php
+++ b/core-bundle/src/Search/Indexer/DefaultIndexer.php
@@ -55,7 +55,7 @@ class DefaultIndexer implements IndexerInterface
         }
 
         try {
-            $title = $document->getContentCrawler()->filterXPath('//head/title')->first()->text();
+            $title = $document->getContentCrawler()->filterXPath('//head/title')->first()->text(null, true);
         } catch (\Exception $e) {
             $title = 'undefined';
         }


### PR DESCRIPTION
Currently the following error will occur when running the Crawler:

```
"exception" => Exception {
    #message: ""Symfony\Component\DomCrawler\Crawler::text()" will normalize whitespaces by default in Symfony 5.0, set the second "$normalizeWhitespace" argument se to retrieve the non-normalized version of the text."
    #code: 16384
    #file: "vendor\terminal42\escargot\src\Subscriber\RobotsSubscriber.php"
    #line: 244
    trace: {
        vendor\terminal42\escargot\src\Subscriber\RobotsSubscriber.php:244 { …}
        Terminal42\Escargot\Subscriber\RobotsSubscriber->Terminal42\Escargot\Subscriber\{closure}() {}
        vendor\symfony\dom-crawler\Crawler.php:622 { …}
        vendor\contao\contao\core-bundle\src\Search\Document.php:113 { …}
        vendor\symfony\dom-crawler\Crawler.php:355 { …}
        vendor\contao\contao\core-bundle\src\Search\Document.php:120 { …}
        vendor\contao\contao\core-bundle\src\Search\Indexer\DefaultIndexer.php:146 { …}
        vendor\contao\contao\core-bundle\src\Search\Indexer\DefaultIndexer.php:76 { …}
        vendor\contao\contao\core-bundle\src\Search\Indexer\DelegatingIndexer.php:34 { …}
        vendor\contao\contao\core-bundle\src\Crawl\Escargot\Subscriber\SearchIndexSubscriber.php:165 { …}
        vendor\terminal42\escargot\src\Escargot.php:515 { …}
        vendor\terminal42\escargot\src\Escargot.php:457 { …}
        vendor\terminal42\escargot\src\Escargot.php:330 { …}
        vendor\contao\contao\core-bundle\src\Command\CrawlCommand.php:135 { …}
        vendor\symfony\console\Command\Command.php:255 { …}
        vendor\symfony\console\Application.php:1027 { …}
        vendor\symfony\framework-bundle\Console\Application.php:97 { …}
        vendor\symfony\console\Application.php:273 { …}
        vendor\symfony\framework-bundle\Console\Application.php:83 { …}
        vendor\symfony\console\Application.php:149 { …}
        vendor\bin\contao-console:21 { …}
        vendor\bin\contao-console:21 { …}
    }
}
```

This PR fixes this by specifically setting the second parameter of `Symfony\Component\DomCrawler\Crawler::text` to `true` (which was previously the default).


