### PR TITLE
Undeprecate reload…tree ajax post actions

### DIFF
--- a/core-bundle/src/Resources/contao/classes/Ajax.php
+++ b/core-bundle/src/Resources/contao/classes/Ajax.php
@@ -353,12 +353,20 @@ class Ajax extends Backend
 
 				// Set the new value
 				$varValue = Input::post('value', true);
-				$strKey = match ($this->strAction)
+
+				switch ($this->strAction)
 				{
-					'reloadPicker' => 'picker',
-					'reloadPagetree' => 'pageTree',
-					'reloadFiletree' => 'fileTree',
-				};
+					case 'reloadPicker':
+						$strKey = 'picker';
+						break;
+
+					case 'reloadPagetree':
+						$strKey = 'pageTree';
+						break;
+
+					default:
+						$strKey = 'fileTree';
+				}
 
 				// Convert the selected values
 				if ($varValue)

--- a/core-bundle/src/Resources/contao/classes/Ajax.php
+++ b/core-bundle/src/Resources/contao/classes/Ajax.php
@@ -353,24 +353,12 @@ class Ajax extends Backend
 
 				// Set the new value
 				$varValue = Input::post('value', true);
-
-				switch ($this->strAction)
+				$strKey = match ($this->strAction)
 				{
-					case 'reloadPicker':
-						$strKey = 'picker';
-						break;
-
-					case 'reloadPagetree':
-						trigger_deprecation('contao/core-bundle', '4.13', 'Calling executePostActions(action=reloadPagetree) has been deprecated and will no longer work in Contao 5.0. Use the picker instead.');
-
-						$strKey = 'pageTree';
-						break;
-
-					default:
-						trigger_deprecation('contao/core-bundle', '4.13', 'Calling executePostActions(action=reloadFiletree) has been deprecated and will no longer work in Contao 5.0. Use the picker instead.');
-
-						$strKey = 'fileTree';
-				}
+					'reloadPicker' => 'picker',
+					'reloadPagetree' => 'pageTree',
+					'reloadFiletree' => 'fileTree',
+				};
 
 				// Convert the selected values
 				if ($varValue)


### PR DESCRIPTION
In 26eb1a34dcf0f342cce9fd5ae03cc985eff007d1 I accidentally deprecated the `reloadPagetree` and `reloadFiletree` ajax post actions. This was by mistake I think, I’ve probably mixed them up with the deprecated `FileSelector` and `PageSelector` widgets.

See also #3993
> …Be aware that the `fileTree` and `pageTree` are different! Even though some of their methods say they are deprecated, that's actually what we still use everywhere, and changing that would be a different PR.

Related: #4513 