### PR TITLE
Register a controller for error page types

### DIFF
--- a/core-bundle/src/Controller/Page/Error4xxPageController.php
+++ b/core-bundle/src/Controller/Page/Error4xxPageController.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Controller\Page;
+
+use Contao\CoreBundle\Controller\AbstractController;
+use Contao\CoreBundle\Framework\ContaoFramework;
+use Contao\CoreBundle\Routing\Page\ContentCompositionInterface;
+use Contao\CoreBundle\ServiceAnnotation\Page;
+use Contao\FrontendIndex;
+use Contao\PageModel;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @Page("error_401", path=false)
+ * @Page("error_403", path=false)
+ * @Page("error_404", path=false)
+ *
+ * @internal
+ */
+class Error4xxPageController extends AbstractController implements ContentCompositionInterface
+{
+    private ContaoFramework $framework;
+
+    public function __construct(ContaoFramework $framework)
+    {
+        $this->framework = $framework;
+    }
+
+    public function __invoke(PageModel $pageModel): Response
+    {
+        $this->framework->initialize();
+
+        return $this->framework
+            ->createInstance(FrontendIndex::class)
+            ->renderPage($pageModel)
+        ;
+    }
+
+    public function supportsContentComposition(PageModel $pageModel): bool
+    {
+        return !$pageModel->autoforward;
+    }
+}

