### PR TITLE
Use generic image format labels

### DIFF
--- a/core-bundle/src/Resources/contao/dca/tl_image_size.php
+++ b/core-bundle/src/Resources/contao/dca/tl_image_size.php
@@ -202,7 +202,6 @@ $GLOBALS['TL_DCA']['tl_image_size'] = array
 		(
 			'inputType'               => 'checkboxWizard',
 			'options_callback'        => array('tl_image_size', 'getFormats'),
-			'reference'               => &$GLOBALS['TL_LANG']['tl_image_size'],
 			'exclude'                 => true,
 			'eval'                    => array('multiple'=>true),
 			'sql'                     => "varchar(1024) NOT NULL default ''"
@@ -434,7 +433,19 @@ class tl_image_size extends Backend
 			);
 		}
 
-		return array_values(array_unique($formats));
+		$options = array();
+		$formats = array_values(array_unique($formats));
+
+		foreach ($formats as $format)
+		{
+			list($first) = explode(';', $format);
+			list($from, $to) = explode(':', $first);
+			$chunks = array_values(array_diff(explode(',', $to), array($from)));
+
+			$options[$format] = strtoupper($from) . ' → ' . strtoupper($chunks[0]);
+		}
+
+		return $options;
 	}
 
 	/**

--- a/core-bundle/src/Resources/contao/languages/en/tl_image_size.xlf
+++ b/core-bundle/src/Resources/contao/languages/en/tl_image_size.xlf
@@ -107,66 +107,6 @@
       <trans-unit id="tl_image_size.crop.1">
         <source>The image will be resized to the given dimensions. If necessary, it will be cropped.</source>
       </trans-unit>
-      <trans-unit id="tl_image_size.png:webp,png">
-        <source>PNG to WEBP</source>
-      </trans-unit>
-      <trans-unit id="tl_image_size.jpg:webp,jpg;jpeg:webp,jpeg">
-        <source>JPEG to WEBP</source>
-      </trans-unit>
-      <trans-unit id="tl_image_size.gif:webp,gif">
-        <source>GIF to WEBP</source>
-      </trans-unit>
-      <trans-unit id="tl_image_size.webp:webp,png">
-        <source>WEBP to PNG</source>
-      </trans-unit>
-      <trans-unit id="tl_image_size.webp:webp,jpg">
-        <source>WEBP to JPG</source>
-      </trans-unit>
-      <trans-unit id="tl_image_size.png:avif,png">
-        <source>PNG to AVIF</source>
-      </trans-unit>
-      <trans-unit id="tl_image_size.jpg:avif,jpg;jpeg:avif,jpeg">
-        <source>JPEG to AVIF</source>
-      </trans-unit>
-      <trans-unit id="tl_image_size.gif:avif,gif">
-        <source>GIF to AVIF</source>
-      </trans-unit>
-      <trans-unit id="tl_image_size.avif:avif,png">
-        <source>AVIF to PNG</source>
-      </trans-unit>
-      <trans-unit id="tl_image_size.avif:avif,jpg">
-        <source>AVIF to JPG</source>
-      </trans-unit>
-      <trans-unit id="tl_image_size.png:heic,png">
-        <source>PNG to HEIC</source>
-      </trans-unit>
-      <trans-unit id="tl_image_size.jpg:heic,jpg;jpeg:heic,jpeg">
-        <source>JPEG to HEIC</source>
-      </trans-unit>
-      <trans-unit id="tl_image_size.gif:heic,gif">
-        <source>GIF to HEIC</source>
-      </trans-unit>
-      <trans-unit id="tl_image_size.heic:heic,png">
-        <source>HEIC to PNG</source>
-      </trans-unit>
-      <trans-unit id="tl_image_size.heic:heic,jpg">
-        <source>HEIC to JPG</source>
-      </trans-unit>
-      <trans-unit id="tl_image_size.png:jxl,png">
-        <source>PNG to JXL</source>
-      </trans-unit>
-      <trans-unit id="tl_image_size.jpg:jxl,jpg;jpeg:jxl,jpeg">
-        <source>JPEG to JXL</source>
-      </trans-unit>
-      <trans-unit id="tl_image_size.gif:jxl,gif">
-        <source>GIF to JXL</source>
-      </trans-unit>
-      <trans-unit id="tl_image_size.jxl:jxl,png">
-        <source>JXL to PNG</source>
-      </trans-unit>
-      <trans-unit id="tl_image_size.jxl:jxl,jpg">
-        <source>JXL to JPG</source>
-      </trans-unit>
       <trans-unit id="tl_image_size.new.0">
         <source>New</source>
       </trans-unit>


### PR DESCRIPTION
We could save our translators some tedious work this way.

<img width="544" alt="" src="https://user-images.githubusercontent.com/1192057/147268468-609677c5-59a6-4b7b-b78b-7cb175f40c9f.png">
