### PR TITLE
Correctly format the locale for legacy requests

### DIFF
--- a/core-bundle/src/Routing/Matcher/LegacyMatcher.php
+++ b/core-bundle/src/Routing/Matcher/LegacyMatcher.php
@@ -14,6 +14,7 @@ namespace Contao\CoreBundle\Routing\Matcher;
 
 use Contao\Config;
 use Contao\CoreBundle\Framework\ContaoFramework;
+use Contao\CoreBundle\Util\LocaleUtil;
 use Contao\Input;
 use Contao\PageModel;
 use Contao\System;
@@ -75,7 +76,7 @@ class LegacyMatcher implements RequestMatcherInterface
         try {
             $match = $this->requestMatcher->matchRequest($request);
             $fragments = $this->createFragmentsFromMatch($match);
-            $locale = $match['_locale'] ?? null;
+            $locale = isset($match['_locale']) ? LocaleUtil::formatAsLanguageTag($match['_locale']) : null;
         } catch (ResourceNotFoundException $e) {
             // continue and parse fragments from path
         }


### PR DESCRIPTION
When parsing a path like `de-DE/foo/bar`, the `$locale` variable is used to re-build a path from hook fragments. If a request can be matched, the `_locale` parameter is incorrectly formatted and re-builds the path as `de_DE/foo/bar` without this fix.