### PR TITLE
Make sure page language is always a string in routing

### DIFF
--- a/core-bundle/src/Routing/Page/PageRoute.php
+++ b/core-bundle/src/Routing/Page/PageRoute.php
@@ -43,7 +43,7 @@ class PageRoute extends Route implements RouteObjectInterface
                 '_token_check' => true,
                 '_controller' => 'Contao\FrontendIndex::renderPage',
                 '_scope' => ContaoCoreBundle::SCOPE_FRONTEND,
-                '_locale' => LocaleUtil::formatAsLocale($pageModel->rootLanguage),
+                '_locale' => LocaleUtil::formatAsLocale((string) $pageModel->rootLanguage),
                 '_format' => 'html',
                 '_canonical_route' => 'tl_page.'.$pageModel->id,
             ],

--- a/core-bundle/src/Routing/Route404Provider.php
+++ b/core-bundle/src/Routing/Route404Provider.php
@@ -157,7 +157,7 @@ class Route404Provider extends AbstractPageRouteProvider
             '_token_check' => true,
             '_controller' => 'Contao\FrontendIndex::renderPage',
             '_scope' => ContaoCoreBundle::SCOPE_FRONTEND,
-            '_locale' => LocaleUtil::formatAsLocale($page->rootLanguage),
+            '_locale' => LocaleUtil::formatAsLocale((string) $page->rootLanguage),
             '_format' => 'html',
             '_canonical_route' => 'tl_page.'.$page->id,
             'pageModel' => $page,


### PR DESCRIPTION
I've had some rare cases (e.g. leftovers in `tl_page` or [folderpage](https://github.com/terminal42/contao-folderpage)) where a page did not have a parent root, and therefore no language was available. We need to make sure this is handled correct in routing. I did not fix this in any other places since a page would never be routed in that case.