### PR TITLE
Allow defining entities alongside DCA definitions

### DIFF
--- a/core-bundle/src/Doctrine/Schema/DcaSchemaProvider.php
+++ b/core-bundle/src/Doctrine/Schema/DcaSchemaProvider.php
@@ -62,7 +62,7 @@ class DcaSchemaProvider
         $config = $this->getSqlDefinitions();
 
         foreach ($config as $tableName => $definitions) {
-            $table = $schema->createTable($tableName);
+            $table = $schema->hasTable($tableName) ? $schema->getTable($tableName) : $schema->createTable($tableName);
 
             // Parse the table options first
             if (isset($definitions['TABLE_OPTIONS'])) {
@@ -82,6 +82,10 @@ class DcaSchemaProvider
 
             if (isset($definitions['SCHEMA_FIELDS'])) {
                 foreach ($definitions['SCHEMA_FIELDS'] as $fieldName => $config) {
+                    if ($table->hasColumn($fieldName)) {
+                        continue;
+                    }
+
                     $options = $config;
                     unset($options['name'], $options['type']);
 
@@ -96,12 +100,20 @@ class DcaSchemaProvider
 
             if (isset($definitions['TABLE_FIELDS'])) {
                 foreach ($definitions['TABLE_FIELDS'] as $fieldName => $sql) {
+                    if ($table->hasColumn($fieldName)) {
+                        continue;
+                    }
+
                     $this->parseColumnSql($table, $fieldName, substr($sql, \strlen($fieldName) + 3));
                 }
             }
 
             if (isset($definitions['TABLE_CREATE_DEFINITIONS'])) {
                 foreach ($definitions['TABLE_CREATE_DEFINITIONS'] as $keyName => $sql) {
+                    if ($table->hasIndex($keyName)) {
+                        continue;
+                    }
+
                     $this->parseIndexSql($table, $keyName, strtolower($sql));
                 }
             }

--- a/core-bundle/tests/Doctrine/Schema/DcaSchemaProviderTest.php
+++ b/core-bundle/tests/Doctrine/Schema/DcaSchemaProviderTest.php
@@ -17,7 +17,9 @@ use Contao\CoreBundle\Tests\Doctrine\DoctrineTestCase;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\MySqlPlatform;
 use Doctrine\DBAL\Statement;
+use Doctrine\ORM\Mapping\Builder\ClassMetadataBuilder;
 use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Tools\SchemaTool;
 
 class DcaSchemaProviderTest extends DoctrineTestCase
 {
@@ -719,5 +721,51 @@ class DcaSchemaProviderTest extends DoctrineTestCase
         $schema = $provider->createSchema();
 
         $this->assertCount(0, $schema->getTables());
+    }
+
+    public function testAppendsSchemaIgnoresExistingMetadataDefinitions(): void
+    {
+        $dcaMetadata = [
+            'tl_page' => [
+                'TABLE_FIELDS' => [
+                    'id' => '`id` int(10) NOT NULL default 0',
+                    'title' => "`title` varchar(128) BINARY NOT NULL default ''",
+                ],
+                'SCHEMA_FIELDS' => [
+                    'published' => ['type' => 'string', 'fixed' => true, 'length' => 1],
+                ],
+                'TABLE_CREATE_DEFINITIONS' => [
+                    'published' => 'KEY `title` (`published`)',
+                ]
+            ],
+        ];
+
+        $entityMetadata = new ClassMetadata('Page');
+        (new ClassMetadataBuilder($entityMetadata))
+            ->setTable('tl_page')
+            ->addField('id', 'integer')
+            ->addField('published', 'boolean')
+            ->addField('bar', 'string')
+            ->addIndex(['published'], 'published')
+        ;
+
+        $registry = $this->mockDoctrineRegistryWithOrm([$entityMetadata]);
+        $manager = $registry->getManager();
+        $schema = (new SchemaTool($manager))->getSchemaFromMetadata($manager->getMetadataFactory()->getAllMetadata());
+
+        $provider = new DcaSchemaProvider(
+            $this->mockContaoFrameworkWithInstaller($dcaMetadata),
+            $registry
+        );
+
+        $provider->appendToSchema($schema);
+
+        $columns = $schema->getTable('tl_page')->getColumns();
+
+        $this->assertCount(4, $columns);
+        $this->assertSame('integer', $columns['id']->getType()->getName());
+        $this->assertSame('boolean', $columns['published']->getType()->getName());
+        $this->assertSame('string', $columns['bar']->getType()->getName());
+        $this->assertSame('string', $columns['title']->getType()->getName());
     }
 }

--- a/core-bundle/tests/Doctrine/Schema/DcaSchemaProviderTest.php
+++ b/core-bundle/tests/Doctrine/Schema/DcaSchemaProviderTest.php
@@ -736,7 +736,7 @@ class DcaSchemaProviderTest extends DoctrineTestCase
                 ],
                 'TABLE_CREATE_DEFINITIONS' => [
                     'published' => 'KEY `title` (`published`)',
-                ]
+                ],
             ],
         ];
 

--- a/core-bundle/tests/Doctrine/Schema/DcaSchemaProviderTest.php
+++ b/core-bundle/tests/Doctrine/Schema/DcaSchemaProviderTest.php
@@ -723,7 +723,7 @@ class DcaSchemaProviderTest extends DoctrineTestCase
         $this->assertCount(0, $schema->getTables());
     }
 
-    public function testAppendsSchemaIgnoresExistingMetadataDefinitions(): void
+    public function testAppendToSchemaIgnoresExistingMetadataDefinitions(): void
     {
         $dcaMetadata = [
             'tl_page' => [
@@ -741,6 +741,7 @@ class DcaSchemaProviderTest extends DoctrineTestCase
         ];
 
         $entityMetadata = new ClassMetadata('Page');
+
         (new ClassMetadataBuilder($entityMetadata))
             ->setTable('tl_page')
             ->addField('id', 'integer')
@@ -753,11 +754,7 @@ class DcaSchemaProviderTest extends DoctrineTestCase
         $manager = $registry->getManager();
         $schema = (new SchemaTool($manager))->getSchemaFromMetadata($manager->getMetadataFactory()->getAllMetadata());
 
-        $provider = new DcaSchemaProvider(
-            $this->mockContaoFrameworkWithInstaller($dcaMetadata),
-            $registry
-        );
-
+        $provider = new DcaSchemaProvider($this->mockContaoFrameworkWithInstaller($dcaMetadata), $registry);
         $provider->appendToSchema($schema);
 
         $columns = $schema->getTable('tl_page')->getColumns();


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes -
| Docs PR or issue | -

If you've got an existing DCA (like `tl_page`) you should be able to create a `Page` entity as well. E.g. to define relations to other entities in your application. IMHO the entity definitions should be preferred and DCA fields added if the respective column does not yet exist.

I'll add tests if we're fine with this change.

/cc @bytehead 