### PR TITLE
Fix a potential PHP 8 error in the Contao\Environment class

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Environment.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Environment.php
@@ -273,6 +273,11 @@ class Environment
 	 */
 	protected static function httpUserAgent()
 	{
+		if (!isset($_SERVER['HTTP_USER_AGENT']))
+		{
+			return '';
+		}
+
 		$ua = strip_tags($_SERVER['HTTP_USER_AGENT']);
 		$ua = preg_replace('/javascript|vbscri?pt|script|applet|alert|document|write|cookie/i', '', $ua);
 


### PR DESCRIPTION
The `HTTP_USER_AGENT` header is optional and it may cause an unnecessary PHP 8 warning:

<img width="984" alt="CleanShot 2022-06-02 at 12 01 32" src="https://user-images.githubusercontent.com/193483/171606282-a19582db-b538-48ac-b188-1e04a74aa277.png">
