### PR TITLE
Fix file uploads erroneously overwriting existing files

### DIFF
--- a/core-bundle/src/Resources/contao/forms/FormFileUpload.php
+++ b/core-bundle/src/Resources/contao/forms/FormFileUpload.php
@@ -243,7 +243,7 @@ class FormFileUpload extends Widget implements UploadableWidgetInterface
 					{
 						$offset = 1;
 
-						$arrAll = Folder::scan($projectDir . '/' . $strUploadFolder);
+						$arrAll = Folder::scan($projectDir . '/' . $strUploadFolder, true);
 						$arrFiles = preg_grep('/^' . preg_quote($objFile->filename, '/') . '.*\.' . preg_quote($objFile->extension, '/') . '/', $arrAll);
 
 						foreach ($arrFiles as $strFile)


### PR DESCRIPTION
Fixes #5773

https://github.com/contao/contao/blob/eec5e801c7760c9a371bf0e38a18f7e160e74d95/core-bundle/src/Resources/contao/forms/FormFileUpload.php#L241-L258

The source of the issue is that our `Folder::scan` method caches the result. So if you have 3 or more file uploads and each upload field contains a file with the same name then:

1. For the first upload field `file_exists` might be `false` (if no uploads took place yet).
2. For the second upload field `Folder::scan` is executed to search for all existing files and determine the next increment number.
3. For the subsequent upload fields `Folder::scan` will return a cached result and thus not contain the file from the previous upload field. Thus it will overwrite the file from the previous upload field.

We must not cache the `Folder::scan` result.