### PR TITLE
Correctly pick fallback root page with domain

### DIFF
--- a/core-bundle/src/Resources/contao/models/PageModel.php
+++ b/core-bundle/src/Resources/contao/models/PageModel.php
@@ -718,6 +718,11 @@ class PageModel extends Model
 		if (isset($arrOptions['fallbackToEmpty']) && $arrOptions['fallbackToEmpty'] === true)
 		{
 			$arrColumns = array("($t.dns=? OR $t.dns='') AND $t.fallback='1'");
+
+			if (!isset($arrOptions['order']))
+			{
+				$arrOptions['order'] = "$t.dns DESC";
+			}
 		}
 
 		if (!static::isPreviewMode($arrOptions))


### PR DESCRIPTION
When looking for the fallback root page (e.g. SitemapController and RobotsTxtController), it currently can return the wrong root page if one exists with and without host name. In my case the root page without DNS was added first, which resulted in it being incorrectly returned.