### PR TITLE
Correctly copy templates from symlinked sources

### DIFF
--- a/core-bundle/src/Resources/contao/dca/tl_templates.php
+++ b/core-bundle/src/Resources/contao/dca/tl_templates.php
@@ -312,6 +312,7 @@ class tl_templates extends Contao\Backend
 							Path::makeAbsolute($strOriginal, $projectDir),
 							Path::makeAbsolute($strTarget, $projectDir)
 						);
+
 						$this->redirect($this->getReferer());
 					}
 				}

--- a/core-bundle/src/Resources/contao/dca/tl_templates.php
+++ b/core-bundle/src/Resources/contao/dca/tl_templates.php
@@ -266,7 +266,6 @@ class tl_templates extends Contao\Backend
 		// Copy an existing template
 		if (Contao\Input::post('FORM_SUBMIT') == 'tl_create_template')
 		{
-			$strOriginal = Contao\Input::post('original', true);
 			$strTarget = Contao\Input::post('target', true);
 
 			if (Contao\Validator::isInsecurePath($strTarget))
@@ -282,6 +281,7 @@ class tl_templates extends Contao\Backend
 			else
 			{
 				$blnFound = false;
+				$strOriginal = Contao\Input::post('original', true);
 
 				// Validate the source path
 				foreach ($arrAllTemplates as $arrTemplates)

--- a/core-bundle/src/Resources/contao/dca/tl_templates.php
+++ b/core-bundle/src/Resources/contao/dca/tl_templates.php
@@ -336,7 +336,7 @@ class tl_templates extends Contao\Backend
 		// Show form
 		return ($strError ? '
 <div class="tl_message">
-<p class="tl_error">' . $strError . '</p>
+<p class="tl_error">' . Contao\StringUtil::specialchars($strError) . '</p>
 </div>' : '') . '
 
 <div id="tl_buttons">

--- a/core-bundle/src/Resources/contao/dca/tl_templates.php
+++ b/core-bundle/src/Resources/contao/dca/tl_templates.php
@@ -8,6 +8,7 @@
  * @license LGPL-3.0-or-later
  */
 
+use Symfony\Component\Filesystem\Filesystem;
 use Webmozart\PathUtil\Path;
 
 Contao\System::loadLanguageFile('tl_files');
@@ -266,12 +267,6 @@ class tl_templates extends Contao\Backend
 		if (Contao\Input::post('FORM_SUBMIT') == 'tl_create_template')
 		{
 			$strOriginal = Contao\Input::post('original', true);
-
-			if (Contao\Validator::isInsecurePath($strOriginal))
-			{
-				throw new RuntimeException('Invalid path ' . $strOriginal);
-			}
-
 			$strTarget = Contao\Input::post('target', true);
 
 			if (Contao\Validator::isInsecurePath($strTarget))
@@ -313,8 +308,10 @@ class tl_templates extends Contao\Backend
 					}
 					else
 					{
-						$this->import('Contao\Files', 'Files');
-						$this->Files->copy($strOriginal, $strTarget);
+						(new Filesystem())->copy(
+							Path::makeAbsolute($strOriginal, $projectDir),
+							Path::makeAbsolute($strTarget, $projectDir)
+						);
 						$this->redirect($this->getReferer());
 					}
 				}


### PR DESCRIPTION
This PR build on top of #5270 and also fixes the creation of templates from symlinked sources.

This includes two things: 
* I removed an unnecessary call for `Validator::isInsecurePath()`. The post data (source) is already checked against the array of options a few lines down.
* The file now gets copied by the `Filesystem` class instead of the `Files` class, because the latter does not allow anything outside the project dir.