### PR TITLE
Fix the global state watcher tests

### DIFF
--- a/faq-bundle/tests/EventListener/SitemapListenerTest.php
+++ b/faq-bundle/tests/EventListener/SitemapListenerTest.php
@@ -23,6 +23,13 @@ use Symfony\Component\HttpFoundation\Request;
 
 class SitemapListenerTest extends ContaoTestCase
 {
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['TL_CONFIG']);
+
+        parent::tearDown();
+    }
+
     public function testNothingIsAddedIfNoPublishedCategory(): void
     {
         $adapters = [

--- a/news-bundle/tests/EventListener/SitemapListenerTest.php
+++ b/news-bundle/tests/EventListener/SitemapListenerTest.php
@@ -23,6 +23,13 @@ use Symfony\Component\HttpFoundation\Request;
 
 class SitemapListenerTest extends ContaoTestCase
 {
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['TL_CONFIG']);
+
+        parent::tearDown();
+    }
+
     public function testNothingIsAddedIfNoPublishedArchive(): void
     {
         $adapters = [

--- a/newsletter-bundle/tests/EventListener/SitemapListenerTest.php
+++ b/newsletter-bundle/tests/EventListener/SitemapListenerTest.php
@@ -23,6 +23,13 @@ use Symfony\Component\HttpFoundation\Request;
 
 class SitemapListenerTest extends ContaoTestCase
 {
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['TL_CONFIG']);
+
+        parent::tearDown();
+    }
+
     public function testNothingIsAddedIfNoPublishedChannel(): void
     {
         $adapters = [


### PR DESCRIPTION
It seems that recent merges have introduced the global state issue again. 🙈 
