### PR TITLE
Do not add the request token to idempotent actions

### DIFF
--- a/comments-bundle/contao/dca/tl_comments.php
+++ b/comments-bundle/contao/dca/tl_comments.php
@@ -501,7 +501,7 @@ class tl_comments extends Backend
 
 				if ($objParent->numRows)
 				{
-					$title .= ' – <a href="' . StringUtil::specialcharsUrl($router->generate('contao_backend', array('do'=>'article', 'table'=>'tl_content', 'id'=>$objParent->id, 'rt'=>System::getContainer()->get('contao.csrf.token_manager')->getDefaultTokenValue()))) . '">' . $objParent->title . '</a>';
+					$title .= ' – <a href="' . StringUtil::specialcharsUrl($router->generate('contao_backend', array('do'=>'article', 'table'=>'tl_content', 'id'=>$objParent->id))) . '">' . $objParent->title . '</a>';
 				}
 				break;
 
@@ -511,7 +511,7 @@ class tl_comments extends Backend
 
 				if ($objParent->numRows)
 				{
-					$title .= ' – <a href="' . StringUtil::specialcharsUrl($router->generate('contao_backend', array('do'=>'page', 'act'=>'edit', 'id'=>$objParent->id, 'rt'=>System::getContainer()->get('contao.csrf.token_manager')->getDefaultTokenValue()))) . '">' . $objParent->title . '</a>';
+					$title .= ' – <a href="' . StringUtil::specialcharsUrl($router->generate('contao_backend', array('do'=>'page', 'act'=>'edit', 'id'=>$objParent->id))) . '">' . $objParent->title . '</a>';
 				}
 				break;
 
@@ -521,7 +521,7 @@ class tl_comments extends Backend
 
 				if ($objParent->numRows)
 				{
-					$title .= ' – <a href="' . StringUtil::specialcharsUrl($router->generate('contao_backend', array('do'=>'news', 'table'=>'tl_news', 'act'=>'edit', 'id'=>$objParent->id, 'rt'=>System::getContainer()->get('contao.csrf.token_manager')->getDefaultTokenValue()))) . '">' . $objParent->headline . '</a>';
+					$title .= ' – <a href="' . StringUtil::specialcharsUrl($router->generate('contao_backend', array('do'=>'news', 'table'=>'tl_news', 'act'=>'edit', 'id'=>$objParent->id))) . '">' . $objParent->headline . '</a>';
 				}
 				break;
 
@@ -531,7 +531,7 @@ class tl_comments extends Backend
 
 				if ($objParent->numRows)
 				{
-					$title .= ' – <a href="' . StringUtil::specialcharsUrl($router->generate('contao_backend', array('do'=>'faq', 'table'=>'tl_faq', 'act'=>'edit', 'id'=>$objParent->id, 'rt'=>System::getContainer()->get('contao.csrf.token_manager')->getDefaultTokenValue()))) . '">' . $objParent->question . '</a>';
+					$title .= ' – <a href="' . StringUtil::specialcharsUrl($router->generate('contao_backend', array('do'=>'faq', 'table'=>'tl_faq', 'act'=>'edit', 'id'=>$objParent->id))) . '">' . $objParent->question . '</a>';
 				}
 				break;
 
@@ -541,7 +541,7 @@ class tl_comments extends Backend
 
 				if ($objParent->numRows)
 				{
-					$title .= ' – <a href="' . StringUtil::specialcharsUrl($router->generate('contao_backend', array('do'=>'calendar', 'table'=>'tl_calendar_events', 'act'=>'edit', 'id'=>$objParent->id, 'rt'=>System::getContainer()->get('contao.csrf.token_manager')->getDefaultTokenValue()))) . '">' . $objParent->title . '</a>';
+					$title .= ' – <a href="' . StringUtil::specialcharsUrl($router->generate('contao_backend', array('do'=>'calendar', 'table'=>'tl_calendar_events', 'act'=>'edit', 'id'=>$objParent->id))) . '">' . $objParent->title . '</a>';
 				}
 				break;
 

--- a/core-bundle/config/listener.yaml
+++ b/core-bundle/config/listener.yaml
@@ -599,4 +599,3 @@ services:
             - '@database_connection'
             - '@router'
             - '@translator'
-            - '@contao.csrf.token_manager'

--- a/core-bundle/contao/classes/Backend.php
+++ b/core-bundle/contao/classes/Backend.php
@@ -444,7 +444,6 @@ abstract class Backend extends Controller
 								'table' => $table,
 								'id' => $objRow->id,
 								'ref' => $request->attributes->get('_contao_referer_id'),
-								'rt' => System::getContainer()->get('contao.csrf.token_manager')->getDefaultTokenValue(),
 							));
 
 							$trail[] = sprintf(' <span><a href="%s">%s</a></span>', $strUrl, $linkLabel);

