### PR TITLE
Fix CronTest::testDoesNotRunCronJobIfAlreadyRun

### DIFF
--- a/core-bundle/tests/Cron/CronTest.php
+++ b/core-bundle/tests/Cron/CronTest.php
@@ -193,7 +193,7 @@ class CronTest extends TestCase
 
         $entity
             ->method('getLastRun')
-            ->willReturn((new \DateTime())->modify('-1 minute'))
+            ->willReturn((new \DateTime())->modify('+2 hours'))
         ;
 
         $entity


### PR DESCRIPTION
Currently this test will always fail when run between the full hour and 59 seconds after. This fixes that by setting the "last" run date 2 hours into the future.