### PR TITLE
Fix undefined array index warnings for content elements and forms

### DIFF
--- a/core-bundle/src/Resources/contao/dca/tl_content.php
+++ b/core-bundle/src/Resources/contao/dca/tl_content.php
@@ -1280,7 +1280,7 @@ class tl_content extends Backend
 
 			if (($group = $this->getContentElementGroup($arrRow['type'])) !== null)
 			{
-				$type = $GLOBALS['TL_LANG']['CTE'][$group] . ' (' . $type . ')';
+				$type = ($GLOBALS['TL_LANG']['CTE'][$group] ?? $group) . ' (' . $type . ')';
 			}
 		}
 
@@ -1289,7 +1289,7 @@ class tl_content extends Backend
 		{
 			if (($group = $this->getContentElementGroup($arrRow['type'])) !== null)
 			{
-				$type = $GLOBALS['TL_LANG']['CTE'][$group] . ' (' . $type . ')';
+				$type = ($GLOBALS['TL_LANG']['CTE'][$group] ?? $group) . ' (' . $type . ')';
 			}
 		}
 
@@ -1517,7 +1517,7 @@ class tl_content extends Backend
 			}
 
 			$text = StringUtil::substr(strip_tags(preg_replace('/[\n\r\t]+/', ' ', $objAlias->text)), 32);
-			$strText = $GLOBALS['TL_LANG']['CTE'][$objAlias->type][0] . ' (';
+			$strText = ($GLOBALS['TL_LANG']['CTE'][$objAlias->type][0] ?? $objAlias->type) . ' (';
 
 			if ($headline)
 			{

--- a/core-bundle/src/Resources/contao/forms/Form.php
+++ b/core-bundle/src/Resources/contao/forms/Form.php
@@ -559,7 +559,7 @@ class Form extends Hybrid
 		// Store the submission time to invalidate the session later on
 		$_SESSION['FORM_DATA']['SUBMITTED_AT'] = time();
 
-		$arrFiles = $_SESSION['FILES'];
+		$arrFiles = $_SESSION['FILES'] ?? null;
 
 		// HOOK: process form data callback
 		if (isset($GLOBALS['TL_HOOKS']['processFormData']) && \is_array($GLOBALS['TL_HOOKS']['processFormData']))


### PR DESCRIPTION
If you use

```php
/**
 * @ContentElement(category="Foobar")
 */
```

and you do not have a translation for that content element category yet (or don't want to use one), an undefined index warning will occur. This PR fixes that. It also fixes another instance related to the content element's name that was inconsistent.

// Update: just added another fix for an undefined index warning when you submit a front end form without file uploads.