### PR TITLE
Always use PHP 8 attributes in the maker bundle

### DIFF
--- a/maker-bundle/config/services.yaml
+++ b/maker-bundle/config/services.yaml
@@ -33,7 +33,6 @@ services:
             - '@contao_maker.generator.class'
             - '@contao_maker.generator.dca'
             - '@contao_maker.generator.language_file'
-            - '@maker.php_compat_util'
             - '%kernel.project_dir%'
         tags:
             - maker.command
@@ -46,7 +45,6 @@ services:
             - '@contao.resource_finder'
             - '@contao_maker.reflection.signature_generator'
             - '@contao_maker.reflection.import_extractor'
-            - '@maker.php_compat_util'
         tags:
             - maker.command
 
@@ -56,7 +54,6 @@ services:
             - '@contao_maker.generator.class'
             - '@contao_maker.reflection.signature_generator'
             - '@contao_maker.reflection.import_extractor'
-            - '@maker.php_compat_util'
         tags:
             - maker.command
 
@@ -68,7 +65,6 @@ services:
             - '@contao_maker.generator.class'
             - '@contao_maker.generator.dca'
             - '@contao_maker.generator.language_file'
-            - '@maker.php_compat_util'
             - '%kernel.project_dir%'
         tags:
             - maker.command
@@ -79,7 +75,6 @@ services:
             - '@contao_maker.generator.class'
             - '@contao_maker.reflection.signature_generator'
             - '@contao_maker.reflection.import_extractor'
-            - '@maker.php_compat_util'
         tags:
             - maker.command
 

--- a/maker-bundle/skeleton/content-element/ContentElement.tpl.php
+++ b/maker-bundle/skeleton/content-element/ContentElement.tpl.php
@@ -6,22 +6,12 @@ namespace App\Controller\ContentElement;
 
 use Contao\ContentModel;
 use Contao\CoreBundle\Controller\ContentElement\AbstractContentElementController;
-<?php if ($use_attributes): ?>
 use Contao\CoreBundle\DependencyInjection\Attribute\AsContentElement;
-<?php else: ?>
-use Contao\CoreBundle\ServiceAnnotation\ContentElement;
-<?php endif; ?>
 use Contao\Template;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-<?php if ($use_attributes): ?>
 #[AsContentElement(category: "<?= $category ?>")]
