### PR TITLE
Allow cronjobs to be skipped

### DIFF
--- a/core-bundle/src/Cron/Cron.php
+++ b/core-bundle/src/Cron/Cron.php
@@ -91,8 +91,6 @@ class Cron
 
                 // Determine the last run date
                 $lastRunDate = null;
-
-                /** @var CronJobEntity $lastRunEntity */
                 $lastRunEntity = $repository->findOneByName($name);
 
                 if (null !== $lastRunEntity) {
@@ -136,7 +134,6 @@ class Cron
                 $cron($scope);
             } catch (CronExecutionSkippedException $e) {
                 // Restore previous run date in case cronjob skips itself
-                /** @var CronJobEntity $lastRunEntity */
                 $lastRunEntity = $repository->findOneByName($cron->getName());
                 $lastRunEntity->setLastRun($cron->getPreviousRun());
                 $entityManager->flush();

--- a/core-bundle/src/Cron/Cron.php
+++ b/core-bundle/src/Cron/Cron.php
@@ -150,7 +150,7 @@ class Cron
 
         // Throw the first exception
         if (null !== $exception) {
-            throw $e;
+            throw $exception;
         }
     }
 }

--- a/core-bundle/src/Cron/Cron.php
+++ b/core-bundle/src/Cron/Cron.php
@@ -140,7 +140,7 @@ class Cron
                 $lastRunEntity = $repository->findOneByName($cron->getName());
                 $lastRunEntity->setLastRun($cron->getPreviousRun());
                 $entityManager->flush();
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 // Catch any exceptions so that other cronjobs are still executed
                 if (null === $exception) {
                     $exception = $e;

--- a/core-bundle/src/Cron/Cron.php
+++ b/core-bundle/src/Cron/Cron.php
@@ -125,7 +125,7 @@ class Cron
         }
 
         $exception = null;
-        
+
         // Execute all cron jobs to be run
         foreach ($cronJobsToBeRun as $cron) {
             try {

--- a/core-bundle/src/Cron/Cron.php
+++ b/core-bundle/src/Cron/Cron.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Cron;
 
 use Contao\CoreBundle\Entity\CronJob as CronJobEntity;
+use Contao\CoreBundle\Exception\CronExecutionSkippedException;
 use Contao\CoreBundle\Repository\CronJobRepository;
 use Cron\CronExpression;
 use Doctrine\ORM\EntityManagerInterface;
@@ -108,6 +109,9 @@ class Cron
                     continue;
                 }
 
+                // Store the previous run in case the cronjob skips itself
+                $cron->setPreviousRun($lastRunEntity->getLastRun());
+
                 // Update the cron entry
                 $lastRunEntity->setLastRun($now);
 
@@ -120,13 +124,33 @@ class Cron
             $repository->unlockTable();
         }
 
+        $exception = null;
+        
         // Execute all cron jobs to be run
         foreach ($cronJobsToBeRun as $cron) {
-            if (null !== $this->logger) {
-                $this->logger->debug(sprintf('Executing cron job "%s"', $cron->getName()));
-            }
+            try {
+                if (null !== $this->logger) {
+                    $this->logger->debug(sprintf('Executing cron job "%s"', $cron->getName()));
+                }
 
-            $cron($scope);
+                $cron($scope);
+            } catch (CronExecutionSkippedException $e) {
+                // Restore previous run date in case cronjob skips itself
+                /** @var CronJobEntity $lastRunEntity */
+                $lastRunEntity = $repository->findOneByName($cron->getName());
+                $lastRunEntity->setLastRun($cron->getPreviousRun());
+                $entityManager->flush();
+            } catch (\Exception $e) {
+                // Catch any exceptions so that other cronjobs are still executed
+                if (null === $exception) {
+                    $exception = $e;
+                }
+            }
+        }
+
+        // Throw the first exception
+        if (null !== $exception) {
+            throw $e;
         }
     }
 }

