### PR TITLE
Fix RelLightboxMigration if ContaoCommentsBundle is not installed

### DIFF
--- a/core-bundle/src/Migration/Version413/RelLightboxMigration.php
+++ b/core-bundle/src/Migration/Version413/RelLightboxMigration.php
@@ -61,7 +61,13 @@ class RelLightboxMigration extends AbstractMigration
 
     public function run(): MigrationResult
     {
+        $schemaManager = $this->connection->createSchemaManager();
+
         foreach ($this->getTargets() as [$table, $column]) {
+            if (!$schemaManager->tablesExist([$table]) || !isset($schemaManager->listTableColumns($table)[$column])) {
+                continue;
+            }
+
             $values = $this->connection->fetchAllKeyValue(
                 "SELECT id, `$column` FROM $table WHERE `$column` REGEXP ' rel=\"lightbox(\\\\[([^\\\\]]+)\\\\])?\"'"
             );


### PR DESCRIPTION
If the `contao/comments-bundle` is not installed, the following error can occur in the Install Tool:

```
Doctrine\DBAL\Exception\TableNotFoundException:
An exception occurred while executing a query: SQLSTATE[42S02]: Base table or view not found: 1146 Table 'd0C9847s.tl_comments' doesn't exist

  at vendor/doctrine/dbal/src/Driver/API/MySQL/ExceptionConverter.php:51
  at Doctrine\DBAL\Driver\API\MySQL\ExceptionConverter->convert(object(Exception), object(Query))
     (vendor/doctrine/dbal/src/Connection.php:1814)
  at Doctrine\DBAL\Connection->handleDriverException(object(Exception), object(Query))
     (vendor/doctrine/dbal/src/Connection.php:1749)
  at Doctrine\DBAL\Connection->convertExceptionDuringQuery(object(Exception), 'SELECT id, `comment` FROM tl_comments WHERE `comment` REGEXP \' rel="lightbox(\\\\[([^\\\\]]+)\\\\])?"\'', array(), array())
     (vendor/doctrine/dbal/src/Connection.php:1055)
  at Doctrine\DBAL\Connection->executeQuery('SELECT id, `comment` FROM tl_comments WHERE `comment` REGEXP \' rel="lightbox(\\\\[([^\\\\]]+)\\\\])?"\'', array(), array())
     (vendor/doctrine/dbal/src/Connection.php:866)
  at Doctrine\DBAL\Connection->fetchAllKeyValue('SELECT id, `comment` FROM tl_comments WHERE `comment` REGEXP \' rel="lightbox(\\\\[([^\\\\]]+)\\\\])?"\'')
     (vendor/contao/core-bundle/src/Migration/Version413/RelLightboxMigration.php:66)
  at Contao\CoreBundle\Migration\Version413\RelLightboxMigration->run()
     (vendor/contao/core-bundle/src/Migration/MigrationCollection.php:58)
  at Contao\CoreBundle\Migration\MigrationCollection->run()
     (vendor/contao/installation-bundle/src/InstallTool.php:427)
  at Contao\InstallationBundle\InstallTool->runMigrations()
     (vendor/contao/installation-bundle/src/Controller/InstallationController.php:361)
  at Contao\InstallationBundle\Controller\InstallationController->runDatabaseUpdates()
     (vendor/contao/installation-bundle/src/Controller/InstallationController.php:96)
  at Contao\InstallationBundle\Controller\InstallationController->installAction()
     (vendor/symfony/http-kernel/HttpKernel.php:152)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw(object(Request), 1)
     (vendor/symfony/http-kernel/HttpKernel.php:74)
  at Symfony\Component\HttpKernel\HttpKernel->handle(object(Request), 1, true)
     (vendor/symfony/http-kernel/Kernel.php:202)
  at Symfony\Component\HttpKernel\Kernel->handle(object(Request))
     (public/index.php:44)
```

