### PR TITLE
Remove the routing error log in breadcrumb module

### DIFF
--- a/core-bundle/src/Resources/contao/modules/ModuleBreadcrumb.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleBreadcrumb.php
@@ -255,8 +255,6 @@ class ModuleBreadcrumb extends Module
 		}
 		catch (ExceptionInterface $exception)
 		{
-			System::log('Unable to generate URL for page ID ' . $pageModel->id . ': ' . $exception->getMessage(), __METHOD__, TL_ERROR);
-
 			return '';
 		}
 	}


### PR DESCRIPTION
This error message is pretty annoying and useless. I have a breadcrumb module on error pages, so I get an error message whenever the current URL is build. It correctly generates an empty URL though and does not link the breadcrumb item.

I think the error message does not make sense for the breadcrumb, because it might also appear on non-routable pages and pages with parameters. It still makes sense in the navigation and other places that should never be generated.