### PR TITLE
Make modern custom templates selectable in the back end

### DIFF
--- a/core-bundle/contao/library/Contao/Controller.php
+++ b/core-bundle/contao/library/Contao/Controller.php
@@ -118,7 +118,9 @@ abstract class Controller extends System
 
 		/** @var TemplateHierarchyInterface $templateHierarchy */
 		$templateHierarchy = System::getContainer()->get('contao.twig.filesystem_loader');
-		$identifierPattern = sprintf('/^%s%s/', preg_quote($strPrefix, '/'), substr($strPrefix, -1) !== '_' ? '($|_)' : '');
+		$identifierPattern = str_contains($strPrefix, '/') ?
+			sprintf('/^%s(\/[^\/]+)$/', preg_quote(rtrim($strPrefix, '_'), '/')) :
+			sprintf('/^%s%s/', preg_quote($strPrefix, '/'), !str_ends_with($strPrefix, '_') ? '($|_)' : '');
 
 		$prefixedFiles = array_merge(
 			array_filter(

--- a/core-bundle/contao/library/Contao/Controller.php
+++ b/core-bundle/contao/library/Contao/Controller.php
@@ -118,9 +118,10 @@ abstract class Controller extends System
 
 		/** @var TemplateHierarchyInterface $templateHierarchy */
 		$templateHierarchy = System::getContainer()->get('contao.twig.filesystem_loader');
-		$identifierPattern = str_contains($strPrefix, '/') ?
-			sprintf('/^%s(\/[^\/]+)$/', preg_quote(rtrim($strPrefix, '_'), '/')) :
-			sprintf('/^%s%s/', preg_quote($strPrefix, '/'), !str_ends_with($strPrefix, '_') ? '($|_)' : '');
+
+		$identifierPattern = str_contains($strPrefix, '/')
+			? sprintf('/^%s(\/[^\/]+)$/', preg_quote(rtrim($strPrefix, '_'), '/'))
+			: sprintf('/^%s%s/', preg_quote($strPrefix, '/'), !str_ends_with($strPrefix, '_') ? '($|_)' : '');
 
 		$prefixedFiles = array_merge(
 			array_filter(

--- a/core-bundle/tests/Contao/TemplateLoaderTest.php
+++ b/core-bundle/tests/Contao/TemplateLoaderTest.php
@@ -285,4 +285,36 @@ class TemplateLoaderTest extends TestCase
             Controller::getTemplateGroup('mod_article_')
         );
     }
+
+    /**
+     * @group legacy
+     */
+    public function testReturnsAModernCustomTwigTemplate(): void
+    {
+        $templateHierarchy = $this->createMock(TemplateHierarchyInterface::class);
+        $templateHierarchy
+            ->method('getInheritanceChains')
+            ->willReturn([
+                'content_element/text' => ['some/path/content_element/text.html.twig' => '@Contao_Global/content_element/text.html.twig'],
+                'content_element/text/special' => ['some/path/content_element/text/special.html.twig' => '@Contao_Global/content_element/text/special.html.twig'],
+                'content_element/text_table' => ['some/path/content_element/text_table.html.twig' => '@Contao_Global/content_element/text_table.html.twig'],
+            ])
+        ;
+
+        System::getContainer()->set('contao.twig.filesystem_loader', $templateHierarchy);
+
+        $this->assertSame(
+            [
+                'content_element/text/special' => 'content_element/text/special',
+            ],
+            Controller::getTemplateGroup('content_element/text')
+        );
+
+        $this->assertSame(
+            [
+                'content_element/text/special' => 'content_element/text/special',
+            ],
+            Controller::getTemplateGroup('content_element/text_')
+        );
+    }
 }


### PR DESCRIPTION
If you want to overwrite the template for the `text` content element and add two variants (`highlight` and `info`), you would setup the following structure in your template directory:

```
📂 templates
 ├─ 📄.twig-root (might be optional, see https://github.com/contao/contao/pull/5242)
 └─ 📂 content_element
     ├─ 📝 text.html.twig
     └─ 📂 text
         ├─ 📝 highlight.html.twig
         └─ 📝 info.html.twig
```

This PR makes the variant templates (here: `content_element/text/highlight` and `content_element/text/info`) selectable in the back end dropdowns for the respective element. Seems I forgot to implement this… :see_no_evil:

The implementation still follows the same ideas as in #4121. I'd like to deprecate `Controller::getTemplateGroups()` at some point and then properly implement this as a service, but we need to get rid of some BC layers first.

/cc @netzarbeiter