### PR TITLE
Fixed counting API commands in Symfony 5.4

### DIFF
--- a/manager-bundle/tests/Api/ApplicationTest.php
+++ b/manager-bundle/tests/Api/ApplicationTest.php
@@ -19,6 +19,7 @@ use Contao\ManagerBundle\ContaoManagerBundle;
 use Contao\ManagerPlugin\Api\ApiPluginInterface;
 use Contao\ManagerPlugin\PluginLoader;
 use Contao\TestCase\ContaoTestCase;
+use Symfony\Component\HttpKernel\Kernel;
 
 class ApplicationTest extends ContaoTestCase
 {
@@ -109,7 +110,13 @@ class ApplicationTest extends ContaoTestCase
         /** @var array $commands */
         $commands = $application->all();
 
-        $this->assertCount(4, $commands);
+        if (Kernel::MINOR_VERSION > 3) {
+            $this->assertCount(6, $commands);
+        } else {
+            // TODO: BC, remove once we drop Symfony 5.3
+            $this->assertCount(4, $commands);
+        }
+
         $this->assertArrayHasKey('config:get', $commands);
     }
 


### PR DESCRIPTION
This fixes failing unit tests in all pull requests for the 4.x branch. Symfony added new default commands (https://github.com/symfony/symfony/blob/5.4/src/Symfony/Component/Console/Application.php#L1082) for the console autocomplete support in version 5.4.

Alternatively to this, we could raise the minimum requirement to 5.4 since we will only support this LTS in 4.13 as far as I know?