### PR TITLE
Introduce finalize method for Widget

### DIFF
--- a/comments-bundle/src/Resources/contao/classes/Comments.php
+++ b/comments-bundle/src/Resources/contao/classes/Comments.php
@@ -267,7 +267,7 @@ class Comments extends Frontend
 			// Validate the widget
 			if (Input::post('FORM_SUBMIT') == $strFormId)
 			{
-				$objWidget->validate();
+				$objWidget->validate(false);
 
 				if ($objWidget->hasErrors())
 				{
@@ -276,6 +276,18 @@ class Comments extends Frontend
 			}
 
 			$arrWidgets[$arrField['name']] = $objWidget;
+		}
+
+		// Finalize form widgets (#1185)
+		if (!$doNotSubmit && Input::post('FORM_SUBMIT') == $strFormId)
+		{
+			foreach ($arrWidgets as $objWidget)
+			{
+				if ($objWidget instanceof FinalizableWidgetInterface)
+				{
+					$objWidget->finalize();
+				}
+			}
 		}
 
 		$objTemplate->fields = $arrWidgets;

--- a/core-bundle/src/Resources/contao/forms/Form.php
+++ b/core-bundle/src/Resources/contao/forms/Form.php
@@ -264,7 +264,7 @@ class Form extends Hybrid
 			// Finalize form widgets (#1185)
 			foreach ($arrWidgets as $objWidget)
 			{
-				if ($objWidget instanceof FinalizableWidget)
+				if ($objWidget instanceof FinalizableWidgetInterface)
 				{
 					$objWidget->finalize();
 				}

--- a/core-bundle/src/Resources/contao/forms/Form.php
+++ b/core-bundle/src/Resources/contao/forms/Form.php
@@ -117,6 +117,7 @@ class Form extends Hybrid
 
 		// Get all form fields
 		$arrFields = array();
+		$arrWidgets = array();
 		$objFields = FormFieldModel::findPublishedByPid($this->id);
 
 		if ($objFields !== null)
@@ -203,10 +204,13 @@ class Form extends Hybrid
 					}
 				}
 
