### PR TITLE
Trigger a deprecation if an old `contao.localconfig` key is used

### DIFF
--- a/core-bundle/src/DependencyInjection/Configuration.php
+++ b/core-bundle/src/DependencyInjection/Configuration.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\DependencyInjection;
 
+use Contao\Config;
 use Contao\CoreBundle\Util\LocaleUtil;
 use Contao\Image\ResizeConfiguration;
 use Imagine\Image\ImageInterface;
@@ -64,6 +65,19 @@ class Configuration implements ConfigurationInterface
                 ->end()
                 ->variableNode('localconfig')
                     ->info('Allows to set TL_CONFIG variables, overriding settings stored in localconfig.php. Changes in the Contao back end will not have any effect.')
+                    ->validate()
+                        ->always(
+                            static function (array $options): array {
+                                foreach (array_keys($options) as $option) {
+                                    if ($newKey = Config::getNewKey($option)) {
+                                        trigger_deprecation('contao/core-bundle', '4.12', 'Setting "contao.localconfig.%s" has been deprecated. Use "%s" instead.', $option, $newKey);
+                                    }
+                                }
+
+                                return $options;
+                            }
+                        )
+                    ->end()
                 ->end()
                 ->arrayNode('locales')
                     ->info('Allows to configure which languages can be used in the Contao back end. Defaults to all languages for which a translation exists.')

--- a/core-bundle/src/Resources/contao/library/Contao/Config.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Config.php
@@ -408,9 +408,9 @@ class Config
 	 */
 	public static function get($strKey)
 	{
-		if (isset(self::$arrDeprecated[$strKey]) || isset(self::$arrDeprecatedMap[$strKey]))
+		if ($newKey = self::getNewKey($strKey))
 		{
-			trigger_deprecation('contao/core-bundle', '4.12', 'Using "%s(\'%s\')" has been deprecated. Use the "%s" parameter instead.', __METHOD__, $strKey, self::$arrDeprecated[$strKey] ?? self::$arrDeprecatedMap[$strKey]);
+			trigger_deprecation('contao/core-bundle', '4.12', 'Using "%s(\'%s\')" has been deprecated. Use the "%s" parameter instead.', __METHOD__, $strKey, $newKey);
 		}
 
 		return $GLOBALS['TL_CONFIG'][$strKey] ?? null;
@@ -424,12 +424,24 @@ class Config
 	 */
 	public static function set($strKey, $varValue)
 	{
-		if (isset(self::$arrDeprecated[$strKey]) || isset(self::$arrDeprecatedMap[$strKey]))
+		if ($newKey = self::getNewKey($strKey))
 		{
-			trigger_deprecation('contao/core-bundle', '4.12', 'Using "%s(\'%s\', …)" has been deprecated. Use the "%s" parameter instead.', __METHOD__, $strKey, self::$arrDeprecated[$strKey] ?? self::$arrDeprecatedMap[$strKey]);
+			trigger_deprecation('contao/core-bundle', '4.12', 'Using "%s(\'%s\', …)" has been deprecated. Use the "%s" parameter instead.', __METHOD__, $strKey, $newKey);
 		}
 
 		$GLOBALS['TL_CONFIG'][$strKey] = $varValue;
+	}
+
+	/**
+	 * Return the new key if the existing one is deprecated
+	 *
+	 * @param string $strKey The short key
+	 *
+	 * @return string|null
+	 */
+	public static function getNewKey($strKey)
+	{
+		return self::$arrDeprecated[$strKey] ?? self::$arrDeprecatedMap[$strKey] ?? null;
 	}
 
 	/**

--- a/core-bundle/src/Resources/contao/library/Contao/Config.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Config.php
@@ -435,6 +435,8 @@ class Config
 	/**
 	 * Return the new key if the existing one is deprecated
 	 *
+	 * @internal
+	 *
 	 * @param string $strKey The short key
 	 *
 	 * @return string|null

--- a/core-bundle/tests/DependencyInjection/ConfigurationTest.php
+++ b/core-bundle/tests/DependencyInjection/ConfigurationTest.php
@@ -15,6 +15,7 @@ namespace Contao\CoreBundle\Tests\DependencyInjection;
 use Contao\CoreBundle\DependencyInjection\Configuration;
 use Contao\CoreBundle\Tests\TestCase;
 use Contao\Image\ResizeConfiguration;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Config\Definition\ArrayNode;
 use Symfony\Component\Config\Definition\BaseNode;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
@@ -24,6 +25,8 @@ use Symfony\Component\Filesystem\Filesystem;
 
 class ConfigurationTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
     /**
      * @var Configuration
      */
@@ -231,6 +234,24 @@ class ConfigurationTest extends TestCase
 
         $this->expectException(InvalidConfigurationException::class);
         $this->expectExceptionMessageMatches('/The attribute name "data-App Name" must be a valid HTML attribute name./');
+
+        (new Processor())->processConfiguration($this->configuration, $params);
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testTriggersContaoLocalconfigDeprecations(): void
+    {
+        $this->expectDeprecation('Since contao/core-bundle 4.12: Setting "contao.localconfig.enableSearch" has been deprecated. Use "contao.search.default_indexer.enable" instead.');
+
+        $params = [
+            'contao' => [
+                'localconfig' => [
+                    'enableSearch' => false,
+                ],
+            ],
+        ];
 
         (new Processor())->processConfiguration($this->configuration, $params);
     }


### PR DESCRIPTION
This is an alternative approach to #4006.