### PR TITLE
Fix the missing module references in the newsletter-bundle hooks

### DIFF
--- a/newsletter-bundle/src/Resources/contao/modules/ModuleSubscribe.php
+++ b/newsletter-bundle/src/Resources/contao/modules/ModuleSubscribe.php
@@ -235,7 +235,7 @@ class ModuleSubscribe extends Module
 			foreach ($GLOBALS['TL_HOOKS']['activateRecipient'] as $callback)
 			{
 				$this->import($callback[0]);
-				$this->{$callback[0]}->{$callback[1]}($optInToken->getEmail(), $arrAdd, $arrCids);
+				$this->{$callback[0]}->{$callback[1]}($optInToken->getEmail(), $arrAdd, $arrCids, $this);
 			}
 		}
 

--- a/newsletter-bundle/src/Resources/contao/modules/ModuleUnsubscribe.php
+++ b/newsletter-bundle/src/Resources/contao/modules/ModuleUnsubscribe.php
@@ -266,7 +266,7 @@ class ModuleUnsubscribe extends Module
 			foreach ($GLOBALS['TL_HOOKS']['removeRecipient'] as $callback)
 			{
 				$this->import($callback[0]);
-				$this->{$callback[0]}->{$callback[1]}($strEmail, $arrRemove);
+				$this->{$callback[0]}->{$callback[1]}($strEmail, $arrRemove, $this);
 			}
 		}
 


### PR DESCRIPTION
Both, the `activateRecipient` as well as the `removeRecipient` hooks lack the module instance making it impossible to apply logic based on module settings.

This is possible in basically all our other module hooks so I'd consider this a bug :) 