### PR TITLE
Set language of redirect page in global context

### DIFF
--- a/core-bundle/src/Resources/contao/pages/PageRedirect.php
+++ b/core-bundle/src/Resources/contao/pages/PageRedirect.php
@@ -27,6 +27,8 @@ class PageRedirect extends Frontend
 	 */
 	public function generate($objPage)
 	{
+		$this->prepare($objPage);
+
 		$this->redirect($this->replaceInsertTags($objPage->url, false), $this->getRedirectStatusCode($objPage));
 	}
 
@@ -39,6 +41,8 @@ class PageRedirect extends Frontend
 	 */
 	public function getResponse($objPage)
 	{
+		$this->prepare($objPage);
+
 		return new RedirectResponse($this->replaceInsertTags($objPage->url, false), $this->getRedirectStatusCode($objPage));
 	}
 
@@ -52,6 +56,21 @@ class PageRedirect extends Frontend
 	protected function getRedirectStatusCode($objPage)
 	{
 		return ($objPage->redirect == 'temporary') ? 303 : 301;
+	}
+
+	/**
+	 * @param PageModel $objPage
+	 */
+	private function prepare($objPage)
+	{
+		$GLOBALS['TL_KEYWORDS'] = '';
+		$GLOBALS['TL_LANGUAGE'] = $objPage->language;
+
+		$locale = str_replace('-', '_', $objPage->language);
+
+		$container = System::getContainer();
+		$container->get('request_stack')->getCurrentRequest()->setLocale($locale);
+		$container->get('translator')->setLocale($locale);
 	}
 }
 

--- a/core-bundle/src/Resources/contao/pages/PageRedirect.php
+++ b/core-bundle/src/Resources/contao/pages/PageRedirect.php
@@ -63,7 +63,6 @@ class PageRedirect extends Frontend
 	 */
 	private function prepare($objPage)
 	{
-		$GLOBALS['TL_KEYWORDS'] = '';
 		$GLOBALS['TL_LANGUAGE'] = $objPage->language;
 
 		$locale = str_replace('-', '_', $objPage->language);


### PR DESCRIPTION
Currently the language of a redirect page is not set in global context. This is especially a problem if you use language dependent insert tags in the redirect.

Affected Version: 4.9+

I'm not sure if we need to add more lines from the `prepare` method of `PageRegular`. The supposed lines are sufficient for my problem with the missing language context.

https://github.com/contao/contao/blob/2a19b186afd59495e9fbd5174d0deb40543c5079/core-bundle/src/Resources/contao/pages/PageRegular.php#L63-L69
