### PR TITLE
Fix another undefined array key warning

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Model/QueryBuilder.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Model/QueryBuilder.php
@@ -45,7 +45,7 @@ class QueryBuilder
 			foreach ($objBase->getRelations() as $strKey=>$arrConfig)
 			{
 				// Automatically join the single-relation records
-				if ($arrConfig['load'] == 'eager' || ($arrOptions['eager'] ?? null))
+                if (($arrConfig['load'] ?? null) == 'eager' || ($arrOptions['eager'] ?? null))
 				{
 					if ($arrConfig['type'] == 'hasOne' || $arrConfig['type'] == 'belongsTo')
 					{

--- a/core-bundle/src/Resources/contao/library/Contao/Model/QueryBuilder.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Model/QueryBuilder.php
@@ -45,7 +45,7 @@ class QueryBuilder
 			foreach ($objBase->getRelations() as $strKey=>$arrConfig)
 			{
 				// Automatically join the single-relation records
-                if (($arrConfig['load'] ?? null) == 'eager' || ($arrOptions['eager'] ?? null))
+				if (($arrConfig['load'] ?? null) == 'eager' || ($arrOptions['eager'] ?? null))
 				{
 					if ($arrConfig['type'] == 'hasOne' || $arrConfig['type'] == 'belongsTo')
 					{


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | n/a
| Docs PR or issue | n/a

Fixes warning on 4.11.x / PHP 8.x:

<img width="1055" alt="Bildschirmfoto 2021-08-18 um 10 55 10" src="https://user-images.githubusercontent.com/754921/129875195-2aa83def-e7a8-4f95-911b-f44b88f55fa3.png">
