### PR TITLE
Always refresh the template hierarchy in the debug:contao-twig command

### DIFF
--- a/core-bundle/src/Command/DebugContaoTwigCommand.php
+++ b/core-bundle/src/Command/DebugContaoTwigCommand.php
@@ -52,7 +52,6 @@ class DebugContaoTwigCommand extends Command
     {
         $this
             ->setDescription('Displays the Contao template hierarchy.')
-            ->addOption('refresh', 'r', InputOption::VALUE_NONE, 'Refresh the cache.')
             ->addOption('theme', 't', InputOption::VALUE_OPTIONAL, 'Include theme templates with a given theme path or alias.')
             ->addArgument('filter', InputArgument::OPTIONAL, 'Filter the output by an identifier or prefix.')
         ;
@@ -60,6 +59,9 @@ class DebugContaoTwigCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        // Make sure the template hierarchy is up-to-date
+        $this->cacheWarmer->refresh();
+
         $rows = [];
         $chains = $this->hierarchy->getInheritanceChains($this->getThemeAlias($input));
 
@@ -89,12 +91,6 @@ class DebugContaoTwigCommand extends Command
         $io = new SymfonyStyle($input, $output);
         $io->title('Template hierarchy');
         $io->table(['Identifier', 'Effective logical name', 'Path'], $rows);
-
-        if ($input->getOption('refresh')) {
-            $this->cacheWarmer->refresh();
-
-            $io->success('Template loader cache and hierarchy was successfully rebuilt.');
-        }
 
         return 0;
     }

--- a/core-bundle/tests/Command/DebugContaoTwigCommandTest.php
+++ b/core-bundle/tests/Command/DebugContaoTwigCommandTest.php
@@ -30,34 +30,11 @@ class DebugContaoTwigCommandTest extends ContaoTestCase
         $this->assertSame('debug:contao-twig', $command->getName());
         $this->assertNotEmpty($command->getDescription());
 
-        $this->assertTrue($command->getDefinition()->hasOption('refresh'));
         $this->assertTrue($command->getDefinition()->hasOption('theme'));
         $this->assertTrue($command->getDefinition()->hasArgument('filter'));
     }
 
-    public function testDoesNotRefreshLoaderByDefault(): void
-    {
-        $cacheWarmer = $this->createMock(ContaoFilesystemLoaderWarmer::class);
-        $cacheWarmer
-            ->expects($this->never())
-            ->method('refresh')
-        ;
-
-        $command = new DebugContaoTwigCommand(
-            $this->createMock(TemplateHierarchyInterface::class),
-            $cacheWarmer,
-        );
-
-        $tester = new CommandTester($command);
-        $tester->execute([]);
-
-        $this->assertSame(0, $tester->getStatusCode());
-    }
-
-    /**
-     * @dataProvider provideRefreshOptions
-     */
-    public function testRefreshesLoader(string $refreshOption): void
+    public function testRefreshesLoader(): void
     {
         $cacheWarmer = $this->createMock(ContaoFilesystemLoaderWarmer::class);
         $cacheWarmer
@@ -71,15 +48,9 @@ class DebugContaoTwigCommandTest extends ContaoTestCase
         );
 
         $tester = new CommandTester($command);
-        $tester->execute([$refreshOption => null]);
+        $tester->execute([]);
 
         $this->assertSame(0, $tester->getStatusCode());
-    }
-
-    public function provideRefreshOptions(): \Generator
-    {
-        yield 'regular' => ['--refresh'];
-        yield 'short' => ['-r'];
     }
 
     /**


### PR DESCRIPTION
We should always reset the loader cache + rebuild the template hierarchy when a user runs `debug:contao-twig`. 

The old implementation had a stupid issue where the reset part was run _after_ outputting results, but I could also create scenarios* where the cache wasn't up to date and you would need to reset it manually and _only_ on the command line. Removing the option and always resetting has a much better DX and is quick enough that you won't notice it.

*) e.g. running `contao-console cache:pool:clear cache.system` = clearing the cache pool, no warming

/cc @ausi 