### PR TITLE
Fix upload directory check in ImageFactory on Windows

### DIFF
--- a/core-bundle/src/Image/ImageFactory.php
+++ b/core-bundle/src/Image/ImageFactory.php
@@ -26,6 +26,7 @@ use Contao\ImageSizeModel;
 use Imagine\Image\ImagineInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Filesystem\Filesystem;
+use Webmozart\PathUtil\Path;
 
 class ImageFactory implements ImageFactoryInterface
 {
@@ -301,7 +302,7 @@ class ImageFactory implements ImageFactoryInterface
      */
     private function createImportantPart(ImageInterface $image): ?ImportantPart
     {
-        if (0 !== strncmp($image->getPath(), $this->uploadDir.'/', \strlen($this->uploadDir) + 1)) {
+        if (!Path::isBasePath($this->uploadDir, $image->getPath())) {
             return null;
         }
 

--- a/core-bundle/tests/Image/ImageFactoryTest.php
+++ b/core-bundle/tests/Image/ImageFactoryTest.php
@@ -883,7 +883,8 @@ class ImageFactoryTest extends TestCase
         }
 
         if (null === $uploadDir) {
-            $uploadDir = Path::join($this->getTempDir(), 'images');
+            // Do not use Path::join here (see #4596)
+            $uploadDir = $this->getTempDir().'/images';
         }
 
         return new ImageFactory(


### PR DESCRIPTION
On Windows, `%kernel.project_dir%/%contao.upload_path%` will be something like this:

```
C:\Users\fmg\www\c49/files
```

However, the given image path might look like this, if it has been normalised beforehand somewhere:

```
C:/Users/fmg/www/c49/files/dts/DeathtoStock_Meticulous-04.jpg
```

In this case the check whether the given file is part of the upload directory (i.e. part of the file manager) will fail due to the string comparison, and thus things like the important part will not be taken into account when creating the image.

This PR fixes that by using `Path::isBasePath` instead, which handles proper path normalisation.
