### PR TITLE
Do not call `kernel.terminate` on fresh cache entries

### DIFF
--- a/manager-bundle/src/HttpKernel/ContaoCache.php
+++ b/manager-bundle/src/HttpKernel/ContaoCache.php
@@ -51,9 +51,9 @@ class ContaoCache extends HttpCache implements CacheInvalidation
     /**
      * Override default terminate method in order to never call the kernel.terminate
      * event on cache hit. This can be removed once symfony/http-kernel is required
-     * in at least ^6.2
+     * in at least ^6.2.
      */
-    public function terminate(Request $request, Response $response)
+    public function terminate(Request $request, Response $response): void
     {
         $traces = $this->getTraces();
 
@@ -91,11 +91,12 @@ class ContaoCache extends HttpCache implements CacheInvalidation
     /**
      * Unfortunately, we need to copy this from the parent as it is private.
      * This can be removed once symfony/http-kernel is required
-     * in at least ^6.2
+     * in at least ^6.2.
      */
     private function getTraceKey(Request $request): string
     {
         $path = $request->getPathInfo();
+
         if ($qs = $request->getQueryString()) {
             $path .= '?'.$qs;
         }

--- a/manager-bundle/src/HttpKernel/ContaoCache.php
+++ b/manager-bundle/src/HttpKernel/ContaoCache.php
@@ -49,9 +49,10 @@ class ContaoCache extends HttpCache implements CacheInvalidation
     }
 
     /**
-     * Override default terminate method in order to never call the kernel.terminate
-     * event on cache hit. This can be removed once symfony/http-kernel is required
-     * in at least ^6.2.
+     * Override default terminate method in order to never call the
+     * "kernel.terminate" event on cache hit.
+     *
+     * @todo Remove once symfony/http-kernel is required in at least ^6.2
      */
     public function terminate(Request $request, Response $response): void
     {
@@ -90,8 +91,8 @@ class ContaoCache extends HttpCache implements CacheInvalidation
 
     /**
      * Unfortunately, we need to copy this from the parent as it is private.
-     * This can be removed once symfony/http-kernel is required
-     * in at least ^6.2.
+     *
+     * @todo Remove once symfony/http-kernel is required in at least ^6.2
      */
     private function getTraceKey(Request $request): string
     {

--- a/manager-bundle/src/HttpKernel/ContaoCache.php
+++ b/manager-bundle/src/HttpKernel/ContaoCache.php
@@ -24,6 +24,7 @@ use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\Cache\Adapter\TagAwareAdapter;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\TerminableInterface;
 use Toflar\Psr6HttpCacheStore\Psr6Store;
 
 class ContaoCache extends HttpCache implements CacheInvalidation
@@ -47,6 +48,24 @@ class ContaoCache extends HttpCache implements CacheInvalidation
         return parent::fetch($request, $catch);
     }
 
+    /**
+     * Override default terminate method in order to never call the kernel.terminate
+     * event on cache hit. This can be removed once symfony/http-kernel is required
+     * in at least ^6.2
+     */
+    public function terminate(Request $request, Response $response)
+    {
+        $traces = $this->getTraces();
+
+        if (\in_array('fresh', $traces[$this->getTraceKey($request)] ?? [], true)) {
+            return;
+        }
+
+        if ($this->getKernel() instanceof TerminableInterface) {
+            $this->getKernel()->terminate($request, $response);
+        }
+    }
+
     protected function getOptions(): array
     {
         $options = parent::getOptions();
@@ -67,5 +86,20 @@ class ContaoCache extends HttpCache implements CacheInvalidation
             'cache_tags_header' => TagHeaderFormatter::DEFAULT_HEADER_NAME,
             'prune_threshold' => 5000,
         ]);
+    }
+
+    /**
+     * Unfortunately, we need to copy this from the parent as it is private.
+     * This can be removed once symfony/http-kernel is required
+     * in at least ^6.2
+     */
+    private function getTraceKey(Request $request): string
+    {
+        $path = $request->getPathInfo();
+        if ($qs = $request->getQueryString()) {
+            $path .= '?'.$qs;
+        }
+
+        return $request->getMethod().' '.$path;
     }
 }

