### PR TITLE
Fix a PHP 8 issue in the PageTree widget

### DIFF
--- a/core-bundle/src/Resources/contao/widgets/PageTree.php
+++ b/core-bundle/src/Resources/contao/widgets/PageTree.php
@@ -237,7 +237,7 @@ class PageTree extends Widget
         e.preventDefault();
         Backend.openModalSelector({
           "id": "tl_listing",
-          "title": ' . json_encode($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['label'][0]) . ',
+          "title": ' . json_encode($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['label'][0] ?? '') . ',
           "url": this.href + document.getElementById("ctrl_' . $this->strId . '").value,
           "callback": function(table, value) {
             new Request.Contao({


### PR DESCRIPTION
Fix `Warning: Trying to access array offset on value of type null` if there is no label set.

If you have no label on a picker field (mostly in development) you became this warning.