### PR TITLE
Rework the @throws annotations

### DIFF
--- a/calendar-bundle/src/EventListener/PreviewUrlCreateListener.php
+++ b/calendar-bundle/src/EventListener/PreviewUrlCreateListener.php
@@ -34,8 +34,6 @@ class PreviewUrlCreateListener
 
     /**
      * Adds the calendar ID to the front end preview URL.
-     *
-     * @throws \RuntimeException
      */
     public function __invoke(PreviewUrlCreateEvent $event): void
     {

--- a/core-bundle/src/Config/Loader/XliffFileLoader.php
+++ b/core-bundle/src/Config/Loader/XliffFileLoader.php
@@ -124,8 +124,6 @@ class XliffFileLoader extends Loader
 
     /**
      * Returns a string representation of the global PHP language array.
-     *
-     * @throws \OutOfBoundsException
      */
     private function getStringRepresentation(array $chunks, string $value): string
     {

--- a/core-bundle/src/Config/ResourceFinder.php
+++ b/core-bundle/src/Config/ResourceFinder.php
@@ -41,8 +41,6 @@ class ResourceFinder implements ResourceFinderInterface
     }
 
     /**
-     * @throws \InvalidArgumentException
-     *
      * @return array<string>
      */
     private function getExistingSubpaths(string $subpath): array

--- a/core-bundle/src/Controller/BackendController.php
+++ b/core-bundle/src/Controller/BackendController.php
@@ -183,8 +183,6 @@ class BackendController extends AbstractController
      * It will determine the current provider URL based on the value, which is usually
      * read dynamically via JavaScript.
      *
-     * @throws BadRequestHttpException
-     *
      * @Route("/picker", name="contao_backend_picker")
      */
     public function pickerAction(Request $request): RedirectResponse

--- a/core-bundle/src/Controller/BackendCsvImportController.php
+++ b/core-bundle/src/Controller/BackendCsvImportController.php
@@ -99,9 +99,6 @@ class BackendCsvImportController
         );
     }
 
-    /**
-     * @throws InternalServerErrorException
-     */
     private function importFromTemplate(callable $callback, string $table, string $field, int $id, string $submitLabel = null, bool $allowLinebreak = false): Response
     {
         $request = $this->requestStack->getCurrentRequest();
@@ -228,9 +225,6 @@ class BackendCsvImportController
         return $separators;
     }
 
