### PR TITLE
Replace FragmentRendererPass with tagged locator

### DIFF
--- a/core-bundle/src/ContaoCoreBundle.php
+++ b/core-bundle/src/ContaoCoreBundle.php
@@ -107,7 +107,6 @@ class ContaoCoreBundle extends Bundle
             )
         );
 
-        $container->addCompilerPass(new FragmentRendererPass('contao.fragment.handler'));
         $container->addCompilerPass(new RemembermeServicesPass('contao_frontend'));
         $container->addCompilerPass(new DataContainerCallbackPass());
         $container->addCompilerPass(new TranslationDataCollectorPass());

--- a/core-bundle/src/ContaoCoreBundle.php
+++ b/core-bundle/src/ContaoCoreBundle.php
@@ -49,7 +49,6 @@ use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\EventDispatcher\DependencyInjection\AddEventAliasesPass;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
-use Symfony\Component\HttpKernel\DependencyInjection\FragmentRendererPass;
 
 class ContaoCoreBundle extends Bundle
 {

--- a/core-bundle/src/Resources/config/services.yml
+++ b/core-bundle/src/Resources/config/services.yml
@@ -283,7 +283,7 @@ services:
         class: Contao\CoreBundle\Fragment\FragmentHandler
         decorates: fragment.handler
         arguments:
-            - ~ # fragment renderer locator
+            - [!tagged_locator { tag: 'kernel.fragment_renderer', index_by: 'alias' }]
             - '@contao.fragment.handler.inner'
             - '@request_stack'
             - '@contao.fragment.registry'

--- a/core-bundle/src/Resources/config/services.yml
+++ b/core-bundle/src/Resources/config/services.yml
@@ -283,7 +283,7 @@ services:
         class: Contao\CoreBundle\Fragment\FragmentHandler
         decorates: fragment.handler
         arguments:
-            - [!tagged_locator { tag: 'kernel.fragment_renderer', index_by: 'alias' }]
+            - [!tagged_locator { tag: kernel.fragment_renderer, index_by: alias }]
             - '@contao.fragment.handler.inner'
             - '@request_stack'
             - '@contao.fragment.registry'

--- a/core-bundle/tests/ContaoCoreBundleTest.php
+++ b/core-bundle/tests/ContaoCoreBundleTest.php
@@ -64,7 +64,6 @@ class ContaoCoreBundleTest extends TestCase
             RegisterPagesPass::class,
             RegisterFragmentsPass::class,
             RegisterFragmentsPass::class,
-            FragmentRendererPass::class,
             RemembermeServicesPass::class,
             DataContainerCallbackPass::class,
             TranslationDataCollectorPass::class,

--- a/core-bundle/tests/ContaoCoreBundleTest.php
+++ b/core-bundle/tests/ContaoCoreBundleTest.php
@@ -46,7 +46,6 @@ use Symfony\Cmf\Component\Routing\DependencyInjection\Compiler\RegisterRouteEnha
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\EventDispatcher\DependencyInjection\AddEventAliasesPass;
-use Symfony\Component\HttpKernel\DependencyInjection\FragmentRendererPass;
 
 class ContaoCoreBundleTest extends TestCase
 {


### PR DESCRIPTION
The `FragmentRendererPass` arguments have become deprecated in https://github.com/symfony/symfony/pull/40468. Luckily, we don't actually need to use the compiler pass to get a list of services 😅 