### PR TITLE
Remove redundant type casts

### DIFF
--- a/core-bundle/src/Asset/ContaoContext.php
+++ b/core-bundle/src/Asset/ContaoContext.php
@@ -46,7 +46,7 @@ class ContaoContext implements ContextInterface
         $page = $this->getPageModel();
 
         if (null !== $page) {
-            return (bool) $page->loadDetails()->rootUseSSL;
+            return $page->loadDetails()->rootUseSSL;
         }
 
         $request = $this->requestStack->getMainRequest();

--- a/core-bundle/src/Controller/ContentElement/ImagesController.php
+++ b/core-bundle/src/Controller/ContentElement/ImagesController.php
@@ -54,7 +54,7 @@ class ImagesController extends AbstractContentElementController
 
         // Limit elements; use client-side logic for only displaying the first
         // $limit elements in case we are dealing with a random order
-        if (($limit = (int) $model->numberOfItems) > 0 && !$randomize) {
+        if (($limit = $model->numberOfItems) > 0 && !$randomize) {
             $filesystemItems = $filesystemItems->limit($limit);
         }
 
@@ -65,7 +65,7 @@ class ImagesController extends AbstractContentElementController
             ->createFigureBuilder()
             ->setSize($model->size)
             ->setLightboxGroupIdentifier('lb'.$model->id)
-            ->enableLightbox((bool) $model->fullsize)
+            ->enableLightbox($model->fullsize)
         ;
 
         if ('image' === $model->type) {
@@ -80,8 +80,8 @@ class ImagesController extends AbstractContentElementController
         );
 
         $template->set('images', $imageList);
-        $template->set('items_per_page', (int) $model->perPage ?: null);
-        $template->set('items_per_row', (int) $model->perRow ?: null);
+        $template->set('items_per_page', $model->perPage ?: null);
+        $template->set('items_per_row', $model->perRow ?: null);
 
         return $template->getResponse();
     }

--- a/core-bundle/src/Controller/ContentElement/TableController.php
+++ b/core-bundle/src/Controller/ContentElement/TableController.php
@@ -34,7 +34,7 @@ class TableController extends AbstractContentElementController
         $template->set('header', $header);
         $template->set('footer', $footer);
         $template->set('rows', $rows);
-        $template->set('use_row_headers', (bool) $model->tleft);
+        $template->set('use_row_headers', $model->tleft);
         $template->set('caption', $model->summary ?: null);
 
         // Client side sorting

--- a/core-bundle/src/Controller/ContentElement/TextController.php
+++ b/core-bundle/src/Controller/ContentElement/TextController.php
@@ -37,7 +37,7 @@ class TextController extends AbstractContentElementController
             ->fromUuid($model->singleSRC ?: '')
             ->setSize($model->size)
             ->setMetadata($model->getOverwriteMetadata())
-            ->enableLightbox((bool) $model->fullsize)
+            ->enableLightbox($model->fullsize)
             ->buildIfResourceExists()
         ;
 

