### PR TITLE
Improve compatibility with JSON in attributes

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/InsertTags.php
+++ b/core-bundle/src/Resources/contao/library/Contao/InsertTags.php
@@ -1210,10 +1210,10 @@ class InsertTags extends Controller
 			$tag = $matches[0][0];
 
 			// Encode insert tags
-			$tag = preg_replace('/(?:\|attr)?}}/', '|attr}}', $tag);
-			$tag = str_replace('|urlattr|attr}}', '|urlattr}}', $tag);
 			$tagPrefix = substr($tag, 0, $matches[1][1] - $matches[0][1] + \strlen($matches[1][0]));
 			$tag = $tagPrefix . $this->fixUnclosedTagsAndUrlAttributes(substr($tag, \strlen($tagPrefix)));
+			$tag = preg_replace('/(?:\|attr)?}}/', '|attr}}', $tag);
+			$tag = str_replace('|urlattr|attr}}', '|urlattr}}', $tag);
 
 			$offset = $matches[0][1] + \strlen($matches[0][0]);
 			$htmlResult .= $tag;
@@ -1296,11 +1296,16 @@ class InsertTags extends Controller
 				$matches[0][0] = StringUtil::stripInsertTags($matches[0][0]);
 				$matches[0][0] = str_replace(array('{{', '}}'), array('[{]', '[}]'), $matches[0][0]);
 			}
