### PR TITLE
Fix parameter name in tl_page::getTitleTag()

### DIFF
--- a/core-bundle/src/Resources/contao/dca/tl_page.php
+++ b/core-bundle/src/Resources/contao/dca/tl_page.php
@@ -1048,12 +1048,12 @@ class tl_page extends Backend
 	 *
 	 * @return string
 	 */
-	public function getTitleTag(PageModel $model)
+	public function getTitleTag(PageModel $page)
 	{
 		$page->loadDetails();
 
 		/** @var LayoutModel $layout */
-		if (!$layout = $model->getRelated('layout'))
+		if (!$layout = $page->getRelated('layout'))
 		{
 			return '';
 		}

--- a/core-bundle/src/Resources/contao/dca/tl_page.php
+++ b/core-bundle/src/Resources/contao/dca/tl_page.php
@@ -1032,19 +1032,19 @@ class tl_page extends Backend
 	/**
 	 * Return the SERP URL
 	 *
-	 * @param PageModel $model
+	 * @param PageModel $page
 	 *
 	 * @return string
 	 */
-	public function getSerpUrl(PageModel $model)
+	public function getSerpUrl(PageModel $page)
 	{
-		return $model->getAbsoluteUrl();
+		return $page->getAbsoluteUrl();
 	}
 
 	/**
 	 * Return the title tag from the associated page layout
 	 *
-	 * @param PageModel $model
+	 * @param PageModel $page
 	 *
 	 * @return string
 	 */


### PR DESCRIPTION
This fixes a wrong parameter name in `tl_page::getTitleTag()`, which probably got introduced when merging 4.12 into 4.x in https://github.com/contao/contao/commit/646b4b792c8e3ba474d04768056bf1af4c98cd9e on top of the changes from https://github.com/contao/contao/commit/e3b473b10a63254a2f9f2d20dbc18315b5b0db74.

I decided to keep the parameter name `$model` instead of `$page` (from https://github.com/contao/contao/commit/e3b473b10a63254a2f9f2d20dbc18315b5b0db74) for consitency with similar methods like `tl_page::getSerpUrl)`, `tl_news::getTitleTag()`.