### PR TITLE
Do not throw an exception if a theme path contains an underscore

### DIFF
--- a/core-bundle/src/Twig/Loader/ContaoFilesystemLoader.php
+++ b/core-bundle/src/Twig/Loader/ContaoFilesystemLoader.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Twig\Loader;
 
+use Contao\CoreBundle\Exception\InvalidThemePathException;
 use Contao\CoreBundle\Twig\ContaoTwigUtil;
 use Contao\CoreBundle\Twig\Inheritance\TemplateHierarchyInterface;
 use Psr\Cache\CacheItemPoolInterface;
@@ -440,6 +441,13 @@ class ContaoFilesystemLoader extends FilesystemLoader implements TemplateHierarc
             return $this->currentThemeSlug = false;
         }
 
-        return $this->currentThemeSlug = $this->themeNamespace->generateSlug(Path::makeRelative($path, 'templates'));
+        // TODO: remove try/catch block in Contao 5.0
+        try {
+            $slug = $this->themeNamespace->generateSlug(Path::makeRelative($path, 'templates'));
+        } catch (InvalidThemePathException $e) {
+            $slug = false;
+        }
+
+        return $this->currentThemeSlug = $slug;
     }
 }


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #3558
| Docs PR or issue | -

We must also catch the `InvalidThemePathException` in the `ContaoFilesystemLoader`. No deprecation warning needed here as it will already be triggered in the `TemplateLocator`.
