### PR TITLE
Hard-code timezone to avoid time deviation

### DIFF
--- a/core-bundle/tests/Controller/InsertTagsControllerTest.php
+++ b/core-bundle/tests/Controller/InsertTagsControllerTest.php
@@ -50,6 +50,7 @@ class InsertTagsControllerTest extends TestCase
 
     public function testSpecialDateInsertTagHandling(): void
     {
+        ini_set('date.timezone', 'UTC');
         $year = date('Y');
 
         $insertTagParser = $this->createMock(InsertTagParser::class);

--- a/core-bundle/tests/Controller/InsertTagsControllerTest.php
+++ b/core-bundle/tests/Controller/InsertTagsControllerTest.php
@@ -50,7 +50,6 @@ class InsertTagsControllerTest extends TestCase
 
     public function testSpecialDateInsertTagHandling(): void
     {
-        ini_set('date.timezone', 'UTC');
         $year = date('Y');
 
         $insertTagParser = $this->createMock(InsertTagParser::class);
@@ -64,7 +63,7 @@ class InsertTagsControllerTest extends TestCase
         $response = $controller->renderAction(new Request(), '{{date::Y}}');
 
         $this->assertTrue($response->headers->hasCacheControlDirective('public'));
-        $this->assertSame($year.'-12-31 23:59:59', $response->getExpires()->format('Y-m-d H:i:s'));
+        $this->assertSame((new \DateTimeImmutable($year.'-12-31 23:59:59'))->getTimestamp(), $response->getExpires()->getTimestamp());
         $this->assertSame($year, $response->getContent());
     }
 }


### PR DESCRIPTION
When I run the test suite locally, the InsertTagsControllerTest always fails due to the expected and actual `expires` time being off by one hour. My local timezone is 'Europe/Berlin`. 