### PR TITLE
Fix indeterministic order for non-unique filters in DC_Table

### DIFF
--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -211,7 +211,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 			// Unless there are any root records specified, use all records with parent ID 0
 			if (!isset($GLOBALS['TL_DCA'][$table]['list']['sorting']['root']) || $GLOBALS['TL_DCA'][$table]['list']['sorting']['root'] === false)
 			{
-				$objIds = $this->Database->prepare("SELECT id FROM " . $table . " WHERE pid=?" . ($this->Database->fieldExists('sorting', $table) ? ' ORDER BY sorting' : ''))
+				$objIds = $this->Database->prepare("SELECT id FROM " . $table . " WHERE pid=?" . ($this->Database->fieldExists('sorting', $table) ? ' ORDER BY sorting, id' : ''))
 										 ->execute(0);
 
 				if ($objIds->numRows > 0)
@@ -1049,12 +1049,12 @@ class DC_Table extends DataContainer implements \listable, \editable
 				{
 					$cond = ($table === 'tl_article') ? "(ptable=? OR ptable='')" : "ptable=?";
 
-					$objCTable = $this->Database->prepare("SELECT * FROM $v WHERE pid=? AND $cond" . ($this->Database->fieldExists('sorting', $v) ? " ORDER BY sorting" : ""))
+					$objCTable = $this->Database->prepare("SELECT * FROM $v WHERE pid=? AND $cond" . ($this->Database->fieldExists('sorting', $v) ? " ORDER BY sorting, id" : ""))
 												->execute($id, $table);
 				}
 				else
 				{
-					$objCTable = $this->Database->prepare("SELECT * FROM $v WHERE pid=?" . ($this->Database->fieldExists('sorting', $v) ? " ORDER BY sorting" : ""))
+					$objCTable = $this->Database->prepare("SELECT * FROM $v WHERE pid=?" . ($this->Database->fieldExists('sorting', $v) ? " ORDER BY sorting, id" : ""))
 												->execute($id);
 				}
 
@@ -1204,7 +1204,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 
 					if ($limit > 0)
 					{
-						$objInsertAfter = $this->Database->prepare("SELECT id FROM " . $this->strTable . " WHERE pid=? ORDER BY sorting")
+						$objInsertAfter = $this->Database->prepare("SELECT id FROM " . $this->strTable . " WHERE pid=? ORDER BY sorting, id")
 														 ->limit(1, $limit - 1)
 														 ->execute($pid);
 
@@ -1232,7 +1232,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 						// Resort if the new sorting value is not an integer or smaller than 1
 						if (($curSorting % 2) != 0 || $curSorting < 1)
 						{
-							$objNewSorting = $this->Database->prepare("SELECT id FROM " . $this->strTable . " WHERE pid=? ORDER BY sorting")
+							$objNewSorting = $this->Database->prepare("SELECT id FROM " . $this->strTable . " WHERE pid=? ORDER BY sorting, id")
 															->execute($pid);
 
 							$count = 2;
@@ -1289,7 +1289,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 								{
 									$count = 1;
 
-									$objNewSorting = $this->Database->prepare("SELECT id, sorting FROM " . $this->strTable . " WHERE pid=? ORDER BY sorting")
+									$objNewSorting = $this->Database->prepare("SELECT id, sorting FROM " . $this->strTable . " WHERE pid=? ORDER BY sorting, id")
 																	->execute($newPID);
 
 									while ($objNewSorting->next())
@@ -1395,7 +1395,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 						{
 							$count = 1;
 
-							$objNewSorting = $this->Database->execute("SELECT id, sorting FROM " . $this->strTable . " ORDER BY sorting");
+							$objNewSorting = $this->Database->execute("SELECT id, sorting FROM " . $this->strTable . " ORDER BY sorting, id");
 
 							while ($objNewSorting->next())
 							{
@@ -3555,12 +3555,12 @@ class DC_Table extends DataContainer implements \listable, \editable
 
 			if ($fld == 'id')
 			{
-				$objRoot = $this->Database->prepare("SELECT id FROM " . $this->strTable . " WHERE " . implode(' AND ', $this->procedure) . ($blnHasSorting ? " ORDER BY sorting" : ""))
+				$objRoot = $this->Database->prepare("SELECT id FROM " . $this->strTable . " WHERE " . implode(' AND ', $this->procedure) . ($blnHasSorting ? " ORDER BY sorting, id" : ""))
 										  ->execute($this->values);
 			}
 			elseif ($blnHasSorting)
 			{
-				$objRoot = $this->Database->prepare("SELECT pid, (SELECT sorting FROM " . $table . " WHERE " . $this->strTable . ".pid=" . $table . ".id) AS psort FROM " . $this->strTable . " WHERE " . implode(' AND ', $this->procedure) . " GROUP BY pid ORDER BY psort")
+				$objRoot = $this->Database->prepare("SELECT pid, (SELECT sorting FROM " . $table . " WHERE " . $this->strTable . ".pid=" . $table . ".id) AS psort FROM " . $this->strTable . " WHERE " . implode(' AND ', $this->procedure) . " GROUP BY pid ORDER BY psort, pid")
 										  ->execute($this->values);
 			}
 			else
@@ -3791,7 +3791,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 		$arrIds = array();
 
 		// Get records
-		$objRows = $this->Database->prepare("SELECT id FROM " . $table . " WHERE pid=?" . ($hasSorting ? " ORDER BY sorting" : ""))
+		$objRows = $this->Database->prepare("SELECT id FROM " . $table . " WHERE pid=?" . ($hasSorting ? " ORDER BY sorting, id" : ""))
 								  ->execute($id);
 
 		while ($objRows->next())
@@ -3879,7 +3879,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 		{
 			if ($this->strTable != $table || $GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] == 5)
 			{
-				$objChilds = $this->Database->prepare("SELECT id FROM " . $table . " WHERE pid=?" . (!empty($arrFound) ? " AND id IN(" . implode(',', array_map('\intval', $arrFound)) . ")" : '') . ($blnHasSorting ? " ORDER BY sorting" : ''))
+				$objChilds = $this->Database->prepare("SELECT id FROM " . $table . " WHERE pid=?" . (!empty($arrFound) ? " AND id IN(" . implode(',', array_map('\intval', $arrFound)) . ")" : '') . ($blnHasSorting ? " ORDER BY sorting, id" : ''))
 											->execute($id);
 
 				if ($objChilds->numRows)
@@ -4078,12 +4078,12 @@ class DC_Table extends DataContainer implements \listable, \editable
 				$arrValues = $this->values;
 				array_unshift($arrValues, $id);
 
-				$objChilds = $this->Database->prepare("SELECT id FROM " . $this->strTable . " WHERE pid=? AND " . (implode(' AND ', $this->procedure)) . ($blnHasSorting ? " ORDER BY sorting" : ''))
+				$objChilds = $this->Database->prepare("SELECT id FROM " . $this->strTable . " WHERE pid=? AND " . (implode(' AND ', $this->procedure)) . ($blnHasSorting ? " ORDER BY sorting, id" : ''))
 											->execute($arrValues);
 			}
 			else
 			{
-				$objChilds = $this->Database->prepare("SELECT id FROM " . $this->strTable . " WHERE pid=?" . ($blnHasSorting ? " ORDER BY sorting" : ''))
+				$objChilds = $this->Database->prepare("SELECT id FROM " . $this->strTable . " WHERE pid=?" . ($blnHasSorting ? " ORDER BY sorting, id" : ''))
 											->execute($id);
 			}
 
@@ -4408,7 +4408,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 					}
 				}
 
-				$query .= " ORDER BY " . implode(', ', $orderBy);
+				$query .= " ORDER BY " . implode(', ', $orderBy) . ', id'; // Always force deterministic order for pagination reasons, see #5077
 			}
 
 			$objOrderByStmt = $this->Database->prepare($query);
@@ -4775,7 +4775,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 				$firstOrderBy = 'pid';
 				$showFields = $GLOBALS['TL_DCA'][$table]['list']['label']['fields'];
 
-				$query .= " ORDER BY (SELECT " . Database::quoteIdentifier($showFields[0]) . " FROM " . $this->ptable . " WHERE " . $this->ptable . ".id=" . $this->strTable . ".pid), " . implode(', ', $orderBy);
+				$query .= " ORDER BY (SELECT " . Database::quoteIdentifier($showFields[0]) . " FROM " . $this->ptable . " WHERE " . $this->ptable . ".id=" . $this->strTable . ".pid), " . implode(', ', $orderBy) . ', id';  // Always force deterministic order for pagination reasons, see #5077
 
 				// Set the foreignKey so that the label is translated
 				if (!$GLOBALS['TL_DCA'][$table]['fields']['pid']['foreignKey'])
@@ -4789,7 +4789,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 			}
 			else
 			{
-				$query .= " ORDER BY " . implode(', ', $orderBy);
+				$query .= " ORDER BY " . implode(', ', $orderBy) . ', id'; // Always force deterministic order for pagination reasons, see #5077
 			}
 		}
 

--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -4408,7 +4408,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 					}
 				}
 
