### PR TITLE
Prevent "array to string conversion" errors when migrating basic entities

### DIFF
--- a/core-bundle/src/Migration/Version500/AbstractBasicEntitiesMigration.php
+++ b/core-bundle/src/Migration/Version500/AbstractBasicEntitiesMigration.php
@@ -84,7 +84,8 @@ abstract class AbstractBasicEntitiesMigration extends AbstractMigration
                 $value = StringUtil::deserialize($value);
 
                 if (\is_array($value)) {
-                    $value = serialize(array_map(static fn ($v) => StringUtil::restoreBasicEntities($v), $value));
+                    array_walk_recursive($value, static fn (&$v) => $v = StringUtil::restoreBasicEntities($v));
+                    $value = serialize($value);
                 } else {
                     $value = StringUtil::restoreBasicEntities($value);
                 }

--- a/core-bundle/src/Migration/Version500/AbstractBasicEntitiesMigration.php
+++ b/core-bundle/src/Migration/Version500/AbstractBasicEntitiesMigration.php
@@ -81,10 +81,12 @@ abstract class AbstractBasicEntitiesMigration extends AbstractMigration
             );
 
             foreach ($values as $id => $value) {
-                $value = StringUtil::restoreBasicEntities(StringUtil::deserialize($value));
+                $value = StringUtil::deserialize($value);
 
                 if (\is_array($value)) {
-                    $value = serialize($value);
+                    $value = serialize(array_map(static fn ($v) => StringUtil::restoreBasicEntities($v), $value));
+                } else {
+                    $value = StringUtil::restoreBasicEntities($value);
                 }
 
                 $this->connection->update($table, [$column => $value], ['id' => (int) $id]);


### PR DESCRIPTION
We do not have unit tests for migrations, so no, I cannot add a unit test to prevent regressions. 😄 