### PR TITLE
Fix project dir path for the console

### DIFF
--- a/manager-bundle/bin/contao-api
+++ b/manager-bundle/bin/contao-api
@@ -20,7 +20,7 @@ set_time_limit(0);
 @ini_set('zlib.output_compression', '0');
 
 if (file_exists(__DIR__.'/../../../../autoload.php')) {
-    $projectDir = \dirname(__DIR__, 5);
+    $projectDir = \dirname(__DIR__, 7);
 } else {
     $projectDir = \dirname(__DIR__, 4);
 }

--- a/manager-bundle/bin/contao-console
+++ b/manager-bundle/bin/contao-console
@@ -21,7 +21,7 @@ set_time_limit(0);
 if (file_exists(__DIR__.'/../autoload.php')) {
     $projectDir = \dirname(__DIR__, 2);
 } elseif (file_exists(__DIR__.'/../../../../autoload.php')) {
-    $projectDir = \dirname(__DIR__, 5);
+    $projectDir = \dirname(__DIR__, 7);
 } elseif (false !== ($cwd = getcwd()) && file_exists($cwd.'/vendor/autoload.php')) {
     $projectDir = $cwd;
 } else {

--- a/manager-bundle/bin/contao-setup
+++ b/manager-bundle/bin/contao-setup
@@ -25,7 +25,7 @@ set_time_limit(0);
 if (file_exists(__DIR__.'/../autoload.php')) {
     $projectDir = \dirname(__DIR__, 2);
 } elseif (file_exists(__DIR__.'/../../../../autoload.php')) {
-    $projectDir = \dirname(__DIR__, 5);
+    $projectDir = \dirname(__DIR__, 7);
 } elseif (false !== ($cwd = getcwd()) && file_exists($cwd.'/vendor/autoload.php')) {
     $projectDir = $cwd;
 } else {


### PR DESCRIPTION
On my system, when using the mono repository, `__DIR__` within `vendor/bin/contao-setup`, which in turn includes `__DIR__ . "/" . '../contao/contao/manager-bundle/bin/contao-setup'`, will be

```
…\c412dev\vendor\bin/../contao/contao/manager-bundle/bin
```

for example. `\dirname(__DIR__, 5)` will then be `…\c412dev\vendor\bin` - which is not the project directory. This results in

```
Warning: require(…\c412dev\vendor\bin/vendor/autoload.php): failed to open stream: No such file or directory in …\www\c412dev\vendor\bin/../contao/contao/manager-bundle/bin/contao-setup on line 38
```

Then `contao-setup`, `contao-console` and `contao-api` will not work.

However, this surely cannot be correct in all cases, since it obviously works for you? It seems to be a platform difference. Also I did not have this issue before, so I am not sure what changed 😕 

/cc @m-vo 