### PR TITLE
Delete uploaded files if a form does not validate

### DIFF
--- a/core-bundle/src/Resources/contao/forms/Form.php
+++ b/core-bundle/src/Resources/contao/forms/Form.php
@@ -259,6 +259,30 @@ class Form extends Hybrid
 			$this->processFormData($arrSubmitted, $arrLabels, $arrFields);
 		}
 
+		// Remove any uploads, if form did not validate (#1185)
+		if ($doNotSubmit && $hasUpload && !empty($_SESSION['FILES']))
+		{
+			foreach ($_SESSION['FILES'] as $field => $upload)
+			{
+				if (empty($arrFields[$field]))
+				{
+					continue;
+				}
+
+				if (!empty($upload['uuid']) && null !== ($file = FilesModel::findById($upload['uuid'])))
+				{
+					$file->delete();
+				}
+
+				if (is_file($upload['tmp_name']))
+				{
+					unlink($upload['tmp_name']);
+				}
+
+				unset($_SESSION['FILES'][$field]);
+			}
+		}
+
 		// Add a warning to the page title
 		if ($doNotSubmit && !Environment::get('isAjaxRequest'))
 		{
@@ -267,7 +291,6 @@ class Form extends Hybrid
 
 			$title = $objPage->pageTitle ?: $objPage->title;
 			$objPage->pageTitle = $GLOBALS['TL_LANG']['ERR']['form'] . ' - ' . $title;
-			$_SESSION['FILES'] = array(); // see #3007
 		}
 
 		$strAttributes = '';


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #1185
| Docs PR or issue | -

This is an alternative, less invasive approach to #3600 in order to fix #1185. Instead of introducing a new mechanic for the legacy framework, this PR instead fixes the specific, original problem by making sure the `Form` removes any uploaded files, if the form itself did not validate. `Form` already purges `$_SESSION['FILES']` when the form did not validate here:

https://github.com/contao/contao/blob/ba5f1ba905f54918641267f2e90965d3d1153df0/core-bundle/src/Resources/contao/forms/Form.php#L262-L271

so the `Form` might as well also properly delete the uploads.
