### PR TITLE
Remove rel="nofollow" for internal pages

### DIFF
--- a/calendar-bundle/src/Resources/contao/templates/calendar/cal_mini.html5
+++ b/calendar-bundle/src/Resources/contao/templates/calendar/cal_mini.html5
@@ -2,9 +2,9 @@
 <table class="minicalendar">
 <thead>
   <tr>
-    <th class="head previous"><?php if ($this->prevHref): ?><a href="<?= $this->prevHref ?>" title="<?= $this->prevTitle ?>"><?= $this->prevLabel ?></a><?php else: ?>&nbsp;<?php endif; ?></th>
+    <th class="head previous"><?php if ($this->prevHref): ?><a href="<?= $this->prevHref ?>" title="<?= $this->prevTitle ?>" data-skip-search-index><?= $this->prevLabel ?></a><?php else: ?>&nbsp;<?php endif; ?></th>
     <th colspan="5" class="head current"><?= $this->current ?></th>
-    <th class="head next"><?php if ($this->nextHref): ?><a href="<?= $this->nextHref ?>" title="<?= $this->nextTitle ?>"><?= $this->nextLabel ?></a><?php else: ?>&nbsp;<?php endif; ?></th>
+    <th class="head next"><?php if ($this->nextHref): ?><a href="<?= $this->nextHref ?>" title="<?= $this->nextTitle ?>" data-skip-search-index><?= $this->nextLabel ?></a><?php else: ?>&nbsp;<?php endif; ?></th>
   </tr>
   <tr>
     <?php foreach ($this->days as $day): ?>

--- a/calendar-bundle/src/Resources/contao/templates/calendar/cal_mini.html5
+++ b/calendar-bundle/src/Resources/contao/templates/calendar/cal_mini.html5
@@ -2,9 +2,9 @@
 <table class="minicalendar">
 <thead>
   <tr>
-    <th class="head previous"><?php if ($this->prevHref): ?><a href="<?= $this->prevHref ?>" rel="nofollow" title="<?= $this->prevTitle ?>"><?= $this->prevLabel ?></a><?php else: ?>&nbsp;<?php endif; ?></th>
+    <th class="head previous"><?php if ($this->prevHref): ?><a href="<?= $this->prevHref ?>" title="<?= $this->prevTitle ?>"><?= $this->prevLabel ?></a><?php else: ?>&nbsp;<?php endif; ?></th>
     <th colspan="5" class="head current"><?= $this->current ?></th>
-    <th class="head next"><?php if ($this->nextHref): ?><a href="<?= $this->nextHref ?>" rel="nofollow" title="<?= $this->nextTitle ?>"><?= $this->nextLabel ?></a><?php else: ?>&nbsp;<?php endif; ?></th>
+    <th class="head next"><?php if ($this->nextHref): ?><a href="<?= $this->nextHref ?>" title="<?= $this->nextTitle ?>"><?= $this->nextLabel ?></a><?php else: ?>&nbsp;<?php endif; ?></th>
   </tr>
   <tr>
     <?php foreach ($this->days as $day): ?>

--- a/composer.json
+++ b/composer.json
@@ -117,7 +117,7 @@
         "symfony/var-dumper": "4.4.*",
         "symfony/web-profiler-bundle": "4.4.*",
         "symfony/yaml": "4.4.*",
-        "terminal42/escargot": "^1.2",
+        "terminal42/escargot": "^1.4.1",
         "terminal42/service-annotation-bundle": "^1.1",
         "toflar/psr6-symfony-http-cache-store": "^2.1 || ^3.0",
         "true/punycode": "^2.1",

--- a/core-bundle/composer.json
+++ b/core-bundle/composer.json
@@ -98,7 +98,7 @@
         "symfony/twig-bundle": "4.4.*",
         "symfony/var-dumper": "4.4.*",
         "symfony/yaml": "4.4.*",
