### PR TITLE
Fix the locales test

### DIFF
--- a/core-bundle/tests/Intl/LocalesTest.php
+++ b/core-bundle/tests/Intl/LocalesTest.php
@@ -154,10 +154,10 @@ class LocalesTest extends TestCase
 
         $this->assertSame(
             [
-                'gsw_Hans_AT' => 'Schwiizertüütsch (Veräifachti Chineesischi Schrift, Ööschtriich) - Schweizerdeutsch (Vereinfacht, Österreich)',
+                'gsw_Latn_AT' => 'Schwiizertüütsch (Latiinisch, Ööschtriich)',
                 'de_CH' => 'Tüütsch (Schwiiz) - Deutsch (Schweiz)',
             ],
-            $this->getLocalesService()->getDisplayNames(['gsw_Hans_AT', 'de_CH'], 'gsw', true)
+            $this->getLocalesService()->getDisplayNames(['gsw_Latn_AT', 'de_CH'], 'gsw', true)
         );
     }
 

--- a/core-bundle/tests/Intl/LocalesTest.php
+++ b/core-bundle/tests/Intl/LocalesTest.php
@@ -154,7 +154,7 @@ class LocalesTest extends TestCase
 
         $this->assertSame(
             [
-                'gsw_Hans_AT' => 'Schwiizertüütsch (Veräifachti Chineesischi Schrift, Ööschtriich)',
+                'gsw_Hans_AT' => 'Schwiizertüütsch (Veräifachti Chineesischi Schrift, Ööschtriich) - Schweizerdeutsch (Vereinfacht, Österreich)',
                 'de_CH' => 'Tüütsch (Schwiiz) - Deutsch (Schweiz)',
             ],
             $this->getLocalesService()->getDisplayNames(['gsw_Hans_AT', 'de_CH'], 'gsw', true)


### PR DESCRIPTION
For some reason, `gsw_Hans_AT` adds a native suffix on my system but not on Github, so the unit tests fail on my system:

<img width="953" alt="" src="https://user-images.githubusercontent.com/1192057/215067095-280b538a-8006-469c-a949-e9800c74d65c.png">

Both Github and I are using PHP 8.2 with the latest intl extension:

<img width="354" alt="" src="https://user-images.githubusercontent.com/1192057/215065495-2fdb2b7a-84a1-4135-be69-c04ab7229240.png">

@ausi Any idea what could cause this?