### PR TITLE
Fix error when using return => Array for models

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Model.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Model.php
@@ -869,10 +869,10 @@ abstract class Model
 
 			if ($objMissing !== null)
 			{
-				foreach ($objMissing as $objMissingRecord)
+				foreach ($objMissing as $objCurrent)
 				{
-					$intId = $objMissingRecord->{static::$strPk};
-					$arrRegistered[$intId] = $objMissingRecord;
+					$intId = $objCurrent->{static::$strPk};
+					$arrRegistered[$intId] = $objCurrent;
 				}
 			}
 		}

--- a/core-bundle/src/Resources/contao/library/Contao/Model.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Model.php
@@ -869,10 +869,10 @@ abstract class Model
 
 			if ($objMissing !== null)
 			{
-				while ($objMissing->next())
+				foreach ($objMissing as $objMissingRecord)
 				{
-					$intId = $objMissing->{static::$strPk};
-					$arrRegistered[$intId] = $objMissing->current();
+					$intId = $objMissingRecord->{static::$strPk};
+					$arrRegistered[$intId] = $objMissingRecord;
 				}
 			}
 		}


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #2897
| Docs PR or issue | -

When using

```php
Model::findMultipleByIds([…], ['return' => 'Array']);
```

the following error occurs:

```
Error:
Call to a member function next() on array

  at vendor\contao\contao\core-bundle\src\Resources\contao\library\Contao\Model.php:872
  at Contao\Model::findMultipleByIds()
```

This PR changes the affected code to always use `foreach` instead of `while` so that it does not matter whether `Array` or `Collection` is used for the `return` option.
