### PR TITLE
Correctly support legacy DC names in picker provider

### DIFF
--- a/core-bundle/src/Picker/AbstractTablePickerProvider.php
+++ b/core-bundle/src/Picker/AbstractTablePickerProvider.php
@@ -137,9 +137,10 @@ abstract class AbstractTablePickerProvider implements PickerProviderInterface, D
         $this->framework->initialize();
         $this->framework->createInstance(DcaLoader::class, [$table])->load();
 
-        return ($this->getDataContainer() === DataContainer::getDriverForTable($table)
-                || $this->getDataContainer() === $GLOBALS['TL_DCA'][$table]['config']['dataContainer']
-            ) && 0 !== \count($this->getModulesForTable($table));
+        $dcName = $this->getDataContainer();
+
+        return ($dcName === DataContainer::getDriverForTable($table) || $dcName === $GLOBALS['TL_DCA'][$table]['config']['dataContainer'])
+            && 0 !== \count($this->getModulesForTable($table));
     }
 
     public function supportsValue(PickerConfig $config): bool

--- a/core-bundle/src/Picker/AbstractTablePickerProvider.php
+++ b/core-bundle/src/Picker/AbstractTablePickerProvider.php
@@ -137,8 +137,9 @@ abstract class AbstractTablePickerProvider implements PickerProviderInterface, D
         $this->framework->initialize();
         $this->framework->createInstance(DcaLoader::class, [$table])->load();
 
-        return $this->getDataContainer() === DataContainer::getDriverForTable($table)
-            && 0 !== \count($this->getModulesForTable($table));
+        return ($this->getDataContainer() === DataContainer::getDriverForTable($table)
+                || $this->getDataContainer() === $GLOBALS['TL_DCA'][$table]['config']['dataContainer']
+            ) && 0 !== \count($this->getModulesForTable($table));
     }
 
     public function supportsValue(PickerConfig $config): bool


### PR DESCRIPTION
The changes in https://github.com/contao/contao/pull/4481 lead to breaking support for DCA and picker with the legacy name.

FYI we don't need to trigger a deprecation for comparing the old name, because calling `DataContainer::getDriverForTable` already does that.