### PR TITLE
Use schema.org JSON-LD in the news-bundle

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Template.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Template.php
@@ -429,10 +429,8 @@ abstract class Template extends Controller
 
 	/**
 	 * Adds schema.org JSON-LD data to the current response context
-	 *
-	 * @param bool $extendExisting allows to extend an existing entry if it exists already
 	 */
-	public function addSchemaOrg(array $jsonLd, bool $extendExisting = false): void
+	public function addSchemaOrg(array $jsonLd): void
 	{
 		/** @var ResponseContext $responseContext */
 		$responseContext = System::getContainer()->get(ResponseContextAccessor::class)->getResponseContext();
@@ -445,44 +443,11 @@ abstract class Template extends Controller
 		/** @var JsonLdManager $jsonLdManager */
 		$jsonLdManager = $responseContext->get(JsonLdManager::class);
 		$type = $jsonLdManager->createSchemaOrgTypeFromArray($jsonLd);
-		$graph = $jsonLdManager->getGraphForSchema(JsonLdManager::SCHEMA_ORG);
-		$identifier = $jsonLd['identifier'] ?? Graph::IDENTIFIER_DEFAULT;
 
-		if (!$extendExisting || !$graph->has(\get_class($type), $identifier))
-		{
-			$graph->set($type, $identifier);
-		}
-		else
-		{
-			$existing = $graph->get(\get_class($type), $identifier);
-			$new = array_replace_recursive($existing->toArray(), $type->toArray());
-			$type = $jsonLdManager->createSchemaOrgTypeFromArray($new);
-			$graph->set($type, $identifier);
-		}
-	}
-
-	public function removeSchemaOrg(string $type, string $identifier = null): void
-	{
-		/** @var ResponseContext $responseContext */
-		$responseContext = System::getContainer()->get(ResponseContextAccessor::class)->getResponseContext();
-
-		if (!$responseContext || !$responseContext->has(JsonLdManager::class))
-		{
-			return;
-		}
-
-		/** @var JsonLdManager $jsonLdManager */
-		$jsonLdManager = $responseContext->get(JsonLdManager::class);
-		$type = $jsonLdManager->createSchemaOrgTypeFromArray(array('@type' => $type));
-		$graph = $jsonLdManager->getGraphForSchema(JsonLdManager::SCHEMA_ORG);
-		$identifier = $identifier ?? Graph::IDENTIFIER_DEFAULT;
-
-		if (!$graph->has(\get_class($type), $identifier))
-		{
-			return;
-		}
-
-		$graph->hide(\get_class($type), $identifier);
+		$jsonLdManager
+			->getGraphForSchema(JsonLdManager::SCHEMA_ORG)
+			->set($type, $jsonLd['identifier'] ?? Graph::IDENTIFIER_DEFAULT)
+		;
 	}
 
 	/**

--- a/core-bundle/src/Resources/contao/library/Contao/Template.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Template.php
@@ -429,8 +429,10 @@ abstract class Template extends Controller
 
 	/**
 	 * Adds schema.org JSON-LD data to the current response context
+	 *
+	 * @param bool $extendExisting allows to extend an existing entry if it exists already
 	 */
