### PR TITLE
Fix infinite loop while loading of languages

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/System.php
+++ b/core-bundle/src/Resources/contao/library/Contao/System.php
@@ -499,7 +499,7 @@ abstract class System
 				$GLOBALS['TL_LANG']['LNG'][$strLocale] = null;
 			}
 
-			foreach (self::getContainer()->get('contao.intl.locales')->getLocales($strLanguage) as $strLocale => $strLabel)
+			foreach (self::getContainer()->get('contao.intl.locales')->getLocales($strCacheKey) as $strLocale => $strLabel)
 			{
 				$GLOBALS['TL_LANG']['LNG'][$strLocale] = $strLabel;
 			}


### PR DESCRIPTION
When upgrading to Contao 4.13 I got an infinite loop on all pages that loaded the languages with `System::getLanguages()`.

The problem was, that my backend user had the legacy language `de_DE` - but I only realized that after the long analysis of this issue. And you cannot change the language because the backend profile page will also end up in an infinite loop 😢 
By the way maybe an migration of the backend language of the users could make sense.

But it will also break the frontend if you use a non 2-letter language and have a frontend element which calls `contao.intl.locales` 👀 

Because of #4043 the method `getLocales` is recursively called while loading the language files.
But the language is shortend shortly before in `loadLanguageFile` so you will get an infinite loop because of different `$strCacheKey`
https://github.com/contao/contao/blob/af3d72daae8f8d9671d1a8dd806608afe91c8a18/core-bundle/src/Resources/contao/library/Contao/System.php#L502