### PR TITLE
Stop using utf8_decode() and utf8_encode()

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/StringUtil.php
+++ b/core-bundle/src/Resources/contao/library/Contao/StringUtil.php
@@ -851,16 +851,6 @@ class StringUtil
 			return $str;
 		}
 
-		if ($from == 'UTF-8' && $to == 'ISO-8859-1')
-		{
-			return utf8_decode($str);
-		}
-
-		if ($from == 'ISO-8859-1' && $to == 'UTF-8')
-		{
-			return utf8_encode($str);
-		}
-
 		return mb_convert_encoding($str, $to, $from);
 	}
 

--- a/core-bundle/tests/Contao/StringUtilTest.php
+++ b/core-bundle/tests/Contao/StringUtilTest.php
@@ -303,14 +303,14 @@ class StringUtilTest extends TestCase
         yield 'From UTF-8 to ISO-8859-1' => [
             '𝚏ōȏճăᴦ',
             'ISO-8859-1',
-            utf8_decode('𝚏ōȏճăᴦ'),
+            '??????',
             'UTF-8',
         ];
 
         yield 'From ISO-8859-1 to UTF-8' => [
             '𝚏ōȏճăᴦ',
             'UTF-8',
-            utf8_encode('𝚏ōȏճăᴦ'),
+            'ðÅÈÕ³Äá´¦',
             'ISO-8859-1',
         ];
 


### PR DESCRIPTION
Backport of #4829. Should fix the PHP 8.2 tests.