### PR TITLE
Fix useSSL default value

### DIFF
--- a/core-bundle/src/EventListener/DataContainer/PageUseSslDefaultListener.php
+++ b/core-bundle/src/EventListener/DataContainer/PageUseSslDefaultListener.php
@@ -29,7 +29,7 @@ class PageUseSslDefaultListener
 
         // Set useSSL to HTTP if the current request does not use HTTPS
         if ($request && !$request->isSecure()) {
-            $GLOBALS['TL_DCA']['tl_page']['fields']['useSSL']['default'] = '';
+            $GLOBALS['TL_DCA']['tl_page']['fields']['useSSL']['default'] = false;
         }
     }
 }


### PR DESCRIPTION
Currently the following error will occur if you try to create a new page in the back end while being logged into the back end via `http://` instead of `https://`:

```
Doctrine\DBAL\Exception\DriverException:
An exception occurred while executing a query: SQLSTATE[22007]: Invalid datetime format: 1366 Incorrect integer value: '' for column `c50`.`tl_page`.`useSSL` at row 1

  at vendor\doctrine\dbal\src\Driver\API\MySQL\ExceptionConverter.php:119
  at Doctrine\DBAL\Driver\API\MySQL\ExceptionConverter->convert(object(Exception), object(Query))
     (vendor\doctrine\dbal\src\Connection.php:1814)
  at Doctrine\DBAL\Connection->handleDriverException(object(Exception), object(Query))
     (vendor\doctrine\dbal\src\Connection.php:1749)
  at Doctrine\DBAL\Connection->convertExceptionDuringQuery(object(Exception), 'INSERT INTO tl_page (`enableCanonical`, `useSSL`, `cuser`, `cgroup`, `chmod`, `pid`, `sorting`, `tstamp`) VALUES (?, ?, ?, ?, ?, ?, ?, ?)', array(1, '', 0, 0, 'a:9:{i:0;s:2:"u1";i:1;s:2:"u2";i:2;s:2:"u3";i:3;s:2:"u4";i:4;s:2:"u5";i:5;s:2:"u6";i:6;s:2:"g4";i:7;s:2:"g5";i:8;s:2:"g6";}', 1, 992, 0), array())
     (vendor\doctrine\dbal\src\Connection.php:1055)
  at Doctrine\DBAL\Connection->executeQuery('INSERT INTO tl_page (`enableCanonical`, `useSSL`, `cuser`, `cgroup`, `chmod`, `pid`, `sorting`, `tstamp`) VALUES (?, ?, ?, ?, ?, ?, ?, ?)', array(1, '', 0, 0, 'a:9:{i:0;s:2:"u1";i:1;s:2:"u2";i:2;s:2:"u3";i:3;s:2:"u4";i:4;s:2:"u5";i:5;s:2:"u6";i:6;s:2:"g4";i:7;s:2:"g5";i:8;s:2:"g6";}', 1, 992, 0), array())
     (vendor\contao\contao\core-bundle\contao\library\Contao\Database\Statement.php:268)
  at Contao\Database\Statement->query('', array(1, '', 0, 0, 'a:9:{i:0;s:2:"u1";i:1;s:2:"u2";i:2;s:2:"u3";i:3;s:2:"u4";i:4;s:2:"u5";i:5;s:2:"u6";i:6;s:2:"g4";i:7;s:2:"g5";i:8;s:2:"g6";}', 1, 992, 0))
     (vendor\contao\contao\core-bundle\contao\library\Contao\Database\Statement.php:222)
  at Contao\Database\Statement->execute()
     (vendor\contao\contao\core-bundle\contao\drivers\DC_Table.php:674)
```

This is because we are still setting an empty string for the default value of `tl_page.useSSL` when it should be `false`.