### PR TITLE
Add a cache timeout for the `{{date::Y}}` insert tag

### DIFF
--- a/core-bundle/src/Controller/InsertTagsController.php
+++ b/core-bundle/src/Controller/InsertTagsController.php
@@ -43,6 +43,13 @@ class InsertTagsController
             $response->headers->addCacheControlDirective('no-store');
         }
 
+        // Special handling for the very common {{date::Y}} (e.g. in the website footer) case until
+        // we have a new way to register insert tags and add that caching information to the tag itself
+        if ('{{date::Y}}' === $insertTag) {
+            $response->setPublic();
+            $response->setExpires(new \DateTimeImmutable(date('Y').'-12-31 23:59:59'));
+        }
+
         return $response;
     }
 }

--- a/core-bundle/tests/Controller/InsertTagsControllerTest.php
+++ b/core-bundle/tests/Controller/InsertTagsControllerTest.php
@@ -47,4 +47,23 @@ class InsertTagsControllerTest extends TestCase
         $this->assertSame(300, $response->getMaxAge());
         $this->assertSame('3858f62230ac3c915f300c664312c63f', $response->getContent());
     }
+
+    public function testSpecialDateInsertTagHandling(): void
+    {
+        $year = date('Y');
+
+        $insertTagParser = $this->createMock(InsertTagParser::class);
+        $insertTagParser
+            ->method('replaceInline')
+            ->with('{{date::Y}}')
+            ->willReturn($year)
+        ;
+
+        $controller = new InsertTagsController($insertTagParser);
+        $response = $controller->renderAction(new Request(), '{{date::Y}}');
+
+        $this->assertTrue($response->headers->hasCacheControlDirective('public'));
+        $this->assertSame($year.'-12-31 23:59:59', $response->getExpires()->format('Y-m-d H:i:s'));
+        $this->assertSame($year, $response->getContent());
+    }
 }


### PR DESCRIPTION
As 4.13 is our last 4.x version with LTS support and we won't have any new insert tag service, I think it's time to introduce special handling for `{{date::Y}}`. I see this being used over and over in hundreds of setups, mostly in the footer. And the pages would be so much faster coming from the cache if this simple case was cached the way it should be.

So I think it qualifies for a special handling.