### PR TITLE
Enforce the MySQL strict mode

### DIFF
--- a/installation-bundle/src/InstallTool.php
+++ b/installation-bundle/src/InstallTool.php
@@ -282,6 +282,23 @@ class InstallTool
             }
         }
 
+        // Ensure the database is running in strict mode
+        $mode = $this->connection
+            ->executeQuery('SELECT @@sql_mode')
+            ->fetchOne() ?: '';
+
+        if (
+            empty(array_intersect(
+                explode(',', strtoupper($mode)),
+            // See https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html
+            ['TRADITIONAL', 'STRICT_ALL_TABLES', 'STRICT_TRANS_TABLES']
+            ))
+        ) {
+            $context['errorCode'] = 7;
+
+            return true;
+        }
+
         return false;
     }
 

--- a/installation-bundle/src/InstallTool.php
+++ b/installation-bundle/src/InstallTool.php
@@ -19,6 +19,7 @@ use Contao\CoreBundle\Migration\MigrationResult;
 use Contao\File;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Driver\Mysqli\Driver as MysqliDriver;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
@@ -291,6 +292,7 @@ class InstallTool
             ))
         ) {
             $context['errorCode'] = 7;
+            $context['driver'] = $this->connection->getDriver() instanceof MysqliDriver ? 'mysqli' : 'pdo';
 
             return true;
         }

--- a/installation-bundle/src/InstallTool.php
+++ b/installation-bundle/src/InstallTool.php
@@ -236,7 +236,7 @@ class InstallTool
         // Check if strict mode is enabled (see https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html)
         if (!array_intersect(explode(',', strtoupper($mode)), ['TRADITIONAL', 'STRICT_ALL_TABLES', 'STRICT_TRANS_TABLES'])) {
             $context['errorCode'] = 7;
-            $context['optionsKey'] = $this->connection->getDriver() instanceof MysqliDriver ? 3 : 1002;
+            $context['optionKey'] = $this->connection->getDriver() instanceof MysqliDriver ? 3 : 1002;
 
             return true;
         }

