### PR TITLE
Fix several VFS/UUID related issues

### DIFF
--- a/core-bundle/src/Filesystem/Dbafs/Dbafs.php
+++ b/core-bundle/src/Filesystem/Dbafs/Dbafs.php
@@ -168,12 +168,8 @@ class Dbafs implements DbafsInterface, ResetInterface
 
     public function setExtraMetadata(string $path, array $metadata): void
     {
-        if (null === ($record = $this->getRecord($path))) {
+        if (null === $this->getRecord($path)) {
             throw new \InvalidArgumentException(sprintf('Record for path "%s" does not exist.', $path));
-        }
-
-        if (!$record->isFile()) {
-            throw new \LogicException(sprintf('Can only set extra metadata for files, directory given under "%s".', $path));
         }
 
         $row = [
@@ -233,6 +229,9 @@ class Dbafs implements DbafsInterface, ResetInterface
             $record['path'] = $newPath;
             unset($this->records[$path]);
             $this->records[$newPath] = $record;
+
+            $this->pathById[array_search($path, $this->pathById, true)] = $newPath;
+            $this->pathByUuid[array_search($path, $this->pathByUuid, true)] = $newPath;
         }
 
         foreach (array_keys($changeSet->getItemsToDelete()) as $identifier) {
@@ -270,13 +269,15 @@ class Dbafs implements DbafsInterface, ResetInterface
      */
     private function toFilesystemItem(array $record): FilesystemItem
     {
+        $uuid = array_search($record['path'], $this->pathByUuid, true);
+
         return new FilesystemItem(
             $record['isFile'],
             $record['path'],
             isset($record['lastModified']) ? (int) ($record['lastModified']) : null,
             isset($record['fileSize']) ? (int) ($record['fileSize']) : null,
             $record['mimeType'] ?? null,
-            $record['extra']
+            array_merge($record['extra'], ['uuid' => Uuid::fromBinary($uuid)])
         );
     }
 

--- a/core-bundle/src/Filesystem/FilesystemItem.php
+++ b/core-bundle/src/Filesystem/FilesystemItem.php
@@ -171,7 +171,7 @@ class FilesystemItem
         return $this->extraMetadata;
     }
 
-    public function getUuid(): Uuid|null
+    public function getUuid(): ?Uuid
     {
         return $this->getExtraMetadata()['uuid'] ?? null;
     }

--- a/core-bundle/src/Filesystem/FilesystemItem.php
+++ b/core-bundle/src/Filesystem/FilesystemItem.php
@@ -15,6 +15,7 @@ namespace Contao\CoreBundle\Filesystem;
 use League\Flysystem\FileAttributes;
 use League\Flysystem\StorageAttributes;
 use Symfony\Component\Filesystem\Path;
+use Symfony\Component\Uid\Uuid;
 
 /**
  * @experimental
@@ -165,10 +166,14 @@ class FilesystemItem
 
     public function getExtraMetadata(): array
     {
-        $this->assertIsFile(__FUNCTION__);
         $this->resolveIfClosure($this->extraMetadata);
 
         return $this->extraMetadata;
+    }
+
+    public function getUuid(): Uuid|null
+    {
+        return $this->getExtraMetadata()['uuid'] ?? null;
     }
 
     private function assertIsFile(string $method): void

--- a/core-bundle/src/Filesystem/VirtualFilesystem.php
+++ b/core-bundle/src/Filesystem/VirtualFilesystem.php
@@ -181,7 +181,14 @@ class VirtualFilesystem implements VirtualFilesystemInterface
         }
 
         if ($this->directoryExists($relativePath, $accessFlags)) {
-            return new FilesystemItem(false, $relativePath);
+            return new FilesystemItem(
+                false,
+                $relativePath,
+                null,
+                null,
+                null,
+                fn () => $this->getExtraMetadata($relativePath, $accessFlags),
+            );
         }
 
         return null;

--- a/core-bundle/tests/Filesystem/FilesystemItemTest.php
+++ b/core-bundle/tests/Filesystem/FilesystemItemTest.php
@@ -16,18 +16,21 @@ use Contao\CoreBundle\Filesystem\FilesystemItem;
 use Contao\CoreBundle\Tests\TestCase;
 use League\Flysystem\DirectoryAttributes;
 use League\Flysystem\FileAttributes;
+use Symfony\Component\Uid\Uuid;
 
 class FilesystemItemTest extends TestCase
 {
     public function testSetAndGetAttributes(): void
     {
+        $uuid = Uuid::fromString('2fcae369-c955-4b43-bcf9-d069f9d25542');
+
         $fileItem = new FilesystemItem(
             true,
             'foo/bar.png',
             123450,
             1024,
             'image/png',
-            ['foo' => 'bar']
+            ['foo' => 'bar', 'uuid' => $uuid]
         );
 
         $this->assertTrue($fileItem->isFile());
@@ -36,18 +39,8 @@ class FilesystemItemTest extends TestCase
         $this->assertSame(123450, $fileItem->getLastModified());
         $this->assertSame(1024, $fileItem->getFileSize());
         $this->assertSame('image/png', $fileItem->getMimeType());
-        $this->assertSame(['foo' => 'bar'], $fileItem->getExtraMetadata());
-
-        $directoryItem = new FilesystemItem(
-            false,
-            'foo/bar',
-            123450
-        );
-
-        $this->assertFalse($directoryItem->isFile());
-        $this->assertSame('foo/bar', $directoryItem->getPath());
-        $this->assertSame('foo/bar', (string) $directoryItem);
-        $this->assertSame(123450, $directoryItem->getLastModified());
+        $this->assertSame('bar', $fileItem->getExtraMetadata()['foo']);
+        $this->assertSame('2fcae369-c955-4b43-bcf9-d069f9d25542', $fileItem->getUuid()->toRfc4122());
     }
 
     /**
@@ -73,11 +66,6 @@ class FilesystemItemTest extends TestCase
         yield 'mime type' => [
             'getMimeType',
             'Cannot call getMimeType() on a non-file filesystem item.',
-        ];
-
-        yield 'extra metadata' => [
-            'getExtraMetadata',
-            'Cannot call getExtraMetadata() on a non-file filesystem item.',
         ];
     }
 


### PR DESCRIPTION
This PR…
- fixes some parts of the DBAFS record caching
- allows DBAFS metadata for directories (currently only possible for files)
- allows accessing UUIDs from the filesystem item:

```php
$fooStorage->get('my/directory')->getUuid(); 
```

This PR probably maybe to be rebased to 4.13. :thinking: 
