### PR TITLE
Use the correct ID for URL parameters when saving and duplicating

### DIFF
--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -2184,7 +2184,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 				// List view
 				else
 				{
-					$strUrl .= $this->ptable ? '&amp;act=copy&amp;mode=2&amp;pid=' . $this->intCurrentPid . '&amp;id=' . $this->intCurrentPid : '&amp;act=copy&amp;id=' . $this->intCurrentPid;
+					$strUrl .= $this->ptable ? '&amp;act=copy&amp;mode=2&amp;pid=' . $this->intCurrentPid . '&amp;id=' . $this->intId : '&amp;act=copy&amp;id=' . $this->intId;
 				}
 
 				$this->redirect($strUrl . '&amp;rt=' . System::getContainer()->get('contao.csrf.token_manager')->getDefaultTokenValue());


### PR DESCRIPTION
Description
-----------

E.g. when trying to _save and duplicate_ a user in the backend you'll get an error (as `$this->intCurrentPid` is null because there is no parent):

```
Contao\CoreBundle\Exception\NotFoundException:
Cannot load record "tl_user.id=".

  at /contao/core-bundle/contao/drivers/DC_Table.php:879
  at Contao\DC_Table->copy()
     (/contao/core-bundle/contao/classes/Backend.php:546)
  at Contao\Backend->getBackendModule('user', null)
     (/contao/core-bundle/contao/controllers/BackendMain.php:148)
  at Contao\BackendMain->run()
     (/contao/core-bundle/src/Controller/BackendController.php:44)
  at Contao\CoreBundle\Controller\BackendController->mainAction()
     (vendor/symfony/http-kernel/HttpKernel.php:163)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw(object(Request), 1)
     (vendor/symfony/http-kernel/HttpKernel.php:74)
  at Symfony\Component\HttpKernel\HttpKernel->handle(object(Request), 1, true)
     (vendor/symfony/http-kernel/Kernel.php:184)
  at Symfony\Component\HttpKernel\Kernel->handle(object(Request))
     (public/index.php:56)                        
```