### PR TITLE
Do not process redirected URLs outside base domains

### DIFF
--- a/core-bundle/src/Crawl/Escargot/Subscriber/BrokenLinkCheckerSubscriber.php
+++ b/core-bundle/src/Crawl/Escargot/Subscriber/BrokenLinkCheckerSubscriber.php
@@ -96,7 +96,7 @@ class BrokenLinkCheckerSubscriber implements EscargotSubscriberInterface, Escarg
             return SubscriberInterface::DECISION_NEGATIVE;
         }
 
-        // Skip any redirected URLs that are now outside our base hosts
+        // Skip any redirected URLs that are now outside our base hosts (#4213)
         $actualHost = parse_url($response->getInfo('url'), PHP_URL_HOST);
 
         if ($crawlUri->getUri()->getHost() !== $actualHost && !$this->escargot->getBaseUris()->containsHost($actualHost)) {

--- a/core-bundle/src/Crawl/Escargot/Subscriber/BrokenLinkCheckerSubscriber.php
+++ b/core-bundle/src/Crawl/Escargot/Subscriber/BrokenLinkCheckerSubscriber.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Crawl\Escargot\Subscriber;
 
+use Nyholm\Psr7\Uri;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 use Psr\Log\LogLevel;
@@ -99,7 +100,7 @@ class BrokenLinkCheckerSubscriber implements EscargotSubscriberInterface, Escarg
         ++$this->stats['ok'];
 
         // Skip any redirected URLs that are now outside our base hosts (#4213)
-        $actualHost = parse_url($response->getInfo('url'), PHP_URL_HOST);
+        $actualHost = (new Uri($response->getInfo('url')))->getHost();
 
         if ($crawlUri->getUri()->getHost() !== $actualHost && !$this->escargot->getBaseUris()->containsHost($actualHost)) {
             return SubscriberInterface::DECISION_NEGATIVE;

--- a/core-bundle/src/Crawl/Escargot/Subscriber/BrokenLinkCheckerSubscriber.php
+++ b/core-bundle/src/Crawl/Escargot/Subscriber/BrokenLinkCheckerSubscriber.php
@@ -96,6 +96,13 @@ class BrokenLinkCheckerSubscriber implements EscargotSubscriberInterface, Escarg
             return SubscriberInterface::DECISION_NEGATIVE;
         }
 
+        // Skip any redirected URLs that are now outside our base hosts
+        $actualHost = parse_url($response->getInfo('url'), PHP_URL_HOST);
+
+        if ($crawlUri->getUri()->getHost() !== $actualHost && !$this->escargot->getBaseUris()->containsHost($actualHost)) {
+            return SubscriberInterface::DECISION_NEGATIVE;
+        }
+
         ++$this->stats['ok'];
 
         // When URI is part of the base uri collection, request content.

--- a/core-bundle/src/Crawl/Escargot/Subscriber/BrokenLinkCheckerSubscriber.php
+++ b/core-bundle/src/Crawl/Escargot/Subscriber/BrokenLinkCheckerSubscriber.php
@@ -96,14 +96,14 @@ class BrokenLinkCheckerSubscriber implements EscargotSubscriberInterface, Escarg
             return SubscriberInterface::DECISION_NEGATIVE;
         }
 
+        ++$this->stats['ok'];
+
         // Skip any redirected URLs that are now outside our base hosts (#4213)
         $actualHost = parse_url($response->getInfo('url'), PHP_URL_HOST);
 
         if ($crawlUri->getUri()->getHost() !== $actualHost && !$this->escargot->getBaseUris()->containsHost($actualHost)) {
             return SubscriberInterface::DECISION_NEGATIVE;
         }
-
-        ++$this->stats['ok'];
 
         // When URI is part of the base uri collection, request content.
         // This is needed to make sure HtmlCrawlerSubscriber::onLastChunk() is triggered.

--- a/core-bundle/src/Crawl/Escargot/Subscriber/SearchIndexSubscriber.php
+++ b/core-bundle/src/Crawl/Escargot/Subscriber/SearchIndexSubscriber.php
@@ -121,7 +121,7 @@ class SearchIndexSubscriber implements EscargotSubscriberInterface, EscargotAwar
             return SubscriberInterface::DECISION_NEGATIVE;
         }
 
-        // Skip any redirected URLs that are now outside our base hosts
+        // Skip any redirected URLs that are now outside our base hosts (#4213)
         $actualHost = parse_url($response->getInfo('url'), PHP_URL_HOST);
 
         if ($crawlUri->getUri()->getHost() !== $actualHost && !$this->escargot->getBaseUris()->containsHost($actualHost)) {

--- a/core-bundle/src/Crawl/Escargot/Subscriber/SearchIndexSubscriber.php
+++ b/core-bundle/src/Crawl/Escargot/Subscriber/SearchIndexSubscriber.php
@@ -15,6 +15,7 @@ namespace Contao\CoreBundle\Crawl\Escargot\Subscriber;
 use Contao\CoreBundle\Search\Document;
 use Contao\CoreBundle\Search\Indexer\IndexerException;
 use Contao\CoreBundle\Search\Indexer\IndexerInterface;
+use Nyholm\Psr7\Uri;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 use Psr\Log\LogLevel;
@@ -122,7 +123,7 @@ class SearchIndexSubscriber implements EscargotSubscriberInterface, EscargotAwar
         }
 
         // Skip any redirected URLs that are now outside our base hosts (#4213)
