### PR TITLE
Return the prefix-relative path when getting filesystem items from the VFS

### DIFF
--- a/core-bundle/src/Filesystem/VirtualFilesystem.php
+++ b/core-bundle/src/Filesystem/VirtualFilesystem.php
@@ -170,7 +170,7 @@ class VirtualFilesystem implements VirtualFilesystemInterface
         if ($this->fileExists($relativePath, $accessFlags)) {
             return new FilesystemItem(
                 true,
-                $path,
+                $relativePath,
                 fn () => $this->getLastModified($relativePath, $accessFlags),
                 fn () => $this->getFileSize($relativePath, $accessFlags),
                 fn () => $this->getMimeType($relativePath, $accessFlags),
@@ -179,7 +179,7 @@ class VirtualFilesystem implements VirtualFilesystemInterface
         }
 
         if ($this->directoryExists($relativePath, $accessFlags)) {
-            return new FilesystemItem(false, $path);
+            return new FilesystemItem(false, $relativePath);
         }
 
         return null;

--- a/core-bundle/tests/Filesystem/VirtualFilesystemTest.php
+++ b/core-bundle/tests/Filesystem/VirtualFilesystemTest.php
@@ -530,7 +530,7 @@ class VirtualFilesystemTest extends TestCase
 
         $this->assertInstanceOf(FilesystemItem::class, $directoryA);
         $this->assertFalse($directoryA->isFile());
-        $this->assertSame('foo/dir_a', $directoryA->getPath());
+        $this->assertSame('dir_a', $directoryA->getPath());
 
         $this->assertInstanceOf(FilesystemItem::class, $fileA);
         $this->assertTrue($fileA->isFile());
@@ -552,7 +552,7 @@ class VirtualFilesystemTest extends TestCase
 
         $this->assertInstanceOf(FilesystemItem::class, $directoryB);
         $this->assertFalse($directoryB->isFile());
-        $this->assertSame('foo/dir_b', $directoryB->getPath());
+        $this->assertSame('dir_b', $directoryB->getPath());
 
         $this->assertInstanceOf(FilesystemItem::class, $fileB);
         $this->assertTrue($fileB->isFile());


### PR DESCRIPTION
Followup fix for #4397 

I'm sorry, I got one thing wrong in the last VFS PR. :see_no_evil: 

When calling `VirtualFilesystem#get()` we need to return prefix-relative paths, so that these two calls result in `FilesystemItem` objects with identical properties:

```php
// directory "files/foo" contains a single file "bar.txt", the $filesStorage is mounted to "files"

$item1 = iterator_to_array($filesStorage->listContents('foo'))[0];
$item2 = $filesStorage->get('foo/bar.txt');

var_dump($item2->getPath()); // "foo/bar.txt" (note, no prefix "files")
var_dump($item1->getPath() === $item2->getPath()); // true
```
