### PR TITLE
Fix pagination item calculation for an even number of links

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Pagination.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Pagination.php
@@ -135,6 +135,7 @@ class Pagination
 		$this->intRows = (int) $intRows;
 		$this->intRowsPerPage = (int) $intPerPage;
 		$this->intNumberOfLinks = (int) $intNumberOfLinks;
+		$this->intTotalPages = $this->intRows > 0 && $this->intRowsPerPage > 0 ? (int) ceil($this->intRows / $this->intRowsPerPage) : 0;
 
 		// Initialize default labels
 		$this->lblFirst = $GLOBALS['TL_LANG']['MSC']['first'];
@@ -227,7 +228,6 @@ class Pagination
 		}
 
 		$this->strVarConnector = $blnQuery ? '&amp;' : '?';
-		$this->intTotalPages = ceil($this->intRows / $this->intRowsPerPage);
 
 		// Return if there is only one page
 		if ($this->intTotalPages < 2 || $this->intRows < 1)
@@ -328,31 +328,38 @@ class Pagination
 	 */
 	public function getItemsAsArray()
 	{
+		if ($this->intTotalPages < 2)
+		{
+			return array();
+		}
+
 		$arrLinks = array();
 
-		$intNumberOfLinks = floor($this->intNumberOfLinks / 2);
-		$intFirstOffset = $this->intPage - $intNumberOfLinks - 1;
+		// Calculate the number of links with a bias to adding one more link after the current page (see #3539)
+		$intNumberOfPreviousLinks = (int) ceil($this->intNumberOfLinks / 2) - 1;
+		$intNumberOfNextLinks = (int) floor($this->intNumberOfLinks / 2);
+		$intFirstOffset = $this->intPage - $intNumberOfPreviousLinks - 1;
 
 		if ($intFirstOffset > 0)
 		{
 			$intFirstOffset = 0;
 		}
 
-		$intLastOffset = $this->intPage + $intNumberOfLinks - $this->intTotalPages;
+		$intLastOffset = $this->intPage + $intNumberOfNextLinks - $this->intTotalPages;
 
 		if ($intLastOffset < 0)
 		{
 			$intLastOffset = 0;
 		}
 
-		$intFirstLink = $this->intPage - $intNumberOfLinks - $intLastOffset;
+		$intFirstLink = $this->intPage - $intNumberOfPreviousLinks - $intLastOffset;
 
 		if ($intFirstLink < 1)
 		{
 			$intFirstLink = 1;
 		}
 
-		$intLastLink = $this->intPage + $intNumberOfLinks - $intFirstOffset;
+		$intLastLink = $this->intPage + $intNumberOfNextLinks - $intFirstOffset;
 
 		if ($intLastLink > $this->intTotalPages)
 		{

--- a/core-bundle/src/Resources/contao/library/Contao/Pagination.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Pagination.php
@@ -135,7 +135,12 @@ class Pagination
 		$this->intRows = (int) $intRows;
 		$this->intRowsPerPage = (int) $intPerPage;
 		$this->intNumberOfLinks = (int) $intNumberOfLinks;
-		$this->intTotalPages = $this->intRows > 0 && $this->intRowsPerPage > 0 ? (int) ceil($this->intRows / $this->intRowsPerPage) : 0;
+		$this->intTotalPages = 0;
+
+		if ($this->intRows > 0 && $this->intRowsPerPage > 0)
+		{
+			$this->intTotalPages = (int) ceil($this->intRows / $this->intRowsPerPage);
+		}
 
 		// Initialize default labels
 		$this->lblFirst = $GLOBALS['TL_LANG']['MSC']['first'];
@@ -402,10 +407,10 @@ class Pagination
 	{
 		if ($intPage <= 1 && !$this->blnForceParam)
 		{
-			return ampersand($this->strUrl);
+			return StringUtil::ampersand($this->strUrl);
 		}
 
-		return ampersand($this->strUrl) . $this->strVarConnector . $this->strParameter . '=' . $intPage;
+		return StringUtil::ampersand($this->strUrl) . $this->strVarConnector . $this->strParameter . '=' . $intPage;
 	}
 }
 

--- a/core-bundle/src/Resources/contao/library/Contao/StringUtil.php
+++ b/core-bundle/src/Resources/contao/library/Contao/StringUtil.php
@@ -1223,6 +1223,19 @@ class StringUtil
 
 		return (string) substr($path, $length + 1);
 	}
