### PR TITLE
Prevent division by zero in gallery element

### DIFF
--- a/core-bundle/src/Resources/contao/elements/ContentGallery.php
+++ b/core-bundle/src/Resources/contao/elements/ContentGallery.php
@@ -69,7 +69,7 @@ class ContentGallery extends ContentElement
 		}
 
 		// Make sure we have at least one row to prevent division by zero
-		$this->perRow = max($this->perRow, 1);
+		$this->perRow = max((int) $this->perRow, 1);
 
 		return parent::generate();
 	}

--- a/core-bundle/src/Resources/contao/elements/ContentGallery.php
+++ b/core-bundle/src/Resources/contao/elements/ContentGallery.php
@@ -69,7 +69,10 @@ class ContentGallery extends ContentElement
 		}
 
 		// Make sure we have at least one item per row to prevent division by zero
-		$this->perRow = max((int) $this->perRow, 1);
+		if ($this->perRow < 1)
+		{
+			$this->perRow = 1;
+		}
 
 		return parent::generate();
 	}

--- a/core-bundle/src/Resources/contao/elements/ContentGallery.php
+++ b/core-bundle/src/Resources/contao/elements/ContentGallery.php
@@ -68,6 +68,9 @@ class ContentGallery extends ContentElement
 			return '';
 		}
 
+		// Make sure we have at least one row to prevent division by zero
+		$this->perRow = max($this->perRow, 1);
+
 		return parent::generate();
 	}
 
@@ -250,7 +253,7 @@ class ContentGallery extends ContentElement
 		}
 
 		$rowcount = 0;
-		$colwidth = $this->perRow > 0 ? floor(100/$this->perRow) : 100;
+		$colwidth = floor(100/$this->perRow);
 		$strLightboxId = 'lb' . $this->id;
 		$body = array();
 

--- a/core-bundle/src/Resources/contao/elements/ContentGallery.php
+++ b/core-bundle/src/Resources/contao/elements/ContentGallery.php
@@ -250,7 +250,7 @@ class ContentGallery extends ContentElement
 		}
 
 		$rowcount = 0;
-		$colwidth = floor(100/$this->perRow);
+		$colwidth = $this->perRow > 0 ? floor(100/$this->perRow) : 100;
 		$strLightboxId = 'lb' . $this->id;
 		$body = array();
 

--- a/core-bundle/src/Resources/contao/elements/ContentGallery.php
+++ b/core-bundle/src/Resources/contao/elements/ContentGallery.php
@@ -68,7 +68,7 @@ class ContentGallery extends ContentElement
 			return '';
 		}
 
-		// Make sure we have at least one row to prevent division by zero
+		// Make sure we have at least one item per row to prevent division by zero
 		$this->perRow = max((int) $this->perRow, 1);
 
 		return parent::generate();


### PR DESCRIPTION
if `$this->perRow` is zero, a `DivisionByZeroError` is thrown in PHP.