### PR TITLE
Added similar news list hook to all other modules

### DIFF
--- a/calendar-bundle/src/Resources/contao/classes/Events.php
+++ b/calendar-bundle/src/Resources/contao/classes/Events.php
@@ -103,7 +103,49 @@ abstract class Events extends Module
 			return array();
 		}
 
+		$this->collectCalendars($arrCalendars, $intStart, $intEnd, $blnFeatured);
+
+		// HOOK: modify the result set
+		if (isset($GLOBALS['TL_HOOKS']['getAllEvents']) && \is_array($GLOBALS['TL_HOOKS']['getAllEvents']))
+		{
+			foreach ($GLOBALS['TL_HOOKS']['getAllEvents'] as $callback)
+			{
+				$this->import($callback[0]);
+				$this->arrEvents = $this->{$callback[0]}->{$callback[1]}($this->arrEvents, $arrCalendars, $intStart, $intEnd, $this);
+			}
+		}
+
+		return $this->arrEvents;
+	}
+
+	/**
+	 * Collect the matching calendars.
+	 *
+	 * @param array   $arrCalendars
+	 * @param integer $intStart
+	 * @param integer $intEnd
+	 * @param boolean $blnFeatured
+	 */
+	protected function collectCalendars($arrCalendars, $intStart, $intEnd, $blnFeatured)
+	{
 		$this->arrEvents = array();
+
+		// HOOK: add custom logic
+		if (isset($GLOBALS['TL_HOOKS']['collectCalendars']) && \is_array($GLOBALS['TL_HOOKS']['collectCalendars']))
+		{
+			foreach ($GLOBALS['TL_HOOKS']['collectCalendars'] as $callback)
+			{
+				if (($this->arrEvents = System::importStatic($callback[0])->{$callback[1]}($arrCalendars, $intStart, $intEnd, $blnFeatured, $this)) === false)
+				{
+					continue;
+				}
+
+				if (\is_array($this->arrEvents))
+				{
+					return;
+				}
+			}
+		}
 
 		foreach ($arrCalendars as $id)
 		{
@@ -167,18 +209,6 @@ abstract class Events extends Module
 		{
 			ksort($this->arrEvents[$key]);
 		}
-
-		// HOOK: modify the result set
-		if (isset($GLOBALS['TL_HOOKS']['getAllEvents']) && \is_array($GLOBALS['TL_HOOKS']['getAllEvents']))
-		{
-			foreach ($GLOBALS['TL_HOOKS']['getAllEvents'] as $callback)
-			{
-				$this->import($callback[0]);
-				$this->arrEvents = $this->{$callback[0]}->{$callback[1]}($this->arrEvents, $arrCalendars, $intStart, $intEnd, $this);
-			}
-		}
-
-		return $this->arrEvents;
 	}
 
 	/**

--- a/faq-bundle/src/Resources/contao/modules/ModuleFaqPage.php
+++ b/faq-bundle/src/Resources/contao/modules/ModuleFaqPage.php
@@ -10,6 +10,8 @@
 
 namespace Contao;
 
+use Contao\Model\Collection;
+
 /**
  * Class ModuleFaqPage
  *
@@ -69,7 +71,7 @@ class ModuleFaqPage extends Module
 	 */
 	protected function compile()
 	{
-		$objFaqs = FaqModel::findPublishedByPids($this->faq_categories);
+		$objFaqs = $this->fetchItems($this->faq_categories);
 
 		if ($objFaqs === null)
 		{
@@ -171,6 +173,35 @@ class ModuleFaqPage extends Module
 		{
 			return ModuleFaq::getSchemaOrgData($objFaqs);
 		};
+	}
+
+	/**
+	 * Fetch the matching items
+	 *
+	 * @param array $faqCategories
+	 *
+	 * @return FaqModel|FaqModel[]|Collection|null
+	 */
+	protected function fetchItems($faqCategories)
+	{
+		// HOOK: add custom logic
+		if (isset($GLOBALS['TL_HOOKS']['faqPageFetchItems']) && \is_array($GLOBALS['TL_HOOKS']['faqPageFetchItems']))
+		{
+			foreach ($GLOBALS['TL_HOOKS']['faqPageFetchItems'] as $callback)
+			{
+				if (($objCollection = System::importStatic($callback[0])->{$callback[1]}($faqCategories, $this)) === false)
+				{
+					continue;
+				}
+
+				if ($objCollection === null || $objCollection instanceof Collection)
+				{
+					return $objCollection;
+				}
+			}
+		}
+
+		return FaqModel::findPublishedByPids($faqCategories);
 	}
 }
 


### PR DESCRIPTION
These hooks are used to implement your own logic and accordingly to obtain more information for evaluation, which is currently not available from the modules.

When programming a filter, I noticed that this is currently only reasonably possible with the news list module. I missed this in the other modules and therefore added it accordingly.

I would be pleased if these changes could be incorporated into the 4.13. Because in order to implement my logic completely, I have to make a not very nice hack.