### PR TITLE
Drop the deprecated article-to-PDF functionality

### DIFF
--- a/core-bundle/composer.json
+++ b/core-bundle/composer.json
@@ -168,9 +168,6 @@
         "terminal42/contao-ce-access": "<3.0",
         "thecodingmachine/safe": "<1.2"
     },
-    "suggest": {
-        "contao/tcpdf-bundle": "To export articles as PDF files"
-    },
     "autoload": {
         "psr-4": {
             "Contao\\CoreBundle\\": "src/"

--- a/core-bundle/contao/library/Contao/Controller.php
+++ b/core-bundle/contao/library/Contao/Controller.php
@@ -469,18 +469,6 @@ abstract class Controller extends System
 			return '';
 		}
 
-		// Print the article as PDF
-		if (Input::get('pdf') !== null && $objRow->printable && Input::get('pdf') == $objRow->id)
-		{
-			$options = StringUtil::deserialize($objRow->printable);
-
-			if (\is_array($options) && \in_array('pdf', $options))
-			{
-				$objArticle = new ModuleArticle($objRow);
-				$objArticle->generatePdf();
-			}
-		}
-
 		$objRow->headline = $objRow->title;
 		$objRow->multiMode = $blnMultiMode;
 

--- a/core-bundle/contao/modules/ModuleArticle.php
+++ b/core-bundle/contao/modules/ModuleArticle.php
@@ -251,37 +251,6 @@ class ModuleArticle extends Module
 		}
 	}
 
-	/**
-	 * Print an article as PDF and stream it to the browser
-	 */
-	public function generatePdf()
-	{
-		$this->headline = $this->title;
-		$this->printable = false;
-
-		$container = System::getContainer();
-
-		// Generate article
-		$strArticle = $container->get('contao.insert_tag.parser')->replaceInline($this->generate());
-		$strArticle = html_entity_decode($strArticle, ENT_QUOTES, $container->getParameter('kernel.charset'));
-		$strArticle = $this->convertRelativeUrls($strArticle, '', true);
-
-		if (empty($GLOBALS['TL_HOOKS']['printArticleAsPdf']))
-		{
-			throw new \Exception('No PDF extension found. Did you forget to install contao/tcpdf-bundle?');
-		}
-
-		// HOOK: allow individual PDF routines
-		if (isset($GLOBALS['TL_HOOKS']['printArticleAsPdf']) && \is_array($GLOBALS['TL_HOOKS']['printArticleAsPdf']))
-		{
-			foreach ($GLOBALS['TL_HOOKS']['printArticleAsPdf'] as $callback)
-			{
-				$this->import($callback[0]);
-				$this->{$callback[0]}->{$callback[1]}($strArticle, $this);
-			}
-		}
-	}
-
 	protected function getResponseCacheTags(): array
 	{
 		// Do not tag with 'contao.db.tl_module.<id>' when rendering articles (see #2814)

--- a/manager-bundle/composer.json
+++ b/manager-bundle/composer.json
@@ -74,9 +74,6 @@
         "phpunit/phpunit": "^9.5",
         "symfony/phpunit-bridge": "^5.4 || ^6.0"
     },
-    "suggest": {
-        "contao/tcpdf-bundle": "To export articles as PDF files"
-    },
     "autoload": {
         "psr-4": {
             "Contao\\ManagerBundle\\": "src/"


### PR DESCRIPTION
Looks like we forgot to drop this since `contao/tcpdf-bundle` is not compatible with Contao 5.