### PR TITLE
Add JSON-LD support for Twig

### DIFF
--- a/core-bundle/src/Resources/views/Image/Studio/_macros.html.twig
+++ b/core-bundle/src/Resources/views/Image/Studio/_macros.html.twig
@@ -1,3 +1,5 @@
+{# @var \Contao\CoreBundle\Image\Studio\Figure figure #}
+
 {#
     Studio Macros
     -------------

--- a/core-bundle/src/Resources/views/Image/Studio/_macros.html.twig
+++ b/core-bundle/src/Resources/views/Image/Studio/_macros.html.twig
@@ -47,7 +47,7 @@
 
     If a link is defined the picture will be wrapped in an <a> tag.
 #}
-{%- macro figure(figure, options = {}) -%}
+{%- macro figure(figure, options = {}, addSchemaOrg = true) -%}
     {%- set figure_attributes = figure.options.attr|default({})|merge(options.attr|default({})) %}
     {%- set link_attributes = figure.options.link_attr|default({})|merge(options.link_attr|default({})) ~%}
     <figure{{ _self.html_attributes(figure_attributes) }}>
@@ -64,6 +64,9 @@
         {% endif %}
         {{ _self.caption(figure, options) }}
     </figure>
+    {% if addSchemaOrg %}
+        {%- do addSchemaOrg(figure.schemaOrgData) -%}
+    {% endif %}
 {%- endmacro -%}
 
 {#

--- a/core-bundle/src/Resources/views/Image/Studio/_macros.html.twig
+++ b/core-bundle/src/Resources/views/Image/Studio/_macros.html.twig
@@ -65,7 +65,7 @@
         {{ _self.caption(figure, options) }}
     </figure>
     {% if addSchemaOrg %}
-        {%- do addSchemaOrg(figure.schemaOrgData) -%}
+        {%- do add_schema_org(figure.schemaOrgData) -%}
     {% endif %}
 {%- endmacro -%}
 

--- a/core-bundle/src/Resources/views/Image/Studio/_macros.html.twig
+++ b/core-bundle/src/Resources/views/Image/Studio/_macros.html.twig
@@ -48,24 +48,18 @@
 {%- macro figure(figure, options = {}) -%}
     {%- set figure_attributes = figure.options.attr|default({})|merge(options.attr|default({})) %}
     {%- set link_attributes = figure.options.link_attr|default({})|merge(options.link_attr|default({})) ~%}
-
-    {%- set base_attributes = {
-        'itemscope': '',
-        'itemtype': 'https://schema.org/ImageObject'
-    } %}
-    <figure{{ _self.html_attributes(base_attributes|merge(figure_attributes)) }}>
+    <figure{{ _self.html_attributes(figure_attributes) }}>
         {% if figure.linkHref -%}
             {%- set base_attributes = {
                 'href': figure.linkHref,
                 'title': figure.hasLightbox and figure.hasMetadata ? figure.metadata.title : null,
             }|merge(figure.linkAttributes) -%}
             <a{{ _self.html_attributes(base_attributes|merge(link_attributes)) }}>
-               {{~ _self.picture(figure, options) }}
+                {{~ _self.picture(figure, options) }}
             </a>
         {%- else %}
             {{- _self.picture(figure, options) -}}
         {% endif %}
-
         {{ _self.caption(figure, options) }}
     </figure>
 {%- endmacro -%}
@@ -79,7 +73,7 @@
     {%- set picture_attributes = figure.options.picture_attr|default({})|merge(options.picture_attr|default({})) %}
     {%- set source_attributes = figure.options.source_attr|default({})|merge(options.source_attr|default({})) %}
 
-    {%- if figure.image.sources %}
+    {%- if figure.image.sources -%}
         <picture{{ _self.html_attributes(picture_attributes) }}>
             {% for source in figure.image.sources %}
                 {%- set defineProportions = source.width|default(false) and source.height|default(false) -%}
@@ -121,7 +115,6 @@
             'height': defineProportions ? img.height : null,
             'loading': img.loading|default(null),
             'class': img.class|default(null),
-            'itemprop': 'image',
         } %}
         <img{{ _self.html_attributes(base_attributes|merge(img_attributes)) }}>
     {% endapply %}
@@ -136,8 +129,7 @@
     {% apply spaceless %}
         {% if figure.hasMetadata and figure.metadata.caption %}
             {% set caption_attributes = figure.options.caption_attr|default({})|merge(options.caption_attr|default({})) %}
-            {% set base_attributes = { 'itemprop': 'caption' } %}
-            <figcaption{{ _self.html_attributes(base_attributes|merge(caption_attributes)) }}>
+            <figcaption{{ _self.html_attributes(caption_attributes) }}>
                 {{- figure.metadata.caption|raw -}}
             </figcaption>
         {% endif %}

--- a/core-bundle/src/Twig/Extension/ContaoTemplateExtension.php
+++ b/core-bundle/src/Twig/Extension/ContaoTemplateExtension.php
@@ -15,6 +15,7 @@ namespace Contao\CoreBundle\Twig\Extension;
 use Contao\BackendCustom;
 use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\CoreBundle\Routing\ScopeMatcher;
+use Contao\CoreBundle\Twig\Runtime\SchemaOrgRuntime;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
@@ -50,6 +51,7 @@ class ContaoTemplateExtension extends AbstractExtension
     {
         return [
             new TwigFunction('render_contao_backend_template', [$this, 'renderContaoBackendTemplate']),
+            new TwigFunction('addSchemaOrg', [SchemaOrgRuntime::class, 'add']),
         ];
     }
 

--- a/core-bundle/src/Twig/Extension/ContaoTemplateExtension.php
+++ b/core-bundle/src/Twig/Extension/ContaoTemplateExtension.php
@@ -51,7 +51,7 @@ class ContaoTemplateExtension extends AbstractExtension
     {
         return [
             new TwigFunction('render_contao_backend_template', [$this, 'renderContaoBackendTemplate']),
-            new TwigFunction('addSchemaOrg', [SchemaOrgRuntime::class, 'add']),
+            new TwigFunction('add_schema_org', [SchemaOrgRuntime::class, 'add']),
         ];
     }
 

--- a/core-bundle/src/Twig/Runtime/SchemaOrgRuntime.php
+++ b/core-bundle/src/Twig/Runtime/SchemaOrgRuntime.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Twig\Runtime;
+
+use Contao\CoreBundle\Routing\ResponseContext\JsonLd\JsonLdManager;
+use Contao\CoreBundle\Routing\ResponseContext\ResponseContextAccessor;
+use Spatie\SchemaOrg\Graph;
+use Twig\Extension\RuntimeExtensionInterface;
+
+final class SchemaOrgRuntime implements RuntimeExtensionInterface
+{
+    /**
+     * @var ResponseContextAccessor
+     */
+    private $responseContextAccessor;
+
+    /**
+     * @internal
+     */
+    public function __construct(ResponseContextAccessor $responseContextAccessor)
+    {
+        $this->responseContextAccessor = $responseContextAccessor;
+    }
+
+    /**
+     * Adds schema.org JSON-LD data to the current response context.
+     */
+    public function add(array $jsonLd): void
+    {
+        $responseContext = $this->responseContextAccessor->getResponseContext();
+
+        if (!$responseContext || !$responseContext->has(JsonLdManager::class)) {
+            return;
+        }
+
+        /** @var JsonLdManager $jsonLdManager */
+        $jsonLdManager = $responseContext->get(JsonLdManager::class);
+        $type = $jsonLdManager->createSchemaOrgTypeFromArray($jsonLd);
+
+        $jsonLdManager
+            ->getGraphForSchema(JsonLdManager::SCHEMA_ORG)
+            ->set($type, $jsonLd['identifier'] ?? Graph::IDENTIFIER_DEFAULT)
+        ;
+    }
+}

--- a/core-bundle/tests/Image/Studio/TwigMacrosTest.php
+++ b/core-bundle/tests/Image/Studio/TwigMacrosTest.php
@@ -596,12 +596,10 @@ class TwigMacrosTest extends TestCase
     {
         $templates = [
             '_macros.html.twig' => self::$macros,
-            'test.html.twig' => '{% import "_macros.html.twig" as studio %}'.
-                "{{ studio.$call }}",
+            'test.html.twig' => "{% import \"_macros.html.twig\" as studio %}{{ studio.$call }}",
         ];
 
         $environment = new Environment(new ArrayLoader($templates));
-
         $environment->setExtensions([
             new ContaoTemplateExtension(
                 new RequestStack(),

--- a/core-bundle/tests/Image/Studio/TwigMacrosTest.php
+++ b/core-bundle/tests/Image/Studio/TwigMacrosTest.php
@@ -13,13 +13,22 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Tests\Image\Studio;
 
 use Contao\CoreBundle\File\Metadata;
+use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\CoreBundle\Image\Studio\Figure;
 use Contao\CoreBundle\Image\Studio\ImageResult;
 use Contao\CoreBundle\Image\Studio\LightboxResult;
+use Contao\CoreBundle\Routing\ResponseContext\JsonLd\JsonLdManager;
+use Contao\CoreBundle\Routing\ResponseContext\ResponseContext;
+use Contao\CoreBundle\Routing\ResponseContext\ResponseContextAccessor;
+use Contao\CoreBundle\Routing\ScopeMatcher;
 use Contao\CoreBundle\Tests\TestCase;
+use Contao\CoreBundle\Twig\Extension\ContaoTemplateExtension;
+use Contao\CoreBundle\Twig\Runtime\SchemaOrgRuntime;
 use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Twig\Environment;
 use Twig\Loader\ArrayLoader;
+use Twig\RuntimeLoader\FactoryRuntimeLoader;
 use Webmozart\PathUtil\Path;
 
 class TwigMacrosTest extends TestCase
@@ -87,25 +96,25 @@ class TwigMacrosTest extends TestCase
         yield 'no options' => [
             '{}',
             [],
-            '<figcaption itemprop="caption">my <b>caption</b></figcaption>',
+            '<figcaption>my <b>caption</b></figcaption>',
         ];
 
         yield 'figure options' => [
             '{}',
             ['caption_attr' => ['data-foo' => 'bar', 'data-foobar' => 'baz']],
-            '<figcaption itemprop="caption" data-foo="bar" data-foobar="baz">my <b>caption</b></figcaption>',
+            '<figcaption data-foo="bar" data-foobar="baz">my <b>caption</b></figcaption>',
         ];
 
         yield 'template options' => [
             "{ 'caption_attr': {'data-foo': 'bar', 'data-foobar': 'baz' }}",
             [],
-            '<figcaption itemprop="caption" data-foo="bar" data-foobar="baz">my <b>caption</b></figcaption>',
+            '<figcaption data-foo="bar" data-foobar="baz">my <b>caption</b></figcaption>',
         ];
 
         yield 'template options overwriting figure options' => [
             "{ 'caption_attr': {'data-foobar': 'other' }}",
             ['caption_attr' => ['data-foo' => 'bar', 'data-foobar' => 'baz']],
-            '<figcaption itemprop="caption" data-foo="bar" data-foobar="other">my <b>caption</b></figcaption>',
+            '<figcaption data-foo="bar" data-foobar="other">my <b>caption</b></figcaption>',
         ];
     }
 
@@ -131,13 +140,13 @@ class TwigMacrosTest extends TestCase
         yield 'minimal' => [
             ['src' => 'foo.png'],
             null,
-            '<img src="foo.png" alt itemprop="image">',
+            '<img src="foo.png" alt>',
         ];
 
         yield 'minimal with empty metadata' => [
             ['src' => 'foo.png'],
             new Metadata([]),
-            '<img src="foo.png" alt itemprop="image">',
+            '<img src="foo.png" alt>',
         ];
 
         yield 'with metadata' => [
@@ -146,7 +155,7 @@ class TwigMacrosTest extends TestCase
                 Metadata::VALUE_ALT => 'my alt',
                 Metadata::VALUE_TITLE => 'my title',
             ]),
-            '<img src="foo.png" alt="my alt" title="my title" itemprop="image">',
+            '<img src="foo.png" alt="my alt" title="my title">',
         ];
 
         yield 'incomplete proportions' => [
@@ -155,7 +164,7 @@ class TwigMacrosTest extends TestCase
                 'width' => 400,
             ],
             null,
-            '<img src="foo.png" alt itemprop="image">',
+            '<img src="foo.png" alt>',
         ];
 
         yield 'complete proportions' => [
@@ -165,7 +174,7 @@ class TwigMacrosTest extends TestCase
                 'height' => 300,
             ],
             null,
-            '<img src="foo.png" alt width="400" height="300" itemprop="image">',
+            '<img src="foo.png" alt width="400" height="300">',
         ];
 
         yield 'full set' => [
@@ -182,7 +191,7 @@ class TwigMacrosTest extends TestCase
                 Metadata::VALUE_ALT => 'my alt',
                 Metadata::VALUE_TITLE => 'my title',
             ]),
