### PR TITLE
Harden more time-sensitive tests

### DIFF
--- a/core-bundle/phpunit.xml.dist
+++ b/core-bundle/phpunit.xml.dist
@@ -58,6 +58,8 @@
                             <element key="1"><string>Contao\CoreBundle\Tests\Command</string></element>
                             <element key="2"><string>Contao\CoreBundle\Cron\Command</string></element>
                             <element key="3"><string>Contao\CoreBundle\Tests\Cron</string></element>
+                            <element key="4"><string>Contao\CoreBundle\EventListener</string></element>
+                            <element key="5"><string>Contao\CoreBundle\Tests\EventListener</string></element>
                         </array>
                     </element>
                 </array>

--- a/core-bundle/tests/EventListener/DataContainer/ContentCompositionListenerTest.php
+++ b/core-bundle/tests/EventListener/DataContainer/ContentCompositionListenerTest.php
@@ -27,6 +27,7 @@ use Contao\LayoutModel;
 use Contao\PageModel;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Bridge\PhpUnit\ClockMock;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface;
@@ -530,6 +531,8 @@ class ContentCompositionListenerTest extends TestCase
 
     public function testGenerateArticleForNewPage(): void
     {
+        ClockMock::withClockMock(true);
+
         $this->expectRequest(true, ['tl_foo' => [17]]);
         $this->expectUser();
 
@@ -559,6 +562,8 @@ class ContentCompositionListenerTest extends TestCase
         $dc = $this->mockClassWithProperties(DC_Table::class, ['id' => 17, 'table' => 'tl_foo', 'activeRecord' => (object) $this->pageRecord]);
 
         $this->listener->generateArticleForPage($dc);
+
+        ClockMock::withClockMock(false);
     }
 
     /**
@@ -566,6 +571,8 @@ class ContentCompositionListenerTest extends TestCase
      */
     public function testUsesTheLayoutColumnForNewArticle(array $modules, string $expectedColumn): void
     {
+        ClockMock::withClockMock(true);
+
         $this->expectRequest(true, ['tl_foo' => [17]]);
         $this->expectUser();
 
@@ -604,6 +611,8 @@ class ContentCompositionListenerTest extends TestCase
         $dc = $this->mockClassWithProperties(DC_Table::class, ['id' => 17, 'table' => 'tl_foo', 'activeRecord' => (object) $this->pageRecord]);
 
         $this->listener->generateArticleForPage($dc);
+
+        ClockMock::withClockMock(false);
     }
 
     public function moduleConfigProvider(): \Generator


### PR DESCRIPTION
The tests that I adjusted in this PR failed in one of the last CI runs because they're using `time()` and the output was off by one.

Unfortunately you cannot see the CI results after rerunning the jobs (which fixed the momentary issue).