### PR TITLE
Fix cache tagging for aliased content elements

### DIFF
--- a/core-bundle/src/Resources/contao/elements/ContentAlias.php
+++ b/core-bundle/src/Resources/contao/elements/ContentAlias.php
@@ -51,8 +51,17 @@ class ContentAlias extends ContentElement
 				$proxy->cssID = ' id="' . $this->cssID[0] . '"';
 			}
 
+			// Tag the alias element
+			if ($this->objModel !== null)
+			{
+				System::getContainer()->get('contao.cache.entity_tags')->tagWithModelInstance($this->objModel);
+			}
+
 			return $proxy->generate();
 		}
+
+		// Tag the included element (see #5248)
+		System::getContainer()->get('contao.cache.entity_tags')->tagWithModelInstance($objElement);
 
 		$objElement->origId = $objElement->origId ?: $objElement->id;
 		$objElement->id = $this->id;

--- a/core-bundle/src/Resources/contao/elements/ContentAlias.php
+++ b/core-bundle/src/Resources/contao/elements/ContentAlias.php
@@ -51,7 +51,7 @@ class ContentAlias extends ContentElement
 				$proxy->cssID = ' id="' . $this->cssID[0] . '"';
 			}
 
-			// Tag the alias element
+			// Tag the alias element (see #5249)
 			if ($this->objModel !== null)
 			{
 				System::getContainer()->get('contao.cache.entity_tags')->tagWithModelInstance($this->objModel);


### PR DESCRIPTION
Fixes #5248

`ContentElement::generate` automatically tags the response with the ID of the content element. However, `ContentAlias` overwrites the ID of the model _with its own ID_ before that happens and thus only the ID of the alias element itself gets tagged - but not the ID of the _included_ element. Thus, if you make any changes to the _included_ content element, the cache will not be invalidated.

This PR fixes that by letting `ContentAlias` always also tag the response with the model of the _included_ element.

Furthermore I noticed that if you are using fragments, the ID of the _alias_ content element does not get tagged at all. This PR also fixes that. Now always both IDs (the original ID and the current ID) get tagged, regardless of whether it's a legacy content element or a fragment.

_Note:_ this issue also happens in Contao 4.9, I will provide a separate PR for that. This PR should be merged first.