### PR TITLE
Use PHP8 attributes instead of annotations

### DIFF
--- a/core-bundle/src/Entity/CrawlQueue.php
+++ b/core-bundle/src/Entity/CrawlQueue.php
@@ -12,61 +12,43 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Entity;
 
-use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\Index;
+use Doctrine\ORM\Mapping\Table;
 
-/**
- * @ORM\Table(
- *     name="tl_crawl_queue",
- *     indexes={
- *         @ORM\Index(name="job_id", columns={"job_id"}),
- *         @ORM\Index(name="uri_hash", columns={"uri_hash"}),
- *         @ORM\Index(name="processed", columns={"processed"}),
- *     }
- * )
- * @ORM\Entity()
- */
+#[Table(name: 'tl_crawl_queue')]
+#[Entity]
+#[Index(columns: ['job_id'], name: 'job_id')]
+#[Index(columns: ['uri_hash'], name: 'uri_hash')]
+#[Index(columns: ['processed'], name: 'processed')]
 class CrawlQueue
 {
-    /**
-     * @ORM\Id
-     * @ORM\Column(type="integer", options={"unsigned"=true})
-     * @GeneratedValue
-     */
+    #[Id]
+    #[Column(type: 'integer', options: ['unsigned' => true])]
+    #[GeneratedValue]
     public int $id;
 
-    /**
-     * @ORM\Column(name="job_id", type="string", length=128, options={"fixed"=true})
-     */
+    #[Column(name: 'job_id', type: 'string', length: 128, options: ['fixed' => true])]
     public string $jobId;
 
-    /**
-     * @ORM\Column(type="text")
-     */
+    #[Column(type: 'text')]
     public string $uri;
 
-    /**
-     * @ORM\Column(name="uri_hash", type="string", length=40, options={"fixed"=true})
-     */
+    #[Column(name: 'uri_hash', type: 'string', length: 40, options: ['fixed' => true])]
     public string $uriHash;
 
-    /**
-     * @ORM\Column(name="found_on", type="text", nullable=true)
-     */
+    #[Column(name: 'found_on', type: 'text', nullable: true)]
     public ?string $foundOn = null;
 
-    /**
-     * @ORM\Column(type="smallint")
-     */
+    #[Column(type: 'smallint')]
     public int $level;
 
-    /**
-     * @ORM\Column(type="boolean")
-     */
+    #[Column(type: 'boolean')]
     public bool $processed;
 
-    /**
-     * @ORM\Column(type="text", nullable=true)
-     */
+    #[Column(type: 'text', nullable: true)]
     public ?string $tags = null;
 }

--- a/core-bundle/src/Entity/CronJob.php
+++ b/core-bundle/src/Entity/CronJob.php
@@ -12,35 +12,28 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Entity;
 
-use Doctrine\ORM\Mapping as ORM;
+use Contao\CoreBundle\Repository\CronJobRepository;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\Index;
+use Doctrine\ORM\Mapping\Table;
 
