### PR TITLE
Fix configuration of TemplateOptionsListener

### DIFF
--- a/core-bundle/config/listener.yaml
+++ b/core-bundle/config/listener.yaml
@@ -215,6 +215,8 @@ services:
             - '@request_stack'
             - ce_
             - Contao\ContentProxy
+        tags:
+            - { name: contao.callback, table: tl_content, target: fields.customTpl.options }
 
     contao.listener.exception_converter:
         class: Contao\CoreBundle\EventListener\ExceptionConverterListener
@@ -341,6 +343,8 @@ services:
             - '@request_stack'
             - mod_
             - Contao\ModuleProxy
+        tags:
+            - { name: contao.callback, table: tl_module, target: fields.customTpl.options }
 
     contao.listener.page_access:
         class: Contao\CoreBundle\EventListener\PageAccessListener

--- a/core-bundle/src/EventListener/DataContainer/TemplateOptionsListener.php
+++ b/core-bundle/src/EventListener/DataContainer/TemplateOptionsListener.php
@@ -13,14 +13,11 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\EventListener\DataContainer;
 
 use Contao\Controller;
-use Contao\CoreBundle\DependencyInjection\Attribute\AsCallback;
 use Contao\CoreBundle\Framework\Adapter;
 use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\DataContainer;
 use Symfony\Component\HttpFoundation\RequestStack;
 
-#[AsCallback(table: 'tl_content', target: 'fields.customTpl.options')]
-#[AsCallback(table: 'tl_module', target: 'fields.customTpl.options')]
 class TemplateOptionsListener
 {
     private array $customTemplates = [];


### PR DESCRIPTION
This reverts #4993

There are two different services, one needs to be tagged for `tl_module` and one for `tl_content`.
Currently the `contao.listener.element_template_options` is tagged with both callbacks and therefore `ce_` instead of `mod_` templates are shown for the custom templates in `tl_module`.