### PR TITLE
Fix the image encoding in the RSS feeds

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/FeedItem.php
+++ b/core-bundle/src/Resources/contao/library/Contao/FeedItem.php
@@ -123,7 +123,7 @@ class FeedItem
 		if ($size && $objFile->isImage)
 		{
 			$image = System::getContainer()->get('contao.image.image_factory')->create(Path::join($rootDir, $strFile), $size);
-			$fileUrl = $strUrl . System::urlEncode($image->getUrl($rootDir));
+			$fileUrl = $strUrl . $image->getUrl($rootDir);
 			$objFile = new File(Path::makeRelative($image->getPath(), $rootDir));
 		}
 


### PR DESCRIPTION
I think there is an issue with image encoding in the RSS feed generator here: https://github.com/contao/contao/blob/4.13/core-bundle/src/Resources/contao/library/Contao/FeedItem.php#L126

We have the following image filename: `0_Wir suchen Verstärkung.jpg`:

```php
// seems correct
$image->getUrl($rootDir); // 0_Wir%20suchen%20Verst%C3%A4rkung-7b0efe98.jpg

// seems wrong (double encoded)
System::urlEncode($image->getUrl($rootDir)); // 0_Wir%2520suchen%2520Verst%25C3%25A4rkung-7b0efe98.jpg
```

Currently the image path seems to be double encoded, which leads to 404. There seems to be one `System::urlEncode` too much.

What do you think?