### PR TITLE
Fix the empty URL check in the getCandidates() method

### DIFF
--- a/core-bundle/src/Routing/Candidates/AbstractCandidates.php
+++ b/core-bundle/src/Routing/Candidates/AbstractCandidates.php
@@ -76,7 +76,7 @@ class AbstractCandidates implements CandidatesInterface
         $url = $request->getPathInfo();
         $url = rawurldecode(substr($url, 1));
 
-        if (empty($url)) {
+        if ('' === $url) {
             throw new \RuntimeException(__METHOD__.' cannot handle empty path');
         }
 

--- a/core-bundle/tests/Routing/Candidates/PageCandidatesTest.php
+++ b/core-bundle/tests/Routing/Candidates/PageCandidatesTest.php
@@ -368,6 +368,16 @@ class PageCandidatesTest extends TestCase
                 'legacy' => [],
             ],
         ];
+
+        // Ensure that 0 does not trigger the "AbstractCandidates::getCandidates cannot handle empty path" exception
+        yield [
+            '/0',
+            ['.html'],
+            [''],
+            [
+                'default' => [],
+            ],
+        ];
     }
 
     public function testIncluesPageWithAbsolutePath(): void


### PR DESCRIPTION
Otherwise URLs like `https://domain.com/0` will trigger the "AbstractCandidates::getCandidates cannot handle empty path" exception.