### PR TITLE
Use static description for commands

### DIFF
--- a/core-bundle/src/Command/AutomatorCommand.php
+++ b/core-bundle/src/Command/AutomatorCommand.php
@@ -44,8 +44,6 @@ class AutomatorCommand extends Command
 
     protected function configure(): void
     {
-        parent::configure();
-
         $this->addArgument('task', InputArgument::OPTIONAL, "The name of the task:\n  - ".implode("\n  - ", $this->getCommands()));
     }
 

--- a/core-bundle/src/Command/AutomatorCommand.php
+++ b/core-bundle/src/Command/AutomatorCommand.php
@@ -30,6 +30,7 @@ use Symfony\Component\Console\Question\ChoiceQuestion;
 class AutomatorCommand extends Command
 {
     protected static $defaultName = 'contao:automator';
+    protected static $defaultDescription = 'Runs automator tasks on the command line.';
 
     private array $commands = [];
     private ContaoFramework $framework;
@@ -45,7 +46,6 @@ class AutomatorCommand extends Command
     {
         $this
             ->addArgument('task', InputArgument::OPTIONAL, "The name of the task:\n  - ".implode("\n  - ", $this->getCommands()))
-            ->setDescription('Runs automator tasks on the command line.')
         ;
     }
 

--- a/core-bundle/src/Command/AutomatorCommand.php
+++ b/core-bundle/src/Command/AutomatorCommand.php
@@ -44,9 +44,9 @@ class AutomatorCommand extends Command
 
     protected function configure(): void
     {
-        $this
-            ->addArgument('task', InputArgument::OPTIONAL, "The name of the task:\n  - ".implode("\n  - ", $this->getCommands()))
-        ;
+        parent::configure();
+
+        $this->addArgument('task', InputArgument::OPTIONAL, "The name of the task:\n  - ".implode("\n  - ", $this->getCommands()));
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/core-bundle/src/Command/Backup/AbstractBackupCommand.php
+++ b/core-bundle/src/Command/Backup/AbstractBackupCommand.php
@@ -35,8 +35,6 @@ abstract class AbstractBackupCommand extends Command
 
     protected function configure(): void
     {
-        parent::configure();
-
         $this
             ->addArgument('name', InputArgument::OPTIONAL, 'The name of the backup')
             ->addOption('ignore-tables', 'i', InputOption::VALUE_OPTIONAL, 'A comma-separated list of database tables to ignore. Defaults to the backup configuration (contao.backup.ignore_tables). You can use the prefixes "+" and "-" to modify the existing configuration (e.g. "+tl_user" would add "tl_user" to the existing list).')

--- a/core-bundle/src/Command/Backup/BackupCreateCommand.php
+++ b/core-bundle/src/Command/Backup/BackupCreateCommand.php
@@ -23,13 +23,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 class BackupCreateCommand extends AbstractBackupCommand
 {
     protected static $defaultName = 'contao:backup:create';
-
-    protected function configure(): void
-    {
-        parent::configure();
-
-        $this->setDescription('Creates a new backup.');
-    }
+    protected static $defaultDescription = 'Creates a new backup.';
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {

--- a/core-bundle/src/Command/Backup/BackupListCommand.php
+++ b/core-bundle/src/Command/Backup/BackupListCommand.php
@@ -23,6 +23,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 class BackupListCommand extends AbstractBackupCommand
 {
     protected static $defaultName = 'contao:backup:list';
+    protected static $defaultDescription = 'Lists the existing backups.';
 
     public static function getFormattedTimeZoneOffset(\DateTimeZone $timeZone): string
     {
@@ -30,13 +31,6 @@ class BackupListCommand extends AbstractBackupCommand
         $formatted = str_pad(str_replace(['.', '-', '+'], [':', '', ''], sprintf('%05.2F', $offset)), 5, '0', STR_PAD_LEFT);
 
         return ($offset >= 0 ? '+' : '-').$formatted;
-    }
-
-    protected function configure(): void
-    {
-        parent::configure();
-
-        $this->setDescription('Lists the existing backups.');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/core-bundle/src/Command/Backup/BackupRestoreCommand.php
+++ b/core-bundle/src/Command/Backup/BackupRestoreCommand.php
@@ -28,8 +28,6 @@ class BackupRestoreCommand extends AbstractBackupCommand
 
     protected function configure(): void
     {
-        parent::configure();
-
         $this->addOption('force', null, InputOption::VALUE_NONE, 'By default, this command only restores backup that have been generated with Contao. Use --force to bypass this check.');
     }
 

--- a/core-bundle/src/Command/Backup/BackupRestoreCommand.php
+++ b/core-bundle/src/Command/Backup/BackupRestoreCommand.php
@@ -28,6 +28,8 @@ class BackupRestoreCommand extends AbstractBackupCommand
 
     protected function configure(): void
     {
+        parent::configure();
+
         $this->addOption('force', null, InputOption::VALUE_NONE, 'By default, this command only restores backup that have been generated with Contao. Use --force to bypass this check.');
     }
 

--- a/core-bundle/src/Command/Backup/BackupRestoreCommand.php
+++ b/core-bundle/src/Command/Backup/BackupRestoreCommand.php
@@ -30,9 +30,7 @@ class BackupRestoreCommand extends AbstractBackupCommand
     {
         parent::configure();
 
-        $this
-            ->addOption('force', null, InputOption::VALUE_NONE, 'By default, this command only restores backup that have been generated with Contao. Use --force to bypass this check.')
-        ;
+        $this->addOption('force', null, InputOption::VALUE_NONE, 'By default, this command only restores backup that have been generated with Contao. Use --force to bypass this check.');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/core-bundle/src/Command/Backup/BackupRestoreCommand.php
+++ b/core-bundle/src/Command/Backup/BackupRestoreCommand.php
@@ -24,6 +24,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 class BackupRestoreCommand extends AbstractBackupCommand
 {
     protected static $defaultName = 'contao:backup:restore';
+    protected static $defaultDescription = 'Restores a backup.';
 
     protected function configure(): void
     {
@@ -31,7 +32,6 @@ class BackupRestoreCommand extends AbstractBackupCommand
 
         $this
             ->addOption('force', null, InputOption::VALUE_NONE, 'By default, this command only restores backup that have been generated with Contao. Use --force to bypass this check.')
-            ->setDescription('Restores a backup.')
         ;
     }
 

--- a/core-bundle/src/Command/Backup/BackupStreamContentCommand.php
+++ b/core-bundle/src/Command/Backup/BackupStreamContentCommand.php
@@ -59,8 +59,6 @@ class BackupStreamContentCommand extends Command
 
     protected function configure(): void
     {
-        parent::configure();
-
         $this
             ->addArgument('name', InputArgument::REQUIRED, 'The name of the backup')
             ->setHidden(true)

--- a/core-bundle/src/Command/CrawlCommand.php
+++ b/core-bundle/src/Command/CrawlCommand.php
@@ -45,7 +45,7 @@ use Terminal42\Escargot\Subscriber\SubscriberInterface;
 class CrawlCommand extends Command
 {
     protected static $defaultName = 'contao:crawl';
-    protected static $defaultDescription = 'Crawls the Contao root pages with the desired subscribers';
+    protected static $defaultDescription = 'Crawls the Contao root pages with the desired subscribers.';
 
     private Factory $escargotFactory;
     private Filesystem $filesystem;

--- a/core-bundle/src/Command/CrawlCommand.php
+++ b/core-bundle/src/Command/CrawlCommand.php
@@ -45,6 +45,7 @@ use Terminal42\Escargot\Subscriber\SubscriberInterface;
 class CrawlCommand extends Command
 {
     protected static $defaultName = 'contao:crawl';
+    protected static $defaultDescription = 'Crawls the Contao root pages with the desired subscribers';
 
     private Factory $escargotFactory;
     private Filesystem $filesystem;
@@ -75,7 +76,6 @@ class CrawlCommand extends Command
             ->addOption('no-progress', null, InputOption::VALUE_NONE, 'Disables the progress bar output')
             ->addOption('enable-debug-csv', null, InputOption::VALUE_NONE, 'Writes the crawl debug log into a separate CSV file')
             ->addOption('debug-csv-path', null, InputOption::VALUE_REQUIRED, 'The path of the debug log CSV file', Path::join(getcwd(), 'crawl_debug_log.csv'))
-            ->setDescription('Crawls the Contao root pages with the desired subscribers')
             ->setHelp('You can add additional URIs via the <info>contao.crawl.additional_uris</info> parameter.')
         ;
     }

--- a/core-bundle/src/Command/CronCommand.php
+++ b/core-bundle/src/Command/CronCommand.php
@@ -20,6 +20,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 class CronCommand extends Command
 {
     protected static $defaultName = 'contao:cron';
+    protected static $defaultDescription = 'Runs all registered cron jobs on the command line.';
 
     protected Cron $cron;
 
@@ -28,13 +29,6 @@ class CronCommand extends Command
         $this->cron = $cron;
 
         parent::__construct();
-    }
-
-    protected function configure(): void
-    {
-        $this
-            ->setDescription('Runs all registered cron jobs on the command line.')
-        ;
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/core-bundle/src/Command/DebugContaoTwigCommand.php
+++ b/core-bundle/src/Command/DebugContaoTwigCommand.php
@@ -30,6 +30,7 @@ use Symfony\Component\Filesystem\Path;
 class DebugContaoTwigCommand extends Command
 {
     protected static $defaultName = 'debug:contao-twig';
+    protected static $defaultDescription = 'Displays the Contao template hierarchy.';
 
     private TemplateHierarchyInterface $hierarchy;
     private ContaoFilesystemLoaderWarmer $cacheWarmer;
@@ -49,7 +50,6 @@ class DebugContaoTwigCommand extends Command
     protected function configure(): void
     {
         $this
-            ->setDescription('Displays the Contao template hierarchy.')
             ->addOption('theme', 't', InputOption::VALUE_OPTIONAL, 'Include theme templates with a given theme path or slug.')
             ->addArgument('filter', InputArgument::OPTIONAL, 'Filter the output by an identifier or prefix.')
         ;

--- a/core-bundle/src/Command/DebugDcaCommand.php
+++ b/core-bundle/src/Command/DebugDcaCommand.php
@@ -30,6 +30,7 @@ use Symfony\Component\VarDumper\Dumper\CliDumper;
 class DebugDcaCommand extends Command
 {
     protected static $defaultName = 'debug:dca';
+    protected static $defaultDescription = 'Dumps the DCA configuration for a table.';
 
     private ContaoFramework $framework;
 
@@ -44,7 +45,6 @@ class DebugDcaCommand extends Command
     {
         $this
             ->addArgument('table', InputArgument::REQUIRED, 'The table name')
-            ->setDescription('Dumps the DCA configuration for a table.')
         ;
     }
 

--- a/core-bundle/src/Command/DebugDcaCommand.php
+++ b/core-bundle/src/Command/DebugDcaCommand.php
@@ -43,9 +43,9 @@ class DebugDcaCommand extends Command
 
     protected function configure(): void
     {
-        $this
-            ->addArgument('table', InputArgument::REQUIRED, 'The table name')
-        ;
+        parent::configure();
+
+        $this->addArgument('table', InputArgument::REQUIRED, 'The table name');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/core-bundle/src/Command/DebugDcaCommand.php
+++ b/core-bundle/src/Command/DebugDcaCommand.php
@@ -43,8 +43,6 @@ class DebugDcaCommand extends Command
 
     protected function configure(): void
     {
-        parent::configure();
-
         $this->addArgument('table', InputArgument::REQUIRED, 'The table name');
     }
 

--- a/core-bundle/src/Command/DebugFragmentsCommand.php
+++ b/core-bundle/src/Command/DebugFragmentsCommand.php
@@ -21,6 +21,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 class DebugFragmentsCommand extends Command
 {
     protected static $defaultName = 'debug:fragments';
+    protected static $defaultDescription = 'Displays the fragment controller configuration.';
 
     private array $identifiers = [];
     private array $attributes = [];
@@ -35,13 +36,6 @@ class DebugFragmentsCommand extends Command
         $this->identifiers[] = $identifier;
         $this->configs[$identifier] = $config;
         $this->attributes[$identifier] = $attributes;
-    }
-
-    protected function configure(): void
-    {
-        $this
-            ->setDescription('Displays the fragment controller configuration.')
-        ;
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/core-bundle/src/Command/DebugPagesCommand.php
+++ b/core-bundle/src/Command/DebugPagesCommand.php
@@ -26,6 +26,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 class DebugPagesCommand extends Command
 {
     protected static $defaultName = 'debug:pages';
+    protected static $defaultDescription = 'Displays the page controller configuration.';
 
     private ContaoFramework $framework;
     private PageRegistry $pageRegistry;
@@ -67,11 +68,6 @@ class DebugPagesCommand extends Command
         if (null !== $contentComposition) {
             $this->contentComposition[$type] = $contentComposition;
         }
-    }
-
-    protected function configure(): void
-    {
-        $this->setDescription('Displays the page controller configuration.');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/core-bundle/src/Command/InstallCommand.php
+++ b/core-bundle/src/Command/InstallCommand.php
@@ -48,8 +48,6 @@ class InstallCommand extends Command
 
     protected function configure(): void
     {
-        parent::configure();
-
         $this->addArgument('target', InputArgument::OPTIONAL, 'The target directory');
     }
 

--- a/core-bundle/src/Command/InstallCommand.php
+++ b/core-bundle/src/Command/InstallCommand.php
@@ -28,6 +28,7 @@ use Symfony\Component\Filesystem\Path;
 class InstallCommand extends Command
 {
     protected static $defaultName = 'contao:install';
+    protected static $defaultDescription = 'Installs the required Contao directories';
 
     private ?Filesystem $fs = null;
     private array $rows = [];
@@ -49,7 +50,6 @@ class InstallCommand extends Command
     {
         $this
             ->addArgument('target', InputArgument::OPTIONAL, 'The target directory')
-            ->setDescription('Installs the required Contao directories')
         ;
     }
 

--- a/core-bundle/src/Command/InstallCommand.php
+++ b/core-bundle/src/Command/InstallCommand.php
@@ -28,7 +28,7 @@ use Symfony\Component\Filesystem\Path;
 class InstallCommand extends Command
 {
     protected static $defaultName = 'contao:install';
-    protected static $defaultDescription = 'Installs the required Contao directories';
+    protected static $defaultDescription = 'Installs the required Contao directories.';
 
     private ?Filesystem $fs = null;
     private array $rows = [];

--- a/core-bundle/src/Command/InstallCommand.php
+++ b/core-bundle/src/Command/InstallCommand.php
@@ -48,9 +48,9 @@ class InstallCommand extends Command
 
     protected function configure(): void
     {
-        $this
-            ->addArgument('target', InputArgument::OPTIONAL, 'The target directory')
-        ;
+        parent::configure();
+
+        $this->addArgument('target', InputArgument::OPTIONAL, 'The target directory');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/core-bundle/src/Command/MigrateCommand.php
+++ b/core-bundle/src/Command/MigrateCommand.php
@@ -31,6 +31,7 @@ use Symfony\Component\Filesystem\Path;
 class MigrateCommand extends Command
 {
     protected static $defaultName = 'contao:migrate';
+    protected static $defaultDescription = 'Executes migrations and updates the database schema.';
 
     private MigrationCollection $migrations;
     private FileLocator $fileLocator;
@@ -61,7 +62,6 @@ class MigrateCommand extends Command
             ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Show pending migrations and schema updates without executing them.')
             ->addOption('format', null, InputOption::VALUE_REQUIRED, 'The output format (txt, ndjson)', 'txt')
             ->addOption('no-backup', null, InputOption::VALUE_NONE, 'Disable the database backup which is created by default before executing the migrations.')
-            ->setDescription('Executes migrations and updates the database schema.')
         ;
     }
 

--- a/core-bundle/src/Command/ResizeImagesCommand.php
+++ b/core-bundle/src/Command/ResizeImagesCommand.php
@@ -43,6 +43,7 @@ use Symfony\Component\Process\Process;
 class ResizeImagesCommand extends Command
 {
     protected static $defaultName = 'contao:resize-images';
+    protected static $defaultDescription = 'Resizes deferred images that have not been processed yet.';
 
     private ImageFactoryInterface $imageFactory;
     private ?DeferredResizerInterface $resizer;
@@ -75,7 +76,6 @@ class ResizeImagesCommand extends Command
             ->addOption('image', null, InputArgument::OPTIONAL, 'Image name to resize a single image')
             ->addOption('no-sub-process', null, InputOption::VALUE_NONE, 'Do not start a sub process per resize')
             ->addOption('preserve-missing', null, InputOption::VALUE_NONE, 'Do not delete deferred image references to images that no longer exist')
-            ->setDescription('Resizes deferred images that have not been processed yet.')
         ;
     }
 

--- a/core-bundle/src/Command/SymlinksCommand.php
+++ b/core-bundle/src/Command/SymlinksCommand.php
@@ -60,9 +60,9 @@ class SymlinksCommand extends Command
 
     protected function configure(): void
     {
-        $this
-            ->addArgument('target', InputArgument::OPTIONAL, 'The target directory')
-        ;
+        parent::configure();
+
+        $this->addArgument('target', InputArgument::OPTIONAL, 'The target directory');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/core-bundle/src/Command/SymlinksCommand.php
+++ b/core-bundle/src/Command/SymlinksCommand.php
@@ -60,8 +60,6 @@ class SymlinksCommand extends Command
 
     protected function configure(): void
     {
-        parent::configure();
-
         $this->addArgument('target', InputArgument::OPTIONAL, 'The target directory');
     }
 

--- a/core-bundle/src/Command/SymlinksCommand.php
+++ b/core-bundle/src/Command/SymlinksCommand.php
@@ -36,6 +36,7 @@ use Symfony\Component\Finder\SplFileInfo;
 class SymlinksCommand extends Command
 {
     protected static $defaultName = 'contao:symlinks';
+    protected static $defaultDescription = 'Symlinks the public resources into the public directory.';
 
     private array $rows = [];
     private string $projectDir;
@@ -61,7 +62,6 @@ class SymlinksCommand extends Command
     {
         $this
             ->addArgument('target', InputArgument::OPTIONAL, 'The target directory')
-            ->setDescription('Symlinks the public resources into the public directory.')
         ;
     }
 

--- a/core-bundle/src/Command/UserCreateCommand.php
+++ b/core-bundle/src/Command/UserCreateCommand.php
@@ -37,6 +37,7 @@ use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface;
 class UserCreateCommand extends Command
 {
     protected static $defaultName = 'contao:user:create';
+    protected static $defaultDescription = 'Create a new Contao back end user.';
 
     private ContaoFramework $framework;
     private Connection $connection;
@@ -64,7 +65,6 @@ class UserCreateCommand extends Command
             ->addOption('admin', null, InputOption::VALUE_NONE, 'Give admin permissions to the new user')
             ->addOption('group', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'The groups to assign the user to')
             ->addOption('change-password', null, InputOption::VALUE_NONE, 'Require user to change the password on the first back end login')
-            ->setDescription('Create a new Contao back end user.')
         ;
     }
 

--- a/core-bundle/src/Command/UserListCommand.php
+++ b/core-bundle/src/Command/UserListCommand.php
@@ -29,6 +29,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 class UserListCommand extends Command
 {
     protected static $defaultName = 'contao:user:list';
+    protected static $defaultDescription = 'Lists Contao back end users.';
 
     private ContaoFramework $framework;
 
@@ -45,7 +46,6 @@ class UserListCommand extends Command
             ->addOption('column', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'The columns display in the table')
             ->addOption('admins', null, InputOption::VALUE_NONE, 'Return only admins')
             ->addOption('format', null, InputOption::VALUE_REQUIRED, 'The output format (txt, json)', 'txt')
-            ->setDescription('Lists Contao back end users.')
         ;
     }
 

--- a/core-bundle/src/Command/UserPasswordCommand.php
+++ b/core-bundle/src/Command/UserPasswordCommand.php
@@ -36,6 +36,7 @@ use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface;
 class UserPasswordCommand extends Command
 {
     protected static $defaultName = 'contao:user:password';
+    protected static $defaultDescription = 'Changes the password of a Contao back end user.';
 
     private ContaoFramework $framework;
     private Connection $connection;
@@ -56,7 +57,6 @@ class UserPasswordCommand extends Command
             ->addArgument('username', InputArgument::REQUIRED, 'The username of the back end user')
             ->addOption('password', 'p', InputOption::VALUE_REQUIRED, 'The new password (using this option is not recommended for security reasons)')
             ->addOption('require-change', 'r', InputOption::VALUE_NONE, 'Require the user to change the password on their next login.')
-            ->setDescription('Changes the password of a Contao back end user.')
         ;
     }
 

--- a/core-bundle/src/Command/VersionCommand.php
+++ b/core-bundle/src/Command/VersionCommand.php
@@ -26,13 +26,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 class VersionCommand extends Command
 {
     protected static $defaultName = 'contao:version';
-
-    protected function configure(): void
-    {
-        $this
-            ->setDescription('Outputs the contao/core-bundle version (deprecated).')
-        ;
-    }
+    protected static $defaultDescription = 'Outputs the contao/core-bundle version (deprecated).';
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {

--- a/installation-bundle/src/Command/LockCommand.php
+++ b/installation-bundle/src/Command/LockCommand.php
@@ -24,6 +24,9 @@ use Symfony\Component\Filesystem\Filesystem;
  */
 class LockCommand extends Command
 {
+    protected static $defaultName = 'contao:install:lock';
+    protected static $defaultDescription = 'Locks the install tool.';
+
     private string $lockFile;
 
     public function __construct(string $lockFile)
@@ -31,14 +34,6 @@ class LockCommand extends Command
         $this->lockFile = $lockFile;
 
         parent::__construct();
-    }
-
-    protected function configure(): void
-    {
-        $this
-            ->setName('contao:install:lock')
-            ->setDescription('Locks the install tool.')
-        ;
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/installation-bundle/src/Command/UnlockCommand.php
+++ b/installation-bundle/src/Command/UnlockCommand.php
@@ -24,6 +24,9 @@ use Symfony\Component\Filesystem\Filesystem;
  */
 class UnlockCommand extends Command
 {
+    protected static $defaultName = 'contao:install:unlock';
+    protected static $defaultDescription = 'Unlocks the install tool.';
+
     private string $lockFile;
 
     public function __construct(string $lockFile)
@@ -31,14 +34,6 @@ class UnlockCommand extends Command
         $this->lockFile = $lockFile;
 
         parent::__construct();
-    }
-
-    protected function configure(): void
-    {
-        $this
-            ->setName('contao:install:unlock')
-            ->setDescription('Unlocks the install tool.')
-        ;
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/manager-bundle/src/Api/Command/VersionCommand.php
+++ b/manager-bundle/src/Api/Command/VersionCommand.php
@@ -23,6 +23,9 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class VersionCommand extends Command
 {
+    protected static $defaultName = 'version';
+    protected static $defaultDescription = 'Gets the Contao Manager API version and features.';
+
     private Application $application;
 
     public function __construct(Application $application)
@@ -30,16 +33,6 @@ class VersionCommand extends Command
         parent::__construct();
 
         $this->application = $application;
-    }
-
-    protected function configure(): void
-    {
-        parent::configure();
-
-        $this
-            ->setName('version')
-            ->setDescription('Gets the Contao Manager API version and features.')
-        ;
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/manager-bundle/src/Command/ContaoSetupCommand.php
+++ b/manager-bundle/src/Command/ContaoSetupCommand.php
@@ -25,6 +25,7 @@ use Symfony\Component\Process\Process;
 class ContaoSetupCommand extends Command
 {
     protected static $defaultName = 'contao:setup';
+    protected static $defaultDescription = 'Sets up a Contao Managed Edition. This command will be run when executing the "contao-setup" binary.';
 
     private string $webDir;
     private string $consolePath;
@@ -57,7 +58,6 @@ class ContaoSetupCommand extends Command
     {
         $this
             ->setHidden(true)
-            ->setDescription('Sets up a Contao Managed Edition. This command will be run when executing the "contao-setup" binary.')
         ;
     }
 

--- a/manager-bundle/src/Command/ContaoSetupCommand.php
+++ b/manager-bundle/src/Command/ContaoSetupCommand.php
@@ -56,9 +56,9 @@ class ContaoSetupCommand extends Command
 
     protected function configure(): void
     {
-        $this
-            ->setHidden(true)
-        ;
+        parent::configure();
+
+        $this->setHidden(true);
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/manager-bundle/src/Command/ContaoSetupCommand.php
+++ b/manager-bundle/src/Command/ContaoSetupCommand.php
@@ -56,8 +56,6 @@ class ContaoSetupCommand extends Command
 
     protected function configure(): void
     {
-        parent::configure();
-
         $this->setHidden(true);
     }
 

--- a/manager-bundle/src/Command/DebugPluginsCommand.php
+++ b/manager-bundle/src/Command/DebugPluginsCommand.php
@@ -40,6 +40,7 @@ use Symfony\Component\Filesystem\Path;
 class DebugPluginsCommand extends Command
 {
     protected static $defaultName = 'debug:plugins';
+    protected static $defaultDescription = 'Displays the Contao Manager plugin configurations';
 
     private ContaoKernel $kernel;
     private ?SymfonyStyle $io = null;
@@ -56,7 +57,6 @@ class DebugPluginsCommand extends Command
         $this
             ->addArgument('name', InputArgument::OPTIONAL, 'The plugin class or package name')
             ->addOption('bundles', null, InputOption::VALUE_NONE, 'List all bundles or the bundle configuration of the given plugin')
-            ->setDescription('Displays the Contao Manager plugin configurations')
         ;
     }
 

--- a/manager-bundle/src/Command/DebugPluginsCommand.php
+++ b/manager-bundle/src/Command/DebugPluginsCommand.php
@@ -40,7 +40,7 @@ use Symfony\Component\Filesystem\Path;
 class DebugPluginsCommand extends Command
 {
     protected static $defaultName = 'debug:plugins';
-    protected static $defaultDescription = 'Displays the Contao Manager plugin configurations';
+    protected static $defaultDescription = 'Displays the Contao Manager plugin configurations.';
 
     private ContaoKernel $kernel;
     private ?SymfonyStyle $io = null;

--- a/manager-bundle/src/Command/InstallWebDirCommand.php
+++ b/manager-bundle/src/Command/InstallWebDirCommand.php
@@ -43,8 +43,6 @@ class InstallWebDirCommand extends Command
 
     protected function configure(): void
     {
-        parent::configure();
-
         $this->addArgument('target', InputArgument::OPTIONAL, 'The target directory');
     }
 

--- a/manager-bundle/src/Command/InstallWebDirCommand.php
+++ b/manager-bundle/src/Command/InstallWebDirCommand.php
@@ -28,7 +28,7 @@ use Symfony\Component\Finder\SplFileInfo;
 class InstallWebDirCommand extends Command
 {
     protected static $defaultName = 'contao:install-web-dir';
-    protected static $defaultDescription = 'Installs the files in the public directory';
+    protected static $defaultDescription = 'Installs the files in the public directory.';
 
     private ?Filesystem $fs = null;
     private ?SymfonyStyle $io = null;

--- a/manager-bundle/src/Command/InstallWebDirCommand.php
+++ b/manager-bundle/src/Command/InstallWebDirCommand.php
@@ -27,6 +27,9 @@ use Symfony\Component\Finder\SplFileInfo;
  */
 class InstallWebDirCommand extends Command
 {
+    protected static $defaultName = 'contao:install-web-dir';
+    protected static $defaultDescription = 'Installs the files in the public directory';
+
     private ?Filesystem $fs = null;
     private ?SymfonyStyle $io = null;
     private string $projectDir;
@@ -41,9 +44,7 @@ class InstallWebDirCommand extends Command
     protected function configure(): void
     {
         $this
-            ->setName('contao:install-web-dir')
             ->addArgument('target', InputArgument::OPTIONAL, 'The target directory')
-            ->setDescription('Installs the files in the public directory')
         ;
     }
 

--- a/manager-bundle/src/Command/InstallWebDirCommand.php
+++ b/manager-bundle/src/Command/InstallWebDirCommand.php
@@ -43,9 +43,9 @@ class InstallWebDirCommand extends Command
 
     protected function configure(): void
     {
-        $this
-            ->addArgument('target', InputArgument::OPTIONAL, 'The target directory')
-        ;
+        parent::configure();
+
+        $this->addArgument('target', InputArgument::OPTIONAL, 'The target directory');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/manager-bundle/src/Command/MaintenanceModeCommand.php
+++ b/manager-bundle/src/Command/MaintenanceModeCommand.php
@@ -27,6 +27,7 @@ use Twig\Environment;
 class MaintenanceModeCommand extends Command
 {
     protected static $defaultName = 'contao:maintenance-mode';
+    protected static $defaultDescription = 'Changes the state of the system maintenance mode.';
 
     private string $maintenanceFilePath;
     private Environment $twig;
@@ -48,7 +49,6 @@ class MaintenanceModeCommand extends Command
             ->addOption('template', 't', InputOption::VALUE_REQUIRED, 'Allows to take a different Twig template name when enabling the maintenance mode.', '@ContaoCore/Error/service_unavailable.html.twig')
             ->addOption('templateVars', null, InputOption::VALUE_OPTIONAL, 'Add custom template variables to the Twig template when enabling the maintenance mode (provide as JSON).', '{}')
             ->addOption('format', null, InputOption::VALUE_REQUIRED, 'The output format (txt, json)', 'txt')
-            ->setDescription('Changes the state of the system maintenance mode.')
         ;
     }
 

--- a/manager-bundle/src/ContaoManager/ApiCommand/GenerateJwtCookieCommand.php
+++ b/manager-bundle/src/ContaoManager/ApiCommand/GenerateJwtCookieCommand.php
@@ -38,8 +38,6 @@ class GenerateJwtCookieCommand extends Command
 
     protected function configure(): void
     {
-        parent::configure();
-
         $this->addOption('debug', null, InputOption::VALUE_NONE, 'Enable debug mode in the JWT cookie');
     }
 

--- a/manager-bundle/src/ContaoManager/ApiCommand/GenerateJwtCookieCommand.php
+++ b/manager-bundle/src/ContaoManager/ApiCommand/GenerateJwtCookieCommand.php
@@ -40,9 +40,7 @@ class GenerateJwtCookieCommand extends Command
     {
         parent::configure();
 
-        $this
-            ->addOption('debug', null, InputOption::VALUE_NONE, 'Enable debug mode in the JWT cookie')
-        ;
+        $this->addOption('debug', null, InputOption::VALUE_NONE, 'Enable debug mode in the JWT cookie');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/manager-bundle/src/ContaoManager/ApiCommand/GenerateJwtCookieCommand.php
+++ b/manager-bundle/src/ContaoManager/ApiCommand/GenerateJwtCookieCommand.php
@@ -24,6 +24,9 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class GenerateJwtCookieCommand extends Command
 {
+    protected static $defaultName = 'jwt-cookie:generate';
+    protected static $defaultDescription = 'Generates a JWT cookie for the preview entry point.';
+
     private JwtManager $jwtManager;
 
     public function __construct(Application $application, JwtManager $jwtManager = null)
@@ -38,9 +41,7 @@ class GenerateJwtCookieCommand extends Command
         parent::configure();
 
         $this
-            ->setName('jwt-cookie:generate')
             ->addOption('debug', null, InputOption::VALUE_NONE, 'Enable debug mode in the JWT cookie')
-            ->setDescription('Generates a JWT cookie for the preview entry point.')
         ;
     }
 

--- a/manager-bundle/src/ContaoManager/ApiCommand/GetConfigCommand.php
+++ b/manager-bundle/src/ContaoManager/ApiCommand/GetConfigCommand.php
@@ -23,6 +23,9 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class GetConfigCommand extends Command
 {
+    protected static $defaultName = 'config:get';
+    protected static $defaultDescription = 'Gets the Contao Manager configuration as JSON string.';
+
     private ManagerConfig $managerConfig;
 
     public function __construct(Application $application)
@@ -30,16 +33,6 @@ class GetConfigCommand extends Command
         parent::__construct();
 
         $this->managerConfig = $application->getManagerConfig();
-    }
-
-    protected function configure(): void
-    {
-        parent::configure();
-
-        $this
-            ->setName('config:get')
-            ->setDescription('Gets the Contao Manager configuration as JSON string.')
-        ;
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/manager-bundle/src/ContaoManager/ApiCommand/GetDotEnvCommand.php
+++ b/manager-bundle/src/ContaoManager/ApiCommand/GetDotEnvCommand.php
@@ -41,9 +41,7 @@ class GetDotEnvCommand extends Command
     {
         parent::configure();
 
-        $this
-            ->addArgument('key', InputArgument::OPTIONAL, 'The variable name')
-        ;
+        $this->addArgument('key', InputArgument::OPTIONAL, 'The variable name');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/manager-bundle/src/ContaoManager/ApiCommand/GetDotEnvCommand.php
+++ b/manager-bundle/src/ContaoManager/ApiCommand/GetDotEnvCommand.php
@@ -25,6 +25,9 @@ use Symfony\Component\Filesystem\Path;
  */
 class GetDotEnvCommand extends Command
 {
+    protected static $defaultName = 'dot-env:get';
+    protected static $defaultDescription = 'Reads a parameter from the .env file.';
+
     private string $projectDir;
 
     public function __construct(Application $application)
@@ -39,8 +42,6 @@ class GetDotEnvCommand extends Command
         parent::configure();
 
         $this
-            ->setName('dot-env:get')
-            ->setDescription('Reads a parameter from the .env file.')
             ->addArgument('key', InputArgument::OPTIONAL, 'The variable name')
         ;
     }

--- a/manager-bundle/src/ContaoManager/ApiCommand/GetDotEnvCommand.php
+++ b/manager-bundle/src/ContaoManager/ApiCommand/GetDotEnvCommand.php
@@ -39,8 +39,6 @@ class GetDotEnvCommand extends Command
 
     protected function configure(): void
     {
-        parent::configure();
-
         $this->addArgument('key', InputArgument::OPTIONAL, 'The variable name');
     }
 

--- a/manager-bundle/src/ContaoManager/ApiCommand/ParseJwtCookieCommand.php
+++ b/manager-bundle/src/ContaoManager/ApiCommand/ParseJwtCookieCommand.php
@@ -24,6 +24,9 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class ParseJwtCookieCommand extends Command
 {
+    protected static $defaultName = 'jwt-cookie:parse';
+    protected static $defaultDescription = 'Parses the content of the preview entry point cookie.';
+
     private JwtManager $jwtManager;
 
     public function __construct(Application $application, JwtManager $jwtManager = null)
@@ -38,9 +41,7 @@ class ParseJwtCookieCommand extends Command
         parent::configure();
 
         $this
-            ->setName('jwt-cookie:parse')
             ->addArgument('content', InputArgument::REQUIRED, 'The JWT cookie content')
-            ->setDescription('Parses the content of the preview entry point cookie.')
         ;
     }
 

--- a/manager-bundle/src/ContaoManager/ApiCommand/ParseJwtCookieCommand.php
+++ b/manager-bundle/src/ContaoManager/ApiCommand/ParseJwtCookieCommand.php
@@ -40,9 +40,7 @@ class ParseJwtCookieCommand extends Command
     {
         parent::configure();
 
-        $this
-            ->addArgument('content', InputArgument::REQUIRED, 'The JWT cookie content')
-        ;
+        $this->addArgument('content', InputArgument::REQUIRED, 'The JWT cookie content');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/manager-bundle/src/ContaoManager/ApiCommand/ParseJwtCookieCommand.php
+++ b/manager-bundle/src/ContaoManager/ApiCommand/ParseJwtCookieCommand.php
@@ -38,8 +38,6 @@ class ParseJwtCookieCommand extends Command
 
     protected function configure(): void
     {
-        parent::configure();
-
         $this->addArgument('content', InputArgument::REQUIRED, 'The JWT cookie content');
     }
 

--- a/manager-bundle/src/ContaoManager/ApiCommand/RemoveDotEnvCommand.php
+++ b/manager-bundle/src/ContaoManager/ApiCommand/RemoveDotEnvCommand.php
@@ -25,6 +25,9 @@ use Symfony\Component\Filesystem\Path;
  */
 class RemoveDotEnvCommand extends Command
 {
+    protected static $defaultName = 'dot-env:remove';
+    protected static $defaultDescription = 'Removes a parameter from the .env file.';
+
     private string $projectDir;
 
     public function __construct(Application $application)
@@ -39,8 +42,6 @@ class RemoveDotEnvCommand extends Command
         parent::configure();
 
         $this
-            ->setName('dot-env:remove')
-            ->setDescription('Removes a parameter from the .env file.')
             ->addArgument('key', InputArgument::REQUIRED, 'The variable name')
         ;
     }

--- a/manager-bundle/src/ContaoManager/ApiCommand/RemoveDotEnvCommand.php
+++ b/manager-bundle/src/ContaoManager/ApiCommand/RemoveDotEnvCommand.php
@@ -41,9 +41,7 @@ class RemoveDotEnvCommand extends Command
     {
         parent::configure();
 
-        $this
-            ->addArgument('key', InputArgument::REQUIRED, 'The variable name')
-        ;
+        $this->addArgument('key', InputArgument::REQUIRED, 'The variable name');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/manager-bundle/src/ContaoManager/ApiCommand/RemoveDotEnvCommand.php
+++ b/manager-bundle/src/ContaoManager/ApiCommand/RemoveDotEnvCommand.php
@@ -39,8 +39,6 @@ class RemoveDotEnvCommand extends Command
 
     protected function configure(): void
     {
-        parent::configure();
-
         $this->addArgument('key', InputArgument::REQUIRED, 'The variable name');
     }
 

--- a/manager-bundle/src/ContaoManager/ApiCommand/SetConfigCommand.php
+++ b/manager-bundle/src/ContaoManager/ApiCommand/SetConfigCommand.php
@@ -38,8 +38,6 @@ class SetConfigCommand extends Command
 
     protected function configure(): void
     {
-        parent::configure();
-
         $this->addArgument('json', InputArgument::REQUIRED, 'The configuration as JSON string');
     }
 

--- a/manager-bundle/src/ContaoManager/ApiCommand/SetConfigCommand.php
+++ b/manager-bundle/src/ContaoManager/ApiCommand/SetConfigCommand.php
@@ -40,9 +40,7 @@ class SetConfigCommand extends Command
     {
         parent::configure();
 
-        $this
-            ->addArgument('json', InputArgument::REQUIRED, 'The configuration as JSON string')
-        ;
+        $this->addArgument('json', InputArgument::REQUIRED, 'The configuration as JSON string');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/manager-bundle/src/ContaoManager/ApiCommand/SetConfigCommand.php
+++ b/manager-bundle/src/ContaoManager/ApiCommand/SetConfigCommand.php
@@ -24,6 +24,9 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class SetConfigCommand extends Command
 {
+    protected static $defaultName = 'config:set';
+    protected static $defaultDescription = 'Sets the Contao Manager configuration from a JSON string.';
+
     private ManagerConfig $managerConfig;
 
     public function __construct(Application $application)
@@ -38,8 +41,6 @@ class SetConfigCommand extends Command
         parent::configure();
 
         $this
-            ->setName('config:set')
-            ->setDescription('Sets the Contao Manager configuration from a JSON string.')
             ->addArgument('json', InputArgument::REQUIRED, 'The configuration as JSON string')
         ;
     }

--- a/manager-bundle/src/ContaoManager/ApiCommand/SetDotEnvCommand.php
+++ b/manager-bundle/src/ContaoManager/ApiCommand/SetDotEnvCommand.php
@@ -39,8 +39,6 @@ class SetDotEnvCommand extends Command
 
     protected function configure(): void
     {
-        parent::configure();
-
         $this
             ->addArgument('key', InputArgument::REQUIRED, 'The variable name')
             ->addArgument('value', InputArgument::REQUIRED, 'The new value')

--- a/manager-bundle/src/ContaoManager/ApiCommand/SetDotEnvCommand.php
+++ b/manager-bundle/src/ContaoManager/ApiCommand/SetDotEnvCommand.php
@@ -25,6 +25,9 @@ use Symfony\Component\Filesystem\Path;
  */
 class SetDotEnvCommand extends Command
 {
+    protected static $defaultName = 'dot-env:set';
+    protected static $defaultDescription = 'Writes a parameter to the .env file.';
+
     private string $projectDir;
 
     public function __construct(Application $application)
@@ -39,8 +42,6 @@ class SetDotEnvCommand extends Command
         parent::configure();
 
         $this
-            ->setName('dot-env:set')
-            ->setDescription('Writes a parameter to the .env file.')
             ->addArgument('key', InputArgument::REQUIRED, 'The variable name')
             ->addArgument('value', InputArgument::REQUIRED, 'The new value')
         ;

--- a/tools/isolated-tests/src/RunTestsIsolatedCommand.php
+++ b/tools/isolated-tests/src/RunTestsIsolatedCommand.php
@@ -43,6 +43,8 @@ class RunTestsIsolatedCommand extends Command
 
     protected function configure(): void
     {
+        parent::configure();
+
         $this->addOption('depth', null, InputOption::VALUE_REQUIRED, '1 for test classes, 2 for test methods, 3 for every single provider data set', '3');
 
         $this->setHelp(

--- a/tools/isolated-tests/src/RunTestsIsolatedCommand.php
+++ b/tools/isolated-tests/src/RunTestsIsolatedCommand.php
@@ -24,6 +24,7 @@ use Symfony\Component\Process\Process;
 class RunTestsIsolatedCommand extends Command
 {
     protected static $defaultName = 'contao:run-tests-isolated';
+    protected static $defaultDescription = 'Runs the unit tests isolated from each other.';
 
     /**
      * @var string|false
@@ -42,7 +43,6 @@ class RunTestsIsolatedCommand extends Command
 
     protected function configure(): void
     {
-        $this->setDescription('Runs the unit tests isolated from each other.');
         $this->addOption('depth', null, InputOption::VALUE_REQUIRED, '1 for test classes, 2 for test methods, 3 for every single provider data set', '3');
 
         $this->setHelp(

--- a/tools/service-linter/src/LintServiceIdsCommand.php
+++ b/tools/service-linter/src/LintServiceIdsCommand.php
@@ -27,6 +27,7 @@ class LintServiceIdsCommand extends Command
     public string $projectDir;
 
     protected static $defaultName = 'contao:lint-service-ids';
+    protected static $defaultDescription = 'Checks the Contao service IDs.';
 
     /**
      * Strip from name if the alias is part of the namespace.
@@ -69,11 +70,6 @@ class LintServiceIdsCommand extends Command
         parent::__construct();
 
         $this->projectDir = $projectDir;
-    }
-
-    protected function configure(): void
-    {
-        $this->setDescription('Checks the Contao service IDs.');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int


### PR DESCRIPTION
From Symfony 5 on, commands should have a static `$defaultDescription` similar to the `$defaultName`, so that they do not have to get instantiated when using the `list` command.