### PR TITLE
Fix an undefiend array key

### DIFF
--- a/core-bundle/src/Resources/contao/classes/DataContainer.php
+++ b/core-bundle/src/Resources/contao/classes/DataContainer.php
@@ -954,7 +954,7 @@ abstract class DataContainer extends Backend
 						$href = $this->addToUrl($v['href'] . '&amp;id=' . $arrRow['id'] . (Input::get('nb') ? '&amp;nc=1' : ''));
 					}
 
-					parse_str(StringUtil::decodeEntities($v['href']), $params);
+					parse_str(StringUtil::decodeEntities($v['href'] ?? ''), $params);
 
 					if (($params['act'] ?? null) == 'toggle' && isset($params['field']))
 					{


### PR DESCRIPTION
This fixes the array key "href" being undefined<sup>1</sup> and throwing an ErrorException/Warning.

<sup>1</sup> This is the case when using the "route" param instead of the "href" param (see 3 lines above the change).

Issue introduced in #3889.