### PR TITLE
Make sure .public is a file and not a directory

### DIFF
--- a/core-bundle/src/Resources/contao/dca/tl_files.php
+++ b/core-bundle/src/Resources/contao/dca/tl_files.php
@@ -823,7 +823,7 @@ class tl_files extends Contao\Backend
 		$blnUnprotected = $objFolder->isUnprotected();
 
 		// Disable the checkbox if a parent folder is public (see #712)
-		$blnDisable = $blnUnprotected && !file_exists($projectDir . '/' . $strPath . '/.public');
+		$blnDisable = $blnUnprotected && !is_file($projectDir . '/' . $strPath . '/.public');
 
 		// Protect or unprotect the folder
 		if (!$blnDisable && Contao\Input::post('FORM_SUBMIT') == 'tl_files')

--- a/core-bundle/src/Resources/contao/drivers/DC_Folder.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Folder.php
@@ -22,6 +22,7 @@ use Imagine\Gd\Imagine;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface;
 use Symfony\Component\HttpFoundation\Session\Session;
+use Webmozart\PathUtil\Path;
 
 /**
  * Provide methods to modify the file system.
@@ -2156,7 +2157,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 		}
 
 		// Protect or unprotect the folder
-		if (file_exists($this->strRootDir . '/' . $this->intId . '/.public'))
+		if (is_file($this->strRootDir . '/' . $this->intId . '/.public'))
 		{
 			$objFolder = new Folder($this->intId);
 			$objFolder->protect();
@@ -2692,7 +2693,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 			$protected = $blnProtected;
 
 			// Check whether the folder is public
-			if ($protected === true && \in_array('.public', $content))
+			if ($protected === true && is_file(Path::join($folders[$f], '.public')))
 			{
 				$protected = false;
 			}

--- a/core-bundle/src/Resources/contao/drivers/DC_Folder.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Folder.php
@@ -2693,7 +2693,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 			$protected = $blnProtected;
 
 			// Check whether the folder is public
-			if ($protected === true && is_file(Path::join($folders[$f], '.public')))
+			if ($protected === true && \in_array('.public', $content) && !is_dir(Path::join($folders[$f], '.public')))
 			{
 				$protected = false;
 			}

--- a/core-bundle/src/Resources/contao/library/Contao/Folder.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Folder.php
@@ -325,8 +325,14 @@ class Folder extends System
 			return;
 		}
 
+		// Check if .public is a directory (see #3465)
+		if (is_dir($this->strRootDir . '/' . $this->strFolder . '/.public'))
+		{
+			throw new \RuntimeException(sprintf('Cannot protect folder "%s" because it contains a directory called ".public"', $this->strFolder));
+		}
+
 		// Check if the .public file exists
-		if (!file_exists($this->strRootDir . '/' . $this->strFolder . '/.public'))
+		if (!is_file($this->strRootDir . '/' . $this->strFolder . '/.public'))
 		{
 			throw new \RuntimeException(sprintf('Cannot protect folder "%s" because one of its parent folders is public', $this->strFolder));
 		}
@@ -339,7 +345,13 @@ class Folder extends System
 	 */
 	public function unprotect()
 	{
-		if (!file_exists($this->strRootDir . '/' . $this->strFolder . '/.public'))
+		// Check if .public is a directory (see #3465)
+		if (is_dir($this->strRootDir . '/' . $this->strFolder . '/.public'))
+		{
+			throw new \RuntimeException(sprintf('Cannot unprotect folder "%s" because it contains a directory called ".public"', $this->strFolder));
+		}
+
+		if (!is_file($this->strRootDir . '/' . $this->strFolder . '/.public'))
 		{
 			System::getContainer()->get('filesystem')->touch($this->strRootDir . '/' . $this->strFolder . '/.public');
 		}
@@ -356,7 +368,7 @@ class Folder extends System
 
 		do
 		{
-			if (file_exists($this->strRootDir . '/' . $path . '/.public'))
+			if (is_file($this->strRootDir . '/' . $path . '/.public'))
 			{
 				return true;
 			}

--- a/core-bundle/src/Resources/contao/widgets/FileSelector.php
+++ b/core-bundle/src/Resources/contao/widgets/FileSelector.php
@@ -474,7 +474,7 @@ class FileSelector extends Widget
 			$protected = $blnProtected;
 
 			// Check whether the folder is public
-			if ($protected === true && is_file(Path::join($folders[$f], '.public')))
+			if ($protected === true && \in_array('.public', $content) && !is_dir(Path::join($folders[$f], '.public')))
 			{
 				$protected = false;
 			}

--- a/core-bundle/src/Resources/contao/widgets/FileSelector.php
+++ b/core-bundle/src/Resources/contao/widgets/FileSelector.php
@@ -13,6 +13,7 @@ namespace Contao;
 use Contao\Image\ResizeConfiguration;
 use Doctrine\DBAL\Exception\DriverException;
 use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface;
+use Webmozart\PathUtil\Path;
 
 /**
  * Provide methods to handle input field "file tree".
@@ -473,7 +474,7 @@ class FileSelector extends Widget
 			$protected = $blnProtected;
 
 			// Check whether the folder is public
-			if ($protected === true && \in_array('.public', $content))
+			if ($protected === true && is_file(Path::join($folders[$f], '.public')))
 			{
 				$protected = false;
 			}
@@ -641,7 +642,7 @@ class FileSelector extends Widget
 
 		do
 		{
-			if (file_exists($projectDir . '/' . $path . '/.public'))
+			if (is_file($projectDir . '/' . $path . '/.public'))
 			{
 				return false;
 			}


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #3465
| Docs PR or issue | -

If you happen to have a _directory_ called `.public` inside one of your directories in `files/`, Contao will think that it is already public, because it uses `file_exists` - which also returns `true` for directories. However, such a directory will then never actually be public (the symlink command filters for files only), nor can it be made public via the file manager

This PR changes the respective `file_exists` calls to `is_file`. It also adds new exceptions to the `Folder` class when trying to protect or unprotect a directory that contains a `.public` directory, so that the `.public` directory does not get accidentally deleted.