### PR TITLE
Cache handling for start and stop dates

### DIFF
--- a/calendar-bundle/src/Resources/contao/classes/Events.php
+++ b/calendar-bundle/src/Resources/contao/classes/Events.php
@@ -342,7 +342,7 @@ abstract class Events extends Module
 			$arrEvent['details'] = function () use ($id)
 			{
 				$strDetails = '';
-				$objElement = ContentModel::findPublishedByPidAndTable($id, 'tl_calendar_events');
+				$objElement = ContentModel::findVisibleByPidAndTable($id, 'tl_calendar_events');
 
 				if ($objElement !== null)
 				{

--- a/core-bundle/src/Resources/contao/elements/ContentModule.php
+++ b/core-bundle/src/Resources/contao/elements/ContentModule.php
@@ -10,6 +10,9 @@
 
 namespace Contao;
 
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\HttpCache\ResponseCacheStrategyInterface;
+
 /**
  * Front end content element "module".
  *
@@ -96,6 +99,15 @@ class ContentModule extends ContentElement
 		{
 			$responseTagger = System::getContainer()->get('fos_http_cache.http.symfony_response_tagger');
 			$responseTagger->addTags(array('contao.db.tl_content.' . $this->id));
+		}
+
+		if ($this->stop && $this->stop > time())
+		{
+			$response = new Response();
+			$response->setPublic();
+			$response->setMaxAge((int) $this->stop - time());
+
+			System::getContainer()->get(ResponseCacheStrategyInterface::class)->add($response);
 		}
 
 		$strBuffer = $objModule->generate();


### PR DESCRIPTION
After some long discussions with @m-vo regarding https://github.com/contao/contao/issues/4386, here's a draft the solution we came up with.

It basically boils down to _it was always wrong_, but we somehow knew that. Some might remember https://github.com/aschempp/contao/commit/245abdd80024e79c2108c1f122146c8015b91fc9 which I did about a year ago during a public call. It was also a foundation for https://github.com/contao/contao/pull/4393, though that seems to be targeted at Contao 5.

However, this is a bugfix since it is currently wrong in Contao. @m-vo and I discussed and agreed that a content element must be responsibility for its cache time, the same as with cache tags.

The difficult thing is that an element (or article) with a start date in the future is not parsed by the system, but it should be to affect the cache time. And that's why `AbstractContentElementController::addSharedMaxAgeToResponse` was always wrong, because it (probably) adds a start time to an element that should not have been generated in the first place.

There are now two cases handled in the core modules:
 1. if an element has a start date in the future (and not a stop date in the past, since that would be invalid), a (empty/fake) response is added to the `ResponseCacheStrategy` to make sure the _main page_ cache is cleared at the point in time when the element should become visible

 2. alternatively, if an element has a stop date in the future, the stop date is added to also reset the page cache at that time.

 There is some special hacking magic regarding news and events, since they lazily generate their content elements if requested by the template. The element **count** (`->hasDetails`) is always the _currently available elements_, so we lazily check whether elements were generated and otherwise check to add a fake response for upcoming elements.
This does unfortunately not work for event lists (or it would be very hard to do), so I skipped that for now.