### PR TITLE
Fix memory issues in the backup command

### DIFF
--- a/core-bundle/src/Doctrine/Backup/Dumper.php
+++ b/core-bundle/src/Doctrine/Backup/Dumper.php
@@ -90,7 +90,7 @@ class Dumper implements DumperInterface
 
         $rows = $connection->executeQuery(sprintf('SELECT %s FROM `%s`', implode(', ', $values), $table->getName()));
 
-        foreach ($rows->fetchAllAssociative() as $row) {
+        foreach ($rows->iterateAssociative() as $row) {
             $insertColumns = [];
             $insertValues = [];
 


### PR DESCRIPTION
I had issues on a client system with memory limit being hit when running `contao:migrate`. This change correctly uses streaming instead of fetching all rows.