### PR TITLE
Correctly hide unknown help options

### DIFF
--- a/core-bundle/src/Resources/contao/controllers/BackendHelp.php
+++ b/core-bundle/src/Resources/contao/controllers/BackendHelp.php
@@ -94,11 +94,11 @@ class BackendHelp extends Backend
 
 					if (\is_array($arrData['reference'][$key]))
 					{
-						$rows[] = array('headspan', $arrData['reference'][$key][0]);
+						$rows[] = array('headspan', $arrData['reference'][$key][0] ?? $key);
 					}
 					else
 					{
-						$rows[] = array('headspan', $arrData['reference'][$key]);
+						$rows[] = array('headspan', $arrData['reference'][$key] ?? $key);
 					}
 
 					foreach ($option as $opt)


### PR DESCRIPTION
Using `null` as value for the option results in a template exception:

<img width="894" alt="Bildschirmfoto 2023-02-09 um 13 52 46" src="https://user-images.githubusercontent.com/1073273/217818129-80c24e84-dc73-4cce-9424-1b9417342f50.png">
