### PR TITLE
Also pass the template object in the "parseFrontendTemplate" hook

### DIFF
--- a/core-bundle/src/Resources/contao/classes/FrontendTemplate.php
+++ b/core-bundle/src/Resources/contao/classes/FrontendTemplate.php
@@ -48,7 +48,7 @@ class FrontendTemplate extends Template
 			foreach ($GLOBALS['TL_HOOKS']['parseFrontendTemplate'] as $callback)
 			{
 				$this->import($callback[0]);
-				$strBuffer = $this->{$callback[0]}->{$callback[1]}($strBuffer, $this->strTemplate);
+				$strBuffer = $this->{$callback[0]}->{$callback[1]}($strBuffer, $this->strTemplate, $this);
 			}
 		}
 


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes https://github.com/contao/contao/issues/3184 
| Docs PR or issue | contao/docs#819

see https://github.com/contao/contao/issues/3184 
Passing the templateObject itself to the parseFrontendTemplate Hook method.

Maybe it´s possible to get it also at the 4.9 branch. That´s because i used the Reflections! But if it´s a feature for future version  we can leave the Reflection-Calls and just add the object itself as third parameter.

Thanks
