### PR TITLE
Add a deprecation helper to detect insert tags in Twig templates

### DIFF
--- a/core-bundle/src/Twig/Extension/ContaoExtension.php
+++ b/core-bundle/src/Twig/Extension/ContaoExtension.php
@@ -87,6 +87,9 @@ final class ContaoExtension extends AbstractExtension
             // Allows rendering PHP templates with the legacy framework by
             // installing proxy nodes
             new PhpTemplateProxyNodeVisitor(self::class),
+            // Triggers PHP deprecations if deprecated constructs are found in
+            // the parsed templates.
+            new DeprecationsNodeVisitor(),
         ];
     }
 

--- a/core-bundle/src/Twig/Extension/DeprecationsNodeVisitor.php
+++ b/core-bundle/src/Twig/Extension/DeprecationsNodeVisitor.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Twig\Extension;
+
+use Twig\Environment;
+use Twig\Node\DeprecatedNode;
+use Twig\Node\Expression\ConstantExpression;
+use Twig\Node\Node;
+use Twig\Node\PrintNode;
+use Twig\NodeVisitor\AbstractNodeVisitor;
+
+/**
+ * @internal
+ */
+class DeprecationsNodeVisitor extends AbstractNodeVisitor
+{
+    public function getPriority(): int
+    {
+        return 10;
+    }
+
+    protected function doEnterNode(Node $node, Environment $env): Node
+    {
+        return $node;
+    }
+
+    protected function doLeaveNode(Node $node, Environment $env): Node
+    {
+        return $this->handleDeprecatedInsertTagUsage($node);
+    }
+
+    /**
+     * Discourage the use of insert tags as strings like "{{ '{{link_url::9}}' }}"
+     * instead of directly evaluating them via the "insert_tag" function.
+     */
+    private function handleDeprecatedInsertTagUsage(Node $node): Node
+    {
+        $insertTagMisusePattern = '/{{([^}]+)}}/';
+
+        if (
+            !$node instanceof PrintNode
+            || !($expression = $node->getNode('expr')) instanceof ConstantExpression
+            || 1 !== preg_match($insertTagMisusePattern, $expression->getAttribute('value'), $matches)
+        ) {
+            return $node;
+        }
+
+        $suggestedTransformation = sprintf('"{{ \'{{%1$s}}\' }}" -> "{{ insert_tag(\'%1$s\') }}".', $matches[1]);
+
+        $message = 'You should not rely on insert tags being replaced in the rendered HTML. '.
+            'This behavior will gradually be phased out in Contao 5 and will no longer work in Contao 6.0. '.
+            "Explicitly replace insert tags with the \"insert_tag\" function instead: $suggestedTransformation";
+
+        return $this->addDeprecation($node, '4.13', $message);
+    }
+
+    private function addDeprecation(Node $node, string $version, string $message): Node
+    {
+        $line = $node->getTemplateLine();
+
+        $deprecatedNode = new DeprecatedNode(
+            new ConstantExpression("Since contao/core-bundle $version: $message", $line),
+            $line,
+            $node->getNodeTag()
+        );
+
+        // Set the source context, so that the template name can be inserted
+        // when compiling the DeprecatedNode.
+        $deprecatedNode->setSourceContext($node->getSourceContext());
+
+        return new Node([$node, $deprecatedNode]);
+    }
+}

--- a/core-bundle/src/Twig/Extension/DeprecationsNodeVisitor.php
+++ b/core-bundle/src/Twig/Extension/DeprecationsNodeVisitor.php
@@ -57,19 +57,19 @@ class DeprecationsNodeVisitor extends AbstractNodeVisitor
 
         $suggestedTransformation = sprintf('"{{ \'{{%1$s}}\' }}" -> "{{ insert_tag(\'%1$s\') }}".', $matches[1]);
 
-        $message = 'You should not rely on insert tags being replaced in the rendered HTML. '.
-            'This behavior will gradually be phased out in Contao 5 and will no longer work in Contao 6.0. '.
-            "Explicitly replace insert tags with the \"insert_tag\" function instead: $suggestedTransformation";
+        $message = 'You should not rely on insert tags being replaced in the rendered HTML. '
+            .'This behavior will gradually be phased out in Contao 5 and will no longer work in Contao 6.0. '
+            .'Explicitly replace insert tags with the "insert_tag" function instead: '.$suggestedTransformation;
 
