### PR TITLE
Remove the system log entry for 'no root page found'

### DIFF
--- a/core-bundle/src/Resources/contao/classes/Frontend.php
+++ b/core-bundle/src/Resources/contao/classes/Frontend.php
@@ -347,8 +347,6 @@ abstract class Frontend extends Controller
 			}
 			catch (RoutingExceptionInterface $exception)
 			{
-				$logger->log(LogLevel::ERROR, $strError, array('contao' => new ContaoContext(__METHOD__, 'ERROR')));
-
 				throw new NoRootPageFoundException('No root page found', 0, $exception);
 			}
 		}

--- a/core-bundle/src/Resources/contao/classes/Frontend.php
+++ b/core-bundle/src/Resources/contao/classes/Frontend.php
@@ -11,9 +11,7 @@
 namespace Contao;
 
 use Contao\CoreBundle\Exception\NoRootPageFoundException;
-use Contao\CoreBundle\Monolog\ContaoContext;
 use Contao\CoreBundle\Search\Document;
-use Psr\Log\LogLevel;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Exception\ExceptionInterface as RoutingExceptionInterface;

--- a/core-bundle/src/Resources/contao/classes/Frontend.php
+++ b/core-bundle/src/Resources/contao/classes/Frontend.php
@@ -316,7 +316,6 @@ abstract class Frontend extends Controller
 		if (!empty($_GET['language']) && Config::get('addLanguageToUrl'))
 		{
 			$strUri = Environment::get('url') . '/' . Input::get('language') . '/';
-			$strError = 'No root page found (host "' . $host . '", language "' . Input::get('language') . '")';
 		}
 
 		// No language given
@@ -329,7 +328,6 @@ abstract class Frontend extends Controller
 			}
 
 			$strUri = Environment::get('url') . '/';
-			$strError = 'No root page found (host "' . Environment::get('host') . '", languages "' . implode(', ', Environment::get('httpAcceptLanguage')) . '")';
 		}
 
 		$objRequest = Request::create($strUri);


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | -
| Docs PR or issue | -

In Contao `4.2.1` (1811b8b632cfa59a2e8f9f8f488249fe444f430a) all system log entries related to 404 responses were removed in order to not spam the system log with such entries anymore.

However, one such log entry remains. Whenever someone randomly accesses a language that does not exist in a multi-language Contao setup (with the language parameter enabled), a 404 response is generated - but still also the following log entry is generated:

```
No root page found (host "example.com", language "xx")
```

While this can be prevented by creating a dedicated 404 page within your site structure for each website root, I think this system log entry should also be removed, as bots can again spam such errors on sites where there happens to be no dedicated 404 page configured (which is not required anyway).