### PR TITLE
Handle another illegal array access on empty labels

### DIFF
--- a/core-bundle/src/Resources/contao/widgets/FileTree.php
+++ b/core-bundle/src/Resources/contao/widgets/FileTree.php
@@ -373,7 +373,7 @@ class FileTree extends Widget
         e.preventDefault();
         Backend.openModalSelector({
           "id": "tl_listing",
-          "title": ' . json_encode($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['label'][0]) . ',
+          "title": ' . json_encode($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['label'][0] ?? '') . ',
           "url": this.href + document.getElementById("ctrl_' . $this->strId . '").value,
           "callback": function(table, value) {
             new Request.Contao({


### PR DESCRIPTION
This PR fixes another PHP8 warning `Trying to access array offset on value of type null` when using a file tree widget without providing a label.