### PR TITLE
Remove superfluous class name in deprecation messages

### DIFF
--- a/core-bundle/src/Controller/BackendController.php
+++ b/core-bundle/src/Controller/BackendController.php
@@ -116,7 +116,7 @@ class BackendController extends AbstractController
      */
     public function fileAction(): Response
     {
-        trigger_deprecation('contao/core-bundle', '4.13', 'Calling "%s::%s()" has been deprecated and will no longer work in Contao 5.0. Use the picker instead.', __CLASS__, __METHOD__);
+        trigger_deprecation('contao/core-bundle', '4.13', 'Calling "%s()" has been deprecated and will no longer work in Contao 5.0. Use the picker instead.', __METHOD__);
 
         $this->initializeContaoFramework();
 

--- a/core-bundle/src/Resources/contao/library/Contao/Controller.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Controller.php
@@ -833,7 +833,7 @@ abstract class Controller extends System
 	 */
 	public static function replaceInsertTags($strBuffer, $blnCache=true)
 	{
-		trigger_deprecation('contao/core-bundle', '4.13', 'Using "%s::%s()" has been deprecated and will no longer work in Contao 5.0. Use the InsertTagParser service instead.', __CLASS__, __METHOD__);
+		trigger_deprecation('contao/core-bundle', '4.13', 'Using "%s()" has been deprecated and will no longer work in Contao 5.0. Use the InsertTagParser service instead.', __METHOD__);
 
 		$parser = System::getContainer()->get('contao.insert_tag.parser');
 


### PR DESCRIPTION
`__METHOD__` already contains the class.