### PR TITLE
Protect users against Google FLoC

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Template.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Template.php
@@ -320,6 +320,7 @@ abstract class Template extends Controller
 
 		$response = new Response($this->strBuffer);
 		$response->headers->set('Content-Type', $this->strContentType . '; charset=' . Config::get('characterSet'));
+		$response->headers->set('Permissions-Policy', 'interest-cohort=()');
 
 		// Mark this response to affect the caching of the current page but remove any default cache headers
 		$response->headers->set(SubrequestCacheSubscriber::MERGE_CACHE_HEADER, true);


### PR DESCRIPTION
Google’s Federated Learning of Cohorts is a new initiative to track internet users without their consent. This feature is already enabled by default for a small percentage of Google Chrome users, and is intended to be enabled for all users at the end of the experiment.

see https://github.com/api-platform/api-platform/pull/1879 and https://github.com/symfony/symfony/issues/40835