### PR TITLE
Allow usages of picker without active record

### DIFF
--- a/core-bundle/src/Resources/contao/classes/Ajax.php
+++ b/core-bundle/src/Resources/contao/classes/Ajax.php
@@ -392,9 +392,9 @@ class Ajax extends Backend
 						}
 					}
 
+					// Keep the previous sorting order when reloading the widget
 					if ($dc->activeRecord)
 					{
-						// Keep the previous sorting order when reloading the widget
 						$varValue = ArrayUtil::sortByOrderField($varValue, $dc->activeRecord->$strField);
 					}
 

--- a/core-bundle/src/Resources/contao/classes/Ajax.php
+++ b/core-bundle/src/Resources/contao/classes/Ajax.php
@@ -392,8 +392,11 @@ class Ajax extends Backend
 						}
 					}
 
-					// Keep the previous sorting order when reloading the widget
-					$varValue = ArrayUtil::sortByOrderField($varValue, $dc->activeRecord->$strField);
+					if ($dc->activeRecord)
+					{
+						// Keep the previous sorting order when reloading the widget
+						$varValue = ArrayUtil::sortByOrderField($varValue, $dc->activeRecord->$strField);
+					}
 
 					$varValue = serialize($varValue);
 				}


### PR DESCRIPTION
Before #2267 it was possible to use the picker outside the context of editing a single database row. E.g. we used it in the filter panel. After that change this is no longer possible as the Ajax class now always expects an active record to be present. This change checks for the existence before trying to access it. 

I know that this might not be a supported use case, however the fix is unobtrusive. 