### PR TITLE
Fix PHPStorm warning

### DIFF
--- a/core-bundle/src/Command/MigrateCommand.php
+++ b/core-bundle/src/Command/MigrateCommand.php
@@ -551,7 +551,8 @@ class MigrateCommand extends Command
     {
         // TODO: Find a replacement for getWrappedConnection() once doctrine/dbal 4.0 is released
         $driverConnection = $this->connection->getWrappedConnection();
-        $currentPlatform = \get_class($this->connection->getDatabasePlatform());
+        $currentPlatform = $this->connection->getDatabasePlatform();
+        $currentPlatform = $currentPlatform ? \get_class($currentPlatform) : null;
         $driver = $this->connection->getDriver();
 
         if (


### PR DESCRIPTION
See https://github.com/contao/contao/pull/5127#discussion_r944257781

But not sure if this should be merged as I think PHPStorm is wrong here. 
`Connection::getDatabasePlatform()` can never return NULL I think.