### PR TITLE
Use lower case for "fixes" in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 | Q                | A               |
 |------------------|-----------------|
-| Fixed issues     | Fixes #...      |
+| Fixed issues     | fixes #...      |
 | Docs PR or issue | contao/docs#... |
 
 <!--

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,4 @@
-| Q                | A               |
-|------------------|-----------------|
-| Fixed issues     | fixes #...      |
-| Docs PR or issue | contao/docs#... |
+Fixes #...
 
 <!--
 Bugfixes should be based on the 4.9 or 4.12 branch and features on the 4.x

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-Fixes #...
+Fixes #
 
 <!--
 Bugfixes should be based on the 4.9 or 4.12 branch and features on the 4.x


### PR DESCRIPTION
I noticed that GitHub is never automatically linking the original issues when creating a PR with the current template, even though it says `Fixes #…`. It appears that it only works when it's lower case (which I find peculiar).