### PR TITLE
Dispatch an event before rendering Twig templates

### DIFF
--- a/core-bundle/src/ContaoCoreBundle.php
+++ b/core-bundle/src/ContaoCoreBundle.php
@@ -28,6 +28,7 @@ use Contao\CoreBundle\DependencyInjection\Compiler\RegisterFragmentsPass;
 use Contao\CoreBundle\DependencyInjection\Compiler\RegisterHookListenersPass;
 use Contao\CoreBundle\DependencyInjection\Compiler\RegisterPagesPass;
 use Contao\CoreBundle\DependencyInjection\Compiler\RemembermeServicesPass;
+use Contao\CoreBundle\DependencyInjection\Compiler\ReplaceTwigEnvironmentPass;
 use Contao\CoreBundle\DependencyInjection\Compiler\RewireTwigPathsPass;
 use Contao\CoreBundle\DependencyInjection\Compiler\SearchIndexerPass;
 use Contao\CoreBundle\DependencyInjection\Compiler\TaggedMigrationsPass;
@@ -118,5 +119,6 @@ class ContaoCoreBundle extends Bundle
         $container->addCompilerPass(new RewireTwigPathsPass());
         $container->addCompilerPass(new AddNativeTransportFactoryPass());
         $container->addCompilerPass(new IntlInstalledLocalesAndCountriesPass());
+        $container->addCompilerPass(new ReplaceTwigEnvironmentPass());
     }
 }

--- a/core-bundle/src/DependencyInjection/Compiler/ReplaceTwigEnvironmentPass.php
+++ b/core-bundle/src/DependencyInjection/Compiler/ReplaceTwigEnvironmentPass.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\DependencyInjection\Compiler;
+
+use Contao\CoreBundle\Twig\Environment;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+class ReplaceTwigEnvironmentPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        $definition = $container->getDefinition('twig');
+
+        // Replace with our own version that supports a render event
+        $definition->setClass(Environment::class);
+
+        $definition->setArguments([
+            new Reference(EventDispatcherInterface::class),
+            ...$definition->getArguments(),
+        ]);
+    }
+}

--- a/core-bundle/src/Event/TwigRenderEvent.php
+++ b/core-bundle/src/Event/TwigRenderEvent.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Event;
+
+use Contao\CoreBundle\Twig\Transformer\PostRenderTransformerInterface;
+
+class TwigRenderEvent
+{
+    private string $name;
+    private array $context;
+
+    /**
+     * @var array<PostRenderTransformerInterface>
+     */
+    private array $transformers = [];
+
+    public function __construct(string $name, array $context)
+    {
+        $this->name = $name;
+        $this->context = $context;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getContext(): array
+    {
+        return $this->context;
+    }
+
+    public function setContext(array $context): void
+    {
+        $this->context = $context;
+    }
+
+    public function addPostRenderTransformer(PostRenderTransformerInterface $transformer): void
+    {
+        $this->transformers[] = $transformer;
+    }
+
+    /**
+     * @return array<PostRenderTransformerInterface>
+     */
+    public function getPostRenderTransformers(): array
+    {
+        return $this->transformers;
+    }
+}

--- a/core-bundle/src/Twig/Environment.php
+++ b/core-bundle/src/Twig/Environment.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Twig;
+
+use Contao\CoreBundle\Event\TwigRenderEvent;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Twig\Environment as BaseEnvironment;
+use Twig\Loader\LoaderInterface;
+
+/**
+ * Dispatches a TwigRenderEvent before rendering but otherwise works
+ * identically to the original @see BaseEnvironment.
+ */
+class Environment extends BaseEnvironment
+{
+    private EventDispatcherInterface $eventDispatcher;
+
+    public function __construct(EventDispatcherInterface $eventDispatcher, LoaderInterface $loader, $options = [])
+    {
+        $this->eventDispatcher = $eventDispatcher;
+
+        parent::__construct($loader, $options);
+    }
+
+    public function render($name, array $context = []): string
+    {
+        $event = new TwigRenderEvent($name, $context);
+        $this->eventDispatcher->dispatch($event);
+
+        $output = parent::render($name, $event->getContext());
+
+        foreach ($event->getPostRenderTransformers() as $transformer) {
+            if ($transformer->supports($name)) {
+                $output = $transformer->transform($output);
+            }
+        }
+
+        return $output;
+    }
+}

--- a/core-bundle/src/Twig/Transformer/HtmlWrapperTransformer.php
+++ b/core-bundle/src/Twig/Transformer/HtmlWrapperTransformer.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Twig\Transformer;
+
+class HtmlWrapperTransformer implements PostRenderTransformerInterface
+{
+    /**
+     * @var array<string, string>
+     */
+    private array $attributes;
+
+    /**
+     * @param array<string, string> $attributes
+     */
+    public function __construct(array $attributes)
+    {
+        $this->attributes = $attributes;
+    }
+
+    public function supports(string $name): bool
+    {
+        return 1 === preg_match('/\.html\.twig|\.html5$/', $name);
+    }
+
+    public function transform(string $rendered): string
+    {
+        // todo: merge attributes into outer wrapper
+
+        return $rendered;
+    }
+}

--- a/core-bundle/src/Twig/Transformer/PostRenderTransformerInterface.php
+++ b/core-bundle/src/Twig/Transformer/PostRenderTransformerInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Twig\Transformer;
+
+interface PostRenderTransformerInterface
+{
+    public function supports(string $name): bool;
+
+    public function transform(string $rendered): string;
+}

--- a/core-bundle/src/Twig/Transformer/PrependTransformer.php
+++ b/core-bundle/src/Twig/Transformer/PrependTransformer.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Twig\Transformer;
+
+class PrependTransformer implements PostRenderTransformerInterface
+{
+    private string $prefix;
+
+    public function __construct(string $prefix)
+    {
+        $this->prefix = $prefix;
+    }
+
+    public function supports(string $name): bool
+    {
+        return true;
+    }
+
+    public function transform(string $rendered): string
+    {
+        return $this->prefix.$rendered;
+    }
+}


### PR DESCRIPTION
This replaces the `Twig\Environment` with our own that dispatches an event before rendering. The intention is to provide an alternative to the `parseTemplate`, `parseFrontendTemplate`, `parseBackendTemplate`, `parseWidget`, `outputFrontendTemplate` and `outputBackendTemplate` hooks. 

I went for a single event that runs *before* rendering and that allows adjusting the context. If you need to adjust the output (which is way less sane), you can now add a `PostRenderTransformer` in the event. This way we can at least encapsulate dangerous things (like adjusting HTML) and there will be a better DX for that:

Example:
```php
public function __invoke(TwigRenderEvent $event): void
{
    // adjust the context
    $event->setContext(array_merge($event->getContext(), ['hello' => 'world']));

    // add `data-foo="bar" to every wrapper
    $event->addPostRenderTransformer(new HtmlWrapperTransformer(['data-foo' => 'bar']));
}
```

We could ship transformers for the most typical scenarios out of the box.

Feedback welcome before I go ahead, polish and add tests. :relaxed: 