### PR TITLE
Modern fragments: template for the markdown element

### DIFF
--- a/core-bundle/src/Resources/contao/templates/_new/content_element/markdown.html.twig
+++ b/core-bundle/src/Resources/contao/templates/_new/content_element/markdown.html.twig
@@ -1,0 +1,5 @@
+{% extends "@Contao/content_element/_base.html.twig" %}
+
+{% block content %}
+    {{ content|raw }}
+{% endblock %}

--- a/core-bundle/tests/Controller/ContentElement/ContentElementTestCase.php
+++ b/core-bundle/tests/Controller/ContentElement/ContentElementTestCase.php
@@ -21,6 +21,7 @@ use Contao\CoreBundle\Csrf\ContaoCsrfTokenManager;
 use Contao\CoreBundle\File\Metadata;
 use Contao\CoreBundle\Filesystem\FilesystemItem;
 use Contao\CoreBundle\Filesystem\VirtualFilesystem;
+use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\CoreBundle\Image\Studio\Studio;
 use Contao\CoreBundle\InsertTag\ChunkedText;
 use Contao\CoreBundle\InsertTag\InsertTagParser;
@@ -41,6 +42,7 @@ use Contao\CoreBundle\Twig\Runtime\InsertTagRuntime;
 use Contao\CoreBundle\Twig\Runtime\SchemaOrgRuntime;
 use Contao\DcaExtractor;
 use Contao\DcaLoader;
+use Contao\Input;
 use Contao\InsertTags;
 use Contao\System;
 use Doctrine\DBAL\Connection;
@@ -102,6 +104,7 @@ class ContentElementTestCase extends TestCase
         $container->set('contao.twig.filesystem_loader', $loader);
         $container->set('contao.twig.interop.context_factory', new ContextFactory());
         $container->set('twig', $environment);
+        $container->set('contao.framework', $this->getDefaultFramework());
 
         $controller->setContainer($container);
         System::setContainer($container);
@@ -349,5 +352,33 @@ class ContentElementTestCase extends TestCase
         ;
 
         return $insertTagParser;
+    }
+
+    protected function getDefaultFramework(): ContaoFramework
+    {
+        $configAdapter = $this->mockAdapter(['get']);
+        $configAdapter
+            ->method('get')
+            ->willReturnCallback(
+                static fn (string $key) => [
+                    'allowedTags' => '<a><b><i>',
+                    'allowedAttributes' => serialize([
+                        ['key' => '*', 'value' => 'data-*,id,class'],
+                        ['key' => 'a', 'value' => 'href,rel,target'],
+                    ]),
+                ][$key] ?? null
+            )
+        ;
+
+        $inputAdapter = $this->mockAdapter(['stripTags']);
+        $inputAdapter
+            ->method('stripTags')
+            ->willReturnArgument(0)
+        ;
+
+        return $this->mockContaoFramework([
+            Config::class => $configAdapter,
+            Input::class => $inputAdapter,
+        ]);
     }
 }

--- a/core-bundle/tests/Controller/ContentElement/MarkdownControllerTest.php
+++ b/core-bundle/tests/Controller/ContentElement/MarkdownControllerTest.php
@@ -16,7 +16,6 @@ use Contao\ContentModel;
 use Contao\CoreBundle\Cache\EntityCacheTags;
 use Contao\CoreBundle\Controller\ContentElement\MarkdownController;
 use Contao\CoreBundle\Framework\Adapter;
-use Contao\CoreBundle\Tests\TestCase;
 use Contao\FilesModel;
 use Contao\FrontendTemplate;
 use Contao\Input;
@@ -26,7 +25,7 @@ use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-class MarkdownControllerTest extends TestCase
+class MarkdownControllerTest extends ContentElementTestCase
 {
     protected function tearDown(): void
     {
@@ -151,5 +150,28 @@ class MarkdownControllerTest extends TestCase
         $container->set('contao.cache.entity_tags', $this->createMock(EntityCacheTags::class));
 
         return $container;
+    }
+
+    public function testOutputsMarkdownAsHtml(): void
+    {
+        $response = $this->renderWithModelData(
+            new MarkdownController(),
+            [
+                'type' => 'markdown',
+                'code' => "## Headline\n * my\n * list",
+            ]
+        );
+
+        $expectedOutput = <<<'HTML'
+            <div class="content_element/markdown">
+                <h2>Headline</h2>
+                    <ul>
+                        <li>my</li>
+                        <li>list</li>
+                    </ul>
+                </div>
+            HTML;
+
+        $this->assertSameHtml($expectedOutput, $response->getContent());
     }
 }


### PR DESCRIPTION
This PR adds a modern template for the existing markdown element/fragment controller.

Note, that you cannot use the `ce_markdown.html5` template anymore without manually including it in the `content_element/markdown.html.twig` template. 
