### PR TITLE
Load the language file before applying default labels

### DIFF
--- a/core-bundle/contao/library/Contao/DcaLoader.php
+++ b/core-bundle/contao/library/Contao/DcaLoader.php
@@ -149,6 +149,8 @@ class DcaLoader extends Controller
 	 */
 	private function addDefaultLabels()
 	{
+		System::loadLanguageFile($this->strTable);
+
 		// Operations
 		foreach (array('global_operations', 'operations') as $key)
 		{

--- a/core-bundle/contao/library/Contao/DcaLoader.php
+++ b/core-bundle/contao/library/Contao/DcaLoader.php
@@ -149,8 +149,6 @@ class DcaLoader extends Controller
 	 */
 	private function addDefaultLabels()
 	{
-		System::loadLanguageFile($this->strTable);
-
 		// Operations
 		foreach (array('global_operations', 'operations') as $key)
 		{
@@ -166,13 +164,11 @@ class DcaLoader extends Controller
 					continue;
 				}
 
-				if (isset($GLOBALS['TL_LANG'][$this->strTable][$k]) || !isset($GLOBALS['TL_LANG']['DCA'][$k]))
+				$v['label'] = &$GLOBALS['TL_LANG'][$this->strTable][$k];
+
+				if (!isset($GLOBALS['TL_LANG'][$this->strTable][$k]) && isset($GLOBALS['TL_LANG']['DCA'][$k]))
 				{
-					$v['label'] = &$GLOBALS['TL_LANG'][$this->strTable][$k];
-				}
-				elseif (isset($GLOBALS['TL_LANG']['DCA'][$k]))
-				{
-					$v['label'] = &$GLOBALS['TL_LANG']['DCA'][$k];
+					$GLOBALS['TL_LANG'][$this->strTable][$k] = $GLOBALS['TL_LANG']['DCA'][$k];
 				}
 			}
 


### PR DESCRIPTION
Fixes https://github.com/contao/contao/issues/5029

I've run into the same issue while implementing a new feature (PR to follow) and this fixed the issue for me. It also makes sense to make sure labels are loaded before checking if they exist 🙃 