### PR TITLE
Harden the version 4.5.0 migration

### DIFF
--- a/core-bundle/src/Migration/Version405/Version450Update.php
+++ b/core-bundle/src/Migration/Version405/Version450Update.php
@@ -51,44 +51,62 @@ class Version450Update extends AbstractMigration
 
     public function run(): MigrationResult
     {
-        $this->connection->query('
-            ALTER TABLE
-                tl_content
-            ADD
-                youtubeOptions text NULL
-        ');
+        $columns = $this->connection
+            ->getSchemaManager()
+            ->listTableColumns('tl_content')
+        ;
 
-        $this->connection->query('
-            ALTER TABLE
-                tl_content
-            ADD
-                youtubeStart int(10) unsigned NOT NULL default 0
-        ');
+        if (!isset($columns['youtubeoptions'])) {
+            $this->connection->query('
+                ALTER TABLE
+                    tl_content
+                ADD
+                    youtubeOptions text NULL
+            ');
+        }
 
-        $this->connection->query('
-            ALTER TABLE
-                tl_content
-            ADD
-                youtubeStop int(10) unsigned NOT NULL default 0
-        ');
+        if (!isset($columns['youtubestart'])) {
+            $this->connection->query('
+                ALTER TABLE
+                    tl_content
+                ADD
+                    youtubeStart int(10) unsigned NOT NULL default 0
+            ');
+        }
 
-        $this->connection->query("
-            UPDATE
-                tl_form_field
-            SET
-                type = 'fieldsetStart'
-            WHERE
-                type = 'fieldset' AND fsType = 'fsStart'
-        ");
+        if (!isset($columns['youtubestop'])) {
+            $this->connection->query('
+                ALTER TABLE
+                    tl_content
+                ADD
+                    youtubeStop int(10) unsigned NOT NULL default 0
+            ');
+        }
 
-        $this->connection->query("
-            UPDATE
-                tl_form_field
-            SET
-                type = 'fieldsetStop'
-            WHERE
-                type = 'fieldset' AND fsType = 'fsStop'
-        ");
+        $columns = $this->connection
+            ->getSchemaManager()
+            ->listTableColumns('tl_form_field')
+        ;
+
+        if (isset($columns['fstype'])) {
+            $this->connection->query("
+                UPDATE
+                    tl_form_field
+                SET
+                    type = 'fieldsetStart'
+                WHERE
+                    type = 'fieldset' AND fsType = 'fsStart'
+            ");
+
+            $this->connection->query("
+                UPDATE
+                    tl_form_field
+                SET
+                    type = 'fieldsetStop'
+                WHERE
+                    type = 'fieldset' AND fsType = 'fsStop'
+            ");
+        }
 
         $columns = $this->connection
             ->getSchemaManager()


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #3403
| Docs PR or issue | -

This hardens the Contao 4.5.0 migration in case errors happened during the migration - or in case of an otherwise inconsistent database state.