### PR TITLE
Support \Attribute::TARGET_METHOD for our DI attributes

### DIFF
--- a/core-bundle/src/DependencyInjection/Attribute/AsCallback.php
+++ b/core-bundle/src/DependencyInjection/Attribute/AsCallback.php
@@ -15,7 +15,7 @@ namespace Contao\CoreBundle\DependencyInjection\Attribute;
 /**
  * An attribute to register a DCA callback.
  */
-#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 class AsCallback
 {
     public function __construct(public string $table, public string $target, public ?string $method = null, public ?int $priority = null)

--- a/core-bundle/src/DependencyInjection/Attribute/AsCronJob.php
+++ b/core-bundle/src/DependencyInjection/Attribute/AsCronJob.php
@@ -15,7 +15,7 @@ namespace Contao\CoreBundle\DependencyInjection\Attribute;
 /**
  * An attribute to register a Contao cron job.
  */
-#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 class AsCronJob
 {
     public function __construct(public string $interval, public ?string $method = null)

--- a/core-bundle/src/DependencyInjection/Attribute/AsHook.php
+++ b/core-bundle/src/DependencyInjection/Attribute/AsHook.php
@@ -15,7 +15,7 @@ namespace Contao\CoreBundle\DependencyInjection\Attribute;
 /**
  * An attribute to register a Contao hook.
  */
-#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 class AsHook
 {
     public function __construct(public string $hook, public ?string $method = null, public ?int $priority = null)

--- a/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
+++ b/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
@@ -36,6 +36,7 @@ use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Exception\LogicException;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
@@ -162,40 +163,32 @@ class ContaoCoreExtension extends Extension implements PrependExtensionInterface
             }
         );
 
-        $container->registerAttributeForAutoconfiguration(
-            AsCronJob::class,
-            static function (ChildDefinition $definition, AsCronJob $attribute): void {
-                $definition->addTag('contao.cronjob', get_object_vars($attribute));
-            }
-        );
+        foreach ([AsPage::class => 'contao.page', AsPickerProvider::class => 'contao.picker_provider'] as $attributeClass => $tag) {
+            $container->registerAttributeForAutoconfiguration(
+                $attributeClass,
+                static function (ChildDefinition $definition, object $attribute) use ($tag): void {
+                    $definition->addTag($tag, get_object_vars($attribute));
+                }
+            );
+        }
 
-        $container->registerAttributeForAutoconfiguration(
-            AsHook::class,
-            static function (ChildDefinition $definition, AsHook $attribute): void {
-                $definition->addTag('contao.hook', get_object_vars($attribute));
-            }
-        );
+        foreach ([AsCronJob::class => 'contao.cronjob', AsHook::class => 'contao.hook', AsCallback::class => 'contao.callback'] as $attributeClass => $tag) {
+            $container->registerAttributeForAutoconfiguration(
+                $attributeClass,
+                static function (ChildDefinition $definition, object $attribute, \Reflector $reflector) use ($attributeClass, $tag): void {
+                    $tagAttributes = get_object_vars($attribute);
 
-        $container->registerAttributeForAutoconfiguration(
-            AsCallback::class,
-            static function (ChildDefinition $definition, AsCallback $attribute): void {
-                $definition->addTag('contao.callback', get_object_vars($attribute));
-            }
-        );
+                    if ($reflector instanceof \ReflectionMethod) {
+                        if (isset($tagAttributes['method'])) {
+                            throw new LogicException(sprintf('%s attribute cannot declare a method on "%s::%s()".', $attributeClass, $reflector->getDeclaringClass()->getName(), $reflector->getName()));
+                        }
+                        $tagAttributes['method'] = $reflector->getName();
+                    }
 
-        $container->registerAttributeForAutoconfiguration(
-            AsPage::class,
-            static function (ChildDefinition $definition, AsPage $attribute): void {
-                $definition->addTag('contao.page', get_object_vars($attribute));
-            }
-        );
-
-        $container->registerAttributeForAutoconfiguration(
-            AsPickerProvider::class,
-            static function (ChildDefinition $definition, AsPickerProvider $attribute): void {
-                $definition->addTag('contao.picker_provider', get_object_vars($attribute));
-            }
-        );
+                    $definition->addTag($tag, $tagAttributes);
+                }
+            );
+        }
     }
 
     public function configureFilesystem(FilesystemConfiguration $config): void

