### PR TITLE
Fix label callback for tree view in picker widget

### DIFF
--- a/core-bundle/src/Resources/contao/widgets/Picker.php
+++ b/core-bundle/src/Resources/contao/widgets/Picker.php
@@ -284,9 +284,7 @@ class Picker extends Widget
 
 			if (\in_array($mode, array(5, 6)))
 			{
-				$isProtected = 'tl_page' === $dc->table && $arrRow['protected'];
-
-				return $this->{$labelConfig['label_callback'][0]}->{$labelConfig['label_callback'][1]}($arrRow, $label, $dc, '', false, $isProtected);
+				return $this->{$labelConfig['label_callback'][0]}->{$labelConfig['label_callback'][1]}($arrRow, $label, $dc, '', false, null);
 			}
 
 			return $this->{$labelConfig['label_callback'][0]}->{$labelConfig['label_callback'][1]}($arrRow, $label, $dc, $arrRow);
@@ -296,9 +294,7 @@ class Picker extends Widget
 		{
 			if (\in_array($mode, array(5, 6)))
 			{
-				$isProtected = 'tl_page' === $dc->table && $arrRow['protected'];
-
-				return $labelConfig['label_callback']($arrRow, $label, $dc, '', false, $isProtected);
+				return $labelConfig['label_callback']($arrRow, $label, $dc, '', false, null);
 			}
 
 			return $labelConfig['label_callback']($arrRow, $label, $dc, $arrRow);

--- a/core-bundle/src/Resources/contao/widgets/Picker.php
+++ b/core-bundle/src/Resources/contao/widgets/Picker.php
@@ -282,11 +282,25 @@ class Picker extends Widget
 		{
 			$this->import($labelConfig['label_callback'][0]);
 
+			if (\in_array($mode, array(5, 6)))
+			{
+				$isProtected = 'tl_page' === $dc->table && $arrRow['protected'];
+
+				return $this->{$labelConfig['label_callback'][0]}->{$labelConfig['label_callback'][1]}($arrRow, $label, $dc, '', false, $isProtected);
+			}
+
 			return $this->{$labelConfig['label_callback'][0]}->{$labelConfig['label_callback'][1]}($arrRow, $label, $dc, $arrRow);
 		}
 
 		if (\is_callable($labelConfig['label_callback']))
 		{
+			if (\in_array($mode, array(5, 6)))
+			{
+				$isProtected = 'tl_page' === $dc->table && $arrRow['protected'];
+
+				return $labelConfig['label_callback']($arrRow, $label, $dc, '', false, $isProtected);
+			}
+
 			return $labelConfig['label_callback']($arrRow, $label, $dc, $arrRow);
 		}
 


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #2882 

Fix the call of the label callbacks of tree views in the picker widget.
With the `isProtected` boolean I was not sure, if we need to solve that recursive.
