### PR TITLE
Correctly replace insert tags within links in the markdown element

### DIFF
--- a/core-bundle/src/Controller/ContentElement/MarkdownController.php
+++ b/core-bundle/src/Controller/ContentElement/MarkdownController.php
@@ -14,6 +14,8 @@ namespace Contao\CoreBundle\Controller\ContentElement;
 
 use Contao\Config;
 use Contao\ContentModel;
+use Contao\CoreBundle\InsertTag\CommonMarkExtension;
+use Contao\CoreBundle\InsertTag\InsertTagParser;
 use Contao\FilesModel;
 use Contao\Input;
 use Contao\Template;
@@ -72,6 +74,7 @@ class MarkdownController extends AbstractContentElementController
             ],
         ]);
 
+        $environment->addExtension(new CommonMarkExtension($this->container->get('contao.insert_tag.parser')));
         $environment->addExtension(new CommonMarkCoreExtension());
 
         // Support GitHub flavoured Markdown (using the individual extensions because we don't want the
@@ -107,5 +110,14 @@ class MarkdownController extends AbstractContentElementController
         }
 
         return (string) file_get_contents($path);
+    }
+
+    public static function getSubscribedServices(): array
+    {
+        $services = parent::getSubscribedServices();
+
+        $services['contao.insert_tag.parser'] = InsertTagParser::class;
+
+        return $services;
     }
 }

--- a/core-bundle/src/InsertTag/CommonMarkExtension.php
+++ b/core-bundle/src/InsertTag/CommonMarkExtension.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\InsertTag;
+
+use League\CommonMark\Environment\EnvironmentBuilderInterface;
+use League\CommonMark\Event\DocumentParsedEvent;
+use League\CommonMark\Extension\CommonMark\Node\Inline\Link;
+use League\CommonMark\Extension\ExtensionInterface;
+use League\CommonMark\Util\UrlEncoder;
+
+class CommonMarkExtension implements ExtensionInterface
+{
+    private InsertTagParser $insertTagParser;
+
+    public function __construct(InsertTagParser $insertTagParser)
+    {
+        $this->insertTagParser = $insertTagParser;
+    }
+
+    public function register(EnvironmentBuilderInterface $environment): void
+    {
+        $environment->addEventListener(
+            DocumentParsedEvent::class,
+            function (DocumentParsedEvent $e): void {
+                foreach ($e->getDocument()->iterator() as $link) {
+                    if (!$link instanceof Link) {
+                        continue;
+                    }
+
+                    // Parser already encodes link contents, so we have to decode it first in order to replace
+                    // insert tags
+                    $url = rawurldecode($link->getUrl());
+                    $url = $this->insertTagParser->replaceInline($url);
+                    $link->setUrl(UrlEncoder::unescapeAndEncode($url));
+                }
+            }
+        );
+    }
+}

--- a/core-bundle/src/InsertTag/CommonMarkExtension.php
+++ b/core-bundle/src/InsertTag/CommonMarkExtension.php
@@ -37,10 +37,11 @@ class CommonMarkExtension implements ExtensionInterface
                         continue;
                     }
 
-                    // Parser already encodes link contents, so we have to decode it first in order to replace
-                    // insert tags
+                    // Parser already encodes link contents, so we have to
+                    // decode it first in order to replace insert tags
                     $url = rawurldecode($link->getUrl());
                     $url = $this->insertTagParser->replaceInline($url);
+
                     $link->setUrl(UrlEncoder::unescapeAndEncode($url));
                 }
             }

--- a/core-bundle/tests/Controller/ContentElement/MarkdownControllerTest.php
+++ b/core-bundle/tests/Controller/ContentElement/MarkdownControllerTest.php
@@ -16,6 +16,7 @@ use Contao\ContentModel;
 use Contao\CoreBundle\Cache\EntityCacheTags;
 use Contao\CoreBundle\Controller\ContentElement\MarkdownController;
 use Contao\CoreBundle\Framework\Adapter;
