### PR TITLE
Update the functional tests section in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,12 +101,10 @@ composer run cs-fixer -- --clear-cache
 
 ## Functional tests
 
-To set up functional tests, create a database named `contao_test` and import
-the `core-bundle/tests/Functional/app/Resources/contao_test.sql` file.
+To set up functional tests, create a database named `contao_test`:
 
 ```bash
 mysql -e "CREATE DATABASE contao_test"
-mysql contao_test < core-bundle/tests/Functional/app/Resources/contao_test.sql
 ```
 
 If your database uses credentials, copy the file `core-bundle/phpunit.xml.dist`


### PR DESCRIPTION
 Remove the reference to the file `contao_test.sql` that was deleted in 65cb20a4

The functional tests run successful without importing said file beforehand.
