### PR TITLE
Do not prefix our JSON-LD context

### DIFF
--- a/core-bundle/src/Routing/ResponseContext/JsonLd/ContaoPageSchema.php
+++ b/core-bundle/src/Routing/ResponseContext/JsonLd/ContaoPageSchema.php
@@ -18,48 +18,18 @@ use Spatie\SchemaOrg\BaseType;
 class ContaoPageSchema extends BaseType
 {
     /**
-     * @var string
-     */
-    private $title;
-
-    /**
-     * @var int
-     */
-    private $pageId;
-
-    /**
-     * @var bool
-     */
-    private $noSearch;
-
-    /**
-     * @var bool
-     */
-    private $protected;
-
-    /**
-     * @var array<int>
-     */
-    private $groups;
-
-    /**
-     * @var bool
-     */
-    private $fePreview;
-
-    /**
      * ContaoPageSchema constructor.
      *
      * @param array<int> $groups
      */
     public function __construct(string $title, int $pageId, bool $noSearch, bool $protected, array $groups, bool $fePreview)
     {
-        $this->title = $title;
-        $this->pageId = $pageId;
-        $this->noSearch = $noSearch;
-        $this->protected = $protected;
-        $this->groups = $groups;
-        $this->fePreview = $fePreview;
+        $this->setTitle($title);
+        $this->setPageId($pageId);
+        $this->setNoSearch($noSearch);
+        $this->setProtected($protected);
+        $this->setGroups($groups);
+        $this->setFePreview($fePreview);
     }
 
     public function getContext(): string
@@ -72,62 +42,50 @@ class ContaoPageSchema extends BaseType
         return 'Page';
     }
 
-    public function toArray(): array
-    {
-        $this->setProperty('title', $this->title);
-        $this->setProperty('pageId', $this->pageId);
-        $this->setProperty('noSearch', $this->noSearch);
-        $this->setProperty('protected', $this->protected);
-        $this->setProperty('groups', $this->groups);
-        $this->setProperty('fePreview', $this->fePreview);
-
-        return parent::toArray();
-    }
-
     public function getTitle(): string
     {
-        return $this->title;
+        return $this->properties['title'];
     }
 
     public function setTitle(string $title): self
     {
-        $this->title = $title;
+        $this->properties['title'] = $title;
 
         return $this;
     }
 
     public function getPageId(): int
     {
-        return $this->pageId;
+        return $this->properties['pageId'];
     }
 
     public function setPageId(int $pageId): self
     {
-        $this->pageId = $pageId;
+        $this->properties['pageId'] = $pageId;
 
         return $this;
     }
 
     public function isNoSearch(): bool
     {
-        return $this->noSearch;
+        return $this->properties['noSearch'];
     }
 
     public function setNoSearch(bool $noSearch): self
     {
-        $this->noSearch = $noSearch;
+        $this->properties['noSearch'] = $noSearch;
 
         return $this;
     }
 
     public function isProtected(): bool
     {
-        return $this->protected;
+        return $this->properties['protected'];
     }
 
     public function setProtected(bool $protected): self
     {
-        $this->protected = $protected;
+        $this->properties['protected'] = $protected;
 
         return $this;
     }
@@ -137,7 +95,7 @@ class ContaoPageSchema extends BaseType
      */
     public function getGroups(): array
     {
-        return $this->groups;
+        return $this->properties['groups'];
     }
 
     /**
@@ -145,19 +103,19 @@ class ContaoPageSchema extends BaseType
      */
     public function setGroups(array $groups): self
     {
-        $this->groups = $groups;
+        $this->properties['groups'] = array_map('intval', $groups);
 
         return $this;
     }
 
     public function isFePreview(): bool
     {
-        return $this->fePreview;
+        return $this->properties['fePreview'];
     }
 
     public function setFePreview(bool $fePreview): self
     {
-        $this->fePreview = $fePreview;
+        $this->properties['fePreview'] = $fePreview;
 
         return $this;
     }

