### PR TITLE
Fix filter options with options callback

### DIFF
--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -5868,9 +5868,6 @@ class DC_Table extends DataContainer implements \listable, \editable
 					{
 						$options_callback = $GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['options_callback']($this);
 					}
-
-					// Sort options according to the keys of the callback array
-					$options = array_intersect(array_keys($options_callback), $options);
 				}
 
 				$options_sorter = array();

--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -5879,7 +5879,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 					$value = $blnDate ? $kk : $vv;
 
 					// Options callback
-					if (!empty($options_callback) && \is_array($options_callback))
+					if (!empty($options_callback) && \is_array($options_callback) && isset($options_callback[$vv]))
 					{
 						$vv = $options_callback[$vv];
 					}


### PR DESCRIPTION
This line in DC_Table has two problems:
 1. sorting the options by callback makes no sense, because the list it later sorted by label (I guess that was added later)
 2. this line causes options to be removed if they are not returned by the options callback. For example if you have some "leftover" values you can never filter for them even though they exist in the database. 

FYI what this does not yet fix is multidimensional array from the options_callback, but I think that's a separate issue.