### PR TITLE
Undeprecate contao.csrf.token_manager

### DIFF
--- a/core-bundle/src/Resources/config/services.yml
+++ b/core-bundle/src/Resources/config/services.yml
@@ -222,7 +222,6 @@ services:
     # Backwards compatibility
     contao.csrf.token_manager:
         alias: Contao\CoreBundle\Csrf\ContaoCsrfTokenManager
-        deprecated: Using the "%alias_id%" service ID has been deprecated and will no longer work in Contao 5.0. Please use "Contao\CoreBundle\Csrf\ContaoCsrfTokenManager" instead.
         public: true
 
     contao.csrf.token_storage:

--- a/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
+++ b/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
@@ -1671,7 +1671,7 @@ class ContaoCoreExtensionTest extends TestCase
 
         $this->assertSame(ContaoCsrfTokenManager::class, (string) $alias);
         $this->assertTrue($alias->isPublic());
-        $this->assertTrue($alias->isDeprecated());
+        $this->assertFalse($alias->isDeprecated());
     }
 
     public function testRegistersTheCsrfTokenStorage(): void


### PR DESCRIPTION
This PR undeprecates the `contao.csrf.token_manager` service ID in Contao 4.9 (see also #4632 & #4589).