--- a/core-bundle/contao/classes/Versions.php
+++ b/core-bundle/contao/classes/Versions.php
@@ -743,12 +743,13 @@ class Versions extends Controller
 
 		parse_str($request->server->get('QUERY_STRING'), $pairs);
 
+		unset($pairs['rt'], $pairs['ref'], $pairs['revise']);
+
 		// Adjust the URL of the "personal data" module (see #7987)
 		if (isset($pairs['do']) && $pairs['do'] == 'login')
 		{
 			$pairs['do'] = 'user';
 			$pairs['id'] = BackendUser::getInstance()->id;
-			$pairs['rt'] = System::getContainer()->get('contao.csrf.token_manager')->getDefaultTokenValue();
 		}
 
 		if (isset($pairs['act']))

--- a/core-bundle/contao/controllers/BackendMain.php
+++ b/core-bundle/contao/controllers/BackendMain.php
@@ -78,7 +78,6 @@ class BackendMain extends Backend
 				'act' => 'edit',
 				'id' => $this->User->id,
 				'ref' => $container->get('request_stack')->getCurrentRequest()->attributes->get('_contao_referer_id'),
-				'rt' => System::getContainer()->get('contao.csrf.token_manager')->getDefaultTokenValue(),
 			));
 
 			$this->redirect($strUrl);

--- a/core-bundle/contao/dca/tl_content.php
+++ b/core-bundle/contao/dca/tl_content.php
@@ -1310,7 +1310,7 @@ class tl_content extends Backend
 		}
 
 		$title = sprintf($GLOBALS['TL_LANG']['tl_content']['editalias'], $dc->value);
-		$href = System::getContainer()->get('router')->generate('contao_backend', array('do'=>'form', 'table'=>'tl_form_field', 'id'=>$dc->value, 'popup'=>'1', 'nb'=>'1', 'rt'=>System::getContainer()->get('contao.csrf.token_manager')->getDefaultTokenValue()));
+		$href = System::getContainer()->get('router')->generate('contao_backend', array('do'=>'form', 'table'=>'tl_form_field', 'id'=>$dc->value, 'popup'=>'1', 'nb'=>'1'));
 
 		return ' <a href="' . StringUtil::specialcharsUrl($href) . '" title="' . StringUtil::specialchars($title) . '" onclick="Backend.openModalIframe({\'title\':\'' . StringUtil::specialchars(str_replace("'", "\\'", $title)) . '\',\'url\':this.href});return false">' . Image::getHtml('alias.svg', $title) . '</a>';
 	}
@@ -1357,7 +1357,7 @@ class tl_content extends Backend
 		}
 
 		$title = sprintf($GLOBALS['TL_LANG']['tl_content']['editalias'], $dc->value);
-		$href = System::getContainer()->get('router')->generate('contao_backend', array('do'=>'themes', 'table'=>'tl_module', 'act'=>'edit', 'id'=>$dc->value, 'popup'=>'1', 'nb'=>'1', 'rt'=>System::getContainer()->get('contao.csrf.token_manager')->getDefaultTokenValue()));
+		$href = System::getContainer()->get('router')->generate('contao_backend', array('do'=>'themes', 'table'=>'tl_module', 'act'=>'edit', 'id'=>$dc->value, 'popup'=>'1', 'nb'=>'1'));
 
 		return ' <a href="' . StringUtil::specialcharsUrl($href) . '" title="' . StringUtil::specialchars($title) . '" onclick="Backend.openModalIframe({\'title\':\'' . StringUtil::specialchars(str_replace("'", "\\'", $title)) . '\',\'url\':this.href});return false">' . Image::getHtml('alias.svg', $title) . '</a>';
 	}

--- a/core-bundle/contao/library/Contao/System.php
+++ b/core-bundle/contao/library/Contao/System.php
@@ -353,7 +353,7 @@ abstract class System
 			}
 
 			// Remove parameters helper
