### PR TITLE
Always set a mock session when creating feeds

### DIFF
--- a/calendar-bundle/src/Resources/contao/classes/Calendar.php
+++ b/calendar-bundle/src/Resources/contao/classes/Calendar.php
@@ -12,6 +12,8 @@ namespace Contao;
 
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 
 /**
  * Provide methods regarding calendars.
@@ -232,7 +234,7 @@ class Calendar extends Frontend
 					$GLOBALS['objPage'] = $this->getPageWithDetails(CalendarModel::findByPk($event['pid'])->jumpTo);
 
 					// Push a new request to the request stack (#3856)
-					$request = null !== $currentRequest ? $this->createSubRequest($event['link'], $currentRequest) : Request::create($event['link']);
+					$request = $this->createSubRequest($event['link'], $currentRequest);
 					$request->attributes->set('_scope', 'frontend');
 					$requestStack->push($request);
 
@@ -631,29 +633,30 @@ class Calendar extends Frontend
 	/**
 	 * Creates a sub request for the given URI.
 	 */
-	private function createSubRequest(string $uri, Request $request): Request
+	private function createSubRequest(string $uri, Request $request = null): Request
 	{
-		$cookies = $request->cookies->all();
-		$server = $request->server->all();
+		$cookies = null !== $request ? $request->cookies->all() : [];
+		$server = null !== $request ? $request->server->all() : [];
 
 		unset($server['HTTP_IF_MODIFIED_SINCE'], $server['HTTP_IF_NONE_MATCH']);
 
 		$subRequest = Request::create($uri, 'get', array(), $cookies, array(), $server);
 
-		if (null !== ($session = $request->getSession()))
+		if (null !== $request)
 		{
-			$subRequest->setSession($session);
+			if ($request->get('_format'))
+			{
+				$subRequest->attributes->set('_format', $request->get('_format'));
+			}
+
+			if ($request->getDefaultLocale() !== $request->getLocale())
+			{
+				$subRequest->setLocale($request->getLocale());
+			}
 		}
 
-		if ($request->get('_format'))
-		{
-			$subRequest->attributes->set('_format', $request->get('_format'));
-		}
-
-		if ($request->getDefaultLocale() !== $request->getLocale())
-		{
-			$subRequest->setLocale($request->getLocale());
-		}
+		// Always set a session (#3856)
+		$subRequest->setSession(new Session(new MockArraySessionStorage()));
 
 		return $subRequest;
 	}

--- a/calendar-bundle/src/Resources/contao/classes/Calendar.php
+++ b/calendar-bundle/src/Resources/contao/classes/Calendar.php
@@ -635,8 +635,8 @@ class Calendar extends Frontend
 	 */
 	private function createSubRequest(string $uri, Request $request = null): Request
 	{
-		$cookies = null !== $request ? $request->cookies->all() : [];
-		$server = null !== $request ? $request->server->all() : [];
+		$cookies = null !== $request ? $request->cookies->all() : array();
+		$server = null !== $request ? $request->server->all() : array();
 
 		unset($server['HTTP_IF_MODIFIED_SINCE'], $server['HTTP_IF_NONE_MATCH']);
 

--- a/news-bundle/src/Resources/contao/classes/News.php
+++ b/news-bundle/src/Resources/contao/classes/News.php
@@ -12,6 +12,8 @@ namespace Contao;
 
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 
 /**
  * Provide methods regarding news archives.
@@ -190,7 +192,7 @@ class News extends Frontend
 				$objItem->published = $objArticle->date;
 
 				// Push a new request to the request stack (#3856)
-				$request = null !== $currentRequest ? $this->createSubRequest($objItem->link, $currentRequest) : Request::create($objItem->link);
+				$request = $this->createSubRequest($objItem->link, $currentRequest);
 				$request->attributes->set('_scope', 'frontend');
 				$requestStack->push($request);
 
@@ -536,29 +538,30 @@ class News extends Frontend
 	/**
 	 * Creates a sub request for the given URI.
 	 */
-	private function createSubRequest(string $uri, Request $request): Request
+	private function createSubRequest(string $uri, Request $request = null): Request
 	{
-		$cookies = $request->cookies->all();
-		$server = $request->server->all();
+		$cookies = null !== $request ? $request->cookies->all() : [];
+		$server = null !== $request ? $request->server->all() : [];
 
 		unset($server['HTTP_IF_MODIFIED_SINCE'], $server['HTTP_IF_NONE_MATCH']);
 
 		$subRequest = Request::create($uri, 'get', array(), $cookies, array(), $server);
 
-		if (null !== ($session = $request->getSession()))
+		if (null !== $request)
 		{
-			$subRequest->setSession($session);
+			if ($request->get('_format'))
+			{
+				$subRequest->attributes->set('_format', $request->get('_format'));
+			}
+
+			if ($request->getDefaultLocale() !== $request->getLocale())
+			{
+				$subRequest->setLocale($request->getLocale());
+			}
 		}
 
-		if ($request->get('_format'))
-		{
-			$subRequest->attributes->set('_format', $request->get('_format'));
-		}
-
-		if ($request->getDefaultLocale() !== $request->getLocale())
-		{
-			$subRequest->setLocale($request->getLocale());
-		}
+		// Always set a session (#3856)
+		$subRequest->setSession(new Session(new MockArraySessionStorage()));
 
 		return $subRequest;
 	}

--- a/news-bundle/src/Resources/contao/classes/News.php
+++ b/news-bundle/src/Resources/contao/classes/News.php
@@ -540,8 +540,8 @@ class News extends Frontend
 	 */
 	private function createSubRequest(string $uri, Request $request = null): Request
 	{
-		$cookies = null !== $request ? $request->cookies->all() : [];
-		$server = null !== $request ? $request->server->all() : [];
+		$cookies = null !== $request ? $request->cookies->all() : array();
+		$server = null !== $request ? $request->server->all() : array();
 
 		unset($server['HTTP_IF_MODIFIED_SINCE'], $server['HTTP_IF_NONE_MATCH']);
 


### PR DESCRIPTION
Fixes #4185

This PR now always sets a session on the created sub requests when generating the feeds, as discussed.