### PR TITLE
Add psr/log ^2.0 and ^3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -82,7 +82,7 @@
         "psr/cache": "^1.0 || ^2.0 || ^3.0",
         "psr/container": "^1.0",
         "psr/http-message": "^1.0",
-        "psr/log": "^1.0 || ^2.0",
+        "psr/log": "^1.0 || ^2.0 || ^3.0",
         "scheb/2fa-backup-code": "^5.8",
         "scheb/2fa-bundle": "^5.8",
         "scheb/2fa-trusted-device": "^5.8",

--- a/composer.json
+++ b/composer.json
@@ -82,7 +82,7 @@
         "psr/cache": "^1.0 || ^2.0 || ^3.0",
         "psr/container": "^1.0",
         "psr/http-message": "^1.0",
-        "psr/log": "^1.0",
+        "psr/log": "^1.0 || ^2.0",
         "scheb/2fa-backup-code": "^5.8",
         "scheb/2fa-bundle": "^5.8",
         "scheb/2fa-trusted-device": "^5.8",

--- a/core-bundle/composer.json
+++ b/core-bundle/composer.json
@@ -80,7 +80,7 @@
         "psr/cache": "^1.0 || ^2.0 || ^3.0",
         "psr/container": "^1",
         "psr/http-message": "^1.0",
-        "psr/log": "^1.0 || ^2.0",
+        "psr/log": "^1.0 || ^2.0 || ^3.0",
         "scheb/2fa-backup-code": "^5.8",
         "scheb/2fa-bundle": "^5.8",
         "scheb/2fa-trusted-device": "^5.8",

--- a/core-bundle/composer.json
+++ b/core-bundle/composer.json
@@ -80,7 +80,7 @@
         "psr/cache": "^1.0 || ^2.0 || ^3.0",
         "psr/container": "^1",
         "psr/http-message": "^1.0",
-        "psr/log": "^1.0",
+        "psr/log": "^1.0 || ^2.0",
         "scheb/2fa-backup-code": "^5.8",
         "scheb/2fa-bundle": "^5.8",
         "scheb/2fa-trusted-device": "^5.8",

--- a/installation-bundle/composer.json
+++ b/installation-bundle/composer.json
@@ -24,7 +24,7 @@
         "php": "^7.4 || ^8.0",
         "contao/core-bundle": "self.version",
         "doctrine/dbal": "^3.2",
-        "psr/log": "^1.0",
+        "psr/log": "^1.0 || ^2.0",
         "sensiolabs/ansi-to-html": "^1.1",
         "symfony/config": "^5.4",
         "symfony/console": "^5.4",

--- a/installation-bundle/composer.json
+++ b/installation-bundle/composer.json
@@ -24,7 +24,7 @@
         "php": "^7.4 || ^8.0",
         "contao/core-bundle": "self.version",
         "doctrine/dbal": "^3.2",
-        "psr/log": "^1.0 || ^2.0",
+        "psr/log": "^1.0 || ^2.0 || ^3.0",
         "sensiolabs/ansi-to-html": "^1.1",
         "symfony/config": "^5.4",
         "symfony/console": "^5.4",


### PR DESCRIPTION
Currently the `psr/log` dependency is set to `^1.0` A package I want to use has it set to `^2.0`. Unfortunately, this causes conflicts. Therefore, I propose to allow `^2.0` here as well. The signatures look identical, the basic tests ran through and the standard should also have no changes. 

Or are there any reasons for `^1.0` that I don't see? (I have also proposed this change in the `terminal42/escargot` dependency, see https://github.com/terminal42/escargot/pull/32)

see https://github.com/contao/contao/pull/5882
