### PR TITLE
Fix link_url::back insert tag backwards compatibility

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/InsertTags.php
+++ b/core-bundle/src/Resources/contao/library/Contao/InsertTags.php
@@ -386,8 +386,10 @@ class InsertTags extends Controller
 					// Back link
 					if ($elements[1] == 'back')
 					{
+						@trigger_error('Using the link::back insert tag has been deprecated and will no longer work in Contao 5.0.', E_USER_DEPRECATED);
+
 						$strUrl = 'javascript:history.go(-1)';
-						$strTitle = $GLOBALS['TL_LANG']['MSC']['goBack'];
+						$strTitle = $GLOBALS['TL_LANG']['MSC']['goBack'] ?? null;
 
 						// No language files if the page is cached
 						if (!$strTitle)
@@ -1261,12 +1263,16 @@ class InsertTags extends Controller
 			// Add the urlattr insert tags flag in URL attributes
 			if (\in_array(strtolower($matches[1][0]), array('src', 'srcset', 'href', 'action', 'formaction', 'codebase', 'cite', 'background', 'longdesc', 'profile', 'usemap', 'classid', 'data', 'icon', 'manifest', 'poster', 'archive'), true))
 			{
-				$attributesResult .= preg_replace('/(?:\|(?:url)?attr)?}}/', '|urlattr}}', $matches[0][0]);
+				$matches[0][0] = preg_replace('/(?:\|(?:url)?attr)?}}/', '|urlattr}}', $matches[0][0]);
+
+				// Backwards compatibility
+				if (trim($matches[0][0]) === 'href="{{link_url::back|urlattr}}"')
+				{
+					$matches[0][0] = str_replace('{{link_url::back|urlattr}}', '{{link_url::back}}', $matches[0][0]);
+				}
 			}
-			else
-			{
-				$attributesResult .= $matches[0][0];
-			}
+
+			$attributesResult .= $matches[0][0];
 		}
 
 		$attributesResult .= substr($attributes, $offset);

--- a/core-bundle/tests/Contao/InsertTagsTest.php
+++ b/core-bundle/tests/Contao/InsertTagsTest.php
@@ -103,6 +103,21 @@ class InsertTagsTest extends TestCase
             '<span title="" &quot;>',
         ];
 
+        yield 'Link URL back backwards compatibility' => [
+            '<a href="{{link_url::back}}">',
+            '<a href="javascript:history.go(-1)">',
+        ];
+
+        yield 'Trick link URL back' => [
+            '<a href="{{link_url::back}},alert(1)">',
+            '<a href="javascript%3Ahistory.go(-1),alert(1)">',
+        ];
+
+        yield 'Trick link URL back without quotes' => [
+            '<a href={{link_url::back}}>',
+            '<a href=javascript%3Ahistory.go(-1)>',
+        ];
+
         yield 'Trick tag detection' => [
             '<span title=">" class=\'{{plain::"}}\'>',
             '<span title=">" class=\'&quot;\'>',


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #3364
| Docs PR or issue | contao/docs#859

Alternative to #3424 implementation as discussed in https://github.com/contao/contao/pull/3424#issuecomment-931327626