### PR TITLE
Fix a potential PHP 8 incompatibility when generating a DCA column

### DIFF
--- a/core-bundle/src/Resources/contao/classes/DataContainer.php
+++ b/core-bundle/src/Resources/contao/classes/DataContainer.php
@@ -1696,7 +1696,7 @@ abstract class DataContainer extends Backend
 
 					foreach ($row_v as $option)
 					{
-						$args_k[] = $GLOBALS['TL_DCA'][$table]['fields'][$v]['reference'][$option] ?: $option;
+						$args_k[] = $GLOBALS['TL_DCA'][$table]['fields'][$v]['reference'][$option] ?? $option;
 					}
 
 					$args[$k] = implode(', ', $args_k);


### PR DESCRIPTION
Fix a potential PHP 8 incompatibility when generating a DCA column of value that is an array, but has no reference set in the field definition.

Given this DCA configuration:

```php
// dca.list
'label' => [
    'fields' => ['myField', 'myAnotherField'],
    'showColumns' => true,
    'label_callback' => ['MyListener', 'myLabelCallback'],
],

// dca.fields
'myField' => [
    'exclude' => true,
    'inputType' => 'checkbox',
    'options_callback' => ['MyListener', 'myFieldCallback'],
    'eval' => ['mandatory' => true, 'multiple' => true, 'tl_class' => 'clr'],
    'sql' => ['type' => 'blob', 'notnull' => false],
],
```

I do get an error when generating the DCA list view:

```
Warning: Undefined array key "reference"
```

Due to `Contao\DataContainer` assuming that there is always a reference option if the value is a serialized array.