### PR TITLE
Fix empty form uploads causing an error

### DIFF
--- a/core-bundle/contao/forms/Form.php
+++ b/core-bundle/contao/forms/Form.php
@@ -218,7 +218,11 @@ class Form extends Hybrid
 
 				if ($objWidget instanceof UploadableWidgetInterface)
 				{
-					$arrFiles[$objField->name] = $objWidget->value;
+					if ($objWidget->value)
+					{
+						$arrFiles[$objField->name] = $objWidget->value;
+					}
+
 					$hasUpload = true;
 				}
 


### PR DESCRIPTION
Fixes #5053 

Previously we only checked `!empty($_SESSION['FILES'])`. In Contao 5.0 we check for `!empty($arrFiles)` and we build `$arrFiles` via the upload widgets' values. This leads to an error since `$arrFiles` will be filled with an empty value if a non-mandatory upload field was submitted without a file.