### PR TITLE
Fix duplicating child records with dynamic ptable

### DIFF
--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -1057,7 +1057,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 					$cond = ($ptable == 'tl_article') ? "(ptable=? OR ptable='')" : "ptable=?";
 
 					$objCTable = $this->Database->prepare("SELECT * FROM $v WHERE pid=? AND $cond" . ($this->Database->fieldExists('sorting', $v) ? " ORDER BY sorting" : ""))
-												->execute($id, $ptable);
+												->execute($id, $table);
 				}
 				else
 				{

--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -1629,11 +1629,10 @@ class DC_Table extends DataContainer implements \listable, \editable
 			// Consider the dynamic parent table (see #4867)
 			if ($GLOBALS['TL_DCA'][$v]['config']['dynamicPtable'])
 			{
-				$ptable = $GLOBALS['TL_DCA'][$v]['config']['ptable'];
-				$cond = ($ptable == 'tl_article') ? "(ptable=? OR ptable='')" : "ptable=?";
+				$cond = ($table === 'tl_article') ? "(ptable=? OR ptable='')" : "ptable=?";
 
 				$objDelete = $this->Database->prepare("SELECT id FROM $v WHERE pid=? AND $cond")
-											->execute($id, $ptable);
+											->execute($id, $table);
 			}
 			else
 			{

--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -1053,8 +1053,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 				// Consider the dynamic parent table (see #4867)
 				if ($GLOBALS['TL_DCA'][$v]['config']['dynamicPtable'])
 				{
-					$ptable = $GLOBALS['TL_DCA'][$v]['config']['ptable'];
-					$cond = ($ptable == 'tl_article') ? "(ptable=? OR ptable='')" : "ptable=?";
+					$cond = ($table === 'tl_article') ? "(ptable=? OR ptable='')" : "ptable=?";
 
 					$objCTable = $this->Database->prepare("SELECT * FROM $v WHERE pid=? AND $cond" . ($this->Database->fieldExists('sorting', $v) ? " ORDER BY sorting" : ""))
 												->execute($id, $table);


### PR DESCRIPTION
Use current table for parent table statement. The configured dynamic ptable might differ from the current table.

## Scenario

1. I have a data container setup where a data container `tl_child` has a `dynamicPtable = (tl_root|tl_category)`
2. The hierarchy of the data containers is `tl_root => tl_category => tl_child` 
3. I want to duplicate a row of `tl_root`

## Expected result

Each children in `tl_category` and `tl_child` should be copied no matter which parent table the entry in `tl_child` has

## Current result

Only rows of `tl_child` matching the configured `ptable` are copied. Furthermore wrong children might be assigned if `pid`s are matching for different `ptable`s.