-/**
- * @ORM\Table(
- *     name="tl_cron_job",
- *     indexes={
- *         @ORM\Index(name="name", columns={"name"})
- *     }
- * )
- * @ORM\Entity(repositoryClass="Contao\CoreBundle\Repository\CronJobRepository")
- */
+#[Table(name: 'tl_cron_job')]
+#[Entity(repositoryClass: CronJobRepository::class)]
+#[Index(columns: ['name'], name: 'name')]
 class CronJob
 {
-    /**
-     * @ORM\Id
-     * @ORM\Column(type="integer", options={"unsigned"=true})
-     * @GeneratedValue
-     */
+    #[Id]
+    #[Column(type: 'integer', options: ['unsigned' => true])]
+    #[GeneratedValue]
     protected int $id;
 
-    /**
-     * @ORM\Column(type="string", length=255, nullable=false)
-     */
+    #[Column(type: 'string', length: 255, nullable: false)]
     protected string $name;
 
-    /**
-     * @ORM\Column(type="datetime", nullable=false)
-     */
+    #[Column(type: 'datetime', nullable: false)]
     protected \DateTimeInterface $lastRun;
 
     public function __construct(string $name, \DateTimeInterface $lastRun = null)

--- a/core-bundle/src/Entity/RememberMe.php
+++ b/core-bundle/src/Entity/RememberMe.php
@@ -12,60 +12,43 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Entity;
 
-use Doctrine\ORM\Mapping as ORM;
+use Contao\CoreBundle\Repository\RememberMeRepository;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\Index;
+use Doctrine\ORM\Mapping\Table;
 use Doctrine\ORM\Mapping\UniqueConstraint;
 use Symfony\Component\Security\Core\User\UserInterface;
 
-/**
- * @ORM\Table(
- *     name="tl_remember_me",
- *     indexes={
- *         @ORM\Index(name="series", columns={"series"})
- *     },
- *     uniqueConstraints={
- *        @UniqueConstraint(name="value", columns={"value"})
- *    }
- * )
- * @ORM\Entity(repositoryClass="Contao\CoreBundle\Repository\RememberMeRepository")
- */
+#[Table(name: 'tl_remember_me')]
+#[Entity(repositoryClass: RememberMeRepository::class)]
+#[Index(columns: ['series'], name: 'series')]
+#[UniqueConstraint(name: 'value', columns: ['value'])]
 class RememberMe
 {
-    /**
-     * @ORM\Id
-     * @ORM\Column(type="integer", options={"unsigned"=true})
-     * @GeneratedValue
-     */
+    #[Id]
+    #[Column(type: 'integer', options: ['unsigned' => true])]
+    #[GeneratedValue]
     protected int $id;
 
-    /**
-     * @ORM\Column(type="binary_string", length=32, nullable=false, options={"fixed"=true})
-     */
+    #[Column(type: 'binary_string', length: 32, nullable: false, options: ['fixed' => true])]
     protected string $series;
 
-    /**
-     * @ORM\Column(type="binary_string", length=64, nullable=false, options={"fixed"=true})
-     */
+    #[Column(type: 'binary_string', length: 64, nullable: false, options: ['fixed' => true])]
     protected string $value;
 
-    /**
-     * @ORM\Column(type="datetime", nullable=false)
-     */
+    #[Column(type: 'datetime', nullable: false)]
     protected \DateTimeInterface $lastUsed;
 
-    /**
-     * @ORM\Column(type="datetime", nullable=true)
-     */
+    #[Column(type: 'datetime', nullable: true)]
     protected ?\DateTimeInterface $expires = null;
 
-    /**
-     * @ORM\Column(type="string", length=100, nullable=false)
-     */
+    #[Column(type: 'string', length: 100, nullable: false)]
     protected string $class;
 
-    /**
-     * @ORM\Column(type="string", length=200, nullable=false)
-     */
+    #[Column(type: 'string', length: 200, nullable: false)]
     protected string $username;
 
     public function __construct(UserInterface $user, string $series)

--- a/core-bundle/src/Entity/TrustedDevice.php
+++ b/core-bundle/src/Entity/TrustedDevice.php
@@ -13,54 +13,40 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Entity;
 
 use Contao\User;
-use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\Table;
 
-/**
- * @ORM\Entity()
- * @ORM\Table(name="tl_trusted_device")
- */
+#[Entity]
+#[Table(name: 'tl_trusted_device')]
 class TrustedDevice
 {
-    /**
-     * @ORM\Id
-     * @ORM\Column(type="integer")
-     * @ORM\GeneratedValue(strategy="AUTO")
-     */
+    #[Id]
+    #[Column(type: 'integer')]
+    #[GeneratedValue(strategy: 'AUTO')]
     protected ?int $id = null;
 
-    /**
-     * @ORM\Column(type="datetime")
-     */
+    #[Column(type: 'datetime')]
     protected \DateTimeInterface $created;
 
-    /**
-     * @ORM\Column(type="string", nullable=true)
-     */
+    #[Column(type: 'string', nullable: true)]
     protected ?string $userClass = null;
 
-    /**
-     * @ORM\Column(type="integer", nullable=true)
-     */
+    #[Column(type: 'integer', nullable: true)]
     protected ?int $userId = null;
 
-    /**
-     * @ORM\Column(type="text", name="user_agent", nullable=true)
-     */
+    #[Column(name: 'user_agent', type: 'text', nullable: true)]
     protected ?string $userAgent = null;
 
-    /**
-     * @ORM\Column(type="string", name="ua_family", nullable=true)
-     */
+    #[Column(name: 'ua_family', type: 'string', nullable: true)]
     protected ?string $uaFamily = null;
 
-    /**
-     * @ORM\Column(type="string", name="os_family", nullable=true)
-     */
+    #[Column(name: 'os_family', type: 'string', nullable: true)]
     protected ?string $osFamily = null;
 
-    /**
-     * @ORM\Column(type="string", name="device_family", nullable=true)
-     */
+    #[Column(name: 'device_family', type: 'string', nullable: true)]
     protected ?string $deviceFamily = null;
 
     public function __construct(User $user)

--- a/core-bundle/src/Entity/TrustedDevice.php
+++ b/core-bundle/src/Entity/TrustedDevice.php
@@ -19,8 +19,8 @@ use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\Table;
 
-#[Entity]
 #[Table(name: 'tl_trusted_device')]
+#[Entity]
 class TrustedDevice
 {
     #[Id]


### PR DESCRIPTION
Refactored the four mapped entities to use PHP8 attributes instead of annotations.

```
⇢ symfony console doctrine:mapping:info

 Found 4 mapped entities:

 [OK]   Contao\CoreBundle\Entity\RememberMe
 [OK]   Contao\CoreBundle\Entity\CronJob
 [OK]   Contao\CoreBundle\Entity\CrawlQueue
 [OK]   Contao\CoreBundle\Entity\TrustedDevice
```