### PR TITLE
Unify the schema.org helper methods

### DIFF
--- a/calendar-bundle/src/Resources/contao/classes/Events.php
+++ b/calendar-bundle/src/Resources/contao/classes/Events.php
@@ -482,6 +482,47 @@ abstract class Events extends Module
 	}
 
 	/**
+	 * Return the schema.org data from an event
+	 *
+	 * @param CalendarEventsModel $objEvent
+	 *
+	 * @return array
+	 */
+	public static function getSchemaOrgData(CalendarEventsModel $objEvent): array
+	{
+		$jsonLd = array(
+			'@type' => 'Event',
+			'identifier' => '#/schema/events/' . $objEvent->id,
+			'name' => StringUtil::inputEncodedToPlainText($objEvent->title),
+			'url' => self::generateEventUrl($objEvent),
+			'startDate' => $objEvent->addTime ? date('Y-m-d\TH:i:sP', $objEvent->startTime) : date('Y-m-d', $objEvent->startTime)
+		);
+
+		if ($objEvent->teaser)
+		{
+			$jsonLd['description'] = $objEvent->teaser;
+		}
+
+		if ($objEvent->location)
+		{
+			$jsonLd['location'] = array(
+				'@type' => 'Place',
+				'name' => StringUtil::inputEncodedToPlainText($objEvent->location)
+			);
+
+			if ($objEvent->address)
+			{
+				$jsonLd['location']['address'] = array(
+					'@type' => 'PostalAddress',
+					'description' => StringUtil::inputEncodedToPlainText($objEvent->address)
+				);
+			}
+		}
+
+		return $jsonLd;
+	}
+
+	/**
 	 * Return the begin and end timestamp and an error message as array
 	 *
 	 * @param Date   $objDate
@@ -578,35 +619,6 @@ abstract class Events extends Module
 			case 'past_all': // 1970-01-01 00:00:00
 				return array(0, time(), $GLOBALS['TL_LANG']['MSC']['cal_empty']);
 		}
-	}
-
-	public static function getBasicSchemaOrgData(CalendarEventsModel $objEvent): array
-	{
-		$jsonLd = array(
-			'@type' => 'Event',
-			'identifier' => '#/schema/events/' . $objEvent->id,
-			'name' => StringUtil::inputEncodedToPlainText($objEvent->title),
-			'url' => self::generateEventUrl($objEvent),
-			'startDate' => $objEvent->addTime ? date('Y-m-d\TH:i:sP', $objEvent->startTime) : date('Y-m-d', $objEvent->startTime)
-		);
-
-		if ($objEvent->location)
-		{
-			$jsonLd['location'] = array(
-				'@type' => 'Place',
-				'name' => StringUtil::inputEncodedToPlainText($objEvent->location)
-			);
-
-			if ($objEvent->address)
-			{
-				$jsonLd['location']['address'] = array(
-					'@type' => 'PostalAddress',
-					'description' => StringUtil::inputEncodedToPlainText($objEvent->address)
-				);
-			}
-		}
-
-		return $jsonLd;
 	}
 }
 

--- a/calendar-bundle/src/Resources/contao/modules/ModuleEventReader.php
+++ b/calendar-bundle/src/Resources/contao/modules/ModuleEventReader.php
@@ -414,9 +414,16 @@ class ModuleEventReader extends Events
 		};
 
 		// schema.org information
-		$objTemplate->getBasicSchemaOrgData = static function () use ($objEvent): array
+		$objTemplate->getSchemaOrgData = static function () use ($objTemplate, $objEvent): array
 		{
-			return Events::getBasicSchemaOrgData($objEvent);
+			$jsonLd = Events::getSchemaOrgData($objEvent);
+
+			if ($objTemplate->addImage && $objTemplate->figure)
+			{
+				$jsonLd['image'] = $objTemplate->figure->getSchemaOrgData();
+			}
+
+			return $jsonLd;
 		};
 
 		$this->Template->event = $objTemplate->parse();

--- a/calendar-bundle/src/Resources/contao/modules/ModuleEventlist.php
+++ b/calendar-bundle/src/Resources/contao/modules/ModuleEventlist.php
@@ -399,9 +399,16 @@ class ModuleEventlist extends Events
 			}
 
 			// schema.org information
-			$objTemplate->getBasicSchemaOrgData = static function () use ($event): array
+			$objTemplate->getSchemaOrgData = static function () use ($objTemplate, $event): array
 			{
-				return Events::getBasicSchemaOrgData($event);
+				$jsonLd = Events::getSchemaOrgData($event);
+
+				if ($objTemplate->addImage && $objTemplate->figure)
+				{
+					$jsonLd['image'] = $objTemplate->figure->getSchemaOrgData();
+				}
+
+				return $jsonLd;
 			};
 
 			$strEvents .= $objTemplate->parse();

--- a/calendar-bundle/src/Resources/contao/templates/events/event_full.html5
+++ b/calendar-bundle/src/Resources/contao/templates/events/event_full.html5
@@ -45,7 +45,7 @@
 
 <?php
 
-$schemaOrg = $this->getBasicSchemaOrgData();
+$schemaOrg = $this->getSchemaOrgData();
 
 if ($this->hasDetails()) {
   $schemaOrg['description'] = $this->rawHtmlToPlainText($this->details);

--- a/calendar-bundle/src/Resources/contao/templates/events/event_list.html5
+++ b/calendar-bundle/src/Resources/contao/templates/events/event_list.html5
@@ -33,5 +33,5 @@
 // This template is used as an event list template by default, so we only add
 // JSON-LD data in case this is an event without a reader
 if (!$this->hasReader) {
-    $this->addSchemaOrg($this->getBasicSchemaOrgData());
+    $this->addSchemaOrg($this->getSchemaOrgData());
 }

--- a/calendar-bundle/src/Resources/contao/templates/events/event_teaser.html5
+++ b/calendar-bundle/src/Resources/contao/templates/events/event_teaser.html5
@@ -44,5 +44,5 @@
 // This template is used as an event list template by default, so we only add
 // JSON-LD data in case this is an event without a reader
 if (!$this->hasReader) {
-  $this->addSchemaOrg($this->getBasicSchemaOrgData());
+  $this->addSchemaOrg($this->getSchemaOrgData());
 }

--- a/calendar-bundle/src/Resources/contao/templates/events/event_upcoming.html5
+++ b/calendar-bundle/src/Resources/contao/templates/events/event_upcoming.html5
@@ -11,5 +11,5 @@
 // This template is used as an event list template by default, so we only add
 // JSON-LD data in case this is an event without a reader
 if (!$this->hasReader) {
-  $this->addSchemaOrg($this->getBasicSchemaOrgData());
+  $this->addSchemaOrg($this->getSchemaOrgData());
 }

--- a/core-bundle/src/Resources/contao/modules/ModuleBreadcrumb.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleBreadcrumb.php
@@ -220,7 +220,7 @@ class ModuleBreadcrumb extends Module
 			}
 		}
 
-		$this->Template->getBasicSchemaOrgData = static function() use ($items): array
+		$this->Template->getSchemaOrgData = static function() use ($items): array
 		{
 			$jsonLd = array(
 				'@type' => 'BreadcrumbList',

--- a/core-bundle/src/Resources/contao/templates/modules/mod_breadcrumb.html5
+++ b/core-bundle/src/Resources/contao/templates/modules/mod_breadcrumb.html5
@@ -16,4 +16,4 @@
 
 <?php
 
-$this->addSchemaOrg($this->getBasicSchemaOrgData());
+$this->addSchemaOrg($this->getSchemaOrgData());

--- a/news-bundle/src/Resources/contao/classes/News.php
+++ b/news-bundle/src/Resources/contao/classes/News.php
@@ -452,6 +452,40 @@ class News extends Frontend
 	}
 
 	/**
+	 * Return the schema.org data from a news article
+	 *
+	 * @param NewsModel $objArticle
+	 *
+	 * @return array
+	 */
+	public static function getSchemaOrgData(NewsModel $objArticle): array
+	{
+		$jsonLd = array(
+			'@type' => 'NewsArticle',
+			'identifier' => '#/schema/news/' . $objArticle->id,
+			'url' => self::generateNewsUrl($objArticle),
+			'headline' => StringUtil::inputEncodedToPlainText($objArticle->headline),
+			'datePublished' => date('Y-m-d\TH:i:sP', $objArticle->date),
+		);
+
+		if ($objArticle->teaser)
+		{
+			$jsonLd['description'] = StringUtil::htmlToPlainText($objArticle->teaser);
+		}
+
+		/** @var UserModel $objAuthor */
+		if (($objAuthor = $objArticle->getRelated('author')) instanceof UserModel)
+		{
+			$jsonLd['author'] = array(
+				'@type' => 'Person',
+				'name' => $objAuthor->name,
+			);
+		}
+
+		return $jsonLd;
+	}
+
+	/**
 	 * Return the link of a news article
 	 *
 	 * @param NewsModel $objItem

--- a/news-bundle/src/Resources/contao/modules/ModuleNews.php
+++ b/news-bundle/src/Resources/contao/modules/ModuleNews.php
@@ -228,32 +228,13 @@ abstract class ModuleNews extends Module
 		}
 
 		// schema.org information
-		$objTemplate->getBasicSchemaOrgData = static function () use ($objTemplate, $objArticle): array
+		$objTemplate->getSchemaOrgData = static function () use ($objTemplate, $objArticle): array
 		{
-			$jsonLd = array(
-				'@type' => 'NewsArticle',
-				'identifier' => '#/schema/news/' . $objArticle->id,
-				'url' => $objTemplate->link,
-				'headline' => StringUtil::inputEncodedToPlainText($objTemplate->headline),
-				'datePublished' => $objTemplate->datetime,
-			);
-
-			if ($objTemplate->hasTeaser)
-			{
-				$jsonLd['description'] = StringUtil::htmlToPlainText($objTemplate->teaser);
-			}
+			$jsonLd = News::getSchemaOrgData($objArticle);
 
 			if ($objTemplate->addImage && $objTemplate->figure)
 			{
 				$jsonLd['image'] = $objTemplate->figure->getSchemaOrgData();
-			}
-
-			if ($objTemplate->authorModel)
-			{
-				$jsonLd['author'] = array(
-					'@type' => 'Person',
-					'name' => $objTemplate->authorModel->name,
-				);
 			}
 
 			return $jsonLd;

--- a/news-bundle/src/Resources/contao/templates/news/news_full.html5
+++ b/news-bundle/src/Resources/contao/templates/news/news_full.html5
@@ -43,7 +43,7 @@
 
 <?php
 
-$schemaOrg = $this->getBasicSchemaOrgData();
+$schemaOrg = $this->getSchemaOrgData();
 
 if ($this->hasText()) {
     $schemaOrg['text'] = $this->rawHtmlToPlainText($this->text);

--- a/news-bundle/src/Resources/contao/templates/news/news_latest.html5
+++ b/news-bundle/src/Resources/contao/templates/news/news_latest.html5
@@ -26,5 +26,5 @@
 // This template is used as a news list template by default, so we only add
 // JSON-LD data in case this is a news article without a reader
 if (!$this->hasReader) {
-    $this->addSchemaOrg($this->getBasicSchemaOrgData());
+    $this->addSchemaOrg($this->getSchemaOrgData());
 }

--- a/news-bundle/src/Resources/contao/templates/news/news_short.html5
+++ b/news-bundle/src/Resources/contao/templates/news/news_short.html5
@@ -22,5 +22,5 @@
 // This template is used as a news list template by default, so we only add
 // JSON-LD data in case this is a news article without a reader
 if (!$this->hasReader) {
-    $this->addSchemaOrg($this->getBasicSchemaOrgData());
+    $this->addSchemaOrg($this->getSchemaOrgData());
 }

--- a/news-bundle/src/Resources/contao/templates/news/news_simple.html5
+++ b/news-bundle/src/Resources/contao/templates/news/news_simple.html5
@@ -9,5 +9,5 @@
 // This template is used as a news list template by default, so we only add
 // JSON-LD data in case this is a news article without a reader
 if (!$this->hasReader) {
-    $this->addSchemaOrg($this->getBasicSchemaOrgData());
+    $this->addSchemaOrg($this->getSchemaOrgData());
 }


### PR DESCRIPTION
Follow-up on https://github.com/contao/contao/pull/3155#discussion_r664641912.

* Adds a `News::getSchemaOrgData()` method
* Renames `getBasicSchemaOrgData` to `getSchemaOrgData()`

@contao/developers: For convenience, I am still using `$objTemplate->figure->getSchemaOrgData()` in the anonymous function instead of in the `getSchemaOrgData()` helper method. Is this something we want to or have to change?
