### PR TITLE
Avoid undefined array key warning

### DIFF
--- a/core-bundle/src/Resources/contao/modules/ModuleProxy.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleProxy.php
@@ -68,7 +68,7 @@ class ModuleProxy extends Module
 
 	public function __get($strKey)
 	{
-		return $this->reference->attributes['templateProperties'][$strKey];
+		return $this->reference->attributes['templateProperties'][$strKey] ?? null;
 	}
 
 	public function __isset($strKey)


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | n/a
| Docs PR or issue | n/a

Fixes warning on PHP 8.x:

<img width="1062" alt="Bildschirmfoto 2021-08-18 um 10 36 46" src="https://user-images.githubusercontent.com/754921/129866371-5ae5815e-34b1-4574-bd13-73fee381d554.png">
