### PR TITLE
Fix several VFS bugs

### DIFF
--- a/core-bundle/src/EventListener/DbafsMetadataSubscriber.php
+++ b/core-bundle/src/EventListener/DbafsMetadataSubscriber.php
@@ -12,8 +12,8 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\EventListener;
 
-use Contao\CoreBundle\Event\AbstractDbafsMetadataEvent;
 use Contao\CoreBundle\File\Metadata;
+use Contao\CoreBundle\Filesystem\Dbafs\AbstractDbafsMetadataEvent;
 use Contao\CoreBundle\Filesystem\Dbafs\RetrieveDbafsMetadataEvent;
 use Contao\CoreBundle\Filesystem\Dbafs\StoreDbafsMetadataEvent;
 use Contao\Image\ImportantPart;

--- a/core-bundle/src/Filesystem/Dbafs/AbstractDbafsMetadataEvent.php
+++ b/core-bundle/src/Filesystem/Dbafs/AbstractDbafsMetadataEvent.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
  * @license LGPL-3.0-or-later
  */
 
-namespace Contao\CoreBundle\Event;
+namespace Contao\CoreBundle\Filesystem\Dbafs;
 
 use Symfony\Component\Uid\Uuid;
 

--- a/core-bundle/src/Filesystem/Dbafs/DbafsManager.php
+++ b/core-bundle/src/Filesystem/Dbafs/DbafsManager.php
@@ -300,7 +300,7 @@ class DbafsManager
     }
 
     /**
-     * @return \Generator<string, DbafsInterface>
+     * @return \Generator<string, DbafsInterface|null>
      */
     private function getDbafsForPath(string $path): \Generator
     {

--- a/core-bundle/src/Filesystem/Dbafs/DbafsManager.php
+++ b/core-bundle/src/Filesystem/Dbafs/DbafsManager.php
@@ -91,9 +91,9 @@ class DbafsManager
      */
     public function resolveUuid(Uuid $uuid, string $prefix = ''): string
     {
-        foreach ($this->getCandidatesForPrefix($prefix) as $dbafs) {
+        foreach ($this->getCandidatesForPrefix($prefix) as $dbafsPrefix => $dbafs) {
             if (null !== ($path = $dbafs->getPathFromUuid($uuid))) {
-                return Path::makeRelative($path, $prefix);
+                return Path::makeRelative(Path::join($dbafsPrefix, $path), $prefix);
             }
         }
 
@@ -288,19 +288,19 @@ class DbafsManager
     }
 
     /**
-     * @return \Generator<DbafsInterface>
+     * @return \Generator<string, DbafsInterface>
      */
     private function getCandidatesForPrefix(string $prefix): \Generator
     {
         foreach ($this->dbafs as $dbafsPrefix => $dbafs) {
             if (Path::isBasePath("/$prefix", "/$dbafsPrefix")) {
-                yield $dbafs;
+                yield $dbafsPrefix => $dbafs;
             }
         }
     }
 
     /**
-     * @return \Generator<string, DbafsInterface|null>
+     * @return \Generator<string, DbafsInterface>
      */
     private function getDbafsForPath(string $path): \Generator
     {

--- a/core-bundle/src/Filesystem/Dbafs/RetrieveDbafsMetadataEvent.php
+++ b/core-bundle/src/Filesystem/Dbafs/RetrieveDbafsMetadataEvent.php
@@ -12,8 +12,6 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Filesystem\Dbafs;
 
-use Contao\CoreBundle\Event\AbstractDbafsMetadataEvent;
-
 class RetrieveDbafsMetadataEvent extends AbstractDbafsMetadataEvent
 {
     /**

--- a/core-bundle/src/Filesystem/Dbafs/StoreDbafsMetadataEvent.php
+++ b/core-bundle/src/Filesystem/Dbafs/StoreDbafsMetadataEvent.php
@@ -12,8 +12,6 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Filesystem\Dbafs;
 
-use Contao\CoreBundle\Event\AbstractDbafsMetadataEvent;
-
 class StoreDbafsMetadataEvent extends AbstractDbafsMetadataEvent
 {
     /**

--- a/core-bundle/src/Filesystem/VirtualFilesystemInterface.php
+++ b/core-bundle/src/Filesystem/VirtualFilesystemInterface.php
@@ -126,6 +126,14 @@ interface VirtualFilesystemInterface
      * @throws VirtualFilesystemException
      * @throws UnableToResolveUuidException
      */
+    public function get($location, int $accessFlags = self::NONE): ?FilesystemItem;
+
+    /**
+     * @param string|Uuid $location
+     *
+     * @throws VirtualFilesystemException
+     * @throws UnableToResolveUuidException
+     */
     public function listContents($location, bool $deep = false, int $accessFlags = self::NONE): FilesystemItemIterator;
 
     /**

--- a/core-bundle/tests/Filesystem/Dbafs/DbafsManagerTest.php
+++ b/core-bundle/tests/Filesystem/Dbafs/DbafsManagerTest.php
@@ -114,15 +114,15 @@ class DbafsManagerTest extends TestCase
 
         $manager->register(
             $this->getDbafsCoveringUuids([
-                'foo/a' => $uuid1,
-                'foo/bar/b' => $uuid2,
+                'a' => $uuid1,
+                'bar/b' => $uuid2,
             ]),
             'foo'
         );
 
         $manager->register(
             $this->getDbafsCoveringUuids([
-                'other/c' => $uuid3,
+                'c' => $uuid3,
             ]),
             'other'
         );

--- a/core-bundle/tests/Filesystem/VirtualFilesystemTest.php
+++ b/core-bundle/tests/Filesystem/VirtualFilesystemTest.php
@@ -427,16 +427,12 @@ class VirtualFilesystemTest extends TestCase
         $mountManager = $this->createMock(MountManager::class);
         $mountManager
             ->method('fileExists')
-            ->willReturnCallback(
-                static fn (string $path): bool => 'foo/file_a' === $path
-            )
+            ->willReturnCallback(static fn (string $path): bool => 'foo/file_a' === $path)
         ;
 
         $mountManager
             ->method('directoryExists')
-            ->willReturnCallback(
-                static fn (string $path): bool => 'foo/dir_a' === $path
-            )
+            ->willReturnCallback(static fn (string $path): bool => 'foo/dir_a' === $path)
         ;
 
         $mountManager

--- a/core-bundle/tests/Filesystem/VirtualFilesystemTest.php
+++ b/core-bundle/tests/Filesystem/VirtualFilesystemTest.php
@@ -12,6 +12,8 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Tests\Filesystem;
 
+use Contao\CoreBundle\Filesystem\Dbafs\ChangeSet;
+use Contao\CoreBundle\Filesystem\Dbafs\DbafsInterface;
 use Contao\CoreBundle\Filesystem\Dbafs\DbafsManager;
 use Contao\CoreBundle\Filesystem\Dbafs\UnableToResolveUuidException;
 use Contao\CoreBundle\Filesystem\FilesystemItem;
@@ -416,6 +418,152 @@ class VirtualFilesystemTest extends TestCase
 
         $filesystem->move('path', 'to/path', ['some' => 'option']);
         $filesystem->move($this->defaultUuid, 'to/path', ['some' => 'option']);
+    }
+
+    public function testGetFilesystemItems(): void
+    {
+        $handlerInvocationCount = 0;
+
+        $mountManager = $this->createMock(MountManager::class);
+        $mountManager
+            ->method('fileExists')
+            ->willReturnCallback(
+                static fn (string $path): bool => 'foo/file_a' === $path
+            )
+        ;
+
+        $mountManager
+            ->method('directoryExists')
+            ->willReturnCallback(
+                static fn (string $path): bool => 'foo/dir_a' === $path
+            )
+        ;
+
+        $mountManager
+            ->method('getLastModified')
+            ->willReturnCallback(
+                static function () use (&$handlerInvocationCount): int {
+                    ++$handlerInvocationCount;
+
+                    return 54321;
+                }
+            )
+        ;
+
+        $mountManager
+            ->method('getFileSize')
+            ->willReturnCallback(
+                static function () use (&$handlerInvocationCount): int {
+                    ++$handlerInvocationCount;
+
+                    return 2048;
+                }
+            )
+        ;
+
+        $mountManager
+            ->method('getMimeType')
+            ->willReturnCallback(
+                static function () use (&$handlerInvocationCount): string {
+                    ++$handlerInvocationCount;
+
+                    return 'text/csv';
+                }
+            )
+        ;
+
+        $dbafs = $this->createMock(DbafsInterface::class);
+        $dbafs
+            ->method('getSupportedFeatures')
+            ->willReturn(DbafsInterface::FEATURE_LAST_MODIFIED | DbafsInterface::FEATURE_FILE_SIZE | DbafsInterface::FEATURE_MIME_TYPE)
+        ;
+
+        $dbafs
+            ->method('getRecord')
+            ->willReturnCallback(
+                static function (string $path) use (&$handlerInvocationCount): ?FilesystemItem {
+                    $items = [
+                        'file_b' => new FilesystemItem(
+                            true,
+                            'foo/file_b',
+                            static function () use (&$handlerInvocationCount) {
+                                ++$handlerInvocationCount;
+
+                                return 12345;
+                            },
+                            static function () use (&$handlerInvocationCount) {
+                                ++$handlerInvocationCount;
+
+                                return 1024;
+                            },
+                            static function () use (&$handlerInvocationCount) {
+                                ++$handlerInvocationCount;
+
+                                return 'image/png';
+                            },
+                            static function () use (&$handlerInvocationCount) {
+                                ++$handlerInvocationCount;
+
+                                return ['extra'];
+                            },
+                        ),
+                        'dir_b' => new FilesystemItem(false, 'foo/dir_b'),
+                    ];
+
+                    return $items[$path] ?? null;
+                }
+            )
+        ;
+
+        $dbafs
+            ->expects($this->once())
+            ->method('sync')
+            ->willReturn(new ChangeSet([], [], []))
+        ;
+
+        $dbafsManager = new DbafsManager();
+        $dbafsManager->register($dbafs, 'foo');
+
+        $filesystem = new VirtualFilesystem($mountManager, $dbafsManager, 'foo');
+
+        // Read from the MountManager
+        $this->assertNull($filesystem->get('non-existing', VirtualFilesystemInterface::BYPASS_DBAFS));
+
+        $directoryA = $filesystem->get('dir_a', VirtualFilesystemInterface::BYPASS_DBAFS);
+        $fileA = $filesystem->get('file_a', VirtualFilesystemInterface::BYPASS_DBAFS);
+
+        $this->assertInstanceOf(FilesystemItem::class, $directoryA);
+        $this->assertFalse($directoryA->isFile());
+        $this->assertSame('foo/dir_a', $directoryA->getPath());
+
+        $this->assertInstanceOf(FilesystemItem::class, $fileA);
+        $this->assertTrue($fileA->isFile());
+
+        $this->assertSame(0, $handlerInvocationCount);
+        $this->assertSame(54321, $fileA->getLastModified());
+        $this->assertSame(2048, $fileA->getFileSize());
+        $this->assertSame('text/csv', $fileA->getMimeType());
+        $this->assertSame(3, $handlerInvocationCount);
+
+        // Read from the DbafsManager
+        $this->assertNull($filesystem->get('non-existing'));
+
+        $directoryB = $filesystem->get('dir_b', VirtualFilesystemInterface::FORCE_SYNC);
+        $fileB = $filesystem->get('file_b');
+
+        $this->assertInstanceOf(FilesystemItem::class, $directoryB);
+        $this->assertFalse($directoryB->isFile());
+        $this->assertSame('foo/dir_b', $directoryB->getPath());
+
+        $this->assertInstanceOf(FilesystemItem::class, $fileB);
+        $this->assertTrue($fileB->isFile());
+
+        $this->assertSame(3, $handlerInvocationCount);
+        $this->assertSame(12345, $fileB->getLastModified());
+        $this->assertSame(1024, $fileB->getFileSize());
+        $this->assertSame('image/png', $fileB->getMimeType());
+        $this->assertSame(['extra'], $fileB->getExtraMetadata());
+        $this->assertSame(7, $handlerInvocationCount);
     }
 
     /**

--- a/core-bundle/tests/Filesystem/VirtualFilesystemTest.php
+++ b/core-bundle/tests/Filesystem/VirtualFilesystemTest.php
@@ -504,7 +504,7 @@ class VirtualFilesystemTest extends TestCase
                             static function () use (&$handlerInvocationCount) {
                                 ++$handlerInvocationCount;
 
-                                return ['extra'];
+                                return ['extra' => 'data'];
                             },
                         ),
                         'dir_b' => new FilesystemItem(false, 'foo/dir_b'),
@@ -540,9 +540,12 @@ class VirtualFilesystemTest extends TestCase
         $this->assertTrue($fileA->isFile());
 
         $this->assertSame(0, $handlerInvocationCount);
+
         $this->assertSame(54321, $fileA->getLastModified());
         $this->assertSame(2048, $fileA->getFileSize());
         $this->assertSame('text/csv', $fileA->getMimeType());
+
+        /** @phpstan-ignore-next-line */
         $this->assertSame(3, $handlerInvocationCount);
 
         // Read from the DbafsManager
@@ -558,11 +561,15 @@ class VirtualFilesystemTest extends TestCase
         $this->assertInstanceOf(FilesystemItem::class, $fileB);
         $this->assertTrue($fileB->isFile());
 
+        /** @phpstan-ignore-next-line */
         $this->assertSame(3, $handlerInvocationCount);
+
         $this->assertSame(12345, $fileB->getLastModified());
         $this->assertSame(1024, $fileB->getFileSize());
         $this->assertSame('image/png', $fileB->getMimeType());
-        $this->assertSame(['extra'], $fileB->getExtraMetadata());
+        $this->assertSame(['extra' => 'data'], $fileB->getExtraMetadata());
+
+        /** @phpstan-ignore-next-line */
         $this->assertSame(7, $handlerInvocationCount);
     }
 


### PR DESCRIPTION
This PR fixes two bugs and a major shortcoming in the VFS implementation:

1) The `AbstractDbafsMetadataEvent` was still in the wrong namespace (contrary to the two child classes). I did not notice it until I wanted to add things in Contao 5. :see_no_evil: It's moved now. [eb11863cbcca142cb200b8865dec1faba4b99b74]
2) There was an issue with prefixed `Dbafs` implementations when retrieving items by UUID. At least the tests were wrong as well. [7906b75d8b4dd8deaad0c90f97d1b1fd8948a8ba]
3) There was currently no way to get a `FilesystemItem` except when listing directories, therefore there is now a `get()` method. As this should also be in the interface, we IMHO need to add this to here (4.13) as well. This is kind of an important part if you want to pass around `FilesystemItems` and use their lazy nature. [964ff70e239a6e58517d4225a726b3412dd93772]