### PR TITLE
Fix the cache and clientCache values

### DIFF
--- a/core-bundle/src/Resources/contao/classes/FrontendTemplate.php
+++ b/core-bundle/src/Resources/contao/classes/FrontendTemplate.php
@@ -148,8 +148,8 @@ class FrontendTemplate extends Template
 		/** @var PageModel $objPage */
 		global $objPage;
 
-		// Do not cache the response if caching was not configured at all or disabled explicitly
-		if (($objPage->cache === false || $objPage->cache < 1) && ($objPage->clientCache === false || $objPage->clientCache < 1))
+		// Do not cache the response if caching was not configured
+		if ($objPage->cache < 1 && $objPage->clientCache < 1)
 		{
 			$response->headers->set('Cache-Control', 'no-cache, no-store');
 

--- a/core-bundle/src/Resources/contao/models/PageModel.php
+++ b/core-bundle/src/Resources/contao/models/PageModel.php
@@ -935,9 +935,9 @@ class PageModel extends Model
 					// Cache
 					if ($objParentPage->includeCache)
 					{
-						$this->cache = $this->cache !== false ? $this->cache : $objParentPage->cache;
-						$this->alwaysLoadFromCache = $this->alwaysLoadFromCache !== false ? $this->alwaysLoadFromCache : $objParentPage->alwaysLoadFromCache;
-						$this->clientCache = $this->clientCache !== false ? $this->clientCache : $objParentPage->clientCache;
+						$this->cache = $this->cache ?: $objParentPage->cache;
+						$this->alwaysLoadFromCache = $this->alwaysLoadFromCache ?: $objParentPage->alwaysLoadFromCache;
+						$this->clientCache = $this->clientCache ?: $objParentPage->clientCache;
 					}
 
 					// Layout

--- a/core-bundle/src/Resources/contao/models/PageModel.php
+++ b/core-bundle/src/Resources/contao/models/PageModel.php
@@ -933,11 +933,11 @@ class PageModel extends Model
 					}
 
 					// Cache
-					if ($objParentPage->includeCache)
+					if ($objParentPage->includeCache && !$this->includeCache)
 					{
-						$this->cache = $this->cache ?: $objParentPage->cache;
-						$this->alwaysLoadFromCache = $this->alwaysLoadFromCache ?: $objParentPage->alwaysLoadFromCache;
-						$this->clientCache = $this->clientCache ?: $objParentPage->clientCache;
+						$this->cache = $objParentPage->cache;
+						$this->alwaysLoadFromCache = $objParentPage->alwaysLoadFromCache;
+						$this->clientCache = $objParentPage->clientCache;
 					}
 
 					// Layout


### PR DESCRIPTION
`$page->cache` and `$page->clientCache` can no longer be `boolean`, therefore I have removed the checks. This is arguably a BC break, so if we want to support setting `$page->cache` to `false`, we should adjust the phpDoc type accordingly.