### PR TITLE
Use the firewall name instead of the scope to determine the access strategy

### DIFF
--- a/core-bundle/src/Resources/config/services.yml
+++ b/core-bundle/src/Resources/config/services.yml
@@ -713,7 +713,8 @@ services:
         arguments:
             - '@.inner'
             - '@contao.security.access_decision_manager.priority'
-            - '@security.firewall.context'
+            - '@request_stack'
+            - '@security.firewall.map'
 
     contao.security.access_decision_manager.priority:
         class: Symfony\Component\Security\Core\Authorization\AccessDecisionManager

--- a/core-bundle/src/Resources/config/services.yml
+++ b/core-bundle/src/Resources/config/services.yml
@@ -713,8 +713,7 @@ services:
         arguments:
             - '@.inner'
             - '@contao.security.access_decision_manager.priority'
-            - '@contao.routing.scope_matcher'
-            - '@request_stack'
+            - '@security.firewall.context'
 
     contao.security.access_decision_manager.priority:
         class: Symfony\Component\Security\Core\Authorization\AccessDecisionManager

--- a/core-bundle/src/Security/Authentication/AccessDecisionManager.php
+++ b/core-bundle/src/Security/Authentication/AccessDecisionManager.php
@@ -12,35 +12,56 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Security\Authentication;
 
-use Symfony\Bundle\SecurityBundle\Security\FirewallContext;
+use Symfony\Bundle\SecurityBundle\Security\FirewallConfig;
+use Symfony\Bundle\SecurityBundle\Security\FirewallMap;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
+use Symfony\Component\Security\Http\FirewallMapInterface;
 
 class AccessDecisionManager implements AccessDecisionManagerInterface
 {
     private AccessDecisionManagerInterface $inner;
     private AccessDecisionManagerInterface $contaoAccessDecisionManager;
-    private FirewallContext $firewallContext;
+    private RequestStack $requestStack;
+    private FirewallMapInterface $firewallMap;
 
     /**
-     * @internal
+     * @internal Do not inherit from this class; decorate the "security.access.decision_manager" service instead
      */
-    public function __construct(AccessDecisionManagerInterface $inner, AccessDecisionManagerInterface $contaoAccessDecisionManager, FirewallContext $firewallContext)
+    public function __construct(AccessDecisionManagerInterface $inner, AccessDecisionManagerInterface $contaoAccessDecisionManager, RequestStack $requestStack, FirewallMapInterface $firewallMap)
     {
         $this->inner = $inner;
         $this->contaoAccessDecisionManager = $contaoAccessDecisionManager;
-        $this->firewallContext = $firewallContext;
+        $this->requestStack = $requestStack;
+        $this->firewallMap = $firewallMap;
     }
 
     public function decide(TokenInterface $token, array $attributes, $object = null): bool
     {
-        $config = $this->firewallContext->getConfig();
-        $firewallName = $config ? $config->getName() : '';
-
-        if ('contao_frontend' === $firewallName || 'contao_backend' === $firewallName) {
+        if ($this->isContaoContext()) {
             return $this->contaoAccessDecisionManager->decide($token, $attributes, $object);
         }
 
         return $this->inner->decide($token, $attributes, $object);
+    }
+
+    private function isContaoContext(): bool
+    {
+        $request = $this->requestStack->getMainRequest();
+
+        if (!$this->firewallMap instanceof FirewallMap || null === $request) {
+            return false;
+        }
+
+        $config = $this->firewallMap->getFirewallConfig($request);
+
+        if (!$config instanceof FirewallConfig) {
+            return false;
+        }
+
+        $context = $config->getContext();
+
+        return 'contao_frontend' === $context || 'contao_backend' === $context;
     }
 }

--- a/core-bundle/src/Security/Authentication/AccessDecisionManager.php
+++ b/core-bundle/src/Security/Authentication/AccessDecisionManager.php
@@ -22,6 +22,9 @@ class AccessDecisionManager implements AccessDecisionManagerInterface
     private AccessDecisionManagerInterface $contaoAccessDecisionManager;
     private FirewallContext $firewallContext;
 
+    /**
+     * @internal
+     */
     public function __construct(AccessDecisionManagerInterface $inner, AccessDecisionManagerInterface $contaoAccessDecisionManager, FirewallContext $firewallContext)
     {
         $this->inner = $inner;

--- a/core-bundle/tests/Security/Authentication/AccessDecisionManagerTest.php
+++ b/core-bundle/tests/Security/Authentication/AccessDecisionManagerTest.php
@@ -121,15 +121,13 @@ class AccessDecisionManagerTest extends TestCase
                 ->method('getFirewallConfig')
                 ->willReturn(null)
             ;
-
-            return $map;
+        } else {
+            $map
+                ->expects($this->once())
+                ->method('getFirewallConfig')
+                ->willReturn(new FirewallConfig($context, '', null, true, false, null, $context))
+            ;
         }
-
-        $map
-            ->expects($this->once())
-            ->method('getFirewallConfig')
-            ->willReturn(new FirewallConfig($context, '', null, true, false, null, $context))
-        ;
 
         return $map;
     }

