### PR TITLE
Correctly handle null values in DCs

### DIFF
--- a/core-bundle/src/Resources/contao/drivers/DC_Folder.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Folder.php
@@ -2317,7 +2317,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 			}
 
 			// Make sure unique fields are unique
-			if ((!is_scalar($varValue) || (string) $varValue !== '') && $arrData['eval']['unique'] && !$this->Database->isUniqueValue($this->strTable, $this->strField, $varValue, $this->objActiveRecord->id))
+			if ((\is_array($varValue) || (string) $varValue !== '') && $arrData['eval']['unique'] && !$this->Database->isUniqueValue($this->strTable, $this->strField, $varValue, $this->objActiveRecord->id))
 			{
 				throw new \Exception(sprintf($GLOBALS['TL_LANG']['ERR']['unique'], $arrData['label'][0] ?: $this->strField));
 			}
@@ -2381,7 +2381,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 			}
 
 			// Save the value if there was no error
-			if ((!is_scalar($varValue) || (string) $varValue !== '' || !$arrData['eval']['doNotSaveEmpty']) && ($this->varValue != $varValue || $arrData['eval']['alwaysSave']))
+			if ((\is_array($varValue) || (string) $varValue !== '' || !$arrData['eval']['doNotSaveEmpty']) && ($this->varValue != $varValue || $arrData['eval']['alwaysSave']))
 			{
 				// If the field is a fallback field, empty all other columns
 				if ($varValue && $arrData['eval']['fallback'])
@@ -2390,7 +2390,7 @@ class DC_Folder extends DataContainer implements \listable, \editable
 				}
 
 				// Set the correct empty value (see #6284, #6373)
-				if (is_scalar($varValue) && (string) $varValue === '')
+				if (!\is_array($varValue) && (string) $varValue === '')
 				{
 					$varValue = Widget::getEmptyValueByFieldType($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['sql']);
 				}

--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -3050,7 +3050,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 		}
 
 		// Make sure unique fields are unique
-		if ((!is_scalar($varValue) || (string) $varValue !== '') && $arrData['eval']['unique'] && !$this->Database->isUniqueValue($this->strTable, $this->strField, $varValue, $this->objActiveRecord->id))
+		if ((\is_array($varValue) || (string) $varValue !== '') && $arrData['eval']['unique'] && !$this->Database->isUniqueValue($this->strTable, $this->strField, $varValue, $this->objActiveRecord->id))
 		{
 			throw new \Exception(sprintf($GLOBALS['TL_LANG']['ERR']['unique'], $arrData['label'][0] ?: $this->strField));
 		}
@@ -3131,7 +3131,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 		}
 
 		// Save the value if there was no error
-		if ((!is_scalar($varValue) || (string) $varValue !== '' || !$arrData['eval']['doNotSaveEmpty']) && ($this->varValue !== $varValue || $arrData['eval']['alwaysSave']))
+		if ((\is_array($varValue) || (string) $varValue !== '' || !$arrData['eval']['doNotSaveEmpty']) && ($this->varValue !== $varValue || $arrData['eval']['alwaysSave']))
 		{
 			// If the field is a fallback field, empty all other columns (see #6498)
 			if ($varValue && $arrData['eval']['fallback'])
@@ -3148,7 +3148,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 			}
 
 			// Set the correct empty value (see #6284, #6373)
-			if (is_scalar($varValue) && (string) $varValue === '')
+			if (!\is_array($varValue) && (string) $varValue === '')
 			{
 				$varValue = Widget::getEmptyValueByFieldType($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['sql']);
 			}


### PR DESCRIPTION
With #3876 we introduced a bug with `null` values because `is_scalar(null) === false` in PHP. 🙈

This means that `eval.doNotSaveEmpty` does not work anymore for `null` values and now tries to save them to the database.

This breaks our custom elements extension because it uses `doNotSaveEmpty` for its “virtual” fields. 🥺