### PR TITLE
Deprecate the User::isMemberOf() method

### DIFF
--- a/core-bundle/contao/library/Contao/User.php
+++ b/core-bundle/contao/library/Contao/User.php
@@ -296,9 +296,13 @@ abstract class User extends System implements UserInterface, EquatableInterface,
 	 * @param mixed $ids A single group ID or an array of group IDs
 	 *
 	 * @return boolean True if the user is a member of the group
+	 *
+	 * @deprecated Deprecated since Contao 5.0, to be removed in Contao 6.
 	 */
 	public function isMemberOf($ids)
 	{
+		trigger_deprecation('contao/core-bundle', '5.0', 'Using "%s()" has been deprecated and will no longer work in Contao 6. Use the "ContaoCorePermissions::MEMBER_IN_GROUPS" permission instead.', __METHOD__);
+
 		// Filter non-numeric values
 		$ids = array_filter((array) $ids, static function ($val) { return (string) (int) $val === (string) $val; });
 


### PR DESCRIPTION
Fixes the first part of #4818.