### PR TITLE
Fix possible undefined headline data

### DIFF
--- a/core-bundle/src/Controller/AbstractFragmentController.php
+++ b/core-bundle/src/Controller/AbstractFragmentController.php
@@ -113,8 +113,8 @@ abstract class AbstractFragmentController extends AbstractController implements 
     protected function addHeadlineToTemplate(Template $template, $headline): void
     {
         $data = StringUtil::deserialize($headline);
-        $template->headline = \is_array($data) ? $data['value'] : $data;
-        $template->hl = \is_array($data) ? $data['unit'] : 'h1';
+        $template->headline = \is_array($data) ? $data['value'] ?? '' : $data;
+        $template->hl = \is_array($data) && isset($data['unit']) ? $data['unit'] : 'h1';
     }
 
     /**


### PR DESCRIPTION
There can be "empty" serialized headline data in the database such as `a:0:{}` which lead to warnings of undefined array keys in `addHeadlineToTemplate`. It is difficult to find where these empty values are or have been written to the database. We have a lot in different content elements like `module`, `rs_columns_stop`, `rs_column_stop`, `accordionStop`, `toplink`, `html`, `divider`.

I wondered if we should even add a migration that sets all the headlines on empty values `''`. What do you think?
To fix the problem manually you can also execute the following query:
```sql
UPDATE `tl_content` SET `headline` = '' WHERE `headline` = 'a:0:{}';
```