### PR TITLE
Draft of URL rewrites

### DIFF
--- a/core-bundle/config/controller.yaml
+++ b/core-bundle/config/controller.yaml
@@ -176,3 +176,9 @@ services:
             - '@contao.routing.page_registry'
         tags:
             - controller.service_arguments
+
+    Contao\CoreBundle\Controller\UrlRewriteController:
+        arguments:
+            - '@contao.insert_tag.parser'
+        tags:
+            - controller.service_arguments

--- a/core-bundle/config/listener.yaml
+++ b/core-bundle/config/listener.yaml
@@ -170,6 +170,23 @@ services:
             - '@contao.twig.loader.theme_namespace'
             - '@translator'
 
+    contao.listener.data_container.rewrite.name_validation:
+        class: Contao\CoreBundle\EventListener\DataContainer\Rewrite\NameValidationListener
+        arguments:
+            - '@contao.framework'
+
+    contao.listener.data_container.rewrite.request_requirement_validation:
+        class: Contao\CoreBundle\EventListener\DataContainer\Rewrite\RequestRequirementsValidationListener
+
+    contao.listener.data_container.rewrite.response_code_options:
+        class: Contao\CoreBundle\EventListener\DataContainer\Rewrite\ResponseCodeOptionsListener
+
+    contao.listener.data_container.rewrite.rewrite_examples:
+        class: Contao\CoreBundle\EventListener\DataContainer\Rewrite\RewriteExamplesListener
+
+    contao.listener.data_container.rewrite.rewrite_label:
+        class: Contao\CoreBundle\EventListener\DataContainer\Rewrite\RewriteLabelListener
+
     contao.listener.data_container.undo.jump_to_parent_button:
         class: Contao\CoreBundle\EventListener\DataContainer\Undo\JumpToParentButtonListener
         arguments:

--- a/core-bundle/config/services.yaml
+++ b/core-bundle/config/services.yaml
@@ -674,6 +674,35 @@ services:
             - '@request_stack'
             - '@contao.insert_tag.parser'
 
+    contao.routing.rewrite_router:
+        class: Symfony\Cmf\Component\Routing\DynamicRouter
+        arguments:
+            - '@router.request_context'
+            - '@contao.routing.rewrite_nested_matcher'
+            - '@contao.routing.rewrite_url_generator'
+            - ''
+            - '@event_dispatcher'
+            - '@contao.routing.rewrite_route_provider'
+        tags:
+            - { name: router, priority: 80 }
+
+    contao.routing.rewrite_nested_matcher:
+        class: Symfony\Cmf\Component\Routing\NestedMatcher\NestedMatcher
+        arguments:
+            - '@contao.routing.rewrite_route_provider'
+            - '@contao.routing.url_matcher'
+
+    contao.routing.rewrite_route_provider:
+        class: Contao\CoreBundle\Routing\RewriteRouteProvider
+        arguments:
+            - '@database_connection'
+
+    contao.routing.rewrite_url_generator:
+        class: Symfony\Cmf\Component\Routing\ProviderBasedGenerator
+        arguments:
+            - '@contao.routing.rewrite_route_provider'
+            - '@logger'
+
     contao.routing.route_404_provider:
         class: Contao\CoreBundle\Routing\Route404Provider
         arguments:

--- a/core-bundle/contao/config/config.php
+++ b/core-bundle/contao/config/config.php
@@ -208,6 +208,10 @@ $GLOBALS['BE_MOD'] = array
 			'tables'                  => array('tl_preview_link'),
 			'javascript'              => 'bundles/contaocore/clipboard.min.js'
 		),
