### PR TITLE
Ensure the numberOfItems label does refer to items only

### DIFF
--- a/core-bundle/src/Resources/contao/languages/en/tl_content.xlf
+++ b/core-bundle/src/Resources/contao/languages/en/tl_content.xlf
@@ -273,10 +273,10 @@
         <source>The number of items per page. Set to 0 to disable pagination.</source>
       </trans-unit>
       <trans-unit id="tl_content.numberOfItems.0">
-        <source>Total number of images</source>
+        <source>Total number of items</source>
       </trans-unit>
       <trans-unit id="tl_content.numberOfItems.1">
-        <source>Here you can limit the total number of images. Set to 0 to show all.</source>
+        <source>Here you can limit the total number of items. Set to 0 to show all.</source>
       </trans-unit>
       <trans-unit id="tl_content.sortBy.0">
         <source>Order by</source>


### PR DESCRIPTION
I'm reusing this field quite a lot in custom elements (and I see others doing the same) and I don't think it makes sense to default that to "images". It's still perfectly valid for the gallery element like this as well :)