### PR TITLE
Support more widgets in DC_Folder

### DIFF
--- a/core-bundle/src/Resources/contao/classes/Ajax.php
+++ b/core-bundle/src/Resources/contao/classes/Ajax.php
@@ -299,7 +299,15 @@ class Ajax extends Backend
 					}
 					elseif ($intId > 0 && $this->Database->tableExists($dc->table))
 					{
-						$objRow = $this->Database->prepare("SELECT * FROM " . $dc->table . " WHERE id=?")
+						$idField = 'id';
+
+						// ID is file path for DC_Folder
+						if ($dc instanceof DC_Folder)
+						{
+							$idField = 'path';
+						}
+
+						$objRow = $this->Database->prepare("SELECT * FROM " . $dc->table . " WHERE " . $idField . "=?")
 												 ->execute($intId);
 
 						// The record does not exist


### PR DESCRIPTION
Currently it is not possible to use a widget within `DC_Folder` that executes an ajax request - e.g. `fileTree`. So something like this does not work:

```php
// contao/dca/tl_files.php
use Contao\CoreBundle\DataContainer\PaletteManipulator;

$GLOBALS['TL_DCA']['tl_files']['fields']['alternative'] = [
    'label' => ['Alternative file', 'Alternative file reference.'],
    'inputType' => 'fileTree',
    'eval' => [
        'extensions' => Contao\Config::get('validImageTypes'),
        'filesOnly' => true, 
        'fieldType' => 'radio', 
        'tl_class' => 'clr',
    ],
    'sql' => 'binary(16) NULL',
];

PaletteManipulator::create()
    ->addField('alternative', 'meta')
    ->applyToPalette('default', 'tl_files')
;
```

If you select a file via this file picker, the resulting ajax request will fail:

```
Symfony\Component\HttpKernel\Exception\BadRequestHttpException:
Bad request

  at vendor\contao\contao\core-bundle\src\Resources\contao\classes\Ajax.php:318
```
System log entry:
```
A record with the ID "files/lorem/ipsum.jpg" does not exist in table "tl_files"
```

This is because the "ID" within `DC_Folder` will always be the relative file path, i.e. `tl_files.path` and not the database ID, i.e. `tl_files.id`.

This PR would fix that by automatically switching to `tl_files.path` for the database query, if the datacontainer is an instance of `DC_Folder`.