### PR TITLE
Fix the skippable cronjobs

### DIFF
--- a/core-bundle/src/Cron/Cron.php
+++ b/core-bundle/src/Cron/Cron.php
@@ -189,7 +189,6 @@ class Cron
     {
         /** @var array<string, PromiseInterface> $promises */
         $promises = [];
-
         $exception = null;
 
         foreach ($crons as $cron) {
@@ -216,7 +215,7 @@ class Cron
                 );
 
                 $promises[] = $promise;
-            } catch (CronExecutionSkippedException $e) {
+            } catch (CronExecutionSkippedException) {
                 $onSkip($cron);
             } catch (\Throwable $e) {
                 // Catch any exceptions so that other cronjobs are still executed

--- a/core-bundle/src/Cron/Cron.php
+++ b/core-bundle/src/Cron/Cron.php
@@ -185,7 +185,7 @@ class Cron
 
         $exception = null;
 
-        $onSkip = static function(CronJob $cron) use ($repository, $entityManager) {
+        $onSkip = static function (CronJob $cron) use ($repository, $entityManager): void {
             // Restore previous run date in case cronjob skips itself
             $lastRunEntity = $repository->findOneByName($cron->getName());
             $lastRunEntity->setLastRun($cron->getPreviousRun());

--- a/core-bundle/tests/Cron/CronTest.php
+++ b/core-bundle/tests/Cron/CronTest.php
@@ -307,12 +307,31 @@ class CronTest extends TestCase
 
     public function testMinutelyCronJob(): void
     {
+        $lastRun = (new \DateTime())->modify('-1 hours');
+
+        $entity = $this->createMock(CronJobEntity::class);
+        $entity
+            ->expects($this->exactly(3))
+            ->method('setLastRun')
+            ->withConsecutive([$this->anything()], [$this->anything()], [$lastRun])
+        ;
+
+        $entity
+            ->method('getName')
+            ->willReturn('Contao\CoreBundle\Cron\Cron::updateMinutelyCliCron')
+        ;
+
+        $entity
+            ->method('getLastRun')
+            ->willReturn($lastRun)
+        ;
+
         $repository = $this->createMock(CronJobRepository::class);
         $repository
-            ->expects($this->exactly(2))
+            ->expects($this->exactly(3))
             ->method('__call')
             ->with($this->equalTo('findOneByName'), $this->equalTo(['Contao\CoreBundle\Cron\Cron::updateMinutelyCliCron']))
-            ->willReturn(null)
+            ->willReturn($entity)
         ;
 
         $logger = $this->createMock(LoggerInterface::class);
@@ -354,5 +373,55 @@ class CronTest extends TestCase
         $cache->clear();
 
         $this->assertFalse($cron->hasMinutelyCliCron());
+    }
+
+    public function testResetsLastRunForSkippedCronJobs(): void
+    {
+        $lastRun = (new \DateTime())->modify('-1 hours');
+
+        $entity = $this->createMock(CronJobEntity::class);
+        $entity
+            ->expects($this->exactly(2))
+            ->method('setLastRun')
+            ->withConsecutive([$this->anything()], [$lastRun])
+        ;
+
+        $entity
+            ->method('getName')
+            ->willReturn('Contao\CoreBundle\Fixtures\Cron\TestCronJob::skippingMethod')
+        ;
+
+        $entity
+            ->method('getLastRun')
+            ->willReturn($lastRun)
+        ;
+
+        $repository = $this->createMock(CronJobRepository::class);
+        $repository
+            ->expects($this->exactly(2))
+            ->method('__call')
+            ->with(
+                $this->equalTo('findOneByName'),
+                $this->equalTo(['Contao\CoreBundle\Fixtures\Cron\TestCronJob::skippingMethod'])
+            )
+            ->willReturn($entity)
+        ;
+
+        $cronjob = new TestCronJob();
+
+        $manager = $this->createMock(EntityManagerInterface::class);
+        $manager
+            ->expects($this->exactly(2))
+            ->method('flush')
+        ;
+
+        $cron = new Cron(
+            static fn () => $repository,
+            static fn () => $manager,
+            new ArrayAdapter()
+        );
+
+        $cron->addCronJob(new CronJob($cronjob, '@hourly', 'skippingMethod'));
+        $cron->run(Cron::SCOPE_CLI);
     }
 }

--- a/core-bundle/tests/Cron/CronTest.php
+++ b/core-bundle/tests/Cron/CronTest.php
@@ -468,7 +468,7 @@ class CronTest extends TestCase
         $cron = new Cron(
             static fn () => $repository,
             static fn () => $manager,
-            new ArrayAdapter()
+            $this->createMock(CacheItemPoolInterface::class)
         );
 
         $cron->addCronJob(new CronJob($cronjob, '@hourly', 'skippingAsyncMethod'));

--- a/core-bundle/tests/Fixtures/src/Cron/TestCronJob.php
+++ b/core-bundle/tests/Fixtures/src/Cron/TestCronJob.php
@@ -54,6 +54,6 @@ class TestCronJob
 
     public function skippingAsyncMethod(): PromiseInterface
     {
-        return $promise = new Promise(static function () use (&$promise): void { throw new CronExecutionSkippedException(); });
+        return $promise = new Promise(static function () : void { throw new CronExecutionSkippedException(); });
     }
 }

--- a/core-bundle/tests/Fixtures/src/Cron/TestCronJob.php
+++ b/core-bundle/tests/Fixtures/src/Cron/TestCronJob.php
@@ -51,4 +51,9 @@ class TestCronJob
     {
         throw new CronExecutionSkippedException();
     }
+
+    public function skippingAsyncMethod(): PromiseInterface
+    {
+        return $promise = new Promise(static function () use (&$promise): void { throw new CronExecutionSkippedException(); });
+    }
 }

--- a/core-bundle/tests/Fixtures/src/Cron/TestCronJob.php
+++ b/core-bundle/tests/Fixtures/src/Cron/TestCronJob.php
@@ -54,6 +54,6 @@ class TestCronJob
 
     public function skippingAsyncMethod(): PromiseInterface
     {
-        return new Promise(static function (): void { throw new CronExecutionSkippedException(); });
+        return new Promise(static function (): never { throw new CronExecutionSkippedException(); });
     }
 }

--- a/core-bundle/tests/Fixtures/src/Cron/TestCronJob.php
+++ b/core-bundle/tests/Fixtures/src/Cron/TestCronJob.php
@@ -54,6 +54,6 @@ class TestCronJob
 
     public function skippingAsyncMethod(): PromiseInterface
     {
-        return $promise = new Promise(static function (): void { throw new CronExecutionSkippedException(); });
+        return new Promise(static function (): void { throw new CronExecutionSkippedException(); });
     }
 }

--- a/core-bundle/tests/Fixtures/src/Cron/TestCronJob.php
+++ b/core-bundle/tests/Fixtures/src/Cron/TestCronJob.php
@@ -54,6 +54,6 @@ class TestCronJob
 
     public function skippingAsyncMethod(): PromiseInterface
     {
-        return $promise = new Promise(static function () : void { throw new CronExecutionSkippedException(); });
+        return $promise = new Promise(static function (): void { throw new CronExecutionSkippedException(); });
     }
 }


### PR DESCRIPTION
Implements #5654 for Contao 5.1.

Within the promise you can also throw the `CronExecutionSkippedException`, which will appropriately reset the `lastRun` time.