### PR TITLE
Fix DBAFS when upload_path contains subfolders

### DIFF
--- a/core-bundle/src/DependencyInjection/Compiler/ConfigureFilesystemPass.php
+++ b/core-bundle/src/DependencyInjection/Compiler/ConfigureFilesystemPass.php
@@ -55,7 +55,7 @@ class ConfigureFilesystemPass implements CompilerPassInterface
         $projectDir = $parameterBag->resolveValue($parameterBag->get('kernel.project_dir'));
         $uploadDir = $parameterBag->resolveValue($parameterBag->get('contao.upload_path'));
 
-        $finder = (new Finder())->in($projectDir)->directories()->path("/^$uploadDir/");
+        $finder = (new Finder())->in($projectDir)->directories()->path('/^'.preg_quote($uploadDir, '/').'/');
 
         foreach ($finder as $item) {
             if (!$item->isLink()) {

--- a/core-bundle/src/Resources/contao/library/Contao/Dbafs.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Dbafs.php
@@ -47,8 +47,8 @@ class Dbafs
 	{
 		self::validateUtf8Path($strResource);
 
-		$strUploadPath = System::getContainer()->getParameter('contao.upload_path') . '/';
-		$projectDir = System::getContainer()->getParameter('kernel.project_dir');
+		$uploadPath = Path::normalize(System::getContainer()->getParameter('contao.upload_path'));
+		$projectDir = Path::normalize(System::getContainer()->getParameter('kernel.project_dir'));
 
 		// Remove trailing slashes (see #5707)
 		if (substr($strResource, -1) == '/')
@@ -60,7 +60,7 @@ class Dbafs
 		$strResource = str_replace(array('\\', '//'), '/', $strResource);
 
 		// The resource does not exist or lies outside the upload directory
-		if (!$strResource || !file_exists($projectDir . '/' . $strResource) || strncmp($strResource, $strUploadPath, \strlen($strUploadPath)) !== 0)
+		if (!$strResource || !file_exists($projectDir . '/' . $strResource) || !Path::isBasePath($uploadPath, $strResource))
 		{
 			throw new \InvalidArgumentException("Invalid resource $strResource");
 		}
@@ -84,8 +84,8 @@ class Dbafs
 		}
 
 		$arrPaths    = array();
-		$arrChunks   = explode('/', $strResource);
-		$strPath     = array_shift($arrChunks);
+		$arrChunks   = array_filter(explode('/', Path::makeRelative($strResource, $uploadPath)));
+		$strPath     = $uploadPath;
 		$arrPids     = array($strPath => null);
 		$arrUpdate   = array($strResource);
 		$objDatabase = Database::getInstance();
@@ -437,14 +437,16 @@ class Dbafs
 			$varResource = array($varResource);
 		}
 
-		$projectDir = System::getContainer()->getParameter('kernel.project_dir');
+		$projectDir = Path::normalize(System::getContainer()->getParameter('kernel.project_dir'));
+		$uploadPath = Path::normalize(System::getContainer()->getParameter('contao.upload_path'));
 
 		foreach ($varResource as $strResource)
 		{
 			self::validateUtf8Path($strResource);
 
-			$arrChunks = explode('/', $strResource);
-			$strPath   = array_shift($arrChunks);
+			$strResource = Path::normalize($strResource);
+			$arrChunks   = array_filter(explode('/', Path::makeRelative($strResource, $uploadPath)));
+			$strPath     = $uploadPath;
 
 			// Do not check files
 			if (is_file($projectDir . '/' . $strResource))


### PR DESCRIPTION
This fixes #4718 for Contao 4.13. There is an additional change necessary in `ConfigureFilesystemPass` as the regex there will fail since `/` is used as a delimiter and `upload_path` can contain `/`.