### PR TITLE
Fix the event endTime adjustment

### DIFF
--- a/calendar-bundle/src/Resources/contao/dca/tl_calendar_events.php
+++ b/calendar-bundle/src/Resources/contao/dca/tl_calendar_events.php
@@ -956,7 +956,7 @@ class tl_calendar_events extends Contao\Backend
 		if ($dc->activeRecord->addTime)
 		{
 			$arrSet['startTime'] = strtotime(date('Y-m-d', $arrSet['startTime']) . ' ' . date('H:i:s', $dc->activeRecord->startTime));
-			$arrSet['endTime'] = strtotime(date('Y-m-d', $arrSet['endTime']) . ' ' . date('H:i:s', $dc->activeRecord->endTime ?: $dc->activeRecord->startTime));
+			$arrSet['endTime'] = strtotime(date('Y-m-d', $arrSet['endTime']) . ' ' . date('H:i:s', $dc->activeRecord->endTime ?? $dc->activeRecord->startTime));
 		}
 
 		// Adjust end time of "all day" events


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #3376
| Docs PR or issue | -

`endTime` can be zero for certain times and thus `?:` would not work here. The `endTime` is not set if it is `null`.
