### PR TITLE
Add a migration for bad playerColor data

### DIFF
--- a/core-bundle/src/Migration/Version409/PlayerColorMigration.php
+++ b/core-bundle/src/Migration/Version409/PlayerColorMigration.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Migration\Version409;
+
+use Contao\CoreBundle\Migration\AbstractMigration;
+use Contao\CoreBundle\Migration\MigrationResult;
+use Doctrine\DBAL\Connection;
+
+/**
+ * @internal
+ */
+class PlayerColorMigration extends AbstractMigration
+{
+    /**
+     * @var Connection
+     */
+    private $connection;
+
+    public function __construct(Connection $connection)
+    {
+        $this->connection = $connection;
+    }
+
+    public function shouldRun(): bool
+    {
+        $schemaManager = $this->connection->getSchemaManager();
+
+        if (!$schemaManager->tablesExist(['tl_content'])) {
+            return false;
+        }
+
+        $columns = $schemaManager->listTableColumns('tl_content');
+
+        if (!isset($columns['playercolor'])) {
+            return false;
+        }
+
+        if ($columns['playercolor']->getLength() <= 6) {
+            return false;
+        }
+
+        return (bool) $this->connection
+            ->executeQuery("
+                SELECT EXISTS(
+                    SELECT playerColor
+                    FROM tl_content
+                    WHERE
+                        CHAR_LENGTH(playerColor) > 6
+                        AND playerColor LIKE 'com_%'
+                )
+            ")
+            ->fetchOne()
+        ;
+    }
+
+    public function run(): MigrationResult
+    {
+        $this->connection
+            ->executeStatement("
+                UPDATE tl_content
+                SET playerColor = ''
+                WHERE
+                    CHAR_LENGTH(playerColor) > 6
+                    AND playerColor LIKE 'com_%'
+            ")
+        ;
+
+        return $this->createResult(true);
+    }
+}

--- a/core-bundle/src/Migration/Version409/PlayerColorMigration.php
+++ b/core-bundle/src/Migration/Version409/PlayerColorMigration.php
@@ -41,11 +41,7 @@ class PlayerColorMigration extends AbstractMigration
 
         $columns = $schemaManager->listTableColumns('tl_content');
 
-        if (!isset($columns['playercolor'])) {
-            return false;
-        }
-
-        if ($columns['playercolor']->getLength() <= 6) {
+        if (!isset($columns['playercolor']) || $columns['playercolor']->getLength() <= 6) {
             return false;
         }
 
@@ -65,15 +61,13 @@ class PlayerColorMigration extends AbstractMigration
 
     public function run(): MigrationResult
     {
-        $this->connection
-            ->executeStatement("
-                UPDATE tl_content
-                SET playerColor = ''
-                WHERE
-                    CHAR_LENGTH(playerColor) > 6
-                    AND playerColor LIKE 'com_%'
-            ")
-        ;
+        $this->connection->executeStatement("
+            UPDATE tl_content
+            SET playerColor = ''
+            WHERE
+                CHAR_LENGTH(playerColor) > 6
+                AND playerColor LIKE 'com_%'
+        ");
 
         return $this->createResult(true);
     }

--- a/core-bundle/src/Resources/config/migrations.yml
+++ b/core-bundle/src/Resources/config/migrations.yml
@@ -52,3 +52,7 @@ services:
         arguments:
             - '@database_connection'
             - '@contao.framework'
+
+    Contao\CoreBundle\Migration\Version409\PlayerColorMigration:
+        arguments:
+            - '@database_connection'


### PR DESCRIPTION
We shortened `playerColor` in #4693 to 6 characters.

The community noticed that there are many installations where a erroneous column rename from `com_template` to `playerColor` because of #1731 which now results in an SQL error `1265 Data truncated for column 'playerColor'` because the column is filled with `'com_default'` values.

This migration should fix the update for this case.