### PR TITLE
Make replacing insert tags more granular

### DIFF
--- a/core-bundle/src/Resources/contao/classes/FrontendTemplate.php
+++ b/core-bundle/src/Resources/contao/classes/FrontendTemplate.php
@@ -113,7 +113,6 @@ class FrontendTemplate extends Template
 			}
 		}
 
-		$this->strBuffer = System::getContainer()->get('contao.insert_tag.parser')->replace($this->strBuffer);
 		$this->strBuffer = $this->replaceDynamicScriptTags($this->strBuffer); // see #4203
 
 		// HOOK: allow to modify the compiled markup (see #4291)

--- a/core-bundle/src/Resources/contao/library/Contao/TemplateInheritance.php
+++ b/core-bundle/src/Resources/contao/library/Contao/TemplateInheritance.php
@@ -141,6 +141,9 @@ trait TemplateInheritance
 			$blnDebug = System::getContainer()->getParameter('kernel.debug');
 		}
 
+		// Replace insert tags
+		$strBuffer = System::getContainer()->get('contao.insert_tag.parser')->replace($strBuffer);
+
 		// Add start and end markers in debug mode
 		if ($blnDebug)
 		{

--- a/core-bundle/src/Resources/contao/library/Contao/TemplateInheritance.php
+++ b/core-bundle/src/Resources/contao/library/Contao/TemplateInheritance.php
@@ -142,7 +142,8 @@ trait TemplateInheritance
 		}
 
 		// Replace insert tags
-		if ($this instanceof FrontendTemplate) {
+		if ($this instanceof FrontendTemplate)
+		{
 			$strBuffer = System::getContainer()->get('contao.insert_tag.parser')->replace($strBuffer);
 		}
 

--- a/core-bundle/src/Resources/contao/library/Contao/TemplateInheritance.php
+++ b/core-bundle/src/Resources/contao/library/Contao/TemplateInheritance.php
@@ -142,7 +142,9 @@ trait TemplateInheritance
 		}
 
 		// Replace insert tags
-		$strBuffer = System::getContainer()->get('contao.insert_tag.parser')->replace($strBuffer);
+		if ($this instanceof FrontendTemplate) {
+			$strBuffer = System::getContainer()->get('contao.insert_tag.parser')->replace($strBuffer);
+		}
 
 		// Add start and end markers in debug mode
 		if ($blnDebug)


### PR DESCRIPTION
This PR reintroduces the reverted changes from #3622 for Contao 5.

With this change, automatic insert tag replacement on the rendered template output will only be applied to the legacy templates. In Twig we're using explicit replacing inside the templates (see #3606).