### PR TITLE
Trigger the oncopy_callback for child records

### DIFF
--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -1096,6 +1096,26 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 						{
 							$this->copyChilds($k, $insertID, $kk, $parentId);
 						}
+
+						if (is_array($GLOBALS['TL_DCA'][$k]['config']['oncopy_callback'] ?? null))
+						{
+							foreach ($GLOBALS['TL_DCA'][$k]['config']['oncopy_callback'] as $callback)
+							{
+								$dc = (new \ReflectionClass(self::class))->newInstanceWithoutConstructor();
+								$dc->table = $k;
+								$dc->id = $kk;
+
+								if (is_array($callback))
+								{
+									$this->import($callback[0]);
+									$this->$callback[0]->$callback[1]($insertID, $dc);
+								}
+								elseif (is_callable($callback))
+								{
+									$callback($insertID, $dc);
+								}
+							}
+						}
 					}
 				}
 			}

--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -1097,7 +1097,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 							$this->copyChilds($k, $insertID, $kk, $parentId);
 						}
 
-						if (is_array($GLOBALS['TL_DCA'][$k]['config']['oncopy_callback'] ?? null))
+						if (\is_array($GLOBALS['TL_DCA'][$k]['config']['oncopy_callback'] ?? null))
 						{
 							foreach ($GLOBALS['TL_DCA'][$k]['config']['oncopy_callback'] as $callback)
 							{
@@ -1105,12 +1105,12 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 								$dc->table = $k;
 								$dc->id = $kk;
 
-								if (is_array($callback))
+								if (\is_array($callback))
 								{
 									$this->import($callback[0]);
 									$this->$callback[0]->$callback[1]($insertID, $dc);
 								}
-								elseif (is_callable($callback))
+								elseif (\is_callable($callback))
 								{
 									$callback($insertID, $dc);
 								}


### PR DESCRIPTION
This one fixes a very old issue that I stumbled across today: https://github.com/contao/core/issues/6847

How to reproduce the original issue:

1. Add a callback to the `tl_news` DCA:

```php
'oncopy_callback' => array
(
	static function ($newId) {
		$db = \Contao\Database::getInstance();
		$db->prepare("UPDATE tl_news SET headline=CONCAT(headline, ' foo') WHERE id=?")->execute($newId);
	}
),
```

2. Copy a single news item → `foo` will be appended to the headline of the copied news item.
3. Copy the entire news archive → `foo` will **not** be appended to the headlines of the copied news items.

After applying the patch from this PR, `foo` should be appended to the headlines of the copied news items when copying an entire news archive.