### PR TITLE
Only create proxy templates for '@Contao' namespaced templates

### DIFF
--- a/core-bundle/src/Twig/ContaoTwigUtil.php
+++ b/core-bundle/src/Twig/ContaoTwigUtil.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Twig;
+
+use Webmozart\PathUtil\Path;
+
+/**
+ * @experimental
+ */
+final class ContaoTwigUtil
+{
+    /**
+     * Split a Contao name into [namespace, short name]. The short name part
+     * will be null if $name is only a namespace.
+     *
+     * If parsing fails - i.e. if the given name does not describe a "Contao"
+     * or "Contao_*" namespace - null is returned instead.
+     */
+    public static function parseContaoName(string $logicalNameOrNamespace): ?array
+    {
+        if (1 === preg_match('%^@(Contao(?:_[a-zA-Z0-9_-]+)?)(?:/(.*))?$%', $logicalNameOrNamespace, $matches)) {
+            return [$matches[1], $matches[2] ?? null];
+        }
+
+        return null;
+    }
+
+    /**
+     * Get the template identifier (= name without namespace or file extension).
+     */
+    public static function getIdentifier(string $name): string
+    {
+        return preg_replace('%(?:.*/)?(.*)(\.html5|\.html\.twig)%', '$1', $name);
+    }
+
+    /**
+     * Returns true if a given template name is a legacy Contao template
+     * (= from a "Contao" of "Contao_*" namespace and with a ".html5" file
+     * extension).
+     */
+    public static function isLegacyTemplate(string $logicalName): bool
+    {
+        if (null === $parts = self::parseContaoName($logicalName)) {
+            return false;
+        }
+
+        return 'html5' === Path::getExtension($parts[1] ?? '', true);
+    }
+}

