### PR TITLE
Fix several argument warnings on PHP methods

### DIFF
--- a/core-bundle/src/Resources/contao/classes/Backend.php
+++ b/core-bundle/src/Resources/contao/classes/Backend.php
@@ -431,7 +431,7 @@ abstract class Backend extends Controller
 		}
 
 		// Trigger the module callback
-		elseif (class_exists($arrModule['callback'] ?? null))
+		elseif (isset($arrModule['callback']) && class_exists($arrModule['callback']))
 		{
 			/** @var Module $objCallback */
 			$objCallback = new $arrModule['callback']($dc);

--- a/core-bundle/src/Resources/contao/classes/DataContainer.php
+++ b/core-bundle/src/Resources/contao/classes/DataContainer.php
@@ -409,7 +409,7 @@ abstract class DataContainer extends Backend
 				}
 			}
 			// Use strlen() here (see #3277)
-			elseif (!\strlen($this->varValue))
+			elseif ('' !== (string) $this->varValue)
 			{
 				$arrData['eval']['required'] = true;
 			}

--- a/core-bundle/src/Resources/contao/classes/DataContainer.php
+++ b/core-bundle/src/Resources/contao/classes/DataContainer.php
@@ -408,7 +408,6 @@ abstract class DataContainer extends Backend
 					$arrData['eval']['required'] = true;
 				}
 			}
-			// Use strlen() here (see #3277)
 			elseif ('' !== (string) $this->varValue)
 			{
 				$arrData['eval']['required'] = true;
@@ -416,7 +415,7 @@ abstract class DataContainer extends Backend
 		}
 
 		// Convert insert tags in src attributes (see #5965)
-		if (isset($arrData['eval']['rte']) && strncmp($arrData['eval']['rte'], 'tiny', 4) === 0)
+		if (isset($arrData['eval']['rte']) && strncmp($arrData['eval']['rte'], 'tiny', 4) === 0 && \is_string($this->varValue))
 		{
 			$this->varValue = StringUtil::insertTagToSrc($this->varValue);
 		}

--- a/core-bundle/src/Resources/contao/classes/DataContainer.php
+++ b/core-bundle/src/Resources/contao/classes/DataContainer.php
@@ -408,7 +408,7 @@ abstract class DataContainer extends Backend
 					$arrData['eval']['required'] = true;
 				}
 			}
-			elseif ('' !== (string) $this->varValue)
+			elseif ('' === (string) $this->varValue)
 			{
 				$arrData['eval']['required'] = true;
 			}

--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -6009,7 +6009,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 		$session = $objSessionBag->all();
 		$filter = ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] ?? null) == self::MODE_PARENT ? $this->strTable . '_' . CURRENT_ID : $this->strTable;
 
-		list($offset, $limit) = explode(',', $this->limit) + array(null, null);
+		list($offset, $limit) = explode(',', $this->limit ?? '') + array(null, null);
 
 		// Set the limit filter based on the page number
 		if (isset($_GET['lp']))

--- a/core-bundle/src/Resources/contao/forms/FormSelectMenu.php
+++ b/core-bundle/src/Resources/contao/forms/FormSelectMenu.php
@@ -191,7 +191,7 @@ class FormSelectMenu extends Widget
 		// Make sure there are no multiple options in single mode
 		elseif (\is_array($this->varValue))
 		{
-			$this->varValue = $this->varValue[0];
+			$this->varValue = $this->varValue[0] ?? null;
 		}
 
 		// Chosen

--- a/core-bundle/src/Resources/contao/forms/FormTextArea.php
+++ b/core-bundle/src/Resources/contao/forms/FormTextArea.php
@@ -140,7 +140,7 @@ class FormTextArea extends Widget
 				return $this->intRows;
 
 			case 'value':
-				return StringUtil::specialchars(str_replace('\n', "\n", $this->varValue));
+				return StringUtil::specialchars(str_replace('\n', "\n", (string) $this->varValue));
 
 			case 'rawValue':
 				return $this->varValue;

--- a/core-bundle/src/Resources/contao/library/Contao/System.php
+++ b/core-bundle/src/Resources/contao/library/Contao/System.php
@@ -719,7 +719,7 @@ abstract class System
 	 */
 	public static function urlEncode($strPath)
 	{
-		return str_replace('%2F', '/', rawurlencode($strPath));
+		return str_replace('%2F', '/', rawurlencode((string) $strPath));
 	}
 
 	/**

--- a/core-bundle/src/Resources/contao/library/Contao/Widget.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Widget.php
@@ -805,7 +805,7 @@ abstract class Widget extends Controller
 			return $varInput;
 		}
 
-		if (!$this->doNotTrim)
+		if (!$this->doNotTrim && \is_string($varInput))
 		{
 			$varInput = trim($varInput);
 		}

--- a/core-bundle/src/Resources/contao/models/FilesModel.php
+++ b/core-bundle/src/Resources/contao/models/FilesModel.php
@@ -154,7 +154,7 @@ class FilesModel extends Model
 			$intPid = StringUtil::uuidToBin($intPid);
 		}
 
-		return static::findBy(array("$t.pid=UNHEX(?)"), bin2hex($intPid), $arrOptions);
+		return static::findBy(array("$t.pid=UNHEX(?)"), bin2hex((string) $intPid), $arrOptions);
 	}
 
 	/**
@@ -210,7 +210,7 @@ class FilesModel extends Model
 			}
 		}
 
-		return static::findOneBy(array("$t.uuid=UNHEX(?)"), bin2hex($strUuid), $arrOptions);
+		return static::findOneBy(array("$t.uuid=UNHEX(?)"), bin2hex((string) $strUuid), $arrOptions);
 	}
 
 	/**
@@ -238,7 +238,7 @@ class FilesModel extends Model
 				$v = StringUtil::uuidToBin($v);
 			}
 
-			$arrUuids[$k] = "UNHEX('" . bin2hex($v) . "')";
+			$arrUuids[$k] = "UNHEX('" . bin2hex((string) $v) . "')";
 		}
 
 		if (!isset($arrOptions['order']))
@@ -354,7 +354,7 @@ class FilesModel extends Model
 				$v = StringUtil::uuidToBin($v);
 			}
 
-			$arrUuids[$k] = "UNHEX('" . bin2hex($v) . "')";
+			$arrUuids[$k] = "UNHEX('" . bin2hex((string) $v) . "')";
 		}
 
 		if (!isset($arrOptions['order']))


### PR DESCRIPTION
I got this error message in Sentry.io

> Deprecated: class_exists(): Passing null to parameter #1 ($class) of type string is deprecated