### PR TITLE
Fix default log context for Email::sendTo

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Email.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Email.php
@@ -604,7 +604,7 @@ class Email
 			}
 		}
 
-		$context = null;
+		$context = array();
 
 		if ($this->strLogFile !== ContaoContext::EMAIL)
 		{


### PR DESCRIPTION
Fixes #3951

Correctly initialize the default log context as an empty array in [`Email::sendTo`](https://github.com/contao/contao/blob/4.13/core-bundle/src/Resources/contao/library/Contao/Email.php#L607).