### PR TITLE
Fix a type error in the event list module

### DIFF
--- a/calendar-bundle/src/Resources/contao/modules/ModuleEventlist.php
+++ b/calendar-bundle/src/Resources/contao/modules/ModuleEventlist.php
@@ -401,7 +401,7 @@ class ModuleEventlist extends Events
 			// schema.org information
 			$objTemplate->getSchemaOrgData = static function () use ($objTemplate, $event): array
 			{
-				$jsonLd = Events::getSchemaOrgData($event);
+				$jsonLd = Events::getSchemaOrgData((new CalendarEventsModel())->setRow($event));
 
 				if ($objTemplate->addImage && $objTemplate->figure)
 				{

--- a/core-bundle/src/Resources/contao/library/Contao/Controller.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Controller.php
@@ -1526,11 +1526,8 @@ abstract class Controller extends System
 		{
 			if ($interpretAsContentModel)
 			{
-				/** @var ContentModel $contentModel */
-				$contentModel = (new \ReflectionClass(ContentModel::class))->newInstanceWithoutConstructor();
-
 				// This will be null if "overwriteMeta" is not set
-				return $contentModel->setRow($rowData)->getOverwriteMetadata();
+				return (new ContentModel())->setRow($rowData)->getOverwriteMetadata();
 			}
 
 			// Manually create metadata that always contains certain properties (BC)


### PR DESCRIPTION
`Events::getSchemaOrgData()` expects a `CalendarEventsModel` and not an array.