### PR TITLE
Correctly handle empty values in the registration module

### DIFF
--- a/core-bundle/src/Resources/contao/modules/ModuleRegistration.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleRegistration.php
@@ -201,7 +201,7 @@ class ModuleRegistration extends Module
 				$arrData['eval']['unique'] = false;
 			}
 
-			$objWidget = new $strClass($strClass::getAttributesFromDca($arrData, $field, $arrData['default'], '', '', $this));
+			$objWidget = new $strClass($strClass::getAttributesFromDca($arrData, $field, $arrData['default'], $field, 'tl_member', $this));
 
 			// Append the module ID to prevent duplicate IDs (see #1493)
 			$objWidget->id .= '_' . $this->id;


### PR DESCRIPTION
If you add an optional field like the following to `tl_member`:

```php
// contao/dca/tl_member.php
$GLOBALS['TL_DCA']['tl_member']['fields']['foobar'] = [
    'inputType' => "text",
    'eval' => ['feEditable'=>true, 'feViewable'=>true, 'feGroup'=>'personal', 'tl_class'=>'w50'],
    'sql' => ['type' => 'integer', 'unsigned' => true, 'default' => 0],
];
```

and then create a registration module and select this field - and then fill out the registration field in the front end, without filling out this new field, the following error will occur:

```
Doctrine\DBAL\Exception\DriverException:
An exception occurred while executing 'INSERT INTO tl_member (`firstname`, `lastname`, `email`, `username`, `password`, `foobar`, `tstamp`, `login`, `dateAdded`, `groups`, `disable`) VALUES ('zui', 'zui', 'zui@zui.zui', 'zui', '…', '', …, '1', …, '…', 1)':

SQLSTATE[22007]: Invalid datetime format: 1366 Incorrect integer value: '' for column `c49dev`.`tl_member`.`foobar` at row 1
```

This is because

https://github.com/contao/contao/blob/2240e871bef27d8b4e32bc76377155f4327c02e5/core-bundle/src/Resources/contao/library/Contao/Widget.php#L1428-L1436

will currently always return an empty string in the registration module, because the registration module does not currently set the DCA field name and table information. This PR fixes that.

_Note:_ It's already done correctly in the personal data module:

https://github.com/contao/contao/blob/2240e871bef27d8b4e32bc76377155f4327c02e5/core-bundle/src/Resources/contao/modules/ModulePersonalData.php#L197