### PR TITLE
Allow to embed fragment controllers in Twig templates

### DIFF
--- a/core-bundle/src/Resources/config/services.yml
+++ b/core-bundle/src/Resources/config/services.yml
@@ -945,6 +945,12 @@ services:
         arguments:
             - '@contao.image.studio.figure_renderer'
 
+    contao.twig.http_kernel_runtime:
+        class: Contao\CoreBundle\Twig\Runtime\HttpKernelRuntime
+        arguments:
+            - '@contao.fragment.registry'
+            - '@contao.framework'
+
     contao.twig.filesystem_loader:
         class: Contao\CoreBundle\Twig\Loader\ContaoFilesystemLoader
         arguments:

--- a/core-bundle/src/Twig/Extension/ContaoExtension.php
+++ b/core-bundle/src/Twig/Extension/ContaoExtension.php
@@ -21,6 +21,7 @@ use Contao\CoreBundle\Twig\Interop\ContaoEscaper;
 use Contao\CoreBundle\Twig\Interop\ContaoEscaperNodeVisitor;
 use Contao\CoreBundle\Twig\Interop\PhpTemplateProxyNodeVisitor;
 use Contao\CoreBundle\Twig\Runtime\FigureRendererRuntime;
+use Contao\CoreBundle\Twig\Runtime\HttpKernelRuntime;
 use Contao\CoreBundle\Twig\Runtime\InsertTagRuntime;
 use Contao\CoreBundle\Twig\Runtime\LegacyTemplateFunctionsRuntime;
 use Contao\CoreBundle\Twig\Runtime\PictureConfigurationRuntime;
@@ -116,6 +117,14 @@ final class ContaoExtension extends AbstractExtension
                     return $includeFunctionCallable(...$args);
                 },
                 ['needs_environment' => true, 'needs_context' => true, 'is_safe' => ['all']]
+            ),
+            new TwigFunction(
+                'contao_content_element',
+                [HttpKernelRuntime::class, 'resolveContentElement']
+            ),
+            new TwigFunction(
+                'contao_module',
+                [HttpKernelRuntime::class, 'resolveModule']
             ),
             new TwigFunction(
                 'contao_figure',

--- a/core-bundle/src/Twig/Runtime/HttpKernelRuntime.php
+++ b/core-bundle/src/Twig/Runtime/HttpKernelRuntime.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Twig\Runtime;
+
+use Contao\ContentModel;
+use Contao\CoreBundle\Fragment\FragmentRegistryInterface;
+use Contao\CoreBundle\Framework\ContaoFramework;
+use Contao\ModuleModel;
+use Symfony\Component\HttpKernel\Controller\ControllerReference;
+use Twig\Extension\RuntimeExtensionInterface;
+
+final class HttpKernelRuntime implements RuntimeExtensionInterface
+{
+    private FragmentRegistryInterface $fragmentRegistry;
+    private ContaoFramework $framework;
+
+    /**
+     * @internal
+     */
+    public function __construct(FragmentRegistryInterface $fragmentRegistry, ContaoFramework $framework)
+    {
+        $this->fragmentRegistry = $fragmentRegistry;
+        $this->framework = $framework;
+    }
+
+    public function resolveContentElement(int $id): ControllerReference
+    {
+        $this->framework->initialize();
+
+        /** @var ContentModel|null $modelAdapter */
+        $modelAdapter = $this->framework->getAdapter(ContentModel::class);
+
+        if (null === ($model = $modelAdapter->findByPk($id))) {
+            throw new \InvalidArgumentException("A content element with the ID '$id' could not be found.");
+        }
+
+        if (null === ($config = $this->fragmentRegistry->get("contao.content_element.$model->type"))) {
+            throw new \InvalidArgumentException("A content element of type '$model->type' could not be found in the fragment registry.");
+        }
+
+        return new ControllerReference($config->getController(), ['model' => $model, 'section' => '']);
+    }
+
+    public function resolveModule(int $id): ControllerReference
+    {
+        $this->framework->initialize();
+
+        /** @var ModuleModel|null $modelAdapter */
+        $modelAdapter = $this->framework->getAdapter(ModuleModel::class);
+
+        if (null === ($model = $modelAdapter->findByPk($id))) {
+            throw new \InvalidArgumentException("A module with the ID '$id' could not be found.");
+        }
+
+        if (null === ($config = $this->fragmentRegistry->get("contao.module.$model->type"))) {
+            throw new \InvalidArgumentException("A module of type '$model->type' could not be found in the fragment registry.");
+        }
+
+        return new ControllerReference($config->getController(), ['model' => $model, 'section' => '']);
+    }
+}


### PR DESCRIPTION
This PR introduces an easy way to embed fragments controllers in your Twig templates as a better alternative to insert tags:

```twig
    {{ render(contao_module(42)) }}
    {{ render(contao_content_element(5)) }}
```

We reuse the functionality that Symfony already provides with the `render` [functions](https://symfony.com/doc/current/reference/twig_reference.html#render), but instead of using the `path` or `controller` functions, you can use the `contao_module` and `contao_content_element` functions to get a `ControllerReference` from a model ID.

This is an early draft, that showcases the general idea. This would currently only work for fragment controllers. We might also want a fail tolerant mode, because exceptions cannot be worked with inside templates.