### PR TITLE
Reload translations if the language changes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -104,6 +104,7 @@
         "symfony/lock": "4.4.*",
         "symfony/monolog-bridge": "4.4.*",
         "symfony/monolog-bundle": "^3.1",
+        "symfony/polyfill-php73": "^1.8",
         "symfony/process": "4.4.*",
         "symfony/proxy-manager-bridge": "4.4.*",
         "symfony/routing": "4.4.*",

--- a/core-bundle/composer.json
+++ b/core-bundle/composer.json
@@ -88,6 +88,7 @@
         "symfony/http-kernel": "4.4.*",
         "symfony/lock": "4.4.*",
         "symfony/monolog-bridge": "4.4.*",
+        "symfony/polyfill-php73": "^1.8",
         "symfony/process": "4.4.*",
         "symfony/routing": "4.4.*",
         "symfony/security-bundle": "4.4.*",

--- a/core-bundle/src/Resources/contao/library/Contao/System.php
+++ b/core-bundle/src/Resources/contao/library/Contao/System.php
@@ -460,7 +460,7 @@ abstract class System
 		}
 
 		// Return if the language file has been loaded already
-		if (!$blnNoCache && isset(static::$arrLanguageFiles[$strName][$strLanguage]))
+		if (!$blnNoCache && array_key_last(static::$arrLanguageFiles[$strName] ?? array()) === $strLanguage)
 		{
 			return;
 		}
@@ -484,6 +484,9 @@ abstract class System
 				$strLanguage = 'en';
 			}
 		}
+
+		// Unset to move the new array key to the last position
+		unset(static::$arrLanguageFiles[$strName][$strCacheKey]);
 
 		// Use a global cache variable to support nested calls
 		static::$arrLanguageFiles[$strName][$strCacheKey] = $strLanguage;

--- a/core-bundle/tests/Contao/SystemTest.php
+++ b/core-bundle/tests/Contao/SystemTest.php
@@ -12,11 +12,24 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Tests\Contao;
 
+use Contao\CoreBundle\Tests\TestCase;
 use Contao\System;
