### PR TITLE
Do not show the urlattr flag for rgxp url fields

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Widget.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Widget.php
@@ -1385,6 +1385,12 @@ abstract class Widget extends Controller
 			$arrAttributes['value'] = $objDate->{$arrData['eval']['rgxp']};
 		}
 
+		// Convert URL insert tags
+		if ($varValue && 'url' === ($arrData['eval']['rgxp'] ?? null))
+		{
+			$arrAttributes['value'] = str_replace('|urlattr}}', '}}', $varValue);
+		}
+
 		// Add the "rootNodes" array as attribute (see #3563)
 		if (isset($arrData['rootNodes']) && !isset($arrData['eval']['rootNodes']))
 		{


### PR DESCRIPTION
When saving `rgxp => url` fields we add the `urlattr` flag in https://github.com/contao/contao/blob/6a676204294a2613013bfb88a1be8d4247ac2254/core-bundle/src/Resources/contao/library/Contao/Widget.php#L983-L984

This pull request does the counterpart by removing it when the value is shown to the user.

Related: https://community.contao.org/de/showthread.php?81418