-            '<img src="foo.png" alt="my alt" title="my title" srcset="foo-1.png 300w, foo-2png 500w" sizes="(max-width: 500px) 100vw, 50vw" width="400" height="300" loading="lazy" class="my-class" itemprop="image">',
+            '<img src="foo.png" alt="my alt" title="my title" srcset="foo-1.png 300w, foo-2png 500w" sizes="(max-width: 500px) 100vw, 50vw" width="400" height="300" loading="lazy" class="my-class">',
         ];
     }
 
@@ -219,25 +228,25 @@ class TwigMacrosTest extends TestCase
         yield 'no options' => [
             '{}',
             [],
-            '<img src="foo.png" alt="my alt" class="my-class" itemprop="image">',
+            '<img src="foo.png" alt="my alt" class="my-class">',
         ];
 
         yield 'figure options (overwriting attributes)' => [
             '{}',
             ['img_attr' => ['data-foo' => 'bar', 'alt' => 'other alt']],
-            '<img src="foo.png" alt="other alt" class="my-class" itemprop="image" data-foo="bar">',
+            '<img src="foo.png" alt="other alt" class="my-class" data-foo="bar">',
         ];
 
         yield 'template options (overwriting attributes)' => [
             "{ 'img_attr': {'data-foo': 'bar', 'alt': 'other alt' }}",
             [],
-            '<img src="foo.png" alt="other alt" class="my-class" itemprop="image" data-foo="bar">',
+            '<img src="foo.png" alt="other alt" class="my-class" data-foo="bar">',
         ];
 
         yield 'template options overwriting figure options' => [
             "{ 'img_attr': {'data-foobar': 'other' }}",
             ['img_attr' => ['class' => 'other-class', 'data-foobar' => 'baz']],
-            '<img src="foo.png" alt="my alt" class="other-class" itemprop="image" data-foobar="other">',
+            '<img src="foo.png" alt="my alt" class="other-class" data-foobar="other">',
         ];
     }
 
