### PR TITLE
Also consider the referer when redirecting back in the login module

### DIFF
--- a/core-bundle/src/Resources/contao/modules/ModuleLogin.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleLogin.php
@@ -66,28 +66,31 @@ class ModuleLogin extends Module
 		{
 			$this->targetPath = base64_decode($request->request->get('_target_path'));
 		}
-		elseif ($this->redirectBack && $request && $request->query->has('redirect'))
+		elseif ($this->redirectBack && $request)
 		{
-			$uriSigner = System::getContainer()->get('uri_signer');
-
-			// We cannot use $request->getUri() here as we want to work with the original URI (no query string reordering)
-			if ($uriSigner->check($request->getSchemeAndHttpHost() . $request->getBaseUrl() . $request->getPathInfo() . (null !== ($qs = $request->server->get('QUERY_STRING')) ? '?' . $qs : '')))
+			if ($request->query->has('redirect'))
 			{
-				$this->targetPath = $request->query->get('redirect');
-			}
-		}
-		// Use the HTTP referer as a fallback, but only if scheme and host matches with the current request (#5860)
-		elseif ($this->redirectBack && $referer = $request->headers->get('referer'))
-		{
-			$refererUri = new Uri($referer);
-			$requestUri = new Uri($request->getUri());
+				$uriSigner = System::getContainer()->get('uri_signer');
 
-			if (
-				$refererUri->getScheme() === $requestUri->getScheme() &&
-				$refererUri->getHost() === $requestUri->getHost() &&
-				$refererUri->getPort() === $requestUri->getPort()
-			) {
-				$this->targetPath = $referer;
+				// We cannot use $request->getUri() here as we want to work with the original URI (no query string reordering)
+				if ($uriSigner->check($request->getSchemeAndHttpHost() . $request->getBaseUrl() . $request->getPathInfo() . (null !== ($qs = $request->server->get('QUERY_STRING')) ? '?' . $qs : '')))
+				{
+					$this->targetPath = $request->query->get('redirect');
+				}
+			}
+			// Use the HTTP referer as a fallback, but only if scheme and host matches with the current request (#5860)
+			elseif ($referer = $request->headers->get('referer'))
+			{
+				$refererUri = new Uri($referer);
+				$requestUri = new Uri($request->getUri());
+
+				if (
+					$refererUri->getScheme() === $requestUri->getScheme() &&
+					$refererUri->getHost() === $requestUri->getHost() &&
+					$refererUri->getPort() === $requestUri->getPort()
+				) {
+					$this->targetPath = $referer;
+				}
 			}
 		}
 

--- a/core-bundle/src/Resources/contao/modules/ModuleLogin.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleLogin.php
@@ -66,7 +66,7 @@ class ModuleLogin extends Module
 		{
 			$this->targetPath = base64_decode($request->request->get('_target_path'));
 		}
-		elseif ($this->redirectBack && $request)
+		elseif ($request && $this->redirectBack)
 		{
 			if ($request->query->has('redirect'))
 			{

--- a/core-bundle/src/Resources/contao/modules/ModuleLogin.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleLogin.php
@@ -76,7 +76,7 @@ class ModuleLogin extends Module
 			}
 		}
 		// Use the HTTP referer as a fallback, but only if scheme and host matches with the current request (#5860)
-		elseif ($this->redirectBack && ($referer = $request->headers->get('referer')) && str_starts_with($referer, $request->getSchemeAndHttpHost()))
+		elseif ($this->redirectBack && ($referer = $request->headers->get('referer')) && str_starts_with($referer, $request->getSchemeAndHttpHost().'/'))
 		{
 			$this->targetPath = $referer;
 		}

--- a/core-bundle/src/Resources/contao/modules/ModuleLogin.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleLogin.php
@@ -78,17 +78,14 @@ class ModuleLogin extends Module
 					$this->targetPath = $request->query->get('redirect');
 				}
 			}
