### PR TITLE
Add an event count to the event list

### DIFF
--- a/calendar-bundle/src/Resources/contao/modules/ModuleEventReader.php
+++ b/calendar-bundle/src/Resources/contao/modules/ModuleEventReader.php
@@ -248,6 +248,7 @@ class ModuleEventReader extends Events
 		$objTemplate->until = $until;
 		$objTemplate->locationLabel = $GLOBALS['TL_LANG']['MSC']['location'];
 		$objTemplate->calendar = $objEvent->getRelated('pid');
+		$objTemplate->count = 0; // see #74
 		$objTemplate->details = '';
 		$objTemplate->hasDetails = false;
 		$objTemplate->hasTeaser = false;

--- a/calendar-bundle/src/Resources/contao/modules/ModuleEventlist.php
+++ b/calendar-bundle/src/Resources/contao/modules/ModuleEventlist.php
@@ -185,6 +185,7 @@ class ModuleEventlist extends Events
 			$sort($arrAllEvents[$key]);
 		}
 
+		$intCount = 0;
 		$arrEvents = array();
 
 		// Remove events outside the scope
@@ -227,6 +228,7 @@ class ModuleEventlist extends Events
 
 					$event['firstDay'] = $GLOBALS['TL_LANG']['DAYS'][date('w', $day)];
 					$event['firstDate'] = Date::parse($objPage->dateFormat, $day);
+					$event['count'] = ++$intCount; // see #74
 
 					$arrEvents[] = $event;
 				}


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Implemented issue     | #74
| Docs PR or issue | -

The implementation behaves exactly like in the news module. However, I have noticed that counting starts at `1` and not at `0`. @ausi Is this something we want to change in the future?