@@ -392,7 +401,7 @@ class TwigMacrosTest extends TestCase
         $html = $this->renderMacro('figure(figure)', ['figure' => $figure]);
 
         // Do not care about the img/picture or figcaption tag internals
-        $html = preg_replace('#<img.*>#', '<picture>', $html);
+        $html = preg_replace('#<img[^<]*>#', '<picture>', $html);
         $html = preg_replace('#<figcaption.*</figcaption>#', '<figcaption>', $html);
 
         // Trim whitespaces in between tags for easier comparison
@@ -407,7 +416,7 @@ class TwigMacrosTest extends TestCase
             null,
             [],
             null,
-            '<figure itemscope itemtype="https://schema.org/ImageObject"><picture></figure>',
+            '<figure><picture></figure>',
         ];
 
         yield 'with link' => [
@@ -417,7 +426,7 @@ class TwigMacrosTest extends TestCase
                 'data-link' => 'bar',
             ],
             null,
-            '<figure itemscope itemtype="https://schema.org/ImageObject"><a href="foo.html" data-link="bar"><picture></a></figure>',
+            '<figure><a href="foo.html" data-link="bar"><picture></a></figure>',
         ];
 
         /** @var LightboxResult&MockObject $lightbox */
@@ -436,21 +445,21 @@ class TwigMacrosTest extends TestCase
             null,
             [],
             $lightbox,
