### PR TITLE
Fix an 'Attempt to read property "language" on null' warning

### DIFF
--- a/core-bundle/src/Resources/contao/elements/ContentDownloads.php
+++ b/core-bundle/src/Resources/contao/elements/ContentDownloads.php
@@ -105,8 +105,8 @@ class ContentDownloads extends ContentDownload
 
 		$objFiles = $this->objFiles;
 		$allowedDownload = StringUtil::trimsplit(',', strtolower(Config::get('allowedDownload')));
-		$pageLanguage = $objPage ? $objPage->language : null;
-		$pageRootFallbackLanguage = $objPage ? $objPage->rootFallbackLanguage : null;
+		$pageLanguage = isset($objPage) ? $objPage->language : null;
+		$pageRootFallbackLanguage = isset($objPage) ? $objPage->rootFallbackLanguage : null;
 
 		// Get all files
 		while ($objFiles->next())

--- a/core-bundle/src/Resources/contao/elements/ContentDownloads.php
+++ b/core-bundle/src/Resources/contao/elements/ContentDownloads.php
@@ -105,8 +105,6 @@ class ContentDownloads extends ContentDownload
 
 		$objFiles = $this->objFiles;
 		$allowedDownload = StringUtil::trimsplit(',', strtolower(Config::get('allowedDownload')));
-		$pageLanguage = isset($objPage) ? $objPage->language : null;
-		$pageRootFallbackLanguage = isset($objPage) ? $objPage->rootFallbackLanguage : null;
 
 		// Get all files
 		while ($objFiles->next())
@@ -127,18 +125,28 @@ class ContentDownloads extends ContentDownload
 					continue;
 				}
 
-				$arrMeta = $this->getMetaData($objFiles->meta, $pageLanguage);
-
-				if (empty($arrMeta))
+				if ($request && System::getContainer()->get('contao.routing.scope_matcher')->isBackendRequest($request))
 				{
-					if ($this->metaIgnore)
-					{
-						continue;
-					}
+					$arrMeta = $this->getMetaData($objFiles->meta, $GLOBALS['TL_LANGUAGE']);
+				}
+				else
+				{
+					/** @var PageModel $objPage */
+					global $objPage;
 
-					if ($pageRootFallbackLanguage !== null)
+					$arrMeta = $this->getMetaData($objFiles->meta, $objPage->language);
+
+					if (empty($arrMeta))
 					{
-						$arrMeta = $this->getMetaData($objFiles->meta, $pageRootFallbackLanguage);
+						if ($this->metaIgnore)
+						{
+							continue;
+						}
+
+						if ($objPage->rootFallbackLanguage !== null)
+						{
+							$arrMeta = $this->getMetaData($objFiles->meta, $objPage->rootFallbackLanguage);
+						}
 					}
 				}
 
@@ -210,18 +218,28 @@ class ContentDownloads extends ContentDownload
 						continue;
 					}
 
-					$arrMeta = $this->getMetaData($objSubfiles->meta, $pageLanguage);
-
-					if (empty($arrMeta))
+					if ($request && System::getContainer()->get('contao.routing.scope_matcher')->isBackendRequest($request))
 					{
-						if ($this->metaIgnore)
-						{
-							continue;
-						}
+						$arrMeta = $this->getMetaData($objSubfiles->meta, $GLOBALS['TL_LANGUAGE']);
+					}
+					else
+					{
+						/** @var PageModel $objPage */
+						global $objPage;
+						
+						$arrMeta = $this->getMetaData($objSubfiles->meta, $objPage->language);
 
-						if ($pageRootFallbackLanguage !== null)
+						if (empty($arrMeta))
 						{
-							$arrMeta = $this->getMetaData($objSubfiles->meta, $pageRootFallbackLanguage);
+							if ($this->metaIgnore)
+							{
+								continue;
+							}
+
+							if ($objPage->rootFallbackLanguage !== null)
+							{
+								$arrMeta = $this->getMetaData($objSubfiles->meta, $objPage->rootFallbackLanguage);
+							}
 						}
 					}
 

