### PR TITLE
German country translation of "Isle of Man"

### DIFF
--- a/core-bundle/src/Resources/contao/languages/de/countries.xlf
+++ b/core-bundle/src/Resources/contao/languages/de/countries.xlf
@@ -423,7 +423,7 @@
       </trans-unit>
       <trans-unit id="CNT.im">
         <source>Isle of Man</source>
-        <target>Isle of </target>
+        <target>Isle of Man</target>
       </trans-unit>
       <trans-unit id="CNT.in">
         <source>India</source>


### PR DESCRIPTION
| Fixed issues | Fix the incomplete German translation of „Isle of Man“ in the language file which contains German translations of country names. The German translation is currently set only to „Isle of“. The associated country code („im“) and the source refers also to the Isle of Man.