### PR TITLE
Fix unknown "ansi_to_html" filter error

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -73,6 +73,7 @@
         "scheb/2fa-bundle": "^5.0",
         "scheb/2fa-trusted-device": "^5.0",
         "scssphp/scssphp": "^1.0",
+        "sensiolabs/ansi-to-html": "^1.1",
         "simplepie/simplepie": "^1.3",
         "spomky-labs/otphp": "^9.1 || ^10.0",
         "symfony-cmf/routing-bundle": "^2.1",

--- a/core-bundle/composer.json
+++ b/core-bundle/composer.json
@@ -70,7 +70,6 @@
         "scheb/2fa-bundle": "^5.0",
         "scheb/2fa-trusted-device": "^5.0",
         "scssphp/scssphp": "^1.0",
-        "sensiolabs/ansi-to-html": "^1.1",
         "simplepie/simplepie": "^1.3",
         "spomky-labs/otphp": "^9.1 || ^10.0",
         "symfony-cmf/routing-bundle": "^2.1",

--- a/core-bundle/composer.json
+++ b/core-bundle/composer.json
@@ -70,6 +70,7 @@
         "scheb/2fa-bundle": "^5.0",
         "scheb/2fa-trusted-device": "^5.0",
         "scssphp/scssphp": "^1.0",
+        "sensiolabs/ansi-to-html": "^1.1",
         "simplepie/simplepie": "^1.3",
         "spomky-labs/otphp": "^9.1 || ^10.0",
         "symfony-cmf/routing-bundle": "^2.1",

--- a/installation-bundle/composer.json
+++ b/installation-bundle/composer.json
@@ -20,6 +20,7 @@
         "doctrine/dbal": "^2.10",
         "patchwork/utf8": "^1.2",
         "psr/log": "^1.0",
+        "sensiolabs/ansi-to-html": "^1.1",
         "symfony/config": "4.4.*",
         "symfony/console": "4.4.*",
         "symfony/dependency-injection": "4.4.*",

--- a/installation-bundle/src/Resources/config/services.yml
+++ b/installation-bundle/src/Resources/config/services.yml
@@ -11,6 +11,9 @@ services:
             - '@Contao\CoreBundle\Migration\MigrationCollection'
         public: true
 
+    contao.install_tool_twig_extension:
+        class: SensioLabs\AnsiConverter\Bridge\Twig\AnsiExtension
+
     contao.install_tool_user:
         class: Contao\InstallationBundle\InstallToolUser
         arguments:


### PR DESCRIPTION
| Q                | A               |
|------------------|-----------------|
| Fixed issues     | Fixes #3772      |
| Docs PR or issue | - |

Restores the erroneously removed `ansi_to_html` twig filter.