### PR TITLE
Fix type warning in event list

### DIFF
--- a/calendar-bundle/src/Resources/contao/modules/ModuleEventlist.php
+++ b/calendar-bundle/src/Resources/contao/modules/ModuleEventlist.php
@@ -210,7 +210,7 @@ class ModuleEventlist extends Events
 						continue;
 					}
 
-					$event['firstDay'] = $GLOBALS['TL_LANG']['DAYS'][date('w', $day)];
+					$event['firstDay'] = $GLOBALS['TL_LANG']['DAYS'][date('w', (int) $day)];
 					$event['firstDate'] = Date::parse($objPage->dateFormat, $day);
 
 					$arrEvents[] = $event;


### PR DESCRIPTION
This PR fixes the following warning:

```
ErrorException:
Warning: date() expects parameter 2 to be int, string given

  at vendor\contao\calendar-bundle\src\Resources\contao\modules\ModuleEventlist.php:213
```

`$day` will be a timestamp - but its type is `string`, since `Events::getAllEvents` will use `$objEvents->startTime` for `$intStart` for `$this->addEvent` - and database values are always returned as a string ([except in PHP 8.1+](https://github.com/contao/contao/issues/4278)).