--- a/core-bundle/src/Cron/Cron.php
+++ b/core-bundle/src/Cron/Cron.php
@@ -142,6 +142,10 @@ class Cron
                 $entityManager->flush();
             } catch (\Throwable $e) {
                 // Catch any exceptions so that other cronjobs are still executed
+                if (null !== $this->logger) {
+                    $this->logger->error((string) $e);
+                }
+
                 if (null === $exception) {
                     $exception = $e;
                 }

--- a/core-bundle/src/Cron/CronJob.php
+++ b/core-bundle/src/Cron/CronJob.php
@@ -36,7 +36,7 @@ class CronJob
      */
     private $name;
 
-    /** 
+    /**
      * @var \DateTimeInterface
      */
     private $previousRun;

--- a/core-bundle/src/Cron/CronJob.php
+++ b/core-bundle/src/Cron/CronJob.php
@@ -36,6 +36,11 @@ class CronJob
      */
     private $name;
 
+    /** 
+     * @var \DateTimeInterface
+     */
+    private $previousRun;
+
     public function __construct(object $service, string $interval, string $method = null)
     {
         $this->service = $service;
@@ -79,5 +84,17 @@ class CronJob
     public function getName(): string
     {
         return $this->name;
+    }
+
+    public function setPreviousRun(\DateTimeInterface $previousRun): self
+    {
+        $this->previousRun = $previousRun;
+
+        return $this;
+    }
+
+    public function getPreviousRun(): \DateTimeInterface
+    {
+        return $this->previousRun;
     }
 }

--- a/core-bundle/src/Exception/CronExecutionSkippedException.php
+++ b/core-bundle/src/Exception/CronExecutionSkippedException.php
@@ -1,5 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
 namespace Contao\CoreBundle\Exception;
 
 class CronExecutionSkippedException extends \RuntimeException

--- a/core-bundle/src/Exception/CronExecutionSkippedException.php
+++ b/core-bundle/src/Exception/CronExecutionSkippedException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Contao\CoreBundle\Exception;
+
+class CronExecutionSkippedException extends \RuntimeException
+{
+}

--- a/core-bundle/src/Repository/CronJobRepository.php
+++ b/core-bundle/src/Repository/CronJobRepository.php
@@ -20,7 +20,7 @@ use Symfony\Bridge\Doctrine\ManagerRegistry;
 /**
  * @internal
  *
- * @method object|null findOneByName(string $name)
+ * @method CronJob|null findOneByName(string $name)
  */
 class CronJobRepository extends ServiceEntityRepository
 {

--- a/core-bundle/tests/Cron/CronTest.php
+++ b/core-bundle/tests/Cron/CronTest.php
@@ -191,4 +191,60 @@ class CronTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $cron->run('invalid_scope');
     }
+
+    public function testResetsLastRunForSkippedCronJobs(): void
+    {
+        $lastRun = (new \DateTime())->modify('-1 hours');
+
+        $entity = $this->createMock(CronJobEntity::class);
+        $entity
+            ->expects($this->exactly(2))
+            ->method('setLastRun')
+            ->withConsecutive(
+                [$this->anything()],
+                [$lastRun]
+            );
+        ;
+
+        $entity
+            ->method('getName')
+            ->willReturn('Contao\CoreBundle\Fixtures\Cron\TestCronJob::skippingMethod')
+        ;
+
+        $entity
+            ->method('getLastRun')
+            ->willReturn($lastRun)
+        ;
+
+        $repository = $this->createMock(CronJobRepository::class);
+        $repository
+            ->expects($this->exactly(2))
+            ->method('__call')
+            ->with(
+                $this->equalTo('findOneByName'),
+                $this->equalTo(['Contao\CoreBundle\Fixtures\Cron\TestCronJob::skippingMethod'])
+            )
+            ->willReturn($entity)
+        ;
+
+        $cronjob = new TestCronJob();
+
+        $manager = $this->createMock(EntityManagerInterface::class);
+        $manager
+            ->expects($this->exactly(2))
+            ->method('flush')
+        ;
+
+        $cron = new Cron(
+            static function () use ($repository) {
+                return $repository;
+            },
+            static function () use ($manager) {
+                return $manager;
+            }
+        );
+
+        $cron->addCronJob(new CronJob($cronjob, '@hourly', 'skippingMethod'));
+        $cron->run(Cron::SCOPE_CLI);
+    }
 }

--- a/core-bundle/tests/Cron/CronTest.php
+++ b/core-bundle/tests/Cron/CronTest.php
@@ -203,7 +203,7 @@ class CronTest extends TestCase
             ->withConsecutive(
                 [$this->anything()],
                 [$lastRun]
-            );
+            )
         ;
 
         $entity

--- a/core-bundle/tests/Cron/CronTest.php
+++ b/core-bundle/tests/Cron/CronTest.php
@@ -200,10 +200,7 @@ class CronTest extends TestCase
         $entity
             ->expects($this->exactly(2))
             ->method('setLastRun')
-            ->withConsecutive(
-                [$this->anything()],
-                [$lastRun]
-            )
+            ->withConsecutive([$this->anything()], [$lastRun])
         ;
 
         $entity

--- a/core-bundle/tests/Fixtures/src/Cron/TestCronJob.php
+++ b/core-bundle/tests/Fixtures/src/Cron/TestCronJob.php
@@ -12,6 +12,8 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Fixtures\Cron;
 
+use Contao\CoreBundle\Exception\CronExecutionSkippedException;
+
 class TestCronJob
 {
     public function onMinutely(): void
@@ -36,5 +38,10 @@ class TestCronJob
 
     public function customMethod(): void
     {
+    }
+
+    public function skippingMethod(): void
+    {
+        throw new CronExecutionSkippedException();
     }
 }


### PR DESCRIPTION
Fixes #5645

This introduces a `CronExecutionSkippedException` allowing you to do the following in your cronjob:

```php
public function __invoke(string $scope): void
{
    if (Cron::SCOPE_CLI !== $scope) {
        throw new CronExecutionSkippedException();
    }
}
```

which will ensure that the cronjob will still be executed on the next _CLI_ run - which it otherwise might not if you just return normally (see the description of #5654).

Furthermore this PR also allows all cron jobs to be executed, even when one cronjob happens to throw another exception. The first occurring exception will then be rethrown.

I'll provide a separate PR for `5.0` if we agree on this concept.