### PR TITLE
Add a Twig runtime for code highlighting

### DIFF
--- a/core-bundle/src/Resources/config/services.yml
+++ b/core-bundle/src/Resources/config/services.yml
@@ -970,6 +970,9 @@ services:
             - { name: kernel.cache_warmer }
             - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest }
 
+    contao.twig.highlighter_runtime:
+        class: Contao\CoreBundle\Twig\Runtime\HighlighterRuntime
+
     contao.twig.insert_tag_runtime:
         class: Contao\CoreBundle\Twig\Runtime\InsertTagRuntime
         arguments:

--- a/core-bundle/src/Twig/Extension/ContaoExtension.php
+++ b/core-bundle/src/Twig/Extension/ContaoExtension.php
@@ -22,6 +22,8 @@ use Contao\CoreBundle\Twig\Interop\ContaoEscaper;
 use Contao\CoreBundle\Twig\Interop\ContaoEscaperNodeVisitor;
 use Contao\CoreBundle\Twig\Interop\PhpTemplateProxyNodeVisitor;
 use Contao\CoreBundle\Twig\Runtime\FigureRendererRuntime;
+use Contao\CoreBundle\Twig\Runtime\HighlighterRuntime;
+use Contao\CoreBundle\Twig\Runtime\HighlightResult;
 use Contao\CoreBundle\Twig\Runtime\InsertTagRuntime;
 use Contao\CoreBundle\Twig\Runtime\LegacyTemplateFunctionsRuntime;
 use Contao\CoreBundle\Twig\Runtime\PictureConfigurationRuntime;
@@ -58,8 +60,9 @@ final class ContaoExtension extends AbstractExtension
         $this->addContaoEscaperRule('%^@Contao(_[a-zA-Z0-9_-]*)?/%');
         $this->addContaoEscaperRule('%^@Contao(Core|Installation)/%');
 
-        // Mark HtmlAttributes class as safe for HTML as it escapes its output itself
+        // Mark classes as safe for HTML that already escape their output themselves
         $escaperExtension->addSafeClass(HtmlAttributes::class, ['html', 'contao_html']);
+        $escaperExtension->addSafeClass(HighlightResult::class, ['html', 'contao_html']);
     }
 
     /**
@@ -189,6 +192,14 @@ final class ContaoExtension extends AbstractExtension
             new TwigFilter(
                 'insert_tag_raw',
                 [InsertTagRuntime::class, 'replaceInsertTagsChunkedRaw']
+            ),
+            new TwigFilter(
+                'highlight',
+                [HighlighterRuntime::class, 'highlight'],
+            ),
+            new TwigFilter(
+                'highlight_auto',
+                [HighlighterRuntime::class, 'highlightAuto'],
             ),
         ];
     }

--- a/core-bundle/src/Twig/Runtime/HighlightResult.php
+++ b/core-bundle/src/Twig/Runtime/HighlightResult.php
@@ -15,7 +15,7 @@ class HighlightResult extends BaseHighlightResult implements \Stringable
     /**
      * @internal
      */
