### PR TITLE
Fix form fields key handling in editAll mode for DC_Folder

### DIFF
--- a/core-bundle/src/Resources/contao/classes/DataContainer.php
+++ b/core-bundle/src/Resources/contao/classes/DataContainer.php
@@ -42,6 +42,12 @@ abstract class DataContainer extends Backend
 	protected $intId;
 
 	/**
+	 * Initial ID of the same record
+	 * @var integer
+	 */
+	protected $initialId;
+
+	/**
 	 * Name of the current table
 	 * @var string
 	 */
@@ -325,7 +331,8 @@ abstract class DataContainer extends Backend
 		// Validate the field
 		if (Input::post('FORM_SUBMIT') == $this->strTable)
 		{
-			$suffix = ($this instanceof DC_Folder ? md5($this->intId) : $this->intId);
+			$initialId = $this->initialId ?: $this->intId;
+			$suffix = ($this instanceof DC_Folder ? md5($initialId) : $this->intId);
 			$key = (Input::get('act') == 'editAll') ? 'FORM_FIELDS_' . $suffix : 'FORM_FIELDS';
 
 			// Calculate the current palette

--- a/core-bundle/src/Resources/contao/drivers/DC_Folder.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Folder.php
@@ -1633,6 +1633,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 			foreach ($ids as $id)
 			{
 				$this->intId = $id;
+				$this->initialId = $id;
 				$this->strPalette = StringUtil::trimsplit('[;,]', $this->getPalette());
 
 				$objModel = null;


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #2577

## Issue

Editing multiple records in the file manager, changing both file name and other fields per record, discards all changes other than the file name.

## Reproduction

(Description adapted from issue #2577 and generalized because this does not only affect the meta field)

1. File manager › Edit multiple > Select 2 or more images
2. Available fields > Select all > Continue
3. Rename file name AND change any other field of the same record
4. Save and close

## Cause

In `DC_Folder`, the ID of the resource is its path. `DC_Folder#editAll()` walks through the records' IDs, updating `$this->intId` with every iteration:
https://github.com/contao/contao/blob/2e762a3eee71ce6076d51cb3fd64cfa0b6ce6758/core-bundle/src/Resources/contao/drivers/DC_Folder.php#L1633-L1635

Per record, it walks through the palette:
https://github.com/contao/contao/blob/2e762a3eee71ce6076d51cb3fd64cfa0b6ce6758/core-bundle/src/Resources/contao/drivers/DC_Folder.php#L1671
at the end of which it calls `DataContainer#row()`:
https://github.com/contao/contao/blob/2e762a3eee71ce6076d51cb3fd64cfa0b6ce6758/core-bundle/src/Resources/contao/drivers/DC_Folder.php#L1726

If the form is submitted, `DataContainer#row()` determines the form fields key by generating a suffix based on `$this->intId`:
https://github.com/contao/contao/blob/2e762a3eee71ce6076d51cb3fd64cfa0b6ce6758/core-bundle/src/Resources/contao/classes/DataContainer.php#L326-L329

**This is where the problem lies.** The changed file name is saved:
https://github.com/contao/contao/blob/2e762a3eee71ce6076d51cb3fd64cfa0b6ce6758/core-bundle/src/Resources/contao/classes/DataContainer.php#L405-L409

And `DC_Folder#save()` updates `$this->intId`:
https://github.com/contao/contao/blob/2e762a3eee71ce6076d51cb3fd64cfa0b6ce6758/core-bundle/src/Resources/contao/drivers/DC_Folder.php#L2300

**Now, the suffix for the same record is different when `DataContainer#row()` is called for the record's subsequent fields.** The form field key does not match anymore, `Input::post($key)` is unexpectedly empty, `$postPaletteFields` therefore ends up empty as well:
https://github.com/contao/contao/blob/2e762a3eee71ce6076d51cb3fd64cfa0b6ce6758/core-bundle/src/Resources/contao/classes/DataContainer.php#L328-L333

So nothing is added to `$paletteFields`:
https://github.com/contao/contao/blob/2e762a3eee71ce6076d51cb3fd64cfa0b6ce6758/core-bundle/src/Resources/contao/classes/DataContainer.php#L367

And thus all fields of the record after `name` are skipped because `\in_array($this->strInputName, $paletteFields)` is always `false`:
https://github.com/contao/contao/blob/2e762a3eee71ce6076d51cb3fd64cfa0b6ce6758/core-bundle/src/Resources/contao/classes/DataContainer.php#L375-L376

All of this is, of course, only a problem in `DC_Folder` because you can't change a database id by editing the record.

## Solution

As we can't *not* update `$this->intId` when the name of the resource is changed, we have to keep track of the initial ID independently. This PR adds a property `$initialId` to `DataContainer` that is set in `DC_Folder`'s editAll mode alongside `$intId` and, if set, has priority over `$intId` in `DataContainer#row()`.