### PR TITLE
Fix a potential error when trying to log the deleted record

### DIFF
--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -1557,7 +1557,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 			}
 
 			// Add a log entry unless we are deleting from tl_log itself
-			if ($this->strTable != 'tl_log')
+			if ($this->strTable != 'tl_log' && isset($data[$this->strTable][0]['id']))
 			{
 				$this->log('DELETE FROM ' . $this->strTable . ' WHERE id=' . $data[$this->strTable][0]['id'], __METHOD__, TL_GENERAL);
 			}

--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -1516,7 +1516,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 		}
 
 		// There is no actual data to be deleted (see #5336)
-		if (!$affected)
+		if (empty($data))
 		{
 			if (!$blnDoNotRedirect)
 			{

--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -1515,6 +1515,17 @@ class DC_Table extends DataContainer implements \listable, \editable
 			}
 		}
 
+		// There is no actual data to be deleted (see #5336)
+		if (!$affected)
+		{
+			if (!$blnDoNotRedirect)
+			{
+				$this->redirect($this->getReferer());
+			}
+
+			return;
+		}
+
 		$this->import(BackendUser::class, 'User');
 
 		$objUndoStmt = $this->Database->prepare("INSERT INTO tl_undo (pid, tstamp, fromTable, query, affectedRows, data) VALUES (?, ?, ?, ?, ?, ?)")
@@ -1557,7 +1568,7 @@ class DC_Table extends DataContainer implements \listable, \editable
 			}
 
 			// Add a log entry unless we are deleting from tl_log itself
-			if ($this->strTable != 'tl_log' && isset($data[$this->strTable][0]['id']))
+			if ($this->strTable != 'tl_log')
 			{
 				$this->log('DELETE FROM ' . $this->strTable . ' WHERE id=' . $data[$this->strTable][0]['id'], __METHOD__, TL_GENERAL);
 			}


### PR DESCRIPTION
I've caught this error in Sentry. It's likely a total edge case and I'm not sure why it happens, but it does 🤷🏻‍♂️

<img width="936" alt="CleanShot 2022-10-04 at 11 30 16" src="https://user-images.githubusercontent.com/193483/193785506-40dbc499-6f77-4f47-93d5-7f12ba10b9ea.png">

URL:

```
https://domain.tld/contao?act=delete&do=page&id=4207&ref=He8_lyIa&rt=45b4feffc1d2a078e9d8.E2v8sFdgGEra2j-JKeapLXi2ZA4xtK3BIQn5DSvAsdU.dymL-TlWfRqNrHWwGLP9FT3nKlpr_szzYni0bkGm2-xiKJXFJC5vJquedg
```

Stack trace:

```
ErrorException: Warning: Trying to access array offset on value of type null
#15 /vendor/contao/core-bundle/src/Resources/contao/drivers/DC_Table.php(1525): Contao\DC_Table::delete
#14 /vendor/contao/core-bundle/src/Resources/contao/classes/Backend.php(667): Contao\Backend::getBackendModule
#13 /vendor/contao/core-bundle/src/Resources/contao/controllers/BackendMain.php(168): Contao\BackendMain::run
#12 /vendor/contao/core-bundle/src/Controller/BackendController.php(49): Contao\CoreBundle\Controller\BackendController::mainAction
#11 /vendor/symfony/http-kernel/HttpKernel.php(152): Symfony\Component\HttpKernel\HttpKernel::handleRaw
#10 /vendor/symfony/http-kernel/HttpKernel.php(74): Symfony\Component\HttpKernel\HttpKernel::handle
#9 /vendor/symfony/http-kernel/Kernel.php(202): Symfony\Component\HttpKernel\Kernel::handle
#8 /vendor/symfony/http-kernel/HttpCache/SubRequestHandler.php(86): Symfony\Component\HttpKernel\HttpCache\SubRequestHandler::handle
#7 /vendor/symfony/http-kernel/HttpCache/HttpCache.php(479): Symfony\Component\HttpKernel\HttpCache\HttpCache::forward
#6 /vendor/symfony/framework-bundle/HttpCache/HttpCache.php(73): Symfony\Bundle\FrameworkBundle\HttpCache\HttpCache::forward
#5 /vendor/symfony/http-kernel/HttpCache/HttpCache.php(452): Symfony\Component\HttpKernel\HttpCache\HttpCache::fetch
#4 /vendor/contao/manager-bundle/src/HttpKernel/ContaoCache.php(66): Contao\ManagerBundle\HttpKernel\ContaoCache::fetch
#3 /vendor/symfony/http-kernel/HttpCache/HttpCache.php(346): Symfony\Component\HttpKernel\HttpCache\HttpCache::lookup
#2 /vendor/symfony/http-kernel/HttpCache/HttpCache.php(224): Symfony\Component\HttpKernel\HttpCache\HttpCache::handle
#1 /vendor/friendsofsymfony/http-cache/src/SymfonyCache/EventDispatchingHttpCache.php(98): Contao\ManagerBundle\HttpKernel\ContaoCache::handle
#0 /web/index.php(44): null
```