### PR TITLE
Keep the ResponseContextAccessor available for autowiring

### DIFF
--- a/core-bundle/src/Resources/config/services.yml
+++ b/core-bundle/src/Resources/config/services.yml
@@ -1056,6 +1056,9 @@ services:
     Contao\CoreBundle\Routing\Page\PageRegistry:
         alias: contao.routing.page_registry
         public: true # backwards compatibility
+    Contao\CoreBundle\Routing\ResponseContext\ResponseContextAccessor:
+        alias: contao.routing.response_context_accessor
+        public: true  # backwards compatibility
     Contao\CoreBundle\Routing\ScopeMatcher: '@contao.routing.scope_matcher'
     Contao\CoreBundle\Security\Authentication\Token\TokenChecker: '@contao.security.token_checker'
     Contao\CoreBundle\Security\TwoFactor\Authenticator: '@contao.security.two_factor.authenticator'
@@ -1144,14 +1147,6 @@ services:
             package: contao/core-bundle
             version: 4.13
             message: Using the "%alias_id%" service ID has been deprecated and will no longer work in Contao 5.0. Please use "contao.image.studio.figure_renderer" instead.
-
-    Contao\CoreBundle\Routing\ResponseContext\ResponseContextAccessor:
-        alias: contao.routing.response_context_accessor
-        public: true
-        deprecated:
-            package: contao/core-bundle
-            version: 4.13
-            message: Using the "%alias_id%" service ID has been deprecated and will no longer work in Contao 5.0. Please use "contao.routing.response_context_accessor" instead.
 
     Contao\CoreBundle\Routing\ResponseContext\CoreResponseContextFactory:
         alias: contao.routing.response_context_factory


### PR DESCRIPTION
Any fragment that needs to change the page title etc. needs the `ResponseContextAccessor`, so this service should continue to be available for autowiring.

FYI we might need to re-add this in Contao 5 since the deprecations have already been removed.