### PR TITLE
Improve the Twig theme path handling

### DIFF
--- a/core-bundle/src/Command/DebugContaoTwigCommand.php
+++ b/core-bundle/src/Command/DebugContaoTwigCommand.php
@@ -14,7 +14,7 @@ namespace Contao\CoreBundle\Command;
 
 use Contao\CoreBundle\Twig\Inheritance\TemplateHierarchyInterface;
 use Contao\CoreBundle\Twig\Loader\ContaoFilesystemLoaderWarmer;
-use Contao\CoreBundle\Twig\Loader\Theme;
+use Contao\CoreBundle\Twig\Loader\ThemeNamespace;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\TableSeparator;
 use Symfony\Component\Console\Input\InputArgument;
@@ -42,20 +42,20 @@ class DebugContaoTwigCommand extends Command
     private $cacheWarmer;
 
     /**
-     * @var Theme
+     * @var ThemeNamespace
      */
-    private $theme;
+    private $themeNamespace;
 
     /**
      * @var string
      */
     private $projectDir;
 
-    public function __construct(TemplateHierarchyInterface $hierarchy, ContaoFilesystemLoaderWarmer $cacheWarmer, Theme $theme, string $projectDir)
+    public function __construct(TemplateHierarchyInterface $hierarchy, ContaoFilesystemLoaderWarmer $cacheWarmer, ThemeNamespace $themeNamespace, string $projectDir)
     {
         $this->hierarchy = $hierarchy;
         $this->cacheWarmer = $cacheWarmer;
-        $this->theme = $theme;
+        $this->themeNamespace = $themeNamespace;
         $this->projectDir = $projectDir;
 
         parent::__construct();
@@ -115,7 +115,7 @@ class DebugContaoTwigCommand extends Command
         }
 
         if (is_dir(Path::join($this->projectDir, 'templates', $pathOrSlug))) {
-            return $this->theme->generateSlug($pathOrSlug);
+            return $this->themeNamespace->generateSlug($pathOrSlug);
         }
 
         return $pathOrSlug;

--- a/core-bundle/src/Command/DebugContaoTwigCommand.php
+++ b/core-bundle/src/Command/DebugContaoTwigCommand.php
@@ -14,7 +14,7 @@ namespace Contao\CoreBundle\Command;
 
 use Contao\CoreBundle\Twig\Inheritance\TemplateHierarchyInterface;
 use Contao\CoreBundle\Twig\Loader\ContaoFilesystemLoaderWarmer;
-use Contao\CoreBundle\Twig\Loader\TemplateLocator;
+use Contao\CoreBundle\Twig\Loader\Theme;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\TableSeparator;
 use Symfony\Component\Console\Input\InputArgument;
@@ -22,6 +22,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Webmozart\PathUtil\Path;
 
 /**
  * @experimental
@@ -40,10 +41,22 @@ class DebugContaoTwigCommand extends Command
      */
     private $cacheWarmer;
 
-    public function __construct(TemplateHierarchyInterface $hierarchy, ContaoFilesystemLoaderWarmer $cacheWarmer)
+    /**
+     * @var Theme
+     */
+    private $theme;
+
+    /**
+     * @var string
+     */
+    private $projectDir;
+
+    public function __construct(TemplateHierarchyInterface $hierarchy, ContaoFilesystemLoaderWarmer $cacheWarmer, Theme $theme, string $projectDir)
     {
         $this->hierarchy = $hierarchy;
         $this->cacheWarmer = $cacheWarmer;
+        $this->theme = $theme;
+        $this->projectDir = $projectDir;
 
         parent::__construct();
     }
@@ -52,7 +65,7 @@ class DebugContaoTwigCommand extends Command
     {
         $this
             ->setDescription('Displays the Contao template hierarchy.')
-            ->addOption('theme', 't', InputOption::VALUE_OPTIONAL, 'Include theme templates with a given theme path or alias.')
+            ->addOption('theme', 't', InputOption::VALUE_OPTIONAL, 'Include theme templates with a given theme path or slug.')
             ->addArgument('filter', InputArgument::OPTIONAL, 'Filter the output by an identifier or prefix.')
         ;
     }
@@ -63,7 +76,7 @@ class DebugContaoTwigCommand extends Command
         $this->cacheWarmer->refresh();
 
         $rows = [];
