### PR TITLE
Set memory limit for sub-processes when running contao-setup

### DIFF
--- a/manager-bundle/src/Command/ContaoSetupCommand.php
+++ b/manager-bundle/src/Command/ContaoSetupCommand.php
@@ -37,11 +37,6 @@ class ContaoSetupCommand extends Command
     private $createProcessHandler;
 
     /**
-     * @var string
-     */
-    private $memoryLimit;
-
-    /**
      * @var string|false
      */
     private $phpPath;
@@ -64,8 +59,6 @@ class ContaoSetupCommand extends Command
             return new Process($command);
         };
 
-        $this->memoryLimit = ini_get('memory_limit');
-
         parent::__construct();
     }
 
@@ -85,7 +78,7 @@ class ContaoSetupCommand extends Command
 
         $php = [
             $this->phpPath,
-            "-dmemory_limit=$this->memoryLimit",
+            '-dmemory_limit='.ini_get('memory_limit')
         ];
 
         if (OutputInterface::VERBOSITY_DEBUG === $output->getVerbosity()) {

--- a/manager-bundle/src/Command/ContaoSetupCommand.php
+++ b/manager-bundle/src/Command/ContaoSetupCommand.php
@@ -37,6 +37,11 @@ class ContaoSetupCommand extends Command
     private $createProcessHandler;
 
     /**
+     * @var string
+     */
+    private $memoryLimit;
+
+    /**
      * @var string|false
      */
     private $phpPath;
@@ -49,7 +54,7 @@ class ContaoSetupCommand extends Command
     /**
      * @param (\Closure(array<string>):Process)|null $createProcessHandler
      */
-    public function __construct(string $projectDir, string $webDir, \Closure $createProcessHandler = null)
+    public function __construct(string $projectDir, string $webDir, \Closure $createProcessHandler = null, string $memoryLimit = null)
     {
         $this->webDir = Path::makeRelative($webDir, $projectDir);
         $this->phpPath = (new PhpExecutableFinder())->find();
@@ -58,6 +63,8 @@ class ContaoSetupCommand extends Command
         $this->createProcessHandler = $createProcessHandler ?? static function (array $command) {
             return new Process($command);
         };
+
+        $this->memoryLimit = $memoryLimit ?? ini_get('memory_limit');
 
         parent::__construct();
     }
@@ -77,6 +84,10 @@ class ContaoSetupCommand extends Command
         }
 
         $php = [$this->phpPath];
+
+        if (!empty($this->memoryLimit)) {
+            $php[] = "-dmemory_limit=$this->memoryLimit";
+        }
 
         if (OutputInterface::VERBOSITY_DEBUG === $output->getVerbosity()) {
             $php[] = '-ddisplay_errors=-1';

--- a/manager-bundle/src/Command/ContaoSetupCommand.php
+++ b/manager-bundle/src/Command/ContaoSetupCommand.php
@@ -78,7 +78,7 @@ class ContaoSetupCommand extends Command
 
         $php = [
             $this->phpPath,
-            '-dmemory_limit='.ini_get('memory_limit')
+            '-dmemory_limit='.ini_get('memory_limit'),
         ];
 
         if (OutputInterface::VERBOSITY_DEBUG === $output->getVerbosity()) {

--- a/manager-bundle/src/Command/ContaoSetupCommand.php
+++ b/manager-bundle/src/Command/ContaoSetupCommand.php
@@ -54,7 +54,7 @@ class ContaoSetupCommand extends Command
     /**
      * @param (\Closure(array<string>):Process)|null $createProcessHandler
      */
-    public function __construct(string $projectDir, string $webDir, \Closure $createProcessHandler = null, string $memoryLimit = null)
+    public function __construct(string $projectDir, string $webDir, \Closure $createProcessHandler = null)
     {
         $this->webDir = Path::makeRelative($webDir, $projectDir);
         $this->phpPath = (new PhpExecutableFinder())->find();
@@ -64,7 +64,7 @@ class ContaoSetupCommand extends Command
             return new Process($command);
         };
 
-        $this->memoryLimit = $memoryLimit ?? ini_get('memory_limit');
+        $this->memoryLimit = ini_get('memory_limit');
 
         parent::__construct();
     }

--- a/manager-bundle/src/Command/ContaoSetupCommand.php
+++ b/manager-bundle/src/Command/ContaoSetupCommand.php
@@ -83,11 +83,10 @@ class ContaoSetupCommand extends Command
             throw new \RuntimeException('The php executable could not be found.');
         }
 
