### PR TITLE
Correctly strip all CSRF token occurrences

### DIFF
--- a/core-bundle/src/Csrf/ContaoCsrfTokenManager.php
+++ b/core-bundle/src/Csrf/ContaoCsrfTokenManager.php
@@ -53,7 +53,7 @@ class ContaoCsrfTokenManager extends CsrfTokenManager implements ResetInterface
         return $this->usedTokenValues;
     }
 
-    public function getToken(string $tokenId): CsrfToken
+    public function getToken($tokenId): CsrfToken
     {
         $token = parent::getToken($tokenId);
         $this->usedTokenValues[] = $token->getValue();
@@ -61,7 +61,7 @@ class ContaoCsrfTokenManager extends CsrfTokenManager implements ResetInterface
         return $token;
     }
 
-    public function refreshToken(string $tokenId): CsrfToken
+    public function refreshToken($tokenId): CsrfToken
     {
         $token = parent::refreshToken($tokenId);
         $this->usedTokenValues[] = $token->getValue();

--- a/core-bundle/src/Csrf/ContaoCsrfTokenManager.php
+++ b/core-bundle/src/Csrf/ContaoCsrfTokenManager.php
@@ -18,8 +18,9 @@ use Symfony\Component\Security\Csrf\CsrfToken;
 use Symfony\Component\Security\Csrf\CsrfTokenManager;
 use Symfony\Component\Security\Csrf\TokenGenerator\TokenGeneratorInterface;
 use Symfony\Component\Security\Csrf\TokenStorage\TokenStorageInterface;
+use Symfony\Contracts\Service\ResetInterface;
 
-class ContaoCsrfTokenManager extends CsrfTokenManager
+class ContaoCsrfTokenManager extends CsrfTokenManager implements ResetInterface
 {
     /**
      * @var RequestStack
@@ -31,12 +32,41 @@ class ContaoCsrfTokenManager extends CsrfTokenManager
      */
     private $csrfCookiePrefix;
 
+    /**
+     * @var array<int, string>
+     */
+    private $usedTokenValues = [];
+
     public function __construct(RequestStack $requestStack, string $csrfCookiePrefix, TokenGeneratorInterface $generator = null, TokenStorageInterface $storage = null, $namespace = null)
     {
         $this->requestStack = $requestStack;
         $this->csrfCookiePrefix = $csrfCookiePrefix;
 
         parent::__construct($generator, $storage, $namespace);
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function getUsedTokenValues(): array
+    {
+        return $this->usedTokenValues;
+    }
+
+    public function getToken(string $tokenId): CsrfToken
+    {
+        $token = parent::getToken($tokenId);
+        $this->usedTokenValues[] = $token->getValue();
+
+        return $token;
+    }
+
+    public function refreshToken(string $tokenId): CsrfToken
+    {
+        $token = parent::refreshToken($tokenId);
+        $this->usedTokenValues[] = $token->getValue();
+
+        return $token;
     }
 
     public function isTokenValid(CsrfToken $token): bool
@@ -66,5 +96,10 @@ class ContaoCsrfTokenManager extends CsrfTokenManager
             )
             && !($request->hasSession() && $request->getSession()->isStarted())
         ;
+    }
+
+    public function reset(): void
+    {
+        $this->usedTokenValues = [];
     }
 }

--- a/core-bundle/src/EventListener/CsrfTokenCookieSubscriber.php
+++ b/core-bundle/src/EventListener/CsrfTokenCookieSubscriber.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\EventListener;
 
+use Contao\CoreBundle\Csrf\ContaoCsrfTokenManager;
 use Contao\CoreBundle\Csrf\MemoryTokenStorage;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Cookie;
