### PR TITLE
Correctly handle rgxp natural text field attributes

### DIFF
--- a/core-bundle/src/Resources/contao/forms/FormTextField.php
+++ b/core-bundle/src/Resources/contao/forms/FormTextField.php
@@ -70,14 +70,14 @@ class FormTextField extends Widget
 		switch ($strKey)
 		{
 			case 'minlength':
-				if ($varValue > 0 && $this->rgxp != 'digit')
+				if ($varValue > 0 && $this->rgxp != 'digit' && $this->rgxp != 'natural')
 				{
 					$this->arrAttributes['minlength'] =  $varValue;
 				}
 				break;
 
 			case 'maxlength':
-				if ($varValue > 0 && $this->rgxp != 'digit')
+				if ($varValue > 0 && $this->rgxp != 'digit' && $this->rgxp != 'natural')
 				{
 					$this->arrAttributes['maxlength'] =  $varValue;
 				}
@@ -97,7 +97,7 @@ class FormTextField extends Widget
 
 			case 'min':
 			case 'minval':
-				if ($this->rgxp == 'digit')
+				if ($this->rgxp == 'digit' || $this->rgxp == 'natural')
 				{
 					$this->arrAttributes['min'] = $varValue;
 				}
@@ -105,7 +105,7 @@ class FormTextField extends Widget
 
 			case 'max':
 			case 'maxval':
-				if ($this->rgxp == 'digit')
+				if ($this->rgxp == 'digit' || $this->rgxp == 'natural')
 				{
 					$this->arrAttributes['max'] = $varValue;
 				}


### PR DESCRIPTION
Input type is set to `number` for `rgxp=digit` and `rgxp=natural`, so we also need to allow min+max for both.