### PR TITLE
Don't return empty theme directories in the TemplateLocator

### DIFF
--- a/core-bundle/src/Twig/Loader/TemplateLocator.php
+++ b/core-bundle/src/Twig/Loader/TemplateLocator.php
@@ -60,7 +60,7 @@ class TemplateLocator
             // Note: We cannot use models or other parts of the Contao
             // framework here because this function will be called when the
             // container is built (see #3567)
-            $themePaths = $this->connection->fetchFirstColumn('SELECT templates FROM tl_theme');
+            $themePaths = $this->connection->fetchFirstColumn("SELECT templates FROM tl_theme WHERE templates != ''");
         } catch (DriverException $e) {
             return [];
         }


### PR DESCRIPTION
This small change makes sure that empty entries in the `tl_theme.templates` column aren't considered as valid theme directories. As these directories are meant to be relative, the `is_dir` check in L69 will otherwise always return `true`, because the effective directory is then the project root. :smiling_face_with_tear: 