### PR TITLE
Fix a potential PHP 8 warning in the backend help wizard

### DIFF
--- a/core-bundle/src/Resources/contao/controllers/BackendHelp.php
+++ b/core-bundle/src/Resources/contao/controllers/BackendHelp.php
@@ -147,7 +147,7 @@ class BackendHelp extends Backend
 		$objTemplate->title = StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['helpWizardTitle']);
 		$objTemplate->host = Backend::getDecodedHostname();
 		$objTemplate->charset = Config::get('characterSet');
-		$objTemplate->headline = $arrData['label'][0] ?: $field;
+		$objTemplate->headline = $arrData['label'][0] ?? $field;
 		$objTemplate->helpWizard = $GLOBALS['TL_LANG']['MSC']['helpWizard'];
 
 		return $objTemplate->getResponse();


### PR DESCRIPTION
It can happen when a backend user opens the help wizard inside a Rocksolid custom content element:

![CleanShot 2022-09-29 at 12 13 01](https://user-images.githubusercontent.com/193483/193005318-40151fb0-f224-4986-b92f-97fd1e0c9ba2.png)

Although this is likely a misconfiguration in my RSCE, I think the warning should be prevented.

<img width="935" alt="CleanShot 2022-09-29 at 12 11 44" src="https://user-images.githubusercontent.com/193483/193004852-003ab2a7-506c-45af-a3de-246aa22ee92a.png">
