### PR TITLE
Allow to pass the actual 40x page to the page type

### DIFF
--- a/core-bundle/src/Resources/contao/controllers/FrontendIndex.php
+++ b/core-bundle/src/Resources/contao/controllers/FrontendIndex.php
@@ -301,7 +301,6 @@ class FrontendIndex extends Frontend
 
 				try
 				{
-					/** @var PageRegular $objHandler */
 					$objHandler->generate($objPage, true);
 					$objResponse = new Response(ob_get_contents(), http_response_code());
 				}
@@ -313,7 +312,6 @@ class FrontendIndex extends Frontend
 				return $objResponse;
 			}
 
-			/** @var PageRegular $objHandler */
 			return $objHandler->getResponse($objPage, true);
 		}
 

--- a/core-bundle/src/Resources/contao/controllers/FrontendIndex.php
+++ b/core-bundle/src/Resources/contao/controllers/FrontendIndex.php
@@ -291,53 +291,30 @@ class FrontendIndex extends Frontend
 
 		try
 		{
-			// Generate the page
-			switch ($objPage->type)
+			$pageType = $GLOBALS['TL_PTY'][$objPage->type] ?? PageRegular::class;
+			$objHandler = new $pageType();
+
+			// Backwards compatibility
+			if (!method_exists($objHandler, 'getResponse'))
 			{
-				case 'error_401':
-					$objHandler = new $GLOBALS['TL_PTY']['error_401']();
+				ob_start();
 
-					/** @var PageError401 $objHandler */
-					return $objHandler->getResponse($objPage->rootId);
-
-				case 'error_403':
-					$objHandler = new $GLOBALS['TL_PTY']['error_403']();
-
-					/** @var PageError403 $objHandler */
-					return $objHandler->getResponse($objPage->rootId);
-
-				case 'error_404':
-					$objHandler = new $GLOBALS['TL_PTY']['error_404']();
-
-					/** @var PageError404 $objHandler */
-					return $objHandler->getResponse();
-
-				default:
-					$pageType = $GLOBALS['TL_PTY'][$objPage->type] ?? PageRegular::class;
-					$objHandler = new $pageType();
-
-					// Backwards compatibility
-					if (!method_exists($objHandler, 'getResponse'))
-					{
-						ob_start();
-
-						try
-						{
-							/** @var PageRegular $objHandler */
-							$objHandler->generate($objPage, true);
-							$objResponse = new Response(ob_get_contents(), http_response_code());
-						}
-						finally
-						{
-							ob_end_clean();
-						}
-
-						return $objResponse;
-					}
-
+				try
+				{
 					/** @var PageRegular $objHandler */
-					return $objHandler->getResponse($objPage, true);
+					$objHandler->generate($objPage, true);
+					$objResponse = new Response(ob_get_contents(), http_response_code());
+				}
+				finally
+				{
+					ob_end_clean();
+				}
+
+				return $objResponse;
 			}
+
+			/** @var PageRegular $objHandler */
+			return $objHandler->getResponse($objPage, true);
 		}
 
 		// Render the error page (see #5570)

--- a/core-bundle/src/Resources/contao/pages/PageError401.php
+++ b/core-bundle/src/Resources/contao/pages/PageError401.php
@@ -102,7 +102,7 @@ class PageError401 extends Frontend
 		}
 		else
 		{
-			$obj401 = PageModel::find401ByPid(\is_numeric($objRootPage) ? $objRootPage : $objRootPage->id);
+			$obj401 = PageModel::find401ByPid(is_numeric($objRootPage) ? $objRootPage : $objRootPage->id);
 		}
 
 		// Die if there is no page at all

--- a/core-bundle/src/Resources/contao/pages/PageError401.php
+++ b/core-bundle/src/Resources/contao/pages/PageError401.php
@@ -94,14 +94,16 @@ class PageError401 extends Frontend
 		if ($objRootPage === null)
 		{
 			$objRootPage = $this->getRootPageFromUrl();
+			$obj401 = PageModel::find401ByPid($objRootPage->id);
+		}
+		elseif ($objRootPage instanceof PageModel)
+		{
+			$obj401 = $objRootPage->type === 'error_401' ? $objRootPage : PageModel::find401ByPid($objRootPage->id);
 		}
 		else
 		{
-			$objRootPage = PageModel::findPublishedById(\is_int($objRootPage) ? $objRootPage : $objRootPage->id);
+			$obj401 = PageModel::find401ByPid(\is_numeric($objRootPage) ? $objRootPage : $objRootPage->id);
 		}