--- a/core-bundle/src/Controller/FrontendModule/AbstractFrontendModuleController.php
+++ b/core-bundle/src/Controller/FrontendModule/AbstractFrontendModuleController.php
@@ -55,7 +55,7 @@ abstract class AbstractFrontendModuleController extends AbstractFragmentControll
     protected function getBackendWildcard(ModuleModel $module): Response
     {
         $context = [
-            'id' => (int) $module->id,
+            'id' => $module->id,
             'name' => $module->name,
             'type' => $module->type,
             'title' => StringUtil::deserialize($module->headline, true)['value'] ?? null,

--- a/core-bundle/src/Controller/Page/RootPageController.php
+++ b/core-bundle/src/Controller/Page/RootPageController.php
@@ -32,7 +32,7 @@ class RootPageController extends AbstractController
 
     public function __invoke(PageModel $pageModel): Response
     {
-        $nextPage = $this->getNextPage((int) $pageModel->id);
+        $nextPage = $this->getNextPage($pageModel->id);
 
         return $this->redirect($nextPage->getAbsoluteUrl());
     }

--- a/core-bundle/src/Entity/TrustedDevice.php
+++ b/core-bundle/src/Entity/TrustedDevice.php
@@ -51,7 +51,7 @@ class TrustedDevice
 
     public function __construct(User $user)
     {
-        $this->userId = (int) $user->id;
+        $this->userId = $user->id;
         $this->created = new \DateTime();
         $this->userClass = $user::class;
     }

--- a/core-bundle/src/EventListener/PageAccessListener.php
+++ b/core-bundle/src/EventListener/PageAccessListener.php
@@ -74,8 +74,8 @@ class PageAccessListener
             isset($GLOBALS['objPage'])
             && $GLOBALS['objPage'] instanceof PageModel
             && (
-                ($pageModel instanceof PageModel && (int) $pageModel->id === (int) $GLOBALS['objPage']->id)
-                || (!$pageModel instanceof PageModel && (int) $GLOBALS['objPage']->id === (int) $pageModel)
+                ($pageModel instanceof PageModel && (int) $pageModel->id === $GLOBALS['objPage']->id)
+                || (!$pageModel instanceof PageModel && $GLOBALS['objPage']->id === (int) $pageModel)
             )
         ) {
             return $GLOBALS['objPage'];

--- a/core-bundle/src/HttpKernel/ModelArgumentResolver.php
+++ b/core-bundle/src/HttpKernel/ModelArgumentResolver.php
@@ -73,7 +73,7 @@ class ModelArgumentResolver implements ArgumentValueResolverInterface
         if (
             isset($GLOBALS['objPage'])
             && $GLOBALS['objPage'] instanceof PageModel
-            && (int) $GLOBALS['objPage']->id === (int) $value
+            && $GLOBALS['objPage']->id === (int) $value
             && is_a($type, PageModel::class, true)
         ) {
             return $GLOBALS['objPage'];

--- a/core-bundle/src/Routing/ResponseContext/CoreResponseContextFactory.php
+++ b/core-bundle/src/Routing/ResponseContext/CoreResponseContextFactory.php
@@ -108,9 +108,9 @@ class CoreResponseContextFactory
             ->set(
                 new ContaoPageSchema(
                     $title ?: '',
-                    (int) $pageModel->id,
-                    (bool) $pageModel->noSearch,
-                    (bool) $pageModel->protected,
+                    $pageModel->id,
+                    $pageModel->noSearch,
+                    $pageModel->protected,
                     array_map('intval', array_filter((array) $pageModel->groups)),
                     $this->tokenChecker->isPreviewMode()
                 )

--- a/core-bundle/src/Security/TwoFactor/TrustedDeviceManager.php
+++ b/core-bundle/src/Security/TwoFactor/TrustedDeviceManager.php
@@ -89,7 +89,7 @@ class TrustedDeviceManager implements TrustedDeviceManagerInterface
             ->andWhere('td.userClass = :userClass')
             ->andWhere('td.userId = :userId')
             ->setParameter('userClass', $user::class)
-            ->setParameter('userId', (int) $user->id)
+            ->setParameter('userId', $user->id)
             ->getQuery()
             ->execute()
         ;

--- a/core-bundle/src/Security/Voter/BackendAccessVoter.php
+++ b/core-bundle/src/Security/Voter/BackendAccessVoter.php
@@ -130,7 +130,7 @@ class BackendAccessVoter extends Voter implements ResetInterface
             $permission[] = 'g'.$flag;
         }
 
-        if ($cuser === (int) $user->id) {
+        if ($cuser === $user->id) {
             $permission[] = 'u'.$flag;
         }
 

--- a/core-bundle/tests/Controller/ContentElement/ImagesControllerTest.php
+++ b/core-bundle/tests/Controller/ContentElement/ImagesControllerTest.php
@@ -63,11 +63,11 @@ class ImagesControllerTest extends ContentElementTestCase
                     StringUtil::uuidToBin(ContentElementTestCase::FILE_IMAGE3),
                 ]),
                 'sortBy' => 'name_desc',
-                'numberOfItems' => '2',
+                'numberOfItems' => 2,
                 'size' => '',
                 'fullsize' => true,
-                'perPage' => '4',
-                'perRow' => '2',
+                'perPage' => 4,
+                'perRow' => 2,
             ],
         );
 

--- a/core-bundle/tests/Routing/ResponseContext/CoreResponseContextFactoryTest.php
+++ b/core-bundle/tests/Routing/ResponseContext/CoreResponseContextFactoryTest.php
@@ -121,11 +121,14 @@ class CoreResponseContextFactoryTest extends TestCase
 
         /** @var PageModel $pageModel */
         $pageModel = $this->mockClassWithProperties(PageModel::class);
+        $pageModel->id = 0;
         $pageModel->title = 'My title';
         $pageModel->description = 'My description';
         $pageModel->robots = 'noindex,nofollow';
         $pageModel->enableCanonical = true;
         $pageModel->canonicalLink = '{{link_url::42}}';
+        $pageModel->noSearch = false;
+        $pageModel->protected = false;
 
         $factory = new CoreResponseContextFactory(
             $responseAccessor,
@@ -174,8 +177,11 @@ class CoreResponseContextFactoryTest extends TestCase
 
         /** @var PageModel $pageModel */
         $pageModel = $this->mockClassWithProperties(PageModel::class);
+        $pageModel->id = 0;
         $pageModel->title = 'We went from Alpha &#62; Omega';
         $pageModel->description = 'My description <strong>contains</strong> HTML<br>.';
+        $pageModel->noSearch = false;
+        $pageModel->protected = false;
 
         $insertTagsParser = $this->createMock(InsertTagParser::class);
         $insertTagsParser


### PR DESCRIPTION
Now that our model class converts integers and booleans, we no longer need these type casts.