### PR TITLE
Do not dynamically disable HttpCache but rely on env vars instead

### DIFF
--- a/manager-bundle/src/HttpKernel/ContaoKernel.php
+++ b/manager-bundle/src/HttpKernel/ContaoKernel.php
@@ -289,8 +289,8 @@ class ContaoKernel extends Kernel implements HttpCacheProvider
         if (!$kernel->isDebug()) {
             $cache = $kernel->getHttpCache();
 
-            // Enable the Symfony reverse proxy if request has no surrogate capability
-            if (($surrogate = $cache->getSurrogate()) && !$surrogate->hasSurrogateCapability($request)) {
+            // Enable HTTP Cache if not disabled explicitly
+            if (!($_SERVER['DISABLE_HTTP_CACHE'] ?? false)) {
                 return $cache;
             }
         }

--- a/manager-bundle/src/HttpKernel/ContaoKernel.php
+++ b/manager-bundle/src/HttpKernel/ContaoKernel.php
@@ -287,11 +287,9 @@ class ContaoKernel extends Kernel implements HttpCacheProvider
         }
 
         if (!$kernel->isDebug()) {
-            $cache = $kernel->getHttpCache();
-
             // Enable HTTP Cache if not disabled explicitly
             if (!($_SERVER['DISABLE_HTTP_CACHE'] ?? false)) {
-                return $cache;
+                return $kernel->getHttpCache();
             }
         }
 

--- a/manager-bundle/src/HttpKernel/ContaoKernel.php
+++ b/manager-bundle/src/HttpKernel/ContaoKernel.php
@@ -286,11 +286,9 @@ class ContaoKernel extends Kernel implements HttpCacheProvider
             $kernel->setJwtManager($jwtManager);
         }
 
-        if (!$kernel->isDebug()) {
-            // Enable HTTP Cache if not disabled explicitly
-            if (!($_SERVER['DISABLE_HTTP_CACHE'] ?? false)) {
-                return $kernel->getHttpCache();
-            }
+        // Enable the Symfony reverse proxy if not disabled explicitly
+        if (!($_SERVER['DISABLE_HTTP_CACHE'] ?? null) && !$kernel->isDebug()) {
+            return $kernel->getHttpCache();
         }
 
         return $kernel;


### PR DESCRIPTION
Bug description:

* Right now, you can circumvent the HttpCache by simply sending `Surrogate-Capability: ESI/1.0` with your request.

Reproducing is easy:

```
# This response will contain the "Contao-Cache" headers
curl "https://contao.org/de/" \
     -H 'Accept: */*' \
     -H 'Connection: keep-alive'

# This will not contain any "Contao-Cache" header but the X-Cache-Tags
curl "https://contao.org/de/" \
     -H 'Accept: */*' \
     -H 'Connection: keep-alive' \
     -H 'Surrogate-Capability: ESI/1.0'
```

Possible solutions:

1. Accept `Surrogate-Capability` only from trusted proxies.
2. Replace current dynamic logic with an explicit env var config

I went for number 2 because:

* No matter which solution we choose, both pose a possible BC break and need adjustments in your .env config. Either the trusted proxies or the new environment variable. But it's a bug, so we need to fix this. So BC is not relevant here.
* The dynamic logic does not allow for having a cache proxy in front of Contao without Surrogate Capabilities (ESI). However, this is totally supported by Symfony as it will just not generate any `<esi...` tags in this case.
* it's way more explicit and clear.

