### PR TITLE
Do not boot the Contao framework during cache warmup

### DIFF
--- a/core-bundle/src/Resources/config/services.yml
+++ b/core-bundle/src/Resources/config/services.yml
@@ -929,7 +929,7 @@ services:
             - '%kernel.bundles%'
             - '%kernel.bundles_metadata%'
             - '@Contao\CoreBundle\Twig\Loader\ThemeNamespace'
-            - '@contao.framework'
+            - '@database_connection'
 
     Contao\CoreBundle\Twig\Loader\FailTolerantFilesystemLoader:
         arguments:

--- a/core-bundle/src/Twig/Loader/TemplateLocator.php
+++ b/core-bundle/src/Twig/Loader/TemplateLocator.php
@@ -68,9 +68,9 @@ class TemplateLocator
         // This code might run early during cache warmup where the 'tl_theme'
         // table couldn't exist, yet.
         try {
-            // Note: we cannot use models or other parts of the Contao
-            //       framework here because this function will be called
-            //       during cache warmup (see #3567)
+            // Note: We cannot use models or other parts of the Contao
+            // framework here because this function will be called when the
+            // container is built (see #3567)
             $themePaths = $this->connection->fetchFirstColumn('SELECT templates FROM tl_theme');
         } catch (TableNotFoundException $e) {
             return [];

--- a/core-bundle/src/Twig/Loader/TemplateLocator.php
+++ b/core-bundle/src/Twig/Loader/TemplateLocator.php
@@ -13,9 +13,8 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Twig\Loader;
 
 use Contao\CoreBundle\Exception\InvalidThemePathException;
-use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\CoreBundle\HttpKernel\Bundle\ContaoModuleBundle;
-use Contao\ThemeModel;
+use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception\TableNotFoundException;
 use Symfony\Component\Finder\Finder;
 use Webmozart\PathUtil\Path;
@@ -46,17 +45,17 @@ class TemplateLocator
     private $themeNamespace;
 
     /**
-     * @var ContaoFramework
+     * @var Connection
      */
-    private $framework;
+    private $connection;
 
-    public function __construct(string $projectDir, array $bundles, array $bundlesMetadata, ThemeNamespace $themeNamespace, ContaoFramework $framework)
+    public function __construct(string $projectDir, array $bundles, array $bundlesMetadata, ThemeNamespace $themeNamespace, Connection $connection)
     {
         $this->projectDir = $projectDir;
         $this->bundles = $bundles;
         $this->bundlesMetadata = $bundlesMetadata;
         $this->themeNamespace = $themeNamespace;
-        $this->framework = $framework;
+        $this->connection = $connection;
     }
 
     /**
@@ -64,27 +63,26 @@ class TemplateLocator
      */
     public function findThemeDirectories(): array
     {
-        $this->framework->initialize();
-
-        /** @var ThemeModel $themeAdapter */
-        $themeAdapter = $this->framework->getAdapter(ThemeModel::class);
         $directories = [];
 
         // This code might run early during cache warmup where the 'tl_theme'
         // table couldn't exist, yet.
         try {
-            $themes = $themeAdapter->findAll() ?? [];
+            // Note: we cannot use models or other parts of the Contao
+            //       framework here because this function will be called
+            //       during cache warmup (see #3567)
+            $themePaths = $this->connection->fetchFirstColumn('SELECT templates FROM tl_theme');
         } catch (TableNotFoundException $e) {
             return [];
         }
 
-        foreach ($themes as $theme) {
-            if (!is_dir($absolutePath = Path::join($this->projectDir, $theme->templates))) {
+        foreach ($themePaths as $themePath) {
+            if (!is_dir($absolutePath = Path::join($this->projectDir, $themePath))) {
                 continue;
             }
 
             try {
-                $slug = $this->themeNamespace->generateSlug(Path::makeRelative($theme->templates, 'templates'));
+                $slug = $this->themeNamespace->generateSlug(Path::makeRelative($themePath, 'templates'));
             } catch (InvalidThemePathException $e) {
                 trigger_deprecation('contao/core-bundle', '4.12', 'Using a theme path with invalid characters has been deprecated and will throw an exception in Contao 5.0.');
 

--- a/core-bundle/tests/Twig/Inheritance/InheritanceTest.php
+++ b/core-bundle/tests/Twig/Inheritance/InheritanceTest.php
@@ -19,8 +19,7 @@ use Contao\CoreBundle\Twig\Loader\ContaoFilesystemLoader;
 use Contao\CoreBundle\Twig\Loader\ContaoFilesystemLoaderWarmer;
 use Contao\CoreBundle\Twig\Loader\TemplateLocator;
 use Contao\CoreBundle\Twig\Loader\ThemeNamespace;
-use Contao\Model\Collection;
-use Contao\ThemeModel;
+use Doctrine\DBAL\Connection;
 use OutOfBoundsException;
 use Symfony\Component\Cache\Adapter\NullAdapter;
 use Twig\Environment;
@@ -94,21 +93,15 @@ class InheritanceTest extends TestCase
             array_fill(0, \count($bundlesMetadata), ContaoModuleBundle::class)
         );
 
-        $themeAdapter = $this->mockAdapter(['findAll']);
-        $themeAdapter
-            ->method('findAll')
-            ->willReturn(
-                new Collection(
-                    [$this->mockClassWithProperties(ThemeModel::class, ['templates' => 'templates/my/theme'])],
-                    'tl_theme'
-                )
-            )
+        $connection = $this->createMock(Connection::class);
+        $connection
+            ->method('fetchFirstColumn')
+            ->willReturn(['templates/my/theme'])
         ;
 
-        $framework = $this->mockContaoFramework([ThemeModel::class => $themeAdapter]);
         $themeNamespace = new ThemeNamespace();
 
-        $templateLocator = new TemplateLocator($projectDir, $bundles, $bundlesMetadata, $themeNamespace, $framework);
+        $templateLocator = new TemplateLocator($projectDir, $bundles, $bundlesMetadata, $themeNamespace, $connection);
         $loader = new ContaoFilesystemLoader(new NullAdapter(), $templateLocator, $themeNamespace, $projectDir);
 
         $warmer = new ContaoFilesystemLoaderWarmer($loader, $templateLocator, $projectDir, 'prod');

--- a/core-bundle/tests/Twig/Loader/ContaoFilesystemLoaderTest.php
+++ b/core-bundle/tests/Twig/Loader/ContaoFilesystemLoaderTest.php
@@ -18,8 +18,7 @@ use Contao\CoreBundle\Twig\Loader\ContaoFilesystemLoader;
 use Contao\CoreBundle\Twig\Loader\ContaoFilesystemLoaderWarmer;
 use Contao\CoreBundle\Twig\Loader\TemplateLocator;
 use Contao\CoreBundle\Twig\Loader\ThemeNamespace;
-use Contao\Model\Collection;
-use Contao\ThemeModel;
+use Doctrine\DBAL\Connection;
 use Symfony\Component\Cache\Adapter\AdapterInterface;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\NullAdapter;
@@ -610,19 +609,10 @@ class ContaoFilesystemLoaderTest extends TestCase
 
     private function getTemplateLocator(string $projectDir = '/', array $themePaths = [], array $bundles = [], array $bundlesMetadata = []): TemplateLocator
     {
-        $themeModels = array_map(
-            function (string $path) {
-                return $this->mockClassWithProperties(ThemeModel::class, [
-                    'templates' => $path,
-                ]);
-            },
-            $themePaths
-        );
-
-        $themeAdapter = $this->mockAdapter(['findAll']);
-        $themeAdapter
-            ->method('findAll')
-            ->willReturn(empty($themePaths) ? null : new Collection($themeModels, 'tl_theme'))
+        $connection = $this->createMock(Connection::class);
+        $connection
+            ->method('fetchFirstColumn')
+            ->willReturn($themePaths)
         ;
 
         return new TemplateLocator(
@@ -630,7 +620,7 @@ class ContaoFilesystemLoaderTest extends TestCase
             $bundles,
             $bundlesMetadata,
             new ThemeNamespace(),
-            $this->mockContaoFramework([ThemeModel::class => $themeAdapter])
+            $connection
         );
     }
 


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #3567
| Docs PR or issue | -

This PR exchanges the use of the Contao framework in `TemplateLocator#findThemeDirectories()` with a bare database connection. This way we do not need to boot the framework which unfortunately cannot be done in a non-request context.
