### PR TITLE
Correctly handle index pages without URL prefix

### DIFF
--- a/core-bundle/src/Routing/AbstractPageRouteProvider.php
+++ b/core-bundle/src/Routing/AbstractPageRouteProvider.php
@@ -135,7 +135,7 @@ abstract class AbstractPageRouteProvider implements RouteProviderInterface
             $langA = $this->getLocalePriority($fallbackA, $fallbackB, $languages);
             $langB = $this->getLocalePriority($fallbackB, $fallbackA, $languages);
 
-            if (null === $langA && null === $langB && LocaleUtil::getPrimaryLanguage($pageA->rootLanguage) === \Locale::getPrimaryLanguage($pageB->rootLanguage)) {
+            if (null === $langA && null === $langB && LocaleUtil::getPrimaryLanguage($pageA->rootLanguage) === LocaleUtil::getPrimaryLanguage($pageB->rootLanguage)) {
                 // If both pages have the same language without region and neither region has a priority,
                 // (e.g. user prefers "de" but we have "de-CH" and "de-DE"), sort by their root page order.
                 $langA = $pageA->rootSorting;

--- a/core-bundle/src/Routing/Matcher/LanguageFilter.php
+++ b/core-bundle/src/Routing/Matcher/LanguageFilter.php
@@ -42,7 +42,7 @@ class LanguageFilter implements RouteFilterInterface
                 continue;
             }
 
-            if ('.fallback' !== substr($name, -9) && ('' !== $pageModel->urlPrefix || '.root' !== substr($name, -5))) {
+            if ('.fallback' !== substr($name, -9) && ('' !== $pageModel->urlPrefix || '.root' !== substr($name, -5) || '/' === $route->getPath())) {
                 continue;
             }
 

--- a/core-bundle/src/Routing/RouteProvider.php
+++ b/core-bundle/src/Routing/RouteProvider.php
@@ -259,6 +259,14 @@ class RouteProvider extends AbstractPageRouteProvider
                     return -1;
                 }
 
+                if ('/' === $a->getPath() && '/' !== $b->getPath()) {
+                    return -1;
+                }
+
+                if ('/' === $b->getPath() && '/' !== $a->getPath()) {
+                    return 1;
+                }
+
                 return $this->compareRoutes($a, $b, $languages);
             }
         );

--- a/core-bundle/tests/Fixtures/Functional/Routing/url-prefix-mix.yml
+++ b/core-bundle/tests/Fixtures/Functional/Routing/url-prefix-mix.yml
@@ -1,0 +1,68 @@
+tl_page:
+    - id: 1
+      pid: 0
+      sorting: 128
+      tstamp: 1550250933
+      title: English root
+      alias: english-root
+      urlPrefix: en
+      urlSuffix: .html
+      type: root
+      language: en
+      dns: example.local
+      fallback: '1'
+      includeLayout: '1'
+      layout: 1
+      published: '1'
+
+    - id: 2
+      pid: 1
+      sorting: 128
+      tstamp: 1539698035
+      title: English site
+      alias: index
+      type: regular
+      published: '1'
+
+    - id: 3
+      pid: 1
+      sorting: 256
+      tstamp: 1539698035
+      title: English 404
+      alias: error404
+      type: error_404
+      published: '1'
+
+    - id: 4
+      pid: 0
+      sorting: 256
+      tstamp: 1539696285
+      title: Dutch root
+      alias: dutch-root
+      urlPrefix: ''
+      urlSuffix: .html
+      type: root
+      language: nl
+      dns: example.local
+      fallback: ''
+      includeLayout: '1'
+      layout: 1
+      published: '1'
+
+    - id: 5
+      pid: 4
+      sorting: 128
+      tstamp: 1539698035
+      title: Dutch site
+      alias: index
+      type: regular
+      published: '1'
+
+    - id: 6
+      pid: 4
+      sorting: 256
+      tstamp: 1539698035
+      title: Dutch 404
+      alias: error404
+      type: error_404
+      published: '1'

--- a/core-bundle/tests/Functional/RoutingTest.php
+++ b/core-bundle/tests/Functional/RoutingTest.php
@@ -1005,15 +1005,6 @@ class RoutingTest extends FunctionalTestCase
             '127.0.0.1:8080',
         ];
 
-        yield 'Renders the 404 exception if no language matches' => [
-            ['theme', 'root-without-fallback-language'],
-            '/',
-            404,
-            'Not Found',
-            'de,fr',
-            'root-without-fallback-language.local',
-        ];
-
         yield 'Redirects to the first language root if the accept languages matches' => [
             ['theme', 'same-domain-root'],
             '/',
@@ -1359,6 +1350,74 @@ class RoutingTest extends FunctionalTestCase
 
         $this->assertSame(401, $response->getStatusCode());
         $this->assertStringContainsString('Error 401 Page', $title);
+    }
+
+    /**
+     * @dataProvider getUrlPrefixMixProvider
+     */
+    public function testUrlPrefixMix(string $request, string $acceptLanguage, int $statusCode, string $pageTitle): void
+    {
+        $_SERVER['REQUEST_URI'] = $request;
+        $_SERVER['HTTP_HOST'] = 'example.local';
+        $_SERVER['HTTP_ACCEPT_LANGUAGE'] = $acceptLanguage;
+        $_SERVER['HTTP_ACCEPT'] = 'text/html';
+
+        $client = $this->createClient([], $_SERVER);
+        System::setContainer($client->getContainer());
+
+        $this->loadFixtureFiles(['theme', 'url-prefix-mix']);
+
+        $crawler = $client->request('GET', "https://example.local$request");
+        $title = trim($crawler->filterXPath('//head/title')->text());
+        $response = $client->getResponse();
+
+        $this->assertSame($statusCode, $response->getStatusCode());
+        $this->assertStringContainsString($pageTitle, $title);
+    }
+
+    public function getUrlPrefixMixProvider(): \Generator
+    {
+        yield 'Renders the index page of supported accept language' => [
+            '/',
+            'nl',
+            200,
+            'Dutch site',
+        ];
+
+        yield 'Renders the index page of root with url prefix' => [
+            '/en/',
+            'en',
+            200,
+            'English site',
+        ];
+
+        yield 'Renders the index page of root without url prefix' => [
+            '/',
+            'en',
+            200,
+            'Dutch site',
+        ];
+
+        yield 'Renders the english 404 with "en" accept language' => [
+            '/nl/',
+            'en',
+            404,
+            'English 404 - English root',
+        ];
+
+        yield 'Renders the dutch 404 with "nl" accept language' => [
+            '/nl/',
+            'nl',
+            404,
+            'Dutch 404 - Dutch root',
+        ];
+
+        yield 'Renders the fallback root 404 on invalid prefix with unsupported accept language' => [
+            '/nl/',
+            'fr',
+            404,
+            'English 404 - English root',
+        ];
     }
 
     private function loadFixtureFiles(array $fileNames): void


### PR DESCRIPTION
Fixes https://github.com/contao/contao/issues/4104 which explains the issue pretty well.

One test failed and was removed because it was incorrect. If a root has no URL prefix and an `index` page exists, we should correctly _show_ that because because `/` is its "actual" url. We must not redirect though if there is a URL prefix, which is still tested for (also see https://github.com/contao/contao/pull/435).