### PR TITLE
Fix invalid HTML output of `DC_Table`

### DIFF
--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -4691,7 +4691,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 		}
 
 		// Make items sortable
-		if ($blnHasSorting && !($GLOBALS['TL_DCA'][$this->strTable]['config']['notSortable'] ?? null) && Input::get('act') != 'select')
+		if ($blnHasSorting)
 		{
 			$return .= '
 </ul>

--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -4700,7 +4700,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 			{
 				$return .= '
 <script>
-	Backend.makeParentViewSortable("ul_' . CURRENT_ID . '");
+  Backend.makeParentViewSortable("ul_' . CURRENT_ID . '");
 </script>';
 			}
 		}

--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -4694,10 +4694,15 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 		if ($blnHasSorting)
 		{
 			$return .= '
-</ul>
+</ul>';
+
+			if (!($GLOBALS['TL_DCA'][$this->strTable]['config']['notSortable'] ?? null) && Input::get('act') != 'select')
+			{
+				$return .= '
 <script>
-  Backend.makeParentViewSortable("ul_' . CURRENT_ID . '");
+	Backend.makeParentViewSortable("ul_' . CURRENT_ID . '");
 </script>';
+			}
 		}
 
 		$return .= ($this->strPickerFieldType == 'radio' ? '


### PR DESCRIPTION
`DC_Table` currently produces invalid HTML output in "Edit multiple" mode. Specifically a `<ul>` is never closed, since the opening tag is added under different conditions than the closing tag.

### Reproduction

1. Edit the content elements of an article.
2. Click on "Edit multiple".
3. Validate the HTML output.

<img src="https://user-images.githubusercontent.com/4970961/220998508-094e6773-2d1c-4b33-ac84-9eb106888456.png" width="380">

This PR fixes that by using the same condition for the closing tag as for the opening tag:

https://github.com/contao/contao/blob/90a747c9f4bf708256f8a530fc93e559aca3c4aa/core-bundle/src/Resources/contao/drivers/DC_Table.php#L4549-L4555
