### PR TITLE
Fix the default quote style

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/StringUtil.php
+++ b/core-bundle/src/Resources/contao/library/Contao/StringUtil.php
@@ -219,12 +219,12 @@ class StringUtil
 	 * Decode all entities
 	 *
 	 * @param string  $strString     The string to decode
-	 * @param integer $strQuoteStyle The quote style (defaults to ENT_COMPAT)
+	 * @param integer $strQuoteStyle The quote style (defaults to ENT_QUOTES)
 	 * @param string  $strCharset    An optional charset
 	 *
 	 * @return string The decoded string
 	 */
-	public static function decodeEntities($strString, $strQuoteStyle=ENT_COMPAT, $strCharset=null)
+	public static function decodeEntities($strString, $strQuoteStyle=ENT_QUOTES, $strCharset=null)
 	{
 		if ((string) $strString === '')
 		{


### PR DESCRIPTION
We had to change `ENT_COMPAT` to `ENT_QUOTES` everywhere in order to fix the latest security vulnerability. However, we forgot to also change the `StringUtil::decodeEntities()` default value.