### PR TITLE
Correctly toggle the favorites menu group

### DIFF
--- a/core-bundle/src/EventListener/Menu/BackendFavoritesListener.php
+++ b/core-bundle/src/EventListener/Menu/BackendFavoritesListener.php
@@ -21,6 +21,7 @@ use Knp\Menu\ItemInterface;
 use Knp\Menu\Util\MenuManipulator;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Security;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -64,7 +65,6 @@ class BackendFavoritesListener
         }
 
         $factory = $event->getFactory();
-        $path = $this->router->generate('contao_backend');
 
         $params = [
             'do' => $request->query->get('do'),
@@ -72,8 +72,9 @@ class BackendFavoritesListener
             'ref' => $request->attributes->get('_contao_referer_id'),
         ];
 
-        $session = $this->requestStack->getSession()->all();
-        $collapsed = 0 === ($session['backend_modules']['favorites'] ?? null);
+        /** @var AttributeBagInterface $bag */
+        $bag = $this->requestStack->getSession()->getBag('contao_backend');
+        $collapsed = 0 === ($bag->get('backend_modules')['favorites'] ?? null);
 
         $tree = $factory
             ->createItem('favorites')
@@ -81,7 +82,8 @@ class BackendFavoritesListener
             ->setUri($this->router->generate('contao_backend', $params))
             ->setLinkAttribute('class', 'group-favorites')
             ->setLinkAttribute('title', $this->translator->trans($collapsed ? 'MSC.expandNode' : 'MSC.collapseNode', [], 'contao_default'))
-            ->setLinkAttribute('onclick', "return AjaxRequest.toggleNavigation(this, 'favorites', '$path')")
+            ->setLinkAttribute('data-action', 'contao--toggle-navigation#toggle:prevent')
+            ->setLinkAttribute('data-contao--toggle-navigation-category-param', 'favorites')
             ->setLinkAttribute('aria-controls', 'favorites')
             ->setChildrenAttribute('id', 'favorites')
             ->setExtra('translation_domain', false)

--- a/core-bundle/tests/EventListener/Menu/BackendFavoritesListenerTest.php
+++ b/core-bundle/tests/EventListener/Menu/BackendFavoritesListenerTest.php
@@ -21,6 +21,7 @@ use Doctrine\DBAL\Connection;
 use Knp\Menu\MenuFactory;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Security;
 use Symfony\Component\Security\Core\User\UserInterface;
@@ -71,17 +72,16 @@ class BackendFavoritesListenerTest extends TestCase
 
         $router = $this->createMock(RouterInterface::class);
         $router
-            ->expects($this->exactly(2))
+            ->expects($this->once())
             ->method('generate')
-            ->willReturnOnConsecutiveCalls(
-                '/contao',
-                '/contao?do=pages&mtg=favorites&ref=foobar'
-            )
+            ->willReturn('/contao?do=pages&mtg=favorites&ref=foobar')
         ;
 
         $session = $this->mockSession();
-        $sessionData['backend_modules']['favorites'] = $collapsed ? 0 : null;
-        $session->replace($sessionData);
+
+        /** @var AttributeBagInterface $bag */
+        $bag = $session->getBag('contao_backend');
+        $bag->set('backend_modules', ['favorites' => $collapsed ? 0 : null]);
 
         $request = Request::create('https://localhost/contao?do=pages&act=edit&id=3');
         $request->attributes->set('_contao_referer_id', 'foobar');
@@ -152,7 +152,8 @@ class BackendFavoritesListenerTest extends TestCase
         $linkAttributes = [
             'class' => 'group-favorites',
             'title' => $collapsed ? 'Expand node' : 'Collapse node',
-            'onclick' => "return AjaxRequest.toggleNavigation(this, 'favorites', '/contao')",
+            'data-action' => 'contao--toggle-navigation#toggle:prevent',
+            'data-contao--toggle-navigation-category-param' => 'favorites',
             'aria-controls' => 'favorites',
         ];
 
@@ -248,12 +249,9 @@ class BackendFavoritesListenerTest extends TestCase
 
         $router = $this->createMock(RouterInterface::class);
         $router
-            ->expects($this->exactly(2))
+            ->expects($this->once())
             ->method('generate')
-            ->willReturnOnConsecutiveCalls(
-                '/contao',
-                '/contao?do=pages&mtg=favorites&ref=foobar'
-            )
+            ->willReturn('/contao?do=pages&mtg=favorites&ref=foobar')
         ;
 
         $session = $this->mockSession();


### PR DESCRIPTION
Now uses the correct session bag and the Stimulus controller instead of `AjaxRequest.toggleNavigation`.