### PR TITLE
Fix the page context when generating RSS feeds

### DIFF
--- a/calendar-bundle/src/Resources/contao/classes/Calendar.php
+++ b/calendar-bundle/src/Resources/contao/classes/Calendar.php
@@ -228,7 +228,7 @@ class Calendar extends Frontend
 						break 3;
 					}
 
-					// Override the global page object
+					// Override the global page object (#2946)
 					$objPage = CalendarModel::findByPk($event['pid'])->getRelated('jumpTo');
 
 					$objItem = new FeedItem();

--- a/calendar-bundle/src/Resources/contao/classes/Calendar.php
+++ b/calendar-bundle/src/Resources/contao/classes/Calendar.php
@@ -164,12 +164,6 @@ class Calendar extends Frontend
 					$arrUrls[$jumpTo] = $objParent->getAbsoluteUrl(Config::get('useAutoItem') ? '/%s' : '/events/%s');
 				}
 
-				// Skip the event if it requires a jumpTo URL but there is none
-				if ($objArticle->source == 'default' && $arrUrls[$jumpTo] === false)
-				{
-					continue;
-				}
-
 				$strUrl = $arrUrls[$jumpTo];
 				$this->addEvent($objArticle, $objArticle->startTime, $objArticle->endTime, $strUrl);
 

--- a/calendar-bundle/src/Resources/contao/classes/Calendar.php
+++ b/calendar-bundle/src/Resources/contao/classes/Calendar.php
@@ -601,8 +601,8 @@ class Calendar extends Frontend
 
 	/**
 	 * Return the page object with loaded details for the given page ID
-	 * 
-	 * @param integer $intPageId
+	 *
+	 * @param  integer        $intPageId
 	 * @return PageModel|null
 	 */
 	private function getPageWithDetails($intPageId)

--- a/calendar-bundle/src/Resources/contao/classes/Calendar.php
+++ b/calendar-bundle/src/Resources/contao/classes/Calendar.php
@@ -613,12 +613,12 @@ class Calendar extends Frontend
 	 */
 	private function getPageWithDetails($intPageId)
 	{
-		if (isset(self::$arrPageCache[$intPageId]))
+		if (!isset(self::$arrPageCache[$intPageId]))
 		{
-			return self::$arrPageCache[$intPageId];
+			self::$arrPageCache[$intPageId] = PageModel::findWithDetails($intPageId)
 		}
 
-		return (self::$arrPageCache[$intPageId] = PageModel::findWithDetails($intPageId));
+		return self::$arrPageCache[$intPageId];
 	}
 }
 

--- a/calendar-bundle/src/Resources/contao/classes/Calendar.php
+++ b/calendar-bundle/src/Resources/contao/classes/Calendar.php
@@ -615,7 +615,7 @@ class Calendar extends Frontend
 	{
 		if (!isset(self::$arrPageCache[$intPageId]))
 		{
-			self::$arrPageCache[$intPageId] = PageModel::findWithDetails($intPageId)
+			self::$arrPageCache[$intPageId] = PageModel::findWithDetails($intPageId);
 		}
 
 		return self::$arrPageCache[$intPageId];

--- a/news-bundle/src/Resources/contao/classes/News.php
+++ b/news-bundle/src/Resources/contao/classes/News.php
@@ -137,6 +137,7 @@ class News extends Frontend
 		if ($objArticle !== null)
 		{
 			$arrUrls = array();
+			$arrParentPages = array();
 
 			$request = System::getContainer()->get('request_stack')->getCurrentRequest();
 
@@ -146,8 +147,7 @@ class News extends Frontend
 				$request->attributes->set('_scope', 'frontend');
 			}
 
-			global $objPage;
-			$origObjPage = $objPage;
+			$origObjPage = $GLOBALS['objPage'] ?? null;
 
 			while ($objArticle->next())
 			{
@@ -159,7 +159,12 @@ class News extends Frontend
 					continue;
 				}
 
-				$objParent = PageModel::findWithDetails($jumpTo);
+				if (!isset($arrParentPages[$jumpTo]))
+				{
+					$arrParentPages[$jumpTo] = PageModel::findWithDetails($jumpTo);
+				}
+
+				$objParent = $arrParentPages[$jumpTo];
 
 				// A jumpTo page is set but does no longer exist (see #5781)
 				if ($objParent === null)
@@ -168,7 +173,7 @@ class News extends Frontend
 				}
 
 				// Override the global page object (#2946)
-				$objPage = $objParent;
+				$GLOBALS['objPage'] = $objParent;
 
 				// Get the jumpTo URL
 				if (!isset($arrUrls[$jumpTo]))
@@ -261,7 +266,7 @@ class News extends Frontend
 				$request->attributes->set('_scope', $origScope);
 			}
 
-			$objPage = $origObjPage;
+			$GLOBALS['objPage'] = $origObjPage;
 		}
 
 		$webDir = StringUtil::stripRootDir(System::getContainer()->getParameter('contao.web_dir'));

--- a/news-bundle/src/Resources/contao/classes/News.php
+++ b/news-bundle/src/Resources/contao/classes/News.php
@@ -528,12 +528,12 @@ class News extends Frontend
 	 */
 	private function getPageWithDetails($intPageId)
 	{
-		if (isset(self::$arrPageCache[$intPageId]))
+		if (!isset(self::$arrPageCache[$intPageId]))
 		{
-			return self::$arrPageCache[$intPageId];
+			self::$arrPageCache[$intPageId] = PageModel::findWithDetails($intPageId)
 		}
 
-		return (self::$arrPageCache[$intPageId] = PageModel::findWithDetails($intPageId));
+		return self::$arrPageCache[$intPageId];
 	}
 }
 

