### PR TITLE
Fix the foreignKey handling when showColumns is enabled

### DIFF
--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -5045,7 +5045,8 @@ class DC_Table extends DataContainer implements \listable, \editable
 							{
 								$key = explode('.', $GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['foreignKey'], 2);
 
-								$reference = $this->Database->prepare("SELECT " . Database::quoteIdentifier($key[1]) . " AS value FROM " . $key[0] . " WHERE id=?")
+								$reference = $this->Database
+									->prepare("SELECT " . Database::quoteIdentifier($key[1]) . " AS value FROM " . $key[0] . " WHERE id=?")
 									->limit(1)
 									->execute($arg);
 

--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -5041,6 +5041,20 @@ class DC_Table extends DataContainer implements \listable, \editable
 
 						if (isset($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['foreignKey']))
 						{
+							if ($arg)
+							{
+								$key = explode('.', $GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['foreignKey'], 2);
+
+								$reference = $this->Database->prepare("SELECT " . Database::quoteIdentifier($key[1]) . " AS value FROM " . $key[0] . " WHERE id=?")
+									->limit(1)
+									->execute($arg);
+
+								if ($reference->numRows)
+								{
+									$arg = $reference->value;
+								}
+							}
+
 							$value = $arg ?: '-';
 						}
 						else


### PR DESCRIPTION
Everywhere else, `foreignKey` is always translated but in the list view when `showColumns` is enabled, it just outputs the ID which I consider a bug as it's very counter-intuitive to the rest of the DCA behavior.