-			// Use the HTTP referer as a fallback, but only if scheme and host matches with the current request (#5860)
 			elseif ($referer = $request->headers->get('referer'))
 			{
 				$refererUri = new Uri($referer);
 				$requestUri = new Uri($request->getUri());
 
-				if (
-					$refererUri->getScheme() === $requestUri->getScheme() &&
-					$refererUri->getHost() === $requestUri->getHost() &&
-					$refererUri->getPort() === $requestUri->getPort()
-				) {
+				// Use the HTTP referer as a fallback, but only if scheme and host matches with the current request (see #5860)
+				if ($refererUri->getScheme() === $requestUri->getScheme() && $refererUri->getHost() === $requestUri->getHost() && $refererUri->getPort() === $requestUri->getPort())
+				{
 					$this->targetPath = $referer;
 				}
 			}

--- a/core-bundle/src/Resources/contao/modules/ModuleLogin.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleLogin.php
@@ -86,8 +86,7 @@ class ModuleLogin extends Module
 				$refererUri->getScheme() === $requestUri->getScheme() &&
 				$refererUri->getHost() === $requestUri->getHost() &&
 				$refererUri->getPort() === $requestUri->getPort()
-			)
-			{
+			) {
 				$this->targetPath = $referer;
 			}
 		}

--- a/core-bundle/src/Resources/contao/modules/ModuleLogin.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleLogin.php
@@ -11,6 +11,7 @@
 namespace Contao;
 
 use Contao\CoreBundle\Security\Exception\LockedException;
+use Nyholm\Psr7\Uri;
 use Scheb\TwoFactorBundle\Security\Authentication\Exception\InvalidTwoFactorCodeException;
 use Scheb\TwoFactorBundle\Security\TwoFactor\Event\TwoFactorAuthenticationEvent;
 use Scheb\TwoFactorBundle\Security\TwoFactor\Event\TwoFactorAuthenticationEvents;
@@ -76,9 +77,19 @@ class ModuleLogin extends Module
 			}
 		}
 		// Use the HTTP referer as a fallback, but only if scheme and host matches with the current request (#5860)
-		elseif ($this->redirectBack && ($referer = $request->headers->get('referer')) && str_starts_with($referer, $request->getSchemeAndHttpHost().'/'))
+		elseif ($this->redirectBack && $referer = $request->headers->get('referer'))
 		{
-			$this->targetPath = $referer;
+			$refererUri = new Uri($referer);
+			$requestUri = new Uri($request->getUri());
+
+			if (
+				$refererUri->getScheme() === $requestUri->getScheme() &&
+				$refererUri->getHost() === $requestUri->getHost() &&
+				$refererUri->getPort() === $requestUri->getPort()
+			)
+			{
+				$this->targetPath = $referer;
+			}
 		}
 
 		return parent::generate();

--- a/core-bundle/src/Resources/contao/modules/ModuleLogin.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleLogin.php
@@ -75,6 +75,10 @@ class ModuleLogin extends Module
 				$this->targetPath = $request->query->get('redirect');
 			}
 		}
+		elseif ($this->redirectBack && ($referer = $request->headers->get('referer')) && str_starts_with($referer, $request->getSchemeAndHttpHost()))
+		{
+			$this->targetPath = $referer;
+		}
 
 		return parent::generate();
 	}

--- a/core-bundle/src/Resources/contao/modules/ModuleLogin.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleLogin.php
@@ -75,6 +75,7 @@ class ModuleLogin extends Module
 				$this->targetPath = $request->query->get('redirect');
 			}
 		}
+		// Use the HTTP referer as a fallback, but only if scheme and host matches with the current request (#5860)
 		elseif ($this->redirectBack && ($referer = $request->headers->get('referer')) && str_starts_with($referer, $request->getSchemeAndHttpHost()))
 		{
 			$this->targetPath = $referer;


### PR DESCRIPTION
Fixes #2872

This re-introduces the usage of the HTTP refer(r)er in a safe way.

This was originally removed in https://github.com/contao/contao/commit/e6e2d8df20b0144bd3d95c492421451c7a51a2ca and after that it only worked in conjunction with a 401 page that redirects to a separate login page (the redirect will contain a signed redirect parameter).