### PR TITLE
Fix multiple page controller routing issues

### DIFF
--- a/core-bundle/src/DependencyInjection/Compiler/RegisterPagesPass.php
+++ b/core-bundle/src/DependencyInjection/Compiler/RegisterPagesPass.php
@@ -95,7 +95,7 @@ class RegisterPagesPass implements CompilerPassInterface
         $pathRegex = null;
 
         if (\is_string($path) && 0 === strncmp($path, '/', 1)) {
-            $compiledRoute = (new Route($path))->compile();
+            $compiledRoute = (new Route($path, $defaults, $attributes['requirements'] ?? [], $attributes['options'] ?? []))->compile();
             $pathRegex = $compiledRoute->getRegex();
         }
 

--- a/core-bundle/src/Routing/Candidates/PageCandidates.php
+++ b/core-bundle/src/Routing/Candidates/PageCandidates.php
@@ -79,6 +79,9 @@ class PageCandidates extends AbstractCandidates
         $paths = [];
 
         foreach ($pathMap as $type => $pathRegex) {
+            // Remove existing named subpatterns
+            $pathRegex = preg_replace('/\?P<[^>]+>/', '', $pathRegex);
+
             $path = '(?P<'.$type.'>'.substr($pathRegex, 2, strrpos($pathRegex, '$') - 2).')';
             $lastParam = strrpos($path, '[^/]++');
 

--- a/core-bundle/src/Routing/Page/PageRoute.php
+++ b/core-bundle/src/Routing/Page/PageRoute.php
@@ -57,6 +57,10 @@ class PageRoute extends Route implements RouteObjectInterface
             $options['utf8'] = true;
         }
 
+        if (!isset($options['compiler_class'])) {
+            $options['compiler_class'] = PageRouteCompiler::class;
+        }
+
         if ('' === $path) {
             $path = '/'.($pageModel->alias ?: $pageModel->id);
         } elseif (0 !== strncmp($path, '/', 1)) {

--- a/core-bundle/src/Routing/Page/PageRouteCompiler.php
+++ b/core-bundle/src/Routing/Page/PageRouteCompiler.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Routing\Page;
+
+use Symfony\Component\Routing\CompiledRoute;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCompiler;
+
+class PageRouteCompiler extends RouteCompiler
+{
+    public static function compile(Route $route): CompiledRoute
+    {
+        if (!$route instanceof PageRoute || '' === $route->getUrlSuffix()) {
+            return parent::compile($route);
+        }
+
+        // Remove URL suffix from path to allow path without optional parameters
+        $urlSuffix = $route->getUrlSuffix();
+        $route->setUrlSuffix('');
+
+        $compiledRoute = parent::compile($route);
+
+        // Re-add the URL suffix to the original route
+        $route->setUrlSuffix($urlSuffix);
+
+        // Manually add the URL suffix to regex and path tokens
+        $regex = preg_replace('/^{\^([^$]+)\$}/', '{^$1'.preg_quote($urlSuffix, null).'$}', $compiledRoute->getRegex());
+        $tokens = $compiledRoute->getTokens();
+        array_unshift($tokens, ['text', $urlSuffix]);
+
+        return new CompiledRoute(
+            $compiledRoute->getStaticPrefix(),
+            $regex,
+            $tokens,
+            $compiledRoute->getPathVariables(),
+            $compiledRoute->getHostRegex(),
+            $compiledRoute->getHostTokens(),
+            $compiledRoute->getHostVariables(),
+            $compiledRoute->getVariables()
+        );
+    }
+}

--- a/core-bundle/src/Routing/Page/PageRouteCompiler.php
+++ b/core-bundle/src/Routing/Page/PageRouteCompiler.php
@@ -24,7 +24,7 @@ class PageRouteCompiler extends RouteCompiler
             return parent::compile($route);
         }
 
-        // Remove URL suffix from path to allow path without optional parameters
+        // Remove the URL suffix from the path to allow paths without optional parameters
         $urlSuffix = $route->getUrlSuffix();
         $route->setUrlSuffix('');
 

--- a/core-bundle/tests/Fixtures/Functional/PageController/page-with-alias.yml
+++ b/core-bundle/tests/Fixtures/Functional/PageController/page-with-alias.yml
@@ -1,0 +1,9 @@
+tl_page:
+    - id: 2
+      pid: 1
+      sorting: 128
+      tstamp: 1539698035
+      title: Test Page
+      alias: test
+      type: foobar
+      published: '1'

--- a/core-bundle/tests/Fixtures/Functional/PageController/page-without-alias.yml
+++ b/core-bundle/tests/Fixtures/Functional/PageController/page-without-alias.yml
@@ -1,0 +1,9 @@
+tl_page:
+    - id: 2
+      pid: 1
+      sorting: 128
+      tstamp: 1539698035
+      title: Test Page
+      alias: ''
+      type: foobar
+      published: '1'

