### PR TITLE
Lower max file size in Dbafs service

### DIFF
--- a/core-bundle/src/Filesystem/Dbafs/Dbafs.php
+++ b/core-bundle/src/Filesystem/Dbafs/Dbafs.php
@@ -51,7 +51,7 @@ class Dbafs implements DbafsInterface, ResetInterface
 
     private string $table;
     private string $dbPathPrefix = '';
-    private int $maxFileSize = 2147483647; // 2 GiB - 1 byte (see #?)
+    private int $maxFileSize = 2147483647; // 2 GiB - 1 byte (see #4208)
     private int $bulkInsertSize = 100;
     private bool $useLastModified = true;
 

--- a/core-bundle/src/Filesystem/Dbafs/Dbafs.php
+++ b/core-bundle/src/Filesystem/Dbafs/Dbafs.php
@@ -51,7 +51,7 @@ class Dbafs implements DbafsInterface, ResetInterface
 
     private string $table;
     private string $dbPathPrefix = '';
-    private int $maxFileSize = 2147483648; // 2 GiB
+    private int $maxFileSize = 2147483647; // 2 GiB - 1 byte (see #?)
     private int $bulkInsertSize = 100;
     private bool $useLastModified = true;
 


### PR DESCRIPTION
Fixes #4200 

This PR reduces the DBAFS max file size by one so that it also fits in a integer on 32-bit PHP versions. The value is opinionated anyways, so the effect is negligible. Without this change an error would occur because property initializers do no coerce or clamp values.