### PR TITLE
Use Controller::getContentElement() in the alias element

### DIFF
--- a/core-bundle/contao/elements/ContentAlias.php
+++ b/core-bundle/contao/elements/ContentAlias.php
@@ -27,7 +27,10 @@ class ContentAlias extends ContentElement
 			return '';
 		}
 
-		$objElement = ContentModel::findByPk($this->cteAlias);
+		if (!$objElement = ContentModel::findByPk($this->cteAlias))
+		{
+			return '';
+		}
 
 		// Clone the model, so we do not modify the shared model in the registry
 		$objModel = $objElement->cloneOriginal();

--- a/core-bundle/contao/elements/ContentModule.php
+++ b/core-bundle/contao/elements/ContentModule.php
@@ -27,9 +27,7 @@ class ContentModule extends ContentElement
 			return '';
 		}
 
-		$objModule = ModuleModel::findByPk($this->module);
-
-		if ($objModule === null)
+		if (!$objModule = ModuleModel::findByPk($this->module))
 		{
 			return '';
 		}


### PR DESCRIPTION
This PR makes the `ContentAlias` and `ContentModule` classes use `Controller::getContentElement()` and `Controller::getFrontendModule()` as discussed in #2678.
