### PR TITLE
Backport support for namespaced DC drivers

### DIFF
--- a/core-bundle/src/Resources/contao/classes/Backend.php
+++ b/core-bundle/src/Resources/contao/classes/Backend.php
@@ -405,7 +405,7 @@ abstract class Backend extends Controller
 				trigger_error('Could not create a data container object', E_USER_ERROR);
 			}
 
-			$dataContainer = 'DC_' . $GLOBALS['TL_DCA'][$strTable]['config']['dataContainer'];
+			$dataContainer = DataContainer::getDriverForTable($strTable);
 
 			/** @var DataContainer $dc */
 			$dc = new $dataContainer($strTable, $arrModule);

--- a/core-bundle/src/Resources/contao/classes/DataContainer.php
+++ b/core-bundle/src/Resources/contao/classes/DataContainer.php
@@ -1414,6 +1414,25 @@ abstract class DataContainer extends Backend
 	 * @throws \Exception
 	 */
 	abstract protected function save($varValue);
+
+	/**
+	 * Return the class name of the DataContainer driver for the given table.
+	 *
+	 * @param string $table
+	 *
+	 * @return string
+	 */
+	public static function getDriverForTable(string $table): string
+	{
+		$dataContainer = $GLOBALS['TL_DCA'][$table]['config']['dataContainer'];
+
+		if (false === strpos($dataContainer, '\\'))
+		{
+			$dataContainer = 'DC_' . $dataContainer;
+		}
+
+		return $dataContainer;
+	}
 }
 
 class_alias(DataContainer::class, 'DataContainer');

--- a/core-bundle/src/Resources/contao/controllers/BackendFile.php
+++ b/core-bundle/src/Resources/contao/controllers/BackendFile.php
@@ -77,7 +77,7 @@ class BackendFile extends Backend
 		\define('CURRENT_ID', (Input::get('table') ? $objSession->get('CURRENT_ID') : Input::get('id')));
 
 		$this->loadDataContainer($strTable);
-		$strDriver = 'DC_' . $GLOBALS['TL_DCA'][$strTable]['config']['dataContainer'];
+		$strDriver = DataContainer::getDriverForTable($strTable);
 		$objDca = new $strDriver($strTable);
 		$objDca->field = $strField;
 

--- a/core-bundle/src/Resources/contao/controllers/BackendPage.php
+++ b/core-bundle/src/Resources/contao/controllers/BackendPage.php
@@ -77,7 +77,7 @@ class BackendPage extends Backend
 		\define('CURRENT_ID', (Input::get('table') ? $objSession->get('CURRENT_ID') : Input::get('id')));
 
 		$this->loadDataContainer($strTable);
-		$strDriver = 'DC_' . $GLOBALS['TL_DCA'][$strTable]['config']['dataContainer'];
+		$strDriver = DataContainer::getDriverForTable($strTable);
 		$objDca = new $strDriver($strTable);
 		$objDca->field = $strField;
 

--- a/core-bundle/src/Resources/contao/widgets/Picker.php
+++ b/core-bundle/src/Resources/contao/widgets/Picker.php
@@ -245,7 +245,7 @@ class Picker extends Widget
 
 			if ($objRows->numRows)
 			{
-				$dataContainer = 'DC_' . $GLOBALS['TL_DCA'][$strRelatedTable]['config']['dataContainer'];
+				$dataContainer = DataContainer::getDriverForTable($strRelatedTable);
 				$dc = new $dataContainer($strRelatedTable);
 
 				while ($objRows->next())


### PR DESCRIPTION
This backports the support for namespaced DC drivers to the current LTS (4.9) as discussed in https://github.com/contao/contao/pull/2706 - in order to make it possible to implement a DC driver while adhering to modern coding standards, without resorting to workarounds.