### PR TITLE
Update the Facebook share link

### DIFF
--- a/core-bundle/src/Resources/contao/controllers/FrontendShare.php
+++ b/core-bundle/src/Resources/contao/controllers/FrontendShare.php
@@ -31,7 +31,7 @@ class FrontendShare extends Frontend
 			case 'facebook':
 				return new RedirectResponse(
 					'https://www.facebook.com/sharer/sharer.php'
-						. '?u=' . rawurlencode(Input::get('u', true))
+						. '?p[url]=' . rawurlencode(Input::get('u', true))
 				);
 
 			case 'twitter':


### PR DESCRIPTION
I noticed that the Facebook share link no longer works. The issue can be reproduced on https://contao.org/en/news/contao-4_12_0.html by clicking the Facebook icon at the bottom. 

Unfortunately, I couldn't find any official documentation since the ? `sharer.php` is deprecated in favor of their JS library, which is not an option for us. Searching through the net I found https://stackoverflow.com/questions/20956229/has-facebook-sharer-php-changed-to-no-longer-accept-detailed-parameters/22969530#22969530 and using `p[url]=` instead of `u=` seems to make it work again.