### PR TITLE
Fix fragments in RSS feeds

### DIFF
--- a/calendar-bundle/src/Resources/contao/classes/Calendar.php
+++ b/calendar-bundle/src/Resources/contao/classes/Calendar.php
@@ -209,6 +209,7 @@ class Calendar extends Frontend
 		ksort($this->arrEvents);
 
 		$container = System::getContainer();
+
 		/** @var RequestStack $requestStack */
 		$requestStack = System::getContainer()->get('request_stack');
 

--- a/calendar-bundle/src/Resources/contao/classes/Calendar.php
+++ b/calendar-bundle/src/Resources/contao/classes/Calendar.php
@@ -10,6 +10,9 @@
 
 namespace Contao;
 
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
 /**
  * Provide methods regarding calendars.
  *
@@ -205,13 +208,9 @@ class Calendar extends Frontend
 		$count = 0;
 		ksort($this->arrEvents);
 
-		$request = System::getContainer()->get('request_stack')->getCurrentRequest();
-
-		if ($request)
-		{
-			$origScope = $request->attributes->get('_scope');
-			$request->attributes->set('_scope', 'frontend');
-		}
+		$container = System::getContainer();
+		/** @var RequestStack $requestStack */
+		$requestStack = System::getContainer()->get('request_stack');
 
 		$origObjPage = $GLOBALS['objPage'] ?? null;
 
@@ -229,6 +228,11 @@ class Calendar extends Frontend
 
 					// Override the global page object (#2946)
 					$GLOBALS['objPage'] = $this->getPageWithDetails(CalendarModel::findByPk($event['pid'])->jumpTo);
+
+					// Push a new request to the request stack (#3856)
+					$request = Request::create($event['link']);
+					$request->attributes->set('_scope', 'frontend');
+					$requestStack->push($request);
 
 					$objItem = new FeedItem();
 					$objItem->title = $event['title'];
@@ -292,18 +296,15 @@ class Calendar extends Frontend
 					}
 
 					$objFeed->addItem($objItem);
+
+					$requestStack->pop();
 				}
 			}
 		}
 
-		if ($request)
-		{
-			$request->attributes->set('_scope', $origScope);
-		}
-
 		$GLOBALS['objPage'] = $origObjPage;
 
-		$webDir = StringUtil::stripRootDir(System::getContainer()->getParameter('contao.web_dir'));
+		$webDir = StringUtil::stripRootDir($container->getParameter('contao.web_dir'));
 
 		// Create the file
 		File::putContent($webDir . '/share/' . $strFile . '.xml', $this->replaceInsertTags($objFeed->$strType(), false));

--- a/news-bundle/src/Resources/contao/classes/News.php
+++ b/news-bundle/src/Resources/contao/classes/News.php
@@ -10,6 +10,9 @@
 
 namespace Contao;
 
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
 /**
  * Provide methods regarding news archives.
  *
@@ -139,18 +142,15 @@ class News extends Frontend
 			$objArticle = NewsModel::findPublishedByPids($arrArchives);
 		}
 
+		$container = System::getContainer();
+
 		// Parse the items
 		if ($objArticle !== null)
 		{
 			$arrUrls = array();
 
-			$request = System::getContainer()->get('request_stack')->getCurrentRequest();
-
-			if ($request)
-			{
-				$origScope = $request->attributes->get('_scope');
-				$request->attributes->set('_scope', 'frontend');
-			}
+			/** @var RequestStack */
+			$requestStack = $container->get('request_stack');
 
 			$origObjPage = $GLOBALS['objPage'] ?? null;
 
@@ -187,6 +187,11 @@ class News extends Frontend
 				$objItem->title = $objArticle->headline;
 				$objItem->link = $this->getLink($objArticle, $strUrl);
 				$objItem->published = $objArticle->date;
+
+				// Push a new request to the request stack (#3856)
+				$request = Request::create($objItem->link);
+				$request->attributes->set('_scope', 'frontend');
+				$requestStack->push($request);
 
 				/** @var UserModel $objAuthor */
 				if (($objAuthor = $objArticle->getRelated('author')) instanceof UserModel)
@@ -253,17 +258,14 @@ class News extends Frontend
 				}
 
 				$objFeed->addItem($objItem);
-			}
 
-			if ($request)
-			{
-				$request->attributes->set('_scope', $origScope);
+				$requestStack->pop();
 			}
 
 			$GLOBALS['objPage'] = $origObjPage;
 		}
 
-		$webDir = StringUtil::stripRootDir(System::getContainer()->getParameter('contao.web_dir'));
+		$webDir = StringUtil::stripRootDir($container->getParameter('contao.web_dir'));
 
 		// Create the file
 		File::putContent($webDir . '/share/' . $strFile . '.xml', $this->replaceInsertTags($objFeed->$strType(), false));

--- a/news-bundle/src/Resources/contao/classes/News.php
+++ b/news-bundle/src/Resources/contao/classes/News.php
@@ -149,7 +149,7 @@ class News extends Frontend
 		{
 			$arrUrls = array();
 
-			/** @var RequestStack */
+			/** @var RequestStack $requestStack */
 			$requestStack = $container->get('request_stack');
 
 			$origObjPage = $GLOBALS['objPage'] ?? null;


### PR DESCRIPTION
Fixes #3856

This PR now always pushes a new request to the request stack for each individual news article. I left the original `Environment::set('request', …)` bit for the legacy framework untouched though.