### PR TITLE
Run the coverage CI job with PHP8.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
               with:
-                  php-version: 7.4
+                  php-version: 8.0
                   extensions: dom, fileinfo, filter, gd, hash, intl, json, mbstring, mysqli, pcre, pdo_mysql, zlib
                   coverage: pcov
               env:


### PR DESCRIPTION
With attributes and directory checks in the VFS we now have (optional) PHP8 features in the code base. IMHO, we should therefore run our coverage job with PHP8 as well.