### PR TITLE
Fix compatibility with doctrine/dbal 3.3.8

### DIFF
--- a/core-bundle/tests/Migration/CommandCompilerTest.php
+++ b/core-bundle/tests/Migration/CommandCompilerTest.php
@@ -16,7 +16,6 @@ use Contao\CoreBundle\Doctrine\Schema\SchemaProvider;
 use Contao\CoreBundle\Migration\CommandCompiler;
 use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\Platforms\MySQL\Comparator;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Schema\MySQLSchemaManager;
 use Doctrine\DBAL\Schema\Schema;
@@ -492,7 +491,7 @@ class CommandCompilerTest extends TestCase
     private function getInstaller(Schema $fromSchema = null, Schema $toSchema = null, array $tables = [], string $filePerTable = 'ON'): CommandCompiler
     {
         $platform = new MySQLPlatform();
-        $comparator = new Comparator($platform);
+        $comparator = (new MySQLSchemaManager($this->createMock(Connection::class), $platform))->createComparator();
 
         $schemaManager = $this->createMock(MySQLSchemaManager::class);
         $schemaManager


### PR DESCRIPTION
See https://github.com/doctrine/dbal/blob/f873a820227bc352d023791775a01f078a30dfe1/src/Platforms/MySQL/Comparator.php#L25

```
     * @internal The comparator can be only instantiated by a schema manager.
```