### PR TITLE
Show native language suffix only in user profile

### DIFF
--- a/core-bundle/src/Resources/contao/dca/tl_member.php
+++ b/core-bundle/src/Resources/contao/dca/tl_member.php
@@ -279,7 +279,7 @@ $GLOBALS['TL_DCA']['tl_member'] = array
 			'eval'                    => array('includeBlankOption'=>true, 'chosen'=>true, 'feEditable'=>true, 'feViewable'=>true, 'feGroup'=>'personal', 'tl_class'=>'w50'),
 			'options_callback' => static function ()
 			{
-				return System::getContainer()->get(Locales::class)->getLocales(null, true);
+				return System::getContainer()->get(Locales::class)->getLocales(null, Input::get('do') != 'member');
 			},
 			'sql'                     => "varchar(64) NOT NULL default ''"
 		),

--- a/core-bundle/src/Resources/contao/dca/tl_member.php
+++ b/core-bundle/src/Resources/contao/dca/tl_member.php
@@ -279,7 +279,7 @@ $GLOBALS['TL_DCA']['tl_member'] = array
 			'eval'                    => array('includeBlankOption'=>true, 'chosen'=>true, 'feEditable'=>true, 'feViewable'=>true, 'feGroup'=>'personal', 'tl_class'=>'w50'),
 			'options_callback' => static function ()
 			{
-				return System::getContainer()->get(Locales::class)->getLocales(null, Input::get('do') != 'member');
+				return System::getContainer()->get(Locales::class)->getLocales(null, false);
 			},
 			'sql'                     => "varchar(64) NOT NULL default ''"
 		),

--- a/core-bundle/src/Resources/contao/dca/tl_user.php
+++ b/core-bundle/src/Resources/contao/dca/tl_user.php
@@ -181,7 +181,7 @@ $GLOBALS['TL_DCA']['tl_user'] = array
 			'eval'                    => array('mandatory'=>true, 'tl_class'=>'w50'),
 			'options_callback' => static function ()
 			{
-				return System::getContainer()->get(Locales::class)->getEnabledLocales(null, true);
+				return System::getContainer()->get(Locales::class)->getEnabledLocales(null, Input::get('do') != 'user');
 			},
 			'sql'                     => "varchar(64) NOT NULL default ''"
 		),


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #3267

Alternative to #3267

Shows the native suffix only in the user profile ~~or the member personal data module~~.