### PR TITLE
Don’t use deprecated getIdentifierQuoteCharacter()

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Database.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Database.php
@@ -711,20 +711,7 @@ class Database
 	 */
 	public static function quoteIdentifier($strName)
 	{
-		static $strQuoteCharacter = null;
-
-		if ($strQuoteCharacter === null)
-		{
-			$strQuoteCharacter = System::getContainer()->get('database_connection')->getDatabasePlatform()->getIdentifierQuoteCharacter();
-		}
-
-		// The identifier is quoted already
-		if (strncmp($strName, $strQuoteCharacter, 1) === 0)
-		{
-			return $strName;
-		}
-
-		// Not an identifier (AbstractPlatform::quoteIdentifier() handles table.column so also allow . here)
+		// Quoted already or not an identifier (AbstractPlatform::quoteIdentifier() handles table.column so also allow . here)
 		if (!preg_match('/^[A-Za-z0-9_$.]+$/', $strName))
 		{
 			return $strName;

--- a/core-bundle/tests/Contao/ModuleTest.php
+++ b/core-bundle/tests/Contao/ModuleTest.php
@@ -26,7 +26,6 @@ use Contao\Module;
 use Contao\PageModel;
 use Contao\System;
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Filesystem\Filesystem;
 
@@ -38,18 +37,7 @@ class ModuleTest extends TestCase
     {
         parent::setUp();
 
-        $platform = $this->createMock(AbstractPlatform::class);
-        $platform
-            ->method('getIdentifierQuoteCharacter')
-            ->willReturn('\'')
-        ;
-
         $connection = $this->createMock(Connection::class);
-        $connection
-            ->method('getDatabasePlatform')
-            ->willReturn($platform)
-        ;
-
         $connection
             ->method('quoteIdentifier')
             ->willReturnArgument(0)

--- a/core-bundle/tests/Contao/PageModelTest.php
+++ b/core-bundle/tests/Contao/PageModelTest.php
@@ -27,7 +27,6 @@ use Contao\Model\Registry;
 use Contao\PageModel;
 use Contao\System;
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Filesystem\Filesystem;
 
@@ -41,18 +40,7 @@ class PageModelTest extends TestCase
 
         $GLOBALS['TL_MODELS']['tl_page'] = PageModel::class;
 
-        $platform = $this->createMock(AbstractPlatform::class);
-        $platform
-            ->method('getIdentifierQuoteCharacter')
-            ->willReturn('\'')
-        ;
-
         $connection = $this->createMock(Connection::class);
-        $connection
-            ->method('getDatabasePlatform')
-            ->willReturn($platform)
-        ;
-
         $connection
             ->method('quoteIdentifier')
             ->willReturnArgument(0)


### PR DESCRIPTION
Was deprecated in doctrine/dbal 3.4.0, see https://github.com/doctrine/dbal/commit/221bd8320740a7e4d7c99050d9493ec85c5c6382