### PR TITLE
Add DCA schemas

### DIFF
--- a/core-bundle/config/commands.yaml
+++ b/core-bundle/config/commands.yaml
@@ -52,6 +52,7 @@ services:
         class: Contao\CoreBundle\Command\DebugDcaCommand
         arguments:
             - '@contao.framework'
+            - '@contao.dca.configuration_provider'
 
     contao.command.debug_fragments:
         class: Contao\CoreBundle\Command\DebugFragmentsCommand

--- a/core-bundle/config/commands.yaml
+++ b/core-bundle/config/commands.yaml
@@ -72,6 +72,9 @@ services:
             - '%kernel.project_dir%'
             - '@contao.twig.inspector'
 
+    contao.command.dump_dca_configuration:
+        class: Contao\CoreBundle\Command\DumpDcaConfigurationCommand
+
     contao.command.filesync:
         class: Contao\CoreBundle\Command\FilesyncCommand
         arguments:

--- a/core-bundle/config/listener.yaml
+++ b/core-bundle/config/listener.yaml
@@ -176,6 +176,22 @@ services:
         arguments:
             - '@database_connection'
 
+    contao.listener.data_container.schema.dc_file_exclude:
+        class: Contao\CoreBundle\EventListener\DataContainer\Schema\DcFileExcludeListener
+
+    contao.listener.data_container.schema.input_type_exclude:
+        class: Contao\CoreBundle\EventListener\DataContainer\Schema\InputTypeExcludeListener
+
+    contao.listener.data_container.schema.toggle_operation:
+        class: Contao\CoreBundle\EventListener\DataContainer\Schema\ToggleOperationListener
+        arguments:
+            - '@security.helper'
+
+    contao.listener.data_container.schema_data_validation:
+        class: Contao\CoreBundle\EventListener\DataContainer\Schema\SchemaDataValidationListener
+        arguments:
+            - '@contao.dca.validation.configuration_validator'
+
     contao.listener.data_container.start_stop_validation:
         class: Contao\CoreBundle\EventListener\DataContainer\StartStopValidationListener
         arguments:

--- a/core-bundle/config/services.yaml
+++ b/core-bundle/config/services.yaml
@@ -193,6 +193,9 @@ services:
         tags:
             - contao.dca.schema_dependency_provider
 
+    contao.dca.validation.configuration_validator:
+        class: Contao\CoreBundle\Dca\Validation\ConfigurationValidator
+
     contao.doctrine.backup.dumper:
         class: Contao\CoreBundle\Doctrine\Backup\Dumper
 

--- a/core-bundle/config/services.yaml
+++ b/core-bundle/config/services.yaml
@@ -186,7 +186,7 @@ services:
     contao.dca.schema_factory:
         class: Contao\CoreBundle\Dca\SchemaFactory
         tags:
-            - { name: 'container.service_subscriber', key: 'service_container', id: 'service_container' }
+            - { name: container.service_subscriber, key: service_container, id: service_container }
 
     contao.dca.schema_provider:
         class: Contao\CoreBundle\Dca\Provider\SchemaProvider

--- a/core-bundle/config/services.yaml
+++ b/core-bundle/config/services.yaml
@@ -157,6 +157,42 @@ services:
         tags:
             - { name: data_collector, template: '@ContaoCore/Collector/contao.html.twig', id: contao }
 
+    contao.dca.configuration_provider:
+        class: Contao\CoreBundle\Dca\Provider\ConfigurationProvider
+        arguments:
+            - '@contao.dca.driver_collection'
+            - '@event_dispatcher'
+
+    contao.dca.driver_collection:
+        class: Contao\CoreBundle\Dca\Driver\DriverCollection
+        arguments:
+            - !tagged_iterator contao.dca.driver
+
+    contao.dca.factory:
+        class: Contao\CoreBundle\Dca\DcaFactory
+        public: true
+        arguments:
+            - '@contao.dca.schema_factory'
+            - '@contao.dca.driver_collection'
+            - '@contao.dca.configuration_provider'
+
+    contao.dca.global_array_driver:
+        class: Contao\CoreBundle\Dca\Driver\GlobalArrayDriver
+        arguments:
+            - '@contao.framework'
+        tags:
+            - 'contao.dca.driver'
+
+    contao.dca.schema_factory:
+        class: Contao\CoreBundle\Dca\SchemaFactory
+        tags:
+            - { name: 'container.service_subscriber', key: 'service_container', id: 'service_container' }
+
+    contao.dca.schema_provider:
+        class: Contao\CoreBundle\Dca\Provider\SchemaProvider
+        tags:
+            - contao.dca.schema_dependency_provider
+
     contao.doctrine.backup.dumper:
         class: Contao\CoreBundle\Doctrine\Backup\Dumper
 
@@ -1154,6 +1190,8 @@ services:
     Contao\CoreBundle\Cache\EntityCacheTags: '@contao.cache.entity_tags'
     Contao\CoreBundle\Config\ResourceFinderInterface: '@contao.resource_finder'
     Contao\CoreBundle\Csrf\ContaoCsrfTokenManager: '@contao.csrf.token_manager'
+    Contao\CoreBundle\Dca\DcaFactory: '@contao.dca.factory'
+    Contao\CoreBundle\Dca\SchemaFactory: '@contao.dca.schema_factory'
     Contao\CoreBundle\Doctrine\Backup\DumperInterface: '@contao.doctrine.backup.dumper'
     Contao\CoreBundle\Framework\ContaoFramework: '@contao.framework'
     Contao\CoreBundle\Image\ImageFactoryInterface: '@contao.image.factory'

--- a/core-bundle/config/services.yaml
+++ b/core-bundle/config/services.yaml
@@ -181,7 +181,7 @@ services:
         arguments:
             - '@contao.framework'
         tags:
-            - 'contao.dca.driver'
+            - contao.dca.driver
 
     contao.dca.schema_factory:
         class: Contao\CoreBundle\Dca\SchemaFactory

--- a/core-bundle/contao/classes/DataContainer.php
+++ b/core-bundle/contao/classes/DataContainer.php
@@ -11,6 +11,7 @@
 namespace Contao;
 
 use Contao\CoreBundle\DataContainer\DataContainerOperation;
+use Contao\CoreBundle\Dca\Schema\Dca;
 use Contao\CoreBundle\Exception\AccessDeniedException;
 use Contao\CoreBundle\Exception\ResponseException;
 use Contao\CoreBundle\Picker\DcaPickerProviderInterface;
@@ -1755,6 +1756,11 @@ abstract class DataContainer extends Backend
 		}
 
 		return sprintf($label, $value);
+	}
+
+	protected function getDca(string $resource): Dca
+	{
+		return System::getContainer()->get('contao.dca.factory')->get($resource);
 	}
 
 	/**

--- a/core-bundle/contao/classes/DataContainer.php
+++ b/core-bundle/contao/classes/DataContainer.php
@@ -893,131 +893,74 @@ abstract class DataContainer extends Backend
 	 */
 	protected function generateButtons($arrRow, $strTable, $arrRootIds=array(), $blnCircularReference=false, $arrChildRecordIds=null, $strPrevious=null, $strNext=null)
 	{
-		if (!\is_array($GLOBALS['TL_DCA'][$strTable]['list']['operations'] ?? null))
+		$dca = $this->getDca($strTable);
+
+		if ($dca->list()->operations()->isEmpty())
 		{
 			return '';
 		}
 
 		$return = '';
 
-		foreach ($GLOBALS['TL_DCA'][$strTable]['list']['operations'] as $k=>$v)
+		foreach ($dca->list()->operations() as $operation)
 		{
-			$v = \is_array($v) ? $v : array($v);
+			$k = $operation->getName();
+			$v = $operation->all();
 
-			$config = new DataContainerOperation($k, $v, $arrRow, $this);
+			$id = StringUtil::specialchars(rawurldecode($arrRow['id']));
+			$label = $operation->parseLabel($id);
+			$title = $operation->parseTitle($id);
+			$attributes = $operation->parseAttributes($id);
+			$params = array(
+				'id' => $id,
+				'nb' => Input::get('nb'),
+			);
+			$toggleState = 0;
 
 			// Call a custom function instead of using the default button
-			if (\is_array($v['button_callback'] ?? null))
+			if ($operation->buttonCallback()->isCallable())
 			{
-				$callback = System::importStatic($v['button_callback'][0]);
-				$ref = new \ReflectionMethod($callback, $v['button_callback'][1]);
-
-				if ($ref->getNumberOfParameters() === 1 && ($type = $ref->getParameters()[0]->getType()) && $type->getName() === DataContainerOperation::class)
-				{
-					$callback->{$v['button_callback'][1]}($config);
-				}
-				else
-				{
-					$return .= $callback->{$v['button_callback'][1]}($arrRow, $config['href'] ?? null, $config['label'], $config['title'], $config['icon'] ?? null, $config['attributes'], $strTable, $arrRootIds, $arrChildRecordIds, $blnCircularReference, $strPrevious, $strNext, $this);
-					continue;
-				}
-			}
-			elseif (\is_callable($v['button_callback'] ?? null))
-			{
-				$ref = new \ReflectionFunction($v['button_callback']);
-
-				if ($ref->getNumberOfParameters() === 1 && ($type = $ref->getParameters()[0]->getType()) && $type->getName() === DataContainerOperation::class)
-				{
-					$v['button_callback']($config);
-				}
-				else
-				{
-					$return .= $v['button_callback']($arrRow, $config['href'] ?? null, $config['label'], $config['title'], $config['icon'] ?? null, $config['attributes'], $strTable, $arrRootIds, $arrChildRecordIds, $blnCircularReference, $strPrevious, $strNext, $this);
-					continue;
-				}
-			}
-
-			if (($html = $config->getHtml()) !== null)
-			{
-				$return .= $html;
+				$return .= $operation->buttonCallback()->call($arrRow, $operation->get('href'), $label, $title, $operation->get('icon'), $attributes, $strTable, $arrRootIds, $arrChildRecordIds, $blnCircularReference, $strPrevious, $strNext, $this);
 				continue;
 			}
 
-			$isPopup = $k == 'show';
-			$href = null;
-
-			if (!empty($config['route']))
+			if ($k === 'show')
 			{
-				$params = array('id' => $arrRow['id']);
-
-				if ($isPopup)
-				{
-					$params['popup'] = '1';
-				}
-
-				$href = System::getContainer()->get('router')->generate($config['route'], $params);
-			}
-			elseif (isset($config['href']))
-			{
-				$href = $this->addToUrl(($config['href'] ?? '') . '&amp;id=' . $arrRow['id'] . (Input::get('nb') ? '&amp;nc=1' : '') . ($isPopup ? '&amp;popup=1' : ''));
+				$params['popup'] = 1;
+				$attributes .= ' onclick="Backend.openModalIframe({\'title\':\'' . StringUtil::specialchars(str_replace("'", "\\'", $label)) . '\',\'url\':this.href});return false"';
 			}
 
-			parse_str(StringUtil::decodeEntities($config['href'] ?? ''), $params);
-
-			if (($params['act'] ?? null) == 'toggle' && isset($params['field']))
+			if ($operation->permissionCallback()->isCallable())
 			{
-				// Hide the toggle icon if the user does not have access to the field
-				if ((($GLOBALS['TL_DCA'][$strTable]['fields'][$params['field']]['toggle'] ?? false) !== true && ($GLOBALS['TL_DCA'][$strTable]['fields'][$params['field']]['reverseToggle'] ?? false) !== true) || (self::isFieldExcluded($strTable, $params['field']) && !System::getContainer()->get('security.helper')->isGranted(ContaoCorePermissions::USER_CAN_EDIT_FIELD_OF_TABLE, $strTable . '::' . $params['field'])))
+				$config = new DataContainerOperation($k, $v, $arrRow, $this);
+
+				if (!$operation->permissionCallback()->call($config))
 				{
-					continue;
-				}
-
-				$icon = $config['icon'];
-				$_icon = pathinfo($config['icon'], PATHINFO_FILENAME) . '_.' . pathinfo($config['icon'], PATHINFO_EXTENSION);
-
-				if (false !== strpos($config['icon'], '/'))
-				{
-					$_icon = \dirname($config['icon']) . '/' . $_icon;
-				}
-
-				if ($icon == 'visible.svg')
-				{
-					$_icon = 'invisible.svg';
-				}
-
-				$state = $arrRow[$params['field']] ? 1 : 0;
-
-				if (($config['reverse'] ?? false) || ($GLOBALS['TL_DCA'][$strTable]['fields'][$params['field']]['reverseToggle'] ?? false))
-				{
-					$state = $arrRow[$params['field']] ? 0 : 1;
-				}
-
-				if ($href === null)
-				{
-					$return .= Image::getHtml($config['icon'], $config['label']) . ' ';
-				}
-				else
-				{
-					if (isset($config['titleDisabled']))
-					{
-						$titleDisabled = $config['titleDisabled'];
-					}
-					else
-					{
-						$titleDisabled = (\is_array($v['label']) && isset($v['label'][2])) ? sprintf($v['label'][2], $arrRow['id']) : $config['title'];
-					}
-
-					$return .= '<a href="' . $href . '" title="' . StringUtil::specialchars($state ? $config['title'] : $titleDisabled) . '" data-title="' . StringUtil::specialchars($config['title']) . '" data-title-disabled="' . StringUtil::specialchars($titleDisabled) . '" onclick="Backend.getScrollOffset();return AjaxRequest.toggleField(this,' . ($icon == 'visible.svg' ? 'true' : 'false') . ')">' . Image::getHtml($state ? $icon : $_icon, $config['label'], 'data-icon="' . $icon . '" data-icon-disabled="' . $_icon . '" data-state="' . $state . '"') . '</a> ';
+					$operation->setDisabled(true);
 				}
 			}
-			elseif ($href === null)
+
+			if ($operation->isHidden())
 			{
-				$return .= Image::getHtml($config['icon'], $config['label']) . ' ';
+				$return .= '';
+				continue;
 			}
-			else
+
+			if ($operation->isDisabled())
 			{
-				$return .= '<a href="' . $href . '" title="' . StringUtil::specialchars($config['title']) . '"' . ($isPopup ? ' onclick="Backend.openModalIframe({\'title\':\'' . StringUtil::specialchars(str_replace("'", "\\'", $config['label'])) . '\',\'url\':this.href});return false"' : '') . $config['attributes'] . '>' . Image::getHtml($config['icon'], $config['label']) . '</a> ';
+				$return .= $operation->parseIcon($id) . ' ';
+				continue;
 			}
+
+			if ($operation->isToggle())
+			{
+				$toggleState = $arrRow[$operation->getParam('field')] ? 1 : 0;
+
+				$titleDisabled = $operation->parseToggleReverseTitle($id);
+				$attributes .= '" data-title="' . StringUtil::specialchars($title) . '" data-title-disabled="' . StringUtil::specialchars($titleDisabled) . '" onclick="Backend.getScrollOffset();return AjaxRequest.toggleField(this,' . (!$toggleState ? 'true' : 'false') . ')"';
+			}
+
+			$return .= '<a href="' . $operation->parseHref($params) . '" title="' . StringUtil::specialchars($title) . '"' . $attributes . '>' . $operation->parseIcon($id, $toggleState) . '</a> ';
 		}
 
 		return trim($return);
@@ -1587,17 +1530,7 @@ abstract class DataContainer extends Backend
 	 */
 	public static function isFieldExcluded(string $table, string $field): bool
 	{
-		if (DC_File::class === self::getDriverForTable($table))
-		{
-			return false;
-		}
-
-		if (isset($GLOBALS['TL_DCA'][$table]['fields'][$field]['exclude']))
-		{
-			return (bool) $GLOBALS['TL_DCA'][$table]['fields'][$field]['exclude'];
-		}
-
-		return !empty($GLOBALS['TL_DCA'][$table]['fields'][$field]['inputType']) || !empty($GLOBALS['TL_DCA'][$table]['fields'][$field]['input_field_callback']);
+		return static::getDca($table)->fields()->field($field)->isExcluded();
 	}
 
 	/**
@@ -1758,7 +1691,7 @@ abstract class DataContainer extends Backend
 		return sprintf($label, $value);
 	}
 
-	protected function getDca(string $resource): Dca
+	protected static function getDca(string $resource): Dca
 	{
 		return System::getContainer()->get('contao.dca.factory')->get($resource);
 	}

--- a/core-bundle/src/Command/DebugDcaCommand.php
+++ b/core-bundle/src/Command/DebugDcaCommand.php
@@ -12,6 +12,8 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Command;
 
+use Contao\ArrayUtil;
+use Contao\CoreBundle\Dca\Provider\ConfigurationProviderInterface;
 use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\DcaLoader;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -19,9 +21,13 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Exception\InvalidArgumentException;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\VarDumper\Cloner\VarCloner;
 use Symfony\Component\VarDumper\Dumper\CliDumper;
+use Symfony\Component\Yaml\Dumper;
+use Symfony\Component\Yaml\Yaml;
 
 #[AsCommand(
     name: 'debug:dca',
@@ -29,22 +35,72 @@ use Symfony\Component\VarDumper\Dumper\CliDumper;
 )]
 class DebugDcaCommand extends Command
 {
-    public function __construct(private readonly ContaoFramework $framework)
-    {
+    public function __construct(
+        private readonly ContaoFramework $framework,
+        private readonly ConfigurationProviderInterface $configurationProvider,
+    ) {
         parent::__construct();
     }
 
     protected function configure(): void
     {
-        $this->addArgument('table', InputArgument::REQUIRED, 'The table name');
+        $this
+            ->addArgument('table', InputArgument::REQUIRED, 'The table name')
+            ->addArgument('path', InputArgument::OPTIONAL, 'Path to a node in the DCA')
+            ->addOption('format', null, InputArgument::OPTIONAL, 'The output format (yaml or php)', 'yaml')
+            ->addOption('raw', null, InputOption::VALUE_NONE, 'Do not parse the DCA configuration and dump the raw configuration data instead.')
+            ->setDescription('Dumps the DCA configuration for a table.')
+        ;
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $table = $input->getArgument('table');
+        $io = new SymfonyStyle($input, $output);
+        $errorIo = $io->getErrorStyle();
 
         $this->framework->initialize();
 
+        $table = $input->getArgument('table');
+        $data = $input->getOption('raw') ? $this->getRawConfiguration($table) : $this->configurationProvider->getConfiguration($table);
+
+        if ($path = $input->getArgument('path')) {
+            $data = ArrayUtil::get($data, $path, null, true);
+        }
+
+        $format = $input->getOption('raw') ? 'php' : $input->getOption('format');
+
+        if ('php' === $format) {
+            $dumper = new CliDumper();
+            $cloner = new VarCloner();
+
+            $dumper->dump($cloner->cloneVar($data));
+
+            return Command::SUCCESS;
+        }
+
+        if ('yaml' === $format && !class_exists(Yaml::class)) {
+            $errorIo->error('Setting the "format" option to "yaml" requires the Symfony Yaml component. Try running "composer install symfony/yaml" or use "--format=php" instead.');
+
+            return 1;
+        }
+
+        switch ($format) {
+            case 'yaml':
+                $dumper = new Dumper();
+                $data = $dumper->dump($data, 10);
+                break;
+
+            default:
+                throw new InvalidArgumentException('Only the yaml and php formats are supported.');
+        }
+
+        $io->writeln($data);
+
+        return Command::SUCCESS;
+    }
+
+    private function getRawConfiguration(string $table): array
+    {
         $dcaLoader = $this->framework->createInstance(DcaLoader::class, [$table]);
         $dcaLoader->load();
 
@@ -52,11 +108,6 @@ class DebugDcaCommand extends Command
             throw new InvalidArgumentException('Invalid table name: '.$table);
         }
 
-        $cloner = new VarCloner();
-        $dumper = new CliDumper();
-
-        $dumper->dump($cloner->cloneVar($GLOBALS['TL_DCA'][$table]));
-
-        return Command::SUCCESS;
+        return $GLOBALS['TL_DCA'][$table];
     }
 }

--- a/core-bundle/src/Command/DebugDcaCommand.php
+++ b/core-bundle/src/Command/DebugDcaCommand.php
@@ -27,7 +27,6 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\VarDumper\Cloner\VarCloner;
 use Symfony\Component\VarDumper\Dumper\CliDumper;
 use Symfony\Component\Yaml\Dumper;
-use Symfony\Component\Yaml\Yaml;
 
 #[AsCommand(
     name: 'debug:dca',
@@ -49,14 +48,12 @@ class DebugDcaCommand extends Command
             ->addArgument('path', InputArgument::OPTIONAL, 'Path to a node in the DCA')
             ->addOption('format', null, InputArgument::OPTIONAL, 'The output format (yaml or php)', 'yaml')
             ->addOption('raw', null, InputOption::VALUE_NONE, 'Do not parse the DCA configuration and dump the raw configuration data instead.')
-            ->setDescription('Dumps the DCA configuration for a table.')
         ;
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
-        $errorIo = $io->getErrorStyle();
 
         $this->framework->initialize();
 
@@ -76,12 +73,6 @@ class DebugDcaCommand extends Command
             $dumper->dump($cloner->cloneVar($data));
 
             return Command::SUCCESS;
-        }
-
-        if ('yaml' === $format && !class_exists(Yaml::class)) {
-            $errorIo->error('Setting the "format" option to "yaml" requires the Symfony Yaml component. Try running "composer install symfony/yaml" or use "--format=php" instead.');
-
-            return 1;
         }
 
         switch ($format) {

--- a/core-bundle/src/Command/DumpDcaConfigurationCommand.php
+++ b/core-bundle/src/Command/DumpDcaConfigurationCommand.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Command;
+
+use Contao\CoreBundle\Dca\DcaConfiguration;
+use Symfony\Component\Config\Definition\Dumper\YamlReferenceDumper;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'config:dump-dca',
+    description: 'Dump the default DCA configuration.',
+)]
+class DumpDcaConfigurationCommand extends Command
+{
+    protected function configure(): void
+    {
+        $this
+            ->addArgument('path', InputArgument::OPTIONAL, 'Path to a node in the DCA')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $configuration = new DcaConfiguration('default');
+
+        $path = $input->getArgument('path');
+        $message = 'Contao DCA configuration';
+
+        if (null !== $path) {
+            $message .= sprintf(' at path "%s"', $path);
+        }
+
+        $io->writeln(sprintf('# %s', $message));
+        $dumper = new YamlReferenceDumper();
+
+        $io->writeln(null === $path ? $dumper->dump($configuration) : $dumper->dumpAtPath($configuration, $path));
+
+        return Command::SUCCESS;
+    }
+}

--- a/core-bundle/src/ContaoCoreBundle.php
+++ b/core-bundle/src/ContaoCoreBundle.php
@@ -30,6 +30,7 @@ use Contao\CoreBundle\DependencyInjection\Compiler\RegisterFragmentsPass;
 use Contao\CoreBundle\DependencyInjection\Compiler\RegisterHookListenersPass;
 use Contao\CoreBundle\DependencyInjection\Compiler\RegisterPagesPass;
 use Contao\CoreBundle\DependencyInjection\Compiler\RewireTwigPathsPass;
+use Contao\CoreBundle\DependencyInjection\Compiler\SchemaServiceProviderPass;
 use Contao\CoreBundle\DependencyInjection\Compiler\SearchIndexerPass;
 use Contao\CoreBundle\DependencyInjection\Compiler\TaggedMigrationsPass;
 use Contao\CoreBundle\DependencyInjection\Compiler\TranslationDataCollectorPass;
@@ -122,6 +123,7 @@ class ContaoCoreBundle extends Bundle
         $container->addCompilerPass(new LoggerChannelPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, -1);
         $container->addCompilerPass(new ConfigureFilesystemPass());
         $container->addCompilerPass(new AddInsertTagsPass());
+        $container->addCompilerPass(new SchemaServiceProviderPass());
     }
 
     public static function getVersion(): string

--- a/core-bundle/src/Dca/Data.php
+++ b/core-bundle/src/Dca/Data.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Dca;
+
+use Contao\ArrayUtil;
+use Contao\CoreBundle\Dca\Observer\ChildDataObserver;
+use Contao\CoreBundle\Dca\Observer\DataObserverInterface;
+
+/**
+ * @internal
+ */
+final class Data
+{
+    /**
+     * @var \SplObjectStorage<DataObserverInterface, mixed>
+     */
+    private readonly \SplObjectStorage $readObservers;
+
+    /**
+     * @var \SplObjectStorage<DataObserverInterface, mixed>
+     */
+    private readonly \SplObjectStorage $writeObservers;
+
+    private Data|null $root = null;
+
+    public function __construct(
+        private array $data = [],
+        private readonly string $path = '',
+    ) {
+        $this->readObservers = new \SplObjectStorage();
+        $this->writeObservers = new \SplObjectStorage();
+    }
+
+    public function all(): array
+    {
+        $this->notifyReadObservers();
+
+        return $this->data;
+    }
+
+    public function get(string $path): mixed
+    {
+        $this->notifyReadObservers();
+
+        return ArrayUtil::get($this->data, $path);
+    }
+
+    public function getData(string $path, array|null $fallback = null): self
+    {
+        $this->notifyReadObservers();
+
+        $part = $this->get($path) ?? $fallback;
+
+        if (!\is_array($part)) {
+            throw new \LogicException(sprintf('Data at path "%s" has to be an array.', $path));
+        }
+
+        $data = new self($part, ($this->getPath() ? $this->getPath().'.' : '').$path);
+        $data->setRoot($this->getRoot());
+
+        $data->getReadObservers()->addAll($this->getReadObservers());
+        $this->getRoot()->attachWriteObsever(new ChildDataObserver($data));
+
+        return $data;
+    }
+
+    public function replace(array $data): void
+    {
+        $this->data = $data;
+
+        $this->notifyWriteObservers();
+    }
+
+    public function getPath(): string
+    {
+        return $this->path;
+    }
+
+    public function setRoot(self|null $root): void
+    {
+        $this->root = $root;
+    }
+
+    public function getRoot(): self
+    {
+        return $this->root ?? $this;
+    }
+
+    public function attachReadObserver(DataObserverInterface $observer): void
+    {
+        $this->readObservers->attach($observer);
+    }
+
+    public function detachReadObserver(DataObserverInterface $observer): void
+    {
+        $this->readObservers->detach($observer);
+    }
+
+    /**
+     * @return \SplObjectStorage<DataObserverInterface, mixed>
+     */
+    public function getReadObservers(): \SplObjectStorage
+    {
+        return $this->readObservers;
+    }
+
+    public function attachWriteObsever(DataObserverInterface $observer): void
+    {
+        $this->writeObservers->attach($observer);
+    }
+
+    public function detachWriteObserver(DataObserverInterface $observer): void
+    {
+        $this->writeObservers->detach($observer);
+    }
+
+    /**
+     * @return \SplObjectStorage<DataObserverInterface, mixed>
+     */
+    public function getWriteObservers(): \SplObjectStorage
+    {
+        return $this->writeObservers;
+    }
+
+    private function notifyReadObservers(): void
+    {
+        foreach ($this->readObservers as $observer) {
+            $observer->update($this);
+        }
+    }
+
+    private function notifyWriteObservers(): void
+    {
+        foreach ($this->writeObservers as $observer) {
+            $observer->update($this);
+        }
+    }
+}

--- a/core-bundle/src/Dca/DcaConfiguration.php
+++ b/core-bundle/src/Dca/DcaConfiguration.php
@@ -1,0 +1,197 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Dca;
+
+use Contao\CoreBundle\Dca\Definition\Builder\DcaArrayNodeDefinition;
+use Contao\CoreBundle\Dca\Definition\Builder\DcaNodeBuilder;
+use Contao\DataContainer;
+use Symfony\Component\Config\Definition\Builder\NodeBuilder;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+class DcaConfiguration implements ConfigurationInterface
+{
+    private readonly NodeBuilder $nodeBuilder;
+
+    public function __construct(private readonly string $name)
+    {
+        $this->nodeBuilder = new DcaNodeBuilder();
+    }
+
+    public function getConfigTreeBuilder(): TreeBuilder
+    {
+        $tree = new TreeBuilder($this->name, 'array', $this->nodeBuilder);
+
+        $tree
+            ->getRootNode()
+                ->ignoreExtraKeys()
+                ->children()
+                    ->append($this->addConfigNode())
+                    ->append($this->addListNode())
+                    ->append($this->addPalettesNode())
+                    ->append($this->addSubpalettesNode())
+                    ->append($this->addFieldsNode())
+        ;
+
+        return $tree;
+    }
+
+    private function addConfigNode(): DcaArrayNodeDefinition
+    {
+        $node = new DcaArrayNodeDefinition('config');
+        $node->setBuilder($this->nodeBuilder);
+
+        $children = $node->children();
+
+        $children
+            ->scalarNode('dataContainer')
+            ->isRequired()
+            ->cannotBeEmpty()
+        ;
+
+        $children
+            ->booleanNode('closed')
+            ->defaultFalse()
+        ;
+
+        $children
+            ->booleanNode('enableVersioning')
+            ->defaultFalse()
+        ;
+
+        $children
+            ->scalarNode('ptable')
+        ;
+
+        $children
+            ->arrayNode('onload_callback')
+            ->defaultNull()
+            ->prototype('callback')
+        ;
+
+        $children
+            ->arrayNode('oncut_callback')
+            ->defaultNull()
+            ->prototype('callback')
+        ;
+
+        return $node;
+    }
+
+    private function addListNode(): DcaArrayNodeDefinition
+    {
+        $node = new DcaArrayNodeDefinition('list');
+        $node->setBuilder($this->nodeBuilder);
+
+        $children = $node->children();
+
+        $children
+            ->append($this->addListSortingNode())
+        ;
+
+        $children
+            ->arrayNode('global_operations')
+            ->prototype('operation')
+        ;
+
+        $children
+            ->arrayNode('operations')
+            ->prototype('operation')
+        ;
+
+        return $node;
+    }
+
+    private function addListSortingNode(): DcaArrayNodeDefinition
+    {
+        $node = new DcaArrayNodeDefinition('sorting');
+        $node->setBuilder($this->nodeBuilder);
+
+        $children = $node->children();
+
+        $children
+            ->scalarNode('mode')
+            ->isRequired()
+            ->validate()
+                ->ifNotInArray([
+                    DataContainer::MODE_SORTED,
+                    DataContainer::MODE_SORTABLE,
+                    DataContainer::MODE_SORTED_PARENT,
+                    DataContainer::MODE_PARENT,
+                    DataContainer::MODE_TREE,
+                    DataContainer::MODE_TREE_EXTENDED,
+                ])
+                ->thenInvalid('Invalid sorting mode %s')
+        ;
+
+        $children
+            ->arrayNode('fields')
+            ->isRequired()
+            ->requiresAtLeastOneElement()
+            ->ignoreExtraKeys(true)
+            ->prototype('scalar')
+            ->validate()
+                ->ifTrue(static fn ($value): bool => !\is_string($value))
+                ->thenInvalid('Only string values allowed.')
+        ;
+
+        $children
+            ->node('panelLayout', 'paletteString')
+        ;
+
+        $children
+            ->node('child_record_callback', 'callback')
+        ;
+
+        return $node;
+    }
+
+    private function addPalettesNode(): DcaArrayNodeDefinition
+    {
+        $node = new DcaArrayNodeDefinition('palettes');
+        $node->setBuilder($this->nodeBuilder);
+
+        $node
+            ->children()
+                ->arrayNode('__selector__')
+                ->ignoreExtraKeys(true)
+                ->prototype('scalar')
+        ;
+
+        return $node;
+    }
+
+    private function addSubpalettesNode(): DcaArrayNodeDefinition
+    {
+        $node = new DcaArrayNodeDefinition('subpalettes');
+        $node->setBuilder($this->nodeBuilder);
+
+        $node
+            ->prototype('palettestring')
+        ;
+
+        return $node;
+    }
+
+    private function addFieldsNode(): DcaArrayNodeDefinition
+    {
+        $node = new DcaArrayNodeDefinition('fields');
+        $node->setBuilder($this->nodeBuilder);
+
+        $node
+            ->prototype('field')
+        ;
+
+        return $node;
+    }
+}

--- a/core-bundle/src/Dca/DcaFactory.php
+++ b/core-bundle/src/Dca/DcaFactory.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Dca;
+
+use Contao\CoreBundle\Dca\Driver\DriverCollection;
+use Contao\CoreBundle\Dca\Driver\MutableDataDriverInterface;
+use Contao\CoreBundle\Dca\Provider\ConfigurationProviderInterface;
+use Contao\CoreBundle\Dca\Schema\Dca;
+
+class DcaFactory
+{
+    private array $dcas = [];
+
+    /**
+     * @internal Do not inherit from this class; decorate the "contao.dca.factory" service instead
+     */
+    public function __construct(
+        private readonly SchemaFactory $schemaFactory,
+        private readonly DriverCollection $driverCollection,
+        private readonly ConfigurationProviderInterface $configurationProvider,
+    ) {
+    }
+
+    public function get(string $resource): Dca
+    {
+        if (!isset($this->dcas[$resource])) {
+            $this->dcas[$resource] = $this->create($resource);
+        }
+
+        return $this->dcas[$resource];
+    }
+
+    private function create(string $resource): Dca
+    {
+        $driver = $this->driverCollection->getDriverForResource($resource);
+        $config = $this->configurationProvider->getConfiguration($resource, $driver);
+
+        $data = new Data($config);
+
+        $dca = $this->schemaFactory->createSchema($resource, Dca::class, $data);
+
+        if ($driver instanceof MutableDataDriverInterface) {
+            $observer = $driver->getMutableDataObserver($resource);
+
+            $observer->setCallback(
+                function (Data $subject) use ($resource, $driver): void {
+                    $subject->replace($this->configurationProvider->getConfiguration($resource, $driver));
+                },
+            );
+
+            $data->attachReadObserver($observer);
+        }
+
+        return $dca;
+    }
+}

--- a/core-bundle/src/Dca/DcaFactory.php
+++ b/core-bundle/src/Dca/DcaFactory.php
@@ -17,13 +17,13 @@ use Contao\CoreBundle\Dca\Driver\MutableDataDriverInterface;
 use Contao\CoreBundle\Dca\Provider\ConfigurationProviderInterface;
 use Contao\CoreBundle\Dca\Schema\Dca;
 
+/**
+ * @internal Do not use this class in your code; use the "contao.dca.factory" service instead
+ */
 class DcaFactory
 {
     private array $dcas = [];
 
-    /**
-     * @internal Do not inherit from this class; decorate the "contao.dca.factory" service instead
-     */
     public function __construct(
         private readonly SchemaFactory $schemaFactory,
         private readonly DriverCollection $driverCollection,

--- a/core-bundle/src/Dca/Definition/Builder/ArrayNodeDefinition.php
+++ b/core-bundle/src/Dca/Definition/Builder/ArrayNodeDefinition.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Dca\Definition\Builder;
+
+use Symfony\Component\Config\Definition\ArrayNode;
+use Symfony\Component\Config\Definition\BaseNode;
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition as StrictArrayNodeDefinition;
+use Symfony\Component\Config\Definition\NodeInterface;
+
+/**
+ * Custom array node definition with access to the DcaNodeBuilder and custom prototypes.
+ *
+ * @method DcaNodeBuilder getNodeBuilder()
+ */
+class ArrayNodeDefinition extends StrictArrayNodeDefinition
+{
+    protected static array $nullables = [];
+
+    public function callbackPrototype(): CallbackDefinition
+    {
+        return $this->prototype = $this->getNodeBuilder()->callbackNode(null)
+            ->setParent($this)
+        ;
+    }
+
+    public function operationPrototype(): OperationDefinition
+    {
+        return $this->prototype = $this->getNodeBuilder()->operationNode(null)
+            ->setParent($this)
+        ;
+    }
+
+    /**
+     * Customize the node creation to allow nullable prototype array nodes that get removed if not set.
+     */
+    protected function createNode(): NodeInterface
+    {
+        if ($nullable = ($this->default && null === $this->defaultValue)) {
+            $this->default = [];
+        }
+
+        $node = parent::createNode();
+
+        if ($nullable && $node instanceof BaseNode) {
+            $parent = $node->getParent();
+
+            if ($parent instanceof ArrayNode) {
+                static::$nullables[spl_object_id($parent)][] = $node->getName();
+
+                $parent->setFinalValidationClosures([static function ($value) use ($parent) {
+                    foreach (static::$nullables[spl_object_id($parent)] as $name) {
+                        if (\is_array($value[$name] ?? null) && empty($value[$name])) {
+                            unset($value[$name]);
+                        }
+                    }
+
+                    return $value;
+                }]);
+            }
+        }
+
+        return $node;
+    }
+}

--- a/core-bundle/src/Dca/Definition/Builder/ArrayNodeDefinition.php
+++ b/core-bundle/src/Dca/Definition/Builder/ArrayNodeDefinition.php
@@ -40,6 +40,13 @@ class ArrayNodeDefinition extends StrictArrayNodeDefinition
         ;
     }
 
+    public function dcaNodePrototype(string $type): DcaNodeDefinition
+    {
+        return $this->prototype = $this->getNodeBuilder()->dcaNode(null, $type)
+            ->setParent($this)
+        ;
+    }
+
     /**
      * Customize the node creation to allow nullable prototype array nodes that get removed if not set.
      */

--- a/core-bundle/src/Dca/Definition/Builder/CallbackDefinition.php
+++ b/core-bundle/src/Dca/Definition/Builder/CallbackDefinition.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Dca\Definition\Builder;
+
+class CallbackDefinition extends DcaArrayNodeDefinition implements PreconfiguredDefinitionInterface
+{
+    public function preconfigure(): void
+    {
+        $this
+            ->beforeNormalization()
+            ->always(
+                static function ($value) {
+                    if ($value instanceof \Closure) {
+                        return [$value];
+                    }
+
+                    return $value;
+                },
+            )
+        ;
+
+        $this
+            ->getNodeBuilder()
+                ->variableNode('0')->end()
+                ->scalarNode('1')->end()
+        ;
+    }
+}

--- a/core-bundle/src/Dca/Definition/Builder/CallbackDefinition.php
+++ b/core-bundle/src/Dca/Definition/Builder/CallbackDefinition.php
@@ -31,8 +31,12 @@ class CallbackDefinition extends DcaArrayNodeDefinition implements Preconfigured
 
         $this
             ->getNodeBuilder()
-                ->variableNode('0')->end()
-                ->scalarNode('1')->end()
+            ->variableNode('0')
+                ->info('Service ID / classname for the callback or a Closure')
+            ->end()
+            ->scalarNode('1')
+                ->info('Callback method of the service or class')
+            ->end()
         ;
     }
 }

