### PR TITLE
Fix an error when unpacking an associative array of model search criteria values

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Model.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Model.php
@@ -1088,7 +1088,7 @@ abstract class Model
 		}
 
 		$objStatement = static::preFind($objStatement);
-		$objResult = $objStatement->execute(...(\is_array($arrOptions['value']) ? $arrOptions['value'] : array($arrOptions['value'])));
+		$objResult = $objStatement->execute(...array_values(\is_array($arrOptions['value']) ? $arrOptions['value'] : array($arrOptions['value'])));
 
 		if ($objResult->numRows < 1)
 		{


### PR DESCRIPTION
In Contao 4.13 we do get an error when using Isotope product filtering:

<img width="809" alt="164628775-6b76e30f-f1cf-436f-bd68-47cbbfa5d939" src="https://user-images.githubusercontent.com/193483/164645125-a8da98d2-8948-44f6-b85e-ebc0b36a8479.png">

After quick discussion with @aschempp we agreed it is a BC break. This PR should fix that.