### PR TITLE
Add feed controller

### DIFF
--- a/core-bundle/src/Controller/FeedController.php
+++ b/core-bundle/src/Controller/FeedController.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Controller;
+
+use Contao\CoreBundle\Event\ContaoCoreEvents;
+use Contao\CoreBundle\Event\FeedEvent;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Annotation\Route;
+use Twig\Environment;
+
+class FeedController
+{
+    private EventDispatcherInterface $dispatcher;
+    private Environment $twig;
+
+    // TODO: Add ATOM feed
+    // TODO: Add JSON feed (see https://www.jsonfeed.org/)
+    private array $types = [
+        'rss' => [
+            'template' => '@ContaoCore/Frontend/Feed/rss.xml.twig',
+            'content_type' => 'application/rss+xml',
+        ],
+    ];
+
+    public function __construct(EventDispatcherInterface $dispatcher, Environment $twig)
+    {
+        $this->dispatcher = $dispatcher;
+        $this->twig = $twig;
+    }
+
+    /**
+     * @Route("/share/{alias}.xml", name="feed", defaults={"_scope" = "frontend"})
+     */
+    public function __invoke(string $alias, Request $request): Response
+    {
+        $request->attributes->set('_feed', $alias);
+
+        $event = new FeedEvent($alias, $request);
+        $this->dispatcher->dispatch($event, ContaoCoreEvents::FEED);
+
+        if (null === $event->getFeed() || null === $event->getType()) {
+            throw new NotFoundHttpException();
+        }
+
+        $view = $this->types[$event->getType()] ?? null;
+
+        if (!$view) {
+            throw new \RuntimeException(sprintf('%s is not a supported feed type. Choose one of %s.', $event->getType(), implode(',', array_keys($this->types))));
+        }
+
+        $renderedFeed = $this->twig->render($view['template'], [
+            'feed' => $event->getFeed(),
+        ]);
+
+        return new Response($renderedFeed, 200, ['Content-Type' => $view['content_type']]);
+    }
+}

