### PR TITLE
Always delete indexed page for unsuccessful responses

### DIFF
--- a/core-bundle/src/EventListener/SearchIndexListener.php
+++ b/core-bundle/src/EventListener/SearchIndexListener.php
@@ -57,9 +57,7 @@ class SearchIndexListener
     {
         $request = $event->getRequest();
         $response = $event->getResponse();
-
         $document = Document::createFromRequestResponse($request, $response);
-
         $needsIndex = $this->needsIndex($request, $response, $document);
 
         try {

--- a/core-bundle/src/EventListener/SearchIndexListener.php
+++ b/core-bundle/src/EventListener/SearchIndexListener.php
@@ -17,6 +17,7 @@ use Contao\CoreBundle\Search\Document;
 use Contao\CoreBundle\Search\Indexer\IndexerException;
 use Contao\CoreBundle\Search\Indexer\IndexerInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\TerminateEvent;
 
 /**
@@ -55,53 +56,16 @@ class SearchIndexListener
     public function __invoke(TerminateEvent $event): void
     {
         $request = $event->getRequest();
-
-        // Only handle GET requests (see #1194)
-        if (!$request->isMethod(Request::METHOD_GET)) {
-            return;
-        }
-
-        // Do not index if called by crawler
-        if (Factory::USER_AGENT === $request->headers->get('User-Agent')) {
-            return;
-        }
-
-        // Do not handle fragments
-        if (preg_match('~(?:^|/)'.preg_quote($this->fragmentPath, '~').'/~', $request->getPathInfo())) {
-            return;
-        }
-
         $response = $event->getResponse();
-
-        // Do not index if the X-Robots-Tag header contains "noindex"
-        if (false !== strpos($response->headers->get('X-Robots-Tag', ''), 'noindex')) {
-            return;
-        }
 
         $document = Document::createFromRequestResponse($request, $response);
 
-        try {
-            $robots = $document->getContentCrawler()->filterXPath('//head/meta[@name="robots"]')->first()->attr('content');
-
-            // Do not index if the meta robots tag contains "noindex"
-            if (false !== strpos($robots, 'noindex')) {
-                return;
-            }
-        } catch (\Exception $e) {
-            // No meta robots tag found
-        }
-
-        $lds = $document->extractJsonLdScripts();
-
-        // If there are no json ld scripts at all, this should not be handled by our indexer
-        if (0 === \count($lds)) {
-            return;
-        }
+        $needsIndex = $this->needsIndex($request, $response, $document);
 
         try {
             $success = $event->getResponse()->isSuccessful();
 
-            if ($success && $this->enabledFeatures & self::FEATURE_INDEX) {
+            if ($needsIndex && $success && $this->enabledFeatures & self::FEATURE_INDEX) {
                 $this->indexer->index($document);
             }
 
@@ -111,5 +75,48 @@ class SearchIndexListener
         } catch (IndexerException $e) {
             // ignore
         }
+    }
+
+    private function needsIndex(Request $request, Response $response, Document $document): bool
+    {
+        // Only handle GET requests (see #1194)
+        if (!$request->isMethod(Request::METHOD_GET)) {
+            return false;
+        }
+
+        // Do not index if called by crawler
+        if (Factory::USER_AGENT === $request->headers->get('User-Agent')) {
+            return false;
+        }
+
+        // Do not handle fragments
+        if (preg_match('~(?:^|/)'.preg_quote($this->fragmentPath, '~').'/~', $request->getPathInfo())) {
+            return false;
+        }
+
+        // Do not index if the X-Robots-Tag header contains "noindex"
+        if (false !== strpos($response->headers->get('X-Robots-Tag', ''), 'noindex')) {
+            return false;
+        }
+
+        try {
+            $robots = $document->getContentCrawler()->filterXPath('//head/meta[@name="robots"]')->first()->attr('content');
+
+            // Do not index if the meta robots tag contains "noindex"
+            if (false !== strpos($robots, 'noindex')) {
+                return false;
+            }
+        } catch (\Exception $e) {
+            // No meta robots tag found
+        }
+
+        $lds = $document->extractJsonLdScripts();
+
+        // If there are no json ld scripts at all, this should not be handled by our indexer
+        if (0 === \count($lds)) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/core-bundle/tests/EventListener/SearchIndexListenerTest.php
+++ b/core-bundle/tests/EventListener/SearchIndexListenerTest.php
@@ -90,17 +90,9 @@ class SearchIndexListenerTest extends TestCase
             false,
         ];
 
-        yield 'Should be ignored because the response was not successful (404) but there was no ld+json data' => [
-            Request::create('/foobar'),
-            new Response('', 404),
-            SearchIndexListener::FEATURE_DELETE | SearchIndexListener::FEATURE_INDEX,
-            false,
-            false,
-        ];
-
         yield 'Should be deleted because the response was not successful (404)' => [
             Request::create('/foobar'),
-            new Response('<html><body><script type="application/ld+json">{"@context":"https:\/\/contao.org\/","@type":"Page","pageId":2,"noSearch":false,"protected":false,"groups":[],"fePreview":false}</script></body></html>', 404),
+            new Response('', 404),
             SearchIndexListener::FEATURE_DELETE | SearchIndexListener::FEATURE_INDEX,
             false,
             true,
@@ -108,7 +100,7 @@ class SearchIndexListenerTest extends TestCase
 
         yield 'Should be deleted because the response was not successful (403)' => [
             Request::create('/foobar'),
-            new Response('<html><body><script type="application/ld+json">{"@context":"https:\/\/contao.org\/","@type":"Page","pageId":2,"noSearch":false,"protected":false,"groups":[],"fePreview":false}</script></body></html>', 403),
+            new Response('', 403),
             SearchIndexListener::FEATURE_DELETE | SearchIndexListener::FEATURE_INDEX,
             false,
             true,
@@ -130,7 +122,7 @@ class SearchIndexListenerTest extends TestCase
             $response,
             SearchIndexListener::FEATURE_DELETE | SearchIndexListener::FEATURE_INDEX,
             false,
-            false,
+            true,
         ];
 
         yield 'Should not be handled because the meta robots tag contains "noindex" ' => [
@@ -138,7 +130,7 @@ class SearchIndexListenerTest extends TestCase
             new Response('<html><head><meta name="robots" content="noindex,nofollow"/></head><body><script type="application/ld+json">{"@context":"https:\/\/contao.org\/","@type":"Page","pageId":2,"noSearch":false,"protected":false,"groups":[],"fePreview":false}</script></body></html>', 403),
             SearchIndexListener::FEATURE_DELETE | SearchIndexListener::FEATURE_INDEX,
             false,
-            false,
+            true,
         ];
     }
 }


### PR DESCRIPTION
Fixes #4685

Our `SearchIndexListener` is supposed to delete search entries for unsuccessful responses. However, as outlined in #4685 this currently does not work, because the early outs checking for whether the page should be indexed will also prevent the URL from being _removed_ from the search index. `404` responses with the default 404 page will for instance never have any `JSON-LD` content and 404 responses with a custom 404 page will always have `X-Robots-Tag: noindex`. Thus pages will actually never be removed from the index currently.

This PR fixes that by separating the check whether the requested page should be indexed and instead always issue a document deletion in case the response is unsuccessful.