### PR TITLE
Explicitly set rootPaste, deprecate implicit rootPaste

### DIFF
--- a/core-bundle/src/Resources/contao/classes/DataContainer.php
+++ b/core-bundle/src/Resources/contao/classes/DataContainer.php
@@ -185,6 +185,12 @@ abstract class DataContainer extends Backend
 	protected $visibleRootTrails = array();
 
 	/**
+	 * If pasting at root level is allowed (permissions)
+	 * @var bool
+	 */
+	protected $rootPaste = false;
+
+	/**
 	 * WHERE clause of the database query
 	 * @var array
 	 */

--- a/core-bundle/src/Resources/contao/dca/tl_page.php
+++ b/core-bundle/src/Resources/contao/dca/tl_page.php
@@ -80,6 +80,7 @@ $GLOBALS['TL_DCA']['tl_page'] = array
 		'sorting' => array
 		(
 			'mode'                    => DataContainer::MODE_TREE,
+			'rootPaste'               => true,
 			'showRootTrails'          => true,
 			'icon'                    => 'pagemounts.svg',
 			'paste_button_callback'   => array('tl_page', 'pastePage'),
@@ -814,6 +815,7 @@ class tl_page extends Backend
 			$root = $this->User->pagemounts;
 		}
 
+		$GLOBALS['TL_DCA']['tl_page']['list']['sorting']['rootPaste'] = false;
 		$GLOBALS['TL_DCA']['tl_page']['list']['sorting']['root'] = $root;
 		$security = System::getContainer()->get('security.helper');
 

--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -3750,7 +3750,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 		$_buttons = '&nbsp;';
 
 		// Show paste button only if there are no root records specified
-		if ($blnClipboard && ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] ?? null) == self::MODE_TREE && (!$this->root || ($GLOBALS['TL_DCA'][$table]['list']['sorting']['rootPaste'] ?? null)) && Input::get('act') != 'select')
+		if ($blnClipboard && ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] ?? null) == self::MODE_TREE && $this->rootPaste && Input::get('act') != 'select')
 		{
 			// Call paste_button_callback (&$dc, $row, $table, $cr, $childs, $previous, $next)
 			if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['paste_button_callback'] ?? null))
@@ -4106,7 +4106,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 				// Regular tree (on cut: disable buttons of the page and all its childs to avoid circular references)
 				if (($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] ?? null) == self::MODE_TREE)
 				{
-					$_buttons .= (($arrClipboard['mode'] == 'cut' && ($blnCircularReference || $arrClipboard['id'] == $id)) || ($arrClipboard['mode'] == 'cutAll' && ($blnCircularReference || \in_array($id, $arrClipboard['id']))) || ($this->root && !$GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['rootPaste'] && \in_array($id, $this->root))) ? Image::getHtml('pasteafter_.svg') . ' ' : '<a href="' . $this->addToUrl('act=' . $arrClipboard['mode'] . '&amp;mode=1&amp;pid=' . $id . (!\is_array($arrClipboard['id']) ? '&amp;id=' . $arrClipboard['id'] : '')) . '" title="' . StringUtil::specialchars(sprintf($labelPasteAfter[1], $id)) . '" onclick="Backend.getScrollOffset()">' . $imagePasteAfter . '</a> ';
+					$_buttons .= (($arrClipboard['mode'] == 'cut' && ($blnCircularReference || $arrClipboard['id'] == $id)) || ($arrClipboard['mode'] == 'cutAll' && ($blnCircularReference || \in_array($id, $arrClipboard['id']))) || (!$this->rootPaste && \in_array($id, $this->root))) ? Image::getHtml('pasteafter_.svg') . ' ' : '<a href="' . $this->addToUrl('act=' . $arrClipboard['mode'] . '&amp;mode=1&amp;pid=' . $id . (!\is_array($arrClipboard['id']) ? '&amp;id=' . $arrClipboard['id'] : '')) . '" title="' . StringUtil::specialchars(sprintf($labelPasteAfter[1], $id)) . '" onclick="Backend.getScrollOffset()">' . $imagePasteAfter . '</a> ';
 					$_buttons .= (($arrClipboard['mode'] == 'cut' && ($blnCircularReference || $arrClipboard['id'] == $id)) || ($arrClipboard['mode'] == 'cutAll' && ($blnCircularReference || \in_array($id, $arrClipboard['id'])))) ? Image::getHtml('pasteinto_.svg') . ' ' : '<a href="' . $this->addToUrl('act=' . $arrClipboard['mode'] . '&amp;mode=2&amp;pid=' . $id . (!\is_array($arrClipboard['id']) ? '&amp;id=' . $arrClipboard['id'] : '')) . '" title="' . StringUtil::specialchars(sprintf($labelPasteInto[1], $id)) . '" onclick="Backend.getScrollOffset()">' . $imagePasteInto . '</a> ';
 				}
 
@@ -6192,6 +6192,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 	protected function initRoots()
 	{
 		$table = $this->strTable;
+		$this->rootPaste = $GLOBALS['TL_DCA'][$table]['list']['sorting']['rootPaste'] ?? false;
 
 		// Get the IDs of all root records (tree view)
 		if ($this->treeView)
@@ -6206,6 +6207,12 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 				if ($objIds->numRows > 0)
 				{
 					$this->root = $objIds->fetchEach('id');
+				}
+
+				if (!isset($GLOBALS['TL_DCA'][$table]['list']['sorting']['rootPaste']))
+				{
+					trigger_deprecation('contao/core-bundle', '4.13', 'Implicitly setting "TL_DCA.%s.list.sorting.rootPaste" to true by leaving "TL_DCA.%s.list.sorting.root" empty has been deprecated and will no longer work in Contao 5.0. Set "rootPaste" to true instead.', $table, $table);
+					$this->rootPaste = true;
 				}
 			}
 


### PR DESCRIPTION
Alternative to #3918

The current behavior is:
- If `list.sorting.root` is not set, pasting (and creating) at the root level is allowed
- If `list.sorting.root` is set, pasting at the root level is **NOT** allowed
- Unless `list.sorting.rootPaste` is set to `true` in which case pasting at the root level is always allowed

AFAIK the reason for this is that `list.sorting.root` was used to differentiate between admins (not set) and users (set to the configured mounts array).
`rootPaste` was only added as an afterthought recently (😉) in https://github.com/contao/core/issues/1312

This pull request changes the behavior by making `rootPaste` always take precedence and keeping BC by still enabling it if `list.sorting.root` is missing (together with a deprecation notice).

_BTW, `rootPaste` was only added for @aschempp it seems and was not used by the core until now ☺️_