### PR TITLE
Fix missing hash option for migrate command

### DIFF
--- a/core-bundle/src/Command/MigrateCommand.php
+++ b/core-bundle/src/Command/MigrateCommand.php
@@ -160,7 +160,6 @@ class MigrateCommand extends Command
     {
         while (true) {
             $first = true;
-
             $migrationLabels = [];
 
             foreach ($this->migrations->getPendingNames() as $migration) {

--- a/core-bundle/src/Command/MigrateCommand.php
+++ b/core-bundle/src/Command/MigrateCommand.php
@@ -79,7 +79,7 @@ class MigrateCommand extends Command
             ->addOption('migrations-only', null, InputOption::VALUE_NONE, 'Only execute the migrations.')
             ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Show pending migrations and schema updates without executing them.')
             ->addOption('format', null, InputOption::VALUE_REQUIRED, 'The output format (txt, ndjson)', 'txt')
-            ->addOption('hash', null, InputOption::VALUE_REQUIRED, 'Hash')
+            ->addOption('hash', null, InputOption::VALUE_REQUIRED, 'A hash value from a --dry-run result')
             ->setDescription('Executes migrations and updates the database schema.')
         ;
     }

--- a/core-bundle/src/Command/MigrateCommand.php
+++ b/core-bundle/src/Command/MigrateCommand.php
@@ -79,6 +79,7 @@ class MigrateCommand extends Command
             ->addOption('migrations-only', null, InputOption::VALUE_NONE, 'Only execute the migrations.')
             ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Show pending migrations and schema updates without executing them.')
             ->addOption('format', null, InputOption::VALUE_REQUIRED, 'The output format (txt, ndjson)', 'txt')
+            ->addOption('hash', null, InputOption::VALUE_REQUIRED, 'Hash')
             ->setDescription('Executes migrations and updates the database schema.')
         ;
     }
@@ -110,6 +111,7 @@ class MigrateCommand extends Command
     {
         $dryRun = (bool) $input->getOption('dry-run');
         $asJson = 'ndjson' === $input->getOption('format');
+        $specifiedHash = $input->getOption('hash');
 
         if (!\in_array($input->getOption('format'), ['txt', 'ndjson'], true)) {
             throw new InvalidOptionException(sprintf('Unsupported format "%s".', $input->getOption('format')));
@@ -128,22 +130,22 @@ class MigrateCommand extends Command
                 throw new InvalidOptionException('--migrations-only cannot be combined with --with-deletes');
             }
 
-            return $this->executeMigrations($dryRun, $asJson) ? 0 : 1;
+            return $this->executeMigrations($dryRun, $asJson, $specifiedHash) ? 0 : 1;
         }
 
         if ($input->getOption('schema-only')) {
-            return $this->executeSchemaDiff($dryRun, $asJson, $input->getOption('with-deletes')) ? 0 : 1;
+            return $this->executeSchemaDiff($dryRun, $asJson, $input->getOption('with-deletes'), $specifiedHash) ? 0 : 1;
         }
 
-        if (!$this->executeMigrations($dryRun, $asJson)) {
+        if (!$this->executeMigrations($dryRun, $asJson, $specifiedHash)) {
             return 1;
         }
 
-        if (!$this->executeSchemaDiff($dryRun, $asJson, $input->getOption('with-deletes'))) {
+        if (!$this->executeSchemaDiff($dryRun, $asJson, $input->getOption('with-deletes'), $specifiedHash)) {
             return 1;
         }
 
-        if (!$dryRun && !$this->executeMigrations($dryRun, $asJson)) {
+        if (!$dryRun && !$this->executeMigrations($dryRun, $asJson, $specifiedHash)) {
             return 1;
         }
 
@@ -154,10 +156,12 @@ class MigrateCommand extends Command
         return 0;
     }
 
-    private function executeMigrations(bool $dryRun, bool $asJson): bool
+    private function executeMigrations(bool $dryRun, bool $asJson, string $specifiedHash = null): bool
     {
         while (true) {
             $first = true;
+
+            $migrationLabels = [];
 
             foreach ($this->migrations->getPendingNames() as $migration) {
                 if ($first) {
@@ -168,9 +172,9 @@ class MigrateCommand extends Command
                     $first = false;
                 }
 
-                if ($asJson) {
-                    $this->writeNdjson('migration-pending', ['name' => $migration]);
-                } else {
+                $migrationLabels[] = $migration;
+
+                if (!$asJson) {
                     $this->io->writeln(' * '.$migration);
                 }
             }
@@ -190,15 +194,25 @@ class MigrateCommand extends Command
                     $first = false;
                 }
 
-                if ($asJson) {
-                    $this->writeNdjson('migration-pending', ['name' => 'Runonce file: '.$file]);
-                } else {
+                $migrationLabels[] = "Runonce file: $file";
+
+                if (!$asJson) {
                     $this->io->writeln(' * Runonce file: '.$file);
                 }
             }
 
+            $actualHash = hash('sha256', json_encode($migrationLabels));
+
+            if ($asJson) {
+                $this->writeNdjson('migration-pending', ['names' => $migrationLabels, 'hash' => $actualHash]);
+            }
+
             if ($first || $dryRun) {
                 break;
+            }
+
+            if (null !== $specifiedHash && $specifiedHash !== $actualHash) {
+                throw new InvalidOptionException(sprintf('Specified hash "%s" does not match the actual hash "%s"', $specifiedHash, $actualHash));
             }
 
             if (!$asJson) {
@@ -247,6 +261,11 @@ class MigrateCommand extends Command
             if (!$asJson) {
                 $this->io->success('Executed '.$count.' migrations.');
             }
+
+            // Do not run the update recursive if a hash was specified
+            if (null !== $specifiedHash) {
+                break;
+            }
         }
 
         return true;
@@ -277,7 +296,7 @@ class MigrateCommand extends Command
         (new Filesystem())->remove($this->projectDir.'/'.$file);
     }
 
-    private function executeSchemaDiff(bool $dryRun, bool $asJson, bool $withDeletesOption): bool
+    private function executeSchemaDiff(bool $dryRun, bool $asJson, bool $withDeletesOption, string $specifiedHash = null): bool
     {
         if (null === $this->installer) {
             $this->io->error('Service "contao.installer" not found. The installation bundle needs to be installed in order to execute schema diff migrations.');
@@ -290,9 +309,7 @@ class MigrateCommand extends Command
         while (true) {
             $this->installer->compileCommands();
 
-            if (!$commands = $this->installer->getCommands(false)) {
-                return true;
-            }
+            $commands = $this->installer->getCommands(false);
 
             $hasNewCommands = \count(array_filter(
                 array_keys($commands),
@@ -301,26 +318,31 @@ class MigrateCommand extends Command
                 }
             ));
 
+            $commandsByHash = $commands;
+            $actualHash = hash('sha256', json_encode($commands));
+
+            if ($asJson) {
+                $this->writeNdjson('schema-pending', [
+                    'commands' => array_values($commandsByHash),
+                    'hash' => $actualHash,
+                ]);
+            }
+
             if (!$hasNewCommands) {
                 return true;
             }
 
             if (!$asJson) {
-                $this->io->section('Pending database migrations');
-            }
-
-            $commandsByHash = $commands;
-
-            if ($asJson) {
-                $this->writeNdjson('schema-pending', [
-                    'commands' => array_values($commandsByHash),
-                ]);
-            } else {
+                $this->io->section("Pending database migrations ($actualHash)");
                 $this->io->listing($commandsByHash);
             }
 
             if ($dryRun) {
                 return true;
+            }
+
+            if (null !== $specifiedHash && $specifiedHash !== $actualHash) {
+                throw new InvalidOptionException(sprintf('Specified hash "%s" does not match the actual hash "%s"', $specifiedHash, $actualHash));
             }
 
             $options = $withDeletesOption
@@ -400,6 +422,11 @@ class MigrateCommand extends Command
 
             if (\count($exceptions)) {
                 return false;
+            }
+
+            // Do not run the update recursive if a hash was specified
+            if (null !== $specifiedHash) {
+                break;
             }
         }
 

--- a/core-bundle/tests/Command/MigrateCommandTest.php
+++ b/core-bundle/tests/Command/MigrateCommandTest.php
@@ -39,7 +39,14 @@ class MigrateCommandTest extends TestCase
         $this->assertSame(0, $code);
 
         if ('ndjson' === $format) {
-            $this->assertEmpty(trim($display));
+            $this->assertSame(
+                [
+                    ['type' => 'migration-pending', 'names' => [], 'hash' => '4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945'],
+                    ['type' => 'schema-pending', 'commands' => [], 'hash' => '4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945'],
+                    ['type' => 'migration-pending', 'names' => [], 'hash' => '4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945'],
+                ],
+                $this->jsonArrayFromNdjson($display)
+            );
         } else {
             $this->assertRegExp('/All migrations completed/', $display);
         }
@@ -66,10 +73,12 @@ class MigrateCommandTest extends TestCase
         if ('ndjson' === $format) {
             $this->assertSame(
                 [
-                    ['type' => 'migration-pending', 'name' => 'Migration 1'],
-                    ['type' => 'migration-pending', 'name' => 'Migration 2'],
+                    ['type' => 'migration-pending', 'names' => ['Migration 1', 'Migration 2'], 'hash' => 'ba37bf15c565f47d20df024e3f18bd32e88985525920011c4669c574d71b69fd'],
                     ['type' => 'migration-result', 'message' => 'Result 1', 'isSuccessful' => true],
                     ['type' => 'migration-result', 'message' => 'Result 2', 'isSuccessful' => true],
+                    ['type' => 'migration-pending', 'names' => [], 'hash' => '4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945'],
+                    ['type' => 'schema-pending', 'commands' => [], 'hash' => '4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945'],
+                    ['type' => 'migration-pending', 'names' => [], 'hash' => '4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945'],
                 ],
                 $this->jsonArrayFromNdjson($display)
             );
@@ -112,8 +121,15 @@ class MigrateCommandTest extends TestCase
         if ('ndjson' === $format) {
             $this->assertSame(
                 [
-                    ['type' => 'migration-pending', 'name' => 'Runonce file: runonceFile.php'],
+                    [
+                        'type' => 'migration-pending',
+                        'names' => ['Runonce file: runonceFile.php'],
+                        'hash' => '1ff509c324643092e7d68c763d03832e4b96f5be8fa3a95ea6765abfe96443ca',
+                    ],
                     ['type' => 'migration-result', 'message' => 'Executed runonce file: runonceFile.php', 'isSuccessful' => true],
+                    ['type' => 'migration-pending', 'names' => [], 'hash' => '4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945'],
+                    ['type' => 'schema-pending', 'commands' => [], 'hash' => '4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945'],
+                    ['type' => 'migration-pending', 'names' => [], 'hash' => '4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945'],
                 ],
                 $this->jsonArrayFromNdjson($display)
             );
@@ -166,16 +182,19 @@ class MigrateCommandTest extends TestCase
         if ('ndjson' === $format) {
             $this->assertSame(
                 [
-                    ['type' => 'schema-pending', 'commands' => ['First call QUERY 1', 'First call QUERY 2']],
+                    ['type' => 'migration-pending', 'names' => [], 'hash' => '4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945'],
+                    ['type' => 'schema-pending', 'commands' => ['First call QUERY 1', 'First call QUERY 2'], 'hash' => 'f8e23e09e1009f794eabb39a6883800162ff828f9a1ccf0c5920fd646204fe58'],
                     ['type' => 'schema-execute', 'command' => 'First call QUERY 1'],
                     ['type' => 'schema-result', 'command' => 'First call QUERY 1', 'isSuccessful' => true],
                     ['type' => 'schema-execute', 'command' => 'First call QUERY 2'],
                     ['type' => 'schema-result', 'command' => 'First call QUERY 2', 'isSuccessful' => true],
-                    ['type' => 'schema-pending', 'commands' => ['Second call QUERY 1', 'Second call QUERY 2', 'DROP QUERY']],
+                    ['type' => 'schema-pending', 'commands' => ['Second call QUERY 1', 'Second call QUERY 2', 'DROP QUERY'], 'hash' => '1cde239fb3063750c8594c21d522b2372d86547d96672f1823f782083f70c788'],
                     ['type' => 'schema-execute', 'command' => 'Second call QUERY 1'],
                     ['type' => 'schema-result', 'command' => 'Second call QUERY 1', 'isSuccessful' => true],
                     ['type' => 'schema-execute', 'command' => 'Second call QUERY 2'],
                     ['type' => 'schema-result', 'command' => 'Second call QUERY 2', 'isSuccessful' => true],
+                    ['type' => 'schema-pending', 'commands' => [], 'hash' => '4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945'],
+                    ['type' => 'migration-pending', 'names' => [], 'hash' => '4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945'],
                 ],
                 $this->jsonArrayFromNdjson($display)
             );
@@ -236,12 +255,15 @@ class MigrateCommandTest extends TestCase
         if ('ndjson' === $format) {
             $this->assertSame(
                 [
-                    ['type' => 'migration-pending', 'name' => 'Migration 1'],
-                    ['type' => 'migration-pending', 'name' => 'Migration 2'],
-                    ['type' => 'migration-pending', 'name' => 'Runonce file: runonceFile.php'],
+                    [
+                        'type' => 'migration-pending',
+                        'names' => ['Migration 1', 'Migration 2', 'Runonce file: runonceFile.php'],
+                        'hash' => 'fd96e0795abea843b443ccd39c746b5f1491c45131611f14a7c5bfb518824252',
+                    ],
                     [
                         'type' => 'schema-pending',
                         'commands' => ['First call QUERY 1', 'First call QUERY 2'],
+                        'hash' => 'f8e23e09e1009f794eabb39a6883800162ff828f9a1ccf0c5920fd646204fe58',
                     ],
                 ],
                 $this->jsonArrayFromNdjson($display)
@@ -305,10 +327,12 @@ class MigrateCommandTest extends TestCase
         if ('ndjson' === $format) {
             $this->assertSame(
                 [
-                    ['type' => 'migration-pending', 'name' => 'Migration 1'],
-                    ['type' => 'migration-pending', 'name' => 'Migration 2'],
+                    ['type' => 'migration-pending', 'names' => ['Migration 1', 'Migration 2'], 'hash' => 'ba37bf15c565f47d20df024e3f18bd32e88985525920011c4669c574d71b69fd'],
                     ['type' => 'migration-result', 'message' => 'Result 1', 'isSuccessful' => false],
                     ['type' => 'migration-result', 'message' => 'Result 2', 'isSuccessful' => true],
+                    ['type' => 'migration-pending', 'names' => [], 'hash' => '4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945'],
+                    ['type' => 'schema-pending', 'commands' => [], 'hash' => '4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945'],
+                    ['type' => 'migration-pending', 'names' => [], 'hash' => '4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945'],
                 ],
                 $this->jsonArrayFromNdjson($display)
             );
@@ -346,7 +370,7 @@ class MigrateCommandTest extends TestCase
 
         $this->assertSame(1, $code);
 
-        $json = $this->jsonArrayFromNdjson($display)[0];
+        $json = $this->jsonArrayFromNdjson($display)[1];
 
         $this->assertSame('error', $json['type']);
         $this->assertSame('Fatal', $json['message']);


### PR DESCRIPTION
With the `--hash` option we can make sure nothing changed between the last execution (e.g. for usage in the manager).

Migrations:

```sh
$ vendor/bin/contao-console contao:migrate --migrations-only --no-interaction --dry-run --format=ndjson
{"type":"migration-pending","names":["Runonce file: contao\/config\/runonce.php"],"hash":"b3af6d3df5fb4b35b8383587f20eb06431c6a134a0acde0410f74e1a290f0618"}

$ vendor/bin/contao-console contao:migrate --migrations-only --hash=b3af6d3df5fb4b35b8383587f20eb06431c6a134a0acde0410f74e1a290f0618
...

$ vendor/bin/contao-console contao:migrate --migrations-only --no-interaction --dry-run --format=ndjson
{"type":"migration-pending","names":[],"hash":"4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"}
```

Schema:

```sh
$ vendor/bin/contao-console contao:migrate --schema-only --no-interaction --dry-run --format=ndjson
{"type":"schema-pending","commands":["CREATE INDEX series ON tl_remember_me (series)",…],"hash":"c61f514987b56bc0c502f2410fdfd31e3b91218a528a312fed9b602bbf62764e"}

$ vendor/bin/contao-console contao:migrate --schema-only --hash=c61f514987b56bc0c502f2410fdfd31e3b91218a528a312fed9b602bbf62764e
...

$ vendor/bin/contao-console contao:migrate --schema-only --no-interaction --dry-run --format=ndjson
{"type":"schema-pending","commands":[],"hash":"4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"}
```