### PR TITLE
Use ClockMock for time sensitive remember me token test

### DIFF
--- a/core-bundle/tests/Security/Authentication/RememberMe/ExpiringTokenBasedRememberMeServicesTest.php
+++ b/core-bundle/tests/Security/Authentication/RememberMe/ExpiringTokenBasedRememberMeServicesTest.php
@@ -17,6 +17,7 @@ use Contao\CoreBundle\Repository\RememberMeRepository;
 use Contao\CoreBundle\Security\Authentication\RememberMe\ExpiringTokenBasedRememberMeServices;
 use Contao\CoreBundle\Tests\TestCase;
 use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Bridge\PhpUnit\ClockMock;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -55,6 +56,8 @@ class ExpiringTokenBasedRememberMeServicesTest extends TestCase
 
     protected function setUp(): void
     {
+        ClockMock::withClockMock(1142164800);
+
         $this->repository = $this->createMock(RememberMeRepository::class);
 
         $user = $this->createMock(UserInterface::class);
@@ -81,6 +84,13 @@ class ExpiringTokenBasedRememberMeServicesTest extends TestCase
             'contao_frontend',
             self::$options
         );
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        ClockMock::withClockMock(false);
     }
 
     public function testExpiresExistingRecordsAndCreatesNewCookieWithNewDatabaseRecord(): void
@@ -118,7 +128,7 @@ class ExpiringTokenBasedRememberMeServicesTest extends TestCase
     public function testUpdatesCookieValueFromDatabaseIfTwoRecordsExist(): void
     {
         $this->expectTableLocking();
-        $this->expectTableReturnsEntities($this->mockEntity('baz'), $this->mockEntity('bar', new \DateTime()));
+        $this->expectTableReturnsEntities($this->mockEntity('baz'), $this->mockEntity('bar', (new \DateTime())->setTimestamp(time())));
 
         $request = $this->mockRequestWithCookie('foo', 'bar');
         $token = $this->listener->autoLogin($request);
@@ -143,7 +153,7 @@ class ExpiringTokenBasedRememberMeServicesTest extends TestCase
     {
         $this->expectTableLocking();
         $this->expectSeriesIsDeleted('foo');
-        $this->expectTableReturnsEntities($this->mockEntity('bar', null, new \DateTime('-2 years')));
+        $this->expectTableReturnsEntities($this->mockEntity('bar', null, (new \DateTime())->setTimestamp(strtotime('-2 years', time()))));
 
         $request = $this->mockRequestWithCookie('foo', 'bar');
         $this->listener->autoLogin($request);
@@ -262,7 +272,7 @@ class ExpiringTokenBasedRememberMeServicesTest extends TestCase
 
         $entity
             ->method('getLastUsed')
-            ->willReturn($lastUsed ?: new \DateTime())
+            ->willReturn($lastUsed ?: (new \DateTime())->setTimestamp(time()))
         ;
 
         $entity

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -65,6 +65,7 @@
                             <element key="3"><string>Contao\CoreBundle\Tests\Cron</string></element>
                             <element key="4"><string>Contao\CoreBundle\Security\Authentication\Provider</string></element>
                             <element key="5"><string>Contao\CoreBundle\Tests\Security\Authentication\Provider</string></element>
+                            <element key="6"><string>Contao\CoreBundle\Tests\Security\Authentication\RememberMe</string></element>
                         </array>
                     </element>
                 </array>


### PR DESCRIPTION
Use `ClockMock` for time sensitive tests in `ExpiringTokenBasedRememberMeServicesTest`.

This prevents random failure of the test as in https://github.com/contao/contao/runs/4242537045 (section PHP 7.4)