### PR TITLE
Fix the PageModel registry state

### DIFF
--- a/core-bundle/src/Resources/contao/models/PageModel.php
+++ b/core-bundle/src/Resources/contao/models/PageModel.php
@@ -92,7 +92,7 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
  * @property boolean $rootIsFallback
  * @property boolean $rootUseSSL
  * @property string  $rootFallbackLanguage
- * @property array   $subpages
+ * @property integer $subpages
  * @property boolean $minifyMarkup
  * @property integer $layoutId
  * @property boolean $hasJQuery
@@ -599,9 +599,11 @@ class PageModel extends Model
 	public static function findPublishedSubpagesWithoutGuestsByPid($intPid, $blnShowHidden=false, $blnIsSitemap=false)
 	{
 		$time = Date::floorToMinute();
-		$blnFeUserLoggedIn = System::getContainer()->get('contao.security.token_checker')->hasFrontendUser();
+		$tokenChecker = System::getContainer()->get('contao.security.token_checker');
+		$blnFeUserLoggedIn = $tokenChecker->hasFrontendUser();
+		$blnBeUserLoggedIn = $tokenChecker->hasBackendUser() && $tokenChecker->isPreviewMode();
 
-		$objSubpages = Database::getInstance()->prepare("SELECT p1.*, (SELECT COUNT(*) FROM tl_page p2 WHERE p2.pid=p1.id AND p2.type!='root' AND p2.type!='error_401' AND p2.type!='error_403' AND p2.type!='error_404'" . (!$blnShowHidden ? ($blnIsSitemap ? " AND (p2.hide='' OR sitemap='map_always')" : " AND p2.hide=''") : "") . ($blnFeUserLoggedIn ? " AND p2.guests=''" : "") . (!BE_USER_LOGGED_IN ? " AND p2.published='1' AND (p2.start='' OR p2.start<='$time') AND (p2.stop='' OR p2.stop>'$time')" : "") . ") AS subpages FROM tl_page p1 WHERE p1.pid=? AND p1.type!='root' AND p1.type!='error_401' AND p1.type!='error_403' AND p1.type!='error_404'" . (!$blnShowHidden ? ($blnIsSitemap ? " AND (p1.hide='' OR sitemap='map_always')" : " AND p1.hide=''") : "") . ($blnFeUserLoggedIn ? " AND p1.guests=''" : "") . (!BE_USER_LOGGED_IN ? " AND p1.published='1' AND (p1.start='' OR p1.start<='$time') AND (p1.stop='' OR p1.stop>'$time')" : "") . " ORDER BY p1.sorting")
+		$objSubpages = Database::getInstance()->prepare("SELECT p1.*, (SELECT COUNT(*) FROM tl_page p2 WHERE p2.pid=p1.id AND p2.type!='root' AND p2.type!='error_401' AND p2.type!='error_403' AND p2.type!='error_404'" . (!$blnShowHidden ? ($blnIsSitemap ? " AND (p2.hide='' OR sitemap='map_always')" : " AND p2.hide=''") : "") . ($blnFeUserLoggedIn ? " AND p2.guests=''" : "") . (!$blnBeUserLoggedIn ? " AND p2.published='1' AND (p2.start='' OR p2.start<='$time') AND (p2.stop='' OR p2.stop>'$time')" : "") . ") AS subpages FROM tl_page p1 WHERE p1.pid=? AND p1.type!='root' AND p1.type!='error_401' AND p1.type!='error_403' AND p1.type!='error_404'" . (!$blnShowHidden ? ($blnIsSitemap ? " AND (p1.hide='' OR sitemap='map_always')" : " AND p1.hide=''") : "") . ($blnFeUserLoggedIn ? " AND p1.guests=''" : "") . (!$blnBeUserLoggedIn ? " AND p1.published='1' AND (p1.start='' OR p1.start<='$time') AND (p1.stop='' OR p1.stop>'$time')" : "") . " ORDER BY p1.sorting")
 											  ->execute($intPid);
 
 		if ($objSubpages->numRows < 1)

--- a/core-bundle/src/Resources/contao/models/PageModel.php
+++ b/core-bundle/src/Resources/contao/models/PageModel.php
@@ -626,7 +626,7 @@ class PageModel extends Model
 	 *
 	 * @return array<array{page:PageModel,hasSubpages:bool}>|null
 	 */
-	public static function findPublishedWithoutGuestsByPid($intPid, $blnShowHidden=false, $blnIsSitemap=false)
+	public static function findPublishedWithoutGuestsByPid($intPid, $blnShowHidden=false, $blnIsSitemap=false): ?array
 	{
 		$time = Date::floorToMinute();
 		$tokenChecker = System::getContainer()->get('contao.security.token_checker');

--- a/core-bundle/src/Resources/contao/models/PageModel.php
+++ b/core-bundle/src/Resources/contao/models/PageModel.php
@@ -614,7 +614,7 @@ class PageModel extends Model
 			return null;
 		}
 
-		return static::createCollectionFromDbResult($objSubpages, static::$strTable);
+		return static::createCollectionFromDbResult($objSubpages, 'tl_page');
 	}
 
 	/**

--- a/core-bundle/src/Resources/contao/modules/Module.php
+++ b/core-bundle/src/Resources/contao/modules/Module.php
@@ -271,7 +271,7 @@ abstract class Module extends Frontend
 	protected function renderNavigation($pid, $level=1, $host=null, $language=null)
 	{
 		// Get all active subpages
-		$arrSubpages = PageModel::findPublishedWithoutGuestsByPid($pid, $this->showHidden, $this instanceof ModuleSitemap);
+		$arrSubpages = static::getPublishedSubpagesWithoutGuestsByPid($pid, $this->showHidden, $this instanceof ModuleSitemap);
 
 		if ($arrSubpages === null)
 		{
@@ -458,6 +458,46 @@ abstract class Module extends Frontend
 		}
 
 		return $row;
+	}
+
+	/**
+	 * Get all published pages by their parent ID and exclude pages only visible for guests
+	 *
+	 * @param integer $intPid        The parent page's ID
+	 * @param boolean $blnShowHidden If true, hidden pages will be included
+	 * @param boolean $blnIsSitemap  If true, the sitemap settings apply
+	 *
+	 * @return array<array{page:PageModel,hasSubpages:bool}>|null
+	 */
+	protected static function getPublishedSubpagesWithoutGuestsByPid($intPid, $blnShowHidden=false, $blnIsSitemap=false): ?array
+	{
+		$time = Date::floorToMinute();
+		$tokenChecker = System::getContainer()->get('contao.security.token_checker');
+		$blnFeUserLoggedIn = $tokenChecker->hasFrontendUser();
+		$blnBeUserLoggedIn = $tokenChecker->hasBackendUser() && $tokenChecker->isPreviewMode();
+
+		$arrPages = Database::getInstance()->prepare("SELECT p1.id, EXISTS(SELECT * FROM tl_page p2 WHERE p2.pid=p1.id AND p2.type!='root' AND p2.type!='error_401' AND p2.type!='error_403' AND p2.type!='error_404'" . (!$blnShowHidden ? ($blnIsSitemap ? " AND (p2.hide='' OR sitemap='map_always')" : " AND p2.hide=''") : "") . ($blnFeUserLoggedIn ? " AND p2.guests=''" : "") . (!$blnBeUserLoggedIn ? " AND p2.published='1' AND (p2.start='' OR p2.start<='$time') AND (p2.stop='' OR p2.stop>'$time')" : "") . ") AS hasSubpages FROM tl_page p1 WHERE p1.pid=? AND p1.type!='root' AND p1.type!='error_401' AND p1.type!='error_403' AND p1.type!='error_404'" . (!$blnShowHidden ? ($blnIsSitemap ? " AND (p1.hide='' OR sitemap='map_always')" : " AND p1.hide=''") : "") . ($blnFeUserLoggedIn ? " AND p1.guests=''" : "") . (!$blnBeUserLoggedIn ? " AND p1.published='1' AND (p1.start='' OR p1.start<='$time') AND (p1.stop='' OR p1.stop>'$time')" : "") . " ORDER BY p1.sorting")
+			->execute($intPid)
+			->fetchAllAssoc();
+
+		if (\count($arrPages) < 1)
+		{
+			return null;
+		}
+
+		// Load models into the registry with a single query
+		PageModel::findMultipleByIds(array_map(static function ($row) { return $row['id']; }, $arrPages));
+
+		return array_map(
+			static function (array $row): array
+			{
+				return array(
+					'page' => PageModel::findByPk($row['id']),
+					'hasSubpages' => (bool) $row['hasSubpages'],
+				);
+			},
+			$arrPages
+		);
 	}
 
 	/**

--- a/core-bundle/src/Resources/contao/modules/Module.php
+++ b/core-bundle/src/Resources/contao/modules/Module.php
@@ -477,8 +477,8 @@ abstract class Module extends Frontend
 		$blnBeUserLoggedIn = $tokenChecker->hasBackendUser() && $tokenChecker->isPreviewMode();
 
 		$arrPages = Database::getInstance()->prepare("SELECT p1.id, EXISTS(SELECT * FROM tl_page p2 WHERE p2.pid=p1.id AND p2.type!='root' AND p2.type!='error_401' AND p2.type!='error_403' AND p2.type!='error_404'" . (!$blnShowHidden ? ($blnIsSitemap ? " AND (p2.hide='' OR sitemap='map_always')" : " AND p2.hide=''") : "") . ($blnFeUserLoggedIn ? " AND p2.guests=''" : "") . (!$blnBeUserLoggedIn ? " AND p2.published='1' AND (p2.start='' OR p2.start<='$time') AND (p2.stop='' OR p2.stop>'$time')" : "") . ") AS hasSubpages FROM tl_page p1 WHERE p1.pid=? AND p1.type!='root' AND p1.type!='error_401' AND p1.type!='error_403' AND p1.type!='error_404'" . (!$blnShowHidden ? ($blnIsSitemap ? " AND (p1.hide='' OR sitemap='map_always')" : " AND p1.hide=''") : "") . ($blnFeUserLoggedIn ? " AND p1.guests=''" : "") . (!$blnBeUserLoggedIn ? " AND p1.published='1' AND (p1.start='' OR p1.start<='$time') AND (p1.stop='' OR p1.stop>'$time')" : "") . " ORDER BY p1.sorting")
-			->execute($intPid)
-			->fetchAllAssoc();
+										   ->execute($intPid)
+										   ->fetchAllAssoc();
 
 		if (\count($arrPages) < 1)
 		{

--- a/core-bundle/src/Resources/contao/modules/Module.php
+++ b/core-bundle/src/Resources/contao/modules/Module.php
@@ -271,9 +271,9 @@ abstract class Module extends Frontend
 	protected function renderNavigation($pid, $level=1, $host=null, $language=null)
 	{
 		// Get all active subpages
-		$objSubpages = PageModel::findPublishedSubpagesWithoutGuestsByPid($pid, $this->showHidden, $this instanceof ModuleSitemap);
+		$arrSubpages = PageModel::findPublishedWithoutGuestsByPid($pid, $this->showHidden, $this instanceof ModuleSitemap);
 
-		if ($objSubpages === null)
+		if ($arrSubpages === null)
 		{
 			return '';
 		}
@@ -299,7 +299,7 @@ abstract class Module extends Frontend
 		global $objPage;
 
 		// Browse subpages
-		foreach ($objSubpages as $objSubpage)
+		foreach ($arrSubpages as list('page' => $objSubpage, 'hasSubpages' => $blnHasSubpages))
 		{
 			// Skip hidden sitemap pages
 			if ($this instanceof ModuleSitemap && $objSubpage->sitemap == 'map_never')
@@ -320,7 +320,7 @@ abstract class Module extends Frontend
 			if (!$objSubpage->protected || $this->showProtected || ($this instanceof ModuleSitemap && $objSubpage->sitemap == 'map_always') || (\is_array($_groups) && \is_array($groups) && \count(array_intersect($_groups, $groups))))
 			{
 				// Check whether there will be subpages
-				if ($objSubpage->subpages > 0 && (!$this->showLevel || $this->showLevel >= $level || (!$this->hardLimit && ($objPage->id == $objSubpage->id || \in_array($objPage->id, $this->Database->getChildRecords($objSubpage->id, 'tl_page'))))))
+				if ($blnHasSubpages && (!$this->showLevel || $this->showLevel >= $level || (!$this->hardLimit && ($objPage->id == $objSubpage->id || \in_array($objPage->id, $this->Database->getChildRecords($objSubpage->id, 'tl_page'))))))
 				{
 					$subitems = $this->renderNavigation($objSubpage->id, $level, $host, $language);
 				}

--- a/core-bundle/src/Resources/contao/modules/ModuleBooknav.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleBooknav.php
@@ -186,14 +186,14 @@ class ModuleBooknav extends Module
 	 */
 	protected function getBookPages($intParentId, $groups, $time)
 	{
-		$objPages = PageModel::findPublishedSubpagesWithoutGuestsByPid($intParentId, $this->showHidden);
+		$arrPages = PageModel::findPublishedWithoutGuestsByPid($intParentId, $this->showHidden);
 
-		if ($objPages === null)
+		if ($arrPages === null)
 		{
 			return;
 		}
 
-		foreach ($objPages as $objPage)
+		foreach ($arrPages as list('page' => $objPage, 'hasSubpages' => $blnHasSubpages))
 		{
 			$_groups = StringUtil::deserialize($objPage->groups);
 
@@ -202,7 +202,7 @@ class ModuleBooknav extends Module
 			{
 				$this->arrPages[$objPage->id] = $objPage;
 
-				if ($objPage->subpages > 0)
+				if ($blnHasSubpages)
 				{
 					$this->getBookPages($objPage->id, $groups, $time);
 				}

--- a/core-bundle/src/Resources/contao/modules/ModuleBooknav.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleBooknav.php
@@ -186,7 +186,7 @@ class ModuleBooknav extends Module
 	 */
 	protected function getBookPages($intParentId, $groups, $time)
 	{
-		$arrPages = PageModel::findPublishedWithoutGuestsByPid($intParentId, $this->showHidden);
+		$arrPages = static::getPublishedSubpagesWithoutGuestsByPid($intParentId, $this->showHidden);
 
 		if ($arrPages === null)
 		{

--- a/core-bundle/tests/Contao/ModuleTest.php
+++ b/core-bundle/tests/Contao/ModuleTest.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\Contao;
+
+use Contao\CoreBundle\Security\Authentication\Token\TokenChecker;
+use Contao\Database;
+use Contao\Database\Result;
+use Contao\Database\Statement;
+use Contao\Model\Registry;
+use Contao\Module;
+use Contao\PageModel;
+use Contao\System;
+use Contao\TestCase\ContaoTestCase;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Symfony\Component\Filesystem\Filesystem;
+
+class ModuleTest extends ContaoTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $platform = $this->createMock(AbstractPlatform::class);
+        $platform
+            ->method('getIdentifierQuoteCharacter')
+            ->willReturn('\'')
+        ;
+
+        $connection = $this->createMock(Connection::class);
+        $connection
+            ->method('getDatabasePlatform')
+            ->willReturn($platform)
+        ;
+
+        $connection
+            ->method('quoteIdentifier')
+            ->willReturnArgument(0)
+        ;
+
+        $container = $this->getContainerWithContaoConfiguration();
+        $container->set('database_connection', $connection);
+        $container->set('contao.security.token_checker', $this->createMock(TokenChecker::class));
+        $container->setParameter('contao.resources_paths', $this->getTempDir());
+
+        (new Filesystem())->mkdir($this->getTempDir().'/languages/en');
+
+        System::setContainer($container);
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        Registry::getInstance()->reset();
+
+        // Reset database instance
+        $property = (new \ReflectionClass(Database::class))->getProperty('arrInstances');
+        $property->setAccessible(true);
+        $property->setValue([]);
+    }
+
+    public function testGetPublishedSubpagesWithoutGuestsByPid(): void
+    {
+        $databaseResultFirstQuery = [
+            ['id' => '1', 'hasSubpages' => '0'],
+            ['id' => '2', 'hasSubpages' => '1'],
+            ['id' => '3', 'hasSubpages' => '1'],
+        ];
+
+        $databaseResultSecondQuery = [
+            ['id' => '1', 'alias' => 'alias1'],
+            ['id' => '2', 'alias' => 'alias2'],
+            ['id' => '3', 'alias' => 'alias3'],
+        ];
+
+        $statement = $this->createMock(Statement::class);
+        $statement
+            ->method('execute')
+            ->willReturnOnConsecutiveCalls(new Result($databaseResultFirstQuery, ''), new Result($databaseResultSecondQuery, ''))
+        ;
+
+        $database = $this->createMock(Database::class);
+        $database
+            ->method('prepare')
+            ->willReturn($statement)
+        ;
+
+        $this->mockDatabase($database);
+
+        $moduleInstance = new class() extends Module {
+            public function __construct()
+            {
+            }
+
+            protected function compile(): void
+            {
+            }
+
+            public function execute()
+            {
+                return static::getPublishedSubpagesWithoutGuestsByPid(1);
+            }
+        };
+
+        $pages = $moduleInstance->execute();
+
+        $this->assertIsArray($pages);
+        $this->assertCount(3, $pages);
+
+        $this->assertSame($databaseResultSecondQuery[0]['id'], $pages[0]['page']->id);
+        $this->assertSame($databaseResultSecondQuery[0]['alias'], $pages[0]['page']->alias);
+        $this->assertFalse($pages[0]['hasSubpages']);
+        $this->assertSame($databaseResultSecondQuery[1]['id'], $pages[1]['page']->id);
+        $this->assertSame($databaseResultSecondQuery[1]['alias'], $pages[1]['page']->alias);
+        $this->assertTrue($pages[1]['hasSubpages']);
+        $this->assertSame($databaseResultSecondQuery[2]['id'], $pages[2]['page']->id);
+        $this->assertSame($databaseResultSecondQuery[2]['alias'], $pages[2]['page']->alias);
+        $this->assertTrue($pages[2]['hasSubpages']);
+
+        // Get from model registry
+        $page2 = PageModel::findByPk(2);
+
+        $this->assertSame($databaseResultSecondQuery[1]['id'], $page2->id);
+        $this->assertSame($databaseResultSecondQuery[1]['alias'], $page2->alias);
+        $this->assertNull($page2->hasSubpages, 'The hasSubpages values should not be set in the model registry as it is contains generated data based on the query');
+    }
+
+    private function mockDatabase(Database $database): void
+    {
+        $property = (new \ReflectionClass($database))->getProperty('arrInstances');
+        $property->setAccessible(true);
+        $property->setValue([md5(implode('', [])) => $database]);
+
+        $this->assertSame($database, Database::getInstance());
+    }
+}

--- a/core-bundle/tests/Contao/PageModelTest.php
+++ b/core-bundle/tests/Contao/PageModelTest.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\Contao;
+
+use Contao\CoreBundle\Security\Authentication\Token\TokenChecker;
+use Contao\Database;
+use Contao\Database\Result;
+use Contao\Database\Statement;
+use Contao\Model\Collection;
+use Contao\Model\Registry;
+use Contao\PageModel;
+use Contao\System;
+use Contao\TestCase\ContaoTestCase;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Symfony\Component\Filesystem\Filesystem;
+
+class PageModelTest extends ContaoTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $platform = $this->createMock(AbstractPlatform::class);
+        $platform
+            ->method('getIdentifierQuoteCharacter')
+            ->willReturn('\'')
+        ;
+
+        $connection = $this->createMock(Connection::class);
+        $connection
+            ->method('getDatabasePlatform')
+            ->willReturn($platform)
+        ;
+
+        $connection
+            ->method('quoteIdentifier')
+            ->willReturnArgument(0)
+        ;
+
+        $container = $this->getContainerWithContaoConfiguration();
+        $container->set('database_connection', $connection);
+        $container->set('contao.security.token_checker', $this->createMock(TokenChecker::class));
+        $container->setParameter('contao.resources_paths', $this->getTempDir());
+
+        (new Filesystem())->mkdir($this->getTempDir().'/languages/en');
+
+        System::setContainer($container);
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        Registry::getInstance()->reset();
+
+        // Reset database instance
+        $property = (new \ReflectionClass(Database::class))->getProperty('arrInstances');
+        $property->setAccessible(true);
+        $property->setValue([]);
+    }
+
+    public function testCreatingEmptyPageModel(): void
+    {
+        $pageModel = new PageModel();
+
+        $this->assertNull($pageModel->id);
+        $this->assertNull($pageModel->alias);
+    }
+
+    public function testCreatingPageModelFromArray(): void
+    {
+        $pageModel = new PageModel(['id' => '1', 'alias' => 'alias']);
+
+        $this->assertSame('1', $pageModel->id);
+        $this->assertSame('alias', $pageModel->alias);
+    }
+
+    public function testCreatingPageModelFromDatabaseResult(): void
+    {
+        $pageModel = new PageModel(new Result([['id' => '1', 'alias' => 'alias']], 'SELECT * FROM tl_page WHERE id = 1'));
+
+        $this->assertSame('1', $pageModel->id);
+        $this->assertSame('alias', $pageModel->alias);
+    }
+
+    public function testFindPublishedSubpagesWithoutGuestsByPid(): void
+    {
+        $databaseResultData = [
+            ['id' => '1', 'alias' => 'alias1', 'subpages' => '0'],
+            ['id' => '2', 'alias' => 'alias2', 'subpages' => '3'],
+            ['id' => '3', 'alias' => 'alias3', 'subpages' => '42'],
+        ];
+
+        $statement = $this->createMock(Statement::class);
+        $statement
+            ->method('execute')
+            ->willReturn(new Result($databaseResultData, ''))
+        ;
+
+        $database = $this->createMock(Database::class);
+        $database
+            ->method('prepare')
+            ->willReturn($statement)
+        ;
+
+        $this->mockDatabase($database);
+
+        $pages = PageModel::findPublishedSubpagesWithoutGuestsByPid(1);
+
+        $this->assertInstanceOf(Collection::class, $pages);
+        $this->assertSame(3, $pages->count());
+
+        $this->assertSame($databaseResultData[0]['id'], $pages->offsetGet(0)->id);
+        $this->assertSame($databaseResultData[0]['alias'], $pages->offsetGet(0)->alias);
+        $this->assertSame($databaseResultData[0]['subpages'], $pages->offsetGet(0)->subpages);
+        $this->assertSame($databaseResultData[1]['id'], $pages->offsetGet(1)->id);
+        $this->assertSame($databaseResultData[1]['alias'], $pages->offsetGet(1)->alias);
+        $this->assertSame($databaseResultData[1]['subpages'], $pages->offsetGet(1)->subpages);
+        $this->assertSame($databaseResultData[2]['id'], $pages->offsetGet(2)->id);
+        $this->assertSame($databaseResultData[2]['alias'], $pages->offsetGet(2)->alias);
+        $this->assertSame($databaseResultData[2]['subpages'], $pages->offsetGet(2)->subpages);
+
+        // Get from model registry
+        $page2 = PageModel::findByPk(2);
+
+        $this->assertSame($databaseResultData[1]['id'], $page2->id);
+        $this->assertSame($databaseResultData[1]['alias'], $page2->alias);
+        $this->assertNull($page2->subpages, 'The subpages values should not be set in the model registry as it is contains generated data based on the query');
+    }
+
+    private function mockDatabase(Database $database): void
+    {
+        $property = (new \ReflectionClass($database))->getProperty('arrInstances');
+        $property->setAccessible(true);
+        $property->setValue([md5(implode('', [])) => $database]);
+
+        $this->assertSame($database, Database::getInstance());
+    }
+}

--- a/core-bundle/tests/Contao/PageModelTest.php
+++ b/core-bundle/tests/Contao/PageModelTest.php
@@ -104,6 +104,7 @@ class PageModelTest extends ContaoTestCase
 
         $database = $this->createMock(Database::class);
         $database
+            ->expects($this->once())
             ->method('prepare')
             ->willReturn($statement)
         ;
@@ -132,6 +133,7 @@ class PageModelTest extends ContaoTestCase
 
         $database = $this->createMock(Database::class);
         $database
+            ->expects($this->once())
             ->method('prepare')
             ->willReturn($statement)
         ;
@@ -141,7 +143,7 @@ class PageModelTest extends ContaoTestCase
         $pages = PageModel::findPublishedSubpagesWithoutGuestsByPid(1);
 
         $this->assertInstanceOf(Collection::class, $pages);
-        $this->assertSame(3, $pages->count());
+        $this->assertCount(3, $pages);
 
         $this->assertSame($databaseResultData[0]['id'], $pages->offsetGet(0)->id);
         $this->assertSame($databaseResultData[0]['alias'], $pages->offsetGet(0)->alias);

--- a/core-bundle/tests/Contao/PageModelTest.php
+++ b/core-bundle/tests/Contao/PageModelTest.php
@@ -161,57 +161,6 @@ class PageModelTest extends ContaoTestCase
         $this->assertSame($databaseResultData[2]['subpages'], $pages->offsetGet(2)->subpages);
     }
 
