### PR TITLE
Fix the list/explodes when the second variable can be null

### DIFF
--- a/core-bundle/src/Doctrine/Schema/DcaSchemaProvider.php
+++ b/core-bundle/src/Doctrine/Schema/DcaSchemaProvider.php
@@ -114,9 +114,7 @@ class DcaSchemaProvider
 
     private function parseColumnSql(Table $table, string $columnName, string $sql): void
     {
-        $chunks = explode(' ', $sql, 2);
-        $dbType = $chunks[0];
-        $def = $chunks[1] ?? null;
+        [$dbType, $def] = explode(' ', $sql, 2) + [null, null];
 
         $type = strtok(strtolower($dbType), '(), ');
         $length = (int) strtok('(), ');

--- a/core-bundle/src/Resources/contao/classes/DataContainer.php
+++ b/core-bundle/src/Resources/contao/classes/DataContainer.php
@@ -563,9 +563,7 @@ abstract class DataContainer extends Backend
 		// Replace the textarea with an RTE instance
 		if (!empty($arrData['eval']['rte']))
 		{
-			$chunks = explode('|', $arrData['eval']['rte'], 2);
-			$file = $chunks[0] ?? null;
-			$type = $chunks[1] ?? null;
+			list($file, $type) = explode('|', $arrData['eval']['rte'], 2) + array(null, null);
 
 			$fileBrowserTypes = array();
 			$pickerBuilder = System::getContainer()->get('contao.picker.builder');

--- a/core-bundle/src/Resources/contao/drivers/DC_File.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_File.php
@@ -166,9 +166,7 @@ class DC_File extends DataContainer implements \editable
 
 				if (isset($legends[$k]))
 				{
-					$chunks = explode(':', $legends[$k]);
-					$key = $chunks[0] ?? null;
-					$cls = $chunks[1] ?? null;
+					list($key, $cls) = explode(':', $legends[$k]) + array(null, null);
 
 					$legend = "\n" . '<legend onclick="AjaxRequest.toggleFieldset(this, \'' . $key . '\', \'' . $this->strTable . '\')">' . ($GLOBALS['TL_LANG'][$this->strTable][$key] ?? $key) . '</legend>';
 				}

--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -1915,9 +1915,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 
 				if (isset($legends[$k]))
 				{
-					$chunks = explode(':', $legends[$k]);
-					$key = $chunks[0] ?? null;
-					$cls = $chunks[1] ?? null;
+					list($key, $cls) = explode(':', $legends[$k]) + array(null, null);
 
 					$legend = "\n" . '<legend onclick="AjaxRequest.toggleFieldset(this,\'' . $key . '\',\'' . $this->strTable . '\')">' . ($GLOBALS['TL_LANG'][$this->strTable][$key] ?? $key) . '</legend>';
 				}
@@ -4723,9 +4721,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 		{
 			foreach ($orderBy as $k=>$v)
 			{
-				$chunks = explode(' ', $v, 2);
-				$key = $chunks[0] ?? null;
-				$direction = $chunks[1] ?? null;
+				list($key, $direction) = explode(' ', $v, 2) + array(null, null);
 
 				// If there is no direction, check the global flag in sorting mode 1 or the field flag in all other sorting modes
 				if (!$direction)


### PR DESCRIPTION
This PR reverts the list/explode changes that we made for PHP 8 and fixes them by adding an array with default values.