-        $php = [$this->phpPath];
-
-        if (!empty($this->memoryLimit)) {
-            $php[] = "-dmemory_limit=$this->memoryLimit";
-        }
+        $php = [
+            $this->phpPath,
+            "-dmemory_limit=$this->memoryLimit",
+        ];
 
         if (OutputInterface::VERBOSITY_DEBUG === $output->getVerbosity()) {
             $php[] = '-ddisplay_errors=-1';

--- a/manager-bundle/tests/Command/ContaoSetupCommandTest.php
+++ b/manager-bundle/tests/Command/ContaoSetupCommandTest.php
@@ -46,9 +46,10 @@ class ContaoSetupCommandTest extends ContaoTestCase
 
         $phpPath = (new PhpExecutableFinder())->find();
 
-        array_unshift($phpFlags, '-dmemory_limit=1G');
-
         $this->assertStringContainsString('php', $phpPath);
+
+        ini_set('memory_limit', '1G');
+        array_unshift($phpFlags, '-dmemory_limit=1G');
 
         $commandFilePath = (new \ReflectionClass(ContaoSetupCommand::class))->getFileName();
         $consolePath = Path::join(Path::getDirectory($commandFilePath), '../../bin/contao-console');
@@ -65,7 +66,7 @@ class ContaoSetupCommandTest extends ContaoTestCase
 
         $createProcessHandler = $this->getCreateProcessHandler($processes, $commandArguments, $invocationCount);
 
-        $command = new ContaoSetupCommand('project/dir', 'project/dir/public', $createProcessHandler, '1G');
+        $command = new ContaoSetupCommand('project/dir', 'project/dir/public', $createProcessHandler);
 
         (new CommandTester($command))->execute([], $options);
 

--- a/manager-bundle/tests/Command/ContaoSetupCommandTest.php
+++ b/manager-bundle/tests/Command/ContaoSetupCommandTest.php
@@ -48,7 +48,6 @@ class ContaoSetupCommandTest extends ContaoTestCase
 
         $this->assertStringContainsString('php', $phpPath);
 
-        ini_set('memory_limit', '1G');
         array_unshift($phpFlags, '-dmemory_limit=1G');
 
         $commandFilePath = (new \ReflectionClass(ContaoSetupCommand::class))->getFileName();
@@ -64,13 +63,15 @@ class ContaoSetupCommandTest extends ContaoTestCase
             array_merge([$phpPath], $phpFlags, [$consolePath, 'contao:symlinks', 'public', '--env=prod'], $flags),
         ];
 
+        $memoryLimit = ini_set('memory_limit', '1G');
         $createProcessHandler = $this->getCreateProcessHandler($processes, $commandArguments, $invocationCount);
-
         $command = new ContaoSetupCommand('project/dir', 'project/dir/public', $createProcessHandler);
 
         (new CommandTester($command))->execute([], $options);
 
         $this->assertSame(7, $invocationCount);
+
+        ini_set('memory_limit', $memoryLimit);
     }
 
     public function provideCommands(): \Generator


### PR DESCRIPTION
Running `php -dmemory_limit=<limit> contao-setup` won't make the sub processes run with a memory limit of `<limit>`. In fact this is true for all arguments because the binary cannot know what the php process was called with. 

We should IMHO at least handle the case for the memory limit, though. This PR does this by reading the value via `ini_get` and adding it to the call if not empty.

/cc @rabauss 