### PR TITLE
Fix boolean empty value for doctrine 3

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Widget.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Widget.php
@@ -1491,14 +1491,9 @@ abstract class Widget extends Controller
 					return null;
 				}
 
-				if (\in_array($sql['type'], array(Types::BIGINT, Types::DECIMAL, Types::INTEGER, Types::SMALLINT, Types::FLOAT)))
+				if (\in_array($sql['type'], array(Types::BIGINT, Types::DECIMAL, Types::INTEGER, Types::SMALLINT, Types::FLOAT, Types::BOOLEAN)))
 				{
 					return 0;
-				}
-
-				if ($sql['type'] === Types::BOOLEAN)
-				{
-					return false;
 				}
 
 				return '';


### PR DESCRIPTION
If you have a field like this:

```php
$GLOBALS['TL_DCA']['tl_page']['fields']['addNewsMenuItems'] = [
    'exclude' => true,
    'inputType' => 'checkbox',
    'eval' => ['submitOnChange' => true],
    'sql' => ['type' => 'boolean', 'default' => false],
];
```

the following error will occur in the back end when saving the unchecked checkbox:

```
Doctrine\DBAL\Driver\PDO\Exception:
SQLSTATE[22007]: Invalid datetime format: 1366 Incorrect integer value: '' for column `c412dev`.`tl_page`.`addNewsMenuItems` at row 1

  at vendor\doctrine\dbal\src\Driver\PDO\Exception.php:26
  at Doctrine\DBAL\Driver\PDO\Exception::new(object(PDOException))
     (vendor\doctrine\dbal\src\Driver\PDO\Statement.php:97)
  at Doctrine\DBAL\Driver\PDO\Statement->execute(array(false, '43'))
     (vendor\doctrine\dbal\src\Connection.php:1031)
  at Doctrine\DBAL\Connection->executeQuery('UPDATE tl_page SET `addNewsMenuItems`=? WHERE id=?', array(false, '43'))
     (vendor\contao\contao\core-bundle\src\Resources\contao\library\Contao\Database\Statement.php:286)
  at Contao\Database\Statement->query('', array(false, '43'))
     (vendor\contao\contao\core-bundle\src\Resources\contao\library\Contao\Database\Statement.php:242)
  at Contao\Database\Statement->execute(array(false, '43'))
     (vendor\contao\contao\core-bundle\src\Resources\contao\drivers\DC_Table.php:3248)
  at Contao\DC_Table->save(false)
     (vendor\contao\contao\core-bundle\src\Resources\contao\classes\DataContainer.php:515)
  at Contao\DataContainer->row('{title_legend},type,title,alias;{meta_legend},pageTitle,robots,description,serpPreview;{canonical_legend:hide},canonicalLink,canonicalKeepParams;{protected_legend:hide},protected;{layout_legend:hide},includeLayout;{cache_legend:hide},includeCache;{chmod_legend:hide},includeChmod;{expert_legend:hide},cssClass,sitemap,hide,noSearch,guests,requireItem;{newsmenu_legend},addNewsMenuItems;{tabnav_legend:hide},tabindex,accesskey;{publish_legend},published,start,stop')
     (vendor\contao\contao\core-bundle\src\Resources\contao\drivers\DC_Table.php:1948)
  at Contao\DC_Table->edit()
     (vendor\contao\contao\core-bundle\src\Resources\contao\classes\Backend.php:653)
  at Contao\Backend->getBackendModule('page', null)
     (vendor\contao\contao\core-bundle\src\Resources\contao\controllers\BackendMain.php:163)
  at Contao\BackendMain->run()
     (vendor\contao\contao\core-bundle\src\Controller\BackendController.php:49)
  at Contao\CoreBundle\Controller\BackendController->mainAction()
     (vendor\symfony\http-kernel\HttpKernel.php:152)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw(object(Request), 1)
     (vendor\symfony\http-kernel\HttpKernel.php:74)
  at Symfony\Component\HttpKernel\HttpKernel->handle(object(Request), 1, true)
     (vendor\symfony\http-kernel\Kernel.php:202)
  at Symfony\Component\HttpKernel\Kernel->handle(object(Request))
     (public\index.php:44)
  at require('public\\index.php')
     (public\app.php:13)   
```

The error is quite odd. The Symfony profiler shows the following database query being executed:

![image](https://user-images.githubusercontent.com/4970961/148564189-35febecc-7551-4512-befe-2af0e0ebf570.png)

The stack trace also shows that the value `false` is used, and not an empty string. However, for some reason this is causing this exception somewhere inside Doctrine. Providing `0` instead of `false` works - and so this PR changes the empty field value for boolean types also to `0`.

This error does not occur in Contao 4.12.