### PR TITLE
Fix missing fallback for densities in preview factory

### DIFF
--- a/core-bundle/src/Image/Preview/PreviewFactory.php
+++ b/core-bundle/src/Image/Preview/PreviewFactory.php
@@ -324,7 +324,7 @@ class PreviewFactory
                     $this->getPreviewSizeFromWidthHeightDensities(
                         $sizeItem['width'] ?? 0,
                         $sizeItem['height'] ?? 0,
-                        $sizeItem['densities'],
+                        $sizeItem['densities'] ?? '',
                     ),
                 );
             }

--- a/core-bundle/tests/Image/Preview/PreviewFactoryTest.php
+++ b/core-bundle/tests/Image/Preview/PreviewFactoryTest.php
@@ -189,7 +189,6 @@ class PreviewFactoryTest extends TestCase
                     [
                         'width' => 50,
                         'height' => 123,
-                        'densities' => '0.5x',
                     ],
                 ],
             ],


### PR DESCRIPTION
If an image config specified `items` but omitted the `densities` key in these `items`, an invalid array access would occur when generating previews.

This PR fixes that by adding a fallback.
