### PR TITLE
Backport the database configuration error checks

### DIFF
--- a/core-bundle/tests/Command/MigrateCommandTest.php
+++ b/core-bundle/tests/Command/MigrateCommandTest.php
@@ -608,6 +608,7 @@ class MigrateCommandTest extends TestCase
                     switch ($query) {
                         case 'SELECT @@sql_mode':
                             return $sqlMode;
+
                         case 'SELECT @@version':
                             return '8.0.0';
 

--- a/core-bundle/tests/Command/MigrateCommandTest.php
+++ b/core-bundle/tests/Command/MigrateCommandTest.php
@@ -604,10 +604,16 @@ class MigrateCommandTest extends TestCase
         $connection
             ->method('fetchOne')
             ->willReturnCallback(
-                static fn (string $query): string|false => match ($query) {
-                    'SELECT @@sql_mode' => $sqlMode,
-                    'SELECT @@version' => '8.0.0',
-                    default => false,
+                static function (string $query) use ($sqlMode) {
+                    switch ($query) {
+                        case 'SELECT @@sql_mode':
+                            return $sqlMode;
+                        case 'SELECT @@version':
+                            return '8.0.0';
+
+                        default:
+                            return false;
+                    }
                 }
             )
         ;


### PR DESCRIPTION
Fixes #4970 

This PR backports the database configuration error checks in the `MigrateCommand` to Contao 4.13. They were originally introduced in #4935 (5.0) when removing the Install tool. I did only adjust the existing tests but did not port the tests for the error checks to minimize the amount of work needed when merging upstream.

