### PR TITLE
Fix global state in unit tests

### DIFF
--- a/core-bundle/phpunit.xml.dist
+++ b/core-bundle/phpunit.xml.dist
@@ -47,11 +47,15 @@
           <element key="time-sensitive">
             <array>
               <element key="0"><string>Contao\CoreBundle\Command</string></element>
-              <element key="1"><string>Contao\CoreBundle\Tests\Command</string></element>
+              <element key="1"><string>Contao\CoreBundle\Controller\ContentElement</string></element>
               <element key="2"><string>Contao\CoreBundle\Cron\Command</string></element>
-              <element key="3"><string>Contao\CoreBundle\Tests\Cron</string></element>
-              <element key="4"><string>Contao\CoreBundle\EventListener</string></element>
-              <element key="5"><string>Contao\CoreBundle\Tests\EventListener</string></element>
+              <element key="3"><string>Contao\CoreBundle\EventListener\DataContainer</string></element>
+              <element key="4"><string>Contao\CoreBundle\Security\Authentication\Provider</string></element>
+              <element key="5"><string>Contao\CoreBundle\Tests\Command</string></element>
+              <element key="6"><string>Contao\CoreBundle\Tests\Controller\ContentElement</string></element>
+              <element key="7"><string>Contao\CoreBundle\Tests\Cron</string></element>
+              <element key="8"><string>Contao\CoreBundle\Tests\Security\Authentication\Provider</string></element>
+              <element key="9"><string>Contao\CoreBundle\Tests\Security\Authentication\RememberMe</string></element>
             </array>
           </element>
         </array>

--- a/manager-bundle/tests/ContaoManager/PluginTest.php
+++ b/manager-bundle/tests/ContaoManager/PluginTest.php
@@ -53,11 +53,29 @@ class PluginTest extends ContaoTestCase
 {
     use ExpectDeprecationTrait;
 
+    private $globalsBackup = [];
+
     protected function setUp(): void
     {
         parent::setUp();
 
+        $this->globalsBackup['_SERVER'] = $_SERVER ?? null;
+        $this->globalsBackup['_ENV'] = $_ENV ?? null;
+
         unset($_SERVER['DATABASE_URL'], $_SERVER['APP_SECRET'], $_ENV['DATABASE_URL']);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->globalsBackup as $key => $value) {
+            if (null === $value) {
+                unset($GLOBALS[$key]);
+            } else {
+                $GLOBALS[$key] = $value;
+            }
+        }
+
+        parent::tearDown();
     }
 
     public function testDependsOnCoreBundlePlugin(): void

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" colors="true" defaultTestSuite="unit" bootstrap="vendor/autoload.php">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" colors="true" defaultTestSuite="unit" bootstrap="vendor/autoload.php" beStrictAboutChangesToGlobalState="true">
   <coverage>
     <include>
       <directory>./calendar-bundle/src</directory>


### PR DESCRIPTION
Our tests should not interfere with `$GLOBALS` ☺️