### PR TITLE
Do not use head and attribute data in search context

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Search.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Search.php
@@ -173,7 +173,7 @@ class Search
 		$strBody = strip_tags($strBody);
 
 		// Put everything together
-		$arrSet['text'] = $strBody . "\n" . $arrData['title'] . ' ' . $arrData['description'] . ' ' . $arrData['keywords'];
+		$arrSet['text'] = $strBody . ' ' . $arrData['description'] . "\n" . $arrData['title'] . "\n" . $arrData['keywords'];
 		$arrSet['text'] = trim(preg_replace('/ +/', ' ', StringUtil::decodeEntities($arrSet['text'])));
 
 		// Calculate the checksum

--- a/core-bundle/src/Resources/contao/library/Contao/Search.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Search.php
@@ -173,7 +173,7 @@ class Search
 		$strBody = strip_tags($strBody);
 
 		// Put everything together
-		$arrSet['text'] = $arrData['title'] . ' ' . $arrData['description'] . ' ' . $strBody . ' ' . $arrData['keywords'];
+		$arrSet['text'] = $strBody . "\n" . $arrData['title'] . ' ' . $arrData['description'] . ' ' . $arrData['keywords'];
 		$arrSet['text'] = trim(preg_replace('/ +/', ' ', StringUtil::decodeEntities($arrSet['text'])));
 
 		// Calculate the checksum

--- a/core-bundle/src/Resources/contao/modules/ModuleSearch.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleSearch.php
@@ -245,7 +245,7 @@ class ModuleSearch extends Module
 				$objTemplate->unit = $GLOBALS['TL_LANG']['UNITS'][1];
 
 				$arrContext = array();
-				$strText = StringUtil::stripInsertTags($arrResult[$i]['text']);
+				$strText = StringUtil::stripInsertTags(strtok($arrResult[$i]['text'], "\n"));
 				$arrMatches = Search::getMatchVariants(StringUtil::trimsplit(',', $arrResult[$i]['matches']), $strText, $GLOBALS['TL_LANGUAGE']);
 
 				// Get the context


### PR DESCRIPTION
The search result module currently shows a context of the page where the search topic was found. It is confusing for a user to see context data that does not actually appear on the page (e.g. link `title` or image `alt` attributes).
This PR is a simple approach of splitting "meta" and body data. It will result in a new index of all pages (because the checksum changes), but it is supposed to seamlessly work with the existing search data until reindexed.