### PR TITLE
Fixed debug:pages command and show dynamic content composition

### DIFF
--- a/core-bundle/src/Command/DebugPagesCommand.php
+++ b/core-bundle/src/Command/DebugPagesCommand.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Command;
 
 use Contao\CoreBundle\Framework\ContaoFramework;
+use Contao\CoreBundle\Routing\Page\ContentCompositionInterface;
 use Contao\CoreBundle\Routing\Page\DynamicRouteInterface;
 use Contao\CoreBundle\Routing\Page\PageRegistry;
 use Contao\CoreBundle\Routing\Page\RouteConfig;
@@ -39,6 +40,11 @@ class DebugPagesCommand extends Command
      */
     private array $routeEnhancers = [];
 
+    /**
+     * @var array<ContentCompositionInterface|bool>
+     */
+    private array $contentComposition = [];
+
     public function __construct(ContaoFramework $framework, PageRegistry $pageRegistry)
     {
         parent::__construct();
@@ -47,12 +53,19 @@ class DebugPagesCommand extends Command
         $this->pageRegistry = $pageRegistry;
     }
 
-    public function add(string $type, RouteConfig $config, DynamicRouteInterface $routeEnhancer = null): void
+    /**
+     * @param ContentCompositionInterface|bool $contentComposition
+     */
+    public function add(string $type, RouteConfig $config, DynamicRouteInterface $routeEnhancer = null, $contentComposition = true): void
     {
         $this->routeConfigs[$type] = $config;
 
         if (null !== $routeEnhancer) {
             $this->routeEnhancers[$type] = $routeEnhancer;
+        }
+
+        if (null !== $contentComposition) {
+            $this->contentComposition[$type] = $contentComposition;
         }
     }
 
@@ -77,11 +90,17 @@ class DebugPagesCommand extends Command
             $page = new PageModel();
             $page->type = $type;
 
+            $contentComposition = $this->pageRegistry->supportsContentComposition($page) ? 'yes' : 'no';
+
+            if (($this->contentComposition[$type] ?? null) instanceof ContentCompositionInterface) {
+                $contentComposition = 'dynamic';
+            }
+
             $rows[] = [
                 $type,
                 $config && $config->getPath() ? $config->getPath() : '*',
                 $config && $config->getUrlSuffix() ? $config->getUrlSuffix() : '*',
-                $this->pageRegistry->supportsContentComposition($page) ? 'yes' : 'no',
+                $contentComposition,
                 isset($this->routeEnhancers[$type]) ? \get_class($this->routeEnhancers[$type]) : '-',
                 $config ? $this->generateArray($config->getRequirements()) : '-',
                 $config ? $this->generateArray($config->getDefaults()) : '-',

--- a/core-bundle/src/DependencyInjection/Compiler/RegisterPagesPass.php
+++ b/core-bundle/src/DependencyInjection/Compiler/RegisterPagesPass.php
@@ -51,7 +51,7 @@ class RegisterPagesPass implements CompilerPassInterface
     protected function registerPages(ContainerBuilder $container): void
     {
         $registry = $container->findDefinition('contao.routing.page_registry');
-        $command = $container->hasDefinition(DebugPagesCommand::class) ? $container->findDefinition(DebugPagesCommand::class) : null;
+        $command = $container->hasDefinition('contao.command.debug_pages') ? $container->findDefinition('contao.command.debug_pages') : null;
 
         foreach ($this->findAndSortTaggedServices(self::TAG_NAME, $container) as $reference) {
             $definition = $container->findDefinition((string) $reference);
@@ -81,7 +81,7 @@ class RegisterPagesPass implements CompilerPassInterface
                 $registry->addMethodCall('add', [$type, $config, $routeEnhancer, $contentComposition]);
 
                 if (null !== $command) {
-                    $command->addMethodCall('add', [$type, $config, $routeEnhancer]);
+                    $command->addMethodCall('add', [$type, $config, $routeEnhancer, $contentComposition]);
                 }
             }
         }

--- a/core-bundle/src/DependencyInjection/Compiler/RegisterPagesPass.php
+++ b/core-bundle/src/DependencyInjection/Compiler/RegisterPagesPass.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\DependencyInjection\Compiler;
 
-use Contao\CoreBundle\Command\DebugPagesCommand;
 use Contao\CoreBundle\Routing\Page\ContentCompositionInterface;
 use Contao\CoreBundle\Routing\Page\DynamicRouteInterface;
 use Contao\CoreBundle\Routing\Page\RouteConfig;

--- a/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
+++ b/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
@@ -25,8 +25,6 @@ use Contao\CoreBundle\Fragment\Reference\ContentElementReference;
 use Contao\CoreBundle\Fragment\Reference\FrontendModuleReference;
 use Contao\CoreBundle\Migration\MigrationInterface;
 use Contao\CoreBundle\Picker\PickerProviderInterface;
-use Contao\CoreBundle\Routing\Page\ContentCompositionInterface;
-use Contao\CoreBundle\Routing\Page\DynamicRouteInterface;
 use Contao\CoreBundle\Search\Indexer\IndexerInterface;
 use Imagine\Exception\RuntimeException;
 use Imagine\Gd\Imagine;

--- a/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
+++ b/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
@@ -128,16 +128,6 @@ class ContaoCoreExtension extends Extension implements PrependExtensionInterface
             ->addTag('contao.migration')
         ;
 
-        $container
-            ->registerForAutoconfiguration(DynamicRouteInterface::class)
-            ->addTag('contao.page')
-        ;
-
-        $container
-            ->registerForAutoconfiguration(ContentCompositionInterface::class)
-            ->addTag('contao.page')
-        ;
-
         $container->registerAttributeForAutoconfiguration(
             AsContentElement::class,
             static function (ChildDefinition $definition, AsContentElement $attribute): void {


### PR DESCRIPTION
While implementing https://github.com/contao/contao/pull/3845 I wanted to show if a page has dynamic content composition in the `debug:pages` command. However, the command didn't work anymore since we renamed the service name!

I also ended up removing the autoconfiguration for our page controller interfaces, since they are only causing issues. Even though I registered a page controller with custom name (`error_404` etc.), the interface caused a page controller with `error4xx` to be registered.