### PR TITLE
Add the missing files to the "prepareFormData" hook

### DIFF
--- a/core-bundle/contao/forms/Form.php
+++ b/core-bundle/contao/forms/Form.php
@@ -319,7 +319,7 @@ class Form extends Hybrid
 			foreach ($GLOBALS['TL_HOOKS']['prepareFormData'] as $callback)
 			{
 				$this->import($callback[0]);
-				$this->{$callback[0]}->{$callback[1]}($arrSubmitted, $arrLabels, $arrFields, $this);
+				$this->{$callback[0]}->{$callback[1]}($arrSubmitted, $arrLabels, $arrFields, $this, $arrFiles);
 			}
 		}
 


### PR DESCRIPTION
It has always been missing but I guess nobody really cared because up to version 5, we did store all uploads in `$_SESSION['FILES']` which we thankfully do not do anymore.

So we need a way to get to the formatted `$arrFiles` which is coming from the upload widgets which are not exactly the same as `$_FILES`.