### PR TITLE
Do not define ptable for tl_content

### DIFF
--- a/core-bundle/contao/dca/tl_content.php
+++ b/core-bundle/contao/dca/tl_content.php
@@ -34,7 +34,6 @@ $GLOBALS['TL_DCA']['tl_content'] = array
 	(
 		'dataContainer'               => DC_Table::class,
 		'enableVersioning'            => true,
-		'ptable'                      => 'tl_article',
 		'dynamicPtable'               => true,
 		'markAsCopy'                  => 'headline',
 		'onload_callback'             => array


### PR DESCRIPTION
Fixes #5157

We must not define a `ptable` for `tl_content` here since we no longer define the `ptable` manually. Otherwise automatically determining the `ptable` will not work due to #5108.