### PR TITLE
Add the removed count increment again

### DIFF
--- a/news-bundle/contao/modules/ModuleNews.php
+++ b/news-bundle/contao/modules/ModuleNews.php
@@ -283,7 +283,7 @@ abstract class ModuleNews extends Module
 
 		foreach ($objArticles as $objArticle)
 		{
-			$arrArticles[] = $this->parseArticle($objArticle, $blnAddArchive, '', $count);
+			$arrArticles[] = $this->parseArticle($objArticle, $blnAddArchive, '', ++$count);
 		}
 
 		return $arrArticles;


### PR DESCRIPTION
In #4178 we accidentally removed the increment for the `$count` variable from the news.