### PR TITLE
Fix version creation for entries with dynamic ptable

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Controller.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Controller.php
@@ -1448,7 +1448,7 @@ abstract class Controller extends System
 	protected function getParentEntries($strTable, $intId)
 	{
 		// No parent table
-		if (!isset($GLOBALS['TL_DCA'][$strTable]['config']['ptable']))
+		if (empty($GLOBALS['TL_DCA'][$strTable]['config']['ptable']))
 		{
 			return '';
 		}


### PR DESCRIPTION
If you try to create a new version for `tl_content` somewhere that is not in the back end in either of the `article` or `page` module, an error will occur. For example if you update content elements somewhere in a custom back end module or in a command etc, and you still want to properly create new versions with

```php
$version = new Versions('tl_content', $id);
$version->initialize();
// …
$version->create();
```

The following error will occur:

```
Exception:
The table name must not be empty

  at vendor\contao\contao\core-bundle\src\Resources\contao\library\Contao\DcaLoader.php:50
  at Contao\DcaLoader->__construct('')
     (vendor\contao\contao\core-bundle\src\Resources\contao\library\Contao\Controller.php:1394)
  at Contao\Controller::loadDataContainer('')
     (vendor\contao\contao\core-bundle\src\Resources\contao\library\Contao\Controller.php:1478)
  at Contao\Controller->getParentEntries('', '33')
     (vendor\contao\contao\core-bundle\src\Resources\contao\classes\Versions.php:246)
  at Contao\Versions->create(true)
     (vendor\contao\contao\core-bundle\src\Resources\contao\classes\Versions.php:146)
  at Contao\Versions->initialize()
```

This is actually already fixed in Contao 4.10 and up, because the same fix was already incorporated in [my PR](https://github.com/contao/contao/pull/1446) back then. This PR backports this fix to Contao 4.9 (sans the actual feature for automatic dynamic ptables).