+				$arrWidgets[] = $objWidget;
+
 				// Validate the input
 				if (Input::post('FORM_SUBMIT') == $formId)
 				{
-					$objWidget->validate();
+					// Do not finalize widget during validation (#1185)
+					$objWidget->validate(false);
 
 					// HOOK: validate form field callback
 					if (isset($GLOBALS['TL_HOOKS']['validateFormField']) && \is_array($GLOBALS['TL_HOOKS']['validateFormField']))
@@ -257,6 +261,15 @@ class Form extends Hybrid
 		// Process the form data
 		if (!$doNotSubmit && Input::post('FORM_SUBMIT') == $formId)
 		{
+			// Finalize form widgets (#1185)
+			foreach ($arrWidgets as $objWidget)
+			{
+				if ($objWidget instanceof FinalizableWidget)
+				{
+					$objWidget->finalize();
+				}
+			}
+
 			$this->processFormData($arrSubmitted, $arrLabels, $arrFields);
 		}
 

--- a/core-bundle/src/Resources/contao/forms/FormFileUpload.php
+++ b/core-bundle/src/Resources/contao/forms/FormFileUpload.php
@@ -10,8 +10,6 @@
 
 namespace Contao;
 
-use Contao\CoreBundle\Monolog\ContaoContext;
-
 /**
  * Class FormFileUpload
  *

--- a/core-bundle/src/Resources/contao/forms/FormFileUpload.php
+++ b/core-bundle/src/Resources/contao/forms/FormFileUpload.php
@@ -26,7 +26,7 @@ use Contao\CoreBundle\Monolog\ContaoContext;
  *
  * @todo Rename to FormUpload in Contao 5.0
  */
-class FormFileUpload extends Widget implements UploadableWidgetInterface, FinalizableWidget
+class FormFileUpload extends Widget implements UploadableWidgetInterface, FinalizableWidgetInterface
 {
 	/**
 	 * Template

--- a/core-bundle/src/Resources/contao/library/Contao/FinalizableWidget.php
+++ b/core-bundle/src/Resources/contao/library/Contao/FinalizableWidget.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao;
+
+/**
+ * Widget can be finalized after all other widgets were validated.
+ */
+interface FinalizableWidget
+{
+	public function finalize(): void;
+}

--- a/core-bundle/src/Resources/contao/library/Contao/FinalizableWidgetInterface.php
+++ b/core-bundle/src/Resources/contao/library/Contao/FinalizableWidgetInterface.php
@@ -11,9 +11,9 @@
 namespace Contao;
 
 /**
- * Widget can be finalized after all other widgets were validated.
+ * Widget can be finalized after a form was submitted and all other widgets of a form were validated.
  */
-interface FinalizableWidget
+interface FinalizableWidgetInterface
 {
 	public function finalize(): void;
 }

--- a/core-bundle/src/Resources/contao/library/Contao/Widget.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Widget.php
@@ -755,7 +755,7 @@ abstract class Widget extends Controller
 		{
 			@trigger_error('Finalizing a widget during Widget::validate() has been deprecated and will no longer work in Contao 5.0.', E_USER_DEPRECATED);
 
-			if ($this instanceof FinalizableWidget)
+			if ($this instanceof FinalizableWidgetInterface)
 			{
 				$this->finalize();
 			}

--- a/core-bundle/src/Resources/contao/library/Contao/Widget.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Widget.php
@@ -753,10 +753,10 @@ abstract class Widget extends Controller
 
 		if ($blnFinalize)
 		{
-			@trigger_error('Finalizing a widget during Widget::validate() has been deprecated and will no longer work in Contao 5.0.', E_USER_DEPRECATED);
-
 			if ($this instanceof FinalizableWidgetInterface)
 			{
+				@trigger_error('Finalizing a widget during Widget::validate() has been deprecated and will no longer work in Contao 5.0. Use Widget::validate(false) and Widget::finalize() instead.', E_USER_DEPRECATED);
+
 				$this->finalize();
 			}
 		}

--- a/core-bundle/src/Resources/contao/library/Contao/Widget.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Widget.php
@@ -730,8 +730,10 @@ abstract class Widget extends Controller
 
 	/**
 	 * Validate the user input and set the value
+	 *
+	 * @param bool $blnFinalize Whether to finalize a finalizable widget during validate
 	 */
-	public function validate()
+	public function validate(/* $blnFinalize = true */)
 	{
 		$varValue = $this->validator($this->getPost($this->strName));
 
@@ -741,6 +743,23 @@ abstract class Widget extends Controller
 		}
 
 		$this->varValue = $varValue;
+
+		$blnFinalize = true;
+
+		if (\func_num_args() > 0)
+		{
+			$blnFinalize = func_get_arg(0);
+		}
+
+		if ($blnFinalize)
+		{
+			@trigger_error('Finalizing a widget during Widget::validate() has been deprecated and will no longer work in Contao 5.0.', E_USER_DEPRECATED);
+
+			if ($this instanceof FinalizableWidget)
+			{
+				$this->finalize();
+			}
+		}
 	}
 
 	/**

--- a/core-bundle/src/Resources/contao/modules/ModuleChangePassword.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleChangePassword.php
@@ -149,7 +149,7 @@ class ModuleChangePassword extends Module
 			// Validate the widget
 			if (Input::post('FORM_SUBMIT') == $strFormId)
 			{
-				$objWidget->validate();
+				$objWidget->validate(false);
 
 				// Validate the old password
 				if ($strKey == 'oldPassword')

--- a/core-bundle/src/Resources/contao/modules/ModuleChangePassword.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleChangePassword.php
@@ -113,6 +113,7 @@ class ModuleChangePassword extends Module
 
 		/** @var FormPassword $objNewPassword */
 		$objNewPassword = null;
+		$arrWidgets = [];
 
 		// Initialize the widgets
 		foreach ($arrFields as $strKey=>$arrField)
@@ -169,6 +170,19 @@ class ModuleChangePassword extends Module
 			}
 
 			$strFields .= $objWidget->parse();
+			$arrWidgets[] = $objWidget;
+		}
+
+		// Finalize form widgets (#1185)
+		if (!$doNotSubmit && Input::post('FORM_SUBMIT') == $strFormId)
+		{
+			foreach ($arrWidgets as $objWidget)
+			{
+				if ($objWidget instanceof FinalizableWidgetInterface)
+				{
+					$objWidget->finalize();
+				}
+			}
 		}
 
 		$this->Template->fields = $strFields;

