### PR TITLE
Fix the non-JS navigation toggle on backend dashboard

### DIFF
--- a/core-bundle/src/Resources/contao/controllers/BackendMain.php
+++ b/core-bundle/src/Resources/contao/controllers/BackendMain.php
@@ -135,7 +135,7 @@ class BackendMain extends Backend
 			$session['backend_modules'][Input::get('mtg')] = (isset($session['backend_modules'][Input::get('mtg')]) && $session['backend_modules'][Input::get('mtg')] == 0) ? 1 : 0;
 			$objSessionBag->replace($session);
 
-			Controller::redirect(preg_replace('/(&(amp;)?|\?)mtg=[^& ]*/i', '', Environment::get('request')));
+			Controller::redirect(preg_replace('/(&(amp;)?|\?)mtg=[^& ]*$|mtg=[^&]*&(amp;)?/i', '', Environment::get('request')));
 		}
 		// Error
 		elseif (Input::get('act') == 'error')


### PR DESCRIPTION
If javascript is disabled in the back end, clicking on the section header in the main navigation will execute a real request with `mtg=xxx`. On the dashboard, this leads to an invalid redirect because it will remove the leading `?` from query parameters but keep `rel=xxx` (the redirect URL would be `/contao&rel=xxx`)