### PR TITLE
Fix icons.css compatbility in downloads element

### DIFF
--- a/core-bundle/contao/templates/content_element/download.html.twig
+++ b/core-bundle/contao/templates/content_element/download.html.twig
@@ -1,6 +1,10 @@
 {% extends "@Contao/content_element/_base.html.twig" %}
 {% use "@Contao/component/_download.html.twig" %}
 
+{% if downloads %}
+    {% set attributes = attrs(attributes|default).addClass(['download-element', "ext-#{(downloads|first).file.extension(true)}"]) %}
+{% endif %}
+
 {% block content %}
     {% if downloads %}
         {% with {download: downloads|first} %}{{ block('download_component') }}{% endwith %}

--- a/core-bundle/contao/templates/content_element/downloads.html.twig
+++ b/core-bundle/contao/templates/content_element/downloads.html.twig
@@ -6,6 +6,10 @@
     {% with {items: downloads} %}{{ block('list_component') }}{% endwith %}
 {% endblock %}
 
+{% block list_item_attributes %}
+    {{- attrs(list.item_attributes|default).addClass(['download-element', "ext-#{item.file.extension(true)}"]) -}}
+{% endblock %}
+
 {% block list_item %}
     {% with {download: item} %}{{ block('download_component') }}{% endwith %}
 {% endblock %}

--- a/core-bundle/tests/Controller/ContentElement/DownloadsControllerTest.php
+++ b/core-bundle/tests/Controller/ContentElement/DownloadsControllerTest.php
@@ -36,7 +36,7 @@ class DownloadsControllerTest extends ContentElementTestCase
         );
 
         $expectedOutput = <<<'HTML'
-            <div class="content-download">
+            <div class="download-element ext-jpg content-download">
                 <a href="https://example.com/files/image1.jpg" title="translated(contao_default:MSC.download[image1 title])" type="image/jpg">image1.jpg</a>
             </div>
             HTML;
@@ -62,7 +62,7 @@ class DownloadsControllerTest extends ContentElementTestCase
         );
 
         $expectedOutput = <<<'HTML'
-            <div class="content-download">
+            <div class="download-element ext-jpg content-download">
                 <a href="https://example.com/files/image1.jpg" title="translated(contao_default:MSC.download[Download the file])" type="image/jpg">The file</a>
             </div>
             HTML;
@@ -110,10 +110,10 @@ class DownloadsControllerTest extends ContentElementTestCase
         $expectedOutput = <<<'HTML'
             <div class="content-downloads">
                 <ul>
-                    <li>
+                    <li class="download-element ext-jpg">
                         <a href="https://example.com/files/image1.jpg" title="translated(contao_default:MSC.download[image1 title])" type="image/jpg">image1.jpg</a>
                     </li>
-                    <li>
+                    <li class="download-element ext-jpg">
                         <a href="https://example.com/files/image2.jpg" title="translated(contao_default:MSC.download[image2.jpg])">image2.jpg</a>
                     </li>
                 </ul>


### PR DESCRIPTION
In the layout settings one can enable the “Basic icons” which loads the *icons.css* from https://github.com/contao-components/contao/blob/44abd0b24e5508ff427b7e722ddf6f8617591fc8/css/icons.css

This PR adds the classes that are needed to show the correct download icons next to the download links.