### PR TITLE
Support request tokens in Symfony forms

### DIFF
--- a/core-bundle/src/Controller/AbstractController.php
+++ b/core-bundle/src/Controller/AbstractController.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Controller;
 
+use Contao\CoreBundle\Csrf\ContaoCsrfTokenManager;
 use Contao\CoreBundle\Framework\ContaoFramework;
 use FOS\HttpCacheBundle\Http\SymfonyResponseTagger;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController as SymfonyAbstractController;
@@ -24,6 +25,7 @@ abstract class AbstractController extends SymfonyAbstractController
 
         $services['contao.framework'] = ContaoFramework::class;
         $services['fos_http_cache.http.symfony_response_tagger'] = '?'.SymfonyResponseTagger::class;
+        $services[] = ContaoCsrfTokenManager::class;
 
         return $services;
     }
@@ -40,5 +42,17 @@ abstract class AbstractController extends SymfonyAbstractController
         }
 
         $this->get('fos_http_cache.http.symfony_response_tagger')->addTags($tags);
+    }
+
+    /**
+     * @return array{csrf_field_name: string, csrf_token_manager: ContaoCsrfTokenManager, csrf_token_id: string}
+     */
+    protected function getCsrfFormOptions(): array
+    {
+        return [
+            'csrf_field_name' => 'REQUEST_TOKEN',
+            'csrf_token_manager' => $this->get(ContaoCsrfTokenManager::class),
+            'csrf_token_id' => $this->getParameter('contao.csrf_token_name'),
+        ];
     }
 }

--- a/core-bundle/src/Csrf/ContaoCsrfTokenManager.php
+++ b/core-bundle/src/Csrf/ContaoCsrfTokenManager.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Csrf;
+
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Security\Csrf\CsrfToken;
+use Symfony\Component\Security\Csrf\CsrfTokenManager;
+use Symfony\Component\Security\Csrf\TokenGenerator\TokenGeneratorInterface;
+use Symfony\Component\Security\Csrf\TokenStorage\TokenStorageInterface;
+
+class ContaoCsrfTokenManager extends CsrfTokenManager
+{
+    /**
+     * @var RequestStack
+     */
+    private $requestStack;
+
+    /**
+     * @var string
+     */
+    private $csrfCookiePrefix;
+
+    public function __construct(RequestStack $requestStack, string $csrfCookiePrefix, TokenGeneratorInterface $generator = null, TokenStorageInterface $storage = null, $namespace = null)
+    {
+        $this->requestStack = $requestStack;
+        $this->csrfCookiePrefix = $csrfCookiePrefix;
+
+        parent::__construct($generator, $storage, $namespace);
+    }
+
+    public function isTokenValid(CsrfToken $token): bool
+    {
+        // Skip the CSRF token validation if the request has no cookies, no
+        // authenticated user and the session has not been started
+        if (
+            ($request = $this->requestStack->getMasterRequest())
+            && 'POST' === $request->getRealMethod()
+            && !$request->getUserInfo()
+            && (
+                0 === $request->cookies->count()
+                || [$this->csrfCookiePrefix.$token->getId()] === $request->cookies->keys()
+            )
+            && !($request->hasSession() && $request->getSession()->isStarted())
+        ) {
+            return true;
+        }
+
+        return parent::isTokenValid($token);
+    }
+}

--- a/core-bundle/src/EventListener/RequestTokenListener.php
+++ b/core-bundle/src/EventListener/RequestTokenListener.php
@@ -16,6 +16,7 @@ use Contao\Config;
 use Contao\CoreBundle\Exception\InvalidRequestTokenException;
 use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\CoreBundle\Routing\ScopeMatcher;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\Security\Csrf\CsrfToken;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
@@ -119,12 +120,28 @@ class RequestTokenListener
             }
         }
 
