### PR TITLE
Do not use the `filesystem` service in the `Folder` class

### DIFF
--- a/core-bundle/contao/library/Contao/Folder.php
+++ b/core-bundle/contao/library/Contao/Folder.php
@@ -10,6 +10,8 @@
 
 namespace Contao;
 
+use Symfony\Component\Filesystem\Filesystem;
+
 /**
  * Creates, reads, writes and deletes folders
  *
@@ -340,7 +342,7 @@ class Folder extends System
 
 		if (!is_file($this->strRootDir . '/' . $this->strFolder . '/.public'))
 		{
-			System::getContainer()->get('filesystem')->touch($this->strRootDir . '/' . $this->strFolder . '/.public');
+			(new Filesystem())->touch($this->strRootDir . '/' . $this->strFolder . '/.public');
 		}
 	}
 
@@ -395,7 +397,7 @@ class Folder extends System
 	{
 		if (!file_exists($this->strRootDir . '/' . $this->strFolder . '/.nosync'))
 		{
-			System::getContainer()->get('filesystem')->touch($this->strRootDir . '/' . $this->strFolder . '/.nosync');
+			(new Filesystem())->touch($this->strRootDir . '/' . $this->strFolder . '/.nosync');
 		}
 	}
 

--- a/core-bundle/src/DependencyInjection/Compiler/MakeServicesPublicPass.php
+++ b/core-bundle/src/DependencyInjection/Compiler/MakeServicesPublicPass.php
@@ -26,6 +26,7 @@ class MakeServicesPublicPass implements CompilerPassInterface
         'assets.packages',
         'database_connection',
         'debug.stopwatch',
+        'filesystem',
         'fragment.handler',
         'mailer',
         'monolog.logger.contao',

--- a/core-bundle/src/DependencyInjection/Compiler/MakeServicesPublicPass.php
+++ b/core-bundle/src/DependencyInjection/Compiler/MakeServicesPublicPass.php
@@ -26,7 +26,6 @@ class MakeServicesPublicPass implements CompilerPassInterface
         'assets.packages',
         'database_connection',
         'debug.stopwatch',
-        'filesystem',
         'fragment.handler',
         'mailer',
         'monolog.logger.contao',


### PR DESCRIPTION
Fixes the following error in Contao `5.0.0` when trying to create a new (public) folder under _Content_ » _Files_:

```
Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException:
The "filesystem" service or alias has been removed or inlined when the container was compiled. You should either make it public, or stop using the container directly and use dependency injection instead.

  at vendor\symfony\dependency-injection\Container.php:235
  at Symfony\Component\DependencyInjection\Container->make('filesystem', 1)
     (vendor\symfony\dependency-injection\Container.php:197)
  at Symfony\Component\DependencyInjection\Container->get('filesystem')
     (vendor\contao\contao\core-bundle\contao\library\Contao\Folder.php:343)
  at Contao\Folder->unprotect()
     (vendor\contao\contao\core-bundle\contao\dca\tl_files.php:893)
  at tl_files->protectFolder(object(DC_Folder), '')
     (vendor\contao\contao\core-bundle\contao\classes\DataContainer.php:396)
  at Contao\DataContainer->row()
     (vendor\contao\contao\core-bundle\contao\drivers\DC_Folder.php:1485)
  at Contao\DC_Folder->edit()
     (vendor\contao\contao\core-bundle\contao\classes\Backend.php:547)
  at Contao\Backend->getBackendModule('files', null)
     (vendor\contao\contao\core-bundle\contao\controllers\BackendMain.php:149)
…
```