### PR TITLE
Store Input::setGet in the request attributes

### DIFF
--- a/core-bundle/contao/library/Contao/Input.php
+++ b/core-bundle/contao/library/Contao/Input.php
@@ -152,6 +152,11 @@ class Input
 		{
 			$keys = $request->query->keys();
 
+			if ($request->attributes->has('auto_item'))
+			{
+				$keys[] = 'auto_item';
+			}
+
 			foreach ($request->attributes->get('_contao_input')['setGet'] ?? array() as $key => $value)
 			{
 				if ($value === null)
@@ -306,9 +311,23 @@ class Input
 
 		if ($request = static::getRequest())
 		{
-			$inputAttributes = $request->attributes->get('_contao_input', array());
-			$inputAttributes['setGet'][$strKey] = $varValue;
-			$request->attributes->set('_contao_input', $inputAttributes);
+			if ('auto_item' === $strKey)
+			{
+				if (null !== $varValue)
+				{
+					$request->attributes->set('auto_item', $varValue);
+				}
+				else
+				{
+					$request->attributes->remove('auto_item');
+				}
+			}
+			else
+			{
+				$inputAttributes = $request->attributes->get('_contao_input', array());
+				$inputAttributes['setGet'][$strKey] = $varValue;
+				$request->attributes->set('_contao_input', $inputAttributes);
+			}
 		}
 
 		if ($varValue === null)
@@ -1058,6 +1077,11 @@ class Input
 	{
 		if ($request = static::getRequest())
 		{
+			if ('auto_item' === $strKey && $request->attributes->has('auto_item'))
+			{
+				return $request->attributes->get('auto_item');
+			}
+
 			$arrGet = $request->attributes->get('_contao_input')['setGet'] ?? array();
 
 			if (\array_key_exists($strKey, $arrGet))

--- a/core-bundle/tests/Contao/InputTest.php
+++ b/core-bundle/tests/Contao/InputTest.php
@@ -932,6 +932,36 @@ class InputTest extends TestCase
         $this->assertTrue(Input::isPost(), 'isPost() should return true, even if the post data was empty');
     }
 
+    public function testAutoItemAttribute(): void
+    {
+        System::getContainer()->set('request_stack', $stack = new RequestStack());
+        $stack->push(new Request());
+
+        $this->assertSame([], Input::getKeys());
+
+        Input::setGet('auto_item', 'foo');
+
+        $this->assertSame(['auto_item'], Input::getKeys());
+        $this->assertSame('foo', Input::get('auto_item'));
+        $this->assertSame('foo', $stack->getCurrentRequest()->attributes->get('auto_item'));
+        $this->assertSame('foo', $_GET['auto_item']);
+
+        Input::setGet('key', 'value');
+
+        $this->assertSame(['auto_item', 'key'], Input::getKeys());
+        $this->assertSame('value', Input::get('key'));
+        $this->assertFalse($stack->getCurrentRequest()->attributes->has('key'));
+        $this->assertSame('value', $stack->getCurrentRequest()->attributes->get('_contao_input')['setGet']['key']);
+        $this->assertSame('value', $_GET['key']);
+
+        Input::setGet('auto_item', null);
+
+        $this->assertSame(['key'], Input::getKeys());
+        $this->assertNull(Input::get('auto_item'));
+        $this->assertFalse($stack->getCurrentRequest()->attributes->has('auto_item'));
+        $this->assertArrayNotHasKey('auto_item', $_GET);
+    }
+
     /**
      * @group legacy
      */

--- a/core-bundle/tests/Contao/InputTest.php
+++ b/core-bundle/tests/Contao/InputTest.php
@@ -884,6 +884,14 @@ class InputTest extends TestCase
         $this->assertSame([123, 'key2'], array_keys($_GET));
         $this->assertSame([123, 'key2'], array_keys($_POST));
 
+        // Duplicating the request should keep the setGet information intact
+        $stack->push($stack->getCurrentRequest()->duplicate());
+
+        $this->assertSame(['123', 'key2'], Input::getKeys());
+        $this->assertSame([123, 'key2'], array_keys($_GET));
+        $this->assertSame([123, 'key2'], array_keys($_POST));
+
+        $stack->pop();
         $stack->pop();
         $stack->push(new Request($data, $data, [], [], [], ['REQUEST_METHOD' => 'POST']));
 


### PR DESCRIPTION
Fixes #5252
Alternative to #5287

I think using the current request (instead of the main request) is correct, but we should store the data that is added via `setGet()` like the `auto_item` value in the request attributes directly so that they are kept when duplicating the request.

This also has the benefit that we could now access the `auto_item` value without using the `Input` class.