+
+	/**
+	 * Convert all ampersands into their HTML entity (default) or unencoded value
+	 *
+	 * @param string  $strString
+	 * @param boolean $blnEncode
+	 *
+	 * @return string
+	 */
+	public static function ampersand($strString, $blnEncode=true): string
+	{
+		return preg_replace('/&(amp;)?/i', ($blnEncode ? '&amp;' : '&'), $strString);
+	}
 }
 
 class_alias(StringUtil::class, 'StringUtil');

--- a/core-bundle/tests/Contao/PaginationTest.php
+++ b/core-bundle/tests/Contao/PaginationTest.php
@@ -17,24 +17,16 @@ use Contao\FrontendTemplate;
 use Contao\Input;
 use Contao\Pagination;
 
-/**
- * Needs to run in a separate process because it includes the functions.php file.
- *
- * @runTestsInSeparateProcesses
- * @preserveGlobalState disabled
- */
 class PaginationTest extends TestCase
 {
     protected function setUp(): void
     {
-        include_once __DIR__.'/../../src/Resources/contao/helper/functions.php';
-
-        $GLOBALS['TL_LANG']['MSC']['first'] = '';
-        $GLOBALS['TL_LANG']['MSC']['previous'] = '';
-        $GLOBALS['TL_LANG']['MSC']['next'] = '';
-        $GLOBALS['TL_LANG']['MSC']['last'] = '';
-        $GLOBALS['TL_LANG']['MSC']['totalPages'] = '';
-        $GLOBALS['TL_LANG']['MSC']['goToPage'] = '';
+        $GLOBALS['TL_LANG']['MSC']['first'] = 'First';
+        $GLOBALS['TL_LANG']['MSC']['previous'] = 'Previous';
+        $GLOBALS['TL_LANG']['MSC']['next'] = 'Next';
+        $GLOBALS['TL_LANG']['MSC']['last'] = 'Last';
+        $GLOBALS['TL_LANG']['MSC']['totalPages'] = 'Total';
+        $GLOBALS['TL_LANG']['MSC']['goToPage'] = 'Go to';
 
         parent::setUp();
     }
@@ -57,7 +49,6 @@ class PaginationTest extends TestCase
         $_GET['page'] = $data['currentPage'] ?? 1;
 
         $pagination = new Pagination($data['total'], $data['perPage'], $data['maxLinks'], 'page', $this->createMock(FrontendTemplate::class));
-
         $items = $pagination->getItemsAsArray();
 
         $this->assertCount($data['expectedCount'], $items);

--- a/core-bundle/tests/Contao/PaginationTest.php
+++ b/core-bundle/tests/Contao/PaginationTest.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\Contao;
+
+use Contao\CoreBundle\Tests\TestCase;
+use Contao\FrontendTemplate;
+use Contao\Input;
+use Contao\Pagination;
+
+/**
+ * Needs to run in a separate process because it includes the functions.php file.
+ *
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+class PaginationTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        include_once __DIR__.'/../../src/Resources/contao/helper/functions.php';
+
+        $GLOBALS['TL_LANG']['MSC']['first'] = '';
+        $GLOBALS['TL_LANG']['MSC']['previous'] = '';
+        $GLOBALS['TL_LANG']['MSC']['next'] = '';
+        $GLOBALS['TL_LANG']['MSC']['last'] = '';
+        $GLOBALS['TL_LANG']['MSC']['totalPages'] = '';
+        $GLOBALS['TL_LANG']['MSC']['goToPage'] = '';
+
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['TL_LANG'], $_GET['page']);
+
+        Input::resetCache();
+        Input::resetUnusedGet();
+
+        parent::tearDown();
+    }
+
+    /**
+     * @dataProvider paginationDataProvider
+     */
+    public function testGeneratesPaginationItems(array $data): void
+    {
+        $_GET['page'] = $data['currentPage'] ?? 1;
+
+        $pagination = new Pagination($data['total'], $data['perPage'], $data['maxLinks'], 'page', $this->createMock(FrontendTemplate::class));
+
+        $items = $pagination->getItemsAsArray();
+
+        $this->assertCount($data['expectedCount'], $items);
+
+        if ($data['expectedCount'] > 0) {
+            $this->assertSame($data['lowestPage'], reset($items)['page']);
+            $this->assertSame($data['highestPage'], end($items)['page']);
+        }
+    }
+
+    public function paginationDataProvider(): \Generator
+    {
+        yield 'lower than limit' => [[
+            'total' => 7,
+            'perPage' => 2,
+            'maxLinks' => 5,
+            'expectedCount' => 4,
+            'lowestPage' => 1,
+            'highestPage' => 4,
+        ]];
+
+        yield 'matches limit' => [[
+            'total' => 10,
+            'perPage' => 2,
+            'maxLinks' => 5,
+            'expectedCount' => 5,
+            'lowestPage' => 1,
+            'highestPage' => 5,
+        ]];
+
+        yield 'even limit' => [[
+            'total' => 10,
+            'perPage' => 2,
+            'maxLinks' => 4,
+            'expectedCount' => 4,
+            'lowestPage' => 1,
+            'highestPage' => 4,
+        ]];
+
+        yield 'above limit' => [[
+            'total' => 10,
+            'perPage' => 2,
+            'maxLinks' => 3,
+            'expectedCount' => 3,
+            'lowestPage' => 1,
+            'highestPage' => 3,
+        ]];
+
+        yield 'somewhat in the middle' => [[
+            'total' => 50,
+            'perPage' => 5,
+            'maxLinks' => 6,
+            'expectedCount' => 6,
+            'lowestPage' => 2,
+            'highestPage' => 7,
+            'currentPage' => 4,
+        ]];
+
+        yield 'on last page' => [[
+            'total' => 15,
+            'perPage' => 2,
+            'maxLinks' => 4,
+            'expectedCount' => 4,
+            'lowestPage' => 5,
+            'highestPage' => 8,
+            'currentPage' => 8,
+        ]];
+
+        yield 'single page' => [[
+            'total' => 8,
+            'perPage' => 10,
+            'maxLinks' => 5,
+            'expectedCount' => 0,
+        ]];
+
+        yield 'no items' => [[
+            'total' => 0,
+            'perPage' => 10,
+            'maxLinks' => 5,
+            'expectedCount' => 0,
+        ]];
+    }
+}


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #3539 

Improve the calculation of pagination links to ensure the pagination never has more items than defined by the `$intNumberOfLinks` parameter (usually the `maxPaginationLinks` configuration value). Add one more link after the current page if an even distribution of links is not possible.

Three notes:
1. To make the `Pagination` class testable, the calculation of `$this->intTotalPages` has been moved from `Pagination::generate` to its constructor. This is possible since its calculated value never changes.

2. `Pagination::getItemAsArray` now returns an empty array if no pagination is required (total pages < 2). Previously an array with a single item would have been generated – but the method was never executed since `Pagination::generate` already returned early in this case. 

3. For Contao 4.10+, the annotations `@runTestsInSeparateProcesses` and `@preserveGlobalState disabled` as well as the `include_once` of `functions.php` can be removed from `PaginationTest`. For Contao 4.9, they are necessary since the pagination relies on the `ampersand` function (which was moved to `StringUtil` in Contao 4.10).