### PR TITLE
Load protected status from parent pages in customnav

### DIFF
--- a/core-bundle/src/Resources/contao/modules/ModuleCustomnav.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleCustomnav.php
@@ -116,10 +116,10 @@ class ModuleCustomnav extends Module
 		/** @var PageModel[] $arrPages */
 		foreach ($arrPages as $objModel)
 		{
-			$_groups = StringUtil::deserialize($objModel->groups);
-
-			// Inherit protected status from the parent pages
+			// Inherit settings from the parent pages
 			$objModel->loadDetails();
+
+			$_groups = StringUtil::deserialize($objModel->groups);
 
 			// Do not show protected pages unless a front end user is logged in
 			if (!$objModel->protected || $this->showProtected || (\is_array($_groups) && \is_array($groups) && \count(array_intersect($_groups, $groups))))

--- a/core-bundle/src/Resources/contao/modules/ModuleCustomnav.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleCustomnav.php
@@ -118,6 +118,9 @@ class ModuleCustomnav extends Module
 		{
 			$_groups = StringUtil::deserialize($objModel->groups);
 
+			// Inherit protected status from the parent pages
+			$objModel->loadDetails();
+
 			// Do not show protected pages unless a front end user is logged in
 			if (!$objModel->protected || $this->showProtected || (\is_array($_groups) && \is_array($groups) && \count(array_intersect($_groups, $groups))))
 			{


### PR DESCRIPTION
The custom navigation module does render protected pages if not logged in, even with the "Show protected items" option disabled, if they do not have the protected status set on the page itself, but rather inherited the status from one of its ancestor pages.

This PR adds a call to `PageModel::loadDetails` to actually inherit the protected status and associated groups setting from parent pages before checking for them, to correctly hide protected pages.