### PR TITLE
Add the "dry-run" and "format=ndjson" options to the migrate command

### DIFF
--- a/core-bundle/src/Command/MigrateCommand.php
+++ b/core-bundle/src/Command/MigrateCommand.php
@@ -186,6 +186,7 @@ class MigrateCommand extends Command
                     if (!$asJson) {
                         $this->io->section('Pending migrations');
                     }
+
                     $first = false;
                 }
 
@@ -293,14 +294,12 @@ class MigrateCommand extends Command
                 return true;
             }
 
-            $hasNewCommands = \count(
-                array_filter(
-                    array_keys($commands),
-                    static function ($hash) use ($commandsByHash) {
-                        return !isset($commandsByHash[$hash]);
-                    }
-                )
-            );
+            $hasNewCommands = \count(array_filter(
+                array_keys($commands),
+                static function ($hash) use ($commandsByHash) {
+                    return !isset($commandsByHash[$hash]);
+                }
+            ));
 
             if (!$hasNewCommands) {
                 return true;
@@ -343,7 +342,6 @@ class MigrateCommand extends Command
             }
 
             $count = 0;
-
             $commandHashes = $this->getCommandHashes($commands, 'yes, with deletes' === $answer);
 
             do {

--- a/core-bundle/src/Command/MigrateCommand.php
+++ b/core-bundle/src/Command/MigrateCommand.php
@@ -429,8 +429,12 @@ class MigrateCommand extends Command
         $this->io->writeln(
             json_encode(
                 array_merge(['type' => $type], $data, ['type' => $type]),
-                JSON_INVALID_UTF8_SUBSTITUTE | JSON_THROW_ON_ERROR
+                JSON_INVALID_UTF8_SUBSTITUTE
             )
         );
+
+        if (JSON_ERROR_NONE !== json_last_error()) {
+            throw new \JsonException(json_last_error_msg());
+        }
     }
 }

--- a/core-bundle/tests/Command/MigrateCommandTest.php
+++ b/core-bundle/tests/Command/MigrateCommandTest.php
@@ -228,7 +228,6 @@ class MigrateCommandTest extends TestCase
         );
 
         $tester = new CommandTester($command);
-
         $code = $tester->execute(['--dry-run' => true, '--format' => $format]);
         $display = $tester->getDisplay();
 
@@ -336,7 +335,6 @@ class MigrateCommandTest extends TestCase
         ;
 
         $command = $this->getCommand([], [], [], $installer);
-
         $tester = new CommandTester($command);
 
         if ('ndjson' !== $format) {
@@ -349,6 +347,7 @@ class MigrateCommandTest extends TestCase
         $this->assertSame(1, $code);
 
         $json = $this->jsonArrayFromNdjson($display)[0];
+
         $this->assertSame('error', $json['type']);
         $this->assertSame('Fatal', $json['message']);
     }

