### PR TITLE
Revert 'Lazy-load the `rootFallbackLanguage` property'

### DIFF
--- a/core-bundle/src/Resources/contao/models/PageModel.php
+++ b/core-bundle/src/Resources/contao/models/PageModel.php
@@ -358,40 +358,6 @@ class PageModel extends Model
 		return parent::__set($strKey, $varValue);
 	}
 
-	public function __get($strKey)
-	{
-		// Lazy-load the fallback language (see contao/core#6874)
-		if ($strKey == 'rootFallbackLanguage' && $this->blnDetailsLoaded && !\array_key_exists('rootFallbackLanguage', $this->arrData))
-		{
-			$this->rootFallbackLanguage = $this->rootIsFallback ? $this->language : null;
-
-			if (!$this->rootIsFallback && ($objFallback = static::findPublishedFallbackByHostname($this->domain)) !== null)
-			{
-				$this->rootFallbackLanguage = $objFallback->language;
-			}
-		}
-
-		return parent::__get($strKey);
-	}
-
-	public function __isset($strKey)
-	{
-		if ($strKey == 'rootFallbackLanguage' && $this->blnDetailsLoaded)
-		{
-			return true;
-		}
-
-		return parent::__isset($strKey);
-	}
-
-	public function row()
-	{
-		// Load lazy properties
-		$this->__get('rootFallbackLanguage');
-
-		return parent::row();
-	}
-
 	/**
 	 * Find a published page by its ID
 	 *
@@ -1195,6 +1161,21 @@ class PageModel extends Model
 			$this->rootIsPublic = ($objParentPage->published && (!$objParentPage->start || $objParentPage->start <= $time) && (!$objParentPage->stop || $objParentPage->stop > $time));
 			$this->rootIsFallback = (bool) $objParentPage->fallback;
 			$this->rootUseSSL = $objParentPage->useSSL;
+			$this->rootFallbackLanguage = $objParentPage->language;
+
+			// Store the fallback language (see #6874)
+			if (!$objParentPage->fallback)
+			{
+				$this->rootIsFallback = false;
+				$this->rootFallbackLanguage = null;
+
+				$objFallback = static::findPublishedFallbackByHostname($objParentPage->dns);
+
+				if ($objFallback !== null)
+				{
+					$this->rootFallbackLanguage = $objFallback->language;
+				}
+			}
 
 			if (System::getContainer()->getParameter('contao.legacy_routing'))
 			{

--- a/core-bundle/src/Resources/contao/models/PageModel.php
+++ b/core-bundle/src/Resources/contao/models/PageModel.php
@@ -1166,7 +1166,6 @@ class PageModel extends Model
 			// Store the fallback language (see #6874)
 			if (!$objParentPage->fallback)
 			{
-				$this->rootIsFallback = false;
 				$this->rootFallbackLanguage = null;
 
 				$objFallback = static::findPublishedFallbackByHostname($objParentPage->dns);


### PR DESCRIPTION
This reverts #3067. The root fallback language model is already stored in the registry:

https://github.com/contao/contao/blob/99e04328a3b8eb06baec750aa8142ceb5804981e/core-bundle/src/Resources/contao/models/PageModel.php#L890-L899

Therefore, the changes from #3067 do reduce the number of calls to the `PageMode::findPublishedFallbackByHostname()` method, however, they do **not** reduce the number of DB queries.

Search the code for `contao.dns-fallback` to learn more about the special handling we already have.