-        return $this->addDeprecation($node, '4.13', $message);
+        return $this->addDeprecation($node, $message);
     }
 
-    private function addDeprecation(Node $node, string $version, string $message): Node
+    private function addDeprecation(Node $node, string $message): Node
     {
         $line = $node->getTemplateLine();
 
         $deprecatedNode = new DeprecatedNode(
-            new ConstantExpression("Since contao/core-bundle $version: $message", $line),
+            new ConstantExpression("Since contao/core-bundle 4.13: $message", $line),
             $line,
             $node->getNodeTag()
         );

--- a/core-bundle/tests/Twig/Extension/ContaoExtensionTest.php
+++ b/core-bundle/tests/Twig/Extension/ContaoExtensionTest.php
@@ -18,6 +18,7 @@ use Contao\CoreBundle\InsertTag\InsertTagParser;
 use Contao\CoreBundle\Security\Authentication\Token\TokenChecker;
 use Contao\CoreBundle\Tests\TestCase;
 use Contao\CoreBundle\Twig\Extension\ContaoExtension;
+use Contao\CoreBundle\Twig\Extension\DeprecationsNodeVisitor;
 use Contao\CoreBundle\Twig\Inheritance\DynamicExtendsTokenParser;
 use Contao\CoreBundle\Twig\Inheritance\DynamicIncludeTokenParser;
 use Contao\CoreBundle\Twig\Inheritance\TemplateHierarchyInterface;
@@ -55,10 +56,11 @@ class ContaoExtensionTest extends TestCase
     {
         $nodeVisitors = $this->getContaoExtension()->getNodeVisitors();
 
-        $this->assertCount(2, $nodeVisitors);
+        $this->assertCount(3, $nodeVisitors);
 
         $this->assertInstanceOf(ContaoEscaperNodeVisitor::class, $nodeVisitors[0]);
         $this->assertInstanceOf(PhpTemplateProxyNodeVisitor::class, $nodeVisitors[1]);
+        $this->assertInstanceOf(DeprecationsNodeVisitor::class, $nodeVisitors[2]);
     }
 
     public function testAddsTheTokenParsers(): void

--- a/core-bundle/tests/Twig/Extension/DeprecationsNodeVisitorTest.php
+++ b/core-bundle/tests/Twig/Extension/DeprecationsNodeVisitorTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\Twig\Extension;
+
+use Contao\CoreBundle\Tests\TestCase;
+use Contao\CoreBundle\Twig\Extension\ContaoExtension;
+use Contao\CoreBundle\Twig\Extension\DeprecationsNodeVisitor;
+use Contao\CoreBundle\Twig\Inheritance\TemplateHierarchyInterface;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
+use Twig\Environment;
+use Twig\Loader\ArrayLoader;
+
+class DeprecationsNodeVisitorTest extends TestCase
+{
+    use ExpectDeprecationTrait;
+
+    public function testHashHighPriority(): void
+    {
+        $this->assertSame(10, (new DeprecationsNodeVisitor())->getPriority());
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testTriggersInsertTagDeprecation(): void
+    {
+        $templateContent = '<a href="{{ \'{{link_url::9}}\' }}">Test</a>';
+        $environment = $this->getEnvironment($templateContent);
+
+        $this->expectDeprecation('%sYou should not rely on insert tags being replaced in the rendered HTML.%s');
+
+        $environment->render('template.html.twig');
+    }
+
+    private function getEnvironment(string $templateContent): Environment
+    {
+        $environment = new Environment(
+            new ArrayLoader(['template.html.twig' => $templateContent])
+        );
+
+        $contaoExtension = new ContaoExtension($environment, $this->createMock(TemplateHierarchyInterface::class));
+        $environment->addExtension($contaoExtension);
+
+        return $environment;
+    }
+}


### PR DESCRIPTION
This PR introduces a Twig node visitor that adds `Twig\Node\DeprecatedNode` nodes when a specific usage is found during compilation.

The first implemented scenario detects this pattern `{{ '{{an_insert_tag'}}' }}` and suggests using the `insert_tag` function instead:
![image](https://user-images.githubusercontent.com/5305677/168308763-0bccab3e-a692-4a56-a701-833fbac93c65.png)

The analysis only happens at compile time and does not affect runtime performance.

/cc @ausi 