### PR TITLE
Fix SitemapController not working for protected pages

### DIFF
--- a/core-bundle/src/Controller/SitemapController.php
+++ b/core-bundle/src/Controller/SitemapController.php
@@ -18,6 +18,7 @@ use Contao\CoreBundle\Event\SitemapEvent;
 use Contao\CoreBundle\Routing\Page\PageRegistry;
 use Contao\CoreBundle\Security\ContaoCorePermissions;
 use Contao\PageModel;
+use Contao\StringUtil;
 use Contao\System;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -132,7 +133,7 @@ class SitemapController extends AbstractController
 
         // Recursively walk through all subpages
         foreach ($pageModels as $pageModel) {
-            if ($pageModel->protected && !$this->isGranted(ContaoCorePermissions::MEMBER_IN_GROUPS, $pageModel->groups)) {
+            if ($pageModel->protected && !$this->isGranted(ContaoCorePermissions::MEMBER_IN_GROUPS, StringUtil::deserialize($pageModel->groups, true))) {
                 continue;
             }
 

--- a/core-bundle/src/Controller/SitemapController.php
+++ b/core-bundle/src/Controller/SitemapController.php
@@ -18,7 +18,6 @@ use Contao\CoreBundle\Event\SitemapEvent;
 use Contao\CoreBundle\Routing\Page\PageRegistry;
 use Contao\CoreBundle\Security\ContaoCorePermissions;
 use Contao\PageModel;
-use Contao\StringUtil;
 use Contao\System;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;

--- a/core-bundle/src/Controller/SitemapController.php
+++ b/core-bundle/src/Controller/SitemapController.php
@@ -133,7 +133,10 @@ class SitemapController extends AbstractController
 
         // Recursively walk through all subpages
         foreach ($pageModels as $pageModel) {
-            if ($pageModel->protected && !$this->isGranted(ContaoCorePermissions::MEMBER_IN_GROUPS, StringUtil::deserialize($pageModel->groups, true))) {
+            // Load details in order to inherit permission settings (see #5556)
+            $pageModel->loadDetails();
+
+            if ($pageModel->protected && !$this->isGranted(ContaoCorePermissions::MEMBER_IN_GROUPS, $pageModel->groups)) {
                 continue;
             }
 

--- a/core-bundle/tests/Controller/SitemapControllerTest.php
+++ b/core-bundle/tests/Controller/SitemapControllerTest.php
@@ -816,7 +816,7 @@ class SitemapControllerTest extends TestCase
                 ->expects($this->exactly(\count($absoluteUrls)))
                 ->method('getAbsoluteUrl')
                 ->withConsecutive(...$parameters)
-                ->willReturnOnConsecutiveCalls(...$absoluteUrls)
+                ->willReturnOnConsecutiveCalls(...array_values($absoluteUrls))
             ;
         } else {
             $page

--- a/core-bundle/tests/Controller/SitemapControllerTest.php
+++ b/core-bundle/tests/Controller/SitemapControllerTest.php
@@ -19,6 +19,7 @@ use Contao\CoreBundle\Event\SitemapEvent;
 use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\CoreBundle\Routing\Page\PageRegistry;
 use Contao\CoreBundle\Routing\Page\RouteConfig;
+use Contao\CoreBundle\Security\ContaoCorePermissions;
 use Contao\CoreBundle\Tests\TestCase;
 use Contao\PageModel;
 use Contao\System;
@@ -82,7 +83,7 @@ class SitemapControllerTest extends TestCase
             'id' => 43,
             'pid' => 42,
             'type' => 'regular',
-            'groups' => [],
+            'groups' => '',
             'published' => '1',
             'rootLanguage' => 'en',
         ]);
@@ -112,7 +113,7 @@ class SitemapControllerTest extends TestCase
             'id' => 43,
             'pid' => 42,
             'type' => 'regular',
-            'groups' => [],
+            'groups' => '',
             'published' => '1',
             'rootLanguage' => 'en',
         ]);
@@ -142,7 +143,7 @@ class SitemapControllerTest extends TestCase
             'id' => 43,
             'pid' => 42,
             'type' => 'regular',
-            'groups' => [],
+            'groups' => '',
             'published' => '1',
             'rootLanguage' => 'en',
         ]);
@@ -157,7 +158,7 @@ class SitemapControllerTest extends TestCase
             'id' => 44,
             'pid' => 43,
             'type' => 'regular',
-            'groups' => [],
+            'groups' => '',
             'published' => '1',
             'rootLanguage' => 'en',
         ]);
@@ -200,7 +201,7 @@ class SitemapControllerTest extends TestCase
             'id' => 43,
             'pid' => 42,
             'type' => 'regular',
-            'groups' => [],
+            'groups' => '',
             'published' => '',
             'rootLanguage' => 'en',
         ]);
@@ -214,7 +215,7 @@ class SitemapControllerTest extends TestCase
             'id' => 44,
             'pid' => 43,
             'type' => 'regular',
-            'groups' => [],
+            'groups' => '',
             'published' => '1',
             'rootLanguage' => 'en',
         ]);
@@ -254,7 +255,7 @@ class SitemapControllerTest extends TestCase
             'id' => 43,
             'pid' => 42,
             'type' => 'regular',
-            'groups' => [],
+            'groups' => '',
             'published' => '1',
             'requireItem' => '1',
             'rootLanguage' => 'en',
@@ -269,7 +270,7 @@ class SitemapControllerTest extends TestCase
             'id' => 44,
             'pid' => 43,
             'type' => 'regular',
-            'groups' => [],
+            'groups' => '',
             'published' => '1',
             'rootLanguage' => 'en',
         ]);
@@ -309,7 +310,7 @@ class SitemapControllerTest extends TestCase
             'id' => 43,
             'pid' => 42,
             'type' => 'forward',