+use Contao\CoreBundle\InsertTag\InsertTagParser;
 use Contao\CoreBundle\Tests\TestCase;
 use Contao\FilesModel;
 use Contao\FrontendTemplate;
@@ -42,6 +43,30 @@ class MarkdownControllerTest extends TestCase
         $contentModel = $this->mockClassWithProperties(ContentModel::class);
         $contentModel->markdownSource = 'sourceText';
         $contentModel->code = '# Headline';
+
+        $controller = new MarkdownController();
+        $controller->setContainer($container);
+        $controller(new Request(), $contentModel, 'main');
+    }
+
+    public function testInsertTagsInLinksAreCorrectlyReplaced(): void
+    {
+        $insertTagParser = $this->createMock(InsertTagParser::class);
+        $insertTagParser
+            ->expects($this->once())
+            ->method('replaceInline')
+            ->with('{{news_url::42}}')
+            ->willReturn('https://contao.org/news-alias that-needs-encoding.html')
+        ;
+
+        $container = $this->mockContainer('<p><a rel="noopener noreferrer" target="_blank" class="external-link" href="https://contao.org/news-alias%20that-needs-encoding.html">My text for my link</a></p>'."\n");
+        $container->set('contao.insert_tag.parser', $insertTagParser);
+
+        $contentModel = $this->mockClassWithProperties(ContentModel::class);
+        $contentModel->markdownSource = 'sourceText';
+        $contentModel->code = '[My text for my link]({{news_url::42}})';
+
+        System::setContainer($container);
 
         $controller = new MarkdownController();
         $controller->setContainer($container);

--- a/core-bundle/tests/InsertTag/CommonMarkExtensionTest.php
+++ b/core-bundle/tests/InsertTag/CommonMarkExtensionTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\InsertTag;
+
+use Contao\CoreBundle\InsertTag\CommonMarkExtension;
+use Contao\CoreBundle\InsertTag\InsertTagParser;
+use League\CommonMark\Environment\Environment;
+use League\CommonMark\Extension\Autolink\AutolinkExtension;
+use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
+use League\CommonMark\Parser\MarkdownParser;
+use League\CommonMark\Renderer\HtmlRenderer;
+use PHPUnit\Framework\TestCase;
+
+class CommonMarkExtensionTest extends TestCase
+{
+    public function testReplacesInsertTags(): void
+    {
+        $insertTagParser = $this->createMock(InsertTagParser::class);
+        $insertTagParser
+            ->expects($this->once())
+            ->method('replaceInline')
+            ->with('{{news_url::42}}')
+            ->willReturn('https://contao.org/news-alias that-needs-encoding.html')
+        ;
+
+        $environment = new Environment();
+        $environment->addExtension(new CommonMarkCoreExtension());
+        $environment->addExtension(new AutolinkExtension());
+        $environment->addExtension(new CommonMarkExtension($insertTagParser));
+
+        $parser = new MarkdownParser($environment);
+        $renderer = new HtmlRenderer($environment);
+
+        $document = $parser->parse('[My text for my link]({{news_url::42}})');
+
+        $html = (string) $renderer->renderDocument($document);
+
+        $this->assertSame('<p><a href="https://contao.org/news-alias%20that-needs-encoding.html">My text for my link</a></p>'."\n", $html);
+    }
+}

--- a/core-bundle/tests/InsertTag/CommonMarkExtensionTest.php
+++ b/core-bundle/tests/InsertTag/CommonMarkExtensionTest.php
@@ -40,7 +40,6 @@ class CommonMarkExtensionTest extends TestCase
 
         $parser = new MarkdownParser($environment);
         $renderer = new HtmlRenderer($environment);
-
         $document = $parser->parse('[My text for my link]({{news_url::42}})');
 
         $html = (string) $renderer->renderDocument($document);


### PR DESCRIPTION
Fixes #4944

Links are automatically encoded and thus not replaced by our insert tag parser.
I moved the logic into our own CommonMark extension so that it can be re-used and easily adjusted in the future when @ausi continues his work on the insert tags parsing. 

Namepace discussed with @ausi too, I think that does make sense :)