### PR TITLE
Fix warning in ModuleArticle if page object is null

### DIFF
--- a/core-bundle/src/Resources/contao/modules/ModuleArticle.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleArticle.php
@@ -121,7 +121,7 @@ class ModuleArticle extends Module
 
 		// Add the modification date
 		$this->Template->timestamp = $this->tstamp;
-		$this->Template->date = Date::parse($objPage->datimFormat, $this->tstamp);
+		$this->Template->date = Date::parse($objPage->datimFormat ?? Config::get('datimFormat'), $this->tstamp);
 
 		// Clean the RTE output
 		$this->teaser = StringUtil::toHtml5($this->teaser ?? '');


### PR DESCRIPTION
Fixes #4205 

$objPage is null in back-end requests. In this case I fall back to the default datim format. 