### PR TITLE
Display an error message if the version cannot be restored

### DIFF
--- a/core-bundle/src/Resources/contao/classes/Versions.php
+++ b/core-bundle/src/Resources/contao/classes/Versions.php
@@ -312,9 +312,17 @@ class Versions extends Controller
 			}
 		}
 
-		$this->Database->prepare("UPDATE " . $this->strTable . " %s WHERE id=?")
-					   ->set($data)
-					   ->execute($this->intPid);
+		try
+		{
+			$this->Database->prepare("UPDATE " . $this->strTable . " %s WHERE id=?")
+						   ->set($data)
+						   ->execute($this->intPid);
+		}
+		catch (\Exception $e)
+		{
+			Message::addError(sprintf($GLOBALS['TL_LANG']['MSC']['versionNotRestored'], $intVersion));
+			Controller::reload();
+		}
 
 		$this->Database->prepare("UPDATE tl_version SET active='' WHERE fromTable=? AND pid=?")
 					   ->execute($this->strTable, $this->intPid);

--- a/core-bundle/src/Resources/contao/classes/Versions.php
+++ b/core-bundle/src/Resources/contao/classes/Versions.php
@@ -320,6 +320,7 @@ class Versions extends Controller
 		}
 		catch (\Exception $e)
 		{
+			System::log(sprintf('Could not restore version %d of %s.%d due to the following exception: %s.', $intVersion, $this->strTable, $this->intPid, $e->getMessage()), __METHOD__, TL_ERROR);
 			Message::addError(sprintf($GLOBALS['TL_LANG']['MSC']['versionNotRestored'], $intVersion));
 			Controller::reload();
 		}

--- a/core-bundle/src/Resources/contao/languages/en/default.xlf
+++ b/core-bundle/src/Resources/contao/languages/en/default.xlf
@@ -243,7 +243,7 @@
         <source>Unknown username: %s</source>
       </trans-unit>
       <trans-unit id="ERR.versionNotRestored">
-        <source>Version %d could not be restored! Please consider restoring the data manually.</source>
+        <source>Version %d could not be restored. Previous data is not compatible with the current database definition anymore. Please consider restoring the data manually.</source>
       </trans-unit>
       <trans-unit id="SEC.question1">
         <source>Please add %d and %d.</source>

--- a/core-bundle/src/Resources/contao/languages/en/default.xlf
+++ b/core-bundle/src/Resources/contao/languages/en/default.xlf
@@ -242,6 +242,9 @@
       <trans-unit id="ERR.previewSwitchInvalidUsername">
         <source>Unknown username: %s</source>
       </trans-unit>
+      <trans-unit id="ERR.versionNotRestored">
+        <source>Version %d could not be restored! Please consider restoring the data manually.</source>
+      </trans-unit>
       <trans-unit id="SEC.question1">
         <source>Please add %d and %d.</source>
       </trans-unit>


### PR DESCRIPTION
This change will display an error message if the version cannot be restored instead of throwing an exception. It's rather an edge case, but it can happen that the column SQL definition has changed, and the previous value of the column is no longer valid.

Example:

1. Have a `my_column` field that is nullable.
2. The record is saved, and the version data contains the `my_column=null`.
3. The `my_column` SQL definition changes; it is no longer nullable.
4. A user wants to restore the previous version, but it ends up in an error because it wants to set the `my_column=null` value on the column that can no longer be null. It's probably not the only case, and it could probably also happen if the new column length is shorter than the previous record value resulting in the "data truncated for column" error.
5. An exception is thrown.

This pull request changes point 5. to display a nice error message explaining what happened instead of throwing the exception.

![CleanShot 2022-06-29 at 10 00 01](https://user-images.githubusercontent.com/193483/176384006-9d68df8d-cbb2-477b-ac2f-cdcc60cd3297.png)

