### PR TITLE
Rename the token value method

### DIFF
--- a/core-bundle/src/Controller/BackendPreviewSwitchController.php
+++ b/core-bundle/src/Controller/BackendPreviewSwitchController.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Controller;
 
 use Contao\BackendUser;
+use Contao\CoreBundle\Csrf\ContaoCsrfTokenManager;
 use Contao\CoreBundle\Security\Authentication\FrontendPreviewAuthenticator;
 use Contao\CoreBundle\Security\Authentication\Token\TokenChecker;
 use Contao\Date;
@@ -23,7 +24,6 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Security;
-use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 use Twig\Environment as TwigEnvironment;
 use Twig\Error\Error as TwigError;
 
@@ -44,11 +44,10 @@ class BackendPreviewSwitchController
     private Connection $connection;
     private Security $security;
     private TwigEnvironment $twig;
-    private CsrfTokenManagerInterface $tokenManager;
-    private string $csrfTokenName;
+    private ContaoCsrfTokenManager $tokenManager;
     private RouterInterface $router;
 
-    public function __construct(FrontendPreviewAuthenticator $previewAuthenticator, TokenChecker $tokenChecker, Connection $connection, Security $security, TwigEnvironment $twig, RouterInterface $router, CsrfTokenManagerInterface $tokenManager, string $csrfTokenName)
+    public function __construct(FrontendPreviewAuthenticator $previewAuthenticator, TokenChecker $tokenChecker, Connection $connection, Security $security, TwigEnvironment $twig, RouterInterface $router, ContaoCsrfTokenManager $tokenManager)
     {
         $this->previewAuthenticator = $previewAuthenticator;
         $this->tokenChecker = $tokenChecker;
@@ -57,7 +56,6 @@ class BackendPreviewSwitchController
         $this->twig = $twig;
         $this->router = $router;
         $this->tokenManager = $tokenManager;
-        $this->csrfTokenName = $csrfTokenName;
     }
 
     /**
@@ -100,7 +98,7 @@ class BackendPreviewSwitchController
             return $this->twig->render(
                 '@ContaoCore/Frontend/preview_toolbar_base.html.twig',
                 [
-                    'request_token' => $this->tokenManager->getToken($this->csrfTokenName)->getValue(),
+                    'request_token' => $this->tokenManager->getDefaultTokenValue(),
                     'action' => $this->router->generate('contao_backend_switch'),
                     'canSwitchUser' => $canSwitchUser,
                     'user' => $frontendUsername,

--- a/core-bundle/src/Controller/FrontendController.php
+++ b/core-bundle/src/Controller/FrontendController.php
@@ -108,7 +108,7 @@ class FrontendController extends AbstractController
      */
     public function requestTokenScriptAction(): Response
     {
-        $tokenValue = json_encode($this->container->get('contao.csrf.token_manager')->getFrontendTokenValue());
+        $tokenValue = json_encode($this->container->get('contao.csrf.token_manager')->getDefaultTokenValue());
 
         $response = new Response();
         $response->setContent('document.querySelectorAll(\'input[name=REQUEST_TOKEN],input[name$="[REQUEST_TOKEN]"]\').forEach(function(i){i.value='.$tokenValue.'})');

--- a/core-bundle/src/Csrf/ContaoCsrfTokenManager.php
+++ b/core-bundle/src/Csrf/ContaoCsrfTokenManager.php
@@ -66,7 +66,7 @@ class ContaoCsrfTokenManager extends CsrfTokenManager
     public function getDefaultTokenValue(): string
     {
         if (null === $this->defaultTokenName) {
-            throw new \RuntimeException('The Contao CSRF token manager was not initialized with a frontend token name.');
+            throw new \RuntimeException('The Contao CSRF token manager was not initialized with a default token name.');
         }
 
         return $this->getToken($this->defaultTokenName)->getValue();

--- a/core-bundle/src/Csrf/ContaoCsrfTokenManager.php
+++ b/core-bundle/src/Csrf/ContaoCsrfTokenManager.php
@@ -23,13 +23,13 @@ class ContaoCsrfTokenManager extends CsrfTokenManager
 {
     private RequestStack $requestStack;
     private string $csrfCookiePrefix;
-    private ?string $frontendTokenName;
+    private ?string $defaultTokenName;
 
-    public function __construct(RequestStack $requestStack, string $csrfCookiePrefix, TokenGeneratorInterface $generator = null, TokenStorageInterface $storage = null, $namespace = null, string $frontendTokenName = null)
+    public function __construct(RequestStack $requestStack, string $csrfCookiePrefix, TokenGeneratorInterface $generator = null, TokenStorageInterface $storage = null, $namespace = null, string $defaultTokenName = null)
     {
         $this->requestStack = $requestStack;
         $this->csrfCookiePrefix = $csrfCookiePrefix;
-        $this->frontendTokenName = $frontendTokenName;
+        $this->defaultTokenName = $defaultTokenName;
 
         parent::__construct($generator, $storage, $namespace);
     }
@@ -63,12 +63,12 @@ class ContaoCsrfTokenManager extends CsrfTokenManager
         ;
     }
 
-    public function getFrontendTokenValue(): string
+    public function getDefaultTokenValue(): string
     {
-        if (null === $this->frontendTokenName) {
+        if (null === $this->defaultTokenName) {
             throw new \RuntimeException('The Contao CSRF token manager was not initialized with a frontend token name.');
         }
 
-        return $this->getToken($this->frontendTokenName)->getValue();
+        return $this->getToken($this->defaultTokenName)->getValue();
     }
 }

--- a/core-bundle/src/Resources/config/controller.yml
+++ b/core-bundle/src/Resources/config/controller.yml
@@ -37,7 +37,6 @@ services:
             - '@twig'
             - '@router'
             - '@contao.csrf.token_manager'
-            - '%contao.csrf_token_name%'
         tags:
             - controller.service_arguments
 

--- a/core-bundle/src/Resources/contao/forms/Form.php
+++ b/core-bundle/src/Resources/contao/forms/Form.php
@@ -110,7 +110,7 @@ class Form extends Hybrid
 		$this->Template->hidden = '';
 		$this->Template->formSubmit = $formId;
 		$this->Template->method = ($this->method == 'GET') ? 'get' : 'post';
-		$this->Template->requestToken = System::getContainer()->get('contao.csrf.token_manager')->getFrontendTokenValue();
+		$this->Template->requestToken = System::getContainer()->get('contao.csrf.token_manager')->getDefaultTokenValue();
 
 		$this->initializeSession($formId);
 		$arrLabels = array();

--- a/core-bundle/src/Resources/contao/library/Contao/RequestToken.php
+++ b/core-bundle/src/Resources/contao/library/Contao/RequestToken.php
@@ -53,7 +53,7 @@ class RequestToken
 	{
 		$container = System::getContainer();
 
-		return $container->get('contao.csrf.token_manager')->getFrontendTokenValue();
+		return $container->get('contao.csrf.token_manager')->getDefaultTokenValue();
 	}
 
 	/**

--- a/core-bundle/src/Resources/contao/modules/ModuleChangePassword.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleChangePassword.php
@@ -220,7 +220,7 @@ class ModuleChangePassword extends Module
 		$this->Template->formId = $strFormId;
 		$this->Template->slabel = StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['changePassword']);
 		$this->Template->rowLast = 'row_' . $row . ' row_last' . ((($row % 2) == 0) ? ' even' : ' odd');
-		$this->Template->requestToken = System::getContainer()->get('contao.csrf.token_manager')->getFrontendTokenValue();
+		$this->Template->requestToken = System::getContainer()->get('contao.csrf.token_manager')->getDefaultTokenValue();
 	}
 }
 

--- a/core-bundle/src/Resources/contao/modules/ModuleCloseAccount.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleCloseAccount.php
@@ -145,7 +145,7 @@ class ModuleCloseAccount extends Module
 		$this->Template->formId = $strFormId;
 		$this->Template->slabel = StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['closeAccount']);
 		$this->Template->rowLast = 'row_1 row_last odd';
-		$this->Template->requestToken = $container->get('contao.csrf.token_manager')->getFrontendTokenValue();
+		$this->Template->requestToken = $container->get('contao.csrf.token_manager')->getDefaultTokenValue();
 	}
 }
 

--- a/core-bundle/src/Resources/contao/modules/ModuleLogin.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleLogin.php
@@ -94,7 +94,7 @@ class ModuleLogin extends Module
 		$exception = null;
 		$lastUsername = '';
 
-		$this->Template->requestToken = $container->get('contao.csrf.token_manager')->getFrontendTokenValue();
+		$this->Template->requestToken = $container->get('contao.csrf.token_manager')->getDefaultTokenValue();
 
 		// Only call the authentication utils if there is an active session to prevent starting an empty session
 		if ($request && $request->hasSession() && ($request->hasPreviousSession() || $request->getSession()->isStarted()))

--- a/core-bundle/src/Resources/contao/modules/ModuleQuicklink.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleQuicklink.php
@@ -156,7 +156,7 @@ class ModuleQuicklink extends Module
 		$this->Template->request = StringUtil::ampersand(Environment::get('request'));
 		$this->Template->title = $this->customLabel ?: $GLOBALS['TL_LANG']['MSC']['quicklink'];
 		$this->Template->button = StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['go']);
-		$this->Template->requestToken = System::getContainer()->get('contao.csrf.token_manager')->getFrontendTokenValue();
+		$this->Template->requestToken = System::getContainer()->get('contao.csrf.token_manager')->getDefaultTokenValue();
 	}
 }
 

--- a/core-bundle/src/Resources/contao/modules/ModuleQuicknav.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleQuicknav.php
@@ -88,7 +88,7 @@ class ModuleQuicknav extends Module
 		$this->Template->button = StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['go']);
 		$this->Template->title = $this->customLabel ?: $GLOBALS['TL_LANG']['MSC']['quicknav'];
 		$this->Template->items = $this->getQuicknavPages($this->rootPage, 1, $host);
-		$this->Template->requestToken = System::getContainer()->get('contao.csrf.token_manager')->getFrontendTokenValue();
+		$this->Template->requestToken = System::getContainer()->get('contao.csrf.token_manager')->getDefaultTokenValue();
 	}
 
 	/**

--- a/core-bundle/src/Resources/contao/modules/ModuleRegistration.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleRegistration.php
@@ -359,7 +359,7 @@ class ModuleRegistration extends Module
 		// Deprecated since Contao 4.0, to be removed in Contao 5.0
 		$this->Template->captcha = $arrFields['captcha']['captcha'];
 
-		$this->Template->requestToken = System::getContainer()->get('contao.csrf.token_manager')->getFrontendTokenValue();
+		$this->Template->requestToken = System::getContainer()->get('contao.csrf.token_manager')->getDefaultTokenValue();
 	}
 
 	/**

--- a/core-bundle/tests/Controller/BackendPreviewSwitchControllerTest.php
+++ b/core-bundle/tests/Controller/BackendPreviewSwitchControllerTest.php
@@ -14,6 +14,7 @@ namespace Contao\CoreBundle\Tests\Controller;
 
 use Contao\BackendUser;
 use Contao\CoreBundle\Controller\BackendPreviewSwitchController;
+use Contao\CoreBundle\Csrf\ContaoCsrfTokenManager;
 use Contao\CoreBundle\Security\Authentication\FrontendPreviewAuthenticator;
 use Contao\CoreBundle\Security\Authentication\Token\TokenChecker;
 use Contao\CoreBundle\Tests\TestCase;
@@ -40,7 +41,6 @@ class BackendPreviewSwitchControllerTest extends TestCase
             $this->getTwigMock(),
             $this->mockRouter(),
             $this->mockTokenManager(),
-            'csrf'
         );
 
         $request = $this->createMock(Request::class);
@@ -64,7 +64,6 @@ class BackendPreviewSwitchControllerTest extends TestCase
             $this->getTwigMock(),
             $this->mockRouter(),
             $this->mockTokenManager(),
-            'csrf'
         );
 
         $request = $this->createMock(Request::class);
@@ -104,7 +103,6 @@ class BackendPreviewSwitchControllerTest extends TestCase
             $this->getTwigMock(),
             $this->mockRouter(),
             $this->mockTokenManager(),
-            'csrf'
         );
 
         $request = new Request(
@@ -141,7 +139,6 @@ class BackendPreviewSwitchControllerTest extends TestCase
             $this->getTwigMock(),
             $this->mockRouter(),
             $this->mockTokenManager(),
-            'csrf'
         );
 
         $request = new Request(
@@ -225,16 +222,16 @@ class BackendPreviewSwitchControllerTest extends TestCase
     }
 
     /**
-     * @return CsrfTokenManagerInterface&MockObject
+     * @return ContaoCsrfTokenManager&MockObject
      */
-    private function mockTokenManager(): CsrfTokenManagerInterface
+    private function mockTokenManager(): ContaoCsrfTokenManager
     {
-        $twig = $this->createMock(CsrfTokenManagerInterface::class);
-        $twig
-            ->method('getToken')
-            ->willReturn(new CsrfToken('csrf', 'csrf'))
+        $tokenManager = $this->createMock(ContaoCsrfTokenManager::class);
+        $tokenManager
+            ->method('getDefaultTokenValue')
+            ->willReturn('csrf')
         ;
 
-        return $twig;
+        return $tokenManager;
     }
 }

--- a/core-bundle/tests/Controller/BackendPreviewSwitchControllerTest.php
+++ b/core-bundle/tests/Controller/BackendPreviewSwitchControllerTest.php
@@ -25,8 +25,6 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Security;
-use Symfony\Component\Security\Csrf\CsrfToken;
-use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 use Twig\Environment;
 
 class BackendPreviewSwitchControllerTest extends TestCase

--- a/core-bundle/tests/Controller/FrontendControllerTest.php
+++ b/core-bundle/tests/Controller/FrontendControllerTest.php
@@ -47,7 +47,7 @@ class FrontendControllerTest extends TestCase
         $tokenManager = $this->createMock(ContaoCsrfTokenManager::class);
         $tokenManager
             ->expects($this->once())
-            ->method('getFrontendTokenValue')
+            ->method('getDefaultTokenValue')
             ->willReturn('tokenValue')
         ;
 

--- a/core-bundle/tests/Csrf/ContaoCsrfTokenManagerTest.php
+++ b/core-bundle/tests/Csrf/ContaoCsrfTokenManagerTest.php
@@ -22,7 +22,7 @@ use Symfony\Component\Security\Csrf\TokenStorage\TokenStorageInterface;
 
 class ContaoCsrfTokenManagerTest extends TestCase
 {
-    public function testGetFrontendTokenValue(): void
+    public function testGetDefaultTokenValue(): void
     {
         $storage = new MemoryTokenStorage();
         $storage->initialize(['contao_csrf_token' => 'foo']);
@@ -36,12 +36,12 @@ class ContaoCsrfTokenManagerTest extends TestCase
             'contao_csrf_token'
         );
 
-        $token = new CsrfToken('contao_csrf_token', $tokenManager->getFrontendTokenValue());
+        $token = new CsrfToken('contao_csrf_token', $tokenManager->getDefaultTokenValue());
 
         $this->assertTrue($tokenManager->isTokenValid($token));
     }
 
-    public function testGetFrontendTokenValueFailsIfTokenNameIsNotSet(): void
+    public function testGetDefaultTokenValueFailsIfTokenNameIsNotSet(): void
     {
         $tokenManager = new ContaoCsrfTokenManager(
             $this->createMock(RequestStack::class),
@@ -54,6 +54,6 @@ class ContaoCsrfTokenManagerTest extends TestCase
         $this->expectException('RuntimeException');
         $this->expectExceptionMessage('The Contao CSRF token manager was not initialized with a frontend token name.');
 
-        $tokenManager->getFrontendTokenValue();
+        $tokenManager->getDefaultTokenValue();
     }
 }

--- a/core-bundle/tests/Csrf/ContaoCsrfTokenManagerTest.php
+++ b/core-bundle/tests/Csrf/ContaoCsrfTokenManagerTest.php
@@ -52,7 +52,7 @@ class ContaoCsrfTokenManagerTest extends TestCase
         );
 
         $this->expectException('RuntimeException');
-        $this->expectExceptionMessage('The Contao CSRF token manager was not initialized with a frontend token name.');
+        $this->expectExceptionMessage('The Contao CSRF token manager was not initialized with a default token name.');
 
         $tokenManager->getDefaultTokenValue();
     }


### PR DESCRIPTION
The `getFrontendTokenValue` method was added in #3620

I however noticed the token is not only used in the front end but also the back end, therefore I suggest to rename the method.