### PR TITLE
Backport lazy services for CronJob repository

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -89,7 +89,7 @@
         "symfony/console": "4.4.*",
         "symfony/debug": "4.4.*",
         "symfony/debug-bundle": "4.4.*",
-        "symfony/dependency-injection": "^4.4.23",
+        "symfony/dependency-injection": "~4.4.23",
         "symfony/deprecation-contracts": "^2.1 || ^3.0",
         "symfony/doctrine-bridge": "4.4.*",
         "symfony/dom-crawler": "4.4.*",

--- a/composer.json
+++ b/composer.json
@@ -89,7 +89,7 @@
         "symfony/console": "4.4.*",
         "symfony/debug": "4.4.*",
         "symfony/debug-bundle": "4.4.*",
-        "symfony/dependency-injection": "4.4.*",
+        "symfony/dependency-injection": "^4.4.23",
         "symfony/deprecation-contracts": "^2.1 || ^3.0",
         "symfony/doctrine-bridge": "4.4.*",
         "symfony/dom-crawler": "4.4.*",

--- a/core-bundle/composer.json
+++ b/core-bundle/composer.json
@@ -83,7 +83,7 @@
         "symfony/cache": "4.4.*",
         "symfony/config": "4.4.*",
         "symfony/console": "4.4.*",
-        "symfony/dependency-injection": "4.4.*",
+        "symfony/dependency-injection": "~4.4.23",
         "symfony/deprecation-contracts": "^2.1 || ^3.0",
         "symfony/dom-crawler": "4.4.*",
         "symfony/event-dispatcher": "4.4.*",

--- a/core-bundle/src/Resources/config/services.yml
+++ b/core-bundle/src/Resources/config/services.yml
@@ -196,8 +196,8 @@ services:
 
     Contao\CoreBundle\Cron\Cron:
         arguments:
-            - '@Contao\CoreBundle\Repository\CronJobRepository'
-            - '@doctrine.orm.entity_manager'
+            - !service_closure '@Contao\CoreBundle\Repository\CronJobRepository'
+            - !service_closure '@doctrine.orm.entity_manager'
             - '@?logger'
         public: true
 

--- a/core-bundle/tests/Cron/CronTest.php
+++ b/core-bundle/tests/Cron/CronTest.php
@@ -36,7 +36,7 @@ class CronTest extends TestCase
             ->method('onHourly')
         ;
 
-        $cron = new Cron($repository, $this->createMock(EntityManagerInterface::class));
+        $cron = new Cron($this->fn($repository), $this->fn($this->createMock(EntityManagerInterface::class)));
         $cron->addCronJob(new CronJob($cronjob, '@hourly', 'onHourly'));
         $cron->run(Cron::SCOPE_CLI);
     }
@@ -71,7 +71,7 @@ class CronTest extends TestCase
             )
         ;
 
-        $cron = new Cron($repository, $this->createMock(EntityManagerInterface::class), $logger);
+        $cron = new Cron($this->fn($repository), $this->fn($this->createMock(EntityManagerInterface::class)), $logger);
         $cron->addCronJob(new CronJob($cronjob, '* * * * *', 'onMinutely'));
         $cron->addCronJob(new CronJob($cronjob, '0 * * * *', 'onHourly'));
         $cron->run(Cron::SCOPE_CLI);
@@ -113,7 +113,7 @@ class CronTest extends TestCase
             ->method('flush')
         ;
 
-        $cron = new Cron($repository, $manager);
+        $cron = new Cron($this->fn($repository), $this->fn($manager));
         $cron->addCronJob(new CronJob($cronjob, '@hourly', 'onHourly'));
         $cron->run(Cron::SCOPE_CLI);
     }
@@ -127,14 +127,14 @@ class CronTest extends TestCase
             ->with(Cron::SCOPE_CLI)
         ;
 