--- a/core-bundle/src/Resources/contao/modules/ModuleChangePassword.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleChangePassword.php
@@ -113,7 +113,7 @@ class ModuleChangePassword extends Module
 
 		/** @var FormPassword $objNewPassword */
 		$objNewPassword = null;
-		$arrWidgets = [];
+		$arrWidgets = array();
 
 		// Initialize the widgets
 		foreach ($arrFields as $strKey=>$arrField)

--- a/core-bundle/src/Resources/contao/modules/ModuleCloseAccount.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleCloseAccount.php
@@ -77,7 +77,7 @@ class ModuleCloseAccount extends Module
 		// Validate widget
 		if (Input::post('FORM_SUBMIT') == $strFormId)
 		{
-			$objWidget->validate();
+			$objWidget->validate(false);
 
 			$encoder = System::getContainer()->get('security.password_hasher_factory')->getEncoder(FrontendUser::class);
 

--- a/core-bundle/src/Resources/contao/modules/ModuleCloseAccount.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleCloseAccount.php
@@ -91,6 +91,11 @@ class ModuleCloseAccount extends Module
 			// Close account
 			if (!$objWidget->hasErrors())
 			{
+				if ($objWidget instanceof FinalizableWidgetInterface)
+				{
+					$objWidget->finalize();
+				}
+
 				// HOOK: send account ID
 				if (isset($GLOBALS['TL_HOOKS']['closeAccount']) && \is_array($GLOBALS['TL_HOOKS']['closeAccount']))
 				{

--- a/core-bundle/src/Resources/contao/modules/ModulePassword.php
+++ b/core-bundle/src/Resources/contao/modules/ModulePassword.php
@@ -137,7 +137,7 @@ class ModulePassword extends Module
 			// Validate the widget
 			if (Input::post('FORM_SUBMIT') == $strFormId)
 			{
-				$objWidget->validate();
+				$objWidget->validate(false);
 
 				if ($objWidget->hasErrors())
 				{
@@ -264,7 +264,7 @@ class ModulePassword extends Module
 		// Validate the field
 		if (Input::post('FORM_SUBMIT') && Input::post('FORM_SUBMIT') == $objSession->get('setPasswordToken'))
 		{
-			$objWidget->validate();
+			$objWidget->validate(false);
 
 			// Set the new password and redirect
 			if (!$objWidget->hasErrors())

--- a/core-bundle/src/Resources/contao/modules/ModulePassword.php
+++ b/core-bundle/src/Resources/contao/modules/ModulePassword.php
@@ -112,6 +112,7 @@ class ModulePassword extends Module
 		$strFields = '';
 		$doNotSubmit = false;
 		$strFormId = 'tl_lost_password_' . $this->id;
+		$arrWidgets = [];
 
 		// Initialize the widgets
 		foreach ($arrFields as $arrField)
@@ -145,6 +146,19 @@ class ModulePassword extends Module
 			}
 
 			$strFields .= $objWidget->parse();
+			$arrWidgets[] = $objWidget;
+		}
+
+		// Finalize form widgets (#1185)
+		if (!$doNotSubmit && Input::post('FORM_SUBMIT') == $strFormId)
+		{
+			foreach ($arrWidgets as $objWidget)
+			{
+				if ($objWidget instanceof FinalizableWidgetInterface)
+				{
+					$objWidget->finalize();
+				}
+			}
 		}
 
 		$this->Template->fields = $strFields;
@@ -255,6 +269,11 @@ class ModulePassword extends Module
 			// Set the new password and redirect
 			if (!$objWidget->hasErrors())
 			{
+				if ($objWidget instanceof FinalizableWidgetInterface)
+				{
+					$objWidget->finalize();
+				}
+
 				$objSession->set('setPasswordToken', '');
 
 				$objMember->tstamp = time();

--- a/core-bundle/src/Resources/contao/modules/ModulePassword.php
+++ b/core-bundle/src/Resources/contao/modules/ModulePassword.php
@@ -112,7 +112,7 @@ class ModulePassword extends Module
 		$strFields = '';
 		$doNotSubmit = false;
 		$strFormId = 'tl_lost_password_' . $this->id;
-		$arrWidgets = [];
+		$arrWidgets = array();
 
 		// Initialize the widgets
 		foreach ($arrFields as $arrField)

--- a/core-bundle/src/Resources/contao/modules/ModulePersonalData.php
+++ b/core-bundle/src/Resources/contao/modules/ModulePersonalData.php
@@ -98,7 +98,7 @@ class ModulePersonalData extends Module
 		$doNotSubmit = false;
 		$hasUpload = false;
 		$row = 0;
-		$arrWidgets = [];
+		$arrWidgets = array();
 
 		// Predefine the group order (other groups will be appended automatically)
 		$arrGroups = array

--- a/core-bundle/src/Resources/contao/modules/ModulePersonalData.php
+++ b/core-bundle/src/Resources/contao/modules/ModulePersonalData.php
@@ -98,6 +98,7 @@ class ModulePersonalData extends Module
 		$doNotSubmit = false;
 		$hasUpload = false;
 		$row = 0;
+		$arrWidgets = [];
 
 		// Predefine the group order (other groups will be appended automatically)
 		$arrGroups = array
@@ -312,6 +313,7 @@ class ModulePersonalData extends Module
 			}
 
 			$arrFields[$strGroup][$field] .= $temp;
+			$arrWidgets[] = $objWidget;
 
 			++$row;
 		}
@@ -334,6 +336,14 @@ class ModulePersonalData extends Module
 		// Redirect or reload if there was no error
 		if (!$doNotSubmit && Input::post('FORM_SUBMIT') == $strFormId)
 		{
+			foreach ($arrWidgets as $objWidget)
+			{
+				if ($objWidget instanceof FinalizableWidgetInterface)
+				{
+					$objWidget->finalize();
+				}
+			}
+
 			// HOOK: updated personal data
 			if (isset($GLOBALS['TL_HOOKS']['updatePersonalData']) && \is_array($GLOBALS['TL_HOOKS']['updatePersonalData']))
 			{

--- a/core-bundle/src/Resources/contao/modules/ModulePersonalData.php
+++ b/core-bundle/src/Resources/contao/modules/ModulePersonalData.php
@@ -210,7 +210,7 @@ class ModulePersonalData extends Module
 			// Validate the form data
 			if (Input::post('FORM_SUBMIT') == $strFormId)
 			{
-				$objWidget->validate();
+				$objWidget->validate(false);
 				$varValue = $objWidget->value;
 
 				$rgxp = $arrData['eval']['rgxp'] ?? null;

--- a/core-bundle/src/Resources/contao/modules/ModuleRegistration.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleRegistration.php
@@ -162,7 +162,7 @@ class ModuleRegistration extends Module
 		$arrFields = array();
 		$hasUpload = false;
 		$i = 0;
-		$arrWidgets = [];
+		$arrWidgets = array();
 
 		// Build the form
 		foreach ($this->editable as $field)

--- a/core-bundle/src/Resources/contao/modules/ModuleRegistration.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleRegistration.php
@@ -162,6 +162,7 @@ class ModuleRegistration extends Module
 		$arrFields = array();
 		$hasUpload = false;
 		$i = 0;
+		$arrWidgets = [];
 
 		// Build the form
 		foreach ($this->editable as $field)
@@ -313,6 +314,7 @@ class ModuleRegistration extends Module
 			}
 
 			$arrFields[$arrData['eval']['feGroup']][$field] .= $temp;
+			$arrWidgets[] = $objWidget;
 
 			++$i;
 		}
@@ -334,6 +336,14 @@ class ModuleRegistration extends Module
 		// Create new user if there are no errors
 		if (!$doNotSubmit && Input::post('FORM_SUBMIT') == $strFormId)
 		{
+			foreach ($arrWidgets as $objWidget)
+			{
+				if ($objWidget instanceof FinalizableWidgetInterface)
+				{
+					$objWidget->finalize();
+				}
+			}
+
 			$this->createNewUser($arrUser);
 		}
 

--- a/core-bundle/src/Resources/contao/modules/ModuleRegistration.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleRegistration.php
@@ -213,7 +213,7 @@ class ModuleRegistration extends Module
 			// Validate input
 			if (Input::post('FORM_SUBMIT') == $strFormId)
 			{
-				$objWidget->validate();
+				$objWidget->validate(false);
 
 				$varValue = $objWidget->value;
 				$encoder = System::getContainer()->get('security.password_hasher_factory')->getEncoder(FrontendUser::class);

--- a/core-bundle/tests/Contao/WidgetTest.php
+++ b/core-bundle/tests/Contao/WidgetTest.php
@@ -142,14 +142,14 @@ class WidgetTest extends TestCase
 
         $widget
             ->setInputCallback(static fn (): string => 'foobar')
-            ->validate()
+            ->validate(false)
         ;
 
         $this->assertSame('foobar', $widget->value);
 
         $widget
             ->setInputCallback(static fn () => null)
-            ->validate()
+            ->validate(false)
         ;
 
         $this->assertNull($widget->value);

--- a/core-bundle/tests/Contao/WidgetTest.php
+++ b/core-bundle/tests/Contao/WidgetTest.php
@@ -156,8 +156,8 @@ class WidgetTest extends TestCase
 
         $widget
             ->setInputCallback()
-            ->validate() // getPost() should be called once here
-;
+            ->validate(false) // getPost() should be called once here
+        ;
     }
 
     /**

--- a/newsletter-bundle/src/Resources/contao/modules/ModuleSubscribe.php
+++ b/newsletter-bundle/src/Resources/contao/modules/ModuleSubscribe.php
@@ -111,6 +111,11 @@ class ModuleSubscribe extends Module
 
 			if ($varSubmitted !== false)
 			{
+				if ($objWidget instanceof FinalizableWidgetInterface)
+				{
+					$objWidget->finalize();
+				}
+
 				$this->addRecipient(...$varSubmitted);
 			}
 		}

--- a/newsletter-bundle/src/Resources/contao/modules/ModuleSubscribe.php
+++ b/newsletter-bundle/src/Resources/contao/modules/ModuleSubscribe.php
@@ -313,7 +313,7 @@ class ModuleSubscribe extends Module
 		// Validate the captcha
 		if ($objWidget !== null)
 		{
-			$objWidget->validate();
+			$objWidget->validate(false);
 
 			if ($objWidget->hasErrors())
 			{

--- a/newsletter-bundle/src/Resources/contao/modules/ModuleUnsubscribe.php
+++ b/newsletter-bundle/src/Resources/contao/modules/ModuleUnsubscribe.php
@@ -102,6 +102,11 @@ class ModuleUnsubscribe extends Module
 
 			if ($varSubmitted !== false)
 			{
+				if ($objWidget instanceof FinalizableWidgetInterface)
+				{
+					$objWidget->finalize();
+				}
+
 				$this->removeRecipient(...$varSubmitted);
 			}
 		}

--- a/newsletter-bundle/src/Resources/contao/modules/ModuleUnsubscribe.php
+++ b/newsletter-bundle/src/Resources/contao/modules/ModuleUnsubscribe.php
@@ -222,7 +222,7 @@ class ModuleUnsubscribe extends Module
 		// Validate the captcha
 		if ($objWidget !== null)
 		{
-			$objWidget->validate();
+			$objWidget->validate(false);
 
 			if ($objWidget->hasErrors())
 			{


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #1185
| Docs PR or issue | https://github.com/contao/docs/pull/862

This PR introduces a `finalize` method for (front end) widgets, which will be executed by the form generator after all widgets were validated. This way the `FormFileUpload` widget will be able to process the uploaded file and move it to its final destination only if the form was submitted successfully.

_Note:_ the `method_exists` call is necessary since any registered form widgets do not really have to extend from `\Contao\Widget`.
