### PR TITLE
Remove the "move" operation from DC_Table

### DIFF
--- a/core-bundle/src/Resources/contao/classes/Backend.php
+++ b/core-bundle/src/Resources/contao/classes/Backend.php
@@ -408,7 +408,7 @@ abstract class Backend extends Controller
 				case 'cutAll':
 				case 'copy':
 				case 'copyAll':
-				case 'move':
+				case 'move': // move = upload file in DC_Folder
 				case 'edit':
 				case 'editAll':
 				case 'toggle':

--- a/core-bundle/src/Resources/contao/classes/Backend.php
+++ b/core-bundle/src/Resources/contao/classes/Backend.php
@@ -408,7 +408,7 @@ abstract class Backend extends Controller
 				case 'cutAll':
 				case 'copy':
 				case 'copyAll':
-				case 'move': // move = upload file in DC_Folder
+				case 'move': // upload a file in DC_Folder
 				case 'edit':
 				case 'editAll':
 				case 'toggle':

--- a/core-bundle/src/Resources/contao/classes/DataContainer.php
+++ b/core-bundle/src/Resources/contao/classes/DataContainer.php
@@ -894,72 +894,66 @@ abstract class DataContainer extends Backend
 				continue;
 			}
 
-			// Generate all buttons except "move up" and "move down" buttons
-			if ($k != 'move' && $v != 'move')
+			if ($k == 'show')
 			{
-				if ($k == 'show')
+				if (!empty($v['route']))
 				{
-					if (!empty($v['route']))
-					{
-						$href = System::getContainer()->get('router')->generate($v['route'], array('id' => $arrRow['id'], 'popup' => '1'));
-					}
-					else
-					{
-						$href = $this->addToUrl(($v['href'] ?? '') . '&amp;id=' . $arrRow['id'] . '&amp;popup=1');
-					}
-
-					$return .= '<a href="' . $href . '" title="' . StringUtil::specialchars($title) . '" onclick="Backend.openModalIframe({\'title\':\'' . StringUtil::specialchars(str_replace("'", "\\'", $label)) . '\',\'url\':this.href});return false"' . $attributes . '>' . Image::getHtml($v['icon'], $label) . '</a> ';
+					$href = System::getContainer()->get('router')->generate($v['route'], array('id' => $arrRow['id'], 'popup' => '1'));
 				}
 				else
 				{
-					if (!empty($v['route']))
-					{
-						$href = System::getContainer()->get('router')->generate($v['route'], array('id' => $arrRow['id']));
-					}
-					else
-					{
-						$href = $this->addToUrl(($v['href'] ?? '') . '&amp;id=' . $arrRow['id'] . (Input::get('nb') ? '&amp;nc=1' : ''));
-					}
-
-					parse_str(StringUtil::decodeEntities($v['href'] ?? ''), $params);
-
-					if (($params['act'] ?? null) == 'toggle' && isset($params['field']))
-					{
-						// Hide the toggle icon if the user does not have access to the field
-						if (($GLOBALS['TL_DCA'][$strTable]['fields'][$params['field']]['toggle'] ?? false) !== true || !System::getContainer()->get('security.helper')->isGranted(ContaoCorePermissions::USER_CAN_EDIT_FIELD_OF_TABLE, $strTable . '::' . $params['field']))
-						{
-							continue;
-						}
-
-						$icon = $v['icon'];
-						$_icon = pathinfo($v['icon'], PATHINFO_FILENAME) . '_.' . pathinfo($v['icon'], PATHINFO_EXTENSION);
-
-						if (false !== strpos($v['icon'], '/'))
-						{
-							$_icon = \dirname($v['icon']) . '/' . $_icon;
-						}
-
-						if ($icon == 'visible.svg')
-						{
-							$_icon = 'invisible.svg';
-						}
-
-						$state = $arrRow[$params['field']] ? 1 : 0;
-
-						if ($v['reverse'] ?? false)
-						{
-							$state = $arrRow[$params['field']] ? 0 : 1;
-						}
-
-						$return .= '<a href="' . $href . '" title="' . StringUtil::specialchars($title) . '" onclick="Backend.getScrollOffset();return AjaxRequest.toggleField(this,' . ($icon == 'visible.svg' ? 'true' : 'false') . ')">' . Image::getHtml($state ? $icon : $_icon, $label, 'data-icon="' . Image::getPath($icon) . '" data-icon-disabled="' . Image::getPath($_icon) . '" data-state="' . $state . '"') . '</a> ';
-					}
-					else
-					{
-						$return .= '<a href="' . $href . '" title="' . StringUtil::specialchars($title) . '"' . $attributes . '>' . Image::getHtml($v['icon'], $label) . '</a> ';
-					}
+					$href = $this->addToUrl(($v['href'] ?? '') . '&amp;id=' . $arrRow['id'] . '&amp;popup=1');
 				}
 
-				continue;
+				$return .= '<a href="' . $href . '" title="' . StringUtil::specialchars($title) . '" onclick="Backend.openModalIframe({\'title\':\'' . StringUtil::specialchars(str_replace("'", "\\'", $label)) . '\',\'url\':this.href});return false"' . $attributes . '>' . Image::getHtml($v['icon'], $label) . '</a> ';
+			}
+			else
+			{
+				if (!empty($v['route']))
+				{
+					$href = System::getContainer()->get('router')->generate($v['route'], array('id' => $arrRow['id']));
+				}
+				else
+				{
+					$href = $this->addToUrl(($v['href'] ?? '') . '&amp;id=' . $arrRow['id'] . (Input::get('nb') ? '&amp;nc=1' : ''));
+				}
+
+				parse_str(StringUtil::decodeEntities($v['href'] ?? ''), $params);
+
+				if (($params['act'] ?? null) == 'toggle' && isset($params['field']))
+				{
+					// Hide the toggle icon if the user does not have access to the field
+					if (($GLOBALS['TL_DCA'][$strTable]['fields'][$params['field']]['toggle'] ?? false) !== true || !System::getContainer()->get('security.helper')->isGranted(ContaoCorePermissions::USER_CAN_EDIT_FIELD_OF_TABLE, $strTable . '::' . $params['field']))
+					{
+						continue;
+					}
+
+					$icon = $v['icon'];
+					$_icon = pathinfo($v['icon'], PATHINFO_FILENAME) . '_.' . pathinfo($v['icon'], PATHINFO_EXTENSION);
+
+					if (false !== strpos($v['icon'], '/'))
+					{
+						$_icon = \dirname($v['icon']) . '/' . $_icon;
+					}
+
+					if ($icon == 'visible.svg')
+					{
+						$_icon = 'invisible.svg';
+					}
+
+					$state = $arrRow[$params['field']] ? 1 : 0;
+
+					if ($v['reverse'] ?? false)
+					{
+						$state = $arrRow[$params['field']] ? 0 : 1;
+					}
+
+					$return .= '<a href="' . $href . '" title="' . StringUtil::specialchars($title) . '" onclick="Backend.getScrollOffset();return AjaxRequest.toggleField(this,' . ($icon == 'visible.svg' ? 'true' : 'false') . ')">' . Image::getHtml($state ? $icon : $_icon, $label, 'data-icon="' . Image::getPath($icon) . '" data-icon-disabled="' . Image::getPath($_icon) . '" data-state="' . $state . '"') . '</a> ';
+				}
+				else
+				{
+					$return .= '<a href="' . $href . '" title="' . StringUtil::specialchars($title) . '"' . $attributes . '>' . Image::getHtml($v['icon'], $label) . '</a> ';
+				}
 			}
 		}
 

