### PR TITLE
Backport support for nested template paths

### DIFF
--- a/core-bundle/src/Twig/ContaoTwigUtil.php
+++ b/core-bundle/src/Twig/ContaoTwigUtil.php
@@ -40,7 +40,7 @@ final class ContaoTwigUtil
      */
     public static function getIdentifier(string $name): string
     {
-        return preg_replace('%(?:.*/)?(.*)(\.html5|\.html\.twig)%', '$1', $name);
+        return preg_replace('%(?:@[^/]+/)?(.*)(?:\.html5|\.html\.twig)%', '$1', $name);
     }
 
     /**

--- a/core-bundle/src/Twig/Loader/TemplateLocator.php
+++ b/core-bundle/src/Twig/Loader/TemplateLocator.php
@@ -16,6 +16,7 @@ use Contao\CoreBundle\Exception\InvalidThemePathException;
 use Contao\CoreBundle\HttpKernel\Bundle\ContaoModuleBundle;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception\DriverException;
+use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Filesystem\Path;
 use Symfony\Component\Finder\Finder;
 
@@ -24,9 +25,12 @@ use Symfony\Component\Finder\Finder;
  */
 class TemplateLocator
 {
+    public const FILE_MARKER_NAMESPACE_ROOT = '.twig-root';
+
     private string $projectDir;
     private ThemeNamespace $themeNamespace;
     private Connection $connection;
+    private Filesystem $filesystem;
 
     /**
      * @var array<string,string>
@@ -45,6 +49,7 @@ class TemplateLocator
         $this->bundlesMetadata = $bundlesMetadata;
         $this->themeNamespace = $themeNamespace;
         $this->connection = $connection;
+        $this->filesystem = new Filesystem();
     }
 
     /**
@@ -132,26 +137,52 @@ class TemplateLocator
         $finder = (new Finder())
             ->files()
             ->in($path)
-            ->depth('< 1')
             ->name('/(\.html\.twig|\.html5)$/')
             ->sortByName()
         ;
 
+        if (!$this->isNamespaceRoot($path)) {
+            $finder = $finder->depth('< 1');
+        }
+
         $templates = [];
 
         foreach ($finder as $file) {
-            $templates[$file->getFilename()] = Path::canonicalize($file->getPathname());
+            $templates[Path::normalize($file->getRelativePathname())] = Path::canonicalize($file->getPathname());
         }
 
         return $templates;
     }
 
+    /**
+     * Return a list of all sub directories in $path that are not inside a
+     * directory containing a namespace root marker file.
+     */
     private function expandSubdirectories(string $path): array
     {
+        $namespaceRoots = [];
+
         $finder = (new Finder())
             ->directories()
             ->in($path)
             ->sortByName()
+            ->filter(
+                function (\SplFileInfo $info) use (&$namespaceRoots): bool {
+                    $path = $info->getPathname();
+
+                    foreach ($namespaceRoots as $directory) {
+                        if (Path::isBasePath($directory, $path)) {
+                            return false;
+                        }
+                    }
+
+                    if ($this->isNamespaceRoot($path)) {
+                        $namespaceRoots[] = $path;
+                    }
+
+                    return true;
+                }
+            )
         ;
 
         $paths = [$path];
@@ -161,5 +192,10 @@ class TemplateLocator
         }
 
         return $paths;
+    }
+
+    private function isNamespaceRoot(string $path): bool
+    {
+        return $this->filesystem->exists(Path::join($path, self::FILE_MARKER_NAMESPACE_ROOT));
     }
 }

--- a/core-bundle/tests/Twig/ContaoTwigUtilTest.php
+++ b/core-bundle/tests/Twig/ContaoTwigUtilTest.php
@@ -105,12 +105,12 @@ class ContaoTwigUtilTest extends TestCase
 
         yield 'complex name (html5)' => [
             '@Foo/bar/foo.html5',
-            'foo',
+            'bar/foo',
         ];
 
         yield 'complex name (Twig)' => [
             '@Foo/bar/foo.html.twig',
-            'foo',
+            'bar/foo',
         ];
 
         yield 'not a Contao template extension' => [


### PR DESCRIPTION
This PR backports #3973 and #4620 (nested template paths via `.twig-root`) for Contao 4.13. 

This makes it possible for extensions to embrace the new directory structures while being compatible with bot 4.13 and 5.

/cc @Toflar 