### PR TITLE
Support news teaser from news content

### DIFF
--- a/news-bundle/src/Resources/contao/classes/News.php
+++ b/news-bundle/src/Resources/contao/classes/News.php
@@ -485,6 +485,27 @@ class News extends Frontend
 		return $jsonLd;
 	}
 
+	public static function hasNewsContent(NewsModel $objArticle, array $arrOptions = [])
+	{
+		return ContentModel::countPublishedByPidAndTable($objArticle->id, 'tl_news', $arrOptions) > 0;
+	}
+
+	public static function getNewsContent(NewsModel $objArticle, array $arrOptions = []): string
+	{
+		$strText = '';
+		$objElement = ContentModel::findPublishedByPidAndTable($objArticle->id, 'tl_news', $arrOptions);
+
+		if ($objElement !== null)
+		{
+			while ($objElement->next())
+			{
+				$strText .= Controller::getContentElement($objElement->current());
+			}
+		}
+
+		return $strText;
+	}
+
 	/**
 	 * Return the link of a news article
 	 *

--- a/news-bundle/src/Resources/contao/languages/en/tl_news.xlf
+++ b/news-bundle/src/Resources/contao/languages/en/tl_news.xlf
@@ -56,11 +56,38 @@
       <trans-unit id="tl_news.subheadline.1">
         <source>Here you can enter a subheadline.</source>
       </trans-unit>
+      <trans-unit id="tl_news.teaserType.0">
+        <source>News teaser type</source>
+      </trans-unit>
+      <trans-unit id="tl_news.teaserType.1">
+        <source>Select the type of news teaser for this news.</source>
+      </trans-unit>
+      <trans-unit id="tl_news.teaserType.default">
+        <source>Rich text field</source>
+      </trans-unit>
+      <trans-unit id="tl_news.teaserType.elements">
+        <source>First content element(s)</source>
+      </trans-unit>
+      <trans-unit id="tl_news.teaserType.substr">
+        <source>First characters from news text</source>
+      </trans-unit>
       <trans-unit id="tl_news.teaser.0">
         <source>News teaser</source>
       </trans-unit>
       <trans-unit id="tl_news.teaser.1">
         <source>The news teaser can be shown in a news list instead of the full story. A "read more …" link will be added automatically.</source>
+      </trans-unit>
+      <trans-unit id="tl_news.teaserElements.0">
+        <source>Number of elements</source>
+      </trans-unit>
+      <trans-unit id="tl_news.teaserElements.1">
+        <source>Enter the number of content elements for the news teaser. A "read more …" link will be added automatically.</source>
+      </trans-unit>
+      <trans-unit id="tl_news.teaserChars.0">
+        <source>Number of characters</source>
+      </trans-unit>
+      <trans-unit id="tl_news.teaserChars.1">
+        <source>Enter the number of characters to generate the news teaser. A "read more …" link will be added automatically.</source>
       </trans-unit>
       <trans-unit id="tl_news.text.0">
         <source>News text</source>

--- a/news-bundle/src/Resources/contao/models/NewsModel.php
+++ b/news-bundle/src/Resources/contao/models/NewsModel.php
@@ -28,7 +28,10 @@ use Contao\Model\Collection;
  * @property string         $robots
  * @property string|null    $description
  * @property string         $subheadline
+ * @property string         $teaserType
  * @property string|null    $teaser
+ * @property string|integer $teaserElements
+ * @property string|integer $teaserChars
  * @property string|boolean $addImage
  * @property string|boolean $overwriteMeta
  * @property string|null    $singleSRC


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #770
| Docs PR or issue | contao/docs#...

This is a POC how to add automatic news teaser support as requested in https://github.com/contao/contao/issues/770. Since I've had similar need when writing news (mostly on contao.org), I thought this might be a good fit.

When creating a news, there are now three options to generate the teaser.
<img width="625" alt="Bildschirmfoto 2021-08-16 um 08 37 22" src="https://user-images.githubusercontent.com/1073273/129521542-8fa50116-6b5f-4c76-b2e9-c3c2e71d48d0.png">

The first option is the same as currently. Second option allows to enter a number of elements to include, the third option will extract a number of characters from the elements as teaser.

### TODOs:
- [ ] actually test the implementation
- [ ] Move the `tl_news::getTeaserTypeOptions` to a listener
- [ ] check/update any other place where teaser is used (e.g. RSS feed)
- [ ] maybe add the same feature to events etc?