--- a/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
+++ b/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
@@ -163,16 +163,15 @@ class ContaoCoreExtension extends Extension implements PrependExtensionInterface
             }
         );
 
-        foreach ([AsPage::class => 'contao.page', AsPickerProvider::class => 'contao.picker_provider'] as $attributeClass => $tag) {
-            $container->registerAttributeForAutoconfiguration(
-                $attributeClass,
-                static function (ChildDefinition $definition, object $attribute) use ($tag): void {
-                    $definition->addTag($tag, get_object_vars($attribute));
-                }
-            );
-        }
+        $attributesForAutoconfiguration = [
+            AsPage::class => 'contao.page',
+            AsPickerProvider::class => 'contao.picker_provider',
+            AsCronJob::class => 'contao.cronjob',
+            AsHook::class => 'contao.hook',
+            AsCallback::class => 'contao.callback',
+        ];
 
-        foreach ([AsCronJob::class => 'contao.cronjob', AsHook::class => 'contao.hook', AsCallback::class => 'contao.callback'] as $attributeClass => $tag) {
+        foreach ($attributesForAutoconfiguration as $attributeClass => $tag) {
             $container->registerAttributeForAutoconfiguration(
                 $attributeClass,
                 static function (ChildDefinition $definition, object $attribute, \Reflector $reflector) use ($attributeClass, $tag): void {

--- a/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
+++ b/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
@@ -181,6 +181,7 @@ class ContaoCoreExtension extends Extension implements PrependExtensionInterface
                         if (isset($tagAttributes['method'])) {
                             throw new LogicException(sprintf('%s attribute cannot declare a method on "%s::%s()".', $attributeClass, $reflector->getDeclaringClass()->getName(), $reflector->getName()));
                         }
+
                         $tagAttributes['method'] = $reflector->getName();
                     }
 

--- a/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
+++ b/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
@@ -940,6 +940,9 @@ class ContaoCoreExtensionTest extends TestCase
         yield 'callback' => [AsCallback::class];
     }
 
+    /**
+     * @return \ReflectionClass<object>
+     */
     private function mockReflectionClass(): \ReflectionClass
     {
         $reflectionClass = $this->createMock(\ReflectionClass::class);

--- a/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
+++ b/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
@@ -772,7 +772,8 @@ class ContaoCoreExtensionTest extends TestCase
                 'json',
                 true,
                 'html'
-            )
+            ),
+            new \ReflectionClass(ClassWithMethod::class)
         );
     }
 
@@ -795,7 +796,11 @@ class ContaoCoreExtensionTest extends TestCase
             ->with('contao.picker_provider', ['priority' => 32])
         ;
 
-        $autoConfiguredAttributes[AsPickerProvider::class]($definition, new AsPickerProvider(32));
+        $autoConfiguredAttributes[AsPickerProvider::class](
+            $definition,
+            new AsPickerProvider(32),
+            new \ReflectionClass(ClassWithMethod::class)
+        );
     }
 
     public function testRegistersAsCronjobAttribute(): void

