### PR TITLE
Fix automatic DBAFS sync for root resources

### DIFF
--- a/core-bundle/src/Filesystem/Dbafs/Dbafs.php
+++ b/core-bundle/src/Filesystem/Dbafs/Dbafs.php
@@ -790,16 +790,16 @@ class Dbafs implements DbafsInterface, ResetInterface
             }
 
             if (null === ($isDir = $analyzedPaths[$searchPath] ?? null)) {
-                if (!$shallow && $this->filesystem->fileExists($searchPath, VirtualFilesystemInterface::BYPASS_DBAFS)) {
-                    // Yield file
-                    yield $searchPath => self::RESOURCE_FILE;
-
-                    continue;
-                }
-
                 // Analyze parent path
                 $analyzedPaths = array_merge($analyzedPaths, $analyzeDirectory(Path::getDirectory($searchPath)));
                 $isDir = $analyzedPaths[$searchPath] ??= false;
+            }
+
+            if (!$isDir && !$shallow && $this->filesystem->fileExists($searchPath, VirtualFilesystemInterface::BYPASS_DBAFS)) {
+                // Yield existing file
+                yield $searchPath => self::RESOURCE_FILE;
+
+                continue;
             }
 
             if ($isDir) {

--- a/core-bundle/src/Filesystem/Dbafs/Dbafs.php
+++ b/core-bundle/src/Filesystem/Dbafs/Dbafs.php
@@ -800,7 +800,6 @@ class Dbafs implements DbafsInterface, ResetInterface
 
                 continue;
             }
-            
             if (!$shallow && $this->filesystem->fileExists($searchPath, VirtualFilesystemInterface::BYPASS_DBAFS)) {
                 // Yield existing file
                 yield $searchPath => self::RESOURCE_FILE;

--- a/core-bundle/src/Filesystem/Dbafs/Dbafs.php
+++ b/core-bundle/src/Filesystem/Dbafs/Dbafs.php
@@ -800,6 +800,7 @@ class Dbafs implements DbafsInterface, ResetInterface
 
                 continue;
             }
+
             if (!$shallow && $this->filesystem->fileExists($searchPath, VirtualFilesystemInterface::BYPASS_DBAFS)) {
                 // Yield existing file
                 yield $searchPath => self::RESOURCE_FILE;

--- a/core-bundle/src/Filesystem/Dbafs/Dbafs.php
+++ b/core-bundle/src/Filesystem/Dbafs/Dbafs.php
@@ -143,15 +143,17 @@ class Dbafs implements DbafsInterface, ResetInterface
         $path = Path::join($this->dbPathPrefix, $path);
         $table = $this->connection->quoteIdentifier($this->table);
 
+        $searchLiteral = '' !== $path ? "$path/%" : '%';
+
         if ($deep) {
             $rows = $this->connection->fetchAllAssociative(
                 "SELECT * FROM $table WHERE path LIKE ? ORDER BY path",
-                ["$path/%"]
+                [$searchLiteral]
             );
         } else {
             $rows = $this->connection->fetchAllAssociative(
                 "SELECT * FROM $table WHERE path LIKE ? AND path NOT LIKE ? ORDER BY path",
-                ["$path/%", "$path/%/%"]
+                [$searchLiteral, "$searchLiteral/%"]
             );
         }
 

--- a/core-bundle/src/Filesystem/Dbafs/Dbafs.php
+++ b/core-bundle/src/Filesystem/Dbafs/Dbafs.php
@@ -795,15 +795,15 @@ class Dbafs implements DbafsInterface, ResetInterface
                 $isDir = $analyzedPaths[$searchPath] ??= false;
             }
 
