### PR TITLE
Fix the sitemap cache invalidation in the news module

### DIFF
--- a/news-bundle/src/Resources/contao/dca/tl_news.php
+++ b/news-bundle/src/Resources/contao/dca/tl_news.php
@@ -949,6 +949,12 @@ class tl_news extends Backend
 	public function addSitemapCacheInvalidationTag($dc, array $tags)
 	{
 		$archiveModel = NewsArchiveModel::findByPk($dc->activeRecord->pid);
+
+		if ($archiveModel === null)
+		{
+			return $tags;
+		}
+
 		$pageModel = PageModel::findWithDetails($archiveModel->jumpTo);
 
 		if ($pageModel === null)


### PR DESCRIPTION
I don't have an exact way of reproducing this, yet Sentry caught this a few times:

<img width="930" alt="CleanShot 2022-09-29 at 12 21 29" src="https://user-images.githubusercontent.com/193483/193006757-60e9b681-9b14-414d-b865-d7f89b203288.png">
