### PR TITLE
Sort routes by region if no preferred language matches

### DIFF
--- a/core-bundle/src/Routing/AbstractPageRouteProvider.php
+++ b/core-bundle/src/Routing/AbstractPageRouteProvider.php
@@ -134,6 +134,28 @@ abstract class AbstractPageRouteProvider implements RouteProviderInterface
         if (null !== $languages && $pageA->rootLanguage !== $pageB->rootLanguage) {
             $langA = $languages[$pageA->rootLanguage] ?? null;
             $langB = $languages[$pageB->rootLanguage] ?? null;
+
+            $primaryA = substr($pageA->rootLanguage, 0, 2);
+            $primaryB = substr($pageB->rootLanguage, 0, 2);
+
+            if ($primaryA !== $primaryB) {
+                // We must not compare by language (without region) if they are the same, otherwise
+                // two pages with same language but different regions might not be sorted by region priority.
+
+                if (null === $langA) {
+                    $langA = $languages[$primaryA] ?? null;
+                }
+
+                if (null === $langB) {
+                    $langB = $languages[$primaryB] ?? null;
+                }
+            } elseif (null === $langA && null === $langB) {
+                // If both pages have the same language without region and neither region has a priority,
+                // (e.g. user prefers "de" but we have "de-CH" and "de-DE"), sort by their root page order.
+
+                $langA = $pageA->rootSorting;
+                $langB = $pageB->rootSorting;
+            }
         }
 
         if (null === $langA && null === $langB) {
@@ -189,19 +211,22 @@ abstract class AbstractPageRouteProvider implements RouteProviderInterface
 
     protected function convertLanguagesForSorting(array $languages): array
     {
-        foreach ($languages as &$language) {
+        $result = [];
+
+        foreach ($languages as $language) {
             $language = str_replace('_', '-', $language);
+            $result[] = $language;
 
             if (5 === \strlen($language)) {
                 $lng = substr($language, 0, 2);
 
                 // Append the language if only language plus dialect is given (see #430)
-                if (!\in_array($lng, $languages, true)) {
-                    $languages[] = $lng;
+                if (!\in_array($lng, $languages, true) && !\in_array($lng, $result, true)) {
+                    $result[] = $lng;
                 }
             }
         }
 
-        return array_flip(array_values($languages));
+        return array_flip($result);
     }
 }

--- a/core-bundle/src/Routing/AbstractPageRouteProvider.php
+++ b/core-bundle/src/Routing/AbstractPageRouteProvider.php
@@ -141,7 +141,6 @@ abstract class AbstractPageRouteProvider implements RouteProviderInterface
             if ($primaryA !== $primaryB) {
                 // We must not compare by language (without region) if they are the same, otherwise
                 // two pages with same language but different regions might not be sorted by region priority.
-
                 if (null === $langA) {
                     $langA = $languages[$primaryA] ?? null;
                 }
@@ -152,7 +151,6 @@ abstract class AbstractPageRouteProvider implements RouteProviderInterface
             } elseif (null === $langA && null === $langB) {
                 // If both pages have the same language without region and neither region has a priority,
                 // (e.g. user prefers "de" but we have "de-CH" and "de-DE"), sort by their root page order.
-
                 $langA = $pageA->rootSorting;
                 $langB = $pageB->rootSorting;
             }

--- a/core-bundle/src/Routing/AbstractPageRouteProvider.php
+++ b/core-bundle/src/Routing/AbstractPageRouteProvider.php
@@ -220,8 +220,9 @@ abstract class AbstractPageRouteProvider implements RouteProviderInterface
             if (5 === \strlen($language)) {
                 $lng = substr($language, 0, 2);
 
-                // Append the language if only language plus dialect is given (see #430)
-                if (!\in_array($lng, $languages, true) && !\in_array($lng, $result, true)) {
+                // For [de-DE, fr, de] this will add "de" as second item in this loop,
+                // but the only last item will be kept by array_flip.
+                if (!\in_array($lng, $result, true)) {
                     $result[] = $lng;
                 }
             }

--- a/core-bundle/src/Routing/Matcher/LanguageFilter.php
+++ b/core-bundle/src/Routing/Matcher/LanguageFilter.php
@@ -47,8 +47,7 @@ class LanguageFilter implements RouteFilterInterface
 
             if (
                 $pageModel->rootIsFallback
-                || \in_array(str_replace('-', '_', $pageModel->rootLanguage), $languages, true)
-                || preg_grep('/'.preg_quote($pageModel->rootLanguage, '/').'_[A-Z]{2}/', $languages)
+                || preg_grep('/^'.substr($pageModel->rootLanguage, 0, 2).'/', $languages)
             ) {
                 continue;
             }

--- a/core-bundle/tests/Fixtures/Functional/Routing/language-and-region.yml
+++ b/core-bundle/tests/Fixtures/Functional/Routing/language-and-region.yml
@@ -1,0 +1,96 @@
+tl_page:
+    - id: 1
+      pid: 0
+      sorting: 128
+      tstamp: 1568196756
+      title: Root de-CH
+      alias: root-de-ch
+      urlSuffix: .html
+      type: root
+      language: de-CH
+      dns: example.com
+      fallback: ''
+      includeLayout: '1'
+      layout: 1
+      published: '1'
+
+    - id: 2
+      pid: 1
+      sorting: 128
+      tstamp: 1568196317
+      title: Index-de
+      alias: index
+      type: regular
+      published: '1'
+
+    - id: 3
+      pid: 0
+      sorting: 256
+      tstamp: 1568196339
+      title: Root FR
+      alias: root-fr
+      urlSuffix: .html
+      type: root
+      language: fr-CH
+      dns: example.com
+      fallback: ''
+      includeLayout: '1'
+      layout: 1
+      published: '1'
+
+    - id: 4
+      pid: 3
+      sorting: 128
+      tstamp: 1568196353
+      title: Index-fr
+      alias: index
+      type: regular
+      published: '1'
+
+    - id: 5
+      pid: 0
+      sorting: 384
+      tstamp: 1568196339
+      title: Root IT
+      alias: root-it
+      urlSuffix: .html
+      type: root
+      language: it-CH
+      dns: example.com
+      fallback: ''
+      includeLayout: '1'
+      layout: 1
+      published: '1'
+
+    - id: 6
+      pid: 5
+      sorting: 128
+      tstamp: 1568196353
+      title: Index-fr
+      alias: index
+      type: regular
+      published: '1'
+
+    - id: 7
+      pid: 0
+      sorting: 512
+      tstamp: 1568196756
+      title: Root de-DE
+      alias: root-de-de
+      urlSuffix: .html
+      type: root
+      language: de-DE
+      dns: example.com
+      fallback: '1'
+      includeLayout: '1'
+      layout: 1
+      published: '1'
+
+    - id: 8
+      pid: 7
+      sorting: 128
+      tstamp: 1568196317
+      title: Index-de-DE
+      alias: index
+      type: regular
+      published: '1'

--- a/core-bundle/tests/Functional/RoutingTest.php
+++ b/core-bundle/tests/Functional/RoutingTest.php
@@ -1165,11 +1165,11 @@ class RoutingTest extends FunctionalTestCase
             'same-domain-root.local',
         ];
 
-        yield 'Redirects to "en" if "de-CH" and "en" are accepted and "de" is not' => [
+        yield 'Redirects to "de" if "de-CH" and "en" are accepted' => [
             ['theme', 'same-domain-root'],
             '/',
             302,
-            'Redirecting to https://same-domain-root.local/en/',
+            'Redirecting to https://same-domain-root.local/de/',
             'de-CH,en',
             'same-domain-root.local',
         ];
@@ -1243,6 +1243,33 @@ class RoutingTest extends FunctionalTestCase
             302,
             'Redirecting to https://example.com/de/',
             'de,en',
+            'example.com',
+        ];
+
+        yield 'Redirects to preferred language and region' => [
+            ['theme', 'language-and-region'],
+            '/',
+            302,
+            'Redirecting to https://example.com/de-CH/',
+            'de,de-CH,fr',
+            'example.com',
+        ];
+
+        yield 'Redirects to preferred language and ignores region if it does not exist' => [
+            ['theme', 'language-and-region'],
+            '/',
+            302,
+            'Redirecting to https://example.com/it-CH/',
+            'it-IT,de',
+            'example.com',
+        ];
+
+        yield 'Redirects to the language region by root page sorting' => [
+            ['theme', 'language-and-region'],
+            '/',
+            302,
+            'Redirecting to https://example.com/de-CH/',
+            'de',
             'example.com',
         ];
     }

--- a/core-bundle/tests/Routing/AbstractPageRouteProviderTest.php
+++ b/core-bundle/tests/Routing/AbstractPageRouteProviderTest.php
@@ -313,6 +313,12 @@ class AbstractPageRouteProviderTest extends TestCase
             ['fr', 'de-CH'],
             ['fr-FR', 'de-DE', 'en-US'],
         ];
