### PR TITLE
Fix DBAFS when upload_path contains subfolders

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Dbafs.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Dbafs.php
@@ -97,7 +97,7 @@ class Dbafs
 		{
 			$strPath .= '/' . array_shift($arrChunks);
 
-			// Skip paths outside the upload_path
+			// Skip paths outside the upload_path (see #4718)
 			if ($strPath === $uploadPath || !Path::isBasePath($uploadPath, $strPath))
 			{
 				continue;
@@ -468,7 +468,7 @@ class Dbafs
 			{
 				$strPath .= '/' . array_shift($arrChunks);
 
-				// Skip paths outside the upload_path
+				// Skip paths outside the upload_path (see #4718)
 				if ($strPath === $uploadPath || !Path::isBasePath($uploadPath, $strPath))
 				{
 					continue;

--- a/core-bundle/src/Resources/contao/library/Contao/Dbafs.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Dbafs.php
@@ -86,8 +86,8 @@ class Dbafs
 		}
 
 		$arrPaths    = array();
-		$arrChunks   = explode('/', $strResource);
-		$strPath     = array_shift($arrChunks);
+		$arrChunks   = array_filter(explode('/', Path::makeRelative($strResource, $uploadPath)));
+		$strPath     = $uploadPath;
 		$arrPids     = array($strPath => null);
 		$arrUpdate   = array($strResource);
 		$objDatabase = Database::getInstance();
@@ -96,13 +96,6 @@ class Dbafs
 		while (\count($arrChunks))
 		{
 			$strPath .= '/' . array_shift($arrChunks);
-
-			// Skip paths outside the upload_path (see #4718)
-			if ($strPath === $uploadPath || !Path::isBasePath($uploadPath, $strPath))
-			{
-				continue;
-			}
-
 			$arrPaths[] = $strPath;
 		}
 
@@ -454,8 +447,8 @@ class Dbafs
 			self::validateUtf8Path($strResource);
 
 			$strResource = Path::normalize($strResource);
-			$arrChunks   = explode('/', $strResource);
-			$strPath     = array_shift($arrChunks);
+			$arrChunks   = array_filter(explode('/', Path::makeRelative($strResource, $uploadPath)));
+			$strPath     = $uploadPath;
 
 			// Do not check files
 			if (is_file($projectDir . '/' . $strResource))
@@ -467,13 +460,6 @@ class Dbafs
 			while (\count($arrChunks))
 			{
 				$strPath .= '/' . array_shift($arrChunks);
-
-				// Skip paths outside the upload_path (see #4718)
-				if ($strPath === $uploadPath || !Path::isBasePath($uploadPath, $strPath))
-				{
-					continue;
-				}
-
 				$arrPaths[] = $strPath;
 			}
 


### PR DESCRIPTION
If your `contao.upload_path` contains additional subfolders, e.g. `media/files/foobar` the following error will occur when uploading a file in the back end for example:

```
InvalidArgumentException: "Invalid resource media/files/foobar" at vendor/contao/core-bundle/src/Resources/contao/library/Contao/Dbafs.php line 65
```

This is because the current DBAFS implementation simply explodes the path and then tries to add all path components to the DBAFS - which will be invalid for paths equal and above to `contao.upload_path`.

This PR fixes that by introducing additional checks whether the traversed path still lies somewhere under `contao.upload_path`.

@m-vo does this need additional handling in Contao 4.13 as well?