### PR TITLE
Fixed unknown opt-in token source

### DIFF
--- a/core-bundle/src/Resources/contao/modules/ModulePassword.php
+++ b/core-bundle/src/Resources/contao/modules/ModulePassword.php
@@ -185,14 +185,13 @@ class ModulePassword extends Module
 
 		// Find an unconfirmed token with only one related tl_member record
 		if (
-		    (!$optInToken = $optIn->find(Input::get('token')))
+			(!$optInToken = $optIn->find(Input::get('token')))
 			|| !$optInToken->isValid()
 			|| !isset($optInToken->getRelatedRecords()['tl_member'])
 			|| \count($arrRelated = $optInToken->getRelatedRecords()['tl_member']) != 1
 			|| \count($arrIds = current($arrRelated)) != 1
 			|| (!$objMember = MemberModel::findByPk($arrIds[0]))
-		)
-		{
+		) {
 			$this->strTemplate = 'mod_message';
 
 			$this->Template = new FrontendTemplate($this->strTemplate);

--- a/core-bundle/src/Resources/contao/modules/ModulePassword.php
+++ b/core-bundle/src/Resources/contao/modules/ModulePassword.php
@@ -183,8 +183,15 @@ class ModulePassword extends Module
 	{
 		$optIn = System::getContainer()->get('contao.opt_in');
 
-		// Find an unconfirmed token with only one related record
-		if ((!$optInToken = $optIn->find(Input::get('token'))) || !$optInToken->isValid() || \count($arrRelated = $optInToken->getRelatedRecords()) != 1 || key($arrRelated) != 'tl_member' || \count($arrIds = current($arrRelated)) != 1 || (!$objMember = MemberModel::findByPk($arrIds[0])))
+		// Find an unconfirmed token with only one related tl_member record
+		if (
+		    (!$optInToken = $optIn->find(Input::get('token')))
+			|| !$optInToken->isValid()
+			|| !isset($optInToken->getRelatedRecords()['tl_member'])
+			|| \count($arrRelated = $optInToken->getRelatedRecords()['tl_member']) != 1
+			|| \count($arrIds = current($arrRelated)) != 1
+			|| (!$objMember = MemberModel::findByPk($arrIds[0]))
+		)
 		{
 			$this->strTemplate = 'mod_message';
 
@@ -311,7 +318,7 @@ class ModulePassword extends Module
 	protected function sendPasswordLink($objMember)
 	{
 		$optIn = System::getContainer()->get('contao.opt_in');
-		$optInToken = $optIn->create('pw', $objMember->email, array('tl_member'=>array($objMember->id)));
+		$optInToken = $optIn->create('pw', $objMember->email, array('tl_member'=>array($objMember->id), 'tl_module'=>array($this->id)));
 
 		// Prepare the simple token data
 		$arrData = $objMember->row();

--- a/core-bundle/src/Resources/contao/modules/ModuleRegistration.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleRegistration.php
@@ -526,14 +526,13 @@ class ModuleRegistration extends Module
 
 		// Find an unconfirmed token with only one related tl_member record
 		if (
-		    (!$optInToken = $optIn->find(Input::get('token')))
+			(!$optInToken = $optIn->find(Input::get('token')))
 			|| !$optInToken->isValid()
 			|| !isset($optInToken->getRelatedRecords()['tl_member'])
 			|| \count($arrRelated = $optInToken->getRelatedRecords()['tl_member']) != 1
 			|| \count($arrIds = current($arrRelated)) != 1
 			|| (!$objMember = MemberModel::findByPk($arrIds[0]))
-		)
-		{
+		) {
 			$this->Template->type = 'error';
 			$this->Template->message = $GLOBALS['TL_LANG']['MSC']['invalidToken'];
 

--- a/core-bundle/src/Resources/contao/modules/ModuleRegistration.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleRegistration.php
@@ -473,7 +473,7 @@ class ModuleRegistration extends Module
 	protected function sendActivationMail($arrData)
 	{
 		$optIn = System::getContainer()->get('contao.opt_in');
-		$optInToken = $optIn->create('reg', $arrData['email'], array('tl_member'=>array($arrData['id'])));
+		$optInToken = $optIn->create('reg', $arrData['email'], array('tl_member'=>array($arrData['id']), 'tl_module'=>array($this->id)));
 
 		// Prepare the simple token data
 		$arrTokenData = $arrData;
@@ -524,8 +524,15 @@ class ModuleRegistration extends Module
 
 		$optIn = System::getContainer()->get('contao.opt_in');
 
-		// Find an unconfirmed token with only one related record
-		if ((!$optInToken = $optIn->find(Input::get('token'))) || !$optInToken->isValid() || \count($arrRelated = $optInToken->getRelatedRecords()) != 1 || key($arrRelated) != 'tl_member' || \count($arrIds = current($arrRelated)) != 1 || (!$objMember = MemberModel::findByPk($arrIds[0])))
+		// Find an unconfirmed token with only one related tl_member record
+		if (
+		    (!$optInToken = $optIn->find(Input::get('token')))
+			|| !$optInToken->isValid()
+			|| !isset($optInToken->getRelatedRecords()['tl_member'])
+			|| \count($arrRelated = $optInToken->getRelatedRecords()['tl_member']) != 1
+			|| \count($arrIds = current($arrRelated)) != 1
+			|| (!$objMember = MemberModel::findByPk($arrIds[0]))
+		)
 		{
 			$this->Template->type = 'error';
 			$this->Template->message = $GLOBALS['TL_LANG']['MSC']['invalidToken'];


### PR DESCRIPTION
We have an `OptInInterface` as well as an `OptInTokenInterface` which allows me to decorate the opt in logic. This is a great helper for me while working on Notification Center 2.0.
However, I currently have no way to find out where that token is coming from. It could've been any module ID. I need to know which one in order to be able to only apply my logic in case of the correct module ID.

Basically, the whole decoration logic is useless if one cannot distinguish where the token is coming from so I consider this a bug.

Can anybody else test those changes too, please?
