### PR TITLE
Fixed tl_page permissions for routing fields

### DIFF
--- a/core-bundle/src/Resources/contao/dca/tl_page.php
+++ b/core-bundle/src/Resources/contao/dca/tl_page.php
@@ -227,14 +227,6 @@ $GLOBALS['TL_DCA']['tl_page'] = array
 			'eval'                    => array('mandatory'=>true, 'maxlength'=>255, 'tl_class'=>'w50'),
 			'sql'                     => "varchar(255) NOT NULL default ''"
 		),
-		'alias' => array
-		(
-			'exclude'                 => true,
-			'search'                  => true,
-			'inputType'               => 'text',
-			'eval'                    => array('rgxp'=>'folderalias', 'doNotCopy'=>true, 'maxlength'=>255, 'tl_class'=>'w50'),
-			'sql'                     => "varchar(255) BINARY NOT NULL default ''"
-		),
 		'type' => array
 		(
 			'exclude'                 => true,
@@ -244,20 +236,38 @@ $GLOBALS['TL_DCA']['tl_page'] = array
 			'reference'               => &$GLOBALS['TL_LANG']['PTY'],
 			'sql'                     => "varchar(64) NOT NULL default 'regular'"
 		),
+		'alias' => array
+		(
+			'exclude'                 => true,
+			'search'                  => true,
+			'inputType'               => 'text',
+			'eval'                    => array('rgxp'=>'folderalias', 'doNotCopy'=>true, 'maxlength'=>255, 'tl_class'=>'w50'),
+			'sql'                     => "varchar(255) BINARY NOT NULL default ''"
+		),
+		'requireItem' => array
+		(
+			'exclude'                 => true,
+			'inputType'               => 'checkbox',
+			'eval'                    => array('tl_class'=>'w50 m12'),
+			'sql'                     => "char(1) NOT NULL default ''"
+		),
 		'routePath' => array
 		(
+			'exclude'                 => true,
 			'inputType'               => 'text',
 			'eval'                    => array('disabled'=>true, 'tl_class'=>'w50 clr'),
 			// load_callback from PageRoutingListener
 		),
 		'routePriority' => array
 		(
+			'exclude'                 => true,
 			'inputType'               => 'text',
 			'eval'                    => array('tl_class'=>'w50'),
 			'sql'                     => "int(10) NOT NULL default 0"
 		),
 		'routeConflicts' => array
 		(
+			'exclude'                 => true,
 			// input_field_callback from PageRoutingListener
 		),
 		'pageTitle' => array
@@ -660,13 +670,6 @@ $GLOBALS['TL_DCA']['tl_page'] = array
 			'filter'                  => true,
 			'inputType'               => 'checkbox',
 			'eval'                    => array('tl_class'=>'w50'),
-			'sql'                     => "char(1) NOT NULL default ''"
-		),
-		'requireItem' => array
-		(
-			'exclude'                 => true,
-			'inputType'               => 'checkbox',
-			'eval'                    => array('tl_class'=>'w50 m12'),
 			'sql'                     => "char(1) NOT NULL default ''"
 		),
 		'cssClass' => array

--- a/core-bundle/src/Resources/contao/languages/en/tl_page.xlf
+++ b/core-bundle/src/Resources/contao/languages/en/tl_page.xlf
@@ -8,17 +8,23 @@
       <trans-unit id="tl_page.title.1">
         <source>Please enter the page name.</source>
       </trans-unit>
+      <trans-unit id="tl_page.type.0">
+        <source>Page type</source>
+      </trans-unit>
+      <trans-unit id="tl_page.type.1">
+        <source>Please choose the page type.</source>
+      </trans-unit>
       <trans-unit id="tl_page.alias.0">
         <source>Page alias</source>
       </trans-unit>
       <trans-unit id="tl_page.alias.1">
         <source>The page alias is a unique reference to the page which can be called instead of its numeric ID.</source>
       </trans-unit>
-      <trans-unit id="tl_page.type.0">
-        <source>Page type</source>
+      <trans-unit id="tl_page.requireItem.0">
+        <source>Require an item</source>
       </trans-unit>
-      <trans-unit id="tl_page.type.1">
-        <source>Please choose the page type.</source>
+      <trans-unit id="tl_page.requireItem.1">
+        <source>Trigger a 404 error if the page URL does not contain an item alias.</source>
       </trans-unit>
       <trans-unit id="tl_page.routePath.0">
         <source>Route path</source>
@@ -284,12 +290,6 @@
       <trans-unit id="tl_page.noSearch.1">
         <source>Exclude the page from the search index.</source>
       </trans-unit>
-      <trans-unit id="tl_page.requireItem.0">
-        <source>Require an item</source>
-      </trans-unit>
-      <trans-unit id="tl_page.requireItem.1">
-        <source>Trigger a 404 error if the page URL does not contain an item alias.</source>
-      </trans-unit>
       <trans-unit id="tl_page.cssClass.0">
         <source>CSS class</source>
       </trans-unit>
@@ -473,7 +473,7 @@
       <trans-unit id="tl_page.legacyRouting">
         <source>Disable legacy routing mode to enable this configuration.</source>
       </trans-unit>
-      <trans-unit id="tl_page.routeConflicts">
+      <trans-unit id="tl_page.routeConflicts.0">
         <source>Route conflicts</source>
       </trans-unit>
       <trans-unit id="tl_page.conflictingAlias">

--- a/core-bundle/src/Resources/contao/languages/en/tl_page.xlf
+++ b/core-bundle/src/Resources/contao/languages/en/tl_page.xlf
@@ -476,7 +476,7 @@
       <trans-unit id="tl_page.routeConflicts.0">
         <source>Route conflicts</source>
       </trans-unit>
-      <trans-unit id="tl_page.conflictingAlias">
+      <trans-unit id="tl_page.routeConflicts.1">
         <source>The following pages have a similar alias that may conflict with this page. If the URL is not resolved correctly, try changing the priority of the routes.</source>
       </trans-unit>
       <trans-unit id="CACHE.0">

--- a/core-bundle/src/Resources/views/Backend/be_route_conflicts.html.twig
+++ b/core-bundle/src/Resources/views/Backend/be_route_conflicts.html.twig
@@ -2,7 +2,7 @@
 <div class="clr widget">
     <h3>{{ 'tl_page.routeConflicts.0'|trans }}</h3>
     <div class="tl_info">
-        <p>{{ 'tl_page.conflictingAlias'|trans }}</p>
+        <p>{{ 'tl_page.routeConflicts.1'|trans }}</p>
         <table class="tl_listing showColumns">
             <tbody>
             <tr>

--- a/core-bundle/src/Resources/views/Backend/be_route_conflicts.html.twig
+++ b/core-bundle/src/Resources/views/Backend/be_route_conflicts.html.twig
@@ -1,6 +1,6 @@
 {% trans_default_domain 'contao_tl_page' %}
 <div class="clr widget">
-    <h3>{{ 'tl_page.routeConflicts'|trans }}</h3>
+    <h3>{{ 'tl_page.routeConflicts.0'|trans }}</h3>
     <div class="tl_info">
         <p>{{ 'tl_page.conflictingAlias'|trans }}</p>
         <table class="tl_listing showColumns">


### PR DESCRIPTION
I forgot to add `exclude => true` to the new routing fields, they would always be available to all users.

The label change is necessary for the field name to correctly show in permissions, otherwise only the first character of the translation would be shown.

Regarding `type` and `requireItem` fields, they are only reordered for the permission to closely match to the field order in the default palettes.