### PR TITLE
Require symfony/deprecation-contracts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -90,6 +90,7 @@
         "symfony/debug": "4.4.*",
         "symfony/debug-bundle": "4.4.*",
         "symfony/dependency-injection": "4.4.*",
+        "symfony/deprecation-contracts": "^2.1 || ^3.0",
         "symfony/doctrine-bridge": "4.4.*",
         "symfony/dom-crawler": "4.4.*",
         "symfony/dotenv": "4.4.*",

--- a/core-bundle/composer.json
+++ b/core-bundle/composer.json
@@ -78,6 +78,7 @@
         "symfony/config": "4.4.*",
         "symfony/console": "4.4.*",
         "symfony/dependency-injection": "4.4.*",
+        "symfony/deprecation-contracts": "^2.1 || ^3.0",
         "symfony/dom-crawler": "4.4.*",
         "symfony/event-dispatcher": "4.4.*",
         "symfony/expression-language": "4.4.*",


### PR DESCRIPTION
Fixes #4550

Turns out we can use `trigger_deprecation()` in Contao 4.9. All we have to do is to require `symfony/deprecation-contracts`. 🤷‍♂️ 
