### PR TITLE
Allow adding document scoped content from within Twig templates

### DIFF
--- a/core-bundle/src/Twig/Extension/ContaoExtension.php
+++ b/core-bundle/src/Twig/Extension/ContaoExtension.php
@@ -21,6 +21,8 @@ use Contao\CoreBundle\Twig\Inheritance\TemplateHierarchyInterface;
 use Contao\CoreBundle\Twig\Interop\ContaoEscaper;
 use Contao\CoreBundle\Twig\Interop\ContaoEscaperNodeVisitor;
 use Contao\CoreBundle\Twig\Interop\PhpTemplateProxyNodeVisitor;
+use Contao\CoreBundle\Twig\ResponseContext\AddTokenParser;
+use Contao\CoreBundle\Twig\ResponseContext\DocumentLocation;
 use Contao\CoreBundle\Twig\Runtime\FigureRendererRuntime;
 use Contao\CoreBundle\Twig\Runtime\InsertTagRuntime;
 use Contao\CoreBundle\Twig\Runtime\LegacyTemplateFunctionsRuntime;
@@ -99,6 +101,8 @@ final class ContaoExtension extends AbstractExtension
             // additionally support the Contao template hierarchy
             new DynamicExtendsTokenParser($this->hierarchy),
             new DynamicIncludeTokenParser($this->hierarchy),
+            // Add a parser for the Contao specific "add" tag
+            new AddTokenParser(self::class),
         ];
     }
 
@@ -227,6 +231,34 @@ final class ContaoExtension extends AbstractExtension
         $partialTemplate->setBlocks($blocks);
 
         return $partialTemplate->parse();
+    }
+
+    /**
+     * @see \Contao\CoreBundle\Twig\ResponseContext\AddNode
+     * @see \Contao\CoreBundle\Twig\ResponseContext\AddTokenParser
+     *
+     * @internal
+     */
+    public function addDocumentContent(string|null $identifier, string $content, DocumentLocation $location): void
+    {
+        // TODO: This should make use of the response context in the future.
+        if (DocumentLocation::head === $location) {
+            if (null !== $identifier) {
+                $GLOBALS['TL_HEAD'][$identifier] = $content;
+            } else {
+                $GLOBALS['TL_HEAD'][] = $content;
+            }
+
+            return;
+        }
+
+        if (DocumentLocation::endOfBody === $location) {
+            if (null !== $identifier) {
+                $GLOBALS['TL_BODY'][$identifier] = $content;
+            } else {
+                $GLOBALS['TL_BODY'][] = $content;
+            }
+        }
     }
 
     private function getTwigIncludeFunction(): TwigFunction

--- a/core-bundle/src/Twig/ResponseContext/AddNode.php
+++ b/core-bundle/src/Twig/ResponseContext/AddNode.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Twig\ResponseContext;
+
+use Twig\Compiler;
+use Twig\Node\Node;
+use Twig\Node\NodeOutputInterface;
+
+/**
+ * @experimental
+ */
+final class AddNode extends Node implements NodeOutputInterface
+{
+    public function __construct(string $extensionName, Node $body, string|null $identifier, DocumentLocation $location, int $lineno)
+    {
+        parent::__construct(
+            [
+                'body' => $body,
+            ],
+            [
+                'extension_name' => $extensionName,
+                'identifier' => $identifier,
+                'location' => $location,
+            ],
+            $lineno
+        );
+    }
+
+    public function compile(Compiler $compiler): void
+    {
+        // if ($this->env->isDebug()) { ob_start(); } else { ob_start(static function () { return ''; }); }
+        // try {
+        //     <sub-compiled content>
+        //     $__contao_document_content = ob_get_contents();
+        // } finally { ob_end_clean(); }
+        // $this->extensions["Contao\\…\\ContaoExtension"]->addDocumentContent(
+        //     '<identifier>', $__contao_document_content, Contao\…\DocumentLocation::<location>
+        // );
+        $compiler
+            ->write('if ($this->env->isDebug()) { ob_start(); } else { ob_start(static function () { return \'\'; }); }'."\n")
+            ->write('try {'."\n")
+            ->indent()
+            ->subcompile($this->getNode('body'))
+            ->write('$__contao_document_content = ob_get_contents();'."\n")
+            ->outdent()
+            ->write('} finally { ob_end_clean(); }'."\n")
+            ->write('$this->extensions[')
+            ->repr($this->getAttribute('extension_name'))
+            ->raw(']->addDocumentContent('."\n")
+            ->indent()
+            ->write('')
+            ->repr($this->getAttribute('identifier'))
+            ->raw(', $__contao_document_content, ')
+            ->raw(sprintf('\\%s::%s', DocumentLocation::class, $this->getAttribute('location')->name)."\n")
+            ->outdent()
+            ->write(');'."\n")
+        ;
+    }
+}

