### PR TITLE
Correctly check ptable when moving records

### DIFF
--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -1756,7 +1756,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 
 			$row = $objRow->fetchAllAssoc();
 
-			if ($row[0]['pid'] == $row[1]['pid'])
+			if ($row[0]['pid'] == $row[1]['pid'] && (!($GLOBALS['TL_DCA'][$this->strTable]['config']['dynamicPtable'] ?? false) || $row[0]['ptable'] == $row[1]['ptable']))
 			{
 				$this->Database->prepare("UPDATE " . $this->strTable . " SET sorting=? WHERE id=?")
 							   ->execute($row[0]['sorting'], $row[1]['id']);


### PR DESCRIPTION
Noticed while reviewing https://github.com/contao/contao/pull/4770

FYI this might result in conflicts merging to 5.x (see https://github.com/contao/contao/pull/4912)