### PR TITLE
Allow partial mocks and row()/setRow() when mocking classes with properties

### DIFF
--- a/core-bundle/tests/Cache/EntityCacheTagsTest.php
+++ b/core-bundle/tests/Cache/EntityCacheTagsTest.php
@@ -93,8 +93,7 @@ class EntityCacheTagsTest extends DoctrineTestCase
     {
         $entityCacheTags = $this->getEntityCacheTags();
 
-        /** @var PageModel $page */
-        $page = (new \ReflectionClass(PageModel::class))->newInstanceWithoutConstructor();
+        $page = $this->mockClassWithProperties(PageModel::class, preserve: ['getTable']);
         $page->id = 5;
 
         $this->assertSame('contao.db.tl_page.5', $entityCacheTags->getTagForModelInstance($page));
@@ -144,12 +143,10 @@ class EntityCacheTagsTest extends DoctrineTestCase
             ->setTags(new ArrayCollection([$tag]))
         ;
 
-        /** @var PageModel $page1 */
-        $page1 = (new \ReflectionClass(PageModel::class))->newInstanceWithoutConstructor();
+        $page1 = $this->mockClassWithProperties(PageModel::class, preserve: ['getTable']);
         $page1->id = 5;
 
-        /** @var PageModel $page2 */
-        $page2 = (new \ReflectionClass(PageModel::class))->newInstanceWithoutConstructor();
+        $page2 = $this->mockClassWithProperties(PageModel::class, preserve: ['getTable']);
         $page2->id = 6;
 
         $modelCollection = new Collection([$page1, $page2], 'tl_page');
@@ -207,8 +204,7 @@ class EntityCacheTagsTest extends DoctrineTestCase
 
         $post = (new BlogPost())->setId(1);
 
-        /** @var PageModel $page */
-        $page = (new \ReflectionClass(PageModel::class))->newInstanceWithoutConstructor();
+        $page = $this->mockClassWithProperties(PageModel::class, preserve: ['getTable']);
         $page->id = 2;
 
         $entityCacheTags = $this->getEntityCacheTags($responseTagger);
@@ -236,8 +232,7 @@ class EntityCacheTagsTest extends DoctrineTestCase
 
         $post = (new BlogPost())->setId(1);
 
-        /** @var PageModel $page */
-        $page = (new \ReflectionClass(PageModel::class))->newInstanceWithoutConstructor();
+        $page = $this->mockClassWithProperties(PageModel::class, preserve: ['getTable']);
         $page->id = 2;
 
         $entityCacheTags = $this->getEntityCacheTags(null, $cacheInvalidator);

--- a/core-bundle/tests/Cache/EntityCacheTagsTest.php
+++ b/core-bundle/tests/Cache/EntityCacheTagsTest.php
@@ -93,7 +93,7 @@ class EntityCacheTagsTest extends DoctrineTestCase
     {
         $entityCacheTags = $this->getEntityCacheTags();
 
-        $page = $this->mockClassWithProperties(PageModel::class, preserve: ['getTable']);
+        $page = $this->mockClassWithProperties(PageModel::class, except: ['getTable']);
         $page->id = 5;
 
         $this->assertSame('contao.db.tl_page.5', $entityCacheTags->getTagForModelInstance($page));
@@ -143,10 +143,10 @@ class EntityCacheTagsTest extends DoctrineTestCase
             ->setTags(new ArrayCollection([$tag]))
         ;
 
-        $page1 = $this->mockClassWithProperties(PageModel::class, preserve: ['getTable']);
+        $page1 = $this->mockClassWithProperties(PageModel::class, except: ['getTable']);
         $page1->id = 5;
 
-        $page2 = $this->mockClassWithProperties(PageModel::class, preserve: ['getTable']);
+        $page2 = $this->mockClassWithProperties(PageModel::class, except: ['getTable']);
         $page2->id = 6;
 
         $modelCollection = new Collection([$page1, $page2], 'tl_page');
@@ -204,7 +204,7 @@ class EntityCacheTagsTest extends DoctrineTestCase
 
         $post = (new BlogPost())->setId(1);
 
-        $page = $this->mockClassWithProperties(PageModel::class, preserve: ['getTable']);
+        $page = $this->mockClassWithProperties(PageModel::class, except: ['getTable']);
         $page->id = 2;
 
         $entityCacheTags = $this->getEntityCacheTags($responseTagger);
@@ -232,7 +232,7 @@ class EntityCacheTagsTest extends DoctrineTestCase
 
         $post = (new BlogPost())->setId(1);
 
-        $page = $this->mockClassWithProperties(PageModel::class, preserve: ['getTable']);
+        $page = $this->mockClassWithProperties(PageModel::class, except: ['getTable']);
         $page->id = 2;
 
         $entityCacheTags = $this->getEntityCacheTags(null, $cacheInvalidator);

--- a/core-bundle/tests/Contao/ControllerTest.php
+++ b/core-bundle/tests/Contao/ControllerTest.php
@@ -248,7 +248,7 @@ class ControllerTest extends TestCase
             ],
         ];
 
