### PR TITLE
Remove redundant arguments from private methods

### DIFF
--- a/core-bundle/src/Command/UserCreateCommand.php
+++ b/core-bundle/src/Command/UserCreateCommand.php
@@ -165,12 +165,7 @@ class UserCreateCommand extends Command
         }
 
         if (false === $input->getOption('admin') && ($options = $this->getGroups()) && 0 !== \count($options)) {
-            $answer = $this->askMultipleChoice(
-                'Assign which groups to the user (select multiple comma-separated)?',
-                $options,
-                $input,
-                $output
-            );
+            $answer = $this->askMultipleChoice($options, $input, $output);
 
             $input->setOption('group', array_values(array_intersect_key(array_flip($options), array_flip($answer))));
         }
@@ -245,9 +240,9 @@ class UserCreateCommand extends Command
         return $helper->ask($input, $output, $question);
     }
 
-    private function askMultipleChoice(string $label, array $options, InputInterface $input, OutputInterface $output): array
+    private function askMultipleChoice(array $options, InputInterface $input, OutputInterface $output): array
     {
-        $question = new ChoiceQuestion($label, $options);
+        $question = new ChoiceQuestion('Assign which groups to the user (select multiple comma-separated)?', $options);
         $question->setAutocompleterValues($options);
         $question->setMultiselect(true);
 

--- a/core-bundle/src/Command/UserCreateCommand.php
+++ b/core-bundle/src/Command/UserCreateCommand.php
@@ -165,7 +165,12 @@ class UserCreateCommand extends Command
         }
 
         if (false === $input->getOption('admin') && ($options = $this->getGroups()) && 0 !== \count($options)) {
-            $answer = $this->askMultipleChoice($options, $input, $output);
+            $answer = $this->askMultipleChoice(
+                'Assign which groups to the user (select multiple comma-separated)?',
+                $options,
+                $input,
+                $output
+            );
 
             $input->setOption('group', array_values(array_intersect_key(array_flip($options), array_flip($answer))));
         }
@@ -240,9 +245,9 @@ class UserCreateCommand extends Command
         return $helper->ask($input, $output, $question);
     }
 
-    private function askMultipleChoice(array $options, InputInterface $input, OutputInterface $output): array
+    private function askMultipleChoice(string $label, array $options, InputInterface $input, OutputInterface $output): array
     {
-        $question = new ChoiceQuestion('Assign which groups to the user (select multiple comma-separated)?', $options);
+        $question = new ChoiceQuestion($label, $options);
         $question->setAutocompleterValues($options);
         $question->setMultiselect(true);
 

--- a/core-bundle/src/DependencyInjection/Configuration.php
+++ b/core-bundle/src/DependencyInjection/Configuration.php
@@ -77,7 +77,7 @@ class Configuration implements ConfigurationInterface
                 ->end()
                 ->booleanNode('prepend_locale')
                     ->info('Whether or not to add the page language to the URL.')
-                    ->setDeprecated(...$this->getDeprecationArgs('contao/core-bundle', '4.10', 'The URL prefix is configured per root page since Contao 4.10. Using this option requires legacy routing.'))
+                    ->setDeprecated(...$this->getDeprecationArgs('4.10', 'The URL prefix is configured per root page since Contao 4.10. Using this option requires legacy routing.'))
                     ->defaultFalse()
                 ->end()
                 ->booleanNode('pretty_error_screens')
@@ -113,7 +113,7 @@ class Configuration implements ConfigurationInterface
                     ->defaultValue('css,csv,html,ini,js,json,less,md,scss,svg,svgz,txt,xliff,xml,yml,yaml')
                 ->end()
                 ->scalarNode('url_suffix')
-                    ->setDeprecated(...$this->getDeprecationArgs('contao/core-bundle', '4.10', 'The URL suffix is configured per root page since Contao 4.10. Using this option requires legacy routing.'))
+                    ->setDeprecated(...$this->getDeprecationArgs('4.10', 'The URL suffix is configured per root page since Contao 4.10. Using this option requires legacy routing.'))
                     ->defaultValue('.html')
                 ->end()
                 ->scalarNode('web_dir')
@@ -282,7 +282,7 @@ class Configuration implements ConfigurationInterface
                                         ->scalarNode('sizes')
                                         ->end()
                                         ->enumNode('resizeMode')
-                                            ->setDeprecated(...$this->getDeprecationArgs('contao/core-bundle', '4.9', 'Using contao.image.sizes.*.items.resizeMode is deprecated. Please use contao.image.sizes.*.items.resize_mode instead.'))
+                                            ->setDeprecated(...$this->getDeprecationArgs('4.9', 'Using contao.image.sizes.*.items.resizeMode is deprecated. Please use contao.image.sizes.*.items.resize_mode instead.'))
                                             ->values([
                                                 ResizeConfiguration::MODE_CROP,
                                                 ResizeConfiguration::MODE_BOX,
@@ -293,7 +293,7 @@ class Configuration implements ConfigurationInterface
                                 ->end()
                             ->end()
                             ->enumNode('resizeMode')
-                                ->setDeprecated(...$this->getDeprecationArgs('contao/core-bundle', '4.9', 'Using contao.image.sizes.*.resizeMode is deprecated. Please use contao.image.sizes.*.resize_mode instead.'))
+                                ->setDeprecated(...$this->getDeprecationArgs('4.9', 'Using contao.image.sizes.*.resizeMode is deprecated. Please use contao.image.sizes.*.resize_mode instead.'))
                                 ->values([
                                     ResizeConfiguration::MODE_CROP,
                                     ResizeConfiguration::MODE_BOX,
@@ -301,13 +301,13 @@ class Configuration implements ConfigurationInterface
                                 ])
                             ->end()
                             ->scalarNode('cssClass')
-                                ->setDeprecated(...$this->getDeprecationArgs('contao/core-bundle', '4.9', 'Using contao.image.sizes.*.cssClass is deprecated. Please use contao.image.sizes.*.css_class instead.'))
+                                ->setDeprecated(...$this->getDeprecationArgs('4.9', 'Using contao.image.sizes.*.cssClass is deprecated. Please use contao.image.sizes.*.css_class instead.'))
                             ->end()
                             ->booleanNode('lazyLoading')
-                                ->setDeprecated(...$this->getDeprecationArgs('contao/core-bundle', '4.9', 'Using contao.image.sizes.*.lazyLoading is deprecated. Please use contao.image.sizes.*.lazy_loading instead.'))
+                                ->setDeprecated(...$this->getDeprecationArgs('4.9', 'Using contao.image.sizes.*.lazyLoading is deprecated. Please use contao.image.sizes.*.lazy_loading instead.'))
                             ->end()
                             ->booleanNode('skipIfDimensionsMatch')
-                                ->setDeprecated(...$this->getDeprecationArgs('contao/core-bundle', '4.9', 'Using contao.image.sizes.*.skipIfDimensionsMatch is deprecated. Please use contao.image.sizes.*.skip_if_dimensions_match instead.'))
+                                ->setDeprecated(...$this->getDeprecationArgs('4.9', 'Using contao.image.sizes.*.skipIfDimensionsMatch is deprecated. Please use contao.image.sizes.*.skip_if_dimensions_match instead.'))
                             ->end()
                         ->end()
                     ->end()
@@ -326,7 +326,7 @@ class Configuration implements ConfigurationInterface
                     ->end()
                 ->end()
                 ->scalarNode('target_path')
-                    ->setDeprecated(...$this->getDeprecationArgs('contao/core-bundle', '4.9', 'Use the "contao.image.target_dir" parameter instead.'))
+                    ->setDeprecated(...$this->getDeprecationArgs('4.9', 'Use the "contao.image.target_dir" parameter instead.'))
                     ->defaultNull()
                 ->end()
                 ->arrayNode('valid_extensions')
@@ -527,13 +527,13 @@ class Configuration implements ConfigurationInterface
      *
      * @todo Remove this as soon as we are on Symfony 5 only
      */
-    private function getDeprecationArgs(string $package, string $version, string $message): array
+    private function getDeprecationArgs(string $version, string $message): array
     {
         /** @phpstan-ignore-next-line */
         if (method_exists('root', TreeBuilder::class)) {
             return [$message];
         }
 
-        return [$package, $version, $message];
+        return ['contao/core-bundle', $version, $message];
     }
 }

--- a/core-bundle/src/EventListener/Menu/BackendMenuListener.php
+++ b/core-bundle/src/EventListener/Menu/BackendMenuListener.php
@@ -146,7 +146,7 @@ class BackendMenuListener
 
         $submenu = $factory
             ->createItem('submenu')
-            ->setLabel($this->trans('MSC.user').' '.$user->username)
+            ->setLabel($this->translator->trans('MSC.user', [], 'contao_default').' '.$user->username)
             ->setAttribute('class', 'submenu')
             ->setLabelAttribute('class', 'h2')
             ->setExtra('translation_domain', false)
@@ -193,11 +193,6 @@ class BackendMenuListener
         ;
 
         $tree->addChild($buger);
-    }
-
-    private function trans(string $id): string
-    {
-        return $this->translator->trans($id, [], 'contao_default');
     }
 
     private function getAlertsLabel(string $systemMessages): string

--- a/core-bundle/tests/Command/UserListCommandTest.php
+++ b/core-bundle/tests/Command/UserListCommandTest.php
@@ -95,14 +95,14 @@ class UserListCommandTest extends TestCase
         $this->assertSame(0, $code);
     }
 
-    private function getCommand(bool $noResult = false): UserListCommand
+    private function getCommand(): UserListCommand
     {
         $collection = new Collection([$this->mockAdminUser(), $this->mockContaoUser()], 'tl_user');
 
         $userModelAdapter = $this->mockAdapter(['findBy', 'findAll']);
         $userModelAdapter
             ->method('findAll')
-            ->willReturn($noResult ? null : $collection, null)
+            ->willReturn($collection, null)
         ;
 
         $collection = new Collection([$this->mockAdminUser()], 'tl_user');
@@ -110,7 +110,7 @@ class UserListCommandTest extends TestCase
         $userModelAdapter
             ->method('findBy')
             ->with('admin', '1')
-            ->willReturn($noResult ? null : $collection, null)
+            ->willReturn($collection, null)
         ;
 
         $command = new UserListCommand($this->mockContaoFramework([UserModel::class => $userModelAdapter]));

--- a/core-bundle/tests/Controller/BackendPreviewSwitchControllerTest.php
+++ b/core-bundle/tests/Controller/BackendPreviewSwitchControllerTest.php
@@ -170,17 +170,17 @@ class BackendPreviewSwitchControllerTest extends TestCase
     /**
      * @return TokenChecker&MockObject
      */
-    private function mockTokenChecker(): TokenChecker
+    private function mockTokenChecker(?string $frontendUsername = null, bool $previewMode = true): TokenChecker
     {
         $tokenChecker = $this->createMock(TokenChecker::class);
         $tokenChecker
             ->method('getFrontendUsername')
-            ->willReturn(null)
+            ->willReturn($frontendUsername)
         ;
 
         $tokenChecker
             ->method('isPreviewMode')
-            ->willReturn(true)
+            ->willReturn($previewMode)
         ;
 
         return $tokenChecker;

--- a/core-bundle/tests/Controller/BackendPreviewSwitchControllerTest.php
+++ b/core-bundle/tests/Controller/BackendPreviewSwitchControllerTest.php
@@ -170,17 +170,17 @@ class BackendPreviewSwitchControllerTest extends TestCase
     /**
      * @return TokenChecker&MockObject
      */
-    private function mockTokenChecker(?string $frontendUsername = null, bool $previewMode = true): TokenChecker
+    private function mockTokenChecker(): TokenChecker
     {
         $tokenChecker = $this->createMock(TokenChecker::class);
         $tokenChecker
             ->method('getFrontendUsername')
-            ->willReturn($frontendUsername)
+            ->willReturn(null)
         ;
 
         $tokenChecker
             ->method('isPreviewMode')
-            ->willReturn($previewMode)
+            ->willReturn(true)
         ;
 
         return $tokenChecker;
@@ -205,12 +205,12 @@ class BackendPreviewSwitchControllerTest extends TestCase
     /**
      * @return Environment&MockObject
      */
-    private function getTwigMock(string $render = 'CONTAO'): Environment
+    private function getTwigMock(): Environment
     {
         $twig = $this->createMock(Environment::class);
         $twig
             ->method('render')
-            ->willReturn($render)
+            ->willReturn('CONTAO')
         ;
 
         return $twig;

--- a/core-bundle/tests/Controller/FrontendModule/TwoFactorControllerTest.php
+++ b/core-bundle/tests/Controller/FrontendModule/TwoFactorControllerTest.php
@@ -47,7 +47,6 @@ class TwoFactorControllerTest extends TestCase
     public function testReturnsEmptyResponseIfTheUserIsNotFullyAuthenticated(): void
     {
         $container = $this->getContainerWithFrameworkTemplate(
-            'mod_two_factor',
             $this->mockAuthenticator(),
             $this->mockAuthenticationUtils(),
             $this->mockSecurityHelper()
@@ -70,7 +69,6 @@ class TwoFactorControllerTest extends TestCase
         $user = $this->createMock(BackendUser::class);
 
         $container = $this->getContainerWithFrameworkTemplate(
-            'mod_two_factor',
             $this->mockAuthenticator(),
             $this->mockAuthenticationUtils(),
             $this->mockSecurityHelper($user, true)
@@ -95,7 +93,6 @@ class TwoFactorControllerTest extends TestCase
         $user->useTwoFactor = '1';
 
         $container = $this->getContainerWithFrameworkTemplate(
-            'mod_two_factor',
             $this->mockAuthenticator(),
             $this->mockAuthenticationUtils(),
             $this->mockSecurityHelper($user, true)
@@ -122,7 +119,6 @@ class TwoFactorControllerTest extends TestCase
         $user->useTwoFactor = '';
 
         $container = $this->getContainerWithFrameworkTemplate(
-            'mod_two_factor',
             $this->mockAuthenticator(),
             $this->mockAuthenticationUtils(),
             $this->mockSecurityHelper($user, true)
@@ -150,7 +146,6 @@ class TwoFactorControllerTest extends TestCase
         $user->useTwoFactor = '1';
 
         $container = $this->getContainerWithFrameworkTemplate(
-            'mod_two_factor',
             $this->mockAuthenticator(),
             $this->mockAuthenticationUtils(),
             $this->mockSecurityHelper($user, true)
@@ -197,7 +192,6 @@ class TwoFactorControllerTest extends TestCase
         $user->useTwoFactor = '1';
 
         $container = $this->getContainerWithFrameworkTemplate(
-            'mod_two_factor',
             $this->mockAuthenticator(),
             $this->mockAuthenticationUtils(),
             $this->mockSecurityHelper($user, true)
@@ -230,7 +224,6 @@ class TwoFactorControllerTest extends TestCase
         $user->useTwoFactor = '';
 
         $container = $this->getContainerWithFrameworkTemplate(
-            'mod_two_factor',
             $this->mockAuthenticator(),
             $this->mockAuthenticationUtils(new InvalidTwoFactorCodeException()),
             $this->mockSecurityHelper($user, true)
@@ -262,7 +255,6 @@ class TwoFactorControllerTest extends TestCase
         $user->useTwoFactor = '';
 
         $container = $this->getContainerWithFrameworkTemplate(
-            'mod_two_factor',
             $this->mockAuthenticator($user, false),
             $this->mockAuthenticationUtils(),
             $this->mockSecurityHelper($user, true)
@@ -301,7 +293,6 @@ class TwoFactorControllerTest extends TestCase
         ;
 
         $container = $this->getContainerWithFrameworkTemplate(
-            'mod_two_factor',
             $this->mockAuthenticator($user, true),
             $this->mockAuthenticationUtils(),
             $this->mockSecurityHelper($user, true)
@@ -337,7 +328,6 @@ class TwoFactorControllerTest extends TestCase
         $user->useTwoFactor = '1';
 
         $container = $this->getContainerWithFrameworkTemplate(
-            'mod_two_factor',
             $this->mockAuthenticator(),
             $this->mockAuthenticationUtils(),
             $this->mockSecurityHelper($user, true)
@@ -366,7 +356,6 @@ class TwoFactorControllerTest extends TestCase
         $user->useTwoFactor = '1';
 
         $container = $this->getContainerWithFrameworkTemplate(
-            'mod_two_factor',
             $this->mockAuthenticator(),
             $this->mockAuthenticationUtils(),
             $this->mockSecurityHelper($user, true)
@@ -476,7 +465,7 @@ class TwoFactorControllerTest extends TestCase
         return $page;
     }
 
-    private function getContainerWithFrameworkTemplate(string $templateName, Authenticator $authenticator, AuthenticationUtils $authenticationUtils, Security $security): ContainerBuilder
+    private function getContainerWithFrameworkTemplate(Authenticator $authenticator, AuthenticationUtils $authenticationUtils, Security $security): ContainerBuilder
     {
         $template = $this->createMock(FrontendTemplate::class);
         $template
@@ -493,7 +482,7 @@ class TwoFactorControllerTest extends TestCase
         $framework = $this->mockContaoFramework([PageModel::class => $adapter]);
         $framework
             ->method('createInstance')
-            ->with(FrontendTemplate::class, [$templateName])
+            ->with(FrontendTemplate::class, ['mod_two_factor'])
             ->willReturn($template)
         ;
 

--- a/core-bundle/tests/EventListener/DataContainer/ContentCompositionListenerTest.php
+++ b/core-bundle/tests/EventListener/DataContainer/ContentCompositionListenerTest.php
@@ -814,7 +814,7 @@ class ContentCompositionListenerTest extends TestCase
 
     public function testCannotPasteAfterArticleIfProviderDoesNotSupportContentComposition(): void
     {
-        $page = $this->expectPageFindByPk(17, $this->pageRecord);
+        $page = $this->expectPageFindByPk($this->pageRecord);
 
         $this->expectSupportsContentComposition(false, $page);
 
@@ -839,7 +839,7 @@ class ContentCompositionListenerTest extends TestCase
 
     public function testCannotPasteAfterArticleIfPageLayoutDoesNotHaveArticles(): void
     {
-        $page = $this->expectPageFindByPk(17, $this->pageRecord, 17);
+        $page = $this->expectPageFindByPk($this->pageRecord, 17);
 
         $this->expectSupportsContentComposition(true, $page);
 
@@ -864,7 +864,7 @@ class ContentCompositionListenerTest extends TestCase
 
     public function testDisablesPasteAfterArticleOnCutCurrentRecord(): void
     {
-        $page = $this->expectPageFindByPk(17, $this->pageRecord, 0);
+        $page = $this->expectPageFindByPk($this->pageRecord, 0);
 
         $this->expectSupportsContentComposition(true, $page);
 
@@ -891,7 +891,7 @@ class ContentCompositionListenerTest extends TestCase
 
     public function testDisablesPasteAfterArticleOnCutAllCurrentRecord(): void
     {
-        $page = $this->expectPageFindByPk(17, $this->pageRecord, 0);
+        $page = $this->expectPageFindByPk($this->pageRecord, 0);
 
         $this->expectSupportsContentComposition(true, $page);
 
@@ -918,7 +918,7 @@ class ContentCompositionListenerTest extends TestCase
 
     public function testDisablesPasteAfterArticleOnCircularReference(): void
     {
-        $page = $this->expectPageFindByPk(17, $this->pageRecord, 0);
+        $page = $this->expectPageFindByPk($this->pageRecord, 0);
 
         $this->expectSupportsContentComposition(true, $page);
 
@@ -945,7 +945,7 @@ class ContentCompositionListenerTest extends TestCase
 
     public function testDisablesPasteAfterArticleIfUserDoesNotHavePermission(): void
     {
-        $page = $this->expectPageFindByPk(17, $this->pageRecord, 0);
+        $page = $this->expectPageFindByPk($this->pageRecord, 0);
 
         $this->expectSupportsContentComposition(true, $page);
 
@@ -974,7 +974,7 @@ class ContentCompositionListenerTest extends TestCase
 
     public function testCanPasteAfterArticle(): void
     {
-        $pageModel = $this->expectPageFindByPk(17, $this->pageRecord, 0);
+        $pageModel = $this->expectPageFindByPk($this->pageRecord, 0);
 
         $this->expectSupportsContentComposition(true, $pageModel);
 
@@ -1114,7 +1114,7 @@ class ContentCompositionListenerTest extends TestCase
      *
      * @return PageModel&MockObject
      */
-    private function expectPageFindByPk(int $id, array $row, $moduleId = false): PageModel
+    private function expectPageFindByPk(array $row, $moduleId = false): PageModel
     {
         /** @var PageModel&MockObject $page */
         $page = $this->mockClassWithProperties(PageModel::class, $row);
@@ -1144,7 +1144,7 @@ class ContentCompositionListenerTest extends TestCase
         $this->pageModelAdapter
             ->expects($this->once())
             ->method('findByPk')
-            ->with($id)
+            ->with(17)
             ->willReturn($page)
         ;
 

--- a/core-bundle/tests/EventListener/DataContainer/ContentCompositionListenerTest.php
+++ b/core-bundle/tests/EventListener/DataContainer/ContentCompositionListenerTest.php
@@ -162,7 +162,7 @@ class ContentCompositionListenerTest extends TestCase
             ->willReturn(true)
         ;
 
-        $page = $this->expectPageWithRow($this->pageRecord);
+        $page = $this->expectPageWithRow();
 
         $this->expectSupportsContentComposition(false, $page);
 
@@ -193,7 +193,7 @@ class ContentCompositionListenerTest extends TestCase
             ->willReturn(true)
         ;
 
-        $page = $this->expectPageWithRow($this->pageRecord, null);
+        $page = $this->expectPageWithRow(null);
 
         $this->expectSupportsContentComposition(true, $page);
 
@@ -224,7 +224,7 @@ class ContentCompositionListenerTest extends TestCase
             ->willReturn(true)
         ;
 
-        $page = $this->expectPageWithRow($this->pageRecord, 17);
+        $page = $this->expectPageWithRow(17);
 
         $this->expectSupportsContentComposition(true, $page);
 
@@ -255,7 +255,7 @@ class ContentCompositionListenerTest extends TestCase
             ->willReturn(true)
         ;
 
-        $page = $this->expectPageWithRow($this->pageRecord, 17);
+        $page = $this->expectPageWithRow(17);
 
         $this->expectSupportsContentComposition(true, $page);
 
@@ -312,7 +312,7 @@ class ContentCompositionListenerTest extends TestCase
             ->willReturn(true)
         ;
 
-        $page = $this->expectPageWithRow($this->pageRecord, 0);
+        $page = $this->expectPageWithRow(0);
 
         $this->expectSupportsContentComposition(true, $page);
 
@@ -434,7 +434,7 @@ class ContentCompositionListenerTest extends TestCase
 
         $this->expectRequest(true);
         $this->expectUser();
-        $this->expectPageWithRow($this->pageRecord);
+        $this->expectPageWithRow();
 
         $this->pageRegistry
             ->expects($this->never())
@@ -452,7 +452,7 @@ class ContentCompositionListenerTest extends TestCase
         $this->expectRequest(true);
         $this->expectUser();
 
-        $page = $this->expectPageWithRow($this->pageRecord);
+        $page = $this->expectPageWithRow();
 
         $this->expectSupportsContentComposition(false, $page);
 
@@ -467,7 +467,7 @@ class ContentCompositionListenerTest extends TestCase
         $this->expectRequest(true);
         $this->expectUser();
 
-        $page = $this->expectPageWithRow($this->pageRecord, 17);
+        $page = $this->expectPageWithRow(17);
 
         $this->expectSupportsContentComposition(true, $page);
 
@@ -482,7 +482,7 @@ class ContentCompositionListenerTest extends TestCase
         $this->expectRequest(true, []);
         $this->expectUser();
 
-        $page = $this->expectPageWithRow($this->pageRecord, 0);
+        $page = $this->expectPageWithRow(0);
 
         $this->expectSupportsContentComposition(true, $page);
 
@@ -497,7 +497,7 @@ class ContentCompositionListenerTest extends TestCase
         $this->expectRequest(true, [12]);
         $this->expectUser();
 
-        $page = $this->expectPageWithRow($this->pageRecord, 0);
+        $page = $this->expectPageWithRow(0);
 
         $this->expectSupportsContentComposition(true, $page);
 
@@ -512,7 +512,7 @@ class ContentCompositionListenerTest extends TestCase
         $this->expectRequest(true, ['tl_foo' => [17]]);
         $this->expectUser();
 
-        $page = $this->expectPageWithRow($this->pageRecord, 0);
+        $page = $this->expectPageWithRow(0);
 
         $this->expectSupportsContentComposition(true, $page);
         $this->expectArticleCount(1);
@@ -533,7 +533,7 @@ class ContentCompositionListenerTest extends TestCase
         $this->expectRequest(true, ['tl_foo' => [17]]);
         $this->expectUser();
 
-        $page = $this->expectPageWithRow($this->pageRecord, 0);
+        $page = $this->expectPageWithRow(0);
 
         $this->expectSupportsContentComposition(true, $page);
         $this->expectArticleCount(0);
@@ -569,7 +569,7 @@ class ContentCompositionListenerTest extends TestCase
         $this->expectRequest(true, ['tl_foo' => [17]]);
         $this->expectUser();
 
-        $page = $this->expectPageWithRow($this->pageRecord);
+        $page = $this->expectPageWithRow();
 
         $this->expectSupportsContentComposition(true, $page);
         $this->expectArticleCount(0);
@@ -644,7 +644,7 @@ class ContentCompositionListenerTest extends TestCase
 
     public function testCannotPasteIntoArticleIfProviderDoesNotSupportContentComposition(): void
     {
-        $page = $this->expectPageWithRow($this->pageRecord);
+        $page = $this->expectPageWithRow();
 
         $this->expectSupportsContentComposition(false, $page);
 
@@ -666,7 +666,7 @@ class ContentCompositionListenerTest extends TestCase
 
     public function testCannotPasteIntoArticleIfPageLayoutDoesNotHaveArticles(): void
     {
-        $page = $this->expectPageWithRow($this->pageRecord, 1);
+        $page = $this->expectPageWithRow(1);
 
         $this->expectSupportsContentComposition(true, $page);
 
@@ -691,7 +691,7 @@ class ContentCompositionListenerTest extends TestCase
 
     public function testDisablesPasteIntoArticleOnCircularReference(): void
     {
-        $page = $this->expectPageWithRow($this->pageRecord, 0);
+        $page = $this->expectPageWithRow(0);
 
         $this->expectSupportsContentComposition(true, $page);
 
@@ -718,7 +718,7 @@ class ContentCompositionListenerTest extends TestCase
 
     public function testDisablesPasteIntoArticleIfUserDoesNotHavePermission(): void
     {
-        $page = $this->expectPageWithRow($this->pageRecord, 0);
+        $page = $this->expectPageWithRow(0);
 
         $this->expectSupportsContentComposition(true, $page);
 
@@ -747,7 +747,7 @@ class ContentCompositionListenerTest extends TestCase
 
     public function testCanPasteIntoArticle(): void
     {
-        $page = $this->expectPageWithRow($this->pageRecord, 0);
+        $page = $this->expectPageWithRow(0);
 
         $this->expectSupportsContentComposition(true, $page);
 
@@ -814,7 +814,7 @@ class ContentCompositionListenerTest extends TestCase
 
     public function testCannotPasteAfterArticleIfProviderDoesNotSupportContentComposition(): void
     {
-        $page = $this->expectPageFindByPk($this->pageRecord);
+        $page = $this->expectPageFindByPk();
 
         $this->expectSupportsContentComposition(false, $page);
 
@@ -839,7 +839,7 @@ class ContentCompositionListenerTest extends TestCase
 
     public function testCannotPasteAfterArticleIfPageLayoutDoesNotHaveArticles(): void
     {
-        $page = $this->expectPageFindByPk($this->pageRecord, 17);
+        $page = $this->expectPageFindByPk(17);
 
         $this->expectSupportsContentComposition(true, $page);
 
@@ -864,7 +864,7 @@ class ContentCompositionListenerTest extends TestCase
 
     public function testDisablesPasteAfterArticleOnCutCurrentRecord(): void
     {
-        $page = $this->expectPageFindByPk($this->pageRecord, 0);
+        $page = $this->expectPageFindByPk(0);
 
         $this->expectSupportsContentComposition(true, $page);
 
@@ -891,7 +891,7 @@ class ContentCompositionListenerTest extends TestCase
 
     public function testDisablesPasteAfterArticleOnCutAllCurrentRecord(): void
     {
-        $page = $this->expectPageFindByPk($this->pageRecord, 0);
+        $page = $this->expectPageFindByPk(0);
 
         $this->expectSupportsContentComposition(true, $page);
 
@@ -918,7 +918,7 @@ class ContentCompositionListenerTest extends TestCase
 
     public function testDisablesPasteAfterArticleOnCircularReference(): void
     {
-        $page = $this->expectPageFindByPk($this->pageRecord, 0);
+        $page = $this->expectPageFindByPk(0);
 
         $this->expectSupportsContentComposition(true, $page);
 
@@ -945,7 +945,7 @@ class ContentCompositionListenerTest extends TestCase
 
     public function testDisablesPasteAfterArticleIfUserDoesNotHavePermission(): void
     {
-        $page = $this->expectPageFindByPk($this->pageRecord, 0);
+        $page = $this->expectPageFindByPk(0);
 
         $this->expectSupportsContentComposition(true, $page);
 
@@ -974,7 +974,7 @@ class ContentCompositionListenerTest extends TestCase
 
     public function testCanPasteAfterArticle(): void
     {
-        $pageModel = $this->expectPageFindByPk($this->pageRecord, 0);
+        $pageModel = $this->expectPageFindByPk(0);
 
         $this->expectSupportsContentComposition(true, $pageModel);
 
@@ -1065,10 +1065,10 @@ class ContentCompositionListenerTest extends TestCase
      *
      * @return PageModel&MockObject
      */
-    private function expectPageWithRow(array $row, $moduleId = false): PageModel
+    private function expectPageWithRow($moduleId = false): PageModel
     {
         /** @var PageModel&MockObject $page */
-        $page = $this->mockClassWithProperties(PageModel::class, $row);
+        $page = $this->mockClassWithProperties(PageModel::class, $this->pageRecord);
         $page
             ->expects($this->once())
             ->method('preventSaving')
@@ -1078,7 +1078,7 @@ class ContentCompositionListenerTest extends TestCase
         $page
             ->expects($this->once())
             ->method('setRow')
-            ->with($row)
+            ->with($this->pageRecord)
         ;
 
         if (false !== $moduleId) {
@@ -1114,13 +1114,13 @@ class ContentCompositionListenerTest extends TestCase
      *
      * @return PageModel&MockObject
      */
-    private function expectPageFindByPk(array $row, $moduleId = false): PageModel
+    private function expectPageFindByPk($moduleId = false): PageModel
     {
         /** @var PageModel&MockObject $page */
-        $page = $this->mockClassWithProperties(PageModel::class, $row);
+        $page = $this->mockClassWithProperties(PageModel::class, $this->pageRecord);
         $page
             ->method('row')
-            ->willReturn($row)
+            ->willReturn($this->pageRecord)
         ;
 
         if (false !== $moduleId) {

--- a/core-bundle/tests/EventListener/DataContainer/TemplateOptionsListenerTest.php
+++ b/core-bundle/tests/EventListener/DataContainer/TemplateOptionsListenerTest.php
@@ -151,7 +151,7 @@ class TemplateOptionsListenerTest extends TestCase
     /**
      * @return ContaoFramework&MockObject
      */
-    private function getFramework(array $adapters = []): ContaoFramework
+    private function getFramework(): ContaoFramework
     {
         $controllerAdapter = $this->mockAdapter(['getTemplateGroup']);
         $controllerAdapter
@@ -168,7 +168,7 @@ class TemplateOptionsListenerTest extends TestCase
             ])
         ;
 
-        return $this->mockContaoFramework(array_merge([Controller::class => $controllerAdapter], $adapters));
+        return $this->mockContaoFramework([Controller::class => $controllerAdapter]);
     }
 
     /**

--- a/core-bundle/tests/EventListener/PreviewAuthenticationListenerTest.php
+++ b/core-bundle/tests/EventListener/PreviewAuthenticationListenerTest.php
@@ -83,7 +83,7 @@ class PreviewAuthenticationListenerTest extends TestCase
         $this->assertInstanceOf(RedirectResponse::class, $requestEvent->getResponse());
     }
 
-    private function getRequestEvent(Request $request = null, bool $isSubRequest = false): RequestEvent
+    private function getRequestEvent(Request $request = null): RequestEvent
     {
         $kernel = $this->createMock(KernelInterface::class);
 
@@ -91,8 +91,6 @@ class PreviewAuthenticationListenerTest extends TestCase
             $request = new Request();
         }
 
-        $type = $isSubRequest ? HttpKernelInterface::SUB_REQUEST : HttpKernelInterface::MASTER_REQUEST;
-
-        return new RequestEvent($kernel, $request, $type);
+        return new RequestEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
     }
 }

--- a/core-bundle/tests/EventListener/PreviewToolbarListenerTest.php
+++ b/core-bundle/tests/EventListener/PreviewToolbarListenerTest.php
@@ -358,12 +358,12 @@ class PreviewToolbarListenerTest extends TestCase
     /**
      * @return Environment&MockObject
      */
-    private function getTwigMock(string $render = 'CONTAO'): Environment
+    private function getTwigMock(): Environment
     {
         $twig = $this->createMock(Environment::class);
         $twig
             ->method('render')
-            ->willReturn($render)
+            ->willReturn('CONTAO')
         ;
 
         return $twig;
@@ -372,12 +372,12 @@ class PreviewToolbarListenerTest extends TestCase
     /**
      * @return RouterInterface&MockObject
      */
-    private function mockRouterWithContext(array $expectedParameters = [], string $expectedRoute = 'contao_backend_switch', int $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH): RouterInterface
+    private function mockRouterWithContext(): RouterInterface
     {
         $router = $this->createMock(RouterInterface::class);
         $router
             ->method('generate')
-            ->with($expectedRoute, $expectedParameters, $referenceType)
+            ->with('contao_backend_switch', [], UrlGeneratorInterface::ABSOLUTE_PATH)
         ;
 
         $router

--- a/core-bundle/tests/EventListener/SubrequestCacheSubscriberTest.php
+++ b/core-bundle/tests/EventListener/SubrequestCacheSubscriberTest.php
@@ -41,7 +41,7 @@ class SubrequestCacheSubscriberTest extends TestCase
     {
         $subscriber = new SubrequestCacheSubscriber();
 
-        $this->onKernelRequest($subscriber, KernelInterface::MASTER_REQUEST);
+        $this->onKernelRequest($subscriber);
 
         $subResponse = new Response();
         $subResponse->headers->set(SubrequestCacheSubscriber::MERGE_CACHE_HEADER, '1');
@@ -66,7 +66,7 @@ class SubrequestCacheSubscriberTest extends TestCase
     {
         $subscriber = new SubrequestCacheSubscriber();
 
-        $this->onKernelRequest($subscriber, KernelInterface::MASTER_REQUEST);
+        $this->onKernelRequest($subscriber);
 
         $subResponse = new Response();
         $subResponse->headers->set(SubrequestCacheSubscriber::MERGE_CACHE_HEADER, '1');
@@ -89,7 +89,7 @@ class SubrequestCacheSubscriberTest extends TestCase
     {
         $subscriber = new SubrequestCacheSubscriber();
 
-        $this->onKernelRequest($subscriber, KernelInterface::MASTER_REQUEST);
+        $this->onKernelRequest($subscriber);
 
         $subResponse = new Response();
         $subResponse->setPrivate();
@@ -111,7 +111,7 @@ class SubrequestCacheSubscriberTest extends TestCase
     {
         $subscriber = new SubrequestCacheSubscriber();
 
-        $this->onKernelRequest($subscriber, KernelInterface::MASTER_REQUEST);
+        $this->onKernelRequest($subscriber);
 
         $subResponse = new Response();
         $subResponse->headers->set(SubrequestCacheSubscriber::MERGE_CACHE_HEADER, '1');
@@ -130,9 +130,9 @@ class SubrequestCacheSubscriberTest extends TestCase
         $this->assertFalse($mainResponse->headers->has(SubrequestCacheSubscriber::MERGE_CACHE_HEADER));
     }
 
-    private function onKernelRequest(SubrequestCacheSubscriber $subscriber, int $requestType): void
+    private function onKernelRequest(SubrequestCacheSubscriber $subscriber): void
     {
-        $event = new RequestEvent($this->createMock(Kernel::class), new Request(), $requestType);
+        $event = new RequestEvent($this->createMock(Kernel::class), new Request(), KernelInterface::MASTER_REQUEST);
         $subscriber->onKernelRequest($event);
     }
 

--- a/core-bundle/tests/Image/PictureFactoryTest.php
+++ b/core-bundle/tests/Image/PictureFactoryTest.php
@@ -724,7 +724,7 @@ class PictureFactoryTest extends TestCase
         yield [false, 20, 100, 22, 100];
     }
 
-    private function getPictureFactory(PictureGeneratorInterface $pictureGenerator = null, ImageFactoryInterface $imageFactory = null, ContaoFramework $framework = null, bool $bypassCache = null, array $imagineOptions = null): PictureFactory
+    private function getPictureFactory(PictureGeneratorInterface $pictureGenerator = null, ImageFactoryInterface $imageFactory = null, ContaoFramework $framework = null): PictureFactory
     {
         if (null === $pictureGenerator) {
             $pictureGenerator = $this->createMock(PictureGeneratorInterface::class);
@@ -738,14 +738,6 @@ class PictureFactoryTest extends TestCase
             $framework = $this->createMock(ContaoFramework::class);
         }
 
-        if (null === $bypassCache) {
-            $bypassCache = false;
-        }
-
-        if (null === $imagineOptions) {
-            $imagineOptions = [];
-        }
-
-        return new PictureFactory($pictureGenerator, $imageFactory, $framework, $bypassCache, $imagineOptions);
+        return new PictureFactory($pictureGenerator, $imageFactory, $framework, false, []);
     }
 }

--- a/core-bundle/tests/Picker/TablePickerProviderTest.php
+++ b/core-bundle/tests/Picker/TablePickerProviderTest.php
@@ -308,7 +308,7 @@ class TablePickerProviderTest extends ContaoTestCase
         $provider = $this->createTableProvider(
             $this->mockFrameworkWithDcaLoader('tl_article'),
             $this->mockRouterWithExpectedParams($params),
-            $this->mockConnectionForQuery('tl_article', ['pid' => 1])
+            $this->mockConnectionForQuery('tl_article', 15, ['pid' => 1])
         );
 
         $provider->getUrl($config);
@@ -327,12 +327,12 @@ class TablePickerProviderTest extends ContaoTestCase
             'id' => '1',
         ];
 
-        $config = $this->mockPickerConfig('tl_article', '15');
+        $config = $this->mockPickerConfig('tl_article', '42');
 
         $provider = $this->createTableProvider(
             $this->mockFrameworkWithDcaLoader('tl_article'),
             $this->mockRouterWithExpectedParams($params),
-            $this->mockConnectionForQuery('tl_article', ['pid' => 1])
+            $this->mockConnectionForQuery('tl_article', 42, ['pid' => 1])
         );
 
         $provider->getUrl($config);
@@ -359,12 +359,12 @@ class TablePickerProviderTest extends ContaoTestCase
             'id' => 7,
         ];
 
-        $config = $this->mockPickerConfig('tl_content', '15');
+        $config = $this->mockPickerConfig('tl_content', '2');
 
         $provider = $this->createTableProvider(
             $this->mockFrameworkWithDcaLoader('tl_content'),
             $this->mockRouterWithExpectedParams($params),
-            $this->mockConnectionForQuery('tl_content', ['pid' => 7, 'ptable' => 'tl_news'], true)
+            $this->mockConnectionForQuery('tl_content', 2, ['pid' => 7, 'ptable' => 'tl_news'], true)
         );
 
         $provider->getUrl($config);
@@ -389,7 +389,7 @@ class TablePickerProviderTest extends ContaoTestCase
         $provider = $this->createTableProvider(
             $this->mockFrameworkWithDcaLoader('tl_content'),
             $this->mockRouterWithExpectedParams($params),
-            $this->mockConnectionForQuery('tl_content', ['pid' => 7, 'ptable' => ''], true)
+            $this->mockConnectionForQuery('tl_content', 15, ['pid' => 7, 'ptable' => ''], true)
         );
 
         $provider->getUrl($config);
@@ -406,12 +406,12 @@ class TablePickerProviderTest extends ContaoTestCase
             'picker' => 'foobar',
         ];
 
-        $config = $this->mockPickerConfig('tl_article', '15');
+        $config = $this->mockPickerConfig('tl_article', '42');
 
         $provider = $this->createTableProvider(
             $this->mockFrameworkWithDcaLoader('tl_article'),
             $this->mockRouterWithExpectedParams($params),
-            $this->mockConnectionForQuery('tl_article', false)
+            $this->mockConnectionForQuery('tl_article', 42, false)
         );
 
         $provider->getUrl($config);
@@ -614,13 +614,13 @@ class TablePickerProviderTest extends ContaoTestCase
     /**
      * @return Connection&MockObject
      */
-    private function mockConnectionForQuery(string $table, $data, bool $dynamicPtable = false): Connection
+    private function mockConnectionForQuery(string $table, int $id, $data, bool $dynamicPtable = false): Connection
     {
         $expr = $this->createMock(ExpressionBuilder::class);
         $expr
             ->expects($this->once())
             ->method('eq')
-            ->with('id', 15)
+            ->with('id', $id)
             ->willReturnSelf()
         ;
 

--- a/core-bundle/tests/Picker/TablePickerProviderTest.php
+++ b/core-bundle/tests/Picker/TablePickerProviderTest.php
@@ -308,7 +308,7 @@ class TablePickerProviderTest extends ContaoTestCase
         $provider = $this->createTableProvider(
             $this->mockFrameworkWithDcaLoader('tl_article'),
             $this->mockRouterWithExpectedParams($params),
-            $this->mockConnectionForQuery('tl_article', 15, ['pid' => 1])
+            $this->mockConnectionForQuery('tl_article', ['pid' => 1])
         );
 
         $provider->getUrl($config);
@@ -332,7 +332,7 @@ class TablePickerProviderTest extends ContaoTestCase
         $provider = $this->createTableProvider(
             $this->mockFrameworkWithDcaLoader('tl_article'),
             $this->mockRouterWithExpectedParams($params),
-            $this->mockConnectionForQuery('tl_article', 15, ['pid' => 1])
+            $this->mockConnectionForQuery('tl_article', ['pid' => 1])
         );
 
         $provider->getUrl($config);
@@ -364,7 +364,7 @@ class TablePickerProviderTest extends ContaoTestCase
         $provider = $this->createTableProvider(
             $this->mockFrameworkWithDcaLoader('tl_content'),
             $this->mockRouterWithExpectedParams($params),
-            $this->mockConnectionForQuery('tl_content', 15, ['pid' => 7, 'ptable' => 'tl_news'], true)
+            $this->mockConnectionForQuery('tl_content', ['pid' => 7, 'ptable' => 'tl_news'], true)
         );
 
         $provider->getUrl($config);
@@ -389,7 +389,7 @@ class TablePickerProviderTest extends ContaoTestCase
         $provider = $this->createTableProvider(
             $this->mockFrameworkWithDcaLoader('tl_content'),
             $this->mockRouterWithExpectedParams($params),
-            $this->mockConnectionForQuery('tl_content', 15, ['pid' => 7, 'ptable' => ''], true)
+            $this->mockConnectionForQuery('tl_content', ['pid' => 7, 'ptable' => ''], true)
         );
 
         $provider->getUrl($config);
@@ -411,7 +411,7 @@ class TablePickerProviderTest extends ContaoTestCase
         $provider = $this->createTableProvider(
             $this->mockFrameworkWithDcaLoader('tl_article'),
             $this->mockRouterWithExpectedParams($params),
-            $this->mockConnectionForQuery('tl_article', 15, false)
+            $this->mockConnectionForQuery('tl_article', false)
         );
 
         $provider->getUrl($config);
@@ -614,13 +614,13 @@ class TablePickerProviderTest extends ContaoTestCase
     /**
      * @return Connection&MockObject
      */
-    private function mockConnectionForQuery(string $table, int $id, $data, bool $dynamicPtable = false): Connection
+    private function mockConnectionForQuery(string $table, $data, bool $dynamicPtable = false): Connection
     {
         $expr = $this->createMock(ExpressionBuilder::class);
         $expr
             ->expects($this->once())
             ->method('eq')
-            ->with('id', $id)
+            ->with('id', 15)
             ->willReturnSelf()
         ;
 

--- a/core-bundle/tests/Routing/RouteProviderTest.php
+++ b/core-bundle/tests/Routing/RouteProviderTest.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Tests\Routing;
 
-use Contao\Config;
 use Contao\CoreBundle\Exception\NoRootPageFoundException;
 use Contao\CoreBundle\Framework\Adapter;
 use Contao\CoreBundle\Framework\ContaoFramework;
@@ -692,7 +691,7 @@ class RouteProviderTest extends TestCase
     /**
      * @return Request&MockObject
      */
-    private function mockRequestWithPath(string $path, array $languages = ['en'], string $host = 'example.com'): Request
+    private function mockRequestWithPath(string $path, array $languages = ['en']): Request
     {
         $request = $this->createMock(Request::class);
         $request
@@ -707,7 +706,7 @@ class RouteProviderTest extends TestCase
 
         $request
             ->method('getHttpHost')
-            ->willReturn($host)
+            ->willReturn('example.com')
         ;
 
         return $request;
@@ -716,9 +715,9 @@ class RouteProviderTest extends TestCase
     /**
      * @return ContaoFramework&MockObject
      */
-    private function mockFramework(Adapter $pageAdapter = null, Adapter $configAdapter = null): ContaoFramework
+    private function mockFramework(Adapter $pageAdapter = null): ContaoFramework
     {
-        return $this->mockContaoFramework([PageModel::class => $pageAdapter, Config::class => $configAdapter]);
+        return $this->mockContaoFramework([PageModel::class => $pageAdapter]);
     }
 
     /**
@@ -748,7 +747,7 @@ class RouteProviderTest extends TestCase
     /**
      * @return PageModel&MockObject
      */
-    private function createRootPage(string $language, string $alias, bool $fallback = true, string $domain = '', string $scheme = null): PageModel
+    private function createRootPage(string $language, string $alias, bool $fallback = true): PageModel
     {
         /** @var PageModel&MockObject $page */
         $page = $this->mockClassWithProperties(PageModel::class);
@@ -756,12 +755,12 @@ class RouteProviderTest extends TestCase
         $page->rootId = 1;
         $page->type = 'root';
         $page->alias = $alias;
-        $page->domain = $domain;
+        $page->domain = '';
         $page->urlPrefix = '';
         $page->urlSuffix = '.html';
         $page->rootLanguage = $language;
         $page->rootIsFallback = $fallback;
-        $page->rootUseSSL = 'https' === $scheme;
+        $page->rootUseSSL = false;
         $page->rootSorting = array_reduce((array) $language, static function ($c, $i) { return $c + \ord($i); }, 0);
 
         return $page;

--- a/manager-bundle/src/Composer/ScriptHandler.php
+++ b/manager-bundle/src/Composer/ScriptHandler.php
@@ -31,10 +31,7 @@ class ScriptHandler
     {
         trigger_deprecation('contao/manager-bundle', '4.11', 'Using ScriptHandler::initializeApplication() has been deprecated and will no longer work in Contao 5.0. Use the "contao-setup" binary instead.');
 
-        $command = array_filter([
-            'contao-setup',
-            $event->getIO()->isDecorated() ? '--ansi' : '--no-ansi',
-        ]);
+        $command = ['contao-setup', $event->getIO()->isDecorated() ? '--ansi' : '--no-ansi'];
 
         $event->getIO()->write(
             sprintf(


### PR DESCRIPTION
For example

```php
class FooTest extends TestCase
{
    public function testFoo(): void
    {
        $this->expectArray(['foo', 'bar']);
    }

    public function testBar(): void
    {
        $this->expectArray(['foo', 'bar']);
    }

    private function expectArray(array $arr): void
    {
        // $arr is always ['foo', 'bar'] therefore it does not make sense to make it a variable
    }
}
```

or

```php
class FooTest extends TestCase
{
    public function testFoo(): void
    {
        $this->getMock();
    }

    public function testBar(): void
    {
        $this->getMock();
    }

    private function getMock(boolean $hasResult = true): MockObject
    {
        $mock = $this->generateMock(/* … */);
        $mock
            ->expects($this->once())
            ->method(/* … */)
            ->willReturn($hasResult ? $result : null); // $hasResult is always true therefore the argument makes no sense
    }
}
```
