### PR TITLE
Order the languages in the meta wizard

### DIFF
--- a/core-bundle/src/Resources/contao/widgets/MetaWizard.php
+++ b/core-bundle/src/Resources/contao/widgets/MetaWizard.php
@@ -123,6 +123,9 @@ class MetaWizard extends Widget
 			}
 		}
 
+		// Sort the metadata by key (see #3818)
+		ksort($varInput);
+
 		return $varInput;
 	}
 
@@ -162,49 +165,61 @@ class MetaWizard extends Widget
 		// Add the existing entries
 		if (!empty($this->varValue))
 		{
-			$return = '<ul id="ctrl_' . $this->strId . '" class="tl_metawizard dcapicker">';
 			$languages = System::getContainer()->get('contao.intl.locales')->getDisplayNames(array_keys($this->varValue));
+			$items = array();
 
 			// Add the input fields
 			foreach ($this->varValue as $lang=>$meta)
 			{
-				$return .= '
-    <li class="' . (($count % 2 == 0) ? 'even' : 'odd') . '" data-language="' . $lang . '"><span class="lang">' . ($languages[$lang] ?? $lang) . ' ' . Image::getHtml('delete.svg', '', 'class="tl_metawizard_img" title="' . $GLOBALS['TL_LANG']['MSC']['delete'] . '" onclick="Backend.metaDelete(this)"') . '</span>';
+				$item = '<li class="' . (($count % 2 == 0) ? 'even' : 'odd') . '" data-language="' . $lang . '"><span class="lang">' . ($languages[$lang] ?? $lang) . ' ' . Image::getHtml('delete.svg', '', 'class="tl_metawizard_img" title="' . $GLOBALS['TL_LANG']['MSC']['delete'] . '" onclick="Backend.metaDelete(this)"') . '</span>';
 
 				// Take the fields from the DCA (see #4327)
 				foreach ($this->metaFields as $field=>$fieldConfig)
 				{
-					$return .= '<label' . (isset($this->arrFieldErrors[$lang][$field]) ? ' class="error"' : '') . ' for="ctrl_' . $this->strId . '_' . $field . '_' . $count . '">' . $GLOBALS['TL_LANG']['MSC']['aw_' . $field] . '</label>';
+					$item .= '<label' . (isset($this->arrFieldErrors[$lang][$field]) ? ' class="error"' : '') . ' for="ctrl_' . $this->strId . '_' . $field . '_' . $count . '">' . $GLOBALS['TL_LANG']['MSC']['aw_' . $field] . '</label>';
 
 					if (isset($fieldConfig['type']) && 'textarea' === $fieldConfig['type'])
 					{
-						$return .= '<textarea name="' . $this->strId . '[' . $lang . '][' . $field . ']" id="ctrl_' . $this->strId . '_' . $field . '_' . $count . '" class="tl_textarea"' . (!empty($fieldConfig['attributes']) ? ' ' . $fieldConfig['attributes'] : '') . '>' . ($meta[$field] ?? '') . '</textarea>';
+						$item .= '<textarea name="' . $this->strId . '[' . $lang . '][' . $field . ']" id="ctrl_' . $this->strId . '_' . $field . '_' . $count . '" class="tl_textarea"' . (!empty($fieldConfig['attributes']) ? ' ' . $fieldConfig['attributes'] : '') . '>' . ($meta[$field] ?? '') . '</textarea>';
 					}
 					else
 					{
-						$return .= '<input type="text" name="' . $this->strId . '[' . $lang . '][' . $field . ']" id="ctrl_' . $this->strId . '_' . $field . '_' . $count . '" class="tl_text" value="' . StringUtil::specialchars($meta[$field] ?? '') . '"' . (!empty($fieldConfig['attributes']) ? ' ' . $fieldConfig['attributes'] : '') . '>';
+						$item .= '<input type="text" name="' . $this->strId . '[' . $lang . '][' . $field . ']" id="ctrl_' . $this->strId . '_' . $field . '_' . $count . '" class="tl_text" value="' . StringUtil::specialchars($meta[$field] ?? '') . '"' . (!empty($fieldConfig['attributes']) ? ' ' . $fieldConfig['attributes'] : '') . '>';
 					}
 
 					// DCA picker
 					if (isset($fieldConfig['dcaPicker']) && (\is_array($fieldConfig['dcaPicker']) || $fieldConfig['dcaPicker'] === true))
 					{
-						$return .= Backend::getDcaPickerWizard($fieldConfig['dcaPicker'], $this->strTable, $this->strField, $this->strId . '_' . $field . '_' . $count);
+						$item .= Backend::getDcaPickerWizard($fieldConfig['dcaPicker'], $this->strTable, $this->strField, $this->strId . '_' . $field . '_' . $count);
 					}
 
-					$return .= '<br>';
+					$item .= '<br>';
 				}
 
-				$return .= '
-    </li>';
+				$item .= '</li>';
+
+				$items[$languages[$lang] ?? $lang] = $item;
 
 				++$count;
 			}
 
-			$return .= '
-  </ul>';
+			// Sort the items by language name (see #3818)
+			ksort($items);
+
+			// Show the user language on top (see #3818)
+			if (isset($languages[$this->User->language], $items[$languages[$this->User->language]]))
+			{
+				$buffer = $items[$languages[$this->User->language]];
+
+				unset($items[$languages[$this->User->language]]);
+
+				$items = array_merge([$languages[$this->User->language] => $buffer], $items);
+			}
+
+			$return = implode('', $items);
 		}
 
