### PR TITLE
Fix inconsistency when copying child records

### DIFF
--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -1088,7 +1088,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 						// Empty unique fields or add a unique identifier in copyAll mode
 						elseif ($GLOBALS['TL_DCA'][$v]['fields'][$kk]['eval']['unique'])
 						{
-							$vv = (Input::get('act') == 'copyAll') ? $vv . '-' . substr(md5(uniqid(mt_rand(), true)), 0, 8) : Widget::getEmptyValueByFieldType($GLOBALS['TL_DCA'][$v]['fields'][$kk]['sql']);
+							$vv = (Input::get('act') == 'copyAll' && !$GLOBALS['TL_DCA'][$v]['fields'][$kk]['eval']['doNotCopy']) ? $vv . '-' . substr(md5(uniqid(mt_rand(), true)), 0, 8) : Widget::getEmptyValueByFieldType($GLOBALS['TL_DCA'][$v]['fields'][$kk]['sql']);
 						}
 
 						// Reset doNotCopy and fallback fields to their default value


### PR DESCRIPTION
While reviewing https://github.com/contao/contao/pull/4770 I noticed this inconsitency between `copy` and `copyChilds`.

Keeping this a draft until https://github.com/contao/contao/pull/4770 is merged as requested by @Toflar 🙃 