### PR TITLE
Refactor HTML into templates in PageRoutingListener

### DIFF
--- a/core-bundle/src/Resources/views/Backend/_route_path.html.twig
+++ b/core-bundle/src/Resources/views/Backend/_route_path.html.twig
@@ -1,0 +1,7 @@
+{%- for chunk in path_chunks  -%}
+    {%- if chunk.regex is defined -%}
+        <span class="tl_tip" title="{{ chunk.regex }}">{{ chunk.name }}</span>
+    {%- else -%}
+        {{ chunk.name }}
+    {%- endif -%}
+{%- endfor -%}

--- a/core-bundle/src/Resources/views/Backend/be_route_conflicts.html.twig
+++ b/core-bundle/src/Resources/views/Backend/be_route_conflicts.html.twig
@@ -20,7 +20,7 @@
                     <td colspan="1" class="tl_file_list">{{ conflict.page.title }}</td>
                     <td colspan="1" class="tl_file_list">{{ ('PTY.'~conflict.page.type~'.0')|trans([], 'contao_default') }}</td>
                     <td colspan="1" class="tl_file_list">{{ conflict.page.alias }}</td>
-                    <td colspan="1" class="tl_file_list">{{ conflict.path|raw }}</td>
+                    <td colspan="1" class="tl_file_list">{% include '@ContaoCore/Backend/_route_path.html.twig' with {path_chunks: conflict.path_chunks } %}</td>
                     <td colspan="1" class="tl_file_list">{{ conflict.page.routePriority }}</td>
                     <td class="tl_file_list tl_right_nowrap">
                         <a

--- a/core-bundle/src/Resources/views/Backend/be_route_path.html.twig
+++ b/core-bundle/src/Resources/views/Backend/be_route_path.html.twig
@@ -1,6 +1,6 @@
 {% trans_default_domain 'contao_tl_page' %}
 <div class="w50 widget">
     <h3>{{ 'tl_page.routePath.0'|trans }}</h3>
-    <p class="info">{{ path|raw }}</p>
+    <p class="info">{% include '@ContaoCore/Backend/_route_path.html.twig' with {path_chunks: path_chunks} %}</p>
     <p class="tl_help tl_tip" title="">{{ 'tl_page.routePath.1'|trans }}</p>
 </div>

--- a/core-bundle/tests/EventListener/DataContainer/PageRoutingListenerTest.php
+++ b/core-bundle/tests/EventListener/DataContainer/PageRoutingListenerTest.php
@@ -27,7 +27,7 @@ class PageRoutingListenerTest extends TestCase
     /**
      * @dataProvider routePathProvider
      */
-    public function testGetsPathFromPageRoute(string $path, array $requirements, string $expected): void
+    public function testGetsPathFromPageRoute(string $path, array $requirements, array $expected): void
     {
         $pageModel = $this->mockClassWithProperties(PageModel::class);
 
@@ -57,7 +57,7 @@ class PageRoutingListenerTest extends TestCase
             ->with(
                 '@ContaoCore/Backend/be_route_path.html.twig',
                 [
-                    'path' => $expected,
+                    'path_chunks' => $expected,
                 ]
             )
             ->willReturn('foobar')
@@ -74,37 +74,43 @@ class PageRoutingListenerTest extends TestCase
         yield 'Path without parameters' => [
             'foobar',
             [],
-            'foobar',
+            [['name' => 'foobar']],
         ];
 
         yield 'Ignores unknown parameters in path' => [
             'foo/bar/{baz}.html',
             [],
-            'foo/bar/{baz}.html',
+            [['name' => 'foo/bar/{baz}.html']],
         ];
 
         yield 'Ignores unknown parameters' => [
             'foo/bar/{baz}.html',
             ['bar' => 'baz'],
-            'foo/bar/{baz}.html',
+            [['name' => 'foo/bar/{baz}.html']],
         ];
 
         yield 'Replaces parameter' => [
             'foo/{bar}.html',
             ['bar' => '.+'],
-            'foo/{<span class="tl_tip" title=".+">bar</span>}.html',
+            [['name' => 'foo/'], ['name' => '{bar}', 'regex' => '.+'], ['name' => '.html']],
         ];
 
         yield 'Replaces parameters' => [
             'foo/{bar}/{baz}.html',
             ['bar' => '.+', 'baz' => '\d+'],
-            'foo/{<span class="tl_tip" title=".+">bar</span>}/{<span class="tl_tip" title="\d+">baz</span>}.html',
+            [
+                ['name' => 'foo/'],
+                ['name' => '{bar}', 'regex' => '.+'],
+                ['name' => '/'],
+                ['name' => '{baz}', 'regex' => '\d+'],
+                ['name' => '.html'],
+            ],
         ];
 
         yield 'Handles parameters starting with exclamation point' => [
             'foo/{!bar}.html',
             ['bar' => '.+'],
-            'foo/{<span class="tl_tip" title=".+">bar</span>}.html',
+            [['name' => 'foo/'], ['name' => '{bar}', 'regex' => '.+'], ['name' => '.html']],
         ];
     }
 
@@ -231,17 +237,17 @@ class PageRoutingListenerTest extends TestCase
                     'conflicts' => [
                         [
                             'page' => $aliasPages[0],
-                            'path' => 'foo',
+                            'path_chunks' => [['name' => 'foo']],
                             'editUrl' => 'editUrl',
                         ],
                         [
                             'page' => $aliasPages[1],
-                            'path' => 'bar',
+                            'path_chunks' => [['name' => 'bar']],
                             'editUrl' => 'editUrl',
                         ],
                         [
                             'page' => $aliasPages[2],
-                            'path' => 'baz',
+                            'path_chunks' => [['name' => 'baz']],
                             'editUrl' => 'editUrl',
                         ],
                     ],


### PR DESCRIPTION
The `PageRoutingListener` already uses templates, so we should IMHO avoid composing HTML in it. 