### PR TITLE
Harden `FigureBuilder::from()` against invalid types

### DIFF
--- a/core-bundle/src/Image/Studio/FigureBuilder.php
+++ b/core-bundle/src/Image/Studio/FigureBuilder.php
@@ -315,7 +315,9 @@ class FigureBuilder
             return $this->fromPath($identifier);
         }
 
-        throw new \TypeError(sprintf('%s(): Argument #1 ($identifier) must be of type FilesModel|ImageInterface|string|int|null, %s given', __METHOD__, \is_object($identifier) ? \get_class($identifier) : \gettype($identifier)));
+        $type = \is_object($identifier) ? \get_class($identifier) : \gettype($identifier);
+
+        throw new \TypeError(sprintf('%s(): Argument #1 ($identifier) must be of type FilesModel|ImageInterface|string|int|null, %s given', __METHOD__, $type));
     }
 
     /**

--- a/core-bundle/src/Image/Studio/FigureBuilder.php
+++ b/core-bundle/src/Image/Studio/FigureBuilder.php
@@ -315,10 +315,7 @@ class FigureBuilder
             return $this->fromPath($identifier);
         }
 
-        $method = __METHOD__;
-        $type = \is_object($identifier) ? \get_class($identifier) : \gettype($identifier);
-
-        throw new \TypeError("$method(): Argument #1 (\$identifier) must be of type FilesModel|ImageInterface|string|int|null, $type given");
+        throw new \TypeError(sprintf('%s(): Argument #1 ($identifier) must be of type FilesModel|ImageInterface|string|int|null, %s given', __METHOD__, \is_object($identifier) ? \get_class($identifier) : \gettype($identifier)));
     }
 
     /**

--- a/core-bundle/src/Image/Studio/FigureBuilder.php
+++ b/core-bundle/src/Image/Studio/FigureBuilder.php
@@ -301,7 +301,9 @@ class FigureBuilder
             return $this->fromImage($identifier);
         }
 
-        if ($this->validatorAdapter()->isUuid($identifier)) {
+        $isString = \is_string($identifier);
+
+        if ($isString && $this->validatorAdapter()->isUuid($identifier)) {
             return $this->fromUuid($identifier);
         }
 
@@ -309,7 +311,14 @@ class FigureBuilder
             return $this->fromId((int) $identifier);
         }
 
-        return $this->fromPath($identifier);
+        if ($isString) {
+            return $this->fromPath($identifier);
+        }
+
+        $method = __METHOD__;
+        $type = \is_object($identifier) ? \get_class($identifier) : \gettype($identifier);
+
+        throw new \TypeError("$method(): Argument #1 (\$identifier) must be of type FilesModel|ImageInterface|string|int|null, $type given");
     }
 
     /**

--- a/core-bundle/tests/Image/Studio/FigureBuilderTest.php
+++ b/core-bundle/tests/Image/Studio/FigureBuilderTest.php
@@ -357,9 +357,11 @@ class FigureBuilderTest extends TestCase
         $figureBuilder = $this->getFigureBuilder(null, $framework);
 
         $this->expectException(\TypeError::class);
-        $this->expectExceptionMessage(
-            sprintf('Contao\CoreBundle\Image\Studio\FigureBuilder::from(): Argument #1 ($identifier) must be of type FilesModel|ImageInterface|string|int|null, %s given', $typeString)
-        );
+
+        $this->expectExceptionMessage(sprintf(
+            'Contao\CoreBundle\Image\Studio\FigureBuilder::from(): Argument #1 ($identifier) must be of type FilesModel|ImageInterface|string|int|null, %s given',
+            $typeString
+        ));
 
         $figureBuilder->from($invalidType);
     }

--- a/core-bundle/tests/Image/Studio/FigureBuilderTest.php
+++ b/core-bundle/tests/Image/Studio/FigureBuilderTest.php
@@ -345,6 +345,43 @@ class FigureBuilderTest extends TestCase
         $figureBuilder->build();
     }
 
+    /**
+     * @dataProvider provideInvalidTypes
+     */
+    public function testFromInvalidTypeThrowsTypeError($invalidType, string $typeString): void
+    {
+        $framework = $this->mockContaoFramework([
+            Validator::class => new Adapter(Validator::class),
+        ]);
+
+        $figureBuilder = $this->getFigureBuilder(null, $framework);
+
+        $this->expectException(\TypeError::class);
+        $this->expectExceptionMessage(
+            sprintf('Contao\CoreBundle\Image\Studio\FigureBuilder::from(): Argument #1 ($identifier) must be of type FilesModel|ImageInterface|string|int|null, %s given', $typeString)
+        );
+
+        $figureBuilder->from($invalidType);
+    }
+
+    public function provideInvalidTypes(): \Generator
+    {
+        yield 'true' => [
+            true,
+            'boolean',
+        ];
+
+        yield 'false' => [
+            false,
+            'boolean',
+        ];
+
+        yield 'object' => [
+            new Metadata([]),
+            Metadata::class,
+        ];
+    }
+
     public function provideMixedIdentifiers(): \Generator
     {
         [$absoluteFilePath, $relativeFilePath] = $this->getTestFilePaths();


### PR DESCRIPTION
This is a followup PR to #3073 that would further enforce type safety in `FigureBuilder#from()`.

With PHP8.0 you could type hint the input argument with `int|string|FilesModel|ImageInterface|null` and would get a `TypeError` if you tried otherwise. This PR introduces a similar forward compatible check. Not sure if we want to go that route but input is welcome.

/cc @ausi