-use PHPUnit\Framework\TestCase;
+use Symfony\Component\Filesystem\Filesystem;
 
 class SystemTest extends TestCase
 {
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        unset($GLOBALS['TL_LANG']);
+        $systemReflection = new \ReflectionClass(System::class);
+        $systemReflection->setStaticPropertyValue('arrLanguageFiles', []);
+        $systemReflection->setStaticPropertyValue('objContainer', null);
+
+        (new Filesystem())->remove($this->getTempDir());
+    }
+
     public function testFormatsANumber(): void
     {
         $number = '12004.34564';
@@ -62,5 +75,94 @@ class SystemTest extends TestCase
 
         $this->assertSame('172.16.254.0', System::anonymizeIp($ipv4));
         $this->assertSame('2001:0db8:85a3:0042:0000:8a2e:0370:0000', System::anonymizeIp($ipv6));
+    }
+
+    public function testLoadsLanguageFiles(): void
+    {
+        $tmpDir = $this->getTempDir();
+
+        (new Filesystem())->dumpFile(
+            "$tmpDir/contao/languages/en/default.php",
+            '<?php $GLOBALS["TL_LANG"]["MSC"]["test"] = "Test English";'
+            .'$GLOBALS["TL_LANG"]["MSC"]["order_test"] = "en";'
+        );
+
+        (new Filesystem())->dumpFile(
+            "$tmpDir/contao/languages/de/default.php",
+            '<?php $GLOBALS["TL_LANG"]["MSC"]["test"] = "Test deutsch";'
+            .'$GLOBALS["TL_LANG"]["MSC"]["order_test"] .= "|de";'
+        );
+
+        (new Filesystem())->dumpFile(
+            "$tmpDir/contao/languages/fr/default.php",
+            '<?php $GLOBALS["TL_LANG"]["MSC"]["test"] = "Test français";'
+            .'$GLOBALS["TL_LANG"]["MSC"]["order_test"] .= "|fr";'
+        );
+
+        $container = $this->getContainerWithContaoConfiguration($tmpDir);
+        $container->setParameter('contao.resources_paths', ["$tmpDir/contao"]);
+
+        System::setContainer($container);
+
+        System::loadLanguageFile('default', 'en');
+
+        $this->assertSame('Test English', $GLOBALS['TL_LANG']['MSC']['test']);
+        $this->assertSame('en', $GLOBALS['TL_LANG']['MSC']['order_test']);
+
+        System::loadLanguageFile('default', 'de');
+
+        $this->assertSame('Test deutsch', $GLOBALS['TL_LANG']['MSC']['test']);
+        $this->assertSame('en|de', $GLOBALS['TL_LANG']['MSC']['order_test']);
+
+        System::loadLanguageFile('default', 'fr');
+
+        $this->assertSame('Test français', $GLOBALS['TL_LANG']['MSC']['test']);
+        $this->assertSame('en|fr', $GLOBALS['TL_LANG']['MSC']['order_test']);
+
+        System::loadLanguageFile('does_not_exist', 'de');
+
+        $this->assertSame('Test français', $GLOBALS['TL_LANG']['MSC']['test']);
+        $this->assertSame('en|fr', $GLOBALS['TL_LANG']['MSC']['order_test']);
+
+        System::loadLanguageFile('default', 'en');
+
+        $this->assertSame('Test English', $GLOBALS['TL_LANG']['MSC']['test']);
+        $this->assertSame('en', $GLOBALS['TL_LANG']['MSC']['order_test']);
+
+        System::loadLanguageFile('default', 'fr');
+
+        $this->assertSame('Test français', $GLOBALS['TL_LANG']['MSC']['test']);
+        $this->assertSame('en|fr', $GLOBALS['TL_LANG']['MSC']['order_test']);
+
+        System::loadLanguageFile('default', 'de');
+
+        $this->assertSame('Test deutsch', $GLOBALS['TL_LANG']['MSC']['test']);
+        $this->assertSame('en|de', $GLOBALS['TL_LANG']['MSC']['order_test']);
+
+        System::loadLanguageFile('does_not_exist', 'fr');
+
+        $this->assertSame('Test deutsch', $GLOBALS['TL_LANG']['MSC']['test']);
+        $this->assertSame('en|de', $GLOBALS['TL_LANG']['MSC']['order_test']);
+
+        (new Filesystem())->dumpFile(
+            "$tmpDir/contao/languages/de/default.php",
+            '<?php $GLOBALS["TL_LANG"]["MSC"]["test"] = "changed";'
+            .'$GLOBALS["TL_LANG"]["MSC"]["order_test"] .= "changed";'
+        );
+
+        System::loadLanguageFile('does_not_exist', 'fr');
+        System::loadLanguageFile('default', 'de');
+
+        $this->assertSame(
+            'Test deutsch',
+            $GLOBALS['TL_LANG']['MSC']['test'],
+            'Should have been cached, not loaded from the PHP file.'
+        );
+
+        $this->assertSame(
+            'en|de',
+            $GLOBALS['TL_LANG']['MSC']['order_test'],
+            'Should have been cached, not loaded from the PHP file.'
+        );
     }
 }

--- a/core-bundle/tests/Contao/SystemTest.php
+++ b/core-bundle/tests/Contao/SystemTest.php
@@ -23,9 +23,16 @@ class SystemTest extends TestCase
         parent::tearDown();
 
         unset($GLOBALS['TL_LANG']);
-        $systemReflection = new \ReflectionClass(System::class);
-        $systemReflection->setStaticPropertyValue('arrLanguageFiles', []);
-        $systemReflection->setStaticPropertyValue('objContainer', null);
+
+        $system = new \ReflectionClass(System::class);
+
+        $langProperty = $system->getProperty('arrLanguageFiles');
+        $langProperty->setAccessible(true);
+        $langProperty->setValue([]);
+
+        $containerProperty = $system->getProperty('objContainer');
+        $containerProperty->setAccessible(true);
+        $containerProperty->setValue(null);
 
         (new Filesystem())->remove($this->getTempDir());
     }

