### PR TITLE
Add the service subscriber tag to the correct controller

### DIFF
--- a/core-bundle/src/Resources/config/controller.yml
+++ b/core-bundle/src/Resources/config/controller.yml
@@ -10,8 +10,6 @@ services:
         Contao\CoreBundle\Controller\AbstractController:
             tags:
                 - { name: container.service_subscriber, id: contao.csrf.token_manager }
-            calls:
-                - [setContainer, ['@Psr\Container\ContainerInterface']]
 
     # We explicitly allow autowiring and FQCN service IDs in controllers
     Contao\CoreBundle\Controller\BackendController: ~

--- a/core-bundle/src/Resources/config/controller.yml
+++ b/core-bundle/src/Resources/config/controller.yml
@@ -4,6 +4,10 @@ services:
 
     _instanceof:
         Symfony\Bundle\FrameworkBundle\Controller\AbstractController:
+            calls:
+                - [setContainer, ['@Psr\Container\ContainerInterface']]
+
+        Contao\CoreBundle\Controller\AbstractController:
             tags:
                 - { name: container.service_subscriber, id: contao.csrf.token_manager }
             calls:

--- a/core-bundle/src/Resources/config/services.yml
+++ b/core-bundle/src/Resources/config/services.yml
@@ -7,10 +7,6 @@ services:
             calls:
                 - [setFramework, ['@contao.framework']]
 
-        Symfony\Bundle\FrameworkBundle\Controller\AbstractController:
-            calls:
-                - [setContainer, ['@Psr\Container\ContainerInterface']]
-
         Symfony\Component\DependencyInjection\ContainerAwareInterface:
             calls:
                 - [setContainer, ['@service_container']]


### PR DESCRIPTION
The service tag `{ name: container.service_subscriber, id: contao.csrf.token_manager }` must not be set to Symfony's `AbstractController` but ours, otherwise extending from this class without specifiying the CSRF token manager in the `getSubscribedServices()` declaration would fail:

```
Service key "contao.csrf.token_manager" does not exist in the map returned by <service>.
```

(We still need to set the container there as well, so that's why I added another definition.)