### PR TITLE
Fix target decoding in figurebuilder

### DIFF
--- a/core-bundle/src/Image/Studio/FigureBuilder.php
+++ b/core-bundle/src/Image/Studio/FigureBuilder.php
@@ -666,7 +666,7 @@ class FigureBuilder
                 return [null, $target];
             }
 
-            $target = urldecode($target);
+            $target = rawurldecode($target);
 
             $filePath = Path::isAbsolute($target)
                 ? Path::canonicalize($target)


### PR DESCRIPTION
I think there might be an issue with the target decoding in the figurebuilder: https://github.com/contao/contao/blob/4.13/core-bundle/src/Image/Studio/FigureBuilder.php#L669

By using ```urldecode()``` a plus symbol ("+") gets decoded to a space (" ").
This leads to an error where images with a plus symbol in the filename eg. "myfile+name.jpg" would not be able to be opened in the lightbox even though the option would be set in a gallery.

By using ```rawurldecode()``` the plus symbols are not decoded into spaces and the images work in the lightbox.  

Is there a special reason to use ```urldecode()``` in this case? I could not find any documentation on that part.

### Reproduce the error
- Create a gallery content-element.
- Upload an image and use a plus symbol in the filename eg. "myfile+name.jpg".
- Enable the lightbox option in the gallery content-element.
- Check the frontend (lightbox-element should not work for this image)

Fix:
- Rename the image (remove plus symbol from filename eg. "myfilename.jpg")
- Check the frontend (lightbox-element should work now)