### PR TITLE
Fix using insert tags in the page title

### DIFF
--- a/core-bundle/src/Resources/contao/dca/tl_page.php
+++ b/core-bundle/src/Resources/contao/dca/tl_page.php
@@ -236,7 +236,7 @@ $GLOBALS['TL_DCA']['tl_page'] = array
 			'exclude'                 => true,
 			'search'                  => true,
 			'inputType'               => 'text',
-			'eval'                    => array('maxlength'=>255, 'decodeEntities'=>true, 'tl_class'=>'w50'),
+			'eval'                    => array('maxlength'=>255, 'tl_class'=>'w50'),
 			'sql'                     => "varchar(255) NOT NULL default ''"
 		),
 		'language' => array

--- a/core-bundle/src/Resources/contao/library/Contao/InsertTags.php
+++ b/core-bundle/src/Resources/contao/library/Contao/InsertTags.php
@@ -697,8 +697,6 @@ class InsertTags extends Controller
 
 				// Page
 				case 'page':
-					$flags[] = 'attr';
-
 					if (!$objPage->pageTitle && $elements[1] == 'pageTitle')
 					{
 						$elements[1] = 'title';
@@ -713,6 +711,11 @@ class InsertTags extends Controller
 					}
 
 					// Do not use StringUtil::specialchars() here (see #4687)
+					if (!\in_array($elements[1], array('title', 'parentTitle', 'mainTitle', 'rootTitle', 'pageTitle', 'parentPageTitle', 'mainPageTitle', 'rootPageTitle'), true))
+					{
+						$flags[] = 'attr';
+					}
+
 					$arrCache[$strTag] = $objPage->{$elements[1]};
 					break;
 


### PR DESCRIPTION
Allowing HTML in the page title and/or using insert tags like `{{br}}` is broken with `{{page::pageTitle}}`.

This pull request should fix this.

Related: https://github.com/contao/core/issues/4687

/cc @aschempp 