### PR TITLE
Fix replacing insert tags on non-strings

### DIFF
--- a/calendar-bundle/src/Resources/contao/classes/Calendar.php
+++ b/calendar-bundle/src/Resources/contao/classes/Calendar.php
@@ -278,7 +278,7 @@ class Calendar extends Frontend
 					}
 					else
 					{
-						$strDescription = $event['teaser'];
+						$strDescription = $event['teaser'] ?? '';
 					}
 
 					$strDescription = System::getContainer()->get('contao.insert_tag.parser')->replaceInline($strDescription);

--- a/core-bundle/src/File/ModelMetadataTrait.php
+++ b/core-bundle/src/File/ModelMetadataTrait.php
@@ -47,7 +47,7 @@ trait ModelMetadataTrait
 
         // Make sure we resolve insert tags pointing to files
         if (isset($data[Metadata::VALUE_URL])) {
-            $data[Metadata::VALUE_URL] = System::getContainer()->get('contao.insert_tag.parser')->replaceInline($data[Metadata::VALUE_URL]);
+            $data[Metadata::VALUE_URL] = System::getContainer()->get('contao.insert_tag.parser')->replaceInline($data[Metadata::VALUE_URL] ?? '');
         }
 
         // Strip superfluous fields by intersecting with tl_files.meta.eval.metaFields

--- a/core-bundle/src/Resources/contao/classes/Frontend.php
+++ b/core-bundle/src/Resources/contao/classes/Frontend.php
@@ -583,7 +583,7 @@ abstract class Frontend extends Controller
 	{
 		trigger_deprecation('contao/core-bundle', '4.12', 'Using "Contao\Frontend::prepareMetaDescription()" has been deprecated and will no longer work Contao 5.0. Use the "Contao\CoreBundle\String\HtmlDecoder" service instead.');
 
-		$strText = System::getContainer()->get('contao.insert_tag.parser')->replaceInline($strText);
+		$strText = System::getContainer()->get('contao.insert_tag.parser')->replaceInline((string) $strText);
 		$strText = strip_tags($strText);
 		$strText = str_replace("\n", ' ', $strText);
 		$strText = StringUtil::substr($strText, 320);

--- a/core-bundle/src/Resources/contao/models/FilesModel.php
+++ b/core-bundle/src/Resources/contao/models/FilesModel.php
@@ -437,7 +437,7 @@ class FilesModel extends Model
 			// Make sure we resolve insert tags pointing to files
 			if (isset($data[Metadata::VALUE_URL]))
 			{
-				$data[Metadata::VALUE_URL] = System::getContainer()->get('contao.insert_tag.parser')->replaceInline($data[Metadata::VALUE_URL]);
+				$data[Metadata::VALUE_URL] = System::getContainer()->get('contao.insert_tag.parser')->replaceInline($data[Metadata::VALUE_URL] ?? '');
 			}
 
 			// Fill missing meta fields with empty values

--- a/news-bundle/src/Resources/contao/classes/News.php
+++ b/news-bundle/src/Resources/contao/classes/News.php
@@ -226,7 +226,7 @@ class News extends Frontend
 				}
 				else
 				{
-					$strDescription = $objArticle->teaser;
+					$strDescription = $objArticle->teaser ?? '';
 				}
 
 				$strDescription = $container->get('contao.insert_tag.parser')->replaceInline($strDescription);

--- a/newsletter-bundle/src/Resources/contao/classes/Newsletter.php
+++ b/newsletter-bundle/src/Resources/contao/classes/Newsletter.php
@@ -95,8 +95,8 @@ class Newsletter extends Backend
 		}
 
 		// Replace insert tags
-		$html = System::getContainer()->get('contao.insert_tag.parser')->replaceInline($objNewsletter->content);
-		$text = System::getContainer()->get('contao.insert_tag.parser')->replaceInline($objNewsletter->text);
+		$html = System::getContainer()->get('contao.insert_tag.parser')->replaceInline($objNewsletter->content ?? '');
+		$text = System::getContainer()->get('contao.insert_tag.parser')->replaceInline($objNewsletter->text ?? '');
 
 		// Convert relative URLs
 		if ($objNewsletter->externalImages)


### PR DESCRIPTION
Fields that are nullable in the database must be converted to string before passing to the new insert tags method.