### PR TITLE
Only warn if the DB server is not running in strict mode

### DIFF
--- a/installation-bundle/src/Controller/InstallationController.php
+++ b/installation-bundle/src/Controller/InstallationController.php
@@ -99,6 +99,8 @@ class InstallationController implements ContainerAwareInterface
 
         $this->runDatabaseUpdates();
 
+        $installTool->checkStrictMode($this->context);
+
         if (null !== ($response = $this->adjustDatabaseTables())) {
             return $response;
         }

--- a/installation-bundle/src/InstallTool.php
+++ b/installation-bundle/src/InstallTool.php
@@ -287,7 +287,7 @@ class InstallTool
     }
 
     /**
-     * Check if strict mode is enabled (see https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html)
+     * Checks if strict mode is enabled (see https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html).
      */
     public function checkStrictMode(array &$context): void
     {

--- a/installation-bundle/src/InstallTool.php
+++ b/installation-bundle/src/InstallTool.php
@@ -231,16 +231,6 @@ class InstallTool
             }
         }
 
-        $mode = $this->connection->fetchOne('SELECT @@sql_mode');
-
-        // Check if strict mode is enabled (see https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html)
-        if (!array_intersect(explode(',', strtoupper($mode)), ['TRADITIONAL', 'STRICT_ALL_TABLES', 'STRICT_TRANS_TABLES'])) {
-            $context['errorCode'] = 7;
-            $context['optionKey'] = $this->connection->getDriver() instanceof MysqliDriver ? 3 : 1002;
-
-            return true;
-        }
-
         // Check if utf8mb4 can be used if the user has configured it
         if (isset($options['engine'], $options['collate']) && 0 === strncmp($options['collate'], 'utf8mb4', 7)) {
             if ('innodb' !== strtolower($options['engine'])) {
@@ -294,6 +284,18 @@ class InstallTool
         }
 
         return false;
+    }
+
+    /**
+     * Check if strict mode is enabled (see https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html)
+     */
+    public function checkStrictMode(array &$context): void
+    {
+        $mode = $this->connection->fetchOne('SELECT @@sql_mode');
+
+        if (!array_intersect(explode(',', strtoupper($mode)), ['TRADITIONAL', 'STRICT_ALL_TABLES', 'STRICT_TRANS_TABLES'])) {
+            $context['option_key'] = $this->connection->getDriver() instanceof MysqliDriver ? 3 : 1002;
+        }
     }
 
     public function handleRunOnce(): void

--- a/installation-bundle/src/InstallTool.php
+++ b/installation-bundle/src/InstallTool.php
@@ -294,7 +294,7 @@ class InstallTool
         $mode = $this->connection->fetchOne('SELECT @@sql_mode');
 
         if (!array_intersect(explode(',', strtoupper($mode)), ['TRADITIONAL', 'STRICT_ALL_TABLES', 'STRICT_TRANS_TABLES'])) {
-            $context['option_key'] = $this->connection->getDriver() instanceof MysqliDriver ? 3 : 1002;
+            $context['optionKey'] = $this->connection->getDriver() instanceof MysqliDriver ? 3 : 1002;
         }
     }
 

--- a/installation-bundle/src/Resources/translations/ContaoInstallationBundle.en.xlf
+++ b/installation-bundle/src/Resources/translations/ContaoInstallationBundle.en.xlf
@@ -267,7 +267,7 @@
         <source>Could not connect to the database using the connection URL found in the &lt;code&gt;DATABASE_URL&lt;/code&gt; environment variable.</source>
       </trans-unit>
       <trans-unit id="89" resname="strict_sql_mode">
-        <source>Your database server does not run in strict mode!</source>
+        <source>Your database server is not running in strict mode!</source>
       </trans-unit>
       <trans-unit id="90" resname="strict_sql_mode_explain">
         <source>Running MySQL in non-strict mode can cause corrupt or truncated data. Please enable the strict mode either in your &lt;code&gt;my.cnf&lt;/code&gt; file or configure the connection options in the &lt;code&gt;config/config.yml&lt;/code&gt; file as follows:</source>

--- a/installation-bundle/src/Resources/views/configuration_error.html.twig
+++ b/installation-bundle/src/Resources/views/configuration_error.html.twig
@@ -63,17 +63,6 @@
 innodb_file_format = Barracuda
 innodb_file_per_table = 1</pre>
       </div>