-	public function addSchemaOrg(array $jsonLd): void
+	public function addSchemaOrg(array $jsonLd, bool $extendExisting = false): void
 	{
 		/** @var ResponseContext $responseContext */
 		$responseContext = System::getContainer()->get(ResponseContextAccessor::class)->getResponseContext();
@@ -443,11 +445,44 @@ abstract class Template extends Controller
 		/** @var JsonLdManager $jsonLdManager */
 		$jsonLdManager = $responseContext->get(JsonLdManager::class);
 		$type = $jsonLdManager->createSchemaOrgTypeFromArray($jsonLd);
+		$graph = $jsonLdManager->getGraphForSchema(JsonLdManager::SCHEMA_ORG);
+		$identifier = $jsonLd['identifier'] ?? Graph::IDENTIFIER_DEFAULT;
 
-		$jsonLdManager
-			->getGraphForSchema(JsonLdManager::SCHEMA_ORG)
-			->set($type, $jsonLd['identifier'] ?? Graph::IDENTIFIER_DEFAULT)
-		;
+		if (!$extendExisting || !$graph->has(\get_class($type), $identifier))
+		{
+			$graph->set($type, $identifier);
+		}
+		else
+		{
+			$existing = $graph->get(\get_class($type), $identifier);
+			$new = array_replace_recursive($existing->toArray(), $type->toArray());
+			$type = $jsonLdManager->createSchemaOrgTypeFromArray($new);
+			$graph->set($type, $identifier);
+		}
+	}
+
+	public function removeSchemaOrg(string $type, string $identifier = null): void
+	{
+		/** @var ResponseContext $responseContext */
+		$responseContext = System::getContainer()->get(ResponseContextAccessor::class)->getResponseContext();
+
+		if (!$responseContext || !$responseContext->has(JsonLdManager::class))
+		{
+			return;
+		}
+
+		/** @var JsonLdManager $jsonLdManager */
+		$jsonLdManager = $responseContext->get(JsonLdManager::class);
+		$type = $jsonLdManager->createSchemaOrgTypeFromArray(array('@type' => $type));
+		$graph = $jsonLdManager->getGraphForSchema(JsonLdManager::SCHEMA_ORG);
+		$identifier = $identifier ?? Graph::IDENTIFIER_DEFAULT;
+
+		if (!$graph->has(\get_class($type), $identifier))
+		{
+			return;
+		}
+
+		$graph->hide(\get_class($type), $identifier);
 	}
 
 	/**

--- a/news-bundle/src/Resources/contao/modules/ModuleNews.php
+++ b/news-bundle/src/Resources/contao/modules/ModuleNews.php
@@ -305,7 +305,7 @@ abstract class ModuleNews extends Module
 					/** @var UserModel $objAuthor */
 					if (($objAuthor = $objArticle->getRelated('author')) instanceof UserModel)
 					{
-						$return['author'] = $GLOBALS['TL_LANG']['MSC']['by'] . ' <span class="author">' . $objAuthor->name . '</span>';
+						$return['author'] = $GLOBALS['TL_LANG']['MSC']['by'] . ' ' . $objAuthor->name;
 						$return['authorModel'] = $objAuthor;
 					}
 					break;

--- a/news-bundle/src/Resources/contao/modules/ModuleNews.php
+++ b/news-bundle/src/Resources/contao/modules/ModuleNews.php
@@ -305,7 +305,8 @@ abstract class ModuleNews extends Module
 					/** @var UserModel $objAuthor */
 					if (($objAuthor = $objArticle->getRelated('author')) instanceof UserModel)
 					{
-						$return['author'] = $GLOBALS['TL_LANG']['MSC']['by'] . ' <span itemprop="author">' . $objAuthor->name . '</span>';
+						$return['author'] = $GLOBALS['TL_LANG']['MSC']['by'] . ' <span class="author">' . $objAuthor->name . '</span>';
+						$return['authorModel'] = $objAuthor;
 					}
 					break;
 
@@ -367,11 +368,11 @@ abstract class ModuleNews extends Module
 		$strArticleUrl = News::generateNewsUrl($objArticle, $blnAddArchive);
 
 		return sprintf(
-			'<a href="%s" title="%s"%s itemprop="url">%s%s</a>',
+			'<a href="%s" title="%s"%s>%s%s</a>',
 			$strArticleUrl,
 			StringUtil::specialchars(sprintf($strReadMore, $blnIsInternal ? $objArticle->headline : $strArticleUrl), true),
 			($objArticle->target && !$blnIsInternal ? ' target="_blank" rel="noreferrer noopener"' : ''),
-			($blnIsReadMore ? $strLink : '<span itemprop="headline">' . $strLink . '</span>'),
+			($blnIsReadMore ? $strLink : '<span class="headline">' . $strLink . '</span>'),
 			($blnIsReadMore && $blnIsInternal ? '<span class="invisible"> ' . $objArticle->headline . '</span>' : '')
 		);
 	}

