### PR TITLE
Remove uncached insert tag flag

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -4,7 +4,7 @@
 
 ### Insert tag flag uncached
 
-The `|uncached` insert tag flag was removed. Use the `{{uncached::*}}` insert tag instead.
+The `|uncached` insert tag flag was removed. Use the `{{fragment::*}}` insert tag instead.
 
 ### Insert tag hooks
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,10 @@
 
 ## Version 4.* to 5.0
 
+### Insert tag flag uncached
+
+The `|uncached` insert tag flag was removed. Use the `{{uncached::*}}` insert tag instead.
+
 ### Insert tag hooks
 
 The `$cache` parameter is no longer passed to the `replaceInsertTags` and the `insertTagFlags` hooks. An empty array is

--- a/core-bundle/src/Resources/contao/library/Contao/InsertTags.php
+++ b/core-bundle/src/Resources/contao/library/Contao/InsertTags.php
@@ -1190,11 +1190,6 @@ class InsertTags extends Controller
 							$arrCache[$strTag] = implode(', ', $result);
 							break;
 
-						case 'uncached':
-							trigger_deprecation('contao/core-bundle', '5.0', 'The insert tag flag "|uncached" has been deprecated and will no longer work in Contao 6.0. use "{{uncached::*}}" instead.');
-							// ignore
-							break;
-
 						case 'refresh':
 							// ignore
 							break;

--- a/core-bundle/src/Resources/contao/library/Contao/InsertTags.php
+++ b/core-bundle/src/Resources/contao/library/Contao/InsertTags.php
@@ -153,7 +153,7 @@ class InsertTags extends Controller
 				break;
 			}
 
-			if (!$blnCache || !str_starts_with(strtolower($tags[$_rit+1]), 'uncached::'))
+			if (!$blnCache || !str_starts_with(strtolower($tags[$_rit+1]), 'fragment::'))
 			{
 				$tags[$_rit+1] = (string) $this->replaceInternal($tags[$_rit+1], $blnCache);
 			}
@@ -164,7 +164,7 @@ class InsertTags extends Controller
 			$elements = explode('::', $tag);
 
 			// Load the value from cache
