### PR TITLE
Disable `ToggleNodesLabelListener` if not in back end

### DIFF
--- a/core-bundle/src/EventListener/DataContainer/ToggleNodesLabelListener.php
+++ b/core-bundle/src/EventListener/DataContainer/ToggleNodesLabelListener.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\EventListener\DataContainer;
 
+use Contao\CoreBundle\Routing\ScopeMatcher;
 use Contao\DataContainer;
 use Symfony\Component\HttpFoundation\Exception\SessionNotFoundException;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -20,14 +21,23 @@ use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface;
 class ToggleNodesLabelListener
 {
     private RequestStack $requestStack;
+    private ScopeMatcher $scopeMatcher;
 
-    public function __construct(RequestStack $requestStack)
+    public function __construct(RequestStack $requestStack, ScopeMatcher $scopeMatcher)
     {
         $this->requestStack = $requestStack;
+        $this->scopeMatcher = $scopeMatcher;
     }
 
     public function __invoke(string $table): void
     {
+        $request = $this->requestStack->getCurrentRequest();
+
+        // Ignore if not in the back end
+        if (!$request || !$this->scopeMatcher->isBackendRequest($request)) {
+            return;
+        }
+
         if (!isset($GLOBALS['TL_DCA'][$table]['list']['global_operations']['toggleNodes'])) {
             return;
         }

--- a/core-bundle/src/Resources/config/listener.yml
+++ b/core-bundle/src/Resources/config/listener.yml
@@ -163,6 +163,7 @@ services:
         class: Contao\CoreBundle\EventListener\DataContainer\ToggleNodesLabelListener
         arguments:
             - '@request_stack'
+            - '@contao.routing.scope_matcher'
         tags:
             - { name: contao.hook, hook: loadDataContainer }
 

--- a/core-bundle/tests/EventListener/DataContainer/ToggleNodesLabelListenerTest.php
+++ b/core-bundle/tests/EventListener/DataContainer/ToggleNodesLabelListenerTest.php
@@ -290,7 +290,7 @@ class ToggleNodesLabelListenerTest extends TestCase
         if ($scope) {
             $attributes['_scope'] = $scope;
         }
-        
+
         $request = new Request([], [], $attributes);
 
         $requestStack = $this->createMock(RequestStack::class);

--- a/core-bundle/tests/EventListener/DataContainer/ToggleNodesLabelListenerTest.php
+++ b/core-bundle/tests/EventListener/DataContainer/ToggleNodesLabelListenerTest.php
@@ -40,13 +40,13 @@ class ToggleNodesLabelListenerTest extends TestCase
 
     public function testDoesNothingIfNotBackendRequest(): void
     {
-        $requestStack = $this->mockRequestStack(null);
+        $requestStack = $this->mockRequestStack();
         $requestStack
             ->expects($this->never())
             ->method('getSession')
         ;
 
-        $listener = new ToggleNodesLabelListener($this->mockRequestStack(null), $this->mockScopeMatcher());
+        $listener = new ToggleNodesLabelListener($this->mockRequestStack(), $this->mockScopeMatcher());
         $listener('tl_foobar');
     }
 
@@ -56,7 +56,7 @@ class ToggleNodesLabelListenerTest extends TestCase
             'global_operations' => [],
         ];
 
-        $requestStack = $this->mockRequestStack();
+        $requestStack = $this->mockRequestStack('backend');
         $requestStack
             ->expects($this->never())
             ->method('getSession')
@@ -78,7 +78,7 @@ class ToggleNodesLabelListenerTest extends TestCase
             ],
         ];
 
-        $requestStack = $this->mockRequestStack();
+        $requestStack = $this->mockRequestStack('backend');
         $requestStack
             ->expects($this->never())
             ->method('getSession')
@@ -100,7 +100,7 @@ class ToggleNodesLabelListenerTest extends TestCase
             ],
         ];
 
-        $requestStack = $this->mockRequestStack();
+        $requestStack = $this->mockRequestStack('backend');
         $requestStack
             ->expects($this->never())
             ->method('getSession')
@@ -122,7 +122,7 @@ class ToggleNodesLabelListenerTest extends TestCase
             ],
         ];
 
-        $requestStack = $this->mockRequestStackWithSession(null);
+        $requestStack = $this->mockRequestStackWithSession();
 
         $listener = new ToggleNodesLabelListener($requestStack, $this->mockScopeMatcher());
         $listener('tl_foobar');
@@ -259,9 +259,9 @@ class ToggleNodesLabelListenerTest extends TestCase
     /**
      * @return RequestStack&MockObject
      */
