### PR TITLE
Add a template helper method to prefix relative URLs

### DIFF
--- a/core-bundle/src/Resources/config/services.yaml
+++ b/core-bundle/src/Resources/config/services.yaml
@@ -950,6 +950,7 @@ services:
         arguments:
             - '@twig'
             - '@contao.twig.filesystem_loader'
+            - '@request_stack'
             - '@contao.csrf.token_manager'
 
     contao.twig.fail_tolerant_filesystem_loader:

--- a/core-bundle/src/Resources/config/services.yaml
+++ b/core-bundle/src/Resources/config/services.yaml
@@ -950,7 +950,6 @@ services:
         arguments:
             - '@twig'
             - '@contao.twig.filesystem_loader'
-            - '@request_stack'
             - '@contao.csrf.token_manager'
 
     contao.twig.fail_tolerant_filesystem_loader:
@@ -1031,6 +1030,11 @@ services:
         class: Contao\CoreBundle\Twig\Runtime\SchemaOrgRuntime
         arguments:
             - '@contao.routing.response_context_accessor'
+
+    contao.twig.url_runtime:
+        class: Contao\CoreBundle\Twig\Runtime\UrlRuntime
+        arguments:
+            - '@request_stack'
 
     # Autowiring aliases
     Contao\CoreBundle\Cache\EntityCacheTags: '@contao.cache.entity_tags'

--- a/core-bundle/src/Resources/contao/library/Contao/Template.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Template.php
@@ -461,6 +461,23 @@ abstract class Template extends Controller
 	}
 
 	/**
+	 * Prefixes a relative URL
+	 *
+	 * @param string $url
+	 *
+	 * @return string
+	 */
+	public function prefixUrl($url)
+	{
+		if (!Validator::isRelativeUrl($url))
+		{
+			return $url;
+		}
+
+		return Environment::get('path') . '/' . $url;
+	}
+
+	/**
 	 * Minify the HTML markup preserving pre, script, style and textarea tags
 	 *
 	 * @param string $strHtml The HTML markup

--- a/core-bundle/src/Twig/Extension/ContaoExtension.php
+++ b/core-bundle/src/Twig/Extension/ContaoExtension.php
@@ -32,11 +32,10 @@ use Contao\CoreBundle\Twig\Runtime\InsertTagRuntime;
 use Contao\CoreBundle\Twig\Runtime\LegacyTemplateFunctionsRuntime;
 use Contao\CoreBundle\Twig\Runtime\PictureConfigurationRuntime;
 use Contao\CoreBundle\Twig\Runtime\SchemaOrgRuntime;
+use Contao\CoreBundle\Twig\Runtime\UrlRuntime;
 use Contao\FrontendTemplateTrait;
 use Contao\Template;
-use Contao\Validator;
 use Symfony\Component\Filesystem\Path;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Twig\Environment;
 use Twig\Extension\AbstractExtension;
 use Twig\Extension\CoreExtension;
@@ -54,7 +53,6 @@ final class ContaoExtension extends AbstractExtension
     public function __construct(
         private Environment $environment,
         private TemplateHierarchyInterface $hierarchy,
-        private RequestStack $requestStack,
         ContaoCsrfTokenManager $tokenManager,
     ) {
         $contaoEscaper = new ContaoEscaper();
@@ -189,13 +187,7 @@ final class ContaoExtension extends AbstractExtension
             ),
             new TwigFunction(
                 'prefix_url',
-                function (string $url) {
-                    if (!Validator::isRelativeUrl($url)) {
-                        return $url;
-                    }
-
-                    return $this->requestStack->getMainRequest()?->getBasePath().'/'.$url;
-                }
+                [UrlRuntime::class, 'prefixUrl'],
             ),
         ];
     }

--- a/core-bundle/src/Twig/FragmentTemplate.php
+++ b/core-bundle/src/Twig/FragmentTemplate.php
@@ -513,6 +513,14 @@ final class FragmentTemplate extends Template
     /**
      * @internal
      */
