### PR TITLE
Add the pagination info to the page title

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Pagination.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Pagination.php
@@ -10,6 +10,8 @@
 
 namespace Contao;
 
+use Contao\CoreBundle\Routing\ResponseContext\HtmlHeadBag\HtmlHeadBag;
+
 /**
  * Provide methods to render a pagination menu.
  *
@@ -293,6 +295,15 @@ class Pagination
 
 		$objTemplate->class = 'pagination-' . $this->strParameter;
 		$objTemplate->pagination = StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['pagination']);
+
+		$responseContext = System::getContainer()->get('contao.routing.response_context_accessor')->getResponseContext();
+
+		if ($responseContext && $responseContext->has(HtmlHeadBag::class))
+		{
+			/** @var HtmlHeadBag $htmlHeadBag */
+			$htmlHeadBag = $responseContext->get(HtmlHeadBag::class);
+			$htmlHeadBag->setTitle(sprintf($htmlHeadBag->getTitle(), ' - ' . sprintf($GLOBALS['TL_LANG']['MSC']['totalPages'], $this->intPage, $this->intTotalPages)));
+		}
 
 		// Adding rel="prev" and rel="next" links is not possible
 		// anymore with unique variable names (see #3515 and #4141)

--- a/core-bundle/src/Resources/contao/pages/PageRegular.php
+++ b/core-bundle/src/Resources/contao/pages/PageRegular.php
@@ -215,6 +215,7 @@ class PageRegular extends Frontend
 			}
 		}
 
+		/** @var HtmlHeadBag $headBag */
 		$headBag = $this->responseContext->get(HtmlHeadBag::class);
 
 		// Set the page title and description AFTER the modules have been generated


### PR DESCRIPTION
Implements #2523

@contao/developers To prevent that the pagination information is added multiple times (e.g. if there are multiple pagination menus on the same page), I am adding the menu with `sprintf()`. This also implies that people will have to add `%s` to the page title of the page to use the feature.

Is this a good approach or would you prefer to add the pagination info automatically?