--- a/core-bundle/src/Twig/ResponseContext/AddTokenParser.php
+++ b/core-bundle/src/Twig/ResponseContext/AddTokenParser.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Twig\ResponseContext;
+
+use Twig\Error\SyntaxError;
+use Twig\Node\Node;
+use Twig\Token;
+use Twig\TokenParser\AbstractTokenParser;
+
+class AddTokenParser extends AbstractTokenParser
+{
+    public function __construct(private readonly string $extensionName)
+    {
+    }
+
+    public function parse(Token $token): Node
+    {
+        $stream = $this->parser->getStream();
+
+        // Parse opening tag: {% add to body %} or {% add 'foo' to body %}
+        $identifier = null;
+
+        if ($stream->test(Token::STRING_TYPE)) {
+            $identifier = $stream->getCurrent()->getValue();
+            $stream->next();
+        }
+
+        $stream->expect(Token::NAME_TYPE, 'to');
+        $locationToken = $stream->expect(Token::NAME_TYPE, null, '');
+        $locationString = $locationToken->getValue();
+
+        if (null === ($location = DocumentLocation::tryFrom($locationString))) {
+            $validLocations = array_map(
+                static fn (DocumentLocation $location): string => $location->value,
+                DocumentLocation::cases()
+            );
+
+            throw new SyntaxError(sprintf('The parameter "%s" is not a valid location for the "add" tag, use "%s" instead.', $locationString, implode('" or "', $validLocations)));
+        }
+
+        $stream->expect(Token::BLOCK_END_TYPE);
+
+        // Parse closing tag: {% endadd %}
+        $body = $this->parser->subparse([$this, 'decideAddEnd'], true);
+        $stream->expect(Token::BLOCK_END_TYPE);
+
+        return new AddNode(
+            $this->extensionName,
+            $body,
+            $identifier,
+            $location,
+            $token->getLine()
+        );
+    }
+
+    public function decideAddEnd(Token $token): bool
+    {
+        return $token->test('endadd');
+    }
+
+    public function getTag(): string
+    {
+        return 'add';
+    }
+}

--- a/core-bundle/src/Twig/ResponseContext/AddTokenParser.php
+++ b/core-bundle/src/Twig/ResponseContext/AddTokenParser.php
@@ -54,13 +54,7 @@ class AddTokenParser extends AbstractTokenParser
         $body = $this->parser->subparse([$this, 'decideAddEnd'], true);
         $stream->expect(Token::BLOCK_END_TYPE);
 
-        return new AddNode(
-            $this->extensionName,
-            $body,
-            $identifier,
-            $location,
-            $token->getLine()
-        );
+        return new AddNode($this->extensionName, $body, $identifier, $location, $token->getLine());
     }
 
     public function decideAddEnd(Token $token): bool

--- a/core-bundle/src/Twig/ResponseContext/DocumentLocation.php
+++ b/core-bundle/src/Twig/ResponseContext/DocumentLocation.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Twig\ResponseContext;
+
+enum DocumentLocation: string
+{
+    case head = 'head';
+
+    case endOfBody = 'body';
+}

