### PR TITLE
Remove the dev firewall

### DIFF
--- a/manager-bundle/src/Resources/skeleton/config/security.yml
+++ b/manager-bundle/src/Resources/skeleton/config/security.yml
@@ -11,10 +11,6 @@ security:
             algorithm: auto
 
     firewalls:
-        dev:
-            pattern: ^/(_(profiler|wdt|error)|css|images|js)/
-            security: false
-
         contao_install:
             pattern: ^/contao/install$
             security: false


### PR DESCRIPTION
The `dev` firewall configuration has been inherited from the default Symfony configuration: https://github.com/symfony/recipes/blob/master/symfony/security-bundle/5.3/config/packages/security.yaml#L8-L10

This makes sense in Symfony, since the main firewall applies to all other requests. However, in Contao, our firewall only apply to requests that have a `frontend` or `backend` scope. Therefore, the dev patterns already do not have a firewall anyway.

The problem with the `dev` configuration is that it disables the firewall for all routes on `/images/` etc. Even if there is a route with a scope on this path, it would not get a firewall. This is mostly problematic since our 404 pages are triggered on any unknown route (e.g. `/images/foobar.html`). In Contao 4.12 we started using voters, and if you for example have a navigation module on the 404 page, the access decision manager will fail due to a missing firewall.

In Contao core (navigation module & voters) the problem only happens in Contao 4.12. However, if any other module would be placed on the 404 page that uses voters, this problem would also appear on 4.9 therefore it should be fixed in 4.9.