### PR TITLE
Do not set the server_version

### DIFF
--- a/core-bundle/src/Doctrine/ORM/FailTolerantProxyCacheWarmer.php
+++ b/core-bundle/src/Doctrine/ORM/FailTolerantProxyCacheWarmer.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Doctrine\ORM;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DBALException as DoctrineDbalDbalException;
+use Doctrine\DBAL\Exception as DoctrineDbalException;
+use Symfony\Bridge\Doctrine\CacheWarmer\ProxyCacheWarmer;
+
+class FailTolerantProxyCacheWarmer extends ProxyCacheWarmer
+{
+    /**
+     * @var ProxyCacheWarmer
+     */
+    private $inner;
+
+    /**
+     * @var Connection
+     */
+    private $connection;
+
+    public function __construct(ProxyCacheWarmer $inner, Connection $connection)
+    {
+        $this->inner = $inner;
+        $this->connection = $connection;
+    }
+
+    public function isOptional(): bool
+    {
+        return (bool) $this->inner->isOptional();
+    }
+
+    public function warmUp($cacheDir): void
+    {
+        // If there are no DB credentials yet (install tool), we have to skip
+        // the ORM warmup to prevent a DBAL exception
+        try {
+            $this->connection->connect();
+            $this->connection->query('SHOW TABLES');
+            $this->connection->close();
+        } catch (DoctrineDbalException | DoctrineDbalDbalException | \mysqli_sql_exception $e) {
+            return;
+        }
+
+        $this->inner->warmUp($cacheDir);
+    }
+}

--- a/core-bundle/src/Doctrine/ORM/FailTolerantProxyCacheWarmer.php
+++ b/core-bundle/src/Doctrine/ORM/FailTolerantProxyCacheWarmer.php
@@ -42,12 +42,11 @@ class FailTolerantProxyCacheWarmer extends ProxyCacheWarmer
 
     public function warmUp($cacheDir): void
     {
-        // If there are no DB credentials yet (install tool), we have to skip
-        // the ORM warmup to prevent a DBAL exception
+        // If there are no DB credentials yet (install tool) and the
+        // server_version was not configured, we have to skip the ORM warmup to
+        // prevent a DBAL exception during the automatic version detection
         try {
-            $this->connection->connect();
-            $this->connection->query('SHOW TABLES');
-            $this->connection->close();
+            $this->connection->getDatabasePlatform();
         } catch (DoctrineDbalException | DoctrineDbalDbalException | \mysqli_sql_exception $e) {
             return;
         }

--- a/core-bundle/src/Resources/config/listener.yml
+++ b/core-bundle/src/Resources/config/listener.yml
@@ -84,9 +84,9 @@ services:
     contao.listener.command_scheduler:
         class: Contao\CoreBundle\EventListener\CommandSchedulerListener
         arguments:
+            - '@Psr\Container\ContainerInterface'
             - '@contao.framework'
             - '@database_connection'
-            - '@Contao\CoreBundle\Cron\Cron'
             - '%fragment.path%'
         tags:
             - kernel.event_listener

--- a/core-bundle/src/Resources/config/services.yml
+++ b/core-bundle/src/Resources/config/services.yml
@@ -231,6 +231,12 @@ services:
         tags:
             - { name: data_collector, template: '@ContaoCore/Collector/contao.html.twig', id: contao }
 
+    Contao\CoreBundle\Doctrine\ORM\FailTolerantProxyCacheWarmer:
+        decorates: doctrine.orm.proxy_cache_warmer
+        arguments:
+            - '@Contao\CoreBundle\Doctrine\ORM\FailTolerantProxyCacheWarmer.inner'
+            - '@database_connection'
+
     contao.doctrine.schema_provider:
         class: Contao\CoreBundle\Doctrine\Schema\DcaSchemaProvider
         arguments:

--- a/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
+++ b/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
@@ -149,6 +149,7 @@ use Contao\ImagineSvg\Imagine as ImagineSvg;
 use Contao\ModuleProxy;
 use Knp\Menu\Matcher\Matcher;
 use Knp\Menu\Renderer\ListRenderer;
+use Psr\Container\ContainerInterface as PsrContainerInterface;
 use Symfony\Cmf\Component\Routing\DynamicRouter;
 use Symfony\Cmf\Component\Routing\NestedMatcher\NestedMatcher;
 use Symfony\Cmf\Component\Routing\ProviderBasedGenerator;
@@ -447,9 +448,9 @@ class ContaoCoreExtensionTest extends TestCase
 
         $this->assertEquals(
             [
+                new Reference(PsrContainerInterface::class),
                 new Reference('contao.framework'),
                 new Reference('database_connection'),
-                new Reference(Cron::class),
                 new Reference('%fragment.path%'),
             ],
             $definition->getArguments()

--- a/core-bundle/tests/EventListener/CommandSchedulerListenerTest.php
+++ b/core-bundle/tests/EventListener/CommandSchedulerListenerTest.php
@@ -22,6 +22,7 @@ use Doctrine\DBAL\Driver\Mysqli\MysqliException;
 use Doctrine\DBAL\Exception\DriverException;
 use Doctrine\DBAL\Schema\MySqlSchemaManager;
 use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Container\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\TerminateEvent;
@@ -38,7 +39,14 @@ class CommandSchedulerListenerTest extends TestCase
             ->with(Cron::SCOPE_WEB)
         ;
 
-        $listener = new CommandSchedulerListener($this->mockContaoFramework(), $this->mockConnection(), $cron);
+        $locator = $this->createMock(ContainerInterface::class);
+        $locator
+            ->method('get')
+            ->with(Cron::class)
+            ->willReturn($cron)
+        ;
+
+        $listener = new CommandSchedulerListener($locator, $this->mockContaoFramework(), $this->mockConnection());
         $listener($this->getTerminateEvent('contao_frontend'));
     }
 
@@ -55,7 +63,7 @@ class CommandSchedulerListenerTest extends TestCase
             ->method('getAdapter')
         ;
 
-        $listener = new CommandSchedulerListener($framework, $this->mockConnection(), $this->createMock(Cron::class));
+        $listener = new CommandSchedulerListener($this->createMock(ContainerInterface::class), $framework, $this->mockConnection());
         $listener($this->getTerminateEvent('contao_backend'));
     }
 
