### PR TITLE
Make sure X-Forwarded-Host is trusted if trusted hosts are configured

### DIFF
--- a/manager-bundle/src/HttpKernel/ContaoKernel.php
+++ b/manager-bundle/src/HttpKernel/ContaoKernel.php
@@ -252,13 +252,18 @@ class ContaoKernel extends Kernel implements HttpCacheProvider
     {
         self::loadEnv($projectDir, 'jwt');
 
-        // See https://github.com/symfony/recipes/blob/master/symfony/framework-bundle/4.2/public/index.php
-        if ($trustedProxies = $_SERVER['TRUSTED_PROXIES'] ?? null) {
-            Request::setTrustedProxies(explode(',', $trustedProxies), Request::HEADER_X_FORWARDED_ALL ^ Request::HEADER_X_FORWARDED_HOST);
-        }
-
         if ($trustedHosts = $_SERVER['TRUSTED_HOSTS'] ?? null) {
             Request::setTrustedHosts(explode(',', $trustedHosts));
+        }
+
+        if ($trustedProxies = $_SERVER['TRUSTED_PROXIES'] ?? null) {
+            $trustedHeaderSet = Request::HEADER_X_FORWARDED_FOR | Request::HEADER_X_FORWARDED_PORT | Request::HEADER_X_FORWARDED_PROTO;
+
+            if ($trustedHosts) {
+                $trustedHeaderSet |= Request::HEADER_X_FORWARDED_HOST;
+            }
+
+            Request::setTrustedProxies(explode(',', $trustedProxies), $trustedHeaderSet);
         }
 
         Request::enableHttpMethodParameterOverride();

--- a/manager-bundle/src/HttpKernel/ContaoKernel.php
+++ b/manager-bundle/src/HttpKernel/ContaoKernel.php
@@ -259,6 +259,7 @@ class ContaoKernel extends Kernel implements HttpCacheProvider
         if ($trustedProxies = $_SERVER['TRUSTED_PROXIES'] ?? null) {
             $trustedHeaderSet = Request::HEADER_X_FORWARDED_FOR | Request::HEADER_X_FORWARDED_PORT | Request::HEADER_X_FORWARDED_PROTO;
 
+            // If we have a limited list of trusted hosts, we can safely use the X-Forwarded-Host header
             if ($trustedHosts) {
                 $trustedHeaderSet |= Request::HEADER_X_FORWARDED_HOST;
             }

--- a/manager-bundle/tests/HttpKernel/ContaoKernelTest.php
+++ b/manager-bundle/tests/HttpKernel/ContaoKernelTest.php
@@ -303,7 +303,7 @@ class ContaoKernelTest extends ContaoTestCase
         ContaoKernel::fromRequest($this->getTempDir(), Request::create('/'));
 
         $this->assertSame(['1.1.1.1', '2.2.2.2'], Request::getTrustedProxies());
-        $this->assertSame(Request::HEADER_X_FORWARDED_ALL ^ Request::HEADER_X_FORWARDED_HOST, Request::getTrustedHeaderSet());
+        $this->assertSame(Request::HEADER_X_FORWARDED_FOR | Request::HEADER_X_FORWARDED_PORT | Request::HEADER_X_FORWARDED_PROTO, Request::getTrustedHeaderSet());
 
         unset($_SERVER['TRUSTED_PROXIES']);
     }
@@ -312,11 +312,13 @@ class ContaoKernelTest extends ContaoTestCase
     {
         $this->assertSame([], Request::getTrustedHosts());
 
+        $_SERVER['TRUSTED_PROXIES'] = '1.1.1.1,2.2.2.2';
         $_SERVER['TRUSTED_HOSTS'] = '1.1.1.1,2.2.2.2';
 
         ContaoKernel::fromRequest($this->getTempDir(), Request::create('/'));
 
         $this->assertSame(['{1.1.1.1}i', '{2.2.2.2}i'], Request::getTrustedHosts());
+        $this->assertSame(Request::HEADER_X_FORWARDED_FOR | Request::HEADER_X_FORWARDED_PORT | Request::HEADER_X_FORWARDED_PROTO | Request::HEADER_X_FORWARDED_HOST, Request::getTrustedHeaderSet());
 
         unset($_SERVER['TRUSTED_HOSTS']);
     }

--- a/manager-bundle/tests/HttpKernel/ContaoKernelTest.php
+++ b/manager-bundle/tests/HttpKernel/ContaoKernelTest.php
@@ -317,7 +317,7 @@ class ContaoKernelTest extends ContaoTestCase
 
         ContaoKernel::fromRequest($this->getTempDir(), Request::create('/'));
 
-        $this->assertSame(['{1.1.1.1}i', '{2.2.2.2}i'], Request::getTrustedHosts());
+        $this->assertSame(['{1.1.1.1}i', '{2.2.2.2}i', '{example.com}i'], Request::getTrustedHosts());
         $this->assertSame(Request::HEADER_X_FORWARDED_FOR | Request::HEADER_X_FORWARDED_PORT | Request::HEADER_X_FORWARDED_PROTO | Request::HEADER_X_FORWARDED_HOST, Request::getTrustedHeaderSet());
 
         unset($_SERVER['TRUSTED_HOSTS']);

--- a/manager-bundle/tests/HttpKernel/ContaoKernelTest.php
+++ b/manager-bundle/tests/HttpKernel/ContaoKernelTest.php
@@ -313,7 +313,7 @@ class ContaoKernelTest extends ContaoTestCase
         $this->assertSame([], Request::getTrustedHosts());
 
         $_SERVER['TRUSTED_PROXIES'] = '1.1.1.1,2.2.2.2';
-        $_SERVER['TRUSTED_HOSTS'] = '1.1.1.1,2.2.2.2';
+        $_SERVER['TRUSTED_HOSTS'] = '1.1.1.1,2.2.2.2,example.com';
 
         ContaoKernel::fromRequest($this->getTempDir(), Request::create('/'));
 


### PR DESCRIPTION
This PR contains two fixes:

1. `Request::HEADER_X_FORWARDED_ALL` is deprecated in favor of `Request::HEADER_X_FORWARDED_FOR | Request::HEADER_X_FORWARDED_PORT | Request::HEADER_X_FORWARDED_PROTO | Request::HEADER_X_FORWARDED_HOST`
2. While fixing the deprecation I noticed that our previous `Request::HEADER_X_FORWARDED_ALL ^ Request::HEADER_X_FORWARDED_HOST` did not make a lot of sense together with `$_SERVER['TRUSTED_HOSTS']`. You could configure the trusted hosts using `$_SERVER['TRUSTED_HOSTS']` but it would've never worked as we excluded `X-Forwarded-Host` from the trusted headers. Now that's automatically trusted if you configure `$_SERVER['TRUSTED_HOSTS']` which then makes sense.