### PR TITLE
Add more null checks for DCA lang references

### DIFF
--- a/core-bundle/src/Resources/contao/dca/tl_files.php
+++ b/core-bundle/src/Resources/contao/dca/tl_files.php
@@ -116,7 +116,7 @@ $GLOBALS['TL_DCA']['tl_files'] = array
 			(
 				'href'                => 'act=delete',
 				'icon'                => 'delete.svg',
-				'attributes'          => 'onclick="if(!confirm(\'' . $GLOBALS['TL_LANG']['MSC']['deleteConfirmFile'] . '\'))return false;Backend.getScrollOffset()"',
+				'attributes'          => 'onclick="if(!confirm(\'' . ($GLOBALS['TL_LANG']['MSC']['deleteConfirmFile'] ?? null) . '\'))return false;Backend.getScrollOffset()"',
 				'button_callback'     => array('tl_files', 'deleteFile')
 			),
 			'show' => array

--- a/core-bundle/src/Resources/contao/dca/tl_templates.php
+++ b/core-bundle/src/Resources/contao/dca/tl_templates.php
@@ -99,7 +99,7 @@ $GLOBALS['TL_DCA']['tl_templates'] = array
 				'label'               => &$GLOBALS['TL_LANG']['tl_files']['delete'],
 				'href'                => 'act=delete',
 				'icon'                => 'delete.svg',
-				'attributes'          => 'onclick="if(!confirm(\'' . $GLOBALS['TL_LANG']['MSC']['deleteConfirmFile'] . '\'))return false;Backend.getScrollOffset()"'
+				'attributes'          => 'onclick="if(!confirm(\'' . ($GLOBALS['TL_LANG']['MSC']['deleteConfirmFile'] ?? null) . '\'))return false;Backend.getScrollOffset()"'
 			),
 			'source' => array
 			(


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes -
| Docs PR or issue | -

We adjusted all `$GLOBALS['TL_LANG']['MSC']['deleteConfirm']` references to include a null check but not the `deleteConfirmFile` ones. 

Is this intended? Just stumbled across this by accident. I did not experience an error yet, but there likely is a way to get one somehow.