### PR TITLE
Filter "guests only" pages to restore backwards compatibility

### DIFF
--- a/core-bundle/src/Resources/contao/modules/Module.php
+++ b/core-bundle/src/Resources/contao/modules/Module.php
@@ -280,6 +280,7 @@ abstract class Module extends Frontend
 
 		$items = array();
 		$security = System::getContainer()->get('security.helper');
+		$user = $security->getUser();
 
 		$objTemplate = new FrontendTemplate($this->navigationTpl ?: 'nav_default');
 		$objTemplate->pid = $pid;

--- a/core-bundle/src/Resources/contao/modules/Module.php
+++ b/core-bundle/src/Resources/contao/modules/Module.php
@@ -280,7 +280,7 @@ abstract class Module extends Frontend
 
 		$items = array();
 		$security = System::getContainer()->get('security.helper');
-		$user = $security->getUser();
+		$isMember = $security->isGranted('ROLE_MEMBER');
 
 		$objTemplate = new FrontendTemplate($this->navigationTpl ?: 'nav_default');
 		$objTemplate->pid = $pid;
@@ -315,7 +315,7 @@ abstract class Module extends Frontend
 			}
 
 			// Hide the page if it is not protected and only visible to guests (backwards compatibility)
-			if ($objSubpage->guests && !$objSubpage->protected && $user)
+			if ($objSubpage->guests && !$objSubpage->protected && $isMember)
 			{
 				trigger_deprecation('contao/core-bundle', '4.12', 'Using the "show to guests only" feature has been deprecated an will no longer work in Contao 5.0. Use the "protect page" function instead.');
 				continue;

--- a/core-bundle/src/Resources/contao/modules/Module.php
+++ b/core-bundle/src/Resources/contao/modules/Module.php
@@ -318,7 +318,7 @@ abstract class Module extends Frontend
 			}
 
 			// Hide the page if it is not protected and only visible to guests (backwards compatibility)
-			if ($objSubpage->guests && !$objSubpage->protected && !$user)
+			if ($objSubpage->guests && !$objSubpage->protected && $user)
 			{
 				trigger_deprecation('contao/core-bundle', '4.12', 'Using the "show to guests only" feature has been deprecated an will no longer work in Contao 5.0. Use the "protect page" function instead.');
 				continue;

--- a/core-bundle/src/Resources/contao/modules/Module.php
+++ b/core-bundle/src/Resources/contao/modules/Module.php
@@ -317,6 +317,13 @@ abstract class Module extends Frontend
 				trigger_deprecation('contao/core-bundle', '4.12', 'Using a tabindex value greater than 0 has been deprecated and will no longer work in Contao 5.0.');
 			}
 
+			// Hide the page if it is not protected and only visible to guests (backwards compatibility)
+			if ($objSubpage->guests && !$objSubpage->protected && !$user)
+			{
+				trigger_deprecation('contao/core-bundle', '4.12', 'Using the "show to guests only" feature has been deprecated an will no longer work in Contao 5.0. Use the "protect page" function instead.');
+				continue;
+			}
+
 			$subitems = '';
 
 			// PageModel->groups is an array after calling loadDetails()

--- a/core-bundle/src/Resources/contao/modules/ModuleBooknav.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleBooknav.php
@@ -195,7 +195,7 @@ class ModuleBooknav extends Module
 		}
 
 		$security = System::getContainer()->get('security.helper');
-		$user = $security->getUser();
+		$isMember = $security->isGranted('ROLE_MEMBER');
 
 		/** @var PageModel $objPage */
 		foreach ($arrPages as list('page' => $objPage, 'hasSubpages' => $blnHasSubpages))
@@ -203,7 +203,7 @@ class ModuleBooknav extends Module
 			$objPage->loadDetails();
 
 			// Hide the page if it is not protected and only visible to guests (backwards compatibility)
