### PR TITLE
Move the favorites voter to the correct namespace

### DIFF
--- a/core-bundle/config/services.yaml
+++ b/core-bundle/config/services.yaml
@@ -778,17 +778,17 @@ services:
         tags:
             - { name: kernel.reset, method: reset }
 
-    contao.security.backend_favorites_voter:
-        class: Contao\CoreBundle\Security\Voter\BackendFavoritesVoter
-        arguments:
-            - '@security.helper'
-            - '@database_connection'
-
     contao.security.backend_user_provider:
         class: Contao\CoreBundle\Security\User\ContaoUserProvider
         arguments:
             - '@contao.framework'
             - Contao\BackendUser
+
+    contao.security.data_container.favorites_voter:
+        class: Contao\CoreBundle\Security\Voter\DataContainer\FavoritesVoter
+        arguments:
+            - '@security.helper'
+            - '@database_connection'
 
     contao.security.data_container.table_access_voter:
         class: Contao\CoreBundle\Security\Voter\DataContainer\TableAccessVoter

--- a/core-bundle/src/Security/Voter/DataContainer/FavoritesVoter.php
+++ b/core-bundle/src/Security/Voter/DataContainer/FavoritesVoter.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
  * @license LGPL-3.0-or-later
  */
 
-namespace Contao\CoreBundle\Security\Voter;
+namespace Contao\CoreBundle\Security\Voter\DataContainer;
 
 use Contao\BackendUser;
 use Contao\CoreBundle\Security\ContaoCorePermissions;
@@ -27,7 +27,7 @@ use Symfony\Component\Security\Core\Security;
 /**
  * @internal
  */
-class BackendFavoritesVoter implements VoterInterface, CacheableVoterInterface
+class FavoritesVoter implements VoterInterface, CacheableVoterInterface
 {
     public function __construct(private Security $security, private Connection $connection)
     {

--- a/core-bundle/tests/Security/Voter/DataContainer/DefaultDataContainerVoterTest.php
+++ b/core-bundle/tests/Security/Voter/DataContainer/DefaultDataContainerVoterTest.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
  * @license LGPL-3.0-or-later
  */
 
-namespace Contao\CoreBundle\Tests\Security\Voter;
+namespace Contao\CoreBundle\Tests\Security\Voter\DataContainer;
 
 use Contao\CoreBundle\Security\ContaoCorePermissions;
 use Contao\CoreBundle\Security\Voter\DataContainer\DefaultDataContainerVoter;

--- a/core-bundle/tests/Security/Voter/DataContainer/FavoritesVoterTest.php
+++ b/core-bundle/tests/Security/Voter/DataContainer/FavoritesVoterTest.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
  * @license LGPL-3.0-or-later
  */
 
-namespace Contao\CoreBundle\Tests\Security\Voter;
+namespace Contao\CoreBundle\Tests\Security\Voter\DataContainer;
 
 use Contao\BackendUser;
 use Contao\CoreBundle\Security\ContaoCorePermissions;
@@ -18,14 +18,14 @@ use Contao\CoreBundle\Security\DataContainer\CreateAction;
 use Contao\CoreBundle\Security\DataContainer\DeleteAction;
 use Contao\CoreBundle\Security\DataContainer\ReadAction;
 use Contao\CoreBundle\Security\DataContainer\UpdateAction;
-use Contao\CoreBundle\Security\Voter\BackendFavoritesVoter;
+use Contao\CoreBundle\Security\Voter\DataContainer\FavoritesVoter;
 use Contao\CoreBundle\Tests\TestCase;
 use Doctrine\DBAL\Connection;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 use Symfony\Component\Security\Core\Security;
 
-class BackendFavoritesVoterTest extends TestCase
+class FavoritesVoterTest extends TestCase
 {
     public function testVoter(): void
     {
@@ -50,7 +50,7 @@ class BackendFavoritesVoterTest extends TestCase
             )
         ;
 
-        $voter = new BackendFavoritesVoter($security, $connection);
+        $voter = new FavoritesVoter($security, $connection);
 
         $this->assertTrue($voter->supportsAttribute(ContaoCorePermissions::DC_PREFIX.'tl_favorites'));
         $this->assertTrue($voter->supportsType(CreateAction::class));

--- a/core-bundle/tests/Security/Voter/DataContainer/TableAccessVoterTest.php
+++ b/core-bundle/tests/Security/Voter/DataContainer/TableAccessVoterTest.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
  * @license LGPL-3.0-or-later
  */
 
-namespace Contao\CoreBundle\Tests\Security\Voter;
+namespace Contao\CoreBundle\Tests\Security\Voter\DataContainer;
 
 use Contao\CoreBundle\Security\ContaoCorePermissions;
 use Contao\CoreBundle\Security\DataContainer\CreateAction;


### PR DESCRIPTION
While creating new voters for Contao 5.2 I noticed these are in the wrong namespace.