### PR TITLE
Fix a potential PHP 8 warning in booknav frontend module

### DIFF
--- a/core-bundle/src/Resources/contao/modules/ModuleBooknav.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleBooknav.php
@@ -94,7 +94,7 @@ class ModuleBooknav extends Module
 			$intKey = $objPage->pid;
 
 			// Skip forward pages (see #5074)
-			while ($this->arrPages[$intKey]->type == 'forward' && isset($this->arrPages[$intKey]->pid))
+			while (isset($this->arrPages[$intKey]->pid) && $this->arrPages[$intKey]->type == 'forward')
 			{
 				$intKey = $this->arrPages[$intKey]->pid;
 			}


### PR DESCRIPTION
I do get the PHP 8 warning in one of the Contao instances when using the booknav frontend module, yet I am not sure what causes that and would be the exact steps to reproduce this. I think this could be prevented by switching the order of the statements on line 97.

<img width="1265" alt="CleanShot 2022-05-31 at 08 55 15" src="https://user-images.githubusercontent.com/193483/171111046-0d5e4903-a68e-4487-9ce0-6ca0dfdaf31f.png">