--- a/core-bundle/src/Resources/contao/elements/ContentDownloads.php
+++ b/core-bundle/src/Resources/contao/elements/ContentDownloads.php
@@ -97,9 +97,6 @@ class ContentDownloads extends ContentDownload
 	 */
 	protected function compile()
 	{
-		/** @var PageModel $objPage */
-		global $objPage;
-
 		$files = array();
 		$auxDate = array();
 

--- a/core-bundle/src/Resources/contao/elements/ContentDownloads.php
+++ b/core-bundle/src/Resources/contao/elements/ContentDownloads.php
@@ -105,6 +105,8 @@ class ContentDownloads extends ContentDownload
 
 		$objFiles = $this->objFiles;
 		$allowedDownload = StringUtil::trimsplit(',', strtolower(Config::get('allowedDownload')));
+		$pageLanguage = $objPage ? $objPage->language : null;
+		$pageRootFallbackLanguage = $objPage ? $objPage->rootFallbackLanguage : null;
 
 		// Get all files
 		while ($objFiles->next())
@@ -125,7 +127,7 @@ class ContentDownloads extends ContentDownload
 					continue;
 				}
 
-				$arrMeta = $this->getMetaData($objFiles->meta, $objPage->language);
+				$arrMeta = $this->getMetaData($objFiles->meta, $pageLanguage);
 
 				if (empty($arrMeta))
 				{
@@ -134,9 +136,9 @@ class ContentDownloads extends ContentDownload
 						continue;
 					}
 
-					if ($objPage->rootFallbackLanguage !== null)
+					if ($pageRootFallbackLanguage !== null)
 					{
-						$arrMeta = $this->getMetaData($objFiles->meta, $objPage->rootFallbackLanguage);
+						$arrMeta = $this->getMetaData($objFiles->meta, $pageRootFallbackLanguage);
 					}
 				}
 
@@ -208,7 +210,7 @@ class ContentDownloads extends ContentDownload
 						continue;
 					}
 
-					$arrMeta = $this->getMetaData($objSubfiles->meta, $objPage->language);
+					$arrMeta = $this->getMetaData($objSubfiles->meta, $pageLanguage);
 
 					if (empty($arrMeta))
 					{
@@ -217,9 +219,9 @@ class ContentDownloads extends ContentDownload
 							continue;
 						}
 
-						if ($objPage->rootFallbackLanguage !== null)
+						if ($pageRootFallbackLanguage !== null)
 						{
-							$arrMeta = $this->getMetaData($objSubfiles->meta, $objPage->rootFallbackLanguage);
+							$arrMeta = $this->getMetaData($objSubfiles->meta, $pageRootFallbackLanguage);
 						}
 					}
 

--- a/core-bundle/src/Resources/contao/elements/ContentDownloads.php
+++ b/core-bundle/src/Resources/contao/elements/ContentDownloads.php
@@ -227,7 +227,7 @@ class ContentDownloads extends ContentDownload
 					{
 						/** @var PageModel $objPage */
 						global $objPage;
-						
+
 						$arrMeta = $this->getMetaData($objSubfiles->meta, $objPage->language);
 
 						if (empty($arrMeta))

--- a/core-bundle/src/Resources/contao/elements/ContentDownloads.php
+++ b/core-bundle/src/Resources/contao/elements/ContentDownloads.php
@@ -104,6 +104,7 @@ class ContentDownloads extends ContentDownload
 		$auxDate = array();
 
 		$objFiles = $this->objFiles;
+		$request = System::getContainer()->get('request_stack')->getCurrentRequest();
 		$allowedDownload = StringUtil::trimsplit(',', strtolower(Config::get('allowedDownload')));
 
 		// Get all files


### PR DESCRIPTION
I am getting a warning in backend with debug mode enabled when I open an article containing the downloads element.

![image](https://user-images.githubusercontent.com/87128053/150656068-0c2c4eb2-8826-49e2-9825-e0f4471b3d7e.png)

The problem is, that $objPage is NULL in backend. When I tried to access a property from NULL PHP7 generated just a notice that was ignored in the debug mode. PHP8 generates a warning, so I have to disable the debug mode when I try to open a article containing a downloads element in backend.

I changed the code to check, if $objPage exists.

Fixes #

<!--
Bugfixes should be based on the 4.9 or 4.13 branch and features on the 5.x
branch. Select the correct branch in the "base:" drop-down menu above.

Replace this notice with a short README for your feature/bugfix. This will help
people to understand your PR and can be used as a start for the documentation.
-->
