### PR TITLE
Evaluate robots setting for sitemap

### DIFF
--- a/core-bundle/src/Controller/SitemapController.php
+++ b/core-bundle/src/Controller/SitemapController.php
@@ -140,9 +140,9 @@ class SitemapController extends AbstractController
                 continue;
             }
 
-            $isPublished = $pageModel->published && (!$pageModel->start || $pageModel->start <= time()) && (!$pageModel->stop || $pageModel->stop > time()) && 'noindex,nofollow' !== $pageModel->robots;
+            $isPublished = $pageModel->published && (!$pageModel->start || $pageModel->start <= time()) && (!$pageModel->stop || $pageModel->stop > time());
 
-            if ($isPublished && !$pageModel->requireItem && $this->pageRegistry->supportsContentComposition($pageModel)) {
+            if ($isPublished && !$pageModel->requireItem && $this->pageRegistry->supportsContentComposition($pageModel) && 'noindex,nofollow' !== $pageModel->robots) {
                 $urls = [$pageModel->getAbsoluteUrl()];
 
                 // Get articles with teaser

--- a/core-bundle/src/Controller/SitemapController.php
+++ b/core-bundle/src/Controller/SitemapController.php
@@ -142,7 +142,7 @@ class SitemapController extends AbstractController
 
             $isPublished = $pageModel->published && (!$pageModel->start || $pageModel->start <= time()) && (!$pageModel->stop || $pageModel->stop > time());
 
-            if ($isPublished && !$pageModel->requireItem && $this->pageRegistry->supportsContentComposition($pageModel) && 'noindex,nofollow' !== $pageModel->robots) {
+            if ($isPublished && !$pageModel->requireItem && 'noindex,nofollow' !== $pageModel->robots && $this->pageRegistry->supportsContentComposition($pageModel)) {
                 $urls = [$pageModel->getAbsoluteUrl()];
 
                 // Get articles with teaser

--- a/core-bundle/src/Controller/SitemapController.php
+++ b/core-bundle/src/Controller/SitemapController.php
@@ -140,7 +140,7 @@ class SitemapController extends AbstractController
                 continue;
             }
 
-            $isPublished = $pageModel->published && (!$pageModel->start || $pageModel->start <= time()) && (!$pageModel->stop || $pageModel->stop > time());
+            $isPublished = $pageModel->published && (!$pageModel->start || $pageModel->start <= time()) && (!$pageModel->stop || $pageModel->stop > time()) && 'noindex,nofollow' !== $pageModel->robots;
 
             if ($isPublished && !$pageModel->requireItem && $this->pageRegistry->supportsContentComposition($pageModel)) {
                 $urls = [$pageModel->getAbsoluteUrl()];

--- a/core-bundle/tests/Controller/SitemapControllerTest.php
+++ b/core-bundle/tests/Controller/SitemapControllerTest.php
@@ -434,6 +434,56 @@ class SitemapControllerTest extends TestCase
         $this->assertSame($this->getExpectedSitemapContent(['https://www.foobar.com/en/page1.html', 'https://www.foobar.com/en/page1/articles/1.html']), $response->getContent());
     }
 
+    public function testSkipsNoindexNofollowPages(): void
+    {
+        /** @var PageModel&MockObject $page1 */
+        $page1 = $this->mockClassWithProperties(PageModel::class, [
+            'id' => 43,
+            'pid' => 42,
+            'groups' => [],
+            'published' => '1',
+            'robots' => 'index,follow',
+        ]);
+
+        $page1
+            ->expects($this->once())
+            ->method('getAbsoluteUrl')
+            ->willReturn('https://www.foobar.com/en/page1.html')
+        ;
+
+        /** @var PageModel&MockObject $page2 */
+        $page2 = $this->mockClassWithProperties(PageModel::class, [
+            'id' => 44,
+            'pid' => 42,
+            'groups' => [],
+            'published' => '1',
+            'robots' => 'noindex,nofollow',
+        ]);
+
+        $page2
+            ->expects($this->never())
+            ->method('getAbsoluteUrl')
+        ;
+
+        $pages = [
+            42 => [$page1, $page2],
+            43 => null,
+            44 => null,
+            21 => null,
+        ];
+
+        $framework = $this->mockFrameworkWithPages($pages, [43 => null, 44 => null]);
+        $container = $this->mockContainer($framework);
+
+        $controller = new SitemapController($this->mockPageRegistry());
+        $controller->setContainer($container);
+        $response = $controller(Request::create('https://www.foobar.com/sitemap.xml'));
+
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertSame('public, s-maxage=2592000', $response->headers->get('Cache-Control'));
+        $this->assertSame($this->getExpectedSitemapContent(['https://www.foobar.com/en/page1.html']), $response->getContent());
+    }
+
     /**
      * @group legacy
      */

--- a/core-bundle/tests/Controller/SitemapControllerTest.php
+++ b/core-bundle/tests/Controller/SitemapControllerTest.php
@@ -472,7 +472,7 @@ class SitemapControllerTest extends TestCase
             21 => null,
         ];
 
-        $framework = $this->mockFrameworkWithPages($pages, [43 => null, 44 => null]);
+        $framework = $this->mockFrameworkWithPages($pages, [43 => null]);
         $container = $this->mockContainer($framework);
 
         $controller = new SitemapController($this->mockPageRegistry());


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #3395
| Docs PR or issue | -

This bug was introduced in https://github.com/contao/contao/commit/485bc50898acf8baca7b4a147692ca8407adcfe7. Previously the sitemap controller used `Backend::findSearchablePages` which checked the `robots` setting of each page - but it's missing in the current implementation.
