### PR TITLE
Fix the global state unit tests

### DIFF
--- a/calendar-bundle/tests/EventListener/SitemapListenerTest.php
+++ b/calendar-bundle/tests/EventListener/SitemapListenerTest.php
@@ -23,6 +23,13 @@ use Symfony\Component\HttpFoundation\Request;
 
 class SitemapListenerTest extends ContaoTestCase
 {
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['TL_CONFIG']);
+
+        parent::tearDown();
+    }
+
     public function testNothingIsAddedIfNoPublishedCalendar(): void
     {
         $adapters = [

--- a/core-bundle/src/Resources/contao/library/Contao/Input.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Input.php
@@ -39,23 +39,23 @@ class Input
 	/**
 	 * Parameters set via setGet() are stored by request
 	 *
-	 * @var \WeakMap<Request,array<string,array|string>>|null
+	 * @var \WeakMap<Request,array<string,array|string>>
 	 */
-	private static \WeakMap|null $setGet = null;
+	private static \WeakMap $setGet;
 
 	/**
 	 * Parameters set via setPost() are stored by request
 	 *
-	 * @var \WeakMap<Request,array<string,array|string>>|null
+	 * @var \WeakMap<Request,array<string,array|string>>
 	 */
-	private static \WeakMap|null $setPost = null;
+	private static \WeakMap $setPost;
 
 	/**
 	 * Parameters set via setCookie() are stored by request
 	 *
-	 * @var \WeakMap<Request,array<string,array|string>>|null
+	 * @var \WeakMap<Request,array<string,array|string>>
 	 */
-	private static \WeakMap|null $setCookie = null;
+	private static \WeakMap $setCookie;
 
 	/**
 	 * Clean the global GPC arrays

--- a/core-bundle/src/Resources/contao/library/Contao/Input.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Input.php
@@ -39,23 +39,23 @@ class Input
 	/**
 	 * Parameters set via setGet() are stored by request
 	 *
-	 * @var \WeakMap<Request,array<string,array|string>>
+	 * @var \WeakMap<Request,array<string,array|string>>|null
 	 */
-	private static \WeakMap $setGet;
+	private static \WeakMap|null $setGet = null;
 
 	/**
 	 * Parameters set via setPost() are stored by request
 	 *
-	 * @var \WeakMap<Request,array<string,array|string>>
+	 * @var \WeakMap<Request,array<string,array|string>>|null
 	 */
-	private static \WeakMap $setPost;
+	private static \WeakMap|null $setPost = null;
 
 	/**
 	 * Parameters set via setCookie() are stored by request
 	 *
-	 * @var \WeakMap<Request,array<string,array|string>>
+	 * @var \WeakMap<Request,array<string,array|string>>|null
 	 */
-	private static \WeakMap $setCookie;
+	private static \WeakMap|null $setCookie = null;
 
 	/**
 	 * Clean the global GPC arrays

--- a/core-bundle/tests/Contao/DcaExtractorTest.php
+++ b/core-bundle/tests/Contao/DcaExtractorTest.php
@@ -12,9 +12,11 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Tests\Contao;
 
+use Contao\Config;
 use Contao\CoreBundle\Config\ResourceFinder;
 use Contao\CoreBundle\Tests\TestCase;
 use Contao\DcaExtractor;
+use Contao\DcaLoader;
 use Contao\System;
 use Doctrine\DBAL\Connection;
 use Symfony\Component\Config\FileLocator;
@@ -47,6 +49,10 @@ class DcaExtractorTest extends TestCase
 
     protected function tearDown(): void
     {
+        unset($GLOBALS['TL_MIME'], $GLOBALS['TL_TEST'], $GLOBALS['TL_LANG'], $GLOBALS['TL_DCA']);
+
+        $this->resetStaticProperties([System::class, DcaExtractor::class, Config::class, DcaLoader::class]);
+
         parent::tearDown();
 
         (new Filesystem())->remove($this->getTempDir());

--- a/core-bundle/tests/Contao/EnvironmentTest.php
+++ b/core-bundle/tests/Contao/EnvironmentTest.php
@@ -17,6 +17,7 @@ use Contao\Environment;
 use Contao\System;
 use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpFoundation\IpUtils;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
@@ -50,7 +51,14 @@ class EnvironmentTest extends TestCase
     protected function tearDown(): void
     {
         $this->restoreServerEnvGetPost();
-        $this->resetStaticProperties([Environment::class, [Environment::class, ['strSapi']], System::class]);
+
+        $this->resetStaticProperties([
+            Environment::class,
+            [Environment::class, ['strSapi']],
+            System::class,
+            Request::class,
+            IpUtils::class,
+        ]);
 
         parent::tearDown();
     }

--- a/core-bundle/tests/Contao/InputTest.php
+++ b/core-bundle/tests/Contao/InputTest.php
@@ -57,6 +57,7 @@ class InputTest extends TestCase
     {
         unset($GLOBALS['TL_CONFIG']);
 
+        $_COOKIE = [];
         $this->restoreServerEnvGetPost();
         $this->resetStaticProperties([System::class, Input::class]);
 

--- a/core-bundle/tests/Contao/InputTest.php
+++ b/core-bundle/tests/Contao/InputTest.php
@@ -58,6 +58,7 @@ class InputTest extends TestCase
         unset($GLOBALS['TL_CONFIG']);
 
         $_COOKIE = [];
+
         $this->restoreServerEnvGetPost();
         $this->resetStaticProperties([System::class, Input::class]);
 

--- a/core-bundle/tests/PhpunitExtension/GlobalStateWatcher.php
+++ b/core-bundle/tests/PhpunitExtension/GlobalStateWatcher.php
@@ -181,6 +181,10 @@ final class GlobalStateWatcher implements AfterTestHook, BeforeTestHook
                     continue;
                 }
 
+                if ($value instanceof \WeakMap && $value->count() === 0 && $property->hasType() && !$property->getType()->allowsNull()) {
+                    continue;
+                }
+
                 if (\is_array($value)) {
                     $value = 'array('.\count($value).')';
                 }

--- a/core-bundle/tests/PhpunitExtension/GlobalStateWatcher.php
+++ b/core-bundle/tests/PhpunitExtension/GlobalStateWatcher.php
@@ -181,7 +181,7 @@ final class GlobalStateWatcher implements AfterTestHook, BeforeTestHook
                     continue;
                 }
 
-                if ($value instanceof \WeakMap && $value->count() === 0 && $property->hasType() && !$property->getType()->allowsNull()) {
+                if ($value instanceof \WeakMap && 0 === $value->count() && $property->hasType() && !$property->getType()->allowsNull()) {
                     continue;
                 }
 

--- a/core-bundle/tests/Twig/Loader/ContaoFilesystemLoaderTest.php
+++ b/core-bundle/tests/Twig/Loader/ContaoFilesystemLoaderTest.php
@@ -30,6 +30,13 @@ use Twig\Error\LoaderError;
 
 class ContaoFilesystemLoaderTest extends TestCase
 {
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['objPage']);
+
+        parent::tearDown();
+    }
+
     public function testAddsPath(): void
     {
         $loader = $this->getContaoFilesystemLoader();
@@ -201,8 +208,6 @@ class ContaoFilesystemLoaderTest extends TestCase
             Path::join($basePath, 'templates/my/theme/text.html.twig'),
             Path::normalize($loader->getCacheKey('@Contao/text.html.twig'))
         );
-
-        unset($GLOBALS['objPage']);
     }
 
     public function testGetsSourceContext(): void
@@ -243,8 +248,6 @@ class ContaoFilesystemLoaderTest extends TestCase
 
         $this->assertSame('@Contao_Theme_my_theme/text.html.twig', $source->getName());
         $this->assertSame(Path::join($basePath, 'templates/my/theme/text.html.twig'), Path::normalize($source->getPath()));
-
-        unset($GLOBALS['objPage']);
     }
 
     public function testGetsSourceContextFromHtml5File(): void
@@ -303,8 +306,6 @@ class ContaoFilesystemLoaderTest extends TestCase
 
         $this->assertTrue($loader->exists('@Contao/text.html.twig'));
         $this->assertFalse($loader->exists('@Contao/foo.html.twig'));
-
-        unset($GLOBALS['objPage']);
     }
 
     /**
@@ -390,8 +391,6 @@ class ContaoFilesystemLoaderTest extends TestCase
         $GLOBALS['objPage'] = $page;
 
         $this->assertFalse($loader->isFresh('@Contao/text.html.twig', $cacheTime));
-
-        unset($GLOBALS['objPage']);
     }
 
     public function testGetsHierarchy(): void
@@ -622,8 +621,6 @@ class ContaoFilesystemLoaderTest extends TestCase
         $GLOBALS['objPage'] = $page;
 
         $this->assertFalse($loader->exists('@Contao/foo.html.twig'));
-
-        unset($GLOBALS['objPage']);
     }
 
     private function getTemplateLocator(string $projectDir = '/', array $themePaths = [], array $bundles = [], array $bundlesMetadata = []): TemplateLocator

--- a/test-case/src/ContaoTestCase.php
+++ b/test-case/src/ContaoTestCase.php
@@ -275,7 +275,6 @@ abstract class ContaoTestCase extends TestCase
             '_ENV' => $_ENV,
             '_GET' => $_GET,
             '_POST' => $_POST,
-            '_COOKIE' => $_COOKIE,
         ];
     }
 
@@ -285,7 +284,6 @@ abstract class ContaoTestCase extends TestCase
         $_ENV = $this->backupServerEnvGetPost['_ENV'] ?? $_ENV;
         $_GET = $this->backupServerEnvGetPost['_GET'] ?? [];
         $_POST = $this->backupServerEnvGetPost['_POST'] ?? [];
-        $_COOKIE = $this->backupServerEnvGetPost['_COOKIE'] ?? [];
     }
 
     /**
@@ -312,7 +310,7 @@ abstract class ContaoTestCase extends TestCase
                 && \is_callable([$class, 'reset'])
                 && method_exists($class, 'reset')
                 && $reflectionClass->getMethod('reset')->isStatic()
-                && $reflectionClass->getMethod('reset')->getDeclaringClass() === $class
+                && $reflectionClass->getMethod('reset')->getDeclaringClass()->getName() === $class
                 && 0 === \count($reflectionClass->getMethod('reset')->getParameters())
             ) {
                 $class::reset();

--- a/test-case/src/ContaoTestCase.php
+++ b/test-case/src/ContaoTestCase.php
@@ -275,6 +275,7 @@ abstract class ContaoTestCase extends TestCase
             '_ENV' => $_ENV,
             '_GET' => $_GET,
             '_POST' => $_POST,
+            '_COOKIE' => $_COOKIE,
         ];
     }
 
@@ -284,6 +285,7 @@ abstract class ContaoTestCase extends TestCase
         $_ENV = $this->backupServerEnvGetPost['_ENV'] ?? $_ENV;
         $_GET = $this->backupServerEnvGetPost['_GET'] ?? [];
         $_POST = $this->backupServerEnvGetPost['_POST'] ?? [];
+        $_COOKIE = $this->backupServerEnvGetPost['_COOKIE'] ?? [];
     }
 
     /**


### PR DESCRIPTION
This should fix https://github.com/contao/contao/runs/6307113827?check_suite_focus=true. Note that the job is only run periodically, so even if the CI chain below is green, the tests might still fail. Run `vendor/bin/phpunit --extensions Contao\\CoreBundle\\Tests\\PhpunitExtension\\GlobalStateWatcher` on the CLI to verify.