-				$query .= " ORDER BY " . implode(', ', $orderBy) . ', id'; // Always force deterministic order for pagination reasons, see #5077
+				$query .= " ORDER BY " . implode(', ', $orderBy) . ', id';
 			}
 
 			$objOrderByStmt = $this->Database->prepare($query);
@@ -4775,7 +4775,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 				$firstOrderBy = 'pid';
 				$showFields = $GLOBALS['TL_DCA'][$table]['list']['label']['fields'];
 
-				$query .= " ORDER BY (SELECT " . Database::quoteIdentifier($showFields[0]) . " FROM " . $this->ptable . " WHERE " . $this->ptable . ".id=" . $this->strTable . ".pid), " . implode(', ', $orderBy) . ', id';  // Always force deterministic order for pagination reasons, see #5077
+				$query .= " ORDER BY (SELECT " . Database::quoteIdentifier($showFields[0]) . " FROM " . $this->ptable . " WHERE " . $this->ptable . ".id=" . $this->strTable . ".pid), " . implode(', ', $orderBy) . ', id';
 
 				// Set the foreignKey so that the label is translated
 				if (!$GLOBALS['TL_DCA'][$table]['fields']['pid']['foreignKey'])
@@ -4789,7 +4789,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 			}
 			else
 			{
-				$query .= " ORDER BY " . implode(', ', $orderBy) . ', id'; // Always force deterministic order for pagination reasons, see #5077
+				$query .= " ORDER BY " . implode(', ', $orderBy) . ', id';
 			}
 		}
 


