### PR TITLE
Support multiple JSON+LD objects in the search document

### DIFF
--- a/core-bundle/src/Search/Document.php
+++ b/core-bundle/src/Search/Document.php
@@ -156,7 +156,7 @@ class Document
             foreach ($jsonLdItems as $jsonLdItem) {
                 if (\is_array($graphs = $jsonLdItem['@graph'] ?? null)) {
                     foreach ($graphs as $graph) {
-                        $this->jsonLds[] = array_merge(['@context' => $jsonLdItem['@context']], $graph);
+                        $this->jsonLds[] = array_merge(array_diff_key($jsonLdItem, ['@graph' => null]), $graph);
                     }
                 } else {
                     $this->jsonLds[] = $jsonLdItem;

--- a/core-bundle/src/Search/Document.php
+++ b/core-bundle/src/Search/Document.php
@@ -154,7 +154,7 @@ class Document
 
             // Parsed the grouped values under the @graph within the same context
             foreach ($jsonLdItems as $jsonLdItem) {
-                if (isset($jsonLdItem['@graph']) && is_array($jsonLdItem['@graph'])) {
+                if (isset($jsonLdItem['@graph']) && \is_array($jsonLdItem['@graph'])) {
                     foreach ($jsonLdItem['@graph'] as $graph) {
                         $this->jsonLds[] = array_merge(['@context' => $jsonLdItem['@context']], $graph);
                     }

--- a/core-bundle/src/Search/Document.php
+++ b/core-bundle/src/Search/Document.php
@@ -154,8 +154,8 @@ class Document
 
             // Parsed the grouped values under the @graph within the same context
             foreach ($jsonLdItems as $jsonLdItem) {
-                if (isset($jsonLdItem['@graph']) && \is_array($jsonLdItem['@graph'])) {
-                    foreach ($jsonLdItem['@graph'] as $graph) {
+                if (\is_array($graphs = $jsonLdItem['@graph'] ?? null)) {
+                    foreach ($graphs as $graph) {
                         $this->jsonLds[] = array_merge(['@context' => $jsonLdItem['@context']], $graph);
                     }
                 } else {

--- a/core-bundle/tests/Search/DocumentTest.php
+++ b/core-bundle/tests/Search/DocumentTest.php
@@ -144,6 +144,38 @@ class DocumentTest extends TestCase
             ],
         ];
 
+        yield 'Test with two valid json ld elements combined in one script tag' => [
+            '<html><body><script type="application/ld+json">[{"@context":"https:\/\/contao.org\/","@type":"Page","foobar":true},{"@context":"https:\/\/contao.org\/","@type":"Page","foobar":false}]</script></body></html>',
+            [
+                [
+                    '@type' => 'Page',
+                    'foobar' => true,
+                ],
+                [
+                    '@type' => 'Page',
+                    'foobar' => false,
+                ],
+            ],
+        ];
+
+        yield 'Test with two valid json ld elements combined in one script tag and one extra json ld element in a separate script tag' => [
+            '<html><body><script type="application/ld+json">[{"@context":"https:\/\/contao.org\/","@type":"Page","foobar":true},{"@context":"https:\/\/contao.org\/","@type":"Page","foobar":false}]</script><script type="application/ld+json">{"@context":"https:\/\/contao.org\/","@type":"Page","foobar":null}</script></body></html>',
+            [
+                [
+                    '@type' => 'Page',
+                    'foobar' => true,
+                ],
+                [
+                    '@type' => 'Page',
+                    'foobar' => false,
+                ],
+                [
+                    '@type' => 'Page',
+                    'foobar' => null,
+                ],
+            ],
+        ];
+
         yield 'Test with one valid and one invalid json ld element' => [
             '<html><body><script type="application/ld+json">{"@context":"https:\/\/contao.org\/","@type":"Page","foobar":true}</script><script type="application/ld+json">{"@context":"https:\/\/contao.org\/", ...</script></body></html>',
             [

--- a/core-bundle/tests/Search/DocumentTest.php
+++ b/core-bundle/tests/Search/DocumentTest.php
@@ -158,6 +158,24 @@ class DocumentTest extends TestCase
             ],
         ];
 
+        yield 'Test with two valid json ld elements combined in one script tag with @graph property' => [
+            '<html><body><script type="application/ld+json">[{"@context":"https:\/\/contao.org\/","@graph":[{"@type":"Page","foobar":true}]},{"@context":"https:\/\/contao.org\/","@graph":[{"@type":"Page","foobar":false},{"@type":"Article","foobar":null}]}]</script></body></html>',
+            [
+                [
+                    '@type' => 'Page',
+                    'foobar' => true,
+                ],
+                [
+                    '@type' => 'Page',
+                    'foobar' => false,
+                ],
+                [
+                    '@type' => 'Article',
+                    'foobar' => null,
+                ],
+            ],
+        ];
+
         yield 'Test with two valid json ld elements combined in one script tag and one extra json ld element in a separate script tag' => [
             '<html><body><script type="application/ld+json">[{"@context":"https:\/\/contao.org\/","@type":"Page","foobar":true},{"@context":"https:\/\/contao.org\/","@type":"Page","foobar":false}]</script><script type="application/ld+json">{"@context":"https:\/\/contao.org\/","@type":"Page","foobar":null}</script></body></html>',
             [


### PR DESCRIPTION
The search document does not seem to properly extract the linked data from `<script>` tags that contain multiple JSON+LD elements:

```html
<script type="application/ld+json">
[
    {
        "@context": "https:\/\/contao.org\/",
        "@type": "Page",
        "foobar": true
    },
    {
        "@context": "https:\/\/contao.org\/",
        "@type": "Page",
        "foobar": false
    }
]
</script>
```

/cc @Toflar 