### PR TITLE
Allow subpalettes based on value 0 in case of selects

### DIFF
--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -3316,9 +3316,9 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 						}
 					}
 
-					if ($trigger)
+					if (($GLOBALS['TL_DCA'][$this->strTable]['fields'][$name]['inputType'] ?? null) == 'checkbox' && !($GLOBALS['TL_DCA'][$this->strTable]['fields'][$name]['eval']['multiple'] ?? null))
 					{
-						if (($GLOBALS['TL_DCA'][$this->strTable]['fields'][$name]['inputType'] ?? null) == 'checkbox' && !($GLOBALS['TL_DCA'][$this->strTable]['fields'][$name]['eval']['multiple'] ?? null))
+						if ($trigger)
 						{
 							$sValues[] = $name;
 
@@ -3328,16 +3328,16 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 								$subpalettes[$name] = $GLOBALS['TL_DCA'][$this->strTable]['subpalettes'][$name];
 							}
 						}
-						else
-						{
-							$sValues[] = $trigger;
-							$key = $name . '_' . $trigger;
+					}
+					else
+					{
+						$sValues[] = $trigger;
+						$key = $name . '_' . $trigger;
 
-							// Look for a subpalette
-							if (isset($GLOBALS['TL_DCA'][$this->strTable]['subpalettes'][$key]))
-							{
-								$subpalettes[$name] = $GLOBALS['TL_DCA'][$this->strTable]['subpalettes'][$key];
-							}
+						// Look for a subpalette
+						if (isset($GLOBALS['TL_DCA'][$this->strTable]['subpalettes'][$key]))
+						{
+							$subpalettes[$name] = $GLOBALS['TL_DCA'][$this->strTable]['subpalettes'][$key];
 						}
 					}
 				}


### PR DESCRIPTION
I have the problem, that I want to show additional fields in a datacontainer, when the user selects a blank option generated with the eval 'includeBlankOption'.

In this case I have a list of locations from another table.

![image](https://user-images.githubusercontent.com/87128053/183769915-717910ac-441b-49f7-981e-b7d6223143e5.png)

When no location is selected, the user should have the option to enter a custom location.

![image](https://user-images.githubusercontent.com/87128053/183769964-808d407d-22bb-4659-8463-d9c5c8ff78ea.png)

The object for the field looks like this.

```php
'home' => [
    'inputType'              => 'select',
    'foreignKey'             => 'tl_gs_home.name',
    'eval'                   => [
        'submitOnChange'     => true,
        'includeBlankOption' => true,
        'tl_class'           => 'clr w50'
    ],
    'sql'                    => "int(10) unsigned NOT NULL default '0'",
]
```

The option 'includeBlankOption' generates an option without a value which results in a int(0) when selected. So the subpalette would look like this.

```php
'subpalettes' => [
    'home_0'                    => 'street,housenumber,zipcode,city'
]
```

The problem is, that I cannot define a subpalette for this case because the complete logic is wrapped in an if statement checking for the value ($trigger) which is false, when the value is 0.

https://github.com/contao/contao/blob/12c7f37523f4f4bfedaaccb1b322ade711dab52c/core-bundle/src/Resources/contao/drivers/DC_Table.php#L3319-L3342

It would be great, if 0 would be allowed in case of selects by using the if statement only in case of a checkbox.

It seems, there is no workaround at the moment. I tried to use the callback "fields.home.options" to generate a select with "none" instead of "0", used callback "fields.home.save" to convert "none" to "0" when writing to database and used callback "fields.home.load" to convert "0" back to "none" when reading from database.

Unfortunately the load callback is completely ignored because the value comes directly from the database.

https://github.com/contao/contao/blob/12c7f37523f4f4bfedaaccb1b322ade711dab52c/core-bundle/src/Resources/contao/drivers/DC_Table.php#L3297-L3299
