### PR TITLE
Disable form autocomplete for preview bar

### DIFF
--- a/core-bundle/src/Resources/views/Frontend/preview_toolbar_base.html.twig
+++ b/core-bundle/src/Resources/views/Frontend/preview_toolbar_base.html.twig
@@ -3,14 +3,14 @@
     <a href="#" title="{{ 'MSC.openToolbar'|trans }}">{{ include('@ContaoCore/Collector/contao.svg') }}</a>
 </div>
 <div class="cto-toolbar__inside">
-    <form action="{{ action }}" method="post">
+    <form action="{{ action }}" method="post" autocomplete="off">
         <div class="formbody">
             <input type="hidden" name="FORM_SUBMIT" value="tl_switch">
             <input type="hidden" name="REQUEST_TOKEN" value="{{ request_token }}">
             {% if canSwitchUser %}
                 <div>
                     <label for="ctrl_user">{{ 'MSC.feUser'|trans }}:</label>
-                    <input type="text" name="user" id="ctrl_user" list="userlist" class="tl_text user" placeholder="{{ 'MSC.username'|trans }}" value="{{ user }}" autocomplete="username">
+                    <input type="text" name="user" id="ctrl_user" list="userlist" class="tl_text user" placeholder="{{ 'MSC.username'|trans }}" value="{{ user }}">
                     <datalist id="userlist"></datalist>
                 </div>
             {% endif %}


### PR DESCRIPTION
The browser's login autofill functionality currently may prevent the preview bar from working properly, if the browser happens to fill in the `name="user"` input field with a username which is not actually available (anymore). This was introduced in Contao 4.9.14 (https://github.com/contao/contao/commit/2e762a3eee71ce6076d51cb3fd64cfa0b6ce6758).

**Reproduction**

1. Create a new member.
2. Login with that member in the front end and save the login data in your browser (e.g. Firefox).
3. Delete the member.
4. Log into the back end and open the front end preview. 
  » The browser should autofill the username field in the preview bar with the previously used username.
5. Select _show_ for _Unpublished_ and click apply.

Applying the _Unpublished_ change will fail silently since a username of a front end member was submitted that does not actually exist. To work around this you always have to manually delete the autofilled member first currently.

This PR fixes that by setting `autocomplete="off"` on the preview bar form. Only removing the `autocomplete` attribute from the `input` field would also work, though I think it's better to specifically disable it.