### PR TITLE
Sanity check template names in FigureRenderer

### DIFF
--- a/core-bundle/src/Image/Studio/FigureRenderer.php
+++ b/core-bundle/src/Image/Studio/FigureRenderer.php
@@ -20,7 +20,6 @@ use Contao\Image\PictureConfiguration;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
 use Twig\Environment;
-use Webmozart\PathUtil\Path;
 
 class FigureRenderer
 {
@@ -92,8 +91,12 @@ class FigureRenderer
 
     private function renderTemplate(Figure $figure, string $template): string
     {
-        if ('twig' === Path::getExtension($template, true)) {
+        if (1 === preg_match('/\.html\.twig$/', $template)) {
             return $this->twig->render($template, ['figure' => $figure]);
+        }
+
+        if (1 !== preg_match('/^[^\/.\s]*$/', $template)) {
+            throw new \InvalidArgumentException("Invalid Contao template name '$template'.");
         }
 
         $imageTemplate = new FrontendTemplate($template);

--- a/core-bundle/tests/Image/Studio/FigureRendererTest.php
+++ b/core-bundle/tests/Image/Studio/FigureRendererTest.php
@@ -146,6 +146,34 @@ class FigureRendererTest extends TestCase
         $figureRenderer->render(1, null, ['invalid' => 'foobar']);
     }
 
+    /**
+     * @dataProvider provideInvalidTemplates
+     */
+    public function testFailsWithInvalidTemplate(string $invalidTemplate): void
+    {
+        $figureRenderer = $this->getFigureRenderer();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches("/Invalid Contao template name '.*'\\./");
+
+        $figureRenderer->render(1, null, [], $invalidTemplate);
+    }
+
+    public function provideInvalidTemplates(): \Generator
+    {
+        yield 'not treated as Twig template, has extension' => [
+            'foo.twig',
+        ];
+
+        yield 'contains slashes' => [
+            '/some/path/foo',
+        ];
+
+        yield 'contains whitespaces' => [
+            'f oo',
+        ];
+    }
+
     public function testReturnsNullIfTheResourceDoesNotExist(): void
     {
         $figureBuilder = $this->createMock(FigureBuilder::class);


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes -
| Docs PR or issue | -

This PR adds some sanity checks for template names in the `FigureRenderer`. A valid Twig template must now have the `.html.twig` file extension and a valid Contao template must not contain dots, slashes or whitespaces. The function now throws an exception with a friendly error message if none of these match (DX).