--- a/news-bundle/src/Resources/contao/modules/ModuleNews.php
+++ b/news-bundle/src/Resources/contao/modules/ModuleNews.php
@@ -100,6 +100,7 @@ abstract class ModuleNews extends Module
 		$objTemplate->text = '';
 		$objTemplate->hasText = false;
 		$objTemplate->hasTeaser = false;
+		$objTemplate->hasReader = true;
 
 		// Clean the RTE output
 		if ($objArticle->teaser)
@@ -114,6 +115,7 @@ abstract class ModuleNews extends Module
 		{
 			$objTemplate->text = true;
 			$objTemplate->hasText = true;
+			$objTemplate->hasReader = false;
 		}
 
 		// Compile the news text

--- a/news-bundle/src/Resources/contao/modules/ModuleNews.php
+++ b/news-bundle/src/Resources/contao/modules/ModuleNews.php
@@ -372,7 +372,7 @@ abstract class ModuleNews extends Module
 			$strArticleUrl,
 			StringUtil::specialchars(sprintf($strReadMore, $blnIsInternal ? $objArticle->headline : $strArticleUrl), true),
 			($objArticle->target && !$blnIsInternal ? ' target="_blank" rel="noreferrer noopener"' : ''),
-			($blnIsReadMore ? $strLink : '<span class="headline">' . $strLink . '</span>'),
+			$strLink,
 			($blnIsReadMore && $blnIsInternal ? '<span class="invisible"> ' . $objArticle->headline . '</span>' : '')
 		);
 	}

--- a/news-bundle/src/Resources/contao/templates/news/news_full.html5
+++ b/news-bundle/src/Resources/contao/templates/news/news_full.html5
@@ -43,31 +43,11 @@
 
 <?php
 
-$jsonLd = [
-    '@type' => 'NewsArticle',
-    'identifier' => $this->link,
-    'url' => $this->link,
-    'headline' => $this->rawPlainText($this->headline),
-    'datePublished' => $this->datetime,
-];
-
-if ($this->hasTeaser) {
-    $jsonLd['description'] = $this->rawHtmlToPlainText($this->teaser);
-}
-
+// Extend the existing JSON-LD data with the text on the reader page.
 if ($this->hasText()) {
-    $jsonLd['text'] = $this->rawHtmlToPlainText($this->text);
+    $this->addSchemaOrg([
+        '@type' => 'NewsArticle',
+        'identifier' => $this->schemaOrgId,
+        'text' => $this->rawHtmlToPlainText($this->text),
+    ], true);
 }
-
-if ($this->addImage && $this->figure) {
-    $jsonLd['image'] = $this->figure->getSchemaOrgData();
-}
-
-if ($this->authorModel) {
-    $jsonLd['author'] = [
-        '@type' => 'Person',
-        'name' => $this->authorModel->name,
-    ];
-}
-
-$this->addSchemaOrg($jsonLd);

--- a/news-bundle/src/Resources/contao/templates/news/news_full.html5
+++ b/news-bundle/src/Resources/contao/templates/news/news_full.html5
@@ -1,14 +1,14 @@
 
-<div class="layout_full block<?= $this->class ?>" itemscope itemtype="https://schema.org/Article">
+<div class="layout_full block<?= $this->class ?>">
 
-  <h1 itemprop="name"><?= $this->newsHeadline ?></h1>
+  <h1><?= $this->newsHeadline ?></h1>
 
   <?php if ($this->hasMetaFields): ?>
-    <p class="info"><time datetime="<?= $this->datetime ?>" itemprop="datePublished"><?= $this->date ?></time> <?= $this->author ?> <?= $this->commentCount ?></p>
+    <p class="info"><time datetime="<?= $this->datetime ?>"><?= $this->date ?></time> <?= $this->author ?> <?= $this->commentCount ?></p>
   <?php endif; ?>
 
   <?php if ($this->hasSubHeadline): ?>
