### PR TITLE
Exclude the ModuleWizard checkbox from keyboard access

### DIFF
--- a/core-bundle/src/Resources/contao/widgets/ModuleWizard.php
+++ b/core-bundle/src/Resources/contao/widgets/ModuleWizard.php
@@ -220,7 +220,7 @@ class ModuleWizard extends Widget
 				}
 				elseif ($button == 'enable')
 				{
-					$return .= ' <button type="button" data-command="enable" class="mw_enable" title="' . StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['mw_enable']) . '">' . Image::getHtml((($this->varValue[$i]['enable']) ? 'visible.svg' : 'invisible.svg')) . '</button><input name="' . $this->strId . '[' . $i . '][enable]" type="checkbox" class="tl_checkbox mw_enable" value="1" onfocus="Backend.getScrollOffset()"' . (($this->varValue[$i]['enable']) ? ' checked' : '') . '>';
+					$return .= ' <button type="button" data-command="enable" class="mw_enable" title="' . StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['mw_enable']) . '">' . Image::getHtml((($this->varValue[$i]['enable']) ? 'visible.svg' : 'invisible.svg')) . '</button><input name="' . $this->strId . '[' . $i . '][enable]" type="checkbox" class="tl_checkbox mw_enable" value="1" tabindex="-1" onfocus="Backend.getScrollOffset()"' . (($this->varValue[$i]['enable']) ? ' checked' : '') . '>';
 				}
 				else
 				{


### PR DESCRIPTION
The module wizard has an invisible checkbox that is toggled by the visibility button to submit the visibility state of a row. This checkbox is visually hidden, but still receives keyboard focus when tabbing through the dropdown and buttons. This PR makes it inaccessible to keyboard focus.

<img width="844" alt="Bildschirmfoto 2022-06-01 um 08 29 27" src="https://user-images.githubusercontent.com/1073273/171342684-d99608b2-5532-4366-803d-a5f5a4cc8424.png">

PS: the checkbox **is** visible when no javascript is available. Which would in theory need keyboard focus. But then again, the whole wizard does not work at all without javascript (can't add, copy or remove rows), so I think we can live with that.