### PR TITLE
Various small filesystem tweaks

### DIFF
--- a/core-bundle/src/DependencyInjection/Filesystem/FilesystemConfiguration.php
+++ b/core-bundle/src/DependencyInjection/Filesystem/FilesystemConfiguration.php
@@ -184,6 +184,8 @@ class FilesystemConfiguration
         );
 
         $definition->setFactory(new Reference('contao.filesystem.dbafs_factory'));
+        $definition->addTag('kernel.reset', ['method' => 'reset']);
+
         $this->container->setDefinition("contao.filesystem.dbafs.$virtualFilesystemName", $definition);
 
         // Register the DBAFS in the DbafsManager using the same prefix as the

--- a/core-bundle/src/Filesystem/Dbafs/Dbafs.php
+++ b/core-bundle/src/Filesystem/Dbafs/Dbafs.php
@@ -271,9 +271,9 @@ class Dbafs implements DbafsInterface, ResetInterface
         return new FilesystemItem(
             $record['isFile'],
             $record['path'],
-            (int) ($record['lastModified'] ?? 0),
-            (int) ($record['fileSize'] ?? 0),
-            $record['mimeType'] ?? '',
+            isset($record['lastModified']) ? (int) ($record['lastModified']) : null,
+            isset($record['fileSize']) ? (int) ($record['fileSize']) : null,
+            $record['mimeType'] ?? null,
             $record['extra']
         );
     }

--- a/core-bundle/src/Filesystem/FilesystemItem.php
+++ b/core-bundle/src/Filesystem/FilesystemItem.php
@@ -30,12 +30,12 @@ class FilesystemItem
     private $lastModified;
 
     /**
-     * @var int|\Closure(self):int
+     * @var int|\Closure(self):int|null
      */
     private $fileSize;
 
     /**
-     * @var string|\Closure(self):string
+     * @var string|\Closure(self):string|null
      */
     private $mimeType;
 
@@ -46,11 +46,11 @@ class FilesystemItem
 
     /**
      * @param int|(\Closure(self):int|null)|null $lastModified
-     * @param int|\Closure(self):int $fileSize
-     * @param string|\Closure(self):string $mimeType
+     * @param int|\Closure(self):int|null $fileSize
+     * @param string|\Closure(self):string|null $mimeType
      * @param array<string, mixed>|\Closure(self):array<string, mixed> $extraMetadata
      */
-    public function __construct(bool $isFile, string $path, $lastModified = 0, $fileSize = 0, $mimeType = '', $extraMetadata = [])
+    public function __construct(bool $isFile, string $path, $lastModified = null, $fileSize = null, $mimeType = null, $extraMetadata = [])
     {
         $this->isFile = $isFile;
         $this->path = $path;
@@ -105,6 +105,23 @@ class FilesystemItem
         );
     }
 
+    /**
+     * @param int|(\Closure(self):int|null)|null $lastModified
+     * @param int|\Closure(self):int|null $fileSize
+     * @param string|\Closure(self):string|null $mimeType
+     */
+    public function withMetadataIfNotDefined($lastModified, $fileSize, $mimeType): self
+    {
+        return new self(
+            $this->isFile,
+            $this->path,
+            $this->lastModified ?? $lastModified,
+            $this->fileSize ?? $fileSize,
+            $this->mimeType ?? $mimeType,
+            $this->extraMetadata,
+        );
+    }
+
     public function withPath(string $path): self
     {
         return new self(
@@ -131,7 +148,6 @@ class FilesystemItem
     {
         $this->resolveIfClosure($this->lastModified);
 
-        /** @var ?int */
         return $this->lastModified;
     }
 
@@ -140,8 +156,7 @@ class FilesystemItem
         $this->assertIsFile(__FUNCTION__);
         $this->resolveIfClosure($this->fileSize);
 
-        /** @var int */
-        return $this->fileSize;
+        return $this->fileSize ?? 0;
     }
 
     public function getMimeType(): string
@@ -149,8 +164,7 @@ class FilesystemItem
         $this->assertIsFile(__FUNCTION__);
         $this->resolveIfClosure($this->mimeType);
 
-        /** @var string */
-        return $this->mimeType;
+        return $this->mimeType ?? '';
     }
 
     public function getExtraMetadata(): array
