### PR TITLE
Fix SQL error in purge expired data cron

### DIFF
--- a/core-bundle/src/Cron/PurgeExpiredDataCron.php
+++ b/core-bundle/src/Cron/PurgeExpiredDataCron.php
@@ -50,7 +50,7 @@ class PurgeExpiredDataCron
         }
 
         $this->connection->executeStatement(
-            sprintf('DELETE FROM %s WHERE tstamp<:tstamp', $table),
+            "DELETE FROM $table WHERE tstamp < :tstamp",
             ['tstamp' => time() - $period],
             ['tstamp' => Types::INTEGER],
         );

--- a/core-bundle/src/Cron/PurgeExpiredDataCron.php
+++ b/core-bundle/src/Cron/PurgeExpiredDataCron.php
@@ -16,6 +16,7 @@ use Contao\Config;
 use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\CoreBundle\ServiceAnnotation\CronJob;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Types\Types;
 
 class PurgeExpiredDataCron
 {
@@ -48,7 +49,10 @@ class PurgeExpiredDataCron
             return;
         }
 
-        $stmt = $this->connection->prepare(sprintf('DELETE FROM %s WHERE tstamp<:tstamp', $table));
-        $stmt->executeStatement(['tstamp' => time() - $period]);
+        $this->connection->executeStatement(
+            sprintf('DELETE FROM %s WHERE tstamp<:tstamp', $table),
+            ['tstamp' => time() - $period],
+            ['tstamp' => Types::INTEGER],
+        );
     }
 }

--- a/core-bundle/tests/Cron/PurgeExpiredDataCronTest.php
+++ b/core-bundle/tests/Cron/PurgeExpiredDataCronTest.php
@@ -33,7 +33,7 @@ class PurgeExpiredDataCronTest extends ContaoTestCase
 
         if ($undoPeriod > 0) {
             $expectedStatements[] = [
-                'DELETE FROM tl_undo WHERE tstamp<:tstamp',
+                'DELETE FROM tl_undo WHERE tstamp < :tstamp',
                 ['tstamp' => $mockedTime - $undoPeriod],
                 ['tstamp' => Types::INTEGER],
             ];
@@ -41,7 +41,7 @@ class PurgeExpiredDataCronTest extends ContaoTestCase
 
         if ($logPeriod > 0) {
             $expectedStatements[] = [
-                'DELETE FROM tl_log WHERE tstamp<:tstamp',
+                'DELETE FROM tl_log WHERE tstamp < :tstamp',
                 ['tstamp' => $mockedTime - $logPeriod],
                 ['tstamp' => Types::INTEGER],
             ];
@@ -49,7 +49,7 @@ class PurgeExpiredDataCronTest extends ContaoTestCase
 
         if ($versionPeriod > 0) {
             $expectedStatements[] = [
-                'DELETE FROM tl_version WHERE tstamp<:tstamp',
+                'DELETE FROM tl_version WHERE tstamp < :tstamp',
                 ['tstamp' => $mockedTime - $versionPeriod],
                 ['tstamp' => Types::INTEGER],
             ];

--- a/core-bundle/tests/Cron/PurgeExpiredDataCronTest.php
+++ b/core-bundle/tests/Cron/PurgeExpiredDataCronTest.php
@@ -16,7 +16,7 @@ use Contao\Config;
 use Contao\CoreBundle\Cron\PurgeExpiredDataCron;
 use Contao\TestCase\ContaoTestCase;
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\Statement;
+use Doctrine\DBAL\Types\Types;
 use Symfony\Bridge\PhpUnit\ClockMock;
 
 class PurgeExpiredDataCronTest extends ContaoTestCase
@@ -30,21 +30,29 @@ class PurgeExpiredDataCronTest extends ContaoTestCase
         ClockMock::withClockMock($mockedTime);
 
         $expectedStatements = [];
-        $expectedExecuteParameters = [];
 
         if ($undoPeriod > 0) {
-            $expectedStatements[] = ['DELETE FROM tl_undo WHERE tstamp<:tstamp'];
-            $expectedExecuteParameters[] = [['tstamp' => $mockedTime - $undoPeriod]];
+            $expectedStatements[] = [
+                'DELETE FROM tl_undo WHERE tstamp<:tstamp',
+                ['tstamp' => $mockedTime - $undoPeriod],
+                ['tstamp' => Types::INTEGER],
+            ];
         }
 
         if ($logPeriod > 0) {
-            $expectedStatements[] = ['DELETE FROM tl_log WHERE tstamp<:tstamp'];
-            $expectedExecuteParameters[] = [['tstamp' => $mockedTime - $logPeriod]];
+            $expectedStatements[] = [
+                'DELETE FROM tl_log WHERE tstamp<:tstamp',
+                ['tstamp' => $mockedTime - $logPeriod],
+                ['tstamp' => Types::INTEGER],
+            ];
         }
 
         if ($versionPeriod > 0) {
-            $expectedStatements[] = ['DELETE FROM tl_version WHERE tstamp<:tstamp'];
-            $expectedExecuteParameters[] = [['tstamp' => $mockedTime - $versionPeriod]];
+            $expectedStatements[] = [
+                'DELETE FROM tl_version WHERE tstamp<:tstamp',
+                ['tstamp' => $mockedTime - $versionPeriod],
+                ['tstamp' => Types::INTEGER],
+            ];
         }
 
         $config = $this->mockAdapter(['get']);
@@ -55,19 +63,11 @@ class PurgeExpiredDataCronTest extends ContaoTestCase
             ->willReturn($undoPeriod, $logPeriod, $versionPeriod)
         ;
 
-        $statement = $this->createMock(Statement::class);
-        $statement
-            ->expects($this->exactly(\count($expectedExecuteParameters)))
-            ->method('executeStatement')
-            ->withConsecutive(...$expectedExecuteParameters)
-        ;
-
         $connection = $this->createMock(Connection::class);
         $connection
             ->expects($this->exactly(\count($expectedStatements)))
-            ->method('prepare')
+            ->method('executeStatement')
             ->withConsecutive(...$expectedStatements)
-            ->willReturn($statement)
         ;
 
         $framework = $this->mockContaoFramework([Config::class => $config]);


### PR DESCRIPTION
Executing this cron runs into the following error: `You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near ':tstamp' at line 1`

`Connection::prepare()` does not support named parameters AFAIK (or maybe that changed in a recent Doctrine version?).