### PR TITLE
Support stateless routes

### DIFF
--- a/core-bundle/src/Routing/Page/PageRoute.php
+++ b/core-bundle/src/Routing/Page/PageRoute.php
@@ -43,6 +43,7 @@ class PageRoute extends Route implements RouteObjectInterface
                 '_scope' => ContaoCoreBundle::SCOPE_FRONTEND,
                 '_locale' => LocaleUtil::formatAsLocale($pageModel->rootLanguage),
                 '_format' => 'html',
+                '_stateless' => $pageModel->includeCache && $pageModel->alwaysLoadFromCache,
                 '_canonical_route' => 'tl_page.'.$pageModel->id,
             ],
             $defaults

--- a/core-bundle/tests/Routing/Page/PageRouteTest.php
+++ b/core-bundle/tests/Routing/Page/PageRouteTest.php
@@ -108,6 +108,21 @@ class PageRouteTest extends TestCase
         $this->assertSame(['https'], $route->getSchemes());
     }
 
+    public function testRouteIsStatelessWhenPageIsAlwaysLoadedFromCache(): void
+    {
+        $route = new PageRoute($this->mockPageModel(['includeCache' => '', 'alwaysLoadFromCache' => '']));
+
+        $this->assertFalse($route->getDefaults()['_stateless']);
+
+        $route = new PageRoute($this->mockPageModel(['includeCache' => '', 'alwaysLoadFromCache' => '1']));
+
+        $this->assertFalse($route->getDefaults()['_stateless']);
+
+        $route = new PageRoute($this->mockPageModel(['includeCache' => '1', 'alwaysLoadFromCache' => '1']));
+
+        $this->assertTrue($route->getDefaults()['_stateless']);
+    }
+
     /**
      * @return PageModel&MockObject
      */


### PR DESCRIPTION
While finishing #3619 I noticed a flag in Symfony to define a route as stateless: https://symfony.com/doc/current/routing.html#stateless-routes
This appears to be similar to our "always load from cache flag". This PR enables `stateless` if the cache flag is set.

I'm unsure this is actually our case. I'm pretty sure people will use the `alwaysLoadFromCache` option even if they have extensions that use the cache. I know I did, but simply because the extension in use (Isotope 😬) does not support ESI etc. However, as far as the documentation goes, it will only produce a warning in production, so this should only help to debug in dev and not affect live systems.