### PR TITLE
Fix database type error in contao:user:create command

### DIFF
--- a/core-bundle/src/Command/UserCreateCommand.php
+++ b/core-bundle/src/Command/UserCreateCommand.php
@@ -19,6 +19,7 @@ use Contao\CoreBundle\Intl\Locales;
 use Contao\UserGroupModel;
 use Contao\Validator;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Types\Types;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\QuestionHelper;
@@ -272,6 +273,6 @@ class UserCreateCommand extends Command
             $data[$this->connection->quoteIdentifier('groups')] = serialize(array_map('strval', $groups));
         }
 
-        $this->connection->insert('tl_user', $data);
+        $this->connection->insert('tl_user', $data, ['admin' => Types::BOOLEAN, 'pwChange' => Types::BOOLEAN]);
     }
 }


### PR DESCRIPTION
Fixes the following issue:

```
Invalid datetime format: 1366 Incorrect integer value: '' for column `tl_user`.`admin` at row 1
```