### PR TITLE
Upgrade to symfony/filesystem 5.4 and migrate webmozart/path-util usage

### DIFF
--- a/calendar-bundle/composer.json
+++ b/calendar-bundle/composer.json
@@ -37,10 +37,7 @@
         "symfony/phpunit-bridge": "4.4.*"
     },
     "extra": {
-        "contao-manager-plugin": "Contao\\CalendarBundle\\ContaoManager\\Plugin",
-        "symfony": {
-            "require": "^4.4"
-        }
+        "contao-manager-plugin": "Contao\\CalendarBundle\\ContaoManager\\Plugin"
     },
     "autoload": {
         "psr-4": {

--- a/comments-bundle/composer.json
+++ b/comments-bundle/composer.json
@@ -29,10 +29,7 @@
         "symfony/http-client": "4.4.*"
     },
     "extra": {
-        "contao-manager-plugin": "Contao\\CommentsBundle\\ContaoManager\\Plugin",
-        "symfony": {
-            "require": "^4.4"
-        }
+        "contao-manager-plugin": "Contao\\CommentsBundle\\ContaoManager\\Plugin"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -89,7 +89,7 @@
         "symfony/dotenv": "4.4.*",
         "symfony/event-dispatcher": "4.4.*",
         "symfony/expression-language": "4.4.*",
-        "symfony/filesystem": "4.4.*",
+        "symfony/filesystem": "^5.4",
         "symfony/finder": "4.4.*",
         "symfony/framework-bundle": "4.4.*",
         "symfony/http-client": "4.4.*",
@@ -117,7 +117,6 @@
         "twig/twig": "^2.7",
         "ua-parser/uap-php": "^3.9",
         "webignition/robots-txt-file": "^3.0",
-        "webmozart/path-util": "^2.2",
         "wikimedia/less.php": "^1.7"
     },
     "replace": {

--- a/composer.json
+++ b/composer.json
@@ -164,9 +164,6 @@
             "contao/manager-bundle": "Contao\\ManagerBundle\\ContaoManager\\Plugin",
             "contao/news-bundle": "Contao\\NewsBundle\\ContaoManager\\Plugin",
             "contao/newsletter-bundle": "Contao\\NewsletterBundle\\ContaoManager\\Plugin"
-        },
-        "symfony": {
-            "require": "^4.4"
         }
     },
     "autoload": {

--- a/core-bundle/composer.json
+++ b/core-bundle/composer.json
@@ -129,10 +129,7 @@
         "lexik/maintenance-bundle": "To put the application into maintenance mode"
     },
     "extra": {
-        "contao-manager-plugin": "Contao\\CoreBundle\\ContaoManager\\Plugin",
-        "symfony": {
-            "require": "^4.4"
-        }
+        "contao-manager-plugin": "Contao\\CoreBundle\\ContaoManager\\Plugin"
     },
     "autoload": {
         "psr-4": {

--- a/core-bundle/composer.json
+++ b/core-bundle/composer.json
@@ -81,7 +81,7 @@
         "symfony/dom-crawler": "4.4.*",
         "symfony/event-dispatcher": "4.4.*",
         "symfony/expression-language": "4.4.*",
-        "symfony/filesystem": "4.4.*",
+        "symfony/filesystem": "^5.4",
         "symfony/finder": "4.4.*",
         "symfony/framework-bundle": "4.4.*",
         "symfony/http-foundation": "4.4.*",
@@ -103,7 +103,6 @@
         "twig/twig": "^2.7",
         "ua-parser/uap-php": "^3.9",
         "webignition/robots-txt-file": "^3.0",
-        "webmozart/path-util": "^2.2",
         "wikimedia/less.php": "^1.7"
     },
     "conflict": {

--- a/core-bundle/src/Controller/FaviconController.php
+++ b/core-bundle/src/Controller/FaviconController.php
@@ -16,11 +16,11 @@ use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\FilesModel;
 use Contao\PageModel;
 use FOS\HttpCache\ResponseTagger;
+use Symfony\Component\Filesystem\Path;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
-use Webmozart\PathUtil\Path;
 
 /**
  * @Route(defaults={"_scope" = "frontend"})

--- a/core-bundle/src/Image/LegacyResizer.php
+++ b/core-bundle/src/Image/LegacyResizer.php
@@ -28,7 +28,7 @@ use Imagine\Exception\RuntimeException as ImagineRuntimeException;
 use Imagine\Gd\Imagine as GdImagine;
 use Imagine\Image\Box;
 use Imagine\Image\ImagineInterface;
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 /**
  * Resizes image objects and executes the legacy hooks.

--- a/core-bundle/src/Resources/contao/drivers/DC_Folder.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Folder.php
@@ -19,10 +19,10 @@ use Contao\Image\ResizeConfiguration;
 use Doctrine\DBAL\Exception\DriverException;
 use Imagine\Exception\RuntimeException;
 use Imagine\Gd\Imagine;
+use Symfony\Component\Filesystem\Path;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface;
 use Symfony\Component\HttpFoundation\Session\Session;
-use Webmozart\PathUtil\Path;
 
 /**
  * Provide methods to modify the file system.

--- a/core-bundle/src/Resources/contao/library/Contao/Config.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Config.php
@@ -11,7 +11,7 @@
 namespace Contao;
 
 use Symfony\Component\Filesystem\Filesystem;
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 /**
  * Loads and writes the local configuration file

--- a/core-bundle/src/Resources/contao/library/Contao/Dbafs.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Dbafs.php
@@ -12,7 +12,7 @@ namespace Contao;
 
 use Contao\Filter\SyncExclude;
 use Contao\Model\Collection;
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 /**
  * Handles the database assisted file system (DBAFS)

--- a/core-bundle/src/Resources/contao/library/Contao/StringUtil.php
+++ b/core-bundle/src/Resources/contao/library/Contao/StringUtil.php
@@ -12,7 +12,7 @@ namespace Contao;
 
 use Patchwork\Utf8;
 use Psr\Log\LogLevel;
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 /**
  * Provides string manipulation methods

--- a/core-bundle/src/Resources/contao/models/FilesModel.php
+++ b/core-bundle/src/Resources/contao/models/FilesModel.php
@@ -12,7 +12,7 @@ namespace Contao;
 
 use Contao\Model\Collection;
 use Contao\Model\Registry;
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 /**
  * Reads and writes file entries

--- a/core-bundle/src/Resources/contao/widgets/FileSelector.php
+++ b/core-bundle/src/Resources/contao/widgets/FileSelector.php
@@ -12,8 +12,8 @@ namespace Contao;
 
 use Contao\Image\ResizeConfiguration;
 use Doctrine\DBAL\Exception\DriverException;
+use Symfony\Component\Filesystem\Path;
 use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface;
-use Webmozart\PathUtil\Path;
 
 /**
  * Provide methods to handle input field "file tree".

--- a/core-bundle/tests/Cache/ContaoCacheWarmerTest.php
+++ b/core-bundle/tests/Cache/ContaoCacheWarmerTest.php
@@ -22,7 +22,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Config\Exception\FileLocatorFileNotFoundException;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Filesystem\Filesystem;
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 class ContaoCacheWarmerTest extends TestCase
 {

--- a/core-bundle/tests/Command/MigrateCommandTest.php
+++ b/core-bundle/tests/Command/MigrateCommandTest.php
@@ -22,7 +22,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Filesystem\Filesystem;
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 class MigrateCommandTest extends TestCase
 {

--- a/core-bundle/tests/Command/ResizeImagesCommandTest.php
+++ b/core-bundle/tests/Command/ResizeImagesCommandTest.php
@@ -23,7 +23,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Bridge\PhpUnit\ClockMock;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Filesystem\Filesystem;
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 class ResizeImagesCommandTest extends TestCase
 {

--- a/core-bundle/tests/Command/SymlinksCommandTest.php
+++ b/core-bundle/tests/Command/SymlinksCommandTest.php
@@ -18,7 +18,7 @@ use Contao\CoreBundle\Tests\TestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Filesystem\Filesystem;
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 class SymlinksCommandTest extends TestCase
 {

--- a/core-bundle/tests/Composer/ScriptHandlerTest.php
+++ b/core-bundle/tests/Composer/ScriptHandlerTest.php
@@ -22,7 +22,7 @@ use Contao\CoreBundle\Composer\ScriptHandler;
 use Contao\CoreBundle\Tests\TestCase;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Filesystem\Filesystem;
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 class ScriptHandlerTest extends TestCase
 {

--- a/core-bundle/tests/Contao/ImageTest.php
+++ b/core-bundle/tests/Contao/ImageTest.php
@@ -28,7 +28,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\NullLogger;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Filesystem\Filesystem;
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 class ImageTest extends TestCase
 {

--- a/core-bundle/tests/Contao/TemplateLoaderTest.php
+++ b/core-bundle/tests/Contao/TemplateLoaderTest.php
@@ -20,7 +20,7 @@ use Contao\ModuleArticleList;
 use Contao\System;
 use Contao\TemplateLoader;
 use Symfony\Component\Filesystem\Filesystem;
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 class TemplateLoaderTest extends TestCase
 {

--- a/core-bundle/tests/Contao/TemplateTest.php
+++ b/core-bundle/tests/Contao/TemplateTest.php
@@ -19,10 +19,10 @@ use Contao\FrontendTemplate;
 use Contao\System;
 use Symfony\Component\Asset\Packages;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Filesystem\Path;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\VarDumper\VarDumper;
-use Webmozart\PathUtil\Path;
 
 class TemplateTest extends TestCase
 {

--- a/core-bundle/tests/Functional/RoutingTest.php
+++ b/core-bundle/tests/Functional/RoutingTest.php
@@ -20,7 +20,7 @@ use Contao\System;
 use Contao\TestCase\ContaoDatabaseTrait;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\Filesystem\Filesystem;
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 class RoutingTest extends WebTestCase
 {

--- a/core-bundle/tests/Image/ImageFactoryTest.php
+++ b/core-bundle/tests/Image/ImageFactoryTest.php
@@ -38,7 +38,7 @@ use Imagine\Image\ImageInterface as ImagineImageInterface;
 use Imagine\Image\ImagineInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Filesystem\Filesystem;
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 class ImageFactoryTest extends TestCase
 {

--- a/faq-bundle/composer.json
+++ b/faq-bundle/composer.json
@@ -35,10 +35,7 @@
         "symfony/phpunit-bridge": "4.4.*"
     },
     "extra": {
-        "contao-manager-plugin": "Contao\\FaqBundle\\ContaoManager\\Plugin",
-        "symfony": {
-            "require": "^4.4"
-        }
+        "contao-manager-plugin": "Contao\\FaqBundle\\ContaoManager\\Plugin"
     },
     "autoload": {
         "psr-4": {

--- a/installation-bundle/composer.json
+++ b/installation-bundle/composer.json
@@ -43,10 +43,7 @@
         "symfony/phpunit-bridge": "4.4.*"
     },
     "extra": {
-        "contao-manager-plugin": "Contao\\InstallationBundle\\ContaoManager\\Plugin",
-        "symfony": {
-            "require": "^4.4"
-        }
+        "contao-manager-plugin": "Contao\\InstallationBundle\\ContaoManager\\Plugin"
     },
     "autoload": {
         "psr-4": {

--- a/installation-bundle/composer.json
+++ b/installation-bundle/composer.json
@@ -25,7 +25,7 @@
         "symfony/console": "4.4.*",
         "symfony/dependency-injection": "4.4.*",
         "symfony/event-dispatcher": "4.4.*",
-        "symfony/filesystem": "4.4.*",
+        "symfony/filesystem": "^5.4",
         "symfony/finder": "4.4.*",
         "symfony/framework-bundle": "4.4.*",
         "symfony/http-foundation": "4.4.*",

--- a/listing-bundle/composer.json
+++ b/listing-bundle/composer.json
@@ -29,10 +29,7 @@
         "symfony/http-client": "4.4.*"
     },
     "extra": {
-        "contao-manager-plugin": "Contao\\ListingBundle\\ContaoManager\\Plugin",
-        "symfony": {
-            "require": "^4.4"
-        }
+        "contao-manager-plugin": "Contao\\ListingBundle\\ContaoManager\\Plugin"
     },
     "autoload": {
         "psr-4": {

--- a/manager-bundle/composer.json
+++ b/manager-bundle/composer.json
@@ -36,7 +36,7 @@
         "symfony/dotenv": "4.4.*",
         "symfony/doctrine-bridge": "4.4.*",
         "symfony/expression-language": "4.4.*",
-        "symfony/filesystem": "4.4.*",
+        "symfony/filesystem": "^5.4",
         "symfony/finder": "4.4.*",
         "symfony/framework-bundle": "4.4.*",
         "symfony/http-client": "4.4.*",

--- a/manager-bundle/composer.json
+++ b/manager-bundle/composer.json
@@ -68,10 +68,7 @@
         "contao/tcpdf-bundle": "To export articles as PDF files"
     },
     "extra": {
-        "contao-manager-plugin": "Contao\\ManagerBundle\\ContaoManager\\Plugin",
-        "symfony": {
-            "require": "^4.4"
-        }
+        "contao-manager-plugin": "Contao\\ManagerBundle\\ContaoManager\\Plugin"
     },
     "autoload": {
         "psr-4": {

--- a/news-bundle/composer.json
+++ b/news-bundle/composer.json
@@ -37,10 +37,7 @@
         "symfony/phpunit-bridge": "4.4.*"
     },
     "extra": {
-        "contao-manager-plugin": "Contao\\NewsBundle\\ContaoManager\\Plugin",
-        "symfony": {
-            "require": "^4.4"
-        }
+        "contao-manager-plugin": "Contao\\NewsBundle\\ContaoManager\\Plugin"
     },
     "autoload": {
         "psr-4": {

--- a/newsletter-bundle/composer.json
+++ b/newsletter-bundle/composer.json
@@ -29,10 +29,7 @@
         "symfony/http-client": "4.4.*"
     },
     "extra": {
-        "contao-manager-plugin": "Contao\\NewsletterBundle\\ContaoManager\\Plugin",
-        "symfony": {
-            "require": "^4.4"
-        }
+        "contao-manager-plugin": "Contao\\NewsletterBundle\\ContaoManager\\Plugin"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This PR requires the `symfony/filesystem` component in version 5.4 and drops the abandoned webmozart/path-util for Contao 4.9.

see https://github.com/contao/image/issues/86#issuecomment-1002958667