### PR TITLE
Fix header fields for blank option

### DIFF
--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -4294,13 +4294,13 @@ class DC_Table extends DataContainer implements \listable, \editable
 					$this->import($strClass);
 					$options_callback = $this->$strClass->$strMethod($this);
 
-					$_v = $options_callback[$_v] ?? '---';
+					$_v = $options_callback[$_v] ?? '-';
 				}
 				elseif (\is_callable($GLOBALS['TL_DCA'][$this->ptable]['fields'][$v]['options_callback']))
 				{
 					$options_callback = $GLOBALS['TL_DCA'][$this->ptable]['fields'][$v]['options_callback']($this);
 
-					$_v = $options_callback[$_v] ?? '---';
+					$_v = $options_callback[$_v] ?? '-';
 				}
 
 				// Add the sorting field

--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -4294,13 +4294,13 @@ class DC_Table extends DataContainer implements \listable, \editable
 					$this->import($strClass);
 					$options_callback = $this->$strClass->$strMethod($this);
 
-					$_v = $options_callback[$_v];
+					$_v = $options_callback[$_v] ?? '---';
 				}
 				elseif (\is_callable($GLOBALS['TL_DCA'][$this->ptable]['fields'][$v]['options_callback']))
 				{
 					$options_callback = $GLOBALS['TL_DCA'][$this->ptable]['fields'][$v]['options_callback']($this);
 
-					$_v = $options_callback[$_v];
+					$_v = $options_callback[$_v] ?? '---';
 				}
 
 				// Add the sorting field


### PR DESCRIPTION
While debugging the contao leads I struggled with the missing blank option for the header fields.
The default for the blank option in the database is `0` but this is not included in the options callback.

Of course we could also only output `''` instead of `'---'`
