### PR TITLE
Run unit tests faster

### DIFF
--- a/test-case/src/ContaoTestCase.php
+++ b/test-case/src/ContaoTestCase.php
@@ -88,19 +88,26 @@ abstract class ContaoTestCase extends TestCase
      */
     protected function getContainerWithContaoConfiguration(string $projectDir = ''): ContainerBuilder
     {
+        static $cachedContainers = [];
+
+        if (!isset($cachedContainers[$projectDir])) {
+            $cachedContainers[$projectDir] = new ContainerBuilder();
+            $cachedContainers[$projectDir]->setParameter('kernel.debug', false);
+            $cachedContainers[$projectDir]->setParameter('kernel.charset', 'UTF-8');
+            $cachedContainers[$projectDir]->setParameter('kernel.default_locale', 'en');
+            $cachedContainers[$projectDir]->setParameter('kernel.cache_dir', $projectDir.'/var/cache');
+            $cachedContainers[$projectDir]->setParameter('kernel.project_dir', $projectDir);
+            $cachedContainers[$projectDir]->setParameter('kernel.root_dir', $projectDir.'/app');
+
+            $cachedContainers[$projectDir]->setDefinition('request_stack', new Definition(RequestStack::class));
+
+            // Load the default configuration
+            $extension = new ContaoCoreExtension();
+            $extension->load([], $cachedContainers[$projectDir]);
+        }
+
         $container = new ContainerBuilder();
-        $container->setParameter('kernel.debug', false);
-        $container->setParameter('kernel.charset', 'UTF-8');
-        $container->setParameter('kernel.default_locale', 'en');
-        $container->setParameter('kernel.cache_dir', $projectDir.'/var/cache');
-        $container->setParameter('kernel.project_dir', $projectDir);
-        $container->setParameter('kernel.root_dir', $projectDir.'/app');
-
-        $container->setDefinition('request_stack', new Definition(RequestStack::class));
-
-        // Load the default configuration
-        $extension = new ContaoCoreExtension();
-        $extension->load([], $container);
+        $container->merge($cachedContainers[$projectDir]);
 
         return $container;
     }


### PR DESCRIPTION
`ContaoCoreExtension::load()` takes quite some time, so I thought we could cache it 😎