### PR TITLE
Lower the maximum insert tag recursion level

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/InsertTags.php
+++ b/core-bundle/src/Resources/contao/library/Contao/InsertTags.php
@@ -33,7 +33,7 @@ use Webmozart\PathUtil\Path;
  */
 class InsertTags extends Controller
 {
-	private const MAX_NESTING_LEVEL = 100;
+	private const MAX_NESTING_LEVEL = 64;
 
 	/**
 	 * @var int

--- a/core-bundle/tests/Contao/InsertTagsTest.php
+++ b/core-bundle/tests/Contao/InsertTagsTest.php
@@ -62,7 +62,7 @@ class InsertTagsTest extends TestCase
             try {
                 return (string) (new InsertTags())->replaceInternal('{{infinite-try-catch::'.((int) $tagParts[1] + 1).'}}', false);
             } catch (\RuntimeException $exception) {
-                $this->assertSame('Maximum insert tag nesting level of 100 reached', $exception->getMessage());
+                $this->assertSame('Maximum insert tag nesting level of 64 reached', $exception->getMessage());
 
                 return '[{]infinite-try-catch::'.((int) $tagParts[1] + 1).'[}]';
             }
@@ -72,7 +72,7 @@ class InsertTagsTest extends TestCase
             try {
                 return (string) (new InsertTags())->replaceInternal('{{infinite-retry::'.((int) $tagParts[1] + 1).'}}', false);
             } catch (\RuntimeException $exception) {
-                $this->assertSame('Maximum insert tag nesting level of 100 reached', $exception->getMessage());
+                $this->assertSame('Maximum insert tag nesting level of 64 reached', $exception->getMessage());
 
                 if ((int) $tagParts[1] >= 100) {
                     return (string) (new InsertTags())->replaceInternal('{{infinite-retry::'.((int) $tagParts[1] + 1).'}}', false);
@@ -838,7 +838,7 @@ class InsertTagsTest extends TestCase
         $insertTagParser = new InsertTagParser($this->mockContaoFramework());
 
         $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Maximum insert tag nesting level of 100 reached');
+        $this->expectExceptionMessage('Maximum insert tag nesting level of 64 reached');
 
         $insertTagParser->replaceInline('{{infinite-nested::1}}');
     }
@@ -850,7 +850,7 @@ class InsertTagsTest extends TestCase
         $insertTagParser = new InsertTagParser($this->mockContaoFramework());
 
         $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Maximum insert tag nesting level of 100 reached');
+        $this->expectExceptionMessage('Maximum insert tag nesting level of 64 reached');
 
         $insertTagParser->replaceInline('{{infinite-recursion::1}}');
     }
@@ -862,7 +862,7 @@ class InsertTagsTest extends TestCase
         $insertTagParser = new InsertTagParser($this->mockContaoFramework());
         $output = $insertTagParser->replaceInline('{{infinite-try-catch::1}}');
 
-        $this->assertSame('[{]infinite-try-catch::101[}]', $output);
+        $this->assertSame('[{]infinite-try-catch::65[}]', $output);
     }
 
     public function testInfiniteRecursionWithCatchAndRetryInsertTag(): void
@@ -872,7 +872,7 @@ class InsertTagsTest extends TestCase
         $insertTagParser = new InsertTagParser($this->mockContaoFramework());
 
         $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Maximum insert tag nesting level of 100 reached');
+        $this->expectExceptionMessage('Maximum insert tag nesting level of 64 reached');
 
         $insertTagParser->replaceInline('{{infinite-retry::1}}');
     }


### PR DESCRIPTION
With the insert tag recursion limit of 100 you'll hit the default xdebug recursion limit when running tests:

```
1) Contao\CoreBundle\Tests\Contao\InsertTagsTest::testInfiniteRecursionWithCatchInsertTag
Error: Xdebug has detected a possible infinite loop, and aborted your script with a stack depth of '256' frames
```

For me it started working with 78  and lower. This PR sets it to 64. We could alternatively increase the level by calling sth. like `ini_set('xdebug.max_nesting_level', 1024);` in the tests but IMHO 64 is more than enough.

Credits @ausi for debugging.