### PR TITLE
Disable the TinyMCE context menu by default

### DIFF
--- a/core-bundle/src/Resources/contao/templates/backend/be_tinyMCE.html5
+++ b/core-bundle/src/Resources/contao/templates/backend/be_tinyMCE.html5
@@ -60,6 +60,10 @@ window.tinymce && tinymce.init({
     toolbar: 'link unlink | image | formatselect | bold italic | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | code',
   <?php $this->endblock(); ?>
 
+  <?php $this->block('contextmenu'); ?>
+    contextmenu: false,
+  <?php $this->endblock(); ?>
+
   <?php $this->block('custom'); ?>
   <?php $this->endblock(); ?>
 


### PR DESCRIPTION
Disable context menu by default and make it configurable

Fixes #4181