@@ -29,6 +30,11 @@ use Symfony\Component\HttpKernel\KernelEvents;
 class CsrfTokenCookieSubscriber implements EventSubscriberInterface
 {
     /**
+     * @var ContaoCsrfTokenManager
+     */
+    private $tokenManager;
+
+    /**
      * @var MemoryTokenStorage
      */
     private $tokenStorage;
@@ -38,8 +44,9 @@ class CsrfTokenCookieSubscriber implements EventSubscriberInterface
      */
     private $cookiePrefix;
 
-    public function __construct(MemoryTokenStorage $tokenStorage, string $cookiePrefix = 'csrf_')
+    public function __construct(ContaoCsrfTokenManager $tokenManager, MemoryTokenStorage $tokenStorage, string $cookiePrefix = 'csrf_')
     {
+        $this->tokenManager = $tokenManager;
         $this->tokenStorage = $tokenStorage;
         $this->cookiePrefix = $cookiePrefix;
     }
@@ -139,7 +146,7 @@ class CsrfTokenCookieSubscriber implements EventSubscriberInterface
         }
 
         $content = $response->getContent();
-        $tokens = $this->tokenStorage->getUsedTokens();
+        $tokens = $this->tokenManager->getUsedTokenValues();
 
         if (!\is_string($content) || empty($tokens)) {
             return;

--- a/core-bundle/src/Resources/config/listener.yml
+++ b/core-bundle/src/Resources/config/listener.yml
@@ -94,6 +94,7 @@ services:
     contao.listener.csrf_token_cookie:
         class: Contao\CoreBundle\EventListener\CsrfTokenCookieSubscriber
         arguments:
+            - '@contao.csrf.token_manager'
             - '@contao.csrf.token_storage'
             - '%contao.csrf_cookie_prefix%'
         tags:

--- a/core-bundle/src/Resources/config/services.yml
+++ b/core-bundle/src/Resources/config/services.yml
@@ -214,6 +214,8 @@ services:
             - '@security.csrf.token_generator'
             - '@contao.csrf.token_storage'
         public: true
+        tags:
+            - { name: kernel.reset, method: reset }
 
     # Backwards compatibility
     contao.csrf.token_manager:

--- a/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
+++ b/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
@@ -477,6 +477,7 @@ class ContaoCoreExtensionTest extends TestCase
 
         $this->assertEquals(
             [
+                new Reference('contao.csrf.token_manager'),
                 new Reference('contao.csrf.token_storage'),
                 new Reference('%contao.csrf_cookie_prefix%'),
             ],

--- a/core-bundle/tests/EventListener/CsrfTokenCookieSubscriberTest.php
+++ b/core-bundle/tests/EventListener/CsrfTokenCookieSubscriberTest.php
@@ -12,12 +12,14 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Tests\EventListener;
 
+use Contao\CoreBundle\Csrf\ContaoCsrfTokenManager;
 use Contao\CoreBundle\Csrf\MemoryTokenStorage;
 use Contao\CoreBundle\EventListener\CsrfTokenCookieSubscriber;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
@@ -40,6 +42,8 @@ class CsrfTokenCookieSubscriberTest extends TestCase
         $request = Request::create('https://foobar.com');
         $request->cookies = $bag;
 
+        $tokenManager = $this->createMock(ContaoCsrfTokenManager::class);
+
         $tokenStorage = $this->createMock(MemoryTokenStorage::class);
         $tokenStorage
             ->expects($this->once())
@@ -50,7 +54,7 @@ class CsrfTokenCookieSubscriberTest extends TestCase
             ])
         ;
 
-        $listener = new CsrfTokenCookieSubscriber($tokenStorage);
+        $listener = new CsrfTokenCookieSubscriber($tokenManager, $tokenStorage);
         $listener->onKernelRequest($this->getRequestEvent($request));
     }
 
@@ -62,13 +66,15 @@ class CsrfTokenCookieSubscriberTest extends TestCase
             ->willReturn(false)
         ;
 
+        $tokenManager = $this->createMock(ContaoCsrfTokenManager::class);
+
         $tokenStorage = $this->createMock(MemoryTokenStorage::class);
         $tokenStorage
             ->expects($this->never())
             ->method('initialize')
         ;
 
