### PR TITLE
Add the `rawPlainText()` and `rawHtmlToPlainText()` template helper methods

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Template.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Template.php
@@ -400,6 +400,46 @@ abstract class Template extends Controller
 	}
 
 	/**
+	 * Helper method to allow quick access in the Contao templates for raw output.
+	 * Be careful when using this. It must NOT be used within regular HTML when $value
+	 * is uncontrolled user input. It's useful to ensure raw values within e.g. <code> examples
+	 * or JSON-LD arrays.
+	 */
+	public function raw(string $value): string
+	{
+		return StringUtil::revertInputEncoding($value);
+	}
+
+	/**
+	 * Helper method to allow quick access in the Contao templates for raw output.
+	 *
+	 * Compared to $this->raw() it does remove HTML.
+	 *
+	 * Be careful when using this. It must NOT be used within regular HTML when $value
+	 * is uncontrolled user input. It's useful to ensure raw values within e.g. <code> examples
+	 * or JSON-LD arrays.
+	 */
+	public function rawPlainText(string $value, bool $removeInsertTags = false): string
+	{
+		return StringUtil::inputEncodedToPlainText($value, $removeInsertTags);
+	}
+
+	/**
+	 * Helper method to allow quick access in the Contao templates for raw output.
+	 *
+	 * Compared to $this->rawPlainText() it adds new lines before and after block level HTML elements
+	 * and only then removes the rest of the HTML tags.
+	 *
+	 * Be careful when using this. It must NOT be used within regular HTML when $value
+	 * is uncontrolled user input. It's useful to ensure raw values within e.g. <code> examples
+	 * or JSON-LD arrays.
+	 */
+	public function rawHtmlToPlainText(string $value, bool $removeInsertTags = false): string
+	{
+		return StringUtil::htmlToPlainText($value, $removeInsertTags);
+	}
+
+	/**
 	 * Adds schema.org JSON-LD data to the current response context
 	 */
 	public function addSchemaOrg(array $jsonLd): void

--- a/core-bundle/src/Resources/contao/library/Contao/Template.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Template.php
@@ -400,20 +400,8 @@ abstract class Template extends Controller
 	}
 
 	/**
-	 * Helper method to allow quick access in the Contao templates for raw output.
-	 * Be careful when using this. It must NOT be used within regular HTML when $value
-	 * is uncontrolled user input. It's useful to ensure raw values within e.g. <code> examples
-	 * or JSON-LD arrays.
-	 */
-	public function raw(string $value): string
-	{
-		return StringUtil::revertInputEncoding($value);
-	}
-
-	/**
-	 * Helper method to allow quick access in the Contao templates for raw output.
-	 *
-	 * Compared to $this->raw() it does remove HTML.
+	 * Helper method to allow quick access in the Contao templates for safe raw (unencoded) output.
+	 * It replaces (or optionally removes) Contao insert tags and removes all HTML.
 	 *
 	 * Be careful when using this. It must NOT be used within regular HTML when $value
 	 * is uncontrolled user input. It's useful to ensure raw values within e.g. <code> examples
@@ -425,7 +413,7 @@ abstract class Template extends Controller
 	}
 
 	/**
-	 * Helper method to allow quick access in the Contao templates for raw output.
+	 * Helper method to allow quick access in the Contao templates for safe raw (unencoded) output.
 	 *
 	 * Compared to $this->rawPlainText() it adds new lines before and after block level HTML elements
 	 * and only then removes the rest of the HTML tags.


### PR DESCRIPTION
Most of the following PRs for JSON-LD will likely require raw values in the template so I wanted to get this in first.
It makes the templates a lot more concise rather than using e.g. the long `Contao\StringUtil::revertInputEncoding()` calls.

I've also made sure they all start using `raw` so it's very clear that they output raw stuff. And I think the `revertInputEncoding` in the names is not required here as we're explicitly in the template context.