+    public function prefixUrl($strKey): never
+    {
+        self::throwOnAccess();
+    }
+
+    /**
+     * @internal
+     */
     public function minifyHtml($strHtml): never
     {
         self::throwOnAccess();

--- a/core-bundle/src/Twig/Runtime/UrlRuntime.php
+++ b/core-bundle/src/Twig/Runtime/UrlRuntime.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Twig\Runtime;
+
+use Contao\Validator;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Twig\Extension\RuntimeExtensionInterface;
+
+final class UrlRuntime implements RuntimeExtensionInterface
+{
+    /**
+     * @internal
+     */
+    public function __construct(private RequestStack $requestStack)
+    {
+    }
+
+    public function prefixUrl(string $url): string
+    {
+        if (!Validator::isRelativeUrl($url)) {
+            return $url;
+        }
+
+        return $this->requestStack->getMainRequest()?->getBasePath().'/'.$url;
+    }
+}

--- a/core-bundle/tests/Controller/ContentElement/ContentElementTestCase.php
+++ b/core-bundle/tests/Controller/ContentElement/ContentElementTestCase.php
@@ -51,6 +51,7 @@ use Symfony\Component\Asset\Packages;
 use Symfony\Component\Cache\Adapter\NullAdapter;
 use Symfony\Component\Filesystem\Path;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Uid\Uuid;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -241,9 +242,17 @@ class ContentElementTestCase extends TestCase
         ;
 
         $environment = new Environment($contaoFilesystemLoader);
-        $environment->addExtension(new ContaoExtension($environment, $contaoFilesystemLoader, $this->createMock(ContaoCsrfTokenManager::class)));
         $environment->addExtension(new TranslationExtension($translator));
         $environment->addExtension(new AssetExtension($packages));
+
+        $environment->addExtension(
+            new ContaoExtension(
+                $environment,
+                $contaoFilesystemLoader,
+                new RequestStack(),
+                $this->createMock(ContaoCsrfTokenManager::class)
+            )
+        );
 
         // Runtime loaders
         $insertTagParser = $this->getDefaultInsertTagParser();

--- a/core-bundle/tests/Controller/ContentElement/ContentElementTestCase.php
+++ b/core-bundle/tests/Controller/ContentElement/ContentElementTestCase.php
@@ -51,7 +51,6 @@ use Symfony\Component\Asset\Packages;
 use Symfony\Component\Cache\Adapter\NullAdapter;
 use Symfony\Component\Filesystem\Path;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Uid\Uuid;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -249,7 +248,6 @@ class ContentElementTestCase extends TestCase
             new ContaoExtension(
                 $environment,
                 $contaoFilesystemLoader,
-                new RequestStack(),
                 $this->createMock(ContaoCsrfTokenManager::class)
             )
         );

--- a/core-bundle/tests/Image/Studio/TwigMacrosTest.php
+++ b/core-bundle/tests/Image/Studio/TwigMacrosTest.php
@@ -25,6 +25,7 @@ use Contao\CoreBundle\Twig\Extension\ContaoExtension;
 use Contao\CoreBundle\Twig\Inheritance\TemplateHierarchyInterface;
 use Contao\CoreBundle\Twig\Runtime\SchemaOrgRuntime;
 use Symfony\Component\Filesystem\Path;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Twig\Environment;
 use Twig\Loader\ArrayLoader;
 use Twig\RuntimeLoader\FactoryRuntimeLoader;
@@ -580,7 +581,15 @@ class TwigMacrosTest extends TestCase
         ];
 
         $environment = new Environment(new ArrayLoader($templates));
-        $environment->setExtensions([new ContaoExtension($environment, $this->createMock(TemplateHierarchyInterface::class), $this->createMock(ContaoCsrfTokenManager::class))]);
+
+        $environment->setExtensions([
+            new ContaoExtension(
+                $environment,
+                $this->createMock(TemplateHierarchyInterface::class),
+                new RequestStack(),
+                $this->createMock(ContaoCsrfTokenManager::class)
+            ),
+        ]);
 
         $responseContextAccessor ??= $this->createMock(ResponseContextAccessor::class);
 

--- a/core-bundle/tests/Image/Studio/TwigMacrosTest.php
+++ b/core-bundle/tests/Image/Studio/TwigMacrosTest.php
@@ -25,7 +25,6 @@ use Contao\CoreBundle\Twig\Extension\ContaoExtension;
 use Contao\CoreBundle\Twig\Inheritance\TemplateHierarchyInterface;
 use Contao\CoreBundle\Twig\Runtime\SchemaOrgRuntime;
 use Symfony\Component\Filesystem\Path;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Twig\Environment;
 use Twig\Loader\ArrayLoader;
 use Twig\RuntimeLoader\FactoryRuntimeLoader;
