### PR TITLE
Add contao.import_user event

### DIFF
--- a/core-bundle/src/Event/ContaoCoreEvents.php
+++ b/core-bundle/src/Event/ContaoCoreEvents.php
@@ -76,4 +76,11 @@ final class ContaoCoreEvents
      * @see SlugValidCharactersEvent
      */
     public const SLUG_VALID_CHARACTERS = 'contao.slug_valid_characters';
+
+    /**
+     * The contao.import_user event is triggered when a username cannot be found in the database.
+     *
+     * @see ImportUserEvent
+     */
+    public const IMPORT_USER = 'contao.import_user';
 }

--- a/core-bundle/src/Event/ImportUserEvent.php
+++ b/core-bundle/src/Event/ImportUserEvent.php
@@ -31,6 +31,11 @@ class ImportUserEvent extends Event
      */
     private $table;
 
+    /**
+     * @var bool
+     */
+    private $isLoaded = false;
+
     public function __construct(string $username, string $password, string $table)
     {
         $this->username = $username;
@@ -51,5 +56,17 @@ class ImportUserEvent extends Event
     public function getTable(): string
     {
         return $this->table;
+    }
+
+    public function isLoaded(): bool
+    {
+        return $this->isLoaded;
+    }
+
+    public function setIsLoaded(bool $isLoaded): self
+    {
+        $this->isLoaded = $isLoaded;
+
+        return $this;
     }
 }

--- a/core-bundle/src/Event/ImportUserEvent.php
+++ b/core-bundle/src/Event/ImportUserEvent.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Event;
+
+use Symfony\Contracts\EventDispatcher\Event;
+
+class ImportUserEvent extends Event
+{
+    /**
+     * @var string
+     */
+    private $username;
+
+    /**
+     * @var string
+     */
+    private $password;
+
+    /**
+     * @var string
+     */
+    private $table;
+
+    public function __construct(string $username, string $password, string $table)
+    {
+        $this->username = $username;
+        $this->password = $password;
+        $this->table = $table;
+    }
+
+    public function getUsername(): string
+    {
+        return $this->username;
+    }
+
+    public function getPassword(): string
+    {
+        return $this->password;
+    }
+
+    public function getTable(): string
+    {
+        return $this->table;
+    }
+}

--- a/core-bundle/src/Resources/contao/library/Contao/User.php
+++ b/core-bundle/src/Resources/contao/library/Contao/User.php
@@ -10,6 +10,8 @@
 
 namespace Contao;
 
+use Contao\CoreBundle\Event\ContaoCoreEvents;
+use Contao\CoreBundle\Event\ImportUserEvent;
 use Contao\CoreBundle\Exception\RedirectResponseException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
@@ -483,10 +485,8 @@ abstract class User extends System implements UserInterface, EquatableInterface,
 
 			$password = $request->request->get('password');
 
-			if (self::triggerImportUserHook($username, $password, $user->strTable) === false)
-			{
-				return null;
-			}
+			self::triggerImportUserHook($username, $password, $user->strTable);
+			System::getContainer()->get('event_dispatcher')->dispatch(new ImportUserEvent($username, $password, $user->strTable), ContaoCoreEvents::IMPORT_USER);
 
 			if ($user->findBy('username', Input::post('username')) === false)
 			{
@@ -646,7 +646,7 @@ abstract class User extends System implements UserInterface, EquatableInterface,
 			return false;
 		}
 
-		trigger_deprecation('contao/core-bundle', '4.5', 'Using the "importUser" hook has been deprecated and will no longer work in Contao 5.0. Use the "contao.import_user" event instead.');
+		trigger_deprecation('contao/core-bundle', '4.12', 'Using the "importUser" hook has been deprecated and will no longer work in Contao 5.0. Use the "contao.import_user" event instead.');
 
 		foreach ($GLOBALS['TL_HOOKS']['importUser'] as $callback)
 		{

--- a/core-bundle/src/Resources/contao/library/Contao/User.php
+++ b/core-bundle/src/Resources/contao/library/Contao/User.php
@@ -485,8 +485,14 @@ abstract class User extends System implements UserInterface, EquatableInterface,
 
 			$password = $request->request->get('password');
 
-			self::triggerImportUserHook($username, $password, $user->strTable);
-			System::getContainer()->get('event_dispatcher')->dispatch(new ImportUserEvent($username, $password, $user->strTable), ContaoCoreEvents::IMPORT_USER);
+			$event = new ImportUserEvent($username, $password, $user->strTable);
+
+            System::getContainer()->get('event_dispatcher')->dispatch($event, ContaoCoreEvents::IMPORT_USER);
+
+            if (!$event->isLoaded() && self::triggerImportUserHook($username, $password, $user->strTable) === false)
+            {
+                return null;
+            }
 
 			if ($user->findBy('username', Input::post('username')) === false)
 			{


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | https://github.com/contao/contao/issues/3157#issuecomment-874945013
| Docs PR or issue | contao/docs#...

Adds the missing `contao.import_user` event as a replacement for the deprecated `importUser` hook.
