### PR TITLE
Do not block the `contao.backend` namespace

### DIFF
--- a/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
+++ b/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
@@ -83,7 +83,10 @@ class ContaoCoreExtension extends Extension
         $container->setParameter('contao.image.reject_large_uploads', $config['image']['reject_large_uploads']);
         $container->setParameter('contao.security.two_factor.enforce_backend', $config['security']['two_factor']['enforce_backend']);
         $container->setParameter('contao.localconfig', $config['localconfig'] ?? []);
-        $container->setParameter('contao.backend', $config['backend']);
+        $container->setParameter('contao.backend.attributes', $config['backend']['attributes']);
+        $container->setParameter('contao.backend.custom_css', $config['backend']['custom_css']);
+        $container->setParameter('contao.backend.custom_js', $config['backend']['custom_js']);
+        $container->setParameter('contao.backend.badge_title', $config['backend']['badge_title']);
         $container->setParameter('contao.intl.locales', $config['intl']['locales']);
         $container->setParameter('contao.intl.enabled_locales', $config['intl']['enabled_locales']);
         $container->setParameter('contao.intl.countries', $config['intl']['countries']);

--- a/core-bundle/src/Resources/contao/classes/BackendTemplate.php
+++ b/core-bundle/src/Resources/contao/classes/BackendTemplate.php
@@ -173,43 +173,54 @@ class BackendTemplate extends Template
 	{
 		$container = System::getContainer();
 
-		if (!$container->hasParameter('contao.backend'))
+		if ($container->hasParameter('contao.backend.attributes'))
 		{
-			return;
-		}
+			$attributes = $container->getParameter('contao.backend.attributes');
 
-		$backendConfig = $container->getParameter('contao.backend');
-
-		if (!empty($backendConfig['attributes']) && \is_array($backendConfig['attributes']))
-		{
-			$this->attributes = ' ' . implode(' ', array_map(
-				static function ($v, $k) { return sprintf('data-%s="%s"', $k, $v); },
-				$backendConfig['attributes'],
-				array_keys($backendConfig['attributes'])
-			));
-		}
-
-		if (!empty($backendConfig['custom_css']) && \is_array($backendConfig['custom_css']))
-		{
-			if (!\is_array($GLOBALS['TL_CSS']))
+			if (!empty($attributes) && \is_array($attributes))
 			{
-				$GLOBALS['TL_CSS'] = array();
+				$this->attributes = ' ' . implode(' ', array_map(
+					static function ($v, $k) { return sprintf('data-%s="%s"', $k, $v); },
+					$attributes,
+					array_keys($attributes)
+				));
 			}
-
-			$GLOBALS['TL_CSS'] = array_merge($GLOBALS['TL_CSS'], $backendConfig['custom_css']);
 		}
 
-		if (!empty($backendConfig['custom_js']) && \is_array($backendConfig['custom_js']))
+		if ($container->hasParameter('contao.backend.custom_css'))
 		{
-			if (!\is_array($GLOBALS['TL_JAVASCRIPT']))
-			{
-				$GLOBALS['TL_JAVASCRIPT'] = array();
-			}
+			$css = $container->getParameter('contao.backend.custom_css');
 
-			$GLOBALS['TL_JAVASCRIPT'] = array_merge($GLOBALS['TL_JAVASCRIPT'], $backendConfig['custom_js']);
+			if (!empty($css) && \is_array($css))
+			{
+				if (!\is_array($GLOBALS['TL_CSS']))
+				{
+					$GLOBALS['TL_CSS'] = array();
+				}
+
+				$GLOBALS['TL_CSS'] = array_merge($GLOBALS['TL_CSS'], $css);
+			}
 		}
 
-		$this->badgeTitle = $backendConfig['badge_title'];
+		if ($container->hasParameter('contao.backend.custom_js'))
+		{
+			$js = $container->getParameter('contao.backend.custom_js');
+
+			if (!empty($js) && \is_array($js))
+			{
+				if (!\is_array($GLOBALS['TL_JAVASCRIPT']))
+				{
+					$GLOBALS['TL_JAVASCRIPT'] = array();
+				}
+
+				$GLOBALS['TL_JAVASCRIPT'] = array_merge($GLOBALS['TL_JAVASCRIPT'], $js);
+			}
+		}
+
+		if ($container->hasParameter('contao.backend.badge_title'))
+		{
+			$this->badgeTitle = $container->getParameter('contao.backend.badge_title');
+		}
 	}
 }
 


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes https://github.com/contao/contao/pull/3472#discussion_r744872390
| Docs PR or issue | -

We need the `contao.backend` namespace to be open for further parameters, therefore we must not take it exclusively for the back end theme options (see #1999). This change is required to merge #3472.