### PR TITLE
Clarify internal style sheets deprecation

### DIFF
--- a/core-bundle/src/Resources/contao/languages/en/default.xlf
+++ b/core-bundle/src/Resources/contao/languages/en/default.xlf
@@ -1971,7 +1971,7 @@
         <source>Disable</source>
       </trans-unit>
       <trans-unit id="MSC.internalCssEditor">
-        <source>The internal CSS editor has been deprecated and will be removed in one of the next Contao versions! Please consider exporting your existing style sheets and re-adding them to the page layout as external style sheets.</source>
+        <source>The internal CSS editor has been deprecated and will be removed in Contao 5.0! Please consider exporting your existing style sheets and re-adding them to the page layout as external style sheets.</source>
       </trans-unit>
       <trans-unit id="MSC.serpPreview.0">
         <source>Google search results preview</source>


### PR DESCRIPTION
Even though we are specifically removing the internal stylesheets in Contao 5.0 - the message in the back end still says:

> The internal CSS editor has been deprecated and will be removed **in one of the next Contao versions**! Please consider exporting your existing style sheets and re-adding them to the page layout as external style sheets.

The question when the internal stylesheets are removed pops up in the community forum and slack every once in a while - and since we have a clear answer now, the message should be updated to reflect that as well.