### PR TITLE
Undeprecate some autowiring aliases

### DIFF
--- a/core-bundle/src/Resources/config/services.yml
+++ b/core-bundle/src/Resources/config/services.yml
@@ -1014,6 +1014,9 @@ services:
     # Autowiring aliases
     Contao\CoreBundle\Cache\EntityCacheTags: '@contao.cache.entity_tags'
     Contao\CoreBundle\Config\ResourceFinderInterface: '@contao.resource_finder'
+    Contao\CoreBundle\Csrf\ContaoCsrfTokenManager:
+        alias: contao.csrf.token_manager
+        public: true # backwards compatibility
     Contao\CoreBundle\Doctrine\Backup\DumperInterface: '@contao.doctrine.backup.dumper'
     Contao\CoreBundle\Framework\ContaoFramework: '@contao.framework'
     Contao\CoreBundle\Image\ImageFactoryInterface: '@contao.image.factory'
@@ -1046,6 +1049,7 @@ services:
     Contao\CoreBundle\Slug\Slug: '@contao.slug'
     Contao\CoreBundle\String\HtmlDecoder: '@contao.string.html_decoder'
     Contao\CoreBundle\String\SimpleTokenParser: '@contao.string.simple_token_parser'
+    Contao\CoreBundle\Twig\Loader\ContaoFilesystemLoader: '@contao.twig.filesystem_loader'
 
     # Backwards compatibility
     contao.cache.clear_internal:
@@ -1112,14 +1116,6 @@ services:
             version: 4.13
             message: Using the "%alias_id%" service ID has been deprecated and will no longer work in Contao 5.0. Please use "contao.cron" instead.
 
-    Contao\CoreBundle\Csrf\ContaoCsrfTokenManager:
-        alias: contao.csrf.token_manager
-        public: true
-        deprecated:
-            package: contao/core-bundle
-            version: 4.13
-            message: Using the "%alias_id%" service ID has been deprecated and will no longer work in Contao 5.0. Please use "contao.csrf.token_manager" instead.
-
     Contao\CoreBundle\Framework\ContaoFrameworkInterface:
         alias: contao.framework
         deprecated:
@@ -1180,13 +1176,6 @@ services:
             package: contao/core-bundle
             version: 4.13
             message: Using the "%alias_id%" service ID has been deprecated and will no longer work in Contao 5.0. Please use "contao.twig.loader.template_locator" instead.
-
-    Contao\CoreBundle\Twig\Loader\ContaoFilesystemLoader:
-        alias: contao.twig.filesystem_loader
-        deprecated:
-            package: contao/core-bundle
-            version: 4.13
-            message: Using the "%alias_id%" service ID has been deprecated and will no longer work in Contao 5.0. Please use "contao.twig.filesystem_loader" instead.
 
     Contao\CoreBundle\Twig\Loader\ContaoFilesystemLoaderWarmer:
         alias: contao.twig.filesystem_loader_warmer


### PR DESCRIPTION
These aliases are no longer deprecated (see https://github.com/contao/contao/pull/4589).