### PR TITLE
Only set login constants in master request

### DIFF
--- a/core-bundle/src/EventListener/LegacyLoginConstantsListener.php
+++ b/core-bundle/src/EventListener/LegacyLoginConstantsListener.php
@@ -34,6 +34,10 @@ class LegacyLoginConstantsListener
 
     public function __invoke(RequestEvent $event): void
     {
+        if (!$event->isMasterRequest()) {
+            return;
+        }
+
         $this->framework->setLoginConstants();
     }
 }

--- a/core-bundle/src/Framework/ContaoFramework.php
+++ b/core-bundle/src/Framework/ContaoFramework.php
@@ -186,6 +186,10 @@ class ContaoFramework implements ContaoFrameworkInterface, ContainerAwareInterfa
      */
     public function setLoginConstants(): void
     {
+        if (\defined('BE_USER_LOGGED_IN') || \defined('FE_USER_LOGGED_IN')) {
+            return;
+        }
+
         // If the framework has not been initialized yet, set the login constants on init (#4968)
         if (!$this->isInitialized()) {
             $this->setLoginConstantsOnInit = true;

--- a/core-bundle/src/Framework/ContaoFramework.php
+++ b/core-bundle/src/Framework/ContaoFramework.php
@@ -186,6 +186,7 @@ class ContaoFramework implements ContaoFrameworkInterface, ContainerAwareInterfa
      */
     public function setLoginConstants(): void
     {
+        // Check if the constants have already been defined (see #5137)
         if (\defined('BE_USER_LOGGED_IN') || \defined('FE_USER_LOGGED_IN')) {
             return;
         }


### PR DESCRIPTION
This adds a check for the master request in the `LegacyLoginConstantsListener` - otherwise the constants might get set twice in one request due to sub requests, leading to a warning.