### PR TITLE
Fix a few potential PHP 8 warnings

### DIFF
--- a/core-bundle/src/Resources/contao/forms/Form.php
+++ b/core-bundle/src/Resources/contao/forms/Form.php
@@ -393,8 +393,8 @@ class Form extends Hybrid
 			// Get subject and message
 			if ($this->format == 'email')
 			{
-				$message = $arrSubmitted['message'];
-				$email->subject = $arrSubmitted['subject'];
+				$message = $arrSubmitted['message'] ?? '';
+				$email->subject = $arrSubmitted['subject'] ?? '';
 			}
 
 			// Set the admin e-mail as "from" address
@@ -460,7 +460,7 @@ class Form extends Hybrid
 				foreach ($_SESSION['FILES'] as $file)
 				{
 					// Add a link to the uploaded file
-					if ($file['uploaded'])
+					if ($file['uploaded'] ?? false)
 					{
 						$uploaded .= "\n" . Environment::get('base') . StringUtil::stripRootDir(\dirname($file['tmp_name'])) . '/' . rawurlencode($file['name']);
 						continue;

--- a/core-bundle/src/Resources/contao/forms/Form.php
+++ b/core-bundle/src/Resources/contao/forms/Form.php
@@ -460,7 +460,7 @@ class Form extends Hybrid
 				foreach ($_SESSION['FILES'] as $file)
 				{
 					// Add a link to the uploaded file
-					if ($file['uploaded'] ?? false)
+					if ($file['uploaded'] ?? null)
 					{
 						$uploaded .= "\n" . Environment::get('base') . StringUtil::stripRootDir(\dirname($file['tmp_name'])) . '/' . rawurlencode($file['name']);
 						continue;

--- a/core-bundle/src/Resources/contao/library/Contao/Environment.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Environment.php
@@ -204,7 +204,7 @@ class Environment
 			}
 			else
 			{
-				$strRequest = $arrComponents['path'] . (isset($arrComponents['query']) ? '?' . $arrComponents['query'] : '');
+				$strRequest = ($arrComponents['path'] ?? '') . (isset($arrComponents['query']) ? '?' . $arrComponents['query'] : '');
 			}
 		}
 		else

--- a/core-bundle/src/Resources/contao/library/Contao/Pagination.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Pagination.php
@@ -149,7 +149,7 @@ class Pagination
 
 		if (Input::get($strParameter) > 0)
 		{
-			$this->intPage = Input::get($strParameter);
+			$this->intPage = (int) Input::get($strParameter);
 		}
 
 		$this->strParameter = $strParameter;

--- a/core-bundle/src/Resources/contao/widgets/SerpPreview.php
+++ b/core-bundle/src/Resources/contao/widgets/SerpPreview.php
@@ -250,9 +250,10 @@ class SerpPreview extends Widget
 			array_shift($steps);
 		}
 
-        if (isset($chunks['host'])) {
-            $steps = array_merge(array($chunks['host']), $steps);
-        }
+		if (isset($chunks['host']))
+		{
+			$steps = array_merge(array($chunks['host']), $steps);
+		}
 
 		return $steps;
 	}

--- a/core-bundle/src/Resources/contao/widgets/SerpPreview.php
+++ b/core-bundle/src/Resources/contao/widgets/SerpPreview.php
@@ -250,6 +250,10 @@ class SerpPreview extends Widget
 			array_shift($steps);
 		}
 
-		return isset($chunks['host']) ? array_merge(array($chunks['host']), $steps) : $steps;
+        if (isset($chunks['host'])) {
+            $steps = array_merge(array($chunks['host']), $steps);
+        }
+
+		return $steps;
 	}
 }

--- a/core-bundle/src/Resources/contao/widgets/SerpPreview.php
+++ b/core-bundle/src/Resources/contao/widgets/SerpPreview.php
@@ -250,6 +250,6 @@ class SerpPreview extends Widget
 			array_shift($steps);
 		}
 
-		return array_merge(array($chunks['host']), $steps);
+		return isset($chunks['host']) ? array_merge(array($chunks['host']), $steps) : $steps;
 	}
 }


### PR DESCRIPTION
We've caught a few minor and potential PHP 8 warnings on Sentry. I hope it's not a problem if they're combined within one PR. Otherwise let me know and I'll create separate pull requests.

1. Pagination issue can happen if the URL contains an invalid URL parameter such as `&page_s1=2'[0]`. Naturally, the pagination links are generated correctly, but the manually malformed URL can lead to the warning.

<img width="1159" alt="CleanShot 2022-06-20 at 11 40 38" src="https://user-images.githubusercontent.com/193483/174573794-1dd3465c-ad7f-4702-9141-baa0e97aaf8d.png">

2. The `Environment` class issue happens when someone tries to enter the URL like `https://domain.tld//index.php`.

<img width="1157" alt="CleanShot 2022-06-20 at 11 43 19" src="https://user-images.githubusercontent.com/193483/174574342-e0bf231b-f9fc-4420-97eb-0eea2d7c0275.png">

3.  The `SerpPreview` class issue did happen a few times, but I am not completely sure what are the exact circumstances to reproduce.

<img width="1158" alt="CleanShot 2022-06-20 at 11 45 32" src="https://user-images.githubusercontent.com/193483/174574797-1f5c161b-156b-4c40-87eb-acfd0e3238a3.png">

4. The `Form` class issues are related to the missing `message` and `subject` fields, which can happen because of wrong form configuration. The smaller issue if about the missing `uploaded` key, which has been already covered at a different place within this class.