### PR TITLE
Fix undefined array key warning when creating new layout sections

### DIFF
--- a/core-bundle/src/Resources/contao/widgets/ModuleWizard.php
+++ b/core-bundle/src/Resources/contao/widgets/ModuleWizard.php
@@ -124,6 +124,9 @@ class ModuleWizard extends Widget
 					{
 						$cols[] = $v['id'];
 						$positions[$v['id']] = $v['position'];
+
+						// Add custom layout section reference
+						$GLOBALS['TL_LANG']['COLS'][$v['id']] = $v['title'];
 					}
 				}
 			}

--- a/core-bundle/src/Resources/contao/widgets/ModuleWizard.php
+++ b/core-bundle/src/Resources/contao/widgets/ModuleWizard.php
@@ -125,7 +125,7 @@ class ModuleWizard extends Widget
 						$cols[] = $v['id'];
 						$positions[$v['id']] = $v['position'];
 
-						// Add custom layout section reference
+						// Add custom layout section reference #4207
 						$GLOBALS['TL_LANG']['COLS'][$v['id']] = $v['title'];
 					}
 				}


### PR DESCRIPTION
If you add a new custom layout section i a page layout under PHP 8 and then save, the following warning will occur:

```
ErrorException:
Warning: Undefined array key "foobar"

  at vendor\contao\core-bundle\src\Resources\contao\classes\Backend.php:1120
  at Contao\Backend::convertLayoutSectionIdsToAssociativeArray(array('main' => 'Main column', 'header' => 'Header', 'footer' => 'Footer', 'menu' => 'Menu', 'foobar' => 'foobar'))
     (vendor\contao\core-bundle\src\Resources\contao\widgets\ModuleWizard.php:135)
  at Contao\ModuleWizard->generate()
```

This is because the `$GLOBALS['TL_LANG']['COLS']` reference for the custom layout section is added via an `onload` callback. However, the `onload` callback is executed _before_ the record is saved, while the `ModuleWizard` widget is executed _after_ the record is saved. Thus the `ModuleWizard` already tries to render the new custom layout section - but the label for the layout section will be missing in `$GLOBALS['TL_LANG']['COLS']`.

This PR fixes that by ensuring in `ModuleWizard` that the label is always present in `$GLOBALS['TL_LANG']['COLS']`.