### PR TITLE
Fix session service check in AddSessionBagsPass

### DIFF
--- a/core-bundle/src/DependencyInjection/Compiler/AddSessionBagsPass.php
+++ b/core-bundle/src/DependencyInjection/Compiler/AddSessionBagsPass.php
@@ -23,7 +23,7 @@ class AddSessionBagsPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void
     {
-        if (!$container->hasDefinition('session')) {
+        if (!$container->has('session')) {
             return;
         }
 

--- a/core-bundle/tests/DependencyInjection/Compiler/AddSessionBagsPassTest.php
+++ b/core-bundle/tests/DependencyInjection/Compiler/AddSessionBagsPassTest.php
@@ -25,7 +25,8 @@ class AddSessionBagsPassTest extends TestCase
     public function testAddsTheSessionBags(): void
     {
         $container = new ContainerBuilder();
-        $container->setDefinition('session', new Definition(Session::class));
+        $container->setDefinition('session.foobar', new Definition(Session::class));
+        $container->setAlias('session', 'session.foobar');
         $container->setDefinition('contao.session.contao_backend', new Definition(ArrayAttributeBag::class));
         $container->setDefinition('contao.session.contao_frontend', new Definition(ArrayAttributeBag::class));
 
@@ -50,6 +51,6 @@ class AddSessionBagsPassTest extends TestCase
         $pass = new AddSessionBagsPass();
         $pass->process($container);
 
-        $this->assertFalse($container->hasDefinition('session'));
+        $this->assertFalse($container->has('session'));
     }
 }


### PR DESCRIPTION
In Symfony 5.3 the `session` service and the `SessionInterface` have been deprecated (you are supposed to use `$request->getSession()` instead). The `session` service is now only an alias for the `.session.do-not-use` service. This causes the `AddSessionBagsPass` to not register the Contao session bags, because `hasDefinition` does not check for aliases. This leads to the following error in the front and back end:

```
InvalidArgumentException:
The SessionBagInterface "contao_backend" is not registered.

  at vendor\symfony\http-foundation\Session\Storage\NativeSessionStorage.php:317
  at Symfony\Component\HttpFoundation\Session\Storage\NativeSessionStorage->getBag()
     (vendor\symfony\http-foundation\Session\Session.php:257)
  at Symfony\Component\HttpFoundation\Session\Session->getBag()
     (vendor\contao\contao\core-bundle\src\Framework\ContaoFramework.php:352)
  at Contao\CoreBundle\Framework\ContaoFramework->initializeLegacySessionAccess()
     (vendor\contao\contao\core-bundle\src\Framework\ContaoFramework.php:297)
  at Contao\CoreBundle\Framework\ContaoFramework->initializeFramework()
     (vendor\contao\contao\core-bundle\src\Framework\ContaoFramework.php:158)
  at Contao\CoreBundle\Framework\ContaoFramework->initialize()
     (vendor\contao\contao\core-bundle\src\Routing\RouteProvider.php:59)
  at Contao\CoreBundle\Routing\RouteProvider->getRouteCollectionForRequest()
     (vendor\symfony-cmf\routing\src\NestedMatcher\NestedMatcher.php:140)
  at Symfony\Cmf\Component\Routing\NestedMatcher\NestedMatcher->matchRequest()
     (vendor\symfony-cmf\routing\src\DynamicRouter.php:278)
  at Symfony\Cmf\Component\Routing\DynamicRouter->matchRequest()
     (vendor\symfony-cmf\routing\src\ChainRouter.php:188)
  at Symfony\Cmf\Component\Routing\ChainRouter->doMatch()
     (vendor\symfony-cmf\routing\src\ChainRouter.php:158)
  at Symfony\Cmf\Component\Routing\ChainRouter->matchRequest()
     (vendor\symfony\http-kernel\EventListener\RouterListener.php:112)
  at Symfony\Component\HttpKernel\EventListener\RouterListener->onKernelRequest()
     (vendor\symfony\event-dispatcher\Debug\WrappedListener.php:117)
  at Symfony\Component\EventDispatcher\Debug\WrappedListener->__invoke()
     (vendor\symfony\event-dispatcher\EventDispatcher.php:230)
  at Symfony\Component\EventDispatcher\EventDispatcher->callListeners()
     (vendor\symfony\event-dispatcher\EventDispatcher.php:59)
  at Symfony\Component\EventDispatcher\EventDispatcher->dispatch()
     (vendor\symfony\event-dispatcher\Debug\TraceableEventDispatcher.php:151)
  at Symfony\Component\EventDispatcher\Debug\TraceableEventDispatcher->dispatch()
     (vendor\symfony\http-kernel\HttpKernel.php:133)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw()
     (vendor\symfony\http-kernel\HttpKernel.php:79)
  at Symfony\Component\HttpKernel\HttpKernel->handle()
     (vendor\symfony\http-kernel\Kernel.php:199)
  at Symfony\Component\HttpKernel\Kernel->handle()
     (web\index.php:31)
  at require('web/index.php')
     (web\app.php:4)                
```

This PR fixes that by using `$container->has`, which checks both for service definitions and aliases.