+
+        yield [
+            ['de-CH', 'fr-CH', 'it-CH'],
+            ['de-DE', 'it-CH', 'fr-FR', 'de'],
+            ['it-CH', 'fr-CH', 'de-CH'],
+        ];
     }
 
     /**
@@ -340,7 +346,7 @@ class AbstractPageRouteProviderTest extends TestCase
 
         yield 'Does not change the sorting' => [
             ['de-DE', 'de-CH', 'fr', 'de', 'en-US', 'en'],
-            array_flip(['de-DE', 'de-CH', 'fr', 'de', 'en-US', 'en']),
+            array_flip(['de-DE', 'de', 'de-CH', 'fr', 'de', 'en-US', 'en', 'en']),
         ];
 
         yield 'Adds primary language if it does not exist' => [

--- a/core-bundle/tests/Routing/AbstractPageRouteProviderTest.php
+++ b/core-bundle/tests/Routing/AbstractPageRouteProviderTest.php
@@ -364,11 +364,13 @@ class AbstractPageRouteProviderTest extends TestCase
      */
     private function mockPageModel(string $language, bool $fallback = false, bool $root = false, int $rootSorting = 128): PageModel
     {
-        return $this->mockClassWithProperties(PageModel::class, [
-            'type' => $root ? 'root' : 'regular',
-            'rootLanguage' => $language,
-            'rootIsFallback' => $fallback,
-            'rootSorting' => $rootSorting,
-        ]);
+        /** @var PageModel&MockObject $pageModel */
+        $pageModel = $this->mockClassWithProperties(PageModel::class);
+        $pageModel->type = $root ? 'root' : 'regular';
+        $pageModel->rootLanguage = $language;
+        $pageModel->rootIsFallback = $fallback;
+        $pageModel->rootSorting = $rootSorting;
+
+        return $pageModel;
     }
 }

