### PR TITLE
Remove the wizard if a DCA field is not editable

### DIFF
--- a/core-bundle/src/Resources/contao/classes/DataContainer.php
+++ b/core-bundle/src/Resources/contao/classes/DataContainer.php
@@ -516,7 +516,7 @@ abstract class DataContainer extends Backend
 			}
 		}
 
-		if ($wizard)
+		if ($wizard && !($arrData['eval']['disabled'] ?? false) && !($arrData['eval']['readonly'] ?? false))
 		{
 			$objWidget->wizard = $wizard;
 


### PR DESCRIPTION
Fixes https://github.com/contao/contao/issues/4173

I've decided against handling each case, but just globally disable wizard if a field is disabled or readonly. I don't think any custom wizard should be available in that case either.