### PR TITLE
Add a conflict for the broken symfony/dependency-injection 6.2.0 release

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -194,7 +194,7 @@
         "nikic/php-parser": "4.7.0",
         "phpunit/phpunit": "<8.0",
         "roave/better-reflection": "<4.12.2 || >=6.0",
-        "symfony/dependency-injection": "5.4.16 || 6.0.16 || 6.1.8",
+        "symfony/dependency-injection": "5.4.16 || 6.0.16 || 6.1.8 || 6.2.0",
         "terminal42/contao-ce-access": "<3.0",
         "thecodingmachine/safe": "<1.2",
         "zendframework/zend-code": "<3.3.1"

--- a/core-bundle/composer.json
+++ b/core-bundle/composer.json
@@ -166,7 +166,7 @@
         "doctrine/cache": "<1.10",
         "doctrine/dbal": "3.3.0",
         "friendsofsymfony/http-cache": "2.14.0",
-        "symfony/dependency-injection": "5.4.16 || 6.0.16 || 6.1.8",
+        "symfony/dependency-injection": "5.4.16 || 6.0.16 || 6.1.8 || 6.2.0",
         "terminal42/contao-ce-access": "<3.0",
         "thecodingmachine/safe": "<1.2"
     },


### PR DESCRIPTION
Fixes the actions (see https://github.com/contao/contao/actions/runs/3586489067/jobs/6037699064 or https://github.com/contao/contao/actions/runs/3586489067/jobs/6037698454)