### PR TITLE
Unset TL_CONFIG in ContaoTestCase::tearDown()

### DIFF
--- a/calendar-bundle/tests/EventListener/InsertTagsListenerTest.php
+++ b/calendar-bundle/tests/EventListener/InsertTagsListenerTest.php
@@ -20,13 +20,6 @@ use Contao\TestCase\ContaoTestCase;
 
 class InsertTagsListenerTest extends ContaoTestCase
 {
-    protected function tearDown(): void
-    {
-        unset($GLOBALS['TL_CONFIG']);
-
-        parent::tearDown();
-    }
-
     public function testReplacesTheCalendarFeedTag(): void
     {
         $feedModel = $this->mockClassWithProperties(CalendarFeedModel::class);

--- a/calendar-bundle/tests/EventListener/PreviewUrlConverterListenerTest.php
+++ b/calendar-bundle/tests/EventListener/PreviewUrlConverterListenerTest.php
@@ -22,13 +22,6 @@ use Symfony\Component\HttpFoundation\Request;
 
 class PreviewUrlConverterListenerTest extends ContaoTestCase
 {
-    protected function tearDown(): void
-    {
-        unset($GLOBALS['TL_CONFIG']);
-
-        parent::tearDown();
-    }
-
     public function testConvertsThePreviewUrl(): void
     {
         $request = new Request();

--- a/calendar-bundle/tests/EventListener/PreviewUrlCreateListenerTest.php
+++ b/calendar-bundle/tests/EventListener/PreviewUrlCreateListenerTest.php
@@ -22,13 +22,6 @@ use Symfony\Component\HttpFoundation\RequestStack;
 
 class PreviewUrlCreateListenerTest extends ContaoTestCase
 {
-    protected function tearDown(): void
-    {
-        unset($GLOBALS['TL_CONFIG']);
-
-        parent::tearDown();
-    }
-
     public function testCreatesThePreviewUrl(): void
     {
         $requestStack = new RequestStack();

--- a/calendar-bundle/tests/Picker/EventPickerProviderTest.php
+++ b/calendar-bundle/tests/Picker/EventPickerProviderTest.php
@@ -26,13 +26,6 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class EventPickerProviderTest extends ContaoTestCase
 {
-    protected function tearDown(): void
-    {
-        unset($GLOBALS['TL_CONFIG']);
-
-        parent::tearDown();
-    }
-
     public function testCreatesTheMenuItem(): void
     {
         $config = json_encode([

--- a/core-bundle/tests/TestCase.php
+++ b/core-bundle/tests/TestCase.php
@@ -31,13 +31,6 @@ abstract class TestCase extends ContaoTestCase
         }
     }
 
-    protected function tearDown(): void
-    {
-        unset($GLOBALS['TL_CONFIG']);
-
-        parent::tearDown();
-    }
-
     protected function getFixturesDir(): string
     {
         return __DIR__.\DIRECTORY_SEPARATOR.'Fixtures';

--- a/faq-bundle/tests/EventListener/InsertTagsListenerTest.php
+++ b/faq-bundle/tests/EventListener/InsertTagsListenerTest.php
@@ -20,13 +20,6 @@ use Contao\TestCase\ContaoTestCase;
 
 class InsertTagsListenerTest extends ContaoTestCase
 {
-    protected function tearDown(): void
-    {
-        unset($GLOBALS['TL_CONFIG']);
-
-        parent::tearDown();
-    }
-
     public function testReplacesTheFaqTags(): void
     {
         $page = $this->createMock(PageModel::class);

--- a/faq-bundle/tests/Picker/FaqPickerProviderTest.php
+++ b/faq-bundle/tests/Picker/FaqPickerProviderTest.php
@@ -26,13 +26,6 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class FaqPickerProviderTest extends ContaoTestCase
 {
-    protected function tearDown(): void
-    {
-        unset($GLOBALS['TL_CONFIG']);
-
-        parent::tearDown();
-    }
-
     public function testCreatesTheMenuItem(): void
     {
         $config = json_encode([

--- a/news-bundle/tests/EventListener/InsertTagsListenerTest.php
+++ b/news-bundle/tests/EventListener/InsertTagsListenerTest.php
@@ -20,13 +20,6 @@ use Contao\TestCase\ContaoTestCase;
 
 class InsertTagsListenerTest extends ContaoTestCase
 {
-    protected function tearDown(): void
-    {
-        unset($GLOBALS['TL_CONFIG']);
-
-        parent::tearDown();
-    }
-
     public function testReplacesTheNewsFeedTag(): void
     {
         $feedModel = $this->mockClassWithProperties(NewsFeedModel::class);

--- a/news-bundle/tests/EventListener/PreviewUrlConverterListenerTest.php
+++ b/news-bundle/tests/EventListener/PreviewUrlConverterListenerTest.php
@@ -22,13 +22,6 @@ use Symfony\Component\HttpFoundation\Request;
 
 class PreviewUrlConverterListenerTest extends ContaoTestCase
 {
-    protected function tearDown(): void
-    {
-        unset($GLOBALS['TL_CONFIG']);
-
-        parent::tearDown();
-    }
-
     public function testConvertsThePreviewUrl(): void
     {
         $request = new Request();

--- a/news-bundle/tests/EventListener/PreviewUrlCreateListenerTest.php
+++ b/news-bundle/tests/EventListener/PreviewUrlCreateListenerTest.php
@@ -22,13 +22,6 @@ use Symfony\Component\HttpFoundation\RequestStack;
 
 class PreviewUrlCreateListenerTest extends ContaoTestCase
 {
-    protected function tearDown(): void
-    {
-        unset($GLOBALS['TL_CONFIG']);
-
-        parent::tearDown();
-    }
-
     public function testCreatesThePreviewUrl(): void
     {
         $requestStack = new RequestStack();

--- a/news-bundle/tests/Picker/NewsPickerProviderTest.php
+++ b/news-bundle/tests/Picker/NewsPickerProviderTest.php
@@ -26,13 +26,6 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class NewsPickerProviderTest extends ContaoTestCase
 {
-    protected function tearDown(): void
-    {
-        unset($GLOBALS['TL_CONFIG']);
-
-        parent::tearDown();
-    }
-
     public function testCreatesTheMenuItem(): void
     {
         $config = json_encode([

--- a/test-case/src/ContaoTestCase.php
+++ b/test-case/src/ContaoTestCase.php
@@ -52,6 +52,14 @@ abstract class ContaoTestCase extends TestCase
         unset(self::$tempDirs[$key]);
     }
 
+    protected function tearDown(): void
+    {
+        // Unset TL_CONFIG, since we populate it in loadDefaultConfiguration
+        unset($GLOBALS['TL_CONFIG']);
+
+        parent::tearDown();
+    }
+
     /**
      * Returns the path to the temporary directory and creates it if it does not yet exist.
      */

--- a/test-case/src/ContaoTestCase.php
+++ b/test-case/src/ContaoTestCase.php
@@ -54,7 +54,7 @@ abstract class ContaoTestCase extends TestCase
 
     protected function tearDown(): void
     {
-        // Unset TL_CONFIG, since we populate it in loadDefaultConfiguration
+        // Unset TL_CONFIG, since we populate it in loadDefaultConfiguration (#4656)
         unset($GLOBALS['TL_CONFIG']);
 
         parent::tearDown();

--- a/test-case/src/ContaoTestCase.php
+++ b/test-case/src/ContaoTestCase.php
@@ -54,7 +54,7 @@ abstract class ContaoTestCase extends TestCase
 
     protected function tearDown(): void
     {
-        // Unset TL_CONFIG, since we populate it in loadDefaultConfiguration (#4656)
+        // Unset TL_CONFIG as we populate it in loadDefaultConfiguration (see #4656)
         unset($GLOBALS['TL_CONFIG']);
 
         parent::tearDown();


### PR DESCRIPTION
Currently the CI fails with many tests that extend from `ContaoTestCase` and use the `mockContaoFramework` method, due to the global state change watcher which detects that `$GLOBALS['TL_CONFIG']` was set.

This is because `mockContaoFramework` will automatically load the default `TL_CONFIG` configuration (and thus `$GLOBALS['TL_CONFIG']` gets populated).

This PR would fix that by unsetting the global in the `tearDown` in this base class.
