### PR TITLE
Move the ECS configuration into the tools folder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
                   composer bin ecs install --no-interaction --no-progress
 
             - name: Run ECS
-              run: tools/ecs/vendor/bin/ecs check *-bundle/bin *-bundle/src *-bundle/tests --config tools/ecs/vendor/contao/easy-coding-standard/config/default.php --no-progress-bar --ansi
+              run: tools/ecs/vendor/bin/ecs check *-bundle/bin *-bundle/src *-bundle/tests --config tools/ecs/config/default.php --no-progress-bar --ansi
 
     ecs-legacy:
         name: ECS Legacy
@@ -92,8 +92,8 @@ jobs:
 
             - name: Run ECS
               run: |
-                  tools/ecs/vendor/bin/ecs check *-bundle/src/Resources/contao --config tools/ecs/vendor/contao/easy-coding-standard/config/legacy.php --no-progress-bar --ansi
-                  tools/ecs/vendor/bin/ecs check *-bundle/src/Resources/contao/templates --config tools/ecs/vendor/contao/easy-coding-standard/config/template.php --no-progress-bar --ansi
+                  tools/ecs/vendor/bin/ecs check *-bundle/src/Resources/contao --config tools/ecs/config/legacy.php --no-progress-bar --ansi
+                  tools/ecs/vendor/bin/ecs check *-bundle/src/Resources/contao/templates --config tools/ecs/config/template.php --no-progress-bar --ansi
 
     phpstan:
         name: PHPStan

--- a/composer.json
+++ b/composer.json
@@ -262,9 +262,9 @@
             "@ecs-legacy",
             "@ecs-templates"
         ],
-        "ecs": "tools/ecs/vendor/bin/ecs check *-bundle/bin *-bundle/src *-bundle/tests --config tools/ecs/vendor/contao/easy-coding-standard/config/default.php --fix --ansi",
-        "ecs-legacy": "tools/ecs/vendor/bin/ecs check *-bundle/src/Resources/contao --config tools/ecs/vendor/contao/easy-coding-standard/config/legacy.php --fix --ansi",
-        "ecs-templates": "tools/ecs/vendor/bin/ecs check *-bundle/src/Resources/contao/templates --config tools/ecs/vendor/contao/easy-coding-standard/config/template.php --fix --ansi",
+        "ecs": "tools/ecs/vendor/bin/ecs check *-bundle/bin *-bundle/src *-bundle/tests --config tools/ecs/config/default.php --fix --ansi",
+        "ecs-legacy": "tools/ecs/vendor/bin/ecs check *-bundle/src/Resources/contao --config tools/ecs/config/legacy.php --fix --ansi",
+        "ecs-templates": "tools/ecs/vendor/bin/ecs check *-bundle/src/Resources/contao/templates --config tools/ecs/config/template.php --fix --ansi",
         "functional-tests": "vendor/bin/phpunit --testsuite=functional --colors=always",
         "monorepo-tools": "tools/monorepo/vendor/bin/monorepo-tools composer-json --validate --ansi",
         "phpstan": "tools/phpstan/vendor/bin/phpstan analyze --ansi",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -13,8 +13,8 @@ parameters:
     level: 5
 
     paths:
-        - core-bundle/src
-        - core-bundle/tests
+        - %currentWorkingDirectory%/core-bundle/src
+        - %currentWorkingDirectory%/core-bundle/tests
 
     dynamicConstantNames:
         - BE_USER_LOGGED_IN

--- a/tools/ecs/composer.json
+++ b/tools/ecs/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "contao/easy-coding-standard": "^3.3"
+        "contao/easy-coding-standard": "^4.0"
     }
 }

