### PR TITLE
Use getCurrentRequest() instead of getMainRequest()

### DIFF
--- a/core-bundle/config/controller.yaml
+++ b/core-bundle/config/controller.yaml
@@ -75,7 +75,6 @@ services:
         arguments:
             - '@contao.image.studio'
             - '@contao.insert_tag.parser'
-            - '@request_stack'
 
     Contao\CoreBundle\Controller\ContentElement\ImagesController:
         arguments:

--- a/core-bundle/src/Asset/ContaoContext.php
+++ b/core-bundle/src/Asset/ContaoContext.php
@@ -27,7 +27,7 @@ class ContaoContext implements ContextInterface
 
     public function getBasePath(): string
     {
-        if (null === ($request = $this->requestStack->getMainRequest())) {
+        if (null === ($request = $this->requestStack->getCurrentRequest())) {
             return '';
         }
 
@@ -49,7 +49,7 @@ class ContaoContext implements ContextInterface
             return $page->loadDetails()->rootUseSSL;
         }
 
-        $request = $this->requestStack->getMainRequest();
+        $request = $this->requestStack->getCurrentRequest();
 
         if (null === $request) {
             return false;
@@ -68,7 +68,7 @@ class ContaoContext implements ContextInterface
 
     private function getPageModel(): PageModel|null
     {
-        $request = $this->requestStack->getMainRequest();
+        $request = $this->requestStack->getCurrentRequest();
 
         if ($request && ($pageModel = $request->attributes->get('pageModel')) instanceof PageModel) {
             return $pageModel;

--- a/core-bundle/src/Controller/ContentElement/HyperlinkController.php
+++ b/core-bundle/src/Controller/ContentElement/HyperlinkController.php
@@ -39,7 +39,7 @@ class HyperlinkController extends AbstractContentElementController
         $href = $this->insertTagParser->replaceInline($model->url);
 
         if (Validator::isRelativeUrl($href)) {
-            $href = $this->requestStack->getMainRequest()?->getBasePath().'/'.$href;
+            $href = $this->requestStack->getCurrentRequest()?->getBasePath().'/'.$href;
         }
 
         $linkAttributes = (new HtmlAttributes())

--- a/core-bundle/src/Controller/ContentElement/HyperlinkController.php
+++ b/core-bundle/src/Controller/ContentElement/HyperlinkController.php
@@ -20,17 +20,13 @@ use Contao\CoreBundle\String\HtmlAttributes;
 use Contao\CoreBundle\Twig\FragmentTemplate;
 use Contao\Validator;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 
 #[AsContentElement(category: 'links')]
 class HyperlinkController extends AbstractContentElementController
 {
-    public function __construct(
-        private readonly Studio $studio,
-        private readonly InsertTagParser $insertTagParser,
-        private readonly RequestStack $requestStack,
-    ) {
+    public function __construct(private readonly Studio $studio, private readonly InsertTagParser $insertTagParser)
+    {
     }
 
     protected function getResponse(FragmentTemplate $template, ContentModel $model, Request $request): Response
@@ -39,7 +35,7 @@ class HyperlinkController extends AbstractContentElementController
         $href = $this->insertTagParser->replaceInline($model->url);
 
         if (Validator::isRelativeUrl($href)) {
-            $href = $this->requestStack->getCurrentRequest()?->getBasePath().'/'.$href;
+            $href = $request->getBasePath().'/'.$href;
         }
 
         $linkAttributes = (new HtmlAttributes())

--- a/core-bundle/src/Csrf/ContaoCsrfTokenManager.php
+++ b/core-bundle/src/Csrf/ContaoCsrfTokenManager.php
@@ -65,7 +65,7 @@ class ContaoCsrfTokenManager extends CsrfTokenManager implements ResetInterface
     public function isTokenValid(CsrfToken $token): bool
     {
         if (
-            ($request = $this->requestStack->getMainRequest())
+            ($request = $this->requestStack->getCurrentRequest())
             && 'POST' === $request->getRealMethod()
             && $this->canSkipTokenValidation($request, $this->csrfCookiePrefix.$token->getId())
         ) {

--- a/core-bundle/src/EventListener/DbafsMetadataSubscriber.php
+++ b/core-bundle/src/EventListener/DbafsMetadataSubscriber.php
@@ -119,7 +119,7 @@ class DbafsMetadataSubscriber implements EventSubscriberInterface
             return $this->defaultLocales;
         }
 
-        $page = $this->requestStack->getMainRequest()?->attributes->get('pageModel');
+        $page = $this->requestStack->getCurrentRequest()?->attributes->get('pageModel');
 
         if (!$page instanceof PageModel) {
             return [];

--- a/core-bundle/src/Filesystem/PublicUri/SymlinkedLocalFilesProvider.php
+++ b/core-bundle/src/Filesystem/PublicUri/SymlinkedLocalFilesProvider.php
@@ -41,7 +41,7 @@ class SymlinkedLocalFilesProvider implements PublicUriProviderInterface
 
     private function getSchemeAndHost(): string
     {
-        if (null === ($request = $this->requestStack->getMainRequest())) {
+        if (null === ($request = $this->requestStack->getCurrentRequest())) {
             return '';
         }
 

--- a/core-bundle/src/Framework/ContaoFramework.php
+++ b/core-bundle/src/Framework/ContaoFramework.php
@@ -88,7 +88,7 @@ class ContaoFramework implements ContainerAwareInterface, ResetInterface
             throw new \LogicException('The service container has not been set.');
         }
 
-        $this->request = $this->requestStack->getMainRequest();
+        $this->request = $this->requestStack->getCurrentRequest();
 
         $this->initializeFramework();
     }

--- a/core-bundle/src/Routing/ResponseContext/CoreResponseContextFactory.php
+++ b/core-bundle/src/Routing/ResponseContext/CoreResponseContextFactory.php
@@ -89,7 +89,7 @@ class CoreResponseContextFactory
 
             // Ensure absolute links
             if (!preg_match('#^https?://#', $url)) {
-                if (!$request = $this->requestStack->getMainRequest()) {
+                if (!$request = $this->requestStack->getCurrentRequest()) {
                     throw new \RuntimeException('The request stack did not contain a request');
                 }
 

--- a/core-bundle/src/Security/Authentication/AccessDecisionManager.php
+++ b/core-bundle/src/Security/Authentication/AccessDecisionManager.php
@@ -43,6 +43,8 @@ class AccessDecisionManager implements AccessDecisionManagerInterface
 
     private function isContaoContext(): bool
     {
+        // Use the main request here because sub-requests cannot have
+        // their own firewall in Symfony
         $request = $this->requestStack->getMainRequest();
 
         if (!$this->firewallMap instanceof FirewallMap || null === $request) {

--- a/core-bundle/src/Security/TwoFactor/TrustedDeviceManager.php
+++ b/core-bundle/src/Security/TwoFactor/TrustedDeviceManager.php
@@ -37,7 +37,7 @@ class TrustedDeviceManager implements TrustedDeviceManagerInterface
             return;
         }
 
-        $userAgent = $this->requestStack->getMainRequest()->headers->get('User-Agent');
+        $userAgent = $this->requestStack->getCurrentRequest()->headers->get('User-Agent');
 
         $parser = Parser::create();
         $parsedUserAgent = $parser->parse($userAgent);

--- a/core-bundle/src/Twig/Runtime/UrlRuntime.php
+++ b/core-bundle/src/Twig/Runtime/UrlRuntime.php
@@ -31,6 +31,6 @@ final class UrlRuntime implements RuntimeExtensionInterface
             return $url;
         }
 
-        return $this->requestStack->getMainRequest()?->getBasePath().'/'.$url;
+        return $this->requestStack->getCurrentRequest()?->getBasePath().'/'.$url;
     }
 }

--- a/core-bundle/tests/Controller/ContentElement/HyperlinkControllerTest.php
+++ b/core-bundle/tests/Controller/ContentElement/HyperlinkControllerTest.php
@@ -14,14 +14,13 @@ namespace Contao\CoreBundle\Tests\Controller\ContentElement;
 
 use Contao\CoreBundle\Controller\ContentElement\HyperlinkController;
 use Contao\StringUtil;
-use Symfony\Component\HttpFoundation\RequestStack;
 
 class HyperlinkControllerTest extends ContentElementTestCase
 {
     public function testOutputsSimpleLink(): void
     {
         $response = $this->renderWithModelData(
-            new HyperlinkController($this->getDefaultStudio(), $this->getDefaultInsertTagParser(), new RequestStack()),
+            new HyperlinkController($this->getDefaultStudio(), $this->getDefaultInsertTagParser()),
             [
                 'type' => 'hyperlink',
                 'url' => 'my-link.html',
@@ -47,7 +46,7 @@ class HyperlinkControllerTest extends ContentElementTestCase
     public function testOutputsLinkWithBeforeAndAfterText(): void
     {
         $response = $this->renderWithModelData(
-            new HyperlinkController($this->getDefaultStudio(), $this->getDefaultInsertTagParser(), new RequestStack()),
+            new HyperlinkController($this->getDefaultStudio(), $this->getDefaultInsertTagParser()),
             [
                 'type' => 'hyperlink',
                 'url' => 'https://www.php.net/manual/en/function.sprintf.php',
@@ -74,7 +73,7 @@ class HyperlinkControllerTest extends ContentElementTestCase
     public function testOutputsImageLink(): void
     {
         $response = $this->renderWithModelData(
-            new HyperlinkController($this->getDefaultStudio(), $this->getDefaultInsertTagParser(), new RequestStack()),
+            new HyperlinkController($this->getDefaultStudio(), $this->getDefaultInsertTagParser()),
             [
                 'type' => 'hyperlink',
                 'url' => 'foo.html#{{demo}}',

--- a/core-bundle/tests/EventListener/DbafsMetadataSubscriberTest.php
+++ b/core-bundle/tests/EventListener/DbafsMetadataSubscriberTest.php
@@ -89,7 +89,7 @@ class DbafsMetadataSubscriberTest extends TestCase
 
         $requestStack = $this->createMock(RequestStack::class);
         $requestStack
-            ->method('getMainRequest')
+            ->method('getCurrentRequest')
             ->willReturn($request)
         ;
 

--- a/core-bundle/tests/Filesystem/PublicUri/SymlinkedLocalFilesProviderTest.php
+++ b/core-bundle/tests/Filesystem/PublicUri/SymlinkedLocalFilesProviderTest.php
@@ -32,7 +32,7 @@ class SymlinkedLocalFilesProviderTest extends TestCase
 
         $requestStack = $this->createMock(RequestStack::class);
         $requestStack
-            ->method('getMainRequest')
+            ->method('getCurrentRequest')
             ->willReturn($request)
         ;
 

--- a/core-bundle/tests/Security/Authentication/Token/TokenCheckerTest.php
+++ b/core-bundle/tests/Security/Authentication/Token/TokenCheckerTest.php
@@ -391,16 +391,10 @@ class TokenCheckerTest extends TestCase
         return $user;
     }
 
-    /**
-     * @return RequestStack&MockObject
-     */
     private function mockRequestStack(Request $request): RequestStack
     {
-        $requestStack = $this->createMock(RequestStack::class);
-        $requestStack
-            ->method('getMainRequest')
-            ->willReturn($request)
-        ;
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
 
         return $requestStack;
     }


### PR DESCRIPTION
This PR fixes the obviously wrong `getMainRequest()` calls as discussed in #5006. It does not touch the other calls, which are subject to further discussion.
