### PR TITLE
[POC] Extendable image studio

### DIFF
--- a/core-bundle/src/Image/Studio/Event/AbstractFigureBuilderEvent.php
+++ b/core-bundle/src/Image/Studio/Event/AbstractFigureBuilderEvent.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Image\Studio\Event;
+
+use Contao\CoreBundle\Image\Studio\Figure;
+use Contao\CoreBundle\Image\Studio\FigureBuilder;
+
+abstract class AbstractFigureBuilderEvent
+{
+    /**
+     * @var FigureBuilder
+     */
+    private $figureBuilder;
+
+    /**
+     * @var Figure
+     */
+    private $figure;
+
+    public function __construct(FigureBuilder $figureBuilder, Figure $figure)
+    {
+        $this->figureBuilder = $figureBuilder;
+        $this->figure = $figure;
+    }
+
+    public function getFigureBuilder(): FigureBuilder
+    {
+        return $this->figureBuilder;
+    }
+
+    public function getFigure(): Figure
+    {
+        return $this->figure;
+    }
+}

--- a/core-bundle/src/Image/Studio/Event/DefineLightboxResultEvent.php
+++ b/core-bundle/src/Image/Studio/Event/DefineLightboxResultEvent.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Image\Studio\Event;
+
+class DefineLightboxResultEvent extends AbstractFigureBuilderEvent
+{
+}

--- a/core-bundle/src/Image/Studio/Event/DefineLinkAttributesEvent.php
+++ b/core-bundle/src/Image/Studio/Event/DefineLinkAttributesEvent.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Image\Studio\Event;
+
+class DefineLinkAttributesEvent extends AbstractFigureBuilderEvent
+{
+}

--- a/core-bundle/src/Image/Studio/Event/DefineMediaResultEvent.php
+++ b/core-bundle/src/Image/Studio/Event/DefineMediaResultEvent.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Image\Studio\Event;
+
+use Contao\CoreBundle\Image\Studio\MediaResultInterface;
+
+class DefineMediaResultEvent extends AbstractFigureBuilderEvent
+{
+    /**
+     * @var MediaResultInterface|null
+     */
+    private $mediaResult;
+
+    public function setMediaResult(MediaResultInterface $mediaResult): void
+    {
+        $this->mediaResult = $mediaResult;
+    }
+
+    public function getMediaResult(): ?MediaResultInterface
+    {
+        return $this->mediaResult;
+    }
+}

--- a/core-bundle/src/Image/Studio/Event/DefineMetadataEvent.php
+++ b/core-bundle/src/Image/Studio/Event/DefineMetadataEvent.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Image\Studio\Event;
+
+class DefineMetadataEvent extends AbstractFigureBuilderEvent
+{
+}

--- a/core-bundle/src/Image/Studio/Event/DefineOptionsEvent.php
+++ b/core-bundle/src/Image/Studio/Event/DefineOptionsEvent.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Image\Studio\Event;
+
+class DefineOptionsEvent extends AbstractFigureBuilderEvent
+{
+}

