### PR TITLE
Make all StringUtil methods available in the template

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Template.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Template.php
@@ -150,6 +150,22 @@ abstract class Template extends Controller
 	 */
 	public function __get($strKey)
 	{
+		if ('stringUtil' === $strKey)
+		{
+			return new class()
+			{
+				public function __call(string $key, array $params)
+				{
+					if (!method_exists(StringUtil::class, $key))
+					{
+						throw new \InvalidArgumentException("$key is not a valid StringUtil method.");
+					}
+
+					return StringUtil::$key(...$params);
+				}
+			};
+		}
+
 		if (isset($this->arrData[$strKey]))
 		{
 			if (\is_object($this->arrData[$strKey]) && \is_callable($this->arrData[$strKey]))
@@ -397,34 +413,6 @@ abstract class Template extends Controller
 	public function trans($strId, array $arrParams=array(), $strDomain='contao_default')
 	{
 		return System::getContainer()->get('translator')->trans($strId, $arrParams, $strDomain);
-	}
-
-	/**
-	 * Helper method to allow quick access in the Contao templates for safe raw (unencoded) output.
-	 * It replaces (or optionally removes) Contao insert tags and removes all HTML.
-	 *
-	 * Be careful when using this. It must NOT be used within regular HTML when $value
-	 * is uncontrolled user input. It's useful to ensure raw values within e.g. <code> examples
-	 * or JSON-LD arrays.
-	 */
-	public function rawPlainText(string $value, bool $removeInsertTags = false): string
-	{
-		return StringUtil::inputEncodedToPlainText($value, $removeInsertTags);
-	}
-
-	/**
-	 * Helper method to allow quick access in the Contao templates for safe raw (unencoded) output.
-	 *
-	 * Compared to $this->rawPlainText() it adds new lines before and after block level HTML elements
-	 * and only then removes the rest of the HTML tags.
-	 *
-	 * Be careful when using this. It must NOT be used within regular HTML when $value
-	 * is uncontrolled user input. It's useful to ensure raw values within e.g. <code> examples
-	 * or JSON-LD arrays.
-	 */
-	public function rawHtmlToPlainText(string $value, bool $removeInsertTags = false): string
-	{
-		return StringUtil::htmlToPlainText($value, $removeInsertTags);
 	}
 
 	/**

--- a/core-bundle/src/Resources/contao/templates/backend/be_crawl.html5
+++ b/core-bundle/src/Resources/contao/templates/backend/be_crawl.html5
@@ -24,7 +24,7 @@
           </div>
         <?php endforeach; ?>
         <p class="wait show-when-running"><?= $this->trans('tl_maintenance.crawlWaitToBeFinished') ?></p>
-        <p class="debug-log show-when-finished"><a href="<?= $this->debugLogHref ?>" title="<?= Contao\StringUtil::specialchars($this->trans('tl_maintenance.crawlDownloadDebugLog')) ?>"><?= Contao\Image::getHtml('theme_import.svg') ?></a></p>
+        <p class="debug-log show-when-finished"><a href="<?= $this->debugLogHref ?>" title="<?= $this->stringUtil->specialchars($this->trans('tl_maintenance.crawlDownloadDebugLog')) ?>"><?= Contao\Image::getHtml('theme_import.svg') ?></a></p>
       </div>
       <script>Backend.crawl()</script>
     </div>

--- a/core-bundle/src/Resources/contao/templates/backend/be_csv_import.html5
+++ b/core-bundle/src/Resources/contao/templates/backend/be_csv_import.html5
@@ -2,7 +2,7 @@
 <?= Contao\Message::generate() ?>
 
 <div id="tl_buttons">
-  <a href="<?= Contao\StringUtil::ampersand($this->backUrl) ?>" class="header_back" title="<?= Contao\StringUtil::specialchars($this->backBTTitle) ?>" accesskey="b"><?= $this->backBT ?></a>
+  <a href="<?= $this->stringUtil->ampersand($this->backUrl) ?>" class="header_back" title="<?= $this->stringUtil->specialchars($this->backBTTitle) ?>" accesskey="b"><?= $this->backBT ?></a>
 </div>
 
 <form id="<?= $this->formId ?>" class="tl_form tl_edit_form" method="post" enctype="multipart/form-data">

--- a/core-bundle/src/Resources/contao/templates/backend/be_two_factor.html5
+++ b/core-bundle/src/Resources/contao/templates/backend/be_two_factor.html5
@@ -1,6 +1,6 @@
 
 <div id="tl_buttons">
-  <a href="<?= $this->href ?>" class="header_back" title="<?= Contao\StringUtil::specialchars($this->trans('MSC.backBTTitle')) ?>"><?= $this->trans('MSC.backBT') ?></a>
+  <a href="<?= $this->href ?>" class="header_back" title="<?= $this->stringUtil->specialchars($this->trans('MSC.backBTTitle')) ?>"><?= $this->trans('MSC.backBT') ?></a>
 </div>
 
 <div class="two-factor">

--- a/core-bundle/src/Resources/contao/templates/backend/be_welcome.html5
+++ b/core-bundle/src/Resources/contao/templates/backend/be_welcome.html5
@@ -38,7 +38,7 @@
             <td><?= $version['active'] ? '<strong>'.$version['version'].'</strong>' : $version['version'] ?></td>
             <td>
               <?php if ($version['deleted']): ?>
-                <a href="<?= $this->route('contao_backend', ['do' => 'undo']) ?>" title="<?= Contao\StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['restore']) ?>"><?= Contao\Image::getHtml('undo.svg', '', 'class="undo"') ?></a>
+                <a href="<?= $this->route('contao_backend', ['do' => 'undo']) ?>" title="<?= $this->stringUtil->specialchars($GLOBALS['TL_LANG']['MSC']['restore']) ?>"><?= Contao\Image::getHtml('undo.svg', '', 'class="undo"') ?></a>
               <?php else: ?>
                 <?php if ($version['editUrl']): ?>
                   <a href="<?= $version['editUrl'] ?>" title="<?= $this->editElement ?>" class="edit"><?= Contao\Image::getHtml('edit.svg', '', 'style="padding:0 2px"') ?></a>

--- a/core-bundle/src/Resources/contao/templates/block/block_section.html5
+++ b/core-bundle/src/Resources/contao/templates/block/block_section.html5
@@ -1,5 +1,5 @@
 
-<div id="<?= Contao\StringUtil::standardize($this->id, true) ?>">
+<div id="<?= $this->stringUtil->standardize($this->id, true) ?>">
   <div class="inside">
     <?= $this->content ?>
   </div>

--- a/core-bundle/src/Resources/contao/templates/forms/form_hidden.html5
+++ b/core-bundle/src/Resources/contao/templates/forms/form_hidden.html5
@@ -1,2 +1,2 @@
 
-<input type="hidden" name="<?= $this->name ?>" value="<?= Contao\StringUtil::specialchars($this->value) ?>">
+<input type="hidden" name="<?= $this->name ?>" value="<?= $this->stringUtil->specialchars($this->value) ?>">

--- a/core-bundle/src/Resources/contao/templates/forms/form_submit.html5
+++ b/core-bundle/src/Resources/contao/templates/forms/form_submit.html5
@@ -2,7 +2,7 @@
 
 <?php $this->block('field'); ?>
   <?php if ($this->src): ?>
-    <input type="image" src="<?= $this->src ?>" id="ctrl_<?= $this->id ?>" class="submit<?php if ($this->class): ?> <?= $this->class ?><?php endif; ?>" title="<?= Contao\StringUtil::specialchars($this->slabel) ?>" alt="<?= Contao\StringUtil::specialchars($this->slabel) ?>"<?= $this->getAttributes() ?>>
+    <input type="image" src="<?= $this->src ?>" id="ctrl_<?= $this->id ?>" class="submit<?php if ($this->class): ?> <?= $this->class ?><?php endif; ?>" title="<?= $this->stringUtil->specialchars($this->slabel) ?>" alt="<?= $this->stringUtil->specialchars($this->slabel) ?>"<?= $this->getAttributes() ?>>
   <?php else: ?>
     <button type="submit" id="ctrl_<?= $this->id ?>" class="submit<?php if ($this->class): ?> <?= $this->class ?><?php endif; ?>"<?= $this->getAttributes() ?>><?= $this->slabel ?></button>
   <?php endif; ?>

--- a/core-bundle/src/Resources/contao/templates/forms/form_textfield.html5
+++ b/core-bundle/src/Resources/contao/templates/forms/form_textfield.html5
@@ -17,5 +17,5 @@
     <p class="error"><?= $this->getErrorAsString() ?></p>
   <?php endif; ?>
 
-  <input type="<?= $this->type ?>" name="<?= $this->name ?>" id="ctrl_<?= $this->id ?>" class="text<?php if ($this->hideInput): ?> password<?php endif; ?><?php if ($this->class): ?> <?= $this->class ?><?php endif; ?>" value="<?= Contao\StringUtil::specialchars($this->value) ?>"<?= $this->getAttributes() ?>>
+  <input type="<?= $this->type ?>" name="<?= $this->name ?>" id="ctrl_<?= $this->id ?>" class="text<?php if ($this->hideInput): ?> password<?php endif; ?><?php if ($this->class): ?> <?= $this->class ?><?php endif; ?>" value="<?= $this->stringUtil->specialchars($this->value) ?>"<?= $this->getAttributes() ?>>
 <?php $this->endblock(); ?>

--- a/core-bundle/src/Resources/contao/templates/frontend/fe_page.html5
+++ b/core-bundle/src/Resources/contao/templates/frontend/fe_page.html5
@@ -9,7 +9,7 @@
 
     <?php $this->block('meta'); ?>
       <meta name="robots" content="<?= $this->robots ?>">
-      <meta name="description" content="<?= Contao\StringUtil::substr($this->description, 320) ?>">
+      <meta name="description" content="<?= $this->stringUtil->substr($this->description, 320) ?>">
       <meta name="generator" content="Contao Open Source CMS">
     <?php $this->endblock(); ?>
 


### PR DESCRIPTION
This PR implements what was requested by @aschempp and refers to https://github.com/contao/contao/pull/3110.
He mentioned that we're already using a few `StringUtil` methods in our templates which is a good indicator that making them available quickly might be desirable. I've adjusted all core templates so they would use the new `$this->stringUtil` service. We use `specialchars()`, `standardize()` and `substr()`. All of which make perfect sense.
There are also other use cases such as `encodeEmail()`, `highlight()` etc.

Regarding the argument that there are methods like `revertInputEncoding()` which should not be used in templates: Well, we cannot prevent that, it's changing one line. If `$this->stringUtil->revertInputEncoding()` was prevented, one might just change this to `Contao\StringUtil::revertInputEncoding()` and continue with their day...