### PR TITLE
Fix Input compatibility with Symfony 6

### DIFF
--- a/core-bundle/contao/library/Contao/Input.php
+++ b/core-bundle/contao/library/Contao/Input.php
@@ -1092,7 +1092,9 @@ class Input
 				return $arrGet[$strKey];
 			}
 
-			return $request->query->get($strKey);
+			// Since we don't know whether the value will be an array or a string,
+			// we can neither use ->get($strKey) nor ->all($strKey) in Symfony 6.
+			return $request->query->all()[$strKey] ?? null;
 		}
 
 		trigger_deprecation('contao/core-bundle', '5.0', 'Getting data from $_GET with the "%s" class has been deprecated and will no longer work in Contao 6.0. Make sure the request_stack has a request instead.', __CLASS__);
@@ -1146,7 +1148,9 @@ class Input
 				return $arrCookie[$strKey];
 			}
 
-			return $request->cookies->get($strKey);
+			// Since we don't know whether the value will be an array or a string,
+			// we can neither use ->get($strKey) nor ->all($strKey) in Symfony 6.
+			return $request->cookies->all()[$strKey] ?? null;
 		}
 
 		trigger_deprecation('contao/core-bundle', '5.0', 'Getting data from $_COOKIE with the "%s" class has been deprecated and will no longer work in Contao 6.0. Make sure the request_stack has a request instead.', __CLASS__);

--- a/core-bundle/tests/Contao/InputTest.php
+++ b/core-bundle/tests/Contao/InputTest.php
@@ -932,7 +932,6 @@ class InputTest extends TestCase
         $data = ['key' => ['value1', 'value2']];
 
         System::getContainer()->set('request_stack', $stack = new RequestStack());
-
         $stack->push(new Request($data, $data, [], $data));
 
         $this->assertSame(['value1', 'value2'], Input::get('key'));

--- a/core-bundle/tests/Contao/InputTest.php
+++ b/core-bundle/tests/Contao/InputTest.php
@@ -923,4 +923,20 @@ class InputTest extends TestCase
 
         $this->assertTrue(Input::isPost(), 'isPost() should return true, even if the post data was empty');
     }
+
+    /**
+     * @group legacy
+     */
+    public function testArrayValuesFromGetAndPost(): void
+    {
+        $data = ['key' => ['value1', 'value2']];
+
+        System::getContainer()->set('request_stack', $stack = new RequestStack());
+
+        $stack->push(new Request($data, $data, [], $data));
+
+        $this->assertSame(['value1', 'value2'], Input::get('key'));
+        $this->assertSame(['value1', 'value2'], Input::post('key'));
+        $this->assertSame(['value1', 'value2'], Input::cookie('key'));
+    }
 }


### PR DESCRIPTION
Fixes `Input value "crawl_subscriber_names" contains a non-scalar value.` when trying to rebuild the search index.