### PR TITLE
Fix undefined array key warning when using an article list

### DIFF
--- a/core-bundle/src/Resources/contao/modules/ModuleArticleList.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleArticleList.php
@@ -102,7 +102,7 @@ class ModuleArticleList extends Module
 			(
 				'link' => $objArticles->title,
 				'title' => StringUtil::specialchars($objArticles->title),
-				'id' => $cssID[0] ?: 'article-' . $objArticles->id,
+				'id' => $cssID[0] ?? 'article-' . $objArticles->id,
 				'articleId' => $objArticles->id,
 				'href' => $objHelper->getFrontendUrl('/articles/' . ($objArticles->alias ?: $objArticles->id))
 			);

--- a/core-bundle/src/Resources/contao/modules/ModuleArticleList.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleArticleList.php
@@ -102,7 +102,7 @@ class ModuleArticleList extends Module
 			(
 				'link' => $objArticles->title,
 				'title' => StringUtil::specialchars($objArticles->title),
-				'id' => $cssID[0] ?? 'article-' . $objArticles->id,
+				'id' => ($cssID[0] ?? null) ?: 'article-' . $objArticles->id,
 				'articleId' => $objArticles->id,
 				'href' => $objHelper->getFrontendUrl('/articles/' . ($objArticles->alias ?: $objArticles->id))
 			);


### PR DESCRIPTION
When you use the Article List module, the following warning will occur under PHP 8:

```
ErrorException:
Warning: Undefined array key 0

  at vendor/contao/contao/core-bundle/src/Resources/contao/modules/ModuleArticleList.php:105
  at Contao\ModuleArticleList->compile()
     (vendor/contao/contao/core-bundle/src/Resources/contao/modules/Module.php:214)
  at Contao\Module->generate()
     (vendor/contao/contao/core-bundle/src/Resources/contao/modules/ModuleArticleList.php:45)
  at Contao\ModuleArticleList->generate()
     (vendor/contao/contao/core-bundle/src/Resources/contao/elements/ContentModule.php:98)
  at Contao\ContentModule->generate()
     (vendor/contao/contao/core-bundle/src/Resources/contao/library/Contao/Controller.php:615)
  at Contao\Controller::getContentElement()
     (vendor/contao/contao/core-bundle/src/Resources/contao/modules/ModuleArticle.php:197)
  at Contao\ModuleArticle->compile()
     (vendor/contao/contao/core-bundle/src/Resources/contao/modules/Module.php:214)
  at Contao\Module->generate()
     (vendor/contao/contao/core-bundle/src/Resources/contao/modules/ModuleArticle.php:70)
  at Contao\ModuleArticle->generate()
     (vendor/contao/contao/core-bundle/src/Resources/contao/library/Contao/Controller.php:543)
  at Contao\Controller::getArticle()
     (vendor/contao/contao/core-bundle/src/Resources/contao/library/Contao/Controller.php:385)
  at Contao\Controller::getFrontendModule()
     (vendor/contao/contao/core-bundle/src/Resources/contao/pages/PageRegular.php:190)
  at Contao\PageRegular->prepare()
     (vendor/contao/contao/core-bundle/src/Resources/contao/pages/PageRegular.php:60)
  at Contao\PageRegular->getResponse()
     (vendor/contao/contao/core-bundle/src/Resources/contao/controllers/FrontendIndex.php:316)
  at Contao\FrontendIndex->renderPage()
     (vendor/symfony/http-kernel/HttpKernel.php:152)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw()
     (vendor/symfony/http-kernel/HttpKernel.php:74)
  at Symfony\Component\HttpKernel\HttpKernel->handle()
     (vendor/symfony/http-kernel/Kernel.php:202)
  at Symfony\Component\HttpKernel\Kernel->handle()
     (web/index.php:44)  
```