--- a/core-bundle/tests/Security/Authentication/AccessDecisionManagerTest.php
+++ b/core-bundle/tests/Security/Authentication/AccessDecisionManagerTest.php
@@ -70,7 +70,10 @@ class AccessDecisionManagerTest extends TestCase
         return $manager;
     }
 
-    private function mockFirewallContext(string $name)
+    /**
+     * @return FirewallContext&MockObject
+     */
+    private function mockFirewallContext(string $name): FirewallContext
     {
         $context = $this->createMock(FirewallContext::class);
 

--- a/core-bundle/tests/Security/Authentication/AccessDecisionManagerTest.php
+++ b/core-bundle/tests/Security/Authentication/AccessDecisionManagerTest.php
@@ -76,7 +76,6 @@ class AccessDecisionManagerTest extends TestCase
     private function mockFirewallContext(string $name): FirewallContext
     {
         $context = $this->createMock(FirewallContext::class);
-
         $context
             ->method('getConfig')
             ->willReturn(new FirewallConfig($name, ''))

--- a/core-bundle/tests/Security/Authentication/AccessDecisionManagerTest.php
+++ b/core-bundle/tests/Security/Authentication/AccessDecisionManagerTest.php
@@ -15,66 +15,41 @@ namespace Contao\CoreBundle\Tests\Security\Authentication;
 use Contao\CoreBundle\Security\Authentication\AccessDecisionManager;
 use Contao\CoreBundle\Tests\TestCase;
 use PHPUnit\Framework\MockObject\MockObject;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Bundle\SecurityBundle\Security\FirewallConfig;
+use Symfony\Bundle\SecurityBundle\Security\FirewallContext;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
 
 class AccessDecisionManagerTest extends TestCase
 {
-    public function testLeavesOriginalConfigurationUntouchedIfNoRequestAvailable(): void
+    public function testUsesOriginalDecisionManagerIfNotContaoFirewall(): void
     {
         $accessDecisionManager = new AccessDecisionManager(
             $this->mockAccessDecisionManager(true),
             $this->mockAccessDecisionManager(false),
-            $this->mockScopeMatcher(),
-            new RequestStack()
+            $this->mockFirewallContext('foobar')
         );
 
         $accessDecisionManager->decide($this->createMock(TokenInterface::class), []);
     }
 
-    public function testLeavesOriginalConfigurationUntouchedIfNotContaoScope(): void
+    public function testUsesContaoDecisionManagerIfContaoBackendFirewall(): void
     {
-        $requestStack = new RequestStack();
-        $requestStack->push(new Request());
-
         $accessDecisionManager = new AccessDecisionManager(
-            $this->mockAccessDecisionManager(true),
             $this->mockAccessDecisionManager(false),
-            $this->mockScopeMatcher(),
-            $requestStack
+            $this->mockAccessDecisionManager(true),
+            $this->mockFirewallContext('contao_backend')
         );
 
         $accessDecisionManager->decide($this->createMock(TokenInterface::class), []);
     }
 
-    public function testLeavesOriginalConfigurationUntouchedIfNotMainRequest(): void
+    public function testUsesContaoDecisionManagerIfContaoFrontendFirewall(): void
     {
-        $requestStack = new RequestStack();
-        $requestStack->push(new Request());
-        $requestStack->push(new Request([], [], ['_scope' => 'frontend']));
-
-        $accessDecisionManager = new AccessDecisionManager(
-            $this->mockAccessDecisionManager(true),
-            $this->mockAccessDecisionManager(false),
-            $this->mockScopeMatcher(),
-            $requestStack
-        );
-
-        $accessDecisionManager->decide($this->createMock(TokenInterface::class), []);
-    }
-
-    public function testUsesContaoDecisionManagerIfContaoRequest(): void
-    {
-        $requestStack = new RequestStack();
-        $requestStack->push(new Request([], [], ['_scope' => 'frontend']));
-
         $accessDecisionManager = new AccessDecisionManager(
             $this->mockAccessDecisionManager(false),
             $this->mockAccessDecisionManager(true),
-            $this->mockScopeMatcher(),
-            $requestStack
+            $this->mockFirewallContext('contao_frontend')
         );
 
         $accessDecisionManager->decide($this->createMock(TokenInterface::class), []);
@@ -93,5 +68,17 @@ class AccessDecisionManagerTest extends TestCase
         ;
 
         return $manager;
+    }
+
+    private function mockFirewallContext(string $name)
+    {
+        $context = $this->createMock(FirewallContext::class);
+
+        $context
+            ->method('getConfig')
+            ->willReturn(new FirewallConfig($name, ''))
+        ;
+
+        return $context;
     }
 }


### PR DESCRIPTION
As discussed regarding https://github.com/contao/contao/pull/5192 we should base the firewall access decision strategy based on the firewall and not the request context.