--- a/core-bundle/src/Dca/Definition/Builder/DcaArrayNodeDefinition.php
+++ b/core-bundle/src/Dca/Definition/Builder/DcaArrayNodeDefinition.php
@@ -12,11 +12,27 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Dca\Definition\Builder;
 
+use Symfony\Component\Config\Definition\Builder\NodeDefinition;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+use Symfony\Component\Config\Definition\NodeInterface;
+use Symfony\Component\Config\Definition\PrototypedArrayNode;
+
 /**
+ * Custom ArrayNodeDefinition to allow extra array keys in the configuration.
+ *
+ * As a transitional solution this node also triggers a deprecation
+ * instead of an exception for missing required nodes, setting their
+ * values to NULL.
+ *
  * @method DcaNodeBuilder children()
+ *
+ * @internal
  */
 class DcaArrayNodeDefinition extends ArrayNodeDefinition
 {
+    use FailableNodeDefinitionTrait;
+    use RootAwareTrait;
+
     /**
      * @var bool
      */
@@ -26,4 +42,64 @@ class DcaArrayNodeDefinition extends ArrayNodeDefinition
      * @var bool
      */
     protected $removeExtraKeys = false;
+
+    public function getNode(bool $forceRootNode = false): NodeInterface
+    {
+        $this
+            ->beforeNormalization()
+            ->always(
+                $this->failableNormalizationCallback(
+                    function ($value) {
+                        // Handle non-array values
+                        if (!\is_array($value)) {
+                            $path = implode(
+                                $this->pathSeparator,
+                                array_filter([
+                                    $this->parent instanceof NodeInterface ? $this->parent->getPath() : '',
+                                    $this->parent instanceof PrototypedArrayNode ? $this->parent->getPrototype()->getName() : $this->name,
+                                ]),
+                            );
+
+                            $exception = new InvalidConfigurationException(
+                                sprintf('Invalid configuration for path "%s". Value must be an array', $path),
+                            );
+                            $exception->setPath($path);
+                            $this->triggerDeprecation($exception, $path, []);
+
+                            return [];
+                        }
+
+                        /**
+                         * @var NodeDefinition $child
+                         */
+                        foreach ($this->children as $name => $child) {
+                            // Handle required child nodes with missing values
+                            if ($child->required && !isset($value[$name])) {
+                                $path = implode(
+                                    $this->pathSeparator,
+                                    array_filter([
+                                        $this->parent instanceof NodeInterface ? $this->parent->getPath() : '',
+                                        $this->name,
+                                        $name,
+                                    ]),
+                                );
+
+                                $exception = new InvalidConfigurationException(
+                                    sprintf('A value for "%s" must be configured', $name),
+                                );
+                                $exception->setPath($path);
+                                $this->triggerDeprecation($exception, $path, null);
+
+                                $value[$name] = null;
+                            }
+                        }
+
+                        return $value;
+                    },
+                ),
+            )
+        ;
+
+        return parent::getNode($forceRootNode);
+    }
 }

--- a/core-bundle/src/Dca/Definition/Builder/DcaArrayNodeDefinition.php
+++ b/core-bundle/src/Dca/Definition/Builder/DcaArrayNodeDefinition.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Dca\Definition\Builder;
+
+/**
+ * @method DcaNodeBuilder children()
+ */
+class DcaArrayNodeDefinition extends ArrayNodeDefinition
+{
+    /**
+     * @var bool
+     */
+    protected $ignoreExtraKeys = true;
+
+    /**
+     * @var bool
+     */
+    protected $removeExtraKeys = false;
+}

--- a/core-bundle/src/Dca/Definition/Builder/DcaNodeBuilder.php
+++ b/core-bundle/src/Dca/Definition/Builder/DcaNodeBuilder.php
@@ -12,6 +12,8 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Dca\Definition\Builder;
 
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\Config\Definition\Builder\BuilderAwareInterface;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 
@@ -52,6 +54,21 @@ class DcaNodeBuilder extends NodeBuilder
     public function operationNode(string|null $name): OperationDefinition
     {
         $node = new OperationDefinition($name);
+        $this->append($node);
+
+        return $node;
+    }
+
+    public function dcaNode(string|null $name, string $realType = 'variable', mixed $invalidFallback = null): DcaNodeDefinition
+    {
+        $inner = new ($this->getNodeClass($realType))($name);
+
+        if ($inner instanceof BuilderAwareInterface) {
+            $inner->setBuilder($this);
+        }
+
+        $node = new DcaNodeDefinition($name, $inner, $invalidFallback);
+
         $this->append($node);
 
         return $node;

--- a/core-bundle/src/Dca/Definition/Builder/DcaNodeBuilder.php
+++ b/core-bundle/src/Dca/Definition/Builder/DcaNodeBuilder.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Dca\Definition\Builder;
+
+use Symfony\Component\Config\Definition\Builder\NodeBuilder;
+use Symfony\Component\Config\Definition\Builder\NodeDefinition;
+
+/**
+ * @method NodeDefinition|DcaNodeBuilder|ArrayNodeDefinition node(?string $name, string $type)()
+ * @method ArrayNodeDefinition                               arrayNode(?string $name)()
+ */
+class DcaNodeBuilder extends NodeBuilder
+{
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->nodeMapping['array'] = ArrayNodeDefinition::class;
+        $this->nodeMapping['callback'] = CallbackDefinition::class;
+        $this->nodeMapping['dca'] = DcaArrayNodeDefinition::class;
+        $this->nodeMapping['field'] = FieldDefinition::class;
+        $this->nodeMapping['operation'] = OperationDefinition::class;
+        $this->nodeMapping['palettestring'] = PaletteStringDefinition::class;
+    }
+
+    public function dcaArrayNode(string|null $name): DcaArrayNodeDefinition
+    {
+        $node = new DcaArrayNodeDefinition($name);
+        $this->append($node);
+
+        return $node;
+    }
+
+    public function callbackNode(string|null $name): CallbackDefinition
+    {
+        $node = new CallbackDefinition($name);
+        $this->append($node);
+
+        return $node;
+    }
+
+    public function operationNode(string|null $name): OperationDefinition
+    {
+        $node = new OperationDefinition($name);
+        $this->append($node);
+
+        return $node;
+    }
+
+    public function append(NodeDefinition $node): static
+    {
+        parent::append($node);
+
+        if ($node instanceof PreconfiguredDefinitionInterface) {
+            $node->preconfigure();
+        }
+
+        return $this;
+    }
+}

--- a/core-bundle/src/Dca/Definition/Builder/DcaNodeDefinition.php
+++ b/core-bundle/src/Dca/Definition/Builder/DcaNodeDefinition.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Dca\Definition\Builder;
+
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\Config\Definition\Builder\NodeBuilder;
+use Symfony\Component\Config\Definition\Builder\NodeDefinition;
+use Symfony\Component\Config\Definition\Builder\NodeParentInterface;
+use Symfony\Component\Config\Definition\Builder\VariableNodeDefinition;
+use Symfony\Component\Config\Definition\NodeInterface;
+
+/**
+ * Custom VariableNodeDefinition as a transitional solution to only
+ * trigger a deprecation instead of an exception for incorrectly configured
+ * nodes.
+ *
+ * The concrete value of the node is determined via the $inner node.
+ *
+ * If an invalid value is detected, the default value or a provided
+ * invalidFallbackValue will be used instead.
+ *
+ * @internal
+ *
+ * @method NodeParentInterface|NodeBuilder|NodeDefinition|ArrayNodeDefinition|VariableNodeDefinition|DcaNodeBuilder|null end()
+ */
+class DcaNodeDefinition extends VariableNodeDefinition
+{
+    use FailableNodeDefinitionTrait;
+    use RootAwareTrait;
+
+    private NodeInterface|null $innerNode = null;
+
+    public function __construct(
+        string|null $name,
+        private readonly NodeDefinition $inner,
+        NodeParentInterface|null $parent = null,
+    ) {
+        parent::__construct($name, $parent);
+    }
+
+    public function cannotBeEmpty(): static
+    {
+        $this->inner->allowEmptyValue = false;
+
+        return $this;
+    }
+
+    public function getNode(bool $forceRootNode = false): NodeInterface
+    {
+        $this
+            ->beforeNormalization()
+            ->always(
+                $this->failableNormalizationCallback(
+                    function ($value) {
+                        if (!$this->innerNode) {
+                            $this->inner->parent = $this->parent;
+
+                            if ($this->inner instanceof PreconfiguredDefinitionInterface) {
+                                $this->inner->preconfigure();
+                            }
+
+                            if ($this->validation) {
+                                $this->inner->validation = $this->validation;
+                            }
+
+                            $this->innerNode = $this->inner->getNode();
+                        }
+
+                        return $this->innerNode->normalize($value);
+                    },
+                ),
+            )
+        ;
+
+        return parent::getNode($forceRootNode);
+    }
+}

--- a/core-bundle/src/Dca/Definition/Builder/DcaTreeBuilder.php
+++ b/core-bundle/src/Dca/Definition/Builder/DcaTreeBuilder.php
@@ -12,12 +12,38 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Dca\Definition\Builder;
 
+use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\NodeInterface;
 
-class DcaTreeBuilder extends TreeBuilder
+/**
+ * @internal
+ */
+final class DcaTreeBuilder extends TreeBuilder
 {
-    public function __construct(string $name)
+    public const FLAG_ALLOW_FAILABLE = 'dca.allow_failable';
+
+    private bool $allowFailableNodes = false;
+
+    public function __construct(string $name, NodeBuilder $builder)
     {
-        parent::__construct($name, 'array', new DcaNodeBuilder());
+        parent::__construct($name, 'dca', $builder);
+    }
+
+    public function buildTree(): NodeInterface
+    {
+        $this->root->attribute(self::FLAG_ALLOW_FAILABLE, $this->allowFailableNodes);
+
+        return parent::buildTree();
+    }
+
+    /**
+     * @phpstan-return static
+     */
+    public function allowFailingNodes(bool $allow): self
+    {
+        $this->allowFailableNodes = $allow;
+
+        return $this;
     }
 }

--- a/core-bundle/src/Dca/Definition/Builder/DcaTreeBuilder.php
+++ b/core-bundle/src/Dca/Definition/Builder/DcaTreeBuilder.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Dca\Definition\Builder;
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+
+class DcaTreeBuilder extends TreeBuilder
+{
+    public function __construct(string $name)
+    {
+        parent::__construct($name, 'array', new DcaNodeBuilder());
+    }
+}

--- a/core-bundle/src/Dca/Definition/Builder/FailableNodeDefinitionTrait.php
+++ b/core-bundle/src/Dca/Definition/Builder/FailableNodeDefinitionTrait.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Dca\Definition\Builder;
+
+use Symfony\Component\Config\Definition\BaseNode;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+
+/**
+ * Utility methods for working with nodes that should only trigger
+ * a deprecation instead of an exception for invalid configurations.
+ *
+ * @internal
+ */
+trait FailableNodeDefinitionTrait
+{
+    /**
+     * @var mixed|null
+     */
+    private mixed $invalidFallback = null;
+
+    private bool $invalidFallbackDefined = false;
+
+    public function invalidFallbackValue(mixed $invalidFallback): self
+    {
+        $this->invalidFallbackDefined = true;
+        $this->invalidFallback = $invalidFallback;
+
+        return $this;
+    }
+
+    public function getInvalidFallbackValue(): mixed
+    {
+        return $this->invalidFallbackDefined ? $this->invalidFallback : ($this->defaultValue ?? null);
+    }
+
+    public function failableNormalizationCallback(\Closure $closure): \Closure
+    {
+        return function ($value) use ($closure) {
+            try {
+                $value = $closure($value);
+            } catch (InvalidConfigurationException $e) {
+                $root = $this->getRootNode();
+
+                if (!$root->getAttribute(DcaTreeBuilder::FLAG_ALLOW_FAILABLE)) {
+                    throw $e;
+                }
+
+                $this->triggerDeprecation($e, $this->createNode()->getPath());
+                $value = $this->getInvalidFallbackValue();
+            }
+
+            return $value;
+        };
+    }
+
+    private function triggerDeprecation(InvalidConfigurationException $e, string|null $path = null, mixed $fallbackValue = null): void
+    {
+        // Use a provided fallbackValue even if it is null
+        $fallbackValue = isset(\func_get_args()[2]) ? $fallbackValue : $this->getInvalidFallbackValue();
+
+        trigger_deprecation(
+            'contao/core-bundle',
+            '5.3',
+            sprintf(
+                'Setting an invalid DCA value has been deprecated and will no longer work in Contao 6. %s at path "%s". Falling back to value "%s" until a valid value is provided.',
+                rtrim($e->getPrevious()?->getMessage() ?? $e->getMessage(), '.'),
+                $path ?? $e->getPath(),
+                var_export($fallbackValue, true),
+            ),
+        );
+    }
+
+    abstract private function getRootNode(): BaseNode;
+}

--- a/core-bundle/src/Dca/Definition/Builder/FieldDefinition.php
+++ b/core-bundle/src/Dca/Definition/Builder/FieldDefinition.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Dca\Definition\Builder;
+
+class FieldDefinition extends DcaArrayNodeDefinition implements PreconfiguredDefinitionInterface
+{
+    public function preconfigure(): void
+    {
+        $builder = $this->getNodeBuilder();
+
+        $builder
+            ->booleanNode('exclude')
+                ->defaultFalse()
+            ->end()
+            ->booleanNode('filter')
+                ->defaultFalse()
+            ->end()
+        ;
+
+        $builder
+            ->scalarNode('inputType')
+                ->validate()
+                    ->always(
+                        static function ($value) {
+                            if (isset($GLOBALS['BE_FFL']) && !isset($GLOBALS['BE_FFL'][$value])) {
+                                throw new \InvalidArgumentException(sprintf('The input type "%s" is unknown.', $value));
+                            }
+
+                            return $value;
+                        },
+                    )
+        ;
+
+        $builder->callbackNode('options_callback');
+
+        $builder->dcaArrayNode('eval');
+
+        $builder
+            ->variableNode('sql')
+            ->validate()
+                ->always(
+                    static function ($value) {
+                        if (null !== $value && !\is_string($value) && !\is_array($value)) {
+                            throw new \InvalidArgumentException(sprintf('The SQL definition has to be either a string or an array (%s).', json_encode($value, JSON_THROW_ON_ERROR)));
+                        }
+
+                        return $value;
+                    },
+                )
+        ;
+    }
+}

--- a/core-bundle/src/Dca/Definition/Builder/FieldDefinition.php
+++ b/core-bundle/src/Dca/Definition/Builder/FieldDefinition.php
@@ -19,9 +19,7 @@ class FieldDefinition extends DcaArrayNodeDefinition implements PreconfiguredDef
         $builder = $this->getNodeBuilder();
 
         $builder
-            ->booleanNode('exclude')
-                ->defaultFalse()
-            ->end()
+            ->booleanNode('exclude')->end()
             ->booleanNode('filter')
                 ->defaultFalse()
             ->end()
