### PR TITLE
Undeprecate the "importUser" hook

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/User.php
+++ b/core-bundle/src/Resources/contao/library/Contao/User.php
@@ -637,8 +637,6 @@ abstract class User extends System implements UserInterface, EquatableInterface,
 			return false;
 		}
 
-		@trigger_error('Using the "importUser" hook has been deprecated and will no longer work in Contao 5.0. Use the "contao.import_user" event instead.', E_USER_DEPRECATED);
-
 		foreach ($GLOBALS['TL_HOOKS']['importUser'] as $callback)
 		{
 			$self->import($callback[0], 'objImport', true);


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | https://github.com/contao/contao/issues/3157#issuecomment-874945013
| Docs PR or issue | contao/docs#...

Removes the deprecation message for the hook `importUser` as the proposed replacement event (`contao.import_user`) does not exist.
