### PR TITLE
Upgrade codecov/codecov-action to v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,9 +34,9 @@ jobs:
               run: php -d pcov.enabled=1 vendor/bin/phpunit --testsuite=coverage --coverage-clover=clover.xml --colors=always
 
             - name: Upload the coverage report
-              uses: codecov/codecov-action@v1
+              uses: codecov/codecov-action@v2
               with:
-                  file: ./clover.xml
+                  files: ./clover.xml
                   fail_ci_if_error: true
 
     coding-style:


### PR DESCRIPTION
Because of https://about.codecov.io/blog/codecov-uploader-deprecation-plan/