### PR TITLE
Ensure parameters are strings

### DIFF
--- a/manager-bundle/src/ContaoManager/Plugin.php
+++ b/manager-bundle/src/ContaoManager/Plugin.php
@@ -384,10 +384,10 @@ class Plugin implements BundlePluginInterface, ConfigPluginInterface, RoutingPlu
         $userPassword = '';
 
         if ($user = $container->getParameter('database_user')) {
-            $userPassword = $this->encodeUrlParameter($user);
+            $userPassword = $this->encodeUrlParameter((string) $user);
 
             if ($password = $container->getParameter('database_password')) {
-                $userPassword .= ':'.$this->encodeUrlParameter($password);
+                $userPassword .= ':'.$this->encodeUrlParameter((string) $password);
             }
 
             $userPassword .= '@';
@@ -396,7 +396,7 @@ class Plugin implements BundlePluginInterface, ConfigPluginInterface, RoutingPlu
         $dbName = '';
 
         if ($name = $container->getParameter('database_name')) {
-            $dbName = '/'.$this->encodeUrlParameter($name);
+            $dbName = '/'.$this->encodeUrlParameter((string) $name);
         }
 
         return sprintf(
@@ -418,15 +418,15 @@ class Plugin implements BundlePluginInterface, ConfigPluginInterface, RoutingPlu
         $parameters = [];
 
         if ($user = $container->getParameter('mailer_user')) {
-            $parameters[] = 'username='.$this->encodeUrlParameter($user);
+            $parameters[] = 'username='.$this->encodeUrlParameter((string) $user);
 
             if ($password = $container->getParameter('mailer_password')) {
-                $parameters[] = 'password='.$this->encodeUrlParameter($password);
+                $parameters[] = 'password='.$this->encodeUrlParameter((string) $password);
             }
         }
 
         if ($encryption = $container->getParameter('mailer_encryption')) {
-            $parameters[] = 'encryption='.$this->encodeUrlParameter($encryption);
+            $parameters[] = 'encryption='.$this->encodeUrlParameter((string) $encryption);
         }
 
         $qs = '';


### PR DESCRIPTION
If your database name, database user, database password, mailer user or mailer password happens to consist only of numbers and you did not put them in quotes, then its value will be parsed as an integer rather than a string. This however will cause the following error:

```
Fatal error: Uncaught TypeError: Contao\ManagerBundle\ContaoManager\Plugin::encodeUrlParameter(): Argument #1 ($parameter) must be of type string, int given, called in vendor/contao/manager-bundle/src/ContaoManager/Plugin.php on line 755 and defined in vendor/contao/manager-bundle/src/ContaoManager/Plugin.php:777
Stack trace:
#0 vendor/contao/manager-bundle/src/ContaoManager/Plugin.php(755): Contao\ManagerBundle\ContaoManager\Plugin->encodeUrlParameter()
#1 vendor/contao/manager-bundle/src/ContaoManager/Plugin.php(238): Contao\ManagerBundle\ContaoManager\Plugin->getMailerDsn()
```

This stack trace is from Contao 4.13 with a `mailer_user` only consisting of numbers.

This PR fixes that by casting these values to strings.

If we do not want to cast we should instead at least throw an appropriate exception - as the current error would not really tell you what the problem really is.