@@ -586,7 +585,6 @@ class TwigMacrosTest extends TestCase
             new ContaoExtension(
                 $environment,
                 $this->createMock(TemplateHierarchyInterface::class),
-                new RequestStack(),
                 $this->createMock(ContaoCsrfTokenManager::class)
             ),
         ]);

--- a/core-bundle/tests/Twig/Extension/ContaoExtensionTest.php
+++ b/core-bundle/tests/Twig/Extension/ContaoExtensionTest.php
@@ -30,6 +30,7 @@ use Contao\CoreBundle\Twig\ResponseContext\AddTokenParser;
 use Contao\System;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Filesystem\Path;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Twig\Environment;
 use Twig\Extension\AbstractExtension;
 use Twig\Extension\CoreExtension;
@@ -90,6 +91,7 @@ class ContaoExtensionTest extends TestCase
             'add_schema_org' => [],
             'contao_sections' => ['html'],
             'contao_section' => ['html'],
+            'prefix_url' => [],
         ];
 
         $functions = $this->getContaoExtension()->getFunctions();
@@ -167,7 +169,12 @@ class ContaoExtensionTest extends TestCase
             ])
         ;
 
-        $extension = new ContaoExtension($environment, $this->createMock(TemplateHierarchyInterface::class), $this->createMock(ContaoCsrfTokenManager::class));
+        $extension = new ContaoExtension(
+            $environment,
+            $this->createMock(TemplateHierarchyInterface::class),
+            new RequestStack(),
+            $this->createMock(ContaoCsrfTokenManager::class)
+        );
 
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('The Twig\Extension\CoreExtension class was expected to register the "include" Twig function but did not.');
@@ -365,6 +372,6 @@ class ContaoExtensionTest extends TestCase
             ])
         ;
 
-        return new ContaoExtension($environment, $hierarchy, $this->createMock(ContaoCsrfTokenManager::class));
+        return new ContaoExtension($environment, $hierarchy, new RequestStack(), $this->createMock(ContaoCsrfTokenManager::class));
     }
 }

--- a/core-bundle/tests/Twig/Extension/ContaoExtensionTest.php
+++ b/core-bundle/tests/Twig/Extension/ContaoExtensionTest.php
@@ -30,7 +30,6 @@ use Contao\CoreBundle\Twig\ResponseContext\AddTokenParser;
 use Contao\System;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Filesystem\Path;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Twig\Environment;
 use Twig\Extension\AbstractExtension;
 use Twig\Extension\CoreExtension;
@@ -172,7 +171,6 @@ class ContaoExtensionTest extends TestCase
         $extension = new ContaoExtension(
             $environment,
             $this->createMock(TemplateHierarchyInterface::class),
-            new RequestStack(),
             $this->createMock(ContaoCsrfTokenManager::class)
         );
 
@@ -372,6 +370,6 @@ class ContaoExtensionTest extends TestCase
             ])
         ;
 
-        return new ContaoExtension($environment, $hierarchy, new RequestStack(), $this->createMock(ContaoCsrfTokenManager::class));
+        return new ContaoExtension($environment, $hierarchy, $this->createMock(ContaoCsrfTokenManager::class));
     }
 }

--- a/core-bundle/tests/Twig/Extension/DeprecationsNodeVisitorTest.php
+++ b/core-bundle/tests/Twig/Extension/DeprecationsNodeVisitorTest.php
@@ -18,7 +18,6 @@ use Contao\CoreBundle\Twig\Extension\ContaoExtension;
 use Contao\CoreBundle\Twig\Extension\DeprecationsNodeVisitor;
 use Contao\CoreBundle\Twig\Inheritance\TemplateHierarchyInterface;
 use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Twig\Environment;
 use Twig\Loader\ArrayLoader;
 
@@ -54,7 +53,6 @@ class DeprecationsNodeVisitorTest extends TestCase
             new ContaoExtension(
                 $environment,
                 $this->createMock(TemplateHierarchyInterface::class),
-                new RequestStack(),
                 $this->createMock(ContaoCsrfTokenManager::class)
             )
         );

--- a/core-bundle/tests/Twig/Extension/DeprecationsNodeVisitorTest.php
+++ b/core-bundle/tests/Twig/Extension/DeprecationsNodeVisitorTest.php
@@ -18,6 +18,7 @@ use Contao\CoreBundle\Twig\Extension\ContaoExtension;
 use Contao\CoreBundle\Twig\Extension\DeprecationsNodeVisitor;
 use Contao\CoreBundle\Twig\Inheritance\TemplateHierarchyInterface;
 use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Twig\Environment;
 use Twig\Loader\ArrayLoader;
 
