### PR TITLE
Sort the selectable templates in install tool

### DIFF
--- a/installation-bundle/src/InstallTool.php
+++ b/installation-bundle/src/InstallTool.php
@@ -348,6 +348,8 @@ class InstallTool
             $templates[] = $file->getRelativePathname();
         }
 
+        natcasesort($templates);
+
         return $templates;
     }
 


### PR DESCRIPTION
This PR sorts the selectable templates in the install tool. (closes #3895)

The result might look like this: 
![image](https://user-images.githubusercontent.com/1247552/162082646-5bb1d284-ffbb-4f8e-ab45-9b039a4ce38f.png)
