### PR TITLE
Add missing type hints to translation classes

### DIFF
--- a/core-bundle/src/Translation/DataCollectorTranslator.php
+++ b/core-bundle/src/Translation/DataCollectorTranslator.php
@@ -40,7 +40,7 @@ class DataCollectorTranslator extends SymfonyDataCollectorTranslator implements 
      * Gets the translation from Contao’s $GLOBALS['TL_LANG'] array if the message
      * domain starts with "contao_". The locale parameter is ignored in this case.
      */
-    public function trans($id, array $parameters = [], $domain = null, $locale = null): string
+    public function trans(string|null $id, array $parameters = [], string $domain = null, string $locale = null): string
     {
         $translated = $this->translator->trans($id, $parameters, $domain, $locale);
 
@@ -54,7 +54,7 @@ class DataCollectorTranslator extends SymfonyDataCollectorTranslator implements 
         return $translated;
     }
 
-    public function setLocale($locale): void
+    public function setLocale(string $locale): void
     {
         $this->translator->setLocale($locale);
     }
@@ -64,7 +64,7 @@ class DataCollectorTranslator extends SymfonyDataCollectorTranslator implements 
         return $this->translator->getLocale();
     }
 
-    public function getCatalogue($locale = null): MessageCatalogueInterface
+    public function getCatalogue(string $locale = null): MessageCatalogueInterface
     {
         return $this->translator->getCatalogue($locale);
     }

--- a/core-bundle/src/Translation/MessageCatalogue.php
+++ b/core-bundle/src/Translation/MessageCatalogue.php
@@ -57,7 +57,7 @@ final class MessageCatalogue implements MessageCatalogueInterface
         return $this->parent->all($domain);
     }
 
-    public function set($id, $translation, $domain = 'messages'): void
+    public function set(string $id, string $translation, string $domain = 'messages'): void
     {
         if ($this->isContaoDomain($domain)) {
             throw new LogicException(sprintf('Setting Contao translations via %s() is not yet supported', __METHOD__));
@@ -66,7 +66,7 @@ final class MessageCatalogue implements MessageCatalogueInterface
         $this->parent->set($id, $translation, $domain);
     }
 
-    public function has($id, $domain = 'messages'): bool
+    public function has(string $id, string $domain = 'messages'): bool
     {
         if (!$this->isContaoDomain($domain)) {
             return $this->parent->has($id, $domain);
@@ -75,7 +75,7 @@ final class MessageCatalogue implements MessageCatalogueInterface
         return null !== $this->loadMessage($id, $domain);
     }
 
-    public function defines($id, $domain = 'messages'): bool
+    public function defines(string $id, string $domain = 'messages'): bool
     {
         if (!$this->isContaoDomain($domain)) {
             return $this->parent->defines($id, $domain);
@@ -84,7 +84,7 @@ final class MessageCatalogue implements MessageCatalogueInterface
         return null !== $this->loadMessage($id, $domain);
     }
 
-    public function get($id, $domain = 'messages'): string
+    public function get(string $id, string $domain = 'messages'): string
     {
         if (!$this->isContaoDomain($domain)) {
             return $this->parent->get($id, $domain);
@@ -93,7 +93,7 @@ final class MessageCatalogue implements MessageCatalogueInterface
         return $this->loadMessage($id, $domain) ?? $id;
     }
 
-    public function replace($messages, $domain = 'messages'): void
+    public function replace(array $messages, string $domain = 'messages'): void
     {
         if ($this->isContaoDomain($domain)) {
             throw new LogicException(sprintf('Setting Contao translations via %s() is not yet supported', __METHOD__));
@@ -102,7 +102,7 @@ final class MessageCatalogue implements MessageCatalogueInterface
         $this->parent->replace($messages, $domain);
     }
 
-    public function add($messages, $domain = 'messages'): void
+    public function add(array $messages, string $domain = 'messages'): void
     {
         if ($this->isContaoDomain($domain)) {
             throw new LogicException(sprintf('Setting Contao translations via %s() is not yet supported', __METHOD__));

--- a/core-bundle/src/Translation/Translator.php
+++ b/core-bundle/src/Translation/Translator.php
@@ -44,7 +44,7 @@ class Translator implements TranslatorInterface, TranslatorBagInterface, LocaleA
      * Gets the translation from Contao’s $GLOBALS['TL_LANG'] array if the message
      * domain starts with "contao_".
      */
-    public function trans($id, array $parameters = [], $domain = null, $locale = null): string
+    public function trans(string $id, array $parameters = [], string $domain = null, string $locale = null): string
     {
         // Forward to the default translator
         if (null === $domain || !str_starts_with($domain, 'contao_')) {
@@ -66,7 +66,7 @@ class Translator implements TranslatorInterface, TranslatorBagInterface, LocaleA
         return $translated;
     }
 
-    public function setLocale($locale): void
+    public function setLocale(string $locale): void
     {
         $this->translator->setLocale($locale);
     }
@@ -76,7 +76,7 @@ class Translator implements TranslatorInterface, TranslatorBagInterface, LocaleA
         return $this->translator->getLocale();
     }
 
-    public function getCatalogue($locale = null): MessageCatalogue
+    public function getCatalogue(string $locale = null): MessageCatalogue
     {
         $parentCatalog = $this->translator->getCatalogue($locale);
 


### PR DESCRIPTION
This should make the CI green again for Contao 5.2

Should we backport this to 5.1? I think we can because all those types are forced by the interfaces anyways.