### PR TITLE
Improve how the Contao Twig escaper works

### DIFF
--- a/core-bundle/src/Twig/Extension/ContaoExtension.php
+++ b/core-bundle/src/Twig/Extension/ContaoExtension.php
@@ -56,8 +56,11 @@ final class ContaoExtension extends AbstractExtension
         $escaperExtension->setEscaper('contao_html', [$contaoEscaper, 'escapeHtml']);
         $escaperExtension->setEscaper('contao_html_attr', [$contaoEscaper, 'escapeHtmlAttr']);
 
-        // Use our escaper on all templates in the "@Contao" and "@Contao_*" namespaces
+        // Use our escaper on all templates in the "@Contao" and "@Contao_*"
+        // namespaces, as well as the existing bundle templates we're already
+        // shipping.
         $this->addContaoEscaperRule('%^@Contao(_[a-zA-Z0-9_-]*)?/%');
+        $this->addContaoEscaperRule('%^@Contao(Core|Installation)/%');
     }
 
     /**

--- a/core-bundle/src/Twig/Loader/ContaoFilesystemLoader.php
+++ b/core-bundle/src/Twig/Loader/ContaoFilesystemLoader.php
@@ -184,7 +184,7 @@ class ContaoFilesystemLoader extends FilesystemLoader implements TemplateHierarc
         // We prefix the cache key to make sure templates from the default
         // Symfony loader won't be reused. Otherwise, we cannot reliably
         // differentiate when to apply our input encoding tolerant escaper
-        // filters (see #todo).
+        // filters (see #4623).
         return 'c'.parent::getCacheKey($templateName);
     }
 

--- a/core-bundle/src/Twig/Loader/ContaoFilesystemLoader.php
+++ b/core-bundle/src/Twig/Loader/ContaoFilesystemLoader.php
@@ -181,7 +181,11 @@ class ContaoFilesystemLoader extends FilesystemLoader implements TemplateHierarc
     {
         $templateName = $this->getThemeTemplateName($name) ?? $name;
 
-        return parent::getCacheKey($templateName);
+        // We prefix the cache key to make sure templates from the default
+        // Symfony loader won't be reused. Otherwise, we cannot reliably
+        // differentiate when to apply our input encoding tolerant escaper
+        // filters (see #todo).
+        return 'c'.parent::getCacheKey($templateName);
     }
 
     /**

--- a/core-bundle/tests/Twig/Extension/ContaoExtensionTest.php
+++ b/core-bundle/tests/Twig/Extension/ContaoExtensionTest.php
@@ -316,6 +316,7 @@ class ContaoExtensionTest extends TestCase
         $extension = $this->getContaoExtension();
 
         $property = new \ReflectionProperty(ContaoExtension::class, 'contaoEscaperFilterRules');
+        $property->setAccessible(true);
         $rules = $property->getValue($extension);
 
         $this->assertCount(2, $rules);

--- a/core-bundle/tests/Twig/Extension/ContaoExtensionTest.php
+++ b/core-bundle/tests/Twig/Extension/ContaoExtensionTest.php
@@ -309,6 +309,37 @@ class ContaoExtensionTest extends TestCase
     }
 
     /**
+     * @dataProvider provideTemplateNames
+     */
+    public function testDefaultEscaperRules(string $templateName): void
+    {
+        $extension = $this->getContaoExtension();
+
+        $property = new \ReflectionProperty(ContaoExtension::class, 'contaoEscaperFilterRules');
+        $rules = $property->getValue($extension);
+
+        $this->assertCount(2, $rules);
+
+        foreach ($rules as $rule) {
+            if (1 === preg_match($rule, $templateName)) {
+                return;
+            }
+        }
+
+        $this->fail(sprintf('No escaper rule matched template "%s".', $templateName));
+    }
+
+    public function provideTemplateNames(): \Generator
+    {
+        yield '@Contao namespace' => ['@Contao/foo.html.twig'];
+        yield '@Contao namespace with folder' => ['@Contao/foo/bar.html.twig'];
+        yield '@Contao_* namespace' => ['@Contao_Global/foo.html.twig'];
+        yield '@Contao_* namespace with folder' => ['@Contao_Global/foo/bar.html.twig'];
+        yield 'core-bundle template' => ['@ContaoCore/Image/Studio/figure.html.twig'];
+        yield 'installation-bundle template' => ['@ContaoInstallation/database.html.twig'];
+    }
+
+    /**
      * @param Environment&MockObject $environment
      */
     private function getContaoExtension(Environment $environment = null, TemplateHierarchyInterface $hierarchy = null): ContaoExtension

--- a/core-bundle/tests/Twig/Loader/ContaoFilesystemLoaderTest.php
+++ b/core-bundle/tests/Twig/Loader/ContaoFilesystemLoaderTest.php
@@ -170,7 +170,7 @@ class ContaoFilesystemLoaderTest extends TestCase
         $loader->addPath($path, 'Contao', true);
 
         $this->assertSame(
-            Path::join($path, '1.html.twig'),
+            'c'.Path::join($path, '1.html.twig'),
             Path::normalize($loader->getCacheKey('@Contao/1.html.twig'))
         );
     }
@@ -184,7 +184,7 @@ class ContaoFilesystemLoaderTest extends TestCase
         $loader->addPath(Path::join($basePath, 'templates/my/theme'), 'Contao_Theme_my_theme');
 
         $this->assertSame(
-            Path::join($basePath, 'templates/text.html.twig'),
+            'c'.Path::join($basePath, 'templates/text.html.twig'),
             Path::normalize($loader->getCacheKey('@Contao/text.html.twig'))
         );
 
@@ -197,7 +197,7 @@ class ContaoFilesystemLoaderTest extends TestCase
         $GLOBALS['objPage'] = $page;
 
         $this->assertSame(
-            Path::join($basePath, 'templates/my/theme/text.html.twig'),
+            'c'.Path::join($basePath, 'templates/my/theme/text.html.twig'),
             Path::normalize($loader->getCacheKey('@Contao/text.html.twig'))
         );
 


### PR DESCRIPTION
This implements fixes for #4551 but in a different way than anticipated. The current problem turned out to be caused mainly by indeterministic behavior. Consider these two examples:
```twig
{% include '@Contao/foo.html.twig' %}
{% include '/foo.html.twig' %}
```

vs

```twig
{% include '/bar.html.twig' %}
{% include '@Contao/bar.html.twig' %}
```

In the first example, the included file will be compiled as if it was a Contao template and then reused by the second statement because of a matching cache key. In the second example, however, things will be exactly the opposite. This is now fixed by applying a prefix to the cache key in our loader.

Inheriting the property of being a "Contao template" in the tree, didn't turn out to be feasible. The second change in this PR, therefore at least adds an escaper rule to include our already shipped bundle templates. 