### PR TITLE
Correctly filter the root nodes in the extended tree view

### DIFF
--- a/core-bundle/src/Resources/contao/dca/tl_page.php
+++ b/core-bundle/src/Resources/contao/dca/tl_page.php
@@ -83,7 +83,7 @@ $GLOBALS['TL_DCA']['tl_page'] = array
 		'sorting' => array
 		(
 			'mode'                    => 5,
-			'showRootTrails' 	      => true,
+			'showRootTrails'          => true,
 			'icon'                    => 'pagemounts.svg',
 			'paste_button_callback'   => array('tl_page', 'pastePage'),
 			'panelLayout'             => 'filter;search'

--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -3837,7 +3837,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 	protected function generateTree($table, $id, $arrPrevNext, $blnHasSorting, $intMargin=0, $arrClipboard=null, $blnCircularReference=false, $protectedPage=false, $blnNoRecursion=false, $arrFound=array())
 	{
 		// Must be either visible in the root trail or allowed by permissions (or their children)
-		if (!\in_array($id, $this->visibleRootTrails) && !\in_array($id, $this->root) && !\in_array($id, $this->rootChildren))
+		if (($GLOBALS['TL_DCA'][$table]['list']['sorting']['showRootTrails'] ?? null) &&!\in_array($id, $this->visibleRootTrails) && !\in_array($id, $this->root) && !\in_array($id, $this->rootChildren))
 		{
 			return '';
 		}


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #3391
| Docs PR or issue | -

I have noticed that the changes from #3391 make some articles disappear:

<img width="690" alt="" src="https://user-images.githubusercontent.com/1192057/136533998-effabae9-4b7a-48a7-bfb9-d7d9f752ce39.png">

Here is how it should look:

<img width="619" alt="" src="https://user-images.githubusercontent.com/1192057/136534072-a4ba6dd2-d7ec-4d24-b0d9-3758aa52df87.png">

@Toflar Can you please confirm that the fix is correct? And could we not omit the check entirely for admins?
