### PR TITLE
Drop support for MAILER_URL

### DIFF
--- a/manager-bundle/src/ContaoManager/Plugin.php
+++ b/manager-bundle/src/ContaoManager/Plugin.php
@@ -171,7 +171,6 @@ class Plugin implements BundlePluginInterface, ConfigPluginInterface, RoutingPlu
                 'COOKIE_WHITELIST',
                 'DATABASE_URL',
                 'DISABLE_HTTP_CACHE',
-                'MAILER_URL',
                 'MAILER_DSN',
                 'TRACE_LEVEL',
                 'TRUSTED_PROXIES',
@@ -211,11 +210,7 @@ class Plugin implements BundlePluginInterface, ConfigPluginInterface, RoutingPlu
                 }
 
                 if (!isset($_SERVER['MAILER_DSN'])) {
-                    if (isset($_SERVER['MAILER_URL'])) {
-                        $container->setParameter('env(MAILER_DSN)', $this->getMailerDsnFromMailerUrl($_SERVER['MAILER_URL']));
-                    } else {
-                        $container->setParameter('env(MAILER_DSN)', $this->getMailerDsn($container));
-                    }
+                    $container->setParameter('env(MAILER_DSN)', $this->getMailerDsn($container));
                 }
 
                 return $extensionConfigs;
@@ -575,118 +570,6 @@ class Plugin implements BundlePluginInterface, ConfigPluginInterface, RoutingPlu
             $container->getParameter('database_host'),
             (int) $container->getParameter('database_port'),
             $dbName
-        );
-    }
-
-    private function getMailerDsnFromMailerUrl(string $mailerUrl): string
-    {
-        if (false === $parts = parse_url($mailerUrl)) {
-            throw new \InvalidArgumentException(sprintf('The MAILER_URL "%s" is not valid.', $mailerUrl));
-        }
-
-        $options = [
-            'transport' => null,
-            'username' => null,
-            'password' => null,
-            'host' => null,
-            'port' => null,
-            'encryption' => null,
-        ];
-
-        $queryOptions = [];
-
-        if (isset($parts['scheme'])) {
-            $options['transport'] = $parts['scheme'];
-        }
-
-        if (isset($parts['user'])) {
-            $options['username'] = rawurldecode($parts['user']);
-        }
-
-        if (isset($parts['pass'])) {
-            $options['password'] = rawurldecode($parts['pass']);
-        }
-
-        if (isset($parts['host'])) {
-            $options['host'] = rawurldecode($parts['host']);
-        }
-
-        if (isset($parts['port'])) {
-            $options['port'] = $parts['port'];
-        }
-
-        if (isset($parts['query'])) {
-            parse_str($parts['query'], $query);
-
-            foreach ($query as $key => $value) {
-                if (empty($key)) {
-                    continue;
-                }
-
-                if (\array_key_exists($key, $options)) {
-                    $options[$key] = $value;
-                } else {
-                    $queryOptions[$key] = $value;
-                }
-            }
-        }
-
-        if (empty($options['transport'])) {
-            throw new \InvalidArgumentException(sprintf('The MAILER_URL "%s" is not valid.', $mailerUrl));
-        }
-
-        if (\in_array($options['transport'], ['mail', 'sendmail'], true)) {
-            return 'sendmail://default';
-        }
-
-        /*
-         * Check for gmail transport.
-         *
-         * With Swiftmailer a DSN like "gmail://username:password@localhost" was
-         * supported out-of-the-box. See https://symfony.com/doc/4.4/email.html#using-gmail-to-send-emails
-         * Symfony Mailer supports something similar, but only with an additional
-         * dependency. See https://symfony.com/doc/4.4/components/mailer.html#transport
-         *
-         * Thus we add backwards compatibility for the "gmail" transport here.
-         */
-        if ('gmail' === $options['transport']) {
-            $options['host'] = 'smtp.gmail.com';
-            $options['transport'] = 'smtps';
-        }
-
-        if (empty($options['host']) || !\in_array($options['transport'], ['smtp', 'smtps'], true)) {
-            throw new \InvalidArgumentException(sprintf('The MAILER_URL "%s" is not valid.', $mailerUrl));
-        }
-
-        $transport = $options['transport'];
-        $credentials = '';
-        $port = '';
-
-        if (!empty($options['encryption']) && 'ssl' === $options['encryption']) {
-            $transport = 'smtps';
-        }
-
-        if (!empty($options['username'])) {
-            $credentials .= $this->encodeUrlParameter($options['username']);
-
-            if (!empty($options['password'])) {
-                $credentials .= ':'.$this->encodeUrlParameter($options['password']);
-            }
-
-            $credentials .= '@';
-        }
-
-        if (!empty($options['port'])) {
-            $port = ':'.$options['port'];
-        }
-
-        return sprintf(
-            '%s://%s%s%s%s',
-            $transport,
-            $credentials,
-            $options['host'],
-            $port,
-            !empty($queryOptions) ? '?'.http_build_query($queryOptions) : ''
         );
     }
 

