### PR TITLE
Adjust cache headers for Twig responses

### DIFF
--- a/core-bundle/src/Controller/AbstractFragmentController.php
+++ b/core-bundle/src/Controller/AbstractFragmentController.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Controller;
 
+use Contao\CoreBundle\EventListener\SubrequestCacheSubscriber;
 use Contao\CoreBundle\Fragment\FragmentOptionsAwareInterface;
 use Contao\CoreBundle\Routing\ScopeMatcher;
 use Contao\FrontendTemplate;
@@ -21,6 +22,7 @@ use Contao\StringUtil;
 use Contao\Template;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Response;
 
 abstract class AbstractFragmentController extends AbstractController implements FragmentOptionsAwareInterface
 {
@@ -153,5 +155,16 @@ abstract class AbstractFragmentController extends AbstractController implements 
         }
 
         return Container::underscore($className);
+    }
+
+    protected function render(string $view, array $parameters = [], Response $response = null): Response
+    {
+        $response = parent::render($view, $parameters, $response);
+
+        // Mark this response to affect the caching of the current page but remove any default cache headers
+        $response->headers->set(SubrequestCacheSubscriber::MERGE_CACHE_HEADER, true);
+        $response->headers->remove('Cache-Control');
+
+        return $response;
     }
 }


### PR DESCRIPTION
If a developer uses `$this->render()` to generate the response from Twig, the response contains incorrect `private` cache header that destroy the page cache.

related to #3263