### PR TITLE
Dispatch an event to define metadata inside the FigureBuilder

### DIFF
--- a/core-bundle/src/Event/DefineMetadataEvent.php
+++ b/core-bundle/src/Event/DefineMetadataEvent.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Event;
+
+use Contao\CoreBundle\File\Metadata;
+
+class DefineMetadataEvent
+{
+    /**
+     * @var Metadata|null
+     */
+    private $metadata;
+
+    public function __construct(?Metadata $metadata)
+    {
+        $this->metadata = $metadata;
+    }
+
+    public function getMetadata(): ?Metadata
+    {
+        return $this->metadata;
+    }
+
+    public function setMetadata(?Metadata $metadata): void
+    {
+        $this->metadata = $metadata;
+    }
+}

--- a/core-bundle/src/Event/FileMetadataEvent.php
+++ b/core-bundle/src/Event/FileMetadataEvent.php
@@ -14,7 +14,7 @@ namespace Contao\CoreBundle\Event;
 
 use Contao\CoreBundle\File\Metadata;
 
-class DefineMetadataEvent
+class FileMetadataEvent
 {
     /**
      * @var Metadata|null

--- a/core-bundle/src/Image/Studio/FigureBuilder.php
+++ b/core-bundle/src/Image/Studio/FigureBuilder.php
@@ -23,6 +23,7 @@ use Contao\PageModel;
 use Contao\Validator;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Webmozart\PathUtil\Path;
 
 /**
@@ -710,7 +711,7 @@ class FigureBuilder
         return $framework->getAdapter(Validator::class);
     }
 
-    private function eventDispatcher()
+    private function eventDispatcher(): EventDispatcherInterface
     {
         return $this->locator->get('event_dispatcher');
     }

--- a/core-bundle/src/Image/Studio/FigureBuilder.php
+++ b/core-bundle/src/Image/Studio/FigureBuilder.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Image\Studio;
 
+use Contao\CoreBundle\Event\DefineMetadataEvent;
 use Contao\CoreBundle\Exception\InvalidResourceException;
 use Contao\CoreBundle\File\Metadata;
 use Contao\FilesModel;
@@ -555,7 +556,11 @@ class FigureBuilder
             $imageResult,
             \Closure::bind(
                 function (Figure $figure): ?Metadata {
-                    return $this->onDefineMetadata();
+                    $event = new DefineMetadataEvent($this->onDefineMetadata());
+
+                    $this->eventDispatcher()->dispatch($event);
+
+                    return $event->getMetadata();
                 },
                 $settings
             ),

--- a/core-bundle/src/Image/Studio/FigureBuilder.php
+++ b/core-bundle/src/Image/Studio/FigureBuilder.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Image\Studio;
 
-use Contao\CoreBundle\Event\DefineMetadataEvent;
+use Contao\CoreBundle\Event\FileMetadataEvent;
 use Contao\CoreBundle\Exception\InvalidResourceException;
 use Contao\CoreBundle\File\Metadata;
 use Contao\FilesModel;
@@ -557,7 +557,7 @@ class FigureBuilder
             $imageResult,
             \Closure::bind(
                 function (Figure $figure): ?Metadata {
-                    $event = new DefineMetadataEvent($this->onDefineMetadata());
+                    $event = new FileMetadataEvent($this->onDefineMetadata());
 
                     $this->eventDispatcher()->dispatch($event);
 

--- a/core-bundle/src/Image/Studio/FigureBuilder.php
+++ b/core-bundle/src/Image/Studio/FigureBuilder.php
@@ -23,7 +23,6 @@ use Contao\PageModel;
 use Contao\Validator;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\Filesystem\Filesystem;
-use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Webmozart\PathUtil\Path;
 
 /**
@@ -559,7 +558,7 @@ class FigureBuilder
                 function (Figure $figure): ?Metadata {
                     $event = new FileMetadataEvent($this->onDefineMetadata());
 
-                    $this->eventDispatcher()->dispatch($event);
+                    $this->locator->get('event_dispatcher')->dispatch($event);
 
                     return $event->getMetadata();
                 },
@@ -709,11 +708,6 @@ class FigureBuilder
         $framework->initialize();
 
         return $framework->getAdapter(Validator::class);
-    }
-
-    private function eventDispatcher(): EventDispatcherInterface
-    {
-        return $this->locator->get('event_dispatcher');
     }
 
     /**

--- a/core-bundle/src/Image/Studio/FigureBuilder.php
+++ b/core-bundle/src/Image/Studio/FigureBuilder.php
@@ -705,6 +705,11 @@ class FigureBuilder
         return $framework->getAdapter(Validator::class);
     }
 
+    private function eventDispatcher()
+    {
+        return $this->locator->get('event_dispatcher');
+    }
+
     /**
      * Returns a list of locales (if available) in the following order:
      *  1. language of current page,

--- a/core-bundle/src/Image/Studio/Studio.php
+++ b/core-bundle/src/Image/Studio/Studio.php
@@ -84,6 +84,7 @@ class Studio implements ServiceSubscriberInterface
             'contao.image.resizer' => ResizerInterface::class,
             'contao.assets.files_context' => ContaoContext::class,
             'contao.framework' => ContaoFramework::class,
+            'event_dispatcher' => 'event_dispatcher',
         ];
     }
 }

--- a/core-bundle/tests/Event/FileMetadataEventTest.php
+++ b/core-bundle/tests/Event/FileMetadataEventTest.php
@@ -21,13 +21,11 @@ class FileMetadataEventTest extends TestCase
     public function testGetsAndSetsMetadata(): void
     {
         $metadata = new Metadata([Metadata::VALUE_TITLE => 'foo']);
-
         $event = new FileMetadataEvent($metadata);
 
         $this->assertSame($metadata, $event->getMetadata());
 
         $newMetadata = new Metadata([Metadata::VALUE_ALT => 'bar']);
-
         $event->setMetadata($newMetadata);
 
         $this->assertSame($newMetadata, $event->getMetadata());

--- a/core-bundle/tests/Event/FileMetadataEventTest.php
+++ b/core-bundle/tests/Event/FileMetadataEventTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\Event;
+
+use Contao\CoreBundle\Event\FileMetadataEvent;
+use Contao\CoreBundle\File\Metadata;
+use PHPUnit\Framework\TestCase;
+
+class FileMetadataEventTest extends TestCase
+{
+    public function testGetsAndSetsMetadata(): void
+    {
+        $metadata = new Metadata([Metadata::VALUE_TITLE => 'foo']);
+
+        $event = new FileMetadataEvent($metadata);
+
+        $this->assertSame($metadata, $event->getMetadata());
+
+        $newMetadata = new Metadata([Metadata::VALUE_ALT => 'bar']);
+
+        $event->setMetadata($newMetadata);
+
+        $this->assertSame($newMetadata, $event->getMetadata());
+    }
+}

--- a/core-bundle/tests/Image/Studio/FigureBuilderIntegrationTest.php
+++ b/core-bundle/tests/Image/Studio/FigureBuilderIntegrationTest.php
@@ -35,6 +35,7 @@ use Imagine\Gd\Imagine as ImagineGd;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\NullLogger;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Webmozart\PathUtil\Path;
@@ -1665,6 +1666,7 @@ class FigureBuilderIntegrationTest extends TestCase
         $container->set('request_stack', new RequestStack());
         $container->set('filesystem', new Filesystem());
         $container->set('monolog.logger.contao', new NullLogger());
+        $container->set('event_dispatcher', new EventDispatcher());
     }
 
     private function assertSameTemplateData(array $expected, object $template): void

--- a/core-bundle/tests/Image/Studio/FigureBuilderTest.php
+++ b/core-bundle/tests/Image/Studio/FigureBuilderTest.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Tests\Image\Studio;
 
-use Contao\CoreBundle\Event\DefineMetadataEvent;
+use Contao\CoreBundle\Event\FileMetadataEvent;
 use Contao\CoreBundle\Exception\InvalidResourceException;
 use Contao\CoreBundle\File\Metadata;
 use Contao\CoreBundle\Framework\ContaoFramework;
@@ -1051,8 +1051,8 @@ class FigureBuilderTest extends TestCase
         $eventDispatcher = new EventDispatcher();
 
         $eventDispatcher->addListener(
-            DefineMetadataEvent::class,
-            function (DefineMetadataEvent $event): void {
+            FileMetadataEvent::class,
+            function (FileMetadataEvent $event): void {
                 $this->assertSame([Metadata::VALUE_TITLE => 'foo'], $event->getMetadata()->all());
 
                 $event->setMetadata(new Metadata([Metadata::VALUE_TITLE => 'bar']));

--- a/core-bundle/tests/Image/Studio/FigureBuilderTest.php
+++ b/core-bundle/tests/Image/Studio/FigureBuilderTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Tests\Image\Studio;
 
+use Contao\CoreBundle\Event\DefineMetadataEvent;
 use Contao\CoreBundle\Exception\InvalidResourceException;
 use Contao\CoreBundle\File\Metadata;
 use Contao\CoreBundle\Framework\ContaoFramework;
@@ -29,6 +30,7 @@ use Contao\System;
 use Contao\Validator;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Container\ContainerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Webmozart\PathUtil\Path;
 
@@ -1040,6 +1042,32 @@ class FigureBuilderTest extends TestCase
         $this->assertSame($lightboxImageResult, $figure2->getLightbox());
     }
 
+    public function testDispatchesDefineMetadataEvent(): void
+    {
+        [$absoluteFilePath] = $this->getTestFilePaths();
+
+        $studio = $this->getStudioMockForImage($absoluteFilePath);
+
+        $eventDispatcher = new EventDispatcher();
+
+        $eventDispatcher->addListener(
+            DefineMetadataEvent::class,
+            function (DefineMetadataEvent $event): void {
+                $this->assertSame([Metadata::VALUE_TITLE => 'foo'], $event->getMetadata()->all());
+
+                $event->setMetadata(new Metadata([Metadata::VALUE_TITLE => 'bar']));
+            }
+        );
+
+        $figure = $this->getFigureBuilder($studio, null, $eventDispatcher)
+            ->fromPath($absoluteFilePath, false)
+            ->setMetadata(new Metadata([Metadata::VALUE_TITLE => 'foo']))
+            ->build()
+        ;
+
+        $this->assertSame([Metadata::VALUE_TITLE => 'bar'], $figure->getMetadata()->all());
+    }
+
     private function getFigure(\Closure $configureBuilderCallback = null, Studio $studio = null): Figure
     {
         [$absoluteFilePath] = $this->getTestFilePaths();
@@ -1097,7 +1125,7 @@ class FigureBuilderTest extends TestCase
         return $studio;
     }
 
-    private function getFigureBuilder(Studio $studio = null, ContaoFramework $framework = null): FigureBuilder
+    private function getFigureBuilder(Studio $studio = null, ContaoFramework $framework = null, EventDispatcher $eventDispatcher = null): FigureBuilder
     {
         [, , $projectDir, $uploadPath] = $this->getTestFilePaths();
         $validExtensions = $this->getTestFileExtensions();
@@ -1109,6 +1137,7 @@ class FigureBuilderTest extends TestCase
             ->willReturnMap([
                 [Studio::class, $studio],
                 ['contao.framework', $framework],
+                ['event_dispatcher', $eventDispatcher ?? new EventDispatcher()],
             ])
         ;
 

--- a/core-bundle/tests/Image/Studio/StudioTest.php
+++ b/core-bundle/tests/Image/Studio/StudioTest.php
@@ -43,6 +43,7 @@ class StudioTest extends TestCase
             ResizerInterface::class,
             ContaoFramework::class,
             ContaoContext::class,
+            'event_dispatcher',
         ];
 
         $this->assertEqualsCanonicalizing($services, Studio::getSubscribedServices());


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | -
| Docs PR or issue | todo

This introduces a `DefineMetadataEvent` that gets dispatched inside the `FigureBuilder` as soon as metadata is requested. It is run *after* the `FigureBuilder` logic and allows to remove/replace/add `Metadata`.
