### PR TITLE
Add missing isSortable checks to the picker widget

### DIFF
--- a/core-bundle/src/Resources/contao/widgets/Picker.php
+++ b/core-bundle/src/Resources/contao/widgets/Picker.php
@@ -135,7 +135,7 @@ class Picker extends Widget
 			$showFields = $GLOBALS['TL_DCA'][$strRelatedTable]['list']['label']['fields'];
 
 			$return .= '
-<table class="tl_listing showColumns' . ($blnHasOrder ? ' sortable' : '') . '">
+<table class="tl_listing showColumns' . ($blnHasOrder || $this->isSortable ? ' sortable' : '') . '">
 <thead>
   <tr>';
 
@@ -179,7 +179,7 @@ class Picker extends Widget
 		else
 		{
 			$return .= '
-    <ul id="sort_' . $this->strId . '" class="' . ($blnHasOrder ? 'sortable' : '') . '">';
+    <ul id="sort_' . $this->strId . '" class="' . ($blnHasOrder || $this->isSortable ? 'sortable' : '') . '">';
 
 			foreach ($arrValues as $k=>$v)
 			{


### PR DESCRIPTION
The `isSortable` checks were added in https://github.com/contao/contao/pull/1468 but I noticed that the `sortable` class is not set when I use the picker widget. I added two more checks, just like it was done in the pageTree and fileTree widgets:

https://github.com/contao/contao/blob/01d8f3ea25115aaf01297c9662ed59f7142a858e/core-bundle/src/Resources/contao/widgets/PageTree.php#L199