### PR TITLE
Do not set header in Ajax::executePostActions

### DIFF
--- a/core-bundle/src/Resources/contao/classes/Ajax.php
+++ b/core-bundle/src/Resources/contao/classes/Ajax.php
@@ -177,8 +177,6 @@ class Ajax extends Backend
 	 */
 	public function executePostActions(DataContainer $dc)
 	{
-		header('Content-Type: text/html; charset=' . System::getContainer()->getParameter('kernel.charset'));
-
 		// Bypass any core logic for non-core drivers (see #5957)
 		if (!$dc instanceof DC_File && !$dc instanceof DC_Folder && !$dc instanceof DC_Table)
 		{


### PR DESCRIPTION
This gets rid of the last remaining `header()` call (after #4930 is merged upstream), apart from the maintenance mode in the entry points and in `NativeHeaderStorage`. This should allow us to deprecate and disable the `MergeHttpHeadersListener` (we can probably only remove it in Contao 6.0).