### PR TITLE
Support sorting and any/all search in FilesystemItemIterator

### DIFF
--- a/core-bundle/src/Filesystem/FilesystemItemIterator.php
+++ b/core-bundle/src/Filesystem/FilesystemItemIterator.php
@@ -17,17 +17,6 @@ namespace Contao\CoreBundle\Filesystem;
  */
 class FilesystemItemIterator implements \IteratorAggregate
 {
-    public const SORT_BY_PATH_ASC = 'name_asc';
-    public const SORT_BY_PATH_DESC = 'name_desc';
-    public const SORT_BY_LAST_MODIFIED_ASC = 'date_asc';
-    public const SORT_BY_LAST_MODIFIED_DESC = 'date_desc';
-
-    public static array $supportedSortingModes = [
-        self::SORT_BY_PATH_ASC,
-        self::SORT_BY_PATH_DESC,
-        self::SORT_BY_LAST_MODIFIED_ASC,
-        self::SORT_BY_LAST_MODIFIED_DESC,
-    ];
     /**
      * @var iterable<FilesystemItem>
      */
@@ -67,16 +56,17 @@ class FilesystemItemIterator implements \IteratorAggregate
         return $this->filter(static fn (FilesystemItem $item) => !$item->isFile());
     }
 
-    public function sort(string $sortingMode = self::SORT_BY_PATH_ASC): self
+    public function sort(SortMode $sortMode = SortMode::pathAscending): self
     {
         $listing = $this->toArray();
 
-        match ($sortingMode) {
-            self::SORT_BY_PATH_ASC => usort($listing, static fn (FilesystemItem $a, FilesystemItem $b): int => strnatcasecmp($a->getPath(), $b->getPath())),
-            self::SORT_BY_PATH_DESC => usort($listing, static fn (FilesystemItem $a, FilesystemItem $b): int => -strnatcasecmp($a->getPath(), $b->getPath())),
-            self::SORT_BY_LAST_MODIFIED_ASC => usort($listing, static fn (FilesystemItem $a, FilesystemItem $b): int => $a->getLastModified() <=> $b->getLastModified()),
-            self::SORT_BY_LAST_MODIFIED_DESC => usort($listing, static fn (FilesystemItem $a, FilesystemItem $b): int => $b->getLastModified() <=> $a->getLastModified()),
-            default => throw new \InvalidArgumentException(sprintf('Unsupported sorting mode "%s", must be one of "%s".', $sortingMode, implode('", "', self::$supportedSortingModes)))
+        match ($sortMode) {
+            SortMode::pathAscending => usort($listing, static fn (FilesystemItem $a, FilesystemItem $b): int => strcasecmp($a->getPath(), $b->getPath())),
+            SortMode::pathDescending => usort($listing, static fn (FilesystemItem $a, FilesystemItem $b): int => -strcasecmp($a->getPath(), $b->getPath())),
+            SortMode::pathNaturalAscending => usort($listing, static fn (FilesystemItem $a, FilesystemItem $b): int => strnatcasecmp($a->getPath(), $b->getPath())),
+            SortMode::pathNaturalDescending => usort($listing, static fn (FilesystemItem $a, FilesystemItem $b): int => -strnatcasecmp($a->getPath(), $b->getPath())),
+            SortMode::lastModifiedAscending => usort($listing, static fn (FilesystemItem $a, FilesystemItem $b): int => $a->getLastModified() <=> $b->getLastModified()),
+            SortMode::lastModifiedDescending => usort($listing, static fn (FilesystemItem $a, FilesystemItem $b): int => $b->getLastModified() <=> $a->getLastModified()),
         };
 
         return new self($listing);

--- a/core-bundle/src/Filesystem/FilesystemItemIterator.php
+++ b/core-bundle/src/Filesystem/FilesystemItemIterator.php
@@ -83,6 +83,34 @@ class FilesystemItemIterator implements \IteratorAggregate
     }
 
     /**
+     * @param callable(FilesystemItem):bool $condition
+     */
+    public function any(callable $condition): bool
+    {
+        foreach ($this as $item) {
+            if ($condition($item)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param callable(FilesystemItem):bool $condition
+     */
+    public function all(callable $condition): bool
+    {
+        foreach ($this as $item) {
+            if (!$condition($item)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
      * @return \Traversable<FilesystemItem>
      */
     public function getIterator(): \Traversable

--- a/core-bundle/src/Filesystem/FilesystemItemIterator.php
+++ b/core-bundle/src/Filesystem/FilesystemItemIterator.php
@@ -60,14 +60,17 @@ class FilesystemItemIterator implements \IteratorAggregate
     {
         $listing = $this->toArray();
 
-        match ($sortMode) {
-            SortMode::pathAscending => usort($listing, static fn (FilesystemItem $a, FilesystemItem $b): int => strcasecmp($a->getPath(), $b->getPath())),
-            SortMode::pathDescending => usort($listing, static fn (FilesystemItem $a, FilesystemItem $b): int => -strcasecmp($a->getPath(), $b->getPath())),
-            SortMode::pathNaturalAscending => usort($listing, static fn (FilesystemItem $a, FilesystemItem $b): int => strnatcasecmp($a->getPath(), $b->getPath())),
-            SortMode::pathNaturalDescending => usort($listing, static fn (FilesystemItem $a, FilesystemItem $b): int => -strnatcasecmp($a->getPath(), $b->getPath())),
-            SortMode::lastModifiedAscending => usort($listing, static fn (FilesystemItem $a, FilesystemItem $b): int => $a->getLastModified() <=> $b->getLastModified()),
-            SortMode::lastModifiedDescending => usort($listing, static fn (FilesystemItem $a, FilesystemItem $b): int => $b->getLastModified() <=> $a->getLastModified()),
-        };
+        usort(
+            $listing,
+            match ($sortMode) {
+                SortMode::pathAscending => static fn (FilesystemItem $a, FilesystemItem $b): int => strcasecmp($a->getPath(), $b->getPath()),
+                SortMode::pathDescending => static fn (FilesystemItem $a, FilesystemItem $b): int => -strcasecmp($a->getPath(), $b->getPath()),
+                SortMode::pathNaturalAscending => static fn (FilesystemItem $a, FilesystemItem $b): int => strnatcasecmp($a->getPath(), $b->getPath()),
+                SortMode::pathNaturalDescending => static fn (FilesystemItem $a, FilesystemItem $b): int => -strnatcasecmp($a->getPath(), $b->getPath()),
+                SortMode::lastModifiedAscending => static fn (FilesystemItem $a, FilesystemItem $b): int => $a->getLastModified() <=> $b->getLastModified(),
+                SortMode::lastModifiedDescending => static fn (FilesystemItem $a, FilesystemItem $b): int => $b->getLastModified() <=> $a->getLastModified(),
+            },
+        );
 
         return new self($listing);
     }

--- a/core-bundle/src/Filesystem/SortMode.php
+++ b/core-bundle/src/Filesystem/SortMode.php
@@ -15,14 +15,9 @@ namespace Contao\CoreBundle\Filesystem;
 enum SortMode: string
 {
     case pathAscending = 'path_asc';
-
     case pathDescending = 'path_desc';
-
     case pathNaturalAscending = 'name_asc';
-
     case pathNaturalDescending = 'name_desc';
-
     case lastModifiedAscending = 'date_asc';
-
     case lastModifiedDescending = 'date_desc';
 }

--- a/core-bundle/src/Filesystem/SortMode.php
+++ b/core-bundle/src/Filesystem/SortMode.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Filesystem;
+
+enum SortMode: string
+{
+    case pathAscending = 'path_asc';
+
+    case pathDescending = 'path_desc';
+
+    case pathNaturalAscending = 'name_asc';
+
+    case pathNaturalDescending = 'name_desc';
+
+    case lastModifiedAscending = 'date_asc';
+
+    case lastModifiedDescending = 'date_desc';
+}

--- a/core-bundle/tests/Filesystem/FilesystemItemIteratorTest.php
+++ b/core-bundle/tests/Filesystem/FilesystemItemIteratorTest.php
@@ -100,6 +100,34 @@ class FilesystemItemIteratorTest extends TestCase
         (new FilesystemItemIterator([]))->sort('foobar');
     }
 
+    public function testAny(): void
+    {
+        $iterator = new FilesystemItemIterator([
+            new FilesystemItem(true, 'foo.jpg'),
+            new FilesystemItem(false, 'bar'),
+            new FilesystemItem(true, 'baz.txt'),
+            new FilesystemItem(false, 'foobar'),
+        ]);
+
+        $this->assertTrue($iterator->any(static fn (FilesystemItem $f): bool => $f->isFile()));
+        $this->assertTrue($iterator->any(static fn (FilesystemItem $f): bool => str_starts_with($f->getPath(), 'ba')));
+        $this->assertFalse($iterator->any(static fn (FilesystemItem $f): bool => str_starts_with($f->getPath(), 'x')));
+    }
+
+    public function testAll(): void
+    {
+        $iterator = new FilesystemItemIterator([
+            new FilesystemItem(true, 'foo.jpg'),
+            new FilesystemItem(true, 'foo.csv'),
+            new FilesystemItem(true, 'baz.txt'),
+            new FilesystemItem(true, 'foo_bar'),
+        ]);
+
+        $this->assertTrue($iterator->all(static fn (FilesystemItem $f): bool => $f->isFile()));
+        $this->assertTrue($iterator->all(static fn (FilesystemItem $f): bool => 7 === \strlen($f->getPath())));
+        $this->assertFalse($iterator->all(static fn (FilesystemItem $f): bool => str_starts_with($f->getPath(), 'foo')));
+    }
+
     /**
      * @dataProvider provideInvalidItems
      *

--- a/core-bundle/tests/Filesystem/FilesystemItemIteratorTest.php
+++ b/core-bundle/tests/Filesystem/FilesystemItemIteratorTest.php
@@ -14,6 +14,7 @@ namespace Contao\CoreBundle\Tests\Filesystem;
 
 use Contao\CoreBundle\Filesystem\FilesystemItem;
 use Contao\CoreBundle\Filesystem\FilesystemItemIterator;
+use Contao\CoreBundle\Filesystem\SortMode;
 use Contao\CoreBundle\Tests\TestCase;
 
 class FilesystemItemIteratorTest extends TestCase
@@ -67,8 +68,8 @@ class FilesystemItemIteratorTest extends TestCase
 
     public function testSort(): void
     {
-        $fileA = new FilesystemItem(true, 'foo/a', 100);
-        $fileB = new FilesystemItem(true, 'foo/b', 200);
+        $fileA = new FilesystemItem(true, 'foo/img2', 100);
+        $fileB = new FilesystemItem(true, 'foo/img10', 200);
         $fileC = new FilesystemItem(true, 'bar/a', 300);
         $fileD = new FilesystemItem(true, 'bar/b', 400);
         $dirFoo = new FilesystemItem(false, 'foo', null);
@@ -76,28 +77,27 @@ class FilesystemItemIteratorTest extends TestCase
 
         $iterator = new FilesystemItemIterator([$fileA, $fileB, $fileC, $fileD, $dirFoo, $dirBar]);
 
-        $sortedByPathAsc = $iterator->sort(FilesystemItemIterator::SORT_BY_PATH_ASC);
-        $sortedByPathDesc = $sortedByPathAsc->sort(FilesystemItemIterator::SORT_BY_PATH_DESC);
-        $sortedByDateAsc = $sortedByPathDesc->sort(FilesystemItemIterator::SORT_BY_LAST_MODIFIED_ASC);
-        $sortedByDateDesc = $sortedByDateAsc->sort(FilesystemItemIterator::SORT_BY_LAST_MODIFIED_DESC);
+        $sortedByPathAsc = $iterator->sort(SortMode::pathAscending);
+        $sortedByPathDesc = $sortedByPathAsc->sort(SortMode::pathDescending);
+        $sortedByPathNaturalAsc = $sortedByPathDesc->sort(SortMode::pathNaturalAscending);
+        $sortedByPathNaturalDesc = $sortedByPathNaturalAsc->sort(SortMode::pathNaturalDescending);
+        $sortedByDateAsc = $sortedByPathNaturalDesc->sort(SortMode::lastModifiedAscending);
+        $sortedByDateDesc = $sortedByDateAsc->sort(SortMode::lastModifiedDescending);
 
-        $expectedByPath = [$dirBar, $fileC, $fileD, $dirFoo, $fileA, $fileB];
+        $expectedByPath = [$dirBar, $fileC, $fileD, $dirFoo, $fileB, $fileA];
 
         $this->assertSame($expectedByPath, iterator_to_array($sortedByPathAsc));
         $this->assertSame(array_reverse($expectedByPath), iterator_to_array($sortedByPathDesc));
+
+        $expectedByNaturalPath = [$dirBar, $fileC, $fileD, $dirFoo, $fileA, $fileB];
+
+        $this->assertSame($expectedByNaturalPath, iterator_to_array($sortedByPathNaturalAsc));
+        $this->assertSame(array_reverse($expectedByNaturalPath), iterator_to_array($sortedByPathNaturalDesc));
 
         $expectedByDate = [$dirFoo, $fileA, $fileB, $fileC, $fileD, $dirBar];
 
         $this->assertSame($expectedByDate, iterator_to_array($sortedByDateAsc));
         $this->assertSame(array_reverse($expectedByDate), iterator_to_array($sortedByDateDesc));
-    }
-
-    public function testThrowsIfSortingModeIsNotSupported(): void
-    {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Unsupported sorting mode "foobar", must be one of "name_asc", "name_desc", "date_asc", "date_desc".');
-
-        (new FilesystemItemIterator([]))->sort('foobar');
     }
 
     public function testAny(): void

--- a/tools/ecs/config/default.php
+++ b/tools/ecs/config/default.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use PhpCsFixer\Fixer\Comment\HeaderCommentFixer;
+use PhpCsFixer\Fixer\Whitespace\BlankLineBeforeStatementFixer;
 use PhpCsFixer\Fixer\Whitespace\MethodChainingIndentationFixer;
 use SlevomatCodingStandard\Sniffs\Variables\UnusedVariableSniff;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
@@ -18,6 +19,9 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         '*/Fixtures/system/*',
         '*/Resources/contao/*',
         'maker-bundle/src/Resources/skeleton/*',
+        BlankLineBeforeStatementFixer::class => [
+            'core-bundle/src/Filesystem/SortMode.php',
+        ],
         MethodChainingIndentationFixer::class => [
             '*/DependencyInjection/Configuration.php',
             '*/Resources/config/*.php',


### PR DESCRIPTION
This implements basic sorting/searching in the `FilesystemItemIterator`, again in preparation for our new fragments.

It allows things like this:
```php
// sort
$items = $vfs->listContents()->sort(FilesystemItemIterator::SORT_BY_PATH_ASC);

// test
$containsFoo = $items->any(fn(FilesystemItem $f): bool => $f->getPath() === 'foo');
$allOrderThan = $items->all(fn(FilesystemItem $f): bool => ($f->getLastModified() ?? 0) > 12345);
```