### PR TITLE
Add a license field to the file metadata

### DIFF
--- a/core-bundle/src/File/Metadata.php
+++ b/core-bundle/src/File/Metadata.php
@@ -28,6 +28,7 @@ class Metadata
     public const VALUE_TITLE = 'title';
     public const VALUE_URL = 'link';
     public const VALUE_UUID = 'uuid';
+    public const VALUE_LICENSE = 'license';
 
     /**
      * Key-value pairs of metadata.
@@ -80,6 +81,11 @@ class Metadata
     public function getTitle(): string
     {
         return $this->values[self::VALUE_TITLE] ?? '';
+    }
+
+    public function getLicense(): string
+    {
+        return $this->values[self::VALUE_LICENSE] ?? '';
     }
 
     public function getUrl(): string

--- a/core-bundle/src/File/Metadata.php
+++ b/core-bundle/src/File/Metadata.php
@@ -83,11 +83,6 @@ class Metadata
         return $this->values[self::VALUE_TITLE] ?? '';
     }
 
-    public function getLicense(): string
-    {
-        return $this->values[self::VALUE_LICENSE] ?? '';
-    }
-
     public function getUrl(): string
     {
         return $this->values[self::VALUE_URL] ?? '';
@@ -99,6 +94,11 @@ class Metadata
     public function getUuid(): ?string
     {
         return $this->values[self::VALUE_UUID] ?? null;
+    }
+
+    public function getLicense(): string
+    {
+        return $this->values[self::VALUE_LICENSE] ?? '';
     }
 
     /**

--- a/core-bundle/src/Resources/contao/dca/tl_files.php
+++ b/core-bundle/src/Resources/contao/dca/tl_files.php
@@ -252,7 +252,8 @@ $GLOBALS['TL_DCA']['tl_files'] = array
 					'title'           => 'maxlength="255"',
 					'alt'             => 'maxlength="255"',
 					'link'            => array('attributes'=>'maxlength="255"', 'dcaPicker'=>true),
-					'caption'         => array('type'=>'textarea')
+					'caption'         => array('type'=>'textarea'),
+					'license'         => array('attributes'=>'maxlength="255"', 'dcaPicker'=>true)
 				)
 			),
 			'sql'                     => "blob NULL"

--- a/core-bundle/src/Resources/contao/languages/en/default.xlf
+++ b/core-bundle/src/Resources/contao/languages/en/default.xlf
@@ -971,6 +971,9 @@
       <trans-unit id="MSC.aw_caption">
         <source>Caption</source>
       </trans-unit>
+      <trans-unit id="MSC.aw_license">
+        <source>License</source>
+      </trans-unit>
       <trans-unit id="MSC.sw_title">
         <source>Title</source>
       </trans-unit>

--- a/core-bundle/tests/File/MetadataTest.php
+++ b/core-bundle/tests/File/MetadataTest.php
@@ -39,6 +39,7 @@ class MetadataTest extends TestCase
             Metadata::VALUE_TITLE => 'title',
             Metadata::VALUE_URL => 'url',
             Metadata::VALUE_UUID => '1234-5678',
+            Metadata::VALUE_LICENSE => 'https://creativecommons.org/licenses/by/4.0/',
             'foo' => 'bar',
         ]);
 
@@ -48,6 +49,7 @@ class MetadataTest extends TestCase
         $this->assertSame('caption', $metadata->getCaption());
         $this->assertSame('title', $metadata->getTitle());
         $this->assertSame('url', $metadata->getUrl());
+        $this->assertSame('https://creativecommons.org/licenses/by/4.0/', $metadata->getLicense());
         $this->assertSame('bar', $metadata->get('foo'));
 
         $this->assertSame(
@@ -57,6 +59,7 @@ class MetadataTest extends TestCase
                 Metadata::VALUE_TITLE => 'title',
                 Metadata::VALUE_URL => 'url',
                 Metadata::VALUE_UUID => '1234-5678',
+                Metadata::VALUE_LICENSE => 'https://creativecommons.org/licenses/by/4.0/',
                 'foo' => 'bar',
             ],
             $metadata->all()
@@ -71,6 +74,7 @@ class MetadataTest extends TestCase
         $this->assertSame('', $metadata->getCaption());
         $this->assertSame('', $metadata->getTitle());
         $this->assertSame('', $metadata->getUrl());
+        $this->assertSame('', $metadata->getLicense());
 
         $this->assertNull($metadata->get('foo'));
     }


### PR DESCRIPTION
File/Image licensing information feels like a very common requirement. Let's add this to the core.
My plan is to use that for JSON-LD once the whole response context stuff is settled :)