### PR TITLE
Do not run our Twig filesystem warmer on sub requests

### DIFF
--- a/core-bundle/src/Twig/Loader/ContaoFilesystemLoaderWarmer.php
+++ b/core-bundle/src/Twig/Loader/ContaoFilesystemLoaderWarmer.php
@@ -91,7 +91,7 @@ class ContaoFilesystemLoaderWarmer implements CacheWarmerInterface
      */
     public function onKernelRequest(RequestEvent $event): void
     {
-        if ('dev' === $this->environment) {
+        if ('dev' === $this->environment && $event->isMainRequest()) {
             $this->refresh();
         }
     }

--- a/core-bundle/tests/Twig/Loader/ContaoFilesystemLoaderWarmerTest.php
+++ b/core-bundle/tests/Twig/Loader/ContaoFilesystemLoaderWarmerTest.php
@@ -106,7 +106,6 @@ class ContaoFilesystemLoaderWarmerTest extends TestCase
     public function testRefreshOnKernelRequest(RequestEvent $event, string $environment, bool $shouldRefresh): void
     {
         $loader = $this->createMock(ContaoFilesystemLoader::class);
-
         $loader
             ->expects($shouldRefresh ? $this->once() : $this->never())
             ->method('clear')
@@ -157,15 +156,6 @@ class ContaoFilesystemLoaderWarmerTest extends TestCase
             ])
         ;
 
-        $expectedData = [
-            'namespaces' => [
-                ['namespace' => 'Contao', 'path' => '../../templates'],
-                ['namespace' => 'Contao_Global', 'path' => '../../templates'],
-                ['namespace' => 'Contao', 'path' => '../../some/place/contao/templates'],
-                ['namespace' => 'Contao_App', 'path' => '../../some/place/contao/templates'],
-            ],
-        ];
-
         $filesystem = $this->createMock(Filesystem::class);
         $filesystem
             ->expects($this->once())
@@ -173,7 +163,16 @@ class ContaoFilesystemLoaderWarmerTest extends TestCase
             ->with(
                 '/cache/contao/ide-twig.json',
                 $this->callback(
-                    function (string $json) use ($expectedData): bool {
+                    function (string $json): bool {
+                        $expectedData = [
+                            'namespaces' => [
+                                ['namespace' => 'Contao', 'path' => '../../templates'],
+                                ['namespace' => 'Contao_Global', 'path' => '../../templates'],
+                                ['namespace' => 'Contao', 'path' => '../../some/place/contao/templates'],
+                                ['namespace' => 'Contao_App', 'path' => '../../some/place/contao/templates'],
+                            ],
+                        ];
+
                         $this->assertJson($json);
                         $this->assertSame($expectedData, json_decode($json, true, 512, JSON_THROW_ON_ERROR));
 

--- a/core-bundle/tests/Twig/Loader/ContaoFilesystemLoaderWarmerTest.php
+++ b/core-bundle/tests/Twig/Loader/ContaoFilesystemLoaderWarmerTest.php
@@ -100,38 +100,45 @@ class ContaoFilesystemLoaderWarmerTest extends TestCase
         $warmer->refresh();
     }
 
-    public function testRefreshOnKernelRequestIfInDevMode(): void
+    /**
+     * @dataProvider provideRequestScenarios
+     */
+    public function testRefreshOnKernelRequest(RequestEvent $event, string $environment, bool $shouldRefresh): void
     {
         $loader = $this->createMock(ContaoFilesystemLoader::class);
+
         $loader
-            ->expects($this->once())
+            ->expects($shouldRefresh ? $this->once() : $this->never())
             ->method('clear')
         ;
 
         $loader
-            ->expects($this->atLeastOnce())
+            ->expects($shouldRefresh ? $this->atLeastOnce() : $this->never())
             ->method('addPath')
         ;
 
-        $warmer = $this->getContaoFilesystemLoaderWarmer($loader, null, 'dev');
-        $warmer->onKernelRequest($this->createMock(RequestEvent::class));
+        $warmer = $this->getContaoFilesystemLoaderWarmer($loader, null, $environment);
+        $warmer->onKernelRequest($event);
     }
 
-    public function testDoesNotRefreshOnKernelRequestIfNotInDevMode(): void
+    public function provideRequestScenarios(): \Generator
     {
-        $loader = $this->createMock(ContaoFilesystemLoader::class);
-        $loader
-            ->expects($this->never())
-            ->method('clear')
+        $mainRequestEvent = $this->createMock(RequestEvent::class);
+        $mainRequestEvent
+            ->method('isMainRequest')
+            ->willReturn(true)
         ;
 
-        $loader
-            ->expects($this->never())
-            ->method('addPath')
+        $subRequestEvent = $this->createMock(RequestEvent::class);
+        $subRequestEvent
+            ->method('isMainRequest')
+            ->willReturn(false)
         ;
 
-        $warmer = $this->getContaoFilesystemLoaderWarmer($loader);
-        $warmer->onKernelRequest($this->createMock(RequestEvent::class));
+        yield 'dev env, main request' => [$mainRequestEvent, 'dev', true];
+        yield 'dev env, sub request' => [$subRequestEvent, 'dev', false];
+        yield 'prod env, main request' => [$mainRequestEvent, 'prod', false];
+        yield 'prod env, sub request' => [$subRequestEvent, 'prod', false];
     }
 
     public function testWritesIdeAutoCompletionFile(): void


### PR DESCRIPTION
This small fix makes sure we're not running the filesystem loader warmer on each sub request. This could otherwise severely harm the dev performance when there are many content elements.

/cc @qzminski 
