### PR TITLE
Handle non-string arguments in the `FilesModel::findByPath()` method

### DIFF
--- a/core-bundle/src/Resources/contao/models/FilesModel.php
+++ b/core-bundle/src/Resources/contao/models/FilesModel.php
@@ -254,6 +254,13 @@ class FilesModel extends Model
 	 */
 	public static function findByPath($path, array $arrOptions=array())
 	{
+		if (!\is_string($path))
+		{
+			trigger_deprecation('contao/core-bundle', '4.9', 'Using Contao\FilesModel::findByPath() with a non-string argument has been deprecated and will no longer work in Contao 5.0.');
+
+			return null;
+		}
+
 		$projectDir = System::getContainer()->getParameter('kernel.project_dir');
 		$uploadPath = System::getContainer()->getParameter('contao.upload_path');
 

--- a/core-bundle/src/Resources/contao/models/FilesModel.php
+++ b/core-bundle/src/Resources/contao/models/FilesModel.php
@@ -256,8 +256,6 @@ class FilesModel extends Model
 	{
 		if (!\is_string($path))
 		{
-			trigger_deprecation('contao/core-bundle', '4.9', 'Using Contao\FilesModel::findByPath() with a non-string argument has been deprecated and will no longer work in Contao 5.0.');
-
 			return null;
 		}
 


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #3001
| Docs PR or issue | -