-    <h2 itemprop="headline"><?= $this->subHeadline ?></h2>
+    <h2><?= $this->subHeadline ?></h2>
   <?php endif; ?>
 
   <?php if ($this->hasText): ?>
@@ -40,3 +40,34 @@
   <?php endif; ?>
 
 </div>
+
+<?php
+
+$jsonLd = [
+    '@type' => 'NewsArticle',
+    'identifier' => $this->link,
+    'url' => $this->link,
+    'headline' => $this->rawPlainText($this->headline),
+    'datePublished' => $this->datetime,
+];
+
+if ($this->hasTeaser) {
+    $jsonLd['description'] = $this->rawHtmlToPlainText($this->teaser);
+}
+
+if ($this->hasText()) {
+    $jsonLd['text'] = $this->rawHtmlToPlainText($this->text);
+}
+
+if ($this->addImage && $this->figure) {
+    $jsonLd['image'] = $this->figure->getSchemaOrgData();
+}
+
+if ($this->authorModel) {
+    $jsonLd['author'] = [
+        '@type' => 'Person',
+        'name' => $this->authorModel->name,
+    ];
+}
+
+$this->addSchemaOrg($jsonLd);

--- a/news-bundle/src/Resources/contao/templates/news/news_full.html5
+++ b/news-bundle/src/Resources/contao/templates/news/news_full.html5
@@ -43,11 +43,9 @@
 
 <?php
 
-// Extend the existing JSON-LD data with the text on the reader page.
+$schmemaOrg = $this->getBasicSchemaOrgData();
+
 if ($this->hasText()) {
-    $this->addSchemaOrg([
-        '@type' => 'NewsArticle',
-        'identifier' => $this->schemaOrgId,
-        'text' => $this->rawHtmlToPlainText($this->text),
-    ], true);
+    $schmemaOrg['text'] = $this->rawHtmlToPlainText($this->text);
 }
+$this->addSchemaOrg($schmemaOrg);

--- a/news-bundle/src/Resources/contao/templates/news/news_full.html5
+++ b/news-bundle/src/Resources/contao/templates/news/news_full.html5
@@ -43,9 +43,10 @@
 
 <?php
 
-$schmemaOrg = $this->getBasicSchemaOrgData();
+$schemaOrg = $this->getBasicSchemaOrgData();
 
 if ($this->hasText()) {
-    $schmemaOrg['text'] = $this->rawHtmlToPlainText($this->text);
+    $schemaOrg['text'] = $this->rawHtmlToPlainText($this->text);
 }
-$this->addSchemaOrg($schmemaOrg);
+
+$this->addSchemaOrg($schemaOrg);

--- a/news-bundle/src/Resources/contao/templates/news/news_latest.html5
+++ b/news-bundle/src/Resources/contao/templates/news/news_latest.html5
@@ -23,8 +23,8 @@
 
 <?php
 
-// This template is used as a news list template by default.
-// We thus only add JSON-LD data in case this is a news article without a reader.
+// This template is used as a news list template by default, so we only add
+// JSON-LD data in case this is a news article without a reader
 if (!$this->hasReader) {
     $this->addSchemaOrg($this->getBasicSchemaOrgData());
 }

--- a/news-bundle/src/Resources/contao/templates/news/news_latest.html5
+++ b/news-bundle/src/Resources/contao/templates/news/news_latest.html5
@@ -1,17 +1,17 @@
 
-<div class="layout_latest arc_<?= $this->archive->id ?> block<?= $this->class ?>" itemscope itemtype="https://schema.org/Article">
+<div class="layout_latest arc_<?= $this->archive->id ?> block<?= $this->class ?>">
 
   <?php if ($this->hasMetaFields): ?>
-    <p class="info"><time datetime="<?= $this->datetime ?>" itemprop="datePublished"><?= $this->date ?></time> <?= $this->author ?> <?= $this->commentCount ?></p>
+    <p class="info"><time datetime="<?= $this->datetime ?>"><?= $this->date ?></time> <?= $this->author ?> <?= $this->commentCount ?></p>
   <?php endif; ?>
 
   <?php if ($this->addImage): ?>
     <?php $this->insert('image', $this->arrData); ?>
   <?php endif; ?>
 
