### PR TITLE
Correctly generate the edit URL of a version

### DIFF
--- a/core-bundle/src/Resources/contao/classes/Versions.php
+++ b/core-bundle/src/Resources/contao/classes/Versions.php
@@ -759,32 +759,36 @@ class Versions extends Controller
 			return sprintf($this->strEditUrl, $this->intPid);
 		}
 
-		$strUrl = Environment::get('request');
+		$pairs = array();
+		$request = System::getContainer()->get('request_stack')->getCurrentRequest();
 
-		// Save the real edit URL if the visibility is toggled via Ajax
-		if (preg_match('/&(amp;)?state=/', $strUrl))
-		{
-			$strUrl = preg_replace
-			(
-				array('/&(amp;)?id=[^&]+/', '/(&(amp;)?)t(id=[^&]+)/', '/(&(amp;)?)state=[^&]*/'),
-				array('', '$1$3', '$1act=edit'),
-				$strUrl
-			);
-		}
+		parse_str($request->server->get('QUERY_STRING'), $pairs);
 
 		// Adjust the URL of the "personal data" module (see #7987)
-		if (preg_match('/do=login(&|$)/', $strUrl))
+		if (isset($pairs['do']) && $pairs['do'] == 'login')
 		{
-			$this->import(BackendUser::class, 'User');
-
-			$strUrl = preg_replace('/do=login(&|$)/', 'do=user$1', $strUrl);
-			$strUrl .= '&amp;act=edit&amp;id=' . $this->User->id . '&amp;rt=' . REQUEST_TOKEN;
+			$pairs['do'] = 'user';
+			$pairs['id'] = BackendUser::getInstance()->id;
+			$pairs['rt'] = REQUEST_TOKEN;
 		}
 
-		// Correct the URL in "edit|override multiple" mode (see #7745)
-		$strUrl = preg_replace('/act=(edit|override)All/', 'act=edit&id=' . $this->intPid, $strUrl);
+		if (isset($pairs['act']))
+		{
+			// Save the real edit URL if the visibility is toggled via Ajax
+			if ($pairs['act'] == 'toggle')
+			{
+				$pairs['act'] = 'edit';
+			}
 
-		return $strUrl;
+			// Correct the URL in "edit|override multiple" mode (see #7745)
+			if ($pairs['act'] == 'editAll' || $pairs['act'] == 'overrideAll')
+			{
+				$pairs['act'] = 'edit';
+				$pairs['id'] = $this->intPid;
+			}
+		}
+
+		return ltrim($request->getPathInfo(), '/').'?'.http_build_query($pairs, '', '&', PHP_QUERY_RFC3986);
 	}
 
 	/**

--- a/core-bundle/src/Resources/contao/classes/Versions.php
+++ b/core-bundle/src/Resources/contao/classes/Versions.php
@@ -788,7 +788,7 @@ class Versions extends Controller
 			}
 		}
 
-		return ltrim($request->getPathInfo(), '/').'?'.http_build_query($pairs, '', '&', PHP_QUERY_RFC3986);
+		return ltrim($request->getPathInfo(), '/') . '?' . http_build_query($pairs, '', '&', PHP_QUERY_RFC3986);
 	}
 
 	/**


### PR DESCRIPTION
Fixes #4460

This is because the icon now uses the new `toggle()` method.
