### PR TITLE
Render the Welcome Screen in the Backend using Fragments

### DIFF
--- a/core-bundle/src/ContaoCoreBundle.php
+++ b/core-bundle/src/ContaoCoreBundle.php
@@ -42,6 +42,7 @@ use Contao\CoreBundle\Event\PreviewUrlCreateEvent;
 use Contao\CoreBundle\Event\RobotsTxtEvent;
 use Contao\CoreBundle\Event\SlugValidCharactersEvent;
 use Contao\CoreBundle\Fragment\Reference\ContentElementReference;
+use Contao\CoreBundle\Fragment\Reference\DashboardWidgetReference;
 use Contao\CoreBundle\Fragment\Reference\FrontendModuleReference;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\SecurityExtension;
 use Symfony\Cmf\Component\Routing\DependencyInjection\Compiler\RegisterRouteEnhancersPass;
@@ -105,6 +106,10 @@ class ContaoCoreBundle extends Bundle
                 ContentElementReference::PROXY_CLASS,
                 'contao.listener.element_template_options'
             )
+        );
+
+        $container->addCompilerPass(
+            new RegisterFragmentsPass(DashboardWidgetReference::TAG_NAME)
         );
 
         $container->addCompilerPass(new FragmentRendererPass('contao.fragment.handler'));

--- a/core-bundle/src/Controller/BackendDashboard/AbstractDashboardWidgetController.php
+++ b/core-bundle/src/Controller/BackendDashboard/AbstractDashboardWidgetController.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Controller\BackendDashboard;
+
+use Contao\CoreBundle\Controller\AbstractController;
+use Contao\CoreBundle\Fragment\FragmentOptionsAwareInterface;
+
+/**
+ * Abstract Controller used to display a widget in the backend dashboard.
+ *
+ * @author Richard Henkenjohann <https://github.com/richardhj>
+ */
+abstract class AbstractDashboardWidgetController extends AbstractController implements FragmentOptionsAwareInterface
+{
+    protected array $options = [];
+
+    public function setFragmentOptions(array $options): void
+    {
+        $this->options = $options;
+    }
+}

--- a/core-bundle/src/Controller/BackendDashboard/WelcomeScreenController.php
+++ b/core-bundle/src/Controller/BackendDashboard/WelcomeScreenController.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Controller\BackendDashboard;
+
+use Contao\Backend;
+use Contao\BackendTemplate;
+use Contao\BackendUser;
+use Contao\Config;
+use Contao\CoreBundle\Framework\ContaoFramework;
+use Contao\Date;
+use Contao\Message;
+use Contao\StringUtil;
+use Contao\Versions;
+use Knp\Bundle\TimeBundle\DateTimeFormatter;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * Shows the welcome screen in the backend dashboard.
+ *
+ * @internal
+ */
+class WelcomeScreenController extends AbstractDashboardWidgetController
+{
+    private ContaoFramework $framework;
+    private TranslatorInterface $translator;
+
+    public function __construct(ContaoFramework $framework, TranslatorInterface $translator)
+    {
+        $this->framework = $framework;
+        $this->translator = $translator;
+    }
+
+    public function __invoke(): Response
+    {
+        $template = new BackendTemplate('be_welcome');
+
+        $messages = $this->framework->createInstance(Message::class);
+        $user = $this->framework->createInstance(BackendUser::class);
+        $config = $this->framework->createInstance(Config::class);
+
+        $template->messages = $messages->generateUnwrapped().Backend::getSystemMessages();
+        $template->loginMsg = $this->trans('MSC.firstLogin');
+
+        // Add the login message
+        if ($user->lastLogin > 0) {
+            $formatter = new DateTimeFormatter($this->translator);
+            $diff = $formatter->formatDiff(new \DateTime(date('Y-m-d H:i:s', (int) $user->lastLogin)), new \DateTime());
+
+            $template->loginMsg = sprintf($this->trans('MSC.lastLogin.1'), sprintf(
+                '<time title="%s">%s</time>',
+                Date::parse($config->get('datimFormat'), (int) $user->lastLogin),
+                $diff
+            ));
+        }
+
+        // Add the versions overview
+        Versions::addToTemplate($template);
+
+        $template->showDifferences = StringUtil::specialchars(str_replace("'", "\\'", $this->trans('MSC.showDifferences')));
+        $template->recordOfTable = StringUtil::specialchars(str_replace("'", "\\'", $this->trans('MSC.recordOfTable')));
+        $template->systemMessages = $this->trans('MSC.systemMessages');
+        $template->shortcuts = $this->trans('MSC.shortcuts.0');
+        $template->shortcutsLink = $this->trans('MSC.shortcuts.1');
+        $template->editElement = StringUtil::specialchars($this->trans('MSC.editElement'));
+
+        return $template->getResponse();
+    }
+
+    private function trans(string $key): string
+    {
+        return $this->translator->trans($key, [], 'contao_default');
+    }
+}

--- a/core-bundle/src/Fragment/Reference/DashboardWidgetReference.php
+++ b/core-bundle/src/Fragment/Reference/DashboardWidgetReference.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Fragment\Reference;
+
+class DashboardWidgetReference extends FragmentReference
+{
+    public const TAG_NAME = 'contao.dashboard_widget';
+
+    public function __construct(string $name)
+    {
+        parent::__construct(self::TAG_NAME.'.'.$name);
+
+        $this->setBackendScope();
+    }
+}

