### PR TITLE
Ensure the decorated access decision manager shows up in profiler

### DIFF
--- a/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
+++ b/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
@@ -190,6 +190,10 @@ class ContaoCoreExtension extends Extension implements PrependExtensionInterface
                 }
             );
         }
+
+        if ($container->hasParameter('kernel.debug') && $container->getParameter('kernel.debug')) {
+            $loader->load('services_debug.yml');
+        }
     }
 
     public function configureFilesystem(FilesystemConfiguration $config): void

--- a/core-bundle/src/Resources/config/services_debug.yml
+++ b/core-bundle/src/Resources/config/services_debug.yml
@@ -1,0 +1,5 @@
+services:
+    contao.debug.security.access.decision_manager:
+        class: Symfony\Component\Security\Core\Authorization\TraceableAccessDecisionManager
+        arguments:
+            - '@.inner'

--- a/core-bundle/src/Resources/config/services_debug.yml
+++ b/core-bundle/src/Resources/config/services_debug.yml
@@ -1,5 +1,6 @@
 services:
     contao.debug.security.access.decision_manager:
         class: Symfony\Component\Security\Core\Authorization\TraceableAccessDecisionManager
+        decorates: security.access.decision_manager
         arguments:
             - '@.inner'

--- a/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
+++ b/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
@@ -43,6 +43,7 @@ use Symfony\Component\HttpKernel\EventListener\AbstractSessionListener;
 use Symfony\Component\HttpKernel\EventListener\ErrorListener;
 use Symfony\Component\HttpKernel\EventListener\LocaleListener as BaseLocaleListener;
 use Symfony\Component\HttpKernel\EventListener\RouterListener;
+use Symfony\Component\Security\Core\Authorization\TraceableAccessDecisionManager;
 use Symfony\Component\Security\Http\Firewall;
 
 class ContaoCoreExtensionTest extends TestCase
@@ -637,6 +638,25 @@ class ContaoCoreExtensionTest extends TestCase
         ;
 
         (new ContaoCoreExtension())->configureFilesystem($config);
+    }
+
+    public function testRegistersTraceableAccessDecisionMangerInDebug(): void
+    {
+        $container = new ContainerBuilder(
+            new ParameterBag([
+                'kernel.debug' => true,
+                'kernel.charset' => 'UTF-8',
+                'kernel.project_dir' => Path::normalize($this->getTempDir()),
+            ])
+        );
+
+        $extension = new ContaoCoreExtension();
+        $extension->load([], $container);
+
+        $this->assertTrue($container->hasDefinition('contao.debug.security.access.decision_manager'));
+
+        $definition = $container->findDefinition('contao.debug.security.access.decision_manager');
+        $this->assertSame(TraceableAccessDecisionManager::class, $definition->getClass());
     }
 
     public function testRegistersAsContentElementAttribute(): void

--- a/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
+++ b/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
@@ -657,6 +657,7 @@ class ContaoCoreExtensionTest extends TestCase
 
         $definition = $container->findDefinition('contao.debug.security.access.decision_manager');
         $this->assertSame(TraceableAccessDecisionManager::class, $definition->getClass());
+        $this->assertSame('security.access.decision_manager', $definition->getDecoratedService()[0]);
     }
 
     public function testRegistersAsContentElementAttribute(): void


### PR DESCRIPTION
Symfony decorates its own access decision manager in the `security-bundle`. See https://github.com/symfony/symfony/blob/5.4/src/Symfony/Bundle/SecurityBundle/Resources/config/security_debug.php#L20.

However, in the ME, our `core-bundle` is loaded after the `security-bundle` and thus we decorate the already decorated service. We need to duplicate the logic in order to bring back the AD logs in the profiler.