### PR TITLE
Do not update the search index on redirects

### DIFF
--- a/core-bundle/src/EventListener/SearchIndexListener.php
+++ b/core-bundle/src/EventListener/SearchIndexListener.php
@@ -57,6 +57,11 @@ class SearchIndexListener
     {
         $request = $event->getRequest();
         $response = $event->getResponse();
+
+        if ($response->isRedirection()) {
+            return;
+        }
+
         $document = Document::createFromRequestResponse($request, $response);
         $needsIndex = $this->needsIndex($request, $response, $document);
 

--- a/core-bundle/src/EventListener/SearchIndexListener.php
+++ b/core-bundle/src/EventListener/SearchIndexListener.php
@@ -55,13 +55,13 @@ class SearchIndexListener
      */
     public function __invoke(TerminateEvent $event): void
     {
-        $request = $event->getRequest();
         $response = $event->getResponse();
 
         if ($response->isRedirection()) {
             return;
         }
 
+        $request = $event->getRequest();
         $document = Document::createFromRequestResponse($request, $response);
         $needsIndex = $this->needsIndex($request, $response, $document);
 

--- a/core-bundle/tests/EventListener/SearchIndexListenerTest.php
+++ b/core-bundle/tests/EventListener/SearchIndexListenerTest.php
@@ -17,6 +17,7 @@ use Contao\CoreBundle\EventListener\SearchIndexListener;
 use Contao\CoreBundle\Search\Document;
 use Contao\CoreBundle\Search\Indexer\IndexerInterface;
 use Contao\CoreBundle\Tests\TestCase;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\TerminateEvent;
@@ -77,6 +78,14 @@ class SearchIndexListenerTest extends TestCase
         yield 'Should be skipped because it was requested by our own crawler' => [
             Request::create('/foobar', 'GET', [], [], [], ['HTTP_USER_AGENT' => Factory::USER_AGENT]),
             new Response(),
+            SearchIndexListener::FEATURE_DELETE | SearchIndexListener::FEATURE_INDEX,
+            false,
+            false,
+        ];
+
+        yield 'Should be skipped because it was a redirect' => [
+            Request::create('/foobar', 'GET'),
+            new RedirectResponse('https://somewhere.else'),
             SearchIndexListener::FEATURE_DELETE | SearchIndexListener::FEATURE_INDEX,
             false,
             false,


### PR DESCRIPTION
Every redirect currently causes a database connection because it tries to delete the entry from the search index.
I think it's safe to assume that we don't need this.