### PR TITLE
Fix download element back end layout

### DIFF
--- a/core-bundle/contao/dca/tl_content.php
+++ b/core-bundle/contao/dca/tl_content.php
@@ -997,6 +997,7 @@ class tl_content extends Backend
 			case 'download':
 			case 'downloads':
 				$GLOBALS['TL_DCA']['tl_content']['fields']['size']['eval']['mandatory'] = true;
+				$GLOBALS['TL_DCA']['tl_content']['fields']['fullsize']['eval']['tl_class'] .= ' m12';
 				break;
 		}
 	}


### PR DESCRIPTION
The checkbox needs an `m12` because it’s next to the image size widget.