### PR TITLE
Fix the registration module throwing a warning in PHP 8 if captcha is disabled

### DIFF
--- a/core-bundle/src/Resources/contao/modules/ModuleRegistration.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleRegistration.php
@@ -355,7 +355,7 @@ class ModuleRegistration extends Module
 		$this->Template->requestToken = System::getContainer()->get('contao.csrf.token_manager')->getDefaultTokenValue();
 
 		// Deprecated since Contao 4.0, to be removed in Contao 5.0
-		$this->Template->captcha = $arrFields['captcha']['captcha'];
+		$this->Template->captcha = $arrFields['captcha']['captcha'] ?? '';
 	}
 
 	/**


### PR DESCRIPTION
I took the solution from https://github.com/contao/contao/blob/5.x/core-bundle/src/Resources/contao/modules/ModuleRegistration.php#L306