-        "terminal42/escargot": "^1.2",
+        "terminal42/escargot": "^1.4.1",
         "terminal42/service-annotation-bundle": "^1.1",
         "true/punycode": "^2.1",
         "twig/twig": "^2.7",

--- a/core-bundle/src/Command/CrawlCommand.php
+++ b/core-bundle/src/Command/CrawlCommand.php
@@ -80,7 +80,7 @@ class CrawlCommand extends Command
             ->addOption('concurrency', 'c', InputOption::VALUE_REQUIRED, 'The number of concurrent requests that are going to be executed', 10)
             ->addOption('delay', null, InputOption::VALUE_REQUIRED, 'The number of microseconds to wait between requests (0 = throttling is disabled)', 0)
             ->addOption('max-requests', null, InputOption::VALUE_REQUIRED, 'The maximum number of requests to execute (0 = no limit)', 0)
-            ->addOption('max-depth', null, InputOption::VALUE_REQUIRED, 'The maximum depth to crawl for (0 = no limit)', 0)
+            ->addOption('max-depth', null, InputOption::VALUE_REQUIRED, 'The maximum depth to crawl for (0 = no limit)', 10)
             ->addOption('no-progress', null, InputOption::VALUE_NONE, 'Disables the progress bar output')
             ->addOption('enable-debug-csv', null, InputOption::VALUE_NONE, 'Writes the crawl debug log into a separate CSV file')
             ->addOption('debug-csv-path', null, InputOption::VALUE_REQUIRED, 'The path of the debug log CSV file', getcwd().'/crawl_debug_log.csv')

