### PR TITLE
Update maintenance response and add to preview endpoint

### DIFF
--- a/manager-bundle/src/Resources/skeleton/public/index.php
+++ b/manager-bundle/src/Resources/skeleton/public/index.php
@@ -27,10 +27,10 @@ if (in_array('phar', stream_get_wrappers(), true)) {
 if (file_exists(__DIR__.'/../var/maintenance.html')) {
     $contents = file_get_contents(__DIR__.'/../var/maintenance.html');
 
-    header('HTTP/1.1 503 Service Unavailable', true, 503);
-    header('Content-Type: text/html; charset=UTF-8', true, 503);
-    header('Content-Length: '.strlen($contents), true, 503);
-    header('Cache-Control: no-store', true, 503);
+    http_response_code(503);
+    header('Content-Type: text/html; charset=UTF-8');
+    header('Content-Length: '.strlen($contents));
+    header('Cache-Control: no-store');
 
     die($contents);
 }

--- a/manager-bundle/src/Resources/skeleton/public/preview.php
+++ b/manager-bundle/src/Resources/skeleton/public/preview.php
@@ -36,7 +36,6 @@ if (file_exists(__DIR__.'/../var/maintenance.html')) {
     die($contents);
 }
 
-
 /** @var ClassLoader $loader */
 $loader = require __DIR__.'/../vendor/autoload.php';
 

--- a/manager-bundle/src/Resources/skeleton/public/preview.php
+++ b/manager-bundle/src/Resources/skeleton/public/preview.php
@@ -24,6 +24,19 @@ if (in_array('phar', stream_get_wrappers(), true)) {
     stream_wrapper_unregister('phar');
 }
 
+// System maintenance mode comes first as it has to work even if the vendor directory does not exist
+if (file_exists(__DIR__.'/../var/maintenance.html')) {
+    $contents = file_get_contents(__DIR__.'/../var/maintenance.html');
+
+    http_response_code(503);
+    header('Content-Type: text/html; charset=UTF-8');
+    header('Content-Length: '.strlen($contents));
+    header('Cache-Control: no-store');
+
+    die($contents);
+}
+
+
 /** @var ClassLoader $loader */
 $loader = require __DIR__.'/../vendor/autoload.php';
 


### PR DESCRIPTION
Fixes https://github.com/contao/contao/pull/3737#discussion_r774685376

I have also added the maintenance response to the preview endpoint. I've already run into situations where I was deploying an update to an installation, and the front end as well as the back end is "locked" through the maintenance file. That's correct, since I'm updating Composer dependencies and the application most likely will not work. But the preview endpoint to the front end was still working, which makes no sense to me.