### PR TITLE
Allow underscores in tag attributes

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Input.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Input.php
@@ -682,7 +682,7 @@ class Input
 	private static function getAttributesFromTag($strAttributes)
 	{
 		// Match every attribute name value pair
-		if (!preg_match_all('@\s+([a-z][a-z0-9:-]*)(?:\s*=\s*("[^"]*"|\'[^\']*\'|[^\s>]*))?@i', $strAttributes, $matches, PREG_SET_ORDER))
+		if (!preg_match_all('@\s+([a-z][a-z0-9_:-]*)(?:\s*=\s*("[^"]*"|\'[^\']*\'|[^\s>]*))?@i', $strAttributes, $matches, PREG_SET_ORDER))
 		{
 			return array();
 		}

--- a/core-bundle/tests/Contao/InputTest.php
+++ b/core-bundle/tests/Contao/InputTest.php
@@ -79,6 +79,11 @@ class InputTest extends TestCase
             'foo <span title="baz"> bar',
         ];
 
+        yield 'Keeps underscores in allowed attributes' => [
+            'foo <span data-foo_bar="baz"> bar',
+            'foo <span data-foo_bar="baz"> bar',
+        ];
+
         yield 'Reformats attributes' => [
             "<span \n \t title = \nwith-spaces class\n=' with \" and &#039; quotes' lang \t =\"with &quot; and ' quotes \t \n \" data-boolean-flag data-int = 0>",
             "<span title=\"with-spaces\" class=\" with &quot; and &#039; quotes\" lang=\"with &quot; and &#039; quotes \t \n \" data-boolean-flag=\"\" data-int=\"0\">",


### PR DESCRIPTION
Tag attributes containing underscores get stripped away, even if you use `*`, e.g:

`<jobalino-joblist company="company-1" additional_companies="company-2"></jobalino-joblist>`

will result in

`<jobalino-joblist company="company-1" additional=""></jobalino-joblist>` 
or 
`<jobalino-joblist company="company-1"></jobalino-joblist>` 

depends on the setting, `*` or `company,additional_companies`.

