### PR TITLE
Adding the option `data-only` to the backup create command, to onyl export the data

### DIFF
--- a/core-bundle/src/Command/Backup/BackupCreateCommand.php
+++ b/core-bundle/src/Command/Backup/BackupCreateCommand.php
@@ -29,7 +29,7 @@ class BackupCreateCommand extends AbstractBackupCommand
     protected function configure(): void
     {
         parent::configure();
-        
+
         $this->addOption('data-only', null, InputOption::VALUE_NONE, 'By default, this command exports the table schema and data. Use --data-only to export only the data.');
     }
 

--- a/core-bundle/src/Command/Backup/BackupCreateCommand.php
+++ b/core-bundle/src/Command/Backup/BackupCreateCommand.php
@@ -14,6 +14,7 @@ namespace Contao\CoreBundle\Command\Backup;
 
 use Contao\CoreBundle\Doctrine\Backup\BackupManagerException;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
@@ -25,12 +26,23 @@ class BackupCreateCommand extends AbstractBackupCommand
     protected static $defaultName = 'contao:backup:create';
     protected static $defaultDescription = 'Creates a new database backup.';
 
+    protected function configure(): void
+    {
+        parent::configure();
+        
+        $this->addOption('data-only', null, InputOption::VALUE_NONE, 'By default, this command exports the table schema and data. Use --data-only to export only the data.');
+    }
+
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
 
         $config = $this->backupManager->createCreateConfig();
         $config = $this->handleCommonConfig($input, $config);
+
+        if ($input->getOption('data-only')) {
+            $config = $config->withDataOnly(true);
+        }
 
         try {
             $this->backupManager->create($config);

--- a/core-bundle/src/Doctrine/Backup/Config/CreateConfig.php
+++ b/core-bundle/src/Doctrine/Backup/Config/CreateConfig.php
@@ -14,4 +14,18 @@ namespace Contao\CoreBundle\Doctrine\Backup\Config;
 
 class CreateConfig extends AbstractConfig
 {
+    private bool $dataOnly = false;
+
+    public function isDataOnlyEnabled(): bool
+    {
+        return $this->dataOnly;
+    }
+
+    public function withDataOnly(bool $enable): self
+    {
+        $new = clone $this;
+        $new->dataOnly = $enable;
+
+        return $new;
+    }
 }

--- a/core-bundle/src/Doctrine/Backup/Dumper.php
+++ b/core-bundle/src/Doctrine/Backup/Dumper.php
@@ -42,11 +42,15 @@ class Dumper implements DumperInterface
         $platform = $connection->getDatabasePlatform();
 
         foreach ($this->getTablesToDump($schemaManager, $config) as $table) {
-            yield from $this->dumpSchema($platform, $table);
+            if (!$config->isDataOnlyEnabled()) {
+                yield from $this->dumpSchema($platform, $table);
+            }
             yield from $this->dumpData($connection, $table);
         }
 
-        yield from $this->dumpViews($schemaManager, $platform);
+        if (!$config->isDataOnlyEnabled()) {
+            yield from $this->dumpViews($schemaManager, $platform);
+        }
 
         // Triggers are currently not supported (contributions welcome!)
 


### PR DESCRIPTION
To have the option to onyl export the data, a new option for the backup create command is added.