--- a/core-bundle/src/Crawl/Escargot/Subscriber/SearchIndexSubscriber.php
+++ b/core-bundle/src/Crawl/Escargot/Subscriber/SearchIndexSubscriber.php
@@ -67,12 +67,12 @@ class SearchIndexSubscriber implements EscargotSubscriberInterface, EscargotAwar
 
     public function shouldRequest(CrawlUri $crawlUri): string
     {
-        // Respect robots.txt info and rel="nofollow" attributes
+        // Respect robots.txt info and nofollow meta data
         if (!Util::isAllowedToFollow($crawlUri, $this->escargot)) {
             $this->logWithCrawlUri(
                 $crawlUri,
                 LogLevel::DEBUG,
-                'Do not request because the URI was disallowed to be followed by either rel="nofollow" or robots.txt hints.'
+                'Do not request because the URI was disallowed to be followed by nofollow or robots.txt hints.'
             );
 
             return SubscriberInterface::DECISION_NEGATIVE;

--- a/core-bundle/src/Crawl/Escargot/Subscriber/SearchIndexSubscriber.php
+++ b/core-bundle/src/Crawl/Escargot/Subscriber/SearchIndexSubscriber.php
@@ -73,7 +73,7 @@ class SearchIndexSubscriber implements EscargotSubscriberInterface, EscargotAwar
             $this->logWithCrawlUri(
                 $crawlUri,
                 LogLevel::DEBUG,
-                'Did not request because it was marked to be skipped using the data-skip-search-index attribute.'
+                'Do not request because it was marked to be skipped using the data-skip-search-index attribute.'
             );
 
             return SubscriberInterface::DECISION_NEGATIVE;

--- a/core-bundle/src/Crawl/Escargot/Subscriber/SearchIndexSubscriber.php
+++ b/core-bundle/src/Crawl/Escargot/Subscriber/SearchIndexSubscriber.php
@@ -39,6 +39,8 @@ class SearchIndexSubscriber implements EscargotSubscriberInterface, EscargotAwar
     use LoggerAwareTrait;
     use SubscriberLoggerTrait;
 
+    public const TAG_SKIP = 'skip-search-index';
+
     /**
      * @var IndexerInterface
      */
@@ -67,6 +69,16 @@ class SearchIndexSubscriber implements EscargotSubscriberInterface, EscargotAwar
 
     public function shouldRequest(CrawlUri $crawlUri): string
     {
+        if ($crawlUri->hasTag(self::TAG_SKIP)) {
+            $this->logWithCrawlUri(
+                $crawlUri,
+                LogLevel::DEBUG,
+                'Did not request because it was marked to be skipped using the data-skip-search-index attribute.'
+            );
+
+            return SubscriberInterface::DECISION_NEGATIVE;
+        }
+
         // Respect robots.txt info and nofollow meta data
         if (!Util::isAllowedToFollow($crawlUri, $this->escargot)) {
             $this->logWithCrawlUri(

--- a/core-bundle/src/EventListener/RobotsTxtListener.php
+++ b/core-bundle/src/EventListener/RobotsTxtListener.php
@@ -60,6 +60,7 @@ class RobotsTxtListener
         foreach ($records as $record) {
             $directiveList = $record->getDirectiveList();
             $directiveList->add(new Directive('Disallow', '/contao/'));
+            $directiveList->add(new Directive('Disallow', '/_contao/'));
         }
 
         /** @var PageModel $pageModel */

--- a/core-bundle/src/Resources/contao/classes/Crawl.php
+++ b/core-bundle/src/Resources/contao/classes/Crawl.php
@@ -180,7 +180,7 @@ class Crawl extends Backend implements \executable
 		// Configure with sane defaults for the back end (maybe we should make this configurable one day)
 		$escargot = $escargot
 			->withConcurrency(5)
-			->withMaxDepth(32)
+			->withMaxDepth(10)
 			->withMaxRequests(20)
 			->withLogger($this->createLogger($factory, $activeSubscribers, $jobId, $debugLogPath));
 

--- a/core-bundle/src/Resources/contao/modules/Module.php
+++ b/core-bundle/src/Resources/contao/modules/Module.php
@@ -429,16 +429,11 @@ abstract class Module extends Frontend
 		$row['link'] = $objSubpage->title;
 		$row['href'] = $href;
 		$row['rel'] = '';
-		$row['nofollow'] = (strncmp($objSubpage->robots, 'noindex,nofollow', 16) === 0); // backwards compatibility
+		$row['nofollow'] = false; // backwards compatibility
 		$row['target'] = '';
 		$row['description'] = str_replace(array("\n", "\r"), array(' ', ''), $objSubpage->description);
 
 		$arrRel = array();
-
-		if (strncmp($objSubpage->robots, 'noindex,nofollow', 16) === 0)
-		{
-			$arrRel[] = 'nofollow';
-		}
 
 		// Override the link target
 		if ($objSubpage->type == 'redirect' && $objSubpage->target)

--- a/core-bundle/src/Resources/contao/modules/ModuleCustomnav.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleCustomnav.php
@@ -178,16 +178,11 @@ class ModuleCustomnav extends Module
 					$row['link'] = $objModel->title;
 					$row['href'] = $href;
 					$row['rel'] = '';
-					$row['nofollow'] = (strncmp($objModel->robots, 'noindex,nofollow', 16) === 0);
+					$row['nofollow'] = false; // backwards compatibility
 					$row['target'] = '';
 					$row['description'] = str_replace(array("\n", "\r"), array(' ', ''), $objModel->description);
 
 					$arrRel = array();
-
-					if (strncmp($objModel->robots, 'noindex,nofollow', 16) === 0)
-					{
-						$arrRel[] = 'nofollow';
-					}
 
 					// Override the link target
 					if ($objModel->type == 'redirect' && $objModel->target)
@@ -221,16 +216,11 @@ class ModuleCustomnav extends Module
 					$row['link'] = $objModel->title;
 					$row['href'] = $href;
 					$row['rel'] = '';
-					$row['nofollow'] = (strncmp($objModel->robots, 'noindex,nofollow', 16) === 0);
+					$row['nofollow'] = false; // backwards compatibility
 					$row['target'] = '';
 					$row['description'] = str_replace(array("\n", "\r"), array(' ', ''), $objModel->description);
 
 					$arrRel = array();
-
-					if (strncmp($objModel->robots, 'noindex,nofollow', 16) === 0)
-					{
-						$arrRel[] = 'nofollow';
-					}
 
 					// Override the link target
 					if ($objModel->type == 'redirect' && $objModel->target)

--- a/core-bundle/src/Resources/contao/templates/modules/mod_article.html5
+++ b/core-bundle/src/Resources/contao/templates/modules/mod_article.html5
@@ -27,16 +27,16 @@
         <!-- indexer::stop -->
         <div class="syndication">
           <?php if ($this->printButton): ?>
-            <a href="<?= $this->print ?>" class="print" title="<?= $this->printTitle ?>" onclick="window.print();return false"><?= Contao\Image::getHtml('assets/contao/images/print.svg') ?></a>
+            <a href="<?= $this->print ?>" class="print" title="<?= $this->printTitle ?>" onclick="window.print();return false" data-skip-search-index><?= Contao\Image::getHtml('assets/contao/images/print.svg') ?></a>
           <?php endif; ?>
           <?php if ($this->pdfButton): ?>
-            <a href="<?= $this->href ?>" class="pdf" title="<?= $this->pdfTitle ?>"><?= Contao\Image::getHtml('assets/contao/images/pdf.svg') ?></a>
+            <a href="<?= $this->href ?>" class="pdf" title="<?= $this->pdfTitle ?>" data-skip-search-index><?= Contao\Image::getHtml('assets/contao/images/pdf.svg') ?></a>
           <?php endif; ?>
           <?php if ($this->facebookButton): ?>
-            <a href="<?= $this->route('contao_frontend_share', ['p' => 'facebook', 'u' => $this->encUrl]) ?>" class="facebook" rel="nofollow" title="<?= $this->facebookTitle ?>" onclick="var w=window.open(this.href,'','width=640,height=380,modal=yes,left=100,top=50,location=no,menubar=no,resizable=yes,scrollbars=yes,status=no,toolbar=no');w.opener=null;return false"><?= Contao\Image::getHtml('assets/contao/images/facebook.svg') ?></a>
+            <a href="<?= $this->route('contao_frontend_share', ['p' => 'facebook', 'u' => $this->encUrl]) ?>" class="facebook" rel="nofollow" title="<?= $this->facebookTitle ?>" onclick="var w=window.open(this.href,'','width=640,height=380,modal=yes,left=100,top=50,location=no,menubar=no,resizable=yes,scrollbars=yes,status=no,toolbar=no');w.opener=null;return false" data-skip-search-index><?= Contao\Image::getHtml('assets/contao/images/facebook.svg') ?></a>
           <?php endif; ?>
           <?php if ($this->twitterButton): ?>
-            <a href="<?= $this->route('contao_frontend_share', ['p' => 'twitter', 'u' => $this->encUrl, 't' => $this->encTitle]) ?>" class="twitter" rel="nofollow" title="<?= $this->twitterTitle ?>" onclick="var w=window.open(this.href,'','width=640,height=380,modal=yes,left=100,top=50,location=no,menubar=no,resizable=yes,scrollbars=yes,status=no,toolbar=no');w.opener=null;return false"><?= Contao\Image::getHtml('assets/contao/images/twitter.svg') ?></a>
+            <a href="<?= $this->route('contao_frontend_share', ['p' => 'twitter', 'u' => $this->encUrl, 't' => $this->encTitle]) ?>" class="twitter" rel="nofollow" title="<?= $this->twitterTitle ?>" onclick="var w=window.open(this.href,'','width=640,height=380,modal=yes,left=100,top=50,location=no,menubar=no,resizable=yes,scrollbars=yes,status=no,toolbar=no');w.opener=null;return false" data-skip-search-index><?= Contao\Image::getHtml('assets/contao/images/twitter.svg') ?></a>
           <?php endif; ?>
         </div>
         <!-- indexer::continue -->

--- a/core-bundle/src/Resources/contao/templates/modules/mod_article.html5
+++ b/core-bundle/src/Resources/contao/templates/modules/mod_article.html5
@@ -33,10 +33,10 @@
             <a href="<?= $this->href ?>" class="pdf" title="<?= $this->pdfTitle ?>" data-skip-search-index><?= Contao\Image::getHtml('assets/contao/images/pdf.svg') ?></a>
           <?php endif; ?>
           <?php if ($this->facebookButton): ?>
-            <a href="<?= $this->route('contao_frontend_share', ['p' => 'facebook', 'u' => $this->encUrl]) ?>" class="facebook" rel="nofollow" title="<?= $this->facebookTitle ?>" onclick="var w=window.open(this.href,'','width=640,height=380,modal=yes,left=100,top=50,location=no,menubar=no,resizable=yes,scrollbars=yes,status=no,toolbar=no');w.opener=null;return false" data-skip-search-index><?= Contao\Image::getHtml('assets/contao/images/facebook.svg') ?></a>
+            <a href="<?= $this->route('contao_frontend_share', ['p' => 'facebook', 'u' => $this->encUrl]) ?>" class="facebook" rel="nofollow" title="<?= $this->facebookTitle ?>" onclick="var w=window.open(this.href,'','width=640,height=380,modal=yes,left=100,top=50,location=no,menubar=no,resizable=yes,scrollbars=yes,status=no,toolbar=no');w.opener=null;return false"><?= Contao\Image::getHtml('assets/contao/images/facebook.svg') ?></a>
           <?php endif; ?>
           <?php if ($this->twitterButton): ?>
-            <a href="<?= $this->route('contao_frontend_share', ['p' => 'twitter', 'u' => $this->encUrl, 't' => $this->encTitle]) ?>" class="twitter" rel="nofollow" title="<?= $this->twitterTitle ?>" onclick="var w=window.open(this.href,'','width=640,height=380,modal=yes,left=100,top=50,location=no,menubar=no,resizable=yes,scrollbars=yes,status=no,toolbar=no');w.opener=null;return false" data-skip-search-index><?= Contao\Image::getHtml('assets/contao/images/twitter.svg') ?></a>
+            <a href="<?= $this->route('contao_frontend_share', ['p' => 'twitter', 'u' => $this->encUrl, 't' => $this->encTitle]) ?>" class="twitter" rel="nofollow" title="<?= $this->twitterTitle ?>" onclick="var w=window.open(this.href,'','width=640,height=380,modal=yes,left=100,top=50,location=no,menubar=no,resizable=yes,scrollbars=yes,status=no,toolbar=no');w.opener=null;return false"><?= Contao\Image::getHtml('assets/contao/images/twitter.svg') ?></a>
           <?php endif; ?>
         </div>
         <!-- indexer::continue -->

--- a/core-bundle/src/Resources/contao/templates/modules/mod_article.html5
+++ b/core-bundle/src/Resources/contao/templates/modules/mod_article.html5
@@ -27,10 +27,10 @@
         <!-- indexer::stop -->
         <div class="syndication">
           <?php if ($this->printButton): ?>
-            <a href="<?= $this->print ?>" class="print" rel="nofollow" title="<?= $this->printTitle ?>" onclick="window.print();return false"><?= Contao\Image::getHtml('assets/contao/images/print.svg') ?></a>
+            <a href="<?= $this->print ?>" class="print" title="<?= $this->printTitle ?>" onclick="window.print();return false"><?= Contao\Image::getHtml('assets/contao/images/print.svg') ?></a>
           <?php endif; ?>
           <?php if ($this->pdfButton): ?>
-            <a href="<?= $this->href ?>" class="pdf" rel="nofollow" title="<?= $this->pdfTitle ?>"><?= Contao\Image::getHtml('assets/contao/images/pdf.svg') ?></a>
+            <a href="<?= $this->href ?>" class="pdf" title="<?= $this->pdfTitle ?>"><?= Contao\Image::getHtml('assets/contao/images/pdf.svg') ?></a>
           <?php endif; ?>
           <?php if ($this->facebookButton): ?>
             <a href="<?= $this->route('contao_frontend_share', ['p' => 'facebook', 'u' => $this->encUrl]) ?>" class="facebook" rel="nofollow" title="<?= $this->facebookTitle ?>" onclick="var w=window.open(this.href,'','width=640,height=380,modal=yes,left=100,top=50,location=no,menubar=no,resizable=yes,scrollbars=yes,status=no,toolbar=no');w.opener=null;return false"><?= Contao\Image::getHtml('assets/contao/images/facebook.svg') ?></a>

--- a/core-bundle/tests/Command/CrawlCommandTest.php
+++ b/core-bundle/tests/Command/CrawlCommandTest.php
@@ -71,7 +71,7 @@ class CrawlCommandTest extends TestCase
         $this->assertSame(10, $command->getEscargot()->getConcurrency());
         $this->assertSame(0, $command->getEscargot()->getRequestDelay());
         $this->assertSame(0, $command->getEscargot()->getMaxRequests());
-        $this->assertSame(0, $command->getEscargot()->getMaxDepth());
+        $this->assertSame(10, $command->getEscargot()->getMaxDepth());
 
         // Test options
         $escargot = Escargot::create($this->createBaseUriCollection(), new InMemoryQueue())

--- a/core-bundle/tests/Crawl/Escargot/Subscriber/SearchIndexSubscriberTest.php
+++ b/core-bundle/tests/Crawl/Escargot/Subscriber/SearchIndexSubscriberTest.php
@@ -124,6 +124,13 @@ class SearchIndexSubscriberTest extends TestCase
             'Did not index because it was not part of the base URI collection.',
         ];
 
+        yield 'Test skips URIs that were marked to be skipped by the data attribue' => [
+            (new CrawlUri(new Uri('https://contao.org/foobar'), 0))->addTag(SearchIndexSubscriber::TAG_SKIP),
+            SubscriberInterface::DECISION_NEGATIVE,
+            LogLevel::DEBUG,
+            'Did not request because it was marked to be skipped using the data-skip-search-index attribute.',
+        ];
+
         yield 'Test requests if everything is okay' => [
             (new CrawlUri(new Uri('https://contao.org/foobar'), 0)),
             SubscriberInterface::DECISION_POSITIVE,

--- a/core-bundle/tests/Crawl/Escargot/Subscriber/SearchIndexSubscriberTest.php
+++ b/core-bundle/tests/Crawl/Escargot/Subscriber/SearchIndexSubscriberTest.php
@@ -128,7 +128,7 @@ class SearchIndexSubscriberTest extends TestCase
             (new CrawlUri(new Uri('https://contao.org/foobar'), 0))->addTag(SearchIndexSubscriber::TAG_SKIP),
             SubscriberInterface::DECISION_NEGATIVE,
             LogLevel::DEBUG,
-            'Did not request because it was marked to be skipped using the data-skip-search-index attribute.',
+            'Do not request because it was marked to be skipped using the data-skip-search-index attribute.',
         ];
 
         yield 'Test requests if everything is okay' => [

--- a/core-bundle/tests/Crawl/Escargot/Subscriber/SearchIndexSubscriberTest.php
+++ b/core-bundle/tests/Crawl/Escargot/Subscriber/SearchIndexSubscriberTest.php
@@ -99,22 +99,15 @@ class SearchIndexSubscriberTest extends TestCase
             (new CrawlUri(new Uri('https://contao.org'), 1, false, new Uri('https://original.contao.org'))),
             SubscriberInterface::DECISION_NEGATIVE,
             LogLevel::DEBUG,
-            'Do not request because the URI was disallowed to be followed by either rel="nofollow" or robots.txt hints.',
+            'Do not request because the URI was disallowed to be followed by nofollow or robots.txt hints.',
             (new CrawlUri(new Uri('https://original.contao.org'), 0, true))->addTag(RobotsSubscriber::TAG_NOFOLLOW),
-        ];
-
-        yield 'Test skips URIs that contained the rel-nofollow tag' => [
-            (new CrawlUri(new Uri('https://contao.org'), 0))->addTag(HtmlCrawlerSubscriber::TAG_REL_NOFOLLOW),
-            SubscriberInterface::DECISION_NEGATIVE,
-            LogLevel::DEBUG,
-            'Do not request because the URI was disallowed to be followed by either rel="nofollow" or robots.txt hints.',
         ];
 
         yield 'Test skips URIs that were disallowed by the robots.txt content' => [
             (new CrawlUri(new Uri('https://contao.org'), 0))->addTag(RobotsSubscriber::TAG_DISALLOWED_ROBOTS_TXT),
             SubscriberInterface::DECISION_NEGATIVE,
             LogLevel::DEBUG,
-            'Do not request because the URI was disallowed to be followed by either rel="nofollow" or robots.txt hints.',
+            'Do not request because the URI was disallowed to be followed by nofollow or robots.txt hints.',
         ];
 
         yield 'Test skips URIs that contained the no-html-type tag' => [

--- a/core-bundle/tests/EventListener/RobotsTxtListenerTest.php
+++ b/core-bundle/tests/EventListener/RobotsTxtListenerTest.php
@@ -77,6 +77,7 @@ class RobotsTxtListenerTest extends TestCase
             <<<'EOF'
 user-agent:*
 disallow:/contao/
+disallow:/_contao/
 
 sitemap:https://www.foobar.com/share/sitemap-name.xml
 EOF
@@ -92,6 +93,7 @@ EOF
 user-agent:*
 allow:/
 disallow:/contao/
+disallow:/_contao/
 
 sitemap:https://www.foobar.com/share/sitemap-name.xml
 EOF
@@ -107,9 +109,11 @@ EOF
 user-agent:googlebot
 allow:/
 disallow:/contao/
+disallow:/_contao/
 
 user-agent:*
 disallow:/contao/
+disallow:/_contao/
 
 sitemap:https://www.foobar.com/share/sitemap-name.xml
 EOF


### PR DESCRIPTION
As discussed on Slack, this removes `rel="nofollow"` for internal page links. This feature was implemented around Contao 2.7.0, probably under the assumption that it directs crawlers to "not follow" that URI. But actually:

> The [nofollow](https://html.spec.whatwg.org/multipage/links.html#link-type-nofollow) keyword indicates that the link is not endorsed by the original author or publisher of the page, or that the link to the referenced document was included primarily because of a commercial relationship between people affiliated with the two pages.

The attribute is not supposed to indicate that a page should not be crawled. Only that the target URI is not "endorsed" by the author of the originating document - and thus it can only serve as a hint for any crawler subscriber.

This PR removes the automatic output of `rel="nofollow"` in the navigation modules, if the target page has `noindex,nofollow` defined. It also removes any `rel="nofollow"` occurrences in templates for internal links, notably the mini calendar.

Links to external pages like the website of a comment's author or social media share URLs retain that attribute.

_Note:_ we briefly discussed whether we should introduce a `data-skip-search-index` so that we can still direct the search index to not index the `example.com/foobar?month=202204` URLs of the calendar for instance. However, this is not actually necessary, as `PageRegular` will automatically enable `noSearch` when these query parameters are present and thus such URLs are not put into the search index by Contao anyway.

Related: https://github.com/terminal42/escargot/pull/26