-
-		// Look for a 401 page
-		$obj401 = PageModel::find401ByPid($objRootPage->id);
 
 		// Die if there is no page at all
 		if (null === $obj401)

--- a/core-bundle/src/Resources/contao/pages/PageError401.php
+++ b/core-bundle/src/Resources/contao/pages/PageError401.php
@@ -25,7 +25,7 @@ class PageError401 extends Frontend
 	/**
 	 * Generate an error 401 page
 	 *
-	 * @param PageModel|integer $objRootPage
+	 * @param PageModel|integer|null $objRootPage
 	 */
 	public function generate($objRootPage=null)
 	{
@@ -52,7 +52,7 @@ class PageError401 extends Frontend
 	/**
 	 * Return a response object
 	 *
-	 * @param PageModel|integer $objRootPage
+	 * @param PageModel|integer|null $objRootPage
 	 *
 	 * @return Response
 	 */
@@ -80,7 +80,7 @@ class PageError401 extends Frontend
 	/**
 	 * Prepare the output
 	 *
-	 * @param PageModel|integer $objRootPage
+	 * @param PageModel|integer|null $objRootPage
 	 *
 	 * @return PageModel
 	 *

--- a/core-bundle/src/Resources/contao/pages/PageError401.php
+++ b/core-bundle/src/Resources/contao/pages/PageError401.php
@@ -29,6 +29,11 @@ class PageError401 extends Frontend
 	 */
 	public function generate($objRootPage=null)
 	{
+		if (is_numeric($objRootPage))
+		{
+			trigger_deprecation('contao/core-bundle', '4.13', 'Passing a numeric ID to PageError401::generate() has been deprecated and will no longer work in Contao 5.0.');
+		}
+
 		/** @var PageModel $objPage */
 		global $objPage;
 
@@ -58,6 +63,11 @@ class PageError401 extends Frontend
 	 */
 	public function getResponse($objRootPage=null)
 	{
+		if (is_numeric($objRootPage))
+		{
+			trigger_deprecation('contao/core-bundle', '4.13', 'Passing a numeric ID to PageError401::getResponse() has been deprecated and will no longer work in Contao 5.0.');
+		}
+
 		/** @var PageModel $objPage */
 		global $objPage;
 

--- a/core-bundle/src/Resources/contao/pages/PageError403.php
+++ b/core-bundle/src/Resources/contao/pages/PageError403.php
@@ -28,6 +28,11 @@ class PageError403 extends Frontend
 	 */
 	public function generate($objRootPage=null)
 	{
+		if (is_numeric($objRootPage))
+		{
+			trigger_deprecation('contao/core-bundle', '4.13', 'Passing a numeric ID to PageError403::generate() has been deprecated and will no longer work in Contao 5.0.');
+		}
+
 		/** @var PageModel $objPage */
 		global $objPage;
 
@@ -57,6 +62,11 @@ class PageError403 extends Frontend
 	 */
 	public function getResponse($objRootPage=null)
 	{
+		if (is_numeric($objRootPage))
+		{
+			trigger_deprecation('contao/core-bundle', '4.13', 'Passing a numeric ID to PageError403::getResponse() has been deprecated and will no longer work in Contao 5.0.');
+		}
+
 		/** @var PageModel $objPage */
 		global $objPage;
 

--- a/core-bundle/src/Resources/contao/pages/PageError403.php
+++ b/core-bundle/src/Resources/contao/pages/PageError403.php
@@ -24,7 +24,7 @@ class PageError403 extends Frontend
 	/**
 	 * Generate an error 403 page
 	 *
-	 * @param PageModel|integer $objRootPage
+	 * @param PageModel|integer|null $objRootPage
 	 */
 	public function generate($objRootPage=null)
 	{
@@ -51,7 +51,7 @@ class PageError403 extends Frontend
 	/**
 	 * Return a response object
 	 *
-	 * @param PageModel|integer $objRootPage
+	 * @param PageModel|integer|null $objRootPage
 	 *
 	 * @return Response
 	 */

--- a/core-bundle/src/Resources/contao/pages/PageError403.php
+++ b/core-bundle/src/Resources/contao/pages/PageError403.php
@@ -101,7 +101,7 @@ class PageError403 extends Frontend
 		}
 		else
 		{
-			$obj403 = PageModel::find403ByPid(\is_numeric($objRootPage) ? $objRootPage : $objRootPage->id);
+			$obj403 = PageModel::find403ByPid(is_numeric($objRootPage) ? $objRootPage : $objRootPage->id);
 		}
 
 		// Die if there is no page at all

--- a/core-bundle/src/Resources/contao/pages/PageError403.php
+++ b/core-bundle/src/Resources/contao/pages/PageError403.php
@@ -93,14 +93,16 @@ class PageError403 extends Frontend
 		if ($objRootPage === null)
 		{
 			$objRootPage = $this->getRootPageFromUrl();
+			$obj403 = PageModel::find403ByPid($objRootPage->id);
+		}
+		elseif ($objRootPage instanceof PageModel)
+		{
+			$obj403 = $objRootPage->type === 'error_403' ? $objRootPage : PageModel::find403ByPid($objRootPage->id);
 		}
 		else
 		{
-			$objRootPage = PageModel::findPublishedById(\is_int($objRootPage) ? $objRootPage : $objRootPage->id);
+			$obj403 = PageModel::find403ByPid(\is_numeric($objRootPage) ? $objRootPage : $objRootPage->id);
 		}
-
-		// Look for a 403 page
-		$obj403 = PageModel::find403ByPid($objRootPage->id);
 
 		// Die if there is no page at all
 		if (null === $obj403)

--- a/core-bundle/src/Resources/contao/pages/PageError404.php
+++ b/core-bundle/src/Resources/contao/pages/PageError404.php
@@ -24,13 +24,15 @@ class PageError404 extends Frontend
 {
 	/**
 	 * Generate an error 404 page
+	 *
+	 * @param PageModel|null $page
 	 */
-	public function generate()
+	public function generate($page=null)
 	{
 		/** @var PageModel $objPage */
 		global $objPage;
 
-		$obj404 = $this->prepare();
+		$obj404 = $this->prepare($page);
 		$objPage = $obj404->loadDetails();
 
 		// Reset inherited cache timeouts (see #231)
@@ -50,14 +52,16 @@ class PageError404 extends Frontend
 	/**
 	 * Return a response object
 	 *
+	 * @param PageModel|null $page
+	 *
 	 * @return Response
 	 */
-	public function getResponse()
+	public function getResponse($page=null)
 	{
 		/** @var PageModel $objPage */
 		global $objPage;
 
-		$obj404 = $this->prepare();
+		$obj404 = $this->prepare($page);
 		$objPage = $obj404->loadDetails();
 
 		// Reset inherited cache timeouts (see #231)
@@ -76,14 +80,23 @@ class PageError404 extends Frontend
 	/**
 	 * Prepare the output
 	 *
+	 * @param PageModel|null $page
+	 *
 	 * @return PageModel
 	 *
 	 * @internal Do not call this method in your code. It will be made private in Contao 5.0.
 	 */
-	protected function prepare()
+	protected function prepare($page=null)
 	{
-		// Find the matching root page
-		$objRootPage = $this->getRootPageFromUrl();
+		if ($page instanceof PageModel && $page->type === 'error_404')
+		{
+			// We don't actually need a root page, we just need the inherited properties to redirect a 404
+			$obj404 = $objRootPage = $page->loadDetails();
+		}
+		else
+		{
+			$objRootPage = $this->getRootPageFromUrl();
+		}
 
 		// Forward if the language should be but is not set (see #4028)
 		if ($objRootPage->urlPrefix && System::getContainer()->getParameter('contao.legacy_routing'))
@@ -116,7 +129,10 @@ class PageError404 extends Frontend
 		}
 
 		// Look for a 404 page
-		$obj404 = PageModel::find404ByPid($objRootPage->id);
+		if (null === $obj404)
+		{
+			$obj404 = PageModel::find404ByPid($objRootPage->id);
+		}
 
 		// Die if there is no page at all
 		if (null === $obj404)

--- a/core-bundle/src/Resources/contao/pages/PageError404.php
+++ b/core-bundle/src/Resources/contao/pages/PageError404.php
@@ -88,6 +88,8 @@ class PageError404 extends Frontend
 	 */
 	protected function prepare($page=null)
 	{
+		$obj404 = null;
+
 		if ($page instanceof PageModel && $page->type === 'error_404')
 		{
 			// We don't actually need a root page, we just need the inherited properties to redirect a 404


### PR DESCRIPTION
The current implementation renders all `TL_PTY` page types through `FrontendIndex::renderPage`. `FrontendIndex::renderPage` handles `error_40x` pages types differently from all other page types and does not forward the page object, which has already been passed to it. It then unnecessarily looks up the root page and error page again, instead of generating the object that has already been passed to `FrontendIndex::renderPage`.