### PR TITLE
Fix database exception during contao-setup

### DIFF
--- a/manager-bundle/skeleton/config/config.yaml
+++ b/manager-bundle/skeleton/config/config.yaml
@@ -62,6 +62,9 @@ doctrine:
         auto_mapping: true
         auto_generate_proxy_classes: false
         naming_strategy: doctrine.orm.naming_strategy.default
+        metadata_cache_driver:
+            type: pool
+            pool: doctrine.system_cache_pool
         query_cache_driver:
             type: pool
             pool: doctrine.system_cache_pool


### PR DESCRIPTION
The `metadata_cache_driver` was removed in #5188 which causes the default metadata cache warmer to try to connect to the database.

An alternative fix for this could be to decorate the default metadata cache warmer similar to:

```yaml
    contao.doctrine.orm.fail_tolerant_metadata_cache_warmer:
        class: Contao\CoreBundle\Doctrine\ORM\FailTolerantProxyCacheWarmer
        decorates: doctrine.orm.default_metadata_cache_warmer
        decoration_on_invalid: ignore
        arguments:
            - '@contao.doctrine.orm.fail_tolerant_metadata_cache_warmer.inner'
            - '@database_connection'
```

_(just for the record if we need to fix this again somtime in the future ☺️)_