@@ -158,7 +172,6 @@ class FilesystemItem
         $this->assertIsFile(__FUNCTION__);
         $this->resolveIfClosure($this->extraMetadata);
 
-        /** @var array */
         return $this->extraMetadata;
     }
 

--- a/core-bundle/src/Filesystem/VirtualFilesystem.php
+++ b/core-bundle/src/Filesystem/VirtualFilesystem.php
@@ -257,7 +257,7 @@ class VirtualFilesystem implements VirtualFilesystemInterface
      */
     private function doListContents(string $path, bool $deep, int $accessFlags): \Generator
     {
-        // Read from DBAFS, but enhance result with file metadata on demand
+        // Read from DBAFS but enhance result with file metadata on demand
         if (!($accessFlags & self::BYPASS_DBAFS) && $this->dbafsManager->match($path)) {
             /** @var FilesystemItem $item */
             foreach ($this->dbafsManager->listContents($path, $deep) as $item) {
@@ -270,13 +270,11 @@ class VirtualFilesystem implements VirtualFilesystemInterface
                     continue;
                 }
 
-                yield $item
-                    ->withMetadataIfNotDefined(
-                        fn () => $this->mountManager->getLastModified($path),
-                        fn () => $this->mountManager->getFileSize($path),
-                        fn () => $this->mountManager->getMimeType($path),
-                    )
-                ;
+                yield $item->withMetadataIfNotDefined(
+                    fn () => $this->mountManager->getLastModified($path),
+                    fn () => $this->mountManager->getFileSize($path),
+                    fn () => $this->mountManager->getMimeType($path),
+                );
             }
 
             return;
@@ -289,9 +287,7 @@ class VirtualFilesystem implements VirtualFilesystemInterface
 
             yield $item
                 ->withPath(Path::makeRelative($path, $this->prefix))
-                ->withExtraMetadata(
-                    fn () => $this->dbafsManager->getExtraMetadata($path)
-                )
+                ->withExtraMetadata(fn () => $this->dbafsManager->getExtraMetadata($path))
             ;
         }
     }

