### PR TITLE
Allow to override dns and protocol of pages by configuration

### DIFF
--- a/core-bundle/src/DependencyInjection/Configuration.php
+++ b/core-bundle/src/DependencyInjection/Configuration.php
@@ -117,6 +117,7 @@ class Configuration implements ConfigurationInterface
                 ->append($this->addInsertTagsNode())
                 ->append($this->addBackupNode())
                 ->append($this->addSanitizerNode())
+                ->append($this->addRoutingNode())
             ->end()
         ;
 
@@ -685,6 +686,28 @@ class Configuration implements ConfigurationInterface
                                 return $protocols;
                             }
                         )
+                    ->end()
+                ->end()
+            ->end()
+        ;
+    }
+
+    private function addRoutingNode(): NodeDefinition
+    {
+        return (new TreeBuilder('routing'))
+            ->getRootNode()
+            ->addDefaultsIfNotSet()
+            ->children()
+                ->arrayNode('override_dns')
+                    ->arrayPrototype()
+                        ->children()
+                            ->scalarNode('dns')
+                                ->info('The domain name')
+                            ->end()
+                            ->scalarNode('protocol')
+                                ->info('The domain name')
+                            ->end()
+                        ->end()
                     ->end()
                 ->end()
             ->end()

--- a/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
+++ b/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
@@ -130,6 +130,7 @@ class ContaoCoreExtension extends Extension implements PrependExtensionInterface
         $container->setParameter('contao.intl.countries', $config['intl']['countries']);
         $container->setParameter('contao.insert_tags.allowed_tags', $config['insert_tags']['allowed_tags']);
         $container->setParameter('contao.sanitizer.allowed_url_protocols', $config['sanitizer']['allowed_url_protocols']);
+        $container->setParameter('contao.routing.override_dns', $config['routing']['override_dns']);
 
         $this->handleSearchConfig($config, $container);
         $this->handleCrawlConfig($config, $container);

--- a/core-bundle/src/EventListener/OverrideDnsSettingsListener.php
+++ b/core-bundle/src/EventListener/OverrideDnsSettingsListener.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\EventListener;
+
+use Contao\CoreBundle\ServiceAnnotation\Hook;
+use Contao\PageModel;
+
+/**
+ * @psalm-type TOverrideDnsConfiguration = array{dns?: string, protocol?: string}
+ */
+class OverrideDnsSettingsListener
+{
+    private array $configuration;
+
+    /**
+     * @param array<string,array<string,string>> $configuration
+     * @psalm-type array<string,TOverrideDnsConfiguration>
+     */
+    public function __construct(array $configuration)
+    {
+        $this->configuration = $configuration;
+    }
+
+    public function __invoke(array $parentModels, PageModel $page): void
+    {
+        if (!isset($this->configuration[$page->domain])) {
+            return;
+        }
+
+        $config = $this->configuration[$page->domain];
+
+        if (isset($config['dns'])) {
+            $page->domain = $config['dns'];
+        }
+
+        if (isset($config['protocol'])) {
+            $page->rootUseSSL = 'https' === $config['protocol'];
+            $page->useSSL = $page->rootUseSSL;
+        }
+    }
+}

--- a/core-bundle/src/Resources/config/listener.yml
+++ b/core-bundle/src/Resources/config/listener.yml
@@ -332,6 +332,13 @@ services:
         tags:
             - { name: contao.callback, table: tl_module, target: fields.customTpl.options }
 
+    contao.listener.override_dns_listener:
+        class: Contao\CoreBundle\EventListener\OverrideDnsSettingsListener
+        arguments:
+            - '%contao.routing.override_dns%'
+        tags:
+            - { name: contao.hook, hook: loadPageDetails }
+
     contao.listener.page_access:
         class: Contao\CoreBundle\EventListener\PageAccessListener
         arguments:

--- a/core-bundle/src/Resources/config/services.yml
+++ b/core-bundle/src/Resources/config/services.yml
@@ -659,6 +659,7 @@ services:
             - '@contao.framework'
             - '@contao.routing.page_candidates'
             - '@contao.routing.page_registry'
+            - '%contao.routing.override_dns%'
 
     contao.routing.scope_matcher:
         class: Contao\CoreBundle\Routing\ScopeMatcher


### PR DESCRIPTION
Fixes #1517

This pull request allow to override the dns and ssl settings of route pages. This feature is designed for multiple stages and local development. Therefore it overrides the dns globally and not root page specific (e.g. different setting for root pages with same dns).