### PR TITLE
Use executeStatement() in the Dbafs class

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Dbafs.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Dbafs.php
@@ -513,7 +513,7 @@ class Dbafs
 		$objDatabase->beginTransaction();
 
 		// Reset the "found" flag
-		$objDatabase->query("UPDATE tl_files SET found=''");
+		$objDatabase->executeStatement("UPDATE tl_files SET found=''");
 
 		$projectDir = System::getContainer()->getParameter('kernel.project_dir');
 
@@ -764,7 +764,7 @@ class Dbafs
 		$objLog->close();
 
 		// Reset the found flag
-		$objDatabase->query("UPDATE tl_files SET found=1 WHERE found=2");
+		$objDatabase->executeStatement("UPDATE tl_files SET found=1 WHERE found=2");
 
 		// Finalize database access
 		$objDatabase->commitTransaction();


### PR DESCRIPTION
Otherwise it will no longer work in Contao 5.

https://github.com/contao/contao/blob/c79ab75e51aee332a28822923adc70603d0b0872/core-bundle/src/Resources/contao/library/Contao/Database/Statement.php#L288-L296