### PR TITLE
Do not combine different asset .js files

### DIFF
--- a/core-bundle/contao/templates/backend/be_main.html5
+++ b/core-bundle/contao/templates/backend/be_main.html5
@@ -26,16 +26,12 @@
     <?= $this->stylesheets ?>
 
     <script><?= $this->getLocaleString() ?></script>
-    <script src="<?php
-      $objCombiner = new Contao\Combiner();
-      $objCombiner->add('assets/mootools/js/mootools.min.js');
-      $objCombiner->add('assets/colorpicker/js/mooRainbow.min.js');
-      $objCombiner->add('assets/chosen/js/chosen.min.js');
-      $objCombiner->add('assets/simplemodal/js/simplemodal.min.js');
-      $objCombiner->add('assets/datepicker/js/datepicker.min.js');
-      $objCombiner->add('system/themes/'.$this->theme.'/hover.min.js');
-      echo $objCombiner->getCombinedFile();
-    ?>"></script>
+    <script src="<?= $this->asset('js/mootools.min.js', 'contao-components/mootools') ?>"></script>
+    <script src="<?= $this->asset('js/mooRainbow.min.js', 'contao-components/colorpicker') ?>"></script>
+    <script src="<?= $this->asset('js/chosen.min.js', 'contao-components/chosen') ?>"></script>
+    <script src="<?= $this->asset('js/simplemodal.min.js', 'contao-components/simplemodal') ?>"></script>
+    <script src="<?= $this->asset('js/datepicker.min.js', 'contao-components/datepicker') ?>"></script>
+    <script src="<?= $this->asset('system/themes/'.$this->theme.'/hover.min.js') ?>"></script>
     <script src="<?= $this->asset('backend.js', 'contao_core') ?>"></script>
     <script><?= $this->getDateString() ?></script>
     <?= $this->javascripts ?>

--- a/core-bundle/contao/templates/backend/be_main.html5
+++ b/core-bundle/contao/templates/backend/be_main.html5
@@ -12,13 +12,13 @@
       <meta name="referrer" content="origin">
     <?php $this->endblock(); ?>
 
+    <link rel="stylesheet" href="<?= $this->asset('assets/colorpicker/css/mooRainbow.min.css') ?>">
+    <link rel="stylesheet" href="<?= $this->asset('assets/chosen/css/chosen.min.css') ?>">
+    <link rel="stylesheet" href="<?= $this->asset('assets/simplemodal/css/simplemodal.min.css') ?>">
+    <link rel="stylesheet" href="<?= $this->asset('assets/datepicker/css/datepicker.min.css') ?>">
     <link rel="stylesheet" href="<?php
       $objCombiner = new Contao\Combiner();
       $objCombiner->add('system/themes/'.$this->theme.'/fonts.min.css');
-      $objCombiner->add('assets/colorpicker/css/mooRainbow.min.css');
-      $objCombiner->add('assets/chosen/css/chosen.min.css');
-      $objCombiner->add('assets/simplemodal/css/simplemodal.min.css');
-      $objCombiner->add('assets/datepicker/css/datepicker.min.css');
       $objCombiner->add('system/themes/'.$this->theme.'/basic.min.css');
       $objCombiner->add('system/themes/'.$this->theme.'/main.min.css');
       echo $objCombiner->getCombinedFile();


### PR DESCRIPTION
Follow-up on https://github.com/contao/contao/pull/5598#discussion_r1053627360

> So? It's even better with single requests. Why would I download a file that contains the scripts for chosen, simplemodal, datepicker etc. combined? Chances that only one of them changes during a Contao update are pretty high. The way it is now it would generate a new combined file forcing me to download it all again.
Yes, I agree it's still better to combine the stuff that belongs together in one file, even with http2/3. But these files are completely independent from each other. Chosen is not related to simplemodal whatsoever. Imho, we should not combine here.

@contao/developers Do we want to apply the same to the asset .css files?