### PR TITLE
Increase the tl_comments_notify.url length

### DIFF
--- a/comments-bundle/src/Resources/contao/classes/Comments.php
+++ b/comments-bundle/src/Resources/contao/classes/Comments.php
@@ -12,6 +12,7 @@ namespace Contao;
 
 use Contao\CoreBundle\Exception\PageNotFoundException;
 use Contao\CoreBundle\OptIn\OptIn;
+use Nyholm\Psr7\Uri;
 
 /**
  * Class Comments
@@ -558,6 +559,9 @@ class Comments extends Frontend
 
 		$time = time();
 
+		// Make sure the request URL does not contain non-ascii characters (see #4708)
+		$request = (string) (new Uri(Environment::get('request')));
+
 		// Prepare the record
 		$arrSet = array
 		(
@@ -566,7 +570,7 @@ class Comments extends Frontend
 			'parent'       => $objComment->parent,
 			'name'         => $objComment->name,
 			'email'        => $objComment->email,
-			'url'          => Environment::get('request'),
+			'url'          => $request,
 			'addedOn'      => $time,
 			'active'       => '',
 			'tokenRemove'  => 'cor-' . bin2hex(random_bytes(10))
@@ -576,7 +580,7 @@ class Comments extends Frontend
 		$objNotify = new CommentsNotifyModel();
 		$objNotify->setRow($arrSet)->save();
 
-		$strUrl = Idna::decode(Environment::get('base')) . Environment::get('request');
+		$strUrl = Idna::decode(Environment::get('base')) . $request;
 		$strConnector = (strpos($strUrl, '?') !== false) ? '&' : '?';
 
 		/** @var OptIn $optIn */

--- a/comments-bundle/src/Resources/contao/classes/Comments.php
+++ b/comments-bundle/src/Resources/contao/classes/Comments.php
@@ -559,7 +559,7 @@ class Comments extends Frontend
 
 		$time = time();
 
-		// Make sure the request URL does not contain non-ascii characters (see #4708)
+		// Ensure that the URL only contains ASCII characters (see #4708)
 		$request = (string) (new Uri(Environment::get('request')));
 
 		// Prepare the record

--- a/comments-bundle/src/Resources/contao/dca/tl_comments_notify.php
+++ b/comments-bundle/src/Resources/contao/dca/tl_comments_notify.php
@@ -56,7 +56,7 @@ $GLOBALS['TL_DCA']['tl_comments_notify'] = array
 		),
 		'url' => array
 		(
-			'sql'                     => "varchar(255) NOT NULL default ''"
+			'sql'                     => "varchar(2048) COLLATE ascii_bin NOT NULL default ''"
 		),
 		'addedOn' => array
 		(

--- a/core-bundle/src/Resources/contao/library/Contao/Search.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Search.php
@@ -11,6 +11,7 @@
 namespace Contao;
 
 use Contao\Database\Result;
+use Nyholm\Psr7\Uri;
 
 /**
  * Creates and queries the search index
@@ -59,14 +60,7 @@ class Search
 		$arrSet['language'] = $arrData['language'];
 
 		// Ensure that the URL only contains ASCII characters (see #4260)
-		$arrSet['url'] = preg_replace_callback(
-			'/[\x80-\xFF]+/',
-			static function ($match)
-			{
-				return rawurlencode($match[0]);
-			},
-			$arrData['url']
-		);
+		$arrSet['url'] = (string) (new Uri($arrData['url']));
 
 		// Get the file size from the raw content
 		if (!$arrSet['filesize'])


### PR DESCRIPTION
Similar to `tl_search.url` the following error can occur when subscribing to comments:

```
Doctrine\DBAL\Exception\DriverException:
An exception occurred while executing 'INSERT INTO tl_comments_notify (`tstamp`, `source`, `parent`, `name`, `email`, `url`, `addedOn`, `active`, `tokenRemove`) VALUES (1653216741, 'tl_news', 324, 'TEST', 'foobar@example.com', 'news/article/news-with-long-headline-news-with-long-headline-news-with-long-headline-news-with-long-headline-news-with-long-headline-news-with-long-headline-news-with-long-headline-news-with-long-headline-news-with-long-headline-news-with-long-headline-news-with-long', 1653216741, '', 'cor-86c865dfa67ad5f886f3')':

SQLSTATE[22001]: String data, right truncated: 1406 Data too long for column 'url' at row 1
```

This PR increases the `tl_comments_notify.url` length, in line with `tl_content.url` and `tl_search.url`.

_Note:_ no automatic length adjustment is required here, as there is no index on this field.
