### PR TITLE
Add end-to-end tests with Cypress

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,28 @@ Then run the functional tests via the `run` command:
 composer run functional-tests
 ```
 
+## End to end tests with Cypress
+
+Install Cypress and copy `cypress.config.dev.js` from `vendor/contao/contao/cypress.config.dev.js` to root and rename to ``cypress.config.js`.
+
+
+```bash
+npm install cypress platform --save-dev
+cp vendor/contao/contao/cypress.config.dev.js ./cypress.config.js
+```
+
+Run e2e tests without ui.
+
+```bash
+npx cypress run
+```
+
+Run e2e tests with Cypress test suite.
+
+```bash
+npx cypress open
+```
+
 ## License
 
 Contao is licensed under the terms of the LGPLv3.

--- a/cypress.config.dev.js
+++ b/cypress.config.dev.js
@@ -1,0 +1,25 @@
+const { defineConfig } = require("cypress");
+var platform = require('platform');
+
+// set path to contao console via env or get it from os
+const CONTAO_CONSOLE = process.env.CONTAO_CONSOLE || ('Win32' !== platform.os.family) ? 'vendor/bin/contao-console' : 'vendor\\bin\\contao-console';
+
+module.exports = defineConfig({
+    downloadsFolder: "vendor/contao/contao/tests/cypress/downloads",
+    fixturesFolder: "vendor/contao/contao/tests/cypress/fixtures",
+    screenshotsFolder: "vendor/contao/contao/tests/cypress/screenshots",
+    videosFolder: "vendor/contao/contao/tests/cypress/videos",
+
+    env: {
+        CONTAO_CONSOLE: CONTAO_CONSOLE
+    },
+
+    e2e: {
+        baseUrl: 'http://localhost:8000',
+        supportFile: 'vendor/contao/contao/tests/cypress/support/e2e.js',
+        specPattern: 'vendor/contao/contao/tests/cypress/e2e/**/*.cy.js',
+        setupNodeEvents(on, config) {
+            // implement node event listeners here
+        },
+    },
+});

--- a/tests/cypress/e2e/core-bundle/backend-login.cy.js
+++ b/tests/cypress/e2e/core-bundle/backend-login.cy.js
@@ -1,0 +1,38 @@
+import app from '../../fixtures/app.json'
+import user from '../../fixtures/users/admin.json'
+
+describe('Backend', { execTimeout: 90000 }, () => {
+
+    before(() => {
+        cy.exec(Cypress.env('CONTAO_CONSOLE')+' contao:migrate --no-interaction --with-deletes --no-backup --quiet', { failOnNonZeroExit: false })
+        cy.exec(Cypress.env('CONTAO_CONSOLE')+' contao:user:create --username='+user.username+' --name='+user.name+' --email='+user.email+' --password='+user.password+' --language='+user.language+' --admin', { failOnNonZeroExit: false })
+    })
+
+    it('Login', () => {
+        cy.visit('/contao/login')
+
+        cy.get('input[name=username]').type(user.username)
+
+        // {enter} causes the form to submit
+        cy.get('input[name=password]').type(`${user.password}{enter}`)
+
+        cy.get('h1').should('contain', 'Dashboard')
+
+        // our auth cookie should be present
+        cy.getCookie('PHPSESSID').should('exist')
+
+        // our csrf_token cookie should be present
+        cy.getCookie('csrf_contao_csrf_token').should('exist')
+
+        // UI should reflect this user being logged in
+        cy.get('ul[id="tmenu"] button').should('contain', 'User ')
+        cy.get('ul[id="tmenu"] button').should('contain', user.username)
+    })
+
+    after(() => {
+        // drop db and recreate
+        cy.exec('mysql -u'+app.database_username+' -e "DROP DATABASE '+app.database_name+'";', {failOnNonZeroExit: false})
+        cy.exec('mysql -u'+app.database_username+' -e "CREATE DATABASE '+app.database_name+'";', {failOnNonZeroExit: false})
+        cy.log('Database is back to initial state.')
+    })
+})

--- a/tests/cypress/fixtures/app.json
+++ b/tests/cypress/fixtures/app.json
@@ -1,0 +1,5 @@
+{
+  "database_name": "contao_test",
+  "database_username": "root",
+  "database_password": "root"
+}

--- a/tests/cypress/fixtures/users/admin.json
+++ b/tests/cypress/fixtures/users/admin.json
@@ -1,0 +1,7 @@
+{
+  "username": "admin",
+  "name": "ADMIN",
+  "email": "test@example.org",
+  "password": "password",
+  "language": "en"
+}

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -1,0 +1,25 @@
+// ***********************************************
+// This example commands.js shows you how to
+// create various custom commands and overwrite
+// existing commands.
+//
+// For more comprehensive examples of custom
+// commands please read more here:
+// https://on.cypress.io/custom-commands
+// ***********************************************
+//
+//
+// -- This is a parent command --
+// Cypress.Commands.add('login', (email, password) => { ... })
+//
+//
+// -- This is a child command --
+// Cypress.Commands.add('drag', { prevSubject: 'element'}, (subject, options) => { ... })
+//
+//
+// -- This is a dual command --
+// Cypress.Commands.add('dismiss', { prevSubject: 'optional'}, (subject, options) => { ... })
+//
+//
+// -- This will overwrite an existing command --
+// Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })

--- a/tests/cypress/support/e2e.js
+++ b/tests/cypress/support/e2e.js
@@ -1,0 +1,21 @@
+import 'fs'
+// ***********************************************************
+// This example support/e2e.js is processed and
+// loaded automatically before your test files.
+//
+// This is a great place to put global configuration and
+// behavior that modifies Cypress.
+//
+// You can change the location of this file or turn off
+// automatically serving support files with the
+// 'supportFile' configuration option.
+//
+// You can read more here:
+// https://on.cypress.io/configuration
+// ***********************************************************
+
+// Import commands.js using ES2015 syntax:
+import './commands'
+
+// Alternatively you can use CommonJS syntax:
+// require('./commands')


### PR DESCRIPTION
Fixes #5273

The test requires an empty Contao installation as described in the [development section](https://github.com/contao/contao/blob/5.x/README.md#development).

For the backend login we run contao:migrate and create a user. Then the tests are executed. After the tests, the database is reset and ready for new tests.
