### PR TITLE
Do not start the session to check if a property exists

### DIFF
--- a/core-bundle/src/Framework/ContaoFramework.php
+++ b/core-bundle/src/Framework/ContaoFramework.php
@@ -327,7 +327,7 @@ class ContaoFramework implements ContaoFrameworkInterface, ContainerAwareInterfa
         }
 
         if (!$session->isStarted()) {
-            $_SESSION = new LazySessionAccess($session);
+            $_SESSION = new LazySessionAccess($session, $this->request && $this->request->hasPreviousSession());
         } else {
             $_SESSION['BE_DATA'] = $session->getBag('contao_backend');
             $_SESSION['FE_DATA'] = $session->getBag('contao_frontend');

--- a/core-bundle/tests/Session/LazySessionAccessTest.php
+++ b/core-bundle/tests/Session/LazySessionAccessTest.php
@@ -197,7 +197,6 @@ class LazySessionAccessTest extends TestCase
         $_SESSION = new LazySessionAccess($session, false);
 
         $this->assertFalse($session->isStarted());
-
         $this->assertCount(0, $_SESSION);
         $this->assertFalse($session->isStarted());
     }

--- a/core-bundle/tests/Session/LazySessionAccessTest.php
+++ b/core-bundle/tests/Session/LazySessionAccessTest.php
@@ -48,6 +48,28 @@ class LazySessionAccessTest extends TestCase
 
     /**
      * @group legacy
+     */
+    public function testDoesNotStartSessionOnOffsetExistsWithoutPreviousSession(): void
+    {
+        $beBag = new AttributeBag();
+        $beBag->setName('contao_backend');
+
+        $feBag = new AttributeBag();
+        $feBag->setName('contao_frontend');
+
+        $session = new Session(new MockNativeSessionStorage());
+        $session->registerBag($beBag);
+        $session->registerBag($feBag);
+
+        $_SESSION = new LazySessionAccess($session, false);
+
+        $this->assertFalse($session->isStarted());
+        $this->assertFalse(isset($_SESSION['foobar']['nested']));
+        $this->assertFalse($session->isStarted());
+    }
+
+    /**
+     * @group legacy
      *
      * @expectedDeprecation Using $_SESSION has been deprecated %s.
      */
@@ -155,5 +177,28 @@ class LazySessionAccessTest extends TestCase
         $this->assertTrue($session->isStarted());
         $this->assertSame($beBag, $_SESSION['BE_DATA']);
         $this->assertSame($feBag, $_SESSION['FE_DATA']);
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testDoesNotStartSessionOnCountWithoutPreviousSession(): void
+    {
+        $beBag = new AttributeBag();
+        $beBag->setName('contao_backend');
+
+        $feBag = new AttributeBag();
+        $feBag->setName('contao_frontend');
+
+        $session = new Session(new MockNativeSessionStorage());
+        $session->registerBag($beBag);
+        $session->registerBag($feBag);
+
+        $_SESSION = new LazySessionAccess($session, false);
+
+        $this->assertFalse($session->isStarted());
+
+        $this->assertCount(0, $_SESSION);
+        $this->assertFalse($session->isStarted());
     }
 }


### PR DESCRIPTION
If legacy code calls `exists($_SESSION['foo'])`, we're starting the session in our `LegacySessionAccess`. However, this is totally unnecessary if there is no previous session, because the value can obviously never be there.