### PR TITLE
Options_callbacks value for Module Listing

### DIFF
--- a/listing-bundle/src/Resources/contao/modules/ModuleListing.php
+++ b/listing-bundle/src/Resources/contao/modules/ModuleListing.php
@@ -484,6 +484,11 @@ class ModuleListing extends Module
 			}
 		}
 
+		// Options Callback
+		elseif (isset($GLOBALS['TL_DCA'][$this->list_table]['fields'][$k]['options_callback'])) {
+			$value = '<span class="value">[' . $value . ']</span> ' . $GLOBALS['TL_DCA'][$this->list_table]['fields'][$k]['options_callback']()[$value];
+		}
+
 		return $value;
 	}
 }


### PR DESCRIPTION
When listing a `tl_member` using `module listing`, the `country` field value is returned as `de`, `it`..., In Contao 3, it is returned as `<span class="value">[de]</span> Deutschland` and `<span class="value">[it]</span> Italien`.

| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #...
| Docs PR or issue | contao/docs#...

<!--
Bugfixes should be based on the 4.9 or 4.11 branch and features on the 4.x
branch. Select the correct branch in the "base:" drop-down menu above.

Replace this notice with a short README for your feature/bugfix. This will help
people to understand your PR and can be used as a start for the documentation.
-->
