### PR TITLE
Deprecate Contao\Request

### DIFF
--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -1,8 +1,13 @@
 # Deprecated features
 
+## Request library
+
+Using `Contao\Request` is deprecated and will no longer work in Contao 5.0. Use an alternative library
+such as `symfony/http-client` instead.
+
 ## Cache library
 
-Using `Contao/Cache` is deprecated and will no longer work in Contao 5.0. Use your own in-memory
+Using `Contao\Cache` is deprecated and will no longer work in Contao 5.0. Use your own in-memory
 caches instead. Use `symfony/cache` for persistence.
 
 ## $GLOBALS['TL_CSS_UNITS']

--- a/core-bundle/src/Resources/contao/library/Contao/Request.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Request.php
@@ -10,6 +10,8 @@
 
 namespace Contao;
 
+trigger_deprecation('contao/core-bundle', '4.13', 'Using the Request class has been deprecated and will no longer work in Contao 5.0. Use an alternative library such as symfony/http-client instead.');
+
 /**
  * Sends HTTP requests and reads the response
  *


### PR DESCRIPTION
It only supports HTTP 1.0 and there's just no point in keeping it in our code base any longer.