### PR TITLE
Prevent unlimited recurrences in the event list

### DIFF
--- a/calendar-bundle/src/Resources/contao/modules/ModuleEventlist.php
+++ b/calendar-bundle/src/Resources/contao/modules/ModuleEventlist.php
@@ -232,16 +232,11 @@ class ModuleEventlist extends Events
 				{
 					if (!isset($unset[$v['id']]))
 					{
-						$unset[$v['id']] = 0;
-					}
-
-					if ($unset[$v['id']] > 99)
-					{
-						unset($arrEvents[$k]);
+						$unset[$v['id']] = true;
 					}
 					else
 					{
-						++$unset[$v['id']];
+						unset($arrEvents[$k]);
 					}
 				}
 			}

--- a/calendar-bundle/src/Resources/contao/modules/ModuleEventlist.php
+++ b/calendar-bundle/src/Resources/contao/modules/ModuleEventlist.php
@@ -219,6 +219,37 @@ class ModuleEventlist extends Events
 		}
 
 		unset($arrAllEvents);
+
+		// Limit the number of recurrences if both the event list and the event
+		// allow unlimited recurrences (see #4037)
+		if (!$this->numberOfItems)
+		{
+			$unset = array();
+
+			foreach ($arrEvents as $k=>$v)
+			{
+				if ($v['recurring'] && !$v['recurrences'])
+				{
+					if (!isset($unset[$v['id']]))
+					{
+						$unset[$v['id']] = 0;
+					}
+
+					if ($unset[$v['id']] > 99)
+					{
+						unset($arrEvents[$k]);
+					}
+					else
+					{
+						++$unset[$v['id']];
+					}
+				}
+			}
+
+			unset($unset);
+			$arrEvents = array_values($arrEvents);
+		}
+
 		$total = \count($arrEvents);
 		$limit = $total;
 		$offset = 0;


### PR DESCRIPTION
Fixes #4037

> * an event list is set to show all future events and
> * there are repeated events without limit,
> 
> we could show these unlimited events only once to prevent infinite repetitions.

<del>The code now sets the limit to 99 recurrences, which seems better than to only show the event once. However, if you want, I can change this.</del> This has been changed as discussed now.

The limit is only applied if neither the event list nor the event defines a limit for recurring events.