### PR TITLE
Improve working with custom back end controllers

### DIFF
--- a/core-bundle/config/controller.yaml
+++ b/core-bundle/config/controller.yaml
@@ -21,6 +21,8 @@ services:
                 - { name: container.service_subscriber, id: contao.csrf.token_manager }
 
     # We explicitly allow autowiring and FQCN service IDs in controllers
+    Contao\CoreBundle\Controller\Backend\FooController: ~
+
     Contao\CoreBundle\Controller\BackendController: ~
 
     Contao\CoreBundle\Controller\BackendCsvImportController:

--- a/core-bundle/contao/templates/_new/backend/_chrome.html.twig
+++ b/core-bundle/contao/templates/_new/backend/_chrome.html.twig
@@ -1,0 +1,72 @@
+{% trans_default_domain "contao_default" %}
+<!DOCTYPE html>
+<html lang="{{ chrome.language }}">
+<head>
+    <meta charset="UTF-8">
+    <title>{{ chrome.title|default(app.request.host) }}</title>
+
+    <meta name="generator" content="Contao Open Source CMS">
+    <meta name="viewport" content="width=device-width,initial-scale=1.0,shrink-to-fit=no">
+    <meta name="referrer" content="origin">
+
+    <link rel="stylesheet" href="{{ chrome.combined_stylesheet_file|raw }}">
+    {{ chrome.stylesheets|default|raw }}
+
+    <script>{{ chrome.locale_string|raw }}</script>
+    <script src="{{ chrome.combined_javascript_file|raw }}"></script>
+    <script src="{{ asset('backend.js', 'contao_core') }}"></script>
+    <script>{{ chrome.date_string|raw }}</script>
+    {{ chrome.javascripts|default|raw }}
+</head>
+<body{{ attrs(chrome.attributes|default).set('id', 'top').addClass('be_main') }}>
+
+<header id="header">
+    <div class="inner">
+        <h1>
+            <a href="{{ path('contao_backend') }}" accesskey="h" id="home" title="{{ 'MSC.home'|trans }}">
+                <span class="app-title">Contao</span>
+                {% if chrome.badgeTitle %}
+                    <span class="badge-title">{{ chrome.badgeTitle }}</span>
+                {% endif %}
+            </a>
+        </h1>
+        {{ include("@ContaoCore/Backend/be_header_menu.html.twig") }}
+    </div>
+</header>
+
+<div id="container">
+    <aside id="left">
+        {{ include("@ContaoCore/Backend/be_menu.html.twig") }}
+        <div class="version">
+            {{ chrome.version }}
+            <br>
+            {{ 'MSC.learnMore'|trans(['<a href="https://contao.org" target="_blank" rel="noreferrer noopener">contao.org</a>'])|raw }}
+        </div>
+    </aside>
+
+    <main id="main" aria-labelledby="main_headline">
+        <h1 id="main_headline">{{ headline|default(app.request.attributes.get('_controller')) }}</h1>
+        <div class="content">
+            {% if chrome.error|default %}
+                <p class="tl_gerror">{{ chrome.error|raw }}</p>
+            {% endif %}
+
+            {% block main_inside %}
+                <p class="tl_new">This page was rendered by your <b>{{ app.request.attributes.get('_controller') }}</b>
+                    via the <b>{{ app.request.attributes.get('_route') }}</b> route. You can replace this text with your
+                    content while keeping the rest of the backend chrome by adjusting the <b>main_inside</b> block in
+                    your
+                    controller template.
+                </p>
+            {% endblock %}
+        </div>
+</div>
+</main>
+</div>
+
+{{ chrome.mootools|default|raw }}
+
+<script>Backend.initScrollOffset()</script>
+
+</body>
+</html>