-        $chains = $this->hierarchy->getInheritanceChains($this->getThemeAlias($input));
+        $chains = $this->hierarchy->getInheritanceChains($this->getThemeSlug($input));
 
         if (null !== ($prefix = $input->getArgument('filter'))) {
             $chains = array_filter(
@@ -95,12 +108,16 @@ class DebugContaoTwigCommand extends Command
         return 0;
     }
 
-    private function getThemeAlias(InputInterface $input): ?string
+    private function getThemeSlug(InputInterface $input): ?string
     {
-        if (null === ($theme = $input->getOption('theme'))) {
+        if (null === ($pathOrSlug = $input->getOption('theme'))) {
             return null;
         }
 
-        return TemplateLocator::createDirectorySlug($theme);
+        if (is_dir(Path::join($this->projectDir, 'templates', $pathOrSlug))) {
+            return $this->theme->generateSlug($pathOrSlug);
+        }
+
+        return $pathOrSlug;
     }
 }

--- a/core-bundle/src/EventListener/DataContainer/ThemeTemplatesListener.php
+++ b/core-bundle/src/EventListener/DataContainer/ThemeTemplatesListener.php
@@ -15,7 +15,7 @@ namespace Contao\CoreBundle\EventListener\DataContainer;
 use Contao\CoreBundle\Exception\InvalidThemePathException;
 use Contao\CoreBundle\ServiceAnnotation\Callback;
 use Contao\CoreBundle\Twig\Loader\ContaoFilesystemLoaderWarmer;
-use Contao\CoreBundle\Twig\Loader\TemplateLocator;
+use Contao\CoreBundle\Twig\Loader\Theme;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
@@ -29,13 +29,19 @@ class ThemeTemplatesListener
     private $filesystemLoaderWarmer;
 
     /**
+     * @var Theme
+     */
+    private $theme;
+
+    /**
      * @var TranslatorInterface
      */
     private $translator;
 
-    public function __construct(ContaoFilesystemLoaderWarmer $filesystemLoaderWarmer, TranslatorInterface $translator)
+    public function __construct(ContaoFilesystemLoaderWarmer $filesystemLoaderWarmer, Theme $theme, TranslatorInterface $translator)
     {
         $this->filesystemLoaderWarmer = $filesystemLoaderWarmer;
+        $this->theme = $theme;
         $this->translator = $translator;
     }
 
@@ -43,7 +49,7 @@ class ThemeTemplatesListener
     {
         try {
             // Make sure the selected theme path can be converted into a slug
-            TemplateLocator::createDirectorySlug($value);
+            $this->theme->generateSlug($value);
         } catch (InvalidThemePathException $e) {
             throw new \RuntimeException($this->translator->trans('ERR.invalidThemeTemplatePath', [$e->getPath(), implode('', $e->getInvalidCharacters())], 'contao_default'), 0, $e);
         }

--- a/core-bundle/src/EventListener/DataContainer/ThemeTemplatesListener.php
+++ b/core-bundle/src/EventListener/DataContainer/ThemeTemplatesListener.php
@@ -15,7 +15,7 @@ namespace Contao\CoreBundle\EventListener\DataContainer;
 use Contao\CoreBundle\Exception\InvalidThemePathException;
 use Contao\CoreBundle\ServiceAnnotation\Callback;
 use Contao\CoreBundle\Twig\Loader\ContaoFilesystemLoaderWarmer;
-use Contao\CoreBundle\Twig\Loader\Theme;
+use Contao\CoreBundle\Twig\Loader\ThemeNamespace;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
@@ -29,19 +29,19 @@ class ThemeTemplatesListener
     private $filesystemLoaderWarmer;
 
     /**
-     * @var Theme
+     * @var ThemeNamespace
      */
-    private $theme;
+    private $themeNamespace;
 
     /**
      * @var TranslatorInterface
      */
     private $translator;
 
-    public function __construct(ContaoFilesystemLoaderWarmer $filesystemLoaderWarmer, Theme $theme, TranslatorInterface $translator)
+    public function __construct(ContaoFilesystemLoaderWarmer $filesystemLoaderWarmer, ThemeNamespace $themeNamespace, TranslatorInterface $translator)
     {
         $this->filesystemLoaderWarmer = $filesystemLoaderWarmer;
-        $this->theme = $theme;
+        $this->themeNamespace = $themeNamespace;
         $this->translator = $translator;
     }
 
@@ -49,7 +49,7 @@ class ThemeTemplatesListener
     {
         try {
             // Make sure the selected theme path can be converted into a slug
-            $this->theme->generateSlug($value);
+            $this->themeNamespace->generateSlug($value);
         } catch (InvalidThemePathException $e) {
             throw new \RuntimeException($this->translator->trans('ERR.invalidThemeTemplatePath', [$e->getPath(), implode('', $e->getInvalidCharacters())], 'contao_default'), 0, $e);
         }

--- a/core-bundle/src/EventListener/DataContainer/ThemeTemplatesListener.php
+++ b/core-bundle/src/EventListener/DataContainer/ThemeTemplatesListener.php
@@ -47,8 +47,8 @@ class ThemeTemplatesListener
 
     public function __invoke(string $value): string
     {
+        // Make sure the selected theme path can be converted into a slug
         try {
-            // Make sure the selected theme path can be converted into a slug
             $this->themeNamespace->generateSlug($value);
         } catch (InvalidThemePathException $e) {
             throw new \RuntimeException($this->translator->trans('ERR.invalidThemeTemplatePath', [$e->getPath(), implode('', $e->getInvalidCharacters())], 'contao_default'), 0, $e);

--- a/core-bundle/src/EventListener/DataContainer/ThemeTemplatesListener.php
+++ b/core-bundle/src/EventListener/DataContainer/ThemeTemplatesListener.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\EventListener\DataContainer;
+
+use Contao\CoreBundle\Exception\InvalidThemePathException;
+use Contao\CoreBundle\ServiceAnnotation\Callback;
+use Contao\CoreBundle\Twig\Loader\ContaoFilesystemLoaderWarmer;
+use Contao\CoreBundle\Twig\Loader\TemplateLocator;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * @Callback(table="tl_theme", target="fields.templates.save")
+ */
+class ThemeTemplatesListener
+{
+    /**
+     * @var ContaoFilesystemLoaderWarmer
+     */
+    private $filesystemLoaderWarmer;
+
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    public function __construct(ContaoFilesystemLoaderWarmer $filesystemLoaderWarmer, TranslatorInterface $translator)
+    {
+        $this->filesystemLoaderWarmer = $filesystemLoaderWarmer;
+        $this->translator = $translator;
+    }
+
+    public function __invoke(string $value): string
+    {
+        try {
+            // Make sure the selected theme path can be converted into a slug
+            TemplateLocator::createDirectorySlug($value);
+        } catch (InvalidThemePathException $e) {
+            throw new \RuntimeException($this->translator->trans('ERR.invalidThemeTemplatePath', [$e->getPath(), implode('', $e->getInvalidCharacters())], 'contao_default'), 0, $e);
+        }
+
+        $this->filesystemLoaderWarmer->refresh();
+
+        return $value;
+    }
+}

--- a/core-bundle/src/Exception/InvalidThemePathException.php
+++ b/core-bundle/src/Exception/InvalidThemePathException.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Exception;
+
+class InvalidThemePathException extends \InvalidArgumentException
+{
+    /**
+     * @var string
+     */
+    private $path;
+
+    /**
+     * @var array<string>
+     */
+    private $invalidCharacters;
+
+    public function __construct(string $path, array $invalidCharacters)
+    {
+        $this->path = $path;
+        $this->invalidCharacters = array_unique($invalidCharacters);
+
+        parent::__construct(
+            sprintf(
+                'The theme path "%s" contains one or more invalid characters: "%s"',
+                $path,
+                implode('", "', $this->invalidCharacters),
+            )
+        );
+    }
+
+    public function getPath(): string
+    {
+        return $this->path;
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getInvalidCharacters(): array
+    {
+        return $this->invalidCharacters;
+    }
+}

--- a/core-bundle/src/Resources/config/commands.yml
+++ b/core-bundle/src/Resources/config/commands.yml
@@ -39,7 +39,7 @@ services:
         arguments:
             - '@Contao\CoreBundle\Twig\Loader\ContaoFilesystemLoader'
             - '@Contao\CoreBundle\Twig\Loader\ContaoFilesystemLoaderWarmer'
-            - '@Contao\CoreBundle\Twig\Loader\Theme'
+            - '@Contao\CoreBundle\Twig\Loader\ThemeNamespace'
             - '%kernel.project_dir%'
 
     contao.command.filesync:

--- a/core-bundle/src/Resources/config/commands.yml
+++ b/core-bundle/src/Resources/config/commands.yml
@@ -39,6 +39,8 @@ services:
         arguments:
             - '@Contao\CoreBundle\Twig\Loader\ContaoFilesystemLoader'
             - '@Contao\CoreBundle\Twig\Loader\ContaoFilesystemLoaderWarmer'
+            - '@Contao\CoreBundle\Twig\Loader\Theme'
+            - '%kernel.project_dir%'
 
     contao.command.filesync:
         class: Contao\CoreBundle\Command\FilesyncCommand

--- a/core-bundle/src/Resources/config/listener.yml
+++ b/core-bundle/src/Resources/config/listener.yml
@@ -61,6 +61,7 @@ services:
     Contao\CoreBundle\EventListener\DataContainer\ThemeTemplatesListener:
         arguments:
             - '@Contao\CoreBundle\Twig\Loader\ContaoFilesystemLoaderWarmer'
+            - '@Contao\CoreBundle\Twig\Loader\Theme'
             - '@translator'
 
     Contao\CoreBundle\EventListener\DataContainer\ValidateCustomRgxpListener:

--- a/core-bundle/src/Resources/config/listener.yml
+++ b/core-bundle/src/Resources/config/listener.yml
@@ -58,6 +58,11 @@ services:
         arguments:
             - '@database_connection'
 
+    Contao\CoreBundle\EventListener\DataContainer\ThemeTemplatesListener:
+        arguments:
+            - '@Contao\CoreBundle\Twig\Loader\ContaoFilesystemLoaderWarmer'
+            - '@translator'
+
     Contao\CoreBundle\EventListener\DataContainer\ValidateCustomRgxpListener:
         arguments:
             - '@translator'

--- a/core-bundle/src/Resources/config/listener.yml
+++ b/core-bundle/src/Resources/config/listener.yml
@@ -61,7 +61,7 @@ services:
     Contao\CoreBundle\EventListener\DataContainer\ThemeTemplatesListener:
         arguments:
             - '@Contao\CoreBundle\Twig\Loader\ContaoFilesystemLoaderWarmer'
-            - '@Contao\CoreBundle\Twig\Loader\Theme'
+            - '@Contao\CoreBundle\Twig\Loader\ThemeNamespace'
             - '@translator'
 
     Contao\CoreBundle\EventListener\DataContainer\ValidateCustomRgxpListener:

--- a/core-bundle/src/Resources/config/services.yml
+++ b/core-bundle/src/Resources/config/services.yml
@@ -921,11 +921,14 @@ services:
             - '@Contao\CoreBundle\Twig\Loader\ContaoFilesystemLoader'
         public: true
 
+    Contao\CoreBundle\Twig\Loader\Theme: ~
+
     Contao\CoreBundle\Twig\Loader\TemplateLocator:
         arguments:
             - '%kernel.project_dir%'
             - '%kernel.bundles%'
             - '%kernel.bundles_metadata%'
+            - '@Contao\CoreBundle\Twig\Loader\Theme'
             - '@contao.framework'
 
     Contao\CoreBundle\Twig\Loader\FailTolerantFilesystemLoader:
@@ -939,6 +942,7 @@ services:
         arguments:
             - '@cache.system'
             - '@Contao\CoreBundle\Twig\Loader\TemplateLocator'
+            - '@Contao\CoreBundle\Twig\Loader\Theme'
             - '%kernel.project_dir%'
         tags:
             - { name: twig.loader, priority: 2 }

--- a/core-bundle/src/Resources/config/services.yml
+++ b/core-bundle/src/Resources/config/services.yml
@@ -926,6 +926,7 @@ services:
             - '%kernel.project_dir%'
             - '%kernel.bundles%'
             - '%kernel.bundles_metadata%'
+            - '@contao.framework'
 
     Contao\CoreBundle\Twig\Loader\FailTolerantFilesystemLoader:
         arguments:

--- a/core-bundle/src/Resources/config/services.yml
+++ b/core-bundle/src/Resources/config/services.yml
@@ -921,14 +921,14 @@ services:
             - '@Contao\CoreBundle\Twig\Loader\ContaoFilesystemLoader'
         public: true
 
-    Contao\CoreBundle\Twig\Loader\Theme: ~
+    Contao\CoreBundle\Twig\Loader\ThemeNamespace: ~
 
     Contao\CoreBundle\Twig\Loader\TemplateLocator:
         arguments:
             - '%kernel.project_dir%'
             - '%kernel.bundles%'
             - '%kernel.bundles_metadata%'
-            - '@Contao\CoreBundle\Twig\Loader\Theme'
+            - '@Contao\CoreBundle\Twig\Loader\ThemeNamespace'
             - '@contao.framework'
 
     Contao\CoreBundle\Twig\Loader\FailTolerantFilesystemLoader:
@@ -942,7 +942,7 @@ services:
         arguments:
             - '@cache.system'
             - '@Contao\CoreBundle\Twig\Loader\TemplateLocator'
-            - '@Contao\CoreBundle\Twig\Loader\Theme'
+            - '@Contao\CoreBundle\Twig\Loader\ThemeNamespace'
             - '%kernel.project_dir%'
         tags:
             - { name: twig.loader, priority: 2 }

--- a/core-bundle/src/Resources/contao/languages/en/default.xlf
+++ b/core-bundle/src/Resources/contao/languages/en/default.xlf
@@ -261,7 +261,7 @@
         <source>Please run the "cache:clear" command or use the Contao Manager to rebuild your application cache.</source>
       </trans-unit>
       <trans-unit id="ERR.invalidThemeTemplatePath">
-        <source>The template path "%s" may not contain the following characters: %s</source>
+        <source>The template path "%s" must not contain the following characters: %s</source>
       </trans-unit>
       <trans-unit id="SEC.question1">
         <source>Please add %d and %d.</source>

--- a/core-bundle/src/Resources/contao/languages/en/default.xlf
+++ b/core-bundle/src/Resources/contao/languages/en/default.xlf
@@ -260,6 +260,9 @@
       <trans-unit id="ERR.applicationCache">
         <source>Please run the "cache:clear" command or use the Contao Manager to rebuild your application cache.</source>
       </trans-unit>
+      <trans-unit id="ERR.invalidThemeTemplatePath">
+        <source>The template path "%s" may not contain the following characters: %s</source>
+      </trans-unit>
       <trans-unit id="SEC.question1">
         <source>Please add %d and %d.</source>
       </trans-unit>

--- a/core-bundle/src/Twig/Inheritance/TemplateHierarchyInterface.php
+++ b/core-bundle/src/Twig/Inheritance/TemplateHierarchyInterface.php
@@ -23,7 +23,7 @@ interface TemplateHierarchyInterface
      * order they should appear in the inheritance chain for the respective
      * template identifier.
      *
-     * If a $themeAlias is given the result will additionally include templates
+     * If a $themeSlug is given the result will additionally include templates
      * of that theme if there are any.
      *
      * For example:
@@ -36,15 +36,15 @@ interface TemplateHierarchyInterface
      *
      * @return array<string,array<string, string>>
      */
-    public function getInheritanceChains(string $themeAlias = null): array;
+    public function getInheritanceChains(string $themeSlug = null): array;
 
     /**
      * Finds the next template in the hierarchy and returns the logical name.
      */
-    public function getDynamicParent(string $shortNameOrIdentifier, string $sourcePath, string $themeAlias = null): string;
+    public function getDynamicParent(string $shortNameOrIdentifier, string $sourcePath, string $themeSlug = null): string;
 
     /**
      * Finds the first template in the hierarchy and returns the logical name.
      */
-    public function getFirst(string $shortNameOrIdentifier, string $themeAlias = null): string;
+    public function getFirst(string $shortNameOrIdentifier, string $themeSlug = null): string;
 }

--- a/core-bundle/src/Twig/Loader/ContaoFilesystemLoader.php
+++ b/core-bundle/src/Twig/Loader/ContaoFilesystemLoader.php
@@ -57,6 +57,11 @@ class ContaoFilesystemLoader extends FilesystemLoader implements TemplateHierarc
     private $templateLocator;
 
     /**
+     * @var Theme
+     */
+    private $theme;
+
+    /**
      * @var array<string,string>
      */
     private $trackedTemplatesPaths = [];
@@ -71,12 +76,13 @@ class ContaoFilesystemLoader extends FilesystemLoader implements TemplateHierarc
      */
     private $currentThemeSlug;
 
-    public function __construct(CacheItemPoolInterface $cachePool, TemplateLocator $templateLocator, string $rootPath = null)
+    public function __construct(CacheItemPoolInterface $cachePool, TemplateLocator $templateLocator, Theme $theme, string $rootPath = null)
     {
         parent::__construct([], $rootPath);
 
         $this->cachePool = $cachePool;
         $this->templateLocator = $templateLocator;
+        $this->theme = $theme;
 
         // Restore paths from cache
         $pathsItem = $cachePool->getItem(self::CACHE_KEY_PATHS);
@@ -300,9 +306,9 @@ class ContaoFilesystemLoader extends FilesystemLoader implements TemplateHierarc
         $this->currentThemeSlug = null;
     }
 
-    public function getDynamicParent(string $shortNameOrIdentifier, string $sourcePath, string $themeAlias = null): string
+    public function getDynamicParent(string $shortNameOrIdentifier, string $sourcePath, string $themeSlug = null): string
     {
-        $hierarchy = $this->getInheritanceChains($themeAlias);
+        $hierarchy = $this->getInheritanceChains($themeSlug);
         $identifier = ContaoTwigUtil::getIdentifier($shortNameOrIdentifier);
 
         if (null === ($chain = $hierarchy[$identifier] ?? null)) {
@@ -320,10 +326,10 @@ class ContaoFilesystemLoader extends FilesystemLoader implements TemplateHierarc
         return $next;
     }
 
-    public function getFirst(string $shortNameOrIdentifier, string $themeAlias = null): string
+    public function getFirst(string $shortNameOrIdentifier, string $themeSlug = null): string
     {
         $identifier = ContaoTwigUtil::getIdentifier($shortNameOrIdentifier);
-        $hierarchy = $this->getInheritanceChains($themeAlias);
+        $hierarchy = $this->getInheritanceChains($themeSlug);
 
         if (null === ($chain = $hierarchy[$identifier] ?? null)) {
             throw new \LogicException("The template '$identifier' could not be found in the template hierarchy.");
@@ -332,7 +338,7 @@ class ContaoFilesystemLoader extends FilesystemLoader implements TemplateHierarc
         return $chain[array_key_first($chain)];
     }
 
-    public function getInheritanceChains(string $themeAlias = null): array
+    public function getInheritanceChains(string $themeSlug = null): array
     {
         if (null === $this->inheritanceChains) {
             $this->buildInheritanceChains();
@@ -342,8 +348,8 @@ class ContaoFilesystemLoader extends FilesystemLoader implements TemplateHierarc
 
         foreach ($chains as $identifier => $chain) {
             foreach ($chain as $path => $name) {
-                // Filter out theme paths that do not match the given alias.
-                if (1 === preg_match('%^@Contao_Theme_([a-zA-Z0-9_-]+)/%', $name, $matches) && $matches[1] !== $themeAlias) {
+                // Filter out theme paths that do not match the given slug.
+                if (null !== ($namespace = $this->theme->matchThemeNamespace($name)) && $namespace !== $themeSlug) {
                     unset($chains[$identifier][$path]);
                 }
             }
@@ -417,7 +423,8 @@ class ContaoFilesystemLoader extends FilesystemLoader implements TemplateHierarc
             return null;
         }
 
-        $template = "@Contao_Theme_$themeSlug/$parts[1]";
+        $namespace = $this->theme->getThemeNamespace($themeSlug);
+        $template = "$namespace/$parts[1]";
 
         return $this->exists($template) ? $template : null;
     }
@@ -433,6 +440,6 @@ class ContaoFilesystemLoader extends FilesystemLoader implements TemplateHierarc
             return $this->currentThemeSlug = false;
         }
 
-        return $this->currentThemeSlug = TemplateLocator::createDirectorySlug(Path::makeRelative($path, 'templates'));
+        return $this->currentThemeSlug = $this->theme->generateSlug(Path::makeRelative($path, 'templates'));
     }
 }

--- a/core-bundle/src/Twig/Loader/ContaoFilesystemLoader.php
+++ b/core-bundle/src/Twig/Loader/ContaoFilesystemLoader.php
@@ -57,9 +57,9 @@ class ContaoFilesystemLoader extends FilesystemLoader implements TemplateHierarc
     private $templateLocator;
 
     /**
-     * @var Theme
+     * @var ThemeNamespace
      */
-    private $theme;
+    private $themeNamespace;
 
     /**
      * @var array<string,string>
@@ -76,13 +76,13 @@ class ContaoFilesystemLoader extends FilesystemLoader implements TemplateHierarc
      */
     private $currentThemeSlug;
 
-    public function __construct(CacheItemPoolInterface $cachePool, TemplateLocator $templateLocator, Theme $theme, string $rootPath = null)
+    public function __construct(CacheItemPoolInterface $cachePool, TemplateLocator $templateLocator, ThemeNamespace $themeNamespace, string $rootPath = null)
     {
         parent::__construct([], $rootPath);
 
         $this->cachePool = $cachePool;
         $this->templateLocator = $templateLocator;
-        $this->theme = $theme;
+        $this->themeNamespace = $themeNamespace;
 
         // Restore paths from cache
         $pathsItem = $cachePool->getItem(self::CACHE_KEY_PATHS);
@@ -349,7 +349,7 @@ class ContaoFilesystemLoader extends FilesystemLoader implements TemplateHierarc
         foreach ($chains as $identifier => $chain) {
             foreach ($chain as $path => $name) {
                 // Filter out theme paths that do not match the given slug.
-                if (null !== ($namespace = $this->theme->matchThemeNamespace($name)) && $namespace !== $themeSlug) {
+                if (null !== ($namespace = $this->themeNamespace->match($name)) && $namespace !== $themeSlug) {
                     unset($chains[$identifier][$path]);
                 }
             }
@@ -423,7 +423,7 @@ class ContaoFilesystemLoader extends FilesystemLoader implements TemplateHierarc
             return null;
         }
 
-        $namespace = $this->theme->getThemeNamespace($themeSlug);
+        $namespace = $this->themeNamespace->getFromSlug($themeSlug);
         $template = "$namespace/$parts[1]";
 
         return $this->exists($template) ? $template : null;
@@ -440,6 +440,6 @@ class ContaoFilesystemLoader extends FilesystemLoader implements TemplateHierarc
             return $this->currentThemeSlug = false;
         }
 
-        return $this->currentThemeSlug = $this->theme->generateSlug(Path::makeRelative($path, 'templates'));
+        return $this->currentThemeSlug = $this->themeNamespace->generateSlug(Path::makeRelative($path, 'templates'));
     }
 }

--- a/core-bundle/src/Twig/Loader/TemplateLocator.php
+++ b/core-bundle/src/Twig/Loader/TemplateLocator.php
@@ -68,7 +68,6 @@ class TemplateLocator
 
         /** @var ThemeModel $themeAdapter */
         $themeAdapter = $this->framework->getAdapter(ThemeModel::class);
-
         $directories = [];
 
         // This code might run early during cache warmup where the 'tl_theme'

--- a/core-bundle/src/Twig/Loader/TemplateLocator.php
+++ b/core-bundle/src/Twig/Loader/TemplateLocator.php
@@ -41,21 +41,21 @@ class TemplateLocator
     private $bundlesMetadata;
 
     /**
-     * @var Theme
+     * @var ThemeNamespace
      */
-    private $theme;
+    private $themeNamespace;
 
     /**
      * @var ContaoFramework
      */
     private $framework;
 
-    public function __construct(string $projectDir, array $bundles, array $bundlesMetadata, Theme $theme, ContaoFramework $framework)
+    public function __construct(string $projectDir, array $bundles, array $bundlesMetadata, ThemeNamespace $themeNamespace, ContaoFramework $framework)
     {
         $this->projectDir = $projectDir;
         $this->bundles = $bundles;
         $this->bundlesMetadata = $bundlesMetadata;
-        $this->theme = $theme;
+        $this->themeNamespace = $themeNamespace;
         $this->framework = $framework;
     }
 
@@ -85,7 +85,7 @@ class TemplateLocator
             }
 
             try {
-                $slug = $this->theme->generateSlug(Path::makeRelative($theme->templates, 'templates'));
+                $slug = $this->themeNamespace->generateSlug(Path::makeRelative($theme->templates, 'templates'));
             } catch (InvalidThemePathException $e) {
                 trigger_deprecation('contao/core-bundle', '4.12', 'Using a theme path with invalid characters has been deprecated and will throw an exception in Contao 5.0.');
 

--- a/core-bundle/src/Twig/Loader/Theme.php
+++ b/core-bundle/src/Twig/Loader/Theme.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Twig\Loader;
+
+use Contao\CoreBundle\Exception\InvalidThemePathException;
+use Webmozart\PathUtil\Path;
+
+class Theme
+{
+    /**
+     * Generates a theme slug from a relative path.
+     *
+     * @throws InvalidThemePathException if the path contains invalid characters
+     */
+    public function generateSlug(string $relativePath): string
+    {
+        if (!Path::isRelative($relativePath)) {
+            throw new \InvalidArgumentException("Path '$relativePath' must be relative.");
+        }
+
+        $path = Path::normalize($relativePath);
+        $invalidCharacters = [];
+
+        $slug = implode('_', array_map(
+            static function (string $chunk) use (&$invalidCharacters) {
+                // Allow paths outside the template directory (see #3271)
+                if ('..' === $chunk) {
+                    return '';
+                }
+
+                // Check for invalid characters (see #3354)
+                if (0 !== preg_match_all('%[^a-zA-Z0-9-]%', $chunk, $matches)) {
+                    $invalidCharacters = array_merge($invalidCharacters, $matches[0]);
+                }
+
+                return $chunk;
+            },
+            explode('/', $path)
+        ));
+
+        if (!empty($invalidCharacters)) {
+            throw new InvalidThemePathException($path, $invalidCharacters);
+        }
+
+        return $slug;
+    }
+
+    /**
+     * Builds the namespace for a certain theme slug.
+     */
+    public function getThemeNamespace(string $slug): string
+    {
+        return "@Contao_Theme_$slug";
+    }
+
+    /**
+     * Extracts a theme slug from a given logical name.
+     *
+     * @return string the theme slug or null if not a theme namespace
+     */
+    public function matchThemeNamespace(string $logicalName): ?string
+    {
+        if (1 === preg_match('%^@Contao_Theme_([a-zA-Z0-9_-]+)/%', $logicalName, $matches)) {
+            return $matches[1];
+        }
+
+        return null;
+    }
+}

--- a/core-bundle/src/Twig/Loader/ThemeNamespace.php
+++ b/core-bundle/src/Twig/Loader/ThemeNamespace.php
@@ -15,7 +15,7 @@ namespace Contao\CoreBundle\Twig\Loader;
 use Contao\CoreBundle\Exception\InvalidThemePathException;
 use Webmozart\PathUtil\Path;
 
-class Theme
+class ThemeNamespace
 {
     /**
      * Generates a theme slug from a relative path.
@@ -58,7 +58,7 @@ class Theme
     /**
      * Builds the namespace for a certain theme slug.
      */
-    public function getThemeNamespace(string $slug): string
+    public function getFromSlug(string $slug): string
     {
         return "@Contao_Theme_$slug";
     }
@@ -68,7 +68,7 @@ class Theme
      *
      * @return string the theme slug or null if not a theme namespace
      */
-    public function matchThemeNamespace(string $logicalName): ?string
+    public function match(string $logicalName): ?string
     {
         if (1 === preg_match('%^@Contao_Theme_([a-zA-Z0-9_-]+)/%', $logicalName, $matches)) {
             return $matches[1];

--- a/core-bundle/tests/Command/DebugContaoTwigCommandTest.php
+++ b/core-bundle/tests/Command/DebugContaoTwigCommandTest.php
@@ -15,17 +15,16 @@ namespace Contao\CoreBundle\Tests\Command;
 use Contao\CoreBundle\Command\DebugContaoTwigCommand;
 use Contao\CoreBundle\Twig\Inheritance\TemplateHierarchyInterface;
 use Contao\CoreBundle\Twig\Loader\ContaoFilesystemLoaderWarmer;
+use Contao\CoreBundle\Twig\Loader\Theme;
 use Contao\TestCase\ContaoTestCase;
 use Symfony\Component\Console\Tester\CommandTester;
+use Webmozart\PathUtil\Path;
 
 class DebugContaoTwigCommandTest extends ContaoTestCase
 {
     public function testNameAndArguments(): void
     {
-        $command = new DebugContaoTwigCommand(
-            $this->createMock(TemplateHierarchyInterface::class),
-            $this->createMock(ContaoFilesystemLoaderWarmer::class),
-        );
+        $command = $this->getCommand();
 
         $this->assertSame('debug:contao-twig', $command->getName());
         $this->assertNotEmpty($command->getDescription());
@@ -42,10 +41,7 @@ class DebugContaoTwigCommandTest extends ContaoTestCase
             ->method('refresh')
         ;
 
-        $command = new DebugContaoTwigCommand(
-            $this->createMock(TemplateHierarchyInterface::class),
-            $cacheWarmer,
-        );
+        $command = $this->getCommand(null, $cacheWarmer);
 
         $tester = new CommandTester($command);
         $tester->execute([]);
@@ -76,10 +72,7 @@ class DebugContaoTwigCommandTest extends ContaoTestCase
             ])
         ;
 
-        $command = new DebugContaoTwigCommand(
-            $hierarchy,
-            $this->createMock(ContaoFilesystemLoaderWarmer::class)
-        );
+        $command = $this->getCommand($hierarchy);
 
         $tester = new CommandTester($command);
         $tester->execute($input);
@@ -149,20 +142,17 @@ class DebugContaoTwigCommandTest extends ContaoTestCase
     /**
      * @dataProvider provideThemeOptions
      */
-    public function testIncludesThemeTemplates(array $input, ?string $expectedThemeAlias): void
+    public function testIncludesThemeTemplates(array $input, ?string $expectedThemeSlug): void
     {
         $hierarchy = $this->createMock(TemplateHierarchyInterface::class);
         $hierarchy
             ->expects($this->once())
             ->method('getInheritanceChains')
-            ->with($expectedThemeAlias)
+            ->with($expectedThemeSlug)
             ->willReturn([])
         ;
 
-        $command = new DebugContaoTwigCommand(
-            $hierarchy,
-            $this->createMock(ContaoFilesystemLoaderWarmer::class)
-        );
+        $command = $this->getCommand($hierarchy);
 
         $tester = new CommandTester($command);
         $tester->execute($input);
@@ -177,19 +167,29 @@ class DebugContaoTwigCommandTest extends ContaoTestCase
             null,
         ];
 
-        yield 'theme alias' => [
-            ['--theme' => 'foo-bar'],
-            'foo-bar',
+        yield 'theme slug' => [
+            ['--theme' => 'my_theme'],
+            'my_theme',
         ];
 
         yield 'theme path' => [
-            ['--theme' => 'path/to/theme'],
-            'path_to_theme',
+            ['--theme' => 'my/theme'],
+            'my_theme',
         ];
 
-        yield 'theme path (non normalized)' => [
-            ['--theme' => 'path\to\theme'],
-            'path_to_theme',
+        yield 'theme path (relative up)' => [
+            ['--theme' => '../themes/foo'],
+            '_themes_foo',
         ];
+    }
+
+    private function getCommand(TemplateHierarchyInterface $hierarchy = null, ContaoFilesystemLoaderWarmer $cacheWarmer = null): DebugContaoTwigCommand
+    {
+        return new DebugContaoTwigCommand(
+            $hierarchy ?? $this->createMock(TemplateHierarchyInterface::class),
+            $cacheWarmer ?? $this->createMock(ContaoFilesystemLoaderWarmer::class),
+            new Theme(),
+            Path::canonicalize(__DIR__.'/../Fixtures/Twig/inheritance')
+        );
     }
 }

--- a/core-bundle/tests/Command/DebugContaoTwigCommandTest.php
+++ b/core-bundle/tests/Command/DebugContaoTwigCommandTest.php
@@ -15,7 +15,7 @@ namespace Contao\CoreBundle\Tests\Command;
 use Contao\CoreBundle\Command\DebugContaoTwigCommand;
 use Contao\CoreBundle\Twig\Inheritance\TemplateHierarchyInterface;
 use Contao\CoreBundle\Twig\Loader\ContaoFilesystemLoaderWarmer;
-use Contao\CoreBundle\Twig\Loader\Theme;
+use Contao\CoreBundle\Twig\Loader\ThemeNamespace;
 use Contao\TestCase\ContaoTestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 use Webmozart\PathUtil\Path;
@@ -188,7 +188,7 @@ class DebugContaoTwigCommandTest extends ContaoTestCase
         return new DebugContaoTwigCommand(
             $hierarchy ?? $this->createMock(TemplateHierarchyInterface::class),
             $cacheWarmer ?? $this->createMock(ContaoFilesystemLoaderWarmer::class),
-            new Theme(),
+            new ThemeNamespace(),
             Path::canonicalize(__DIR__.'/../Fixtures/Twig/inheritance')
         );
     }

--- a/core-bundle/tests/Command/DebugContaoTwigCommandTest.php
+++ b/core-bundle/tests/Command/DebugContaoTwigCommandTest.php
@@ -178,8 +178,8 @@ class DebugContaoTwigCommandTest extends ContaoTestCase
         ];
 
         yield 'theme alias' => [
-            ['--theme' => 'foo_bar'],
-            'foo_bar',
+            ['--theme' => 'foo-bar'],
+            'foo-bar',
         ];
 
         yield 'theme path' => [

--- a/core-bundle/tests/EventListener/DataContainer/ThemeTemplatesListenerTest.php
+++ b/core-bundle/tests/EventListener/DataContainer/ThemeTemplatesListenerTest.php
@@ -15,7 +15,7 @@ namespace Contao\CoreBundle\Tests\EventListener\DataContainer;
 use Contao\CoreBundle\EventListener\DataContainer\ThemeTemplatesListener;
 use Contao\CoreBundle\Tests\TestCase;
 use Contao\CoreBundle\Twig\Loader\ContaoFilesystemLoaderWarmer;
-use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 class ThemeTemplatesListenerTest extends TestCase
 {

--- a/core-bundle/tests/EventListener/DataContainer/ThemeTemplatesListenerTest.php
+++ b/core-bundle/tests/EventListener/DataContainer/ThemeTemplatesListenerTest.php
@@ -16,7 +16,7 @@ use Contao\CoreBundle\EventListener\DataContainer\ThemeTemplatesListener;
 use Contao\CoreBundle\Exception\InvalidThemePathException;
 use Contao\CoreBundle\Tests\TestCase;
 use Contao\CoreBundle\Twig\Loader\ContaoFilesystemLoaderWarmer;
-use Contao\CoreBundle\Twig\Loader\Theme;
+use Contao\CoreBundle\Twig\Loader\ThemeNamespace;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class ThemeTemplatesListenerTest extends TestCase
@@ -36,8 +36,8 @@ class ThemeTemplatesListenerTest extends TestCase
 
     public function testThrowsFriendlyErrorMessageIfPathIsInvalid(): void
     {
-        $theme = $this->createMock(Theme::class);
-        $theme
+        $themeNamespace = $this->createMock(ThemeNamespace::class);
+        $themeNamespace
             ->method('generateSlug')
             ->with('<bad-path>')
             ->willThrowException(new InvalidThemePathException('<bad-path>', ['.', '_']))
@@ -54,7 +54,7 @@ class ThemeTemplatesListenerTest extends TestCase
             ->willReturn('<message>')
         ;
 
-        $listener = $this->getListener(null, $theme, $translator);
+        $listener = $this->getListener(null, $themeNamespace, $translator);
 
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('<message>');
@@ -62,11 +62,11 @@ class ThemeTemplatesListenerTest extends TestCase
         $listener('<bad-path>');
     }
 
-    private function getListener(ContaoFilesystemLoaderWarmer $filesystemLoaderWarmer = null, Theme $theme = null, TranslatorInterface $translator = null): ThemeTemplatesListener
+    private function getListener(ContaoFilesystemLoaderWarmer $filesystemLoaderWarmer = null, ThemeNamespace $themeNamespace = null, TranslatorInterface $translator = null): ThemeTemplatesListener
     {
         return new ThemeTemplatesListener(
             $filesystemLoaderWarmer ?? $this->createMock(ContaoFilesystemLoaderWarmer::class),
-            $theme ?? $this->createMock(Theme::class),
+            $themeNamespace ?? $this->createMock(ThemeNamespace::class),
             $translator ?? $this->createMock(TranslatorInterface::class)
         );
     }

--- a/core-bundle/tests/EventListener/DataContainer/ThemeTemplatesListenerTest.php
+++ b/core-bundle/tests/EventListener/DataContainer/ThemeTemplatesListenerTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\EventListener\DataContainer;
+
+use Contao\CoreBundle\EventListener\DataContainer\ThemeTemplatesListener;
+use Contao\CoreBundle\Tests\TestCase;
+use Contao\CoreBundle\Twig\Loader\ContaoFilesystemLoaderWarmer;
+use Symfony\Component\Translation\TranslatorInterface;
+
+class ThemeTemplatesListenerTest extends TestCase
+{
+    public function testRefreshesCache(): void
+    {
+        $filesystemLoaderWarmer = $this->createMock(ContaoFilesystemLoaderWarmer::class);
+        $filesystemLoaderWarmer
+            ->expects($this->once())
+            ->method('refresh')
+        ;
+
+        $translator = $this->createMock(TranslatorInterface::class);
+
+        $listener = new ThemeTemplatesListener($filesystemLoaderWarmer, $translator);
+
+        $this->assertSame('templates/foo/bar', $listener('templates/foo/bar'));
+    }
+
+    public function testThrowsFriendlyErrorMessageIfPathIsInvalid(): void
+    {
+        $filesystemLoaderWarmer = $this->createMock(ContaoFilesystemLoaderWarmer::class);
+
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator
+            ->method('trans')
+            ->with(
+                'ERR.invalidThemeTemplatePath',
+                ['templates/invalid.path/b_ar', '._'],
+                'contao_default',
+            )
+            ->willReturn('<message>')
+        ;
+
+        $listener = new ThemeTemplatesListener($filesystemLoaderWarmer, $translator);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('<message>');
+
+        $listener('templates/invalid.path/b_ar');
+    }
+}

--- a/core-bundle/tests/Exception/InvalidThemePathExceptionTest.php
+++ b/core-bundle/tests/Exception/InvalidThemePathExceptionTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\Exception;
+
+use Contao\CoreBundle\Exception\InvalidThemePathException;
+use PHPUnit\Framework\TestCase;
+
+class InvalidThemePathExceptionTest extends TestCase
+{
+    public function testSetsTheResponseStatusCodeAndContent(): void
+    {
+        $exception = new InvalidThemePathException('foo/bar._baz', ['.', '_', '.']);
+
+        $this->assertSame('The theme path "foo/bar._baz" contains one or more invalid characters: ".", "_"', $exception->getMessage());
+        $this->assertSame('foo/bar._baz', $exception->getPath());
+        $this->assertSame(['.', '_'], $exception->getInvalidCharacters());
+    }
+}

--- a/core-bundle/tests/Twig/Inheritance/InheritanceTest.php
+++ b/core-bundle/tests/Twig/Inheritance/InheritanceTest.php
@@ -18,6 +18,8 @@ use Contao\CoreBundle\Twig\Extension\ContaoExtension;
 use Contao\CoreBundle\Twig\Loader\ContaoFilesystemLoader;
 use Contao\CoreBundle\Twig\Loader\ContaoFilesystemLoaderWarmer;
 use Contao\CoreBundle\Twig\Loader\TemplateLocator;
+use Contao\Model\Collection;
+use Contao\ThemeModel;
 use OutOfBoundsException;
 use Symfony\Component\Cache\Adapter\NullAdapter;
 use Twig\Environment;
@@ -91,7 +93,22 @@ class InheritanceTest extends TestCase
             array_fill(0, \count($bundlesMetadata), ContaoModuleBundle::class)
         );
 
-        $templateLocator = new TemplateLocator($projectDir, $bundles, $bundlesMetadata);
+        $themeAdapter = $this->mockAdapter(['findAll']);
+        $themeAdapter
+            ->method('findAll')
+            ->willReturn(
+                new Collection(
+                    [
+                        $this->mockClassWithProperties(ThemeModel::class, ['templates' => 'templates/my/theme']),
+                    ],
+                    'tl_theme'
+                )
+            )
+        ;
+
+        $framework = $this->mockContaoFramework([ThemeModel::class => $themeAdapter]);
+
+        $templateLocator = new TemplateLocator($projectDir, $bundles, $bundlesMetadata, $framework);
         $loader = new ContaoFilesystemLoader(new NullAdapter(), $templateLocator, $projectDir);
 
         $warmer = new ContaoFilesystemLoaderWarmer($loader, $templateLocator, $projectDir, 'prod');

--- a/core-bundle/tests/Twig/Inheritance/InheritanceTest.php
+++ b/core-bundle/tests/Twig/Inheritance/InheritanceTest.php
@@ -18,7 +18,7 @@ use Contao\CoreBundle\Twig\Extension\ContaoExtension;
 use Contao\CoreBundle\Twig\Loader\ContaoFilesystemLoader;
 use Contao\CoreBundle\Twig\Loader\ContaoFilesystemLoaderWarmer;
 use Contao\CoreBundle\Twig\Loader\TemplateLocator;
-use Contao\CoreBundle\Twig\Loader\Theme;
+use Contao\CoreBundle\Twig\Loader\ThemeNamespace;
 use Contao\Model\Collection;
 use Contao\ThemeModel;
 use OutOfBoundsException;
@@ -108,10 +108,10 @@ class InheritanceTest extends TestCase
         ;
 
         $framework = $this->mockContaoFramework([ThemeModel::class => $themeAdapter]);
-        $slugGenerator = new Theme();
+        $themeNamespace = new ThemeNamespace();
 
-        $templateLocator = new TemplateLocator($projectDir, $bundles, $bundlesMetadata, $slugGenerator, $framework);
-        $loader = new ContaoFilesystemLoader(new NullAdapter(), $templateLocator, $slugGenerator, $projectDir);
+        $templateLocator = new TemplateLocator($projectDir, $bundles, $bundlesMetadata, $themeNamespace, $framework);
+        $loader = new ContaoFilesystemLoader(new NullAdapter(), $templateLocator, $themeNamespace, $projectDir);
 
         $warmer = new ContaoFilesystemLoaderWarmer($loader, $templateLocator, $projectDir, 'prod');
         $warmer->warmUp('');

--- a/core-bundle/tests/Twig/Inheritance/InheritanceTest.php
+++ b/core-bundle/tests/Twig/Inheritance/InheritanceTest.php
@@ -99,9 +99,7 @@ class InheritanceTest extends TestCase
             ->method('findAll')
             ->willReturn(
                 new Collection(
-                    [
-                        $this->mockClassWithProperties(ThemeModel::class, ['templates' => 'templates/my/theme']),
-                    ],
+                    [$this->mockClassWithProperties(ThemeModel::class, ['templates' => 'templates/my/theme'])],
                     'tl_theme'
                 )
             )

--- a/core-bundle/tests/Twig/Inheritance/InheritanceTest.php
+++ b/core-bundle/tests/Twig/Inheritance/InheritanceTest.php
@@ -18,6 +18,7 @@ use Contao\CoreBundle\Twig\Extension\ContaoExtension;
 use Contao\CoreBundle\Twig\Loader\ContaoFilesystemLoader;
 use Contao\CoreBundle\Twig\Loader\ContaoFilesystemLoaderWarmer;
 use Contao\CoreBundle\Twig\Loader\TemplateLocator;
+use Contao\CoreBundle\Twig\Loader\Theme;
 use Contao\Model\Collection;
 use Contao\ThemeModel;
 use OutOfBoundsException;
@@ -107,9 +108,10 @@ class InheritanceTest extends TestCase
         ;
 
         $framework = $this->mockContaoFramework([ThemeModel::class => $themeAdapter]);
+        $slugGenerator = new Theme();
 
-        $templateLocator = new TemplateLocator($projectDir, $bundles, $bundlesMetadata, $framework);
-        $loader = new ContaoFilesystemLoader(new NullAdapter(), $templateLocator, $projectDir);
+        $templateLocator = new TemplateLocator($projectDir, $bundles, $bundlesMetadata, $slugGenerator, $framework);
+        $loader = new ContaoFilesystemLoader(new NullAdapter(), $templateLocator, $slugGenerator, $projectDir);
 
         $warmer = new ContaoFilesystemLoaderWarmer($loader, $templateLocator, $projectDir, 'prod');
         $warmer->warmUp('');

--- a/core-bundle/tests/Twig/Loader/ContaoFilesystemLoaderTest.php
+++ b/core-bundle/tests/Twig/Loader/ContaoFilesystemLoaderTest.php
@@ -17,7 +17,7 @@ use Contao\CoreBundle\Tests\TestCase;
 use Contao\CoreBundle\Twig\Loader\ContaoFilesystemLoader;
 use Contao\CoreBundle\Twig\Loader\ContaoFilesystemLoaderWarmer;
 use Contao\CoreBundle\Twig\Loader\TemplateLocator;
-use Contao\CoreBundle\Twig\Loader\Theme;
+use Contao\CoreBundle\Twig\Loader\ThemeNamespace;
 use Contao\Model\Collection;
 use Contao\ThemeModel;
 use Symfony\Component\Cache\Adapter\AdapterInterface;
@@ -629,7 +629,7 @@ class ContaoFilesystemLoaderTest extends TestCase
             $projectDir,
             $bundles,
             $bundlesMetadata,
-            new Theme(),
+            new ThemeNamespace(),
             $this->mockContaoFramework([ThemeModel::class => $themeAdapter])
         );
     }
@@ -667,7 +667,7 @@ class ContaoFilesystemLoaderTest extends TestCase
         return new ContaoFilesystemLoader(
             $cacheAdapter ?? new NullAdapter(),
             $templateLocator ?? $this->createMock(TemplateLocator::class),
-            new Theme(),
+            new ThemeNamespace(),
             '/',
         );
     }

--- a/core-bundle/tests/Twig/Loader/ContaoFilesystemLoaderTest.php
+++ b/core-bundle/tests/Twig/Loader/ContaoFilesystemLoaderTest.php
@@ -36,7 +36,7 @@ class ContaoFilesystemLoaderTest extends TestCase
         $path2 = Path::canonicalize(__DIR__.'/../../Fixtures/Twig/paths/2');
 
         $loader->addPath($path1);
-        $loader->addPath($path2, 'Contao');
+        $loader->addPath($path2);
         $loader->addPath($path1, 'Contao_foo-Bar_Baz2');
 
         $this->assertTrue($loader->exists('@Contao/1.html.twig'));
@@ -53,7 +53,7 @@ class ContaoFilesystemLoaderTest extends TestCase
         $path2 = Path::canonicalize(__DIR__.'/../../Fixtures/Twig/paths/2');
 
         $loader->prependPath($path1);
-        $loader->prependPath($path2, 'Contao');
+        $loader->prependPath($path2);
         $loader->prependPath($path1, 'Contao_Foo');
 
         $this->assertTrue($loader->exists('@Contao/1.html.twig'));

--- a/core-bundle/tests/Twig/Loader/ContaoFilesystemLoaderTest.php
+++ b/core-bundle/tests/Twig/Loader/ContaoFilesystemLoaderTest.php
@@ -17,6 +17,7 @@ use Contao\CoreBundle\Tests\TestCase;
 use Contao\CoreBundle\Twig\Loader\ContaoFilesystemLoader;
 use Contao\CoreBundle\Twig\Loader\ContaoFilesystemLoaderWarmer;
 use Contao\CoreBundle\Twig\Loader\TemplateLocator;
+use Contao\CoreBundle\Twig\Loader\Theme;
 use Contao\Model\Collection;
 use Contao\ThemeModel;
 use Symfony\Component\Cache\Adapter\AdapterInterface;
@@ -553,9 +554,9 @@ class ContaoFilesystemLoaderTest extends TestCase
     }
 
     /**
-     * @dataProvider provideThemeAliases
+     * @dataProvider provideThemeSlugs
      */
-    public function testGetInheritanceChains(?string $themeAlias, array $expectedChains): void
+    public function testGetInheritanceChains(?string $themeSlug, array $expectedChains): void
     {
         $projectDir = Path::canonicalize(__DIR__.'/../../Fixtures/Twig/inheritance');
 
@@ -572,14 +573,14 @@ class ContaoFilesystemLoaderTest extends TestCase
         $loader->addPath(Path::join($projectDir, 'templates/my'), 'Contao_Theme_my', true);
         $loader->addPath(Path::join($projectDir, 'src/Resources/contao/templates'), 'Contao_App', true);
 
-        $this->assertSame($expectedChains, $loader->getInheritanceChains($themeAlias));
+        $this->assertSame($expectedChains, $loader->getInheritanceChains($themeSlug));
     }
 
-    public function provideThemeAliases(): \Generator
+    public function provideThemeSlugs(): \Generator
     {
         $projectDir = Path::canonicalize(__DIR__.'/../../Fixtures/Twig/inheritance');
 
-        yield 'no theme alias' => [
+        yield 'no theme slug' => [
             null,
             [
                 'text' => [Path::join($projectDir, 'templates/text.html.twig') => '@Contao_Global/text.html.twig'],
@@ -587,7 +588,7 @@ class ContaoFilesystemLoaderTest extends TestCase
             ],
         ];
 
-        yield 'non-existing alias or no theme templates' => [
+        yield 'non-existing slug or no theme templates' => [
             'foo-theme',
             [
                 'text' => [Path::join($projectDir, 'templates/text.html.twig') => '@Contao_Global/text.html.twig'],
@@ -595,7 +596,7 @@ class ContaoFilesystemLoaderTest extends TestCase
             ],
         ];
 
-        yield 'existing theme alias and templates' => [
+        yield 'existing theme slug and templates' => [
             'my_theme',
             [
                 'text' => [
@@ -628,6 +629,7 @@ class ContaoFilesystemLoaderTest extends TestCase
             $projectDir,
             $bundles,
             $bundlesMetadata,
+            new Theme(),
             $this->mockContaoFramework([ThemeModel::class => $themeAdapter])
         );
     }
@@ -665,6 +667,7 @@ class ContaoFilesystemLoaderTest extends TestCase
         return new ContaoFilesystemLoader(
             $cacheAdapter ?? new NullAdapter(),
             $templateLocator ?? $this->createMock(TemplateLocator::class),
+            new Theme(),
             '/',
         );
     }

--- a/core-bundle/tests/Twig/Loader/TemplateLocatorTest.php
+++ b/core-bundle/tests/Twig/Loader/TemplateLocatorTest.php
@@ -56,7 +56,6 @@ class TemplateLocatorTest extends TestCase
         $this->expectDeprecation('Since contao/core-bundle 4.12: Using a theme path with invalid characters has been deprecated and will throw an exception in Contao 5.0.');
 
         $projectDir = Path::canonicalize(__DIR__.'/../../Fixtures/Twig/inheritance');
-
         $locator = $this->getTemplateLocator($projectDir, ['themes/invalid.theme']);
 
         $this->assertEmpty($locator->findThemeDirectories());

--- a/core-bundle/tests/Twig/Loader/TemplateLocatorTest.php
+++ b/core-bundle/tests/Twig/Loader/TemplateLocatorTest.php
@@ -15,7 +15,7 @@ namespace Contao\CoreBundle\Tests\Twig\Loader;
 use Contao\CoreBundle\HttpKernel\Bundle\ContaoModuleBundle;
 use Contao\CoreBundle\Tests\TestCase;
 use Contao\CoreBundle\Twig\Loader\TemplateLocator;
-use Contao\CoreBundle\Twig\Loader\Theme;
+use Contao\CoreBundle\Twig\Loader\ThemeNamespace;
 use Contao\Model\Collection;
 use Contao\ThemeModel;
 use Doctrine\DBAL\Driver\DriverException;
@@ -81,7 +81,7 @@ class TemplateLocatorTest extends TestCase
             '',
             [],
             [],
-            $this->createMock(Theme::class),
+            $this->createMock(ThemeNamespace::class),
             $framework
         );
 
@@ -173,7 +173,7 @@ class TemplateLocatorTest extends TestCase
             $projectDir,
             $bundles,
             $bundlesMetadata,
-            new Theme(),
+            new ThemeNamespace(),
             $this->mockContaoFramework([ThemeModel::class => $themeAdapter])
         );
     }

--- a/core-bundle/tests/Twig/Loader/ThemeTest.php
+++ b/core-bundle/tests/Twig/Loader/ThemeTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\Twig\Loader;
+
+use Contao\CoreBundle\Exception\InvalidThemePathException;
+use Contao\CoreBundle\Tests\TestCase;
+use Contao\CoreBundle\Twig\Loader\Theme;
+
+class ThemeTest extends TestCase
+{
+    /**
+     * @dataProvider providePaths
+     */
+    public function testCreateDirectorySlug(string $path, string $expectedSlug): void
+    {
+        $theme = $this->getTheme();
+
+        $this->assertSame($expectedSlug, $theme->generateSlug($path));
+    }
+
+    public function providePaths(): \Generator
+    {
+        yield 'simple' => ['foo', 'foo'];
+
+        yield 'with dashes' => ['foo-bar', 'foo-bar'];
+
+        yield 'nested' => ['foo/bar/baz', 'foo_bar_baz'];
+
+        yield 'relative (up one)' => ['../foo', '_foo'];
+
+        yield 'relative (up multiple)' => ['../../../foo', '___foo'];
+
+        yield 'relative and nested' => ['../foo/bar', '_foo_bar'];
+    }
+
+    public function testCreateDirectorySlugThrowsIfPathIsAbsolute(): void
+    {
+        $theme = $this->getTheme();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("Path '/foo/bar' must be relative.");
+
+        $theme->generateSlug('/foo/bar');
+    }
+
+    public function testCreateDirectorySlugThrowsIfPathContainsInvalidCharacters(): void
+    {
+        $theme = $this->getTheme();
+
+        $this->expectException(InvalidThemePathException::class);
+
+        try {
+            $theme->generateSlug('foo.bar/bar_baz');
+        } catch (InvalidThemePathException $e) {
+            $this->assertSame(['.', '_'], $e->getInvalidCharacters());
+
+            throw $e;
+        }
+    }
+
+    public function testGetThemeNamespace(): void
+    {
+        $theme = $this->getTheme();
+
+        $this->assertSame('@Contao_Theme_foo_bar', $theme->getThemeNamespace('foo_bar'));
+    }
+
+    /**
+     * @dataProvider provideNamespaces
+     */
+    public function testMatchThemeNamespace(string $name, ?string $expectedSlug): void
+    {
+        $theme = $this->getTheme();
+
+        $this->assertSame($expectedSlug, $theme->matchThemeNamespace($name));
+    }
+
+    public function provideNamespaces(): \Generator
+    {
+        yield 'theme namespace' => [
+            '@Contao_Theme_foo_bar-baz/a.html.twig',
+            'foo_bar-baz',
+        ];
+
+        yield 'theme namespace with sub directory' => [
+            '@Contao_Theme_foo_bar-baz/b/a.html.twig',
+            'foo_bar-baz',
+        ];
+
+        yield 'not a theme namespace' => [
+            '@Contao_Foo/bar.html.twig',
+            null,
+        ];
+
+        yield 'not a logical name' => [
+            '',
+            null,
+        ];
+    }
+
+    private function getTheme(): Theme
+    {
+        return new Theme();
+    }
+}

--- a/core-bundle/tests/Twig/Loader/ThemeTest.php
+++ b/core-bundle/tests/Twig/Loader/ThemeTest.php
@@ -23,9 +23,7 @@ class ThemeTest extends TestCase
      */
     public function testGenerateSlug(string $path, string $expectedSlug): void
     {
-        $themeNamespace = $this->getThemeNamespace();
-
-        $this->assertSame($expectedSlug, $themeNamespace->generateSlug($path));
+        $this->assertSame($expectedSlug, (new ThemeNamespace())->generateSlug($path));
     }
 
     public function providePaths(): \Generator
@@ -45,7 +43,7 @@ class ThemeTest extends TestCase
 
     public function testGenerateSlugThrowsIfPathIsAbsolute(): void
     {
-        $themeNamespace = $this->getThemeNamespace();
+        $themeNamespace = new ThemeNamespace();
 
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage("Path '/foo/bar' must be relative.");
@@ -55,7 +53,7 @@ class ThemeTest extends TestCase
 
     public function testGenerateSlugThrowsIfPathContainsInvalidCharacters(): void
     {
-        $themeNamespace = $this->getThemeNamespace();
+        $themeNamespace = new ThemeNamespace();
 
         $this->expectException(InvalidThemePathException::class);
 
@@ -70,9 +68,7 @@ class ThemeTest extends TestCase
 
     public function testGetFromSlug(): void
     {
-        $themeNamespace = $this->getThemeNamespace();
-
-        $this->assertSame('@Contao_Theme_foo_bar', $themeNamespace->getFromSlug('foo_bar'));
+        $this->assertSame('@Contao_Theme_foo_bar', (new ThemeNamespace())->getFromSlug('foo_bar'));
     }
 
     /**
@@ -80,9 +76,7 @@ class ThemeTest extends TestCase
      */
     public function testMatchThemeNamespace(string $name, ?string $expectedSlug): void
     {
-        $themeNamespace = $this->getThemeNamespace();
-
-        $this->assertSame($expectedSlug, $themeNamespace->match($name));
+        $this->assertSame($expectedSlug, (new ThemeNamespace())->match($name));
     }
 
     public function provideNamespaces(): \Generator
@@ -106,10 +100,5 @@ class ThemeTest extends TestCase
             '',
             null,
         ];
-    }
-
-    private function getThemeNamespace(): ThemeNamespace
-    {
-        return new ThemeNamespace();
     }
 }

--- a/core-bundle/tests/Twig/Loader/ThemeTest.php
+++ b/core-bundle/tests/Twig/Loader/ThemeTest.php
@@ -14,18 +14,18 @@ namespace Contao\CoreBundle\Tests\Twig\Loader;
 
 use Contao\CoreBundle\Exception\InvalidThemePathException;
 use Contao\CoreBundle\Tests\TestCase;
-use Contao\CoreBundle\Twig\Loader\Theme;
+use Contao\CoreBundle\Twig\Loader\ThemeNamespace;
 
 class ThemeTest extends TestCase
 {
     /**
      * @dataProvider providePaths
      */
-    public function testCreateDirectorySlug(string $path, string $expectedSlug): void
+    public function testGenerateSlug(string $path, string $expectedSlug): void
     {
-        $theme = $this->getTheme();
+        $themeNamespace = $this->getThemeNamespace();
 
-        $this->assertSame($expectedSlug, $theme->generateSlug($path));
+        $this->assertSame($expectedSlug, $themeNamespace->generateSlug($path));
     }
 
     public function providePaths(): \Generator
@@ -43,24 +43,24 @@ class ThemeTest extends TestCase
         yield 'relative and nested' => ['../foo/bar', '_foo_bar'];
     }
 
-    public function testCreateDirectorySlugThrowsIfPathIsAbsolute(): void
+    public function testGenerateSlugThrowsIfPathIsAbsolute(): void
     {
-        $theme = $this->getTheme();
+        $themeNamespace = $this->getThemeNamespace();
 
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage("Path '/foo/bar' must be relative.");
 
-        $theme->generateSlug('/foo/bar');
+        $themeNamespace->generateSlug('/foo/bar');
     }
 
-    public function testCreateDirectorySlugThrowsIfPathContainsInvalidCharacters(): void
+    public function testGenerateSlugThrowsIfPathContainsInvalidCharacters(): void
     {
-        $theme = $this->getTheme();
+        $themeNamespace = $this->getThemeNamespace();
 
         $this->expectException(InvalidThemePathException::class);
 
         try {
-            $theme->generateSlug('foo.bar/bar_baz');
+            $themeNamespace->generateSlug('foo.bar/bar_baz');
         } catch (InvalidThemePathException $e) {
             $this->assertSame(['.', '_'], $e->getInvalidCharacters());
 
@@ -68,11 +68,11 @@ class ThemeTest extends TestCase
         }
     }
 
-    public function testGetThemeNamespace(): void
+    public function testGetFromSlug(): void
     {
-        $theme = $this->getTheme();
+        $themeNamespace = $this->getThemeNamespace();
 
-        $this->assertSame('@Contao_Theme_foo_bar', $theme->getThemeNamespace('foo_bar'));
+        $this->assertSame('@Contao_Theme_foo_bar', $themeNamespace->getFromSlug('foo_bar'));
     }
 
     /**
@@ -80,9 +80,9 @@ class ThemeTest extends TestCase
      */
     public function testMatchThemeNamespace(string $name, ?string $expectedSlug): void
     {
-        $theme = $this->getTheme();
+        $themeNamespace = $this->getThemeNamespace();
 
-        $this->assertSame($expectedSlug, $theme->matchThemeNamespace($name));
+        $this->assertSame($expectedSlug, $themeNamespace->match($name));
     }
 
     public function provideNamespaces(): \Generator
@@ -108,8 +108,8 @@ class ThemeTest extends TestCase
         ];
     }
 
-    private function getTheme(): Theme
+    private function getThemeNamespace(): ThemeNamespace
     {
-        return new Theme();
+        return new ThemeNamespace();
     }
 }


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #3354, #3271
| Docs PR or issue | todo

This PR improves the Twig theme path handling:

- we now check for invalid characters and throw an `InvalidThemePathException` if the name contains anything else than `a-zA-Z0-9-`
- until Contao 5.0 we handle the exception and trigger a deprecation warning (except on CLI)
- when saving via the back end, paths with invalid characters are now rejected<sup>*)</sup>
- we allow relative paths outside the template directory. so `../../foo/bar` will get the slug  `__foo_bar`.
- theme paths aren't searched on the file system anymore, instead we ask the theme models for configured paths and refresh the cache when a user changes a path.

<sup>*)</sup> This is a small BC break but IMHO makes for a better UX and only affects changes made after the update.

A word of warning: This is untested, yet (in a real project). 