### PR TITLE
Pass the request object to the Environment::phpSelf() method

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Environment.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Environment.php
@@ -107,7 +107,7 @@ class Environment
 	 *
 	 * @return string The relative path to the script
 	 */
-	protected static function scriptName($request)
+	protected static function scriptName(Request $request)
 	{
 		return $request->getScriptName();
 	}
@@ -117,9 +117,9 @@ class Environment
 	 *
 	 * @return string The script name
 	 */
-	protected static function phpSelf()
+	protected static function phpSelf(Request $request)
 	{
-		return static::scriptName();
+		return static::scriptName($request);
 	}
 
 	/**


### PR DESCRIPTION
This fixes the `Required parameter $request missing` error.