### PR TITLE
Only check for registration opt-in tokens when purging registrations

### DIFF
--- a/core-bundle/src/Resources/contao/models/MemberModel.php
+++ b/core-bundle/src/Resources/contao/models/MemberModel.php
@@ -243,7 +243,7 @@ class MemberModel extends Model
 		$t = static::$strTable;
 		$objDatabase = Database::getInstance();
 
-		$objResult = $objDatabase->prepare("SELECT * FROM $t WHERE disable='1' AND EXISTS (SELECT * FROM tl_opt_in_related r LEFT JOIN tl_opt_in o ON r.pid=o.id WHERE r.relTable='$t' AND r.relId=$t.id AND o.createdOn<=? AND o.confirmedOn=0)")
+		$objResult = $objDatabase->prepare("SELECT * FROM $t WHERE disable='1' AND EXISTS (SELECT * FROM tl_opt_in_related r LEFT JOIN tl_opt_in o ON r.pid=o.id WHERE r.relTable='$t' AND r.relId=$t.id AND o.createdOn<=? AND o.confirmedOn=0 AND o.token LIKE 'reg-%')")
 								 ->execute(strtotime('-24 hours'));
 
 		if ($objResult->numRows < 1)
@@ -266,7 +266,7 @@ class MemberModel extends Model
 		$t = static::$strTable;
 		$objDatabase = Database::getInstance();
 
-		$objResult = $objDatabase->prepare("SELECT * FROM $t WHERE email=? AND disable='1' AND EXISTS (SELECT * FROM tl_opt_in_related r LEFT JOIN tl_opt_in o ON r.pid=o.id WHERE r.relTable='$t' AND r.relId=$t.id AND o.createdOn<=? AND o.confirmedOn=0)")
+		$objResult = $objDatabase->prepare("SELECT * FROM $t WHERE email=? AND disable='1' AND EXISTS (SELECT * FROM tl_opt_in_related r LEFT JOIN tl_opt_in o ON r.pid=o.id WHERE r.relTable='$t' AND r.relId=$t.id AND o.createdOn<=? AND o.confirmedOn=0 AND o.token LIKE 'reg-%')")
 								 ->limit(1)
 								 ->execute($strEmail, strtotime('-24 hours'));
 


### PR DESCRIPTION
Under certain circumstances Contao currently deletes members on accident. Specifically `MemberModel::findExpiredRegistrations` (and `::findExpiredRegistrationByEmail`) currently checks for _any_ expired opt-in tokens related to the member, and not just the ones from the registration. Thus, for example, if a completely different token with a `tl_member` relationship is older than 24h, `Automator::purgeRegistrations` will also delete the member.

This happened in a customer's Contao instance, where a member suddenly got deleted after disabling the member - because the member happened to use the _Lost password_ module without confirming the opt-in token at some point within the past 3 years (after the 3 years the opt-in tokens would have been removed).

### Reproduction

1. Create a _Lost password_ module and insert it on a page.
2. Create a member via the back end.
3. Disable the member.
4. Use the _Lost password_ module in the front end and enter the previously created member's email address.
5. Do _not_ confirm the sent opt-in link.
6. Manually change the created `tl_opt_in` record so that the `createdOn` field contains a timestamp that is older than 24 hours (or just set it to `0`).
7. Execute `contao:automator purgeRegistrations`.

The created member will be deleted.

This PR fixes this by adding a `token LIKE 'reg-'` check to the query so that only opt-in tokens from the registration module are taken into account.