### PR TITLE
Use 4 spaces to indent the strict mode notice

### DIFF
--- a/installation-bundle/src/Resources/views/main.html.twig
+++ b/installation-bundle/src/Resources/views/main.html.twig
@@ -8,11 +8,11 @@
         <p>{{ 'strict_sql_mode_explain'|trans|raw }}</p>
         <div id="sql_wrapper">
         <pre>doctrine:
-  dbal:
-    connections:
-      default:
-        options:
-          {{ optionKey }}: "SET SESSION sql_mode=(SELECT CONCAT(@@sql_mode, ',TRADITIONAL'))"</pre>
+    dbal:
+        connections:
+            default:
+                options:
+                    {{ optionKey }}: "SET SESSION sql_mode=(SELECT CONCAT(@@sql_mode, ',TRADITIONAL'))"</pre>
         </div>
     </fieldset>
   {% endif %}


### PR DESCRIPTION
In [configuration_error.html.twig](https://github.com/contao/contao/blob/4.12/installation-bundle/src/Resources/views/configuration_error.html.twig) we use 4 spaces for indentation in the YAML examples. However for the new strict mode notice we only use 2 spaces. This PR normalises it to 4 spaces.