--- a/core-bundle/src/Twig/ResponseContext/DocumentLocation.php
+++ b/core-bundle/src/Twig/ResponseContext/DocumentLocation.php
@@ -15,6 +15,5 @@ namespace Contao\CoreBundle\Twig\ResponseContext;
 enum DocumentLocation: string
 {
     case head = 'head';
-
     case endOfBody = 'body';
 }

--- a/core-bundle/tests/Twig/Extension/ContaoExtensionTest.php
+++ b/core-bundle/tests/Twig/Extension/ContaoExtensionTest.php
@@ -23,6 +23,7 @@ use Contao\CoreBundle\Twig\Inheritance\DynamicIncludeTokenParser;
 use Contao\CoreBundle\Twig\Inheritance\TemplateHierarchyInterface;
 use Contao\CoreBundle\Twig\Interop\ContaoEscaperNodeVisitor;
 use Contao\CoreBundle\Twig\Interop\PhpTemplateProxyNodeVisitor;
+use Contao\CoreBundle\Twig\ResponseContext\AddTokenParser;
 use Contao\System;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Filesystem\Path;
@@ -65,10 +66,11 @@ class ContaoExtensionTest extends TestCase
     {
         $tokenParsers = $this->getContaoExtension()->getTokenParsers();
 
-        $this->assertCount(2, $tokenParsers);
+        $this->assertCount(3, $tokenParsers);
 
         $this->assertInstanceOf(DynamicExtendsTokenParser::class, $tokenParsers[0]);
         $this->assertInstanceOf(DynamicIncludeTokenParser::class, $tokenParsers[1]);
+        $this->assertInstanceOf(AddTokenParser::class, $tokenParsers[2]);
     }
 
     public function testAddsTheFunctions(): void

--- a/core-bundle/tests/Twig/ResponseContext/AddNodeTest.php
+++ b/core-bundle/tests/Twig/ResponseContext/AddNodeTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\Twig\ResponseContext;
+
+use Contao\CoreBundle\Tests\TestCase;
+use Contao\CoreBundle\Twig\Extension\ContaoExtension;
+use Contao\CoreBundle\Twig\ResponseContext\AddNode;
+use Contao\CoreBundle\Twig\ResponseContext\DocumentLocation;
+use Twig\Compiler;
+use Twig\Environment;
+use Twig\Node\Expression\ConstantExpression;
+use Twig\Node\PrintNode;
+
+class AddNodeTest extends TestCase
+{
+    public function testCompilesAddNode(): void
+    {
+        $addNode = new AddNode(
+            ContaoExtension::class,
+            new PrintNode(new ConstantExpression('foobar', 42), 42),
+            'identifier',
+            DocumentLocation::endOfBody,
+            1
+        );
+
+        $compiler = new Compiler($this->createMock(Environment::class));
+        $compiler->compile($addNode);
+
+        $expectedSource = <<<'SOURCE'
+            if ($this->env->isDebug()) { ob_start(); } else { ob_start(static function () { return ''; }); }
+            try {
+                // line 42
+                echo "foobar";
+                $__contao_document_content = ob_get_contents();
+            } finally { ob_end_clean(); }
+            $this->extensions["Contao\\CoreBundle\\Twig\\Extension\\ContaoExtension"]->addDocumentContent(
+                "identifier", $__contao_document_content, \Contao\CoreBundle\Twig\ResponseContext\DocumentLocation::endOfBody
+            );
+
+            SOURCE;
+
+        $this->assertSame($expectedSource, $compiler->getSource());
+    }
+}

