### PR TITLE
Correctly handle empty image size formats

### DIFF
--- a/core-bundle/src/Image/PictureFactory.php
+++ b/core-bundle/src/Image/PictureFactory.php
@@ -182,23 +182,25 @@ class PictureFactory implements PictureFactoryInterface
                     $formatsString = implode(';', StringUtil::deserialize($imageSizes->formats, true));
                     $formats = [];
 
-                    foreach (explode(';', $formatsString) as $format) {
-                        [$source, $targets] = explode(':', $format, 2);
-                        $targets = explode(',', $targets);
+                    if ('' !== $formatsString) {
+                        foreach (explode(';', $formatsString) as $format) {
+                            [$source, $targets] = explode(':', $format, 2);
+                            $targets = explode(',', $targets);
 
-                        if (!isset($formats[$source])) {
-                            $formats[$source] = $targets;
-                            continue;
-                        }
-
-                        $formats[$source] = array_unique(array_merge($formats[$source], $targets));
-
-                        usort(
-                            $formats[$source],
-                            static function ($a, $b) {
-                                return (self::FORMATS_ORDER[$a] ?? $a) <=> (self::FORMATS_ORDER[$b] ?? $b);
+                            if (!isset($formats[$source])) {
+                                $formats[$source] = $targets;
+                                continue;
                             }
-                        );
+
+                            $formats[$source] = array_unique(array_merge($formats[$source], $targets));
+
+                            usort(
+                                $formats[$source],
+                                static function ($a, $b) {
+                                    return (self::FORMATS_ORDER[$a] ?? $a) <=> (self::FORMATS_ORDER[$b] ?? $b);
+                                }
+                            );
+                        }
                     }
 
                     $config->setFormats($formats);

--- a/core-bundle/src/Image/PictureFactory.php
+++ b/core-bundle/src/Image/PictureFactory.php
@@ -179,10 +179,11 @@ class PictureFactory implements PictureFactoryInterface
                 if (null !== $imageSizes) {
                     $options->setSkipIfDimensionsMatch((bool) $imageSizes->skipIfDimensionsMatch);
 
-                    $formatsString = implode(';', StringUtil::deserialize($imageSizes->formats, true));
                     $formats = [];
 
-                    if ('' !== $formatsString) {
+                    if ('' !== $imageSizes->formats) {
+                        $formatsString = implode(';', StringUtil::deserialize($imageSizes->formats, true));
+
                         foreach (explode(';', $formatsString) as $format) {
                             [$source, $targets] = explode(':', $format, 2);
                             $targets = explode(',', $targets);

--- a/core-bundle/tests/Image/PictureFactoryTest.php
+++ b/core-bundle/tests/Image/PictureFactoryTest.php
@@ -165,6 +165,68 @@ class PictureFactoryTest extends TestCase
         $this->assertSame('lazy', $picture->getImg()['loading']);
     }
 
+    public function testCorrectlyHandlesEmptyImageFormats(): void
+    {
+        $path = $this->getTempDir().'/images/dummy.jpg';
+        $imageMock = $this->createMock(ImageInterface::class);
+        $pictureMock = new Picture(['src' => $imageMock, 'srcset' => []], []);
+
+        $pictureGenerator = $this->createMock(PictureGeneratorInterface::class);
+        $pictureGenerator
+            ->expects($this->once())
+            ->method('generate')
+            ->with(
+                $this->anything(),
+                $this->callback(
+                    function (PictureConfiguration $pictureConfig): bool {
+                        $this->assertSame([PictureConfiguration::FORMAT_DEFAULT => [PictureConfiguration::FORMAT_DEFAULT]], $pictureConfig->getFormats());
+
+                        return true;
+                    }
+                )
+            )
+            ->willReturn($pictureMock)
+        ;
+
+        $imageFactory = $this->createMock(ImageFactoryInterface::class);
+        $imageFactory
+            ->method('create')
+            ->willReturn($imageMock)
+        ;
+
+        $imageSizeProperties = [
+            'width' => 100,
+            'height' => 200,
+            'resizeMode' => ResizeConfiguration::MODE_BOX,
+            'zoom' => 50,
+            'sizes' => '100vw',
+            'densities' => '1x, 2x',
+            'cssClass' => 'my-size',
+            'lazyLoading' => true,
+            'formats' => '',
+        ];
+
+        /** @var ImageSizeModel&MockObject $imageSizeModel */
+        $imageSizeModel = $this->mockClassWithProperties(ImageSizeModel::class, $imageSizeProperties);
+        $imageSizeModel
+            ->method('row')
+            ->willReturn($imageSizeProperties)
+        ;
+
+        $imageSizeAdapter = $this->mockConfiguredAdapter(['findByPk' => $imageSizeModel]);
+        $imageSizeItemAdapter = $this->mockConfiguredAdapter(['findVisibleByPid' => null]);
+
+        $adapters = [
+            ImageSizeModel::class => $imageSizeAdapter,
+            ImageSizeItemModel::class => $imageSizeItemAdapter,
+        ];
+
+        $framework = $this->mockContaoFramework($adapters);
+
+        $pictureFactory = $this->getPictureFactory($pictureGenerator, $imageFactory, $framework);
+        $pictureFactory->create($path, 1);
+    }
+
     public function testCreatesAPictureObjectFromAnImageObjectWithAPredefinedImageSize(): void
     {
         $predefinedSizes = [


### PR DESCRIPTION
The changes in #3475 break on my system if `$imageSizes->formats` is empty (no image conversion is enabled). It previously did not cause any problem because `array_map()` was not executed on an empty array.