### PR TITLE
Use the date formats from the page context for insert tags

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/InsertTags.php
+++ b/core-bundle/src/Resources/contao/library/Contao/InsertTags.php
@@ -170,7 +170,7 @@ class InsertTags extends Controller
 			{
 				// Date
 				case 'date':
-					$arrCache[$strTag] = Date::parse($elements[1] ?: Config::get('dateFormat'));
+					$arrCache[$strTag] = Date::parse($elements[1] ?: $objPage->dateFormat ?: Config::get('dateFormat'));
 					break;
 
 				// Accessibility tags
@@ -329,15 +329,15 @@ class InsertTags extends Controller
 
 						if ($rgxp == 'date')
 						{
-							$arrCache[$strTag] = Date::parse(Config::get('dateFormat'), $value);
+							$arrCache[$strTag] = Date::parse($objPage->dateFormat ?: Config::get('dateFormat'), $value);
 						}
 						elseif ($rgxp == 'time')
 						{
-							$arrCache[$strTag] = Date::parse(Config::get('timeFormat'), $value);
+							$arrCache[$strTag] = Date::parse($objPage->timeFormat ?: Config::get('timeFormat'), $value);
 						}
 						elseif ($rgxp == 'datim')
 						{
-							$arrCache[$strTag] = Date::parse(Config::get('datimFormat'), $value);
+							$arrCache[$strTag] = Date::parse($objPage->datimFormat ?: Config::get('datimFormat'), $value);
 						}
 						elseif (\is_array($value))
 						{
@@ -589,7 +589,7 @@ class InsertTags extends Controller
 
 					if ($objUpdate->numRows)
 					{
-						$arrCache[$strTag] = Date::parse($elements[1] ?: Config::get('datimFormat'), max($objUpdate->tc, $objUpdate->tn, $objUpdate->te));
+						$arrCache[$strTag] = Date::parse($elements[1] ?: $objPage->datimFormat ?: Config::get('datimFormat'), max($objUpdate->tc, $objUpdate->tn, $objUpdate->te));
 					}
 					break;
 

--- a/core-bundle/src/Resources/contao/library/Contao/InsertTags.php
+++ b/core-bundle/src/Resources/contao/library/Contao/InsertTags.php
@@ -170,7 +170,7 @@ class InsertTags extends Controller
 			{
 				// Date
 				case 'date':
-					$arrCache[$strTag] = Date::parse($elements[1] ?: $objPage->dateFormat ?: Config::get('dateFormat'));
+					$arrCache[$strTag] = Date::parse($elements[1] ?: $objPage->dateFormat);
 					break;
 
 				// Accessibility tags
@@ -329,15 +329,15 @@ class InsertTags extends Controller
 
 						if ($rgxp == 'date')
 						{
-							$arrCache[$strTag] = Date::parse($objPage->dateFormat ?: Config::get('dateFormat'), $value);
+							$arrCache[$strTag] = Date::parse($objPage->dateFormat, $value);
 						}
 						elseif ($rgxp == 'time')
 						{
-							$arrCache[$strTag] = Date::parse($objPage->timeFormat ?: Config::get('timeFormat'), $value);
+							$arrCache[$strTag] = Date::parse($objPage->timeFormat, $value);
 						}
 						elseif ($rgxp == 'datim')
 						{
-							$arrCache[$strTag] = Date::parse($objPage->datimFormat ?: Config::get('datimFormat'), $value);
+							$arrCache[$strTag] = Date::parse($objPage->datimFormat, $value);
 						}
 						elseif (\is_array($value))
 						{
@@ -589,7 +589,7 @@ class InsertTags extends Controller
 
 					if ($objUpdate->numRows)
 					{
-						$arrCache[$strTag] = Date::parse($elements[1] ?: $objPage->datimFormat ?: Config::get('datimFormat'), max($objUpdate->tc, $objUpdate->tn, $objUpdate->te));
+						$arrCache[$strTag] = Date::parse($elements[1] ?: $objPage->datimFormat, max($objUpdate->tc, $objUpdate->tn, $objUpdate->te));
 					}
 					break;
 


### PR DESCRIPTION
Currently the following insert tags will only fall back to the back end date and time formats if no specific date format is given in the insert tag:

* `{{date}}`
* `{{last_update}}`
* `{{user::*}}` if `*` is a `tl_member` DCA field with a `rgxp` of either `date`, `time` or `datim`.

In the front end context the date formats of the page should always be used when displaying dates.

_Note:_ this automatically falls back to the date formats of the back end (the local config), see [here](https://github.com/contao/contao/blob/13ca9de98fdef79992a094d962ae9297138a8b24/core-bundle/src/Resources/contao/models/PageModel.php#L1057-L1071).