### PR TITLE
Lazy-load the `rootFallbackLanguage` property

### DIFF
--- a/core-bundle/src/Resources/contao/models/PageModel.php
+++ b/core-bundle/src/Resources/contao/models/PageModel.php
@@ -284,7 +284,8 @@ class PageModel extends Model
 	public function __get($strKey)
 	{
 		// Lazy-load the fallback language (see contao/core#6874)
-		if ($strKey == 'rootFallbackLanguage' && $this->blnDetailsLoaded && !\array_key_exists('rootFallbackLanguage', $this->arrData)) {
+		if ($strKey == 'rootFallbackLanguage' && $this->blnDetailsLoaded && !\array_key_exists('rootFallbackLanguage', $this->arrData))
+		{
 			$this->rootFallbackLanguage = $this->rootIsFallback ? $this->language : null;
 
 			if (!$this->rootIsFallback && ($objFallback = static::findPublishedFallbackByHostname($this->domain)) !== null)

--- a/core-bundle/src/Resources/contao/models/PageModel.php
+++ b/core-bundle/src/Resources/contao/models/PageModel.php
@@ -284,7 +284,7 @@ class PageModel extends Model
 	public function __get($strKey)
 	{
 		// Lazy-load the fallback language (see contao/core#6874)
-		if ($strKey == 'rootFallbackLanguage' && !\array_key_exists('rootFallbackLanguage', $this->arrData)) {
+		if ($strKey == 'rootFallbackLanguage' && $this->blnDetailsLoaded && !\array_key_exists('rootFallbackLanguage', $this->arrData)) {
 			$this->rootFallbackLanguage = $this->rootIsFallback ? $this->language : null;
 
 			if (!$this->rootIsFallback && ($objFallback = static::findPublishedFallbackByHostname($this->domain)) !== null)
@@ -294,6 +294,24 @@ class PageModel extends Model
 		}
 
 		return parent::__get($strKey);
+	}
+
+	public function __isset($strKey)
+	{
+		if ($strKey == 'rootFallbackLanguage' && $this->blnDetailsLoaded)
+		{
+			return true;
+		}
+
+		return parent::__isset($strKey);
+	}
+
+	public function row()
+	{
+		// Load lazy properties
+		$this->__get('rootFallbackLanguage');
+
+		return parent::row();
 	}
 
 	/**

--- a/core-bundle/src/Resources/contao/models/PageModel.php
+++ b/core-bundle/src/Resources/contao/models/PageModel.php
@@ -284,7 +284,7 @@ class PageModel extends Model
 	public function __get($strKey)
 	{
 		// Lazy-load the fallback language (see contao/core#6874)
-		if ($strKey == 'rootFallbackLanguage' && !array_key_exists('rootFallbackLanguage', $this->arrData)) {
+		if ($strKey == 'rootFallbackLanguage' && !\array_key_exists('rootFallbackLanguage', $this->arrData)) {
 			$this->rootFallbackLanguage = $this->rootIsFallback ? $this->language : null;
 
 			if (!$this->rootIsFallback && ($objFallback = static::findPublishedFallbackByHostname($this->domain)) !== null)


### PR DESCRIPTION
I noticed the `rootFallbackLanguage` is always loaded for a page, but it is only ever used to fetch (fallback) metadata. I think we can save that SQL query by lazy loading the data.

Also, as far as I understand, this SQL query would be done for EVERY `PageModel::loadDetails()` since it cannot be cached in the registry. That means potentially a lot of calls because Sf routing uses `loadDetails` on all candidates.
