### PR TITLE
Load DataContainer before determining empty value

### DIFF
--- a/core-bundle/src/Resources/contao/forms/Form.php
+++ b/core-bundle/src/Resources/contao/forms/Form.php
@@ -502,7 +502,7 @@ class Form extends Hybrid
 				}
 			}
 
-			// Load DataContainer of target table before trying to determine empty value
+			// Load DataContainer of target table before trying to determine empty value (see #3499)
 			Controller::loadDataContainer($this->targetTable);
 
 			// Set the correct empty value (see #6284, #6373)

--- a/core-bundle/src/Resources/contao/forms/Form.php
+++ b/core-bundle/src/Resources/contao/forms/Form.php
@@ -502,6 +502,9 @@ class Form extends Hybrid
 				}
 			}
 
+			// Load DataContainer of target table before trying to determine empty value
+			Controller::loadDataContainer($this->targetTable);
+
 			// Set the correct empty value (see #6284, #6373)
 			foreach ($arrSet as $k=>$v)
 			{


### PR DESCRIPTION
Suppose you have generated a form with which you are storing the data into a table, created via a DataContainer. If this table contains an optional field with the definition `int(10) unsigned NULL` for example, the operation will fail with

```
SQLSTATE[22007]: Invalid datetime format: 1366 Incorrect integer value: '' for column `tl_foobar`.`foobar` at row 1
```

if only an empty string was submitted for that field in the front end. `\Contao\Form` actually tries to load the proper empty value for empty submitted fields:

https://github.com/contao/contao/blob/cb45c67fe234fa2e261cfb96b93dcceef7cb9a2b/core-bundle/src/Resources/contao/forms/Form.php#L505-L512

However, this does not actually work, as 

```php
$GLOBALS['TL_DCA'][$this->targetTable]['fields'][$k]['sql']
```

will be null, if the DCA is not loaded. And the DCA is likely never loaded for arbitrary tables.

This PR fixes that by ensuring that the DCA is loaded before trying to extract the empty value for the respective field.