### PR TITLE
Do not confirm password changes in the widget

### DIFF
--- a/core-bundle/src/Resources/contao/classes/DataContainer.php
+++ b/core-bundle/src/Resources/contao/classes/DataContainer.php
@@ -321,7 +321,6 @@ abstract class DataContainer extends Backend
 
 		/** @var Widget $objWidget */
 		$objWidget = new $strClass($strClass::getAttributesFromDca($arrData, $this->strInputName, $this->varValue, $this->strField, $this->strTable, $this));
-
 		$objWidget->xlabel = $xlabel;
 		$objWidget->currentRecord = $this->intId;
 
@@ -403,6 +402,12 @@ abstract class DataContainer extends Backend
 					try
 					{
 						$this->save($varValue);
+
+						// Confirm password changes
+						if ($objWidget instanceof Password)
+						{
+							Message::addConfirmation($GLOBALS['TL_LANG']['MSC']['pw_changed']);
+						}
 					}
 					catch (ResponseException $e)
 					{

--- a/core-bundle/src/Resources/contao/forms/FormPassword.php
+++ b/core-bundle/src/Resources/contao/forms/FormPassword.php
@@ -137,6 +137,7 @@ class FormPassword extends Widget
 		if (!$this->hasErrors())
 		{
 			$this->blnSubmitInput = true;
+
 			$encoder = System::getContainer()->get('security.encoder_factory')->getEncoder(FrontendUser::class);
 
 			return $encoder->encodePassword($varInput, null);

--- a/core-bundle/src/Resources/contao/widgets/Password.php
+++ b/core-bundle/src/Resources/contao/widgets/Password.php
@@ -132,7 +132,6 @@ class Password extends Widget
 		if (!$this->hasErrors())
 		{
 			$this->blnSubmitInput = true;
-			Message::addConfirmation($GLOBALS['TL_LANG']['MSC']['pw_changed']);
 
 			$encoder = System::getContainer()->get('security.encoder_factory')->getEncoder(BackendUser::class);
 


### PR DESCRIPTION
The reason why we have to use the ugly `Messages::reset()` hack in #5415 is that the password widgets wrongly assumes that a password has been changed if it **validates**. However, only the controller that actually **saves** the password can know this, so only the controller should add the confirmation message.

The `BackendPassword` controller already does this correctly. This PR adds the same functionality to the `DataContainer` class.