### PR TITLE
Fixed nested http client options not supported

### DIFF
--- a/core-bundle/src/DependencyInjection/Configuration.php
+++ b/core-bundle/src/DependencyInjection/Configuration.php
@@ -414,7 +414,7 @@ class Configuration implements ConfigurationInterface
                 ->end()
                 ->arrayNode('default_http_client_options')
                     ->info('Allows to configure the default HttpClient options (useful for proxy settings, SSL certificate validation and more).')
-                    ->prototype('scalar')->end()
+                    ->prototype('variable')->end()
                     ->defaultValue([])
                 ->end()
             ->end()

--- a/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
+++ b/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
@@ -3492,6 +3492,9 @@ class ContaoCoreExtensionTest extends TestCase
                         ],
                         'default_http_client_options' => [
                             'proxy' => 'http://localhost:7080',
+                            'headers' => [
+                                'Foo' => 'Bar'
+                            ],
                         ],
                     ],
                 ],
@@ -3506,7 +3509,7 @@ class ContaoCoreExtensionTest extends TestCase
                 new Reference('database_connection'),
                 new Reference('contao.framework'),
                 ['https://example.com'],
-                ['proxy' => 'http://localhost:7080'],
+                ['proxy' => 'http://localhost:7080', 'headers' => ['Foo' => 'Bar']],
             ],
             $definition->getArguments()
         );

--- a/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
+++ b/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
@@ -3493,7 +3493,7 @@ class ContaoCoreExtensionTest extends TestCase
                         'default_http_client_options' => [
                             'proxy' => 'http://localhost:7080',
                             'headers' => [
-                                'Foo' => 'Bar'
+                                'Foo' => 'Bar',
                             ],
                         ],
                     ],


### PR DESCRIPTION
Fixes https://github.com/contao/contao/issues/4387

I tried getting the options from the framework bundle but it's too complicated and I don't care enough to pursue it.