### PR TITLE
Enable putenv for Dotenv

### DIFF
--- a/manager-bundle/src/HttpKernel/ContaoKernel.php
+++ b/manager-bundle/src/HttpKernel/ContaoKernel.php
@@ -406,7 +406,7 @@ class ContaoKernel extends Kernel implements HttpCacheProvider
                 $_ENV[$k] = $_ENV[$k] ?? (isset($_SERVER[$k]) && 0 !== strpos($k, 'HTTP_') ? $_SERVER[$k] : $v);
             }
         } elseif (file_exists($projectDir.'/.env')) {
-            (new Dotenv(false))->loadEnv($projectDir.'/.env', 'APP_ENV', $defaultEnv);
+            (new Dotenv(true))->loadEnv($projectDir.'/.env', 'APP_ENV', $defaultEnv);
         }
 
         $_SERVER += $_ENV;


### PR DESCRIPTION
While developing a Google Firestore connection within Contao I noticed that defining the project ID and service credentials could not be set via the respective environment variables when using the `.env` files.

This is because `google/cloud-core` for instance reads these environment variables only via `getenv()`. The `ContaoKernel` of the manager bundle however specifically disables the usage of `putenv()` for `Dotenv`.

Is there any specific reason for that? Otherwise I think it would be helpful to enable this for the Managed Edition.