### PR TITLE
Show zero values in the list view and DCA filters

### DIFF
--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -5038,7 +5038,18 @@ class DC_Table extends DataContainer implements \listable, \editable
 				{
 					foreach ($args as $j=>$arg)
 					{
-						$return .= '<td colspan="' . $colspan . '" class="tl_file_list col_' . $GLOBALS['TL_DCA'][$this->strTable]['list']['label']['fields'][$j] . (($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['fields'][$j] == $firstOrderBy) ? ' ordered_by' : '') . '">' . ($arg ?: '-') . '</td>';
+						$field = $GLOBALS['TL_DCA'][$this->strTable]['list']['label']['fields'][$j];
+
+						if (isset($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['foreignKey']))
+						{
+							$value = $arg ?: '-';
+						}
+						else
+						{
+							$value = (string) $arg !== '' ? $arg : '-';
+						}
+
+						$return .= '<td colspan="' . $colspan . '" class="tl_file_list col_' . $GLOBALS['TL_DCA'][$this->strTable]['list']['label']['fields'][$j] . (($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['fields'][$j] == $firstOrderBy) ? ' ordered_by' : '') . '">' . $value . '</td>';
 					}
 				}
 				else
@@ -5935,7 +5946,14 @@ class DC_Table extends DataContainer implements \listable, \editable
 					// No empty options allowed
 					if (!$option_label)
 					{
-						$option_label = $vv ?: '-';
+						if (isset($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['foreignKey']))
+						{
+							$option_label = $vv ?: '-';
+						}
+						else
+						{
+							$option_label = (string) $vv !== '' ? $vv : '-';
+						}
 					}
 
 					$options_sorter['  <option value="' . StringUtil::specialchars($value) . '"' . ((isset($session['filter'][$filter][$field]) && $value == $session['filter'][$filter][$field]) ? ' selected="selected"' : '') . '>' . $option_label . '</option>'] = Utf8::toAscii($option_label);


### PR DESCRIPTION
If you add something like this to your DCA:

```php
// contao/dca/tl_member.php
use Contao\CoreBundle\DataContainer\PaletteManipulator;

$GLOBALS['TL_DCA']['tl_member']['fields']['some_number'] = [
    'label' => ['Some number', 'Some foobar number.'],
    'filter' => true,
    'inputType' => 'text',
    'eval' => ['rgxp' => 'digit', 'tl_class' => 'w50', 'maxlength' => 32],
    'sql' => ['type' => 'string', 'length' => 32, 'default' => ''],
];

$GLOBALS['TL_DCA']['tl_member']['list']['label']['fields'][5] = 'some_number';

PaletteManipulator::create()
    ->addField('some_number', 'personal_legend', PaletteManipulator::POSITION_APPEND)
    ->applyToPalette('default', 'tl_member')
;
```` 

and then enter a zero (`0`) into the new field, the back end will show `-` instead of `0` both in the list view when `showColumns` is enabled and in the filter menu of that field.

In my opinion it only makes sense to display `-` instead of `0` if the field acts as a foreign key to another table. Otherwise no presumptions can be made about the semantics of the field.

This PR would show `-` whenever `foreignKey` is set for the field and its content is falsy and otherwise it will only show `-` whenever the field is an empty string.

**Before:**

![Screenshot_2021-04-17 Mitglieder c49 local(1)](https://user-images.githubusercontent.com/4970961/115109095-c3c95200-9f6b-11eb-8af1-75103e28a747.png) ![2021-04-17 (1)_](https://user-images.githubusercontent.com/4970961/115109104-c88e0600-9f6b-11eb-8c0d-e3782b0d8356.png)

**After:**

![Screenshot_2021-04-17 Mitglieder c49 local](https://user-images.githubusercontent.com/4970961/115109111-cfb51400-9f6b-11eb-9089-8ed94f29f497.png) ![2021-04-17_](https://user-images.githubusercontent.com/4970961/115109113-d2b00480-9f6b-11eb-913c-3c908f95b6c9.png)


