### PR TITLE
Fix the `Adapter::__call()` method signature

### DIFF
--- a/core-bundle/src/Framework/Adapter.php
+++ b/core-bundle/src/Framework/Adapter.php
@@ -39,7 +39,7 @@ class Adapter
     /**
      * Calls a method of the adapted class.
      */
-    public function __call(string $name, array $arguments = [])
+    public function __call(string $name, array $arguments)
     {
         return \call_user_func_array([$this->class, $name], $arguments);
     }


### PR DESCRIPTION
Currently it is impossible to mock Contao's `Adapter` class with the [Mockery framework](https://github.com/mockery/mockery):

````php
Mockery::mock(\Contao\CoreBundle\Framework\Adapter::class);

// Declaration of Mockery_X_Contao_CoreBundle_Framework_Adapter::__call(string $method, array $args) 
// should be compatible with Contao\CoreBundle\Framework\Adapter::__call(string $name, array $arguments = Array)
````

This is due to the method signature of the `Adapter` defining `$arguments` as an optional parameter with a default value:

````php
public function __call(string $name, array $arguments = [])
````

This differs from the standard method signature of [__call](https://www.php.net/manual/en/language.oop5.overloading.php#object.call):

````php
public __call(string $name, array $arguments): mixed
````

Even though Contao isn't using Mockery itself, it would be nice if we could use Mockery in our projects.

There are multiple similar (old) issues in mockery/mockery#263