### PR TITLE
Fix the PHP 8 warning in Contao\Date class

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Date.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Date.php
@@ -272,6 +272,8 @@ class Date
 
 		foreach ($arrCharacters as $strCharacter)
 		{
+			$arrInputFormat[$strFormat] ??= '';
+
 			if (isset($arrCharacterMapper[$strCharacter]))
 			{
 				$arrInputFormat[$strFormat] .= $arrCharacterMapper[$strCharacter];


### PR DESCRIPTION
<img width="1076" alt="CleanShot 2022-05-16 at 15 35 54" src="https://user-images.githubusercontent.com/193483/168604962-11bd18f0-fabe-4abc-8096-89da7d2c2f33.png">
