### PR TITLE
Always set `currentRecord` when initializing widgets

### DIFF
--- a/core-bundle/src/Resources/contao/controllers/BackendPassword.php
+++ b/core-bundle/src/Resources/contao/controllers/BackendPassword.php
@@ -63,6 +63,7 @@ class BackendPassword extends Backend
 		$widget->password = $GLOBALS['TL_LANG']['MSC']['password'][0];
 		$widget->confirm = $GLOBALS['TL_LANG']['MSC']['confirm'][0];
 		$widget->wizard = Backend::getTogglePasswordWizard('password');
+		$widget->currentRecord = $this->User->id;
 
 		$objTemplate = new BackendTemplate('be_password');
 		$objTemplate->widget = $widget->parse();

--- a/core-bundle/src/Resources/contao/modules/ModuleChangePassword.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleChangePassword.php
@@ -127,9 +127,9 @@ class ModuleChangePassword extends Module
 
 			/** @var Widget $objWidget */
 			$objWidget = new $strClass($strClass::getAttributesFromDca($arrField, $arrField['name']));
-
 			$objWidget->storeValues = true;
 			$objWidget->rowClass = 'row_' . $row . (($row == 0) ? ' row_first' : '') . ((($row % 2) == 0) ? ' even' : ' odd');
+			$objWidget->currentRecord = $objMember->id;
 
 			// Increase the row count if it is a password field
 			if ($objWidget instanceof FormPassword)

--- a/core-bundle/src/Resources/contao/modules/ModuleCloseAccount.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleCloseAccount.php
@@ -61,6 +61,7 @@ class ModuleCloseAccount extends Module
 		$this->loadDataContainer('tl_member');
 
 		$container = System::getContainer();
+		$objMember = MemberModel::findByPk($this->User->id);
 
 		// Initialize the password widget
 		$arrField = $GLOBALS['TL_DCA']['tl_member']['fields']['password'];
@@ -69,6 +70,7 @@ class ModuleCloseAccount extends Module
 
 		$objWidget = new FormTextField(FormTextField::getAttributesFromDca($arrField, $arrField['name']));
 		$objWidget->rowClass = 'row_0 row_first even';
+		$objWidget->currentRecord = $objMember->id;
 
 		$strFormId = 'tl_close_account_' . $this->id;
 
@@ -98,8 +100,6 @@ class ModuleCloseAccount extends Module
 						$this->{$callback[0]}->{$callback[1]}($this->User->id, $this->reg_close, $this);
 					}
 				}
-
-				$objMember = MemberModel::findByPk($this->User->id);
 
 				// Remove the account
 				if ($this->reg_close == 'close_delete')

--- a/core-bundle/src/Resources/contao/modules/ModulePassword.php
+++ b/core-bundle/src/Resources/contao/modules/ModulePassword.php
@@ -125,9 +125,9 @@ class ModulePassword extends Module
 
 			/** @var Widget $objWidget */
 			$objWidget = new $strClass($strClass::getAttributesFromDca($arrField, $arrField['name']));
-
 			$objWidget->storeValues = true;
 			$objWidget->rowClass = 'row_' . $row . (($row == 0) ? ' row_first' : '') . ((($row % 2) == 0) ? ' even' : ' odd');
+
 			++$row;
 
 			// Validate the widget
@@ -236,6 +236,7 @@ class ModulePassword extends Module
 
 		/** @var Widget $objWidget */
 		$objWidget = new $strClass($strClass::getAttributesFromDca($arrField, 'password'));
+		$objWidget->currentRecord = $objMember->id;
 
 		// Set row classes
 		$objWidget->rowClass = 'row_0 row_first even';

--- a/core-bundle/src/Resources/contao/modules/ModulePersonalData.php
+++ b/core-bundle/src/Resources/contao/modules/ModulePersonalData.php
@@ -198,6 +198,7 @@ class ModulePersonalData extends Module
 			$objWidget->id .= '_' . $this->id;
 			$objWidget->storeValues = true;
 			$objWidget->rowClass = 'row_' . $row . (($row == 0) ? ' row_first' : '') . ((($row % 2) == 0) ? ' even' : ' odd');
+			$objWidget->currentRecord = $objMember->id;
 
 			// Increase the row count if it is a password field
 			if ($objWidget instanceof FormPassword)


### PR DESCRIPTION
First of all, this is **not to be mistaken** with `$objCurrentRecord` in the DCA, which we have recently reworked for Contao 5.

Our widgets have a `currentRecord` property, which is set when they are initialized:

https://github.com/contao/contao/blob/e581d92fc8d7d2447369acf036265b41ad567852/core-bundle/src/Resources/contao/classes/DataContainer.php#L433-L435

However, we are not doing this everywhere, so sometimes the value is unexpectedly `null`. This PR fixes that.