### PR TITLE
Fix return type of FilterIterator

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Filter/SqlFiles.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Filter/SqlFiles.php
@@ -20,7 +20,7 @@ class SqlFiles extends \RecursiveFilterIterator
 	 *
 	 * @return boolean True if the element is acceptable
 	 */
-	public function accept()
+	public function accept(): bool
 	{
 		if ($this->hasChildren())
 		{

--- a/core-bundle/src/Resources/contao/library/Contao/Filter/SyncExclude.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Filter/SyncExclude.php
@@ -26,7 +26,7 @@ class SyncExclude extends \RecursiveFilterIterator
 	 *
 	 * @return boolean True if the element is acceptable
 	 */
-	public function accept()
+	public function accept(): bool
 	{
 		// The resource is to be ignored
 		if (strncmp($this->current()->getFilename(), '.', 1) === 0)


### PR DESCRIPTION
Fixes ErrorException
> Deprecated: Return type of Contao\Filter\SyncExclude::accept() should either be compatible with FilterIterator::accept(): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice
