### PR TITLE
Add a configuration for allowed URL protocols

### DIFF
--- a/core-bundle/src/DependencyInjection/Configuration.php
+++ b/core-bundle/src/DependencyInjection/Configuration.php
@@ -426,7 +426,7 @@ class Configuration implements ConfigurationInterface
             ->children()
                 ->arrayNode('allowed_url_protocols')
                     ->prototype('scalar')->end()
-                    ->defaultValue(['http', 'https', 'ftp', 'mailto', 'tel', 'data'])
+                    ->defaultValue(['http', 'https', 'ftp', 'mailto', 'tel', 'data', 'skype', 'whatsapp'])
                     ->validate()
                         ->always(
                             static function (array $protocols): array {

--- a/core-bundle/src/DependencyInjection/Configuration.php
+++ b/core-bundle/src/DependencyInjection/Configuration.php
@@ -121,6 +121,23 @@ class Configuration implements ConfigurationInterface
                         )
                     ->end()
                 ->end()
+                ->arrayNode('allowed_protocols')
+                    ->prototype('scalar')->end()
+                    ->defaultValue(['http', 'https', 'ftp', 'mailto', 'tel', 'data'])
+                    ->validate()
+                        ->always(
+                            static function (array $protocols): array {
+                                foreach ($protocols as $protocol) {
+                                    if (!preg_match('/^[a-z][a-z0-9\-+.]*$/i', (string) $protocol)) {
+                                        throw new \InvalidArgumentException(sprintf('The protocol name "%s" must be a valid URI scheme.', $protocol));
+                                    }
+                                }
+
+                                return $protocols;
+                            }
+                        )
+                    ->end()
+                ->end()
                 ->append($this->addImageNode())
                 ->append($this->addSecurityNode())
                 ->append($this->addSearchNode())

--- a/core-bundle/src/DependencyInjection/Configuration.php
+++ b/core-bundle/src/DependencyInjection/Configuration.php
@@ -121,27 +121,11 @@ class Configuration implements ConfigurationInterface
                         )
                     ->end()
                 ->end()
-                ->arrayNode('allowed_protocols')
-                    ->prototype('scalar')->end()
-                    ->defaultValue(['http', 'https', 'ftp', 'mailto', 'tel', 'data'])
-                    ->validate()
-                        ->always(
-                            static function (array $protocols): array {
-                                foreach ($protocols as $protocol) {
-                                    if (!preg_match('/^[a-z][a-z0-9\-+.]*$/i', (string) $protocol)) {
-                                        throw new \InvalidArgumentException(sprintf('The protocol name "%s" must be a valid URI scheme.', $protocol));
-                                    }
-                                }
-
-                                return $protocols;
-                            }
-                        )
-                    ->end()
-                ->end()
                 ->append($this->addImageNode())
                 ->append($this->addSecurityNode())
                 ->append($this->addSearchNode())
                 ->append($this->addCrawlNode())
+                ->append($this->addSanitizerNode())
             ->end()
         ;
 
@@ -429,6 +413,33 @@ class Configuration implements ConfigurationInterface
                     ->info('Allows to configure the default HttpClient options (useful for proxy settings, SSL certificate validation and more).')
                     ->prototype('scalar')->end()
                     ->defaultValue([])
