### PR TITLE
Make the `crontao.cron` service lazy

### DIFF
--- a/core-bundle/src/EventListener/CommandSchedulerListener.php
+++ b/core-bundle/src/EventListener/CommandSchedulerListener.php
@@ -26,14 +26,14 @@ use Symfony\Component\HttpKernel\Event\TerminateEvent;
  */
 class CommandSchedulerListener
 {
-    private ContainerInterface $locator;
+    private Cron $cron;
     private ContaoFramework $framework;
     private Connection $connection;
     private string $fragmentPath;
 
-    public function __construct(ContainerInterface $locator, ContaoFramework $framework, Connection $connection, string $fragmentPath = '_fragment')
+    public function __construct(Cron $cron, ContaoFramework $framework, Connection $connection, string $fragmentPath = '_fragment')
     {
-        $this->locator = $locator;
+        $this->cron = $cron;
         $this->framework = $framework;
         $this->connection = $connection;
         $this->fragmentPath = $fragmentPath;
@@ -45,7 +45,7 @@ class CommandSchedulerListener
     public function __invoke(TerminateEvent $event): void
     {
         if ($this->framework->isInitialized() && $this->canRunCron($event->getRequest())) {
-            $this->locator->get('contao.cron')->run(Cron::SCOPE_WEB);
+            $this->cron->run(Cron::SCOPE_WEB);
         }
     }
 

--- a/core-bundle/src/EventListener/CommandSchedulerListener.php
+++ b/core-bundle/src/EventListener/CommandSchedulerListener.php
@@ -17,7 +17,6 @@ use Contao\CoreBundle\Cron\Cron;
 use Contao\CoreBundle\Framework\ContaoFramework;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception;
-use Psr\Container\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\TerminateEvent;
 

--- a/core-bundle/src/Resources/config/listener.yml
+++ b/core-bundle/src/Resources/config/listener.yml
@@ -36,8 +36,7 @@ services:
     contao.listener.command_scheduler:
         class: Contao\CoreBundle\EventListener\CommandSchedulerListener
         arguments:
-            - !service_locator
-              contao.cron: '@contao.cron'
+            - '@contao.cron'
             - '@contao.framework'
             - '@database_connection'
             - '%fragment.path%'

--- a/core-bundle/src/Resources/config/services.yml
+++ b/core-bundle/src/Resources/config/services.yml
@@ -98,6 +98,7 @@ services:
     contao.cron:
         class: Contao\CoreBundle\Cron\Cron
         public: true
+        lazy: true # defer creating the doctrine repository for when the database connection is not configured
         arguments:
             - '@contao.repository.cron_job'
             - '@doctrine.orm.entity_manager'

--- a/core-bundle/src/Resources/config/services.yml
+++ b/core-bundle/src/Resources/config/services.yml
@@ -98,7 +98,7 @@ services:
     contao.cron:
         class: Contao\CoreBundle\Cron\Cron
         public: true
-        lazy: true # defer creating the doctrine repository for when the database connection is not configured
+        lazy: true # Defer creating the Doctrine repository in case the DB connection is not configured
         arguments:
             - '@contao.repository.cron_job'
             - '@doctrine.orm.entity_manager'

--- a/core-bundle/tests/EventListener/CommandSchedulerListenerTest.php
+++ b/core-bundle/tests/EventListener/CommandSchedulerListenerTest.php
@@ -21,7 +21,6 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception\DriverException;
 use Doctrine\DBAL\Schema\MySQLSchemaManager;
 use PHPUnit\Framework\MockObject\MockObject;
-use Psr\Container\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\TerminateEvent;

--- a/core-bundle/tests/EventListener/CommandSchedulerListenerTest.php
+++ b/core-bundle/tests/EventListener/CommandSchedulerListenerTest.php
@@ -38,19 +38,18 @@ class CommandSchedulerListenerTest extends TestCase
             ->with(Cron::SCOPE_WEB)
         ;
 
-        $locator = $this->createMock(ContainerInterface::class);
-        $locator
-            ->method('get')
-            ->with('contao.cron')
-            ->willReturn($cron)
-        ;
-
-        $listener = new CommandSchedulerListener($locator, $this->mockContaoFramework(), $this->mockConnection());
+        $listener = new CommandSchedulerListener($cron, $this->mockContaoFramework(), $this->mockConnection());
         $listener($this->getTerminateEvent('contao_frontend'));
     }
 
     public function testDoesNotRunTheCommandSchedulerIfTheContaoFrameworkIsNotInitialized(): void
     {
+        $cron = $this->createMock(Cron::class);
+        $cron
+            ->expects($this->never())
+            ->method('run')
+        ;
+
         $framework = $this->createMock(ContaoFramework::class);
         $framework
             ->method('isInitialized')
@@ -62,12 +61,18 @@ class CommandSchedulerListenerTest extends TestCase
             ->method('getAdapter')
         ;
 
-        $listener = new CommandSchedulerListener($this->createMock(ContainerInterface::class), $framework, $this->mockConnection());
+        $listener = new CommandSchedulerListener($cron, $framework, $this->mockConnection());
         $listener($this->getTerminateEvent('contao_backend'));
     }
 
     public function testDoesNotRunTheCommandSchedulerInTheInstallTool(): void
     {
+        $cron = $this->createMock(Cron::class);
+        $cron
+            ->expects($this->never())
+            ->method('run')
+        ;
+
         $framework = $this->mockContaoFramework();
         $framework
             ->expects($this->never())
@@ -85,12 +90,18 @@ class CommandSchedulerListenerTest extends TestCase
 
         $event = new TerminateEvent($this->createMock(KernelInterface::class), $request, new Response());
 
-        $listener = new CommandSchedulerListener($this->createMock(ContainerInterface::class), $framework, $this->mockConnection());
+        $listener = new CommandSchedulerListener($cron, $framework, $this->mockConnection());
         $listener($event);
     }
 
     public function testDoesNotRunTheCommandSchedulerUponFragmentRequests(): void
     {
+        $cron = $this->createMock(Cron::class);
+        $cron
+            ->expects($this->never())
+            ->method('run')
+        ;
+
         $framework = $this->mockContaoFramework();
         $framework
             ->expects($this->never())
@@ -108,12 +119,18 @@ class CommandSchedulerListenerTest extends TestCase
 
         $event = new TerminateEvent($this->createMock(KernelInterface::class), $request, new Response());
 
-        $listener = new CommandSchedulerListener($this->createMock(ContainerInterface::class), $framework, $this->mockConnection());
+        $listener = new CommandSchedulerListener($cron, $framework, $this->mockConnection());
         $listener($event);
     }
 
     public function testDoesNotRunTheCommandSchedulerIfTheInstallationIsIncomplete(): void
     {
+        $cron = $this->createMock(Cron::class);
+        $cron
+            ->expects($this->never())
+            ->method('run')
+        ;
+
         $adapter = $this->mockAdapter(['isComplete', 'get']);
         $adapter
             ->method('isComplete')
@@ -131,12 +148,18 @@ class CommandSchedulerListenerTest extends TestCase
             ->method('createInstance')
         ;
 
-        $listener = new CommandSchedulerListener($this->createMock(ContainerInterface::class), $framework, $this->mockConnection());
+        $listener = new CommandSchedulerListener($cron, $framework, $this->mockConnection());
         $listener($this->getTerminateEvent('contao_backend'));
     }
 
     public function testDoesNotRunTheCommandSchedulerIfCronjobsAreDisabled(): void
     {
+        $cron = $this->createMock(Cron::class);
+        $cron
+            ->expects($this->never())
+            ->method('run')
+        ;
+
         $adapter = $this->mockAdapter(['isComplete', 'get']);
         $adapter
             ->method('isComplete')
@@ -155,7 +178,7 @@ class CommandSchedulerListenerTest extends TestCase
             ->method('createInstance')
         ;
 
-        $listener = new CommandSchedulerListener($this->createMock(ContainerInterface::class), $framework, $this->mockConnection());
+        $listener = new CommandSchedulerListener($cron, $framework, $this->mockConnection());
         $listener($this->getTerminateEvent('contao_frontend'));
     }
 
@@ -173,20 +196,13 @@ class CommandSchedulerListenerTest extends TestCase
             ->method('run')
         ;
 
-        $locator = $this->createMock(ContainerInterface::class);
-        $locator
-            ->method('get')
-            ->with('contao.cron')
-            ->willReturn($cron)
-        ;
-
         $connection = $this->createMock(Connection::class);
         $connection
             ->method('isConnected')
             ->willThrowException($this->createMock(DriverException::class))
         ;
 
-        $listener = new CommandSchedulerListener($locator, $framework, $connection);
+        $listener = new CommandSchedulerListener($cron, $framework, $connection);
         $listener($this->getTerminateEvent('contao_backend'));
     }
 


### PR DESCRIPTION
Fixes https://github.com/contao/contao/issues/4131

Making `crontao.cron` lazy will result in the Doctrine repository not being created. Creating it if the database connection is not configured would fail.