### PR TITLE
Fix type error when creating website root

### DIFF
--- a/core-bundle/src/Routing/Page/PageRoute.php
+++ b/core-bundle/src/Routing/Page/PageRoute.php
@@ -43,7 +43,7 @@ class PageRoute extends Route implements RouteObjectInterface
                 '_token_check' => true,
                 '_controller' => 'Contao\FrontendIndex::renderPage',
                 '_scope' => ContaoCoreBundle::SCOPE_FRONTEND,
-                '_locale' => LocaleUtil::formatAsLocale($pageModel->rootLanguage),
+                '_locale' => LocaleUtil::formatAsLocale($pageModel->rootLanguage ?? ''),
                 '_format' => 'html',
                 '_canonical_route' => 'tl_page.'.$pageModel->id,
             ],


### PR DESCRIPTION
Currently if you want to create a new website root, the following error occurs:

```
TypeError:
Argument 1 passed to Contao\CoreBundle\Util\LocaleUtil::formatAsLocale() must be of the type string, null given, called in vendor\contao\contao\core-bundle\src\Routing\Page\PageRoute.php on line 46

  at vendor\contao\contao\core-bundle\src\Util\LocaleUtil.php:108
  at Contao\CoreBundle\Util\LocaleUtil::formatAsLocale(null)
     (vendor\contao\contao\core-bundle\src\Routing\Page\PageRoute.php:46)
  at Contao\CoreBundle\Routing\Page\PageRoute->__construct(object(PageModel), '/d779ee982b2789a8f6bb{!parameters}', array('parameters' => ''), array('parameters' => '(/.+?)?'), array(), array())
     (vendor\contao\contao\core-bundle\src\Routing\Page\PageRegistry.php:72)
  at Contao\CoreBundle\Routing\Page\PageRegistry->getRoute(object(PageModel))
     (vendor\contao\contao\core-bundle\src\Routing\PageUrlGenerator.php:48)
  at Contao\CoreBundle\Routing\PageUrlGenerator->generate('cmf_routing_object', array('_content' => object(PageModel), 'parameters' => null), 0)
     (vendor\symfony-cmf\routing\src\DynamicRouter.php:180)
  at Symfony\Cmf\Component\Routing\DynamicRouter->generate('cmf_routing_object', array('_content' => object(PageModel), 'parameters' => null), 0)
     (vendor\symfony-cmf\routing\src\ChainRouter.php:248)
  at Symfony\Cmf\Component\Routing\ChainRouter->generate('cmf_routing_object', array('_content' => object(PageModel), 'parameters' => null), 0)
     (vendor\contao\contao\core-bundle\src\Resources\contao\models\PageModel.php:1346)
  at Contao\PageModel->getAbsoluteUrl()
     (vendor\contao\contao\core-bundle\src\Resources\contao\dca\tl_page.php:1071)
  at tl_page->getSerpUrl(object(PageModel))
     (vendor\contao\contao\core-bundle\src\Resources\contao\widgets\SerpPreview.php:159)
  at Contao\SerpPreview->getUrl(object(PageModel))
     (vendor\contao\contao\core-bundle\src\Resources\contao\widgets\SerpPreview.php:51)
  at Contao\SerpPreview->generate()
     (vendor\contao\contao\core-bundle\src\Resources\contao\library\Contao\Widget.php:654)
  at Contao\Widget->generateWithError(true)
     (vendor\contao\contao\core-bundle\src\Resources\contao\templates\backend\be_widget.html5:3)
  at include('vendor\\contao\\contao\\core-bundle\\src\\Resources\\contao\\templates\\backend\\be_widget.html5')
     (vendor\contao\contao\core-bundle\src\Resources\contao\library\Contao\TemplateInheritance.php:112)
  at Contao\Widget->inherit()
     (vendor\contao\contao\core-bundle\src\Resources\contao\library\Contao\Widget.php:601)
  at Contao\Widget->parse()
     (vendor\contao\contao\core-bundle\src\Resources\contao\classes\DataContainer.php:780)
  at Contao\DataContainer->row('{title_legend},type,title,alias;{meta_legend},pageTitle,robots,description,serpPreview;{canonical_legend:hide},canonicalLink,canonicalKeepParams;{protected_legend:hide},protected;{layout_legend:hide},includeLayout;{cache_legend:hide},includeCache;{chmod_legend:hide},includeChmod;{expert_legend:hide},cssClass,sitemap,hide,noSearch,guests,requireItem;{newsmenu_legend},addNewsMenuItems;{tabnav_legend:hide},tabindex,accesskey;{publish_legend},published,start,stop')
     (vendor\contao\contao\core-bundle\src\Resources\contao\drivers\DC_Table.php:1948)
  at Contao\DC_Table->edit()
     (vendor\contao\contao\core-bundle\src\Resources\contao\classes\Backend.php:653)
  at Contao\Backend->getBackendModule('page', null)
     (vendor\contao\contao\core-bundle\src\Resources\contao\controllers\BackendMain.php:163)
  at Contao\BackendMain->run()
     (vendor\contao\contao\core-bundle\src\Controller\BackendController.php:49)
  at Contao\CoreBundle\Controller\BackendController->mainAction()
     (vendor\symfony\http-kernel\HttpKernel.php:152)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw(object(Request), 1)
     (vendor\symfony\http-kernel\HttpKernel.php:74)
  at Symfony\Component\HttpKernel\HttpKernel->handle(object(Request), 1, true)
     (vendor\symfony\http-kernel\Kernel.php:202)
  at Symfony\Component\HttpKernel\Kernel->handle(object(Request))
     (public\index.php:44)
  at require('public\\index.php')
     (public\app.php:13)                
```

This is because the root language will be null initially - however the `PageRoute` will already be initialised on the empty website root.

@aschempp or do you have a better idea on how to prevent this may be?