### PR TITLE
Fix an "unknown system variable" error

### DIFF
--- a/core-bundle/src/Doctrine/Schema/MysqlInnodbRowSizeCalculator.php
+++ b/core-bundle/src/Doctrine/Schema/MysqlInnodbRowSizeCalculator.php
@@ -85,7 +85,10 @@ class MysqlInnodbRowSizeCalculator
     {
         static $size = null;
 
-        return $size ??= (int) $this->connection->executeQuery('SELECT @@innodb_page_size / 2 - 66')->fetchOne();
+        return $size ??= (int) (
+            $this->connection->executeQuery("SHOW STATUS LIKE 'innodb_page_size'")->fetchAssociative()['Value']
+            / 2 - 66
+        );
     }
 
     public function measureMysqlColumnSizeBits(Column $column, string $charset): int

--- a/core-bundle/src/Doctrine/Schema/MysqlInnodbRowSizeCalculator.php
+++ b/core-bundle/src/Doctrine/Schema/MysqlInnodbRowSizeCalculator.php
@@ -85,10 +85,12 @@ class MysqlInnodbRowSizeCalculator
     {
         static $size = null;
 
-        return $size ??= (int) (
-            $this->connection->executeQuery("SHOW STATUS LIKE 'innodb_page_size'")->fetchAssociative()['Value']
-            / 2 - 66
-        );
+        if (null === $size) {
+            $res = $this->connection->executeQuery("SHOW STATUS LIKE 'innodb_page_size'");
+            $size = (int) ($res->fetchAssociative()['Value'] / 2 - 66);
+        }
+
+        return $size;
     }
 
     public function measureMysqlColumnSizeBits(Column $column, string $charset): int


### PR DESCRIPTION
Running the migrate command with a MySQL 5.5 server currently results in `ER_UNKNOWN_SYSTEM_VARIABLE: Unknown system variable 'innodb_page_size'`

/cc @fritzmg 