### PR TITLE
Handle broken images in FigureBuilder#buildIfResourceExists()

### DIFF
--- a/core-bundle/src/Image/Studio/FigureBuilder.php
+++ b/core-bundle/src/Image/Studio/FigureBuilder.php
@@ -512,7 +512,18 @@ class FigureBuilder
             return null;
         }
 
-        return $this->doBuild();
+        $figure = $this->doBuild();
+
+        try {
+            // Make sure the resource can be processed
+            $figure->getImage()->getOriginalDimensions();
+        } catch (\Throwable $e) {
+            $this->lastException = new InvalidResourceException(sprintf('The file "%s" could not be opened as an image.', $this->filePath), 0, $e);
+
+            return null;
+        }
+
+        return $figure;
     }
 
     /**

--- a/core-bundle/tests/Image/Studio/FigureBuilderTest.php
+++ b/core-bundle/tests/Image/Studio/FigureBuilderTest.php
@@ -415,6 +415,38 @@ class FigureBuilderTest extends TestCase
         yield 'absolute path' => [$absoluteFilePath];
     }
 
+    public function testBuildIfResourceExistsHandlesFilesThatCannotBeProcessed(): void
+    {
+        $image = $this->createMock(ImageResult::class);
+        $image
+            ->method('getOriginalDimensions')
+            ->willThrowException($innerException = new \Exception('Broken image'))
+        ;
+
+        [$brokenImagePath] = $this->getTestFilePaths();
+
+        $studio = $this->createMock(Studio::class);
+        $studio
+            ->expects($this->once())
+            ->method('createImage')
+            ->with($brokenImagePath, null, null)
+            ->willReturn($image)
+        ;
+
+        $figureBuilder = $this
+            ->getFigureBuilder($studio)
+            ->fromPath($brokenImagePath, false)
+        ;
+
+        $this->assertNull($figureBuilder->buildIfResourceExists());
+
+        $exception = $figureBuilder->getLastException();
+
+        $this->assertInstanceOf(InvalidResourceException::class, $exception);
+        $this->assertSame('The file "'.$brokenImagePath.'" could not be opened as an image.', $exception->getMessage());
+        $this->assertSame($innerException, $exception->getPrevious());
+    }
+
     public function testLastExceptionIsResetWhenCallingFrom(): void
     {
         [$absoluteFilePath, $relativeFilePath] = $this->getTestFilePaths();


### PR DESCRIPTION
When the resizer tries to open an invalid image file, it will throw an exception. This is all fine except for the case that the `FigureBuilder` was used with `buildIfResourceExists()`. Due to the lazy nature, we do get a `Figure` object (instead of `null`) and the exception will only appear once accessing the image/picture data.

To solve this issue, we are now accessing `$figure->getImage()->getOriginalDimensions();` before returning the object, which makes the underlying system open the image (no resize yet) and then catch the exception/return null in case of an error. Props to @ausi for this idea.
