### PR TITLE
Fix trailing slashes in URL when requireItem is enabled

### DIFF
--- a/core-bundle/src/Routing/Page/PageRegistry.php
+++ b/core-bundle/src/Routing/Page/PageRegistry.php
@@ -73,7 +73,7 @@ class PageRegistry
         if (null === $path) {
             $path = '/'.($pageModel->alias ?: $pageModel->id).'{!parameters}';
             $defaults['parameters'] = '';
-            $requirements['parameters'] = $pageModel->requireItem ? '/.+' : '(/.+?)?';
+            $requirements['parameters'] = $pageModel->requireItem ? '/.+?' : '(/.+?)?';
         }
 
         $route = new PageRoute($pageModel, $path, $defaults, $requirements, $config->getOptions(), $config->getMethods());

--- a/core-bundle/tests/Routing/Page/PageRegistryTest.php
+++ b/core-bundle/tests/Routing/Page/PageRegistryTest.php
@@ -63,7 +63,7 @@ class PageRegistryTest extends TestCase
 
         $this->assertSame('/foo/bar{!parameters}.baz', $route->getPath());
         $this->assertSame('', $route->getDefault('parameters'));
-        $this->assertSame('/.+', $route->getRequirement('parameters'));
+        $this->assertSame('/.+?', $route->getRequirement('parameters'));
     }
 
     /**


### PR DESCRIPTION
Somehow we forgot to apply the fix from #2690 if `requireItem` is enabled. Fixes #3531 for Contao 4.12+