### PR TITLE
Improve the JwtManager

### DIFF
--- a/manager-bundle/src/HttpKernel/JwtManager.php
+++ b/manager-bundle/src/HttpKernel/JwtManager.php
@@ -52,7 +52,7 @@ class JwtManager
             $filesystem->dumpFile($secretFile, $secret);
         }
 
-        $this->config = $config ?: Configuration::forSymmetricSigner(new Sha256(), InMemory::file($secretFile));
+        $this->config = $config ?: Configuration::forSymmetricSigner(new Sha256(), InMemory::plainText($secret));
         $this->config->setValidationConstraints(new SignedWith($this->config->signer(), $this->config->signingKey()));
     }
 


### PR DESCRIPTION
While validating whether https://github.com/lcobucci/jwt/security/advisories/GHSA-7322-jrq4-x5hf affects Contao (it does not!), I noticed we unnecessarily ask the JWT signer to load the sign from file even though it already is available in a variable.