### PR TITLE
Disallow Composer plugin from `php-http/discovery`

### DIFF
--- a/calendar-bundle/composer.json
+++ b/calendar-bundle/composer.json
@@ -64,7 +64,8 @@
     "config": {
         "allow-plugins": {
             "contao-components/installer": true,
-            "contao/manager-plugin": true
+            "contao/manager-plugin": true,
+            "php-http/discovery": false
         }
     },
     "extra": {

--- a/comments-bundle/composer.json
+++ b/comments-bundle/composer.json
@@ -51,7 +51,8 @@
     "config": {
         "allow-plugins": {
             "contao-components/installer": true,
-            "contao/manager-plugin": true
+            "contao/manager-plugin": true,
+            "php-http/discovery": false
         }
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -239,7 +239,8 @@
         "allow-plugins": {
             "bamarni/composer-bin-plugin": true,
             "contao-components/installer": true,
-            "contao/manager-plugin": true
+            "contao/manager-plugin": true,
+            "php-http/discovery": false
         }
     },
     "extra": {

--- a/core-bundle/composer.json
+++ b/core-bundle/composer.json
@@ -168,7 +168,8 @@
     "config": {
         "allow-plugins": {
             "contao-components/installer": true,
-            "contao/manager-plugin": true
+            "contao/manager-plugin": true,
+            "php-http/discovery": false
         }
     },
     "extra": {

--- a/faq-bundle/composer.json
+++ b/faq-bundle/composer.json
@@ -62,7 +62,8 @@
     "config": {
         "allow-plugins": {
             "contao-components/installer": true,
-            "contao/manager-plugin": true
+            "contao/manager-plugin": true,
+            "php-http/discovery": false
         }
     },
     "extra": {

--- a/installation-bundle/composer.json
+++ b/installation-bundle/composer.json
@@ -61,7 +61,8 @@
     "config": {
         "allow-plugins": {
             "contao-components/installer": true,
-            "contao/manager-plugin": true
+            "contao/manager-plugin": true,
+            "php-http/discovery": false
         }
     },
     "extra": {

--- a/listing-bundle/composer.json
+++ b/listing-bundle/composer.json
@@ -51,7 +51,8 @@
     "config": {
         "allow-plugins": {
             "contao-components/installer": true,
-            "contao/manager-plugin": true
+            "contao/manager-plugin": true,
+            "php-http/discovery": false
         }
     },
     "extra": {

--- a/manager-bundle/composer.json
+++ b/manager-bundle/composer.json
@@ -89,7 +89,8 @@
     "config": {
         "allow-plugins": {
             "contao-components/installer": true,
-            "contao/manager-plugin": true
+            "contao/manager-plugin": true,
+            "php-http/discovery": false
         }
     },
     "extra": {

--- a/news-bundle/composer.json
+++ b/news-bundle/composer.json
@@ -64,7 +64,8 @@
     "config": {
         "allow-plugins": {
             "contao-components/installer": true,
-            "contao/manager-plugin": true
+            "contao/manager-plugin": true,
+            "php-http/discovery": false
         }
     },
     "extra": {

--- a/newsletter-bundle/composer.json
+++ b/newsletter-bundle/composer.json
@@ -51,7 +51,8 @@
     "config": {
         "allow-plugins": {
             "contao-components/installer": true,
-            "contao/manager-plugin": true
+            "contao/manager-plugin": true,
+            "php-http/discovery": false
         }
     },
     "extra": {

--- a/test-case/composer.json
+++ b/test-case/composer.json
@@ -30,7 +30,8 @@
     },
     "config": {
         "allow-plugins": {
-            "contao-components/installer": true
+            "contao-components/installer": true,
+            "php-http/discovery": false
         }
     }
 }


### PR DESCRIPTION
See also https://github.com/php-http/discovery/pull/208, https://github.com/contao/managed-edition/pull/62 and https://github.com/contao/conflicts/pull/44.

Fixes the CI chain.