### PR TITLE
Improve version diff of recursive array data

### DIFF
--- a/core-bundle/src/Resources/contao/classes/Versions.php
+++ b/core-bundle/src/Resources/contao/classes/Versions.php
@@ -822,14 +822,14 @@ class Versions extends Controller
 	 *
 	 * @return string
 	 */
-	protected function implodeRecursive($var, $binary=false)
+	protected function implodeRecursive($var, $binary=false, $level=0)
 	{
 		if (!\is_array($var))
 		{
 			return $binary && Validator::isBinaryUuid($var) ? StringUtil::binToUuid($var) : $var;
 		}
 
-		if (!\is_array(current($var)))
+		if (!\is_array(current($var)) && !ArrayUtil::isAssoc($var))
 		{
 			if ($binary)
 			{
@@ -843,10 +843,11 @@ class Versions extends Controller
 
 		foreach ($var as $k=>$v)
 		{
-			$buffer .= $k . ": " . $this->implodeRecursive($v) . "\n";
+			$isArray = \is_array($v);
+			$buffer .=  str_repeat(' ', $level * 4) . $k . ": " . ($isArray ? "\n" : '') . $this->implodeRecursive($v, false, $level+1) . (($isArray && $level === 0) ? "\n\n" : "\n");
 		}
 
-		return trim($buffer);
+		return $buffer;
 	}
 }
 


### PR DESCRIPTION
I'm using https://github.com/m-vo/contao-group-widget here but I think it applies to any recursive array. Be aware that this only affects fields with `eval => multiple = true` set, otherwise the source data is not unserialized (e.g. it does not affect headline fields).

**Before:**
<img width="891" alt="Bildschirmfoto 2022-03-17 um 14 15 14" src="https://user-images.githubusercontent.com/1073273/158816568-b423d41d-bb6c-4423-bd04-3d9733498881.png">


**After:**
<img width="889" alt="Bildschirmfoto 2022-03-17 um 14 11 36" src="https://user-images.githubusercontent.com/1073273/158816627-128d3caf-fd5c-4cad-8f1f-f4363a4e7ab6.png">

_Screenshots are not exactly the same content but the same markup_ 😉
