### PR TITLE
Add missing SchemaOrgRuntime service declaration

### DIFF
--- a/core-bundle/src/Resources/config/services.yml
+++ b/core-bundle/src/Resources/config/services.yml
@@ -962,6 +962,10 @@ services:
 
     Contao\CoreBundle\Twig\Runtime\PictureConfigurationRuntime: ~
 
+    Contao\CoreBundle\Twig\Runtime\SchemaOrgRuntime:
+        arguments:
+            - '@Contao\CoreBundle\Routing\ResponseContext\ResponseContextAccessor'
+
     Contao\CoreBundle\Util\SimpleTokenExpressionLanguage:
         arguments:
             - ~


### PR DESCRIPTION
Super silly mistake. This commit that registers the `SchemaOrgRuntime` as a service was lost in the main Twig PR. :see_no_evil: 

Without it you'd get a `Unable to load the "Contao\CoreBundle\Twig\Runtime\SchemaOrgRuntime" runtime.` message when you tried to use the Figure macros or the `add_schema_org` function.