### PR TITLE
Backport the autocomplete changes

### DIFF
--- a/core-bundle/src/Resources/contao/dca/tl_member.php
+++ b/core-bundle/src/Resources/contao/dca/tl_member.php
@@ -287,7 +287,7 @@ $GLOBALS['TL_DCA']['tl_member'] = array
 			'sorting'                 => true,
 			'flag'                    => 1,
 			'inputType'               => 'text',
-			'eval'                    => array('mandatory'=>true, 'unique'=>true, 'rgxp'=>'extnd', 'nospace'=>true, 'maxlength'=>64, 'feEditable'=>true, 'feViewable'=>true, 'feGroup'=>'login', 'tl_class'=>'w50'),
+			'eval'                    => array('mandatory'=>true, 'unique'=>true, 'rgxp'=>'extnd', 'nospace'=>true, 'maxlength'=>64, 'feEditable'=>true, 'feViewable'=>true, 'feGroup'=>'login', 'tl_class'=>'w50', 'autocapitalize'=>'off', 'autocomplete'=>'username'),
 			'sql'                     => 'varchar(64) BINARY NULL'
 		),
 		'password' => array

--- a/core-bundle/src/Resources/contao/dca/tl_user.php
+++ b/core-bundle/src/Resources/contao/dca/tl_user.php
@@ -133,7 +133,7 @@ $GLOBALS['TL_DCA']['tl_user'] = array
 			'sorting'                 => true,
 			'flag'                    => 1,
 			'inputType'               => 'text',
-			'eval'                    => array('mandatory'=>true, 'rgxp'=>'extnd', 'nospace'=>true, 'unique'=>true, 'maxlength'=>64, 'tl_class'=>'w50'),
+			'eval'                    => array('mandatory'=>true, 'rgxp'=>'extnd', 'nospace'=>true, 'unique'=>true, 'maxlength'=>64, 'tl_class'=>'w50', 'autocapitalize'=>'off', 'autocomplete'=>'username'),
 			'sql'                     => "varchar(64) BINARY NULL"
 		),
 		'name' => array