--- a/core-bundle/src/Routing/ResponseContext/JsonLd/ContaoPageSchema.php
+++ b/core-bundle/src/Routing/ResponseContext/JsonLd/ContaoPageSchema.php
@@ -69,22 +69,19 @@ class ContaoPageSchema extends BaseType
 
     public function getType(): string
     {
-        return 'contao:Page';
+        return 'Page';
     }
 
     public function toArray(): array
     {
-        $this->setProperty('contao:title', $this->title);
-        $this->setProperty('contao:pageId', $this->pageId);
-        $this->setProperty('contao:noSearch', $this->noSearch);
-        $this->setProperty('contao:protected', $this->protected);
-        $this->setProperty('contao:groups', $this->groups);
-        $this->setProperty('contao:fePreview', $this->fePreview);
+        $this->setProperty('title', $this->title);
+        $this->setProperty('pageId', $this->pageId);
+        $this->setProperty('noSearch', $this->noSearch);
+        $this->setProperty('protected', $this->protected);
+        $this->setProperty('groups', $this->groups);
+        $this->setProperty('fePreview', $this->fePreview);
 
-        $data = parent::toArray();
-        $data['@context'] = ['contao' => $data['@context']];
-
-        return $data;
+        return parent::toArray();
     }
 
     public function getTitle(): string

--- a/core-bundle/tests/Routing/ResponseContext/CoreResponseContextFactoryTest.php
+++ b/core-bundle/tests/Routing/ResponseContext/CoreResponseContextFactoryTest.php
@@ -120,16 +120,14 @@ class CoreResponseContextFactoryTest extends ContaoTestCase
 
         $this->assertSame(
             [
-                '@context' => [
-                    'contao' => 'https://schema.contao.org/',
-                ],
-                '@type' => 'contao:Page',
-                'contao:title' => 'My title',
-                'contao:pageId' => 0,
-                'contao:noSearch' => false,
-                'contao:protected' => false,
-                'contao:groups' => [],
-                'contao:fePreview' => false,
+                '@context' => 'https://schema.contao.org/',
+                '@type' => 'Page',
+                'title' => 'My title',
+                'pageId' => 0,
+                'noSearch' => false,
+                'protected' => false,
+                'groups' => [],
+                'fePreview' => false,
             ],
             $jsonLdManager->getGraphForSchema(JsonLdManager::SCHEMA_CONTAO)->get(ContaoPageSchema::class)->toArray()
         );
@@ -160,16 +158,14 @@ class CoreResponseContextFactoryTest extends ContaoTestCase
 
         $this->assertSame(
             [
-                '@context' => [
-                    'contao' => 'https://schema.contao.org/',
-                ],
-                '@type' => 'contao:Page',
-                'contao:title' => 'We went from Alpha > Omega',
-                'contao:pageId' => 0,
-                'contao:noSearch' => false,
-                'contao:protected' => false,
-                'contao:groups' => [],
-                'contao:fePreview' => false,
+                '@context' => 'https://schema.contao.org/',
+                '@type' => 'Page',
+                'title' => 'We went from Alpha > Omega',
+                'pageId' => 0,
+                'noSearch' => false,
+                'protected' => false,
+                'groups' => [],
+                'fePreview' => false,
             ],
             $jsonLdManager->getGraphForSchema(JsonLdManager::SCHEMA_CONTAO)->get(ContaoPageSchema::class)->toArray()
         );

--- a/core-bundle/tests/Search/DocumentTest.php
+++ b/core-bundle/tests/Search/DocumentTest.php
@@ -120,6 +120,16 @@ class DocumentTest extends TestCase
             ],
         ];
 
