### PR TITLE
Improve the order of operations during the Contao setup

### DIFF
--- a/manager-bundle/src/Command/ContaoSetupCommand.php
+++ b/manager-bundle/src/Command/ContaoSetupCommand.php
@@ -77,12 +77,12 @@ class ContaoSetupCommand extends Command
 
         $commands = [
             ['contao:install-web-dir', $this->webDir, '--env=prod'],
-            ['cache:clear', '--no-warmup', '--env=prod'],
-            ['cache:clear', '--no-warmup', '--env=dev'],
-            ['cache:warmup', '--env=prod'],
             ['assets:install', $this->webDir, '--symlink', '--relative', '--env=prod'],
             ['contao:install', $this->webDir, '--env=prod'],
             ['contao:symlinks', $this->webDir, '--env=prod'],
+            ['cache:clear', '--no-warmup', '--env=prod'],
+            ['cache:clear', '--no-warmup', '--env=dev'],
+            ['cache:warmup', '--env=prod'],
         ];
 
         $commandFlags = array_filter([

--- a/manager-bundle/tests/Command/ContaoSetupCommandTest.php
+++ b/manager-bundle/tests/Command/ContaoSetupCommandTest.php
@@ -55,12 +55,12 @@ class ContaoSetupCommandTest extends ContaoTestCase
 
         $commandArguments = [
             array_merge([$phpPath], $phpFlags, [$consolePath, 'contao:install-web-dir', 'public', '--env=prod'], $flags),
-            array_merge([$phpPath], $phpFlags, [$consolePath, 'cache:clear', '--no-warmup', '--env=prod'], $flags),
-            array_merge([$phpPath], $phpFlags, [$consolePath, 'cache:clear', '--no-warmup', '--env=dev'], $flags),
-            array_merge([$phpPath], $phpFlags, [$consolePath, 'cache:warmup', '--env=prod'], $flags),
             array_merge([$phpPath], $phpFlags, [$consolePath, 'assets:install', 'public', '--symlink', '--relative', '--env=prod'], $flags),
             array_merge([$phpPath], $phpFlags, [$consolePath, 'contao:install', 'public', '--env=prod'], $flags),
             array_merge([$phpPath], $phpFlags, [$consolePath, 'contao:symlinks', 'public', '--env=prod'], $flags),
+            array_merge([$phpPath], $phpFlags, [$consolePath, 'cache:clear', '--no-warmup', '--env=prod'], $flags),
+            array_merge([$phpPath], $phpFlags, [$consolePath, 'cache:clear', '--no-warmup', '--env=dev'], $flags),
+            array_merge([$phpPath], $phpFlags, [$consolePath, 'cache:warmup', '--env=prod'], $flags),
         ];
 
         $memoryLimit = ini_set('memory_limit', '1G');


### PR DESCRIPTION
See https://github.com/contao/contao/issues/5069#issuecomment-1226903463.

This PR changes that clear/warmup operations are executed last when running `contao:setup`.

This makes sure the compiler passes that act depending on the filesystem structure will see the structure they need (directories are created, symlinks were made, …). The `bin/contao-setup.php` entrypoint makes sure the cache directory gets nuked beforehand, so the commands will still run on a freshly built container.

@chiron501 Can you test if this solves your issue from #5059?
/cc @ausi 