### PR TITLE
Check if the indexer service exists when purging search tables

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Automator.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Automator.php
@@ -35,13 +35,13 @@ class Automator extends System
 	 */
 	public function purgeSearchTables()
 	{
-		$searchIndexer = System::getContainer()->get('contao.search.indexer');
-
 		// The search indexer is disabled
-		if (null === $searchIndexer)
+		if (!System::getContainer()->has('contao.search.indexer'))
 		{
 			return;
 		}
+
+		$searchIndexer = System::getContainer()->get('contao.search.indexer');
 
 		// Clear the index
 		$searchIndexer->clear();

--- a/core-bundle/src/Resources/contao/library/Contao/Automator.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Automator.php
@@ -43,6 +43,11 @@ class Automator extends System
 
 		$searchIndexer = System::getContainer()->get('contao.search.indexer');
 
+		if (null === $searchIndexer)
+		{
+		    return;
+		}
+
 		// Clear the index
 		$searchIndexer->clear();
 

--- a/core-bundle/src/Resources/contao/library/Contao/Automator.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Automator.php
@@ -45,7 +45,7 @@ class Automator extends System
 
 		if (null === $searchIndexer)
 		{
-		    return;
+			return;
 		}
 
 		// Clear the index

--- a/core-bundle/src/Resources/contao/library/Contao/Automator.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Automator.php
@@ -43,11 +43,6 @@ class Automator extends System
 
 		$searchIndexer = System::getContainer()->get('contao.search.indexer');
 
-		if (null === $searchIndexer)
-		{
-			return;
-		}
-
 		// Clear the index
 		$searchIndexer->clear();
 


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | n/a
| Docs PR or issue | n/a

When the default search indexer is disabled and you click on purge search index you'll get a `ServiceNotFoundException`: `You have requested a non-existent service "contao.search.indexer".`