### PR TITLE
Skip pages in sitemap.xml if URL cannot be generated

### DIFF
--- a/core-bundle/src/Controller/SitemapController.php
+++ b/core-bundle/src/Controller/SitemapController.php
@@ -152,18 +152,18 @@ class SitemapController extends AbstractController
             ) {
                 try {
                     $urls = [$pageModel->getAbsoluteUrl()];
-                } catch (ExceptionInterface $exception) {
-                    continue;
-                }
 
-                // Get articles with teaser
-                if (null !== ($articleModels = $articleModelAdapter->findPublishedWithTeaserByPid($pageModel->id, ['ignoreFePreview' => true]))) {
-                    foreach ($articleModels as $articleModel) {
-                        $urls[] = $pageModel->getAbsoluteUrl('/articles/'.($articleModel->alias ?: $articleModel->id));
+                    // Get articles with teaser
+                    if (null !== ($articleModels = $articleModelAdapter->findPublishedWithTeaserByPid($pageModel->id, ['ignoreFePreview' => true]))) {
+                        foreach ($articleModels as $articleModel) {
+                            $urls[] = $pageModel->getAbsoluteUrl('/articles/'.($articleModel->alias ?: $articleModel->id));
+                        }
                     }
-                }
 
-                $result[] = $urls;
+                    $result[] = $urls;
+                } catch (ExceptionInterface $exception) {
+                    // Skip URL for this page but generate child pages
+                }
             }
 
             $result[] = $this->getPageAndArticleUrls((int) $pageModel->id);

--- a/core-bundle/src/Controller/SitemapController.php
+++ b/core-bundle/src/Controller/SitemapController.php
@@ -22,6 +22,7 @@ use Contao\System;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Exception\ExceptionInterface;
 
 /**
  * @Route(defaults={"_scope" = "frontend"})
@@ -149,7 +150,11 @@ class SitemapController extends AbstractController
                 && $this->pageRegistry->isRoutable($pageModel)
                 && 'html' === $this->pageRegistry->getRoute($pageModel)->getDefault('_format')
             ) {
-                $urls = [$pageModel->getAbsoluteUrl()];
+                try {
+                    $urls = [$pageModel->getAbsoluteUrl()];
+                } catch (ExceptionInterface $exception) {
+                    continue;
+                }
 
                 // Get articles with teaser
                 if (null !== ($articleModels = $articleModelAdapter->findPublishedWithTeaserByPid($pageModel->id, ['ignoreFePreview' => true]))) {

--- a/core-bundle/tests/Controller/SitemapControllerTest.php
+++ b/core-bundle/tests/Controller/SitemapControllerTest.php
@@ -30,6 +30,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Exception\RuntimeException;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
 class SitemapControllerTest extends TestCase
@@ -382,6 +383,69 @@ class SitemapControllerTest extends TestCase
             ->method('isRoutable')
             ->withConsecutive([$page1], [$page2])
             ->willReturn(false, true)
+        ;
+
+        $controller = new SitemapController($registry);
+        $controller->setContainer($container);
+        $response = $controller(Request::create('https://www.foobar.com/sitemap.xml'));
+
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertSame('public, s-maxage=2592000', $response->headers->get('Cache-Control'));
+        $this->assertSame($this->getExpectedSitemapContent(['https://www.foobar.com/en/page2.html']), $response->getContent());
+    }
+
+    public function testSkipsPagesWithRoutingException(): void
+    {
+        $page1 = $this->mockClassWithProperties(PageModel::class, [
+            'id' => 43,
+            'pid' => 42,
+            'type' => 'error_404',
+            'groups' => [],
+            'published' => '1',
+            'rootLanguage' => 'en',
+        ]);
+
+        $page1
+            ->expects($this->once())
+            ->method('getAbsoluteUrl')
+            ->willThrowException(new RuntimeException())
+        ;
+
+        $page2 = $this->mockPage(
+            [
+                'id' => 44,
+                'pid' => 43,
+                'type' => 'regular',
+                'groups' => [],
+                'published' => '1',
+                'rootLanguage' => 'en',
+            ],
+            ['' => 'https://www.foobar.com/en/page2.html']
+        );
+
+        $pages = [
+            42 => [$page1],
+            43 => [$page2],
+            44 => null,
+            21 => null,
+        ];
+
+        $framework = $this->mockFrameworkWithPages($pages, [44 => null]);
+        $container = $this->getContainer($framework);
+
+        $registry = $this->createPartialMock(PageRegistry::class, ['isRoutable', 'supportsContentComposition']);
+        $registry
+            ->expects($this->exactly(2))
+            ->method('supportsContentComposition')
+            ->withConsecutive([$page1], [$page2])
+            ->willReturn(true, true)
+        ;
+
+        $registry
+            ->expects($this->exactly(2))
+            ->method('isRoutable')
+            ->withConsecutive([$page1], [$page2])
+            ->willReturn(true, true)
         ;
 
         $controller = new SitemapController($registry);


### PR DESCRIPTION
I'm using a custom page controller in my project that requires additional route parameters. The `/sitemap.xml` route generates a 500 error because one page URL could not be generated.