### PR TITLE
Fix 'Warning: Undefined array key 1' in insert tags

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Controller.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Controller.php
@@ -74,7 +74,7 @@ abstract class Controller extends System
 		// Check for a theme folder
 		if (\defined('TL_MODE') && TL_MODE == 'FE')
 		{
-			/** @var PageModel $objPage */
+			/** @var PageModel|null $objPage */
 			global $objPage;
 
 			if (null !== $objPage && $objPage->templateGroup)

--- a/core-bundle/src/Resources/contao/library/Contao/Controller.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Controller.php
@@ -77,7 +77,7 @@ abstract class Controller extends System
 			/** @var PageModel $objPage */
 			global $objPage;
 
-			if ($objPage->templateGroup)
+			if (null !== $objPage && $objPage->templateGroup)
 			{
 				if (Validator::isInsecurePath($objPage->templateGroup))
 				{

--- a/core-bundle/src/Resources/contao/library/Contao/Controller.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Controller.php
@@ -77,7 +77,7 @@ abstract class Controller extends System
 			/** @var PageModel|null $objPage */
 			global $objPage;
 
-			if (null !== $objPage && $objPage->templateGroup)
+			if ($objPage->templateGroup ?? null)
 			{
 				if (Validator::isInsecurePath($objPage->templateGroup))
 				{

--- a/core-bundle/src/Resources/contao/library/Contao/InsertTags.php
+++ b/core-bundle/src/Resources/contao/library/Contao/InsertTags.php
@@ -237,7 +237,7 @@ class InsertTags extends Controller
 				// Date
 				case 'date':
 					$flags[] = 'attr';
-					$arrCache[$strTag] = Date::parse($elements[1] ?: ($objPage->dateFormat ?? Config::get('dateFormat')));
+					$arrCache[$strTag] = Date::parse((isset($elements[1]) ? ($objPage->dateFormat ?? Config::get('dateFormat')) : Config::get('dateFormat')));
 					break;
 
 				// Accessibility tags

--- a/core-bundle/src/Resources/contao/library/Contao/InsertTags.php
+++ b/core-bundle/src/Resources/contao/library/Contao/InsertTags.php
@@ -702,7 +702,7 @@ class InsertTags extends Controller
 
 					if ($objUpdate->numRows)
 					{
-						$arrCache[$strTag] = Date::parse($elements[1] ?: ($objPage->datimFormat ?? Config::get('datimFormat')), max($objUpdate->tc, $objUpdate->tn, $objUpdate->te));
+						$arrCache[$strTag] = Date::parse((isset($elements[1]) ? ($objPage->dateFormat ?? Config::get('dateFormat')) : Config::get('dateFormat')), max($objUpdate->tc, $objUpdate->tn, $objUpdate->te));
 					}
 					break;
 

--- a/core-bundle/src/Resources/contao/library/Contao/InsertTags.php
+++ b/core-bundle/src/Resources/contao/library/Contao/InsertTags.php
@@ -237,7 +237,7 @@ class InsertTags extends Controller
 				// Date
 				case 'date':
 					$flags[] = 'attr';
-					$arrCache[$strTag] = Date::parse((isset($elements[1]) ? ($objPage->dateFormat ?? Config::get('dateFormat')) : Config::get('dateFormat')));
+					$arrCache[$strTag] = Date::parse($elements[1] ?? ($objPage->dateFormat ?? Config::get('dateFormat')));
 					break;
 
 				// Accessibility tags
@@ -702,7 +702,7 @@ class InsertTags extends Controller
 
 					if ($objUpdate->numRows)
 					{
-						$arrCache[$strTag] = Date::parse((isset($elements[1]) ? ($objPage->dateFormat ?? Config::get('dateFormat')) : Config::get('dateFormat')), max($objUpdate->tc, $objUpdate->tn, $objUpdate->te));
+						$arrCache[$strTag] = Date::parse($elements[1] ?? ($objPage->datimFormat ?? Config::get('datimFormat')), max($objUpdate->tc, $objUpdate->tn, $objUpdate->te));
 					}
 					break;
 


### PR DESCRIPTION
Fixes "Warning: Undefined array key 1" on PHP 8
