### PR TITLE
Remove remaining deprecations

### DIFF
--- a/core-bundle/src/Controller/FrontendController.php
+++ b/core-bundle/src/Controller/FrontendController.php
@@ -29,6 +29,13 @@ use Symfony\Component\Security\Core\Exception\LogoutException;
  */
 class FrontendController extends AbstractController
 {
+    private Cron $cron;
+
+    public function __construct(Cron $cron)
+    {
+        $this->cron = $cron;
+    }
+
     public function indexAction(): Response
     {
         $this->initializeContaoFramework();
@@ -43,10 +50,10 @@ class FrontendController extends AbstractController
     /**
      * @Route("/_contao/cron", name="contao_frontend_cron")
      */
-    public function cronAction(Request $request, Cron $cron): Response
+    public function cronAction(Request $request): Response
     {
         if ($request->isMethod(Request::METHOD_GET)) {
-            $cron->run(Cron::SCOPE_WEB);
+            $this->cron->run(Cron::SCOPE_WEB);
         }
 
         return new Response('', Response::HTTP_NO_CONTENT);

--- a/core-bundle/src/Controller/FrontendController.php
+++ b/core-bundle/src/Controller/FrontendController.php
@@ -29,13 +29,6 @@ use Symfony\Component\Security\Core\Exception\LogoutException;
  */
 class FrontendController extends AbstractController
 {
-    private Cron $cron;
-
-    public function __construct(Cron $cron)
-    {
-        $this->cron = $cron;
-    }
-
     public function indexAction(): Response
     {
         $this->initializeContaoFramework();
@@ -53,7 +46,7 @@ class FrontendController extends AbstractController
     public function cronAction(Request $request): Response
     {
         if ($request->isMethod(Request::METHOD_GET)) {
-            $this->cron->run(Cron::SCOPE_WEB);
+            $this->container->get('contao.cron')->run(Cron::SCOPE_WEB);
         }
 
         return new Response('', Response::HTTP_NO_CONTENT);
@@ -130,6 +123,7 @@ class FrontendController extends AbstractController
     {
         $services = parent::getSubscribedServices();
 
+        $services['contao.cron'] = Cron::class;
         $services['contao.csrf.token_manager'] = ContaoCsrfTokenManager::class;
 
         return $services;

--- a/core-bundle/src/Resources/config/controller.yml
+++ b/core-bundle/src/Resources/config/controller.yml
@@ -59,10 +59,9 @@ services:
             - controller.service_arguments
 
     Contao\CoreBundle\Controller\FrontendController:
-        arguments:
-            - '@contao.cron'
         tags:
             - controller.service_arguments
+            - { name: container.service_subscriber, id: contao.cron }
 
     Contao\CoreBundle\Controller\FrontendModule\RootPageDependentModulesController:
         tags:

--- a/core-bundle/src/Resources/config/controller.yml
+++ b/core-bundle/src/Resources/config/controller.yml
@@ -4,6 +4,8 @@ services:
 
     _instanceof:
         Symfony\Bundle\FrameworkBundle\Controller\AbstractController:
+            tags:
+                - { name: container.service_subscriber, id: contao.csrf.token_manager }
             calls:
                 - [setContainer, ['@Psr\Container\ContainerInterface']]
 
@@ -62,6 +64,7 @@ services:
         tags:
             - controller.service_arguments
             - { name: container.service_subscriber, id: contao.cron }
+            - { name: container.service_subscriber, id: contao.csrf.token_manager }
 
     Contao\CoreBundle\Controller\FrontendModule\RootPageDependentModulesController:
         tags:

--- a/core-bundle/src/Resources/config/controller.yml
+++ b/core-bundle/src/Resources/config/controller.yml
@@ -59,6 +59,8 @@ services:
             - controller.service_arguments
 
     Contao\CoreBundle\Controller\FrontendController:
+        arguments:
+            - '@contao.cron'
         tags:
             - controller.service_arguments
 

--- a/core-bundle/tests/Controller/FrontendControllerTest.php
+++ b/core-bundle/tests/Controller/FrontendControllerTest.php
@@ -23,7 +23,7 @@ class FrontendControllerTest extends TestCase
 {
     public function testThrowsALogoutExceptionUponLogout(): void
     {
-        $controller = new FrontendController($this->createMock(Cron::class));
+        $controller = new FrontendController();
 
         $this->expectException(LogoutException::class);
         $this->expectExceptionMessage('The user was not logged out correctly.');
@@ -33,7 +33,7 @@ class FrontendControllerTest extends TestCase
 
     public function testCheckCookiesAction(): void
     {
-        $controller = new FrontendController($this->createMock(Cron::class));
+        $controller = new FrontendController();
         $response = $controller->checkCookiesAction();
 
         $this->assertTrue($response->headers->hasCacheControlDirective('private'));
@@ -54,7 +54,7 @@ class FrontendControllerTest extends TestCase
         $container = $this->getContainerWithContaoConfiguration();
         $container->set('contao.csrf.token_manager', $tokenManager);
 
-        $controller = new FrontendController($this->createMock(Cron::class));
+        $controller = new FrontendController();
         $controller->setContainer($container);
 
         $response = $controller->requestTokenScriptAction();
@@ -79,8 +79,9 @@ class FrontendControllerTest extends TestCase
 
         $container = $this->getContainerWithContaoConfiguration();
         $container->set('contao.framework', $framework);
+        $container->set('contao.cron', $cron);
 
-        $controller = new FrontendController($cron);
+        $controller = new FrontendController();
         $controller->setContainer($container);
 
         $request = $this->createMock(Request::class);
@@ -106,8 +107,9 @@ class FrontendControllerTest extends TestCase
 
         $container = $this->getContainerWithContaoConfiguration();
         $container->set('contao.framework', $framework);
+        $container->set('contao.cron', $cron);
 
-        $controller = new FrontendController($cron);
+        $controller = new FrontendController();
         $controller->setContainer($container);
 
         $request = $this->createMock(Request::class);

--- a/core-bundle/tests/Functional/app/config/config_test.yml
+++ b/core-bundle/tests/Functional/app/config/config_test.yml
@@ -16,7 +16,7 @@ framework:
     csrf_protection: ~
     default_locale: '%locale%'
     session:
-        storage_id: session.storage.mock_file
+        storage_factory_id: session.storage.factory.mock_file
     fragments: { path: /_fragment }
 
 twig:


### PR DESCRIPTION
Fixes #3936 

**Deprecations**: 
- [x] Not setting the "framework.session.storage_factory_id" - https://github.com/contao/contao/pull/3938#issuecomment-1013917398
- [ ] The "session" service and "SessionInterface" - https://github.com/contao/contao/pull/3938#issuecomment-1013918081
- [x] Contao\CoreBundle\Cron\Cron - https://github.com/contao/contao/pull/3938#issuecomment-1013920466
- [x] Contao\CoreBundle\Csrf\ContaoCsrfTokenManager - https://github.com/contao/contao/pull/3938#issuecomment-1013924775
- [ ] Symfony\Bridge\Doctrine\Logger\DbalLogger - https://github.com/contao/contao/pull/3938#issuecomment-1013925517