### PR TITLE
Fix a regression in the limit menu compilation

### DIFF
--- a/core-bundle/src/Resources/contao/classes/DataContainer.php
+++ b/core-bundle/src/Resources/contao/classes/DataContainer.php
@@ -1238,7 +1238,7 @@ abstract class DataContainer extends Backend
 		// Compile limit menu if placeholder is present
 		foreach ($arrPanels as $key => $strPanel)
 		{
-			if (strpos('###limit_menu###', $strPanel) === false)
+			if (strpos($strPanel, '###limit_menu###') === false)
 			{
 				continue;
 			}


### PR DESCRIPTION
Follow-up to #2933 
As it turns out, parameters passed to `strpos` where in the wrong order 🙈 