### PR TITLE
Fix cache tagging for aliased content elements

### DIFF
--- a/core-bundle/src/Resources/contao/elements/ContentAlias.php
+++ b/core-bundle/src/Resources/contao/elements/ContentAlias.php
@@ -53,7 +53,21 @@ class ContentAlias extends ContentElement
 				$proxy->cssID = ' id="' . $this->cssID[0] . '"';
 			}
 
+			// Tag the alias element (see #5249)
+			if (System::getContainer()->has('fos_http_cache.http.symfony_response_tagger'))
+			{
+				$responseTagger = System::getContainer()->get('fos_http_cache.http.symfony_response_tagger');
+				$responseTagger->addTags(array('contao.db.tl_content.' . $this->id));
+			}
+
 			return $proxy->generate();
+		}
+
+		// Tag the included element (see #5248)
+		if (System::getContainer()->has('fos_http_cache.http.symfony_response_tagger'))
+		{
+			$responseTagger = System::getContainer()->get('fos_http_cache.http.symfony_response_tagger');
+			$responseTagger->addTags(array('contao.db.tl_content.' . $this->cteAlias));
 		}
 
 		$objElement->origId = $objElement->origId ?: $objElement->id;


### PR DESCRIPTION
Same as #5249 for Contao 4.9.
