### PR TITLE
Fix issues in images content element if no images are defined

### DIFF
--- a/core-bundle/src/Controller/ContentElement/ImagesController.php
+++ b/core-bundle/src/Controller/ContentElement/ImagesController.php
@@ -77,6 +77,10 @@ class ImagesController extends AbstractContentElementController
             iterator_to_array($filesystemItems)
         );
 
+        if (empty($imageList)) {
+            return new Response();
+        }
+
         $template->set('images', $imageList);
         $template->set('items_per_page', $model->perPage ?: null);
         $template->set('items_per_row', $model->perRow ?: null);
@@ -102,6 +106,6 @@ class ImagesController extends AbstractContentElementController
             return $user->homeDir;
         }
 
-        return $model->multiSRC;
+        return $model->multiSRC ?? [];
     }
 }

--- a/core-bundle/tests/Controller/ContentElement/ImagesControllerTest.php
+++ b/core-bundle/tests/Controller/ContentElement/ImagesControllerTest.php
@@ -90,4 +90,33 @@ class ImagesControllerTest extends ContentElementTestCase
 
         $this->assertSameHtml($expectedOutput, $response->getContent());
     }
+
+    public function testDoesNotOutputAnythingWithoutImages(): void
+    {
+        $security = $this->createMock(Security::class);
+
+        $response = $this->renderWithModelData(
+            new ImagesController($security, $this->getDefaultStorage(), $this->getDefaultStudio()),
+            [
+                'type' => 'image',
+                'singleSRC' => null,
+                'sortBy' => 'name_desc',
+                'fullsize' => true,
+            ],
+        );
+
+        $this->assertSame('', $response->getContent());
+
+        $response = $this->renderWithModelData(
+            new ImagesController($security, $this->getDefaultStorage(), $this->getDefaultStudio()),
+            [
+                'type' => 'gallery',
+                'multiSRC' => null,
+                'sortBy' => 'name_desc',
+                'fullsize' => true,
+            ],
+        );
+
+        $this->assertSame('', $response->getContent());
+    }
 }


### PR DESCRIPTION
This PR fixes two issues. The first issue is that `tl_content.singleSRC` and `tl_content.multiSRC` are nullable fields and thus the following error can occur:

```
TypeError: Contao\CoreBundle\Controller\ContentElement\ImagesController::getSources(): Return value must be of type array|string, null returned
```

To reproduce this create a new content element, set the type to _Gallery_, then save and close.

The second issue is that if no image has been defined - or the defined images have been deleted, the content element currently creates empty HTML output:

```html
<div class="content-image">            
</div>

<div class="content-gallery--cols-4 content-gallery">            
  <ul>
  </ul>
</div>
```

In Contao 4 nothing will be rendered if there are no actual images to be rendered and I think we should do the same in Contao 5.