### PR TITLE
Fix images in search results not working

### DIFF
--- a/core-bundle/src/Resources/contao/modules/ModuleSearch.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleSearch.php
@@ -311,7 +311,7 @@ class ModuleSearch extends Module
 			}
 
 			$figureBuilder = System::getContainer()->get('contao.image.studio')->createFigureBuilder();
-			$figureBuilder->fromPath($v['https://schema.org/primaryImageOfPage']['contentUrl']);
+			$figureBuilder->fromPath(ltrim($v['https://schema.org/primaryImageOfPage']['contentUrl'], '/'));
 
 			$figureMeta = new Metadata(array_filter(array(
 				Metadata::VALUE_CAPTION => $v['https://schema.org/primaryImageOfPage']['caption'] ?? null,


### PR DESCRIPTION
If you add the following to your `news_full` template for example:

```php
if ($this->figure) {
    $primaryImage = [
        '@type' => 'WebPage',
        'primaryImageOfPage' => $this->figure->getSchemaOrgData(),
    ];

    $this->addSchemaOrg($primaryImage);
}
```

the search results will still not display this image. The reason is because the meta data looks like this:

```json
{
    "@type": "WebPage",
    "primaryImageOfPage": {
        "@id": "#\/schema\/image\/a9cda59d-064e-11ec-944c-d8bbc1145c99",
        "@type": "ImageObject",
        "caption": "Dolor sit amet",
        "contentUrl": "\/files\/foobar.jpg",
        "license": "https://example.com",
        "name": "Lorem ipsum"
    }
}
```

`ModuleSearch` then uses the `contentUrl` for `FigureBuilder::fromPath`. 

https://github.com/contao/contao/blob/4ed12cfa9c39a394e9dcf7b46be6a314df9a84ce/core-bundle/src/Resources/contao/modules/ModuleSearch.php#L314

However, the `FigureBuilder` will then interpret this as an absolute path relative to the file system, rather than an absolute URL relative to the domain of the web page.

This PR fixes that by removing any preceding slash in the `contentUrl` path.

We could also change `Figure::getSchemaOrgData` so that it does not output the preceding slash for `contentUrl`. However I think the meta data output with a preceding slash is actually correct. @Toflar @m-vo wdyt?