### PR TITLE
Backport the localconfig file check to Contao 4.13

### DIFF
--- a/core-bundle/src/Resources/contao/drivers/DC_File.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_File.php
@@ -10,6 +10,7 @@
 
 namespace Contao;
 
+use Symfony\Component\Filesystem\Path;
 use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface;
 
 /**
@@ -258,8 +259,10 @@ class DC_File extends DataContainer implements EditableDataContainerInterface
 
 		$this->import(Files::class, 'Files');
 
+		$configFile = Path::join(System::getContainer()->getParameter('kernel.project_dir'), 'system/config/localconfig.php');
+
 		// Check whether the target file is writeable
-		if (!$this->Files->is_writeable('system/config/localconfig.php'))
+		if (file_exists($configFile) && !is_writable($configFile))
 		{
 			Message::addError(sprintf($GLOBALS['TL_LANG']['ERR']['notWriteable'], 'system/config/localconfig.php'));
 		}


### PR DESCRIPTION
Fixes #5210 for Contao 4.13.

Even in Contao 4 it is not strictly necessary to run the Install Tool once, especially if you use something like this in your application:

```yaml
# config/config.yaml
contao:
    localconfig:
        licenseAccepted: true
        installPassword: '%env(INSTALL_PASSWORD)%'
```

Hence even in Contao 4 the `system/config/localconfig.php` file might not exist yet when opening the back end system settings for the first time and thus the aforementioned error occurs.

This PR backports #5238 to Contao 4.13.