### PR TITLE
Make `$consolePath` a required argument

### DIFF
--- a/core-bundle/src/Util/ProcessUtil.php
+++ b/core-bundle/src/Util/ProcessUtil.php
@@ -22,7 +22,7 @@ class ProcessUtil implements ResetInterface
 {
     private string|null $phpBinary = null;
 
-    public function __construct(private readonly string $consolePath = 'bin/console')
+    public function __construct(private readonly string $consolePath)
     {
     }
 

--- a/core-bundle/tests/Cron/MessengerCronTest.php
+++ b/core-bundle/tests/Cron/MessengerCronTest.php
@@ -26,7 +26,7 @@ class MessengerCronTest extends TestCase
 {
     public function testIsSkippedIfNotOnCli(): void
     {
-        $cron = new MessengerCron(new Container(), new ProcessUtil(), []);
+        $cron = new MessengerCron(new Container(), new ProcessUtil('bin/console'), []);
 
         $this->expectException(CronExecutionSkippedException::class);
 

--- a/core-bundle/tests/Cron/MessengerCronTest.php
+++ b/core-bundle/tests/Cron/MessengerCronTest.php
@@ -45,6 +45,7 @@ class MessengerCronTest extends TestCase
         $processUtil = $this
             ->getMockBuilder(ProcessUtil::class)
             ->onlyMethods(['createPromise'])
+            ->setConstructorArgs(['bin/console'])
             ->getMock()
         ;
 

--- a/core-bundle/tests/Util/ProcessUtilTest.php
+++ b/core-bundle/tests/Util/ProcessUtilTest.php
@@ -22,7 +22,7 @@ class ProcessUtilTest extends TestCase
 {
     public function testCreateSymfonyConsoleProcess(): void
     {
-        $util = new ProcessUtil();
+        $util = new ProcessUtil('bin/console');
         $process = $util->createSymfonyConsoleProcess('foobar', 'argument-1', 'argument-2');
 
         $this->assertSame('bin/console foobar argument-1 argument-2', $this->getCommandLine($process));
@@ -38,7 +38,7 @@ class ProcessUtilTest extends TestCase
      */
     public function testPromise(bool $successful, bool $autostart): void
     {
-        $util = new ProcessUtil();
+        $util = new ProcessUtil('bin/console');
         $process = $this->mockProcess($successful, $autostart);
         $promise = $util->createPromise($process, $autostart);
 


### PR DESCRIPTION
The default argument `string $consolePath = 'bin/console'` does not work because the class actually requires the full path to the entry point. Therefore, the argument is implicitly not optional already.