### PR TITLE
Allow providing Twig templates alongside PHP templates

### DIFF
--- a/core-bundle/src/Resources/config/services.yml
+++ b/core-bundle/src/Resources/config/services.yml
@@ -944,6 +944,7 @@ services:
             - '@Contao\CoreBundle\Twig\Loader\TemplateLocator'
             - '@Contao\CoreBundle\Twig\Loader\ThemeNamespace'
             - '%kernel.project_dir%'
+        public: true
         tags:
             - { name: twig.loader, priority: 2 }
             - { name: kernel.reset, method: reset }

--- a/core-bundle/src/Twig/Inheritance/TemplateHierarchyInterface.php
+++ b/core-bundle/src/Twig/Inheritance/TemplateHierarchyInterface.php
@@ -47,4 +47,11 @@ interface TemplateHierarchyInterface
      * Finds the first template in the hierarchy and returns the logical name.
      */
     public function getFirst(string $shortNameOrIdentifier, string $themeSlug = null): string;
+
+    /**
+     * Returns the current theme slug or false if not applicable.
+     *
+     * @return string|false
+     */
+    public function getCurrentThemeSlug();
 }

--- a/core-bundle/tests/Twig/Inheritance/InheritanceTest.php
+++ b/core-bundle/tests/Twig/Inheritance/InheritanceTest.php
@@ -67,12 +67,12 @@ class InheritanceTest extends TestCase
         unset($GLOBALS['objPage']);
     }
 
-    public function testThrowsIfTemplatesAreAmbiguous(): void
+    public function testThrowsIfTemplatesOfSameTypeAreAmbiguous(): void
     {
         $bundlePath = Path::canonicalize(__DIR__.'/../../Fixtures/Twig/inheritance/vendor-bundles/InvalidBundle');
 
         $this->expectException(\OutOfBoundsException::class);
-        $this->expectExceptionMessage("There cannot be more than one 'foo' template in '$bundlePath/templates'.");
+        $this->expectExceptionMessage("There cannot be more than one 'foo.html.twig' template in '$bundlePath/templates'.");
 
         $this->getDemoEnvironment(['InvalidBundle' => ['path' => $bundlePath]]);
     }


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | One step towards #3387
| Docs PR or issue | todo

This PR aims at allowing Twig and PHP Templates side by side. This way we could add Twig versions of our own templates and deprecate the PHP ones. Users could still use PHP templates for the existing stuff but we could introduce new features for Twig only. This would also allow us to provide the correct content when creating Twig templates from within the BE 

Note: It still won't be possible to inherit a Twig template from a PHP template. So if an extension decides to overwrite/extend a Twig template from the core, a user will only be able to use/extend it if when using Twig as well. Otherwise the core PHP template would be used as a base.