### PR TITLE
Remove the script name before signing a redirect URI

### DIFF
--- a/core-bundle/src/EventListener/PreviewAuthenticationListener.php
+++ b/core-bundle/src/EventListener/PreviewAuthenticationListener.php
@@ -65,6 +65,8 @@ class PreviewAuthenticationListener
         }
 
         $context = $this->router->getContext();
+        $baseUrl = $context->getBaseUrl();
+
         $context->setBaseUrl('');
 
         $url = $this->router->generate(
@@ -72,6 +74,8 @@ class PreviewAuthenticationListener
             ['redirect' => $request->getUri()],
             UrlGeneratorInterface::ABSOLUTE_URL
         );
+
+        $context->setBaseUrl($baseUrl);
 
         $event->setResponse(new RedirectResponse($this->uriSigner->sign($url)));
     }

--- a/core-bundle/src/EventListener/PreviewAuthenticationListener.php
+++ b/core-bundle/src/EventListener/PreviewAuthenticationListener.php
@@ -70,6 +70,8 @@ class PreviewAuthenticationListener
             UrlGeneratorInterface::ABSOLUTE_URL
         );
 
+        $url = str_replace($request->getScriptName(), '', $url);
+
         $event->setResponse(new RedirectResponse($this->uriSigner->sign($url)));
     }
 }

--- a/core-bundle/src/EventListener/PreviewAuthenticationListener.php
+++ b/core-bundle/src/EventListener/PreviewAuthenticationListener.php
@@ -64,13 +64,14 @@ class PreviewAuthenticationListener
             return;
         }
 
+        $context = $this->router->getContext();
+        $context->setBaseUrl('');
+
         $url = $this->router->generate(
             'contao_backend_login',
             ['redirect' => $request->getUri()],
             UrlGeneratorInterface::ABSOLUTE_URL
         );
-
-        $url = str_replace($request->getScriptName(), '', $url);
 
         $event->setResponse(new RedirectResponse($this->uriSigner->sign($url)));
     }

--- a/core-bundle/tests/EventListener/PreviewAuthenticationListenerTest.php
+++ b/core-bundle/tests/EventListener/PreviewAuthenticationListenerTest.php
@@ -61,8 +61,12 @@ class PreviewAuthenticationListenerTest extends TestCase
         $context = $this->createMock(RequestContext::class);
         $context
             ->expects($this->once())
+            ->method('getBaseUrl')
+        ;
+
+        $context
+            ->expects($this->exactly(2))
             ->method('setBaseUrl')
-            ->with('')
         ;
 
         $router = $this->createMock(UrlGeneratorInterface::class);

--- a/core-bundle/tests/EventListener/PreviewAuthenticationListenerTest.php
+++ b/core-bundle/tests/EventListener/PreviewAuthenticationListenerTest.php
@@ -23,6 +23,7 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\HttpKernel\UriSigner;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Routing\RequestContext;
 
 class PreviewAuthenticationListenerTest extends TestCase
 {
@@ -57,12 +58,25 @@ class PreviewAuthenticationListenerTest extends TestCase
             ->willReturn(false)
         ;
 
+        $context = $this->createMock(RequestContext::class);
+        $context
+            ->expects($this->once())
+            ->method('setBaseUrl')
+            ->with('')
+        ;
+
         $router = $this->createMock(UrlGeneratorInterface::class);
+        $router
+            ->expects($this->once())
+            ->method('getContext')
+            ->willReturn($context)
+        ;
+
         $router
             ->expects($this->once())
             ->method('generate')
             ->with('contao_backend_login')
-            ->willReturn('/preview.php/contao/login')
+            ->willReturn('/contao/login')
         ;
 
         $uriSigner = $this->createMock(UriSigner::class);
@@ -82,7 +96,6 @@ class PreviewAuthenticationListenerTest extends TestCase
         $listener($requestEvent);
 
         $this->assertInstanceOf(RedirectResponse::class, $requestEvent->getResponse());
-        $this->assertStringNotContainsStringIgnoringCase('/preview.php', $requestEvent->getResponse()->headers->get('location'));
     }
 
     private function getRequestEvent(Request $request = null, bool $isSubRequest = false): RequestEvent

--- a/core-bundle/tests/EventListener/PreviewAuthenticationListenerTest.php
+++ b/core-bundle/tests/EventListener/PreviewAuthenticationListenerTest.php
@@ -62,13 +62,14 @@ class PreviewAuthenticationListenerTest extends TestCase
             ->expects($this->once())
             ->method('generate')
             ->with('contao_backend_login')
-            ->willReturn('/contao/login')
+            ->willReturn('/preview.php/contao/login')
         ;
 
         $uriSigner = $this->createMock(UriSigner::class);
         $uriSigner
             ->expects($this->once())
             ->method('sign')
+            ->with('/contao/login')
             ->willReturn('/contao/login')
         ;
 
@@ -81,6 +82,7 @@ class PreviewAuthenticationListenerTest extends TestCase
         $listener($requestEvent);
 
         $this->assertInstanceOf(RedirectResponse::class, $requestEvent->getResponse());
+        $this->assertStringNotContainsStringIgnoringCase('/preview.php', $requestEvent->getResponse()->headers->get('location'));
     }
 
     private function getRequestEvent(Request $request = null, bool $isSubRequest = false): RequestEvent


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #3689
| Docs PR or issue | n/a

Remove any script name (normally `/preview.php`) from the generated URI before signing, otherwise the signed request is invalid after the redirect.