-    private function mockRequestStackWithSession(?Session $session): RequestStack
+    private function mockRequestStackWithSession(Session $session = null): RequestStack
     {
-        $requestStack = $this->mockRequestStack();
+        $requestStack = $this->mockRequestStack('backend');
 
         if (null === $session) {
             $requestStack
@@ -283,7 +283,7 @@ class ToggleNodesLabelListenerTest extends TestCase
     /**
      * @return RequestStack&MockObject
      */
-    private function mockRequestStack(?string $scope = 'backend'): RequestStack
+    private function mockRequestStack(string $scope = null): RequestStack
     {
         $attributes = [];
 
@@ -291,12 +291,10 @@ class ToggleNodesLabelListenerTest extends TestCase
             $attributes['_scope'] = $scope;
         }
 
-        $request = new Request([], [], $attributes);
-
         $requestStack = $this->createMock(RequestStack::class);
         $requestStack
             ->method('getCurrentRequest')
-            ->willReturn($request)
+            ->willReturn(new Request([], [], $attributes))
         ;
 
         return $requestStack;

--- a/core-bundle/tests/EventListener/DataContainer/ToggleNodesLabelListenerTest.php
+++ b/core-bundle/tests/EventListener/DataContainer/ToggleNodesLabelListenerTest.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Tests\EventListener\DataContainer;
 
 use Contao\CoreBundle\EventListener\DataContainer\ToggleNodesLabelListener;
-use Contao\CoreBundle\Routing\ScopeMatcher;
 use Contao\CoreBundle\Tests\TestCase;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\HttpFoundation\Exception\SessionNotFoundException;


### PR DESCRIPTION
The `ToggleNodesLabelListener` uses the `loadDataContainer` hook to dynamically change the label of the "Expand all"/"Collapse all" label in the back end. However, the `loadDataContainer` hook can be executed in _any_ scope, not just the back end.  This can lead to the following issue:

```

  [InvalidArgumentException]
  The SessionBagInterface "contao_backend" is not registered.  


Exception trace:
  at vendor\symfony\http-foundation\Session\Storage\MockArraySessionStorage.php:189
 Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage->getBag() at vendor\symfony\http-foundation\Session\Session.php:261
 Symfony\Component\HttpFoundation\Session\Session->getBag() at vendor\contao\contao\core-bundle\src\EventListener\DataContainer\ToggleNodesLabelListener.php:63
 Contao\CoreBundle\EventListener\DataContainer\ToggleNodesLabelListener->__invoke() at vendor\contao\contao\core-bundle\src\Resources\contao\library\Contao\DcaLoader.php:133
 Contao\DcaLoader->loadDcaFiles() at vendor\contao\contao\core-bundle\src\Resources\contao\library\Contao\DcaLoader.php:75        
 Contao\DcaLoader->load() at vendor\contao\contao\core-bundle\src\Resources\contao\library\Contao\Controller.php:1448
 Contao\Controller::loadDataContainer() at vendor\contao\contao\core-bundle\src\Resources\contao\library\Contao\DcaExtractor.php:378
 Contao\DcaExtractor->createExtract() at vendor\contao\contao\core-bundle\src\Resources\contao\library\Contao\DcaExtractor.php:126 Contao\DcaExtractor->__construct() at vendor\contao\contao\core-bundle\src\Resources\contao\library\Contao\DcaExtractor.php:148  
 Contao\DcaExtractor::getInstance() at vendor\contao\contao\core-bundle\src\Resources\contao\library\Contao\Model.php:273
 Contao\Model::getUniqueFields() at vendor\contao\contao\core-bundle\src\Resources\contao\library\Contao\Model.php:1050
 Contao\Model::find() at vendor\contao\contao\core-bundle\src\Resources\contao\library\Contao\Model.php:917
 Contao\Model::findOneBy() at vendor\contao\contao\core-bundle\src\Resources\contao\models\FilesModel.php:213
 Contao\FilesModel::findByUuid() at vendor\contao\contao\core-bundle\src\Framework\Adapter.php:46
 Contao\CoreBundle\Framework\Adapter->__call() at vendor\contao\contao\core-bundle\src\Image\Studio\FigureBuilder.php:180
 Contao\CoreBundle\Image\Studio\FigureBuilder->fromUuid() at vendor\contao\contao\core-bundle\src\Image\Studio\FigureBuilder.php:273
 Contao\CoreBundle\Image\Studio\FigureBuilder->from() at vendor\contao\contao\core-bundle\src\Resources\contao\elements\ContentText.php:46
 Contao\ContentText->compile() at vendor\contao\contao\core-bundle\src\Resources\contao\elements\ContentElement.php:246
 Contao\ContentElement->generate() at vendor\contao\contao\core-bundle\src\Resources\contao\library\Contao\Controller.php:621     
 Contao\Controller::getContentElement() at vendor\contao\contao\news-bundle\src\Resources\contao\classes\News.php:226
 Contao\News->generateFiles() at vendor\contao\contao\news-bundle\src\Resources\contao\classes\News.php:82
```

To reproduce this you need to do the following:

* Create a _News feed_ for a news archive with **Export settings** set to _Full stories_.
* Edit a regular news article and insert a `text` or `image` content element and choose an image.
* Execute `contao:automator generateXmlFiles`

This issue happens because we create a mock session while rendering the content elements of the news article for the RSS feed. The mock session has no actual attribute bags - however the `ToggleNodesLabelListener` relies on the `contao_backend` session bag from the back end.

I'd argue the `ToggleNodesLabelListener` should not be executed outside the back end at all.