### PR TITLE
Allow mocking final classes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -153,6 +153,7 @@
         "bamarni/composer-bin-plugin": "^1.4",
         "composer/composer": "^1.0 || ^2.0",
         "contao/test-case": "^4.4",
+        "nunomaduro/mock-final-classes": "^1.0",
         "phpunit/phpunit": "^8.5",
         "symfony/browser-kit": "4.4.* || 5.2.*",
         "symfony/phpunit-bridge": "^5.2"

--- a/core-bundle/composer.json
+++ b/core-bundle/composer.json
@@ -126,6 +126,7 @@
         "contao/maintenance-bundle-deprecated": "^2.1.5",
         "contao/manager-plugin": "^2.3.1",
         "contao/test-case": "^4.4",
+        "nunomaduro/mock-final-classes": "^1.0",
         "phpunit/phpunit": "^8.5",
         "symfony/browser-kit": "4.4.* || 5.2.*",
         "symfony/http-client": "4.4.* || 5.2.*",


### PR DESCRIPTION
@m-vo and I have discussed the `@final` annotation here https://github.com/contao/contao/pull/3182/files#r667789346, because the class needs to be mocked and therefore cannot be `final` anymore. This PR solves the problem by using [nunomaduro/mock-final-classes](https://github.com/nunomaduro/mock-final-classes), which is based on [dg/bypass-finals](https://github.com/dg/bypass-finals) and simply removes the `final` keyword before running the unit tests.

This would not only solve the `@final` problem but also allow us to declare many of our `@internal` classes (such as listeners etc.) as `final`. @contao/developers WDYT?