### PR TITLE
Implemented a contao:database:dump command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -119,6 +119,7 @@
         "twig/extra-bundle": "^3.0",
         "twig/twig": "^3.0",
         "ua-parser/uap-php": "^3.9",
+        "webfactory/slimdump": "^1.12",
         "webignition/robots-txt-file": "^3.0",
         "webmozart/path-util": "^2.2",
         "wikimedia/less.php": "^1.7"

--- a/core-bundle/composer.json
+++ b/core-bundle/composer.json
@@ -106,6 +106,7 @@
         "twig/twig": "^3.0",
         "ua-parser/uap-php": "^3.9",
         "webignition/robots-txt-file": "^3.0",
+        "webfactory/slimdump": "^1.12",
         "webmozart/path-util": "^2.2",
         "wikimedia/less.php": "^1.7"
     },

--- a/core-bundle/src/Command/DatabaseDumpCommand.php
+++ b/core-bundle/src/Command/DatabaseDumpCommand.php
@@ -1,0 +1,160 @@
+<?php
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Command;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Schema\Table;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Formatter\OutputFormatterInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Output\StreamOutput;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Webfactory\Slimdump\Config\Config;
+use Webfactory\Slimdump\Config\ConfigBuilder;
+use Webfactory\Slimdump\DumpTask;
+
+/**
+ * Dumps the database.
+ *
+ * @internal
+ */
+class DatabaseDumpCommand extends Command
+{
+    protected static $defaultName = 'contao:database:dump';
+
+    private Connection $connection;
+
+    public function __construct(Connection $connection)
+    {
+        $this->connection = $connection;
+
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->setAliases(['contao:db:dump'])
+            ->addArgument('file', InputArgument::REQUIRED, 'The path to the SQL dump.')
+            ->addOption('buffer-size', 'b', InputOption::VALUE_OPTIONAL, 'Maximum length of a single SQL statement generated. Requires said amount of RAM. Defaults to "100MB".')
+            ->addOption('ignore-tables', 'i', InputOption::VALUE_OPTIONAL, 'A comma-separated list of database tables to ignore. Defaults to the Contao configuration (contao.db.dump.ignoreTables).')
+            ->setDescription('Dumps an database to a given target file.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $file = $input->getArgument('file');
+        $bufferSize = $this->parseBufferSize($input->getOption('buffer-size') ?: '100MB');
+        $tablesToIgnore = $input->getOption('ignore-tables') ? explode(',', $input->getOption('ignore-tables')) : ['tl_crawl_queue', 'tl_log', 'tl_search', 'tl_search_index', 'tl_search_term']; // TODO: Make this a bundle config (e.g. contao.db.dump.ignoreTable or something similar)
+        $config = $this->createConfig($tablesToIgnore);
+        $enableGzCompression = strcasecmp(substr($file, -3), '.gz') === 0;
+        $handler = fopen($file, 'w');
+        $deflateContext = $enableGzCompression ? deflate_init(ZLIB_ENCODING_GZIP, ['level' => 9]) : null;
+
+        $output = $this->getOutput($handler, $deflateContext);
+
+        $dumptask = new DumpTask($this->connection, $config, true, true, $bufferSize, $output);
+        $dumptask->dump();
+
+        if ($deflateContext) {
+            fwrite($handler, deflate_add($deflateContext, '', ZLIB_FINISH));
+        }
+
+        fclose($handler);
+
+        $io->success(sprintf('Successfully created an SQL dump while ignoring following tables: %s.', implode(', ', $tablesToIgnore)));
+
+        return 0;
+    }
+
+    private function createConfig(array $tablesToIgnore = []): Config
+    {
+        $tables = $this->connection->getSchemaManager()->listTables();
+        $tableNames = array_map(function(Table $table) {
+            return $table->getName();
+        }, $tables);
+
+        $tableNames = array_diff($tableNames, $tablesToIgnore);
+
+        $doc = new \DOMDocument();
+        $slimDump = $doc->createElement('slimdump');
+
+        foreach ($tableNames as $tableName) {
+            $table = $doc->createElement('table');
+            $table->setAttribute('name', $tableName);
+            $table->setAttribute('dump', 'full');
+            $slimDump->appendChild($table);
+        }
+
+        $doc->appendChild($slimDump);
+
+        return ConfigBuilder::createFromXmlString($doc->saveXML());
+    }
+
+    private function getOutput($handler, $deflateContext = null): OutputInterface
+    {
+        $output = new class($handler) extends StreamOutput {
+            private $deflateContext = null;
+
+            public function setDeflateContext($deflateContext)
+            {
+                $this->deflateContext = $deflateContext;
+            }
+
+            protected function doWrite(string $message, bool $newline)
+            {
+                if ($newline) {
+                    $message .= \PHP_EOL;
+                }
+
+                if ($this->deflateContext) {
+                    $message = deflate_add($this->deflateContext, $message, ZLIB_NO_FLUSH);
+                }
+
+                parent::doWrite($message, false);
+            }
+        };
+
+        $output->setDeflateContext($deflateContext);
+
+        return $output;
+    }
+
+    private function parseBufferSize(string $bufferSize): ?int
+    {
+        $match = preg_match('/^(\d+)(KB|MB|GB)?$/', $bufferSize, $matches);
+
+        if (false === $match || 0 === $match) {
+            throw new \InvalidArgumentException('The buffer size must be an unsigned integer, optionally ending with KB, MB or GB.');
+        }
+        $bufferSize = (int) $matches[1];
+        $bufferFactor = 1;
+
+        switch ($matches[2]) {
+            case 'GB':
+                $bufferFactor *= 1024;
+            // no break
+            case 'MB':
+                $bufferFactor *= 1024;
+            // no break
+            case 'KB':
+                $bufferFactor *= 1024;
+        }
+
+        return $bufferSize * $bufferFactor;
+    }
+}

--- a/core-bundle/src/Resources/config/commands.yml
+++ b/core-bundle/src/Resources/config/commands.yml
@@ -22,6 +22,10 @@ services:
         arguments:
             - '@Contao\CoreBundle\Cron\Cron'
 
+    Contao\CoreBundle\Command\DatabaseDumpCommand:
+        arguments:
+            - '@database_connection'
+
     contao.command.debug_dca:
         class: Contao\CoreBundle\Command\DebugDcaCommand
         arguments:


### PR DESCRIPTION
This is the complementary draft PR for https://github.com/contao/contao/pull/3466.

I've researched the use on the dump library (or none at all) quite a bit before going for `webfactory/slimdump`.
Here are the reasons for my decision

* Requiring the `mysqldump` command line tool seemed like an option but this has 2 serious disadvantages:
    1. We all know, not everybody has access to `mysqldump` with their hosting provider
    2. Actually, even if they had access, we could have an issue with making the dump process compatible with the import process as we have no control over the version of `mysqldump` installed and thus, we might run into compatibility issues.
* https://packagist.org/packages/ifsnop/mysqldump-php is the most popular library but there does not seem to be a lot of activity. Especially PRs regarding PHP 8 are being ignored.
* https://packagist.org/packages/dg/mysql-dump seems popular too but uses `mysqli` directly and thus does not seem to be the right fit for us as we use Doctrine/PDO.
* https://packagist.org/packages/rah/danpu is also very popular but kind of has the same issue as it requires to pass the DSN.
* I then decided for https://github.com/webfactory/slimdump because it seems maintained, I like the code, it's based on Doctrine and I know at least one maintainer which is also active in the Symfony environment :) 

To do:

- [ ] Decide on whether that should be core-bundle or manager-bundle (and then we should also move contao:migrate maybe)
- [x] Should I merge both PR's (so this one with https://github.com/contao/contao/pull/3466) into one so we have everything db related in one PR? I could add functional tests to ensure the import command can handle the dumps generated by the dump command.
- [ ] Tests