### PR TITLE
Fix the query string being lost during the preview script redirect

### DIFF
--- a/core-bundle/src/Controller/BackendPreviewController.php
+++ b/core-bundle/src/Controller/BackendPreviewController.php
@@ -52,7 +52,9 @@ class BackendPreviewController
         // Skip the redirect if there is no preview script, otherwise we will
         // end up in an endless loop (see #1511)
         if ($this->previewScript && substr($request->getScriptName(), \strlen($request->getBasePath())) !== $this->previewScript) {
-            return new RedirectResponse($request->getBasePath().$this->previewScript.$request->getPathInfo());
+            $qs = $request->getQueryString();
+
+            return new RedirectResponse($request->getBasePath().$this->previewScript.$request->getPathInfo().($qs ? '?'.$qs : ''));
         }
 
         if (!$this->authorizationChecker->isGranted('ROLE_USER')) {

--- a/core-bundle/tests/Controller/BackendPreviewControllerTest.php
+++ b/core-bundle/tests/Controller/BackendPreviewControllerTest.php
@@ -50,7 +50,7 @@ class BackendPreviewControllerTest extends TestCase
             $this->mockAuthorizationChecker()
         );
 
-        $request = Request::create('https://localhost/managed-edition/public/contao/preview');
+        $request = Request::create('https://localhost/managed-edition/public/contao/preview?page=123');
         $request->server->set('SCRIPT_NAME', '/managed-edition/public/index.php');
         $request->server->set('SCRIPT_FILENAME', '/managed-edition/public/index.php');
 
@@ -58,7 +58,7 @@ class BackendPreviewControllerTest extends TestCase
         $response = $controller($request);
 
         $this->assertInstanceOf(RedirectResponse::class, $response);
-        $this->assertSame('/managed-edition/public/preview.php/contao/preview', $response->getTargetUrl());
+        $this->assertSame('/managed-edition/public/preview.php/contao/preview?page=123', $response->getTargetUrl());
     }
 
     public function testDeniesAccessIfNotGranted(): void


### PR DESCRIPTION
This is a follow-up on #4857. Since that pull request got merged, the frontend preview has always shown the homepage due to missing query string parameters.