### PR TITLE
Fix extending multiple levels of Contao templates

### DIFF
--- a/core-bundle/src/Twig/Extension/ContaoExtension.php
+++ b/core-bundle/src/Twig/Extension/ContaoExtension.php
@@ -173,8 +173,12 @@ final class ContaoExtension extends AbstractExtension
         $partialTemplate = new class($template) extends FrontendTemplate {
             public function setBlocks(array $blocks): void
             {
-                $this->arrBlocks = $blocks;
-                $this->arrBlockNames = array_keys($blocks);
+                $this->arrBlocks = array_map(
+                    static function ($block) {
+                        return \is_array($block) ? $block : [$block];
+                    },
+                    $blocks
+                );
             }
 
             public function parse(): string

--- a/core-bundle/src/Twig/Loader/ContaoFilesystemLoader.php
+++ b/core-bundle/src/Twig/Loader/ContaoFilesystemLoader.php
@@ -213,6 +213,18 @@ class ContaoFilesystemLoader extends FilesystemLoader implements TemplateHierarc
             return $source;
         }
 
+        // Look up the blocks of the parent template if present
+        if (
+            1 === preg_match(
+                '/\$this\s*->\s*extend\s*\(\s*[\'"]([a-z0-9_-]+)[\'"]\s*\)/i',
+                file_get_contents($source->getPath()),
+                $match
+            )
+            && '@Contao/'.$match[1].'.html5' !== $name
+        ) {
+            return new Source($this->getSourceContext('@Contao/'.$match[1].'.html5')->getCode(), $source->getName(), $source->getPath());
+        }
+
         preg_match_all(
             '/\$this\s*->\s*block\s*\(\s*[\'"]([a-z0-9_-]+)[\'"]\s*\)/i',
             file_get_contents($source->getPath()),

--- a/core-bundle/tests/Fixtures/Twig/legacy/templates/bar.html5
+++ b/core-bundle/tests/Fixtures/Twig/legacy/templates/bar.html5
@@ -1,0 +1,9 @@
+...ignored
+<?php echo $this->extend('foo'); ?>
+...ignored
+<?php $this->block('A'); ?>
+bar before A
+<?php $this->parent() ?>
+bar after A
+<?php $this->endblock(); ?>
+...ignored

--- a/core-bundle/tests/Fixtures/Twig/legacy/templates/baz.html5
+++ b/core-bundle/tests/Fixtures/Twig/legacy/templates/baz.html5
@@ -1,0 +1,15 @@
+...ignored
+<?php echo $this->extend('bar'); ?>
+...ignored
+<?php $this->block('A'); ?>
+baz before A
+<?php $this->parent() ?>
+baz after A
+<?php $this->endblock(); ?>
+...ignored
+<?php $this->block('B'); ?>
+baz before B
+<?php $this->parent() ?>
+baz after B
+<?php $this->endblock(); ?>
+...ignored

--- a/core-bundle/tests/Twig/Extension/ContaoExtensionTest.php
+++ b/core-bundle/tests/Twig/Extension/ContaoExtensionTest.php
@@ -201,6 +201,38 @@ class ContaoExtensionTest extends TestCase
         $this->assertSame("foo: bar\noriginal A block\noverwritten B block", $output);
     }
 
+    public function testRenderLegacyTemplateNested(): void
+    {
+        $extension = $this->getContaoExtension();
+
+        System::setContainer($this->getContainerWithContaoConfiguration(
+            Path::canonicalize(__DIR__.'/../../Fixtures/Twig/legacy')
+        ));
+
+        $output = $extension->renderLegacyTemplate(
+            'baz.html5',
+            ['B' => "root before B\n[[TL_PARENT]]root after B"],
+            ['foo' => 'bar']
+        );
+
+        $this->assertSame(
+            implode("\n", [
+                'foo: bar',
+                'baz before A',
+                'bar before A',
+                'original A block',
+                'bar after A',
+                'baz after A',
+                'root before B',
+                'baz before B',
+                'original B block',
+                'baz after B',
+                'root after B',
+            ]),
+            $output
+        );
+    }
+
     /**
      * @param Environment&MockObject $environment
      */

--- a/core-bundle/tests/Twig/Loader/ContaoFilesystemLoaderTest.php
+++ b/core-bundle/tests/Twig/Loader/ContaoFilesystemLoaderTest.php
@@ -262,6 +262,22 @@ class ContaoFilesystemLoaderTest extends TestCase
         $this->assertSame("A\nB", $source->getCode());
     }
 
+    public function testGetsSourceContextFromNestedHtml5File(): void
+    {
+        $path = Path::canonicalize(__DIR__.'/../../Fixtures/Twig/legacy/templates');
+
+        $loader = $this->getContaoFilesystemLoader(null, new TemplateLocator('/', [], []));
+        $loader->addPath($path);
+
+        $source = $loader->getSourceContext('@Contao/bar.html5');
+
+        $this->assertSame('@Contao/bar.html5', $source->getName());
+        $this->assertSame(Path::join($path, 'bar.html5'), Path::normalize($source->getPath()));
+
+        // Block names should be taken from the root template to include all blocks
+        $this->assertSame("A\nB", $source->getCode());
+    }
+
     public function testExists(): void
     {
         $loader = $this->getContaoFilesystemLoader();


### PR DESCRIPTION
Fixes the `{% extends '@Contao/ce_text' %}` part of #3200