-			if (isset($arrCache[$strTag]) && $elements[0] != 'page' && $elements[0] != 'uncached' && !\in_array('refresh', $flags))
+			if (isset($arrCache[$strTag]) && $elements[0] != 'page' && $elements[0] != 'fragment' && !\in_array('refresh', $flags))
 			{
 				$arrBuffer[$_rit+1] = (string) $arrCache[$strTag];
 				continue;
@@ -180,7 +180,7 @@ class InsertTags extends Controller
 			// Skip certain elements if the output will be cached
 			if ($blnCache)
 			{
-				if ($elements[0] == 'date' || $elements[0] == 'form_session_data' || $elements[0] == 'uncached' || ($elements[1] ?? null) == 'referer' || strncmp($elements[0], 'cache_', 6) === 0)
+				if ($elements[0] == 'date' || $elements[0] == 'form_session_data' || $elements[0] == 'fragment' || ($elements[1] ?? null) == 'referer' || strncmp($elements[0], 'cache_', 6) === 0)
 				{
 					/** @var FragmentHandler $fragmentHandler */
 					$fragmentHandler = $container->get('fragment.handler');
@@ -217,7 +217,7 @@ class InsertTags extends Controller
 			switch (strtolower($elements[0]))
 			{
 				// Uncached (ESI) fragments
-				case 'uncached':
+				case 'fragment':
 					$arrCache[$strTag] = substr($strTag, 10);
 					break;
 

--- a/core-bundle/src/Resources/contao/library/Contao/InsertTags.php
+++ b/core-bundle/src/Resources/contao/library/Contao/InsertTags.php
@@ -153,7 +153,10 @@ class InsertTags extends Controller
 				break;
 			}
 
-			$tags[$_rit+1] = (string) $this->replaceInternal($tags[$_rit+1], $blnCache);
+			if (!$blnCache || !str_starts_with(strtolower($tags[$_rit+1]), 'uncached::'))
+			{
+				$tags[$_rit+1] = (string) $this->replaceInternal($tags[$_rit+1], $blnCache);
+			}
 
 			$strTag = $tags[$_rit+1];
 			$flags = explode('|', $strTag);
@@ -161,7 +164,7 @@ class InsertTags extends Controller
 			$elements = explode('::', $tag);
 
 			// Load the value from cache
-			if (isset($arrCache[$strTag]) && $elements[0] != 'page' && !\in_array('refresh', $flags))
+			if (isset($arrCache[$strTag]) && $elements[0] != 'page' && $elements[0] != 'uncached' && !\in_array('refresh', $flags))
 			{
 				$arrBuffer[$_rit+1] = (string) $arrCache[$strTag];
 				continue;
@@ -177,7 +180,7 @@ class InsertTags extends Controller
 			// Skip certain elements if the output will be cached
 			if ($blnCache)
 			{
-				if ($elements[0] == 'date' || $elements[0] == 'form_session_data' || ($elements[1] ?? null) == 'referer' || \in_array('uncached', $flags) || strncmp($elements[0], 'cache_', 6) === 0)
+				if ($elements[0] == 'date' || $elements[0] == 'form_session_data' || $elements[0] == 'uncached' || ($elements[1] ?? null) == 'referer' || strncmp($elements[0], 'cache_', 6) === 0)
 				{
 					/** @var FragmentHandler $fragmentHandler */
 					$fragmentHandler = $container->get('fragment.handler');
@@ -213,6 +216,11 @@ class InsertTags extends Controller
 			// Replace the tag
 			switch (strtolower($elements[0]))
 			{
+				// Uncached (ESI) fragments
+				case 'uncached':
+					$arrCache[$strTag] = substr($strTag, 10);
+					break;
+
 				// Date
 				case 'date':
 					$flags[] = 'attr';
@@ -1182,8 +1190,12 @@ class InsertTags extends Controller
 							$arrCache[$strTag] = implode(', ', $result);
 							break;
 
-						case 'refresh':
 						case 'uncached':
+							trigger_deprecation('contao/core-bundle', '5.0', 'The insert tag flag "|uncached" has been deprecated and will no longer work in Contao 6.0. use "{{uncached::*}}" instead.');
+							// ignore
+							break;
+
+						case 'refresh':
 							// ignore
 							break;
 

--- a/core-bundle/tests/InsertTag/InsertTagParserTest.php
+++ b/core-bundle/tests/InsertTag/InsertTagParserTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Tests\InsertTag;
 
 use Contao\Config;
+use Contao\CoreBundle\Fragment\FragmentHandler;
 use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\CoreBundle\InsertTag\ChunkedText;
 use Contao\CoreBundle\InsertTag\InsertTagParser;
@@ -24,6 +25,7 @@ use Monolog\Logger;
 use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpKernel\Controller\ControllerReference;
 
 class InsertTagParserTest extends TestCase
 {
@@ -90,5 +92,24 @@ class InsertTagParserTest extends TestCase
         $this->expectDeprecation('%sInsert tags with uppercase letters%s');
 
         $this->assertSame('<br>', $parser->render('bR'));
+    }
+
+    public function testReplaceUncached(): void
+    {
+        $handler = $this->createMock(FragmentHandler::class);
+        $handler
+            ->method('render')
+            ->willReturnCallback(static fn (ControllerReference $reference) => '<esi '.$reference->attributes['insertTag'].'>')
+        ;
+
+        System::getContainer()->set('fragment.handler', $handler);
+
+        $parser = new InsertTagParser($this->createMock(ContaoFramework::class));
+
+        $this->assertSame('<esi {{uncached::{{br}}}}>', $parser->replace('{{uncached::{{br}}}}'));
+        $this->assertSame([[ChunkedText::TYPE_RAW, '<esi {{uncached::{{br}}}}>']], iterator_to_array($parser->replaceChunked('{{uncached::{{br}}}}')));
+
+        $this->assertSame('<br>', $parser->replaceInline('{{uncached::{{br}}}}'));
+        $this->assertSame([[ChunkedText::TYPE_RAW, '<br>']], iterator_to_array($parser->replaceInlineChunked('{{uncached::{{br}}}}')));
     }
 }

--- a/core-bundle/tests/InsertTag/InsertTagParserTest.php
+++ b/core-bundle/tests/InsertTag/InsertTagParserTest.php
@@ -94,7 +94,7 @@ class InsertTagParserTest extends TestCase
         $this->assertSame('<br>', $parser->render('bR'));
     }
 
-    public function testReplaceUncached(): void
+    public function testReplaceFragment(): void
     {
         $handler = $this->createMock(FragmentHandler::class);
         $handler
@@ -106,10 +106,10 @@ class InsertTagParserTest extends TestCase
 
         $parser = new InsertTagParser($this->createMock(ContaoFramework::class));
 
-        $this->assertSame('<esi {{uncached::{{br}}}}>', $parser->replace('{{uncached::{{br}}}}'));
-        $this->assertSame([[ChunkedText::TYPE_RAW, '<esi {{uncached::{{br}}}}>']], iterator_to_array($parser->replaceChunked('{{uncached::{{br}}}}')));
+        $this->assertSame('<esi {{fragment::{{br}}}}>', $parser->replace('{{fragment::{{br}}}}'));
+        $this->assertSame([[ChunkedText::TYPE_RAW, '<esi {{fragment::{{br}}}}>']], iterator_to_array($parser->replaceChunked('{{fragment::{{br}}}}')));
 
-        $this->assertSame('<br>', $parser->replaceInline('{{uncached::{{br}}}}'));
-        $this->assertSame([[ChunkedText::TYPE_RAW, '<br>']], iterator_to_array($parser->replaceInlineChunked('{{uncached::{{br}}}}')));
+        $this->assertSame('<br>', $parser->replaceInline('{{fragment::{{br}}}}'));
+        $this->assertSame([[ChunkedText::TYPE_RAW, '<br>']], iterator_to_array($parser->replaceInlineChunked('{{fragment::{{br}}}}')));
     }
 }


### PR DESCRIPTION
Insert tag flags are used for post processing.

With #4779 it will no longer be possible to implement flags that do something completley different like the `|uncached` flag does. Therefore we have to replace this flag with a proper insert tag now in order to not break BC once #4779 is finished.

Deprecated the flag in Contao 4.13: #4932