### PR TITLE
Ignore empy layout selection

### DIFF
--- a/core-bundle/src/Resources/contao/models/PageModel.php
+++ b/core-bundle/src/Resources/contao/models/PageModel.php
@@ -892,7 +892,7 @@ class PageModel extends Model
 		// Set some default values
 		$this->protected = (bool) $this->protected;
 		$this->groups = $this->protected ? StringUtil::deserialize($this->groups) : false;
-		$this->layout = $this->includeLayout ? $this->layout : false;
+		$this->layout = ($this->includeLayout && $this->layout) ? $this->layout : false;
 		$this->cache = $this->includeCache ? $this->cache : false;
 		$this->alwaysLoadFromCache = $this->includeCache ? $this->alwaysLoadFromCache : false;
 		$this->clientCache = $this->includeCache ? $this->clientCache : false;


### PR DESCRIPTION
Fixes #5729

Currently, as soon as you click on **Assign a layout** in the settings of the page, that page will not work anymore in the front end, with the error "No layout specified". This is because the layout assignment is activated but no layout has been set yet at that point (assuming no layout was set previously in the database for that page).

This however can easily be fixed by letting `PageModel::loadDetails` ignore the `includeLayout` setting, if the `layout` setting is still falsey (i.e. `0`).