### PR TITLE
Fix another invalid array access

### DIFF
--- a/core-bundle/src/Resources/contao/elements/ContentProxy.php
+++ b/core-bundle/src/Resources/contao/elements/ContentProxy.php
@@ -68,7 +68,7 @@ class ContentProxy extends ContentElement
 
 	public function __get($strKey)
 	{
-		return $this->reference->attributes['templateProperties'][$strKey];
+		return $this->reference->attributes['templateProperties'][$strKey] ?? null;
 	}
 
 	public function __isset($strKey)


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes -
| Docs PR or issue | -

Prevents `Warning: Undefined array key "protected"`.

The code in question is called here: https://github.com/contao/contao/blob/3a8da4a6e638645f0730ebd477f33eac21e92b61/core-bundle/src/Resources/contao/library/Contao/Controller.php#L568-L569