-        $actualHost = parse_url($response->getInfo('url'), PHP_URL_HOST);
+        $actualHost = (new Uri($response->getInfo('url')))->getHost();
 
         if ($crawlUri->getUri()->getHost() !== $actualHost && !$this->escargot->getBaseUris()->containsHost($actualHost)) {
             $this->logWithCrawlUri(

--- a/core-bundle/src/Crawl/Escargot/Subscriber/SearchIndexSubscriber.php
+++ b/core-bundle/src/Crawl/Escargot/Subscriber/SearchIndexSubscriber.php
@@ -121,6 +121,19 @@ class SearchIndexSubscriber implements EscargotSubscriberInterface, EscargotAwar
             return SubscriberInterface::DECISION_NEGATIVE;
         }
 
+        // Skip any redirected URLs that are now outside our base hosts
+        $actualHost = parse_url($response->getInfo('url'), PHP_URL_HOST);
+
+        if ($crawlUri->getUri()->getHost() !== $actualHost && !$this->escargot->getBaseUris()->containsHost($actualHost)) {
+            $this->logWithCrawlUri(
+                $crawlUri,
+                LogLevel::DEBUG,
+                'Did not index because it was not part of the base URI collection.'
+            );
+
+            return SubscriberInterface::DECISION_NEGATIVE;
+        }
+
         // No HTML, no index
         if (!Util::isOfContentType($response, 'text/html')) {
             $this->logWithCrawlUri(

--- a/core-bundle/tests/Crawl/Escargot/Subscriber/BrokenLinkCheckerSubscriberTest.php
+++ b/core-bundle/tests/Crawl/Escargot/Subscriber/BrokenLinkCheckerSubscriberTest.php
@@ -229,7 +229,7 @@ class BrokenLinkCheckerSubscriberTest extends TestCase
             SubscriberInterface::DECISION_NEGATIVE,
             '',
             '',
-            ['ok' => 0, 'error' => 0],
+            ['ok' => 1, 'error' => 0],
         ];
     }
 

--- a/core-bundle/tests/Crawl/Escargot/Subscriber/BrokenLinkCheckerSubscriberTest.php
+++ b/core-bundle/tests/Crawl/Escargot/Subscriber/BrokenLinkCheckerSubscriberTest.php
@@ -206,7 +206,7 @@ class BrokenLinkCheckerSubscriberTest extends TestCase
 
         yield 'Test does not report successful responses if url not in base collection' => [
             new CrawlUri(new Uri('https://github.com'), 0),
-            $this->getResponse(),
+            $this->getResponse(200, 'https://github.com'),
             SubscriberInterface::DECISION_NEGATIVE,
             '',
             '',
@@ -221,6 +221,15 @@ class BrokenLinkCheckerSubscriberTest extends TestCase
             '',
             ['ok' => 2, 'error' => 0],
             ['ok' => 1, 'error' => 0],
+        ];
+
+        yield 'Test does not report redirected responses outside the target domain' => [
+            new CrawlUri(new Uri('https://contao.org'), 0),
+            $this->getResponse(200, 'https://example.com'),
+            SubscriberInterface::DECISION_NEGATIVE,
+            '',
+            '',
+            ['ok' => 0, 'error' => 0],
         ];
     }
 
@@ -361,7 +370,7 @@ class BrokenLinkCheckerSubscriberTest extends TestCase
     /**
      * @return ResponseInterface&MockObject
      */
-    private function getResponse(int $statusCode = 200): ResponseInterface
+    private function getResponse(int $statusCode = 200, string $url = 'https://contao.org'): ResponseInterface
     {
         $response = $this->createMock(ResponseInterface::class);
         $response
@@ -372,13 +381,13 @@ class BrokenLinkCheckerSubscriberTest extends TestCase
         $response
             ->method('getInfo')
             ->willReturnCallback(
-                static function (string $key) use ($statusCode) {
+                static function (string $key) use ($statusCode, $url) {
                     if ('http_code' === $key) {
                         return $statusCode;
                     }
 
                     if ('url' === $key) {
-                        return '';
+                        return $url;
                     }
 
                     if ('response_headers' === $key) {


### PR DESCRIPTION
Fixes #4213

See https://github.com/contao/contao/issues/4213#issuecomment-1052022561 for a detailed explanation of the problem.

This PR fixes this by comparing the host of the actual URL of the response with the base URI collection and returning a negative decision in `needsContent`, so that any internal URL that was redirected to an external URL is not getting processed.