### PR TITLE
Rename the internal route name for generating page routes

### DIFF
--- a/core-bundle/src/EventListener/DataContainer/PageUrlListener.php
+++ b/core-bundle/src/EventListener/DataContainer/PageUrlListener.php
@@ -16,6 +16,7 @@ use Contao\CoreBundle\Exception\DuplicateAliasException;
 use Contao\CoreBundle\Exception\RouteParametersException;
 use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\CoreBundle\Routing\Page\PageRegistry;
+use Contao\CoreBundle\Routing\Page\PageRoute;
 use Contao\CoreBundle\ServiceAnnotation\Callback;
 use Contao\CoreBundle\Slug\Slug;
 use Contao\DataContainer;
@@ -215,7 +216,7 @@ class PageUrlListener
 
         try {
             $currentUrl = $this->urlGenerator->generate(
-                RouteObjectInterface::OBJECT_BASED_ROUTE_NAME,
+                PageRoute::PAGE_BASED_ROUTE_NAME,
                 [RouteObjectInterface::ROUTE_OBJECT => $currentRoute],
                 UrlGeneratorInterface::ABSOLUTE_URL
             );

--- a/core-bundle/src/Resources/contao/classes/Frontend.php
+++ b/core-bundle/src/Resources/contao/classes/Frontend.php
@@ -13,6 +13,7 @@ namespace Contao;
 use Contao\CoreBundle\Exception\LegacyRoutingException;
 use Contao\CoreBundle\Exception\NoRootPageFoundException;
 use Contao\CoreBundle\Framework\ContaoFramework;
+use Contao\CoreBundle\Routing\Page\PageRoute;
 use Contao\CoreBundle\Search\Document;
 use Contao\CoreBundle\Util\LocaleUtil;
 use Symfony\Cmf\Component\Routing\RouteObjectInterface;
@@ -465,7 +466,7 @@ abstract class Frontend extends Controller
 			}
 		}
 
-		$strUrl = System::getContainer()->get('router')->generate(RouteObjectInterface::OBJECT_BASED_ROUTE_NAME, array(RouteObjectInterface::CONTENT_OBJECT => $objPage, 'parameters' => $strParams));
+		$strUrl = System::getContainer()->get('router')->generate(PageRoute::PAGE_BASED_ROUTE_NAME, array(RouteObjectInterface::CONTENT_OBJECT => $objPage, 'parameters' => $strParams));
 		$strUrl = substr($strUrl, \strlen(Environment::get('path')) + 1);
 
 		return $strUrl;

--- a/core-bundle/src/Resources/contao/library/Contao/Controller.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Controller.php
@@ -17,6 +17,7 @@ use Contao\CoreBundle\Exception\PageNotFoundException;
 use Contao\CoreBundle\Exception\RedirectResponseException;
 use Contao\CoreBundle\File\Metadata;
 use Contao\CoreBundle\Framework\ContaoFramework;
+use Contao\CoreBundle\Routing\Page\PageRoute;
 use Contao\CoreBundle\Security\ContaoCorePermissions;
 use Contao\CoreBundle\Twig\Inheritance\TemplateHierarchyInterface;
 use Contao\CoreBundle\Util\LocaleUtil;
@@ -1298,7 +1299,7 @@ abstract class Controller extends System
 		}
 
 		$objRouter = System::getContainer()->get('router');
-		$strUrl = $objRouter->generate(RouteObjectInterface::OBJECT_BASED_ROUTE_NAME, array(RouteObjectInterface::CONTENT_OBJECT => $page, 'parameters' => $strParams));
+		$strUrl = $objRouter->generate(PageRoute::PAGE_BASED_ROUTE_NAME, array(RouteObjectInterface::CONTENT_OBJECT => $page, 'parameters' => $strParams));
 
 		// Remove path from absolute URLs
 		if (0 === strncmp($strUrl, '/', 1) && 0 !== strncmp($strUrl, '//', 2))

--- a/core-bundle/src/Resources/contao/models/PageModel.php
+++ b/core-bundle/src/Resources/contao/models/PageModel.php
@@ -11,6 +11,7 @@
 namespace Contao;
 
 use Contao\CoreBundle\Exception\NoRootPageFoundException;
