### PR TITLE
Allow empty key for subpalette suffix based on select

### DIFF
--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -3226,9 +3226,9 @@ class DC_Table extends DataContainer implements \listable, \editable
 						}
 					}
 
-					if ($trigger)
+					if ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$name]['inputType'] == 'checkbox' && !$GLOBALS['TL_DCA'][$this->strTable]['fields'][$name]['eval']['multiple'])
 					{
-						if ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$name]['inputType'] == 'checkbox' && !$GLOBALS['TL_DCA'][$this->strTable]['fields'][$name]['eval']['multiple'])
+						if ($trigger)
 						{
 							$sValues[] = $name;
 
@@ -3238,16 +3238,16 @@ class DC_Table extends DataContainer implements \listable, \editable
 								$subpalettes[$name] = $GLOBALS['TL_DCA'][$this->strTable]['subpalettes'][$name];
 							}
 						}
-						else
-						{
-							$sValues[] = $trigger;
-							$key = $name . '_' . $trigger;
+					}
+					else
+					{
+						$sValues[] = $trigger;
+						$key = $name . '_' . $trigger;
 
-							// Look for a subpalette
-							if (isset($GLOBALS['TL_DCA'][$this->strTable]['subpalettes'][$key]))
-							{
-								$subpalettes[$name] = $GLOBALS['TL_DCA'][$this->strTable]['subpalettes'][$key];
-							}
+						// Look for a subpalette
+						if (isset($GLOBALS['TL_DCA'][$this->strTable]['subpalettes'][$key]))
+						{
+							$subpalettes[$name] = $GLOBALS['TL_DCA'][$this->strTable]['subpalettes'][$key];
 						}
 					}
 				}


### PR DESCRIPTION
This pull request for contao 4.9 is the equivalent to a pull request for contao 4.13. https://github.com/contao/contao/pull/5112

It allows to set a subpalette for a select field, when the value is empty or 0.