### PR TITLE
Fix PHP8 Warning picture_default

### DIFF
--- a/core-bundle/src/Resources/contao/templates/picture/picture_default.html5
+++ b/core-bundle/src/Resources/contao/templates/picture/picture_default.html5
@@ -6,7 +6,7 @@
     <?php endforeach; ?>
 <?php endif; ?>
 
-<img src="<?= $this->img['src'] ?>"<?php if ($this->img['srcset'] !== $this->img['src']): ?> srcset="<?= $this->img['srcset'] ?>"<?php endif; ?><?php if (!empty($this->img['sizes'])): ?> sizes="<?= $this->img['sizes'] ?>"<?php endif; ?><?php if (!empty($this->img['width']) && !empty($this->img['height'])): ?> width="<?= $this->img['width'] ?>" height="<?= $this->img['height'] ?>"<?php endif; ?> alt="<?= $this->alt ?>"<?php if (!empty($this->img['loading'])): ?> loading="<?= $this->img['loading'] ?>"<?php endif; ?><?php if ($this->title): ?> title="<?= $this->title ?>"<?php endif; ?><?php if ($this->class || !empty($this->img['class'])): ?> class="<?= trim($this->class.' '.$this->img['class']??'') ?>"<?php endif; ?><?= $this->attributes ?>>
+<img src="<?= $this->img['src'] ?>"<?php if ($this->img['srcset'] !== $this->img['src']): ?> srcset="<?= $this->img['srcset'] ?>"<?php endif; ?><?php if (!empty($this->img['sizes'])): ?> sizes="<?= $this->img['sizes'] ?>"<?php endif; ?><?php if (!empty($this->img['width']) && !empty($this->img['height'])): ?> width="<?= $this->img['width'] ?>" height="<?= $this->img['height'] ?>"<?php endif; ?> alt="<?= $this->alt ?>"<?php if (!empty($this->img['loading'])): ?> loading="<?= $this->img['loading'] ?>"<?php endif; ?><?php if ($this->title): ?> title="<?= $this->title ?>"<?php endif; ?><?php if ($this->class || !empty($this->img['class'])): ?> class="<?= trim($this->class.' '.$this->img['class'] ?? '') ?>"<?php endif; ?><?= $this->attributes ?>>
 
 <?php if ($this->sources): ?>
   </picture>

--- a/core-bundle/src/Resources/contao/templates/picture/picture_default.html5
+++ b/core-bundle/src/Resources/contao/templates/picture/picture_default.html5
@@ -6,7 +6,7 @@
     <?php endforeach; ?>
 <?php endif; ?>
 
-<img src="<?= $this->img['src'] ?>"<?php if ($this->img['srcset'] !== $this->img['src']): ?> srcset="<?= $this->img['srcset'] ?>"<?php endif; ?><?php if (!empty($this->img['sizes'])): ?> sizes="<?= $this->img['sizes'] ?>"<?php endif; ?><?php if (!empty($this->img['width']) && !empty($this->img['height'])): ?> width="<?= $this->img['width'] ?>" height="<?= $this->img['height'] ?>"<?php endif; ?> alt="<?= $this->alt ?>"<?php if (!empty($this->img['loading'])): ?> loading="<?= $this->img['loading'] ?>"<?php endif; ?><?php if ($this->title): ?> title="<?= $this->title ?>"<?php endif; ?><?php if ($this->class || !empty($this->img['class'])): ?> class="<?= trim($this->class.' '.$this->img['class']) ?>"<?php endif; ?><?= $this->attributes ?>>
+<img src="<?= $this->img['src'] ?>"<?php if ($this->img['srcset'] !== $this->img['src']): ?> srcset="<?= $this->img['srcset'] ?>"<?php endif; ?><?php if (!empty($this->img['sizes'])): ?> sizes="<?= $this->img['sizes'] ?>"<?php endif; ?><?php if (!empty($this->img['width']) && !empty($this->img['height'])): ?> width="<?= $this->img['width'] ?>" height="<?= $this->img['height'] ?>"<?php endif; ?> alt="<?= $this->alt ?>"<?php if (!empty($this->img['loading'])): ?> loading="<?= $this->img['loading'] ?>"<?php endif; ?><?php if ($this->title): ?> title="<?= $this->title ?>"<?php endif; ?><?php if ($this->class || !empty($this->img['class'])): ?> class="<?= trim($this->class.' '.$this->img['class']??'') ?>"<?php endif; ?><?= $this->attributes ?>>
 
 <?php if ($this->sources): ?>
   </picture>

--- a/core-bundle/src/Resources/contao/templates/picture/picture_default.html5
+++ b/core-bundle/src/Resources/contao/templates/picture/picture_default.html5
@@ -6,7 +6,7 @@
     <?php endforeach; ?>
 <?php endif; ?>
 
-<img src="<?= $this->img['src'] ?>"<?php if ($this->img['srcset'] !== $this->img['src']): ?> srcset="<?= $this->img['srcset'] ?>"<?php endif; ?><?php if (!empty($this->img['sizes'])): ?> sizes="<?= $this->img['sizes'] ?>"<?php endif; ?><?php if (!empty($this->img['width']) && !empty($this->img['height'])): ?> width="<?= $this->img['width'] ?>" height="<?= $this->img['height'] ?>"<?php endif; ?> alt="<?= $this->alt ?>"<?php if (!empty($this->img['loading'])): ?> loading="<?= $this->img['loading'] ?>"<?php endif; ?><?php if ($this->title): ?> title="<?= $this->title ?>"<?php endif; ?><?php if ($this->class || !empty($this->img['class'])): ?> class="<?= trim($this->class.' '.$this->img['class'] ?? '') ?>"<?php endif; ?><?= $this->attributes ?>>
+<img src="<?= $this->img['src'] ?>"<?php if ($this->img['srcset'] !== $this->img['src']): ?> srcset="<?= $this->img['srcset'] ?>"<?php endif; ?><?php if (!empty($this->img['sizes'])): ?> sizes="<?= $this->img['sizes'] ?>"<?php endif; ?><?php if (!empty($this->img['width']) && !empty($this->img['height'])): ?> width="<?= $this->img['width'] ?>" height="<?= $this->img['height'] ?>"<?php endif; ?> alt="<?= $this->alt ?>"<?php if (!empty($this->img['loading'])): ?> loading="<?= $this->img['loading'] ?>"<?php endif; ?><?php if ($this->title): ?> title="<?= $this->title ?>"<?php endif; ?><?php if ($this->class || !empty($this->img['class'])): ?> class="<?= trim($this->class.' '.($this->img['class'] ?? '')) ?>"<?php endif; ?><?= $this->attributes ?>>
 
 <?php if ($this->sources): ?>
   </picture>


### PR DESCRIPTION
Fixes #5580

wenn `$this->class` gesetzt ist, wird `!empty($this->img['class'])` nicht weiter abgeprüft in

` if ($this->class || !empty($this->img['class'])):`

der Key "class" muss aber nicht vorhanden sein und bringt eine entsprechende Warning in 

`<?= trim($this->class.' '.$this->img['class']) ?>`
