### PR TITLE
Use constants for return values of commands

### DIFF
--- a/core-bundle/src/Command/AutomatorCommand.php
+++ b/core-bundle/src/Command/AutomatorCommand.php
@@ -53,10 +53,10 @@ class AutomatorCommand extends Command
         } catch (InvalidArgumentException $e) {
             $output->writeln(sprintf('%s (see help contao:automator).', $e->getMessage()));
 
-            return 1;
+            return Command::FAILURE;
         }
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     private function runAutomator(InputInterface $input, OutputInterface $output): void

--- a/core-bundle/src/Command/Backup/BackupCreateCommand.php
+++ b/core-bundle/src/Command/Backup/BackupCreateCommand.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Command\Backup;
 
 use Contao\CoreBundle\Doctrine\Backup\BackupManagerException;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
@@ -41,17 +42,17 @@ class BackupCreateCommand extends AbstractBackupCommand
                 $io->error($e->getMessage());
             }
 
-            return 1;
+            return Command::FAILURE;
         }
 
         if ($this->isJson($input)) {
             $io->writeln(json_encode($config->getBackup()->toArray()));
 
-            return 0;
+            return Command::SUCCESS;
         }
 
         $io->success(sprintf('Successfully created SQL dump "%s".', $config->getBackup()->getFilename()));
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/core-bundle/src/Command/Backup/BackupListCommand.php
+++ b/core-bundle/src/Command/Backup/BackupListCommand.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Command\Backup;
 
 use Contao\CoreBundle\Doctrine\Backup\Backup;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
@@ -40,7 +41,7 @@ class BackupListCommand extends AbstractBackupCommand
         if ($this->isJson($input)) {
             $io->writeln($this->formatForJson($this->backupManager->listBackups()));
 
-            return 0;
+            return Command::SUCCESS;
         }
 
         $timeZone = new \DateTimeZone(date_default_timezone_get());