-        $token = new CsrfToken($this->csrfTokenName, $request->request->get('REQUEST_TOKEN'));
+        $token = new CsrfToken($this->csrfTokenName, $this->getTokenFromRequest($request));
 
         if ($this->csrfTokenManager->isTokenValid($token)) {
             return;
         }
 
         throw new InvalidRequestTokenException('Invalid CSRF token. Please reload the page and try again.');
+    }
+
+    private function getTokenFromRequest(Request $request): ?string
+    {
+        if ($request->request->has('REQUEST_TOKEN')) {
+            return $request->request->get('REQUEST_TOKEN');
+        }
+
+        // Look for the token inside the root level arrays as they would be in named Symfony forms
+        foreach ($request->request as $value) {
+            if (\is_array($value) && isset($value['REQUEST_TOKEN'])) {
+                return $value['REQUEST_TOKEN'];
+            }
+        }
+
+        return null;
     }
 }

--- a/core-bundle/src/EventListener/RequestTokenListener.php
+++ b/core-bundle/src/EventListener/RequestTokenListener.php
@@ -13,13 +13,13 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\EventListener;
 
 use Contao\Config;
+use Contao\CoreBundle\Csrf\ContaoCsrfTokenManager;
 use Contao\CoreBundle\Exception\InvalidRequestTokenException;
 use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\CoreBundle\Routing\ScopeMatcher;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\Security\Csrf\CsrfToken;
-use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 
 /**
  * Validates the request token if the request is a Contao request.
@@ -39,7 +39,7 @@ class RequestTokenListener
     private $scopeMatcher;
 
     /**
-     * @var CsrfTokenManagerInterface
+     * @var ContaoCsrfTokenManager
      */
     private $csrfTokenManager;
 
@@ -53,7 +53,7 @@ class RequestTokenListener
      */
     private $csrfCookiePrefix;
 
-    public function __construct(ContaoFramework $framework, ScopeMatcher $scopeMatcher, CsrfTokenManagerInterface $csrfTokenManager, string $csrfTokenName, string $csrfCookiePrefix = 'csrf_')
+    public function __construct(ContaoFramework $framework, ScopeMatcher $scopeMatcher, ContaoCsrfTokenManager $csrfTokenManager, string $csrfTokenName, string $csrfCookiePrefix = 'csrf_')
     {
         $this->framework = $framework;
         $this->scopeMatcher = $scopeMatcher;
@@ -84,11 +84,7 @@ class RequestTokenListener
             || $request->isXmlHttpRequest()
             || false === $request->attributes->get('_token_check')
             || (!$request->attributes->has('_token_check') && !$this->scopeMatcher->isContaoRequest($request))
-            || (
-                (0 === $request->cookies->count() || [$this->csrfCookiePrefix.$this->csrfTokenName] === $request->cookies->keys())
-                && !$request->getUserInfo()
-                && !($request->hasSession() && $request->getSession()->isStarted())
-            )
+            || $this->csrfTokenManager->canSkipTokenValidation($request, $this->csrfCookiePrefix.$this->csrfTokenName)
         ) {
             return;
         }

--- a/core-bundle/src/Resources/config/listener.yml
+++ b/core-bundle/src/Resources/config/listener.yml
@@ -228,7 +228,7 @@ services:
         arguments:
             - '@contao.framework'
             - '@contao.routing.scope_matcher'
-            - '@contao.csrf.token_manager'
+            - '@Contao\CoreBundle\Csrf\ContaoCsrfTokenManager'
             - '%contao.csrf_token_name%'
             - '%contao.csrf_cookie_prefix%'
         tags:

--- a/core-bundle/src/Resources/config/services.yml
+++ b/core-bundle/src/Resources/config/services.yml
@@ -94,7 +94,7 @@ services:
             - '@security.helper'
             - '@twig'
             - '@router'
-            - '@contao.csrf.token_manager'
+            - '@Contao\CoreBundle\Csrf\ContaoCsrfTokenManager'
             - '%contao.csrf_token_name%'
         tags:
             - controller.service_arguments