--- a/core-bundle/src/Image/Studio/Figure.php
+++ b/core-bundle/src/Image/Studio/Figure.php
@@ -28,7 +28,7 @@ use Contao\Template;
 final class Figure
 {
     /**
-     * @var MediaResultInterface
+     * @var MediaResultInterface|(\Closure(self):MediaResultInterface)
      */
     private $media;
 
@@ -55,16 +55,15 @@ final class Figure
     /**
      * Creates a figure container.
      *
-     * All arguments but the main image result can also be set via a Closure
-     * that only returns the value on demand.
+     * All arguments also be set via a Closure that returns the value on demand.
      *
-     * @param MediaResultInterface                                                        $media          Main media
+     * @param MediaResultInterface|(\Closure(self):MediaResultInterface)                  $media          Main media
      * @param Metadata|(\Closure(self):Metadata|null)|null                                $metadata       Metadata container
      * @param array<string, string|null>|(\Closure(self):array<string, string|null>)|null $linkAttributes Link attributes
      * @param LightboxResult|(\Closure(self):LightboxResult|null)|null                    $lightbox       Lightbox
      * @param array<string, mixed>|(\Closure(self):array<string, mixed>)|null             $options        Template options
      */
-    public function __construct(MediaResultInterface $media, $metadata = null, $linkAttributes = null, $lightbox = null, $options = null)
+    public function __construct($media, $metadata = null, $linkAttributes = null, $lightbox = null, $options = null)
     {
         $this->media = $media;
         $this->metadata = $metadata;
@@ -78,6 +77,8 @@ final class Figure
      */
     public function getMedia(): MediaResultInterface
     {
+        $this->resolveIfClosure($this->media);
+
         return $this->media;
     }
 
@@ -86,6 +87,8 @@ final class Figure
      */
     public function hasImage(): bool
     {
+        $this->resolveIfClosure($this->media);
+
         return $this->media instanceof ImageResult;
     }
 

--- a/core-bundle/src/Image/Studio/Figure.php
+++ b/core-bundle/src/Image/Studio/Figure.php
@@ -112,7 +112,7 @@ final class Figure
     }
 
     /**
-     * Returns the lightbox result (if available).
+     * Returns the lightbox result.
      */
     public function getLightbox(): LightboxResult
     {
@@ -124,6 +124,9 @@ final class Figure
         return $this->lightbox;
     }
 
+    /**
+     * Returns true if metadata can be obtained.
+     */
     public function hasMetadata(): bool
     {
         $this->resolveIfClosure($this->metadata);

--- a/core-bundle/src/Image/Studio/FigureBuilder.php
+++ b/core-bundle/src/Image/Studio/FigureBuilder.php
@@ -545,14 +545,17 @@ class FigureBuilder
         // Freeze settings to allow reusing this builder object
         $settings = clone $this;
 
-        $imageResult = $this->locator
-            ->get(Studio::class)
-            ->createImage($settings->filePath, $settings->sizeConfiguration, $settings->resizeOptions)
-        ;
-
         // Define the values via closure to make their evaluation lazy
         return new Figure(
-            $imageResult,
+            \Closure::bind(
+                function (Figure $figure): ImageResult {
+                    return $this->locator
+                        ->get(Studio::class)
+                        ->createImage($this->filePath, $this->sizeConfiguration, $this->resizeOptions)
+                    ;
+                },
+                $settings
+            ),
             \Closure::bind(
                 function (Figure $figure): ?Metadata {
                     return $this->onDefineMetadata();

--- a/core-bundle/src/Image/Studio/ImageResult.php
+++ b/core-bundle/src/Image/Studio/ImageResult.php
@@ -26,7 +26,7 @@ use Contao\Image\ResizeOptions;
 use Psr\Container\ContainerInterface;
 use Webmozart\PathUtil\Path;
 
-class ImageResult
+class ImageResult implements MediaResultInterface
 {
     /**
      * @var ContainerInterface

--- a/core-bundle/src/Image/Studio/MediaResultInterface.php
+++ b/core-bundle/src/Image/Studio/MediaResultInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Image\Studio;
+
+interface MediaResultInterface
+{
+}

--- a/core-bundle/src/Image/Studio/Studio.php
+++ b/core-bundle/src/Image/Studio/Studio.php
@@ -84,6 +84,7 @@ class Studio implements ServiceSubscriberInterface
             'contao.image.resizer' => ResizerInterface::class,
             'contao.assets.files_context' => ContaoContext::class,
             'contao.framework' => ContaoFramework::class,
+            'event_dispatcher' => 'event_dispatcher',
         ];
     }
 }

--- a/core-bundle/tests/Image/Studio/FigureBuilderIntegrationTest.php
+++ b/core-bundle/tests/Image/Studio/FigureBuilderIntegrationTest.php
@@ -36,6 +36,7 @@ use Imagine\Gd\Imagine as ImagineGd;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\NullLogger;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Webmozart\PathUtil\Path;
@@ -1666,6 +1667,7 @@ class FigureBuilderIntegrationTest extends TestCase
         $container->set('request_stack', new RequestStack());
         $container->set('filesystem', new Filesystem());
         $container->set('monolog.logger.contao', new NullLogger());
+        $container->set('event_dispatcher', new EventDispatcher());
     }
 
     private function assertSameTemplateData(array $expected, object $template): void

--- a/core-bundle/tests/Image/Studio/FigureBuilderTest.php
+++ b/core-bundle/tests/Image/Studio/FigureBuilderTest.php
@@ -29,6 +29,7 @@ use Contao\System;
 use Contao\Validator;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Container\ContainerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Webmozart\PathUtil\Path;
 
@@ -1114,6 +1115,7 @@ class FigureBuilderTest extends TestCase
             ->willReturnMap([
                 [Studio::class, $studio],
                 ['contao.framework', $framework],
+                ['event_dispatcher', new EventDispatcher()],
             ])
         ;
 

--- a/core-bundle/tests/Image/Studio/StudioTest.php
+++ b/core-bundle/tests/Image/Studio/StudioTest.php
@@ -43,6 +43,7 @@ class StudioTest extends TestCase
             ResizerInterface::class,
             ContaoFramework::class,
             ContaoContext::class,
+            'event_dispatcher',
         ];
 
         $this->assertEqualsCanonicalizing($services, Studio::getSubscribedServices());


### PR DESCRIPTION
This is a rough outline how the image studio concept could be extended to allow arbitrary media instead of "just" images that are processed by our image factories as well as an event based system (inspired by @Toflar's #2962) to alter the output. 

I've got a use case in my mind where I wanted to display [lottie files](https://lottiefiles.com/web-player) and want them to act like regular images.  These are `json` files that must not be put through the image processing pipelines. I try to find out if things like this could be made possible. If so, you would be able to reuse the infrastructure, meta data and so on. :slightly_smiling_face: 

That said, at this point it's a rather quick draft to get the discussion going.