### PR TITLE
Add the missing option to resume crawling from CLI

### DIFF
--- a/core-bundle/src/Command/CrawlCommand.php
+++ b/core-bundle/src/Command/CrawlCommand.php
@@ -68,6 +68,7 @@ class CrawlCommand extends Command
     {
         $this
             ->addArgument('job', InputArgument::OPTIONAL, 'An optional existing job ID')
+            ->addOption('queue', 'q', InputArgument::OPTIONAL, 'Queue to use ("memory" or "doctrine")', 'memory')
             ->addOption('subscribers', 's', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'A list of subscribers to enable', $this->escargotFactory->getSubscriberNames())
             ->addOption('concurrency', 'c', InputOption::VALUE_REQUIRED, 'The number of concurrent requests that are going to be executed', '10')
             ->addOption('delay', null, InputOption::VALUE_REQUIRED, 'The number of microseconds to wait between requests (0 = throttling is disabled)', '0')
@@ -86,7 +87,6 @@ class CrawlCommand extends Command
         $io->title('Contao Crawler');
 
         $subscribers = $input->getOption('subscribers');
-        $queue = new InMemoryQueue();
         $baseUris = $this->escargotFactory->getCrawlUriCollection();
 
         if ($baseUris->containsHost('localhost')) {
@@ -94,6 +94,20 @@ class CrawlCommand extends Command
         }
 
         try {
+            switch ($input->getOption('queue')) {
+                case 'memory':
+                    $queue = new InMemoryQueue();
+                    break;
+                case 'doctrine':
+                    $queue = $this->escargotFactory->createLazyQueue();
+                    break;
+
+                default:
+                    $io->error('Only "memory" or "doctrine" are allowed for the "queue" option.');
+
+                    return 1;
+            }
+
             if ($jobId = $input->getArgument('job')) {
                 $this->escargot = $this->escargotFactory->createFromJobId($jobId, $queue, $subscribers);
             } else {
@@ -127,7 +141,12 @@ class CrawlCommand extends Command
 
         $output->writeln('');
         $output->writeln('');
-        $io->comment('Finished crawling! Find the details for each subscriber below:');
+        $io->comment(
+            sprintf(
+                '[Job ID: %s] Finished crawling! Find the details for each subscriber below:',
+                $this->escargot->getJobId()
+            )
+        );
 
         $errored = false;
 

--- a/core-bundle/src/Command/CrawlCommand.php
+++ b/core-bundle/src/Command/CrawlCommand.php
@@ -93,21 +93,21 @@ class CrawlCommand extends Command
             $io->warning('You are going to crawl localhost URIs. This is likely not desired and due to a missing domain configuration in your root page settings. You may also configure a fallback request context using "router.request_context.*" if you want to execute all CLI commands with the same request context.');
         }
 
+        switch ($input->getOption('queue')) {
+            case 'memory':
+                $queue = new InMemoryQueue();
+                break;
+            case 'doctrine':
+                $queue = $this->escargotFactory->createLazyQueue();
+                break;
+
+            default:
+                $io->error('Only "memory" or "doctrine" are allowed for the "queue" option.');
+
+                return 1;
+        }
+
         try {
-            switch ($input->getOption('queue')) {
-                case 'memory':
-                    $queue = new InMemoryQueue();
-                    break;
-                case 'doctrine':
-                    $queue = $this->escargotFactory->createLazyQueue();
-                    break;
-
-                default:
-                    $io->error('Only "memory" or "doctrine" are allowed for the "queue" option.');
-
-                    return 1;
-            }
-
             if ($jobId = $input->getArgument('job')) {
                 $this->escargot = $this->escargotFactory->createFromJobId($jobId, $queue, $subscribers);
             } else {

--- a/core-bundle/src/Command/CrawlCommand.php
+++ b/core-bundle/src/Command/CrawlCommand.php
@@ -97,6 +97,7 @@ class CrawlCommand extends Command
             case 'memory':
                 $queue = new InMemoryQueue();
                 break;
+
             case 'doctrine':
                 $queue = $this->escargotFactory->createLazyQueue();
                 break;
@@ -141,6 +142,7 @@ class CrawlCommand extends Command
 
         $output->writeln('');
         $output->writeln('');
+
         $io->comment(
             sprintf(
                 '[Job ID: %s] Finished crawling! Find the details for each subscriber below:',

--- a/core-bundle/tests/Command/CrawlCommandTest.php
+++ b/core-bundle/tests/Command/CrawlCommandTest.php
@@ -100,14 +100,14 @@ class CrawlCommandTest extends TestCase
     {
         $client = new MockHttpClient();
         $queue = new InMemoryQueue();
+        $jobId = null;
+
         $escargotFactory = $this->createMock(Factory::class);
         $escargotFactory
             ->expects($this->exactly(2))
             ->method('getCrawlUriCollection')
             ->willReturn($this->getBaseUriCollection())
         ;
-
-        $jobId = null;
 
         $escargotFactory
             ->expects($this->once())
@@ -144,6 +144,7 @@ class CrawlCommandTest extends TestCase
         $this->assertStringContainsString($expectCli, $tester->getDisplay(true));
 
         $tester->execute(['-q' => 'doctrine', 'job' => $jobId]);
+
         $this->assertStringContainsString($expectCli, $tester->getDisplay(true));
     }
 


### PR DESCRIPTION
Fixes https://github.com/contao/contao/issues/5521

When you want to be able to resume crawling from CLI, you can do so now by doing this:

1. `contao:crawl -q doctrine` (tells it to generate a new job and store the queue in doctrine, by default it does `memory` as it has always done)
2. Copy the Job ID from the output.
3. `contao:crawl -q doctrine <job-id>`