-		return $return;
+		return '<ul id="ctrl_' . $this->strId . '" class="tl_metawizard dcapicker">' . $return . '</ul>';
 	}
 }
 

--- a/core-bundle/src/Resources/contao/widgets/MetaWizard.php
+++ b/core-bundle/src/Resources/contao/widgets/MetaWizard.php
@@ -203,7 +203,7 @@ class MetaWizard extends Widget
 				++$count;
 			}
 
-			// Sort the items by language name (see #3818)
+			// Sort the items by language name with the user language on top (see #3818)
 			uksort($items, function ($a, $b) use ($languages)
 			{
 				if ($this->User->language === $a)

--- a/core-bundle/src/Resources/contao/widgets/MetaWizard.php
+++ b/core-bundle/src/Resources/contao/widgets/MetaWizard.php
@@ -215,7 +215,6 @@ class MetaWizard extends Widget
 				{
 					return 1;
 				}
-				
 				return ($languages[$a] ?? $a) <=> ($languages[$b] ?? $b);
 			});
 

--- a/core-bundle/src/Resources/contao/widgets/MetaWizard.php
+++ b/core-bundle/src/Resources/contao/widgets/MetaWizard.php
@@ -215,6 +215,7 @@ class MetaWizard extends Widget
 				{
 					return 1;
 				}
+
 				return ($languages[$a] ?? $a) <=> ($languages[$b] ?? $b);
 			});
 

--- a/core-bundle/src/Resources/contao/widgets/MetaWizard.php
+++ b/core-bundle/src/Resources/contao/widgets/MetaWizard.php
@@ -209,11 +209,7 @@ class MetaWizard extends Widget
 			// Show the user language on top (see #3818)
 			if (isset($languages[$this->User->language], $items[$languages[$this->User->language]]))
 			{
-				$buffer = $items[$languages[$this->User->language]];
-
-				unset($items[$languages[$this->User->language]]);
-
-				$items = array_merge(array($languages[$this->User->language] => $buffer), $items);
+				$items = array($languages[$this->User->language] => $items[$languages[$this->User->language]]) + $items;
 			}
 
 			$return = implode('', $items);

--- a/core-bundle/src/Resources/contao/widgets/MetaWizard.php
+++ b/core-bundle/src/Resources/contao/widgets/MetaWizard.php
@@ -198,19 +198,26 @@ class MetaWizard extends Widget
 
 				$item .= '</li>';
 
-				$items[$languages[$lang] ?? $lang] = $item;
+				$items[$lang] = $item;
 
 				++$count;
 			}
 
 			// Sort the items by language name (see #3818)
-			ksort($items);
-
-			// Show the user language on top (see #3818)
-			if (isset($languages[$this->User->language], $items[$languages[$this->User->language]]))
+			uksort($items, function ($a, $b) use ($languages)
 			{
-				$items = array_merge(array($languages[$this->User->language] => null), $items);
-			}
+				if ($this->User->language === $a)
+				{
+					return -1;
+				}
+
+				if ($this->User->language === $b)
+				{
+					return 1;
+				}
+				
+				return ($languages[$a] ?? $a) <=> ($languages[$b] ?? $b);
+			});
 
 			$return = implode('', $items);
 		}

--- a/core-bundle/src/Resources/contao/widgets/MetaWizard.php
+++ b/core-bundle/src/Resources/contao/widgets/MetaWizard.php
@@ -209,7 +209,7 @@ class MetaWizard extends Widget
 			// Show the user language on top (see #3818)
 			if (isset($languages[$this->User->language], $items[$languages[$this->User->language]]))
 			{
-				$items = array($languages[$this->User->language] => $items[$languages[$this->User->language]]) + $items;
+				$items = array_merge(array($languages[$this->User->language] => null), $items);
 			}
 
 			$return = implode('', $items);

--- a/core-bundle/src/Resources/contao/widgets/MetaWizard.php
+++ b/core-bundle/src/Resources/contao/widgets/MetaWizard.php
@@ -213,7 +213,7 @@ class MetaWizard extends Widget
 
 				unset($items[$languages[$this->User->language]]);
 
-				$items = array_merge([$languages[$this->User->language] => $buffer], $items);
+				$items = array_merge(array($languages[$this->User->language] => $buffer), $items);
 			}
 
 			$return = implode('', $items);


### PR DESCRIPTION
Fixes #3818

* we should render the fields alphabetically by label ("English", "German", "Polish") ✅ 
* but store them by language code ("de", "en", "pl"). ✅
* The language that matches the back end user's language shall be on top. ✅ 
