### PR TITLE
Do not check on null as the username can be empty

### DIFF
--- a/core-bundle/src/Controller/BackendPreviewSwitchController.php
+++ b/core-bundle/src/Controller/BackendPreviewSwitchController.php
@@ -122,7 +122,7 @@ class BackendPreviewSwitchController
 
         $showUnpublished = 'hide' !== $request->request->get('unpublished');
 
-        if (null !== $frontendUsername) {
+        if ($frontendUsername) {
             $this->previewAuthenticator->authenticateFrontendUser((string) $frontendUsername, $showUnpublished);
         } else {
             $this->previewAuthenticator->authenticateFrontendGuest($showUnpublished);


### PR DESCRIPTION
Fixes #3752 and extends the tests for all possible scenarios.
