### PR TITLE
Allow null for PaletteManipulator parent

### DIFF
--- a/core-bundle/src/DataContainer/PaletteManipulator.php
+++ b/core-bundle/src/DataContainer/PaletteManipulator.php
@@ -44,10 +44,10 @@ class PaletteManipulator
     /**
      * If the legend already exists, nothing will be changed.
      *
-     * @param string|array $parent
-     * @param bool         $hide
+     * @param string|array|null $parent
+     * @param bool              $hide
      */
-    public function addLegend(string $name, $parent, string $position = self::POSITION_AFTER, $hide = false): self
+    public function addLegend(string $name, $parent = null, string $position = self::POSITION_AFTER, $hide = false): self
     {
         $this->validatePosition($position);
 
@@ -65,13 +65,13 @@ class PaletteManipulator
      * If $position is PREPEND or APPEND, pass a legend as parent; otherwise pass a field name.
      *
      * @param string|array               $name
-     * @param string|array               $parent
+     * @param string|array|null          $parent
      * @param string|array|\Closure|null $fallback
      * @param string                     $fallbackPosition
      *
      * @throws PalettePositionException
      */
-    public function addField($name, $parent, string $position = self::POSITION_AFTER, $fallback = null, $fallbackPosition = self::POSITION_APPEND): self
+    public function addField($name, $parent = null, string $position = self::POSITION_AFTER, $fallback = null, $fallbackPosition = self::POSITION_APPEND): self
     {
         $this->validatePosition($position);
 

--- a/core-bundle/tests/DataContainer/PaletteManipulatorTest.php
+++ b/core-bundle/tests/DataContainer/PaletteManipulatorTest.php
@@ -462,4 +462,54 @@ class PaletteManipulatorTest extends TestCase
             $pm->applyToString('{contact_legend},firstname,lastname')
         );
     }
+
+    public function testAddsLegendToEndIfParentDoesNotExist(): void
+    {
+        $pm = PaletteManipulator::create()
+            ->addLegend('config_legend', 'notexist_legend')
+            ->addField('foo', 'config_legend', 'append')
+        ;
+
+        $this->assertSame(
+            '{foo_legend},baz;{config_legend},foo',
+            $pm->applyToString('{foo_legend},baz')
+        );
+    }
+
+    public function testAddsLegendToEndIfParentIsNull(): void
+    {
+        $pm = PaletteManipulator::create()
+            ->addLegend('config_legend')
+            ->addField('foo', 'config_legend', 'append')
+        ;
+
+        $this->assertSame(
+            '{foo_legend},baz;{config_legend},foo',
+            $pm->applyToString('{foo_legend},baz')
+        );
+    }
+
+    public function testAddsFieldToEndIfParentDoesNotExist(): void
+    {
+        $pm = PaletteManipulator::create()
+            ->addField('foo', 'notexist')
+        ;
+
+        $this->assertSame(
+            '{config_legend},baz,foo',
+            $pm->applyToString('{config_legend},baz')
+        );
+    }
+
+    public function testAddsFieldToEndIfParentIsNull(): void
+    {
+        $pm = PaletteManipulator::create()
+            ->addField('foo')
+        ;
+
+        $this->assertSame(
+            '{config_legend},baz,foo',
+            $pm->applyToString('{config_legend},baz')
+        );
+    }
 }


### PR DESCRIPTION
There are palettes that do not contain any legends, e.g. `tl_files`. If you want to add a field to that legend via the `PaletteManipulator` you currently have to do either of these methods:

```php
// The parent is null but PaletteManipulator::applyFallback will add the field to the end
PaletteManipulator::create()
    ->addField('groups', null)
    ->applyToPalette('default', 'tl_files')
;
```

```php
// The palette "foobar" does not exist but PaletteManipulator::applyFallback will add the field to the end
PaletteManipulator::create()
    ->addField('groups', 'foobar')
    ->applyToPalette('default', 'tl_files')
;
```

Since it is possible (and necessary) to define the `$parent` as `null`, this PR fixes the type hint in the doc. And since it is not necessary to define a parent the argument can be omitted altogether.

It's important to merge this upstream to `5.0` as there you _must_ define a not null `$parent`, otherwise you get the following error:

```
TypeError:
Contao\CoreBundle\DataContainer\PaletteManipulator::addField(): Argument #2 ($parent) must be of type array|string, null given, called in vendor\fritzmg\contao-file-access\src\DataContainer\FilesCallbacks.php on line 34

  at vendor\contao\contao\core-bundle\src\DataContainer\PaletteManipulator.php:57
  at Contao\CoreBundle\DataContainer\PaletteManipulator->addField('groups', null)
```

To circumvent this you would have to apply option no. 2 from above - but having to pass a legend that does not exist only to force the fallback (since there is no valid legend to begin with) makes no sense.

The same applies to when you want to add a new legend to the end of any palette.