### PR TITLE
Fix deleting multiple records

### DIFF
--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -1531,6 +1531,11 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 
 		if (null === $currentRecord)
 		{
+			if ($blnDoNotRedirect)
+			{
+				return;
+			}
+
 			throw new NotFoundException('Cannot load record "' . $this->strTable . '.id=' . $this->intId . '".');
 		}
 


### PR DESCRIPTION
Fixes https://github.com/contao/contao/issues/5839

In `deleteAll()` we delete all the IDs that have been selected. If you select a parent and its child, you will get a `NotFoundException` for the child record. This is, because the parent already deleted the child during the first `delete()` and its respective `deleteChilds()` call. So by the time the second ID wants to be deleted in `deleteAll()`, it's already gone.

Fix is simple: We don't need to throw a `NotFoundException` at all. If a record is already gone then that's good, why would there be any error? :) 
