### PR TITLE
Remove the "generateSitemap" cronjob

### DIFF
--- a/core-bundle/src/Resources/contao/config/config.php
+++ b/core-bundle/src/Resources/contao/config/config.php
@@ -498,7 +498,6 @@ $GLOBALS['TL_CRON'] = array
 	'daily' => array
 	(
 		'purgeTempFolder' => array(Automator::class, 'purgeTempFolder'),
-		'generateSitemap' => array(Automator::class, 'generateSitemap'),
 		'purgeRegistrations' => array(Automator::class, 'purgeRegistrations'),
 		'purgeOptInTokens' => array(Automator::class, 'purgeOptInTokens')
 	),


### PR DESCRIPTION
Currently the `SitemapController` defines that its response can be cached up to 30 days. However there is also a cronjob that will invalidate all sitemaps every 24 hours. This cronjob existed historically before the current sitemap implementation as a controller, in order to purge and regenerate the static sitemap XML files. This is not needed anymore.