+        yield 'Test with one valid json ld element with context' => [
+            '<html><body><script type="application/ld+json">{"@context":"https:\/\/contao.org\/","@type":"Page","foobar":true}</script></body></html>',
+            [
+                [
+                    '@type' => 'Page',
+                    'foobar' => true,
+                ],
+            ],
+        ];
+
         yield 'Test with one valid json ld element with context prefix' => [
             '<html><body><script type="application/ld+json">{"@context":{"contao":"https:\/\/contao.org\/"},"@type":"contao:Page","contao:foobar":true}</script></body></html>',
             [
@@ -166,6 +176,23 @@ class DocumentTest extends TestCase
         ];
 
         yield 'Test with no context filter provided' => [
+            '<html><body><script type="application/ld+json">{"@context":"https:\/\/schema.contao.org\/","@type":"Page","title":"Welcome to the official Contao Demo Site","pageId":2,"noSearch":false,"protected":false,"groups":[],"fePreview":false}</script></body></html>',
+            [
+                [
+                    '@context' => 'https://schema.contao.org/',
+                    '@type' => 'https://schema.contao.org/Page',
+                    'https://schema.contao.org/title' => 'Welcome to the official Contao Demo Site',
+                    'https://schema.contao.org/pageId' => 2,
+                    'https://schema.contao.org/noSearch' => false,
+                    'https://schema.contao.org/protected' => false,
+                    'https://schema.contao.org/groups' => [],
+                    'https://schema.contao.org/fePreview' => false,
+                ],
+            ],
+            '',
+        ];
+
+        yield 'Test with no context filter provided prefix context' => [
             '<html><body><script type="application/ld+json">{"@context":{"contao":"https:\/\/schema.contao.org\/"},"@type":"contao:Page","contao:title":"Welcome to the official Contao Demo Site","contao:pageId":2,"contao:noSearch":false,"contao:protected":false,"contao:groups":[],"contao:fePreview":false}</script></body></html>',
             [
                 [

--- a/core-bundle/tests/Search/Indexer/DefaultIndexerTest.php
+++ b/core-bundle/tests/Search/Indexer/DefaultIndexerTest.php
@@ -102,10 +102,10 @@ class DefaultIndexerTest extends ContaoTestCase
         ];
 
         yield 'Test valid index when not protected' => [
-            new Document(new Uri('https://example.com/valid'), 200, [], '<html><body><script type="application/ld+json">{"@context":{"contao":"https:\/\/schema.contao.org\/"},"@type":"contao:Page","contao:pageId":2,"contao:noSearch":false,"contao:protected":false,"contao:groups":[],"contao:fePreview":false}</script></body></html>'),
+            new Document(new Uri('https://example.com/valid'), 200, [], '<html><body><script type="application/ld+json">{"@context":"https:\/\/schema.contao.org\/","@type":"Page","pageId":2,"noSearch":false,"protected":false,"groups":[],"fePreview":false}</script></body></html>'),
             [
                 'url' => 'https://example.com/valid',
-                'content' => '<html><body><script type="application/ld+json">{"@context":{"contao":"https:\/\/schema.contao.org\/"},"@type":"contao:Page","contao:pageId":2,"contao:noSearch":false,"contao:protected":false,"contao:groups":[],"contao:fePreview":false}</script></body></html>',
+                'content' => '<html><body><script type="application/ld+json">{"@context":"https:\/\/schema.contao.org\/","@type":"Page","pageId":2,"noSearch":false,"protected":false,"groups":[],"fePreview":false}</script></body></html>',
                 'protected' => '',
                 'groups' => [],
                 'pid' => 2,
@@ -113,7 +113,7 @@ class DefaultIndexerTest extends ContaoTestCase
                 'language' => 'en',
                 'meta' => [
                     [
-                        '@context' => ['contao' => 'https://schema.contao.org/'],
+                        '@context' => 'https://schema.contao.org/',
                         '@type' => 'https://schema.contao.org/Page',
                         'https://schema.contao.org/pageId' => 2,
                         'https://schema.contao.org/noSearch' => false,


### PR DESCRIPTION
With the answer from https://github.com/schemaorg/schemaorg/issues/2921#issuecomment-879817283 it should be safe now to use the “correct” `@context` format for our own json-ld data.