### PR TITLE
Improve DropSearchMigration

### DIFF
--- a/core-bundle/src/Migration/Version410/DropSearchMigration.php
+++ b/core-bundle/src/Migration/Version410/DropSearchMigration.php
@@ -32,10 +32,7 @@ class DropSearchMigration extends AbstractMigration
     {
         $schemaManager = $this->connection->createSchemaManager();
 
-        if (
-            !$schemaManager->tablesExist('tl_search_index')
-            || $schemaManager->tablesExist('tl_search_term')
-        ) {
+        if (!$schemaManager->tablesExist('tl_search_index')) {
             return false;
         }
 


### PR DESCRIPTION
If something fails when upgrading the database from Contao <4.10 to >=4.10 you might want to re-do the migration by importing the backup from the state before the migration and then excute `contao:migrate` again. However, unless you happen to be dropping all tables before importing, the `DropSearchMigration` will not be executed again, since it checks for the existence of the `tl_search_term` table - which at that point will now already exist in the database. But the state of `tl_search` and `tl_search_index` will be from <4.10 and thus the following error will occur:

```
[ERROR] An exception occurred while executing a query: SQLSTATE[42000]: Syntax error or access violation: 1068 Multiple primary key defined
```

since Contao wants to execute `ALTER TABLE tl_search_index ADD PRIMARY KEY (termid,pid)` - but that won't be possible due to the previously existing primary KEY on `tl_search_index`.

For the purpose of this migration, only the existence of `tl_search_index.termid` should be relevant and thus the migration should not check for the existence of the `tl_search_term` table.