@@ -78,7 +86,7 @@ class CommandSchedulerListenerTest extends TestCase
 
         $event = new TerminateEvent($this->createMock(KernelInterface::class), $request, new Response());
 
-        $listener = new CommandSchedulerListener($framework, $this->mockConnection(), $this->createMock(Cron::class));
+        $listener = new CommandSchedulerListener($this->createMock(ContainerInterface::class), $framework, $this->mockConnection());
         $listener($event);
     }
 
@@ -101,7 +109,7 @@ class CommandSchedulerListenerTest extends TestCase
 
         $event = new TerminateEvent($this->createMock(KernelInterface::class), $request, new Response());
 
-        $listener = new CommandSchedulerListener($framework, $this->mockConnection(), $this->createMock(Cron::class));
+        $listener = new CommandSchedulerListener($this->createMock(ContainerInterface::class), $framework, $this->mockConnection());
         $listener($event);
     }
 
@@ -124,7 +132,7 @@ class CommandSchedulerListenerTest extends TestCase
             ->method('createInstance')
         ;
 
-        $listener = new CommandSchedulerListener($framework, $this->mockConnection(), $this->createMock(Cron::class));
+        $listener = new CommandSchedulerListener($this->createMock(ContainerInterface::class), $framework, $this->mockConnection());
         $listener($this->getTerminateEvent('contao_backend'));
     }
 
@@ -148,7 +156,7 @@ class CommandSchedulerListenerTest extends TestCase
             ->method('createInstance')
         ;
 
-        $listener = new CommandSchedulerListener($framework, $this->mockConnection(), $this->createMock(Cron::class));
+        $listener = new CommandSchedulerListener($this->createMock(ContainerInterface::class), $framework, $this->mockConnection());
         $listener($this->getTerminateEvent('contao_frontend'));
     }
 
@@ -166,13 +174,20 @@ class CommandSchedulerListenerTest extends TestCase
             ->method('run')
         ;
 
+        $locator = $this->createMock(ContainerInterface::class);
+        $locator
+            ->method('get')
+            ->with(Cron::class)
+            ->willReturn($cron)
+        ;
+
         $connection = $this->createMock(Connection::class);
         $connection
             ->method('isConnected')
             ->willThrowException(new DriverException('Could not connect', new MysqliException('Invalid password')))
         ;
 
