### PR TITLE
Always create an article if page has no layout

### DIFF
--- a/core-bundle/src/EventListener/DataContainer/ContentCompositionListener.php
+++ b/core-bundle/src/EventListener/DataContainer/ContentCompositionListener.php
@@ -228,7 +228,7 @@ class ContentCompositionListener
         $layout = $pageModel->getRelated('layout');
 
         if (null === $layout) {
-            return null;
+            return 'main';
         }
 
         $columns = [];

--- a/core-bundle/tests/EventListener/DataContainer/ContentCompositionListenerTest.php
+++ b/core-bundle/tests/EventListener/DataContainer/ContentCompositionListenerTest.php
@@ -176,37 +176,6 @@ class ContentCompositionListenerTest extends TestCase
         );
     }
 
-    public function testRendersEmptyArticlesOperationIfPageLayoutIsNotFound(): void
-    {
-        $this->security
-            ->expects($this->once())
-            ->method('isGranted')
-            ->with('contao_user.modules', 'article')
-            ->willReturn(true)
-        ;
-
-        $page = $this->mockPageWithRow(null);
-
-        $this->expectSupportsContentComposition(true, $page);
-
-        $this->imageAdapter
-            ->expects($this->once())
-            ->method('getHtml')
-            ->with('foo_.svg')
-            ->willReturn('<img src="foo_.svg">')
-        ;
-
-        $this->backendAdapter
-            ->expects($this->never())
-            ->method('addToUrl')
-        ;
-
-        $this->assertSame(
-            '<img src="foo_.svg"> ',
-            $this->listener->renderPageArticlesOperation($this->pageRecord, '', '', '', 'foo.svg')
-        );
-    }
-
     public function testRendersEmptyArticlesOperationIfPageLayoutDoesNotHaveArticles(): void
     {
         $this->security
@@ -299,6 +268,39 @@ class ContentCompositionListenerTest extends TestCase
         ;
 
         $page = $this->mockPageWithRow(0);
+
+        $this->expectSupportsContentComposition(true, $page);
+
+        $this->imageAdapter
+            ->expects($this->once())
+            ->method('getHtml')
+            ->with('foo.svg', 'label')
+            ->willReturn('<img src="foo.svg" alt="label">')
+        ;
+
+        $this->backendAdapter
+            ->expects($this->once())
+            ->method('addToUrl')
+            ->with('link&amp;pn=17')
+            ->willReturn('linkWithPn')
+        ;
+
+        $this->assertSame(
+            '<a href="linkWithPn" title="title"><img src="foo.svg" alt="label"></a> ',
+            $this->listener->renderPageArticlesOperation($this->pageRecord, 'link', 'label', 'title', 'foo.svg')
+        );
+    }
+
+    public function testRendersArticlesOperationIfPageLayoutIsNotFound(): void
+    {
+        $this->security
+            ->expects($this->once())
+            ->method('isGranted')
+            ->with('contao_user.modules', 'article')
+            ->willReturn(true)
+        ;
+
+        $page = $this->mockPageWithRow(null);
 
         $this->expectSupportsContentComposition(true, $page);
 


### PR DESCRIPTION
When creating new pages, we do not create articles if the current page layout does not have an article module in its structure. However, if you start a new page tree in Contao 4.13, and do not assign a layout to the root/first page, no articles are created by default. This is pretty annoying since it _forces_ to create the page layout first. This PR changes the behaviour to allow articles if no layout can be found.

Per request of @fenepedia 😉 