+                ->end()
+            ->end()
+        ;
+    }
+
+    private function addSanitizerNode(): NodeDefinition
+    {
+        return (new TreeBuilder('sanitizer'))
+            ->getRootNode()
+            ->addDefaultsIfNotSet()
+            ->children()
+                ->arrayNode('allowed_url_protocols')
+                    ->prototype('scalar')->end()
+                    ->defaultValue(['http', 'https', 'ftp', 'mailto', 'tel', 'data'])
+                    ->validate()
+                        ->always(
+                            static function (array $protocols): array {
+                                foreach ($protocols as $protocol) {
+                                    if (!preg_match('/^[a-z][a-z0-9\-+.]*$/i', (string) $protocol)) {
+                                        throw new \InvalidArgumentException(sprintf('The protocol name "%s" must be a valid URI scheme.', $protocol));
+                                    }
+                                }
+
+                                return $protocols;
+                            }
+                        )
+                    ->end()
                 ->end()
             ->end()
         ;

--- a/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
+++ b/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
@@ -61,6 +61,7 @@ class ContaoCoreExtension extends Extension
         $loader->load('services.yml');
         $loader->load('migrations.yml');
 
+        $container->setParameter('contao.allowed_protocols', $config['allowed_protocols']);
         $container->setParameter('contao.web_dir', $config['web_dir']);
         $container->setParameter('contao.prepend_locale', $config['prepend_locale']);
         $container->setParameter('contao.encryption_key', $config['encryption_key']);

--- a/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
+++ b/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
@@ -61,7 +61,6 @@ class ContaoCoreExtension extends Extension
         $loader->load('services.yml');
         $loader->load('migrations.yml');
 
-        $container->setParameter('contao.sanitizer.allowed_url_protocols', $config['sanitizer']['allowed_url_protocols']);
         $container->setParameter('contao.web_dir', $config['web_dir']);
         $container->setParameter('contao.prepend_locale', $config['prepend_locale']);
         $container->setParameter('contao.encryption_key', $config['encryption_key']);
@@ -80,6 +79,7 @@ class ContaoCoreExtension extends Extension
         $container->setParameter('contao.image.imagine_options', $config['image']['imagine_options']);
         $container->setParameter('contao.image.reject_large_uploads', $config['image']['reject_large_uploads']);
         $container->setParameter('contao.security.two_factor.enforce_backend', $config['security']['two_factor']['enforce_backend']);
+        $container->setParameter('contao.sanitizer.allowed_url_protocols', $config['sanitizer']['allowed_url_protocols']);
 
         if (isset($config['localconfig'])) {
             $container->setParameter('contao.localconfig', $config['localconfig']);

--- a/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
+++ b/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
@@ -61,7 +61,7 @@ class ContaoCoreExtension extends Extension
         $loader->load('services.yml');
         $loader->load('migrations.yml');
 
-        $container->setParameter('contao.allowed_protocols', $config['allowed_protocols']);
+        $container->setParameter('contao.sanitizer.allowed_url_protocols', $config['sanitizer']['allowed_url_protocols']);
         $container->setParameter('contao.web_dir', $config['web_dir']);
         $container->setParameter('contao.prepend_locale', $config['prepend_locale']);
         $container->setParameter('contao.encryption_key', $config['encryption_key']);

--- a/core-bundle/src/Resources/contao/library/Contao/StringUtil.php
+++ b/core-bundle/src/Resources/contao/library/Contao/StringUtil.php
@@ -1053,7 +1053,7 @@ class StringUtil
 
 		// URL-encode colon to prevent disallowed protocols
 		if (
-			!preg_match('@^(?:' . implode('|', array_map('preg_quote', $arrAllowedProtocols)) . '):@i', self::decodeEntities($strString))
+			!preg_match('(^(?:' . implode('|', array_map('preg_quote', $arrAllowedProtocols)) . '):)i', self::decodeEntities($strString))
 			&& preg_match($colonRegEx, self::stripInsertTags($strString))
 		) {
 			$strString = preg_replace($colonRegEx, '%3A', $strString);

--- a/core-bundle/src/Resources/contao/library/Contao/StringUtil.php
+++ b/core-bundle/src/Resources/contao/library/Contao/StringUtil.php
@@ -1049,11 +1049,11 @@ class StringUtil
 			. ');?'               // Optional semicolon
 		. ')i';
 
-		$arrAllowedProtocols = System::getContainer()->getParameter('contao.allowed_protocols');
+		$arrAllowedUrlProtocols = System::getContainer()->getParameter('contao.sanitizer.allowed_url_protocols');
 
 		// URL-encode colon to prevent disallowed protocols
 		if (
-			!preg_match('(^(?:' . implode('|', array_map('preg_quote', $arrAllowedProtocols)) . '):)i', self::decodeEntities($strString))
+			!preg_match('(^(?:' . implode('|', array_map('preg_quote', $arrAllowedUrlProtocols)) . '):)i', self::decodeEntities($strString))
 			&& preg_match($colonRegEx, self::stripInsertTags($strString))
 		) {
 			$strString = preg_replace($colonRegEx, '%3A', $strString);

--- a/core-bundle/src/Resources/contao/library/Contao/StringUtil.php
+++ b/core-bundle/src/Resources/contao/library/Contao/StringUtil.php
@@ -1049,9 +1049,11 @@ class StringUtil
 			. ');?'               // Optional semicolon
 		. ')i';
 
+		$arrAllowedProtocols = System::getContainer()->getParameter('contao.allowed_protocols');
+
 		// URL-encode colon to prevent disallowed protocols
 		if (
-			!preg_match('@^(?:https?|ftp|mailto|tel|data):@i', self::decodeEntities($strString))
+			!preg_match('@^(?:' . implode('|', array_map('preg_quote', $arrAllowedProtocols)) . '):@i', self::decodeEntities($strString))
 			&& preg_match($colonRegEx, self::stripInsertTags($strString))
 		) {
 			$strString = preg_replace($colonRegEx, '%3A', $strString);


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #3473
| Docs PR or issue | contao/docs#840

This adds a new configuration option:

```yaml
contao:
    sanitizer:
        allowed_url_protocols:

            # Defaults:
            - https
            - http
            - ftp
            - mailto
            - tel
            - data
            - skype
            - whatsapp
```
However, I'm not sure if it is a good idea to directly use the input in the `preg_match` pattern? To help with that, I added a validation based on this [specification](https://datatracker.ietf.org/doc/html/rfc3986#section-3.1):

>Scheme names consist of a sequence of characters beginning with a letter and followed by any combination of letters, digits, plus ("+"), period ("."), or hyphen ("-").  Although schemes are case- insensitive, the canonical form is lowercase and documents that specify schemes must do so with lowercase letters.  An implementation should accept uppercase letters as equivalent to lowercase in scheme names (e.g., allow "HTTP" as well as "http") for the sake of robustness but should only produce lowercase scheme names for consistency.
>
>scheme      = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )