### PR TITLE
Increase the minimum version of the Composer runtime API

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "ext-pdo": "*",
         "ext-session": "*",
         "ext-zlib": "*",
-        "composer-runtime-api": "^2.0",
+        "composer-runtime-api": "^2.0.14",
         "ausi/slug-generator": "^1.1",
         "bacon/bacon-qr-code": "^2.0",
         "contao-components/ace": "^1.2",

--- a/core-bundle/composer.json
+++ b/core-bundle/composer.json
@@ -32,7 +32,7 @@
         "ext-pdo": "*",
         "ext-session": "*",
         "ext-zlib": "*",
-        "composer-runtime-api": "^2.0",
+        "composer-runtime-api": "^2.0.14",
         "ausi/slug-generator": "^1.1",
         "bacon/bacon-qr-code": "^2.0",
         "contao-components/ace": "^1.2",


### PR DESCRIPTION
Contao uses InstalledVersions::getAllRawData() which was introduced in this release, see https://github.com/composer/composer/commit/f5e6cc89cd8d45c99cff77ee80d0f324ada45686

https://github.com/contao/contao/blob/a5c401df53881cd09edd0e5dfc9813dbb659c251/core-bundle/src/DependencyInjection/Compiler/AddPackagesPass.php#L32-L34
