### PR TITLE
Remove some deprecated constants

### DIFF
--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -1,25 +1,5 @@
 # Deprecated features
 
-## BE_USER_LOGGED_IN
-
-The constant `BE_USER_LOGGED_IN` has been deprecated and will be removed in
-Contao 5.0. It was historically used to preview unpublished elements in the
-front end. Use the token checker service to check the separate cases instead:
-
-```php
-$hasBackendUser = System::getContainer()->get('contao.security.token_checker')->hasBackendUser();
-$showUnpublished = System::getContainer()->get('contao.security.token_checker')->isPreviewMode();
-```
-
-## FE_USER_LOGGED_IN
-
-The constant `FE_USER_LOGGED_IN` has been deprecated and will be removed in
-Contao 5.0. Use the token checker service instead:
-
-```php
-$hasFrontendUser = System::getContainer()->get('contao.security.token_checker')->hasFrontendUser();
-```
-
 ## kernel.packages
 
 The `kernel.packages` parameter has been deprecated in Contao 4.5 and will be
@@ -233,8 +213,8 @@ You can use the static helper methods such as `System::loadLanguageFile()` or
 
 ## Constants
 
-The constants `TL_ROOT`, `TL_MODE`, `TL_START`, `TL_SCRIPT` and `TL_REFERER_ID`
-have been deprecated and will be removed in Contao 5.0.
+The constants `TL_ROOT`, `TL_MODE` and `TL_SCRIPT` have been deprecated and will
+be removed in Contao 5.0.
 
 Use the `kernel.project_dir` instead of `TL_ROOT`:
 
@@ -267,12 +247,6 @@ class Test {
 }
 ```
 
-Use the kernel start time instead of `TL_START`:
-
-```php
-$startTime = System::getContainer()->get('kernel')->getStartTime();
-```
-
 Use the request stack to get the route instead of using `TL_SCRIPT`:
 
 ```php