### PR DESCRIPTION
Currently, the `DC_Table` pagination might be broken, if you apply a filter on a non-unique field as the databases are not forced to return a deterministic order within all the results that share the same result.
See example database queries:

![30_30](https://user-images.githubusercontent.com/481937/182550937-b001a9b5-7d32-4c63-bebb-98f57e4bc8fd.png)
![60_30](https://user-images.githubusercontent.com/481937/182550947-e7ebd363-408c-48c3-b14a-ce1ad8750ccc.png)

That’s because `course_day` is not a unique field. All that was done is configuring the DCA to sort by `course_day` in the back end and now the same course is displayed on both, pages 2 and 3.

Many courses happen on the very same day so if you `ORDER BY course_day` only, you get a correct order overall but you are never guaranteed to always get the same order of rows within all the entries that share the same date. That’s because `DC_Table` did not ask for it. Databases are explicitly allowed to return random orders within all of the entries that have the **exact same** `course_day` value here. That allows them to apply additional file sort optimizations. While this was always true, I think MySQL did not have any such optimization in place until version 5.7 (and I suppose in MariaDB it landed as well at some point) and also, those optimizations only seem to kick in with a certain amount of database entries. So it might very well be the case that it always worked for most of our users even though the queries were always indeterministic.

You can read more on the subject here: https://dev.mysql.com/doc/refman/5.7/en/order-by-optimization.html

The solution is actually rather simple. We just always have to add `id` to the `ORDER BY` clause as well. That way, it's ordered by the value we want and within that set, it's always deterministc as it's ordered by ID there.
I also applied the fix to all the `ORDER BY sorting` queries because that is not unique either.