### PR TITLE
Pass the unmodified row to the onshow callback

### DIFF
--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -564,11 +564,11 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 				if (\is_array($callback))
 				{
 					$this->import($callback[0]);
-					$data = $this->{$callback[0]}->{$callback[1]}($data, $row, $this);
+					$data = $this->{$callback[0]}->{$callback[1]}($data, $currentRecord, $this);
 				}
 				elseif (\is_callable($callback))
 				{
-					$data = $callback($data, $row, $this);
+					$data = $callback($data, $currentRecord, $this);
 				}
 			}
 		}


### PR DESCRIPTION
In Contao 4 the `onshow_callback` received the row as retrieved from the database without modifications.
This was changed in #4770, by accident I believe.

Contao 4: `[… "type" => "headline" …]`
Contao 5 before this PR: `[… "type" => "Überschrift" …]`