### PR TITLE
Correctly describe our breadcrumbs with WAI-ARIA tags

### DIFF
--- a/core-bundle/src/Resources/contao/templates/modules/mod_breadcrumb.html5
+++ b/core-bundle/src/Resources/contao/templates/modules/mod_breadcrumb.html5
@@ -2,14 +2,16 @@
 
 <?php $this->block('content'); ?>
 
+<nav aria-label="Breadcrumb">
   <ul itemprop="breadcrumb" itemscope itemtype="http://schema.org/BreadcrumbList">
     <?php foreach ($this->items as $position => $item): ?>
       <?php if ($item['isActive']): ?>
-        <li class="active<?php if ($item['class']): ?> <?= $item['class'] ?><?php endif; ?> last"><?= $item['link'] ?></li>
+        <li class="active<?php if ($item['class']): ?> <?= $item['class'] ?><?php endif; ?> last" aria-current="page"><?= $item['link'] ?></li>
       <?php else: ?>
         <li<?php if ($item['class']): ?> class="<?= $item['class'] ?>"<?php endif; ?> itemscope itemtype="http://schema.org/ListItem" itemprop="itemListElement"><a href="<?= $item['href'] ?: './' ?>" title="<?= $item['title'] ?>" itemprop="item"><span itemprop="name"><?= $item['link'] ?></span></a><meta itemprop="position" content="<?= $position + 1 ?>"></li>
       <?php endif; ?>
     <?php endforeach; ?>
   </ul>
+</nav>
 
 <?php $this->endblock(); ?>

--- a/core-bundle/src/Resources/contao/templates/modules/mod_breadcrumb.html5
+++ b/core-bundle/src/Resources/contao/templates/modules/mod_breadcrumb.html5
@@ -1,6 +1,11 @@
 
 <!-- indexer::stop -->
 <nav class="<?= $this->class ?> block"<?= $this->cssID ?><?php if ($this->style): ?> style="<?= $this->style ?>"<?php endif; ?> aria-label="Breadcrumb" itemscope itemtype="http://schema.org/BreadcrumbList">
+
+  <?php if ($this->headline): ?>
+  <<?= $this->hl ?>><?= $this->headline ?></<?= $this->hl ?>>
+  <?php endif; ?>
+
     <ul>
       <?php foreach ($this->items as $position => $item): ?>
         <?php if ($item['isActive']): ?>

--- a/core-bundle/src/Resources/contao/templates/modules/mod_breadcrumb.html5
+++ b/core-bundle/src/Resources/contao/templates/modules/mod_breadcrumb.html5
@@ -2,18 +2,23 @@
 <!-- indexer::stop -->
 <nav class="<?= $this->class ?> block"<?= $this->cssID ?><?php if ($this->style): ?> style="<?= $this->style ?>"<?php endif; ?> aria-label="Breadcrumb" itemscope itemtype="http://schema.org/BreadcrumbList">
 
+  <?php $this->block('headline'); ?>
   <?php if ($this->headline): ?>
   <<?= $this->hl ?>><?= $this->headline ?></<?= $this->hl ?>>
   <?php endif; ?>
+  <?php $this->endblock(); ?>
 