-			if ($objPage->guests && !$objPage->protected && $user)
+			if ($objPage->guests && !$objPage->protected && $isMember)
 			{
 				trigger_deprecation('contao/core-bundle', '4.12', 'Using the "show to guests only" feature has been deprecated an will no longer work in Contao 5.0. Use the "protect page" function instead.');
 				continue;

--- a/core-bundle/src/Resources/contao/modules/ModuleBooknav.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleBooknav.php
@@ -206,7 +206,7 @@ class ModuleBooknav extends Module
 			$objPage->loadDetails();
 
 			// Hide the page if it is not protected and only visible to guests (backwards compatibility)
-			if ($objPage->guests && !$objPage->protected && !$user)
+			if ($objPage->guests && !$objPage->protected && $user)
 			{
 				trigger_deprecation('contao/core-bundle', '4.12', 'Using the "show to guests only" feature has been deprecated an will no longer work in Contao 5.0. Use the "protect page" function instead.');
 				continue;

--- a/core-bundle/src/Resources/contao/modules/ModuleBooknav.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleBooknav.php
@@ -195,6 +195,7 @@ class ModuleBooknav extends Module
 		}
 
 		$security = System::getContainer()->get('security.helper');
+		$user = $security->getUser();
 
 		/** @var PageModel $objPage */
 		foreach ($arrPages as list('page' => $objPage, 'hasSubpages' => $blnHasSubpages))

--- a/core-bundle/src/Resources/contao/modules/ModuleBooknav.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleBooknav.php
@@ -205,6 +205,13 @@ class ModuleBooknav extends Module
 		{
 			$objPage->loadDetails();
 
+			// Hide the page if it is not protected and only visible to guests (backwards compatibility)
+			if ($objPage->guests && !$objPage->protected && !$user)
+			{
+				trigger_deprecation('contao/core-bundle', '4.12', 'Using the "show to guests only" feature has been deprecated an will no longer work in Contao 5.0. Use the "protect page" function instead.');
+				continue;
+			}
+
 			// PageModel->groups is an array after calling loadDetails()
 			if (!$objPage->protected || $this->showProtected || (!$user && \in_array(-1, $objPage->groups)) || ($user && $user->isMemberOf($objPage->groups)))
 			{

--- a/core-bundle/src/Resources/contao/modules/ModuleCustomnav.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleCustomnav.php
@@ -86,6 +86,7 @@ class ModuleCustomnav extends Module
 		$objTemplate->module = $this; // see #155
 
 		$security = System::getContainer()->get('security.helper');
+		$user = $security->getUser();
 
 		/** @var PageModel[] $objPages */
 		foreach ($objPages as $objModel)

--- a/core-bundle/src/Resources/contao/modules/ModuleCustomnav.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleCustomnav.php
@@ -96,7 +96,7 @@ class ModuleCustomnav extends Module
 			$objModel->loadDetails();
 
 			// Hide the page if it is not protected and only visible to guests (backwards compatibility)
-			if ($objModel->guests && !$objModel->protected && !$user)
+			if ($objModel->guests && !$objModel->protected && $user)
 			{
 				trigger_deprecation('contao/core-bundle', '4.12', 'Using the "show to guests only" feature has been deprecated an will no longer work in Contao 5.0. Use the "protect page" function instead.');
 				continue;

--- a/core-bundle/src/Resources/contao/modules/ModuleCustomnav.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleCustomnav.php
@@ -95,6 +95,13 @@ class ModuleCustomnav extends Module
 		{
 			$objModel->loadDetails();
 
+			// Hide the page if it is not protected and only visible to guests (backwards compatibility)
+			if ($objModel->guests && !$objModel->protected && !$user)
+			{
+				trigger_deprecation('contao/core-bundle', '4.12', 'Using the "show to guests only" feature has been deprecated an will no longer work in Contao 5.0. Use the "protect page" function instead.');
+				continue;
+			}
+
 			// PageModel->groups is an array after calling loadDetails()
 			if (!$objModel->protected || $this->showProtected || (!$user && \in_array(-1, $objModel->groups)) || ($user && $user->isMemberOf($objModel->groups)))
 			{

--- a/core-bundle/src/Resources/contao/modules/ModuleCustomnav.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleCustomnav.php
@@ -86,7 +86,7 @@ class ModuleCustomnav extends Module
 		$objTemplate->module = $this; // see #155
 
 		$security = System::getContainer()->get('security.helper');
-		$user = $security->getUser();
+		$isMember = $security->isGranted('ROLE_MEMBER');
 
 		/** @var PageModel[] $objPages */
 		foreach ($objPages as $objModel)
@@ -94,7 +94,7 @@ class ModuleCustomnav extends Module
 			$objModel->loadDetails();
 
 			// Hide the page if it is not protected and only visible to guests (backwards compatibility)
-			if ($objModel->guests && !$objModel->protected && $user)
+			if ($objModel->guests && !$objModel->protected && $isMember)
 			{
 				trigger_deprecation('contao/core-bundle', '4.12', 'Using the "show to guests only" feature has been deprecated an will no longer work in Contao 5.0. Use the "protect page" function instead.');
 				continue;

--- a/core-bundle/src/Resources/contao/modules/ModuleQuicklink.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleQuicklink.php
@@ -94,6 +94,13 @@ class ModuleQuicklink extends Module
 		{
 			$objSubpage->loadDetails();
 
+			// Hide the page if it is not protected and only visible to guests (backwards compatibility)
+			if ($objSubpage->guests && !$objSubpage->protected && !$user)
+			{
+				trigger_deprecation('contao/core-bundle', '4.12', 'Using the "show to guests only" feature has been deprecated an will no longer work in Contao 5.0. Use the "protect page" function instead.');
+				continue;
+			}
+
 			// PageModel->groups is an array after calling loadDetails()
 			if (!$objSubpage->protected || $this->showProtected || (!$user && \in_array(-1, $objSubpage->groups)) || ($user && $user->isMemberOf($objSubpage->groups)))
 			{

--- a/core-bundle/src/Resources/contao/modules/ModuleQuicklink.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleQuicklink.php
@@ -83,7 +83,7 @@ class ModuleQuicklink extends Module
 
 		$items = array();
 		$security = System::getContainer()->get('security.helper');
-		$user = $security->getUser();
+		$isMember = $security->isGranted('ROLE_MEMBER');
 
 		/** @var PageModel[] $objPages */
 		foreach ($objPages as $objSubpage)
@@ -91,7 +91,7 @@ class ModuleQuicklink extends Module
 			$objSubpage->loadDetails();
 
 			// Hide the page if it is not protected and only visible to guests (backwards compatibility)
-			if ($objSubpage->guests && !$objSubpage->protected && $user)
+			if ($objSubpage->guests && !$objSubpage->protected && $isMember)
 			{
 				trigger_deprecation('contao/core-bundle', '4.12', 'Using the "show to guests only" feature has been deprecated an will no longer work in Contao 5.0. Use the "protect page" function instead.');
 				continue;

--- a/core-bundle/src/Resources/contao/modules/ModuleQuicklink.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleQuicklink.php
@@ -95,7 +95,7 @@ class ModuleQuicklink extends Module
 			$objSubpage->loadDetails();
 
 			// Hide the page if it is not protected and only visible to guests (backwards compatibility)
-			if ($objSubpage->guests && !$objSubpage->protected && !$user)
+			if ($objSubpage->guests && !$objSubpage->protected && $user)
 			{
 				trigger_deprecation('contao/core-bundle', '4.12', 'Using the "show to guests only" feature has been deprecated an will no longer work in Contao 5.0. Use the "protect page" function instead.');
 				continue;

--- a/core-bundle/src/Resources/contao/modules/ModuleQuicklink.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleQuicklink.php
@@ -81,8 +81,9 @@ class ModuleQuicklink extends Module
 			return;
 		}
 
-		$security = System::getContainer()->get('security.helper');
 		$items = array();
+		$security = System::getContainer()->get('security.helper');
+		$user = $security->getUser();
 
 		/** @var PageModel[] $objPages */
 		foreach ($objPages as $objSubpage)

--- a/core-bundle/src/Resources/contao/modules/ModuleQuicknav.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleQuicknav.php
@@ -115,8 +115,9 @@ class ModuleQuicknav extends Module
 			return array();
 		}
 
-		$security = System::getContainer()->get('security.helper');
 		++$level;
+		$security = System::getContainer()->get('security.helper');
+		$user = $security->getUser();
 
 		foreach ($objSubpages as $objSubpage)
 		{

--- a/core-bundle/src/Resources/contao/modules/ModuleQuicknav.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleQuicknav.php
@@ -132,6 +132,13 @@ class ModuleQuicknav extends Module
 				$objSubpage->domain = $host;
 			}
 
+			// Hide the page if it is not protected and only visible to guests (backwards compatibility)
+			if ($objSubpage->guests && !$objSubpage->protected && !$user)
+			{
+				trigger_deprecation('contao/core-bundle', '4.12', 'Using the "show to guests only" feature has been deprecated an will no longer work in Contao 5.0. Use the "protect page" function instead.');
+				continue;
+			}
+
 			// PageModel->groups is an array after calling loadDetails()
 			if (!$objSubpage->protected || $this->showProtected || (!$user && \in_array(-1, $objSubpage->groups)) || ($user && $user->isMemberOf($objSubpage->groups)))
 			{

--- a/core-bundle/src/Resources/contao/modules/ModuleQuicknav.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleQuicknav.php
@@ -117,7 +117,7 @@ class ModuleQuicknav extends Module
 
 		++$level;
 		$security = System::getContainer()->get('security.helper');
-		$user = $security->getUser();
+		$isMember = $security->isGranted('ROLE_MEMBER');
 
 		foreach ($objSubpages as $objSubpage)
 		{
@@ -130,7 +130,7 @@ class ModuleQuicknav extends Module
 			}
 
 			// Hide the page if it is not protected and only visible to guests (backwards compatibility)
-			if ($objSubpage->guests && !$objSubpage->protected && $user)
+			if ($objSubpage->guests && !$objSubpage->protected && $isMember)
 			{
 				trigger_deprecation('contao/core-bundle', '4.12', 'Using the "show to guests only" feature has been deprecated an will no longer work in Contao 5.0. Use the "protect page" function instead.');
 				continue;

--- a/core-bundle/src/Resources/contao/modules/ModuleQuicknav.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleQuicknav.php
@@ -133,7 +133,7 @@ class ModuleQuicknav extends Module
 			}
 
 			// Hide the page if it is not protected and only visible to guests (backwards compatibility)
-			if ($objSubpage->guests && !$objSubpage->protected && !$user)
+			if ($objSubpage->guests && !$objSubpage->protected && $user)
 			{
 				trigger_deprecation('contao/core-bundle', '4.12', 'Using the "show to guests only" feature has been deprecated an will no longer work in Contao 5.0. Use the "protect page" function instead.');
 				continue;


### PR DESCRIPTION
Another follow-up PR to #3143.

Since we are no longer using the `find*WithoutGuests()` methods, we have to filter the "guests only" pages in the menu modules. This also allows us to trigger a deprecation warning, which is desirable.