### PR TITLE
Show the video URL in the backend preview

### DIFF
--- a/core-bundle/contao/templates/_new/content_element/_video.html.twig
+++ b/core-bundle/contao/templates/_new/content_element/_video.html.twig
@@ -12,10 +12,14 @@
             {{ block('splash_screen_component') }}
         {% else %}
             {% block iframe %}
-                {% set iframe_attrs = attrs({width, height, src: source.url, allowfullscreen: true})
-                    .mergeWith(iframe_attrs|default)
-                %}
-                <iframe{{ iframe_attrs }}></iframe>
+                {% if as_editor_view %}
+                    <p><a href="{{ source.base_url }}" target="_blank" rel="noreferrer noopener">{{ source.base_url }}</a></p>
+                {% else %}
+                    {% set iframe_attrs = attrs({width, height, src: source.url, allowfullscreen: true})
+                        .mergeWith(iframe_attrs|default)
+                    %}
+                    <iframe{{ iframe_attrs }}></iframe>
+                {% endif %}
             {% endblock %}
         {% endif %}
 

--- a/core-bundle/contao/templates/_new/content_element/_video.html.twig
+++ b/core-bundle/contao/templates/_new/content_element/_video.html.twig
@@ -7,30 +7,31 @@
     {% set video_attributes = attrs(video_attributes|default)
         .addClass('aspect aspect--' ~ aspect_ratio, aspect_ratio)
     %}
-    <figure{{ video_attributes }}>
-        {% if splash_image %}
-            {{ block('splash_screen_component') }}
-        {% else %}
-            {% block iframe %}
-                {% if as_editor_view %}
-                    <p><a href="{{ source.base_url }}" target="_blank" rel="noreferrer noopener">{{ source.base_url }}</a></p>
-                {% else %}
+
+    {% if as_editor_view %}
+        <p><a href="{{ source.base_url }}" target="_blank" rel="noreferrer noopener">{{ source.base_url }}</a></p>
+    {% else %}
+        <figure{{ video_attributes }}>
+            {% if splash_image %}
+                {{ block('splash_screen_component') }}
+            {% else %}
+                {% block iframe %}
                     {% set iframe_attrs = attrs({width, height, src: source.url, allowfullscreen: true})
                         .mergeWith(iframe_attrs|default)
                     %}
                     <iframe{{ iframe_attrs }}></iframe>
+                {% endblock %}
+            {% endif %}
+
+            {% block video_caption %}
+                {% if caption %}
+                    <figcaption{{ attrs(video_caption_attributes|default) }}>
+                        {{- caption|insert_tag_raw -}}
+                    </figcaption>
                 {% endif %}
             {% endblock %}
-        {% endif %}
-
-        {% block video_caption %}
-            {% if caption %}
-                <figcaption{{ attrs(video_caption_attributes|default) }}>
-                    {{- caption|insert_tag_raw -}}
-                </figcaption>
-            {% endif %}
-        {% endblock %}
-    </figure>
+        </figure>
+    {% endif %}
 {% endblock %}
 
 {% block splash_screen_button_content %}


### PR DESCRIPTION
Fix #5078 

<img width="1179" alt="Bildschirmfoto 2022-08-04 um 08 42 38" src="https://user-images.githubusercontent.com/754921/182780842-408d94de-d9af-4248-ac0a-a10f27fb9148.png">

