### PR TITLE
Prevent search for pages with alias "index"

### DIFF
--- a/core-bundle/src/Routing/Candidates/AbstractCandidates.php
+++ b/core-bundle/src/Routing/Candidates/AbstractCandidates.php
@@ -120,6 +120,10 @@ class AbstractCandidates implements CandidatesInterface
                     $withoutSuffix = substr($withoutPrefix, 0, -\strlen($suffix));
                 }
 
+                if ('index' === $withoutSuffix) {
+                    continue;
+                }
+
                 $this->addCandidatesFor($withoutSuffix, $candidates);
             }
         }


### PR DESCRIPTION
It's possible to call a page in the frontend in case of using "index" as alias. Actually this should not be possible, because it can lead to duplicate content.

The error is reproducable in Contao 4.4, 4.9 and 4.11.

In my opinion it should never be possible to search for the index alias. So it can be removed completely from collected candidates.

Example:
https://contao.org/de/index.html
https://contao.org/de/
