### PR TITLE
Handle errors with important parts

### DIFF
--- a/core-bundle/src/Image/ImageFactory.php
+++ b/core-bundle/src/Image/ImageFactory.php
@@ -16,6 +16,7 @@ use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\CoreBundle\Monolog\ContaoContext;
 use Contao\FilesModel;
 use Contao\Image\DeferredResizerInterface;
+use Contao\Image\Exception\CoordinatesOutOfBoundsException;
 use Contao\Image\Image;
 use Contao\Image\ImageInterface;
 use Contao\Image\ImportantPart;
@@ -158,7 +159,11 @@ class ImageFactory implements ImageFactoryInterface
 
         if (!\is_object($path) || !$path instanceof ImageInterface) {
             if (null === $importantPart) {
-                $importantPart = $this->createImportantPart($image);
+                try {
+                    $importantPart = $this->createImportantPart($image);
+                } catch (CoordinatesOutOfBoundsException $exception) {
+                    throw new CoordinatesOutOfBoundsException($exception->getMessage()." for file \"$path\"", $exception->getCode(), $exception);
+                }
             }
 
             $image->setImportantPart($importantPart);

--- a/core-bundle/src/Image/ImageFactory.php
+++ b/core-bundle/src/Image/ImageFactory.php
@@ -162,7 +162,7 @@ class ImageFactory implements ImageFactoryInterface
                 try {
                     $importantPart = $this->createImportantPart($image);
                 } catch (CoordinatesOutOfBoundsException $exception) {
-                    throw new CoordinatesOutOfBoundsException($exception->getMessage()." for file \"$path\"", $exception->getCode(), $exception);
+                    throw new CoordinatesOutOfBoundsException(sprintf('%s for file "%s"', $exception->getMessage(), $path), $exception->getCode(), $exception);
                 }
             }
 

--- a/core-bundle/src/Resources/contao/classes/DataContainer.php
+++ b/core-bundle/src/Resources/contao/classes/DataContainer.php
@@ -632,7 +632,16 @@ abstract class DataContainer extends Backend
 				{
 					$container = System::getContainer();
 					$projectDir = $container->getParameter('kernel.project_dir');
-					$image = rawurldecode($container->get('contao.image.image_factory')->create($projectDir . '/' . $objFile->path, array(699, 524, ResizeConfiguration::MODE_BOX))->getUrl($projectDir));
+
+					try
+					{
+						$image = rawurldecode($container->get('contao.image.image_factory')->create($projectDir . '/' . $objFile->path, array(699, 524, ResizeConfiguration::MODE_BOX))->getUrl($projectDir));
+					}
+					catch (\Exception $e)
+					{
+						Message::addError($e->getMessage());
+						$image = Image::getPath('placeholder.svg');
+					}
 				}
 				else
 				{


### PR DESCRIPTION
I still occasionally get the _The Y coordinate plus the height must not be greater than 1_ error in my client project, possibly due to old image resize configurations.

This PR fixes two issues:
 1. it adds the file information to the `CoordinatesOutOfBoundsException` so one knows which file is actually affected
 2. it then allows to edit the file in the back end, since it currently would throw the same error again when editing in the file manager. The file manager now looks like this and I can easily fix the errors.
 
<img width="1069" alt="Bildschirmfoto 2022-10-25 um 07 33 28" src="https://user-images.githubusercontent.com/1073273/197691422-65c161a7-8770-47f0-81d4-7d368df434ab.png">
