### PR TITLE
Add a markdown help text

### DIFF
--- a/core-bundle/contao/languages/en/explain.xlf
+++ b/core-bundle/contao/languages/en/explain.xlf
@@ -6,19 +6,25 @@
         <source>Rich text editor</source>
       </trans-unit>
       <trans-unit id="XPL.insertTags.0.1">
-        <source>For more information on TinyMCE, please visit &lt;a href="https://www.tiny.cloud/tinymce/" target="_blank" rel="noreferrer noopener"&gt;https://www.tiny.cloud/tinymce/&lt;/a&gt;.</source>
+        <source>For more information about TinyMCE, see &lt;a href="https://www.tiny.cloud/tinymce/" target="_blank" rel="noreferrer noopener"&gt;https://www.tiny.cloud/tinymce/&lt;/a&gt;.</source>
       </trans-unit>
       <trans-unit id="XPL.insertTags.1.0">
         <source>Insert tags</source>
       </trans-unit>
       <trans-unit id="XPL.insertTags.1.1">
-        <source>For more information on insert tags, please visit &lt;a href="https://docs.contao.org/dev/framework/insert-tags/" target="_blank" rel="noreferrer noopener"&gt;https://docs.contao.org/dev/framework/insert-tags/&lt;/a&gt;.</source>
+        <source>For more information about insert tags, see &lt;a href="https://docs.contao.org/dev/framework/insert-tags/" target="_blank" rel="noreferrer noopener"&gt;https://docs.contao.org/dev/framework/insert-tags/&lt;/a&gt;.</source>
       </trans-unit>
       <trans-unit id="XPL.insertTags.2.0">
         <source>Code editor</source>
       </trans-unit>
       <trans-unit id="XPL.insertTags.2.1">
-        <source>For more information on Ace, please visit &lt;a href="https://ace.c9.io" target="_blank" rel="noreferrer noopener"&gt;https://ace.c9.io&lt;/a&gt;.</source>
+        <source>For more information about Ace, see &lt;a href="https://ace.c9.io" target="_blank" rel="noreferrer noopener"&gt;https://ace.c9.io&lt;/a&gt;.</source>
+      </trans-unit>
+      <trans-unit id="XPL.insertTags.3.0">
+        <source>Markdown</source>
+      </trans-unit>
+      <trans-unit id="XPL.insertTags.3.1">
+        <source>To learn more about markdown, see the &lt;a href="https://docs.contao.org/manual/en/article-management/content-elements/text-elements/#markdown" target="_blank" rel="noreferrer noopener"&gt;Contao manual&lt;/a&gt;.</source>
       </trans-unit>
       <trans-unit id="XPL.dateFormat.0.0">
         <source>colspan</source>


### PR DESCRIPTION
Implements #5263

<img width="853" alt="" src="https://user-images.githubusercontent.com/1192057/194353455-adfbd1a5-f65e-4563-a8f4-1173d5048206.png">