-        $listener = new CommandSchedulerListener($framework, $connection, $cron);
+        $listener = new CommandSchedulerListener($locator, $framework, $connection);
         $listener($this->getTerminateEvent('contao_backend'));
     }
 

--- a/manager-bundle/src/ContaoManager/Plugin.php
+++ b/manager-bundle/src/ContaoManager/Plugin.php
@@ -31,9 +31,6 @@ use Contao\ManagerPlugin\Config\ExtensionPluginInterface;
 use Contao\ManagerPlugin\Dependency\DependentPluginInterface;
 use Contao\ManagerPlugin\Routing\RoutingPluginInterface;
 use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
-use Doctrine\DBAL\DBALException as DoctrineDbalDbalException;
-use Doctrine\DBAL\DriverManager;
-use Doctrine\DBAL\Exception as DoctrineDbalException;
 use FOS\HttpCacheBundle\FOSHttpCacheBundle;
 use Lexik\Bundle\MaintenanceBundle\LexikMaintenanceBundle;
 use Nelmio\CorsBundle\NelmioCorsBundle;
@@ -63,16 +60,6 @@ class Plugin implements BundlePluginInterface, ConfigPluginInterface, RoutingPlu
      * @var string|null
      */
     private static $autoloadModules;
-
-    /**
-     * @var callable
-     */
-    private $dbalConnectionFactory;
-
-    public function __construct(callable $dbalConnectionFactory = null)
-    {
-        $this->dbalConnectionFactory = $dbalConnectionFactory ?: [DriverManager::class, 'getConnection'];
-    }
 
     /**
      * Sets the path to enable autoloading of legacy Contao modules.
@@ -240,8 +227,6 @@ class Plugin implements BundlePluginInterface, ConfigPluginInterface, RoutingPlu
                     $container->setParameter('env(DATABASE_URL)', $this->getDatabaseUrl($container, $extensionConfigs));
                 }
 
-                $extensionConfigs = $this->addDefaultServerVersion($extensionConfigs, $container);
-
                 return $this->addDefaultPdoDriverOptions($extensionConfigs, $container);
 
             case 'swiftmailer':
@@ -279,53 +264,6 @@ class Plugin implements BundlePluginInterface, ConfigPluginInterface, RoutingPlu
         $extensionConfigs[] = [
             'prepend_locale' => '%prepend_locale%',
         ];
-
-        return $extensionConfigs;
-    }
-
-    /**
-     * Adds the database server version to the Doctrine DBAL configuration.
-     *
-     * @return array<string,array<string,array<string,array<string,mixed>>>>
-     */
-    private function addDefaultServerVersion(array $extensionConfigs, ContainerBuilder $container): array
-    {
-        $params = [];
-
-        foreach ($extensionConfigs as $extensionConfig) {
-            if (isset($extensionConfig['dbal']['connections']['default'])) {
-                $params[] = $extensionConfig['dbal']['connections']['default'];
-            }
-        }
-
-        if (!empty($params)) {
-            $params = array_merge(...$params);
-        }
-
-        $parameterBag = $container->getParameterBag();
-
-        foreach ($params as $key => $value) {
-            $params[$key] = $parameterBag->unescapeValue($container->resolveEnvPlaceholders($value, true));
-        }
-
-        // If there are no DB credentials yet (install tool), we have to set
-        // the server version to prevent a DBAL exception (see #1422)
-        try {
-            $connection = \call_user_func($this->dbalConnectionFactory, $params);
-            $connection->connect();
-            $connection->query('SHOW TABLES');
-            $connection->close();
-        } catch (DoctrineDbalException | DoctrineDbalDbalException | \mysqli_sql_exception $e) {
-            $extensionConfigs[] = [
-                'dbal' => [
-                    'connections' => [
-                        'default' => [
-                            'server_version' => '5.5',
-                        ],
-                    ],
-                ],
-            ];
-        }
 
         return $extensionConfigs;
     }


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #1696

For the record as described in https://github.com/contao/contao/pull/3623#issuecomment-952708988 the `CommandSchedulerListener` must only load the `Cron` service when it needs it. Otherwise the install tool would fail when terminating because the `Cron` service needs ORM metadata which itself needs to know the `server_version`.