### PR TITLE
Fix PHP 8 warning in ModuleRegistration

### DIFF
--- a/core-bundle/src/Resources/contao/modules/ModuleRegistration.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleRegistration.php
@@ -647,7 +647,7 @@ class ModuleRegistration extends Module
 		// Add user details
 		foreach ($arrData as $k=>$v)
 		{
-			if ($k == 'password' || $k == 'tstamp' || $k == 'dateAdded')
+			if ($k == 'id' || $k == 'password' || $k == 'tstamp' || $k == 'dateAdded')
 			{
 				continue;
 			}

--- a/core-bundle/src/Resources/contao/modules/ModuleRegistration.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleRegistration.php
@@ -659,7 +659,7 @@ class ModuleRegistration extends Module
 				$v = Date::parse(Config::get('dateFormat'), $v);
 			}
 
-			$strData .= ($GLOBALS['TL_LANG']['tl_member'][$k][0] ?? null) . ': ' . (\is_array($v) ? implode(', ', $v) : $v) . "\n";
+			$strData .= ($GLOBALS['TL_LANG']['tl_member'][$k][0] ?? $k) . ': ' . (\is_array($v) ? implode(', ', $v) : $v) . "\n";
 		}
 
 		$objEmail->text = sprintf($GLOBALS['TL_LANG']['MSC']['adminText'], $intId, $strData . "\n") . "\n";

--- a/core-bundle/src/Resources/contao/modules/ModuleRegistration.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleRegistration.php
@@ -659,7 +659,7 @@ class ModuleRegistration extends Module
 				$v = Date::parse(Config::get('dateFormat'), $v);
 			}
 
-			$strData .= $GLOBALS['TL_LANG']['tl_member'][$k][0] . ': ' . (\is_array($v) ? implode(', ', $v) : $v) . "\n";
+			$strData .= ($GLOBALS['TL_LANG']['tl_member'][$k][0] ?? null) . ': ' . (\is_array($v) ? implode(', ', $v) : $v) . "\n";
 		}
 
 		$objEmail->text = sprintf($GLOBALS['TL_LANG']['MSC']['adminText'], $intId, $strData . "\n") . "\n";


### PR DESCRIPTION
Registration module triggers a warning under PHP 8 while sending admin notification.

```
Warning: Trying to access array offset on value of type null
```

This happens because `id` column does not have translated label, but this field is, in fact, not really needed in this list altogether, because it is already present in the first line of the default message:

```
A new member (ID 10) has registered at your website.

Username: test9
Allow login: 1
Member groups: 
Deactivate: 1

If you did not allow e-mail activation, you have to enable the account manually in the back end.
```

So I fixed it by adding `id` to the list of skipped fields. For any other similar cases (e.g. if a developer adds another field to the DCA but forgets to add translation) the proposed fix is to use the column name instead.

<!--
Bugfixes should be based on the 4.9 or 4.13 branch and features on the 5.x
branch. Select the correct branch in the "base:" drop-down menu above.

Replace this notice with a short README for your feature/bugfix. This will help
people to understand your PR and can be used as a start for the documentation.
-->
