### PR TITLE
Warning: Undefined array key "PATH_TRANSLATED"

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Environment.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Environment.php
@@ -95,7 +95,7 @@ class Environment
 	 */
 	protected static function scriptFilename()
 	{
-		return str_replace('//', '/', strtr((static::$strSapi == 'cgi' || static::$strSapi == 'isapi' || static::$strSapi == 'cgi-fcgi' || static::$strSapi == 'fpm-fcgi') && ($_SERVER['ORIG_PATH_TRANSLATED'] ?? $_SERVER['PATH_TRANSLATED']) ? ($_SERVER['ORIG_PATH_TRANSLATED'] ?? $_SERVER['PATH_TRANSLATED']) : ($_SERVER['ORIG_SCRIPT_FILENAME'] ?? $_SERVER['SCRIPT_FILENAME']), '\\', '/'));
+		return str_replace('//', '/', strtr((static::$strSapi == 'cgi' || static::$strSapi == 'isapi' || static::$strSapi == 'cgi-fcgi' || static::$strSapi == 'fpm-fcgi') && ($_SERVER['ORIG_PATH_TRANSLATED'] ?? $_SERVER['PATH_TRANSLATED'] ?? null) ? ($_SERVER['ORIG_PATH_TRANSLATED'] ?? $_SERVER['PATH_TRANSLATED']) : ($_SERVER['ORIG_SCRIPT_FILENAME'] ?? $_SERVER['SCRIPT_FILENAME']), '\\', '/'));
 	}
 
 	/**


### PR DESCRIPTION
Got the following warning in debug mode when I tried to use Environment::get('documentRoot') under PHP 8.1.

<img width="812" alt="image" src="https://user-images.githubusercontent.com/87128053/199060492-9f3f87c7-78fc-49c0-ad65-bdb2260015e3.png">

Added "?? null" in the condition to prevent this.

```php
($_SERVER['ORIG_PATH_TRANSLATED'] ?? $_SERVER['PATH_TRANSLATED'] ?? null)
```