### PR TITLE
Fix the Gulp watch task

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -84,14 +84,6 @@ gulp.task('minify-dark-theme-icons', function (cb) {
 gulp.task('watch', function () {
     gulp.watch(
         [
-            'core-bundle/public/core.js',
-            'core-bundle/public/mootao.js'
-        ],
-        gulp.series('minify-public')
-    );
-
-    gulp.watch(
-        [
             'core-bundle/contao/themes/flexible/*.js',
             '!core-bundle/contao/themes/flexible/*.min.js'
         ],


### PR DESCRIPTION
The `minify-public` task has been removed in https://github.com/contao/contao/pull/5598 - however, it was still referenced in the `watch` task.