### PR TITLE
Fix the PHP 8 warning if a $_SERVER variable does not exist

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Environment.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Environment.php
@@ -63,7 +63,7 @@ class Environment
 		{
 			$arrChunks = preg_split('/([A-Z][a-z]*)/', $strKey, -1, PREG_SPLIT_DELIM_CAPTURE|PREG_SPLIT_NO_EMPTY);
 			$strServerKey = strtoupper(implode('_', $arrChunks));
-			static::$arrCache[$strKey] = $_SERVER[$strServerKey];
+			static::$arrCache[$strKey] = $_SERVER[$strServerKey] ?? null;
 		}
 
 		return static::$arrCache[$strKey];


### PR DESCRIPTION
Some extensions use `\Contao\Environment::get()` method to fetch custom `$_SERVER` variables: https://github.com/terminal42/contao-ajaxform/blob/main/AjaxForm.php#L43

This can lead to PHP 8 warnings as follows:

<img width="1254" alt="CleanShot 2022-05-24 at 10 59 42" src="https://user-images.githubusercontent.com/193483/169993297-60028c72-8da6-4ff8-9af1-29e3b059070e.png">

I am not sure if it's a real bug in Contao core though, or if we should change it in the extension. 