### PR TITLE
Feature/bearer scope

### DIFF
--- a/core-bundle/src/Controller/Bearer/BearerController.php
+++ b/core-bundle/src/Controller/Bearer/BearerController.php
@@ -82,7 +82,7 @@ class BearerController extends AbstractController
                 return (new JsonResponse($user->getData()));
 
             } else {
-                throw new \Exception('invalid user');
+                throw new \Exception('invalid userInstance');
             }
 
         } catch (\Exception $exception) {
@@ -107,7 +107,7 @@ class BearerController extends AbstractController
                 return (new JsonResponse($user->getData()));
 
             } else {
-                throw new \Exception('invalid user');
+                throw new \Exception('invalid userInstance');
             }
 
         } catch (\Exception $exception) {
@@ -181,15 +181,21 @@ class BearerController extends AbstractController
 
             $this->framework->initialize();
 
-            $user = MemberModel::findByUsername($user->username);
-            if ($user === null) {
-                throw new \Exception('user not found');
+            if ($user instanceof FrontendUser) {
+
+                $user = MemberModel::findByUsername($user->username);
+                if ($user === null) {
+                    throw new \Exception('user not found');
+                }
+
+                $user->bearerToken = null;
+                $user->save();
+
+                return (new JsonResponse(true));
+
+            } else {
+                throw new \Exception('invalid userInstance');
             }
-
-            $user->bearerToken = null;
-            $user->save();
-
-            return (new JsonResponse(true));
 
         } catch (\Exception $exception) {
             return (new JsonResponse($exception->getMessage(), 400));
@@ -213,15 +219,21 @@ class BearerController extends AbstractController
 
             $this->framework->initialize();
 
-            $user = UserModel::findByUsername($user->username);
-            if ($user === null) {
-                throw new \Exception('user not found');
+            if ($user instanceof BackendUser) {
+
+                $user = UserModel::findByUsername($user->username);
+                if ($user === null) {
+                    throw new \Exception('user not found');
+                }
+
+                $user->bearerToken = null;
+                $user->save();
+
+                return (new JsonResponse(true));
+
+            } else {
+                throw new \Exception('invalid userInstance');
             }
-
-            $user->bearerToken = null;
-            $user->save();
-
-            return (new JsonResponse(true));
 
         } catch (\Exception $exception) {
             return (new JsonResponse($exception->getMessage(), 400));

--- a/core-bundle/src/Controller/Bearer/BearerController.php
+++ b/core-bundle/src/Controller/Bearer/BearerController.php
@@ -67,6 +67,9 @@ class BearerController extends AbstractController
 
     /**
      * @Route("/bearerFrontend/memberInfo", name="contao_bearerFrontend_memberinfo", defaults={"_scope" = "bearerFrontend", "_token_check" = false}, methods="GET")
+     *
+     * $user is instance of \Contao\FrontendUser
+     *
      */
     public function memberInfo(Request $request, UserInterface $user): JsonResponse
     {
@@ -89,6 +92,9 @@ class BearerController extends AbstractController
 
     /**
      * @Route("/bearerBackend/userInfo", name="contao_bearerBackend_userinfo", defaults={"_scope" = "bearerBackend", "_token_check" = false}, methods="GET")
+     *
+     * $user is instance of \Contao\BackendUser
+     *
      */
     public function userInfo(Request $request, UserInterface $user): JsonResponse
     {
@@ -111,6 +117,8 @@ class BearerController extends AbstractController
 
     /**
      * @Route("/bearerFrontend/refresh", name="contao_bearerFrontend_refresh", defaults={"_scope" = "bearerFrontend", "_token_check" = false}, methods="POST")
+     *
+     * $user is instance of \Contao\FrontendUser
      *
      * @param Request $request
      * @param UserInterface $user
@@ -135,6 +143,8 @@ class BearerController extends AbstractController
     /**
      * @Route("/bearerBackend/refresh", name="contao_bearerBackend_refresh", defaults={"_scope" = "bearerBackend", "_token_check" = false}, methods="POST")
      *
+     * $user is instance of \Contao\BackendUser
+     *
      * @param Request $request
      * @param UserInterface $user
      * @return JsonResponse
@@ -158,6 +168,8 @@ class BearerController extends AbstractController
     /**
      * @Route("/bearerFrontend/logout", name="contao_bearerFrontend_logout", defaults={"_scope" = "bearerFrontend", "_token_check" = false}, methods="GET")
      *
+     * $user is instance of \Contao\FrontendUser
+     *
      * @param Request $request
      * @param UserInterface $user
      * @return JsonResponse
@@ -169,12 +181,12 @@ class BearerController extends AbstractController
 
             $this->framework->initialize();
 
-            $user = MemberModel::findByUsername($user->getUsername());
+            $user = MemberModel::findByUsername($user->username);
             if ($user === null) {
                 throw new \Exception('user not found');
             }
 
-            $user->jwt = null;
+            $user->bearerToken = null;
             $user->save();
 
             return (new JsonResponse(true));
@@ -188,6 +200,8 @@ class BearerController extends AbstractController
     /**
      * @Route("/bearerBackend/logout", name="contao_bearerBackend_logout", defaults={"_scope" = "bearerBackend", "_token_check" = false}, methods="GET")
      *
+     * $user is instance of \Contao\BackendUser
+     *
      * @param Request $request
      * @param UserInterface $user
      * @return JsonResponse
@@ -199,12 +213,12 @@ class BearerController extends AbstractController
 
             $this->framework->initialize();
 
-            $user = UserModel::findByUsername($user->getUsername());
+            $user = UserModel::findByUsername($user->username);
             if ($user === null) {
                 throw new \Exception('user not found');
             }
 
-            $user->jwt = null;
+            $user->bearerToken = null;
             $user->save();
 
             return (new JsonResponse(true));
@@ -248,7 +262,7 @@ class BearerController extends AbstractController
 
         if (!$encoder->isPasswordValid($user->password, $password, null)) {
 
-            $user->jwt = null;
+            $user->bearerToken = null;
             $user->save();
 
             throw new \Exception("error auth - invalid password for username:" . $username);
@@ -258,7 +272,7 @@ class BearerController extends AbstractController
         $token = Jwt::generate(\base64_encode($username), $ttl, array('username' => $username));
         $refresh_token = Jwt::generate(\base64_encode($username), $ttl, array('username' => $username, 'isRefreshToken' => true));
 
-        $user->jwt = $token;
+        $user->bearerToken = $token;
         $user->save();
 
         return [
@@ -288,7 +302,7 @@ class BearerController extends AbstractController
 
         $refreshToken = (string)$data['refresh_token'];
 
-        $username = $user->getUsername();
+        $username = $user->username;
 
         try {
 
@@ -316,7 +330,7 @@ class BearerController extends AbstractController
             $token = Jwt::generate(\base64_encode($username), $ttl, array('username' => $username));
             $refresh_token = Jwt::generate(\base64_encode($username), $ttl, array('username' => $username, 'isRefreshToken' => true));
 
-            $user->jwt = $token;
+            $user->bearerToken = $token;
             $user->save();
 
             return [

--- a/core-bundle/src/Controller/Bearer/BearerController.php
+++ b/core-bundle/src/Controller/Bearer/BearerController.php
@@ -1,0 +1,289 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Contao\CoreBundle\Controller\Bearer;
+
+use Contao\BackendUser;
+use Contao\CoreBundle\Controller\AbstractController;
+use Contao\CoreBundle\Framework\ContaoFramework;
+use Contao\CoreBundle\Security\Jwt\Jwt;
+use Contao\FrontendUser;
+use Contao\MemberModel;
+use Contao\System;
+use Contao\User;
+use Contao\UserModel;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+class BearerController extends AbstractController
+{
+    protected $framework;
+
+    public function __construct(ContaoFramework $framework)
+    {
+        $this->framework = $framework;
+    }
+
+    /**
+     * @Route("/bearerFrontend/auth", name="contao_bearerFrontend_auth", defaults={"_scope" = "frontend", "_token_check" = false}, methods="POST")
+     */
+    public function memberAuth(Request $request): JsonResponse
+    {
+        try {
+
+            $this->framework->initialize();
+
+            $data = (array)\json_decode($request->getContent(), true);
+            $response = $this->generateAuthResponse($data, false);
+
+            return (new JsonResponse($response));
+
+        } catch (\Exception $exception) {
+            return (new JsonResponse($exception->getMessage(), 400));
+        }
+    }
+
+    /**
+     * @Route("/bearerBackend/auth", name="contao_bearerBackend_auth", defaults={"_scope" = "frontend", "_token_check" = false}, methods="POST")
+     */
+    public function userAuth(Request $request): JsonResponse
+    {
+        try {
+
+            $this->framework->initialize();
+
+            $data = (array)\json_decode($request->getContent(), true);
+            $response = $this->generateAuthResponse($data, true);
+
+            return (new JsonResponse($response));
+
+        } catch (\Exception $exception) {
+            return (new JsonResponse($exception->getMessage(), 400));
+        }
+    }
+
+    /**
+     * @Route("/bearerFrontend/memberInfo", name="contao_bearerFrontend_memberinfo", defaults={"_scope" = "bearerFrontend", "_token_check" = false}, methods="GET")
+     */
+    public function memberInfo(Request $request, UserInterface $user): JsonResponse
+    {
+        try {
+
+            $this->framework->initialize();
+
+            if ($user instanceof FrontendUser) {
+
+                return (new JsonResponse($user->getData()));
+
+            } else {
+                throw new \Exception('invalid user');
+            }
+
+        } catch (\Exception $exception) {
+            return (new JsonResponse($exception->getMessage(), 400));
+        }
+    }
+
+    /**
+     * @Route("/bearerBackend/userInfo", name="contao_bearerBackend_userinfo", defaults={"_scope" = "bearerBackend", "_token_check" = false}, methods="GET")
+     */
+    public function userInfo(Request $request, UserInterface $user): JsonResponse
+    {
+        try {
+
+            $this->framework->initialize();
+
+            if ($user instanceof BackendUser) {
+
+                return (new JsonResponse($user->getData()));
+
+            } else {
+                throw new \Exception('invalid user');
+            }
+
+        } catch (\Exception $exception) {
+            return (new JsonResponse($exception->getMessage(), 400));
+        }
+    }
+
+    /**
+     * @Route("/bearerFrontend/refresh", name="contao_bearerFrontend_refresh", defaults={"_scope" = "bearerFrontend", "_token_check" = false}, methods="POST")
+     *
+     * @param Request $request
+     * @param UserInterface $user
+     * @return JsonResponse
+     */
+    public function refreshMember(Request $request, UserInterface $user): JsonResponse
+    {
+        try {
+
+            $this->framework->initialize();
+
+            $data = (array)\json_decode($request->getContent(), true);
+            $response = $this->refreshToken($data, $user, false);
+
+            return (new JsonResponse($response));
+
+        } catch (\Exception $exception) {
+            return (new JsonResponse($exception->getMessage(), 400));
+        }
+    }
+
+    /**
+     * @Route("/bearerBackend/refresh", name="contao_bearerBackend_refresh", defaults={"_scope" = "bearerBackend", "_token_check" = false}, methods="POST")
+     *
+     * @param Request $request
+     * @param UserInterface $user
+     * @return JsonResponse
+     */
+    public function refreshUser(Request $request, UserInterface $user): JsonResponse
+    {
+        try {
+
+            $this->framework->initialize();
+
+            $data = (array)\json_decode($request->getContent(), true);
+            $response = $this->refreshToken($data, $user, true);
+
+            return (new JsonResponse($response));
+
+        } catch (\Exception $exception) {
+            return (new JsonResponse($exception->getMessage(), 400));
+        }
+    }
+
+    /**
+     * @Route("/bearerFrontend/logout", name="contao_bearer_logout", defaults={"_scope" = "bearerFrontend", "_token_check" = false}, methods="GET")
+     *
+     * @param Request $request
+     * @param UserInterface $user
+     * @return JsonResponse
+     * @throws \Exception
+     */
+    public function logoutMember(Request $request, UserInterface $user): JsonResponse
+    {
+        // For future use - but therefore the tokens has to be stored in database and auth should compare to existing database entries
+        throw new \Exception('not supported');
+    }
+
+    /**
+     * @Route("/bearerBackend/logout", name="contao_bearer_logout", defaults={"_scope" = "bearerBackend", "_token_check" = false}, methods="GET")
+     *
+     * @param Request $request
+     * @param UserInterface $user
+     * @return JsonResponse
+     * @throws \Exception
+     */
+    public function logoutUser(Request $request, UserInterface $user): JsonResponse
+    {
+        // For future use - but therefore the tokens has to be stored in database and auth should compare to existing database entries
+        throw new \Exception('not supported');
+    }
+
+    /**
+     * @param array $data
+     * @param bool $isBackendUser
+     * @return array
+     * @throws \Exception
+     */
+    private function generateAuthResponse(array $data, bool $isBackendUser): array
+    {
+        if (!\array_key_exists('username', $data) || !\array_key_exists('password', $data)) {
+            throw new \Exception('invalid key-parameters for auth');
+        }
+
+        $ttl = 3000;
+        if (\array_key_exists('ttl', $data)) {
+            $ttl = (int)$data['ttl'];
+        }
+
+        $username = (string)$data['username'];
+        $password = (string)$data['password'];
+
+        $encoder = System::getContainer()->get('security.encoder_factory')->getEncoder(User::class);
+
+        if ($isBackendUser) {
+
+            $userObject = UserModel::findByUsername($username);
+            if ($userObject === null) {
+                throw new \Exception('user not found');
+            }
+
+            if (!$encoder->isPasswordValid($userObject->password, $password, null)) {
+                throw new \Exception("error auth - invalid password for username:" . $username);
+            }
+
+        } else {
+
+            $memberObject = MemberModel::findByUsername($username);
+            if ($memberObject === null) {
+                throw new \Exception('user not found');
+            }
+
+            if (!$encoder->isPasswordValid($memberObject->password, $password, null)) {
+                throw new \Exception("error auth - invalid password for username:" . $username);
+            }
+
+        }
+
+        return [
+            'username' => $username,
+            'token' => Jwt::generate(\base64_encode($username), $ttl, array('username' => $username)),
+            'refresh_token' => Jwt::generate(\base64_encode($username), $ttl, array('username' => $username, 'isRefreshToken' => true))
+        ];
+    }
+
+    /**
+     * @param array $data
+     * @param UserInterface $user
+     * @param bool $isBackendUser
+     * @return array
+     * @throws \Exception
+     */
+    public function refreshToken(array $data, UserInterface $user, bool $isBackendUser): array
+    {
+        if (!\array_key_exists('refresh_token', $data)) {
+            throw new \Exception('invalid key-parameters for refresh token');
+        }
+
+        $ttl = 3000;
+        if (\array_key_exists('ttl', $data)) {
+            $ttl = (int)$data['ttl'];
+        }
+
+        $refreshToken = (string)$data['refresh_token'];
+
+        $username = $user->getUsername();
+
+        try {
+
+            if (Jwt::validateAndVerify($refreshToken, \base64_encode($username)) === false) {
+                throw new \Exception('refresh_token not valid');
+            }
+
+            $tokenUsername = Jwt::getClaim($refreshToken, 'username');
+
+            if ($tokenUsername == null || $tokenUsername == '') {
+                throw new \Exception('refresh_token does not match with username');
+            }
+
+            $isRefreshToken = Jwt::getClaim($refreshToken, 'isRefreshToken');
+            if (!$isRefreshToken) {
+                throw new \Exception('invalid refresh_token');
+            }
+
+        } catch (\Exception $ex) {
+            throw new \Exception($ex->getMessage());
+        }
+
+        return [
+            'username' => $username,
+            'token' => Jwt::generate(\base64_encode($username), $ttl, array('username' => $username)),
+            'refresh_token' => Jwt::generate(\base64_encode($username), $ttl, array('username' => $username, 'isRefreshToken' => true))
+        ];
+    }
+
+}

--- a/core-bundle/src/Resources/config/services.yml
+++ b/core-bundle/src/Resources/config/services.yml
@@ -5,15 +5,15 @@ services:
     _instanceof:
         Contao\CoreBundle\Framework\FrameworkAwareInterface:
             calls:
-                - [setFramework, ['@contao.framework']]
+                - [ setFramework, [ '@contao.framework' ] ]
 
         Symfony\Bundle\FrameworkBundle\Controller\AbstractController:
             calls:
-                - [setContainer, ['@Psr\Container\ContainerInterface']]
+                - [ setContainer, [ '@Psr\Container\ContainerInterface' ] ]
 
         Symfony\Component\DependencyInjection\ContainerAwareInterface:
             calls:
-                - [setContainer, ['@service_container']]
+                - [ setContainer, [ '@service_container' ] ]
 
     Contao\CoreBundle\Framework\ContaoFramework: '@contao.framework'
     Contao\CoreBundle\Image\ImageFactoryInterface: '@contao.image.image_factory'
@@ -293,7 +293,7 @@ services:
     contao.fragment.pre_handlers:
         class: Symfony\Component\DependencyInjection\ServiceLocator
         arguments:
-            - []
+            - [ ]
 
     contao.fragment.registry:
         class: Contao\CoreBundle\Fragment\FragmentRegistry
@@ -304,7 +304,7 @@ services:
             - '@http_kernel'
             - '@event_dispatcher'
         calls:
-            - [setFragmentPath, ['%fragment.path%']]
+            - [ setFragmentPath, [ '%fragment.path%' ] ]
         tags:
             - { name: kernel.fragment_renderer, alias: forward }
 
@@ -566,7 +566,7 @@ services:
     contao.routing.backend_matcher:
         class: Symfony\Component\HttpFoundation\RequestMatcher
         calls:
-            - [matchAttribute, [_scope, backend]]
+            - [ matchAttribute, [ _scope, backend ] ]
 
     contao.routing.candidates:
         class: Contao\CoreBundle\Routing\Candidates\PageCandidates
@@ -588,7 +588,7 @@ services:
     contao.routing.frontend_matcher:
         class: Symfony\Component\HttpFoundation\RequestMatcher
         calls:
-            - [matchAttribute, [_scope, frontend]]
+            - [ matchAttribute, [ _scope, frontend ] ]
 
     contao.routing.images_loader:
         class: Contao\CoreBundle\Routing\ImagesLoader
@@ -614,9 +614,9 @@ services:
             - '@contao.routing.route_provider'
             - '@contao.routing.final_matcher'
         calls:
-            - [addRouteFilter, ['@contao.routing.domain_filter']]
-            - [addRouteFilter, ['@contao.routing.published_filter']]
-            - [addRouteFilter, ['@contao.routing.language_filter']]
+            - [ addRouteFilter, [ '@contao.routing.domain_filter' ] ]
+            - [ addRouteFilter, [ '@contao.routing.published_filter' ] ]
+            - [ addRouteFilter, [ '@contao.routing.language_filter' ] ]
         public: true
 
     contao.routing.nested_404_matcher:
@@ -625,8 +625,8 @@ services:
             - '@contao.routing.route_404_provider'
             - '@contao.routing.final_matcher'
         calls:
-            - [addRouteFilter, ['@contao.routing.domain_filter']]
-            - [addRouteFilter, ['@contao.routing.published_filter']]
+            - [ addRouteFilter, [ '@contao.routing.domain_filter' ] ]
+            - [ addRouteFilter, [ '@contao.routing.published_filter' ] ]
         public: true
 
     Contao\CoreBundle\Routing\Page\PageRegistry:
@@ -730,7 +730,7 @@ services:
             - ~
             - '@contao.security.authentication_success_handler'
             - '@contao.security.authentication_failure_handler'
-            - []
+            - [ ]
             - '@?logger'
             - '@?event_dispatcher'
         tags:
@@ -865,14 +865,14 @@ services:
         arguments:
             - _contao_be_attributes
         calls:
-            - [setName, [contao_backend]]
+            - [ setName, [ contao_backend ] ]
 
     contao.session.contao_frontend:
         class: Contao\CoreBundle\Session\Attribute\ArrayAttributeBag
         arguments:
             - _contao_fe_attributes
         calls:
-            - [setName, [contao_frontend]]
+            - [ setName, [ contao_frontend ] ]
 
     contao.slug:
         class: Contao\CoreBundle\Slug\Slug
@@ -929,7 +929,7 @@ services:
 
     Contao\CoreBundle\Twig\Loader\FailTolerantFilesystemLoader:
         arguments:
-            - []
+            - [ ]
             - '%kernel.project_dir%'
         tags:
             - { name: twig.loader, priority: 1 }
@@ -982,3 +982,24 @@ services:
         arguments:
             - '@Contao\CoreBundle\Util\SimpleTokenExpressionLanguage'
         public: true
+
+    contao.security.bearer_token_authenticator:
+        class: Contao\CoreBundle\Security\Authentication\Bearer\BearerTokenAuthenticator
+        arguments:
+            - '@contao.framework'
+
+    Contao\CoreBundle\Controller\Bearer\BearerController:
+        arguments:
+            - '@contao.framework'
+        tags:
+            - controller.service_arguments
+
+    contao.routing.bearer_frontend_matcher:
+        class: Symfony\Component\HttpFoundation\RequestMatcher
+        calls:
+            - [ matchAttribute, [ _scope, bearerFrontend ] ]
+
+    contao.routing.bearer_backend_matcher:
+        class: Symfony\Component\HttpFoundation\RequestMatcher
+        calls:
+            - [ matchAttribute, [ _scope, bearerBackend ] ]

--- a/core-bundle/src/Resources/contao/dca/tl_member.php
+++ b/core-bundle/src/Resources/contao/dca/tl_member.php
@@ -135,7 +135,7 @@ $GLOBALS['TL_DCA']['tl_member'] = array
 		(
 			'sql'                     => "int(10) unsigned NOT NULL default 0"
 		),
-		'jwt' => array
+		'bearerToken' => array
 		(
 			'sql'                     => "text NULL"
 		),

--- a/core-bundle/src/Resources/contao/dca/tl_member.php
+++ b/core-bundle/src/Resources/contao/dca/tl_member.php
@@ -135,6 +135,10 @@ $GLOBALS['TL_DCA']['tl_member'] = array
 		(
 			'sql'                     => "int(10) unsigned NOT NULL default 0"
 		),
+		'jwt' => array
+		(
+			'sql'                     => "text NULL"
+		),
 		'firstname' => array
 		(
 			'exclude'                 => true,

--- a/core-bundle/src/Resources/contao/dca/tl_user.php
+++ b/core-bundle/src/Resources/contao/dca/tl_user.php
@@ -144,6 +144,10 @@ $GLOBALS['TL_DCA']['tl_user'] = array
 		(
 			'sql'                     => "int(10) unsigned NOT NULL default 0"
 		),
+		'jwt' => array
+		(
+			'sql'                     => "text NULL"
+		),
 		'username' => array
 		(
 			'exclude'                 => true,

--- a/core-bundle/src/Resources/contao/dca/tl_user.php
+++ b/core-bundle/src/Resources/contao/dca/tl_user.php
@@ -144,7 +144,7 @@ $GLOBALS['TL_DCA']['tl_user'] = array
 		(
 			'sql'                     => "int(10) unsigned NOT NULL default 0"
 		),
-		'jwt' => array
+		'bearerToken' => array
 		(
 			'sql'                     => "text NULL"
 		),

--- a/core-bundle/src/Security/Authentication/Bearer/BearerTokenAuthenticator.php
+++ b/core-bundle/src/Security/Authentication/Bearer/BearerTokenAuthenticator.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Contao\CoreBundle\Security\Authentication\Bearer;
+
+use Contao\CoreBundle\Framework\ContaoFramework;
+use Contao\CoreBundle\Security\Jwt\Jwt;
+use Contao\CoreBundle\Security\User\ContaoUserProvider;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Core\User\UserProviderInterface;
+use Symfony\Component\Security\Guard\AbstractGuardAuthenticator;
+
+class BearerTokenAuthenticator extends AbstractGuardAuthenticator
+{
+    /**
+     * @var ContaoFramework
+     */
+    private $framework;
+
+    private static $prefix = 'Bearer';
+    private static $name = 'Authorization';
+
+    public function __construct(ContaoFramework $framework)
+    {
+        $this->framework = $framework;
+    }
+
+    public function supports(Request $request): ?bool
+    {
+        if ('bearerFrontend' === $request->attributes->get('_scope') || 'bearerBackend' === $request->attributes->get('_scope')) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public function onAuthenticationSuccess(Request $request, TokenInterface $token, string $providerKey): ?Response
+    {
+        return null;
+    }
+
+    public function onAuthenticationFailure(Request $request, AuthenticationException $exception): ?Response
+    {
+        return new JsonResponse($exception->getMessage(), Response::HTTP_FORBIDDEN);
+    }
+
+    public function start(Request $request, AuthenticationException $authException = null): JsonResponse
+    {
+        return new JsonResponse('Auth required', Response::HTTP_UNAUTHORIZED);
+    }
+
+    public function getCredentials(Request $request): array
+    {
+        $this->framework->initialize();
+
+        if (!$request->headers->has(self::$name)) {
+            throw new AuthenticationException(self::$name . ' not found in Header');
+        }
+
+        $authorizationHeader = $request->headers->get(self::$name);
+        if (empty($authorizationHeader)) {
+            throw new AuthenticationException(self::$name . ' empty in Header');
+        }
+
+        $headerParts = explode(' ', $authorizationHeader);
+        if (!(2 === count($headerParts) && 0 === strcasecmp($headerParts[0], self::$prefix))) {
+            throw new AuthenticationException('no valid value for ' . self::$name . ' in Header');
+        }
+
+        return ['token' => $headerParts[1]];
+    }
+
+    public function getUser($credentials, UserProviderInterface $userProvider)
+    {
+        if ($userProvider instanceof ContaoUserProvider) {
+
+            $username = Jwt::getClaim($credentials['token'], 'username');
+
+            if ($username == null || $username == '') {
+                throw new AuthenticationException('invalid username in token');
+            }
+
+            return $userProvider->loadUserByUsername($username);
+
+        } else {
+            throw new AuthenticationException('invalid provider');
+        }
+
+    }
+
+    public function checkCredentials($credentials, UserInterface $user): bool
+    {
+        try {
+
+            return Jwt::validateAndVerify($credentials['token'], \base64_encode($user->getUsername()));
+
+        } catch (\Exception $ex) {
+            throw new AuthenticationException($ex->getMessage());
+        }
+
+    }
+
+    public function supportsRememberMe(): bool
+    {
+        return false;
+    }
+}

--- a/core-bundle/src/Security/Authentication/Bearer/BearerTokenAuthenticator.php
+++ b/core-bundle/src/Security/Authentication/Bearer/BearerTokenAuthenticator.php
@@ -98,7 +98,15 @@ class BearerTokenAuthenticator extends AbstractGuardAuthenticator
     {
         try {
 
-            return Jwt::validateAndVerify($credentials['token'], \base64_encode($user->getUsername()));
+            $currentToken = (string)$credentials['token'];
+            $userToken = (string)$user->jwt;
+            $username = $user->username;
+
+            if ($currentToken === null || $currentToken === '' || $currentToken !== $userToken || Jwt::validateAndVerify($currentToken, \base64_encode($username)) === false) {
+                return false;
+            }
+
+            return true;
 
         } catch (\Exception $ex) {
             throw new AuthenticationException($ex->getMessage());

--- a/core-bundle/src/Security/Jwt/Jwt.php
+++ b/core-bundle/src/Security/Jwt/Jwt.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Contao\CoreBundle\Security\Jwt;
+
+use Contao\System;
+use Lcobucci\JWT\Configuration;
+use Lcobucci\JWT\Signer\Hmac\Sha256;
+use Lcobucci\JWT\Signer\Key\InMemory;
+use Lcobucci\JWT\Token;
+use Lcobucci\JWT\Validation\Constraint\IdentifiedBy;
+use Lcobucci\JWT\Validation\Constraint\IssuedBy;
+use Lcobucci\JWT\Validation\Constraint\PermittedFor;
+use Lcobucci\JWT\Validation\Constraint\SignedWith;
+
+class Jwt
+{
+    private static $issuedBy = 'Contao';
+    private static $permittedFor = 'https://contao.org';
+
+    private static function getDefaultKeyString(): string
+    {
+        $keyString = System::getContainer()->getParameter('kernel.secret');
+        return substr($keyString, 10, 32);
+    }
+
+    private static function getConfig(): Configuration
+    {
+        return Configuration::forSymmetricSigner(new Sha256(), InMemory::plainText(self::getDefaultKeyString()));
+    }
+
+    public static function generate(string $jti, int $nbf = 3600, array $claims = array()): string
+    {
+        $time = time();
+
+        $config = self::getConfig();
+
+        $issuesAt = (new \DateTimeImmutable())->setTimestamp($time);
+        $usedAfter = (new \DateTimeImmutable())->setTimestamp($time + 0);
+        $expiresAt = (new \DateTimeImmutable())->setTimestamp($time + $nbf);
+
+        $builder = $config->builder();
+        $builder->issuedBy(self::$issuedBy); // iss claim
+        $builder->permittedFor(self::$permittedFor); // iss claim
+        $builder->identifiedBy($jti); // jti claim
+        $builder->issuedAt($issuesAt); // iat claim
+
+        $builder->canOnlyBeUsedAfter($usedAfter); // Configures the time that the token can be used (nbf claim)
+        if ($nbf > 0) {
+            $builder->expiresAt($expiresAt); // Configures the expiration time of the token (exp claim)
+        }
+
+        if (\count($claims) > 0) {
+            foreach ($claims as $keyClaim => $valueClaim) {
+                $builder->withClaim($keyClaim, $valueClaim);
+            }
+        }
+
+        $token = $builder->getToken($config->signer(), $config->signingKey());
+
+        return $token->toString();
+    }
+
+    public static function parse(string $token): Token
+    {
+        $config = self::getConfig();
+        $parser = $config->parser();
+
+        return $parser->parse($token);
+    }
+
+    public static function getClaim(string $token, string $name)
+    {
+        try {
+
+            $tokenObject = self::parse($token);
+            $value = $tokenObject->claims()->get($name);
+
+        } catch (\Exception $ex) {
+            $value = null;
+        }
+
+        return $value;
+    }
+
+    public static function validateAndVerify(string $token, string $jti): bool
+    {
+        $tokenObject = self::parse($token);
+
+        $config = self::getConfig();
+
+        $issuedByConstraints = new IssuedBy(self::$issuedBy);
+        $permittedForConstraints = new PermittedFor(self::$permittedFor);
+        $identifiedByConstraints = new IdentifiedBy($jti);
+
+        $validator = $config->validator();
+
+        try {
+
+            $signer = new SignedWith($config->signer(), InMemory::plainText(self::getDefaultKeyString()));
+            $validator->assert($tokenObject, $signer);
+
+            $value = $validator->validate($tokenObject, $issuedByConstraints, $permittedForConstraints, $identifiedByConstraints);
+
+            if ($value == true) {
+                $now = (new \DateTimeImmutable())->setTimestamp(time());
+                $value = !$tokenObject->isExpired($now);
+            }
+
+        } catch (\Exception $ex) {
+            $value = false;
+        }
+
+        return $value;
+    }
+}

--- a/manager-bundle/src/Resources/skeleton/config/security.yml
+++ b/manager-bundle/src/Resources/skeleton/config/security.yml
@@ -52,8 +52,24 @@ security:
                     - contao.security.logout_handler
                 success_handler: contao.security.logout_success_handler
 
+        contao_bearer_frontend:
+            request_matcher: contao.routing.bearer_frontend_matcher
+            provider: contao.security.frontend_user_provider
+            stateless: true
+            guard:
+                authenticators:
+                    - contao.security.bearer_token_authenticator
+
+        contao_bearer_backend:
+            request_matcher: contao.routing.bearer_backend_matcher
+            provider: contao.security.backend_user_provider
+            stateless: true
+            guard:
+                authenticators:
+                    - contao.security.bearer_token_authenticator
+
     access_control:
         - { path: ^/contao/login$, roles: IS_AUTHENTICATED_ANONYMOUSLY }
         - { path: ^/contao/logout$, roles: IS_AUTHENTICATED_ANONYMOUSLY }
         - { path: ^/contao(/|$), roles: ROLE_USER }
-        - { path: ^/, roles: [IS_AUTHENTICATED_ANONYMOUSLY] }
+        - { path: ^/, roles: [ IS_AUTHENTICATED_ANONYMOUSLY ] }

--- a/manager-bundle/src/Resources/skeleton/config/security.yml
+++ b/manager-bundle/src/Resources/skeleton/config/security.yml
@@ -56,6 +56,9 @@ security:
             request_matcher: contao.routing.bearer_frontend_matcher
             provider: contao.security.frontend_user_provider
             user_checker: contao.security.user_checker
+            anonymous: true
+            lazy: true
+            logout: ~
             stateless: true
             guard:
                 authenticators:
@@ -65,6 +68,9 @@ security:
             request_matcher: contao.routing.bearer_backend_matcher
             provider: contao.security.backend_user_provider
             user_checker: contao.security.user_checker
+            anonymous: true
+            lazy: true
+            logout: ~
             stateless: true
             guard:
                 authenticators:

--- a/manager-bundle/src/Resources/skeleton/config/security.yml
+++ b/manager-bundle/src/Resources/skeleton/config/security.yml
@@ -55,6 +55,7 @@ security:
         contao_bearer_frontend:
             request_matcher: contao.routing.bearer_frontend_matcher
             provider: contao.security.frontend_user_provider
+            user_checker: contao.security.user_checker
             stateless: true
             guard:
                 authenticators:
@@ -63,6 +64,7 @@ security:
         contao_bearer_backend:
             request_matcher: contao.routing.bearer_backend_matcher
             provider: contao.security.backend_user_provider
+            user_checker: contao.security.user_checker
             stateless: true
             guard:
                 authenticators:


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #...
| Docs PR or issue | https://github.com/contao/contao/issues/3024

Hello,

this request is a prototype for authentication using the JWT Bearer method which can be a feature for future version. 

I need this very often and wanted to discuss with you guys whether it might be something for the core :-)

**Goal:**
- There are two new scopes called "bearerFrontend" and "bearerBackend"
- Controller/Routes can be annotated with this scope and so the Controllers/Routes are only avalible in the bearer scope
- There is a new Controller "BearerController" where some basic features (Routes) are implemented (Login, UserInfo, RefreshToken, Logout) 

Currently only the basic features are included, which can be expanded.

**Note:**
Currently the deprecated AbstractGuardAuthenticator (https://symfony.com/doc/current/security/guard_authentication.html) is used because in don´t really know if the currenty Security of Contao is compatible to the new Authenticator-based Security (https://symfony.com/doc/current/security/authenticator_manager.html). The goal should be to use this but the deprecated  AbstractGuardAuthenticator still works in 5.4. So we have to discuss if the new Security can be used here...


**More features for future:**
- generate token from Backend
- make possibility to generate alternative token without TTL (e.g. to use it in machines without username/password)
- maybe show a list of active tokens in Backend
- ...

Would be great if you take a look at it and give your opinion on it :-)

Thank a lot and greetings
