### PR TITLE
Deprecate the move operation

### DIFF
--- a/core-bundle/src/Resources/contao/classes/DataContainer.php
+++ b/core-bundle/src/Resources/contao/classes/DataContainer.php
@@ -993,6 +993,8 @@ abstract class DataContainer extends Backend
 				continue;
 			}
 
+			trigger_deprecation('contao/core-bundle', '4.13', 'The DCA "move" operation is deprecated and will be removed in Contao 5.');
+
 			$arrDirections = array('up', 'down');
 			$arrRootIds = \is_array($arrRootIds) ? $arrRootIds : array($arrRootIds);
 


### PR DESCRIPTION
I didn't even know this one existed 😂 
It generates non-JS up/down buttons and was probably the predecessor to our drag handle in parent view mode. Since I'm going to update the operations support following https://github.com/contao/contao/pull/4648 imho we don't need to support this anymore.