### PR TITLE
Add the missing @throws tags

### DIFF
--- a/core-bundle/src/Controller/BackendCsvImportController.php
+++ b/core-bundle/src/Controller/BackendCsvImportController.php
@@ -20,6 +20,7 @@ use Contao\DataContainer;
 use Contao\FileUpload;
 use Contao\Message;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -100,6 +101,7 @@ class BackendCsvImportController
     }
 
     /**
+     * @throws Exception
      * @throws InternalServerErrorException
      */
     private function importFromTemplate(callable $callback, string $table, string $field, int $id, string $submitLabel = null, bool $allowLinebreak = false): Response

--- a/core-bundle/src/Controller/BackendCsvImportController.php
+++ b/core-bundle/src/Controller/BackendCsvImportController.php
@@ -53,6 +53,9 @@ class BackendCsvImportController
         $this->projectDir = $projectDir;
     }
 
+    /**
+     * @throws Exception
+     */
     public function importListWizardAction(DataContainer $dc): Response
     {
         return $this->importFromTemplate(
@@ -65,6 +68,9 @@ class BackendCsvImportController
         );
     }
 
+    /**
+     * @throws Exception
+     */
     public function importTableWizardAction(DataContainer $dc): Response
     {
         return $this->importFromTemplate(
@@ -80,6 +86,9 @@ class BackendCsvImportController
         );
     }
 
+    /**
+     * @throws Exception
+     */
     public function importOptionWizardAction(DataContainer $dc): Response
     {
         return $this->importFromTemplate(
@@ -246,8 +255,6 @@ class BackendCsvImportController
 
     /**
      * Returns the uploaded files from a FileUpload instance.
-     *
-     * @throws \RuntimeException
      *
      * @return array<string>
      */

--- a/core-bundle/src/Controller/BackendPreviewSwitchController.php
+++ b/core-bundle/src/Controller/BackendPreviewSwitchController.php
@@ -63,6 +63,8 @@ class BackendPreviewSwitchController
 
     /**
      * @Route("/preview_switch", name="contao_backend_switch")
+     *
+     * @throws Exception
      */
     public function __invoke(Request $request): Response
     {

--- a/core-bundle/src/Controller/BackendPreviewSwitchController.php
+++ b/core-bundle/src/Controller/BackendPreviewSwitchController.php
@@ -17,6 +17,7 @@ use Contao\CoreBundle\Security\Authentication\FrontendPreviewAuthenticator;
 use Contao\CoreBundle\Security\Authentication\Token\TokenChecker;
 use Contao\Date;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -129,6 +130,9 @@ class BackendPreviewSwitchController
         }
     }
 
+    /**
+     * @throws Exception
+     */
     private function getMembersDataList(BackendUser $user, Request $request): array
     {
         $andWhereGroups = '';

--- a/core-bundle/src/Crawl/Escargot/Subscriber/BrokenLinkCheckerSubscriber.php
+++ b/core-bundle/src/Crawl/Escargot/Subscriber/BrokenLinkCheckerSubscriber.php
@@ -81,6 +81,9 @@ class BrokenLinkCheckerSubscriber implements EscargotSubscriberInterface, Escarg
         return SubscriberInterface::DECISION_POSITIVE;
     }
 
+    /**
+     * @throws TransportExceptionInterface
+     */
     public function needsContent(CrawlUri $crawlUri, ResponseInterface $response, ChunkInterface $chunk): string
     {
         $statusCode = $response->getStatusCode();

--- a/core-bundle/src/Crawl/Escargot/Subscriber/BrokenLinkCheckerSubscriber.php
+++ b/core-bundle/src/Crawl/Escargot/Subscriber/BrokenLinkCheckerSubscriber.php
@@ -134,6 +134,9 @@ class BrokenLinkCheckerSubscriber implements EscargotSubscriberInterface, Escarg
         $this->logError($crawlUri, 'Could not request properly: '.$exception->getMessage());
     }
 
+    /**
+     * @throws TransportExceptionInterface
+     */
     public function onHttpException(CrawlUri $crawlUri, HttpExceptionInterface $exception, ResponseInterface $response, ChunkInterface $chunk): void
     {
         $this->logError($crawlUri, 'HTTP Status Code: '.$response->getStatusCode());

--- a/core-bundle/src/DependencyInjection/Compiler/AddCronJobsPass.php
+++ b/core-bundle/src/DependencyInjection/Compiler/AddCronJobsPass.php
@@ -64,6 +64,7 @@ class AddCronJobsPass implements CompilerPassInterface
     }
 
     /**
+     * @throws \ReflectionException
      * @throws InvalidDefinitionException
      */
     private function getMethod(array $attributes, string $class, string $serviceId): ?string

--- a/core-bundle/src/Doctrine/Backup/Dumper.php
+++ b/core-bundle/src/Doctrine/Backup/Dumper.php
@@ -14,6 +14,7 @@ namespace Contao\CoreBundle\Doctrine\Backup;
 
 use Contao\CoreBundle\Doctrine\Backup\Config\CreateConfig;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\Column;
@@ -119,6 +120,8 @@ class Dumper implements DumperInterface
     }
 
     /**
+     * @throws Exception
+     *
      * @return array<Table>
      */
     private function getTablesToDump(AbstractSchemaManager $schemaManager, CreateConfig $config): array

