### PR TITLE
Handle cross-website-root redirects in the Frontend::jumpToOrReload method

### DIFF
--- a/core-bundle/src/Resources/contao/classes/Frontend.php
+++ b/core-bundle/src/Resources/contao/classes/Frontend.php
@@ -492,7 +492,14 @@ abstract class Frontend extends Controller
 
 		if ($intId > 0 && ($intId != $objPage->id || $blnForceRedirect) && ($objNextPage = PageModel::findPublishedById($intId)) !== null)
 		{
-			$this->redirect($objNextPage->getFrontendUrl($strParams, $strForceLang));
+			if (!$strForceLang)
+			{
+				$this->redirect($objNextPage->getAbsoluteUrl($strParams));
+			}
+			else
+			{
+				$this->redirect($objNextPage->getFrontendUrl($strParams, $strForceLang));
+			}
 		}
 
 		$this->reload();


### PR DESCRIPTION
For example, if the target page of a form is set to another website root, the resulting URL will be rendered incorrectly.

Example:

```
https://sub.domain.tld/domain.tld/en/confirmation.html
```

Whereas it should be:

```
https://domain.tld/en/confirmation.html
```