### PR TITLE
Fix `DC_Folder` ID not being determined correctly due to special characters

### DIFF
--- a/core-bundle/src/Resources/contao/classes/Ajax.php
+++ b/core-bundle/src/Resources/contao/classes/Ajax.php
@@ -268,7 +268,7 @@ class Ajax extends Backend
 			case 'reloadPagetree':
 			case 'reloadFiletree':
 			case 'reloadPicker':
-				$intId = Input::get('id');
+				$intId = Input::get('id', true);
 				$strField = $dc->inputName = Input::post('name');
 
 				// Handle the keys in "edit multiple" mode
@@ -297,7 +297,7 @@ class Ajax extends Backend
 					{
 						$varValue = Config::get($strField);
 					}
-					elseif ($intId > 0 && $this->Database->tableExists($dc->table))
+					elseif ($intId && $this->Database->tableExists($dc->table))
 					{
 						$idField = 'id';
 
@@ -313,7 +313,7 @@ class Ajax extends Backend
 						// The record does not exist
 						if ($objRow->numRows < 1)
 						{
-							$this->log('A record with the ID "' . $intId . '" does not exist in table "' . $dc->table . '"', __METHOD__, TL_ERROR);
+							$this->log('A record with the ID "' . Input::encodeSpecialChars($intId) . '" does not exist in table "' . $dc->table . '"', __METHOD__, TL_ERROR);
 
 							throw new BadRequestHttpException('Bad request');
 						}

--- a/core-bundle/src/Resources/contao/classes/Backend.php
+++ b/core-bundle/src/Resources/contao/classes/Backend.php
@@ -661,7 +661,7 @@ abstract class Backend extends Controller
 			return null;
 		}
 
-		$id = Input::get('id');
+		$id = Input::get('id', true);
 		$pid = Input::get('pid');
 		$act = Input::get('act');
 		$mode = Input::get('mode');

--- a/core-bundle/src/Resources/contao/classes/Backend.php
+++ b/core-bundle/src/Resources/contao/classes/Backend.php
@@ -661,7 +661,7 @@ abstract class Backend extends Controller
 			return null;
 		}
 
-		$id = Input::get('id', true);
+		$id = Input::get('id');
 		$pid = Input::get('pid');
 		$act = Input::get('act');
 		$mode = Input::get('mode');


### PR DESCRIPTION
Within `DC_Folder` the `id` parameter is not a numeric ID, but the path of the file. Entries from `tl_files` are retrieved via `tl_files.path`, rather than `tl_files.uuid` or `tl_files.id`. However, this will fail if the path contains special characters. So for a file like

```
files/foobar/moo(bar).jpg
```

The query in `Ajax::executePostActions` would thus be

```
SELECT * FROM tl_files WHERE path = 'files/foobar/moo&#41;bar&#92;.jpg';
```

resulting in a Bad Request.