--- a/core-bundle/src/Resources/contao/dca/tl_article.php
+++ b/core-bundle/src/Resources/contao/dca/tl_article.php
@@ -443,11 +443,6 @@ class tl_article extends Backend
 					$permission = ContaoCorePermissions::USER_CAN_EDIT_ARTICLES;
 					break;
 
-				case 'move':
-					$permission = ContaoCorePermissions::USER_CAN_EDIT_ARTICLE_HIERARCHY;
-					$ids[] = Input::get('sid');
-					break;
-
 				// Do not insert articles into a website root page
 				case 'create':
 				case 'copy':

--- a/core-bundle/src/Resources/contao/dca/tl_page.php
+++ b/core-bundle/src/Resources/contao/dca/tl_page.php
@@ -902,11 +902,6 @@ class tl_page extends Backend
 					$permission = ContaoCorePermissions::USER_CAN_EDIT_PAGE;
 					break;
 
-				case 'move':
-					$permission = ContaoCorePermissions::USER_CAN_EDIT_PAGE_HIERARCHY;
-					$ids[] = Input::get('sid');
-					break;
-
 				case 'create':
 				case 'copy':
 				case 'copyAll':

--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -1769,35 +1769,6 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 	}
 
 	/**
-	 * Change the order of two neighbour database records
-	 */
-	public function move()
-	{
-		// Proceed only if all mandatory variables are set
-		if ($this->intId && Input::get('sid') && (!$this->root || !\in_array($this->intId, $this->root)))
-		{
-			$objRow = $this->Database->prepare("SELECT * FROM " . $this->strTable . " WHERE id=? OR id=?")
-									 ->limit(2)
-									 ->execute($this->intId, Input::get('sid'));
-
-			$row = $objRow->fetchAllAssoc();
-
-			if ($row[0]['pid'] == $row[1]['pid'])
-			{
-				$this->Database->prepare("UPDATE " . $this->strTable . " SET sorting=? WHERE id=?")
-							   ->execute($row[0]['sorting'], $row[1]['id']);
-
-				$this->Database->prepare("UPDATE " . $this->strTable . " SET sorting=? WHERE id=?")
-							   ->execute($row[1]['sorting'], $row[0]['id']);
-
-				$this->invalidateCacheTags();
-			}
-		}
-
-		$this->redirect($this->getReferer());
-	}
-
-	/**
 	 * Auto-generate a form to edit the current database record
 	 *
 	 * @param integer $intId

--- a/core-bundle/src/Resources/contao/library/Contao/EditableDataContainerInterface.php
+++ b/core-bundle/src/Resources/contao/library/Contao/EditableDataContainerInterface.php
@@ -18,7 +18,5 @@ interface EditableDataContainerInterface
 
 	public function copy();
 
-	public function move();
-
 	public function edit();
 }


### PR DESCRIPTION
The move operation swaps two adjacent records in sorting. The operation has been deprecated in 4.13 (https://github.com/contao/contao/pull/4662) and has not been used for years (I didn't even know it existed).

I noticed this because the `DC_Table::move()` operation did not have any permission checks 😉 