### PR TITLE
Directly jump to news archives if the user can only access one

### DIFF
--- a/news-bundle/src/EventListener/BackendMenuListener.php
+++ b/news-bundle/src/EventListener/BackendMenuListener.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\NewsBundle\EventListener;
+
+use Contao\CoreBundle\Event\MenuEvent;
+use Contao\NewsBundle\Security\ContaoNewsPermissions;
+use Contao\StringUtil;
+use Symfony\Component\Security\Core\Security;
+
+/**
+ * Adjusts the link to the news module, so that non-admin users who can only
+ * access one single news archive are directly taken there instead of to the
+ * news archives overview page.
+ *
+ * @internal
+ */
+class BackendMenuListener
+{
+    private Security $security;
+
+    public function __construct(Security $security)
+    {
+        $this->security = $security;
+    }
+
+    public function __invoke(MenuEvent $event): void
+    {
+        if ('mainMenu' !== $event->getTree()->getName()) {
+            return;
+        }
+
+        // Return if the node is not present in the menu
+        if ((!$content = $event->getTree()->getChild('content')) || (!$news = $content->getChild('news'))) {
+            return;
+        }
+
+        // Return if the user can create archives
+        if ($this->security->isGranted(ContaoNewsPermissions::USER_CAN_CREATE_ARCHIVES)) {
+            return;
+        }
+
+        $archiveIds = StringUtil::deserialize($this->security->getUser()->news, true);
+
+        // Return if there is more than one news archive
+        if (\count($archiveIds) > 1) {
+            return;
+        }
+
+        $news->setUri($news->getUri().'&table=tl_news&id='.$archiveIds[0]);
+    }
+}

--- a/news-bundle/src/Resources/config/services.yml
+++ b/news-bundle/src/Resources/config/services.yml
@@ -7,6 +7,13 @@ services:
             calls:
                 - [setFramework, ['@contao.framework']]
 
+    contao_news.listener.backend_menu:
+        class: Contao\NewsBundle\EventListener\BackendMenuListener
+        arguments:
+            - '@security.helper'
+        tags:
+            - { name: kernel.event_listener, event: contao.backend_menu_build }
+
     contao_news.listener.generate_page:
         class: Contao\NewsBundle\EventListener\GeneratePageListener
         arguments:


### PR DESCRIPTION
Implements contao/core#4603

If a non-admin user has access to only one news archive, a listener modifies the URL of the back end menu item "news" to point directly to this new archive instead of to the news archives overview page.

@contao/developers Is this something we want to add to news, events, FAQs and forms? And if so, do you agree with the implementation?

I am aware that unit tests and the other listeners are still missing.