### PR TITLE
Do not run the DC constructor inside the picker widget

### DIFF
--- a/core-bundle/src/Resources/contao/widgets/Picker.php
+++ b/core-bundle/src/Resources/contao/widgets/Picker.php
@@ -247,8 +247,8 @@ class Picker extends Widget
 
 			if ($objRows->numRows)
 			{
-				$dataContainer = DataContainer::getDriverForTable($strRelatedTable);
-				$dc = new $dataContainer($strRelatedTable);
+				$dc = (new \ReflectionClass(DataContainer::getDriverForTable($strRelatedTable)))->newInstanceWithoutConstructor();
+				$dc->table = $strRelatedTable;
 
 				while ($objRows->next())
 				{

--- a/core-bundle/src/Resources/contao/widgets/Picker.php
+++ b/core-bundle/src/Resources/contao/widgets/Picker.php
@@ -247,7 +247,9 @@ class Picker extends Widget
 
 			if ($objRows->numRows)
 			{
-				$dc = (new \ReflectionClass(DataContainer::getDriverForTable($strRelatedTable)))->newInstanceWithoutConstructor();
+				$dataContainer = DataContainer::getDriverForTable($strRelatedTable);
+
+				$dc = (new \ReflectionClass($dataContainer))->newInstanceWithoutConstructor();
 				$dc->table = $strRelatedTable;
 
 				while ($objRows->next())


### PR DESCRIPTION
Fixes #3011 (especially the second reproduction from https://github.com/contao/contao/issues/3011#issuecomment-888945467 )

In the picker widget we instantiate a data container just to be able to pass it to callbacks in `renderLabel()`. But this executes load callbacks and permission checks that are then based on the wrong `Input` parameters. Therefore we should not execute the constructor here.