### PR TITLE
Make sure GUIDs in RSS feeds are unique

### DIFF
--- a/calendar-bundle/src/Resources/contao/classes/Calendar.php
+++ b/calendar-bundle/src/Resources/contao/classes/Calendar.php
@@ -195,7 +195,7 @@ class Calendar extends Frontend
 
 						if ($intStartTime >= $time)
 						{
-							$this->addEvent($objArticle, $intStartTime, $intEndTime, $strUrl);
+							$this->addEvent($objArticle, $intStartTime, $intEndTime, $strUrl, '', true);
 						}
 					}
 				}
@@ -231,12 +231,16 @@ class Calendar extends Frontend
 					$GLOBALS['objPage'] = $this->getPageWithDetails(CalendarModel::findByPk($event['pid'])->jumpTo);
 
 					$objItem = new FeedItem();
-
 					$objItem->title = $event['title'];
 					$objItem->link = $event['link'];
 					$objItem->published = $event['tstamp'];
 					$objItem->begin = $event['startTime'];
 					$objItem->end = $event['endTime'];
+
+					if ($event['isRepeated'] ?? null)
+					{
+						$objItem->guid = $event['link'] . '#' . date('Y-m-d', $event['startTime']);
+					}
 
 					if (($objAuthor = UserModel::findById($event['author'])) !== null)
 					{
@@ -408,8 +412,9 @@ class Calendar extends Frontend
 	 * @param integer             $intEnd
 	 * @param string              $strUrl
 	 * @param string              $strBase
+	 * @param boolean             $isRepeated
 	 */
-	protected function addEvent($objEvent, $intStart, $intEnd, $strUrl, $strBase='')
+	protected function addEvent($objEvent, $intStart, $intEnd, $strUrl, $strBase='', $isRepeated=false)
 	{
 		if ($intEnd < time())
 		{
@@ -491,6 +496,11 @@ class Calendar extends Frontend
 		// Override link and title
 		$arrEvent['link'] = $link;
 		$arrEvent['title'] = $title;
+
+		// Set the current start and end date
+		$arrEvent['startDate'] = $intStart;
+		$arrEvent['endDate'] = $intEnd;
+		$arrEvent['isRepeated'] = $isRepeated;
 
 		// Clean the RTE output
 		$arrEvent['teaser'] = StringUtil::toHtml5($objEvent->teaser);

--- a/core-bundle/src/Resources/contao/library/Contao/Feed.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Feed.php
@@ -142,15 +142,7 @@ class Feed
 			// Add the GUID
 			if ($objItem->guid)
 			{
-				// Add the isPermaLink attribute if the guid is not a link (see #4930)
-				if (strncmp($objItem->guid, 'http://', 7) !== 0 && strncmp($objItem->guid, 'https://', 8) !== 0)
-				{
-					$xml .= '<guid isPermaLink="false">' . $objItem->guid . '</guid>';
-				}
-				else
-				{
-					$xml .= '<guid>' . $objItem->guid . '</guid>';
-				}
+				$xml .= '<guid isPermaLink="false">' . $objItem->guid . '</guid>';
 			}
 			else
 			{


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #3572
| Docs PR or issue | -

Use custom GUIDs (with a `#Y-m-d` suffix) for repeated events, so the GUIDs remain unique in the RSS file.