### PR TITLE
Correctly cast the column types

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Model.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Model.php
@@ -401,9 +401,11 @@ abstract class Model
 		{
 			foreach ($table->getColumns() as $column)
 			{
-				if (\in_array($column->getType()->getName(), array(Types::INTEGER, Types::SMALLINT, Types::FLOAT, Types::BOOLEAN), true))
+				$type = strtolower($column->getType()->getName());
+
+				if (\in_array($type, array(Types::INTEGER, Types::SMALLINT, Types::FLOAT, Types::BOOLEAN), true))
 				{
-					$types[$table->getName()][$column->getName()] = $column->getType()->getName();
+					$types[strtolower($table->getName())][strtolower($column->getName())] = $type;
 				}
 			}
 		}

--- a/core-bundle/src/Resources/contao/models/PageModel.php
+++ b/core-bundle/src/Resources/contao/models/PageModel.php
@@ -877,7 +877,7 @@ class PageModel extends Model
 		$this->layout = $this->includeLayout ? $this->layout : 0;
 		$this->cache = $this->includeCache ? $this->cache : 0;
 		$this->alwaysLoadFromCache = $this->includeCache ? $this->alwaysLoadFromCache : false;
-		$this->clientCache = $this->includeCache ? $this->clientCache : false;
+		$this->clientCache = $this->includeCache ? $this->clientCache : 0;
 
 		$pid = $this->pid;
 		$type = $this->type;


### PR DESCRIPTION
Without this fix, `Model::$arrColumnCastTypes` will not match `strtolower(static::$strTable)` and `strtolower($strKey)` and return `0` instead of `false` for columns such as `useSSL`.