### PR TITLE
Fix the ScriptHandlers for Composer 2.3

### DIFF
--- a/core-bundle/tests/Composer/ScriptHandlerTest.php
+++ b/core-bundle/tests/Composer/ScriptHandlerTest.php
@@ -171,17 +171,17 @@ class ScriptHandlerTest extends TestCase
         );
 
         $this->assertSame(
-            ' -v',
+            '-v',
             $method->invokeArgs($this->handler, [$this->getComposerEvent([], 'isVerbose')])
         );
 
         $this->assertSame(
-            ' -vv',
+            '-vv',
             $method->invokeArgs($this->handler, [$this->getComposerEvent([], 'isVeryVerbose')])
         );
 
         $this->assertSame(
-            ' -vvv',
+            '-vvv',
             $method->invokeArgs($this->handler, [$this->getComposerEvent([], 'isDebug')])
         );
     }


### PR DESCRIPTION
Composer 2.3 will currently break our ScriptHandlers, because the PHP and `symfony/process` requirement of Composer are finally bumped up (https://github.com/composer/composer/commit/d2ede370be20aedfc74749bc87394a79ed4c1e52). 

```
Fatal error: Uncaught TypeError: Argument 1 passed to Symfony\Component\Process\Process::__construct() must be of the type array, string given, called in vendor\contao\contao\manager-bundle\src\Composer\ScriptHandler.php on line 69
```

This PR backports the changes from Contao 4.10 to 4.9, where the `symfony/process` cross-compatibility was already introduced.