### PR TITLE
Add transitive dependency on symfony/twig-bridge

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -104,6 +104,7 @@
         "symfony/stopwatch": "4.4.*",
         "symfony/swiftmailer-bundle": "^2.6.2 || ^3.1.5",
         "symfony/translation": "4.4.*",
+        "symfony/twig-bridge": "4.4.*",
         "symfony/twig-bundle": "4.4.*",
         "symfony/var-dumper": "4.4.*",
         "symfony/web-profiler-bundle": "4.4.*",

--- a/core-bundle/composer.json
+++ b/core-bundle/composer.json
@@ -93,6 +93,7 @@
         "symfony/security-bundle": "4.4.*",
         "symfony/swiftmailer-bundle": "^2.6.2 || ^3.1.5",
         "symfony/translation": "4.4.*",
+        "symfony/twig-bridge": "4.4.*",
         "symfony/twig-bundle": "4.4.*",
         "symfony/var-dumper": "4.4.*",
         "symfony/yaml": "4.4.*",


### PR DESCRIPTION
| Q                | A
| -----------------| ---
| Fixed issues     | Fixes #...
| Docs PR or issue | contao/docs#...

We use functions like `{% trans_default_domain %}` which are part of `symfony/twig-bridge`. As a consequence, we have a transitive dependency on this package. This PR adds the missing dependency.

I noticed this issue when (while being on 4.13@dev) I was updated on symfony/twig-bridge v6.0 which is currently incompatible with Contao (because of the usage of AnonymousToken, for example).