### PR TITLE
Undeprecate the third Input::get() parameter

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Input.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Input.php
@@ -138,12 +138,13 @@ class Input
 	/**
 	 * Return a $_GET variable
 	 *
-	 * @param string  $strKey            The variable name
-	 * @param boolean $blnDecodeEntities If true, all entities will be decoded
+	 * @param string  $strKey                      The variable name
+	 * @param boolean $blnDecodeEntities           If true, all entities will be decoded
+	 * @param boolean $blnKeepUnusedRouteParameter If true, the route parameter will not be marked as used (see #4277)
 	 *
 	 * @return array|string|null The cleaned variable value
 	 */
-	public static function get($strKey, $blnDecodeEntities=false)
+	public static function get($strKey, $blnDecodeEntities=false, $blnKeepUnusedRouteParameter=false)
 	{
 		$varValue = static::findGet($strKey);
 
@@ -153,11 +154,7 @@ class Input
 		}
 
 		// Mark the parameter as used (see #4277)
-		if (\func_num_args() > 2 && func_get_arg(2))
-		{
-			trigger_deprecation('contao/core-bundle', '5.0', 'Using %s() with the third parameter "$blnKeepUnused" has been deprecated and will no longer work in Contao 6.0.', __METHOD__);
-		}
-		else
+		if (!$blnKeepUnusedRouteParameter)
 		{
 			unset(self::$arrUnusedRouteParameters[$strKey]);
 		}


### PR DESCRIPTION
In #4510 I deprecated the third parameter of `Input::get($strKey, $blnDecodeEntities=false, $blnKeepUnused=false)`

@fritzmg raised concerns in https://github.com/contao/contao/pull/4510#issuecomment-1114279367 and the core itself still uses it in https://github.com/contao/contao/blob/67608ff61bfb118971852617c80f135c4e9aef2b/core-bundle/src/Resources/contao/classes/Frontend.php#L96

Therefore I think we should revert this deprecation.