### PR TITLE
Remove reference to other table from column classname in DC_Table

### DIFF
--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -5061,8 +5061,10 @@ class DC_Table extends DataContainer implements \listable, \editable
 						{
 							$value = (string) $arg !== '' ? $arg : '-';
 						}
+						
+						$colclass = 'col_' . array_shift(explode(":", $field, 2));
 
-						$return .= '<td colspan="' . $colspan . '" class="tl_file_list col_' . $field . ($field == $firstOrderBy ? ' ordered_by' : '') . '">' . $value . '</td>';
+						$return .= '<td colspan="' . $colspan . '" class="tl_file_list ' . $colclass . ($field == $firstOrderBy ? ' ordered_by' : '') . '">' . $value . '</td>';
 					}
 				}
 				else

--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -5062,7 +5062,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 							$value = (string) $arg !== '' ? $arg : '-';
 						}
 						
-						$colclass = 'col_' . array_shift(explode(":", $field, 2));
+						$colclass = 'col_' . explode(":", $field, 2)[0];
 
 						$return .= '<td colspan="' . $colspan . '" class="tl_file_list ' . $colclass . ($field == $firstOrderBy ? ' ordered_by' : '') . '">' . $value . '</td>';
 					}


### PR DESCRIPTION
When I reference to another table in the list.label.fields of a dca, I get the request as column classname.

```
...
'list' => [
  'label' => [
    'fields' => [
      'send_to_customer',
      'member:tl_member.CONCAT(lastname,", ",firstname)',
      'event:tl_calendar_events.CONCAT(title, DATE_FORMAT(FROM_UNIXTIME(startTime), CHAR(32, 91, 37, 100, 46, 37, 109, 46, 37, 89, 93)))',
      'amount',
      'tstamp'
    ]
  ]
],
...
```

![image](https://user-images.githubusercontent.com/87128053/129586079-9884b1fe-7a7c-4553-ada3-878104e927e3.png)

The bugfix removes everything from the colon.

![image](https://user-images.githubusercontent.com/87128053/129588142-26caaa5f-c2f2-4412-b302-0f3623441fd6.png)
