### PR TITLE
Always use the security voter to check member groups

### DIFF
--- a/core-bundle/src/Resources/contao/classes/FrontendUser.php
+++ b/core-bundle/src/Resources/contao/classes/FrontendUser.php
@@ -251,11 +251,14 @@ class FrontendUser extends User
 	}
 
 	/**
-	 * @param array|int|string $ids
-	 * @return bool
+	 * Return true if the user is member of a particular group
 	 *
-	 * @deprecated Deprecated since Contao 4.12, to be removed in Contao 5.0.
-	 *             Use Symfony security instead.
+	 * @param mixed $ids A single group ID or an array of group IDs
+	 *
+	 * @return boolean True if the user is a member of the group
+	 *
+	 * @deprecated Deprecated since Contao 4.12, to be removed in Contao 5.0;
+	 *             use Symfony security instead
 	 */
 	public function isMemberOf($ids)
 	{

--- a/core-bundle/src/Resources/contao/classes/FrontendUser.php
+++ b/core-bundle/src/Resources/contao/classes/FrontendUser.php
@@ -10,6 +10,8 @@
 
 namespace Contao;
 
+use Contao\CoreBundle\Security\ContaoCorePermissions;
+
 /**
  * Provide methods to manage front end users.
  *
@@ -246,6 +248,27 @@ class FrontendUser extends User
 				$this->strLoginPage = $objGroup->jumpTo;
 			}
 		}
+	}
+
+	/**
+	 * @param array|int|string $ids
+	 * @return bool
+	 *
+  	 * @deprecated Deprecated since Contao 4.12, to be removed in Contao 5.0.
+	 *             Use Symfony security instead.
+	 */
+	public function isMemberOf($ids)
+	{
+		$security = System::getContainer()->get('security.helper');
+
+		if ($security->getUser() === $this)
+		{
+			trigger_deprecation('contao/core-bundle', '4.12', 'Using "Contao\FrontendUser::isMemberOf()" has been deprecated and will no longer work in Contao 5.0. Use Symfony security instead.');
+
+			return $security->isGranted(ContaoCorePermissions::MEMBER_IN_GROUPS, $ids);
+		}
+
+		return parent::isMemberOf($ids);
 	}
 
 	/**

--- a/core-bundle/src/Resources/contao/classes/FrontendUser.php
+++ b/core-bundle/src/Resources/contao/classes/FrontendUser.php
@@ -254,7 +254,7 @@ class FrontendUser extends User
 	 * @param array|int|string $ids
 	 * @return bool
 	 *
-  	 * @deprecated Deprecated since Contao 4.12, to be removed in Contao 5.0.
+	 * @deprecated Deprecated since Contao 4.12, to be removed in Contao 5.0.
 	 *             Use Symfony security instead.
 	 */
 	public function isMemberOf($ids)

--- a/core-bundle/src/Resources/contao/library/Contao/User.php
+++ b/core-bundle/src/Resources/contao/library/Contao/User.php
@@ -425,7 +425,7 @@ abstract class User extends System implements UserInterface, EquatableInterface,
 		}
 
 		// Filter non-numeric values
