### PR TITLE
Remove the `q` shortcut from `contao:crawl`

### DIFF
--- a/core-bundle/src/Command/CrawlCommand.php
+++ b/core-bundle/src/Command/CrawlCommand.php
@@ -68,7 +68,7 @@ class CrawlCommand extends Command
     {
         $this
             ->addArgument('job', InputArgument::OPTIONAL, 'An optional existing job ID')
-            ->addOption('queue', 'q', InputArgument::OPTIONAL, 'Queue to use ("memory" or "doctrine")', 'memory')
+            ->addOption('queue', null, InputArgument::OPTIONAL, 'Queue to use ("memory" or "doctrine")', 'memory')
             ->addOption('subscribers', 's', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'A list of subscribers to enable', $this->escargotFactory->getSubscriberNames())
             ->addOption('concurrency', 'c', InputOption::VALUE_REQUIRED, 'The number of concurrent requests that are going to be executed', '10')
             ->addOption('delay', null, InputOption::VALUE_REQUIRED, 'The number of microseconds to wait between requests (0 = throttling is disabled)', '0')

--- a/core-bundle/tests/Command/CrawlCommandTest.php
+++ b/core-bundle/tests/Command/CrawlCommandTest.php
@@ -137,13 +137,13 @@ class CrawlCommandTest extends TestCase
         $command = new CrawlCommand($escargotFactory, new Filesystem());
 
         $tester = new CommandTester($command);
-        $tester->execute(['-q' => 'doctrine']);
+        $tester->execute(['--queue' => 'doctrine']);
 
         $expectCli = sprintf('[Job ID: %s]', $jobId);
 
         $this->assertStringContainsString($expectCli, $tester->getDisplay(true));
 
-        $tester->execute(['-q' => 'doctrine', 'job' => $jobId]);
+        $tester->execute(['--queue' => 'doctrine', 'job' => $jobId]);
 
         $this->assertStringContainsString($expectCli, $tester->getDisplay(true));
     }


### PR DESCRIPTION
In #5795 we added the `--queue` option to the `contao:crawl` command. However, we also defined the shortcut `q` for this option - which unfortunately is already used for the global `--quiet` option, thus resulting in the following error:

```
$ vendor/bin/contao-console contao:crawl --help
18:32:59 CRITICAL  [console] Error thrown while running command ""contao:crawl" --help". Message: "An option with shortcut "q" already exists." ["exception" => Symfony\Component\Console\Exception\LogicException^ { …},"command" => ""contao:crawl" --help","message" => "An option with shortcut "q" already exists."]  

  An option with shortcut "q" already exists.
```

This also breaks the Contao Manager since this error also occurs when running `list --format=json`:

```
$ vendor/bin/contao-console list --format=json
18:34:55 CRITICAL  [console] Error thrown while running command "list --format=json". Message: "An option with shortcut "q" already exists." ["exception" => Symfony\Component\Console\Exception\LogicException^ { …},"command" => "list --format=json","message" => "An option with shortcut "q" already exists."]        


  An option with shortcut "q" already exists.
```

This PR removes the shortcut from the option.

This will likely fix https://github.com/contao/contao-manager/issues/767 (and related issues with the Contao Manager).