-            if (!$isDir && !$shallow && $this->filesystem->fileExists($searchPath, VirtualFilesystemInterface::BYPASS_DBAFS)) {
-                // Yield existing file
-                yield $searchPath => self::RESOURCE_FILE;
+            if ($isDir) {
+                yield from $traverseRecursively($searchPath, $shallow);
 
                 continue;
             }
-
-            if ($isDir) {
-                yield from $traverseRecursively($searchPath, $shallow);
+            
+            if (!$shallow && $this->filesystem->fileExists($searchPath, VirtualFilesystemInterface::BYPASS_DBAFS)) {
+                // Yield existing file
+                yield $searchPath => self::RESOURCE_FILE;
 
                 continue;
             }

--- a/core-bundle/tests/Functional/DbafsTest.php
+++ b/core-bundle/tests/Functional/DbafsTest.php
@@ -20,32 +20,14 @@ use Contao\CoreBundle\Filesystem\MountManager;
 use Contao\CoreBundle\Filesystem\VirtualFilesystem;
 use Contao\TestCase\FunctionalTestCase;
 use League\Flysystem\Config;
+use League\Flysystem\FilesystemAdapter;
 use League\Flysystem\InMemory\InMemoryFilesystemAdapter;
 
 class DbafsTest extends FunctionalTestCase
 {
     public function testAlterFilesystemAndSync(): void
     {
-        $client = $this->createClient();
-        $container = $client->getContainer();
-
-        static::resetDatabaseSchema();
-
-        $filesystem = new VirtualFilesystem(
-            (new MountManager())->mount($adapter = new InMemoryFilesystemAdapter()),
-            $dbafsManager = new DbafsManager()
-        );
-
-        $dbafs = new Dbafs(
-            new HashGenerator('md5', true),
-            $container->get('database_connection'),
-            $container->get('event_dispatcher'),
-            $filesystem,
-            'tl_files'
-        );
-
-        $dbafsManager->register($dbafs, '');
-        $dbafs->useLastModified();
+        [$filesystem, $dbafs, $adapter] = $this->setupFilesystemAndDbafs();
 
         // Expect no changes initially
         $this->assertTrue($dbafs->sync()->isEmpty());
@@ -70,6 +52,31 @@ class DbafsTest extends FunctionalTestCase
 
         $this->assertFile1Deleted($dbafs->sync('foo/**'));
         $this->assertFile3Deleted($dbafs->sync());
+    }
+
+    public function testAutomaticallySyncsFiles(): void
+    {
+        [$filesystem] = $this->setupFilesystemAndDbafs();
+
+        // Adding a file should automatically update the Dbafs
+        $filesystem->write('a', '');
+
+        $contents = $filesystem->listContents('')->toArray();
+        $this->assertCount(1, $contents);
+        $this->assertSame('a', $contents[0]->getPath());
+
+        // Moving a file should automatically update the Dbafs
+        $filesystem->move('a', 'b');
+
+        $contents = $filesystem->listContents('')->toArray();
+        $this->assertCount(1, $contents);
+        $this->assertSame('b', $contents[0]->getPath());
+
+        // Deleting a file should automatically update the Dbafs
+        $filesystem->delete('b');
+
+        $contents = $filesystem->listContents('')->toArray();
+        $this->assertCount(0, $contents);
     }
 
     private function assertFile1MovedAndFile3Created(ChangeSet $changeSet): void
@@ -120,5 +127,34 @@ class DbafsTest extends FunctionalTestCase
             ],
             $changeSet->getItemsToDelete()
         );
+    }
+
+    /**
+     * @return array{0: VirtualFilesystem, 1: Dbafs, 2:FilesystemAdapter}
+     */
+    private function setupFilesystemAndDbafs(): array
+    {
+        $client = $this->createClient();
+        $container = $client->getContainer();
+
+        $filesystem = new VirtualFilesystem(
+            (new MountManager())->mount($adapter = new InMemoryFilesystemAdapter()),
+            $dbafsManager = new DbafsManager()
+        );
+
+        $dbafs = new Dbafs(
+            new HashGenerator('md5', true),
+            $container->get('database_connection'),
+            $container->get('event_dispatcher'),
+            $filesystem,
+            'tl_files'
+        );
+
+        $dbafsManager->register($dbafs, '');
+        $dbafs->useLastModified();
+
+        static::resetDatabaseSchema();
+
+        return [$filesystem, $dbafs, $adapter];
     }
 }


### PR DESCRIPTION
There was a bug with automatic DBAFS syncing if the updated resource was situated in the search root: When the `Dbafs` service was analyzing at the filesystem, resources didn't get yielded as "file" then but as "non-existing". This meant files would not be tracked when calling `$filesystem->move('a', 'b');`. 

I also fixed a related bug for DBAFSs without a prefix: There, when searching for an empty prefix (`''`), the logic would still add a leading `/` making the query not return any results.

The added functional test case now covers both cases.