### PR TITLE
Fix public folder renaming on Windows

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Files.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Files.php
@@ -219,7 +219,7 @@ class Files
 
 			$fs->rename($this->strRootDir . '/' . $strOldName, $this->strRootDir . '/' . $strNewName, true);
 		}
-		catch (IOException)
+		catch (IOException $e)
 		{
 			return false;
 		}
@@ -283,7 +283,7 @@ class Files
 		{
 			(new Filesystem())->remove($this->strRootDir . '/' . $strFile);
 		}
-		catch (IOException)
+		catch (IOException $e)
 		{
 			return false;
 		}


### PR DESCRIPTION
Currently the following error occurs if you try to rename a public folder under Windows:

```
ErrorException:
Warning: unlink(public/files/foobar): Is a directory

  at vendor\contao\contao\core-bundle\src\Resources\contao\library\Contao\Files.php:274
  at Contao\Files->delete('public/files/foobar')
     (vendor\contao\contao\core-bundle\src\Resources\contao\drivers\DC_Folder.php:2349)
  at Contao\DC_Folder->save('uuu')
     (vendor\contao\contao\core-bundle\src\Resources\contao\classes\DataContainer.php:515)
  at Contao\DataContainer->row()
     (vendor\contao\contao\core-bundle\src\Resources\contao\drivers\DC_Folder.php:1446)
```

PHP's `unlink` function apparently does not work correctly for Windows symlinks where the target does not exist anymore (since the original folder is renamed first). Symfony Filesystem's remove method handles this case though.

Additionally I removed a Windows check in `Files::rename` that got unnecessary since we are using also Symfony Filesystem to rename files and folder since #3793.

This also fixes an issue introduced by #3793: the `Files::rename` method now always returned true, even if the operation failed, which was previously not the case.