### PR TITLE
Ensure Doctrine connections are closed after message handling

### DIFF
--- a/manager-bundle/skeleton/config/config.yaml
+++ b/manager-bundle/skeleton/config/config.yaml
@@ -32,6 +32,11 @@ framework:
             doctrine.system_cache_pool:
                 adapter: cache.system
     messenger:
+        buses:
+            messenger.bus.default:
+                middleware:
+                    - doctrine_ping_connection
+                    - doctrine_close_connection
         failure_transport: contao_failure
         transports:
             sync: sync://


### PR DESCRIPTION
I'm using the Doctrine queue for trakked.io as well and this configuration has made sure, the "`max_user_connections` reached" errors have gone completely. I forgot to add it in https://github.com/contao/contao/pull/5405 and noticed only now.

Basically, it just closes the DB connection after a message was received. Here's to illustrate the issue:

1. Let's say you have a message handler that runs 60 seconds and only does file I/O. 
2. Now the DoctrineTransport establishes a connection in order to fetch the next message from the queue
3. The message is then passed on to the handler which runs 60 seconds.

That means, the Doctrine connection is kept open for as long as the message handler (and the worker process) run.
This middleware converts above example to this:

1. Let's say you have a message handler that runs 60 seconds and only does file I/O. 
2. Now the DoctrineTransport establishes a connection in order to fetch the next message from the queue
3. **The Doctrine connection is closed**
4. The message is then passed on to the handler which runs 60 seconds.

See https://symfony.com/doc/current/messenger.html#middleware-for-doctrine