### PR TITLE
Stop using compat()

### DIFF
--- a/core-bundle/src/DataContainer/PaletteManipulator.php
+++ b/core-bundle/src/DataContainer/PaletteManipulator.php
@@ -186,7 +186,7 @@ class PaletteManipulator
                 $legend = $legendCount++;
             }
 
-            $legendMap[$legend] = compact('fields', 'hide');
+            $legendMap[$legend] = ['fields' => $fields, 'hide' => $hide];
         }
 
         return $legendMap;

--- a/core-bundle/src/DependencyInjection/Filesystem/FilesystemConfiguration.php
+++ b/core-bundle/src/DependencyInjection/Filesystem/FilesystemConfiguration.php
@@ -58,7 +58,7 @@ class FilesystemConfiguration
 
         $definition = new Definition(VirtualFilesystem::class, [$prefix, $readonly]);
         $definition->setFactory(new Reference('contao.filesystem.virtual_factory'));
-        $definition->addTag('contao.virtual_filesystem', compact('name', 'prefix'));
+        $definition->addTag('contao.virtual_filesystem', ['name' => $name, 'prefix' => $prefix]);
 
         $this->container->setDefinition($id = "contao.filesystem.virtual.$name", $definition);
         $this->container->registerAliasForArgument($id, VirtualFilesystemInterface::class, "{$name}Storage");

--- a/core-bundle/src/Filesystem/MountManager.php
+++ b/core-bundle/src/Filesystem/MountManager.php
@@ -238,7 +238,7 @@ class MountManager
             $visibility = $options['visibility'] ?? $adapterFrom->visibility($adapterPathFrom)->visibility();
 
             $stream = $adapterFrom->readStream($adapterPathFrom);
-            $adapterTo->writeStream($adapterPathTo, $stream, new Config(compact('visibility')));
+            $adapterTo->writeStream($adapterPathTo, $stream, new Config(['visibility' => $visibility]));
         } catch (FilesystemException $e) {
             throw VirtualFilesystemException::unableToCopy($pathFrom, $pathTo, $e);
         }
@@ -265,7 +265,7 @@ class MountManager
             $visibility = $options['visibility'] ?? $adapterFrom->visibility($adapterPathFrom)->visibility();
 
             $stream = $adapterFrom->readStream($adapterPathFrom);
-            $adapterTo->writeStream($adapterPathTo, $stream, new Config(compact('visibility')));
+            $adapterTo->writeStream($adapterPathTo, $stream, new Config(['visibility' => $visibility]));
 
             $adapterFrom->delete($adapterPathFrom);
         } catch (FilesystemException $e) {

--- a/core-bundle/src/Picker/PickerBuilder.php
+++ b/core-bundle/src/Picker/PickerBuilder.php
@@ -93,6 +93,6 @@ class PickerBuilder implements PickerBuilderInterface
             return '';
         }
 
-        return $this->router->generate('contao_backend_picker', compact('context', 'extras', 'value'));
+        return $this->router->generate('contao_backend_picker', ['context' => $context, 'extras' => $extras, 'value' => $value]);
     }
 }

--- a/core-bundle/src/Resources/contao/library/Contao/Controller.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Controller.php
@@ -1067,7 +1067,7 @@ abstract class Controller extends System
 		}
 
 		$return = array();
-		$arrDir = compact('top', 'right', 'bottom', 'left');
+		$arrDir = array('top'=>$top, 'right'=>$right, 'bottom'=>$bottom, 'left'=>$left);
 
 		foreach ($arrDir as $k=>$v)
 		{

--- a/core-bundle/src/Twig/Loader/ContaoFilesystemLoaderWarmer.php
+++ b/core-bundle/src/Twig/Loader/ContaoFilesystemLoaderWarmer.php
@@ -111,7 +111,7 @@ class ContaoFilesystemLoaderWarmer implements CacheWarmerInterface
 
         foreach ($mappings as $path => $namespace) {
             $data['namespaces'][] = ['namespace' => 'Contao', 'path' => $path];
-            $data['namespaces'][] = compact('namespace', 'path');
+            $data['namespaces'][] = ['namespace' => $namespace, 'path' => $path];
         }
 
         if (null === $this->filesystem) {

--- a/core-bundle/tests/Controller/PreviewLinkControllerTest.php
+++ b/core-bundle/tests/Controller/PreviewLinkControllerTest.php
@@ -34,7 +34,7 @@ class PreviewLinkControllerTest extends TestCase
         $listener = new PreviewLinkController(
             $this->mockAuthenticator($showUnpublished),
             $this->mockUriSigner(true),
-            $this->mockConnection(compact('url', 'showUnpublished'))
+            $this->mockConnection(['url' => $url, 'showUnpublished' => $showUnpublished])
         );
 
         $response = $listener($request, 42);

--- a/core-bundle/tests/DependencyInjection/Compiler/ConfigureFilesystemPassTest.php
+++ b/core-bundle/tests/DependencyInjection/Compiler/ConfigureFilesystemPassTest.php
@@ -170,7 +170,7 @@ class ConfigureFilesystemPassTest extends TestCase
             $isDirectory = !str_ends_with($target, '.txt');
             $command = sprintf('mklink%s "${:link}" "${:target}"', $isDirectory ? ' /d' : '');
 
-            Process::fromShellCommandline($command, $cwd)->mustRun(null, compact('link', 'target'));
+            Process::fromShellCommandline($command, $cwd)->mustRun(null, ['link' => $link, 'target' => $target]);
         } else {
             chdir($cwd);
 

--- a/core-bundle/tests/EventListener/DataContainer/PreviewLinkListenerTest.php
+++ b/core-bundle/tests/EventListener/DataContainer/PreviewLinkListenerTest.php
@@ -121,7 +121,7 @@ class PreviewLinkListenerTest extends TestCase
             ],
         ];
 
-        $input = $this->mockInputAdapter(compact('url', 'showUnpublished'));
+        $input = $this->mockInputAdapter(['url' => $url, 'showUnpublished' => $showUnpublished]);
 
         $listener = new PreviewLinkListener(
             $this->mockContaoFramework([Input::class => $input, Message::class => $this->mockAdapter(['addInfo'])]),

--- a/core-bundle/tests/EventListener/FilterPageTypeListenerTest.php
+++ b/core-bundle/tests/EventListener/FilterPageTypeListenerTest.php
@@ -124,7 +124,7 @@ class FilterPageTypeListenerTest extends TestCase
      */
     private function mockDataContainer(?int $pid, int $id = null): DataContainer
     {
-        $activeRecord = array_filter(compact('id', 'pid'), static fn ($v): bool => null !== $v);
+        $activeRecord = array_filter(['id' => $id, 'pid' => $pid], static fn ($v): bool => null !== $v);
 
         return $this->mockClassWithProperties(
             DataContainer::class,

--- a/core-bundle/tests/Routing/Page/PageRegistryTest.php
+++ b/core-bundle/tests/Routing/Page/PageRegistryTest.php
@@ -385,7 +385,7 @@ class PageRegistryTest extends TestCase
             ->expects($this->once())
             ->method('fetchAllAssociative')
             ->with("SELECT urlPrefix, urlSuffix FROM tl_page WHERE type='root'")
-            ->willReturn([compact('urlPrefix', 'urlSuffix')])
+            ->willReturn([['urlPrefix' => $urlPrefix, 'urlSuffix' => $urlSuffix]])
         ;
 
         return $connection;


### PR DESCRIPTION
Because `compat()` is no longer a language construct but a regular PHP function.