### PR TITLE
Fix a potential version comparison if the field definitions are missing

### DIFF
--- a/core-bundle/src/Resources/contao/classes/Versions.php
+++ b/core-bundle/src/Resources/contao/classes/Versions.php
@@ -459,14 +459,19 @@ class Versions extends Controller
 							continue;
 						}
 
-						if (\is_array($arrFields[$k]))
+						$blnIsBinary = false;
+
+						if (isset($arrFields[$k]))
 						{
-							// Detect binary fields using Doctrine's built-in types or Contao's BinaryStringType (see #3665)
-							$blnIsBinary = \in_array($arrFields[$k]['type'] ?? null, array(BinaryType::class, BlobType::class, Types::BINARY, Types::BLOB, BinaryStringType::NAME), true);
-						}
-						else
-						{
-							$blnIsBinary = strncmp($arrFields[$k], 'binary(', 7) === 0 || strncmp($arrFields[$k], 'blob ', 5) === 0;
+							if (\is_array($arrFields[$k]))
+							{
+								// Detect binary fields using Doctrine's built-in types or Contao's BinaryStringType (see #3665)
+								$blnIsBinary = \in_array($arrFields[$k]['type'] ?? null, array(BinaryType::class, BlobType::class, Types::BINARY, Types::BLOB, BinaryStringType::NAME), true);
+							}
+							else
+							{
+								$blnIsBinary = strncmp($arrFields[$k], 'binary(', 7) === 0 || strncmp($arrFields[$k], 'blob ', 5) === 0;
+							}
 						}
 
 						// Decrypt the values


### PR DESCRIPTION
I have a setup where I use Doctrine entities and have no SQL definitions in the DCA table. This results in a PHP 8 warning when comparing the record versions due to missing field definitions like `tstamp`.

The field definitions are not available, because the `Versions` class uses `DcaExtractor` behind the scenes, which sees only the fields that have a SQL definition. That is of course not the case for me, because those are defined in the Doctrine entities.