### PR TITLE
Do not generate URLs for insert tags that don’t need it

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/InsertTags.php
+++ b/core-bundle/src/Resources/contao/library/Contao/InsertTags.php
@@ -436,8 +436,9 @@ class InsertTags extends Controller
 							break;
 						}
 
-						// Do not generate URL for insert tags that don't need it
 						$strUrl = '';
+
+						// Do not generate URL for insert tags that don't need it
 						if (\in_array(strtolower($elements[0]), array('link', 'link_open', 'link_url'), true))
 						{
 							switch ($objNextPage->type)

--- a/core-bundle/src/Resources/contao/library/Contao/InsertTags.php
+++ b/core-bundle/src/Resources/contao/library/Contao/InsertTags.php
@@ -436,6 +436,23 @@ class InsertTags extends Controller
 							break;
 						}
 
+						$strName = $objNextPage->title;
+						$strTarget = $objNextPage->target ? ' target="_blank" rel="noreferrer noopener"' : '';
+						$strClass = $objNextPage->cssClass ? sprintf(' class="%s"', $objNextPage->cssClass) : '';
+						$strTitle = $objNextPage->pageTitle ?: $objNextPage->title;
+
+						// Early return for tags that do not need the URL
+						switch (strtolower($elements[0]))
+						{
+							case 'link_title':
+								$arrCache[$strTag] = StringUtil::specialcharsAttribute($strTitle);
+								break 2;
+
+							case 'link_name':
+								$arrCache[$strTag] = StringUtil::specialcharsAttribute($strName);
+								break 2;
+						}
+
 						// Page type specific settings (thanks to Andreas Schempp)
 						switch ($objNextPage->type)
 						{
@@ -469,11 +486,6 @@ class InsertTags extends Controller
 								$strUrl = \in_array('absolute', $flags, true) ? $objNextPage->getAbsoluteUrl() : $objNextPage->getFrontendUrl();
 								break;
 						}
-
-						$strName = $objNextPage->title;
-						$strTarget = $objNextPage->target ? ' target="_blank" rel="noreferrer noopener"' : '';
-						$strClass = $objNextPage->cssClass ? sprintf(' class="%s"', $objNextPage->cssClass) : '';
-						$strTitle = $objNextPage->pageTitle ?: $objNextPage->title;
 					}
 
 					// Replace the tag

--- a/core-bundle/src/Resources/contao/library/Contao/InsertTags.php
+++ b/core-bundle/src/Resources/contao/library/Contao/InsertTags.php
@@ -436,56 +436,48 @@ class InsertTags extends Controller
 							break;
 						}
 
+						// Do not generate URL for insert tags that don't need it
+						$strUrl = '';
+						if (\in_array(strtolower($elements[0]), array('link', 'link_open', 'link_url'), true))
+						{
+							switch ($objNextPage->type)
+							{
+								case 'redirect':
+									$strUrl = $objNextPage->url;
+
+									if (strncasecmp($strUrl, 'mailto:', 7) === 0)
+									{
+										$strUrl = StringUtil::encodeEmail($strUrl);
+									}
+									break;
+
+								case 'forward':
+									if ($objNextPage->jumpTo)
+									{
+										$objNext = PageModel::findPublishedById($objNextPage->jumpTo);
+									}
+									else
+									{
+										$objNext = PageModel::findFirstPublishedRegularByPid($objNextPage->id);
+									}
+
+									if ($objNext instanceof PageModel)
+									{
+										$strUrl = \in_array('absolute', $flags, true) ? $objNext->getAbsoluteUrl() : $objNext->getFrontendUrl();
+										break;
+									}
+									// no break
+
+								default:
+									$strUrl = \in_array('absolute', $flags, true) ? $objNextPage->getAbsoluteUrl() : $objNextPage->getFrontendUrl();
+									break;
+							}
+						}
+
 						$strName = $objNextPage->title;
 						$strTarget = $objNextPage->target ? ' target="_blank" rel="noreferrer noopener"' : '';
 						$strClass = $objNextPage->cssClass ? sprintf(' class="%s"', $objNextPage->cssClass) : '';
 						$strTitle = $objNextPage->pageTitle ?: $objNextPage->title;
-
-						// Early return for tags that do not need the URL
-						switch (strtolower($elements[0]))
-						{
-							case 'link_title':
-								$arrCache[$strTag] = StringUtil::specialcharsAttribute($strTitle);
-								break 2;
-
-							case 'link_name':
-								$arrCache[$strTag] = StringUtil::specialcharsAttribute($strName);
-								break 2;
-						}
-
-						// Page type specific settings (thanks to Andreas Schempp)
-						switch ($objNextPage->type)
-						{
-							case 'redirect':
-								$strUrl = $objNextPage->url;
-
-								if (strncasecmp($strUrl, 'mailto:', 7) === 0)
-								{
-									$strUrl = StringUtil::encodeEmail($strUrl);
-								}
-								break;
-
-							case 'forward':
-								if ($objNextPage->jumpTo)
-								{
-									$objNext = PageModel::findPublishedById($objNextPage->jumpTo);
-								}
-								else
-								{
-									$objNext = PageModel::findFirstPublishedRegularByPid($objNextPage->id);
-								}
-
-								if ($objNext instanceof PageModel)
-								{
-									$strUrl = \in_array('absolute', $flags, true) ? $objNext->getAbsoluteUrl() : $objNext->getFrontendUrl();
-									break;
-								}
-								// no break
-
-							default:
-								$strUrl = \in_array('absolute', $flags, true) ? $objNextPage->getAbsoluteUrl() : $objNextPage->getFrontendUrl();
-								break;
-						}
 					}
 
 					// Replace the tag


### PR DESCRIPTION
It makes no sense to call routing and generate a URL if the insert tag does not need it. It also unnecessarily prevents these insert tags from working in Contao 4.12/4.13 if the page URL cannot be generated (non-routable / requires parameter).

FYI I intentionally did not remove the `case` for the same tags in the later method because it is required for non-regular pages (the new switch-case is inside an if-else handling).