### PR TITLE
Show member groups for content elements when protected

### DIFF
--- a/core-bundle/src/Resources/contao/dca/tl_content.php
+++ b/core-bundle/src/Resources/contao/dca/tl_content.php
@@ -19,6 +19,7 @@ use Contao\CoreBundle\Security\ContaoCorePermissions;
 use Contao\DataContainer;
 use Contao\Image;
 use Contao\Input;
+use Contao\MemberGroupModel;
 use Contao\Message;
 use Contao\PageModel;
 use Contao\StringUtil;
@@ -1291,7 +1292,23 @@ class tl_content extends Backend
 		// Add the protection status
 		if ($arrRow['protected'])
 		{
-			$type .= ' (' . $GLOBALS['TL_LANG']['MSC']['protected'] . ')';
+			$groupIds = StringUtil::deserialize($arrRow['groups'], true);
+			$groupNames = array();
+
+			if (!empty($groupIds))
+			{
+				if (in_array(-1, array_map('intval', $groupIds)))
+				{
+					$groupNames[] = $GLOBALS['TL_LANG']['MSC']['guests'];
+				}
+
+				if (null !== ($groups = MemberGroupModel::findMultipleByIds($groupIds)))
+				{
+					$groupNames += $groups->fetchEach('name');
+				}
+			}
+
+			$type .= ' (' . $GLOBALS['TL_LANG']['MSC']['protected'] . ($groupNames ? ': ' . implode(', ', $groupNames) : '') . ')';
 		}
 
 		// Add the headline level (see #5858)

--- a/core-bundle/src/Resources/contao/dca/tl_content.php
+++ b/core-bundle/src/Resources/contao/dca/tl_content.php
@@ -1297,7 +1297,7 @@ class tl_content extends Backend
 
 			if (!empty($groupIds))
 			{
-				if (in_array(-1, array_map('intval', $groupIds)))
+				if (in_array(-1, array_map('intval', $groupIds), true))
 				{
 					$groupNames[] = $GLOBALS['TL_LANG']['MSC']['guests'];
 				}


### PR DESCRIPTION
| Q                | A               |
|------------------|-----------------|
| Fixed issues     | fixes #3784      |
| Docs PR or issue | - |

This will show the chosen member groups (including "Guests") when an element is protected:

<img src="https://user-images.githubusercontent.com/4970961/145386154-437fc0c2-964a-4ca9-8cfd-2e96d75cc3d3.png" width="453">