### PR TITLE
Reworked preview toolbar using Shadow DOM

### DIFF
--- a/core-bundle/src/Resources/views/Frontend/preview_toolbar_base_js.html.twig
+++ b/core-bundle/src/Resources/views/Frontend/preview_toolbar_base_js.html.twig
@@ -198,7 +198,7 @@
 
         const toolbar = document.createElement('div');
         toolbar.classList.add('cto-toolbar');
-        shadow.appendChild(toolbar);
+        toolbarWrapper.shadowRoot.appendChild(toolbar);
 
         function request(method, uri, body, callback, addClass = true) {
             body = body || null;

--- a/core-bundle/src/Resources/views/Frontend/preview_toolbar_base_js.html.twig
+++ b/core-bundle/src/Resources/views/Frontend/preview_toolbar_base_js.html.twig
@@ -1,4 +1,11 @@
-<style>
+<style cto-toolbar>
+    cto-toolbar {
+        display: block;
+        position: fixed;
+        top: 0;
+        left: 0;
+        z-index: 99999;
+    }
     .cto-toolbar {
         font-family: -apple-system,system-ui,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
         font-weight: 400;
@@ -180,9 +187,19 @@
 </style>
 <script>
     (function () {
+
+        const toolbarWrapper = document.createElement('cto-toolbar');
+        document.querySelector('body').prepend(toolbarWrapper);
+
+        const shadow = toolbarWrapper.attachShadow({mode: 'open'});
+        toolbarWrapper.appendChild(shadow);
+
+        const css = document.querySelector('style[cto-toolbar]');
+        shadow.innerHTML = css.outerHTML;
+
         const toolbar = document.createElement('div');
         toolbar.classList.add('cto-toolbar');
-        document.querySelector('body').prepend(toolbar);
+        shadow.appendChild(toolbar);
 
         function request(method, uri, body, callback, addClass = true) {
             body = body || null;
@@ -248,29 +265,32 @@
 
             if (document.createElement('datalist') && window.HTMLDataListElement) {
                 const userField = form.querySelector('input[name="user"]');
+                let timer;
 
                 if (userField) {
                     userField.addEventListener('input', function () {
                         if (userField.value.length < 2) {
                             return;
                         }
-
-                        const body = {
-                            FORM_SUBMIT: 'datalist_members',
-                            REQUEST_TOKEN: form.querySelector('input[name="REQUEST_TOKEN"]').value,
-                            value: userField.value
-                        };
-
-                        const userList = form.querySelector('datalist[id="userlist"]');
-
-                        request('POST', form.action, new URLSearchParams(body), function () {
-                            userList.innerHTML = '';
-                            JSON.parse(this.response).forEach(item => {
-                                const option = document.createElement('option');
-                                option.value = item;
-                                userList.appendChild(option);
-                            });
-                        }, false);
+                        if (timer) {
+                            clearTimeout(timer);
+                        }
+                        timer = setTimeout(function () {
+                            const body = {
+                                FORM_SUBMIT: 'datalist_members',
+                                REQUEST_TOKEN: form.querySelector('input[name="REQUEST_TOKEN"]').value,
+                                value: userField.value
+                            };
+                            const userList = form.querySelector('datalist[id="userlist"]');
+                            request('POST', form.action, new URLSearchParams(body), function () {
+                                userList.innerHTML = '';
+                                JSON.parse(this.response).forEach(item => {
+                                    const option = document.createElement('option');
+                                    option.value = item;
+                                    userList.appendChild(option);
+                                });
+                            }, false);
+                        }, 300);
                     });
                 }
             }

--- a/core-bundle/src/Resources/views/Frontend/preview_toolbar_base_js.html.twig
+++ b/core-bundle/src/Resources/views/Frontend/preview_toolbar_base_js.html.twig
@@ -191,8 +191,7 @@
         const toolbarWrapper = document.createElement('cto-toolbar');
         document.querySelector('body').prepend(toolbarWrapper);
 
-        const shadow = toolbarWrapper.attachShadow({mode: 'open'});
-        toolbarWrapper.appendChild(shadow);
+        toolbarWrapper.attachShadow({mode: 'open'});
 
         const css = document.querySelector('style[cto-toolbar]');
         shadow.innerHTML = css.outerHTML;


### PR DESCRIPTION
Using the magic of Shadow DOM it should be possible to make the styling of the preview toolbar truly independent of any CSS that might come with the users theme.

Quote from my comment in #3688:

- Created a wrapper element to encapsulate the whole thing
- Created the actual Shadow DOM with mode `open` so the contents can be modified by the rest of the JS and attached it to the wrapper (needed for the `copyButton` to work)
- Moved all the toolbar related styles inside the Shadow DOM
- Attaching the "original" toolbar-DIV to the Shadow DOM

Feel free to play around with it. 

I tested it by adding

```css
.formbody button {
    background: red !important;
    width: 500px;
    height: 500px;
}
```

to the main stylesheet of the page which would of course totally destroy the styling of the buttons but with Shadow DOM this doesn't bother the toolbar at all 😁