### PR TITLE
Preserve safe HTML in the Twig insert tag filters

### DIFF
--- a/core-bundle/src/Twig/Extension/ContaoExtension.php
+++ b/core-bundle/src/Twig/Extension/ContaoExtension.php
@@ -225,11 +225,13 @@ final class ContaoExtension extends AbstractExtension
             ),
             new TwigFilter(
                 'insert_tag',
-                [InsertTagRuntime::class, 'replaceInsertTags']
+                [InsertTagRuntime::class, 'replaceInsertTags'],
+                ['preserves_safety' => ['html']]
             ),
             new TwigFilter(
                 'insert_tag_raw',
-                [InsertTagRuntime::class, 'replaceInsertTagsChunkedRaw']
+                [InsertTagRuntime::class, 'replaceInsertTagsChunkedRaw'],
+                ['preserves_safety' => ['html']]
             ),
             new TwigFilter(
                 'highlight',

--- a/core-bundle/tests/Twig/TwigIntegrationTest.php
+++ b/core-bundle/tests/Twig/TwigIntegrationTest.php
@@ -197,9 +197,8 @@ class TwigIntegrationTest extends TestCase
             {{ unsafe|insert_tag_raw }}
             TEMPLATE;
 
-        // With 'preserve_safety' set, we expect the unescaped versions in the
-        // first two lines, while the unsafe parameter is still escaped (last
-        // line):
+        // With 'preserve_safety' set, we expect the unescaped versions in the first
+        // two lines, while the unsafe parameter is still escaped (last line):
         $expectedOutput = <<<'TEMPLATE'
             <i>foo</i><br>
             <i>foo</i><br>
@@ -207,7 +206,6 @@ class TwigIntegrationTest extends TestCase
             TEMPLATE;
 
         $parser = $this->createMock(InsertTagParser::class);
-
         $parser
             ->method('replaceChunked')
             ->willReturnCallback(
@@ -235,12 +233,7 @@ class TwigIntegrationTest extends TestCase
             )
         );
 
-        $output = $environment->render(
-            'test.html.twig',
-            [
-                'unsafe' => '<i>foo</i>{{br}}',
-            ]
-        );
+        $output = $environment->render('test.html.twig', ['unsafe' => '<i>foo</i>{{br}}']);
 
         $this->assertSame($expectedOutput, $output);
     }

--- a/core-bundle/tests/Twig/TwigIntegrationTest.php
+++ b/core-bundle/tests/Twig/TwigIntegrationTest.php
@@ -14,11 +14,14 @@ namespace Contao\CoreBundle\Tests\Twig;
 
 use Contao\Config;
 use Contao\CoreBundle\Csrf\ContaoCsrfTokenManager;
+use Contao\CoreBundle\InsertTag\ChunkedText;
+use Contao\CoreBundle\InsertTag\InsertTagParser;
 use Contao\CoreBundle\Tests\TestCase;
 use Contao\CoreBundle\Twig\Extension\ContaoExtension;
 use Contao\CoreBundle\Twig\Inheritance\TemplateHierarchyInterface;
 use Contao\CoreBundle\Twig\Interop\ContextFactory;
 use Contao\CoreBundle\Twig\Runtime\HighlighterRuntime;
+use Contao\CoreBundle\Twig\Runtime\InsertTagRuntime;
 use Contao\FormText;
 use Contao\System;
 use Contao\TemplateLoader;
@@ -184,5 +187,61 @@ class TwigIntegrationTest extends TestCase
         $this->assertSame($expectedOutput, $output);
 
         $this->resetStaticProperties([Highlighter::class]);
+    }
+
+    public function testPreservesSafetyInInsertTagFilters(): void
+    {
+        $templateContent = <<<'TEMPLATE'
+            {{ '<i>foo</i>{{br}}'|insert_tag_raw }}
+            {{ unsafe|raw|insert_tag }}
+            {{ unsafe|insert_tag_raw }}
+            TEMPLATE;
+
+        // With 'preserve_safety' set, we expect the unescaped versions in the
+        // first two lines, while the unsafe parameter is still escaped (last
+        // line):
+        $expectedOutput = <<<'TEMPLATE'
+            <i>foo</i><br>
+            <i>foo</i><br>
+            &lt;i&gt;foo&lt;/i&gt;<br>
+            TEMPLATE;
+
+        $parser = $this->createMock(InsertTagParser::class);
+
+        $parser
+            ->method('replaceChunked')
+            ->willReturnCallback(
+                static fn (string $input): ChunkedText => match ($input) {
+                    '<i>foo</i>{{br}}' => new ChunkedText(['<i>foo</i>', '<br>']),
+                    default => new ChunkedText([$input])
+                }
+            )
+        ;
+
+        $parser
+            ->method('replaceInline')
+            ->with('<i>foo</i>{{br}}')
+            ->willReturn('<i>foo</i><br>')
+        ;
+
+        $environment = new Environment(new ArrayLoader(['test.html.twig' => $templateContent]));
+        $environment->addRuntimeLoader(new FactoryRuntimeLoader([InsertTagRuntime::class => static fn () => new InsertTagRuntime($parser)]));
+
+        $environment->addExtension(
+            new ContaoExtension(
+                $environment,
+                $this->createMock(TemplateHierarchyInterface::class),
+                $this->createMock(ContaoCsrfTokenManager::class)
+            )
+        );
+
+        $output = $environment->render(
+            'test.html.twig',
+            [
+                'unsafe' => '<i>foo</i>{{br}}',
+            ]
+        );
+
+        $this->assertSame($expectedOutput, $output);
     }
 }


### PR DESCRIPTION
If you pass HTML into our `|insert_tag` or `|insert_tag_raw` filters, that was previously considered *safe*, the `SafeAnalysisNodeVisitor` now treats the output as "still safe".

Here are some examples:

```twig
{# will not escape, because a constant is safe #}
{{ '<i>foo</i>{{br}}'|insert_tag_raw }}

{# will escape, because the parameter is not trusted #}
{{ some_parameter|insert_tag_raw }}

{# will not escape, because the input was already considered safe after the |raw #}
{{ some_parameter|raw|insert_tag }}