### PR TITLE
Add a default value for the worker "min" configuration

### DIFF
--- a/core-bundle/src/DependencyInjection/Configuration.php
+++ b/core-bundle/src/DependencyInjection/Configuration.php
@@ -161,6 +161,7 @@ class Configuration implements ConfigurationInterface
                                     ->end()
                                     ->integerNode('min')
                                         ->min(1)
+                                        ->defaultValue(1)
                                         ->info('Contao will never scale down to less than this configured number of workers.')
                                     ->end()
                                     ->integerNode('max')

--- a/core-bundle/tests/DependencyInjection/ConfigurationTest.php
+++ b/core-bundle/tests/DependencyInjection/ConfigurationTest.php
@@ -285,6 +285,7 @@ class ConfigurationTest extends TestCase
                         'options' => ['--time-limit=60'],
                         'autoscale' => [
                             'enabled' => false,
+                            'min' => 1,
                         ],
                     ],
                     [
@@ -294,6 +295,7 @@ class ConfigurationTest extends TestCase
                             'desired_size' => 10,
                             'max' => 20,
                             'enabled' => true,
+                            'min' => 1,
                         ],
                     ],
                     [


### PR DESCRIPTION
Fixes the current `Warning: Undefined array key "min"` on `vendor/contao/core-bundle/src/Cron/MessengerCron.php(64): Contao\CoreBundle\Cron\MessengerCron::addWorkerPromises`.
