### PR TITLE
Fix the indentation in the news_full template

### DIFF
--- a/news-bundle/src/Resources/contao/templates/news/news_full.html5
+++ b/news-bundle/src/Resources/contao/templates/news/news_full.html5
@@ -33,7 +33,7 @@
     <ul class="enclosure">
       <?php foreach ($this->enclosure as $enclosure): ?>
         <li class="download-element ext-<?= $enclosure['extension'] ?>">
-           <a href="<?= $enclosure['href'] ?>" title="<?= $enclosure['title'] ?>"><?= $enclosure['link'] ?> <span class="size">(<?= $enclosure['filesize'] ?>)</span></a>
+          <a href="<?= $enclosure['href'] ?>" title="<?= $enclosure['title'] ?>"><?= $enclosure['link'] ?> <span class="size">(<?= $enclosure['filesize'] ?>)</span></a>
         </li>
       <?php endforeach; ?>
     </ul>


### PR DESCRIPTION
Noticed via https://github.com/contao/contao/pull/2962