### PR TITLE
Fix the hasText/hasDetails usage

### DIFF
--- a/calendar-bundle/src/Resources/contao/templates/events/event_full.html5
+++ b/calendar-bundle/src/Resources/contao/templates/events/event_full.html5
@@ -47,7 +47,7 @@
 
 $schemaOrg = $this->getSchemaOrgData();
 
-if ($this->hasDetails()) {
+if ($this->hasDetails) {
     $schemaOrg['description'] = $this->rawHtmlToPlainText($this->details);
 }
 

--- a/news-bundle/src/Resources/contao/templates/news/news_full.html5
+++ b/news-bundle/src/Resources/contao/templates/news/news_full.html5
@@ -45,7 +45,7 @@
 
 $schemaOrg = $this->getSchemaOrgData();
 
-if ($this->hasText()) {
+if ($this->hasText) {
     $schemaOrg['text'] = $this->rawHtmlToPlainText($this->text);
 }
 


### PR DESCRIPTION
We must not tread `hasText` and `hasDetails` as callables, because they can also be booleans. And if that is the case, an `InvalidArgumentException: hasDetails is not set or not a callable` exception will be triggered.