### PR TITLE
Add a debounce wrapper to the username autosuggester

### DIFF
--- a/core-bundle/src/Resources/views/Frontend/preview_toolbar_base_js.html.twig
+++ b/core-bundle/src/Resources/views/Frontend/preview_toolbar_base_js.html.twig
@@ -248,6 +248,7 @@
 
             if (document.createElement('datalist') && window.HTMLDataListElement) {
                 const userField = form.querySelector('input[name="user"]');
+                let timer;
 
                 if (userField) {
                     userField.addEventListener('input', function () {
@@ -255,22 +256,28 @@
                             return;
                         }
 
-                        const body = {
-                            FORM_SUBMIT: 'datalist_members',
-                            REQUEST_TOKEN: form.querySelector('input[name="REQUEST_TOKEN"]').value,
-                            value: userField.value
-                        };
+                        if (timer) {
+                            clearTimeout(timer);
+                        }
 
-                        const userList = form.querySelector('datalist[id="userlist"]');
+                        timer = setTimeout(function () {
+                            const body = {
+                                FORM_SUBMIT: 'datalist_members',
+                                REQUEST_TOKEN: form.querySelector('input[name="REQUEST_TOKEN"]').value,
+                                value: userField.value
+                            };
 
-                        request('POST', form.action, new URLSearchParams(body), function () {
-                            userList.innerHTML = '';
-                            JSON.parse(this.response).forEach(item => {
-                                const option = document.createElement('option');
-                                option.value = item;
-                                userList.appendChild(option);
-                            });
-                        }, false);
+                            const userList = form.querySelector('datalist[id="userlist"]');
+
+                            request('POST', form.action, new URLSearchParams(body), function () {
+                                userList.innerHTML = '';
+                                JSON.parse(this.response).forEach(item => {
+                                    const option = document.createElement('option');
+                                    option.value = item;
+                                    userList.appendChild(option);
+                                });
+                            }, false);
+                        }, 300);
                     });
                 }
             }


### PR DESCRIPTION
This adds a simple debounce wrapper to the members autosuggester in Preview Bar. It prevents autosuggester from sending POST request on each key stroke; instead, it waits while you type and makes a request 1 second after you've done.