### PR TITLE
Fix DcaLoader exceptions

### DIFF
--- a/core-bundle/contao/library/Contao/Controller.php
+++ b/core-bundle/contao/library/Contao/Controller.php
@@ -1167,13 +1167,12 @@ abstract class Controller extends System
 	/**
 	 * Load a set of DCA files
 	 *
-	 * @param string  $strTable   The table name
-	 * @param boolean $blnNoCache If true, the cache will be bypassed
+	 * @param string $strTable The table name
 	 */
-	public static function loadDataContainer($strTable, $blnNoCache=false)
+	public static function loadDataContainer($strTable)
 	{
 		$loader = new DcaLoader($strTable);
-		$loader->load($blnNoCache);
+		$loader->load();
 	}
 
 	/**

--- a/core-bundle/contao/library/Contao/DcaLoader.php
+++ b/core-bundle/contao/library/Contao/DcaLoader.php
@@ -60,18 +60,30 @@ class DcaLoader extends Controller
 
 	/**
 	 * Load a set of DCA files
-	 *
-	 * @param boolean $blnNoCache If true, the cache will be bypassed
 	 */
-	public function load($blnNoCache=false)
+	public function load()
 	{
+		// Return if the data has been loaded already
+		if (isset(static::$arrLoaded['dcaFiles'][$this->strTable]))
+		{
+			// Throw the original exception if the first load failed
+			if (static::$arrLoaded['dcaFiles'][$this->strTable] instanceof \Throwable)
+			{
+				throw static::$arrLoaded['dcaFiles'][$this->strTable];
+			}
+
+			return;
+		}
+
 		try
 		{
-			$this->loadDcaFiles($blnNoCache);
+			static::$arrLoaded['dcaFiles'][$this->strTable] = true; // see #6145
+
+			$this->loadDcaFiles();
 		}
 		catch (\Throwable $e)
 		{
-			unset(static::$arrLoaded['dcaFiles'][$this->strTable]);
+			static::$arrLoaded['dcaFiles'][$this->strTable] = $e;
 
 			throw $e;
 		}
@@ -79,19 +91,9 @@ class DcaLoader extends Controller
 
 	/**
 	 * Load the DCA files
-	 *
-	 * @param boolean $blnNoCache
 	 */
-	private function loadDcaFiles($blnNoCache)
+	private function loadDcaFiles()
 	{
-		// Return if the data has been loaded already
-		if (!$blnNoCache && isset(static::$arrLoaded['dcaFiles'][$this->strTable]))
-		{
-			return;
-		}
-
-		static::$arrLoaded['dcaFiles'][$this->strTable] = true; // see #6145
-
 		$strCacheDir = System::getContainer()->getParameter('kernel.cache_dir');
 
 		// Try to load from cache
@@ -129,15 +131,13 @@ class DcaLoader extends Controller
 			}
 		}
 
-		$this->addDefaultLabels($blnNoCache);
+		$this->addDefaultLabels();
 	}
 
 	/**
 	 * Add the default labels (see #509)
-	 *
-	 * @param boolean $blnNoCache
 	 */
-	private function addDefaultLabels($blnNoCache)
+	private function addDefaultLabels()
 	{
 		// Operations
 		foreach (array('global_operations', 'operations') as $key)

--- a/core-bundle/src/Twig/FragmentTemplate.php
+++ b/core-bundle/src/Twig/FragmentTemplate.php
@@ -273,7 +273,7 @@ final class FragmentTemplate extends Template
     /**
      * @internal
      */
-    public static function loadDataContainer($strTable, $blnNoCache = false): never
+    public static function loadDataContainer($strTable): never
     {
         self::throwOnAccess();
     }

--- a/core-bundle/tests/Contao/DcaLoaderTest.php
+++ b/core-bundle/tests/Contao/DcaLoaderTest.php
@@ -35,8 +35,6 @@ class DcaLoaderTest extends TestCase
         $this->resetStaticProperties([System::class, Config::class, DcaLoader::class]);
 
         parent::tearDown();
-
-        (new Filesystem())->remove($this->getTempDir());
     }
 
     public function testThrowsTheSameExceptionWhenLoadingTwice(): void

--- a/core-bundle/tests/Contao/DcaLoaderTest.php
+++ b/core-bundle/tests/Contao/DcaLoaderTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\Contao;
+
+use Contao\Config;
+use Contao\CoreBundle\Tests\TestCase;
+use Contao\DcaLoader;
+use Contao\System;
+use Symfony\Component\Filesystem\Filesystem;
+
+class DcaLoaderTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $container = $this->getContainerWithContaoConfiguration($this->getTempDir());
+        System::setContainer($container);
+    }
+
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['TL_DCA'], $GLOBALS['TL_MIME']);
+
+        $this->resetStaticProperties([System::class, Config::class, DcaLoader::class]);
+
+        parent::tearDown();
+
+        (new Filesystem())->remove($this->getTempDir());
+    }
+
+    public function testThrowsTheSameExceptionWhenLoadingTwice(): void
+    {
+        // Loading this file twice would cause a "Cannot declare class …,
+        // because the name is already in use" error
+        (new Filesystem())->dumpFile(
+            $this->getTempDir().'/var/cache/contao/dca/tl_foo.php',
+            sprintf(
+                <<<'EOD'
+                    <?php
+                        class tl_foo_%s {}
+                        throw new Exception('From tl_foo');
+                    EOD,
+                bin2hex(random_bytes(16)),
+            ),
+        );
+
+        $firstException = $secondException = null;
+
+        try {
+            (new DcaLoader('tl_foo'))->load();
+        } catch (\Throwable $exception) {
+            $firstException = $exception;
+        }
+
+        try {
+            (new DcaLoader('tl_foo'))->load();
+        } catch (\Throwable $exception) {
+            $secondException = $exception;
+        }
+
+        $this->assertSame($firstException, $secondException);
+    }
+}


### PR DESCRIPTION
Followup to https://github.com/contao/contao/pull/4881#issuecomment-1167421657

Loading DCAs inside a try/catch block was still buggy because a second `->load()` possibly caused a `Cannot declare class …, because the name is already in use` error.

Also removed the `$blnNoCache` parameter as this has never worked (would’ve caused the same redeclare class issue).