### PR TITLE
Add cache busting for the public core bundle scripts

### DIFF
--- a/core-bundle/src/DependencyInjection/Compiler/AddAssetsPackagesPass.php
+++ b/core-bundle/src/DependencyInjection/Compiler/AddAssetsPackagesPass.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\DependencyInjection\Compiler;
 
 use Composer\InstalledVersions;
+use Contao\CoreBundle\ContaoCoreBundle;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Container;
@@ -70,6 +71,13 @@ class AddAssetsPackagesPass implements CompilerPassInterface
 
                 $container->setDefinition('assets._version_'.$packageName, $def);
                 $packageVersion = new Reference('assets._version_'.$packageName);
+            } elseif ('contao_core' === $packageName) {
+                $def = new ChildDefinition('assets.static_version_strategy');
+                $def->replaceArgument(0, ContaoCoreBundle::getVersion());
+                $def->replaceArgument(1, '%%s?v=%%s');
+
+                $container->setDefinition('assets._version_'.$name, $def);
+                $packageVersion = new Reference('assets._version_'.$name);
             }
 
             $container->setDefinition($serviceId, $this->createPackageDefinition($basePath, $packageVersion, $context));


### PR DESCRIPTION
After merging this, we could use `$this->asset('ajax-form.min.js', 'contao_core')` in #5307. It might be rendered redundant by #5406 therefore it is a draft PR at the moment.