### PR TITLE
Ignore file symlinks when auto-mounting adapters

### DIFF
--- a/core-bundle/src/DependencyInjection/Compiler/ConfigureFilesystemPass.php
+++ b/core-bundle/src/DependencyInjection/Compiler/ConfigureFilesystemPass.php
@@ -55,7 +55,7 @@ class ConfigureFilesystemPass implements CompilerPassInterface
         $projectDir = $parameterBag->resolveValue($parameterBag->get('kernel.project_dir'));
         $uploadDir = $parameterBag->resolveValue($parameterBag->get('contao.upload_path'));
 
-        $finder = (new Finder())->in($projectDir)->path("/^$uploadDir/");
+        $finder = (new Finder())->in($projectDir)->directories()->path("/^$uploadDir/");
 
         foreach ($finder as $item) {
             if (!$item->isLink()) {

--- a/core-bundle/tests/DependencyInjection/Compiler/ConfigureFilesystemPassTest.php
+++ b/core-bundle/tests/DependencyInjection/Compiler/ConfigureFilesystemPassTest.php
@@ -103,9 +103,10 @@ class ConfigureFilesystemPassTest extends TestCase
         // Setup directories with symlink
         $filesystem = new Filesystem();
         $filesystem->mkdir(Path::join($tempDir, 'files'));
-        $filesystem->dumpFile(Path::join($tempDir, 'vendor/foo/dummy.txt'), 'dummy');
+        $filesystem->dumpFile($dummyFile = Path::join($tempDir, 'vendor/foo/dummy.txt'), 'dummy');
 
         $this->createSymlink($target, $link, Path::join($tempDir, 'files'));
+        $this->createSymlink($dummyFile, 'dummy.txt', Path::join($tempDir, 'files')); // should get ignored
 
         $container = new ContainerBuilder(
             new ParameterBag([


### PR DESCRIPTION
Fixes #4277 

This makes sure file symlinks are ignored when executing `mountAdaptersForSymlinks()` in the compiler pass.