--- a/core-bundle/tests/Twig/ResponseContext/AddTokenParserTest.php
+++ b/core-bundle/tests/Twig/ResponseContext/AddTokenParserTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\Twig\ResponseContext;
+
+use Contao\CoreBundle\Tests\TestCase;
+use Contao\CoreBundle\Twig\Extension\ContaoExtension;
+use Contao\CoreBundle\Twig\Inheritance\TemplateHierarchyInterface;
+use Contao\CoreBundle\Twig\ResponseContext\AddTokenParser;
+use Twig\Environment;
+use Twig\Error\SyntaxError;
+use Twig\Lexer;
+use Twig\Loader\ArrayLoader;
+use Twig\Loader\LoaderInterface;
+use Twig\Parser;
+use Twig\Source;
+
+class AddTokenParserTest extends TestCase
+{
+    public function testGetTag(): void
+    {
+        $tokenParser = new AddTokenParser(ContaoExtension::class);
+
+        $this->assertSame('add', $tokenParser->getTag());
+    }
+
+    /**
+     * @dataProvider provideSources
+     *
+     * @param list<string>|array<string, string> $expectedHeadContent
+     * @param list<string>|array<string, string> $expectedBodyContent
+     */
+    public function testAddsContent(string $code, array $expectedHeadContent, array $expectedBodyContent): void
+    {
+        $environment = new Environment($this->createMock(LoaderInterface::class));
+
+        $environment->addExtension(new ContaoExtension($environment, $this->createMock(TemplateHierarchyInterface::class)));
+        $environment->addTokenParser(new AddTokenParser(ContaoExtension::class));
+        $environment->setLoader(new ArrayLoader(['template.html.twig' => $code]));
+
+        $environment->render('template.html.twig');
+
+        $this->assertSame($GLOBALS['TL_HEAD'] ?? [], $expectedHeadContent);
+        $this->assertSame($GLOBALS['TL_BODY'] ?? [], $expectedBodyContent);
+
+        unset($GLOBALS['TL_HEAD'], $GLOBALS['TL_BODY']);
+    }
+
+    public function provideSources(): \Generator
+    {
+        yield 'add to head' => [
+            '{% add to head %}head content{% endadd %}',
+            ['head content'],
+            [],
+        ];
+
+        yield 'add to body' => [
+            '{% add to body %}body content{% endadd %}',
+            [],
+            ['body content'],
+        ];
+
+        yield 'add multiple' => [
+            "{% add to head %}head content{% endadd %}\n".
+            "{% add to body %}body content{% endadd %}\n".
+            "{% add to head %}head content{% endadd %}\n".
+            '{% add to body %}body content{% endadd %}',
+            ['head content', 'head content'],
+            ['body content', 'body content'],
+        ];
+
+        yield 'add named to head' => [
+            "{% add 'foo' to head %}head content{% endadd %}\n".
+            "{% add 'foo' to head %}overwritten head content{% endadd %}",
+            ['foo' => 'overwritten head content'],
+            [],
+        ];
+
+        yield 'add named to body' => [
+            "{% add 'foo' to body %}body content{% endadd %}\n".
+            "{% add 'foo' to body %}overwritten body content{% endadd %}",
+            [],
+            ['foo' => 'overwritten body content'],
+        ];
+
+        yield 'add multiple named' => [
+            "{% add 'foo' to head %}head content{% endadd %}\n".
+            "{% add 'foo' to body %}body content{% endadd %}\n".
+            "{% add 'foo' to head %}head content{% endadd %}\n".
+            "{% add 'foo' to body %}body content{% endadd %}",
+            ['foo' => 'head content'],
+            ['foo' => 'body content'],
+        ];
+
+        yield 'add with complex content' => [
+            "{% set var = 'bar' %}\n".
+            '{% add to body %}foo {{ var }}{% endadd %}',
+            [],
+            ['foo bar'],
+        ];
+    }
+
+    /**
+     * @dataProvider provideInvalidSources
+     */
+    public function testValidatesSource(string $code, string $expectedException): void
+    {
+        $environment = new Environment($this->createMock(LoaderInterface::class));
+
+        $environment->addTokenParser(new AddTokenParser(ContaoExtension::class));
+
+        $parser = new Parser($environment);
+        $source = new Source($code, 'template.html.twig');
+        $tokenStream = (new Lexer($environment))->tokenize($source);
+
+        $this->expectException(SyntaxError::class);
+        $this->expectExceptionMessage($expectedException);
+
+        $parser->parse($tokenStream);
+    }
+
+    public function provideInvalidSources(): \Generator
+    {
+        yield 'invalid target' => [
+            '{% add to stomach %}apple{% endadd %}',
+            'The parameter "stomach" is not a valid location for the "add" tag, use "head" or "body" instead in "template.html.twig"',
+        ];
+
+        yield 'malformed target' => [
+            '{% add to "head" %}foo{% endadd %}',
+            'Unexpected token "string" of value "head" ("name" expected) in "template.html.twig"',
+        ];
+
+        yield 'missing target' => [
+            '{% add %}foo{% endadd %}',
+            'Unexpected token "end of statement block" ("name" expected with value "to") in "template.html.twig"',
+        ];
+
+        yield 'parameter at wrong place' => [
+            '{% add to body "foo" %}bar{% endadd %}',
+            'Unexpected token "string" of value "foo" ("end of statement block" expected) in "template.html.twig"',
+        ];
+    }
+}

