### PR TITLE
Drop the DBAFS file size limit

### DIFF
--- a/core-bundle/src/Filesystem/Dbafs/Dbafs.php
+++ b/core-bundle/src/Filesystem/Dbafs/Dbafs.php
@@ -51,7 +51,6 @@ class Dbafs implements DbafsInterface, ResetInterface
 
     private string $table;
     private string $dbPathPrefix = '';
-    private int $maxFileSize = 2147483647; // 2 GiB - 1 byte (see #4208)
     private int $bulkInsertSize = 100;
     private bool $useLastModified = true;
 
@@ -90,7 +89,7 @@ class Dbafs implements DbafsInterface, ResetInterface
 
     public function setMaxFileSize(int $bytes): void
     {
-        $this->maxFileSize = $bytes;
+        trigger_deprecation('contao/core-bundle', '4.13', 'Setting a maximum file size has no effect anymore. The "%s()" method will be removed in Contao 5.', __METHOD__);
     }
 
     public function setBulkInsertSize(int $chunkSize): void
@@ -740,11 +739,6 @@ class Dbafs implements DbafsInterface, ResetInterface
 
                 // Ignore dot files
                 if (0 === strpos(basename($path), '.')) {
-                    continue;
-                }
-
-                // Ignore files that are too big
-                if ($item->getFileSize() > $this->maxFileSize) {
                     continue;
                 }
 

--- a/core-bundle/src/Filesystem/Dbafs/Dbafs.php
+++ b/core-bundle/src/Filesystem/Dbafs/Dbafs.php
@@ -87,6 +87,9 @@ class Dbafs implements DbafsInterface, ResetInterface
         $this->dbPathPrefix = Path::canonicalize($prefix);
     }
 
+    /**
+     * @deprecated Deprecated since Contao 4.13, to be removed in Contao 5.0.
+     */
     public function setMaxFileSize(int $bytes): void
     {
         trigger_deprecation('contao/core-bundle', '4.13', 'Setting a maximum file size has no effect anymore. The "%s()" method will be removed in Contao 5.', __METHOD__);

--- a/core-bundle/src/Resources/contao/library/Contao/File.php
+++ b/core-bundle/src/Resources/contao/library/Contao/File.php
@@ -879,12 +879,6 @@ class File extends System
 	 */
 	protected function getHash()
 	{
-		// Do not try to hash if bigger than 2 GB
-		if ($this->filesize >= 2147483648)
-		{
-			return '';
-		}
-
 		return md5_file($this->strRootDir . '/' . $this->strFile);
 	}
 

--- a/core-bundle/tests/Filesystem/Dbafs/DbafsTest.php
+++ b/core-bundle/tests/Filesystem/Dbafs/DbafsTest.php
@@ -572,9 +572,6 @@ class DbafsTest extends TestCase
 
         $dbafs = $this->getDbafs($connection, $filesystem);
 
-        // Lower max file size, so that we can test the limit without excessive memory usage
-        $dbafs->setMaxFileSize(100);
-
         $changeSet = $dbafs->computeChangeSet(...((array) $paths));
 
         $this->assertSame($expected->getItemsToCreate(), $changeSet->getItemsToCreate(), 'items to create');
@@ -754,18 +751,14 @@ class DbafsTest extends TestCase
         ];
 
         $filesystem7 = $getFilesystem();
-        $filesystem7->write('large', str_pad('A', 100));
-        $filesystem7->write('too-large', str_pad('A', 101));
         $filesystem7->write('bar/'.Dbafs::FILE_MARKER_EXCLUDED, '');
         $filesystem7->write('foo/'.Dbafs::FILE_MARKER_PUBLIC, '');
 
-        yield 'large and ignored files' => [
+        yield 'ignored files' => [
             $filesystem7,
             '',
             new ChangeSet(
-                [
-                    ['hash' => '7866a94bb1745dee3a9601b4a5518b71', 'path' => 'large', 'type' => ChangeSet::TYPE_FILE],
-                ],
+                [],
                 [],
                 [
                     'bar' => ChangeSet::TYPE_DIRECTORY,


### PR DESCRIPTION
This removes the 2GB file size limit for the DBAFS and therefore also removes incoherent behavior between the old and new implementation.

see https://github.com/contao/contao/issues/4678#issuecomment-1128184839

@Kahmoon Can you please check, if this solves your issue?