-    <ul>
-      <?php foreach ($this->items as $position => $item): ?>
-        <?php if ($item['isActive']): ?>
-          <li class="active<?php if ($item['class']): ?> <?= $item['class'] ?><?php endif; ?> last" aria-current="page"><?= $item['link'] ?></li>
-        <?php else: ?>
-          <li<?php if ($item['class']): ?> class="<?= $item['class'] ?>"<?php endif; ?> itemscope itemtype="http://schema.org/ListItem" itemprop="itemListElement"><a href="<?= $item['href'] ?: './' ?>" title="<?= $item['title'] ?>" itemprop="item"><span itemprop="name"><?= $item['link'] ?></span></a><meta itemprop="position" content="<?= $position + 1 ?>"></li>
-        <?php endif; ?>
-      <?php endforeach; ?>
-    </ul>
-  </nav>
+  <?php $this->block('content'); ?>
+  <ul>
+    <?php foreach ($this->items as $position => $item): ?>
+      <?php if ($item['isActive']): ?>
+        <li class="active<?php if ($item['class']): ?> <?= $item['class'] ?><?php endif; ?> last" aria-current="page"><?= $item['link'] ?></li>
+      <?php else: ?>
+        <li<?php if ($item['class']): ?> class="<?= $item['class'] ?>"<?php endif; ?> itemscope itemtype="http://schema.org/ListItem" itemprop="itemListElement"><a href="<?= $item['href'] ?: './' ?>" title="<?= $item['title'] ?>" itemprop="item"><span itemprop="name"><?= $item['link'] ?></span></a><meta itemprop="position" content="<?= $position + 1 ?>"></li>
+      <?php endif; ?>
+    <?php endforeach; ?>
+  </ul>
+  <?php $this->endblock(); ?>
+
+</nav>
 <!-- indexer::continue -->

--- a/core-bundle/src/Resources/contao/templates/modules/mod_breadcrumb.html5
+++ b/core-bundle/src/Resources/contao/templates/modules/mod_breadcrumb.html5
@@ -1,17 +1,14 @@
-<?php $this->extend('block_unsearchable'); ?>
 
-<?php $this->block('content'); ?>
-
-<nav aria-label="Breadcrumb">
-  <ul itemprop="breadcrumb" itemscope itemtype="http://schema.org/BreadcrumbList">
-    <?php foreach ($this->items as $position => $item): ?>
-      <?php if ($item['isActive']): ?>
-        <li class="active<?php if ($item['class']): ?> <?= $item['class'] ?><?php endif; ?> last" aria-current="page"><?= $item['link'] ?></li>
-      <?php else: ?>
-        <li<?php if ($item['class']): ?> class="<?= $item['class'] ?>"<?php endif; ?> itemscope itemtype="http://schema.org/ListItem" itemprop="itemListElement"><a href="<?= $item['href'] ?: './' ?>" title="<?= $item['title'] ?>" itemprop="item"><span itemprop="name"><?= $item['link'] ?></span></a><meta itemprop="position" content="<?= $position + 1 ?>"></li>
-      <?php endif; ?>
-    <?php endforeach; ?>
-  </ul>
-</nav>
-
-<?php $this->endblock(); ?>
+<!-- indexer::stop -->
+<nav class="<?= $this->class ?> block"<?= $this->cssID ?><?php if ($this->style): ?> style="<?= $this->style ?>"<?php endif; ?> aria-label="Breadcrumb" itemscope itemtype="http://schema.org/BreadcrumbList">
+    <ul>
+      <?php foreach ($this->items as $position => $item): ?>
+        <?php if ($item['isActive']): ?>
+          <li class="active<?php if ($item['class']): ?> <?= $item['class'] ?><?php endif; ?> last" aria-current="page"><?= $item['link'] ?></li>
+        <?php else: ?>
+          <li<?php if ($item['class']): ?> class="<?= $item['class'] ?>"<?php endif; ?> itemscope itemtype="http://schema.org/ListItem" itemprop="itemListElement"><a href="<?= $item['href'] ?: './' ?>" title="<?= $item['title'] ?>" itemprop="item"><span itemprop="name"><?= $item['link'] ?></span></a><meta itemprop="position" content="<?= $position + 1 ?>"></li>
+        <?php endif; ?>
+      <?php endforeach; ?>
+    </ul>
+  </nav>
+<!-- indexer::continue -->

--- a/core-bundle/src/Resources/contao/templates/modules/mod_breadcrumb.html5
+++ b/core-bundle/src/Resources/contao/templates/modules/mod_breadcrumb.html5
@@ -3,9 +3,9 @@
 <nav class="<?= $this->class ?> block"<?= $this->cssID ?><?php if ($this->style): ?> style="<?= $this->style ?>"<?php endif; ?> aria-label="Breadcrumb" itemscope itemtype="http://schema.org/BreadcrumbList">
 
   <?php $this->block('headline'); ?>
