### PR TITLE
Allow to json-serialize the HtmlAttributes class

### DIFF
--- a/core-bundle/src/String/HtmlAttributes.php
+++ b/core-bundle/src/String/HtmlAttributes.php
@@ -16,7 +16,7 @@ namespace Contao\CoreBundle\String;
  * @implements \IteratorAggregate<string, string>
  * @implements \ArrayAccess<string, string|int|bool|\Stringable|null>
  */
-class HtmlAttributes implements \Stringable, \IteratorAggregate, \ArrayAccess
+class HtmlAttributes implements \Stringable, \JsonSerializable, \IteratorAggregate, \ArrayAccess
 {
     /**
      * @var array<string, string>
@@ -194,6 +194,11 @@ class HtmlAttributes implements \Stringable, \IteratorAggregate, \ArrayAccess
     public function offsetUnset(mixed $offset): void
     {
         unset($this->attributes[$offset]);
+    }
+
+    public function jsonSerialize(): mixed
+    {
+        return $this->attributes;
     }
 
     /**

--- a/core-bundle/tests/String/HtmlAttributesTest.php
+++ b/core-bundle/tests/String/HtmlAttributesTest.php
@@ -344,4 +344,14 @@ class HtmlAttributesTest extends TestCase
         /** @phpstan-ignore-next-line */
         $attributes['foo'];
     }
+
+    public function testCanBeJsonSerialized(): void
+    {
+        $attributes = new HtmlAttributes(['foo' => 'bar', 'baz' => 42]);
+
+        $this->assertSame(
+            '{"foo":"bar","baz":"42"}',
+            json_encode($attributes, JSON_THROW_ON_ERROR)
+        );
+    }
 }

--- a/core-bundle/tests/String/HtmlAttributesTest.php
+++ b/core-bundle/tests/String/HtmlAttributesTest.php
@@ -349,9 +349,6 @@ class HtmlAttributesTest extends TestCase
     {
         $attributes = new HtmlAttributes(['foo' => 'bar', 'baz' => 42]);
 
-        $this->assertSame(
-            '{"foo":"bar","baz":"42"}',
-            json_encode($attributes, JSON_THROW_ON_ERROR)
-        );
+        $this->assertSame('{"foo":"bar","baz":"42"}', json_encode($attributes, JSON_THROW_ON_ERROR));
     }
 }


### PR DESCRIPTION
This is a small upgrade to the `HtmlAttributes` class, that allows it to be serialized with `json_encode()`. I need this functionality for the fragment controller tests of my upcoming PR but figured it would be nice to have anyways.