### PR TITLE
Add a tree view for the debug:contao-twig command

### DIFF
--- a/core-bundle/src/Command/DebugContaoTwigCommand.php
+++ b/core-bundle/src/Command/DebugContaoTwigCommand.php
@@ -108,8 +108,8 @@ class DebugContaoTwigCommand extends Command
             // sorted ascending by its key (identifier part)
             uksort(
                 $node,
-                static function ($keyA, $keyB) {
-                    if (0 !== ($leafNodes = ('/' === $keyB) <=> ('/' === $keyA))) {
+                static function ($keyA, $keyB) use ($node) {
+                    if (0 !== ($leafNodes = (\is_array($node[$keyA]) <=> \is_array($node[$keyB])))) {
                         return $leafNodes;
                     }
 

--- a/core-bundle/src/Command/DebugContaoTwigCommand.php
+++ b/core-bundle/src/Command/DebugContaoTwigCommand.php
@@ -79,6 +79,9 @@ class DebugContaoTwigCommand extends Command
         return Command::SUCCESS;
     }
 
+    /**
+     * @param array<string,array<string, string>> $chains
+     */
     private function listTree(array $chains, SymfonyStyle $io): void
     {
         // Split identifier prefixes by '/' and arrange them in a prefix tree
@@ -86,17 +89,17 @@ class DebugContaoTwigCommand extends Command
 
         foreach ($chains as $identifier => $chain) {
             $parts = explode('/', $identifier);
-            $root = &$prefixTree;
+            $node = &$prefixTree;
 
             foreach ($parts as $part) {
                 /** @phpstan-ignore-next-line */
-                if (!isset($root[$part])) {
-                    $root[$part] = [];
+                if (!isset($node[$part])) {
+                    $node[$part] = [];
                 }
-                $root = &$root[$part];
+                $node = &$node[$part];
             }
 
-            $root = [...$root, ...$chain];
+            $node = [...$node, ...$chain];
         }
 
         // Recursively display tree nodes
@@ -151,6 +154,9 @@ class DebugContaoTwigCommand extends Command
         $displayNode($prefixTree);
     }
 
+    /**
+     * @param array<string,array<string, string>> $chains
+     */
     private function listDetailed(array $chains, SymfonyStyle $io): void
     {
         $nameCellStyle = new TableCellStyle(['fg' => 'yellow']);

--- a/core-bundle/src/Command/DebugContaoTwigCommand.php
+++ b/core-bundle/src/Command/DebugContaoTwigCommand.php
@@ -48,7 +48,7 @@ class DebugContaoTwigCommand extends Command
     {
         $this
             ->addOption('theme', 't', InputOption::VALUE_OPTIONAL, 'Include theme templates with a given theme path or slug.')
-            ->addOption('tree', null, InputOption::VALUE_NONE, 'Display as a prefix-tree listing.')
+            ->addOption('tree', null, InputOption::VALUE_NONE, 'Display the templates as prefix tree.')
             ->addArgument('filter', InputArgument::OPTIONAL, 'Filter the output by an identifier or prefix.')
         ;
     }
@@ -84,7 +84,7 @@ class DebugContaoTwigCommand extends Command
      */
     private function listTree(array $chains, SymfonyStyle $io): void
     {
-        // Split identifier prefixes by '/' and arrange them in a prefix tree
+        // Split identifier prefixes by "/" and arrange them in a prefix tree
         $prefixTree = [];
 
         foreach ($chains as $identifier => $chain) {
@@ -96,6 +96,7 @@ class DebugContaoTwigCommand extends Command
                 if (!isset($node[$part])) {
                     $node[$part] = [];
                 }
+
                 $node = &$node[$part];
             }
 
@@ -129,6 +130,7 @@ class DebugContaoTwigCommand extends Command
                     // Display part of the template identifier. If this is the
                     // last bit, we also display the effective @Contao name.
                     $identifier = ltrim("$namePrefix/$label", '/');
+
                     $io->writeln(sprintf(
                         '%s<fg=green;options=bold>%s</>%s',
                         $currentPrefix,
@@ -143,6 +145,7 @@ class DebugContaoTwigCommand extends Command
 
                 // Display file and logical name
                 $io->writeln($currentPrefix.$label);
+
                 $io->writeln(sprintf(
                     '%s<fg=white>Original name:</> <fg=yellow>%s</>',
                     $currentPrefixWithNewline,

--- a/core-bundle/tests/Command/DebugContaoTwigCommandTest.php
+++ b/core-bundle/tests/Command/DebugContaoTwigCommandTest.php
@@ -196,6 +196,53 @@ class DebugContaoTwigCommandTest extends TestCase
         ];
     }
 
+    public function testOutputsHierarchyAsATree(): void
+    {
+        $hierarchy = $this->createMock(TemplateHierarchyInterface::class);
+        $hierarchy
+            ->expects($this->once())
+            ->method('getInheritanceChains')
+            ->willReturn([
+                'content_element/text' => [
+                    '/path1/content_element/text.html.twig' => '@A/content_element/text.html.twig',
+                ],
+                'content_element/text/info' => [
+                    '/path1/content_element/text/info.html.twig' => '@A/content_element/text/info.html.twig',
+                ],
+                'content_element/text/highlight' => [
+                    '/path1/content_element/text/highlight.html.twig' => '@A/content_element/text/highlight.html.twig',
+                    '/path2/content_element/text/highlight.html.twig' => '@B/content_element/text/highlight.html.twig',
+                ],
+            ])
+        ;
+
+        $command = $this->getCommand($hierarchy);
+
+        $tester = new CommandTester($command);
+        $tester->execute(['--tree' => true]);
+
+        $normalizedOutput = preg_replace("/\\s+\n/", "\n", $tester->getDisplay(true));
+
+        $expectedOutput = <<<'OUTPUT'
+            └──content_element
+               └──text (@Contao/content_element/text.html.twig)
+                  ├──/path1/content_element/text.html.twig
+                  │  Original name: @A/content_element/text.html.twig
+                  ├──highlight (@Contao/content_element/text/highlight.html.twig)
+                  │  ├──/path1/content_element/text/highlight.html.twig
+                  │  │  Original name: @A/content_element/text/highlight.html.twig
+                  │  └──/path2/content_element/text/highlight.html.twig
+                  │     Original name: @B/content_element/text/highlight.html.twig
+                  └──info (@Contao/content_element/text/info.html.twig)
+                     └──/path1/content_element/text/info.html.twig
+                        Original name: @A/content_element/text/info.html.twig
+
+            OUTPUT;
+
+        $this->assertSame($expectedOutput, $normalizedOutput);
+        $this->assertSame(0, $tester->getStatusCode());
+    }
+
     /**
      * @dataProvider provideThemeOptions
      */

--- a/core-bundle/tests/Command/DebugContaoTwigCommandTest.php
+++ b/core-bundle/tests/Command/DebugContaoTwigCommandTest.php
@@ -203,15 +203,15 @@ class DebugContaoTwigCommandTest extends TestCase
             ->expects($this->once())
             ->method('getInheritanceChains')
             ->willReturn([
-                'content_element/text' => [
-                    '/path1/content_element/text.html.twig' => '@A/content_element/text.html.twig',
-                ],
                 'content_element/text/info' => [
                     '/path1/content_element/text/info.html.twig' => '@A/content_element/text/info.html.twig',
                 ],
                 'content_element/text/highlight' => [
                     '/path1/content_element/text/highlight.html.twig' => '@A/content_element/text/highlight.html.twig',
                     '/path2/content_element/text/highlight.html.twig' => '@B/content_element/text/highlight.html.twig',
+                ],
+                'content_element/text' => [
+                    '/path1/content_element/text.html.twig' => '@A/content_element/text.html.twig',
                 ],
             ])
         ;


### PR DESCRIPTION
With custom templates like described in #5243 I figured it could be very helpful if the `debug:contao-twig` command was able to display the hierarchy in tree form. This makes it easier to debug your template structure.

This PR does exactly that: If you now add `--tree` as an option, you get an output of existing templates sorted and displayed in a prefix-tree (identifier parts split by `/`). 

Here is an example how this looks if you filter for text content elements for instance: 

![image](https://user-images.githubusercontent.com/5305677/188282112-c908d626-2f54-4df9-8d4a-5f551cbd8f0a.png)