+		'url_rewrite' => array
+		(
+			'tables'                  => array('tl_url_rewrite'),
+		),
 		'opt_in' => array
 		(
 			'tables'                  => array('tl_opt_in'),

--- a/core-bundle/contao/dca/tl_url_rewrite.php
+++ b/core-bundle/contao/dca/tl_url_rewrite.php
@@ -1,0 +1,164 @@
+<?php
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+use Contao\DC_Table;
+
+$GLOBALS['TL_DCA']['tl_url_rewrite'] = [
+    // Config
+    'config' => [
+        'dataContainer' => DC_Table::class,
+        'enableVersioning' => true,
+        'sql' => [
+            'keys' => [
+                'id' => 'primary',
+            ],
+        ],
+    ],
+
+    // List
+    'list' => [
+        'sorting' => [
+            'mode' => 2,
+            'fields' => ['name'],
+            'flag' => 1,
+            'panelLayout' => 'filter;sort,search,limit',
+        ],
+        'label' => [
+            'fields' => ['name'],
+            'format' => '%s',
+        ],
+        'global_operations' => [
+            'all' => [
+                'label' => &$GLOBALS['TL_LANG']['MSC']['all'],
+                'href' => 'act=select',
+                'class' => 'header_edit_all',
+                'attributes' => 'onclick="Backend.getScrollOffset()" accesskey="e"',
+            ],
+        ],
+    ],
+
+    // Palettes
+    'palettes' => [
+        '__selector__' => ['type', 'responseCode'],
+        'default' => '{name_legend},name,type,priority,comment,disable',
+        'basic' => '{name_legend},name,type,priority,comment,disable;{request_legend},requestHost,requestPath,requestRequirements;{response_legend},responseCode;{examples_legend},examples',
+        'expert' => '{name_legend},name,type,priority,comment,disable;{request_legend},requestHost,requestPath,requestCondition;{response_legend},responseCode;{examples_legend},examples',
+    ],
+
+    // Subpalettes
+    'subpalettes' => [
+        'responseCode_301' => 'responseUri',
+        'responseCode_302' => 'responseUri',
+        'responseCode_303' => 'responseUri',
+        'responseCode_307' => 'responseUri',
+    ],
+
+    // Fields
+    'fields' => [
+        'id' => [
+            'sql' => 'int(10) unsigned NOT NULL auto_increment',
+        ],
+        'tstamp' => [
+            'sql' => "int(10) unsigned NOT NULL default '0'",
+        ],
+        'name' => [
+            'search' => true,
+            'sorting' => true,
+            'inputType' => 'text',
+            'eval' => ['maxlength' => 255, 'tl_class' => 'w50'],
+            'flag' => 1,
+            'sql' => ['type' => 'string', 'length' => 255, 'default' => ''],
+        ],
+        'type' => [
+            'default' => 'basic',
+            'filter' => true,
+            'inputType' => 'select',
+            'options' => ['basic', 'expert'],
+            'reference' => &$GLOBALS['TL_LANG']['tl_url_rewrite']['typeRef'],
+            'eval' => ['submitOnChange' => true, 'helpwizard' => true, 'tl_class' => 'w50'],
+            'sql' => ['type' => 'string', 'length' => 255, 'default' => ''],
+        ],
+        'priority' => [
+            'default' => '0',
+            'filter' => true,
+            'sorting' => true,
+            'flag' => 12,
+            'inputType' => 'text',
+            'eval' => ['tl_class' => 'w50'],
+            'sql' => ['type' => 'integer', 'default' => '0'],
+            'save_callback' => [static function ($value) {
+                if (!preg_match('/^-?\d+$/', $value)) {
+                    throw new \RuntimeException($GLOBALS['TL_LANG']['ERR']['digit']);
+                }
+
+                return $value;
+            }]
+        ],
+        'comment' => [
+            'search' => true,
+            'inputType' => 'text',
+            'eval' => ['maxlength' => 255, 'tl_class' => 'w50'],
+            'sql' => ['type' => 'string', 'length' => 255, 'default' => ''],
+        ],
+        'disable' => [
+			'reverseToggle' => true,
+            'filter' => true,
+            'inputType' => 'checkbox',
+            'eval' => ['tl_class' => 'clr'],
+            'sql' => ['type' => 'boolean', 'default' => 0],
+        ],
+        'requestHost' => [
+            'search' => true,
+            'inputType' => 'text',
+            'eval' => ['tl_class' => 'clr'],
+            'sql' => ['type' => 'string', 'default' => ''],
+        ],
+        'requestPath' => [
+            'search' => true,
+            'inputType' => 'text',
+            'eval' => ['mandatory' => true, 'tl_class' => 'long clr'],
+            'sql' => ['type' => 'string', 'default' => ''],
+        ],
+        'requestRequirements' => [
+            'inputType' => 'keyValueWizard',
+            'eval' => ['decodeEntities' => true, 'tl_class' => 'clr'],
+            'sql' => ['type' => 'blob', 'notnull' => false],
+        ],
+        'requestCondition' => [
+            'inputType' => 'text',
+            'eval' => ['mandatory' => true, 'decodeEntities' => true, 'tl_class' => 'clr'],
+            'sql' => ['type' => 'string', 'default' => ''],
+        ],
+        'responseCode' => [
+            'default' => 301,
+            'filter' => true,
+            'sorting' => true,
+            'flag' => 11,
+            'inputType' => 'select',
+            'eval' => ['submitOnChange' => true, 'tl_class' => 'w50'],
+            'sql' => ['type' => 'integer', 'unsigned' => true],
+        ],
+        'responseUri' => [
+            'search' => true,
+            'inputType' => 'text',
+            'eval' => [
+                'decodeEntities' => true,
+                'dcaPicker' => true,
+                'fieldType' => 'radio',
+                'filesOnly' => true,
+                'tl_class' => 'clr wizard',
+            ],
+            'sql' => ['type' => 'text', 'notnull' => false],
+        ],
+        'examples' => [
+            // input_field_callback from RewriteExamplesListener
+        ],
+    ],
+];

--- a/core-bundle/contao/languages/en/modules.xlf
+++ b/core-bundle/contao/languages/en/modules.xlf
@@ -98,6 +98,9 @@
       <trans-unit id="MOD.preview_link.1">
         <source>Manage preview links for the front end.</source>
       </trans-unit>
+      <trans-unit id="MOD.url_rewrite.0">
+        <source>URL rewrites</source>
+      </trans-unit>
       <trans-unit id="MOD.maintenance.0">
         <source>Maintenance</source>
       </trans-unit>

--- a/core-bundle/contao/languages/en/tl_url_rewrite.xlf
+++ b/core-bundle/contao/languages/en/tl_url_rewrite.xlf
@@ -26,10 +26,10 @@
             <trans-unit id="tl_url_rewrite.comment.1">
                 <source>Please enter a comment (visible only in backend).</source>
             </trans-unit>
-            <trans-unit id="tl_url_rewrite.inactive.0">
+            <trans-unit id="tl_url_rewrite.disable.0">
                 <source>Deactivate the rule</source>
             </trans-unit>
-            <trans-unit id="tl_url_rewrite.inactive.1">
+            <trans-unit id="tl_url_rewrite.disable.1">
                 <source>Deactivate the rewrite rule. It will not be loaded into the router configuration.</source>
             </trans-unit>
             <trans-unit id="tl_url_rewrite.requestHost.0">

--- a/core-bundle/contao/languages/en/tl_url_rewrite.xlf
+++ b/core-bundle/contao/languages/en/tl_url_rewrite.xlf
@@ -1,0 +1,180 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.1">
+    <file datatype="php" original="contao/languages/en/tl_url_rewrite.php" source-language="en" >
+        <body>
+            <trans-unit id="tl_url_rewrite.name.0">
+                <source>Internal name</source>
+            </trans-unit>
+            <trans-unit id="tl_url_rewrite.name.1">
+                <source>Please enter the rewrite internal name (visible only in backend).</source>
+            </trans-unit>
+            <trans-unit id="tl_url_rewrite.type.0">
+                <source>Type</source>
+            </trans-unit>
+            <trans-unit id="tl_url_rewrite.type.1">
+                <source>Here you can choose the type.</source>
+            </trans-unit>
+            <trans-unit id="tl_url_rewrite.priority.0">
+                <source>Priority</source>
+            </trans-unit>
+            <trans-unit id="tl_url_rewrite.priority.1">
+                <source>Here you can define a priority sorted descending.</source>
+            </trans-unit>
+            <trans-unit id="tl_url_rewrite.comment.0">
+                <source>Comment</source>
+            </trans-unit>
+            <trans-unit id="tl_url_rewrite.comment.1">
+                <source>Please enter a comment (visible only in backend).</source>
+            </trans-unit>
+            <trans-unit id="tl_url_rewrite.inactive.0">
+                <source>Deactivate the rule</source>
+            </trans-unit>
+            <trans-unit id="tl_url_rewrite.inactive.1">
+                <source>Deactivate the rewrite rule. It will not be loaded into the router configuration.</source>
+            </trans-unit>
+            <trans-unit id="tl_url_rewrite.requestHost.0">
+                <source>Host restriction</source>
+            </trans-unit>
+            <trans-unit id="tl_url_rewrite.requestHost.1">
+                <source>Here you can restrict the rule to a host.</source>
+            </trans-unit>
+            <trans-unit id="tl_url_rewrite.requestPath.0">
+                <source>Path restriction</source>
+            </trans-unit>
+            <trans-unit id="tl_url_rewrite.requestPath.1">
+                <source>Here you can enter the path to match.</source>
+            </trans-unit>
+            <trans-unit id="tl_url_rewrite.requestRequirements.0">
+                <source>Extra requirements</source>
+            </trans-unit>
+            <trans-unit id="tl_url_rewrite.requestRequirements.1">
+                <source>Here you can add extra requirements for the match.</source>
+            </trans-unit>
+            <trans-unit id="tl_url_rewrite.requestRequirements.invalid">
+                <source>Invalid regular expression for key "%s".</source>
+            </trans-unit>
+            <trans-unit id="tl_url_rewrite.requestCondition.0">
+                <source>Request condition</source>
+            </trans-unit>
+            <trans-unit id="tl_url_rewrite.requestCondition.1">
+                <source>Please enter the request condition using Symfony's Expression Language (e.g. &lt;em&gt;context.getMethod() in ['GET'] and request.query.has('foo')&lt;/em&gt;).</source>
+            </trans-unit>
+            <trans-unit id="tl_url_rewrite.responseCode.0">
+                <source>Response status code</source>
+            </trans-unit>
+            <trans-unit id="tl_url_rewrite.responseCode.1">
+                <source>Here you can select the response status code.</source>
+            </trans-unit>
+            <trans-unit id="tl_url_rewrite.responseUri.0">
+                <source>Response redirect URL</source>
+            </trans-unit>
+            <trans-unit id="tl_url_rewrite.responseUri.1">
+                <source>Here you can enter the response redirect URI. You can use the insert tags, route attributes and query parameters as wildcards (e.g. &lt;em&gt;/foo/{bar}&lt;/em&gt;). To generate absolute URLs using insert tags you can use the &quot;absolute&quot; insert tag flag (e.g. &lt;em&gt;{{link_url::123|absolute}}&lt;/em&gt;).</source>
+            </trans-unit>
+
+            <trans-unit id="tl_url_rewrite.name_legend">
+                <source>Rewrite name</source>
+            </trans-unit>
+            <trans-unit id="tl_url_rewrite.request_legend">
+                <source>Request matching</source>
+            </trans-unit>
+            <trans-unit id="tl_url_rewrite.response_legend">
+                <source>Response processing</source>
+            </trans-unit>
+            <trans-unit id="tl_url_rewrite.examples_legend">
+                <source>Examples</source>
+            </trans-unit>
+
+            <trans-unit id="tl_url_rewrite.typeRef.basic.0">
+                <source>Basic</source>
+            </trans-unit>
+            <trans-unit id="tl_url_rewrite.typeRef.basic.1">
+                <source>Allows to define the request matching using the basic Symfony routing features.</source>
+            </trans-unit>
+            <trans-unit id="tl_url_rewrite.typeRef.expert.0">
+                <source>Expert</source>
+            </trans-unit>
+            <trans-unit id="tl_url_rewrite.typeRef.expert.1">
+                <source>Allows to define the request condition using the &lt;a href=&quot;https://symfony.com/doc/current/components/expression_language.html&quot; target=&quot;_blank&quot;>Expression Language&lt;/a&gt;. For more information please &lt;a href=&quot;https://symfony.com/doc/current/routing/conditions.html&quot; target=&quot;_blank&quot;>visit this link&lt;/a&gt;.</source>
+            </trans-unit>
+
+            <trans-unit id="tl_url_rewrite.qrCodeRef.headline">
+                <source>Generate QR code</source>
+            </trans-unit>
+            <trans-unit id="tl_url_rewrite.qrCodeRef.explanation">
+                <source>Use the form below to generate the QR code for this rule. You may need to provide the necessary parameters if the rule requires them.</source>
+            </trans-unit>
+            <trans-unit id="tl_url_rewrite.qrCodeRef.submit">
+                <source>Generate</source>
+            </trans-unit>
+            <trans-unit id="tl_url_rewrite.qrCodeRef.scheme">
+                <source>Scheme</source>
+            </trans-unit>
+            <trans-unit id="tl_url_rewrite.qrCodeRef.host">
+                <source>Host</source>
+            </trans-unit>
+            <trans-unit id="tl_url_rewrite.qrCodeRef.requirement">
+                <source>Requirement: %s (%s)</source>
+            </trans-unit>
+            <trans-unit id="tl_url_rewrite.qrCodeRef.requirementError">
+                <source>The value does not match pattern "%s"!</source>
+            </trans-unit>
+            <trans-unit id="tl_url_rewrite.qrCodeRef.routeError">
+                <source>System was unable to generate the URL, please verify your configuration.</source>
+            </trans-unit>
+            <trans-unit id="tl_url_rewrite.qrCodeRef.copy">
+                <source>Copy the image URL:</source>
+            </trans-unit>
+
+            <trans-unit id="tl_url_rewrite.examples.0.0">
+                <source>Find address on Google Maps:</source>
+            </trans-unit>
+            <trans-unit id="tl_url_rewrite.examples.0.1">
+                <source>Type: basic
+Path restriction: find/{address}
+Response code: 303 See Other
+Response redirect URL: https://www.google.com/maps?q={address}
+---
+Result: domain.tld/find/Switzerland → https://www.google.com/maps?q=Switzerland</source>
+            </trans-unit>
+            <trans-unit id="tl_url_rewrite.examples.1.0">
+                <source>Redirect to a specific news entry:</source>
+            </trans-unit>
+            <trans-unit id="tl_url_rewrite.examples.1.1">
+                <source>Type: basic
+Path restriction: news/{news}
+Requirements: [news => \d+]
+Response code: 301 Moved Permanently
+Response redirect URL: {{news_url::{news}|absolute}}
+---
+Result: domain.tld/news/123 → domain.tld/news-reader/foobar-123.html
+Result: domain.tld/news/foobar → 404 Page Not Found</source>
+            </trans-unit>
+            <trans-unit id="tl_url_rewrite.examples.2.0">
+                <source>Rewrite legacy URLs with query string:</source>
+            </trans-unit>
+            <trans-unit id="tl_url_rewrite.examples.2.1">
+                <source>Type: expert
+Path restriction: home.php
+Request condition: context.getMethod() == 'GET' and request.query.has('page')
+Response code: 301 Moved Permanently
+Response redirect URL: {{link_url::{page}|absolute}}
+---
+Result: domain.tld/home.php?page=123 → domain.tld/foobar-123.html</source>
+            </trans-unit>
+            <trans-unit id="tl_url_rewrite.examples.3.0">
+                <source>Rewrite URLs including slashes (without query string) to new domain:</source>
+            </trans-unit>
+            <trans-unit id="tl_url_rewrite.examples.3.1">
+                <source>Type: basic
+Host restriction: domain.com
+Path restriction: /{wildcard}
+Requirements: [wildcard => .*]
+Response code: 301 Moved Permanently
+Response redirect URL: https://domain.tld/{wildcard}
+---
+Result: domain.com/blog/test → https://domain.tld/blog/test</source>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/core-bundle/contao/models/UrlRewriteModel.php
+++ b/core-bundle/contao/models/UrlRewriteModel.php
@@ -19,7 +19,7 @@ namespace Contao;
  * @property string            $type
  * @property int               $priority
  * @property string            $comment
- * @property bool              $inactive
+ * @property bool              $disable
  * @property string            $requestHost
  * @property string            $requestPath
  * @property array|string|null $requestRequirements

--- a/core-bundle/contao/models/UrlRewriteModel.php
+++ b/core-bundle/contao/models/UrlRewriteModel.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao;
+
+/**
+ * Reads and writes url rewrite rules.
+ *
+ * @property integer           $id
+ * @property integer           $tstamp
+ * @property string            $name
+ * @property string            $type
+ * @property int               $priority
+ * @property string            $comment
+ * @property bool              $inactive
+ * @property string            $requestHost
+ * @property string            $requestPath
+ * @property array|string|null $requestRequirements
+ * @property string            $requestCondition
+ * @property int               $responseCode
+ * @property string            $responseUri
+ */
+class UrlRewriteModel extends Model
+{
+	/**
+	 * Table name
+	 * @var string
+	 */
+	protected static $strTable = 'tl_url_rewrite';
+}

--- a/core-bundle/src/Controller/UrlRewriteController.php
+++ b/core-bundle/src/Controller/UrlRewriteController.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Contao\CoreBundle\Controller;
+
+use Contao\CoreBundle\Exception\InternalServerErrorException;
+use Contao\CoreBundle\InsertTag\InsertTagParser;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Exception\RouteNotFoundException;
+
+class UrlRewriteController
+{
+    public const ATTRIBUTE_NAME = '_url_rewrite';
+
+    public function __construct(private readonly InsertTagParser $insertTagParser)
+    {
+    }
+
+    public function __invoke(Request $request): Response
+    {
+        if (!$request->attributes->has(self::ATTRIBUTE_NAME)) {
+            throw new RouteNotFoundException(sprintf('The "%s" attribute is missing', self::ATTRIBUTE_NAME));
+        }
+
+        $rule = $request->attributes->get(self::ATTRIBUTE_NAME);
+        $responseCode = $rule['responseCode'];
+
+        if (410 === $responseCode) {
+            return new Response(Response::$statusTexts[$responseCode], $responseCode);
+        }
+
+        if (null !== ($uri = $this->generateUri($request, $rule))) {
+            return new RedirectResponse($uri, $responseCode);
+        }
+
+        throw new InternalServerErrorException();
+    }
+
+    /**
+     * Generate the URI.
+     */
+    private function generateUri(Request $request, array $rule): ?string
+    {
+        if (empty($uri = $rule['responseUri'])) {
+            return null;
+        }
+
+        $uri = $this->replaceWildcards($request, $uri);
+        $uri = $this->replaceInsertTags($uri);
+
+        // Replace the multiple slashes except the ones for protocol
+        $uri = preg_replace('@(?<!http:|https:|^)/+@', '/', $uri);
+
+        // Make the URL absolute if it's not yet already
+        if (!preg_match('@^(https?:)?//@', $uri)) {
+            $uri = $request->getSchemeAndHttpHost().$request->getBasePath().'/'.ltrim($uri, '/');
+        }
+
+        return $uri;
+    }
+
+    /**
+     * Replace the wildcards.
+     */
+    private function replaceWildcards(Request $request, string $uri): string
+    {
+        $wildcards = [];
+
+        // Get the route params wildcards
+        foreach ($request->attributes->get('_route_params', []) as $k => $v) {
+            $wildcards['{'.$k.'}'] = $v;
+        }
+
+        // Get the query wildcards
+        foreach ($request->query->all() as $k => $v) {
+            $wildcards['{'.$k.'}'] = $v;
+        }
+
+        return strtr($uri, $wildcards);
+    }
+
+    /**
+     * Replace the insert tags.
+     */
+    private function replaceInsertTags(string $uri): string
+    {
+        if (!str_contains($uri, '{{')) {
+            return $uri;
+        }
+
+        return $this->insertTagParser->replaceInline($uri);
+    }
+}

--- a/core-bundle/src/Controller/UrlRewriteController.php
+++ b/core-bundle/src/Controller/UrlRewriteController.php
@@ -9,6 +9,7 @@ use Contao\CoreBundle\InsertTag\InsertTagParser;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\GoneHttpException;
 use Symfony\Component\Routing\Exception\RouteNotFoundException;
 
 class UrlRewriteController
@@ -29,7 +30,7 @@ class UrlRewriteController
         $responseCode = $rule['responseCode'];
 
         if (410 === $responseCode) {
-            return new Response(Response::$statusTexts[$responseCode], $responseCode);
+            throw new GoneHttpException();
         }
 
         if (null !== ($uri = $this->generateUri($request, $rule))) {

--- a/core-bundle/src/DataContainer/DataContainerOperation.php
+++ b/core-bundle/src/DataContainer/DataContainerOperation.php
@@ -66,7 +66,7 @@ class DataContainerOperation implements \ArrayAccess
 
     public function offsetGet(mixed $offset): mixed
     {
-        return $this->operation[$offset];
+        return $this->operation[$offset] ?? null;
     }
 
     public function offsetSet(mixed $offset, mixed $value): void

--- a/core-bundle/src/EventListener/DataContainer/Rewrite/NameValidationListener.php
+++ b/core-bundle/src/EventListener/DataContainer/Rewrite/NameValidationListener.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Contao\CoreBundle\EventListener\DataContainer\Rewrite;
+
+use Contao\CoreBundle\DependencyInjection\Attribute\AsCallback;
+use Contao\CoreBundle\Framework\ContaoFramework;
+use Contao\DataContainer;
+use Contao\Input;
+
+#[AsCallback('tl_url_rewrite', 'fields.name.save')]
+class NameValidationListener
+{
+    public function __construct(private readonly ContaoFramework $framework)
+    {
+    }
+
+    public function __invoke($value, DataContainer $dataContainer)
+    {
+        if ('' === $value) {
+            $inputAdapter = $this->framework->getAdapter(Input::class);
+            $value = $inputAdapter->post('requestPath') ?: $dataContainer->activeRecord->requestPath;
+        }
+
+        if ('' === $value) {
+            throw new \InvalidArgumentException(sprintf($GLOBALS['TL_LANG']['ERR']['mandatory'], $dataContainer->field));
+        }
+
+        return $value;
+    }
+}

--- a/core-bundle/src/EventListener/DataContainer/Rewrite/RequestRequirementsValidationListener.php
+++ b/core-bundle/src/EventListener/DataContainer/Rewrite/RequestRequirementsValidationListener.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Contao\CoreBundle\EventListener\DataContainer\Rewrite;
+
+use Contao\CoreBundle\DependencyInjection\Attribute\AsCallback;
+use Contao\StringUtil;
+
+#[AsCallback('tl_url_rewrite', 'fields.requestRequirements.save')]
+class RequestRequirementsValidationListener
+{
+    public function __invoke($value)
+    {
+        foreach (StringUtil::deserialize($value, true) as $regex) {
+            try {
+                if (false === preg_match('('.$regex['value'].')', '')) {
+                    throw new \RuntimeException();
+                }
+            } catch (\Exception $e) {
+                throw new \InvalidArgumentException(sprintf($GLOBALS['TL_LANG']['tl_url_rewrite']['requestRequirements']['invalid'], $regex['key']), 0, $e);
+            }
+        }
+
+        return $value;
+    }
+}

--- a/core-bundle/src/EventListener/DataContainer/Rewrite/ResponseCodeOptionsListener.php
+++ b/core-bundle/src/EventListener/DataContainer/Rewrite/ResponseCodeOptionsListener.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Contao\CoreBundle\EventListener\DataContainer\Rewrite;
+
+use Contao\CoreBundle\DependencyInjection\Attribute\AsCallback;
+use Symfony\Component\HttpFoundation\Response;
+
+#[AsCallback('tl_url_rewrite', 'fields.responseCode.options')]
+class ResponseCodeOptionsListener
+{
+    public function __invoke(): array
+    {
+        $options = [];
+
+        foreach ([301, 302, 303, 307, 410] as $code) {
+            $options[$code] = $code.' '.Response::$statusTexts[$code];
+        }
+
+        return $options;
+    }
+}

--- a/core-bundle/src/EventListener/DataContainer/Rewrite/RewriteExamplesListener.php
+++ b/core-bundle/src/EventListener/DataContainer/Rewrite/RewriteExamplesListener.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Contao\CoreBundle\EventListener\DataContainer\Rewrite;
+
+use Contao\CoreBundle\DependencyInjection\Attribute\AsCallback;
+
+#[AsCallback('tl_url_rewrite', 'fields.examples.input_field')]
+class RewriteExamplesListener
+{
+    public function __invoke(): string
+    {
+        $buffer = '';
+
+        foreach ($GLOBALS['TL_LANG']['tl_url_rewrite']['examples'] as $i => $example) {
+            $buffer .= sprintf(
+                '<h3>%s. %s</h3><pre style="margin-top:.5rem;padding:1rem;background:#f6f6f8;font-size:.75rem;">%s</pre>',
+                $i + 1,
+                $example[0],
+                $example[1]
+            );
+        }
+
+        return sprintf('<div class="widget long">%s</div>', $buffer);
+    }
+}

--- a/core-bundle/src/EventListener/DataContainer/Rewrite/RewriteLabelListener.php
+++ b/core-bundle/src/EventListener/DataContainer/Rewrite/RewriteLabelListener.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Contao\CoreBundle\EventListener\DataContainer\Rewrite;
+
+use Contao\CoreBundle\DependencyInjection\Attribute\AsCallback;
+
+#[AsCallback('tl_url_rewrite', 'list.label.label')]
+class RewriteLabelListener
+{
+    public function __invoke(array $row): string
+    {
+        if (410 === (int) $row['responseCode']) {
+            $response = $row['responseCode'];
+        } else {
+            $response = sprintf('%s, %s', $row['responseUri'], $row['responseCode']);
+        }
+
+        return sprintf(
+            '%s <span style="padding-left:3px;color:#b3b3b3;word-break:break-all;">[%s &rarr; %s (%s: %s)]</span>',
+            $row['name'],
+            $row['requestPath'],
+            $response,
+            $GLOBALS['TL_LANG']['tl_url_rewrite']['priority'][0],
+            $row['priority']
+        );
+    }
+}

--- a/core-bundle/src/EventListener/PrettyErrorScreenListener.php
+++ b/core-bundle/src/EventListener/PrettyErrorScreenListener.php
@@ -25,6 +25,7 @@ use Symfony\Component\HttpFoundation\AcceptHeader;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\GoneHttpException;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\Exception\ServiceUnavailableHttpException;
@@ -97,6 +98,14 @@ class PrettyErrorScreenListener
 
             case $exception instanceof NotFoundHttpException:
                 $this->renderErrorScreenByType(404, $event);
+                break;
+
+            case $exception instanceof GoneHttpException:
+                $this->renderErrorScreenByType(404, $event);
+
+                if ($response = $event->getResponse()) {
+                    $response->setStatusCode(Response::HTTP_GONE);
+                }
                 break;
 
             case $exception instanceof ServiceUnavailableHttpException:

--- a/core-bundle/src/Migration/Version510/UrlRewriteMigration.php
+++ b/core-bundle/src/Migration/Version510/UrlRewriteMigration.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Migration\Version510;
+
+use Contao\Controller;
+use Contao\CoreBundle\Config\ResourceFinder;
+use Contao\CoreBundle\Framework\ContaoFramework;
+use Contao\CoreBundle\Migration\AbstractMigration;
+use Contao\CoreBundle\Migration\MigrationResult;
+use Contao\StringUtil;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Types\StringType;
+use Doctrine\DBAL\Types\Types;
+use Symfony\Component\Finder\SplFileInfo;
+
+/**
+ * Migrates data from the terminal42/contao-url-rewrite bundle
+ */
+class UrlRewriteMigration extends AbstractMigration
+{
+    public function __construct(private Connection $connection)
+    {
+    }
+
+    public function shouldRun(): bool
+    {
+        $schemaManager = $this->connection->createSchemaManager();
+
+        if (!$schemaManager->tablesExist('tl_url_rewrite')) {
+            return false;
+        }
+
+        $columns = $schemaManager->listTableColumns('tl_url_rewrite');
+
+        return (\array_key_exists('inactive', $columns) && !\array_key_exists('disable', $columns))
+            || (\array_key_exists('requestHosts', $columns) && !\array_key_exists('requestHost', $columns));
+    }
+
+    public function run(): MigrationResult
+    {
+        $columns = $this->connection->createSchemaManager()->listTableColumns('tl_url_rewrite');
+
+        if (\array_key_exists('inactive', $columns) && !\array_key_exists('disable', $columns)) {
+            $this->connection->executeStatement('ALTER TABLE tl_url_rewrite CHANGE `inactive` `disable` bool DEFAULT 0');
+        }
+
+        if (\array_key_exists('requestHosts', $columns) && !\array_key_exists('requestHost', $columns)) {
+            $this->connection->executeStatement("ALTER TABLE tl_url_rewrite ADD `requestHost` varchar(255) NOT NULL default ''");
+
+            $rules = $this->connection->executeQuery("SELECT * FROM tl_url_rewrite WHERE requestHosts IS NOT NULL AND requestHosts != 'a:1:{i:0;s:0:\"\";}'");
+            foreach ($rules->iterateAssociative() as $rule) {
+                $hosts = array_values(StringUtil::deserialize($rule['requestHosts'], true));
+
+                if (\count($hosts) < 2) {
+                    $this->connection->executeStatement(
+                        'UPDATE tl_url_rewrite SET requestHost=? WHERE id=?',
+                        [$hosts[0] ?? ''],
+                        $rule['id']
+                    );
+
+                    continue;
+                }
+
+                foreach ($hosts as $host) {
+                    $data = $rule;
+                    unset($data['id']);
+                    $data['requestHost'] = $host;
+
+                    $this->connection->insert('tl_url_rewrite', $data);
+                }
+
+                $this->connection->delete('tl_url_rewrite', ['id' => $rule['id']]);
+            }
+        }
+
+        return $this->createResult(true);
+    }
+}

--- a/core-bundle/src/Routing/AbstractPageRouteProvider.php
+++ b/core-bundle/src/Routing/AbstractPageRouteProvider.php
@@ -25,6 +25,8 @@ use Symfony\Component\Routing\Route;
 
 abstract class AbstractPageRouteProvider implements RouteProviderInterface
 {
+    use RouteIdTrait;
+
     public function __construct(protected ContaoFramework $framework, protected CandidatesInterface $candidates, protected PageRegistry $pageRegistry)
     {
     }
@@ -72,30 +74,6 @@ abstract class AbstractPageRouteProvider implements RouteProviderInterface
         $models = $pages->getModels();
 
         return array_filter($models, fn (PageModel $model) => $this->pageRegistry->isRoutable($model));
-    }
-
-    /**
-     * @return array<int>
-     */
-    protected function getPageIdsFromNames(array $names): array
-    {
-        $ids = [];
-
-        foreach ($names as $name) {
-            if (!str_starts_with($name, 'tl_page.')) {
-                continue;
-            }
-
-            [, $id] = explode('.', (string) $name);
-
-            if (!preg_match('/^[1-9]\d*$/', $id)) {
-                continue;
-            }
-
-            $ids[] = (int) $id;
-        }
-
-        return array_unique($ids);
     }
 
     protected function compareRoutes(Route $a, Route $b, array $languages = null): int

--- a/core-bundle/src/Routing/RewriteRouteProvider.php
+++ b/core-bundle/src/Routing/RewriteRouteProvider.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Contao\CoreBundle\Routing;
+
+use Contao\CoreBundle\Controller\UrlRewriteController;
+use Contao\StringUtil;
+use Doctrine\DBAL\Connection;
+use Symfony\Cmf\Component\Routing\RouteProviderInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Exception\RouteNotFoundException;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
+
+class RewriteRouteProvider implements RouteProviderInterface
+{
+    public function __construct(private readonly Connection $connection)
+    {
+    }
+
+    public function getRouteCollectionForRequest(Request $request): RouteCollection
+    {
+        $collection = new RouteCollection();
+
+        $rewrites = $this->connection->executeQuery("SELECT * FROM tl_url_rewrite WHERE inactive=''");
+
+        foreach ($rewrites->iterateAssociative() as $rule) {
+            $requirements = [];
+            $condition = null;
+
+            switch ($rule['type']) {
+                case 'basic':
+                    foreach (StringUtil::deserialize($rule['requestRequirements'], true) as $requirement) {
+                        if ('' !== $requirement['key'] && '' !== $requirement['value']) {
+                            $requirements[$requirement['key']] = $requirement['value'];
+                        }
+                    }
+                    break;
+
+                case 'expert':
+                    $condition = $rule['requestCondition'] ?? null;
+                    break;
+            }
+
+            $route = new Route(
+                $rule['requestPath'],
+                ['_controller' => UrlRewriteController::class, UrlRewriteController::ATTRIBUTE_NAME => $rule],
+                $requirements,
+                ['utf8' => true],
+                $rule['requestHost'] ?? null,
+                [],
+                [],
+                $condition
+            );
+
+            $collection->add('tl_url_rewrite.'.$rule['id'], $route);
+        }
+
+        return $collection;
+    }
+
+    public function getRouteByName($name): Route
+    {
+        throw new RouteNotFoundException('This router does not support routes by name');
+    }
+
+    public function getRoutesByNames(?array $names = null): iterable
+    {
+        return [];
+    }
+}

--- a/core-bundle/src/Routing/RewriteRouteProvider.php
+++ b/core-bundle/src/Routing/RewriteRouteProvider.php
@@ -23,7 +23,7 @@ class RewriteRouteProvider implements RouteProviderInterface
     {
         $collection = new RouteCollection();
 
-        $rewrites = $this->connection->executeQuery("SELECT * FROM tl_url_rewrite WHERE inactive=''");
+        $rewrites = $this->connection->executeQuery("SELECT * FROM tl_url_rewrite WHERE disable=''");
 
         foreach ($rewrites->iterateAssociative() as $rule) {
             $requirements = [];

--- a/core-bundle/src/Routing/Route404Provider.php
+++ b/core-bundle/src/Routing/Route404Provider.php
@@ -59,7 +59,7 @@ class Route404Provider extends AbstractPageRouteProvider
     {
         $this->framework->initialize();
 
-        $ids = $this->getPageIdsFromNames([$name]);
+        $ids = $this->getIdsFromRouteNames([$name], 'tl_page');
 
         if (empty($ids)) {
             throw new RouteNotFoundException('Route name does not match a page ID');
@@ -96,7 +96,7 @@ class Route404Provider extends AbstractPageRouteProvider
         if (null === $names) {
             $pages = $pageAdapter->findAll();
         } else {
-            $ids = $this->getPageIdsFromNames($names);
+            $ids = $this->getIdsFromRouteNames($names, 'tl_page');
 
             if (empty($ids)) {
                 return [];

--- a/core-bundle/src/Routing/RouteIdTrait.php
+++ b/core-bundle/src/Routing/RouteIdTrait.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Routing;
+
+use Contao\CoreBundle\Framework\ContaoFramework;
+use Contao\CoreBundle\Routing\Page\PageRegistry;
+use Contao\CoreBundle\Routing\Page\PageRoute;
+use Contao\CoreBundle\Util\LocaleUtil;
+use Contao\Model\Collection;
+use Contao\PageModel;
+use Symfony\Cmf\Component\Routing\Candidates\CandidatesInterface;
+use Symfony\Cmf\Component\Routing\RouteProviderInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Route;
+
+trait RouteIdTrait
+{
+    /**
+     * @return array<int>
+     */
+    protected function getIdsFromRouteNames(array $names, string $table): array
+    {
+        $ids = [];
+
+        foreach ($names as $name) {
+            if (!str_starts_with($name, $table.'.')) {
+                continue;
+            }
+
+            [, $id] = explode('.', (string) $name);
+
+            if (!preg_match('/^[1-9]\d*$/', $id)) {
+                continue;
+            }
+
+            $ids[] = (int) $id;
+        }
+
+        return array_values(array_unique($ids));
+    }
+}

--- a/core-bundle/src/Routing/RouteProvider.php
+++ b/core-bundle/src/Routing/RouteProvider.php
@@ -60,7 +60,7 @@ class RouteProvider extends AbstractPageRouteProvider
     {
         $this->framework->initialize();
 
-        $ids = $this->getPageIdsFromNames([$name]);
+        $ids = $this->getIdsFromRouteNames([$name], 'tl_page');
 
         if (empty($ids)) {
             throw new RouteNotFoundException('Route name does not match a page ID');
@@ -93,7 +93,7 @@ class RouteProvider extends AbstractPageRouteProvider
         if (null === $names) {
             $pages = $pageModel->findAll();
         } else {
-            $ids = $this->getPageIdsFromNames($names);
+            $ids = $this->getIdsFromRouteNames($names, 'tl_page');
 
             if (empty($ids)) {
                 return [];


### PR DESCRIPTION
This merges the basic features of our [terminal42/contao-url-rewrite](https://github.com/terminal42/contao-url-rewrite) extension into the core. It will allow users to add custom URL rewrite rules, as well as the core possibility to e.g. add an automatic rewrite if a page is deleted or an alias is changed.

We have discussed to not use the `tl_page` here because the page tree (mostly) represents a navigational structure, but url rewrites are not really related to a navigation.

**TODOs**:
- [ ] limit the routes from DB search based on the current URL
- [x] implement the `getRouteByName(s)` methods
- [x] ~add a 410 error page controller that generates a message if a page is gone~ render the 404 page for 410 errors
- [ ] write tests