--- a/news-bundle/src/Resources/contao/classes/News.php
+++ b/news-bundle/src/Resources/contao/classes/News.php
@@ -530,7 +530,7 @@ class News extends Frontend
 	{
 		if (!isset(self::$arrPageCache[$intPageId]))
 		{
-			self::$arrPageCache[$intPageId] = PageModel::findWithDetails($intPageId)
+			self::$arrPageCache[$intPageId] = PageModel::findWithDetails($intPageId);
 		}
 
 		return self::$arrPageCache[$intPageId];

--- a/news-bundle/src/Resources/contao/classes/News.php
+++ b/news-bundle/src/Resources/contao/classes/News.php
@@ -167,7 +167,7 @@ class News extends Frontend
 					continue;
 				}
 
-				// Override the global page object
+				// Override the global page object (#2946)
 				$objPage = $objParent;
 
 				// Get the jumpTo URL

--- a/news-bundle/src/Resources/contao/classes/News.php
+++ b/news-bundle/src/Resources/contao/classes/News.php
@@ -516,8 +516,8 @@ class News extends Frontend
 
 	/**
 	 * Return the page object with loaded details for the given page ID
-	 * 
-	 * @param integer $intPageId
+	 *
+	 * @param  integer        $intPageId
 	 * @return PageModel|null
 	 */
 	private function getPageWithDetails($intPageId)

--- a/news-bundle/src/Resources/contao/classes/News.php
+++ b/news-bundle/src/Resources/contao/classes/News.php
@@ -24,6 +24,12 @@ class News extends Frontend
 	private static $arrUrlCache = array();
 
 	/**
+	 * Page cache array
+	 * @var array
+	 */
+	private static $arrPageCache = array();
+
+	/**
 	 * Update a particular RSS feed
 	 *
 	 * @param integer $intId
@@ -137,7 +143,6 @@ class News extends Frontend
 		if ($objArticle !== null)
 		{
 			$arrUrls = array();
-			$arrParentPages = array();
 
 			$request = System::getContainer()->get('request_stack')->getCurrentRequest();
 
@@ -159,12 +164,7 @@ class News extends Frontend
 					continue;
 				}
 
-				if (!isset($arrParentPages[$jumpTo]))
-				{
-					$arrParentPages[$jumpTo] = PageModel::findWithDetails($jumpTo);
-				}
-
-				$objParent = $arrParentPages[$jumpTo];
+				$objParent = $this->getPageWithDetails($jumpTo);
 
 				// A jumpTo page is set but does no longer exist (see #5781)
 				if ($objParent === null)
@@ -518,6 +518,22 @@ class News extends Frontend
 		}
 
 		return $arrFeeds;
+	}
+
+	/**
+	 * Return the page object with loaded details for the given page ID
+	 * 
+	 * @param integer $intPageId
+	 * @return PageModel|null
+	 */
+	private function getPageWithDetails($intPageId)
+	{
+		if (isset(self::$arrPageCache[$intPageId]))
+		{
+			return self::$arrPageCache[$intPageId];
+		}
+
+		return (self::$arrPageCache[$intPageId] = PageModel::findWithDetails($intPageId));
 	}
 }
 

--- a/news-bundle/src/Resources/contao/classes/News.php
+++ b/news-bundle/src/Resources/contao/classes/News.php
@@ -181,12 +181,6 @@ class News extends Frontend
 					$arrUrls[$jumpTo] = $objParent->getAbsoluteUrl(Config::get('useAutoItem') ? '/%s' : '/items/%s');
 				}
 
-				// Skip the event if it requires a jumpTo URL but there is none
-				if ($objArticle->source == 'default' && $arrUrls[$jumpTo] === false)
-				{
-					continue;
-				}
-
 				$strUrl = $arrUrls[$jumpTo];
 
 				$objItem = new FeedItem();


### PR DESCRIPTION
This is a follow up to #2848.

### Reproduction of the problem

1. Create a page article with some content.
2. Create a news archive and a published news article.
3. Put `{{insert_article::*}}` into the teaser of the news article (replace `*` with the ID of the previously generated page article).
4. Create an RSS feed and select the created news archive.

Unter PHP 8.0, the following error will occur upon saving the RSS feed or when regenerating the XML files in the maintenance section:

```
ErrorException:
Warning: Attempt to read property "datimFormat" on null

  at vendor\contao\contao\core-bundle\src\Resources\contao\modules\ModuleArticle.php:124
```

Same basic reproduction with events as well.

Since the XML feeds are always generated without a proper front end context, we also need to set the global `$objPage` variable (not just the front end scope) according to the `jumpTo` page of the news archive (or calendar respectively).

### Notes

* This PR includes a behaviour change: if the configured `jumpTo` page of a news archive or calendar is deleted, the affected news and event entries will be skipped now. In my opinion this is fine, since the news archive or calendar is then in a misconfigured state. See also the original issue of the affected lines of code: https://github.com/contao/core/issues/5781
* This PR is based against **4.11**. While the original issue does not cause an error in Contao **4.9** I do consider it a bug that the global `$objPage` object is not set properly for the feed generation. Should I rebase it against **4.9** instead?