### PR TITLE
Improve the XDebug experience

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -307,14 +307,14 @@
             "@ecs-legacy",
             "@ecs-templates"
         ],
-        "ecs": "@php -dxdebug.mode=off tools/ecs/vendor/bin/ecs check *-bundle/bin *-bundle/src *-bundle/tests test-case/src tools/*/src --config tools/ecs/config/default.php --fix --ansi",
-        "ecs-legacy": "@php -dxdebug.mode=off tools/ecs/vendor/bin/ecs check *-bundle/src/Resources/contao --config tools/ecs/config/legacy.php --fix --ansi",
-        "ecs-templates": "@php -dxdebug.mode=off tools/ecs/vendor/bin/ecs check *-bundle/src/Resources/contao/templates --config tools/ecs/config/template.php --fix --ansi",
-        "functional-tests": "@php -dxdebug.mode=off vendor/bin/phpunit --testsuite=functional --colors=always",
-        "monorepo-tools": "@php -dxdebug.mode=off tools/monorepo/vendor/bin/monorepo-tools composer-json --validate --ansi",
-        "phpstan": "@php -dxdebug.mode=off tools/phpstan/vendor/bin/phpstan analyze --ansi",
-        "require-checker": "@php -dxdebug.mode=off tools/require-checker/vendor/bin/composer-require-checker check --config-file=tools/require-checker/config.json composer.json",
-        "service-linter": "@php -dxdebug.mode=off tools/service-linter/bin/lint-service-ids --ansi",
-        "unit-tests": "@php -dxdebug.mode=off vendor/bin/phpunit --colors=always"
+        "ecs": "@php tools/ecs/vendor/bin/ecs check *-bundle/bin *-bundle/src *-bundle/tests test-case/src tools/*/src --config tools/ecs/config/default.php --fix --ansi",
+        "ecs-legacy": "@php tools/ecs/vendor/bin/ecs check *-bundle/src/Resources/contao --config tools/ecs/config/legacy.php --fix --ansi",
+        "ecs-templates": "@php tools/ecs/vendor/bin/ecs check *-bundle/src/Resources/contao/templates --config tools/ecs/config/template.php --fix --ansi",
+        "functional-tests": "@php vendor/bin/phpunit --testsuite=functional --colors=always",
+        "monorepo-tools": "@php tools/monorepo/vendor/bin/monorepo-tools composer-json --validate --ansi",
+        "phpstan": "@php tools/phpstan/vendor/bin/phpstan analyze --ansi",
+        "require-checker": "@php tools/require-checker/vendor/bin/composer-require-checker check --config-file=tools/require-checker/config.json composer.json",
+        "service-linter": "@php tools/service-linter/bin/lint-service-ids --ansi",
+        "unit-tests": "@php vendor/bin/phpunit --colors=always"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -307,14 +307,14 @@
             "@ecs-legacy",
             "@ecs-templates"
         ],
-        "ecs": "@php tools/ecs/vendor/bin/ecs check *-bundle/bin *-bundle/src *-bundle/tests test-case/src tools/*/src --config tools/ecs/config/default.php --fix --ansi",
-        "ecs-legacy": "@php tools/ecs/vendor/bin/ecs check *-bundle/src/Resources/contao --config tools/ecs/config/legacy.php --fix --ansi",
-        "ecs-templates": "@php tools/ecs/vendor/bin/ecs check *-bundle/src/Resources/contao/templates --config tools/ecs/config/template.php --fix --ansi",
-        "functional-tests": "@php vendor/bin/phpunit --testsuite=functional --colors=always",
-        "monorepo-tools": "@php tools/monorepo/vendor/bin/monorepo-tools composer-json --validate --ansi",
-        "phpstan": "@php tools/phpstan/vendor/bin/phpstan analyze --ansi",
-        "require-checker": "@php tools/require-checker/vendor/bin/composer-require-checker check --config-file=tools/require-checker/config.json composer.json",
-        "service-linter": "@php tools/service-linter/bin/lint-service-ids --ansi",
-        "unit-tests": "@php vendor/bin/phpunit --colors=always"
+        "ecs": "@php -dxdebug.mode=off tools/ecs/vendor/bin/ecs check *-bundle/bin *-bundle/src *-bundle/tests test-case/src tools/*/src --config tools/ecs/config/default.php --fix --ansi",
+        "ecs-legacy": "@php -dxdebug.mode=off tools/ecs/vendor/bin/ecs check *-bundle/src/Resources/contao --config tools/ecs/config/legacy.php --fix --ansi",
+        "ecs-templates": "@php -dxdebug.mode=off tools/ecs/vendor/bin/ecs check *-bundle/src/Resources/contao/templates --config tools/ecs/config/template.php --fix --ansi",
+        "functional-tests": "@php -dxdebug.mode=off vendor/bin/phpunit --testsuite=functional --colors=always",
+        "monorepo-tools": "@php -dxdebug.mode=off tools/monorepo/vendor/bin/monorepo-tools composer-json --validate --ansi",
+        "phpstan": "@php -dxdebug.mode=off tools/phpstan/vendor/bin/phpstan analyze --ansi",
+        "require-checker": "@php -dxdebug.mode=off tools/require-checker/vendor/bin/composer-require-checker check --config-file=tools/require-checker/config.json composer.json",
+        "service-linter": "@php -dxdebug.mode=off tools/service-linter/bin/lint-service-ids --ansi",
+        "unit-tests": "@php -dxdebug.mode=off vendor/bin/phpunit --colors=always"
     }
 }

--- a/test-case/src/WarnXdebugPhpunitExtension.php
+++ b/test-case/src/WarnXdebugPhpunitExtension.php
@@ -19,7 +19,7 @@ class WarnXdebugPhpunitExtension implements BeforeFirstTestHook
     public function executeBeforeFirstTest(): void
     {
         if (\is_callable('xdebug_info') && [] !== xdebug_info('mode') && ['off'] !== xdebug_info('mode')) {
-            trigger_error('XDebug is enabled, consider disabling it to speed up unit tests.', E_USER_WARNING);
+            fwrite(STDERR, "XDebug is enabled, consider disabling it to speed up unit tests.\n\n");
         }
     }
 }

--- a/test-case/src/WarnXdebugPhpunitExtension.php
+++ b/test-case/src/WarnXdebugPhpunitExtension.php
@@ -19,7 +19,7 @@ class WarnXdebugPhpunitExtension implements BeforeFirstTestHook
     public function executeBeforeFirstTest(): void
     {
         if (\is_callable('xdebug_info') && [] !== xdebug_info('mode') && ['off'] !== xdebug_info('mode')) {
-            fwrite(STDERR, "XDebug is enabled, consider disabling it to speed up unit tests.\n\n");
+            fwrite(STDERR, "XDebug is enabled, consider disabling it to speed up the unit tests.\n\n");
         }
     }
 }


### PR DESCRIPTION
Here is a followup to #4394 with some tweaks regarding running with XDebug.

Writing to `STDTERR` is less obtrusive than triggering an error [1fdb124f088de941888e2bc936399018e46e798e]. It will be colored depending on your terminal. In PHPStorm, by default, you'll basically get this in the terminal when running `vendor/bin/phpunit` / running selected tests via the run configuration:

![image](https://user-images.githubusercontent.com/5305677/163023720-c29d610b-18a1-499f-b49c-fe5cbb87a552.png)
![image](https://user-images.githubusercontent.com/5305677/163023977-693d8148-a152-4a19-bf4c-a44023ba9889.png)

With 1118426d3e5163cf311550f9d5b36b185134737d, running `composer run …` will default to disabling xdebug.