### PR TITLE
Remove unnecessary special treatment for tl_undo

### DIFF
--- a/core-bundle/src/Resources/contao/dca/tl_undo.php
+++ b/core-bundle/src/Resources/contao/dca/tl_undo.php
@@ -99,6 +99,7 @@ $GLOBALS['TL_DCA']['tl_undo'] = array
 		'data' => array
 		(
 			'search'                  => true,
+			'eval'                    => array('doNotShow'=>true),
 			'sql'                     => "mediumblob NULL"
 		)
 	)

--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -395,12 +395,6 @@ class DC_Table extends DataContainer implements \listable, \editable
 				continue;
 			}
 
-			// Special treatment for table tl_undo
-			if ($this->strTable == 'tl_undo' && $i == 'data')
-			{
-				continue;
-			}
-
 			$value = StringUtil::deserialize($row[$i]);
 
 			// Decrypt the value


### PR DESCRIPTION
This seems to be a rather unnecessary special case handling in DC_Table, so I prefer to clean that up.

Just FYI if someone were to unset the `doNotShow` on that field, the back end would generate an error because `DC_Table::show()` is unable to correctly handle recursive array data. But I think that error is unrelated to this and should not prevent the cleanup.