### PR TITLE
Fix a PHP8 issue if the confirmation key is not translated

### DIFF
--- a/core-bundle/src/Resources/contao/templates/backend/be_confirm.html5
+++ b/core-bundle/src/Resources/contao/templates/backend/be_confirm.html5
@@ -43,7 +43,7 @@
           <table>
             <?php foreach ($this->info as $key => $info): ?>
               <tr>
-                <th scope="row"><?= $this->labels[$key] ?></th>
+                <th scope="row"><?= $this->labels[$key] ?? $key ?></th>
                 <td><?= $info ?></td>
               </tr>
             <?php endforeach; ?>


### PR DESCRIPTION
This showed up in my Sentry.io reports 🙃 