### PR TITLE
Fix SQL commands not supported in prepared statements

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Database/Statement.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Database/Statement.php
@@ -287,6 +287,16 @@ class Statement
 		}
 		catch (DriverException|\ArgumentCountError $exception)
 		{
+			// SQLSTATE[HY000]: This command is not supported in the prepared statement protocol
+			if ($exception->getCode() === 1295)
+			{
+				$this->resConnection->executeStatement($this->strQuery, $arrParams, $arrTypes);
+
+				trigger_deprecation('contao/core-bundle', '4.13', 'Using "%s()" for statements (instead of queries) has been deprecated and will no longer work in Contao 5.0. Use "%s::executeStatement()" instead.', __METHOD__, Connection::class);
+
+				return $this;
+			}
+
 			if (!$arrParams)
 			{
 				throw $exception;


### PR DESCRIPTION
`Database::getInstance()->query("LOCK TABLES")` currently runs into the following error with MySQLi:
`SQLSTATE[HY000]: This command is not supported in the prepared statement protocol`