### PR TITLE
Fix DCA extractor wrongly assuming every DCA is database driven

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/DcaExtractor.php
+++ b/core-bundle/src/Resources/contao/library/Contao/DcaExtractor.php
@@ -517,38 +517,6 @@ class DcaExtractor extends Controller
 			}
 		}
 
-		// Return if there are no fields
-		if (empty($fields))
-		{
-			return;
-		}
-
-		$params = System::getContainer()->get('database_connection')->getParams();
-
-		// Add the default engine and charset if none is given
-		if (empty($sql['engine']))
-		{
-			$sql['engine'] = $params['defaultTableOptions']['engine'] ?? 'InnoDB';
-		}
-
-		if (empty($sql['charset']))
-		{
-			$sql['charset'] = $params['defaultTableOptions']['charset'] ?? 'utf8mb4';
-		}
-
-		if (empty($sql['collate']))
-		{
-			$sql['collate'] = $params['defaultTableOptions']['collate'] ?? 'utf8mb4_unicode_ci';
-		}
-
-		// Meta
-		$this->arrMeta = array
-		(
-			'engine' => $sql['engine'],
-			'charset' => $sql['charset'],
-			'collate' => $sql['collate']
-		);
-
 		// Fields
 		$this->arrFields = array();
 		$this->arrOrderFields = array();
@@ -589,7 +557,37 @@ class DcaExtractor extends Controller
 		}
 
 		$this->arrUniqueFields = array_unique($this->arrUniqueFields);
-		$this->blnIsDbTable = true;
+
+		if (!empty($this->arrFields) || !empty($this->arrKeys))
+		{
+			$params = System::getContainer()->get('database_connection')->getParams();
+
+			// Add the default engine and charset if none is given
+			if (empty($sql['engine']))
+			{
+				$sql['engine'] = $params['defaultTableOptions']['engine'] ?? 'InnoDB';
+			}
+
+			if (empty($sql['charset']))
+			{
+				$sql['charset'] = $params['defaultTableOptions']['charset'] ?? 'utf8mb4';
+			}
+
+			if (empty($sql['collate']))
+			{
+				$sql['collate'] = $params['defaultTableOptions']['collate'] ?? 'utf8mb4_unicode_ci';
+			}
+
+			// Meta
+			$this->arrMeta = array
+			(
+				'engine' => $sql['engine'],
+				'charset' => $sql['charset'],
+				'collate' => $sql['collate']
+			);
+
+			$this->blnIsDbTable = true;
+		}
 	}
 
 	private function getDatabaseSqlFiles(): array


### PR DESCRIPTION
Fixes #4253

The underlying problem is that the DCA extractor actually assumes that _every_ data container is database driven, except for a few specific ones. However, people can create - and have created - their own custom data container drivers that are in fact not database driven. This just happened to be not a problem before #4233, because most of the time such DCAs either had no config.sql definition or no fields. However, now that we can create database driven DCAs with only sql fields (and no config.sql) this problem surfaces.

Unfortunately there is no way to define in a DCA that your driver is actually database driven.

This PR checks whether any field or key definitions were actually set and only then sets the appropriate SQL meta data plus `$this->blnIsDbTable`. This PR will also allow config.sql defintions without having sql fields.