### PR TITLE
Add "Do Not Track" option to the Vimeo content element

### DIFF
--- a/core-bundle/src/Resources/contao/dca/tl_content.php
+++ b/core-bundle/src/Resources/contao/dca/tl_content.php
@@ -721,7 +721,7 @@ $GLOBALS['TL_DCA']['tl_content'] = array
 			'label'                   => &$GLOBALS['TL_LANG']['tl_content']['playerOptions'],
 			'exclude'                 => true,
 			'inputType'               => 'checkbox',
-			'options'                 => array('vimeo_autoplay', 'vimeo_loop', 'vimeo_portrait', 'vimeo_title', 'vimeo_byline'),
+			'options'                 => array('vimeo_autoplay', 'vimeo_loop', 'vimeo_portrait', 'vimeo_title', 'vimeo_byline', 'vimeo_dnt'),
 			'reference'               => &$GLOBALS['TL_LANG']['tl_content'],
 			'eval'                    => array('multiple'=>true, 'tl_class'=>'clr'),
 			'sql'                     => "text NULL"

--- a/core-bundle/src/Resources/contao/languages/en/tl_content.xlf
+++ b/core-bundle/src/Resources/contao/languages/en/tl_content.xlf
@@ -641,6 +641,9 @@
       <trans-unit id="tl_content.vimeo_byline">
         <source>Hide the author</source>
       </trans-unit>
+      <trans-unit id="tl_content.vimeo_dnt">
+        <source>Set to "Do Not Track"</source>
+      </trans-unit>
       <trans-unit id="tl_content.new.0">
         <source>New</source>
       </trans-unit>

--- a/core-bundle/src/Resources/contao/languages/en/tl_content.xlf
+++ b/core-bundle/src/Resources/contao/languages/en/tl_content.xlf
@@ -642,7 +642,7 @@
         <source>Hide the author</source>
       </trans-unit>
       <trans-unit id="tl_content.vimeo_dnt">
-        <source>Prevent session data tracking (dnt)</source>
+        <source>Prevent session data tracking</source>
       </trans-unit>
       <trans-unit id="tl_content.new.0">
         <source>New</source>

--- a/core-bundle/src/Resources/contao/languages/en/tl_content.xlf
+++ b/core-bundle/src/Resources/contao/languages/en/tl_content.xlf
@@ -642,7 +642,7 @@
         <source>Hide the author</source>
       </trans-unit>
       <trans-unit id="tl_content.vimeo_dnt">
-        <source>Set to "Do Not Track"</source>
+        <source>Prevent session data tracking (dnt)</source>
       </trans-unit>
       <trans-unit id="tl_content.new.0">
         <source>New</source>


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #1657
| Docs PR or issue | -

This adds an option to the Vimeo content element to set the url parameter `dnt` to 1.