-    public function __construct(self|\stdClass $result)
+    public function __construct(BaseHighlightResult|\stdClass $result)
     {
         foreach (get_object_vars($result) as $key => $value) {
             $this->$key = $value;

--- a/core-bundle/src/Twig/Runtime/HighlightResult.php
+++ b/core-bundle/src/Twig/Runtime/HighlightResult.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Contao\CoreBundle\Twig\Runtime;
+
+use Highlight\HighlightResult as BaseHighlightResult;
+
+/**
+ * This class is a thin wrapper around @see \Highlight\HighlightResult that
+ * provides an additional __toString() function.
+ */
+class HighlightResult extends BaseHighlightResult implements \Stringable
+{
+    /**
+     * @internal
+     */
+    public function __construct(self|\stdClass $result)
+    {
+        foreach (get_object_vars($result) as $key => $value) {
+            $this->$key = $value;
+        }
+    }
+
+    public function __toString(): string
+    {
+        return $this->value;
+    }
+}

--- a/core-bundle/src/Twig/Runtime/HighlighterRuntime.php
+++ b/core-bundle/src/Twig/Runtime/HighlighterRuntime.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Twig\Runtime;
+
+use Highlight\Highlighter;
+use Twig\Extension\RuntimeExtensionInterface;
+
+final class HighlighterRuntime implements RuntimeExtensionInterface
+{
+    private Highlighter $highlighter;
+
+    /**
+     * @internal
+     */
+    public function __construct(Highlighter|null $highlighter = null)
+    {
+        $this->highlighter = $highlighter ?? new Highlighter();
+    }
+
+    /**
+     * Highlights code.
+     */
+    public function highlight(string $code, string|null $languageName = null): HighlightResult
+    {
+        $languageName = match ($languageName) {
+            'C#' => 'csharp',
+            'C++' => 'cpp',
+            '', null => 'plaintext',
+            default => strtolower($languageName),
+        };
+
+        return new HighlightResult($this->highlighter->highlight($languageName, $code));
+    }
+
+    /**
+     * @param array<string>|null $languageSubset
+     */
+    public function highlightAuto(string $code, array|null $languageSubset = null): HighlightResult
+    {
+        return new HighlightResult($this->highlighter->highlightAuto($code, $languageSubset));
+    }
+}

--- a/core-bundle/src/Twig/Runtime/HighlighterRuntime.php
+++ b/core-bundle/src/Twig/Runtime/HighlighterRuntime.php
@@ -27,9 +27,6 @@ final class HighlighterRuntime implements RuntimeExtensionInterface
         $this->highlighter = $highlighter ?? new Highlighter();
     }
 
-    /**
-     * Highlights code.
-     */
     public function highlight(string $code, string|null $languageName = null): HighlightResult
     {
         $languageName = match ($languageName) {

--- a/core-bundle/tests/Twig/Extension/ContaoExtensionTest.php
+++ b/core-bundle/tests/Twig/Extension/ContaoExtensionTest.php
@@ -103,13 +103,15 @@ class ContaoExtensionTest extends TestCase
     {
         $filters = $this->getContaoExtension()->getFilters();
 
-        $this->assertCount(4, $filters);
+        $this->assertCount(6, $filters);
 
         $expectedFilters = [
             'escape',
             'e',
             'insert_tag',
             'insert_tag_raw',
+            'highlight',
+            'highlight_auto',
         ];
 
         foreach ($filters as $filter) {

--- a/core-bundle/tests/Twig/Runtime/HighlighterRuntimeTest.php
+++ b/core-bundle/tests/Twig/Runtime/HighlighterRuntimeTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Contao\CoreBundle\Tests\Twig\Runtime;
+
+use Contao\CoreBundle\Tests\TestCase;
+use Contao\CoreBundle\Twig\Runtime\HighlighterRuntime;
+use Highlight\Highlighter;
+
+class HighlighterRuntimeTest extends TestCase
+{
+    /**
+     * @dataProvider provideLanguageNames
+     */
+    public function testHighlight(string|null $languageName, string $expectedLanguageName): void
+    {
+        $result = new \stdClass();
+        $result->relevance = 50;
+        $result->value = 'the <highlighted> code';
+
+        $highlighter = $this->createMock(Highlighter::class);
+        $highlighter
+            ->expects($this->once())
+            ->method('highlight')
+            ->with($expectedLanguageName, 'code')
+            ->willReturn($result)
+        ;
+
+        $runtime = new HighlighterRuntime($highlighter);
+
+        $result = $runtime->highlight('code', $languageName);
+
+        $this->assertSame(50, $result->relevance);
+        $this->assertSame('the <highlighted> code', $result->value);
+        $this->assertSame('the <highlighted> code', (string) $result);
+    }
+
+    public function provideLanguageNames(): \Generator
+    {
+        yield 'unchanged default' => ['php', 'php'];
+
+        yield 'uppercase input' => ['XML', 'xml'];
+
+        yield 'no language specified (null)' => [null, 'plaintext'];
+
+        yield 'no language specified (empty string)' => ['', 'plaintext'];
+
+        yield 'C#' => ['C#', 'csharp'];
+
+        yield 'C++' => ['C++', 'cpp'];
+    }
+
+    public function testHighlightAuto(): void
+    {
+        $result = new \stdClass();
+        $result->relevance = 50;
+        $result->value = 'the <highlighted> code';
+
+        $highlighter = $this->createMock(Highlighter::class);
+        $highlighter
+            ->expects($this->once())
+            ->method('highlightAuto')
+            ->with('code', ['lang1', 'lang2', 'lang3'])
+            ->willReturn($result)
+        ;
+
+        $runtime = new HighlighterRuntime($highlighter);
+
+        $result = $runtime->highlightAuto('code', ['lang1', 'lang2', 'lang3']);
+
+        $this->assertSame(50, $result->relevance);
+        $this->assertSame('the <highlighted> code', $result->value);
+        $this->assertSame('the <highlighted> code', (string) $result);
+    }
+}

--- a/core-bundle/tests/Twig/Runtime/HighlighterRuntimeTest.php
+++ b/core-bundle/tests/Twig/Runtime/HighlighterRuntimeTest.php
@@ -28,7 +28,6 @@ class HighlighterRuntimeTest extends TestCase
         ;
 
         $runtime = new HighlighterRuntime($highlighter);
-
         $result = $runtime->highlight('code', $languageName);
 
         $this->assertSame(50, $result->relevance);
@@ -66,7 +65,6 @@ class HighlighterRuntimeTest extends TestCase
         ;
 
         $runtime = new HighlighterRuntime($highlighter);
-
         $result = $runtime->highlightAuto('code', ['lang1', 'lang2', 'lang3']);
 
         $this->assertSame(50, $result->relevance);

--- a/core-bundle/tests/Twig/TwigIntegrationTest.php
+++ b/core-bundle/tests/Twig/TwigIntegrationTest.php
@@ -17,6 +17,7 @@ use Contao\CoreBundle\Tests\TestCase;
 use Contao\CoreBundle\Twig\Extension\ContaoExtension;
 use Contao\CoreBundle\Twig\Inheritance\TemplateHierarchyInterface;
 use Contao\CoreBundle\Twig\Interop\ContextFactory;
+use Contao\CoreBundle\Twig\Runtime\HighlighterRuntime;
 use Contao\FormText;
 use Contao\System;
 use Contao\TemplateLoader;
@@ -24,6 +25,7 @@ use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Filesystem\Path;
 use Twig\Environment;
 use Twig\Loader\ArrayLoader;
+use Twig\RuntimeLoader\FactoryRuntimeLoader;
 
 class TwigIntegrationTest extends TestCase
 {
@@ -112,6 +114,47 @@ class TwigIntegrationTest extends TestCase
                 'style' => '',
                 'headline' => 'Test headline',
                 'text' => 'Some text',
+            ]
+        );
+
+        $this->assertSame($expectedOutput, $output);
+    }
+
+    public function testHighlightsCode(): void
+    {
+        $templateContent = <<<'TEMPLATE'
+            <h2>js</h2>
+            <pre>
+                {{ code|highlight('js') }}
+            </pre>
+
+            {% set highlighted = code|highlight_auto(['php', 'c++']) %}
+            <h2>{{ highlighted.language }}</h2>
+            <pre>
+                {{ highlighted }}
+            </pre>
+            TEMPLATE;
+
+        $expectedOutput = <<<'TEMPLATE'
+            <h2>js</h2>
+            <pre>
+                <span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">foo</span>(<span class="hljs-params"></span>) </span>{ <span class="hljs-keyword">return</span> <span class="hljs-string">"&lt;b&gt;ar"</span>; };
+            </pre>
+
+            <h2>php</h2>
+            <pre>
+                <span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">foo</span><span class="hljs-params">()</span> </span>{ <span class="hljs-keyword">return</span> <span class="hljs-string">"&lt;b&gt;ar"</span>; };
+            </pre>
+            TEMPLATE;
+
+        $environment = new Environment(new ArrayLoader(['test.html.twig' => $templateContent]));
+        $environment->addExtension(new ContaoExtension($environment, $this->createMock(TemplateHierarchyInterface::class)));
+        $environment->addRuntimeLoader(new FactoryRuntimeLoader([HighlighterRuntime::class => static fn () => new HighlighterRuntime()]));
+
+        $output = $environment->render(
+            'test.html.twig',
+            [
+                'code' => 'function foo() { return "<b>ar"; };',
             ]
         );
 

--- a/core-bundle/tests/Twig/TwigIntegrationTest.php
+++ b/core-bundle/tests/Twig/TwigIntegrationTest.php
@@ -21,6 +21,7 @@ use Contao\CoreBundle\Twig\Runtime\HighlighterRuntime;
 use Contao\FormText;
 use Contao\System;
 use Contao\TemplateLoader;
+use Highlight\Highlighter;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Filesystem\Path;
 use Twig\Environment;
@@ -159,5 +160,7 @@ class TwigIntegrationTest extends TestCase
         );
 
         $this->assertSame($expectedOutput, $output);
+
+        $this->resetStaticProperties([Highlighter::class]);
     }
 }


### PR DESCRIPTION
This is another thing extracted from #4444 - two new Twig functions `highlight` and `highlight_auto` that apply code highlighting with the `scrivo/highlight.php` component we're already using:

```twig
<pre>{{ code|highlight('php') }}</pre>

<pre>{{ code|highlight_auto }}</pre>
<pre>{{ code|highlight_auto(['C', 'C#', 'C++']) }}</pre>
```

The return value of the filters is a stringable, HTML-safe object. This allows a simple usage like a above, but also to output additional information about the highlighted result:

```twig
{% set highlighted = code|highlight_auto %}

language: {{ highlighted.language }} 
relevance: {{ highlighted.relevance }} 
[…]
```