-        $listener = new CsrfTokenCookieSubscriber($tokenStorage);
+        $listener = new CsrfTokenCookieSubscriber($tokenManager, $tokenStorage);
         $listener->onKernelRequest($requestEvent);
     }
 
@@ -81,6 +87,8 @@ class CsrfTokenCookieSubscriberTest extends TestCase
         $request = Request::create('https://foobar.com');
         $request->cookies = $bag;
 
+        $tokenManager = $this->createMock(ContaoCsrfTokenManager::class);
+
         $tokenStorage = $this->createMock(MemoryTokenStorage::class);
         $tokenStorage
             ->expects($this->once())
@@ -90,7 +98,7 @@ class CsrfTokenCookieSubscriberTest extends TestCase
 
         $response = new Response();
 
-        $listener = new CsrfTokenCookieSubscriber($tokenStorage);
+        $listener = new CsrfTokenCookieSubscriber($tokenManager, $tokenStorage);
         $listener->onKernelResponse($this->getResponseEvent($request, $response));
 
         $cookies = $response->headers->getCookies();
@@ -118,6 +126,8 @@ class CsrfTokenCookieSubscriberTest extends TestCase
         $request = Request::create('https://foobar.com');
         $request->cookies = $bag;
 
+        $tokenManager = $this->createMock(ContaoCsrfTokenManager::class);
+
         $tokenStorage = $this->createMock(MemoryTokenStorage::class);
         $tokenStorage
             ->expects($this->once())
@@ -127,7 +137,7 @@ class CsrfTokenCookieSubscriberTest extends TestCase
 
         $response = new Response();
 
-        $listener = new CsrfTokenCookieSubscriber($tokenStorage);
+        $listener = new CsrfTokenCookieSubscriber($tokenManager, $tokenStorage);
         $listener->onKernelResponse($this->getResponseEvent($request, $response));
 
         $this->assertCount(0, $response->headers->getCookies());
@@ -144,19 +154,28 @@ class CsrfTokenCookieSubscriberTest extends TestCase
 
         $tokenStorage = new MemoryTokenStorage();
         $tokenStorage->initialize(['tokenName' => 'tokenValue']);
-        $tokenStorage->getToken('tokenName');
+
+        $tokenManager = new ContaoCsrfTokenManager(new RequestStack(), 'csrf_', null, $tokenStorage);
+        $tokenValue1 = $tokenManager->getToken('tokenName');
+        $tokenValue2 = $tokenManager->getToken('tokenName');
 
         $response = new Response(
-            '<html><body><form><input name="REQUEST_TOKEN" value="tokenValue"></form></body></html>',
+            '<html><body><form>'
+            .'<input name="REQUEST_TOKEN" value="'.$tokenValue1.'">'
+            .'<input name="REQUEST_TOKEN" value="'.$tokenValue2.'">'
+            .'</form></body></html>',
             200,
             ['Content-Type' => 'text/html', 'Content-Length' => 1234]
         );
 
-        $listener = new CsrfTokenCookieSubscriber($tokenStorage);
+        $listener = new CsrfTokenCookieSubscriber($tokenManager, $tokenStorage);
         $listener->onKernelResponse($this->getResponseEvent($request, $response));
 
         $this->assertSame(
-            '<html><body><form><input name="REQUEST_TOKEN" value=""></form></body></html>',
+            '<html><body><form>'
+                .'<input name="REQUEST_TOKEN" value="">'
+                .'<input name="REQUEST_TOKEN" value="">'
+                .'</form></body></html>',
             $response->getContent()
         );
 
@@ -186,6 +205,8 @@ class CsrfTokenCookieSubscriberTest extends TestCase
         $request = Request::create('https://foobar.com');
         $request->cookies = $bag;
 
+        $tokenManager = $this->createMock(ContaoCsrfTokenManager::class);
+
         $tokenStorage = new MemoryTokenStorage();
         $tokenStorage->initialize([]);
 
@@ -195,7 +216,7 @@ class CsrfTokenCookieSubscriberTest extends TestCase
             ['Content-Type' => 'text/html', 'Content-Length' => 1234]
         );
 
