### PR TITLE
Remove TL_CROP

### DIFF
--- a/core-bundle/src/Image/ImageFactory.php
+++ b/core-bundle/src/Image/ImageFactory.php
@@ -217,6 +217,8 @@ class ImageFactory implements ImageFactoryInterface
             return [$config, null, null];
         }
 
+        trigger_deprecation('contao/core-bundle', '5.0', 'Using the legacy resize mode "%s" has been deprecated and will no longer work in Contao 6.0.', $size[2]);
+
         $config->setMode(ResizeConfiguration::MODE_CROP);
 
         return [$config, $this->getImportantPartFromLegacyMode($image, $size[2]), null];

--- a/core-bundle/src/Image/ImageSizes.php
+++ b/core-bundle/src/Image/ImageSizes.php
@@ -162,7 +162,7 @@ class ImageSizes implements ResetInterface
         $filteredSizes = [];
 
         foreach ($this->options as $group => $sizes) {
-            if ('custom' === $group) {
+            if ('custom' === $group || 'relative' === $group || 'exact' === $group) {
                 $this->filterResizeModes($sizes, $allowedSizes, $filteredSizes, $group);
             } else {
                 $this->filterImageSizes($sizes, $allowedSizes, $filteredSizes, $group);

--- a/core-bundle/src/Image/ImageSizes.php
+++ b/core-bundle/src/Image/ImageSizes.php
@@ -15,7 +15,6 @@ namespace Contao\CoreBundle\Image;
 use Contao\BackendUser;
 use Contao\CoreBundle\Event\ContaoCoreEvents;
 use Contao\CoreBundle\Event\ImageSizesEvent;
-use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\StringUtil;
 use Doctrine\DBAL\Connection;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -33,7 +32,6 @@ class ImageSizes implements ResetInterface
     public function __construct(
         private Connection $connection,
         private EventDispatcherInterface $eventDispatcher,
-        private ContaoFramework $framework,
         private TranslatorInterface $translator,
     ) {
     }
@@ -101,21 +99,6 @@ class ImageSizes implements ResetInterface
             return;
         }
 
-        // The framework is required to have the TL_CROP options available
-        $this->framework->initialize();
-
-        // Backwards compatibility
-        $this->options = $GLOBALS['TL_CROP'] ?? [];
-
-        if (
-            3 !== \count($this->options)
-            || 0 !== \count($this->options['image_sizes'] ?? [])
-            || 2 !== \count($this->options['relative'] ?? [])
-            || 10 !== \count($this->options['exact'] ?? [])
-        ) {
-            trigger_deprecation('contao/core-bundle', '4.13', 'Using $GLOBALS[\'TL_CROP\'] has been deprecated and will be removed in Contao 5.0. Use the "contao.image.sizes" service instead.');
-        }
-
         $rows = $this->connection->fetchAllAssociative(
             'SELECT
                 s.id, s.name, s.width, s.height, t.name as theme
@@ -140,7 +123,7 @@ class ImageSizes implements ResetInterface
 
         foreach ($rows as $imageSize) {
             // Prefix theme names that are numeric or collide with existing group names
-            if (is_numeric($imageSize['theme']) || \in_array($imageSize['theme'], ['exact', 'relative', 'image_sizes'], true)) {
+            if (is_numeric($imageSize['theme']) || \in_array($imageSize['theme'], ['custom', 'image_sizes', 'exact', 'relative'], true)) {
                 $imageSize['theme'] = 'Theme '.$imageSize['theme'];
             }
 
@@ -156,7 +139,13 @@ class ImageSizes implements ResetInterface
             );
         }
 
-        $this->options = array_merge_recursive($options, $this->options);
+        $this->options = array_merge_recursive(
+            $options,
+            [
+                'image_sizes' => [],
+                'custom' => ['crop', 'proportional', 'box'],
+            ]
+        );
     }
 
     /**
@@ -173,7 +162,7 @@ class ImageSizes implements ResetInterface
         $filteredSizes = [];
 
         foreach ($this->options as $group => $sizes) {
-            if ('relative' === $group || 'exact' === $group) {
+            if ('custom' === $group) {
                 $this->filterResizeModes($sizes, $allowedSizes, $filteredSizes, $group);
             } else {
                 $this->filterImageSizes($sizes, $allowedSizes, $filteredSizes, $group);

--- a/core-bundle/src/Image/PictureFactory.php
+++ b/core-bundle/src/Image/PictureFactory.php
@@ -91,6 +91,8 @@ class PictureFactory implements PictureFactoryInterface
             && !isset($this->predefinedSizes[$size[2]])
             && 1 === substr_count($size[2], '_')
         ) {
+            trigger_deprecation('contao/core-bundle', '5.0', 'Using the legacy resize mode "%s" has been deprecated and will no longer work in Contao 6.0.', $size[2]);
+
             $image->setImportantPart($this->imageFactory->getImportantPartFromLegacyMode($image, $size[2]));
             $size[2] = ResizeConfiguration::MODE_CROP;
         }

--- a/core-bundle/src/Migration/Version401/Version410Update.php
+++ b/core-bundle/src/Migration/Version401/Version410Update.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Migration\Version401;
 
 use Contao\CoreBundle\Framework\ContaoFramework;
+use Contao\CoreBundle\Image\ImageSizes;
 use Contao\CoreBundle\Migration\AbstractMigration;
 use Contao\CoreBundle\Migration\MigrationResult;
 use Doctrine\DBAL\Connection;
@@ -22,7 +23,7 @@ use Doctrine\DBAL\Connection;
  */
 class Version410Update extends AbstractMigration
 {
-    public function __construct(private Connection $connection, private ContaoFramework $framework)
+    public function __construct(private Connection $connection, private ContaoFramework $framework, private ImageSizes $imageSizes)
     {
     }
 
@@ -48,31 +49,14 @@ class Version410Update extends AbstractMigration
     {
         $this->framework->initialize();
 
-        $crop = $GLOBALS['TL_CROP'] ?? [];
-
-        if (empty($crop)) {
-            return $this->createResult(true);
-        }
-
         $options = [];
 
-        foreach ($crop as $modes) {
+        foreach ($this->imageSizes->getAllOptions() as $modes) {
             $options[] = array_values($modes);
         }
 
         if (!empty($options)) {
             $options = array_merge(...$options);
-        }
-
-        $rows = $this->connection->fetchAllAssociative('
-            SELECT
-                id
-            FROM
-                tl_image_size
-        ');
-
-        foreach ($rows as $imageSize) {
-            $options[] = $imageSize['id'];
         }
 
         // Add the database fields

--- a/core-bundle/src/Resources/config/services.yml
+++ b/core-bundle/src/Resources/config/services.yml
@@ -334,7 +334,6 @@ services:
         arguments:
             - '@database_connection'
             - '@event_dispatcher'
-            - '@contao.framework'
             - '@contao.translation.translator'
         tags:
             - { name: kernel.reset, method: reset }

--- a/core-bundle/src/Resources/contao/config/config.php
+++ b/core-bundle/src/Resources/contao/config/config.php
@@ -468,27 +468,6 @@ $GLOBALS['TL_PURGE'] = array
 );
 
 // Backwards compatibility
-// Image crop modes
-$GLOBALS['TL_CROP'] = array
-(
-	'image_sizes' => array
-	(
-		// will be added dynamically
-	),
-	'relative' => array
-	(
-		'proportional', 'box'
-	),
-	'exact' => array
-	(
-		'crop',
-		'left_top',    'center_top',    'right_top',
-		'left_center', 'center_center', 'right_center',
-		'left_bottom', 'center_bottom', 'right_bottom'
-	)
-);
-
-// Backwards compatibility
 // Cron jobs
 $GLOBALS['TL_CRON'] = array
 (

--- a/core-bundle/src/Resources/contao/languages/en/default.xlf
+++ b/core-bundle/src/Resources/contao/languages/en/default.xlf
@@ -1004,8 +1004,11 @@
       <trans-unit id="MSC.image_sizes">
         <source>Predefined dimensions</source>
       </trans-unit>
-      <trans-unit id="MSC.relative">
-        <source>Relative dimensions</source>
+      <trans-unit id="MSC.custom.0">
+        <source>Custom dimensions</source>
+      </trans-unit>
+      <trans-unit id="MSC.custom.1">
+        <source>The image will be resized to the given dimensions.</source>
       </trans-unit>
       <trans-unit id="MSC.proportional.0">
         <source>Proportional</source>
@@ -1019,17 +1022,11 @@
       <trans-unit id="MSC.box.1">
         <source>The shorter side of the image is adjusted to the given dimensions and the image is resized proportionally.</source>
       </trans-unit>
-      <trans-unit id="MSC.exact.0">
-        <source>Exact dimensions</source>
-      </trans-unit>
-      <trans-unit id="MSC.exact.1">
-        <source>The image will be resized to the given dimensions. If necessary, it will be cropped.</source>
-      </trans-unit>
       <trans-unit id="MSC.crop.0">
-        <source>Important part</source>
+        <source>Crop (important part)</source>
       </trans-unit>
       <trans-unit id="MSC.crop.1">
-        <source>Preserves the important part of an image as specified in the file manager.</source>
+        <source>Preserves the important part of an image as specified in the file manager. If necessary, the image will be cropped.</source>
       </trans-unit>
       <trans-unit id="MSC.left_top.0">
         <source>Left | Top</source>

--- a/core-bundle/src/Resources/contao/widgets/ImageSize.php
+++ b/core-bundle/src/Resources/contao/widgets/ImageSize.php
@@ -133,7 +133,7 @@ class ImageSize extends Widget
 
 		foreach ($this->arrAvailableOptions as $strGroup=>$arrValues)
 		{
-			if ($strGroup == 'relative' || $strGroup == 'exact')
+			if ($strGroup == 'custom' || $strGroup == 'relative' || $strGroup == 'exact')
 			{
 				if (\in_array($varInput, $arrValues))
 				{

--- a/core-bundle/tests/EventListener/ImageSizeOptionsListenerTest.php
+++ b/core-bundle/tests/EventListener/ImageSizeOptionsListenerTest.php
@@ -24,14 +24,8 @@ class ImageSizeOptionsListenerTest extends TestCase
     {
         $imageSizeConfig = [
             'image_sizes' => [],
-            'relative' => [
-                'proportional', 'box',
-            ],
-            'exact' => [
-                'crop',
-                'left_top', 'center_top', 'right_top',
-                'left_center', 'center_center', 'right_center',
-                'left_bottom', 'center_bottom', 'right_bottom',
+            'custom' => [
+                'crop', 'proportional', 'box',
             ],
         ];
 

--- a/core-bundle/tests/Image/ImageFactoryTest.php
+++ b/core-bundle/tests/Image/ImageFactoryTest.php
@@ -447,6 +447,8 @@ class ImageFactoryTest extends TestCase
 
     /**
      * @dataProvider getCreateWithLegacyMode
+     *
+     * @group legacy
      */
     public function testCreatesAnImageObjectFromAnImagePathInLegacyMode(string $mode, array $expected): void
     {
@@ -506,6 +508,9 @@ class ImageFactoryTest extends TestCase
         $filesAdapter = $this->mockConfiguredAdapter(['findByPath' => $filesModel]);
         $framework = $this->mockContaoFramework([FilesModel::class => $filesAdapter]);
         $imageFactory = $this->getImageFactory($resizer, $imagine, $imagine, $filesystem, $framework);
+
+        $this->expectDeprecation("%slegacy resize mode \"$mode\" has been deprecated%s");
+
         $image = $imageFactory->create($path, [50, 50, $mode]);
         $imageFromSerializedConfig = $imageFactory->create($path, serialize([50, 50, $mode]));
 

--- a/core-bundle/tests/Image/ImageSizesTest.php
+++ b/core-bundle/tests/Image/ImageSizesTest.php
@@ -41,35 +41,14 @@ class ImageSizesTest extends TestCase
     {
         parent::setUp();
 
-        $GLOBALS['TL_CROP'] = [
-            'image_sizes' => [],
-            'relative' => [
-                'proportional', 'box',
-            ],
-            'exact' => [
-                'crop',
-                'left_top', 'center_top', 'right_top',
-                'left_center', 'center_center', 'right_center',
-                'left_bottom', 'center_bottom', 'right_bottom',
-            ],
-        ];
-
         $this->connection = $this->createMock(Connection::class);
         $this->eventDispatcher = $this->createMock(EventDispatcherInterface::class);
 
         $this->imageSizes = new ImageSizes(
             $this->connection,
             $this->eventDispatcher,
-            $this->mockContaoFramework(),
             $this->createMock(TranslatorInterface::class)
         );
-    }
-
-    protected function tearDown(): void
-    {
-        unset($GLOBALS['TL_CROP']);
-
-        parent::tearDown();
     }
 
     public function testReturnsAllOptionsWithImageSizes(): void
@@ -80,8 +59,7 @@ class ImageSizesTest extends TestCase
 
         $options = $this->imageSizes->getAllOptions();
 
-        $this->assertArrayHasKey('relative', $options);
-        $this->assertArrayHasKey('exact', $options);
+        $this->assertArrayHasKey('custom', $options);
         $this->assertArrayHasKey('My theme', $options);
         $this->assertArrayHasKey('42', $options['My theme']);
         $this->assertArrayHasKey('image_sizes', $options);
@@ -96,8 +74,7 @@ class ImageSizesTest extends TestCase
 
         $options = $this->imageSizes->getAllOptions();
 
-        $this->assertArrayHasKey('relative', $options);
-        $this->assertArrayHasKey('exact', $options);
+        $this->assertArrayHasKey('custom', $options);
         $this->assertArrayNotHasKey('My theme', $options);
     }
 
@@ -111,9 +88,9 @@ class ImageSizesTest extends TestCase
 
         $options = $this->imageSizes->getOptionsForUser($user);
 
-        // TL_CROP would not be returned without the admin check, because it is
-        // not within the allowed image sizes
-        $this->assertArrayHasKey('relative', $options);
+        // Default options would not be returned without the admin check,
+        // because it is not within the allowed image sizes
+        $this->assertArrayHasKey('custom', $options);
     }
 
     public function testReturnsTheRegularUserOptions(): void
@@ -129,21 +106,19 @@ class ImageSizesTest extends TestCase
 
         $options = $this->imageSizes->getOptionsForUser($user);
 
-        $this->assertArrayNotHasKey('relative', $options);
-        $this->assertArrayNotHasKey('exact', $options);
+        $this->assertArrayNotHasKey('custom', $options);
         $this->assertArrayHasKey('My theme', $options);
         $this->assertArrayHasKey('42', $options['My theme']);
 
         $user = $this->mockClassWithProperties(BackendUser::class);
         $user->isAdmin = false;
 
-        // Allow only some TL_CROP options
+        // Allow only some default options
         $user->imageSizes = ['proportional', 'box'];
 
         $options = $this->imageSizes->getOptionsForUser($user);
 
-        $this->assertArrayHasKey('relative', $options);
-        $this->assertArrayNotHasKey('exact', $options);
+        $this->assertArrayHasKey('custom', $options);
         $this->assertArrayNotHasKey('My theme', $options);
 
         $user = $this->mockClassWithProperties(BackendUser::class);

--- a/core-bundle/tests/Image/PictureFactoryTest.php
+++ b/core-bundle/tests/Image/PictureFactoryTest.php
@@ -27,9 +27,12 @@ use Contao\ImageSizeItemModel;
 use Contao\ImageSizeModel;
 use Contao\Model\Collection;
 use Contao\System;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 
 class PictureFactoryTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -387,6 +390,9 @@ class PictureFactoryTest extends TestCase
         $this->assertSame($imageMock, $picture->getImg()['src']);
     }
 
+    /**
+     * @group legacy
+     */
     public function testCreatesAPictureObjectInLegacyMode(): void
     {
         $path = $this->getTempDir().'/images/dummy.jpg';
@@ -445,6 +451,8 @@ class PictureFactoryTest extends TestCase
                 )
             )
         ;
+
+        $this->expectDeprecation('%slegacy resize mode "left_top" has been deprecated%s');
 
         $pictureFactory = $this->getPictureFactory($pictureGenerator, $imageFactory);
         $picture = $pictureFactory->create($path, [100, 200, 'left_top']);


### PR DESCRIPTION
For a smoother upgrade path I kept support for the legacy resize modes (like `left_top`, `center_center`,…) but deprecated their usage and removed them from the default image size dropdown.