### PR TITLE
Fix the FAQ page module throwing a warning in PHP 8 if author could not be fetched

### DIFF
--- a/faq-bundle/src/Resources/contao/modules/ModuleFaqPage.php
+++ b/faq-bundle/src/Resources/contao/modules/ModuleFaqPage.php
@@ -122,9 +122,15 @@ class ModuleFaqPage extends Module
 				$this->addEnclosuresToTemplate($objTemp, $objFaq->row());
 			}
 
+			$strAuthor = '';
+
 			/** @var UserModel $objAuthor */
-			$objAuthor = $objFaq->getRelated('author');
-			$objTemp->info = sprintf($GLOBALS['TL_LANG']['MSC']['faqCreatedBy'], Date::parse($objPage->dateFormat, $objFaq->tstamp), $objAuthor->name);
+			if (($objAuthor = $objFaq->getRelated('author')) instanceof UserModel)
+			{
+				$strAuthor = $objAuthor->name;
+			}
+
+			$objTemp->info = sprintf($GLOBALS['TL_LANG']['MSC']['faqCreatedBy'], Date::parse($objPage->dateFormat, $objFaq->tstamp), $strAuthor);
 
 			/** @var FaqCategoryModel $objPid */
 			$objPid = $objFaq->getRelated('pid');


### PR DESCRIPTION
I have basically copied the logic from the FAQ reader module: https://github.com/contao/contao/blob/5.x/faq-bundle/src/Resources/contao/modules/ModuleFaqReader.php#L155-L163