### PR TITLE
Add the `multiple` attribute to the list and table wizards

### DIFF
--- a/core-bundle/src/Resources/contao/dca/tl_content.php
+++ b/core-bundle/src/Resources/contao/dca/tl_content.php
@@ -341,7 +341,7 @@ $GLOBALS['TL_DCA']['tl_content'] = array
 		(
 			'exclude'                 => true,
 			'inputType'               => 'listWizard',
-			'eval'                    => array('allowHtml'=>true, 'tl_class'=>'clr'),
+			'eval'                    => array('multiple'=>true, 'allowHtml'=>true, 'tl_class'=>'clr'),
 			'xlabel' => array
 			(
 				array('tl_content', 'listImportWizard')
@@ -352,7 +352,7 @@ $GLOBALS['TL_DCA']['tl_content'] = array
 		(
 			'exclude'                 => true,
 			'inputType'               => 'tableWizard',
-			'eval'                    => array('allowHtml'=>true, 'doNotSaveEmpty'=>true, 'style'=>'width:142px;height:66px'),
+			'eval'                    => array('multiple'=>true, 'allowHtml'=>true, 'doNotSaveEmpty'=>true, 'style'=>'width:142px;height:66px'),
 			'xlabel' => array
 			(
 				array('tl_content', 'tableImportWizard')


### PR DESCRIPTION
Otherwise the version compare view will not unserialize the field:

**Before**

<img width="895" alt="" src="https://user-images.githubusercontent.com/1192057/223958679-f58997cf-81e3-4c1e-b1c8-089df52cd992.png">

**After**

<img width="380" alt="" src="https://user-images.githubusercontent.com/1192057/223958755-bcf6589f-b5cc-4689-8dca-be327832f2fc.png">
