### PR TITLE
Do not add `target="_blank"` to the `{{link}}` insert tag for non-redirect pages

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/InsertTags.php
+++ b/core-bundle/src/Resources/contao/library/Contao/InsertTags.php
@@ -476,7 +476,7 @@ class InsertTags extends Controller
 						}
 
 						$strName = $objNextPage->title;
-						$strTarget = $objNextPage->target ? ' target="_blank" rel="noreferrer noopener"' : '';
+						$strTarget = ($objNextPage->target && 'redirect' === $objNextPage->type) ? ' target="_blank" rel="noreferrer noopener"' : '';
 						$strClass = $objNextPage->cssClass ? sprintf(' class="%s"', $objNextPage->cssClass) : '';
 						$strTitle = $objNextPage->pageTitle ?: $objNextPage->title;
 					}


### PR DESCRIPTION
Fixes the following issue:

1. Create a new page of type `redirect` and enter a title and alias.
2. Enable the **Open in new window** setting and save.
3. Change the page type to `regular` and save.
4. Insert the `{{link::*}}` insert tag (with the ID of the created page) somewhere.

The output of the insert tag will be

```html
<a href="…" title="…" target="_blank" rel="noreferrer noopener">…</a>
```

instead of

```html
<a href="…" title="…">…</a>
```