### PR TITLE
Check page no search setting

### DIFF
--- a/core-bundle/src/EventListener/DataContainer/PageSearchSettingListener.php
+++ b/core-bundle/src/EventListener/DataContainer/PageSearchSettingListener.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\EventListener\DataContainer;
+
+use Contao\CoreBundle\ServiceAnnotation\Callback;
+use Contao\DataContainer;
+use Contao\Search;
+use Doctrine\DBAL\Connection;
+use Contao\CoreBundle\Framework\ContaoFramework;
+
+/**
+ * @Callback(table="tl_page", target="fields.noSearch.save")
+ */
+class PageSearchSettingListener
+{
+    private ContaoFramework $framework;
+    private Connection $connection;
+
+    public function __construct(ContaoFramework $framework, Connection $connection)
+    {
+        $this->framework = $framework;
+        $this->connection = $connection;
+    }
+
+
+    public function __invoke($value, DataContainer $dc)
+    {
+
+        if ($dc->activeRecord->noSearch || $dc->activeRecord->type != 'regular') {
+            $this->purgeSearchIndex((int) $dc->activeRecord->id);
+        }
+
+        return $value;
+    }
+
+    public function purgeSearchIndex(int $pageId): void
+    {
+        $urls = $this->connection->fetchFirstColumn(
+            'SELECT url FROM tl_search WHERE pid=:pageId',
+            ['pageId' => $pageId]
+        );
+
+        $search = $this->framework->getAdapter(Search::class);
+
+        foreach ($urls as $url) {
+            $search->removeEntry($url);
+        }
+    }
+}

--- a/core-bundle/src/Resources/config/listener.yml
+++ b/core-bundle/src/Resources/config/listener.yml
@@ -12,6 +12,11 @@ services:
         arguments:
             - '@database_connection'
 
+    Contao\CoreBundle\EventListener\DataContainer\PageSearchSettingListener:
+        arguments:
+            - '@contao.framework'
+            - '@database_connection'
+
     Contao\CoreBundle\EventListener\PreviewUrlCreateListener:
         arguments:
             - '@request_stack'

--- a/core-bundle/src/Resources/contao/dca/tl_page.php
+++ b/core-bundle/src/Resources/contao/dca/tl_page.php
@@ -38,7 +38,8 @@ $GLOBALS['TL_DCA']['tl_page'] = array
 		'onsubmit_callback' => array
 		(
 			array('tl_page', 'scheduleUpdate'),
-			array('tl_page', 'generateArticle')
+			array('tl_page', 'generateArticle'),
+			array('tl_page', 'removeIndexEntry')
 		),
 		'sql' => array
 		(
@@ -1119,6 +1120,23 @@ class tl_page extends Contao\Backend
 		$objSession->set('sitemap_updater', array_unique($session));
 	}
 
+	/**
+	 * Remove already indexed page, if Do not search is checked
+	 */
+	public function removeIndexEntry(Contao\DataContainer $dc)
+	{
+		// Return if there is no ID
+		if (!$dc->activeRecord || !$dc->activeRecord->id) {
+			return;
+		}
+
+		if ($dc->activeRecord->noSearch || $dc->activeRecord->type != 'regular') {
+			$objPage = Contao\PageModel::findById($dc->activeRecord->id);
+			$pageUrl = $objPage->getAbsoluteUrl();
+			Contao\Search::removeEntry($pageUrl);
+		}
+	}
+	
 	/**
 	 * Auto-generate a page alias if it has not been set yet
 	 *


### PR DESCRIPTION
As discussed, and suggested by @Toflar. This creates a callback on the `noSearch` field to remove indexes when it's checked. (https://github.com/contao/contao/pull/3766)
But for a unit test, I don't have any idea, how to write one!