### PR TITLE
Fix requireItem sorting

### DIFF
--- a/core-bundle/src/Routing/AbstractPageRouteProvider.php
+++ b/core-bundle/src/Routing/AbstractPageRouteProvider.php
@@ -189,11 +189,11 @@ abstract class AbstractPageRouteProvider implements RouteProviderInterface
             $paramA = $a->getRequirement('parameters');
             $paramB = $b->getRequirement('parameters');
 
-            if ('/.+' === $paramA && '(/.+?)?' === $paramB) {
+            if ('/.+?' === $paramA && '(/.+?)?' === $paramB) {
                 return -1;
             }
 
-            if ('(/.+?)?' === $paramA && '/.+' === $paramB) {
+            if ('(/.+?)?' === $paramA && '/.+?' === $paramB) {
                 return 1;
             }
         }

--- a/core-bundle/tests/Routing/AbstractPageRouteProviderTest.php
+++ b/core-bundle/tests/Routing/AbstractPageRouteProviderTest.php
@@ -192,7 +192,7 @@ class AbstractPageRouteProviderTest extends TestCase
         ];
 
         yield 'Sorts route with required parameters first (1)' => [
-            new Route('/foo{!parameters}', ['pageModel' => $this->mockPageModel('de')], ['parameters' => '/.+']),
+            new Route('/foo{!parameters}', ['pageModel' => $this->mockPageModel('de')], ['parameters' => '/.+?']),
             new Route('/foo{!parameters}', ['pageModel' => $this->mockPageModel('de')], ['parameters' => '(/.+?)?']),
             ['de', 'de'],
             -1,
@@ -200,14 +200,14 @@ class AbstractPageRouteProviderTest extends TestCase
 
         yield 'Sorts route with required parameters first (2)' => [
             new Route('/foo{!parameters}', ['pageModel' => $this->mockPageModel('de')], ['parameters' => '(/.+?)?']),
-            new Route('/foo{!parameters}', ['pageModel' => $this->mockPageModel('de')], ['parameters' => '/.+']),
+            new Route('/foo{!parameters}', ['pageModel' => $this->mockPageModel('de')], ['parameters' => '/.+?']),
             ['de', 'de'],
             1,
         ];
 
         yield 'Ignores required parameters with equal requirement' => [
-            new Route('/foo{!parameters}', ['pageModel' => $this->mockPageModel('de')], ['parameters' => '/.+']),
-            new Route('/foo{!parameters}', ['pageModel' => $this->mockPageModel('de')], ['parameters' => '/.+']),
+            new Route('/foo{!parameters}', ['pageModel' => $this->mockPageModel('de')], ['parameters' => '/.+?']),
+            new Route('/foo{!parameters}', ['pageModel' => $this->mockPageModel('de')], ['parameters' => '/.+?']),
             ['de', 'de'],
             0,
         ];


### PR DESCRIPTION
Merging https://github.com/contao/contao/pull/4106 upstream did break the sorting of pages with `requireItem` enabled.