### PR TITLE
Execute BackendTemplate#compile() when using the AbstractBackendController

### DIFF
--- a/core-bundle/src/Controller/AbstractBackendController.php
+++ b/core-bundle/src/Controller/AbstractBackendController.php
@@ -41,7 +41,7 @@ abstract class AbstractBackendController extends AbstractController
 
                 $this->Template->setData($this->compileTemplateData($this->Template->getData()));
 
-                // Make sure the compile function is executed that adds additional context (see #?)
+                // Make sure the compile function is executed that adds additional context (see #4224)
                 $this->Template->getResponse();
 
                 return $this->Template->getData();

--- a/core-bundle/src/Controller/AbstractBackendController.php
+++ b/core-bundle/src/Controller/AbstractBackendController.php
@@ -39,7 +39,12 @@ abstract class AbstractBackendController extends AbstractController
                     $this->objAjax->executePreActions();
                 }
 
-                return $this->compileTemplateData($this->Template->getData());
+                $this->Template->setData($this->compileTemplateData($this->Template->getData()));
+
+                // Make sure the compile function is executed that adds additional context (see #?)
+                $this->Template->getResponse();
+
+                return $this->Template->getData();
             }
         })();
 

--- a/core-bundle/tests/Controller/AbstractBackendControllerTest.php
+++ b/core-bundle/tests/Controller/AbstractBackendControllerTest.php
@@ -20,9 +20,11 @@ use Contao\CoreBundle\Tests\TestCase;
 use Contao\Database;
 use Contao\Environment as ContaoEnvironment;
 use Contao\System;
+use Contao\TemplateLoader;
 use Doctrine\DBAL\Driver\Connection;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Filesystem\Path;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\Routing\RouterInterface;
@@ -44,7 +46,7 @@ class AbstractBackendControllerTest extends TestCase
         unset($GLOBALS['TL_LANG'], $GLOBALS['TL_LANGUAGE'], $GLOBALS['TL_MIME']);
 
         $this->restoreServerEnvGetPost();
-        $this->resetStaticProperties([ContaoEnvironment::class, BackendUser::class, Database::class, System::class, Config::class]);
+        $this->resetStaticProperties([ContaoEnvironment::class, BackendUser::class, Database::class, System::class, Config::class, TemplateLoader::class]);
 
         parent::tearDown();
     }
@@ -60,7 +62,10 @@ class AbstractBackendControllerTest extends TestCase
 
         // Legacy setup
         ContaoEnvironment::reset();
-        (new Filesystem())->mkdir($this->getTempDir().'/languages/en');
+
+        $filesystem = new Filesystem();
+        $filesystem->mkdir(Path::join($this->getTempDir(), 'languages/en'));
+        $filesystem->touch(Path::join($this->getTempDir(), 'be_main.html5'));
 
         $GLOBALS['TL_LANG']['MSC'] = [
             'version' => 'version',
@@ -73,6 +78,8 @@ class AbstractBackendControllerTest extends TestCase
 
         $_SERVER['HTTP_USER_AGENT'] = 'Contao/Foo';
         $_SERVER['HTTP_HOST'] = 'localhost';
+
+        TemplateLoader::addFile('be_main', '');
 
         $expectedContext = [
             'version' => 'my version',
@@ -88,6 +95,8 @@ class AbstractBackendControllerTest extends TestCase
             'learnMore' => 'learn more',
             'menu' => '<menu>',
             'headerMenu' => '<header_menu>',
+            'ua' => 'unknown other ',
+            'badgeTitle' => '',
             'foo' => 'bar',
         ];
 

--- a/core-bundle/tests/Controller/AbstractBackendControllerTest.php
+++ b/core-bundle/tests/Controller/AbstractBackendControllerTest.php
@@ -22,6 +22,7 @@ use Contao\Environment as ContaoEnvironment;
 use Contao\System;
 use Contao\TemplateLoader;
 use Doctrine\DBAL\Driver\Connection;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Filesystem\Path;
@@ -34,6 +35,8 @@ use Twig\Environment;
 
 class AbstractBackendControllerTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -51,8 +54,15 @@ class AbstractBackendControllerTest extends TestCase
         parent::tearDown();
     }
 
+    /**
+     * @group legacy
+     */
     public function testAddsAndMergesBackendContext(): void
     {
+        $this->expectDeprecation('Since contao/core-bundle 4.13: Using "Contao\Environment::get(\'agent\')" has been deprecated %s');
+        $this->expectDeprecation('Since contao/core-bundle 4.13: Using "Contao\Config::get(\'os\')" has been deprecated.');
+        $this->expectDeprecation('Since contao/core-bundle 4.13: Using "Contao\Config::get(\'browser\')" has been deprecated.');
+
         $controller = new class() extends AbstractBackendController {
             public function fooAction(): Response
             {


### PR DESCRIPTION
Until we refactored the legacy templates' compile methods, we need to call them when rendering inside the `AbstractBackendController`. Otherwise things like the custom back end attributes (badge, …) and ua string are missing.

In Contao 5 we should refactor these things and move them into controllers/listeners.