-    public function testFindPublishedWithoutGuestsByPid(): void
-    {
-        $databaseResultFirstQuery = [
-            ['id' => '1', 'hasSubpages' => '0'],
-            ['id' => '2', 'hasSubpages' => '1'],
-            ['id' => '3', 'hasSubpages' => '1'],
-        ];
-
-        $databaseResultSecondQuery = [
-            ['id' => '1', 'alias' => 'alias1'],
-            ['id' => '2', 'alias' => 'alias2'],
-            ['id' => '3', 'alias' => 'alias3'],
-        ];
-
-        $statement = $this->createMock(Statement::class);
-        $statement
-            ->method('execute')
-            ->willReturnOnConsecutiveCalls(new Result($databaseResultFirstQuery, ''), new Result($databaseResultSecondQuery, ''))
-        ;
-
-        $database = $this->createMock(Database::class);
-        $database
-            ->method('prepare')
-            ->willReturn($statement)
-        ;
-
-        $this->mockDatabase($database);
-
-        $pages = PageModel::findPublishedWithoutGuestsByPid(1);
-
-        $this->assertIsArray($pages);
-        $this->assertCount(3, $pages);
-
-        $this->assertSame($databaseResultSecondQuery[0]['id'], $pages[0]['page']->id);
-        $this->assertSame($databaseResultSecondQuery[0]['alias'], $pages[0]['page']->alias);
-        $this->assertFalse($pages[0]['hasSubpages']);
-        $this->assertSame($databaseResultSecondQuery[1]['id'], $pages[1]['page']->id);
-        $this->assertSame($databaseResultSecondQuery[1]['alias'], $pages[1]['page']->alias);
-        $this->assertTrue($pages[1]['hasSubpages']);
-        $this->assertSame($databaseResultSecondQuery[2]['id'], $pages[2]['page']->id);
-        $this->assertSame($databaseResultSecondQuery[2]['alias'], $pages[2]['page']->alias);
-        $this->assertTrue($pages[2]['hasSubpages']);
-
-        // Get from model registry
-        $page2 = PageModel::findByPk(2);
-
-        $this->assertSame($databaseResultSecondQuery[1]['id'], $page2->id);
-        $this->assertSame($databaseResultSecondQuery[1]['alias'], $page2->alias);
-        $this->assertNull($page2->hasSubpages, 'The hasSubpages values should not be set in the model registry as it is contains generated data based on the query');
-    }
-
     private function mockDatabase(Database $database): void
     {
         $property = (new \ReflectionClass($database))->getProperty('arrInstances');

--- a/core-bundle/tests/Contao/PageModelTest.php
+++ b/core-bundle/tests/Contao/PageModelTest.php
@@ -94,6 +94,28 @@ class PageModelTest extends ContaoTestCase
         $this->assertSame('alias', $pageModel->alias);
     }
 
+    public function testFindByPk(): void
+    {
+        $statement = $this->createMock(Statement::class);
+        $statement
+            ->method('execute')
+            ->willReturn(new Result([['id' => '1', 'alias' => 'alias']], ''))
+        ;
+
+        $database = $this->createMock(Database::class);
+        $database
+            ->method('prepare')
+            ->willReturn($statement)
+        ;
+
+        $this->mockDatabase($database);
+
+        $pageModel = PageModel::findByPk(1);
+
+        $this->assertSame('1', $pageModel->id);
+        $this->assertSame('alias', $pageModel->alias);
+    }
+
     public function testFindPublishedSubpagesWithoutGuestsByPid(): void
     {
         $databaseResultData = [


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #2934

~~Work in progress. Adds a tests that shows the issue from #2934~~

With these changes, the models get stored in the registry without the `subpages` column.