+use Contao\CoreBundle\Routing\Page\PageRoute;
 use Contao\CoreBundle\Routing\ResponseContext\HtmlHeadBag\HtmlHeadBag;
 use Contao\CoreBundle\Routing\ResponseContext\JsonLd\ContaoPageSchema;
 use Contao\CoreBundle\Routing\ResponseContext\JsonLd\JsonLdManager;
@@ -1362,7 +1363,7 @@ class PageModel extends Model
 
 		try
 		{
-			$strUrl = $objRouter->generate(RouteObjectInterface::OBJECT_BASED_ROUTE_NAME, array(RouteObjectInterface::CONTENT_OBJECT => $this, 'parameters' => $strParams));
+			$strUrl = $objRouter->generate(PageRoute::PAGE_BASED_ROUTE_NAME, array(RouteObjectInterface::CONTENT_OBJECT => $this, 'parameters' => $strParams));
 		}
 		catch (RouteNotFoundException $e)
 		{
@@ -1403,7 +1404,7 @@ class PageModel extends Model
 
 		try
 		{
-			$strUrl = $objRouter->generate(RouteObjectInterface::OBJECT_BASED_ROUTE_NAME, array(RouteObjectInterface::CONTENT_OBJECT => $this, 'parameters' => $strParams), UrlGeneratorInterface::ABSOLUTE_URL);
+			$strUrl = $objRouter->generate(PageRoute::PAGE_BASED_ROUTE_NAME, array(RouteObjectInterface::CONTENT_OBJECT => $this, 'parameters' => $strParams), UrlGeneratorInterface::ABSOLUTE_URL);
 		}
 		catch (RouteNotFoundException $e)
 		{
@@ -1451,7 +1452,7 @@ class PageModel extends Model
 
 		try
 		{
-			$strUrl = $objRouter->generate(RouteObjectInterface::OBJECT_BASED_ROUTE_NAME, array(RouteObjectInterface::CONTENT_OBJECT => $this, 'parameters' => $strParams), UrlGeneratorInterface::ABSOLUTE_URL);
+			$strUrl = $objRouter->generate(PageRoute::PAGE_BASED_ROUTE_NAME, array(RouteObjectInterface::CONTENT_OBJECT => $this, 'parameters' => $strParams), UrlGeneratorInterface::ABSOLUTE_URL);
 		}
 		catch (RouteNotFoundException $e)
 		{

--- a/core-bundle/src/Routing/Page/PageRoute.php
+++ b/core-bundle/src/Routing/Page/PageRoute.php
@@ -20,6 +20,8 @@ use Symfony\Component\Routing\Route;
 
 class PageRoute extends Route implements RouteObjectInterface
 {
+    public const PAGE_BASED_ROUTE_NAME = 'page_routing_object';
+
     private PageModel $pageModel;
     private ?string $urlPrefix;
     private ?string $urlSuffix;

--- a/core-bundle/src/Routing/PageUrlGenerator.php
+++ b/core-bundle/src/Routing/PageUrlGenerator.php
@@ -41,10 +41,25 @@ class PageUrlGenerator extends SymfonyUrlGenerator
     public function generate(string $name, array $parameters = [], int $referenceType = self::ABSOLUTE_PATH): string
     {
         if (
+            PageRoute::PAGE_BASED_ROUTE_NAME === $name
+            && \array_key_exists(RouteObjectInterface::CONTENT_OBJECT, $parameters)
+            && $parameters[RouteObjectInterface::CONTENT_OBJECT] instanceof PageModel
+        ) {
+            $route = $this->pageRegistry->getRoute($parameters[RouteObjectInterface::CONTENT_OBJECT]);
+            unset($parameters[RouteObjectInterface::CONTENT_OBJECT]);
+        } elseif (
+            PageRoute::PAGE_BASED_ROUTE_NAME === $name
+            && \array_key_exists(RouteObjectInterface::ROUTE_OBJECT, $parameters)
+            && $parameters[RouteObjectInterface::ROUTE_OBJECT] instanceof PageRoute
+        ) {
+            $route = $parameters[RouteObjectInterface::ROUTE_OBJECT];
+            unset($parameters[RouteObjectInterface::ROUTE_OBJECT]);
+        } elseif (
             RouteObjectInterface::OBJECT_BASED_ROUTE_NAME === $name
             && \array_key_exists(RouteObjectInterface::CONTENT_OBJECT, $parameters)
             && $parameters[RouteObjectInterface::CONTENT_OBJECT] instanceof PageModel
         ) {
+            trigger_deprecation('contao/core-bundle', '4.13.13', 'RouteObjectInterface::OBJECT_BASED_ROUTE_NAME should not be used to generate a page URL, use PageRoute::PAGE_BASED_ROUTE_NAME instead.');
             $route = $this->pageRegistry->getRoute($parameters[RouteObjectInterface::CONTENT_OBJECT]);
             unset($parameters[RouteObjectInterface::CONTENT_OBJECT]);
         } elseif (
@@ -52,6 +67,7 @@ class PageUrlGenerator extends SymfonyUrlGenerator
             && \array_key_exists(RouteObjectInterface::ROUTE_OBJECT, $parameters)
             && $parameters[RouteObjectInterface::ROUTE_OBJECT] instanceof PageRoute
         ) {
+            trigger_deprecation('contao/core-bundle', '4.13.13', 'RouteObjectInterface::OBJECT_BASED_ROUTE_NAME should not be used to generate a page URL, use PageRoute::PAGE_BASED_ROUTE_NAME instead.');
             $route = $parameters[RouteObjectInterface::ROUTE_OBJECT];
             unset($parameters[RouteObjectInterface::ROUTE_OBJECT]);
         } else {

--- a/core-bundle/src/Routing/PageUrlGenerator.php
+++ b/core-bundle/src/Routing/PageUrlGenerator.php
@@ -59,7 +59,7 @@ class PageUrlGenerator extends SymfonyUrlGenerator
             && \array_key_exists(RouteObjectInterface::CONTENT_OBJECT, $parameters)
             && $parameters[RouteObjectInterface::CONTENT_OBJECT] instanceof PageModel
         ) {
-            trigger_deprecation('contao/core-bundle', '4.13.13', 'RouteObjectInterface::OBJECT_BASED_ROUTE_NAME should not be used to generate a page URL, use PageRoute::PAGE_BASED_ROUTE_NAME instead.');
+            trigger_deprecation('contao/core-bundle', '4.13', 'Using RouteObjectInterface::OBJECT_BASED_ROUTE_NAME to generate page URLs has been deprecated and will no longer work in Contao 6.0. Use PageRoute::PAGE_BASED_ROUTE_NAME instead.');
             $route = $this->pageRegistry->getRoute($parameters[RouteObjectInterface::CONTENT_OBJECT]);
             unset($parameters[RouteObjectInterface::CONTENT_OBJECT]);
         } elseif (
@@ -67,7 +67,7 @@ class PageUrlGenerator extends SymfonyUrlGenerator
             && \array_key_exists(RouteObjectInterface::ROUTE_OBJECT, $parameters)
             && $parameters[RouteObjectInterface::ROUTE_OBJECT] instanceof PageRoute
         ) {
-            trigger_deprecation('contao/core-bundle', '4.13.13', 'RouteObjectInterface::OBJECT_BASED_ROUTE_NAME should not be used to generate a page URL, use PageRoute::PAGE_BASED_ROUTE_NAME instead.');
+            trigger_deprecation('contao/core-bundle', '4.13', 'Using RouteObjectInterface::OBJECT_BASED_ROUTE_NAME to generate page URLs has been deprecated and will no longer work in Contao 6.0. Use PageRoute::PAGE_BASED_ROUTE_NAME instead.');
             $route = $parameters[RouteObjectInterface::ROUTE_OBJECT];
             unset($parameters[RouteObjectInterface::ROUTE_OBJECT]);
         } else {

--- a/core-bundle/tests/EventListener/DataContainer/PageUrlListenerTest.php
+++ b/core-bundle/tests/EventListener/DataContainer/PageUrlListenerTest.php
@@ -1827,7 +1827,7 @@ class PageUrlListenerTest extends TestCase
                 ->expects($this->atLeastOnce())
                 ->method('generate')
                 ->with(
-                    RouteObjectInterface::OBJECT_BASED_ROUTE_NAME,
+                    PageRoute::PAGE_BASED_ROUTE_NAME,
                     [RouteObjectInterface::ROUTE_OBJECT => $route],
                     UrlGeneratorInterface::ABSOLUTE_URL,
                 )
@@ -1838,7 +1838,7 @@ class PageUrlListenerTest extends TestCase
                 ->expects($this->exactly($route))
                 ->method('generate')
                 ->with(
-                    RouteObjectInterface::OBJECT_BASED_ROUTE_NAME,
+                    PageRoute::PAGE_BASED_ROUTE_NAME,
                     $this->isType('array'),
                     UrlGeneratorInterface::ABSOLUTE_URL,
                 )

--- a/core-bundle/tests/Routing/PageUrlGeneratorTest.php
+++ b/core-bundle/tests/Routing/PageUrlGeneratorTest.php
@@ -66,7 +66,7 @@ class PageUrlGeneratorTest extends TestCase
         ;
 
         $url = $this->generator->generate(
-            RouteObjectInterface::OBJECT_BASED_ROUTE_NAME,
+            PageRoute::PAGE_BASED_ROUTE_NAME,
             [RouteObjectInterface::CONTENT_OBJECT => $page],
             UrlGeneratorInterface::ABSOLUTE_URL
         );
@@ -98,7 +98,7 @@ class PageUrlGeneratorTest extends TestCase
         ;
 
         $url = $this->generator->generate(
-            RouteObjectInterface::OBJECT_BASED_ROUTE_NAME,
+            PageRoute::PAGE_BASED_ROUTE_NAME,
             [RouteObjectInterface::CONTENT_OBJECT => $page],
             UrlGeneratorInterface::ABSOLUTE_URL
         );
@@ -130,7 +130,7 @@ class PageUrlGeneratorTest extends TestCase
         ;
 
         $url = $this->generator->generate(
-            RouteObjectInterface::OBJECT_BASED_ROUTE_NAME,
+            PageRoute::PAGE_BASED_ROUTE_NAME,
             [RouteObjectInterface::CONTENT_OBJECT => $page, 'parameters' => null],
             UrlGeneratorInterface::ABSOLUTE_URL
         );
@@ -162,7 +162,7 @@ class PageUrlGeneratorTest extends TestCase
         ;
 
         $url = $this->generator->generate(
-            RouteObjectInterface::OBJECT_BASED_ROUTE_NAME,
+            PageRoute::PAGE_BASED_ROUTE_NAME,
             [RouteObjectInterface::CONTENT_OBJECT => $page, 'parameters' => '/foobar'],
             UrlGeneratorInterface::ABSOLUTE_URL
         );
@@ -194,7 +194,7 @@ class PageUrlGeneratorTest extends TestCase
         ;
 
         $url = $this->generator->generate(
-            RouteObjectInterface::OBJECT_BASED_ROUTE_NAME,
+            PageRoute::PAGE_BASED_ROUTE_NAME,
             [RouteObjectInterface::CONTENT_OBJECT => $page],
             UrlGeneratorInterface::ABSOLUTE_URL
         );
@@ -229,7 +229,7 @@ class PageUrlGeneratorTest extends TestCase
 
         try {
             $this->generator->generate(
-                RouteObjectInterface::OBJECT_BASED_ROUTE_NAME,
+                PageRoute::PAGE_BASED_ROUTE_NAME,
                 [RouteObjectInterface::CONTENT_OBJECT => $page, 'bar' => 'baz'],
                 UrlGeneratorInterface::NETWORK_PATH
             );


### PR DESCRIPTION
Fixes https://github.com/terminal42/contao-shortlink/issues/20

I have noticed an issue with our current routing implementation which might need some explanation.

Symfony CMF replaces the regular Symfony router with a chain router that allows multiple routers to handle route matching and generating. By default, the chain consists of the regular Sf router plus our route provider.

When generating a route, Sf enforces the route to have a name, it is not possible to generate a route for an object. Symfony CMF works around this by using a generic name and placing the route object in the attribute. We re-use this implementation for our own URL generator that knows about page routes.

However, there is a problem as soon as a third router is added to the chain router (done so e.g. by our shortlink extension). Since we use the generic CMF name for generating our routes, **but we do not handle them as if they are generic**, any other URL generator that understands the generic name and has a higher priority will try to handle them.

I've discussed this with @Toflar and imho the correct solution would be to change our internal route name. Since we do **not** want the default CMF router to ever handle our specific routes, we should not use their default name.