### PR TITLE
Handle doctrine binary types in version compare view

### DIFF
--- a/core-bundle/src/Resources/contao/classes/Versions.php
+++ b/core-bundle/src/Resources/contao/classes/Versions.php
@@ -13,6 +13,7 @@ namespace Contao;
 use Contao\CoreBundle\Exception\ResponseException;
 use Doctrine\DBAL\Types\BinaryType;
 use Doctrine\DBAL\Types\BlobType;
+use Doctrine\DBAL\Types\Types;
 
 /**
  * Provide methods to handle versioning.
@@ -458,7 +459,7 @@ class Versions extends Controller
 
 						if (\is_array($arrFields[$k]))
 						{
-							$blnIsBinary = $arrFields[$k]['type'] === BinaryType::class || $arrFields[$k]['type'] === BlobType::class;
+							$blnIsBinary = \in_array($arrFields[$k]['type'] ?? null, array(BinaryType::class, BlobType::class, Types::BINARY, Types::BLOB), true);
 						}
 						else
 						{

--- a/core-bundle/src/Resources/contao/classes/Versions.php
+++ b/core-bundle/src/Resources/contao/classes/Versions.php
@@ -10,6 +10,7 @@
 
 namespace Contao;
 
+use Contao\CoreBundle\Doctrine\DBAL\Types\BinaryStringType;
 use Contao\CoreBundle\Exception\ResponseException;
 use Doctrine\DBAL\Types\BinaryType;
 use Doctrine\DBAL\Types\BlobType;
@@ -459,8 +460,8 @@ class Versions extends Controller
 
 						if (\is_array($arrFields[$k]))
 						{
-							// Detect binary fields using Doctrine's built-in types (see #3665)
-							$blnIsBinary = \in_array($arrFields[$k]['type'] ?? null, array(BinaryType::class, BlobType::class, Types::BINARY, Types::BLOB), true);
+							// Detect binary fields using Doctrine's built-in types or Contao's BinaryStringType (see #3665)
+							$blnIsBinary = \in_array($arrFields[$k]['type'] ?? null, array(BinaryType::class, BlobType::class, Types::BINARY, Types::BLOB, BinaryStringType::NAME), true);
 						}
 						else
 						{

--- a/core-bundle/src/Resources/contao/classes/Versions.php
+++ b/core-bundle/src/Resources/contao/classes/Versions.php
@@ -459,6 +459,7 @@ class Versions extends Controller
 
 						if (\is_array($arrFields[$k]))
 						{
+							// Detect binary fields using Doctrine's built-in types (see #3665)
 							$blnIsBinary = \in_array($arrFields[$k]['type'] ?? null, array(BinaryType::class, BlobType::class, Types::BINARY, Types::BLOB), true);
 						}
 						else


### PR DESCRIPTION
The `Versions::compare` method tries to detect binary DCA fields to transform their values to a readable UUID. However, this detection does not work if you declare your DCA field using the built-in types from `Doctrine\DBAL\Types\Types`:

Not detected as binary field:

````php
'sql' => ['type' => Doctrine\DBAL\Types\Types::BINARY, 'length' => 16, 'fixed' => true, 'notnull' => false]
````

Detected as binary field:

````php
'sql' => 'binary(16) NULL'
````

This pull request adds Doctrine's two built-in binary types to the detection.