-            '<figure itemscope itemtype="https://schema.org/ImageObject"><a href="lightbox/resource" data-lightbox="gal1"><picture></a></figure>',
+            '<figure><a href="lightbox/resource" data-lightbox="gal1"><picture></a></figure>',
         ];
 
         yield 'with lightbox link and title' => [
             new Metadata([Metadata::VALUE_TITLE => 'foo title']),
             [],
             $lightbox,
-            '<figure itemscope itemtype="https://schema.org/ImageObject"><a href="lightbox/resource" title="foo title" data-lightbox="gal1"><picture></a></figure>',
+            '<figure><a href="lightbox/resource" title="foo title" data-lightbox="gal1"><picture></a></figure>',
         ];
 
         yield 'with caption' => [
             new Metadata([Metadata::VALUE_CAPTION => 'foo caption']),
             [],
             null,
-            '<figure itemscope itemtype="https://schema.org/ImageObject"><picture><figcaption></figure>',
+            '<figure><picture><figcaption></figure>',
         ];
     }
 
@@ -499,7 +508,7 @@ class TwigMacrosTest extends TestCase
         yield 'no options' => [
             '{}',
             [],
-            '<figure itemscope itemtype="https://schema.org/ImageObject"><a href="foo.html" title="foo title" data-link="bar" data-lightbox="gal1"><picture></a></figure>',
+            '<figure><a href="foo.html" title="foo title" data-link="bar" data-lightbox="gal1"><picture></a></figure>',
         ];
 
         yield 'figure options' => [
@@ -508,13 +517,13 @@ class TwigMacrosTest extends TestCase
                 'attr' => ['data-foo' => 'foo'],
                 'link_attr' => ['data-bar' => 'bar'],
             ],