--- a/tools/ecs/composer.lock
+++ b/tools/ecs/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "87881aefe1c6faa5e23edc7a5a2ec019",
+    "content-hash": "de54af0d95141a0830286a4fba1c6528",
     "packages": [
         {
             "name": "contao/easy-coding-standard",
-            "version": "3.6.0",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/contao/easy-coding-standard.git",
-                "reference": "d680103a1c62a1987c60678dfed12d2b7b5f425a"
+                "reference": "621d05d44a1a76784f658f4196b02d5035d472e4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/contao/easy-coding-standard/zipball/d680103a1c62a1987c60678dfed12d2b7b5f425a",
-                "reference": "d680103a1c62a1987c60678dfed12d2b7b5f425a",
+                "url": "https://api.github.com/repos/contao/easy-coding-standard/zipball/621d05d44a1a76784f658f4196b02d5035d472e4",
+                "reference": "621d05d44a1a76784f658f4196b02d5035d472e4",
                 "shasum": ""
             },
             "require": {
@@ -47,9 +47,9 @@
             "description": "EasyCodingStandard configurations for Contao",
             "support": {
                 "issues": "https://github.com/contao/easy-coding-standard/issues",
-                "source": "https://github.com/contao/easy-coding-standard/tree/3.6.0"
+                "source": "https://github.com/contao/easy-coding-standard/tree/4.0.0"
             },
-            "time": "2021-11-17T10:22:00+00:00"
+            "time": "2021-11-23T10:27:58+00:00"
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",

--- a/tools/ecs/config/default.php
+++ b/tools/ecs/config/default.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+use PhpCsFixer\Fixer\Comment\HeaderCommentFixer;
+use PhpCsFixer\Fixer\Whitespace\MethodChainingIndentationFixer;
+use SlevomatCodingStandard\Sniffs\Variables\UnusedVariableSniff;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symplify\EasyCodingStandard\ValueObject\Option;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $containerConfigurator->import(__DIR__.'/../vendor/contao/easy-coding-standard/config/contao.php');
+
+    $parameters = $containerConfigurator->parameters();
+    $parameters->set(Option::PARALLEL, true);
+
+    $parameters->set(Option::SKIP, [
+        '*/Fixtures/system/*',
+        '*/Resources/contao/*',
+        MethodChainingIndentationFixer::class => [
+            '*/DependencyInjection/Configuration.php',
+            '*/Resources/config/*.php',
+        ],
+        UnusedVariableSniff::class => [
+            'core-bundle/tests/Session/Attribute/ArrayAttributeBagTest.php',
+            'manager-bundle/src/Resources/skeleton/*.php',
+        ],
+    ]);
+
+    $services = $containerConfigurator->services();
+    $services
+        ->set(HeaderCommentFixer::class)
+        ->call('configure', [[
+            'header' => "This file is part of Contao.\n\n(c) Leo Feyer\n\n@license LGPL-3.0-or-later",
+        ]])
+    ;
+
+    $parameters->set(Option::LINE_ENDING, "\n");
+    $parameters->set(Option::CACHE_DIRECTORY, sys_get_temp_dir().'/ecs_default_cache');
+};

--- a/tools/ecs/config/legacy.php
+++ b/tools/ecs/config/legacy.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+use Contao\EasyCodingStandard\Fixer\MultiLineLambdaFunctionArgumentsFixer;
+use PhpCsFixer\Fixer\ArrayNotation\ArraySyntaxFixer;
+use PhpCsFixer\Fixer\Basic\BracesFixer;
+use PhpCsFixer\Fixer\ClassNotation\OrderedClassElementsFixer;
+use PhpCsFixer\Fixer\ClassNotation\VisibilityRequiredFixer;
+use PhpCsFixer\Fixer\Comment\HeaderCommentFixer;
+use PhpCsFixer\Fixer\ControlStructure\TrailingCommaInMultilineFixer;
+use PhpCsFixer\Fixer\ControlStructure\YodaStyleFixer;
+use PhpCsFixer\Fixer\FunctionNotation\NoSpacesAfterFunctionNameFixer;
+use PhpCsFixer\Fixer\FunctionNotation\UseArrowFunctionsFixer;
+use PhpCsFixer\Fixer\FunctionNotation\VoidReturnFixer;
+use PhpCsFixer\Fixer\ListNotation\ListSyntaxFixer;
+use PhpCsFixer\Fixer\Operator\BinaryOperatorSpacesFixer;
+use PhpCsFixer\Fixer\Operator\ConcatSpaceFixer;
+use PhpCsFixer\Fixer\Operator\IncrementStyleFixer;
+use PhpCsFixer\Fixer\Phpdoc\NoSuperfluousPhpdocTagsFixer;
+use PhpCsFixer\Fixer\Phpdoc\PhpdocOrderFixer;
+use PhpCsFixer\Fixer\Phpdoc\PhpdocScalarFixer;
+use PhpCsFixer\Fixer\Phpdoc\PhpdocSeparationFixer;
+use PhpCsFixer\Fixer\Phpdoc\PhpdocSummaryFixer;
+use PhpCsFixer\Fixer\Phpdoc\PhpdocToCommentFixer;
+use PhpCsFixer\Fixer\ReturnNotation\ReturnAssignmentFixer;
+use PhpCsFixer\Fixer\Semicolon\MultilineWhitespaceBeforeSemicolonsFixer;
+use PhpCsFixer\Fixer\Strict\DeclareStrictTypesFixer;
+use PhpCsFixer\Fixer\Strict\StrictComparisonFixer;
+use PhpCsFixer\Fixer\Strict\StrictParamFixer;
+use PhpCsFixer\Fixer\StringNotation\SingleQuoteFixer;
+use PhpCsFixer\Fixer\Whitespace\BlankLineBeforeStatementFixer;
+use PhpCsFixer\Fixer\Whitespace\MethodChainingIndentationFixer;
+use PhpCsFixer\Fixer\Whitespace\NoExtraBlankLinesFixer;
+use SlevomatCodingStandard\Sniffs\PHP\UselessParenthesesSniff;
+use SlevomatCodingStandard\Sniffs\TypeHints\DisallowArrayTypeHintSyntaxSniff;
+use SlevomatCodingStandard\Sniffs\Variables\UnusedVariableSniff;
+use SlevomatCodingStandard\Sniffs\Variables\UselessVariableSniff;
+use SlevomatCodingStandard\Sniffs\Whitespaces\DuplicateSpacesSniff;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symplify\EasyCodingStandard\ValueObject\Option;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $containerConfigurator->import(__DIR__.'/../vendor/contao/easy-coding-standard/config/contao.php');
+
+    $parameters = $containerConfigurator->parameters();
+    $parameters->set(Option::PARALLEL, true);
+
+    $parameters->set(Option::SKIP, [
+        '*/languages/*',
+        '*/templates/*',
+        '*/themes/*',
+        BinaryOperatorSpacesFixer::class => null,
+        DeclareStrictTypesFixer::class => null,
+        DisallowArrayTypeHintSyntaxSniff::class => null,
+        DuplicateSpacesSniff::class => null,
+        IncrementStyleFixer::class => null,
+        MethodChainingIndentationFixer::class => null,
+        MultiLineLambdaFunctionArgumentsFixer::class => null,
+        MultilineWhitespaceBeforeSemicolonsFixer::class => null,
+        NoSpacesAfterFunctionNameFixer::class => null,
+        NoSuperfluousPhpdocTagsFixer::class => null,
+        OrderedClassElementsFixer::class => null,
+        PhpdocOrderFixer::class => null,
+        PhpdocScalarFixer::class => null,
+        PhpdocSeparationFixer::class => null,
+        PhpdocSummaryFixer::class => null,
+        PhpdocToCommentFixer::class => null,
+        ReturnAssignmentFixer::class => null,
+        SingleQuoteFixer::class => null,
+        StrictComparisonFixer::class => null,
+        StrictParamFixer::class => null,
+        TrailingCommaInMultilineFixer::class => null,
+        UnusedVariableSniff::class => null,
+        UseArrowFunctionsFixer::class => null,
+        UselessParenthesesSniff::class => null,
+        UselessVariableSniff::class => null,
+        VisibilityRequiredFixer::class => null,
+        VoidReturnFixer::class => null,
+        YodaStyleFixer::class => null,
+    ]);
+
+    $parameters->set(Option::INDENTATION, 'tab');
+    $parameters->set(Option::LINE_ENDING, "\n");
+    $parameters->set(Option::CACHE_DIRECTORY, sys_get_temp_dir().'/ecs_legacy_cache');
+
+    $services = $containerConfigurator->services();
+    $services
+        ->set(ArraySyntaxFixer::class)
+        ->call('configure', [[
+            'syntax' => 'long',
+        ]])
+    ;
+
+    $services
+        ->set(BlankLineBeforeStatementFixer::class)
+        ->call('configure', [[
+            // Remove "case"
+            'statements' => ['declare', 'default', 'do', 'for', 'foreach', 'if', 'return', 'switch', 'throw', 'try', 'while'],
+        ]])
+    ;
+
+    $services
+        ->set(BracesFixer::class)
+        ->call('configure', [[
+            'allow_single_line_closure' => true,
+            'position_after_anonymous_constructs' => BracesFixer::LINE_NEXT,
+            'position_after_control_structures' => BracesFixer::LINE_NEXT,
+        ]])
+    ;
+
+    $services
+        ->set(ConcatSpaceFixer::class)
+        ->call('configure', [[
+            'spacing' => 'one',
+        ]])
+    ;
+
+    $services
+        ->set(HeaderCommentFixer::class)
+        ->call('configure', [[
+            'header' => "This file is part of Contao.\n\n(c) Leo Feyer\n\n@license LGPL-3.0-or-later",
+        ]])
+    ;
+
+    $services
+        ->set(ListSyntaxFixer::class)
+        ->call('configure', [[
+            'syntax' => 'long',
+        ]])
+    ;
+
+    $services
+        ->set(NoExtraBlankLinesFixer::class)
+        ->call('configure', [[
+            // Remove "throw"
+            'tokens' => ['curly_brace_block', 'extra', 'parenthesis_brace_block', 'square_brace_block', 'use'],
+        ]])
+    ;
+};