+			elseif ($intLastOpen === false && $intLastClose !== false)
+			{
+				// Improve compatibility with JSON in attributes
+				$matches[0][0] = str_replace('}}', '&#125;&#125;', $matches[0][0]);
+			}
 
 			// Add the urlattr insert tags flag in URL attributes
 			if (\in_array(strtolower($matches[1][0]), array('src', 'srcset', 'href', 'action', 'formaction', 'codebase', 'cite', 'background', 'longdesc', 'profile', 'usemap', 'classid', 'data', 'icon', 'manifest', 'poster', 'archive'), true))
 			{
-				$attributesResult .= str_replace('|attr}}', '|urlattr}}', $matches[0][0]);
+				$attributesResult .= preg_replace('/(?:\|(?:url)?attr)?}}/', '|urlattr}}', $matches[0][0]);
 			}
 			else
 			{

--- a/core-bundle/src/Resources/contao/library/Contao/StringUtil.php
+++ b/core-bundle/src/Resources/contao/library/Contao/StringUtil.php
@@ -974,6 +974,12 @@ class StringUtil
 	{
 		$strString = self::specialchars($strString, $blnStripInsertTags, $blnDoubleEncode);
 
+		// Improve compatibility with JSON in attributes if no insert tags are present
+		if ($strString === self::stripInsertTags($strString))
+		{
+			$strString = str_replace('}}', '&#125;&#125;', $strString);
+		}
+
 		// Encode insert tags too
 		$strString = preg_replace('/(?:\|attr)?}}/', '|attr}}', $strString);
 		$strString = str_replace('|urlattr|attr}}', '|urlattr}}', $strString);

--- a/core-bundle/tests/Contao/InputTest.php
+++ b/core-bundle/tests/Contao/InputTest.php
@@ -110,6 +110,31 @@ class InputTest extends TestCase
             '<img src="foo{{bar&#125;{{noop|urlattr}}&#125;baz">',
         ];
 
+        yield 'Do not destroy JSON attributes' => [
+            '<span data-myjson=\'{"foo":{"bar":"baz"}}\'>',
+            '<span data-myjson="{&quot;foo&quot;:{&quot;bar&quot;:&quot;baz&quot;&#125;&#125;">',
+        ];
+
+        yield 'Do not destroy nested JSON attributes' => [
+            '<span data-myjson=\'[{"foo":{"bar":"baz"}},12.3,"string"]\'>',
+            '<span data-myjson="[{&quot;foo&quot;:{&quot;bar&quot;:&quot;baz&quot;&#125;&#125;,12.3,&quot;string&quot;]">',
+        ];
+
+        yield 'Do not destroy quoted JSON attributes' => [
+            '<span data-myjson="{&quot;foo&quot;:{&quot;bar&quot;:&quot;baz&quot;}}">',
+            '<span data-myjson="{&quot;foo&quot;:{&quot;bar&quot;:&quot;baz&quot;&#125;&#125;">',
+        ];
+
+        yield 'Do not destroy nested quoted JSON attributes' => [
+            '<span data-myjson="[{&quot;foo&quot;:{&quot;bar&quot;:&quot;baz&quot;}},12.3,&quot;string&quot;]">',
+            '<span data-myjson="[{&quot;foo&quot;:{&quot;bar&quot;:&quot;baz&quot;&#125;&#125;,12.3,&quot;string&quot;]">',
+        ];
+
+        yield 'Trick insert tag detection with JSON' => [
+            '<span data-myjson=\'{"foo":{"{{bar::":"baz"}}\'>',
+            '<span data-myjson="{&quot;foo&quot;:{&quot;{{bar::&quot;:&quot;baz&quot;|attr}}">',
+        ];
+
         yield [
             '<form action="javascript:alert(document.domain)"><input type="submit" value="XSS" /></form>',
             '<form><input></form>',

--- a/core-bundle/tests/Contao/InsertTagsTest.php
+++ b/core-bundle/tests/Contao/InsertTagsTest.php
@@ -44,7 +44,7 @@ class InsertTagsTest extends TestCase
 
     public function replaceInsertTagsHook(string $tag): string
     {
-        return explode('::', $tag, 2)[1];
+        return explode('::', $tag, 2)[1] ?? '';
     }
 
     /**
@@ -235,6 +235,31 @@ class InsertTagsTest extends TestCase
         yield 'Trick comments detection with insert tag' => [
             '<!-- {{plain::--}}> got you! -->',
             '<!-- [{]plain::--[}]> got you! -->',
+        ];
+
+        yield 'Do not destroy JSON attributes' => [
+            '<span data-myjson=\'{"foo":{"bar":"baz"}}\'>',
+            '<span data-myjson=\'{"foo":{"bar":"baz"&#125;&#125;\'>',
+        ];
+
+        yield 'Do not destroy nested JSON attributes' => [
+            '<span data-myjson=\'[{"foo":{"bar":"baz"}},12.3,"string"]\'>',
+            '<span data-myjson=\'[{"foo":{"bar":"baz"&#125;&#125;,12.3,"string"]\'>',
+        ];
+
+        yield 'Do not destroy quoted JSON attributes' => [
+            '<span data-myjson="{&quot;foo&quot;:{&quot;bar&quot;:&quot;baz&quot;}}">',
+            '<span data-myjson="{&quot;foo&quot;:{&quot;bar&quot;:&quot;baz&quot;&#125;&#125;">',
+        ];
+
+        yield 'Do not destroy nested quoted JSON attributes' => [
+            '<span data-myjson="[{&quot;foo&quot;:{&quot;bar&quot;:&quot;baz&quot;}},12.3,&quot;string&quot;]">',
+            '<span data-myjson="[{&quot;foo&quot;:{&quot;bar&quot;:&quot;baz&quot;&#125;&#125;,12.3,&quot;string&quot;]">',
+        ];
+
+        yield 'Trick insert tag detection with JSON' => [
+            '<span data-myjson=\'{"foo":{"{{bar::":"baz"}}\'>',
+            '<span data-myjson=\'{"foo":{"&quot;:&quot;baz&quot;\'>',
         ];
     }
 }


### PR DESCRIPTION
**Affected version(s)**

Contao 4.4.56, 4.9.18, 4.11.7

**Description**

With the security fix some attributes that contain JSON no longer work

```html
<span data-json="{foo:{bar:123}}"></span>
```

gets replaced with

```html
<span data-json="{foo:{bar:123|attr}}"></span>
```

This should be fixed with this pull request (without loosing the safety).