### PR TITLE
Do not count to check if there is a language file

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/System.php
+++ b/core-bundle/src/Resources/contao/library/Contao/System.php
@@ -564,9 +564,7 @@ abstract class System
 			}
 			else
 			{
-				/** @var SplFileInfo[] $files */
-				$files = static::getContainer()->get('contao.resource_finder')->findIn('languages')->depth(0)->directories()->name($strLanguage);
-				static::$arrLanguages[$strLanguage] = \count($files) > 0;
+				static::$arrLanguages[$strLanguage] = static::getContainer()->get('contao.resource_finder')->findIn('languages')->depth(0)->directories()->name($strLanguage)->hasResults();
 			}
 		}
 


### PR DESCRIPTION
A small performance optimisation, there's no point in searching for all files if we just need to know there's at least one.