### PR TITLE
Fix the missing request token in ModulePassword.php

### DIFF
--- a/core-bundle/src/Resources/contao/modules/ModulePassword.php
+++ b/core-bundle/src/Resources/contao/modules/ModulePassword.php
@@ -74,6 +74,8 @@ class ModulePassword extends Module
 			}
 		}
 
+		$this->Template->requestToken = System::getContainer()->get('contao.csrf.token_manager')->getDefaultTokenValue();
+
 		// Set new password
 		if (strncmp(Input::get('token'), 'pw-', 3) === 0)
 		{
@@ -174,7 +176,6 @@ class ModulePassword extends Module
 		$this->Template->email = StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['emailAddress']);
 		$this->Template->slabel = StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['requestPassword']);
 		$this->Template->rowLast = 'row_' . $row . ' row_last' . ((($row % 2) == 0) ? ' even' : ' odd');
-		$this->Template->requestToken = System::getContainer()->get('contao.csrf.token_manager')->getDefaultTokenValue();
 	}
 
 	/**


### PR DESCRIPTION
There is a bug in the lostPassword module since Conato 4.13.

The requestToken is missing, when I open the link in the mail to change the password.

This is because when I open the url to change the password with the get parameter "token", the script doesnt reach the token definition on line 177.

https://github.com/contao/contao/blob/3691e1d7f9ee4eb35a9f5e05a3537dc633f94ffc/core-bundle/src/Resources/contao/modules/ModulePassword.php#L77-L83

https://github.com/contao/contao/blob/3691e1d7f9ee4eb35a9f5e05a3537dc633f94ffc/core-bundle/src/Resources/contao/modules/ModulePassword.php#L177

I changed the file ModulePassword.php to set the requestToken above the if statement.