-  <h2 itemprop="name"><?= $this->linkHeadline ?></h2>
+  <h2><?= $this->linkHeadline ?></h2>
 
-  <div class="ce_text block" itemprop="description">
+  <div class="ce_text block">
     <?= $this->teaser ?>
   </div>
 

--- a/news-bundle/src/Resources/contao/templates/news/news_latest.html5
+++ b/news-bundle/src/Resources/contao/templates/news/news_latest.html5
@@ -20,3 +20,11 @@
   <?php endif; ?>
 
 </div>
+
+<?php
+
+// This template is used as a news list template by default.
+// We thus only add JSON-LD data in case this is a news article without a reader.
+if (!$this->hasReader) {
+    $this->addSchemaOrg($this->getBasicSchemaOrgData());
+}

--- a/news-bundle/src/Resources/contao/templates/news/news_short.html5
+++ b/news-bundle/src/Resources/contao/templates/news/news_short.html5
@@ -19,8 +19,8 @@
 
 <?php
 
-// This template is used as a news list template by default.
-// We thus only add JSON-LD data in case this is a news article without a reader.
+// This template is used as a news list template by default, so we only add
+// JSON-LD data in case this is a news article without a reader
 if (!$this->hasReader) {
     $this->addSchemaOrg($this->getBasicSchemaOrgData());
 }

--- a/news-bundle/src/Resources/contao/templates/news/news_short.html5
+++ b/news-bundle/src/Resources/contao/templates/news/news_short.html5
@@ -1,13 +1,13 @@
 
-<div class="layout_short arc_<?= $this->archive->id ?> block<?= $this->class ?>" itemscope itemtype="https://schema.org/Article">
+<div class="layout_short arc_<?= $this->archive->id ?> block<?= $this->class ?>">
 
   <?php if ($this->hasMetaFields): ?>
-    <p class="info"><time datetime="<?= $this->datetime ?>" itemprop="datePublished"><?= $this->date ?></time> <?= $this->author ?> <?= $this->commentCount ?></p>
+    <p class="info"><time datetime="<?= $this->datetime ?>"><?= $this->date ?></time> <?= $this->author ?> <?= $this->commentCount ?></p>
   <?php endif; ?>
 
-  <h2 itemprop="name"><?= $this->linkHeadline ?></h2>
+  <h2><?= $this->linkHeadline ?></h2>
 
-  <div class="ce_text block" itemprop="description">
+  <div class="ce_text block">
     <?= $this->teaser ?>
   </div>
 

--- a/news-bundle/src/Resources/contao/templates/news/news_short.html5
+++ b/news-bundle/src/Resources/contao/templates/news/news_short.html5
@@ -17,33 +17,11 @@
 
 </div>
 
-
 <?php
 
