### PR TITLE
Update TL_LANGUAGE deprecation

### DIFF
--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -4,3 +4,12 @@
 
 Relying on the `<base>` tag has been deprecated in Contao 5.0 and will no longer work in Contao 6. Use absolute paths
 for links and assets instead.
+
+## $GLOBALS['TL_LANGUAGE']
+
+Using the global `$GLOBALS['TL_LANGUAGE']` has been deprecated in Contao 4.0 and
+will no longer work in Contao 6.0. Use the locale from the request object instead:
+
+```php
+$locale = System::getContainer()->get('request_stack')->getCurrentRequest()->getLocale();
+```

--- a/core-bundle/contao/pages/PageRedirect.php
+++ b/core-bundle/contao/pages/PageRedirect.php
@@ -55,6 +55,7 @@ class PageRedirect extends Frontend
 	 */
 	private function prepare($objPage)
 	{
+		// Deprecated since Contao 4.0, to be removed in Contao 6.0
 		$GLOBALS['TL_LANGUAGE'] = $objPage->language;
 
 		$locale = str_replace('-', '_', $objPage->language);

--- a/core-bundle/contao/pages/PageRegular.php
+++ b/core-bundle/contao/pages/PageRegular.php
@@ -60,6 +60,7 @@ class PageRegular extends Frontend
 	 */
 	private function prepare($objPage)
 	{
+		// Deprecated since Contao 4.0, to be removed in Contao 6.0
 		$GLOBALS['TL_LANGUAGE'] = LocaleUtil::formatAsLanguageTag($objPage->language);
 
 		$locale = LocaleUtil::formatAsLocale($objPage->language);

--- a/core-bundle/src/EventListener/BackendLocaleListener.php
+++ b/core-bundle/src/EventListener/BackendLocaleListener.php
@@ -43,7 +43,7 @@ class BackendLocaleListener
 
         $this->translator->setLocale($user->language);
 
-        // Deprecated since Contao 4.0, to be removed in Contao 5.0
+        // Deprecated since Contao 4.0, to be removed in Contao 6.0
         $GLOBALS['TL_LANGUAGE'] = LocaleUtil::formatAsLanguageTag($user->language);
     }
 }

--- a/core-bundle/src/Framework/ContaoFramework.php
+++ b/core-bundle/src/Framework/ContaoFramework.php
@@ -194,7 +194,7 @@ class ContaoFramework implements ContainerAwareInterface, ResetInterface
             $language = LocaleUtil::formatAsLanguageTag($this->request->getLocale());
         }
 
-        // Deprecated since Contao 4.0, to be removed in Contao 5.0
+        // Deprecated since Contao 4.0, to be removed in Contao 6.0
         $GLOBALS['TL_LANGUAGE'] = $language;
     }
 


### PR DESCRIPTION
We did not remove it in Contao 5.0 (not sure if on purpose?), but I think we should remove it in Contao 6.