### PR TITLE
Deprecate System::getTimeZones()

### DIFF
--- a/core-bundle/src/Resources/contao/config/default.php
+++ b/core-bundle/src/Resources/contao/config/default.php
@@ -19,7 +19,7 @@ $GLOBALS['TL_CONFIG']['folderUrl']      = true;
 $GLOBALS['TL_CONFIG']['datimFormat'] = 'Y-m-d H:i';
 $GLOBALS['TL_CONFIG']['dateFormat']  = 'Y-m-d';
 $GLOBALS['TL_CONFIG']['timeFormat']  = 'H:i';
-$GLOBALS['TL_CONFIG']['timeZone']    = ini_get('date.timezone') ?: 'GMT';
+$GLOBALS['TL_CONFIG']['timeZone']    = date_default_timezone_get();
 
 // Input and security
 $GLOBALS['TL_CONFIG']['allowedTags']

--- a/core-bundle/src/Resources/contao/config/timezones.php
+++ b/core-bundle/src/Resources/contao/config/timezones.php
@@ -8,6 +8,8 @@
  * @license LGPL-3.0-or-later
  */
 
+trigger_deprecation('contao/core-bundle', '4.13', 'Using the timezones.php file has been deprecated and will no longer work in Contao 5.0. Use the intl library instead.');
+
 $timezones = array
 (
 	'General' => array

--- a/core-bundle/src/Resources/contao/dca/tl_settings.php
+++ b/core-bundle/src/Resources/contao/dca/tl_settings.php
@@ -9,7 +9,6 @@
  */
 
 use Contao\StringUtil;
-use Contao\System;
 
 $GLOBALS['TL_DCA']['tl_settings'] = array
 (
@@ -50,7 +49,7 @@ $GLOBALS['TL_DCA']['tl_settings'] = array
 			'inputType'               => 'select',
 			'options_callback' => static function ()
 			{
-				return System::getTimeZones();
+				return array_values(DateTimeZone::listIdentifiers());
 			},
 			'eval'                    => array('chosen'=>true, 'tl_class'=>'w50')
 		),

--- a/core-bundle/src/Resources/contao/library/Contao/System.php
+++ b/core-bundle/src/Resources/contao/library/Contao/System.php
@@ -638,6 +638,8 @@ abstract class System
 	 */
 	public static function getTimeZones()
 	{
+		trigger_deprecation('contao/core-bundle', '4.13', 'Using the %s method has been deprecated and will no longer work in Contao 5.0. Use the DateTimeZone::listIdentifiers() instead.', __METHOD__);
+
 		$arrReturn = array();
 		$timezones = array();
 

--- a/core-bundle/tests/Contao/ControllerTest.php
+++ b/core-bundle/tests/Contao/ControllerTest.php
@@ -32,8 +32,14 @@ class ControllerTest extends TestCase
 {
     use ExpectDeprecationTrait;
 
+    /**
+     * @group legacy
+     */
     public function testReturnsTheTimeZones(): void
     {
+        $this->expectDeprecation('%sgetTimeZones%shas been deprecated%s');
+        $this->expectDeprecation('%stimezones.php%s');
+
         $timeZones = System::getTimeZones();
 
         $this->assertCount(9, $timeZones['General']);


### PR DESCRIPTION
Fixes #3661

While looking at this code, I realized, that we currently set the default time zone when initializing the framework in https://github.com/contao/contao/blob/6a815a472a46c44c4dbf3885f44c229a26fb8510/core-bundle/src/Framework/ContaoFramework.php#L361-L367 I’m not sure if this is a good idea as Symfony code that runs before our framework potentially has a different time zone set then.

I think we should deprecate the `timeZone` setting and remove it in Contao 5.0