### PR TITLE
Allow filtering for files/directories when listing contents

### DIFF
--- a/core-bundle/src/Filesystem/FilesystemItemIterator.php
+++ b/core-bundle/src/Filesystem/FilesystemItemIterator.php
@@ -63,6 +63,7 @@ class FilesystemItemIterator implements \IteratorAggregate
     {
         foreach ($this->listing as $item) {
             if (!$item instanceof FilesystemItem) {
+                /** @phpstan-ignore-next-line */
                 $type = \is_object($item) ? \get_class($item) : \gettype($item);
 
                 throw new \TypeError(sprintf('%s can only iterate over elements of type %s, got %s.', __CLASS__, FilesystemItem::class, $type));

--- a/core-bundle/src/Filesystem/FilesystemItemIterator.php
+++ b/core-bundle/src/Filesystem/FilesystemItemIterator.php
@@ -70,7 +70,6 @@ class FilesystemItemIterator implements \IteratorAggregate
      */
     public function toArray(): array
     {
-        return $this->listing instanceof \Traversable ?
-            iterator_to_array($this->listing, false) : (array) $this->listing;
+        return iterator_to_array($this, false);
     }
 }

--- a/core-bundle/src/Filesystem/FilesystemItemIterator.php
+++ b/core-bundle/src/Filesystem/FilesystemItemIterator.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Filesystem;
+
+/**
+ * @implements \IteratorAggregate<int, FilesystemItem>
+ */
+class FilesystemItemIterator implements \IteratorAggregate
+{
+    /**
+     * @var iterable<FilesystemItem>
+     */
+    private iterable $listing;
+
+    /**
+     * @param iterable<FilesystemItem> $listing
+     */
+    public function __construct(iterable $listing)
+    {
+        $this->listing = $listing;
+    }
+
+    public function filter(callable $filter): self
+    {
+        $listFiltered = static function (iterable $listing) use ($filter): \Generator {
+            foreach ($listing as $item) {
+                if ($filter($item)) {
+                    yield $item;
+                }
+            }
+        };
+
+        return new self($listFiltered($this->listing));
+    }
+
+    public function files(): self
+    {
+        return $this->filter(static fn (FilesystemItem $item) => $item->isFile());
+    }
+
+    public function directories(): self
+    {
+        return $this->filter(static fn (FilesystemItem $item) => !$item->isFile());
+    }
+
+    /**
+     * @return iterable<FilesystemItem>
+     */
+    public function getIterator(): iterable
+    {
+        return $this->listing instanceof \Traversable ?
+            $this->listing : new \ArrayIterator($this->listing);
+    }
+
+    /**
+     * @return array<FilesystemItem>
+     */
+    public function toArray(): array
+    {
+        return $this->listing instanceof \Traversable ?
+            iterator_to_array($this->listing, false) : (array) $this->listing;
+    }
+}

--- a/core-bundle/src/Filesystem/FilesystemItemIterator.php
+++ b/core-bundle/src/Filesystem/FilesystemItemIterator.php
@@ -61,8 +61,15 @@ class FilesystemItemIterator implements \IteratorAggregate
      */
     public function getIterator(): \Traversable
     {
-        return $this->listing instanceof \Traversable ?
-            $this->listing : new \ArrayIterator($this->listing);
+        foreach ($this->listing as $item) {
+            if (!$item instanceof FilesystemItem) {
+                $type = \is_object($item) ? \get_class($item) : \gettype($item);
+
+                throw new \TypeError(sprintf('%s can only iterate over elements of type %s, got %s.', __CLASS__, FilesystemItem::class, $type));
+            }
+
+            yield $item;
+        }
     }
 
     /**

--- a/core-bundle/src/Filesystem/FilesystemItemIterator.php
+++ b/core-bundle/src/Filesystem/FilesystemItemIterator.php
@@ -30,6 +30,9 @@ class FilesystemItemIterator implements \IteratorAggregate
         $this->listing = $listing;
     }
 
+    /**
+     * @param callable(FilesystemItem):bool $filter
+     */
     public function filter(callable $filter): self
     {
         $listFiltered = static function (iterable $listing) use ($filter): \Generator {

--- a/core-bundle/src/Filesystem/FilesystemItemIterator.php
+++ b/core-bundle/src/Filesystem/FilesystemItemIterator.php
@@ -57,9 +57,9 @@ class FilesystemItemIterator implements \IteratorAggregate
     }
 
     /**
-     * @return iterable<FilesystemItem>
+     * @return \Traversable<FilesystemItem>
      */
-    public function getIterator(): iterable
+    public function getIterator(): \Traversable
     {
         return $this->listing instanceof \Traversable ?
             $this->listing : new \ArrayIterator($this->listing);

--- a/core-bundle/src/Filesystem/VirtualFilesystem.php
+++ b/core-bundle/src/Filesystem/VirtualFilesystem.php
@@ -157,7 +157,7 @@ class VirtualFilesystem implements VirtualFilesystemInterface
         $this->dbafsManager->sync($pathFrom, $pathTo);
     }
 
-    public function listContents($location, bool $deep = false, int $accessFlags = self::NONE): iterable
+    public function listContents($location, bool $deep = false, int $accessFlags = self::NONE): FilesystemItemIterator
     {
         $path = $this->resolve($location);
 
@@ -165,7 +165,7 @@ class VirtualFilesystem implements VirtualFilesystemInterface
             $this->dbafsManager->sync($path);
         }
 
-        return $this->doListContents($path, $deep, $accessFlags);
+        return new FilesystemItemIterator($this->doListContents($path, $deep, $accessFlags));
     }
 
     public function getLastModified($location, int $accessFlags = self::NONE): int

--- a/core-bundle/src/Filesystem/VirtualFilesystemInterface.php
+++ b/core-bundle/src/Filesystem/VirtualFilesystemInterface.php
@@ -125,10 +125,8 @@ interface VirtualFilesystemInterface
      *
      * @throws VirtualFilesystemException
      * @throws UnableToResolveUuidException
-     *
-     * @return iterable<FilesystemItem>
      */
-    public function listContents($location, bool $deep = false, int $accessFlags = self::NONE): iterable;
+    public function listContents($location, bool $deep = false, int $accessFlags = self::NONE): FilesystemItemIterator;
 
     /**
      * @param string|Uuid $location

--- a/core-bundle/tests/Filesystem/Dbafs/DbafsTest.php
+++ b/core-bundle/tests/Filesystem/Dbafs/DbafsTest.php
@@ -21,6 +21,7 @@ use Contao\CoreBundle\Filesystem\Dbafs\Hashing\HashGenerator;
 use Contao\CoreBundle\Filesystem\Dbafs\Hashing\HashGeneratorInterface;
 use Contao\CoreBundle\Filesystem\Dbafs\RetrieveDbafsMetadataEvent;
 use Contao\CoreBundle\Filesystem\Dbafs\StoreDbafsMetadataEvent;
+use Contao\CoreBundle\Filesystem\FilesystemItemIterator;
 use Contao\CoreBundle\Filesystem\MountManager;
 use Contao\CoreBundle\Filesystem\VirtualFilesystem;
 use Contao\CoreBundle\Filesystem\VirtualFilesystemInterface;
@@ -1191,7 +1192,7 @@ class DbafsTest extends TestCase
         $filesystem = $this->createMock(VirtualFilesystemInterface::class);
         $filesystem
             ->method('listContents')
-            ->willReturn([])
+            ->willReturn(new FilesystemItemIterator([]))
         ;
 
         $dbafs = $this->getDbafs(null, $filesystem);

--- a/core-bundle/tests/Filesystem/FilesystemItemIteratorTest.php
+++ b/core-bundle/tests/Filesystem/FilesystemItemIteratorTest.php
@@ -66,6 +66,27 @@ class FilesystemItemIteratorTest extends TestCase
     }
 
     /**
+     * @dataProvider provideInvalidItems
+     *
+     * @param mixed $item
+     */
+    public function testEnsuresTypeSafetyWhenIterating($item, string $expectedType): void
+    {
+        $iterator = new FilesystemItemIterator([$item]);
+
+        $this->expectException(\TypeError::class);
+        $this->expectExceptionMessage("Contao\\CoreBundle\\Filesystem\\FilesystemItemIterator can only iterate over elements of type Contao\\CoreBundle\\Filesystem\\FilesystemItem, got $expectedType.");
+
+        iterator_to_array($iterator);
+    }
+
+    public function provideInvalidItems(): \Generator
+    {
+        yield 'scalar' => [42, 'integer'];
+        yield 'object of wrong type' => [new \stdClass(), 'stdClass'];
+    }
+
+    /**
      * @param array<string>         $expected
      * @param array<FilesystemItem> $actual
      */

--- a/core-bundle/tests/Filesystem/FilesystemItemIteratorTest.php
+++ b/core-bundle/tests/Filesystem/FilesystemItemIteratorTest.php
@@ -75,7 +75,7 @@ class FilesystemItemIteratorTest extends TestCase
         $iterator = new FilesystemItemIterator([$item]);
 
         $this->expectException(\TypeError::class);
-        $this->expectExceptionMessage("Contao\\CoreBundle\\Filesystem\\FilesystemItemIterator can only iterate over elements of type Contao\\CoreBundle\\Filesystem\\FilesystemItem, got $expectedType.");
+        $this->expectExceptionMessage('Contao\CoreBundle\Filesystem\FilesystemItemIterator can only iterate over elements of type Contao\CoreBundle\Filesystem\FilesystemItem, got '.$expectedType);
 
         iterator_to_array($iterator);
     }
@@ -92,12 +92,6 @@ class FilesystemItemIteratorTest extends TestCase
      */
     private function assertSameItems(array $expected, array $actual): void
     {
-        $this->assertSame(
-            $expected,
-            array_map(
-                static fn (FilesystemItem $item): string => $item->getPath(),
-                $actual
-            )
-        );
+        $this->assertSame($expected, array_map(static fn (FilesystemItem $item): string => $item->getPath(), $actual));
     }
 }

