### PR TITLE
Fix the getCurrentRecord() method

### DIFF
--- a/core-bundle/src/Resources/contao/classes/DataContainer.php
+++ b/core-bundle/src/Resources/contao/classes/DataContainer.php
@@ -1761,7 +1761,7 @@ abstract class DataContainer extends Backend
 		}
 
 		// In case this record was not part of the preloaded result, we don't need to apply any permission checks
-		if (!array_key_exists($key, self::$arrCurrentRecordCache))
+		if (!isset(self::$arrCurrentRecordCache[$key]))
 		{
 			return null;
 		}

--- a/core-bundle/src/Resources/contao/classes/DataContainer.php
+++ b/core-bundle/src/Resources/contao/classes/DataContainer.php
@@ -1761,7 +1761,7 @@ abstract class DataContainer extends Backend
 		}
 
 		// In case this record was not part of the preloaded result, we don't need to apply any permission checks
-		if (!isset($key, self::$arrCurrentRecordCache))
+		if (!array_key_exists($key, self::$arrCurrentRecordCache))
 		{
 			return null;
 		}


### PR DESCRIPTION
Not sure if it should be `if (!isset(self::$arrCurrentRecordCache[$key]))` instead as in line 1758?