@@ -44,6 +42,11 @@ class FieldDefinition extends DcaArrayNodeDefinition implements PreconfiguredDef
         $builder->callbackNode('options_callback');
 
         $builder->dcaArrayNode('eval');
+
+        $builder
+            ->booleanNode('toggle')->end()
+            ->booleanNode('reverseToggle')->end()
+        ;
 
         $builder
             ->variableNode('sql')

--- a/core-bundle/src/Dca/Definition/Builder/OperationDefinition.php
+++ b/core-bundle/src/Dca/Definition/Builder/OperationDefinition.php
@@ -17,20 +17,29 @@ namespace Contao\CoreBundle\Dca\Definition\Builder;
  */
 class OperationDefinition extends DcaArrayNodeDefinition implements PreconfiguredDefinitionInterface
 {
-    protected $ignoreExtraKeys = false;
-
-    protected $removeExtraKeys = true;
-
     public function preconfigure(): void
     {
-        $this
-            ->getNodeBuilder()
+        $builder = $this->getNodeBuilder();
+
+        $builder
             ->variableNode('label')->end()
             ->scalarNode('href')->end()
             ->scalarNode('icon')->end()
             ->scalarNode('class')->end()
             ->scalarNode('attributes')->end()
-            ->node('button_callback', 'callback')
+            ->booleanNode('hidden')->end()
         ;
+
+        $builder
+            ->dcaNode('disabled', 'boolean')
+        ;
+
+        $builder
+            ->dcaNode('reverse', 'boolean')
+            ->invalidFallbackValue(false)
+        ;
+
+        $builder->node('permission_callback', 'callback')->end();
+        $builder->node('button_callback', 'callback')->end();
     }
 }

--- a/core-bundle/src/Dca/Definition/Builder/OperationDefinition.php
+++ b/core-bundle/src/Dca/Definition/Builder/OperationDefinition.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Dca\Definition\Builder;
+
+/**
+ * Preconfigured ArrayNodeDefinition for a DCA operation.
+ */
+class OperationDefinition extends DcaArrayNodeDefinition implements PreconfiguredDefinitionInterface
+{
+    protected $ignoreExtraKeys = false;
+
+    protected $removeExtraKeys = true;
+
+    public function preconfigure(): void
+    {
+        $this
+            ->getNodeBuilder()
+            ->variableNode('label')->end()
+            ->scalarNode('href')->end()
+            ->scalarNode('icon')->end()
+            ->scalarNode('class')->end()
+            ->scalarNode('attributes')->end()
+            ->node('button_callback', 'callback')
+        ;
+    }
+}

--- a/core-bundle/src/Dca/Definition/Builder/PaletteStringDefinition.php
+++ b/core-bundle/src/Dca/Definition/Builder/PaletteStringDefinition.php
@@ -22,15 +22,15 @@ class PaletteStringDefinition extends ScalarNodeDefinition implements Preconfigu
     public function preconfigure(): void
     {
         $this
-            ->isRequired()
-                ->validate()
-                ->ifTrue(
-                    static function (string $value) {
-                        // TODO: Add validation.
-                        return false;
-                    },
-                )
-                ->thenInvalid('Invalid palette string.')
+            ->defaultNull()
+            ->validate()
+            ->ifTrue(
+                static function (?string $value) {
+                    // TODO: Add validation.
+                    return false;
+                },
+            )
+            ->thenInvalid('Invalid palette string.')
         ;
     }
 }

--- a/core-bundle/src/Dca/Definition/Builder/PaletteStringDefinition.php
+++ b/core-bundle/src/Dca/Definition/Builder/PaletteStringDefinition.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Dca\Definition\Builder;
+
+use Symfony\Component\Config\Definition\Builder\ScalarNodeDefinition;
+
+/**
+ * Preconfigured ScalarNodeDefinition for a DCA palette string.
+ */
+class PaletteStringDefinition extends ScalarNodeDefinition implements PreconfiguredDefinitionInterface
+{
+    public function preconfigure(): void
+    {
+        $this
+            ->isRequired()
+                ->validate()
+                ->ifTrue(
+                    static function (string $value) {
+                        // TODO: Add validation.
+                        return false;
+                    },
+                )
+                ->thenInvalid('Invalid palette string.')
+        ;
+    }
+}

--- a/core-bundle/src/Dca/Definition/Builder/PreconfiguredDefinitionInterface.php
+++ b/core-bundle/src/Dca/Definition/Builder/PreconfiguredDefinitionInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Dca\Definition\Builder;
+
+interface PreconfiguredDefinitionInterface
+{
+    public function preconfigure(): void;
+}

--- a/core-bundle/src/Dca/Definition/Builder/RootAwareTrait.php
+++ b/core-bundle/src/Dca/Definition/Builder/RootAwareTrait.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Dca\Definition\Builder;
+
+use Symfony\Component\Config\Definition\BaseNode;
+
+/**
+ * @internal
+ */
+trait RootAwareTrait
+{
+    private function getRootNode(): BaseNode
+    {
+        $root = $this->parent;
+
+        while ($root instanceof BaseNode && ($parent = $root->getParent()) && $parent instanceof BaseNode) {
+            $root = $parent;
+        }
+
+        return $root;
+    }
+}

--- a/core-bundle/src/Dca/Driver/ArrayDriver.php
+++ b/core-bundle/src/Dca/Driver/ArrayDriver.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Dca\Driver;
+
+abstract class ArrayDriver implements DriverInterface
+{
+    private array $cache = [];
+
+    public function read(string $resource): array
+    {
+        return $this->cache[$resource] = $this->getData($resource);
+    }
+
+    public function hasChanged(string $resource): bool
+    {
+        $data = $this->getData($resource);
+        $changed = $data !== ($this->cache[$resource] ?? $data);
+
+        $this->cache[$resource] = $data;
+
+        return $changed;
+    }
+
+    abstract protected function getData(string $name): array;
+}

--- a/core-bundle/src/Dca/Driver/DriverCollection.php
+++ b/core-bundle/src/Dca/Driver/DriverCollection.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Dca\Driver;
+
+class DriverCollection
+{
+    public function __construct(
+        /**
+         * @var array<DriverInterface>
+         */
+        private readonly iterable $drivers,
+    ) {
+    }
+
+    public function getDriverForResource(string $resource): DriverInterface
+    {
+        foreach ($this->drivers as $driver) {
+            if ($driver->handles($resource)) {
+                return $driver;
+            }
+        }
+
+        throw new \LogicException(sprintf('No driver found to handle resource "%s" in %s.', $resource, implode(', ', array_map(static fn ($driver) => $driver::class, $this->getDriversArray()))));
+    }
+
+    public function hasDriverForResource(string $resource): bool
+    {
+        foreach ($this->drivers as $driver) {
+            if ($driver->handles($resource)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function getDriversArray(): array
+    {
+        return $this->drivers instanceof \Traversable ? iterator_to_array($this->drivers) : (array) $this->drivers;
+    }
+}

--- a/core-bundle/src/Dca/Driver/DriverInterface.php
+++ b/core-bundle/src/Dca/Driver/DriverInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Dca\Driver;
+
+interface DriverInterface
+{
+    /**
+     * Read the data for the given source and return a parsed array.
+     */
+    public function read(string $resource): array;
+
+    /**
+     * Returns whether the specified resource is handled by this driver.
+     */
+    public function handles(string $resource): bool;
+}

--- a/core-bundle/src/Dca/Driver/GlobalArrayDriver.php
+++ b/core-bundle/src/Dca/Driver/GlobalArrayDriver.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Dca\Driver;
+
+use Contao\Controller;
+use Contao\CoreBundle\Dca\Observer\DataCallbackObserverInterface;
+use Contao\CoreBundle\Dca\Observer\DriverDataChangeDataCallbackObserver;
+use Contao\CoreBundle\Framework\ContaoFramework;
+
+/**
+ * Special array driver that reads data from $GLOBALS['TL_DCA'].
+ */
+class GlobalArrayDriver extends ArrayDriver implements MutableDataDriverInterface
+{
+    public function __construct(private readonly ContaoFramework $framework)
+    {
+    }
+
+    public function getMutableDataObserver(string $resource): DataCallbackObserverInterface
+    {
+        return new DriverDataChangeDataCallbackObserver($resource, $this);
+    }
+
+    public function handles(string $resource): bool
+    {
+        $this->framework->getAdapter(Controller::class)->loadDataContainer($resource);
+
+        return \is_array($GLOBALS['TL_DCA'][$resource] ?? null);
+    }
+
+    protected function getData(string $name): array
+    {
+        $this->framework->getAdapter(Controller::class)->loadDataContainer($name);
+
+        return $GLOBALS['TL_DCA'][$name] ?? [];
+    }
+}

--- a/core-bundle/src/Dca/Driver/MutableDataDriverInterface.php
+++ b/core-bundle/src/Dca/Driver/MutableDataDriverInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Dca\Driver;
+
+use Contao\CoreBundle\Dca\Observer\DataCallbackObserverInterface;
+
+interface MutableDataDriverInterface
+{
+    public function getMutableDataObserver(string $resource): DataCallbackObserverInterface;
+
+    /**
+     * Check if the source data for a given resource has changed.
+     */
+    public function hasChanged(string $resource): bool;
+}

--- a/core-bundle/src/Dca/Observer/ChildDataObserver.php
+++ b/core-bundle/src/Dca/Observer/ChildDataObserver.php
@@ -22,8 +22,12 @@ class ChildDataObserver implements DataObserverInterface
 
     public function update(Data $subject): void
     {
-        if ('' !== $this->data->getPath()) {
-            $this->data->replace($subject->get($this->data->getPath()));
+        if (!$this->data->isRoot()) {
+            $updated = $subject->get($this->data->getPath()) ?? [];
+
+            if (!$this->data->isEqualTo($updated)) {
+                $this->data->replace($updated);
+            }
         }
     }
 }

--- a/core-bundle/src/Dca/Observer/ChildDataObserver.php
+++ b/core-bundle/src/Dca/Observer/ChildDataObserver.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Dca\Observer;
+
+use Contao\CoreBundle\Dca\Data;
+
+class ChildDataObserver implements DataObserverInterface
+{
+    public function __construct(private readonly Data $data)
+    {
+    }
+
+    public function update(Data $subject): void
+    {
+        if ('' !== $this->data->getPath()) {
+            $this->data->replace($subject->get($this->data->getPath()));
+        }
+    }
+}

--- a/core-bundle/src/Dca/Observer/DataCallbackObserverInterface.php
+++ b/core-bundle/src/Dca/Observer/DataCallbackObserverInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Dca\Observer;
+
+use Contao\CoreBundle\Dca\Data;
+
+interface DataCallbackObserverInterface extends DataObserverInterface
+{
+    public function setCallback(callable|null $callback): self;
+
+    public function runCallback(Data $subject): void;
+}

--- a/core-bundle/src/Dca/Observer/DataObserverInterface.php
+++ b/core-bundle/src/Dca/Observer/DataObserverInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Dca\Observer;
+
+use Contao\CoreBundle\Dca\Data;
+
+interface DataObserverInterface
+{
+    public function update(Data $subject): void;
+}

--- a/core-bundle/src/Dca/Observer/DriverDataChangeDataCallbackObserver.php
+++ b/core-bundle/src/Dca/Observer/DriverDataChangeDataCallbackObserver.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Dca\Observer;
+
+use Contao\CoreBundle\Dca\Data;
+use Contao\CoreBundle\Dca\Driver\MutableDataDriverInterface;
+
+class DriverDataChangeDataCallbackObserver implements DataCallbackObserverInterface
+{
+    /**
+     * @var callable|null
+     */
+    private $callback;
+
+    public function __construct(
+        private readonly string $name,
+        private readonly MutableDataDriverInterface $driver,
+    ) {
+    }
+
+    public function setCallback(callable|null $callback): self
+    {
+        $this->callback = $callback;
+
+        return $this;
+    }
+
+    public function runCallback(Data $subject): void
+    {
+        ($this->callback)($subject);
+    }
+
+    public function getResourceName(): string
+    {
+        return $this->name;
+    }
+
+    public function getDriver(): MutableDataDriverInterface
+    {
+        return $this->driver;
+    }
+
+    public function update(Data $subject): void
+    {
+        if (\is_callable($this->callback) && $this->getDriver()->hasChanged($this->getResourceName())) {
+            $this->runCallback($subject->getRoot());
+        }
+    }
+}

--- a/core-bundle/src/Dca/Observer/RootDataUpdater.php
+++ b/core-bundle/src/Dca/Observer/RootDataUpdater.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Dca\Observer;
+
+use Contao\CoreBundle\Dca\Data;
+
+class RootDataUpdater implements DataObserverInterface
+{
+    public function update(Data $subject): void
+    {
+        $subject->getRoot()->set($subject->getPath(), $subject->all());
+    }
+}

--- a/core-bundle/src/Dca/Provider/ConfigurationProvider.php
+++ b/core-bundle/src/Dca/Provider/ConfigurationProvider.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Dca\Provider;
+
+use Contao\CoreBundle\Dca\DcaConfiguration;
+use Contao\CoreBundle\Dca\Driver\DriverCollection;
+use Contao\CoreBundle\Dca\Driver\DriverInterface;
+use Contao\CoreBundle\Event\Dca\ConfigurationSourceEvent;
+use Symfony\Component\Config\Definition\Processor;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+class ConfigurationProvider implements ConfigurationProviderInterface
+{
+    public function __construct(
+        private readonly DriverCollection $drivers,
+        private readonly EventDispatcherInterface $eventDispatcher,
+    ) {
+    }
+
+    public function getConfiguration(string $resource, DriverInterface|null $driver = null): array
+    {
+        $driver ??= $this->drivers->getDriverForResource($resource);
+        $configs = [$driver->read($resource)];
+        $event = new ConfigurationSourceEvent($resource, $configs, $driver);
+
+        return (new Processor())->processConfiguration(
+            new DcaConfiguration($resource),
+            $this->eventDispatcher->dispatch($event)->getConfigurations(),
+        );
+    }
+}

--- a/core-bundle/src/Dca/Provider/ConfigurationProviderInterface.php
+++ b/core-bundle/src/Dca/Provider/ConfigurationProviderInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Dca\Provider;
+
+use Contao\CoreBundle\Dca\Driver\DriverInterface;
+
+interface ConfigurationProviderInterface
+{
+    /**
+     * Get the configuration array for the given resource, optionally using the provided driver.
+     */
+    public function getConfiguration(string $resource, DriverInterface|null $driver = null): array;
+}

--- a/core-bundle/src/Dca/Provider/SchemaProvider.php
+++ b/core-bundle/src/Dca/Provider/SchemaProvider.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Dca\Provider;
 
 use Contao\CoreBundle\Dca\Schema\Field;
+use Contao\CoreBundle\Dca\Schema\Operation;
 
 class SchemaProvider implements SchemaProviderInterface
 {
@@ -20,6 +21,7 @@ class SchemaProvider implements SchemaProviderInterface
     {
         return [
             Field::class,
+            Operation::class,
         ];
     }
 }

--- a/core-bundle/src/Dca/Provider/SchemaProvider.php
+++ b/core-bundle/src/Dca/Provider/SchemaProvider.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Dca\Provider;
+
+use Contao\CoreBundle\Dca\Schema\Field;
+
+class SchemaProvider implements SchemaProviderInterface
+{
+    public static function getServiceSubscribingSchemas(): array
+    {
+        return [
+            Field::class,
+        ];
+    }
+}

--- a/core-bundle/src/Dca/Provider/SchemaProviderInterface.php
+++ b/core-bundle/src/Dca/Provider/SchemaProviderInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Dca\Provider;
+
+use Contao\CoreBundle\Dca\Schema\ServiceSubscriberSchemaInterface;
+
+interface SchemaProviderInterface
+{
+    /**
+     * Provide all schema classes that have custom dependencies.
+     * Each returned class must implement Contao\CoreBundle\Dca\Schema\ServiceSubscriberSchemaInterface.
+     *
+     * @return array<class-string<ServiceSubscriberSchemaInterface>>
+     */
+    public static function getServiceSubscribingSchemas(): array;
+}

--- a/core-bundle/src/Dca/Schema/Callback.php
+++ b/core-bundle/src/Dca/Schema/Callback.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Dca\Schema;
+
+use Contao\CoreBundle\Framework\FrameworkAwareInterface;
+use Contao\CoreBundle\Framework\FrameworkAwareTrait;
+use Contao\System;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+
+/**
+ * @template CallbackInput of mixed
+ * @template CallbackResult of mixed
+ */
+class Callback extends Schema implements ContainerAwareInterface, FrameworkAwareInterface, ValidatingSchemaInterface
+{
+    use ContainerAwareTrait;
+    use FrameworkAwareTrait;
+
+    protected bool $allowServiceCalls = true;
+
+    // TODO: Set assureCallable from the configuration array when creating the callback.
+    protected bool $assureCallable = true;
+
+    public function __invoke(mixed ...$arguments): mixed
+    {
+        return $this->call(...$arguments);
+    }
+
+    /**
+     * @param CallbackInput ...$arguments
+     *
+     * @return CallbackResult
+     */
+    public function call(...$arguments)
+    {
+        $callback = $this->getCallback();
+
+        if (\is_array($callback)) {
+            if (!$this->framework) {
+                throw new \LogicException(sprintf('You must set the framework service via "Callback::setFramework()" before calling the callback %s:%s', $callback[0], $callback[1]));
+            }
+
+            return $this->framework->getAdapter(System::class)->importStatic($callback[0])->{$callback[1]}(...$arguments);
+        }
+
+        if (!\is_callable($callback)) {
+            throw new \LogicException('This callback is not callable.');
+        }
+
+        return $callback(...$arguments);
+    }
+
+    public function allowsServiceCalls(): bool
+    {
+        return $this->allowServiceCalls;
+    }
+
+    public function validate(): void
+    {
+        $data = $this->all();
+
+        if ($this->isClosureCallback($data)) {
+            return;
+        }
+
+        if ($this->allowsServiceCalls()) {
+            if (null === $this->container) {
+                throw new \LogicException('You must set the service container via "Callback::setContainer()" or disallow service calls for this callback.');
+            }
+
+            if (($data[0] ?? false) && $this->container->has($data[0])) {
+                return;
+            }
+        }
+
+        if (!\is_callable($data)) {
+            throw new \InvalidArgumentException(sprintf('Callback %s is not callable', implode('::', $data)));
+        }
+    }
+
+    /**
+     * @return array|\Closure
+     */
+    private function getCallback()
+    {
+        /** @var array<\Closure> $data */
+        $data = $this->all();
+
+        if ($this->assureCallable && empty($data)) {
+            return static function (): void {};
+        }
+
+        return $this->isClosureCallback($data) ? $data[0] : $data;
+    }
+
+    private function isClosureCallback(array $data): bool
+    {
+        return 1 === \count($data) && $data[0] instanceof \Closure;
+    }
+}

--- a/core-bundle/src/Dca/Schema/Callback.php
+++ b/core-bundle/src/Dca/Schema/Callback.php
@@ -65,7 +65,7 @@ class Callback extends Schema implements ContainerAwareInterface, FrameworkAware
 
         $data = $this->all();
 
-        if (empty($data)) {
+        if ([] === $data) {
             return false;
         }
 
@@ -95,7 +95,7 @@ class Callback extends Schema implements ContainerAwareInterface, FrameworkAware
     {
         $data = $this->all();
 
-        if (!empty($data) && !$this->isCallable()) {
+        if ([] !== $data && !$this->isCallable()) {
             throw new \InvalidArgumentException(sprintf('Callback %s is not callable at %s', implode('::', $data), $this->getData()->getPath()));
         }
     }

--- a/core-bundle/src/Dca/Schema/Callback.php
+++ b/core-bundle/src/Dca/Schema/Callback.php
@@ -54,10 +54,6 @@ class Callback extends Schema implements ContainerAwareInterface, FrameworkAware
             return $this->framework->getAdapter(System::class)->importStatic($callback[0])->{$callback[1]}(...$arguments);
         }
 
-        if (!\is_callable($callback)) {
-            throw new \LogicException('This callback is not callable.');
-        }
-
         return $callback(...$arguments);
     }
 
@@ -84,7 +80,7 @@ class Callback extends Schema implements ContainerAwareInterface, FrameworkAware
             }
         }
 
-        if (!\is_callable($data)) {
+        if (!\is_callable($data) && (!method_exists($data[0], $data[1]))) {
             throw new \InvalidArgumentException(sprintf('Callback %s is not callable', implode('::', $data)));
         }
     }

--- a/core-bundle/src/Dca/Schema/CallbackCollection.php
+++ b/core-bundle/src/Dca/Schema/CallbackCollection.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Dca\Schema;
+
+/**
+ * @extends SchemaCollection<Callback>
+ */
+class CallbackCollection extends SchemaCollection
+{
+    public function call(mixed ...$arguments): void
+    {
+        foreach ($this->children() as $callback) {
+            $callback->call(...$arguments);
+        }
+    }
+
+    /**
+     * @return class-string<Callback<mixed, mixed>>
+     */
+    protected function getChildSchema(): string
+    {
+        return Callback::class;
+    }
+}

--- a/core-bundle/src/Dca/Schema/Config.php
+++ b/core-bundle/src/Dca/Schema/Config.php
@@ -12,6 +12,8 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Dca\Schema;
 
+use Contao\DataContainer;
+
 /**
  * Object representation of the config part of a data container array.
  */
@@ -39,5 +41,13 @@ class Config extends Schema
     public function callback(string $name): CallbackCollection
     {
         return $this->getSchema($name.'_callback', CallbackCollection::class);
+    }
+
+    /**
+     * @return class-string<DataContainer>|null
+     */
+    public function driverClassName(): string|null
+    {
+        return $this->get('dataContainer');
     }
 }

--- a/core-bundle/src/Dca/Schema/Config.php
+++ b/core-bundle/src/Dca/Schema/Config.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Dca\Schema;
+
+/**
+ * Object representation of the config part of a data container array.
+ */
+class Config extends Schema
+{
+    protected array $schemaClasses = [
+        '*_callback' => CallbackCollection::class,
+    ];
+
+    public function isClosed(): bool
+    {
+        return $this->is('closed');
+    }
+
+    public function isEditable(): bool
+    {
+        return !$this->is('notEditable');
+    }
+
+    public function usesVersioning(): bool
+    {
+        return $this->is('enableVersioning');
+    }
+
+    public function callback(string $name): CallbackCollection
+    {
+        return $this->getSchema($name.'_callback', CallbackCollection::class);
+    }
+}

--- a/core-bundle/src/Dca/Schema/Dca.php
+++ b/core-bundle/src/Dca/Schema/Dca.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Dca\Schema;
+
+class Dca extends Schema
+{
+    protected array $schemaClasses = [
+        'config' => Config::class,
+        'list' => Listing::class,
+        'palettes' => Palettes::class,
+        'subpalettes' => Subpalettes::class,
+    ];
+
+    public function config(): Config
+    {
+        return $this->getSchema('config', Config::class);
+    }
+
+    public function list(): Listing
+    {
+        return $this->getSchema('list', Listing::class);
+    }
+
+    public function palettes(): Palettes
+    {
+        return $this->getSchema('palettes', Palettes::class);
+    }
+
+    public function subpalettes(): Subpalettes
+    {
+        return $this->getSchema('subpalettes', Subpalettes::class);
+    }
+
+    public function fields(): FieldCollection
+    {
+        return $this->getSchema('fields', FieldCollection::class);
+    }
+}

--- a/core-bundle/src/Dca/Schema/Field.php
+++ b/core-bundle/src/Dca/Schema/Field.php
@@ -31,6 +31,11 @@ class Field extends Schema implements ServiceSubscriberSchemaInterface
         return $this->is('exclude');
     }
 
+    public function inputType(): string
+    {
+        return $this->get('inputType');
+    }
+
     public function column(): Column
     {
         // TODO: Implement.
@@ -40,6 +45,16 @@ class Field extends Schema implements ServiceSubscriberSchemaInterface
     public function setLocator(ContainerInterface $locator): void
     {
         $this->locator = $locator;
+    }
+
+    public function isToggle(): bool
+    {
+        return $this->get('toggle') ?? false;
+    }
+
+    public function isReverseToggle(): bool
+    {
+        return $this->get('reverseToggle') ?? false;
     }
 
     public static function getSubscribedServices(): array

--- a/core-bundle/src/Dca/Schema/Field.php
+++ b/core-bundle/src/Dca/Schema/Field.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Dca\Schema;
+
+use Doctrine\DBAL\Schema\Column;
+use Psr\Container\ContainerInterface;
+
+/**
+ * Object representation of a single field of a data container array.
+ */
+class Field extends Schema implements ServiceSubscriberSchemaInterface
+{
+    protected array $schemaClasses = [
+        '*_callback' => CallbackCollection::class,
+    ];
+
+    protected ContainerInterface $locator;
+
+    public function isExcluded(): bool
+    {
+        return $this->is('exclude');
+    }
+
+    public function column(): Column
+    {
+        // TODO: Implement.
+        throw new \BadMethodCallException('The column method is not implemented yet.');
+    }
+
+    public function setLocator(ContainerInterface $locator): void
+    {
+        $this->locator = $locator;
+    }
+
+    public static function getSubscribedServices(): array
+    {
+        return [
+            // TODO: Implement service to get the column from the field's SQL.
+        ];
+    }
+}

--- a/core-bundle/src/Dca/Schema/FieldCollection.php
+++ b/core-bundle/src/Dca/Schema/FieldCollection.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Dca\Schema;
+
+/**
+ * @extends SchemaCollection<Field>
+ */
+class FieldCollection extends SchemaCollection
+{
+    public function field(string $key): Field
+    {
+        return $this->getSchema($key, Field::class);
+    }
+
+    protected function getChildSchema(): string
+    {
+        return Field::class;
+    }
+}

--- a/core-bundle/src/Dca/Schema/Listing.php
+++ b/core-bundle/src/Dca/Schema/Listing.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Dca\Schema;
+
+/**
+ * Object representation of the list part of a data container array.
+ */
+class Listing extends Schema
+{
+    protected array $schemaClasses = [
+        'operations' => OperationsCollection::class,
+        'sorting' => Sorting::class,
+    ];
+
+    public function operations(): OperationsCollection
+    {
+        return $this->getSchema('operations', OperationsCollection::class);
+    }
+
+    public function sorting(): Sorting
+    {
+        return $this->getSchema('sorting', Sorting::class);
+    }
+}

--- a/core-bundle/src/Dca/Schema/Operation.php
+++ b/core-bundle/src/Dca/Schema/Operation.php
@@ -15,6 +15,7 @@ namespace Contao\CoreBundle\Dca\Schema;
 use Contao\Backend;
 use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\Image;
+use Contao\StringUtil;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\Routing\RouterInterface;
 
@@ -37,6 +38,14 @@ class Operation extends Schema implements ServiceSubscriberSchemaInterface
         return $this->getSchema('button_callback', Callback::class);
     }
 
