### PR TITLE
Fix potential PHP 8 warnings when resizing an uploaded image

### DIFF
--- a/core-bundle/src/Resources/contao/classes/FileUpload.php
+++ b/core-bundle/src/Resources/contao/classes/FileUpload.php
@@ -302,7 +302,7 @@ class FileUpload extends Backend
 		$arrImageSize = $objFile->imageSize;
 
 		// Image size could not be determined
-		if (count($arrImageSize) < 2)
+		if (!isset($arrImageSize[0], $arrImageSize[1]))
 		{
 			return false;
 		}

--- a/core-bundle/src/Resources/contao/classes/FileUpload.php
+++ b/core-bundle/src/Resources/contao/classes/FileUpload.php
@@ -301,6 +301,12 @@ class FileUpload extends Backend
 
 		$arrImageSize = $objFile->imageSize;
 
+		// Image size could not be determined
+		if (count($arrImageSize) < 2)
+		{
+			return false;
+		}
+
 		// The image is too big to be handled by the GD library
 		if ($objFile->isGdImage && ($arrImageSize[0] > Config::get('gdMaxImgWidth') || $arrImageSize[1] > Config::get('gdMaxImgHeight')))
 		{


### PR DESCRIPTION
In case the image size of an uploaded file cannot be determined, we may get a few PHP 8 warnings (see Sentry reports below). This pull request fixes the problem, although I am not entirely sure if it's the best solution.

<img width="1031" alt="CleanShot 2022-07-05 at 09 33 53" src="https://user-images.githubusercontent.com/193483/177274606-1f8d14fa-f777-4173-a835-2d010b60d8ff.png">
<img width="1038" alt="CleanShot 2022-07-05 at 09 34 05" src="https://user-images.githubusercontent.com/193483/177274643-ab99ff0e-c891-4569-a007-1a877bc88163.png">
<img width="1030" alt="CleanShot 2022-07-05 at 09 34 12" src="https://user-images.githubusercontent.com/193483/177274671-90a74017-6762-439f-86f1-f854e74ccf67.png">