--- a/core-bundle/tests/Routing/AbstractPageRouteProviderTest.php
+++ b/core-bundle/tests/Routing/AbstractPageRouteProviderTest.php
@@ -26,7 +26,6 @@ class AbstractPageRouteProviderTest extends TestCase
     public function testCompareRoutes(Route $a, Route $b, ?array $languages, int $expected): void
     {
         $instance = $this->getMockForAbstractClass(AbstractPageRouteProvider::class, [], '', false);
-
         $class = new \ReflectionClass($instance);
 
         if (null !== $languages) {
@@ -258,6 +257,7 @@ class AbstractPageRouteProviderTest extends TestCase
         $method->setAccessible(true);
 
         $sorting = 0;
+
         $routes = array_map(
             function ($language) use ($sorting) {
                 return new Route('', ['pageModel' => $this->mockPageModel($language, false, false, ++$sorting)]);

--- a/core-bundle/tests/Routing/AbstractPageRouteProviderTest.php
+++ b/core-bundle/tests/Routing/AbstractPageRouteProviderTest.php
@@ -1,0 +1,293 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\Routing;
+
+use Contao\CoreBundle\Routing\AbstractPageRouteProvider;
+use Contao\CoreBundle\Tests\TestCase;
+use Contao\PageModel;
+use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Component\Routing\Route;
+
+class AbstractPageRouteProviderTest extends TestCase
+{
+    /**
+     * @dataProvider compareRoutesProvider
+     */
+    public function testCompareRoutes(Route $a, Route $b, ?array $languages, int $expected): void
+    {
+        $instance = $this->getMockForAbstractClass(AbstractPageRouteProvider::class, [], '', false);
+
+        $class = new \ReflectionClass($instance);
+
+        if (null !== $languages) {
+            $method = $class->getMethod('convertLanguagesForSorting');
+            $method->setAccessible(true);
+            $languages = $method->invoke($instance, $languages);
+        }
+
+        $method = $class->getMethod('compareRoutes');
+        $method->setAccessible(true);
+
+        $result = $method->invoke($instance, $a, $b, $languages);
+
+        $this->assertSame($expected, $result);
+    }
+
+    public function compareRoutesProvider(): \Generator
+    {
+        yield 'Sorts route with host higher' => [
+            new Route('', [], [], [], 'www.example.com'),
+            new Route('', [], [], [], ''),
+            null,
+            -1,
+        ];
+
+        yield 'Sorts route without host lower' => [
+            new Route('', [], [], [], ''),
+            new Route('', [], [], [], 'www.example.com'),
+            null,
+            1,
+        ];
+
+        yield 'Sorting unknown if route has no PageModel' => [
+            new Route('', [], [], [], 'www.example.org'),
+            new Route('', [], [], [], 'www.example.com'),
+            null,
+            0,
+        ];
+
+        yield 'Sorts route higher if it is fallback and no languages match' => [
+            new Route('', ['pageModel' => $this->mockPageModel('en', true)]),
+            new Route('', ['pageModel' => $this->mockPageModel('de', false)]),
+            null,
+            -1,
+        ];
+
+        yield 'Sorts route lower if it is not fallback and no languages match' => [
+            new Route('', ['pageModel' => $this->mockPageModel('en', false)]),
+            new Route('', ['pageModel' => $this->mockPageModel('de', true)]),
+            null,
+            1,
+        ];
+
+        yield 'Sorts route higher if it matches a preferred language' => [
+            new Route('', ['pageModel' => $this->mockPageModel('en')]),
+            new Route('', ['pageModel' => $this->mockPageModel('de')]),
+            ['en'],
+            -1,
+        ];
+
+        yield 'Sorts route lower if it does not match a preferred language' => [
+            new Route('', ['pageModel' => $this->mockPageModel('en')]),
+            new Route('', ['pageModel' => $this->mockPageModel('de')]),
+            ['de'],
+            1,
+        ];
+
+        yield 'Sorts route higher if preferred language has higher priority' => [
+            new Route('', ['pageModel' => $this->mockPageModel('en')]),
+            new Route('', ['pageModel' => $this->mockPageModel('de')]),
+            ['en', 'de'],
+            -1,
+        ];
+
+        yield 'Sorts route lower lower if preferred language has lower priority' => [
+            new Route('', ['pageModel' => $this->mockPageModel('en')]),
+            new Route('', ['pageModel' => $this->mockPageModel('de')]),
+            ['de', 'en'],
+            1,
+        ];
+
+        yield 'Sorts route higher if preferred language has higher priority with region' => [
+            new Route('', ['pageModel' => $this->mockPageModel('en-US')]),
+            new Route('', ['pageModel' => $this->mockPageModel('de-CH')]),
+            ['en-US', 'de-CH'],
+            -1,
+        ];
+
+        yield 'Sorts route lower lower if preferred language has lower priority with region' => [
+            new Route('', ['pageModel' => $this->mockPageModel('en-US')]),
+            new Route('', ['pageModel' => $this->mockPageModel('de-CH')]),
+            ['de-CH', 'en-US'],
+            1,
+        ];
+
+        yield 'Sorts route by preferred language if region does not match' => [
+            new Route('', ['pageModel' => $this->mockPageModel('en')]),
+            new Route('', ['pageModel' => $this->mockPageModel('de')]),
+            ['de-CH', 'en-US'],
+            1,
+        ];
+
+        yield 'Sorts route by preferred language if one region matches' => [
+            new Route('', ['pageModel' => $this->mockPageModel('en')]),
+            new Route('', ['pageModel' => $this->mockPageModel('de')]),
+            ['de-CH', 'en-US', 'en'],
+            -1,
+        ];
+
+        yield 'Sorts route by language (1)' => [
+            new Route('', ['pageModel' => $this->mockPageModel('de-CH')]),
+            new Route('', ['pageModel' => $this->mockPageModel('en-US')]),
+            ['en', 'de'],
+            0,
+        ];
+
+        yield 'Sorts route by language (2)' => [
+            new Route('', ['pageModel' => $this->mockPageModel('de-CH')]),
+            new Route('', ['pageModel' => $this->mockPageModel('en-US')]),
+            ['de', 'en'],
+            0,
+        ];
+
+        yield 'Sorts route by language (3)' => [
+            new Route('', ['pageModel' => $this->mockPageModel('de-CH')]),
+            new Route('', ['pageModel' => $this->mockPageModel('en-US')]),
+            ['de', 'en-US'],
+            1,
+        ];
+
+        yield 'Sorts route by language (4)' => [
+            new Route('', ['pageModel' => $this->mockPageModel('de')]),
+            new Route('', ['pageModel' => $this->mockPageModel('en-US')]),
+            ['en', 'de'],
+            -1,
+        ];
+
+        yield 'Sorts route by language (5)' => [
+            new Route('', ['pageModel' => $this->mockPageModel('de')]),
+            new Route('', ['pageModel' => $this->mockPageModel('en-US')]),
+            ['en', 'de', 'en-US'],
+            -1,
+        ];
+
+        yield 'Sorts route by language (6)' => [
+            new Route('', ['pageModel' => $this->mockPageModel('de-CH')]),
+            new Route('', ['pageModel' => $this->mockPageModel('en-US')]),
+            ['en-GB', 'de', 'en-US'],
+            1,
+        ];
+
+        yield 'Sorts route by language (7)' => [
+            new Route('', ['pageModel' => $this->mockPageModel('de-CH')]),
+            new Route('', ['pageModel' => $this->mockPageModel('de-DE')]),
+            ['de-AT', 'de-CH'],
+            -1,
+        ];
+
+        yield 'Sorts route lower if it is a root page' => [
+            new Route('', ['pageModel' => $this->mockPageModel('en', false, false)]),
+            new Route('', ['pageModel' => $this->mockPageModel('de', false, true)]),
+            null,
+            -1,
+        ];
+
+        yield 'Sorts route higher if it is not a root page' => [
+            new Route('', ['pageModel' => $this->mockPageModel('en', false, true)]),
+            new Route('', ['pageModel' => $this->mockPageModel('de', false, false)]),
+            null,
+            1,
+        ];
+
+        yield 'Sorting is undefined if both are root page' => [
+            new Route('', ['pageModel' => $this->mockPageModel('en', false, true)]),
+            new Route('', ['pageModel' => $this->mockPageModel('de', false, true)]),
+            null,
+            0,
+        ];
+
+        yield 'Sorts by number of slashes in path (1)' => [
+            new Route('/foo/bar', ['pageModel' => $this->mockPageModel('en')]),
+            new Route('/bar', ['pageModel' => $this->mockPageModel('de')]),
+            null,
+            -1,
+        ];
+
+        yield 'Sorts by number of slashes in path (2)' => [
+            new Route('/foo', ['pageModel' => $this->mockPageModel('en')]),
+            new Route('/bar/foo', ['pageModel' => $this->mockPageModel('de')]),
+            null,
+            1,
+        ];
+
+        yield 'Sorts by number of slashes in path (3)' => [
+            new Route('/foo/bar/baz', ['pageModel' => $this->mockPageModel('en')]),
+            new Route('/bar/foo/baz/x', ['pageModel' => $this->mockPageModel('de')]),
+            null,
+            1,
+        ];
+
+        yield 'Sorts by path string if it has the same number of slashes' => [
+            new Route('/foo/bar/baz', ['pageModel' => $this->mockPageModel('en')]),
+            new Route('/bar/foo/baz', ['pageModel' => $this->mockPageModel('de')]),
+            null,
+            1,
+        ];
+    }
+
+    /**
+     * @dataProvider convertLanguageForSortingProvider
+     */
+    public function testConvertLanguagesForSorting(array $languages, array $expected): void
+    {
+        $instance = $this->getMockForAbstractClass(AbstractPageRouteProvider::class, [], '', false);
+
+        $class = new \ReflectionClass($instance);
+        $method = $class->getMethod('convertLanguagesForSorting');
+        $method->setAccessible(true);
+
+        $result = $method->invoke($instance, $languages);
+
+        $this->assertSame($expected, $result);
+    }
+
+    public function convertLanguageForSortingProvider(): \Generator
+    {
+        yield 'Does nothing on empty array' => [
+            [],
+            [],
+        ];
+
+        yield 'Does not change the sorting' => [
+            ['de-DE', 'de-CH', 'fr', 'de', 'en-US', 'en'],
+            array_flip(['de-DE', 'de-CH', 'fr', 'de', 'en-US', 'en']),
+        ];
+
+        yield 'Adds primary language if it does not exist' => [
+            ['de_DE'],
+            array_flip(['de-DE', 'de']),
+        ];
+
+        yield 'Adds all primary languages at the end' => [
+            ['de_DE', 'de_CH', 'en', 'en_US', 'fr_FR'],
+            array_flip(['de-DE', 'de-CH', 'en', 'en-US', 'fr-FR', 'de', 'fr']),
+        ];
+
+        yield 'Strips array keys' => [
+            ['foo' => 'de', 'bar' => 'en'],
+            array_flip(['de', 'en']),
+        ];
+    }
+
+    /**
+     * @return PageModel&MockObject
+     */
+    private function mockPageModel(string $language, bool $fallback = false, bool $root = false): PageModel
+    {
+        return $this->mockClassWithProperties(PageModel::class, [
+            'rootLanguage' => $language,
+            'rootIsFallback' => $fallback,
+            'type' => $root ? 'root' : 'regular',
+        ]);
+    }
+}

--- a/core-bundle/tests/Routing/AbstractPageRouteProviderTest.php
+++ b/core-bundle/tests/Routing/AbstractPageRouteProviderTest.php
@@ -360,9 +360,9 @@ class AbstractPageRouteProviderTest extends TestCase
     }
 
     /**
-     * @return MockObject&PageModel
+     * @return PageModel&MockObject
      */
-    private function mockPageModel(string $language, bool $fallback = false, bool $root = false, int $rootSorting = 128): MockObject
+    private function mockPageModel(string $language, bool $fallback = false, bool $root = false, int $rootSorting = 128): PageModel
     {
         return $this->mockClassWithProperties(PageModel::class, [
             'type' => $root ? 'root' : 'regular',

--- a/core-bundle/tests/Routing/RouteProviderTest.php
+++ b/core-bundle/tests/Routing/RouteProviderTest.php
@@ -425,9 +425,9 @@ class RouteProviderTest extends TestCase
 
         yield 'Appends "de" in case "de_CH" is accepted and "de" is not' => [
             [
-                1 => $this->createPage('de', 'foo', false),
                 3 => $this->createPage('fr', 'foo', false),
-                0 => $this->createPage('en', 'foo', false),
+                0 => $this->createPage('de', 'foo', false),
+                1 => $this->createPage('en', 'foo', false),
                 2 => $this->createPage('it', 'foo'),
             ],
             ['de_CH', 'en'],


### PR DESCRIPTION
As discussed preparing for https://github.com/contao/contao/pull/2305

### Current situation 1:
- Page languages: `de-CH` and `en-US`
- Preferred languages: `de, en`

**Result:** Language is undefined = ships fallback language because no match of pages and preferred languages


### Current situation 2:
- Page languages: `de-CH` and `en`
- Preferred languages: `de, en`

**Result:** Ships `en` page even though the user prefers german

### Desired situation:

1. The preferred region should be ignored both in the preferred regions as well as the root page settings. If the user accepts `de-CH, en` we should always prefer a german page tree (but still prefer `de-CH` over `de-DE`).

2. If the user prefers `de` and we have `de-CH` and `de-DE`, the sorting should be based on root page sorting. We've discussed relying on "dominant region" but there's no advantage in preferring `en-US` over `en-GB` just because of a larger population; by using root page sorting the same can be achieved but it's more flexible at the same time.