--- a/installation-bundle/src/InstallTool.php
+++ b/installation-bundle/src/InstallTool.php
@@ -252,7 +252,7 @@ class InstallTool
                 // Large prefixes are always enabled as of MySQL 5.7.7 and MariaDB 10.2.2
                 if (version_compare($version, $vok, '<')) {
                     // The innodb_large_prefix option is disabled
-                    if (!\in_array(strtolower((string)$row['Value']), ['1', 'on'], true)) {
+                    if (!\in_array(strtolower((string) $row['Value']), ['1', 'on'], true)) {
                         $context['errorCode'] = 5;
 
                         return true;
@@ -261,7 +261,7 @@ class InstallTool
                     $row = $this->connection->fetchAssociative("SHOW VARIABLES LIKE 'innodb_file_per_table'");
 
                     // The innodb_file_per_table option is disabled
-                    if (!\in_array(strtolower((string)$row['Value']), ['1', 'on'], true)) {
+                    if (!\in_array(strtolower((string) $row['Value']), ['1', 'on'], true)) {
                         $context['errorCode'] = 6;
 
                         return true;
@@ -270,7 +270,7 @@ class InstallTool
                     $row = $this->connection->fetchAssociative("SHOW VARIABLES LIKE 'innodb_file_format'");
 
                     // The InnoDB file format is not Barracuda
-                    if ('' !== $row['Value'] && 'barracuda' !== strtolower((string)$row['Value'])) {
+                    if ('' !== $row['Value'] && 'barracuda' !== strtolower((string) $row['Value'])) {
                         $context['errorCode'] = 6;
 
                         return true;
@@ -280,9 +280,7 @@ class InstallTool
         }
 
         // Ensure the database is running in strict mode
-        $mode = $this->connection
-            ->executeQuery('SELECT @@sql_mode')
-            ->fetchOne() ?: '';
+        $mode = $this->connection->fetchOne('SELECT @@sql_mode');
 
         if (
             empty(array_intersect(

--- a/installation-bundle/src/InstallTool.php
+++ b/installation-bundle/src/InstallTool.php
@@ -236,7 +236,7 @@ class InstallTool
         // Check if strict mode is enabled (see https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html)
         if (!array_intersect(explode(',', strtoupper($mode)), ['TRADITIONAL', 'STRICT_ALL_TABLES', 'STRICT_TRANS_TABLES'])) {
             $context['errorCode'] = 7;
-            $context['driver'] = $this->connection->getDriver() instanceof MysqliDriver ? 'mysqli' : 'pdo';
+            $context['optionsKey'] = $this->connection->getDriver() instanceof MysqliDriver ? 3 : 1002;
 
             return true;
         }

--- a/installation-bundle/src/Resources/translations/ContaoInstallationBundle.en.xlf
+++ b/installation-bundle/src/Resources/translations/ContaoInstallationBundle.en.xlf
@@ -269,13 +269,9 @@
       <trans-unit id="89" resname="strict_sql_mode">
         <source>Your database server does not run in strict mode.</source>
       </trans-unit>
-      <trans-unit id="90" resname="strict_sql_mode_explain1">
-        <source>Running without strict mode enabled is bad practice and can lead to unnoticed loss of data. If you cannot change your SQL mode globally, you can add the following command to your connection &lt;code&gt;options&lt;/code&gt; that will enable it on each connection:</source>
+      <trans-unit id="90" resname="strict_sql_mode_explain">
+        <source>Running without strict mode enabled is not supported! Please change your SQL mode globally or add the following command to your connection &lt;code&gt;options&lt;/code&gt; that will enable it on each connection:</source>
       </trans-unit>
-      <trans-unit id="91" resname="strict_sql_mode_explain2">
-        <source>If you want to suppress this error you can do [todo]…</source>
-      </trans-unit>
-
     </body>
   </file>
 </xliff>

--- a/installation-bundle/src/Resources/translations/ContaoInstallationBundle.en.xlf
+++ b/installation-bundle/src/Resources/translations/ContaoInstallationBundle.en.xlf
@@ -267,10 +267,10 @@
         <source>Could not connect to the database using the connection URL found in the &lt;code&gt;DATABASE_URL&lt;/code&gt; environment variable.</source>
       </trans-unit>
       <trans-unit id="89" resname="strict_sql_mode">
-        <source>Your database server does not run in strict mode.</source>
+        <source>Your database server does not run in strict mode!</source>
       </trans-unit>
       <trans-unit id="90" resname="strict_sql_mode_explain">
-        <source>Running without strict mode enabled is not supported! Please change your SQL mode globally or add the following command to your connection &lt;code&gt;options&lt;/code&gt; that will enable it on each connection:</source>
+        <source>Running MySQL in non-strict mode can cause corrupt or truncated data. Please enable the strict mode either in your &lt;code&gt;my.cnf&lt;/code&gt; file or configure the connection options in the &lt;code&gt;config/config.yml&lt;/code&gt; file as follows:</source>
       </trans-unit>
     </body>
   </file>

--- a/installation-bundle/src/Resources/translations/ContaoInstallationBundle.en.xlf
+++ b/installation-bundle/src/Resources/translations/ContaoInstallationBundle.en.xlf
@@ -266,6 +266,16 @@
       <trans-unit id="88" resname="misconfigured_database_url_explain">
         <source>Could not connect to the database using the connection URL found in the &lt;code&gt;DATABASE_URL&lt;/code&gt; environment variable.</source>
       </trans-unit>
+      <trans-unit id="89" resname="strict_sql_mode">
+        <source>Your database server does not run in strict mode.</source>
+      </trans-unit>
+      <trans-unit id="90" resname="strict_sql_mode_explain1">
+        <source>Running without strict mode enabled is bad practice and can lead to unnoticed loss of data. If you cannot change your SQL mode globally, you can add the following command to your connection &lt;code&gt;options&lt;/code&gt; that will enable it on each connection:</source>
+      </trans-unit>
+      <trans-unit id="91" resname="strict_sql_mode_explain2">
+        <source>If you want to suppress this error you can do [todo]…</source>
+      </trans-unit>
+
     </body>
   </file>
 </xliff>

--- a/installation-bundle/src/Resources/views/configuration_error.html.twig
+++ b/installation-bundle/src/Resources/views/configuration_error.html.twig
@@ -72,7 +72,7 @@ innodb_file_per_table = 1</pre>
     connections:
       default:
         options:
-          {{ optionsKey }}: "SET SESSION sql_mode=(SELECT CONCAT(@@sql_mode, ',TRADITIONAL'))"</pre>
+          {{ optionKey }}: "SET SESSION sql_mode=(SELECT CONCAT(@@sql_mode, ',TRADITIONAL'))"</pre>
         </div>
     {% endif %}
   </fieldset>

--- a/installation-bundle/src/Resources/views/configuration_error.html.twig
+++ b/installation-bundle/src/Resources/views/configuration_error.html.twig
@@ -63,6 +63,19 @@
 innodb_file_format = Barracuda
 innodb_file_per_table = 1</pre>
       </div>
+    {% elseif errorCode == 7 %}
+        <p class="tl_error">{{ 'strict_sql_mode'|trans }}</p>
+        <p>{{ 'strict_sql_mode_explain1'|trans|raw }}</p>
+        <div id="sql_wrapper">
+        <pre>doctrine:
+  dbal:
+    connections:
+      default:
+        options:
+          # Define a MYSQL_ATTR_INIT_COMMAND
+          1002: "SET SESSION sql_mode=(SELECT CONCAT(@@sql_mode, ',TRADITIONAL'))"</pre>
+        </div>
+        <p>{{ 'strict_sql_mode_explain2'|trans }}</p>
     {% endif %}
   </fieldset>
 {% endblock %}

--- a/installation-bundle/src/Resources/views/configuration_error.html.twig
+++ b/installation-bundle/src/Resources/views/configuration_error.html.twig
@@ -72,8 +72,14 @@ innodb_file_per_table = 1</pre>
     connections:
       default:
         options:
+          {% if driver == 'mysqli' -%}
+          # Define a MYSQLI_INIT_COMMAND
+          1002: "SET SESSION sql_mode=(SELECT CONCAT(@@sql_mode, ',TRADITIONAL'))"
+          {% else -%}
           # Define a MYSQL_ATTR_INIT_COMMAND
-          1002: "SET SESSION sql_mode=(SELECT CONCAT(@@sql_mode, ',TRADITIONAL'))"</pre>
+          3: "SET SESSION sql_mode=(SELECT CONCAT(@@sql_mode, ',TRADITIONAL'))"
+          {% endif %}
+        </pre>
         </div>
         <p>{{ 'strict_sql_mode_explain2'|trans }}</p>
     {% endif %}

--- a/installation-bundle/src/Resources/views/configuration_error.html.twig
+++ b/installation-bundle/src/Resources/views/configuration_error.html.twig
@@ -65,7 +65,7 @@ innodb_file_per_table = 1</pre>
       </div>
     {% elseif errorCode == 7 %}
         <p class="tl_error">{{ 'strict_sql_mode'|trans }}</p>
-        <p>{{ 'strict_sql_mode_explain1'|trans|raw }}</p>
+        <p>{{ 'strict_sql_mode_explain'|trans|raw }}</p>
         <div id="sql_wrapper">
         <pre>doctrine:
   dbal:
@@ -81,7 +81,6 @@ innodb_file_per_table = 1</pre>
           {% endif %}
         </pre>
         </div>
-        <p>{{ 'strict_sql_mode_explain2'|trans }}</p>
     {% endif %}
   </fieldset>
 {% endblock %}

--- a/installation-bundle/src/Resources/views/configuration_error.html.twig
+++ b/installation-bundle/src/Resources/views/configuration_error.html.twig
@@ -73,10 +73,8 @@ innodb_file_per_table = 1</pre>
       default:
         options:
           {% if driver == 'mysqli' -%}
-          # Define a MYSQLI_INIT_COMMAND
           3: "SET SESSION sql_mode=(SELECT CONCAT(@@sql_mode, ',TRADITIONAL'))"
           {% else -%}
-          # Define a PDO::MYSQL_ATTR_INIT_COMMAND
           1002: "SET SESSION sql_mode=(SELECT CONCAT(@@sql_mode, ',TRADITIONAL'))"
           {% endif %}
         </pre>

--- a/installation-bundle/src/Resources/views/configuration_error.html.twig
+++ b/installation-bundle/src/Resources/views/configuration_error.html.twig
@@ -72,12 +72,7 @@ innodb_file_per_table = 1</pre>
     connections:
       default:
         options:
-          {% if driver == 'mysqli' -%}
-          3: "SET SESSION sql_mode=(SELECT CONCAT(@@sql_mode, ',TRADITIONAL'))"
-          {% else -%}
-          1002: "SET SESSION sql_mode=(SELECT CONCAT(@@sql_mode, ',TRADITIONAL'))"
-          {% endif %}
-        </pre>
+          {{ optionsKey }}: "SET SESSION sql_mode=(SELECT CONCAT(@@sql_mode, ',TRADITIONAL'))"</pre>
         </div>
     {% endif %}
   </fieldset>

--- a/installation-bundle/src/Resources/views/configuration_error.html.twig
+++ b/installation-bundle/src/Resources/views/configuration_error.html.twig
@@ -74,10 +74,10 @@ innodb_file_per_table = 1</pre>
         options:
           {% if driver == 'mysqli' -%}
           # Define a MYSQLI_INIT_COMMAND
-          1002: "SET SESSION sql_mode=(SELECT CONCAT(@@sql_mode, ',TRADITIONAL'))"
-          {% else -%}
-          # Define a MYSQL_ATTR_INIT_COMMAND
           3: "SET SESSION sql_mode=(SELECT CONCAT(@@sql_mode, ',TRADITIONAL'))"
+          {% else -%}
+          # Define a PDO::MYSQL_ATTR_INIT_COMMAND
+          1002: "SET SESSION sql_mode=(SELECT CONCAT(@@sql_mode, ',TRADITIONAL'))"
           {% endif %}
         </pre>
         </div>

--- a/installation-bundle/tests/InstallToolTest.php
+++ b/installation-bundle/tests/InstallToolTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\InstallationBundle\Tests;
+
+use Contao\CoreBundle\Migration\MigrationCollection;
+use Contao\InstallationBundle\InstallTool;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver\AbstractMySQLDriver;
+use Doctrine\DBAL\Driver\Mysqli\Driver as MysqliDriver;
+use Doctrine\DBAL\Driver\PDO\MySQL\Driver as PdoDriver;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+class InstallToolTest extends TestCase
+{
+    /**
+     * @dataProvider provideInvalidSqlModes
+     */
+    public function testRaisesErrorIfNonRunningInStrictMode(string $sqlMode, AbstractMySQLDriver $driver, string $expectedDriver): void
+    {
+        $installTool = $this->getInstallTool($sqlMode, $driver);
+
+        $context = [];
+
+        $this->assertTrue($installTool->hasConfigurationError($context));
+
+        $this->assertSame(7, $context['errorCode']);
+        $this->assertSame($expectedDriver, $context['driver']);
+    }
+
+    public function provideInvalidSqlModes(): \Generator
+    {
+        $pdoDriver = new PdoDriver();
+        $mysqliDriver = new MysqliDriver();
+
+        yield 'empty sql_mode, pdo driver' => [
+            '', $pdoDriver, 'pdo',
+        ];
+
+        yield 'empty sql_mode, mysqli driver' => [
+            '', $mysqliDriver, 'mysqli',
+        ];
+
+        yield 'unrelated values, pdo driver' => [
+            'IGNORE_SPACE,ONLY_FULL_GROUP_BY', $pdoDriver, 'pdo',
+        ];
+
+        yield 'unrelated values, mysqli driver' => [
+            'NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION', $mysqliDriver, 'mysqli',
+        ];
+    }
+
+    /**
+     * @dataProvider provideValidSqlModes
+     */
+    public function testRunsInStrictMode(string $sqlMode): void
+    {
+        $installTool = $this->getInstallTool($sqlMode);
+
+        $context = [];
+
+        $this->assertFalse($installTool->hasConfigurationError($context));
+
+        $this->assertEmpty($context);
+    }
+
+    public function provideValidSqlModes(): \Generator
+    {
+        yield 'TRADITIONAL' => [
+            'TRADITIONAL',
+        ];
+
+        yield 'STRICT_ALL_TABLES' => [
+            'STRICT_ALL_TABLES',
+        ];
+
+        yield 'STRICT_TRANS_TABLES' => [
+            'STRICT_TRANS_TABLES',
+        ];
+
+        yield 'mixed' => [
+            'IGNORE_SPACE,ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION',
+        ];
+    }
+
+    private function getInstallTool(string $sqlMode, AbstractMySQLDriver $driver = null): InstallTool
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection
+            ->method('fetchOne')
+            ->willReturnMap([
+                ['SELECT @@version', [], [], '8.0.0-system'],
+                ['SELECT @@sql_mode', [], [], $sqlMode],
+            ])
+        ;
+
+        $connection
+            ->method('getParams')
+            ->willReturn([
+                'defaultTableOptions' => [],
+            ])
+        ;
+
+        $connection
+            ->method('getDriver')
+            ->willReturn($driver ?? new PdoDriver())
+        ;
+
+        return new InstallTool(
+            $connection,
+            '/project/dir',
+            new NullLogger(),
+            $this->createMock(MigrationCollection::class)
+        );
+    }
+}

--- a/installation-bundle/tests/InstallToolTest.php
+++ b/installation-bundle/tests/InstallToolTest.php
@@ -26,14 +26,14 @@ class InstallToolTest extends TestCase
     /**
      * @dataProvider provideInvalidSqlModes
      */
-    public function testRaisesErrorIfNonRunningInStrictMode(string $sqlMode, AbstractMySQLDriver $driver, string $expectedDriver): void
+    public function testRaisesErrorIfNonRunningInStrictMode(string $sqlMode, AbstractMySQLDriver $driver, int $expectedOptionKey): void
     {
         $installTool = $this->getInstallTool($sqlMode, $driver);
         $context = [];
 
         $this->assertTrue($installTool->hasConfigurationError($context));
         $this->assertSame(7, $context['errorCode']);
-        $this->assertSame($expectedDriver, $context['driver']);
+        $this->assertSame($expectedOptionKey, $context['optionKey']);
     }
 
     public function provideInvalidSqlModes(): \Generator
@@ -42,19 +42,19 @@ class InstallToolTest extends TestCase
         $mysqliDriver = new MysqliDriver();
 
         yield 'empty sql_mode, pdo driver' => [
-            '', $pdoDriver, 'pdo',
+            '', $pdoDriver, 1002,
         ];
 
         yield 'empty sql_mode, mysqli driver' => [
-            '', $mysqliDriver, 'mysqli',
+            '', $mysqliDriver, 3,
         ];
 
         yield 'unrelated values, pdo driver' => [
-            'IGNORE_SPACE,ONLY_FULL_GROUP_BY', $pdoDriver, 'pdo',
+            'IGNORE_SPACE,ONLY_FULL_GROUP_BY', $pdoDriver, 1002,
         ];
 
         yield 'unrelated values, mysqli driver' => [
-            'NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION', $mysqliDriver, 'mysqli',
+            'NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION', $mysqliDriver, 3,
         ];
     }
 

--- a/installation-bundle/tests/InstallToolTest.php
+++ b/installation-bundle/tests/InstallToolTest.php
@@ -29,11 +29,9 @@ class InstallToolTest extends TestCase
     public function testRaisesErrorIfNonRunningInStrictMode(string $sqlMode, AbstractMySQLDriver $driver, string $expectedDriver): void
     {
         $installTool = $this->getInstallTool($sqlMode, $driver);
-
         $context = [];
 
         $this->assertTrue($installTool->hasConfigurationError($context));
-
         $this->assertSame(7, $context['errorCode']);
         $this->assertSame($expectedDriver, $context['driver']);
     }
@@ -66,11 +64,9 @@ class InstallToolTest extends TestCase
     public function testRunsInStrictMode(string $sqlMode): void
     {
         $installTool = $this->getInstallTool($sqlMode);
-
         $context = [];
 
         $this->assertFalse($installTool->hasConfigurationError($context));
-
         $this->assertEmpty($context);
     }
 
@@ -116,11 +112,6 @@ class InstallToolTest extends TestCase
             ->willReturn($driver ?? new PdoDriver())
         ;
 
-        return new InstallTool(
-            $connection,
-            '/project/dir',
-            new NullLogger(),
-            $this->createMock(MigrationCollection::class)
-        );
+        return new InstallTool($connection, '/project/dir', new NullLogger(), $this->createMock(MigrationCollection::class));
     }
 }


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | followup to #3131 for 4.x
| Docs PR or issue | todo

This will prevent the installer from running when MySQL strict mode is disabled. 