+    /**
+     * @return Callback<mixed, bool>
+     */
+    public function permissionCallback(): Callback
+    {
+        return $this->getSchema('permission_callback', Callback::class);
+    }
+
     public function parseLabel(string $id = ''): string
     {
         if ($label = $this->get('label')) {
@@ -54,6 +63,15 @@ class Operation extends Schema implements ServiceSubscriberSchemaInterface
     {
         if ($label = $this->get('label')) {
             $label = \is_array($label) ? sprintf($label[1] ?? $label[0] ?? '', $id) : sprintf($label, $id);
+        }
+
+        return $label ?: $this->getName();
+    }
+
+    public function parseToggleReverseTitle(string $id = ''): string
+    {
+        if ($label = $this->get('label')) {
+            $label = \is_array($label) ? sprintf($label[2] ?? $label[0] ?? '', $id) : sprintf($label, $id);
         }
 
         return $label ?: $this->getName();
@@ -89,12 +107,47 @@ class Operation extends Schema implements ServiceSubscriberSchemaInterface
             $href .= '&amp;popup=1';
         }
 
-        return $this->locator->get('framework')->getAdapter(Backend::class)->addToUrl($href);
+        if ($params['nb'] ?? null) {
+            $href .= '&amp;nc=1';
+        }
+
+        return $this->locator->get('contao.framework')->getAdapter(Backend::class)->addToUrl($href);
     }
 
-    public function parseIcon(string $id = ''): string
+    public function parseIcon(string $id = '', int $toggleState = 0): string
     {
-        return $this->locator->get('framework')->getAdapter(Image::class)->getHtml($this->get('icon'), $this->parseLabel($id));
+        $icon = $this->get('icon');
+        $attributes = '';
+
+        if ($this->isDisabled()) {
+            $icon = str_replace('.svg', '--disabled.svg', $icon);
+        }
+
+        if ($this->isToggle()) {
+            $field = $this->getDca()->fields()->field($this->getParam('field'));
+
+            if ($this->isReverse() || $field->isReverseToggle()) {
+                $toggleState = $toggleState ? 0 : 1;
+            }
+
+            $_icon = pathinfo($icon, PATHINFO_FILENAME).'_.'.pathinfo($icon, PATHINFO_EXTENSION);
+
+            if (str_contains($icon, '/')) {
+                $_icon = \dirname($icon).'/'.$_icon;
+            }
+
+            if ('visible.svg' === $icon) {
+                $_icon = 'invisible.svg';
+            }
+
+            $attributes .= ' data-icon="'.$icon.'" data-icon-disabled="'.$_icon.'" data-state="'.$toggleState.'"';
+
+            if (0 === $toggleState) {
+                $icon = $_icon;
+            }
+        }
+
+        return $this->locator->get('contao.framework')->getAdapter(Image::class)->getHtml($icon, $this->parseLabel($id), trim($attributes));
     }
 
     public function setLocator(ContainerInterface $locator): void
@@ -102,10 +155,48 @@ class Operation extends Schema implements ServiceSubscriberSchemaInterface
         $this->locator = $locator;
     }
 
+    public function isToggle(): bool
+    {
+        return 'toggle' === $this->getParam('act') && null !== $this->getParam('field');
+    }
+
+    public function isReverse(): bool
+    {
+        return $this->get('reverse') ?? false;
+    }
+
+    public function getParams(): array
+    {
+        $params = [];
+        parse_str(StringUtil::decodeEntities($this->parseHref()), $params);
+
+        return $params;
+    }
+
+    public function getParam(string $key): string|null
+    {
+        return $this->getParams()[$key] ?? null;
+    }
+
+    public function isHidden(): bool
+    {
+        return $this->is('hidden');
+    }
+
+    public function isDisabled(): bool
+    {
+        return $this->is('disabled');
+    }
+
+    public function setDisabled(bool $disabled): void
+    {
+        $this->data->set('disabled', $disabled);
+    }
+
     public static function getSubscribedServices(): array
     {
         return [
-            'framework' => ContaoFramework::class,
+            'contao.framework' => ContaoFramework::class,
             'router' => RouterInterface::class,
         ];
     }

--- a/core-bundle/src/Dca/Schema/Operation.php
+++ b/core-bundle/src/Dca/Schema/Operation.php
@@ -64,7 +64,7 @@ class Operation extends Schema implements ServiceSubscriberSchemaInterface
         $attributes = ltrim(sprintf($this->get('attributes') ?? '', $id, $id));
         $classes = $this->getName().($this->get('class') ? ' '.$this->get('class') : '');
 
-        if (false !== strpos($attributes, 'class="')) {
+        if (str_contains($attributes, 'class="')) {
             $attributes = ' '.str_replace('class="', 'class="'.$classes.' ', $attributes);
         } else {
             $attributes = ' class="'.$classes.'" '.$attributes;

--- a/core-bundle/src/Dca/Schema/Operation.php
+++ b/core-bundle/src/Dca/Schema/Operation.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Dca\Schema;
+
+/**
+ * Object representation of an operation.
+ */
+class Operation extends Schema
+{
+    protected array $schemaClasses = [
+        'button_callback' => Callback::class,
+    ];
+
+    /**
+     * @return Callback<mixed, string>
+     */
+    public function buttonCallback(): Callback
+    {
+        return $this->getSchema('button_callback', Callback::class);
+    }
+}

--- a/core-bundle/src/Dca/Schema/Operation.php
+++ b/core-bundle/src/Dca/Schema/Operation.php
@@ -12,14 +12,22 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Dca\Schema;
 
+use Contao\Backend;
+use Contao\CoreBundle\Framework\ContaoFramework;
+use Contao\Image;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\Routing\RouterInterface;
+
 /**
  * Object representation of an operation.
  */
-class Operation extends Schema
+class Operation extends Schema implements ServiceSubscriberSchemaInterface
 {
     protected array $schemaClasses = [
         'button_callback' => Callback::class,
     ];
+
+    private ContainerInterface $locator;
 
     /**
      * @return Callback<mixed, string>
@@ -27,5 +35,78 @@ class Operation extends Schema
     public function buttonCallback(): Callback
     {
         return $this->getSchema('button_callback', Callback::class);
+    }
+
+    public function parseLabel(string $id = ''): string
+    {
+        if ($label = $this->get('label')) {
+            if (\is_array($label)) {
+                $label = $label[0] ?? null;
+            }
+
+            $label = sprintf($label, $id);
+        }
+
+        return $label ?: $this->getName();
+    }
+
+    public function parseTitle(string $id = ''): string
+    {
+        if ($label = $this->get('label')) {
+            $label = \is_array($label) ? sprintf($label[1] ?? $label[0] ?? '', $id) : sprintf($label, $id);
+        }
+
+        return $label ?: $this->getName();
+    }
+
+    public function parseAttributes(string $id): string
+    {
+        $attributes = ltrim(sprintf($this->get('attributes') ?? '', $id, $id));
+        $classes = $this->getName().($this->get('class') ? ' '.$this->get('class') : '');
+
+        if (false !== strpos($attributes, 'class="')) {
+            $attributes = ' '.str_replace('class="', 'class="'.$classes.' ', $attributes);
+        } else {
+            $attributes = ' class="'.$classes.'" '.$attributes;
+        }
+
+        return rtrim($attributes);
+    }
+
+    public function parseHref(array $params = []): string
+    {
+        if ($route = $this->get('route')) {
+            return $this->locator->get('router')->generate($route, $params);
+        }
+
+        $href = $this->get('href');
+
+        if ($id = $params['id'] ?? null) {
+            $href .= '&amp;id='.$id;
+        }
+
+        if ($params['popup'] ?? null) {
+            $href .= '&amp;popup=1';
+        }
+
+        return $this->locator->get('framework')->getAdapter(Backend::class)->addToUrl($href);
+    }
+
+    public function parseIcon(string $id = ''): string
+    {
+        return $this->locator->get('framework')->getAdapter(Image::class)->getHtml($this->get('icon'), $this->parseLabel($id));
+    }
+
+    public function setLocator(ContainerInterface $locator): void
+    {
+        $this->locator = $locator;
+    }
+
+    public static function getSubscribedServices(): array
+    {
+        return [
+            'framework' => ContaoFramework::class,
+            'router' => RouterInterface::class,
+        ];
     }
 }

--- a/core-bundle/src/Dca/Schema/OperationsCollection.php
+++ b/core-bundle/src/Dca/Schema/OperationsCollection.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Dca\Schema;
+
+/**
+ * @extends SchemaCollection<Operation>
+ */
+class OperationsCollection extends SchemaCollection
+{
+    public function operation(string $name): Operation
+    {
+        return $this->getSchema($name, $this->getChildSchema());
+    }
+
+    protected function getChildSchema(): string
+    {
+        return Operation::class;
+    }
+}

--- a/core-bundle/src/Dca/Schema/Palettes.php
+++ b/core-bundle/src/Dca/Schema/Palettes.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Dca\Schema;
+
+use Contao\CoreBundle\Dca\Util\Palette;
+
+/**
+ * Object representation of the palettes part of a data container array.
+ */
+class Palettes extends Schema
+{
+    public function palette(string $key): Palette
+    {
+        return Palette::createFromString($key, $this->get($key));
+    }
+}

--- a/core-bundle/src/Dca/Schema/ParentAwareSchemaInterface.php
+++ b/core-bundle/src/Dca/Schema/ParentAwareSchemaInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Dca\Schema;
+
+interface ParentAwareSchemaInterface
+{
+    public function getParent(): SchemaInterface|null;
+
+    public function setParent(SchemaInterface|null $schema): void;
+
+    public function getRoot(): SchemaInterface|null;
+}

--- a/core-bundle/src/Dca/Schema/ParentAwareSchemaInterface.php
+++ b/core-bundle/src/Dca/Schema/ParentAwareSchemaInterface.php
@@ -12,9 +12,13 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Dca\Schema;
 
+use Contao\CoreBundle\Dca\Util\Path;
+
 interface ParentAwareSchemaInterface
 {
     public function getParent(): SchemaInterface|null;
+
+    public function getPath(): Path;
 
     public function setParent(SchemaInterface|null $schema): void;
 

--- a/core-bundle/src/Dca/Schema/Schema.php
+++ b/core-bundle/src/Dca/Schema/Schema.php
@@ -14,6 +14,7 @@ namespace Contao\CoreBundle\Dca\Schema;
 
 use Contao\CoreBundle\Dca\Data;
 use Contao\CoreBundle\Dca\SchemaFactory;
+use Contao\CoreBundle\Dca\Util\Path;
 
 class Schema implements SchemaInterface, SchemaManagerInterface, ParentAwareSchemaInterface
 {
@@ -120,11 +121,42 @@ class Schema implements SchemaInterface, SchemaManagerInterface, ParentAwareSche
     {
         $current = $this;
 
-        while ($current instanceof ParentAwareSchemaInterface) {
+        while ($current instanceof ParentAwareSchemaInterface && $current->getParent()) {
             $current = $current->getParent();
         }
 
         return $current;
+    }
+
+    public function getPath(): Path
+    {
+        $path = [];
+        $current = $this;
+
+        while ($current instanceof ParentAwareSchemaInterface && $current->getParent()) {
+            $path[] = $current->getName();
+            $current = $current->getParent();
+        }
+
+        return new Path(array_reverse($path));
+    }
+
+    public function getDca(): Dca|null
+    {
+        $root = $this->getRoot();
+
+        return $root instanceof Dca ? $root : null;
+    }
+
+    public function copyWith(Data $data): static
+    {
+        return $this->schemaFactory->createSchema(
+            $this->getName(),
+            static::class,
+            $data,
+            $this->parent,
+            true,
+        );
     }
 
     protected function getSchemaFactory(): SchemaFactory

--- a/core-bundle/src/Dca/Schema/Schema.php
+++ b/core-bundle/src/Dca/Schema/Schema.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Dca\Schema;
+
+use Contao\CoreBundle\Dca\Data;
+use Contao\CoreBundle\Dca\SchemaFactory;
+
+class Schema implements SchemaInterface, SchemaManagerInterface, ParentAwareSchemaInterface
+{
+    protected SchemaFactory $schemaFactory;
+
+    protected array $schemas = [];
+
+    /**
+     * @var array<class-string>
+     */
+    protected array $schemaClasses = [];
+
+    private SchemaInterface|null $parent = null;
+
+    public function __construct(
+        protected string $name,
+        protected Data $data,
+        SchemaFactory|null $schemaFactory = null,
+    ) {
+        if ($schemaFactory) {
+            $this->schemaFactory = $schemaFactory;
+        }
+    }
+
+    /**
+     * @template T of SchemaInterface
+     *
+     * @param class-string<T> $className
+     *
+     * @return T
+     */
+    public function getSchema(string $key, string|null $className = null, Data|null $data = null, bool $allowCustomClassName = true): SchemaInterface
+    {
+        if (!isset($this->schemas[$key])) {
+            $className = $className && !$allowCustomClassName ? $className : $this->getSchemaClass($key, $className);
+
+            $this->schemas[$key] = $this->getSchemaFactory()->createSchema($key, $className, $data ?? $this->getData($key), $this);
+        }
+
+        return $this->schemas[$key];
+    }
+
+    public function setSchemaFactory(SchemaFactory $factory): void
+    {
+        $this->schemaFactory = $factory;
+    }
+
+    public function setSchemaClass(string $key, string $className): void
+    {
+        $this->schemaClasses[$key] = $className;
+    }
+
+    public function setSchemaClasses(array $map): void
+    {
+        $this->schemaClasses = $map;
+    }
+
+    public function resetSchemas(): void
+    {
+        $this->schemas = [];
+    }
+
+    public function setSchema(string $key, SchemaInterface $schema): void
+    {
+        $this->schemas[$key] = $schema;
+    }
+
+    public function all(): array
+    {
+        return $this->data->all();
+    }
+
+    public function get(string $key)
+    {
+        return $this->data->get($key);
+    }
+
+    public function getData(string|null $key = null): Data
+    {
+        return null === $key ? $this->data : $this->data->getData($key, []);
+    }
+
+    public function is(string $key, bool $default = false): bool
+    {
+        return true === ($this->get($key) ?? $default);
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getParent(): SchemaInterface|null
+    {
+        return $this->parent;
+    }
+
+    public function setParent(SchemaInterface|null $schema): void
+    {
+        $this->parent = $schema;
+    }
+
+    public function getRoot(): SchemaInterface|null
+    {
+        $current = $this;
+
+        while ($current instanceof ParentAwareSchemaInterface) {
+            $current = $current->getParent();
+        }
+
+        return $current;
+    }
+
+    protected function getSchemaFactory(): SchemaFactory
+    {
+        return $this->schemaFactory;
+    }
+
+    /**
+     * @param class-string|null $fallback
+     *
+     * @return class-string|null
+     */
+    protected function getSchemaClass(string $key, string|null $fallback = null): string|null
+    {
+        $className = $this->schemaClasses[$key] ?? null;
+
+        if (!$className) {
+            foreach (array_keys($this->schemaClasses) as $schemaKey) {
+                if (!str_contains($schemaKey, '*')) {
+                    continue;
+                }
+
+                if (preg_match('/'.str_replace('*', '.+', $schemaKey).'/i', $key)) {
+                    $className = $this->schemaClasses[$schemaKey];
+                }
+            }
+        }
+
+        if (!$className && !$fallback) {
+            throw new \LogicException(sprintf('No schema class defined for "%s" in %s', $key, static::class));
+        }
+
+        return $className ?? $fallback;
+    }
+}

--- a/core-bundle/src/Dca/Schema/SchemaCollection.php
+++ b/core-bundle/src/Dca/Schema/SchemaCollection.php
@@ -14,8 +14,9 @@ namespace Contao\CoreBundle\Dca\Schema;
 
 /**
  * @template T of SchemaInterface
+ * @implements \IteratorAggregate<string, T>
  */
-abstract class SchemaCollection extends Schema
+abstract class SchemaCollection extends Schema implements \IteratorAggregate
 {
     public function isEmpty(): bool
     {
@@ -28,6 +29,14 @@ abstract class SchemaCollection extends Schema
     public function children(): array
     {
         return array_map(fn ($key) => $this->getSchema($key, $this->getChildSchema()), array_map('\strval', array_keys($this->all())));
+    }
+
+    /**
+     * @return \Iterator<T>
+     */
+    public function getIterator(): \Traversable
+    {
+        return new \ArrayIterator($this->children());
     }
 
     /**

--- a/core-bundle/src/Dca/Schema/SchemaCollection.php
+++ b/core-bundle/src/Dca/Schema/SchemaCollection.php
@@ -14,6 +14,7 @@ namespace Contao\CoreBundle\Dca\Schema;
 
 /**
  * @template T of SchemaInterface
+ *
  * @implements \IteratorAggregate<string, T>
  */
 abstract class SchemaCollection extends Schema implements \IteratorAggregate

--- a/core-bundle/src/Dca/Schema/SchemaCollection.php
+++ b/core-bundle/src/Dca/Schema/SchemaCollection.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Dca\Schema;
+
+/**
+ * @template T of SchemaInterface
+ */
+abstract class SchemaCollection extends Schema
+{
+    public function isEmpty(): bool
+    {
+        return [] === $this->data->all();
+    }
+
+    /**
+     * @return array<T>
+     */
+    public function children(): array
+    {
+        return array_map(fn ($key) => $this->getSchema($key, $this->getChildSchema()), array_map('\strval', array_keys($this->all())));
+    }
+
+    /**
+     * @return class-string<T>
+     */
+    abstract protected function getChildSchema(): string;
+}

--- a/core-bundle/src/Dca/Schema/SchemaCollection.php
+++ b/core-bundle/src/Dca/Schema/SchemaCollection.php
@@ -25,11 +25,16 @@ abstract class SchemaCollection extends Schema implements \IteratorAggregate
     }
 
     /**
-     * @return array<T>
+     * @return array<string, T>
      */
     public function children(): array
     {
-        return array_map(fn ($key) => $this->getSchema($key, $this->getChildSchema()), array_map('\strval', array_keys($this->all())));
+        $key = array_map('\strval', array_keys($this->all()));
+
+        return array_combine(
+            $key,
+            array_map(fn ($key) => $this->getSchema($key, $this->getChildSchema()), $key),
+        );
     }
 
     /**

--- a/core-bundle/src/Dca/Schema/SchemaInterface.php
+++ b/core-bundle/src/Dca/Schema/SchemaInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Dca\Schema;
+
+use Contao\CoreBundle\Dca\Data;
+
+interface SchemaInterface
+{
+    /**
+     * @return mixed|null
+     */
+    public function get(string $key);
+
+    public function getData(string|null $key = null): Data;
+
+    public function all(): array;
+
+    public function is(string $key, bool $default): bool;
+
+    public function getName(): string;
+}

--- a/core-bundle/src/Dca/Schema/SchemaManagerInterface.php
+++ b/core-bundle/src/Dca/Schema/SchemaManagerInterface.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Dca\Schema;
+
+use Contao\CoreBundle\Dca\Data;
+use Contao\CoreBundle\Dca\SchemaFactory;
+
+interface SchemaManagerInterface
+{
+    /**
+     * @template T of SchemaInterface
+     *
+     * @param class-string<T> $className
+     *
+     * @return T
+     */
+    public function getSchema(string $key, string $className, Data|null $data = null, bool $allowCustomClassName = true): SchemaInterface;
+
+    public function setSchema(string $key, SchemaInterface $schema): void;
+
+    public function setSchemaFactory(SchemaFactory $factory): void;
+
+    /**
+     * @param class-string $className
+     */
+    public function setSchemaClass(string $key, string $className): void;
+
+    /**
+     * @param array<string, class-string> $map
+     */
+    public function setSchemaClasses(array $map): void;
+
+    public function resetSchemas(): void;
+}

--- a/core-bundle/src/Dca/Schema/ServiceSubscriberSchemaInterface.php
+++ b/core-bundle/src/Dca/Schema/ServiceSubscriberSchemaInterface.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Dca\Schema;
+
+use Psr\Container\ContainerInterface;
+
+interface ServiceSubscriberSchemaInterface
+{
+    /**
+     * Set the service locator with all subscribed services.
+     */
+    public function setLocator(ContainerInterface $locator): void;
+
+    /**
+     * Returns an array of service types required by such instances, optionally keyed by the service names used internally.
+     *
+     *  * ['logger' => 'Psr\Log\LoggerInterface'] means the objects use the "logger" name
+     *    internally to fetch a service which must implement Psr\Log\LoggerInterface.
+     *  * ['loggers' => 'Psr\Log\LoggerInterface[]'] means the objects use the "loggers" name
+     *    internally to fetch an iterable of Psr\Log\LoggerInterface instances.
+     *  * ['Psr\Log\LoggerInterface'] is a shortcut for
+     *  * ['Psr\Log\LoggerInterface' => 'Psr\Log\LoggerInterface']
+     *
+     * @return array<string> The required service types, optionally keyed by service names
+     */
+    public static function getSubscribedServices(): array;
+}

--- a/core-bundle/src/Dca/Schema/Sorting.php
+++ b/core-bundle/src/Dca/Schema/Sorting.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Dca\Schema;
+
+/**
+ * Object representation of the sorting part of a data container array.
+ */
+class Sorting extends Schema
+{
+    /**
+     * @return Callback<mixed, string>
+     */
+    public function childRecordCallback(): Callback
+    {
+        return $this->getSchema('child_record_callback', Callback::class);
+    }
+}

--- a/core-bundle/src/Dca/Schema/Subpalettes.php
+++ b/core-bundle/src/Dca/Schema/Subpalettes.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Dca\Schema;
+
+use Contao\CoreBundle\Dca\Util\Palette;
+
+/**
+ * Object representation of the subpalettes part of a data container array.
+ */
+class Subpalettes extends Schema
+{
+    public function palette(string $key): Palette
+    {
+        return Palette::createFromString($key, $this->get($key));
+    }
+}

--- a/core-bundle/src/Dca/Schema/ValidatingSchemaInterface.php
+++ b/core-bundle/src/Dca/Schema/ValidatingSchemaInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Dca\Schema;
+
+interface ValidatingSchemaInterface
+{
+    /**
+     * Validate the schema data.
+     *
+     * @throws \Exception
+     */
+    public function validate(): void;
+}

--- a/core-bundle/src/Dca/SchemaFactory.php
+++ b/core-bundle/src/Dca/SchemaFactory.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Dca;
+
+use Contao\CoreBundle\Dca\Schema\ParentAwareSchemaInterface;
+use Contao\CoreBundle\Dca\Schema\SchemaInterface;
+use Contao\CoreBundle\Dca\Schema\SchemaManagerInterface;
+use Contao\CoreBundle\Dca\Schema\ServiceSubscriberSchemaInterface;
+use Contao\CoreBundle\Dca\Schema\ValidatingSchemaInterface;
+use Contao\CoreBundle\Event\Dca\SchemaCreatedEvent;
+use Contao\CoreBundle\Framework\ContaoFramework;
+use Contao\CoreBundle\Framework\FrameworkAwareInterface;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\Service\ServiceSubscriberInterface;
+
+class SchemaFactory implements ServiceSubscriberInterface
+{
+    private readonly Container $container;
+
+    private readonly ContaoFramework $framework;
+
+    private readonly EventDispatcherInterface|null $eventDispatcher;
+
+    private readonly ContainerInterface $serviceLocator;
+
+    private static array $dependencies = [];
+
+    /**
+     * @internal Do not inherit from this class; decorate the "contao.dca.schema_factory" service instead
+     */
+    public function __construct(ContainerInterface $serviceLocator)
+    {
+        $this->container = $serviceLocator->get('service_container');
+        $this->framework = $serviceLocator->get('contao.framework');
+        $this->eventDispatcher = $serviceLocator->get('event_dispatcher');
+
+        $this->serviceLocator = $serviceLocator;
+    }
+
+    /**
+     * @template T of SchemaInterface
+     *
+     * @param class-string<T> $className
+     *
+     * @return T
+     */
+    public function createSchema(string $name, string $className, Data $data, SchemaInterface|null $parent = null): SchemaInterface
+    {
+        if (!is_a($className, SchemaInterface::class, true)) {
+            throw new \InvalidArgumentException(sprintf('Class %s must implement SchemaInterface.', $className));
+        }
+
+        $schema = new $className($name, $data);
+
+        $this->addSchemaDependencies($schema, $parent, $className);
+
+        if ($this->eventDispatcher) {
+            /** @var T $schema */
+            $schema = $this->eventDispatcher->dispatch(new SchemaCreatedEvent($schema))->getSchema();
+        }
+
+        if ($schema instanceof ValidatingSchemaInterface) {
+            $schema->validate();
+        }
+
+        return $schema;
+    }
+
+    public static function getSubscribedServices(): array
+    {
+        return [
+            ...self::$dependencies,
+            'service_container' => ContainerInterface::class,
+            'contao.framework' => ContaoFramework::class,
+            'event_dispatcher' => EventDispatcherInterface::class,
+        ];
+    }
+
+    public static function addDependency(string $service): void
+    {
+        self::$dependencies[] = $service;
+    }
+
+    private function addSchemaDependencies(SchemaInterface $schema, SchemaInterface|null $parent, string $className): void
+    {
+        if ($schema instanceof ParentAwareSchemaInterface) {
+            $schema->setParent($parent);
+        }
+
+        if ($schema instanceof SchemaManagerInterface) {
+            $schema->setSchemaFactory($this);
+        }
+
+        if ($schema instanceof ContainerAwareInterface) {
+            $schema->setContainer($this->container);
+        }
+
+        if ($schema instanceof FrameworkAwareInterface) {
+            $schema->setFramework($this->framework);
+        }
+
+        if ($schema instanceof ServiceSubscriberSchemaInterface) {
+            $schema->setLocator($this->serviceLocator->get($className));
+        }
+    }
+}

--- a/core-bundle/src/Dca/Util/Palette.php
+++ b/core-bundle/src/Dca/Util/Palette.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Dca\Util;
+
+use Contao\StringUtil;
+
+/**
+ * Object representation of a DCA palette.
+ */
+class Palette
+{
+    public function __construct(
+        private readonly string $name,
+        private readonly array $boxes,
+    ) {
+    }
+
+    public static function createFromString(string $name, string $palette): self
+    {
+        $boxes = StringUtil::trimsplit(';', $palette);
+
+        return new self($name, $boxes);
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getBoxes(): array
+    {
+        return $this->boxes;
+    }
+}

--- a/core-bundle/src/Dca/Util/Path.php
+++ b/core-bundle/src/Dca/Util/Path.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Dca\Util;
+
+class Path implements \Stringable
+{
+    public function __construct(
+        private array $parts,
+        private readonly string $separator = '.',
+    ) {
+    }
+
+    public function __toString(): string
+    {
+        return implode($this->separator, $this->parts);
+    }
+
+    public function isEmpty(): bool
+    {
+        return [] === $this->parts;
+    }
+
+    public function shift(): string
+    {
+        return array_shift($this->parts);
+    }
+}

--- a/core-bundle/src/Dca/Validation/ConfigurationValidator.php
+++ b/core-bundle/src/Dca/Validation/ConfigurationValidator.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Dca\Validation;
+
+use Contao\CoreBundle\Dca\DcaConfiguration;
+use Contao\CoreBundle\Dca\Schema\ParentAwareSchemaInterface;
+use Contao\CoreBundle\Dca\Schema\SchemaInterface;
+use Contao\CoreBundle\Dca\Util\Path;
+use Symfony\Component\Config\Definition\ArrayNode;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+use Symfony\Component\Config\Definition\NodeInterface;
+use Symfony\Component\Config\Definition\Processor;
+use Symfony\Component\Config\Definition\PrototypedArrayNode;
+
+class ConfigurationValidator
+{
+    private readonly Processor $processor;
+
+    public function __construct()
+    {
+        $this->processor = new Processor();
+    }
+
+    /**
+     * Validate the data of a schema using its root resource configuration
+     * but only processing the subset at the schema's path in the configuration tree.
+     *
+     * @throws InvalidConfigurationException
+     */
+    public function validateSchemaData(SchemaInterface&ParentAwareSchemaInterface $schema, bool $allowFailingNodes = false): array
+    {
+        return $this->processor->process(
+            $this->getConfigurationTreeSubset(
+                (new DcaConfiguration($schema->getRoot()->getName()))
+                    ->allowFailingNodes($allowFailingNodes)
+                    ->getConfigTreeBuilder()
+                    ->buildTree(),
+                $schema->getPath(),
+            ),
+            [$schema->getData()->all()],
+        );
+    }
+
+    private function getConfigurationTreeSubset(NodeInterface $tree, Path $path): NodeInterface
+    {
+        if ($path->isEmpty()) {
+            return $tree;
+        }
+
+        if (!$tree instanceof ArrayNode) {
+            throw new \RuntimeException('Cannot get children of node '.$tree->getPath());
+        }
+
+        $step = $path->shift();
+
+        if ($tree instanceof PrototypedArrayNode) {
+            $prototype = $tree->getPrototype();
+            $prototype->setName($step);
+
+            return $this->getConfigurationTreeSubset($prototype, $path);
+        }
+
+        $subset = $tree->getChildren()[$step] ?? null;
+
+        if (null === $subset) {
+            throw new \RuntimeException('Cannot find node '.$tree->getPath().'.'.$step);
+        }
+
+        return $this->getConfigurationTreeSubset($subset, $path);
+    }
+}

--- a/core-bundle/src/DependencyInjection/Compiler/SchemaServiceProviderPass.php
+++ b/core-bundle/src/DependencyInjection/Compiler/SchemaServiceProviderPass.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\DependencyInjection\Compiler;
+
+use Contao\CoreBundle\Dca\Provider\SchemaProviderInterface;
+use Contao\CoreBundle\Dca\Schema\ServiceSubscriberSchemaInterface;
+use Contao\CoreBundle\Dca\SchemaFactory;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Compiler\ServiceLocatorTagPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\TypedReference;
+
+class SchemaServiceProviderPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        $schemaFactory = $container->getDefinition('contao.dca.schema_factory');
+        $providers = $container->findTaggedServiceIds('contao.dca.schema_dependency_provider');
+        $schemas = [];
+
+        foreach (array_keys($providers) as $id) {
+            $provider = $container->getDefinition($id)->getClass();
+
+            if (!$container->getReflectionClass($provider)->isSubclassOf(SchemaProviderInterface::class)) {
+                throw new \LogicException(sprintf('Service "%s" must implement interface "%s".', $provider, SchemaProviderInterface::class));
+            }
+
+            $schemas[] = $provider::getServiceSubscribingSchemas();
+        }
+
+        $schemas = array_merge([], ...$schemas);
+
+        foreach ($schemas as $class) {
+            $subscriberMap = [];
+
+            if (!$container->getReflectionClass($class)->isSubclassOf(ServiceSubscriberSchemaInterface::class)) {
+                throw new \LogicException(sprintf('Schema "%s" must implement interface "%s".', $class, ServiceSubscriberSchemaInterface::class));
+            }
+
+            foreach ($class::getSubscribedServices() as $key => $type) {
+                if (!\is_string($type) || !preg_match('/(?(DEFINE)(?<cn>[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*+))(?(DEFINE)(?<fqcn>(?&cn)(?:\\\\(?&cn))*+))^\??(?&fqcn)(?:(?:\|(?&fqcn))*+|(?:&(?&fqcn))*+)$/', $type)) {
+                    throw new InvalidArgumentException(sprintf('"%s::getSubscribedServices()" must return valid PHP types for service "%s", "%s" returned.', $class, $key, \is_string($type) ? $type : get_debug_type($type)));
+                }
+
+                if (\is_int($name = $key)) {
+                    $key = $type;
+                    $name = null;
+                }
+
+                $subscriberMap[$key] = new TypedReference((string) new Reference($type), $type, ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, $name);
+            }
+
+            $locatorRef = ServiceLocatorTagPass::register($container, $subscriberMap);
+
+            SchemaFactory::addDependency($class);
+
+            $schemaFactory->addTag('container.service_subscriber', [
+                'key' => $class,
+                'id' => (string) $locatorRef,
+            ]);
+        }
+    }
+}

--- a/core-bundle/src/DependencyInjection/Compiler/SchemaServiceProviderPass.php
+++ b/core-bundle/src/DependencyInjection/Compiler/SchemaServiceProviderPass.php
@@ -38,6 +38,7 @@ class SchemaServiceProviderPass implements CompilerPassInterface
                 throw new \LogicException(sprintf('Service "%s" must implement interface "%s".', $provider, SchemaProviderInterface::class));
             }
 
+            /** @var SchemaProviderInterface $provider */
             $schemas[] = $provider::getServiceSubscribingSchemas();
         }
 
@@ -50,9 +51,15 @@ class SchemaServiceProviderPass implements CompilerPassInterface
                 throw new \LogicException(sprintf('Schema "%s" must implement interface "%s".', $class, ServiceSubscriberSchemaInterface::class));
             }
 
-            foreach ($class::getSubscribedServices() as $key => $type) {
+            $services = $class::getSubscribedServices();
+
+            if (empty($services)) {
+                continue;
+            }
+
+            foreach ($services as $key => $type) {
                 if (!\is_string($type) || !preg_match('/(?(DEFINE)(?<cn>[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*+))(?(DEFINE)(?<fqcn>(?&cn)(?:\\\\(?&cn))*+))^\??(?&fqcn)(?:(?:\|(?&fqcn))*+|(?:&(?&fqcn))*+)$/', $type)) {
-                    throw new InvalidArgumentException(sprintf('"%s::getSubscribedServices()" must return valid PHP types for service "%s", "%s" returned.', $class, $key, \is_string($type) ? $type : get_debug_type($type)));
+                    throw new InvalidArgumentException(sprintf('"%s::getSubscribedServices()" must return valid PHP types for service "%s", "%s" returned.', $class, $key, get_debug_type($type)));
                 }
 
                 if (\is_int($name = $key)) {

--- a/core-bundle/src/DependencyInjection/Compiler/SchemaServiceProviderPass.php
+++ b/core-bundle/src/DependencyInjection/Compiler/SchemaServiceProviderPass.php
@@ -53,10 +53,6 @@ class SchemaServiceProviderPass implements CompilerPassInterface
 
             $services = $class::getSubscribedServices();
 
-            if (empty($services)) {
-                continue;
-            }
-
             foreach ($services as $key => $type) {
                 if (!\is_string($type) || !preg_match('/(?(DEFINE)(?<cn>[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*+))(?(DEFINE)(?<fqcn>(?&cn)(?:\\\\(?&cn))*+))^\??(?&fqcn)(?:(?:\|(?&fqcn))*+|(?:&(?&fqcn))*+)$/', $type)) {
                     throw new InvalidArgumentException(sprintf('"%s::getSubscribedServices()" must return valid PHP types for service "%s", "%s" returned.', $class, $key, get_debug_type($type)));

--- a/core-bundle/src/Event/Dca/ConfigurationSourceEvent.php
+++ b/core-bundle/src/Event/Dca/ConfigurationSourceEvent.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Event\Dca;
+
+use Contao\CoreBundle\Dca\Driver\DriverInterface;
+
+class ConfigurationSourceEvent
+{
+    public function __construct(
+        private readonly string $resource,
+        private array $configurations,
+        private readonly DriverInterface $driver,
+    ) {
+    }
+
+    public function appendConfiguration(array $configuration): void
+    {
+        $this->configurations[] = $configuration;
+    }
+
+    public function prependConfiguration(array $configuration): void
+    {
+        array_unshift($this->configurations, $configuration);
+    }
+
+    public function getConfigurations(): array
+    {
+        return $this->configurations;
+    }
+
+    public function getResource(): string
+    {
+        return $this->resource;
+    }
+
+    public function getDriver(): DriverInterface
+    {
+        return $this->driver;
+    }
+}

--- a/core-bundle/src/Event/Dca/SchemaCreatedEvent.php
+++ b/core-bundle/src/Event/Dca/SchemaCreatedEvent.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Event\Dca;
+
+use Contao\CoreBundle\Dca\Schema\SchemaInterface;
+use Symfony\Contracts\EventDispatcher\Event;
+
+class SchemaCreatedEvent extends Event
+{
+    public function __construct(private SchemaInterface $schema)
+    {
+    }
+
+    public function getSchema(): SchemaInterface
+    {
+        return $this->schema;
+    }
+
+    public function setSchema(SchemaInterface $schema): void
+    {
+        $this->schema = $schema;
+    }
+}

--- a/core-bundle/src/Event/Dca/SchemaCreatedEvent.php
+++ b/core-bundle/src/Event/Dca/SchemaCreatedEvent.php
@@ -17,8 +17,10 @@ use Symfony\Contracts\EventDispatcher\Event;
 
 class SchemaCreatedEvent extends Event
 {
-    public function __construct(private SchemaInterface $schema)
-    {
+    public function __construct(
+        private SchemaInterface $schema,
+        private readonly bool $triggerValidation = false,
+    ) {
     }
 
     public function getSchema(): SchemaInterface
@@ -29,5 +31,10 @@ class SchemaCreatedEvent extends Event
     public function setSchema(SchemaInterface $schema): void
     {
         $this->schema = $schema;
+    }
+
+    public function triggerValidation(): bool
+    {
+        return $this->triggerValidation;
     }
 }

--- a/core-bundle/src/Event/Dca/SchemaCreatingEvent.php
+++ b/core-bundle/src/Event/Dca/SchemaCreatingEvent.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Event\Dca;
+
+use Contao\CoreBundle\Dca\Data;
+use Contao\CoreBundle\Dca\Schema\SchemaInterface;
+use Symfony\Contracts\EventDispatcher\Event;
+
+class SchemaCreatingEvent extends Event
+{
+    public function __construct(
+        private readonly Data $data,
+        /**
+         * @var class-string<SchemaInterface>
+         */
+        private readonly string $schema,
+        private readonly string $name,
+        private readonly SchemaInterface|null $parent,
+    ) {
+    }
+
+    public function getData(): Data
+    {
+        return $this->data;
+    }
+
+    /**
+     * @return class-string<SchemaInterface>
+     */
+    public function getSchema(): string
+    {
+        return $this->schema;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getParent(): SchemaInterface|null
+    {
+        return $this->parent;
+    }
+}

--- a/core-bundle/src/EventListener/DataContainer/DefaultOperationsListener.php
+++ b/core-bundle/src/EventListener/DataContainer/DefaultOperationsListener.php
@@ -90,7 +90,7 @@ class DefaultOperationsListener
                 'edit' => [
                     'href' => 'act=edit',
                     'icon' => 'edit.svg',
-                    'button_callback' => $this->isGrantedCallback(UpdateAction::class, $table),
+                    'permission_callback' => $this->isGrantedCallback(UpdateAction::class, $table),
                 ],
             ];
         }
@@ -110,7 +110,7 @@ class DefaultOperationsListener
                     'href' => 'act=paste&amp;mode=copy',
                     'icon' => 'copy.svg',
                     'attributes' => 'onclick="Backend.getScrollOffset()"',
-                    'button_callback' => $this->isGrantedCallback(CreateAction::class, $table),
+                    'permission_callback' => $this->isGrantedCallback(CreateAction::class, $table),
                 ];
 
                 if ($isTreeMode) {
@@ -118,7 +118,7 @@ class DefaultOperationsListener
                         'href' => 'act=paste&amp;mode=copy&amp;childs=1',
                         'icon' => 'copychilds.svg',
                         'attributes' => 'onclick="Backend.getScrollOffset()"',
-                        'button_callback' => $this->copyChildsCallback($table),
+                        'permission_callback' => $this->copyChildsCallback($table),
                     ];
                 }
             }
@@ -128,14 +128,14 @@ class DefaultOperationsListener
                     'href' => 'act=paste&amp;mode=cut',
                     'icon' => 'cut.svg',
                     'attributes' => 'onclick="Backend.getScrollOffset()"',
-                    'button_callback' => $this->isGrantedCallback(UpdateAction::class, $table),
+                    'permission_callback' => $this->isGrantedCallback(UpdateAction::class, $table),
                 ];
             }
         } elseif ($canCopy) {
             $operations['copy'] = [
                 'href' => 'act=copy',
                 'icon' => 'copy.svg',
-                'button_callback' => $this->isGrantedCallback(CreateAction::class, $table),
+                'permission_callback' => $this->isGrantedCallback(CreateAction::class, $table),
             ];
         }
 
@@ -144,7 +144,7 @@ class DefaultOperationsListener
                 'href' => 'act=delete',
                 'icon' => 'delete.svg',
                 'attributes' => 'onclick="if(!confirm(\''.($GLOBALS['TL_LANG']['MSC']['deleteConfirm'] ?? null).'\'))return false;Backend.getScrollOffset()"',
-                'button_callback' => $this->isGrantedCallback(DeleteAction::class, $table),
+                'permission_callback' => $this->isGrantedCallback(DeleteAction::class, $table),
             ];
         }
 
