### PR TITLE
Unify newlines in textarea widgets

### DIFF
--- a/core-bundle/src/Resources/contao/forms/FormTextArea.php
+++ b/core-bundle/src/Resources/contao/forms/FormTextArea.php
@@ -159,6 +159,15 @@ class FormTextArea extends Widget
 	}
 
 	/**
+	 * Unify newline characters to UNIX style.
+	 * This will also prevent our maxlength from counting newlines as two characters.
+	 */
+	protected function getPost($strKey)
+	{
+		return str_replace("\r\n", "\n", parent::getPost($strKey));
+	}
+
+	/**
 	 * Generate the widget and return it as string
 	 *
 	 * @return string The widget markup

--- a/core-bundle/src/Resources/contao/widgets/TextArea.php
+++ b/core-bundle/src/Resources/contao/widgets/TextArea.php
@@ -99,6 +99,15 @@ class TextArea extends Widget
 	}
 
 	/**
+	 * Unify newline characters to UNIX style.
+	 * This will also prevent our maxlength from counting newlines as two characters.
+	 */
+	protected function getPost($strKey)
+	{
+		return str_replace("\r\n", "\n", parent::getPost($strKey));
+	}
+
+	/**
 	 * Generate the widget and return it as string
 	 *
 	 * @return string


### PR DESCRIPTION
As recently discussed (and mentioned by @ausi afair), the browser default/HTML standard says textarea newlines should always be submitted in Windows-style (`\r\n`). However, this causes multiple issues. We originally discussed that template files should not be saved/converted to Windows style newlines. However, I also noticed our `maxlength` property counts `\r\n` as two characters, even though for a user it only is one.

I'm not exactly sure this is the right place to fix it, and I don't know if @ausi remembers the RFC about newlines in textarea?