### PR TITLE
POC: add-on domains

### DIFF
--- a/core-bundle/src/Resources/contao/dca/tl_page.php
+++ b/core-bundle/src/Resources/contao/dca/tl_page.php
@@ -178,8 +178,8 @@ $GLOBALS['TL_DCA']['tl_page'] = array
 		'regular'                     => '{title_legend},title,type;{routing_legend},alias,requireItem,routePath,routePriority,routeConflicts;{meta_legend},pageTitle,robots,description,serpPreview;{canonical_legend:hide},canonicalLink,canonicalKeepParams;{protected_legend:hide},protected;{layout_legend:hide},includeLayout;{cache_legend:hide},includeCache;{chmod_legend:hide},includeChmod;{expert_legend:hide},cssClass,sitemap,hide,noSearch,guests;{tabnav_legend:hide},tabindex,accesskey;{publish_legend},published,start,stop',
 		'forward'                     => '{title_legend},title,type;{routing_legend},alias,routePath,routePriority,routeConflicts;{meta_legend},pageTitle,robots;{redirect_legend},jumpTo,redirect;{protected_legend:hide},protected;{layout_legend:hide},includeLayout;{cache_legend:hide},includeCache;{chmod_legend:hide},includeChmod;{expert_legend:hide},cssClass,sitemap,hide,guests;{tabnav_legend:hide},tabindex,accesskey;{publish_legend},published,start,stop',
 		'redirect'                    => '{title_legend},title,type;{routing_legend},alias,routePath,routePriority,routeConflicts;{meta_legend},pageTitle,robots;{redirect_legend},redirect,url,target;{protected_legend:hide},protected;{layout_legend:hide},includeLayout;{cache_legend:hide},includeCache;{chmod_legend:hide},includeChmod;{expert_legend:hide},cssClass,sitemap,hide,guests;{tabnav_legend:hide},tabindex,accesskey;{publish_legend},published,start,stop',
-		'root'                        => '{title_legend},title,type;{routing_legend},alias;{meta_legend},pageTitle;{url_legend},dns,useSSL,urlPrefix,urlSuffix,validAliasCharacters,useFolderUrl;{language_legend},language,fallback,disableLanguageRedirect;{website_legend:hide},maintenanceMode;{global_legend:hide},mailerTransport,enableCanonical,adminEmail,dateFormat,timeFormat,datimFormat,staticFiles,staticPlugins;{protected_legend:hide},protected;{layout_legend},includeLayout;{twoFactor_legend:hide},enforceTwoFactor;{cache_legend:hide},includeCache;{chmod_legend:hide},includeChmod;{publish_legend},published,start,stop',
-		'rootfallback'                => '{title_legend},title,type;{routing_legend},alias;{meta_legend},pageTitle;{url_legend},dns,useSSL,urlPrefix,urlSuffix,validAliasCharacters,useFolderUrl;{language_legend},language,fallback,disableLanguageRedirect;{website_legend:hide},favicon,robotsTxt,maintenanceMode;{global_legend:hide},mailerTransport,enableCanonical,adminEmail,dateFormat,timeFormat,datimFormat,staticFiles,staticPlugins;{protected_legend:hide},protected;{layout_legend},includeLayout;{twoFactor_legend:hide},enforceTwoFactor;{cache_legend:hide},includeCache;{chmod_legend:hide},includeChmod;{publish_legend},published,start,stop',
+		'root'                        => '{title_legend},title,type;{routing_legend},alias;{meta_legend},pageTitle;{url_legend},dns,useSSL,urlPrefix,urlSuffix,validAliasCharacters,useFolderUrl,addonDns;{language_legend},language,fallback,disableLanguageRedirect;{website_legend:hide},maintenanceMode;{global_legend:hide},mailerTransport,enableCanonical,adminEmail,dateFormat,timeFormat,datimFormat,staticFiles,staticPlugins;{protected_legend:hide},protected;{layout_legend},includeLayout;{twoFactor_legend:hide},enforceTwoFactor;{cache_legend:hide},includeCache;{chmod_legend:hide},includeChmod;{publish_legend},published,start,stop',
+		'rootfallback'                => '{title_legend},title,type;{routing_legend},alias;{meta_legend},pageTitle;{url_legend},dns,useSSL,urlPrefix,urlSuffix,validAliasCharacters,useFolderUrl,addonDns;{language_legend},language,fallback,disableLanguageRedirect;{website_legend:hide},favicon,robotsTxt,maintenanceMode;{global_legend:hide},mailerTransport,enableCanonical,adminEmail,dateFormat,timeFormat,datimFormat,staticFiles,staticPlugins;{protected_legend:hide},protected;{layout_legend},includeLayout;{twoFactor_legend:hide},enforceTwoFactor;{cache_legend:hide},includeCache;{chmod_legend:hide},includeChmod;{publish_legend},published,start,stop',
 		'logout'                      => '{title_legend},title,type;{routing_legend},alias,routePath,routePriority,routeConflicts;{forward_legend},jumpTo,redirectBack;{protected_legend:hide},protected;{chmod_legend:hide},includeChmod;{expert_legend:hide},cssClass,sitemap,hide;{tabnav_legend:hide},tabindex,accesskey;{publish_legend},published,start,stop',
 		'error_401'                   => '{title_legend},title,type;{meta_legend},pageTitle,robots,description;{forward_legend},autoforward;{layout_legend:hide},includeLayout;{cache_legend:hide},includeCache;{chmod_legend:hide},includeChmod;{expert_legend:hide},cssClass;{publish_legend},published,start,stop',
 		'error_403'                   => '{title_legend},title,type;{meta_legend},pageTitle,robots,description;{forward_legend},autoforward;{layout_legend:hide},includeLayout;{cache_legend:hide},includeCache;{chmod_legend:hide},includeChmod;{expert_legend:hide},cssClass;{publish_legend},published,start,stop',
