### PR TITLE
Handle invalid array access in tl_page

### DIFF
--- a/core-bundle/src/Resources/contao/dca/tl_page.php
+++ b/core-bundle/src/Resources/contao/dca/tl_page.php
@@ -772,7 +772,7 @@ class tl_page extends Backend
 		$GLOBALS['TL_DCA']['tl_page']['list']['sorting']['root'] = $root;
 
 		// Set allowed page IDs (edit multiple)
-		if (is_array($session['CURRENT']['IDS']))
+		if (is_array($session['CURRENT']['IDS'] ?? null))
 		{
 			$edit_all = array();
 			$delete_all = array();


### PR DESCRIPTION
![Screenshot_20210910_101434](https://user-images.githubusercontent.com/5305677/132822577-69e0ff3a-14fe-40ac-a08d-34bba1211ac6.png)

Here is another one. The session array may not contain the key `CURRENT`.