### PR TITLE
Handle cases when layoutId is not set on page model

### DIFF
--- a/core-bundle/src/DataCollector/ContaoDataCollector.php
+++ b/core-bundle/src/DataCollector/ContaoDataCollector.php
@@ -22,6 +22,7 @@ use Contao\StringUtil;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\DataCollector\DataCollector;
+use Symfony\Component\VarDumper\VarDumper;
 
 /**
  * @internal
@@ -183,12 +184,12 @@ class ContaoDataCollector extends DataCollector implements FrameworkAwareInterfa
         /** @var PageModel $objPage */
         $objPage = $GLOBALS['objPage'];
 
-        /** @var LayoutModel $layout */
-        $layout = $this->framework->getAdapter(LayoutModel::class);
-
         if (!$objPage->layoutId) {
             return null;
         }
+
+        /** @var LayoutModel $layout */
+        $layout = $this->framework->getAdapter(LayoutModel::class);
 
         return $layout->findByPk($objPage->layoutId);
     }

--- a/core-bundle/src/DataCollector/ContaoDataCollector.php
+++ b/core-bundle/src/DataCollector/ContaoDataCollector.php
@@ -22,7 +22,6 @@ use Contao\StringUtil;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\DataCollector\DataCollector;
-use Symfony\Component\VarDumper\VarDumper;
 
 /**
  * @internal

--- a/core-bundle/src/DataCollector/ContaoDataCollector.php
+++ b/core-bundle/src/DataCollector/ContaoDataCollector.php
@@ -186,6 +186,10 @@ class ContaoDataCollector extends DataCollector implements FrameworkAwareInterfa
         /** @var LayoutModel $layout */
         $layout = $this->framework->getAdapter(LayoutModel::class);
 
+        if (!$objPage->layoutId) {
+            return null;
+        }
+
         return $layout->findByPk($objPage->layoutId);
     }
 }


### PR DESCRIPTION
I had the issue that I removed `setLoadAfter()` in my Manager plugin. This caused some palette manipulation to fail in one of my DCA. However the `PaletteNotFoundException` was covered up by an error in the ContaoDataCollector. This PR checks for the existence of `$objPage->layoutId` and returns null otherwise. This way, the actual exception will be show by the error listener.

# Steps to reproduce

Throw any exception in a `tl_layout` DCA file

```php
// tl_layout.php
throw new Exception('🔥');
``` 

# What I expect
I will see the error listener showing me the actual exception

# What I got

An error in the `ContaoDataCollector`

```
TypeError:
Model::findByPk(): Argument #1 ($varValue) must be of type int|string, got null

  at /home/benedict/dev/contao-managed/vendor/contao/contao/core-bundle/src/Resources/contao/library/Contao/Model.php:741
  at Contao\Model::findByPk()
     (/home/benedict/dev/contao-managed/vendor/contao/contao/core-bundle/src/Framework/Adapter.php:40)
  at Contao\CoreBundle\Framework\Adapter->__call()
     (/home/benedict/dev/contao-managed/vendor/contao/contao/core-bundle/src/DataCollector/ContaoDataCollector.php:189)
  at Contao\CoreBundle\DataCollector\ContaoDataCollector->getLayout()
     (/home/benedict/dev/contao-managed/vendor/contao/contao/core-bundle/src/DataCollector/ContaoDataCollector.php:160)
  at Contao\CoreBundle\DataCollector\ContaoDataCollector->getLayoutName()
     (/home/benedict/dev/contao-managed/vendor/contao/contao/core-bundle/src/DataCollector/ContaoDataCollector.php:153)
  at Contao\CoreBundle\DataCollector\ContaoDataCollector->addSummaryData()
     (/home/benedict/dev/contao-managed/vendor/contao/contao/core-bundle/src/DataCollector/ContaoDataCollector.php:43)
  at Contao\CoreBundle\DataCollector\ContaoDataCollector->collect()
     (/home/benedict/dev/contao-managed/vendor/symfony/http-kernel/Profiler/Profiler.php:161)
  at Symfony\Component\HttpKernel\Profiler\Profiler->collect()
     (/home/benedict/dev/contao-managed/vendor/symfony/http-kernel/EventListener/ProfilerListener.php:99)
  at Symfony\Component\HttpKernel\EventListener\ProfilerListener->onKernelResponse()
     (/home/benedict/dev/contao-managed/vendor/symfony/event-dispatcher/Debug/WrappedListener.php:117)
  at Symfony\Component\EventDispatcher\Debug\WrappedListener->__invoke()
     (/home/benedict/dev/contao-managed/vendor/symfony/event-dispatcher/EventDispatcher.php:230)
  at Symfony\Component\EventDispatcher\EventDispatcher->callListeners()
     (/home/benedict/dev/contao-managed/vendor/symfony/event-dispatcher/EventDispatcher.php:59)
  at Symfony\Component\EventDispatcher\EventDispatcher->dispatch()
     (/home/benedict/dev/contao-managed/vendor/symfony/event-dispatcher/Debug/TraceableEventDispatcher.php:154)
  at Symfony\Component\EventDispatcher\Debug\TraceableEventDispatcher->dispatch()
     (/home/benedict/dev/contao-managed/vendor/symfony/http-kernel/HttpKernel.php:185)
  at Symfony\Component\HttpKernel\HttpKernel->filterResponse()
     (/home/benedict/dev/contao-managed/vendor/symfony/http-kernel/HttpKernel.php:173)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw()
     (/home/benedict/dev/contao-managed/vendor/symfony/http-kernel/HttpKernel.php:74)
  at Symfony\Component\HttpKernel\HttpKernel->handle()
     (/home/benedict/dev/contao-managed/vendor/symfony/http-kernel/EventListener/ErrorListener.php:85)
  at Symfony\Component\HttpKernel\EventListener\ErrorListener->onKernelException()
     (/home/benedict/dev/contao-managed/vendor/symfony/event-dispatcher/Debug/WrappedListener.php:117)
  at Symfony\Component\EventDispatcher\Debug\WrappedListener->__invoke()
     (/home/benedict/dev/contao-managed/vendor/symfony/event-dispatcher/EventDispatcher.php:230)
  at Symfony\Component\EventDispatcher\EventDispatcher->callListeners()
     (/home/benedict/dev/contao-managed/vendor/symfony/event-dispatcher/EventDispatcher.php:59)
  at Symfony\Component\EventDispatcher\EventDispatcher->dispatch()
     (/home/benedict/dev/contao-managed/vendor/symfony/event-dispatcher/Debug/TraceableEventDispatcher.php:154)
  at Symfony\Component\EventDispatcher\Debug\TraceableEventDispatcher->dispatch()
     (/home/benedict/dev/contao-managed/vendor/symfony/http-kernel/HttpKernel.php:213)
  at Symfony\Component\HttpKernel\HttpKernel->handleThrowable()
     (/home/benedict/dev/contao-managed/vendor/symfony/http-kernel/HttpKernel.php:106)
  at Symfony\Component\HttpKernel\HttpKernel->terminateWithException()
     (/home/benedict/dev/contao-managed/vendor/symfony/http-kernel/EventListener/DebugHandlersListener.php:131)
  at Symfony\Component\HttpKernel\EventListener\DebugHandlersListener::Symfony\Component\HttpKernel\EventListener\{closure}()
     (/home/benedict/dev/contao-managed/vendor/symfony/error-handler/ErrorHandler.php:607)
  at Symfony\Component\ErrorHandler\ErrorHandler->handleException()
```