### PR TITLE
Fix the double encoding in DC_File

### DIFF
--- a/core-bundle/src/Resources/contao/drivers/DC_File.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_File.php
@@ -216,18 +216,6 @@ class DC_File extends DataContainer implements EditableDataContainerInterface
 						{
 							$this->varValue = StringUtil::deserialize($this->varValue);
 						}
-
-						if (!\is_array($this->varValue))
-						{
-							$this->varValue = htmlspecialchars($this->varValue);
-						}
-						else
-						{
-							foreach ($this->varValue as $key=>$val)
-							{
-								$this->varValue[$key] = htmlspecialchars($val);
-							}
-						}
 					}
 
 					// Call load_callback


### PR DESCRIPTION
Now that we have `Widget::specialcharsValue()`, we must not apply `htmlspecialchars()` anymore, otherwise the values in the `localconfig.php` file will be double encoded.