@@ -281,12 +255,6 @@ $route = System::getContainer()->get('request_stack')->getCurrentRequest()->get(
 if ('contao_backend' === $route) {
     // Do something
 }
-```
-
-Use the request attribute `_contao_referer_id` instead of `TL_REFERER_ID`:
-
-```php
-$refererId = System::getContainer()->get('request_stack')->getCurrentRequest()->get('_contao_referer_id');
 ```
 
 ## PHP entry points

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -190,6 +190,36 @@ The following global functions have been removed:
 Most of them have alternatives in either `StringUtil`, `ArrayUtil` or may have PHP native alternatives such as
 the `mb_*` functions. For advanced UTF-8 handling, use `symfony/string`.
 
+### Constants
+
+The constants `BE_USER_LOGGED_IN`, `FE_USER_LOGGED_IN`, `TL_START` and `TL_REFERER_ID` have been removed.
+
+`BE_USER_LOGGED_IN` was historically used to preview unpublished elements in the
+front end. Use the token checker service to check the separate cases instead:
+
+```php
+$hasBackendUser = System::getContainer()->get('contao.security.token_checker')->hasBackendUser();
+$showUnpublished = System::getContainer()->get('contao.security.token_checker')->isPreviewMode();
+```
+
+Use the token checker service instead of `FE_USER_LOGGED_IN`:
+
+```php
+$hasFrontendUser = System::getContainer()->get('contao.security.token_checker')->hasFrontendUser();
+```
+
+Use the kernel start time instead of `TL_START`:
+
+```php
+$startTime = System::getContainer()->get('kernel')->getStartTime();
+```
+
+Use the request attribute `_contao_referer_id` instead of `TL_REFERER_ID`:
+
+```php
+$refererId = System::getContainer()->get('request_stack')->getCurrentRequest()->get('_contao_referer_id');
+```
+
 ### eval->orderField in PageTree and Picker widgets
 
 Support for a separate database `orderField` column has been removed. Use `isSortable` instead which

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,36 @@
 
 ## Version 4.* to 5.0
 
+### Constants
+
+The constants `BE_USER_LOGGED_IN`, `FE_USER_LOGGED_IN`, `TL_START` and `TL_REFERER_ID` have been removed.
+
+`BE_USER_LOGGED_IN` was historically used to preview unpublished elements in the front end. Use the
+token checker service to check the separate cases instead:
+
+```php
+$hasBackendUser = System::getContainer()->get('contao.security.token_checker')->hasBackendUser();
+$showUnpublished = System::getContainer()->get('contao.security.token_checker')->isPreviewMode();
+```
+
+Use the token checker service instead of `FE_USER_LOGGED_IN`:
+
+```php
+$hasFrontendUser = System::getContainer()->get('contao.security.token_checker')->hasFrontendUser();
+```
+
+Use the kernel start time instead of `TL_START`:
+
+```php
+$startTime = System::getContainer()->get('kernel')->getStartTime();
+```
+
+Use the request attribute `_contao_referer_id` instead of `TL_REFERER_ID`:
+
+```php
+$refererId = System::getContainer()->get('request_stack')->getCurrentRequest()->get('_contao_referer_id');
+```
+
 ### TL_CRON
 
 Cronjobs can no longer be registered via `$GLOBALS['TL_CRON']`. Use a service tagged with `contao.cronjob`
@@ -189,36 +219,6 @@ The following global functions have been removed:
 
 Most of them have alternatives in either `StringUtil`, `ArrayUtil` or may have PHP native alternatives such as
 the `mb_*` functions. For advanced UTF-8 handling, use `symfony/string`.
-
-### Constants
-
-The constants `BE_USER_LOGGED_IN`, `FE_USER_LOGGED_IN`, `TL_START` and `TL_REFERER_ID` have been removed.
-
-`BE_USER_LOGGED_IN` was historically used to preview unpublished elements in the
-front end. Use the token checker service to check the separate cases instead:
-
-```php
-$hasBackendUser = System::getContainer()->get('contao.security.token_checker')->hasBackendUser();
-$showUnpublished = System::getContainer()->get('contao.security.token_checker')->isPreviewMode();
-```
-
-Use the token checker service instead of `FE_USER_LOGGED_IN`:
-
-```php
-$hasFrontendUser = System::getContainer()->get('contao.security.token_checker')->hasFrontendUser();
-```
-
-Use the kernel start time instead of `TL_START`:
-
-```php
-$startTime = System::getContainer()->get('kernel')->getStartTime();
-```
-
-Use the request attribute `_contao_referer_id` instead of `TL_REFERER_ID`:
-
-```php
-$refererId = System::getContainer()->get('request_stack')->getCurrentRequest()->get('_contao_referer_id');
-```
 
 ### eval->orderField in PageTree and Picker widgets
 

--- a/core-bundle/src/Resources/config/services.yml
+++ b/core-bundle/src/Resources/config/services.yml
@@ -258,7 +258,6 @@ services:
         arguments:
             - '@request_stack'
             - '@contao.routing.scope_matcher'
-            - '@contao.security.token_checker'
             - '@router'
             - '%kernel.project_dir%'
             - '%contao.error_level%'

--- a/core-bundle/tests/Framework/ContaoFrameworkTest.php
+++ b/core-bundle/tests/Framework/ContaoFrameworkTest.php
@@ -19,7 +19,6 @@ use Contao\CoreBundle\Fixtures\Adapter\LegacySingletonClass;
 use Contao\CoreBundle\Framework\Adapter;
 use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\CoreBundle\Routing\ScopeMatcher;
-use Contao\CoreBundle\Security\Authentication\Token\TokenChecker;
 use Contao\CoreBundle\Session\Attribute\ArrayAttributeBag;
 use Contao\CoreBundle\Tests\TestCase;
 use Contao\Environment;
@@ -64,20 +63,11 @@ class ContaoFrameworkTest extends TestCase
         $framework->initialize();
 
         $this->assertTrue(\defined('TL_MODE'));
-        $this->assertTrue(\defined('TL_START'));
         $this->assertTrue(\defined('TL_ROOT'));
-        $this->assertTrue(\defined('TL_REFERER_ID'));
         $this->assertTrue(\defined('TL_SCRIPT'));
-        $this->assertTrue(\defined('BE_USER_LOGGED_IN'));
-        $this->assertTrue(\defined('FE_USER_LOGGED_IN'));
-        $this->assertTrue(\defined('TL_PATH'));
         $this->assertSame('FE', TL_MODE);
         $this->assertSame($this->getTempDir(), TL_ROOT);
-        $this->assertSame('', TL_REFERER_ID);
         $this->assertSame('index.html', TL_SCRIPT);
-        $this->assertFalse(BE_USER_LOGGED_IN);
-        $this->assertFalse(FE_USER_LOGGED_IN);
-        $this->assertSame('', TL_PATH);
         $this->assertSame('en', $GLOBALS['TL_LANGUAGE']);
     }
 
@@ -98,20 +88,11 @@ class ContaoFrameworkTest extends TestCase
         $framework->initialize();
 
         $this->assertTrue(\defined('TL_MODE'));
-        $this->assertTrue(\defined('TL_START'));
         $this->assertTrue(\defined('TL_ROOT'));
-        $this->assertTrue(\defined('TL_REFERER_ID'));
         $this->assertTrue(\defined('TL_SCRIPT'));
-        $this->assertTrue(\defined('BE_USER_LOGGED_IN'));
-        $this->assertTrue(\defined('FE_USER_LOGGED_IN'));
-        $this->assertTrue(\defined('TL_PATH'));
         $this->assertSame('BE', TL_MODE);
         $this->assertSame($this->getTempDir(), TL_ROOT);
-        $this->assertSame('foobar', TL_REFERER_ID);
         $this->assertSame('contao/login', TL_SCRIPT);
-        $this->assertFalse(BE_USER_LOGGED_IN);
-        $this->assertFalse(FE_USER_LOGGED_IN);
-        $this->assertSame('', TL_PATH);
         $this->assertSame('de', $GLOBALS['TL_LANGUAGE']);
     }
 
@@ -126,20 +107,11 @@ class ContaoFrameworkTest extends TestCase
         $framework->initialize();
 
         $this->assertTrue(\defined('TL_MODE'));
-        $this->assertTrue(\defined('TL_START'));
         $this->assertTrue(\defined('TL_ROOT'));
-        $this->assertTrue(\defined('TL_REFERER_ID'));
         $this->assertTrue(\defined('TL_SCRIPT'));
-        $this->assertTrue(\defined('BE_USER_LOGGED_IN'));
-        $this->assertTrue(\defined('FE_USER_LOGGED_IN'));
-        $this->assertTrue(\defined('TL_PATH'));
         $this->assertNull(TL_MODE);
         $this->assertSame($this->getTempDir(), TL_ROOT);
-        $this->assertNull(TL_REFERER_ID);
         $this->assertNull(TL_SCRIPT);
-        $this->assertFalse(BE_USER_LOGGED_IN);
-        $this->assertFalse(FE_USER_LOGGED_IN);
-        $this->assertNull(TL_PATH);
     }
 
     /**
@@ -153,20 +125,11 @@ class ContaoFrameworkTest extends TestCase
         $framework->initialize(true);
 
         $this->assertTrue(\defined('TL_MODE'));
-        $this->assertTrue(\defined('TL_START'));
         $this->assertTrue(\defined('TL_ROOT'));
-        $this->assertTrue(\defined('TL_REFERER_ID'));
         $this->assertTrue(\defined('TL_SCRIPT'));
-        $this->assertTrue(\defined('BE_USER_LOGGED_IN'));
-        $this->assertTrue(\defined('FE_USER_LOGGED_IN'));
-        $this->assertTrue(\defined('TL_PATH'));
         $this->assertSame('FE', TL_MODE);
         $this->assertSame($this->getTempDir(), TL_ROOT);
-        $this->assertNull(TL_REFERER_ID);
         $this->assertNull(TL_SCRIPT);
-        $this->assertFalse(BE_USER_LOGGED_IN);
-        $this->assertFalse(FE_USER_LOGGED_IN);
-        $this->assertNull(TL_PATH);
     }
 
     /**
@@ -184,20 +147,11 @@ class ContaoFrameworkTest extends TestCase
         $framework->initialize(true);
 
         $this->assertTrue(\defined('TL_MODE'));
-        $this->assertTrue(\defined('TL_START'));
         $this->assertTrue(\defined('TL_ROOT'));
-        $this->assertTrue(\defined('TL_REFERER_ID'));
         $this->assertTrue(\defined('TL_SCRIPT'));
-        $this->assertTrue(\defined('BE_USER_LOGGED_IN'));
-        $this->assertTrue(\defined('FE_USER_LOGGED_IN'));
-        $this->assertTrue(\defined('TL_PATH'));
         $this->assertSame('FE', TL_MODE);
         $this->assertSame($this->getTempDir(), TL_ROOT);
-        $this->assertSame('', TL_REFERER_ID);
         $this->assertSame('index.php/index.html', TL_SCRIPT);
-        $this->assertFalse(BE_USER_LOGGED_IN);
-        $this->assertFalse(FE_USER_LOGGED_IN);
-        $this->assertSame('/contao4/public', TL_PATH);
     }
 
     /**
@@ -215,20 +169,11 @@ class ContaoFrameworkTest extends TestCase
         $framework->initialize();
 
         $this->assertTrue(\defined('TL_MODE'));
-        $this->assertTrue(\defined('TL_START'));
         $this->assertTrue(\defined('TL_ROOT'));
-        $this->assertTrue(\defined('TL_REFERER_ID'));
         $this->assertTrue(\defined('TL_SCRIPT'));
-        $this->assertTrue(\defined('BE_USER_LOGGED_IN'));
-        $this->assertTrue(\defined('FE_USER_LOGGED_IN'));
-        $this->assertTrue(\defined('TL_PATH'));
         $this->assertNull(TL_MODE);
         $this->assertSame($this->getTempDir(), TL_ROOT);
-        $this->assertSame('foobar', TL_REFERER_ID);
         $this->assertSame('contao/login', TL_SCRIPT);
-        $this->assertFalse(BE_USER_LOGGED_IN);
-        $this->assertFalse(FE_USER_LOGGED_IN);
-        $this->assertSame('', TL_PATH);
     }
 
     /**
@@ -254,38 +199,16 @@ class ContaoFrameworkTest extends TestCase
         $request->cookies->set($session->getName(), 'foobar');
         $request->setSession($session);
 
-        $tokenChecker = $this->createMock(TokenChecker::class);
-        $tokenChecker
-            ->expects($this->once())
-            ->method('isPreviewMode')
-            ->willReturn(true)
-        ;
-
-        $tokenChecker
-            ->expects($this->once())
-            ->method('hasFrontendUser')
-            ->willReturn(true)
-        ;
-
-        $framework = $this->getFramework($request, null, $tokenChecker);
+        $framework = $this->getFramework($request);
         $framework->setContainer($this->getContainerWithContaoConfiguration());
         $framework->initialize();
 
         $this->assertTrue(\defined('TL_MODE'));
-        $this->assertTrue(\defined('TL_START'));
         $this->assertTrue(\defined('TL_ROOT'));
-        $this->assertTrue(\defined('TL_REFERER_ID'));
         $this->assertTrue(\defined('TL_SCRIPT'));
-        $this->assertTrue(\defined('BE_USER_LOGGED_IN'));
-        $this->assertTrue(\defined('FE_USER_LOGGED_IN'));
-        $this->assertTrue(\defined('TL_PATH'));
         $this->assertSame('FE', TL_MODE);
         $this->assertSame($this->getTempDir(), TL_ROOT);
-        $this->assertSame('', TL_REFERER_ID);
         $this->assertSame('index.html', TL_SCRIPT);
-        $this->assertTrue(BE_USER_LOGGED_IN);
-        $this->assertTrue(FE_USER_LOGGED_IN);
-        $this->assertSame('', TL_PATH);
         $this->assertSame('en', $GLOBALS['TL_LANGUAGE']);
     }
 
@@ -297,13 +220,13 @@ class ContaoFrameworkTest extends TestCase
     {
         $scopeMatcher = $this->createMock(ScopeMatcher::class);
         $scopeMatcher
-            ->expects($this->exactly(2))
+            ->expects($this->once())
             ->method('isBackendRequest')
             ->willReturn(false)
         ;
 
         $scopeMatcher
-            ->expects($this->exactly(2))
+            ->expects($this->once())
             ->method('isFrontendRequest')
             ->willReturn(false)
         ;
@@ -368,7 +291,6 @@ class ContaoFrameworkTest extends TestCase
         $framework = new ContaoFramework(
             $requestStack,
             $this->mockScopeMatcher(),
-            $this->createMock(TokenChecker::class),
             $urlGenerator,
             $this->getTempDir(),
             error_reporting()
@@ -407,7 +329,6 @@ class ContaoFrameworkTest extends TestCase
         $framework = new ContaoFramework(
             $requestStack,
             $this->mockScopeMatcher(),
-            $this->createMock(TokenChecker::class),
             $this->createMock(UrlGeneratorInterface::class),
             $this->getTempDir(),
             error_reporting()
@@ -641,7 +562,7 @@ class ContaoFrameworkTest extends TestCase
         $this->assertCount(0, $registry);
     }
 
-    private function getFramework(Request $request = null, ScopeMatcher $scopeMatcher = null, TokenChecker $tokenChecker = null): ContaoFramework
+    private function getFramework(Request $request = null, ScopeMatcher $scopeMatcher = null): ContaoFramework
     {
         $requestStack = new RequestStack();
 
@@ -652,7 +573,6 @@ class ContaoFrameworkTest extends TestCase
         $framework = new ContaoFramework(
             $requestStack,
             $scopeMatcher ?? $this->mockScopeMatcher(),
-            $tokenChecker ?? $this->createMock(TokenChecker::class),
             $this->createMock(UrlGeneratorInterface::class),
             $this->getTempDir(),
             error_reporting()

--- a/news-bundle/src/Resources/contao/modules/ModuleNewsMenu.php
+++ b/news-bundle/src/Resources/contao/modules/ModuleNewsMenu.php
@@ -111,9 +111,10 @@ class ModuleNewsMenu extends ModuleNews
 	{
 		$arrData = array();
 		$time = Date::floorToMinute();
+		$blnShowUnpublished = System::getContainer()->get('contao.security.token_checker')->isPreviewMode();
 
 		// Get the dates
-		$objDates = $this->Database->query("SELECT FROM_UNIXTIME(date, '%Y') AS year, COUNT(*) AS count FROM tl_news WHERE pid IN(" . implode(',', array_map('\intval', $this->news_archives)) . ")" . ((!BE_USER_LOGGED_IN || TL_MODE == 'BE') ? " AND published='1' AND (start='' OR start<='$time') AND (stop='' OR stop>'$time')" : "") . " GROUP BY year ORDER BY year DESC");
+		$objDates = $this->Database->query("SELECT FROM_UNIXTIME(date, '%Y') AS year, COUNT(*) AS count FROM tl_news WHERE pid IN(" . implode(',', array_map('\intval', $this->news_archives)) . ")" . ((!$blnShowUnpublished || TL_MODE == 'BE') ? " AND published='1' AND (start='' OR start<='$time') AND (stop='' OR stop>'$time')" : "") . " GROUP BY year ORDER BY year DESC");
 
 		while ($objDates->next())
 		{
@@ -153,9 +154,10 @@ class ModuleNewsMenu extends ModuleNews
 	{
 		$arrData = array();
 		$time = Date::floorToMinute();
+		$blnShowUnpublished = System::getContainer()->get('contao.security.token_checker')->isPreviewMode();
 
 		// Get the dates
-		$objDates = $this->Database->query("SELECT FROM_UNIXTIME(date, '%Y') AS year, FROM_UNIXTIME(date, '%m') AS month, COUNT(*) AS count FROM tl_news WHERE pid IN(" . implode(',', array_map('\intval', $this->news_archives)) . ")" . ((!BE_USER_LOGGED_IN || TL_MODE == 'BE') ? " AND published='1' AND (start='' OR start<='$time') AND (stop='' OR stop>'$time')" : "") . " GROUP BY year, month ORDER BY year DESC, month DESC");
+		$objDates = $this->Database->query("SELECT FROM_UNIXTIME(date, '%Y') AS year, FROM_UNIXTIME(date, '%m') AS month, COUNT(*) AS count FROM tl_news WHERE pid IN(" . implode(',', array_map('\intval', $this->news_archives)) . ")" . ((!$blnShowUnpublished || TL_MODE == 'BE') ? " AND published='1' AND (start='' OR start<='$time') AND (stop='' OR stop>'$time')" : "") . " GROUP BY year, month ORDER BY year DESC, month DESC");
 
 		while ($objDates->next())
 		{
@@ -207,9 +209,10 @@ class ModuleNewsMenu extends ModuleNews
 	{
 		$arrData = array();
 		$time = Date::floorToMinute();
+		$blnShowUnpublished = System::getContainer()->get('contao.security.token_checker')->isPreviewMode();
 
 		// Get the dates
-		$objDates = $this->Database->query("SELECT FROM_UNIXTIME(date, '%Y%m%d') AS day, COUNT(*) AS count FROM tl_news WHERE pid IN(" . implode(',', array_map('\intval', $this->news_archives)) . ")" . ((!BE_USER_LOGGED_IN || TL_MODE == 'BE') ? " AND published='1' AND (start='' OR start<='$time') AND (stop='' OR stop>'$time')" : "") . " GROUP BY day ORDER BY day DESC");
+		$objDates = $this->Database->query("SELECT FROM_UNIXTIME(date, '%Y%m%d') AS day, COUNT(*) AS count FROM tl_news WHERE pid IN(" . implode(',', array_map('\intval', $this->news_archives)) . ")" . ((!$blnShowUnpublished || TL_MODE == 'BE') ? " AND published='1' AND (start='' OR start<='$time') AND (stop='' OR stop>'$time')" : "") . " GROUP BY day ORDER BY day DESC");
 
 		while ($objDates->next())
 		{

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -16,9 +16,6 @@ parameters:
         - %currentWorkingDirectory%/core-bundle/src
         - %currentWorkingDirectory%/core-bundle/tests
 
-    dynamicConstantNames:
-        - BE_USER_LOGGED_IN
-
     universalObjectCratesClasses:
         - Contao\Model
         - Contao\Template


### PR DESCRIPTION
Removes  `TL_START`, `TL_REFERER_ID`, `FE_USER_LOGGED_IN`, `FE_USER_LOGGED_IN` and `TL_PATH`