### PR TITLE
Ignore port in Favicon and RobotsTxt controller

### DIFF
--- a/core-bundle/src/Controller/FaviconController.php
+++ b/core-bundle/src/Controller/FaviconController.php
@@ -63,7 +63,7 @@ class FaviconController
 
         /** @var PageModel|null $rootPage */
         $rootPage = $pageModel->findPublishedFallbackByHostname(
-            $request->server->get('HTTP_HOST'),
+            $request->getHost(),
             ['fallbackToEmpty' => true]
         );
 

--- a/core-bundle/src/Controller/RobotsTxtController.php
+++ b/core-bundle/src/Controller/RobotsTxtController.php
@@ -57,7 +57,7 @@ class RobotsTxtController
 
         /** @var PageModel|null $rootPage */
         $rootPage = $pageModel->findPublishedFallbackByHostname(
-            $request->server->get('HTTP_HOST'),
+            $request->getHost(),
             ['fallbackToEmpty' => true]
         );
 

--- a/core-bundle/tests/Controller/FaviconControllerTest.php
+++ b/core-bundle/tests/Controller/FaviconControllerTest.php
@@ -55,6 +55,17 @@ class FaviconControllerTest extends TestCase
         $this->assertSame('image/x-icon', $response->headers->get('Content-Type'));
     }
 
+    public function testIgnoresRequestPort(): void
+    {
+        $controller = $this->getController('images/favicon.ico');
+
+        $request = Request::create('https://localhost:8000/favicon.ico');
+        $response = $controller($request);
+
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertSame('image/x-icon', $response->headers->get('Content-Type'));
+    }
+
     public function testSvgFavicon(): void
     {
         $controller = $this->getController('images/favicon.svg');
@@ -80,6 +91,7 @@ class FaviconControllerTest extends TestCase
         $pageModelAdapter
             ->expects($this->once())
             ->method('findPublishedFallbackByHostname')
+            ->with('localhost')
             ->willReturn($pageModel)
         ;
 

--- a/core-bundle/tests/Controller/RobotsTxtControllerTest.php
+++ b/core-bundle/tests/Controller/RobotsTxtControllerTest.php
@@ -78,4 +78,35 @@ class RobotsTxtControllerTest extends TestCase
 
         $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
     }
+
+    public function testRobotsTxtIgnoresRequestPort(): void
+    {
+        $pageModel = $this->mockClassWithProperties(PageModel::class);
+
+        $pageModelAdapter = $this->mockAdapter(['findPublishedFallbackByHostname']);
+        $pageModelAdapter
+            ->expects($this->once())
+            ->method('findPublishedFallbackByHostname')
+            ->with('localhost')
+            ->willReturn($pageModel)
+        ;
+
+        $framework = $this->mockContaoFramework([PageModel::class => $pageModelAdapter]);
+        $framework
+            ->expects($this->once())
+            ->method('initialize')
+        ;
+
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $eventDispatcher
+            ->expects($this->once())
+            ->method('dispatch')
+        ;
+
+        $request = Request::create('https://localhost:8000/robots.txt');
+        $controller = new RobotsTxtController($framework, $eventDispatcher);
+        $response = $controller($request);
+
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+    }
 }


### PR DESCRIPTION
This is a follow-up to #4604 for Contao 4.9 as requested by @fritzmg 