@@ -152,7 +152,7 @@ class DefaultOperationsListener
             $operations['toggle'] = [
                 'href' => 'act=toggle&amp;field='.$toggleField,
                 'icon' => 'visible.svg',
-                'button_callback' => $this->isGrantedCallback(UpdateAction::class, $table),
+                'permission_callback' => $this->isGrantedCallback(UpdateAction::class, $table),
             ];
         }
 
@@ -166,11 +166,7 @@ class DefaultOperationsListener
 
     private function isGrantedCallback(string $actionClass, string $table): \Closure
     {
-        return function (DataContainerOperation $operation) use ($actionClass, $table): void {
-            if (!$this->isGranted($actionClass, $table, $operation)) {
-                $this->disableOperation($operation);
-            }
-        };
+        return fn (DataContainerOperation $operation) => $this->isGranted($actionClass, $table, $operation);
     }
 
     private function copyChildsCallback(string $table): \Closure

--- a/core-bundle/src/EventListener/DataContainer/Schema/DcFileExcludeListener.php
+++ b/core-bundle/src/EventListener/DataContainer/Schema/DcFileExcludeListener.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\EventListener\DataContainer\Schema;
+
+use Contao\CoreBundle\Dca\Schema\Field;
+use Contao\CoreBundle\Dca\Schema\Schema;
+use Contao\CoreBundle\Event\Dca\SchemaCreatingEvent;
+use Contao\DC_File;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+
+/**
+ * @internal
+ *
+ * Assure fields in a DCA based on \Contao\DC_File are never excluded
+ * since this driver does not support excluded fields
+ */
+#[AsEventListener(priority: 250)]
+class DcFileExcludeListener
+{
+    public function __invoke(SchemaCreatingEvent $event): void
+    {
+        $data = $event->getData();
+
+        if (Field::class !== $event->getSchema() || false === $data->get('exclude')) {
+            return;
+        }
+
+        $parent = $event->getParent();
+
+        if ($parent instanceof Schema && DC_File::class === $parent->getDca()->config()->driverClassName()) {
+            $data->set('exclude', false);
+        }
+    }
+}

--- a/core-bundle/src/EventListener/DataContainer/Schema/InputTypeExcludeListener.php
+++ b/core-bundle/src/EventListener/DataContainer/Schema/InputTypeExcludeListener.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\EventListener\DataContainer\Schema;
+
+use Contao\CoreBundle\Dca\Schema\Field;
+use Contao\CoreBundle\Event\Dca\SchemaCreatingEvent;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+
+/**
+ * @internal
+ *
+ * Assure fields with an input type or an input field callback
+ * are excluded by default
+ */
+#[AsEventListener]
+class InputTypeExcludeListener
+{
+    public function __invoke(SchemaCreatingEvent $event): void
+    {
+        $data = $event->getData();
+
+        if (!is_a($event->getSchema(), Field::class, true) || null !== $data->get('exclude')) {
+            return;
+        }
+
+        if ($data->get('inputType') || $data->get('input_field_callback')) {
+            $data->set('exclude', true);
+        }
+    }
+}

--- a/core-bundle/src/EventListener/DataContainer/Schema/SchemaDataValidationListener.php
+++ b/core-bundle/src/EventListener/DataContainer/Schema/SchemaDataValidationListener.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\EventListener\DataContainer\Schema;
+
+use Contao\CoreBundle\Dca\Schema\Schema;
+use Contao\CoreBundle\Dca\Validation\ConfigurationValidator;
+use Contao\CoreBundle\Event\Dca\SchemaCreatedEvent;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+
+/**
+ * @internal
+ *
+ * Validate the data of a created schema against its resource configuration
+ */
+#[AsEventListener]
+class SchemaDataValidationListener
+{
+    public function __construct(private readonly ConfigurationValidator $validator)
+    {
+    }
+
+    public function __invoke(SchemaCreatedEvent $event): void
+    {
+        if (!$event->triggerValidation()) {
+            return;
+        }
+
+        $schema = $event->getSchema();
+
+        if (!$schema instanceof Schema) {
+            return;
+        }
+
+        $this->validator->validateSchemaData($schema, true);
+    }
+}

--- a/core-bundle/src/EventListener/DataContainer/Schema/ToggleOperationListener.php
+++ b/core-bundle/src/EventListener/DataContainer/Schema/ToggleOperationListener.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\EventListener\DataContainer\Schema;
+
+use Contao\CoreBundle\Dca\Schema\Dca;
+use Contao\CoreBundle\Dca\Schema\Operation;
+use Contao\CoreBundle\Event\Dca\SchemaCreatedEvent;
+use Contao\CoreBundle\Security\ContaoCorePermissions;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+
+/**
+ * @internal
+ */
+#[AsEventListener]
+class ToggleOperationListener
+{
+    public function __construct(
+        private readonly Security $security,
+    ) {
+    }
+
+    public function __invoke(SchemaCreatedEvent $event): void
+    {
+        $schema = $event->getSchema();
+
+        if (!$schema instanceof Operation || $schema->isHidden() || !$schema->isToggle()) {
+            return;
+        }
+
+        $field = $schema->getParam('field');
+
+        /** @var Dca $dca */
+        $dca = $schema->getRoot();
+        $field = $dca->fields()->field($field);
+
+        // Hide the toggle icon if the target field is not toggleable
+        // or if the user does not have access to the target field
+        if (
+            (!$field->isToggle() && !$field->isReverseToggle())
+            || ($field->isExcluded() && !$this->security->isGranted(ContaoCorePermissions::USER_CAN_EDIT_FIELD_OF_TABLE, $dca->getName().'::'.$field->getName()))
+        ) {
+            $event->setSchema(
+                $schema->copyWith(
+                    $schema->getData()->set('hidden', true),
+                ),
+            );
+        }
+    }
+}

--- a/core-bundle/tests/Contao/ArrayUtilTest.php
+++ b/core-bundle/tests/Contao/ArrayUtilTest.php
@@ -143,9 +143,6 @@ class ArrayUtilTest extends TestCase
     }
 
     /**
-     * @param mixed        $expected
-     * @param string|array $path
-     *
      * @dataProvider getDataProvider
      */
     public function testGetsDataViaDotNotation(array $data, array|string $path, mixed $expected): void
@@ -205,10 +202,6 @@ class ArrayUtilTest extends TestCase
     }
 
     /**
-     * @param string|array $path
-     * @param mixed        $value
-     * @param mixed        $expected
-     *
      * @dataProvider setDataProvider
      */
     public function testSetsDataViaDotNotation(array $source, array|string $path, mixed $value, mixed $expected, bool $overwrite = true): void

--- a/core-bundle/tests/Contao/ArrayUtilTest.php
+++ b/core-bundle/tests/Contao/ArrayUtilTest.php
@@ -143,7 +143,7 @@ class ArrayUtilTest extends TestCase
     }
 
     /**
-     * @param mixed $expected
+     * @param mixed        $expected
      * @param string|array $path
      *
      * @dataProvider getDataProvider
@@ -206,8 +206,8 @@ class ArrayUtilTest extends TestCase
 
     /**
      * @param string|array $path
-     * @param mixed $value
-     * @param mixed $expected
+     * @param mixed        $value
+     * @param mixed        $expected
      *
      * @dataProvider setDataProvider
      */

--- a/core-bundle/tests/Contao/ArrayUtilTest.php
+++ b/core-bundle/tests/Contao/ArrayUtilTest.php
@@ -143,6 +143,9 @@ class ArrayUtilTest extends TestCase
     }
 
     /**
+     * @param mixed $expected
+     * @param string|array $path
+     *
      * @dataProvider getDataProvider
      */
     public function testGetsDataViaDotNotation(array $data, array|string $path, mixed $expected): void
@@ -202,6 +205,10 @@ class ArrayUtilTest extends TestCase
     }
 
     /**
+     * @param string|array $path
+     * @param mixed $value
+     * @param mixed $expected
+     *
      * @dataProvider setDataProvider
      */
     public function testSetsDataViaDotNotation(array $source, array|string $path, mixed $value, mixed $expected, bool $overwrite = true): void

--- a/core-bundle/tests/ContaoCoreBundleTest.php
+++ b/core-bundle/tests/ContaoCoreBundleTest.php
@@ -30,6 +30,7 @@ use Contao\CoreBundle\DependencyInjection\Compiler\RegisterFragmentsPass;
 use Contao\CoreBundle\DependencyInjection\Compiler\RegisterHookListenersPass;
 use Contao\CoreBundle\DependencyInjection\Compiler\RegisterPagesPass;
 use Contao\CoreBundle\DependencyInjection\Compiler\RewireTwigPathsPass;
+use Contao\CoreBundle\DependencyInjection\Compiler\SchemaServiceProviderPass;
 use Contao\CoreBundle\DependencyInjection\Compiler\SearchIndexerPass;
 use Contao\CoreBundle\DependencyInjection\Compiler\TaggedMigrationsPass;
 use Contao\CoreBundle\DependencyInjection\Compiler\TranslationDataCollectorPass;
@@ -76,6 +77,7 @@ class ContaoCoreBundleTest extends TestCase
             LoggerChannelPass::class,
             ConfigureFilesystemPass::class,
             AddInsertTagsPass::class,
+            SchemaServiceProviderPass::class,
         ];
 
         $security = $this->createMock(SecurityExtension::class);

--- a/core-bundle/tests/Dca/DataTest.php
+++ b/core-bundle/tests/Dca/DataTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Dca;
+
+use Contao\CoreBundle\Dca\Data;
+use Contao\CoreBundle\Dca\Observer\DataObserverInterface;
+use PHPUnit\Framework\TestCase;
+
+class DataTest extends TestCase
+{
+    public function testGetsDataViaDotNotation(): void
+    {
+        $source = [
+            'foo' => [
+                'bar' => 'baz',
+            ],
+        ];
+
+        $data = new Data($source);
+
+        $this->assertSame('baz', $data->get('foo.bar'));
+        $this->assertNull($data->get('baz'));
+    }
+
+    public function testReturnsItsSourceArray(): void
+    {
+        $source = ['foo' => 'bar'];
+        $data = new Data($source);
+
+        $this->assertSame($source, $data->all());
+    }
+
+    public function testReturnsDataSubset(): void
+    {
+        $parent = new Data(['baz' => ['foo']]);
+        $subset = $parent->getData('baz');
+
+        $this->assertSame(['foo'], $subset->all());
+    }
+
+    public function testAllowsFallbackForUndefinedDataSubset(): void
+    {
+        $parent = new Data([]);
+        $subset = $parent->getData('foo', ['foo' => 'bar']);
+
+        $this->assertSame(['foo' => 'bar'], $subset->all());
+    }
+
+    public function testThrowsExceptionForInvalidSubset(): void
+    {
+        $parent = new Data(['baz' => ['foo']]);
+
+        $this->expectException(\LogicException::class);
+
+        $parent->getData('bar');
+    }
+
+    public function testIsAwareOfItsPath(): void
+    {
+        $this->assertSame('', (new Data([], ''))->getPath());
+        $this->assertSame('foo.bar', (new Data([], 'foo.bar'))->getPath());
+    }
+
+    public function testPassesSubpathToDataSubset(): void
+    {
+        $parent = new Data(['baz' => ['foo']], 'foo.bar');
+        $subset = $parent->getData('baz');
+
+        $this->assertSame('foo.bar.baz', $subset->getPath());
+    }
+
+    public function testIsAwareOfItsRootData(): void
+    {
+        $root = new Data();
+        $subset = new Data();
+
+        $subset->setRoot($root);
+
+        $this->assertSame($root, $root->getRoot());
+        $this->assertSame($root, $subset->getRoot());
+    }
+
+    public function testPassesRootToDataSubset(): void
+    {
+        $root = new Data();
+        $parent = new Data(['baz' => []]);
+        $parent->setRoot($root);
+
+        $subset = $parent->getData('baz');
+
+        $this->assertSame($root, $subset->getRoot());
+    }
+
+    public function testReturnsDataSubsetWithObservers(): void
+    {
+        $data = new Data(['foo' => ['bar' => 'baz']]);
+        $observerA = $this->createMock(DataObserverInterface::class);
+        $observerB = $this->createMock(DataObserverInterface::class);
+
+        $data->attachReadObserver($observerA);
+        $data->attachReadObserver($observerB);
+
+        $part = $data->getData('foo');
+
+        $observerA
+            ->expects($this->once())
+            ->method('update')
+            ->with($part)
+        ;
+
+        $observerB
+            ->expects($this->once())
+            ->method('update')
+            ->with($part)
+        ;
+
+        $part->get('bar');
+    }
+
+    // TODO: Add tests for writeObservers.
+    // TODO: Add tests for attaching observers.
+}

