### PR TITLE
Fix a potential PHP 8 warning in the sitemap module

### DIFF
--- a/core-bundle/src/Resources/contao/modules/ModuleSitemap.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleSitemap.php
@@ -67,8 +67,11 @@ class ModuleSitemap extends Module
 		{
 			$objRootPage = PageModel::findWithDetails($this->rootPage);
 
-			$lang = $objRootPage->rootLanguage;
-			$host = $objRootPage->domain;
+			if ($objRootPage !== null)
+			{
+				$lang = $objRootPage->rootLanguage;
+				$host = $objRootPage->domain;
+			}
 		}
 
 		$this->showLevel = 0;


### PR DESCRIPTION
I don't know under what circumstances it can actually happen, but it may happen:

<img width="1236" alt="CleanShot 2022-05-25 at 16 18 45" src="https://user-images.githubusercontent.com/193483/170284410-ecee481a-c0d2-4d6a-9909-0a5f24f188af.png">
<img width="1245" alt="CleanShot 2022-05-25 at 16 18 15" src="https://user-images.githubusercontent.com/193483/170284417-599fe649-0291-4b20-bf54-e0ce1a3b16db.png">

