### PR TITLE
Fix simple token parser default value for unknown variables

### DIFF
--- a/core-bundle/src/String/SimpleTokenParser.php
+++ b/core-bundle/src/String/SimpleTokenParser.php
@@ -167,7 +167,7 @@ class SimpleTokenParser implements LoggerAwareInterface
 
         try {
             return (bool) $this->expressionLanguage->evaluate($expression, $data);
-        } catch (SyntaxError|\TypeError $e) {
+        } catch (\Throwable $e) {
             throw new \InvalidArgumentException($e->getMessage(), 0, $e);
         }
     }

--- a/core-bundle/src/String/SimpleTokenParser.php
+++ b/core-bundle/src/String/SimpleTokenParser.php
@@ -160,7 +160,7 @@ class SimpleTokenParser implements LoggerAwareInterface
 
             // Define variables that weren't provided with the value 'null'
             $data = array_merge(
-                array_combine($unmatchedVariables, array_fill(0, \count($unmatchedVariables), null)),
+                array_combine($unmatchedVariables, array_fill(0, \count($unmatchedVariables), '')),
                 $data
             );
         }

--- a/core-bundle/src/String/SimpleTokenParser.php
+++ b/core-bundle/src/String/SimpleTokenParser.php
@@ -160,14 +160,14 @@ class SimpleTokenParser implements LoggerAwareInterface
 
             // Define variables that weren't provided with the value 'null'
             $data = array_merge(
-                array_combine($unmatchedVariables, array_fill(0, \count($unmatchedVariables), '')),
+                array_combine($unmatchedVariables, array_fill(0, \count($unmatchedVariables), null)),
                 $data
             );
         }
 
         try {
             return (bool) $this->expressionLanguage->evaluate($expression, $data);
-        } catch (SyntaxError $e) {
+        } catch (SyntaxError|\TypeError $e) {
             throw new \InvalidArgumentException($e->getMessage(), 0, $e);
         }
     }

--- a/core-bundle/tests/String/SimpleTokenParserTest.php
+++ b/core-bundle/tests/String/SimpleTokenParserTest.php
@@ -366,8 +366,8 @@ class SimpleTokenParserTest extends TestCase
             true,
         ];
 
-        yield 'Test unknown token is equal to be null' => [
-            'foo === null',
+        yield 'Test unknown token is equal to empty string' => [
+            "foo === ''",
             'Tried to evaluate unknown simple token(s): "foo".',
             true,
         ];
@@ -379,7 +379,8 @@ class SimpleTokenParserTest extends TestCase
         ];
 
         yield 'Test single unknown token (regex test)' => [
-            'foo matches "/whatever/"', 'Tried to evaluate unknown simple token(s): "foo".',
+            'foo matches "/whatever/"',
+            'Tried to evaluate unknown simple token(s): "foo".',
             false,
         ];
 

--- a/core-bundle/tests/String/SimpleTokenParserTest.php
+++ b/core-bundle/tests/String/SimpleTokenParserTest.php
@@ -366,20 +366,14 @@ class SimpleTokenParserTest extends TestCase
             true,
         ];
 
-        yield 'Test unknown token is equal to empty string' => [
-            "foo === ''",
+        yield 'Test unknown token is equal to be null' => [
+            'foo === null',
             'Tried to evaluate unknown simple token(s): "foo".',
             true,
         ];
 
         yield 'Test single unknown token (array test)' => [
             'foo in [1, 2, 3]',
-            'Tried to evaluate unknown simple token(s): "foo".',
-            false,
-        ];
-
-        yield 'Test single unknown token (regex test)' => [
-            'foo matches "/whatever/"',
             'Tried to evaluate unknown simple token(s): "foo".',
             false,
         ];
@@ -622,6 +616,7 @@ class SimpleTokenParserTest extends TestCase
         yield 'Unknown operator (=)' => ['{if foo="bar"}{endif}'];
         yield 'Unknown operator (====)' => ['{if foo===="bar"}{endif}'];
         yield 'Unknown operator (<==)' => ['{if foo<=="bar"}{endif}'];
+        yield 'Unknown subject with match' => ['{if baz matches "/whatever/"}{endif}'];
     }
 
     public function testParseSimpleTokenWithCustomExtensionProvider(): void

--- a/core-bundle/tests/String/SimpleTokenParserTest.php
+++ b/core-bundle/tests/String/SimpleTokenParserTest.php
@@ -616,7 +616,6 @@ class SimpleTokenParserTest extends TestCase
         yield 'Unknown operator (=)' => ['{if foo="bar"}{endif}'];
         yield 'Unknown operator (====)' => ['{if foo===="bar"}{endif}'];
         yield 'Unknown operator (<==)' => ['{if foo<=="bar"}{endif}'];
-        yield 'Unknown subject with match' => ['{if baz matches "/whatever/"}{endif}'];
     }
 
     public function testParseSimpleTokenWithCustomExtensionProvider(): void


### PR DESCRIPTION
We automatically detect missing variables in the simple token parser and provide them (initialized with `null`). In Contao 5, the used expression language component now got type hints and now a problem appears when using `match`, because this relies on the subject being a `string`.

This PR therefore changes the default value for unknown values to `''` (empty string) which is a small BC break that will only affect people that explicitly wrote things like `{if foo == null}bar{endif}` and had a scenario where `foo` only existed in some cases.