--- a/core-bundle/tests/Dca/DcaConfigurationTest.php
+++ b/core-bundle/tests/Dca/DcaConfigurationTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Dca;
+
+use Contao\CoreBundle\Dca\DcaConfiguration;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+class DcaConfigurationTest extends TestCase
+{
+    public function testImplementsConfigurationInterface(): void
+    {
+        $configuration = new DcaConfiguration('tl_foo');
+
+        $this->assertInstanceOf(ConfigurationInterface::class, $configuration);
+    }
+}

--- a/core-bundle/tests/Dca/DcaFactoryTest.php
+++ b/core-bundle/tests/Dca/DcaFactoryTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Dca;
+
+use Contao\CoreBundle\Dca\Data;
+use Contao\CoreBundle\Dca\DcaFactory;
+use Contao\CoreBundle\Dca\Driver\DriverCollection;
+use Contao\CoreBundle\Dca\Driver\DriverInterface;
+use Contao\CoreBundle\Dca\Provider\ConfigurationProviderInterface;
+use Contao\CoreBundle\Dca\Schema\Dca;
+use Contao\CoreBundle\Dca\SchemaFactory;
+use Contao\CoreBundle\Tests\TestCase;
+
+class DcaFactoryTest extends TestCase
+{
+    public function testCreatesDcaObjectViaSchemaFactory(): void
+    {
+        $data = ['config' => []];
+
+        $schemaFactory = $this->createMock(SchemaFactory::class);
+        $driverCollection = $this->createMock(DriverCollection::class);
+        $configuration = $this->createMock(ConfigurationProviderInterface::class);
+        $driver = $this->createMock(DriverInterface::class);
+        $dca = $this->createMock(Dca::class);
+
+        $configuration
+            ->expects($this->once())
+            ->method('getConfiguration')
+            ->with('tl_foo', $driver)
+            ->willReturn($data)
+        ;
+
+        $driverCollection
+            ->expects($this->once())
+            ->method('getDriverForResource')
+            ->with('tl_foo')
+            ->willReturn($driver)
+        ;
+
+        $schemaFactory
+            ->expects($this->once())
+            ->method('createSchema')
+            ->with('tl_foo', Dca::class, new Data($data))
+            ->willReturn($dca)
+        ;
+
+        $factory = new DcaFactory($schemaFactory, $driverCollection, $configuration);
+
+        $result = $factory->get('tl_foo');
+
+        $this->assertSame($dca, $result);
+    }
+
+    public function testReturnsSingletonForEachResource(): void
+    {
+        $dataFoo = ['config' => []];
+        $dataBar = ['config' => ['foo' => 'bar']];
+
+        $schemaFactory = $this->createMock(SchemaFactory::class);
+        $driverCollection = $this->createMock(DriverCollection::class);
+        $configuration = $this->createMock(ConfigurationProviderInterface::class);
+        $driver = $this->createMock(DriverInterface::class);
+        $dcaFoo = $this->createMock(Dca::class);
+        $dcaBar = $this->createMock(Dca::class);
+
+        $configuration
+            ->expects($this->exactly(2))
+            ->method('getConfiguration')
+            ->withConsecutive(
+                ['tl_foo', $driver],
+                ['tl_bar', $driver],
+            )
+            ->willReturnOnConsecutiveCalls($dataFoo, $dataBar)
+        ;
+
+        $driverCollection
+            ->expects($this->exactly(2))
+            ->method('getDriverForResource')
+            ->withConsecutive(['tl_foo'], ['tl_bar'])
+            ->willReturn($driver)
+        ;
+
+        $schemaFactory
+            ->expects($this->exactly(2))
+            ->method('createSchema')
+            ->withConsecutive(
+                ['tl_foo', Dca::class, new Data($dataFoo)],
+                ['tl_bar', Dca::class, new Data($dataBar)],
+            )
+            ->willReturnOnConsecutiveCalls($dcaFoo, $dcaBar)
+        ;
+
+        $factory = new DcaFactory($schemaFactory, $driverCollection, $configuration);
+
+        $resultA = $factory->get('tl_foo');
+        $resultB = $factory->get('tl_foo');
+        $resultC = $factory->get('tl_bar');
+
+        $this->assertSame($dcaFoo, $resultA);
+        $this->assertSame($resultA, $resultB);
+        $this->assertSame($dcaBar, $resultC);
+    }
+}

--- a/core-bundle/tests/Dca/DcaMockBuilderTest.php
+++ b/core-bundle/tests/Dca/DcaMockBuilderTest.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Dca;
+
+use Contao\CoreBundle\Dca\Schema\CallbackCollection;
+use Contao\CoreBundle\Dca\Schema\Config;
+use Contao\CoreBundle\Dca\Schema\OperationsCollection;
+use Contao\CoreBundle\Dca\Schema\Palettes;
+use Contao\CoreBundle\Dca\Schema\Sorting;
+use Contao\CoreBundle\Tests\TestCase;
+
+class DcaMockBuilderTest extends TestCase
+{
+    public function testMocksDcaData(): void
+    {
+        $factory = $this->getDcaMockBuilder()
+            ->addDcaData('tl_foo', [
+                'config.closed' => true,
+            ])
+            ->addDcaData('tl_bar', [
+                'config' => [
+                    'closed' => true,
+                ],
+                'list.operations' => [
+                    'edit' => [],
+                ],
+            ])
+            ->getMock()
+        ;
+
+        $dcaFoo = $factory->get('tl_foo');
+        $dcaBar = $factory->get('tl_bar');
+
+        $this->assertTrue($dcaFoo->get('config.closed'));
+        $this->assertTrue($dcaFoo->config()->isClosed());
+
+        $this->assertTrue($dcaBar->get('config.closed'));
+        $this->assertSame([], $dcaBar->get('list.operations.edit'));
+    }
+
+    public function testAddsSpiesToDcaNodes(): void
+    {
+        $factory = $this->getDcaMockBuilder()
+            ->addDcaData('tl_foo', [
+                'config.closed' => true,
+                'list.sorting.child_record_callback' => [static function (): void {}],
+            ])
+            ->addSpies('tl_foo', [
+                // Add a spy on config()->callback('onload')->call
+                'config.callback[onload].call' => $this->atLeast(2),
+                'list.sorting.childRecordCallback' => $this->exactly(1),
+
+                // Notes:
+                // It's not possible to spy on a child node of another spied node
+                // So spying on 'config.usesVersioning' in addition to 'config.callback[onload].call' is not possible.
+                // However, multiple spies on the same node or on multiple child nodes are supported.
+            ])
+            ->getMock()
+        ;
+
+        $dca = $factory->get('tl_foo');
+
+        $dca->list()->sorting()->childRecordCallback();
+        $dca->config()->callback('onload')->call();
+        $dca->config()->callback('onload')->call();
+    }
+
+    public function testAddsMocksToDcaNodes(): void
+    {
+        $onloadCallbacksMock = $this->createMock(CallbackCollection::class);
+        $oncutCallbacksMock = $this->createMock(CallbackCollection::class);
+        $operationsMock = $this->createMock(OperationsCollection::class);
+        $sortingMock = $this->createMock(Sorting::class);
+        $palettesMock = $this->createMock(Palettes::class);
+
+        $factory = $this->getDcaMockBuilder()
+            ->addDcaData('tl_foo', [
+                'config' => [
+                    'bar' => 'baz',
+                ],
+                'list' => [
+                    'foo' => 'bar',
+                ],
+            ])
+            ->addMocks('tl_foo', [
+                // Use [] syntax to set arguments for the method call
+                // Caveat: There are no more proxied calls to the original method if the method is mocked with any parameter!
+                'config.callback[onload]' => $onloadCallbacksMock,
+                'config.callback[oncut]' => $oncutCallbacksMock,
+                'list.operations' => $operationsMock,
+                'list.sorting' => $sortingMock,
+                'palettes' => $palettesMock,
+
+                // Notes:
+                // It's not possible to mock both a parent and a child node.
+                // So mocking 'list' in addition to 'list.sorting' is not possible.
+                // In this case, the 'list' mock would have to return the correct mock.
+            ])
+            ->getMock()
+        ;
+
+        $dca = $factory->get('tl_foo');
+
+        $this->assertSame($onloadCallbacksMock, $dca->config()->callback('onload'), 'DCA did not return the correct mock object.');
+        $this->assertSame($oncutCallbacksMock, $dca->config()->callback('oncut'), 'DCA did not return the correct mock object.');
+        $this->assertSame($operationsMock, $dca->list()->operations(), 'DCA did not return the correct mock object.');
+        $this->assertSame($sortingMock, $dca->list()->sorting(), 'DCA did not return the correct mock object.');
+        $this->assertSame($palettesMock, $dca->palettes(), 'DCA did not return the correct mock object.');
+
+        $this->assertSame('baz', $dca->config()->get('bar'), 'Shadow mock did not return the original value.');
+        $this->assertSame('bar', $dca->list()->get('foo'), 'Shadow mock did not return the original value.');
+    }
+
+    public function testThrowsExceptionForCollidingSpiesAndMocks(): void
+    {
+        $configMock = $this->createMock(Config::class);
+        $configMock
+            ->expects($this->never())
+            ->method('isClosed')
+        ;
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('config.isClosed');
+
+        $this->getDcaMockBuilder()
+            ->addDcaData('tl_foo', [
+                'config.closed' => true,
+            ])
+            ->addSpies('tl_foo', [
+                'config.isClosed' => $this->exactly(1),
+            ])
+            ->addMocks('tl_foo', [
+                'config' => $configMock,
+            ])
+            ->getMock()
+        ;
+    }
+}

--- a/core-bundle/tests/Dca/Definition/Builder/FieldDefinitionTest.php
+++ b/core-bundle/tests/Dca/Definition/Builder/FieldDefinitionTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Dca\Definition\Builder;
+
+use Contao\CoreBundle\Dca\Definition\Builder\DcaNodeBuilder;
+use Contao\CoreBundle\Dca\Definition\Builder\FieldDefinition;
+use Contao\CoreBundle\Dca\Definition\Builder\PreconfiguredDefinitionInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\Definition\ArrayNode;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+
+class FieldDefinitionTest extends TestCase
+{
+    public function testIsPreconfigured(): void
+    {
+        $this->assertInstanceOf(PreconfiguredDefinitionInterface::class, new FieldDefinition(null));
+    }
+
+    public function testReturnsArrayNode(): void
+    {
+        $definition = new FieldDefinition(null);
+        $definition->setBuilder(new DcaNodeBuilder());
+        $definition->preconfigure();
+
+        $node = $definition->getNode();
+
+        $this->assertInstanceOf(ArrayNode::class, $node);
+    }
+
+    /**
+     * @dataProvider sqlDataProvider
+     */
+    public function testAcceptsStringAndArraySql(mixed $sql, bool $valid): void
+    {
+        $definition = new FieldDefinition(null);
+        $definition->setBuilder(new DcaNodeBuilder());
+        $definition->preconfigure();
+
+        $node = $definition->getNode();
+
+        if (!$valid) {
+            $this->expectException(InvalidConfigurationException::class);
+        }
+
+        $node->finalize([
+            'sql' => $sql,
+        ]);
+
+        $this->assertTrue(true);
+    }
+
+    public function sqlDataProvider(): array
+    {
+        return [
+            ['foo', true],
+            [['name' => 'foo', 'type' => 'string', 'length' => 64], true],
+            [123, false],
+            [new \stdClass(), false],
+        ];
+    }
+}

--- a/core-bundle/tests/Dca/Driver/DriverCollectionTest.php
+++ b/core-bundle/tests/Dca/Driver/DriverCollectionTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Dca\Driver;
+
+use Contao\CoreBundle\Dca\Driver\DriverCollection;
+use Contao\CoreBundle\Dca\Driver\DriverInterface;
+use PHPUnit\Framework\TestCase;
+
+class DriverCollectionTest extends TestCase
+{
+    public function testFindsDriverForResource(): void
+    {
+        $driverA = $this->createMock(DriverInterface::class);
+        $driverA
+            ->method('handles')
+            ->willReturnCallback(static fn (string $resource): bool => 'tl_foo' === $resource)
+        ;
+
+        $driverB = $this->createMock(DriverInterface::class);
+        $driverB
+            ->method('handles')
+            ->willReturnCallback(static fn (string $resource): bool => 'tl_bar' === $resource)
+        ;
+
+        $collection = new DriverCollection([
+            $driverA,
+            $driverB,
+        ]);
+
+        $this->assertSame($driverA, $collection->getDriverForResource('tl_foo'));
+        $this->assertSame($driverB, $collection->getDriverForResource('tl_bar'));
+    }
+
+    public function testThrowsExceptionForMissingDriver(): void
+    {
+        $collection = new DriverCollection([]);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('tl_bar');
+
+        $collection->getDriverForResource('tl_bar');
+    }
+
+    public function testChecksIfDriverExistsForResource(): void
+    {
+        $driverA = $this->createMock(DriverInterface::class);
+        $driverA
+            ->method('handles')
+            ->willReturnCallback(static fn (string $resource): bool => 'tl_foo' === $resource)
+        ;
+
+        $driverB = $this->createMock(DriverInterface::class);
+        $driverB
+            ->method('handles')
+            ->willReturnCallback(static fn (string $resource): bool => 'tl_bar' === $resource)
+        ;
+
+        $collection = new DriverCollection([
+            $driverA,
+            $driverB,
+        ]);
+
+        $this->assertTrue($collection->hasDriverForResource('tl_foo'));
+        $this->assertTrue($collection->hasDriverForResource('tl_bar'));
+        $this->assertFalse($collection->hasDriverForResource('tl_baz'));
+    }
+}

--- a/core-bundle/tests/Dca/Driver/GlobalArrayDriverTest.php
+++ b/core-bundle/tests/Dca/Driver/GlobalArrayDriverTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Dca\Driver;
+
+use Contao\Controller;
+use Contao\CoreBundle\Dca\Driver\GlobalArrayDriver;
+use Contao\CoreBundle\Dca\Driver\MutableDataDriverInterface;
+use Contao\CoreBundle\Dca\Observer\DriverDataChangeDataCallbackObserver;
+use Contao\CoreBundle\Tests\TestCase;
+use PHPUnit\Framework\MockObject\Rule\InvocationOrder;
+
+class GlobalArrayDriverTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        unset($GLOBALS['TL_DCA']);
+    }
+
+    public function testLoadsTheDataContainerAndReadsItsData(): void
+    {
+        $source = [
+            'foo' => 'bar',
+            'baz' => [],
+        ];
+
+        $driver = $this->createDriverWithData('tl_bar', $source);
+
+        $data = $driver->read('tl_bar');
+
+        $this->assertSame($source, $data);
+    }
+
+    public function testHandlesAllResourcesWithDataContainerData(): void
+    {
+        $GLOBALS['TL_DCA']['tl_foo'] = ['foo' => 'bar'];
+        $GLOBALS['TL_DCA']['tl_bar'] = [];
+        $GLOBALS['TL_DCA']['tl_baz'] = new \stdClass();
+        $GLOBALS['TL_DCA']['tl_bat'] = null;
+
+        $controllerAdapter = $this->mockAdapter(['loadDataContainer']);
+        $controllerAdapter
+            ->expects($this->exactly(5))
+            ->method('loadDataContainer')
+            ->withConsecutive(['tl_foo'], ['tl_bar'], ['tl_baz'], ['tl_bat'], ['tl_qux'])
+        ;
+
+        $framework = $this->mockContaoFramework([
+            Controller::class => $controllerAdapter,
+        ]);
+
+        $driver = new GlobalArrayDriver($framework);
+
+        $this->assertTrue($driver->handles('tl_foo'));
+        $this->assertTrue($driver->handles('tl_bar'), 'Driver should handle an empty array.');
+        $this->assertFalse($driver->handles('tl_baz'), 'Driver should not handle a non-array value.');
+        $this->assertFalse($driver->handles('tl_bat'), 'Driver should not handle a null value.');
+        $this->assertFalse($driver->handles('tl_qux'), 'Driver should not handle an undefined data container.');
+    }
+
+    public function testDetectsChangesInGlobalArray(): void
+    {
+        $source = [
+            'foo' => 'bar',
+            'baz' => [],
+        ];
+
+        $driver = $this->createDriverWithData('tl_foo', $source, $this->any());
+
+        $this->assertFalse($driver->hasChanged('tl_foo'), 'The data should not be flagged as changed before the first read.');
+
+        $driver->read('tl_foo');
+
+        $this->assertFalse($driver->hasChanged('tl_foo'), 'The data should not be flagged as changed after a read.');
+
+        $GLOBALS['TL_DCA']['tl_foo']['foo'] = 'foo';
+
+        $this->assertTrue($driver->hasChanged('tl_foo'));
+
+        $GLOBALS['TL_DCA']['tl_bar']['foo'] = 'foo';
+
+        $this->assertFalse($driver->hasChanged('tl_foo'), 'Resource should not be affected by data change of another resource.');
+    }
+
+    public function testIsMutableDataDriver(): void
+    {
+        $this->assertInstanceOf(MutableDataDriverInterface::class, new GlobalArrayDriver($this->mockContaoFramework()));
+    }
+
+    public function testReturnsDriverDataChangeDataCallbackObserver(): void
+    {
+        $driver = new GlobalArrayDriver($this->mockContaoFramework());
+
+        $this->assertInstanceOf(DriverDataChangeDataCallbackObserver::class, $driver->getMutableDataObserver('tl_foo'));
+    }
+
+    private function createDriverWithData(string $resource, array $data, InvocationOrder|null $loadCalls = null): GlobalArrayDriver
+    {
+        $GLOBALS['TL_DCA'][$resource] = $data;
+
+        $controllerAdapter = $this->mockAdapter(['loadDataContainer']);
+        $controllerAdapter
+            ->expects($loadCalls ?? $this->once())
+            ->method('loadDataContainer')
+            ->with($resource)
+        ;
+
+        $framework = $this->mockContaoFramework([
+            Controller::class => $controllerAdapter,
+        ]);
+
+        return new GlobalArrayDriver($framework);
+    }
+}

--- a/core-bundle/tests/Dca/Schema/ConfigTest.php
+++ b/core-bundle/tests/Dca/Schema/ConfigTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\Dca\Schema;
+
+use Contao\CoreBundle\Dca\Data;
+use Contao\CoreBundle\Dca\Schema\Config;
+use PHPUnit\Framework\TestCase;
+
+class ConfigTest extends TestCase
+{
+    public function testIsEditable(): void
+    {
+        $this->assertFalse((new Config('config', new Data(['notEditable' => true])))->isEditable());
+        $this->assertTrue((new Config('config', new Data(['notEditable' => false])))->isEditable());
+        $this->assertTrue((new Config('config', new Data()))->isEditable());
+    }
+
+    public function testIsClosed(): void
+    {
+        $this->assertTrue((new Config('config', new Data(['closed' => true])))->isClosed());
+        $this->assertFalse((new Config('config', new Data(['closed' => false])))->isClosed());
+        $this->assertFalse((new Config('config', new Data()))->isClosed());
+    }
+}

--- a/core-bundle/tests/Dca/Schema/FieldTest.php
+++ b/core-bundle/tests/Dca/Schema/FieldTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Dca\Schema;
+
+use Contao\CoreBundle\Dca\Data;
+use Contao\CoreBundle\Dca\Schema\Field;
+use PHPUnit\Framework\TestCase;
+
+class FieldTest extends TestCase
+{
+    public function testIsExcluded(): void
+    {
+        $this->assertTrue((new Field('foo', new Data(['exclude' => true])))->isExcluded());
+        $this->assertFalse((new Field('foo', new Data(['exclude' => false])))->isExcluded());
+        $this->assertFalse((new Field('foo', new Data()))->isExcluded());
+    }
+}

--- a/core-bundle/tests/Dca/Schema/OperationTest.php
+++ b/core-bundle/tests/Dca/Schema/OperationTest.php
@@ -151,7 +151,7 @@ class OperationTest extends TestCase
         $container = $this->createMock(ContainerInterface::class);
         $container
             ->method('get')
-            ->with('framework')
+            ->with('contao.framework')
             ->willReturn($framework)
         ;
 
@@ -184,14 +184,22 @@ class OperationTest extends TestCase
             ->willReturn('<img />')
         ;
 
+        $backendAdapter = $this->mockAdapter(['addToUrl']);
+        $backendAdapter
+            ->expects($this->once())
+            ->method('addToUrl')
+            ->willReturn('contao?do=foo')
+        ;
+
         $framework = $this->mockContaoFramework([
             Image::class => $imageAdapter,
+            Backend::class => $backendAdapter,
         ]);
 
         $container = $this->createMock(ContainerInterface::class);
         $container
             ->method('get')
-            ->with('framework')
+            ->with('contao.framework')
             ->willReturn($framework)
         ;
 

--- a/core-bundle/tests/Dca/Schema/OperationTest.php
+++ b/core-bundle/tests/Dca/Schema/OperationTest.php
@@ -1,0 +1,203 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\Dca\Schema;
+
+use Contao\Backend;
+use Contao\CoreBundle\Dca\Data;
+use Contao\CoreBundle\Dca\Schema\Operation;
+use Contao\CoreBundle\Tests\TestCase;
+use Contao\Image;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\Routing\RouterInterface;
+
+class OperationTest extends TestCase
+{
+    /**
+     * @param string|array|null $label
+     *
+     * @dataProvider labelProvider
+     */
+    public function testParseLabel($label, string $id, string $expected, string $name = 'foo'): void
+    {
+        $operation = new Operation($name, new Data(['label' => $label]));
+
+        $this->assertSame($expected, $operation->parseLabel($id));
+    }
+
+    public function labelProvider(): array
+    {
+        return [
+            'string' => ['Foo', '1', 'Foo'],
+            'string with placeholder' => ['Foo %s', '1', 'Foo 1'],
+            'array' => [['Foo', 'bar'], '1', 'Foo'],
+            'array with placeholder' => [['Foo %s', 'bar'], '1', 'Foo 1'],
+            'empty string' => ['', '1', 'operation_foo', 'operation_foo'],
+            'empty array' => [[], '1', 'operation_foo', 'operation_foo'],
+            'null' => [null, '1', 'operation_foo', 'operation_foo'],
+        ];
+    }
+
+    /**
+     * @param string|array|null $label
+     *
+     * @dataProvider titleProvider
+     */
+    public function testParseTitle($label, string $id, string $expected, string $name = 'foo'): void
+    {
+        $operation = new Operation($name, new Data(['label' => $label]));
+
+        $this->assertSame($expected, $operation->parseTitle($id));
+    }
+
+    public function titleProvider(): array
+    {
+        return [
+            'label string' => ['Foo', '1', 'Foo'],
+            'label string with placeholder' => ['Foo %s', '1', 'Foo 1'],
+            'array with title' => [['Foo', 'bar'], '1', 'bar'],
+            'array without title' => [['Foo'], '1', 'Foo'],
+            'array with placeholder' => [['Foo %s', 'bar %s'], '1', 'bar 1'],
+            'empty string' => [['', ''], '1', 'operation_foo', 'operation_foo'],
+            'empty array' => [[], '1', 'operation_foo', 'operation_foo'],
+            'null' => [null, '1', 'operation_foo', 'operation_foo'],
+        ];
+    }
+
+    /**
+     * @dataProvider attributesProvider
+     */
+    public function testParseAttributes(array $data, string $id, string $expected, string $name = 'foo'): void
+    {
+        $operation = new Operation($name, new Data($data));
+
+        $this->assertSame($expected, $operation->parseAttributes($id));
+    }
+
+    public function attributesProvider(): array
+    {
+        return [
+            'no attributes' => [[], '1', ' class="foo"'],
+            'empty attributes' => [['attributes' => ''], '1', ' class="foo"'],
+            'custom attributes' => [['attributes' => 'data-foo="bar"'], '1', ' class="foo" data-foo="bar"'],
+            'attributes with placeholder' => [['attributes' => 'data-foo="bar %s"'], '1', ' class="foo" data-foo="bar 1"'],
+            'merge class value' => [['attributes' => 'data-foo="bar"', 'class' => 'class-a class-b'], '1', ' class="foo class-a class-b" data-foo="bar"'],
+            'merge class value and attribute' => [['attributes' => 'data-foo="bar" class="class-c"', 'class' => 'class-a class-b'], '1', ' data-foo="bar" class="foo class-a class-b class-c"'],
+            'trim whitespace' => [['attributes' => '   data-foo="bar"  '], '1', ' class="foo" data-foo="bar"'],
+        ];
+    }
+
+    public function testParseHrefFromRouteAttribute(): void
+    {
+        $data = [
+            'route' => 'contao.custom',
+            'href' => 'foo',
+        ];
+        $params = [
+            'id' => 1,
+        ];
+
+        $router = $this->createMock(RouterInterface::class);
+        $router
+            ->expects($this->once())
+            ->method('generate')
+            ->with('contao.custom', $params)
+            ->willReturn('contao/custom?id=1')
+        ;
+
+        $container = $this->createMock(ContainerInterface::class);
+        $container
+            ->method('get')
+            ->with('router')
+            ->willReturn($router)
+        ;
+
+        $operation = new Operation('foo', new Data($data));
+        $operation->setLocator($container);
+
+        $this->assertSame('contao/custom?id=1', $operation->parseHref($params));
+    }
+
+    /**
+     * @dataProvider hrefProvider
+     */
+    public function testParseHrefFromHrefAttribute(string $href, array $params, string $expected): void
+    {
+        $data = [
+            'href' => $href,
+        ];
+
+        $backendAdapter = $this->mockAdapter(['addToUrl']);
+        $backendAdapter
+            ->expects($this->once())
+            ->method('addToUrl')
+            ->with($expected)
+            ->willReturn('contao?do=foo&'.$expected)
+        ;
+
+        $framework = $this->mockContaoFramework([
+            Backend::class => $backendAdapter,
+        ]);
+
+        $container = $this->createMock(ContainerInterface::class);
+        $container
+            ->method('get')
+            ->with('framework')
+            ->willReturn($framework)
+        ;
+
+        $operation = new Operation('foo', new Data($data));
+        $operation->setLocator($container);
+
+        $this->assertSame('contao?do=foo&'.$expected, $operation->parseHref($params));
+    }
+
+    public function hrefProvider(): array
+    {
+        return [
+            'with ID' => ['act=foo', ['id' => 1], 'act=foo&amp;id=1'],
+            'with ID and popup' => ['act=bar', ['id' => 2, 'popup' => true], 'act=bar&amp;id=2&amp;popup=1'],
+        ];
+    }
+
+    public function testParseIcon(): void
+    {
+        $data = [
+            'label' => 'foo %s',
+            'icon' => 'bar.svg',
+        ];
+
+        $imageAdapter = $this->mockAdapter(['getHtml']);
+        $imageAdapter
+            ->expects($this->once())
+            ->method('getHtml')
+            ->with('bar.svg', 'foo 2')
+            ->willReturn('<img />')
+        ;
+
+        $framework = $this->mockContaoFramework([
+            Image::class => $imageAdapter,
+        ]);
+
+        $container = $this->createMock(ContainerInterface::class);
+        $container
+            ->method('get')
+            ->with('framework')
+            ->willReturn($framework)
+        ;
+
+        $operation = new Operation('foo', new Data($data));
+        $operation->setLocator($container);
+
+        $this->assertSame('<img />', $operation->parseIcon('2'));
+    }
+}

