### PR TITLE
Ensure defined admin email is always used as sender

### DIFF
--- a/core-bundle/src/OptIn/OptInToken.php
+++ b/core-bundle/src/OptIn/OptInToken.php
@@ -135,6 +135,8 @@ class OptInToken implements OptInTokenInterface
         $email = $this->framework->createInstance(Email::class);
         $email->subject = $this->model->emailSubject;
         $email->text = $this->model->emailText;
+        $email->from = $GLOBALS['TL_ADMIN_EMAIL'] ?? null;
+        $email->fromName = $GLOBALS['TL_ADMIN_NAME'] ?? null;
         $email->sendTo($this->model->email);
     }
 

--- a/core-bundle/src/Resources/contao/library/Contao/Email.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Email.php
@@ -433,7 +433,15 @@ class Email
 		// Add the administrator e-mail as default sender
 		if (!$this->strSender)
 		{
-			list($this->strSenderName, $this->strSender) = StringUtil::splitFriendlyEmail(Config::get('adminEmail'));
+			if (!empty($GLOBALS['TL_ADMIN_EMAIL']))
+			{
+				$this->strSender = $GLOBALS['TL_ADMIN_EMAIL'];
+				$this->strSenderName = $GLOBALS['TL_ADMIN_NAME'] ?? null;
+			}
+			else
+			{
+				list($this->strSenderName, $this->strSender) = StringUtil::splitFriendlyEmail(Config::get('adminEmail'));
+			}
 		}
 
 		// Sender


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #3573
| Docs PR or issue | -

This PR fixes #3573 by setting the `$GLOBALS['TL_ADMIN_EMAIL']` value as the sender within `OptInToken`, if available. This PR also ensures that `Contao\Email` _always_ uses `$GLOBALS['TL_ADMIN_EMAIL']` if available.