### PR TITLE
Fix the favicon.ico route

### DIFF
--- a/core-bundle/src/Controller/FaviconController.php
+++ b/core-bundle/src/Controller/FaviconController.php
@@ -20,6 +20,7 @@ use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
+use Webmozart\PathUtil\Path;
 
 /**
  * @Route(defaults={"_scope" = "frontend"})
@@ -34,13 +35,19 @@ class FaviconController
     private $contaoFramework;
 
     /**
+     * @var string
+     */
+    private $projectDir;
+
+    /**
      * @var ResponseTagger|null
      */
     private $responseTagger;
 
-    public function __construct(ContaoFramework $contaoFramework, ResponseTagger $responseTagger = null)
+    public function __construct(ContaoFramework $contaoFramework, string $projectDir, ResponseTagger $responseTagger = null)
     {
         $this->contaoFramework = $contaoFramework;
+        $this->projectDir = $projectDir;
         $this->responseTagger = $responseTagger;
     }
 
@@ -73,7 +80,7 @@ class FaviconController
         }
 
         // Cache the response for 1 year and tag it so it is invalidated when the settings are edited
-        $response = new BinaryFileResponse($faviconModel->path);
+        $response = new BinaryFileResponse(Path::join($this->projectDir, $faviconModel->path));
         $response->setSharedMaxAge(31556952);
 
         switch ($faviconModel->extension) {

--- a/core-bundle/src/Resources/config/services.yml
+++ b/core-bundle/src/Resources/config/services.yml
@@ -108,6 +108,7 @@ services:
     Contao\CoreBundle\Controller\FaviconController:
         arguments:
             - '@contao.framework'
+            - '%kernel.project_dir%'
             - '@?fos_http_cache.http.symfony_response_tagger'
         tags:
             - controller.service_arguments

--- a/core-bundle/tests/Controller/FaviconControllerTest.php
+++ b/core-bundle/tests/Controller/FaviconControllerTest.php
@@ -38,7 +38,7 @@ class FaviconControllerTest extends TestCase
         ;
 
         $request = Request::create('/robots.txt');
-        $controller = new FaviconController($framework, $this->createMock(ResponseTagger::class));
+        $controller = new FaviconController($framework, $this->getFixturesDir(), $this->createMock(ResponseTagger::class));
         $response = $controller($request);
 
         $this->assertSame(Response::HTTP_NOT_FOUND, $response->getStatusCode());
@@ -108,6 +108,6 @@ class FaviconControllerTest extends TestCase
             ->with(['contao.db.tl_page.42'])
         ;
 
-        return new FaviconController($framework, $responseTagger);
+        return new FaviconController($framework, $this->getFixturesDir(), $responseTagger);
     }
 }

--- a/core-bundle/tests/Controller/FaviconControllerTest.php
+++ b/core-bundle/tests/Controller/FaviconControllerTest.php
@@ -46,7 +46,7 @@ class FaviconControllerTest extends TestCase
 
     public function testRegularFavicon(): void
     {
-        $controller = $this->getController(__DIR__.'/../Fixtures/images/favicon.ico');
+        $controller = $this->getController('images/favicon.ico');
 
         $request = Request::create('/favicon.ico');
         $response = $controller($request);
@@ -57,7 +57,7 @@ class FaviconControllerTest extends TestCase
 
     public function testSvgFavicon(): void
     {
-        $controller = $this->getController(__DIR__.'/../Fixtures/images/favicon.svg');
+        $controller = $this->getController('images/favicon.svg');
 
         $request = Request::create('/favicon.ico');
         $response = $controller($request);

--- a/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
+++ b/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
@@ -1361,6 +1361,7 @@ class ContaoCoreExtensionTest extends TestCase
         $this->assertEquals(
             [
                 new Reference('contao.framework'),
+                new Reference('%kernel.project_dir%'),
                 new Reference('fos_http_cache.http.symfony_response_tagger', ContainerInterface::IGNORE_ON_INVALID_REFERENCE),
             ],
             $definition->getArguments()


### PR DESCRIPTION
Currently the favicon selection in the website root does not actually work. The following error will occur when accessing the `/favicon.ico` route:

```
Symfony\Component\HttpFoundation\File\Exception\FileNotFoundException:
The file "files/foobar/favicon.ico" does not exist

  at vendor\symfony\http-foundation\File\File.php:36
  at Symfony\Component\HttpFoundation\File\File->__construct()
     (vendor\symfony\http-foundation\BinaryFileResponse.php:92)
  at Symfony\Component\HttpFoundation\BinaryFileResponse->setFile()
     (vendor\symfony\http-foundation\BinaryFileResponse.php:51)
  at Symfony\Component\HttpFoundation\BinaryFileResponse->__construct()
     (vendor\contao\contao\core-bundle\src\Controller\FaviconController.php:76)
  at Contao\CoreBundle\Controller\FaviconController->__invoke()
     (vendor\symfony\http-kernel\HttpKernel.php:158)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw()
     (vendor\symfony\http-kernel\HttpKernel.php:80)
  at Symfony\Component\HttpKernel\HttpKernel->handle()
     (vendor\symfony\http-kernel\Kernel.php:201)
  at Symfony\Component\HttpKernel\Kernel->handle()
     (web\index.php:31)
  at require('web/index.php')
     (web\app.php:4)
```

The `BinaryFileResponse` needs an absolute path to the file, while the `FilesModel` only contains the relative path. This PR adds the project directory to the path to fix that error.