### PR TITLE
Truncate tl_search* tables independently from indexer service

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Automator.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Automator.php
@@ -35,16 +35,11 @@ class Automator extends System
 	 */
 	public function purgeSearchTables()
 	{
-		// The search indexer is disabled
-		if (!System::getContainer()->has('contao.search.indexer'))
-		{
-			return;
-		}
+		$objDatabase = Database::getInstance();
 
-		$searchIndexer = System::getContainer()->get('contao.search.indexer');
-
-		// Clear the index
-		$searchIndexer->clear();
+		// Truncate the tables
+		$objDatabase->execute("TRUNCATE TABLE tl_search");
+		$objDatabase->execute("TRUNCATE TABLE tl_search_index");
 
 		$strCachePath = StringUtil::stripRootDir(System::getContainer()->getParameter('kernel.cache_dir'));
 


### PR DESCRIPTION
Follow up for #3283:
Purging search tables after disabling the indexer is now only possible directly via database.