### PR TITLE
Allow symlinked bundle paths in the template files listing

### DIFF
--- a/core-bundle/src/Resources/contao/dca/tl_templates.php
+++ b/core-bundle/src/Resources/contao/dca/tl_templates.php
@@ -246,15 +246,15 @@ class tl_templates extends Contao\Backend
 			$strRelpath = Path::makeRelative($file->getPathname(), $projectDir);
 
 			$modulePatterns = array(
-				"vendor/(?'module'[^/]+/[^/]+)",
-				"\\.\\..*(?'module'[^/]+/[^/]+)/(?:src/Resources/contao/templates|contao/templates)",
-				"system/modules/(?'module'[^/]+)"
+				"vendor/([^/]+/[^/]+)",
+				"\\.\\..*?([^/]+/[^/]+)/(?:src/Resources/contao/templates|contao/templates)",
+				"system/modules/([^/]+)"
 			);
-			preg_match('@^(?:' . implode('|', $modulePatterns) . ')/.*$@UJ', $strRelpath, $matches);
+			preg_match('@^(?|' . implode('|', $modulePatterns) . ')/.*$@', $strRelpath, $matches);
 
 			// Use the matched "module" group and fall back to the full
 			// directory path (e.g. "contao/templates" in the app).
-			$strModule = $matches['module'] ?? dirname($strRelpath);
+			$strModule = $matches[1] ?? dirname($strRelpath);
 
 			$arrAllTemplates[$strModule][$strRelpath] = basename($strRelpath);
 		}

--- a/core-bundle/src/Resources/contao/dca/tl_templates.php
+++ b/core-bundle/src/Resources/contao/dca/tl_templates.php
@@ -250,6 +250,7 @@ class tl_templates extends Contao\Backend
 				"\\.\\..*?([^/]+/[^/]+)/(?:src/Resources/contao/templates|contao/templates)",
 				"system/modules/([^/]+)"
 			);
+
 			preg_match('@^(?|' . implode('|', $modulePatterns) . ')/.*$@', $strRelpath, $matches);
 
 			// Use the matched "module" group and fall back to the full

--- a/core-bundle/src/Resources/contao/dca/tl_templates.php
+++ b/core-bundle/src/Resources/contao/dca/tl_templates.php
@@ -244,7 +244,18 @@ class tl_templates extends Contao\Backend
 			// Do not use "StringUtil::stripRootDir()" here, because for
 			// symlinked bundles, the path will be outside the project dir.
 			$strRelpath = Path::makeRelative($file->getPathname(), $projectDir);
-			$strModule = preg_replace('@^(vendor/([^/]+/[^/]+)/|system/modules/([^/]+)/).*$@', '$2$3', strtr($strRelpath, '\\', '/'));
+
+			$modulePatterns = array(
+				"vendor/(?'module'[^/]+/[^/]+)",
+				"\.\..*(?'module'[^/]+/[^/]+)/(?:src/Resources/contao/templates|contao/templates)",
+				"system/modules/(?'module'[^/]+)"
+			);
+			preg_match('@^(?:'. implode('|', $modulePatterns)  .')/.*$@UJ', $strRelpath, $matches);
+
+			// Use the matched "module" group and fall back to the full
+			// directory path (e.g. "contao/templates" in the app).
+			$strModule = $matches['module'] ?? \dirname($strRelpath);
+
 			$arrAllTemplates[$strModule][$strRelpath] = basename($strRelpath);
 		}
 

--- a/core-bundle/src/Resources/contao/dca/tl_templates.php
+++ b/core-bundle/src/Resources/contao/dca/tl_templates.php
@@ -247,14 +247,14 @@ class tl_templates extends Contao\Backend
 
 			$modulePatterns = array(
 				"vendor/(?'module'[^/]+/[^/]+)",
-				"\.\..*(?'module'[^/]+/[^/]+)/(?:src/Resources/contao/templates|contao/templates)",
+				"\\.\\..*(?'module'[^/]+/[^/]+)/(?:src/Resources/contao/templates|contao/templates)",
 				"system/modules/(?'module'[^/]+)"
 			);
-			preg_match('@^(?:'. implode('|', $modulePatterns)  .')/.*$@UJ', $strRelpath, $matches);
+			preg_match('@^(?:' . implode('|', $modulePatterns) . ')/.*$@UJ', $strRelpath, $matches);
 
 			// Use the matched "module" group and fall back to the full
 			// directory path (e.g. "contao/templates" in the app).
-			$strModule = $matches['module'] ?? \dirname($strRelpath);
+			$strModule = $matches['module'] ?? dirname($strRelpath);
 
 			$arrAllTemplates[$strModule][$strRelpath] = basename($strRelpath);
 		}


### PR DESCRIPTION
See https://github.com/contao/contao/pull/5247#issuecomment-1243987509

`StringUtil::stripRootDir` throws an exception if the given path is outside the project dir. Exactly this is the case, when listing templates from a symlinked source. In my development setup this happens if my app requires `contao/contao` and there is a respective `repositories` entry in the `composer.json`, so that the bundle files will get symlinked. The resource paths will now be outside the project dir.

This PR allows arbitrary relative paths and adjusts the pattern matching.