--- a/core-bundle/src/Event/ContaoCoreEvents.php
+++ b/core-bundle/src/Event/ContaoCoreEvents.php
@@ -22,6 +22,13 @@ final class ContaoCoreEvents
     public const BACKEND_MENU_BUILD = 'contao.backend_menu_build';
 
     /**
+     * The contao.feed event is triggered when a feed route is called.
+     *
+     * @see FeedEvent
+     */
+    public const FEED = 'contao.feed';
+
+    /**
      * The contao.generate_symlinks event is triggered when the symlinks are generated.
      *
      * @see GenerateSymlinksEvent

--- a/core-bundle/src/Event/FeedEvent.php
+++ b/core-bundle/src/Event/FeedEvent.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Event;
+
+use Contao\CoreBundle\Feed\Feed;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Contracts\EventDispatcher\Event;
+
+class FeedEvent extends Event
+{
+    private string $alias;
+
+    private ?Feed $feed = null;
+
+    private ?string $type;
+
+    private Request $request;
+
+    public function __construct(string $alias, Request $request)
+    {
+        $this->alias = $alias;
+        $this->request = $request;
+    }
+
+    public function getAlias(): string
+    {
+        return $this->alias;
+    }
+
+    public function getFeed(): ?Feed
+    {
+        return $this->feed;
+    }
+
+    public function setFeed(Feed $feed): void
+    {
+        $this->feed = $feed;
+    }
+
+    public function getType(): ?string
+    {
+        return $this->type;
+    }
+
+    public function setType(?string $type): void
+    {
+        $this->type = $type;
+    }
+
+    public function getRequest(): Request
+    {
+        return $this->request;
+    }
+}

--- a/core-bundle/src/EventListener/AbstractFeedListener.php
+++ b/core-bundle/src/EventListener/AbstractFeedListener.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\EventListener;
+
+use Contao\CoreBundle\Event\FeedEvent;
+
+abstract class AbstractFeedListener
+{
+    public function __invoke(FeedEvent $event): void
+    {
+        if (!$this->supports($event->getAlias())) {
+            return;
+        }
+
+        $this->generate($event);
+    }
+
+    abstract public function supports(string $alias);
+
+    abstract public function generate(FeedEvent $event);
+}

--- a/core-bundle/src/Feed/Enclosure.php
+++ b/core-bundle/src/Feed/Enclosure.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Feed;
+
+class Enclosure
+{
+    private string $media;
+    private string $url;
+    private string $type;
+    private int $length;
+
+    public static function create(string $path): self
+    {
+        $self = new self();
+        $self->media = $path;
+        return $self;
+    }
+
+    public function getMedia(): string
+    {
+        return $this->media;
+    }
+
+    public function setMedia(string $media): void
+    {
+        $this->media = $media;
+    }
+
+    public function getUrl(): string
+    {
+        return $this->url;
+    }
+
+    public function setUrl(string $url): void
+    {
+        $this->url = $url;
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    public function setType(string $type): void
+    {
+        $this->type = $type;
+    }
+
+    public function getLength(): int
+    {
+        return $this->length;
+    }
+
+    public function setLength(int $length): void
+    {
+        $this->length = $length;
+    }
+}

--- a/core-bundle/src/Feed/Feed.php
+++ b/core-bundle/src/Feed/Feed.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Feed;
+
+use DateTime;
+
+class Feed
+{
+    private string $alias;
+
+    private string $title;
+
+    private ?string $description = null;
+
+    private string $link = '';
+
+    private string $language = '';
+
+    private DateTime $lastUpdated;
+
+    /**
+     * @var FeedItem[]
+     */
+    private array $items = [];
+
+    public static function create(string $alias): self
+    {
+        return new self($alias);
+    }
+
+    public function __construct(string $alias)
+    {
+        $this->alias = $alias;
+    }
+
+    public function getAlias(): string
+    {
+        return $this->alias;
+    }
+
+    public function setAlias(string $alias): void
+    {
+        $this->alias = $alias;
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    public function setTitle(string $title): self
+    {
+        $this->title = $title;
+
+        return $this;
+    }
+
+    public function getDescription(): ?string
+    {
+        return $this->description;
+    }
+
+    public function setDescription(?string $description): self
+    {
+        $this->description = $description;
+
+        return $this;
+    }
+
+    public function getLink(): string
+    {
+        return $this->link;
+    }
+
+    public function setLink(string $link): self
+    {
+        $this->link = $link;
+
+        return $this;
+    }
+
+    public function getLanguage(): string
+    {
+        return $this->language;
+    }
+
+    public function setLanguage(string $language): self
+    {
+        $this->language = $language;
+
+        return $this;
+    }
+
+    public function getLastUpdated(): DateTime
+    {
+        return $this->lastUpdated;
+    }
+
+    public function setLastUpdated(DateTime $lastUpdated): self
+    {
+        $this->lastUpdated = $lastUpdated;
+
+        return $this;
+    }
+
+    public function getItems(): array
+    {
+        return $this->items;
+    }
+
+    public function addItem(FeedItem $item): self
+    {
+        $this->items[] = $item;
+
+        return $this;
+    }
+}

