### PR TITLE
Fix infinite loop while loading of countries

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/System.php
+++ b/core-bundle/src/Resources/contao/library/Contao/System.php
@@ -519,7 +519,7 @@ abstract class System
 				$GLOBALS['TL_LANG']['CNT'][$strLocale] = null;
 			}
 
-			foreach (self::getContainer()->get('contao.intl.countries')->getCountries($strLanguage) as $strCountryCode => $strLabel)
+			foreach (self::getContainer()->get('contao.intl.countries')->getCountries($strCacheKey) as $strCountryCode => $strLabel)
 			{
 				$GLOBALS['TL_LANG']['CNT'][strtolower($strCountryCode)] = $strLabel;
 			}


### PR DESCRIPTION
Relates to #4254 

While loading of countries we get a infinite loop like described in #4254
The problem occurs if you use a non 2-letter language in the frontend.

I'm still not really happy with the solution because there could be again a loop if there is something broken with the cache - see: https://github.com/contao/contao/issues/4502 But maybe the broken cache was also related to this problem while loading of the countries.