### PR TITLE
Clarify the backup command description

### DIFF
--- a/core-bundle/src/Command/Backup/BackupCreateCommand.php
+++ b/core-bundle/src/Command/Backup/BackupCreateCommand.php
@@ -23,7 +23,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 class BackupCreateCommand extends AbstractBackupCommand
 {
     protected static $defaultName = 'contao:backup:create';
-    protected static $defaultDescription = 'Creates a new backup.';
+    protected static $defaultDescription = 'Creates a new database backup.';
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {

--- a/core-bundle/src/Command/Backup/BackupListCommand.php
+++ b/core-bundle/src/Command/Backup/BackupListCommand.php
@@ -23,7 +23,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 class BackupListCommand extends AbstractBackupCommand
 {
     protected static $defaultName = 'contao:backup:list';
-    protected static $defaultDescription = 'Lists the existing backups.';
+    protected static $defaultDescription = 'Lists the existing database backups.';
 
     public static function getFormattedTimeZoneOffset(\DateTimeZone $timeZone): string
     {

--- a/core-bundle/src/Command/Backup/BackupRestoreCommand.php
+++ b/core-bundle/src/Command/Backup/BackupRestoreCommand.php
@@ -24,7 +24,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 class BackupRestoreCommand extends AbstractBackupCommand
 {
     protected static $defaultName = 'contao:backup:restore';
-    protected static $defaultDescription = 'Restores a backup.';
+    protected static $defaultDescription = 'Restores a database backup.';
 
     protected function configure(): void
     {


### PR DESCRIPTION
Clarification in the description of the backup commands, so it is immediately clear that the backups cover only to the database (not templates, files, ...).