--- a/core-bundle/tests/Fixtures/Functional/PageController/root-with-suffix.yml
+++ b/core-bundle/tests/Fixtures/Functional/PageController/root-with-suffix.yml
@@ -1,0 +1,14 @@
+tl_page:
+    - id: 1
+      pid: 0
+      sorting: 128
+      tstamp: 1539696285
+      title: Test Domain
+      alias: root
+      urlSuffix: .html
+      type: root
+      language: en
+      fallback: '1'
+      includeLayout: '1'
+      layout: 1
+      published: '1'

--- a/core-bundle/tests/Fixtures/Functional/PageController/root-without-suffix.yml
+++ b/core-bundle/tests/Fixtures/Functional/PageController/root-without-suffix.yml
@@ -1,0 +1,14 @@
+tl_page:
+    - id: 1
+      pid: 0
+      sorting: 128
+      tstamp: 1539696285
+      title: Test Domain
+      alias: root
+      urlSuffix: ''
+      type: root
+      language: en
+      fallback: '1'
+      includeLayout: '1'
+      layout: 1
+      published: '1'

--- a/core-bundle/tests/Fixtures/Functional/PageController/theme.yml
+++ b/core-bundle/tests/Fixtures/Functional/PageController/theme.yml
@@ -1,0 +1,27 @@
+tl_theme:
+    - id: 1
+      tstamp: 1539598899
+      name: Default
+      author: Leo Feyer
+
+tl_layout:
+    - id: 1
+      tstamp: 1539617638
+      name: Default
+      rows: 1rw
+      cols: 1cl
+      modules: a:1:{i:0;a:3:{s:3:"mod";s:1:"0";s:3:"col";s:4:"main";s:6:"enable";s:1:"1";}}
+      template: fe_page
+
+tl_user:
+    - id: 1
+      tstamp: 1539598726
+      username: k.jones
+      name: Kevin Jones
+      email: k.jones@example.com
+      language: de
+      password: $argon2id$v=19$m=65536,t=4,p=1$Qz+phxHnVCqYnMd3xZWmbQ$86GiZ3h9sDmXrbvzwXwjxgXNf1jwSitZr4fsbEkp7/U
+      admin: '1'
+      dateAdded: 1539598726
+      lastLogin: 1539686648
+      currentLogin: 1539694637

--- a/core-bundle/tests/Fixtures/src/Controller/Page/TestPageController.php
+++ b/core-bundle/tests/Fixtures/src/Controller/Page/TestPageController.php
@@ -17,11 +17,13 @@ use Contao\CoreBundle\Routing\Page\DynamicRouteInterface;
 use Contao\CoreBundle\Routing\Page\PageRoute;
 use Contao\PageModel;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
 
 class TestPageController extends AbstractController implements DynamicRouteInterface, ContentCompositionInterface
 {
-    public function __invoke(): void
+    public function __invoke(): Response
     {
+        return new Response();
     }
 
     public function supportsContentComposition(PageModel $pageModel): bool

--- a/core-bundle/tests/Functional/PageControllerTest.php
+++ b/core-bundle/tests/Functional/PageControllerTest.php
@@ -45,7 +45,7 @@ class PageControllerTest extends FunctionalTestCase
     }
 
     /**
-     * @param string|null|false $path
+     * @param string|false|null $path
      *
      * @dataProvider getPageController
      */

--- a/core-bundle/tests/Functional/PageControllerTest.php
+++ b/core-bundle/tests/Functional/PageControllerTest.php
@@ -118,9 +118,7 @@ class PageControllerTest extends FunctionalTestCase
         self::$lastImport = $fileNames;
 
         static::loadFixtures(array_map(
-            static function ($file) {
-                return __DIR__.'/../Fixtures/Functional/PageController/'.$file.'.yml';
-            },
+            static fn ($file) => __DIR__.'/../Fixtures/Functional/PageController/'.$file.'.yml',
             $fileNames
         ));
     }

--- a/core-bundle/tests/Functional/PageControllerTest.php
+++ b/core-bundle/tests/Functional/PageControllerTest.php
@@ -45,6 +45,8 @@ class PageControllerTest extends FunctionalTestCase
     }
 
     /**
+     * @param string|null|false $path
+     *
      * @dataProvider getPageController
      */
     public function testResolvesPageController(array $fixtures, string $request, $path, array $requirements, array $defaults): void