@@ -381,6 +381,22 @@ $GLOBALS['TL_DCA']['tl_page'] = array
 			(
 				array('tl_page', 'checkDns')
 			),
+			'sql'                     => "varchar(255) NOT NULL default ''"
+		),
+		'addonDns' => array
+		(
+			'exclude'                 => true,
+			'search'                  => true,
+			'inputType'               => 'text',
+			'eval'                    => array('rgxp'=>'url', 'decodeEntities'=>true, 'maxlength'=>255, 'tl_class'=>'w50'),
+			//'load_callback' => array
+			//(
+			//	array('tl_page', 'loadDns')
+			//),
+			//'save_callback' => array
+			//(
+			//	array('tl_page', 'checkDns')
+			//),
 			'sql'                     => "varchar(255) NOT NULL default ''"
 		),
 		'staticFiles' => array

--- a/core-bundle/src/Resources/contao/languages/en/tl_page.xlf
+++ b/core-bundle/src/Resources/contao/languages/en/tl_page.xlf
@@ -116,6 +116,12 @@
       <trans-unit id="tl_page.dns.1">
         <source>Here you can restrict the access to the website to a certain domain name.</source>
       </trans-unit>
+      <trans-unit id="tl_page.addonDns.0">
+        <source>Add-on domains</source>
+      </trans-unit>
+      <trans-unit id="tl_page.addonDns.1">
+        <source>Optionally enter a comma-separated list of add-on domains for this website.</source>
+      </trans-unit>
       <trans-unit id="tl_page.staticFiles.0">
         <source>Files URL</source>
       </trans-unit>

--- a/core-bundle/src/Resources/contao/models/PageModel.php
+++ b/core-bundle/src/Resources/contao/models/PageModel.php
@@ -1246,6 +1246,14 @@ class PageModel extends Model
 			$this->rootUseSSL = $objParentPage->useSSL;
 			$this->rootFallbackLanguage = $objParentPage->language;
 
+			if ($objParentPage->addonDns) {
+				$request = System::getContainer()->get('request_stack')->getMainRequest();
+
+				if ($request && \in_array($request->getHost(), explode(',', $objParentPage->addonDns))) {
+					$this->domain = $request->getHost();
+				}
+			}
+
 			// Store the fallback language (see #6874)
 			if (!$objParentPage->fallback)
 			{

--- a/core-bundle/src/Routing/Candidates/PageCandidates.php
+++ b/core-bundle/src/Routing/Candidates/PageCandidates.php
@@ -62,7 +62,7 @@ class PageCandidates extends AbstractCandidates
 
         $candidates[] = '/';
 
-        $queryBuilder->orWhere("type='root' AND (dns=:httpHost OR dns='')");
+        $queryBuilder->orWhere("type='root' AND (dns=:httpHost OR dns='' OR FIND_IN_SET(:httpHost, addonDns)");
         $queryBuilder->setParameter('httpHost', $httpHost);
 
         return true;

--- a/core-bundle/src/Routing/RouteProvider.php
+++ b/core-bundle/src/Routing/RouteProvider.php
@@ -288,7 +288,7 @@ class RouteProvider extends AbstractPageRouteProvider
         $models = [];
 
         $pageModel = $this->framework->getAdapter(PageModel::class);
-        $pages = $pageModel->findBy(["(tl_page.type='root' AND (tl_page.dns=? OR tl_page.dns=''))"], $httpHost);
+        $pages = $pageModel->findBy(["(tl_page.type='root' AND (tl_page.dns=? OR tl_page.dns='' OR FIND_IN_SET(?, tl_page.addonDns)))"], [$httpHost, $httpHost]);
 
         if ($pages instanceof Collection) {
             $models = $pages->getModels();


### PR DESCRIPTION
After running again into the issue of copying a product DB to dev and having to change the host name, I had another attempt at fixing this. I first discussed with @Toflar we could use the Symfony reverse proxy to change the host name on-the-fly. However, this does not really work, because Contao will generate all page URLs with the original host name. But I found a pretty simple solution to the problem I think 😎 

There's still a lot to do, and I intend to rewrite our static routes for `/favicon.ico` etc. before this is useable. But feel free to leave a comment about your thoughts 🙃 