### PR TITLE
Fix member registration issues

### DIFF
--- a/core-bundle/contao/models/OptInModel.php
+++ b/core-bundle/contao/models/OptInModel.php
@@ -102,7 +102,7 @@ class OptInModel extends Model
 		$objDatabase = Database::getInstance();
 
 		$objResult = $objDatabase->prepare("SELECT * FROM $t WHERE $t.id IN (SELECT pid FROM tl_opt_in_related WHERE relTable=? AND relId IN(" . implode(',', array_map('\intval', $arrIds)) . ")) ORDER BY $t.createdOn DESC")
-								 ->execute($strTable, $arrIds);
+								 ->execute($strTable);
 
 		if ($objResult->numRows < 1)
 		{

--- a/core-bundle/contao/modules/ModuleRegistration.php
+++ b/core-bundle/contao/modules/ModuleRegistration.php
@@ -464,7 +464,7 @@ class ModuleRegistration extends Module
 			// Make sure newsletter is an array
 			if (!\is_array($arrData['newsletter'] ?? null))
 			{
-				if ($arrData['newsletter'])
+				if ($arrData['newsletter'] ?? null)
 				{
 					$arrData['newsletter'] = array($arrData['newsletter']);
 				}

--- a/core-bundle/contao/modules/ModuleRegistration.php
+++ b/core-bundle/contao/modules/ModuleRegistration.php
@@ -462,17 +462,7 @@ class ModuleRegistration extends Module
 		if (isset($bundles['ContaoNewsletterBundle']))
 		{
 			// Make sure newsletter is an array
-			if (!\is_array($arrData['newsletter'] ?? null))
-			{
-				if ($arrData['newsletter'] ?? null)
-				{
-					$arrData['newsletter'] = array($arrData['newsletter']);
-				}
-				else
-				{
-					$arrData['newsletter'] = array();
-				}
-			}
+			$arrData['newsletter'] = (array) ($arrData['newsletter'] ?? null);
 
 			// Replace the wildcard
 			if (!empty($arrData['newsletter']))


### PR DESCRIPTION
This PR fixes the following issues:

```
ErrorException:
Warning: Undefined array key "newsletter"

  at vendor\contao\contao\core-bundle\contao\modules\ModuleRegistration.php:467
  at Contao\ModuleRegistration->sendActivationMail(array('email' => 'foo@example.com', 'username' => 'foo@example.com', 'password' => '...', 'tstamp' => 1660153021, 'login' => true, 'dateAdded' => 1660153021, 'groups' => 'a:1:{i:0;s:1:"1";}', 'disable' => 1, 'id' => 4))
     (vendor\contao\contao\core-bundle\contao\modules\ModuleRegistration.php:380)
  at Contao\ModuleRegistration->createNewUser(array('email' => 'foo@example.com', 'username' => 'foo@example.com', 'password' => '...', 'tstamp' => 1660153021, 'login' => true, 'dateAdded' => 1660153021, 'groups' => 'a:1:{i:0;s:1:"1";}', 'disable' => 1, 'id' => 4))
     (vendor\contao\contao\core-bundle\contao\modules\ModuleRegistration.php:322)
  at Contao\ModuleRegistration->compile()
     (vendor\contao\contao\core-bundle\contao\modules\Module.php:213)
  at Contao\Module->generate()
     (vendor\contao\contao\core-bundle\contao\modules\ModuleRegistration.php:55)
```

(side note: we should probably move this to the `newsletter-bundle` at some point, if possible)

```
Doctrine\DBAL\Exception\DriverException:
An exception occurred while executing a query: SQLSTATE[HY093]: Invalid parameter number: number of bound variables does not match number of tokens

  at vendor\doctrine\dbal\src\Driver\API\MySQL\ExceptionConverter.php:119
  at Doctrine\DBAL\Driver\API\MySQL\ExceptionConverter->convert(object(Exception), object(Query))
     (vendor\doctrine\dbal\src\Connection.php:1822)
  at Doctrine\DBAL\Connection->handleDriverException(object(Exception), object(Query))
     (vendor\doctrine\dbal\src\Connection.php:1763)
  at Doctrine\DBAL\Connection->convertExceptionDuringQuery(object(Exception), 'SELECT * FROM tl_opt_in WHERE tl_opt_in.id IN (SELECT pid FROM tl_opt_in_related WHERE relTable=? AND relId IN(6)) ORDER BY tl_opt_in.createdOn DESC', array('tl_member', 'a:1:{i:0;i:6;}'), array())
     (vendor\doctrine\dbal\src\Connection.php:1034)
  at Doctrine\DBAL\Connection->executeQuery('SELECT * FROM tl_opt_in WHERE tl_opt_in.id IN (SELECT pid FROM tl_opt_in_related WHERE relTable=? AND relId IN(6)) ORDER BY tl_opt_in.createdOn DESC', array('tl_member', 'a:1:{i:0;i:6;}'), array())
     (vendor\contao\contao\core-bundle\contao\library\Contao\Database\Statement.php:268)
  at Contao\Database\Statement->query('', array('tl_member', 'a:1:{i:0;i:6;}'))
     (vendor\contao\contao\core-bundle\contao\library\Contao\Database\Statement.php:222)
  at Contao\Database\Statement->execute('tl_member', array(6))
     (vendor\contao\contao\core-bundle\contao\models\OptInModel.php:105)
  at Contao\OptInModel::findByRelatedTableAndIds('tl_member', array(6))
     (vendor\contao\contao\core-bundle\src\Framework\Adapter.php:40)
  at Contao\CoreBundle\Framework\Adapter->__call('findByRelatedTableAndIds', array('tl_member', array(6)))
     (vendor\contao\contao\core-bundle\src\OptIn\OptInToken.php:66)
  at Contao\CoreBundle\OptIn\OptInToken->confirm()
     (vendor\contao\contao\core-bundle\contao\modules\ModuleRegistration.php:534)
```

Fixes #5114