### PR TITLE
Fix the number of bound variables in the MemberModel class

### DIFF
--- a/core-bundle/contao/models/MemberModel.php
+++ b/core-bundle/contao/models/MemberModel.php
@@ -195,13 +195,15 @@ class MemberModel extends Model
 		$time = Date::floorToMinute();
 
 		$arrColumns = array("$t.email=? AND $t.login=1 AND $t.disable=0 AND ($t.start='' OR $t.start<='$time') AND ($t.stop='' OR $t.stop>'$time')");
+		$arrValues = array($strEmail);
 
 		if ($strUsername !== null)
 		{
 			$arrColumns[] = "$t.username=?";
+			$arrValues[] = $strUsername;
 		}
 
-		return static::findOneBy($arrColumns, array($strEmail, $strUsername), $arrOptions);
+		return static::findOneBy($arrColumns, $arrValues, $arrOptions);
 	}
 
 	/**


### PR DESCRIPTION
Description
-----------
When using the `ModuleLostPassword` with the option to skip the username following error occurs:

`An exception occurred while executing a query: SQLSTATE[HY093]: Invalid parameter number: number of bound variables does not match number of tokens`.

See https://contao.slack.com/archives/CK4J0KNDB/p1674644741754939
