### PR TITLE
Also override Return-Path and Sender address

### DIFF
--- a/core-bundle/src/Mailer/ContaoMailer.php
+++ b/core-bundle/src/Mailer/ContaoMailer.php
@@ -107,7 +107,7 @@ final class ContaoMailer implements MailerInterface
 
         $message->from($from);
 
-        // Also override 'Return-Path' and 'Sender', if set
+        // Also override 'Return-Path' and 'Sender', if set (see #4712)
         if (null !== $message->getReturnPath()) {
             $message->returnPath($from);
         }

--- a/core-bundle/src/Mailer/ContaoMailer.php
+++ b/core-bundle/src/Mailer/ContaoMailer.php
@@ -107,7 +107,7 @@ final class ContaoMailer implements MailerInterface
 
         $message->from($from);
 
-        // Also override 'Return-Path' and 'Sender', if set (see #4712)
+        // Also override "Return-Path" and "Sender" if set (see #4712)
         if (null !== $message->getReturnPath()) {
             $message->returnPath($from);
         }

--- a/core-bundle/src/Mailer/ContaoMailer.php
+++ b/core-bundle/src/Mailer/ContaoMailer.php
@@ -106,5 +106,14 @@ final class ContaoMailer implements MailerInterface
         }
 
         $message->from($from);
+
+        // Also override 'Return-Path' and 'Sender', if set
+        if (null !== $message->getReturnPath()) {
+            $message->returnPath($from);
+        }
+
+        if (null !== $message->getSender()) {
+            $message->sender($from);
+        }
     }
 }

--- a/core-bundle/tests/Mailer/ContaoMailerTest.php
+++ b/core-bundle/tests/Mailer/ContaoMailerTest.php
@@ -46,9 +46,9 @@ class ContaoMailerTest extends TestCase
         $availableTransports = new AvailableTransports();
         $availableTransports->addTransport(new TransportConfig('foobar', 'Lorem Ipsum <foo@example.org>'));
 
-        $contaoMailer = new ContaoMailer($mailer, $availableTransports, $requestStack);
-
         $email = new Email();
+
+        $contaoMailer = new ContaoMailer($mailer, $availableTransports, $requestStack);
         $contaoMailer->send($email);
 
         $this->assertTrue($email->getHeaders()->has('X-Transport'));
@@ -63,9 +63,9 @@ class ContaoMailerTest extends TestCase
         $availableTransports = new AvailableTransports();
         $availableTransports->addTransport(new TransportConfig('foobar', 'Lorem Ipsum <foo@example.org>'));
 
-        $contaoMailer = new ContaoMailer($mailer, $availableTransports, new RequestStack());
-
         $email = new Email(new Headers(new UnstructuredHeader('X-Transport', 'foobar')));
+
+        $contaoMailer = new ContaoMailer($mailer, $availableTransports, new RequestStack());
         $contaoMailer->send($email);
 
         $from = $email->getFrom();
@@ -85,12 +85,11 @@ class ContaoMailerTest extends TestCase
         $availableTransports = new AvailableTransports();
         $availableTransports->addTransport(new TransportConfig('foobar', 'Lorem Ipsum <foo@example.org>'));
 
-        $contaoMailer = new ContaoMailer($mailer, $availableTransports, new RequestStack());
-
         $email = new Email(new Headers(new UnstructuredHeader('X-Transport', 'foobar')));
         $email->returnPath('return-path@example.com');
         $email->sender('sender@example.com');
 
+        $contaoMailer = new ContaoMailer($mailer, $availableTransports, new RequestStack());
         $contaoMailer->send($email);
 
         $from = $email->getFrom();
@@ -111,7 +110,6 @@ class ContaoMailerTest extends TestCase
         $availableTransports->addTransport(new TransportConfig('foobar', 'Lorem Ipsum <foo@example.org>'));
 
         $email = new Email(new Headers(new UnstructuredHeader('X-Transport', 'foobar')));
-
         $envelope = new Envelope(Address::create('envelope-sender@example.com'), [Address::create('envelope-recipient@example.com')]);
 
         $contaoMailer = new ContaoMailer($mailer, $availableTransports, new RequestStack());


### PR DESCRIPTION
Fixes #4712

`Contao\Email` also sets the `Return-Path` to the administrator email address (see https://github.com/contao/core/issues/5004). This will cause the `From` and `Return-Path` header to diverge when using a custom mailer transport with an override for `From`, evidently causing issues for some mail servers (see #4712).

This PR fixes that by also overriding the `Return-Path` (and also `Sender`) headers, if set. This fix has been verified by @contaoacademy