-			$cleanUrl = static function ($url, $params = array('rt', 'ref'))
+			$cleanUrl = static function ($url, $params = array('rt', 'ref', 'revise'))
 			{
 				if (!$url || strpos($url, '?') === false)
 				{

--- a/core-bundle/contao/modules/ModuleChangePassword.php
+++ b/core-bundle/contao/modules/ModuleChangePassword.php
@@ -105,7 +105,7 @@ class ModuleChangePassword extends Module
 		$objVersions = new Versions($strTable, $objMember->id);
 		$objVersions->setUsername($objMember->username);
 		$objVersions->setUserId(0);
-		$objVersions->setEditUrl(System::getContainer()->get('router')->generate('contao_backend', array('do'=>'member', 'act'=>'edit', 'id'=>$objMember->id, 'rt'=>'1')));
+		$objVersions->setEditUrl(System::getContainer()->get('router')->generate('contao_backend', array('do'=>'member', 'act'=>'edit', 'id'=>$objMember->id)));
 		$objVersions->initialize();
 
 		/** @var FormPassword $objNewPassword */

--- a/core-bundle/contao/modules/ModuleLostPassword.php
+++ b/core-bundle/contao/modules/ModuleLostPassword.php
@@ -212,7 +212,7 @@ class ModuleLostPassword extends Module
 		$objVersions = new Versions('tl_member', $objMember->id);
 		$objVersions->setUsername($objMember->username);
 		$objVersions->setUserId(0);
-		$objVersions->setEditUrl(System::getContainer()->get('router')->generate('contao_backend', array('do'=>'member', 'act'=>'edit', 'id'=>$objMember->id, 'rt'=>'1')));
+		$objVersions->setEditUrl(System::getContainer()->get('router')->generate('contao_backend', array('do'=>'member', 'act'=>'edit', 'id'=>$objMember->id)));
 		$objVersions->initialize();
 
 		// Define the form field

--- a/core-bundle/contao/modules/ModulePersonalData.php
+++ b/core-bundle/contao/modules/ModulePersonalData.php
@@ -117,7 +117,7 @@ class ModulePersonalData extends Module
 		$objVersions = new Versions($strTable, $objMember->id);
 		$objVersions->setUsername($objMember->username);
 		$objVersions->setUserId(0);
-		$objVersions->setEditUrl(System::getContainer()->get('router')->generate('contao_backend', array('do'=>'member', 'act'=>'edit', 'id'=>$objMember->id, 'rt'=>'1')));
+		$objVersions->setEditUrl(System::getContainer()->get('router')->generate('contao_backend', array('do'=>'member', 'act'=>'edit', 'id'=>$objMember->id)));
 		$objVersions->initialize();
 
 		$arrSubmitted = array();

--- a/core-bundle/contao/modules/ModuleRegistration.php
+++ b/core-bundle/contao/modules/ModuleRegistration.php
@@ -423,7 +423,7 @@ class ModuleRegistration extends Module
 		$objVersions = new Versions('tl_member', $objNewUser->id);
 		$objVersions->setUsername($objNewUser->username);
 		$objVersions->setUserId(0);
-		$objVersions->setEditUrl(System::getContainer()->get('router')->generate('contao_backend', array('do'=>'member', 'act'=>'edit', 'id'=>$objNewUser->id, 'rt'=>'1')));
+		$objVersions->setEditUrl(System::getContainer()->get('router')->generate('contao_backend', array('do'=>'member', 'act'=>'edit', 'id'=>$objNewUser->id)));
 		$objVersions->initialize();
 
 		// Inform admin if no activation link is sent

--- a/core-bundle/contao/widgets/ModuleWizard.php
+++ b/core-bundle/contao/widgets/ModuleWizard.php
@@ -212,7 +212,7 @@ class ModuleWizard extends Widget
 				{
 					if (($this->varValue[$i]['mod'] ?? null) > 0)
 					{
-						$href = StringUtil::specialcharsUrl(System::getContainer()->get('router')->generate('contao_backend', array('do'=>'themes', 'table'=>'tl_module', 'act'=>'edit', 'id'=>($this->varValue[$i]['mod'] ?? null), 'popup'=>'1', 'rt'=>System::getContainer()->get('contao.csrf.token_manager')->getDefaultTokenValue())));
+						$href = StringUtil::specialcharsUrl(System::getContainer()->get('router')->generate('contao_backend', array('do'=>'themes', 'table'=>'tl_module', 'act'=>'edit', 'id'=>($this->varValue[$i]['mod'] ?? null), 'popup'=>'1')));
 						$return .= ' <a href="' . $href . '" title="' . StringUtil::specialchars($GLOBALS['TL_LANG']['tl_layout']['edit_module']) . '" class="module_link" onclick="Backend.openModalIframe({\'title\':\'' . StringUtil::specialchars(str_replace("'", "\\'", $GLOBALS['TL_LANG']['tl_layout']['edit_module'])) . '\',\'url\':this.href});return false">' . Image::getHtml('edit.svg') . '</a>';
 					}
 					else

--- a/core-bundle/src/EventListener/Widget/RootPageDependentSelectListener.php
+++ b/core-bundle/src/EventListener/Widget/RootPageDependentSelectListener.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\EventListener\Widget;
 
-use Contao\CoreBundle\Csrf\ContaoCsrfTokenManager;
 use Contao\CoreBundle\DependencyInjection\Attribute\AsCallback;
 use Contao\DataContainer;
 use Contao\Image;
@@ -30,7 +29,6 @@ class RootPageDependentSelectListener
         private Connection $connection,
         private UrlGeneratorInterface $router,
         private TranslatorInterface $translator,
-        private ContaoCsrfTokenManager $csrfTokenManager,
     ) {
     }
 
@@ -100,7 +98,7 @@ class RootPageDependentSelectListener
             }
 
             $title = $this->translator->trans('tl_content.editalias', [$id], 'contao_content');
-            $href = $this->router->generate('contao_backend', ['do' => 'themes', 'table' => 'tl_module', 'act' => 'edit', 'id' => $id, 'popup' => '1', 'nb' => '1', 'rt' => $this->csrfTokenManager->getDefaultTokenValue()]);
+            $href = $this->router->generate('contao_backend', ['do' => 'themes', 'table' => 'tl_module', 'act' => 'edit', 'id' => $id, 'popup' => '1', 'nb' => '1']);
 
             $wizards[$rootPage] = sprintf(
                 ' <a href="%s" title="%s" onclick="Backend.openModalIframe({\'title\':\'%s\',\'url\':this.href});return false">%s</a>',

--- a/core-bundle/tests/EventListener/Widget/RootPageDependentSelectListenerTest.php
+++ b/core-bundle/tests/EventListener/Widget/RootPageDependentSelectListenerTest.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Tests\EventListener\Widget;
 
-use Contao\CoreBundle\Csrf\ContaoCsrfTokenManager;
 use Contao\CoreBundle\EventListener\Widget\RootPageDependentSelectListener;
 use Contao\CoreBundle\Tests\TestCase;
 use Contao\DataContainer;
@@ -39,8 +38,7 @@ class RootPageDependentSelectListenerTest extends TestCase
         $listener = new RootPageDependentSelectListener(
             $this->createMock(Connection::class),
             $this->createMock(UrlGeneratorInterface::class),
-            $this->createMock(TranslatorInterface::class),
-            $this->createMock(ContaoCsrfTokenManager::class)
+            $this->createMock(TranslatorInterface::class)
         );
 
         $dataContainer = $this->mockClassWithProperties(DataContainer::class);
@@ -58,19 +56,12 @@ class RootPageDependentSelectListenerTest extends TestCase
             ->willReturn('title')
         ;
 
-        $csrfTokenManager = $this->createMock(ContaoCsrfTokenManager::class);
-        $csrfTokenManager
-            ->expects($this->exactly(3))
-            ->method('getDefaultTokenValue')
-        ;
-
         System::setContainer($this->getContainerWithContaoConfiguration('/directory/project'));
 
         $listener = new RootPageDependentSelectListener(
             $this->createMock(Connection::class),
             $this->createMock(UrlGeneratorInterface::class),
-            $translator,
-            $csrfTokenManager,
+            $translator
         );
 
         $dataContainer = $this->mockClassWithProperties(DataContainer::class);
@@ -91,8 +82,7 @@ class RootPageDependentSelectListenerTest extends TestCase
         $listener = new RootPageDependentSelectListener(
             $this->createMock(Connection::class),
             $this->createMock(UrlGeneratorInterface::class),
-            $this->createMock(TranslatorInterface::class),
-            $this->createMock(ContaoCsrfTokenManager::class)
+            $this->createMock(TranslatorInterface::class)
         );
 
         $this->assertSame('foobar', $listener->saveCallback('foobar', $dataContainer));
@@ -106,8 +96,7 @@ class RootPageDependentSelectListenerTest extends TestCase
         $listener = new RootPageDependentSelectListener(
             $connection,
             $this->createMock(UrlGeneratorInterface::class),
-            $this->createMock(TranslatorInterface::class),
-            $this->createMock(ContaoCsrfTokenManager::class),
+            $this->createMock(TranslatorInterface::class)
         );
 
         $this->assertSame(
@@ -139,8 +128,7 @@ class RootPageDependentSelectListenerTest extends TestCase
         $listener = new RootPageDependentSelectListener(
             $connection,
             $this->createMock(UrlGeneratorInterface::class),
-            $this->createMock(TranslatorInterface::class),
-            $this->createMock(ContaoCsrfTokenManager::class)
+            $this->createMock(TranslatorInterface::class)
         );
 
         $this->assertSame(
@@ -183,8 +171,7 @@ class RootPageDependentSelectListenerTest extends TestCase
         $listener = new RootPageDependentSelectListener(
             $connection,
             $this->createMock(UrlGeneratorInterface::class),
-            $this->createMock(TranslatorInterface::class),
-            $this->createMock(ContaoCsrfTokenManager::class)
+            $this->createMock(TranslatorInterface::class)
         );
 
         $this->assertSame(


### PR DESCRIPTION
Follow-up on #5461 and #5594. Now that we no longer check the request token for idempotent actions, we can remove it from the URL.