### PR TITLE
Remove basic entities from SerpPreview

### DIFF
--- a/core-bundle/assets/scripts/mootao.js
+++ b/core-bundle/assets/scripts/mootao.js
@@ -348,9 +348,9 @@ Contao.SerpPreview = new Class(
 
 		titleField && titleField.addEvent('input', function() {
 			if (titleField.value) {
-				serpTitle.set('text', this.shorten(titleTag.replace(/%s/, titleField.value).replace(/%%/g, '%'), 64));
+				serpTitle.set('text', this.shorten(titleTag.replace(/%s/, titleField.value).replace(/%%/g, '%').replace(/\[-\]/g, '\xAD').replace(/\[nbsp\]/g, '\xA0'), 64));
 			} else if (titleFallbackField && titleFallbackField.value) {
-				serpTitle.set('text', this.shorten(this.html2string(titleTag.replace(/%s/, titleFallbackField.value)).replace(/%%/g, '%'), 64));
+				serpTitle.set('text', this.shorten(this.html2string(titleTag.replace(/%s/, titleFallbackField.value)).replace(/%%/g, '%').replace(/\[-\]/g, '\xAD').replace(/\[nbsp\]/g, '\xA0'), 64));
 			} else {
 				serpTitle.set('text', '');
 			}
@@ -358,7 +358,7 @@ Contao.SerpPreview = new Class(
 
 		titleFallbackField && titleFallbackField.addEvent('input', function() {
 			if (titleField && titleField.value) return;
-			serpTitle.set('text', this.shorten(this.html2string(titleTag.replace(/%s/, titleFallbackField.value)).replace(/%%/g, '%'), 64));
+			serpTitle.set('text', this.shorten(this.html2string(titleTag.replace(/%s/, titleFallbackField.value)).replace(/%%/g, '%').replace(/\[-\]/g, '\xAD').replace(/\[nbsp\]/g, '\xA0'), 64));
 		}.bind(this));
 
 		aliasField && aliasField.addEvent('input', function() {

--- a/core-bundle/contao/widgets/SerpPreview.php
+++ b/core-bundle/contao/widgets/SerpPreview.php
@@ -41,7 +41,7 @@ class SerpPreview extends Widget
 		}
 
 		$id = $model->id;
-		$title = StringUtil::substr($this->getTitle($model), 64);
+		$title = StringUtil::substr(str_replace(array('&nbsp;', '&shy;'), array(' ', ''), $this->getTitle($model)), 64);
 		$description = StringUtil::substr($this->getDescription($model), 160);
 		$alias = $this->getAlias($model);
 


### PR DESCRIPTION
Remove [Basic Entities](https://docs.contao.org/manual/de/artikelverwaltung/insert-tags/#basic-entities) [-] `&shy;` and [nbsp] `&nbsp;` in title or pageTitle fields for the serp preview.

#5565