### PR TITLE
Inline fragments should not compile the front end template

### DIFF
--- a/core-bundle/src/Controller/AbstractFragmentController.php
+++ b/core-bundle/src/Controller/AbstractFragmentController.php
@@ -85,11 +85,11 @@ abstract class AbstractFragmentController extends AbstractController implements 
      */
     protected function createTemplate(Model $model, string $templateName): Template
     {
-        $request = $this->get('request_stack')->getCurrentRequest();
-
         if (isset($this->options['template'])) {
             $templateName = $this->options['template'];
         }
+
+        $request = $this->get('request_stack')->getCurrentRequest();
 
         if ($model->customTpl) {
             // Use the custom template unless it is a back end request

--- a/core-bundle/src/Controller/AbstractFragmentController.php
+++ b/core-bundle/src/Controller/AbstractFragmentController.php
@@ -86,8 +86,6 @@ abstract class AbstractFragmentController extends AbstractController implements 
     protected function createTemplate(Model $model, string $templateName): Template
     {
         $request = $this->get('request_stack')->getCurrentRequest();
-        $mainRequest = $this->get('request_stack')->getMasterRequest();
-        $templateClass = FragmentTemplate::class;
 
         if (isset($this->options['template'])) {
             $templateName = $this->options['template'];
@@ -100,9 +98,11 @@ abstract class AbstractFragmentController extends AbstractController implements 
             }
         }
 
+        $templateClass = FragmentTemplate::class;
+
         // Current request is the main request (e.g. ESI fragment), so we have to replace
-        // insert tags etc. on the template output.
-        if ($request === $mainRequest) {
+        // insert tags etc. on the template output
+        if ($request === $this->get('request_stack')->getMasterRequest()) {
             $templateClass = FrontendTemplate::class;
         }
 

--- a/core-bundle/src/Controller/AbstractFragmentController.php
+++ b/core-bundle/src/Controller/AbstractFragmentController.php
@@ -98,11 +98,13 @@ abstract class AbstractFragmentController extends AbstractController implements 
             }
         }
 
-        // Current request is the main request, which means this must be an ESI fragment
+        // Current request is the main request (e.g. ESI fragment), so we have to replace
+        // insert tags etc. on the template output.
         if ($request === $mainRequest) {
             $templateClass = FrontendTemplate::class;
         }
 
+        /** @var Template $template */
         $template = $this->get('contao.framework')->createInstance($templateClass, [$templateName]);
         $template->setData($model->row());
 

--- a/core-bundle/src/Resources/contao/classes/FragmentTemplate.php
+++ b/core-bundle/src/Resources/contao/classes/FragmentTemplate.php
@@ -36,5 +36,3 @@ class FragmentTemplate extends FrontendTemplate
 		$this->strBuffer = $this->parse();
 	}
 }
-
-class_alias(FragmentTemplate::class, 'FragmentTemplate');

--- a/core-bundle/src/Resources/contao/classes/FragmentTemplate.php
+++ b/core-bundle/src/Resources/contao/classes/FragmentTemplate.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao;
+
+use Contao\CoreBundle\EventListener\SubrequestCacheSubscriber;
+use Symfony\Component\HttpFoundation\Response;
+
+class FragmentTemplate extends FrontendTemplate
+{
+	/**
+	 * Return a response object
+	 *
+	 * @return Response The response object
+	 */
+	public function getResponse($blnCheckRequest=false, $blnForceCacheHeaders=false)
+	{
+		$response = parent::getResponse();
+
+		// Mark this response to affect the caching of the current page but remove any default cache headers
+		$response->headers->set(SubrequestCacheSubscriber::MERGE_CACHE_HEADER, true);
+		$response->headers->remove('Cache-Control');
+
+		return $response;
+	}
+
+	protected function compile()
+	{
+		$this->strBuffer = $this->parse();
+	}
+}
+
+class_alias(FragmentTemplate::class, 'FragmentTemplate');

