### PR TITLE
Correctly clean up left-over records in DCA mode 5

### DIFF
--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -3301,6 +3301,11 @@ class DC_Table extends DataContainer implements \listable, \editable
 		$ptable = $GLOBALS['TL_DCA'][$this->strTable]['config']['ptable'];
 		$ctable = $GLOBALS['TL_DCA'][$this->strTable]['config']['ctable'];
 
+		if ($ptable === null && $GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] == 5)
+		{
+			$ptable = $this->strTable;
+		}
+
 		/** @var AttributeBagInterface $objSessionBag */
 		$objSessionBag = System::getContainer()->get('session')->getBag('contao_backend');
 
@@ -3393,6 +3398,10 @@ class DC_Table extends DataContainer implements \listable, \editable
 			if ($GLOBALS['TL_DCA'][$this->strTable]['config']['dynamicPtable'])
 			{
 				$objIds = $this->Database->execute("SELECT c.id FROM " . $this->strTable . " c LEFT JOIN " . $ptable . " p ON c.pid=p.id WHERE c.ptable='" . $ptable . "' AND p.id IS NULL");
+			}
+			elseif ($ptable == $this->strTable)
+			{
+				$objIds = $this->Database->execute('SELECT c.id FROM '.$this->strTable.' c LEFT JOIN '.$ptable.' p ON c.pid=p.id WHERE p.id IS NULL AND c.pid > 0');
 			}
 			else
 			{

--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -3301,7 +3301,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 		$ptable = $GLOBALS['TL_DCA'][$this->strTable]['config']['ptable'];
 		$ctable = $GLOBALS['TL_DCA'][$this->strTable]['config']['ctable'];
 
-		if ($ptable === null && $GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] == 5)
+		if ($ptable === null && ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] ?? null) == 5)
 		{
 			$ptable = $this->strTable;
 		}

--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -3401,7 +3401,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 			}
 			elseif ($ptable == $this->strTable)
 			{
-				$objIds = $this->Database->execute('SELECT c.id FROM '.$this->strTable.' c LEFT JOIN '.$ptable.' p ON c.pid=p.id WHERE p.id IS NULL AND c.pid > 0');
+				$objIds = $this->Database->execute('SELECT c.id FROM ' . $this->strTable . ' c LEFT JOIN ' . $ptable . ' p ON c.pid=p.id WHERE p.id IS NULL AND c.pid > 0');
 			}
 			else
 			{

--- a/core-bundle/src/Routing/Route404Provider.php
+++ b/core-bundle/src/Routing/Route404Provider.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Routing;
 
 use Contao\CoreBundle\ContaoCoreBundle;
-use Contao\CoreBundle\Exception\NoRootPageFoundException;
 use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\PageModel;
 use Symfony\Cmf\Component\Routing\RouteProviderInterface;
@@ -101,15 +100,7 @@ class Route404Provider implements RouteProviderInterface
 
     private function addRoutesForPage(PageModel $page, array &$routes): void
     {
-        try {
-            $page->loadDetails();
-
-            if (!$page->rootId) {
-                return;
-            }
-        } catch (NoRootPageFoundException $e) {
-            return;
-        }
+        $page->loadDetails();
 
         $defaults = [
             '_token_check' => true,

--- a/core-bundle/src/Routing/RouteProvider.php
+++ b/core-bundle/src/Routing/RouteProvider.php
@@ -14,7 +14,6 @@ namespace Contao\CoreBundle\Routing;
 
 use Contao\Config;
 use Contao\CoreBundle\ContaoCoreBundle;
-use Contao\CoreBundle\Exception\NoRootPageFoundException;
 use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\Model;
 use Contao\Model\Collection;
@@ -236,15 +235,7 @@ class RouteProvider implements RouteProviderInterface
 
     private function addRoutesForPage(PageModel $page, array &$routes): void
     {
-        try {
-            $page->loadDetails();
-
-            if (!$page->rootId) {
-                return;
-            }
-        } catch (NoRootPageFoundException $e) {
-            return;
-        }
+        $page->loadDetails();
 
         $defaults = $this->getRouteDefaults($page);
         $defaults['parameters'] = '';

--- a/core-bundle/tests/Routing/Route404ProviderTest.php
+++ b/core-bundle/tests/Routing/Route404ProviderTest.php
@@ -324,35 +324,6 @@ class Route404ProviderTest extends TestCase
         ];
     }
 
-    public function testIgnoresRoutesWithoutRootId(): void
-    {
-        /** @var PageModel&MockObject $page */
-        $page = $this->mockClassWithProperties(PageModel::class);
-        $page->id = 17;
-
-        $page
-            ->expects($this->once())
-            ->method('loadDetails')
-        ;
-
-        $pageAdapter = $this->mockAdapter(['findByType']);
-        $pageAdapter
-            ->expects($this->once())
-            ->method('findByType')
-            ->with('error_404')
-            ->willReturn(new Collection([$page], 'tl_page'))
-        ;
-
-        $framework = $this->mockContaoFramework([PageModel::class => $pageAdapter]);
-        $request = $this->mockRequestWithPath('/');
-
-        $provider = new Route404Provider($framework, false);
-        $routes = $provider->getRouteCollectionForRequest($request)->all();
-
-        $this->assertIsArray($routes);
-        $this->assertEmpty($routes);
-    }
-
     /**
      * @return Request&MockObject
      */

--- a/core-bundle/tests/Routing/Route404ProviderTest.php
+++ b/core-bundle/tests/Routing/Route404ProviderTest.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Tests\Routing;
 
-use Contao\CoreBundle\Exception\NoRootPageFoundException;
 use Contao\CoreBundle\Routing\Route404Provider;
 use Contao\CoreBundle\Tests\TestCase;
 use Contao\Model\Collection;
@@ -334,37 +333,6 @@ class Route404ProviderTest extends TestCase
         $page
             ->expects($this->once())
             ->method('loadDetails')
-        ;
-
-        $pageAdapter = $this->mockAdapter(['findByType']);
-        $pageAdapter
-            ->expects($this->once())
-            ->method('findByType')
-            ->with('error_404')
-            ->willReturn(new Collection([$page], 'tl_page'))
-        ;
-
-        $framework = $this->mockContaoFramework([PageModel::class => $pageAdapter]);
-        $request = $this->mockRequestWithPath('/');
-
-        $provider = new Route404Provider($framework, false);
-        $routes = $provider->getRouteCollectionForRequest($request)->all();
-
-        $this->assertIsArray($routes);
-        $this->assertEmpty($routes);
-    }
-
-    public function testIgnoresPagesWithNoRootPageFoundException(): void
-    {
-        /** @var PageModel&MockObject $page */
-        $page = $this->mockClassWithProperties(PageModel::class);
-        $page->id = 17;
-        $page->rootId = 1;
-
-        $page
-            ->expects($this->once())
-            ->method('loadDetails')
-            ->willThrowException(new NoRootPageFoundException())
         ;
 
         $pageAdapter = $this->mockAdapter(['findByType']);

--- a/core-bundle/tests/Routing/RouteProviderTest.php
+++ b/core-bundle/tests/Routing/RouteProviderTest.php
@@ -570,33 +570,6 @@ class RouteProviderTest extends TestCase
         }
     }
 
