### PR TITLE
Make sure `eval.rte` is a string

### DIFF
--- a/core-bundle/src/Migration/Version413/RelLightboxMigration.php
+++ b/core-bundle/src/Migration/Version413/RelLightboxMigration.php
@@ -93,7 +93,9 @@ class RelLightboxMigration extends AbstractMigration
             }
 
             foreach ($GLOBALS['TL_DCA'][$tableName]['fields'] ?? [] as $fieldName => $fieldConfig) {
-                if (0 === strpos($fieldConfig['eval']['rte'] ?? '', 'tiny')) {
+                $rte = $fieldConfig['eval']['rte'] ?? '';
+
+                if (\is_string($rte) && 0 === strpos($rte, 'tiny')) {
                     $targets[] = [$tableName, strtolower($fieldName)];
                 }
             }

--- a/core-bundle/src/Migration/Version413/RelLightboxMigration.php
+++ b/core-bundle/src/Migration/Version413/RelLightboxMigration.php
@@ -93,7 +93,7 @@ class RelLightboxMigration extends AbstractMigration
             }
 
             foreach ($GLOBALS['TL_DCA'][$tableName]['fields'] ?? [] as $fieldName => $fieldConfig) {
-                $rte = $fieldConfig['eval']['rte'] ?? '';
+                $rte = $fieldConfig['eval']['rte'] ?? null;
 
                 if (\is_string($rte) && 0 === strpos($rte, 'tiny')) {
                     $targets[] = [$tableName, strtolower($fieldName)];


### PR DESCRIPTION
If some DCA erroneously defined something like

```php
'eval' => ['rte' => true]  
```

the `RelLightboxMigration` will currently fail with 

```
TypeError:
substr() expects parameter 1 to be string, bool given

  at vendor/contao/core-bundle/src/Migration/Version413/RelLightboxMigration.php:96
```

This PR makes the migration more robust by checking whether the value is actually a string.
