### PR TITLE
Show the values of unknown options

### DIFF
--- a/core-bundle/src/Resources/contao/languages/en/default.xlf
+++ b/core-bundle/src/Resources/contao/languages/en/default.xlf
@@ -2004,7 +2004,7 @@
         <source>Close the Contao toolbar</source>
       </trans-unit>
       <trans-unit id="MSC.unknownOption">
-        <source>Unknown option</source>
+        <source>Unknown option: %s</source>
       </trans-unit>
       <trans-unit id="UNITS.0">
         <source>Byte</source>

--- a/core-bundle/src/Resources/contao/widgets/CheckBox.php
+++ b/core-bundle/src/Resources/contao/widgets/CheckBox.php
@@ -135,7 +135,7 @@ class CheckBox extends Widget
 		{
 			foreach ($this->unknownOption as $val)
 			{
-				$arrAllOptions[] = array('value' => $val, 'label' => $GLOBALS['TL_LANG']['MSC']['unknownOption']);
+				$arrAllOptions[] = array('value' => $val, 'label' => sprintf($GLOBALS['TL_LANG']['MSC']['unknownOption'], $val));
 			}
 		}
 

--- a/core-bundle/src/Resources/contao/widgets/CheckBoxWizard.php
+++ b/core-bundle/src/Resources/contao/widgets/CheckBoxWizard.php
@@ -133,7 +133,7 @@ class CheckBoxWizard extends Widget
 		{
 			foreach ($this->unknownOption as $val)
 			{
-				$arrAllOptions[] = array('value' => $val, 'label' => $GLOBALS['TL_LANG']['MSC']['unknownOption']);
+				$arrAllOptions[] = array('value' => $val, 'label' => sprintf($GLOBALS['TL_LANG']['MSC']['unknownOption'], $val));
 			}
 		}
 

--- a/core-bundle/src/Resources/contao/widgets/ImageSize.php
+++ b/core-bundle/src/Resources/contao/widgets/ImageSize.php
@@ -181,7 +181,7 @@ class ImageSize extends Widget
 		// Add an unknown option, so it is not lost when saving the record (see #920)
 		if (isset($this->unknownOption[2]))
 		{
-			$arrAllOptions[] = array('value'=>$this->unknownOption[2], 'label'=>$GLOBALS['TL_LANG']['MSC']['unknownOption']);
+			$arrAllOptions[] = array('value' => $this->unknownOption[2], 'label' => sprintf($GLOBALS['TL_LANG']['MSC']['unknownOption'], $this->unknownOption[2]));
 		}
 
 		foreach ($arrAllOptions as $strKey=>$arrOption)

--- a/core-bundle/src/Resources/contao/widgets/RadioButton.php
+++ b/core-bundle/src/Resources/contao/widgets/RadioButton.php
@@ -115,7 +115,7 @@ class RadioButton extends Widget
 		// Add an unknown option, so it is not lost when saving the record (see #920)
 		if (isset($this->unknownOption[0]))
 		{
-			$arrAllOptions[] = array('value'=>$this->unknownOption[0], 'label'=>$GLOBALS['TL_LANG']['MSC']['unknownOption']);
+			$arrAllOptions[] = array('value' => $this->unknownOption[0], 'label' => sprintf($GLOBALS['TL_LANG']['MSC']['unknownOption'], $this->unknownOption[0]));
 		}
 
 		foreach ($arrAllOptions as $i=>$arrOption)

--- a/core-bundle/src/Resources/contao/widgets/SelectMenu.php
+++ b/core-bundle/src/Resources/contao/widgets/SelectMenu.php
@@ -146,7 +146,7 @@ class SelectMenu extends Widget
 		// Add an unknown option, so it is not lost when saving the record (see #920)
 		if (isset($this->unknownOption[0]))
 		{
-			$arrAllOptions[] = array('value'=>$this->unknownOption[0], 'label'=>$GLOBALS['TL_LANG']['MSC']['unknownOption']);
+			$arrAllOptions[] = array('value' => $this->unknownOption[0], 'label' => sprintf($GLOBALS['TL_LANG']['MSC']['unknownOption'], $this->unknownOption[0]));
 		}
 
 		foreach ($arrAllOptions as $strKey=>$arrOption)


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #2943

Closes #2943

I decided to use the format `Unknown option: j_foo` bei the one the the brackets is often used (this hopefully helps a litte more to recognize the unknown option is an error like state).

I modified the label in the english `default.xlf`. This must also be done in the other languages. Can somebody help me to get into transifex to get the job done? 