### PR TITLE
Add missing option showFilePreview to fileTree widget

### DIFF
--- a/core-bundle/src/Resources/contao/widgets/FileTree.php
+++ b/core-bundle/src/Resources/contao/widgets/FileTree.php
@@ -10,6 +10,8 @@
 
 namespace Contao;
 
+use Contao\CoreBundle\Image\Preview\MissingPreviewProviderException;
+use Contao\CoreBundle\Image\Preview\UnableToGeneratePreviewException;
 use Contao\Image\ResizeConfiguration;
 
 /**
@@ -22,6 +24,7 @@ use Contao\Image\ResizeConfiguration;
  * @property boolean $isDownloads
  * @property boolean $files
  * @property boolean $filesOnly
+ * @property boolean $showFilePreview
  * @property string  $path
  * @property string  $extensions
  * @property string  $fieldType
@@ -264,7 +267,7 @@ class FileTree extends Widget
 							$objFile = new File($objFiles->path);
 							$strInfo = $objFiles->path . ' <span class="tl_gray">(' . $this->getReadableSize($objFile->size) . ($objFile->isImage ? ', ' . $objFile->width . 'x' . $objFile->height . ' px' : '') . ')</span>';
 
-							if ($objFile->isImage)
+							if ($this->showAsImage($objFile))
 							{
 								$arrValues[$objFiles->uuid] = $this->getPreviewImage($objFile, $strInfo);
 							}
@@ -307,7 +310,14 @@ class FileTree extends Widget
 							// Only show allowed download types
 							elseif (\in_array($objFile->extension, $allowedDownload) && !preg_match('/^meta(_[a-z]{2})?\.txt$/', $objFile->basename))
 							{
-								$arrValues[$objSubfiles->uuid] = Image::getHtml($objFile->icon) . ' ' . $strInfo;
+								if ($this->showAsImage($objFile))
+								{
+									$arrValues[$objSubfiles->uuid] = $this->getPreviewImage($objFile, $strInfo);
+								}
+								else
+								{
+									$arrValues[$objSubfiles->uuid] = Image::getHtml($objFile->icon) . ' ' . $strInfo;
+								}
 							}
 						}
 					}
@@ -327,7 +337,14 @@ class FileTree extends Widget
 						// Only show allowed download types
 						elseif (\in_array($objFile->extension, $allowedDownload) && !preg_match('/^meta(_[a-z]{2})?\.txt$/', $objFile->basename))
 						{
-							$arrValues[$objFiles->uuid] = Image::getHtml($objFile->icon) . ' ' . $strInfo;
+							if ($this->showAsImage($objFile))
+							{
+								$arrValues[$objFiles->uuid] = $this->getPreviewImage($objFile, $strInfo, 'gimage removable');
+							}
+							else
+							{
+								$arrValues[$objFiles->uuid] = Image::getHtml($objFile->icon) . ' ' . $strInfo;
+							}
 						}
 					}
 				}
@@ -444,6 +461,11 @@ class FileTree extends Widget
 	 */
 	protected function getPreviewImage(File $objFile, $strInfo, $strClass='gimage')
 	{
+		if ($previewPath = $this->getFilePreviewPath($objFile->path))
+		{
+			$objFile = new File(StringUtil::stripRootDir($previewPath));
+		}
+
 		if ($objFile->viewWidth && $objFile->viewHeight && ($objFile->isSvgImage || ($objFile->height <= Config::get('gdMaxImgHeight') && $objFile->width <= Config::get('gdMaxImgWidth'))))
 		{
 			// Inline the image if no preview image will be generated (see #636)
@@ -468,6 +490,37 @@ class FileTree extends Widget
 		}
 
 		return Image::getHtml($image, '', 'class="' . $strClass . '" title="' . StringUtil::specialchars($strInfo) . '"');
+	}
+
+	private function getFilePreviewPath(string $path): ?string
+	{
+		if (!$this->showFilePreview)
+		{
+			return null;
+		}
+
+		$container = System::getContainer();
+		$factory = $container->get('contao.image.preview_factory');
+		$sourcePath = $container->getParameter('kernel.project_dir') . '/' . $path;
+
+		try
+		{
+			return $factory->createPreview($sourcePath, 100)->getPath();
+		}
+		catch (UnableToGeneratePreviewException|MissingPreviewProviderException $exception)
+		{
+			return null;
+		}
+	}
+
+	private function showAsImage(File $objFile): bool
+	{
+		if ($objFile->isImage && !$this->isDownloads)
+		{
+			return true;
+		}
+
+		return $this->getFilePreviewPath($objFile->path) !== null;
 	}
 }
 


### PR DESCRIPTION
Followup to #3848

With `'showFilePreview' => true` regular files will also be shown as images in the picker widget.