### PR TITLE
Use PHP 8 attributes everywhere

### DIFF
--- a/calendar-bundle/src/Cron/GenerateFeedsCron.php
+++ b/calendar-bundle/src/Cron/GenerateFeedsCron.php
@@ -13,12 +13,10 @@ declare(strict_types=1);
 namespace Contao\CalendarBundle\Cron;
 
 use Contao\Calendar;
+use Contao\CoreBundle\DependencyInjection\Attribute\AsCronJob;
 use Contao\CoreBundle\Framework\ContaoFramework;
-use Contao\CoreBundle\ServiceAnnotation\CronJob;
 
-/**
- * @CronJob("daily")
- */
+#[AsCronJob("daily")]
 class GenerateFeedsCron
 {
     public function __construct(private ContaoFramework $framework)

--- a/calendar-bundle/src/Cron/GenerateFeedsCron.php
+++ b/calendar-bundle/src/Cron/GenerateFeedsCron.php
@@ -16,7 +16,7 @@ use Contao\Calendar;
 use Contao\CoreBundle\DependencyInjection\Attribute\AsCronJob;
 use Contao\CoreBundle\Framework\ContaoFramework;
 
-#[AsCronJob("daily")]
+#[AsCronJob('daily')]
 class GenerateFeedsCron
 {
     public function __construct(private ContaoFramework $framework)

--- a/comments-bundle/src/Cron/PurgeSubscriptionsCron.php
+++ b/comments-bundle/src/Cron/PurgeSubscriptionsCron.php
@@ -17,7 +17,7 @@ use Contao\CoreBundle\DependencyInjection\Attribute\AsCronJob;
 use Contao\CoreBundle\Framework\ContaoFramework;
 use Psr\Log\LoggerInterface;
 
-#[AsCronJob("daily")]
+#[AsCronJob('daily')]
 class PurgeSubscriptionsCron
 {
     public function __construct(private ContaoFramework $framework, private LoggerInterface|null $logger)

--- a/comments-bundle/src/Cron/PurgeSubscriptionsCron.php
+++ b/comments-bundle/src/Cron/PurgeSubscriptionsCron.php
@@ -13,13 +13,11 @@ declare(strict_types=1);
 namespace Contao\CommentsBundle\Cron;
 
 use Contao\CommentsNotifyModel;
+use Contao\CoreBundle\DependencyInjection\Attribute\AsCronJob;
 use Contao\CoreBundle\Framework\ContaoFramework;
-use Contao\CoreBundle\ServiceAnnotation\CronJob;
 use Psr\Log\LoggerInterface;
 
-/**
- * @CronJob("daily")
- */
+#[AsCronJob("daily")]
 class PurgeSubscriptionsCron
 {
     public function __construct(private ContaoFramework $framework, private LoggerInterface|null $logger)

--- a/core-bundle/src/Controller/BackendController.php
+++ b/core-bundle/src/Controller/BackendController.php
@@ -29,15 +29,12 @@ use Symfony\Component\HttpKernel\UriSigner;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
- * @Route(path="%contao.backend.route_prefix%", defaults={"_scope" = "backend", "_token_check" = true})
- *
  * @internal
  */
+#[Route(path: '%contao.backend.route_prefix%', defaults: ['_scope' => 'backend', '_token_check' => true])]
 class BackendController extends AbstractController
 {
-    /**
-     * @Route("", name="contao_backend")
-     */
+    #[Route('', name: 'contao_backend')]
     public function mainAction(): Response
     {
         $this->initializeContaoFramework();
@@ -47,9 +44,7 @@ class BackendController extends AbstractController
         return $controller->run();
     }
 
-    /**
-     * @Route("/login", name="contao_backend_login")
-     */
+    #[Route('/login', name: 'contao_backend_login')]
     public function loginAction(Request $request): Response
     {
         $this->initializeContaoFramework();
@@ -74,17 +69,14 @@ class BackendController extends AbstractController
 
     /**
      * Symfony will un-authenticate the user automatically by calling this route.
-     *
-     * @Route("/logout", name="contao_backend_logout")
      */
+    #[Route('/logout', name: 'contao_backend_logout')]
     public function logoutAction(): RedirectResponse
     {
         return $this->redirectToRoute('contao_backend_login');
     }
 
-    /**
-     * @Route("/password", name="contao_backend_password")
-     */
+    #[Route('/password', name: 'contao_backend_password')]
     public function passwordAction(): Response
     {
         $this->initializeContaoFramework();
@@ -94,9 +86,7 @@ class BackendController extends AbstractController
         return $controller->run();
     }
 
-    /**
-     * @Route("/confirm", name="contao_backend_confirm")
-     */
+    #[Route('/confirm', name: 'contao_backend_confirm')]
     public function confirmAction(): Response
     {
         $this->initializeContaoFramework();
@@ -106,9 +96,7 @@ class BackendController extends AbstractController
         return $controller->run();
     }
 
-    /**
-     * @Route("/help", name="contao_backend_help")
-     */
+    #[Route('/help', name: 'contao_backend_help')]
     public function helpAction(): Response
     {
         $this->initializeContaoFramework();
@@ -118,9 +106,7 @@ class BackendController extends AbstractController
         return $controller->run();
     }
 
-    /**
-     * @Route("/popup", name="contao_backend_popup")
-     */
+    #[Route('/popup', name: 'contao_backend_popup')]
     public function popupAction(): Response
     {
         $this->initializeContaoFramework();
@@ -130,9 +116,7 @@ class BackendController extends AbstractController
         return $controller->run();
     }
 
-    /**
-     * @Route("/alerts", name="contao_backend_alerts")
-     */
+    #[Route('/alerts', name: 'contao_backend_alerts')]
     public function alertsAction(): Response
     {
         $this->initializeContaoFramework();
@@ -146,9 +130,8 @@ class BackendController extends AbstractController
      * Redirects the user to the Contao back end and adds the picker query parameter.
      * It will determine the current provider URL based on the value, which is usually
      * read dynamically via JavaScript.
-     *
-     * @Route("/picker", name="contao_backend_picker")
      */
+    #[Route('/picker', name: 'contao_backend_picker')]
     public function pickerAction(Request $request): RedirectResponse
     {
         $extras = [];

--- a/core-bundle/src/Controller/BackendPreviewController.php
+++ b/core-bundle/src/Controller/BackendPreviewController.php
@@ -26,9 +26,8 @@ use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
  * This controller handles the back end preview call and redirects to the
  * requested front end page while ensuring that the /preview.php entry point is
  * used. When requested, the front end user gets authenticated.
- *
- * @Route(path="%contao.backend.route_prefix%", defaults={"_scope" = "backend", "_allow_preview" = true})
  */
+#[Route(path: '%contao.backend.route_prefix%', defaults: ['_scope' => 'backend', '_allow_preview' => true])]
 class BackendPreviewController
 {
     public function __construct(
@@ -39,9 +38,7 @@ class BackendPreviewController
     ) {
     }
 
-    /**
-     * @Route("/preview", name="contao_backend_preview")
-     */
+    #[Route('/preview', name: 'contao_backend_preview')]
     public function __invoke(Request $request): Response
     {
         // Skip the redirect if there is no preview script, otherwise we will

--- a/core-bundle/src/Controller/BackendPreviewSwitchController.php
+++ b/core-bundle/src/Controller/BackendPreviewSwitchController.php
@@ -36,9 +36,8 @@ use Twig\Error\Error as TwigError;
  *    loading and force back end scope)
  * b) Provide the member usernames for the datalist
  * c) Process the switch action (i.e. log in a specific front end user).
- *
- * @Route(path="%contao.backend.route_prefix%", defaults={"_scope" = "backend", "_allow_preview" = true})
  */
+#[Route(path: '%contao.backend.route_prefix%', defaults: ['_scope' => 'backend', '_allow_preview' => true])]
 class BackendPreviewSwitchController
 {
     public function __construct(
@@ -55,9 +54,7 @@ class BackendPreviewSwitchController
     ) {
     }
 
-    /**
-     * @Route("/preview_switch", name="contao_backend_switch")
-     */
+    #[Route('/preview_switch', name: 'contao_backend_switch')]
     public function __invoke(Request $request): Response
     {
         $user = $this->security->getUser();

--- a/core-bundle/src/Controller/ContentElement/CodeController.php
+++ b/core-bundle/src/Controller/ContentElement/CodeController.php
@@ -13,14 +13,12 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Controller\ContentElement;
 
 use Contao\ContentModel;
-use Contao\CoreBundle\ServiceAnnotation\ContentElement;
+use Contao\CoreBundle\DependencyInjection\Attribute\AsContentElement;
 use Contao\CoreBundle\Twig\FragmentTemplate;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-/**
- * @ContentElement(category="texts")
- */
+#[AsContentElement(category: "texts")]
 class CodeController extends AbstractContentElementController
 {
     protected function getResponse(FragmentTemplate $template, ContentModel $model, Request $request): Response

--- a/core-bundle/src/Controller/ContentElement/CodeController.php
+++ b/core-bundle/src/Controller/ContentElement/CodeController.php
@@ -18,7 +18,7 @@ use Contao\CoreBundle\Twig\FragmentTemplate;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-#[AsContentElement(category: "texts")]
+#[AsContentElement(category: 'texts')]
 class CodeController extends AbstractContentElementController
 {
     protected function getResponse(FragmentTemplate $template, ContentModel $model, Request $request): Response

--- a/core-bundle/src/Controller/ContentElement/HeadlineController.php
+++ b/core-bundle/src/Controller/ContentElement/HeadlineController.php
@@ -13,14 +13,12 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Controller\ContentElement;
 
 use Contao\ContentModel;
-use Contao\CoreBundle\ServiceAnnotation\ContentElement;
+use Contao\CoreBundle\DependencyInjection\Attribute\AsContentElement;
 use Contao\CoreBundle\Twig\FragmentTemplate;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-/**
- * @ContentElement(category="texts")
- */
+#[AsContentElement(category: "texts")]
 class HeadlineController extends AbstractContentElementController
 {
     protected function getResponse(FragmentTemplate $template, ContentModel $model, Request $request): Response

--- a/core-bundle/src/Controller/ContentElement/HeadlineController.php
+++ b/core-bundle/src/Controller/ContentElement/HeadlineController.php
@@ -18,7 +18,7 @@ use Contao\CoreBundle\Twig\FragmentTemplate;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-#[AsContentElement(category: "texts")]
+#[AsContentElement(category: 'texts')]
 class HeadlineController extends AbstractContentElementController
 {
     protected function getResponse(FragmentTemplate $template, ContentModel $model, Request $request): Response

--- a/core-bundle/src/Controller/ContentElement/HtmlController.php
+++ b/core-bundle/src/Controller/ContentElement/HtmlController.php
@@ -13,14 +13,12 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Controller\ContentElement;
 
 use Contao\ContentModel;
-use Contao\CoreBundle\ServiceAnnotation\ContentElement;
+use Contao\CoreBundle\DependencyInjection\Attribute\AsContentElement;
 use Contao\CoreBundle\Twig\FragmentTemplate;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-/**
- * @ContentElement(category="texts")
- */
+#[AsContentElement(category: "texts")]
 class HtmlController extends AbstractContentElementController
 {
     protected function getResponse(FragmentTemplate $template, ContentModel $model, Request $request): Response

--- a/core-bundle/src/Controller/ContentElement/HtmlController.php
+++ b/core-bundle/src/Controller/ContentElement/HtmlController.php
@@ -18,7 +18,7 @@ use Contao\CoreBundle\Twig\FragmentTemplate;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-#[AsContentElement(category: "texts")]
+#[AsContentElement(category: 'texts')]
 class HtmlController extends AbstractContentElementController
 {
     protected function getResponse(FragmentTemplate $template, ContentModel $model, Request $request): Response

--- a/core-bundle/src/Controller/ContentElement/HyperlinkController.php
+++ b/core-bundle/src/Controller/ContentElement/HyperlinkController.php
@@ -23,7 +23,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 
-#[AsContentElement(category: "links")]
+#[AsContentElement(category: 'links')]
 class HyperlinkController extends AbstractContentElementController
 {
     public function __construct(

--- a/core-bundle/src/Controller/ContentElement/HyperlinkController.php
+++ b/core-bundle/src/Controller/ContentElement/HyperlinkController.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Controller\ContentElement;
 
 use Contao\ContentModel;
+use Contao\CoreBundle\DependencyInjection\Attribute\AsContentElement;
 use Contao\CoreBundle\Image\Studio\Studio;
 use Contao\CoreBundle\InsertTag\InsertTagParser;
-use Contao\CoreBundle\ServiceAnnotation\ContentElement;
 use Contao\CoreBundle\String\HtmlAttributes;
 use Contao\CoreBundle\Twig\FragmentTemplate;
 use Contao\Validator;
@@ -23,9 +23,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 
-/**
- * @ContentElement(category="links")
- */
+#[AsContentElement(category: "links")]
 class HyperlinkController extends AbstractContentElementController
 {
     public function __construct(

--- a/core-bundle/src/Controller/ContentElement/ImagesController.php
+++ b/core-bundle/src/Controller/ContentElement/ImagesController.php
@@ -13,23 +13,21 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Controller\ContentElement;
 
 use Contao\ContentModel;
+use Contao\CoreBundle\DependencyInjection\Attribute\AsContentElement;
 use Contao\CoreBundle\Filesystem\FilesystemItem;
 use Contao\CoreBundle\Filesystem\FilesystemUtil;
 use Contao\CoreBundle\Filesystem\SortMode;
 use Contao\CoreBundle\Filesystem\VirtualFilesystem;
 use Contao\CoreBundle\Image\Studio\Figure;
 use Contao\CoreBundle\Image\Studio\Studio;
-use Contao\CoreBundle\ServiceAnnotation\ContentElement;
 use Contao\CoreBundle\Twig\FragmentTemplate;
 use Contao\FrontendUser;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Security;
 
-/**
- * @ContentElement("image", category="media")
- * @ContentElement("gallery", category="media")
- */
+#[AsContentElement("image", category: "media")]
+#[AsContentElement("gallery", category: "media")]
 class ImagesController extends AbstractContentElementController
 {
     public function __construct(

--- a/core-bundle/src/Controller/ContentElement/ImagesController.php
+++ b/core-bundle/src/Controller/ContentElement/ImagesController.php
@@ -26,8 +26,8 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Security;
 
-#[AsContentElement("image", category: "media")]
-#[AsContentElement("gallery", category: "media")]
+#[AsContentElement('image', category: 'media')]
+#[AsContentElement('gallery', category: 'media')]
 class ImagesController extends AbstractContentElementController
 {
     public function __construct(

--- a/core-bundle/src/Controller/ContentElement/ListController.php
+++ b/core-bundle/src/Controller/ContentElement/ListController.php
@@ -13,15 +13,13 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Controller\ContentElement;
 
 use Contao\ContentModel;
-use Contao\CoreBundle\ServiceAnnotation\ContentElement;
+use Contao\CoreBundle\DependencyInjection\Attribute\AsContentElement;
 use Contao\CoreBundle\Twig\FragmentTemplate;
 use Contao\StringUtil;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-/**
- * @ContentElement(category="texts")
- */
+#[AsContentElement(category: "texts")]
 class ListController extends AbstractContentElementController
 {
     protected function getResponse(FragmentTemplate $template, ContentModel $model, Request $request): Response

--- a/core-bundle/src/Controller/ContentElement/ListController.php
+++ b/core-bundle/src/Controller/ContentElement/ListController.php
@@ -19,7 +19,7 @@ use Contao\StringUtil;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-#[AsContentElement(category: "texts")]
+#[AsContentElement(category: 'texts')]
 class ListController extends AbstractContentElementController
 {
     protected function getResponse(FragmentTemplate $template, ContentModel $model, Request $request): Response

--- a/core-bundle/src/Controller/ContentElement/MarkdownController.php
+++ b/core-bundle/src/Controller/ContentElement/MarkdownController.php
@@ -31,7 +31,7 @@ use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-#[AsContentElement(category: "texts")]
+#[AsContentElement(category: 'texts')]
 class MarkdownController extends AbstractContentElementController
 {
     protected function getResponse(Template $template, ContentModel $model, Request $request): Response

--- a/core-bundle/src/Controller/ContentElement/MarkdownController.php
+++ b/core-bundle/src/Controller/ContentElement/MarkdownController.php
@@ -14,7 +14,7 @@ namespace Contao\CoreBundle\Controller\ContentElement;
 
 use Contao\Config;
 use Contao\ContentModel;
-use Contao\CoreBundle\ServiceAnnotation\ContentElement;
+use Contao\CoreBundle\DependencyInjection\Attribute\AsContentElement;
 use Contao\FilesModel;
 use Contao\Input;
 use Contao\Template;
@@ -31,9 +31,7 @@ use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-/**
- * @ContentElement(category="texts")
- */
+#[AsContentElement(category: "texts")]
 class MarkdownController extends AbstractContentElementController
 {
     protected function getResponse(Template $template, ContentModel $model, Request $request): Response

--- a/core-bundle/src/Controller/ContentElement/TableController.php
+++ b/core-bundle/src/Controller/ContentElement/TableController.php
@@ -13,15 +13,13 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Controller\ContentElement;
 
 use Contao\ContentModel;
-use Contao\CoreBundle\ServiceAnnotation\ContentElement;
+use Contao\CoreBundle\DependencyInjection\Attribute\AsContentElement;
 use Contao\CoreBundle\Twig\FragmentTemplate;
 use Contao\StringUtil;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-/**
- * @ContentElement(category="texts")
- */
+#[AsContentElement(category: "texts")]
 class TableController extends AbstractContentElementController
 {
     protected function getResponse(FragmentTemplate $template, ContentModel $model, Request $request): Response

--- a/core-bundle/src/Controller/ContentElement/TableController.php
+++ b/core-bundle/src/Controller/ContentElement/TableController.php
@@ -19,7 +19,7 @@ use Contao\StringUtil;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-#[AsContentElement(category: "texts")]
+#[AsContentElement(category: 'texts')]
 class TableController extends AbstractContentElementController
 {
     protected function getResponse(FragmentTemplate $template, ContentModel $model, Request $request): Response

--- a/core-bundle/src/Controller/ContentElement/TemplateController.php
+++ b/core-bundle/src/Controller/ContentElement/TemplateController.php
@@ -19,7 +19,7 @@ use Contao\Template;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-#[AsContentElement(category: "includes")]
+#[AsContentElement(category: 'includes')]
 class TemplateController extends AbstractContentElementController
 {
     protected function getResponse(Template $template, ContentModel $model, Request $request): Response

--- a/core-bundle/src/Controller/ContentElement/TemplateController.php
+++ b/core-bundle/src/Controller/ContentElement/TemplateController.php
@@ -13,15 +13,13 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Controller\ContentElement;
 
 use Contao\ContentModel;
-use Contao\CoreBundle\ServiceAnnotation\ContentElement;
+use Contao\CoreBundle\DependencyInjection\Attribute\AsContentElement;
 use Contao\StringUtil;
 use Contao\Template;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-/**
- * @ContentElement(category="includes")
- */
+#[AsContentElement(category: "includes")]
 class TemplateController extends AbstractContentElementController
 {
     protected function getResponse(Template $template, ContentModel $model, Request $request): Response

--- a/core-bundle/src/Controller/ContentElement/TextController.php
+++ b/core-bundle/src/Controller/ContentElement/TextController.php
@@ -19,7 +19,7 @@ use Contao\CoreBundle\Twig\FragmentTemplate;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-#[AsContentElement(category: "texts")]
+#[AsContentElement(category: 'texts')]
 class TextController extends AbstractContentElementController
 {
     public function __construct(private readonly Studio $studio)

--- a/core-bundle/src/Controller/ContentElement/TextController.php
+++ b/core-bundle/src/Controller/ContentElement/TextController.php
@@ -13,15 +13,13 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Controller\ContentElement;
 
 use Contao\ContentModel;
+use Contao\CoreBundle\DependencyInjection\Attribute\AsContentElement;
 use Contao\CoreBundle\Image\Studio\Studio;
-use Contao\CoreBundle\ServiceAnnotation\ContentElement;
 use Contao\CoreBundle\Twig\FragmentTemplate;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-/**
- * @ContentElement(category="texts")
- */
+#[AsContentElement(category: "texts")]
 class TextController extends AbstractContentElementController
 {
     public function __construct(private readonly Studio $studio)

--- a/core-bundle/src/Controller/ContentElement/ToplinkController.php
+++ b/core-bundle/src/Controller/ContentElement/ToplinkController.php
@@ -18,7 +18,7 @@ use Contao\CoreBundle\Twig\FragmentTemplate;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-#[AsContentElement(category: "links")]
+#[AsContentElement(category: 'links')]
 class ToplinkController extends AbstractContentElementController
 {
     protected function getResponse(FragmentTemplate $template, ContentModel $model, Request $request): Response

--- a/core-bundle/src/Controller/ContentElement/ToplinkController.php
+++ b/core-bundle/src/Controller/ContentElement/ToplinkController.php
@@ -13,14 +13,12 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Controller\ContentElement;
 
 use Contao\ContentModel;
-use Contao\CoreBundle\ServiceAnnotation\ContentElement;
+use Contao\CoreBundle\DependencyInjection\Attribute\AsContentElement;
 use Contao\CoreBundle\Twig\FragmentTemplate;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-/**
- * @ContentElement(category="links")
- */
+#[AsContentElement(category: "links")]
 class ToplinkController extends AbstractContentElementController
 {
     protected function getResponse(FragmentTemplate $template, ContentModel $model, Request $request): Response

--- a/core-bundle/src/Controller/ContentElement/UnfilteredHtmlController.php
+++ b/core-bundle/src/Controller/ContentElement/UnfilteredHtmlController.php
@@ -18,7 +18,7 @@ use Contao\CoreBundle\Twig\FragmentTemplate;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-#[AsContentElement(category: "texts")]
+#[AsContentElement(category: 'texts')]
 class UnfilteredHtmlController extends AbstractContentElementController
 {
     protected function getResponse(FragmentTemplate $template, ContentModel $model, Request $request): Response

--- a/core-bundle/src/Controller/ContentElement/UnfilteredHtmlController.php
+++ b/core-bundle/src/Controller/ContentElement/UnfilteredHtmlController.php
@@ -13,14 +13,12 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Controller\ContentElement;
 
 use Contao\ContentModel;
-use Contao\CoreBundle\ServiceAnnotation\ContentElement;
+use Contao\CoreBundle\DependencyInjection\Attribute\AsContentElement;
 use Contao\CoreBundle\Twig\FragmentTemplate;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-/**
- * @ContentElement(category="texts")
- */
+#[AsContentElement(category: "texts")]
 class UnfilteredHtmlController extends AbstractContentElementController
 {
     protected function getResponse(FragmentTemplate $template, ContentModel $model, Request $request): Response

--- a/core-bundle/src/Controller/ContentElement/VideoController.php
+++ b/core-bundle/src/Controller/ContentElement/VideoController.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Controller\ContentElement;
 
 use Contao\ContentModel;
+use Contao\CoreBundle\DependencyInjection\Attribute\AsContentElement;
 use Contao\CoreBundle\Image\Studio\Studio;
 use Contao\CoreBundle\ServiceAnnotation\ContentElement;
 use Contao\CoreBundle\Twig\FragmentTemplate;
@@ -21,9 +22,6 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
- * @ContentElement("vimeo", category="media")
- * @ContentElement("youtube", category="media")
- *
  * @phpstan-type VideoSourceParameters array{
  *      provider: 'vimeo'|'youtube',
  *      video_id: string,
@@ -33,6 +31,8 @@ use Symfony\Component\HttpFoundation\Response;
  *      url: string
  *  }
  */
+#[AsContentElement("vimeo", category: "media")]
+#[AsContentElement("youtube", category: "media")]
 class VideoController extends AbstractContentElementController
 {
     public function __construct(private readonly Studio $studio)

--- a/core-bundle/src/Controller/ContentElement/VideoController.php
+++ b/core-bundle/src/Controller/ContentElement/VideoController.php
@@ -31,8 +31,8 @@ use Symfony\Component\HttpFoundation\Response;
  *      url: string
  *  }
  */
-#[AsContentElement("vimeo", category: "media")]
-#[AsContentElement("youtube", category: "media")]
+#[AsContentElement('vimeo', category: 'media')]
+#[AsContentElement('youtube', category: 'media')]
 class VideoController extends AbstractContentElementController
 {
     public function __construct(private readonly Studio $studio)

--- a/core-bundle/src/Controller/ContentElement/VideoController.php
+++ b/core-bundle/src/Controller/ContentElement/VideoController.php
@@ -15,7 +15,6 @@ namespace Contao\CoreBundle\Controller\ContentElement;
 use Contao\ContentModel;
 use Contao\CoreBundle\DependencyInjection\Attribute\AsContentElement;
 use Contao\CoreBundle\Image\Studio\Studio;
-use Contao\CoreBundle\ServiceAnnotation\ContentElement;
 use Contao\CoreBundle\Twig\FragmentTemplate;
 use Contao\StringUtil;
 use Symfony\Component\HttpFoundation\Request;

--- a/core-bundle/src/Controller/FaviconController.php
+++ b/core-bundle/src/Controller/FaviconController.php
@@ -32,7 +32,7 @@ class FaviconController
     {
     }
 
-    #[Route("/favicon.ico")]
+    #[Route('/favicon.ico')]
     public function __invoke(Request $request): Response
     {
         $this->framework->initialize();

--- a/core-bundle/src/Controller/FaviconController.php
+++ b/core-bundle/src/Controller/FaviconController.php
@@ -23,19 +23,16 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
- * @Route(defaults={"_scope" = "frontend"})
- *
  * @internal
  */
+#[Route(defaults: ['_scope' => 'frontend'])]
 class FaviconController
 {
     public function __construct(private ContaoFramework $framework, private string $projectDir, private EntityCacheTags $entityCacheTags)
     {
     }
 
-    /**
-     * @Route("/favicon.ico")
-     */
+    #[Route("/favicon.ico")]
     public function __invoke(Request $request): Response
     {
         $this->framework->initialize();

--- a/core-bundle/src/Controller/FrontendController.php
+++ b/core-bundle/src/Controller/FrontendController.php
@@ -22,15 +22,12 @@ use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Security\Core\Exception\LogoutException;
 
 /**
- * @Route(defaults={"_scope" = "frontend", "_token_check" = true})
- *
  * @internal
  */
+#[Route(defaults: ['_scope' => 'frontend', '_token_check' => true])]
 class FrontendController extends AbstractController
 {
-    /**
-     * @Route("/_contao/cron", name="contao_frontend_cron")
-     */
+    #[Route('/_contao/cron', name: 'contao_frontend_cron')]
     public function cronAction(Request $request): Response
     {
         if ($request->isMethod(Request::METHOD_GET)) {
@@ -40,9 +37,7 @@ class FrontendController extends AbstractController
         return new Response('', Response::HTTP_NO_CONTENT);
     }
 
-    /**
-     * @Route("/_contao/share", name="contao_frontend_share")
-     */
+    #[Route('/_contao/share', name: 'contao_frontend_share')]
     public function shareAction(): RedirectResponse
     {
         $this->initializeContaoFramework();
@@ -54,9 +49,8 @@ class FrontendController extends AbstractController
 
     /**
      * Symfony will un-authenticate the user automatically by calling this route.
-     *
-     * @Route("/_contao/logout", name="contao_frontend_logout")
      */
+    #[Route('/_contao/logout', name: 'contao_frontend_logout')]
     public function logoutAction(): never
     {
         throw new LogoutException('The user was not logged out correctly.');
@@ -70,9 +64,8 @@ class FrontendController extends AbstractController
      * the output is cached (used in the core if the "alwaysLoadFromCache"
      * option is enabled to evaluate the RememberMe cookie and then set
      * the session cookie).
-     *
-     * @Route("/_contao/check_cookies", name="contao_frontend_check_cookies")
      */
+    #[Route('/_contao/check_cookies', name: 'contao_frontend_check_cookies')]
     public function checkCookiesAction(): Response
     {
         static $image = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=';
@@ -89,9 +82,8 @@ class FrontendController extends AbstractController
     /**
      * Returns a script that makes sure a valid request token is filled into
      * all forms if the "alwaysLoadFromCache" option is enabled.
-     *
-     * @Route("/_contao/request_token_script", name="contao_frontend_request_token_script")
      */
+    #[Route('/_contao/request_token_script', name: 'contao_frontend_request_token_script')]
     public function requestTokenScriptAction(): Response
     {
         $tokenValue = json_encode($this->container->get('contao.csrf.token_manager')->getDefaultTokenValue());

--- a/core-bundle/src/Controller/FrontendModule/RootPageDependentModulesController.php
+++ b/core-bundle/src/Controller/FrontendModule/RootPageDependentModulesController.php
@@ -20,7 +20,7 @@ use Contao\Template;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-#[AsFrontendModule(category: "miscellaneous")]
+#[AsFrontendModule(category: 'miscellaneous')]
 class RootPageDependentModulesController extends AbstractFrontendModuleController
 {
     public function __invoke(Request $request, ModuleModel $model, string $section, array $classes = null): Response

--- a/core-bundle/src/Controller/FrontendModule/RootPageDependentModulesController.php
+++ b/core-bundle/src/Controller/FrontendModule/RootPageDependentModulesController.php
@@ -13,16 +13,14 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Controller\FrontendModule;
 
 use Contao\Controller;
-use Contao\CoreBundle\ServiceAnnotation\FrontendModule;
+use Contao\CoreBundle\DependencyInjection\Attribute\AsFrontendModule;
 use Contao\ModuleModel;
 use Contao\StringUtil;
 use Contao\Template;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-/**
- * @FrontendModule(category="miscellaneous")
- */
+#[AsFrontendModule(category: "miscellaneous")]
 class RootPageDependentModulesController extends AbstractFrontendModuleController
 {
     public function __invoke(Request $request, ModuleModel $model, string $section, array $classes = null): Response

--- a/core-bundle/src/Controller/FrontendModule/TemplateController.php
+++ b/core-bundle/src/Controller/FrontendModule/TemplateController.php
@@ -12,16 +12,14 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Controller\FrontendModule;
 
-use Contao\CoreBundle\ServiceAnnotation\FrontendModule;
+use Contao\CoreBundle\DependencyInjection\Attribute\AsFrontendModule;
 use Contao\ModuleModel;
 use Contao\StringUtil;
 use Contao\Template;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-/**
- * @FrontendModule(category="miscellaneous")
- */
+#[AsFrontendModule(category: "miscellaneous")]
 class TemplateController extends AbstractFrontendModuleController
 {
     protected function getResponse(Template $template, ModuleModel $model, Request $request): Response

--- a/core-bundle/src/Controller/FrontendModule/TemplateController.php
+++ b/core-bundle/src/Controller/FrontendModule/TemplateController.php
@@ -19,7 +19,7 @@ use Contao\Template;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-#[AsFrontendModule(category: "miscellaneous")]
+#[AsFrontendModule(category: 'miscellaneous')]
 class TemplateController extends AbstractFrontendModuleController
 {
     protected function getResponse(Template $template, ModuleModel $model, Request $request): Response

--- a/core-bundle/src/Controller/FrontendModule/TwoFactorController.php
+++ b/core-bundle/src/Controller/FrontendModule/TwoFactorController.php
@@ -34,7 +34,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * @internal
  */
-#[AsFrontendModule(category: "user")]
+#[AsFrontendModule(category: 'user')]
 class TwoFactorController extends AbstractFrontendModuleController
 {
     protected PageModel|null $pageModel = null;

--- a/core-bundle/src/Controller/FrontendModule/TwoFactorController.php
+++ b/core-bundle/src/Controller/FrontendModule/TwoFactorController.php
@@ -12,12 +12,12 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Controller\FrontendModule;
 
+use Contao\CoreBundle\DependencyInjection\Attribute\AsFrontendModule;
 use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\CoreBundle\Routing\ScopeMatcher;
 use Contao\CoreBundle\Security\TwoFactor\Authenticator;
 use Contao\CoreBundle\Security\TwoFactor\BackupCodeManager;
 use Contao\CoreBundle\Security\TwoFactor\TrustedDeviceManager;
-use Contao\CoreBundle\ServiceAnnotation\FrontendModule;
 use Contao\FrontendUser;
 use Contao\ModuleModel;
 use Contao\PageModel;
@@ -33,9 +33,8 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * @internal
- *
- * @FrontendModule(category="user")
  */
+#[AsFrontendModule(category: "user")]
 class TwoFactorController extends AbstractFrontendModuleController
 {
     protected PageModel|null $pageModel = null;

--- a/core-bundle/src/Controller/FrontendModule/UnfilteredHtmlController.php
+++ b/core-bundle/src/Controller/FrontendModule/UnfilteredHtmlController.php
@@ -12,15 +12,13 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Controller\FrontendModule;
 
-use Contao\CoreBundle\ServiceAnnotation\FrontendModule;
+use Contao\CoreBundle\DependencyInjection\Attribute\AsFrontendModule;
 use Contao\CoreBundle\Twig\FragmentTemplate;
 use Contao\ModuleModel;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-/**
- * @FrontendModule(category="miscellaneous")
- */
+#[AsFrontendModule(category: "miscellaneous")]
 class UnfilteredHtmlController extends AbstractFrontendModuleController
 {
     protected function getResponse(FragmentTemplate $template, ModuleModel $model, Request $request): Response

--- a/core-bundle/src/Controller/FrontendModule/UnfilteredHtmlController.php
+++ b/core-bundle/src/Controller/FrontendModule/UnfilteredHtmlController.php
@@ -18,7 +18,7 @@ use Contao\ModuleModel;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-#[AsFrontendModule(category: "miscellaneous")]
+#[AsFrontendModule(category: 'miscellaneous')]
 class UnfilteredHtmlController extends AbstractFrontendModuleController
 {
     protected function getResponse(FragmentTemplate $template, ModuleModel $model, Request $request): Response

--- a/core-bundle/src/Controller/Page/ErrorPageController.php
+++ b/core-bundle/src/Controller/Page/ErrorPageController.php
@@ -13,21 +13,20 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Controller\Page;
 
 use Contao\CoreBundle\Controller\AbstractController;
+use Contao\CoreBundle\DependencyInjection\Attribute\AsPage;
 use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\CoreBundle\Routing\Page\ContentCompositionInterface;
-use Contao\CoreBundle\ServiceAnnotation\Page;
 use Contao\FrontendIndex;
 use Contao\PageModel;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
- * @Page("error_401", path=false)
- * @Page("error_403", path=false)
- * @Page("error_404", path=false)
- * @Page("error_503", path=false)
- *
  * @internal
  */
+#[AsPage('error_401', path: false)]
+#[AsPage('error_403', path: false)]
+#[AsPage('error_404', path: false)]
+#[AsPage('error_503', path: false)]
 class ErrorPageController extends AbstractController implements ContentCompositionInterface
 {
     public function __construct(private ContaoFramework $framework)

--- a/core-bundle/src/Controller/Page/RootPageController.php
+++ b/core-bundle/src/Controller/Page/RootPageController.php
@@ -13,17 +13,16 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Controller\Page;
 
 use Contao\CoreBundle\Controller\AbstractController;
+use Contao\CoreBundle\DependencyInjection\Attribute\AsPage;
 use Contao\CoreBundle\Exception\NoActivePageFoundException;
-use Contao\CoreBundle\ServiceAnnotation\Page;
 use Contao\PageModel;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
- * @Page(contentComposition=false)
- *
  * @internal
  */
+#[AsPage(contentComposition: false)]
 class RootPageController extends AbstractController
 {
     public function __construct(private LoggerInterface|null $logger = null)

--- a/core-bundle/src/Controller/PreviewLinkController.php
+++ b/core-bundle/src/Controller/PreviewLinkController.php
@@ -22,19 +22,16 @@ use Symfony\Component\HttpKernel\UriSigner;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
- * @Route(defaults={"_scope" = "frontend", "_allow_preview" = true})
- *
  * @internal
  */
+#[Route(defaults: ['_scope' => 'frontend', '_allow_preview' => true])]
 class PreviewLinkController
 {
     public function __construct(private FrontendPreviewAuthenticator $previewAuthenticator, private UriSigner $uriSigner, private Connection $connection)
     {
     }
 
-    /**
-     * @Route("/_contao/preview/{id}", name="contao_preview_link", requirements={"id"="\d+"})
-     */
+    #[Route('/_contao/preview/{id}', name: 'contao_preview_link', requirements: ['id' => '\d+'])]
     public function __invoke(Request $request, int $id): RedirectResponse
     {
         if (!$this->uriSigner->checkRequest($request)) {

--- a/core-bundle/src/Controller/RobotsTxtController.php
+++ b/core-bundle/src/Controller/RobotsTxtController.php
@@ -23,19 +23,16 @@ use Symfony\Component\Routing\Annotation\Route;
 use webignition\RobotsTxt\File\Parser;
 
 /**
- * @Route(defaults={"_scope" = "frontend"})
- *
  * @internal
  */
+#[Route(defaults: ['_scope' => 'frontend'])]
 class RobotsTxtController
 {
     public function __construct(private ContaoFramework $framework, private EventDispatcherInterface $eventDispatcher)
     {
     }
 
-    /**
-     * @Route("/robots.txt")
-     */
+    #[Route('/robots.txt')]
     public function __invoke(Request $request): Response
     {
         $this->framework->initialize();

--- a/core-bundle/src/Controller/SitemapController.php
+++ b/core-bundle/src/Controller/SitemapController.php
@@ -23,19 +23,16 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
- * @Route(defaults={"_scope" = "frontend"})
- *
  * @internal
  */
+#[Route(defaults: ['_scope' => 'frontend'])]
 class SitemapController extends AbstractController
 {
     public function __construct(private PageRegistry $pageRegistry)
     {
     }
 
-    /**
-     * @Route("/sitemap.xml")
-     */
+    #[Route('/sitemap.xml')]
     public function __invoke(Request $request): Response
     {
         $this->initializeContaoFramework();

--- a/core-bundle/src/Cron/PurgeExpiredDataCron.php
+++ b/core-bundle/src/Cron/PurgeExpiredDataCron.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Cron;
 
 use Contao\Config;
+use Contao\CoreBundle\DependencyInjection\Attribute\AsCronJob;
 use Contao\CoreBundle\Framework\ContaoFramework;
-use Contao\CoreBundle\ServiceAnnotation\CronJob;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Types\Types;
 
@@ -24,9 +24,7 @@ class PurgeExpiredDataCron
     {
     }
 
-    /**
-     * @CronJob("hourly")
-     */
+    #[AsCronJob("hourly")]
     public function onHourly(): void
     {
         $this->framework->initialize();

--- a/core-bundle/src/Cron/PurgeExpiredDataCron.php
+++ b/core-bundle/src/Cron/PurgeExpiredDataCron.php
@@ -24,7 +24,7 @@ class PurgeExpiredDataCron
     {
     }
 
-    #[AsCronJob("hourly")]
+    #[AsCronJob('hourly')]
     public function onHourly(): void
     {
         $this->framework->initialize();

--- a/core-bundle/src/Cron/PurgeOptInTokensCron.php
+++ b/core-bundle/src/Cron/PurgeOptInTokensCron.php
@@ -12,13 +12,11 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Cron;
 
+use Contao\CoreBundle\DependencyInjection\Attribute\AsCronJob;
 use Contao\CoreBundle\OptIn\OptIn;
-use Contao\CoreBundle\ServiceAnnotation\CronJob;
 use Psr\Log\LoggerInterface;
 
-/**
- * @CronJob("daily")
- */
+#[AsCronJob("daily")]
 class PurgeOptInTokensCron
 {
     public function __construct(private OptIn $optIn, private LoggerInterface|null $logger)

--- a/core-bundle/src/Cron/PurgeOptInTokensCron.php
+++ b/core-bundle/src/Cron/PurgeOptInTokensCron.php
@@ -16,7 +16,7 @@ use Contao\CoreBundle\DependencyInjection\Attribute\AsCronJob;
 use Contao\CoreBundle\OptIn\OptIn;
 use Psr\Log\LoggerInterface;
 
-#[AsCronJob("daily")]
+#[AsCronJob('daily')]
 class PurgeOptInTokensCron
 {
     public function __construct(private OptIn $optIn, private LoggerInterface|null $logger)

--- a/core-bundle/src/Cron/PurgePreviewLinksCron.php
+++ b/core-bundle/src/Cron/PurgePreviewLinksCron.php
@@ -12,17 +12,16 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Cron;
 
-use Contao\CoreBundle\ServiceAnnotation\CronJob;
+use Contao\CoreBundle\DependencyInjection\Attribute\AsCronJob;
 use Doctrine\DBAL\Connection;
 
 /**
  * Deletes preview links that are older than 31 days, since the maximum expiration is 30 days.
  * We don't purge right after expiration date since days can be changed to increase the lifetime.
  *
- * @CronJob("daily")
- *
  * @internal
  */
+#[AsCronJob("daily")]
 class PurgePreviewLinksCron
 {
     public function __construct(private Connection $connection)

--- a/core-bundle/src/Cron/PurgePreviewLinksCron.php
+++ b/core-bundle/src/Cron/PurgePreviewLinksCron.php
@@ -21,7 +21,7 @@ use Doctrine\DBAL\Connection;
  *
  * @internal
  */
-#[AsCronJob("daily")]
+#[AsCronJob('daily')]
 class PurgePreviewLinksCron
 {
     public function __construct(private Connection $connection)

--- a/core-bundle/src/Cron/PurgeRegistrationsCron.php
+++ b/core-bundle/src/Cron/PurgeRegistrationsCron.php
@@ -12,14 +12,12 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Cron;
 
+use Contao\CoreBundle\DependencyInjection\Attribute\AsCronJob;
 use Contao\CoreBundle\Framework\ContaoFramework;
-use Contao\CoreBundle\ServiceAnnotation\CronJob;
 use Contao\MemberModel;
 use Psr\Log\LoggerInterface;
 
-/**
- * @CronJob("daily")
- */
+#[AsCronJob("daily")]
 class PurgeRegistrationsCron
 {
     public function __construct(private ContaoFramework $framework, private LoggerInterface|null $logger)

--- a/core-bundle/src/Cron/PurgeRegistrationsCron.php
+++ b/core-bundle/src/Cron/PurgeRegistrationsCron.php
@@ -17,7 +17,7 @@ use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\MemberModel;
 use Psr\Log\LoggerInterface;
 
-#[AsCronJob("daily")]
+#[AsCronJob('daily')]
 class PurgeRegistrationsCron
 {
     public function __construct(private ContaoFramework $framework, private LoggerInterface|null $logger)

--- a/core-bundle/src/Cron/PurgeTempFolderCron.php
+++ b/core-bundle/src/Cron/PurgeTempFolderCron.php
@@ -18,7 +18,7 @@ use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Filesystem\Path;
 use Symfony\Component\Finder\Finder;
 
-#[AsCronJob("daily")]
+#[AsCronJob('daily')]
 class PurgeTempFolderCron
 {
     public function __construct(private Filesystem $filesystem, private string $projectDir, private LoggerInterface|null $logger)

--- a/core-bundle/src/Cron/PurgeTempFolderCron.php
+++ b/core-bundle/src/Cron/PurgeTempFolderCron.php
@@ -12,15 +12,13 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Cron;
 
-use Contao\CoreBundle\ServiceAnnotation\CronJob;
+use Contao\CoreBundle\DependencyInjection\Attribute\AsCronJob;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Filesystem\Path;
 use Symfony\Component\Finder\Finder;
 
-/**
- * @CronJob("daily")
- */
+#[AsCronJob("daily")]
 class PurgeTempFolderCron
 {
     public function __construct(private Filesystem $filesystem, private string $projectDir, private LoggerInterface|null $logger)

--- a/core-bundle/src/EventListener/DataContainer/ContentCompositionListener.php
+++ b/core-bundle/src/EventListener/DataContainer/ContentCompositionListener.php
@@ -54,7 +54,7 @@ class ContentCompositionListener
         $this->backend = $this->framework->getAdapter(Backend::class);
     }
 
-    #[AsCallback(table: "tl_page", target: "list.operations.articles.button")]
+    #[AsCallback(table: 'tl_page', target: 'list.operations.articles.button')]
     public function renderPageArticlesOperation(array $row, string|null $href, string $label, string $title, string|null $icon): string
     {
         if ((null === $href && null === $icon) || !$this->security->isGranted(ContaoCorePermissions::USER_CAN_ACCESS_MODULE, 'article')) {
@@ -80,7 +80,7 @@ class ContentCompositionListener
     /**
      * Automatically creates an article in the main column of a new page.
      */
-    #[AsCallback(table: "tl_page", target: "config.onsubmit", priority: -16)]
+    #[AsCallback(table: 'tl_page', target: 'config.onsubmit', priority: -16)]
     public function generateArticleForPage(DataContainer $dc): void
     {
         $request = $this->requestStack->getCurrentRequest();
@@ -140,7 +140,7 @@ class ContentCompositionListener
         $this->connection->insert('tl_article', $article);
     }
 
-    #[AsCallback(table: "tl_article", target: "list.sorting.paste_button")]
+    #[AsCallback(table: 'tl_article', target: 'list.sorting.paste_button')]
     public function renderArticlePasteButton(DataContainer $dc, array $row, string $table, bool $cr, array $clipboard = null): string
     {
         if ($table === ($GLOBALS['TL_DCA'][$dc->table]['config']['ptable'] ?? null)) {

--- a/core-bundle/src/EventListener/DataContainer/ContentCompositionListener.php
+++ b/core-bundle/src/EventListener/DataContainer/ContentCompositionListener.php
@@ -14,11 +14,11 @@ namespace Contao\CoreBundle\EventListener\DataContainer;
 
 use Contao\Backend;
 use Contao\BackendUser;
+use Contao\CoreBundle\DependencyInjection\Attribute\AsCallback;
 use Contao\CoreBundle\Framework\Adapter;
 use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\CoreBundle\Routing\Page\PageRegistry;
 use Contao\CoreBundle\Security\ContaoCorePermissions;
-use Contao\CoreBundle\ServiceAnnotation\Callback;
 use Contao\DataContainer;
 use Contao\Image;
 use Contao\LayoutModel;
@@ -54,9 +54,7 @@ class ContentCompositionListener
         $this->backend = $this->framework->getAdapter(Backend::class);
     }
 
-    /**
-     * @Callback(table="tl_page", target="list.operations.articles.button")
-     */
+    #[AsCallback(table: "tl_page", target: "list.operations.articles.button")]
     public function renderPageArticlesOperation(array $row, string|null $href, string $label, string $title, string|null $icon): string
     {
         if ((null === $href && null === $icon) || !$this->security->isGranted(ContaoCorePermissions::USER_CAN_ACCESS_MODULE, 'article')) {
@@ -81,9 +79,8 @@ class ContentCompositionListener
 
     /**
      * Automatically creates an article in the main column of a new page.
-     *
-     * @Callback(table="tl_page", target="config.onsubmit", priority=-16)
      */
+    #[AsCallback(table: "tl_page", target: "config.onsubmit", priority: -16)]
     public function generateArticleForPage(DataContainer $dc): void
     {
         $request = $this->requestStack->getCurrentRequest();
@@ -143,9 +140,7 @@ class ContentCompositionListener
         $this->connection->insert('tl_article', $article);
     }
 
-    /**
-     * @Callback(table="tl_article", target="list.sorting.paste_button")
-     */
+    #[AsCallback(table: "tl_article", target: "list.sorting.paste_button")]
     public function renderArticlePasteButton(DataContainer $dc, array $row, string $table, bool $cr, array $clipboard = null): string
     {
         if ($table === ($GLOBALS['TL_DCA'][$dc->table]['config']['ptable'] ?? null)) {

--- a/core-bundle/src/EventListener/DataContainer/DefaultOperationsListener.php
+++ b/core-bundle/src/EventListener/DataContainer/DefaultOperationsListener.php
@@ -25,7 +25,7 @@ use Symfony\Component\Security\Core\Security;
 /**
  * @internal
  */
-#[AsHook("loadDataContainer", priority: 200)]
+#[AsHook('loadDataContainer', priority: 200)]
 class DefaultOperationsListener
 {
     public function __construct(private readonly Security $security, private readonly Connection $connection)

--- a/core-bundle/src/EventListener/DataContainer/DefaultOperationsListener.php
+++ b/core-bundle/src/EventListener/DataContainer/DefaultOperationsListener.php
@@ -13,20 +13,19 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\EventListener\DataContainer;
 
 use Contao\CoreBundle\DataContainer\DataContainerOperation;
+use Contao\CoreBundle\DependencyInjection\Attribute\AsHook;
 use Contao\CoreBundle\Security\ContaoCorePermissions;
 use Contao\CoreBundle\Security\DataContainer\CreateAction;
 use Contao\CoreBundle\Security\DataContainer\DeleteAction;
 use Contao\CoreBundle\Security\DataContainer\UpdateAction;
-use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\DataContainer;
 use Doctrine\DBAL\Connection;
 use Symfony\Component\Security\Core\Security;
 
 /**
  * @internal
- *
- * @Hook("loadDataContainer", priority=200)
  */
+#[AsHook("loadDataContainer", priority: 200)]
 class DefaultOperationsListener
 {
     public function __construct(private readonly Security $security, private readonly Connection $connection)

--- a/core-bundle/src/EventListener/DataContainer/DisableAppConfiguredSettingsListener.php
+++ b/core-bundle/src/EventListener/DataContainer/DisableAppConfiguredSettingsListener.php
@@ -18,7 +18,7 @@ use Contao\Image;
 use Contao\StringUtil;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-#[AsCallback(table: "tl_settings", target: "config.onload")]
+#[AsCallback(table: 'tl_settings', target: 'config.onload')]
 class DisableAppConfiguredSettingsListener
 {
     public function __construct(private TranslatorInterface $translator, private ContaoFramework $framework, private array $localConfig)

--- a/core-bundle/src/EventListener/DataContainer/DisableAppConfiguredSettingsListener.php
+++ b/core-bundle/src/EventListener/DataContainer/DisableAppConfiguredSettingsListener.php
@@ -12,15 +12,13 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\EventListener\DataContainer;
 
+use Contao\CoreBundle\DependencyInjection\Attribute\AsCallback;
 use Contao\CoreBundle\Framework\ContaoFramework;
-use Contao\CoreBundle\ServiceAnnotation\Callback;
 use Contao\Image;
 use Contao\StringUtil;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-/**
- * @Callback(table="tl_settings", target="config.onload")
- */
+#[AsCallback(table: "tl_settings", target: "config.onload")]
 class DisableAppConfiguredSettingsListener
 {
     public function __construct(private TranslatorInterface $translator, private ContaoFramework $framework, private array $localConfig)

--- a/core-bundle/src/EventListener/DataContainer/DisableCanonicalFieldsListener.php
+++ b/core-bundle/src/EventListener/DataContainer/DisableCanonicalFieldsListener.php
@@ -20,8 +20,8 @@ use Contao\PageModel;
 use Contao\StringUtil;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-#[AsCallback(table: "tl_page", target: "fields.canonicalLink.load")]
-#[AsCallback(table: "tl_page", target: "fields.canonicalKeepParams.load")]
+#[AsCallback(table: 'tl_page', target: 'fields.canonicalLink.load')]
+#[AsCallback(table: 'tl_page', target: 'fields.canonicalKeepParams.load')]
 class DisableCanonicalFieldsListener
 {
     public function __construct(private ContaoFramework $framework, private TranslatorInterface $translator)

--- a/core-bundle/src/EventListener/DataContainer/DisableCanonicalFieldsListener.php
+++ b/core-bundle/src/EventListener/DataContainer/DisableCanonicalFieldsListener.php
@@ -12,18 +12,16 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\EventListener\DataContainer;
 
+use Contao\CoreBundle\DependencyInjection\Attribute\AsCallback;
 use Contao\CoreBundle\Framework\ContaoFramework;
-use Contao\CoreBundle\ServiceAnnotation\Callback;
 use Contao\DataContainer;
 use Contao\Image;
 use Contao\PageModel;
 use Contao\StringUtil;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-/**
- * @Callback(table="tl_page", target="fields.canonicalLink.load")
- * @Callback(table="tl_page", target="fields.canonicalKeepParams.load")
- */
+#[AsCallback(table: "tl_page", target: "fields.canonicalLink.load")]
+#[AsCallback(table: "tl_page", target: "fields.canonicalKeepParams.load")]
 class DisableCanonicalFieldsListener
 {
     public function __construct(private ContaoFramework $framework, private TranslatorInterface $translator)

--- a/core-bundle/src/EventListener/DataContainer/LayoutOptionsListener.php
+++ b/core-bundle/src/EventListener/DataContainer/LayoutOptionsListener.php
@@ -16,8 +16,8 @@ use Contao\CoreBundle\DependencyInjection\Attribute\AsCallback;
 use Doctrine\DBAL\Connection;
 use Symfony\Contracts\Service\ResetInterface;
 
-#[AsCallback(table: "tl_page", target: "fields.layout.options")]
-#[AsCallback(table: "tl_page", target: "fields.subpageLayout.options")]
+#[AsCallback(table: 'tl_page', target: 'fields.layout.options')]
+#[AsCallback(table: 'tl_page', target: 'fields.subpageLayout.options')]
 class LayoutOptionsListener implements ResetInterface
 {
     private array|null $options = null;

--- a/core-bundle/src/EventListener/DataContainer/LayoutOptionsListener.php
+++ b/core-bundle/src/EventListener/DataContainer/LayoutOptionsListener.php
@@ -12,14 +12,12 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\EventListener\DataContainer;
 
-use Contao\CoreBundle\ServiceAnnotation\Callback;
+use Contao\CoreBundle\DependencyInjection\Attribute\AsCallback;
 use Doctrine\DBAL\Connection;
 use Symfony\Contracts\Service\ResetInterface;
 
-/**
- * @Callback(table="tl_page", target="fields.layout.options")
- * @Callback(table="tl_page", target="fields.subpageLayout.options")
- */
+#[AsCallback(table: "tl_page", target: "fields.layout.options")]
+#[AsCallback(table: "tl_page", target: "fields.subpageLayout.options")]
 class LayoutOptionsListener implements ResetInterface
 {
     private array|null $options = null;

--- a/core-bundle/src/EventListener/DataContainer/MemberGroupsListener.php
+++ b/core-bundle/src/EventListener/DataContainer/MemberGroupsListener.php
@@ -16,10 +16,10 @@ use Contao\CoreBundle\DependencyInjection\Attribute\AsCallback;
 use Doctrine\DBAL\Connection;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-#[AsCallback(table: "tl_article", target: "fields.groups.options")]
-#[AsCallback(table: "tl_content", target: "fields.groups.options")]
-#[AsCallback(table: "tl_module", target: "fields.groups.options")]
-#[AsCallback(table: "tl_page", target: "fields.groups.options")]
+#[AsCallback(table: 'tl_article', target: 'fields.groups.options')]
+#[AsCallback(table: 'tl_content', target: 'fields.groups.options')]
+#[AsCallback(table: 'tl_module', target: 'fields.groups.options')]
+#[AsCallback(table: 'tl_page', target: 'fields.groups.options')]
 class MemberGroupsListener
 {
     public function __construct(private Connection $connection, private TranslatorInterface $translator)

--- a/core-bundle/src/EventListener/DataContainer/MemberGroupsListener.php
+++ b/core-bundle/src/EventListener/DataContainer/MemberGroupsListener.php
@@ -12,16 +12,14 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\EventListener\DataContainer;
 
-use Contao\CoreBundle\ServiceAnnotation\Callback;
+use Contao\CoreBundle\DependencyInjection\Attribute\AsCallback;
 use Doctrine\DBAL\Connection;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-/**
- * @Callback(table="tl_article", target="fields.groups.options")
- * @Callback(table="tl_content", target="fields.groups.options")
- * @Callback(table="tl_module", target="fields.groups.options")
- * @Callback(table="tl_page", target="fields.groups.options")
- */
+#[AsCallback(table: "tl_article", target: "fields.groups.options")]
+#[AsCallback(table: "tl_content", target: "fields.groups.options")]
+#[AsCallback(table: "tl_module", target: "fields.groups.options")]
+#[AsCallback(table: "tl_page", target: "fields.groups.options")]
 class MemberGroupsListener
 {
     public function __construct(private Connection $connection, private TranslatorInterface $translator)

--- a/core-bundle/src/EventListener/DataContainer/PageRoutingListener.php
+++ b/core-bundle/src/EventListener/DataContainer/PageRoutingListener.php
@@ -28,7 +28,7 @@ class PageRoutingListener
     {
     }
 
-    #[AsCallback(table: "tl_page", target: "fields.routePath.input_field")]
+    #[AsCallback(table: 'tl_page', target: 'fields.routePath.input_field')]
     public function generateRoutePath(DataContainer $dc): string
     {
         $pageModel = $this->framework->getAdapter(PageModel::class)->findByPk($dc->id);
@@ -45,7 +45,7 @@ class PageRoutingListener
         );
     }
 
-    #[AsCallback(table: "tl_page", target: "fields.routeConflicts.input_field")]
+    #[AsCallback(table: 'tl_page', target: 'fields.routeConflicts.input_field')]
     public function generateRouteConflicts(DataContainer $dc): string
     {
         $pageAdapter = $this->framework->getAdapter(PageModel::class);

--- a/core-bundle/src/EventListener/DataContainer/PageRoutingListener.php
+++ b/core-bundle/src/EventListener/DataContainer/PageRoutingListener.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\EventListener\DataContainer;
 
 use Contao\Backend;
+use Contao\CoreBundle\DependencyInjection\Attribute\AsCallback;
 use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\CoreBundle\Routing\Page\PageRegistry;
 use Contao\CoreBundle\Routing\Page\PageRoute;
-use Contao\CoreBundle\ServiceAnnotation\Callback;
 use Contao\DataContainer;
 use Contao\PageModel;
 use Contao\StringUtil;
@@ -28,9 +28,7 @@ class PageRoutingListener
     {
     }
 
-    /**
-     * @Callback(table="tl_page", target="fields.routePath.input_field")
-     */
+    #[AsCallback(table: "tl_page", target: "fields.routePath.input_field")]
     public function generateRoutePath(DataContainer $dc): string
     {
         $pageModel = $this->framework->getAdapter(PageModel::class)->findByPk($dc->id);
@@ -47,9 +45,7 @@ class PageRoutingListener
         );
     }
 
-    /**
-     * @Callback(table="tl_page", target="fields.routeConflicts.input_field")
-     */
+    #[AsCallback(table: "tl_page", target: "fields.routeConflicts.input_field")]
     public function generateRouteConflicts(DataContainer $dc): string
     {
         $pageAdapter = $this->framework->getAdapter(PageModel::class);

--- a/core-bundle/src/EventListener/DataContainer/PageSearchListener.php
+++ b/core-bundle/src/EventListener/DataContainer/PageSearchListener.php
@@ -12,8 +12,8 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\EventListener\DataContainer;
 
+use Contao\CoreBundle\DependencyInjection\Attribute\AsCallback;
 use Contao\CoreBundle\Framework\ContaoFramework;
-use Contao\CoreBundle\ServiceAnnotation\Callback;
 use Contao\DataContainer;
 use Contao\Search;
 use Doctrine\DBAL\Connection;
@@ -27,9 +27,7 @@ class PageSearchListener
     {
     }
 
-    /**
-     * @Callback(table="tl_page", target="fields.alias.save")
-     */
+    #[AsCallback(table: "tl_page", target: "fields.alias.save")]
     public function onSaveAlias(string $value, DataContainer $dc): string
     {
         if ($value === ($dc->getCurrentRecord()['alias'] ?? null)) {
@@ -41,9 +39,7 @@ class PageSearchListener
         return $value;
     }
 
-    /**
-     * @Callback(table="tl_page", target="fields.noSearch.save")
-     */
+    #[AsCallback(table: "tl_page", target: "fields.noSearch.save")]
     public function onSaveNoSearch(string $value, DataContainer $dc): string
     {
         if (!$value || (bool) $value === (bool) ($dc->getCurrentRecord()['noSearch'] ?? false)) {
@@ -55,9 +51,7 @@ class PageSearchListener
         return $value;
     }
 
-    /**
-     * @Callback(table="tl_page", target="fields.robots.save")
-     */
+    #[AsCallback(table: "tl_page", target: "fields.robots.save")]
     public function onSaveRobots(string $value, DataContainer $dc): string
     {
         if ($value === ($dc->getCurrentRecord()['robots'] ?? null) || !str_starts_with($value, 'noindex')) {
@@ -69,9 +63,7 @@ class PageSearchListener
         return $value;
     }
 
-    /**
-     * @Callback(table="tl_page", target="config.ondelete", priority=16)
-     */
+    #[AsCallback(table: "tl_page", target: "config.ondelete", priority: 16)]
     public function onDelete(DataContainer $dc): void
     {
         if (!$dc->id) {

--- a/core-bundle/src/EventListener/DataContainer/PageSearchListener.php
+++ b/core-bundle/src/EventListener/DataContainer/PageSearchListener.php
@@ -27,7 +27,7 @@ class PageSearchListener
     {
     }
 
-    #[AsCallback(table: "tl_page", target: "fields.alias.save")]
+    #[AsCallback(table: 'tl_page', target: 'fields.alias.save')]
     public function onSaveAlias(string $value, DataContainer $dc): string
     {
         if ($value === ($dc->getCurrentRecord()['alias'] ?? null)) {
@@ -39,7 +39,7 @@ class PageSearchListener
         return $value;
     }
 
-    #[AsCallback(table: "tl_page", target: "fields.noSearch.save")]
+    #[AsCallback(table: 'tl_page', target: 'fields.noSearch.save')]
     public function onSaveNoSearch(string $value, DataContainer $dc): string
     {
         if (!$value || (bool) $value === (bool) ($dc->getCurrentRecord()['noSearch'] ?? false)) {
@@ -51,7 +51,7 @@ class PageSearchListener
         return $value;
     }
 
-    #[AsCallback(table: "tl_page", target: "fields.robots.save")]
+    #[AsCallback(table: 'tl_page', target: 'fields.robots.save')]
     public function onSaveRobots(string $value, DataContainer $dc): string
     {
         if ($value === ($dc->getCurrentRecord()['robots'] ?? null) || !str_starts_with($value, 'noindex')) {
@@ -63,7 +63,7 @@ class PageSearchListener
         return $value;
     }
 
-    #[AsCallback(table: "tl_page", target: "config.ondelete", priority: 16)]
+    #[AsCallback(table: 'tl_page', target: 'config.ondelete', priority: 16)]
     public function onDelete(DataContainer $dc): void
     {
         if (!$dc->id) {

--- a/core-bundle/src/EventListener/DataContainer/PageTypeOptionsListener.php
+++ b/core-bundle/src/EventListener/DataContainer/PageTypeOptionsListener.php
@@ -20,9 +20,9 @@ use Contao\DataContainer;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Security\Core\Security;
 
-#[AsCallback(table: "tl_page", target: "fields.type.options")]
-#[AsCallback(table: "tl_user", target: "fields.alpty.options")]
-#[AsCallback(table: "tl_user_group", target: "fields.alpty.options")]
+#[AsCallback(table: 'tl_page', target: 'fields.type.options')]
+#[AsCallback(table: 'tl_user', target: 'fields.alpty.options')]
+#[AsCallback(table: 'tl_user_group', target: 'fields.alpty.options')]
 class PageTypeOptionsListener
 {
     public function __construct(private PageRegistry $pageRegistry, private Security $security, private EventDispatcherInterface|null $eventDispatcher = null)

--- a/core-bundle/src/EventListener/DataContainer/PageTypeOptionsListener.php
+++ b/core-bundle/src/EventListener/DataContainer/PageTypeOptionsListener.php
@@ -12,19 +12,17 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\EventListener\DataContainer;
 
+use Contao\CoreBundle\DependencyInjection\Attribute\AsCallback;
 use Contao\CoreBundle\Event\FilterPageTypeEvent;
 use Contao\CoreBundle\Routing\Page\PageRegistry;
 use Contao\CoreBundle\Security\ContaoCorePermissions;
-use Contao\CoreBundle\ServiceAnnotation\Callback;
 use Contao\DataContainer;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Security\Core\Security;
 
-/**
- * @Callback(table="tl_page", target="fields.type.options")
- * @Callback(table="tl_user", target="fields.alpty.options")
- * @Callback(table="tl_user_group", target="fields.alpty.options")
- */
+#[AsCallback(table: "tl_page", target: "fields.type.options")]
+#[AsCallback(table: "tl_user", target: "fields.alpty.options")]
+#[AsCallback(table: "tl_user_group", target: "fields.alpty.options")]
 class PageTypeOptionsListener
 {
     public function __construct(private PageRegistry $pageRegistry, private Security $security, private EventDispatcherInterface|null $eventDispatcher = null)

--- a/core-bundle/src/EventListener/DataContainer/PageUrlListener.php
+++ b/core-bundle/src/EventListener/DataContainer/PageUrlListener.php
@@ -46,7 +46,7 @@ class PageUrlListener
     ) {
     }
 
-    #[AsCallback(table: "tl_page", target: "fields.alias.save")]
+    #[AsCallback(table: 'tl_page', target: 'fields.alias.save')]
     public function generateAlias(string $value, DataContainer $dc): string
     {
         $pageAdapter = $this->framework->getAdapter(PageModel::class);
@@ -96,7 +96,7 @@ class PageUrlListener
         return $value;
     }
 
-    #[AsCallback(table: "tl_page", target: "fields.urlPrefix.save")]
+    #[AsCallback(table: 'tl_page', target: 'fields.urlPrefix.save')]
     public function validateUrlPrefix(string $value, DataContainer $dc): string
     {
         $currentRecord = $dc->getCurrentRecord();
@@ -137,7 +137,7 @@ class PageUrlListener
         return $value;
     }
 
-    #[AsCallback(table: "tl_page", target: "fields.urlSuffix.save")]
+    #[AsCallback(table: 'tl_page', target: 'fields.urlSuffix.save')]
     public function validateUrlSuffix(mixed $value, DataContainer $dc): mixed
     {
         $currentRecord = $dc->getCurrentRecord();

--- a/core-bundle/src/EventListener/DataContainer/PageUrlListener.php
+++ b/core-bundle/src/EventListener/DataContainer/PageUrlListener.php
@@ -12,11 +12,11 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\EventListener\DataContainer;
 
+use Contao\CoreBundle\DependencyInjection\Attribute\AsCallback;
 use Contao\CoreBundle\Exception\DuplicateAliasException;
 use Contao\CoreBundle\Exception\RouteParametersException;
 use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\CoreBundle\Routing\Page\PageRegistry;
-use Contao\CoreBundle\ServiceAnnotation\Callback;
 use Contao\CoreBundle\Slug\Slug;
 use Contao\DataContainer;
 use Contao\Input;
@@ -46,9 +46,7 @@ class PageUrlListener
     ) {
     }
 
-    /**
-     * @Callback(table="tl_page", target="fields.alias.save")
-     */
+    #[AsCallback(table: "tl_page", target: "fields.alias.save")]
     public function generateAlias(string $value, DataContainer $dc): string
     {
         $pageAdapter = $this->framework->getAdapter(PageModel::class);
@@ -98,9 +96,7 @@ class PageUrlListener
         return $value;
     }
 
-    /**
-     * @Callback(table="tl_page", target="fields.urlPrefix.save")
-     */
+    #[AsCallback(table: "tl_page", target: "fields.urlPrefix.save")]
     public function validateUrlPrefix(string $value, DataContainer $dc): string
     {
         $currentRecord = $dc->getCurrentRecord();
@@ -141,9 +137,7 @@ class PageUrlListener
         return $value;
     }
 
-    /**
-     * @Callback(table="tl_page", target="fields.urlSuffix.save")
-     */
+    #[AsCallback(table: "tl_page", target: "fields.urlSuffix.save")]
     public function validateUrlSuffix(mixed $value, DataContainer $dc): mixed
     {
         $currentRecord = $dc->getCurrentRecord();

--- a/core-bundle/src/EventListener/DataContainer/PageUseSslDefaultListener.php
+++ b/core-bundle/src/EventListener/DataContainer/PageUseSslDefaultListener.php
@@ -16,7 +16,7 @@ use Contao\CoreBundle\DependencyInjection\Attribute\AsCallback;
 use Contao\DataContainer;
 use Symfony\Component\HttpFoundation\RequestStack;
 
-#[AsCallback(table: "tl_page", target: "config.onload")]
+#[AsCallback(table: 'tl_page', target: 'config.onload')]
 class PageUseSslDefaultListener
 {
     public function __construct(private RequestStack $requestStack)

--- a/core-bundle/src/EventListener/DataContainer/PageUseSslDefaultListener.php
+++ b/core-bundle/src/EventListener/DataContainer/PageUseSslDefaultListener.php
@@ -12,13 +12,11 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\EventListener\DataContainer;
 
-use Contao\CoreBundle\ServiceAnnotation\Callback;
+use Contao\CoreBundle\DependencyInjection\Attribute\AsCallback;
 use Contao\DataContainer;
 use Symfony\Component\HttpFoundation\RequestStack;
 
-/**
- * @Callback(table="tl_page", target="config.onload")
- */
+#[AsCallback(table: "tl_page", target: "config.onload")]
 class PageUseSslDefaultListener
 {
     public function __construct(private RequestStack $requestStack)

--- a/core-bundle/src/EventListener/DataContainer/PreviewLinkListener.php
+++ b/core-bundle/src/EventListener/DataContainer/PreviewLinkListener.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\EventListener\DataContainer;
 
 use Contao\BackendUser;
+use Contao\CoreBundle\DependencyInjection\Attribute\AsCallback;
+use Contao\CoreBundle\DependencyInjection\Attribute\AsHook;
 use Contao\CoreBundle\Exception\AccessDeniedException;
 use Contao\CoreBundle\Framework\ContaoFramework;
-use Contao\CoreBundle\ServiceAnnotation\Callback;
-use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\DataContainer;
 use Contao\Image;
 use Contao\Input;
@@ -46,9 +46,7 @@ class PreviewLinkListener
     ) {
     }
 
-    /**
-     * @Hook("initializeSystem")
-     */
+    #[AsHook("initializeSystem")]
     public function unloadModuleWithoutPreviewScript(): void
     {
         if (empty($this->previewScript)) {
@@ -56,9 +54,7 @@ class PreviewLinkListener
         }
     }
 
-    /**
-     * @Hook("loadDataContainer")
-     */
+    #[AsHook("loadDataContainer")]
     public function unloadTableWithoutPreviewScript(string $table): void
     {
         if ('tl_preview_link' === $table && empty($this->previewScript)) {
@@ -68,9 +64,8 @@ class PreviewLinkListener
 
     /**
      * Only allow to create new records if a front end preview URL is given.
-     *
-     * @Callback(table="tl_preview_link", target="config.onload")
      */
+    #[AsCallback(table: "tl_preview_link", target: "config.onload")]
     public function createFromUrl(DataContainer $dc): void
     {
         $input = $this->framework->getAdapter(Input::class);
@@ -132,9 +127,8 @@ class PreviewLinkListener
 
     /**
      * Adds a hint and modifies the edit view buttons.
-     *
-     * @Callback(table="tl_preview_link", target="config.onload")
      */
+    #[AsCallback(table: "tl_preview_link", target: "config.onload")]
     public function adjustEditView(DataContainer $dc): void
     {
         $input = $this->framework->getAdapter(Input::class);
@@ -167,9 +161,8 @@ class PreviewLinkListener
 
     /**
      * Updates tl_preview_link.expiresAt based on expiresInDays selection.
-     *
-     * @Callback(table="tl_preview_link", target="config.onsubmit")
      */
+    #[AsCallback(table: "tl_preview_link", target: "config.onsubmit")]
     public function updateExpiresAt(DataContainer $dc): void
     {
         $this->connection->executeStatement(
@@ -178,9 +171,7 @@ class PreviewLinkListener
         );
     }
 
-    /**
-     * @Callback(table="tl_preview_link", target="list.label.label")
-     */
+    #[AsCallback(table: "tl_preview_link", target: "list.label.label")]
     public function formatColumnView(array $row, string $label, DataContainer $dc, array $args): array
     {
         if ($row['expiresAt'] < time()) {
@@ -194,9 +185,7 @@ class PreviewLinkListener
         return $args;
     }
 
-    /**
-     * @Callback(table="tl_preview_link", target="list.operations.share.button")
-     */
+    #[AsCallback(table: "tl_preview_link", target: "list.operations.share.button")]
     public function shareOperation(array $row, string|null $href, string|null $label, string|null $title, string $icon): string
     {
         if ($row['expiresAt'] < time()) {

--- a/core-bundle/src/EventListener/DataContainer/PreviewLinkListener.php
+++ b/core-bundle/src/EventListener/DataContainer/PreviewLinkListener.php
@@ -46,7 +46,7 @@ class PreviewLinkListener
     ) {
     }
 
-    #[AsHook("initializeSystem")]
+    #[AsHook('initializeSystem')]
     public function unloadModuleWithoutPreviewScript(): void
     {
         if (empty($this->previewScript)) {
@@ -54,7 +54,7 @@ class PreviewLinkListener
         }
     }
 
-    #[AsHook("loadDataContainer")]
+    #[AsHook('loadDataContainer')]
     public function unloadTableWithoutPreviewScript(string $table): void
     {
         if ('tl_preview_link' === $table && empty($this->previewScript)) {
@@ -65,7 +65,7 @@ class PreviewLinkListener
     /**
      * Only allow to create new records if a front end preview URL is given.
      */
-    #[AsCallback(table: "tl_preview_link", target: "config.onload")]
+    #[AsCallback(table: 'tl_preview_link', target: 'config.onload')]
     public function createFromUrl(DataContainer $dc): void
     {
         $input = $this->framework->getAdapter(Input::class);
@@ -128,7 +128,7 @@ class PreviewLinkListener
     /**
      * Adds a hint and modifies the edit view buttons.
      */
-    #[AsCallback(table: "tl_preview_link", target: "config.onload")]
+    #[AsCallback(table: 'tl_preview_link', target: 'config.onload')]
     public function adjustEditView(DataContainer $dc): void
     {
         $input = $this->framework->getAdapter(Input::class);
@@ -162,7 +162,7 @@ class PreviewLinkListener
     /**
      * Updates tl_preview_link.expiresAt based on expiresInDays selection.
      */
-    #[AsCallback(table: "tl_preview_link", target: "config.onsubmit")]
+    #[AsCallback(table: 'tl_preview_link', target: 'config.onsubmit')]
     public function updateExpiresAt(DataContainer $dc): void
     {
         $this->connection->executeStatement(
@@ -171,7 +171,7 @@ class PreviewLinkListener
         );
     }
 
-    #[AsCallback(table: "tl_preview_link", target: "list.label.label")]
+    #[AsCallback(table: 'tl_preview_link', target: 'list.label.label')]
     public function formatColumnView(array $row, string $label, DataContainer $dc, array $args): array
     {
         if ($row['expiresAt'] < time()) {
@@ -185,7 +185,7 @@ class PreviewLinkListener
         return $args;
     }
 
-    #[AsCallback(table: "tl_preview_link", target: "list.operations.share.button")]
+    #[AsCallback(table: 'tl_preview_link', target: 'list.operations.share.button')]
     public function shareOperation(array $row, string|null $href, string|null $label, string|null $title, string $icon): string
     {
         if ($row['expiresAt'] < time()) {

--- a/core-bundle/src/EventListener/DataContainer/RecordPreviewListener.php
+++ b/core-bundle/src/EventListener/DataContainer/RecordPreviewListener.php
@@ -28,7 +28,7 @@ class RecordPreviewListener
     {
     }
 
-    #[AsHook("loadDataContainer")]
+    #[AsHook('loadDataContainer')]
     public function registerDeleteCallbacks(string $table): void
     {
         if ($GLOBALS['TL_DCA'][$table]['config']['notDeletable'] ?? false) {

--- a/core-bundle/src/EventListener/DataContainer/RecordPreviewListener.php
+++ b/core-bundle/src/EventListener/DataContainer/RecordPreviewListener.php
@@ -12,8 +12,8 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\EventListener\DataContainer;
 
+use Contao\CoreBundle\DependencyInjection\Attribute\AsHook;
 use Contao\CoreBundle\Framework\ContaoFramework;
-use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\DataContainer;
 use Contao\DC_Table;
 use Contao\System;
@@ -28,9 +28,7 @@ class RecordPreviewListener
     {
     }
 
-    /**
-     * @Hook("loadDataContainer")
-     */
+    #[AsHook("loadDataContainer")]
     public function registerDeleteCallbacks(string $table): void
     {
         if ($GLOBALS['TL_DCA'][$table]['config']['notDeletable'] ?? false) {

--- a/core-bundle/src/EventListener/DataContainer/ResetCustomTemplateListener.php
+++ b/core-bundle/src/EventListener/DataContainer/ResetCustomTemplateListener.php
@@ -12,16 +12,15 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\EventListener\DataContainer;
 
-use Contao\CoreBundle\ServiceAnnotation\Callback;
+use Contao\CoreBundle\DependencyInjection\Attribute\AsCallback;
 use Contao\DataContainer;
 use Doctrine\DBAL\Connection;
 
 /**
  * @internal
- *
- * @Callback(table="tl_content", target="fields.type.save")
- * @Callback(table="tl_module", target="fields.type.save")
  */
+#[AsCallback(table: "tl_content", target: "fields.type.save")]
+#[AsCallback(table: "tl_module", target: "fields.type.save")]
 class ResetCustomTemplateListener
 {
     public function __construct(private Connection $connection)

--- a/core-bundle/src/EventListener/DataContainer/ResetCustomTemplateListener.php
+++ b/core-bundle/src/EventListener/DataContainer/ResetCustomTemplateListener.php
@@ -19,8 +19,8 @@ use Doctrine\DBAL\Connection;
 /**
  * @internal
  */
-#[AsCallback(table: "tl_content", target: "fields.type.save")]
-#[AsCallback(table: "tl_module", target: "fields.type.save")]
+#[AsCallback(table: 'tl_content', target: 'fields.type.save')]
+#[AsCallback(table: 'tl_module', target: 'fields.type.save')]
 class ResetCustomTemplateListener
 {
     public function __construct(private Connection $connection)

--- a/core-bundle/src/EventListener/DataContainer/TemplateOptionsListener.php
+++ b/core-bundle/src/EventListener/DataContainer/TemplateOptionsListener.php
@@ -19,8 +19,8 @@ use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\DataContainer;
 use Symfony\Component\HttpFoundation\RequestStack;
 
-#[AsCallback(table: "tl_content", target: "fields.customTpl.options")]
-#[AsCallback(table: "tl_module", target: "fields.customTpl.options")]
+#[AsCallback(table: 'tl_content', target: 'fields.customTpl.options')]
+#[AsCallback(table: 'tl_module', target: 'fields.customTpl.options')]
 class TemplateOptionsListener
 {
     private array $customTemplates = [];

--- a/core-bundle/src/EventListener/DataContainer/TemplateOptionsListener.php
+++ b/core-bundle/src/EventListener/DataContainer/TemplateOptionsListener.php
@@ -13,16 +13,14 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\EventListener\DataContainer;
 
 use Contao\Controller;
+use Contao\CoreBundle\DependencyInjection\Attribute\AsCallback;
 use Contao\CoreBundle\Framework\Adapter;
 use Contao\CoreBundle\Framework\ContaoFramework;
-use Contao\CoreBundle\ServiceAnnotation\Callback;
 use Contao\DataContainer;
 use Symfony\Component\HttpFoundation\RequestStack;
 
-/**
- * @Callback(table="tl_content", target="fields.customTpl.options")
- * @Callback(table="tl_module", target="fields.customTpl.options")
- */
+#[AsCallback(table: "tl_content", target: "fields.customTpl.options")]
+#[AsCallback(table: "tl_module", target: "fields.customTpl.options")]
 class TemplateOptionsListener
 {
     private array $customTemplates = [];

--- a/core-bundle/src/EventListener/DataContainer/ThemeTemplatesListener.php
+++ b/core-bundle/src/EventListener/DataContainer/ThemeTemplatesListener.php
@@ -18,7 +18,7 @@ use Contao\CoreBundle\Twig\Loader\ContaoFilesystemLoaderWarmer;
 use Contao\CoreBundle\Twig\Loader\ThemeNamespace;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-#[AsCallback(table: "tl_theme", target: "fields.templates.save")]
+#[AsCallback(table: 'tl_theme', target: 'fields.templates.save')]
 class ThemeTemplatesListener
 {
     public function __construct(

--- a/core-bundle/src/EventListener/DataContainer/ThemeTemplatesListener.php
+++ b/core-bundle/src/EventListener/DataContainer/ThemeTemplatesListener.php
@@ -12,15 +12,13 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\EventListener\DataContainer;
 
+use Contao\CoreBundle\DependencyInjection\Attribute\AsCallback;
 use Contao\CoreBundle\Exception\InvalidThemePathException;
-use Contao\CoreBundle\ServiceAnnotation\Callback;
 use Contao\CoreBundle\Twig\Loader\ContaoFilesystemLoaderWarmer;
 use Contao\CoreBundle\Twig\Loader\ThemeNamespace;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-/**
- * @Callback(table="tl_theme", target="fields.templates.save")
- */
+#[AsCallback(table: "tl_theme", target: "fields.templates.save")]
 class ThemeTemplatesListener
 {
     public function __construct(

--- a/core-bundle/src/EventListener/DataContainer/Undo/JumpToParentButtonListener.php
+++ b/core-bundle/src/EventListener/DataContainer/Undo/JumpToParentButtonListener.php
@@ -25,7 +25,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * @internal
  */
-#[AsCallback(table: "tl_undo", target: "list.operations.jumpToParent.button")]
+#[AsCallback(table: 'tl_undo', target: 'list.operations.jumpToParent.button')]
 class JumpToParentButtonListener
 {
     public function __construct(private ContaoFramework $framework, private Connection $connection, private TranslatorInterface $translator)

--- a/core-bundle/src/EventListener/DataContainer/Undo/JumpToParentButtonListener.php
+++ b/core-bundle/src/EventListener/DataContainer/Undo/JumpToParentButtonListener.php
@@ -14,8 +14,8 @@ namespace Contao\CoreBundle\EventListener\DataContainer\Undo;
 
 use Contao\Backend;
 use Contao\Controller;
+use Contao\CoreBundle\DependencyInjection\Attribute\AsCallback;
 use Contao\CoreBundle\Framework\ContaoFramework;
-use Contao\CoreBundle\ServiceAnnotation\Callback;
 use Contao\DataContainer;
 use Contao\Image;
 use Contao\StringUtil;
@@ -23,10 +23,9 @@ use Doctrine\DBAL\Connection;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
- * @Callback(target="list.operations.jumpToParent.button", table="tl_undo")
- *
  * @internal
  */
+#[AsCallback(table: "tl_undo", target: "list.operations.jumpToParent.button")]
 class JumpToParentButtonListener
 {
     public function __construct(private ContaoFramework $framework, private Connection $connection, private TranslatorInterface $translator)

--- a/core-bundle/src/EventListener/DataContainer/Undo/LabelListener.php
+++ b/core-bundle/src/EventListener/DataContainer/Undo/LabelListener.php
@@ -24,7 +24,7 @@ use Twig\Environment;
 /**
  * @internal
  */
-#[AsCallback(table: "tl_undo", target: "list.label.label")]
+#[AsCallback(table: 'tl_undo', target: 'list.label.label')]
 class LabelListener
 {
     public function __construct(private ContaoFramework $framework, private Environment $twig)

--- a/core-bundle/src/EventListener/DataContainer/Undo/LabelListener.php
+++ b/core-bundle/src/EventListener/DataContainer/Undo/LabelListener.php
@@ -14,18 +14,17 @@ namespace Contao\CoreBundle\EventListener\DataContainer\Undo;
 
 use Contao\Config;
 use Contao\Controller;
+use Contao\CoreBundle\DependencyInjection\Attribute\AsCallback;
 use Contao\CoreBundle\Framework\ContaoFramework;
-use Contao\CoreBundle\ServiceAnnotation\Callback;
 use Contao\DataContainer;
 use Contao\StringUtil;
 use Contao\UserModel;
 use Twig\Environment;
 
 /**
- * @Callback(target="list.label.label", table="tl_undo")
- *
  * @internal
  */
+#[AsCallback(table: "tl_undo", target: "list.label.label")]
 class LabelListener
 {
     public function __construct(private ContaoFramework $framework, private Environment $twig)

--- a/core-bundle/src/EventListener/DataContainer/ValidateCustomRgxpListener.php
+++ b/core-bundle/src/EventListener/DataContainer/ValidateCustomRgxpListener.php
@@ -12,12 +12,10 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\EventListener\DataContainer;
 
-use Contao\CoreBundle\ServiceAnnotation\Callback;
+use Contao\CoreBundle\DependencyInjection\Attribute\AsCallback;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-/**
- * @Callback(table="tl_form_field", target="fields.customRgxp.save")
- */
+#[AsCallback(table: "tl_form_field", target: "fields.customRgxp.save")]
 class ValidateCustomRgxpListener
 {
     public function __construct(private TranslatorInterface $translator)

--- a/core-bundle/src/EventListener/DataContainer/ValidateCustomRgxpListener.php
+++ b/core-bundle/src/EventListener/DataContainer/ValidateCustomRgxpListener.php
@@ -15,7 +15,7 @@ namespace Contao\CoreBundle\EventListener\DataContainer;
 use Contao\CoreBundle\DependencyInjection\Attribute\AsCallback;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-#[AsCallback(table: "tl_form_field", target: "fields.customRgxp.save")]
+#[AsCallback(table: 'tl_form_field', target: 'fields.customRgxp.save')]
 class ValidateCustomRgxpListener
 {
     public function __construct(private TranslatorInterface $translator)

--- a/core-bundle/src/EventListener/ImageSizeOptionsListener.php
+++ b/core-bundle/src/EventListener/ImageSizeOptionsListener.php
@@ -17,9 +17,9 @@ use Contao\CoreBundle\DependencyInjection\Attribute\AsCallback;
 use Contao\CoreBundle\Image\ImageSizes;
 use Symfony\Component\Security\Core\Security;
 
-#[AsCallback(table: "tl_layout", target: "fields.lightboxSize.options")]
-#[AsCallback(table: "tl_content", target: "fields.size.options")]
-#[AsCallback(table: "tl_module", target: "fields.imgSize.options")]
+#[AsCallback(table: 'tl_layout', target: 'fields.lightboxSize.options')]
+#[AsCallback(table: 'tl_content', target: 'fields.size.options')]
+#[AsCallback(table: 'tl_module', target: 'fields.imgSize.options')]
 class ImageSizeOptionsListener
 {
     public function __construct(private Security $security, private ImageSizes $imageSizes)

--- a/core-bundle/src/EventListener/ImageSizeOptionsListener.php
+++ b/core-bundle/src/EventListener/ImageSizeOptionsListener.php
@@ -13,15 +13,13 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\EventListener;
 
 use Contao\BackendUser;
+use Contao\CoreBundle\DependencyInjection\Attribute\AsCallback;
 use Contao\CoreBundle\Image\ImageSizes;
-use Contao\CoreBundle\ServiceAnnotation\Callback;
 use Symfony\Component\Security\Core\Security;
 
-/**
- * @Callback(table="tl_layout", target="fields.lightboxSize.options")
- * @Callback(table="tl_content", target="fields.size.options")
- * @Callback(table="tl_module", target="fields.imgSize.options")
- */
+#[AsCallback(table: "tl_layout", target: "fields.lightboxSize.options")]
+#[AsCallback(table: "tl_content", target: "fields.size.options")]
+#[AsCallback(table: "tl_module", target: "fields.imgSize.options")]
 class ImageSizeOptionsListener
 {
     public function __construct(private Security $security, private ImageSizes $imageSizes)

--- a/core-bundle/src/EventListener/InsertTags/DateListener.php
+++ b/core-bundle/src/EventListener/InsertTags/DateListener.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\EventListener\InsertTags;
 
 use Contao\Config;
+use Contao\CoreBundle\DependencyInjection\Attribute\AsHook;
 use Contao\CoreBundle\Framework\ContaoFramework;
-use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\Date;
 use Contao\PageModel;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -55,9 +55,8 @@ use Symfony\Component\HttpFoundation\RequestStack;
  *     Tuesday, 26. May 2020, 12:30:35
  *
  * @internal
- *
- * @Hook("replaceInsertTags")
  */
+#[AsHook("replaceInsertTags")]
 class DateListener
 {
     public function __construct(private ContaoFramework $framework, private RequestStack $requestStack)

--- a/core-bundle/src/EventListener/InsertTags/DateListener.php
+++ b/core-bundle/src/EventListener/InsertTags/DateListener.php
@@ -56,7 +56,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
  *
  * @internal
  */
-#[AsHook("replaceInsertTags")]
+#[AsHook('replaceInsertTags')]
 class DateListener
 {
     public function __construct(private ContaoFramework $framework, private RequestStack $requestStack)

--- a/core-bundle/src/EventListener/Widget/CustomRgxpListener.php
+++ b/core-bundle/src/EventListener/Widget/CustomRgxpListener.php
@@ -16,7 +16,7 @@ use Contao\CoreBundle\DependencyInjection\Attribute\AsHook;
 use Contao\Widget;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-#[AsHook("addCustomRegexp")]
+#[AsHook('addCustomRegexp')]
 class CustomRgxpListener
 {
     final public const RGXP_NAME = 'custom';

--- a/core-bundle/src/EventListener/Widget/CustomRgxpListener.php
+++ b/core-bundle/src/EventListener/Widget/CustomRgxpListener.php
@@ -12,13 +12,11 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\EventListener\Widget;
 
-use Contao\CoreBundle\ServiceAnnotation\Hook;
+use Contao\CoreBundle\DependencyInjection\Attribute\AsHook;
 use Contao\Widget;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-/**
- * @Hook("addCustomRegexp")
- */
+#[AsHook("addCustomRegexp")]
 class CustomRgxpListener
 {
     final public const RGXP_NAME = 'custom';

--- a/core-bundle/src/EventListener/Widget/HttpUrlListener.php
+++ b/core-bundle/src/EventListener/Widget/HttpUrlListener.php
@@ -17,7 +17,7 @@ use Contao\Validator;
 use Contao\Widget;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-#[AsHook("addCustomRegexp")]
+#[AsHook('addCustomRegexp')]
 class HttpUrlListener
 {
     final public const RGXP_NAME = 'httpurl';

--- a/core-bundle/src/EventListener/Widget/HttpUrlListener.php
+++ b/core-bundle/src/EventListener/Widget/HttpUrlListener.php
@@ -12,14 +12,12 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\EventListener\Widget;
 
-use Contao\CoreBundle\ServiceAnnotation\Hook;
+use Contao\CoreBundle\DependencyInjection\Attribute\AsHook;
 use Contao\Validator;
 use Contao\Widget;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-/**
- * @Hook("addCustomRegexp")
- */
+#[AsHook("addCustomRegexp")]
 class HttpUrlListener
 {
     final public const RGXP_NAME = 'httpurl';

--- a/core-bundle/src/EventListener/Widget/RootPageDependentSelectListener.php
+++ b/core-bundle/src/EventListener/Widget/RootPageDependentSelectListener.php
@@ -34,7 +34,7 @@ class RootPageDependentSelectListener
     ) {
     }
 
-    #[AsCallback(table: "tl_module", target: "fields.rootPageDependentModules.options")]
+    #[AsCallback(table: 'tl_module', target: 'fields.rootPageDependentModules.options')]
     public function optionsCallback(DataContainer $dc): array
     {
         $options = [];
@@ -65,7 +65,7 @@ class RootPageDependentSelectListener
         return $options;
     }
 
-    #[AsCallback(table: "tl_module", target: "fields.rootPageDependentModules.save")]
+    #[AsCallback(table: 'tl_module', target: 'fields.rootPageDependentModules.save')]
     public function saveCallback(mixed $value, DataContainer $dataContainer): string
     {
         $values = StringUtil::deserialize($value);
@@ -84,7 +84,7 @@ class RootPageDependentSelectListener
         return serialize($newValues);
     }
 
-    #[AsCallback(table: "tl_module", target: "fields.rootPageDependentModules.wizard")]
+    #[AsCallback(table: 'tl_module', target: 'fields.rootPageDependentModules.wizard')]
     public function wizardCallback(DataContainer $dc): string
     {
         $wizards = [];

--- a/core-bundle/src/EventListener/Widget/RootPageDependentSelectListener.php
+++ b/core-bundle/src/EventListener/Widget/RootPageDependentSelectListener.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\EventListener\Widget;
 
 use Contao\CoreBundle\Csrf\ContaoCsrfTokenManager;
-use Contao\CoreBundle\ServiceAnnotation\Callback;
+use Contao\CoreBundle\DependencyInjection\Attribute\AsCallback;
 use Contao\DataContainer;
 use Contao\Image;
 use Contao\StringUtil;
@@ -34,9 +34,7 @@ class RootPageDependentSelectListener
     ) {
     }
 
-    /**
-     * @Callback(table="tl_module", target="fields.rootPageDependentModules.options")
-     */
+    #[AsCallback(table: "tl_module", target: "fields.rootPageDependentModules.options")]
     public function optionsCallback(DataContainer $dc): array
     {
         $options = [];
@@ -67,9 +65,7 @@ class RootPageDependentSelectListener
         return $options;
     }
 
-    /**
-     * @Callback(table="tl_module", target="fields.rootPageDependentModules.save")
-     */
+    #[AsCallback(table: "tl_module", target: "fields.rootPageDependentModules.save")]
     public function saveCallback(mixed $value, DataContainer $dataContainer): string
     {
         $values = StringUtil::deserialize($value);
@@ -88,9 +84,7 @@ class RootPageDependentSelectListener
         return serialize($newValues);
     }
 
-    /**
-     * @Callback(table="tl_module", target="fields.rootPageDependentModules.wizard")
-     */
+    #[AsCallback(table: "tl_module", target: "fields.rootPageDependentModules.wizard")]
     public function wizardCallback(DataContainer $dc): string
     {
         $wizards = [];

--- a/core-bundle/src/Mailer/AvailableTransports.php
+++ b/core-bundle/src/Mailer/AvailableTransports.php
@@ -44,8 +44,8 @@ class AvailableTransports
      *
      * @return array<string, string>
      */
-    #[AsCallback(table: "tl_page", target: "fields.mailerTransport.options")]
-    #[AsCallback(table: "tl_form", target: "fields.mailerTransport.options")]
+    #[AsCallback(table: 'tl_page', target: 'fields.mailerTransport.options')]
+    #[AsCallback(table: 'tl_form', target: 'fields.mailerTransport.options')]
     public function getTransportOptions(): array
     {
         $options = [];

--- a/core-bundle/src/Mailer/AvailableTransports.php
+++ b/core-bundle/src/Mailer/AvailableTransports.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Mailer;
 
-use Contao\CoreBundle\ServiceAnnotation\Callback;
+use Contao\CoreBundle\DependencyInjection\Attribute\AsCallback;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class AvailableTransports
@@ -43,10 +43,9 @@ class AvailableTransports
      * Returns the available transports as options suitable for widgets.
      *
      * @return array<string, string>
-     *
-     * @Callback(table="tl_page", target="fields.mailerTransport.options")
-     * @Callback(table="tl_form", target="fields.mailerTransport.options")
      */
+    #[AsCallback(table: "tl_page", target: "fields.mailerTransport.options")]
+    #[AsCallback(table: "tl_form", target: "fields.mailerTransport.options")]
     public function getTransportOptions(): array
     {
         $options = [];

--- a/core-bundle/tests/EventListener/DataContainer/DisableAppConfiguredSettingsListenerTest.php
+++ b/core-bundle/tests/EventListener/DataContainer/DisableAppConfiguredSettingsListenerTest.php
@@ -13,10 +13,8 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Tests\EventListener\DataContainer;
 
 use Contao\CoreBundle\EventListener\DataContainer\DisableAppConfiguredSettingsListener;
-use Contao\CoreBundle\ServiceAnnotation\Callback;
 use Contao\CoreBundle\Tests\TestCase;
 use Contao\Image;
-use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\Annotations\AnnotationRegistry;
 use Doctrine\Common\Annotations\DocParser;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -30,18 +28,6 @@ class DisableAppConfiguredSettingsListenerTest extends TestCase
         $this->resetStaticProperties([[AnnotationRegistry::class, ['failedToAutoload']], DocParser::class]);
 
         parent::tearDown();
-    }
-
-    public function testAnnotatedCallbacks(): void
-    {
-        $listener = $this->createListener();
-        $annotationReader = new AnnotationReader();
-
-        /** @var Callback $annotation */
-        $annotation = $annotationReader->getClassAnnotation(new \ReflectionClass($listener), Callback::class);
-
-        $this->assertSame('tl_settings', $annotation->table);
-        $this->assertSame('config.onload', $annotation->target);
     }
 
     public function testLoadCallbackExitsOnMissingLocalconfigParameter(): void

--- a/core-bundle/tests/EventListener/DataContainer/ValidateCustomRgxpListenerTest.php
+++ b/core-bundle/tests/EventListener/DataContainer/ValidateCustomRgxpListenerTest.php
@@ -13,9 +13,7 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Tests\EventListener\DataContainer;
 
 use Contao\CoreBundle\EventListener\DataContainer\ValidateCustomRgxpListener;
-use Contao\CoreBundle\ServiceAnnotation\Callback;
 use Contao\CoreBundle\Tests\TestCase;
-use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\Annotations\AnnotationRegistry;
 use Doctrine\Common\Annotations\DocParser;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -27,25 +25,6 @@ class ValidateCustomRgxpListenerTest extends TestCase
         $this->resetStaticProperties([[AnnotationRegistry::class, ['failedToAutoload']], DocParser::class]);
 
         parent::tearDown();
-    }
-
-    public function testServiceAnnotation(): void
-    {
-        $translator = $this->createMock(TranslatorInterface::class);
-        $translator
-            ->expects($this->never())
-            ->method('trans')
-            ->willReturnArgument(0)
-        ;
-
-        $listener = new ValidateCustomRgxpListener($translator);
-
-        $annotationReader = new AnnotationReader();
-        $annotation = $annotationReader->getClassAnnotation(new \ReflectionClass($listener), Callback::class);
-
-        $this->assertSame('tl_form_field', $annotation->table);
-        $this->assertSame('fields.customRgxp.save', $annotation->target);
-        $this->assertSame(0, (int) $annotation->priority);
     }
 
     public function testThrowsExceptionIfInvalidRegex(): void

--- a/core-bundle/tests/EventListener/InsertTags/DateListenerTest.php
+++ b/core-bundle/tests/EventListener/InsertTags/DateListenerTest.php
@@ -15,11 +15,9 @@ namespace Contao\CoreBundle\Tests\EventListener\InsertTags;
 use Contao\Config;
 use Contao\CoreBundle\EventListener\InsertTags\DateListener;
 use Contao\CoreBundle\Framework\ContaoFramework;
-use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\CoreBundle\Tests\TestCase;
 use Contao\Date;
 use Contao\PageModel;
-use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\Annotations\AnnotationRegistry;
 use Doctrine\Common\Annotations\DocParser;
 use Symfony\Component\HttpFoundation\Request;
@@ -32,17 +30,6 @@ class DateListenerTest extends TestCase
         $this->resetStaticProperties([[AnnotationRegistry::class, ['failedToAutoload']], DocParser::class]);
 
         parent::tearDown();
-    }
-
-    public function testAnnotatedCallbacks(): void
-    {
-        $listener = new DateListener($this->getFramework(), new RequestStack());
-        $annotationReader = new AnnotationReader();
-
-        /** @var Hook $annotation */
-        $annotation = $annotationReader->getClassAnnotation(new \ReflectionClass($listener), Hook::class);
-
-        $this->assertSame('replaceInsertTags', $annotation->value);
     }
 
     /**

--- a/core-bundle/tests/EventListener/Widget/CustomRgxpListenerTest.php
+++ b/core-bundle/tests/EventListener/Widget/CustomRgxpListenerTest.php
@@ -13,10 +13,8 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Tests\EventListener\Widget;
 
 use Contao\CoreBundle\EventListener\Widget\CustomRgxpListener;
-use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\CoreBundle\Tests\TestCase;
 use Contao\Widget;
-use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\Annotations\AnnotationRegistry;
 use Doctrine\Common\Annotations\DocParser;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -28,24 +26,6 @@ class CustomRgxpListenerTest extends TestCase
         $this->resetStaticProperties([[AnnotationRegistry::class, ['failedToAutoload']], DocParser::class]);
 
         parent::tearDown();
-    }
-
-    public function testServiceAnnotation(): void
-    {
-        $translator = $this->createMock(TranslatorInterface::class);
-        $translator
-            ->expects($this->never())
-            ->method('trans')
-            ->willReturnArgument(0)
-        ;
-
-        $listener = new CustomRgxpListener($translator);
-
-        $annotationReader = new AnnotationReader();
-        $annotation = $annotationReader->getClassAnnotation(new \ReflectionClass($listener), Hook::class);
-
-        $this->assertSame('addCustomRegexp', $annotation->value);
-        $this->assertSame(0, (int) $annotation->priority);
     }
 
     public function testReturnsFalseIfNotCustomRgxpType(): void

--- a/core-bundle/tests/EventListener/Widget/HttpUrlListenerTest.php
+++ b/core-bundle/tests/EventListener/Widget/HttpUrlListenerTest.php
@@ -13,10 +13,8 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Tests\EventListener\Widget;
 
 use Contao\CoreBundle\EventListener\Widget\HttpUrlListener;
-use Contao\CoreBundle\ServiceAnnotation\Hook;
 use Contao\CoreBundle\Tests\TestCase;
 use Contao\Widget;
-use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\Annotations\AnnotationRegistry;
 use Doctrine\Common\Annotations\DocParser;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -28,24 +26,6 @@ class HttpUrlListenerTest extends TestCase
         $this->resetStaticProperties([[AnnotationRegistry::class, ['failedToAutoload']], DocParser::class]);
 
         parent::tearDown();
-    }
-
-    public function testServiceAnnotation(): void
-    {
-        $translator = $this->createMock(TranslatorInterface::class);
-        $translator
-            ->expects($this->never())
-            ->method('trans')
-            ->willReturnArgument(0)
-        ;
-
-        $listener = new HttpUrlListener($translator);
-
-        $annotationReader = new AnnotationReader();
-        $annotation = $annotationReader->getClassAnnotation(new \ReflectionClass($listener), Hook::class);
-
-        $this->assertSame('addCustomRegexp', $annotation->value);
-        $this->assertSame(0, (int) $annotation->priority);
     }
 
     public function testReturnsFalseIfNotHttpurlType(): void

--- a/core-bundle/tests/Mailer/AvailableTransportsTest.php
+++ b/core-bundle/tests/Mailer/AvailableTransportsTest.php
@@ -14,9 +14,7 @@ namespace Contao\CoreBundle\Tests\Mailer;
 
 use Contao\CoreBundle\Mailer\AvailableTransports;
 use Contao\CoreBundle\Mailer\TransportConfig;
-use Contao\CoreBundle\ServiceAnnotation\Callback;
 use Contao\CoreBundle\Tests\TestCase;
-use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\Annotations\AnnotationRegistry;
 use Doctrine\Common\Annotations\DocParser;
 
@@ -27,39 +25,6 @@ class AvailableTransportsTest extends TestCase
         $this->resetStaticProperties([[AnnotationRegistry::class, ['failedToAutoload']], DocParser::class]);
 
         parent::tearDown();
-    }
-
-    public function testAnnotatedCallbacks(): void
-    {
-        $service = new AvailableTransports();
-
-        $annotationReader = new AnnotationReader();
-        $annotations = $annotationReader->getMethodAnnotations(new \ReflectionMethod($service, 'getTransportOptions'));
-
-        $this->assertCount(2, $annotations);
-
-        [$pageCallback, $formCallback] = $annotations;
-
-        $this->assertInstanceOf(Callback::class, $pageCallback);
-        $this->assertInstanceOf(Callback::class, $formCallback);
-
-        $this->assertSame(
-            [
-                'table' => 'tl_page',
-                'target' => 'fields.mailerTransport.options',
-                'priority' => null,
-            ],
-            get_object_vars($pageCallback)
-        );
-
-        $this->assertSame(
-            [
-                'table' => 'tl_form',
-                'target' => 'fields.mailerTransport.options',
-                'priority' => null,
-            ],
-            get_object_vars($formCallback)
-        );
     }
 
     public function testAddsTransports(): void

--- a/maker-bundle/skeleton/content-element/ContentElement.tpl.php
+++ b/maker-bundle/skeleton/content-element/ContentElement.tpl.php
@@ -11,7 +11,7 @@ use Contao\Template;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-#[AsContentElement(category: "<?= $category ?>")]
+#[AsContentElement(category: '<?= $category ?>')]
 class <?= $className ?> extends AbstractContentElementController
 {
     protected function getResponse(Template $template, ContentModel $model, Request $request): Response

--- a/maker-bundle/skeleton/dca-callback/Callback.tpl.php
+++ b/maker-bundle/skeleton/dca-callback/Callback.tpl.php
@@ -9,7 +9,7 @@ use Contao\CoreBundle\DependencyInjection\Attribute\AsCallback;
 use <?= $use ?>;
 <?php endforeach; ?>
 
-#[AsCallback(table: "<?= $table ?>", target: "<?= $target ?>")]
+#[AsCallback(table: '<?= $table ?>', target: '<?= $target ?>')]
 class <?= $className."\n" ?>
 {
     <?= $signature."\n" ?>

--- a/maker-bundle/skeleton/event-listener/EventListener.tpl.php
+++ b/maker-bundle/skeleton/event-listener/EventListener.tpl.php
@@ -9,7 +9,7 @@ use <?= $use ?>;
 <?php endforeach; ?>
 use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
 
-#[AsEventListener("<?= $event ?>")]
+#[AsEventListener('<?= $event ?>')]
 class <?= $className."\n" ?>
 {
     <?= $signature."\n" ?>

--- a/maker-bundle/skeleton/frontend-module/FrontendModule.tpl.php
+++ b/maker-bundle/skeleton/frontend-module/FrontendModule.tpl.php
@@ -11,7 +11,7 @@ use Contao\Template;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-#[AsFrontendModule(category: "<?= $category ?>")]
+#[AsFrontendModule(category: '<?= $category ?>')]
 class <?= $className ?> extends AbstractFrontendModuleController
 {
     protected function getResponse(Template $template, ModuleModel $model, Request $request): Response

--- a/maker-bundle/skeleton/hook/Hook.tpl.php
+++ b/maker-bundle/skeleton/hook/Hook.tpl.php
@@ -9,7 +9,7 @@ use Contao\CoreBundle\DependencyInjection\Attribute\AsHook;
 use <?= $use ?>;
 <?php endforeach; ?>
 
-#[AsHook("<?= $hook ?>")]
+#[AsHook('<?= $hook ?>')]
 class <?= $className."\n" ?>
 {
     <?= $signature."\n" ?>

--- a/news-bundle/src/Cron/GenerateFeedsCron.php
+++ b/news-bundle/src/Cron/GenerateFeedsCron.php
@@ -12,13 +12,11 @@ declare(strict_types=1);
 
 namespace Contao\NewsBundle\Cron;
 
+use Contao\CoreBundle\DependencyInjection\Attribute\AsCronJob;
 use Contao\CoreBundle\Framework\ContaoFramework;
-use Contao\CoreBundle\ServiceAnnotation\CronJob;
 use Contao\News;
 
-/**
- * @CronJob("daily")
- */
+#[AsCronJob("daily")]
 class GenerateFeedsCron
 {
     public function __construct(private ContaoFramework $framework)

--- a/news-bundle/src/Cron/GenerateFeedsCron.php
+++ b/news-bundle/src/Cron/GenerateFeedsCron.php
@@ -16,7 +16,7 @@ use Contao\CoreBundle\DependencyInjection\Attribute\AsCronJob;
 use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\News;
 
-#[AsCronJob("daily")]
+#[AsCronJob('daily')]
 class GenerateFeedsCron
 {
     public function __construct(private ContaoFramework $framework)

--- a/newsletter-bundle/src/Cron/PurgeSubscriptionsCron.php
+++ b/newsletter-bundle/src/Cron/PurgeSubscriptionsCron.php
@@ -12,14 +12,12 @@ declare(strict_types=1);
 
 namespace Contao\NewsletterBundle\Cron;
 
+use Contao\CoreBundle\DependencyInjection\Attribute\AsCronJob;
 use Contao\CoreBundle\Framework\ContaoFramework;
-use Contao\CoreBundle\ServiceAnnotation\CronJob;
 use Contao\NewsletterRecipientsModel;
 use Psr\Log\LoggerInterface;
 
-/**
- * @CronJob("daily")
- */
+#[AsCronJob("daily")]
 class PurgeSubscriptionsCron
 {
     public function __construct(private ContaoFramework $framework, private LoggerInterface|null $logger)

--- a/newsletter-bundle/src/Cron/PurgeSubscriptionsCron.php
+++ b/newsletter-bundle/src/Cron/PurgeSubscriptionsCron.php
@@ -17,7 +17,7 @@ use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\NewsletterRecipientsModel;
 use Psr\Log\LoggerInterface;
 
-#[AsCronJob("daily")]
+#[AsCronJob('daily')]
 class PurgeSubscriptionsCron
 {
     public function __construct(private ContaoFramework $framework, private LoggerInterface|null $logger)


### PR DESCRIPTION
The PR does not deprecate or remove using service annotations, so extensions can be compatible with Contao 4 on PHP 7.4. At some point in the future, however, we should deprecate service annotations to be removed in Contao 6.