-    {% elseif errorCode == 7 %}
-        <p class="tl_error">{{ 'strict_sql_mode'|trans }}</p>
-        <p>{{ 'strict_sql_mode_explain'|trans|raw }}</p>
-        <div id="sql_wrapper">
-        <pre>doctrine:
-  dbal:
-    connections:
-      default:
-        options:
-          {{ optionKey }}: "SET SESSION sql_mode=(SELECT CONCAT(@@sql_mode, ',TRADITIONAL'))"</pre>
-        </div>
     {% endif %}
   </fieldset>
 {% endblock %}

--- a/installation-bundle/src/Resources/views/main.html.twig
+++ b/installation-bundle/src/Resources/views/main.html.twig
@@ -2,7 +2,7 @@
 {% trans_default_domain 'ContaoInstallationBundle' %}
 
 {% block main %}
-  {% if option_key is defined %}
+  {% if optionKey is defined %}
     <fieldset class="tl_tbox nolegend">
         <p class="tl_error">{{ 'strict_sql_mode'|trans }}</p>
         <p>{{ 'strict_sql_mode_explain'|trans|raw }}</p>
@@ -12,7 +12,7 @@
     connections:
       default:
         options:
-          {{ option_key }}: "SET SESSION sql_mode=(SELECT CONCAT(@@sql_mode, ',TRADITIONAL'))"</pre>
+          {{ optionKey }}: "SET SESSION sql_mode=(SELECT CONCAT(@@sql_mode, ',TRADITIONAL'))"</pre>
         </div>
     </fieldset>
   {% endif %}

--- a/installation-bundle/src/Resources/views/main.html.twig
+++ b/installation-bundle/src/Resources/views/main.html.twig
@@ -2,6 +2,20 @@
 {% trans_default_domain 'ContaoInstallationBundle' %}
 
 {% block main %}
+  {% if option_key is defined %}
+    <fieldset class="tl_tbox nolegend">
+        <p class="tl_error">{{ 'strict_sql_mode'|trans }}</p>
+        <p>{{ 'strict_sql_mode_explain'|trans|raw }}</p>
+        <div id="sql_wrapper">
+        <pre>doctrine:
+  dbal:
+    connections:
+      default:
+        options:
+          {{ option_key }}: "SET SESSION sql_mode=(SELECT CONCAT(@@sql_mode, ',TRADITIONAL'))"</pre>
+        </div>
+    </fieldset>
+  {% endif %}
   <fieldset class="tl_tbox{% if sql_form is empty and sql_message is empty %} collapsed{% endif %}">
     <legend onclick="this.getParent().toggleClass('collapsed')">{{ 'update_tables'|trans }}</legend>
     <div>

--- a/installation-bundle/tests/InstallToolTest.php
+++ b/installation-bundle/tests/InstallToolTest.php
@@ -28,11 +28,11 @@ class InstallToolTest extends TestCase
      */
     public function testRaisesErrorIfNonRunningInStrictMode(string $sqlMode, AbstractMySQLDriver $driver, int $expectedOptionKey): void
     {
-        $installTool = $this->getInstallTool($sqlMode, $driver);
         $context = [];
 
-        $this->assertTrue($installTool->hasConfigurationError($context));
-        $this->assertSame(7, $context['errorCode']);
+        $installTool = $this->getInstallTool($sqlMode, $driver);
+        $installTool->checkStrictMode($context);
+
         $this->assertSame($expectedOptionKey, $context['optionKey']);
     }
 
@@ -63,10 +63,11 @@ class InstallToolTest extends TestCase
      */
     public function testRunsInStrictMode(string $sqlMode): void
     {
-        $installTool = $this->getInstallTool($sqlMode);
         $context = [];
 
-        $this->assertFalse($installTool->hasConfigurationError($context));
+        $installTool = $this->getInstallTool($sqlMode);
+        $installTool->checkStrictMode($context);
+
         $this->assertEmpty($context);
     }
 


### PR DESCRIPTION
Follow-up on #3151. ATM, we only want to warn if the DB server is not running in strict mode. We might enforce it in a future version.

<img width="788" alt="" src="https://user-images.githubusercontent.com/1192057/125079175-99e37f80-e0c3-11eb-84a5-255c703cf9ce.png">
