### PR TITLE
Adjust the service ID of the new interest cohort listener

### DIFF
--- a/core-bundle/src/Resources/config/listener.yml
+++ b/core-bundle/src/Resources/config/listener.yml
@@ -195,7 +195,8 @@ services:
         tags:
             - { name: contao.callback, table: tl_content, target: fields.customTpl.options }
 
-    Contao\CoreBundle\EventListener\InterestCohortListener:
+    contao.listener.interest_cohort:
+        class: Contao\CoreBundle\EventListener\InterestCohortListener
         arguments:
             - '@contao.routing.scope_matcher'
         tags:


### PR DESCRIPTION
The listener is new and should have the same service ID as in Contao 4.13, so we can merge it upstream more easily.