### PR TITLE
Deprecate CURRENT_ID

### DIFF
--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -2,9 +2,9 @@
 
 ## CURRENT_ID
 
-The constant `CURRENT_ID` as well as the session variable `CURRENT_ID` has been
-deprecated and will be removed in Contao 5.0. Use `DataContainer::$currentPid`
-instead to determine the ID of the current parent record.
+The `CURRENT_ID` constant and session variable have been deprecated and will be
+removed in Contao 5.0. Use `DataContainer::$currentPid` instead to determine
+the ID of the current parent record.
 
 ```php
 $intCurrentParentRecordId = $dc->currentPid;

--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -3,8 +3,12 @@
 ## CURRENT_ID
 
 The constant `CURRENT_ID` as well as the session variable `CURRENT_ID` has been
-deprecated and will be removed in Contao 5.0. Use the current request to
-determine the ID of the current or the parent record.
+deprecated and will be removed in Contao 5.0. Use `DataContainer::$currentPid`
+instead to determine the ID of the current parent record.
+
+```php
+$intCurrentParentRecordId = $dc->currentPid;
+```
 
 ## FE_USER_LOGGED_IN
 

--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -1,5 +1,11 @@
 # Deprecated features
 
+## CURRENT_ID
+
+The constant `CURRENT_ID` as well as the session variable `CURRENT_ID` has been
+deprecated and will be removed in Contao 5.0. Use the current request to
+determine the ID of the current or the parent record.
+
 ## FE_USER_LOGGED_IN
 
 The constant `FE_USER_LOGGED_IN` has been deprecated and will be removed in

--- a/core-bundle/src/EventListener/ClearSessionDataListener.php
+++ b/core-bundle/src/EventListener/ClearSessionDataListener.php
@@ -41,11 +41,14 @@ class ClearSessionDataListener
             return;
         }
 
+        $session = $request->getSession();
+
         if ($event->getResponse()->isSuccessful()) {
-            $this->clearLoginData($request->getSession());
+            $this->clearLoginData($session);
         }
 
-        $request->getSession()->remove('CURRENT_ID');
+        $session->remove('CURRENT_ID');
+
         $this->clearLegacyAttributeBags('FE_DATA');
         $this->clearLegacyAttributeBags('BE_DATA');
         $this->clearLegacyFormData();

--- a/core-bundle/src/EventListener/ClearSessionDataListener.php
+++ b/core-bundle/src/EventListener/ClearSessionDataListener.php
@@ -45,6 +45,7 @@ class ClearSessionDataListener
             $this->clearLoginData($request->getSession());
         }
 
+        $request->getSession()->remove('CURRENT_ID');
         $this->clearLegacyAttributeBags('FE_DATA');
         $this->clearLegacyAttributeBags('BE_DATA');
         $this->clearLegacyFormData();

--- a/core-bundle/src/Resources/contao/classes/Backend.php
+++ b/core-bundle/src/Resources/contao/classes/Backend.php
@@ -338,13 +338,9 @@ abstract class Backend extends Controller
 
 		$arrTables = (array) $arrModule['tables'];
 		$strTable = Input::get('table') ?: $arrTables[0];
-		$id = (!Input::get('act') && Input::get('id')) ? Input::get('id') : $objSession->get('CURRENT_ID');
 
-		// Store the current ID in the current session
-		if ($id != $objSession->get('CURRENT_ID'))
-		{
-			$objSession->set('CURRENT_ID', $id);
-		}
+		$id = $this->findCurrentId($strTable);
+		$objSession->set('CURRENT_ID', $id);
 
 		\define('CURRENT_ID', (Input::get('table') ? $id : Input::get('id')));
 		$this->Template->headline = $GLOBALS['TL_LANG']['MOD'][$module][0];
@@ -642,6 +638,85 @@ abstract class Backend extends Controller
 			}
 
 			return $dc->$act();
+		}
+
+		return null;
+	}
+
+	/**
+	 * With this method the id of the current (parent) record can be determined
+	 * stateless based on the current request only.
+	 *
+	 * In older versions Contao stored the id of the current (parent) record in
+	 * the user session as "CURRENT_ID" to make it known on subsequent requests.
+	 * This was unreliable and caused several issues, like for example if the
+	 * user used multiple browser tabs at the same time.
+	 */
+	protected function findCurrentId(?string $table): ?string
+	{
+		if (!$table)
+		{
+			return null;
+		}
+
+		$id = Input::get('id');
+		$pid = Input::get('pid');
+		$act = Input::get('act');
+		$mode = Input::get('mode');
+
+		// For these actions the id parameter refers to the parent record
+		if (
+			($act === 'paste' && $mode === 'create')
+			|| \in_array($act, array(null, 'select', 'editAll', 'overrideAll', 'deleteAll'), true)
+		) {
+			return $id;
+		}
+
+		// For these actions the pid parameter refers to the insert position
+		if (\in_array($act, array('create', 'cut', 'copy', 'cutAll', 'copyAll'), true))
+		{
+			// Mode “paste into”
+			if ($mode === '2')
+			{
+				return $pid;
+			}
+
+			// Mode “paste after”
+			$id = $pid;
+		}
+
+		if (!$id)
+		{
+			return null;
+		}
+
+		$allTables = array_merge(
+			...array_map(
+				static function ($module)
+				{
+					return (array) ($module['tables'] ?? array());
+				},
+				array_merge(...array_values($GLOBALS['BE_MOD']))
+			)
+		);
+
+		// Do not run database queries for unknown tables
+		if (!\in_array($table, $allTables, true))
+		{
+			return null;
+		}
+
+		try
+		{
+			$objPid = $this->Database->prepare("SELECT pid FROM `$table` WHERE id=?")
+				->limit(1)
+				->execute($id);
+
+			return $objPid->pid;
+		}
+		catch (\Throwable $exception)
+		{
+			// Ignore errors
 		}
 
 		return null;

--- a/core-bundle/src/Resources/contao/classes/Backend.php
+++ b/core-bundle/src/Resources/contao/classes/Backend.php
@@ -342,7 +342,9 @@ abstract class Backend extends Controller
 		$id = $this->findCurrentId($strTable);
 		$objSession->set('CURRENT_ID', $id);
 
+		// Define the current ID
 		\define('CURRENT_ID', (Input::get('table') ? $id : Input::get('id')));
+
 		$this->Template->headline = $GLOBALS['TL_LANG']['MOD'][$module][0];
 
 		// Add the module style sheet
@@ -644,13 +646,13 @@ abstract class Backend extends Controller
 	}
 
 	/**
-	 * With this method the id of the current (parent) record can be determined
-	 * stateless based on the current request only.
+	 * With this method, the ID of the current (parent) record can be
+	 * determined stateless based on the current request only.
 	 *
-	 * In older versions Contao stored the id of the current (parent) record in
-	 * the user session as "CURRENT_ID" to make it known on subsequent requests.
-	 * This was unreliable and caused several issues, like for example if the
-	 * user used multiple browser tabs at the same time.
+	 * In older versions, Contao stored the ID of the current (parent) record
+	 * in the user session as "CURRENT_ID" to make it known on subsequent
+	 * requests. This was unreliable and caused several issues, like for
+	 * example if the user used multiple browser tabs at the same time.
 	 */
 	protected function findCurrentId(?string $table): ?string
 	{
@@ -665,10 +667,8 @@ abstract class Backend extends Controller
 		$mode = Input::get('mode');
 
 		// For these actions the id parameter refers to the parent record
-		if (
-			($act === 'paste' && $mode === 'create')
-			|| \in_array($act, array(null, 'select', 'editAll', 'overrideAll', 'deleteAll'), true)
-		) {
+		if (($act === 'paste' && $mode === 'create') || \in_array($act, array(null, 'select', 'editAll', 'overrideAll', 'deleteAll'), true))
+		{
 			return $id;
 		}
 
@@ -710,11 +710,7 @@ abstract class Backend extends Controller
 
 		try
 		{
-			$objPid = $this->Database->prepare("SELECT pid FROM `$table` WHERE id=?")
-				->limit(1)
-				->execute($id);
-
-			return $objPid->pid;
+			return $this->Database->prepare("SELECT pid FROM `$table` WHERE id=?")->limit(1)->execute($id)->pid;
 		}
 		catch (\Throwable $exception)
 		{

--- a/core-bundle/src/Resources/contao/classes/Backend.php
+++ b/core-bundle/src/Resources/contao/classes/Backend.php
@@ -691,12 +691,14 @@ abstract class Backend extends Controller
 		}
 
 		$allTables = array_merge(
-			...array_map(
-				static function ($module)
-				{
-					return (array) ($module['tables'] ?? array());
-				},
-				array_merge(...array_values($GLOBALS['BE_MOD']))
+			...array_values(
+				array_map(
+					static function ($module)
+					{
+						return (array) ($module['tables'] ?? array());
+					},
+					array_merge(...array_values($GLOBALS['BE_MOD']))
+				)
 			)
 		);
 

--- a/core-bundle/src/Resources/contao/classes/DataContainer.php
+++ b/core-bundle/src/Resources/contao/classes/DataContainer.php
@@ -205,6 +205,10 @@ abstract class DataContainer extends Backend
 
 			case 'createNewVersion':
 				return $this->blnCreateNewVersion;
+
+			// Forward compatibility with Contao 5.0
+			case 'currentPid':
+				return ((int) (\defined('CURRENT_ID') ? CURRENT_ID : 0)) ?: null;
 		}
 
 		return parent::__get($strKey);

--- a/core-bundle/src/Resources/contao/controllers/BackendFile.php
+++ b/core-bundle/src/Resources/contao/controllers/BackendFile.php
@@ -72,6 +72,7 @@ class BackendFile extends Backend
 
 		$strTable = Input::get('table');
 		$strField = Input::get('field');
+
 		$id = $this->findCurrentId($strTable);
 		$objSession->set('CURRENT_ID', $id);
 

--- a/core-bundle/src/Resources/contao/controllers/BackendFile.php
+++ b/core-bundle/src/Resources/contao/controllers/BackendFile.php
@@ -72,9 +72,11 @@ class BackendFile extends Backend
 
 		$strTable = Input::get('table');
 		$strField = Input::get('field');
+		$id = $this->findCurrentId($strTable);
+		$objSession->set('CURRENT_ID', $id);
 
 		// Define the current ID
-		\define('CURRENT_ID', (Input::get('table') ? $objSession->get('CURRENT_ID') : Input::get('id')));
+		\define('CURRENT_ID', (Input::get('table') ? $id : Input::get('id')));
 
 		$this->loadDataContainer($strTable);
 		$strDriver = DataContainer::getDriverForTable($strTable);

--- a/core-bundle/src/Resources/contao/controllers/BackendPage.php
+++ b/core-bundle/src/Resources/contao/controllers/BackendPage.php
@@ -72,9 +72,11 @@ class BackendPage extends Backend
 
 		$strTable = Input::get('table');
 		$strField = Input::get('field');
+		$id = $this->findCurrentId($strTable);
+		$objSession->set('CURRENT_ID', $id);
 
 		// Define the current ID
-		\define('CURRENT_ID', (Input::get('table') ? $objSession->get('CURRENT_ID') : Input::get('id')));
+		\define('CURRENT_ID', (Input::get('table') ? $id : Input::get('id')));
 
 		$this->loadDataContainer($strTable);
 		$strDriver = DataContainer::getDriverForTable($strTable);

--- a/core-bundle/src/Resources/contao/controllers/BackendPage.php
+++ b/core-bundle/src/Resources/contao/controllers/BackendPage.php
@@ -72,6 +72,7 @@ class BackendPage extends Backend
 
 		$strTable = Input::get('table');
 		$strField = Input::get('field');
+
 		$id = $this->findCurrentId($strTable);
 		$objSession->set('CURRENT_ID', $id);
 


### PR DESCRIPTION
This should also fix several `CURRENT_ID` related issues like working with multiple browser tabs, opening a picker and so on.