### PR TITLE
Fix template options when using legacy elements

### DIFF
--- a/core-bundle/src/EventListener/DataContainer/TemplateOptionsListener.php
+++ b/core-bundle/src/EventListener/DataContainer/TemplateOptionsListener.php
@@ -46,7 +46,10 @@ class TemplateOptionsListener
         }
 
         $type = $dc->getCurrentRecord()['type'] ?? null;
-        $defaultTemplate = $this->customTemplates[$type] ?? $this->getLegacyDefaultTemplate($dc);
+
+        if (null !== $type) {
+            $defaultTemplate = $this->getLegacyDefaultTemplate($type) ?? $this->customTemplates[$type] ?? null;
+        }
 
         if (empty($defaultTemplate)) {
             $defaultTemplate = $this->templatePrefix.$type;
@@ -63,13 +66,13 @@ class TemplateOptionsListener
     /**
      * Uses the reflection API to return the default template from a legacy class.
      */
-    private function getLegacyDefaultTemplate(DataContainer $dc): string|null
+    private function getLegacyDefaultTemplate(string $type): string|null
     {
         if (null === $this->proxyClass || !method_exists($this->proxyClass, 'findClass')) {
             return null;
         }
 
-        $class = $this->proxyClass::findClass($dc->getCurrentRecord()['type'] ?? null);
+        $class = $this->proxyClass::findClass($type);
 
         if (empty($class) || $class === $this->proxyClass) {
             return null;
@@ -77,7 +80,7 @@ class TemplateOptionsListener
 
         $properties = (new \ReflectionClass($class))->getDefaultProperties();
 
-        return $properties['strTemplate'] ?? null;
+        return $properties['strTemplate'] ?? $this->templatePrefix.$type;
     }
 
     private function isOverrideAll(): bool

--- a/core-bundle/tests/EventListener/DataContainer/TemplateOptionsListenerTest.php
+++ b/core-bundle/tests/EventListener/DataContainer/TemplateOptionsListenerTest.php
@@ -92,10 +92,13 @@ class TemplateOptionsListenerTest extends TestCase
             ContentProxy::class
         );
 
-        $callback->setCustomTemplates(['fragment_element' => 'ce_custom_fragment_template']);
+        $callback->setCustomTemplates([
+            'fragment_element' => 'content_element/fragment',
+            'legacy_element' => 'content_element/legacy',
+        ]);
 
         $this->assertSame(
-            ['' => 'ce_custom_fragment_template'],
+            ['' => 'content_element/fragment'],
             $callback($this->mockDataContainer('tl_content', ['type' => 'fragment_element']))
         );
 
@@ -114,10 +117,13 @@ class TemplateOptionsListenerTest extends TestCase
             ModuleProxy::class
         );
 
-        $callback->setCustomTemplates(['fragment_module' => 'mod_custom_fragment_template']);
+        $callback->setCustomTemplates([
+            'fragment_module' => 'frontend_module/fragment',
+            'legacy_module' => 'frontend_module/legacy',
+        ]);
 
         $this->assertSame(
-            ['' => 'mod_custom_fragment_template'],
+            ['' => 'frontend_module/fragment'],
             $callback($this->mockDataContainer('tl_module', ['type' => 'fragment_module']))
         );
 
@@ -158,12 +164,14 @@ class TemplateOptionsListenerTest extends TestCase
             ->willReturnMap([
                 ['ce_', ['ce_all' => 'ce_all']],
                 ['ce_fragment_element_', [], 'ce_fragment_element', ['' => 'ce_fragment_element']],
-                ['ce_custom_fragment_template_', [], 'ce_custom_fragment_template', ['' => 'ce_custom_fragment_template']],
                 ['ce_custom_legacy_template_', [], 'ce_custom_legacy_template', ['' => 'ce_custom_legacy_template']],
                 ['mod_', ['mod_all' => 'mod_all']],
                 ['mod_fragment_module_', [], 'mod_fragment_module', ['' => 'mod_fragment_module']],
-                ['mod_custom_fragment_template_', [], 'mod_custom_fragment_template', ['' => 'mod_custom_fragment_template']],
                 ['mod_custom_legacy_template_', [], 'mod_custom_legacy_template', ['' => 'mod_custom_legacy_template']],
+                ['content_element/fragment_', [], 'content_element/fragment', ['' => 'content_element/fragment']],
+                ['content_element/legacy_', [], 'content_element/legacy', ['' => 'content_element/legacy']],
+                ['frontend_module/fragment_', [], 'frontend_module/fragment', ['' => 'frontend_module/fragment']],
+                ['frontend_module/legacy_', [], 'frontend_module/legacy', ['' => 'frontend_module/legacy']],
             ])
         ;
 


### PR DESCRIPTION
Currently the template options in the back end only allow you to select the new fragment templates, even if you switch back to the legacy content element, e.g. via

```php
// contao/config/config.php
$GLOBALS['TL_CTE']['texts']['text'] = \Contao\ContentText::class;
```

Thus you won't be able to select a `templates/ce_text_custom.html5` template for example.

This is because the actual fragment and its template is still registered and currently in the `TemplateOptionsListener` any custom template takes precedence over the legacy logic.

This PR fixes that by always using the legacy logic when the element/module type is not registered via the proxy class.
