### PR TITLE
Fix the "runContextLength" migration when the previous migration has failed

### DIFF
--- a/core-bundle/src/Migration/Version408/Version480Update.php
+++ b/core-bundle/src/Migration/Version408/Version480Update.php
@@ -417,6 +417,10 @@ class Version480Update extends AbstractMigration
 
         // Consolidate the search context fields
         while (false !== ($row = $statement->fetch(\PDO::FETCH_OBJ))) {
+            if (!empty($row->contextLength) && !is_numeric($row->contextLength)) {
+                continue;
+            }
+
             $stmt = $this->connection->prepare('
                 UPDATE
                     tl_module


### PR DESCRIPTION
If the `Version480Update` migration failed prior to Contao `4.9.13` then the `tl_module.totalLength` field will still be present in the database. If you then create a new `search` module and save it, `tl_module.contextLength` will then already contain the correct serialized data. However, if you then update to Contao `4.9.13` and run the migration again, the `runContextLength` migration will fail with the following error:

```
  [Doctrine\DBAL\Exception\DriverException]
  An exception occurred while executing '
                  UPDATE
                      tl_module
                  SET
                      contextLength = :context
                  WHERE
                      id = :id
              ' with params ["3", "a:2:{i:0;s:34:\"a:2:{i:0;s:2:\"48\";i:1;s:4:\"1000\";}\";i:1;s:4:\"1000\";}"]:  

  SQLSTATE[22001]: String data, right truncated: 1406 Data too long for column 'contextLength' at row 1


Exception trace:
  at vendor\doctrine\dbal\lib\Doctrine\DBAL\Driver\AbstractMySQLDriver.php:128
 Doctrine\DBAL\Driver\AbstractMySQLDriver->convertException() at vendor\doctrine\dbal\lib\Doctrine\DBAL\DBALException.php:182
 Doctrine\DBAL\DBALException::wrapException() at vendor\doctrine\dbal\lib\Doctrine\DBAL\DBALException.php:159
 Doctrine\DBAL\DBALException::driverExceptionDuringQuery() at vendor\doctrine\dbal\lib\Doctrine\DBAL\Connection.php:2121
 Doctrine\DBAL\Connection->handleExceptionDuringQuery() at vendor\doctrine\dbal\lib\Doctrine\DBAL\Statement.php:173
 Doctrine\DBAL\Statement->execute() at vendor\contao\core-bundle\src\Migration\Version408\Version480Update.php:431
```

This PR fixes that by checking whether the `tl_module.contextLength` field actually contains a numeric value that needs to be migrated, otherwise this particular record will be ignored.