-<?php else: ?>
-/**
- * @ContentElement(category="<?= $category ?>")
- */
-<?php endif; ?>
 class <?= $className ?> extends AbstractContentElementController
 {
     protected function getResponse(Template $template, ContentModel $model, Request $request): Response

--- a/maker-bundle/skeleton/dca-callback/Callback.tpl.php
+++ b/maker-bundle/skeleton/dca-callback/Callback.tpl.php
@@ -4,22 +4,12 @@ declare(strict_types=1);
 
 namespace App\EventListener;
 
-<?php if ($use_attributes): ?>
 use Contao\CoreBundle\DependencyInjection\Attribute\AsCallback;
-<?php else: ?>
-use Contao\CoreBundle\ServiceAnnotation\Callback;
-<?php endif; ?>
 <?php foreach ($uses as $use): ?>
 use <?= $use ?>;
 <?php endforeach; ?>
 
-<?php if ($use_attributes): ?>
 #[AsCallback(table: "<?= $table ?>", target: "<?= $target ?>")]
-<?php else: ?>
-/**
- * @Callback(table="<?= $table ?>", target="<?= $target ?>")
- */
-<?php endif; ?>
 class <?= $className."\n" ?>
 {
     <?= $signature."\n" ?>

--- a/maker-bundle/skeleton/event-listener/EventListener.tpl.php
+++ b/maker-bundle/skeleton/event-listener/EventListener.tpl.php
@@ -7,19 +7,9 @@ namespace App\EventListener;
 <?php foreach ($uses as $use): ?>
 use <?= $use ?>;
 <?php endforeach; ?>
-<?php if ($use_attributes): ?>
 use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
-<?php else: ?>
-use Terminal42\ServiceAnnotationBundle\Annotation\ServiceTag;
-<?php endif; ?>
 
-<?php if ($use_attributes): ?>
 #[AsEventListener("<?= $event ?>")]
-<?php else: ?>
-/**
- * @ServiceTag("kernel.event_listener", event=<?= $event ?>)
- */
-<?php endif; ?>
 class <?= $className."\n" ?>
 {
     <?= $signature."\n" ?>

--- a/maker-bundle/skeleton/frontend-module/FrontendModule.tpl.php
+++ b/maker-bundle/skeleton/frontend-module/FrontendModule.tpl.php
@@ -5,23 +5,13 @@ declare(strict_types=1);
 namespace App\Controller\FrontendModule;
 
 use Contao\CoreBundle\Controller\FrontendModule\AbstractFrontendModuleController;
-<?php if ($use_attributes): ?>
 use Contao\CoreBundle\DependencyInjection\Attribute\AsFrontendModule;
-<?php else: ?>
-use Contao\CoreBundle\ServiceAnnotation\FrontendModule;
-<?php endif; ?>
 use Contao\ModuleModel;
 use Contao\Template;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-<?php if ($use_attributes): ?>
 #[AsFrontendModule(category: "<?= $category ?>")]
-<?php else: ?>
-/**
- * @FrontendModule(category="<?= $category ?>")
- */
-<?php endif; ?>
 class <?= $className ?> extends AbstractFrontendModuleController
 {
     protected function getResponse(Template $template, ModuleModel $model, Request $request): Response

--- a/maker-bundle/skeleton/hook/Hook.tpl.php
+++ b/maker-bundle/skeleton/hook/Hook.tpl.php
@@ -4,22 +4,12 @@ declare(strict_types=1);
 
 namespace App\EventListener;
 
-<?php if ($use_attributes): ?>
 use Contao\CoreBundle\DependencyInjection\Attribute\AsHook;
-<?php else: ?>
-use Contao\CoreBundle\ServiceAnnotation\Hook;
-<?php endif; ?>
 <?php foreach ($uses as $use): ?>
 use <?= $use ?>;
 <?php endforeach; ?>
 
-<?php if ($use_attributes): ?>
 #[AsHook("<?= $hook ?>")]
-<?php else: ?>
-/**
- * @Hook("<?= $hook ?>")
- */
-<?php endif; ?>
 class <?= $className."\n" ?>
 {
     <?= $signature."\n" ?>

--- a/maker-bundle/src/Maker/AbstractFragmentMaker.php
+++ b/maker-bundle/src/Maker/AbstractFragmentMaker.php
@@ -20,7 +20,6 @@ use Contao\MakerBundle\Generator\TemplateGenerator;
 use Symfony\Bundle\MakerBundle\ConsoleStyle;
 use Symfony\Bundle\MakerBundle\DependencyBuilder;
 use Symfony\Bundle\MakerBundle\Maker\AbstractMaker;
-use Symfony\Bundle\MakerBundle\Util\PhpCompatUtil;
 use Symfony\Bundle\MakerBundle\Validator;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -38,7 +37,6 @@ abstract class AbstractFragmentMaker extends AbstractMaker
         protected ClassGenerator $classGenerator,
         protected DcaGenerator $dcaGenerator,
         protected LanguageFileGenerator $languageFileGenerator,
-        protected PhpCompatUtil $phpCompatUtil,
         protected string $projectDir,
     ) {
     }

--- a/maker-bundle/src/Maker/MakeContentElement.php
+++ b/maker-bundle/src/Maker/MakeContentElement.php
@@ -59,7 +59,6 @@ class MakeContentElement extends AbstractFragmentMaker
                 'className' => $elementDetails->getShortName(),
                 'elementName' => $elementName,
                 'category' => $category,
-                'use_attributes' => $this->phpCompatUtil->canUseAttributes(),
             ],
         ]);
 

--- a/maker-bundle/src/Maker/MakeDcaCallback.php
+++ b/maker-bundle/src/Maker/MakeDcaCallback.php
@@ -24,7 +24,6 @@ use Symfony\Bundle\MakerBundle\Generator;
 use Symfony\Bundle\MakerBundle\InputConfiguration;
 use Symfony\Bundle\MakerBundle\Maker\AbstractMaker;
 use Symfony\Bundle\MakerBundle\Str;
-use Symfony\Bundle\MakerBundle\Util\PhpCompatUtil;
 use Symfony\Bundle\MakerBundle\Validator;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -41,7 +40,6 @@ class MakeDcaCallback extends AbstractMaker
         private ResourceFinder $resourceFinder,
         private SignatureGenerator $signatureGenerator,
         private ImportExtractor $importExtractor,
-        private PhpCompatUtil $phpCompatUtil,
     ) {
     }
 