--- a/core-bundle/src/Feed/FeedItem.php
+++ b/core-bundle/src/Feed/FeedItem.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Feed;
+
+class FeedItem
+{
+    private string $title;
+
+    private ?string $description = null;
+
+    private string $link;
+
+    private string $guid;
+
+    private \DateTime $lastUpdated;
+
+    /**
+     * @var array<Enclosure>
+     */
+    private array $enclosures = [];
+
+    public static function create(): self
+    {
+        return new self();
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    public function setTitle(string $title): self
+    {
+        $this->title = $title;
+        return $this;
+    }
+
+    public function getDescription(): ?string
+    {
+        return $this->description;
+    }
+
+    public function setDescription(?string $description): self
+    {
+        $this->description = $description;
+        return $this;
+    }
+
+    public function getLink(): string
+    {
+        return $this->link;
+    }
+
+    public function setLink(string $link): self
+    {
+        $this->link = $link;
+        return $this;
+    }
+
+    public function getGuid(): string
+    {
+        return $this->guid;
+    }
+
+    public function setGuid(string $guid): self
+    {
+        $this->guid = $guid;
+        return $this;
+    }
+
+    public function getLastUpdated(): \DateTime
+    {
+        return $this->lastUpdated;
+    }
+
+    public function setLastUpdated(\DateTime $lastUpdated): self
+    {
+        $this->lastUpdated = $lastUpdated;
+        return $this;
+    }
+
+    public function getEnclosures(): array
+    {
+        return $this->enclosures;
+    }
+
+    public function setEnclosures(array $enclosures): self
+    {
+        $this->enclosures = $enclosures;
+        return $this;
+    }
+
+    public function addEnclosure(Enclosure $enclosure): self
+    {
+        $this->enclosures[] = $enclosure;
+        return $this;
+    }
+}

--- a/core-bundle/src/Resources/config/controller.yml
+++ b/core-bundle/src/Resources/config/controller.yml
@@ -80,6 +80,13 @@ services:
         tags:
             - { name: contao.frontend_module, category: user }
 
+    Contao\CoreBundle\Controller\FeedController:
+        arguments:
+            - '@event_dispatcher'
+            - '@twig'
+        tags:
+            - controller.service_arguments
+
     Contao\CoreBundle\Controller\ImagesController:
         public: true
         arguments:

--- a/core-bundle/src/Resources/views/Frontend/Feed/rss.xml.twig
+++ b/core-bundle/src/Resources/views/Frontend/Feed/rss.xml.twig
@@ -1,0 +1,38 @@
+{#<?xml version="1.0" encoding="{{ kernel.charset }}" ?>#}
+<rss version="2.0" xmlns:media="http://search.yahoo.com/mrss/" xmlns:atom="http://www.w3.org/2005/Atom">
+<channel>
+    <atom:link href="{{ feed.link }}" rel="self" type="application/rss+xml" />
+    <title>{{ feed.title }}</title>
+{%  if feed.description %}
+    <description>{{ feed.description }}</description>
+{% endif %}
+    <link>{{ feed.link}}</link>
+    <language>{{ feed.language }}</language>
+    <pubDate>{{ feed.lastUpdated|date }}</pubDate>
+    <generator>Contao Open Source CMS</generator>
+
+    {% for item in feed.items %}
+        <item>
+            <title>{{ item.title }}</title>
+            <description><![CDATA[{{ item.description }}]]></description>
+            <link>{{ item.link }}</link>
+            <pubDate>{{ item.lastUpdated|date }}</pubDate>
+            {% if item.guid %}
+                <guid isPermaLink="false">{{ item.guid }}</guid>
+            {% else %}
+                <guid>{{ item.link }}</guid>
+            {% endif %}
+
+            {% if item.enclosures %}
+                {% for enclosure in item.enclosures %}
+                    {% if enclosure.media is same as('media:content') %}
+                        <media:content url="{{ enclosure.url }}" type="{{ enclosure.type }}" />
+                    {% else %}
+                        <enclosure url="{{ enclosure.url }}" type="{{ enclosure.type }}"{% if enclosure.length %} length="{{ enclosure.length }}"{% endif %} />';
+                    {% endif %}
+                {% endfor %}
+            {% endif %}
+        </item>
+    {% endfor %}
+</channel>
+</rss>

--- a/news-bundle/src/EventListener/FeedListener.php
+++ b/news-bundle/src/EventListener/FeedListener.php
@@ -1,0 +1,100 @@
+<?php declare(strict_types=1);
+
+namespace Contao\NewsBundle\EventListener;
+
+use Contao\CoreBundle\Event\FeedEvent;
+use Contao\CoreBundle\EventListener\AbstractFeedListener;
+use Contao\CoreBundle\Feed\Enclosure;
+use Contao\CoreBundle\Feed\Feed;
+use Contao\CoreBundle\Feed\FeedItem;
+use Contao\CoreBundle\Framework\ContaoFramework;
+use Contao\NewsFeedModel;
+use Contao\NewsModel;
+use Contao\StringUtil;
+use Doctrine\DBAL\Connection;
+
+class FeedListener extends AbstractFeedListener
+{
+    private Connection $connection;
+
+    private ContaoFramework $framework;
+
+    public function __construct(Connection $connection, ContaoFramework $framework)
+    {
+        $this->connection = $connection;
+        $this->framework = $framework;
+    }
+
+    public function supports(string $name): bool
+    {
+        $result = $this->connection->executeQuery(
+            "SELECT COUNT(id) FROM {$this->connection->quoteIdentifier('tl_news_feed')} WHERE alias = ?",
+            [$name]
+        );
+
+        return $result->rowCount() > 0;
+    }
+
+    public function generate(FeedEvent $event): void
+    {
+        $feedModel = $this->framework->getAdapter(NewsFeedModel::class)->findByAlias($event->getAlias());
+
+        if (!$feedModel) {
+            return;
+        }
+
+        $archiveIds = StringUtil::deserialize($feedModel->archives);
+
+        if (empty($archiveIds)) {
+            return;
+        }
+
+        $feed = Feed::create($event->getAlias())
+            ->setTitle($feedModel->title)
+            ->setDescription($feedModel->description)
+            ->setLanguage($feedModel->language)
+            ->setLink('https://foobar')
+            ->setLastUpdated(new \DateTime('@'.$feedModel->tstamp))
+        ;
+
+        // TODO: Implement only featured
+        $onlyFeatured = null;
+
+        $models = $this->framework->getAdapter(NewsModel::class)->findPublishedByPids($archiveIds, $onlyFeatured, $feedModel->maxItems);
+
+        if (null === $models) {
+            return;
+        }
+
+        foreach ($models as $model) {
+            $item = $this->transformModel($model, $feedModel);
+
+            if ($item->getLastUpdated() > $feed->getLastUpdated()) {
+                $feed->setLastUpdated($item->getLastUpdated());
+            }
+
+            $feed->addItem($item);
+        }
+
+        $event->setFeed($feed);
+        $event->setType($feedModel->format);
+    }
+
+    private function transformModel(NewsModel $model, NewsFeedModel $feedModel): FeedItem
+    {
+        $item = FeedItem::create()
+            ->setTitle($model->headline)
+            ->setLastUpdated(new \DateTime('@'.$model->tstamp))
+            ->setLink('')
+            ->setGuid('')
+        ;
+
+        // TODO: Add content depending on $feedModel->source
+
+        if ($model->addImage) {
+            $item->addEnclosure(Enclosure::create($model->singleSRC));
+        }
+
+        return $item;
+    }
+}

--- a/news-bundle/src/Resources/config/services.yml
+++ b/news-bundle/src/Resources/config/services.yml
@@ -45,3 +45,10 @@ services:
             - '@security.helper'
         tags:
             - { name: contao.picker_provider, priority: 128 }
+
+    Contao\NewsBundle\EventListener\FeedListener:
+        arguments:
+            - '@database_connection'
+            - '@contao.framework'
+        tags:
+            - { name: kernel.event_listener, event: 'contao.feed' }


### PR DESCRIPTION
Hi all,

this is my first take on a real feed controller: This is a rough draft that I wanted to discuss, before working on the many details still missing. 

It is a generic controller for `/share/*.xml` that dispatches an **feed event**, to which custom implementation can listen to. See `Contao\NewsBundle\EventListener\FeedListener` for a rough sketch of an implementation. 

Since Contao feeds are database managed, the event does not contain anything else except the alias of the feed and the current request. The Listener then decides, if it is supposed to return a feed for this, e.g. the news feed listener checks, if a feed with the given alias is configured in `tl_news_feed`. If yes, it created Feed and FeedItems from NewsModel and NewsFeedModel.

The generated Feed and FeedItem objects are then rendered in a proper template, so a little less HTML-in-PHP. 

Happy to hear your thoughts. Also, if you remember some related issues, that should be adressed with this PR, too, please feel free to link them here.

----
Partially inspired by [spatie/laravel-feed](https://github.com/spatie/laravel-feed) and [eko/feedbundle](https://packagist.org/packages/eko/feedbundle)