### PR TITLE
Add conditional setting/unsetting to the HtmlAttributes class

### DIFF
--- a/core-bundle/src/String/HtmlAttributes.php
+++ b/core-bundle/src/String/HtmlAttributes.php
@@ -90,7 +90,7 @@ class HtmlAttributes implements \Stringable, \JsonSerializable, \IteratorAggrega
      */
     public function set(string $name, \Stringable|bool|int|string|null $value = true, \Stringable|bool|int|string|null $condition = true): self
     {
-        if (!$condition) {
+        if (!$condition || ($condition instanceof \Stringable && !(string) $condition)) {
             return $this;
         }
 

--- a/core-bundle/src/String/HtmlAttributes.php
+++ b/core-bundle/src/String/HtmlAttributes.php
@@ -111,6 +111,21 @@ class HtmlAttributes implements \Stringable, \JsonSerializable, \IteratorAggrega
         return $this;
     }
 
+    /**
+     * Enable the property $name if the $condition is truthy.
+     */
+    public function setIf(string $name, \Stringable|bool|int|string|null $condition): self
+    {
+        if ($condition) {
+            $this->set($name);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Set the property $name to $value if the value is truthy.
+     */
     public function setIfExists(string $name, \Stringable|bool|int|string|null $value): self
     {
         if (!empty($value)) {
@@ -120,9 +135,24 @@ class HtmlAttributes implements \Stringable, \JsonSerializable, \IteratorAggrega
         return $this;
     }
 
-    public function unset(string $key): self
+    /**
+     * Unset the property $name.
+     */
+    public function unset(string $name): self
     {
-        unset($this->attributes[$key]);
+        unset($this->attributes[$name]);
+
+        return $this;
+    }
+
+    /**
+     * Disable the property $name if the $condition is truthy.
+     */
+    public function unsetIf(string $name, \Stringable|bool|int|string|null $condition): self
+    {
+        if ($condition) {
+            $this->unset($name);
+        }
 
         return $this;
     }

--- a/core-bundle/src/String/HtmlAttributes.php
+++ b/core-bundle/src/String/HtmlAttributes.php
@@ -136,7 +136,7 @@ class HtmlAttributes implements \Stringable, \JsonSerializable, \IteratorAggrega
      */
     public function unset(string $name, \Stringable|bool|int|string|null $condition = true): self
     {
-        if (!$condition) {
+        if (!$condition || ($condition instanceof \Stringable && !(string) $condition)) {
             return $this;
         }
 

--- a/core-bundle/src/String/HtmlAttributes.php
+++ b/core-bundle/src/String/HtmlAttributes.php
@@ -85,9 +85,15 @@ class HtmlAttributes implements \Stringable, \JsonSerializable, \IteratorAggrega
      * Sets a property and validates the name. If the given $value is false the
      * property will be unset instead. All values will be coerced to strings,
      * whereby null and true will result in an empty string.
+     *
+     * If a falsy $condition is specified, the method is a no-op.
      */
-    public function set(string $name, \Stringable|bool|int|string|null $value = true): self
+    public function set(string $name, \Stringable|bool|int|string|null $value = true, \Stringable|bool|int|string|null $condition = true): self
     {
+        if (!$condition) {
+            return $this;
+        }
+
         $name = strtolower($name);
 
         if (1 !== preg_match('/^[a-z](?:[_-]?[a-z0-9])*$/', $name)) {
@@ -112,18 +118,6 @@ class HtmlAttributes implements \Stringable, \JsonSerializable, \IteratorAggrega
     }
 
     /**
-     * Enable the property $name if the $condition is truthy.
-     */
-    public function setIf(string $name, \Stringable|bool|int|string|null $condition): self
-    {
-        if ($condition) {
-            $this->set($name);
-        }
-
-        return $this;
-    }
-
-    /**
      * Set the property $name to $value if the value is truthy.
      */
     public function setIfExists(string $name, \Stringable|bool|int|string|null $value): self
@@ -137,22 +131,16 @@ class HtmlAttributes implements \Stringable, \JsonSerializable, \IteratorAggrega
 
     /**
      * Unset the property $name.
+     *
+     * If a falsy $condition is specified, the method is a no-op.
      */
-    public function unset(string $name): self
+    public function unset(string $name, \Stringable|bool|int|string|null $condition = true): self
     {
-        unset($this->attributes[$name]);
-
-        return $this;
-    }
-
-    /**
-     * Disable the property $name if the $condition is truthy.
-     */
-    public function unsetIf(string $name, \Stringable|bool|int|string|null $condition): self
-    {
-        if ($condition) {
-            $this->unset($name);
+        if (!$condition) {
+            return $this;
         }
+
+        unset($this->attributes[$name]);
 
         return $this;
     }

--- a/core-bundle/tests/String/HtmlAttributesTest.php
+++ b/core-bundle/tests/String/HtmlAttributesTest.php
@@ -255,6 +255,7 @@ class HtmlAttributesTest extends TestCase
         $attributes->set('data-feature1', condition: null);
         $attributes->set('data-feature2', condition: false);
         $attributes->set('data-feature3', condition: 0);
+
         $attributes->set(
             'data-feature5',
             condition: new class() implements \Stringable {

--- a/core-bundle/tests/String/HtmlAttributesTest.php
+++ b/core-bundle/tests/String/HtmlAttributesTest.php
@@ -257,9 +257,8 @@ class HtmlAttributesTest extends TestCase
         $attributes->set('data-feature3', condition: 0);
         $attributes->set(
             'data-feature5',
-            condition: new class implements \Stringable 
-            { 
-                public function __toString(): string 
+            condition: new class() implements \Stringable {
+                public function __toString(): string
                 {
                     return '';
                 }

--- a/core-bundle/tests/String/HtmlAttributesTest.php
+++ b/core-bundle/tests/String/HtmlAttributesTest.php
@@ -252,31 +252,31 @@ class HtmlAttributesTest extends TestCase
     {
         $attributes = new HtmlAttributes();
 
-        $attributes->setIf('data-feature1', null);
-        $attributes->setIf('data-feature2', false);
-        $attributes->setIf('data-feature3', 0);
-        $attributes->setIf('data-feature4', '');
+        $attributes->set('data-feature1', condition: null);
+        $attributes->set('data-feature2', condition: false);
+        $attributes->set('data-feature3', condition: 0);
+        $attributes->set('data-feature4', condition: '');
 
         $this->assertSame([], iterator_to_array($attributes));
 
-        $attributes->setIf('data-feature1', true);
-        $attributes->setIf('data-feature2', 1);
-        $attributes->setIf('data-feature3', 'true');
-        $attributes->setIf('data-feature4', '1');
+        $attributes->set('data-feature1', condition: true);
+        $attributes->set('data-feature2', condition: 1);
+        $attributes->set('data-feature3', condition: 'true');
+        $attributes->set('data-feature4', condition: '1');
 
         $this->assertSame(['data-feature1' => '', 'data-feature2' => '', 'data-feature3' => '', 'data-feature4' => ''], iterator_to_array($attributes));
 
-        $attributes->unsetIf('data-feature1', null);
-        $attributes->unsetIf('data-feature2', false);
-        $attributes->unsetIf('data-feature3', 0);
-        $attributes->unsetIf('data-feature4', '');
+        $attributes->unset('data-feature1', null);
+        $attributes->unset('data-feature2', false);
+        $attributes->unset('data-feature3', 0);
+        $attributes->unset('data-feature4', '');
 
         $this->assertSame(['data-feature1' => '', 'data-feature2' => '', 'data-feature3' => '', 'data-feature4' => ''], iterator_to_array($attributes));
 
-        $attributes->unsetIf('data-feature1', true);
-        $attributes->unsetIf('data-feature2', 1);
-        $attributes->unsetIf('data-feature3', 'true');
-        $attributes->unsetIf('data-feature4', '1');
+        $attributes->unset('data-feature1', true);
+        $attributes->unset('data-feature2', 1);
+        $attributes->unset('data-feature3', 'true');
+        $attributes->unset('data-feature4', '1');
 
         $this->assertSame([], iterator_to_array($attributes));
     }

--- a/core-bundle/tests/String/HtmlAttributesTest.php
+++ b/core-bundle/tests/String/HtmlAttributesTest.php
@@ -248,6 +248,39 @@ class HtmlAttributesTest extends TestCase
         $this->assertSame(['e' => ' ', 'f' => 'abc'], iterator_to_array($attributes));
     }
 
+    public function testSetAndUnsetConditionalProperties(): void
+    {
+        $attributes = new HtmlAttributes();
+
+        $attributes->setIf('data-feature1', null);
+        $attributes->setIf('data-feature2', false);
+        $attributes->setIf('data-feature3', 0);
+        $attributes->setIf('data-feature4', '');
+
+        $this->assertSame([], iterator_to_array($attributes));
+
+        $attributes->setIf('data-feature1', true);
+        $attributes->setIf('data-feature2', 1);
+        $attributes->setIf('data-feature3', 'true');
+        $attributes->setIf('data-feature4', '1');
+
+        $this->assertSame(['data-feature1' => '', 'data-feature2' => '', 'data-feature3' => '', 'data-feature4' => ''], iterator_to_array($attributes));
+
+        $attributes->unsetIf('data-feature1', null);
+        $attributes->unsetIf('data-feature2', false);
+        $attributes->unsetIf('data-feature3', 0);
+        $attributes->unsetIf('data-feature4', '');
+
+        $this->assertSame(['data-feature1' => '', 'data-feature2' => '', 'data-feature3' => '', 'data-feature4' => ''], iterator_to_array($attributes));
+
+        $attributes->unsetIf('data-feature1', true);
+        $attributes->unsetIf('data-feature2', 1);
+        $attributes->unsetIf('data-feature3', 'true');
+        $attributes->unsetIf('data-feature4', '1');
+
+        $this->assertSame([], iterator_to_array($attributes));
+    }
+
     public function testAddAndRemoveClasses(): void
     {
         // Whitespaces should get normalized by default

--- a/core-bundle/tests/String/HtmlAttributesTest.php
+++ b/core-bundle/tests/String/HtmlAttributesTest.php
@@ -255,7 +255,16 @@ class HtmlAttributesTest extends TestCase
         $attributes->set('data-feature1', condition: null);
         $attributes->set('data-feature2', condition: false);
         $attributes->set('data-feature3', condition: 0);
-        $attributes->set('data-feature4', condition: '');
+        $attributes->set(
+            'data-feature5',
+            condition: new class implements \Stringable 
+            { 
+                public function __toString(): string 
+                {
+                    return '';
+                }
+            },
+        );
 
         $this->assertSame([], iterator_to_array($attributes));
 


### PR DESCRIPTION
This PR allows to conditionally set/unset boolean `HtmlAttributes` without leaving the fluid interface. This is especially helpful in Twig:

before:
```twig
{% set attributes = attrs().addClass('foo') %}
{% if condition %}
  {% set attributes = attributes.set('data-property') %}
{% endif %}
```

after:
```twig
{% set attributes = attrs().addClass('foo').setIf('data-property', condition) %}
```

Same goes for unsetting, where we now have a `unsetIf()` method.