### PR TITLE
Migrate the newsletter module keys in version 4.0

### DIFF
--- a/core-bundle/src/Migration/Version400/Version400Update.php
+++ b/core-bundle/src/Migration/Version400/Version400Update.php
@@ -225,24 +225,6 @@ class Version400Update extends AbstractMigration
 
         $this->connection->query("
             UPDATE
-                tl_module
-            SET
-                type = 'newsletterlist'
-            WHERE
-                type = 'nl_list'
-        ");
-
-        $this->connection->query("
-            UPDATE
-                tl_module
-            SET
-                type = 'newsletterreader'
-            WHERE
-                type = 'nl_reader'
-        ");
-
-        $this->connection->query("
-            UPDATE
                 tl_form_field
             SET
                 type = 'explanation'

--- a/core-bundle/src/Migration/Version400/Version400Update.php
+++ b/core-bundle/src/Migration/Version400/Version400Update.php
@@ -225,6 +225,24 @@ class Version400Update extends AbstractMigration
 
         $this->connection->query("
             UPDATE
+                tl_module
+            SET
+                type = 'newsletterlist'
+            WHERE
+                type = 'nl_list'
+        ");
+
+        $this->connection->query("
+            UPDATE
+                tl_module
+            SET
+                type = 'newsletterreader'
+            WHERE
+                type = 'nl_reader'
+        ");
+
+        $this->connection->query("
+            UPDATE
                 tl_form_field
             SET
                 type = 'explanation'

--- a/newsletter-bundle/src/Migration/Version400/NewsletterModuleMigration.php
+++ b/newsletter-bundle/src/Migration/Version400/NewsletterModuleMigration.php
@@ -39,6 +39,12 @@ class NewsletterModuleMigration extends AbstractMigration
             return false;
         }
 
+        $columns = $schemaManager->listTableColumns('tl_module');
+
+        if (!isset($columns['type']) {
+            return false;
+        }
+
         return $this->connection->fetchOne("SELECT COUNT(*) FROM tl_module WHERE type='nl_list' OR type='nl_reader'") > 0;
     }
 

--- a/newsletter-bundle/src/Migration/Version400/NewsletterModuleMigration.php
+++ b/newsletter-bundle/src/Migration/Version400/NewsletterModuleMigration.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\NewsletterBundle\Migration\Version400;
+
+use Contao\CoreBundle\Migration\AbstractMigration;
+use Contao\CoreBundle\Migration\MigrationResult;
+use Doctrine\DBAL\Connection;
+
+/**
+ * @internal
+ */
+class NewsletterModuleMigration extends AbstractMigration
+{
+    /**
+     * @var Connection
+     */
+    private $connection;
+
+    public function __construct(Connection $connection)
+    {
+        $this->connection = $connection;
+    }
+
+    public function shouldRun(): bool
+    {
+        $schemaManager = $this->connection->getSchemaManager();
+
+        if (!$schemaManager->tablesExist(['tl_module'])) {
+            return false;
+        }
+
+        return $this->connection->fetchOne("SELECT COUNT(*) FROM tl_module WHERE type='nl_list' OR type='nl_reader'") > 0;
+    }
+
+    public function run(): MigrationResult
+    {
+        $this->connection->executeStatement("
+            UPDATE
+                tl_module
+            SET
+                type = 'newsletterlist'
+            WHERE
+                type = 'nl_list'
+        ");
+
+        $this->connection->executeStatement("
+            UPDATE
+                tl_module
+            SET
+                type = 'newsletterreader'
+            WHERE
+                type = 'nl_reader'
+        ");
+
+        return $this->createResult(true);
+    }
+}

--- a/newsletter-bundle/src/Migration/Version400/NewsletterModuleMigration.php
+++ b/newsletter-bundle/src/Migration/Version400/NewsletterModuleMigration.php
@@ -41,7 +41,7 @@ class NewsletterModuleMigration extends AbstractMigration
 
         $columns = $schemaManager->listTableColumns('tl_module');
 
-        if (!isset($columns['type']) {
+        if (!isset($columns['type'])) {
             return false;
         }
 


### PR DESCRIPTION
According to https://github.com/contao/contao/blob/4.x/UPGRADE.md#front-end-module-keys these modules have been renamed in Contao 4. I noticed my RSS feed modules were automatically migrated, but the newsletter modules were not.

Since the newsletter-bundle does not have any migrations, and migrating this in core does not harm if they just don't exist, I would propose to add these migrations here 🙃 