-            'groups' => [],
+            'groups' => '',
             'published' => '1',
             'rootLanguage' => 'en',
         ]);
@@ -323,7 +324,7 @@ class SitemapControllerTest extends TestCase
             'id' => 44,
             'pid' => 43,
             'type' => 'regular',
-            'groups' => [],
+            'groups' => '',
             'published' => '1',
             'rootLanguage' => 'en',
         ]);
@@ -377,7 +378,7 @@ class SitemapControllerTest extends TestCase
             'id' => 43,
             'pid' => 42,
             'type' => 'error_404',
-            'groups' => [],
+            'groups' => '',
             'published' => '1',
             'rootLanguage' => 'en',
         ]);
@@ -391,7 +392,7 @@ class SitemapControllerTest extends TestCase
             'id' => 44,
             'pid' => 43,
             'type' => 'regular',
-            'groups' => [],
+            'groups' => '',
             'published' => '1',
             'rootLanguage' => 'en',
         ]);
@@ -443,7 +444,7 @@ class SitemapControllerTest extends TestCase
             'pid' => 42,
             'type' => 'regular',
             'protected' => '',
-            'groups' => [],
+            'groups' => '',
             'published' => '1',
             'rootLanguage' => 'en',
         ]);
@@ -459,7 +460,7 @@ class SitemapControllerTest extends TestCase
             'pid' => 43,
             'type' => 'regular',
             'protected' => '1',
-            'groups' => [],
+            'groups' => 'a:1:{i:0;s:1:"1";}',
             'published' => '1',
             'rootLanguage' => 'en',
         ]);
@@ -469,14 +470,31 @@ class SitemapControllerTest extends TestCase
             ->method('getAbsoluteUrl')
         ;
 
+        $page3 = $this->mockClassWithProperties(PageModel::class, [
+            'id' => 45,
+            'pid' => 43,
+            'type' => 'regular',
+            'protected' => '1',
+            'groups' => 'a:1:{i:0;s:1:"2";}',
+            'published' => '1',
+            'rootLanguage' => 'en',
+        ]);
+
+        $page3
+            ->expects($this->once())
+            ->method('getAbsoluteUrl')
+            ->willReturn('https://www.foobar.com/en/page3.html')
+        ;
+
         $pages = [
-            42 => [$page1, $page2],
+            42 => [$page1, $page2, $page3],
             43 => null,
+            45 => null,
             21 => null,
         ];
 
-        $framework = $this->mockFrameworkWithPages($pages, [43 => null]);
-        $container = $this->getContainer($framework, [44 => false]);
+        $framework = $this->mockFrameworkWithPages($pages, [43 => null, 45 => null]);
+        $container = $this->getContainer($framework, [2]);
         $registry = new PageRegistry($this->createMock(Connection::class));
 
         $controller = new SitemapController($registry);
@@ -488,6 +506,7 @@ class SitemapControllerTest extends TestCase
 
         $expectedUrls = [
             'https://www.foobar.com/en/page1.html',
+            'https://www.foobar.com/en/page3.html',
         ];
 
         $this->assertSame($this->getExpectedSitemapContent($expectedUrls), $response->getContent());
@@ -500,7 +519,7 @@ class SitemapControllerTest extends TestCase
             'pid' => 42,
             'type' => 'regular',
             'protected' => '',
-            'groups' => [],
+            'groups' => '',
             'published' => '1',
             'rootLanguage' => 'en',
         ]);
@@ -538,7 +557,7 @@ class SitemapControllerTest extends TestCase
             'pid' => 42,
             'type' => 'regular',
             'protected' => '',
-            'groups' => [],
+            'groups' => '',
             'published' => '1',
             'rootLanguage' => 'en',
         ]);
@@ -575,7 +594,7 @@ class SitemapControllerTest extends TestCase
             'id' => 43,
             'pid' => 42,
             'type' => 'regular',
-            'groups' => [],
+            'groups' => '',
             'published' => '1',
             'robots' => 'index,follow',
             'rootLanguage' => 'en',
@@ -591,7 +610,7 @@ class SitemapControllerTest extends TestCase
             'id' => 44,
             'pid' => 42,
             'type' => 'regular',
-            'groups' => [],
+            'groups' => '',
             'published' => '1',
             'robots' => 'noindex,nofollow',
             'rootLanguage' => 'en',
@@ -632,7 +651,7 @@ class SitemapControllerTest extends TestCase
             'pid' => 42,
             'type' => 'regular',
             'protected' => '',
-            'groups' => [],
+            'groups' => '',
             'published' => '1',
             'rootLanguage' => 'en',
         ]);
@@ -648,7 +667,7 @@ class SitemapControllerTest extends TestCase
             'pid' => 21,
             'type' => 'regular',
             'protected' => '',
-            'groups' => [],
+            'groups' => '',
             'published' => '1',
             'rootLanguage' => 'en',
         ]);
@@ -704,7 +723,7 @@ class SitemapControllerTest extends TestCase
             'id' => 43,
             'pid' => 42,
             'type' => 'custom1',
-            'groups' => [],
+            'groups' => '',
             'published' => '1',
             'rootLanguage' => 'en',
         ]);
@@ -718,7 +737,7 @@ class SitemapControllerTest extends TestCase
             'id' => 44,
             'pid' => 43,
             'type' => 'custom2',
-            'groups' => [],
+            'groups' => '',
             'published' => '1',
             'rootLanguage' => 'en',
         ]);
@@ -883,9 +902,12 @@ class SitemapControllerTest extends TestCase
             ;
         } else {
             $authorizationChecker
-                ->expects($this->exactly(\count($isGranted)))
+                ->expects($this->any())
                 ->method('isGranted')
-                ->willReturnOnConsecutiveCalls(...$isGranted)
+                ->willReturnCallback(function(string $attribute, array $pageGroups) use ($isGranted) {
+                    $this->assertSame(ContaoCorePermissions::MEMBER_IN_GROUPS, $attribute);
+                    return \count(array_intersect(array_map('intval', $pageGroups), $isGranted)) > 0;
+                });
             ;
         }
 