-            '<figure itemscope itemtype="https://schema.org/ImageObject" data-foo="foo"><a href="foo.html" title="foo title" data-link="bar" data-lightbox="gal1" data-bar="bar"><picture></a></figure>',
+            '<figure data-foo="foo"><a href="foo.html" title="foo title" data-link="bar" data-lightbox="gal1" data-bar="bar"><picture></a></figure>',
         ];
 
         yield 'template options' => [
             "{ 'attr': {'data-foo': 'foo'}, 'link_attr': {'data-bar': 'bar'} }",
             [],
-            '<figure itemscope itemtype="https://schema.org/ImageObject" data-foo="foo"><a href="foo.html" title="foo title" data-link="bar" data-lightbox="gal1" data-bar="bar"><picture></a></figure>',
+            '<figure data-foo="foo"><a href="foo.html" title="foo title" data-link="bar" data-lightbox="gal1" data-bar="bar"><picture></a></figure>',
         ];
 
         yield 'template options overwriting figure options' => [
@@ -523,11 +532,67 @@ class TwigMacrosTest extends TestCase
                 'attr' => ['data-foo' => 'foo'],
                 'link_attr' => ['data-bar' => 'bar'],
             ],
-            '<figure itemscope itemtype="https://schema.org/ImageObject" data-foo="other foo"><a href="foo.html" title="foo title" data-link="bar" data-lightbox="gal1" data-bar="other bar"><picture></a></figure>',
+            '<figure data-foo="other foo"><a href="foo.html" title="foo title" data-link="bar" data-lightbox="gal1" data-bar="other bar"><picture></a></figure>',
         ];
     }
 
-    private function renderMacro(string $call, array $context = []): string
+    /**
+     * @dataProvider provideAddSchemaOrgOptions
+     */
+    public function testDoesAddsSchemaOrgDataIfEnabled(string $call, array $schemaData): void
+    {
+        $figure = new Figure(
+            $this->createMock(ImageResult::class),
+            new Metadata([
+                Metadata::VALUE_TITLE => 'foo title',
+                Metadata::VALUE_UUID => '<uuid>',
+            ])
+        );
+
+        $responseContext = new ResponseContext();
+        $jsonLdManager = new JsonLdManager($responseContext);
+        $responseContext->add($jsonLdManager);
+
+        $responseContextAccessor = $this->createMock(ResponseContextAccessor::class);
+        $responseContextAccessor
+            ->method('getResponseContext')
+            ->willReturn($responseContext)
+        ;
+
+        $this->renderMacro($call, ['figure' => $figure], $responseContextAccessor);
+
+        $graph = $jsonLdManager->getGraphForSchema(JsonLdManager::SCHEMA_ORG)->toArray();
+
+        $this->assertSame($graph['@graph'], $schemaData);
+    }
+
+    public function provideAddSchemaOrgOptions(): \Generator
+    {
+        yield 'default (enabled)' => [
+            'figure(figure)',
+            [[
+                '@type' => 'ImageObject',
+                'name' => 'foo title',
+                '@id' => '#/schema/image/<uuid>',
+            ]],
+        ];
+
+        yield 'explicitly enabled' => [
+            'figure(figure, {}, true)',
+            [[
+                '@type' => 'ImageObject',
+                'name' => 'foo title',
+                '@id' => '#/schema/image/<uuid>',
+            ]],
+        ];
+
+        yield 'disabled' => [
+            'figure(figure, {}, false)',
+            [],
+        ];
+    }
+
+    private function renderMacro(string $call, array $context = [], ResponseContextAccessor $responseContextAccessor = null): string
     {
         $templates = [
             '_macros.html.twig' => self::$macros,
@@ -536,6 +601,26 @@ class TwigMacrosTest extends TestCase
         ];
 
         $environment = new Environment(new ArrayLoader($templates));
+
+        $environment->setExtensions([
+            new ContaoTemplateExtension(
+                new RequestStack(),
+                $this->createMock(ContaoFramework::class),
+                $this->createMock(ScopeMatcher::class)
+            ),
+        ]);
+
+        if (null === $responseContextAccessor) {
+            $responseContextAccessor = $this->createMock(ResponseContextAccessor::class);
+        }
+
+        $environment->addRuntimeLoader(
+            new FactoryRuntimeLoader([
+                SchemaOrgRuntime::class => static function () use ($responseContextAccessor) {
+                    return new SchemaOrgRuntime($responseContextAccessor);
+                },
+            ])
+        );
 
         return $environment->render('test.html.twig', $context);
     }

