### PR TITLE
Remove dead code from the Database class

### DIFF
--- a/core-bundle/contao/library/Contao/Database.php
+++ b/core-bundle/contao/library/Contao/Database.php
@@ -33,22 +33,16 @@ use Doctrine\DBAL\Exception\DriverException;
 class Database
 {
 	/**
-	 * Object instances (Singleton)
-	 * @var array
+	 * Object instance (Singleton)
+	 * @var Database
 	 */
-	protected static $arrInstances = array();
+	protected static $objInstance;
 
 	/**
 	 * Connection ID
 	 * @var Connection
 	 */
 	protected $resConnection;
-
-	/**
-	 * Disable autocommit
-	 * @var boolean
-	 */
-	protected $blnDisableAutocommit = false;
 
 	/**
 	 * Cache
@@ -72,14 +66,6 @@ class Database
 	}
 
 	/**
-	 * Close the database connection
-	 */
-	public function __destruct()
-	{
-		$this->resConnection = null;
-	}
-
-	/**
 	 * Prevent cloning of the object (Singleton)
 	 */
 	final public function __clone()
@@ -95,6 +81,8 @@ class Database
 	 */
 	public function __get($strKey)
 	{
+		trigger_deprecation('contao/core-bundle', '5.0', 'Using "%s->%s" has been deprecated and will no longer work in Contao 6.0.', __CLASS__, $strKey);
+
 		if ($strKey == 'error')
 		{
 			$info = $this->resConnection->errorInfo();
@@ -106,42 +94,13 @@ class Database
 	}
 
 	/**
-	 * Instantiate the Database object (Factory)
-	 *
-	 * @param array $arrCustomConfig A configuration array
+	 * Instantiate the Database object (Singleton)
 	 *
 	 * @return Database The Database object
 	 */
-	public static function getInstance(array $arrCustomConfig=null)
+	public static function getInstance()
 	{
-		$arrConfig = array();
-
-		if (\is_array($arrCustomConfig))
-		{
-			$container = System::getContainer();
-
-			$arrDefaultConfig = array
-			(
-				'dbHost'     => $container->hasParameter('database_host') ? $container->getParameter('database_host') : null,
-				'dbPort'     => $container->hasParameter('database_port') ? $container->getParameter('database_port') : null,
-				'dbUser'     => $container->hasParameter('database_user') ? $container->getParameter('database_user') : null,
-				'dbPass'     => $container->hasParameter('database_password') ? $container->getParameter('database_password') : null,
-				'dbDatabase' => $container->hasParameter('database_name') ? $container->getParameter('database_name') : null,
-			);
-
-			$arrConfig = array_merge($arrDefaultConfig, $arrCustomConfig);
-		}
-
-		// Sort the array before generating the key
-		ksort($arrConfig);
-		$strKey = md5(implode('', $arrConfig));
-
-		if (!isset(static::$arrInstances[$strKey]))
-		{
-			static::$arrInstances[$strKey] = new static($arrConfig);
-		}
-
-		return static::$arrInstances[$strKey];
+		return static::$objInstance ??= new static();
 	}
 
 	/**

--- a/core-bundle/tests/Contao/ModuleTest.php
+++ b/core-bundle/tests/Contao/ModuleTest.php
@@ -140,8 +140,8 @@ class ModuleTest extends TestCase
 
     private function mockDatabase(Database $database): void
     {
-        $property = (new \ReflectionClass($database))->getProperty('arrInstances');
-        $property->setValue([md5(implode('', [])) => $database]);
+        $property = (new \ReflectionClass($database))->getProperty('objInstance');
+        $property->setValue($database);
 
         $this->assertSame($database, Database::getInstance());
     }

--- a/core-bundle/tests/Contao/PageModelTest.php
+++ b/core-bundle/tests/Contao/PageModelTest.php
@@ -443,8 +443,8 @@ class PageModelTest extends TestCase
 
     private function mockDatabase(Database $database): void
     {
-        $property = (new \ReflectionClass($database))->getProperty('arrInstances');
-        $property->setValue([md5(implode('', [])) => $database]);
+        $property = (new \ReflectionClass($database))->getProperty('objInstance');
+        $property->setValue($database);
 
         $this->assertSame($database, Database::getInstance());
     }


### PR DESCRIPTION
…and deprecate magic `__get()`

We forgot to remove the `$arrCustomConfig` from the `getInstance()` method in #4291 I think, it does not work anymore in Contao 5 because the constructor argument was removed.