### PR TITLE
Fix more invalid array access and missing null checks

### DIFF
--- a/core-bundle/src/Resources/contao/classes/FrontendTemplate.php
+++ b/core-bundle/src/Resources/contao/classes/FrontendTemplate.php
@@ -143,11 +143,11 @@ class FrontendTemplate extends Template
 			throw new \UnusedArgumentsException('Unused arguments: ' . implode(', ', Input::getUnusedGet()));
 		}
 
-		/** @var PageModel $objPage */
+		/** @var PageModel|null $objPage */
 		global $objPage;
 
 		// Minify the markup
-		if ($objPage->minifyMarkup)
+		if ($objPage !== null && $objPage->minifyMarkup)
 		{
 			$this->strBuffer = $this->minifyHtml($this->strBuffer);
 		}

--- a/core-bundle/src/Resources/contao/classes/FrontendTemplate.php
+++ b/core-bundle/src/Resources/contao/classes/FrontendTemplate.php
@@ -102,7 +102,7 @@ class FrontendTemplate extends Template
 	protected function compile()
 	{
 		$this->keywords = '';
-		$arrKeywords = StringUtil::trimsplit(',', $GLOBALS['TL_KEYWORDS']);
+		$arrKeywords = StringUtil::trimsplit(',', $GLOBALS['TL_KEYWORDS'] ?? '');
 
 		// Add the meta keywords
 		if (isset($arrKeywords[0]))

--- a/core-bundle/src/Resources/contao/library/Contao/Controller.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Controller.php
@@ -853,10 +853,10 @@ abstract class Controller extends System
 			}
 		}
 
-		/** @var PageModel $objPage */
+		/** @var PageModel|null $objPage */
 		global $objPage;
 
-		$objLayout = LayoutModel::findByPk($objPage->layoutId);
+		$objLayout = ($objPage !== null) ? LayoutModel::findByPk($objPage->layoutId) : null;
 		$blnCombineScripts = ($objLayout === null) ? false : $objLayout->combineScripts;
 
 		$arrReplace['[[TL_BODY]]'] = $strScripts;


### PR DESCRIPTION
Fixes `Warning: Undefined array key "TL_KEYWORDS"` and other warnings in the back end.

This will happen when you use `$template->getResponse()` in a fragment. 