### PR TITLE
Allow data-lightbox in TinyMCE by default

### DIFF
--- a/core-bundle/src/Resources/contao/templates/backend/be_tinyMCE.html5
+++ b/core-bundle/src/Resources/contao/templates/backend/be_tinyMCE.html5
@@ -52,7 +52,7 @@ window.tinymce && tinymce.init({
   <?php $this->endblock(); ?>
 
   <?php $this->block('valid_elements'); ?>
-    extended_valid_elements: 'q[cite|class|title],article,section,hgroup,figure,figcaption',
+    extended_valid_elements: 'q[cite|class|title],article,section,hgroup,figure,figcaption,a[rev|charset|hreflang|tabindex|accesskey|type|name|href|target|title|class|onfocus|onblur|data-lightbox]',
   <?php $this->endblock(); ?>
 
   <?php $this->block('menubar'); ?>

--- a/core-bundle/src/Resources/contao/templates/backend/be_tinyMCE.html5
+++ b/core-bundle/src/Resources/contao/templates/backend/be_tinyMCE.html5
@@ -52,7 +52,7 @@ window.tinymce && tinymce.init({
   <?php $this->endblock(); ?>
 
   <?php $this->block('valid_elements'); ?>
-    extended_valid_elements: 'q[cite|class|title],article,section,hgroup,figure,figcaption,a[rev|charset|hreflang|tabindex|accesskey|type|name|href|target|title|class|onfocus|onblur|data-lightbox]',
+    extended_valid_elements: 'q[cite|class|title],article,section,hgroup,figure,figcaption,a[rel|rev|charset|hreflang|tabindex|accesskey|type|name|href|target|title|class|onfocus|onblur|data-lightbox]',
   <?php $this->endblock(); ?>
 
   <?php $this->block('menubar'); ?>


### PR DESCRIPTION
Since https://github.com/contao/contao/pull/4396 we do not automatically convert `rel="lightbox"` to `data-lightbox` anymore. However, our TinyMCE still allows `<a rel="lightbox">` and disallows `<a data-lightbox>` thus since Contao 4.13 it is not possible anymore to create lightbox links within TinyMCE.

I don't think we will revert this, however I think we should specifically disallow the use of `rel="lightbox"` within TinyMCE (since it would then get transformed again when running the migration - and _only_ when running the migration) and also specifically allow `data-lightbox` instead.

```diff
-a[rel|rev|charset|hreflang|tabindex|accesskey|type|name|href|target|title|class|onfocus|onblur]
+a[rev|charset|hreflang|tabindex|accesskey|type|name|href|target|title|class|onfocus|onblur|data-lightbox]
```

Note: this would then also allow you to customise your `be_tinyMCE` template like this:

```php
 <?php $this->extend('be_tinyMCE'); ?>

<?php $this->block('custom'); ?>
  formats: {
    lightbox: { selector: 'a', attributes: { 'data-lightbox': 'true' } }
  },
  style_formats: [
    { title: 'Open in Lightbox', format: 'lightbox' },
  ],
<?php $this->endblock(); ?> 
```

which will insert a convenient _Open in Lightbox_ button under _Format_ » _Formats_.

_Update:_ changed to

```diff
-a[rel|rev|charset|hreflang|tabindex|accesskey|type|name|href|target|title|class|onfocus|onblur]
+a[rel|rev|charset|hreflang|tabindex|accesskey|type|name|href|target|title|class|onfocus|onblur|data-lightbox]
```

to continue allowing `rel` in general, but also `data-lightbox`.