### PR TITLE
Add id check to dc table

### DIFF
--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -117,6 +117,12 @@ class DC_Table extends DataContainer implements \listable, \editable
 
 		$this->intId = Input::get('id');
 
+		if (!is_numeric($this->intId)) {
+			$this->intId = null;
+		} else {
+			$this->intId = (int) $this->intId;
+		}
+
 		// Clear the clipboard
 		if (isset($_GET['clipboard']))
 		{
@@ -1788,6 +1794,10 @@ class DC_Table extends DataContainer implements \listable, \editable
 		if ($intId)
 		{
 			$this->intId = $intId;
+		}
+
+		if (!$this->intId || !is_numeric($this->intId)) {
+			throw new AccessDeniedException('Invalid ' . $this->strTable . ' ID.');
 		}
 
 		// Get the current record


### PR DESCRIPTION
This PR adds additional checks for id to DC_Table.

Problem: DC_Table accepts values other then int when loading the id (any value coming from Input::get() is accepted and not further checked). Since the the database queries are prepared statements, this is direct issue as queries like `/contao?act=edit&do=nc_notifications&id=1%20or%20true&table=tl_nc_message` lead to database queries like `SELECT * FROM tl_nc_message WHERE id='1 or true' LIMIT 0,1`, which still works. But since the DataContainer object is passed to many events/callbacks, some code may expect an integer value (which the name and annotation suggest) and therefore produce problems. In my case DcaWizard produced wrong queries leading to this issue: https://github.com/terminal42/contao-dcawizard/issues/32

My idea is to check if the value is numeric, and, if not, don't use it. Otherwise cast it to integer.

This problem and possible solution were also discussed her: https://contao.slack.com/archives/CK4J0KNDB/p1663238445510959