### PR TITLE
Allow WebP to PNG/JPG conversion

### DIFF
--- a/core-bundle/src/Image/PictureFactory.php
+++ b/core-bundle/src/Image/PictureFactory.php
@@ -28,6 +28,7 @@ use Contao\StringUtil;
 class PictureFactory implements PictureFactoryInterface
 {
     private const ASPECT_RATIO_THRESHOLD = 0.05;
+
     private const FORMATS_ORDER = [
         'jxl' => 1,
         'avif' => 2,

--- a/core-bundle/src/Image/PictureFactory.php
+++ b/core-bundle/src/Image/PictureFactory.php
@@ -28,6 +28,16 @@ use Contao\StringUtil;
 class PictureFactory implements PictureFactoryInterface
 {
     private const ASPECT_RATIO_THRESHOLD = 0.05;
+    private const FORMATS_ORDER = [
+        'jxl' => 1,
+        'avif' => 2,
+        'heic' => 3,
+        'webp' => 4,
+        'png' => 5,
+        'jpg' => 6,
+        'jpeg' => 7,
+        'gif' => 8,
+    ];
 
     /**
      * @var array
@@ -168,22 +178,29 @@ class PictureFactory implements PictureFactoryInterface
                 if (null !== $imageSizes) {
                     $options->setSkipIfDimensionsMatch((bool) $imageSizes->skipIfDimensionsMatch);
 
-                    $config->setFormats(array_merge(
-                        [],
-                        ...array_map(
-                            static function ($formatsString) {
-                                $formats = [];
+                    $formatsString = implode(';', StringUtil::deserialize($imageSizes->formats, true));
+                    $formats = [];
 
-                                foreach (explode(';', $formatsString) as $format) {
-                                    [$source, $targets] = explode(':', $format, 2);
-                                    $formats[$source] = explode(',', $targets);
-                                }
+                    foreach (explode(';', $formatsString) as $format) {
+                        [$source, $targets] = explode(':', $format, 2);
+                        $targets = explode(',', $targets);
 
-                                return $formats;
-                            },
-                            StringUtil::deserialize($imageSizes->formats, true)
-                        )
-                    ));
+                        if (!isset($formats[$source])) {
+                            $formats[$source] = $targets;
+                            continue;
+                        }
+
+                        $formats[$source] = array_unique(array_merge($formats[$source], $targets));
+
+                        usort(
+                            $formats[$source],
+                            static function ($a, $b) {
+                                return (self::FORMATS_ORDER[$a] ?? $a) <=> (self::FORMATS_ORDER[$b] ?? $b);
+                            }
+                        );
+                    }
+
+                    $config->setFormats($formats);
                 }
 
                 if ($imageSizes) {

--- a/core-bundle/src/Resources/contao/dca/tl_image_size.php
+++ b/core-bundle/src/Resources/contao/dca/tl_image_size.php
@@ -408,7 +408,7 @@ class tl_image_size extends Contao\Backend
 			return $formats;
 		}
 
-		return array_merge($formats, array('png:webp,png', 'jpg:webp,jpg;jpeg:webp,jpeg', 'gif:webp,gif'));
+		return array_merge($formats, array('png:webp,png', 'jpg:webp,jpg;jpeg:webp,jpeg', 'gif:webp,gif', 'webp:webp,png', 'webp:webp,jpg'));
 	}
 
 	/**

--- a/core-bundle/src/Resources/contao/languages/en/tl_image_size.xlf
+++ b/core-bundle/src/Resources/contao/languages/en/tl_image_size.xlf
@@ -116,6 +116,12 @@
       <trans-unit id="tl_image_size.gif:webp,gif">
         <source>GIF to WEBP</source>
       </trans-unit>
+      <trans-unit id="tl_image_size.webp:webp,png">
+        <source>WEBP to PNG</source>
+      </trans-unit>
+      <trans-unit id="tl_image_size.webp:webp,jpg">
+        <source>WEBP to JPG</source>
+      </trans-unit>
       <trans-unit id="tl_image_size.new.0">
         <source>New</source>
       </trans-unit>

--- a/core-bundle/tests/Image/PictureFactoryTest.php
+++ b/core-bundle/tests/Image/PictureFactoryTest.php
@@ -77,6 +77,9 @@ class PictureFactoryTest extends TestCase
                         $this->assertSame('50vw', $sizeItem->getSizes());
                         $this->assertSame('(max-width: 900px)', $sizeItem->getMedia());
 
+                        $this->assertSame(['webp', 'gif'], $pictureConfig->getFormats()['gif']);
+                        $this->assertSame(['webp', 'png', 'jpg'], $pictureConfig->getFormats()['webp']);
+
                         return true;
                     }
                 )
@@ -115,6 +118,7 @@ class PictureFactoryTest extends TestCase
             'densities' => '1x, 2x',
             'cssClass' => 'my-size',
             'lazyLoading' => true,
+            'formats' => serialize(['gif:webp,gif', 'webp:webp,png', 'webp:webp,jpg']),
         ];
 
         /** @var ImageSizeModel&MockObject $imageSizeModel */


### PR DESCRIPTION
Currently you can only let Contao convert from JPG/PNG _to_ WEBP via database image size definitions - but not the other way around. The only way to implement seamless JPG/PNG to WEBP conversion _and vice versa_ is via the bundle configuration, e.g.:

```yaml
contao:
    image:
        sizes:
            example:
                width: 100
                formats:
                    jpg: [webp, jpg]
                    png: [webp, png]
                    webp: [webp, jpg]
```

With this PR the same will also be possible via the image size configuration in the database/backend:

<img src="https://user-images.githubusercontent.com/4970961/133432845-bbbc5519-2b48-420e-9d05-7e0ffafd8c30.png" width="332">

This allows you to seamlessly convert selected JPGs to WEBP and selected WEBP images to JPG (for the fallback) - which in turn means it will not matter whether your editors select a JPG, PNG or WEBP image in the backend. The output will always be

```html
<picture>
  <source srcset="foobar.webp" type="image/webp" …>
  <img src="foobar.jpg" …><!-- or .png -->
</picture>
```

for example.

As discussed with @ausi previously we decided to implement this as a bugfix.

_Note:_ this will allow you to select both _WEBP to JPG_ and _WEBP to PNG_ at the same time, though as far as I tested it does not matter. Contao will always pick _WEBP to JPG_ in such a case. @ausi should we implement some special handling or error message when both are selected? The bundle configuration would of course give you an error, if you tried to use two `webp` keys.

_Question:_ should we also allow _WEBP to GIF_ there?