### PR TITLE
Fix typos in the Environment class

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Environment.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Environment.php
@@ -404,7 +404,7 @@ class Environment
 	}
 
 	/**
-	 * Return the relativ path to the script (e.g. index.php)
+	 * Return the relative path to the script (e.g. index.php)
 	 *
 	 * @return string The relative path to the script
 	 */
@@ -414,7 +414,7 @@ class Environment
 	}
 
 	/**
-	 * Return the relativ path to the script and include the request (e.g. index.php?id=2)
+	 * Return the relative path to the script and include the request (e.g. index.php?id=2)
 	 *
 	 * @return string The relative path to the script including the request string
 	 */


### PR DESCRIPTION
Fixes two minor typos in the Environment class.