### PR TITLE
Fix external news targets not opening in a new window

### DIFF
--- a/news-bundle/src/Resources/contao/modules/ModuleNews.php
+++ b/news-bundle/src/Resources/contao/modules/ModuleNews.php
@@ -369,9 +369,10 @@ abstract class ModuleNews extends Module
 		$strArticleUrl = News::generateNewsUrl($objArticle, $blnAddArchive);
 
 		return sprintf(
-			'<a href="%s" title="%s" itemprop="url">%s%s</a>',
+			'<a href="%s" title="%s"%s itemprop="url">%s%s</a>',
 			$strArticleUrl,
 			StringUtil::specialchars(sprintf($strReadMore, $blnIsInternal ? $objArticle->headline : $strArticleUrl), true),
+			($objArticle->target && !$blnIsInternal ? ' target="_blank" rel="noreferrer noopener"' : ''),
 			($blnIsReadMore ? $strLink : '<span itemprop="headline">' . $strLink . '</span>'),
 			($blnIsReadMore && $blnIsInternal ? '<span class="invisible"> ' . $objArticle->headline . '</span>' : '')
 		);


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #2947
| Docs PR or issue | -

The implementation for opening external target URLs for news articles in a new window was erroneously removed in https://github.com/contao/contao/pull/2615. This PR fixes that.