--- a/tools/ecs/config/template.php
+++ b/tools/ecs/config/template.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+use PhpCsFixer\Fixer\ClassNotation\VisibilityRequiredFixer;
+use PhpCsFixer\Fixer\Comment\HeaderCommentFixer;
+use PhpCsFixer\Fixer\ControlStructure\NoAlternativeSyntaxFixer;
+use PhpCsFixer\Fixer\FunctionNotation\VoidReturnFixer;
+use PhpCsFixer\Fixer\PhpTag\BlankLineAfterOpeningTagFixer;
+use PhpCsFixer\Fixer\PhpTag\LinebreakAfterOpeningTagFixer;
+use PhpCsFixer\Fixer\Semicolon\SemicolonAfterInstructionFixer;
+use PhpCsFixer\Fixer\Strict\DeclareStrictTypesFixer;
+use PhpCsFixer\Fixer\Strict\StrictComparisonFixer;
+use PhpCsFixer\Fixer\Strict\StrictParamFixer;
+use SlevomatCodingStandard\Sniffs\Namespaces\ReferenceUsedNamesOnlySniff;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symplify\EasyCodingStandard\ValueObject\Option;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $containerConfigurator->import(__DIR__.'/../vendor/contao/easy-coding-standard/config/contao.php');
+
+    $parameters = $containerConfigurator->parameters();
+    $parameters->set(Option::PARALLEL, true);
+
+    $parameters->set(Option::SKIP, [
+        BlankLineAfterOpeningTagFixer::class => null,
+        DeclareStrictTypesFixer::class => null,
+        HeaderCommentFixer::class => null,
+        LinebreakAfterOpeningTagFixer::class => null,
+        NoAlternativeSyntaxFixer::class => null,
+        ReferenceUsedNamesOnlySniff::class => null,
+        SemicolonAfterInstructionFixer::class => null,
+        StrictComparisonFixer::class => null,
+        StrictParamFixer::class => null,
+        VisibilityRequiredFixer::class => null,
+        VoidReturnFixer::class => null,
+    ]);
+
+    $parameters->set(Option::FILE_EXTENSIONS, ['html5']);
+    $parameters->set(Option::CACHE_DIRECTORY, sys_get_temp_dir().'/ecs_template_cache');
+};


### PR DESCRIPTION
So we can remove the `contao/contao` specific configuration from `contao/easy-coding-standard`.