-    /**
-     * @throws \RuntimeException
-     */
     private function getDelimiter(string $separator): string
     {
         $separators = $this->getSeparators(true);
@@ -244,8 +238,6 @@ class BackendCsvImportController
 
     /**
      * Returns the uploaded files from a FileUpload instance.
-     *
-     * @throws \RuntimeException
      *
      * @return array<string>
      */

--- a/core-bundle/src/Controller/FrontendController.php
+++ b/core-bundle/src/Controller/FrontendController.php
@@ -68,6 +68,8 @@ class FrontendController extends AbstractController
      * Symfony will un-authenticate the user automatically by calling this route.
      *
      * @Route("/_contao/logout", name="contao_frontend_logout")
+     *
+     * @return never
      */
     public function logoutAction(): void
     {

--- a/core-bundle/src/Controller/FrontendController.php
+++ b/core-bundle/src/Controller/FrontendController.php
@@ -67,8 +67,6 @@ class FrontendController extends AbstractController
     /**
      * Symfony will un-authenticate the user automatically by calling this route.
      *
-     * @throws LogoutException
-     *
      * @Route("/_contao/logout", name="contao_frontend_logout")
      */
     public function logoutAction(): void

--- a/core-bundle/src/Controller/InitializeController.php
+++ b/core-bundle/src/Controller/InitializeController.php
@@ -57,8 +57,6 @@ class InitializeController
 
     /**
      * Initializes the Contao framework.
-     *
-     * @throws \RuntimeException
      */
     public function __invoke(): InitializeControllerResponse
     {

--- a/core-bundle/src/Crawl/Escargot/Factory.php
+++ b/core-bundle/src/Crawl/Escargot/Factory.php
@@ -196,9 +196,6 @@ class Factory
         }
     }
 
-    /**
-     * @throws \InvalidArgumentException
-     */
     private function validateSubscribers(array $selectedSubscribers): array
     {
         $msg = sprintf(

--- a/core-bundle/src/Crawl/Escargot/Factory.php
+++ b/core-bundle/src/Crawl/Escargot/Factory.php
@@ -138,9 +138,6 @@ class Factory
         return $collection;
     }
 
-    /**
-     * @throws \InvalidArgumentException
-     */
     public function create(BaseUriCollection $baseUris, QueueInterface $queue, array $selectedSubscribers, array $clientOptions = []): Escargot
     {
         $escargot = Escargot::create($baseUris, $queue)->withHttpClient($this->createHttpClient($clientOptions));
@@ -152,7 +149,6 @@ class Factory
     }
 
     /**
-     * @throws \InvalidArgumentException
      * @throws InvalidJobIdException
      */
     public function createFromJobId(string $jobId, QueueInterface $queue, array $selectedSubscribers, array $clientOptions = []): Escargot

--- a/core-bundle/src/Csrf/MemoryTokenStorage.php
+++ b/core-bundle/src/Csrf/MemoryTokenStorage.php
@@ -85,9 +85,6 @@ class MemoryTokenStorage implements TokenStorageInterface, ResetInterface
         $this->usedTokens = [];
     }
 
-    /**
-     * @throws \LogicException
-     */
     private function assertInitialized(): void
     {
         if (null === $this->tokens) {

--- a/core-bundle/src/DataContainer/PaletteManipulator.php
+++ b/core-bundle/src/DataContainer/PaletteManipulator.php
@@ -35,6 +35,8 @@ class PaletteManipulator
      *
      * @param string|array $parent
      * @param bool         $hide
+     *
+     * @throws PalettePositionException
      */
     public function addLegend(string $name, $parent, string $position = self::POSITION_AFTER, $hide = false): self
     {
@@ -146,6 +148,9 @@ class PaletteManipulator
         return $this->implode($config);
     }
 
+    /**
+     * @throws PalettePositionException
+     */
     private function validatePosition(string $position): void
     {
         static $positions = [

--- a/core-bundle/src/DataContainer/PaletteManipulator.php
+++ b/core-bundle/src/DataContainer/PaletteManipulator.php
@@ -146,9 +146,6 @@ class PaletteManipulator
         return $this->implode($config);
     }
 
-    /**
-     * @throws PalettePositionException
-     */
     private function validatePosition(string $position): void
     {
         static $positions = [

--- a/core-bundle/src/DependencyInjection/Compiler/AddCronJobsPass.php
+++ b/core-bundle/src/DependencyInjection/Compiler/AddCronJobsPass.php
@@ -63,9 +63,6 @@ class AddCronJobsPass implements CompilerPassInterface
         }
     }
 
-    /**
-     * @throws InvalidDefinitionException
-     */
     private function getMethod(array $attributes, string $class, string $serviceId): ?string
     {
         $ref = new \ReflectionClass($class);

--- a/core-bundle/src/DependencyInjection/Compiler/RegisterHookListenersPass.php
+++ b/core-bundle/src/DependencyInjection/Compiler/RegisterHookListenersPass.php
@@ -66,9 +66,6 @@ class RegisterHookListenersPass implements CompilerPassInterface
         return $hooks;
     }
 
-    /**
-     * @throws InvalidDefinitionException
-     */
     private function addHookCallback(array &$hooks, string $serviceId, string $class, array $attributes): void
     {
         if (!isset($attributes['hook'])) {

--- a/core-bundle/src/Doctrine/Backup/Backup.php
+++ b/core-bundle/src/Doctrine/Backup/Backup.php
@@ -73,9 +73,6 @@ class Backup
         ];
     }
 
-    /**
-     * @throws BackupManagerException
-     */
     private static function extractDatetime(string $filepath): \DateTimeInterface
     {
         preg_match(self::VALID_BACKUP_NAME_REGEX, $filepath, $matches);

--- a/core-bundle/src/Doctrine/Backup/BackupManager.php
+++ b/core-bundle/src/Doctrine/Backup/BackupManager.php
@@ -109,9 +109,6 @@ class BackupManager
         $this->executeTransactional(fn () => $this->doRestore($config));
     }
 
-    /**
-     * @throws BackupManagerException
-     */
     private function executeTransactional(\Closure $func): void
     {
         $isAutoCommit = $this->connection->isAutoCommit();
@@ -133,9 +130,6 @@ class BackupManager
         }
     }
 
-    /**
-     * @throws BackupManagerException
-     */
     private function doCreate(CreateConfig $config): void
     {
         $backup = $config->getBackup();

--- a/core-bundle/src/EventListener/DataContainer/PageUrlListener.php
+++ b/core-bundle/src/EventListener/DataContainer/PageUrlListener.php
@@ -211,9 +211,6 @@ class PageUrlListener implements ResetInterface
         }
     }
 
-    /**
-     * @throws DuplicateAliasException
-     */
     private function aliasExists(string $currentAlias, int $currentId, PageModel $currentPage, bool $throw = false): bool
     {
         $currentPage->loadDetails();

--- a/core-bundle/src/EventListener/DataContainer/PageUrlListener.php
+++ b/core-bundle/src/EventListener/DataContainer/PageUrlListener.php
@@ -211,6 +211,9 @@ class PageUrlListener implements ResetInterface
         }
     }
 
+    /**
+     * @throws DuplicateAliasException
+     */
     private function aliasExists(string $currentAlias, int $currentId, PageModel $currentPage, bool $throw = false): bool
     {
         $currentPage->loadDetails();

--- a/core-bundle/src/EventListener/InsecureInstallationListener.php
+++ b/core-bundle/src/EventListener/InsecureInstallationListener.php
@@ -22,8 +22,6 @@ class InsecureInstallationListener
 {
     /**
      * Throws an exception if the document root is insecure.
-     *
-     * @throws InsecureInstallationException
      */
     public function __invoke(RequestEvent $event): void
     {

--- a/core-bundle/src/EventListener/PreviewToolbarListener.php
+++ b/core-bundle/src/EventListener/PreviewToolbarListener.php
@@ -18,7 +18,6 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\Routing\RouterInterface;
 use Twig\Environment as TwigEnvironment;
-use Twig\Error\Error as TwigError;
 
 /**
  * Injects the back end preview toolbar on any response within the /preview.php

--- a/core-bundle/src/EventListener/PreviewToolbarListener.php
+++ b/core-bundle/src/EventListener/PreviewToolbarListener.php
@@ -76,9 +76,6 @@ class PreviewToolbarListener
         $this->injectToolbar($response, $request);
     }
 
-    /**
-     * @throws TwigError
-     */
     private function injectToolbar(Response $response, Request $request): void
     {
         $content = $response->getContent();

--- a/core-bundle/src/EventListener/PreviewUrlCreateListener.php
+++ b/core-bundle/src/EventListener/PreviewUrlCreateListener.php
@@ -34,8 +34,6 @@ class PreviewUrlCreateListener
 
     /**
      * Adds the page ID to the front end preview URL.
-     *
-     * @throws \RuntimeException
      */
     public function __invoke(PreviewUrlCreateEvent $event): void
     {

--- a/core-bundle/src/EventListener/RequestTokenListener.php
+++ b/core-bundle/src/EventListener/RequestTokenListener.php
@@ -43,9 +43,6 @@ class RequestTokenListener
         $this->csrfCookiePrefix = $csrfCookiePrefix;
     }
 
-    /**
-     * @throws InvalidRequestTokenException
-     */
     public function __invoke(RequestEvent $event): void
     {
         // Don't do anything if it's not the main request

--- a/core-bundle/src/EventListener/Security/SwitchUserListener.php
+++ b/core-bundle/src/EventListener/Security/SwitchUserListener.php
@@ -33,8 +33,6 @@ class SwitchUserListener
 
     /**
      * Logs successful user impersonations.
-     *
-     * @throws \RuntimeException
      */
     public function __invoke(SwitchUserEvent $event): void
     {

--- a/core-bundle/src/EventListener/UserSessionListener.php
+++ b/core-bundle/src/EventListener/UserSessionListener.php
@@ -93,8 +93,6 @@ class UserSessionListener
 
     /**
      * Returns the session bag.
-     *
-     * @throws \RuntimeException
      */
     private function getSessionBag(Request $request): SessionBagInterface
     {

--- a/core-bundle/src/HttpKernel/Bundle/ContaoModuleBundle.php
+++ b/core-bundle/src/HttpKernel/Bundle/ContaoModuleBundle.php
@@ -22,8 +22,6 @@ final class ContaoModuleBundle extends Bundle
 {
     /**
      * Sets the module name and application root directory.
-     *
-     * @throws \LogicException
      */
     public function __construct(string $name, string $projectDir)
     {

--- a/core-bundle/src/Monolog/ContaoContext.php
+++ b/core-bundle/src/Monolog/ContaoContext.php
@@ -32,9 +32,6 @@ class ContaoContext
     private ?string $browser;
     private ?string $source;
 
-    /**
-     * @throws \InvalidArgumentException
-     */
     public function __construct(string $func, string $action = null, string $username = null, string $ip = null, string $browser = null, string $source = null)
     {
         if ('' === $func) {

--- a/core-bundle/src/Monolog/ContaoTableHandler.php
+++ b/core-bundle/src/Monolog/ContaoTableHandler.php
@@ -91,8 +91,6 @@ class ContaoTableHandler extends AbstractProcessingHandler implements ContainerA
 
     /**
      * Verifies the database connection and prepares the statement.
-     *
-     * @throws \RuntimeException
      */
     private function createStatement(): void
     {

--- a/core-bundle/src/OptIn/OptInToken.php
+++ b/core-bundle/src/OptIn/OptInToken.php
@@ -100,9 +100,6 @@ class OptInToken implements OptInTokenInterface
         return $this->model->confirmedOn > 0;
     }
 
-    /**
-     * @throws \LogicException
-     */
     public function send(string $subject = null, string $text = null): void
     {
         if ($this->isConfirmed()) {

--- a/core-bundle/src/Routing/UrlGenerator.php
+++ b/core-bundle/src/Routing/UrlGenerator.php
@@ -102,8 +102,6 @@ class UrlGenerator implements UrlGeneratorInterface
 
     /**
      * Adds the parameters to the alias.
-     *
-     * @throws MissingMandatoryParametersException
      */
     private function prepareAlias(string $alias, array &$parameters): void
     {

--- a/core-bundle/src/Search/Indexer/DefaultIndexer.php
+++ b/core-bundle/src/Search/Indexer/DefaultIndexer.php
@@ -122,6 +122,9 @@ class DefaultIndexer implements IndexerInterface
         $this->connection->executeStatement('TRUNCATE TABLE tl_search_term');
     }
 
+    /**
+     * @return never
+     */
     private function throwBecause(string $message, bool $onlyWarning = true): void
     {
         if ($onlyWarning) {

--- a/core-bundle/src/Search/Indexer/DefaultIndexer.php
+++ b/core-bundle/src/Search/Indexer/DefaultIndexer.php
@@ -122,9 +122,6 @@ class DefaultIndexer implements IndexerInterface
         $this->connection->executeStatement('TRUNCATE TABLE tl_search_term');
     }
 
-    /**
-     * @throws IndexerException
-     */
     private function throwBecause(string $message, bool $onlyWarning = true): void
     {
         if ($onlyWarning) {

--- a/core-bundle/src/Security/Authentication/AuthenticationFailureHandler.php
+++ b/core-bundle/src/Security/Authentication/AuthenticationFailureHandler.php
@@ -34,8 +34,6 @@ class AuthenticationFailureHandler implements AuthenticationFailureHandlerInterf
 
     /**
      * Logs the security exception to the Contao back end.
-     *
-     * @throws \RuntimeException
      */
     public function onAuthenticationFailure(Request $request, AuthenticationException $exception): Response
     {

--- a/core-bundle/src/Security/User/ContaoUserProvider.php
+++ b/core-bundle/src/Security/User/ContaoUserProvider.php
@@ -118,8 +118,6 @@ class ContaoUserProvider implements UserProviderInterface, PasswordUpgraderInter
 
     /**
      * Validates the session lifetime and logs the user out if the session has expired.
-     *
-     * @throws UsernameNotFoundException
      */
     private function validateSessionLifetime(User $user): void
     {

--- a/core-bundle/src/Security/User/ContaoUserProvider.php
+++ b/core-bundle/src/Security/User/ContaoUserProvider.php
@@ -38,9 +38,6 @@ class ContaoUserProvider implements UserProviderInterface, PasswordUpgraderInter
      */
     private string $userClass;
 
-    /**
-     * @throws \RuntimeException
-     */
     public function __construct(ContaoFramework $framework, SessionInterface $session, string $userClass, LoggerInterface $logger = null)
     {
         if (BackendUser::class !== $userClass && FrontendUser::class !== $userClass) {

--- a/core-bundle/src/Security/User/UserChecker.php
+++ b/core-bundle/src/Security/User/UserChecker.php
@@ -50,9 +50,6 @@ class UserChecker implements UserCheckerInterface
     {
     }
 
-    /**
-     * @throws LockedException
-     */
     private function checkIfAccountIsLocked(User $user): void
     {
         $lockedSeconds = $user->locked - time();

--- a/core-bundle/src/Session/LazySessionAccess.php
+++ b/core-bundle/src/Session/LazySessionAccess.php
@@ -90,9 +90,6 @@ class LazySessionAccess implements \ArrayAccess, \Countable
         return \count($_SESSION);
     }
 
-    /**
-     * @throws \RuntimeException
-     */
     private function startSession(): void
     {
         trigger_deprecation('contao/core-bundle', '4.5', 'Using "$_SESSION" has been deprecated and will no longer work in Contao 5.0. Use the Symfony session instead.');

--- a/installation-bundle/src/Controller/InstallationController.php
+++ b/installation-bundle/src/Controller/InstallationController.php
@@ -130,8 +130,6 @@ class InstallationController implements ContainerAwareInterface
     /**
      * Renders a form to accept the license.
      *
-     * @throws \RuntimeException
-     *
      * @return Response|RedirectResponse
      */
     private function acceptLicense(): Response
@@ -153,8 +151,6 @@ class InstallationController implements ContainerAwareInterface
 
     /**
      * Renders a form to set the install tool password.
-     *
-     * @throws \RuntimeException
      *
      * @return Response|RedirectResponse
      */
@@ -189,8 +185,6 @@ class InstallationController implements ContainerAwareInterface
 
     /**
      * Renders a form to log in.
-     *
-     * @throws \RuntimeException
      *
      * @return Response|RedirectResponse
      */
@@ -291,8 +285,6 @@ class InstallationController implements ContainerAwareInterface
     /**
      * Renders a form to set up the database connection.
      *
-     * @throws \RuntimeException
-     *
      * @return Response|RedirectResponse
      */
     private function setUpDatabaseConnection(): Response
@@ -358,8 +350,6 @@ class InstallationController implements ContainerAwareInterface
 
     /**
      * Renders a form to adjust the database tables.
-     *
-     * @throws \RuntimeException
      */
     private function adjustDatabaseTables(): ?RedirectResponse
     {
@@ -392,8 +382,6 @@ class InstallationController implements ContainerAwareInterface
 
     /**
      * Renders a form to import the example website.
-     *
-     * @throws \RuntimeException
      */
     private function importExampleWebsite(): ?RedirectResponse
     {
@@ -442,9 +430,6 @@ class InstallationController implements ContainerAwareInterface
         return $this->getRedirectResponse();
     }
 
-    /**
-     * @throws \RuntimeException
-     */
     private function createAdminUser(): ?RedirectResponse
     {
         $installTool = $this->container->get('contao_installation.install_tool');
@@ -555,8 +540,6 @@ class InstallationController implements ContainerAwareInterface
 
     /**
      * Returns a redirect response to reload the page.
-     *
-     * @throws \RuntimeException
      */
     private function getRedirectResponse(): RedirectResponse
     {
@@ -571,8 +554,6 @@ class InstallationController implements ContainerAwareInterface
 
     /**
      * Adds the default values to the context.
-     *
-     * @throws \RuntimeException
      *
      * @return array<string,string>
      */

--- a/news-bundle/src/EventListener/PreviewUrlCreateListener.php
+++ b/news-bundle/src/EventListener/PreviewUrlCreateListener.php
@@ -34,8 +34,6 @@ class PreviewUrlCreateListener
 
     /**
      * Adds the news ID to the front end preview URL.
-     *
-     * @throws \RuntimeException
      */
     public function __invoke(PreviewUrlCreateEvent $event): void
     {


### PR DESCRIPTION
With regard to #3791, this is a new attempt to create rules for `@throws` annotations.

As already discussed, we do not want to add `@throws` exceptions to every method that calls another method that calls another method that might throw an exception. Instead, we want to add `@throws` to indicate that an exception should be handled in a try/catch block in contrast to letting it bubble up to the general exception handler.

### Example 1

```php
/**
 * @throws \InvalidArgumentException If the file does not exist
 */
public function loadFile(string $file): SplFileInfo
{
    // ...
}
```

We add the `@throws` annotation here to indicate that the method should not be used without a try/catch block.

### Example 2

```php
public function __construct(string $func, string $action = null, string $username = null)
{
    if ('' === $func) {
        throw new \InvalidArgumentException('The function name in the Contao context must not be empty');
    }

    // ...
}
```

We do not add a `@throws` annotation here because we want the exception to bubble up to the general exception listener. The developer is not supposed to add a try/catch block here but to provide a non empty function name.

### Conclusions

Following these rules, `@throws` annotations never make sense for

- private methods (because only we use them);
- internal classes (e.g. event listeners);
- classes that nobody is supposed to work with (e.g. controllers);
- any exception that is supposed to bubble up to the general exception handler.

They primarily make sense for

- interfaces and abstract classes;
- methods that should only be used inside a try/catch block.

### Ambiguous cases

How about invalid argument exceptions? Are these meant to bubble up or is a developer supposed to wrap them in a try/catch block?