--- a/manager-bundle/tests/HttpKernel/ContaoCacheTest.php
+++ b/manager-bundle/tests/HttpKernel/ContaoCacheTest.php
@@ -80,11 +80,13 @@ class ContaoCacheTest extends ContaoTestCase
             ->method('getContainer')
             ->willReturn(new Container())
         ;
+
         $kernel
             ->expects($this->once()) // Second is coming from the cache
             ->method('handle')
             ->willReturnOnConsecutiveCalls($response, $response)
         ;
+
         $kernel
             ->expects($this->once()) // Second is coming from the cache
             ->method('terminate')

--- a/manager-bundle/tests/HttpKernel/ContaoCacheTest.php
+++ b/manager-bundle/tests/HttpKernel/ContaoCacheTest.php
@@ -78,15 +78,18 @@ class ContaoCacheTest extends ContaoTestCase
         $kernel
             ->expects($this->once())
             ->method('getContainer')
-            ->willReturn(new Container());
+            ->willReturn(new Container())
+        ;
         $kernel
             ->expects($this->once()) // Second is coming from the cache
             ->method('handle')
-            ->willReturnOnConsecutiveCalls($response, $response);
+            ->willReturnOnConsecutiveCalls($response, $response)
+        ;
         $kernel
             ->expects($this->once()) // Second is coming from the cache
             ->method('terminate')
-            ->willReturnOnConsecutiveCalls($response, $response);
+            ->willReturnOnConsecutiveCalls($response, $response)
+        ;
 
         $cache = new ContaoCache($kernel, $this->getTempDir());
         $request = Request::create('/foobar');

--- a/manager-bundle/tests/HttpKernel/ContaoCacheTest.php
+++ b/manager-bundle/tests/HttpKernel/ContaoCacheTest.php
@@ -20,6 +20,9 @@ use FOS\HttpCache\SymfonyCache\CleanupCacheTagsListener;
 use FOS\HttpCache\SymfonyCache\Events;
 use FOS\HttpCache\SymfonyCache\PurgeListener;
 use FOS\HttpCache\SymfonyCache\PurgeTagsListener;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Toflar\Psr6HttpCacheStore\Psr6Store;
 
 class ContaoCacheTest extends ContaoTestCase
@@ -65,6 +68,34 @@ class ContaoCacheTest extends ContaoTestCase
         $cache = new ContaoCache($this->createMock(ContaoKernel::class), $this->getTempDir());
 
         $this->assertInstanceOf(Psr6Store::class, $cache->getStore());
+    }
+
+    public function testDoesNotDispatchTerminateEventOnCacheHit(): void
+    {
+        $response = (new Response())->setSharedMaxAge(500);
+
+        $kernel = $this->createMock(ContaoKernel::class);
+        $kernel
+            ->expects($this->once())
+            ->method('getContainer')
+            ->willReturn(new Container());
+        $kernel
+            ->expects($this->once()) // Second is coming from the cache
+            ->method('handle')
+            ->willReturnOnConsecutiveCalls($response, $response);
+        $kernel
+            ->expects($this->once()) // Second is coming from the cache
+            ->method('terminate')
+            ->willReturnOnConsecutiveCalls($response, $response);
+
+        $cache = new ContaoCache($kernel, $this->getTempDir());
+        $request = Request::create('/foobar');
+
+        $cache->handle($request);
+        $cache->terminate($request, $response);
+
+        $cache->handle($request);
+        $cache->terminate($request, $response);
     }
 
     public function cookeWhitelistProvider(): \Generator


### PR DESCRIPTION
Fixes https://github.com/contao/contao/issues/4869

As of Symfon y 6.2, the usage of it is deprecated and will be removed. As discussed within the Core team, we want to fix this already now.