-		$ids = array_values(array_filter($ids, static function ($val) { return is_numeric($val); }));
+		$ids = array_filter($ids, static function ($val) { return (string)(int) $val === (string) $val; });
 
 		if (empty($ids))
 		{

--- a/core-bundle/src/Resources/contao/library/Contao/User.php
+++ b/core-bundle/src/Resources/contao/library/Contao/User.php
@@ -419,13 +419,8 @@ abstract class User extends System implements UserInterface, EquatableInterface,
 	 */
 	public function isMemberOf($ids)
 	{
-		if (!\is_array($ids))
-		{
-			$ids = array($ids);
-		}
-
 		// Filter non-numeric values
-		$ids = array_filter($ids, static function ($val) { return (string)(int) $val === (string) $val; });
+		$ids = array_filter((array) $ids, static function ($val) { return (string)(int) $val === (string) $val; });
 
 		if (empty($ids))
 		{

--- a/core-bundle/src/Security/Voter/MemberGroupVoter.php
+++ b/core-bundle/src/Security/Voter/MemberGroupVoter.php
@@ -22,17 +22,7 @@ class MemberGroupVoter extends Voter
 {
     protected function supports($attribute, $subject): bool
     {
-        if (ContaoCorePermissions::MEMBER_IN_GROUPS !== $attribute) {
-            return false;
-        }
-
-        if (!\is_array($subject)) {
-            return (string) (int) $subject === (string) $subject;
-        }
-
-        $filtered = array_filter($subject, static function ($val) { return (string) (int) $val === (string) $val; });
-
-        return \count($subject) === \count($filtered);
+        return ContaoCorePermissions::MEMBER_IN_GROUPS === $attribute;
     }
 
     protected function voteOnAttribute($attribute, $subject, TokenInterface $token): bool

--- a/core-bundle/src/Security/Voter/MemberGroupVoter.php
+++ b/core-bundle/src/Security/Voter/MemberGroupVoter.php
@@ -26,18 +26,19 @@ class MemberGroupVoter extends Voter
             return false;
         }
 
-        return is_numeric($subject)
-            || (\is_array($subject) && \count($subject) === \count(array_filter($subject, 'is_numeric')));
+        if (!\is_array($subject)) {
+            return (string) (int) $subject === (string) $subject;
+        }
+
+        $filtered = array_filter($subject, static function ($val) { return (string) (int) $val === (string) $val; });
+
+        return \count($subject) === \count($filtered);
     }
 
     protected function voteOnAttribute($attribute, $subject, TokenInterface $token): bool
     {
-        if (!\is_array($subject)) {
-            $subject = [$subject];
-        }
-
         // Filter non-numeric values
-        $subject = array_filter($subject, static function ($val) { return (string)(int) $val === (string) $val; });
+        $subject = array_filter((array) $subject, static function ($val) { return (string) (int) $val === (string) $val; });
 
         if (empty($subject)) {
             return false;

--- a/core-bundle/src/Security/Voter/MemberGroupVoter.php
+++ b/core-bundle/src/Security/Voter/MemberGroupVoter.php
@@ -32,8 +32,12 @@ class MemberGroupVoter extends Voter
 
     protected function voteOnAttribute($attribute, $subject, TokenInterface $token): bool
     {
+        if (!\is_array($subject)) {
+            $subject = [$subject];
+        }
+
         // Filter non-numeric values
-        $subject = array_filter(array_map('intval', (array) $subject));
+        $subject = array_filter($subject, static function ($val) { return (string)(int) $val === (string) $val; });
 
         if (empty($subject)) {
             return false;
@@ -42,7 +46,7 @@ class MemberGroupVoter extends Voter
         $user = $token->getUser();
 
         if (!$user instanceof FrontendUser) {
-            return \in_array(-1, $subject, true);
+            return \in_array(-1, array_map('intval', $subject), true);
         }
 
         $groups = StringUtil::deserialize($user->groups, true);

--- a/core-bundle/tests/Security/Voter/MemberGroupVoterTest.php
+++ b/core-bundle/tests/Security/Voter/MemberGroupVoterTest.php
@@ -33,7 +33,7 @@ class MemberGroupVoterTest extends TestCase
         $this->voter = new MemberGroupVoter();
     }
 
-    public function testAbstainsIfTheAttributeIsNotContaoGroup(): void
+    public function testAbstainsIfTheAttributeIsNotContaoMemberGroup(): void
     {
         $token = $this->createMock(TokenInterface::class);
 
@@ -64,13 +64,12 @@ class MemberGroupVoterTest extends TestCase
         $this->assertSame(VoterInterface::ACCESS_GRANTED, $this->voter->vote($token, ['-1', '1'], [ContaoCorePermissions::MEMBER_IN_GROUPS]));
     }
 
-    public function testDeniesAccessIfTheUserObjectDeniesAccess(): void
+    public function testDeniesAccessIfTheUserIsNotInGroups(): void
     {
-        $user = $this->createMock(FrontendUser::class);
+        $user = $this->mockClassWithProperties(FrontendUser::class, ['groups' => '2']);
         $user
-            ->expects($this->once())
+            ->expects($this->never())
             ->method('isMemberOf')
-            ->willReturn(false)
         ;
 
         $token = $this->createMock(TokenInterface::class);
@@ -83,13 +82,12 @@ class MemberGroupVoterTest extends TestCase
         $this->assertSame(VoterInterface::ACCESS_DENIED, $this->voter->vote($token, '1', [ContaoCorePermissions::MEMBER_IN_GROUPS]));
     }
 
-    public function testGrantsAccessIfTheUserObjectGrantsAccess(): void
+    public function testGrantsAccessIfTheUserIsInGroups(): void
     {
-        $user = $this->createMock(FrontendUser::class);
+        $user = $this->mockClassWithProperties(FrontendUser::class, ['groups' => [1,2,3]]);
         $user
-            ->expects($this->once())
+            ->expects($this->never())
             ->method('isMemberOf')
-            ->willReturn(true)
         ;
 
         $token = $this->createMock(TokenInterface::class);
@@ -106,12 +104,10 @@ class MemberGroupVoterTest extends TestCase
     {
         $ids = [1, 2, 3, 4];
 
-        $user = $this->createMock(FrontendUser::class);
+        $user = $this->mockClassWithProperties(FrontendUser::class, ['groups' => $ids]);
         $user
-            ->expects($this->once())
+            ->expects($this->never())
             ->method('isMemberOf')
-            ->with($ids)
-            ->willReturn(true)
         ;
 
         $token = $this->createMock(TokenInterface::class);

--- a/core-bundle/tests/Security/Voter/MemberGroupVoterTest.php
+++ b/core-bundle/tests/Security/Voter/MemberGroupVoterTest.php
@@ -84,7 +84,7 @@ class MemberGroupVoterTest extends TestCase
 
     public function testGrantsAccessIfTheUserIsInGroups(): void
     {
-        $user = $this->mockClassWithProperties(FrontendUser::class, ['groups' => [1,2,3]]);
+        $user = $this->mockClassWithProperties(FrontendUser::class, ['groups' => [1, 2, 3]]);
         $user
             ->expects($this->never())
             ->method('isMemberOf')


### PR DESCRIPTION
Since we have security voters to check for member group access, we must make sure it is always used and deprecated the old methods.