### PR TITLE
Fix another invalid array access

### DIFF
--- a/core-bundle/src/Resources/contao/classes/DataContainer.php
+++ b/core-bundle/src/Resources/contao/classes/DataContainer.php
@@ -901,7 +901,7 @@ abstract class DataContainer extends Backend
 			// Custom icon (see #5541)
 			if ($v['icon'] ?? null)
 			{
-				$v['class'] = trim($v['class'] ?? '' . ' header_icon');
+				$v['class'] = trim(($v['class'] ?? '') . ' header_icon');
 
 				// Add the theme path if only the file name is given
 				if (strpos($v['icon'], '/') === false)

--- a/core-bundle/src/Resources/contao/classes/DataContainer.php
+++ b/core-bundle/src/Resources/contao/classes/DataContainer.php
@@ -901,7 +901,7 @@ abstract class DataContainer extends Backend
 			// Custom icon (see #5541)
 			if ($v['icon'] ?? null)
 			{
-				$v['class'] = trim($v['class'] . ' header_icon');
+				$v['class'] = trim($v['class'] ?? '' . ' header_icon');
 
 				// Add the theme path if only the file name is given
 				if (strpos($v['icon'], '/') === false)


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes n/a
| Docs PR or issue | n/a

Fixes `Warning: Undefined array key "class"`:

```
ErrorException:
Warning: Undefined array key "class"

  at vendor/contao/core-bundle/src/Resources/contao/classes/DataContainer.php:900
  at Contao\DataContainer->generateGlobalButtons()
     (vendor/contao/core-bundle/src/Resources/contao/drivers/DC_Table.php:4822)
  at Contao\DC_Table->listView()
     (vendor/contao/core-bundle/src/Resources/contao/drivers/DC_Table.php:350)
  at Contao\DC_Table->showAll()
     (vendor/contao/core-bundle/src/Resources/contao/classes/Backend.php:648)
  at Contao\Backend->getBackendModule('news', null)
     (vendor/contao/core-bundle/src/Resources/contao/controllers/BackendMain.php:167)
  at Contao\BackendMain->run()
     (vendor/contao/core-bundle/src/Controller/BackendController.php:49)
  at Contao\CoreBundle\Controller\BackendController->mainAction()
     (vendor/symfony/http-kernel/HttpKernel.php:158)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw(object(Request), 1)
     (vendor/symfony/http-kernel/HttpKernel.php:80)
  at Symfony\Component\HttpKernel\HttpKernel->handle(object(Request), 1, true)
     (vendor/symfony/http-kernel/Kernel.php:201)
  at Symfony\Component\HttpKernel\Kernel->handle(object(Request))
     (public/index.php:43)
```
