### PR TITLE
Respect showHidden option in last breadcrumb as well

### DIFF
--- a/core-bundle/contao/modules/ModuleBreadcrumb.php
+++ b/core-bundle/contao/modules/ModuleBreadcrumb.php
@@ -190,15 +190,18 @@ class ModuleBreadcrumb extends Module
 		// Active page
 		else
 		{
-			$items[] = array
-			(
-				'isRoot'   => false,
-				'isActive' => true,
-				'href'     => $this->getPageFrontendUrl($pages[0]),
-				'title'    => StringUtil::specialchars($pages[0]->pageTitle ?: $pages[0]->title),
-				'link'     => $pages[0]->title,
-				'data'     => $pages[0]->row(),
-			);
+			if ($pages[0]->hide && !$this->showHidden)
+			{
+				$items[] = array
+				(
+					'isRoot'   => false,
+					'isActive' => true,
+					'href'     => $this->getPageFrontendUrl($pages[0]),
+					'title'    => StringUtil::specialchars($pages[0]->pageTitle ?: $pages[0]->title),
+					'link'     => $pages[0]->title,
+					'data'     => $pages[0]->row(),
+				);
+			}
 		}
 
 		// HOOK: add custom logic


### PR DESCRIPTION
We've identified this issue in Contao 4.13.8. The option not to show hidden elements in the breadcrumb is not respected in case we're on the last item in the list.