### PR TITLE
Re-introduce autowiring aliases for subscribed services

### DIFF
--- a/core-bundle/src/Controller/FrontendModule/AbstractFrontendModuleController.php
+++ b/core-bundle/src/Controller/FrontendModule/AbstractFrontendModuleController.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Controller\FrontendModule;
 
 use Contao\CoreBundle\Controller\AbstractFragmentController;
-use Contao\CoreBundle\Csrf\ContaoCsrfTokenManager;
 use Contao\CoreBundle\String\HtmlAttributes;
 use Contao\CoreBundle\Twig\FragmentTemplate;
 use Contao\ModuleModel;

--- a/core-bundle/src/Controller/FrontendModule/AbstractFrontendModuleController.php
+++ b/core-bundle/src/Controller/FrontendModule/AbstractFrontendModuleController.php
@@ -44,15 +44,6 @@ abstract class AbstractFrontendModuleController extends AbstractFragmentControll
         return $this->getResponse($template, $model, $request);
     }
 
-    public static function getSubscribedServices(): array
-    {
-        $services = parent::getSubscribedServices();
-
-        $services['contao.csrf.token_manager'] = ContaoCsrfTokenManager::class;
-
-        return $services;
-    }
-
     protected function getBackendWildcard(ModuleModel $module): Response
     {
         $context = [

--- a/core-bundle/src/Controller/FrontendModule/AbstractFrontendModuleController.php
+++ b/core-bundle/src/Controller/FrontendModule/AbstractFrontendModuleController.php
@@ -43,6 +43,15 @@ abstract class AbstractFrontendModuleController extends AbstractFragmentControll
         return $this->getResponse($template, $model, $request);
     }
 
+    public static function getSubscribedServices(): array
+    {
+        $services = parent::getSubscribedServices();
+
+        $services['contao.csrf.token_manager'] = ContaoCsrfTokenManager::class;
+
+        return $services;
+    }
+
     protected function getBackendWildcard(ModuleModel $module): Response
     {
         $context = [

--- a/core-bundle/src/Controller/FrontendModule/AbstractFrontendModuleController.php
+++ b/core-bundle/src/Controller/FrontendModule/AbstractFrontendModuleController.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Controller\FrontendModule;
 
 use Contao\CoreBundle\Controller\AbstractFragmentController;
+use Contao\CoreBundle\Csrf\ContaoCsrfTokenManager;
 use Contao\CoreBundle\String\HtmlAttributes;
 use Contao\CoreBundle\Twig\FragmentTemplate;
 use Contao\ModuleModel;

--- a/core-bundle/src/Resources/config/services.yml
+++ b/core-bundle/src/Resources/config/services.yml
@@ -1002,6 +1002,7 @@ services:
     # Autowiring aliases
     Contao\CoreBundle\Cache\EntityCacheTags: '@contao.cache.entity_tags'
     Contao\CoreBundle\Config\ResourceFinderInterface: '@contao.resource_finder'
+    Contao\CoreBundle\Csrf\ContaoCsrfTokenManager: '@contao.csrf.token_manager'
     Contao\CoreBundle\Doctrine\Backup\DumperInterface: '@contao.doctrine.backup.dumper'
     Contao\CoreBundle\Framework\ContaoFramework: '@contao.framework'
     Contao\CoreBundle\Image\ImageFactoryInterface: '@contao.image.factory'

--- a/core-bundle/src/Resources/config/services.yml
+++ b/core-bundle/src/Resources/config/services.yml
@@ -1025,3 +1025,4 @@ services:
     Contao\CoreBundle\String\HtmlDecoder: '@contao.string.html_decoder'
     Contao\CoreBundle\String\SimpleTokenParser: '@contao.string.simple_token_parser'
     Contao\CoreBundle\Twig\Interop\ContextFactory: '@contao.twig.interop.context_factory'
+    Contao\CoreBundle\Twig\Loader\ContaoFilesystemLoader: '@contao.twig.filesystem_loader'


### PR DESCRIPTION
Currently the following error happens, if you try to implement a content element or module as a fragment when extending from the appropriate abstract classes:

```
Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException:
The service ".service_locator.t.IY1uE" has a dependency on a non-existent service "Contao\CoreBundle\Csrf\ContaoCsrfTokenManager".
```

This is because we are registering `contao.csrf.token_manager` as a subscribed service in our `AbstractController`. However autowiring is still used for service subscribers and due to the removal of the alias for `ContaoCsrfTokenManager` in #4554 autowiring is not possible anymore.

This PR fixes that by re-introducing an autowiring alias for the `ContaoCsrfTokenManager`. This makes sense independently from this issue anyway, as it is currently not possible to autowire the `ContaoCsrfTokenManager` in your `App` - which is important since we want to use its `getDefaultValue` method.

The same error also happens for `Contao\CoreBundle\Twig\Loader\ContaoFilesystemLoader` which is subscribed in the `AbstractFragmentController`.

~~This PR also removes a superfluous `getSubscribedServices` definition in `AbstractFrontendModuleController`. It only adds the `ContaoCsrfTokenManager` - which is already added in on of the parent classes.~~