### PR TITLE
Fix 'Purge the preview cache' (path not found)

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Automator.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Automator.php
@@ -14,6 +14,7 @@ use FOS\HttpCache\CacheInvalidator;
 use FOS\HttpCacheBundle\CacheManager;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Output\NullOutput;
+use Contao\CoreBundle\Monolog\ContaoContext;
 
 /**
  * Provide methods to run automated jobs.

--- a/core-bundle/src/Resources/contao/library/Contao/Automator.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Automator.php
@@ -14,7 +14,6 @@ use FOS\HttpCache\CacheInvalidator;
 use FOS\HttpCacheBundle\CacheManager;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Output\NullOutput;
-use Contao\CoreBundle\Monolog\ContaoContext;
 
 /**
  * Provide methods to run automated jobs.

--- a/core-bundle/src/Resources/contao/library/Contao/Folder.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Folder.php
@@ -597,6 +597,7 @@ class Folder extends System
 				$arrReturn[] = $strFile;
 			}
 		}
+
 		// Cache the result
 		if (!$blnUncached)
 		{

--- a/core-bundle/src/Resources/contao/library/Contao/Folder.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Folder.php
@@ -585,7 +585,8 @@ class Folder extends System
 		$arrReturn = array();
 
 		// Scan directory
-		if (is_dir($strFolder)) {
+		if (is_dir($strFolder))
+		{
 			foreach (scandir($strFolder, SCANDIR_SORT_ASCENDING) as $strFile)
 			{
 				if ($strFile == '.' || $strFile == '..')

--- a/core-bundle/src/Resources/contao/library/Contao/Folder.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Folder.php
@@ -585,16 +585,17 @@ class Folder extends System
 		$arrReturn = array();
 
 		// Scan directory
-		foreach (scandir($strFolder, SCANDIR_SORT_ASCENDING) as $strFile)
-		{
-			if ($strFile == '.' || $strFile == '..')
+		if (is_dir($strFolder)) {
+			foreach (scandir($strFolder, SCANDIR_SORT_ASCENDING) as $strFile)
 			{
-				continue;
+				if ($strFile == '.' || $strFile == '..')
+				{
+					continue;
+				}
+
+				$arrReturn[] = $strFile;
 			}
-
-			$arrReturn[] = $strFile;
 		}
-
 		// Cache the result
 		if (!$blnUncached)
 		{


### PR DESCRIPTION
**Version:** 4.13-RC1 / PHP 7.4.27
**URL:** /contao?do=maintenance

**Steps that will reproduce the problem?**
1. Setup a new Contao instance from scratch
2. Go to System > Maintenance, select `Purge the preview cache`
3. Press `Purge data`

**What is the expected result?**

Purged preview cache.

**What happens instead?**

* Folder not found exception
* Class not found exception

Possible workaround:

See patches.
