### PR TITLE
Fix loop when loading DCA and BackendUser

### DIFF
--- a/calendar-bundle/contao/dca/tl_calendar_events.php
+++ b/calendar-bundle/contao/dca/tl_calendar_events.php
@@ -181,7 +181,7 @@ $GLOBALS['TL_DCA']['tl_calendar_events'] = array
 		),
 		'author' => array
 		(
-			'default'                 => BackendUser::getInstance()->id,
+			'default'                 => static fn () => BackendUser::getInstance()->id,
 			'search'                  => true,
 			'filter'                  => true,
 			'sorting'                 => true,

--- a/comments-bundle/contao/dca/tl_comments.php
+++ b/comments-bundle/contao/dca/tl_comments.php
@@ -202,7 +202,7 @@ $GLOBALS['TL_DCA']['tl_comments'] = array
 		),
 		'author' => array
 		(
-			'default'                 => BackendUser::getInstance()->id,
+			'default'                 => static fn () => BackendUser::getInstance()->id,
 			'inputType'               => 'select',
 			'foreignKey'              => 'tl_user.name',
 			'eval'                    => array('mandatory'=>true, 'chosen'=>true, 'doNotCopy'=>true, 'includeBlankOption'=>true, 'tl_class'=>'w50'),

--- a/core-bundle/contao/dca/tl_article.php
+++ b/core-bundle/contao/dca/tl_article.php
@@ -195,7 +195,7 @@ $GLOBALS['TL_DCA']['tl_article'] = array
 		),
 		'author' => array
 		(
-			'default'                 => BackendUser::getInstance()->id,
+			'default'                 => static fn () => BackendUser::getInstance()->id,
 			'search'                  => true,
 			'filter'                  => true,
 			'inputType'               => 'select',

--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -636,7 +636,14 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 			// Use array_key_exists here (see #5252)
 			if (\array_key_exists('default', $v))
 			{
-				$this->set[$k] = \is_array($v['default']) ? serialize($v['default']) : $v['default'];
+				$default = $v['default'];
+
+				if ($default instanceof \Closure)
+				{
+					$default = $default($this);
+				}
+
+				$this->set[$k] = \is_array($default) ? serialize($default) : $default;
 			}
 		}
 
@@ -913,7 +920,14 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 						// Use array_key_exists to allow NULL (see #5252)
 						if (\array_key_exists('default', $GLOBALS['TL_DCA'][$this->strTable]['fields'][$k] ?? array()))
 						{
-							$v = \is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['default']) ? serialize($GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['default']) : $GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['default'];
+							$default = $GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['default'];
+
+							if ($default instanceof \Closure)
+							{
+								$default = $default($this);
+							}
+
+							$v = \is_array($default) ? serialize($default) : $default;
 						}
 					}
 
@@ -1109,7 +1123,14 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 							// Use array_key_exists to allow NULL (see #5252)
 							if (\array_key_exists('default', $GLOBALS['TL_DCA'][$v]['fields'][$kk] ?? array()))
 							{
-								$vv = \is_array($GLOBALS['TL_DCA'][$v]['fields'][$kk]['default']) ? serialize($GLOBALS['TL_DCA'][$v]['fields'][$kk]['default']) : $GLOBALS['TL_DCA'][$v]['fields'][$kk]['default'];
+								$default = $GLOBALS['TL_DCA'][$v]['fields'][$kk]['default'];
+
+								if ($default instanceof \Closure)
+								{
+									$default = $default($this);
+								}
+
+								$vv = \is_array($default) ? serialize($default) : $default;
 							}
 						}
 
@@ -2458,7 +2479,14 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 						// Set the default value and try to load the current value from DB (see #5252)
 						if (\array_key_exists('default', $GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField] ?? array()))
 						{
-							$this->varValue = \is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['default']) ? serialize($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['default']) : $GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['default'];
+							$default = $GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['default'];
+
+							if ($default instanceof \Closure)
+							{
+								$default = $default($this);
+							}
+
+							$this->varValue = \is_array($default) ? serialize($default) : $default;
 						}
 
 						if (($currentRecord[$v] ?? null) !== false)

--- a/core-bundle/contao/library/Contao/DcaLoader.php
+++ b/core-bundle/contao/library/Contao/DcaLoader.php
@@ -72,6 +72,11 @@ class DcaLoader extends Controller
 				throw static::$arrLoaded['dcaFiles'][$this->strTable];
 			}
 
+			if (!isset($GLOBALS['TL_DCA'][$this->strTable]))
+			{
+				trigger_deprecation('contao/core-bundle', '5.0', 'Loading a non-existent DCA has has been deprecated and will throw an exception in Contao 6.0.');
+			}
+
 			return;
 		}
 
@@ -86,6 +91,11 @@ class DcaLoader extends Controller
 			static::$arrLoaded['dcaFiles'][$this->strTable] = $e;
 
 			throw $e;
+		}
+
+		if (!isset($GLOBALS['TL_DCA'][$this->strTable]))
+		{
+			trigger_deprecation('contao/core-bundle', '5.0', 'Loading a non-existent DCA has has been deprecated and will throw an exception in Contao 6.0.');
 		}
 	}
 

--- a/faq-bundle/contao/dca/tl_faq.php
+++ b/faq-bundle/contao/dca/tl_faq.php
@@ -132,7 +132,7 @@ $GLOBALS['TL_DCA']['tl_faq'] = array
 		),
 		'author' => array
 		(
-			'default'                 => BackendUser::getInstance()->id,
+			'default'                 => static fn () => BackendUser::getInstance()->id,
 			'search'                  => true,
 			'filter'                  => true,
 			'sorting'                 => true,

--- a/news-bundle/contao/dca/tl_news.php
+++ b/news-bundle/contao/dca/tl_news.php
@@ -170,7 +170,7 @@ $GLOBALS['TL_DCA']['tl_news'] = array
 		),
 		'author' => array
 		(
-			'default'                 => BackendUser::getInstance()->id,
+			'default'                 => static fn () => BackendUser::getInstance()->id,
 			'search'                  => true,
 			'filter'                  => true,
 			'sorting'                 => true,


### PR DESCRIPTION
Fixes #5014

While analyzing the stack trace from https://github.com/contao/contao/issues/5014#issuecomment-1214395708 I saw that loading the `User` object caused a loop:

1. When loading the user the `Contao\Model::convertToPhpValue()` method gets executed
2. This needs the DcaExtractor so it gets loaded which itself loads all DCAs
3. Some DCA files directly call `BackendUser::getInstance()` which loads the user object
4. goto 1

I now created closures for the default values so that this only gets executed on the fly when needed.