--- a/core-bundle/tests/Twig/ResponseContext/AddTokenParserTest.php
+++ b/core-bundle/tests/Twig/ResponseContext/AddTokenParserTest.php
@@ -42,11 +42,9 @@ class AddTokenParserTest extends TestCase
     public function testAddsContent(string $code, array $expectedHeadContent, array $expectedBodyContent): void
     {
         $environment = new Environment($this->createMock(LoaderInterface::class));
-
         $environment->addExtension(new ContaoExtension($environment, $this->createMock(TemplateHierarchyInterface::class)));
         $environment->addTokenParser(new AddTokenParser(ContaoExtension::class));
         $environment->setLoader(new ArrayLoader(['template.html.twig' => $code]));
-
         $environment->render('template.html.twig');
 
         $this->assertSame($GLOBALS['TL_HEAD'] ?? [], $expectedHeadContent);
@@ -115,7 +113,6 @@ class AddTokenParserTest extends TestCase
     public function testValidatesSource(string $code, string $expectedException): void
     {
         $environment = new Environment($this->createMock(LoaderInterface::class));
-
         $environment->addTokenParser(new AddTokenParser(ContaoExtension::class));
 
         $parser = new Parser($environment);

--- a/tools/ecs/config/default.php
+++ b/tools/ecs/config/default.php
@@ -19,8 +19,10 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         '*/Fixtures/system/*',
         '*/Resources/contao/*',
         'maker-bundle/src/Resources/skeleton/*',
+        // TODO: remove these once we can define rules for enums
         BlankLineBeforeStatementFixer::class => [
             'core-bundle/src/Filesystem/SortMode.php',
+            'core-bundle/src/Twig/ResponseContext/DocumentLocation.php',
         ],
         MethodChainingIndentationFixer::class => [
             '*/DependencyInjection/Configuration.php',


### PR DESCRIPTION
This PR introduces a new Twig tag `{% add %}`, that works like this:

```twig
{% add to body %}
  <div>I will appear at the end of the body</div>
{% endadd %}

{% add to head %}
  {# Add an additional head tag #}
  <link rel="stylesheet" href="my-fancy-style.css">
{% endadd %}
```

Currently the content inside the tag will be rendered and simply put into `$GLOBALS['TL_HEAD']` and `$GLOBALS['TL_BODY']` but the idea is to use the response context in the future as soon it supports these things. :slightly_smiling_face:.

Optionally, you can define an identifier to make sure the content gets output only once when used multiple times - this will basically use a key in the above global arrays:

```twig
{% for i in range(0, 10) %}
  {% add 'foo' to body %}
    <script type="application/javascript">
      console.log('I will only be executed once!');
    </script>
  {% endadd %}
{% endfor %}
```

This feature for instance allows to easily add small inline scripts that are then output only once - e.g. for displaying a splash screen, scrolling the viewport, and so on. In #4444 I already stumbled about multiple of these scenarios.