### PR TITLE
Fix `{{date::Y}}` caching

### DIFF
--- a/core-bundle/src/Controller/InsertTagsController.php
+++ b/core-bundle/src/Controller/InsertTagsController.php
@@ -48,6 +48,7 @@ class InsertTagsController
         if ('{{date::Y}}' === $insertTag) {
             $response->setPublic();
             $response->setExpires(new \DateTimeImmutable(date('Y').'-12-31 23:59:59'));
+            $response->headers->removeCacheControlDirective('no-store');
         }
 
         return $response;

--- a/core-bundle/tests/Controller/InsertTagsControllerTest.php
+++ b/core-bundle/tests/Controller/InsertTagsControllerTest.php
@@ -63,6 +63,7 @@ class InsertTagsControllerTest extends TestCase
         $response = $controller->renderAction(new Request(), '{{date::Y}}');
 
         $this->assertTrue($response->headers->hasCacheControlDirective('public'));
+        $this->assertFalse($response->headers->hasCacheControlDirective('no-store'));
         $this->assertSame((new \DateTimeImmutable($year.'-12-31 23:59:59'))->getTimestamp(), $response->getExpires()->getTimestamp());
         $this->assertSame($year, $response->getContent());
     }


### PR DESCRIPTION
In #4782 we introduced special handling for the `{{date::Y}}` insert tag, so that it can be cached until the end of the current year, rather than always being evaluated on every request.

However, the response was never actually cached as we add the `no-store` directive to any insert tag response (if no client cache setting is involved):

https://github.com/contao/contao/blob/accec603257a4fcc6c560b273623c5d265ca243d/core-bundle/src/Controller/InsertTagsController.php#L43

This PR fixes that by removing `no-store` for the special `{{date::Y}}` case.