### PR TITLE
Serialize array value before saving

### DIFF
--- a/core-bundle/src/Resources/contao/dca/tl_layout.php
+++ b/core-bundle/src/Resources/contao/dca/tl_layout.php
@@ -588,6 +588,6 @@ class tl_layout extends Contao\Backend
 			array_insert($array, $i, 'layout.css');
 		}
 
-		return $array;
+		return serialize($array);
 	}
 }


### PR DESCRIPTION
It actually should return the serialized array:

https://github.com/contao/contao/blob/effd5447f8072607f7dffc94c33241d154971ee2/core-bundle/src/Resources/contao/dca/tl_layout.php#L565-L572

<img width="278" alt="Bildschirmfoto 2021-12-26 um 14 30 42" src="https://user-images.githubusercontent.com/754921/147409687-2cea5430-098c-4c9b-90a1-6224a412258a.png">
