### PR TITLE
Fix wrong dependency name for PurgeExpiredDataCron

### DIFF
--- a/core-bundle/src/Resources/config/services.yml
+++ b/core-bundle/src/Resources/config/services.yml
@@ -206,7 +206,7 @@ services:
     Contao\CoreBundle\Cron\PurgeExpiredDataCron:
         arguments:
             - '@contao.framework'
-            - '@connection'
+            - '@database_connection'
 
     contao.csrf.token_manager:
         class: Symfony\Component\Security\Csrf\CsrfTokenManager


### PR DESCRIPTION
Current `4.9` branch has the following error:

```
Script Contao\ManagerBundle\Composer\ScriptHandler::initializeApplication handling the post-update-cmd event terminated with an exception
                                                                                                                     
  [RuntimeException]                                                                                                  
  An error occurred while executing the "contao:install-web-dir" command:                                             
  In CheckExceptionOnInvalidReferenceBehaviorPass.php line 86:

    The service "Contao\CoreBundle\Cron\PurgeExpiredDataCron" has a dependency on a non-existent service "connection".
```

