### PR TITLE
Fix preview toolbar always showing error

### DIFF
--- a/core-bundle/src/Resources/views/Frontend/preview_toolbar_base_js.html.twig
+++ b/core-bundle/src/Resources/views/Frontend/preview_toolbar_base_js.html.twig
@@ -240,13 +240,13 @@
                 const formData = new FormData(form);
 
                 request('POST', form.action, formData, function () {
-                    if (422 !== this.status) {
+                    if (422 === this.status) {
+                        if (userField) {
+                            userField.setCustomValidity(this.responseText || 'An unknown error occurred.');
+                            userField.reportValidity();
+                        }
+                    } else {
                         location.reload();
-                    }
-
-                    if (userField) {
-                        userField.setCustomValidity(this.responseText || 'An unknown error occurred.');
-                        userField.reportValidity();
                     }
                 });
             });

--- a/core-bundle/src/Resources/views/Frontend/preview_toolbar_base_js.html.twig
+++ b/core-bundle/src/Resources/views/Frontend/preview_toolbar_base_js.html.twig
@@ -240,13 +240,11 @@
                 const formData = new FormData(form);
 
                 request('POST', form.action, formData, function () {
-                    if (422 === this.status) {
-                        if (userField) {
-                            userField.setCustomValidity(this.responseText || 'An unknown error occurred.');
-                            userField.reportValidity();
-                        }
-                    } else {
+                    if (422 !== this.status) {
                         location.reload();
+                    } else if (userField) {
+                        userField.setCustomValidity(this.responseText || 'An unknown error occurred.');
+                        userField.reportValidity();
                     }
                 });
             });


### PR DESCRIPTION
Follow up to #3742

The changes made in https://github.com/contao/contao/pull/3742/commits/7812e091edf1d3f8aad2c112457f573b2e2a8b60 are now causing the message 'An unknown error occurred.' to always be shown now, even if no error occurred at all. This PR reverts that commit to fix that.