### PR TITLE
Explicitly set the legacy template in the TwoFactorController

### DIFF
--- a/core-bundle/src/Controller/FrontendModule/TwoFactorController.php
+++ b/core-bundle/src/Controller/FrontendModule/TwoFactorController.php
@@ -34,7 +34,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * @internal
  */
-#[AsFrontendModule(category: 'user')]
+#[AsFrontendModule(category: 'user', template: 'mod_two_factor')]
 class TwoFactorController extends AbstractFrontendModuleController
 {
     protected PageModel|null $pageModel = null;


### PR DESCRIPTION
Fixes #5859

The two factor controller is the only fragment controller that does not have a modern template, yet. :see_no_evil: Unfortunately, we cannot really introduce one now without breaking cases where people adjusted the legacy template (this won't work anymore then). The downside is, that we will only be able to move away from this in Contao 6. But as modules should be phased out anyways in the distant future, this might not be such a big problem…

This PR fixes the issue by manually defining the legacy template (`mod_two_factor`) in the controller, effectively overwriting the new default (`frontend_module/two_factor`).

@Kabathus Can you check if this fixes your issue?

