### PR TITLE
Fix illegal string offsets in the translator

### DIFF
--- a/core-bundle/src/Translation/Translator.php
+++ b/core-bundle/src/Translation/Translator.php
@@ -130,7 +130,7 @@ class Translator implements TranslatorInterface, TranslatorBagInterface, LocaleA
         $item = &$GLOBALS['TL_LANG'];
 
         foreach ($parts as $part) {
-            if (!isset($item[$part])) {
+            if (!\is_array($item) || !isset($item[$part])) {
                 return null;
             }
 

--- a/core-bundle/tests/Translation/TranslatorTest.php
+++ b/core-bundle/tests/Translation/TranslatorTest.php
@@ -117,6 +117,8 @@ class TranslatorTest extends TestCase
 
         $this->assertSame('bar', $translator->trans('MSC.foo', [], 'contao_default'));
         $this->assertSame('MSC.foo.bar', $translator->trans('MSC.foo.bar', [], 'contao_default'));
+        $this->assertSame('MSC.foo.0', $translator->trans('MSC.foo.0', [], 'contao_default'));
+        $this->assertSame('MSC.foo.123', $translator->trans('MSC.foo.123', [], 'contao_default'));
 
         $GLOBALS['TL_LANG']['MSC']['foo'] = 'bar %s baz %s';
 


### PR DESCRIPTION
Fixes the `Cannot create references to/from string offsets` bug from #5041