--- a/core-bundle/src/Twig/ContaoTwigUtil.php
+++ b/core-bundle/src/Twig/ContaoTwigUtil.php
@@ -20,7 +20,7 @@ use Webmozart\PathUtil\Path;
 final class ContaoTwigUtil
 {
     /**
-     * Split a Contao name into [namespace, short name]. The short name part
+     * Splits a Contao name into [namespace, short name]. The short name part
      * will be null if $name is only a namespace.
      *
      * If parsing fails - i.e. if the given name does not describe a "Contao"
@@ -36,7 +36,7 @@ final class ContaoTwigUtil
     }
 
     /**
-     * Get the template identifier (= name without namespace or file extension).
+     * Returns the template name without namespace and file extension.
      */
     public static function getIdentifier(string $name): string
     {
@@ -44,9 +44,8 @@ final class ContaoTwigUtil
     }
 
     /**
-     * Returns true if a given template name is a legacy Contao template
-     * (= from a "Contao" of "Contao_*" namespace and with a ".html5" file
-     * extension).
+     * Returns true if a given template name is a legacy Contao template from a
+     * "Contao" or "Contao_*" namespace and with a ".html5" file extension.
      */
     public static function isLegacyTemplate(string $logicalName): bool
     {

--- a/core-bundle/src/Twig/Inheritance/DynamicExtendsTokenParser.php
+++ b/core-bundle/src/Twig/Inheritance/DynamicExtendsTokenParser.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Twig\Inheritance;
 
+use Contao\CoreBundle\Twig\ContaoTwigUtil;
 use Twig\Error\SyntaxError;
 use Twig\Node\Node;
 use Twig\Token;
@@ -73,12 +74,14 @@ final class DynamicExtendsTokenParser extends AbstractTokenParser
         TokenParserHelper::traverseConstantExpressions(
             $expr,
             function (Node $node) use ($stream): void {
-                if (null === ($shortName = TokenParserHelper::getContaoTemplate($node->getAttribute('value')))) {
+                $parts = ContaoTwigUtil::parseContaoName($node->getAttribute('value'));
+
+                if ('Contao' !== ($parts[0] ?? null)) {
                     return;
                 }
 
                 $sourcePath = $stream->getSourceContext()->getPath();
-                $parentName = $this->hierarchy->getDynamicParent($shortName, $sourcePath);
+                $parentName = $this->hierarchy->getDynamicParent($parts[1] ?? '', $sourcePath);
 
                 // Adjust parent template according to the template hierarchy
                 $node->setAttribute('value', $parentName);

--- a/core-bundle/src/Twig/Inheritance/DynamicIncludeTokenParser.php
+++ b/core-bundle/src/Twig/Inheritance/DynamicIncludeTokenParser.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Twig\Inheritance;
 
+use Contao\CoreBundle\Twig\ContaoTwigUtil;
 use Twig\Node\IncludeNode;
 use Twig\Node\Node;
 use Twig\Token;
@@ -51,12 +52,14 @@ final class DynamicIncludeTokenParser extends IncludeTokenParser
      */
     public static function adjustTemplateName(string $name, TemplateHierarchyInterface $hierarchy): string
     {
-        if (null === ($shortNameOrIdentifier = TokenParserHelper::getContaoTemplate($name))) {
+        $parts = ContaoTwigUtil::parseContaoName($name);
+
+        if ('Contao' !== ($parts[0] ?? null)) {
             return $name;
         }
 
         try {
-            return $hierarchy->getFirst($shortNameOrIdentifier);
+            return $hierarchy->getFirst($parts[1] ?? '');
         } catch (\LogicException $e) {
             throw new \LogicException($e->getMessage().' Did you try to include a non-existent template or a template from a theme directory?', 0, $e);
         }

--- a/core-bundle/src/Twig/Inheritance/TokenParserHelper.php
+++ b/core-bundle/src/Twig/Inheritance/TokenParserHelper.php
@@ -32,13 +32,4 @@ final class TokenParserHelper
             self::traverseConstantExpressions($child, $onEnter);
         }
     }
-
-    public static function getContaoTemplate(string $name): ?string
-    {
-        if (1 !== preg_match('%^@Contao/(.*)%', $name, $matches)) {
-            return null;
-        }
-
-        return $matches[1];
-    }
 }

--- a/core-bundle/src/Twig/Interop/PhpTemplateProxyNodeVisitor.php
+++ b/core-bundle/src/Twig/Interop/PhpTemplateProxyNodeVisitor.php
@@ -65,6 +65,11 @@ final class PhpTemplateProxyNodeVisitor extends AbstractNodeVisitor
         $blockNodes = [];
 
         foreach (explode("\n", $node->getSourceContext()->getCode()) as $name) {
+            // Sanity check for valid block names
+            if (1 !== preg_match('/^[a-z0-9_-]+$/i', $name)) {
+                continue;
+            }
+
             $blockNodes[$name] = new BlockNode($name, new TextNode('[[TL_PARENT]]', 0), 0);
         }
 

--- a/core-bundle/src/Twig/Interop/PhpTemplateProxyNodeVisitor.php
+++ b/core-bundle/src/Twig/Interop/PhpTemplateProxyNodeVisitor.php
@@ -12,13 +12,13 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Twig\Interop;
 
+use Contao\CoreBundle\Twig\ContaoTwigUtil;
 use Twig\Environment;
 use Twig\Node\BlockNode;
 use Twig\Node\ModuleNode;
 use Twig\Node\Node;
 use Twig\Node\TextNode;
 use Twig\NodeVisitor\AbstractNodeVisitor;
-use Webmozart\PathUtil\Path;
 
 /**
  * @experimental
@@ -47,7 +47,7 @@ final class PhpTemplateProxyNodeVisitor extends AbstractNodeVisitor
 
     protected function doLeaveNode(Node $node, Environment $env): Node
     {
-        if ($node instanceof ModuleNode && 'html5' === Path::getExtension($node->getTemplateName(), true)) {
+        if ($node instanceof ModuleNode && ContaoTwigUtil::isLegacyTemplate($node->getTemplateName() ?? '')) {
             $this->configurePhpTemplateProxy($node);
         }
 

--- a/core-bundle/src/Twig/Loader/ContaoFilesystemLoader.php
+++ b/core-bundle/src/Twig/Loader/ContaoFilesystemLoader.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Twig\Loader;
 
+use Contao\CoreBundle\Twig\ContaoTwigUtil;
 use Contao\CoreBundle\Twig\Inheritance\TemplateHierarchyInterface;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Contracts\Service\ResetInterface;
@@ -103,7 +104,7 @@ class ContaoFilesystemLoader extends FilesystemLoader implements TemplateHierarc
      */
     public function addPath($path, $namespace = 'Contao', bool $trackTemplates = false): void
     {
-        if (null === $this->parseContaoName("@$namespace")) {
+        if (null === ContaoTwigUtil::parseContaoName("@$namespace")) {
             throw new LoaderError("Tried to register an invalid Contao namespace '$namespace'.");
         }
 
@@ -129,7 +130,7 @@ class ContaoFilesystemLoader extends FilesystemLoader implements TemplateHierarc
      */
     public function prependPath($path, $namespace = 'Contao'): void
     {
-        if (null === $this->parseContaoName("@$namespace")) {
+        if (null === ContaoTwigUtil::parseContaoName("@$namespace")) {
             throw new LoaderError("Tried to register an invalid Contao namespace '$namespace'.");
         }
 
@@ -266,7 +267,7 @@ class ContaoFilesystemLoader extends FilesystemLoader implements TemplateHierarc
             return false;
         }
 
-        $chain = $this->getInheritanceChains()[$this->getIdentifier($name)] ?? [];
+        $chain = $this->getInheritanceChains()[ContaoTwigUtil::getIdentifier($name)] ?? [];
 
         foreach (array_keys($chain) as $path) {
             if (filemtime($path) > $time) {
@@ -290,7 +291,7 @@ class ContaoFilesystemLoader extends FilesystemLoader implements TemplateHierarc
     public function getDynamicParent(string $shortNameOrIdentifier, string $sourcePath): string
     {
         $hierarchy = $this->getInheritanceChains();
-        $identifier = $this->getIdentifier($shortNameOrIdentifier);
+        $identifier = ContaoTwigUtil::getIdentifier($shortNameOrIdentifier);
 
         if (null === ($chain = $hierarchy[$identifier] ?? null)) {
             throw new \LogicException("The template '$identifier' could not be found in the template hierarchy.");
@@ -309,7 +310,7 @@ class ContaoFilesystemLoader extends FilesystemLoader implements TemplateHierarc
 
     public function getFirst(string $shortNameOrIdentifier): string
     {
-        $identifier = $this->getIdentifier($shortNameOrIdentifier);
+        $identifier = ContaoTwigUtil::getIdentifier($shortNameOrIdentifier);
         $hierarchy = $this->getInheritanceChains();
 
         if (null === ($chain = $hierarchy[$identifier] ?? null)) {
@@ -340,7 +341,7 @@ class ContaoFilesystemLoader extends FilesystemLoader implements TemplateHierarc
             $templates = $this->templateLocator->findTemplates($searchPath);
 
             foreach ($templates as $shortName => $templatePath) {
-                $identifier = $this->getIdentifier($shortName);
+                $identifier = ContaoTwigUtil::getIdentifier($shortName);
 
                 if (isset($templatesByNamespace[$namespace][$identifier])) {
                     $basePath = Path::getLongestCommonBasePath($this->paths[$namespace]);
@@ -368,33 +369,12 @@ class ContaoFilesystemLoader extends FilesystemLoader implements TemplateHierarc
     }
 
     /**
-     * Split a Contao name into [namespace, short name]. The short name part
-     * will be null if $name is only a namespace.
-     *
-     * If parsing fails - i.e. if the given name does not describe a "Contao"
-     * or "Contao_*" namespace - null is returned instead.
-     */
-    private function parseContaoName(string $logicalNameOrNamespace): ?array
-    {
-        if (1 === preg_match('%^@(Contao(?:_[a-zA-Z0-9_-]+)?)(?:/(.*))?$%', $logicalNameOrNamespace, $matches)) {
-            return [$matches[1], $matches[2] ?? null];
-        }
-
-        return null;
-    }
-
-    private function getIdentifier(string $name): string
-    {
-        return preg_replace('%(?:.*/)?(.*)(\.html5|\.html.twig)%', '$1', $name);
-    }
-
-    /**
      * Returns the template name of a theme specific variant of the given name
      * or null if not applicable.
      */
     private function getThemeTemplateName(string $name): ?string
     {
-        if (null === ($parts = $this->parseContaoName($name)) || 'Contao' !== $parts[0]) {
+        if (null === ($parts = ContaoTwigUtil::parseContaoName($name)) || 'Contao' !== $parts[0]) {
             return null;
         }
 

--- a/core-bundle/src/Twig/Loader/ContaoFilesystemLoader.php
+++ b/core-bundle/src/Twig/Loader/ContaoFilesystemLoader.php
@@ -374,7 +374,9 @@ class ContaoFilesystemLoader extends FilesystemLoader implements TemplateHierarc
      */
     private function getThemeTemplateName(string $name): ?string
     {
-        if (null === ($parts = ContaoTwigUtil::parseContaoName($name)) || 'Contao' !== $parts[0]) {
+        $parts = ContaoTwigUtil::parseContaoName($name);
+
+        if ('Contao' !== ($parts[0] ?? null)) {
             return null;
         }
 

--- a/core-bundle/tests/Twig/ContaoTwigUtilTest.php
+++ b/core-bundle/tests/Twig/ContaoTwigUtilTest.php
@@ -1,0 +1,193 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\Twig;
+
+use Contao\CoreBundle\Tests\TestCase;
+use Contao\CoreBundle\Twig\ContaoTwigUtil;
+
+class ContaoTwigUtilTest extends TestCase
+{
+    /**
+     * @dataProvider provideContaoNames
+     */
+    public function testParseContaoNameSplitsNames(string $name, string $expectedNamespace, ?string $expectedShortName): void
+    {
+        [$namespace, $shortName] = ContaoTwigUtil::parseContaoName($name);
+
+        $this->assertSame($expectedNamespace, $namespace, 'namespace');
+        $this->assertSame($expectedShortName, $shortName, 'short name');
+    }
+
+    public function provideContaoNames(): \Generator
+    {
+        yield 'base namespace' => [
+            '@Contao/foo.html.twig',
+            'Contao',
+            'foo.html.twig',
+        ];
+
+        yield 'sub namespace' => [
+            '@Contao_Bar/foo.html.twig',
+            'Contao_Bar',
+            'foo.html.twig',
+        ];
+
+        yield 'complex name and namespace' => [
+            '@Contao_a-b_c/f~oo.html.twig',
+            'Contao_a-b_c',
+            'f~oo.html.twig',
+        ];
+
+        yield 'legacy template' => [
+            '@Contao_Foo/foo.html5',
+            'Contao_Foo',
+            'foo.html5',
+        ];
+
+        yield 'only base namespace' => [
+            '@Contao',
+            'Contao',
+            null,
+        ];
+
+        yield 'only sub namespace' => [
+            '@Contao_foo_bar',
+            'Contao_foo_bar',
+            null,
+        ];
+    }
+
+    /**
+     * @dataProvider provideInvalidNamespaces
+     */
+    public function testParseContaoNameIgnoresInvalidNamespaces(string $name): void
+    {
+        $this->assertNull(ContaoTwigUtil::parseContaoName($name));
+    }
+
+    public function provideInvalidNamespaces(): \Generator
+    {
+        yield 'not a Contao namespace' => [
+            '@Foobar/foo.html.twig',
+        ];
+
+        yield 'invalid characters' => [
+            '@Contao_:Foo',
+        ];
+
+        yield 'no namespace' => [
+            'foo.html.twig',
+        ];
+
+        yield 'empty input' => [
+            '',
+        ];
+    }
+
+    /**
+     * @dataProvider provideNames
+     */
+    public function testGetIdentifier(string $name, string $expectedIdentifier): void
+    {
+        $this->assertSame($expectedIdentifier, ContaoTwigUtil::getIdentifier($name));
+    }
+
+    public function provideNames(): \Generator
+    {
+        yield 'html5 template' => [
+            'bar.html5',
+            'bar',
+        ];
+
+        yield 'Twig template' => [
+            'bar.html.twig',
+            'bar',
+        ];
+
+        yield 'complex name (html5)' => [
+            '@Foo/bar/foo.html5',
+            'foo',
+        ];
+
+        yield 'complex name (Twig)' => [
+            '@Foo/bar/foo.html.twig',
+            'foo',
+        ];
+
+        yield 'not a Contao template extension' => [
+            'foo/bar.txt',
+            'foo/bar.txt',
+        ];
+
+        yield 'already an identifier' => [
+            'foo',
+            'foo',
+        ];
+    }
+
+    /**
+     * @dataProvider provideLegacyTemplateNames
+     */
+    public function testIsLegacyTemplate(string $name, bool $isLegacyTemplate): void
+    {
+        $this->assertSame($isLegacyTemplate, ContaoTwigUtil::isLegacyTemplate($name));
+    }
+
+    public function provideLegacyTemplateNames(): \Generator
+    {
+        yield 'base namespace' => [
+            '@Contao/bar.html5',
+            true,
+        ];
+
+        yield 'sub namespace' => [
+            '@Contao_Foo/bar.html5',
+            true,
+        ];
+
+        yield 'uppercase extension' => [
+            '@Contao_Foo/bar.HTML5',
+            true,
+        ];
+
+        yield 'invalid file extension' => [
+            '@Contao/bar.html.twig',
+            false,
+        ];
+
+        yield 'not a Contao namespace' => [
+            '@Foo/bar.html5',
+            false,
+        ];
+
+        yield 'not a logical name (just namespace)' => [
+            '@Foo',
+            false,
+        ];
+
+        yield 'not a logical name (just short name)' => [
+            'bar.html5',
+            false,
+        ];
+
+        yield 'not a logical name (just identifier)' => [
+            'bar',
+            false,
+        ];
+
+        yield 'empty input' => [
+            '',
+            false,
+        ];
+    }
+}

--- a/core-bundle/tests/Twig/ContaoTwigUtilTest.php
+++ b/core-bundle/tests/Twig/ContaoTwigUtilTest.php
@@ -77,21 +77,10 @@ class ContaoTwigUtilTest extends TestCase
 
     public function provideInvalidNamespaces(): \Generator
     {
-        yield 'not a Contao namespace' => [
-            '@Foobar/foo.html.twig',
-        ];
-
-        yield 'invalid characters' => [
-            '@Contao_:Foo',
-        ];
-
-        yield 'no namespace' => [
-            'foo.html.twig',
-        ];
-
-        yield 'empty input' => [
-            '',
-        ];
+        yield 'not a Contao namespace' => ['@Foobar/foo.html.twig'];
+        yield 'invalid characters' => ['@Contao_:Foo'];
+        yield 'no namespace' => ['foo.html.twig'];
+        yield 'empty input' => [''];
     }
 
     /**

--- a/core-bundle/tests/Twig/Inheritance/TokenParserHelperTest.php
+++ b/core-bundle/tests/Twig/Inheritance/TokenParserHelperTest.php
@@ -22,37 +22,6 @@ use Twig\Node\Node;
 
 class TokenParserHelperTest extends TestCase
 {
-    /**
-     * @dataProvider provideNameInputs
-     */
-    public function testGetContaoTemplate(string $name, ?string $expected): void
-    {
-        $this->assertSame($expected, TokenParserHelper::getContaoTemplate($name));
-    }
-
-    public function provideNameInputs(): \Generator
-    {
-        yield 'extract name from Contao template' => [
-            '@Contao/foo.html.twig',
-            'foo.html.twig',
-        ];
-
-        yield 'extract name from Contao template without extension' => [
-            '@Contao/foo',
-            'foo',
-        ];
-
-        yield 'ignore other namespaces' => [
-            '@Contao_Thing/foo.html.twig',
-            null,
-        ];
-
-        yield 'ignore arbitrary input' => [
-            'foo',
-            null,
-        ];
-    }
-
     public function testTraversesNodeTree(): void
     {
         $tree = new ConditionalExpression(

--- a/core-bundle/tests/Twig/Interop/PhpTemplateProxyNodeVisitorTest.php
+++ b/core-bundle/tests/Twig/Interop/PhpTemplateProxyNodeVisitorTest.php
@@ -43,7 +43,7 @@ class PhpTemplateProxyNodeVisitorTest extends TestCase
             new Node(),
             new Node(),
             null,
-            new Source("a\nb", 'foo.html5')
+            new Source("a\n<?php invalid block\nb", '@Contao_Foo/foo.html5')
         );
 
         $environment = $this->createMock(Environment::class);
@@ -52,7 +52,7 @@ class PhpTemplateProxyNodeVisitorTest extends TestCase
         /** @var array<BlockNode> $blocks */
         $blocks = iterator_to_array($module->getNode('blocks'));
 
-        $this->assertCount(2, $blocks);
+        $this->assertCount(2, $blocks, 'invalid block names should be ignored');
 
         $this->assertSame('a', $blocks['a']->getAttribute('name'));
         $this->assertSame('b', $blocks['b']->getAttribute('name'));


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #3199 
| Docs PR or issue | -

The `PhpTempalteProxyNodeVisitor` did only check if a template had a `.html5` file extension and not if it was actually from a `@Contao` or `@Contao_*` namespace. This is now fixed in 33ddca5097a0c34811b839e32fae911e799342d2 (guard + sanity check) - I also refactored the name parsing into a util class.

The error in #3199 happened because the `system/modules/test/templates` directory got registered as a bundle template folder by Symfony. And as everything can be a template, the `html5` files in there got parsed as well - which then caused our node visitor to generate nonsense.

/cc @fritzmg 