### PR TITLE
Clean-up 2

### DIFF
--- a/core-bundle/src/Cache/EntityCacheTags.php
+++ b/core-bundle/src/Cache/EntityCacheTags.php
@@ -22,7 +22,7 @@ use FOS\HttpCache\CacheInvalidator;
 use FOS\HttpCache\ResponseTagger;
 
 /**
- * Use this helper service to derive 'contao.db.*' cache tags from entity/model
+ * Use this helper service to derive "contao.db.*" cache tags from entity/model
  * classes and instances. The tagWith*() and invalidateFor*() shortcut methods
  * directly tag the response or invalidate tags. If your application does not
  * use response tagging, these methods are no-ops.

--- a/core-bundle/src/Config/Loader/PhpFileLoader.php
+++ b/core-bundle/src/Config/Loader/PhpFileLoader.php
@@ -79,7 +79,7 @@ class PhpFileLoader extends Loader
                     return NodeTraverser::REMOVE_NODE;
                 }
 
-                // Drop 'strict_types' definition
+                // Drop the "strict_types" definition
                 if ($node instanceof Declare_) {
                     foreach ($node->declares as $key => $declare) {
                         if ('strict_types' === $declare->key->name) {

--- a/core-bundle/src/Controller/AbstractBackendController.php
+++ b/core-bundle/src/Controller/AbstractBackendController.php
@@ -23,7 +23,7 @@ use Symfony\Component\HttpFoundation\Response;
 abstract class AbstractBackendController extends AbstractController
 {
     /**
-     * Renders a Twig template with additional context for `@Contao/be_main`.
+     * Renders a Twig template with additional context for "@Contao/be_main".
      */
     protected function render(string $view, array $parameters = [], Response $response = null): Response
     {

--- a/core-bundle/src/DependencyInjection/Configuration.php
+++ b/core-bundle/src/DependencyInjection/Configuration.php
@@ -93,7 +93,7 @@ class Configuration implements ConfigurationInterface
                     ->defaultValue(false)
                 ->end()
                 ->scalarNode('preview_script')
-                    ->info("An optional entry point script that bypasses the front end cache for previewing changes (e.g. '/preview.php').")
+                    ->info('An optional entry point script that bypasses the front end cache for previewing changes (e.g. "/preview.php").')
                     ->cannotBeEmpty()
                     ->defaultValue('')
                     ->validate()

--- a/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
+++ b/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
@@ -197,9 +197,9 @@ class ContaoCoreExtension extends Extension implements PrependExtensionInterface
         // User uploads
         $filesStorageName = 'files';
 
-        // TODO: Deprecate the 'contao.upload_path' config key. In the next
-        // major version, $uploadPath can then be replaced with 'files' and the
-        // redundant 'files' attribute removed when mounting the local adapter.
+        // TODO: Deprecate the "contao.upload_path" config key. In the next
+        // major version, $uploadPath can then be replaced with "files" and the
+        // redundant "files" attribute removed when mounting the local adapter.
         $uploadPath = $config->getContainer()->getParameterBag()->resolveValue('%contao.upload_path%');
 
         $config
@@ -285,7 +285,7 @@ class ContaoCoreExtension extends Extension implements PrependExtensionInterface
 
         $imageSizes = [];
 
-        // Do not add a size with the special name '_defaults' but merge its values into all other definitions instead.
+        // Do not add a size with the special name "_defaults" but merge its values into all other definitions instead.
         foreach ($config['image']['sizes'] as $name => $value) {
             if ('_defaults' === $name) {
                 continue;

--- a/core-bundle/src/DependencyInjection/Filesystem/FilesystemConfiguration.php
+++ b/core-bundle/src/DependencyInjection/Filesystem/FilesystemConfiguration.php
@@ -46,9 +46,9 @@ class FilesystemConfiguration
     /**
      * Adds another new VirtualFilesystem service.
      *
-     * Setting the name to 'foo' will create a 'contao.filesystem.virtual.foo'
+     * Setting the name to "foo" will create a "contao.filesystem.virtual.foo"
      * service and additionally enable constructor injection with an argument
-     * 'VirtualFilesystemInterface $fooStorage' if autowiring is available.
+     * "VirtualFilesystemInterface $fooStorage" if autowiring is available.
      *
      * @return Definition the newly created definition
      */
@@ -78,7 +78,7 @@ class FilesystemConfiguration
      * @see https://github.com/thephpleague/flysystem-bundle#basic-usage
      *
      * The $mountPath must be a path relative to and inside the project root
-     * (e.g. 'files/foo' or 'assets/images').
+     * (e.g. "files/foo" or "assets/images").
      *
      * If you do not set a name, the id/alias for the adapter service will be
      * derived from the mount path.
@@ -117,7 +117,7 @@ class FilesystemConfiguration
      * mountAdapter() instead.
      *
      * The $mountPath must be a path relative to and inside the project root
-     * (e.g. 'files/foo' or 'assets/images'); the $filesystemPath can either
+     * (e.g. "files/foo" or "assets/images"); the $filesystemPath can either
      * be absolute or relative to the project root and may contain
      * placeholders (%name%).
      *

--- a/core-bundle/src/EventListener/DataContainer/PageUrlListener.php
+++ b/core-bundle/src/EventListener/DataContainer/PageUrlListener.php
@@ -201,8 +201,8 @@ class PageUrlListener
      */
     private function aliasExists(string $currentAlias, PageModel $currentPage, bool $throw = false): bool
     {
-        // We can safely modify the page model since `loadDetails` detaches it
-        // from the registry and calls `preventSaving()`
+        // We can safely modify the page model since loadDetails() detaches it
+        // from the registry and calls preventSaving()
         $currentPage->loadDetails();
         $currentPage->alias = $currentAlias;
 
@@ -244,7 +244,7 @@ class PageUrlListener
 
             // Even if we cannot generate the path because of parameter requirements,
             // two pages can never have the same path AND the same requirements. This
-            // could be two regular pages with same alias and  `requireItem` enabled.
+            // could be two regular pages with same alias and "requireItem" enabled.
             if (
                 null === $currentUrl
                 && $currentRoute->getPath() === $aliasRoute->getPath()

--- a/core-bundle/src/Filesystem/Dbafs/Dbafs.php
+++ b/core-bundle/src/Filesystem/Dbafs/Dbafs.php
@@ -591,7 +591,7 @@ class Dbafs implements DbafsInterface, ResetInterface
 
         if (!empty($inserts)) {
             $table = $this->connection->quoteIdentifier($this->table);
-            $columns = sprintf('`%s`', implode('`, `', array_keys($inserts[0]))); // `uuid`, `pid`, …
+            $columns = sprintf('`%s`', implode('`, `', array_keys($inserts[0]))); // "uuid", "pid", …
             $placeholders = sprintf('(%s)', implode(', ', array_fill(0, \count($inserts[0]), '?'))); // (?, ?, …, ?)
 
             foreach (array_chunk($inserts, $this->bulkInsertSize) as $chunk) {
@@ -653,7 +653,7 @@ class Dbafs implements DbafsInterface, ResetInterface
      * This includes all parent directories and - in case of directories - all
      * resources that reside in it.
      *
-     * This method also builds lookup tables for hashes, 'last modified' timestamps
+     * This method also builds lookup tables for hashes, "last modified" timestamps
      * and UUIDs of the entire table.
      *
      * @param array<string> $searchPaths       non-empty list of search paths
@@ -816,7 +816,7 @@ class Dbafs implements DbafsInterface, ResetInterface
      * double slash (//) as suffix.
      *
      * If $considerShallowDirectories is set to false, paths that are directly
-     * inside shallow directories (e.g. 'foo/bar' in 'foo') do NOT yield a
+     * inside shallow directories (e.g. "foo/bar" in "foo") do NOT yield a
      * truthy result.
      *
      * @param array<string> $basePaths
@@ -893,7 +893,7 @@ class Dbafs implements DbafsInterface, ResetInterface
         $shallowDirectories = [];
         $deepDirectories = [];
 
-        // Normalize '/**' and '/*' suffixes
+        // Normalize "/**" and "/*" suffixes
         $paths = array_map(
             static function (string $path) use (&$shallowDirectories, &$deepDirectories): string {
                 if (preg_match('@^[^*]+/(\*\*?)@', $path, $matches)) {

--- a/core-bundle/src/Filesystem/Dbafs/DbafsInterface.php
+++ b/core-bundle/src/Filesystem/Dbafs/DbafsInterface.php
@@ -71,9 +71,9 @@ interface DbafsInterface
      * All $paths must be relative to the DBAFS root and can occur in one of
      * the following forms:
      *
-     *   'foo/bar/baz' = just the single file/directory 'foo/bar/baz'
-     *   'foo/**' = 'foo' and all resources in all subdirectories
-     *   'foo/*' = 'foo' and only direct child resources of 'foo'
+     *    'foo/bar/baz' -> just the single file/directory "foo/bar/baz"
+     *    'foo/**' -> "foo" and all child resources in all subdirectories
+     *    'foo/*' -> "foo" and only direct child resources of "foo"
      */
     public function sync(string ...$paths): ChangeSet;
 
@@ -85,8 +85,9 @@ interface DbafsInterface
      * returned items.
      *
      * Example:
+     *
      *    public function getSupportedFeatures(): int {
-     *        // We support 'file size' and 'mime type' and set it in each record.
+     *        // We support "file size" and "mime type" and set it in each record.
      *        return DbafsInterface::FEATURE_FILE_SIZE | DbafsInterface::FEATURE_MIME_TYPE;
      *    }
      */

--- a/core-bundle/src/Filesystem/Dbafs/DbafsManager.php
+++ b/core-bundle/src/Filesystem/Dbafs/DbafsManager.php
@@ -84,8 +84,8 @@ class DbafsManager
      *
      * The returned path will always be relative to the provided prefix:
      *
-     *     resolveUuid($uuid); // returns 'files/foo/bar'
-     *     resolveUuid($uuid, 'files/foo'); // returns 'bar'
+     *     resolveUuid($uuid); // returns "files/foo/bar"
+     *     resolveUuid($uuid, 'files/foo'); // returns "bar"
      *
      * @throws UnableToResolveUuidException
      */
@@ -315,9 +315,9 @@ class DbafsManager
      * Ensures that all DBAFS with a more specific prefix are also supporting
      * everything each less specific one does.
      *
-     * For example, a DBAFS with prefix 'files/media' must also support
-     * 'fileSize' if the DBAFS under 'files' does. It could, however, support
-     * additional properties like 'mimeType' even if the 'files' DBAFS does not.
+     * For example, a DBAFS with prefix "files/media" must also support
+     * "fileSize" if the DBAFS under "files" does. It could, however, support
+     * additional properties like "mimeType" even if the "files" DBAFS does not.
      */
     private function validateTransitiveProperties(): void
     {

--- a/core-bundle/src/Filesystem/Dbafs/Hashing/HashGenerator.php
+++ b/core-bundle/src/Filesystem/Dbafs/Hashing/HashGenerator.php
@@ -25,7 +25,7 @@ class HashGenerator implements HashGeneratorInterface
     public function __construct(string $hashAlgorithm, bool $useLastModified = true)
     {
         if (!\in_array($hashAlgorithm, $supportedHashAlgorithms = hash_algos(), true)) {
-            throw new \InvalidArgumentException(sprintf("The '%s' hash algorithm isn't available on this system. Try '%s' instead.", $hashAlgorithm, implode("' or '", $supportedHashAlgorithms)));
+            throw new \InvalidArgumentException(sprintf('The "%s" hash algorithm is not available on this system. Try "%s" instead.', $hashAlgorithm, implode('" or "', $supportedHashAlgorithms)));
         }
 
         $this->hashAlgorithm = $hashAlgorithm;

--- a/core-bundle/src/Filesystem/VirtualFilesystem.php
+++ b/core-bundle/src/Filesystem/VirtualFilesystem.php
@@ -20,7 +20,7 @@ use Symfony\Component\Uid\Uuid;
 /**
  * Use the VirtualFilesystem to access resources from mounted adapters and
  * registered DBAFS instances. The class can be instantiated with a path
- * prefix (e.g. 'assets/images') to get a different root and/or as a readonly
+ * prefix (e.g. "assets/images") to get a different root and/or as a readonly
  * view to prevent accidental mutations.
  *
  * In each method you can either pass in a path (string) or a @see Uuid to

--- a/core-bundle/src/Filesystem/VirtualFilesystemException.php
+++ b/core-bundle/src/Filesystem/VirtualFilesystemException.php
@@ -47,7 +47,7 @@ class VirtualFilesystemException extends \RuntimeException
     {
         return new self(
             $path,
-            "Unable to check if a file exists at '$path'.",
+            sprintf('Unable to check if a file exists at "%s".', $path),
             self::UNABLE_TO_CHECK_IF_FILE_EXISTS,
             $previous
         );
@@ -57,7 +57,7 @@ class VirtualFilesystemException extends \RuntimeException
     {
         return new self(
             $path,
-            "Unable to check if a directory exists at '$path'.",
+            sprintf('Unable to check if a directory exists at "%s".', $path),
             self::UNABLE_TO_CHECK_IF_DIRECTORY_EXISTS,
             $previous
         );
@@ -67,7 +67,7 @@ class VirtualFilesystemException extends \RuntimeException
     {
         return new self(
             $path,
-            "Unable to read from '$path'.",
+            sprintf('Unable to read from "%s".', $path),
             self::UNABLE_TO_READ,
             $previous
         );
@@ -77,7 +77,7 @@ class VirtualFilesystemException extends \RuntimeException
     {
         return new self(
             $path,
-            "Unable to write to '$path'.",
+            sprintf('Unable to write to "%s".', $path),
             self::UNABLE_TO_WRITE,
             $previous
         );
@@ -87,7 +87,7 @@ class VirtualFilesystemException extends \RuntimeException
     {
         return new self(
             $path,
-            "Unable to delete file at '$path'.",
+            sprintf('Unable to delete file at "%s".', $path),
             self::UNABLE_TO_DELETE,
             $previous
         );
@@ -97,7 +97,7 @@ class VirtualFilesystemException extends \RuntimeException
     {
         return new self(
             $path,
-            "Unable to delete directory at '$path'.",
+            sprintf('Unable to delete directory at "%s".', $path),
             self::UNABLE_TO_DELETE_DIRECTORY,
             $previous
         );
@@ -107,7 +107,7 @@ class VirtualFilesystemException extends \RuntimeException
     {
         return new self(
             $path,
-            "Unable to create directory at '$path'.",
+            sprintf('Unable to create directory at "%s".', $path),
             self::UNABLE_TO_CREATE_DIRECTORY,
             $previous
         );
@@ -117,7 +117,7 @@ class VirtualFilesystemException extends \RuntimeException
     {
         return new self(
             $pathFrom,
-            "Unable to copy file from '$pathFrom' to '$pathTo'.",
+            sprintf('Unable to copy file from "%s" to "%s".', $pathFrom, $pathTo),
             self::UNABLE_TO_COPY,
             $previous
         );
@@ -127,7 +127,7 @@ class VirtualFilesystemException extends \RuntimeException
     {
         return new self(
             $pathFrom,
-            "Unable to move file from '$pathFrom' to '$pathTo'.",
+            sprintf('Unable to move file from "%s" to "%s".', $pathFrom, $pathTo),
             self::UNABLE_TO_MOVE,
             $previous
         );
@@ -137,7 +137,7 @@ class VirtualFilesystemException extends \RuntimeException
     {
         return new self(
             $path,
-            "Unable to list contents from '$path'.",
+            sprintf('Unable to list contents from "%s".', $path),
             self::UNABLE_TO_LIST_CONTENTS,
             $previous
         );
@@ -147,7 +147,7 @@ class VirtualFilesystemException extends \RuntimeException
     {
         return new self(
             $path,
-            "Unable to retrieve metadata from '$path'.",
+            sprintf('Unable to retrieve metadata from "%s".', $path),
             self::UNABLE_TO_RETRIEVE_METADATA,
             $previous
         );

--- a/core-bundle/src/Image/Preview/PreviewFactory.php
+++ b/core-bundle/src/Image/Preview/PreviewFactory.php
@@ -374,7 +374,7 @@ class PreviewFactory
     {
         // Unlike the Contao\Image\PictureFactory, the PictureFactoryInterface
         // does not know about ResizeOptions. We therefore check if the third
-        // argument of the 'create' method allows setting them.
+        // argument of the "create" method allows setting them.
         // TODO: Adjust this in Contao 5 after the interface has been adjusted.
         $canHandleResizeOptions = static function (PictureFactoryInterface $factory): bool {
             if ($factory instanceof PictureFactory) {

--- a/core-bundle/src/Image/Studio/FigureBuilder.php
+++ b/core-bundle/src/Image/Studio/FigureBuilder.php
@@ -155,7 +155,7 @@ class FigureBuilder
         $this->lastException = null;
 
         if ('file' !== $filesModel->type) {
-            $this->lastException = new InvalidResourceException("DBAFS item '$filesModel->path' is not a file.");
+            $this->lastException = new InvalidResourceException(sprintf('DBAFS item "%s" is not a file.', $filesModel->path));
 
             return $this;
         }
@@ -164,7 +164,7 @@ class FigureBuilder
         $this->filesModel = $filesModel;
 
         if (!$this->filesystem->exists($this->filePath)) {
-            $this->lastException = new InvalidResourceException("No resource could be located at path '$this->filePath'.");
+            $this->lastException = new InvalidResourceException(sprintf('No resource could be located at path "%s".', $this->filePath));
         }
 
         return $this;
@@ -180,7 +180,7 @@ class FigureBuilder
         $filesModel = $this->getFilesModelAdapter()->findByUuid($uuid);
 
         if (null === $filesModel) {
-            $this->lastException = new InvalidResourceException("DBAFS item with UUID '$uuid' could not be found.");
+            $this->lastException = new InvalidResourceException(sprintf('DBAFS item with UUID "%s" could not be found.', $uuid));
 
             return $this;
         }
@@ -198,7 +198,7 @@ class FigureBuilder
         $filesModel = $this->getFilesModelAdapter()->findByPk($id);
 
         if (null === $filesModel) {
-            $this->lastException = new InvalidResourceException("DBAFS item with ID '$id' could not be found.");
+            $this->lastException = new InvalidResourceException(sprintf('DBAFS item with ID "%s" could not be found.', $id));
 
             return $this;
         }
@@ -231,7 +231,7 @@ class FigureBuilder
         $this->filesModel = null;
 
         if (!$this->filesystem->exists($this->filePath)) {
-            $this->lastException = new InvalidResourceException("No resource could be located at path '$this->filePath'.");
+            $this->lastException = new InvalidResourceException(sprintf('No resource could be located at path "%s".', $this->filePath));
         }
 
         return $this;
@@ -253,7 +253,7 @@ class FigureBuilder
     public function from($identifier): self
     {
         if (null === $identifier) {
-            $this->lastException = new InvalidResourceException("The defined resource is 'null'.");
+            $this->lastException = new InvalidResourceException('The defined resource is "null".');
 
             return $this;
         }

--- a/core-bundle/src/Image/Studio/ImageResult.php
+++ b/core-bundle/src/Image/Studio/ImageResult.php
@@ -78,7 +78,7 @@ class ImageResult
 
         // Unlike the Contao\Image\PictureFactory the PictureFactoryInterface
         // does not know about ResizeOptions. We therefore check if the third
-        // argument of the 'create' method allows setting them.
+        // argument of the "create" method allows setting them.
         $canHandleResizeOptions = static function (PictureFactoryInterface $factory): bool {
             if ($factory instanceof PictureFactory) {
                 return true;

--- a/core-bundle/src/Routing/AbstractPageRouteProvider.php
+++ b/core-bundle/src/Routing/AbstractPageRouteProvider.php
@@ -184,7 +184,7 @@ abstract class AbstractPageRouteProvider implements RouteProviderInterface
         $pathA = $a instanceof PageRoute && $a->getUrlSuffix() ? substr($a->getPath(), 0, -\strlen($a->getUrlSuffix())) : $a->getPath();
         $pathB = $b instanceof PageRoute && $b->getUrlSuffix() ? substr($b->getPath(), 0, -\strlen($b->getUrlSuffix())) : $b->getPath();
 
-        // Prioritize the default behaviour when `requireItem` is enabled
+        // Prioritize the default behaviour when "requireItem" is enabled
         if ($pathA === $pathB && '{!parameters}' === substr($pathA, -13)) {
             $paramA = $a->getRequirement('parameters');
             $paramB = $b->getRequirement('parameters');

--- a/core-bundle/src/Twig/Extension/ContaoExtension.php
+++ b/core-bundle/src/Twig/Extension/ContaoExtension.php
@@ -56,7 +56,7 @@ final class ContaoExtension extends AbstractExtension
         $escaperExtension->setEscaper('contao_html', [$contaoEscaper, 'escapeHtml']);
         $escaperExtension->setEscaper('contao_html_attr', [$contaoEscaper, 'escapeHtmlAttr']);
 
-        // Use our escaper on all templates in the `@Contao` and `@Contao_*` namespaces
+        // Use our escaper on all templates in the "@Contao" and "@Contao_*" namespaces
         $this->addContaoEscaperRule('%^@Contao(_[a-zA-Z0-9_-]*)?/%');
     }
 
@@ -64,7 +64,7 @@ final class ContaoExtension extends AbstractExtension
      * Adds a Contao escaper rule.
      *
      * If a template name matches any of the defined rules, it will be processed
-     * with the 'contao_html' escaper strategy. Make sure your rule will only
+     * with the "contao_html" escaper strategy. Make sure your rule will only
      * match templates with input encoded contexts!
      */
     public function addContaoEscaperRule(string $regularExpression): void
@@ -79,7 +79,7 @@ final class ContaoExtension extends AbstractExtension
     public function getNodeVisitors(): array
     {
         return [
-            // Enables the 'contao_twig' escaper for Contao templates with
+            // Enables the "contao_twig" escaper for Contao templates with
             // input encoding
             new ContaoEscaperNodeVisitor(
                 fn () => $this->contaoEscaperFilterRules
@@ -93,7 +93,7 @@ final class ContaoExtension extends AbstractExtension
     public function getTokenParsers(): array
     {
         return [
-            // Overwrite the parsers for the 'extends' and 'include' tags to
+            // Overwrite the parsers for the "extends" and "include" tags to
             // additionally support the Contao template hierarchy
             new DynamicExtendsTokenParser($this->hierarchy),
             new DynamicIncludeTokenParser($this->hierarchy),
@@ -105,7 +105,7 @@ final class ContaoExtension extends AbstractExtension
         $includeFunctionCallable = $this->getTwigIncludeFunction()->getCallable();
 
         return [
-            // Overwrite the 'include' function to additionally support the
+            // Overwrite the "include" function to additionally support the
             // Contao template hierarchy
             new TwigFunction(
                 'include',
@@ -170,7 +170,7 @@ final class ContaoExtension extends AbstractExtension
         };
 
         return [
-            // Overwrite the 'escape'/'e' filter to additionally support chunked text
+            // Overwrite the "escape" filter to additionally support chunked text
             new TwigFilter(
                 'escape',
                 $escaperFilter,

--- a/core-bundle/src/Twig/Interop/ContaoEscaperNodeVisitor.php
+++ b/core-bundle/src/Twig/Interop/ContaoEscaperNodeVisitor.php
@@ -34,7 +34,7 @@ final class ContaoEscaperNodeVisitor extends AbstractNodeVisitor
     /**
      * We evaluate affected templates on the fly so that rules can be adjusted
      * after building the container. Expects a list of regular expressions to
-     * be returned. A template counts as 'affected' if it matches any of the
+     * be returned. A template counts as "affected" if it matches any of the
      * rules.
      */
     private \Closure $rules;

--- a/core-bundle/src/Twig/Interop/ContextFactory.php
+++ b/core-bundle/src/Twig/Interop/ContextFactory.php
@@ -142,7 +142,7 @@ final class ContextFactory
             }
 
             /**
-             * Called when evaluating `{{ var }}` in a Twig template.
+             * Called when evaluating "{{ var }}" in a Twig template.
              */
             public function __toString(): string
             {
@@ -154,7 +154,7 @@ final class ContextFactory
             }
 
             /**
-             * Called when evaluating '{{ var.invoke(…) }}' in a Twig template.
+             * Called when evaluating "{{ var.invoke(…) }}" in a Twig template.
              * We do not cast to string here, so that other types (like arrays)
              * are supported as well.
              *

--- a/core-bundle/src/Twig/Loader/ContaoFilesystemLoader.php
+++ b/core-bundle/src/Twig/Loader/ContaoFilesystemLoader.php
@@ -34,9 +34,9 @@ use Twig\Source;
  *     cache keys/source contexts if a matching variant exists in the current
  *     theme's namespace.
  *
- *  3) When adding paths, there is an option to 'track templates'. If enabled
+ *  3) When adding paths, there is an option to "track templates". If enabled
  *     templates will be located and kept in a hierarchy. This allows us to
- *     support inheritance chains by dynamically rewriting 'extends'. Similar
+ *     support inheritance chains by dynamically rewriting "extends". Similar
  *     to the directory paths, the hierarchy is also cacheable and gets
  *     automatically restored at construct time.
  *
@@ -101,7 +101,7 @@ class ContaoFilesystemLoader extends FilesystemLoader implements TemplateHierarc
     public function addPath(string $path, string $namespace = 'Contao', bool $trackTemplates = false): void
     {
         if (null === ContaoTwigUtil::parseContaoName("@$namespace")) {
-            throw new LoaderError("Tried to register an invalid Contao namespace '$namespace'.");
+            throw new LoaderError(sprintf('Tried to register an invalid Contao namespace "%s".', $namespace));
         }
 
         try {
@@ -127,7 +127,7 @@ class ContaoFilesystemLoader extends FilesystemLoader implements TemplateHierarc
     public function prependPath(string $path, string $namespace = 'Contao'): void
     {
         if (null === ContaoTwigUtil::parseContaoName("@$namespace")) {
-            throw new LoaderError("Tried to register an invalid Contao namespace '$namespace'.");
+            throw new LoaderError(sprintf('Tried to register an invalid Contao namespace "%s".', $namespace));
         }
 
         try {

--- a/core-bundle/src/Util/LocaleUtil.php
+++ b/core-bundle/src/Util/LocaleUtil.php
@@ -44,7 +44,8 @@ class LocaleUtil
      *
      * This can also be used to load languages files that override each other.
      * A script tag (e.g. chinese traditional) always overrides a region.
-     * Example: 'zh_Hant_TW' returns [zh, zh_TW, zh_Hant, zh_Hant_TW]
+     *
+     * Example: "zh_Hant_TW" returns [zh, zh_TW, zh_Hant, zh_Hant_TW]
      *
      * @see https://unicode-org.github.io/icu/userguide/locale/resources.html#find-the-best-available-data
      *

--- a/core-bundle/tests/Filesystem/Dbafs/Hashing/HashGeneratorTest.php
+++ b/core-bundle/tests/Filesystem/Dbafs/Hashing/HashGeneratorTest.php
@@ -26,7 +26,7 @@ class HashGeneratorTest extends TestCase
     public function testValidateHashFunctionExists(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches("/The 'foofoo' hash algorithm isn't available on this system. Try '.*' instead\\./");
+        $this->expectExceptionMessageMatches('/The "foofoo" hash algorithm is not available on this system. Try ".*" instead\./');
 
         new HashGenerator('foofoo');
     }

--- a/core-bundle/tests/Filesystem/MountManagerTest.php
+++ b/core-bundle/tests/Filesystem/MountManagerTest.php
@@ -448,9 +448,9 @@ class MountManagerTest extends TestCase
             [
                 'file1 (file)',
                 'files (dir)',
-                // Note: 'files/media' must not be reported as a directory
+                // Note: "files/media" must not be reported as a directory
                 // here, because it is virtual and implicit (i.e. only the
-                // explicitly mounted 'files/media/extra' is included).
+                // explicitly mounted "files/media/extra" is included).
                 'files/media/extra (dir)',
                 'files/media/extra/cat.avif (file)',
                 'files/media/extra/videos (dir)',

--- a/core-bundle/tests/Filesystem/VirtualFilesystemExceptionTest.php
+++ b/core-bundle/tests/Filesystem/VirtualFilesystemExceptionTest.php
@@ -33,57 +33,57 @@ class VirtualFilesystemExceptionTest extends TestCase
 
         yield 'unable to check if file exists' => [
             VirtualFilesystemException::unableToCheckIfFileExists('foo/bar', $previous),
-            'Unable to check if a file exists at \'foo/bar\'.',
+            'Unable to check if a file exists at "foo/bar".',
         ];
 
         yield 'unable to check if directory exists' => [
             VirtualFilesystemException::unableToCheckIfDirectoryExists('foo/bar', $previous),
-            'Unable to check if a directory exists at \'foo/bar\'.',
+            'Unable to check if a directory exists at "foo/bar".',
         ];
 
         yield 'unable to read' => [
             VirtualFilesystemException::unableToRead('foo/bar', $previous),
-            'Unable to read from \'foo/bar\'.',
+            'Unable to read from "foo/bar".',
         ];
 
         yield 'unable to write' => [
             VirtualFilesystemException::unableToWrite('foo/bar', $previous),
-            'Unable to write to \'foo/bar\'.',
+            'Unable to write to "foo/bar".',
         ];
 
         yield 'unable to delete file' => [
             VirtualFilesystemException::unableToDelete('foo/bar', $previous),
-            'Unable to delete file at \'foo/bar\'.',
+            'Unable to delete file at "foo/bar".',
         ];
 
         yield 'unable to delete directory' => [
             VirtualFilesystemException::unableToDeleteDirectory('foo/bar', $previous),
-            'Unable to delete directory at \'foo/bar\'.',
+            'Unable to delete directory at "foo/bar".',
         ];
 
         yield 'unable to create directory' => [
             VirtualFilesystemException::unableToCreateDirectory('foo/bar', $previous),
-            'Unable to create directory at \'foo/bar\'.',
+            'Unable to create directory at "foo/bar".',
         ];
 
         yield 'unable to copy' => [
             VirtualFilesystemException::unableToCopy('foo/bar', 'path/to', $previous),
-            'Unable to copy file from \'foo/bar\' to \'path/to\'.',
+            'Unable to copy file from "foo/bar" to "path/to".',
         ];
 
         yield 'unable to move' => [
             VirtualFilesystemException::unableToMove('foo/bar', 'path/to', $previous),
-            'Unable to move file from \'foo/bar\' to \'path/to\'.',
+            'Unable to move file from "foo/bar" to "path/to".',
         ];
 
         yield 'unable to list contents' => [
             VirtualFilesystemException::unableToListContents('foo/bar', $previous),
-            'Unable to list contents from \'foo/bar\'.',
+            'Unable to list contents from "foo/bar".',
         ];
 
         yield 'unable to retrieve metadata' => [
             VirtualFilesystemException::unableToRetrieveMetadata('foo/bar', $previous),
-            'Unable to retrieve metadata from \'foo/bar\'.',
+            'Unable to retrieve metadata from "foo/bar".',
         ];
     }
 }

--- a/core-bundle/tests/Image/Studio/FigureBuilderTest.php
+++ b/core-bundle/tests/Image/Studio/FigureBuilderTest.php
@@ -72,7 +72,7 @@ class FigureBuilderTest extends TestCase
         $exception = $figureBuilder->getLastException();
 
         $this->assertInstanceOf(InvalidResourceException::class, $exception);
-        $this->assertSame("DBAFS item 'foo' is not a file.", $exception->getMessage());
+        $this->assertSame('DBAFS item "foo" is not a file.', $exception->getMessage());
         $this->assertNull($figureBuilder->buildIfResourceExists());
 
         $this->expectExceptionObject($exception);
@@ -129,7 +129,7 @@ class FigureBuilderTest extends TestCase
         $exception = $figureBuilder->getLastException();
 
         $this->assertInstanceOf(InvalidResourceException::class, $exception);
-        $this->assertSame("DBAFS item with UUID 'invalid-uuid' could not be found.", $exception->getMessage());
+        $this->assertSame('DBAFS item with UUID "invalid-uuid" could not be found.', $exception->getMessage());
         $this->assertNull($figureBuilder->buildIfResourceExists());
 
         $this->expectExceptionObject($exception);
@@ -167,7 +167,7 @@ class FigureBuilderTest extends TestCase
         $exception = $figureBuilder->getLastException();
 
         $this->assertInstanceOf(InvalidResourceException::class, $exception);
-        $this->assertSame("DBAFS item with ID '99' could not be found.", $exception->getMessage());
+        $this->assertSame('DBAFS item with ID "99" could not be found.', $exception->getMessage());
         $this->assertNull($figureBuilder->buildIfResourceExists());
 
         $this->expectExceptionObject($exception);
@@ -336,7 +336,7 @@ class FigureBuilderTest extends TestCase
         $exception = $figureBuilder->getLastException();
 
         $this->assertInstanceOf(InvalidResourceException::class, $exception);
-        $this->assertSame("The defined resource is 'null'.", $exception->getMessage());
+        $this->assertSame('The defined resource is "null".', $exception->getMessage());
         $this->assertNull($figureBuilder->buildIfResourceExists());
 
         $this->expectExceptionObject($exception);

--- a/core-bundle/tests/Image/Studio/ImageResultTest.php
+++ b/core-bundle/tests/Image/Studio/ImageResultTest.php
@@ -66,7 +66,7 @@ class ImageResultTest extends TestCase
             ->method('create')
             ->willReturnCallback(
                 function () use ($supportsResizeOptions, $resizeOptions) {
-                    // Expect factories with a compatible 'create' method signature
+                    // Expect factories with a compatible "create" method signature
                     // to be called with $resizeOptions as 3rd argument.
                     if ($supportsResizeOptions) {
                         $this->assertSame($resizeOptions, func_get_arg(2));

--- a/core-bundle/tests/Twig/Loader/ContaoFilesystemLoaderTest.php
+++ b/core-bundle/tests/Twig/Loader/ContaoFilesystemLoaderTest.php
@@ -68,7 +68,7 @@ class ContaoFilesystemLoaderTest extends TestCase
         $loader = $this->getContaoFilesystemLoader();
 
         $this->expectException(LoaderError::class);
-        $this->expectExceptionMessage("Tried to register an invalid Contao namespace 'Foo'.");
+        $this->expectExceptionMessage('Tried to register an invalid Contao namespace "Foo".');
 
         $loader->addPath('foo/path', 'Foo');
     }
@@ -78,7 +78,7 @@ class ContaoFilesystemLoaderTest extends TestCase
         $loader = $this->getContaoFilesystemLoader();
 
         $this->expectException(LoaderError::class);
-        $this->expectExceptionMessage("Tried to register an invalid Contao namespace 'Foo'.");
+        $this->expectExceptionMessage('Tried to register an invalid Contao namespace "Foo".');
 
         $loader->prependPath('foo/path', 'Foo');
     }


### PR DESCRIPTION
This PR mainly fixes the quotation mark madness. 😄 We should always use double quotes in exception and deprecation messages, because the Symfony profiler will automatically render them nicely.

<img width="883" alt="" src="https://user-images.githubusercontent.com/1192057/156024204-8f21c31d-c7c4-4748-90b8-cda0d5766d45.png">
