### PR TITLE
Do not show errors twice in console

### DIFF
--- a/manager-bundle/bin/contao-console
+++ b/manager-bundle/bin/contao-console
@@ -17,13 +17,7 @@ use Symfony\Component\Console\Input\ArgvInput;
 
 set_time_limit(0);
 @ini_set('zlib.output_compression', '0');
-
-foreach ($_SERVER['argv'] as $arg) {
-    if (0 === strncmp($arg, '--format=', 9) && 0 !== strncmp($arg, '--format=txt', 12)) {
-        ini_set('display_errors', '0');
-        break;
-    }
-}
+@ini_set('display_errors', '0');
 
 if (file_exists(__DIR__.'/../autoload.php')) {
     $projectDir = \dirname(__DIR__, 2);

--- a/manager-bundle/bin/contao-console
+++ b/manager-bundle/bin/contao-console
@@ -18,6 +18,13 @@ use Symfony\Component\Console\Input\ArgvInput;
 set_time_limit(0);
 @ini_set('zlib.output_compression', '0');
 
+foreach ($_SERVER['argv'] as $arg) {
+    if (0 === strncmp($arg, '--format=', 9) && 0 !== strncmp($arg, '--format=txt', 12)) {
+        ini_set('display_errors', '0');
+        break;
+    }
+}
+
 if (file_exists(__DIR__.'/../autoload.php')) {
     $projectDir = \dirname(__DIR__, 2);
 } elseif (file_exists(__DIR__.'/../../../../autoload.php')) {


### PR DESCRIPTION
Fixes part of https://github.com/contao/contao-manager/issues/726

I think this needs to be fixed here directly because every usage of `--format=json` should never end up with invalid output due to printed PHP warnings. (And they still show up in STDERR)

But I’m not sure if we should instead just set `ini_set('display_errors', '0');` regardles of the `--format` option?