### PR TITLE
Fix bug with cache in Database::listTables()

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Database.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Database.php
@@ -54,10 +54,16 @@ class Database
 	protected $blnDisableAutocommit = false;
 
 	/**
-	 * Cache
+	 * listFields Cache
 	 * @var array
 	 */
 	protected $arrCache = array();
+
+	/**
+	 * listTables Cache
+	 * @var array
+	 */
+	protected $arrTablesCache = array();
 
 	/**
 	 * Establish the database connection
@@ -246,7 +252,7 @@ class Database
 	 */
 	public function listTables($strDatabase=null, $blnNoCache=false)
 	{
-		if ($blnNoCache || !isset($this->arrCache[$strDatabase]))
+		if ($blnNoCache || !isset($this->arrTablesCache[$strDatabase]))
 		{
 			$strOldDatabase = $this->resConnection->getDatabase();
 
@@ -256,7 +262,7 @@ class Database
 				$this->setDatabase($strDatabase);
 			}
 
-			$this->arrCache[$strDatabase] = $this->resConnection->getSchemaManager()->listTableNames();
+			$this->arrTablesCache[$strDatabase] = $this->resConnection->getSchemaManager()->listTableNames();
 
 			// Restore the database
 			if ($strDatabase !== null && $strDatabase != $strOldDatabase)
@@ -265,7 +271,7 @@ class Database
 			}
 		}
 
-		return $this->arrCache[$strDatabase];
+		return $this->arrTablesCache[$strDatabase];
 	}
 
 	/**

--- a/core-bundle/tests/Contao/DatabaseTest.php
+++ b/core-bundle/tests/Contao/DatabaseTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\Contao;
+
+use Contao\Database;
+use Contao\System;
+use Contao\TestCase\ContaoTestCase;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver\ResultStatement;
+use Doctrine\DBAL\Schema\AbstractSchemaManager;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class DatabaseTest extends ContaoTestCase
+{
+    protected function tearDown(): void
+    {
+        $this->resetStaticProperties([Database::class]);
+
+        parent::tearDown();
+    }
+
+    public function testTableAndDatabaseCacheDoNotCollide(): void
+    {
+        $schemaManager = $this->createMock(AbstractSchemaManager::class);
+        $schemaManager
+            ->method('listTableNames')
+            ->willReturn(['samename'])
+        ;
+
+        $result = $this->createMock(ResultStatement::class);
+
+        $result
+            ->method('columnCount')
+            ->willReturn(1)
+        ;
+
+        $result
+            ->method('fetch')
+            ->willReturnOnConsecutiveCalls(
+                ['Field' => 'columnname', 'Type' => 'varchar(255)'],
+                false,
+                false,
+                ['Field' => 'columnname', 'Type' => 'varchar(255)'],
+                false,
+                false,
+            )
+        ;
+
+        $connection = $this->createMock(Connection::class);
+
+        $connection
+            ->method('getDatabase')
+            ->willReturn('samename')
+        ;
+
+        $connection
+            ->method('getSchemaManager')
+            ->willReturn($schemaManager)
+        ;
+
+        $connection
+            ->method('executeQuery')
+            ->willReturnMap([
+                ['SHOW FULL COLUMNS FROM samename', [], [], null, $result],
+                ['SHOW INDEXES FROM `samename`', [], [], null, $result],
+            ])
+        ;
+
+        $container = new ContainerBuilder();
+        $container->set('database_connection', $connection);
+
+        System::setContainer($container);
+
+        $database = Database::getInstance();
+
+        // Without cache
+        $this->assertSame(['samename'], $database->listTables('samename', true));
+        $this->assertSame('columnname', $database->listFields('samename', true)[0]['name']);
+
+        // With cache
+        $this->assertSame(['samename'], $database->listTables('samename'));
+        $this->assertSame(['samename'], $database->listTables('samename'));
+        $this->assertSame('columnname', $database->listFields('samename')[0]['name']);
+        $this->assertSame('columnname', $database->listFields('samename')[0]['name']);
+    }
+}

--- a/core-bundle/tests/Contao/DatabaseTest.php
+++ b/core-bundle/tests/Contao/DatabaseTest.php
@@ -24,7 +24,10 @@ class DatabaseTest extends ContaoTestCase
 {
     protected function tearDown(): void
     {
-        $this->resetStaticProperties([Database::class]);
+        // Reset database instance
+        $property = (new \ReflectionClass(Database::class))->getProperty('arrInstances');
+        $property->setAccessible(true);
+        $property->setValue([]);
 
         parent::tearDown();
     }

--- a/core-bundle/tests/Contao/DatabaseTest.php
+++ b/core-bundle/tests/Contao/DatabaseTest.php
@@ -55,7 +55,7 @@ class DatabaseTest extends ContaoTestCase
                 false,
                 ['Field' => 'columnname', 'Type' => 'varchar(255)'],
                 false,
-                false,
+                false
             )
         ;
 


### PR DESCRIPTION
`Database::listFields()` and `Database::listTables()` currently use the same array to cache its values. This results in incorrect data if you have a table with the same name as your database.