### PR TITLE
Improve the news archive permission labels

### DIFF
--- a/news-bundle/src/Resources/contao/languages/en/tl_user.xlf
+++ b/news-bundle/src/Resources/contao/languages/en/tl_user.xlf
@@ -9,10 +9,10 @@
         <source>Here you can grant access to one or more news archives.</source>
       </trans-unit>
       <trans-unit id="tl_user.newp.0">
-        <source>News permissions</source>
+        <source>News archive permissions</source>
       </trans-unit>
       <trans-unit id="tl_user.newp.1">
-        <source>Here you can define the news permissions.</source>
+        <source>Here you can define the news archive permissions.</source>
       </trans-unit>
       <trans-unit id="tl_user.newsfeeds.0">
         <source>Allowed news feeds</source>


### PR DESCRIPTION
Otherwise one could expect that this relates to the permissions **within** an archive (so creating and deleting news) which is not what it does.