### PR TITLE
Make sure tl_content.type has an index

### DIFF
--- a/core-bundle/src/Resources/contao/dca/tl_content.php
+++ b/core-bundle/src/Resources/contao/dca/tl_content.php
@@ -47,7 +47,8 @@ $GLOBALS['TL_DCA']['tl_content'] = array
 			'keys' => array
 			(
 				'id' => 'primary',
-				'pid,ptable,invisible,start,stop' => 'index'
+				'pid,ptable,invisible,start,stop' => 'index',
+				'type' => 'index',
 			)
 		)
 	),
@@ -1105,7 +1106,7 @@ class tl_content extends Backend
 	{
 		if (Input::get('act') == 'delete')
 		{
-			$objCes = $this->Database->prepare("SELECT COUNT(*) AS cnt FROM tl_content WHERE (ptable='tl_article' OR ptable='') AND type='alias' AND cteAlias=?")
+			$objCes = $this->Database->prepare("SELECT COUNT(*) AS cnt FROM tl_content WHERE type='alias' AND cteAlias=? AND (ptable='tl_article' OR ptable='')")
 									 ->execute(Input::get('id'));
 
 			if ($objCes->cnt > 0)
@@ -1116,7 +1117,7 @@ class tl_content extends Backend
 
 		if (Input::get('act') == 'deleteAll')
 		{
-			$objCes = $this->Database->prepare("SELECT cteAlias FROM tl_content WHERE (ptable='tl_article' OR ptable='') AND type='alias'")
+			$objCes = $this->Database->prepare("SELECT cteAlias FROM tl_content WHERE type='alias' AND (ptable='tl_article' OR ptable='')")
 									 ->execute();
 
 			$objSession = System::getContainer()->get('session');
@@ -1874,7 +1875,7 @@ class tl_content extends Backend
 			return Image::getHtml(preg_replace('/\.svg$/i', '_.svg', $icon)) . ' ';
 		}
 
-		$objElement = $this->Database->prepare("SELECT id FROM tl_content WHERE cteAlias=? AND type='alias'")
+		$objElement = $this->Database->prepare("SELECT id FROM tl_content WHERE type='alias' AND cteAlias=?")
 									 ->limit(1)
 									 ->execute($row['id']);
 


### PR DESCRIPTION
Thanks to APM with Tideways I found that the back end has become quite a bit slower in Contao 4.13 than it was the case previously. This seems to be due to more alias check queries in `tl_content` which are not present in 4.9. I couldn't believe we have no DB index on `tl_content.type`? `WHERE type='xy'` seems to be a very common query?!

I don't think we need an index on `cteAlias` because usually you won't have hundreds of alias elements but I'm fine adding one there too, wdyt @contao/developers? 