### PR TITLE
Translate all languages in the file meta data

### DIFF
--- a/core-bundle/src/Resources/contao/widgets/MetaWizard.php
+++ b/core-bundle/src/Resources/contao/widgets/MetaWizard.php
@@ -133,7 +133,7 @@ class MetaWizard extends Widget
 			return '<p class="tl_info">' . $GLOBALS['TL_LANG']['MSC']['metaNoLanguages'] . '</p>';
 		}
 
-		$languages = $this->getLanguages(true);
+		$languages = $this->getLanguages();
 
 		// Add the existing entries
 		if (!empty($this->varValue))


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes https://github.com/contao/contao/issues/3533

The first parameter to `System::getLanguages()` says to only return installed languages - which can't be right in this context.