### PR TITLE
Add missing service argument for Version410Update

### DIFF
--- a/core-bundle/src/Resources/config/migrations.yml
+++ b/core-bundle/src/Resources/config/migrations.yml
@@ -17,6 +17,7 @@ services:
         arguments:
             - '@database_connection'
             - '@contao.framework'
+            - '@contao.image.sizes'
 
     contao.migration.version_403.version_430_update:
         class: Contao\CoreBundle\Migration\Version403\Version430Update


### PR DESCRIPTION
Follow up for #4562. Fixes

```
Too few arguments to function Contao\CoreBundle\Migration\Version401\Version410Update::__construct(), 2 passed in var\cache\dev\ContainerKqpboko\getContao_Migration_CollectionService.php on line 49 and exactly 3 expected
```
