### PR TITLE
Correctly toggle checkbox groups with collapseUncheckedGroups

### DIFF
--- a/core-bundle/src/Resources/contao/widgets/CheckBox.php
+++ b/core-bundle/src/Resources/contao/widgets/CheckBox.php
@@ -162,32 +162,24 @@ class CheckBox extends Widget
 			$img = 'folPlus.svg';
 			$display = 'none';
 
-			if ($this->collapseUncheckedGroups || !isset($state[$id]) || !empty($state[$id]))
+			$blnIsOpen = ($state[$id] ?? null) || ($this->collapseUncheckedGroups && $blnFirst && empty($this->varValue));
+
+			if (!$blnIsOpen && $this->collapseUncheckedGroups && !isset($state[$id]))
 			{
-				$blnIsOpen = !$this->collapseUncheckedGroups && (!isset($state[$id]) || !empty($state[$id]));
-
-				if ($this->collapseUncheckedGroups && $blnFirst && empty($this->varValue))
+				foreach ($arrOption as $v)
 				{
-					$blnIsOpen = true;
-				}
-
-				if (!$blnIsOpen && $this->collapseUncheckedGroups)
-				{
-					foreach ($arrOption as $v)
+					if ($this->isChecked($v))
 					{
-						if ($this->isChecked($v))
-						{
-							$blnIsOpen = true;
-							break;
-						}
+						$blnIsOpen = true;
+						break;
 					}
 				}
+			}
 
-				if ($blnIsOpen)
-				{
-					$img = 'folMinus.svg';
-					$display = 'block';
-				}
+			if ($blnIsOpen)
+			{
+				$img = 'folMinus.svg';
+				$display = 'block';
 			}
 
 			$arrOptions[] = '<div class="checkbox_toggler' . ($blnFirst ? '_first' : '') . '"><a href="' . Backend::addToUrl('cbc=' . $id) . '" onclick="AjaxRequest.toggleCheckboxGroup(this,\'' . $id . '\');Backend.getScrollOffset();return false">' . Image::getHtml($img) . '</a>' . $i . '</div><fieldset id="' . $id . '" class="tl_checkbox_container checkbox_options" style="display:' . $display . '"><input type="checkbox" id="check_all_' . $id . '" class="tl_checkbox" onclick="Backend.toggleCheckboxGroup(this, \'' . $id . '\')"> <label for="check_all_' . $id . '" style="color:#a6a6a6"><em>' . $GLOBALS['TL_LANG']['MSC']['selectAll'] . '</em></label>';


### PR DESCRIPTION
While trying to implement a vanilla-JS version of the checkbox group toggling, I noticed the `collapseUncheckedGroups` (https://github.com/contao/contao/pull/3674) is not working as expected.

If `collapseUncheckedGroups` was enabled, the session state of checkbox groups was always ignored. All empty groups are collapsed, and non-empty groups are open. This has two problems:
 1. it makes the session obsolete
 2. if Javascript is disabled, there is a fallback link to toggle the group through a GET request. But since the state is ignored, it is impossible to open (or close) a checkbox group without Javascript.

Be aware that **all** multiple checkbox fields in the core do use `collapseUncheckedGroups`, so this affects all our fields 😉 

/cc @SeverinGloeckle 