### PR TITLE
Remove an unused setup method

### DIFF
--- a/core-bundle/tests/Controller/FrontendModule/TwoFactorControllerTest.php
+++ b/core-bundle/tests/Controller/FrontendModule/TwoFactorControllerTest.php
@@ -43,13 +43,6 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class TwoFactorControllerTest extends TestCase
 {
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        System::setContainer($this->getContainerWithContaoConfiguration());
-    }
-
     public function testReturnsEmptyResponseIfTheUserIsNotFullyAuthenticated(): void
     {
         $container = $this->getContainerWithFrameworkTemplate(


### PR DESCRIPTION
Figured out this setup method is never used because every test method calls `getContainerWithFrameworkTemplate` which sets `System::setContainer` anyway.