--- a/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
+++ b/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
@@ -641,6 +641,10 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersAsContentElementAttribute(): void
     {
+        if (\PHP_VERSION_ID <= 80000) {
+            $this->markTestSkipped('Attributes support is only available since PHP8.');
+        }
+
         $container = $this->getContainerBuilder();
         (new ContaoCoreExtension())->load([], $container);
         $autoConfiguredAttributes = $container->getAutoconfiguredAttributes();
@@ -679,6 +683,10 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersAsFrontendModuleAttribute(): void
     {
+        if (\PHP_VERSION_ID <= 80000) {
+            $this->markTestSkipped('Attributes support is only available since PHP8.');
+        }
+
         $container = $this->getContainerBuilder();
         (new ContaoCoreExtension())->load([], $container);
         $autoConfiguredAttributes = $container->getAutoconfiguredAttributes();
@@ -717,6 +725,10 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersAsPageAttribute(): void
     {
+        if (\PHP_VERSION_ID <= 80000) {
+            $this->markTestSkipped('Attributes support is only available since PHP8.');
+        }
+
         $container = $this->getContainerBuilder();
         (new ContaoCoreExtension())->load([], $container);
         $autoConfiguredAttributes = $container->getAutoconfiguredAttributes();
@@ -765,6 +777,10 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersAsPickerProviderAttribute(): void
     {
+        if (\PHP_VERSION_ID <= 80000) {
+            $this->markTestSkipped('Attributes support is only available since PHP8.');
+        }
+
         $container = $this->getContainerBuilder();
         (new ContaoCoreExtension())->load([], $container);
         $autoConfiguredAttributes = $container->getAutoconfiguredAttributes();
@@ -783,6 +799,10 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersAsCronjobAttribute(): void
     {
+        if (\PHP_VERSION_ID <= 80000) {
+            $this->markTestSkipped('Attributes support is only available since PHP8.');
+        }
+
         $container = $this->getContainerBuilder();
         (new ContaoCoreExtension())->load([], $container);
         $autoConfiguredAttributes = $container->getAutoconfiguredAttributes();
@@ -811,6 +831,10 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersAsHookAttribute(): void
     {
+        if (\PHP_VERSION_ID <= 80000) {
+            $this->markTestSkipped('Attributes support is only available since PHP8.');
+        }
+
         $container = $this->getContainerBuilder();
         (new ContaoCoreExtension())->load([], $container);
         $autoConfiguredAttributes = $container->getAutoconfiguredAttributes();
@@ -839,6 +863,10 @@ class ContaoCoreExtensionTest extends TestCase
 
     public function testRegistersAsCallbackAttribute(): void
     {
+        if (\PHP_VERSION_ID <= 80000) {
+            $this->markTestSkipped('Attributes support is only available since PHP8.');
+        }
+
         $container = $this->getContainerBuilder();
         (new ContaoCoreExtension())->load([], $container);
         $autoConfiguredAttributes = $container->getAutoconfiguredAttributes();
@@ -878,6 +906,10 @@ class ContaoCoreExtensionTest extends TestCase
      */
     public function testThrowsExceptionWhenTryingToDeclareTheMethodPropertyOnAMethodAttribute(string $attributeClass): void
     {
+        if (\PHP_VERSION_ID <= 80000) {
+            $this->markTestSkipped('Attributes support is only available since PHP8.');
+        }
+
         $container = $this->getContainerBuilder();
         (new ContaoCoreExtension())->load([], $container);
         $autoConfiguredAttributes = $container->getAutoconfiguredAttributes();
@@ -888,12 +920,15 @@ class ContaoCoreExtensionTest extends TestCase
             ->method('addTag')
         ;
 
+        $attribute = new \stdClass();
+        $attribute->method = 'bar';
+
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage($attributeClass.' attribute cannot declare a method on "Contao\Foo::bar()".');
 
         $autoConfiguredAttributes[$attributeClass](
             $definition,
-            new AsCronJob('daily', 'bar'),
+            $attribute,
             $this->mockReflectionMethod()
         );
     }

--- a/core-bundle/tests/Fixtures/ClassWithMethod.php
+++ b/core-bundle/tests/Fixtures/ClassWithMethod.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\Fixtures;
+
+class ClassWithMethod
+{
+    public function someMethod(): void
+    {
+    }
+}


### PR DESCRIPTION
Fixes #4048 

With this PR it's possible to use annotations on methods for hooks, callbacks and cronjobs.

Example:
```php
use Contao\CoreBundle\DependencyInjection\Attribute\AsCallback;

class Things
{
    #[AsCallback(table: 'tl_project', target:'list.label.label')]
    public function listThings(array $row): string
    {
        // …
    }

    // …
}
```

I also added tests to the existing code which took forever in comparison to the actual changes. :neutral_face: 