--- a/core-bundle/src/Resources/contao/forms/FormPassword.php
+++ b/core-bundle/src/Resources/contao/forms/FormPassword.php
@@ -167,7 +167,7 @@ class FormPassword extends Widget
 	public function generate()
 	{
 		return sprintf(
-			'<input type="password" name="%s" id="ctrl_%s" class="text password%s" value=""%s%s',
+			'<input type="password" name="%s" id="ctrl_%s" class="text password%s" value="" autocomplete="new-password"%s%s',
 			$this->strName,
 			$this->strId,
 			($this->strClass ? ' ' . $this->strClass : ''),
@@ -201,7 +201,7 @@ class FormPassword extends Widget
 	public function generateConfirmation()
 	{
 		return sprintf(
-			'<input type="password" name="%s_confirm" id="ctrl_%s_confirm" class="text password confirm%s" value=""%s%s',
+			'<input type="password" name="%s_confirm" id="ctrl_%s_confirm" class="text password confirm%s" value="" autocomplete="new-password"%s%s',
 			$this->strName,
 			$this->strId,
 			($this->strClass ? ' ' . $this->strClass : ''),

--- a/core-bundle/src/Resources/contao/modules/ModuleChangePassword.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleChangePassword.php
@@ -94,7 +94,7 @@ class ModuleChangePassword extends Module
 			'name'      => 'oldpassword',
 			'label'     => &$GLOBALS['TL_LANG']['MSC']['oldPassword'],
 			'inputType' => 'text',
-			'eval'      => array('mandatory'=>true, 'preserveTags'=>true, 'hideInput'=>true),
+			'eval'      => array('mandatory'=>true, 'preserveTags'=>true, 'hideInput'=>true, 'autocomplete'=>'current-password'),
 		);
 
 		// New password widget

--- a/core-bundle/src/Resources/contao/templates/backend/be_login.html5
+++ b/core-bundle/src/Resources/contao/templates/backend/be_login.html5
@@ -50,11 +50,11 @@
             <h1><?= $this->headline ?></h1>
             <div class="widget widget-text">
               <label for="username"><?= $this->username ?></label>
-              <input type="text" name="username" id="username" class="tl_text" value="<?= $this->curUsername ?>" autocapitalize="off" placeholder="<?= $this->username ?>" required>
+              <input type="text" name="username" id="username" class="tl_text" value="<?= $this->curUsername ?>" autocapitalize="off" autocomplete="username" placeholder="<?= $this->username ?>" required>
             </div>
             <div class="widget widget-password">
               <label for="password"><?= $this->password ?></label>
-              <input type="password" name="password" id="password" class="tl_text" value="" placeholder="<?= $this->password ?>" required>
+              <input type="password" name="password" id="password" class="tl_text" value="" autocomplete="current-password" placeholder="<?= $this->password ?>" required>
             </div>
             <div class="submit_container cf">
               <button type="submit" name="login" id="login" class="tl_submit"><?= $this->loginButton ?></button>

--- a/core-bundle/src/Resources/contao/templates/backend/be_login_two_factor.html5
+++ b/core-bundle/src/Resources/contao/templates/backend/be_login_two_factor.html5
@@ -50,7 +50,7 @@
             <h1><?= $this->headline ?></h1>
             <div class="widget widget-text">
               <label for="verify"><?= $this->authCode ?></label>
-              <input type="text" name="verify" id="verify" class="tl_text" value="" autocapitalize="off" autocomplete="off" placeholder="<?= $this->authCode ?>" required>
+              <input type="text" name="verify" id="verify" class="tl_text" value="" autocapitalize="off" autocomplete="one-time-code" placeholder="<?= $this->authCode ?>" required>
             </div>
             <div class="widget widget-checkbox">
               <input type="checkbox" name="trusted" id="trusted" class="tl_checkbox" value="1">

--- a/core-bundle/src/Resources/contao/templates/backend/be_password.html5
+++ b/core-bundle/src/Resources/contao/templates/backend/be_password.html5
@@ -42,11 +42,11 @@
           <p><?= $this->explain ?></p>
           <div class="widget">
             <label for="password"><?= $this->password ?></label>
-            <input type="password" name="password" id="password" class="tl_text" value="" placeholder="<?= $this->password ?>" required>
+            <input type="password" name="password" id="password" class="tl_text" value="" autocomplete="new-password" placeholder="<?= $this->password ?>" required>
           </div>
           <div class="widget">
             <label for="confirm"><?= $this->confirm ?></label>
-            <input type="password" name="confirm" id="confirm" class="tl_text" value="" placeholder="<?= $this->confirm ?>" required>
+            <input type="password" name="confirm" id="confirm" class="tl_text" value="" autocomplete="new-password" placeholder="<?= $this->confirm ?>" required>
           </div>
           <div class="submit_container cf">
             <button type="submit" name="login" id="login" class="tl_submit"><?= $this->submitButton ?></button>

--- a/core-bundle/src/Resources/contao/templates/backend/be_two_factor.html5
+++ b/core-bundle/src/Resources/contao/templates/backend/be_two_factor.html5
@@ -22,7 +22,7 @@
         </div>
         <div class="widget w50 clr">
           <h3><label for="verify"<?php if ($this->error): ?> class="error"<?php endif; ?>><?= $this->trans('MSC.twoFactorVerification') ?></label></h3>
-          <input type="text" name="verify" id="verify" class="tl_text<?php if ($this->error): ?> error<?php endif; ?>" value="" autocapitalize="off" autocomplete="off" required>
+          <input type="text" name="verify" id="verify" class="tl_text<?php if ($this->error): ?> error<?php endif; ?>" value="" autocapitalize="off" autocomplete="one-time-code" required>
           <p class="<?= $this->error ? 'tl_error' : 'tl_help' ?> tl_tip"><?= $this->trans('MSC.twoFactorVerificationHelp') ?></p>
         </div>
         <div class="submit_container cf">

--- a/core-bundle/src/Resources/contao/templates/forms/form_password.html5
+++ b/core-bundle/src/Resources/contao/templates/forms/form_password.html5
@@ -17,7 +17,7 @@
     <p class="error"><?= $this->getErrorAsString() ?></p>
   <?php endif; ?>
 
-  <input type="password" name="<?= $this->name ?>" id="ctrl_<?= $this->id ?>" class="text password<?php if ($this->class): ?> <?= $this->class ?><?php endif; ?>" value=""<?= $this->getAttributes() ?>>
+  <input type="password" name="<?= $this->name ?>" id="ctrl_<?= $this->id ?>" class="text password<?php if ($this->class): ?> <?= $this->class ?><?php endif; ?>" value="" autocomplete="new-password"<?= $this->getAttributes() ?>>
 <?php $this->endblock(); ?>
 
 <?php $this->block('label2'); ?>
@@ -33,5 +33,5 @@
 <?php $this->endblock(); ?>
 
 <?php $this->block('field2'); ?>
-  <input type="password" name="<?= $this->name ?>_confirm" id="ctrl_<?= $this->id ?>_confirm" class="text password<?php if ($this->class): ?> <?= $this->class ?><?php endif; ?>" value=""<?= $this->getAttributes() ?>>
+  <input type="password" name="<?= $this->name ?>_confirm" id="ctrl_<?= $this->id ?>_confirm" class="text password<?php if ($this->class): ?> <?= $this->class ?><?php endif; ?>" value="" autocomplete="new-password"<?= $this->getAttributes() ?>>
 <?php $this->endblock(); ?>

--- a/core-bundle/src/Resources/contao/templates/modules/mod_login.html5
+++ b/core-bundle/src/Resources/contao/templates/modules/mod_login.html5
@@ -21,7 +21,7 @@
         <h3><?= $this->twoFactorAuthentication ?></h3>
         <div class="widget widget-text">
           <label for="verify"><?= $this->authCode ?></label>
-          <input type="text" name="verify" id="verify" class="text" value="" autocapitalize="off" autocomplete="off" required>
+          <input type="text" name="verify" id="verify" class="text" value="" autocapitalize="off" autocomplete="one-time-code" required>
         </div>
         <div class="widget widget-checkbox">
           <input type="checkbox" name="trusted" id="trusted" class="tl_checkbox" value="1">
@@ -30,11 +30,11 @@
       <?php else: ?>
         <div class="widget widget-text">
           <label for="username"><?= $this->username ?></label>
-          <input type="text" name="username" id="username" class="text" value="<?= $this->value ?>" required>
+          <input type="text" name="username" id="username" class="text" value="<?= $this->value ?>" autocapitalize="off" autocomplete="username" required>
         </div>
         <div class="widget widget-password">
           <label for="password"><?= $this->password ?></label>
-          <input type="password" name="password" id="password" class="text password" value="" required>
+          <input type="password" name="password" id="password" class="text password" value="" autocomplete="current-password" required>
         </div>
         <?php if ($this->autologin): ?>
           <div class="widget widget-checkbox">

--- a/core-bundle/src/Resources/contao/templates/modules/mod_two_factor.html5
+++ b/core-bundle/src/Resources/contao/templates/modules/mod_two_factor.html5
@@ -24,7 +24,7 @@
         </div>
         <div class="widget widget-text">
           <label for="verify"><?= $this->trans('MSC.twoFactorVerification') ?></label>
-          <input type="text" name="verify" id="verify" class="text" value="" autocapitalize="off" autocomplete="off" required>
+          <input type="text" name="verify" id="verify" class="text" value="" autocapitalize="off" autocomplete="one-time-code" required>
           <p class="help"><?= $this->trans('MSC.twoFactorVerificationHelp') ?></p>
         </div>
         <div class="submit_container">

--- a/core-bundle/src/Resources/contao/widgets/Password.php
+++ b/core-bundle/src/Resources/contao/widgets/Password.php
@@ -150,7 +150,7 @@ class Password extends Widget
 	public function generate()
 	{
 		return sprintf(
-			'<input type="password" autocomplete="off" name="%s" id="ctrl_%s" class="tl_text tl_password%s" value="%s"%s onfocus="Backend.getScrollOffset()">%s%s',
+			'<input type="password" autocomplete="off" name="%s" id="ctrl_%s" class="tl_text tl_password%s" value="%s" autocomplete="new-password"%s onfocus="Backend.getScrollOffset()">%s%s',
 			$this->strName,
 			$this->strId,
 			($this->strClass ? ' ' . $this->strClass : ''),
@@ -186,7 +186,7 @@ class Password extends Widget
 	public function generateConfirmation()
 	{
 		return sprintf(
-			'<input type="password" autocomplete="off" name="%s_confirm" id="ctrl_%s_confirm" class="tl_text tl_password confirm%s" value="%s"%s onfocus="Backend.getScrollOffset()">%s',
+			'<input type="password" autocomplete="off" name="%s_confirm" id="ctrl_%s_confirm" class="tl_text tl_password confirm%s" value="%s" autocomplete="new-password"%s onfocus="Backend.getScrollOffset()">%s',
 			$this->strName,
 			$this->strId,
 			($this->strClass ? ' ' . $this->strClass : ''),

--- a/core-bundle/src/Resources/views/Frontend/preview_toolbar_base.html.twig
+++ b/core-bundle/src/Resources/views/Frontend/preview_toolbar_base.html.twig
@@ -10,7 +10,7 @@
             {% if canSwitchUser %}
                 <div>
                     <label for="ctrl_user">{{ 'MSC.feUser'|trans }}:</label>
-                    <input type="text" name="user" id="ctrl_user" list="userlist" class="tl_text user" placeholder="{{ 'MSC.username'|trans }}" value="{{ user }}" autocomplete="off">
+                    <input type="text" name="user" id="ctrl_user" list="userlist" class="tl_text user" placeholder="{{ 'MSC.username'|trans }}" value="{{ user }}" autocomplete="username">
                     <datalist id="userlist"></datalist>
                 </div>
             {% endif %}

--- a/installation-bundle/src/Resources/views/login.html.twig
+++ b/installation-bundle/src/Resources/views/login.html.twig
@@ -14,7 +14,7 @@
         <input type="hidden" name="FORM_SUBMIT" value="tl_login">
         <input type="hidden" name="REQUEST_TOKEN" value="{{ request_token }}">
         <h4><label for="password">{{ 'password'|trans }}</label></h4>
-        <input type="password" name="password" id="password" autocomplete="off" class="tl_text" value="">
+        <input type="password" name="password" id="password" class="tl_text" value="" autocomplete="current-password">
       </div>
       <div class="tl_formbody_submit">
         <div class="tl_submit_container">

--- a/installation-bundle/src/Resources/views/password.html.twig
+++ b/installation-bundle/src/Resources/views/password.html.twig
@@ -13,9 +13,9 @@
         <input type="hidden" name="FORM_SUBMIT" value="tl_password">
         <input type="hidden" name="REQUEST_TOKEN" value="{{ request_token }}">
         <h4><label for="password">{{ 'password'|trans }}</label></h4>
-        <input type="password" name="password" id="password" autocomplete="off" class="tl_text" value="">
+        <input type="password" name="password" id="password" class="tl_text" value="" autocomplete="new-password">
         <h4><label for="confirmation">{{ 'confirmation'|trans }}</label></h4>
-        <input type="password" name="confirmation" id="confirmation" autocomplete="off" class="tl_text" value="">
+        <input type="password" name="confirmation" id="confirmation" class="tl_text" value="" autocomplete="new-password">
       </div>
       <div class="tl_formbody_submit">
         <div class="tl_submit_container">


### PR DESCRIPTION
This PR backports the changes from #2432. I consider this a bugfix, because password managers like 1password no longer work properly without the correct attributes (especially not with `autocomplete="off"`).