-  <?php if ($this->headline): ?>
-  <<?= $this->hl ?>><?= $this->headline ?></<?= $this->hl ?>>
-  <?php endif; ?>
+    <?php if ($this->headline): ?>
+      <<?= $this->hl ?>><?= $this->headline ?></<?= $this->hl ?>>
+    <?php endif; ?>
   <?php $this->endblock(); ?>
 
   <?php $this->block('content'); ?>

--- a/core-bundle/src/Resources/contao/templates/modules/mod_breadcrumb.html5
+++ b/core-bundle/src/Resources/contao/templates/modules/mod_breadcrumb.html5
@@ -1,6 +1,6 @@
 
 <!-- indexer::stop -->
-<nav class="<?= $this->class ?> block"<?= $this->cssID ?><?php if ($this->style): ?> style="<?= $this->style ?>"<?php endif; ?> aria-label="Breadcrumb" itemscope itemtype="http://schema.org/BreadcrumbList">
+<nav class="<?= $this->class ?> block"<?= $this->cssID ?><?php if ($this->style): ?> style="<?= $this->style ?>"<?php endif; ?> aria-label="Breadcrumb" itemprop="breadcrumb" itemscope itemtype="http://schema.org/BreadcrumbList">
 
   <?php $this->block('headline'); ?>
     <?php if ($this->headline): ?>

--- a/core-bundle/src/Resources/contao/templates/modules/mod_breadcrumb.html5
+++ b/core-bundle/src/Resources/contao/templates/modules/mod_breadcrumb.html5
@@ -9,15 +9,15 @@
   <?php $this->endblock(); ?>
 
   <?php $this->block('content'); ?>
-  <ul>
-    <?php foreach ($this->items as $position => $item): ?>
-      <?php if ($item['isActive']): ?>
-        <li class="active<?php if ($item['class']): ?> <?= $item['class'] ?><?php endif; ?> last" aria-current="page"><?= $item['link'] ?></li>
-      <?php else: ?>
-        <li<?php if ($item['class']): ?> class="<?= $item['class'] ?>"<?php endif; ?> itemscope itemtype="http://schema.org/ListItem" itemprop="itemListElement"><a href="<?= $item['href'] ?: './' ?>" title="<?= $item['title'] ?>" itemprop="item"><span itemprop="name"><?= $item['link'] ?></span></a><meta itemprop="position" content="<?= $position + 1 ?>"></li>
-      <?php endif; ?>
-    <?php endforeach; ?>
-  </ul>
+    <ul>
+      <?php foreach ($this->items as $position => $item): ?>
+        <?php if ($item['isActive']): ?>
+          <li class="active<?php if ($item['class']): ?> <?= $item['class'] ?><?php endif; ?> last" aria-current="page"><?= $item['link'] ?></li>
+        <?php else: ?>
+          <li<?php if ($item['class']): ?> class="<?= $item['class'] ?>"<?php endif; ?> itemscope itemtype="http://schema.org/ListItem" itemprop="itemListElement"><a href="<?= $item['href'] ?: './' ?>" title="<?= $item['title'] ?>" itemprop="item"><span itemprop="name"><?= $item['link'] ?></span></a><meta itemprop="position" content="<?= $position + 1 ?>"></li>
+        <?php endif; ?>
+      <?php endforeach; ?>
+    </ul>
   <?php $this->endblock(); ?>
 
 </nav>


### PR DESCRIPTION
I had one of our Contao projects reviewed by an accessibility specialst and one issue mentioned was a missing `aria-lable="Breadcrumb"` and `aria-current="page"` on our breadcrumb module.
It's also recommended to wrap the `<ul>` into a `<nav>` to indicated, that this is a navigation.

I did not change `<ul>` to `<ol>` because I think we should do that in all our navigations if we think that's needed and we should probably do that only in 5.x.

See https://www.w3.org/WAI/ARIA/apg/example-index/breadcrumb/index.html for reference.
