### PR TITLE
Fix the picker for child tables without PID

### DIFF
--- a/core-bundle/src/Picker/AbstractTablePickerProvider.php
+++ b/core-bundle/src/Picker/AbstractTablePickerProvider.php
@@ -241,6 +241,8 @@ abstract class AbstractTablePickerProvider implements PickerProviderInterface, D
             return [null, null];
         }
 
+        $data = false;
+
         if ($id) {
             $qb = $this->connection->createQueryBuilder();
             $qb->select('pid')->from($table)->where($qb->expr()->eq('id', $id));
@@ -250,8 +252,6 @@ abstract class AbstractTablePickerProvider implements PickerProviderInterface, D
             }
 
             $data = $qb->execute()->fetch();
-        } else {
-            $data = false;
         }
 
         if ($dynamicPtable) {

--- a/core-bundle/src/Picker/AbstractTablePickerProvider.php
+++ b/core-bundle/src/Picker/AbstractTablePickerProvider.php
@@ -85,6 +85,11 @@ abstract class AbstractTablePickerProvider implements PickerProviderInterface, D
             return $this->getUrlForValue($config, $module);
         }
 
+        // If the pid is missing for a child table do not add table=xy to the URL
+        if ($ptable && !$pid) {
+            return $this->getUrlForValue($config, $module);
+        }
+
         return $this->getUrlForValue($config, $module, $table, $pid);
     }
 
@@ -226,14 +231,9 @@ abstract class AbstractTablePickerProvider implements PickerProviderInterface, D
         // Use the first value if array to find a database record
         $id = (int) explode(',', $value)[0];
 
-        if (!$value) {
-            return [null, null];
-        }
-
         $this->framework->initialize();
         $this->framework->createInstance(DcaLoader::class, [$table])->load();
 
-        $pid = null;
         $ptable = $GLOBALS['TL_DCA'][$table]['config']['ptable'] ?? null;
         $dynamicPtable = $GLOBALS['TL_DCA'][$table]['config']['dynamicPtable'] ?? false;
 
@@ -241,20 +241,18 @@ abstract class AbstractTablePickerProvider implements PickerProviderInterface, D
             return [null, null];
         }
 
-        $qb = $this->connection->createQueryBuilder();
-        $qb->select('pid')->from($table)->where($qb->expr()->eq('id', $id));
+        if ($id) {
+            $qb = $this->connection->createQueryBuilder();
+            $qb->select('pid')->from($table)->where($qb->expr()->eq('id', $id));
 
-        if ($dynamicPtable) {
-            $qb->addSelect('ptable');
+            if ($dynamicPtable) {
+                $qb->addSelect('ptable');
+            }
+
+            $data = $qb->execute()->fetch();
+        } else {
+            $data = false;
         }
-
-        $data = $qb->execute()->fetch();
-
-        if (false === $data) {
-            return [null, null];
-        }
-
-        $pid = (int) $data['pid'];
 
         if ($dynamicPtable) {
             $ptable = $data['ptable'] ?: $ptable;
@@ -264,7 +262,11 @@ abstract class AbstractTablePickerProvider implements PickerProviderInterface, D
             }
         }
 
-        return [$ptable, $pid];
+        if (false === $data) {
+            return [$ptable, null];
+        }
+
+        return [$ptable, (int) $data['pid']];
     }
 
     /**

--- a/core-bundle/src/Picker/AbstractTablePickerProvider.php
+++ b/core-bundle/src/Picker/AbstractTablePickerProvider.php
@@ -255,7 +255,9 @@ abstract class AbstractTablePickerProvider implements PickerProviderInterface, D
         }
 
         if ($dynamicPtable) {
-            $ptable = $data['ptable'] ?: $ptable;
+            if (!empty($data['ptable'])) {
+                $ptable = $data['ptable'];
+            }
 
             if (!$ptable) {
                 $ptable = 'tl_article'; // backwards compatibility

--- a/core-bundle/tests/Picker/TablePickerProviderTest.php
+++ b/core-bundle/tests/Picker/TablePickerProviderTest.php
@@ -262,7 +262,7 @@ class TablePickerProviderTest extends ContaoTestCase
         $config = $this->mockPickerConfig('tl_article');
 
         $provider = $this->createTableProvider(
-            null,
+            $this->mockFrameworkWithDcaLoader('tl_article'),
             $this->mockRouterWithExpectedParams($params),
             $this->mockUnusedConnection()
         );
@@ -419,13 +419,12 @@ class TablePickerProviderTest extends ContaoTestCase
             'do' => 'article',
             'popup' => '1',
             'picker' => 'foobar',
-            'table' => 'tl_content',
         ];
 
         $config = $this->mockPickerConfig('tl_content');
 
         $provider = $this->createTableProvider(
-            null,
+            $this->mockFrameworkWithDcaLoader('tl_content'),
             $this->mockRouterWithExpectedParams($params),
             $this->mockUnusedConnection()
         );


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #2046

A picker that picks elements from a child table like the one used in the include content element currently creates links like `?do=article&table=tl_content` which show an empty page because the pid (`id=`) is missing.

If there is a `CURRENT_ID` in the session, an arbitrary page might show up instead of an empty page, or it causes a permission error as in #2046.

This pull request fixes this by only adding the `table=` parameter if there is a valid pid.