### PR TITLE
Fix the option sorting in the back end drop-downs

### DIFF
--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -5273,11 +5273,12 @@ class DC_Table extends DataContainer implements \listable, \editable
 				$option_label = \is_array($GLOBALS['TL_LANG']['MSC'][$field]) ? $GLOBALS['TL_LANG']['MSC'][$field][0] : $GLOBALS['TL_LANG']['MSC'][$field];
 			}
 
-			$options_sorter[Utf8::toAscii($option_label) . '_' . $field] = '  <option value="' . StringUtil::specialchars($field) . '"' . (($field == $session['search'][$this->strTable]['field']) ? ' selected="selected"' : '') . '>' . $option_label . '</option>';
+			$options_sorter[$option_label . '_' . $field] = '  <option value="' . StringUtil::specialchars($field) . '"' . (($field == $session['search'][$this->strTable]['field']) ? ' selected="selected"' : '') . '>' . $option_label . '</option>';
 		}
 
 		// Sort by option values
-		$options_sorter = natcaseksort($options_sorter);
+		uksort($options_sorter, array(Utf8::class, 'strnatcasecmp'));
+
 		$active = isset($session['search'][$this->strTable]['value']) && (string) $session['search'][$this->strTable]['value'] !== '';
 
 		return '
@@ -5374,7 +5375,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 		}
 
 		// Sort by option values
-		uksort($options_sorter, 'strcasecmp');
+		uksort($options_sorter, array(Utf8::class, 'strnatcasecmp'));
 
 		return '
 <div class="tl_sorting tl_subpanel">
@@ -5956,13 +5957,13 @@ class DC_Table extends DataContainer implements \listable, \editable
 						}
 					}
 
-					$options_sorter['  <option value="' . StringUtil::specialchars($value) . '"' . ((isset($session['filter'][$filter][$field]) && $value == $session['filter'][$filter][$field]) ? ' selected="selected"' : '') . '>' . StringUtil::specialchars($option_label) . '</option>'] = Utf8::toAscii($option_label);
+					$options_sorter[$option_label . '_' . $field] = '  <option value="' . StringUtil::specialchars($value) . '"' . ((isset($session['filter'][$filter][$field]) && $value == $session['filter'][$filter][$field]) ? ' selected="selected"' : '') . '>' . StringUtil::specialchars($option_label) . '</option>';
 				}
 
 				// Sort by option values
 				if (!$blnDate)
 				{
-					natcasesort($options_sorter);
+					uksort($options_sorter, array(Utf8::class, 'strnatcasecmp'));
 
 					if (\in_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['flag'], array(2, 4, 12)))
 					{
@@ -5970,7 +5971,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 					}
 				}
 
-				$fields .= "\n" . implode("\n", array_keys($options_sorter));
+				$fields .= "\n" . implode("\n", array_values($options_sorter));
 			}
 
 			// End select menu

--- a/core-bundle/src/Resources/contao/library/Contao/System.php
+++ b/core-bundle/src/Resources/contao/library/Contao/System.php
@@ -604,22 +604,16 @@ abstract class System
 	{
 		$return = array();
 		$countries = array();
-		$arrAux = array();
 
 		static::loadLanguageFile('countries');
 		include __DIR__ . '/../../config/countries.php';
 
 		foreach ($countries as $strKey=>$strName)
 		{
-			$arrAux[$strKey] = isset($GLOBALS['TL_LANG']['CNT'][$strKey]) ? Utf8::toAscii($GLOBALS['TL_LANG']['CNT'][$strKey]) : $strName;
+			$return[$strKey] = $GLOBALS['TL_LANG']['CNT'][$strKey] ?? $strName;
 		}
 
-		asort($arrAux);
-
-		foreach (array_keys($arrAux) as $strKey)
-		{
-			$return[$strKey] = $GLOBALS['TL_LANG']['CNT'][$strKey] ?? $countries[$strKey];
-		}
+		uasort($return, array(Utf8::class, 'strnatcasecmp'));
 
 		// HOOK: add custom logic
 		if (isset($GLOBALS['TL_HOOKS']['getCountries']) && \is_array($GLOBALS['TL_HOOKS']['getCountries']))
@@ -644,35 +638,29 @@ abstract class System
 	{
 		$return = array();
 		$languages = array();
-		$arrAux = array();
 		$langsNative = array();
 
 		static::loadLanguageFile('languages');
 		include __DIR__ . '/../../config/languages.php';
 
-		foreach ($languages as $strKey=>$strName)
-		{
-			$arrAux[$strKey] = isset($GLOBALS['TL_LANG']['LNG'][$strKey]) ? Utf8::toAscii($GLOBALS['TL_LANG']['LNG'][$strKey]) : $strName;
-		}
-
-		asort($arrAux);
-
 		$arrBackendLanguages = self::getContainer()->getParameter('contao.locales');
 
-		foreach (array_keys($arrAux) as $strKey)
+		foreach ($languages as $strKey=>$strName)
 		{
 			if ($blnInstalledOnly && !\in_array($strKey, $arrBackendLanguages))
 			{
 				continue;
 			}
 
-			$return[$strKey] = $GLOBALS['TL_LANG']['LNG'][$strKey] ?? $languages[$strKey];
+			$return[$strKey] = $GLOBALS['TL_LANG']['LNG'][$strKey] ?? $strName;
 
 			if (isset($langsNative[$strKey]) && $langsNative[$strKey] != $return[$strKey])
 			{
 				$return[$strKey] .= ' - ' . $langsNative[$strKey];
 			}
 		}
+
+		uasort($return, array(Utf8::class, 'strnatcasecmp'));
 
 		// HOOK: add custom logic
 		if (isset($GLOBALS['TL_HOOKS']['getLanguages']) && \is_array($GLOBALS['TL_HOOKS']['getLanguages']))


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #3494
| Docs PR or issue | -

Uses `Patchwork\Utf8::strnatcasecmp()` to do the heavy lifting.