### PR TITLE
Automatically inject container for tagged controllers

### DIFF
--- a/core-bundle/src/DependencyInjection/Compiler/RegisterFragmentsPass.php
+++ b/core-bundle/src/DependencyInjection/Compiler/RegisterFragmentsPass.php
@@ -16,6 +16,8 @@ use Contao\CoreBundle\EventListener\GlobalsMapListener;
 use Contao\CoreBundle\Fragment\FragmentConfig;
 use Contao\CoreBundle\Fragment\FragmentOptionsAwareInterface;
 use Contao\CoreBundle\Fragment\FragmentPreHandlerInterface;
+use Psr\Container\ContainerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
@@ -124,6 +126,10 @@ class RegisterFragmentsPass implements CompilerPassInterface
 
                 if (is_a($definition->getClass(), FragmentOptionsAwareInterface::class, true)) {
                     $childDefinition->addMethodCall('setFragmentOptions', [$attributes]);
+                }
+
+                if (is_a($definition->getClass(), AbstractController::class, true) && !$childDefinition->hasMethodCall('setContainer')) {
+                    $childDefinition->addMethodCall('setContainer', [new Reference(ContainerInterface::class)]);
                 }
 
                 $registry->addMethodCall('add', [$identifier, $config]);

--- a/core-bundle/src/DependencyInjection/Compiler/RegisterPagesPass.php
+++ b/core-bundle/src/DependencyInjection/Compiler/RegisterPagesPass.php
@@ -18,6 +18,8 @@ use Contao\CoreBundle\Routing\Page\DynamicRouteInterface;
 use Contao\CoreBundle\Routing\Page\PageRegistry;
 use Contao\CoreBundle\Routing\Page\RouteConfig;
 use Contao\FrontendIndex;
+use Psr\Container\ContainerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Compiler\PriorityTaggedServiceTrait;
 use Symfony\Component\DependencyInjection\Container;
@@ -57,6 +59,10 @@ class RegisterPagesPass implements CompilerPassInterface
             $tags = $definition->getTag(self::TAG_NAME);
 
             $definition->clearTag(self::TAG_NAME);
+
+            if (is_a($definition->getClass(), AbstractController::class, true) && !$definition->hasMethodCall('setContainer')) {
+                $definition->addMethodCall('setContainer', [new Reference(ContainerInterface::class)]);
+            }
 
             foreach ($tags as $attributes) {
                 $routeEnhancer = null;

--- a/core-bundle/tests/DependencyInjection/Compiler/RegisterFragmentsPassTest.php
+++ b/core-bundle/tests/DependencyInjection/Compiler/RegisterFragmentsPassTest.php
@@ -156,6 +156,7 @@ class RegisterFragmentsPassTest extends TestCase
         /** @var ChildDefinition $definition */
         $definition = $container->findDefinition('contao.fragment._contao.frontend_module.two_factor');
         $calls = $definition->getMethodCalls();
+
         $this->assertCount(2, $calls);
         $this->assertSame('setContainer', $calls[1][0]);
         $this->assertInstanceOf(Reference::class, $calls[1][1][0]);

--- a/core-bundle/tests/DependencyInjection/Compiler/RegisterFragmentsPassTest.php
+++ b/core-bundle/tests/DependencyInjection/Compiler/RegisterFragmentsPassTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Tests\DependencyInjection\Compiler;
 
 use Contao\ContentProxy;
+use Contao\CoreBundle\Controller\FrontendModule\TwoFactorController;
 use Contao\CoreBundle\DependencyInjection\Compiler\RegisterFragmentsPass;
 use Contao\CoreBundle\EventListener\GlobalsMapListener;
 use Contao\CoreBundle\Fragment\FragmentPreHandlerInterface;
@@ -20,11 +21,13 @@ use Contao\CoreBundle\Fragment\FragmentRegistry;
 use Contao\CoreBundle\Fragment\Reference\ContentElementReference;
 use Contao\CoreBundle\Fragment\Reference\FrontendModuleReference;
 use Contao\CoreBundle\Tests\TestCase;
+use Psr\Container\ContainerInterface;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Compiler\ResolveClassPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\ServiceLocator;
 
 class RegisterFragmentsPassTest extends TestCase
@@ -135,6 +138,28 @@ class RegisterFragmentsPassTest extends TestCase
         $this->assertInstanceOf(ChildDefinition::class, $definition);
         $this->assertSame('app.fragments.content_controller', $definition->getParent());
         $this->assertTrue($definition->isPublic());
+    }
+
+    public function testAddsContainerCallIfClassExtendsSymfonyAbstractController(): void
+    {
+        $definition = new Definition(TwoFactorController::class);
+        $definition->addTag('contao.frontend_module');
+
+        $container = $this->getContainerWithFragmentServices();
+        $container->setDefinition('app.fragments.two_factor', $definition);
+
+        (new ResolveClassPass())->process($container);
+
+        $pass = new RegisterFragmentsPass(FrontendModuleReference::TAG_NAME);
+        $pass->process($container);
+
+        /** @var ChildDefinition $definition */
+        $definition = $container->findDefinition('contao.fragment._contao.frontend_module.two_factor');
+        $calls = $definition->getMethodCalls();
+        $this->assertCount(2, $calls);
+        $this->assertSame('setContainer', $calls[1][0]);
+        $this->assertInstanceOf(Reference::class, $calls[1][1][0]);
+        $this->assertSame(ContainerInterface::class, (string) $calls[1][1][0]);
     }
 
     public function testCopiesTagsToChildDefinition(): void

--- a/core-bundle/tests/DependencyInjection/Compiler/RegisterPagesPassTest.php
+++ b/core-bundle/tests/DependencyInjection/Compiler/RegisterPagesPassTest.php
@@ -255,15 +255,12 @@ class RegisterPagesPassTest extends TestCase
 
     public function testAddsContainerCallIfClassExtendsSymfonyAbstractController(): void
     {
-        $registry = $this->createMock(Definition::class);
-
         $definition = $this
             ->getMockBuilder(Definition::class)
             ->setConstructorArgs([TestPageController::class])
             ->onlyMethods(['addMethodCall'])
             ->getMock()
         ;
-        $definition->addTag('contao.page');
 
         $definition
             ->expects($this->once())
@@ -284,8 +281,10 @@ class RegisterPagesPassTest extends TestCase
             )
         ;
 
+        $definition->addTag('contao.page');
+
         $container = new ContainerBuilder();
-        $container->setDefinition(PageRegistry::class, $registry);
+        $container->setDefinition(PageRegistry::class, $this->createMock(Definition::class));
         $container->setDefinition('test.controller', $definition);
 
         $pass = new RegisterPagesPass();

--- a/core-bundle/tests/Fixtures/src/Controller/Page/TestPageController.php
+++ b/core-bundle/tests/Fixtures/src/Controller/Page/TestPageController.php
@@ -16,8 +16,9 @@ use Contao\CoreBundle\Routing\Page\ContentCompositionInterface;
 use Contao\CoreBundle\Routing\Page\DynamicRouteInterface;
 use Contao\CoreBundle\Routing\Page\PageRoute;
 use Contao\PageModel;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 
-class TestPageController implements DynamicRouteInterface, ContentCompositionInterface
+class TestPageController extends AbstractController implements DynamicRouteInterface, ContentCompositionInterface
 {
     public function __invoke(): void
     {


### PR DESCRIPTION
should automatically fix the following exceptions:
```
LogicException: ""contao.fragment._contao.frontend_module.xxx" has no container set, did you forget to define it as a service subscriber?" at /www/htdocs/mywebsitepath/vendor/symfony/framework-bundle/Controller/ControllerResolver.php line 39 {"exception":"[object] (LogicException(code: 0): \"contao.fragment._contao.frontend_module.pageimage\" has no container set, did you forget to define it as a service subscriber? at /www/htdocs/mywebsitepath/vendor/symfony/framework-bundle/Controller/ControllerResolver.php:39)"} []
```

see https://github.com/symfony/symfony/issues/33755
for example fixes https://github.com/terminal42/contao-pageimage/issues/46
