### PR TITLE
Set regular pages regarding XML sitemap

### DIFF
--- a/core-bundle/src/Controller/SitemapController.php
+++ b/core-bundle/src/Controller/SitemapController.php
@@ -141,7 +141,7 @@ class SitemapController extends AbstractController
             if (
                 $isPublished
                 && !$pageModel->requireItem
-                && 'noindex,nofollow' !== $pageModel->robots
+                && ('noindex,nofollow' !== $pageModel->robots && 'map_never' !== $pageModel->xml || 'map_always' === $pageModel->xml)
                 && $this->pageRegistry->supportsContentComposition($pageModel)
                 && $this->pageRegistry->isRoutable($pageModel)
                 && 'html' === $this->pageRegistry->getRoute($pageModel)->getDefault('_format')

--- a/core-bundle/src/Resources/contao/dca/tl_page.php
+++ b/core-bundle/src/Resources/contao/dca/tl_page.php
@@ -175,7 +175,7 @@ $GLOBALS['TL_DCA']['tl_page'] = array
 	(
 		'__selector__'                => array('type', 'fallback', 'autoforward', 'protected', 'includeLayout', 'includeCache', 'includeChmod', 'enforceTwoFactor'),
 		'default'                     => '{title_legend},title,type',
-		'regular'                     => '{title_legend},title,type;{routing_legend},alias,requireItem,routePath,routePriority,routeConflicts;{meta_legend},pageTitle,robots,description,serpPreview;{canonical_legend:hide},canonicalLink,canonicalKeepParams;{protected_legend:hide},protected;{layout_legend:hide},includeLayout;{cache_legend:hide},includeCache;{chmod_legend:hide},includeChmod;{expert_legend:hide},cssClass,sitemap,hide,noSearch,guests;{tabnav_legend:hide},tabindex,accesskey;{publish_legend},published,start,stop',
+		'regular'                     => '{title_legend},title,type;{routing_legend},alias,requireItem,routePath,routePriority,routeConflicts;{meta_legend},pageTitle,robots,description,serpPreview;{canonical_legend:hide},canonicalLink,canonicalKeepParams;{protected_legend:hide},protected;{layout_legend:hide},includeLayout;{cache_legend:hide},includeCache;{chmod_legend:hide},includeChmod;{expert_legend:hide},cssClass,sitemap,xml,hide,noSearch,guests;{tabnav_legend:hide},tabindex,accesskey;{publish_legend},published,start,stop',
 		'forward'                     => '{title_legend},title,type;{routing_legend},alias,routePath,routePriority,routeConflicts;{meta_legend},pageTitle,robots;{redirect_legend},jumpTo,redirect;{protected_legend:hide},protected;{layout_legend:hide},includeLayout;{cache_legend:hide},includeCache;{chmod_legend:hide},includeChmod;{expert_legend:hide},cssClass,sitemap,hide,guests;{tabnav_legend:hide},tabindex,accesskey;{publish_legend},published,start,stop',
 		'redirect'                    => '{title_legend},title,type;{routing_legend},alias,routePath,routePriority,routeConflicts;{meta_legend},pageTitle,robots;{redirect_legend},redirect,url,target;{protected_legend:hide},protected;{layout_legend:hide},includeLayout;{cache_legend:hide},includeCache;{chmod_legend:hide},includeChmod;{expert_legend:hide},cssClass,sitemap,hide,guests;{tabnav_legend:hide},tabindex,accesskey;{publish_legend},published,start,stop',
 		'root'                        => '{title_legend},title,type;{routing_legend},alias;{meta_legend},pageTitle;{url_legend},dns,useSSL,urlPrefix,urlSuffix,validAliasCharacters,useFolderUrl;{language_legend},language,fallback,disableLanguageRedirect;{website_legend:hide},maintenanceMode;{global_legend:hide},mailerTransport,enableCanonical,adminEmail,dateFormat,timeFormat,datimFormat,staticFiles,staticPlugins;{protected_legend:hide},protected;{layout_legend},includeLayout;{twoFactor_legend:hide},enforceTwoFactor;{cache_legend:hide},includeCache;{chmod_legend:hide},includeChmod;{publish_legend},published,start,stop',
@@ -687,6 +687,15 @@ $GLOBALS['TL_DCA']['tl_page'] = array
 			'sql'                     => "varchar(64) NOT NULL default ''"
 		),
 		'sitemap' => array
+		(
+			'exclude'                 => true,
+			'inputType'               => 'select',
+			'options'                 => array('map_default', 'map_always', 'map_never'),
+			'eval'                    => array('maxlength'=>32, 'tl_class'=>'w50'),
+			'reference'               => &$GLOBALS['TL_LANG']['tl_page'],
+			'sql'                     => "varchar(32) NOT NULL default ''"
+		),
+		'xml' => array
 		(
 			'exclude'                 => true,
 			'inputType'               => 'select',

--- a/core-bundle/src/Resources/contao/languages/de/tl_page.xlf
+++ b/core-bundle/src/Resources/contao/languages/de/tl_page.xlf
@@ -409,6 +409,14 @@
         <source>Here you can define whether the page is shown in the HTML sitemap.</source>
         <target>Hier können Sie festlegen, ob die Seite in der HTML-Sitemap angezeigt wird.</target>
       </trans-unit>
+      <trans-unit id="tl_page.xml.0">
+        <source>Show in XML sitemap</source>
+        <target>In der XML-Sitemap zeigen</target>
+      </trans-unit>
+      <trans-unit id="tl_page.xml.1">
+        <source>Here you can define whether the page is shown in the XML sitemap.</source>
+        <target>Hier können Sie festlegen, ob die Seite in der XML-Sitemap angezeigt wird.</target>
+      </trans-unit>
       <trans-unit id="tl_page.hide.0">
         <source>Hide in navigation</source>
         <target>Im Menü verstecken</target>

--- a/core-bundle/src/Resources/contao/languages/en/tl_page.xlf
+++ b/core-bundle/src/Resources/contao/languages/en/tl_page.xlf
@@ -308,6 +308,12 @@
       <trans-unit id="tl_page.sitemap.1">
         <source>Here you can define whether the page is shown in the HTML sitemap.</source>
       </trans-unit>
+      <trans-unit id="tl_page.xml.0">
+        <source>Show in XML sitemap</source>
+      </trans-unit>
+      <trans-unit id="tl_page.xml.1">
+        <source>Here you can define whether the page is shown in the XML sitemap.</source>
+      </trans-unit>
       <trans-unit id="tl_page.hide.0">
         <source>Hide in navigation</source>
       </trans-unit>


### PR DESCRIPTION
Regarding this issue:
https://github.com/contao/contao/issues/501

@leofeyer wrote
> We want to distinguish between "XML sitemap" and "HTML sitemap" in the future, so we need to adjust the following

Sorry if sth. is wrong, this is my first Contao pull request. This is a first suggestion.

**Explanation**
- Nearly the same settings like the settings of the HTML sitemap, but this setting is only for regular pages
- map_default = no changes in sitemap.xml
- map_always = it always show this page in the sitemap.xml - independent from the robot settings `noindex,nofollow`
- map_never = page won't be added to sitemap.xml

**Current problems of this PR**
- We need to change the tl_class of the backend fields below or the position in the palette has to be changed - I think it would be nice to show both sidemap settings side by side, however it is a problem that the XML sitemap field is only visible in the regular page type
- The new Backend labels are only available in _en_ and _de_ currently
