### PR TITLE
Lazy-load the RememberMeRepository

### DIFF
--- a/core-bundle/config/services.yaml
+++ b/core-bundle/config/services.yaml
@@ -811,7 +811,7 @@ services:
     contao.security.remember_me_token_provider:
         class: Contao\CoreBundle\Security\Authentication\RememberMe\RememberMeTokenProvider
         arguments:
-            - '@contao.repository.remember_me'
+            - !service_closure '@contao.repository.remember_me'
 
     contao.security.token_checker:
         public: true

--- a/core-bundle/src/Security/Authentication/RememberMe/RememberMeTokenProvider.php
+++ b/core-bundle/src/Security/Authentication/RememberMe/RememberMeTokenProvider.php
@@ -20,13 +20,15 @@ use Symfony\Component\Security\Core\Authentication\RememberMe\TokenProviderInter
 
 class RememberMeTokenProvider implements TokenProviderInterface
 {
-    public function __construct(private RememberMeRepository $repository)
+    private RememberMeRepository|null $repository = null;
+
+    public function __construct(private \Closure $repositoryClosure)
     {
     }
 
     public function loadTokenBySeries(string $series): PersistentToken
     {
-        $rememberMe = $this->repository->findBySeries($series);
+        $rememberMe = $this->getRepository()->findBySeries($series);
 
         return new PersistentToken(
             $rememberMe->getClass(),
@@ -39,21 +41,21 @@ class RememberMeTokenProvider implements TokenProviderInterface
 
     public function deleteTokenBySeries(string $series): void
     {
-        $this->repository->deleteBySeries($series);
+        $this->getRepository()->deleteBySeries($series);
     }
 
     public function updateToken(string $series, string $tokenValue, \DateTime $lastUsed): void
     {
-        $rememberMe = $this->repository->findBySeries($series);
+        $rememberMe = $this->getRepository()->findBySeries($series);
         $rememberMe->setValue($tokenValue);
         $rememberMe->setLastUsed($lastUsed);
 
-        $this->repository->persist($rememberMe);
+        $this->getRepository()->persist($rememberMe);
     }
 
     public function createNewToken(PersistentTokenInterface $token): void
     {
-        $this->repository->persist(
+        $this->getRepository()->persist(
             new RememberMe(
                 $token->getClass(),
                 $token->getUserIdentifier(),
@@ -62,5 +64,14 @@ class RememberMeTokenProvider implements TokenProviderInterface
                 $token->getLastUsed()
             )
         );
+    }
+
+    private function getRepository(): RememberMeRepository
+    {
+        if (null === $this->repository) {
+            $this->repository = ($this->repositoryClosure)();
+        }
+
+        return $this->repository;
     }
 }

--- a/core-bundle/tests/Security/Authentication/RememberMe/RememberMeTokenProviderTest.php
+++ b/core-bundle/tests/Security/Authentication/RememberMe/RememberMeTokenProviderTest.php
@@ -38,7 +38,7 @@ class RememberMeTokenProviderTest extends TestCase
             ->willReturn($rememberMe)
         ;
 
-        $rememberMeTokenProvider = new RememberMeTokenProvider($rememberMeRepository);
+        $rememberMeTokenProvider = new RememberMeTokenProvider(fn () => $rememberMeRepository);
         $token = $rememberMeTokenProvider->loadTokenBySeries($series);
 
         $this->assertSame(FrontendUser::class, $token->getClass());
@@ -59,7 +59,7 @@ class RememberMeTokenProviderTest extends TestCase
             ->with($series)
         ;
 
-        $rememberMeTokenProvider = new RememberMeTokenProvider($rememberMeRepository);
+        $rememberMeTokenProvider = new RememberMeTokenProvider(fn () => $rememberMeRepository);
         $rememberMeTokenProvider->deleteTokenBySeries($series);
     }
 
@@ -82,7 +82,7 @@ class RememberMeTokenProviderTest extends TestCase
             ->method('persist')
         ;
 
-        $rememberMeTokenProvider = new RememberMeTokenProvider($rememberMeRepository);
+        $rememberMeTokenProvider = new RememberMeTokenProvider(fn () => $rememberMeRepository);
         $rememberMeTokenProvider->updateToken($series, 'new-value', new \DateTime());
     }
 
@@ -96,7 +96,7 @@ class RememberMeTokenProviderTest extends TestCase
             ->method('persist')
         ;
 
-        $rememberMeTokenProvider = new RememberMeTokenProvider($rememberMeRepository);
+        $rememberMeTokenProvider = new RememberMeTokenProvider(fn () => $rememberMeRepository);
         $rememberMeTokenProvider->createNewToken($token);
     }
 }

--- a/core-bundle/tests/Security/Authentication/RememberMe/RememberMeTokenProviderTest.php
+++ b/core-bundle/tests/Security/Authentication/RememberMe/RememberMeTokenProviderTest.php
@@ -38,7 +38,7 @@ class RememberMeTokenProviderTest extends TestCase
             ->willReturn($rememberMe)
         ;
 
-        $rememberMeTokenProvider = new RememberMeTokenProvider(fn () => $rememberMeRepository);
+        $rememberMeTokenProvider = new RememberMeTokenProvider(static fn () => $rememberMeRepository);
         $token = $rememberMeTokenProvider->loadTokenBySeries($series);
 
         $this->assertSame(FrontendUser::class, $token->getClass());
@@ -59,7 +59,7 @@ class RememberMeTokenProviderTest extends TestCase
             ->with($series)
         ;
 
-        $rememberMeTokenProvider = new RememberMeTokenProvider(fn () => $rememberMeRepository);
+        $rememberMeTokenProvider = new RememberMeTokenProvider(static fn () => $rememberMeRepository);
         $rememberMeTokenProvider->deleteTokenBySeries($series);
     }
 
@@ -82,7 +82,7 @@ class RememberMeTokenProviderTest extends TestCase
             ->method('persist')
         ;
 
-        $rememberMeTokenProvider = new RememberMeTokenProvider(fn () => $rememberMeRepository);
+        $rememberMeTokenProvider = new RememberMeTokenProvider(static fn () => $rememberMeRepository);
         $rememberMeTokenProvider->updateToken($series, 'new-value', new \DateTime());
     }
 
@@ -96,7 +96,7 @@ class RememberMeTokenProviderTest extends TestCase
             ->method('persist')
         ;
 
-        $rememberMeTokenProvider = new RememberMeTokenProvider(fn () => $rememberMeRepository);
+        $rememberMeTokenProvider = new RememberMeTokenProvider(static fn () => $rememberMeRepository);
         $rememberMeTokenProvider->createNewToken($token);
     }
 }


### PR DESCRIPTION
Similar to the problems fixed by https://github.com/contao/contao/pull/4265, having a service that requires a doctrine repository is problematic because it could trigger a DB connection.

In current dev, easily reproducible by running `contao-console list --format=json`