--- a/manager-bundle/tests/ContaoManager/PluginTest.php
+++ b/manager-bundle/tests/ContaoManager/PluginTest.php
@@ -305,7 +305,6 @@ class PluginTest extends ContaoTestCase
                     'COOKIE_WHITELIST',
                     'DATABASE_URL',
                     'DISABLE_HTTP_CACHE',
-                    'MAILER_URL',
                     'MAILER_DSN',
                     'TRACE_LEVEL',
                     'TRUSTED_PROXIES',
@@ -919,127 +918,6 @@ class PluginTest extends ContaoTestCase
             'tls',
             'smtp://foo%%40bar.com:foobar@127.0.0.1:587',
         ];
-    }
-
-    /**
-     * @dataProvider getMailerUrlParameters
-     */
-    public function testSetsTheMailerDsnFromMailerUrl(string $mailerUrl, string $expected): void
-    {
-        $_SERVER['MAILER_URL'] = $mailerUrl;
-
-        $container = $this->getContainer();
-
-        (new Plugin())->getExtensionConfig('framework', [], $container);
-
-        $bag = $container->getParameterBag()->all();
-
-        $this->assertSame($expected, $bag['env(MAILER_DSN)']);
-    }
-
-    public function getMailerUrlParameters(): \Generator
-    {
-        yield [
-            'sendmail://localhost',
-            'sendmail://default',
-        ];
-
-        yield [
-            'mail://localhost',
-            'sendmail://default',
-        ];
-
-        yield [
-            'smtp://127.0.0.1:25',
-            'smtp://127.0.0.1:25',
-        ];
-
-        yield [
-            'smtp://127.0.0.1:25?local_domain=example.org&foo=bar',
-            'smtp://127.0.0.1:25?local_domain=example.org&foo=bar',
-        ];
-
-        yield [
-            'smtp://127.0.0.1:25?username=foo@bar.com',
-            'smtp://foo%%40bar.com@127.0.0.1:25',
-        ];
-
-        yield [
-            'smtp://127.0.0.1:25?username=foo@bar.com&password=foobar',
-            'smtp://foo%%40bar.com:foobar@127.0.0.1:25',
-        ];
-
-        yield [
-            'smtp://foo@bar.com:foobar@127.0.0.1:25',
-            'smtp://foo%%40bar.com:foobar@127.0.0.1:25',
-        ];
-
-        yield [
-            'smtp://127.0.0.1:587?encryption=tls',
-            'smtp://127.0.0.1:587',
-        ];
-
-        yield [
-            'smtp://127.0.0.1:587?username=foo@bar.com&password=foobar&encryption=tls',
-            'smtp://foo%%40bar.com:foobar@127.0.0.1:587',
-        ];
-
-        yield [
-            'smtp://127.0.0.1?encryption=ssl',
-            'smtps://127.0.0.1',
-        ];
-
-        yield [
-            'smtp://foo@bar.com:foobar@127.0.0.1?encryption=ssl',
-            'smtps://foo%%40bar.com:foobar@127.0.0.1',
-        ];
-
-        yield [
-            'smtp://127.0.0.1:465?encryption=ssl',
-            'smtps://127.0.0.1:465',
-        ];
-
-        yield [
-            'smtp://127.0.0.1:465?username=foo@bar.com&password=foobar&encryption=ssl',
-            'smtps://foo%%40bar.com:foobar@127.0.0.1:465',
-        ];
-
-        yield [
-            'gmail://localhost',
-            'smtps://smtp.gmail.com',
-        ];
-
-        yield [
-            '?transport=gmail',
-            'smtps://smtp.gmail.com',
-        ];
-    }
-
-    /**
-     * @dataProvider getInvalidMailerUrlParameters
-     */
-    public function testThrowsExceptionIfMailerUrlIsInvalid(string $invalidMailerUrl): void
-    {
-        $_SERVER['MAILER_URL'] = $invalidMailerUrl;
-
-        $container = $this->getContainer();
-
-        $this->expectException(\InvalidArgumentException::class);
-
-        (new Plugin())->getExtensionConfig('framework', [], $container);
-    }
-
-    public function getInvalidMailerUrlParameters(): \Generator
-    {
-        yield['smtp'];
-
-        yield['smtp://'];
-
-        yield['//smtp'];
-
-        yield['?host=localhost'];
-
-        yield['foo://localhost'];
     }
 
     public function testUpdatesTheClickjackingPaths(): void


### PR DESCRIPTION
`MAILER_DSN` is the Symfony standard that should be used since Symfony Mailer.