### PR TITLE
Fix wrong page alias when changing the title of a page

### DIFF
--- a/core-bundle/src/EventListener/DataContainer/PageUrlListener.php
+++ b/core-bundle/src/EventListener/DataContainer/PageUrlListener.php
@@ -80,12 +80,10 @@ class PageUrlListener
             return $value;
         }
 
-        $currentRecord = $dc->getCurrentRecord();
-
         // Generate an alias if there is none
         $value = $this->slug->generate(
-            $currentRecord['title'] ?? '',
-            (int) ($currentRecord['id'] ?? null),
+            $pageModel->title ?? '',
+            (int) $dc->id,
             fn ($alias) => $isRoutable && $this->aliasExists(($pageModel->useFolderUrl ? $pageModel->folderUrl : '').$alias, $pageModel)
         );
 
@@ -288,6 +286,10 @@ class PageUrlListener
 
         if (null !== ($type = $input->post('type'))) {
             $pageModel->type = $type;
+        }
+
+        if (null !== ($title = $input->post('title'))) {
+            $pageModel->title = $title;
         }
 
         if (null !== ($requireItem = $input->post('requireItem'))) {

--- a/core-bundle/tests/EventListener/DataContainer/PageUrlListenerTest.php
+++ b/core-bundle/tests/EventListener/DataContainer/PageUrlListenerTest.php
@@ -37,7 +37,7 @@ class PageUrlListenerTest extends TestCase
     /**
      * @dataProvider generatesAliasProvider
      */
-    public function testGeneratesAlias(array $currentRecord, string $expectedAlias): void
+    public function testGeneratesAlias(array $currentRecord, array $input, string $slugResult, string $expectedAlias): void
     {
         $page = $this->mockClassWithProperties(PageModel::class, $currentRecord);
 
@@ -52,23 +52,21 @@ class PageUrlListenerTest extends TestCase
         $framework = $this->mockContaoFramework(
             [
                 PageModel::class => $pageAdapter,
-                Input::class => $this->mockInputAdapter([]),
+                Input::class => $this->mockInputAdapter($input),
             ]
         );
+
+        $expectedTitle = $input['title'] ?? $page->title;
 
         $slug = $this->createMock(Slug::class);
         $slug
             ->expects($this->once())
             ->method('generate')
-            ->with($page->title, $page->id, $this->isType('callable'))
-            ->willReturn($page->alias)
+            ->with($expectedTitle, $page->id, $this->isType('callable'))
+            ->willReturn($slugResult)
         ;
 
         $dc = $this->mockClassWithProperties(DataContainer::class, ['id' => $page->id]);
-        $dc
-            ->method('getCurrentRecord')
-            ->willReturn($currentRecord)
-        ;
 
         $listener = new PageUrlListener(
             $framework,
@@ -85,37 +83,56 @@ class PageUrlListenerTest extends TestCase
 
     public function generatesAliasProvider(): \Generator
     {
-        yield [
+        yield 'Test alias without changes and no folderUrl' => [
             [
                 'id' => 17,
                 'title' => 'Foo',
-                'alias' => 'foo',
                 'useFolderUrl' => false,
                 'folderUrl' => '',
             ],
+            [],
+            'foo',
             'foo',
         ];
 
-        yield [
-            [
-                'id' => 22,
-                'title' => 'Bar',
-                'alias' => 'bar',
-                'useFolderUrl' => false,
-                'folderUrl' => '',
-            ],
-            'bar',
-        ];
-
-        yield [
+        yield 'Test alias without changes and folderUrl' => [
             [
                 'id' => 17,
                 'title' => 'Foo',
-                'alias' => 'foo',
                 'useFolderUrl' => true,
                 'folderUrl' => 'bar/',
             ],
+            [],
+            'foo',
             'bar/foo',
+        ];
+
+        yield 'Test alias when changing the title and without folder url' => [
+            [
+                'id' => 17,
+                'title' => 'Foo',
+                'useFolderUrl' => false,
+                'folderUrl' => '',
+            ],
+            [
+                'title' => 'Bar',
+            ],
+            'bar',
+            'bar',
+        ];
+
+        yield 'Test alias when changing the title and folder url' => [
+            [
+                'id' => 17,
+                'title' => 'Foo',
+                'useFolderUrl' => true,
+                'folderUrl' => 'bar/',
+            ],
+            [
+                'title' => 'Bar',
+            ],
+            'bar',
+            'bar/bar',
         ];
     }
 

--- a/core-bundle/tests/EventListener/DataContainer/PageUrlListenerTest.php
+++ b/core-bundle/tests/EventListener/DataContainer/PageUrlListenerTest.php
@@ -107,7 +107,7 @@ class PageUrlListenerTest extends TestCase
             'bar/foo',
         ];
 
-        yield 'Test alias when changing the title and without folder url' => [
+        yield 'Test alias when changing the title and without folderUrl' => [
             [
                 'id' => 17,
                 'title' => 'Foo',
@@ -121,7 +121,7 @@ class PageUrlListenerTest extends TestCase
             'bar',
         ];
 
-        yield 'Test alias when changing the title and folder url' => [
+        yield 'Test alias when changing the title and folderUrl' => [
             [
                 'id' => 17,
                 'title' => 'Foo',


### PR DESCRIPTION
Steps to reproduce:

1. Duplicate a page (or empty the alias of an existing page which results in the same initial situation)
2. Change the title of the page
3. Save the changes

Result:

Alias is based on the previous title.

Expected result:

Alias is based on the new title.

The listener is actually wrong already in 4.13 but because it relies on the now deprecated active record there, the output is still correct. Hence, I figured I only adjust and fix this in 5.0 as otherwise we'll have upstream merging issues anyway.
Generating the alias on `getCurrentRecord()` can of course never work, it always represents the current state in the database.
