### PR TITLE
Correctly explode foreign keys in the DCA

### DIFF
--- a/core-bundle/src/Resources/contao/drivers/DC_Folder.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Folder.php
@@ -340,7 +340,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 
 			if (isset($GLOBALS['TL_DCA'][$this->strTable]['fields']['name']['foreignKey']))
 			{
-				list($t, $f) = explode('.', $GLOBALS['TL_DCA'][$this->strTable]['fields']['name']['foreignKey']);
+				list($t, $f) = explode('.', $GLOBALS['TL_DCA'][$this->strTable]['fields']['name']['foreignKey'], 2);
 
 				$objRoot = $this->Database->prepare("SELECT path, type, extension FROM " . $this->strTable . " WHERE (" . $strPattern . " OR " . sprintf($strPattern, "(SELECT " . Database::quoteIdentifier($f) . " FROM $t WHERE $t.id=" . $this->strTable . ".name)") . ")")
 										  ->execute($for, $for);
@@ -2909,7 +2909,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 
 			if (isset($GLOBALS['TL_DCA'][$this->strTable]['fields']['name']['foreignKey']))
 			{
-				list($t, $f) = explode('.', $GLOBALS['TL_DCA'][$this->strTable]['fields']['name']['foreignKey']);
+				list($t, $f) = explode('.', $GLOBALS['TL_DCA'][$this->strTable]['fields']['name']['foreignKey'], 2);
 				$this->procedure[] = "(" . $strPattern . " OR " . sprintf($strPattern, "(SELECT " . Database::quoteIdentifier($f) . " FROM $t WHERE $t.id=" . $this->strTable . ".name)") . ")";
 				$this->values[] = $searchValue;
 			}

--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -3961,7 +3961,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 
 			if (strpos($v, ':') !== false)
 			{
-				list($strKey, $strTable) = explode(':', $v);
+				list($strKey, $strTable) = explode(':', $v, 2);
 				list($strTable, $strField) = explode('.', $strTable, 2);
 
 				$objRef = $this->Database->prepare("SELECT " . Database::quoteIdentifier($strField) . " FROM " . $strTable . " WHERE id=?")
@@ -4900,7 +4900,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 
 					if (strpos($v, ':') !== false)
 					{
-						list($strKey, $strTable) = explode(':', $v);
+						list($strKey, $strTable) = explode(':', $v, 2);
 						list($strTable, $strField) = explode('.', $strTable, 2);
 
 						$objRef = $this->Database->prepare("SELECT " . Database::quoteIdentifier($strField) . " FROM " . $strTable . " WHERE id=?")

--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -3962,7 +3962,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 			if (strpos($v, ':') !== false)
 			{
 				list($strKey, $strTable) = explode(':', $v);
-				list($strTable, $strField) = explode('.', $strTable);
+				list($strTable, $strField) = explode('.', $strTable, 2);
 
 				$objRef = $this->Database->prepare("SELECT " . Database::quoteIdentifier($strField) . " FROM " . $strTable . " WHERE id=?")
 										 ->limit(1)
@@ -4901,7 +4901,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 					if (strpos($v, ':') !== false)
 					{
 						list($strKey, $strTable) = explode(':', $v);
-						list($strTable, $strField) = explode('.', $strTable);
+						list($strTable, $strField) = explode('.', $strTable, 2);
 
 						$objRef = $this->Database->prepare("SELECT " . Database::quoteIdentifier($strField) . " FROM " . $strTable . " WHERE id=?")
 												 ->limit(1)

--- a/core-bundle/src/Resources/contao/library/Contao/DcaExtractor.php
+++ b/core-bundle/src/Resources/contao/library/Contao/DcaExtractor.php
@@ -418,7 +418,7 @@ class DcaExtractor extends Controller
 
 					if (isset($config['foreignKey']))
 					{
-						$table = substr($config['foreignKey'], 0, strrpos($config['foreignKey'], '.'));
+						$table = substr($config['foreignKey'], 0, strpos($config['foreignKey'], '.'));
 					}
 
 					$arrRelations[$field] = array_merge(array('table'=>$table, 'field'=>'id'), $config['relation']);

--- a/core-bundle/src/Resources/contao/library/Contao/DcaExtractor.php
+++ b/core-bundle/src/Resources/contao/library/Contao/DcaExtractor.php
@@ -418,7 +418,7 @@ class DcaExtractor extends Controller
 
 					if (isset($config['foreignKey']))
 					{
-						$table = substr($config['foreignKey'], 0, strpos($config['foreignKey'], '.'));
+						$table = explode('.', $config['foreignKey'])[0];
 					}
 
 					$arrRelations[$field] = array_merge(array('table'=>$table, 'field'=>'id'), $config['relation']);


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #3318
| Docs PR or issue | -

When defining a `foreignKey` for a database relation, or a field label in `list.label.fields` for your DCA, you are able to write the following syntax: `tl_member.CONCAT("firstname", " ", "lastname")` (or `member:tl_member.CONCAT("firstname", " ", "lastname")` for `list.label.fields`). This string is then split in two by using the first occurrence of `.` as the delimiter. However, some places of the `explode()` call were missing the third parameter, causing the string to be split into more than two parts, if there happen to be dots in other places. This PR fixes that by adding the necessary third parameter to the remaining `explode()` calls.
