### PR TITLE
Also ignore the Resources folder

### DIFF
--- a/manager-bundle/src/Resources/skeleton/config/services.php
+++ b/manager-bundle/src/Resources/skeleton/config/services.php
@@ -28,7 +28,7 @@ return static function(ContainerConfigurator $configurator) use ($container) {
     try {
         $config
             ->load('App\\', $servicesDir.'/*')
-            ->exclude($servicesDir.'/{DependencyInjection,Entity,Tests}')
+            ->exclude($servicesDir.'/{DependencyInjection,Entity,Resources,Tests}')
         ;
 
         // Trigger __destruct handler


### PR DESCRIPTION
The _magic_ autoloading might fail, if the `Resources` folder contains invalid files.

/cc @zonky2 