### PR TITLE
Add template properties to fragment proxy

### DIFF
--- a/core-bundle/src/Controller/AbstractFragmentController.php
+++ b/core-bundle/src/Controller/AbstractFragmentController.php
@@ -120,7 +120,7 @@ abstract class AbstractFragmentController extends AbstractController implements 
         $template->class = trim($templateName.' '.($data[1] ?? ''));
 
         if (!empty($overrideCssID)) {
-            $template->cssID = $overrideCssID;
+            $template->cssID = ' id="'.$overrideCssID.'"';
         } else {
             $template->cssID = !empty($data[0]) ? ' id="'.$data[0].'"' : '';
         }

--- a/core-bundle/src/Controller/AbstractFragmentController.php
+++ b/core-bundle/src/Controller/AbstractFragmentController.php
@@ -132,9 +132,6 @@ abstract class AbstractFragmentController extends AbstractController implements 
         }
     }
 
-    /**
-     * @deprecated Deprecated since Contao 4.9.13. Use addPropertiesToTemplate instead.
-     */
     protected function addSectionToTemplate(Template $template, string $section): void
     {
         $template->inColumn = $section;

--- a/core-bundle/src/Controller/AbstractFragmentController.php
+++ b/core-bundle/src/Controller/AbstractFragmentController.php
@@ -114,22 +114,27 @@ abstract class AbstractFragmentController extends AbstractController implements 
     /**
      * @param string|array $cssID
      */
-    protected function addCssAttributesToTemplate(Template $template, string $templateName, $cssID, array $classes = null, string $overrideCssID = null): void
+    protected function addCssAttributesToTemplate(Template $template, string $templateName, $cssID, array $classes = null): void
     {
         $data = StringUtil::deserialize($cssID, true);
         $template->class = trim($templateName.' '.($data[1] ?? ''));
-
-        if (!empty($overrideCssID)) {
-            $template->cssID = ' id="'.$overrideCssID.'"';
-        } else {
-            $template->cssID = !empty($data[0]) ? ' id="'.$data[0].'"' : '';
-        }
+        $template->cssID = !empty($data[0]) ? ' id="'.$data[0].'"' : '';
 
         if (!empty($classes)) {
             $template->class .= ' '.implode(' ', $classes);
         }
     }
 
+    protected function addPropertiesToTemplate(Template $template, array $properties): void
+    {
+        foreach ($properties as $k => $v) {
+            $template->{$k} = $v;
+        }
+    }
+
+    /**
+     * @deprecated Deprecated since Contao 4.9.13. Use addPropertiesToTemplate instead.
+     */
     protected function addSectionToTemplate(Template $template, string $section): void
     {
         $template->inColumn = $section;

--- a/core-bundle/src/Controller/AbstractFragmentController.php
+++ b/core-bundle/src/Controller/AbstractFragmentController.php
@@ -114,11 +114,16 @@ abstract class AbstractFragmentController extends AbstractController implements 
     /**
      * @param string|array $cssID
      */
-    protected function addCssAttributesToTemplate(Template $template, string $templateName, $cssID, array $classes = null): void
+    protected function addCssAttributesToTemplate(Template $template, string $templateName, $cssID, array $classes = null, string $overrideCssID = null): void
     {
         $data = StringUtil::deserialize($cssID, true);
         $template->class = trim($templateName.' '.($data[1] ?? ''));
-        $template->cssID = !empty($data[0]) ? ' id="'.$data[0].'"' : '';
+
+        if (!empty($overrideCssID)) {
+            $template->cssID = $overrideCssID;
+        } else {
+            $template->cssID = !empty($data[0]) ? ' id="'.$data[0].'"' : '';
+        }
 
         if (!empty($classes)) {
             $template->class .= ' '.implode(' ', $classes);

--- a/core-bundle/src/Controller/ContentElement/AbstractContentElementController.php
+++ b/core-bundle/src/Controller/ContentElement/AbstractContentElementController.php
@@ -20,26 +20,15 @@ use Symfony\Component\HttpFoundation\Response;
 
 abstract class AbstractContentElementController extends AbstractFragmentController
 {
-    public function __invoke(Request $request, ContentModel $model /* , string $section, array $classes = null */): Response
+    public function __invoke(Request $request, ContentModel $model , string $section, array $classes = null): Response
     {
         $type = $this->getType();
         $template = $this->createTemplate($model, 'ce_'.$type);
 
-        $classes = func_num_args() > 3 ? func_get_arg(3) : $request->attributes->get('classes');
-        $templateProps = $request->attributes->get('templateProps', []);
-
         $this->addHeadlineToTemplate($template, $model->headline);
         $this->addCssAttributesToTemplate($template, 'ce_'.$type, $model->cssID, $classes);
-        $this->addPropertiesToTemplate($template, $templateProps);
-
-        if (func_num_args() > 2) {
-            @trigger_error('Passing $section and $classes to '.__METHOD__.' is deprecated since Contao 4.9.14.', E_USER_DEPRECATED);
-
-            if (!empty($section = func_get_arg(2))) {
-                $this->addSectionToTemplate($template, $section);
-            }
-        }
-
+        $this->addPropertiesToTemplate($template, $request->attributes->get('templateProps', []));
+        $this->addSectionToTemplate($template, $section);
         $this->tagResponse(['contao.db.tl_content.'.$model->id]);
 
         $response = $this->getResponse($template, $model, $request);

--- a/core-bundle/src/Controller/ContentElement/AbstractContentElementController.php
+++ b/core-bundle/src/Controller/ContentElement/AbstractContentElementController.php
@@ -20,7 +20,7 @@ use Symfony\Component\HttpFoundation\Response;
 
 abstract class AbstractContentElementController extends AbstractFragmentController
 {
-    public function __invoke(Request $request, ContentModel $model , string $section, array $classes = null): Response
+    public function __invoke(Request $request, ContentModel $model, string $section, array $classes = null): Response
     {
         $type = $this->getType();
         $template = $this->createTemplate($model, 'ce_'.$type);

--- a/core-bundle/src/Controller/ContentElement/AbstractContentElementController.php
+++ b/core-bundle/src/Controller/ContentElement/AbstractContentElementController.php
@@ -20,7 +20,7 @@ use Symfony\Component\HttpFoundation\Response;
 
 abstract class AbstractContentElementController extends AbstractFragmentController
 {
-    public function __invoke(Request $request, ContentModel $model/* , string $section, array $classes = null */): Response
+    public function __invoke(Request $request, ContentModel $model /* , string $section, array $classes = null */): Response
     {
         $type = $this->getType();
         $template = $this->createTemplate($model, 'ce_'.$type);

--- a/core-bundle/src/Controller/ContentElement/AbstractContentElementController.php
+++ b/core-bundle/src/Controller/ContentElement/AbstractContentElementController.php
@@ -20,14 +20,26 @@ use Symfony\Component\HttpFoundation\Response;
 
 abstract class AbstractContentElementController extends AbstractFragmentController
 {
-    public function __invoke(Request $request, ContentModel $model, string $section, array $classes = null): Response
+    public function __invoke(Request $request, ContentModel $model/* , string $section, array $classes = null */): Response
     {
         $type = $this->getType();
         $template = $this->createTemplate($model, 'ce_'.$type);
 
+        $classes = func_num_args() > 3 ? func_get_arg(3) : $request->attributes->get('classes');
+        $templateProps = $request->attributes->get('templateProps', []);
+
         $this->addHeadlineToTemplate($template, $model->headline);
-        $this->addCssAttributesToTemplate($template, 'ce_'.$type, $model->cssID, $classes, $request->attributes->get('cssID'));
-        $this->addSectionToTemplate($template, $section);
+        $this->addCssAttributesToTemplate($template, 'ce_'.$type, $model->cssID, $classes);
+        $this->addPropertiesToTemplate($template, $templateProps);
+
+        if (func_num_args() > 2) {
+            @trigger_error('Passing $section and $classes to '.__METHOD__.' is deprecated since Contao 4.9.14.', E_USER_DEPRECATED);
+
+            if (!empty($section = func_get_arg(2))) {
+                $this->addSectionToTemplate($template, $section);
+            }
+        }
+
         $this->tagResponse(['contao.db.tl_content.'.$model->id]);
 
         $response = $this->getResponse($template, $model, $request);

--- a/core-bundle/src/Controller/ContentElement/AbstractContentElementController.php
+++ b/core-bundle/src/Controller/ContentElement/AbstractContentElementController.php
@@ -27,7 +27,7 @@ abstract class AbstractContentElementController extends AbstractFragmentControll
 
         $this->addHeadlineToTemplate($template, $model->headline);
         $this->addCssAttributesToTemplate($template, 'ce_'.$type, $model->cssID, $classes);
-        $this->addPropertiesToTemplate($template, $request->attributes->get('templateProps', []));
+        $this->addPropertiesToTemplate($template, $request->attributes->get('templateProperties', []));
         $this->addSectionToTemplate($template, $section);
         $this->tagResponse(['contao.db.tl_content.'.$model->id]);
 

--- a/core-bundle/src/Controller/ContentElement/AbstractContentElementController.php
+++ b/core-bundle/src/Controller/ContentElement/AbstractContentElementController.php
@@ -26,7 +26,7 @@ abstract class AbstractContentElementController extends AbstractFragmentControll
         $template = $this->createTemplate($model, 'ce_'.$type);
 
         $this->addHeadlineToTemplate($template, $model->headline);
-        $this->addCssAttributesToTemplate($template, 'ce_'.$type, $model->cssID, $classes);
+        $this->addCssAttributesToTemplate($template, 'ce_'.$type, $model->cssID, $classes, $request->attributes->get('cssID'));
         $this->addSectionToTemplate($template, $section);
         $this->tagResponse(['contao.db.tl_content.'.$model->id]);
 

--- a/core-bundle/src/Controller/FrontendModule/AbstractFrontendModuleController.php
+++ b/core-bundle/src/Controller/FrontendModule/AbstractFrontendModuleController.php
@@ -32,7 +32,7 @@ abstract class AbstractFrontendModuleController extends AbstractFragmentControll
         $template = $this->createTemplate($model, 'mod_'.$type);
 
         $this->addHeadlineToTemplate($template, $model->headline);
-        $this->addCssAttributesToTemplate($template, 'mod_'.$type, $model->cssID, $classes);
+        $this->addCssAttributesToTemplate($template, 'mod_'.$type, $model->cssID, $classes, $request->attributes->get('cssID'));
         $this->addSectionToTemplate($template, $section);
         $this->tagResponse(['contao.db.tl_module.'.$model->id]);
 

--- a/core-bundle/src/Controller/FrontendModule/AbstractFrontendModuleController.php
+++ b/core-bundle/src/Controller/FrontendModule/AbstractFrontendModuleController.php
@@ -22,7 +22,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 abstract class AbstractFrontendModuleController extends AbstractFragmentController
 {
-    public function __invoke(Request $request, ModuleModel $model /* , string $section, array $classes = null */): Response
+    public function __invoke(Request $request, ModuleModel $model, string $section, array $classes = null): Response
     {
         if ($this->get('contao.routing.scope_matcher')->isBackendRequest($request)) {
             return $this->getBackendWildcard($model);
@@ -31,21 +31,10 @@ abstract class AbstractFrontendModuleController extends AbstractFragmentControll
         $type = $this->getType();
         $template = $this->createTemplate($model, 'mod_'.$type);
 
-        $classes = func_num_args() > 3 ? func_get_arg(3) : $request->attributes->get('classes');
-        $templateProps = $request->attributes->get('templateProps', []);
-
         $this->addHeadlineToTemplate($template, $model->headline);
         $this->addCssAttributesToTemplate($template, 'mod_'.$type, $model->cssID, $classes);
-        $this->addPropertiesToTemplate($template, $templateProps);
-
-        if (func_num_args() > 2) {
-            @trigger_error('Passing $section and $classes to '.__METHOD__.' is deprecated since Contao 4.9.14.', E_USER_DEPRECATED);
-
-            if (!empty($section = func_get_arg(2))) {
-                $this->addSectionToTemplate($template, $section);
-            }
-        }
-
+        $this->addPropertiesToTemplate($template, $request->attributes->get('templateProps', []));
+        $this->addSectionToTemplate($template, $section);
         $this->tagResponse(['contao.db.tl_module.'.$model->id]);
 
         $response = $this->getResponse($template, $model, $request);

--- a/core-bundle/src/Controller/FrontendModule/AbstractFrontendModuleController.php
+++ b/core-bundle/src/Controller/FrontendModule/AbstractFrontendModuleController.php
@@ -33,7 +33,7 @@ abstract class AbstractFrontendModuleController extends AbstractFragmentControll
 
         $this->addHeadlineToTemplate($template, $model->headline);
         $this->addCssAttributesToTemplate($template, 'mod_'.$type, $model->cssID, $classes);
-        $this->addPropertiesToTemplate($template, $request->attributes->get('templateProps', []));
+        $this->addPropertiesToTemplate($template, $request->attributes->get('templateProperties', []));
         $this->addSectionToTemplate($template, $section);
         $this->tagResponse(['contao.db.tl_module.'.$model->id]);
 

--- a/core-bundle/src/Controller/FrontendModule/AbstractFrontendModuleController.php
+++ b/core-bundle/src/Controller/FrontendModule/AbstractFrontendModuleController.php
@@ -32,7 +32,7 @@ abstract class AbstractFrontendModuleController extends AbstractFragmentControll
         $template = $this->createTemplate($model, 'mod_'.$type);
 
         $this->addHeadlineToTemplate($template, $model->headline);
-        $this->addCssAttributesToTemplate($template, 'mod_'.$type, $model->cssID, $classes, $request->attributes->get('cssID'));
+        $this->addCssAttributesToTemplate($template, 'mod_'.$type, $model->cssID, $classes);
         $this->addSectionToTemplate($template, $section);
         $this->tagResponse(['contao.db.tl_module.'.$model->id]);
 

--- a/core-bundle/src/Fragment/Reference/ContentElementReference.php
+++ b/core-bundle/src/Fragment/Reference/ContentElementReference.php
@@ -21,12 +21,18 @@ class ContentElementReference extends FragmentReference
     public const GLOBALS_KEY = 'TL_CTE';
     public const PROXY_CLASS = ContentProxy::class;
 
-    public function __construct(ContentModel $model, string $section = 'main')
+    public function __construct(ContentModel $model, /* array */ $templateProps = ['section' => 'main'])
     {
         parent::__construct(self::TAG_NAME.'.'.$model->type);
 
+        if (!\is_array($templateProps)) {
+            @trigger_error('The second argument to '.__METHOD__.' should be an array of template properties since Contao 4.9.14');
+
+            $templateProps = ['section' => (string) $templateProps];
+        }
+
         $this->attributes['contentModel'] = $model->id;
-        $this->attributes['section'] = $section;
+        $this->attributes['templateProps'] = $templateProps;
         $this->attributes['classes'] = $model->classes;
     }
 }

--- a/core-bundle/src/Fragment/Reference/ContentElementReference.php
+++ b/core-bundle/src/Fragment/Reference/ContentElementReference.php
@@ -21,7 +21,7 @@ class ContentElementReference extends FragmentReference
     public const GLOBALS_KEY = 'TL_CTE';
     public const PROXY_CLASS = ContentProxy::class;
 
-    public function __construct(ContentModel $model, string $section = 'main',  array $templateProps = [])
+    public function __construct(ContentModel $model, string $section = 'main', array $templateProps = [])
     {
         parent::__construct(self::TAG_NAME.'.'.$model->type);
 

--- a/core-bundle/src/Fragment/Reference/ContentElementReference.php
+++ b/core-bundle/src/Fragment/Reference/ContentElementReference.php
@@ -33,6 +33,7 @@ class ContentElementReference extends FragmentReference
 
         $this->attributes['contentModel'] = $model->id;
         $this->attributes['templateProps'] = $templateProps;
+        $this->attributes['section'] = $templateProps['section'];
         $this->attributes['classes'] = $model->classes;
     }
 }

--- a/core-bundle/src/Fragment/Reference/ContentElementReference.php
+++ b/core-bundle/src/Fragment/Reference/ContentElementReference.php
@@ -21,19 +21,13 @@ class ContentElementReference extends FragmentReference
     public const GLOBALS_KEY = 'TL_CTE';
     public const PROXY_CLASS = ContentProxy::class;
 
-    public function __construct(ContentModel $model, /* array */ $templateProps = ['section' => 'main'])
+    public function __construct(ContentModel $model, string $section = 'main',  array $templateProps = [])
     {
         parent::__construct(self::TAG_NAME.'.'.$model->type);
 
-        if (!\is_array($templateProps)) {
-            @trigger_error('The second argument to '.__METHOD__.' must be an array of template properties since Contao 4.9.14');
-
-            $templateProps = ['section' => (string) $templateProps];
-        }
-
         $this->attributes['contentModel'] = $model->id;
-        $this->attributes['templateProps'] = $templateProps;
-        $this->attributes['section'] = $templateProps['section'];
+        $this->attributes['section'] = $section;
         $this->attributes['classes'] = $model->classes;
+        $this->attributes['templateProps'] = $templateProps;
     }
 }

--- a/core-bundle/src/Fragment/Reference/ContentElementReference.php
+++ b/core-bundle/src/Fragment/Reference/ContentElementReference.php
@@ -21,13 +21,13 @@ class ContentElementReference extends FragmentReference
     public const GLOBALS_KEY = 'TL_CTE';
     public const PROXY_CLASS = ContentProxy::class;
 
-    public function __construct(ContentModel $model, string $section = 'main', array $templateProps = [])
+    public function __construct(ContentModel $model, string $section = 'main', array $templateProperties = [])
     {
         parent::__construct(self::TAG_NAME.'.'.$model->type);
 
         $this->attributes['contentModel'] = $model->id;
         $this->attributes['section'] = $section;
         $this->attributes['classes'] = $model->classes;
-        $this->attributes['templateProps'] = $templateProps;
+        $this->attributes['templateProperties'] = $templateProperties;
     }
 }

--- a/core-bundle/src/Fragment/Reference/ContentElementReference.php
+++ b/core-bundle/src/Fragment/Reference/ContentElementReference.php
@@ -26,7 +26,7 @@ class ContentElementReference extends FragmentReference
         parent::__construct(self::TAG_NAME.'.'.$model->type);
 
         if (!\is_array($templateProps)) {
-            @trigger_error('The second argument to '.__METHOD__.' should be an array of template properties since Contao 4.9.14');
+            @trigger_error('The second argument to '.__METHOD__.' must be an array of template properties since Contao 4.9.14');
 
             $templateProps = ['section' => (string) $templateProps];
         }

--- a/core-bundle/src/Fragment/Reference/FrontendModuleReference.php
+++ b/core-bundle/src/Fragment/Reference/FrontendModuleReference.php
@@ -21,19 +21,13 @@ class FrontendModuleReference extends FragmentReference
     public const GLOBALS_KEY = 'FE_MOD';
     public const PROXY_CLASS = ModuleProxy::class;
 
-    public function __construct(ModuleModel $model, /* array */ $templateProps = ['section' => 'main'])
+    public function __construct(ModuleModel $model, string $section, array  $templateProps = [])
     {
         parent::__construct(self::TAG_NAME.'.'.$model->type);
 
-        if (!\is_array($templateProps)) {
-            @trigger_error('The second argument to '.__METHOD__.' must be an array of template properties since Contao 4.9.14');
-
-            $templateProps = ['section' => (string) $templateProps];
-        }
-
         $this->attributes['moduleModel'] = $model->id;
-        $this->attributes['templateProps'] = $templateProps;
-        $this->attributes['section'] = $templateProps['section'];
+        $this->attributes['section'] = $section;
         $this->attributes['classes'] = $model->classes;
+        $this->attributes['templateProps'] = $templateProps;
     }
 }

--- a/core-bundle/src/Fragment/Reference/FrontendModuleReference.php
+++ b/core-bundle/src/Fragment/Reference/FrontendModuleReference.php
@@ -21,12 +21,18 @@ class FrontendModuleReference extends FragmentReference
     public const GLOBALS_KEY = 'FE_MOD';
     public const PROXY_CLASS = ModuleProxy::class;
 
-    public function __construct(ModuleModel $model, string $section = 'main')
+    public function __construct(ModuleModel $model, /* array */ $templateProps = ['section' => 'main'])
     {
         parent::__construct(self::TAG_NAME.'.'.$model->type);
 
+        if (!\is_array($templateProps)) {
+            @trigger_error('The second argument to '.__METHOD__.' must be an array of template properties since Contao 4.9.14');
+
+            $templateProps = ['section' => (string) $templateProps];
+        }
+
         $this->attributes['moduleModel'] = $model->id;
-        $this->attributes['section'] = $section;
+        $this->attributes['templateProps'] = $templateProps;
         $this->attributes['classes'] = $model->classes;
     }
 }

--- a/core-bundle/src/Fragment/Reference/FrontendModuleReference.php
+++ b/core-bundle/src/Fragment/Reference/FrontendModuleReference.php
@@ -21,7 +21,7 @@ class FrontendModuleReference extends FragmentReference
     public const GLOBALS_KEY = 'FE_MOD';
     public const PROXY_CLASS = ModuleProxy::class;
 
-    public function __construct(ModuleModel $model, string $section, array  $templateProps = [])
+    public function __construct(ModuleModel $model, string $section, array $templateProps = [])
     {
         parent::__construct(self::TAG_NAME.'.'.$model->type);
 

--- a/core-bundle/src/Fragment/Reference/FrontendModuleReference.php
+++ b/core-bundle/src/Fragment/Reference/FrontendModuleReference.php
@@ -21,7 +21,7 @@ class FrontendModuleReference extends FragmentReference
     public const GLOBALS_KEY = 'FE_MOD';
     public const PROXY_CLASS = ModuleProxy::class;
 
-    public function __construct(ModuleModel $model, string $section, array $templateProps = [])
+    public function __construct(ModuleModel $model, string $section = 'main', array $templateProps = [])
     {
         parent::__construct(self::TAG_NAME.'.'.$model->type);
 

--- a/core-bundle/src/Fragment/Reference/FrontendModuleReference.php
+++ b/core-bundle/src/Fragment/Reference/FrontendModuleReference.php
@@ -21,13 +21,13 @@ class FrontendModuleReference extends FragmentReference
     public const GLOBALS_KEY = 'FE_MOD';
     public const PROXY_CLASS = ModuleProxy::class;
 
-    public function __construct(ModuleModel $model, string $section = 'main', array $templateProps = [])
+    public function __construct(ModuleModel $model, string $section = 'main', array $templateProperties = [])
     {
         parent::__construct(self::TAG_NAME.'.'.$model->type);
 
         $this->attributes['moduleModel'] = $model->id;
         $this->attributes['section'] = $section;
         $this->attributes['classes'] = $model->classes;
-        $this->attributes['templateProps'] = $templateProps;
+        $this->attributes['templateProperties'] = $templateProperties;
     }
 }

--- a/core-bundle/src/Fragment/Reference/FrontendModuleReference.php
+++ b/core-bundle/src/Fragment/Reference/FrontendModuleReference.php
@@ -33,6 +33,7 @@ class FrontendModuleReference extends FragmentReference
 
         $this->attributes['moduleModel'] = $model->id;
         $this->attributes['templateProps'] = $templateProps;
+        $this->attributes['section'] = $templateProps['section'];
         $this->attributes['classes'] = $model->classes;
     }
 }

--- a/core-bundle/src/Resources/contao/elements/ContentAlias.php
+++ b/core-bundle/src/Resources/contao/elements/ContentAlias.php
@@ -50,7 +50,7 @@ class ContentAlias extends ContentElement
 
 			if (!empty($this->cssID[0]))
 			{
-				$proxy->addFragmentAttributes(['cssID' => $this->cssID[0]]);
+				$proxy->cssID = ' id="'.$this->cssID[0].'"';
 			}
 
 			return $proxy->generate();

--- a/core-bundle/src/Resources/contao/elements/ContentAlias.php
+++ b/core-bundle/src/Resources/contao/elements/ContentAlias.php
@@ -42,7 +42,7 @@ class ContentAlias extends ContentElement
 		{
 			if (!empty($this->cssID[1]))
 			{
-				$objElement->classes = array_merge((array) $objElement->classes, [$this->cssID[1]]);
+				$objElement->classes = array_merge((array) $objElement->classes, array($this->cssID[1]));
 			}
 
 			/** @var ContentProxy $proxy */
@@ -50,7 +50,7 @@ class ContentAlias extends ContentElement
 
 			if (!empty($this->cssID[0]))
 			{
-				$proxy->cssID = ' id="'.$this->cssID[0].'"';
+				$proxy->cssID = ' id="' . $this->cssID[0] . '"';
 			}
 
 			return $proxy->generate();

--- a/core-bundle/src/Resources/contao/elements/ContentAlias.php
+++ b/core-bundle/src/Resources/contao/elements/ContentAlias.php
@@ -38,12 +38,30 @@ class ContentAlias extends ContentElement
 			return '';
 		}
 
+		if (is_a($strClass, ContentProxy::class, true))
+		{
+			if (!empty($this->cssID[1]))
+			{
+				$objElement->classes = array_merge((array) $objElement->classes, [$this->cssID[1]]);
+			}
+
+			/** @var ContentProxy $proxy */
+			$proxy = new $strClass($objElement, $this->strColumn);
+
+			if (!empty($this->cssID[0]))
+			{
+				$proxy->addFragmentAttributes(['cssID' => $this->cssID[0]]);
+			}
+
+			return $proxy->generate();
+		}
+
 		$objElement->origId = $objElement->origId ?: $objElement->id;
 		$objElement->id = $this->id;
 		$objElement->typePrefix = 'ce_';
 
 		/** @var ContentElement $objElement */
-		$objElement = new $strClass($objElement);
+		$objElement = new $strClass($objElement, $this->strColumn);
 
 		$cssID = StringUtil::deserialize($objElement->cssID, true);
 

--- a/core-bundle/src/Resources/contao/elements/ContentModule.php
+++ b/core-bundle/src/Resources/contao/elements/ContentModule.php
@@ -55,7 +55,7 @@ class ContentModule extends ContentElement
 
 			if (!empty($this->cssID[0]))
 			{
-				$proxy->addFragmentAttributes(['cssID' => $this->cssID[0]]);
+				$proxy->cssID = ' id="'.$this->cssID[0].'"';
 			}
 
 			return $proxy->generate();

--- a/core-bundle/src/Resources/contao/elements/ContentModule.php
+++ b/core-bundle/src/Resources/contao/elements/ContentModule.php
@@ -47,7 +47,7 @@ class ContentModule extends ContentElement
 		{
 			if (!empty($this->cssID[1]))
 			{
-				$objModel->classes = array_merge((array) $objModel->classes, [$this->cssID[1]]);
+				$objModel->classes = array_merge((array) $objModel->classes, array($this->cssID[1]));
 			}
 
 			/** @var ContentProxy $proxy */
@@ -55,7 +55,7 @@ class ContentModule extends ContentElement
 
 			if (!empty($this->cssID[0]))
 			{
-				$proxy->cssID = ' id="'.$this->cssID[0].'"';
+				$proxy->cssID = ' id="' . $this->cssID[0] . '"';
 			}
 
 			return $proxy->generate();

--- a/core-bundle/src/Resources/contao/elements/ContentModule.php
+++ b/core-bundle/src/Resources/contao/elements/ContentModule.php
@@ -43,6 +43,24 @@ class ContentModule extends ContentElement
 			return '';
 		}
 
+		if (is_a($strClass, ContentProxy::class, true))
+		{
+			if (!empty($this->cssID[1]))
+			{
+				$objModel->classes = array_merge((array) $objModel->classes, [$this->cssID[1]]);
+			}
+
+			/** @var ContentProxy $proxy */
+			$proxy = new $strClass($objModel, $this->strColumn);
+
+			if (!empty($this->cssID[0]))
+			{
+				$proxy->addFragmentAttributes(['cssID' => $this->cssID[0]]);
+			}
+
+			return $proxy->generate();
+		}
+
 		$cssID = StringUtil::deserialize($objModel->cssID, true);
 
 		// Override the CSS ID (see #305)

--- a/core-bundle/src/Resources/contao/elements/ContentProxy.php
+++ b/core-bundle/src/Resources/contao/elements/ContentProxy.php
@@ -63,17 +63,17 @@ class ContentProxy extends ContentElement
 
 	public function __set($strKey, $varValue)
 	{
-		$this->reference->attributes['templateProps'][$strKey] = $varValue;
+		$this->reference->attributes['templateProperties'][$strKey] = $varValue;
 	}
 
 	public function __get($strKey)
 	{
-		return $this->reference->attributes[$strKey]['templateProps'];
+		return $this->reference->attributes['templateProperties'][$strKey];
 	}
 
 	public function __isset($strKey)
 	{
-		return isset($this->reference->attributes['templateProps'][$strKey]);
+		return isset($this->reference->attributes['templateProperties'][$strKey]);
 	}
 
 	/**

--- a/core-bundle/src/Resources/contao/elements/ContentProxy.php
+++ b/core-bundle/src/Resources/contao/elements/ContentProxy.php
@@ -20,10 +20,13 @@ use Contao\Model\Collection;
  */
 class ContentProxy extends ContentElement
 {
+	/**
+	 * @var ContentElementReference
+	 */
 	private $reference;
 
 	/**
-	 * @param ContentElement|Collection $objElement
+	 * @param ContentModel|Collection $objElement
 	 */
 	public function __construct($objElement, $strColumn = 'main')
 	{
@@ -31,19 +34,13 @@ class ContentProxy extends ContentElement
 		{
 			$objElement = $objElement->current();
 		}
-		elseif (!$objElement instanceof Model)
+
+		if (!$objElement instanceof ContentModel)
 		{
-			throw new \RuntimeException('ContentProxy must be constructed with a model');
+			throw new \RuntimeException('ContentProxy must be constructed with a ContentModel');
 		}
 
 		$this->reference = new ContentElementReference($objElement, ['section' => $strColumn]);
-		$request = System::getContainer()->get('request_stack')->getCurrentRequest();
-
-		if ($request && System::getContainer()->get('contao.routing.scope_matcher')->isBackendRequest($request))
-		{
-			$this->reference->setBackendScope();
-		}
-
 		$this->strColumn = $strColumn;
 
 		// Do not call parent constructor
@@ -54,6 +51,13 @@ class ContentProxy extends ContentElement
 	 */
 	public function generate()
 	{
+		$request = System::getContainer()->get('request_stack')->getCurrentRequest();
+
+		if ($request && System::getContainer()->get('contao.routing.scope_matcher')->isBackendRequest($request))
+		{
+			$this->reference->setBackendScope();
+		}
+
 		return System::getContainer()->get('fragment.handler')->render($this->reference);
 	}
 

--- a/core-bundle/src/Resources/contao/elements/ContentProxy.php
+++ b/core-bundle/src/Resources/contao/elements/ContentProxy.php
@@ -20,6 +20,11 @@ use Contao\CoreBundle\Fragment\Reference\ContentElementReference;
 class ContentProxy extends ContentElement
 {
 	/**
+	 * @var array
+	 */
+	private $fragmentAttributes = [];
+
+	/**
 	 * {@inheritdoc}
 	 */
 	public function generate()
@@ -32,7 +37,17 @@ class ContentProxy extends ContentElement
 			$reference->setBackendScope();
 		}
 
+		foreach ($this->fragmentAttributes as $k => $v)
+		{
+			$reference->attributes[$k] = $v;
+		}
+
 		return System::getContainer()->get('fragment.handler')->render($reference);
+	}
+
+	public function addFragmentAttributes(array $attributes)
+	{
+		$this->fragmentAttributes = array_merge($this->fragmentAttributes, $attributes);
 	}
 
 	/**

--- a/core-bundle/src/Resources/contao/elements/ContentProxy.php
+++ b/core-bundle/src/Resources/contao/elements/ContentProxy.php
@@ -40,7 +40,7 @@ class ContentProxy extends ContentElement
 			throw new \RuntimeException('ContentProxy must be constructed with a ContentModel');
 		}
 
-		$this->reference = new ContentElementReference($objElement, ['section' => $strColumn]);
+		$this->reference = new ContentElementReference($objElement, $strColumn);
 		$this->strColumn = $strColumn;
 
 		// Do not call parent constructor

--- a/core-bundle/src/Resources/contao/modules/ModuleProxy.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleProxy.php
@@ -63,17 +63,17 @@ class ModuleProxy extends Module
 
 	public function __set($strKey, $varValue)
 	{
-		$this->reference->attributes['templateProps'][$strKey] = $varValue;
+		$this->reference->attributes['templateProperties'][$strKey] = $varValue;
 	}
 
 	public function __get($strKey)
 	{
-		return $this->reference->attributes[$strKey]['templateProps'];
+		return $this->reference->attributes['templateProperties'][$strKey];
 	}
 
 	public function __isset($strKey)
 	{
-		return isset($this->reference->attributes['templateProps'][$strKey]);
+		return isset($this->reference->attributes['templateProperties'][$strKey]);
 	}
 
 	/**

--- a/core-bundle/src/Resources/contao/modules/ModuleProxy.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleProxy.php
@@ -11,6 +11,7 @@
 namespace Contao;
 
 use Contao\CoreBundle\Fragment\Reference\FrontendModuleReference;
+use Contao\Model\Collection;
 
 /**
  * Proxy for new front end module fragments so they are accessible via $GLOBALS['FE_MOD'].
@@ -20,34 +21,59 @@ use Contao\CoreBundle\Fragment\Reference\FrontendModuleReference;
 class ModuleProxy extends Module
 {
 	/**
-	 * @var array
+	 * @var FrontendModuleReference
 	 */
-	private $fragmentAttributes = [];
+	private $reference;
+
+	/**
+	 * @param ModuleModel|Collection $objElement
+	 */
+	public function __construct($objElement, $strColumn = 'main')
+	{
+		if ($objElement instanceof Collection)
+		{
+			$objElement = $objElement->current();
+		}
+
+		if (!$objElement instanceof ModuleModel)
+		{
+			throw new \RuntimeException('ModuleProxy must be constructed with a ModuleModel');
+		}
+
+		$this->reference = new FrontendModuleReference($objElement, ['section' => $strColumn]);
+		$this->strColumn = $strColumn;
+
+		// Do not call parent constructor
+	}
 
 	/**
 	 * {@inheritdoc}
 	 */
 	public function generate()
 	{
-		$reference = new FrontendModuleReference($this->objModel, $this->strColumn);
 		$request = System::getContainer()->get('request_stack')->getCurrentRequest();
 
 		if ($request && System::getContainer()->get('contao.routing.scope_matcher')->isBackendRequest($request))
 		{
-			$reference->setBackendScope();
+			$this->reference->setBackendScope();
 		}
 
-		foreach ($this->fragmentAttributes as $k => $v)
-		{
-			$reference->attributes[$k] = $v;
-		}
-
-		return System::getContainer()->get('fragment.handler')->render($reference);
+		return System::getContainer()->get('fragment.handler')->render($this->reference);
 	}
 
-	public function addFragmentAttributes(array $attributes)
+	public function __set($strKey, $varValue)
 	{
-		$this->fragmentAttributes = array_merge($this->fragmentAttributes, $attributes);
+		$this->reference->attributes['templateProps'][$strKey] = $varValue;
+	}
+
+	public function __get($strKey)
+	{
+		return $this->reference->attributes[$strKey]['templateProps'];
+	}
+
+	public function __isset($strKey)
+	{
+		return isset($this->reference->attributes['templateProps'][$strKey]);
 	}
 
 	/**

--- a/core-bundle/src/Resources/contao/modules/ModuleProxy.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleProxy.php
@@ -40,7 +40,7 @@ class ModuleProxy extends Module
 			throw new \RuntimeException('ModuleProxy must be constructed with a ModuleModel');
 		}
 
-		$this->reference = new FrontendModuleReference($objElement, ['section' => $strColumn]);
+		$this->reference = new FrontendModuleReference($objElement, $strColumn);
 		$this->strColumn = $strColumn;
 
 		// Do not call parent constructor

--- a/core-bundle/src/Resources/contao/modules/ModuleProxy.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleProxy.php
@@ -20,6 +20,11 @@ use Contao\CoreBundle\Fragment\Reference\FrontendModuleReference;
 class ModuleProxy extends Module
 {
 	/**
+	 * @var array
+	 */
+	private $fragmentAttributes = [];
+
+	/**
 	 * {@inheritdoc}
 	 */
 	public function generate()
@@ -32,7 +37,17 @@ class ModuleProxy extends Module
 			$reference->setBackendScope();
 		}
 
+		foreach ($this->fragmentAttributes as $k => $v)
+		{
+			$reference->attributes[$k] = $v;
+		}
+
 		return System::getContainer()->get('fragment.handler')->render($reference);
+	}
+
+	public function addFragmentAttributes(array $attributes)
+	{
+		$this->fragmentAttributes = array_merge($this->fragmentAttributes, $attributes);
 	}
 
 	/**


### PR DESCRIPTION
This is an alternative implementation to https://github.com/contao/contao/pull/2851 I came up with while fixing issues in https://github.com/contao/contao/pull/2851.

Basically, instead of adding more _arbritrary_ known properties from the proxy to the fragment, it implements a way of passing any property to the fragment template, even across ESI requests.