### PR TITLE
Make sure language is always a string

### DIFF
--- a/core-bundle/src/Routing/AbstractPageRouteProvider.php
+++ b/core-bundle/src/Routing/AbstractPageRouteProvider.php
@@ -217,6 +217,8 @@ abstract class AbstractPageRouteProvider implements RouteProviderInterface
         $result = [];
 
         foreach ($languages as $language) {
+            $language = (string) $language;
+
             if (!$locales = LocaleUtil::getFallbacks($language)) {
                 continue;
             }


### PR DESCRIPTION
I have no idea why, but I got a request logged with header `Accept-Language: 1`. This did lead to an error of `Contao\CoreBundle\Util\LocaleUtil::getFallbacks(): Argument #1 ($locale) must be of type string, int given` which should not happen anymore with this change.