--- a/core-bundle/tests/Functional/PageControllerTest.php
+++ b/core-bundle/tests/Functional/PageControllerTest.php
@@ -23,10 +23,7 @@ use Symfony\Component\Routing\Route;
 
 class PageControllerTest extends FunctionalTestCase
 {
-    /**
-     * @var array|null
-     */
-    private static $lastImport;
+    private static ?array $lastImport = null;
 
     public static function setUpBeforeClass(): void
     {

--- a/core-bundle/tests/Functional/PageControllerTest.php
+++ b/core-bundle/tests/Functional/PageControllerTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\Functional;
+
+use Contao\CoreBundle\Fixtures\Controller\Page\TestPageController;
+use Contao\CoreBundle\Routing\Page\PageRegistry;
+use Contao\CoreBundle\Routing\Page\RouteConfig;
+use Contao\System;
+use Contao\TestCase\FunctionalTestCase;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Filesystem\Path;
+use Symfony\Component\Routing\Route;
+
+class PageControllerTest extends FunctionalTestCase
+{
+    /**
+     * @var array|null
+     */
+    private static $lastImport;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        static::bootKernel();
+        static::resetDatabaseSchema();
+        static::ensureKernelShutdown();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+
+        (new Filesystem())->remove(Path::canonicalize(__DIR__.'/../../var'));
+    }
+
+    /**
+     * @dataProvider getPageController
+     */
+    public function testResolvesPageController(array $fixtures, string $request, $path, array $requirements, array $defaults): void
+    {
+        $_SERVER['REQUEST_URI'] = $request;
+        $_SERVER['HTTP_HOST'] = 'example.com';
+        $_SERVER['HTTP_ACCEPT_LANGUAGE'] = 'en';
+        $_SERVER['HTTP_ACCEPT'] = 'text/html';
+
+        $client = $this->createClient([], $_SERVER);
+        $container = $client->getContainer();
+        System::setContainer($container);
+
+        $pageController = new TestPageController();
+        $pageController->setContainer($container);
+        $container->set(TestPageController::class, $pageController);
+
+        $pathRegex = null;
+
+        if (\is_string($path) && 0 === strncmp($path, '/', 1)) {
+            $compiledRoute = (new Route($path, $defaults, $requirements))->compile();
+            $pathRegex = $compiledRoute->getRegex();
+        }
+
+        $defaults['_controller'] = TestPageController::class;
+        $routeConfig = new RouteConfig($path, $pathRegex, null, $requirements, [], $defaults);
+        $container->get(PageRegistry::class)->add('foobar', $routeConfig);
+
+        $this->loadFixtureFiles($fixtures);
+
+        $client->request('GET', "https://example.com$request");
+        $response = $client->getResponse();
+
+        $this->assertSame(200, $response->getStatusCode());
+    }
+
+    public function getPageController(): \Generator
+    {
+        foreach (['/test', '/test/5', '/test/5/abc'] as $request) {
+            foreach ([true, false] as $withDefault) {
+                foreach ([true, false] as $withSuffix) {
+                    foreach ([true, false] as $withAlias) {
+                        $description = sprintf(
+                            'Request: %s, withDefault: %s, withSuffix: %s, withAlias: %s',
+                            $request,
+                            $withDefault ? 'yes' : 'no',
+                            $withSuffix ? 'yes' : 'no',
+                            $withAlias ? 'yes' : 'no'
+                        );
+
+                        yield $description => [
+                            ['theme', ($withSuffix ? 'root-with-suffix' : 'root-without-suffix'), ($withAlias ? 'page-with-alias' : 'page-without-alias')],
+                            $request.($withSuffix ? '.html' : ''),
+                            '/test/{slug'.($withDefault ? '' : '?').'}',
+                            ['slug' => '.+'],
+                            $withDefault ? ['slug' => null] : [],
+                        ];
+                    }
+                }
+            }
+        }
+    }
+
+    private function loadFixtureFiles(array $fileNames): void
+    {
+        // Do not reload the fixtures if they have not changed
+        if (self::$lastImport && self::$lastImport === $fileNames) {
+            return;
+        }
+
+        self::$lastImport = $fileNames;
+
+        static::loadFixtures(array_map(
+            static function ($file) {
+                return __DIR__.'/../Fixtures/Functional/PageController/'.$file.'.yml';
+            },
+            $fileNames
+        ));
+    }
+}

--- a/core-bundle/tests/Functional/RoutingTest.php
+++ b/core-bundle/tests/Functional/RoutingTest.php
@@ -30,6 +30,7 @@ class RoutingTest extends FunctionalTestCase
         parent::setUpBeforeClass();
 
         static::bootKernel();
+        System::setContainer(self::$container);
         static::resetDatabaseSchema();
         static::ensureKernelShutdown();
     }


### PR DESCRIPTION
Fixes https://github.com/contao/contao/issues/3959
Fixes https://github.com/contao/contao/issues/3989

This PR adds some initial functional tests for page controllers based on https://github.com/contao/contao/issues/3989#issuecomment-1019490082 and fixes the following three issues
1. The changes in `RegisterPagesPass` allows optional parameters from default configuration (thats why `{slug?}` worked but empty default did not in #3989)

2. The change in `PageCandidates` fixes #3959 

3. In Symfony, optional parameters are only allowed if they are "the last thing" in a URL. [The docs](https://symfony.com/doc/5.4/routing.html#optional-parameters) say
    > You can have more than one optional parameter (e.g. `/blog/{slug}/{page}`), but everything after an optional parameter must be optional. For example, `/{page}/blog` is a valid path, but page will always be required (i.e. `/blog` will not match this route).

    This conflicts with our URL suffix, because if the URL suffix is not empty no parameters can be optional for Symfony. I therefore introduced our adjusted route compiler that adjusts the route path/regex accordingly. The functional tests show that this works successfully now 🎉 

---

**Changes to `PageControllerTest` when merging upstream in 4.13:**
- [x] Replace class name for page registry service with service alias on line 74
- [x] Convert `static function` to inline function (probably done automatically by the CS fixer)