### PR TITLE
Fix undo preview for fragments

### DIFF
--- a/core-bundle/src/EventListener/DataContainer/Undo/LabelListener.php
+++ b/core-bundle/src/EventListener/DataContainer/Undo/LabelListener.php
@@ -90,18 +90,22 @@ class LabelListener
      */
     private function renderPreview(array $row, DataContainer $dc)
     {
-        if (DataContainer::MODE_PARENT === ($GLOBALS['TL_DCA'][$dc->table]['list']['sorting']['mode'] ?? null)) {
-            $callback = $GLOBALS['TL_DCA'][$dc->table]['list']['sorting']['child_record_callback'] ?? null;
+        try {
+            if (DataContainer::MODE_PARENT === ($GLOBALS['TL_DCA'][$dc->table]['list']['sorting']['mode'] ?? null)) {
+                $callback = $GLOBALS['TL_DCA'][$dc->table]['list']['sorting']['child_record_callback'] ?? null;
 
-            if (\is_array($callback)) {
-                return System::importStatic($callback[0])->{$callback[1]}($row);
+                if (\is_array($callback)) {
+                    return System::importStatic($callback[0])->{$callback[1]}($row);
+                }
+
+                if (\is_callable($callback)) {
+                    return $callback($row);
+                }
             }
 
-            if (\is_callable($callback)) {
-                return $callback($row);
-            }
+            return $dc->generateRecordLabel($row, $dc->table);
+        } catch (\Throwable $exception) {
+            return '';
         }
-
-        return $dc->generateRecordLabel($row, $dc->table);
     }
 }

--- a/core-bundle/src/Fragment/FragmentHandler.php
+++ b/core-bundle/src/Fragment/FragmentHandler.php
@@ -53,6 +53,10 @@ class FragmentHandler extends BaseFragmentHandler
             throw new UnknownFragmentException(sprintf('Invalid fragment identifier "%s"', $uri->controller));
         }
 
+        if ($uri->isBackendScope()) {
+            $config->setRenderer('inline');
+        }
+
         $this->preHandleFragment($uri, $config);
 
         $renderer = $config->getRenderer();

--- a/core-bundle/src/Fragment/FragmentHandler.php
+++ b/core-bundle/src/Fragment/FragmentHandler.php
@@ -14,6 +14,7 @@ namespace Contao\CoreBundle\Fragment;
 
 use Contao\CoreBundle\Exception\ResponseException;
 use Contao\CoreBundle\Fragment\Reference\FragmentReference;
+use Contao\Model;
 use Contao\PageModel;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -85,6 +86,14 @@ class FragmentHandler extends BaseFragmentHandler
     {
         if (!isset($uri->attributes['pageModel']) && $this->hasGlobalPageObject()) {
             $uri->attributes['pageModel'] = $GLOBALS['objPage']->id;
+        }
+
+        if (!\in_array($config->getRenderer(), ['inline', 'forward'])) {
+            foreach ($uri->attributes as $k => $v) {
+                if ($v instanceof Model) {
+                    $uri->attributes[$k] = $v->{$v::getPk()};
+                }
+            }
         }
 
         if ($this->preHandlers->has($uri->controller)) {

--- a/core-bundle/src/Fragment/Reference/ContentElementReference.php
+++ b/core-bundle/src/Fragment/Reference/ContentElementReference.php
@@ -25,7 +25,7 @@ class ContentElementReference extends FragmentReference
     {
         parent::__construct(self::TAG_NAME.'.'.$model->type);
 
-        $this->attributes['contentModel'] = $model->id;
+        $this->attributes['contentModel'] = $model;
         $this->attributes['section'] = $section;
         $this->attributes['classes'] = $model->classes;
         $this->attributes['templateProperties'] = $templateProperties;

--- a/core-bundle/src/Fragment/Reference/FrontendModuleReference.php
+++ b/core-bundle/src/Fragment/Reference/FrontendModuleReference.php
@@ -25,7 +25,7 @@ class FrontendModuleReference extends FragmentReference
     {
         parent::__construct(self::TAG_NAME.'.'.$model->type);
 
-        $this->attributes['moduleModel'] = $model->id;
+        $this->attributes['moduleModel'] = $model;
         $this->attributes['section'] = $section;
         $this->attributes['classes'] = $model->classes;
         $this->attributes['templateProperties'] = $templateProperties;


### PR DESCRIPTION
The new undo preview feature in 4.13 does not work with fragments, since they require the database record to be present. This PR contains three changes (see 3 commits).

 1. it try-catches any exception to make sure the back end undo section works if anything goes wrong in the child_record/label callback
 2. It enforces the inline renderer in the back end, since you never want an ESI tag there
 3. It changes the fragment handling to always use the original model for inline fragments. This might be a behaviour change, not sure if someone has any doubts.

We might want to fix 2 and 3 in Contao 4.9 and merge upstream instead of just here, since they seem like an inconsistency to me to change just in this version.