### PR TITLE
Fix service tagging for url_callback + title_tag_callback

### DIFF
--- a/core-bundle/src/EventListener/DataContainerCallbackListener.php
+++ b/core-bundle/src/EventListener/DataContainerCallbackListener.php
@@ -27,6 +27,8 @@ class DataContainerCallbackListener
         'input_field_callback',
         'options_callback',
         'group_callback',
+        'url_callback',
+        'title_tag_callback',
     ];
 
     /**


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Docs PR or issue | contao/docs#694

Fix the service tagging for `url_callback` + `title_tag_callback` of the serp preview widget.