### PR TITLE
Add psr/log 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -91,7 +91,7 @@
         "psr/cache": "^1.0 || ^2.0 || ^3.0",
         "psr/container": "^1.0",
         "psr/http-message": "^1.0",
-        "psr/log": "^1.0",
+        "psr/log": "^1.0 || ^2.0",
         "scheb/2fa-backup-code": "^6.0",
         "scheb/2fa-bundle": "^6.0",
         "scheb/2fa-trusted-device": "^6.0",

--- a/core-bundle/composer.json
+++ b/core-bundle/composer.json
@@ -89,7 +89,7 @@
         "psr/cache": "^1.0 || ^2.0 || ^3.0",
         "psr/container": "^1",
         "psr/http-message": "^1.0",
-        "psr/log": "^1.0",
+        "psr/log": "^1.0 || ^2.0",
         "scheb/2fa-backup-code": "^6.0",
         "scheb/2fa-bundle": "^6.0",
         "scheb/2fa-trusted-device": "^6.0",


### PR DESCRIPTION
Currently the `psr/log` dependency is set to `^1.0` A package I want to use has it set to `^2.0`. Unfortunately, this causes conflicts. Therefore, I propose to allow `^2.0` here as well. The signatures look identical, the basic tests ran through and the standard should also have no changes. 

Or are there any reasons for `^1.0` that I don't see? (I have also proposed this change in the `terminal42/escargot` dependency, see https://github.com/terminal42/escargot/pull/32)
