### PR TITLE
Reduce the scope of the authentication listener

### DIFF
--- a/core-bundle/src/Security/Authentication/ContaoLoginAuthenticationListener.php
+++ b/core-bundle/src/Security/Authentication/ContaoLoginAuthenticationListener.php
@@ -48,7 +48,7 @@ class ContaoLoginAuthenticationListener extends AbstractAuthenticationListener
     {
         return $request->isMethod('POST')
             && $request->request->has('FORM_SUBMIT')
-            && preg_match('/^tl_login(_[0-9]+)?$/', $request->request->get('FORM_SUBMIT'), $matches);
+            && preg_match('/^tl_login(_[0-9]+)?$/', $request->request->get('FORM_SUBMIT'));
     }
 
     /**

--- a/core-bundle/src/Security/Authentication/ContaoLoginAuthenticationListener.php
+++ b/core-bundle/src/Security/Authentication/ContaoLoginAuthenticationListener.php
@@ -48,7 +48,7 @@ class ContaoLoginAuthenticationListener extends AbstractAuthenticationListener
     {
         return $request->isMethod('POST')
             && $request->request->has('FORM_SUBMIT')
-            && preg_match('/^tl_login($|_[0-9]+$)/', $request->request->get('FORM_SUBMIT'), $matches);
+            && preg_match('/^tl_login(_[0-9]+)?$/', $request->request->get('FORM_SUBMIT'), $matches);
     }
 
     /**

--- a/core-bundle/src/Security/Authentication/ContaoLoginAuthenticationListener.php
+++ b/core-bundle/src/Security/Authentication/ContaoLoginAuthenticationListener.php
@@ -48,7 +48,7 @@ class ContaoLoginAuthenticationListener extends AbstractAuthenticationListener
     {
         return $request->isMethod('POST')
             && $request->request->has('FORM_SUBMIT')
-            && 0 === strncmp($request->request->get('FORM_SUBMIT'), 'tl_login', 8);
+            && preg_match('/^tl_login($|_[0-9]+$)/', $request->request->get('FORM_SUBMIT'), $matches);
     }
 
     /**


### PR DESCRIPTION
If you create a DCA called `tl_login`, `tl_loginrecords` or `tl_login_records` for example (any DCA which begins with `tl_login`) you will not be able to save or edit any records there, since it will trigger the `ContaoLoginAuthenticationListener`. And then the following error happens (unless your DCA happens to have a `username` field):

```
Symfony\Component\HttpKernel\Exception\BadRequestHttpException:
The key "username" must be a string, "NULL" given.

  at vendor/contao/core-bundle/src/Security/Authentication/ContaoLoginAuthenticationListener.php:71
```

This is because the backend form uses the table name of the DCA for `FORM_SUBMIT` - and our `ContaoLoginAuthenticationListener` is triggered for any `POST` request that contains a `FORM_SUBMIT` parameter that starts with `tl_login`.

This PR partially solves this by restricting the `FORM_SUBMIT` check to `tl_login` (used by the back end login) and `tl_login_<number>` (used by the front end login) (may be @ausi can optimise the regex 🦊 😁). However, this means you still cannot use a DCA called `tl_login` or `tl_login_<number>` of course. But I think narrowing the `ContaoLoginAuthenticationListener` would make sense in any case.

/cc @cmartin6

