### PR TITLE
Add assertions to the picture factory tests

### DIFF
--- a/core-bundle/tests/Image/PictureFactoryTest.php
+++ b/core-bundle/tests/Image/PictureFactoryTest.php
@@ -251,30 +251,7 @@ class PictureFactoryTest extends TestCase
             ->willReturn($pictureMock)
         ;
 
-        $imageFactory = $this->createMock(ImageFactoryInterface::class);
-        $imageFactory
-            ->expects($this->once())
-            ->method('create')
-            ->with(
-                $this->callback(
-                    function (string $imagePath) use ($path): bool {
-                        $this->assertSame($path, $imagePath);
-
-                        return true;
-                    }
-                ),
-                $this->callback(
-                    function (?ResizeConfiguration $size): bool {
-                        $this->assertNull($size);
-
-                        return true;
-                    }
-                )
-            )
-            ->willReturn($imageMock)
-        ;
-
-        $pictureFactory = $this->getPictureFactory($pictureGenerator, $imageFactory, $this->mockContaoFramework());
+        $pictureFactory = $this->getPictureFactory($pictureGenerator);
         $pictureFactory->setPredefinedSizes($predefinedSizes);
 
         $picture = $pictureFactory->create($imageMock, [null, null, 'foobar']);

--- a/core-bundle/tests/Image/PictureFactoryTest.php
+++ b/core-bundle/tests/Image/PictureFactoryTest.php
@@ -46,6 +46,7 @@ class PictureFactoryTest extends TestCase
 
         $pictureGenerator = $this->createMock(PictureGeneratorInterface::class);
         $pictureGenerator
+            ->expects($this->once())
             ->method('generate')
             ->with(
                 $this->callback(
@@ -89,6 +90,7 @@ class PictureFactoryTest extends TestCase
 
         $imageFactory = $this->createMock(ImageFactoryInterface::class);
         $imageFactory
+            ->expects($this->once())
             ->method('create')
             ->with(
                 $this->callback(
@@ -201,6 +203,7 @@ class PictureFactoryTest extends TestCase
 
         $pictureGenerator = $this->createMock(PictureGeneratorInterface::class);
         $pictureGenerator
+            ->expects($this->once())
             ->method('generate')
             ->with(
                 $this->callback(
@@ -250,6 +253,7 @@ class PictureFactoryTest extends TestCase
 
         $imageFactory = $this->createMock(ImageFactoryInterface::class);
         $imageFactory
+            ->expects($this->once())
             ->method('create')
             ->with(
                 $this->callback(
@@ -315,6 +319,7 @@ class PictureFactoryTest extends TestCase
 
         $pictureGenerator = $this->createMock(PictureGeneratorInterface::class);
         $pictureGenerator
+            ->expects($this->once())
             ->method('generate')
             ->with(
                 $this->callback(
@@ -427,6 +432,7 @@ class PictureFactoryTest extends TestCase
 
         $pictureGenerator = $this->createMock(PictureGeneratorInterface::class);
         $pictureGenerator
+            ->expects($this->exactly(2))
             ->method('generate')
             ->with(
                 $this->callback(
@@ -466,6 +472,7 @@ class PictureFactoryTest extends TestCase
 
         $imageFactory = $this->createMock(ImageFactoryInterface::class);
         $imageFactory
+            ->expects($this->exactly(2))
             ->method('create')
             ->with(
                 $this->callback(
@@ -507,6 +514,7 @@ class PictureFactoryTest extends TestCase
 
         $pictureGenerator = $this->createMock(PictureGeneratorInterface::class);
         $pictureGenerator
+            ->expects($this->exactly(2))
             ->method('generate')
             ->with(
                 $this->callback(
@@ -539,6 +547,7 @@ class PictureFactoryTest extends TestCase
 
         $imageFactory = $this->createMock(ImageFactoryInterface::class);
         $imageFactory
+            ->expects($this->exactly(2))
             ->method('create')
             ->with(
                 $this->callback(
@@ -581,6 +590,7 @@ class PictureFactoryTest extends TestCase
 
         $pictureGenerator = $this->createMock(PictureGeneratorInterface::class);
         $pictureGenerator
+            ->expects($this->once())
             ->method('generate')
             ->willReturnCallback(
                 function (ImageInterface $image, PictureConfiguration $config, ResizeOptions $options) use ($imageMock, $expected) {
@@ -593,6 +603,7 @@ class PictureFactoryTest extends TestCase
 
         $imageFactory = $this->createMock(ImageFactoryInterface::class);
         $imageFactory
+            ->expects($this->once())
             ->method('create')
             ->willReturn($imageMock)
         ;
@@ -675,6 +686,7 @@ class PictureFactoryTest extends TestCase
         $pictureGenerator = $this->createMock(PictureGeneratorInterface::class);
 
         $pictureGenerator
+            ->expects($this->once())
             ->method('generate')
             ->willReturnCallback(
                 static function (ImageInterface $image, PictureConfiguration $config) use ($imageMock, $imgWidth, $imgHeight, $sourceWidth, $sourceHeight): Picture {

--- a/core-bundle/tests/Image/PictureFactoryTest.php
+++ b/core-bundle/tests/Image/PictureFactoryTest.php
@@ -197,7 +197,6 @@ class PictureFactoryTest extends TestCase
             ],
         ];
 
-        $path = $this->getTempDir().'/images/dummy.jpg';
         $imageMock = $this->createMock(ImageInterface::class);
         $pictureMock = new Picture(['src' => $imageMock, 'srcset' => []], []);
 


### PR DESCRIPTION
While implementing https://github.com/contao/contao/pull/3503 I noticed that the `PictureFactoryTest` contains a lot of assertions in method callbacks, but there is not assertion that the method (and therefore the callbacks) are actually executed.

Unfortunately, now one test fails because apparently there's an invalid assertion. @qzminski @ausi maybe you can tell whether the assertions should not be there or something else is wrong?