@@ -116,7 +116,6 @@ services:
     Contao\CoreBundle\Controller\FrontendController:
         tags:
             - controller.service_arguments
-            - { name: container.service_subscriber, id: contao.csrf.token_manager }
 
     Contao\CoreBundle\Controller\FrontendModule\TwoFactorController:
         tags:
@@ -208,13 +207,18 @@ services:
             - '@contao.framework'
             - '@database_connection'
 
-    contao.csrf.token_manager:
-        class: Contao\CoreBundle\Csrf\ContaoCsrfTokenManager
+    Contao\CoreBundle\Csrf\ContaoCsrfTokenManager:
         arguments:
             - '@request_stack'
             - '%contao.csrf_cookie_prefix%'
             - '@security.csrf.token_generator'
             - '@contao.csrf.token_storage'
+        public: true
+
+    # Backwards compatibility
+    contao.csrf.token_manager:
+        alias: Contao\CoreBundle\Csrf\ContaoCsrfTokenManager
+        deprecated: Using the "%alias_id%" service ID has been deprecated and will no longer work in Contao 5.0. Please use "Contao\CoreBundle\Csrf\ContaoCsrfTokenManager" instead.
         public: true
 
     contao.csrf.token_storage:

--- a/core-bundle/src/Resources/config/services.yml
+++ b/core-bundle/src/Resources/config/services.yml
@@ -209,8 +209,10 @@ services:
             - '@database_connection'
 
     contao.csrf.token_manager:
-        class: Symfony\Component\Security\Csrf\CsrfTokenManager
+        class: Contao\CoreBundle\Csrf\ContaoCsrfTokenManager
         arguments:
+            - '@request_stack'
+            - '%contao.csrf_cookie_prefix%'
             - '@security.csrf.token_generator'
             - '@contao.csrf.token_storage'
         public: true

--- a/core-bundle/src/Resources/contao/library/Contao/RequestToken.php
+++ b/core-bundle/src/Resources/contao/library/Contao/RequestToken.php
@@ -10,6 +10,7 @@
 
 namespace Contao;
 
+use Contao\CoreBundle\Csrf\ContaoCsrfTokenManager;
 use Symfony\Component\Security\Csrf\CsrfToken;
 
 @trigger_error('Using the "Contao\RequestToken" class has been deprecated and will no longer work in Contao 5.0. Use the Symfony CSRF service via the container instead.', E_USER_DEPRECATED);
