### PR TITLE
Make sure redirects are at least path-absolute

### DIFF
--- a/core-bundle/src/EventListener/MakeRedirectResponseUrlAbsoluteListener.php
+++ b/core-bundle/src/EventListener/MakeRedirectResponseUrlAbsoluteListener.php
@@ -41,7 +41,7 @@ class MakeRedirectResponseUrlAbsoluteListener
 
         $url = $response->getTargetUrl();
 
-        if (preg_match('@^(http|/)@i', $url)) {
+        if ('/' === $url[0] || null !== parse_url($url, PHP_URL_SCHEME)) {
             return;
         }
 

--- a/core-bundle/src/EventListener/MakeRedirectResponseUrlAbsoluteListener.php
+++ b/core-bundle/src/EventListener/MakeRedirectResponseUrlAbsoluteListener.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Contao\CoreBundle\EventListener;
+
+use Contao\CoreBundle\Routing\ScopeMatcher;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Terminal42\ServiceAnnotationBundle\Annotation\ServiceTag;
+
+/**
+ * This makes sure that any redirect response in the Contao frontend scope is at least path-absolute (see #3065).
+ * 
+ * @ServiceTag("kernel.event_listener")
+ */
+class MakeRedirectResponseUrlAbsoluteListener
+{
+    private $scopeMatcher;
+
+    public function __construct(ScopeMatcher $scopeMatcher)
+    {
+        $this->scopeMatcher = $scopeMatcher;
+    }
+
+    public function __invoke(ResponseEvent $event): void
+    {
+        $response = $event->getResponse();
+
+        if (!$this->scopeMatcher->isFrontendMasterRequest($event) || !$response instanceof RedirectResponse) {
+            return;
+        }
+
+        $url = $response->getTargetUrl();
+
+        if (preg_match('@^(http|/)@i', $url)) {
+            return;
+        }
+
+        $response->setTargetUrl('/'.$url);
+    }
+}

--- a/core-bundle/src/EventListener/MakeRedirectResponseUrlAbsoluteListener.php
+++ b/core-bundle/src/EventListener/MakeRedirectResponseUrlAbsoluteListener.php
@@ -1,5 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
 namespace Contao\CoreBundle\EventListener;
 
 use Contao\CoreBundle\Routing\ScopeMatcher;
@@ -9,7 +19,7 @@ use Terminal42\ServiceAnnotationBundle\Annotation\ServiceTag;
 
 /**
  * This makes sure that any redirect response in the Contao frontend scope is at least path-absolute (see #3065).
- * 
+ *
  * @ServiceTag("kernel.event_listener")
  */
 class MakeRedirectResponseUrlAbsoluteListener

--- a/core-bundle/src/Resources/config/listener.yml
+++ b/core-bundle/src/Resources/config/listener.yml
@@ -158,6 +158,10 @@ services:
         tags:
             - kernel.event_subscriber
 
+    Contao\CoreBundle\EventListener\MakeRedirectResponseUrlAbsoluteListener:
+        arguments:
+            - '@contao.routing.scope_matcher'
+
     contao.listener.make_response_private:
         class: Contao\CoreBundle\EventListener\MakeResponsePrivateListener
         arguments:


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #3065 
| Docs PR or issue | -

This PR fixes the relative path issue for redirect responses by implementing a response listener (instead of changing every instance where a `RedirectResponse` object is created) which checks whether this was a Contao frontend request and makes sure that the redirect response is at least path-absolute.

@contao/developers wdyt?

TODO: small test for the listener (to make sure it does not change the URL when it's not a Contao frontend request or already an absolute URL).