### PR TITLE
Unify the command output format

### DIFF
--- a/core-bundle/src/Command/UserListCommand.php
+++ b/core-bundle/src/Command/UserListCommand.php
@@ -61,9 +61,9 @@ class UserListCommand extends Command
         $columns = $input->getOption('column');
 
         switch ($input->getOption('format')) {
-            case 'text': // Backwards compatibility
+            case 'text':
                 trigger_deprecation('contao/core-bundle', '4.13', 'Using --format=text is deprecated and will be removed in Contao 5. Use --format=txt instead.');
-                // no break!
+                // no break
 
             case 'txt':
                 if (0 === $users->count()) {

--- a/core-bundle/src/Command/UserListCommand.php
+++ b/core-bundle/src/Command/UserListCommand.php
@@ -61,8 +61,11 @@ class UserListCommand extends Command
         $columns = $input->getOption('column');
 
         switch ($input->getOption('format')) {
-            case 'txt':
             case 'text': // Backwards compatibility
+                trigger_deprecation('contao/core-bundle', '4.13', 'Using --format=text is deprecated and will be removed in Contao 5. Use --format=txt instead.');
+                // no break!
+
+            case 'txt':
                 if (0 === $users->count()) {
                     $io->note('No accounts found.');
 

--- a/core-bundle/src/Command/UserListCommand.php
+++ b/core-bundle/src/Command/UserListCommand.php
@@ -44,7 +44,7 @@ class UserListCommand extends Command
         $this
             ->addOption('column', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'The columns display in the table')
             ->addOption('admins', null, InputOption::VALUE_NONE, 'Return only admins')
-            ->addOption('format', null, InputOption::VALUE_REQUIRED, 'The output format', 'text')
+            ->addOption('format', null, InputOption::VALUE_REQUIRED, 'The output format (txt, json)', 'txt')
             ->setDescription('Lists Contao back end users.')
         ;
     }
@@ -61,7 +61,8 @@ class UserListCommand extends Command
         $columns = $input->getOption('column');
 
         switch ($input->getOption('format')) {
-            case 'text':
+            case 'txt':
+            case 'text': // Backwards compatibility
                 if (0 === $users->count()) {
                     $io->note('No accounts found.');
 


### PR DESCRIPTION
`txt` is the default we use in other commands and Symfony uses as well.