### PR TITLE
Fix trailing slashes in URL for Contao 4.9

### DIFF
--- a/core-bundle/src/Routing/RouteProvider.php
+++ b/core-bundle/src/Routing/RouteProvider.php
@@ -249,7 +249,7 @@ class RouteProvider implements RouteProviderInterface
         $defaults = $this->getRouteDefaults($page);
         $defaults['parameters'] = '';
 
-        $requirements = ['parameters' => '(/.+)?'];
+        $requirements = ['parameters' => '(/.+?)?'];
         $path = sprintf('/%s{parameters}%s', $page->alias ?: $page->id, $this->urlSuffix);
 
         if ($this->prependLocale) {

--- a/core-bundle/tests/Routing/RouteProviderTest.php
+++ b/core-bundle/tests/Routing/RouteProviderTest.php
@@ -529,7 +529,7 @@ class RouteProviderTest extends TestCase
         $route = $collection->get('tl_page.'.$page->id);
 
         $this->assertInstanceOf(Route::class, $route);
-        $this->assertSame('(/.+)?', $route->getRequirement('parameters'));
+        $this->assertSame('(/.+?)?', $route->getRequirement('parameters'));
         $this->assertTrue($route->getOption('utf8'));
         $this->assertSame($domain, $route->getHost());
 


### PR DESCRIPTION
Looks like we forgot to backport the changes from #2690 so Contao 4.9. Fixes https://github.com/contao/contao/issues/3531

This does not/cannot be merged upstream, see https://github.com/contao/contao/pull/4106 for the fix in Contao 4.12