### PR TITLE
Use `Webmozart\PathUtil\Path` instead of `Symfony\Component\Filesystem\Path`

### DIFF
--- a/core-bundle/src/Resources/contao/dca/tl_templates.php
+++ b/core-bundle/src/Resources/contao/dca/tl_templates.php
@@ -8,7 +8,7 @@
  * @license LGPL-3.0-or-later
  */
 
-use Symfony\Component\Filesystem\Path;
+use Webmozart\PathUtil\Path;
 
 Contao\System::loadLanguageFile('tl_files');
 


### PR DESCRIPTION
Fixes the following error:

```
Attempted to load class "Path" from namespace "Symfony\Component\Filesystem". Did you forget a "use" statement for e.g. "Webmozart\PathUtil\Path", "ScssPhp\ScssPhp\Util\Path" or "BaconQrCode\Renderer\Path\Path"?
```

Contao 4.9 still allows

```json
"symfony/filesystem": "4.4.* || 5.4.*"
```

and `Symfony\Component\Filesystem\Path` is only available in Symfony 5.4. In Contao 4.9 we thus still use `Webmozart\PathUtil\Path`.