--- a/core-bundle/src/Resources/config/services.yml
+++ b/core-bundle/src/Resources/config/services.yml
@@ -67,6 +67,13 @@ services:
 
     Contao\CoreBundle\Controller\BackendController: ~
 
+    Contao\CoreBundle\Controller\BackendDashboard\WelcomeScreenController:
+        tags:
+            - { name: contao.dashboard_widget, priority: 100 }
+        arguments: ['@contao.framework', '@translator']
+
+    Contao\CoreBundle\Controller\BackendModule\BackendModuleController: ~
+
     Contao\CoreBundle\Controller\BackendCsvImportController:
         arguments:
             - '@contao.framework'
@@ -282,6 +289,7 @@ services:
     contao.fragment.handler:
         class: Contao\CoreBundle\Fragment\FragmentHandler
         decorates: fragment.handler
+        public: true
         arguments:
             - ~ # fragment renderer locator
             - '@contao.fragment.handler.inner'
@@ -297,6 +305,7 @@ services:
 
     contao.fragment.registry:
         class: Contao\CoreBundle\Fragment\FragmentRegistry
+        public: true
 
     contao.fragment.renderer.forward:
         class: Contao\CoreBundle\Fragment\ForwardFragmentRenderer

--- a/core-bundle/src/ServiceAnnotation/DashboardWidget.php
+++ b/core-bundle/src/ServiceAnnotation/DashboardWidget.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\ServiceAnnotation;
+
+use Contao\CoreBundle\Fragment\Reference\DashboardWidgetReference;
+use Doctrine\Common\Annotations\Annotation\Attribute;
+use Doctrine\Common\Annotations\Annotation\Attributes;
+use Doctrine\Common\Annotations\Annotation\Target;
+
+/**
+ * Annotation to define a controller as widget in the Contao backend dashboard.
+ *
+ * @Annotation
+ * @Target({"CLASS", "METHOD"})
+ * @Attributes({
+ *     @Attribute("value", type = "string"),
+ *     @Attribute("renderer", type = "string"),
+ *     @Attribute("attributes", type = "array"),
+ * })
+ */
+final class DashboardWidget extends AbstractFragmentAnnotation
+{
+    public function getName(): string
+    {
+        return DashboardWidgetReference::TAG_NAME;
+    }
+}

--- a/core-bundle/tests/ContaoCoreBundleTest.php
+++ b/core-bundle/tests/ContaoCoreBundleTest.php
@@ -64,6 +64,7 @@ class ContaoCoreBundleTest extends TestCase
             RegisterPagesPass::class,
             RegisterFragmentsPass::class,
             RegisterFragmentsPass::class,
+            RegisterFragmentsPass::class,
             FragmentRendererPass::class,
             RemembermeServicesPass::class,
             DataContainerCallbackPass::class,

--- a/core-bundle/tests/Controller/BackendDashboard/WelcomeScreenControllerTest.php
+++ b/core-bundle/tests/Controller/BackendDashboard/WelcomeScreenControllerTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\Controller\BackendDashboard;
+
+use Contao\BackendUser;
+use Contao\Config;
+use Contao\CoreBundle\Controller\BackendDashboard\WelcomeScreenController;
+use Contao\CoreBundle\Tests\TestCase;
+use Contao\Message;
+use Contao\System;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class WelcomeScreenControllerTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        System::setContainer($this->getContainerWithContaoConfiguration());
+    }
+
+    public function testPrintsWelcomeScreen(): void
+    {
+        $framework = $this->mockContaoFramework();
+        $framework
+            ->expects($this->exactly(3))
+            ->method('createInstance')
+            ->withConsecutive([Message::class], [BackendUser::class], [Config::class])
+            ->willReturnOnConsecutiveCalls(
+                new Message(),
+                $this->createMock(BackendUser::class),
+                $this->createMock(Config::class)
+            )
+        ;
+
+        $translator = $this->createMock(TranslatorInterface::class);
+
+        $controller = new WelcomeScreenController($framework, $translator);
+
+        $controller();
+    }
+}


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | 
| Docs PR or issue | tba.

This PR allows adding new widgets/fragments to the dashboard. Often, extension developers used to use the `getSystemMessages` hook to show information to the user on the home screen. This always has been a hack.

```php
// src/Controller/Dashboard/HelloWidgetController.php

<?php

namespace App\Controller\Dashboard;

use Contao\CoreBundle\Controller\BackendDashboard\AbstractDashboardWidgetController;
use Contao\CoreBundle\ServiceAnnotation\DashboardWidget;
use Symfony\Component\HttpFoundation\Response;

/**
 * @DashboardWidget()
 */
class HelloWidgetController extends AbstractDashboardWidgetController
{
    public function __invoke(): Response
    {
        return new Response('This section will be added on the backend dashboard.');
    }
}
```

<img width="813" alt="Screenshot 2021-09-18 at 19 09 56" src="https://user-images.githubusercontent.com/1284725/133897131-ee89f3aa-ca21-4cf4-9f46-f96275114503.png">

Supersedes #2748.