### PR TITLE
Fix custom paste modes not working properly

### DIFF
--- a/core-bundle/src/Resources/contao/classes/Backend.php
+++ b/core-bundle/src/Resources/contao/classes/Backend.php
@@ -667,7 +667,7 @@ abstract class Backend extends Controller
 		$mode = Input::get('mode');
 
 		// For these actions the id parameter refers to the parent record
-		if (($act === 'paste' && $mode === 'create') || \in_array($act, array(null, 'select', 'editAll', 'overrideAll', 'deleteAll'), true))
+		if (($act === 'paste' && $mode !== 'copy' && $mode !== 'cut') || \in_array($act, array(null, 'select', 'editAll', 'overrideAll', 'deleteAll'), true))
 		{
 			return $id;
 		}


### PR DESCRIPTION
In one of our projects, we allow backend users to have some custom paste logic. What I mean by that are custom global operation buttons that trigger the "select new record position" backend view but have a custom `mode` parameter, which then is used to apply custom logic (e.g., paste several custom content elements instead of one):

`act=paste&mode=multiple_content_elements`

Since #4819 got merged, this is no longer possible, as records are not rendered due to missing `CURRENT_ID`:

<img width="1198" alt="image" src="https://user-images.githubusercontent.com/21078664/184479127-56f8f651-6b15-4412-9c60-35a8c5752a14.png">

This pull request should fix that. I am aware that this is an extreme edge case, but this used to work, and I think we should not limit this flexibility. Let me know what you think about it.