### PR TITLE
tl_content.ptable is mandatory now

### DIFF
--- a/core-bundle/src/Resources/contao/dca/tl_content.php
+++ b/core-bundle/src/Resources/contao/dca/tl_content.php
@@ -177,7 +177,7 @@ $GLOBALS['TL_DCA']['tl_content'] = array
 		),
 		'ptable' => array
 		(
-			'sql'                     => "varchar(64) COLLATE ascii_bin NOT NULL default ''"
+			'sql'                     => "varchar(64) COLLATE ascii_bin NOT NULL"
 		),
 		'sorting' => array
 		(

--- a/core-bundle/src/Resources/contao/dca/tl_content.php
+++ b/core-bundle/src/Resources/contao/dca/tl_content.php
@@ -177,7 +177,7 @@ $GLOBALS['TL_DCA']['tl_content'] = array
 		),
 		'ptable' => array
 		(
-			'sql'                     => "varchar(64) COLLATE ascii_bin NOT NULL"
+			'sql'                     => "varchar(64) COLLATE ascii_bin NOT NULL default 'tl_article'"
 		),
 		'sorting' => array
 		(


### PR DESCRIPTION
Follow up to https://github.com/contao/contao/pull/4653.

I think we don't want to default to `''` anymore now, do we? It's a mandatory definition now, imho.