### PR TITLE
Hide the "icon" table header in the user and member module

### DIFF
--- a/core-bundle/src/Resources/contao/dca/tl_member.php
+++ b/core-bundle/src/Resources/contao/dca/tl_member.php
@@ -55,7 +55,7 @@ $GLOBALS['TL_DCA']['tl_member'] = array
 		),
 		'label' => array
 		(
-			'fields'                  => array('icon', 'firstname', 'lastname', 'username', 'dateAdded'),
+			'fields'                  => array('', 'firstname', 'lastname', 'username', 'dateAdded'),
 			'showColumns'             => true,
 			'label_callback'          => array('tl_member', 'addIcon')
 		),

--- a/core-bundle/src/Resources/contao/dca/tl_user.php
+++ b/core-bundle/src/Resources/contao/dca/tl_user.php
@@ -66,7 +66,7 @@ $GLOBALS['TL_DCA']['tl_user'] = array
 		),
 		'label' => array
 		(
-			'fields'                  => array('icon', 'name', 'username', 'dateAdded'),
+			'fields'                  => array('', 'name', 'username', 'dateAdded'),
 			'showColumns'             => true,
 			'label_callback'          => array('tl_user', 'addIcon')
 		),


### PR DESCRIPTION
Follow-up on #4849

<img width="827" alt="" src="https://user-images.githubusercontent.com/1192057/175961767-e0617e4d-56a3-4297-844f-45c69f108a23.png">

Now that the array key is used as fallback, we have to use an empty string instead.