-        $cron = new Cron($this->createMock(CronJobRepository::class), $this->createMock(EntityManagerInterface::class));
+        $cron = new Cron($this->fn($this->createMock(CronJobRepository::class)), $this->fn($this->createMock(EntityManagerInterface::class)));
         $cron->addCronJob(new CronJob($cronjob, '@hourly'));
         $cron->run(Cron::SCOPE_CLI);
     }
 
     public function testInvalidArgumentExceptionForScope(): void
     {
-        $cron = new Cron($this->createMock(CronJobRepository::class), $this->createMock(EntityManagerInterface::class));
+        $cron = new Cron($this->fn($this->createMock(CronJobRepository::class)), $this->fn($this->createMock(EntityManagerInterface::class)));
 
         try {
             $cron->run(Cron::SCOPE_CLI);
@@ -164,5 +164,12 @@ class CronTest extends TestCase
         ;
 
         return $entity;
+    }
+
+    private function fn($service)
+    {
+        return static function () use ($service) {
+            return $service;
+        };
     }
 }

--- a/core-bundle/tests/Cron/LegacyCronTest.php
+++ b/core-bundle/tests/Cron/LegacyCronTest.php
@@ -80,7 +80,7 @@ class LegacyCronTest extends TestCase
         // Create a LegacyCron instance and add cron jobs to the cron service
         $legacyCron = new LegacyCron($framework);
 
-        $cron = new Cron($this->createMock(CronJobRepository::class), $this->createMock(EntityManagerInterface::class));
+        $cron = new Cron($this->fn($this->createMock(CronJobRepository::class)), $this->fn($this->createMock(EntityManagerInterface::class)));
         $cron->addCronJob(new CronJob($legacyCron, '* * * * *', 'onMinutely'));
         $cron->addCronJob(new CronJob($legacyCron, '@hourly', 'onHourly'));
         $cron->addCronJob(new CronJob($legacyCron, '@daily', 'onDaily'));
@@ -105,5 +105,12 @@ class LegacyCronTest extends TestCase
         $legacyCron->onDaily();
         $legacyCron->onWeekly();
         $legacyCron->onMonthly();
+    }
+
+    private function fn($service)
+    {
+        return static function () use ($service) {
+            return $service;
+        };
     }
 }

--- a/core-bundle/tests/Cron/LegacyCronTest.php
+++ b/core-bundle/tests/Cron/LegacyCronTest.php
@@ -80,7 +80,15 @@ class LegacyCronTest extends TestCase
         // Create a LegacyCron instance and add cron jobs to the cron service
         $legacyCron = new LegacyCron($framework);
 
-        $cron = new Cron($this->fn($this->createMock(CronJobRepository::class)), $this->fn($this->createMock(EntityManagerInterface::class)));
+        $cron = new Cron(
+            function () {
+                return $this->createMock(CronJobRepository::class);
+            },
+            function () {
+                return $this->createMock(EntityManagerInterface::class);
+            }
+        );
+
         $cron->addCronJob(new CronJob($legacyCron, '* * * * *', 'onMinutely'));
         $cron->addCronJob(new CronJob($legacyCron, '@hourly', 'onHourly'));
         $cron->addCronJob(new CronJob($legacyCron, '@daily', 'onDaily'));
@@ -105,12 +113,5 @@ class LegacyCronTest extends TestCase
         $legacyCron->onDaily();
         $legacyCron->onWeekly();
         $legacyCron->onMonthly();
-    }
-
-    private function fn($service)
-    {
-        return static function () use ($service) {
-            return $service;
-        };
     }
 }

--- a/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
+++ b/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
@@ -154,6 +154,7 @@ use Symfony\Cmf\Component\Routing\DynamicRouter;
 use Symfony\Cmf\Component\Routing\NestedMatcher\NestedMatcher;
 use Symfony\Cmf\Component\Routing\ProviderBasedGenerator;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\Compiler\ResolvePrivatesPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -1621,8 +1622,8 @@ class ContaoCoreExtensionTest extends TestCase
 
         $this->assertEquals(
             [
-                new Reference(CronJobRepository::class),
-                new Reference('doctrine.orm.entity_manager'),
+                new ServiceClosureArgument(new Reference(CronJobRepository::class)),
+                new ServiceClosureArgument(new Reference('doctrine.orm.entity_manager')),
                 new Reference('logger', ContainerInterface::IGNORE_ON_INVALID_REFERENCE),
             ],
             $definition->getArguments()


### PR DESCRIPTION
Somehow https://github.com/contao/contao/pull/4265 only made it into 4.13 even though the same problem exists in the current 4.9 version. Running `contao-console list --format=json` results in a database exception.