### PR TITLE
Fix the SendNewsletterEvent when sending as text only

### DIFF
--- a/newsletter-bundle/src/Resources/contao/classes/Newsletter.php
+++ b/newsletter-bundle/src/Resources/contao/classes/Newsletter.php
@@ -413,7 +413,7 @@ class Newsletter extends Backend
 			$objEmail->imageDir = System::getContainer()->getParameter('kernel.project_dir') . '/';
 		}
 
-		$event = (new SendNewsletterEvent($arrRecipient['email'], $objEmail->text, $objEmail->html))
+		$event = (new SendNewsletterEvent($arrRecipient['email'], $objEmail->text, $objEmail->html ?? ''))
 			->setHtmlAllowed(!$objNewsletter->sendText)
 			->setNewsletterData($objNewsletter->row())
 			->setRecipientData($arrRecipient);


### PR DESCRIPTION
Fixes

```
Uncaught PHP Exception TypeError: "Argument 3 passed to Contao\NewsletterBundle\Event\SendNewsletterEvent::__construct() must be of the type string, null given
```

To reproduce send the newsletter as text only (no HTML).

/cc @SeverinGloeckle 