### PR TITLE
Stop using utf8_decode() and utf8_encode()

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/StringUtil.php
+++ b/core-bundle/src/Resources/contao/library/Contao/StringUtil.php
@@ -945,16 +945,6 @@ class StringUtil
 			return $str;
 		}
 
-		if ($from == 'UTF-8' && $to == 'ISO-8859-1')
-		{
-			return utf8_decode($str);
-		}
-
-		if ($from == 'ISO-8859-1' && $to == 'UTF-8')
-		{
-			return utf8_encode($str);
-		}
-
 		return mb_convert_encoding($str, $to, $from);
 	}
 

--- a/core-bundle/tests/Contao/StringUtilTest.php
+++ b/core-bundle/tests/Contao/StringUtilTest.php
@@ -20,6 +20,8 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class StringUtilTest extends TestCase
 {
+    private $prevSubstituteCharacter;
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -29,6 +31,16 @@ class StringUtilTest extends TestCase
         $container->set('monolog.logger.contao', new NullLogger());
 
         System::setContainer($container);
+
+        // Save the previous substitute character, as we need to override it in the tests (see #5011)
+        $this->prevSubstituteCharacter = mb_substitute_character();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        mb_substitute_character($this->prevSubstituteCharacter);
     }
 
     public function testGeneratesAliases(): void
@@ -603,6 +615,9 @@ class StringUtilTest extends TestCase
      */
     public function testConvertsEncodingOfAString($string, string $toEncoding, $expected, $fromEncoding = null): void
     {
+        // Enforce substitute character for these tests (see #5011)
+        mb_substitute_character(0x3F);
+
         $result = StringUtil::convertEncoding($string, $toEncoding, $fromEncoding);
 
         $this->assertSame($expected, $result);
@@ -627,7 +642,7 @@ class StringUtilTest extends TestCase
         yield 'From UTF-8 to ASCII' => [
             '𝚏ōȏճăᴦbaz',
             'ASCII',
-            'baz',
+            '??????baz',
             'UTF-8',
         ];
 

--- a/core-bundle/tests/Contao/StringUtilTest.php
+++ b/core-bundle/tests/Contao/StringUtilTest.php
@@ -613,14 +613,14 @@ class StringUtilTest extends TestCase
         yield 'From UTF-8 to ISO-8859-1' => [
             '𝚏ōȏճăᴦ',
             'ISO-8859-1',
-            utf8_decode('𝚏ōȏճăᴦ'),
+            '??????',
             'UTF-8',
         ];
 
         yield 'From ISO-8859-1 to UTF-8' => [
             '𝚏ōȏճăᴦ',
             'UTF-8',
-            utf8_encode('𝚏ōȏճăᴦ'),
+            'ðÅÈÕ³Äá´¦',
             'ISO-8859-1',
         ];
 

--- a/core-bundle/tests/Contao/StringUtilTest.php
+++ b/core-bundle/tests/Contao/StringUtilTest.php
@@ -20,8 +20,6 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class StringUtilTest extends TestCase
 {
-    private $prevSubstituteCharacter;
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -31,16 +29,6 @@ class StringUtilTest extends TestCase
         $container->set('monolog.logger.contao', new NullLogger());
 
         System::setContainer($container);
-
-        // Save the previous substitute character, as we need to override it in the tests (see #5011)
-        $this->prevSubstituteCharacter = mb_substitute_character();
-    }
-
-    protected function tearDown(): void
-    {
-        parent::tearDown();
-
-        mb_substitute_character($this->prevSubstituteCharacter);
     }
 
     public function testGeneratesAliases(): void
@@ -615,12 +603,16 @@ class StringUtilTest extends TestCase
      */
     public function testConvertsEncodingOfAString($string, string $toEncoding, $expected, $fromEncoding = null): void
     {
+        $prevSubstituteCharacter = mb_substitute_character();
+
         // Enforce substitute character for these tests (see #5011)
         mb_substitute_character(0x3F);
 
         $result = StringUtil::convertEncoding($string, $toEncoding, $fromEncoding);
 
         $this->assertSame($expected, $result);
+
+        mb_substitute_character($prevSubstituteCharacter);
     }
 
     public function validEncodingsProvider(): \Generator


### PR DESCRIPTION
Backport of https://github.com/contao/contao/pull/4829 to 4.9 to fix the CI. See also https://github.com/contao/contao/pull/4841