### PR TITLE
Rename the database error type

### DIFF
--- a/core-bundle/src/Command/MigrateCommand.php
+++ b/core-bundle/src/Command/MigrateCommand.php
@@ -71,7 +71,7 @@ class MigrateCommand extends Command
             if ($errors = $this->compileConfigurationErrors()) {
                 if ($asJson) {
                     foreach ($errors as $message) {
-                        $this->writeNdjson('error', ['message' => $message]);
+                        $this->writeNdjson('problem', ['message' => $message]);
                     }
                 } else {
                     foreach ($errors as $error) {
@@ -419,6 +419,7 @@ class MigrateCommand extends Command
     {
         $this->io->writeln(
             json_encode(
+                // make sure $type is the first in array but always wins
                 array_merge(['type' => $type], $data, ['type' => $type]),
                 JSON_INVALID_UTF8_SUBSTITUTE
             )

--- a/core-bundle/src/Command/MigrateCommand.php
+++ b/core-bundle/src/Command/MigrateCommand.php
@@ -420,7 +420,7 @@ class MigrateCommand extends Command
         $this->io->writeln(
             json_encode(
                 // make sure $type is the first in array but always wins
-                array_merge(['type' => $type], $data, ['type' => $type]),
+                ['type' => $type] + $data,
                 JSON_INVALID_UTF8_SUBSTITUTE
             )
         );


### PR DESCRIPTION
It is currently impossible to distinguish between an exception and a database error. By renaming the type the Contao Manager will at least be able to know what _could_ be shown.

FYI we cannot rename the exception because the same type is already in use in Contao 4.13