### PR TITLE
Unset key in URL when switching edit mode

### DIFF
--- a/core-bundle/src/Resources/contao/classes/DataContainer.php
+++ b/core-bundle/src/Resources/contao/classes/DataContainer.php
@@ -727,7 +727,7 @@ abstract class DataContainer extends Backend
 	protected function switchToEdit($id)
 	{
 		$arrKeys = array();
-		$arrUnset = array('act', 'id', 'table', 'mode', 'pid');
+		$arrUnset = array('act', 'key', 'id', 'table', 'mode', 'pid');
 
 		foreach (array_keys($_GET) as $strKey)
 		{


### PR DESCRIPTION
I'm using a custom global operation and backend module (`$GLOBALS['BE_MOD'][...]['foo'] = ['controller', 'method')` to create a database record with specific data. I can leverage the `DataContainer::create` method for that, which explicitly allows to pass additional data to the new records.

When creating the data, `DataContainer::create` redirects to the new record and in the process removes known "invalid" parameters from the URL. But since it does not remove `key`, it results in an endless redirect (because my module is called again). I think we can safely remove `key` as well since thats a well supported pattern imho.