### PR TITLE
Ignore website roots with empty language in the meta wizard

### DIFF
--- a/core-bundle/src/Resources/contao/widgets/MetaWizard.php
+++ b/core-bundle/src/Resources/contao/widgets/MetaWizard.php
@@ -116,7 +116,7 @@ class MetaWizard extends Widget
 		$this->import(BackendUser::class, 'User');
 
 		// Only show the root page languages (see #7112, #7667)
-		$objRootLangs = $this->Database->query("SELECT REPLACE(language, '-', '_') AS language FROM tl_page WHERE type='root'");
+		$objRootLangs = $this->Database->query("SELECT REPLACE(language, '-', '_') AS language FROM tl_page WHERE type='root' AND language != ''");
 		$existing = $objRootLangs->fetchEach('language');
 
 		foreach ($existing as $lang)


### PR DESCRIPTION
In Contao 4.13:

1. Go to the site structure.
2. Create a new page and insert it at the root level (do not save).
3. Immediately go to the file manager.
4. Edit the meta data of a file.

The following error will occur:

```
TypeError:
Contao\CoreBundle\Translation\MessageCatalogue::getFromGlobals(): Return value must be of type ?string, array returned

  at vendor\contao\contao\core-bundle\src\Translation\MessageCatalogue.php:181
  at Contao\CoreBundle\Translation\MessageCatalogue->getFromGlobals('LNG.')
     (vendor\contao\contao\core-bundle\src\Translation\MessageCatalogue.php:158)
  at Contao\CoreBundle\Translation\MessageCatalogue->loadMessage('LNG.', 'contao_languages')
     (vendor\contao\contao\core-bundle\src\Translation\MessageCatalogue.php:82)
  at Contao\CoreBundle\Translation\MessageCatalogue->has('LNG.', 'contao_languages')
     (vendor\contao\contao\core-bundle\src\Intl\Locales.php:218)
  at Contao\CoreBundle\Intl\Locales->getDisplayNamesWithoutHook(array('', 'en', 'de'), 'en', false)
     (vendor\contao\contao\core-bundle\src\Intl\Locales.php:191)
  at Contao\CoreBundle\Intl\Locales->getDisplayNames(array('', 'en', 'de'))
     (vendor\contao\contao\core-bundle\src\Resources\contao\widgets\MetaWizard.php:166)
```

This PR fixes that by ignoring any website roots that do not have a language defined (yet). While the aforementioned error only occurs in Contao 4.13 - it should be fixed in Contao 4.9 as well, otherwise you end up with a meta input for an empty language:

![image](https://user-images.githubusercontent.com/4970961/172396601-f472811c-1892-4333-bc0f-e9a99516febe.png)