### PR TITLE
Allow to disable ChmodTable widget

### DIFF
--- a/core-bundle/contao/widgets/ChmodTable.php
+++ b/core-bundle/contao/widgets/ChmodTable.php
@@ -58,7 +58,7 @@ class ChmodTable extends Widget
 			for ($j=1; $j<=6; $j++)
 			{
 				$return .= '
-      <td><input type="checkbox" name="' . $this->strName . '[]" value="' . self::specialcharsValue($k . $j) . '"' . static::optionChecked($k . $j, $this->varValue) . ' onfocus="Backend.getScrollOffset()"></td>';
+      <td><input type="checkbox" name="' . $this->strName . '[]" value="' . self::specialcharsValue($k . $j) . '"' . $this->getAttributes() . static::optionChecked($k . $j, $this->varValue) . ' onfocus="Backend.getScrollOffset()"></td>';
 			}
 
 			$return .= '


### PR DESCRIPTION
The bugfix from https://github.com/contao/contao/pull/4870/commits/9425670360713310d83952b603c79f8dc829c75d didn't make it into 5.0.