### PR TITLE
Compile the limit menu after all other filter panels

### DIFF
--- a/core-bundle/src/Resources/contao/classes/DataContainer.php
+++ b/core-bundle/src/Resources/contao/classes/DataContainer.php
@@ -1181,7 +1181,7 @@ abstract class DataContainer extends Backend
 
 				// The limit menu depends on other panels that may set a filter query, e.g. search and filter.
 				// In order to correctly calculate the total row count, the limit menu must be compiled last.
-				// We isnert a placeholder here and compile the limit menu after all other panels.
+				// We insert a placeholder here and compile the limit menu after all other panels.
 				if ($strSubPanel == 'limit')
 				{
 					// Set placeholder to inject compiled limit menu later

--- a/core-bundle/src/Resources/contao/classes/DataContainer.php
+++ b/core-bundle/src/Resources/contao/classes/DataContainer.php
@@ -1179,40 +1179,41 @@ abstract class DataContainer extends Backend
 			{
 				$panel = '';
 
-				// The limit menu depends on other panels that may set a filter query, e.g. search and filter.
-				// In order to correctly calculate the total row count, the limit menu must be compiled last.
-				// We insert a placeholder here and compile the limit menu after all other panels.
-				if ($strSubPanel == 'limit')
+				switch ($strSubPanel)
 				{
-					// Set placeholder to inject compiled limit menu later
-					$panel = '###limit_menu###';
-				}
-				// Regular panels
-				elseif ($strSubPanel == 'search' || $strSubPanel == 'sort')
-				{
-					$panel = $this->{$strSubPanel . 'Menu'}();
-				}
+					case 'limit':
+						// The limit menu depends on other panels that may set a filter query, e.g. search and filter.
+						// In order to correctly calculate the total row count, the limit menu must be compiled last.
+						// We insert a placeholder here and compile the limit menu after all other panels.
+						$panel = '###limit_menu###';
+						break;
 
-				// Multiple filter subpanels can be defined to split the fields across panels
-				elseif ($strSubPanel == 'filter')
-				{
-					$panel = $this->{$strSubPanel . 'Menu'}(++$intFilterPanel);
-				}
+					case 'search':
+						$panel = $this->searchMenu();
+						break;
 
-				// Call the panel_callback
-				else
-				{
-					$arrCallback = $GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['panel_callback'][$strSubPanel];
+					case 'sort':
+						$panel = $this->sortMenu();
+						break;
 
-					if (\is_array($arrCallback))
-					{
-						$this->import($arrCallback[0]);
-						$panel = $this->{$arrCallback[0]}->{$arrCallback[1]}($this);
-					}
-					elseif (\is_callable($arrCallback))
-					{
-						$panel = $arrCallback($this);
-					}
+					case 'filter':
+						// Multiple filter subpanels can be defined to split the fields across panels
+						$panel = $this->filterMenu(++$intFilterPanel);
+						break;
+
+					default:
+						// Call the panel_callback
+						$arrCallback = $GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['panel_callback'][$strSubPanel];
+
+						if (\is_array($arrCallback))
+						{
+							$this->import($arrCallback[0]);
+							$panel = $this->{$arrCallback[0]}->{$arrCallback[1]}($this);
+						}
+						elseif (\is_callable($arrCallback))
+						{
+							$panel = $arrCallback($this);
+						}
 				}
 
 				// Add the panel if it is not empty

--- a/core-bundle/src/Resources/contao/classes/DataContainer.php
+++ b/core-bundle/src/Resources/contao/classes/DataContainer.php
@@ -1242,8 +1242,7 @@ abstract class DataContainer extends Backend
 				continue;
 			}
 
-			$limitPanel = $this->limitMenu();
-			$arrPanels[$key] = str_replace('###limit_menu###', $limitPanel, $strPanel);
+			$arrPanels[$key] = str_replace('###limit_menu###', $this->limitMenu(), $strPanel);
 		}
 
 		if (Input::post('FORM_SUBMIT') == 'tl_filters')

--- a/core-bundle/src/Resources/contao/classes/DataContainer.php
+++ b/core-bundle/src/Resources/contao/classes/DataContainer.php
@@ -1235,8 +1235,10 @@ abstract class DataContainer extends Backend
 		}
 
 		// Compile limit menu if placeholder is present
-		foreach ($arrPanels as $key => $strPanel) {
-			if (strpos('###limit_menu###', $strPanel) === false) {
+		foreach ($arrPanels as $key => $strPanel)
+		{
+			if (strpos('###limit_menu###', $strPanel) === false)
+			{
 				continue;
 			}
 

--- a/core-bundle/src/Resources/contao/classes/DataContainer.php
+++ b/core-bundle/src/Resources/contao/classes/DataContainer.php
@@ -1179,8 +1179,16 @@ abstract class DataContainer extends Backend
 			{
 				$panel = '';
 
+				// The limit menu depends on other panels that may set a filter query, e.g. search and filter.
+				// In order to correctly calculate the total row count, the limit menu must be compiled last.
+				// We isnert a placeholder here and compile the limit menu after all other panels.
+				if ($strSubPanel == 'limit')
+				{
+					// Set placeholder to inject compiled limit menu later
+					$panel = '###limit_menu###';
+				}
 				// Regular panels
-				if ($strSubPanel == 'search' || $strSubPanel == 'limit' || $strSubPanel == 'sort')
+				elseif ($strSubPanel == 'search' || $strSubPanel == 'sort')
 				{
 					$panel = $this->{$strSubPanel . 'Menu'}();
 				}
@@ -1224,6 +1232,16 @@ abstract class DataContainer extends Backend
 		if (empty($arrPanels))
 		{
 			return '';
+		}
+
+		// Compile limit menu if placeholder is present
+		foreach ($arrPanels as $key => $strPanel) {
+			if (strpos('###limit_menu###', $strPanel) === false) {
+				continue;
+			}
+
+			$limitPanel = $this->limitMenu();
+			$arrPanels[$key] = str_replace('###limit_menu###', $limitPanel, $strPanel);
 		}
 
 		if (Input::post('FORM_SUBMIT') == 'tl_filters')


### PR DESCRIPTION
Fixes #2932. Basically if there is a limit menu, I insert a placeholder and skip compiling the menu at first. After all other panels were compiled, especially search and filter, I compile the limit menu and replace the placeholder. 