### PR TITLE
Do not override the global language in some front end modules

### DIFF
--- a/core-bundle/src/Resources/contao/modules/ModuleChangePassword.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleChangePassword.php
@@ -67,8 +67,6 @@ class ModuleChangePassword extends Module
 
 		$this->import(FrontendUser::class, 'User');
 
-		$GLOBALS['TL_LANGUAGE'] = LocaleUtil::formatAsLanguageTag($objPage->language);
-
 		System::loadLanguageFile('tl_member');
 		$this->loadDataContainer('tl_member');
 

--- a/core-bundle/src/Resources/contao/modules/ModulePassword.php
+++ b/core-bundle/src/Resources/contao/modules/ModulePassword.php
@@ -63,8 +63,6 @@ class ModulePassword extends Module
 		/** @var PageModel $objPage */
 		global $objPage;
 
-		$GLOBALS['TL_LANGUAGE'] = LocaleUtil::formatAsLanguageTag($objPage->language);
-
 		System::loadLanguageFile('tl_member');
 		$this->loadDataContainer('tl_member');
 

--- a/core-bundle/src/Resources/contao/modules/ModulePersonalData.php
+++ b/core-bundle/src/Resources/contao/modules/ModulePersonalData.php
@@ -77,8 +77,6 @@ class ModulePersonalData extends Module
 
 		$this->import(FrontendUser::class, 'User');
 
-		$GLOBALS['TL_LANGUAGE'] = LocaleUtil::formatAsLanguageTag($objPage->language);
-
 		System::loadLanguageFile('tl_member');
 		$this->loadDataContainer('tl_member');
 

--- a/core-bundle/src/Resources/contao/modules/ModuleRegistration.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleRegistration.php
@@ -69,8 +69,6 @@ class ModuleRegistration extends Module
 		/** @var PageModel $objPage */
 		global $objPage;
 
-		$GLOBALS['TL_LANGUAGE'] = LocaleUtil::formatAsLanguageTag($objPage->language);
-
 		System::loadLanguageFile('tl_member');
 		$this->loadDataContainer('tl_member');
 


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes https://github.com/contao/contao/pull/2305#discussion_r664000184
| Docs PR or issue | -

In the front end, the global language is set in the `PageRegular` class:

https://github.com/contao/contao/blob/fbbcf2f943461ce658cd2e7f10941a88c58260cf/core-bundle/src/Resources/contao/pages/PageRegular.php#L78

It does not really make sense to randomly override it in some modules but not in others.