### PR TITLE
Do not render an empty custom navigation

### DIFF
--- a/core-bundle/src/Resources/contao/modules/ModuleCustomnav.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleCustomnav.php
@@ -249,8 +249,9 @@ class ModuleCustomnav extends Module
 			}
 		}
 
-		if (!empty($items)) {
-			// Add classes first and last
+		// Add classes first and last if there are items
+		if (!empty($items))
+		{
 			$items[0]['class'] = trim($items[0]['class'] . ' first');
 			$last = \count($items) - 1;
 			$items[$last]['class'] = trim($items[$last]['class'] . ' last');

--- a/core-bundle/src/Resources/contao/modules/ModuleCustomnav.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleCustomnav.php
@@ -249,10 +249,12 @@ class ModuleCustomnav extends Module
 			}
 		}
 
-		// Add classes first and last
-		$items[0]['class'] = trim($items[0]['class'] . ' first');
-		$last = \count($items) - 1;
-		$items[$last]['class'] = trim($items[$last]['class'] . ' last');
+		if (!empty($items)) {
+			// Add classes first and last
+			$items[0]['class'] = trim($items[0]['class'] . ' first');
+			$last = \count($items) - 1;
+			$items[$last]['class'] = trim($items[$last]['class'] . ' last');
+		}
 
 		$objTemplate->items = $items;
 


### PR DESCRIPTION
When a Custom Navigation module has no items to be rendered (e.g. because all the pages are protected and the user is not allowed to access them), the `first` and `last` classes are "added" regardless, to an actually not existing item, thus creating an otherwise empty item with just those classes. This leads to the module being rendered with a single empty item, instead of not being rendered at all, as intended, as `$items` is never empty, even if it should be. https://github.com/contao/contao/blob/33027f89eb2a1333ff13205659767eb1484c1037/core-bundle/src/Resources/contao/modules/ModuleCustomnav.php#L262

This PR adds a check to not add the `first` and `last` classes, if there are no items to add them to.