### PR TITLE
Fix Atom feed generation

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Feed.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Feed.php
@@ -197,7 +197,7 @@ class Feed
 		{
 			$xml .= '<entry>';
 			$xml .= '<title>' . StringUtil::specialchars(strip_tags(StringUtil::stripInsertTags($objItem->title))) . '</title>';
-			$xml .= '<content type="html">' . preg_replace('/[\n\r]+/', ' ', StringUtil::specialchars($objItem->description)) . '</content>';
+			$xml .= '<content type="html">' . preg_replace('/[\n\r]+/', ' ', htmlspecialchars($objItem->description, ENT_XML1, 'UTF-8')) . '</content>';
 			$xml .= '<link rel="alternate" href="' . StringUtil::specialchars($objItem->link) . '" />';
 			$xml .= '<updated>' . preg_replace('/00$/', ':00', date('Y-m-d\TH:i:sO', $objItem->published)) . '</updated>';
 			$xml .= '<id>' . ($objItem->guid ?: StringUtil::specialchars($objItem->link)) . '</id>';

--- a/core-bundle/src/Resources/contao/library/Contao/Feed.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Feed.php
@@ -197,7 +197,7 @@ class Feed
 		{
 			$xml .= '<entry>';
 			$xml .= '<title>' . StringUtil::specialchars(strip_tags(StringUtil::stripInsertTags($objItem->title))) . '</title>';
-			$xml .= '<content type="xhtml"><div xmlns="http://www.w3.org/1999/xhtml">' . preg_replace('/[\n\r]+/', ' ', StringUtil::toXhtml($objItem->description)) . '</div></content>';
+			$xml .= '<content type="html">' . preg_replace('/[\n\r]+/', ' ', StringUtil::specialchars($objItem->description)) . '</content>';
 			$xml .= '<link rel="alternate" href="' . StringUtil::specialchars($objItem->link) . '" />';
 			$xml .= '<updated>' . preg_replace('/00$/', ':00', date('Y-m-d\TH:i:sO', $objItem->published)) . '</updated>';
 			$xml .= '<id>' . ($objItem->guid ?: StringUtil::specialchars($objItem->link)) . '</id>';

--- a/core-bundle/src/Resources/contao/library/Contao/StringUtil.php
+++ b/core-bundle/src/Resources/contao/library/Contao/StringUtil.php
@@ -21,7 +21,7 @@ use Webmozart\PathUtil\Path;
  *
  *     $short = StringUtil::substr($str, 32);
  *     $html  = StringUtil::substrHtml($str, 32);
- *     $xhtml = StringUtil::toXhtml($html5);
+ *     $decoded = StringUtil::decodeEntities($str);
  *
  * @author Leo Feyer <https://github.com/leofeyer>
  */
@@ -484,9 +484,13 @@ class StringUtil
 	 * @param string $strString The HTML5 string
 	 *
 	 * @return string The XHTML string
+	 *
+	 * @deprecated Deprecated since Contao 4.9, to be removed in Contao 5.0
 	 */
 	public static function toXhtml($strString)
 	{
+		trigger_deprecation('contao/core-bundle', '4.9', 'The "StringUtil::toXhtml()" method has been deprecated and will no longer work in Contao 5.0.');
+
 		$arrPregReplace = array
 		(
 			'/<(br|hr|img)([^>]*)>/i' => '<$1$2 />', // Close stand-alone tags


### PR DESCRIPTION
Fixes #4439

See https://github.com/contao/contao/issues/4439#issuecomment-1087243402

This PR removes the usage of `StringUtil::toXhtml` and deprecates the method accordingly. According to the Atom spec you can set the content type of nodes like `title` and `content` to `html` - but you need to escape the markup. See https://datatracker.ietf.org/doc/html/rfc4287#section-3.1.1.2

The resulting feed works correctly in RSS readers like Mozilla Thunderbird, as far as I tested.

@leofeyer _Note:_ `StringUtil::toXhtml` was erroneously deprecated in Contao 4.13, without removing its usage. Do you need a separate PR for 4.13 that reverts that change, so that you can merge this change upstream without issues?

_Note:_ due to the deprecation in 4.13, the method `StringUtil::toXhtml` was erroneously removed in `5.x` and thus you get an exception currently in `5.x` when trying to generate an Atom RSS feed. This issue would be fixed if this PR is merged and then merged upstream into `5.x`.