### PR TITLE
Fix rootPaste not being enabled for tl_page

### DIFF
--- a/core-bundle/src/Resources/contao/dca/tl_page.php
+++ b/core-bundle/src/Resources/contao/dca/tl_page.php
@@ -83,7 +83,8 @@ $GLOBALS['TL_DCA']['tl_page'] = array
 			'showRootTrails'          => true,
 			'icon'                    => 'pagemounts.svg',
 			'paste_button_callback'   => array('tl_page', 'pastePage'),
-			'panelLayout'             => 'filter;search'
+			'panelLayout'             => 'filter;search',
+			'rootPaste'               => true,
 		),
 		'label' => array
 		(


### PR DESCRIPTION
This fixes not being able to insert new website roots in `4.x` (supersedes #3918).