--- a/core-bundle/tests/DcaMockBuilder.php
+++ b/core-bundle/tests/DcaMockBuilder.php
@@ -21,6 +21,7 @@ use Contao\CoreBundle\Dca\SchemaFactory;
 use Contao\CoreBundle\Framework\ContaoFramework;
 use PHPUnit\Framework\MockObject\MockBuilder;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Rule\InvocationOrder;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\DependencyInjection\Container;
 
@@ -142,7 +143,7 @@ final class DcaMockBuilder
 
         foreach ($mocks as $method => $mock) {
             if (!empty($mock['_mocks'] ?? null)) {
-                /** @var Dca $originalSchema */
+                /** @var SchemaInterface $originalSchema */
                 $originalSchema = $original ? $original->{$method}() : $dca->{$method}();
 
                 if (isset($mock['_mock'])) {
@@ -243,6 +244,9 @@ final class DcaMockBuilder
         return $mocks;
     }
 
+    /**
+     * @param array<MockObject>|MockObject $mock
+     */
     private function addMock(array $mocks, string $path, mixed $mock): array
     {
         if (\is_array($mock)) {
@@ -265,7 +269,10 @@ final class DcaMockBuilder
         return $mocks;
     }
 
-    private function parseSpies(array $spies, string $path, mixed $spy): array
+    /**
+     * @param array<InvocationOrder>|InvocationOrder $spy
+     */
+    private function parseSpies(array $spies, string $path, $spy): array
     {
         if (\is_array($spy)) {
             foreach ($spy as $k => $v) {

--- a/core-bundle/tests/DcaMockBuilder.php
+++ b/core-bundle/tests/DcaMockBuilder.php
@@ -1,0 +1,388 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests;
+
+use Contao\ArrayUtil;
+use Contao\CoreBundle\Dca\Data;
+use Contao\CoreBundle\Dca\DcaFactory;
+use Contao\CoreBundle\Dca\Schema\Dca;
+use Contao\CoreBundle\Dca\Schema\SchemaInterface;
+use Contao\CoreBundle\Dca\SchemaFactory;
+use Contao\CoreBundle\Framework\ContaoFramework;
+use PHPUnit\Framework\MockObject\MockBuilder;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\DependencyInjection\Container;
+
+/**
+ * Builder class to generate a DcaFactory with predefined data and mockable and spyable schema nodes.
+ */
+final class DcaMockBuilder
+{
+    private readonly SchemaFactory $schemaFactory;
+
+    private array $dcas = [];
+
+    private array $dcaData = [];
+
+    private array $spies = [];
+
+    private array $mocks = [];
+
+    public function __construct(
+        private readonly TestCase $testCase,
+        ContaoFramework $framework,
+        Container $container,
+    ) {
+        $locator = $this->createMock(ContainerInterface::class);
+        $locator
+            ->method('get')
+            ->willReturnMap([
+                ['service_container', $container],
+                ['contao.framework', $framework],
+            ])
+        ;
+
+        $this->schemaFactory = new SchemaFactory($locator);
+    }
+
+    public function addDcaData(string $resource, array $data): self
+    {
+        $this->dcaData[$resource] = $data;
+        $this->addResource($resource);
+
+        return $this;
+    }
+
+    public function addSpies(string $resource, array $spies): self
+    {
+        $this->spies[$resource] = array_merge_recursive($this->spies[$resource] ?? [], $spies);
+        $this->addResource($resource);
+
+        return $this;
+    }
+
+    public function addMocks(string $resource, array $mocks): self
+    {
+        $this->mocks[$resource] = array_merge_recursive($this->mocks[$resource] ?? [], $mocks);
+        $this->addResource($resource);
+
+        return $this;
+    }
+
+    public function getMock(): MockObject&DcaFactory
+    {
+        $factory = $this->getMockBuilder(DcaFactory::class)
+            ->disableOriginalConstructor()
+            ->disableOriginalClone()
+            ->disableArgumentCloning()
+            ->disallowMockingUnknownTypes()
+            ->getMock()
+        ;
+
+        $resourceMap = [];
+
+        foreach ($this->dcas as $resource) {
+            $source = [];
+
+            foreach ($this->dcaData[$resource] ?? [] as $k => $v) {
+                $source = ArrayUtil::set($source, $k, $v);
+            }
+
+            $dca = $this->getDcaMock($resource, $source);
+            $mocks = $this->getMocks($resource, $dca);
+            $dca = $this->attachMocksToDca($resource, $dca, $mocks, $dca);
+
+            $resourceMap[] = [$resource, $dca];
+        }
+
+        $factory
+            ->method('get')
+            ->willReturnMap($resourceMap)
+        ;
+
+        return $factory;
+    }
+
+    private function getDcaMock(string $resource, array $source): MockObject&Dca
+    {
+        return $this->testCase
+            ->getMockBuilder(Dca::class)
+            ->disableOriginalClone()
+            ->disableArgumentCloning()
+            ->disallowMockingUnknownTypes()
+            ->setConstructorArgs([$resource, new Data($source), $this->schemaFactory])
+            ->onlyMethods([])
+            ->getMock()
+        ;
+    }
+
+    private function attachMocksToDca(string $resource, SchemaInterface $dca, array $mocks, SchemaInterface|null $original = null): MockObject
+    {
+        $new = $this
+            ->getMockBuilder($dca::class)
+            ->disableOriginalClone()
+            ->disableArgumentCloning()
+            ->disallowMockingUnknownTypes()
+            ->setConstructorArgs([$resource, $dca->getData(), $this->schemaFactory])
+            ->onlyMethods(array_keys($mocks))
+            ->setProxyTarget($dca)
+            ->getMock()
+        ;
+
+        foreach ($mocks as $method => $mock) {
+            if (!empty($mock['_mocks'] ?? null)) {
+                /** @var Dca $originalSchema */
+                $originalSchema = $original ? $original->{$method}() : $dca->{$method}();
+
+                if (isset($mock['_mock'])) {
+                    throw new \LogicException(sprintf('You cannot define a spy on a child node of another spy at "%s"', $method.'.'.array_key_first($mock['_mocks'])));
+                }
+
+                $mock['_mock'] = $this->testCase
+                    ->getMockBuilder($originalSchema::class)
+                    ->disableOriginalClone()
+                    ->disableArgumentCloning()
+                    ->disallowMockingUnknownTypes()
+                    ->setConstructorArgs([$resource, $originalSchema->getData(), $this->schemaFactory])
+                    ->onlyMethods(array_keys($mock['_mocks']))
+                    ->getMock()
+                ;
+
+                $mock['_mock'] = $this->attachMocksToDca($resource, $mock['_mock'], $mock['_mocks'], $originalSchema);
+            }
+
+            if (isset($mock['_mock'])) {
+                if (\is_array($mock['_mock'])) {
+                    $new
+                        ->method($method)
+                        ->willReturnMap($mock['_mock'])
+                    ;
+
+                    continue;
+                }
+
+                $new
+                    ->method($method)
+                    ->willReturn($mock['_mock'])
+                ;
+            }
+        }
+
+        return $new;
+    }
+
+    /**
+     * @template T of object
+     *
+     * @param class-string<T> $className
+     *
+     * @return MockBuilder<T>
+     */
+    private function getMockBuilder(string $className): MockBuilder
+    {
+        return $this->testCase->getMockBuilder($className);
+    }
+
+    private function addResource(string $resource): void
+    {
+        if (!\in_array($resource, $this->dcas, true)) {
+            $this->dcas[] = $resource;
+        }
+    }
+
+    private function getMocks(string $resource, MockObject&Dca $dca): array
+    {
+        $mocks = [];
+        $spies = [];
+
+        foreach ($this->mocks[$resource] ?? [] as $path => $mock) {
+            $parsed = ArrayUtil::set([], $path, $mock);
+
+            foreach ($parsed as $k => $v) {
+                $mocks = $this->addMock($mocks, $k, $v);
+            }
+        }
+
+        foreach ($this->spies[$resource] ?? [] as $path => $count) {
+            $check = ArrayUtil::pathToArray($path);
+            array_pop($check);
+            $check[] = '_mock';
+
+            $existing = ArrayUtil::get($mocks, $check);
+
+            if ($existing) {
+                throw new \LogicException(sprintf('Spy at position "%s" would replace an existing mock. Add the spy to the mock.', $path));
+            }
+
+            if (!str_contains($path, '.')) {
+                throw new \LogicException(sprintf('You cannot add a spy to the root level of the DCA. Add a mock for "%s" if necessary.', $path));
+            }
+
+            $parsed = ArrayUtil::set([], $path, $count);
+
+            foreach ($parsed as $k => $v) {
+                $spies = $this->parseSpies($spies, $k, $v);
+            }
+        }
+
+        foreach ($spies as $path => $spy) {
+            $mocks = $this->addSpy($mocks, $path, $spy, $dca);
+        }
+
+        return $mocks;
+    }
+
+    private function addMock(array $mocks, string $path, mixed $mock): array
+    {
+        if (\is_array($mock)) {
+            foreach ($mock as $k => $v) {
+                if (!isset($mocks[$path]['_mocks'])) {
+                    $mocks[$path]['_mocks'] = [];
+                }
+
+                $mocks[$path]['_mocks'] = $this->addMock($mocks[$path]['_mocks'], $k, $v);
+            }
+        } elseif ($this->isArgumentPath($path)) {
+            $arguments = $this->parseArgumentPath($path);
+            $path = $arguments['path'];
+
+            $mocks[$path]['_mock'][] = array_merge($arguments['arguments'], [$mock]);
+        } else {
+            $mocks[$path]['_mock'] = $mock;
+        }
+
+        return $mocks;
+    }
+
+    private function parseSpies(array $spies, string $path, mixed $spy): array
+    {
+        if (\is_array($spy)) {
+            foreach ($spy as $k => $v) {
+                if (\is_array($v)) {
+                    if (!isset($spies[$path]['_children'])) {
+                        $spies[$path]['_children'] = [];
+                    }
+
+                    $spies[$path]['_children'] = $this->parseSpies($spies[$path]['_children'], $k, $v);
+                } else {
+                    $spies[$path]['_spies'][$k] = $v;
+                }
+            }
+        } else {
+            $arguments = [];
+
+            if (preg_match('/\[(.*)\]/', $path, $arguments)) {
+                $path = str_replace($arguments[0], '', $path);
+
+                $spies['_spies'][$path][] = array_merge(explode(',', $arguments[1]), [$spy]);
+            } else {
+                $spies['_spies'][$path] = $spy;
+            }
+        }
+
+        return $spies;
+    }
+
+    private function addSpy(array $mocks, string $path, mixed $spy, MockObject&SchemaInterface $dca): array
+    {
+        $mock = $this->createSpy($dca, $path);
+
+        if (!empty($spy['_spies'] ?? null)) {
+            foreach ($spy['_spies'] as $method => $times) {
+                $mock
+                    ->expects($times)
+                    ->method($method)
+                ;
+            }
+
+            if ($this->isArgumentPath($path)) {
+                $arguments = $this->parseArgumentPath($path);
+                $path = $arguments['path'];
+
+                $mocks[$path]['_mock'][] = array_merge($arguments['arguments'], [$mock]);
+            } else {
+                $mocks[$path]['_mock'] = $mock;
+            }
+        }
+
+        if (!empty($spy['_children'] ?? null)) {
+            foreach ($spy['_children'] as $k => $v) {
+                if (!isset($mocks[$path]['_mocks'])) {
+                    $mocks[$path]['_mocks'] = [];
+                }
+
+                $mocks[$path]['_mocks'] = $this->addSpy($mocks[$path]['_mocks'], $k, $v, $mock);
+            }
+        }
+
+        return $mocks;
+    }
+
+    private function createSpy(MockObject&SchemaInterface $dca, string $path): MockObject&SchemaInterface
+    {
+        if ($this->isArgumentPath($path)) {
+            $arguments = $this->parseArgumentPath($path);
+            $target = $dca->{$arguments['path']}(...$arguments['arguments']);
+        } else {
+            $target = $dca->{$path}();
+        }
+
+        if (!$target instanceof SchemaInterface) {
+            throw new \LogicException(sprintf('Invalid spy path with parent "%s".', $dca->getName().'.'.$path));
+        }
+
+        return $target instanceof MockObject ? $target : $this
+            ->getMockBuilder($target::class)
+            ->setConstructorArgs([$path, $target->getData(), $this->schemaFactory])
+            ->enableProxyingToOriginalMethods()
+            ->getMock()
+        ;
+    }
+
+    private function isArgumentPath(string $path): bool
+    {
+        return 1 === preg_match('/\[(.*)\]/', $path);
+    }
+
+    private function parseArgumentPath(string $path): array
+    {
+        $arguments = [];
+        preg_match('/\[(.*)\]/', $path, $arguments);
+
+        $path = str_replace($arguments[0], '', $path);
+
+        return [
+            'path' => str_replace($arguments[0], '', $path),
+            'arguments' => explode(',', $arguments[1]),
+        ];
+    }
+
+    /**
+     * @template T of object
+     *
+     * @param class-string<T> $originalClassName
+     *
+     * @return MockObject&T
+     */
+    private function createMock(string $originalClassName): MockObject
+    {
+        return $this->getMockBuilder($originalClassName)
+            ->disableOriginalConstructor()
+            ->disableOriginalClone()
+            ->disableArgumentCloning()
+            ->disallowMockingUnknownTypes()
+            ->getMock()
+        ;
+    }
+}

--- a/core-bundle/tests/EventListener/DataContainer/DefaultOperationsListenerTest.php
+++ b/core-bundle/tests/EventListener/DataContainer/DefaultOperationsListenerTest.php
@@ -555,7 +555,7 @@ class DefaultOperationsListenerTest extends TestCase
         ;
 
         $config = new DataContainerOperation($name, $operation, $record, $this->createMock(DataContainer::class));
-        $operation['button_callback']($config);
+        $operation['permission_callback']($config);
     }
 
     public function checkPermissionsProvider(): \Generator
@@ -641,10 +641,10 @@ class DefaultOperationsListenerTest extends TestCase
         $this->assertSame($operation['icon'], $icon);
 
         if ($hasCallback) {
-            $this->assertArrayHasKey('button_callback', $operation);
-            $this->assertIsCallable($operation['button_callback']);
+            $this->assertArrayHasKey('permission_callback', $operation);
+            $this->assertIsCallable($operation['permission_callback']);
 
-            $ref = new \ReflectionFunction($operation['button_callback']);
+            $ref = new \ReflectionFunction($operation['permission_callback']);
 
             $this->assertSame(1, $ref->getNumberOfParameters());
 
@@ -652,7 +652,7 @@ class DefaultOperationsListenerTest extends TestCase
             $type = $ref->getParameters()[0]->getType();
             $this->assertSame(DataContainerOperation::class, $type->getName());
         } else {
-            $this->assertArrayNotHasKey('button_callback', $operation);
+            $this->assertArrayNotHasKey('permission_callback', $operation);
         }
     }
 }

--- a/core-bundle/tests/Fixtures/Functional/Dca/tl_test.php
+++ b/core-bundle/tests/Fixtures/Functional/Dca/tl_test.php
@@ -1,0 +1,636 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+use Contao\Config;
+use Contao\DataContainer;
+use Contao\System;
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+$GLOBALS['TL_DCA']['tl_test'] = [
+    // Config
+    'config' => [
+        'dataContainer' => 'Table',
+        'ctable' => ['tl_article'],
+        'enableVersioning' => true,
+        'markAsCopy' => 'title',
+        'onload_callback' => [
+            ['tl_test', 'callback1'],
+            ['tl_test', 'callback2'],
+        ],
+        'oncut_callback' => [
+            ['tl_test', 'callback1'],
+        ],
+        'ondelete_callback' => [
+            ['tl_test', 'callback1'],
+        ],
+        'onsubmit_callback' => [
+            ['tl_test', 'callback1'],
+        ],
+        'oninvalidate_cache_tags_callback' => [
+            ['tl_test', 'callback1'],
+        ],
+        'sql' => [
+            'keys' => [
+                'id' => 'primary',
+                'alias' => 'index',
+                'type,dns' => 'index',
+                'pid,published,type,start,stop' => 'index',
+            ],
+        ],
+    ],
+
+    // List
+    'list' => [
+        'sorting' => [
+            'mode' => DataContainer::MODE_TREE,
+            'showRootTrails' => true,
+            'icon' => 'pagemounts.svg',
+            'paste_button_callback' => ['tl_test', 'pastePage'],
+            'panelLayout' => 'filter;search',
+        ],
+        'label' => [
+            'fields' => ['title'],
+            'format' => '%s',
+            'label_callback' => ['tl_test', 'addIcon'],
+        ],
+        'global_operations' => [
+            'toggleNodes' => [
+                'href' => 'ptg=all',
+                'class' => 'header_toggle',
+                'showOnSelect' => true,
+            ],
+            'all' => [
+                'href' => 'act=select',
+                'class' => 'header_edit_all',
+                'attributes' => 'onclick="Backend.getScrollOffset()" accesskey="e"',
+            ],
+        ],
+        'operations' => [
+            'edit' => [
+                'href' => 'act=edit',
+                'icon' => 'edit.svg',
+                'button_callback' => ['tl_test', 'editPage'],
+            ],
+            'copy' => [
+                'href' => 'act=paste&amp;mode=copy',
+                'icon' => 'copy.svg',
+                'attributes' => 'onclick="Backend.getScrollOffset()"',
+                'button_callback' => ['tl_test', 'copyPage'],
+            ],
+            'copyChilds' => [
+                'href' => 'act=paste&amp;mode=copy&amp;childs=1',
+                'icon' => 'copychilds.svg',
+                'attributes' => 'onclick="Backend.getScrollOffset()"',
+                'button_callback' => ['tl_test', 'copyPageWithSubpages'],
+            ],
+            'cut' => [
+                'href' => 'act=paste&amp;mode=cut',
+                'icon' => 'cut.svg',
+                'attributes' => 'onclick="Backend.getScrollOffset()"',
+                'button_callback' => ['tl_test', 'cutPage'],
+            ],
+            'delete' => [
+                'href' => 'act=delete',
+                'icon' => 'delete.svg',
+                'attributes' => 'onclick="if(!confirm(\''.($GLOBALS['TL_LANG']['MSC']['deleteConfirm'] ?? null).'\'))return false;Backend.getScrollOffset()"',
+                'button_callback' => ['tl_test', 'deletePage'],
+            ],
+            'toggle' => [
+                'icon' => 'visible.svg',
+                'attributes' => 'onclick="Backend.getScrollOffset();return AjaxRequest.toggleVisibility(this,%s)"',
+                'button_callback' => ['tl_test', 'toggleIcon'],
+            ],
+            'show' => [
+                'href' => 'act=show',
+                'icon' => 'show.svg',
+            ],
+            'articles' => [
+                'href' => 'do=article',
+                'icon' => 'article.svg',
+            ],
+        ],
+    ],
+
+    // Select
+    'select' => [
+        'buttons_callback' => [
+            ['tl_test', 'addAliasButton'],
+        ],
+    ],
+
+    // Palettes
+    'palettes' => [
+        '__selector__' => ['type', 'fallback', 'autoforward', 'protected', 'includeLayout', 'includeCache', 'includeChmod', 'enforceTwoFactor'],
+        'default' => '{title_legend},title,alias,type',
+        'regular' => '{title_legend},title,alias,type;{meta_legend},pageTitle,robots,description,serpPreview;{canonical_legend:hide},canonicalLink,canonicalKeepParams;{protected_legend:hide},protected;{layout_legend:hide},includeLayout;{cache_legend:hide},includeCache;{chmod_legend:hide},includeChmod;{expert_legend:hide},cssClass,sitemap,hide,noSearch,guests,requireItem;{tabnav_legend:hide},tabindex,accesskey;{publish_legend},published,start,stop',
+        'forward' => '{title_legend},title,alias,type;{meta_legend},pageTitle,robots;{redirect_legend},jumpTo,redirect;{protected_legend:hide},protected;{layout_legend:hide},includeLayout;{cache_legend:hide},includeCache;{chmod_legend:hide},includeChmod;{expert_legend:hide},cssClass,sitemap,hide,guests;{tabnav_legend:hide},tabindex,accesskey;{publish_legend},published,start,stop',
+        'redirect' => '{title_legend},title,alias,type;{meta_legend},pageTitle,robots;{redirect_legend},redirect,url,target;{protected_legend:hide},protected;{layout_legend:hide},includeLayout;{cache_legend:hide},includeCache;{chmod_legend:hide},includeChmod;{expert_legend:hide},cssClass,sitemap,hide,guests;{tabnav_legend:hide},tabindex,accesskey;{publish_legend},published,start,stop',
+        'root' => '{title_legend},title,alias,type;{meta_legend},pageTitle;{url_legend},dns,useSSL,urlPrefix,urlSuffix,validAliasCharacters,useFolderUrl;{language_legend},language,fallback,disableLanguageRedirect;{global_legend:hide},mailerTransport,enableCanonical,adminEmail,dateFormat,timeFormat,datimFormat,staticFiles,staticPlugins;{protected_legend:hide},protected;{layout_legend},includeLayout;{twoFactor_legend:hide},enforceTwoFactor;{cache_legend:hide},includeCache;{chmod_legend:hide},includeChmod;{publish_legend},published,start,stop',
+        'rootfallback' => '{title_legend},title,alias,type;{meta_legend},pageTitle;{url_legend},dns,useSSL,urlPrefix,urlSuffix,validAliasCharacters,useFolderUrl;{language_legend},language,fallback,disableLanguageRedirect;{website_legend:hide},favicon,robotsTxt;{global_legend:hide},mailerTransport,enableCanonical,adminEmail,dateFormat,timeFormat,datimFormat,staticFiles,staticPlugins;{protected_legend:hide},protected;{layout_legend},includeLayout;{twoFactor_legend:hide},enforceTwoFactor;{cache_legend:hide},includeCache;{chmod_legend:hide},includeChmod;{publish_legend},published,start,stop',
+        'logout' => '{title_legend},title,alias,type;{forward_legend},jumpTo,redirectBack;{protected_legend:hide},protected;{chmod_legend:hide},includeChmod;{expert_legend:hide},cssClass,sitemap,hide;{tabnav_legend:hide},tabindex,accesskey;{publish_legend},published,start,stop',
+        'error_401' => '{title_legend},title,alias,type;{meta_legend},pageTitle,robots,description;{forward_legend},autoforward;{layout_legend:hide},includeLayout;{cache_legend:hide},includeCache;{chmod_legend:hide},includeChmod;{expert_legend:hide},cssClass;{publish_legend},published,start,stop',
+        'error_403' => '{title_legend},title,alias,type;{meta_legend},pageTitle,robots,description;{forward_legend},autoforward;{layout_legend:hide},includeLayout;{cache_legend:hide},includeCache;{chmod_legend:hide},includeChmod;{expert_legend:hide},cssClass;{publish_legend},published,start,stop',
+        'error_404' => '{title_legend},title,alias,type;{meta_legend},pageTitle,robots,description;{forward_legend},autoforward;{layout_legend:hide},includeLayout;{cache_legend:hide},includeCache;{chmod_legend:hide},includeChmod;{expert_legend:hide},cssClass;{publish_legend},published,start,stop',
+    ],
+
+    // Subpalettes
+    'subpalettes' => [
+        'autoforward' => 'jumpTo',
+        'protected' => 'groups',
+        'includeLayout' => 'layout',
+        'includeCache' => 'clientCache,cache,alwaysLoadFromCache',
+        'includeChmod' => 'cuser,cgroup,chmod',
+        'enforceTwoFactor' => 'twoFactorJumpTo',
+    ],
+
+    // Fields
+    'fields' => [
+        'id' => [
+            'label' => ['ID'],
+            'search' => true,
+            'sql' => 'int(10) unsigned NOT NULL auto_increment',
+        ],
+        'pid' => [
+            'sql' => 'int(10) unsigned NOT NULL default 0',
+        ],
+        'sorting' => [
+            'sql' => 'int(10) unsigned NOT NULL default 0',
+        ],
+        'tstamp' => [
+            'sql' => 'int(10) unsigned NOT NULL default 0',
+        ],
+        'title' => [
+            'exclude' => true,
+            'search' => true,
+            'inputType' => 'text',
+            'eval' => ['mandatory' => true, 'maxlength' => 255, 'tl_class' => 'w50'],
+            'sql' => "varchar(255) NOT NULL default ''",
+        ],
+        'alias' => [
+            'exclude' => true,
+            'search' => true,
+            'inputType' => 'text',
+            'eval' => ['rgxp' => 'folderalias', 'doNotCopy' => true, 'maxlength' => 255, 'tl_class' => 'w50 clr'],
+            'sql' => "varchar(255) BINARY NOT NULL default ''",
+        ],
+        'type' => [
+            'exclude' => true,
+            'filter' => true,
+            'inputType' => 'select',
+            'eval' => ['helpwizard' => true, 'submitOnChange' => true, 'tl_class' => 'w50'],
+            'reference' => &$GLOBALS['TL_LANG']['PTY'],
+            'sql' => "varchar(64) NOT NULL default 'regular'",
+        ],
+        'pageTitle' => [
+            'exclude' => true,
+            'search' => true,
+            'inputType' => 'text',
+            'eval' => ['maxlength' => 255, 'tl_class' => 'w50'],
+            'sql' => "varchar(255) NOT NULL default ''",
+        ],
+        'language' => [
+            'exclude' => true,
+            'search' => true,
+            'inputType' => 'text',
+            'eval' => ['mandatory' => true, 'maxlength' => 64, 'nospace' => true, 'decodeEntities' => true, 'doNotCopy' => true, 'tl_class' => 'w50'],
+            'sql' => "varchar(64) NOT NULL default ''",
+            'save_callback' => [
+                static function ($value) {
+                    // Make sure there is at least a basic language
+                    if (!preg_match('/^[a-z]{2,}/i', $value)) {
+                        throw new RuntimeException($GLOBALS['TL_LANG']['ERR']['language']);
+                    }
+
+                    return LocaleUtil::canonicalize($value);
+                },
+            ],
+        ],
+        'robots' => [
+            'exclude' => true,
+            'search' => true,
+            'inputType' => 'select',
+            'options' => ['index,follow', 'index,nofollow', 'noindex,follow', 'noindex,nofollow'],
+            'eval' => ['tl_class' => 'w50'],
+            'sql' => "varchar(32) NOT NULL default ''",
+        ],
+        'description' => [
+            'exclude' => true,
+            'search' => true,
+            'inputType' => 'textarea',
+            'eval' => ['style' => 'height:60px', 'decodeEntities' => true, 'tl_class' => 'clr'],
+            'sql' => 'text NULL',
+        ],
+        'serpPreview' => [
+            'label' => &$GLOBALS['TL_LANG']['MSC']['serpPreview'],
+            'exclude' => true,
+            'inputType' => 'serpPreview',
+            'eval' => ['url_callback' => ['tl_test', 'getSerpUrl'], 'title_tag_callback' => ['tl_test', 'getTitleTag'], 'titleFields' => ['pageTitle', 'title']],
+            'sql' => null,
+        ],
+        'redirect' => [
+            'exclude' => true,
+            'inputType' => 'select',
+            'options' => ['permanent', 'temporary'],
+            'eval' => ['tl_class' => 'w50'],
+            'reference' => &$GLOBALS['TL_LANG']['tl_test'],
+            'sql' => "varchar(32) NOT NULL default 'permanent'",
+        ],
+        'jumpTo' => [
+            'exclude' => true,
+            'inputType' => 'pageTree',
+            'foreignKey' => 'tl_test.title',
+            'eval' => ['fieldType' => 'radio'], // do not set mandatory (see #5453)
+            'save_callback' => [
+                ['tl_test', 'checkJumpTo'],
+            ],
+            'sql' => 'int(10) unsigned NOT NULL default 0',
+            'relation' => ['type' => 'hasOne', 'load' => 'lazy'],
+        ],
+        'redirectBack' => [
+            'exclude' => true,
+            'inputType' => 'checkbox',
+            'sql' => "char(1) NOT NULL default ''",
+        ],
+        'url' => [
+            'label' => &$GLOBALS['TL_LANG']['MSC']['url'],
+            'exclude' => true,
+            'search' => true,
+            'inputType' => 'text',
+            'eval' => ['mandatory' => true, 'rgxp' => 'url', 'decodeEntities' => true, 'maxlength' => 255, 'dcaPicker' => true, 'tl_class' => 'w50 clr'],
+            'sql' => "varchar(255) NOT NULL default ''",
+        ],
+        'target' => [
+            'label' => &$GLOBALS['TL_LANG']['MSC']['target'],
+            'exclude' => true,
+            'inputType' => 'checkbox',
+            'eval' => ['tl_class' => 'w50 m12'],
+            'sql' => "char(1) NOT NULL default ''",
+        ],
+        'dns' => [
+            'exclude' => true,
+            'search' => true,
+            'inputType' => 'text',
+            'eval' => ['rgxp' => 'url', 'decodeEntities' => true, 'maxlength' => 255, 'tl_class' => 'w50'],
+            'load_callback' => [
+                ['tl_test', 'loadDns'],
+            ],
+            'save_callback' => [
+                ['tl_test', 'checkDns'],
+            ],
+            'sql' => "varchar(255) NOT NULL default ''",
+        ],
+        'staticFiles' => [
+            'exclude' => true,
+            'search' => true,
+            'inputType' => 'text',
+            'eval' => ['rgxp' => 'url', 'trailingSlash' => false, 'tl_class' => 'w50'],
+            'save_callback' => [
+                ['tl_test', 'checkStaticUrl'],
+            ],
+            'sql' => "varchar(255) NOT NULL default ''",
+        ],
+        'staticPlugins' => [
+            'exclude' => true,
+            'search' => true,
+            'inputType' => 'text',
+            'eval' => ['rgxp' => 'url', 'trailingSlash' => false, 'tl_class' => 'w50'],
+            'save_callback' => [
+                ['tl_test', 'checkStaticUrl'],
+            ],
+            'sql' => "varchar(255) NOT NULL default ''",
+        ],
+        'fallback' => [
+            'exclude' => true,
+            'inputType' => 'checkbox',
+            'eval' => ['doNotCopy' => true, 'submitOnChange' => true, 'tl_class' => 'w50 clr'],
+            'save_callback' => [
+                ['tl_test', 'checkFallback'],
+            ],
+            'sql' => "char(1) NOT NULL default ''",
+        ],
+        'disableLanguageRedirect' => [
+            'exclude' => true,
+            'inputType' => 'checkbox',
+            'eval' => ['doNotCopy' => true, 'tl_class' => 'w50'],
+            'sql' => "char(1) NOT NULL default ''",
+        ],
+        'favicon' => [
+            'exclude' => true,
+            'inputType' => 'fileTree',
+            'eval' => ['filesOnly' => true, 'fieldType' => 'radio', 'extensions' => 'ico,svg'],
+            'sql' => 'binary(16) NULL',
+        ],
+        'robotsTxt' => [
+            'exclude' => true,
+            'inputType' => 'textarea',
+            'eval' => ['doNotCopy' => true, 'decodeEntities' => true],
+            'sql' => 'text NULL',
+        ],
+        'mailerTransport' => [
+            'exclude' => true,
+            'inputType' => 'select',
+            'eval' => ['tl_class' => 'w50', 'includeBlankOption' => true],
+            'sql' => "varchar(255) NOT NULL default ''",
+        ],
+        'enableCanonical' => [
+            'exclude' => true,
+            'inputType' => 'checkbox',
+            'default' => true,
+            'eval' => ['tl_class' => 'w50 m12'],
+            'sql' => "char(1) NOT NULL default ''",
+        ],
+        'canonicalLink' => [
+            'exclude' => true,
+            'search' => true,
+            'inputType' => 'text',
+            'eval' => ['rgxp' => 'url', 'decodeEntities' => true, 'maxlength' => 255, 'dcaPicker' => true, 'tl_class' => 'w50'],
+            'sql' => "varchar(255) NOT NULL default ''",
+        ],
+        'canonicalKeepParams' => [
+            'exclude' => true,
+            'inputType' => 'text',
+            'eval' => ['decodeEntities' => true, 'maxlength' => 255, 'tl_class' => 'w50'],
+            'sql' => "varchar(255) NOT NULL default ''",
+        ],
+        'adminEmail' => [
+            'exclude' => true,
+            'search' => true,
+            'inputType' => 'text',
+            'eval' => ['maxlength' => 255, 'rgxp' => 'friendly', 'decodeEntities' => true, 'placeholder' => Config::get('adminEmail'), 'tl_class' => 'w50'],
+            'sql' => "varchar(255) NOT NULL default ''",
+        ],
+        'dateFormat' => [
+            'exclude' => true,
+            'search' => true,
+            'inputType' => 'text',
+            'eval' => ['helpwizard' => true, 'decodeEntities' => true, 'placeholder' => Contao\Config::get('dateFormat'), 'tl_class' => 'w50'],
+            'explanation' => 'dateFormat',
+            'sql' => "varchar(32) NOT NULL default ''",
+        ],
+        'timeFormat' => [
+            'exclude' => true,
+            'search' => true,
+            'inputType' => 'text',
+            'eval' => ['decodeEntities' => true, 'placeholder' => Contao\Config::get('timeFormat'), 'tl_class' => 'w50'],
+            'sql' => "varchar(32) NOT NULL default ''",
+        ],
+        'datimFormat' => [
+            'exclude' => true,
+            'search' => true,
+            'inputType' => 'text',
+            'eval' => ['decodeEntities' => true, 'placeholder' => Contao\Config::get('datimFormat'), 'tl_class' => 'w50'],
+            'sql' => "varchar(32) NOT NULL default ''",
+        ],
+        'validAliasCharacters' => [
+            'exclude' => true,
+            'inputType' => 'select',
+            'options_callback' => static fn () => System::getContainer()->get('contao.slug.valid_characters')->getOptions(),
+            'eval' => ['includeBlankOption' => true, 'decodeEntities' => true, 'tl_class' => 'w50'],
+            'sql' => "varchar(255) NOT NULL default ''",
+        ],
+        'useFolderUrl' => [
+            'inputType' => 'checkbox',
+            'eval' => ['tl_class' => 'w50 m12'],
+            'sql' => "char(1) NOT NULL default ''",
+        ],
+        'urlPrefix' => [
+            'exclude' => true,
+            'inputType' => 'text',
+            'eval' => ['rgxp' => 'folderalias', 'doNotCopy' => true, 'maxlength' => 128, 'tl_class' => 'w50'],
+            'sql' => "varchar(128) BINARY NOT NULL default ''",
+        ],
+        'urlSuffix' => [
+            'inputType' => 'text',
+            'eval' => ['nospace' => 'true', 'maxlength' => 16, 'tl_class' => 'w50'],
+            'sql' => "varchar(16) NOT NULL default ''",
+        ],
+        'useSSL' => [
+            'exclude' => true,
+            'inputType' => 'select',
+            'options' => ['' => 'http://', '1' => 'https://'],
+            'eval' => ['tl_class' => 'w50'],
+            'sql' => "char(1) NOT NULL default '1'",
+        ],
+        'autoforward' => [
+            'exclude' => true,
+            'inputType' => 'checkbox',
+            'eval' => ['submitOnChange' => true],
+            'sql' => "char(1) NOT NULL default ''",
+        ],
+        'protected' => [
+            'exclude' => true,
+            'filter' => true,
+            'inputType' => 'checkbox',
+            'eval' => ['submitOnChange' => true],
+            'sql' => "char(1) NOT NULL default ''",
+        ],
+        'groups' => [
+            'exclude' => true,
+            'filter' => true,
+            'inputType' => 'checkbox',
+            'foreignKey' => 'tl_member_group.name',
+            'eval' => ['mandatory' => true, 'multiple' => true],
+            'sql' => 'blob NULL',
+            'relation' => ['type' => 'hasMany', 'load' => 'lazy'],
+        ],
+        'includeLayout' => [
+            'exclude' => true,
+            'inputType' => 'checkbox',
+            'eval' => ['submitOnChange' => true],
+            'sql' => "char(1) NOT NULL default ''",
+        ],
+        'layout' => [
+            'exclude' => true,
+            'search' => true,
+            'inputType' => 'select',
+            'foreignKey' => 'tl_layout.name',
+            'options_callback' => ['tl_test', 'getPageLayouts'],
+            'eval' => ['chosen' => true, 'tl_class' => 'w50'],
+            'sql' => 'int(10) unsigned NOT NULL default 0',
+            'relation' => ['type' => 'hasOne', 'load' => 'lazy'],
+        ],
+        'includeCache' => [
+            'exclude' => true,
+            'inputType' => 'checkbox',
+            'eval' => ['submitOnChange' => true],
+            'sql' => "char(1) NOT NULL default ''",
+        ],
+        'cache' => [
+            'exclude' => true,
+            'search' => true,
+            'inputType' => 'select',
+            'options' => [0, 5, 15, 30, 60, 300, 900, 1800, 3600, 10800, 21600, 43200, 86400, 259200, 604800, 2592000, 7776000, 15552000, 31536000],
+            'reference' => &$GLOBALS['TL_LANG']['CACHE'],
+            'eval' => ['tl_class' => 'w50 clr'],
+            'sql' => 'int(10) unsigned NOT NULL default 0',
+        ],
+        'alwaysLoadFromCache' => [
+            'exclude' => true,
+            'inputType' => 'checkbox',
+            'eval' => ['tl_class' => 'w50 m12'],
+            'sql' => "char(1) NOT NULL default ''",
+        ],
+        'clientCache' => [
+            'exclude' => true,
+            'search' => true,
+            'inputType' => 'select',
+            'options' => [0, 5, 15, 30, 60, 300, 900, 1800, 3600, 10800, 21600, 43200, 86400, 259200, 604800, 2592000],
+            'reference' => &$GLOBALS['TL_LANG']['CACHE'],
+            'eval' => ['tl_class' => 'w50'],
+            'sql' => 'int(10) unsigned NOT NULL default 0',
+        ],
+        'includeChmod' => [
+            'exclude' => true,
+            'inputType' => 'checkbox',
+            'eval' => ['submitOnChange' => true],
+            'sql' => "char(1) NOT NULL default ''",
+        ],
+        'cuser' => [
+            'default' => (int) Contao\Config::get('defaultUser'),
+            'search' => true,
+            'exclude' => true,
+            'inputType' => 'select',
+            'foreignKey' => 'tl_user.name',
+            'eval' => ['mandatory' => true, 'chosen' => true, 'includeBlankOption' => true, 'tl_class' => 'w50'],
+            'sql' => 'int(10) unsigned NOT NULL default 0',
+            'relation' => ['type' => 'hasOne', 'load' => 'lazy'],
+        ],
+        'cgroup' => [
+            'default' => (int) Contao\Config::get('defaultGroup'),
+            'search' => true,
+            'exclude' => true,
+            'inputType' => 'select',
+            'foreignKey' => 'tl_user_group.name',
+            'eval' => ['mandatory' => true, 'chosen' => true, 'includeBlankOption' => true, 'tl_class' => 'w50'],
+            'sql' => 'int(10) unsigned NOT NULL default 0',
+            'relation' => ['type' => 'hasOne', 'load' => 'lazy'],
+        ],
+        'chmod' => [
+            'default' => Contao\Config::get('defaultChmod'),
+            'exclude' => true,
+            'inputType' => 'chmod',
+            'eval' => ['tl_class' => 'clr'],
+            'sql' => "varchar(255) NOT NULL default ''",
+        ],
+        'noSearch' => [
+            'exclude' => true,
+            'filter' => true,
+            'inputType' => 'checkbox',
+            'eval' => ['tl_class' => 'w50'],
+            'sql' => "char(1) NOT NULL default ''",
+        ],
+        'requireItem' => [
+            'exclude' => true,
+            'inputType' => 'checkbox',
+            'eval' => ['tl_class' => 'w50'],
+            'sql' => "char(1) NOT NULL default ''",
+        ],
+        'cssClass' => [
+            'exclude' => true,
+            'search' => true,
+            'inputType' => 'text',
+            'eval' => ['maxlength' => 64, 'tl_class' => 'w50'],
+            'sql' => "varchar(64) NOT NULL default ''",
+        ],
+        'sitemap' => [
+            'exclude' => true,
+            'inputType' => 'select',
+            'options' => ['map_default', 'map_always', 'map_never'],
+            'eval' => ['maxlength' => 32, 'tl_class' => 'w50'],
+            'reference' => &$GLOBALS['TL_LANG']['tl_test'],
+            'sql' => "varchar(32) NOT NULL default ''",
+        ],
+        'hide' => [
+            'exclude' => true,
+            'inputType' => 'checkbox',
+            'eval' => ['tl_class' => 'w50'],
+            'sql' => "char(1) NOT NULL default ''",
+        ],
+        'guests' => [
+            'exclude' => true,
+            'filter' => true,
+            'inputType' => 'checkbox',
+            'eval' => ['tl_class' => 'w50'],
+            'sql' => "char(1) NOT NULL default ''",
+        ],
+        'tabindex' => [
+            'exclude' => true,
+            'search' => true,
+            'inputType' => 'text',
+            'eval' => ['rgxp' => 'natural', 'nospace' => true, 'tl_class' => 'w50'],
+            'sql' => 'smallint(5) unsigned NOT NULL default 0',
+        ],
+        'accesskey' => [
+            'exclude' => true,
+            'search' => true,
+            'inputType' => 'text',
+            'eval' => ['rgxp' => 'alnum', 'maxlength' => 1, 'tl_class' => 'w50'],
+            'sql' => "char(1) NOT NULL default ''",
+        ],
+        'published' => [
+            'exclude' => true,
+            'filter' => true,
+            'inputType' => 'checkbox',
+            'eval' => ['doNotCopy' => true],
+            'sql' => "char(1) NOT NULL default ''",
+        ],
+        'start' => [
+            'exclude' => true,
+            'inputType' => 'text',
+            'eval' => ['rgxp' => 'datim', 'datepicker' => true, 'tl_class' => 'w50 wizard'],
+            'sql' => "varchar(10) NOT NULL default ''",
+        ],
+        'stop' => [
+            'exclude' => true,
+            'inputType' => 'text',
+            'eval' => ['rgxp' => 'datim', 'datepicker' => true, 'tl_class' => 'w50 wizard'],
+            'sql' => "varchar(10) NOT NULL default ''",
+        ],
+        'enforceTwoFactor' => [
+            'exclude' => true,
+            'inputType' => 'checkbox',
+            'eval' => ['submitOnChange' => true],
+            'sql' => "char(1) NOT NULL default ''",
+        ],
+        'twoFactorJumpTo' => [
+            'exclude' => true,
+            'inputType' => 'pageTree',
+            'foreignKey' => 'tl_test.title',
+            'eval' => ['fieldType' => 'radio', 'mandatory' => true],
+            'save_callback' => [
+                ['tl_test', 'checkJumpTo'],
+            ],
+            'sql' => 'int(10) unsigned NOT NULL default 0',
+            'relation' => ['type' => 'hasOne', 'load' => 'lazy'],
+        ],
+    ],
+];
+
+if (!class_exists('tl_test')) {
+    class tl_test
+    {
+        public function callback1(): void
+        {
+        }
+
+        public function callback2(): void
+        {
+        }
+    }
+}

--- a/core-bundle/tests/Functional/Dca/DcaTest.php
+++ b/core-bundle/tests/Functional/Dca/DcaTest.php
@@ -65,16 +65,11 @@ class DcaTest extends TestCase
         $this->assertFalse($dca->config()->usesVersioning());
     }
 
-    public function testSchemaNodes(): void
+    public function testCallbackNodes(): void
     {
         $dca = $this->getDcaFactory()->get('tl_test');
 
         $dca->config()->callback('onload')->call();
-
-        $GLOBALS['TL_DCA']['tl_test']['config']['enableVersioning'] = false;
-
-        $this->assertFalse($dca->get('config.enableVersioning'));
-        $this->assertFalse($dca->config()->usesVersioning());
     }
 
     protected function getDcaFactory(): DcaFactory

--- a/core-bundle/tests/Functional/Dca/DcaTest.php
+++ b/core-bundle/tests/Functional/Dca/DcaTest.php
@@ -83,7 +83,7 @@ class DcaTest extends TestCase
 
         // TODO: Make this mockable / spyable!
         $callbackConsumer = new class() {
-            public function __call(mixed $method, mixed $arguments): void
+            public function __call(string $method, array $arguments): void
             {
             }
         };

--- a/core-bundle/tests/Functional/Dca/DcaTest.php
+++ b/core-bundle/tests/Functional/Dca/DcaTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\Functional\Dca;
+
+use Contao\Controller;
+use Contao\CoreBundle\Dca\DcaFactory;
+use Contao\CoreBundle\Dca\Driver\DriverCollection;
+use Contao\CoreBundle\Dca\Driver\GlobalArrayDriver;
+use Contao\CoreBundle\Dca\Provider\ConfigurationProvider;
+use Contao\CoreBundle\Dca\SchemaFactory;
+use Contao\CoreBundle\Tests\TestCase;
+use Contao\System;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+
+class DcaTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        require $this->getFixturesDir().'/Functional/Dca/tl_test.php';
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        unset($GLOBALS['TL_DCA']);
+    }
+
+    public function testReadsFromGlobals(): void
+    {
+        $dca = $this->getDcaFactory()->get('tl_test');
+
+        $this->assertTrue($dca->config()->usesVersioning());
+        $this->assertTrue($dca->get('config.enableVersioning'));
+    }
+
+    public function testDetectsChangesInGlobals(): void
+    {
+        $dca = $this->getDcaFactory()->get('tl_test');
+
+        // Detach a schema from the DCA to validate its data gets updates as well
+        $config = $dca->config();
+
+        $this->assertTrue($config->usesVersioning());
+        $this->assertTrue($dca->config()->usesVersioning());
+        $this->assertTrue($dca->get('config.enableVersioning'));
+
+        $GLOBALS['TL_DCA']['tl_test']['config']['enableVersioning'] = false;
+
+        $this->assertFalse($config->usesVersioning());
+        $this->assertFalse($dca->get('config.enableVersioning'));
+        $this->assertFalse($dca->config()->usesVersioning());
+    }
+
+    public function testSchemaNodes(): void
+    {
+        $dca = $this->getDcaFactory()->get('tl_test');
+
+        $dca->config()->callback('onload')->call();
+
+        $GLOBALS['TL_DCA']['tl_test']['config']['enableVersioning'] = false;
+
+        $this->assertFalse($dca->get('config.enableVersioning'));
+        $this->assertFalse($dca->config()->usesVersioning());
+    }
+
+    protected function getDcaFactory(): DcaFactory
+    {
+        $container = $this->getContainerWithContaoConfiguration();
+
+        // TODO: Make this mockable / spyable!
+        $callbackConsumer = new class() {
+            public function __call(mixed $method, mixed $arguments): void
+            {
+            }
+        };
+
+        $controllerAdapter = $this->mockAdapter(['loadDataContainer']);
+        $systemAdapter = $this->mockConfiguredAdapter([
+            'importStatic' => $callbackConsumer,
+        ]);
+
+        $framework = $this->mockContaoFramework([
+            Controller::class => $controllerAdapter,
+            System::class => $systemAdapter,
+        ]);
+
+        $controllerAdapter
+            // Allow some tests to load the data container more than once, e.g. to reload after changes
+            ->expects($this->atLeastOnce())
+            ->method('loadDataContainer')
+            ->with('tl_test')
+        ;
+
+        $locator = $this->createMock(ContainerInterface::class);
+        $locator
+            ->method('get')
+            ->willReturnMap([
+                ['service_container', $container],
+                ['contao.framework', $framework],
+            ])
+        ;
+
+        $factory = new SchemaFactory($locator);
+        $drivers = new DriverCollection([new GlobalArrayDriver($framework)]);
+        $configuration = new ConfigurationProvider($drivers, new EventDispatcher());
+
+        return new DcaFactory($factory, $drivers, $configuration);
+    }
+}

