### PR TITLE
Improve handling of pages with `tl_page.requireItem`

### DIFF
--- a/core-bundle/src/EventListener/PreviewUrlConvertListener.php
+++ b/core-bundle/src/EventListener/PreviewUrlConvertListener.php
@@ -70,7 +70,7 @@ class PreviewUrlConvertListener
             } catch (RouteParametersException $e) {
                 $route = $e->getRoute();
 
-                if (!$e->getPrevious() instanceof InvalidParameterException || !$route instanceof PageRoute || !$route->getPageModel()->requireItem) {
+                if (!$route instanceof PageRoute || !$route->getPageModel()->requireItem) {
                     $event->setUrl($this->getFragmentUrl($request, $page));
                 }
 

--- a/core-bundle/src/EventListener/PreviewUrlConvertListener.php
+++ b/core-bundle/src/EventListener/PreviewUrlConvertListener.php
@@ -24,7 +24,6 @@ use Symfony\Component\HttpKernel\Controller\ControllerReference;
 use Symfony\Component\HttpKernel\Fragment\FragmentUriGenerator;
 use Symfony\Component\HttpKernel\UriSigner;
 use Symfony\Component\Routing\Exception\ExceptionInterface;
-use Symfony\Component\Routing\Exception\InvalidParameterException;
 
 /**
  * @internal

--- a/core-bundle/src/EventListener/PreviewUrlConvertListener.php
+++ b/core-bundle/src/EventListener/PreviewUrlConvertListener.php
@@ -73,7 +73,7 @@ class PreviewUrlConvertListener
                     $event->setUrl($this->getFragmentUrl($request, $page));
                 }
 
-                // Swallow exception and set no url for pages with requireItem (see #3525)
+                // Ignore the exception and set no URL for pages with requireItem (see #3525)
             } catch (ExceptionInterface $e) {
                 $event->setUrl($this->getFragmentUrl($request, $page));
             }

--- a/core-bundle/src/Resources/contao/classes/Backend.php
+++ b/core-bundle/src/Resources/contao/classes/Backend.php
@@ -1053,6 +1053,11 @@ abstract class Backend extends Controller
 			$label = '<span>' . $label . '</span>';
 		}
 
+		if ($row['requireItem'])
+		{
+			return Image::getHtml($image, '', $imageAttribute) . $label;
+		}
+
 		// Return the image
 		return '<a href="' . StringUtil::specialcharsUrl(System::getContainer()->get('router')->generate('contao_backend_preview', array('page'=>$row['id']))) . '" title="' . StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['view']) . '" target="_blank">' . Image::getHtml($image, '', $imageAttribute) . '</a> ' . $label;
 	}

--- a/core-bundle/src/Resources/contao/modules/ModuleBreadcrumb.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleBreadcrumb.php
@@ -96,8 +96,8 @@ class ModuleBreadcrumb extends Module
 
 		for ($i=(\count($pages)-1); $i>0; $i--)
 		{
-			// Skip pages that require an item (see #3450)
-			if (($pages[$i]->hide && !$this->showHidden) || $pages[$i]->requireItem || (!$pages[$i]->published && !$blnShowUnpublished))
+			// Skip pages that require an item (see #3450) and hidden or unpublished pages
+			if ($pages[$i]->requireItem || ($pages[$i]->hide && !$this->showHidden) || (!$pages[$i]->published && !$blnShowUnpublished))
 			{
 				continue;
 			}
@@ -137,7 +137,7 @@ class ModuleBreadcrumb extends Module
 			}
 
 			// Do not add non-root pages with an empty URL to the breadcrumbs
-			if ('' !== $href)
+			if ($href)
 			{
 				$items[] = array
 				(

--- a/core-bundle/tests/EventListener/PreviewUrlConverterListenerTest.php
+++ b/core-bundle/tests/EventListener/PreviewUrlConverterListenerTest.php
@@ -226,9 +226,17 @@ class PreviewUrlConverterListenerTest extends TestCase
         $this->assertSame($expectedUrl, $event->getUrl());
     }
 
-    public function testReturnsEmptyUrlForFailedRouteGenerationForPageWithRequireItem(): void
+    public function testReturnsEmptyUrlForPagesThatRequireAnItem(): void
     {
-        $pageModel = $this->mockClassWithProperties(PageModel::class, ['id' => 42, 'rootLanguage' => 'en', 'requireItem' => '1']);
+        $pageModel = $this->mockClassWithProperties(
+            PageModel::class,
+            [
+                'id' => 42,
+                'rootLanguage' => 'en',
+                'requireItem' => '1',
+            ]
+        );
+
         $route = new PageRoute($pageModel);
 
         $pageModel

--- a/core-bundle/tests/EventListener/PreviewUrlConverterListenerTest.php
+++ b/core-bundle/tests/EventListener/PreviewUrlConverterListenerTest.php
@@ -225,29 +225,6 @@ class PreviewUrlConverterListenerTest extends TestCase
         $this->assertSame($expectedUrl, $event->getUrl());
     }
 
-    /**
-     * @return PageRegistry&MockObject
-     */
-    private function mockPageRegistry(PageRoute $route = null): PageRegistry
-    {
-        $pageRegistry = $this->createMock(PageRegistry::class);
-
-        if (null === $route) {
-            $pageRegistry
-                ->expects($this->never())
-                ->method('getRoute')
-            ;
-        } else {
-            $pageRegistry
-                ->expects($this->once())
-                ->method('getRoute')
-                ->willReturn($route)
-            ;
-        }
-
-        return $pageRegistry;
-    }
-
     public function testReturnsEmptyUrlForFailedRouteGenerationForPageWithRequireItem(): void
     {
         $request = new Request();
@@ -289,5 +266,28 @@ class PreviewUrlConverterListenerTest extends TestCase
         $listener($event);
 
         $this->assertNull($event->getUrl());
+    }
+
+    /**
+     * @return PageRegistry&MockObject
+     */
+    private function mockPageRegistry(PageRoute $route = null): PageRegistry
+    {
+        $pageRegistry = $this->createMock(PageRegistry::class);
+
+        if (null === $route) {
+            $pageRegistry
+                ->expects($this->never())
+                ->method('getRoute')
+            ;
+        } else {
+            $pageRegistry
+                ->expects($this->once())
+                ->method('getRoute')
+                ->willReturn($route)
+            ;
+        }
+
+        return $pageRegistry;
     }
 }

--- a/core-bundle/tests/EventListener/PreviewUrlConverterListenerTest.php
+++ b/core-bundle/tests/EventListener/PreviewUrlConverterListenerTest.php
@@ -27,7 +27,6 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\UriSigner;
 use Symfony\Component\Routing\Exception\MissingMandatoryParametersException;
 use Symfony\Component\Routing\Exception\RouteNotFoundException;
-use Symfony\Component\Routing\Exception\InvalidParameterException;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class PreviewUrlConverterListenerTest extends TestCase


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #3450 , #3525 

With the new routing, trying to generate a URL for a page with `tl_page.requireItem=1` throws a `RouteParametersException`. This pull request prevents or improves the handling of this exception in breadcrumbs and navigation modules as well as in the frontend preview.

Improved cases:

**1. Breadcrumbs, current item has `requireItem`**
Generate the URL from the current request instead of re-generating it from the taget page.

Note: The URL is generated via `strtok(Environment::get('request'), '?')` so any query string is not added to the breadcrumbs URL. 

**2. Breadcrumbs, item in parent trail has `requireItem`**
Skip pages with `tl_page.requireItem=1` in the parent trail of the breadcrumbs, even if `showHidden` is enabled.

Note: These pages are skipped explicitly in the breadcrumbs (and not handled by the future proof fix below) to prevent spamming the log with error messages for failed URL generations.

**3. Future proof breadcrumbs**
Only add items with a non-empty URL (`$href`) to the breadcrumbs (except root page).

This way, if some page types will not generate a proper URL (after an exception or for pages with no public route in the future), they will neither get added to the breadcrumbs nor to the JSON-LD data.


**4. Frontend preview**
If a `RouteParametersException` is thrown for a page when converting the frontend preview URL and the reason for the exception is an `InvalidParameterException` on a page with `tl_page.requireItem`, catch the exception and do not set a URL for the preview, thus starting the preview on the root page.
