### PR TITLE
Use target URL from redirect in route

### DIFF
--- a/core-bundle/src/Controller/Page/RedirectPageController.php
+++ b/core-bundle/src/Controller/Page/RedirectPageController.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Controller\Page;
+
+use Contao\CoreBundle\InsertTag\InsertTagParser;
+use Contao\CoreBundle\Routing\Page\DynamicRouteInterface;
+use Contao\CoreBundle\Routing\Page\PageRoute;
+use Contao\CoreBundle\ServiceAnnotation\Page;
+use Contao\PageModel;
+use Symfony\Bundle\FrameworkBundle\Controller\RedirectController;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @Page(contentComposition=false)
+ *
+ * @internal
+ */
+class RedirectPageController implements DynamicRouteInterface
+{
+    private InsertTagParser $insertTags;
+
+    public function __construct(InsertTagParser $insertTags)
+    {
+        $this->insertTags = $insertTags;
+    }
+
+    public function __invoke(PageModel $pageModel): Response
+    {
+        return new RedirectResponse(
+            $this->insertTags->render($pageModel->url),
+            'temporary' === $pageModel->redirect ? Response::HTTP_FOUND : Response::HTTP_MOVED_PERMANENTLY
+        );
+    }
+
+    public function configurePageRoute(PageRoute $route): void
+    {
+        $pageModel = $route->getPageModel();
+
+        $route->setDefault('_controller', RedirectController::class);
+        $route->setDefault('path', $this->insertTags->render($pageModel->url));
+        $route->setDefault('permanent', 'temporary' !== $pageModel->redirect);
+    }
+
+    public function getUrlSuffixes(): array
+    {
+        return [];
+    }
+}

--- a/core-bundle/src/Controller/Page/RootPageController.php
+++ b/core-bundle/src/Controller/Page/RootPageController.php
@@ -46,7 +46,7 @@ class RootPageController extends AbstractController implements DynamicRouteInter
 
         $route->setDefault('_controller', RedirectController::class);
         $route->setDefault('path', $nextPage->getAbsoluteUrl());
-        $route->setDefault('permanent', true);
+        $route->setDefault('permanent', false);
     }
 
     public function getUrlSuffixes(): array

--- a/core-bundle/src/Resources/config/controller.yml
+++ b/core-bundle/src/Resources/config/controller.yml
@@ -98,6 +98,10 @@ services:
         arguments:
             - '@contao.framework'
 
+    Contao\CoreBundle\Controller\Page\RedirectPageController:
+        arguments:
+            - '@contao.insert_tag.parser'
+
     Contao\CoreBundle\Controller\Page\RootPageController: ~
 
     Contao\CoreBundle\Controller\RobotsTxtController:

--- a/core-bundle/src/Routing/Page/PageRegistry.php
+++ b/core-bundle/src/Routing/Page/PageRegistry.php
@@ -17,7 +17,7 @@ use Doctrine\DBAL\Connection;
 
 class PageRegistry
 {
-    private const DISABLE_CONTENT_COMPOSITION = ['redirect', 'forward', 'logout'];
+    private const DISABLE_CONTENT_COMPOSITION = ['forward', 'logout'];
 
     private Connection $connection;
     private ?array $urlPrefixes = null;

--- a/core-bundle/src/Routing/PageUrlGenerator.php
+++ b/core-bundle/src/Routing/PageUrlGenerator.php
@@ -17,6 +17,7 @@ use Contao\CoreBundle\Routing\Page\PageRegistry;
 use Contao\CoreBundle\Routing\Page\PageRoute;
 use Contao\PageModel;
 use Psr\Log\LoggerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\RedirectController;
 use Symfony\Cmf\Component\Routing\RouteObjectInterface;
 use Symfony\Cmf\Component\Routing\RouteProviderInterface;
 use Symfony\Component\Routing\CompiledRoute;
@@ -56,6 +57,15 @@ class PageUrlGenerator extends SymfonyUrlGenerator
             unset($parameters[RouteObjectInterface::ROUTE_OBJECT]);
         } else {
             $route = $this->provider->getRouteByName($name);
+        }
+
+        // If route is a redirect to an absolute URL, use it directly as the route path
+        if (
+            $route->getDefault('_controller') === RedirectController::class
+            && !empty($path = $route->getDefault('path'))
+            && parse_url($path, \PHP_URL_SCHEME)
+        ) {
+            return $path;
         }
 
         /** @var CompiledRoute $compiledRoute */


### PR DESCRIPTION
Fixes the discussion in https://github.com/contao/contao/pull/3838/files#r775749282 that we need to duplicate the code handling for target page type in multiple places, yet again in the KnpMenu. Superseeds https://github.com/contao/contao/pull/2031 with a much simpler solution by just leveraging the Symfony redirect controller.

This means 2 things:
 - A page still has its route, as it previously did. E.g. a redirect page to `https://example.com/` can still be called in Contao through its domain and alias, and will then redirect. The redirect however happens directly through the Symfony RedirectController, because the target URL is already known. If the target URL cannot be generated (e.g. if a root page does not have a subpage), the original controller can still handle that case and throw an exception.

Since we now have the target URL in the route information, we can use it when **generating** a route. Which allows the route to generate non-internal links to pages! Instead of handling the two known types in every place (see initial link), we can simply to `$route->generate(RouteObjectInterface::OBJECT_BASED_ROUTE_NAME, [RouteObjectInterface::CONTENT_OBJECT => $pageModel]);`

**TODO:**
 - [ ] Requires https://github.com/contao/contao/pull/3930 to check for access permission to the redirect page
 - [ ] Not yet implemented the `ForwardPageController` just to get some feedback first