--- a/core-bundle/contao/templates/_new/foo.html.twig
+++ b/core-bundle/contao/templates/_new/foo.html.twig
@@ -1,0 +1,9 @@
+{% extends "@Contao/backend/_chrome.html.twig" %}
+
+{#
+    Users can either extend from the default backend chrome template or completely
+    build their own.
+
+    We can add as many blocks and other things (like HtmlAttributes, reusable
+    components, refactoring…) to the new base template without breaking stuff.
+#}

--- a/core-bundle/src/Controller/Backend/AbstractBackendController.php
+++ b/core-bundle/src/Controller/Backend/AbstractBackendController.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Controller\Backend;
+
+use Contao\Backend;
+use Contao\BackendMain;
+use Contao\BackendTemplate;
+use Contao\Combiner;
+use Contao\CoreBundle\ContaoCoreBundle;
+use Contao\CoreBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+
+abstract class AbstractBackendController extends AbstractController
+{
+    /**
+     * Renders a view. By default, a parameter "chrome" will be added that
+     * contains the necessary data in order to extend from or directly render
+     * the "@Contao/Backend/_chrome.html.twig" template; set $withChrome to
+     * "false" to disable.
+     */
+    protected function render(string $view, array $parameters = [], Response $response = null, bool $withChrome = true): Response
+    {
+        $backendContext = (new class() extends BackendMain {
+            public function __invoke(): array
+            {
+                $this->Template = (new class() extends BackendTemplate {
+                    public function __construct()
+                    {
+                        parent::__construct('be_main');
+
+                        $theme = Backend::getTheme();
+
+                        $styleCombiner = new Combiner();
+                        $styleCombiner->add('system/themes/'.$theme.'/fonts.min.css');
+                        $styleCombiner->add('assets/colorpicker/css/mooRainbow.min.css');
+                        $styleCombiner->add('assets/chosen/css/chosen.min.css');
+                        $styleCombiner->add('assets/simplemodal/css/simplemodal.min.css');
+                        $styleCombiner->add('assets/datepicker/css/datepicker.min.css');
+                        $styleCombiner->add('system/themes/'.$theme.'/basic.min.css');
+                        $styleCombiner->add('system/themes/'.$theme.'/main.min.css');
+
+                        $javascriptCombiner = new Combiner();
+                        $javascriptCombiner->add('assets/mootools/js/mootools.min.js');
+                        $javascriptCombiner->add('assets/colorpicker/js/mooRainbow.min.js');
+                        $javascriptCombiner->add('assets/chosen/js/chosen.min.js');
+                        $javascriptCombiner->add('assets/simplemodal/js/simplemodal.min.js');
+                        $javascriptCombiner->add('assets/datepicker/js/datepicker.min.js');
+                        $javascriptCombiner->add('system/themes/'.$theme.'/hover.min.js');
+
+                        $this->arrData = [
+                            'combined_stylesheet_file' => $styleCombiner->getCombinedFile(),
+                            'combined_javascript_file' => $javascriptCombiner->getCombinedFile(),
+                            'locale_string' => $this->getLocaleString(),
+                            'date_string' => $this->getDateString(),
+                            'version' => $GLOBALS['TL_LANG']['MSC']['version'].' '.ContaoCoreBundle::getVersion(),
+                            'language' => $GLOBALS['TL_LANGUAGE'],
+                        ];
+
+                        // Make sure the compile function is executed that adds additional context (see #4224)
+                        $this->getResponse();
+                    }
+                });
+
+                return $this->Template->getData();
+            }
+        });
+
+        return parent::render(
+            $view,
+            $withChrome ?
+                // Allow overwriting keys
+                [...$parameters, 'chrome' => [...$backendContext(), ...$parameters['chrome'] ?? []]] :
+                $parameters,
+            $response,
+        );
+    }
+}

--- a/core-bundle/src/Controller/Backend/FooController.php
+++ b/core-bundle/src/Controller/Backend/FooController.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Controller\Backend;
+
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+class FooController extends AbstractBackendController
+{
+    #[Route('/contao/foo', name: 'contao_foo', defaults: ['_scope' => 'backend'])]
+    public function __invoke(): Response
+    {
+        return $this->render('@Contao/foo.html.twig');
+    }
+}


### PR DESCRIPTION
This is a very early draft that should help the discussion how custom back end controllers could be improved. Here is the  strategy I'm currently after:

**Primary goals:**

* Have an abstract base class, that adds a thin layer over the current `Contao\CoreBundle\Controller\AbstractController`. This class should be able to generate everything needed to render the chrome. Could alternatively be a trait or a service.
* Allow to opt out from creating the chrome data. This is for example needed if a controller contains multiple actions and some of them return AJAX data (no full page).
* Have a Twig base template `@Contao/backend/_chrome.html.twig`, that renders the familiar Contao back end and has all the things, that needs to be adjusted (blocks, `HtmlAttributes` and so on).

**Secondary goals:**

* Consider a class level attribute (e.g. `#[AsBackendModule('foo', category: 'bar')]` that can be placed on the controller and adds a respective entry in the main menu.


**For Contao 6:**

* Use the controller and template to render all of the back end. This would for instance allow extensions to adjust general things like they can now with the content element base template.

So all in all this is quite similar to the current way of doing things except that we've got a Twig base template and therefore get the need and opportunity to change things up in the abstract controller as well.

<sup>I'm using the word <i>chrome</i> in the code/description meaning [a GUI wrapper](https://stackoverflow.com/questions/5071905/what-does-chrome-mean) (not referring to the browser).</sup>