### PR TITLE
Handle UUIDs in the file metadata class

### DIFF
--- a/core-bundle/src/File/Metadata.php
+++ b/core-bundle/src/File/Metadata.php
@@ -45,8 +45,8 @@ class Metadata
     }
 
     /**
-     * Get a new metadata representation that also contains the given values.
-     * Existing keys will get overwritten.
+     * Returns a new metadata representation that also contains the given
+     * values. Existing keys will be overwritten.
      *
      * @param array<string, mixed> $values
      */
@@ -88,7 +88,7 @@ class Metadata
     }
 
     /**
-     * Get a UUID reference in ASCII format or null if not set.
+     * Returns a UUID reference in ASCII format or null if not set.
      */
     public function getUuid(): ?string
     {

--- a/core-bundle/src/File/Metadata.php
+++ b/core-bundle/src/File/Metadata.php
@@ -27,6 +27,7 @@ class Metadata
     public const VALUE_CAPTION = 'caption';
     public const VALUE_TITLE = 'title';
     public const VALUE_URL = 'link';
+    public const VALUE_UUID = 'uuid';
 
     /**
      * Key-value pairs of metadata.
@@ -84,6 +85,11 @@ class Metadata
     public function getUrl(): string
     {
         return $this->values[self::VALUE_URL] ?? '';
+    }
+
+    public function getUuid(): ?string
+    {
+        return $this->values[self::VALUE_UUID] ?? null;
     }
 
     /**

--- a/core-bundle/src/File/Metadata.php
+++ b/core-bundle/src/File/Metadata.php
@@ -87,6 +87,9 @@ class Metadata
         return $this->values[self::VALUE_URL] ?? '';
     }
 
+    /**
+     * Get a UUID reference in ASCII format or null if not set.
+     */
     public function getUuid(): ?string
     {
         return $this->values[self::VALUE_UUID] ?? null;

--- a/core-bundle/src/File/Metadata.php
+++ b/core-bundle/src/File/Metadata.php
@@ -35,9 +35,27 @@ class Metadata
      */
     private $values;
 
+    /**
+     * @param array<string, mixed> $values
+     */
     public function __construct(array $values)
     {
         $this->values = $values;
+    }
+
+    /**
+     * Get a new metadata representation that also contains the given values.
+     * Existing keys will get overwritten.
+     *
+     * @param array<string, mixed> $values
+     */
+    public function with(array $values): self
+    {
+        if (empty($values)) {
+            return $this;
+        }
+
+        return new self(array_merge($this->values, $values));
     }
 
     /**

--- a/core-bundle/src/Image/Studio/FigureBuilder.php
+++ b/core-bundle/src/Image/Studio/FigureBuilder.php
@@ -611,7 +611,7 @@ class FigureBuilder
         $metaFields = $this->filesModelAdapter()->getMetaFields();
 
         $data = array_merge(
-            array_combine($metaFields, array_fill(0, \count($metaFields), '')).
+            array_combine($metaFields, array_fill(0, \count($metaFields), '')),
             $fileReferenceData
         );
 

--- a/core-bundle/src/Image/Studio/FigureBuilder.php
+++ b/core-bundle/src/Image/Studio/FigureBuilder.php
@@ -584,8 +584,14 @@ class FigureBuilder
             return null;
         }
 
+        $fileReferenceData = array_filter([
+            Metadata::VALUE_UUID => null !== $this->filesModel ? $this->filesModel->uuid : null,
+        ]);
+
         if (null !== $this->metadata) {
-            return $this->metadata;
+            return $this->metadata
+                ->with($fileReferenceData)
+            ;
         }
 
         if (null === $this->filesModel) {
@@ -597,14 +603,19 @@ class FigureBuilder
         $metadata = $this->filesModel->getMetadata(...$locales);
 
         if (null !== $metadata) {
-            return $metadata;
+            return $metadata->with($fileReferenceData);
         }
 
         // If no metadata can be obtained from the model, we create a
         // container from the default meta fields with empty values instead
         $metaFields = $this->filesModelAdapter()->getMetaFields();
 
-        return new Metadata(array_combine($metaFields, array_fill(0, \count($metaFields), '')));
+        $data = array_merge(
+            array_combine($metaFields, array_fill(0, \count($metaFields), '')).
+            $fileReferenceData
+        );
+
+        return new Metadata($data);
     }
 
     /**

--- a/core-bundle/src/Image/Studio/FigureBuilder.php
+++ b/core-bundle/src/Image/Studio/FigureBuilder.php
@@ -19,6 +19,7 @@ use Contao\Image\ImageInterface;
 use Contao\Image\PictureConfiguration;
 use Contao\Image\ResizeOptions;
 use Contao\PageModel;
+use Contao\StringUtil;
 use Contao\Validator;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\Filesystem\Filesystem;
@@ -584,8 +585,18 @@ class FigureBuilder
             return null;
         }
 
+        $getUuid = static function (?FilesModel $filesModel): ?string {
+            if (null === $filesModel || null === $filesModel->uuid) {
+                return null;
+            }
+
+            // Normalize UUID to ASCII format
+            return Validator::isBinaryUuid($filesModel->uuid) ?
+                StringUtil::binToUuid($filesModel->uuid) : $filesModel->uuid;
+        };
+
         $fileReferenceData = array_filter([
-            Metadata::VALUE_UUID => null !== $this->filesModel ? $this->filesModel->uuid : null,
+            Metadata::VALUE_UUID => $getUuid($this->filesModel),
         ]);
 
         if (null !== $this->metadata) {

--- a/core-bundle/src/Image/Studio/FigureBuilder.php
+++ b/core-bundle/src/Image/Studio/FigureBuilder.php
@@ -591,18 +591,15 @@ class FigureBuilder
             }
 
             // Normalize UUID to ASCII format
-            return Validator::isBinaryUuid($filesModel->uuid) ?
-                StringUtil::binToUuid($filesModel->uuid) : $filesModel->uuid;
+            return Validator::isBinaryUuid($filesModel->uuid)
+                ? StringUtil::binToUuid($filesModel->uuid)
+                : $filesModel->uuid;
         };
 
-        $fileReferenceData = array_filter([
-            Metadata::VALUE_UUID => $getUuid($this->filesModel),
-        ]);
+        $fileReferenceData = array_filter([Metadata::VALUE_UUID => $getUuid($this->filesModel)]);
 
         if (null !== $this->metadata) {
-            return $this->metadata
-                ->with($fileReferenceData)
-            ;
+            return $this->metadata->with($fileReferenceData);
         }
 
         if (null === $this->filesModel) {
@@ -617,8 +614,8 @@ class FigureBuilder
             return $metadata->with($fileReferenceData);
         }
 
-        // If no metadata can be obtained from the model, we create a
-        // container from the default meta fields with empty values instead
+        // If no metadata can be obtained from the model, we create a container
+        // from the default meta fields with empty values instead
         $metaFields = $this->filesModelAdapter()->getMetaFields();
 
         $data = array_merge(

--- a/core-bundle/tests/File/MetadataTest.php
+++ b/core-bundle/tests/File/MetadataTest.php
@@ -185,4 +185,31 @@ class MetadataTest extends TestCase
             'return null if no metadata is available for a locale'
         );
     }
+
+    public function testMergesMetadata(): void
+    {
+        $metadata = new Metadata(['foo' => 'FOO', 'bar' => 'BAR']);
+
+        $newMetadata = $metadata->with(['foobar' => 'FOOBAR', 'bar' => 'BAZ']);
+
+        $this->assertNotSame($metadata, $newMetadata, 'Should be a different instance.');
+
+        $this->assertSame(
+            [
+                'foo' => 'FOO',
+                'bar' => 'BAZ',
+                'foobar' => 'FOOBAR',
+            ],
+            $newMetadata->all()
+        );
+    }
+
+    public function testDoesNotCreateANewInstanceWhenMergingEmptyMetadata(): void
+    {
+        $metadata = new Metadata(['foo' => 'FOO', 'bar' => 'BAR']);
+
+        $newMetadata = $metadata->with([]);
+
+        $this->assertSame($metadata, $newMetadata, 'Should be the same instance.');
+    }
 }

--- a/core-bundle/tests/File/MetadataTest.php
+++ b/core-bundle/tests/File/MetadataTest.php
@@ -38,6 +38,7 @@ class MetadataTest extends TestCase
             Metadata::VALUE_CAPTION => 'caption',
             Metadata::VALUE_TITLE => 'title',
             Metadata::VALUE_URL => 'url',
+            Metadata::VALUE_UUID => '1234-5678',
             'foo' => 'bar',
         ]);
 
@@ -55,6 +56,7 @@ class MetadataTest extends TestCase
                 Metadata::VALUE_CAPTION => 'caption',
                 Metadata::VALUE_TITLE => 'title',
                 Metadata::VALUE_URL => 'url',
+                Metadata::VALUE_UUID => '1234-5678',
                 'foo' => 'bar',
             ],
             $metadata->all()

--- a/core-bundle/tests/File/MetadataTest.php
+++ b/core-bundle/tests/File/MetadataTest.php
@@ -191,7 +191,6 @@ class MetadataTest extends TestCase
     public function testMergesMetadata(): void
     {
         $metadata = new Metadata(['foo' => 'FOO', 'bar' => 'BAR']);
-
         $newMetadata = $metadata->with(['foobar' => 'FOOBAR', 'bar' => 'BAZ']);
 
         $this->assertNotSame($metadata, $newMetadata, 'Should be a different instance.');
@@ -209,7 +208,6 @@ class MetadataTest extends TestCase
     public function testDoesNotCreateANewInstanceWhenMergingEmptyMetadata(): void
     {
         $metadata = new Metadata(['foo' => 'FOO', 'bar' => 'BAR']);
-
         $newMetadata = $metadata->with([]);
 
         $this->assertSame($metadata, $newMetadata, 'Should be the same instance.');

--- a/core-bundle/tests/Image/Studio/FigureBuilderTest.php
+++ b/core-bundle/tests/Image/Studio/FigureBuilderTest.php
@@ -14,6 +14,7 @@ namespace Contao\CoreBundle\Tests\Image\Studio;
 
 use Contao\CoreBundle\Exception\InvalidResourceException;
 use Contao\CoreBundle\File\Metadata;
+use Contao\CoreBundle\Framework\Adapter;
 use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\CoreBundle\Image\Studio\Figure;
 use Contao\CoreBundle\Image\Studio\FigureBuilder;
@@ -25,6 +26,7 @@ use Contao\FilesModel;
 use Contao\Image\ImageInterface;
 use Contao\Image\ResizeOptions;
 use Contao\PageModel;
+use Contao\StringUtil;
 use Contao\System;
 use Contao\Validator;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -693,6 +695,137 @@ class FigureBuilderTest extends TestCase
 
         // Note: $GLOBALS['objPage'] is not set at this point
         $this->assertSame($emptyMetadata, $figure->getMetadata()->all());
+    }
+
+    /**
+     * @dataProvider provideUuidMetadataAutoFetchCases
+     */
+    public function testAutoSetUuidFromFilesModelWhenDefiningMetadata($resource, ?Metadata $metadataToSet, ?string $locale, array $expectedMetadata): void
+    {
+        $container = $this->getContainerWithContaoConfiguration();
+        $container->set('request_stack', $this->createMock(RequestStack::class));
+
+        System::setContainer($container);
+
+        $GLOBALS['TL_DCA']['tl_files']['fields']['meta']['eval']['metaFields'] = ['title' => ''];
+
+        /** @var PageModel&MockObject $currentPage */
+        $currentPage = $this->mockClassWithProperties(PageModel::class);
+        $currentPage->language = 'en';
+        $currentPage->rootFallbackLanguage = 'de';
+
+        $GLOBALS['objPage'] = $currentPage;
+
+        [$absoluteFilePath] = $this->getTestFilePaths();
+
+        $filesModelAdapter = $this->mockAdapter(['getMetaFields', 'findByPath']);
+        $filesModelAdapter
+            ->method('getMetaFields')
+            ->willReturn(array_keys($GLOBALS['TL_DCA']['tl_files']['fields']['meta']['eval']['metaFields']))
+        ;
+
+        $filesModelAdapter
+            ->method('findByPath')
+            ->willReturn(null)
+        ;
+
+        $framework = $this->mockContaoFramework([
+            FilesModel::class => $filesModelAdapter,
+            Validator::class => new Adapter(Validator::class),
+        ]);
+
+        $studio = $this->getStudioMockForImage($absoluteFilePath);
+
+        $figure = $this->getFigureBuilder($studio, $framework)
+            ->from($resource)
+            ->setMetadata($metadataToSet)
+            ->setLocale($locale)
+            ->build()
+        ;
+
+        $this->assertSame($expectedMetadata, $figure->getMetadata()->all());
+
+        unset($GLOBALS['TL_DCA'], $GLOBALS['objPage']);
+    }
+
+    public function provideUuidMetadataAutoFetchCases(): \Generator
+    {
+        [$absoluteFilePath, $relativeFilePath] = $this->getTestFilePaths();
+
+        $getFilesModel = static function (array $metaData, ?string $uuid) use ($relativeFilePath) {
+            /** @var FilesModel $filesModel */
+            $filesModel = (new \ReflectionClass(FilesModel::class))->newInstanceWithoutConstructor();
+
+            $filesModel->setRow([
+                'type' => 'file',
+                'path' => $relativeFilePath,
+                'meta' => serialize($metaData),
+                'uuid' => $uuid,
+            ]);
+
+            return $filesModel;
+        };
+
+        yield 'explicitly set metadata without files model' => [
+            $absoluteFilePath,
+            new Metadata(['foo' => 'bar']),
+            'de',
+            ['foo' => 'bar'],
+        ];
+
+        yield 'explicitly set metadata with files model (no uuid)' => [
+            $getFilesModel(['foobar' => 'baz'], null),
+            new Metadata(['foo' => 'bar']),
+            'de',
+            ['foo' => 'bar'],
+        ];
+
+        yield 'explicitly set metadata with files model (ASCII uuid)' => [
+            $getFilesModel(
+                ['foobar' => 'baz'],
+                'beefaff3-434a-106e-8ff0-f0b59095e5a1'
+            ),
+            new Metadata(['foo' => 'bar']),
+            'de',
+            ['foo' => 'bar', Metadata::VALUE_UUID => 'beefaff3-434a-106e-8ff0-f0b59095e5a1'],
+        ];
+
+        yield 'explicitly set metadata with files model (binary uuid)' => [
+            $getFilesModel(
+                ['foobar' => 'baz'],
+                StringUtil::uuidToBin('beefaff3-434a-106e-8ff0-f0b59095e5a1')
+            ),
+            new Metadata(['foo' => 'bar']),
+            'de',
+            ['foo' => 'bar', Metadata::VALUE_UUID => 'beefaff3-434a-106e-8ff0-f0b59095e5a1'],
+        ];
+
+        yield 'metadata from files model in a matching locale' => [
+            $getFilesModel(
+                ['en' => ['foo' => 'bar']],
+                'beefaff3-434a-106e-8ff0-f0b59095e5a1'
+            ),
+            null,
+            'en',
+            [
+                Metadata::VALUE_TITLE => '',
+                'foo' => 'bar',
+                Metadata::VALUE_UUID => 'beefaff3-434a-106e-8ff0-f0b59095e5a1',
+            ],
+        ];
+
+        yield 'default metadata from meta fields' => [
+            $getFilesModel(
+                ['en' => ['foo' => 'bar']],
+                'beefaff3-434a-106e-8ff0-f0b59095e5a1'
+            ),
+            null,
+            'es',
+            [
+                Metadata::VALUE_TITLE => '',
+                Metadata::VALUE_UUID => 'beefaff3-434a-106e-8ff0-f0b59095e5a1',
+            ],
+        ];
     }
 
     public function testSetLinkAttribute(): void

--- a/core-bundle/tests/Image/Studio/FigureBuilderTest.php
+++ b/core-bundle/tests/Image/Studio/FigureBuilderTest.php
@@ -781,30 +781,21 @@ class FigureBuilderTest extends TestCase
         ];
 
         yield 'explicitly set metadata with files model (ASCII uuid)' => [
-            $getFilesModel(
-                ['foobar' => 'baz'],
-                'beefaff3-434a-106e-8ff0-f0b59095e5a1'
-            ),
+            $getFilesModel(['foobar' => 'baz'], 'beefaff3-434a-106e-8ff0-f0b59095e5a1'),
             new Metadata(['foo' => 'bar']),
             'de',
             ['foo' => 'bar', Metadata::VALUE_UUID => 'beefaff3-434a-106e-8ff0-f0b59095e5a1'],
         ];
 
         yield 'explicitly set metadata with files model (binary uuid)' => [
-            $getFilesModel(
-                ['foobar' => 'baz'],
-                StringUtil::uuidToBin('beefaff3-434a-106e-8ff0-f0b59095e5a1')
-            ),
+            $getFilesModel(['foobar' => 'baz'], StringUtil::uuidToBin('beefaff3-434a-106e-8ff0-f0b59095e5a1')),
             new Metadata(['foo' => 'bar']),
             'de',
             ['foo' => 'bar', Metadata::VALUE_UUID => 'beefaff3-434a-106e-8ff0-f0b59095e5a1'],
         ];
 
         yield 'metadata from files model in a matching locale' => [
-            $getFilesModel(
-                ['en' => ['foo' => 'bar']],
-                'beefaff3-434a-106e-8ff0-f0b59095e5a1'
-            ),
+            $getFilesModel(['en' => ['foo' => 'bar']], 'beefaff3-434a-106e-8ff0-f0b59095e5a1'),
             null,
             'en',
             [
@@ -815,10 +806,7 @@ class FigureBuilderTest extends TestCase
         ];
 
         yield 'default metadata from meta fields' => [
-            $getFilesModel(
-                ['en' => ['foo' => 'bar']],
-                'beefaff3-434a-106e-8ff0-f0b59095e5a1'
-            ),
+            $getFilesModel(['en' => ['foo' => 'bar']], 'beefaff3-434a-106e-8ff0-f0b59095e5a1'),
             null,
             'es',
             [

--- a/tools/ecs/composer.lock
+++ b/tools/ecs/composer.lock
@@ -8,23 +8,23 @@
     "packages": [
         {
             "name": "contao/easy-coding-standard",
-            "version": "3.2.0",
+            "version": "3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/contao/easy-coding-standard.git",
-                "reference": "688b5b157788e0a29407dff844f6b5818ca520fe"
+                "reference": "9b96c3260349c306816b4a39baef917138a50114"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/contao/easy-coding-standard/zipball/688b5b157788e0a29407dff844f6b5818ca520fe",
-                "reference": "688b5b157788e0a29407dff844f6b5818ca520fe",
+                "url": "https://api.github.com/repos/contao/easy-coding-standard/zipball/9b96c3260349c306816b4a39baef917138a50114",
+                "reference": "9b96c3260349c306816b4a39baef917138a50114",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.3 || ^8.0",
                 "slevomat/coding-standard": "^6.4",
-                "symplify/coding-standard": "^9.0",
-                "symplify/easy-coding-standard": "^9.0"
+                "symplify/coding-standard": "^9.3.3",
+                "symplify/easy-coding-standard": "^9.3.3"
             },
             "require-dev": {
                 "phpunit/phpunit": "^8.5"
@@ -48,9 +48,9 @@
             "description": "EasyCodingStandard configurations for Contao",
             "support": {
                 "issues": "https://github.com/contao/easy-coding-standard/issues",
-                "source": "https://github.com/contao/easy-coding-standard/tree/3.2.0"
+                "source": "https://github.com/contao/easy-coding-standard/tree/3.2.1"
             },
-            "time": "2021-05-13T13:23:51+00:00"
+            "time": "2021-05-21T16:17:40+00:00"
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
@@ -711,16 +711,16 @@
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v5.2.8",
+            "version": "v5.2.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "024e929da5a994cbab0ce2291d332f7edf926acf"
+                "reference": "2761ca2f7e2f41af3a45951e1ce8c01f121245eb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/024e929da5a994cbab0ce2291d332f7edf926acf",
-                "reference": "024e929da5a994cbab0ce2291d332f7edf926acf",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/2761ca2f7e2f41af3a45951e1ce8c01f121245eb",
+                "reference": "2761ca2f7e2f41af3a45951e1ce8c01f121245eb",
                 "shasum": ""
             },
             "require": {
@@ -778,7 +778,7 @@
             "description": "Allows you to standardize and centralize the way objects are constructed in your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/dependency-injection/tree/v5.2.8"
+                "source": "https://github.com/symfony/dependency-injection/tree/v5.2.9"
             },
             "funding": [
                 {
@@ -794,7 +794,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-11T16:07:35+00:00"
+            "time": "2021-05-16T13:07:46+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -1160,16 +1160,16 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v5.2.8",
+            "version": "v5.2.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "eccb8be70d7a6a2230d05f6ecede40f3fdd9e252"
+                "reference": "ccccb9d48ca42757dd12f2ca4bf857a4e217d90d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/eccb8be70d7a6a2230d05f6ecede40f3fdd9e252",
-                "reference": "eccb8be70d7a6a2230d05f6ecede40f3fdd9e252",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/ccccb9d48ca42757dd12f2ca4bf857a4e217d90d",
+                "reference": "ccccb9d48ca42757dd12f2ca4bf857a4e217d90d",
                 "shasum": ""
             },
             "require": {
@@ -1201,7 +1201,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v5.2.8"
+                "source": "https://github.com/symfony/finder/tree/v5.2.9"
             },
             "funding": [
                 {
@@ -1217,7 +1217,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-10T14:39:23+00:00"
+            "time": "2021-05-16T13:07:46+00:00"
         },
         {
             "name": "symfony/http-client-contracts",
@@ -1372,16 +1372,16 @@
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v5.2.8",
+            "version": "v5.2.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "c3cb71ee7e2d3eae5fe1001f81780d6a49b37937"
+                "reference": "eb540ef6870dbf33c92e372cfb869ebf9649e6cb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/c3cb71ee7e2d3eae5fe1001f81780d6a49b37937",
-                "reference": "c3cb71ee7e2d3eae5fe1001f81780d6a49b37937",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/eb540ef6870dbf33c92e372cfb869ebf9649e6cb",
+                "reference": "eb540ef6870dbf33c92e372cfb869ebf9649e6cb",
                 "shasum": ""
             },
             "require": {
@@ -1464,7 +1464,7 @@
             "description": "Provides a structured process for converting a Request into a Response",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-kernel/tree/v5.2.8"
+                "source": "https://github.com/symfony/http-kernel/tree/v5.2.9"
             },
             "funding": [
                 {
@@ -1480,7 +1480,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-12T13:27:53+00:00"
+            "time": "2021-05-19T12:23:45+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -2220,23 +2220,23 @@
         },
         {
             "name": "symplify/autowire-array-parameter",
-            "version": "v9.3.11",
+            "version": "v9.3.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symplify/autowire-array-parameter.git",
-                "reference": "269fcb76ed64ca1e9dd0abe6c13273be8dfba64c"
+                "reference": "da3dda1dc42d868ed2005933d1e4efc601c15051"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symplify/autowire-array-parameter/zipball/269fcb76ed64ca1e9dd0abe6c13273be8dfba64c",
-                "reference": "269fcb76ed64ca1e9dd0abe6c13273be8dfba64c",
+                "url": "https://api.github.com/repos/symplify/autowire-array-parameter/zipball/da3dda1dc42d868ed2005933d1e4efc601c15051",
+                "reference": "da3dda1dc42d868ed2005933d1e4efc601c15051",
                 "shasum": ""
             },
             "require": {
                 "nette/utils": "^3.2",
                 "php": ">=7.3",
                 "symfony/dependency-injection": "^5.2",
-                "symplify/package-builder": "^9.3.11"
+                "symplify/package-builder": "^9.3.14"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5"
@@ -2258,7 +2258,7 @@
             ],
             "description": "Autowire array parameters for your Symfony applications",
             "support": {
-                "source": "https://github.com/symplify/autowire-array-parameter/tree/v9.3.11"
+                "source": "https://github.com/symplify/autowire-array-parameter/tree/v9.3.14"
             },
             "funding": [
                 {
@@ -2270,30 +2270,30 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-05-13T11:33:56+00:00"
+            "time": "2021-05-21T11:18:54+00:00"
         },
         {
             "name": "symplify/coding-standard",
-            "version": "v9.3.11",
+            "version": "v9.3.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symplify/coding-standard.git",
-                "reference": "b329c794af006f0890b1ab42143431f95bbb0874"
+                "reference": "d4dae53b316372c7b4fed984758dee69cd15c6ef"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symplify/coding-standard/zipball/b329c794af006f0890b1ab42143431f95bbb0874",
-                "reference": "b329c794af006f0890b1ab42143431f95bbb0874",
+                "url": "https://api.github.com/repos/symplify/coding-standard/zipball/d4dae53b316372c7b4fed984758dee69cd15c6ef",
+                "reference": "d4dae53b316372c7b4fed984758dee69cd15c6ef",
                 "shasum": ""
             },
             "require": {
                 "friendsofphp/php-cs-fixer": "^3.0",
                 "nette/utils": "^3.2",
                 "php": ">=7.3",
-                "symplify/autowire-array-parameter": "^9.3.11",
-                "symplify/package-builder": "^9.3.11",
-                "symplify/rule-doc-generator-contracts": "^9.3.11",
-                "symplify/symplify-kernel": "^9.3.11"
+                "symplify/autowire-array-parameter": "^9.3.14",
+                "symplify/package-builder": "^9.3.14",
+                "symplify/rule-doc-generator-contracts": "^9.3.14",
+                "symplify/symplify-kernel": "^9.3.14"
             },
             "require-dev": {
                 "doctrine/orm": "^2.7",
@@ -2302,10 +2302,10 @@
                 "phpunit/phpunit": "^9.5",
                 "symfony/framework-bundle": "^4.4|^5.2",
                 "symfony/http-kernel": "^4.4|^5.2",
-                "symplify/easy-coding-standard-tester": "^9.3.11",
-                "symplify/php-config-printer": "^9.3.11",
-                "symplify/rule-doc-generator": "^9.3.11",
-                "symplify/smart-file-system": "^9.3.11"
+                "symplify/easy-coding-standard-tester": "^9.3.14",
+                "symplify/php-config-printer": "^9.3.14",
+                "symplify/rule-doc-generator": "^9.3.14",
+                "symplify/smart-file-system": "^9.3.14"
             },
             "type": "library",
             "extra": {
@@ -2324,7 +2324,7 @@
             ],
             "description": "Set of Symplify rules for PHP_CodeSniffer and PHP CS Fixer.",
             "support": {
-                "source": "https://github.com/symplify/coding-standard/tree/v9.3.11"
+                "source": "https://github.com/symplify/coding-standard/tree/v9.3.14"
             },
             "funding": [
                 {
@@ -2336,20 +2336,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-05-13T11:33:58+00:00"
+            "time": "2021-05-21T11:18:54+00:00"
         },
         {
             "name": "symplify/composer-json-manipulator",
-            "version": "v9.3.11",
+            "version": "v9.3.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symplify/composer-json-manipulator.git",
-                "reference": "87a675a761aa5df90f5d5cf2c7d49d1e7e7a91be"
+                "reference": "7545c13ea35e83b70ffa92d0fff98eb70c8c6b93"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symplify/composer-json-manipulator/zipball/87a675a761aa5df90f5d5cf2c7d49d1e7e7a91be",
-                "reference": "87a675a761aa5df90f5d5cf2c7d49d1e7e7a91be",
+                "url": "https://api.github.com/repos/symplify/composer-json-manipulator/zipball/7545c13ea35e83b70ffa92d0fff98eb70c8c6b93",
+                "reference": "7545c13ea35e83b70ffa92d0fff98eb70c8c6b93",
                 "shasum": ""
             },
             "require": {
@@ -2359,8 +2359,8 @@
                 "symfony/dependency-injection": "^5.2",
                 "symfony/filesystem": "^4.4|^5.2",
                 "symfony/http-kernel": "^4.4|^5.2",
-                "symplify/package-builder": "^9.3.11",
-                "symplify/smart-file-system": "^9.3.11"
+                "symplify/package-builder": "^9.3.14",
+                "symplify/smart-file-system": "^9.3.14"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5"
@@ -2382,7 +2382,7 @@
             ],
             "description": "Package to load, merge and save composer.json file(s)",
             "support": {
-                "source": "https://github.com/symplify/composer-json-manipulator/tree/v9.3.11"
+                "source": "https://github.com/symplify/composer-json-manipulator/tree/v9.3.14"
             },
             "funding": [
                 {
@@ -2394,32 +2394,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-05-13T11:33:58+00:00"
+            "time": "2021-05-21T11:18:52+00:00"
         },
         {
             "name": "symplify/console-package-builder",
-            "version": "v9.3.11",
+            "version": "v9.3.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symplify/console-package-builder.git",
-                "reference": "4fd36633c3607f74a21eee5bd32c00f24130261f"
+                "reference": "8b41a17553dcd0eac335f2c0ee4e147354def504"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symplify/console-package-builder/zipball/4fd36633c3607f74a21eee5bd32c00f24130261f",
-                "reference": "4fd36633c3607f74a21eee5bd32c00f24130261f",
+                "url": "https://api.github.com/repos/symplify/console-package-builder/zipball/8b41a17553dcd0eac335f2c0ee4e147354def504",
+                "reference": "8b41a17553dcd0eac335f2c0ee4e147354def504",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.3",
                 "symfony/console": "^4.4|^5.2",
                 "symfony/dependency-injection": "^5.2",
-                "symplify/symplify-kernel": "^9.3.11"
+                "symplify/symplify-kernel": "^9.3.14"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5",
                 "symfony/http-kernel": "^4.4|^5.2",
-                "symplify/package-builder": "^9.3.11"
+                "symplify/package-builder": "^9.3.14"
             },
             "type": "library",
             "extra": {
@@ -2438,22 +2438,22 @@
             ],
             "description": "Package to speed up building command line applications",
             "support": {
-                "source": "https://github.com/symplify/console-package-builder/tree/v9.3.11"
+                "source": "https://github.com/symplify/console-package-builder/tree/v9.3.14"
             },
-            "time": "2021-05-13T11:33:59+00:00"
+            "time": "2021-05-21T11:18:51+00:00"
         },
         {
             "name": "symplify/easy-coding-standard",
-            "version": "v9.3.11",
+            "version": "v9.3.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symplify/easy-coding-standard.git",
-                "reference": "634da6abea9e7f9b4489d8bd313227c968c94d2c"
+                "reference": "a384f5bc3e3b4c9c62fcbb9544606280bc3e67b3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symplify/easy-coding-standard/zipball/634da6abea9e7f9b4489d8bd313227c968c94d2c",
-                "reference": "634da6abea9e7f9b4489d8bd313227c968c94d2c",
+                "url": "https://api.github.com/repos/symplify/easy-coding-standard/zipball/a384f5bc3e3b4c9c62fcbb9544606280bc3e67b3",
+                "reference": "a384f5bc3e3b4c9c62fcbb9544606280bc3e67b3",
                 "shasum": ""
             },
             "require": {
@@ -2471,13 +2471,18 @@
                 "bin/ecs"
             ],
             "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
             "description": "Prefixed scoped version of ECS package",
             "support": {
-                "source": "https://github.com/symplify/easy-coding-standard/tree/v9.3.11"
+                "source": "https://github.com/symplify/easy-coding-standard/tree/v9.3.14"
             },
             "funding": [
                 {
@@ -2489,20 +2494,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-05-13T11:38:11+00:00"
+            "time": "2021-05-21T11:22:15+00:00"
         },
         {
             "name": "symplify/easy-testing",
-            "version": "v9.3.11",
+            "version": "v9.3.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symplify/easy-testing.git",
-                "reference": "5662ac6e55dca7d7ae7df0b47e84a165573359ed"
+                "reference": "3732986315e0dc58a8eae818853d8ecf167903c2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symplify/easy-testing/zipball/5662ac6e55dca7d7ae7df0b47e84a165573359ed",
-                "reference": "5662ac6e55dca7d7ae7df0b47e84a165573359ed",
+                "url": "https://api.github.com/repos/symplify/easy-testing/zipball/3732986315e0dc58a8eae818853d8ecf167903c2",
+                "reference": "3732986315e0dc58a8eae818853d8ecf167903c2",
                 "shasum": ""
             },
             "require": {
@@ -2512,10 +2517,10 @@
                 "symfony/dependency-injection": "^5.2",
                 "symfony/finder": "^4.4|^5.2",
                 "symfony/http-kernel": "^4.4|^5.2",
-                "symplify/console-package-builder": "^9.3.11",
-                "symplify/package-builder": "^9.3.11",
-                "symplify/smart-file-system": "^9.3.11",
-                "symplify/symplify-kernel": "^9.3.11"
+                "symplify/console-package-builder": "^9.3.14",
+                "symplify/package-builder": "^9.3.14",
+                "symplify/smart-file-system": "^9.3.14",
+                "symplify/symplify-kernel": "^9.3.14"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5"
@@ -2540,7 +2545,7 @@
             ],
             "description": "Testing made easy",
             "support": {
-                "source": "https://github.com/symplify/easy-testing/tree/v9.3.11"
+                "source": "https://github.com/symplify/easy-testing/tree/v9.3.14"
             },
             "funding": [
                 {
@@ -2552,20 +2557,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-05-13T11:34:12+00:00"
+            "time": "2021-05-21T11:18:57+00:00"
         },
         {
             "name": "symplify/package-builder",
-            "version": "v9.3.11",
+            "version": "v9.3.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symplify/package-builder.git",
-                "reference": "479752e9b19efbd0470aba8e92b9d6a01722430b"
+                "reference": "d6795f196e35945fa00619c872012b3b1c014ec5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symplify/package-builder/zipball/479752e9b19efbd0470aba8e92b9d6a01722430b",
-                "reference": "479752e9b19efbd0470aba8e92b9d6a01722430b",
+                "url": "https://api.github.com/repos/symplify/package-builder/zipball/d6795f196e35945fa00619c872012b3b1c014ec5",
+                "reference": "d6795f196e35945fa00619c872012b3b1c014ec5",
                 "shasum": ""
             },
             "require": {
@@ -2577,8 +2582,8 @@
                 "symfony/dependency-injection": "^5.2",
                 "symfony/finder": "^4.4|^5.2",
                 "symfony/http-kernel": "^4.4|^5.2",
-                "symplify/easy-testing": "^9.3.11",
-                "symplify/symplify-kernel": "^9.3.11"
+                "symplify/easy-testing": "^9.3.14",
+                "symplify/symplify-kernel": "^9.3.14"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5"
@@ -2600,7 +2605,7 @@
             ],
             "description": "Dependency Injection, Console and Kernel toolkit for Symplify packages.",
             "support": {
-                "source": "https://github.com/symplify/package-builder/tree/v9.3.11"
+                "source": "https://github.com/symplify/package-builder/tree/v9.3.14"
             },
             "funding": [
                 {
@@ -2612,20 +2617,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-05-13T11:34:38+00:00"
+            "time": "2021-05-21T11:19:31+00:00"
         },
         {
             "name": "symplify/rule-doc-generator-contracts",
-            "version": "v9.3.11",
+            "version": "v9.3.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symplify/rule-doc-generator-contracts.git",
-                "reference": "06f23a3bfe1426030c4032e99665472a229d5b43"
+                "reference": "75bda667533565fe72ddee131234851f1893e091"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symplify/rule-doc-generator-contracts/zipball/06f23a3bfe1426030c4032e99665472a229d5b43",
-                "reference": "06f23a3bfe1426030c4032e99665472a229d5b43",
+                "url": "https://api.github.com/repos/symplify/rule-doc-generator-contracts/zipball/75bda667533565fe72ddee131234851f1893e091",
+                "reference": "75bda667533565fe72ddee131234851f1893e091",
                 "shasum": ""
             },
             "require": {
@@ -2649,7 +2654,7 @@
             ],
             "description": "Contracts for production code of RuleDocGenerator",
             "support": {
-                "source": "https://github.com/symplify/rule-doc-generator-contracts/tree/v9.3.11"
+                "source": "https://github.com/symplify/rule-doc-generator-contracts/tree/v9.3.14"
             },
             "funding": [
                 {
@@ -2661,20 +2666,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-05-11T13:31:15+00:00"
+            "time": "2021-05-20T20:17:13+00:00"
         },
         {
             "name": "symplify/smart-file-system",
-            "version": "v9.3.11",
+            "version": "v9.3.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symplify/smart-file-system.git",
-                "reference": "aafc000f17d9f4b2d1274115095e3cbc2c32d63d"
+                "reference": "a2a8d39fe46b01ead8d2af7368b0b36b68fac979"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symplify/smart-file-system/zipball/aafc000f17d9f4b2d1274115095e3cbc2c32d63d",
-                "reference": "aafc000f17d9f4b2d1274115095e3cbc2c32d63d",
+                "url": "https://api.github.com/repos/symplify/smart-file-system/zipball/a2a8d39fe46b01ead8d2af7368b0b36b68fac979",
+                "reference": "a2a8d39fe46b01ead8d2af7368b0b36b68fac979",
                 "shasum": ""
             },
             "require": {
@@ -2704,7 +2709,7 @@
             ],
             "description": "Sanitized FileInfo with safe getRealPath() and other handy methods",
             "support": {
-                "source": "https://github.com/symplify/smart-file-system/tree/v9.3.11"
+                "source": "https://github.com/symplify/smart-file-system/tree/v9.3.14"
             },
             "funding": [
                 {
@@ -2716,20 +2721,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-05-11T13:30:32+00:00"
+            "time": "2021-05-20T20:16:49+00:00"
         },
         {
             "name": "symplify/symplify-kernel",
-            "version": "v9.3.11",
+            "version": "v9.3.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symplify/symplify-kernel.git",
-                "reference": "d79a26c90ebd292d8b474dbee26b602379be3f66"
+                "reference": "6f08d14763b255373cd8edc6e53529965e086713"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symplify/symplify-kernel/zipball/d79a26c90ebd292d8b474dbee26b602379be3f66",
-                "reference": "d79a26c90ebd292d8b474dbee26b602379be3f66",
+                "url": "https://api.github.com/repos/symplify/symplify-kernel/zipball/6f08d14763b255373cd8edc6e53529965e086713",
+                "reference": "6f08d14763b255373cd8edc6e53529965e086713",
                 "shasum": ""
             },
             "require": {
@@ -2737,10 +2742,10 @@
                 "symfony/console": "^4.4|^5.2",
                 "symfony/dependency-injection": "^5.2",
                 "symfony/http-kernel": "^4.4|^5.2",
-                "symplify/autowire-array-parameter": "^9.3.11",
-                "symplify/composer-json-manipulator": "^9.3.11",
-                "symplify/package-builder": "^9.3.11",
-                "symplify/smart-file-system": "^9.3.11"
+                "symplify/autowire-array-parameter": "^9.3.14",
+                "symplify/composer-json-manipulator": "^9.3.14",
+                "symplify/package-builder": "^9.3.14",
+                "symplify/smart-file-system": "^9.3.14"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5"
@@ -2762,9 +2767,9 @@
             ],
             "description": "Internal Kernel for Symplify packages",
             "support": {
-                "source": "https://github.com/symplify/symplify-kernel/tree/v9.3.11"
+                "source": "https://github.com/symplify/symplify-kernel/tree/v9.3.14"
             },
-            "time": "2021-05-13T11:35:17+00:00"
+            "time": "2021-05-21T11:20:06+00:00"
         }
     ],
     "packages-dev": [],

--- a/tools/phpstan/composer.lock
+++ b/tools/phpstan/composer.lock
@@ -64,16 +64,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "0.12.87",
+            "version": "0.12.88",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "d464e00776afb711f419faffa96826dc02e4d145"
+                "reference": "464d1a81af49409c41074aa6640ed0c4cbd9bb68"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/d464e00776afb711f419faffa96826dc02e4d145",
-                "reference": "d464e00776afb711f419faffa96826dc02e4d145",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/464d1a81af49409c41074aa6640ed0c4cbd9bb68",
+                "reference": "464d1a81af49409c41074aa6640ed0c4cbd9bb68",
                 "shasum": ""
             },
             "require": {
@@ -104,7 +104,7 @@
             "description": "PHPStan - PHP Static Analysis Tool",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan/issues",
-                "source": "https://github.com/phpstan/phpstan/tree/0.12.87"
+                "source": "https://github.com/phpstan/phpstan/tree/0.12.88"
             },
             "funding": [
                 {
@@ -120,7 +120,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-12T15:17:52+00:00"
+            "time": "2021-05-17T12:24:49+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",

--- a/tools/psalm/composer.lock
+++ b/tools/psalm/composer.lock
@@ -1235,16 +1235,16 @@
         },
         {
             "name": "symfony/cache",
-            "version": "v5.2.8",
+            "version": "v5.2.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/cache.git",
-                "reference": "c13bfc6682a669e6ba592ba3305139ebf946a811"
+                "reference": "17a6d585603fade3838bc692548b619d97ded67e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/cache/zipball/c13bfc6682a669e6ba592ba3305139ebf946a811",
-                "reference": "c13bfc6682a669e6ba592ba3305139ebf946a811",
+                "url": "https://api.github.com/repos/symfony/cache/zipball/17a6d585603fade3838bc692548b619d97ded67e",
+                "reference": "17a6d585603fade3838bc692548b619d97ded67e",
                 "shasum": ""
             },
             "require": {
@@ -1269,7 +1269,7 @@
             },
             "require-dev": {
                 "cache/integration-tests": "dev-master",
-                "doctrine/cache": "^1.6",
+                "doctrine/cache": "^1.6|^2.0",
                 "doctrine/dbal": "^2.10|^3.0",
                 "predis/predis": "^1.1",
                 "psr/simple-cache": "^1.0",
@@ -1310,7 +1310,7 @@
                 "psr6"
             ],
             "support": {
-                "source": "https://github.com/symfony/cache/tree/v5.2.8"
+                "source": "https://github.com/symfony/cache/tree/v5.2.9"
             },
             "funding": [
                 {
@@ -1326,7 +1326,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-07T13:41:16+00:00"
+            "time": "2021-05-17T19:35:40+00:00"
         },
         {
             "name": "symfony/cache-contracts",
@@ -1584,16 +1584,16 @@
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v5.2.8",
+            "version": "v5.2.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "024e929da5a994cbab0ce2291d332f7edf926acf"
+                "reference": "2761ca2f7e2f41af3a45951e1ce8c01f121245eb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/024e929da5a994cbab0ce2291d332f7edf926acf",
-                "reference": "024e929da5a994cbab0ce2291d332f7edf926acf",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/2761ca2f7e2f41af3a45951e1ce8c01f121245eb",
+                "reference": "2761ca2f7e2f41af3a45951e1ce8c01f121245eb",
                 "shasum": ""
             },
             "require": {
@@ -1651,7 +1651,7 @@
             "description": "Allows you to standardize and centralize the way objects are constructed in your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/dependency-injection/tree/v5.2.8"
+                "source": "https://github.com/symfony/dependency-injection/tree/v5.2.9"
             },
             "funding": [
                 {
@@ -1667,7 +1667,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-11T16:07:35+00:00"
+            "time": "2021-05-16T13:07:46+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -2033,16 +2033,16 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v5.2.8",
+            "version": "v5.2.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "eccb8be70d7a6a2230d05f6ecede40f3fdd9e252"
+                "reference": "ccccb9d48ca42757dd12f2ca4bf857a4e217d90d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/eccb8be70d7a6a2230d05f6ecede40f3fdd9e252",
-                "reference": "eccb8be70d7a6a2230d05f6ecede40f3fdd9e252",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/ccccb9d48ca42757dd12f2ca4bf857a4e217d90d",
+                "reference": "ccccb9d48ca42757dd12f2ca4bf857a4e217d90d",
                 "shasum": ""
             },
             "require": {
@@ -2074,7 +2074,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v5.2.8"
+                "source": "https://github.com/symfony/finder/tree/v5.2.9"
             },
             "funding": [
                 {
@@ -2090,27 +2090,27 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-10T14:39:23+00:00"
+            "time": "2021-05-16T13:07:46+00:00"
         },
         {
             "name": "symfony/framework-bundle",
-            "version": "v5.2.7",
+            "version": "v5.2.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/framework-bundle.git",
-                "reference": "af652965c2a598e192200c6932ab9edd283ffe42"
+                "reference": "81720c6e7740a99dc70d5eb2123bcdf3d5d113f1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/framework-bundle/zipball/af652965c2a598e192200c6932ab9edd283ffe42",
-                "reference": "af652965c2a598e192200c6932ab9edd283ffe42",
+                "url": "https://api.github.com/repos/symfony/framework-bundle/zipball/81720c6e7740a99dc70d5eb2123bcdf3d5d113f1",
+                "reference": "81720c6e7740a99dc70d5eb2123bcdf3d5d113f1",
                 "shasum": ""
             },
             "require": {
                 "ext-xml": "*",
                 "php": ">=7.2.5",
                 "symfony/cache": "^5.2",
-                "symfony/config": "^5.0",
+                "symfony/config": "~5.0.11|^5.1.3",
                 "symfony/dependency-injection": "^5.2",
                 "symfony/deprecation-contracts": "^2.1",
                 "symfony/error-handler": "^4.4.1|^5.0.1",
@@ -2152,7 +2152,7 @@
             },
             "require-dev": {
                 "doctrine/annotations": "^1.10.4",
-                "doctrine/cache": "~1.0",
+                "doctrine/cache": "^1.0|^2.0",
                 "doctrine/persistence": "^1.3|^2.0",
                 "paragonie/sodium_compat": "^1.8",
                 "phpdocumentor/reflection-docblock": "^3.0|^4.0|^5.0",
@@ -2223,7 +2223,7 @@
             "description": "Provides a tight integration between Symfony components and the Symfony full-stack framework",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/framework-bundle/tree/v5.2.7"
+                "source": "https://github.com/symfony/framework-bundle/tree/v5.2.9"
             },
             "funding": [
                 {
@@ -2239,7 +2239,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-04-16T17:21:25+00:00"
+            "time": "2021-05-19T11:52:18+00:00"
         },
         {
             "name": "symfony/http-client-contracts",
@@ -2394,16 +2394,16 @@
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v5.2.8",
+            "version": "v5.2.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "c3cb71ee7e2d3eae5fe1001f81780d6a49b37937"
+                "reference": "eb540ef6870dbf33c92e372cfb869ebf9649e6cb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/c3cb71ee7e2d3eae5fe1001f81780d6a49b37937",
-                "reference": "c3cb71ee7e2d3eae5fe1001f81780d6a49b37937",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/eb540ef6870dbf33c92e372cfb869ebf9649e6cb",
+                "reference": "eb540ef6870dbf33c92e372cfb869ebf9649e6cb",
                 "shasum": ""
             },
             "require": {
@@ -2486,7 +2486,7 @@
             "description": "Provides a structured process for converting a Request into a Response",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-kernel/tree/v5.2.8"
+                "source": "https://github.com/symfony/http-kernel/tree/v5.2.9"
             },
             "funding": [
                 {
@@ -2502,7 +2502,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-12T13:27:53+00:00"
+            "time": "2021-05-19T12:23:45+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -2992,16 +2992,16 @@
         },
         {
             "name": "symfony/routing",
-            "version": "v5.2.7",
+            "version": "v5.2.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "3f0cab2e95b5e92226f34c2c1aa969d3fc41f48c"
+                "reference": "4a7b2bf5e1221be1902b6853743a9bb317f6925e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/3f0cab2e95b5e92226f34c2c1aa969d3fc41f48c",
-                "reference": "3f0cab2e95b5e92226f34c2c1aa969d3fc41f48c",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/4a7b2bf5e1221be1902b6853743a9bb317f6925e",
+                "reference": "4a7b2bf5e1221be1902b6853743a9bb317f6925e",
                 "shasum": ""
             },
             "require": {
@@ -3061,7 +3061,7 @@
                 "url"
             ],
             "support": {
-                "source": "https://github.com/symfony/routing/tree/v5.2.7"
+                "source": "https://github.com/symfony/routing/tree/v5.2.9"
             },
             "funding": [
                 {
@@ -3077,7 +3077,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-04-11T22:55:21+00:00"
+            "time": "2021-05-16T13:07:46+00:00"
         },
         {
             "name": "symfony/service-contracts",


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #...
| Docs PR or issue | contao/docs#...

This PR adds a new `uuid` key to our file metadata, that gets set inside the `FigureBuilder` when it is defining meta data. 

As `Metadata` is immutable we now also have a `with()` method that allows merging by returning a new instance with the merged values. 