### PR TITLE
Use the request language to match `iflng` tags

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/InsertTags.php
+++ b/core-bundle/src/Resources/contao/library/Contao/InsertTags.php
@@ -1527,14 +1527,14 @@ class InsertTags extends Controller
 	 */
 	private function languageMatches($language)
 	{
-		$request = $container->get('request_stack')->getCurrentRequest();
+		$request = System::getContainer()->get('request_stack')->getCurrentRequest();
 
 		if (null === $request)
 		{
 			return false;
 		}
 
-		$pageLanguage = LocaleUtil::formatAsLocale($request->getLanguage());
+		$pageLanguage = LocaleUtil::formatAsLocale($request->getLocale());
 
 		foreach (StringUtil::trimsplit(',', $language) as $lang)
 		{

--- a/core-bundle/src/Resources/contao/library/Contao/InsertTags.php
+++ b/core-bundle/src/Resources/contao/library/Contao/InsertTags.php
@@ -1527,7 +1527,14 @@ class InsertTags extends Controller
 	 */
 	private function languageMatches($language)
 	{
-		$pageLanguage = LocaleUtil::formatAsLocale($GLOBALS['objPage']->language);
+		$request = $container->get('request_stack')->getCurrentRequest();
+
+		if (null === $request)
+		{
+			return false;
+		}
+
+		$pageLanguage = LocaleUtil::formatAsLocale($request->getLanguage());
 
 		foreach (StringUtil::trimsplit(',', $language) as $lang)
 		{

--- a/core-bundle/tests/Contao/InsertTagsTest.php
+++ b/core-bundle/tests/Contao/InsertTagsTest.php
@@ -18,7 +18,6 @@ use Contao\CoreBundle\InsertTag\InsertTagParser;
 use Contao\CoreBundle\Security\Authentication\Token\TokenChecker;
 use Contao\CoreBundle\Tests\TestCase;
 use Contao\InsertTags;
-use Contao\PageModel;
 use Contao\System;
 use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\HttpFoundation\Request;

--- a/core-bundle/tests/Contao/InsertTagsTest.php
+++ b/core-bundle/tests/Contao/InsertTagsTest.php
@@ -655,9 +655,7 @@ class InsertTagsTest extends TestCase
             ->willReturn($request)
         ;
 
-        $this->setContainerWithContaoConfiguration([
-            'request_stack' => $requestStack,
-        ]);
+        $this->setContainerWithContaoConfiguration(['request_stack' => $requestStack]);
 
         $reflectionClass = new \ReflectionClass(InsertTags::class);
 


### PR DESCRIPTION
If insert tags are replaced in the back end, the language cannot be matched on the page model. In my case this happens in the Isotope order details template, but it could also happen for our new Twig templates if I'm right.