-        $filesModel = (new \ReflectionClass(FilesModel::class))->newInstanceWithoutConstructor();
+        $filesModel = $this->mockClassWithProperties(FilesModel::class);
         $filesModel->path = '/path/that/should/get/corrected';
 
         yield 'resource from files model' => [

--- a/core-bundle/tests/File/MetadataTest.php
+++ b/core-bundle/tests/File/MetadataTest.php
@@ -116,8 +116,7 @@ class MetadataTest extends TestCase
 
     public function testCreatesMetadataContainerFromContentModel(): void
     {
-        /** @var ContentModel $model */
-        $model = (new \ReflectionClass(ContentModel::class))->newInstanceWithoutConstructor();
+        $model = $this->mockClassWithProperties(ContentModel::class, preserve: ['getOverwriteMetadata']);
 
         $model->setRow([
             'id' => 100,
@@ -142,8 +141,7 @@ class MetadataTest extends TestCase
 
     public function testDoesNotCreateMetadataContainerFromContentModelIfOverwriteIsDisabled(): void
     {
-        /** @var ContentModel $model */
-        $model = (new \ReflectionClass(ContentModel::class))->newInstanceWithoutConstructor();
+        $model = $this->mockClassWithProperties(ContentModel::class, preserve: ['getOverwriteMetadata']);
 
         $model->setRow([
             'id' => 100,
@@ -157,8 +155,7 @@ class MetadataTest extends TestCase
 
     public function testCreatesMetadataContainerFromFilesModel(): void
     {
-        /** @var FilesModel $model */
-        $model = (new \ReflectionClass(FilesModel::class))->newInstanceWithoutConstructor();
+        $model = $this->mockClassWithProperties(FilesModel::class, preserve: ['getMetadata']);
 
         $model->setRow([
             'id' => 100,

--- a/core-bundle/tests/File/MetadataTest.php
+++ b/core-bundle/tests/File/MetadataTest.php
@@ -116,7 +116,7 @@ class MetadataTest extends TestCase
 
     public function testCreatesMetadataContainerFromContentModel(): void
     {
-        $model = $this->mockClassWithProperties(ContentModel::class, preserve: ['getOverwriteMetadata']);
+        $model = $this->mockClassWithProperties(ContentModel::class, except: ['getOverwriteMetadata']);
 
         $model->setRow([
             'id' => 100,
@@ -141,7 +141,7 @@ class MetadataTest extends TestCase
 
     public function testDoesNotCreateMetadataContainerFromContentModelIfOverwriteIsDisabled(): void
     {
-        $model = $this->mockClassWithProperties(ContentModel::class, preserve: ['getOverwriteMetadata']);
+        $model = $this->mockClassWithProperties(ContentModel::class, except: ['getOverwriteMetadata']);
 
         $model->setRow([
             'id' => 100,
@@ -155,7 +155,7 @@ class MetadataTest extends TestCase
 
     public function testCreatesMetadataContainerFromFilesModel(): void
     {
-        $model = $this->mockClassWithProperties(FilesModel::class, preserve: ['getMetadata']);
+        $model = $this->mockClassWithProperties(FilesModel::class, except: ['getMetadata']);
 
         $model->setRow([
             'id' => 100,

--- a/core-bundle/tests/Image/Preview/PreviewFactoryTest.php
+++ b/core-bundle/tests/Image/Preview/PreviewFactoryTest.php
@@ -143,7 +143,7 @@ class PreviewFactoryTest extends TestCase
      */
     public function testGetPreviewSizeFromImageSize(PictureConfiguration|ResizeConfiguration|array|int|string|null $size, int $expectedSize, string $defaultDensities = ''): void
     {
-        $imageSizeModel = (new \ReflectionClass(ImageSizeModel::class))->newInstanceWithoutConstructor();
+        $imageSizeModel = $this->mockClassWithProperties(ImageSizeModel::class);
         $imageSizeModel->setRow([
             'id' => 456,
             'width' => 20,
@@ -151,7 +151,7 @@ class PreviewFactoryTest extends TestCase
             'densities' => '1x, 2x, 120w',
         ]);
 
-        $imageSizeItemModel = (new \ReflectionClass(ImageSizeItemModel::class))->newInstanceWithoutConstructor();
+        $imageSizeItemModel = $this->mockClassWithProperties(ImageSizeItemModel::class);
         $imageSizeItemModel->setRow([
             'pid' => 456,
             'width' => 789,

--- a/core-bundle/tests/Image/Studio/FigureBuilderTest.php
+++ b/core-bundle/tests/Image/Studio/FigureBuilderTest.php
@@ -542,7 +542,7 @@ class FigureBuilderTest extends TestCase
 
         [$absoluteFilePath, $relativeFilePath] = $this->getTestFilePaths();
 
-        $filesModel = $this->mockClassWithProperties(FilesModel::class, preserve: ['getMetadata']);
+        $filesModel = $this->mockClassWithProperties(FilesModel::class, except: ['getMetadata']);
         $filesModel->setRow([
             'type' => 'file',
             'path' => $relativeFilePath,
@@ -752,7 +752,7 @@ class FigureBuilderTest extends TestCase
         [$absoluteFilePath, $relativeFilePath] = $this->getTestFilePaths();
 
         $getFilesModel = function (array $metaData, ?string $uuid) use ($relativeFilePath) {
-            $filesModel = $this->mockClassWithProperties(FilesModel::class, preserve: ['getMetadata']);
+            $filesModel = $this->mockClassWithProperties(FilesModel::class, except: ['getMetadata']);
             $filesModel->setRow([
                 'type' => 'file',
                 'path' => $relativeFilePath,

--- a/core-bundle/tests/Image/Studio/FigureBuilderTest.php
+++ b/core-bundle/tests/Image/Studio/FigureBuilderTest.php
@@ -542,9 +542,7 @@ class FigureBuilderTest extends TestCase
 
         [$absoluteFilePath, $relativeFilePath] = $this->getTestFilePaths();
 
-        /** @var FilesModel $filesModel */
-        $filesModel = (new \ReflectionClass(FilesModel::class))->newInstanceWithoutConstructor();
-
+        $filesModel = $this->mockClassWithProperties(FilesModel::class, preserve: ['getMetadata']);
         $filesModel->setRow([
             'type' => 'file',
             'path' => $relativeFilePath,
@@ -674,9 +672,7 @@ class FigureBuilderTest extends TestCase
 
         [$absoluteFilePath, $relativeFilePath] = $this->getTestFilePaths();
 
-        /** @var FilesModel $filesModel */
-        $filesModel = (new \ReflectionClass(FilesModel::class))->newInstanceWithoutConstructor();
-
+        $filesModel = $this->mockClassWithProperties(FilesModel::class);
         $filesModel->setRow([
             'type' => 'file',
             'path' => $relativeFilePath,
@@ -755,10 +751,8 @@ class FigureBuilderTest extends TestCase
     {
         [$absoluteFilePath, $relativeFilePath] = $this->getTestFilePaths();
 
-        $getFilesModel = static function (array $metaData, ?string $uuid) use ($relativeFilePath) {
-            /** @var FilesModel $filesModel */
-            $filesModel = (new \ReflectionClass(FilesModel::class))->newInstanceWithoutConstructor();
-
+        $getFilesModel = function (array $metaData, ?string $uuid) use ($relativeFilePath) {
+            $filesModel = $this->mockClassWithProperties(FilesModel::class, preserve: ['getMetadata']);
             $filesModel->setRow([
                 'type' => 'file',
                 'path' => $relativeFilePath,

--- a/test-case/README.md
+++ b/test-case/README.md
@@ -120,6 +120,17 @@ $mock = $this->mockClassWithProperties(Contao\PageModel::class, $properties);
 echo $mock->title; // will output "Home"
 ```
 
+If you need to call a method of the original class, you can pass the method
+name as third argument. The resulting mock object will be a partial mock object
+without the given method(s).
+
+```php
+$mock = $this->mockClassWithProperties(Contao\PageModel::class, [], ['getTable']);
+$mock->id = 2;
+
+echo $mock->getTable(); // will call the original method
+```
+
 ## Mocking a token storage
 
 The `mockTokenStorage()` mocks a token storage with a token returning either a

--- a/test-case/src/ContaoTestCase.php
+++ b/test-case/src/ContaoTestCase.php
@@ -171,14 +171,14 @@ abstract class ContaoTestCase extends TestCase
      *
      * @return T&MockObject
      */
-    protected function mockClassWithProperties(string $class, array $properties = [], array $preserve = []): MockObject
+    protected function mockClassWithProperties(string $class, array $properties = [], array $except = []): MockObject
     {
         $classMethods = get_class_methods($class);
 
-        if (!$preserve) {
+        if (!$except) {
             $mock = $this->createMock($class);
         } else {
-            $mock = $this->createPartialMock($class, array_diff($classMethods, $preserve));
+            $mock = $this->createPartialMock($class, array_diff($classMethods, $except));
         }
 
         $mock

--- a/test-case/src/ContaoTestCase.php
+++ b/test-case/src/ContaoTestCase.php
@@ -171,9 +171,16 @@ abstract class ContaoTestCase extends TestCase
      *
      * @return T&MockObject
      */
-    protected function mockClassWithProperties(string $class, array $properties = []): MockObject
+    protected function mockClassWithProperties(string $class, array $properties = [], array $preserve = []): MockObject
     {
-        $mock = $this->createMock($class);
+        $classMethods = get_class_methods($class);
+
+        if (!$preserve) {
+            $mock = $this->createMock($class);
+        } else {
+            $mock = $this->createPartialMock($class, array_diff($classMethods, $preserve));
+        }
+
         $mock
             ->method('__get')
             ->willReturnCallback(
@@ -183,7 +190,7 @@ abstract class ContaoTestCase extends TestCase
             )
         ;
 
-        if (\in_array('__set', get_class_methods($class), true)) {
+        if (\in_array('__set', $classMethods, true)) {
             $mock
                 ->method('__set')
                 ->willReturnCallback(
@@ -194,12 +201,34 @@ abstract class ContaoTestCase extends TestCase
             ;
         }
 
-        if (\in_array('__isset', get_class_methods($class), true)) {
+        if (\in_array('__isset', $classMethods, true)) {
             $mock
                 ->method('__isset')
                 ->willReturnCallback(
                     static function (string $key) use (&$properties) {
                         return isset($properties[$key]);
+                    }
+                )
+            ;
+        }
+
+        if (\in_array('row', $classMethods, true)) {
+            $mock
+                ->method('row')
+                ->willReturnCallback(
+                    static function () use (&$properties) {
+                        return $properties;
+                    }
+                )
+            ;
+        }
+
+        if (\in_array('setRow', $classMethods, true)) {
+            $mock
+                ->method('setRow')
+                ->willReturnCallback(
+                    static function (array $data) use (&$properties): void {
+                        $properties = $data;
                     }
                 )
             ;


### PR DESCRIPTION
This PR allows getting rid of `(new \ReflectionClass(PageModel::class))->newInstanceWithoutConstructor();` in our unit tests and using `$this->mockClassWithProperties()` instead.

Naming and PHP 8 syntax can still be discussed. 😄 