### PR TITLE
Fix filtering for recurring events

### DIFF
--- a/calendar-bundle/src/Resources/contao/dca/tl_calendar_events.php
+++ b/calendar-bundle/src/Resources/contao/dca/tl_calendar_events.php
@@ -520,7 +520,6 @@ $GLOBALS['TL_DCA']['tl_calendar_events'] = array
 		'noComments' => array
 		(
 			'exclude'                 => true,
-			'filter'                  => true,
 			'inputType'               => 'checkbox',
 			'eval'                    => array('tl_class'=>'w50 clr'),
 			'sql'                     => "char(1) NOT NULL default ''"

--- a/calendar-bundle/src/Resources/contao/dca/tl_calendar_events.php
+++ b/calendar-bundle/src/Resources/contao/dca/tl_calendar_events.php
@@ -426,7 +426,7 @@ $GLOBALS['TL_DCA']['tl_calendar_events'] = array
 		'recurring' => array
 		(
 			'exclude'                 => true,
-			'search'                  => true,
+			'filter'                  => true,
 			'inputType'               => 'checkbox',
 			'eval'                    => array('submitOnChange'=>true),
 			'sql'                     => "char(1) NOT NULL default ''"


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | -
| Docs PR or issue | -

In 7670ee1e9fc5adf63a73ce662e57d73ab63138f9 `filter => true` was replaced with `search => true` for `tl_calendar_events.recurring`. However this field is a checkbox and you cannot search through such fields. I think this has been changed on accident - @bytehead or was there a specific reason? Currently you can neither search nor filter for events that have been set to _recurring_.

Keep in mind that re-enabling the filtering for _recurring_ will increase the amount of filtering options for Contao 4.11, making the filters take up two rows instead of one. But that's just how it is if we want to be able to keep filtering for the appropriate fields.