-    public function testIgnoresRoutesWithoutRootId(): void
-    {
-        /** @var PageModel&MockObject $page */
-        $page = $this->createPage('de', 'foo');
-        $page->rootId = null;
-
-        $page
-            ->expects($this->once())
-            ->method('loadDetails')
-        ;
-
-        $pageAdapter = $this->mockAdapter(['findBy']);
-        $pageAdapter
-            ->expects($this->once())
-            ->method('findBy')
-            ->willReturn(new Collection([$page], 'tl_page'))
-        ;
-
-        $framework = $this->mockFramework($pageAdapter);
-        $request = $this->mockRequestWithPath('/foo.html');
-
-        $routes = $this->getRouteProvider($framework)->getRouteCollectionForRequest($request)->all();
-
-        $this->assertIsArray($routes);
-        $this->assertEmpty($routes);
-    }
-
     private function mockConfigAdapter(array $config): Adapter
     {
         $configAdapter = $this->mockAdapter(['get']);

--- a/core-bundle/tests/Routing/RouteProviderTest.php
+++ b/core-bundle/tests/Routing/RouteProviderTest.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Tests\Routing;
 
 use Contao\Config;
-use Contao\CoreBundle\Exception\NoRootPageFoundException;
 use Contao\CoreBundle\Framework\Adapter;
 use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\CoreBundle\Routing\RouteProvider;
@@ -580,32 +579,6 @@ class RouteProviderTest extends TestCase
         $page
             ->expects($this->once())
             ->method('loadDetails')
-        ;
-
-        $pageAdapter = $this->mockAdapter(['findBy']);
-        $pageAdapter
-            ->expects($this->once())
-            ->method('findBy')
-            ->willReturn(new Collection([$page], 'tl_page'))
-        ;
-
-        $framework = $this->mockFramework($pageAdapter);
-        $request = $this->mockRequestWithPath('/foo.html');
-
-        $routes = $this->getRouteProvider($framework)->getRouteCollectionForRequest($request)->all();
-
-        $this->assertIsArray($routes);
-        $this->assertEmpty($routes);
-    }
-
-    public function testIgnoresPagesWithNoRootPageFoundException(): void
-    {
-        /** @var PageModel&MockObject $page */
-        $page = $this->createPage('de', 'foo');
-        $page
-            ->expects($this->once())
-            ->method('loadDetails')
-            ->willThrowException(new NoRootPageFoundException())
         ;
 
         $pageAdapter = $this->mockAdapter(['findBy']);


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #1408, #1411

Since we yet-again had issues the router generating `NoRootPageFoundException`s, we looked into why there are orphan pages in the page tree at all. Looks like a DCA in tree mode (5) was never correctly cleaned up!