### PR TITLE
Allow DCAs without driver

### DIFF
--- a/core-bundle/src/Resources/contao/classes/DataContainer.php
+++ b/core-bundle/src/Resources/contao/classes/DataContainer.php
@@ -1612,13 +1612,13 @@ abstract class DataContainer extends Backend
 	 * @param string $table
 	 *
 	 * @return string
+	 *
+	 * @todo Change the return type to ?string in Contao 5.0
 	 */
 	public static function getDriverForTable(string $table): string
 	{
 		if (!isset($GLOBALS['TL_DCA'][$table]['config']['dataContainer']))
 		{
-			trigger_deprecation('contao/core-bundle', '4.13', 'Passing an unknown table name to DataContainer::getDriverForTable() will trigger an InvalidArgumentException in Contao 5.0.');
-
 			return '';
 		}
 


### PR DESCRIPTION
Because some DCAs like `tl_search` only have SQL definitions and when the schema manager builds the DCA schema, it will run `DcaExtractor::createExtract()` and these DCAs will not get a driver.