### PR TITLE
Fix the available transports service

### DIFF
--- a/core-bundle/src/DependencyInjection/Compiler/AddAvailableTransportsPass.php
+++ b/core-bundle/src/DependencyInjection/Compiler/AddAvailableTransportsPass.php
@@ -22,7 +22,7 @@ class AddAvailableTransportsPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void
     {
-        if (!$container->has(AvailableTransports::class)) {
+        if (!$container->has('contao.mailer.available_transports')) {
             return;
         }
 
@@ -34,7 +34,7 @@ class AddAvailableTransportsPass implements CompilerPassInterface
         }
 
         $frameworkConfig = $container->getExtensionConfig('framework');
-        $definition = $container->findDefinition(AvailableTransports::class);
+        $definition = $container->findDefinition('contao.mailer.available_transports');
 
         foreach ($frameworkConfig as $v) {
             if (!isset($v['mailer']['transports'])) {

--- a/core-bundle/src/DependencyInjection/Compiler/AddAvailableTransportsPass.php
+++ b/core-bundle/src/DependencyInjection/Compiler/AddAvailableTransportsPass.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\DependencyInjection\Compiler;
 
-use Contao\CoreBundle\Mailer\AvailableTransports;
 use Contao\CoreBundle\Mailer\TransportConfig;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;

--- a/core-bundle/src/Resources/config/services.yml
+++ b/core-bundle/src/Resources/config/services.yml
@@ -407,6 +407,7 @@ services:
 
     contao.mailer.available_transports:
         class: Contao\CoreBundle\Mailer\AvailableTransports
+        public: true
         arguments:
             - '@?translator'
 
@@ -1020,6 +1021,7 @@ services:
     Contao\CoreBundle\Intl\Locales:
         alias: contao.intl.locales
         public: true # backwards compatibility
+    Contao\CoreBundle\Mailer\AvailableTransports: '@contao.mailer.available_transports'
     Contao\CoreBundle\OptIn\OptIn:
         alias: contao.opt_in
         public: true # backwards compatibility

--- a/core-bundle/tests/DependencyInjection/Compiler/AddAvailableTransportsPassTest.php
+++ b/core-bundle/tests/DependencyInjection/Compiler/AddAvailableTransportsPassTest.php
@@ -30,7 +30,7 @@ class AddAvailableTransportsPassTest extends TestCase
         $pass = new AddAvailableTransportsPass();
         $pass->process($container);
 
-        $definition = $container->getDefinition(AvailableTransports::class);
+        $definition = $container->getDefinition('contao.mailer.available_transports');
 
         $this->assertEmpty($definition->getMethodCalls());
     }
@@ -49,7 +49,7 @@ class AddAvailableTransportsPassTest extends TestCase
         $pass = new AddAvailableTransportsPass();
         $pass->process($container);
 
-        $definition = $container->getDefinition(AvailableTransports::class);
+        $definition = $container->getDefinition('contao.mailer.available_transports');
 
         $this->assertEmpty($definition->getMethodCalls());
     }
@@ -72,7 +72,7 @@ class AddAvailableTransportsPassTest extends TestCase
         $pass = new AddAvailableTransportsPass();
         $pass->process($container);
 
-        $definition = $container->getDefinition(AvailableTransports::class);
+        $definition = $container->getDefinition('contao.mailer.available_transports');
 
         $this->assertEmpty($definition->getMethodCalls());
     }
@@ -167,7 +167,7 @@ class AddAvailableTransportsPassTest extends TestCase
     private function getContainerBuilder(): ContainerBuilder
     {
         $container = new ContainerBuilder();
-        $container->setDefinition(AvailableTransports::class, new Definition(AvailableTransports::class, []));
+        $container->setDefinition('contao.mailer.available_transports', new Definition(AvailableTransports::class, []));
 
         return $container;
     }
@@ -177,9 +177,9 @@ class AddAvailableTransportsPassTest extends TestCase
      */
     private function getTransportsFromDefinition(ContainerBuilder $container): array
     {
-        $this->assertTrue($container->hasDefinition(AvailableTransports::class));
+        $this->assertTrue($container->hasDefinition('contao.mailer.available_transports'));
 
-        $definition = $container->getDefinition(AvailableTransports::class);
+        $definition = $container->getDefinition('contao.mailer.available_transports');
         $methodCalls = $definition->getMethodCalls();
 
         $this->assertIsArray($methodCalls);

--- a/newsletter-bundle/src/Resources/contao/dca/tl_newsletter.php
+++ b/newsletter-bundle/src/Resources/contao/dca/tl_newsletter.php
@@ -224,7 +224,7 @@ $GLOBALS['TL_DCA']['tl_newsletter'] = array
 			'exclude'                 => true,
 			'inputType'               => 'select',
 			'eval'                    => array('tl_class'=>'w50', 'includeBlankOption'=>true),
-			'options_callback'        => array(AvailableTransports::class, 'getTransportOptions'),
+			'options_callback'        => array('contao.mailer.available_transports', 'getTransportOptions'),
 			'sql'                     => "varchar(255) NOT NULL default ''"
 		),
 		'sender' => array

--- a/newsletter-bundle/src/Resources/contao/dca/tl_newsletter.php
+++ b/newsletter-bundle/src/Resources/contao/dca/tl_newsletter.php
@@ -13,7 +13,6 @@ use Contao\BackendUser;
 use Contao\Config;
 use Contao\Controller;
 use Contao\CoreBundle\Exception\AccessDeniedException;
-use Contao\CoreBundle\Mailer\AvailableTransports;
 use Contao\DataContainer;
 use Contao\Date;
 use Contao\Environment;

--- a/newsletter-bundle/src/Resources/contao/dca/tl_newsletter_channel.php
+++ b/newsletter-bundle/src/Resources/contao/dca/tl_newsletter_channel.php
@@ -12,7 +12,6 @@ use Contao\Backend;
 use Contao\BackendUser;
 use Contao\Controller;
 use Contao\CoreBundle\Exception\AccessDeniedException;
-use Contao\CoreBundle\Mailer\AvailableTransports;
 use Contao\CoreBundle\Security\ContaoCorePermissions;
 use Contao\DataContainer;
 use Contao\Image;

--- a/newsletter-bundle/src/Resources/contao/dca/tl_newsletter_channel.php
+++ b/newsletter-bundle/src/Resources/contao/dca/tl_newsletter_channel.php
@@ -166,7 +166,7 @@ $GLOBALS['TL_DCA']['tl_newsletter_channel'] = array
 			'exclude'                 => true,
 			'inputType'               => 'select',
 			'eval'                    => array('tl_class'=>'w50', 'includeBlankOption'=>true),
-			'options_callback'        => array(AvailableTransports::class, 'getTransportOptions'),
+			'options_callback'        => array('contao.mailer.available_transports', 'getTransportOptions'),
 			'sql'                     => "varchar(255) NOT NULL default ''"
 		),
 		'sender' => array


### PR DESCRIPTION
Currently in Contao 4.13 you cannot select any available mailer transports that you have defined. This is because the service name of the `AvailableTransports` service was changed in 4.13 - but no adjustments to the code had been made accordingly (or rather no alias was created).