### PR TITLE
Do not instantiate real data container for undo process

### DIFF
--- a/core-bundle/src/EventListener/DataContainer/Undo/LabelListener.php
+++ b/core-bundle/src/EventListener/DataContainer/Undo/LabelListener.php
@@ -62,7 +62,11 @@ class LabelListener
     private function getTemplateData(string $table, array $row, array $originalRow): array
     {
         $dataContainer = $this->framework->getAdapter(DataContainer::class)->getDriverForTable($table);
-        $originalDC = new $dataContainer($table);
+        $ref = new \ReflectionClass($dataContainer);
+        $originalDC = $ref->newInstanceWithoutConstructor();
+        $originalDC->table = $table;
+        $originalDC->id = $originalRow['id'];
+        $originalDC->activeRecord = (object) $originalRow;
 
         $user = $this->framework->getAdapter(UserModel::class)->findById($row['pid']);
         $config = $this->framework->getAdapter(Config::class);


### PR DESCRIPTION
Unfortunately, instantiating a DataContainer will call the `onload_callback` (and a lot of other stuff), which will check permissions and fail for non-existing records and when not being in the "assumed" backend scope.