--- a/core-bundle/tests/Controller/SitemapControllerTest.php
+++ b/core-bundle/tests/Controller/SitemapControllerTest.php
@@ -79,20 +79,14 @@ class SitemapControllerTest extends TestCase
 
     public function testIgnoresRequestPort(): void
     {
-        $page1 = $this->mockClassWithProperties(PageModel::class, [
+        $page1 = $this->mockPage([
             'id' => 43,
             'pid' => 42,
             'type' => 'regular',
-            'groups' => '',
+            'groups' => [],
             'published' => '1',
             'rootLanguage' => 'en',
-        ]);
-
-        $page1
-            ->expects($this->once())
-            ->method('getAbsoluteUrl')
-            ->willReturn('https://www.foobar.com:8000/en/page1.html')
-        ;
+        ], ['' => 'https://www.foobar.com:8000/en/page1.html']);
 
         $framework = $this->mockFrameworkWithPages([42 => [$page1], 43 => null, 21 => null], [43 => null]);
         $container = $this->getContainer($framework, null, 'https://www.foobar.com:8000');
@@ -109,20 +103,14 @@ class SitemapControllerTest extends TestCase
 
     public function testGeneratesSitemapForRegularPages(): void
     {
-        $page1 = $this->mockClassWithProperties(PageModel::class, [
+        $page1 = $this->mockPage([
             'id' => 43,
             'pid' => 42,
             'type' => 'regular',
-            'groups' => '',
+            'groups' => [],
             'published' => '1',
             'rootLanguage' => 'en',
-        ]);
-
-        $page1
-            ->expects($this->once())
-            ->method('getAbsoluteUrl')
-            ->willReturn('https://www.foobar.com/en/page1.html')
-        ;
+        ], ['' => 'https://www.foobar.com/en/page1.html']);
 
         $framework = $this->mockFrameworkWithPages([42 => [$page1], 43 => null, 21 => null], [43 => null]);
         $container = $this->getContainer($framework);
@@ -139,35 +127,23 @@ class SitemapControllerTest extends TestCase
 
     public function testRecursivelyWalksThePageTree(): void
     {
-        $page1 = $this->mockClassWithProperties(PageModel::class, [
+        $page1 = $this->mockPage([
             'id' => 43,
             'pid' => 42,
             'type' => 'regular',
-            'groups' => '',
+            'groups' => [],
             'published' => '1',
             'rootLanguage' => 'en',
-        ]);
+        ], ['' => 'https://www.foobar.com/en/page1.html']);
 
-        $page1
-            ->expects($this->once())
-            ->method('getAbsoluteUrl')
-            ->willReturn('https://www.foobar.com/en/page1.html')
-        ;
-
-        $page2 = $this->mockClassWithProperties(PageModel::class, [
+        $page2 = $this->mockPage([
             'id' => 44,
             'pid' => 43,
             'type' => 'regular',
-            'groups' => '',
+            'groups' => [],
             'published' => '1',
             'rootLanguage' => 'en',
-        ]);
-
-        $page2
-            ->expects($this->once())
-            ->method('getAbsoluteUrl')
-            ->willReturn('https://www.foobar.com/en/page2.html')
-        ;
+        ], ['' => 'https://www.foobar.com/en/page2.html']);
 
         $pages = [
             42 => [$page1],
@@ -197,34 +173,23 @@ class SitemapControllerTest extends TestCase
 
     public function testSkipsUnpublishedPagesButAddsChildPages(): void
     {
-        $page1 = $this->mockClassWithProperties(PageModel::class, [
+        $page1 = $this->mockPage([
             'id' => 43,
             'pid' => 42,
             'type' => 'regular',
-            'groups' => '',
+            'groups' => [],
             'published' => '',
             'rootLanguage' => 'en',
         ]);
 
-        $page1
-            ->expects($this->never())
-            ->method('getAbsoluteUrl')
-        ;
-
-        $page2 = $this->mockClassWithProperties(PageModel::class, [
+        $page2 = $this->mockPage([
             'id' => 44,
             'pid' => 43,
             'type' => 'regular',
-            'groups' => '',
+            'groups' => [],
             'published' => '1',
             'rootLanguage' => 'en',
-        ]);
-
-        $page2
-            ->expects($this->once())
-            ->method('getAbsoluteUrl')
-            ->willReturn('https://www.foobar.com/en/page2.html')
-        ;
+        ], ['' => 'https://www.foobar.com/en/page2.html']);
 
         $pages = [
             42 => [$page1],
@@ -251,35 +216,24 @@ class SitemapControllerTest extends TestCase
 
     public function testSkipsPagesThatRequireItemButAddsChildPages(): void
     {
-        $page1 = $this->mockClassWithProperties(PageModel::class, [
+        $page1 = $this->mockPage([
             'id' => 43,
             'pid' => 42,
             'type' => 'regular',
-            'groups' => '',
+            'groups' => [],
             'published' => '1',
             'requireItem' => '1',
             'rootLanguage' => 'en',
         ]);
 
-        $page1
-            ->expects($this->never())
-            ->method('getAbsoluteUrl')
-        ;
-
-        $page2 = $this->mockClassWithProperties(PageModel::class, [
+        $page2 = $this->mockPage([
             'id' => 44,
             'pid' => 43,
             'type' => 'regular',
-            'groups' => '',
+            'groups' => [],
             'published' => '1',
             'rootLanguage' => 'en',
-        ]);
-
-        $page2
-            ->expects($this->once())
-            ->method('getAbsoluteUrl')
-            ->willReturn('https://www.foobar.com/en/page2.html')
-        ;
+        ], ['' => 'https://www.foobar.com/en/page2.html']);
 
         $pages = [
             42 => [$page1],
@@ -306,34 +260,23 @@ class SitemapControllerTest extends TestCase
 
     public function testSkipsPagesWithoutContentComposition(): void
     {
-        $page1 = $this->mockClassWithProperties(PageModel::class, [
+        $page1 = $this->mockPage([
             'id' => 43,
             'pid' => 42,
             'type' => 'forward',
-            'groups' => '',
+            'groups' => [],
             'published' => '1',
             'rootLanguage' => 'en',
         ]);
 
-        $page1
-            ->expects($this->never())
-            ->method('getAbsoluteUrl')
-        ;
-
-        $page2 = $this->mockClassWithProperties(PageModel::class, [
+        $page2 = $this->mockPage([
             'id' => 44,
             'pid' => 43,
             'type' => 'regular',
-            'groups' => '',
+            'groups' => [],
             'published' => '1',
             'rootLanguage' => 'en',
-        ]);
-
-        $page2
-            ->expects($this->once())
-            ->method('getAbsoluteUrl')
-            ->willReturn('https://www.foobar.com/en/page2.html')
-        ;
+        ], ['' => 'https://www.foobar.com/en/page2.html']);
 
         $pages = [
             42 => [$page1],
@@ -374,34 +317,23 @@ class SitemapControllerTest extends TestCase
 
     public function testSkipsUnroutablePages(): void
     {
-        $page1 = $this->mockClassWithProperties(PageModel::class, [
+        $page1 = $this->mockPage([
             'id' => 43,
             'pid' => 42,
             'type' => 'error_404',
-            'groups' => '',
+            'groups' => [],
             'published' => '1',
             'rootLanguage' => 'en',
         ]);
 
-        $page1
-            ->expects($this->never())
-            ->method('getAbsoluteUrl')
-        ;
-
-        $page2 = $this->mockClassWithProperties(PageModel::class, [
+        $page2 = $this->mockPage([
             'id' => 44,
             'pid' => 43,
             'type' => 'regular',
-            'groups' => '',
+            'groups' => [],
             'published' => '1',
             'rootLanguage' => 'en',
-        ]);
-
-        $page2
-            ->expects($this->once())
-            ->method('getAbsoluteUrl')
-            ->willReturn('https://www.foobar.com/en/page2.html')
-        ;
+        ], ['' => 'https://www.foobar.com/en/page2.html']);
 
         $pages = [
             42 => [$page1],
@@ -439,52 +371,35 @@ class SitemapControllerTest extends TestCase
 
     public function testSkipsPagesIfTheUserDoesNotHaveAccess(): void
     {
-        $page1 = $this->mockClassWithProperties(PageModel::class, [
+        $page1 = $this->mockPage([
             'id' => 43,
             'pid' => 42,
             'type' => 'regular',
             'protected' => '',
-            'groups' => '',
+            'groups' => [],
             'published' => '1',
             'rootLanguage' => 'en',
-        ]);
+        ], ['' => 'https://www.foobar.com/en/page1.html']);
 
-        $page1
-            ->expects($this->once())
-            ->method('getAbsoluteUrl')
-            ->willReturn('https://www.foobar.com/en/page1.html')
-        ;
-
-        $page2 = $this->mockClassWithProperties(PageModel::class, [
+        $page2 = $this->mockPage([
             'id' => 44,
             'pid' => 43,
             'type' => 'regular',
             'protected' => '1',
-            'groups' => 'a:1:{i:0;s:1:"1";}',
+            'groups' => ['1'],
             'published' => '1',
             'rootLanguage' => 'en',
         ]);
 
-        $page2
-            ->expects($this->never())
-            ->method('getAbsoluteUrl')
-        ;
-
-        $page3 = $this->mockClassWithProperties(PageModel::class, [
+        $page3 = $this->mockPage([
             'id' => 45,
             'pid' => 43,
             'type' => 'regular',
             'protected' => '1',
-            'groups' => 'a:1:{i:0;s:1:"2";}',
+            'groups' => ['2'],
             'published' => '1',
             'rootLanguage' => 'en',
-        ]);
-
-        $page3
-            ->expects($this->once())
-            ->method('getAbsoluteUrl')
-            ->willReturn('https://www.foobar.com/en/page3.html')
-        ;
+        ], ['' => 'https://www.foobar.com/en/page3.html']);
 
         $pages = [
             42 => [$page1, $page2, $page3],
@@ -514,22 +429,15 @@ class SitemapControllerTest extends TestCase
 
     public function testGeneratesTheTeaserArticleUrls(): void
     {
-        $page1 = $this->mockClassWithProperties(PageModel::class, [
+        $page1 = $this->mockPage([
             'id' => 43,
             'pid' => 42,
             'type' => 'regular',
             'protected' => '',
-            'groups' => '',
+            'groups' => [],
             'published' => '1',
             'rootLanguage' => 'en',
-        ]);
-
-        $page1
-            ->expects($this->exactly(2))
-            ->method('getAbsoluteUrl')
-            ->withConsecutive([null], ['/articles/foobar'])
-            ->willReturnOnConsecutiveCalls('https://www.foobar.com/en/page1.html', 'https://www.foobar.com/en/page1/articles/foobar.html')
-        ;
+        ], ['' => 'https://www.foobar.com/en/page1.html', '/articles/foobar' => 'https://www.foobar.com/en/page1/articles/foobar.html']);
 
         $article1 = $this->mockClassWithProperties(ArticleModel::class, [
             'id' => 1,
@@ -552,22 +460,15 @@ class SitemapControllerTest extends TestCase
 
     public function testGeneratesTheTeaserArticleUrlsByIdIfAliasIsEmpty(): void
     {
-        $page1 = $this->mockClassWithProperties(PageModel::class, [
+        $page1 = $this->mockPage([
             'id' => 43,
             'pid' => 42,
             'type' => 'regular',
             'protected' => '',
-            'groups' => '',
+            'groups' => [],
             'published' => '1',
             'rootLanguage' => 'en',
-        ]);
-
-        $page1
-            ->expects($this->exactly(2))
-            ->method('getAbsoluteUrl')
-            ->withConsecutive([null], ['/articles/1'])
-            ->willReturnOnConsecutiveCalls('https://www.foobar.com/en/page1.html', 'https://www.foobar.com/en/page1/articles/1.html')
-        ;
+        ], ['' => 'https://www.foobar.com/en/page1.html', '/articles/1' => 'https://www.foobar.com/en/page1/articles/1.html']);
 
         $article1 = $this->mockClassWithProperties(ArticleModel::class, [
             'id' => 1,
@@ -590,36 +491,25 @@ class SitemapControllerTest extends TestCase
 
     public function testSkipsNoindexNofollowPages(): void
     {
-        $page1 = $this->mockClassWithProperties(PageModel::class, [
+        $page1 = $this->mockPage([
             'id' => 43,
             'pid' => 42,
             'type' => 'regular',
-            'groups' => '',
+            'groups' => [],
             'published' => '1',
             'robots' => 'index,follow',
             'rootLanguage' => 'en',
-        ]);
+        ], ['' => 'https://www.foobar.com/en/page1.html']);
 
-        $page1
-            ->expects($this->once())
-            ->method('getAbsoluteUrl')
-            ->willReturn('https://www.foobar.com/en/page1.html')
-        ;
-
-        $page2 = $this->mockClassWithProperties(PageModel::class, [
+        $page2 = $this->mockPage([
             'id' => 44,
             'pid' => 42,
             'type' => 'regular',
-            'groups' => '',
+            'groups' => [],
             'published' => '1',
             'robots' => 'noindex,nofollow',
             'rootLanguage' => 'en',
         ]);
-
-        $page2
-            ->expects($this->never())
-            ->method('getAbsoluteUrl')
-        ;
 
         $pages = [
             42 => [$page1, $page2],
@@ -646,37 +536,25 @@ class SitemapControllerTest extends TestCase
      */
     public function testCallsTheLegacyHookForEachRootPage(): void
     {
-        $page1 = $this->mockClassWithProperties(PageModel::class, [
+        $page1 = $this->mockPage([
             'id' => 43,
             'pid' => 42,
             'type' => 'regular',
             'protected' => '',
-            'groups' => '',
+            'groups' => [],
             'published' => '1',
             'rootLanguage' => 'en',
-        ]);
+        ], ['' => 'https://www.foobar.com/en/page1.html']);
 
-        $page1
-            ->expects($this->once())
-            ->method('getAbsoluteUrl')
-            ->willReturn('https://www.foobar.com/en/page1.html')
-        ;
-
-        $page2 = $this->mockClassWithProperties(PageModel::class, [
+        $page2 = $this->mockPage([
             'id' => 22,
             'pid' => 21,
             'type' => 'regular',
             'protected' => '',
-            'groups' => '',
+            'groups' => [],
             'published' => '1',
             'rootLanguage' => 'en',
-        ]);
-
-        $page2
-            ->expects($this->once())
-            ->method('getAbsoluteUrl')
-            ->willReturn('https://www.foobar.com/en/page2.html')
-        ;
+        ], ['' => 'https://www.foobar.com/en/page2.html']);
 
         $GLOBALS['TL_HOOKS']['getSearchablePages'] = [['FooClass', 'fooFunction'], ['BarClass', 'barFunction']];
 
@@ -719,34 +597,23 @@ class SitemapControllerTest extends TestCase
 
     public function testSkipsNonHtmlPages(): void
     {
-        $page1 = $this->mockClassWithProperties(PageModel::class, [
+        $page1 = $this->mockPage([
             'id' => 43,
             'pid' => 42,
             'type' => 'custom1',
-            'groups' => '',
+            'groups' => [],
             'published' => '1',
             'rootLanguage' => 'en',
         ]);
 
-        $page1
-            ->expects($this->never())
-            ->method('getAbsoluteUrl')
-        ;
-
-        $page2 = $this->mockClassWithProperties(PageModel::class, [
+        $page2 = $this->mockPage([
             'id' => 44,
             'pid' => 43,
             'type' => 'custom2',
-            'groups' => '',
+            'groups' => [],
             'published' => '1',
             'rootLanguage' => 'en',
-        ]);
-
-        $page2
-            ->expects($this->once())
-            ->method('getAbsoluteUrl')
-            ->willReturn('https://www.foobar.com/en/page2.html')
-        ;
+        ], ['' => 'https://www.foobar.com/en/page2.html']);
 
         $pages = [
             42 => [$page1],
@@ -929,5 +796,35 @@ class SitemapControllerTest extends TestCase
         $container->set('contao.cache.entity_tags', $entityCacheTags);
 
         return $container;
+    }
+
+    private function mockPage(array $data, array $absoluteUrls = null): PageModel
+    {
+        $page = $this->mockClassWithProperties(PageModel::class, $data);
+        $page
+            ->expects($this->atLeastOnce())
+            ->method('loadDetails')
+        ;
+
+        if (null !== $absoluteUrls) {
+            $parameters = [];
+            foreach(array_keys($absoluteUrls) as $suffix) {
+                $parameters[] = [$suffix];
+            }
+
+            $page
+                ->expects($this->exactly(\count($absoluteUrls)))
+                ->method('getAbsoluteUrl')
+                ->withConsecutive(...$parameters)
+                ->willReturnOnConsecutiveCalls(...$absoluteUrls)
+            ;
+        } else {
+            $page
+                ->expects($this->never())
+                ->method('getAbsoluteUrl')
+            ;
+        }
+
+        return $page;
     }
 }

--- a/core-bundle/tests/Controller/SitemapControllerTest.php
+++ b/core-bundle/tests/Controller/SitemapControllerTest.php
@@ -742,9 +742,9 @@ class SitemapControllerTest extends TestCase
     }
 
     /**
-     * @param array<bool> $isGranted
+     * @param array<int> $allowedPageIds
      */
-    private function getContainer(ContaoFramework $framework, array $isGranted = null, string $baseUrl = 'https://www.foobar.com'): ContainerBuilder
+    private function getContainer(ContaoFramework $framework, array $allowedPageIds = null, string $baseUrl = 'https://www.foobar.com'): ContainerBuilder
     {
         $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
         $eventDispatcher
@@ -762,7 +762,7 @@ class SitemapControllerTest extends TestCase
 
         $authorizationChecker = $this->createMock(AuthorizationCheckerInterface::class);
 
-        if (null === $isGranted) {
+        if (null === $allowedPageIds) {
             $authorizationChecker
                 ->method('isGranted')
                 ->willReturn(true)
@@ -771,10 +771,10 @@ class SitemapControllerTest extends TestCase
             $authorizationChecker
                 ->method('isGranted')
                 ->willReturnCallback(
-                    function (string $attribute, array $pageGroups) use ($isGranted) {
+                    function (string $attribute, array $pageGroups) use ($allowedPageIds) {
                         $this->assertSame(ContaoCorePermissions::MEMBER_IN_GROUPS, $attribute);
 
-                        return \count(array_intersect(array_map('intval', $pageGroups), $isGranted)) > 0;
+                        return \count(array_intersect(array_map('intval', $pageGroups), $allowedPageIds)) > 0;
                     }
                 )
             ;

--- a/core-bundle/tests/Controller/SitemapControllerTest.php
+++ b/core-bundle/tests/Controller/SitemapControllerTest.php
@@ -79,14 +79,17 @@ class SitemapControllerTest extends TestCase
 
     public function testIgnoresRequestPort(): void
     {
-        $page1 = $this->mockPage([
-            'id' => 43,
-            'pid' => 42,
-            'type' => 'regular',
-            'groups' => [],
-            'published' => '1',
-            'rootLanguage' => 'en',
-        ], ['' => 'https://www.foobar.com:8000/en/page1.html']);
+        $page1 = $this->mockPage(
+            [
+                'id' => 43,
+                'pid' => 42,
+                'type' => 'regular',
+                'groups' => [],
+                'published' => '1',
+                'rootLanguage' => 'en',
+            ],
+            ['' => 'https://www.foobar.com:8000/en/page1.html']
+        );
 
         $framework = $this->mockFrameworkWithPages([42 => [$page1], 43 => null, 21 => null], [43 => null]);
         $container = $this->getContainer($framework, null, 'https://www.foobar.com:8000');
@@ -103,14 +106,17 @@ class SitemapControllerTest extends TestCase
 
     public function testGeneratesSitemapForRegularPages(): void
     {
-        $page1 = $this->mockPage([
-            'id' => 43,
-            'pid' => 42,
-            'type' => 'regular',
-            'groups' => [],
-            'published' => '1',
-            'rootLanguage' => 'en',
-        ], ['' => 'https://www.foobar.com/en/page1.html']);
+        $page1 = $this->mockPage(
+            [
+                'id' => 43,
+                'pid' => 42,
+                'type' => 'regular',
+                'groups' => [],
+                'published' => '1',
+                'rootLanguage' => 'en',
+            ],
+            ['' => 'https://www.foobar.com/en/page1.html']
+        );
 
         $framework = $this->mockFrameworkWithPages([42 => [$page1], 43 => null, 21 => null], [43 => null]);
         $container = $this->getContainer($framework);
@@ -127,23 +133,29 @@ class SitemapControllerTest extends TestCase
 
     public function testRecursivelyWalksThePageTree(): void
     {
-        $page1 = $this->mockPage([
-            'id' => 43,
-            'pid' => 42,
-            'type' => 'regular',
-            'groups' => [],
-            'published' => '1',
-            'rootLanguage' => 'en',
-        ], ['' => 'https://www.foobar.com/en/page1.html']);
+        $page1 = $this->mockPage(
+            [
+                'id' => 43,
+                'pid' => 42,
+                'type' => 'regular',
+                'groups' => [],
+                'published' => '1',
+                'rootLanguage' => 'en',
+            ],
+            ['' => 'https://www.foobar.com/en/page1.html']
+        );
 
-        $page2 = $this->mockPage([
-            'id' => 44,
-            'pid' => 43,
-            'type' => 'regular',
-            'groups' => [],
-            'published' => '1',
-            'rootLanguage' => 'en',
-        ], ['' => 'https://www.foobar.com/en/page2.html']);
+        $page2 = $this->mockPage(
+            [
+                'id' => 44,
+                'pid' => 43,
+                'type' => 'regular',
+                'groups' => [],
+                'published' => '1',
+                'rootLanguage' => 'en',
+            ],
+            ['' => 'https://www.foobar.com/en/page2.html']
+        );
 
         $pages = [
             42 => [$page1],
@@ -182,14 +194,17 @@ class SitemapControllerTest extends TestCase
             'rootLanguage' => 'en',
         ]);
 
-        $page2 = $this->mockPage([
-            'id' => 44,
-            'pid' => 43,
-            'type' => 'regular',
-            'groups' => [],
-            'published' => '1',
-            'rootLanguage' => 'en',
-        ], ['' => 'https://www.foobar.com/en/page2.html']);
+        $page2 = $this->mockPage(
+            [
+                'id' => 44,
+                'pid' => 43,
+                'type' => 'regular',
+                'groups' => [],
+                'published' => '1',
+                'rootLanguage' => 'en',
+            ],
+            ['' => 'https://www.foobar.com/en/page2.html']
+        );
 
         $pages = [
             42 => [$page1],
@@ -226,14 +241,17 @@ class SitemapControllerTest extends TestCase
             'rootLanguage' => 'en',
         ]);
 
-        $page2 = $this->mockPage([
-            'id' => 44,
-            'pid' => 43,
-            'type' => 'regular',
-            'groups' => [],
-            'published' => '1',
-            'rootLanguage' => 'en',
-        ], ['' => 'https://www.foobar.com/en/page2.html']);
+        $page2 = $this->mockPage(
+            [
+                'id' => 44,
+                'pid' => 43,
+                'type' => 'regular',
+                'groups' => [],
+                'published' => '1',
+                'rootLanguage' => 'en',
+            ],
+            ['' => 'https://www.foobar.com/en/page2.html']
+        );
 
         $pages = [
             42 => [$page1],
@@ -269,14 +287,17 @@ class SitemapControllerTest extends TestCase
             'rootLanguage' => 'en',
         ]);
 
-        $page2 = $this->mockPage([
-            'id' => 44,
-            'pid' => 43,
-            'type' => 'regular',
-            'groups' => [],
-            'published' => '1',
-            'rootLanguage' => 'en',
-        ], ['' => 'https://www.foobar.com/en/page2.html']);
+        $page2 = $this->mockPage(
+            [
+                'id' => 44,
+                'pid' => 43,
+                'type' => 'regular',
+                'groups' => [],
+                'published' => '1',
+                'rootLanguage' => 'en',
+            ],
+            ['' => 'https://www.foobar.com/en/page2.html']
+        );
 
         $pages = [
             42 => [$page1],
@@ -326,14 +347,17 @@ class SitemapControllerTest extends TestCase
             'rootLanguage' => 'en',
         ]);
 
-        $page2 = $this->mockPage([
-            'id' => 44,
-            'pid' => 43,
-            'type' => 'regular',
-            'groups' => [],
-            'published' => '1',
-            'rootLanguage' => 'en',
-        ], ['' => 'https://www.foobar.com/en/page2.html']);
+        $page2 = $this->mockPage(
+            [
+                'id' => 44,
+                'pid' => 43,
+                'type' => 'regular',
+                'groups' => [],
+                'published' => '1',
+                'rootLanguage' => 'en',
+            ],
+            ['' => 'https://www.foobar.com/en/page2.html']
+        );
 
         $pages = [
             42 => [$page1],
@@ -371,15 +395,18 @@ class SitemapControllerTest extends TestCase
 
     public function testSkipsPagesIfTheUserDoesNotHaveAccess(): void
     {
-        $page1 = $this->mockPage([
-            'id' => 43,
-            'pid' => 42,
-            'type' => 'regular',
-            'protected' => '',
-            'groups' => [],
-            'published' => '1',
-            'rootLanguage' => 'en',
-        ], ['' => 'https://www.foobar.com/en/page1.html']);
+        $page1 = $this->mockPage(
+            [
+                'id' => 43,
+                'pid' => 42,
+                'type' => 'regular',
+                'protected' => '',
+                'groups' => [],
+                'published' => '1',
+                'rootLanguage' => 'en',
+            ],
+            ['' => 'https://www.foobar.com/en/page1.html']
+        );
 
         $page2 = $this->mockPage([
             'id' => 44,
@@ -391,15 +418,18 @@ class SitemapControllerTest extends TestCase
             'rootLanguage' => 'en',
         ]);
 
-        $page3 = $this->mockPage([
-            'id' => 45,
-            'pid' => 43,
-            'type' => 'regular',
-            'protected' => '1',
-            'groups' => ['2'],
-            'published' => '1',
-            'rootLanguage' => 'en',
-        ], ['' => 'https://www.foobar.com/en/page3.html']);
+        $page3 = $this->mockPage(
+            [
+                'id' => 45,
+                'pid' => 43,
+                'type' => 'regular',
+                'protected' => '1',
+                'groups' => ['2'],
+                'published' => '1',
+                'rootLanguage' => 'en',
+            ],
+            ['' => 'https://www.foobar.com/en/page3.html']
+        );
 
         $pages = [
             42 => [$page1, $page2, $page3],
@@ -429,15 +459,21 @@ class SitemapControllerTest extends TestCase
 
     public function testGeneratesTheTeaserArticleUrls(): void
     {
-        $page1 = $this->mockPage([
-            'id' => 43,
-            'pid' => 42,
-            'type' => 'regular',
-            'protected' => '',
-            'groups' => [],
-            'published' => '1',
-            'rootLanguage' => 'en',
-        ], ['' => 'https://www.foobar.com/en/page1.html', '/articles/foobar' => 'https://www.foobar.com/en/page1/articles/foobar.html']);
+        $page1 = $this->mockPage(
+            [
+                'id' => 43,
+                'pid' => 42,
+                'type' => 'regular',
+                'protected' => '',
+                'groups' => [],
+                'published' => '1',
+                'rootLanguage' => 'en',
+            ],
+            [
+                '' => 'https://www.foobar.com/en/page1.html',
+                '/articles/foobar' => 'https://www.foobar.com/en/page1/articles/foobar.html',
+            ]
+        );
 
         $article1 = $this->mockClassWithProperties(ArticleModel::class, [
             'id' => 1,
@@ -460,15 +496,21 @@ class SitemapControllerTest extends TestCase
 
     public function testGeneratesTheTeaserArticleUrlsByIdIfAliasIsEmpty(): void
     {
-        $page1 = $this->mockPage([
-            'id' => 43,
-            'pid' => 42,
-            'type' => 'regular',
-            'protected' => '',
-            'groups' => [],
-            'published' => '1',
-            'rootLanguage' => 'en',
-        ], ['' => 'https://www.foobar.com/en/page1.html', '/articles/1' => 'https://www.foobar.com/en/page1/articles/1.html']);
+        $page1 = $this->mockPage(
+            [
+                'id' => 43,
+                'pid' => 42,
+                'type' => 'regular',
+                'protected' => '',
+                'groups' => [],
+                'published' => '1',
+                'rootLanguage' => 'en',
+            ],
+            [
+                '' => 'https://www.foobar.com/en/page1.html',
+                '/articles/1' => 'https://www.foobar.com/en/page1/articles/1.html',
+            ]
+        );
 
         $article1 = $this->mockClassWithProperties(ArticleModel::class, [
             'id' => 1,
@@ -491,15 +533,18 @@ class SitemapControllerTest extends TestCase
 
     public function testSkipsNoindexNofollowPages(): void
     {
-        $page1 = $this->mockPage([
-            'id' => 43,
-            'pid' => 42,
-            'type' => 'regular',
-            'groups' => [],
-            'published' => '1',
-            'robots' => 'index,follow',
-            'rootLanguage' => 'en',
-        ], ['' => 'https://www.foobar.com/en/page1.html']);
+        $page1 = $this->mockPage(
+            [
+                'id' => 43,
+                'pid' => 42,
+                'type' => 'regular',
+                'groups' => [],
+                'published' => '1',
+                'robots' => 'index,follow',
+                'rootLanguage' => 'en',
+            ],
+            ['' => 'https://www.foobar.com/en/page1.html']
+        );
 
         $page2 = $this->mockPage([
             'id' => 44,
@@ -536,25 +581,31 @@ class SitemapControllerTest extends TestCase
      */
     public function testCallsTheLegacyHookForEachRootPage(): void
     {
-        $page1 = $this->mockPage([
-            'id' => 43,
-            'pid' => 42,
-            'type' => 'regular',
-            'protected' => '',
-            'groups' => [],
-            'published' => '1',
-            'rootLanguage' => 'en',
-        ], ['' => 'https://www.foobar.com/en/page1.html']);
+        $page1 = $this->mockPage(
+            [
+                'id' => 43,
+                'pid' => 42,
+                'type' => 'regular',
+                'protected' => '',
+                'groups' => [],
+                'published' => '1',
+                'rootLanguage' => 'en',
+            ],
+            ['' => 'https://www.foobar.com/en/page1.html']
+        );
 
-        $page2 = $this->mockPage([
-            'id' => 22,
-            'pid' => 21,
-            'type' => 'regular',
-            'protected' => '',
-            'groups' => [],
-            'published' => '1',
-            'rootLanguage' => 'en',
-        ], ['' => 'https://www.foobar.com/en/page2.html']);
+        $page2 = $this->mockPage(
+            [
+                'id' => 22,
+                'pid' => 21,
+                'type' => 'regular',
+                'protected' => '',
+                'groups' => [],
+                'published' => '1',
+                'rootLanguage' => 'en',
+            ],
+            ['' => 'https://www.foobar.com/en/page2.html']
+        );
 
         $GLOBALS['TL_HOOKS']['getSearchablePages'] = [['FooClass', 'fooFunction'], ['BarClass', 'barFunction']];
 
@@ -606,14 +657,17 @@ class SitemapControllerTest extends TestCase
             'rootLanguage' => 'en',
         ]);
 
-        $page2 = $this->mockPage([
-            'id' => 44,
-            'pid' => 43,
-            'type' => 'custom2',
-            'groups' => [],
-            'published' => '1',
-            'rootLanguage' => 'en',
-        ], ['' => 'https://www.foobar.com/en/page2.html']);
+        $page2 = $this->mockPage(
+            [
+                'id' => 44,
+                'pid' => 43,
+                'type' => 'custom2',
+                'groups' => [],
+                'published' => '1',
+                'rootLanguage' => 'en',
+            ],
+            ['' => 'https://www.foobar.com/en/page2.html']
+        );
 
         $pages = [
             42 => [$page1],

--- a/core-bundle/tests/Controller/SitemapControllerTest.php
+++ b/core-bundle/tests/Controller/SitemapControllerTest.php
@@ -769,12 +769,14 @@ class SitemapControllerTest extends TestCase
             ;
         } else {
             $authorizationChecker
-                ->expects($this->any())
                 ->method('isGranted')
-                ->willReturnCallback(function(string $attribute, array $pageGroups) use ($isGranted) {
-                    $this->assertSame(ContaoCorePermissions::MEMBER_IN_GROUPS, $attribute);
-                    return \count(array_intersect(array_map('intval', $pageGroups), $isGranted)) > 0;
-                });
+                ->willReturnCallback(
+                    function (string $attribute, array $pageGroups) use ($isGranted) {
+                        $this->assertSame(ContaoCorePermissions::MEMBER_IN_GROUPS, $attribute);
+
+                        return \count(array_intersect(array_map('intval', $pageGroups), $isGranted)) > 0;
+                    }
+                )
             ;
         }
 
@@ -808,7 +810,8 @@ class SitemapControllerTest extends TestCase
 
         if (null !== $absoluteUrls) {
             $parameters = [];
-            foreach(array_keys($absoluteUrls) as $suffix) {
+
+            foreach (array_keys($absoluteUrls) as $suffix) {
                 $parameters[] = [$suffix];
             }
 


### PR DESCRIPTION
`$pageModel->groups` is a serialized string of groups so it never returned `true`. Or in other words, the `sitemap.xml` did not return protected pages even when logged in for 1.5 years without anybody noticing...

The tests were pretty nonsense because they tested only that a page is not added when protected which of course was always green since the check never worked. The inverse (check whether a protected is added if access is given) was not checked. This is fixed now.