### PR TITLE
Remove the deprecated Model.php stuff

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -172,3 +172,7 @@ The public folder is now called `public` by default. It can be renamed in the `c
 The `Contao\CoreBundle\Image\Studio\Figure::getLinkAttributes()` method will now return an
 `Contao\CoreBundle\String\HtmlAttributes` object instead of an array. Use `iterator_to_array()` to transform it
 back to an array representation. If you are just using array access, nothing needs to be changed.
+
+
+### Model
+The protected `$arrClassNames` property was removed from the `Contao\Model` base class.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,10 @@
 
 ## Version 4.* to 5.0
 
+### Model
+
+The protected `$arrClassNames` property was removed from the `Contao\Model` base class.
+
 ### Request
 
 The `Contao\Request` library has been removed. Use another library such as `symfony/http-client` instead.
@@ -172,7 +176,3 @@ The public folder is now called `public` by default. It can be renamed in the `c
 The `Contao\CoreBundle\Image\Studio\Figure::getLinkAttributes()` method will now return an
 `Contao\CoreBundle\String\HtmlAttributes` object instead of an array. Use `iterator_to_array()` to transform it
 back to an array representation. If you are just using array access, nothing needs to be changed.
-
-
-### Model
-The protected `$arrClassNames` property was removed from the `Contao\Model` base class.

--- a/core-bundle/src/Resources/contao/library/Contao/Model.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Model.php
@@ -729,8 +729,8 @@ abstract class Model
 	/**
 	 * Find a single record by its primary key
 	 *
-	 * @param mixed $varValue   The property value
-	 * @param array $arrOptions An optional options array
+	 * @param int|string $varValue   The property value
+	 * @param array      $arrOptions An optional options array
 	 *
 	 * @return static The model or null if the result is empty
 	 */
@@ -738,7 +738,7 @@ abstract class Model
 	{
 		if ($varValue === null)
 		{
-			throw new \TypeError('Model::findByPk(): Argument #1 ($varValue) must not be of type null.');
+			throw new \TypeError('Model::findByPk(): Argument #1 ($varValue) must be of type int|string, got null');
 		}
 
 		// Try to load from the registry
@@ -920,6 +920,11 @@ abstract class Model
 		if (\count($arrColumn) == 1 && ($arrColumn[0] === static::getPk() || \in_array($arrColumn[0], static::getUniqueFields())))
 		{
 			$blnModel = true;
+
+			if ($varValue === null && $arrColumn[0] === static::getPk())
+			{
+				throw new \TypeError('Model::findBy(): Argument #2 ($varValue) must be of type int|string when querying for the primary key, got null');
+			}
 		}
 
 		$arrOptions = array_merge

--- a/core-bundle/src/Resources/contao/library/Contao/Model.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Model.php
@@ -1177,12 +1177,12 @@ abstract class Model
 	 */
 	public static function getClassFromTable($strTable)
 	{
-		if (null === ($strClass = $GLOBALS['TL_MODELS'][$strTable] ?? null))
+		if (!isset($GLOBALS['TL_MODELS'][$strTable]))
 		{
 			throw new \RuntimeException(sprintf('There is no class for table "%s" registered in $GLOBALS[\'TL_MODELS\'].', $strTable));
 		}
 
-		return $strClass;
+		return $GLOBALS['TL_MODELS'][$strTable];
 	}
 
 	/**

--- a/core-bundle/src/Resources/contao/library/Contao/Model.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Model.php
@@ -67,12 +67,6 @@ abstract class Model
 	protected static $strPk = 'id';
 
 	/**
-	 * Class name cache
-	 * @var array
-	 */
-	protected static $arrClassNames = array();
-
-	/**
 	 * Data
 	 * @var array
 	 */
@@ -409,12 +403,6 @@ abstract class Model
 	 */
 	public function save()
 	{
-		// Deprecated call
-		if (\func_num_args() > 0)
-		{
-			throw new \InvalidArgumentException('The $blnForceInsert argument has been removed (see system/docs/UPGRADE.md)');
-		}
-
 		// The instance cannot be saved
 		if ($this->blnPreventSaving)
 		{
@@ -750,9 +738,7 @@ abstract class Model
 	{
 		if ($varValue === null)
 		{
-			trigger_deprecation('contao/core-bundle', '4.13', 'Passing "null" as primary key has been deprecated and will no longer work in Contao 5.0.', __CLASS__);
-
-			return null;
+			throw new \TypeError('Model::findByPk(): Argument #1 ($varValue) must not be of type null.');
 		}
 
 		// Try to load from the registry
@@ -934,13 +920,6 @@ abstract class Model
 		if (\count($arrColumn) == 1 && ($arrColumn[0] === static::getPk() || \in_array($arrColumn[0], static::getUniqueFields())))
 		{
 			$blnModel = true;
-
-			if ($varValue === null && $arrColumn[0] === static::getPk())
-			{
-				trigger_deprecation('contao/core-bundle', '4.13', 'Passing "null" as primary key has been deprecated and will no longer work in Contao 5.0.', __CLASS__);
-
-				return null;
-			}
 		}
 
 		$arrOptions = array_merge
@@ -1193,30 +1172,12 @@ abstract class Model
 	 */
 	public static function getClassFromTable($strTable)
 	{
-		if (isset(static::$arrClassNames[$strTable]))
+		if (null === ($strClass = $GLOBALS['TL_MODELS'][$strTable] ?? null))
 		{
-			return static::$arrClassNames[$strTable];
+			throw new \RuntimeException(sprintf('There is no class for table "%s" registered in $GLOBALS[\'TL_MODELS\'].', $strTable));
 		}
 
-		if (isset($GLOBALS['TL_MODELS'][$strTable]))
-		{
-			static::$arrClassNames[$strTable] = $GLOBALS['TL_MODELS'][$strTable]; // see 4796
-
-			return static::$arrClassNames[$strTable];
-		}
-
-		trigger_deprecation('contao/core-bundle', '4.10', sprintf('Not registering table "%s" in $GLOBALS[\'TL_MODELS\'] has been deprecated and will no longer work in Contao 5.0.', $strTable));
-
-		$arrChunks = explode('_', $strTable);
-
-		if ($arrChunks[0] == 'tl')
-		{
-			array_shift($arrChunks);
-		}
-
-		static::$arrClassNames[$strTable] = implode('', array_map('ucfirst', $arrChunks)) . 'Model';
-
-		return static::$arrClassNames[$strTable];
+		return $strClass;
 	}
 
 	/**


### PR DESCRIPTION
I also removed the `$arrClassNames` property where class names where cached, because with the current code it doesn't provide any speedup. Should we annotate this with `@deprecated` in 4.13?