--- a/core-bundle/src/Resources/contao/library/Contao/Template.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Template.php
@@ -321,10 +321,6 @@ abstract class Template extends Controller
 		$response = new Response($this->strBuffer);
 		$response->headers->set('Content-Type', $this->strContentType . '; charset=' . Config::get('characterSet'));
 
-		// Mark this response to affect the caching of the current page but remove any default cache headers
-		$response->headers->set(SubrequestCacheSubscriber::MERGE_CACHE_HEADER, true);
-		$response->headers->remove('Cache-Control');
-
 		return $response;
 	}
 

--- a/core-bundle/src/Resources/contao/library/Contao/Template.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Template.php
@@ -10,7 +10,6 @@
 
 namespace Contao;
 
-use Contao\CoreBundle\EventListener\SubrequestCacheSubscriber;
 use MatthiasMullie\Minify;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\VarDumper\VarDumper;

--- a/core-bundle/tests/Controller/ContentElement/ContentElementControllerTest.php
+++ b/core-bundle/tests/Controller/ContentElement/ContentElementControllerTest.php
@@ -36,6 +36,7 @@ class ContentElementControllerTest extends TestCase
         parent::setUp();
 
         $this->container = $this->getContainerWithContaoConfiguration();
+
         System::setContainer($this->container);
     }
 
@@ -254,8 +255,8 @@ class ContentElementControllerTest extends TestCase
         $this->container->set('contao.routing.scope_matcher', $this->mockScopeMatcher());
 
         $currentRequest = new Request([], [], ['_scope' => 'frontend']);
-        $requestStack = $this->container->get('request_stack');
 
+        $requestStack = $this->container->get('request_stack');
         $requestStack->push(new Request()); // Main request
         $requestStack->push($currentRequest); // Sub request
 

--- a/core-bundle/tests/Controller/ContentElement/ContentElementControllerTest.php
+++ b/core-bundle/tests/Controller/ContentElement/ContentElementControllerTest.php
@@ -20,6 +20,7 @@ use Contao\FragmentTemplate;
 use Contao\FrontendTemplate;
 use Contao\System;
 use FOS\HttpCache\ResponseTagger;
+use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -263,7 +264,7 @@ class ContentElementControllerTest extends TestCase
         $controller = new TestController();
         $controller->setContainer($this->container);
 
-        $controller(new Request(), $this->getContentModel(), 'main');
+        $controller($currentRequest, $this->getContentModel(), 'main');
     }
 
     private function mockContainerWithFrameworkTemplate(string $templateName): ContainerBuilder
@@ -281,8 +282,11 @@ class ContentElementControllerTest extends TestCase
         return $this->container;
     }
 
+    /**
+     * @return ContentModel&MockObject
+     */
     private function getContentModel(): ContentModel
     {
-        return (new \ReflectionClass(ContentModel::class))->newInstanceWithoutConstructor();
+        return $this->mockClassWithProperties(ContentModel::class);
     }
 }

--- a/core-bundle/tests/Controller/ContentElement/ContentElementControllerTest.php
+++ b/core-bundle/tests/Controller/ContentElement/ContentElementControllerTest.php
@@ -256,9 +256,6 @@ class ContentElementControllerTest extends TestCase
 
     private function getContentModel(): ContentModel
     {
-        /** @var ContentModel $model */
-        $model = (new \ReflectionClass(ContentModel::class))->newInstanceWithoutConstructor();
-
-        return $model;
+        return (new \ReflectionClass(ContentModel::class))->newInstanceWithoutConstructor();
     }
 }

--- a/core-bundle/tests/Controller/FrontendModule/FrontendModuleControllerTest.php
+++ b/core-bundle/tests/Controller/FrontendModule/FrontendModuleControllerTest.php
@@ -35,6 +35,7 @@ class FrontendModuleControllerTest extends TestCase
         parent::setUp();
 
         $this->container = $this->getContainerWithContaoConfiguration();
+
         System::setContainer($this->container);
     }
 
