### PR TITLE
Remove invalid duplicate CSV handling

### DIFF
--- a/core-bundle/src/Resources/contao/drivers/DC_Folder.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Folder.php
@@ -2347,10 +2347,6 @@ class DC_Folder extends DataContainer implements \listable, \editable
 				{
 					$varValue = '';
 				}
-				elseif (isset($arrData['eval']['csv']))
-				{
-					$varValue = implode($arrData['eval']['csv'], $varValue); // see #2890
-				}
 				else
 				{
 					$varValue = serialize($varValue);

--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -3102,10 +3102,6 @@ class DC_Table extends DataContainer implements \listable, \editable
 			{
 				$varValue = Widget::getEmptyStringOrNullByFieldType($arrData['sql']);
 			}
-			elseif (isset($arrData['eval']['csv']))
-			{
-				$varValue = implode($arrData['eval']['csv'], $varValue); // see #2890
-			}
 			else
 			{
 				$varValue = serialize($varValue);


### PR DESCRIPTION
we already handle CSV data a few lines below, but only if `$arrData['eval']['multiple']` is enabled. This looks like a duplicate to me, but I didn't manually test it.