### PR TITLE
Use "user groups" instead of "groups" where applicable

### DIFF
--- a/core-bundle/src/Resources/contao/languages/en/tl_page.xlf
+++ b/core-bundle/src/Resources/contao/languages/en/tl_page.xlf
@@ -234,7 +234,7 @@
         <source>Group</source>
       </trans-unit>
       <trans-unit id="tl_page.cgroup.1">
-        <source>Please select a group as the owner of the page.</source>
+        <source>Please select a user group as the owner of the page.</source>
       </trans-unit>
       <trans-unit id="tl_page.chmod.0">
         <source>Access rights</source>

--- a/core-bundle/src/Resources/contao/languages/en/tl_settings.xlf
+++ b/core-bundle/src/Resources/contao/languages/en/tl_settings.xlf
@@ -120,7 +120,7 @@
         <source>Default page group</source>
       </trans-unit>
       <trans-unit id="tl_settings.defaultGroup.1">
-        <source>Here you can select a group as the default owner of a page.</source>
+        <source>Here you can select a user group as the default owner of a page.</source>
       </trans-unit>
       <trans-unit id="tl_settings.defaultChmod.0">
         <source>Default access rights</source>


### PR DESCRIPTION
Adjustment of the explanation ``tl_settings.defaultGroup.1`` in respect of the title of the back end module "User groups".