### PR TITLE
Ensure type-safety when replacing legacy insert tags

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Controller.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Controller.php
@@ -807,10 +807,10 @@ abstract class Controller extends System
 
 		if ($blnCache)
 		{
-			return $parser->replace($strBuffer);
+			return $parser->replace((string) $strBuffer);
 		}
 
-		return $parser->replaceInline($strBuffer);
+		return $parser->replaceInline((string) $strBuffer);
 	}
 
 	/**


### PR DESCRIPTION
I just had a case where something would pass `null` instead of a string to the legacy method.

`Argument 1 passed to Contao\CoreBundle\InsertTag\InsertTagParser::replace() must be of the type string, null given, called in vendor/contao/core-bundle/src/Resources/contao/library/Contao/Controller.php on line 810`