### PR TITLE
Deprecate Frontend::getCronTimeout

### DIFF
--- a/core-bundle/src/Resources/contao/classes/Frontend.php
+++ b/core-bundle/src/Resources/contao/classes/Frontend.php
@@ -582,12 +582,12 @@ abstract class Frontend extends Controller
 	 * Return the cron timeout in seconds
 	 *
 	 * @return integer
-	 * 
+	 *
 	 * @deprecated Deprecated since Contao 4.9, to be removed in Contao 5.0.
 	 */
 	public static function getCronTimeout()
 	{
-		trigger_deprecation('contao/core-bundle', '4.9', 'Calling "%s::%s()" has been deprecated and will no longer work in Contao 5.0.', __CLASS__, __METHOD__);
+		trigger_deprecation('contao/core-bundle', '4.9', 'Calling "%s::%s()" has been deprecated and will no longer work in Contao 5.0.', self::class, __METHOD__);
 
 		if (!empty($GLOBALS['TL_CRON']['minutely']))
 		{

--- a/core-bundle/src/Resources/contao/classes/Frontend.php
+++ b/core-bundle/src/Resources/contao/classes/Frontend.php
@@ -587,7 +587,7 @@ abstract class Frontend extends Controller
 	 */
 	public static function getCronTimeout()
 	{
-		trigger_deprecation('contao/core-bundle', '4.9', 'Calling "%s::%s()" has been deprecated and will no longer work in Contao 5.0.', self::class, __METHOD__);
+		trigger_deprecation('contao/core-bundle', '4.9', 'Calling "%s()" has been deprecated and will no longer work in Contao 5.0.', __METHOD__);
 
 		if (!empty($GLOBALS['TL_CRON']['minutely']))
 		{

--- a/core-bundle/src/Resources/contao/classes/Frontend.php
+++ b/core-bundle/src/Resources/contao/classes/Frontend.php
@@ -582,9 +582,13 @@ abstract class Frontend extends Controller
 	 * Return the cron timeout in seconds
 	 *
 	 * @return integer
+	 * 
+	 * @deprecated Deprecated since Contao 4.9, to be removed in Contao 5.0.
 	 */
 	public static function getCronTimeout()
 	{
+		trigger_deprecation('contao/core-bundle', '4.9', 'Calling "%s::%s()" has been deprecated and will no longer work in Contao 5.0.', __CLASS__, __METHOD__);
+
 		if (!empty($GLOBALS['TL_CRON']['minutely']))
 		{
 			return 60;


### PR DESCRIPTION
This method was used prior to Contao 4.9 for the old cronjob implementation. This will be removed in Contao 5.0.
