### PR TITLE
Prevent an 'Undefined array key "id"' warning in the clipboard

### DIFF
--- a/core-bundle/src/Resources/contao/drivers/DC_Folder.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Folder.php
@@ -308,6 +308,10 @@ class DC_Folder extends DataContainer implements \listable, \editable
 			$blnClipboard = true;
 			$arrClipboard = $arrClipboard[$this->strTable];
 		}
+		else
+		{
+			$arrClipboard = null;
+		}
 
 		$this->import(Files::class, 'Files');
 		$this->import(BackendUser::class, 'User');
@@ -2579,6 +2583,10 @@ class DC_Folder extends DataContainer implements \listable, \editable
 		{
 			$blnClipboard = true;
 			$arrClipboard = $arrClipboard[$this->strTable];
+		}
+		else
+		{
+			$arrClipboard = null;
 		}
 
 		$this->import(Files::class, 'Files');

--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -3544,6 +3544,10 @@ class DC_Table extends DataContainer implements \listable, \editable
 			$blnClipboard = true;
 			$arrClipboard = $arrClipboard[$this->strTable];
 		}
+		else
+		{
+			$arrClipboard = null;
+		}
 
 		if (isset($GLOBALS['TL_DCA'][$table]['config']['label']))
 		{
@@ -3838,6 +3842,10 @@ class DC_Table extends DataContainer implements \listable, \editable
 		{
 			$blnClipboard = true;
 			$arrClipboard = $arrClipboard[$this->strTable];
+		}
+		else
+		{
+			$arrClipboard = null;
 		}
 
 		for ($i=0, $c=\count($arrIds); $i<$c; $i++)
@@ -4163,10 +4171,14 @@ class DC_Table extends DataContainer implements \listable, \editable
 			$blnClipboard = true;
 			$arrClipboard = $arrClipboard[$table];
 
-			if (\is_array($arrClipboard['id']))
+			if (!empty($arrClipboard['id']) && \is_array($arrClipboard['id']))
 			{
 				$blnMultiboard = true;
 			}
+		}
+		else
+		{
+			$arrClipboard = null;
 		}
 
 		// Load the language file and data container array of the parent table

--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -4171,7 +4171,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 			$blnClipboard = true;
 			$arrClipboard = $arrClipboard[$table];
 
-			if (!empty($arrClipboard['id']) && \is_array($arrClipboard['id']))
+			if (\is_array($arrClipboard['id'] ?? null))
 			{
 				$blnMultiboard = true;
 			}


### PR DESCRIPTION
It is so nice that undefined array keys are now warnings in PHP 8. 😉 