### PR TITLE
Fatal error: Missing type definitions in User.php

### DIFF
--- a/core-bundle/src/Resources/contao/classes/FrontendUser.php
+++ b/core-bundle/src/Resources/contao/classes/FrontendUser.php
@@ -277,7 +277,7 @@ class FrontendUser extends User
 	/**
 	 * {@inheritdoc}
 	 */
-	public function getRoles()
+	public function getRoles(): array
 	{
 		return $this->roles;
 	}

--- a/core-bundle/src/Resources/contao/library/Contao/User.php
+++ b/core-bundle/src/Resources/contao/library/Contao/User.php
@@ -447,7 +447,7 @@ abstract class User extends System implements UserInterface, EquatableInterface,
 	/**
 	 * {@inheritdoc}
 	 */
-	public function getRoles()
+	public function getRoles(): array
 	{
 		return array();
 	}
@@ -621,7 +621,7 @@ abstract class User extends System implements UserInterface, EquatableInterface,
 	/**
 	 * {@inheritdoc}
 	 */
-	public function isEqualTo(UserInterface $user)
+	public function isEqualTo(UserInterface $user): bool
 	{
 		if (!$user instanceof self)
 		{


### PR DESCRIPTION
I got the following error messages when I tried to install the contao-search-bundle.

> Fatal error: Declaration of Contao\User::isEqualTo(Symfony\Component\Security\Core\User\UserInterface $user) must be compatible with Symfony\Component\Security\Core\User\EquatableInterface::isEqualTo(Symfony\Component\Security\Core\User\UserInterface $user): bool in .../vendor/contao/core-bundle/src/Resources/contao/library/Contao/User.php on line 624

> Fatal error: Declaration of Contao\User::getRoles() must be compatible with Symfony\Component\Security\Core\User\UserInterface::getRoles(): array in .../vendor/contao/core-bundle/src/Resources/contao/library/Contao/User.php on line 450

The [symfony/security-bundle (5.4) uses the symfony/security-core (^6.0)](https://github.com/symfony/symfony/blob/a02a8e3bedeb7da42af84fde652cdf1f9286b37e/src/Symfony/Bundle/SecurityBundle/composer.json#L29) with additional type definitions in [EquatableInterface](https://github.com/symfony/symfony/blob/c5a4947c045e8a32e5c685d4f4950b493c3b129d/src/Symfony/Component/Security/Core/User/EquatableInterface.php#L29) and [UserInterface](https://github.com/symfony/symfony/blob/c5a4947c045e8a32e5c685d4f4950b493c3b129d/src/Symfony/Component/Security/Core/User/UserInterface.php#L47).