-// Only add schema.org data if there's no reader page with more details
-if (!$this->hasReader) {
-    $jsonLd = [
-        '@type' => 'NewsArticle',
-        'identifier' => '#/schema/news/'.$this->id,
-        'url' => $this->link,
-        'headline' => $this->rawPlainText($this->headline),
-        'datePublished' => $this->datetime,
-    ];
-
-    if ($this->hasTeaser) {
-        $jsonLd['description'] = $this->rawHtmlToPlainText($this->teaser);
-    }
-
-    if ($this->addImage && $this->figure) {
-        $jsonLd['image'] = $this->figure->getSchemaOrgData();
-    }
-
-    if ($this->authorModel) {
-        $jsonLd['author'] = [
-            '@type' => 'Person',
-            'name' => $this->authorModel->name,
-        ];
-    }
-
-    $this->addSchemaOrg($jsonLd);
+// This template is used as a news list template by default
+// Ensure that there's no JSON-LD for this news article if there is a reader as that one will
+// list all the details.
+if ($this->hasReader) {
+    $this->removeSchemaOrg('NewsArticle', $this->schemaOrgId);
 }

--- a/news-bundle/src/Resources/contao/templates/news/news_short.html5
+++ b/news-bundle/src/Resources/contao/templates/news/news_short.html5
@@ -16,3 +16,34 @@
   <?php endif; ?>
 
 </div>
+
+
+<?php
+
+// Only add schema.org data if there's no reader page with more details
+if (!$this->hasReader) {
+    $jsonLd = [
+        '@type' => 'NewsArticle',
+        'identifier' => '#/schema/news/'.$this->id,
+        'url' => $this->link,
+        'headline' => $this->rawPlainText($this->headline),
+        'datePublished' => $this->datetime,
+    ];
+
+    if ($this->hasTeaser) {
+        $jsonLd['description'] = $this->rawHtmlToPlainText($this->teaser);
+    }
+
+    if ($this->addImage && $this->figure) {
+        $jsonLd['image'] = $this->figure->getSchemaOrgData();
+    }
+
+    if ($this->authorModel) {
+        $jsonLd['author'] = [
+            '@type' => 'Person',
+            'name' => $this->authorModel->name,
+        ];
+    }
+
+    $this->addSchemaOrg($jsonLd);
+}

--- a/news-bundle/src/Resources/contao/templates/news/news_short.html5
+++ b/news-bundle/src/Resources/contao/templates/news/news_short.html5
@@ -19,9 +19,8 @@
 
 <?php
 
-// This template is used as a news list template by default
-// Ensure that there's no JSON-LD for this news article if there is a reader as that one will
-// list all the details.
-if ($this->hasReader) {
-    $this->removeSchemaOrg('NewsArticle', $this->schemaOrgId);
+// This template is used as a news list template by default.
+// We thus only add JSON-LD data in case this is a news article without a reader.
+if (!$this->hasReader) {
+    $this->addSchemaOrg($this->getBasicSchemaOrgData());
 }

--- a/news-bundle/src/Resources/contao/templates/news/news_simple.html5
+++ b/news-bundle/src/Resources/contao/templates/news/news_simple.html5
@@ -6,8 +6,8 @@
 
 <?php
 
-// This template is used as a news list template by default.
-// We thus only add JSON-LD data in case this is a news article without a reader.
+// This template is used as a news list template by default, so we only add
+// JSON-LD data in case this is a news article without a reader
 if (!$this->hasReader) {
     $this->addSchemaOrg($this->getBasicSchemaOrgData());
 }

--- a/news-bundle/src/Resources/contao/templates/news/news_simple.html5
+++ b/news-bundle/src/Resources/contao/templates/news/news_simple.html5
@@ -1,5 +1,5 @@
 
-<div class="layout_simple arc_<?= $this->archive->id ?> block<?= $this->class ?>" itemscope itemtype="https://schema.org/Article">
-  <?php if ($this->date): ?><time datetime="<?= $this->datetime ?>" itemprop="datePublished"><?= $this->date ?></time><?php endif; ?>
+<div class="layout_simple arc_<?= $this->archive->id ?> block<?= $this->class ?>">
+  <?php if ($this->date): ?><time datetime="<?= $this->datetime ?>"><?= $this->date ?></time><?php endif; ?>
   <?= $this->linkHeadline ?>
 </div>

--- a/news-bundle/src/Resources/contao/templates/news/news_simple.html5
+++ b/news-bundle/src/Resources/contao/templates/news/news_simple.html5
@@ -3,3 +3,11 @@
   <?php if ($this->date): ?><time datetime="<?= $this->datetime ?>"><?= $this->date ?></time><?php endif; ?>
   <?= $this->linkHeadline ?>
 </div>
+
+<?php
+
+// This template is used as a news list template by default.
+// We thus only add JSON-LD data in case this is a news article without a reader.
+if (!$this->hasReader) {
+    $this->addSchemaOrg($this->getBasicSchemaOrgData());
+}


### PR DESCRIPTION
Using the new means for the news-bundle :)

Note for @m-vo: I've considered having some of the data in the `NewsModel` so it can be reused by Twig but there's not really much to be reused here, really. The links require the router, `hasText` queries the DB...so I left it all to the template.