### PR TITLE
Fix page mounts not being applied correctly

### DIFF
--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -6246,7 +6246,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 			{
 				$parentRecords = $this->Database->getParentRecords($id, $table, true);
 
- 				// If $id already is a root page itself, there won't be any parent records.
+				// If $id already is a root page itself, there won't be any parent records.
 				// In this case, we have to add $id to the visible root trails.
 				if (empty($parentRecords))
 				{

--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -6246,8 +6246,8 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 			{
 				$parentRecords = $this->Database->getParentRecords($id, $table, true);
 
-				// If $id already is a root page itself, there won't be any parent records. In this case, we have
-				// to add $id to the visible root trails.
+ 				// If $id already is a root page itself, there won't be any parent records.
+				// In this case, we have to add $id to the visible root trails.
 				if (empty($parentRecords))
 				{
 					$parentRecords = array($id);

--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -6248,9 +6248,9 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 
 				// If $id already is a root page itself, there won't be any parent records. In this case, we have
 				// to add $id to the visible root trails.
-				if ([] === $parentRecords)
+				if (empty($parentRecords))
 				{
-					$parentRecords = [$id];
+					$parentRecords = array($id);
 				}
 
 				$this->visibleRootTrails = array_unique(array_merge($this->visibleRootTrails, $parentRecords));

--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -6244,7 +6244,16 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 		{
 			foreach ($this->root as $id)
 			{
-				$this->visibleRootTrails = array_unique(array_merge($this->visibleRootTrails, $this->Database->getParentRecords($id, $table, true)));
+				$parentRecords = $this->Database->getParentRecords($id, $table, true);
+
+				// If $id already is a root page itself, there won't be any parent records. In this case, we have
+				// to add $id to the visible root trails.
+				if ([] === $parentRecords)
+				{
+					$parentRecords = [$id];
+				}
+
+				$this->visibleRootTrails = array_unique(array_merge($this->visibleRootTrails, $parentRecords));
 			}
 		}
 


### PR DESCRIPTION
Fixes page mount permissions not being applied correctly.

Steps to reproduce:

1. Log into demo.contao.org
2. Create a second root page and name it `Test root`
3. Add a page `Foobar` to your new root page `Test root`
4. Edit e.g. h.lewis and configure the page mounts to only `Contao Official Demo` and your new `Foobar Page`

<img width="747" alt="Bildschirmfoto 2022-09-12 um 16 11 02" src="https://user-images.githubusercontent.com/481937/189676004-77909630-8119-4417-be39-8efab2d5303f.png">

5. Switch to `h.lewis`
6. Access the page structure. It will look like this:

<img width="356" alt="Bildschirmfoto 2022-09-12 um 16 12 50" src="https://user-images.githubusercontent.com/481937/189676505-71d5ed5a-09a1-411c-b6a4-918894fdf9cf.png">

The entire `Contao Official Demo` page tree is missing.

That's because the configured page mount itself is already a root page and does not have any parent records. It needs to be added itself to the visible root trails.