### PR TITLE
Restore previous translations in `$GLOBALS['TL_LANG']`

### DIFF
--- a/core-bundle/src/Translation/Translator.php
+++ b/core-bundle/src/Translation/Translator.php
@@ -59,19 +59,21 @@ class Translator implements TranslatorInterface, TranslatorBagInterface, LocaleA
         }
 
         $this->framework->initialize();
-        $this->loadLanguageFile(substr($domain, 7), $locale);
+        $contaoDomain = substr($domain, 7);
+        $this->loadLanguageFile($contaoDomain, $locale);
 
         $translated = $this->getFromGlobals($id);
 
-        if (null === $translated) {
-            return $id;
-        }
-
-        if (!empty($parameters)) {
+        if (!empty($parameters) && null !== $translated) {
             $translated = vsprintf($translated, $parameters);
         }
 
-        return $translated;
+        // Restore previous translations in $GLOBALS['TL_LANG'] (#5371)
+        if ($locale !== $this->getLocale()) {
+            $this->loadLanguageFile($contaoDomain, $this->getLocale());
+        }
+
+        return $translated ?? $id;
     }
 
     public function transChoice($id, $number, array $parameters = [], $domain = null, $locale = null): string

--- a/core-bundle/src/Translation/Translator.php
+++ b/core-bundle/src/Translation/Translator.php
@@ -58,8 +58,9 @@ class Translator implements TranslatorInterface, TranslatorBagInterface, LocaleA
             $locale = $this->translator->getLocale();
         }
 
-        $this->framework->initialize();
         $contaoDomain = substr($domain, 7);
+
+        $this->framework->initialize();
         $this->loadLanguageFile($contaoDomain, $locale);
 
         $translated = $this->getFromGlobals($id);


### PR DESCRIPTION
Same as #5434 but for Contao 4.9 (as we do not use a `MessageCatalogue` here yet).