### PR TITLE
Fix undefined value/unit for empty array in headline

### DIFF
--- a/core-bundle/src/Resources/contao/classes/Hybrid.php
+++ b/core-bundle/src/Resources/contao/classes/Hybrid.php
@@ -154,8 +154,8 @@ abstract class Hybrid extends Frontend
 		$this->typePrefix = $objElement->typePrefix;
 
 		$arrHeadline = StringUtil::deserialize($objElement->headline);
-		$this->headline = \is_array($arrHeadline) ? $arrHeadline['value'] : $arrHeadline;
-		$this->hl = \is_array($arrHeadline) ? $arrHeadline['unit'] : 'h1';
+		$this->headline = \is_array($arrHeadline) ? $arrHeadline['value'] ?? '' : $arrHeadline;
+		$this->hl = \is_array($arrHeadline) && isset($arrHeadline['unit']) ? $arrHeadline['unit'] : 'h1';
 		$this->strColumn = $strColumn;
 	}
 

--- a/core-bundle/src/Resources/contao/classes/Hybrid.php
+++ b/core-bundle/src/Resources/contao/classes/Hybrid.php
@@ -155,7 +155,7 @@ abstract class Hybrid extends Frontend
 
 		$arrHeadline = StringUtil::deserialize($objElement->headline);
 		$this->headline = \is_array($arrHeadline) ? $arrHeadline['value'] ?? '' : $arrHeadline;
-		$this->hl = \is_array($arrHeadline) && isset($arrHeadline['unit']) ? $arrHeadline['unit'] : 'h1';
+		$this->hl = $arrHeadline['unit'] ?? 'h1';
 		$this->strColumn = $strColumn;
 	}
 

--- a/core-bundle/src/Resources/contao/elements/ContentElement.php
+++ b/core-bundle/src/Resources/contao/elements/ContentElement.php
@@ -185,7 +185,7 @@ abstract class ContentElement extends Frontend
 
 		$arrHeadline = StringUtil::deserialize($objElement->headline);
 		$this->headline = \is_array($arrHeadline) ? $arrHeadline['value'] ?? '' : $arrHeadline;
-		$this->hl = \is_array($arrHeadline) && isset($arrHeadline['unit']) ? $arrHeadline['unit'] : 'h1';
+		$this->hl = $arrHeadline['unit'] ?? 'h1';
 		$this->strColumn = $strColumn;
 	}
 

--- a/core-bundle/src/Resources/contao/elements/ContentElement.php
+++ b/core-bundle/src/Resources/contao/elements/ContentElement.php
@@ -184,8 +184,8 @@ abstract class ContentElement extends Frontend
 		}
 
 		$arrHeadline = StringUtil::deserialize($objElement->headline);
-		$this->headline = \is_array($arrHeadline) ? $arrHeadline['value'] : $arrHeadline;
-		$this->hl = \is_array($arrHeadline) ? $arrHeadline['unit'] : 'h1';
+		$this->headline = \is_array($arrHeadline) ? $arrHeadline['value'] ?? '' : $arrHeadline;
+		$this->hl = \is_array($arrHeadline) && isset($arrHeadline['unit']) ? $arrHeadline['unit'] : 'h1';
 		$this->strColumn = $strColumn;
 	}
 

--- a/core-bundle/src/Resources/contao/modules/Module.php
+++ b/core-bundle/src/Resources/contao/modules/Module.php
@@ -151,8 +151,8 @@ abstract class Module extends Frontend
 		}
 
 		$arrHeadline = StringUtil::deserialize($objModule->headline);
-		$this->headline = \is_array($arrHeadline) ? $arrHeadline['value'] : $arrHeadline;
-		$this->hl = \is_array($arrHeadline) ? $arrHeadline['unit'] : 'h1';
+		$this->headline = \is_array($arrHeadline) ? $arrHeadline['value'] ?? '' : $arrHeadline;
+		$this->hl = \is_array($arrHeadline) && isset($arrHeadline['unit']) ? $arrHeadline['unit'] : 'h1';
 		$this->strColumn = $strColumn;
 	}
 

--- a/core-bundle/src/Resources/contao/modules/Module.php
+++ b/core-bundle/src/Resources/contao/modules/Module.php
@@ -152,7 +152,7 @@ abstract class Module extends Frontend
 
 		$arrHeadline = StringUtil::deserialize($objModule->headline);
 		$this->headline = \is_array($arrHeadline) ? $arrHeadline['value'] ?? '' : $arrHeadline;
-		$this->hl = \is_array($arrHeadline) && isset($arrHeadline['unit']) ? $arrHeadline['unit'] : 'h1';
+		$this->hl = $arrHeadline['unit'] ?? 'h1';
 		$this->strColumn = $strColumn;
 	}
 


### PR DESCRIPTION
In one of our projects we have a lot of different content elements, which have an empty array in headline.
You can check your database for that elements with the following query:
```sql
SELECT * FROM tl_content WHERE headline = 'a:0:{}';
```
This results in an undefined key `value` and `unit` for the headline while rendering.
I did not find empty headlines in the `tl_modules` but I replaced all positions for consistent code. 

Might be also a fix for the 4.9 not only 4.13 😉 

Of course we could also fix the existing empty headlines with the following query. I'm not really sure how this empty headlines are created :-/
```sql
UPDATE `tl_content` SET `headline` = '' WHERE headline = 'a:0:{}';
```