### PR TITLE
Unlock flatten option for imagine configuration

### DIFF
--- a/core-bundle/src/DependencyInjection/Configuration.php
+++ b/core-bundle/src/DependencyInjection/Configuration.php
@@ -160,6 +160,8 @@ class Configuration implements ConfigurationInterface
                         ->end()
                         ->booleanNode('webp_lossless')
                         ->end()
+                        ->booleanNode('flatten')
+                        ->end()
                         ->scalarNode('interlace')
                             ->defaultValue(ImageInterface::INTERLACE_PLANE)
                         ->end()

--- a/core-bundle/src/DependencyInjection/Configuration.php
+++ b/core-bundle/src/DependencyInjection/Configuration.php
@@ -161,6 +161,7 @@ class Configuration implements ConfigurationInterface
                         ->booleanNode('webp_lossless')
                         ->end()
                         ->booleanNode('flatten')
+                            ->info('Allows to disable the layer flattening of animated images. Set this option to false to support animations. It has no effect with Gd as Imagine service.')
                         ->end()
                         ->scalarNode('interlace')
                             ->defaultValue(ImageInterface::INTERLACE_PLANE)


### PR DESCRIPTION
Fix: Support for animated gifs 

With the `flatten: false` option you can keep animation of GIFs.
By default if the option is not set it is equivalent to `flatten: true`
**Attention:** The `flatten` option is only supported by imagine via Imagick or Gmagick and obviously not by GD - see: 
* https://github.com/php-imagine/Imagine/blob/1.2.4/src/Imagick/Image.php#L422
* https://github.com/php-imagine/Imagine/blob/1.2.4/src/Gmagick/Image.php#L446

This PR unlocks the support for the `flatten` option, so you can disable it globally:
```yml
// config/config.yml
contao:
    image:
        imagine_options:
            flatten: false
``` 