### PR TITLE
Correctly encode redirect URLs between 401 pages and login forms

### DIFF
--- a/core-bundle/src/Resources/contao/pages/PageError401.php
+++ b/core-bundle/src/Resources/contao/pages/PageError401.php
@@ -122,7 +122,7 @@ class PageError401 extends Frontend
 			}
 
 			// Add the referer so the login module can redirect back
-			$url = $objNextPage->getAbsoluteUrl() . '?redirect=' . urlencode(Environment::get('base') . Environment::get('request'));
+			$url = $objNextPage->getAbsoluteUrl() . '?redirect=' . rawurlencode(Environment::get('base') . Environment::get('request'));
 
 			/** @var UriSigner $uriSigner */
 			$uriSigner = System::getContainer()->get('uri_signer');

--- a/core-bundle/src/Resources/contao/pages/PageError401.php
+++ b/core-bundle/src/Resources/contao/pages/PageError401.php
@@ -122,7 +122,7 @@ class PageError401 extends Frontend
 			}
 
 			// Add the referer so the login module can redirect back
-			$url = $objNextPage->getAbsoluteUrl() . '?redirect=' . Environment::get('base') . Environment::get('request');
+			$url = $objNextPage->getAbsoluteUrl() . '?redirect=' . urlencode(Environment::get('base') . Environment::get('request'));
 
 			/** @var UriSigner $uriSigner */
 			$uriSigner = System::getContainer()->get('uri_signer');


### PR DESCRIPTION
Fixes #3782

Since the Environment::get('request') is not urlencoded everything after the first & in Environment::get('request') was lost on the redirect back.

Now if a 401 page redirects to a login page the originating url is now encoded correctly if they contain query strings.
