### PR TITLE
Renamed method to check for main scope

### DIFF
--- a/core-bundle/src/Routing/ScopeMatcher.php
+++ b/core-bundle/src/Routing/ScopeMatcher.php
@@ -37,19 +37,49 @@ class ScopeMatcher
         $this->frontendMatcher = $frontendMatcher;
     }
 
-    public function isContaoMasterRequest(KernelEvent $event): bool
+    public function isContaoMainRequest(KernelEvent $event): bool
     {
         return $event->isMainRequest() && $this->isContaoRequest($event->getRequest());
     }
 
-    public function isBackendMasterRequest(KernelEvent $event): bool
+    /**
+     * @deprecated Deprecated since Contao 4.13, use isContaoMainRequest instead.
+     */
+    public function isContaoMasterRequest(KernelEvent $event): bool
+    {
+        trigger_deprecation('contao/core-bundle', '4.13', 'Using ScopeMatcher::isContaoMasterRequest() has been deprecated. Use ScopeMatcher::isContaoMainRequest() instead');
+
+        return $this->isContaoMainRequest($event);
+    }
+
+    public function isBackendMainRequest(KernelEvent $event): bool
     {
         return $event->isMainRequest() && $this->isBackendRequest($event->getRequest());
     }
 
-    public function isFrontendMasterRequest(KernelEvent $event): bool
+    /**
+     * @deprecated Deprecated since Contao 4.13, use isBackendMainRequest instead.
+     */
+    public function isBackendMasterRequest(KernelEvent $event): bool
+    {
+        trigger_deprecation('contao/core-bundle', '4.13', 'Using ScopeMatcher::isBackendMasterRequest() has been deprecated. Use ScopeMatcher::isBackendMainRequest() instead');
+
+        return $this->isBackendMainRequest($event);
+    }
+
+    public function isFrontendMainRequest(KernelEvent $event): bool
     {
         return $event->isMainRequest() && $this->isFrontendRequest($event->getRequest());
+    }
+
+    /**
+     * @deprecated Deprecated since Contao 4.13, use isFrontendMainRequest instead.
+     */
+    public function isFrontendMasterRequest(KernelEvent $event): bool
+    {
+        trigger_deprecation('contao/core-bundle', '4.13', 'Using ScopeMatcher::isFrontendMasterRequest() has been deprecated. Use ScopeMatcher::isFrontendMainRequest() instead');
+
+        return $this->isFrontendMainRequest($event);
     }
 
     public function isContaoRequest(Request $request): bool


### PR DESCRIPTION
We could also consider changing/adding this in Contao 4.9.x to allow future-proof extensions already 🙃
I would rebase the PR if you agree.