--- a/core-bundle/tests/Command/MigrateCommandTest.php
+++ b/core-bundle/tests/Command/MigrateCommandTest.php
@@ -26,18 +26,29 @@ use Webmozart\PathUtil\Path;
 
 class MigrateCommandTest extends TestCase
 {
-    public function testExecutesWithoutPendingMigrations(): void
+    /**
+     * @dataProvider getOutputFormats
+     */
+    public function testExecutesWithoutPendingMigrations(string $format): void
     {
         $command = $this->getCommand();
         $tester = new CommandTester($command);
-        $code = $tester->execute([]);
+        $code = $tester->execute(['--format' => $format], ['interactive' => 'ndjson' !== $format]);
         $display = $tester->getDisplay();
 
         $this->assertSame(0, $code);
-        $this->assertRegExp('/All migrations completed/', $display);
+
+        if ('ndjson' === $format) {
+            $this->assertEmpty(trim($display));
+        } else {
+            $this->assertRegExp('/All migrations completed/', $display);
+        }
     }
 
-    public function testExecutesPendingMigrations(): void
+    /**
+     * @dataProvider getOutputFormats
+     */
+    public function testExecutesPendingMigrations(string $format): void
     {
         $command = $this->getCommand(
             [['Migration 1', 'Migration 2']],
@@ -47,24 +58,38 @@ class MigrateCommandTest extends TestCase
         $tester = new CommandTester($command);
         $tester->setInputs(['y']);
 
-        $code = $tester->execute([]);
+        $code = $tester->execute(['--format' => $format], ['interactive' => 'ndjson' !== $format]);
         $display = $tester->getDisplay();
 
         $this->assertSame(0, $code);
-        $this->assertRegExp('/Migration 1/', $display);
-        $this->assertRegExp('/Migration 2/', $display);
-        $this->assertRegExp('/Result 1/', $display);
-        $this->assertRegExp('/Result 2/', $display);
-        $this->assertRegExp('/Executed 2 migrations/', $display);
-        $this->assertRegExp('/All migrations completed/', $display);
+
+        if ('ndjson' === $format) {
+            $this->assertSame(
+                [
+                    ['type' => 'migration-pending', 'name' => 'Migration 1'],
+                    ['type' => 'migration-pending', 'name' => 'Migration 2'],
+                    ['type' => 'migration-result', 'message' => 'Result 1', 'isSuccessful' => true],
+                    ['type' => 'migration-result', 'message' => 'Result 2', 'isSuccessful' => true],
+                ],
+                $this->jsonArrayFromNdjson($display)
+            );
+        } else {
+            $this->assertRegExp('/Migration 1/', $display);
+            $this->assertRegExp('/Migration 2/', $display);
+            $this->assertRegExp('/Result 1/', $display);
+            $this->assertRegExp('/Result 2/', $display);
+            $this->assertRegExp('/Executed 2 migrations/', $display);
+            $this->assertRegExp('/All migrations completed/', $display);
+        }
     }
 
     /**
      * @group legacy
+     * @dataProvider getOutputFormats
      *
      * @expectedDeprecation Using runonce.php files has been deprecated %s.
      */
-    public function testExecutesRunOnceFiles(): void
+    public function testExecutesRunOnceFiles(string $format): void
     {
         $runOnceFile = Path::join($this->getTempDir(), 'runonceFile.php');
 
@@ -75,7 +100,7 @@ class MigrateCommandTest extends TestCase
         $tester = new CommandTester($command);
         $tester->setInputs(['y']);
 
-        $code = $tester->execute([]);
+        $code = $tester->execute(['--format' => $format], ['interactive' => 'ndjson' !== $format]);
         $display = $tester->getDisplay();
 
         $this->assertSame('executed', $GLOBALS['test_'.self::class]);
@@ -83,12 +108,26 @@ class MigrateCommandTest extends TestCase
         unset($GLOBALS['test_'.self::class]);
 
         $this->assertSame(0, $code);
-        $this->assertRegExp('/runonceFile.php/', $display);
-        $this->assertRegExp('/All migrations completed/', $display);
-        $this->assertFileNotExists($runOnceFile, 'File should be gone once executed');
+
+        if ('ndjson' === $format) {
+            $this->assertSame(
+                [
+                    ['type' => 'migration-pending', 'name' => 'Runonce file: runonceFile.php'],
+                    ['type' => 'migration-result', 'message' => 'Executed runonce file: runonceFile.php', 'isSuccessful' => true],
+                ],
+                $this->jsonArrayFromNdjson($display)
+            );
+        } else {
+            $this->assertRegExp('/runonceFile.php/', $display);
+            $this->assertRegExp('/All migrations completed/', $display);
+            $this->assertFileNotExists($runOnceFile, 'File should be gone once executed');
+        }
     }
 
-    public function testExecutesSchemaDiff(): void
+    /**
+     * @dataProvider getOutputFormats
+     */
+    public function testExecutesSchemaDiff(string $format): void
     {
         $installer = $this->createMock(Installer::class);
         $installer
@@ -119,25 +158,45 @@ class MigrateCommandTest extends TestCase
         $tester = new CommandTester($command);
         $tester->setInputs(['yes', 'yes']);
 
-        $code = $tester->execute([]);
+        $code = $tester->execute(['--format' => $format], ['interactive' => 'ndjson' !== $format]);
         $display = $tester->getDisplay();
 
         $this->assertSame(0, $code);
-        $this->assertRegExp('/First call QUERY 1/', $display);
-        $this->assertRegExp('/First call QUERY 2/', $display);
-        $this->assertRegExp('/Second call QUERY 1/', $display);
-        $this->assertRegExp('/Second call QUERY 2/', $display);
-        $this->assertRegExp('/Executed 2 SQL queries/', $display);
-        $this->assertNotRegExp('/Executed 3 SQL queries/', $display);
-        $this->assertRegExp('/All migrations completed/', $display);
+
+        if ('ndjson' === $format) {
+            $this->assertSame(
+                [
+                    ['type' => 'schema-pending', 'commands' => ['First call QUERY 1', 'First call QUERY 2']],
+                    ['type' => 'schema-execute', 'command' => 'First call QUERY 1'],
+                    ['type' => 'schema-result', 'command' => 'First call QUERY 1', 'isSuccessful' => true],
+                    ['type' => 'schema-execute', 'command' => 'First call QUERY 2'],
+                    ['type' => 'schema-result', 'command' => 'First call QUERY 2', 'isSuccessful' => true],
+                    ['type' => 'schema-pending', 'commands' => ['Second call QUERY 1', 'Second call QUERY 2', 'DROP QUERY']],
+                    ['type' => 'schema-execute', 'command' => 'Second call QUERY 1'],
+                    ['type' => 'schema-result', 'command' => 'Second call QUERY 1', 'isSuccessful' => true],
+                    ['type' => 'schema-execute', 'command' => 'Second call QUERY 2'],
+                    ['type' => 'schema-result', 'command' => 'Second call QUERY 2', 'isSuccessful' => true],
+                ],
+                $this->jsonArrayFromNdjson($display)
+            );
+        } else {
+            $this->assertRegExp('/First call QUERY 1/', $display);
+            $this->assertRegExp('/First call QUERY 2/', $display);
+            $this->assertRegExp('/Second call QUERY 1/', $display);
+            $this->assertRegExp('/Second call QUERY 2/', $display);
+            $this->assertRegExp('/Executed 2 SQL queries/', $display);
+            $this->assertNotRegExp('/Executed 3 SQL queries/', $display);
+            $this->assertRegExp('/All migrations completed/', $display);
+        }
     }
 
     /**
      * @group legacy
+     * @dataProvider getOutputFormats
      *
      * @expectedDeprecation Using runonce.php files has been deprecated %s.
      */
-    public function testDoesNotExecuteWithDryRun(): void
+    public function testDoesNotExecuteWithDryRun(string $format): void
     {
         $installer = $this->createMock(Installer::class);
         $installer
@@ -170,23 +229,39 @@ class MigrateCommandTest extends TestCase
 
         $tester = new CommandTester($command);
 
-        $code = $tester->execute(['--dry-run' => true]);
+        $code = $tester->execute(['--dry-run' => true, '--format' => $format]);
         $display = $tester->getDisplay();
 
         $this->assertSame(0, $code);
-        $this->assertRegExp('/Migration 1/', $display);
-        $this->assertRegExp('/Migration 2/', $display);
-        $this->assertNotRegExp('/Result 1/', $display);
-        $this->assertNotRegExp('/Result 2/', $display);
 
-        $this->assertRegExp('/runonceFile.php/', $display);
-        $this->assertFileExists($runOnceFile, 'File should not be gone in dry-run mode');
+        if ('ndjson' === $format) {
+            $this->assertSame(
+                [
+                    ['type' => 'migration-pending', 'name' => 'Migration 1'],
+                    ['type' => 'migration-pending', 'name' => 'Migration 2'],
+                    ['type' => 'migration-pending', 'name' => 'Runonce file: runonceFile.php'],
+                    [
+                        'type' => 'schema-pending',
+                        'commands' => ['First call QUERY 1', 'First call QUERY 2'],
+                    ],
+                ],
+                $this->jsonArrayFromNdjson($display)
+            );
+        } else {
+            $this->assertRegExp('/Migration 1/', $display);
+            $this->assertRegExp('/Migration 2/', $display);
+            $this->assertNotRegExp('/Result 1/', $display);
+            $this->assertNotRegExp('/Result 2/', $display);
 
-        $this->assertRegExp('/First call QUERY 1/', $display);
-        $this->assertRegExp('/First call QUERY 2/', $display);
-        $this->assertNotRegExp('/Executed 2 SQL queries/', $display);
+            $this->assertRegExp('/runonceFile.php/', $display);
+            $this->assertFileExists($runOnceFile, 'File should not be gone in dry-run mode');
 
-        $this->assertRegExp('/All migrations completed/', $display);
+            $this->assertRegExp('/First call QUERY 1/', $display);
+            $this->assertRegExp('/First call QUERY 2/', $display);
+            $this->assertNotRegExp('/Executed 2 SQL queries/', $display);
+
+            $this->assertRegExp('/All migrations completed/', $display);
+        }
     }
 
     public function testAbortsIfAnswerIsNo(): void
@@ -210,7 +285,10 @@ class MigrateCommandTest extends TestCase
         $this->assertNotRegExp('/All migrations completed/', $display);
     }
 
-    public function testDoesNotAbortIfMigrationFails(): void
+    /**
+     * @dataProvider getOutputFormats
+     */
+    public function testDoesNotAbortIfMigrationFails(string $format): void
     {
         $command = $this->getCommand(
             [['Migration 1', 'Migration 2']],
@@ -220,16 +298,65 @@ class MigrateCommandTest extends TestCase
         $tester = new CommandTester($command);
         $tester->setInputs(['y']);
 
-        $code = $tester->execute([]);
+        $code = $tester->execute(['--format' => $format], ['interactive' => 'ndjson' !== $format]);
         $display = $tester->getDisplay();
 
         $this->assertSame(0, $code);
-        $this->assertRegExp('/Migration 1/', $display);
-        $this->assertRegExp('/Migration 2/', $display);
-        $this->assertRegExp('/Result 1/', $display);
-        $this->assertRegExp('/Migration failed/', $display);
-        $this->assertRegExp('/Result 2/', $display);
-        $this->assertRegExp('/All migrations completed/', $display);
+
+        if ('ndjson' === $format) {
+            $this->assertSame(
+                [
+                    ['type' => 'migration-pending', 'name' => 'Migration 1'],
+                    ['type' => 'migration-pending', 'name' => 'Migration 2'],
+                    ['type' => 'migration-result', 'message' => 'Result 1', 'isSuccessful' => false],
+                    ['type' => 'migration-result', 'message' => 'Result 2', 'isSuccessful' => true],
+                ],
+                $this->jsonArrayFromNdjson($display)
+            );
+        } else {
+            $this->assertRegExp('/Migration 1/', $display);
+            $this->assertRegExp('/Migration 2/', $display);
+            $this->assertRegExp('/Result 1/', $display);
+            $this->assertRegExp('/Migration failed/', $display);
+            $this->assertRegExp('/Result 2/', $display);
+            $this->assertRegExp('/All migrations completed/', $display);
+        }
+    }
+
+    /**
+     * @dataProvider getOutputFormats
+     */
+    public function testDoesAbortOnFatalError(string $format): void
+    {
+        $installer = $this->createMock(Installer::class);
+        $installer
+            ->expects($this->atLeastOnce())
+            ->method('compileCommands')
+            ->willThrowException(new \Exception('Fatal'))
+        ;
+
+        $command = $this->getCommand([], [], [], $installer);
+
+        $tester = new CommandTester($command);
+
+        if ('ndjson' !== $format) {
+            $this->expectException(\Exception::class);
+        }
+
+        $code = $tester->execute(['--format' => $format], ['interactive' => 'ndjson' !== $format]);
+        $display = $tester->getDisplay();
+
+        $this->assertSame(1, $code);
+
+        $json = $this->jsonArrayFromNdjson($display)[0];
+        $this->assertSame('error', $json['type']);
+        $this->assertSame('Fatal', $json['message']);
+    }
+
+    public function getOutputFormats(): \Generator
+    {
+        yield ['txt'];
+        yield ['ndjson'];
     }
 
     /**
@@ -280,6 +407,16 @@ class MigrateCommandTest extends TestCase
             $this->getTempDir(),
             $this->createMock(ContaoFramework::class),
             $installer ?? $this->createMock(Installer::class)
+        );
+    }
+
+    private function jsonArrayFromNdjson(string $ndjson): array
+    {
+        return array_map(
+            static function (string $line) {
+                return json_decode($line, true, 512, JSON_THROW_ON_ERROR);
+            },
+            explode("\n", trim($ndjson))
         );
     }
 }

--- a/core-bundle/tests/Command/MigrateCommandTest.php
+++ b/core-bundle/tests/Command/MigrateCommandTest.php
@@ -414,7 +414,7 @@ class MigrateCommandTest extends TestCase
     {
         return array_map(
             static function (string $line) {
-                return json_decode($line, true, 512, JSON_THROW_ON_ERROR);
+                return json_decode($line, true);
             },
             explode("\n", trim($ndjson))
         );


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #3068

As discussed in https://github.com/contao/contao/pull/3068#issuecomment-877072227

Example output for `contao:migrate --dry-run --format=ndjson`

```
{"type":"migration-pending","name":"Contao 4.8.0 Update"}
{"type":"migration-pending","name":"Runonce file: contao\/config\/runonce.php"}
{"type":"schema-pending","commands":["ALTER TABLE tl_files ADD meta BLOB DEFAULT NULL"]}
```

Example output for `contao:migrate --format=ndjson --no-interaction`

```
{"type":"migration-pending","name":"Contao 4.8.0 Update"}
{"type":"migration-pending","name":"Runonce file: contao\/config\/runonce.php"}
{"type":"migration-result","message":"Deleted invalid important part [10,10,50,50] from image \"files\/contaodemo\/media\/content-images\".","isSuccessful":true}
{"type":"migration-result","message":"Executed runonce file: contao\/config\/runonce.php","isSuccessful":true}
{"type":"schema-pending","commands":["ALTER TABLE tl_files ADD meta BLOB DEFAULT NULL"]}
{"type":"schema-execute","command":"ALTER TABLE tl_files ADD meta BLOB DEFAULT NULL"}
{"type":"schema-result","command":"ALTER TABLE tl_files ADD meta BLOB DEFAULT NULL","isSuccessful":true}
```

ndjson format: http://ndjson.org/ (alternative: https://jsonlines.org/ not sure what the correct “standard” is here).
This format is used so that the manager can stream the output (every single line is a valid JSON) of the potentially long running command.

@aschempp is this something you can work with in the manager?