--- a/core-bundle/src/Controller/Page/RootPageController.php
+++ b/core-bundle/src/Controller/Page/RootPageController.php
@@ -21,6 +21,8 @@ use Symfony\Component\HttpFoundation\Response;
 
 /**
  * @Page(contentComposition=false)
+ *
+ * @internal
  */
 class RootPageController extends AbstractController
 {

--- a/core-bundle/src/Resources/config/controller.yml
+++ b/core-bundle/src/Resources/config/controller.yml
@@ -49,6 +49,10 @@ services:
         tags:
             - { name: contao.content_element, category: includes }
 
+    Contao\CoreBundle\Controller\Page\Error4xxPageController:
+        arguments:
+            - '@contao.framework'
+
     Contao\CoreBundle\Controller\FaviconController:
         arguments:
             - '@contao.framework'

--- a/core-bundle/src/Resources/config/controller.yml
+++ b/core-bundle/src/Resources/config/controller.yml
@@ -49,10 +49,6 @@ services:
         tags:
             - { name: contao.content_element, category: includes }
 
-    Contao\CoreBundle\Controller\Page\Error4xxPageController:
-        arguments:
-            - '@contao.framework'
-
     Contao\CoreBundle\Controller\FaviconController:
         arguments:
             - '@contao.framework'
@@ -99,14 +95,18 @@ services:
         tags:
             - controller.service_arguments
 
+    Contao\CoreBundle\Controller\Page\Error4xxPageController:
+        arguments:
+            - '@contao.framework'
+
+    Contao\CoreBundle\Controller\Page\RootPageController: ~
+
     Contao\CoreBundle\Controller\RobotsTxtController:
         arguments:
             - '@contao.framework'
             - '@event_dispatcher'
         tags:
             - controller.service_arguments
-
-    Contao\CoreBundle\Controller\Page\RootPageController: ~
 
     Contao\CoreBundle\Controller\SitemapController:
         arguments:

--- a/core-bundle/src/Routing/Page/PageRegistry.php
+++ b/core-bundle/src/Routing/Page/PageRegistry.php
@@ -18,7 +18,6 @@ use Doctrine\DBAL\Connection;
 class PageRegistry
 {
     private const DISABLE_CONTENT_COMPOSITION = ['redirect', 'forward', 'logout'];
-    private const DISABLE_ROUTING = ['error_401', 'error_403', 'error_404'];
 
     private Connection $connection;
     private ?array $urlPrefixes = null;
@@ -61,7 +60,7 @@ class PageRegistry
         $options = $config->getOptions();
         $path = $config->getPath();
 
-        if (false === $path || \in_array($type, self::DISABLE_ROUTING, true)) {
+        if (false === $path) {
             $path = '';
             $options['compiler_class'] = UnroutablePageRouteCompiler::class;
         } elseif (null === $path) {
@@ -183,11 +182,6 @@ class PageRegistry
     {
         $type = $page->type;
 
-        // Check for non-routable legacy error pages
-        if (\in_array($type, self::DISABLE_ROUTING, true)) {
-            return false;
-        }
-
         // Any legacy page without route config is routable by default
         if (!isset($this->routeConfigs[$type])) {
             return true;
@@ -202,7 +196,7 @@ class PageRegistry
      */
     public function getUnroutableTypes(): array
     {
-        $types = self::DISABLE_ROUTING;
+        $types = [];
 
         foreach ($this->routeConfigs as $type => $config) {
             if (false === $config->getPath()) {

--- a/core-bundle/tests/Controller/Page/Error4xxPageControllerTest.php
+++ b/core-bundle/tests/Controller/Page/Error4xxPageControllerTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\Controller\Page;
+
+use Contao\CoreBundle\Controller\Page\Error4xxPageController;
+use Contao\CoreBundle\Tests\TestCase;
+use Contao\FrontendIndex;
+use Contao\PageModel;
+use Symfony\Component\HttpFoundation\Response;
+
+class Error4xxPageControllerTest extends TestCase
+{
+    public function testRendersThePageThroughFrontendIndex(): void
+    {
+        $response = $this->createMock(Response::class);
+        $pageModel = $this->mockClassWithProperties(PageModel::class, []);
+
+        $frontendIndex = $this->createMock(FrontendIndex::class);
+        $frontendIndex
+            ->expects($this->once())
+            ->method('renderPage')
+            ->with($pageModel)
+            ->willReturn($response)
+        ;
+
+        $framework = $this->mockContaoFramework();
+        $framework
+            ->expects($this->once())
+            ->method('createInstance')
+            ->with(FrontendIndex::class)
+            ->willReturn($frontendIndex)
+        ;
+
+        $controller = new Error4xxPageController($framework);
+
+        $this->assertSame($response, $controller($pageModel));
+    }
+}

--- a/core-bundle/tests/Controller/SitemapControllerTest.php
+++ b/core-bundle/tests/Controller/SitemapControllerTest.php
@@ -277,7 +277,6 @@ class SitemapControllerTest extends TestCase
             'type' => 'forward',
             'groups' => [],
             'published' => '1',
-            'requireItem' => '1',
             'rootLanguage' => 'en',
         ]);
 
@@ -313,7 +312,21 @@ class SitemapControllerTest extends TestCase
 
         $framework = $this->mockFrameworkWithPages($pages, $articles);
         $container = $this->getContainer($framework);
-        $registry = new PageRegistry($this->createMock(Connection::class));
+        $registry = $this->createPartialMock(PageRegistry::class, ['isRoutable', 'supportsContentComposition']);
+
+        $registry
+            ->expects($this->exactly(2))
+            ->method('supportsContentComposition')
+            ->withConsecutive([$page1], [$page2])
+            ->willReturn(false, true)
+        ;
+
+        $registry
+            ->expects($this->once())
+            ->method('isRoutable')
+            ->withConsecutive([$page1])
+            ->willReturn(true)
+        ;
 
         $controller = new SitemapController($registry);
         $controller->setContainer($container);
@@ -324,7 +337,7 @@ class SitemapControllerTest extends TestCase
         $this->assertSame($this->getExpectedSitemapContent(['https://www.foobar.com/en/page2.html']), $response->getContent());
     }
 
-    public function testSkipsNonRegularPages(): void
+    public function testSkipsUnroutablePages(): void
     {
         $page1 = $this->mockClassWithProperties(PageModel::class, [
             'id' => 43,
@@ -364,7 +377,21 @@ class SitemapControllerTest extends TestCase
 
         $framework = $this->mockFrameworkWithPages($pages, [44 => null]);
         $container = $this->getContainer($framework);
-        $registry = new PageRegistry($this->createMock(Connection::class));
+        $registry = $this->createPartialMock(PageRegistry::class, ['isRoutable', 'supportsContentComposition']);
+
+        $registry
+            ->expects($this->exactly(2))
+            ->method('supportsContentComposition')
+            ->withConsecutive([$page1], [$page2])
+            ->willReturn(true, true)
+        ;
+
+        $registry
+            ->expects($this->exactly(2))
+            ->method('isRoutable')
+            ->withConsecutive([$page1], [$page2])
+            ->willReturn(false, true)
+        ;
 
         $controller = new SitemapController($registry);
         $controller->setContainer($container);

--- a/core-bundle/tests/Controller/SitemapControllerTest.php
+++ b/core-bundle/tests/Controller/SitemapControllerTest.php
@@ -312,8 +312,8 @@ class SitemapControllerTest extends TestCase
 
         $framework = $this->mockFrameworkWithPages($pages, $articles);
         $container = $this->getContainer($framework);
-        $registry = $this->createPartialMock(PageRegistry::class, ['isRoutable', 'supportsContentComposition']);
 
+        $registry = $this->createPartialMock(PageRegistry::class, ['isRoutable', 'supportsContentComposition']);
         $registry
             ->expects($this->exactly(2))
             ->method('supportsContentComposition')
@@ -377,8 +377,8 @@ class SitemapControllerTest extends TestCase
 
         $framework = $this->mockFrameworkWithPages($pages, [44 => null]);
         $container = $this->getContainer($framework);
-        $registry = $this->createPartialMock(PageRegistry::class, ['isRoutable', 'supportsContentComposition']);
 
+        $registry = $this->createPartialMock(PageRegistry::class, ['isRoutable', 'supportsContentComposition']);
         $registry
             ->expects($this->exactly(2))
             ->method('supportsContentComposition')

--- a/core-bundle/tests/Routing/Page/PageRegistryTest.php
+++ b/core-bundle/tests/Routing/Page/PageRegistryTest.php
@@ -362,40 +362,6 @@ class PageRegistryTest extends TestCase
         $registry->supportsContentComposition($pageModel);
     }
 
-    /**
-     * @dataProvider errorPageTypeProvider
-     */
-    public function testDoesNotGenerateRoutableRoutesForErrorPages(string $type): void
-    {
-        $pageModel = $this->mockClassWithProperties(
-            PageModel::class,
-            [
-                'type' => $type,
-                'rootLanguage' => 'en',
-            ]
-        );
-
-        $registry = new PageRegistry($this->createMock(Connection::class));
-        $registry->add($type, new RouteConfig());
-
-        $this->assertFalse($registry->isRoutable($pageModel));
-    }
-
-    public function errorPageTypeProvider(): \Generator
-    {
-        yield 'Does not generate route for error_401' => [
-            'error_401',
-        ];
-
-        yield 'Does not generate route for error_403' => [
-            'error_403',
-        ];
-
-        yield 'Does not generate route for error_404' => [
-            'error_404',
-        ];
-    }
-
     public function testDoesNotGenerateRoutableRoutesForNonRoutablePages(): void
     {
         $pageModel = $this->mockClassWithProperties(


### PR DESCRIPTION
Based on https://github.com/contao/contao/pull/3729/files#diff-3b5e721d4a4885d1cbca85acd8ee1c702601930f9e80aa09a06d55c3b708557a and https://github.com/contao/contao/pull/2015/files this adds a controller class for our 401, 403 and 404 page. In a first step, this allows do dynamically determine whether the page supports content composition, and makes the legacy configuration for unroutable pages obsolete.

The fixes in `SitemapControllerTest` show that this was actually incorrectly implemented, which is now fixed as well.