### PR TITLE
Do not disable search and cache in FAQ and newsletter readers

### DIFF
--- a/calendar-bundle/src/Resources/contao/modules/ModuleEventReader.php
+++ b/calendar-bundle/src/Resources/contao/modules/ModuleEventReader.php
@@ -72,7 +72,7 @@ class ModuleEventReader extends Events
 
 		if (empty($this->cal_calendar) || !\is_array($this->cal_calendar))
 		{
-			throw new InternalServerErrorException('The event reader ID ' . $this->id . ' has no calendars specified.', $this->id);
+			throw new InternalServerErrorException('The event reader ID ' . $this->id . ' has no calendars specified.');
 		}
 
 		return parent::generate();

--- a/faq-bundle/src/Resources/contao/modules/ModuleFaqReader.php
+++ b/faq-bundle/src/Resources/contao/modules/ModuleFaqReader.php
@@ -68,7 +68,7 @@ class ModuleFaqReader extends Module
 
 		if (empty($this->faq_categories) || !\is_array($this->faq_categories))
 		{
-			throw new InternalServerErrorException('The faq reader ID ' . $this->id . ' has no categories specified.');
+			throw new InternalServerErrorException('The FAQ reader ID ' . $this->id . ' has no categories specified.');
 		}
 
 		return parent::generate();

--- a/faq-bundle/src/Resources/contao/modules/ModuleFaqReader.php
+++ b/faq-bundle/src/Resources/contao/modules/ModuleFaqReader.php
@@ -10,6 +10,7 @@
 
 namespace Contao;
 
+use Contao\CoreBundle\Exception\InternalServerErrorException;
 use Contao\CoreBundle\Exception\PageNotFoundException;
 use Patchwork\Utf8;
 
@@ -57,30 +58,17 @@ class ModuleFaqReader extends Module
 			Input::setGet('items', Input::get('auto_item'));
 		}
 
-		// Do not index or cache the page if no FAQ has been specified
+		// Return an empty string if "items" is not set (to combine list and reader on same page)
 		if (!Input::get('items'))
 		{
-			/** @var PageModel $objPage */
-			global $objPage;
-
-			$objPage->noSearch = 1;
-			$objPage->cache = 0;
-
 			return '';
 		}
 
 		$this->faq_categories = StringUtil::deserialize($this->faq_categories);
 
-		// Do not index or cache the page if there are no categories
 		if (empty($this->faq_categories) || !\is_array($this->faq_categories))
 		{
-			/** @var PageModel $objPage */
-			global $objPage;
-
-			$objPage->noSearch = 1;
-			$objPage->cache = 0;
-
-			return '';
+			throw new InternalServerErrorException('The faq reader ID ' . $this->id . ' has no categories specified.', $this->id);
 		}
 
 		return parent::generate();

--- a/faq-bundle/src/Resources/contao/modules/ModuleFaqReader.php
+++ b/faq-bundle/src/Resources/contao/modules/ModuleFaqReader.php
@@ -68,7 +68,7 @@ class ModuleFaqReader extends Module
 
 		if (empty($this->faq_categories) || !\is_array($this->faq_categories))
 		{
-			throw new InternalServerErrorException('The faq reader ID ' . $this->id . ' has no categories specified.', $this->id);
+			throw new InternalServerErrorException('The faq reader ID ' . $this->id . ' has no categories specified.');
 		}
 
 		return parent::generate();

--- a/news-bundle/src/Resources/contao/modules/ModuleNewsReader.php
+++ b/news-bundle/src/Resources/contao/modules/ModuleNewsReader.php
@@ -71,7 +71,7 @@ class ModuleNewsReader extends ModuleNews
 
 		if (empty($this->news_archives) || !\is_array($this->news_archives))
 		{
-			throw new InternalServerErrorException('The news reader ID ' . $this->id . ' has no archives specified.', $this->id);
+			throw new InternalServerErrorException('The news reader ID ' . $this->id . ' has no archives specified.');
 		}
 
 		return parent::generate();

--- a/newsletter-bundle/src/Resources/contao/modules/ModuleNewsletterReader.php
+++ b/newsletter-bundle/src/Resources/contao/modules/ModuleNewsletterReader.php
@@ -10,6 +10,7 @@
 
 namespace Contao;
 
+use Contao\CoreBundle\Exception\InternalServerErrorException;
 use Contao\CoreBundle\Exception\PageNotFoundException;
 use Patchwork\Utf8;
 
@@ -55,30 +56,17 @@ class ModuleNewsletterReader extends Module
 			Input::setGet('items', Input::get('auto_item'));
 		}
 
-		// Do not index or cache the page if no news item has been specified
+		// Return an empty string if "items" is not set (to combine list and reader on same page)
 		if (!Input::get('items'))
 		{
-			/** @var PageModel $objPage */
-			global $objPage;
-
-			$objPage->noSearch = 1;
-			$objPage->cache = 0;
-
 			return '';
 		}
 
 		$this->nl_channels = StringUtil::deserialize($this->nl_channels);
 
-		// Do not index or cache the page if there are no channels
 		if (empty($this->nl_channels) || !\is_array($this->nl_channels))
 		{
-			/** @var PageModel $objPage */
-			global $objPage;
-
-			$objPage->noSearch = 1;
-			$objPage->cache = 0;
-
-			return '';
+			throw new InternalServerErrorException('The newsletter reader ID ' . $this->id . ' has no channels specified.', $this->id);
 		}
 
 		return parent::generate();

--- a/newsletter-bundle/src/Resources/contao/modules/ModuleNewsletterReader.php
+++ b/newsletter-bundle/src/Resources/contao/modules/ModuleNewsletterReader.php
@@ -66,7 +66,7 @@ class ModuleNewsletterReader extends Module
 
 		if (empty($this->nl_channels) || !\is_array($this->nl_channels))
 		{
-			throw new InternalServerErrorException('The newsletter reader ID ' . $this->id . ' has no channels specified.', $this->id);
+			throw new InternalServerErrorException('The newsletter reader ID ' . $this->id . ' has no channels specified.');
 		}
 
 		return parent::generate();


### PR DESCRIPTION
In Contao 4.6.0 the reader modules where changed so that they do not dynamically change `$objPage->noSearch` and `$objPage->cache` anymore - which is not really necessary anyway, because a page that contains a reader but does not show anything should still be perfectly search- and cacheable (see https://github.com/contao/contao/commit/65b60a1130af2af4169e63ffac481490ef598765#diff-9daf81af7f0708c0faabb8cb8859d3a1032b6318dc1abbe8d58208a7a0cf2f44L59-R72 for example). 

Another change was to throw an exception if no calendar or archive was selected in the module but still included in the front end.

These changes were still absent in the FAQ and Newsletter reader modules. Probably, because cache tagging for FAQ and Newsletters was added much later in https://github.com/contao/contao/commit/103649e2971e34b8b956c0a645272d07f708a649 - but without the other changes to the respective readers.

On that note though: does it really make sense to pass the module ID as an error code? An error code should be unique to the error itself and should not depend on a random database ID?

https://github.com/contao/contao/blob/4bc1479dab9dce3bf461d46632f380b2958afbcb/news-bundle/src/Resources/contao/modules/ModuleNewsReader.php#L72-L75