--- a/core-bundle/tests/TestCase.php
+++ b/core-bundle/tests/TestCase.php
@@ -17,12 +17,18 @@ use Contao\CoreBundle\Routing\Matcher\FrontendMatcher;
 use Contao\CoreBundle\Routing\ScopeMatcher;
 use Contao\CoreBundle\Session\Attribute\ArrayAttributeBag;
 use Contao\TestCase\ContaoTestCase;
+use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 
 abstract class TestCase extends ContaoTestCase
 {
+    public function getDcaMockBuilder(): DcaMockBuilder
+    {
+        return new DcaMockBuilder($this, $this->mockContaoFramework(), $this->createMock(Container::class));
+    }
+
     protected function getFixturesDir(): string
     {
         return __DIR__.\DIRECTORY_SEPARATOR.'Fixtures';

--- a/tools/ecs/config/default.php
+++ b/tools/ecs/config/default.php
@@ -22,6 +22,8 @@ return static function (ECSConfig $ecsConfig): void {
         '*-bundle/contao/*',
         MethodChainingIndentationFixer::class => [
             '*/DependencyInjection/Configuration.php',
+            'core-bundle/src/Dca/DcaConfiguration.php',
+            'core-bundle/src/Dca/Definition/Builder/*.php',
         ],
         UnusedVariableSniff::class => [
             'core-bundle/tests/Session/Attribute/ArrayAttributeBagTest.php',


### PR DESCRIPTION
Implements #3687 

The current draft is a working concept for an object-oriented and standardised access of DCA data.

The basic approach is as follows:
- A new service `DcaFactory` allows the creation of a Dca schema for a given resource (e.g. `tl_content`).
- Within the factory, a suitable driver for the resource is determined from a collection of appropriately tagged services.
	- Initially there is only one `GlobalArrayDriver`.
- Based on the data provided by the driver and a config-tree from the `DcaConfiguration`, an array with the configuration of the resource is created.
	- The `DcaConfiguration` is based on Symfony's configuration bundle and its config tree.
- The array with the configuration data is passed to a `Dca` schema.
- This schema allows querying the individual data nodes of the configuration via a fluid interface.

````php
$dca = $this->dcaFactory->get('tl_content');
$dca->list()->operations()->operation('edit')->get('href');
````

Note: When accessing the `Dca`, the individual nodes are created (and cached) dynamically at runtime. This way only the schemas of accessed nodes are initialized.

## Customization

For developers there are possibilities for customization:
- custom DCA sources can be queried via custom drivers
- configuration data can be added via `ConfigurationSourceEvent`
- schemas can be adjusted via `SchemaCreatedEvent`


## Mutable `Data`:
Internally, all schemas are based on a new `Data` class which wraps the original configuration array. Depending on the driver, the `Data` can be configured with observers so that all schemas are able to react to changes in the source data at runtime:

````php
$dca = $this->dcaFactory->get('tl_content');
$config = $dca->config();

$dca->config()->usesVersioning(); // true
$config()->usesVersioning(); // true

$GLOBALS['TL_DCA']['tl_content']['config']['enableVersioning'] = false;

$dca->config()->usesVersioning(); // false
$config()->usesVersioning(); // false
````

## Unit-testing
For a comfortable use of schemas within tests, a `DcaMockBuilder` is available, which makes the mocking of a DCA for unit tests very easy:

````php
$factory = $this->getDcaMockBuilder()
  ->addDcaData('tl_foo', [
    'config' => [
      'bar' => 'baz',
    ]
  ])
  ->addMocks('tl_foo', [
    'config.callback[onload]' => $onloadCallbacksMock
  ])
  ->addSpies('tl_foo', [
    'config.isClosed' => $this->exactly(1),
  ])
  ->getMock()
;

// Inject $factory to the subject of the test.
````



## Next steps
Since there is only little time left until Contao 4.13, I would suggest the following procedure (assuming the feature is appreciated for Contao 4.13):
- Integrate the DCA schemas for Contao 4.13 as an experimental feature.
- Use the schemas step-by-step within the core during Contao 4.13
	- thereby possibly also preparing/simplifying the DataContainers for a rework in the future
- Extend and finalize the schemas and the configuration tree during Contao 4.13


## Open issues
The following issues are still outstanding, but should be doable until Contao 4.13 RC:
- Agree onthe concept and fine-tune the implementation
- Clean up todos
- Create more unit tests
- Add additional nodes to the DcaConfiguration
- Add additional schemas and utility methods for schemas

## Assistance needed
- Maybe someone has an idea how to correctly mark up the individual callbacks for static code analysis with templates for a various number of parameters (e.g. `onload` with `DataContainer` and `button_callback` with `array, string, string etc.` instead of a generic `Callback<mixed>`).
- The individual schemas are not services, which is why regular dependency injection is not possible. Therefore, the draft currently includes a `ServiceSubscriberSchemaInterface`, which prepares the services for individual schemas. However, each subscribing schema has to be provided manually to the corresponding compiler pass. There may be a simpler way to allow schemas (= non-service classes) to access specific dependencies?

## Discuss this
I' m looking forward to input on this draft.

Ideally, the initial discussion should be limited to the concept and the basic features while the concrete schemas and nodes can be discussed in more detail at a later time.