### PR TITLE
Clarify contao.preview_script usage

### DIFF
--- a/core-bundle/src/DependencyInjection/Configuration.php
+++ b/core-bundle/src/DependencyInjection/Configuration.php
@@ -79,7 +79,7 @@ class Configuration implements ConfigurationInterface
                     ->defaultValue(false)
                 ->end()
                 ->scalarNode('preview_script')
-                    ->info('An optional entry point script that bypasses the front end cache for previewing changes (e.g. preview.php).')
+                    ->info("An optional entry point script that bypasses the front end cache for previewing changes (e.g. '/preview.php').")
                     ->cannotBeEmpty()
                     ->defaultValue('')
                     ->validate()


### PR DESCRIPTION
This PR indicates in the `contao.preview_script` description that the custom `preview_script` must start with a `/`, otherwise the redirect that Contao produces here

https://github.com/contao/contao/blob/22a8f0dacab71e0943bdc32e1721bcae25e94349/core-bundle/src/Controller/BackendPreviewController.php#L70

will be relative to the current path and produce a wrong url. e.g. when using

```yaml
# config/config.yaml
contao:
    preview_script: preview_foobar.php
```

the resulting URL would be

```
https://example.com/contao/preview_foobar.php/contao/preview?page=2
```

We could also implement

```diff
-return new RedirectResponse($this->previewScript.$request->getRequestUri());
+return new RedirectResponse('/'.ltrim($this->previewScript, '/').$request->getRequestUri());