### PR TITLE
Also hover over the parent records in "paste" mode

### DIFF
--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -3909,7 +3909,17 @@ class DC_Table extends DataContainer implements \listable, \editable
 		}
 
 		$session[$node][$id] = (\is_int($session[$node][$id])) ? $session[$node][$id] : 0;
-		$mouseover = ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] == 5 || $table == $this->strTable) ? ' toggle_select hover-div' : '';
+
+		$mouseover = '';
+
+		if ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] == 5 || $table == $this->strTable)
+		{
+			$mouseover = ' toggle_select hover-div';
+		}
+		elseif ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] == 6 && Input::get('act') == 'paste')
+		{
+			$mouseover = ' hover-div';
+		}
 
 		$return .= "\n  " . '<li class="' . ((($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] == 5 && $objRow->type == 'root') || $table != $this->strTable) ? 'tl_folder' : 'tl_file') . ' click2edit' . $mouseover . ' cf"><div class="tl_left" style="padding-left:' . ($intMargin + $intSpacing + (empty($childs) ? 20 : 0)) . 'px">';
 


### PR DESCRIPTION
Fixes #4295

This will add the hover effect to parent records in "paste" mode.

<img width="596" alt="" src="https://user-images.githubusercontent.com/1192057/160875920-007c68b4-55ee-4be5-8dfe-a1136966d158.png">
