### PR TITLE
Always set the _locale attribute from the page language

### DIFF
--- a/core-bundle/src/Routing/Page/PageRoute.php
+++ b/core-bundle/src/Routing/Page/PageRoute.php
@@ -47,19 +47,17 @@ class PageRoute extends Route implements RouteObjectInterface
     {
         $pageModel->loadDetails();
 
-        $initialDefaults = [
-            '_token_check' => true,
-            '_controller' => 'Contao\FrontendIndex::renderPage',
-            '_scope' => ContaoCoreBundle::SCOPE_FRONTEND,
-            '_format' => 'html',
-            '_canonical_route' => 'tl_page.'.$pageModel->id,
-        ];
-
-        if ($pageModel->rootLanguage) {
-            $initialDefaults['_locale'] = LocaleUtil::formatAsLocale($pageModel->rootLanguage);
-        }
-
-        $defaults = array_merge($initialDefaults, $defaults);
+        $defaults = array_merge(
+            [
+                '_token_check' => true,
+                '_controller' => 'Contao\FrontendIndex::renderPage',
+                '_scope' => ContaoCoreBundle::SCOPE_FRONTEND,
+                '_locale' => LocaleUtil::formatAsLocale($pageModel->rootLanguage),
+                '_format' => 'html',
+                '_canonical_route' => 'tl_page.'.$pageModel->id,
+            ],
+            $defaults
+        );
 
         // Always use the given page model in the defaults
         $defaults['pageModel'] = $pageModel;

--- a/core-bundle/src/Routing/Route404Provider.php
+++ b/core-bundle/src/Routing/Route404Provider.php
@@ -156,14 +156,11 @@ class Route404Provider extends AbstractPageRouteProvider
             '_token_check' => true,
             '_controller' => 'Contao\FrontendIndex::renderPage',
             '_scope' => ContaoCoreBundle::SCOPE_FRONTEND,
+            '_locale' => LocaleUtil::formatAsLocale($page->rootLanguage),
             '_format' => 'html',
             '_canonical_route' => 'tl_page.'.$page->id,
             'pageModel' => $page,
         ];
-
-        if ($page->rootLanguage) {
-            $defaults['_locale'] = LocaleUtil::formatAsLocale($page->rootLanguage);
-        }
 
         $requirements = ['_url_fragment' => '.*'];
         $path = '/{_url_fragment}';

--- a/core-bundle/tests/Routing/Page/PageRouteTest.php
+++ b/core-bundle/tests/Routing/Page/PageRouteTest.php
@@ -83,11 +83,11 @@ class PageRouteTest extends TestCase
     {
         $route = new PageRoute($this->mockPageModel());
 
-        $this->assertSame('xy', $route->getDefault('_locale'));
+        $this->assertSame('xx', $route->getDefault('_locale'));
 
-        $route = new PageRoute($this->mockPageModel(['rootLanguage' => 'en']));
+        $route = new PageRoute($this->mockPageModel(['rootLanguage' => 'en-US']));
 
-        $this->assertSame('en', $route->getDefault('_locale'));
+        $this->assertSame('en_US', $route->getDefault('_locale'));
     }
 
     public function testSetsPageDomainAsRouteHost(): void
@@ -121,7 +121,7 @@ class PageRouteTest extends TestCase
                     'id' => 17,
                     'alias' => 'bar',
                     'domain' => 'www.example.com',
-                    'rootLanguage' => 'xy',
+                    'rootLanguage' => 'xx',
                     'rootUseSSL' => '1',
                     'urlPrefix' => 'foo',
                     'urlSuffix' => '.baz',

--- a/core-bundle/tests/Routing/Route404ProviderTest.php
+++ b/core-bundle/tests/Routing/Route404ProviderTest.php
@@ -209,6 +209,7 @@ class Route404ProviderTest extends TestCase
                 'type' => 'error_404',
                 'domain' => 'example.com',
                 'rootUseSSL' => true,
+                'rootLanguage' => 'en',
             ]
         );
 


### PR DESCRIPTION
see https://github.com/contao/contao/pull/3506#pullrequestreview-771748070

FYI the `xx` is the official short code for an unknown language. The tests now also actually test the locale is correctly converted 😬 