### PR TITLE
Fix infinite 4.8.0 migration when custom templates are present

### DIFF
--- a/core-bundle/src/Migration/Version408/Version480Update.php
+++ b/core-bundle/src/Migration/Version408/Version480Update.php
@@ -133,8 +133,8 @@ class Version480Update extends AbstractMigration
                         SELECT id
                         FROM tl_layout
                         WHERE
-                            jquery LIKE '%j_mediaelement%'
-                            OR scripts LIKE '%js_mediaelement%'
+                            jquery LIKE '%\"j_mediaelement\"%'
+                            OR scripts LIKE '%\"js_mediaelement\"%'
                     )
                 ")
                 ->fetchColumn()
@@ -161,7 +161,7 @@ class Version480Update extends AbstractMigration
                             SELECT id
                             FROM tl_layout
                             WHERE
-                                $column LIKE '%$templateName%'
+                                $column LIKE '%\"$templateName\"%'
                         )
                     ")
                     ->fetchColumn()


### PR DESCRIPTION
If you have a custom template like `j_mediaelement_foobar.html5` or `js_mediaelement_foobar` present in your `templates/` folder and selected in your page layout, then the `4.8.0` migration wants to be executed infinitely often.

**Reproduction**

1. Create a file called `templates/js_mediaelement_foobar.html5`.
2. Edit your page layout and enable the `js_mediaelement_foobar` template and then save.
3. Run `vendor/bin/contao-console contao:migrate --migrations-only --no-interaction`.

The migration will run infinitely often.

**Fix**

We only want to specifically remove the old `j_mediaelement` and `js_mediaelement` templates of the `contao/core-bundle` when still enabled in the layout. However, we need to ignore templates that start with the same name. Thus this PR changes the database queries so that it searches for `%"js_mediaelement"%` in the serialized array, instead of `%js_mediaelement%`.