--- a/core-bundle/tests/Filesystem/FilesystemItemIteratorTest.php
+++ b/core-bundle/tests/Filesystem/FilesystemItemIteratorTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\Filesystem;
+
+use Contao\CoreBundle\Filesystem\FilesystemItem;
+use Contao\CoreBundle\Filesystem\FilesystemItemIterator;
+use Contao\CoreBundle\Tests\TestCase;
+
+class FilesystemItemIteratorTest extends TestCase
+{
+    public function testFilterAndIterate(): void
+    {
+        $iterator = new FilesystemItemIterator([
+            new FilesystemItem(true, 'foo.jpg'),
+            new FilesystemItem(false, 'bar'),
+            new FilesystemItem(true, 'baz.txt'),
+            new FilesystemItem(false, 'foobar'),
+        ]);
+
+        $allItems = [];
+
+        foreach ($iterator as $item) {
+            $allItems[] = $item;
+        }
+
+        $this->assertSameItems(['foo.jpg', 'bar', 'baz.txt', 'foobar'], $allItems);
+        $this->assertSameItems(['foo.jpg', 'bar', 'baz.txt', 'foobar'], $iterator->toArray());
+
+        $files = [];
+
+        foreach ($iterator->files() as $item) {
+            $files[] = $item;
+        }
+
+        $this->assertSameItems(['foo.jpg', 'baz.txt'], $files);
+        $this->assertSameItems(['foo.jpg', 'baz.txt'], $iterator->files()->toArray());
+
+        $directories = [];
+
+        foreach ($iterator->directories() as $item) {
+            $directories[] = $item;
+        }
+
+        $this->assertSameItems(['bar', 'foobar'], $directories);
+        $this->assertSameItems(['bar', 'foobar'], $iterator->directories()->toArray());
+
+        $custom = [];
+        $customFilter = static fn (FilesystemItem $item) => 'b' === $item->getPath()[0];
+
+        foreach ($iterator->filter($customFilter) as $item) {
+            $custom[] = $item;
+        }
+
+        $this->assertSameItems(['bar', 'baz.txt'], $custom);
+        $this->assertSameItems(['bar', 'baz.txt'], $iterator->filter($customFilter)->toArray());
+    }
+
+    /**
+     * @param array<string>         $expected
+     * @param array<FilesystemItem> $actual
+     */
+    private function assertSameItems(array $expected, array $actual): void
+    {
+        $this->assertSame(
+            $expected,
+            array_map(
+                static fn (FilesystemItem $item): string => $item->getPath(),
+                $actual
+            )
+        );
+    }
+}


### PR DESCRIPTION
Implements #4011 

This introduces a `FilesystemItemIterator` that allows filtering the result on the go. There is a shortcut `files()` and `directories()` that filters for, well, files and directories. :smile: Everything is on-demand, because it uses generators under the hood.

After implementing, I realized, that Flysystem uses somthing awfully similar with their [DirectoryListing](https://github.com/thephpleague/flysystem/blob/3.x/src/DirectoryListing.php) which to me is an indicator, that we're on the right track.

**Usage:**
```php
// Listing files
foreach ($this->myStorage->listContents('images')->files() as $file) {
    $item->isFile(); // will be true
}

// Custom filter
$textFilesFilter = static fn(FilesystemItem $item): bool =>
    $item->isFile() && 'txt' === Path::getExtension($item->getPath(), true)
;

foreach ($this->myStorage->listContents('images')->filter($textFilesFilter) as $textFiles) {
    // …
}
```