-        $listener = new CsrfTokenCookieSubscriber($tokenStorage);
+        $listener = new CsrfTokenCookieSubscriber($tokenManager, $tokenStorage);
         $listener->onKernelResponse($this->getResponseEvent($request, $response));
 
         $this->assertSame(
@@ -214,6 +235,8 @@ class CsrfTokenCookieSubscriberTest extends TestCase
 
         $request = Request::create('https://foobar.com');
         $request->cookies = $bag;
+
+        $tokenManager = $this->createMock(ContaoCsrfTokenManager::class);
 
         $tokenStorage = new MemoryTokenStorage();
         $tokenStorage->initialize(['tokenName' => 'tokenValue']);
@@ -241,7 +264,7 @@ class CsrfTokenCookieSubscriberTest extends TestCase
 
         $response->headers = new ResponseHeaderBag(['Content-Type' => 'text/html']);
 
-        $listener = new CsrfTokenCookieSubscriber($tokenStorage);
+        $listener = new CsrfTokenCookieSubscriber($tokenManager, $tokenStorage);
         $listener->onKernelResponse($this->getResponseEvent($request, $response));
     }
 
@@ -258,13 +281,15 @@ class CsrfTokenCookieSubscriberTest extends TestCase
             ->method('getRequest')
         ;
 
+        $tokenManager = $this->createMock(ContaoCsrfTokenManager::class);
+
         $tokenStorage = $this->createMock(MemoryTokenStorage::class);
         $tokenStorage
             ->expects($this->never())
             ->method('getUsedTokens')
         ;
 
-        $listener = new CsrfTokenCookieSubscriber($tokenStorage);
+        $listener = new CsrfTokenCookieSubscriber($tokenManager, $tokenStorage);
         $listener->onKernelResponse($responseEvent);
     }
 
@@ -274,18 +299,20 @@ class CsrfTokenCookieSubscriberTest extends TestCase
 
         $tokenStorage = new MemoryTokenStorage();
         $tokenStorage->initialize(['tokenName' => 'tokenValue']);
-        $tokenStorage->getToken('tokenName');
+
+        $tokenManager = new ContaoCsrfTokenManager(new RequestStack(), 'csrf_', null, $tokenStorage);
+        $tokenValue = $tokenManager->getToken('tokenName');
 
         $response = new Response(
-            'value="tokenValue"',
+            'value="'.$tokenValue.'"',
             200,
             ['Content-Type' => 'application/octet-stream']
         );
 
-        $listener = new CsrfTokenCookieSubscriber($tokenStorage);
+        $listener = new CsrfTokenCookieSubscriber($tokenManager, $tokenStorage);
         $listener->onKernelResponse($this->getResponseEvent($request, $response));
 
-        $this->assertSame('value="tokenValue"', $response->getContent());
+        $this->assertSame('value="'.$tokenValue.'"', $response->getContent());
     }
 
     /**

--- a/core-bundle/tests/EventListener/CsrfTokenCookieSubscriberTest.php
+++ b/core-bundle/tests/EventListener/CsrfTokenCookieSubscriberTest.php
@@ -161,9 +161,9 @@ class CsrfTokenCookieSubscriberTest extends TestCase
 
         $response = new Response(
             '<html><body><form>'
-            .'<input name="REQUEST_TOKEN" value="'.$tokenValue1.'">'
-            .'<input name="REQUEST_TOKEN" value="'.$tokenValue2.'">'
-            .'</form></body></html>',
+                .'<input name="REQUEST_TOKEN" value="'.$tokenValue1.'">'
+                .'<input name="REQUEST_TOKEN" value="'.$tokenValue2.'">'
+                .'</form></body></html>',
             200,
             ['Content-Type' => 'text/html', 'Content-Length' => 1234]
         );


### PR DESCRIPTION
Fixes #4038

If my tests are correct, only stripping unnecessary tokens did not work as expected. 
The validation itself still worked.