### PR TITLE
Report HTTP exceptions as warnings for the crawler instead of errors

### DIFF
--- a/core-bundle/src/Crawl/Escargot/Subscriber/SearchIndexSubscriber.php
+++ b/core-bundle/src/Crawl/Escargot/Subscriber/SearchIndexSubscriber.php
@@ -195,18 +195,18 @@ class SearchIndexSubscriber implements EscargotSubscriberInterface, EscargotAwar
 
     public function onTransportException(CrawlUri $crawlUri, TransportExceptionInterface $exception, ResponseInterface $response): void
     {
-        $this->logError($crawlUri, 'Could not request properly: '.$exception->getMessage());
+        $this->logWarning($crawlUri, 'Could not request properly: '.$exception->getMessage());
     }
 
     public function onHttpException(CrawlUri $crawlUri, HttpExceptionInterface $exception, ResponseInterface $response, ChunkInterface $chunk): void
     {
-        $this->logError($crawlUri, 'HTTP Status Code: '.$response->getStatusCode());
+        $this->logWarning($crawlUri, 'HTTP Status Code: '.$response->getStatusCode());
     }
 
-    private function logError(CrawlUri $crawlUri, string $message): void
+    private function logWarning(CrawlUri $crawlUri, string $message): void
     {
-        ++$this->stats['error'];
+        ++$this->stats['warning'];
 
-        $this->logWithCrawlUri($crawlUri, LogLevel::ERROR, sprintf('Broken link! %s.', $message));
+        $this->logWithCrawlUri($crawlUri, LogLevel::DEBUG, sprintf('Broken link! %s.', $message));
     }
 }

--- a/core-bundle/tests/Crawl/Escargot/Subscriber/SearchIndexSubscriberTest.php
+++ b/core-bundle/tests/Crawl/Escargot/Subscriber/SearchIndexSubscriberTest.php
@@ -377,10 +377,10 @@ class SearchIndexSubscriberTest extends TestCase
         yield 'Test reports transport exception responses' => [
             new TransportException('Could not resolve host or timeout'),
             $this->getResponse(true, 404),
-            LogLevel::ERROR,
+            LogLevel::DEBUG,
             'Broken link! Could not request properly: Could not resolve host or timeout.',
-            ['ok' => 0, 'warning' => 0, 'error' => 2],
-            ['ok' => 0, 'warning' => 0, 'error' => 1],
+            ['ok' => 0, 'warning' => 2, 'error' => 0],
+            ['ok' => 0, 'warning' => 1, 'error' => 0],
         ];
     }
 
@@ -446,19 +446,19 @@ class SearchIndexSubscriberTest extends TestCase
             new ClientException($this->getResponse(true, 404)),
             $this->getResponse(true, 404),
             new LastChunk(),
-            LogLevel::ERROR,
+            LogLevel::DEBUG,
             'Broken link! HTTP Status Code: 404.',
-            ['ok' => 0, 'warning' => 0, 'error' => 1],
+            ['ok' => 0, 'warning' => 1, 'error' => 0],
         ];
 
         yield 'Test reports responses that were not successful (with previous result)' => [
             new ClientException($this->getResponse(true, 404)),
             $this->getResponse(true, 404),
             new LastChunk(),
-            LogLevel::ERROR,
+            LogLevel::DEBUG,
             'Broken link! HTTP Status Code: 404.',
-            ['ok' => 0, 'warning' => 0, 'error' => 2],
-            ['ok' => 0, 'warning' => 0, 'error' => 1],
+            ['ok' => 0, 'warning' => 2, 'error' => 0],
+            ['ok' => 0, 'warning' => 1, 'error' => 0],
         ];
     }
 


### PR DESCRIPTION
I propose to change failing HTTP requests in our `SearchIndexSubscriber` to be reported as warnings instead of errors. 
Errors cause a hard failure which e.g. cause `contao:crawl` to return a non `0` exit code. This indicates that something went wrong. However, everything was just fine, there are just URLs that end up in e.g. a 401 or whatever else which can be happily ignored by the search index subscriber.

What cannot be ignored is if there's a real failure during indexing a document (e.g. a DB issue when writing to our search tables) which is already the case now.
