### PR TITLE
Add getBackendWildcard to AbstractContentElementController

### DIFF
--- a/core-bundle/src/Controller/ContentElement/AbstractContentElementController.php
+++ b/core-bundle/src/Controller/ContentElement/AbstractContentElementController.php
@@ -97,5 +97,18 @@ abstract class AbstractContentElementController extends AbstractFragmentControll
         ]);
     }
 
+    protected function getBackendWildcard(ContentModel $element): Response
+    {
+        $context = [
+            'id' => (int) $element->id,
+            'name' => $element->name,
+            'type' => $element->type,
+            'title' => StringUtil::deserialize($element->headline, true)['value'] ?? null,
+            'request_token' => $this->container->get('contao.csrf.token_manager')->getDefaultTokenValue(),
+        ];
+
+        return $this->render('@Contao/backend/content_wildcard.html.twig', $context);
+    }
+
     abstract protected function getResponse(FragmentTemplate $template, ContentModel $model, Request $request): Response;
 }

--- a/core-bundle/src/Resources/contao/templates/_new/backend/content_wildcard.html.twig
+++ b/core-bundle/src/Resources/contao/templates/_new/backend/content_wildcard.html.twig
@@ -1,0 +1,12 @@
+{% trans_default_domain 'contao_elements' %}
+
+{% if title %}
+    <h1>{{ title }}</h1>
+{% endif %}
+
+<div class="tl_gray">
+    <span class="upper">### {{ ('CTE.' ~ type ~ '.0')|trans }} ###</span>
+    <br>
+    {% set href = path('contao_backend', {do: 'articles', table: 'tl_content', act: 'edit', id, rt: request_token}) %}
+    {{ name }} (<a href="{{ href }}" class="tl_gray">ID: {{ id }}</a>)
+</div>


### PR DESCRIPTION
I would love to see this in the Core bundle. For e.g. my list / detail controllers I do not need the reusability provided by modules. In this situation I rather dislike the way they are configured in a different place. So I prefer content elements over modules more and more. Yet for list and detail controllers I just want to show a placeholder in the backend which IMHO could just look like the module placeholder. This is what this PR implements. 