### PR TITLE
Remove two redundant body classes

### DIFF
--- a/core-bundle/contao/templates/backend/be_help.html5
+++ b/core-bundle/contao/templates/backend/be_help.html5
@@ -29,7 +29,7 @@
   <?= $this->javascripts ?>
 
 </head>
-<body class="popup">
+<body>
 
   <div id="container">
     <main id="main">

--- a/core-bundle/contao/templates/backend/be_popup.html5
+++ b/core-bundle/contao/templates/backend/be_popup.html5
@@ -29,7 +29,7 @@
   <?= $this->javascripts ?>
 
 </head>
-<body class="popup">
+<body>
 
   <div id="container">
     <main id="main">


### PR DESCRIPTION
These templates have their own style sheets and don‘t use a `.popup` CSS class.