### PR TITLE
Correctly list the templates in "override all" mode

### DIFF
--- a/core-bundle/src/Resources/contao/dca/tl_form_field.php
+++ b/core-bundle/src/Resources/contao/dca/tl_form_field.php
@@ -767,7 +767,7 @@ class tl_form_field extends Backend
 	{
 		if (Input::get('act') == 'overrideAll')
 		{
-			return $this->getTemplateGroup('form_');
+			return array_merge(['' => '-'], $this->getTemplateGroup('form_'));
 		}
 
 		$default = 'form_' . $dc->activeRecord->type;

--- a/core-bundle/src/Resources/contao/dca/tl_form_field.php
+++ b/core-bundle/src/Resources/contao/dca/tl_form_field.php
@@ -767,7 +767,7 @@ class tl_form_field extends Backend
 	{
 		if (Input::get('act') == 'overrideAll')
 		{
-			return array_merge(['' => '-'], $this->getTemplateGroup('form_'));
+			return array_merge(array('' => '-'), $this->getTemplateGroup('form_'));
 		}
 
 		$default = 'form_' . $dc->activeRecord->type;

--- a/core-bundle/src/Resources/contao/library/Contao/Controller.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Controller.php
@@ -175,6 +175,14 @@ abstract class Controller extends System
 			$strGlobPrefix = substr($strGlobPrefix, 0, -1) . '[_-]';
 		}
 
+		// Add the matching bundle templates, e.g. in "override all" mode (see #5131)
+		$arrBundleMatches = array_unique(preg_grep('/' . $strGlobPrefix . '/', $arrBundleTemplates));
+
+		foreach ($arrBundleMatches as $strTemplate)
+		{
+			$arrTemplates[$strTemplate][] = 'root';
+		}
+
 		$projectDir = System::getContainer()->getParameter('kernel.project_dir');
 		$arrCustomized = self::braceGlob($projectDir . '/templates/' . $strGlobPrefix . '*.html5');
 

--- a/core-bundle/src/Resources/contao/library/Contao/Controller.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Controller.php
@@ -175,14 +175,6 @@ abstract class Controller extends System
 			$strGlobPrefix = substr($strGlobPrefix, 0, -1) . '[_-]';
 		}
 
-		// Add the matching bundle templates, e.g. in "override all" mode (see #5131)
-		$arrBundleMatches = array_unique(preg_grep('/' . $strGlobPrefix . '/', $arrBundleTemplates));
-
-		foreach ($arrBundleMatches as $strTemplate)
-		{
-			$arrTemplates[$strTemplate][] = 'root';
-		}
-
 		$projectDir = System::getContainer()->getParameter('kernel.project_dir');
 		$arrCustomized = self::braceGlob($projectDir . '/templates/' . $strGlobPrefix . '*.html5');
 


### PR DESCRIPTION
Fixes #5131

### Before

<img width="628" alt="" src="https://user-images.githubusercontent.com/1192057/187662375-63d86c88-f0bc-4bf7-83cd-14d59b5ffeec.png">

### After

<img width="614" alt="" src="https://user-images.githubusercontent.com/1192057/187662410-33932e37-3fd4-4066-8cd0-d18900588b9b.png">
