### PR TITLE
Also set collation for database.sql files

### DIFF
--- a/core-bundle/src/Doctrine/Schema/DcaSchemaProvider.php
+++ b/core-bundle/src/Doctrine/Schema/DcaSchemaProvider.php
@@ -69,10 +69,12 @@ class DcaSchemaProvider
                 if (preg_match('/DEFAULT CHARSET=([^ ]+)/i', $definitions['TABLE_OPTIONS'], $match)) {
                     $table->addOption('charset', $match[1]);
                     $table->addOption('collate', $match[1].'_general_ci');
+                    $table->addOption('collation', $match[1].'_general_ci');
                 }
 
                 if (preg_match('/COLLATE ([^ ]+)/i', $definitions['TABLE_OPTIONS'], $match)) {
                     $table->addOption('collate', $match[1]);
+                    $table->addOption('collation', $match[1]);
                 }
             }
 


### PR DESCRIPTION
In Contao 4.13 the following error might occur during migration with old style `database.sql` files like [this one](https://github.com/friends-of-contao/contao-associategroups/blob/master/contao/config/database.sql):

```
'ALTER TABLE tl_member_to_group CONVERT TO CHARACTER SET utf8 COLLATE utf8mb4_unicode_ci'
Syntax error or access violation: 1253 COLLATION 'utf8mb4_unicode_ci' is not valid for CHARACTER SET 'utf8'
```

In Contao 4.13 we are setting default table options for `collation`. This leads to issues if a `CHARSET` is defined for the table in the `database.sql` file - as the `collation` from the default table options might not be suitable. While the `DcaSchemaProvider` also tries to sets the collation of the table in such a case - it only sets the older `collate` option and not the newer `collation` option, thus leading to this issue.