### PR TITLE
Add a conflict with symfony/security-core >=5.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -145,6 +145,7 @@
         "symfony/config": "<4.4.2",
         "symfony/mime": "^4.4 <4.4.10 || ^5.0 <5.0.10 || 5.1.0",
         "symfony/security-bundle": "^4.4 <4.4.5",
+        "symfony/security-core": "^5.2 >=5.4",
         "terminal42/contao-ce-access": "<3.0",
         "zendframework/zend-code": "<3.3.1"
     },

--- a/core-bundle/composer.json
+++ b/core-bundle/composer.json
@@ -118,6 +118,7 @@
         "doctrine/cache": "<1.10",
         "symfony/mime": "^4.4 <4.4.10 || ^5.0 <5.0.10 || 5.1.0",
         "symfony/security-bundle": "^4.4 <4.4.5",
+        "symfony/security-core": "^5.2 >=5.4",
         "terminal42/contao-ce-access": "<3.0"
     },
     "require-dev": {


### PR DESCRIPTION
Don't allow `symfony/security-core >= 5.4` in Contao 4.12. This fixes the PHPStan issues in #3745.