### PR TITLE
Correctly add the preview script

### DIFF
--- a/core-bundle/src/Controller/BackendPreviewController.php
+++ b/core-bundle/src/Controller/BackendPreviewController.php
@@ -51,8 +51,14 @@ class BackendPreviewController
     {
         // Skip the redirect if there is no preview script, otherwise we will
         // end up in an endless loop (see #1511)
-        if ($this->previewScript && $request->getScriptName() !== $this->previewScript) {
-            return new RedirectResponse($this->previewScript.$request->getRequestUri());
+        if ($this->previewScript) {
+            $script = '/'.basename($request->getScriptName());
+
+            if ($script !== $this->previewScript) {
+                $path = dirname($request->getScriptName());
+
+                return new RedirectResponse($path.$this->previewScript.str_replace($path, '', $request->getRequestUri()));
+            }
         }
 
         if (!$this->authorizationChecker->isGranted('ROLE_USER')) {

--- a/core-bundle/src/Controller/BackendPreviewController.php
+++ b/core-bundle/src/Controller/BackendPreviewController.php
@@ -51,14 +51,8 @@ class BackendPreviewController
     {
         // Skip the redirect if there is no preview script, otherwise we will
         // end up in an endless loop (see #1511)
-        if ($this->previewScript) {
-            $script = '/'.basename($request->getScriptName());
-
-            if ($script !== $this->previewScript) {
-                $path = \dirname($request->getScriptName());
-
-                return new RedirectResponse($path.$this->previewScript.str_replace($path, '', $request->getRequestUri()));
-            }
+        if ($this->previewScript && substr($request->getScriptName(), \strlen($request->getBasePath())) !== $this->previewScript) {
+            return new RedirectResponse($request->getBasePath().$this->previewScript.$request->getPathInfo());
         }
 
         if (!$this->authorizationChecker->isGranted('ROLE_USER')) {

--- a/core-bundle/src/Controller/BackendPreviewController.php
+++ b/core-bundle/src/Controller/BackendPreviewController.php
@@ -55,7 +55,7 @@ class BackendPreviewController
             $script = '/'.basename($request->getScriptName());
 
             if ($script !== $this->previewScript) {
-                $path = dirname($request->getScriptName());
+                $path = \dirname($request->getScriptName());
 
                 return new RedirectResponse($path.$this->previewScript.str_replace($path, '', $request->getRequestUri()));
             }

--- a/core-bundle/tests/Controller/BackendPreviewControllerTest.php
+++ b/core-bundle/tests/Controller/BackendPreviewControllerTest.php
@@ -29,7 +29,7 @@ class BackendPreviewControllerTest extends TestCase
     public function testRedirectsToPreviewEntrypoint(): void
     {
         $controller = new BackendPreviewController(
-            'preview.php',
+            '/preview.php',
             $this->createMock(FrontendPreviewAuthenticator::class),
             new EventDispatcher(),
             $this->mockAuthorizationChecker()
@@ -39,13 +39,32 @@ class BackendPreviewControllerTest extends TestCase
         $response = $controller(new Request());
 
         $this->assertInstanceOf(RedirectResponse::class, $response);
-        $this->assertSame('preview.php', $response->getTargetUrl());
+        $this->assertSame('/preview.php', $response->getTargetUrl());
+    }
+
+    public function testAddsThePreviewEntrypointAtTheCorrectPosition(): void
+    {
+        $controller = new BackendPreviewController(
+            '/preview.php',
+            $this->createMock(FrontendPreviewAuthenticator::class),
+            new EventDispatcher(),
+            $this->mockAuthorizationChecker()
+        );
+
+        $request = Request::create('https://localhost/managed-edition/public/contao/preview');
+        $request->server->set('SCRIPT_NAME', '/managed-edition/public/index.php');
+
+        /** @var RedirectResponse $response */
+        $response = $controller($request);
+
+        $this->assertInstanceOf(RedirectResponse::class, $response);
+        $this->assertSame('/managed-edition/public/preview.php/contao/preview', $response->getTargetUrl());
     }
 
     public function testDeniesAccessIfNotGranted(): void
     {
         $controller = new BackendPreviewController(
-            'preview.php',
+            '/preview.php',
             $this->createMock(FrontendPreviewAuthenticator::class),
             new EventDispatcher(),
             $this->mockAuthorizationChecker(false)
@@ -69,7 +88,7 @@ class BackendPreviewControllerTest extends TestCase
         $request->query->set('user', '9');
 
         $controller = new BackendPreviewController(
-            'preview.php',
+            '/preview.php',
             $previewAuthenticator,
             new EventDispatcher(),
             $this->mockAuthorizationChecker()
@@ -90,7 +109,7 @@ class BackendPreviewControllerTest extends TestCase
         ;
 
         $controller = new BackendPreviewController(
-            'preview.php',
+            '/preview.php',
             $this->createMock(FrontendPreviewAuthenticator::class),
             $dispatcher,
             $this->mockAuthorizationChecker()
@@ -105,7 +124,7 @@ class BackendPreviewControllerTest extends TestCase
     public function testRedirectsToRootPage(): void
     {
         $controller = new BackendPreviewController(
-            'preview.php',
+            '/preview.php',
             $this->createMock(FrontendPreviewAuthenticator::class),
             new EventDispatcher(),
             $this->mockAuthorizationChecker()

--- a/core-bundle/tests/Controller/BackendPreviewControllerTest.php
+++ b/core-bundle/tests/Controller/BackendPreviewControllerTest.php
@@ -18,7 +18,6 @@ use Contao\CoreBundle\Security\Authentication\FrontendPreviewAuthenticator;
 use Contao\CoreBundle\Tests\TestCase;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\EventDispatcher\EventDispatcher;
-use Symfony\Component\HttpFoundation\InputBag;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -39,7 +38,7 @@ class BackendPreviewControllerTest extends TestCase
         $response = $controller(new Request());
 
         $this->assertInstanceOf(RedirectResponse::class, $response);
-        $this->assertSame('/preview.php', $response->getTargetUrl());
+        $this->assertSame('/preview.php/', $response->getTargetUrl());
     }
 
     public function testAddsThePreviewEntrypointAtTheCorrectPosition(): void
@@ -53,6 +52,7 @@ class BackendPreviewControllerTest extends TestCase
 
         $request = Request::create('https://localhost/managed-edition/public/contao/preview');
         $request->server->set('SCRIPT_NAME', '/managed-edition/public/index.php');
+        $request->server->set('SCRIPT_FILENAME', '/managed-edition/public/index.php');
 
         /** @var RedirectResponse $response */
         $response = $controller($request);
@@ -70,7 +70,11 @@ class BackendPreviewControllerTest extends TestCase
             $this->mockAuthorizationChecker(false)
         );
 
-        $response = $controller($this->mockRequest());
+        $request = Request::create('https://localhost/preview.php/en/');
+        $request->server->set('SCRIPT_NAME', '/preview.php');
+        $request->server->set('SCRIPT_FILENAME', '/preview.php');
+
+        $response = $controller($request);
 
         $this->assertSame($response->getStatusCode(), Response::HTTP_FORBIDDEN);
     }
@@ -84,7 +88,9 @@ class BackendPreviewControllerTest extends TestCase
             ->willReturn(true)
         ;
 
-        $request = $this->mockRequest();
+        $request = Request::create('https://localhost/managed-edition/preview.php/en/');
+        $request->server->set('SCRIPT_NAME', '/managed-edition/preview.php');
+        $request->server->set('SCRIPT_FILENAME', '/managed-edition/preview.php');
         $request->query->set('user', '9');
 
         $controller = new BackendPreviewController(
@@ -115,8 +121,12 @@ class BackendPreviewControllerTest extends TestCase
             $this->mockAuthorizationChecker()
         );
 
+        $request = Request::create('https://localhost/preview.php/en/');
+        $request->server->set('SCRIPT_NAME', '/preview.php');
+        $request->server->set('SCRIPT_FILENAME', '/preview.php');
+
         /** @var RedirectResponse $response */
-        $response = $controller($this->mockRequest());
+        $response = $controller($request);
 
         $this->assertTrue($response->isRedirection());
     }
@@ -130,34 +140,15 @@ class BackendPreviewControllerTest extends TestCase
             $this->mockAuthorizationChecker()
         );
 
-        $request = $this->mockRequest();
-        $request
-            ->expects($this->once())
-            ->method('getBaseUrl')
-            ->willReturn('/preview.php')
-        ;
+        $request = Request::create('https://localhost/preview.php/en/');
+        $request->server->set('SCRIPT_NAME', '/preview.php');
+        $request->server->set('SCRIPT_FILENAME', '/preview.php');
 
         /** @var RedirectResponse $response */
         $response = $controller($request);
 
         $this->assertInstanceOf(RedirectResponse::class, $response);
         $this->assertSame('/preview.php/', $response->getTargetUrl());
-    }
-
-    /**
-     * @return Request&MockObject
-     */
-    private function mockRequest(): Request
-    {
-        $request = $this->createMock(Request::class);
-        $request->query = new InputBag();
-
-        $request
-            ->method('getScriptName')
-            ->willReturn('preview.php')
-        ;
-
-        return $request;
     }
 
     /**


### PR DESCRIPTION
If Contao runs in a subfolder (which we allow locally), the `/preview.php` fragment will be added incorrectly.

URL: `https://domain.wip/managed-edition/public/contao/preview`
Before: `https://domain.wip/preview.php/managed-edition/public/contao/preview`
After: `https://domain.wip/managed-edition/public/preview.php/contao/preview`
