### PR TITLE
Add the missing dot-env features

### DIFF
--- a/manager-bundle/src/ContaoManager/Plugin.php
+++ b/manager-bundle/src/ContaoManager/Plugin.php
@@ -197,6 +197,13 @@ class Plugin implements BundlePluginInterface, ConfigPluginInterface, RoutingPlu
     {
         return [
             'dot-env' => [
+                'APP_SECRET',
+                'APP_ENV',
+                'COOKIE_WHITELIST',
+                'DATABASE_URL',
+                'DISABLE_HTTP_CACHE',
+                'MAILER_URL',
+                'TRACE_LEVEL',
                 'TRUSTED_PROXIES',
                 'TRUSTED_HOSTS',
             ],

--- a/manager-bundle/tests/ContaoManager/PluginTest.php
+++ b/manager-bundle/tests/ContaoManager/PluginTest.php
@@ -288,6 +288,13 @@ class PluginTest extends ContaoTestCase
         $this->assertSame(
             [
                 'dot-env' => [
+                    'APP_SECRET',
+                    'APP_ENV',
+                    'COOKIE_WHITELIST',
+                    'DATABASE_URL',
+                    'DISABLE_HTTP_CACHE',
+                    'MAILER_URL',
+                    'TRACE_LEVEL',
                     'TRUSTED_PROXIES',
                     'TRUSTED_HOSTS',
                 ],


### PR DESCRIPTION
This enables the Contao Manager to know what configuration can be done in the `.env` file.

PS: this needs to be updated after merging into 4.12