### PR TITLE
Check for unpublished elements when generating the RSS feed

### DIFF
--- a/calendar-bundle/src/Resources/contao/classes/Calendar.php
+++ b/calendar-bundle/src/Resources/contao/classes/Calendar.php
@@ -144,6 +144,12 @@ class Calendar extends Frontend
 		{
 			while ($objArticle->next())
 			{
+				// Never add unpublished elements to the RSS feeds
+				if (!$objArticle->published || ($objArticle->start && $objArticle->start > $time) || ($objArticle->stop && $objArticle->stop <= $time))
+				{
+					continue;
+				}
+
 				$jumpTo = $objArticle->getRelated('pid')->jumpTo;
 
 				// No jumpTo page set (see #4784)

--- a/news-bundle/src/Resources/contao/classes/News.php
+++ b/news-bundle/src/Resources/contao/classes/News.php
@@ -146,7 +146,6 @@ class News extends Frontend
 		if ($objArticle !== null)
 		{
 			$arrUrls = array();
-
 			$request = $container->get('request_stack')->getCurrentRequest();
 
 			if ($request)
@@ -155,10 +154,17 @@ class News extends Frontend
 				$request->attributes->set('_scope', 'frontend');
 			}
 
+			$time = time();
 			$origObjPage = $GLOBALS['objPage'] ?? null;
 
 			while ($objArticle->next())
 			{
+				// Never add unpublished elements to the RSS feeds
+				if (!$objArticle->published || ($objArticle->start && $objArticle->start > $time) || ($objArticle->stop && $objArticle->stop <= $time))
+				{
+					continue;
+				}
+
 				$jumpTo = $objArticle->getRelated('pid')->jumpTo;
 
 				// No jumpTo page set (see #4784)

--- a/news-bundle/src/Resources/contao/models/NewsModel.php
+++ b/news-bundle/src/Resources/contao/models/NewsModel.php
@@ -244,8 +244,7 @@ class NewsModel extends Model
 			$arrColumns[] = "$t.featured=''";
 		}
 
-		// Never return unpublished elements in the back end, so they don't end up in the RSS feed
-		if (!BE_USER_LOGGED_IN || TL_MODE == 'BE')
+		if (!BE_USER_LOGGED_IN)
 		{
 			$time = Date::floorToMinute();
 			$arrColumns[] = "$t.published='1' AND ($t.start='' OR $t.start<='$time') AND ($t.stop='' OR $t.stop>'$time')";


### PR DESCRIPTION
The previous attempt was checking `TL_MODE` in the model, which leads to incorrect results if the model is used in a different context.