### PR TITLE
Do not add the native suffix in System::getLanguages()

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/System.php
+++ b/core-bundle/src/Resources/contao/library/Contao/System.php
@@ -606,10 +606,10 @@ abstract class System
 
 		if ($blnInstalledOnly)
 		{
-			return self::getContainer()->get(Locales::class)->getEnabledLocales(null, true);
+			return self::getContainer()->get(Locales::class)->getEnabledLocales();
 		}
 
-		return self::getContainer()->get(Locales::class)->getLocales(null, true);
+		return self::getContainer()->get(Locales::class)->getLocales();
 	}
 
 	/**


### PR DESCRIPTION
<img width="582" alt="" src="https://user-images.githubusercontent.com/1192057/128197136-39ca9cc7-e44e-4fa3-9d95-e29bb3168d5e.png">

The native suffix has not been added in Contao <4.12, either, therefore we should not change the behavior.