### PR TITLE
Create deferred image in legacy image class

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Image.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Image.php
@@ -118,6 +118,9 @@ class Image
 	{
 		trigger_deprecation('contao/core-bundle', '4.3', 'Using the "Contao\Image" class has been deprecated and will no longer work in Contao 5.0. Use the "contao.image.factory" service instead.');
 
+		// Make sure the image physically exists
+		$file->createIfDeferred();
+
 		// Check whether the file exists
 		if (!$file->exists())
 		{

--- a/core-bundle/src/Resources/contao/library/Contao/Image.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Image.php
@@ -118,7 +118,7 @@ class Image
 	{
 		trigger_deprecation('contao/core-bundle', '4.3', 'Using the "Contao\Image" class has been deprecated and will no longer work in Contao 5.0. Use the "contao.image.factory" service instead.');
 
-		// Make sure the image physically exists
+		// Make sure the image physically exists (#5873)
 		$file->createIfDeferred();
 
 		// Check whether the file exists

--- a/core-bundle/src/Resources/contao/library/Contao/Image.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Image.php
@@ -118,7 +118,7 @@ class Image
 	{
 		trigger_deprecation('contao/core-bundle', '4.3', 'Using the "Contao\Image" class has been deprecated and will no longer work in Contao 5.0. Use the "contao.image.factory" service instead.');
 
-		// Make sure the image physically exists (#5873)
+		// Create deferred images (see #5873)
 		$file->createIfDeferred();
 
 		// Check whether the file exists


### PR DESCRIPTION
If you feed the `create()` method of `contao.image.picture_factory` or `contao.image.image_factory` with an instance of `DeferredImageInterface` _and_ an `executeResize` or `getImage` hook is registered in the system, then the following error will occur currently:

```
InvalidArgumentException:
Image "assets/images/6/foobar-96343ed6.jpg" could not be found

  at vendor\contao\contao\core-bundle\src\Resources\contao\library\Contao\Image.php:133
  at Contao\Image->__construct(object(File))
     (vendor\contao\contao\core-bundle\src\Image\LegacyResizer.php:56)
  at Contao\CoreBundle\Image\LegacyResizer->resize(object(DeferredImage), object(ResizeConfiguration), object(ResizeOptions))
     (vendor\contao\image\src\PictureGenerator.php:188)
  at Contao\Image\PictureGenerator->generateSrcsetItem(object(DeferredImage), object(PictureConfigurationItem), 1.0, 'x', 300, 'jpg')
     (vendor\contao\image\src\PictureGenerator.php:110)
  at Contao\Image\PictureGenerator->generateSource(object(DeferredImage), object(PictureConfigurationItem), 'jpg', true)
     (vendor\contao\image\src\PictureGenerator.php:65)
  at Contao\Image\PictureGenerator->generate(object(DeferredImage), object(PictureConfiguration), object(ResizeOptions))
     (vendor\contao\contao\core-bundle\src\Image\PictureFactory.php:118)
```

This PR fixes that by making sure the image exists for these hooks in case it is deferred.