### PR TITLE
Harden literal insert tag replacement

### DIFF
--- a/core-bundle/src/Resources/contao/classes/FrontendTemplate.php
+++ b/core-bundle/src/Resources/contao/classes/FrontendTemplate.php
@@ -152,7 +152,7 @@ class FrontendTemplate extends Template
 			$this->strBuffer = $this->minifyHtml($this->strBuffer);
 		}
 
-		// Replace literal insert tags (see #670)
+		// Replace literal insert tags (see #670, #3249)
 		$this->strBuffer = preg_replace_callback(
 			'/<script[^>]*>.*?<\/script[^>]*>|\[[{}]]/is',
 			static function ($matches)

--- a/core-bundle/src/Resources/contao/classes/FrontendTemplate.php
+++ b/core-bundle/src/Resources/contao/classes/FrontendTemplate.php
@@ -154,7 +154,7 @@ class FrontendTemplate extends Template
 
 		// Replace literal insert tags (see #670)
 		$this->strBuffer = preg_replace_callback(
-			'/<script[^>]*>.*?<\/script[^>]*>|\[[{}]\]/is',
+			'/<script[^>]*>.*?<\/script[^>]*>|\[[{}]]/is',
 			static function ($matches)
 			{
 				return $matches[0][0] === '<' ? $matches[0] : $matches[0][1] . $matches[0][1];

--- a/core-bundle/src/Resources/contao/classes/FrontendTemplate.php
+++ b/core-bundle/src/Resources/contao/classes/FrontendTemplate.php
@@ -153,7 +153,9 @@ class FrontendTemplate extends Template
 		}
 
 		// Replace literal insert tags (see #670)
-		$this->strBuffer = preg_replace('/\[{](.*)\[}]/', '{{$1}}', $this->strBuffer);
+		$this->strBuffer = preg_replace_callback('/<script[^>]*>.*?<\/script[^>]*>|\[[{}]\]/is', function ($matches) {
+			return $matches[0][0] === '<' ? $matches[0] : $matches[0][1] . $matches[0][1];
+		}, $this->strBuffer);
 
 		parent::compile();
 	}

--- a/core-bundle/src/Resources/contao/classes/FrontendTemplate.php
+++ b/core-bundle/src/Resources/contao/classes/FrontendTemplate.php
@@ -153,7 +153,7 @@ class FrontendTemplate extends Template
 		}
 
 		// Replace literal insert tags (see #670)
-		$this->strBuffer = str_replace(array('[{]', '[}]'), array('{{', '}}'), $this->strBuffer);
+		$this->strBuffer = preg_replace('/\[{](.*)\[}]/', '{{$1}}', $this->strBuffer);
 
 		parent::compile();
 	}

--- a/core-bundle/src/Resources/contao/classes/FrontendTemplate.php
+++ b/core-bundle/src/Resources/contao/classes/FrontendTemplate.php
@@ -153,9 +153,14 @@ class FrontendTemplate extends Template
 		}
 
 		// Replace literal insert tags (see #670)
-		$this->strBuffer = preg_replace_callback('/<script[^>]*>.*?<\/script[^>]*>|\[[{}]\]/is', function ($matches) {
-			return $matches[0][0] === '<' ? $matches[0] : $matches[0][1] . $matches[0][1];
-		}, $this->strBuffer);
+		$this->strBuffer = preg_replace_callback(
+			'/<script[^>]*>.*?<\/script[^>]*>|\[[{}]\]/is',
+			static function ($matches)
+			{
+				return $matches[0][0] === '<' ? $matches[0] : $matches[0][1] . $matches[0][1];
+			},
+			$this->strBuffer
+		);
 
 		parent::compile();
 	}

--- a/core-bundle/tests/Contao/TemplateTest.php
+++ b/core-bundle/tests/Contao/TemplateTest.php
@@ -250,4 +250,79 @@ EOF
 
         $this->assertSame(['test' => 1], $dump);
     }
+
+    /**
+     * @dataProvider provideBuffer
+     */
+    public function testCompileReplacesLiteralInsertTags(string $buffer, string $expectedOutput): void
+    {
+        $page = new \stdClass();
+        $page->minifyMarkup = false;
+
+        $GLOBALS['objPage'] = $page;
+        $GLOBALS['TL_KEYWORDS'] = '';
+
+        $template = new class($buffer) extends FrontendTemplate {
+            /**
+             * @var string
+             */
+            private $testBuffer;
+
+            public function __construct(string $testBuffer)
+            {
+                $this->testBuffer = $testBuffer;
+
+                parent::__construct();
+            }
+
+            public function parse(): string
+            {
+                return $this->testBuffer;
+            }
+
+            public function testCompile(): string
+            {
+                $this->compile();
+
+                return $this->strBuffer;
+            }
+
+            public static function replaceInsertTags($strBuffer, $blnCache = true)
+            {
+                return $strBuffer; // ignore insert tags
+            }
+
+            public static function replaceDynamicScriptTags($strBuffer)
+            {
+                return $strBuffer; // ignore dynamic script tags
+            }
+        };
+
+        $this->assertSame($expectedOutput, $template->testCompile());
+
+        unset($GLOBALS['objPage'],$GLOBALS['TL_KEYWORDS']);
+    }
+
+    public function provideBuffer(): \Generator
+    {
+        yield 'plain string' => [
+            'foo bar',
+            'foo bar',
+        ];
+
+        yield 'literal insert tags are replaced' => [
+            'foo[{]bar[{]baz[}]',
+            'foo{{bar{{baz}}',
+        ];
+
+        yield 'literal insert tags inside script tag are not replaced' => [
+            '<script type="application/javascript">if (/[\[{]$/.test(foo)) {}</script>',
+            '<script type="application/javascript">if (/[\[{]$/.test(foo)) {}</script>',
+        ];
+
+        yield 'multiple occurrences' => [
+            '[{][}]<script>[{][}]</script>[{][}]<script>[{][}]</script>[{][}]',
+            '{{}}<script>[{][}]</script>{{}}<script>[{][}]</script>{{}}',
+        ];
+    }
 }


### PR DESCRIPTION
This is an attempt at fixing #3249.

This way only `[{]the_tag[}]` will be transformed to `{{the_tag}}`, arbitrary single delimiters stay the same.