### PR TITLE
Fix missing PurgePreviewLinksCron registration

### DIFF
--- a/core-bundle/src/Resources/config/services.yml
+++ b/core-bundle/src/Resources/config/services.yml
@@ -110,6 +110,11 @@ services:
             - '@contao.framework'
             - '@database_connection'
 
+    contao.cron.purge_preview_links:
+        class: Contao\CoreBundle\Cron\PurgePreviewLinksCron
+        arguments:
+            - '@database_connection'
+
     contao.csrf.token_manager:
         class: Contao\CoreBundle\Csrf\ContaoCsrfTokenManager
         public: true


### PR DESCRIPTION
The `PurgePreviewLinksCron` cron job was never actually registered as a service - and thus it was never executed so far.