### PR TITLE
Set logout response depending on scope

### DIFF
--- a/core-bundle/src/EventListener/Security/LogoutSuccessListener.php
+++ b/core-bundle/src/EventListener/Security/LogoutSuccessListener.php
@@ -32,10 +32,6 @@ class LogoutSuccessListener
 
     public function __invoke(LogoutEvent $event): void
     {
-        if (null !== $event->getResponse()) {
-            return;
-        }
-
         $request = $event->getRequest();
 
         if ($this->scopeMatcher->isBackendRequest($request)) {


### PR DESCRIPTION
Fixes #3824

Symfony redirects to `/` by default and this is the already given response when our `LogoutSuccessListener` is called.