@@ -169,8 +170,8 @@ class FrontendModuleControllerTest extends TestCase
         $this->container->set('contao.routing.scope_matcher', $this->mockScopeMatcher());
 
         $currentRequest = new Request([], [], ['_scope' => 'frontend']);
-        $requestStack = $this->container->get('request_stack');
 
+        $requestStack = $this->container->get('request_stack');
         $requestStack->push(new Request()); // Main request
         $requestStack->push($currentRequest); // Sub request
 

--- a/core-bundle/tests/Controller/FrontendModule/FrontendModuleControllerTest.php
+++ b/core-bundle/tests/Controller/FrontendModule/FrontendModuleControllerTest.php
@@ -19,6 +19,7 @@ use Contao\FrontendTemplate;
 use Contao\ModuleModel;
 use Contao\System;
 use FOS\HttpCache\ResponseTagger;
+use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -197,8 +198,11 @@ class FrontendModuleControllerTest extends TestCase
         return $this->container;
     }
 
+    /**
+     * @return ModuleModel&MockObject
+     */
     private function getModuleModel(): ModuleModel
     {
-        return (new \ReflectionClass(ModuleModel::class))->newInstanceWithoutConstructor();
+        return $this->mockClassWithProperties(ModuleModel::class);
     }
 }

--- a/core-bundle/tests/Controller/FrontendModule/FrontendModuleControllerTest.php
+++ b/core-bundle/tests/Controller/FrontendModule/FrontendModuleControllerTest.php
@@ -172,9 +172,6 @@ class FrontendModuleControllerTest extends TestCase
 
     private function getModuleModel(): ModuleModel
     {
-        /** @var ModuleModel $model */
-        $model = (new \ReflectionClass(ModuleModel::class))->newInstanceWithoutConstructor();
-
-        return $model;
+        return (new \ReflectionClass(ModuleModel::class))->newInstanceWithoutConstructor();
     }
 }

--- a/core-bundle/tests/Controller/FrontendModule/FrontendModuleControllerTest.php
+++ b/core-bundle/tests/Controller/FrontendModule/FrontendModuleControllerTest.php
@@ -24,11 +24,17 @@ use Symfony\Component\HttpFoundation\RequestStack;
 
 class FrontendModuleControllerTest extends TestCase
 {
+    /**
+     * @var ContainerBuilder
+     */
+    private $container;
+
     protected function setUp(): void
     {
         parent::setUp();
 
-        System::setContainer($this->getContainerWithContaoConfiguration());
+        $this->container = $this->getContainerWithContaoConfiguration();
+        System::setContainer($this->container);
     }
 
     public function testCreatesTheTemplateFromTheClassName(): void
@@ -36,7 +42,7 @@ class FrontendModuleControllerTest extends TestCase
         $controller = new TestController();
         $controller->setContainer($this->mockContainerWithFrameworkTemplate('mod_test'));
 
-        $controller(new Request([], [], ['_scope' => 'frontend']), new ModuleModel(), 'main');
+        $controller(new Request([], [], ['_scope' => 'frontend']), $this->getModuleModel(), 'main');
     }
 
     public function testCreatesTheTemplateFromTheTypeFragmentOption(): void
@@ -45,7 +51,7 @@ class FrontendModuleControllerTest extends TestCase
         $controller->setContainer($this->mockContainerWithFrameworkTemplate('mod_foo'));
         $controller->setFragmentOptions(['type' => 'foo']);
 
-        $controller(new Request(), new ModuleModel(), 'main');
+        $controller(new Request(), $this->getModuleModel(), 'main');
     }
 
     public function testCreatesTheTemplateFromTheTemplateFragmentOption(): void
@@ -54,12 +60,12 @@ class FrontendModuleControllerTest extends TestCase
         $controller->setContainer($this->mockContainerWithFrameworkTemplate('mod_bar'));
         $controller->setFragmentOptions(['template' => 'mod_bar']);
 