--- a/core-bundle/src/Filesystem/VirtualFilesystem.php
+++ b/core-bundle/src/Filesystem/VirtualFilesystem.php
@@ -257,10 +257,26 @@ class VirtualFilesystem implements VirtualFilesystemInterface
      */
     private function doListContents(string $path, bool $deep, int $accessFlags): \Generator
     {
-        // Read from DBAFS
+        // Read from DBAFS, but enhance result with file metadata on demand
         if (!($accessFlags & self::BYPASS_DBAFS) && $this->dbafsManager->match($path)) {
+            /** @var FilesystemItem $item */
             foreach ($this->dbafsManager->listContents($path, $deep) as $item) {
-                yield $item->withPath(Path::makeRelative($item->getPath(), $this->prefix));
+                $path = $item->getPath();
+                $item = $item->withPath(Path::makeRelative($path, $this->prefix));
+
+                if (!$item->isFile()) {
+                    yield $item;
+
+                    continue;
+                }
+
+                yield $item
+                    ->withMetadataIfNotDefined(
+                        fn () => $this->mountManager->getLastModified($path),
+                        fn () => $this->mountManager->getFileSize($path),
+                        fn () => $this->mountManager->getMimeType($path),
+                    )
+                ;
             }
 
             return;
@@ -269,10 +285,12 @@ class VirtualFilesystem implements VirtualFilesystemInterface
         // Read from adapter, but enhance result with extra metadata on demand
         /** @var FilesystemItem $item */
         foreach ($this->mountManager->listContents($path, $deep) as $item) {
+            $path = $item->getPath();
+
             yield $item
-                ->withPath(Path::makeRelative($item->getPath(), $this->prefix))
+                ->withPath(Path::makeRelative($path, $this->prefix))
                 ->withExtraMetadata(
-                    fn () => $this->dbafsManager->getExtraMetadata($item->getPath())
+                    fn () => $this->dbafsManager->getExtraMetadata($path)
                 )
             ;
         }

--- a/core-bundle/src/Filesystem/VirtualFilesystemInterface.php
+++ b/core-bundle/src/Filesystem/VirtualFilesystemInterface.php
@@ -111,6 +111,8 @@ interface VirtualFilesystemInterface
      *
      * @throws VirtualFilesystemException
      * @throws UnableToResolveUuidException
+     *
+     * @return iterable<FilesystemItem>
      */
     public function listContents($location, bool $deep = false, int $accessFlags = self::NONE): iterable;
 

--- a/core-bundle/tests/DependencyInjection/Filesystem/FilesystemConfigurationTest.php
+++ b/core-bundle/tests/DependencyInjection/Filesystem/FilesystemConfigurationTest.php
@@ -244,6 +244,7 @@ class FilesystemConfigurationTest extends TestCase
         $this->assertSame('contao.filesystem.virtual.foo', (string) $dbafs->getArgument(0));
         $this->assertSame('contao.filesystem.hash_generator.foo', (string) $dbafs->getArgument(1));
         $this->assertSame('tl_foo', $dbafs->getArgument(2));
+        $this->assertTrue($definition->hasTag('kernel.reset'));
 
         // Registered at DbafsManager
         $this->assertSame(

--- a/core-bundle/tests/Filesystem/VirtualFilesystemTest.php
+++ b/core-bundle/tests/Filesystem/VirtualFilesystemTest.php
@@ -439,7 +439,7 @@ class VirtualFilesystemTest extends TestCase
 
         $mountManager
             ->expects($this->once())
-            ->method('fileSize')
+            ->method('getFileSize')
             ->willReturn(1024)
             ->with('prefix/foo/bar/file')
         ;
@@ -489,9 +489,9 @@ class VirtualFilesystemTest extends TestCase
                 new FilesystemItem(
                     true,
                     'prefix/foo/bar/file',
-                    0,
-                    0,
-                    '',
+                    null,
+                    null,
+                    null,
                     ['extra' => 'data']
                 ),
                 new FilesystemItem(false, 'prefix/foo/bar/things'),
@@ -508,9 +508,9 @@ class VirtualFilesystemTest extends TestCase
                 new FilesystemItem(
                     true,
                     'prefix/foo/bar/file',
-                    0,
-                    0,
-                    '',
+                    null,
+                    null,
+                    null,
                     ['extra' => 'data']
                 ),
                 new FilesystemItem(false, 'prefix/foo/bar/things'),

--- a/core-bundle/tests/Filesystem/VirtualFilesystemTest.php
+++ b/core-bundle/tests/Filesystem/VirtualFilesystemTest.php
@@ -437,6 +437,13 @@ class VirtualFilesystemTest extends TestCase
             ->method('listContents')
         ;
 
+        $mountManager
+            ->expects($this->once())
+            ->method('fileSize')
+            ->willReturn(1024)
+            ->with('prefix/foo/bar/file')
+        ;
+
         $dbafsManager = $this->createMock(DbafsManager::class);
         $dbafsManager
             ->expects($this->once())
@@ -460,6 +467,8 @@ class VirtualFilesystemTest extends TestCase
             ['extra' => 'data'],
             $listedContents[0]->getExtraMetadata()
         );
+
+        $this->assertSame(1024, $listedContents[0]->getFileSize());
 
         // Normalize listing for comparison
         $listing = array_map(


### PR DESCRIPTION
This PR tweaks and fixes some small things in the filesystem implementation (followup to #3774):

* Services instantiated from the `Dbafs` class are now tagged with `kernel.reset` (the interface was already there, but the tag was missing).
* The VFS now enhances filesystem items read from the DBAFS with on-demand file metadata from the filesystem.<sup>*)</sup>
* `VirtualFilesystemInterface#listContents()` got a generic return type hint (docbloc only).


<sup>*)</sup> This means you will always get all information (like file size, mime type) when listing contents no matter what's the source. We do this by enhancing the `FilesystemItem` with closures that retrieve the data on access if they haven't been set already.