--- a/core-bundle/tests/Twig/Runtime/SchemaOrgRuntimeTest.php
+++ b/core-bundle/tests/Twig/Runtime/SchemaOrgRuntimeTest.php
@@ -39,13 +39,16 @@ class SchemaOrgRuntimeTest extends TestCase
 
         $graph = $manager->getGraphForSchema(JsonLdManager::SCHEMA_ORG)->toArray();
 
-        $this->assertSame([
-            '@context' => 'https://schema.org',
-            '@graph' => [[
-                '@type' => 'ImageObject',
-                '@id' => 'https://assets.url/files/public/foo.jpg',
-            ]],
-        ], $graph);
+        $this->assertSame(
+            [
+                '@context' => 'https://schema.org',
+                '@graph' => [[
+                    '@type' => 'ImageObject',
+                    '@id' => 'https://assets.url/files/public/foo.jpg',
+                ]],
+            ],
+            $graph
+        );
     }
 
     public function testToleratesMissingResponseContext(): void

--- a/core-bundle/tests/Twig/Runtime/SchemaOrgRuntimeTest.php
+++ b/core-bundle/tests/Twig/Runtime/SchemaOrgRuntimeTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\Twig\Runtime;
+
+use Contao\CoreBundle\Routing\ResponseContext\JsonLd\JsonLdManager;
+use Contao\CoreBundle\Routing\ResponseContext\ResponseContext;
+use Contao\CoreBundle\Routing\ResponseContext\ResponseContextAccessor;
+use Contao\CoreBundle\Tests\TestCase;
+use Contao\CoreBundle\Twig\Runtime\SchemaOrgRuntime;
+
+class SchemaOrgRuntimeTest extends TestCase
+{
+    public function testAddsSchemaData(): void
+    {
+        $context = new ResponseContext();
+        $manager = new JsonLdManager($context);
+        $context->add($manager);
+
+        $accessor = $this->createMock(ResponseContextAccessor::class);
+        $accessor
+            ->method('getResponseContext')
+            ->willReturn($context)
+        ;
+
+        (new SchemaOrgRuntime($accessor))->add([
+            '@type' => 'ImageObject',
+            'identifier' => 'https://assets.url/files/public/foo.jpg',
+        ]);
+
+        $graph = $manager->getGraphForSchema(JsonLdManager::SCHEMA_ORG)->toArray();
+
+        $this->assertSame([
+            '@context' => 'https://schema.org',
+            '@graph' => [[
+                '@type' => 'ImageObject',
+                '@id' => 'https://assets.url/files/public/foo.jpg',
+            ]],
+        ], $graph);
+    }
+
+    public function testToleratesMissingResponseContext(): void
+    {
+        $accessor = $this->createMock(ResponseContextAccessor::class);
+        $accessor
+            ->expects($this->once())
+            ->method('getResponseContext')
+            ->willReturn(null)
+        ;
+
+        (new SchemaOrgRuntime($accessor))->add(['foo']);
+    }
+
+    public function testToleratesMissingJsonLdManager(): void
+    {
+        $accessor = $this->createMock(ResponseContextAccessor::class);
+        $accessor
+            ->expects($this->once())
+            ->method('getResponseContext')
+            ->willReturn(new ResponseContext())
+        ;
+
+        (new SchemaOrgRuntime($accessor))->add(['foo']);
+    }
+}


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | see https://github.com/contao/contao/pull/3163#issuecomment-875930255
| Docs PR or issue | todo

This refactors the image studio macros to use our new JSON-LD system instead of item* attributes (+ some housekeeping).

I registered the `addSchemaOrg` Twig function in the `ContaoTemplateExtension` extension for now. Note, that this is only temporary. Once #2988 is merged, I'd like to move everything in a single `ContaoExtension`. Having multiple runtimes is a good idea for SOC, but it turned out that multiple extensions doesn't make any sense for our use case (IMHO BC is not relevant in this case).

/cc @Toflar @ausi 
