### PR TITLE
Do not override manually defined ptable configuration

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/DcaLoader.php
+++ b/core-bundle/src/Resources/contao/library/Contao/DcaLoader.php
@@ -203,7 +203,7 @@ class DcaLoader extends Controller
 	 */
 	private function setDynamicPTable(): void
 	{
-		if (!($GLOBALS['TL_DCA'][$this->strTable]['config']['dynamicPtable'] ?? null) || !isset($GLOBALS['BE_MOD']))
+		if (!($GLOBALS['TL_DCA'][$this->strTable]['config']['dynamicPtable'] ?? null) || !isset($GLOBALS['BE_MOD']) || isset($GLOBALS['TL_DCA'][$this->strTable]['config']['ptable']))
 		{
 			return;
 		}


### PR DESCRIPTION
Since https://github.com/contao/contao/pull/1446 the ptable configuration is always overriden. The default algorithm assumes that only one table defines a ptable in the same backend module. But if I have following table structure `tl_root > tl_parent > tl_child` and both `tl_root` and `tl_child` refers to `tl_example` this does not work. 

Therefore checking if the ptable if configured manually is required.