### PR TITLE
Fix undefined array keys

### DIFF
--- a/core-bundle/src/Resources/contao/classes/StyleSheets.php
+++ b/core-bundle/src/Resources/contao/classes/StyleSheets.php
@@ -640,10 +640,10 @@ class StyleSheets extends Backend
 			// Border width
 			if (\is_array($row['borderwidth']))
 			{
-				$top = $row['borderwidth']['top'];
-				$right = $row['borderwidth']['right'];
-				$bottom = $row['borderwidth']['bottom'];
-				$left = $row['borderwidth']['left'];
+				$top = $row['borderwidth']['top'] ?? '';
+				$right = $row['borderwidth']['right'] ?? '';
+				$bottom = $row['borderwidth']['bottom'] ?? '';
+				$left = $row['borderwidth']['left'] ?? '';
 
 				// Try to shorten the definition
 				if ($top != '' && $right != '' && $bottom != '' && $left != '' && $top == $right && $top == $bottom && $top == $left)
@@ -849,7 +849,7 @@ class StyleSheets extends Backend
 			$fnColor = StringUtil::deserialize($row['fontcolor'], true);
 
 			// Font color
-			if ($fnColor[0] != '')
+			if (isset($fnColor[0]) && $fnColor[0] != '')
 			{
 				$return .= $lb . 'color:' . $this->compileColor($fnColor, $blnWriteToFile, $vars) . ';';
 			}

--- a/core-bundle/src/Resources/contao/classes/StyleSheets.php
+++ b/core-bundle/src/Resources/contao/classes/StyleSheets.php
@@ -849,7 +849,7 @@ class StyleSheets extends Backend
 			$fnColor = StringUtil::deserialize($row['fontcolor'], true);
 
 			// Font color
-			if (isset($fnColor[0]) && $fnColor[0] != '')
+			if (!empty($fnColor[0]))
 			{
 				$return .= $lb . 'color:' . $this->compileColor($fnColor, $blnWriteToFile, $vars) . ';';
 			}


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fix Undefined array keys

When importing a CSS in debug mode, with this content, warnings are displayed.
```css
.mod_visitors .visitor_name {
    margin:10px 10px 4px 10px;
    border-bottom:1px solid #C6AD8D;
    font-weight:bold;
}
```
```
Warning: Undefined array key "top"
Warning: Undefined array key 0
```
Second warning comes only after the first one is fixed.


