### PR TITLE
Generate URL from route for the button_callback

### DIFF
--- a/core-bundle/src/Resources/contao/classes/DataContainer.php
+++ b/core-bundle/src/Resources/contao/classes/DataContainer.php
@@ -797,17 +797,23 @@ abstract class DataContainer extends Backend
 				$attributes = ' class="' . $k . '"' . $attributes;
 			}
 
+			$href = $v['href'] ?? '';
+			if (!empty($v['route']))
+			{
+				$href = System::getContainer()->get('router')->generate($v['route'], array('id' => $arrRow['id']));
+			}
+
 			// Call a custom function instead of using the default button
 			if (\is_array($v['button_callback'] ?? null))
 			{
 				$this->import($v['button_callback'][0]);
-				$return .= $this->{$v['button_callback'][0]}->{$v['button_callback'][1]}($arrRow, $v['href'] ?? null, $label, $title, $v['icon'] ?? null, $attributes, $strTable, $arrRootIds, $arrChildRecordIds, $blnCircularReference, $strPrevious, $strNext, $this);
+				$return .= $this->{$v['button_callback'][0]}->{$v['button_callback'][1]}($arrRow, $href, $label, $title, $v['icon'] ?? null, $attributes, $strTable, $arrRootIds, $arrChildRecordIds, $blnCircularReference, $strPrevious, $strNext, $this);
 				continue;
 			}
 
 			if (\is_callable($v['button_callback'] ?? null))
 			{
-				$return .= $v['button_callback']($arrRow, $v['href'] ?? null, $label, $title, $v['icon'] ?? null, $attributes, $strTable, $arrRootIds, $arrChildRecordIds, $blnCircularReference, $strPrevious, $strNext, $this);
+				$return .= $v['button_callback']($arrRow, $href, $label, $title, $v['icon'] ?? null, $attributes, $strTable, $arrRootIds, $arrChildRecordIds, $blnCircularReference, $strPrevious, $strNext, $this);
 				continue;
 			}
 
@@ -831,7 +837,7 @@ abstract class DataContainer extends Backend
 				{
 					if (!empty($v['route']))
 					{
-						$href = System::getContainer()->get('router')->generate($v['route'], array('id' => $arrRow['id']));
+						$href = System::getContainer()->get('router')->generate($v['route'], array('id' => $arrRow['id'], 'nc' => Input::get('nb') ? '1' : null));
 					}
 					else
 					{
@@ -919,25 +925,27 @@ abstract class DataContainer extends Backend
 				$title = $label;
 			}
 
+			$href = $v['href'] ?? '';
+			if (!empty($v['route']))
+			{
+				$href = System::getContainer()->get('router')->generate($v['route']);
+			}
+
 			// Call a custom function instead of using the default button
 			if (\is_array($v['button_callback'] ?? null))
 			{
 				$this->import($v['button_callback'][0]);
-				$return .= $this->{$v['button_callback'][0]}->{$v['button_callback'][1]}($v['href'], $label, $title, $v['class'], $attributes, $this->strTable, $this->root);
+				$return .= $this->{$v['button_callback'][0]}->{$v['button_callback'][1]}($href, $label, $title, $v['class'], $attributes, $this->strTable, $this->root);
 				continue;
 			}
 
 			if (\is_callable($v['button_callback'] ?? null))
 			{
-				$return .= $v['button_callback']($v['href'], $label, $title, $v['class'], $attributes, $this->strTable, $this->root);
+				$return .= $v['button_callback']($href, $label, $title, $v['class'], $attributes, $this->strTable, $this->root);
 				continue;
 			}
 
-			if (!empty($v['route']))
-			{
-				$href = System::getContainer()->get('router')->generate($v['route']);
-			}
-			else
+			if (empty($v['route']))
 			{
 				$href = $this->addToUrl($v['href']);
 			}
@@ -1042,7 +1050,7 @@ abstract class DataContainer extends Backend
 			{
 				if (!empty($v['route']))
 				{
-					$href = System::getContainer()->get('router')->generate($v['route'], array('id' => $arrRow['id']));
+					$href = System::getContainer()->get('router')->generate($v['route'], array('id' => $arrRow['id'], 'nc' => Input::get('nb') ? '1' : null));
 				}
 				else
 				{

--- a/core-bundle/src/Resources/contao/classes/DataContainer.php
+++ b/core-bundle/src/Resources/contao/classes/DataContainer.php
@@ -797,7 +797,8 @@ abstract class DataContainer extends Backend
 				$attributes = ' class="' . $k . '"' . $attributes;
 			}
 
-			$href = $v['href'] ?? '';
+			$href = $v['href'] ?? null;
+
 			if (!empty($v['route']))
 			{
 				$href = System::getContainer()->get('router')->generate($v['route'], array('id' => $arrRow['id']));
@@ -926,6 +927,7 @@ abstract class DataContainer extends Backend
 			}
 
 			$href = $v['href'] ?? null;
+
 			if (!empty($v['route']))
 			{
 				$href = System::getContainer()->get('router')->generate($v['route']);

--- a/core-bundle/src/Resources/contao/classes/DataContainer.php
+++ b/core-bundle/src/Resources/contao/classes/DataContainer.php
@@ -949,7 +949,7 @@ abstract class DataContainer extends Backend
 
 			if (empty($v['route']))
 			{
-				$href = $this->addToUrl($v['href']);
+				$href = $this->addToUrl($href);
 			}
 
 			$return .= '<a href="' . $href . '" class="' . $v['class'] . '" title="' . StringUtil::specialchars($title) . '"' . $attributes . '>' . $label . '</a> ';

--- a/core-bundle/src/Resources/contao/classes/DataContainer.php
+++ b/core-bundle/src/Resources/contao/classes/DataContainer.php
@@ -925,7 +925,7 @@ abstract class DataContainer extends Backend
 				$title = $label;
 			}
 
-			$href = $v['href'] ?? '';
+			$href = $v['href'] ?? null;
 			if (!empty($v['route']))
 			{
 				$href = System::getContainer()->get('router')->generate($v['route']);


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #2951 
| Docs PR or issue | 

Generate the URL from the route parameter before passing it to the button_callback.

I decided to target this to 4.11 so you don't have to merge those PHP8 changes upstream 😅 