### PR TITLE
Add missing return type hint in ResponseContext

### DIFF
--- a/core-bundle/src/Routing/ResponseContext/ResponseContext.php
+++ b/core-bundle/src/Routing/ResponseContext/ResponseContext.php
@@ -55,7 +55,7 @@ final class ResponseContext
         return $this;
     }
 
-    public function addLazy(string $classname, \Closure $factory = null)
+    public function addLazy(string $classname, \Closure $factory = null): self
     {
         if (null === $factory) {
             $factory = function () use ($classname) {


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | -
| Docs PR or issue | -

I think this type hint got left away accidentally and can safely be added.

/cc @Toflar 