### PR TITLE
Always retrieve the session from the request instead of the container

### DIFF
--- a/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
+++ b/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
@@ -382,10 +382,11 @@ class ContaoCoreExtension extends Extension implements PrependExtensionInterface
         }
 
         $tokenChecker = $container->getDefinition('contao.security.token_checker');
-        $tokenChecker->replaceArgument(5, new Reference('security.access.simple_role_voter'));
 
         if ($container->hasParameter('security.role_hierarchy.roles') && \count($container->getParameter('security.role_hierarchy.roles')) > 0) {
-            $tokenChecker->replaceArgument(5, new Reference('security.access.role_hierarchy_voter'));
+            $tokenChecker->replaceArgument(4, new Reference('security.access.role_hierarchy_voter'));
+        } else {
+            $tokenChecker->replaceArgument(4, new Reference('security.access.simple_role_voter'));
         }
     }
 

--- a/core-bundle/src/Resources/config/services.yaml
+++ b/core-bundle/src/Resources/config/services.yaml
@@ -755,7 +755,7 @@ services:
         public: true
         arguments:
             - '@security.helper'
-            - '@session'
+            - '@request_stack'
             - '@contao.security.frontend_user_provider'
             - '@?logger'
 
@@ -813,7 +813,6 @@ services:
             - '@request_stack'
             - '@security.firewall.map'
             - '@security.token_storage'
-            - '@session'
             - '@security.authentication.trust_resolver'
             - ~
 

--- a/core-bundle/src/Security/Authentication/FrontendPreviewAuthenticator.php
+++ b/core-bundle/src/Security/Authentication/FrontendPreviewAuthenticator.php
@@ -47,7 +47,7 @@ class FrontendPreviewAuthenticator
 
         $token = new UsernamePasswordToken($user, 'contao_frontend');
 
