### PR TITLE
Fix boolean fields always being saved as true

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Database/Statement.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Database/Statement.php
@@ -260,7 +260,7 @@ class Statement
 					return (int) $varParam;
 				}
 
-				if (\is_string($varParam) || \is_float($varParam) || \is_int($varParam) || $varParam === null)
+				if (\is_string($varParam) || \is_bool($varParam) || \is_float($varParam) || \is_int($varParam) || $varParam === null)
 				{
 					return $varParam;
 				}


### PR DESCRIPTION
Follow up to #4797

If types for a `Contao\Database\Statement` are defined, any boolean will not automatically be cast to `(int)`. However, in #4797 I (initially) also removed the `\is_bool` check in line 263 - so line 268 always gets executed now for booleans. 

https://github.com/contao/contao/blob/5e9c622b2666bf703bb6c8f6103f4b1f342807ad/core-bundle/src/Resources/contao/library/Contao/Database/Statement.php#L253-L271

This means any boolean values are then converted to `b:1;` or `b:0;` respectively - and since the boolean parameter type is defined, Doctrine will cast these strings to boolean (or rather integers) and thus they will always be true/`1`.