-        $controller(new Request(), new ModuleModel(), 'main');
+        $controller(new Request(), $this->getModuleModel(), 'main');
     }
 
     public function testCreatesTheTemplateFromACustomTpl(): void
     {
-        $model = new ModuleModel();
+        $model = $this->getModuleModel();
         $model->customTpl = 'mod_bar';
 
         $container = $this->mockContainerWithFrameworkTemplate('mod_bar');
@@ -79,7 +85,7 @@ class FrontendModuleControllerTest extends TestCase
         $controller = new TestController();
         $controller->setContainer($this->mockContainerWithFrameworkTemplate('mod_test'));
 
-        $response = $controller(new Request(), new ModuleModel(), 'main');
+        $response = $controller(new Request(), $this->getModuleModel(), 'main');
         $template = json_decode($response->getContent(), true);
 
         $this->assertSame('', $template['cssID']);
@@ -88,7 +94,7 @@ class FrontendModuleControllerTest extends TestCase
 
     public function testSetsTheHeadlineFromTheModel(): void
     {
-        $model = new ModuleModel();
+        $model = $this->getModuleModel();
         $model->headline = serialize(['unit' => 'h6', 'value' => 'foobar']);
 
         $controller = new TestController();
@@ -103,7 +109,7 @@ class FrontendModuleControllerTest extends TestCase
 
     public function testSetsTheCssIdAndClassFromTheModel(): void
     {
-        $model = new ModuleModel();
+        $model = $this->getModuleModel();
         $model->cssID = serialize(['foo', 'bar']);
 
         $controller = new TestController();
@@ -121,7 +127,7 @@ class FrontendModuleControllerTest extends TestCase
         $controller = new TestController();
         $controller->setContainer($this->mockContainerWithFrameworkTemplate('mod_test'));
 
-        $response = $controller(new Request(), new ModuleModel(), 'left');
+        $response = $controller(new Request(), $this->getModuleModel(), 'left');
         $template = json_decode($response->getContent(), true);
 
         $this->assertSame('left', $template['inColumn']);
@@ -129,7 +135,7 @@ class FrontendModuleControllerTest extends TestCase
 
     public function testAddsTheCacheTags(): void
     {
-        $model = new ModuleModel();
+        $model = $this->getModuleModel();
         $model->id = 42;
 
         $responseTagger = $this->createMock(ResponseTagger::class);
@@ -158,10 +164,17 @@ class FrontendModuleControllerTest extends TestCase
             ->willReturn(new FrontendTemplate($templateName))
         ;
 
-        $container = new ContainerBuilder();
-        $container->set('contao.framework', $framework);
-        $container->set('contao.routing.scope_matcher', $this->mockScopeMatcher());
+        $this->container->set('contao.framework', $framework);
+        $this->container->set('contao.routing.scope_matcher', $this->mockScopeMatcher());
 
-        return $container;
+        return $this->container;
+    }
+
+    private function getModuleModel(): ModuleModel
+    {
+        /** @var ModuleModel $model */
+        $model = (new \ReflectionClass(ModuleModel::class))->newInstanceWithoutConstructor();
+
+        return $model;
     }
 }

--- a/core-bundle/tests/Controller/FrontendModule/TwoFactorControllerTest.php
+++ b/core-bundle/tests/Controller/FrontendModule/TwoFactorControllerTest.php
@@ -33,6 +33,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\Security;
@@ -541,6 +542,7 @@ class TwoFactorControllerTest extends TestCase
         $container->set('security.helper', $security);
         $container->set('contao.resource_finder', $finder);
         $container->set('parameter_bag', $parameterBag);
+        $container->set('request_stack', new RequestStack());
 
         $pass = new AddResourcesPathsPass();
         $pass->process($container);


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #3263


This is a draft attempt to not handle inline fragments like page content. However, ESI fragments **should** actually behave like the main page controller, it **should** minify markup etc.

An alternative idea by @fritzmg and me would be to register a response listener that minifies the main response content etc., but we're not sure that's a good idea 🙃 