### PR TITLE
Add canonical name to routes

### DIFF
--- a/core-bundle/src/Routing/Route404Provider.php
+++ b/core-bundle/src/Routing/Route404Provider.php
@@ -107,6 +107,7 @@ class Route404Provider implements RouteProviderInterface
             '_controller' => 'Contao\FrontendIndex::renderPage',
             '_scope' => ContaoCoreBundle::SCOPE_FRONTEND,
             '_locale' => $page->rootLanguage,
+            '_canonical_route' => 'tl_page.'.$page->id,
             'pageModel' => $page,
         ];
 

--- a/core-bundle/src/Routing/RouteProvider.php
+++ b/core-bundle/src/Routing/RouteProvider.php
@@ -317,6 +317,7 @@ class RouteProvider implements RouteProviderInterface
             '_controller' => 'Contao\FrontendIndex::renderPage',
             '_scope' => ContaoCoreBundle::SCOPE_FRONTEND,
             '_locale' => $page->rootLanguage,
+            '_canonical_route' => 'tl_page.'.$page->id,
             'pageModel' => $page,
         ];
     }


### PR DESCRIPTION
The canonical route name represents the "real" route name if you have multiple copies to match specific cases. In Symfony core, they use canonical names if a route has multiple locales and should e.g. be matched on `/en/foo` and `/de/foo`.

In our case, a lot of pages have multiple routes, e.g. a root page has a route for `/`, one for `/en/` and possibly one for `/en/home.html`. These are separate route objects, but they are actually the same _canonical_ route.

Adding this change is a mere improvement because the system _knows_ which route this actually is (and possible which one is the "main one"). The only noticeable difference I could find atm is that the Symfony Web Inspector now shows the canonical route name instead of the "internal" one, which I think is desirable.

Before:
<img width="294" alt="Bildschirmfoto 2021-09-08 um 22 28 15" src="https://user-images.githubusercontent.com/1073273/132580761-78ba89ff-baa1-4799-8c19-13b0fddab9ca.png">

After:
<img width="337" alt="Bildschirmfoto 2021-09-08 um 22 28 33" src="https://user-images.githubusercontent.com/1073273/132580782-051db1b0-e4df-44da-a0eb-c10633738fc2.png">