@@ -50,7 +51,7 @@ class BackupListCommand extends AbstractBackupCommand
             $this->formatForTable($this->backupManager->listBackups(), $timeZone)
         );
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     /**

--- a/core-bundle/src/Command/Backup/BackupRestoreCommand.php
+++ b/core-bundle/src/Command/Backup/BackupRestoreCommand.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Command\Backup;
 
 use Contao\CoreBundle\Doctrine\Backup\BackupManagerException;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -53,17 +54,17 @@ class BackupRestoreCommand extends AbstractBackupCommand
                 $io->error($e->getMessage());
             }
 
-            return 1;
+            return Command::FAILURE;
         }
 
         if ($this->isJson($input)) {
             $io->writeln(json_encode($config->getBackup()->toArray()));
 
-            return 0;
+            return Command::SUCCESS;
         }
 
         $io->success(sprintf('Successfully restored backup from "%s".', $config->getBackup()->getFilename()));
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/core-bundle/src/Command/CrawlCommand.php
+++ b/core-bundle/src/Command/CrawlCommand.php
@@ -97,11 +97,11 @@ class CrawlCommand extends Command
         } catch (InvalidJobIdException) {
             $io->error('Could not find the given job ID.');
 
-            return 1;
+            return Command::FAILURE;
         } catch (InvalidArgumentException $e) {
             $io->error($e->getMessage());
 
-            return 1;
+            return Command::FAILURE;
         }
 
         $logOutput = $output instanceof ConsoleOutput ? $output->section() : $output;
@@ -143,7 +143,7 @@ class CrawlCommand extends Command
             }
         }
 
-        return (int) $errored;
+        return $errored ? Command::FAILURE : Command::SUCCESS;
     }
 
     private function createLogger(OutputInterface $output, InputInterface $input): LoggerInterface

--- a/core-bundle/src/Command/CronCommand.php
+++ b/core-bundle/src/Command/CronCommand.php
@@ -31,6 +31,6 @@ class CronCommand extends Command
     {
         $this->cron->run(Cron::SCOPE_CLI);
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/core-bundle/src/Command/DebugContaoTwigCommand.php
+++ b/core-bundle/src/Command/DebugContaoTwigCommand.php
@@ -82,7 +82,7 @@ class DebugContaoTwigCommand extends Command
         $io->title('Template hierarchy');
         $io->table(['Identifier', 'Effective logical name', 'Path'], $rows);
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     private function getThemeSlug(InputInterface $input): string|null

--- a/core-bundle/src/Command/DebugDcaCommand.php
+++ b/core-bundle/src/Command/DebugDcaCommand.php
@@ -59,6 +59,6 @@ class DebugDcaCommand extends Command
 
         $dumper->dump($cloner->cloneVar($GLOBALS['TL_DCA'][$table]));
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/core-bundle/src/Command/DebugFragmentsCommand.php
+++ b/core-bundle/src/Command/DebugFragmentsCommand.php
@@ -62,7 +62,7 @@ class DebugFragmentsCommand extends Command
         $io->title('Contao Fragments');
         $io->table(['Identifier', 'Controller', 'Renderer', 'Render Options', 'Fragment Options'], $rows);
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     private function generateArray(array $values): string

--- a/core-bundle/src/Command/DebugPagesCommand.php
+++ b/core-bundle/src/Command/DebugPagesCommand.php
@@ -98,7 +98,7 @@ class DebugPagesCommand extends Command
         $io->title('Contao Pages');
         $io->table(['Type', 'Path', 'URL Suffix', 'Content Composition', 'Route Enhancer', 'Requirements', 'Defaults', 'Options'], $rows);
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     private function generateArray(array $values): string

--- a/core-bundle/src/Command/FilesyncCommand.php
+++ b/core-bundle/src/Command/FilesyncCommand.php
@@ -54,7 +54,7 @@ class FilesyncCommand extends Command
 
         (new SymfonyStyle($input, $output))->success("Synchronization complete in {$timeTotal}s.");
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     private function renderStats(ChangeSet $changeSet, OutputInterface $output): void

--- a/core-bundle/src/Command/InstallCommand.php
+++ b/core-bundle/src/Command/InstallCommand.php
@@ -57,7 +57,7 @@ class InstallCommand extends Command
             $io->listing($this->rows);
         }
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     private function addEmptyDirs(): void

--- a/core-bundle/src/Command/MigrateCommand.php
+++ b/core-bundle/src/Command/MigrateCommand.php
@@ -80,7 +80,7 @@ class MigrateCommand extends Command
             ]);
         }
 
-        return 1;
+        return Command::FAILURE;
     }
 
     private function backup(InputInterface $input): void
@@ -147,22 +147,22 @@ class MigrateCommand extends Command
         }
 
         if (!$this->executeMigrations($dryRun, $asJson, $specifiedHash)) {
-            return 1;
+            return Command::FAILURE;
         }
 
         if (!$this->executeSchemaDiff($dryRun, $asJson, $input->getOption('with-deletes'), $specifiedHash)) {
-            return 1;
+            return Command::FAILURE;
         }
 
         if (!$dryRun && null === $specifiedHash && !$this->executeMigrations($dryRun, $asJson)) {
-            return 1;
+            return Command::FAILURE;
         }
 
         if (!$asJson) {
             $this->io->success('All migrations completed.');
         }
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     private function executeMigrations(bool &$dryRun, bool $asJson, string $specifiedHash = null): bool

--- a/core-bundle/src/Command/ResizeImagesCommand.php
+++ b/core-bundle/src/Command/ResizeImagesCommand.php
@@ -117,7 +117,7 @@ class ResizeImagesCommand extends Command
     private function resizeImage(string $path, bool $preserveMissing, bool $quiet = false): int
     {
         if ($this->filesystem->exists(Path::join($this->targetDir, $path))) {
-            return 0;
+            return Command::SUCCESS;
         }
 
         try {
@@ -144,14 +144,14 @@ class ResizeImagesCommand extends Command
                 $this->io->writeln('Image "'.$path.'" does not exist anymore, deleted deferred image reference');
             }
 
-            return 1;
+            return Command::FAILURE;
         }
 
         if (!$quiet) {
             $this->io->writeln('Image "'.$path.'" resized successfully');
         }
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     private function resizeImages(float $timeLimit, float $concurrent, bool $noSubProcess, bool $preserveMissing): int
@@ -222,11 +222,11 @@ class ResizeImagesCommand extends Command
             if (0 !== $failedCount && $count - $failedCount <= 0) {
                 $this->io->error('No image could be resized successfully.');
 
-                return 1;
+                return Command::FAILURE;
             }
         }
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     private function executeConcurrent(float $timeLimit, float $concurrent): int
@@ -316,10 +316,10 @@ class ResizeImagesCommand extends Command
         if (0 !== $failedCount && $count - $failedCount <= 0) {
             $this->io->error('No image could be resized successfully.');
 
-            return 1;
+            return Command::FAILURE;
         }
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     private function updateOutput(array $processes, array $counts, array $paths): void

--- a/core-bundle/src/Command/SymlinksCommand.php
+++ b/core-bundle/src/Command/SymlinksCommand.php
@@ -40,7 +40,7 @@ class SymlinksCommand extends Command
 
     private array $rows = [];
     private string|null $webDir = null;
-    private int $statusCode = 0;
+    private int $statusCode = Command::SUCCESS;
 
     public function __construct(
         private string $projectDir,
@@ -179,7 +179,7 @@ class SymlinksCommand extends Command
                 $target,
             ];
         } catch (\Exception $e) {
-            $this->statusCode = 1;
+            $this->statusCode = Command::FAILURE;
 
             $this->rows[] = [
                 sprintf(

--- a/core-bundle/src/Command/UserCreateCommand.php
+++ b/core-bundle/src/Command/UserCreateCommand.php
@@ -170,7 +170,7 @@ class UserCreateCommand extends Command
         ) {
             $io->error('Please provide at least and each of: username, name, email, password');
 
-            return 1;
+            return Command::FAILURE;
         }
 
         $isAdmin = $input->getOption('admin');
@@ -188,7 +188,7 @@ class UserCreateCommand extends Command
 
         $io->success(sprintf('User %s%s created.', $username, $isAdmin ? ' with admin permissions' : ''));
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     private function ask(string $label, InputInterface $input, OutputInterface $output, callable $callback = null): string

--- a/core-bundle/src/Command/UserListCommand.php
+++ b/core-bundle/src/Command/UserListCommand.php
@@ -61,7 +61,7 @@ class UserListCommand extends Command
                 if (!$users || 0 === $users->count()) {
                     $io->note('No accounts found.');
 
-                    return 0;
+                    return Command::SUCCESS;
                 }
 
                 $rows = $this->formatTableRows($users, $columns);
@@ -79,7 +79,7 @@ class UserListCommand extends Command
                 throw new \LogicException('Invalid format: '.$input->getOption('format'));
         }
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     private function getUsers(bool $onlyAdmins = false): Collection|null

--- a/core-bundle/src/Command/UserPasswordCommand.php
+++ b/core-bundle/src/Command/UserPasswordCommand.php
@@ -78,7 +78,7 @@ class UserPasswordCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         if (null === $input->getArgument('username') || null === $input->getOption('password')) {
-            return 1;
+            return Command::FAILURE;
         }
 
         $this->framework->initialize();
@@ -111,7 +111,7 @@ class UserPasswordCommand extends Command
         $io = new SymfonyStyle($input, $output);
         $io->success('The password has been changed successfully.');
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     /**

--- a/core-bundle/src/Command/VersionCommand.php
+++ b/core-bundle/src/Command/VersionCommand.php
@@ -32,6 +32,6 @@ class VersionCommand extends Command
     {
         $output->writeln(ContaoCoreBundle::getVersion());
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/installation-bundle/src/Command/UnlockCommand.php
+++ b/installation-bundle/src/Command/UnlockCommand.php
@@ -37,7 +37,7 @@ class UnlockCommand extends Command
         if (!file_exists($this->lockFile)) {
             $output->writeln('<comment>The install tool was not locked.</comment>');
 
-            return 1;
+            return Command::FAILURE;
         }
 
         $fs = new Filesystem();

--- a/manager-bundle/src/Command/ContaoSetupCommand.php
+++ b/manager-bundle/src/Command/ContaoSetupCommand.php
@@ -92,7 +92,7 @@ class ContaoSetupCommand extends Command
 
         $output->writeln('<info>Done! Please open the Contao install tool or run contao:migrate on the command line to make sure the database is up-to-date.</info>');
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     /**

--- a/manager-bundle/src/Command/DebugPluginsCommand.php
+++ b/manager-bundle/src/Command/DebugPluginsCommand.php
@@ -106,7 +106,7 @@ class DebugPluginsCommand extends Command
         $this->io->title($title);
         $this->io->table($headers, $rows);
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     private function listBundles(): int
@@ -136,7 +136,7 @@ class DebugPluginsCommand extends Command
         $this->io->title($title);
         $this->io->table($headers, $rows);
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     private function showPlugin(string $name, InputInterface $input): int
@@ -204,7 +204,7 @@ class DebugPluginsCommand extends Command
         $this->io->title($title);
         $this->io->table($headers, $rows);
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     private function findPlugin(string $name): array|null

--- a/manager-bundle/src/Command/InstallWebDirCommand.php
+++ b/manager-bundle/src/Command/InstallWebDirCommand.php
@@ -55,7 +55,7 @@ class InstallWebDirCommand extends Command
         $this->addFiles($path);
         $this->purgeOldFiles($path);
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     /**

--- a/manager-bundle/src/Command/MaintenanceModeCommand.php
+++ b/manager-bundle/src/Command/MaintenanceModeCommand.php
@@ -56,21 +56,21 @@ class MaintenanceModeCommand extends Command
             $this->enable($input->getOption('template'), $input->getOption('templateVars'));
             $this->outputResult($input, $output, true, true);
 
-            return 0;
+            return Command::SUCCESS;
         }
 
         if (\in_array($state, ['disable', 'off'], true)) {
             $this->disable();
             $this->outputResult($input, $output, false, true);
 
-            return 0;
+            return Command::SUCCESS;
         }
 
         $isEnabled = $this->filesystem->exists($this->maintenanceFilePath);
 
         $this->outputResult($input, $output, $isEnabled, false);
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     private function enable(string $templateName, string $templateVars): void


### PR DESCRIPTION
Now that we require `symfony/console` in at least version `5.4`, we can use constants for return values:

 `return 0;` &rarr; `return Command::SUCCESS;`
 `return 1;` &rarr; `return Command::FAILURE;`