### PR TITLE
Make the Input::post() method compatible with Symfony 6

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Input.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Input.php
@@ -1119,7 +1119,9 @@ class Input
 				return $arrPost[$strKey];
 			}
 
-			return $request->request->get($strKey);
+			// Since we don't know whether the value will be an array or a string,
+			// we can neither use ->get($strKey) nor ->all($strKey) in Symfony 6.
+			return $request->request->all()[$strKey] ?? null;
 		}
 
 		trigger_deprecation('contao/core-bundle', '5.0', 'Getting data from $_POST with the "%s" class has been deprecated and will no longer work in Contao 6.0. Make sure the request_stack has a request instead.', __CLASS__);


### PR DESCRIPTION
Symfony 6 wants `$request->request->get($key)` to always return a string and `$request->request->all($key)` to always return an array. Since we don‘t know what type to expect, I have added a workaround. Although I‘m not sure if that is really what Symfony wants people to do.