### PR TITLE
Return an empty string if there is no driver

### DIFF
--- a/core-bundle/src/Resources/contao/classes/DataContainer.php
+++ b/core-bundle/src/Resources/contao/classes/DataContainer.php
@@ -1615,6 +1615,11 @@ abstract class DataContainer extends Backend
 	 */
 	public static function getDriverForTable(string $table): string
 	{
+		if (!isset($GLOBALS['TL_DCA'][$table]['config']['dataContainer']))
+		{
+			return '';
+		}
+
 		$dataContainer = $GLOBALS['TL_DCA'][$table]['config']['dataContainer'];
 
 		if (false === strpos($dataContainer, '\\'))

--- a/core-bundle/src/Resources/contao/classes/DataContainer.php
+++ b/core-bundle/src/Resources/contao/classes/DataContainer.php
@@ -1612,6 +1612,8 @@ abstract class DataContainer extends Backend
 	 * @param string $table
 	 *
 	 * @return string
+	 *
+	 * @todo Change the return type to ?string in Contao 5.0
 	 */
 	public static function getDriverForTable(string $table): string
 	{

--- a/core-bundle/src/Resources/contao/classes/DataContainer.php
+++ b/core-bundle/src/Resources/contao/classes/DataContainer.php
@@ -1612,13 +1612,13 @@ abstract class DataContainer extends Backend
 	 * @param string $table
 	 *
 	 * @return string
-	 *
-	 * @todo Change the return type to ?string in Contao 5.0
 	 */
 	public static function getDriverForTable(string $table): string
 	{
 		if (!isset($GLOBALS['TL_DCA'][$table]['config']['dataContainer']))
 		{
+			trigger_deprecation('contao/core-bundle', '4.13', 'Passing an unknown table name to DataContainer::getDriverForTable() will trigger an InvalidArgumentException in Contao 5.0.');
+
 			return '';
 		}
 


### PR DESCRIPTION
Otherwise the method would return `DC_` if `$GLOBALS['TL_DCA'][$table]['config']['dataContainer']` is not set.