### PR TITLE
Check for specific commands in ApplicationTest

### DIFF
--- a/manager-bundle/tests/Api/ApplicationTest.php
+++ b/manager-bundle/tests/Api/ApplicationTest.php
@@ -106,11 +106,10 @@ class ApplicationTest extends ContaoTestCase
         $application = $this->getApplication();
         $application->setPluginLoader($pluginLoader);
 
-        /** @var array $commands */
-        $commands = $application->all();
+        $expectedCommands = ['help', 'list', 'version', 'config:get'];
+        $actualCommands = array_intersect($expectedCommands, array_keys($application->all()));
 
-        $this->assertCount(4, $commands);
-        $this->assertArrayHasKey('config:get', $commands);
+        $this->assertSame($expectedCommands, $actualCommands);
     }
 
     public function testThrowsExceptionIfPluginReturnsInvalidCommand(): void


### PR DESCRIPTION
Symfony 5.4 added two new commands in https://github.com/symfony/symfony/pull/42251 - `_complete` and `completion`. This makes the test fail, since it checks for exactly 4 commands. To support _prefer lowest_ this PR fixes this by checking for an intersection of the commands instead.