### PR TITLE
Allow saving the value `0` in the KeyValueWizard

### DIFF
--- a/core-bundle/src/Resources/contao/widgets/KeyValueWizard.php
+++ b/core-bundle/src/Resources/contao/widgets/KeyValueWizard.php
@@ -66,7 +66,7 @@ class KeyValueWizard extends Widget
 			foreach ($options as $key=>$option)
 			{
 				// Unset empty rows
-				if (!$option['key'])
+				if (trim($option['key']) === '')
 				{
 					unset($options[$key]);
 					continue;


### PR DESCRIPTION
Replaces the pull request #3006.

---

This PR fixes the bug that 0 values cannot be entered in the KeyValueWizard.

It seems that this possibility was removed in the preparation for PHP8.
In further versions of contao 4.9 it was possible to set 0 as value.

(#2347, #2342)
