### PR TITLE
Evaluate custom regex in backend pwd validation.

### DIFF
--- a/core-bundle/src/Resources/contao/controllers/BackendPassword.php
+++ b/core-bundle/src/Resources/contao/controllers/BackendPassword.php
@@ -142,33 +142,26 @@ class BackendPassword extends Backend
 	 */
 	private function _evalRegexp($pw)
 	{
-		// no custom regex available
-		if (!isset($GLOBALS['TL_HOOKS']['addCustomRegexp']) || !\is_array($GLOBALS['TL_HOOKS']['addCustomRegexp']))
-		{
-			return false;
-		}
-
 		// load user data container
 		$this->loadDataContainer('tl_user');
 		$dc = new DC_Table('tl_user');
 		$dc->id = $this->User->id;
 
+		// no custom regex available
+		if (empty($GLOBALS['TL_DCA']['tl_user']['fields']['password']['eval']['rgxp']))
+		{
+			return false;
+		}
+
 		// load regex
-		$rgxp = $GLOBALS['TL_DCA']['tl_user']['fields']['password']['eval']['rgxp'];
 		$widget = new Password(Password::getAttributesFromDca($GLOBALS['TL_DCA']['tl_user']['fields']['password'], 'password'));
 		$widget->dataContainer = $dc;
+		$widget->validate();
 
-		// iterate over available regex hooks
-		foreach ($GLOBALS['TL_HOOKS']['addCustomRegexp'] as $callback)
+		// return the actual error message if it exists
+		if ($widget->hasErrors())
 		{
-			$this->import($callback[0]);
-			$break = $this->{$callback[0]}->{$callback[1]}($rgxp, $pw, $widget);
-
-			// return the actual error message if it exists
-			if ($break === true && $widget->hasErrors())
-			{
-				return $widget->getErrorsAsString();
-			}
+			return $widget->getErrorsAsString();
 		}
 
 		return false;

--- a/core-bundle/src/Resources/contao/controllers/BackendPassword.php
+++ b/core-bundle/src/Resources/contao/controllers/BackendPassword.php
@@ -11,7 +11,6 @@
 namespace Contao;
 
 use Contao\CoreBundle\Exception\AccessDeniedException;
-use Contao\DC_Table;
 use Symfony\Component\HttpFoundation\Response;
 
 /**

--- a/core-bundle/src/Resources/contao/controllers/BackendPassword.php
+++ b/core-bundle/src/Resources/contao/controllers/BackendPassword.php
@@ -58,7 +58,8 @@ class BackendPassword extends Backend
 
 			// Make sure the password gets evaluated against custom regex if they exist
 			// First rule, as these requirements are usually stronger than the default ones
-			if ($message = self::_evalRegexp($pw)) {
+			if ($message = self::_evalRegexp($pw))
+			{
 				Message::addError($message);
 			}
 			// Password too short
@@ -137,18 +138,20 @@ class BackendPassword extends Backend
 	/**
 	 * Evaluate custom regex. See https://github.com/contao/contao/issues/5316
 	 *
-	 * @param  string      The password
+	 * @param  string      $pw The password
 	 * @return bool|string The error message, false otherwise
 	 */
 	private function _evalRegexp($pw)
 	{
 		// no custom regex available
 		if (!isset($GLOBALS['TL_HOOKS']['addCustomRegexp']) || !\is_array($GLOBALS['TL_HOOKS']['addCustomRegexp']))
+		{
 			return false;
+		}
 
 		// load user data container
 		$this->loadDataContainer('tl_user');
-		$dc = new \DC_Table('tl_user');
+		$dc = new DC_Table('tl_user');
 		$dc->id = $this->User->id;
 
 		// load regex
@@ -157,12 +160,14 @@ class BackendPassword extends Backend
 		$widget->dataContainer = $dc;
 
 		// iterate over available regex hooks
-		foreach ($GLOBALS['TL_HOOKS']['addCustomRegexp'] as $callback) {
+		foreach ($GLOBALS['TL_HOOKS']['addCustomRegexp'] as $callback)
+		{
 			$this->import($callback[0]);
 			$break = $this->{$callback[0]}->{$callback[1]}($rgxp, $pw, $widget);
 
 			// return the actual error message if it exists
-			if ($break === true && $widget->hasErrors()) {
+			if ($break === true && $widget->hasErrors())
+			{
 				return $widget->getErrorsAsString();
 			}
 		}

--- a/core-bundle/src/Resources/contao/controllers/BackendPassword.php
+++ b/core-bundle/src/Resources/contao/controllers/BackendPassword.php
@@ -11,6 +11,7 @@
 namespace Contao;
 
 use Contao\CoreBundle\Exception\AccessDeniedException;
+use Contao\DC_Table;
 use Symfony\Component\HttpFoundation\Response;
 
 /**


### PR DESCRIPTION
This commit is based on the initial pull request https://github.com/contao/contao/pull/2190 that addresses https://github.com/terminal42/contao-password-validation/issues/3. In the context of https://github.com/contao/contao/issues/5316 the changes were rebased for Contao 4.13 and also refactored after initial tests.

Fixes #5316