### PR TITLE
Some small improvements for the HtmlAttribute class

### DIFF
--- a/core-bundle/src/String/HtmlAttributes.php
+++ b/core-bundle/src/String/HtmlAttributes.php
@@ -49,6 +49,10 @@ class HtmlAttributes implements \Stringable, \JsonSerializable, \IteratorAggrega
      */
     public function mergeWith(iterable|string|self|null $attributes = null): self
     {
+        if (empty($attributes)) {
+            return $this;
+        }
+
         // Merge values if possible, set them otherwise
         $mergeSet = function (string $name, string|int|bool|\Stringable|null $value): void {
             if ('class' === $name) {
@@ -70,7 +74,7 @@ class HtmlAttributes implements \Stringable, \JsonSerializable, \IteratorAggrega
             return $this;
         }
 
-        foreach ($attributes ?? [] as $name => $value) {
+        foreach ($attributes as $name => $value) {
             $mergeSet($name, $value);
         }
 

--- a/core-bundle/src/String/HtmlAttributes.php
+++ b/core-bundle/src/String/HtmlAttributes.php
@@ -130,6 +130,10 @@ class HtmlAttributes implements \Stringable, \JsonSerializable, \IteratorAggrega
             array_unique($this->split(($this->attributes['class'] ?? '').' '.implode(' ', $classes)))
         );
 
+        if (empty($this->attributes['class'])) {
+            unset($this->attributes['class']);
+        }
+
         return $this;
     }
 
@@ -142,6 +146,10 @@ class HtmlAttributes implements \Stringable, \JsonSerializable, \IteratorAggrega
                 $this->split(implode(' ', $classes))
             )
         );
+
+        if (empty($this->attributes['class'])) {
+            unset($this->attributes['class']);
+        }
 
         return $this;
     }

--- a/core-bundle/src/String/HtmlAttributes.php
+++ b/core-bundle/src/String/HtmlAttributes.php
@@ -82,7 +82,7 @@ class HtmlAttributes implements \Stringable, \JsonSerializable, \IteratorAggrega
      * property will be unset instead. All values will be coerced to strings,
      * whereby null and true will result in an empty string.
      */
-    public function set(string $name, string|int|bool|\Stringable|null $value): self
+    public function set(string $name, string|int|bool|\Stringable|null $value = true): self
     {
         $name = strtolower($name);
 

--- a/core-bundle/tests/String/HtmlAttributesTest.php
+++ b/core-bundle/tests/String/HtmlAttributesTest.php
@@ -262,6 +262,19 @@ class HtmlAttributesTest extends TestCase
         $this->assertSame('foo bar baz foobar', $attributes['class']);
     }
 
+    public function testDoesNotOutputEmptyClassAttribute(): void
+    {
+        $attributes = new HtmlAttributes();
+        $attributes->addClass('');
+
+        $this->assertSame('', $attributes->toString());
+
+        $attributes->addClass('foo');
+        $attributes->removeClass('foo');
+
+        $this->assertSame('', $attributes->toString());
+    }
+
     public function testAllowsChaining(): void
     {
         $attributes = (new HtmlAttributes())


### PR DESCRIPTION
Namely:
- the `set()` function got a default value, which makes setting boolean properties easier [c68a329242c8a6f707d148befaa2f8cbc0de3bec]
- an empty `class` attribute will not be output anymore [8f9d1733c5f17573d01b62c55d006d7ce4b9eb64]
- short circuit merging empty input (small optimization, because this happens a lot) [d99a6e2d5c48f03813278f4f4953be7949db9a3e]
