### PR TITLE
Allow checking whether any field is allowed in the BackendAccessVoter

### DIFF
--- a/core-bundle/src/Security/ContaoCorePermissions.php
+++ b/core-bundle/src/Security/ContaoCorePermissions.php
@@ -106,7 +106,8 @@ final class ContaoCorePermissions
 
     /**
      * Access is granted if the current user can access the form field type.
-     * Subject must be a content element type (e.g. "hidden").
+     * Subject can be a content element type (e.g. "hidden")
+     * or NULL to check if any field type is allowed.
      */
     public const USER_CAN_ACCESS_FIELD_TYPE = 'contao_user.fields';
 

--- a/core-bundle/src/Security/ContaoCorePermissions.php
+++ b/core-bundle/src/Security/ContaoCorePermissions.php
@@ -106,8 +106,8 @@ final class ContaoCorePermissions
 
     /**
      * Access is granted if the current user can access the form field type.
-     * Subject can be a content element type (e.g. "hidden")
-     * or NULL to check if any field type is allowed.
+     * Subject can be a content element type (e.g. "hidden") or null to
+     * check if any field type is allowed.
      */
     public const USER_CAN_ACCESS_FIELD_TYPE = 'contao_user.fields';
 

--- a/core-bundle/src/Security/Voter/BackendAccessVoter.php
+++ b/core-bundle/src/Security/Voter/BackendAccessVoter.php
@@ -88,6 +88,14 @@ class BackendAccessVoter extends Voter implements ResetInterface
      */
     private function hasAccess(mixed $subject, string $field, BackendUser $user): bool
     {
+        if ($user->isAdmin) {
+            return true;
+        }
+
+        if (null === $subject) {
+            return \is_array($user->$field) && 0 !== \count($user->$field);
+        }
+
         if (!\is_scalar($subject) && !\is_array($subject)) {
             return false;
         }

--- a/core-bundle/src/Security/Voter/BackendAccessVoter.php
+++ b/core-bundle/src/Security/Voter/BackendAccessVoter.php
@@ -88,10 +88,6 @@ class BackendAccessVoter extends Voter implements ResetInterface
      */
     private function hasAccess(mixed $subject, string $field, BackendUser $user): bool
     {
-        if ($user->isAdmin) {
-            return true;
-        }
-
         if (null === $subject) {
             return \is_array($user->$field) && 0 !== \count($user->$field);
         }

--- a/core-bundle/tests/Security/Voter/BackendAccessVoterTest.php
+++ b/core-bundle/tests/Security/Voter/BackendAccessVoterTest.php
@@ -74,6 +74,30 @@ class BackendAccessVoterTest extends TestCase
         $this->assertSame(VoterInterface::ACCESS_DENIED, $this->voter->vote($token, 'foo', ['contao_user.alexf']));
     }
 
+    public function testGrantsAccessIfTheSubjectIsNullAndTheFieldIsNotEmpty(): void
+    {
+        $token = $this->createMock(TokenInterface::class);
+        $token
+            ->expects($this->once())
+            ->method('getUser')
+            ->willReturn($this->mockClassWithProperties(BackendUser::class, ['fields' => ['text', 'select']]))
+        ;
+
+        $this->assertSame(VoterInterface::ACCESS_GRANTED, $this->voter->vote($token, null, ['contao_user.fields']));
+    }
+
+    public function testDeniesAccessIfTheSubjectIsNullAndTheFieldIsEmpty(): void
+    {
+        $token = $this->createMock(TokenInterface::class);
+        $token
+            ->expects($this->once())
+            ->method('getUser')
+            ->willReturn($this->mockClassWithProperties(BackendUser::class, ['fields' => []]))
+        ;
+
+        $this->assertSame(VoterInterface::ACCESS_DENIED, $this->voter->vote($token, null, ['contao_user.fields']));
+    }
+
     public function testDeniesAccessIfTheSubjectIsNotAScalarOrArray(): void
     {
         $token = $this->createMock(TokenInterface::class);


### PR DESCRIPTION
The `BackendAccessVoter` can currently vote whether a property is allowed in a field. However, it cannot tell whether anything is allowed.

On a concrete example, `->isGranted(ContaoCorePermissions::USER_CAN_ACCESS_FIELD_TYPE, 'hidden')` would tell whether the current user can access the form field type `hidden`. However, it is not possible to check whether any field type is allowed. But this case is necessary to check whether the create action should be allowed at all, since no fields can be created if no field type is allowed.

This simply change extends the existing voter to support a `null` subject. I can now vote on _any_ permission field whether _any_ option is allowed.