### PR TITLE
Make the contao:install:lock command idempotent

### DIFF
--- a/installation-bundle/src/Command/LockCommand.php
+++ b/installation-bundle/src/Command/LockCommand.php
@@ -46,12 +46,6 @@ class LockCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        if (file_exists($this->lockFile)) {
-            $output->writeln('<comment>The install tool has been locked already.</comment>');
-
-            return 1;
-        }
-
         $fs = new Filesystem();
         $fs->dumpFile($this->lockFile, 3);
 


### PR DESCRIPTION
Deployment-wise it would be great if the `contao:install:lock` command would be idempotent so that you can call the command on every deployment without working around the exception.

This change is also an easy way to increase coverage 🤣 