@@ -49,8 +50,14 @@ class DeprecationsNodeVisitorTest extends TestCase
             new ArrayLoader(['template.html.twig' => $templateContent])
         );
 
-        $contaoExtension = new ContaoExtension($environment, $this->createMock(TemplateHierarchyInterface::class), $this->createMock(ContaoCsrfTokenManager::class));
-        $environment->addExtension($contaoExtension);
+        $environment->addExtension(
+            new ContaoExtension(
+                $environment,
+                $this->createMock(TemplateHierarchyInterface::class),
+                new RequestStack(),
+                $this->createMock(ContaoCsrfTokenManager::class)
+            )
+        );
 
         return $environment;
     }

--- a/core-bundle/tests/Twig/Extension/InsertTagTest.php
+++ b/core-bundle/tests/Twig/Extension/InsertTagTest.php
@@ -23,6 +23,7 @@ use Contao\CoreBundle\Twig\Inheritance\TemplateHierarchyInterface;
 use Contao\CoreBundle\Twig\Runtime\InsertTagRuntime;
 use Contao\InsertTags;
 use Contao\System;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Twig\Environment;
 use Twig\Loader\ArrayLoader;
 use Twig\RuntimeLoader\FactoryRuntimeLoader;
@@ -83,7 +84,15 @@ class InsertTagTest extends TestCase
         ];
 
         $environment = new Environment(new ArrayLoader($templates));
-        $environment->setExtensions([new ContaoExtension($environment, $this->createMock(TemplateHierarchyInterface::class), $this->createMock(ContaoCsrfTokenManager::class))]);
+
+        $environment->setExtensions([
+            new ContaoExtension(
+                $environment,
+                $this->createMock(TemplateHierarchyInterface::class),
+                new RequestStack(),
+                $this->createMock(ContaoCsrfTokenManager::class)
+            ),
+        ]);
 
         $tokenChecker = $this->createMock(TokenChecker::class);
         $tokenChecker

--- a/core-bundle/tests/Twig/Extension/InsertTagTest.php
+++ b/core-bundle/tests/Twig/Extension/InsertTagTest.php
@@ -23,7 +23,6 @@ use Contao\CoreBundle\Twig\Inheritance\TemplateHierarchyInterface;
 use Contao\CoreBundle\Twig\Runtime\InsertTagRuntime;
 use Contao\InsertTags;
 use Contao\System;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Twig\Environment;
 use Twig\Loader\ArrayLoader;
 use Twig\RuntimeLoader\FactoryRuntimeLoader;
@@ -89,7 +88,6 @@ class InsertTagTest extends TestCase
             new ContaoExtension(
                 $environment,
                 $this->createMock(TemplateHierarchyInterface::class),
-                new RequestStack(),
                 $this->createMock(ContaoCsrfTokenManager::class)
             ),
         ]);

--- a/core-bundle/tests/Twig/Inheritance/DynamicUseTokenParserTest.php
+++ b/core-bundle/tests/Twig/Inheritance/DynamicUseTokenParserTest.php
@@ -26,6 +26,7 @@ use Doctrine\DBAL\Connection;
 use Symfony\Component\Cache\Adapter\NullAdapter;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Filesystem\Path;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Twig\Environment;
 
 class DynamicUseTokenParserTest extends TestCase
@@ -63,7 +64,15 @@ class DynamicUseTokenParserTest extends TestCase
         $warmer->warmUp('');
 
         $environment = new Environment($loader);
-        $environment->addExtension(new ContaoExtension($environment, $loader, $this->createMock(ContaoCsrfTokenManager::class)));
+
+        $environment->addExtension(
+            new ContaoExtension(
+                $environment,
+                $loader,
+                new RequestStack(),
+                $this->createMock(ContaoCsrfTokenManager::class)
+            )
+        );
 
         // A component is adjusted by overwriting the component's template
         // (here by adding the item "ice" and turning apples into pineapples).

--- a/core-bundle/tests/Twig/Inheritance/DynamicUseTokenParserTest.php
+++ b/core-bundle/tests/Twig/Inheritance/DynamicUseTokenParserTest.php
@@ -26,7 +26,6 @@ use Doctrine\DBAL\Connection;
 use Symfony\Component\Cache\Adapter\NullAdapter;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Filesystem\Path;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Twig\Environment;
 
 class DynamicUseTokenParserTest extends TestCase
