### PR TITLE
Remove leftover code in the DataContainer class

### DIFF
--- a/core-bundle/src/Resources/contao/classes/DataContainer.php
+++ b/core-bundle/src/Resources/contao/classes/DataContainer.php
@@ -360,6 +360,8 @@ abstract class DataContainer extends Backend
 					$newPaletteFields[$k] = $v . '_' . $suffix;
 				}
 
+				$this->import(BackendUser::class, 'User');
+
 				if ($this->User->isAdmin)
 				{
 					$newPaletteFields['pid'] = 'pid_' . $suffix;

--- a/core-bundle/src/Resources/contao/classes/DataContainer.php
+++ b/core-bundle/src/Resources/contao/classes/DataContainer.php
@@ -359,14 +359,6 @@ abstract class DataContainer extends Backend
 				{
 					$newPaletteFields[$k] = $v . '_' . $suffix;
 				}
-
-				$this->import(BackendUser::class, 'User');
-
-				if ($this->User->isAdmin)
-				{
-					$newPaletteFields['pid'] = 'pid_' . $suffix;
-					$newPaletteFields['sorting'] = 'sorting_' . $suffix;
-				}
 			}
 
 			$paletteFields = array_intersect($postPaletteFields, $newPaletteFields);


### PR DESCRIPTION
Fixes #4969

`DataContainer::row` uses `$this->User->isAdmin` on form submit - however at this stage the `BackendUser` instance is not imported yet.