-        if (!$request = $this->requestStack->getMainRequest()) {
+        if ((!$request = $this->requestStack->getMainRequest()) || !$request->hasSession()) {
             return false;
         }
 
@@ -60,7 +60,7 @@ class FrontendPreviewAuthenticator
 
     public function authenticateFrontendGuest(bool $showUnpublished): bool
     {
-        if (!$request = $this->requestStack->getMainRequest()) {
+        if ((!$request = $this->requestStack->getMainRequest()) || !$request->hasSession()) {
             return false;
         }
 
@@ -74,7 +74,7 @@ class FrontendPreviewAuthenticator
      */
     public function removeFrontendAuthentication(): bool
     {
-        if (!$request = $this->requestStack->getMainRequest()) {
+        if ((!$request = $this->requestStack->getMainRequest()) || !$request->hasSession()) {
             return false;
         }
 

--- a/core-bundle/src/Security/Authentication/Token/TokenChecker.php
+++ b/core-bundle/src/Security/Authentication/Token/TokenChecker.php
@@ -66,7 +66,7 @@ class TokenChecker
      */
     public function hasFrontendGuest(): bool
     {
-        if (!$request = $this->requestStack->getMainRequest()) {
+        if ((!$request = $this->requestStack->getMainRequest()) || !$request->hasSession()) {
             return false;
         }
 
@@ -165,18 +165,14 @@ class TokenChecker
 
     private function getTokenFromSession(string $sessionKey): TokenInterface|null
     {
-        if (!$request = $this->requestStack->getMainRequest()) {
+        if ((!$request = $this->requestStack->getMainRequest()) || !$request->hasSession()) {
             return null;
         }
 
         $session = $request->getSession();
 
-        if (!$session->isStarted()) {
-            $request = $this->requestStack->getMainRequest();
-
-            if (!$request || !$request->hasPreviousSession()) {
-                return null;
-            }
+        if (!$session->isStarted() && !$request->hasPreviousSession()) {
+            return null;
         }
 
         // This will start the session if Request::hasPreviousSession() was true

--- a/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
+++ b/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
@@ -121,7 +121,7 @@ class ContaoCoreExtensionTest extends TestCase
 
         $definition = $container->getDefinition('contao.security.token_checker');
 
-        $this->assertEquals(new Reference('security.access.role_hierarchy_voter'), $definition->getArgument(5));
+        $this->assertEquals(new Reference('security.access.role_hierarchy_voter'), $definition->getArgument(4));
     }
 
     public function testRegistersThePredefinedImageSizes(): void

--- a/core-bundle/tests/Security/Authentication/FrontendPreviewAuthenticatorTest.php
+++ b/core-bundle/tests/Security/Authentication/FrontendPreviewAuthenticatorTest.php
@@ -16,6 +16,8 @@ use Contao\CoreBundle\Security\Authentication\FrontendPreviewAuthenticator;
 use Contao\CoreBundle\Tests\TestCase;
 use Contao\FrontendUser;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\Exception\UserNotFoundException;
@@ -212,10 +214,16 @@ class FrontendPreviewAuthenticatorTest extends TestCase
             ;
         }
 
+        $request = new Request();
+        $request->setSession($session);
+
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
         $security ??= $this->createMock(Security::class);
         $userProvider ??= $this->createMock(UserProviderInterface::class);
         $logger ??= $this->createMock(LoggerInterface::class);
 
-        return new FrontendPreviewAuthenticator($security, $session, $userProvider, $logger);
+        return new FrontendPreviewAuthenticator($security, $requestStack, $userProvider, $logger);
     }
 }

--- a/core-bundle/tests/Security/Authentication/Token/TokenCheckerTest.php
+++ b/core-bundle/tests/Security/Authentication/Token/TokenCheckerTest.php
@@ -46,6 +46,9 @@ class TokenCheckerTest extends TestCase
             ->method('isStarted')
         ;
 
+        $request = new Request();
+        $request->setSession($session);
+
         $tokenStorage = $this->createMock(TokenStorageInterface::class);
         $tokenStorage
             ->method('getToken')
@@ -53,10 +56,9 @@ class TokenCheckerTest extends TestCase
         ;
 
         $tokenChecker = new TokenChecker(
-            $this->mockRequestStack(),
+            $this->mockRequestStack($request),
             $this->mockFirewallMapWithConfigContext($firewallContext),
             $tokenStorage,
-            $session,
             new AuthenticationTrustResolver(),
             $this->getRoleVoter()
         );
@@ -98,6 +100,9 @@ class TokenCheckerTest extends TestCase
             ->method('isStarted')
         ;
 
+        $request = new Request();
+        $request->setSession($session);
+
         $tokenStorage = $this->createMock(TokenStorageInterface::class);
         $tokenStorage
             ->method('getToken')
@@ -105,10 +110,9 @@ class TokenCheckerTest extends TestCase
         ;
 
         $tokenChecker = new TokenChecker(
-            $this->mockRequestStack(),
+            $this->mockRequestStack($request),
             $this->mockFirewallMapWithConfigContext($firewallContext),
             $tokenStorage,
-            $session,
             new AuthenticationTrustResolver(),
             $this->getRoleVoter()
         );
@@ -130,12 +134,15 @@ class TokenCheckerTest extends TestCase
     {
         $user = $this->mockUser(FrontendUser::class);
         $token = new UsernamePasswordToken($user, 'provider', ['ROLE_MEMBER']);
+        $session = $this->mockSessionWithToken($token);
+
+        $request = new Request();
+        $request->setSession($session);
 
         $tokenChecker = new TokenChecker(
-            $this->mockRequestStack(),
+            $this->mockRequestStack($request),
             $this->mockFirewallMapWithConfigContext('contao_backend'),
             $this->mockTokenStorage(FrontendUser::class),
-            $this->mockSessionWithToken($token),
             new AuthenticationTrustResolver(),
             $this->getRoleVoter()
         );
@@ -147,12 +154,15 @@ class TokenCheckerTest extends TestCase
     {
         $user = $this->mockUser(BackendUser::class);
         $token = new UsernamePasswordToken($user, 'provider', ['ROLE_USER']);
+        $session = $this->mockSessionWithToken($token);
+
+        $request = new Request();
+        $request->setSession($session);
 
         $tokenChecker = new TokenChecker(
-            $this->mockRequestStack(),
+            $this->mockRequestStack($request),
             $this->mockFirewallMapWithConfigContext('contao_frontend'),
             $this->mockTokenStorage(BackendUser::class),
-            $this->mockSessionWithToken($token),
             new AuthenticationTrustResolver(),
             $this->getRoleVoter()
         );
@@ -179,7 +189,6 @@ class TokenCheckerTest extends TestCase
             $this->mockRequestStack($request),
             $this->mockFirewallMapWithConfigContext('contao_backend'),
             $this->mockTokenStorage(BackendUser::class),
-            $session,
             new AuthenticationTrustResolver(),
             $this->getRoleVoter()
         );
@@ -203,15 +212,23 @@ class TokenCheckerTest extends TestCase
         ;
 
         $session
+            ->expects($this->once())
+            ->method('getName')
+            ->willReturn('foo')
+        ;
+
+        $session
             ->expects($this->never())
             ->method('has')
         ;
 
+        $request = new Request();
+        $request->setSession($session);
+
         $tokenChecker = new TokenChecker(
-            $this->mockRequestStack(),
+            $this->mockRequestStack($request),
             $this->mockFirewallMapWithConfigContext('contao_backend'),
             $this->mockTokenStorage(BackendUser::class),
-            $session,
             new AuthenticationTrustResolver(),
             $this->getRoleVoter()
         );
@@ -234,11 +251,13 @@ class TokenCheckerTest extends TestCase
             ->willReturn(false)
         ;
 
+        $request = new Request();
+        $request->setSession($session);
+
         $tokenChecker = new TokenChecker(
-            $this->mockRequestStack(),
+            $this->mockRequestStack($request),
             $this->mockFirewallMapWithConfigContext('contao_frontend'),
             $this->mockTokenStorage(FrontendUser::class),
-            $session,
             new AuthenticationTrustResolver(),
             $this->getRoleVoter()
         );
@@ -267,11 +286,13 @@ class TokenCheckerTest extends TestCase
             ->willReturn(serialize(new \stdClass()))
         ;
 
+        $request = new Request();
+        $request->setSession($session);
+
         $tokenChecker = new TokenChecker(
-            $this->mockRequestStack(),
+            $this->mockRequestStack($request),
             $this->mockFirewallMapWithConfigContext('contao_backend'),
             $this->mockTokenStorage(BackendUser::class),
-            $session,
             new AuthenticationTrustResolver(),
             $this->getRoleVoter()
         );
@@ -289,11 +310,15 @@ class TokenCheckerTest extends TestCase
             ->willReturn(null)
         ;
 
+        $session = $this->mockSessionWithToken($token);
+
+        $request = new Request();
+        $request->setSession($session);
+
         $tokenChecker = new TokenChecker(
-            $this->mockRequestStack(),
+            $this->mockRequestStack($request),
             $this->mockFirewallMapWithConfigContext('contao_frontend'),
             $tokenStorage,
-            $this->mockSessionWithToken($token),
             new AuthenticationTrustResolver(),
             $this->getRoleVoter()
         );
@@ -303,11 +328,15 @@ class TokenCheckerTest extends TestCase
 
     public function testDoesNotReturnATokenIfTheTokenIsAnonymous(): void
     {
+        $session = $this->mockSession();
+
+        $request = new Request();
+        $request->setSession($session);
+
         $tokenChecker = new TokenChecker(
-            $this->mockRequestStack(),
+            $this->mockRequestStack($request),
             $this->mockFirewallMapWithConfigContext('contao_backend'),
             $this->mockTokenStorage(BackendUser::class),
-            $this->mockSession(),
             new AuthenticationTrustResolver(),
             $this->getRoleVoter()
         );
@@ -328,11 +357,13 @@ class TokenCheckerTest extends TestCase
             ->willReturn($hasFrontendGuest)
         ;
 
+        $request = new Request();
+        $request->setSession($session);
+
         $tokenChecker = new TokenChecker(
-            $this->mockRequestStack(),
+            $this->mockRequestStack($request),
             $this->mockFirewallMapWithConfigContext('contao_backend'),
             $this->mockTokenStorage(BackendUser::class),
-            $session,
             new AuthenticationTrustResolver(),
             $this->getRoleVoter()
         );
@@ -363,10 +394,8 @@ class TokenCheckerTest extends TestCase
     /**
      * @return RequestStack&MockObject
      */
-    private function mockRequestStack(Request $request = null): RequestStack
+    private function mockRequestStack(Request $request): RequestStack
     {
-        $request ??= $this->createMock(Request::class);
-
         $requestStack = $this->createMock(RequestStack::class);
         $requestStack
             ->method('getMainRequest')


### PR DESCRIPTION
```
  1x: Since symfony/framework-bundle 5.3: The "session" service and "SessionInterface" alias are deprecated, use "$requestStack->getSession()" instead. It is being referenced by the "contao.security.frontend_preview_authenticator" service.
    1x in DbafsTest::testAlterFilesystemAndSync from Contao\CoreBundle\Tests\Functional

  1x: Since symfony/framework-bundle 5.3: The "session" service and "SessionInterface" alias are deprecated, use "$requestStack->getSession()" instead. It is being referenced by the "contao.security.token_checker" service.
    1x in DbafsTest::testAlterFilesystemAndSync from Contao\CoreBundle\Tests\Functional
```