### PR TITLE
Use FQCN instead of aliased class name

### DIFF
--- a/calendar-bundle/src/Resources/contao/dca/tl_calendar.php
+++ b/calendar-bundle/src/Resources/contao/dca/tl_calendar.php
@@ -13,7 +13,7 @@ $GLOBALS['TL_DCA']['tl_calendar'] = array
 	// Config
 	'config' => array
 	(
-		'dataContainer'               => 'Table',
+		'dataContainer'               => Contao\DC_Table::class,
 		'ctable'                      => array('tl_calendar_events'),
 		'switchToEdit'                => true,
 		'enableVersioning'            => true,

--- a/calendar-bundle/src/Resources/contao/dca/tl_calendar_events.php
+++ b/calendar-bundle/src/Resources/contao/dca/tl_calendar_events.php
@@ -15,7 +15,7 @@ $GLOBALS['TL_DCA']['tl_calendar_events'] = array
 	// Config
 	'config' => array
 	(
-		'dataContainer'               => 'Table',
+		'dataContainer'               => Contao\DC_Table::class,
 		'ptable'                      => 'tl_calendar',
 		'ctable'                      => array('tl_content'),
 		'switchToEdit'                => true,

--- a/calendar-bundle/src/Resources/contao/dca/tl_calendar_feed.php
+++ b/calendar-bundle/src/Resources/contao/dca/tl_calendar_feed.php
@@ -13,7 +13,7 @@ $GLOBALS['TL_DCA']['tl_calendar_feed'] = array
 	// Config
 	'config' => array
 	(
-		'dataContainer'               => 'Table',
+		'dataContainer'               => Contao\DC_Table::class,
 		'enableVersioning'            => true,
 		'markAsCopy'                  => 'title',
 		'onload_callback' => array

--- a/comments-bundle/src/Resources/contao/dca/tl_comments.php
+++ b/comments-bundle/src/Resources/contao/dca/tl_comments.php
@@ -13,7 +13,7 @@ $GLOBALS['TL_DCA']['tl_comments'] = array
 	// Config
 	'config' => array
 	(
-		'dataContainer'               => 'Table',
+		'dataContainer'               => Contao\DC_Table::class,
 		'enableVersioning'            => true,
 		'closed'                      => true,
 		'notCopyable'                 => true,

--- a/comments-bundle/src/Resources/contao/dca/tl_comments_notify.php
+++ b/comments-bundle/src/Resources/contao/dca/tl_comments_notify.php
@@ -13,7 +13,7 @@ $GLOBALS['TL_DCA']['tl_comments_notify'] = array
 	// Config
 	'config' => array
 	(
-		'dataContainer'               => 'Table',
+		'dataContainer'               => Contao\DC_Table::class,
 		'closed'                      => true,
 		'notEditable'                 => true,
 		'sql' => array

--- a/core-bundle/src/Picker/TablePickerProvider.php
+++ b/core-bundle/src/Picker/TablePickerProvider.php
@@ -12,6 +12,8 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Picker;
 
+use Contao\DC_Table;
+
 class TablePickerProvider extends AbstractTablePickerProvider
 {
     public function getName(): string
@@ -21,6 +23,6 @@ class TablePickerProvider extends AbstractTablePickerProvider
 
     protected function getDataContainer(): string
     {
-        return 'Table';
+        return DC_Table::class;
     }
 }

--- a/core-bundle/src/Resources/contao/classes/Ajax.php
+++ b/core-bundle/src/Resources/contao/classes/Ajax.php
@@ -293,7 +293,7 @@ class Ajax extends Backend
 				// Load the value
 				if (Input::get('act') != 'overrideAll')
 				{
-					if ($GLOBALS['TL_DCA'][$dc->table]['config']['dataContainer'] == 'File')
+					if (is_a($GLOBALS['TL_DCA'][$dc->table]['config']['dataContainer'], DC_File::class, true))
 					{
 						$varValue = Config::get($strField);
 					}

--- a/core-bundle/src/Resources/contao/classes/Backend.php
+++ b/core-bundle/src/Resources/contao/classes/Backend.php
@@ -520,7 +520,7 @@ abstract class Backend extends Controller
 				$table = $strTable;
 				$ptable = ($act != 'edit') ? $GLOBALS['TL_DCA'][$strTable]['config']['ptable'] : $strTable;
 
-				while ($ptable && !\in_array($GLOBALS['TL_DCA'][$table]['list']['sorting']['mode'], array(5, 6)) && ($GLOBALS['TL_DCA'][$ptable]['config']['dataContainer'] ?? null) === 'Table')
+				while ($ptable && !\in_array($GLOBALS['TL_DCA'][$table]['list']['sorting']['mode'], array(5, 6)) && is_a(($GLOBALS['TL_DCA'][$ptable]['config']['dataContainer'] ?? null), DC_Table::class, true))
 				{
 					$objRow = $this->Database->prepare("SELECT * FROM " . $ptable . " WHERE id=?")
 											 ->limit(1)

--- a/core-bundle/src/Resources/contao/dca/tl_article.php
+++ b/core-bundle/src/Resources/contao/dca/tl_article.php
@@ -15,7 +15,7 @@ $GLOBALS['TL_DCA']['tl_article'] = array
 	// Config
 	'config' => array
 	(
-		'dataContainer'               => 'Table',
+		'dataContainer'               => Contao\DC_Table::class,
 		'ptable'                      => 'tl_page',
 		'ctable'                      => array('tl_content'),
 		'switchToEdit'                => true,

--- a/core-bundle/src/Resources/contao/dca/tl_content.php
+++ b/core-bundle/src/Resources/contao/dca/tl_content.php
@@ -13,7 +13,7 @@ $GLOBALS['TL_DCA']['tl_content'] = array
 	// Config
 	'config' => array
 	(
-		'dataContainer'               => 'Table',
+		'dataContainer'               => Contao\DC_Table::class,
 		'enableVersioning'            => true,
 		'ptable'                      => '',
 		'dynamicPtable'               => true,

--- a/core-bundle/src/Resources/contao/dca/tl_files.php
+++ b/core-bundle/src/Resources/contao/dca/tl_files.php
@@ -13,7 +13,7 @@ $GLOBALS['TL_DCA']['tl_files'] = array
 	// Config
 	'config' => array
 	(
-		'dataContainer'               => 'Folder',
+		'dataContainer'               => Contao\DC_Folder::class,
 		'enableVersioning'            => true,
 		'databaseAssisted'            => true,
 		'onload_callback' => array

--- a/core-bundle/src/Resources/contao/dca/tl_form.php
+++ b/core-bundle/src/Resources/contao/dca/tl_form.php
@@ -13,7 +13,7 @@ $GLOBALS['TL_DCA']['tl_form'] = array
 	// Config
 	'config' => array
 	(
-		'dataContainer'               => 'Table',
+		'dataContainer'               => Contao\DC_Table::class,
 		'switchToEdit'                => true,
 		'enableVersioning'            => true,
 		'ctable'                      => array('tl_form_field'),

--- a/core-bundle/src/Resources/contao/dca/tl_form_field.php
+++ b/core-bundle/src/Resources/contao/dca/tl_form_field.php
@@ -13,7 +13,7 @@ $GLOBALS['TL_DCA']['tl_form_field'] = array
 	// Config
 	'config' => array
 	(
-		'dataContainer'               => 'Table',
+		'dataContainer'               => Contao\DC_Table::class,
 		'enableVersioning'            => true,
 		'ptable'                      => 'tl_form',
 		'markAsCopy'                  => 'label',

--- a/core-bundle/src/Resources/contao/dca/tl_image_size.php
+++ b/core-bundle/src/Resources/contao/dca/tl_image_size.php
@@ -13,7 +13,7 @@ $GLOBALS['TL_DCA']['tl_image_size'] = array
 	// Config
 	'config' => array
 	(
-		'dataContainer'               => 'Table',
+		'dataContainer'               => Contao\DC_Table::class,
 		'ptable'                      => 'tl_theme',
 		'ctable'                      => array('tl_image_size_item'),
 		'switchToEdit'                => true,

--- a/core-bundle/src/Resources/contao/dca/tl_image_size_item.php
+++ b/core-bundle/src/Resources/contao/dca/tl_image_size_item.php
@@ -15,7 +15,7 @@ $GLOBALS['TL_DCA']['tl_image_size_item'] = array
 	// Config
 	'config' => array
 	(
-		'dataContainer'               => 'Table',
+		'dataContainer'               => Contao\DC_Table::class,
 		'ptable'                      => 'tl_image_size',
 		'enableVersioning'            => true,
 		'onload_callback' => array

--- a/core-bundle/src/Resources/contao/dca/tl_layout.php
+++ b/core-bundle/src/Resources/contao/dca/tl_layout.php
@@ -13,7 +13,7 @@ $GLOBALS['TL_DCA']['tl_layout'] = array
 	// Config
 	'config' => array
 	(
-		'dataContainer'               => 'Table',
+		'dataContainer'               => Contao\DC_Table::class,
 		'ptable'                      => 'tl_theme',
 		'enableVersioning'            => true,
 		'markAsCopy'                  => 'name',

--- a/core-bundle/src/Resources/contao/dca/tl_log.php
+++ b/core-bundle/src/Resources/contao/dca/tl_log.php
@@ -13,7 +13,7 @@ $GLOBALS['TL_DCA']['tl_log'] = array
 	// Config
 	'config' => array
 	(
-		'dataContainer'               => 'Table',
+		'dataContainer'               => Contao\DC_Table::class,
 		'closed'                      => true,
 		'notEditable'                 => true,
 		'notCopyable'                 => true,

--- a/core-bundle/src/Resources/contao/dca/tl_member.php
+++ b/core-bundle/src/Resources/contao/dca/tl_member.php
@@ -13,7 +13,7 @@ $GLOBALS['TL_DCA']['tl_member'] = array
 	// Config
 	'config' => array
 	(
-		'dataContainer'               => 'Table',
+		'dataContainer'               => Contao\DC_Table::class,
 		'enableVersioning'            => true,
 		'onsubmit_callback' => array
 		(

--- a/core-bundle/src/Resources/contao/dca/tl_member_group.php
+++ b/core-bundle/src/Resources/contao/dca/tl_member_group.php
@@ -13,7 +13,7 @@ $GLOBALS['TL_DCA']['tl_member_group'] = array
 	// Config
 	'config' => array
 	(
-		'dataContainer'               => 'Table',
+		'dataContainer'               => Contao\DC_Table::class,
 		'enableVersioning'            => true,
 		'sql' => array
 		(

--- a/core-bundle/src/Resources/contao/dca/tl_module.php
+++ b/core-bundle/src/Resources/contao/dca/tl_module.php
@@ -13,7 +13,7 @@ $GLOBALS['TL_DCA']['tl_module'] = array
 	// Config
 	'config' => array
 	(
-		'dataContainer'               => 'Table',
+		'dataContainer'               => Contao\DC_Table::class,
 		'ptable'                      => 'tl_theme',
 		'enableVersioning'            => true,
 		'markAsCopy'                  => 'name',

--- a/core-bundle/src/Resources/contao/dca/tl_opt_in.php
+++ b/core-bundle/src/Resources/contao/dca/tl_opt_in.php
@@ -13,7 +13,7 @@ $GLOBALS['TL_DCA']['tl_opt_in'] = array
 	// Config
 	'config' => array
 	(
-		'dataContainer'               => 'Table',
+		'dataContainer'               => Contao\DC_Table::class,
 		'closed'                      => true,
 		'notEditable'                 => true,
 		'notCopyable'                 => true,

--- a/core-bundle/src/Resources/contao/dca/tl_page.php
+++ b/core-bundle/src/Resources/contao/dca/tl_page.php
@@ -13,7 +13,7 @@ $GLOBALS['TL_DCA']['tl_page'] = array
 	// Config
 	'config' => array
 	(
-		'dataContainer'               => 'Table',
+		'dataContainer'               => Contao\DC_Table::class,
 		'ctable'                      => array('tl_article'),
 		'enableVersioning'            => true,
 		'markAsCopy'                  => 'title',

--- a/core-bundle/src/Resources/contao/dca/tl_settings.php
+++ b/core-bundle/src/Resources/contao/dca/tl_settings.php
@@ -13,7 +13,7 @@ $GLOBALS['TL_DCA']['tl_settings'] = array
 	// Config
 	'config' => array
 	(
-		'dataContainer'               => 'File',
+		'dataContainer'               => Contao\DC_File::class,
 		'closed'                      => true
 	),
 

--- a/core-bundle/src/Resources/contao/dca/tl_style.php
+++ b/core-bundle/src/Resources/contao/dca/tl_style.php
@@ -13,7 +13,7 @@ $GLOBALS['TL_DCA']['tl_style'] = array
 	// Config
 	'config' => array
 	(
-		'dataContainer'               => 'Table',
+		'dataContainer'               => Contao\DC_Table::class,
 		'ptable'                      => 'tl_style_sheet',
 		'enableVersioning'            => true,
 		'onload_callback' => array

--- a/core-bundle/src/Resources/contao/dca/tl_style_sheet.php
+++ b/core-bundle/src/Resources/contao/dca/tl_style_sheet.php
@@ -13,7 +13,7 @@ $GLOBALS['TL_DCA']['tl_style_sheet'] = array
 	// Config
 	'config' => array
 	(
-		'dataContainer'               => 'Table',
+		'dataContainer'               => Contao\DC_Table::class,
 		'ptable'                      => 'tl_theme',
 		'ctable'                      => array('tl_style'),
 		'switchToEdit'                => true,

--- a/core-bundle/src/Resources/contao/dca/tl_templates.php
+++ b/core-bundle/src/Resources/contao/dca/tl_templates.php
@@ -15,7 +15,7 @@ $GLOBALS['TL_DCA']['tl_templates'] = array
 	// Config
 	'config' => array
 	(
-		'dataContainer'               => 'Folder',
+		'dataContainer'               => Contao\DC_Folder::class,
 		'closed'                      => true,
 		'onload_callback' => array
 		(

--- a/core-bundle/src/Resources/contao/dca/tl_theme.php
+++ b/core-bundle/src/Resources/contao/dca/tl_theme.php
@@ -13,7 +13,7 @@ $GLOBALS['TL_DCA']['tl_theme'] = array
 	// Config
 	'config' => array
 	(
-		'dataContainer'               => 'Table',
+		'dataContainer'               => Contao\DC_Table::class,
 		'ctable'                      => array('tl_module', 'tl_style_sheet', 'tl_layout', 'tl_image_size'),
 		'notCopyable'                 => true,
 		'enableVersioning'            => true,

--- a/core-bundle/src/Resources/contao/dca/tl_undo.php
+++ b/core-bundle/src/Resources/contao/dca/tl_undo.php
@@ -13,7 +13,7 @@ $GLOBALS['TL_DCA']['tl_undo'] = array
 	// Config
 	'config' => array
 	(
-		'dataContainer'               => 'Table',
+		'dataContainer'               => Contao\DC_Table::class,
 		'closed'                      => true,
 		'notEditable'                 => true,
 		'sql' => array

--- a/core-bundle/src/Resources/contao/dca/tl_user.php
+++ b/core-bundle/src/Resources/contao/dca/tl_user.php
@@ -13,7 +13,7 @@ $GLOBALS['TL_DCA']['tl_user'] = array
 	// Config
 	'config' => array
 	(
-		'dataContainer'               => 'Table',
+		'dataContainer'               => Contao\DC_Table::class,
 		'enableVersioning'            => true,
 		'onload_callback' => array
 		(

--- a/core-bundle/src/Resources/contao/dca/tl_user_group.php
+++ b/core-bundle/src/Resources/contao/dca/tl_user_group.php
@@ -15,7 +15,7 @@ $GLOBALS['TL_DCA']['tl_user_group'] = array
 	// Config
 	'config' => array
 	(
-		'dataContainer'               => 'Table',
+		'dataContainer'               => Contao\DC_Table::class,
 		'enableVersioning'            => true,
 		'onload_callback' => array
 		(

--- a/core-bundle/src/Resources/contao/drivers/DC_File.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_File.php
@@ -386,7 +386,7 @@ class DC_File extends DataContainer implements \editable
 				}
 				else
 				{
-					$varValue = serialize(array_map('StringUtil::binToUuid', $varValue));
+					$varValue = serialize(array_map('\Contao\StringUtil::binToUuid', $varValue));
 				}
 			}
 
@@ -408,7 +408,7 @@ class DC_File extends DataContainer implements \editable
 				}
 				else
 				{
-					$varValue = serialize(array_map('StringUtil::restoreBasicEntities', $varValue));
+					$varValue = serialize(array_map('\Contao\StringUtil::restoreBasicEntities', $varValue));
 				}
 			}
 		}

--- a/core-bundle/src/Resources/contao/library/Contao/Database/Updater.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Database/Updater.php
@@ -14,6 +14,8 @@ use Contao\Config;
 use Contao\Controller;
 use Contao\Database;
 use Contao\Dbafs;
+use Contao\DC_File;
+use Contao\DC_Folder;
 use Contao\File;
 use Contao\Files;
 use Contao\FilesModel;
@@ -760,12 +762,12 @@ class Updater extends Controller
 			$arrConfig = &$GLOBALS['TL_DCA'][$strTable]['config'];
 
 			// Skip non-database DCAs
-			if ($arrConfig['dataContainer'] == 'File')
+			if (is_a($arrConfig['dataContainer'], DC_File::class, true))
 			{
 				continue;
 			}
 
-			if ($arrConfig['dataContainer'] == 'Folder' && !$arrConfig['databaseAssisted'])
+			if (is_a($arrConfig['dataContainer'], DC_Folder::class, true) && !$arrConfig['databaseAssisted'])
 			{
 				continue;
 			}

--- a/core-bundle/src/Resources/contao/library/Contao/DcaExtractor.php
+++ b/core-bundle/src/Resources/contao/library/Contao/DcaExtractor.php
@@ -386,13 +386,13 @@ class DcaExtractor extends Controller
 		}
 
 		// Return if the DC type is "File"
-		if ($GLOBALS['TL_DCA'][$this->strTable]['config']['dataContainer'] == 'File')
+		if (is_a($GLOBALS['TL_DCA'][$this->strTable]['config']['dataContainer'], DC_File::class, true))
 		{
 			return;
 		}
 
 		// Return if the DC type is "Folder" and the DC is not database assisted
-		if ($GLOBALS['TL_DCA'][$this->strTable]['config']['dataContainer'] == 'Folder' && empty($GLOBALS['TL_DCA'][$this->strTable]['config']['databaseAssisted']))
+		if (is_a($GLOBALS['TL_DCA'][$this->strTable]['config']['dataContainer'], DC_Folder::class, true) && empty($GLOBALS['TL_DCA'][$this->strTable]['config']['databaseAssisted']))
 		{
 			return;
 		}

--- a/core-bundle/src/Resources/contao/widgets/FileSelector.php
+++ b/core-bundle/src/Resources/contao/widgets/FileSelector.php
@@ -298,32 +298,29 @@ class FileSelector extends Widget
 		$this->loadDataContainer($this->strTable);
 
 		// Load the current values
-		switch ($GLOBALS['TL_DCA'][$this->strTable]['config']['dataContainer'])
+		if (is_a($GLOBALS['TL_DCA'][$this->strTable]['config']['dataContainer'], DC_File::class, true))
 		{
-			case 'File':
-				if (Config::get($this->strField))
-				{
-					$this->varValue = Config::get($this->strField);
-				}
-				break;
+			if (Config::get($this->strField))
+			{
+				$this->varValue = Config::get($this->strField);
+			}
+		}
 
-			case 'Table':
-				$this->import(Database::class, 'Database');
+		elseif (is_a($GLOBALS['TL_DCA'][$this->strTable]['config']['dataContainer'], DC_Table::class, true))
+		{
+			$this->import(Database::class, 'Database');
 
-				if (!$this->Database->fieldExists($this->strField, $this->strTable))
-				{
-					break;
-				}
-
+			if ($this->Database->fieldExists($this->strField, $this->strTable))
+			{
 				$objField = $this->Database->prepare("SELECT " . Database::quoteIdentifier($this->strField) . " FROM " . $this->strTable . " WHERE id=?")
-										   ->limit(1)
-										   ->execute($this->strId);
+					->limit(1)
+					->execute($this->strId);
 
 				if ($objField->numRows)
 				{
 					$this->varValue = StringUtil::deserialize($objField->{$this->strField});
 				}
-				break;
+			}
 		}
 
 		$this->convertValuesToPaths();

--- a/core-bundle/src/Resources/contao/widgets/FileSelector.php
+++ b/core-bundle/src/Resources/contao/widgets/FileSelector.php
@@ -305,7 +305,6 @@ class FileSelector extends Widget
 				$this->varValue = Config::get($this->strField);
 			}
 		}
-
 		elseif (is_a($GLOBALS['TL_DCA'][$this->strTable]['config']['dataContainer'], DC_Table::class, true))
 		{
 			$this->import(Database::class, 'Database');

--- a/core-bundle/src/Resources/contao/widgets/FileSelector.php
+++ b/core-bundle/src/Resources/contao/widgets/FileSelector.php
@@ -316,13 +316,14 @@ class FileSelector extends Widget
 				}
 
 				$objField = $this->Database->prepare("SELECT " . Database::quoteIdentifier($this->strField) . " FROM " . $this->strTable . " WHERE id=?")
-					->limit(1)
-					->execute($this->strId);
+										   ->limit(1)
+										   ->execute($this->strId);
 
 				if ($objField->numRows)
 				{
 					$this->varValue = StringUtil::deserialize($objField->{$this->strField});
 				}
+				break;
 		}
 
 		$this->convertValuesToPaths();

--- a/core-bundle/src/Resources/contao/widgets/FileSelector.php
+++ b/core-bundle/src/Resources/contao/widgets/FileSelector.php
@@ -298,7 +298,7 @@ class FileSelector extends Widget
 		$this->loadDataContainer($this->strTable);
 
 		// Load the current values
-		switch(true)
+		switch (true)
 		{
 			case is_a($GLOBALS['TL_DCA'][$this->strTable]['config']['dataContainer'], DC_File::class, true):
 				if (Config::get($this->strField))

--- a/core-bundle/src/Resources/contao/widgets/FileSelector.php
+++ b/core-bundle/src/Resources/contao/widgets/FileSelector.php
@@ -298,19 +298,23 @@ class FileSelector extends Widget
 		$this->loadDataContainer($this->strTable);
 
 		// Load the current values
-		if (is_a($GLOBALS['TL_DCA'][$this->strTable]['config']['dataContainer'], DC_File::class, true))
+		switch(true)
 		{
-			if (Config::get($this->strField))
-			{
-				$this->varValue = Config::get($this->strField);
-			}
-		}
-		elseif (is_a($GLOBALS['TL_DCA'][$this->strTable]['config']['dataContainer'], DC_Table::class, true))
-		{
-			$this->import(Database::class, 'Database');
+			case is_a($GLOBALS['TL_DCA'][$this->strTable]['config']['dataContainer'], DC_File::class, true):
+				if (Config::get($this->strField))
+				{
+					$this->varValue = Config::get($this->strField);
+				}
+				break;
 
-			if ($this->Database->fieldExists($this->strField, $this->strTable))
-			{
+			case is_a($GLOBALS['TL_DCA'][$this->strTable]['config']['dataContainer'], DC_Table::class, true):
+				$this->import(Database::class, 'Database');
+
+				if (!$this->Database->fieldExists($this->strField, $this->strTable))
+				{
+					break;
+				}
+
 				$objField = $this->Database->prepare("SELECT " . Database::quoteIdentifier($this->strField) . " FROM " . $this->strTable . " WHERE id=?")
 					->limit(1)
 					->execute($this->strId);
@@ -319,7 +323,6 @@ class FileSelector extends Widget
 				{
 					$this->varValue = StringUtil::deserialize($objField->{$this->strField});
 				}
-			}
 		}
 
 		$this->convertValuesToPaths();

--- a/core-bundle/src/Resources/contao/widgets/FileTree.php
+++ b/core-bundle/src/Resources/contao/widgets/FileTree.php
@@ -102,7 +102,7 @@ class FileTree extends Widget
 
 			if ($order = Input::post($this->strOrderName))
 			{
-				$arrNew = array_map('StringUtil::uuidToBin', explode(',', $order));
+				$arrNew = array_map('\Contao\StringUtil::uuidToBin', explode(',', $order));
 			}
 
 			// Only proceed if the value has changed
@@ -135,7 +135,7 @@ class FileTree extends Widget
 
 		$arrValue = array_values(array_filter(explode(',', $varInput)));
 
-		return $this->multiple ? array_map('StringUtil::uuidToBin', $arrValue) : StringUtil::uuidToBin($arrValue[0]);
+		return $this->multiple ? array_map('\Contao\StringUtil::uuidToBin', $arrValue) : StringUtil::uuidToBin($arrValue[0]);
 	}
 
 	/**
@@ -345,8 +345,8 @@ class FileTree extends Widget
 		}
 
 		// Convert the binary UUIDs
-		$strSet = implode(',', array_map('StringUtil::binToUuid', $arrSet));
-		$strOrder = $blnHasOrder ? implode(',', array_map('StringUtil::binToUuid', $this->{$this->orderField})) : '';
+		$strSet = implode(',', array_map('\Contao\StringUtil::binToUuid', $arrSet));
+		$strOrder = $blnHasOrder ? implode(',', array_map('\Contao\StringUtil::binToUuid', $this->{$this->orderField})) : '';
 
 		$return = '<input type="hidden" name="' . $this->strName . '" id="ctrl_' . $this->strId . '" value="' . $strSet . '"' . ($this->onchange ? ' onchange="' . $this->onchange . '"' : '') . '>' . ($blnHasOrder ? '
   <input type="hidden" name="' . $this->strOrderName . '" id="ctrl_' . $this->strOrderId . '" value="' . $strOrder . '">' : '') . '

--- a/core-bundle/src/Resources/contao/widgets/PageSelector.php
+++ b/core-bundle/src/Resources/contao/widgets/PageSelector.php
@@ -251,8 +251,7 @@ class PageSelector extends Widget
 	 */
 	public function generateAjax($id, $strField, $level)
 	{
-		if (!Environment::get('isAjaxRequest'))
-		{
+		if (!Environment::get('isAjaxRequest')) {
 			return '';
 		}
 
@@ -260,30 +259,27 @@ class PageSelector extends Widget
 		$this->loadDataContainer($this->strTable);
 
 		// Load current values
-		switch ($GLOBALS['TL_DCA'][$this->strTable]['config']['dataContainer'])
+		if (is_a($GLOBALS['TL_DCA'][$this->strTable]['config']['dataContainer'], DC_File::class, true))
 		{
-			case 'File':
-				if (Config::get($this->strField))
-				{
-					$this->varValue = Config::get($this->strField);
-				}
-				break;
+			if (Config::get($this->strField))
+			{
+				$this->varValue = Config::get($this->strField);
+			}
+		}
 
-			case 'Table':
-				if (!$this->Database->fieldExists($this->strField, $this->strTable))
-				{
-					break;
-				}
-
+		elseif (is_a($GLOBALS['TL_DCA'][$this->strTable]['config']['dataContainer'], DC_Table::class, true))
+		{
+			if ($this->Database->fieldExists($this->strField, $this->strTable))
+			{
 				$objField = $this->Database->prepare("SELECT " . Database::quoteIdentifier($this->strField) . " FROM " . $this->strTable . " WHERE id=?")
-										   ->limit(1)
-										   ->execute($this->strId);
+					->limit(1)
+					->execute($this->strId);
 
 				if ($objField->numRows)
 				{
 					$this->varValue = StringUtil::deserialize($objField->{$this->strField});
 				}
-				break;
+			}
 		}
 
 		$this->getPathNodes();

--- a/core-bundle/src/Resources/contao/widgets/PageSelector.php
+++ b/core-bundle/src/Resources/contao/widgets/PageSelector.php
@@ -260,7 +260,7 @@ class PageSelector extends Widget
 		$this->loadDataContainer($this->strTable);
 
 		// Load current values
-		switch(true)
+		switch (true)
 		{
 			case is_a($GLOBALS['TL_DCA'][$this->strTable]['config']['dataContainer'], DC_File::class, true):
 				if (Config::get($this->strField))

--- a/core-bundle/src/Resources/contao/widgets/PageSelector.php
+++ b/core-bundle/src/Resources/contao/widgets/PageSelector.php
@@ -251,7 +251,8 @@ class PageSelector extends Widget
 	 */
 	public function generateAjax($id, $strField, $level)
 	{
-		if (!Environment::get('isAjaxRequest')) {
+		if (!Environment::get('isAjaxRequest'))
+		{
 			return '';
 		}
 
@@ -266,7 +267,6 @@ class PageSelector extends Widget
 				$this->varValue = Config::get($this->strField);
 			}
 		}
-
 		elseif (is_a($GLOBALS['TL_DCA'][$this->strTable]['config']['dataContainer'], DC_Table::class, true))
 		{
 			if ($this->Database->fieldExists($this->strField, $this->strTable))

--- a/core-bundle/src/Resources/contao/widgets/PageSelector.php
+++ b/core-bundle/src/Resources/contao/widgets/PageSelector.php
@@ -260,17 +260,21 @@ class PageSelector extends Widget
 		$this->loadDataContainer($this->strTable);
 
 		// Load current values
-		if (is_a($GLOBALS['TL_DCA'][$this->strTable]['config']['dataContainer'], DC_File::class, true))
+		switch(true)
 		{
-			if (Config::get($this->strField))
-			{
-				$this->varValue = Config::get($this->strField);
-			}
-		}
-		elseif (is_a($GLOBALS['TL_DCA'][$this->strTable]['config']['dataContainer'], DC_Table::class, true))
-		{
-			if ($this->Database->fieldExists($this->strField, $this->strTable))
-			{
+			case is_a($GLOBALS['TL_DCA'][$this->strTable]['config']['dataContainer'], DC_File::class, true):
+				if (Config::get($this->strField))
+				{
+					$this->varValue = Config::get($this->strField);
+				}
+				break;
+
+			case is_a($GLOBALS['TL_DCA'][$this->strTable]['config']['dataContainer'], DC_Table::class, true):
+				if (!$this->Database->fieldExists($this->strField, $this->strTable))
+				{
+					break;
+				}
+
 				$objField = $this->Database->prepare("SELECT " . Database::quoteIdentifier($this->strField) . " FROM " . $this->strTable . " WHERE id=?")
 					->limit(1)
 					->execute($this->strId);
@@ -279,7 +283,6 @@ class PageSelector extends Widget
 				{
 					$this->varValue = StringUtil::deserialize($objField->{$this->strField});
 				}
-			}
 		}
 
 		$this->getPathNodes();

--- a/core-bundle/src/Resources/contao/widgets/PageSelector.php
+++ b/core-bundle/src/Resources/contao/widgets/PageSelector.php
@@ -276,13 +276,14 @@ class PageSelector extends Widget
 				}
 
 				$objField = $this->Database->prepare("SELECT " . Database::quoteIdentifier($this->strField) . " FROM " . $this->strTable . " WHERE id=?")
-					->limit(1)
-					->execute($this->strId);
+										   ->limit(1)
+										   ->execute($this->strId);
 
 				if ($objField->numRows)
 				{
 					$this->varValue = StringUtil::deserialize($objField->{$this->strField});
 				}
+				break;
 		}
 
 		$this->getPathNodes();

--- a/core-bundle/tests/Config/Loader/PhpFileLoaderTest.php
+++ b/core-bundle/tests/Config/Loader/PhpFileLoaderTest.php
@@ -59,7 +59,7 @@ EOF;
 
         $content = <<<'EOF'
 
-$GLOBALS['TL_DCA']['tl_test'] = ['config' => ['dataContainer' => 'Table', 'sql' => ['keys' => ['id' => 'primary']]], 'fields' => ['id' => ['sql' => "int(10) unsigned NOT NULL auto_increment"]]];
+$GLOBALS['TL_DCA']['tl_test'] = ['config' => ['dataContainer' => 'Contao\DC_Table', 'sql' => ['keys' => ['id' => 'primary']]], 'fields' => ['id' => ['sql' => "int(10) unsigned NOT NULL auto_increment"]]];
 
 EOF;
 
@@ -74,7 +74,7 @@ EOF;
         $expects = <<<'EOF'
 
 namespace Foo\Bar {
-$GLOBALS['TL_DCA']['tl_test']['config']['dataContainer'] = 'Table';
+$GLOBALS['TL_DCA']['tl_test']['config']['dataContainer'] = 'Contao\DC_Table';
 }
 
 EOF;
@@ -90,7 +90,7 @@ EOF;
         $expects = <<<'EOF'
 
 namespace {
-$GLOBALS['TL_DCA']['tl_test']['config']['dataContainer'] = 'Table';
+$GLOBALS['TL_DCA']['tl_test']['config']['dataContainer'] = 'Contao\DC_Table';
 }
 
 EOF;
@@ -127,7 +127,7 @@ EOF;
     {
         $content = <<<'EOF'
 
-$GLOBALS['TL_DCA']['tl_test'] = ['config' => ['dataContainer' => 'Table', 'sql' => ['keys' => ['id' => 'primary']]], 'fields' => ['id' => ['sql' => "int(10) unsigned NOT NULL auto_increment"]]];
+$GLOBALS['TL_DCA']['tl_test'] = ['config' => ['dataContainer' => 'Contao\DC_Table', 'sql' => ['keys' => ['id' => 'primary']]], 'fields' => ['id' => ['sql' => "int(10) unsigned NOT NULL auto_increment"]]];
 
 EOF;
 
@@ -146,7 +146,7 @@ EOF;
     {
         $content = <<<'EOF'
 
-$GLOBALS['TL_DCA']['tl_test'] = ['config' => ['dataContainer' => 'Table', 'sql' => ['keys' => ['id' => 'primary']]], 'fields' => ['id' => ['sql' => "int(10) unsigned NOT NULL auto_increment"]]];
+$GLOBALS['TL_DCA']['tl_test'] = ['config' => ['dataContainer' => 'Contao\DC_Table', 'sql' => ['keys' => ['id' => 'primary']]], 'fields' => ['id' => ['sql' => "int(10) unsigned NOT NULL auto_increment"]]];
 
 EOF;
 
@@ -172,7 +172,7 @@ EOF;
         $content = <<<'EOF'
 
 declare (ticks=1);
-$GLOBALS['TL_DCA']['tl_test'] = ['config' => ['dataContainer' => 'Table', 'sql' => ['keys' => ['id' => 'primary']]], 'fields' => ['id' => ['sql' => "int(10) unsigned NOT NULL auto_increment"]]];
+$GLOBALS['TL_DCA']['tl_test'] = ['config' => ['dataContainer' => 'Contao\DC_Table', 'sql' => ['keys' => ['id' => 'primary']]], 'fields' => ['id' => ['sql' => "int(10) unsigned NOT NULL auto_increment"]]];
 
 EOF;
 

--- a/core-bundle/tests/Config/Loader/PhpFileLoaderTest.php
+++ b/core-bundle/tests/Config/Loader/PhpFileLoaderTest.php
@@ -59,7 +59,7 @@ EOF;
 
         $content = <<<'EOF'
 
-$GLOBALS['TL_DCA']['tl_test'] = ['config' => ['dataContainer' => 'Contao\DC_Table', 'sql' => ['keys' => ['id' => 'primary']]], 'fields' => ['id' => ['sql' => "int(10) unsigned NOT NULL auto_increment"]]];
+$GLOBALS['TL_DCA']['tl_test'] = ['config' => ['dataContainer' => \Contao\DC_Table::class, 'sql' => ['keys' => ['id' => 'primary']]], 'fields' => ['id' => ['sql' => "int(10) unsigned NOT NULL auto_increment"]]];
 
 EOF;
 
@@ -74,7 +74,7 @@ EOF;
         $expects = <<<'EOF'
 
 namespace Foo\Bar {
-$GLOBALS['TL_DCA']['tl_test']['config']['dataContainer'] = 'Contao\DC_Table';
+$GLOBALS['TL_DCA']['tl_test']['config']['dataContainer'] = \Contao\DC_Table::class;
 }
 
 EOF;
@@ -90,7 +90,7 @@ EOF;
         $expects = <<<'EOF'
 
 namespace {
-$GLOBALS['TL_DCA']['tl_test']['config']['dataContainer'] = 'Contao\DC_Table';
+$GLOBALS['TL_DCA']['tl_test']['config']['dataContainer'] = \Contao\DC_Table::class;
 }
 
 EOF;
@@ -127,7 +127,7 @@ EOF;
     {
         $content = <<<'EOF'
 
-$GLOBALS['TL_DCA']['tl_test'] = ['config' => ['dataContainer' => 'Contao\DC_Table', 'sql' => ['keys' => ['id' => 'primary']]], 'fields' => ['id' => ['sql' => "int(10) unsigned NOT NULL auto_increment"]]];
+$GLOBALS['TL_DCA']['tl_test'] = ['config' => ['dataContainer' => \Contao\DC_Table::class, 'sql' => ['keys' => ['id' => 'primary']]], 'fields' => ['id' => ['sql' => "int(10) unsigned NOT NULL auto_increment"]]];
 
 EOF;
 
@@ -146,7 +146,7 @@ EOF;
     {
         $content = <<<'EOF'
 
-$GLOBALS['TL_DCA']['tl_test'] = ['config' => ['dataContainer' => 'Contao\DC_Table', 'sql' => ['keys' => ['id' => 'primary']]], 'fields' => ['id' => ['sql' => "int(10) unsigned NOT NULL auto_increment"]]];
+$GLOBALS['TL_DCA']['tl_test'] = ['config' => ['dataContainer' => \Contao\DC_Table::class, 'sql' => ['keys' => ['id' => 'primary']]], 'fields' => ['id' => ['sql' => "int(10) unsigned NOT NULL auto_increment"]]];
 
 EOF;
 
@@ -172,7 +172,7 @@ EOF;
         $content = <<<'EOF'
 
 declare (ticks=1);
-$GLOBALS['TL_DCA']['tl_test'] = ['config' => ['dataContainer' => 'Contao\DC_Table', 'sql' => ['keys' => ['id' => 'primary']]], 'fields' => ['id' => ['sql' => "int(10) unsigned NOT NULL auto_increment"]]];
+$GLOBALS['TL_DCA']['tl_test'] = ['config' => ['dataContainer' => \Contao\DC_Table::class, 'sql' => ['keys' => ['id' => 'primary']]], 'fields' => ['id' => ['sql' => "int(10) unsigned NOT NULL auto_increment"]]];
 
 EOF;
 

--- a/core-bundle/tests/Fixtures/vendor/contao/test-bundle/Resources/contao/dca/tl_test.php
+++ b/core-bundle/tests/Fixtures/vendor/contao/test-bundle/Resources/contao/dca/tl_test.php
@@ -2,7 +2,7 @@
 
 $GLOBALS['TL_DCA']['tl_test'] = [
     'config' => [
-        'dataContainer' => 'Table',
+        'dataContainer' => Contao\DC_Table::class,
         'sql' => [
             'keys' => [
                 'id' => 'primary',

--- a/core-bundle/tests/Fixtures/vendor/contao/test-bundle/Resources/contao/dca/tl_test_with_declare1.php
+++ b/core-bundle/tests/Fixtures/vendor/contao/test-bundle/Resources/contao/dca/tl_test_with_declare1.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 $GLOBALS['TL_DCA']['tl_test'] = [
     'config' => [
-        'dataContainer' => 'Table',
+        'dataContainer' => Contao\DC_Table::class,
         'sql' => [
             'keys' => [
                 'id' => 'primary',

--- a/core-bundle/tests/Fixtures/vendor/contao/test-bundle/Resources/contao/dca/tl_test_with_declare2.php
+++ b/core-bundle/tests/Fixtures/vendor/contao/test-bundle/Resources/contao/dca/tl_test_with_declare2.php
@@ -4,7 +4,7 @@ declare(    strict_types=1    );
 
 $GLOBALS['TL_DCA']['tl_test'] = [
     'config' => [
-        'dataContainer' => 'Table',
+        'dataContainer' => Contao\DC_Table::class,
         'sql' => [
             'keys' => [
                 'id' => 'primary',

--- a/core-bundle/tests/Fixtures/vendor/contao/test-bundle/Resources/contao/dca/tl_test_with_declare3.php
+++ b/core-bundle/tests/Fixtures/vendor/contao/test-bundle/Resources/contao/dca/tl_test_with_declare3.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
 
 $GLOBALS['TL_DCA']['tl_test'] = [
     'config' => [
-        'dataContainer' => 'Table',
+        'dataContainer' => Contao\DC_Table::class,
         'sql' => [
             'keys' => [
                 'id' => 'primary',

--- a/core-bundle/tests/Fixtures/vendor/contao/test-bundle/Resources/contao/dca/tl_test_with_declare4.php
+++ b/core-bundle/tests/Fixtures/vendor/contao/test-bundle/Resources/contao/dca/tl_test_with_declare4.php
@@ -4,7 +4,7 @@ declare(strict_types  =   1,ticks = 1);
 
 $GLOBALS['TL_DCA']['tl_test'] = [
     'config' => [
-        'dataContainer' => 'Table',
+        'dataContainer' => Contao\DC_Table::class,
         'sql' => [
             'keys' => [
                 'id' => 'primary',

--- a/core-bundle/tests/Fixtures/vendor/contao/test-bundle/Resources/contao/dca/tl_test_with_declare5.php
+++ b/core-bundle/tests/Fixtures/vendor/contao/test-bundle/Resources/contao/dca/tl_test_with_declare5.php
@@ -4,7 +4,7 @@ declare(ticks=1,strict_types=1);
 
 $GLOBALS['TL_DCA']['tl_test'] = [
     'config' => [
-        'dataContainer' => 'Table',
+        'dataContainer' => Contao\DC_Table::class,
         'sql' => [
             'keys' => [
                 'id' => 'primary',

--- a/core-bundle/tests/Fixtures/vendor/contao/test-bundle/Resources/contao/dca/tl_test_with_declare6.php
+++ b/core-bundle/tests/Fixtures/vendor/contao/test-bundle/Resources/contao/dca/tl_test_with_declare6.php
@@ -4,7 +4,7 @@ declare(ticks=1 , strict_types=1);
 
 $GLOBALS['TL_DCA']['tl_test'] = [
     'config' => [
-        'dataContainer' => 'Table',
+        'dataContainer' => Contao\DC_Table::class,
         'sql' => [
             'keys' => [
                 'id' => 'primary',

--- a/core-bundle/tests/Fixtures/vendor/contao/test-bundle/Resources/contao/dca/tl_test_with_namespace1.php
+++ b/core-bundle/tests/Fixtures/vendor/contao/test-bundle/Resources/contao/dca/tl_test_with_namespace1.php
@@ -2,6 +2,8 @@
 
 namespace Foo\Bar;
 
-$GLOBALS['TL_DCA']['tl_test']['config']['dataContainer'] = Contao\DC_Table::class;
+use Contao\DC_Table;
+
+$GLOBALS['TL_DCA']['tl_test']['config']['dataContainer'] = DC_Table::class;
 
 ?>

--- a/core-bundle/tests/Fixtures/vendor/contao/test-bundle/Resources/contao/dca/tl_test_with_namespace1.php
+++ b/core-bundle/tests/Fixtures/vendor/contao/test-bundle/Resources/contao/dca/tl_test_with_namespace1.php
@@ -2,6 +2,6 @@
 
 namespace Foo\Bar;
 
-$GLOBALS['TL_DCA']['tl_test']['config']['dataContainer'] = 'Table';
+$GLOBALS['TL_DCA']['tl_test']['config']['dataContainer'] = Contao\DC_Table::class;
 
 ?>

--- a/core-bundle/tests/Fixtures/vendor/contao/test-bundle/Resources/contao/dca/tl_test_with_namespace2.php
+++ b/core-bundle/tests/Fixtures/vendor/contao/test-bundle/Resources/contao/dca/tl_test_with_namespace2.php
@@ -1,7 +1,7 @@
 <?php
 
 namespace {
-    $GLOBALS['TL_DCA']['tl_test']['config']['dataContainer'] = 'Table';
+    $GLOBALS['TL_DCA']['tl_test']['config']['dataContainer'] = Contao\DC_Table::class;
 }
 
 ?>

--- a/core-bundle/tests/Picker/TablePickerProviderTest.php
+++ b/core-bundle/tests/Picker/TablePickerProviderTest.php
@@ -49,7 +49,7 @@ class TablePickerProviderTest extends ContaoTestCase
 
     public function testSupportsContext(): void
     {
-        $GLOBALS['TL_DCA']['tl_foobar']['config']['dataContainer'] = 'Table';
+        $GLOBALS['TL_DCA']['tl_foobar']['config']['dataContainer'] = Contao\DC_Table::class;
         $GLOBALS['BE_MOD']['foo']['bar']['tables'] = ['tl_foobar'];
 
         $provider = $this->createTableProvider($this->mockFrameworkWithDcaLoader('tl_foobar'));
@@ -76,7 +76,7 @@ class TablePickerProviderTest extends ContaoTestCase
 
     public function testDoesNotSupportContextWithoutModule(): void
     {
-        $GLOBALS['TL_DCA']['tl_foobar']['config']['dataContainer'] = 'Table';
+        $GLOBALS['TL_DCA']['tl_foobar']['config']['dataContainer'] = Contao\DC_Table::class;
         $GLOBALS['BE_MOD']['foo']['bar']['tables'] = ['tl_page'];
 
         $provider = $this->createTableProvider($this->mockFrameworkWithDcaLoader('tl_foobar'));
@@ -251,7 +251,7 @@ class TablePickerProviderTest extends ContaoTestCase
     public function testGetUrlWithoutValue(): void
     {
         $GLOBALS['BE_MOD']['foo']['article'] = ['tables' => ['tl_article']];
-        $GLOBALS['TL_DCA']['tl_article'] = ['config' => ['dataContainer' => 'Table']];
+        $GLOBALS['TL_DCA']['tl_article'] = ['config' => ['dataContainer' => Contao\DC_Table::class]];
 
         $params = [
             'do' => 'article',
@@ -273,7 +273,7 @@ class TablePickerProviderTest extends ContaoTestCase
     public function testGetUrlWithoutPtable(): void
     {
         $GLOBALS['BE_MOD']['foo']['article'] = ['tables' => ['tl_article']];
-        $GLOBALS['TL_DCA']['tl_article'] = ['config' => ['dataContainer' => 'Table']];
+        $GLOBALS['TL_DCA']['tl_article'] = ['config' => ['dataContainer' => Contao\DC_Table::class]];
 
         $params = [
             'do' => 'article',
@@ -295,7 +295,7 @@ class TablePickerProviderTest extends ContaoTestCase
     public function testGetUrlWithPtable(): void
     {
         $GLOBALS['BE_MOD']['foo']['article'] = ['tables' => ['tl_article']];
-        $GLOBALS['TL_DCA']['tl_article'] = ['config' => ['dataContainer' => 'Table', 'ptable' => 'tl_page']];
+        $GLOBALS['TL_DCA']['tl_article'] = ['config' => ['dataContainer' => Contao\DC_Table::class, 'ptable' => 'tl_page']];
 
         $params = [
             'do' => 'article',
@@ -317,7 +317,7 @@ class TablePickerProviderTest extends ContaoTestCase
     public function testGetUrlWithPtableAndMultipleTables(): void
     {
         $GLOBALS['BE_MOD']['foo']['article'] = ['tables' => ['tl_page', 'tl_article']];
-        $GLOBALS['TL_DCA']['tl_article'] = ['config' => ['dataContainer' => 'Table', 'ptable' => 'tl_page']];
+        $GLOBALS['TL_DCA']['tl_article'] = ['config' => ['dataContainer' => Contao\DC_Table::class, 'ptable' => 'tl_page']];
 
         $params = [
             'do' => 'article',
@@ -342,7 +342,7 @@ class TablePickerProviderTest extends ContaoTestCase
     {
         $GLOBALS['BE_MOD']['foo']['article'] = ['tables' => ['tl_article', 'tl_content']];
         $GLOBALS['BE_MOD']['foo']['news'] = ['tables' => ['tl_news', 'tl_content']];
-        $GLOBALS['TL_DCA']['tl_content'] = ['config' => ['dataContainer' => 'Table', 'dynamicPtable' => true]];
+        $GLOBALS['TL_DCA']['tl_content'] = ['config' => ['dataContainer' => Contao\DC_Table::class, 'dynamicPtable' => true]];
 
         $params = [
             'do' => 'news',
@@ -367,7 +367,7 @@ class TablePickerProviderTest extends ContaoTestCase
     {
         $GLOBALS['BE_MOD']['foo']['article'] = ['tables' => ['tl_article', 'tl_content']];
         $GLOBALS['BE_MOD']['foo']['news'] = ['tables' => ['tl_news', 'tl_content']];
-        $GLOBALS['TL_DCA']['tl_content'] = ['config' => ['dataContainer' => 'Table', 'dynamicPtable' => true]];
+        $GLOBALS['TL_DCA']['tl_content'] = ['config' => ['dataContainer' => Contao\DC_Table::class, 'dynamicPtable' => true]];
 
         $params = [
             'do' => 'article',
@@ -391,7 +391,7 @@ class TablePickerProviderTest extends ContaoTestCase
     public function testGetUrlWithoutDbRecordRendersFirstModule(): void
     {
         $GLOBALS['BE_MOD']['foo']['article'] = ['tables' => ['tl_article']];
-        $GLOBALS['TL_DCA']['tl_article'] = ['config' => ['dataContainer' => 'Table', 'ptable' => 'tl_page']];
+        $GLOBALS['TL_DCA']['tl_article'] = ['config' => ['dataContainer' => Contao\DC_Table::class, 'ptable' => 'tl_page']];
 
         $params = [
             'do' => 'article',
@@ -413,7 +413,7 @@ class TablePickerProviderTest extends ContaoTestCase
     public function testGetUrlAddsTableIfItsNotFirstInModule(): void
     {
         $GLOBALS['BE_MOD']['foo']['article'] = ['tables' => ['tl_article', 'tl_content']];
-        $GLOBALS['TL_DCA']['tl_content'] = ['config' => ['dataContainer' => 'Table', 'ptable' => 'tl_article']];
+        $GLOBALS['TL_DCA']['tl_content'] = ['config' => ['dataContainer' => Contao\DC_Table::class, 'ptable' => 'tl_article']];
 
         $params = [
             'do' => 'article',

--- a/core-bundle/tests/Picker/TablePickerProviderTest.php
+++ b/core-bundle/tests/Picker/TablePickerProviderTest.php
@@ -15,6 +15,7 @@ namespace Contao\CoreBundle\Tests\Picker;
 use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\CoreBundle\Picker\PickerConfig;
 use Contao\CoreBundle\Picker\TablePickerProvider;
+use Contao\DC_Table;
 use Contao\DcaLoader;
 use Contao\TestCase\ContaoTestCase;
 use Doctrine\DBAL\Connection;
@@ -49,7 +50,7 @@ class TablePickerProviderTest extends ContaoTestCase
 
     public function testSupportsContext(): void
     {
-        $GLOBALS['TL_DCA']['tl_foobar']['config']['dataContainer'] = Contao\DC_Table::class;
+        $GLOBALS['TL_DCA']['tl_foobar']['config']['dataContainer'] = DC_Table::class;
         $GLOBALS['BE_MOD']['foo']['bar']['tables'] = ['tl_foobar'];
 
         $provider = $this->createTableProvider($this->mockFrameworkWithDcaLoader('tl_foobar'));
@@ -76,7 +77,7 @@ class TablePickerProviderTest extends ContaoTestCase
 
     public function testDoesNotSupportContextWithoutModule(): void
     {
-        $GLOBALS['TL_DCA']['tl_foobar']['config']['dataContainer'] = Contao\DC_Table::class;
+        $GLOBALS['TL_DCA']['tl_foobar']['config']['dataContainer'] = DC_Table::class;
         $GLOBALS['BE_MOD']['foo']['bar']['tables'] = ['tl_page'];
 
         $provider = $this->createTableProvider($this->mockFrameworkWithDcaLoader('tl_foobar'));

--- a/core-bundle/tests/Picker/TablePickerProviderTest.php
+++ b/core-bundle/tests/Picker/TablePickerProviderTest.php
@@ -252,7 +252,7 @@ class TablePickerProviderTest extends ContaoTestCase
     public function testGetUrlWithoutValue(): void
     {
         $GLOBALS['BE_MOD']['foo']['article'] = ['tables' => ['tl_article']];
-        $GLOBALS['TL_DCA']['tl_article'] = ['config' => ['dataContainer' => Contao\DC_Table::class]];
+        $GLOBALS['TL_DCA']['tl_article'] = ['config' => ['dataContainer' => DC_Table::class]];
 
         $params = [
             'do' => 'article',
@@ -274,7 +274,7 @@ class TablePickerProviderTest extends ContaoTestCase
     public function testGetUrlWithoutPtable(): void
     {
         $GLOBALS['BE_MOD']['foo']['article'] = ['tables' => ['tl_article']];
-        $GLOBALS['TL_DCA']['tl_article'] = ['config' => ['dataContainer' => Contao\DC_Table::class]];
+        $GLOBALS['TL_DCA']['tl_article'] = ['config' => ['dataContainer' => DC_Table::class]];
 
         $params = [
             'do' => 'article',
@@ -296,7 +296,7 @@ class TablePickerProviderTest extends ContaoTestCase
     public function testGetUrlWithPtable(): void
     {
         $GLOBALS['BE_MOD']['foo']['article'] = ['tables' => ['tl_article']];
-        $GLOBALS['TL_DCA']['tl_article'] = ['config' => ['dataContainer' => Contao\DC_Table::class, 'ptable' => 'tl_page']];
+        $GLOBALS['TL_DCA']['tl_article'] = ['config' => ['dataContainer' => DC_Table::class, 'ptable' => 'tl_page']];
 
         $params = [
             'do' => 'article',
@@ -318,7 +318,7 @@ class TablePickerProviderTest extends ContaoTestCase
     public function testGetUrlWithPtableAndMultipleTables(): void
     {
         $GLOBALS['BE_MOD']['foo']['article'] = ['tables' => ['tl_page', 'tl_article']];
-        $GLOBALS['TL_DCA']['tl_article'] = ['config' => ['dataContainer' => Contao\DC_Table::class, 'ptable' => 'tl_page']];
+        $GLOBALS['TL_DCA']['tl_article'] = ['config' => ['dataContainer' => DC_Table::class, 'ptable' => 'tl_page']];
 
         $params = [
             'do' => 'article',
@@ -343,7 +343,7 @@ class TablePickerProviderTest extends ContaoTestCase
     {
         $GLOBALS['BE_MOD']['foo']['article'] = ['tables' => ['tl_article', 'tl_content']];
         $GLOBALS['BE_MOD']['foo']['news'] = ['tables' => ['tl_news', 'tl_content']];
-        $GLOBALS['TL_DCA']['tl_content'] = ['config' => ['dataContainer' => Contao\DC_Table::class, 'dynamicPtable' => true]];
+        $GLOBALS['TL_DCA']['tl_content'] = ['config' => ['dataContainer' => DC_Table::class, 'dynamicPtable' => true]];
 
         $params = [
             'do' => 'news',
@@ -368,7 +368,7 @@ class TablePickerProviderTest extends ContaoTestCase
     {
         $GLOBALS['BE_MOD']['foo']['article'] = ['tables' => ['tl_article', 'tl_content']];
         $GLOBALS['BE_MOD']['foo']['news'] = ['tables' => ['tl_news', 'tl_content']];
-        $GLOBALS['TL_DCA']['tl_content'] = ['config' => ['dataContainer' => Contao\DC_Table::class, 'dynamicPtable' => true]];
+        $GLOBALS['TL_DCA']['tl_content'] = ['config' => ['dataContainer' => DC_Table::class, 'dynamicPtable' => true]];
 
         $params = [
             'do' => 'article',
@@ -392,7 +392,7 @@ class TablePickerProviderTest extends ContaoTestCase
     public function testGetUrlWithoutDbRecordRendersFirstModule(): void
     {
         $GLOBALS['BE_MOD']['foo']['article'] = ['tables' => ['tl_article']];
-        $GLOBALS['TL_DCA']['tl_article'] = ['config' => ['dataContainer' => Contao\DC_Table::class, 'ptable' => 'tl_page']];
+        $GLOBALS['TL_DCA']['tl_article'] = ['config' => ['dataContainer' => DC_Table::class, 'ptable' => 'tl_page']];
 
         $params = [
             'do' => 'article',
@@ -414,7 +414,7 @@ class TablePickerProviderTest extends ContaoTestCase
     public function testGetUrlAddsTableIfItsNotFirstInModule(): void
     {
         $GLOBALS['BE_MOD']['foo']['article'] = ['tables' => ['tl_article', 'tl_content']];
-        $GLOBALS['TL_DCA']['tl_content'] = ['config' => ['dataContainer' => Contao\DC_Table::class, 'ptable' => 'tl_article']];
+        $GLOBALS['TL_DCA']['tl_content'] = ['config' => ['dataContainer' => DC_Table::class, 'ptable' => 'tl_article']];
 
         $params = [
             'do' => 'article',

--- a/faq-bundle/src/Resources/contao/dca/tl_faq.php
+++ b/faq-bundle/src/Resources/contao/dca/tl_faq.php
@@ -15,7 +15,7 @@ $GLOBALS['TL_DCA']['tl_faq'] = array
 	// Config
 	'config' => array
 	(
-		'dataContainer'               => 'Table',
+		'dataContainer'               => Contao\DC_Table::class,
 		'ptable'                      => 'tl_faq_category',
 		'enableVersioning'            => true,
 		'markAsCopy'                  => 'question',

--- a/faq-bundle/src/Resources/contao/dca/tl_faq_category.php
+++ b/faq-bundle/src/Resources/contao/dca/tl_faq_category.php
@@ -13,7 +13,7 @@ $GLOBALS['TL_DCA']['tl_faq_category'] = array
 	// Config
 	'config' => array
 	(
-		'dataContainer'               => 'Table',
+		'dataContainer'               => Contao\DC_Table::class,
 		'ctable'                      => array('tl_faq'),
 		'switchToEdit'                => true,
 		'enableVersioning'            => true,

--- a/news-bundle/src/Resources/contao/dca/tl_news.php
+++ b/news-bundle/src/Resources/contao/dca/tl_news.php
@@ -15,7 +15,7 @@ $GLOBALS['TL_DCA']['tl_news'] = array
 	// Config
 	'config' => array
 	(
-		'dataContainer'               => 'Table',
+		'dataContainer'               => Contao\DC_Table::class,
 		'ptable'                      => 'tl_news_archive',
 		'ctable'                      => array('tl_content'),
 		'switchToEdit'                => true,

--- a/news-bundle/src/Resources/contao/dca/tl_news_archive.php
+++ b/news-bundle/src/Resources/contao/dca/tl_news_archive.php
@@ -13,7 +13,7 @@ $GLOBALS['TL_DCA']['tl_news_archive'] = array
 	// Config
 	'config' => array
 	(
-		'dataContainer'               => 'Table',
+		'dataContainer'               => Contao\DC_Table::class,
 		'ctable'                      => array('tl_news'),
 		'switchToEdit'                => true,
 		'enableVersioning'            => true,

--- a/news-bundle/src/Resources/contao/dca/tl_news_feed.php
+++ b/news-bundle/src/Resources/contao/dca/tl_news_feed.php
@@ -13,7 +13,7 @@ $GLOBALS['TL_DCA']['tl_news_feed'] = array
 	// Config
 	'config' => array
 	(
-		'dataContainer'               => 'Table',
+		'dataContainer'               => Contao\DC_Table::class,
 		'enableVersioning'            => true,
 		'markAsCopy'                  => 'title',
 		'onload_callback' => array

--- a/newsletter-bundle/src/Resources/contao/dca/tl_newsletter.php
+++ b/newsletter-bundle/src/Resources/contao/dca/tl_newsletter.php
@@ -13,7 +13,7 @@ $GLOBALS['TL_DCA']['tl_newsletter'] = array
 	// Config
 	'config' => array
 	(
-		'dataContainer'               => 'Table',
+		'dataContainer'               => Contao\DC_Table::class,
 		'ptable'                      => 'tl_newsletter_channel',
 		'enableVersioning'            => true,
 		'markAsCopy'                  => 'subject',

--- a/newsletter-bundle/src/Resources/contao/dca/tl_newsletter_channel.php
+++ b/newsletter-bundle/src/Resources/contao/dca/tl_newsletter_channel.php
@@ -13,7 +13,7 @@ $GLOBALS['TL_DCA']['tl_newsletter_channel'] = array
 	// Config
 	'config' => array
 	(
-		'dataContainer'               => 'Table',
+		'dataContainer'               => Contao\DC_Table::class,
 		'ctable'                      => array('tl_newsletter', 'tl_newsletter_recipients'),
 		'switchToEdit'                => true,
 		'enableVersioning'            => true,

--- a/newsletter-bundle/src/Resources/contao/dca/tl_newsletter_recipients.php
+++ b/newsletter-bundle/src/Resources/contao/dca/tl_newsletter_recipients.php
@@ -13,7 +13,7 @@ $GLOBALS['TL_DCA']['tl_newsletter_recipients'] = array
 	// Config
 	'config' => array
 	(
-		'dataContainer'               => 'Table',
+		'dataContainer'               => Contao\DC_Table::class,
 		'ptable'                      => 'tl_newsletter_channel',
 		'enableVersioning'            => true,
 		'onload_callback' => array


### PR DESCRIPTION
Follow up for #4314

```
Symfony\Component\ErrorHandler\Error\ClassNotFoundError:
Attempted to load class "DC_Table" from the global namespace.
Did you forget a "use" statement?

  at /contao/core-bundle/src/Resources/contao/classes/Backend.php:417
  at Contao\Backend->getBackendModule('page', null)
     (/contao/core-bundle/src/Resources/contao/controllers/BackendMain.php:154)
  at Contao\BackendMain->run()
     (/contao/core-bundle/src/Controller/BackendController.php:49)
  at Contao\CoreBundle\Controller\BackendController->mainAction()
     (vendor/symfony/http-kernel/HttpKernel.php:152)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw(object(Request), 1)
     (vendor/symfony/http-kernel/HttpKernel.php:74)
  at Symfony\Component\HttpKernel\HttpKernel->handle(object(Request), 1, true)
     (vendor/symfony/http-kernel/Kernel.php:202)
  at Symfony\Component\HttpKernel\Kernel->handle(object(Request))
     (public/index.php:43)
```