### PR TITLE
Define line endings for templates

### DIFF
--- a/tools/ecs/config/template.php
+++ b/tools/ecs/config/template.php
@@ -32,6 +32,7 @@ return static function (ECSConfig $ecsConfig): void {
     ]);
 
     $ecsConfig->parallel();
+    $ecsConfig->lineEnding("\n");
 
     $parameters = $ecsConfig->parameters();
     $parameters->set(Option::FILE_EXTENSIONS, ['html5']);


### PR DESCRIPTION
When executing the template CS fix under Windows, the line endings are currently changed to CRLF.