### PR TITLE
Drop support for an empty `tl_content.ptable` column

### DIFF
--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -217,16 +217,6 @@ $session = System::getContainer()->get('session');
 The `Widget::addSubmit()` method has been deprecated in Contao 4.0 and will be
 removed in Contao 5.0. It already does not add a submit button anymore.
 
-## Content elements
-
-For reasons of backwards compatibility, it is currently not required to set the
-`tl_content.ptable` column; it will treat an empty column like it had been set
-to `tl_article`.
-
-This behavior has been deprecated in Contao 4.0 and will no longer be supported
-in Contao 5.0. If you have developed an extension which creates content
-elements, make sure to always set the `ptable` column.
-
 ## Contao class loader
 
 Even though we are still using the Contao class loader, it has been deprecated

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,11 @@
 
 ## Version 4.* to 5.0
 
+## tl_content.ptable
+
+Contao no longer treats an empty `tl_content.ptable` column like it had been set to `tl_article`. Make
+sure to always set the `ptable` column.
+
 ### runonce.php
 
 The support for `runonce.php` files has been dropped. Use the migration framework instead.

--- a/core-bundle/src/Migration/Version500/EmptyPtableMigration.php
+++ b/core-bundle/src/Migration/Version500/EmptyPtableMigration.php
@@ -35,11 +35,7 @@ class EmptyPtableMigration extends AbstractMigration
 
         $test = $this->connection->fetchOne("SELECT TRUE FROM tl_content WHERE ptable='' LIMIT 1");
 
-        if (false !== $test) {
-            return true;
-        }
-
-        return false;
+        return false !== $test;
     }
 
     public function run(): MigrationResult

--- a/core-bundle/src/Migration/Version500/EmptyPtableMigration.php
+++ b/core-bundle/src/Migration/Version500/EmptyPtableMigration.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Migration\Version500;
+
+use Contao\CoreBundle\Migration\AbstractMigration;
+use Contao\CoreBundle\Migration\MigrationResult;
+use Doctrine\DBAL\Connection;
+
+/**
+ * @internal
+ */
+class EmptyPtableMigration extends AbstractMigration
+{
+    public function __construct(private Connection $connection)
+    {
+    }
+
+    public function shouldRun(): bool
+    {
+        $schemaManager = $this->connection->createSchemaManager();
+
+        if (!$schemaManager->tablesExist(['tl_content'])) {
+            return false;
+        }
+
+        $test = $this->connection->fetchOne("SELECT TRUE FROM tl_content WHERE ptable='' LIMIT 1");
+
+        if (false !== $test) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public function run(): MigrationResult
+    {
+        $this->connection->update('tl_content', ['ptable' => 'tl_article'], ['ptable' => '']);
+
+        return $this->createResult(true);
+    }
+}

--- a/core-bundle/src/Picker/AbstractTablePickerProvider.php
+++ b/core-bundle/src/Picker/AbstractTablePickerProvider.php
@@ -230,14 +230,8 @@ abstract class AbstractTablePickerProvider implements PickerProviderInterface, D
             $data = $qb->executeQuery()->fetchAssociative();
         }
 
