### PR TITLE
Check if tstamp exists before hiding unsaved elements

### DIFF
--- a/core-bundle/src/Resources/contao/classes/Hybrid.php
+++ b/core-bundle/src/Resources/contao/classes/Hybrid.php
@@ -264,7 +264,7 @@ abstract class Hybrid extends Frontend
 		}
 
 		// Skip unsaved elements (see #2708)
-		if (!$this->objParent->tstamp)
+		if (isset($this->objParent->tstamp) && !$this->objParent->tstamp)
 		{
 			return true;
 		}

--- a/core-bundle/src/Resources/contao/elements/ContentElement.php
+++ b/core-bundle/src/Resources/contao/elements/ContentElement.php
@@ -286,7 +286,7 @@ abstract class ContentElement extends Frontend
 	protected function isHidden()
 	{
 		// Skip unsaved elements (see #2708)
-		if (!$this->tstamp)
+		if (isset($this->tstamp) && !$this->tstamp)
 		{
 			return true;
 		}


### PR DESCRIPTION
If a content model is manually created to render an element, and the tstamp is not set, it should still be possible to generate the element in the front end. 

Origin PR in Contao: #2994
Fix in Isotope: https://github.com/isotope/core/commit/857c15bda0376c5b03c2d87f7d82e7b81703ac6b