### PR TITLE
Correctly build Twig logical name from fragment template name

### DIFF
--- a/core-bundle/src/Controller/AbstractFragmentController.php
+++ b/core-bundle/src/Controller/AbstractFragmentController.php
@@ -81,10 +81,12 @@ abstract class AbstractFragmentController extends AbstractController implements 
     {
         $templateName = $this->getTemplateName($model, $fallbackTemplateName);
         $isLegacyTemplate = $this->isLegacyTemplate($templateName);
+        $templateNameToView = static fn (string $name): string => "@Contao/$name.html.twig";
 
         // Allow calling render() without a view
-        $templateNameToView = static fn (string $name): string => "@Contao/$name.html.twig";
-        $this->view = !$isLegacyTemplate ? $templateNameToView($templateName) : null;
+        if (!$isLegacyTemplate) {
+            $this->view = $templateNameToView($templateName);
+        }
 
         $onGetResponse = function (FragmentTemplate $template, Response|null $preBuiltResponse) use ($templateNameToView, $templateName, $isLegacyTemplate): Response {
             if ($isLegacyTemplate) {

--- a/core-bundle/src/Controller/AbstractFragmentController.php
+++ b/core-bundle/src/Controller/AbstractFragmentController.php
@@ -83,9 +83,10 @@ abstract class AbstractFragmentController extends AbstractController implements 
         $isLegacyTemplate = $this->isLegacyTemplate($templateName);
 
         // Allow calling render() without a view
-        $this->view = !$isLegacyTemplate ? "@Contao/$templateName.html.twig" : null;
+        $templateNameToView = static fn (string $name): string => "@Contao/$name.html.twig";
+        $this->view = !$isLegacyTemplate ? $templateNameToView($templateName) : null;
 
-        $onGetResponse = function (FragmentTemplate $template, Response|null $preBuiltResponse) use ($templateName, $isLegacyTemplate): Response {
+        $onGetResponse = function (FragmentTemplate $template, Response|null $preBuiltResponse) use ($templateNameToView, $templateName, $isLegacyTemplate): Response {
             if ($isLegacyTemplate) {
                 // Render using the legacy framework
                 $legacyTemplate = $this->container->get('contao.framework')->createInstance(FrontendTemplate::class, [$templateName]);
@@ -105,7 +106,7 @@ abstract class AbstractFragmentController extends AbstractController implements 
             // Directly render with Twig
             $context = $this->container->get('contao.twig.interop.context_factory')->fromData($template->getData());
 
-            return $this->render($template->getName(), $context, $preBuiltResponse);
+            return $this->render($templateNameToView($template->getName()), $context, $preBuiltResponse);
         };
 
         $template = new FragmentTemplate($templateName, $onGetResponse);

--- a/core-bundle/tests/Controller/AbstractFragmentControllerTest.php
+++ b/core-bundle/tests/Controller/AbstractFragmentControllerTest.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\Controller;
+
+use Contao\CoreBundle\Controller\AbstractFragmentController;
+use Contao\CoreBundle\EventListener\SubrequestCacheSubscriber;
+use Contao\CoreBundle\Tests\TestCase;
+use Contao\CoreBundle\Twig\FragmentTemplate;
+use Contao\CoreBundle\Twig\Interop\ContextFactory;
+use Contao\Model;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\HttpFoundation\Response;
+use Twig\Environment;
+use Twig\Loader\LoaderInterface;
+
+class AbstractFragmentControllerTest extends TestCase
+{
+    public function testCreateAndRenderFragmentTemplate(): void
+    {
+        $fragmentController = $this->getFragmentController('foo/bar');
+
+        // Create template
+        /** @var FragmentTemplate $template */
+        $template = $fragmentController->doCreateTemplate($this->mockClassWithProperties(Model::class));
+        $this->assertSame('foo/bar', $template->getName());
+        $this->assertEmpty($template->getData());
+
+        // Get response via fragment template
+        $template->set('some', 'data');
+        $response = $template->getResponse();
+
+        $this->assertSame('rendered foo/bar', $response->getContent());
+        $this->assertFalse($response->headers->has('Cache-Control'));
+        $this->assertTrue($response->headers->has(SubrequestCacheSubscriber::MERGE_CACHE_HEADER));
+
+        // Get response by calling render
+        $response = $fragmentController->doRender(parameters: ['some' => 'data']);
+
+        $this->assertSame('rendered foo/bar', $response->getContent());
+        $this->assertFalse($response->headers->has('Cache-Control'));
+        $this->assertTrue($response->headers->has(SubrequestCacheSubscriber::MERGE_CACHE_HEADER));
+    }
+
+    public function testCreateAndRenderModifiedFragmentTemplate(): void
+    {
+        $twig = $this->createMock(Environment::class);
+        $twig
+            ->method('render')
+            ->with('@Contao/modified/template.html.twig', ['some' => 'data'])
+            ->willReturn('rendered modified/template')
+        ;
+
+        $fragmentController = $this->getFragmentController('original/template', $twig);
+
+        // Create and modify template
+        /** @var FragmentTemplate $template */
+        $template = $fragmentController->doCreateTemplate($this->mockClassWithProperties(Model::class));
+        $template->setName('modified/template');
+
+        // Get response of modified template
+        $template->set('some', 'data');
+        $response = $template->getResponse();
+
+        $this->assertSame('rendered modified/template', $response->getContent());
+    }
+
+    public function testRenderUsingPreBuiltResponse(): void
+    {
+        $preBuiltResponse = new Response();
+
+        $twig = $this->createMock(Environment::class);
+        $twig
+            ->method('render')
+            ->with('@Contao/foo/bar.html.twig', [])
+            ->willReturn('rendered foo/bar')
+        ;
+
+        $fragmentController = $this->getFragmentController('foo/bar', $twig);
+
+        // GGet original response with rendered content via fragment template
+        /** @var FragmentTemplate $template */
+        $template = $fragmentController->doCreateTemplate($this->mockClassWithProperties(Model::class));
+        $response = $template->getResponse($preBuiltResponse);
+
+        $this->assertSame($preBuiltResponse, $response);
+        $this->assertSame('rendered foo/bar', $response->getContent());
+        $this->assertFalse($response->headers->has(SubrequestCacheSubscriber::MERGE_CACHE_HEADER));
+
+        // Get original response with rendered content by calling render
+        $response = $fragmentController->doRender(response: $preBuiltResponse);
+
+        $this->assertSame($preBuiltResponse, $response);
+        $this->assertSame('rendered foo/bar', $response->getContent());
+        $this->assertFalse($response->headers->has(SubrequestCacheSubscriber::MERGE_CACHE_HEADER));
+    }
+
+    private function getFragmentController(string $defaultTemplateName, Environment|null $twig = null): object
+    {
+        $loader = $this->createMock(LoaderInterface::class);
+        $loader
+            ->method('exists')
+            ->with("@Contao/$defaultTemplateName.html.twig")
+            ->willReturn(true)
+        ;
+
+        if (null === $twig) {
+            $twig = $this->createMock(Environment::class);
+            $twig
+                ->method('render')
+                ->with("@Contao/$defaultTemplateName.html.twig", ['some' => 'data'])
+                ->willReturn("rendered $defaultTemplateName")
+            ;
+        }
+
+        $container = new Container();
+        $container->set('contao.twig.filesystem_loader', $loader);
+        $container->set('contao.twig.interop.context_factory', new ContextFactory());
+        $container->set('twig', $twig);
+
+        $fragmentController = new class() extends AbstractFragmentController {
+            public function doCreateTemplate(Model $model): FragmentTemplate
+            {
+                return $this->createTemplate($model);
+            }
+
+            public function doRender(string|null $view = null, array $parameters = [], Response $response = null): Response
+            {
+                return $this->render($view, $parameters, $response);
+            }
+        };
+
+        $fragmentController->setContainer($container);
+        $fragmentController->setFragmentOptions(['template' => $defaultTemplateName]);
+
+        return $fragmentController;
+    }
+}

--- a/core-bundle/tests/Controller/AbstractFragmentControllerTest.php
+++ b/core-bundle/tests/Controller/AbstractFragmentControllerTest.php
@@ -12,10 +12,9 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Tests\Controller;
 
-use Contao\CoreBundle\Controller\AbstractFragmentController;
 use Contao\CoreBundle\EventListener\SubrequestCacheSubscriber;
+use Contao\CoreBundle\Fixtures\Controller\FragmentController;
 use Contao\CoreBundle\Tests\TestCase;
-use Contao\CoreBundle\Twig\FragmentTemplate;
 use Contao\CoreBundle\Twig\Interop\ContextFactory;
 use Contao\Model;
 use Symfony\Component\DependencyInjection\Container;
@@ -30,7 +29,6 @@ class AbstractFragmentControllerTest extends TestCase
         $fragmentController = $this->getFragmentController('foo/bar');
 
         // Create template
-        /** @var FragmentTemplate $template */
         $template = $fragmentController->doCreateTemplate($this->mockClassWithProperties(Model::class));
         $this->assertSame('foo/bar', $template->getName());
         $this->assertEmpty($template->getData());
@@ -63,7 +61,6 @@ class AbstractFragmentControllerTest extends TestCase
         $fragmentController = $this->getFragmentController('original/template', $twig);
 
         // Create and modify template
-        /** @var FragmentTemplate $template */
         $template = $fragmentController->doCreateTemplate($this->mockClassWithProperties(Model::class));
         $template->setName('modified/template');
 
@@ -88,7 +85,6 @@ class AbstractFragmentControllerTest extends TestCase
         $fragmentController = $this->getFragmentController('foo/bar', $twig);
 
         // GGet original response with rendered content via fragment template
-        /** @var FragmentTemplate $template */
         $template = $fragmentController->doCreateTemplate($this->mockClassWithProperties(Model::class));
         $response = $template->getResponse($preBuiltResponse);
 
@@ -127,18 +123,7 @@ class AbstractFragmentControllerTest extends TestCase
         $container->set('contao.twig.interop.context_factory', new ContextFactory());
         $container->set('twig', $twig);
 
-        $fragmentController = new class() extends AbstractFragmentController {
-            public function doCreateTemplate(Model $model): FragmentTemplate
-            {
-                return $this->createTemplate($model);
-            }
-
-            public function doRender(string|null $view = null, array $parameters = [], Response $response = null): Response
-            {
-                return $this->render($view, $parameters, $response);
-            }
-        };
-
+        $fragmentController = new FragmentController();
         $fragmentController->setContainer($container);
         $fragmentController->setFragmentOptions(['template' => $defaultTemplateName]);
 

--- a/core-bundle/tests/Fixtures/src/Controller/FragmentController.php
+++ b/core-bundle/tests/Fixtures/src/Controller/FragmentController.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Fixtures\Controller;
+
+use Contao\CoreBundle\Controller\AbstractFragmentController;
+use Contao\CoreBundle\Twig\FragmentTemplate;
+use Contao\Model;
+use Symfony\Component\HttpFoundation\Response;
+
+class FragmentController extends AbstractFragmentController
+{
+    public function doCreateTemplate(Model $model): FragmentTemplate
+    {
+        return $this->createTemplate($model);
+    }
+
+    public function doRender(string|null $view = null, array $parameters = [], Response $response = null): Response
+    {
+        return $this->render($view, $parameters, $response);
+    }
+}


### PR DESCRIPTION
Followup to #4393 with a small fix.

I noticed this when writing first tests for #4444, now already including them here.