### PR TITLE
Allow empty content element translation key

### DIFF
--- a/core-bundle/src/Resources/contao/dca/tl_content.php
+++ b/core-bundle/src/Resources/contao/dca/tl_content.php
@@ -1241,7 +1241,7 @@ class tl_content extends Backend
 	public function addCteType($arrRow)
 	{
 		$key = $arrRow['invisible'] ? 'unpublished' : 'published';
-		$type = ($GLOBALS['TL_LANG']['CTE'][$arrRow['type']][0] ?? null) ?: '&nbsp;';
+		$type = $GLOBALS['TL_LANG']['CTE'][$arrRow['type']][0] ?? $arrRow['type'];
 		$class = 'limit_height';
 
 		// Remove the class if it is a wrapper element

--- a/core-bundle/src/Resources/contao/dca/tl_content.php
+++ b/core-bundle/src/Resources/contao/dca/tl_content.php
@@ -1241,7 +1241,7 @@ class tl_content extends Backend
 	public function addCteType($arrRow)
 	{
 		$key = $arrRow['invisible'] ? 'unpublished' : 'published';
-		$type = $GLOBALS['TL_LANG']['CTE'][$arrRow['type']][0] ?: '&nbsp;';
+		$type = ($GLOBALS['TL_LANG']['CTE'][$arrRow['type']][0] ?? null) ?: '&nbsp;';
 		$class = 'limit_height';
 
 		// Remove the class if it is a wrapper element


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | -
| Docs PR or issue | -

Fixes `Warning: Undefined array key "foo"` if a new `foo` content element controller was created but no translation added yet.

The existing check (elvis) only checks for falsy values but not if the array key actually exists.
