### PR TITLE
Pass the contao.web_dir in the Automator::generateSymlinks() method

### DIFF
--- a/core-bundle/contao/library/Contao/Automator.php
+++ b/core-bundle/contao/library/Contao/Automator.php
@@ -365,7 +365,7 @@ class Automator extends System
 	{
 		$container = System::getContainer();
 
-		$webDir = ltrim(str_replace($container->getParameter('kernel.project_dir'), '', $container->getParameter('contao.web_dir')), '/');
+		$webDir = Path::makeRelative($container->getParameter('contao.web_dir'), $container->getParameter('kernel.project_dir'));
 		$command = $container->get('contao.command.symlinks');
 		$status = $command->run(new ArgvInput(array('', $webDir)), new NullOutput());
 

--- a/core-bundle/contao/library/Contao/Automator.php
+++ b/core-bundle/contao/library/Contao/Automator.php
@@ -14,6 +14,7 @@ use FOS\HttpCache\CacheInvalidator;
 use FOS\HttpCacheBundle\CacheManager;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\Filesystem\Path;
 
 /**
  * Provide methods to run automated jobs.
@@ -360,12 +361,17 @@ class Automator extends System
 
 	/**
 	 * Generate the symlinks in the public folder
+	 *
+	 * @deprecated Deprecated since Contao 5.0, to be removed in Contao 6.
+	 *             Use the contao:symlinks command instead.
 	 */
 	public function generateSymlinks()
 	{
-		$container = System::getContainer();
+		trigger_deprecation('contao/core-bundle', '5.0', 'Using %s() has been deprecated and will no longer work in Contao 6. Use the "contao:symlinks" command instead.');
 
+		$container = System::getContainer();
 		$webDir = Path::makeRelative($container->getParameter('contao.web_dir'), $container->getParameter('kernel.project_dir'));
+
 		$command = $container->get('contao.command.symlinks');
 		$status = $command->run(new ArgvInput(array('', $webDir)), new NullOutput());
 

--- a/core-bundle/contao/library/Contao/Automator.php
+++ b/core-bundle/contao/library/Contao/Automator.php
@@ -361,14 +361,9 @@ class Automator extends System
 
 	/**
 	 * Generate the symlinks in the public folder
-	 *
-	 * @deprecated Deprecated since Contao 5.0, to be removed in Contao 6.
-	 *             Use the contao:symlinks command instead.
 	 */
 	public function generateSymlinks()
 	{
-		trigger_deprecation('contao/core-bundle', '5.0', 'Using %s() has been deprecated and will no longer work in Contao 6. Use the "contao:symlinks" command instead.');
-
 		$container = System::getContainer();
 		$webDir = Path::makeRelative($container->getParameter('contao.web_dir'), $container->getParameter('kernel.project_dir'));
 

--- a/core-bundle/contao/library/Contao/Automator.php
+++ b/core-bundle/contao/library/Contao/Automator.php
@@ -365,8 +365,9 @@ class Automator extends System
 	{
 		$container = System::getContainer();
 
+		$webDir = ltrim(str_replace($container->getParameter('kernel.project_dir'), '', $container->getParameter('contao.web_dir')), '/');
 		$command = $container->get('contao.command.symlinks');
-		$status = $command->run(new ArgvInput(array()), new NullOutput());
+		$status = $command->run(new ArgvInput(array('', $webDir)), new NullOutput());
 
 		if ($status > 0)
 		{


### PR DESCRIPTION
Fixes #5215

However, I wonder if we should remove the `Automator::generateSymlinks()` completely as we already have the `contao:symlinks` command? We could deprecate the usage in Contao 4.13 and remove it in Contao 5.
