### PR TITLE
Correctly open and close tree nodes if there is a filter

### DIFF
--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -3676,7 +3676,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 			$node = ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] ?? null) == self::MODE_TREE_EXTENDED ? $this->strTable . '_' . $table . '_tree' : $this->strTable . '_tree';
 
 			// Expand tree
-			if (empty($session[$node]) || !\is_array($session[$node]) || current($session[$node]) !== 1)
+			if (empty($session[$node]) || !\is_array($session[$node]) || current($session[$node]) != 1)
 			{
 				$session[$node] = array();
 				$objNodes = $this->Database->execute("SELECT DISTINCT pid FROM " . $table . " WHERE pid>0");
@@ -4161,7 +4161,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 
 		// Calculate label and add a toggle button
 		$level = ($intMargin / $intSpacing + 1);
-		$blnIsOpen = isset($session[$node][$id]) && $session[$node][$id] === 1;
+		$blnIsOpen = isset($session[$node][$id]) && $session[$node][$id] == 1;
 
 		// Always show selected nodes
 		if (!$blnIsOpen && !empty($this->arrPickerValue) && (($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] ?? null) == self::MODE_TREE || $table !== $this->strTable))

--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -3676,7 +3676,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 			$node = ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] ?? null) == self::MODE_TREE_EXTENDED ? $this->strTable . '_' . $table . '_tree' : $this->strTable . '_tree';
 
 			// Expand tree
-			if (empty($session[$node]) || !\is_array($session[$node]) || current($session[$node]) != 1)
+			if (empty($session[$node]) || !\is_array($session[$node]) || current($session[$node]) !== 1)
 			{
 				$session[$node] = array();
 				$objNodes = $this->Database->execute("SELECT DISTINCT pid FROM " . $table . " WHERE pid>0");
@@ -4161,7 +4161,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 
 		// Calculate label and add a toggle button
 		$level = ($intMargin / $intSpacing + 1);
-		$blnIsOpen = (!empty($arrFound) || $session[$node][$id] == 1);
+		$blnIsOpen = isset($session[$node][$id]) && $session[$node][$id] === 1;
 
 		// Always show selected nodes
 		if (!$blnIsOpen && !empty($this->arrPickerValue) && (($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] ?? null) == self::MODE_TREE || $table !== $this->strTable))
@@ -4330,32 +4330,21 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 			}
 		}
 
-		// Begin a new submenu
-		if (!$blnNoRecursion)
+		// Begin a new submenu if the node is open or $arrFound is not empty (which means that there
+		// is an active filter and all matching nodes have to be loaded to avoid Ajax requests).
+		if (!$blnNoRecursion && !empty($childs) && ($blnIsOpen || !empty($arrFound)))
 		{
-			$blnAddParent = ($blnIsOpen || !empty($arrFound) || (!empty($childs) && $session[$node][$id] == 1));
+			$return .= '<li class="parent" id="' . $node . '_' . $id . '"' . (!$blnIsOpen ? ' style="display:none"' : '') . '><ul class="level_' . $level . '">';
 
-			if ($blnAddParent)
-			{
-				$return .= '<li class="parent" id="' . $node . '_' . $id . '"><ul class="level_' . $level . '">';
-			}
+			static::preloadCurrentRecords($childs, $table);
 
 			// Add the records of the parent table
-			if ($blnIsOpen && \is_array($childs))
+			for ($k=0, $c=\count($childs); $k<$c; $k++)
 			{
-				static::preloadCurrentRecords($childs, $table);
-
-				for ($k=0, $c=\count($childs); $k<$c; $k++)
-				{
-					$return .= $this->generateTree($table, $childs[$k], array('p'=>($childs[($k-1)] ?? null), 'n'=>($childs[($k+1)] ?? null)), $blnHasSorting, ($intMargin + $intSpacing), $arrClipboard, ((($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] ?? null) == self::MODE_TREE && \is_array($arrClipboard) && $childs[$k] == $arrClipboard['id']) || $blnCircularReference), ($blnProtected || $protectedPage), $blnNoRecursion, $arrFound);
-				}
+				$return .= $this->generateTree($table, $childs[$k], array('p'=>($childs[($k-1)] ?? null), 'n'=>($childs[($k+1)] ?? null)), $blnHasSorting, ($intMargin + $intSpacing), $arrClipboard, ((($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] ?? null) == self::MODE_TREE && \is_array($arrClipboard) && $childs[$k] == $arrClipboard['id']) || $blnCircularReference), ($blnProtected || $protectedPage), $blnNoRecursion, $arrFound);
 			}
 
-			// Close the submenu
-			if ($blnAddParent)
-			{
-				$return .= '</ul></li>';
-			}
+			$return .= '</ul></li>';
 		}
 
 		$objSessionBag->replace($session);


### PR DESCRIPTION
How to reproduce:

1. Log into the back end of the official demo and go to pages.

2. Search for all pages with an `o` in their name.

<img width="484" alt="" src="https://user-images.githubusercontent.com/1192057/208713094-3349b60c-2e8e-4371-af52-16913fd06472.png">

3. The tree will look like this with **all nodes open**:

<img width="629" alt="" src="https://user-images.githubusercontent.com/1192057/208713318-c1de06e4-919f-447f-8700-328a68cc1fb4.png">

4. Try closing a node or toggling all nodes. It does not work.

5. Checkout this PR and try again. Now it works. 😄 

<img width="558" alt="" src="https://user-images.githubusercontent.com/1192057/208713584-a5d61f9a-e310-482a-850c-6b96e2693550.png">

Hint: The diff is best viewed with whitespaces ignored.