--- a/core-bundle/tests/Fragment/Reference/ContentElementReferenceTest.php
+++ b/core-bundle/tests/Fragment/Reference/ContentElementReferenceTest.php
@@ -20,7 +20,7 @@ class ContentElementReferenceTest extends TestCase
 {
     public function testCreatesTheControllerNameFromTheModelType(): void
     {
-        $model = new ContentModel();
+        $model = (new \ReflectionClass(ContentModel::class))->newInstanceWithoutConstructor();
         $model->type = 'foobar';
 
         $reference = new ContentElementReference($model);
@@ -30,7 +30,7 @@ class ContentElementReferenceTest extends TestCase
 
     public function testAddsTheSectionAttribute(): void
     {
-        $model = new ContentModel();
+        $model = (new \ReflectionClass(ContentModel::class))->newInstanceWithoutConstructor();
         $model->type = 'foobar';
 
         $reference = new ContentElementReference($model);

--- a/core-bundle/tests/Fragment/Reference/ContentElementReferenceTest.php
+++ b/core-bundle/tests/Fragment/Reference/ContentElementReferenceTest.php
@@ -20,8 +20,10 @@ class ContentElementReferenceTest extends TestCase
 {
     public function testCreatesTheControllerNameFromTheModelType(): void
     {
-        $model = (new \ReflectionClass(ContentModel::class))->newInstanceWithoutConstructor();
-        $model->type = 'foobar';
+        $model = $this->mockClassWithProperties(
+            ContentModel::class,
+            ['type' => 'foobar']
+        );
 
         $reference = new ContentElementReference($model);
 
@@ -30,8 +32,7 @@ class ContentElementReferenceTest extends TestCase
 
     public function testAddsTheSectionAttribute(): void
     {
-        $model = (new \ReflectionClass(ContentModel::class))->newInstanceWithoutConstructor();
-        $model->type = 'foobar';
+        $model = $this->createMock(ContentModel::class);
 
         $reference = new ContentElementReference($model);
         $this->assertSame('main', $reference->attributes['section']);

--- a/core-bundle/tests/Fragment/Reference/FrontendModuleReferenceTest.php
+++ b/core-bundle/tests/Fragment/Reference/FrontendModuleReferenceTest.php
@@ -20,7 +20,7 @@ class FrontendModuleReferenceTest extends TestCase
 {
     public function testCreatesTheControllerNameFromTheModelType(): void
     {
-        $model = new ModuleModel();
+        $model = (new \ReflectionClass(ModuleModel::class))->newInstanceWithoutConstructor();
         $model->type = 'foobar';
 
         $reference = new FrontendModuleReference($model);
@@ -30,7 +30,7 @@ class FrontendModuleReferenceTest extends TestCase
 
     public function testAddsTheSectionAttribute(): void
     {
-        $model = new ModuleModel();
+        $model = (new \ReflectionClass(ModuleModel::class))->newInstanceWithoutConstructor();
         $model->type = 'foobar';
 
         $reference = new FrontendModuleReference($model);

--- a/core-bundle/tests/Fragment/Reference/FrontendModuleReferenceTest.php
+++ b/core-bundle/tests/Fragment/Reference/FrontendModuleReferenceTest.php
@@ -20,8 +20,10 @@ class FrontendModuleReferenceTest extends TestCase
 {
     public function testCreatesTheControllerNameFromTheModelType(): void
     {
-        $model = (new \ReflectionClass(ModuleModel::class))->newInstanceWithoutConstructor();
-        $model->type = 'foobar';
+        $model = $this->mockClassWithProperties(
+            ModuleModel::class,
+            ['type' => 'foobar']
+        );
 
         $reference = new FrontendModuleReference($model);
 
@@ -30,8 +32,7 @@ class FrontendModuleReferenceTest extends TestCase
 
     public function testAddsTheSectionAttribute(): void
     {
-        $model = (new \ReflectionClass(ModuleModel::class))->newInstanceWithoutConstructor();
-        $model->type = 'foobar';
+        $model = $this->createMock(ModuleModel::class);
 
         $reference = new FrontendModuleReference($model);
         $this->assertSame('main', $reference->attributes['section']);


### PR DESCRIPTION
Fixes #4008

I kept the existing structure of `System::$arrLanguageFiles` for better backwards compatibility.

@bennyborn can you test if the two changes from _core-bundle/src/Resources/contao/library/Contao/System.php_ fix your issue in Contao 4.12?