### PR TITLE
Fix compatibility with Composer 2.2.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -232,7 +232,6 @@
     "config": {
         "allow-plugins": {
             "bamarni/composer-bin-plugin": true,
-            "composer/package-versions-deprecated": true,
             "contao-components/installer": true,
             "contao/manager-plugin": true
         }

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "ext-zlib": "*",
         "ausi/slug-generator": "^1.1",
         "bacon/bacon-qr-code": "^2.0",
-        "composer/package-versions-deprecated": "^1.8",
+        "composer/package-versions-deprecated": "^1.11.99.5",
         "contao-components/ace": "^1.2",
         "contao-components/chosen": "^1.2",
         "contao-components/colorbox": "^1.6",

--- a/core-bundle/composer.json
+++ b/core-bundle/composer.json
@@ -26,7 +26,7 @@
         "ext-zlib": "*",
         "ausi/slug-generator": "^1.1",
         "bacon/bacon-qr-code": "^2.0",
-        "composer/package-versions-deprecated": "^1.8",
+        "composer/package-versions-deprecated": "^1.11.99.5",
         "contao-components/ace": "^1.2",
         "contao-components/chosen": "^1.2",
         "contao-components/colorbox": "^1.6",

--- a/core-bundle/src/DependencyInjection/Compiler/AddAssetsPackagesPass.php
+++ b/core-bundle/src/DependencyInjection/Compiler/AddAssetsPackagesPass.php
@@ -91,10 +91,7 @@ class AddAssetsPackagesPass implements CompilerPassInterface
             && method_exists(InstalledVersions::class, 'getPrettyVersion')
         ) {
             $versions = InstalledVersions::getInstalledPackagesByType('contao-component');
-            $versions = array_combine(
-                $versions,
-                array_map([InstalledVersions::class, 'getPrettyVersion'], $versions)
-            );
+            $versions = array_combine($versions, array_map([InstalledVersions::class, 'getPrettyVersion'], $versions));
         } else {
             $versions = Versions::VERSIONS;
         }

--- a/core-bundle/src/DependencyInjection/Compiler/AddAssetsPackagesPass.php
+++ b/core-bundle/src/DependencyInjection/Compiler/AddAssetsPackagesPass.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\DependencyInjection\Compiler;
 
+use Composer\InstalledVersions;
 use Contao\CoreBundle\Util\PackageUtil;
 use PackageVersions\Versions;
 use Symfony\Component\DependencyInjection\ChildDefinition;
@@ -84,7 +85,21 @@ class AddAssetsPackagesPass implements CompilerPassInterface
         $packages = $container->getDefinition('assets.packages');
         $context = new Reference('contao.assets.assets_context');
 
-        foreach (Versions::VERSIONS as $name => $version) {
+        // The Versions::VERSIONS constant is empty since Composer 2.2.5
+        if (
+            method_exists(InstalledVersions::class, 'getInstalledPackagesByType')
+            && method_exists(InstalledVersions::class, 'getPrettyVersion')
+        ) {
+            $versions = InstalledVersions::getInstalledPackagesByType('contao-component');
+            $versions = array_combine(
+                $versions,
+                array_map([InstalledVersions::class, 'getPrettyVersion'], $versions)
+            );
+        } else {
+            $versions = Versions::VERSIONS;
+        }
+
+        foreach ($versions as $name => $version) {
             if (0 !== strncmp('contao-components/', $name, 18)) {
                 continue;
             }

--- a/core-bundle/src/DependencyInjection/Compiler/AddPackagesPass.php
+++ b/core-bundle/src/DependencyInjection/Compiler/AddPackagesPass.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\DependencyInjection\Compiler;
 
+use Composer\InstalledVersions;
 use Contao\CoreBundle\Util\PackageUtil;
 use PackageVersions\Versions;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
@@ -28,8 +29,19 @@ class AddPackagesPass implements CompilerPassInterface
     {
         $packages = [];
 
-        foreach (Versions::VERSIONS as $name => $version) {
-            $packages[$name] = PackageUtil::parseVersion($version);
+        // The Versions::VERSIONS constant is empty since Composer 2.2.5
+        if (method_exists(InstalledVersions::class, 'getAllRawData')) {
+            foreach (InstalledVersions::getAllRawData() as $installed) {
+                foreach ($installed['versions'] as $name => $version) {
+                    if (isset($version['pretty_version'])) {
+                        $packages[$name] = ltrim($version['pretty_version'], 'v');
+                    }
+                }
+            }
+        } else {
+            foreach (Versions::VERSIONS as $name => $version) {
+                $packages[$name] = PackageUtil::parseVersion($version);
+            }
         }
 
         $container->setParameter('kernel.packages', $packages);

--- a/core-bundle/src/Util/PackageUtil.php
+++ b/core-bundle/src/Util/PackageUtil.php
@@ -49,7 +49,7 @@ class PackageUtil
      */
     public static function parseVersion(string $version): string
     {
-        return ltrim(strstr($version, '@', true), 'v');
+        return ltrim(strstr($version.'@', '@', true), 'v');
     }
 
     /**

--- a/core-bundle/tests/DependencyInjection/Compiler/AddPackagesPassTest.php
+++ b/core-bundle/tests/DependencyInjection/Compiler/AddPackagesPassTest.php
@@ -12,10 +12,10 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Tests\DependencyInjection\Compiler;
 
+use Composer\InstalledVersions;
 use Contao\CoreBundle\DependencyInjection\Compiler\AddPackagesPass;
 use Contao\CoreBundle\Tests\TestCase;
 use Contao\CoreBundle\Util\PackageUtil;
-use PackageVersions\Versions;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class AddPackagesPassTest extends TestCase
@@ -29,7 +29,7 @@ class AddPackagesPassTest extends TestCase
 
         $this->assertTrue($container->hasParameter('kernel.packages'));
 
-        $keys = array_keys(Versions::VERSIONS);
+        $keys = InstalledVersions::getInstalledPackages();
         $packages = $container->getParameter('kernel.packages');
 
         $this->assertIsArray($packages);


### PR DESCRIPTION
Fixes #4017

For everyone experiencing the issue `There is no "contao-components/*" asset package`:  
Downgrading to Composer 2.2.4 (e.g. via `composer self-update 2.2.4`) can be a way to workaround this issue for now.