### PR TITLE
Deprecate already moved config options

### DIFF
--- a/calendar-bundle/composer.json
+++ b/calendar-bundle/composer.json
@@ -32,7 +32,7 @@
     },
     "require-dev": {
         "contao/manager-plugin": "^2.3.1",
-        "contao/test-case": "^4.2",
+        "contao/test-case": "^4.3.1",
         "phpunit/phpunit": "^8.5",
         "symfony/http-client": "4.4.* || 5.2.*",
         "symfony/phpunit-bridge": "^5.2"

--- a/calendar-bundle/composer.json
+++ b/calendar-bundle/composer.json
@@ -14,12 +14,6 @@
             "homepage": "https://contao.org/contributors"
         }
     ],
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/ausi/contao-test-case"
-        }
-    ],
     "require": {
         "php": "^7.3 || ^8.0",
         "contao/core-bundle": "self.version",
@@ -38,7 +32,7 @@
     },
     "require-dev": {
         "contao/manager-plugin": "^2.3.1",
-        "contao/test-case": "dev-fix/missing-kernel-charset as 4.3.99",
+        "contao/test-case": "^4.2",
         "phpunit/phpunit": "^8.5",
         "symfony/http-client": "4.4.* || 5.2.*",
         "symfony/phpunit-bridge": "^5.2"

--- a/calendar-bundle/composer.json
+++ b/calendar-bundle/composer.json
@@ -14,6 +14,12 @@
             "homepage": "https://contao.org/contributors"
         }
     ],
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/ausi/contao-test-case"
+        }
+    ],
     "require": {
         "php": "^7.3 || ^8.0",
         "contao/core-bundle": "self.version",
@@ -32,7 +38,7 @@
     },
     "require-dev": {
         "contao/manager-plugin": "^2.3.1",
-        "contao/test-case": "^4.2",
+        "contao/test-case": "dev-fix/missing-kernel-charset as 4.3.99",
         "phpunit/phpunit": "^8.5",
         "symfony/http-client": "4.4.* || 5.2.*",
         "symfony/phpunit-bridge": "^5.2"

--- a/calendar-bundle/src/Resources/contao/dca/tl_calendar_events.php
+++ b/calendar-bundle/src/Resources/contao/dca/tl_calendar_events.php
@@ -344,7 +344,7 @@ $GLOBALS['TL_DCA']['tl_calendar_events'] = array
 			'label'                   => &$GLOBALS['TL_LANG']['tl_content']['singleSRC'],
 			'exclude'                 => true,
 			'inputType'               => 'fileTree',
-			'eval'                    => array('filesOnly'=>true, 'fieldType'=>'radio', 'extensions'=>implode(',', System::getContainer()->getParameter('contao.image.valid_extensions')), 'mandatory'=>true),
+			'eval'                    => array('filesOnly'=>true, 'fieldType'=>'radio', 'extensions'=>'%contao.image.valid_extensions%', 'mandatory'=>true),
 			'sql'                     => "binary(16) NULL"
 		),
 		'alt' => array

--- a/calendar-bundle/src/Resources/contao/dca/tl_calendar_events.php
+++ b/calendar-bundle/src/Resources/contao/dca/tl_calendar_events.php
@@ -344,7 +344,7 @@ $GLOBALS['TL_DCA']['tl_calendar_events'] = array
 			'label'                   => &$GLOBALS['TL_LANG']['tl_content']['singleSRC'],
 			'exclude'                 => true,
 			'inputType'               => 'fileTree',
-			'eval'                    => array('filesOnly'=>true, 'fieldType'=>'radio', 'extensions'=>Config::get('validImageTypes'), 'mandatory'=>true),
+			'eval'                    => array('filesOnly'=>true, 'fieldType'=>'radio', 'extensions'=>implode(',', System::getContainer()->getParameter('contao.image.valid_extensions')), 'mandatory'=>true),
 			'sql'                     => "binary(16) NULL"
 		),
 		'alt' => array

