### PR TITLE
Correctly check for tinyMCE

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Widget.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Widget.php
@@ -1278,7 +1278,8 @@ abstract class Widget extends Controller
 
 		if (!isset($arrAttributes['allowHtml']))
 		{
-			$arrAttributes['allowHtml'] = \in_array($arrData['eval']['rte'] ?? null, array('tinyMCE', 'ace|html'), true);
+			$rte = $arrData['eval']['rte'] ?? '';
+			$arrAttributes['allowHtml'] = 'ace|html' === $rte || 0 === strpos($rte, 'tiny');
 		}
 
 		// Decode entities if HTML is allowed


### PR DESCRIPTION
The changes in https://github.com/contao/contao/pull/3513/files#diff-785aa5fc38b938ea78f20ed7b0b939f04b0ccdc803a0c5545a6f4da8e5215038R1281 do not correctly work if a custom tinyMCE template (e.g. `tinyNews`, `tinyMCExy`) is used.