### PR TITLE
Only save personal data if there is no error

### DIFF
--- a/core-bundle/src/Resources/contao/modules/ModulePersonalData.php
+++ b/core-bundle/src/Resources/contao/modules/ModulePersonalData.php
@@ -316,7 +316,7 @@ class ModulePersonalData extends Module
 		}
 
 		// Save the model
-		if ($blnModified)
+		if ($blnModified && !$doNotSubmit)
 		{
 			$objMember->tstamp = time();
 			$objMember->save();


### PR DESCRIPTION
If the personal data is modified in the front end, but one of the fields has an error, the module currently saves the model data but does not trigger any hook or submit callbacks. Looks like a major bug to me 😆 