### PR TITLE
Always concatenate the 'image_container' class in figure.html.twig

### DIFF
--- a/core-bundle/src/Resources/views/Image/Studio/figure.html.twig
+++ b/core-bundle/src/Resources/views/Image/Studio/figure.html.twig
@@ -1,3 +1,5 @@
 {% import "@ContaoCore/Image/Studio/_macros.html.twig" as studio %}
 
-{{- studio.figure(figure, { attr: { class: 'image_container' }}) -}}
+{{- studio.figure(figure, figure.options|default({})|merge({
+    attr: { class: ('image_container ' ~ figure.options.attr.class|default(''))|trim }
+})) -}}

--- a/core-bundle/tests/Image/Studio/TwigMacrosTest.php
+++ b/core-bundle/tests/Image/Studio/TwigMacrosTest.php
@@ -534,9 +534,7 @@ class TwigMacrosTest extends TestCase
             null,
             null,
             null,
-            [
-                'attr' => ['class' => 'foo', 'data-bar' => 'bar'],
-            ]
+            ['attr' => ['class' => 'foo', 'data-bar' => 'bar']]
         );
 
         $figureTemplate = file_get_contents(
@@ -549,7 +547,6 @@ class TwigMacrosTest extends TestCase
         ];
 
         $environment = new Environment(new ArrayLoader($templates));
-
         $html = $environment->render('figure.html.twig', ['figure' => $figure]);
 
         $this->assertRegExp('/<figure.* class="image_container foo" data-bar="bar">/', $html);
@@ -559,8 +556,7 @@ class TwigMacrosTest extends TestCase
     {
         $templates = [
             '_macros.html.twig' => self::$macros,
-            'test.html.twig' => '{% import "_macros.html.twig" as studio %}'.
-                "{{ studio.$call }}",
+            'test.html.twig' => '{% import "_macros.html.twig" as studio %}'."{{ studio.$call }}",
         ];
 
         $environment = new Environment(new ArrayLoader($templates));

--- a/core-bundle/tests/Image/Studio/TwigMacrosTest.php
+++ b/core-bundle/tests/Image/Studio/TwigMacrosTest.php
@@ -527,6 +527,34 @@ class TwigMacrosTest extends TestCase
         ];
     }
 
+    public function testFigureTemplateMergesFigureOptionsClass(): void
+    {
+        $figure = new Figure(
+            $this->createMock(ImageResult::class),
+            null,
+            null,
+            null,
+            [
+                'attr' => ['class' => 'foo', 'data-bar' => 'bar'],
+            ]
+        );
+
+        $figureTemplate = file_get_contents(
+            Path::canonicalize(__DIR__.'/../../../src/Resources/views/Image/Studio/figure.html.twig')
+        );
+
+        $templates = [
+            '@ContaoCore/Image/Studio/_macros.html.twig' => self::$macros,
+            'figure.html.twig' => $figureTemplate,
+        ];
+
+        $environment = new Environment(new ArrayLoader($templates));
+
+        $html = $environment->render('figure.html.twig', ['figure' => $figure]);
+
+        $this->assertRegExp('/<figure.* class="image_container foo" data-bar="bar">/', $html);
+    }
+
     private function renderMacro(string $call, array $context = []): string
     {
         $templates = [


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #-
| Docs PR or issue | -

We must explicitly concatenate the `image_container` class in the `figure.html.twig` template instead of just setting it. Because these are template options that always win over `Figure` options, you would otherwise not be able to set your own class via `FigureBuilder#setOptions(['attr' => ['class' => 'foo]]);`.

If you really need the class to be gone, you can simply overwrite the template with:

```twig
{% import "@ContaoCore/Image/Studio/_macros.html.twig" as studio %}

{{- studio.figure(figure) -}}
```

/cc @fritzmg 