--- a/core-bundle/src/EventListener/BackendRebuildCacheMessageListener.php
+++ b/core-bundle/src/EventListener/BackendRebuildCacheMessageListener.php
@@ -14,6 +14,7 @@ namespace Contao\CoreBundle\EventListener;
 
 use Contao\CoreBundle\Routing\ScopeMatcher;
 use Psr\Cache\CacheItemPoolInterface;
+use Psr\Cache\InvalidArgumentException;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -36,6 +37,9 @@ class BackendRebuildCacheMessageListener
         $this->translator = $translator;
     }
 
+    /**
+     * @throws InvalidArgumentException
+     */
     public function __invoke(RequestEvent $event): void
     {
         $request = $event->getRequest();

--- a/core-bundle/src/EventListener/CommandSchedulerListener.php
+++ b/core-bundle/src/EventListener/CommandSchedulerListener.php
@@ -17,6 +17,7 @@ use Contao\CoreBundle\Cron\Cron;
 use Contao\CoreBundle\Framework\ContaoFramework;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception;
+use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\TerminateEvent;
@@ -41,6 +42,8 @@ class CommandSchedulerListener
 
     /**
      * Runs the command scheduler.
+     *
+     * @throws ContainerExceptionInterface
      */
     public function __invoke(TerminateEvent $event): void
     {

--- a/core-bundle/src/EventListener/DataContainer/PageUrlListener.php
+++ b/core-bundle/src/EventListener/DataContainer/PageUrlListener.php
@@ -21,6 +21,7 @@ use Contao\Input;
 use Contao\PageModel;
 use Contao\Search;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception;
 use Symfony\Contracts\Service\ResetInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
@@ -209,6 +210,7 @@ class PageUrlListener implements ResetInterface
 
     /**
      * @throws DuplicateAliasException
+     * @throws Exception
      */
     private function aliasExists(string $currentAlias, int $currentId, PageModel $currentPage, bool $throw = false): bool
     {

--- a/core-bundle/src/Image/Studio/FigureBuilder.php
+++ b/core-bundle/src/Image/Studio/FigureBuilder.php
@@ -24,7 +24,9 @@ use Contao\Image\ResizeOptions;
 use Contao\PageModel;
 use Contao\StringUtil;
 use Contao\Validator;
+use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
+use Psr\Container\NotFoundExceptionInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Webmozart\PathUtil\Path;
 
@@ -210,6 +212,9 @@ class FigureBuilder
      * Sets the image resource from an absolute or relative path.
      *
      * @param bool $autoDetectDbafsPaths Set to false to skip searching for a FilesModel
+     *
+     * @throws ContainerExceptionInterface
+     * @throws NotFoundExceptionInterface
      */
     public function fromPath(string $path, bool $autoDetectDbafsPaths = true): self
     {
@@ -249,6 +254,9 @@ class FigureBuilder
      * Sets the image resource by guessing the identifier type.
      *
      * @param int|string|FilesModel|ImageInterface|null $identifier Can be a FilesModel, an ImageInterface, a tl_files UUID/ID/path or a file system path
+     *
+     * @throws ContainerExceptionInterface
+     * @throws NotFoundExceptionInterface
      */
     public function from($identifier): self
     {
@@ -689,6 +697,9 @@ class FigureBuilder
     }
 
     /**
+     * @throws ContainerExceptionInterface
+     * @throws NotFoundExceptionInterface
+     *
      * @return FilesModel
      *
      * @phpstan-return Adapter<FilesModel>
@@ -702,6 +713,9 @@ class FigureBuilder
     }
 
     /**
+     * @throws ContainerExceptionInterface
+     * @throws NotFoundExceptionInterface
+     *
      * @return Validator
      *
      * @phpstan-return Adapter<Validator>

--- a/core-bundle/src/Image/Studio/FigureBuilder.php
+++ b/core-bundle/src/Image/Studio/FigureBuilder.php
@@ -174,6 +174,8 @@ class FigureBuilder
 
     /**
      * Sets the image resource from a tl_files UUID.
+     *
+     * @throws ContainerExceptionInterface
      */
     public function fromUuid(string $uuid): self
     {

--- a/core-bundle/src/Image/Studio/LightboxResult.php
+++ b/core-bundle/src/Image/Studio/LightboxResult.php
@@ -19,7 +19,9 @@ use Contao\Image\ResizeOptions;
 use Contao\LayoutModel;
 use Contao\PageModel;
 use Contao\StringUtil;
+use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
+use Psr\Container\NotFoundExceptionInterface;
 
 class LightboxResult
 {
@@ -33,6 +35,9 @@ class LightboxResult
      * @param array|PictureConfiguration|int|string|null $sizeConfiguration
      *
      * @internal Use the Contao\CoreBundle\Image\Studio\Studio factory to get an instance of this class
+     *
+     * @throws ContainerExceptionInterface
+     * @throws NotFoundExceptionInterface
      */
     public function __construct(ContainerInterface $locator, $filePathOrImage, ?string $url, $sizeConfiguration = null, string $groupIdentifier = null, ResizeOptions $resizeOptions = null)
     {

--- a/core-bundle/src/Image/Studio/Studio.php
+++ b/core-bundle/src/Image/Studio/Studio.php
@@ -15,6 +15,7 @@ namespace Contao\CoreBundle\Image\Studio;
 use Contao\Image\ImageInterface;
 use Contao\Image\PictureConfiguration;
 use Contao\Image\ResizeOptions;
+use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
 
 class Studio
@@ -52,6 +53,8 @@ class Studio
     /**
      * @param string|ImageInterface|null                 $filePathOrImage
      * @param array|PictureConfiguration|int|string|null $sizeConfiguration
+     *
+     * @throws ContainerExceptionInterface
      */
     public function createLightboxImage($filePathOrImage, string $url = null, $sizeConfiguration = null, string $groupIdentifier = null, ResizeOptions $resizeOptions = null): LightboxResult
     {

--- a/core-bundle/src/Migration/Version409/CeAccessMigration.php
+++ b/core-bundle/src/Migration/Version409/CeAccessMigration.php
@@ -16,6 +16,7 @@ use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\CoreBundle\Migration\AbstractMigration;
 use Contao\CoreBundle\Migration\MigrationResult;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception;
 
 /**
  * @internal
@@ -31,6 +32,9 @@ class CeAccessMigration extends AbstractMigration
         $this->framework = $framework;
     }
 
+    /**
+     * @throws Exception
+     */
     public function shouldRun(): bool
     {
         $schemaManager = $this->connection->createSchemaManager();

--- a/core-bundle/src/Migration/Version409/CeAccessMigration.php
+++ b/core-bundle/src/Migration/Version409/CeAccessMigration.php
@@ -16,6 +16,7 @@ use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\CoreBundle\Migration\AbstractMigration;
 use Contao\CoreBundle\Migration\MigrationResult;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver\Exception as DriverException;
 use Doctrine\DBAL\Exception;
 
 /**
@@ -48,6 +49,10 @@ class CeAccessMigration extends AbstractMigration
         return !isset($columns['elements']);
     }
 
+    /**
+     * @throws DriverException
+     * @throws Exception
+     */
     public function run(): MigrationResult
     {
         $this->framework->initialize();

--- a/core-bundle/src/Migration/Version412/AllowedExcludedFieldsMigration.php
+++ b/core-bundle/src/Migration/Version412/AllowedExcludedFieldsMigration.php
@@ -16,6 +16,7 @@ use Contao\CoreBundle\Migration\AbstractMigration;
 use Contao\CoreBundle\Migration\MigrationResult;
 use Contao\StringUtil;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception;
 
 /**
  * @internal
@@ -29,6 +30,9 @@ class AllowedExcludedFieldsMigration extends AbstractMigration
         $this->connection = $connection;
     }
 
+    /**
+     * @throws Exception
+     */
     public function shouldRun(): bool
     {
         $schemaManager = $this->connection->createSchemaManager();

--- a/core-bundle/src/Migration/Version412/AllowedExcludedFieldsMigration.php
+++ b/core-bundle/src/Migration/Version412/AllowedExcludedFieldsMigration.php
@@ -16,6 +16,7 @@ use Contao\CoreBundle\Migration\AbstractMigration;
 use Contao\CoreBundle\Migration\MigrationResult;
 use Contao\StringUtil;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver\Exception as DriverException;
 use Doctrine\DBAL\Exception;
 
 /**
@@ -75,6 +76,10 @@ class AllowedExcludedFieldsMigration extends AbstractMigration
         return false;
     }
 
+    /**
+     * @throws DriverException
+     * @throws Exception
+     */
     public function run(): MigrationResult
     {
         $groups = $this->connection->fetchAllAssociative("

--- a/core-bundle/src/Monolog/ContaoTableHandler.php
+++ b/core-bundle/src/Monolog/ContaoTableHandler.php
@@ -15,6 +15,7 @@ namespace Contao\CoreBundle\Monolog;
 use Contao\StringUtil;
 use Contao\System;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Statement;
 use Monolog\Formatter\FormatterInterface;
 use Monolog\Formatter\LineFormatter;
@@ -93,6 +94,7 @@ class ContaoTableHandler extends AbstractProcessingHandler implements ContainerA
      * Verifies the database connection and prepares the statement.
      *
      * @throws \RuntimeException
+     * @throws Exception
      */
     private function createStatement(): void
     {

--- a/core-bundle/src/Picker/AbstractTablePickerProvider.php
+++ b/core-bundle/src/Picker/AbstractTablePickerProvider.php
@@ -41,6 +41,9 @@ abstract class AbstractTablePickerProvider implements PickerProviderInterface, D
         $this->connection = $connection;
     }
 
+    /**
+     * @throws Exception
+     */
     public function getUrl(PickerConfig $config): string
     {
         $table = $this->getTableFromContext($config->getContext());

--- a/core-bundle/src/Picker/AbstractTablePickerProvider.php
+++ b/core-bundle/src/Picker/AbstractTablePickerProvider.php
@@ -15,6 +15,7 @@ namespace Contao\CoreBundle\Picker;
 use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\DcaLoader;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception;
 use Knp\Menu\FactoryInterface;
 use Knp\Menu\ItemInterface;
 use Symfony\Component\Routing\RouterInterface;
@@ -208,6 +209,9 @@ abstract class AbstractTablePickerProvider implements PickerProviderInterface, D
         return $this->router->generate('contao_backend', $params);
     }
 
+    /**
+     * @throws Exception
+     */
     protected function getPtableAndPid(string $table, string $value): array
     {
         // Use the first value if array to find a database record

--- a/core-bundle/src/Resources/contao/library/Contao/File.php
+++ b/core-bundle/src/Resources/contao/library/Contao/File.php
@@ -127,7 +127,7 @@ class File extends System
 	 *
 	 * @param string $strFile The file path
 	 *
-	 * @throws \Exception If $strFile is a directory
+	 * @throws \LogicException If $strFile is a directory
 	 */
 	public function __construct($strFile)
 	{
@@ -142,7 +142,7 @@ class File extends System
 		// Make sure we are not pointing to a directory
 		if (is_dir($this->strRootDir . '/' . $strFile))
 		{
-			throw new \Exception(sprintf('Directory "%s" is not a file', $strFile));
+			throw new \LogicException(sprintf('Directory "%s" is not a file', $strFile));
 		}
 
 		$this->import(Files::class, 'Files');

--- a/core-bundle/src/Resources/contao/library/Contao/Model.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Model.php
@@ -568,7 +568,7 @@ abstract class Model
 	 *
 	 * @return static|Collection|null The model or a model collection if there are multiple rows
 	 *
-	 * @throws \Exception If $strKey is not a related field
+	 * @throws \LogicException If $strKey is not a related field
 	 */
 	public function getRelated($strKey, array $arrOptions=array())
 	{
@@ -583,7 +583,7 @@ abstract class Model
 		{
 			$table = static::getTable();
 
-			throw new \Exception("Field $table.$strKey does not seem to be related");
+			throw new \LogicException("Field $table.$strKey does not seem to be related");
 		}
 
 		// The relation exists but there is no reference yet (see #6161 and #458)

--- a/core-bundle/src/Twig/Inheritance/DynamicIncludeTokenParser.php
+++ b/core-bundle/src/Twig/Inheritance/DynamicIncludeTokenParser.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Twig\Inheritance;
 
 use Contao\CoreBundle\Twig\ContaoTwigUtil;
+use Twig\Error\SyntaxError;
 use Twig\Node\Expression\ArrayExpression;
 use Twig\Node\Expression\ConstantExpression;
 use Twig\Node\IncludeNode;
@@ -70,6 +71,9 @@ final class DynamicIncludeTokenParser extends AbstractTokenParser
         }
     }
 
+    /**
+     * @throws SyntaxError
+     */
     private function parseArguments(): array
     {
         $stream = $this->parser->getStream();

--- a/core-bundle/src/Twig/Interop/ContaoEscaper.php
+++ b/core-bundle/src/Twig/Interop/ContaoEscaper.php
@@ -32,6 +32,8 @@ final class ContaoEscaper
      * htmlspecialchars with the double_encode parameter set to false.
      *
      * @see twig_escape_filter
+     *
+     * @throws RuntimeError
      */
     public function escapeHtml(Environment $environment, $string, ?string $charset): string
     {
@@ -56,6 +58,8 @@ final class ContaoEscaper
      * replaces insert tags and decodes entities beforehand.
      *
      * @see twig_escape_filter
+     *
+     * @throws RuntimeError
      */
     public function escapeHtmlAttr(Environment $environment, $string, ?string $charset): string
     {

--- a/core-bundle/src/Twig/Loader/ContaoFilesystemLoader.php
+++ b/core-bundle/src/Twig/Loader/ContaoFilesystemLoader.php
@@ -16,6 +16,7 @@ use Contao\CoreBundle\Exception\InvalidThemePathException;
 use Contao\CoreBundle\Twig\ContaoTwigUtil;
 use Contao\CoreBundle\Twig\Inheritance\TemplateHierarchyInterface;
 use Psr\Cache\CacheItemPoolInterface;
+use Psr\Cache\InvalidArgumentException;
 use Symfony\Contracts\Service\ResetInterface;
 use Twig\Error\LoaderError;
 use Twig\Loader\FilesystemLoader;
@@ -66,6 +67,9 @@ class ContaoFilesystemLoader extends FilesystemLoader implements TemplateHierarc
      */
     private $currentThemeSlug;
 
+    /**
+     * @throws InvalidArgumentException
+     */
     public function __construct(CacheItemPoolInterface $cachePool, TemplateLocator $templateLocator, ThemeNamespace $themeNamespace, string $rootPath = null)
     {
         parent::__construct([], $rootPath);
@@ -97,6 +101,8 @@ class ContaoFilesystemLoader extends FilesystemLoader implements TemplateHierarc
      *
      * @param string $path      A path where to look for templates
      * @param string $namespace A "Contao" or "Contao_*" path namespace
+     *
+     * @throws LoaderError
      */
     public function addPath(string $path, string $namespace = 'Contao', bool $trackTemplates = false): void
     {
@@ -123,6 +129,8 @@ class ContaoFilesystemLoader extends FilesystemLoader implements TemplateHierarc
      *
      * @param string $path      A path where to look for templates
      * @param string $namespace A "Contao" or "Contao_*" path namespace
+     *
+     * @throws LoaderError
      */
     public function prependPath(string $path, string $namespace = 'Contao'): void
     {
@@ -154,6 +162,8 @@ class ContaoFilesystemLoader extends FilesystemLoader implements TemplateHierarc
     /**
      * Writes the currently registered template paths and hierarchy to the
      * cache.
+     *
+     * @throws InvalidArgumentException
      */
     public function persist(): void
     {
@@ -175,6 +185,8 @@ class ContaoFilesystemLoader extends FilesystemLoader implements TemplateHierarc
      *
      * @param string $name The name of the template to load
      *
+     * @throws LoaderError
+     *
      * @return string The cache key
      */
     public function getCacheKey(string $name): string
@@ -191,6 +203,8 @@ class ContaoFilesystemLoader extends FilesystemLoader implements TemplateHierarc
      * the template exists, its source context will be returned instead.
      *
      * @param string $name The template logical name
+     *
+     * @throws LoaderError
      */
     public function getSourceContext(string $name): Source
     {
@@ -260,6 +274,8 @@ class ContaoFilesystemLoader extends FilesystemLoader implements TemplateHierarc
      * @param string $name The template name
      * @param int    $time Timestamp of the last modification time of the
      *                     cached template
+     *
+     * @throws LoaderError
      *
      * @return bool true if the template is fresh, false otherwise
      */

--- a/core-bundle/src/Twig/Loader/TemplateLocator.php
+++ b/core-bundle/src/Twig/Loader/TemplateLocator.php
@@ -15,6 +15,7 @@ namespace Contao\CoreBundle\Twig\Loader;
 use Contao\CoreBundle\Exception\InvalidThemePathException;
 use Contao\CoreBundle\HttpKernel\Bundle\ContaoModuleBundle;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Exception\ConnectionException;
 use Doctrine\DBAL\Exception\TableNotFoundException;
 use Symfony\Component\Finder\Finder;
@@ -49,6 +50,8 @@ class TemplateLocator
     }
 
     /**
+     * @throws Exception
+     *
      * @return array<string, string>
      */
     public function findThemeDirectories(): array

--- a/core-bundle/tests/Crawl/Escargot/Subscriber/BrokenLinkCheckerSubscriberTest.php
+++ b/core-bundle/tests/Crawl/Escargot/Subscriber/BrokenLinkCheckerSubscriberTest.php
@@ -24,6 +24,7 @@ use Symfony\Component\HttpClient\Exception\ClientException;
 use Symfony\Component\HttpClient\Exception\TransportException;
 use Symfony\Contracts\HttpClient\ChunkInterface;
 use Symfony\Contracts\HttpClient\Exception\HttpExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Terminal42\Escargot\BaseUriCollection;
@@ -123,6 +124,8 @@ class BrokenLinkCheckerSubscriberTest extends TestCase
 
     /**
      * @dataProvider needsContentProvider
+     *
+     * @throws TransportExceptionInterface
      */
     public function testNeedsContent(CrawlUri $crawlUri, ResponseInterface $response, string $expectedDecision, string $expectedLogLevel, string $expectedLogMessage, array $expectedStats, array $previousStats = []): void
     {

--- a/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
+++ b/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
@@ -490,6 +490,8 @@ class ContaoCoreExtensionTest extends TestCase
 
     /**
      * @dataProvider provideComposerJsonContent
+     *
+     * @throws \JsonException
      */
     public function testSetsTheWebDirFromTheRootComposerJson(array $composerJson, string $expectedWebDir): void
     {

--- a/core-bundle/tests/Doctrine/DBAL/Types/BinaryStringTypeTest.php
+++ b/core-bundle/tests/Doctrine/DBAL/Types/BinaryStringTypeTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Tests\Doctrine\DBAL\Types;
 
 use Contao\CoreBundle\Doctrine\DBAL\Types\BinaryStringType;
+use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type;
 use PHPUnit\Framework\TestCase;
@@ -21,6 +22,9 @@ class BinaryStringTypeTest extends TestCase
 {
     private Type $type;
 
+    /**
+     * @throws Exception
+     */
     public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();

--- a/core-bundle/tests/Doctrine/DBAL/Types/BinaryStringTypeTest.php
+++ b/core-bundle/tests/Doctrine/DBAL/Types/BinaryStringTypeTest.php
@@ -32,6 +32,9 @@ class BinaryStringTypeTest extends TestCase
         Type::addType(BinaryStringType::NAME, BinaryStringType::class);
     }
 
+    /**
+     * @throws Exception
+     */
     protected function setUp(): void
     {
         parent::setUp();

--- a/core-bundle/tests/Doctrine/DoctrineTestCase.php
+++ b/core-bundle/tests/Doctrine/DoctrineTestCase.php
@@ -23,9 +23,11 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\SchemaConfig;
+use Doctrine\DBAL\Schema\SchemaException;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
+use Doctrine\ORM\ORMException;
 use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use PHPUnit\Framework\MockObject\MockObject;
 
@@ -108,6 +110,8 @@ abstract class DoctrineTestCase extends TestCase
 
     /**
      * Returns an empty Schema which has the default table options set.
+     *
+     * @throws SchemaException
      */
     protected function getSchema(): Schema
     {
@@ -120,6 +124,8 @@ abstract class DoctrineTestCase extends TestCase
     /**
      * Returns an EntityManager configured to load the annotated entities in
      * the tests/Fixture/Entity directory.
+     *
+     * @throws ORMException
      */
     protected function getTestEntityManager(): EntityManager
     {

--- a/core-bundle/tests/Doctrine/Schema/DcaSchemaProviderTest.php
+++ b/core-bundle/tests/Doctrine/Schema/DcaSchemaProviderTest.php
@@ -21,6 +21,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\SchemaException;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\ORM\Mapping\Builder\ClassMetadataBuilder;
 use Doctrine\ORM\Mapping\ClassMetadata;
@@ -345,6 +346,8 @@ class DcaSchemaProviderTest extends DoctrineTestCase
      * @dataProvider provideIndexes
      *
      * @param bool|string $largePrefixes
+     *
+     * @throws SchemaException
      */
     public function testAppendToSchemaAddsTheIndexLength(?int $expected, string $tableOptions, $largePrefixes = null, string $version = null, string $filePerTable = null, string $fileFormat = null): void
     {

--- a/core-bundle/tests/EventListener/BackendRebuildCacheMessageListenerTest.php
+++ b/core-bundle/tests/EventListener/BackendRebuildCacheMessageListenerTest.php
@@ -16,6 +16,7 @@ use Contao\CoreBundle\EventListener\BackendRebuildCacheMessageListener;
 use Contao\CoreBundle\Routing\ScopeMatcher;
 use Contao\CoreBundle\Tests\TestCase;
 use Psr\Cache\CacheItemPoolInterface;
+use Psr\Cache\InvalidArgumentException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
 use Symfony\Component\HttpFoundation\Session\Session;
@@ -28,6 +29,8 @@ class BackendRebuildCacheMessageListenerTest extends TestCase
 {
     /**
      * @dataProvider provideRequestAndDirty
+     *
+     * @throws InvalidArgumentException
      */
     public function testDoesNotAddMessageIfNotBackendRequestOrAppCacheIsNotDirty(bool $backendRequest, bool $dirty): void
     {
@@ -72,6 +75,9 @@ class BackendRebuildCacheMessageListenerTest extends TestCase
         yield [false, false];
     }
 
+    /**
+     * @throws InvalidArgumentException
+     */
     public function testAddsMessage(): void
     {
         $scopeMatcher = $this->createMock(ScopeMatcher::class);

--- a/core-bundle/tests/Mailer/AvailableTransportsTest.php
+++ b/core-bundle/tests/Mailer/AvailableTransportsTest.php
@@ -20,6 +20,9 @@ use Doctrine\Common\Annotations\AnnotationReader;
 
 class AvailableTransportsTest extends TestCase
 {
+    /**
+     * @throws \ReflectionException
+     */
     public function testAnnotatedCallbacks(): void
     {
         $service = new AvailableTransports();

--- a/core-bundle/tests/Migration/Version409/CeAccessMigrationTest.php
+++ b/core-bundle/tests/Migration/Version409/CeAccessMigrationTest.php
@@ -17,6 +17,7 @@ use Contao\CoreBundle\Migration\Version409\CeAccessMigration;
 use Contao\CoreBundle\Tests\TestCase;
 use Contao\FormTextField;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver\Exception as DriverException;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\MySQLSchemaManager;
@@ -48,6 +49,10 @@ class CeAccessMigrationTest extends TestCase
         unset($GLOBALS['TL_CTE'], $GLOBALS['TL_FFL']);
     }
 
+    /**
+     * @throws DriverException
+     * @throws Exception
+     */
     public function testActivatesTheFieldsInAllUserGroups(): void
     {
         $schemaManager = $this->createMock(MySQLSchemaManager::class);
@@ -95,6 +100,9 @@ class CeAccessMigrationTest extends TestCase
         $this->assertTrue($migration->run()->isSuccessful());
     }
 
+    /**
+     * @throws Exception
+     */
     public function testDoesNothingIfTheUserGroupTableDoesNotExist(): void
     {
         $schemaManager = $this->createMock(MySQLSchemaManager::class);

--- a/core-bundle/tests/Migration/Version409/CeAccessMigrationTest.php
+++ b/core-bundle/tests/Migration/Version409/CeAccessMigrationTest.php
@@ -17,8 +17,10 @@ use Contao\CoreBundle\Migration\Version409\CeAccessMigration;
 use Contao\CoreBundle\Tests\TestCase;
 use Contao\FormTextField;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\MySQLSchemaManager;
+use Doctrine\DBAL\Schema\SchemaException;
 use Doctrine\DBAL\Statement;
 use Doctrine\DBAL\Types\Type;
 
@@ -126,6 +128,10 @@ class CeAccessMigrationTest extends TestCase
         $this->assertFalse($migration->shouldRun());
     }
 
+    /**
+     * @throws Exception
+     * @throws SchemaException
+     */
     public function testDoesNothingIfTheElementsColumnDoesNotExist(): void
     {
         $schemaManager = $this->createMock(MySQLSchemaManager::class);

--- a/core-bundle/tests/Routing/AbstractPageRouteProviderTest.php
+++ b/core-bundle/tests/Routing/AbstractPageRouteProviderTest.php
@@ -22,6 +22,8 @@ class AbstractPageRouteProviderTest extends TestCase
 {
     /**
      * @dataProvider compareRoutesProvider
+     *
+     * @throws \ReflectionException
      */
     public function testCompareRoutes(Route $a, Route $b, ?array $languages, int $expected): void
     {
@@ -243,6 +245,8 @@ class AbstractPageRouteProviderTest extends TestCase
 
     /**
      * @dataProvider ordersRoutesByPreferredLanguages
+     *
+     * @throws \ReflectionException
      */
     public function testOrdersRoutesByPreferredLanguages(array $pageLanguages, array $preferredLanguages, array $expected): void
     {
@@ -359,6 +363,8 @@ class AbstractPageRouteProviderTest extends TestCase
 
     /**
      * @dataProvider convertLanguageForSortingProvider
+     *
+     * @throws \ReflectionException
      */
     public function testConvertLanguagesForSorting(array $languages, array $expected): void
     {

--- a/core-bundle/tests/Twig/Inheritance/DynamicIncludeTokenParserTest.php
+++ b/core-bundle/tests/Twig/Inheritance/DynamicIncludeTokenParserTest.php
@@ -16,6 +16,7 @@ use Contao\CoreBundle\Tests\TestCase;
 use Contao\CoreBundle\Twig\Inheritance\DynamicIncludeTokenParser;
 use Contao\CoreBundle\Twig\Inheritance\TemplateHierarchyInterface;
 use Twig\Environment;
+use Twig\Error\SyntaxError;
 use Twig\Lexer;
 use Twig\Loader\LoaderInterface;
 use Twig\Node\Expression\AbstractExpression;
@@ -35,6 +36,8 @@ class DynamicIncludeTokenParserTest extends TestCase
 
     /**
      * @dataProvider provideSources
+     *
+     * @throws SyntaxError
      */
     public function testHandlesContaoIncludes(string $code, string ...$expectedStrings): void
     {
@@ -103,6 +106,9 @@ class DynamicIncludeTokenParserTest extends TestCase
         ];
     }
 
+    /**
+     * @throws SyntaxError
+     */
     public function testEnhancesErrorMessageWhenIncludingAnInvalidTemplate(): void
     {
         $templateHierarchy = $this->createMock(TemplateHierarchyInterface::class);
@@ -131,6 +137,8 @@ class DynamicIncludeTokenParserTest extends TestCase
 
     /**
      * @dataProvider provideTokens
+     *
+     * @throws SyntaxError
      */
     public function testParsesArguments(string $source, ?AbstractExpression $variables, bool $only, bool $ignoreMissing): void
     {

--- a/core-bundle/tests/Twig/Interop/ContaoEscaperNodeVisitorTest.php
+++ b/core-bundle/tests/Twig/Interop/ContaoEscaperNodeVisitorTest.php
@@ -22,6 +22,9 @@ use Contao\CoreBundle\Twig\Interop\ContaoEscaperNodeVisitor;
 use Contao\CoreBundle\Twig\Runtime\InsertTagRuntime;
 use Contao\System;
 use Twig\Environment;
+use Twig\Error\LoaderError;
+use Twig\Error\RuntimeError;
+use Twig\Error\SyntaxError;
 use Twig\Loader\ArrayLoader;
 use Twig\RuntimeLoader\FactoryRuntimeLoader;
 use Twig\TwigFunction;
@@ -35,6 +38,11 @@ class ContaoEscaperNodeVisitorTest extends TestCase
         $this->assertSame(1, $visitor->getPriority());
     }
 
+    /**
+     * @throws LoaderError
+     * @throws RuntimeError
+     * @throws SyntaxError
+     */
     public function testEscapesEntities(): void
     {
         $templateContent = '<h1>{{ headline }}</h1><p>{{ content|raw }}</p>';

--- a/core-bundle/tests/Twig/Interop/ContaoEscaperTest.php
+++ b/core-bundle/tests/Twig/Interop/ContaoEscaperTest.php
@@ -151,6 +151,9 @@ class ContaoEscaperTest extends TestCase
         $this->invokeEscapeHtmlAttr('foo', 'ISO-8859-1');
     }
 
+    /**
+     * @throws RuntimeError
+     */
     private function invokeEscapeHtml($input, ?string $charset): string
     {
         return (new ContaoEscaper())->escapeHtml(
@@ -160,6 +163,9 @@ class ContaoEscaperTest extends TestCase
         );
     }
 
+    /**
+     * @throws RuntimeError
+     */
     private function invokeEscapeHtmlAttr($input, ?string $charset): string
     {
         return (new ContaoEscaper())->escapeHtmlAttr(

--- a/core-bundle/tests/Twig/Loader/ContaoFilesystemLoaderTest.php
+++ b/core-bundle/tests/Twig/Loader/ContaoFilesystemLoaderTest.php
@@ -28,6 +28,9 @@ use Webmozart\PathUtil\Path;
 
 class ContaoFilesystemLoaderTest extends TestCase
 {
+    /**
+     * @throws LoaderError
+     */
     public function testAddsPath(): void
     {
         $loader = $this->getContaoFilesystemLoader();
@@ -45,6 +48,9 @@ class ContaoFilesystemLoaderTest extends TestCase
         $this->assertFalse($loader->exists('@Contao_foo-Bar_Baz2/2.html.twig'));
     }
 
+    /**
+     * @throws LoaderError
+     */
     public function testPrependsPath(): void
     {
         $loader = $this->getContaoFilesystemLoader();

--- a/installation-bundle/src/Database/Installer.php
+++ b/installation-bundle/src/Database/Installer.php
@@ -15,6 +15,7 @@ namespace Contao\InstallationBundle\Database;
 use Contao\CoreBundle\Doctrine\Schema\SchemaProvider;
 use Contao\System;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Table;
 
@@ -72,6 +73,7 @@ class Installer
 
     /**
      * @throws \InvalidArgumentException
+     * @throws Exception
      */
     public function execCommand(string $hash): void
     {


### PR DESCRIPTION
This is a follow-up on https://github.com/Toflar/contao/pull/11#discussion_r755230151 that aims to clarify how the changes would look like, so we can agree on a concept. This is my PHPStorm config:

<img width="464" alt="" src="https://user-images.githubusercontent.com/1192057/143481416-76d14c2a-cdaf-42f9-891f-6abae94d65ec.png">

Note that I have added `\ReflectionException` as unchecked exception, which might be wrong. 🤔 See https://phpstan.org/blog/bring-your-exceptions-under-control#checked-vs.-unchecked-exceptions 