### PR TITLE
Handle invalid accept-language headers

### DIFF
--- a/core-bundle/src/Routing/AbstractPageRouteProvider.php
+++ b/core-bundle/src/Routing/AbstractPageRouteProvider.php
@@ -202,7 +202,10 @@ abstract class AbstractPageRouteProvider implements RouteProviderInterface
         $result = [];
 
         foreach ($languages as $language) {
-            $locales = LocaleUtil::getFallbacks($language);
+            if (!$locales = LocaleUtil::getFallbacks($language)) {
+                continue;
+            }
+
             $language = array_pop($locales);
             $result[] = $language;
 

--- a/core-bundle/src/Util/LocaleUtil.php
+++ b/core-bundle/src/Util/LocaleUtil.php
@@ -61,6 +61,8 @@ class LocaleUtil
 
         if (isset($data[\Locale::LANG_TAG])) {
             $result[] = $data[\Locale::LANG_TAG];
+        } else {
+            $data[\Locale::LANG_TAG] = '';
         }
 
         if (isset($data[\Locale::REGION_TAG])) {

--- a/core-bundle/src/Util/LocaleUtil.php
+++ b/core-bundle/src/Util/LocaleUtil.php
@@ -56,6 +56,10 @@ class LocaleUtil
             return self::$fallbacks[$locale];
         }
 
+        if ('' === $locale) {
+            return [];
+        }
+
         $result = [];
         $data = \Locale::parseLocale($locale);
 

--- a/core-bundle/src/Util/LocaleUtil.php
+++ b/core-bundle/src/Util/LocaleUtil.php
@@ -56,8 +56,12 @@ class LocaleUtil
             return self::$fallbacks[$locale];
         }
 
+        $result = [];
         $data = \Locale::parseLocale($locale);
-        $result = [$data[\Locale::LANG_TAG]];
+
+        if (isset($data[\Locale::LANG_TAG])) {
+            $result[] = $data[\Locale::LANG_TAG];
+        }
 
         if (isset($data[\Locale::REGION_TAG])) {
             $result[] = $data[\Locale::LANG_TAG].'_'.$data[\Locale::REGION_TAG];

--- a/core-bundle/tests/Util/LocaleUtilTest.php
+++ b/core-bundle/tests/Util/LocaleUtilTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\Util;
+
+use Contao\CoreBundle\Tests\TestCase;
+use Contao\CoreBundle\Util\LocaleUtil;
+
+class LocaleUtilTest extends TestCase
+{
+    /**
+     * @dataProvider getFallbacks
+     */
+    public function testGetFallbacks(string $locale, array $expected): void
+    {
+        $this->assertSame($expected, LocaleUtil::getFallbacks($locale));
+        $this->assertSame($expected, LocaleUtil::getFallbacks(strtolower($locale)));
+        $this->assertSame($expected, LocaleUtil::getFallbacks(strtoupper($locale)));
+        $this->assertSame($expected, LocaleUtil::getFallbacks(str_replace('_', '-', $locale)));
+    }
+
+    public function getFallbacks(): \Generator
+    {
+        yield ['de', ['de']];
+        yield ['de_DE', ['de', 'de_DE']];
+        yield ['zh_Hant_TW', ['zh', 'zh_TW', 'zh_Hant', 'zh_Hant_TW']];
+        yield ['', []];
+        yield ['_', []];
+        yield ['__', []];
+        yield ['und', []];
+        yield ['und_DE', ['_DE']];
+        yield ['und_Hant', ['_Hant']];
+        yield ['und_Hant_TW', ['_TW', '_Hant', '_Hant_TW']];
+        yield ['0', ['0']];
+        yield ['00', ['00']];
+        yield ['_00', ['_00']];
+        yield ['_000', ['_000']];
+    }
+}


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | -
| Docs PR or issue | -

If the accept language header contains an invalid locale, e.g. `en,en-US;q=0.9,pt-BR;q=0.8,pt;q=0.7,und;q=0.6`, `Request::getLanguages()` will return:

```php
[
  0 => "de"
  1 => "de_DE"
  2 => "pt_BR"
  3 => "pt"
  4 => "und"
]
```

This array will be passed to our `AbstractPageRouteProvider::convertLanguagesForSorting()` method and the method then calls `LocaleUtil::getFallbacks()` with every given locale. The latter returns an empty array for `und`, which triggers an `Warning: Undefined array key "language"` warning here:

https://github.com/contao/contao/blob/cbead7bbe42c47206f05cd237ee25fc79140d0a1/core-bundle/src/Util/LocaleUtil.php#L59-L60

The `$result` variable of the `convertLanguagesForSorting()` method is then compiled as:

```php
[
  0 => "de"
  1 => "de_DE"
  2 => "pt_BR"
  3 => "pt"
  4 => "pt"
  5 => null
]
```

This triggers a `Warning: array_flip(): Can only flip string and integer values, entry skipped` warning here:

https://github.com/contao/contao/blob/cbead7bbe42c47206f05cd237ee25fc79140d0a1/core-bundle/src/Routing/AbstractPageRouteProvider.php#L216

The PR should fix both, although I am not 100% sure if the changes are correct. @ausi /cc