### PR TITLE
Exclude the migrations from coverage

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -45,6 +45,8 @@
                 <directory>./faq-bundle/src/Resources</directory>
                 <directory>./manager-bundle/src/Resources</directory>
                 <directory>./news-bundle/src/Resources</directory>
+                <!-- exclude migrations as we do not require to test them -->
+                <directory>./core-bundle/src/Migration/Version*</directory>
                 <!-- exclude files with symbols and side-effects -->
                 <file>./core-bundle/src/EventListener/UserAwareTrait.php</file>
                 <file>./core-bundle/src/Exception/ServiceUnavailableException.php</file>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -46,7 +46,7 @@
                 <directory>./manager-bundle/src/Resources</directory>
                 <directory>./news-bundle/src/Resources</directory>
                 <!-- exclude migrations as we do not require to test them -->
-                <directory>./core-bundle/src/Migration/Version*</directory>
+                <directory>./*-bundle/src/Migration/Version*</directory>
                 <!-- exclude files with symbols and side-effects -->
                 <file>./core-bundle/src/EventListener/UserAwareTrait.php</file>
                 <file>./core-bundle/src/Exception/ServiceUnavailableException.php</file>


### PR DESCRIPTION
We do not require writing unit tests for migrations, because unit tests that only check if the SQL queries are passed as arguments are pointless. If a migration is more complex than just checking if a table and column exist, we **can** still add unit tests (we also have two migration test classes) but thanks to this change, we no longer **have to** add pointless test classes.