### PR TITLE
Deprecate the Page*::generate() methods

### DIFF
--- a/core-bundle/src/Resources/contao/pages/PageError401.php
+++ b/core-bundle/src/Resources/contao/pages/PageError401.php
@@ -26,9 +26,13 @@ class PageError401 extends Frontend
 	 * Generate an error 401 page
 	 *
 	 * @param PageModel|integer $objRootPage
+	 *
+	 * @deprecated Deprecated since Contao 4.9, to be removed in Contao 5. Use the PageError401::getResponse() method instead.
 	 */
 	public function generate($objRootPage=null)
 	{
+		@trigger_error('Using PageError401::generate() has been deprecated in Contao 4.9 and will be removed in Contao 5.0. Use the PageError401::getResponse() method instead.');
+
 		/** @var PageModel $objPage */
 		global $objPage;
 

--- a/core-bundle/src/Resources/contao/pages/PageError403.php
+++ b/core-bundle/src/Resources/contao/pages/PageError403.php
@@ -25,9 +25,13 @@ class PageError403 extends Frontend
 	 * Generate an error 403 page
 	 *
 	 * @param PageModel|integer $objRootPage
+	 *
+	 * @deprecated Deprecated since Contao 4.9, to be removed in Contao 5. Use the PageError403::getResponse() method instead.
 	 */
 	public function generate($objRootPage=null)
 	{
+		@trigger_error('Using PageError403::generate() has been deprecated in Contao 4.9 and will be removed in Contao 5.0. Use the PageError403::getResponse() method instead.');
+
 		/** @var PageModel $objPage */
 		global $objPage;
 

--- a/core-bundle/src/Resources/contao/pages/PageError404.php
+++ b/core-bundle/src/Resources/contao/pages/PageError404.php
@@ -23,9 +23,13 @@ class PageError404 extends Frontend
 {
 	/**
 	 * Generate an error 404 page
+	 *
+	 * @deprecated Deprecated since Contao 4.9, to be removed in Contao 5. Use the PageError404::getResponse() method instead.
 	 */
 	public function generate()
 	{
+		@trigger_error('Using PageError404::generate() has been deprecated in Contao 4.9 and will be removed in Contao 5.0. Use the PageError404::getResponse() method instead.');
+
 		/** @var PageModel $objPage */
 		global $objPage;
 

--- a/core-bundle/src/Resources/contao/pages/PageForward.php
+++ b/core-bundle/src/Resources/contao/pages/PageForward.php
@@ -25,9 +25,13 @@ class PageForward extends Frontend
 	 * Redirect to an internal page
 	 *
 	 * @param PageModel $objPage
+	 *
+	 * @deprecated Deprecated since Contao 4.9, to be removed in Contao 5. Use the PageForward::getResponse() method instead.
 	 */
 	public function generate($objPage)
 	{
+		@trigger_error('Using PageForward::generate() has been deprecated in Contao 4.9 and will be removed in Contao 5.0. Use the PageForward::getResponse() method instead.');
+
 		$this->redirect($this->getForwardUrl($objPage), $this->getRedirectStatusCode($objPage));
 	}
 

--- a/core-bundle/src/Resources/contao/pages/PageRedirect.php
+++ b/core-bundle/src/Resources/contao/pages/PageRedirect.php
@@ -24,9 +24,13 @@ class PageRedirect extends Frontend
 	 * Redirect to an external page
 	 *
 	 * @param PageModel $objPage
+	 *
+	 * @deprecated Deprecated since Contao 4.9, to be removed in Contao 5. Use the PageRedirect::getResponse() method instead.
 	 */
 	public function generate($objPage)
 	{
+		@trigger_error('Using PageRedirect::generate() has been deprecated in Contao 4.9 and will be removed in Contao 5.0. Use the PageRedirect::getResponse() method instead.');
+
 		$this->prepare($objPage);
 
 		$this->redirect($this->replaceInsertTags($objPage->url, false), $this->getRedirectStatusCode($objPage));

--- a/core-bundle/src/Resources/contao/pages/PageRegular.php
+++ b/core-bundle/src/Resources/contao/pages/PageRegular.php
@@ -34,9 +34,13 @@ class PageRegular extends Frontend
 	 *
 	 * @param PageModel $objPage
 	 * @param boolean   $blnCheckRequest
+	 *
+	 * @deprecated Deprecated since Contao 4.9, to be removed in Contao 5. Use the PageRegular::getResponse() method instead.
 	 */
 	public function generate($objPage, $blnCheckRequest=false)
 	{
+		@trigger_error('Using PageRegular::generate() has been deprecated in Contao 4.9 and will be removed in Contao 5.0. Use the PageRegular::getResponse() method instead.');
+
 		$this->prepare($objPage);
 
 		$this->Template->output($blnCheckRequest);

--- a/core-bundle/src/Resources/contao/pages/PageRoot.php
+++ b/core-bundle/src/Resources/contao/pages/PageRoot.php
@@ -29,9 +29,13 @@ class PageRoot extends Frontend
 	 * @param boolean $blnPreferAlias
 	 *
 	 * @return integer
+	 *
+	 * @deprecated Deprecated since Contao 4.9, to be removed in Contao 5. Use the PageRoot::getResponse() method instead.
 	 */
 	public function generate($rootPageId, $blnReturn=false, $blnPreferAlias=false)
 	{
+		@trigger_error('Using PageRoot::generate() has been deprecated in Contao 4.9 and will be removed in Contao 5.0. Use the PageRoot::getResponse() method instead.');
+
 		if (!$blnReturn)
 		{
 			$this->redirect($this->getRedirectUrl($rootPageId));


### PR DESCRIPTION
These should have been deprecated a long time ago, so we can remove them in Contao 5 🙃 