### PR TITLE
Harden against invalid input

### DIFF
--- a/calendar-bundle/src/Resources/contao/modules/ModuleEventlist.php
+++ b/calendar-bundle/src/Resources/contao/modules/ModuleEventlist.php
@@ -11,6 +11,7 @@
 namespace Contao;
 
 use Contao\CoreBundle\Exception\PageNotFoundException;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
 /**
  * Front end module "event list".
@@ -98,6 +99,11 @@ class ModuleEventlist extends Events
 		$intYear = Input::get('year');
 		$intMonth = Input::get('month');
 		$intDay = Input::get('day');
+
+		if (\is_array($intYear) || \is_array($intMonth) || \is_array($intDay))
+		{
+			throw new BadRequestHttpException('Expected string, got array');
+		}
 
 		// Handle featured events
 		$blnFeatured = null;

--- a/calendar-bundle/src/Resources/contao/modules/ModuleEventlist.php
+++ b/calendar-bundle/src/Resources/contao/modules/ModuleEventlist.php
@@ -11,7 +11,6 @@
 namespace Contao;
 
 use Contao\CoreBundle\Exception\PageNotFoundException;
-use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
 /**
  * Front end module "event list".
@@ -96,14 +95,9 @@ class ModuleEventlist extends Events
 
 		$blnClearInput = false;
 
-		$intYear = Input::get('year');
-		$intMonth = Input::get('month');
-		$intDay = Input::get('day');
-
-		if (\is_array($intYear) || \is_array($intMonth) || \is_array($intDay))
-		{
-			throw new BadRequestHttpException('Expected string, got array');
-		}
+		$intYear = (int) Input::get('year');
+		$intMonth = (int) Input::get('month');
+		$intDay = (int) Input::get('day');
 
 		// Handle featured events
 		$blnFeatured = null;

--- a/core-bundle/src/EventListener/RequestTokenListener.php
+++ b/core-bundle/src/EventListener/RequestTokenListener.php
@@ -17,10 +17,8 @@ use Contao\CoreBundle\Csrf\ContaoCsrfTokenManager;
 use Contao\CoreBundle\Exception\InvalidRequestTokenException;
 use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\CoreBundle\Routing\ScopeMatcher;
-use Contao\Validator;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
-use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\Security\Csrf\CsrfToken;
 
 /**

--- a/core-bundle/src/EventListener/RequestTokenListener.php
+++ b/core-bundle/src/EventListener/RequestTokenListener.php
@@ -95,13 +95,7 @@ class RequestTokenListener
             }
         }
 
-        $value = $this->getTokenFromRequest($request);
-
-        if (Validator::isInsecurePath($value)) {
-            throw new BadRequestHttpException('Invalid CSRF token');
-        }
-
-        $token = new CsrfToken($this->csrfTokenName, $value);
+        $token = new CsrfToken($this->csrfTokenName, $this->getTokenFromRequest($request));
 
         if ($this->csrfTokenManager->isTokenValid($token)) {
             return;

--- a/core-bundle/src/EventListener/RequestTokenListener.php
+++ b/core-bundle/src/EventListener/RequestTokenListener.php
@@ -17,8 +17,10 @@ use Contao\CoreBundle\Csrf\ContaoCsrfTokenManager;
 use Contao\CoreBundle\Exception\InvalidRequestTokenException;
 use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\CoreBundle\Routing\ScopeMatcher;
+use Contao\Validator;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\Security\Csrf\CsrfToken;
 
 /**
@@ -93,7 +95,13 @@ class RequestTokenListener
             }
         }
 
-        $token = new CsrfToken($this->csrfTokenName, $this->getTokenFromRequest($request));
+        $value = $this->getTokenFromRequest($request);
+
+        if (Validator::isInsecurePath($value)) {
+            throw new BadRequestHttpException('Invalid CSRF token');
+        }
+
+        $token = new CsrfToken($this->csrfTokenName, $value);
 
         if ($this->csrfTokenManager->isTokenValid($token)) {
             return;

--- a/core-bundle/src/Resources/contao/modules/ModuleSearch.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleSearch.php
@@ -13,6 +13,7 @@ namespace Contao;
 use Contao\CoreBundle\Exception\PageNotFoundException;
 use Contao\CoreBundle\File\Metadata;
 use Contao\CoreBundle\Security\ContaoCorePermissions;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
 /**
  * Front end module "search".
@@ -73,6 +74,12 @@ class ModuleSearch extends Module
 
 		$blnFuzzy = $this->fuzzy;
 		$strQueryType = Input::get('query_type') ?: $this->queryType;
+
+		if (\is_array(Input::get('keywords')))
+		{
+			throw new BadRequestHttpException('Expected string, got array');
+		}
+
 		$strKeywords = trim(Input::get('keywords'));
 
 		$this->Template->uniqueId = $this->id;

--- a/core-bundle/tests/EventListener/RequestTokenListenerTest.php
+++ b/core-bundle/tests/EventListener/RequestTokenListenerTest.php
@@ -23,7 +23,6 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
-use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\Security\Csrf\TokenGenerator\UriSafeTokenGenerator;
 use Symfony\Component\Security\Csrf\TokenStorage\TokenStorageInterface;
 
@@ -163,45 +162,6 @@ class RequestTokenListenerTest extends TestCase
         $listener = new RequestTokenListener($framework, $scopeMatcher, $csrfTokenManager, 'contao_csrf_token');
 
         $this->expectException(InvalidRequestTokenException::class);
-        $this->expectExceptionMessage('Invalid CSRF token');
-
-        $listener($event);
-    }
-
-    public function testFailsIfTheRequestTokenIsAnInsecurePath(): void
-    {
-        $config = $this->mockConfiguredAdapter(['get' => false]);
-        $framework = $this->mockContaoFramework([Config::class => $config]);
-        $scopeMatcher = $this->createMock(ScopeMatcher::class);
-
-        $csrfTokenManager = $this->createMock(ContaoCsrfTokenManager::class);
-        $csrfTokenManager
-            ->expects($this->never())
-            ->method('isTokenValid')
-        ;
-
-        $request = Request::create('/account.html');
-        $request->setMethod('POST');
-        $request->request->set('REQUEST_TOKEN', '../1');
-        $request->attributes->set('_token_check', true);
-        $request->cookies = new InputBag(['unrelated-cookie' => 'to-activate-csrf']);
-
-        $event = $this->createMock(RequestEvent::class);
-        $event
-            ->expects($this->once())
-            ->method('getRequest')
-            ->willReturn($request)
-        ;
-
-        $event
-            ->expects($this->once())
-            ->method('isMainRequest')
-            ->willReturn(true)
-        ;
-
-        $listener = new RequestTokenListener($framework, $scopeMatcher, $csrfTokenManager, 'contao_csrf_token');
-
-        $this->expectException(BadRequestHttpException::class);
         $this->expectExceptionMessage('Invalid CSRF token');
 
         $listener($event);

--- a/news-bundle/src/Resources/contao/modules/ModuleNewsArchive.php
+++ b/news-bundle/src/Resources/contao/modules/ModuleNewsArchive.php
@@ -11,6 +11,7 @@
 namespace Contao;
 
 use Contao\CoreBundle\Exception\PageNotFoundException;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
 /**
  * Front end module "news archive".
@@ -96,6 +97,11 @@ class ModuleNewsArchive extends ModuleNews
 		$intYear = Input::get('year');
 		$intMonth = Input::get('month');
 		$intDay = Input::get('day');
+
+		if (\is_array($intYear) || \is_array($intMonth) || \is_array($intDay))
+		{
+			throw new BadRequestHttpException('Expected string, got array');
+		}
 
 		// Jump to the current period
 		if (!isset($_GET['year']) && !isset($_GET['month']) && !isset($_GET['day']) && $this->news_jumpToCurrent != 'all_items')

--- a/news-bundle/src/Resources/contao/modules/ModuleNewsArchive.php
+++ b/news-bundle/src/Resources/contao/modules/ModuleNewsArchive.php
@@ -11,7 +11,6 @@
 namespace Contao;
 
 use Contao\CoreBundle\Exception\PageNotFoundException;
-use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
 /**
  * Front end module "news archive".
@@ -94,14 +93,9 @@ class ModuleNewsArchive extends ModuleNews
 		$intBegin = 0;
 		$intEnd = 0;
 
-		$intYear = Input::get('year');
-		$intMonth = Input::get('month');
-		$intDay = Input::get('day');
-
-		if (\is_array($intYear) || \is_array($intMonth) || \is_array($intDay))
-		{
-			throw new BadRequestHttpException('Expected string, got array');
-		}
+		$intYear = (int) Input::get('year');
+		$intMonth = (int) Input::get('month');
+		$intDay = (int) Input::get('day');
 
 		// Jump to the current period
 		if (!isset($_GET['year']) && !isset($_GET['month']) && !isset($_GET['day']) && $this->news_jumpToCurrent != 'all_items')


### PR DESCRIPTION
The changes are based on my Sentry reports. As far as I see, they have been triggered by some security research tool.

All of the requests were caught by the error handler, mostly because they triggered PHP type errors such as:

* A non-numeric value encountered
* Warning: substr() expects parameter 1 to be string, array given
* Warning: preg_match() expects parameter 2 to be string, array given

So actually, we do not have to handle these cases at all because they will trigger the error handler one way or another. But maybe a `BadRequestHttpException` is better than some unspecific `TypeError` or `ErrorException`?