@@ -69,7 +68,6 @@ class DynamicUseTokenParserTest extends TestCase
             new ContaoExtension(
                 $environment,
                 $loader,
-                new RequestStack(),
                 $this->createMock(ContaoCsrfTokenManager::class)
             )
         );

--- a/core-bundle/tests/Twig/Inheritance/InheritanceTest.php
+++ b/core-bundle/tests/Twig/Inheritance/InheritanceTest.php
@@ -24,6 +24,7 @@ use Doctrine\DBAL\Connection;
 use Symfony\Component\Cache\Adapter\NullAdapter;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Filesystem\Path;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Twig\Environment;
 
 /**
@@ -104,8 +105,14 @@ class InheritanceTest extends TestCase
 
         $environment = new Environment($loader);
 
-        $contaoExtension = new ContaoExtension($environment, $loader, $this->createMock(ContaoCsrfTokenManager::class));
-        $environment->addExtension($contaoExtension);
+        $environment->addExtension(
+            new ContaoExtension(
+                $environment,
+                $loader,
+                new RequestStack(),
+                $this->createMock(ContaoCsrfTokenManager::class)
+            )
+        );
 
         return $environment;
     }

--- a/core-bundle/tests/Twig/Inheritance/InheritanceTest.php
+++ b/core-bundle/tests/Twig/Inheritance/InheritanceTest.php
@@ -24,7 +24,6 @@ use Doctrine\DBAL\Connection;
 use Symfony\Component\Cache\Adapter\NullAdapter;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Filesystem\Path;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Twig\Environment;
 
 /**
@@ -109,7 +108,6 @@ class InheritanceTest extends TestCase
             new ContaoExtension(
                 $environment,
                 $loader,
-                new RequestStack(),
                 $this->createMock(ContaoCsrfTokenManager::class)
             )
         );

--- a/core-bundle/tests/Twig/Interop/ContaoEscaperNodeVisitorTest.php
+++ b/core-bundle/tests/Twig/Interop/ContaoEscaperNodeVisitorTest.php
@@ -24,7 +24,6 @@ use Contao\CoreBundle\Twig\Interop\ContaoEscaperNodeVisitor;
 use Contao\CoreBundle\Twig\Runtime\InsertTagRuntime;
 use Contao\InsertTags;
 use Contao\System;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Twig\Environment;
 use Twig\Loader\ArrayLoader;
 use Twig\RuntimeLoader\FactoryRuntimeLoader;
@@ -144,7 +143,6 @@ class ContaoEscaperNodeVisitorTest extends TestCase
         $contaoExtension = new ContaoExtension(
             $environment,
             $this->createMock(TemplateHierarchyInterface::class),
-            new RequestStack(),
             $this->createMock(ContaoCsrfTokenManager::class)
         );
 

--- a/core-bundle/tests/Twig/Interop/ContaoEscaperNodeVisitorTest.php
+++ b/core-bundle/tests/Twig/Interop/ContaoEscaperNodeVisitorTest.php
@@ -24,6 +24,7 @@ use Contao\CoreBundle\Twig\Interop\ContaoEscaperNodeVisitor;
 use Contao\CoreBundle\Twig\Runtime\InsertTagRuntime;
 use Contao\InsertTags;
 use Contao\System;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Twig\Environment;
 use Twig\Loader\ArrayLoader;
 use Twig\RuntimeLoader\FactoryRuntimeLoader;
@@ -140,7 +141,13 @@ class ContaoEscaperNodeVisitorTest extends TestCase
 
         $environment = new Environment($loader);
 
-        $contaoExtension = new ContaoExtension($environment, $this->createMock(TemplateHierarchyInterface::class), $this->createMock(ContaoCsrfTokenManager::class));
+        $contaoExtension = new ContaoExtension(
+            $environment,
+            $this->createMock(TemplateHierarchyInterface::class),
+            new RequestStack(),
+            $this->createMock(ContaoCsrfTokenManager::class)
+        );
+
         $contaoExtension->addContaoEscaperRule('/legacy\.html\.twig/');
 
         $environment->addExtension($contaoExtension);

--- a/core-bundle/tests/Twig/ResponseContext/AddTokenParserTest.php
+++ b/core-bundle/tests/Twig/ResponseContext/AddTokenParserTest.php
@@ -17,7 +17,6 @@ use Contao\CoreBundle\Tests\TestCase;
 use Contao\CoreBundle\Twig\Extension\ContaoExtension;
 use Contao\CoreBundle\Twig\Inheritance\TemplateHierarchyInterface;
 use Contao\CoreBundle\Twig\ResponseContext\AddTokenParser;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Twig\Environment;
 use Twig\Error\SyntaxError;
 use Twig\Lexer;
@@ -49,7 +48,6 @@ class AddTokenParserTest extends TestCase
             new ContaoExtension(
                 $environment,
                 $this->createMock(TemplateHierarchyInterface::class),
-                new RequestStack(),
                 $this->createMock(ContaoCsrfTokenManager::class)
             )
         );

--- a/core-bundle/tests/Twig/ResponseContext/AddTokenParserTest.php
+++ b/core-bundle/tests/Twig/ResponseContext/AddTokenParserTest.php
@@ -17,6 +17,7 @@ use Contao\CoreBundle\Tests\TestCase;
 use Contao\CoreBundle\Twig\Extension\ContaoExtension;
 use Contao\CoreBundle\Twig\Inheritance\TemplateHierarchyInterface;
 use Contao\CoreBundle\Twig\ResponseContext\AddTokenParser;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Twig\Environment;
 use Twig\Error\SyntaxError;
 use Twig\Lexer;
@@ -43,7 +44,16 @@ class AddTokenParserTest extends TestCase
     public function testAddsContent(string $code, array $expectedHeadContent, array $expectedBodyContent): void
     {
         $environment = new Environment($this->createMock(LoaderInterface::class));
-        $environment->addExtension(new ContaoExtension($environment, $this->createMock(TemplateHierarchyInterface::class), $this->createMock(ContaoCsrfTokenManager::class)));
+
+        $environment->addExtension(
+            new ContaoExtension(
+                $environment,
+                $this->createMock(TemplateHierarchyInterface::class),
+                new RequestStack(),
+                $this->createMock(ContaoCsrfTokenManager::class)
+            )
+        );
+
         $environment->addTokenParser(new AddTokenParser(ContaoExtension::class));
         $environment->setLoader(new ArrayLoader(['template.html.twig' => $code]));
         $environment->render('template.html.twig');

--- a/core-bundle/tests/Twig/Runtime/UrlRuntimeTest.php
+++ b/core-bundle/tests/Twig/Runtime/UrlRuntimeTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\Twig\Runtime;
+
+use Contao\CoreBundle\Tests\TestCase;
+use Contao\CoreBundle\Twig\Runtime\UrlRuntime;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+class UrlRuntimeTest extends TestCase
+{
+    public function testPrefixesRelativeUrls(): void
+    {
+        $requestStack = new RequestStack();
+        $requestStack->push(new Request());
+
+        $runtime = new UrlRuntime($requestStack);
+
+        $this->assertSame('/en/content-elements.html', $runtime->prefixUrl('en/content-elements.html'));
+    }
+
+    public function testAddsTheBasePathWhenPrefixingUrls(): void
+    {
+        $request = Request::create('https://localhost/managed-edition/public/contao/preview');
+        $request->server->set('SCRIPT_NAME', '/managed-edition/public/index.php');
+        $request->server->set('SCRIPT_FILENAME', '/managed-edition/public/index.php');
+
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
+        $runtime = new UrlRuntime($requestStack);
+
+        $this->assertSame('/managed-edition/public/en/content-elements.html', $runtime->prefixUrl('en/content-elements.html'));
+    }
+
+    public function testAddsASlashIfThereIsNoRequest(): void
+    {
+        $runtime = new UrlRuntime(new RequestStack());
+
+        $this->assertSame('/en/content-elements.html', $runtime->prefixUrl('en/content-elements.html'));
+    }
+
+    public function testDoesNotPrefixNonRelativeUrls(): void
+    {
+        $request = new Request();
+
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
+        $runtime = new UrlRuntime($requestStack);
+
+        $this->assertSame('/en/content-elements.html', $runtime->prefixUrl('/en/content-elements.html'));
+        $this->assertSame('https://localhost', $runtime->prefixUrl('https://localhost'));
+        $this->assertSame('#foo', $runtime->prefixUrl('#foo'));
+        $this->assertSame('{{link::52}}', $runtime->prefixUrl('{{link::52}}'));
+    }
+}

--- a/core-bundle/tests/Twig/TwigIntegrationTest.php
+++ b/core-bundle/tests/Twig/TwigIntegrationTest.php
@@ -25,6 +25,7 @@ use Contao\TemplateLoader;
 use Highlight\Highlighter;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Filesystem\Path;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Twig\Environment;
 use Twig\Loader\ArrayLoader;
 use Twig\RuntimeLoader\FactoryRuntimeLoader;
@@ -69,7 +70,15 @@ class TwigIntegrationTest extends TestCase
         TemplateLoader::addFile('form_text', 'templates');
 
         $environment = new Environment(new ArrayLoader(['@Contao/form_text.html.twig' => $content]));
-        $environment->addExtension(new ContaoExtension($environment, $this->createMock(TemplateHierarchyInterface::class), $this->createMock(ContaoCsrfTokenManager::class)));
+
+        $environment->addExtension(
+            new ContaoExtension(
+                $environment,
+                $this->createMock(TemplateHierarchyInterface::class),
+                new RequestStack(),
+                $this->createMock(ContaoCsrfTokenManager::class)
+            )
+        );
 
         $container = $this->getContainerWithContaoConfiguration($this->getTempDir());
         $container->set('twig', $environment);
@@ -105,7 +114,15 @@ class TwigIntegrationTest extends TestCase
             TEMPLATE;
 
         $environment = new Environment(new ArrayLoader(['test.html.twig' => $templateContent]));
-        $environment->addExtension(new ContaoExtension($environment, $this->createMock(TemplateHierarchyInterface::class), $this->createMock(ContaoCsrfTokenManager::class)));
+
+        $environment->addExtension(
+            new ContaoExtension(
+                $environment,
+                $this->createMock(TemplateHierarchyInterface::class),
+                new RequestStack(),
+                $this->createMock(ContaoCsrfTokenManager::class)
+            )
+        );
 
         $output = $environment->render(
             'test.html.twig',
@@ -150,8 +167,16 @@ class TwigIntegrationTest extends TestCase
             TEMPLATE;
 
         $environment = new Environment(new ArrayLoader(['test.html.twig' => $templateContent]));
-        $environment->addExtension(new ContaoExtension($environment, $this->createMock(TemplateHierarchyInterface::class), $this->createMock(ContaoCsrfTokenManager::class)));
         $environment->addRuntimeLoader(new FactoryRuntimeLoader([HighlighterRuntime::class => static fn () => new HighlighterRuntime()]));
+
+        $environment->addExtension(
+            new ContaoExtension(
+                $environment,
+                $this->createMock(TemplateHierarchyInterface::class),
+                new RequestStack(),
+                $this->createMock(ContaoCsrfTokenManager::class)
+            )
+        );
 
         $output = $environment->render(
             'test.html.twig',

--- a/core-bundle/tests/Twig/TwigIntegrationTest.php
+++ b/core-bundle/tests/Twig/TwigIntegrationTest.php
@@ -25,7 +25,6 @@ use Contao\TemplateLoader;
 use Highlight\Highlighter;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Filesystem\Path;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Twig\Environment;
 use Twig\Loader\ArrayLoader;
 use Twig\RuntimeLoader\FactoryRuntimeLoader;
@@ -75,7 +74,6 @@ class TwigIntegrationTest extends TestCase
             new ContaoExtension(
                 $environment,
                 $this->createMock(TemplateHierarchyInterface::class),
-                new RequestStack(),
                 $this->createMock(ContaoCsrfTokenManager::class)
             )
         );
@@ -119,7 +117,6 @@ class TwigIntegrationTest extends TestCase
             new ContaoExtension(
                 $environment,
                 $this->createMock(TemplateHierarchyInterface::class),
-                new RequestStack(),
                 $this->createMock(ContaoCsrfTokenManager::class)
             )
         );
@@ -173,7 +170,6 @@ class TwigIntegrationTest extends TestCase
             new ContaoExtension(
                 $environment,
                 $this->createMock(TemplateHierarchyInterface::class),
-                new RequestStack(),
                 $this->createMock(ContaoCsrfTokenManager::class)
             )
         );


### PR DESCRIPTION
Fixes #4871

I am open for a different method name.

@m-vo I am not sure if adding another dependency to the `ContaoExtension` class was the correct thing to do. If not, please point me in the right direction and I will adjust the PR accordingly.