@@ -110,7 +108,6 @@ class MakeDcaCallback extends AbstractMaker
                 'className' => $elementDetails->getShortName(),
                 'signature' => $this->signatureGenerator->generate($definition, '__invoke'),
                 'body' => $definition->getBody(),
-                'use_attributes' => $this->phpCompatUtil->canUseAttributes(),
             ],
         ]);
 

--- a/maker-bundle/src/Maker/MakeEventListener.php
+++ b/maker-bundle/src/Maker/MakeEventListener.php
@@ -22,7 +22,6 @@ use Symfony\Bundle\MakerBundle\Generator;
 use Symfony\Bundle\MakerBundle\InputConfiguration;
 use Symfony\Bundle\MakerBundle\Maker\AbstractMaker;
 use Symfony\Bundle\MakerBundle\Str;
-use Symfony\Bundle\MakerBundle\Util\PhpCompatUtil;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -35,7 +34,6 @@ class MakeEventListener extends AbstractMaker
         private ClassGenerator $classGenerator,
         private SignatureGenerator $signatureGenerator,
         private ImportExtractor $importExtractor,
-        private PhpCompatUtil $phpCompatUtil,
     ) {
     }
 
@@ -100,7 +98,6 @@ class MakeEventListener extends AbstractMaker
                 'className' => $elementDetails->getShortName(),
                 'signature' => $this->signatureGenerator->generate($definition, '__invoke'),
                 'body' => $definition->getBody(),
-                'use_attributes' => $this->phpCompatUtil->canUseAttributes(),
             ],
         ]);
 

--- a/maker-bundle/src/Maker/MakeFrontendModule.php
+++ b/maker-bundle/src/Maker/MakeFrontendModule.php
@@ -60,7 +60,6 @@ class MakeFrontendModule extends AbstractFragmentMaker
                 'className' => $elementDetails->getShortName(),
                 'elementName' => $elementName,
                 'category' => $category,
-                'use_attributes' => $this->phpCompatUtil->canUseAttributes(),
             ],
         ]);
 

--- a/maker-bundle/src/Maker/MakeHook.php
+++ b/maker-bundle/src/Maker/MakeHook.php
@@ -22,7 +22,6 @@ use Symfony\Bundle\MakerBundle\Generator;
 use Symfony\Bundle\MakerBundle\InputConfiguration;
 use Symfony\Bundle\MakerBundle\Maker\AbstractMaker;
 use Symfony\Bundle\MakerBundle\Str;
-use Symfony\Bundle\MakerBundle\Util\PhpCompatUtil;
 use Symfony\Bundle\MakerBundle\Validator;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -36,7 +35,6 @@ class MakeHook extends AbstractMaker
         private ClassGenerator $classGenerator,
         private SignatureGenerator $signatureGenerator,
         private ImportExtractor $importExtractor,
-        private PhpCompatUtil $phpCompatUtil,
     ) {
     }
 
@@ -102,7 +100,6 @@ class MakeHook extends AbstractMaker
                 'className' => $elementDetails->getShortName(),
                 'signature' => $this->signatureGenerator->generate($definition, '__invoke'),
                 'body' => $definition->getBody(),
-                'use_attributes' => $this->phpCompatUtil->canUseAttributes(),
             ],
         ]);
 


### PR DESCRIPTION
Since Contao 5 is PHP 8.1+, the legacy service annotations would never be used anyway.