### PR TITLE
Service priority 0 is not the same as not-set priority

### DIFF
--- a/core-bundle/src/ServiceAnnotation/Callback.php
+++ b/core-bundle/src/ServiceAnnotation/Callback.php
@@ -57,7 +57,7 @@ final class Callback implements ServiceTagInterface
             'target' => $this->target,
         ];
 
-        if ($this->priority) {
+        if (null !== $this->priority) {
             $attributes['priority'] = $this->priority;
         }
 

--- a/core-bundle/src/ServiceAnnotation/Hook.php
+++ b/core-bundle/src/ServiceAnnotation/Hook.php
@@ -48,7 +48,7 @@ final class Hook implements ServiceTagInterface
     {
         $attributes = ['hook' => $this->value];
 
-        if ($this->priority) {
+        if (null !== $this->priority) {
             $attributes['priority'] = $this->priority;
         }
 

--- a/core-bundle/src/ServiceAnnotation/PickerProvider.php
+++ b/core-bundle/src/ServiceAnnotation/PickerProvider.php
@@ -40,7 +40,7 @@ final class PickerProvider implements ServiceTagInterface
 
     public function getAttributes(): array
     {
-        if ($this->priority) {
+        if (null !== $this->priority) {
             return ['priority' => $this->priority];
         }
 


### PR DESCRIPTION
Preparing for https://github.com/contao/contao/pull/3439#discussion_r704441417

A priority of `0` is not the same as not having a priority. The `PriorityTaggedServiceTrait` will call a `getDefaultPriority` method if it exists on the service and a priority is not defined, which should not be called if priority is `0`.

FYI we cannot add `int|null` to the public property because Doctrine Annotations cannot handle that (see https://github.com/contao/contao/pull/764). We do not set a default property value because Psalm might complain about the annotation not including `null`. This becomes obsolete with #3439 in Contao 4.13 anyway.