--- a/composer.json
+++ b/composer.json
@@ -14,12 +14,6 @@
             "homepage": "https://contao.org/contributors"
         }
     ],
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/ausi/contao-test-case"
-        }
-    ],
     "require": {
         "php": "^7.3 || ^8.0",
         "ext-dom": "*",
@@ -156,7 +150,7 @@
         "ext-fileinfo": "*",
         "bamarni/composer-bin-plugin": "^1.4",
         "composer/composer": "^1.0 || ^2.0",
-        "contao/test-case": "dev-fix/missing-kernel-charset as 4.3.99",
+        "contao/test-case": "^4.3",
         "phpunit/phpunit": "^8.5",
         "symfony/browser-kit": "4.4.* || 5.2.*",
         "symfony/phpunit-bridge": "^5.2"

--- a/composer.json
+++ b/composer.json
@@ -150,7 +150,7 @@
         "ext-fileinfo": "*",
         "bamarni/composer-bin-plugin": "^1.4",
         "composer/composer": "^1.0 || ^2.0",
-        "contao/test-case": "^4.3",
+        "contao/test-case": "^4.3.1",
         "phpunit/phpunit": "^8.5",
         "symfony/browser-kit": "4.4.* || 5.2.*",
         "symfony/phpunit-bridge": "^5.2"

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,12 @@
             "homepage": "https://contao.org/contributors"
         }
     ],
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/ausi/contao-test-case"
+        }
+    ],
     "require": {
         "php": "^7.3 || ^8.0",
         "ext-dom": "*",
@@ -150,7 +156,7 @@
         "ext-fileinfo": "*",
         "bamarni/composer-bin-plugin": "^1.4",
         "composer/composer": "^1.0 || ^2.0",
-        "contao/test-case": "^4.3",
+        "contao/test-case": "dev-fix/missing-kernel-charset as 4.3.99",
         "phpunit/phpunit": "^8.5",
         "symfony/browser-kit": "4.4.* || 5.2.*",
         "symfony/phpunit-bridge": "^5.2"

--- a/core-bundle/composer.json
+++ b/core-bundle/composer.json
@@ -123,7 +123,7 @@
         "ext-fileinfo": "*",
         "contao/maintenance-bundle-deprecated": "^2.1.5",
         "contao/manager-plugin": "^2.3.1",
-        "contao/test-case": "^4.3",
+        "contao/test-case": "^4.3.1",
         "phpunit/phpunit": "^8.5",
         "symfony/browser-kit": "4.4.* || 5.2.*",
         "symfony/http-client": "4.4.* || 5.2.*",

--- a/core-bundle/composer.json
+++ b/core-bundle/composer.json
@@ -14,12 +14,6 @@
             "homepage": "https://contao.org/contributors"
         }
     ],
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/ausi/contao-test-case"
-        }
-    ],
     "require": {
         "php": "^7.3 || ^8.0",
         "ext-dom": "*",
@@ -129,7 +123,7 @@
         "ext-fileinfo": "*",
         "contao/maintenance-bundle-deprecated": "^2.1.5",
         "contao/manager-plugin": "^2.3.1",
-        "contao/test-case": "dev-fix/missing-kernel-charset as 4.3.99",
+        "contao/test-case": "^4.3",
         "phpunit/phpunit": "^8.5",
         "symfony/browser-kit": "4.4.* || 5.2.*",
         "symfony/http-client": "4.4.* || 5.2.*",

--- a/core-bundle/composer.json
+++ b/core-bundle/composer.json
@@ -14,6 +14,12 @@
             "homepage": "https://contao.org/contributors"
         }
     ],
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/ausi/contao-test-case"
+        }
+    ],
     "require": {
         "php": "^7.3 || ^8.0",
         "ext-dom": "*",
@@ -123,7 +129,7 @@
         "ext-fileinfo": "*",
         "contao/maintenance-bundle-deprecated": "^2.1.5",
         "contao/manager-plugin": "^2.3.1",
-        "contao/test-case": "^4.3",
+        "contao/test-case": "dev-fix/missing-kernel-charset as 4.3.99",
         "phpunit/phpunit": "^8.5",
         "symfony/browser-kit": "4.4.* || 5.2.*",
         "symfony/http-client": "4.4.* || 5.2.*",

--- a/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
+++ b/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
@@ -48,6 +48,10 @@ class ContaoCoreExtension extends Extension
 
     public function load(array $configs, ContainerBuilder $container): void
     {
+        if ('UTF-8' !== $container->getParameter('kernel.charset')) {
+            trigger_error(sprintf('Using the charset "%s" is not supported by Contao, use "UTF-8" instead.', $container->getParameter('kernel.charset')), E_USER_WARNING);
+        }
+
         $configuration = new Configuration(
             $container->getParameter('kernel.project_dir'),
             $container->getParameter('kernel.default_locale')

--- a/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
+++ b/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
@@ -49,7 +49,7 @@ class ContaoCoreExtension extends Extension
     public function load(array $configs, ContainerBuilder $container): void
     {
         if ('UTF-8' !== $container->getParameter('kernel.charset')) {
-            trigger_error(sprintf('Using the charset "%s" is not supported by Contao, use "UTF-8" instead.', $container->getParameter('kernel.charset')), E_USER_WARNING);
+            trigger_deprecation('contao/core-bundle', '4.12', 'Using the charset "%s" is not supported, use "UTF-8" instead. In Contao 5.0 an exception will be thrown for unsupported charsets.', $container->getParameter('kernel.charset'));
         }
 
         $configuration = new Configuration(

--- a/core-bundle/src/Resources/contao/classes/Ajax.php
+++ b/core-bundle/src/Resources/contao/classes/Ajax.php
@@ -178,7 +178,7 @@ class Ajax extends Backend
 	 */
 	public function executePostActions(DataContainer $dc)
 	{
-		header('Content-Type: text/html; charset=' . Config::get('characterSet'));
+		header('Content-Type: text/html; charset=' . System::getContainer()->getParameter('kernel.charset'));
 
 		// Bypass any core logic for non-core drivers (see #5957)
 		if (!$dc instanceof DC_File && !$dc instanceof DC_Folder && !$dc instanceof DC_Table)

--- a/core-bundle/src/Resources/contao/classes/Backend.php
+++ b/core-bundle/src/Resources/contao/classes/Backend.php
@@ -1034,8 +1034,8 @@ abstract class Backend extends Controller
 		}
 
 		$objUser  = BackendUser::getInstance();
-		$strPath  = Config::get('uploadPath');
-		$arrNodes = explode('/', preg_replace('/^' . preg_quote(Config::get('uploadPath'), '/') . '\//', '', $strNode));
+		$strPath  = System::getContainer()->getParameter('contao.upload_path');
+		$arrNodes = explode('/', preg_replace('/^' . preg_quote($strPath, '/') . '\//', '', $strNode));
 		$arrLinks = array();
 
 		// Add root link
@@ -1314,7 +1314,7 @@ abstract class Backend extends Controller
 
 		if ($this->User->isAdmin)
 		{
-			return $this->doCreateFileList(Config::get('uploadPath'), -1, $strFilter);
+			return $this->doCreateFileList(System::getContainer()->getParameter('contao.upload_path'), -1, $strFilter);
 		}
 
 		$return = '';

--- a/core-bundle/src/Resources/contao/classes/Backend.php
+++ b/core-bundle/src/Resources/contao/classes/Backend.php
@@ -193,7 +193,7 @@ abstract class Backend extends Controller
 	 */
 	public static function getTinyTemplates()
 	{
-		$strDir = Config::get('uploadPath') . '/tiny_templates';
+		$strDir = System::getContainer()->getParameter('contao.upload_path') . '/tiny_templates';
 		$projectDir = System::getContainer()->getParameter('kernel.project_dir');
 
 		if (!is_dir($projectDir . '/' . $strDir))

--- a/core-bundle/src/Resources/contao/classes/Frontend.php
+++ b/core-bundle/src/Resources/contao/classes/Frontend.php
@@ -321,9 +321,10 @@ abstract class Frontend extends Controller
 		$host = Environment::get('host');
 		$logger = System::getContainer()->get('monolog.logger.contao');
 		$accept_language = Environment::get('httpAcceptLanguage');
+		$blnAddLanguageToUrl = System::getContainer()->getParameter('contao.prepend_locale');
 
 		// Get the language from the URL if it is not set (see #456)
-		if (!isset($_GET['language']) && $GLOBALS['TL_CONFIG']['addLanguageToUrl'])
+		if (!isset($_GET['language']) && $blnAddLanguageToUrl)
 		{
 			$arrMatches = array();
 
@@ -337,7 +338,7 @@ abstract class Frontend extends Controller
 		}
 
 		// The language is set in the URL
-		if (!empty($_GET['language']) && $GLOBALS['TL_CONFIG']['addLanguageToUrl'])
+		if (!empty($_GET['language']) && $blnAddLanguageToUrl)
 		{
 			$strUri = Environment::get('url') . '/' . Input::get('language') . '/';
 		}
@@ -377,7 +378,7 @@ abstract class Frontend extends Controller
 		// Redirect to the website root or language root (e.g. en/)
 		if (!Environment::get('relativeRequest'))
 		{
-			if ($GLOBALS['TL_CONFIG']['addLanguageToUrl'])
+			if ($blnAddLanguageToUrl)
 			{
 				$arrParams = array('_locale' => $objRootPage->language);
 

--- a/core-bundle/src/Resources/contao/classes/Frontend.php
+++ b/core-bundle/src/Resources/contao/classes/Frontend.php
@@ -323,7 +323,7 @@ abstract class Frontend extends Controller
 		$accept_language = Environment::get('httpAcceptLanguage');
 
 		// Get the language from the URL if it is not set (see #456)
-		if (!isset($_GET['language']) && Config::get('addLanguageToUrl'))
+		if (!isset($_GET['language']) && $GLOBALS['TL_CONFIG']['addLanguageToUrl'])
 		{
 			$arrMatches = array();
 
@@ -337,7 +337,7 @@ abstract class Frontend extends Controller
 		}
 
 		// The language is set in the URL
-		if (!empty($_GET['language']) && Config::get('addLanguageToUrl'))
+		if (!empty($_GET['language']) && $GLOBALS['TL_CONFIG']['addLanguageToUrl'])
 		{
 			$strUri = Environment::get('url') . '/' . Input::get('language') . '/';
 		}
@@ -377,7 +377,7 @@ abstract class Frontend extends Controller
 		// Redirect to the website root or language root (e.g. en/)
 		if (!Environment::get('relativeRequest'))
 		{
-			if (Config::get('addLanguageToUrl'))
+			if ($GLOBALS['TL_CONFIG']['addLanguageToUrl'])
 			{
 				$arrParams = array('_locale' => $objRootPage->language);
 

--- a/core-bundle/src/Resources/contao/classes/Theme.php
+++ b/core-bundle/src/Resources/contao/classes/Theme.php
@@ -1082,19 +1082,21 @@ class Theme extends Backend
 	 */
 	protected function addFolderToArchive(ZipWriter $objArchive, $strFolder, \DOMDocument $xml, \DOMElement $table, array $arrOrder=array())
 	{
+		$strUploadPath = System::getContainer()->getParameter('contao.upload_path');
+
 		// Strip the custom upload folder name
-		$strFolder = preg_replace('@^' . preg_quote(Config::get('uploadPath'), '@') . '/@', '', $strFolder);
+		$strFolder = preg_replace('@^' . preg_quote($strUploadPath, '@') . '/@', '', $strFolder);
 
 		// Add the default upload folder name
 		if (!$strFolder)
 		{
 			$strTarget = 'files';
-			$strFolder = Config::get('uploadPath');
+			$strFolder = $strUploadPath;
 		}
 		else
 		{
 			$strTarget = 'files/' . $strFolder;
-			$strFolder = Config::get('uploadPath') . '/' . $strFolder;
+			$strFolder = $strUploadPath . '/' . $strFolder;
 		}
 
 		if (Validator::isInsecurePath($strFolder))
@@ -1206,7 +1208,7 @@ class Theme extends Backend
 			return '';
 		}
 
-		return preg_replace('@^(tl_)?files/@', Config::get('uploadPath') . '/', $strPath);
+		return preg_replace('@^(tl_)?files/@', System::getContainer()->getParameter('contao.upload_path') . '/', $strPath);
 	}
 
 	/**
@@ -1223,7 +1225,7 @@ class Theme extends Backend
 			return '';
 		}
 
-		return preg_replace('@^' . preg_quote(Config::get('uploadPath'), '@') . '/@', 'files/', $strPath);
+		return preg_replace('@^' . preg_quote(System::getContainer()->getParameter('contao.upload_path'), '@') . '/@', 'files/', $strPath);
 	}
 }
 

--- a/core-bundle/src/Resources/contao/classes/Versions.php
+++ b/core-bundle/src/Resources/contao/classes/Versions.php
@@ -597,7 +597,7 @@ class Versions extends Controller
 		$objTemplate->base = Environment::get('base');
 		$objTemplate->language = $GLOBALS['TL_LANGUAGE'];
 		$objTemplate->title = StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['showDifferences']);
-		$objTemplate->charset = Config::get('characterSet');
+		$objTemplate->charset = System::getContainer()->getParameter('kernel.charset');
 
 		throw new ResponseException($objTemplate->getResponse());
 	}

--- a/core-bundle/src/Resources/contao/controllers/BackendAlerts.php
+++ b/core-bundle/src/Resources/contao/controllers/BackendAlerts.php
@@ -55,7 +55,7 @@ class BackendAlerts extends Backend
 		$objTemplate->language = $GLOBALS['TL_LANGUAGE'];
 		$objTemplate->title = StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['systemMessages']);
 		$objTemplate->host = Backend::getDecodedHostname();
-		$objTemplate->charset = Config::get('characterSet');
+		$objTemplate->charset = System::getContainer()->getParameter('kernel.charset');
 		$objTemplate->messages = Message::generateUnwrapped() . Backend::getSystemMessages();
 		$objTemplate->noMessages = $GLOBALS['TL_LANG']['MSC']['noSystemMessages'];
 

--- a/core-bundle/src/Resources/contao/controllers/BackendConfirm.php
+++ b/core-bundle/src/Resources/contao/controllers/BackendConfirm.php
@@ -156,7 +156,7 @@ class BackendConfirm extends Backend
 		$objTemplate->h1 = $GLOBALS['TL_LANG']['MSC']['invalidToken'];
 		$objTemplate->title = StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['invalidToken']);
 		$objTemplate->host = Backend::getDecodedHostname();
-		$objTemplate->charset = Config::get('characterSet');
+		$objTemplate->charset = System::getContainer()->getParameter('kernel.charset');
 
 		return $objTemplate->getResponse();
 	}

--- a/core-bundle/src/Resources/contao/controllers/BackendFile.php
+++ b/core-bundle/src/Resources/contao/controllers/BackendFile.php
@@ -149,7 +149,7 @@ class BackendFile extends Backend
 		$objTemplate->language = $GLOBALS['TL_LANGUAGE'];
 		$objTemplate->title = StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['filepicker']);
 		$objTemplate->host = Backend::getDecodedHostname();
-		$objTemplate->charset = Config::get('characterSet');
+		$objTemplate->charset = System::getContainer()->getParameter('kernel.charset');
 		$objTemplate->addSearch = true;
 		$objTemplate->search = $GLOBALS['TL_LANG']['MSC']['search'];
 		$objTemplate->searchExclude = $GLOBALS['TL_LANG']['MSC']['searchExclude'];

--- a/core-bundle/src/Resources/contao/controllers/BackendHelp.php
+++ b/core-bundle/src/Resources/contao/controllers/BackendHelp.php
@@ -149,7 +149,7 @@ class BackendHelp extends Backend
 		$objTemplate->language = $GLOBALS['TL_LANGUAGE'];
 		$objTemplate->title = StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['helpWizardTitle']);
 		$objTemplate->host = Backend::getDecodedHostname();
-		$objTemplate->charset = Config::get('characterSet');
+		$objTemplate->charset = System::getContainer()->getParameter('kernel.charset');
 		$objTemplate->headline = $arrData['label'][0] ?: $field;
 		$objTemplate->helpWizard = $GLOBALS['TL_LANG']['MSC']['helpWizard'];
 

--- a/core-bundle/src/Resources/contao/controllers/BackendIndex.php
+++ b/core-bundle/src/Resources/contao/controllers/BackendIndex.php
@@ -109,7 +109,7 @@ class BackendIndex extends Backend
 		$objTemplate->language = $GLOBALS['TL_LANGUAGE'];
 		$objTemplate->languages = System::getLanguages(true); // backwards compatibility
 		$objTemplate->host = Backend::getDecodedHostname();
-		$objTemplate->charset = Config::get('characterSet');
+		$objTemplate->charset = System::getContainer()->getParameter('kernel.charset');
 		$objTemplate->userLanguage = $GLOBALS['TL_LANG']['tl_user']['language'][0];
 		$objTemplate->curLanguage = Input::post('language') ?: str_replace('-', '_', $GLOBALS['TL_LANGUAGE']);
 		$objTemplate->curUsername = Input::post('username') ?: '';

--- a/core-bundle/src/Resources/contao/controllers/BackendMain.php
+++ b/core-bundle/src/Resources/contao/controllers/BackendMain.php
@@ -243,7 +243,7 @@ class BackendMain extends Backend
 		$this->Template->language = $GLOBALS['TL_LANGUAGE'];
 		$this->Template->title = StringUtil::specialchars(strip_tags($this->Template->title));
 		$this->Template->host = Backend::getDecodedHostname();
-		$this->Template->charset = Config::get('characterSet');
+		$this->Template->charset = System::getContainer()->getParameter('kernel.charset');
 		$this->Template->home = $GLOBALS['TL_LANG']['MSC']['home'];
 		$this->Template->isPopup = Input::get('popup');
 		$this->Template->learnMore = sprintf($GLOBALS['TL_LANG']['MSC']['learnMore'], '<a href="https://contao.org" target="_blank" rel="noreferrer noopener">contao.org</a>');

--- a/core-bundle/src/Resources/contao/controllers/BackendPage.php
+++ b/core-bundle/src/Resources/contao/controllers/BackendPage.php
@@ -139,7 +139,7 @@ class BackendPage extends Backend
 		$objTemplate->language = $GLOBALS['TL_LANGUAGE'];
 		$objTemplate->title = StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['pagepicker']);
 		$objTemplate->host = Backend::getDecodedHostname();
-		$objTemplate->charset = Config::get('characterSet');
+		$objTemplate->charset = System::getContainer()->getParameter('kernel.charset');
 		$objTemplate->addSearch = true;
 		$objTemplate->search = $GLOBALS['TL_LANG']['MSC']['search'];
 		$objTemplate->value = $objSessionBag->get('page_selector_search');

--- a/core-bundle/src/Resources/contao/controllers/BackendPassword.php
+++ b/core-bundle/src/Resources/contao/controllers/BackendPassword.php
@@ -130,7 +130,7 @@ class BackendPassword extends Backend
 		$objTemplate->language = $GLOBALS['TL_LANGUAGE'];
 		$objTemplate->title = StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['pw_new']);
 		$objTemplate->host = Backend::getDecodedHostname();
-		$objTemplate->charset = Config::get('characterSet');
+		$objTemplate->charset = System::getContainer()->getParameter('kernel.charset');
 		$objTemplate->headline = $GLOBALS['TL_LANG']['MSC']['pw_new'];
 		$objTemplate->explain = $GLOBALS['TL_LANG']['MSC']['pw_change'];
 		$objTemplate->submitButton = StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['continue']);

--- a/core-bundle/src/Resources/contao/controllers/BackendPopup.php
+++ b/core-bundle/src/Resources/contao/controllers/BackendPopup.php
@@ -161,7 +161,7 @@ class BackendPopup extends Backend
 		$objTemplate->language = $GLOBALS['TL_LANGUAGE'];
 		$objTemplate->title = StringUtil::specialchars($this->strFile);
 		$objTemplate->host = Backend::getDecodedHostname();
-		$objTemplate->charset = Config::get('characterSet');
+		$objTemplate->charset = System::getContainer()->getParameter('kernel.charset');
 		$objTemplate->labels = (object) $GLOBALS['TL_LANG']['MSC'];
 		$objTemplate->download = StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['fileDownload']);
 

--- a/core-bundle/src/Resources/contao/controllers/BackendPopup.php
+++ b/core-bundle/src/Resources/contao/controllers/BackendPopup.php
@@ -73,7 +73,7 @@ class BackendPopup extends Backend
 		}
 
 		// Limit preview to the files directory
-		if (!preg_match('@^' . preg_quote(Config::get('uploadPath'), '@') . '@i', $this->strFile))
+		if (!preg_match('@^' . preg_quote(System::getContainer()->getParameter('contao.upload_path'), '@') . '@i', $this->strFile))
 		{
 			die('Invalid path');
 		}

--- a/core-bundle/src/Resources/contao/controllers/FrontendIndex.php
+++ b/core-bundle/src/Resources/contao/controllers/FrontendIndex.php
@@ -129,7 +129,7 @@ class FrontendIndex extends Frontend
 			}
 
 			// Use the first result (see #4872)
-			if (!System::getContainer()->getParameter('contao.legacy_routing') || !$GLOBALS['TL_CONFIG']['addLanguageToUrl'])
+			if (!System::getContainer()->getParameter('contao.legacy_routing') || !System::getContainer()->getParameter('contao.prepend_locale'))
 			{
 				$objNewPage = current($arrLangs);
 			}

--- a/core-bundle/src/Resources/contao/controllers/FrontendIndex.php
+++ b/core-bundle/src/Resources/contao/controllers/FrontendIndex.php
@@ -247,7 +247,7 @@ class FrontendIndex extends Frontend
 		}
 
 		// Check wether the language matches the root page language
-		if (isset($_GET['language']) && !$objPage->urlPrefix && Input::get('language') != $objPage->rootLanguage)
+		if (isset($_GET['language']) && $objPage->urlPrefix && Input::get('language') != $objPage->rootLanguage)
 		{
 			throw new PageNotFoundException('Page not found: ' . Environment::get('uri'));
 		}

--- a/core-bundle/src/Resources/contao/controllers/FrontendIndex.php
+++ b/core-bundle/src/Resources/contao/controllers/FrontendIndex.php
@@ -129,7 +129,7 @@ class FrontendIndex extends Frontend
 			}
 
 			// Use the first result (see #4872)
-			if (!System::getContainer()->getParameter('contao.legacy_routing') || !Config::get('addLanguageToUrl'))
+			if (!System::getContainer()->getParameter('contao.legacy_routing') || !$GLOBALS['TL_CONFIG']['addLanguageToUrl'])
 			{
 				$objNewPage = current($arrLangs);
 			}
@@ -247,7 +247,7 @@ class FrontendIndex extends Frontend
 		}
 
 		// Check wether the language matches the root page language
-		if (isset($_GET['language']) && Config::get('addLanguageToUrl') && Input::get('language') != $objPage->rootLanguage)
+		if (isset($_GET['language']) && !$objPage->urlPrefix && Input::get('language') != $objPage->rootLanguage)
 		{
 			throw new PageNotFoundException('Page not found: ' . Environment::get('uri'));
 		}

--- a/core-bundle/src/Resources/contao/dca/tl_content.php
+++ b/core-bundle/src/Resources/contao/dca/tl_content.php
@@ -1859,7 +1859,7 @@ class tl_content extends Backend
 				case 'accordionSingle':
 				case 'youtube':
 				case 'vimeo':
-					$GLOBALS['TL_DCA'][$dc->table]['fields'][$dc->field]['eval']['extensions'] = Config::get('validImageTypes');
+					$GLOBALS['TL_DCA'][$dc->table]['fields'][$dc->field]['eval']['extensions'] = implode(',', System::getContainer()->getParameter('contao.image.valid_extensions'));
 					break;
 
 				case 'download':
@@ -1887,7 +1887,7 @@ class tl_content extends Backend
 			{
 				case 'gallery':
 					$GLOBALS['TL_DCA'][$dc->table]['fields'][$dc->field]['eval']['isGallery'] = true;
-					$GLOBALS['TL_DCA'][$dc->table]['fields'][$dc->field]['eval']['extensions'] = Config::get('validImageTypes');
+					$GLOBALS['TL_DCA'][$dc->table]['fields'][$dc->field]['eval']['extensions'] = implode(',', System::getContainer()->getParameter('contao.image.valid_extensions'));
 					break;
 
 				case 'downloads':

--- a/core-bundle/src/Resources/contao/dca/tl_content.php
+++ b/core-bundle/src/Resources/contao/dca/tl_content.php
@@ -1859,7 +1859,7 @@ class tl_content extends Backend
 				case 'accordionSingle':
 				case 'youtube':
 				case 'vimeo':
-					$GLOBALS['TL_DCA'][$dc->table]['fields'][$dc->field]['eval']['extensions'] = implode(',', System::getContainer()->getParameter('contao.image.valid_extensions'));
+					$GLOBALS['TL_DCA'][$dc->table]['fields'][$dc->field]['eval']['extensions'] = '%contao.image.valid_extensions%';
 					break;
 
 				case 'download':
@@ -1887,7 +1887,7 @@ class tl_content extends Backend
 			{
 				case 'gallery':
 					$GLOBALS['TL_DCA'][$dc->table]['fields'][$dc->field]['eval']['isGallery'] = true;
-					$GLOBALS['TL_DCA'][$dc->table]['fields'][$dc->field]['eval']['extensions'] = implode(',', System::getContainer()->getParameter('contao.image.valid_extensions'));
+					$GLOBALS['TL_DCA'][$dc->table]['fields'][$dc->field]['eval']['extensions'] = '%contao.image.valid_extensions%';
 					break;
 
 				case 'downloads':

--- a/core-bundle/src/Resources/contao/dca/tl_files.php
+++ b/core-bundle/src/Resources/contao/dca/tl_files.php
@@ -477,7 +477,7 @@ class tl_files extends Backend
 		}
 
 		// Only show the important part fields for images
-		if ($blnIsFolder || !in_array(strtolower(substr($dc->id, strrpos($dc->id, '.') + 1)), StringUtil::trimsplit(',', strtolower(Config::get('validImageTypes')))))
+		if ($blnIsFolder || !in_array(strtolower(substr($dc->id, strrpos($dc->id, '.') + 1)), System::getContainer()->getParameter('contao.image.valid_extensions')))
 		{
 			PaletteManipulator::create()
 				->removeField(array('importantPartX', 'importantPartY', 'importantPartWidth', 'importantPartHeight'))

--- a/core-bundle/src/Resources/contao/dca/tl_files.php
+++ b/core-bundle/src/Resources/contao/dca/tl_files.php
@@ -35,6 +35,8 @@ $GLOBALS['TL_DCA']['tl_files'] = array
 		'dataContainer'               => 'Folder',
 		'enableVersioning'            => true,
 		'databaseAssisted'            => true,
+		'uploadPath'                  => $GLOBALS['TL_CONFIG']['uploadPath'] ?? System::getContainer()->getParameter('contao.upload_path'),
+		'editableFileTypes'           => $GLOBALS['TL_CONFIG']['editableFiles'] ?? System::getContainer()->getParameter('contao.editable_files'),
 		'onload_callback' => array
 		(
 			array('tl_files', 'checkPermission'),
@@ -498,7 +500,7 @@ class tl_files extends Backend
 	{
 		$model = FilesModel::findByPk($pid);
 
-		if ($model === null || !in_array($model->extension, StringUtil::trimsplit(',', strtolower(Config::get('editableFiles')))))
+		if ($model === null || !in_array($model->extension, StringUtil::trimsplit(',', strtolower($GLOBALS['TL_DCA'][$table]['config']['editableFileTypes'] ?? $GLOBALS['TL_CONFIG']['editableFiles'] ?? System::getContainer()->getParameter('contao.editable_files')))))
 		{
 			return;
 		}
@@ -530,7 +532,7 @@ class tl_files extends Backend
 	{
 		$model = FilesModel::findByPk($pid);
 
-		if ($model === null || !in_array($model->extension, StringUtil::trimsplit(',', strtolower(Config::get('editableFiles')))))
+		if ($model === null || !in_array($model->extension, StringUtil::trimsplit(',', strtolower($GLOBALS['TL_DCA'][$table]['config']['editableFileTypes'] ?? $GLOBALS['TL_CONFIG']['editableFiles'] ?? System::getContainer()->getParameter('contao.editable_files')))))
 		{
 			return;
 		}
@@ -789,7 +791,10 @@ class tl_files extends Backend
 
 		$objFile = new File($strDecoded);
 
-		if (!in_array($objFile->extension, StringUtil::trimsplit(',', strtolower(Config::get('editableFiles')))))
+		/** @var DC_Folder $dc */
+		$dc = (@func_get_arg(12) ?: null);
+
+		if (!in_array($objFile->extension, $dc ? $dc->editableFileTypes : StringUtil::trimsplit(',', strtolower($GLOBALS['TL_DCA'][$table]['config']['editableFileTypes'] ?? $GLOBALS['TL_CONFIG']['editableFiles'] ?? System::getContainer()->getParameter('contao.editable_files')))))
 		{
 			return Image::getHtml(preg_replace('/\.svg$/i', '_.svg', $icon)) . ' ';
 		}

--- a/core-bundle/src/Resources/contao/dca/tl_image_size.php
+++ b/core-bundle/src/Resources/contao/dca/tl_image_size.php
@@ -10,7 +10,6 @@
 
 use Contao\Backend;
 use Contao\BackendUser;
-use Contao\Config;
 use Contao\CoreBundle\Exception\AccessDeniedException;
 use Contao\DataContainer;
 use Contao\Image;
@@ -405,7 +404,7 @@ class tl_image_size extends Backend
 			$formats = StringUtil::deserialize($dc->value, true);
 		}
 
-		if (!in_array('webp', StringUtil::trimsplit(',', Config::get('validImageTypes'))))
+		if (!in_array('webp', System::getContainer()->getParameter('contao.image.valid_extensions')))
 		{
 			return $formats;
 		}

--- a/core-bundle/src/Resources/contao/dca/tl_module.php
+++ b/core-bundle/src/Resources/contao/dca/tl_module.php
@@ -836,7 +836,7 @@ class tl_module extends Backend
 		if ($dc->activeRecord && $dc->activeRecord->type == 'randomImage')
 		{
 			$GLOBALS['TL_DCA'][$dc->table]['fields'][$dc->field]['eval']['isGallery'] = true;
-			$GLOBALS['TL_DCA'][$dc->table]['fields'][$dc->field]['eval']['extensions'] = implode(',', System::getContainer()->getParameter('contao.image.valid_extensions'));
+			$GLOBALS['TL_DCA'][$dc->table]['fields'][$dc->field]['eval']['extensions'] = '%contao.image.valid_extensions%';
 		}
 
 		return $varValue;

--- a/core-bundle/src/Resources/contao/dca/tl_module.php
+++ b/core-bundle/src/Resources/contao/dca/tl_module.php
@@ -10,7 +10,6 @@
 
 use Contao\Backend;
 use Contao\BackendUser;
-use Contao\Config;
 use Contao\Controller;
 use Contao\CoreBundle\Exception\AccessDeniedException;
 use Contao\DataContainer;
@@ -837,7 +836,7 @@ class tl_module extends Backend
 		if ($dc->activeRecord && $dc->activeRecord->type == 'randomImage')
 		{
 			$GLOBALS['TL_DCA'][$dc->table]['fields'][$dc->field]['eval']['isGallery'] = true;
-			$GLOBALS['TL_DCA'][$dc->table]['fields'][$dc->field]['eval']['extensions'] = Config::get('validImageTypes');
+			$GLOBALS['TL_DCA'][$dc->table]['fields'][$dc->field]['eval']['extensions'] = implode(',', System::getContainer()->getParameter('contao.image.valid_extensions'));
 		}
 
 		return $varValue;

--- a/core-bundle/src/Resources/contao/dca/tl_style.php
+++ b/core-bundle/src/Resources/contao/dca/tl_style.php
@@ -10,7 +10,6 @@
 
 use Contao\Backend;
 use Contao\BackendUser;
-use Contao\Config;
 use Contao\CoreBundle\Exception\AccessDeniedException;
 use Contao\DataContainer;
 use Contao\Image;
@@ -352,7 +351,7 @@ $GLOBALS['TL_DCA']['tl_style'] = array
 		'bgimage' => array
 		(
 			'inputType'               => 'text',
-			'eval'                    => array('dcaPicker'=>array('do'=>'files', 'context'=>'file', 'icon'=>'pickfile.svg', 'fieldType'=>'radio', 'filesOnly'=>true, 'extensions'=>Config::get('validImageTypes')), 'tl_class'=>'w50 wizard'),
+			'eval'                    => array('dcaPicker'=>array('do'=>'files', 'context'=>'file', 'icon'=>'pickfile.svg', 'fieldType'=>'radio', 'filesOnly'=>true, 'extensions'=>implode(',', System::getContainer()->getParameter('contao.image.valid_extensions'))), 'tl_class'=>'w50 wizard'),
 			'sql'                     => "varchar(255) NOT NULL default ''"
 		),
 		'bgposition' => array
@@ -527,7 +526,7 @@ $GLOBALS['TL_DCA']['tl_style'] = array
 		'liststyleimage' => array
 		(
 			'inputType'               => 'text',
-			'eval'                    => array('dcaPicker'=>array('do'=>'files', 'context'=>'file', 'icon'=>'pickfile.svg', 'fieldType'=>'radio', 'filesOnly'=>true, 'extensions'=>Config::get('validImageTypes')), 'tl_class'=>'w50 wizard'),
+			'eval'                    => array('dcaPicker'=>array('do'=>'files', 'context'=>'file', 'icon'=>'pickfile.svg', 'fieldType'=>'radio', 'filesOnly'=>true, 'extensions'=>implode(',', System::getContainer()->getParameter('contao.image.valid_extensions'))), 'tl_class'=>'w50 wizard'),
 			'sql'                     => "varchar(255) NOT NULL default ''"
 		),
 		'own' => array

--- a/core-bundle/src/Resources/contao/dca/tl_style.php
+++ b/core-bundle/src/Resources/contao/dca/tl_style.php
@@ -351,7 +351,7 @@ $GLOBALS['TL_DCA']['tl_style'] = array
 		'bgimage' => array
 		(
 			'inputType'               => 'text',
-			'eval'                    => array('dcaPicker'=>array('do'=>'files', 'context'=>'file', 'icon'=>'pickfile.svg', 'fieldType'=>'radio', 'filesOnly'=>true, 'extensions'=>implode(',', System::getContainer()->getParameter('contao.image.valid_extensions'))), 'tl_class'=>'w50 wizard'),
+			'eval'                    => array('dcaPicker'=>array('do'=>'files', 'context'=>'file', 'icon'=>'pickfile.svg', 'fieldType'=>'radio', 'filesOnly'=>true, 'extensions'=>'%contao.image.valid_extensions%'), 'tl_class'=>'w50 wizard'),
 			'sql'                     => "varchar(255) NOT NULL default ''"
 		),
 		'bgposition' => array
@@ -526,7 +526,7 @@ $GLOBALS['TL_DCA']['tl_style'] = array
 		'liststyleimage' => array
 		(
 			'inputType'               => 'text',
-			'eval'                    => array('dcaPicker'=>array('do'=>'files', 'context'=>'file', 'icon'=>'pickfile.svg', 'fieldType'=>'radio', 'filesOnly'=>true, 'extensions'=>implode(',', System::getContainer()->getParameter('contao.image.valid_extensions'))), 'tl_class'=>'w50 wizard'),
+			'eval'                    => array('dcaPicker'=>array('do'=>'files', 'context'=>'file', 'icon'=>'pickfile.svg', 'fieldType'=>'radio', 'filesOnly'=>true, 'extensions'=>'%contao.image.valid_extensions%'), 'tl_class'=>'w50 wizard'),
 			'sql'                     => "varchar(255) NOT NULL default ''"
 		),
 		'own' => array

--- a/core-bundle/src/Resources/contao/dca/tl_templates.php
+++ b/core-bundle/src/Resources/contao/dca/tl_templates.php
@@ -501,7 +501,8 @@ class tl_templates extends Backend
 		$objTemplate->title = StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['showDifferences']);
 		$objTemplate->charset = Config::get('characterSet');
 
-		Config::set('debugMode', false);
+		System::getContainer()->setParameter('kernel.debug', false);
+		$GLOBALS['TL_CONFIG']['debugMode'] = false;
 
 		throw new ResponseException($objTemplate->getResponse());
 	}

--- a/core-bundle/src/Resources/contao/dca/tl_templates.php
+++ b/core-bundle/src/Resources/contao/dca/tl_templates.php
@@ -36,6 +36,8 @@ $GLOBALS['TL_DCA']['tl_templates'] = array
 	'config' => array
 	(
 		'dataContainer'               => 'Folder',
+		'uploadPath'                  => 'templates',
+		'editableFileTypes'           => 'html5,twig',
 		'closed'                      => true,
 		'onload_callback' => array
 		(
@@ -158,8 +160,9 @@ class tl_templates extends Backend
 	 */
 	public function adjustSettings()
 	{
-		Config::set('uploadPath', 'templates');
-		Config::set('editableFiles', 'html5,twig');
+		// Backwards compatibility
+		$GLOBALS['TL_CONFIG']['uploadPath'] = $GLOBALS['TL_DCA']['tl_templates']['config']['uploadPath'];
+		$GLOBALS['TL_CONFIG']['editableFiles'] = $GLOBALS['TL_DCA']['tl_templates']['config']['editableFileTypes'];
 	}
 
 	/**
@@ -583,7 +586,11 @@ class tl_templates extends Backend
 	 */
 	public function editSource($row, $href, $label, $title, $icon, $attributes)
 	{
-		return in_array(Path::getExtension($row['id'], true), array('html5', 'twig')) && is_file(System::getContainer()->getParameter('kernel.project_dir') . '/' . rawurldecode($row['id'])) ? '<a href="' . $this->addToUrl($href . '&amp;id=' . $row['id']) . '" title="' . StringUtil::specialchars($title) . '"' . $attributes . '>' . Image::getHtml($icon, $label) . '</a> ' : Image::getHtml(preg_replace('/\.svg$/i', '_.svg', $icon)) . ' ';
+		/** @var DC_Folder $dc */
+		$dc = (@func_get_arg(12) ?: null);
+		$arrEditableFileTypes = $dc ? $dc->editableFileTypes : StringUtil::trimsplit(',', strtolower($GLOBALS['TL_DCA'][$table]['config']['editableFileTypes'] ?? $GLOBALS['TL_CONFIG']['editableFiles'] ?? System::getContainer()->getParameter('contao.editable_files')));
+
+		return in_array(Path::getExtension($row['id'], true), $arrEditableFileTypes) && is_file(System::getContainer()->getParameter('kernel.project_dir') . '/' . rawurldecode($row['id'])) ? '<a href="' . $this->addToUrl($href . '&amp;id=' . $row['id']) . '" title="' . StringUtil::specialchars($title) . '"' . $attributes . '>' . Image::getHtml($icon, $label) . '</a> ' : Image::getHtml(preg_replace('/\.svg$/i', '_.svg', $icon)) . ' ';
 	}
 
 	/**

--- a/core-bundle/src/Resources/contao/dca/tl_templates.php
+++ b/core-bundle/src/Resources/contao/dca/tl_templates.php
@@ -499,7 +499,7 @@ class tl_templates extends Backend
 		$objTemplate->base = Environment::get('base');
 		$objTemplate->language = $GLOBALS['TL_LANGUAGE'];
 		$objTemplate->title = StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['showDifferences']);
-		$objTemplate->charset = Config::get('characterSet');
+		$objTemplate->charset = System::getContainer()->getParameter('kernel.charset');
 
 		System::getContainer()->setParameter('kernel.debug', false);
 		$GLOBALS['TL_CONFIG']['debugMode'] = false;

--- a/core-bundle/src/Resources/contao/dca/tl_theme.php
+++ b/core-bundle/src/Resources/contao/dca/tl_theme.php
@@ -10,7 +10,6 @@
 
 use Contao\Backend;
 use Contao\BackendUser;
-use Contao\Config;
 use Contao\CoreBundle\Exception\AccessDeniedException;
 use Contao\FilesModel;
 use Contao\Folder;
@@ -189,7 +188,7 @@ $GLOBALS['TL_DCA']['tl_theme'] = array
 		(
 			'exclude'                 => true,
 			'inputType'               => 'fileTree',
-			'eval'                    => array('fieldType'=>'radio', 'filesOnly'=>true, 'isGallery'=>true, 'extensions'=>Config::get('validImageTypes')),
+			'eval'                    => array('fieldType'=>'radio', 'filesOnly'=>true, 'isGallery'=>true, 'extensions'=>implode(',', System::getContainer()->getParameter('contao.image.valid_extensions'))),
 			'sql'                     => "binary(16) NULL"
 		),
 		'templates' => array

--- a/core-bundle/src/Resources/contao/dca/tl_theme.php
+++ b/core-bundle/src/Resources/contao/dca/tl_theme.php
@@ -188,7 +188,7 @@ $GLOBALS['TL_DCA']['tl_theme'] = array
 		(
 			'exclude'                 => true,
 			'inputType'               => 'fileTree',
-			'eval'                    => array('fieldType'=>'radio', 'filesOnly'=>true, 'isGallery'=>true, 'extensions'=>implode(',', System::getContainer()->getParameter('contao.image.valid_extensions'))),
+			'eval'                    => array('fieldType'=>'radio', 'filesOnly'=>true, 'isGallery'=>true, 'extensions'=>'%contao.image.valid_extensions%'),
 			'sql'                     => "binary(16) NULL"
 		),
 		'templates' => array

--- a/core-bundle/src/Resources/contao/drivers/DC_File.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_File.php
@@ -440,7 +440,7 @@ class DC_File extends DataContainer implements \editable
 		}
 		elseif (\is_string($strCurrent))
 		{
-			$strCurrent = html_entity_decode($this->varValue, ENT_QUOTES, Config::get('characterSet'));
+			$strCurrent = html_entity_decode($this->varValue, ENT_QUOTES, System::getContainer()->getParameter('kernel.charset'));
 		}
 
 		// Save the value if there was no error

--- a/core-bundle/src/Resources/contao/drivers/DC_Folder.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Folder.php
@@ -31,6 +31,8 @@ use Webmozart\PathUtil\Path;
  *
  * @property string  $path
  * @property string  $extension
+ * @property string  $uploadPath
+ * @property array   $editableFileTypes
  * @property boolean $createNewVersion
  * @property boolean $isDbAssisted
  *
@@ -57,6 +59,12 @@ class DC_Folder extends DataContainer implements \listable, \editable
 	protected $strRootDir;
 
 	/**
+	 * Upload path
+	 * @var string
+	 */
+	protected $strUploadPath;
+
+	/**
 	 * Current filemounts
 	 * @var array
 	 */
@@ -67,6 +75,12 @@ class DC_Folder extends DataContainer implements \listable, \editable
 	 * @var array
 	 */
 	protected $arrValidFileTypes = array();
+
+	/**
+	 * Editable file types
+	 * @var array
+	 */
+	protected $arrEditableFileTypes = array();
 
 	/**
 	 * Messages
@@ -211,6 +225,20 @@ class DC_Folder extends DataContainer implements \listable, \editable
 			}
 		}
 
+		if (!isset($GLOBALS['TL_DCA'][$this->strTable]['config']['editableFileTypes']))
+		{
+			trigger_deprecation('contao/core-bundle', '4.12', 'Not specifying config.editableFileTypes for DC_Folder is deprecated and will no longer work in Contao 5.0.');
+		}
+
+		$this->arrEditableFileTypes = StringUtil::trimsplit(',', strtolower($GLOBALS['TL_DCA'][$this->strTable]['config']['editableFileTypes'] ?? $GLOBALS['TL_CONFIG']['editableFiles'] ?? System::getContainer()->getParameter('contao.editable_files')));
+
+		if (!isset($GLOBALS['TL_DCA'][$this->strTable]['config']['uploadPath']))
+		{
+			trigger_deprecation('contao/core-bundle', '4.12', 'Not specifying config.uploadPath for DC_Folder is deprecated and will no longer work in Contao 5.0.');
+		}
+
+		$this->strUploadPath = $GLOBALS['TL_DCA'][$this->strTable]['config']['uploadPath'] ?? $GLOBALS['TL_CONFIG']['uploadPath'] ?? System::getContainer()->getParameter('contao.upload_path');
+
 		// Get all filemounts (root folders)
 		if (\is_array($GLOBALS['TL_DCA'][$strTable]['list']['sorting']['root'] ?? null))
 		{
@@ -235,8 +263,14 @@ class DC_Folder extends DataContainer implements \listable, \editable
 			case 'extension':
 				return $this->strExtension;
 
+			case 'uploadPath':
+				return $this->strUploadPath;
+
 			case 'isDbAssisted':
 				return $this->blnIsDbAssisted;
+
+			case 'editableFileTypes':
+				return $this->arrEditableFileTypes;
 		}
 
 		return parent::__get($strKey);
@@ -287,7 +321,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 			// Expand tree
 			if (empty($session['filetree']) || !\is_array($session['filetree']) || current($session['filetree']) != 1)
 			{
-				$session['filetree'] = $this->getMD5Folders(Config::get('uploadPath'));
+				$session['filetree'] = $this->getMD5Folders($this->strUploadPath);
 			}
 			// Collapse tree
 			else
@@ -404,7 +438,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 		}
 		elseif (empty($this->arrFilemounts) && !\is_array($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['root'] ?? null) && ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['root'] ?? null) !== false)
 		{
-			$return .= $this->generateTree($this->strRootDir . '/' . Config::get('uploadPath'), 0, false, true, ($blnClipboard ? $arrClipboard : false), $arrFound);
+			$return .= $this->generateTree($this->strRootDir . '/' . $this->strUploadPath, 0, false, true, ($blnClipboard ? $arrClipboard : false), $arrFound);
 		}
 		else
 		{
@@ -475,7 +509,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 <label for="tl_select_trigger" class="tl_select_label">' . $GLOBALS['TL_LANG']['MSC']['selectAll'] . '</label> <input type="checkbox" id="tl_select_trigger" onclick="Backend.toggleCheckboxes(this)" class="tl_tree_checkbox">
 </div>' : '') . '
 <ul class="tl_listing tl_file_manager' . ($this->strPickerFieldType ? ' picker unselectable' : '') . '">
-  <li class="tl_folder_top cf"><div class="tl_left">' . $label . '</div> <div class="tl_right">' . (($blnClipboard && empty($this->arrFilemounts) && !\is_array($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['root'] ?? null) && ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['root'] ?? null) !== false) ? '<a href="' . $this->addToUrl('&amp;act=' . $arrClipboard['mode'] . '&amp;mode=2&amp;pid=' . Config::get('uploadPath') . (!\is_array($arrClipboard['id'] ?? null) ? '&amp;id=' . $arrClipboard['id'] : '')) . '" title="' . StringUtil::specialchars($labelPasteInto[0]) . '" onclick="Backend.getScrollOffset()">' . $imagePasteInto . '</a>' : '&nbsp;') . '</div></li>' . $return . '
+  <li class="tl_folder_top cf"><div class="tl_left">' . $label . '</div> <div class="tl_right">' . (($blnClipboard && empty($this->arrFilemounts) && !\is_array($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['root'] ?? null) && ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['root'] ?? null) !== false) ? '<a href="' . $this->addToUrl('&amp;act=' . $arrClipboard['mode'] . '&amp;mode=2&amp;pid=' . $this->strUploadPath . (!\is_array($arrClipboard['id'] ?? null) ? '&amp;id=' . $arrClipboard['id'] : '')) . '" title="' . StringUtil::specialchars($labelPasteInto[0]) . '" onclick="Backend.getScrollOffset()">' . $imagePasteInto . '</a>' : '&nbsp;') . '</div></li>' . $return . '
 </ul>' . ($this->strPickerFieldType == 'radio' ? '
 <div class="tl_radio_reset">
 <label for="tl_radio_reset" class="tl_radio_label">' . $GLOBALS['TL_LANG']['MSC']['resetSelected'] . '</label> <input type="radio" name="picker" id="tl_radio_reset" value="" class="tl_tree_radio">
@@ -564,7 +598,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 			$return .= '<script>'
 				. 'Dropzone.autoDiscover = false;'
 				. 'Backend.enableFileTreeUpload("tl_listing", ' . json_encode(array(
-					'url' => html_entity_decode($this->addToUrl('act=move&mode=2&pid=' . urlencode($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['root'][0] ?? Config::get('uploadPath')))),
+					'url' => html_entity_decode($this->addToUrl('act=move&mode=2&pid=' . urlencode($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['root'][0] ?? $this->strUploadPath))),
 					'paramName' => 'files',
 					'maxFilesize' => $intMaxSize,
 					'acceptedFiles' => $strAccepted,
@@ -578,7 +612,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 
 		$return .= '<script>'
 			. 'Backend.enableFileTreeDragAndDrop($("tl_listing").getChildren(".tl_file_manager")[0], ' . json_encode(array(
-				'url' => html_entity_decode($this->addToUrl('act=cut&mode=2&pid=' . urlencode($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['root'][0] ?? Config::get('uploadPath')))),
+				'url' => html_entity_decode($this->addToUrl('act=cut&mode=2&pid=' . urlencode($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['root'][0] ?? $this->strUploadPath))),
 			)) . ')</script>'
 		;
 
@@ -1091,7 +1125,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 			throw new AccessDeniedException('Folder "' . $strFolder . '" is not mounted or is not a directory.');
 		}
 
-		if (!preg_match('/^' . preg_quote(Config::get('uploadPath'), '/') . '/i', $strFolder))
+		if (!preg_match('/^' . preg_quote($this->strUploadPath, '/') . '/i', $strFolder))
 		{
 			throw new AccessDeniedException('Parent folder "' . $strFolder . '" is not within the files directory.');
 		}
@@ -1956,7 +1990,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 		$objFile = new File($this->intId);
 
 		// Check whether file type is editable
-		if (!\in_array($objFile->extension, StringUtil::trimsplit(',', strtolower(Config::get('editableFiles')))))
+		if (!\in_array($objFile->extension, $this->arrEditableFileTypes))
 		{
 			throw new AccessDeniedException('File type "' . $objFile->extension . '" (' . $this->intId . ') is not allowed to be edited.');
 		}
@@ -3051,13 +3085,13 @@ class DC_Folder extends DataContainer implements \listable, \editable
 		}
 
 		// Check whether the file is within the files directory
-		if (!preg_match('/^' . preg_quote(Config::get('uploadPath'), '/') . '/i', $strFile))
+		if (!preg_match('/^' . preg_quote($this->strUploadPath, '/') . '/i', $strFile))
 		{
 			throw new AccessDeniedException('File or folder "' . $strFile . '" is not within the files directory.');
 		}
 
 		// Check whether the parent folder is within the files directory
-		if ($strFolder && !preg_match('/^' . preg_quote(Config::get('uploadPath'), '/') . '/i', $strFolder))
+		if ($strFolder && !preg_match('/^' . preg_quote($this->strUploadPath, '/') . '/i', $strFolder))
 		{
 			throw new AccessDeniedException('Parent folder "' . $strFolder . '" is not within the files directory.');
 		}

--- a/core-bundle/src/Resources/contao/drivers/DC_Folder.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Folder.php
@@ -2271,7 +2271,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 				throw new \Exception(sprintf($GLOBALS['TL_LANG']['ERR']['fileExists'], $varValue));
 			}
 
-			$arrImageTypes = StringUtil::trimsplit(',', strtolower(Config::get('validImageTypes')));
+			$arrImageTypes = System::getContainer()->getParameter('contao.image.valid_extensions');
 
 			// Remove potentially existing thumbnails (see #6641)
 			if (\in_array(substr($this->strExtension, 1), $arrImageTypes))
@@ -2747,7 +2747,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 			$folderImg = $protected ? 'folderCP.svg' : 'folderC.svg';
 
 			// Add the current folder
-			$strFolderNameEncoded = StringUtil::convertEncoding(StringUtil::specialchars(basename($currentFolder)), Config::get('characterSet'));
+			$strFolderNameEncoded = StringUtil::convertEncoding(StringUtil::specialchars(basename($currentFolder)), System::getContainer()->getParameter('kernel.charset'));
 			$return .= Image::getHtml($folderImg) . ' <a href="' . $this->addToUrl('fn=' . $currentEncoded) . '" title="' . StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['selectNode']) . '"><strong>' . $strFolderNameEncoded . '</strong></a></div> <div class="tl_right">';
 
 			// Paste buttons
@@ -2877,7 +2877,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 				}
 			}
 
-			$strFileNameEncoded = StringUtil::convertEncoding(StringUtil::specialchars(basename($currentFile)), Config::get('characterSet'));
+			$strFileNameEncoded = StringUtil::convertEncoding(StringUtil::specialchars(basename($currentFile)), System::getContainer()->getParameter('kernel.charset'));
 
 			// No popup links for protected files, templates and in the popup file manager
 			if ($blnProtected || $this->strTable == 'tl_templates' || Input::get('popup'))

--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -2189,7 +2189,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 				$objTemplate->language = $GLOBALS['TL_LANGUAGE'];
 				$objTemplate->title = StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['versionConflict']);
 				$objTemplate->theme = Backend::getTheme();
-				$objTemplate->charset = Config::get('characterSet');
+				$objTemplate->charset = System::getContainer()->getParameter('kernel.charset');
 				$objTemplate->base = Environment::get('base');
 				$objTemplate->h1 = $GLOBALS['TL_LANG']['MSC']['versionConflict'];
 				$objTemplate->explain1 = sprintf($GLOBALS['TL_LANG']['MSC']['versionConflict1'], $intLatestVersion, Input::post('VERSION_NUMBER'));

--- a/core-bundle/src/Resources/contao/elements/ContentText.php
+++ b/core-bundle/src/Resources/contao/elements/ContentText.php
@@ -35,7 +35,7 @@ class ContentText extends ContentElement
 		// Add the static files URL to images
 		if ($staticUrl = System::getContainer()->get('contao.assets.files_context')->getStaticUrl())
 		{
-			$path = Config::get('uploadPath') . '/';
+			$path = System::getContainer()->getParameter('contao.upload_path') . '/';
 			$this->text = str_replace(' src="' . $path, ' src="' . $staticUrl . $path, $this->text);
 		}
 

--- a/core-bundle/src/Resources/contao/forms/Form.php
+++ b/core-bundle/src/Resources/contao/forms/Form.php
@@ -417,7 +417,7 @@ class Form extends Hybrid
 			{
 				$objTemplate = new FrontendTemplate('form_xml');
 				$objTemplate->fields = $fields;
-				$objTemplate->charset = Config::get('characterSet');
+				$objTemplate->charset = System::getContainer()->getParameter('kernel.charset');
 
 				$email->attachFileFromString($objTemplate->parse(), 'form.xml', 'application/xml');
 			}

--- a/core-bundle/src/Resources/contao/forms/FormExplanation.php
+++ b/core-bundle/src/Resources/contao/forms/FormExplanation.php
@@ -52,7 +52,7 @@ class FormExplanation extends Widget
 		// Add the static files URL to images
 		if ($staticUrl = System::getContainer()->get('contao.assets.files_context')->getStaticUrl())
 		{
-			$path = Config::get('uploadPath') . '/';
+			$path = System::getContainer()->getParameter('contao.upload_path') . '/';
 			$this->text = str_replace(' src="' . $path, ' src="' . $staticUrl . $path, $this->text);
 		}
 

--- a/core-bundle/src/Resources/contao/forms/FormFileUpload.php
+++ b/core-bundle/src/Resources/contao/forms/FormFileUpload.php
@@ -77,7 +77,7 @@ class FormFileUpload extends Widget implements \uploadable
 			case 'extensions':
 				if ($varValue)
 				{
-					$this->arrAttributes['accept'] = '.' . implode(',.', StringUtil::trimsplit(',', strtolower($varValue)));
+					$this->arrAttributes['accept'] = '.' . implode(',.', StringUtil::trimsplit(',', strtolower(\is_array($varValue) ? implode(',', $varValue) : $varValue)));
 				}
 				parent::__set($strKey, $varValue);
 				break;

--- a/core-bundle/src/Resources/contao/forms/FormFileUpload.php
+++ b/core-bundle/src/Resources/contao/forms/FormFileUpload.php
@@ -77,7 +77,7 @@ class FormFileUpload extends Widget implements \uploadable
 			case 'extensions':
 				if ($varValue)
 				{
-					$this->arrAttributes['accept'] = '.' . implode(',.', StringUtil::trimsplit(',', strtolower(\is_array($varValue) ? implode(',', $varValue) : $varValue)));
+					$this->arrAttributes['accept'] = '.' . strtolower(implode(',.', \is_array($varValue) ? $varValue : StringUtil::trimsplit(',', $varValue)));
 				}
 				parent::__set($strKey, $varValue);
 				break;

--- a/core-bundle/src/Resources/contao/helper/functions.php
+++ b/core-bundle/src/Resources/contao/helper/functions.php
@@ -86,7 +86,7 @@ function specialchars($strString, $blnStripInsertTags=false)
 	}
 
 	// Use ENT_COMPAT here (see #4889)
-	return htmlspecialchars($strString, ENT_COMPAT, $GLOBALS['TL_CONFIG']['characterSet'], false);
+	return htmlspecialchars($strString, ENT_COMPAT, System::getContainer()->getParameter('kernel.charset'), false);
 }
 
 /**
@@ -107,7 +107,7 @@ function standardize($strString, $blnPreserveUppercase=false)
 	$arrSearch = array('/[^\pN\pL \.\&\/_-]+/u', '/[ \.\&\/-]+/');
 	$arrReplace = array('', '-');
 
-	$strString = html_entity_decode($strString, ENT_QUOTES, $GLOBALS['TL_CONFIG']['characterSet']);
+	$strString = html_entity_decode($strString, ENT_QUOTES, System::getContainer()->getParameter('kernel.charset'));
 	$strString = strip_insert_tags($strString);
 	$strString = preg_replace($arrSearch, $arrReplace, $strString);
 

--- a/core-bundle/src/Resources/contao/library/Contao/ClassLoader.php
+++ b/core-bundle/src/Resources/contao/library/Contao/ClassLoader.php
@@ -157,7 +157,7 @@ class ClassLoader
 		// The class file is set in the mapper
 		if (isset(self::$classes[$class]))
 		{
-			if (Config::get('debugMode'))
+			if (System::getContainer()->getParameter('kernel.debug'))
 			{
 				$GLOBALS['TL_DEBUG']['classes_set'][$class] = $class;
 			}
@@ -170,7 +170,7 @@ class ClassLoader
 		{
 			if (!class_exists($namespaced, false) && !interface_exists($namespaced, false) && !trait_exists($namespaced, false))
 			{
-				if (Config::get('debugMode'))
+				if (System::getContainer()->getParameter('kernel.debug'))
 				{
 					$GLOBALS['TL_DEBUG']['classes_aliased'][$class] = $namespaced;
 				}
@@ -188,7 +188,7 @@ class ClassLoader
 
 			if (class_exists($namespaced) || interface_exists($namespaced) || trait_exists($namespaced))
 			{
-				if (Config::get('debugMode'))
+				if (System::getContainer()->getParameter('kernel.debug'))
 				{
 					$GLOBALS['TL_DEBUG']['classes_composerized'][$class] = $namespaced;
 				}

--- a/core-bundle/src/Resources/contao/library/Contao/Combiner.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Combiner.php
@@ -93,8 +93,6 @@ class Combiner extends System
 
 		$this->strRootDir = $container->getParameter('kernel.project_dir');
 		$this->strWebDir = StringUtil::stripRootDir($container->getParameter('contao.web_dir'));
-
-		parent::__construct();
 	}
 
 	/**

--- a/core-bundle/src/Resources/contao/library/Contao/Combiner.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Combiner.php
@@ -209,6 +209,7 @@ class Combiner extends System
 
 		$return = array();
 		$strTarget = substr($this->strMode, 1);
+		$blnDebug = System::getContainer()->getParameter('kernel.debug');
 
 		foreach ($this->arrFiles as $arrFile)
 		{
@@ -217,7 +218,7 @@ class Combiner extends System
 			{
 				$strPath = 'assets/' . $strTarget . '/' . str_replace('/', '_', $arrFile['name']) . $this->strMode;
 
-				if (Config::get('debugMode') || !file_exists($this->strRootDir . '/' . $strPath))
+				if ($blnDebug || !file_exists($this->strRootDir . '/' . $strPath))
 				{
 					$objFile = new File($strPath);
 					$objFile->write($this->handleScssLess(file_get_contents($this->strRootDir . '/' . $arrFile['name']), $arrFile));
@@ -258,7 +259,7 @@ class Combiner extends System
 	 */
 	public function getCombinedFile($strUrl=null)
 	{
-		if (Config::get('debugMode'))
+		if (System::getContainer()->getParameter('kernel.debug'))
 		{
 			return $this->getDebugMarkup($strUrl);
 		}
@@ -404,13 +405,15 @@ class Combiner extends System
 	 */
 	protected function handleScssLess($content, $arrFile)
 	{
+		$blnDebug = System::getContainer()->getParameter('kernel.debug');
+
 		if ($arrFile['extension'] == self::SCSS)
 		{
 			$objCompiler = new Compiler();
 			$objCompiler->setImportPaths($this->strRootDir . '/' . \dirname($arrFile['name']));
-			$objCompiler->setOutputStyle((Config::get('debugMode') ? OutputStyle::EXPANDED : OutputStyle::COMPRESSED));
+			$objCompiler->setOutputStyle(($blnDebug ? OutputStyle::EXPANDED : OutputStyle::COMPRESSED));
 
-			if (Config::get('debugMode'))
+			if ($blnDebug)
 			{
 				$objCompiler->setSourceMap(Compiler::SOURCE_MAP_INLINE);
 			}
@@ -423,7 +426,7 @@ class Combiner extends System
 		$arrOptions = array
 		(
 			'strictMath' => true,
-			'compress' => !Config::get('debugMode'),
+			'compress' => !$blnDebug,
 			'import_dirs' => array($this->strRootDir . '/' . $strPath => $strPath)
 		);
 

--- a/core-bundle/src/Resources/contao/library/Contao/Config.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Config.php
@@ -102,7 +102,7 @@ class Config
 	private static $arrDeprecated = array
 	(
 		'validImageTypes' => 'contao.image.valid_extensions',
-		'jpgQuality'      => 'contao.image.imagine_options.jpeg_quality',
+		'jpgQuality'      => 'contao.image.imagine_options[jpeg_quality]',
 	);
 
 	/**

--- a/core-bundle/src/Resources/contao/library/Contao/Config.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Config.php
@@ -77,6 +77,34 @@ class Config
 	 */
 	protected $strRootDir;
 
+	private static $arrDeprecatedMap = array
+	(
+		'dbHost'           => 'database_host',
+		'dbPort'           => 'database_port',
+		'dbUser'           => 'database_user',
+		'dbPass'           => 'database_password',
+		'dbDatabase'       => 'database_name',
+		'smtpHost'         => 'mailer_host',
+		'smtpUser'         => 'mailer_user',
+		'smtpPass'         => 'mailer_password',
+		'smtpPort'         => 'mailer_port',
+		'smtpEnc'          => 'mailer_encryption',
+		'addLanguageToUrl' => 'contao.prepend_locale',
+		'urlSuffix'        => 'contao.url_suffix',
+		'uploadPath'       => 'contao.upload_path',
+		'editableFiles'    => 'contao.editable_files',
+		'debugMode'        => 'kernel.debug',
+		'characterSet'     => 'kernel.charset',
+		'enableSearch'     => 'contao.search.default_indexer.enable',
+		'indexProtected'   => 'contao.search.index_protected',
+	);
+
+	private static $arrDeprecated = array
+	(
+		'validImageTypes' => 'contao.image.valid_extensions',
+		'jpgQuality'      => 'contao.image.imagine_options.jpeg_quality',
+	);
+
 	/**
 	 * Prevent direct instantiation (Singleton)
 	 */
@@ -380,6 +408,11 @@ class Config
 	 */
 	public static function get($strKey)
 	{
+		if (isset(self::$arrDeprecated[$strKey]) || isset(self::$arrDeprecatedMap[$strKey]))
+		{
+			trigger_deprecation('contao/core-bundle', '4.12', 'Using "%s(\'%s\')" has been deprecated. Use the "%s" parameter instead.', __METHOD__, $strKey, self::$arrDeprecated[$strKey] ?? self::$arrDeprecatedMap[$strKey]);
+		}
+
 		return $GLOBALS['TL_CONFIG'][$strKey] ?? null;
 	}
 
@@ -391,6 +424,11 @@ class Config
 	 */
 	public static function set($strKey, $varValue)
 	{
+		if (isset(self::$arrDeprecated[$strKey]) || isset(self::$arrDeprecatedMap[$strKey]))
+		{
+			trigger_deprecation('contao/core-bundle', '4.12', 'Using "%s(\'%s\', …)" has been deprecated. Use the "%s" parameter instead.', __METHOD__, $strKey, self::$arrDeprecated[$strKey] ?? self::$arrDeprecatedMap[$strKey]);
+		}
+
 		$GLOBALS['TL_CONFIG'][$strKey] = $varValue;
 	}
 
@@ -472,28 +510,7 @@ class Config
 			}
 		}
 
-		$arrMap = array
-		(
-			'dbHost'           => 'database_host',
-			'dbPort'           => 'database_port',
-			'dbUser'           => 'database_user',
-			'dbPass'           => 'database_password',
-			'dbDatabase'       => 'database_name',
-			'smtpHost'         => 'mailer_host',
-			'smtpUser'         => 'mailer_user',
-			'smtpPass'         => 'mailer_password',
-			'smtpPort'         => 'mailer_port',
-			'smtpEnc'          => 'mailer_encryption',
-			'addLanguageToUrl' => 'contao.prepend_locale',
-			'urlSuffix'        => 'contao.url_suffix',
-			'uploadPath'       => 'contao.upload_path',
-			'editableFiles'    => 'contao.editable_files',
-			'debugMode'        => 'kernel.debug',
-			'enableSearch'     => 'contao.search.default_indexer.enable',
-			'indexProtected'   => 'contao.search.index_protected',
-		);
-
-		foreach ($arrMap as $strKey=>$strParam)
+		foreach (self::$arrDeprecatedMap as $strKey=>$strParam)
 		{
 			if ($container->hasParameter($strParam))
 			{

--- a/core-bundle/src/Resources/contao/library/Contao/Controller.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Controller.php
@@ -1275,7 +1275,7 @@ abstract class Controller extends System
 		}
 
 		// Limit downloads to the files directory
-		if (!preg_match('@^' . preg_quote(Config::get('uploadPath'), '@') . '@i', $strFile))
+		if (!preg_match('@^' . preg_quote(System::getContainer()->getParameter('contao.upload_path'), '@') . '@i', $strFile))
 		{
 			throw new PageNotFoundException('Invalid path');
 		}

--- a/core-bundle/src/Resources/contao/library/Contao/Database/Updater.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Database/Updater.php
@@ -11,7 +11,6 @@
 namespace Contao\Database;
 
 use Contao\ArrayUtil;
-use Contao\Config;
 use Contao\Controller;
 use Contao\Database;
 use Contao\Dbafs;
@@ -644,7 +643,7 @@ class Updater extends Controller
 	{
 		if ($strPath === null)
 		{
-			$strPath = Config::get('uploadPath');
+			$strPath = System::getContainer()->getParameter('contao.upload_path');
 		}
 
 		$arrMeta = array();
@@ -975,17 +974,18 @@ class Updater extends Controller
 	protected static function generateHelperObject($value)
 	{
 		$return = new \stdClass();
+		$strUploadPath = System::getContainer()->getParameter('contao.upload_path');
 
 		if (!\is_array($value))
 		{
 			$return->value = rtrim($value, "\x00");
-			$return->isUuid = (\strlen($value) == 16 && !is_numeric($return->value) && strncmp($return->value, Config::get('uploadPath') . '/', \strlen(Config::get('uploadPath')) + 1) !== 0);
+			$return->isUuid = (\strlen($value) == 16 && !is_numeric($return->value) && strncmp($return->value, $strUploadPath . '/', \strlen($strUploadPath) + 1) !== 0);
 			$return->isNumeric = (is_numeric($return->value) && $return->value > 0);
 		}
 		else
 		{
 			$return->value = array_map(static function ($var) { return rtrim($var, "\x00"); }, $value);
-			$return->isUuid = (\strlen($value[0]) == 16 && !is_numeric($return->value[0]) && strncmp($return->value[0], Config::get('uploadPath') . '/', \strlen(Config::get('uploadPath')) + 1) !== 0);
+			$return->isUuid = (\strlen($value[0]) == 16 && !is_numeric($return->value[0]) && strncmp($return->value[0], $strUploadPath . '/', \strlen($strUploadPath) + 1) !== 0);
 			$return->isNumeric = (is_numeric($return->value[0]) && $return->value[0] > 0);
 		}
 

--- a/core-bundle/src/Resources/contao/library/Contao/Dbafs.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Dbafs.php
@@ -49,7 +49,7 @@ class Dbafs
 	{
 		self::validateUtf8Path($strResource);
 
-		$strUploadPath = Config::get('uploadPath') . '/';
+		$strUploadPath = System::getContainer()->getParameter('contao.upload_path') . '/';
 		$projectDir = System::getContainer()->getParameter('kernel.project_dir');
 
 		// Remove trailing slashes (see #5707)
@@ -255,7 +255,7 @@ class Dbafs
 		$strFolder = \dirname($strDestination);
 
 		// Set the new parent ID
-		if ($strFolder == Config::get('uploadPath'))
+		if ($strFolder == System::getContainer()->getParameter('contao.upload_path'))
 		{
 			$objFile->pid = null;
 		}
@@ -292,12 +292,12 @@ class Dbafs
 		}
 
 		// Update the MD5 hash of the parent folders
-		if (($strPath = \dirname($strSource)) != Config::get('uploadPath'))
+		if (($strPath = \dirname($strSource)) != System::getContainer()->getParameter('contao.upload_path'))
 		{
 			static::updateFolderHashes($strPath);
 		}
 
-		if (($strPath = \dirname($strDestination)) != Config::get('uploadPath'))
+		if (($strPath = \dirname($strDestination)) != System::getContainer()->getParameter('contao.upload_path'))
 		{
 			static::updateFolderHashes($strPath);
 		}
@@ -333,7 +333,7 @@ class Dbafs
 		$objNewFile = clone $objFile->current();
 
 		// Set the new parent ID
-		if ($strFolder == Config::get('uploadPath'))
+		if ($strFolder == System::getContainer()->getParameter('contao.upload_path'))
 		{
 			$objNewFile->pid = null;
 		}
@@ -378,12 +378,12 @@ class Dbafs
 		}
 
 		// Update the MD5 hash of the parent folders
-		if (($strPath = \dirname($strSource)) != Config::get('uploadPath'))
+		if (($strPath = \dirname($strSource)) != System::getContainer()->getParameter('contao.upload_path'))
 		{
 			static::updateFolderHashes($strPath);
 		}
 
-		if (($strPath = \dirname($strDestination)) != Config::get('uploadPath'))
+		if (($strPath = \dirname($strDestination)) != System::getContainer()->getParameter('contao.upload_path'))
 		{
 			static::updateFolderHashes($strPath);
 		}
@@ -521,7 +521,7 @@ class Dbafs
 		$objFiles = new \RecursiveIteratorIterator(
 			new SyncExclude(
 				new \RecursiveDirectoryIterator(
-					$projectDir . '/' . Config::get('uploadPath'),
+					$projectDir . '/' . System::getContainer()->getParameter('contao.upload_path'),
 					\FilesystemIterator::UNIX_PATHS|\FilesystemIterator::FOLLOW_SYMLINKS|\FilesystemIterator::SKIP_DOTS
 				)
 			),
@@ -575,7 +575,7 @@ class Dbafs
 				$strParent = \dirname($strRelpath);
 
 				// Get the parent ID
-				if ($strParent == Config::get('uploadPath'))
+				if ($strParent == System::getContainer()->getParameter('contao.upload_path'))
 				{
 					$strPid = null;
 				}

--- a/core-bundle/src/Resources/contao/library/Contao/Dbafs.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Dbafs.php
@@ -830,11 +830,6 @@ class Dbafs
 	 */
 	protected static function isFileSyncExclude($strPath)
 	{
-		if (Config::get('uploadPath') == 'templates')
-		{
-			return true;
-		}
-
 		self::validateUtf8Path($strPath);
 
 		$projectDir = System::getContainer()->getParameter('kernel.project_dir');

--- a/core-bundle/src/Resources/contao/library/Contao/Email.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Email.php
@@ -129,7 +129,7 @@ class Email
 	public function __construct($objMailer = null)
 	{
 		$this->objMailer = $objMailer ?: System::getContainer()->get('mailer');
-		$this->strCharset = Config::get('characterSet');
+		$this->strCharset = System::getContainer()->getParameter('kernel.charset');
 
 		if ($this->objMailer instanceof MailerInterface)
 		{

--- a/core-bundle/src/Resources/contao/library/Contao/Feed.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Feed.php
@@ -120,7 +120,7 @@ class Feed
 	{
 		$this->adjustPublicationDate();
 
-		$xml  = '<?xml version="1.0" encoding="' . Config::get('characterSet') . '"?>';
+		$xml  = '<?xml version="1.0" encoding="' . System::getContainer()->getParameter('kernel.charset') . '"?>';
 		$xml .= '<rss version="2.0" xmlns:media="http://search.yahoo.com/mrss/" xmlns:atom="http://www.w3.org/2005/Atom">';
 		$xml .= '<channel>';
 		$xml .= '<title>' . StringUtil::specialchars($this->title) . '</title>';
@@ -191,7 +191,7 @@ class Feed
 	{
 		$this->adjustPublicationDate();
 
-		$xml  = '<?xml version="1.0" encoding="' . Config::get('characterSet') . '"?>';
+		$xml  = '<?xml version="1.0" encoding="' . System::getContainer()->getParameter('kernel.charset') . '"?>';
 		$xml .= '<feed xmlns="http://www.w3.org/2005/Atom" xmlns:media="http://search.yahoo.com/mrss/" xml:lang="' . $this->language . '">';
 		$xml .= '<title>' . StringUtil::specialchars($this->title) . '</title>';
 		$xml .= '<subtitle>' . StringUtil::specialchars($this->description) . '</subtitle>';

--- a/core-bundle/src/Resources/contao/library/Contao/Image.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Image.php
@@ -139,7 +139,7 @@ class Image
 		}
 
 		$this->fileObj = $file;
-		$arrAllowedTypes = StringUtil::trimsplit(',', strtolower(Config::get('validImageTypes')));
+		$arrAllowedTypes = System::getContainer()->getParameter('contao.image.valid_extensions');
 
 		// Check the file type
 		if (!\in_array($this->fileObj->extension, $arrAllowedTypes))

--- a/core-bundle/src/Resources/contao/library/Contao/Input.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Input.php
@@ -672,7 +672,7 @@ class Input
 
 		// Preserve basic entities
 		$varValue = static::preserveBasicEntities($varValue);
-		$varValue = html_entity_decode($varValue, ENT_QUOTES, Config::get('characterSet'));
+		$varValue = html_entity_decode($varValue, ENT_QUOTES, System::getContainer()->getParameter('kernel.charset'));
 
 		return $varValue;
 	}

--- a/core-bundle/src/Resources/contao/library/Contao/StringUtil.php
+++ b/core-bundle/src/Resources/contao/library/Contao/StringUtil.php
@@ -233,7 +233,7 @@ class StringUtil
 
 		if ($strCharset === null)
 		{
-			$strCharset = Config::get('characterSet');
+			$strCharset = $GLOBALS['TL_CONFIG']['characterSet'] ?? 'UTF-8';
 		}
 
 		$strString = preg_replace('/(&#*\w+)[\x00-\x20]+;/i', '$1;', $strString);
@@ -792,7 +792,7 @@ class StringUtil
 		}
 
 		// Use ENT_COMPAT here (see #4889)
-		return htmlspecialchars($strString, ENT_COMPAT, Config::get('characterSet'), $blnDoubleEncode);
+		return htmlspecialchars($strString, ENT_COMPAT, $GLOBALS['TL_CONFIG']['characterSet'] ?? 'UTF-8', $blnDoubleEncode);
 	}
 
 	/**
@@ -827,7 +827,7 @@ class StringUtil
 		$arrSearch = array('/[^\pN\pL \.\&\/_-]+/u', '/[ \.\&\/-]+/');
 		$arrReplace = array('', '-');
 
-		$strString = html_entity_decode($strString, ENT_QUOTES, $GLOBALS['TL_CONFIG']['characterSet']);
+		$strString = html_entity_decode($strString, ENT_QUOTES, $GLOBALS['TL_CONFIG']['characterSet'] ?? 'UTF-8');
 		$strString = static::stripInsertTags($strString);
 		$strString = preg_replace($arrSearch, $arrReplace, $strString);
 

--- a/core-bundle/src/Resources/contao/library/Contao/StringUtil.php
+++ b/core-bundle/src/Resources/contao/library/Contao/StringUtil.php
@@ -233,7 +233,7 @@ class StringUtil
 
 		if ($strCharset === null)
 		{
-			$strCharset = $GLOBALS['TL_CONFIG']['characterSet'] ?? 'UTF-8';
+			$strCharset = 'UTF-8';
 		}
 
 		$strString = preg_replace('/(&#*\w+)[\x00-\x20]+;/i', '$1;', $strString);

--- a/core-bundle/src/Resources/contao/library/Contao/Template.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Template.php
@@ -308,7 +308,7 @@ abstract class Template extends Controller
 
 		$this->compile();
 
-		header('Content-Type: ' . $this->strContentType . '; charset=' . Config::get('characterSet'));
+		header('Content-Type: ' . $this->strContentType . '; charset=' . System::getContainer()->getParameter('kernel.charset'));
 
 		echo $this->strBuffer;
 	}
@@ -323,7 +323,8 @@ abstract class Template extends Controller
 		$this->compile();
 
 		$response = new Response($this->strBuffer);
-		$response->headers->set('Content-Type', $this->strContentType . '; charset=' . Config::get('characterSet'));
+		$response->headers->set('Content-Type', $this->strContentType);
+		$response->setCharset(System::getContainer()->getParameter('kernel.charset'));
 		$response->headers->set('Permissions-Policy', 'interest-cohort=()');
 
 		// Mark this response to affect the caching of the current page but remove any default cache headers
@@ -473,7 +474,7 @@ abstract class Template extends Controller
 	 */
 	public function minifyHtml($strHtml)
 	{
-		if (Config::get('debugMode'))
+		if (System::getContainer()->getParameter('kernel.debug'))
 		{
 			return $strHtml;
 		}

--- a/core-bundle/src/Resources/contao/library/Contao/TemplateInheritance.php
+++ b/core-bundle/src/Resources/contao/library/Contao/TemplateInheritance.php
@@ -134,7 +134,7 @@ trait TemplateInheritance
 		$this->arrBlocks = array();
 
 		// Add start and end markers in debug mode
-		if (Config::get('debugMode'))
+		if (System::getContainer()->getParameter('kernel.debug'))
 		{
 			$strRelPath = StringUtil::stripRootDir($this->getTemplatePath($this->strTemplate, $this->strFormat));
 			$strBuffer = "\n<!-- TEMPLATE START: $strRelPath -->\n$strBuffer\n<!-- TEMPLATE END: $strRelPath -->\n";

--- a/core-bundle/src/Resources/contao/library/Contao/Widget.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Widget.php
@@ -1257,11 +1257,6 @@ abstract class Widget extends Controller
 				$varAttrValue = $objParameterBag->resolveValue($varAttrValue);
 				$varAttrValue = $objParameterBag->unescapeValue($varAttrValue);
 
-				if ($strAttrKey === 'extensions' && \is_array($varAttrValue))
-				{
-					$varAttrValue = implode(',', $varAttrValue);
-				}
-
 				$arrAttributes[$strAttrKey] = $varAttrValue;
 			}
 		}

--- a/core-bundle/src/Resources/contao/library/Contao/Widget.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Widget.php
@@ -1253,6 +1253,19 @@ abstract class Widget extends Controller
 		$arrAttributes['dataContainer'] = $objDca;
 		$arrAttributes['value'] = StringUtil::deserialize($varValue);
 
+		if (method_exists(System::getContainer(), 'getParameterBag'))
+		{
+			if (isset($arrAttributes['extensions']))
+			{
+				$arrAttributes['extensions'] = System::getContainer()->getParameterBag()->resolveString($arrAttributes['extensions']);
+
+				if (\is_array($arrAttributes['extensions']))
+				{
+					$arrAttributes['extensions'] = implode(',', $arrAttributes['extensions']);
+				}
+			}
+		}
+
 		// Internet Explorer does not support onchange for checkboxes and radio buttons
 		if ($arrData['eval']['submitOnChange'] ?? null)
 		{

--- a/core-bundle/src/Resources/contao/library/Contao/Widget.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Widget.php
@@ -1243,6 +1243,29 @@ abstract class Widget extends Controller
 	{
 		$arrAttributes = $arrData['eval'] ?? array();
 
+		if (method_exists(System::getContainer(), 'getParameterBag'))
+		{
+			$objParameterBag = System::getContainer()->getParameterBag();
+
+			foreach ($arrAttributes as $strAttrKey => $varAttrValue)
+			{
+				if (!\is_string($varAttrValue) || !preg_match('/%[a-z][a-z0-9_]*\.[a-z0-9_.]+%/i', $varAttrValue, $arrMatches))
+				{
+					continue;
+				}
+
+				$varAttrValue = $objParameterBag->resolveValue($varAttrValue);
+				$varAttrValue = $objParameterBag->unescapeValue($varAttrValue);
+
+				if ($strAttrKey === 'extensions' && \is_array($varAttrValue))
+				{
+					$varAttrValue = implode(',', $varAttrValue);
+				}
+
+				$arrAttributes[$strAttrKey] = $varAttrValue;
+			}
+		}
+
 		$arrAttributes['id'] = $strName;
 		$arrAttributes['name'] = $strName;
 		$arrAttributes['strField'] = $strField;
@@ -1252,19 +1275,6 @@ abstract class Widget extends Controller
 		$arrAttributes['type'] = $arrData['inputType'] ?? null;
 		$arrAttributes['dataContainer'] = $objDca;
 		$arrAttributes['value'] = StringUtil::deserialize($varValue);
-
-		if (method_exists(System::getContainer(), 'getParameterBag'))
-		{
-			if (isset($arrAttributes['extensions']))
-			{
-				$arrAttributes['extensions'] = System::getContainer()->getParameterBag()->resolveString($arrAttributes['extensions']);
-
-				if (\is_array($arrAttributes['extensions']))
-				{
-					$arrAttributes['extensions'] = implode(',', $arrAttributes['extensions']);
-				}
-			}
-		}
 
 		// Internet Explorer does not support onchange for checkboxes and radio buttons
 		if ($arrData['eval']['submitOnChange'] ?? null)

--- a/core-bundle/src/Resources/contao/modules/ModuleArticle.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleArticle.php
@@ -280,7 +280,7 @@ class ModuleArticle extends Module
 
 		// Generate article
 		$strArticle = $this->replaceInsertTags($this->generate(), false);
-		$strArticle = html_entity_decode($strArticle, ENT_QUOTES, Config::get('characterSet'));
+		$strArticle = html_entity_decode($strArticle, ENT_QUOTES, System::getContainer()->getParameter('kernel.charset'));
 		$strArticle = $this->convertRelativeUrls($strArticle, '', true);
 
 		if (empty($GLOBALS['TL_HOOKS']['printArticleAsPdf']))

--- a/core-bundle/src/Resources/contao/modules/ModuleRssReader.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleRssReader.php
@@ -65,7 +65,7 @@ class ModuleRssReader extends Module
 			$this->objFeed->set_feed_url($arrUrls[0]);
 		}
 
-		$this->objFeed->set_output_encoding(Config::get('characterSet'));
+		$this->objFeed->set_output_encoding(System::getContainer()->getParameter('kernel.charset'));
 		$this->objFeed->set_cache_location(System::getContainer()->getParameter('kernel.project_dir') . '/system/tmp');
 		$this->objFeed->enable_cache(false);
 

--- a/core-bundle/src/Resources/contao/pages/PageRegular.php
+++ b/core-bundle/src/Resources/contao/pages/PageRegular.php
@@ -442,7 +442,7 @@ class PageRegular extends Frontend
 		// Default settings
 		$this->Template->layout = $objLayout;
 		$this->Template->language = $GLOBALS['TL_LANGUAGE'];
-		$this->Template->charset = Config::get('characterSet');
+		$this->Template->charset = System::getContainer()->getParameter('kernel.charset');
 		$this->Template->base = Environment::get('base');
 		$this->Template->isRTL = false;
 	}

--- a/core-bundle/src/Resources/contao/widgets/FileSelector.php
+++ b/core-bundle/src/Resources/contao/widgets/FileSelector.php
@@ -245,7 +245,7 @@ class FileSelector extends Widget
 		// Start from root
 		elseif ($this->User->isAdmin)
 		{
-			$tree .= $this->renderFiletree($projectDir . '/' . Config::get('uploadPath'), 0, false, true, $arrFound);
+			$tree .= $this->renderFiletree($projectDir . '/' . System::getContainer()->getParameter('contao.upload_path'), 0, false, true, $arrFound);
 		}
 
 		// Show mounted files to regular users
@@ -556,7 +556,7 @@ class FileSelector extends Widget
 					}
 				}
 
-				$return .= Image::getHtml($objFile->icon, $objFile->mime) . ' ' . StringUtil::convertEncoding(StringUtil::specialchars(basename($currentFile)), Config::get('characterSet')) . $thumbnail . '</div> <div class="tl_right">';
+				$return .= Image::getHtml($objFile->icon, $objFile->mime) . ' ' . StringUtil::convertEncoding(StringUtil::specialchars(basename($currentFile)), System::getContainer()->getParameter('kernel.charset')) . $thumbnail . '</div> <div class="tl_right">';
 
 				// Add checkbox or radio button
 				switch ($this->fieldType)
@@ -603,7 +603,7 @@ class FileSelector extends Widget
 		}
 
 		// TinyMCE will pass the path instead of the ID
-		if (strpos($this->varValue[0], Config::get('uploadPath') . '/') === 0)
+		if (strpos($this->varValue[0], System::getContainer()->getParameter('contao.upload_path') . '/') === 0)
 		{
 			return;
 		}
@@ -615,7 +615,7 @@ class FileSelector extends Widget
 		}
 
 		// Return if the custom path is not within the upload path (see #8562)
-		if ($this->path && strpos($this->path, Config::get('uploadPath') . '/') !== 0)
+		if ($this->path && strpos($this->path, System::getContainer()->getParameter('contao.upload_path') . '/') !== 0)
 		{
 			return;
 		}

--- a/core-bundle/src/Resources/contao/widgets/FileSelector.php
+++ b/core-bundle/src/Resources/contao/widgets/FileSelector.php
@@ -63,6 +63,16 @@ class FileSelector extends Widget
 		parent::__construct($arrAttributes);
 	}
 
+	public function __set($strKey, $varValue)
+	{
+		if ($strKey === 'extensions' && \is_array($varValue))
+		{
+			$varValue = implode(',', $varValue);
+		}
+
+		parent::__set($strKey, $varValue);
+	}
+
 	/**
 	 * Generate the widget and return it as string
 	 *

--- a/core-bundle/src/Resources/contao/widgets/FileTree.php
+++ b/core-bundle/src/Resources/contao/widgets/FileTree.php
@@ -85,6 +85,16 @@ class FileTree extends Widget
 		}
 	}
 
+	public function __set($strKey, $varValue)
+	{
+		if ($strKey === 'extensions' && \is_array($varValue))
+		{
+			$varValue = implode(',', $varValue);
+		}
+
+		parent::__set($strKey, $varValue);
+	}
+
 	/**
 	 * Return an array if the "multiple" attribute is set
 	 *

--- a/core-bundle/tests/Contao/CombinerTest.php
+++ b/core-bundle/tests/Contao/CombinerTest.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Tests\Contao;
 
 use Contao\Combiner;
-use Contao\Config;
 use Contao\CoreBundle\Asset\ContaoContext;
 use Contao\System;
 use Contao\TestCase\ContaoTestCase;
@@ -52,7 +51,6 @@ class CombinerTest extends ContaoTestCase
         $container->setParameter('contao.web_dir', $this->getTempDir().'/web');
         $container->set('contao.assets.assets_context', $context);
 
-        Config::set('debugMode', false);
         System::setContainer($container);
     }
 
@@ -100,7 +98,7 @@ class CombinerTest extends ContaoTestCase
             "file1 { background: url(\"../../foo.bar\") }\n@media screen{\nweb/file2\n}\n@media screen{\nfile3\n}\n"
         );
 
-        Config::set('debugMode', true);
+        System::getContainer()->setParameter('kernel.debug', true);
 
         $hash = substr(md5((string) $mtime), 0, 8);
 
@@ -241,7 +239,7 @@ class CombinerTest extends ContaoTestCase
             "body{color:red}\nbody{color:green}\n"
         );
 
-        Config::set('debugMode', true);
+        System::getContainer()->setParameter('kernel.debug', true);
 
         $hash1 = substr(md5((string) $mtime1), 0, 8);
         $hash2 = substr(md5((string) $mtime2), 0, 8);
@@ -277,7 +275,7 @@ class CombinerTest extends ContaoTestCase
         $this->assertRegExp('/^assets\/js\/file1\.js\,file2\.js-[a-z0-9]+\.js$/', $combinedFile);
         $this->assertStringEqualsFile($this->getTempDir().'/'.$combinedFile, "file1();\nfile2();\n");
 
-        Config::set('debugMode', true);
+        System::getContainer()->setParameter('kernel.debug', true);
 
         $hash1 = substr(md5((string) $mtime1), 0, 8);
         $hash2 = substr(md5((string) $mtime2), 0, 8);

--- a/core-bundle/tests/Contao/RoutingTest.php
+++ b/core-bundle/tests/Contao/RoutingTest.php
@@ -39,12 +39,13 @@ class RoutingTest extends ContaoTestCase
         parent::setUp();
 
         Config::set('urlSuffix', '.html');
-        Config::set('addLanguageToUrl', false);
+        $GLOBALS['TL_CONFIG']['addLanguageToUrl'] = false;
         Config::set('useAutoItem', false);
 
         Environment::reset();
 
         $container = new ContainerBuilder();
+        $container->setParameter('kernel.charset', 'UTF-8');
         $container->setParameter('contao.legacy_routing', true);
 
         System::setContainer($container);
@@ -308,7 +309,7 @@ class RoutingTest extends ContaoTestCase
         $requestStack->push($request);
 
         System::getContainer()->set('request_stack', $requestStack);
-        Config::set('addLanguageToUrl', true);
+        $GLOBALS['TL_CONFIG']['addLanguageToUrl'] = true;
 
         $this->assertNull(Frontend::getPageIdFromUrl());
         $this->assertSame(['language' => 'en'], $_GET);
@@ -335,7 +336,7 @@ class RoutingTest extends ContaoTestCase
         $requestStack->push($request);
 
         System::getContainer()->set('request_stack', $requestStack);
-        Config::set('addLanguageToUrl', true);
+        $GLOBALS['TL_CONFIG']['addLanguageToUrl'] = true;
 
         $this->assertFalse(Frontend::getPageIdFromUrl());
         $this->assertEmpty($_GET);
@@ -363,7 +364,7 @@ class RoutingTest extends ContaoTestCase
 
         System::getContainer()->set('request_stack', $requestStack);
         System::getContainer()->set('contao.framework', $this->mockFrameworkWithPageAdapter());
-        Config::set('addLanguageToUrl', true);
+        $GLOBALS['TL_CONFIG']['addLanguageToUrl'] = true;
         Config::set('useAutoItem', true);
 
         $this->assertFalse(Frontend::getPageIdFromUrl());
@@ -517,7 +518,7 @@ class RoutingTest extends ContaoTestCase
 
         System::getContainer()->set('request_stack', $requestStack);
         System::getContainer()->set('contao.framework', $framework);
-        Config::set('addLanguageToUrl', true);
+        $GLOBALS['TL_CONFIG']['addLanguageToUrl'] = true;
 
         $this->assertSame('foo/bar/home', Frontend::getPageIdFromUrl());
         $this->assertSame(['language' => 'en', 'news' => 'test'], $_GET);

--- a/core-bundle/tests/Contao/StringUtilTest.php
+++ b/core-bundle/tests/Contao/StringUtilTest.php
@@ -40,8 +40,6 @@ class StringUtilTest extends TestCase
 
     public function testGeneratesAliases(): void
     {
-        $GLOBALS['TL_CONFIG']['characterSet'] = 'UTF-8';
-
         $this->assertSame('foo', StringUtil::generateAlias('foo'));
         $this->assertSame('foo', StringUtil::generateAlias('FOO'));
         $this->assertSame('foo-bar', StringUtil::generateAlias('foo bar'));

--- a/core-bundle/tests/Contao/StringUtilTest.php
+++ b/core-bundle/tests/Contao/StringUtilTest.php
@@ -31,6 +31,7 @@ class StringUtilTest extends TestCase
         $container->setParameter('kernel.project_dir', $this->getFixturesDir());
         $container->setParameter('kernel.cache_dir', $this->getFixturesDir().'/cache');
         $container->setParameter('kernel.debug', false);
+        $container->setParameter('kernel.charset', 'UTF-8');
         $container->set('request_stack', new RequestStack());
         $container->set('contao.security.token_checker', $this->createMock(TokenChecker::class));
         $container->set('monolog.logger.contao', new NullLogger());

--- a/core-bundle/tests/Contao/TemplateTest.php
+++ b/core-bundle/tests/Contao/TemplateTest.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Tests\Contao;
 
 use Contao\BackendTemplate;
-use Contao\Config;
 use Contao\CoreBundle\Image\Studio\FigureRenderer;
 use Contao\CoreBundle\Tests\TestCase;
 use Contao\FrontendTemplate;
@@ -33,7 +32,6 @@ class TemplateTest extends TestCase
         (new Filesystem())->mkdir(Path::join($this->getTempDir(), 'templates'));
 
         System::setContainer($this->getContainerWithContaoConfiguration($this->getTempDir()));
-        Config::set('debugMode', false);
     }
 
     protected function tearDown(): void
@@ -45,8 +43,6 @@ class TemplateTest extends TestCase
 
     public function testReplacesTheVariables(): void
     {
-        Config::set('debugMode', false);
-
         (new Filesystem())->dumpFile(
             Path::join($this->getTempDir(), 'templates/test_template.html5'),
             '<?= $this->value ?>'

--- a/core-bundle/tests/Contao/WidgetTest.php
+++ b/core-bundle/tests/Contao/WidgetTest.php
@@ -28,6 +28,7 @@ class WidgetTest extends TestCase
 
         $container = new ContainerBuilder();
         $container->set('request_stack', new RequestStack());
+        $container->setParameter('kernel.charset', 'UTF-8');
 
         System::setContainer($container);
     }

--- a/core-bundle/tests/Contao/WidgetTest.php
+++ b/core-bundle/tests/Contao/WidgetTest.php
@@ -228,16 +228,9 @@ class WidgetTest extends TestCase
         ];
 
         yield [
-            [['eval' => ['foo' => '%contao.image.valid_extensions%']], 'name'],
-            [
-                'foo' => ['jpg', 'gif', 'png'],
-            ],
-        ];
-
-        yield [
             [['eval' => ['extensions' => '%contao.image.valid_extensions%']], 'name'],
             [
-                'extensions' => 'jpg,gif,png',
+                'extensions' => ['jpg', 'gif', 'png'],
             ],
         ];
     }

--- a/core-bundle/tests/Contao/WidgetTest.php
+++ b/core-bundle/tests/Contao/WidgetTest.php
@@ -29,6 +29,7 @@ class WidgetTest extends TestCase
         $container = new ContainerBuilder();
         $container->set('request_stack', new RequestStack());
         $container->setParameter('kernel.charset', 'UTF-8');
+        $container->setParameter('contao.image.valid_extensions', ['jpg', 'gif', 'png']);
 
         System::setContainer($container);
     }
@@ -167,5 +168,77 @@ class WidgetTest extends TestCase
             ->setInputCallback()
             ->validate() // getPost() should be called once here
 ;
+    }
+
+    /**
+     * @dataProvider getAttributesFromDca
+     */
+    public function testGetsAttributesFromDca(array $parameters, array $expected): void
+    {
+        $attrs = Widget::getAttributesFromDca(...$parameters);
+
+        foreach ($expected as $key => $value) {
+            $this->assertSame($value, $attrs[$key]);
+        }
+    }
+
+    public function getAttributesFromDca()
+    {
+        yield [
+            [[], 'foo'],
+            [
+                'name' => 'foo',
+                'id' => 'foo',
+            ],
+        ];
+
+        yield [
+            [['eval' => ['foo' => '%kernel.charset%']], 'name'],
+            [
+                'foo' => 'UTF-8',
+            ],
+        ];
+
+        yield [
+            [['eval' => ['foo' => 'bar%kernel.charset%baz']], 'name'],
+            [
+                'foo' => 'barUTF-8baz',
+            ],
+        ];
+
+        yield [
+            [['eval' => ['foo' => '%%b%%ar%kernel.charset%ba%%z']], 'name'],
+            [
+                'foo' => '%b%arUTF-8ba%z',
+            ],
+        ];
+
+        yield [
+            [['eval' => ['foo' => '%%% xxx %%%']], 'name'],
+            [
+                'foo' => '%%% xxx %%%',
+            ],
+        ];
+
+        yield [
+            [['eval' => ['foo' => '50% discount 20% VAT']], 'name'],
+            [
+                'foo' => '50% discount 20% VAT',
+            ],
+        ];
+
+        yield [
+            [['eval' => ['foo' => '%contao.image.valid_extensions%']], 'name'],
+            [
+                'foo' => ['jpg', 'gif', 'png'],
+            ],
+        ];
+
+        yield [
+            [['eval' => ['extensions' => '%contao.image.valid_extensions%']], 'name'],
+            [
+                'extensions' => 'jpg,gif,png',
+            ],
+        ];
     }
 }

--- a/core-bundle/tests/Controller/BackendCsvImportControllerTest.php
+++ b/core-bundle/tests/Controller/BackendCsvImportControllerTest.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Tests\Controller;
 
-use Contao\Config;
 use Contao\CoreBundle\Config\ResourceFinder;
 use Contao\CoreBundle\Controller\BackendCsvImportController;
 use Contao\CoreBundle\Exception\InternalServerErrorException;
@@ -44,7 +43,6 @@ class BackendCsvImportControllerTest extends TestCase
         $container->set('contao.resource_finder', $finder);
 
         System::setContainer($container);
-        Config::set('debugMode', false);
     }
 
     public function testRendersTheListWizardMarkup(): void

--- a/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
+++ b/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
@@ -4350,6 +4350,7 @@ class ContaoCoreExtensionTest extends TestCase
         $container = new ContainerBuilder(
             new ParameterBag([
                 'kernel.debug' => false,
+                'kernel.charset' => 'UTF-8',
                 'kernel.project_dir' => Path::normalize($this->getTempDir()),
                 'kernel.default_locale' => 'en',
             ])
@@ -4377,6 +4378,7 @@ class ContaoCoreExtensionTest extends TestCase
         $container = new ContainerBuilder(
             new ParameterBag([
                 'kernel.debug' => false,
+                'kernel.charset' => 'UTF-8',
                 'kernel.project_dir' => $this->getTempDir(),
                 'kernel.default_locale' => 'en',
             ])

--- a/core-bundle/tests/Functional/RoutingTest.php
+++ b/core-bundle/tests/Functional/RoutingTest.php
@@ -51,7 +51,7 @@ class RoutingTest extends FunctionalTestCase
         $_GET = [];
 
         Config::set('useAutoItem', true);
-        Config::set('addLanguageToUrl', false);
+        $GLOBALS['TL_CONFIG']['addLanguageToUrl'] = false;
     }
 
     /**
@@ -411,7 +411,7 @@ class RoutingTest extends FunctionalTestCase
         $this->expectDeprecation('Since contao/core-bundle 4.10: Using the "Contao\CoreBundle\Routing\FrontendLoader" class has been deprecated %s.');
 
         Config::set('useAutoItem', $autoItem);
-        Config::set('addLanguageToUrl', true);
+        $GLOBALS['TL_CONFIG']['addLanguageToUrl'] = true;
 
         $_SERVER['REQUEST_URI'] = $request;
         $_SERVER['HTTP_HOST'] = $host;
@@ -1097,7 +1097,7 @@ class RoutingTest extends FunctionalTestCase
     {
         $this->expectDeprecation('Since contao/core-bundle 4.10: Using the "Contao\CoreBundle\Routing\FrontendLoader" class has been deprecated %s.');
 
-        Config::set('addLanguageToUrl', true);
+        $GLOBALS['TL_CONFIG']['addLanguageToUrl'] = true;
 
         $_SERVER['REQUEST_URI'] = $request;
         $_SERVER['HTTP_HOST'] = $host;
@@ -1305,7 +1305,7 @@ class RoutingTest extends FunctionalTestCase
         $this->expectDeprecation('Since contao/core-bundle 4.10: Using the "Contao\CoreBundle\Routing\FrontendLoader" class has been deprecated %s.');
 
         Config::set('folderUrl', true);
-        Config::set('addLanguageToUrl', true);
+        $GLOBALS['TL_CONFIG']['addLanguageToUrl'] = true;
 
         $request = 'https://domain1.local/it/';
 
@@ -1335,7 +1335,7 @@ class RoutingTest extends FunctionalTestCase
         $this->expectDeprecation('Since contao/core-bundle 4.10: Using the "Contao\CoreBundle\Routing\FrontendLoader" class has been deprecated %s.');
 
         Config::set('folderUrl', true);
-        Config::set('addLanguageToUrl', true);
+        $GLOBALS['TL_CONFIG']['addLanguageToUrl'] = true;
 
         $request = 'https://domain1.local/de/';
 

--- a/core-bundle/tests/Functional/RoutingTest.php
+++ b/core-bundle/tests/Functional/RoutingTest.php
@@ -50,7 +50,6 @@ class RoutingTest extends FunctionalTestCase
 
         $_GET = [];
 
-        Config::set('debugMode', false);
         Config::set('useAutoItem', true);
         Config::set('addLanguageToUrl', false);
     }

--- a/faq-bundle/composer.json
+++ b/faq-bundle/composer.json
@@ -29,7 +29,7 @@
     },
     "require-dev": {
         "contao/manager-plugin": "^2.3.1",
-        "contao/test-case": "^4.2",
+        "contao/test-case": "^4.3.1",
         "phpunit/phpunit": "^8.5",
         "symfony/http-client": "4.4.* || 5.2.*",
         "symfony/phpunit-bridge": "^5.2"

--- a/faq-bundle/composer.json
+++ b/faq-bundle/composer.json
@@ -14,12 +14,6 @@
             "homepage": "https://contao.org/contributors"
         }
     ],
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/ausi/contao-test-case"
-        }
-    ],
     "require": {
         "php": "^7.3 || ^8.0",
         "contao/core-bundle": "self.version",
@@ -35,7 +29,7 @@
     },
     "require-dev": {
         "contao/manager-plugin": "^2.3.1",
-        "contao/test-case": "dev-fix/missing-kernel-charset as 4.3.99",
+        "contao/test-case": "^4.2",
         "phpunit/phpunit": "^8.5",
         "symfony/http-client": "4.4.* || 5.2.*",
         "symfony/phpunit-bridge": "^5.2"

--- a/faq-bundle/composer.json
+++ b/faq-bundle/composer.json
@@ -14,6 +14,12 @@
             "homepage": "https://contao.org/contributors"
         }
     ],
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/ausi/contao-test-case"
+        }
+    ],
     "require": {
         "php": "^7.3 || ^8.0",
         "contao/core-bundle": "self.version",
@@ -29,7 +35,7 @@
     },
     "require-dev": {
         "contao/manager-plugin": "^2.3.1",
-        "contao/test-case": "^4.2",
+        "contao/test-case": "dev-fix/missing-kernel-charset as 4.3.99",
         "phpunit/phpunit": "^8.5",
         "symfony/http-client": "4.4.* || 5.2.*",
         "symfony/phpunit-bridge": "^5.2"

--- a/faq-bundle/src/Resources/contao/dca/tl_faq.php
+++ b/faq-bundle/src/Resources/contao/dca/tl_faq.php
@@ -246,7 +246,7 @@ $GLOBALS['TL_DCA']['tl_faq'] = array
 			'label'                   => &$GLOBALS['TL_LANG']['tl_content']['singleSRC'],
 			'exclude'                 => true,
 			'inputType'               => 'fileTree',
-			'eval'                    => array('fieldType'=>'radio', 'filesOnly'=>true, 'extensions'=>Config::get('validImageTypes'), 'mandatory'=>true),
+			'eval'                    => array('fieldType'=>'radio', 'filesOnly'=>true, 'extensions'=>implode(',', System::getContainer()->getParameter('contao.image.valid_extensions')), 'mandatory'=>true),
 			'sql'                     => "binary(16) NULL"
 		),
 		'alt' => array

--- a/faq-bundle/src/Resources/contao/dca/tl_faq.php
+++ b/faq-bundle/src/Resources/contao/dca/tl_faq.php
@@ -246,7 +246,7 @@ $GLOBALS['TL_DCA']['tl_faq'] = array
 			'label'                   => &$GLOBALS['TL_LANG']['tl_content']['singleSRC'],
 			'exclude'                 => true,
 			'inputType'               => 'fileTree',
-			'eval'                    => array('fieldType'=>'radio', 'filesOnly'=>true, 'extensions'=>implode(',', System::getContainer()->getParameter('contao.image.valid_extensions')), 'mandatory'=>true),
+			'eval'                    => array('fieldType'=>'radio', 'filesOnly'=>true, 'extensions'=>'%contao.image.valid_extensions%', 'mandatory'=>true),
 			'sql'                     => "binary(16) NULL"
 		),
 		'alt' => array

--- a/manager-bundle/composer.json
+++ b/manager-bundle/composer.json
@@ -59,7 +59,7 @@
     },
     "require-dev": {
         "composer/composer": "^1.0 || ^2.0",
-        "contao/test-case": "^4.3",
+        "contao/test-case": "^4.3.1",
         "phpunit/phpunit": "^8.5",
         "symfony/phpunit-bridge": "^5.2"
     },

--- a/manager-bundle/composer.json
+++ b/manager-bundle/composer.json
@@ -14,12 +14,6 @@
             "homepage": "https://contao.org/contributors"
         }
     ],
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/ausi/contao-test-case"
-        }
-    ],
     "require": {
         "php": "^7.3 || ^8.0",
         "ext-json": "*",
@@ -65,7 +59,7 @@
     },
     "require-dev": {
         "composer/composer": "^1.0 || ^2.0",
-        "contao/test-case": "dev-fix/missing-kernel-charset as 4.3.99",
+        "contao/test-case": "^4.3",
         "phpunit/phpunit": "^8.5",
         "symfony/phpunit-bridge": "^5.2"
     },

--- a/manager-bundle/composer.json
+++ b/manager-bundle/composer.json
@@ -14,6 +14,12 @@
             "homepage": "https://contao.org/contributors"
         }
     ],
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/ausi/contao-test-case"
+        }
+    ],
     "require": {
         "php": "^7.3 || ^8.0",
         "ext-json": "*",
@@ -59,7 +65,7 @@
     },
     "require-dev": {
         "composer/composer": "^1.0 || ^2.0",
-        "contao/test-case": "^4.3",
+        "contao/test-case": "dev-fix/missing-kernel-charset as 4.3.99",
         "phpunit/phpunit": "^8.5",
         "symfony/phpunit-bridge": "^5.2"
     },

--- a/news-bundle/composer.json
+++ b/news-bundle/composer.json
@@ -32,7 +32,7 @@
     },
     "require-dev": {
         "contao/manager-plugin": "^2.3.1",
-        "contao/test-case": "^4.2",
+        "contao/test-case": "^4.3.1",
         "phpunit/phpunit": "^8.5",
         "symfony/http-client": "4.4.* || 5.2.*",
         "symfony/phpunit-bridge": "^5.2"

--- a/news-bundle/composer.json
+++ b/news-bundle/composer.json
@@ -14,12 +14,6 @@
             "homepage": "https://contao.org/contributors"
         }
     ],
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/ausi/contao-test-case"
-        }
-    ],
     "require": {
         "php": "^7.3 || ^8.0",
         "contao/core-bundle": "self.version",
@@ -38,7 +32,7 @@
     },
     "require-dev": {
         "contao/manager-plugin": "^2.3.1",
-        "contao/test-case": "dev-fix/missing-kernel-charset as 4.3.99",
+        "contao/test-case": "^4.2",
         "phpunit/phpunit": "^8.5",
         "symfony/http-client": "4.4.* || 5.2.*",
         "symfony/phpunit-bridge": "^5.2"

--- a/news-bundle/composer.json
+++ b/news-bundle/composer.json
@@ -14,6 +14,12 @@
             "homepage": "https://contao.org/contributors"
         }
     ],
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/ausi/contao-test-case"
+        }
+    ],
     "require": {
         "php": "^7.3 || ^8.0",
         "contao/core-bundle": "self.version",
@@ -32,7 +38,7 @@
     },
     "require-dev": {
         "contao/manager-plugin": "^2.3.1",
-        "contao/test-case": "^4.2",
+        "contao/test-case": "dev-fix/missing-kernel-charset as 4.3.99",
         "phpunit/phpunit": "^8.5",
         "symfony/http-client": "4.4.* || 5.2.*",
         "symfony/phpunit-bridge": "^5.2"

--- a/news-bundle/src/Resources/contao/dca/tl_news.php
+++ b/news-bundle/src/Resources/contao/dca/tl_news.php
@@ -309,7 +309,7 @@ $GLOBALS['TL_DCA']['tl_news'] = array
 			'label'                   => &$GLOBALS['TL_LANG']['tl_content']['singleSRC'],
 			'exclude'                 => true,
 			'inputType'               => 'fileTree',
-			'eval'                    => array('fieldType'=>'radio', 'filesOnly'=>true, 'extensions'=>Config::get('validImageTypes'), 'mandatory'=>true),
+			'eval'                    => array('fieldType'=>'radio', 'filesOnly'=>true, 'extensions'=>implode(',', System::getContainer()->getParameter('contao.image.valid_extensions')), 'mandatory'=>true),
 			'sql'                     => "binary(16) NULL"
 		),
 		'alt' => array

--- a/news-bundle/src/Resources/contao/dca/tl_news.php
+++ b/news-bundle/src/Resources/contao/dca/tl_news.php
@@ -309,7 +309,7 @@ $GLOBALS['TL_DCA']['tl_news'] = array
 			'label'                   => &$GLOBALS['TL_LANG']['tl_content']['singleSRC'],
 			'exclude'                 => true,
 			'inputType'               => 'fileTree',
-			'eval'                    => array('fieldType'=>'radio', 'filesOnly'=>true, 'extensions'=>implode(',', System::getContainer()->getParameter('contao.image.valid_extensions')), 'mandatory'=>true),
+			'eval'                    => array('fieldType'=>'radio', 'filesOnly'=>true, 'extensions'=>'%contao.image.valid_extensions%', 'mandatory'=>true),
 			'sql'                     => "binary(16) NULL"
 		),
 		'alt' => array

--- a/newsletter-bundle/src/Resources/contao/classes/Newsletter.php
+++ b/newsletter-bundle/src/Resources/contao/classes/Newsletter.php
@@ -388,7 +388,7 @@ class Newsletter extends Backend
 			$objTemplate->setData($objNewsletter->row());
 			$objTemplate->title = $objNewsletter->subject;
 			$objTemplate->body = $simpleTokenParser->parse($html, $arrRecipient);
-			$objTemplate->charset = Config::get('characterSet');
+			$objTemplate->charset = System::getContainer()->getParameter('kernel.charset');
 			$objTemplate->recipient = $arrRecipient['email'];
 
 			// Deprecated since Contao 4.0, to be removed in Contao 5.0


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #3050
| Docs PR or issue | contao/docs#769

Working on #3050 I noticed that we don’t yet trigger deprecations for `Contao::get()` and `set()` calls to configs we moved to the container.

I added these deprecations in this PR and mapped `characterSet` to `kernel.charset`.

I also added a warning if someone uses a custom kernel with the `Kernel::getCharset()` method overwritten and returning something different than `"UTF-8"`.

And moved the configuration of the DC_Folder uploadPath and editableFiles to the DCA config, best seen in the [*tl_templates.php* diff](https://github.com/contao/contao/pull/3056/files#diff-d38dc1262eca6e265e775fc25926e0d111687e593eb0b03d844f809884ffee53)