@@ -53,7 +54,7 @@ class RequestToken
 	{
 		$container = System::getContainer();
 
-		return $container->get('contao.csrf.token_manager')->getToken($container->getParameter('contao.csrf_token_name'))->getValue();
+		return $container->get(ContaoCsrfTokenManager::class)->getToken($container->getParameter('contao.csrf_token_name'))->getValue();
 	}
 
 	/**
@@ -87,7 +88,7 @@ class RequestToken
 
 		$container = System::getContainer();
 
-		return $container->get('contao.csrf.token_manager')->isTokenValid(new CsrfToken($container->getParameter('contao.csrf_token_name'), $strToken));
+		return $container->get(ContaoCsrfTokenManager::class)->isTokenValid(new CsrfToken($container->getParameter('contao.csrf_token_name'), $strToken));
 	}
 }
 

--- a/core-bundle/tests/Controller/FrontendControllerTest.php
+++ b/core-bundle/tests/Controller/FrontendControllerTest.php
@@ -14,6 +14,7 @@ namespace Contao\CoreBundle\Tests\Controller;
 
 use Contao\CoreBundle\Controller\FrontendController;
 use Contao\CoreBundle\Cron\Cron;
+use Contao\CoreBundle\Csrf\ContaoCsrfTokenManager;
 use Contao\CoreBundle\Tests\TestCase;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
@@ -67,7 +68,7 @@ class FrontendControllerTest extends TestCase
 
         $container = $this->getContainerWithContaoConfiguration();
         $container->set('parameter_bag', $bag);
-        $container->set('contao.csrf.token_manager', $tokenManager);
+        $container->set(ContaoCsrfTokenManager::class, $tokenManager);
 
         $controller = new FrontendController();
         $controller->setContainer($container);
@@ -78,7 +79,7 @@ class FrontendControllerTest extends TestCase
         $this->assertTrue($response->headers->hasCacheControlDirective('no-store'));
         $this->assertTrue($response->headers->hasCacheControlDirective('must-revalidate'));
         $this->assertSame('application/javascript; charset=UTF-8', $response->headers->get('Content-Type'));
-        $this->assertSame('document.querySelectorAll("input[name=REQUEST_TOKEN]").forEach(function(i){i.value="tokenValue"})', $response->getContent());
+        $this->assertSame('document.querySelectorAll(\'input[name=REQUEST_TOKEN],input[name$="[REQUEST_TOKEN]"]\').forEach(function(i){i.value="tokenValue"})', $response->getContent());
     }
 
     public function testRunsTheCronJobsUponGetRequests(): void

--- a/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
+++ b/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
@@ -43,6 +43,7 @@ use Contao\CoreBundle\Crawl\Escargot\Subscriber\BrokenLinkCheckerSubscriber;
 use Contao\CoreBundle\Crawl\Escargot\Subscriber\SearchIndexSubscriber;
 use Contao\CoreBundle\Cron\Cron;
 use Contao\CoreBundle\Cron\LegacyCron;
+use Contao\CoreBundle\Csrf\ContaoCsrfTokenManager;
 use Contao\CoreBundle\Csrf\MemoryTokenStorage;
 use Contao\CoreBundle\DataCollector\ContaoDataCollector;
 use Contao\CoreBundle\DependencyInjection\ContaoCoreExtension;
@@ -162,7 +163,6 @@ use Symfony\Component\HttpKernel\EventListener\AbstractSessionListener;
 use Symfony\Component\HttpKernel\EventListener\ErrorListener;
 use Symfony\Component\HttpKernel\EventListener\LocaleListener as BaseLocaleListener;
 use Symfony\Component\HttpKernel\EventListener\RouterListener;
-use Symfony\Component\Security\Csrf\CsrfTokenManager;
 use Symfony\Component\Security\Csrf\TokenGenerator\UriSafeTokenGenerator;
 use Symfony\Component\Security\Http\Firewall;
 
@@ -1634,11 +1634,13 @@ class ContaoCoreExtensionTest extends TestCase
 
         $definition = $this->container->getDefinition('contao.csrf.token_manager');
 
-        $this->assertSame(CsrfTokenManager::class, $definition->getClass());
+        $this->assertSame(ContaoCsrfTokenManager::class, $definition->getClass());
         $this->assertTrue($definition->isPublic());
 
         $this->assertEquals(
             [
+                new Reference('request_stack'),
+                '%contao.csrf_cookie_prefix%',
                 new Reference('security.csrf.token_generator'),
                 new Reference('contao.csrf.token_storage'),
             ],

--- a/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
+++ b/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
@@ -953,7 +953,7 @@ class ContaoCoreExtensionTest extends TestCase
                 new Reference('security.helper'),
                 new Reference('twig'),
                 new Reference('router'),
-                new Reference('contao.csrf.token_manager'),
+                new Reference(ContaoCsrfTokenManager::class),
                 new Reference('%contao.csrf_token_name%'),
             ],
             $definition->getArguments()
@@ -1002,7 +1002,7 @@ class ContaoCoreExtensionTest extends TestCase
             [
                 new Reference('contao.framework'),
                 new Reference('contao.routing.scope_matcher'),
-                new Reference('contao.csrf.token_manager'),
+                new Reference(ContaoCsrfTokenManager::class),
                 new Reference('%contao.csrf_token_name%'),
                 new Reference('%contao.csrf_cookie_prefix%'),
             ],
@@ -1390,9 +1390,6 @@ class ContaoCoreExtensionTest extends TestCase
                 'controller.service_arguments' => [
                     [],
                 ],
-                'container.service_subscriber' => [
-                    ['id' => 'contao.csrf.token_manager'],
-                ],
             ],
             $definition->getTags()
         );
@@ -1630,11 +1627,10 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersTheCsrfTokenManager(): void
     {
-        $this->assertTrue($this->container->has('contao.csrf.token_manager'));
+        $this->assertTrue($this->container->has(ContaoCsrfTokenManager::class));
 
-        $definition = $this->container->getDefinition('contao.csrf.token_manager');
+        $definition = $this->container->getDefinition(ContaoCsrfTokenManager::class);
 
-        $this->assertSame(ContaoCsrfTokenManager::class, $definition->getClass());
         $this->assertTrue($definition->isPublic());
 
         $this->assertEquals(
@@ -1646,6 +1642,17 @@ class ContaoCoreExtensionTest extends TestCase
             ],
             $definition->getArguments()
         );
+    }
+
+    public function testRegistersTheDeprecatedCsrfTokenManager(): void
+    {
+        $this->assertTrue($this->container->has('contao.csrf.token_manager'));
+
+        $alias = $this->container->getAlias('contao.csrf.token_manager');
+
+        $this->assertSame(ContaoCsrfTokenManager::class, (string) $alias);
+        $this->assertTrue($alias->isPublic());
+        $this->assertTrue($alias->isDeprecated());
     }
 
     public function testRegistersTheCsrfTokenStorage(): void

--- a/core-bundle/tests/EventListener/RequestTokenListenerTest.php
+++ b/core-bundle/tests/EventListener/RequestTokenListenerTest.php
@@ -13,15 +13,18 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Tests\EventListener;
 
 use Contao\Config;
+use Contao\CoreBundle\Csrf\ContaoCsrfTokenManager;
 use Contao\CoreBundle\EventListener\RequestTokenListener;
 use Contao\CoreBundle\Exception\InvalidRequestTokenException;
 use Contao\CoreBundle\Routing\ScopeMatcher;
 use Contao\CoreBundle\Tests\TestCase;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
-use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
+use Symfony\Component\Security\Csrf\TokenGenerator\UriSafeTokenGenerator;
+use Symfony\Component\Security\Csrf\TokenStorage\TokenStorageInterface;
 
 class RequestTokenListenerTest extends TestCase
 {
@@ -92,7 +95,7 @@ class RequestTokenListenerTest extends TestCase
             ->willReturn(true)
         ;
 
-        $csrfTokenManager = $this->createMock(CsrfTokenManagerInterface::class);
+        $csrfTokenManager = $this->createMock(ContaoCsrfTokenManager::class);
         $csrfTokenManager
             ->expects($this->once())
             ->method('isTokenValid')
@@ -126,7 +129,7 @@ class RequestTokenListenerTest extends TestCase
         $framework = $this->mockContaoFramework([Config::class => $config]);
         $scopeMatcher = $this->createMock(ScopeMatcher::class);
 
-        $csrfTokenManager = $this->createMock(CsrfTokenManagerInterface::class);
+        $csrfTokenManager = $this->createMock(ContaoCsrfTokenManager::class);
         $csrfTokenManager
             ->expects($this->once())
             ->method('isTokenValid')
@@ -167,7 +170,7 @@ class RequestTokenListenerTest extends TestCase
         ;
 
         $scopeMatcher = $this->createMock(ScopeMatcher::class);
-        $csrfTokenManager = $this->createMock(CsrfTokenManagerInterface::class);
+        $csrfTokenManager = $this->createMock(ContaoCsrfTokenManager::class);
 
         $request = Request::create('/account.html');
         $request->setMethod('GET');
@@ -200,7 +203,7 @@ class RequestTokenListenerTest extends TestCase
         ;
 
         $scopeMatcher = $this->createMock(ScopeMatcher::class);
-        $csrfTokenManager = $this->createMock(CsrfTokenManagerInterface::class);
+        $csrfTokenManager = $this->createMock(ContaoCsrfTokenManager::class);
 
         $request = Request::create('/account.html');
         $request->setMethod('POST');
@@ -234,7 +237,7 @@ class RequestTokenListenerTest extends TestCase
         ;
 
         $scopeMatcher = $this->createMock(ScopeMatcher::class);
-        $csrfTokenManager = $this->createMock(CsrfTokenManagerInterface::class);
+        $csrfTokenManager = $this->createMock(ContaoCsrfTokenManager::class);
 
         $request = Request::create('/account.html');
         $request->setMethod('POST');
@@ -273,7 +276,7 @@ class RequestTokenListenerTest extends TestCase
             ->willReturn(false)
         ;
 
-        $csrfTokenManager = $this->createMock(CsrfTokenManagerInterface::class);
+        $csrfTokenManager = $this->createMock(ContaoCsrfTokenManager::class);
 
         $request = Request::create('/account.html');
         $request->setMethod('POST');
@@ -305,7 +308,7 @@ class RequestTokenListenerTest extends TestCase
         ;
 
         $scopeMatcher = $this->createMock(ScopeMatcher::class);
-        $csrfTokenManager = $this->createMock(CsrfTokenManagerInterface::class);
+        $csrfTokenManager = $this->createMock(ContaoCsrfTokenManager::class);
 
         $event = $this->createMock(RequestEvent::class);
         $event
@@ -329,11 +332,22 @@ class RequestTokenListenerTest extends TestCase
         $framework = $this->mockContaoFramework([Config::class => $config]);
         $scopeMatcher = $this->createMock(ScopeMatcher::class);
 
-        $csrfTokenManager = $this->createMock(CsrfTokenManagerInterface::class);
+        $csrfTokenManager = $this->createMock(ContaoCsrfTokenManager::class);
         $csrfTokenManager
             ->expects($shouldValidate ? $this->once() : $this->never())
             ->method('isTokenValid')
             ->willReturn(true)
+        ;
+
+        $csrfTokenManager
+            ->method('canSkipTokenValidation')
+            ->willReturnCallback(
+                function () {
+                    $tokenManager = new ContaoCsrfTokenManager($this->createMock(RequestStack::class), 'csrf_', new UriSafeTokenGenerator(), $this->createMock(TokenStorageInterface::class));
+
+                    return $tokenManager->canSkipTokenValidation(...\func_get_args());
+                }
+            )
         ;
 
         $event = $this->createMock(RequestEvent::class);

--- a/installation-bundle/src/Controller/InstallationController.php
+++ b/installation-bundle/src/Controller/InstallationController.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\InstallationBundle\Controller;
 
+use Contao\CoreBundle\Csrf\ContaoCsrfTokenManager;
 use Contao\Environment;
 use Contao\InstallationBundle\Config\ParameterDumper;
 use Contao\InstallationBundle\Database\ConnectionFactory;
@@ -633,7 +634,7 @@ class InstallationController implements ContainerAwareInterface
             return '';
         }
 
-        return $this->container->get('contao.csrf.token_manager')->getToken($tokenName)->getValue();
+        return $this->container->get(ContaoCsrfTokenManager::class)->getToken($tokenName)->getValue();
     }
 
     /**


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #3211
| Docs PR or issue | contao/docs#795

This should make it possible to use request tokens in Symfony forms with the following configuration:

```php
$this->createFormBuilder(…, [
    'csrf_field_name' => 'REQUEST_TOKEN',
    'csrf_token_manager' => $manager, // @contao.csrf.token_manager
    'csrf_token_id' => $tokenName, // %contao.csrf_token_name%
]);
```

**UPDATE 2021-07-26:** Can now be used like this:

```php
$this->createFormBuilder($data, $this->getCsrfFormOptions());
```
or like this:
```php
$this->createFormBuilder($data, array_merge(
    $this->getCsrfFormOptions(),
    [ /* custom options */ ]
));
```