### PR TITLE
Fix a potential PHP 8 warning in tl_article callback

### DIFF
--- a/core-bundle/src/Resources/contao/dca/tl_article.php
+++ b/core-bundle/src/Resources/contao/dca/tl_article.php
@@ -410,7 +410,7 @@ class tl_article extends Backend
 		}
 
 		// Set allowed clipboard IDs
-		if (isset($session['CLIPBOARD']['tl_article']) && is_array($session['CLIPBOARD']['tl_article']['id']))
+		if (!empty($session['CLIPBOARD']['tl_article']['id']) && is_array($session['CLIPBOARD']['tl_article']['id']))
 		{
 			$clipboard = array();
 


### PR DESCRIPTION
<img width="1120" alt="CleanShot 2022-06-28 at 09 41 50" src="https://user-images.githubusercontent.com/193483/176122264-990f7c02-df90-48f6-8287-2e83dde41675.png">

All the other places seem to be doing it correctly:

1. https://github.com/contao/contao/blob/eb37857c26de5fd3a230d583681e78ced0178ce4/core-bundle/src/Resources/contao/dca/tl_content.php#L1183
2. https://github.com/contao/contao/blob/eb37857c26de5fd3a230d583681e78ced0178ce4/core-bundle/src/Resources/contao/dca/tl_form_field.php#L643