### PR TITLE
Do not deep merge messenger workers

### DIFF
--- a/core-bundle/src/DependencyInjection/Configuration.php
+++ b/core-bundle/src/DependencyInjection/Configuration.php
@@ -134,6 +134,7 @@ class Configuration implements ConfigurationInterface
             ->info('Allows to define Symfony Messenger workers (messenger:consume). Workers are started every minute using the Contao cron job framework.')
             ->children()
                 ->arrayNode('workers')
+                    ->performNoDeepMerging()
                     ->arrayPrototype()
                         ->children()
                             ->arrayNode('transports')

--- a/core-bundle/tests/DependencyInjection/ConfigurationTest.php
+++ b/core-bundle/tests/DependencyInjection/ConfigurationTest.php
@@ -43,7 +43,7 @@ class ConfigurationTest extends TestCase
         $this->assertNull($configuration['image']['imagine_service']);
 
         $params = [
-            'contao' => [
+            [
                 'image' => [
                     'imagine_service' => 'my_super_service',
                 ],
@@ -65,7 +65,7 @@ class ConfigurationTest extends TestCase
         $this->expectDeprecation('Since contao/core-bundle 4.13: Setting the web directory in a config file is deprecated. Use the "extra.public-dir" config key in your root composer.json instead.');
 
         $params = [
-            'contao' => [
+           [
                 'web_dir' => $unix,
                 'image' => [
                     'target_dir' => $windows,
@@ -97,7 +97,7 @@ class ConfigurationTest extends TestCase
     public function testFailsIfTheUploadPathIsInvalid(string $uploadPath): void
     {
         $params = [
-            'contao' => [
+            [
                 'upload_path' => $uploadPath,
             ],
         ];
@@ -128,7 +128,7 @@ class ConfigurationTest extends TestCase
     public function testFailsIfAPredefinedImageSizeNameContainsOnlyDigits(): void
     {
         $params = [
-            'contao' => [
+            [
                 'image' => [
                     'sizes' => [
                         '123' => ['width' => 100, 'height' => 200],
@@ -149,7 +149,7 @@ class ConfigurationTest extends TestCase
     public function testFailsIfAPredefinedImageSizeNameIsReserved(string $name): void
     {
         $params = [
-            'contao' => [
+            [
                 'image' => [
                     'sizes' => [
                         $name => ['width' => 100, 'height' => 200],
@@ -183,7 +183,7 @@ class ConfigurationTest extends TestCase
     public function testDeniesInvalidCrawlUris(): void
     {
         $params = [
-            'contao' => [
+            [
                 'crawl' => [
                     'additional_uris' => ['invalid.com'],
                 ],
@@ -209,7 +209,7 @@ class ConfigurationTest extends TestCase
     public function testFailsIfABackendAttributeNameContainsInvalidCharacters(): void
     {
         $params = [
-            'contao' => [
+            [
                 'backend' => [
                     'attributes' => [
                         'data-App Name' => 'My App',
@@ -227,7 +227,7 @@ class ConfigurationTest extends TestCase
     public function testFailsOnInvalidBackupKeepIntervals(): void
     {
         $params = [
-            'contao' => [
+            [
                 'backup' => [
                     'keep_intervals' => [
                         'foobar',
@@ -245,7 +245,18 @@ class ConfigurationTest extends TestCase
     public function testMessengerConfiguration(): void
     {
         $params = [
-            'contao' => [
+            // This first configuration should be overridden by the latter (no deep merging), in order to control all the
+            // workers in your app.
+            [
+                'messenger' => [
+                    'workers' => [
+                        [
+                            'transports' => ['prio_low'],
+                        ],
+                    ],
+                ],
+            ],
+            [
                 'messenger' => [
                     'workers' => [
                         [
@@ -313,7 +324,7 @@ class ConfigurationTest extends TestCase
 
         try {
             (new Processor())->processConfiguration($this->configuration, [
-                'contao' => [
+                [
                     'messenger' => [
                         'workers' => [
                             [
@@ -336,7 +347,7 @@ class ConfigurationTest extends TestCase
 
         try {
             (new Processor())->processConfiguration($this->configuration, [
-                'contao' => [
+                [
                     'messenger' => [
                         'workers' => [
                             [
@@ -372,7 +383,7 @@ class ConfigurationTest extends TestCase
     public function testInvalidCronConfiguration(): void
     {
         $params = [
-            'contao' => [
+            [
                 'cron' => [
                     'web_listener' => 'foobar',
                 ],
@@ -392,15 +403,15 @@ class ConfigurationTest extends TestCase
         ];
 
         yield 'Explicit auto' => [
-            ['contao' => ['cron' => ['web_listener' => 'auto']]], 'auto',
+            [['cron' => ['web_listener' => 'auto']]], 'auto',
         ];
 
         yield 'Explicit false' => [
-            ['contao' => ['cron' => ['web_listener' => false]]], false,
+            [['cron' => ['web_listener' => false]]], false,
         ];
 
         yield 'Explicit true' => [
-            ['contao' => ['cron' => ['web_listener' => true]]], true,
+            [['cron' => ['web_listener' => true]]], true,
         ];
     }
 

--- a/core-bundle/tests/DependencyInjection/ConfigurationTest.php
+++ b/core-bundle/tests/DependencyInjection/ConfigurationTest.php
@@ -65,7 +65,7 @@ class ConfigurationTest extends TestCase
         $this->expectDeprecation('Since contao/core-bundle 4.13: Setting the web directory in a config file is deprecated. Use the "extra.public-dir" config key in your root composer.json instead.');
 
         $params = [
-           [
+            [
                 'web_dir' => $unix,
                 'image' => [
                     'target_dir' => $windows,


### PR DESCRIPTION
We must not deep merge `contao.workers`. Otherwise, if you configure them yourself in your `config.yaml`, you will add workers on top of the default definition instead of replacing them.

I've also removed the `'contao'` key in all the configuration params because that is confusing. There should be no key :) /cc @aschempp 