### PR TITLE
Add error handling to the form data processing

### DIFF
--- a/core-bundle/contao/forms/Form.php
+++ b/core-bundle/contao/forms/Form.php
@@ -64,7 +64,7 @@ class Form extends Hybrid
 	/**
 	 * @var array<string>
 	 */
-	private array $errors = [];
+	private array $errors = array();
 
 	/**
 	 * Remove name attributes in the back end so the form is not validated

--- a/core-bundle/contao/forms/Form.php
+++ b/core-bundle/contao/forms/Form.php
@@ -67,14 +67,6 @@ class Form extends Hybrid
 	private array $errors = [];
 
 	/**
-	 * {@inheritDoc}
-	 */
-	public function __construct($objElement, $strColumn='main')
-	{
-		parent::__construct($objElement, $strColumn);
-	}
-
-	/**
 	 * Remove name attributes in the back end so the form is not validated
 	 *
 	 * @return string

--- a/core-bundle/contao/forms/Form.php
+++ b/core-bundle/contao/forms/Form.php
@@ -325,7 +325,7 @@ class Form extends Hybrid
 		}
 
 		$this->Template->hasError = $doNotSubmit || $this->hasErrors();
-		$this->Template->errors = $this->getErrors()->toArray();
+		$this->Template->errors = $this->getErrors();
 		$this->Template->attributes = $strAttributes;
 		$this->Template->enctype = $hasUpload ? 'multipart/form-data' : 'application/x-www-form-urlencoded';
 		$this->Template->maxFileSize = $hasUpload ? $this->objModel->getMaxUploadFileSize() : false;

--- a/core-bundle/contao/forms/Form.php
+++ b/core-bundle/contao/forms/Form.php
@@ -12,8 +12,6 @@ namespace Contao;
 
 use Contao\CoreBundle\Routing\ResponseContext\HtmlHeadBag\HtmlHeadBag;
 use Contao\CoreBundle\Session\Attribute\AutoExpiringAttribute;
-use Doctrine\Common\Collections\ArrayCollection;
-use Doctrine\Common\Collections\Collection;
 
 /**
  * Provide methods to handle front end forms.
@@ -64,9 +62,9 @@ class Form extends Hybrid
 	protected $strTemplate = 'form_wrapper';
 
 	/**
-	 * @var Collection<string>
+	 * @var array<string>
 	 */
-	private Collection $errors;
+	private array $errors = [];
 
 	/**
 	 * {@inheritDoc}
@@ -74,7 +72,6 @@ class Form extends Hybrid
 	public function __construct($objElement, $strColumn='main')
 	{
 		parent::__construct($objElement, $strColumn);
-		$this->errors = new ArrayCollection();
 	}
 
 	/**
@@ -112,22 +109,22 @@ class Form extends Hybrid
 	}
 
 	/**
-	 * @return Collection<string>
+	 * @return array<string>
 	 */
-	public function getErrors(): Collection
+	public function getErrors(): array
 	{
 		return $this->errors;
 	}
 
 	public function hasErrors(): bool
 	{
-		return !$this->errors->isEmpty();
+		return !empty($this->errors);
 	}
 
 	/**
-	 * @param Collection<string> $errors
+	 * @param array<string> $errors
 	 */
-	public function setErrors(Collection $errors): self
+	public function setErrors(array $errors): self
 	{
 		$this->errors = $errors;
 
@@ -136,7 +133,7 @@ class Form extends Hybrid
 
 	public function addError(string $error): self
 	{
-		$this->errors->add($error);
+		$this->errors[] = $error;
 
 		return $this;
 	}

--- a/core-bundle/contao/templates/forms/form_wrapper.html5
+++ b/core-bundle/contao/templates/forms/form_wrapper.html5
@@ -8,6 +8,11 @@
 
   <form<?php if ($this->action): ?> action="<?= $this->action ?>"<?php endif; ?> method="<?= $this->method ?>" enctype="<?= $this->enctype ?>"<?= $this->attributes ?><?= $this->novalidate ?>>
     <div class="formbody">
+      <?php if ($this->errors): ?>
+        <?php foreach ($this->errors as $error): ?>
+          <p class="error"><?= $error ?></p>
+        <?php endforeach; ?>
+      <?php endif; ?>
       <?php if ('get' != $this->method): ?>
         <input type="hidden" name="FORM_SUBMIT" value="<?= $this->formSubmit ?>">
         <input type="hidden" name="REQUEST_TOKEN" value="<?= $this->requestToken ?>">


### PR DESCRIPTION
Currently, it's not possible to pass errors to the form while executing the hook `processFormData`, e.g. in the notification center (see: https://github.com/terminal42/contao-notification_center/issues/258). That's why I added some error handling to the `Form` class.

In the notification center there needs to be added something like this:
```php
//classes/tl_form.php
public function sendFormNotification($arrData, $arrForm, $arrFiles, $arrLabels, $form)
{
...
    $form->addError('A mail error occurred!');
...
}
```

I'm not sure how to automatically test this new feature or is it not really possible? 🤔 