### PR TITLE
Fix adjustTime in tl_calendar_events

### DIFF
--- a/calendar-bundle/src/Resources/contao/dca/tl_calendar_events.php
+++ b/calendar-bundle/src/Resources/contao/dca/tl_calendar_events.php
@@ -932,8 +932,8 @@ class tl_calendar_events extends Contao\Backend
 	 */
 	public function adjustTime(Contao\DataContainer $dc)
 	{
-		// Return if there is no active record (override all)
-		if (!$dc->activeRecord)
+		// Return if there is no active record (override all) or no start date has been set yet
+		if (!$dc->activeRecord || !$dc->activeRecord->startDate)
 		{
 			return;
 		}
@@ -960,7 +960,7 @@ class tl_calendar_events extends Contao\Backend
 		if ($dc->activeRecord->addTime)
 		{
 			$arrSet['startTime'] = strtotime(date('Y-m-d', $arrSet['startTime']) . ' ' . date('H:i:s', $dc->activeRecord->startTime));
-			$arrSet['endTime'] = strtotime(date('Y-m-d', $arrSet['endTime']) . ' ' . date('H:i:s', $dc->activeRecord->endTime ?? $dc->activeRecord->startTime));
+			$arrSet['endTime'] = strtotime(date('Y-m-d', $arrSet['endTime']) . ' ' . date('H:i:s', '' !== (string) $dc->activeRecord->endTime ? $dc->activeRecord->endTime : $dc->activeRecord->startTime));
 		}
 
 		// Adjust end time of "all day" events


### PR DESCRIPTION
Fixes #4999

There are two issues during a `submitOnChange` event:

1. `startDate` - although mandatory - will not be set during a `submitOnChange` event and thus `$arrSet['endTime']` can be empty.
2. `$dc->activeRecord->endTime` can be an empty string when not set during a `submitOnChange` event.