-        if ($dynamicPtable) {
-            if (!empty($data['ptable'])) {
-                $ptable = $data['ptable'];
-            }
-
-            if (!$ptable) {
-                $ptable = 'tl_article'; // backwards compatibility
-            }
+        if ($dynamicPtable && !empty($data['ptable'])) {
+            $ptable = $data['ptable'];
         }
 
         if (false === $data) {

--- a/core-bundle/src/Resources/config/migrations.yml
+++ b/core-bundle/src/Resources/config/migrations.yml
@@ -111,3 +111,8 @@ services:
         class: Contao\CoreBundle\Migration\Version500\BasicEntitiesMigration
         arguments:
             - '@database_connection'
+
+    contao.migration.version_500.empty_ptable:
+        class: Contao\CoreBundle\Migration\Version500\EmptyPtableMigration
+        arguments:
+            - '@database_connection'

--- a/core-bundle/src/Resources/contao/dca/tl_content.php
+++ b/core-bundle/src/Resources/contao/dca/tl_content.php
@@ -955,7 +955,7 @@ class tl_content extends Backend
 					$this->checkAccessToElement(Input::get('pid'), $pagemounts, (Input::get('mode') == 2));
 				}
 
-				$objCes = $this->Database->prepare("SELECT id FROM tl_content WHERE (ptable='tl_article' OR ptable='') AND pid=?")
+				$objCes = $this->Database->prepare("SELECT id FROM tl_content WHERE ptable='tl_article' AND pid=?")
 										 ->execute(CURRENT_ID);
 
 				$objSession = System::getContainer()->get('session');
@@ -1106,7 +1106,7 @@ class tl_content extends Backend
 	{
 		if (Input::get('act') == 'delete')
 		{
-			$objCes = $this->Database->prepare("SELECT COUNT(*) AS cnt FROM tl_content WHERE type='alias' AND cteAlias=? AND (ptable='tl_article' OR ptable='')")
+			$objCes = $this->Database->prepare("SELECT COUNT(*) AS cnt FROM tl_content WHERE type='alias' AND cteAlias=? AND ptable='tl_article'")
 									 ->execute(Input::get('id'));
 
 			if ($objCes->cnt > 0)
@@ -1117,7 +1117,7 @@ class tl_content extends Backend
 
 		if (Input::get('act') == 'deleteAll')
 		{
-			$objCes = $this->Database->prepare("SELECT cteAlias FROM tl_content WHERE type='alias' AND (ptable='tl_article' OR ptable='')")
+			$objCes = $this->Database->prepare("SELECT cteAlias FROM tl_content WHERE type='alias' AND ptable='tl_article'")
 									 ->execute();
 
 			$objSession = System::getContainer()->get('session');

--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -980,9 +980,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 				// Consider the dynamic parent table (see #4867)
 				if ($GLOBALS['TL_DCA'][$v]['config']['dynamicPtable'] ?? null)
 				{
-					$cond = ($table === 'tl_article') ? "(ptable=? OR ptable='')" : "ptable=?";
-
-					$objCTable = $this->Database->prepare("SELECT * FROM $v WHERE pid=? AND $cond" . ($this->Database->fieldExists('sorting', $v) ? " ORDER BY sorting" : ""))
+					$objCTable = $this->Database->prepare("SELECT * FROM $v WHERE pid=? AND ptable=?" . ($this->Database->fieldExists('sorting', $v) ? " ORDER BY sorting" : ""))
 												->execute($id, $table);
 				}
 				else
@@ -1561,9 +1559,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 			// Consider the dynamic parent table (see #4867)
 			if ($GLOBALS['TL_DCA'][$v]['config']['dynamicPtable'] ?? null)
 			{
-				$cond = ($table === 'tl_article') ? "(ptable=? OR ptable='')" : "ptable=?";
-
-				$objDelete = $this->Database->prepare("SELECT id FROM $v WHERE pid=? AND $cond")
+				$objDelete = $this->Database->prepare("SELECT id FROM $v WHERE pid=? AND ptable=?")
 											->execute($id, $table);
 			}
 			else
@@ -4416,10 +4412,9 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 			$arrProcedure = $this->procedure;
 			$arrValues = $this->values;
 
-			// Support empty ptable fields
 			if ($GLOBALS['TL_DCA'][$this->strTable]['config']['dynamicPtable'] ?? null)
 			{
-				$arrProcedure[] = ($this->ptable == 'tl_article') ? "(ptable=? OR ptable='')" : "ptable=?";
+				$arrProcedure[] = 'ptable=?';
 				$arrValues[] = $this->ptable;
 			}
 
@@ -5428,10 +5423,9 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 				$arrProcedure[] = 'id IN(' . implode(',', $this->root) . ')';
 			}
 
-			// Support empty ptable fields
 			if ($GLOBALS['TL_DCA'][$this->strTable]['config']['dynamicPtable'] ?? null)
 			{
-				$arrProcedure[] = ($this->ptable == 'tl_article') ? "(ptable=? OR ptable='')" : "ptable=?";
+				$arrProcedure[] = 'ptable=?';
 				$arrValues[] = $this->ptable;
 			}
 
@@ -5680,10 +5674,9 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 				}
 			}
 
-			// Support empty ptable fields
 			if ($GLOBALS['TL_DCA'][$this->strTable]['config']['dynamicPtable'] ?? null)
 			{
-				$arrProcedure[] = ($this->ptable == 'tl_article') ? "(ptable=? OR ptable='')" : "ptable=?";
+				$arrProcedure[] = 'ptable=?';
 				$arrValues[] = $this->ptable;
 			}
 

--- a/core-bundle/src/Resources/contao/models/ContentModel.php
+++ b/core-bundle/src/Resources/contao/models/ContentModel.php
@@ -402,16 +402,7 @@ class ContentModel extends Model
 	public static function findPublishedByPidAndTable($intPid, $strParentTable, array $arrOptions=array())
 	{
 		$t = static::$strTable;
-
-		// Also handle empty ptable fields
-		if ($strParentTable == 'tl_article')
-		{
-			$arrColumns = array("$t.pid=? AND ($t.ptable=? OR $t.ptable='')");
-		}
-		else
-		{
-			$arrColumns = array("$t.pid=? AND $t.ptable=?");
-		}
+		$arrColumns = array("$t.pid=? AND $t.ptable=?");
 
 		if (!static::isPreviewMode($arrOptions))
 		{
@@ -442,16 +433,7 @@ class ContentModel extends Model
 	public static function countPublishedByPidAndTable($intPid, $strParentTable, array $arrOptions=array())
 	{
 		$t = static::$strTable;
-
-		// Also handle empty ptable fields (backwards compatibility)
-		if ($strParentTable == 'tl_article')
-		{
-			$arrColumns = array("$t.pid=? AND ($t.ptable=? OR $t.ptable='')");
-		}
-		else
-		{
-			$arrColumns = array("$t.pid=? AND $t.ptable=?");
-		}
+		$arrColumns = array("$t.pid=? AND $t.ptable=?");
 
 		if (!static::isPreviewMode($arrOptions))
 		{


### PR DESCRIPTION
@contao/developers What do you think about adding a migration that automatically changes empty columns to `tl_article`?

```sql
UPDATE tl_content SET ptable='tl_article' WHERE ptable='';
```

I‘m not sure if that would be too destructive. On the other hand, an empty column is treated as `tl_article` in Contao 4, so the value cannot really have a different meaning, can it?