### PR TITLE
Fix srcToInsertTag() for URL encoded paths

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/StringUtil.php
+++ b/core-bundle/src/Resources/contao/library/Contao/StringUtil.php
@@ -780,7 +780,7 @@ class StringUtil
 				continue;
 			}
 
-			$file = FilesModel::findByPath($paths[$i+3]);
+			$file = FilesModel::findByPath(rawurldecode($paths[$i+3]));
 
 			if ($file !== null)
 			{


### PR DESCRIPTION
If you insert an image in a text element that contains spaces or other url encoded characters in its path, then `StringUtil::srcToInsertTag` will not convert the file path to a `{{file::*}}` insert tag because `FilesModel::findByPath` will not find the image in its url encoded format (TinyMCE stores the URL url encoded).