### PR TITLE
Disable the request token check for idempotent actions

### DIFF
--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -116,13 +116,13 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 		$objSession = $container->get('request_stack')->getSession();
 
 		// Check the request token (see #4007)
-		if (Input::get('act') !== null)
-		{
-			if (Input::get('rt') === null || !$container->get('contao.csrf.token_manager')->isTokenValid(new CsrfToken($container->getParameter('contao.csrf_token_name'), Input::get('rt'))))
-			{
-				$objSession->set('INVALID_TOKEN_URL', Environment::get('requestUri'));
-				$this->redirect($container->get('router')->generate('contao_backend_confirm'));
-			}
+		if (
+			Input::get('act') !== null
+			&& (!\in_array(Input::get('act'), array('edit', 'show', 'select'), true) || Input::isPost())
+			&& (Input::get('rt') === null || !$container->get('contao.csrf.token_manager')->isTokenValid(new CsrfToken($container->getParameter('contao.csrf_token_name'), Input::get('rt'))))
+		) {
+			$objSession->set('INVALID_TOKEN_URL', Environment::get('requestUri'));
+			$this->redirect($container->get('router')->generate('contao_backend_confirm'));
 		}
 
 		$this->intId = Input::get('id');

--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -118,7 +118,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 		// Check the request token (see #4007)
 		if (
 			Input::get('act') !== null
-			&& (!\in_array(Input::get('act'), array('edit', 'show', 'select'), true) || Input::isPost())
+			&& !\in_array(Input::get('act'), array('edit', 'show', 'select'), true)
 			&& (Input::get('rt') === null || !$container->get('contao.csrf.token_manager')->isTokenValid(new CsrfToken($container->getParameter('contao.csrf_token_name'), Input::get('rt'))))
 		) {
 			$objSession->set('INVALID_TOKEN_URL', Environment::get('requestUri'));

--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -117,8 +117,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 
 		// Check the request token (see #4007)
 		if (
-			Input::get('act') !== null
-			&& !\in_array(Input::get('act'), array('edit', 'show', 'select'), true)
+			!\in_array(Input::get('act'), array(null, 'edit', 'show', 'select'), true)
 			&& (Input::get('rt') === null || !$container->get('contao.csrf.token_manager')->isTokenValid(new CsrfToken($container->getParameter('contao.csrf_token_name'), Input::get('rt'))))
 		) {
 			$objSession->set('INVALID_TOKEN_URL', Environment::get('requestUri'));


### PR DESCRIPTION
FINALLY removes the request token check for idempotent actions in the back end.