### PR TITLE
Refresh the cache after updating metadata in the Dbafs class

### DIFF
--- a/core-bundle/src/Filesystem/Dbafs/Dbafs.php
+++ b/core-bundle/src/Filesystem/Dbafs/Dbafs.php
@@ -197,6 +197,9 @@ class Dbafs implements DbafsInterface, ResetInterface
             array_intersect_key($event->getRow(), $columnFilter),
             ['uuid' => $uuid]
         );
+
+        // Update the cache
+        $this->records[$path]['extra'] = $event->getExtraMetadata();
     }
 
     /**

--- a/core-bundle/tests/Filesystem/Dbafs/DbafsTest.php
+++ b/core-bundle/tests/Filesystem/Dbafs/DbafsTest.php
@@ -320,6 +320,11 @@ class DbafsTest extends TestCase
                 'baz' => 'complex c',
             ]
         );
+
+        // Assert internal cache is cleared and file item correctly contains new metadata
+        $item = $dbafs->getRecord('some/path');
+        $this->assertSame('complex a', $item->getExtraMetadata()['foo']);
+        $this->assertSame('complex c', $item->getExtraMetadata()['baz']);
     }
 
     public function testSetExtraMetadataThrowsOnInvalidPath(): void

--- a/core-bundle/tests/Filesystem/Dbafs/DbafsTest.php
+++ b/core-bundle/tests/Filesystem/Dbafs/DbafsTest.php
@@ -323,6 +323,7 @@ class DbafsTest extends TestCase
 
         // Assert internal cache is cleared and file item correctly contains new metadata
         $item = $dbafs->getRecord('some/path');
+
         $this->assertSame('complex a', $item->getExtraMetadata()['foo']);
         $this->assertSame('complex c', $item->getExtraMetadata()['baz']);
     }


### PR DESCRIPTION
The cache means that currently, setting and retrieving meta data right away in the same request, does not work.
Reproducer:

```php
$this->filesystem->setExtraMetadata($uuid, ['foobar' => 'foo']);
$item = $this->filesystem->get($uuid); // $item will not have 'foobar' data available
```