### PR TITLE
Make the template element more flexible

### DIFF
--- a/core-bundle/src/Controller/ContentElement/TemplateController.php
+++ b/core-bundle/src/Controller/ContentElement/TemplateController.php
@@ -22,7 +22,12 @@ class TemplateController extends AbstractContentElementController
 {
     protected function getResponse(Template $template, ContentModel $model, Request $request): Response
     {
-        $template->data = StringUtil::deserialize($model->data, true);
+        $arrData = StringUtil::deserialize($model->data, true);
+
+        $template->data = array_combine(
+            array_column($arrData, 'key'),
+            array_column($arrData, 'value'),
+        );
 
         return $template->getResponse();
     }

--- a/core-bundle/src/Controller/ContentElement/TemplateController.php
+++ b/core-bundle/src/Controller/ContentElement/TemplateController.php
@@ -22,11 +22,10 @@ class TemplateController extends AbstractContentElementController
 {
     protected function getResponse(Template $template, ContentModel $model, Request $request): Response
     {
-        $arrData = StringUtil::deserialize($model->data, true);
-
-        $template->data = array_combine(
-            array_column($arrData, 'key'),
-            array_column($arrData, 'value'),
+        $template->data = StringUtil::deserialize($model->data, true);
+        $template->keys = array_combine(
+            array_column($template->data, 'key'),
+            array_column($template->data, 'value'),
         );
 
         return $template->getResponse();

--- a/core-bundle/src/Controller/ContentElement/TemplateController.php
+++ b/core-bundle/src/Controller/ContentElement/TemplateController.php
@@ -22,11 +22,15 @@ class TemplateController extends AbstractContentElementController
 {
     protected function getResponse(Template $template, ContentModel $model, Request $request): Response
     {
-        $template->data = StringUtil::deserialize($model->data, true);
+        $data = StringUtil::deserialize($model->data, true);
+
         $template->keys = array_combine(
-            array_column($template->data, 'key'),
-            array_column($template->data, 'value'),
+            array_column($data, 'key'),
+            array_column($data, 'value')
         );
+
+        // Backwards compatibililty
+        $template->data = $data;
 
         return $template->getResponse();
     }

--- a/core-bundle/src/Resources/contao/templates/elements/ce_template.html5
+++ b/core-bundle/src/Resources/contao/templates/elements/ce_template.html5
@@ -2,10 +2,10 @@
 
 <?php $this->block('content'); ?>
 
-  <?php foreach ($this->data as $entry): ?>
+  <?php foreach ($this->keys as $key => $value): ?>
     <dl>
-      <dt><?= $entry['key'] ?></dt>
-      <dd><?= $entry['value'] ?></dd>
+      <dt><?= $key ?></dt>
+      <dd><?= $value ?></dd>
     </dl>
   <?php endforeach; ?>
 

--- a/core-bundle/src/Resources/contao/templates/elements/ce_template.html5
+++ b/core-bundle/src/Resources/contao/templates/elements/ce_template.html5
@@ -2,10 +2,10 @@
 
 <?php $this->block('content'); ?>
 
-  <?php foreach ($this->data as $key => $entry): ?>
+  <?php foreach ($this->data as $entry): ?>
     <dl>
-      <dt><?= $key ?></dt>
-      <dd><?= $entry ?></dd>
+      <dt><?= $entry['key'] ?></dt>
+      <dd><?= $entry['value'] ?></dd>
     </dl>
   <?php endforeach; ?>
 

--- a/core-bundle/src/Resources/contao/templates/elements/ce_template.html5
+++ b/core-bundle/src/Resources/contao/templates/elements/ce_template.html5
@@ -2,10 +2,10 @@
 
 <?php $this->block('content'); ?>
 
-  <?php foreach ($this->data as $entry): ?>
+  <?php foreach ($this->data as $key => $entry): ?>
     <dl>
-      <dt><?= $entry['key'] ?></dt>
-      <dd><?= $entry['value'] ?></dd>
+      <dt><?= $key ?></dt>
+      <dd><?= $entry ?></dd>
     </dl>
   <?php endforeach; ?>
 


### PR DESCRIPTION
Currently, the defined values must always be traversed with a foreach or similar. For more flexibility I would rather pass the data array in the following structure. This way I would have direct access to my keys and could use a more complex dom structure in my template if needed.

We could also consider passing the flattened array in addition and keeping the old structure as well?