### PR TITLE
Enable the PhpdocTypesOrderFixer again

### DIFF
--- a/core-bundle/src/DataContainer/PaletteManipulator.php
+++ b/core-bundle/src/DataContainer/PaletteManipulator.php
@@ -74,7 +74,7 @@ class PaletteManipulator
             'fields' => (array) $name,
             'parents' => (array) $parent,
             'position' => $position,
-            'fallback' => is_scalar($fallback) ? [$fallback] : $fallback,
+            'fallback' => \is_scalar($fallback) ? [$fallback] : $fallback,
             'fallbackPosition' => $fallbackPosition,
         ];
 

--- a/core-bundle/src/EventListener/ClearSessionDataListener.php
+++ b/core-bundle/src/EventListener/ClearSessionDataListener.php
@@ -64,7 +64,7 @@ class ClearSessionDataListener
     private function clearLegacyFormData(): void
     {
         if (isset($_SESSION['FORM_DATA']['SUBMITTED_AT'])) {
-            $waitingTime = max(30, (int) ini_get('max_execution_time')) * 2;
+            $waitingTime = max(30, (int) \ini_get('max_execution_time')) * 2;
 
             // Leave the data available for $waitingTime seconds (for redirect confirmation pages)
             if ($_SESSION['FORM_DATA']['SUBMITTED_AT'] + $waitingTime > time()) {

--- a/core-bundle/src/Resources/contao/library/Contao/Config.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Config.php
@@ -341,7 +341,7 @@ class Config
 		}
 
 		// Recompile the APC file (thanks to Trenker)
-		if (\function_exists('apc_compile_file') && !ini_get('apc.stat'))
+		if (\function_exists('apc_compile_file') && !\ini_get('apc.stat'))
 		{
 			apc_compile_file($strDestination);
 		}

--- a/core-bundle/src/Resources/contao/library/Contao/Dbafs.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Dbafs.php
@@ -496,7 +496,7 @@ class Dbafs
 		// Consider the suhosin.memory_limit (see #7035)
 		if (\extension_loaded('suhosin'))
 		{
-			if (($limit = ini_get('suhosin.memory_limit')) !== '')
+			if (($limit = \ini_get('suhosin.memory_limit')) !== '')
 			{
 				@ini_set('memory_limit', $limit);
 			}

--- a/core-bundle/src/Resources/contao/library/Contao/StringUtil.php
+++ b/core-bundle/src/Resources/contao/library/Contao/StringUtil.php
@@ -825,7 +825,7 @@ class StringUtil
 	 */
 	public static function convertEncoding($str, $to, $from=null)
 	{
-		if ($str !== null && !is_scalar($str) && !(\is_object($str) && method_exists($str, '__toString')))
+		if ($str !== null && !\is_scalar($str) && !(\is_object($str) && method_exists($str, '__toString')))
 		{
 			trigger_deprecation('contao/core-bundle', '4.9', 'Passing a non-stringable argument to StringUtil::convertEncoding() has been deprecated an will no longer work in Contao 5.0.');
 

--- a/core-bundle/src/Resources/contao/library/Contao/ZipReader.php
+++ b/core-bundle/src/Resources/contao/library/Contao/ZipReader.php
@@ -423,7 +423,7 @@ class ZipReader
 		$strMbCharset = null;
 
 		// Set the mbstring encoding to ASCII (see #5842)
-		if (ini_get('mbstring.func_overload') > 0)
+		if (\ini_get('mbstring.func_overload') > 0)
 		{
 			$strMbCharset = mb_internal_encoding();
 

--- a/core-bundle/src/Security/Voter/BackendAccessVoter.php
+++ b/core-bundle/src/Security/Voter/BackendAccessVoter.php
@@ -100,7 +100,7 @@ class BackendAccessVoter extends Voter implements ResetInterface
      */
     private function hasAccess($subject, string $field, BackendUser $user): bool
     {
-        if (!is_scalar($subject) && !\is_array($subject)) {
+        if (!\is_scalar($subject) && !\is_array($subject)) {
             return false;
         }
 

--- a/installation-bundle/src/Controller/InstallationController.php
+++ b/installation-bundle/src/Controller/InstallationController.php
@@ -248,7 +248,7 @@ class InstallationController implements ContainerAwareInterface
             opcache_reset();
         }
 
-        if (\function_exists('apc_clear_cache') && !ini_get('apc.stat')) {
+        if (\function_exists('apc_clear_cache') && !\ini_get('apc.stat')) {
             apc_clear_cache();
         }
     }
@@ -277,7 +277,7 @@ class InstallationController implements ContainerAwareInterface
             opcache_reset();
         }
 
-        if (\function_exists('apc_clear_cache') && !ini_get('apc.stat')) {
+        if (\function_exists('apc_clear_cache') && !\ini_get('apc.stat')) {
             apc_clear_cache();
         }
     }

--- a/manager-bundle/src/Command/ContaoSetupCommand.php
+++ b/manager-bundle/src/Command/ContaoSetupCommand.php
@@ -67,7 +67,7 @@ class ContaoSetupCommand extends Command
 
         $php = [
             $this->phpPath,
-            '-dmemory_limit='.ini_get('memory_limit'),
+            '-dmemory_limit='.\ini_get('memory_limit'),
         ];
 
         if (OutputInterface::VERBOSITY_DEBUG === $output->getVerbosity()) {

--- a/tools/ecs/composer.lock
+++ b/tools/ecs/composer.lock
@@ -177,32 +177,32 @@
         },
         {
             "name": "slevomat/coding-standard",
-            "version": "7.0.18",
+            "version": "7.0.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/slevomat/coding-standard.git",
-                "reference": "b81ac84f41a4797dc25c8ede1b0718e2a74be0fc"
+                "reference": "cbfadfe34c2c29473bf1e891306b3950b3b4350b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/b81ac84f41a4797dc25c8ede1b0718e2a74be0fc",
-                "reference": "b81ac84f41a4797dc25c8ede1b0718e2a74be0fc",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/cbfadfe34c2c29473bf1e891306b3950b3b4350b",
+                "reference": "cbfadfe34c2c29473bf1e891306b3950b3b4350b",
                 "shasum": ""
             },
             "require": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7",
                 "php": "^7.1 || ^8.0",
                 "phpstan/phpdoc-parser": "^1.0.0",
-                "squizlabs/php_codesniffer": "^3.6.1"
+                "squizlabs/php_codesniffer": "^3.6.2"
             },
             "require-dev": {
-                "phing/phing": "2.17.0",
-                "php-parallel-lint/php-parallel-lint": "1.3.1",
-                "phpstan/phpstan": "1.2.0",
+                "phing/phing": "2.17.2",
+                "php-parallel-lint/php-parallel-lint": "1.3.2",
+                "phpstan/phpstan": "1.4.10|1.5.0",
                 "phpstan/phpstan-deprecation-rules": "1.0.0",
                 "phpstan/phpstan-phpunit": "1.0.0",
                 "phpstan/phpstan-strict-rules": "1.1.0",
-                "phpunit/phpunit": "7.5.20|8.5.21|9.5.10"
+                "phpunit/phpunit": "7.5.20|8.5.21|9.5.19"
             },
             "type": "phpcodesniffer-standard",
             "extra": {
@@ -222,7 +222,7 @@
             "description": "Slevomat Coding Standard for PHP_CodeSniffer complements Consistence Coding Standard by providing sniffs with additional checks.",
             "support": {
                 "issues": "https://github.com/slevomat/coding-standard/issues",
-                "source": "https://github.com/slevomat/coding-standard/tree/7.0.18"
+                "source": "https://github.com/slevomat/coding-standard/tree/7.0.20"
             },
             "funding": [
                 {
@@ -234,7 +234,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-12-07T17:19:06+00:00"
+            "time": "2022-03-25T09:43:20+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -294,16 +294,16 @@
         },
         {
             "name": "symplify/easy-coding-standard",
-            "version": "10.0.21",
+            "version": "10.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symplify/easy-coding-standard.git",
-                "reference": "740472eebb80b17ab48d753fe6e2c5625e82ca43"
+                "reference": "3fdbead9da24889727dc11804e9bbfb9d4502d3a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symplify/easy-coding-standard/zipball/740472eebb80b17ab48d753fe6e2c5625e82ca43",
-                "reference": "740472eebb80b17ab48d753fe6e2c5625e82ca43",
+                "url": "https://api.github.com/repos/symplify/easy-coding-standard/zipball/3fdbead9da24889727dc11804e9bbfb9d4502d3a",
+                "reference": "3fdbead9da24889727dc11804e9bbfb9d4502d3a",
                 "shasum": ""
             },
             "require": {
@@ -333,7 +333,7 @@
             ],
             "description": "Prefixed scoped version of ECS package",
             "support": {
-                "source": "https://github.com/symplify/easy-coding-standard/tree/10.0.21"
+                "source": "https://github.com/symplify/easy-coding-standard/tree/10.1.4"
             },
             "funding": [
                 {
@@ -345,7 +345,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-02-04T16:37:35+00:00"
+            "time": "2022-03-16T15:18:55+00:00"
         }
     ],
     "packages-dev": [],

--- a/tools/ecs/config/default.php
+++ b/tools/ecs/config/default.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use PhpCsFixer\Fixer\Comment\HeaderCommentFixer;
-use PhpCsFixer\Fixer\Phpdoc\PhpdocTypesOrderFixer;
 use PhpCsFixer\Fixer\Whitespace\MethodChainingIndentationFixer;
 use SlevomatCodingStandard\Sniffs\Variables\UnusedVariableSniff;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
@@ -23,8 +22,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             '*/DependencyInjection/Configuration.php',
             '*/Resources/config/*.php',
         ],
-        // TODO: enable this again once https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/6243 has been merged
-        PhpdocTypesOrderFixer::class => null,
         UnusedVariableSniff::class => [
             'core-bundle/tests/Session/Attribute/ArrayAttributeBagTest.php',
             'manager-bundle/src/Resources/skeleton/*.php',

--- a/tools/isolated-tests/src/RunTestsIsolatedCommand.php
+++ b/tools/isolated-tests/src/RunTestsIsolatedCommand.php
@@ -71,7 +71,7 @@ class RunTestsIsolatedCommand extends Command
 
         $php = [
             $this->phpPath,
-            '-dmemory_limit='.ini_get('memory_limit'),
+            '-dmemory_limit='.\ini_get('memory_limit'),
         ];
 
         if (OutputInterface::VERBOSITY_DEBUG === $output->getVerbosity()) {


### PR DESCRIPTION
This can be enabled now that https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/6243 has been merged.

Originally added [here](https://github.com/contao/contao/commit/4849881532595317a5c8ef7b99a9677b88f08ebf#diff-a95817c1c2b59c07bf78b5c0565bdf836c7459dee80a13573ae1689c04440040).

I originally created PR https://github.com/contao/contao/pull/4392 but couldn't seem to switch the base branch.