### PR TITLE
Do not initialize the framework to get the Automator commands

### DIFF
--- a/core-bundle/src/Command/AutomatorCommand.php
+++ b/core-bundle/src/Command/AutomatorCommand.php
@@ -96,8 +96,6 @@ class AutomatorCommand extends Command
      */
     private function generateCommandMap(): array
     {
-        $this->framework->initialize();
-
         $commands = [];
 
         // Find all public methods


### PR DESCRIPTION
Since we no longer need the legacy `ClassLoader`, we don't need to initialize the Contao framework to read the class methods. Initializing the framework can lead to an exception when trying to list the available console commands, e.g. if a database connection is not correctly set up.