### PR TITLE
Improve the stability of the JSON export for the "user list" command

### DIFF
--- a/core-bundle/src/Command/UserListCommand.php
+++ b/core-bundle/src/Command/UserListCommand.php
@@ -53,7 +53,7 @@ class UserListCommand extends Command
     {
         $io = new SymfonyStyle($input, $output);
 
-        if ($input->getOption('admins')) {
+        if ($input->getOption('admins') && 'json' !== $input->getOption('format')) {
             $io->note('Only showing admin accounts');
         }
 

--- a/core-bundle/src/Command/UserListCommand.php
+++ b/core-bundle/src/Command/UserListCommand.php
@@ -140,7 +140,7 @@ class UserListCommand extends Command
         }
 
         if ([] === $columns) {
-            return $users->fetchAll();
+            $columns = ['username', 'name', 'admin', 'dateAdded', 'lastLogin'];
         }
 
         $data = [];

--- a/core-bundle/src/Command/UserListCommand.php
+++ b/core-bundle/src/Command/UserListCommand.php
@@ -80,7 +80,7 @@ class UserListCommand extends Command
             case 'json':
                 $data = $this->formatJson($users, $columns);
 
-                $io->write(json_encode($data));
+                $io->write(json_encode($data, JSON_THROW_ON_ERROR));
                 break;
 
             default:


### PR DESCRIPTION
This PR improves stability for the JSON output of the `contao:user:list --format=json` command.

In particular:

- Use JSON_THROW_ON_ERROR to not silence unexpected errors
- Use the same default columns as for text output (fixes errors when trying to export columns with binary data, i.e., `secret`).
- Silence informational output, so the output is JSON only


This PR closes #4937.
