### PR TITLE
Do not start the session in the login module

### DIFF
--- a/core-bundle/src/Resources/contao/modules/ModuleLogin.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleLogin.php
@@ -93,9 +93,20 @@ class ModuleLogin extends Module
 		global $objPage;
 
 		$container = System::getContainer();
+		$request = $container->get('request_stack')->getCurrentRequest();
 
 		/** @var AuthenticationException|null $exception */
-		$exception = $container->get('security.authentication_utils')->getLastAuthenticationError();
+		$exception = null;
+		$lastUsername = '';
+
+		// Only call the authentication utils if there is an active session to prevent starting an empty session
+		if ($request && $request->hasSession() && ($request->hasPreviousSession() || $request->getSession()->isStarted()))
+		{
+			$authUtils = $container->get('security.authentication_utils');
+			$exception = $authUtils->getLastAuthenticationError();
+			$lastUsername = $authUtils->getLastUsername();
+		}
+
 		$authorizationChecker = $container->get('security.authorization_checker');
 
 		if ($authorizationChecker->isGranted('ROLE_MEMBER'))
@@ -171,7 +182,6 @@ class ModuleLogin extends Module
 		if ($authorizationChecker->isGranted('IS_AUTHENTICATED_2FA_IN_PROGRESS'))
 		{
 			// Dispatch 2FA form event to prepare 2FA providers
-			$request = $container->get('request_stack')->getCurrentRequest();
 			$token = $container->get('security.token_storage')->getToken();
 			$event = new TwoFactorAuthenticationEvent($request, $token);
 			$container->get('event_dispatcher')->dispatch($event, TwoFactorAuthenticationEvents::FORM);
@@ -188,7 +198,7 @@ class ModuleLogin extends Module
 		$this->Template->username = $GLOBALS['TL_LANG']['MSC']['username'];
 		$this->Template->password = $GLOBALS['TL_LANG']['MSC']['password'][0];
 		$this->Template->slabel = StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['login']);
-		$this->Template->value = Input::encodeInsertTags(StringUtil::specialchars($container->get('security.authentication_utils')->getLastUsername()));
+		$this->Template->value = Input::encodeInsertTags(StringUtil::specialchars($lastUsername));
 		$this->Template->autologin = $this->autologin;
 		$this->Template->autoLabel = $GLOBALS['TL_LANG']['MSC']['autologin'];
 	}

--- a/core-bundle/src/Resources/contao/modules/ModuleLogin.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleLogin.php
@@ -94,8 +94,6 @@ class ModuleLogin extends Module
 
 		$container = System::getContainer();
 		$request = $container->get('request_stack')->getCurrentRequest();
-
-		/** @var AuthenticationException|null $exception */
 		$exception = null;
 		$lastUsername = '';
 


### PR DESCRIPTION
Placing a login module on a page currently starts the session and therefore prevents caching.

This pull request should fix that. (Successfully tested in a 4.11.5 setup).