### PR TITLE
Prevent foreign key check errors when deleting a parent record with children

### DIFF
--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -1545,8 +1545,8 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 			// Invalidate cache tags (no need to invalidate the parent)
 			$this->invalidateCacheTags();
 
-			// Delete the records
-			foreach ($delete as $table=>$fields)
+			// Delete the records in the reverse order to start from child records and avoid foreign key errors
+			foreach (array_reverse($delete) as $table=>$fields)
 			{
 				foreach ($fields as $v)
 				{


### PR DESCRIPTION
This pull request fixes the foreign key check errors when deleting a parent record with children. The described situation happens mostly when using the Doctrine ORM entities that have a parent-child relation defined (or OneToMany to be precise).

The problem is that Contao will first attempt to delete the parent record (e.g. tl_news_archive) and only then its children (e.g. tl_news), which will result in a SQL error:

> An exception occurred while executing a query: SQLSTATE[23000]: Integrity constraint violation: 1451 Cannot delete or update a parent row: a foreign key constraint fails (`database`.`tl_news`, CONSTRAINT `FK_6B010D645550C4ED` FOREIGN KEY (`pid`) REFERENCES `tl_news_archive` (`id`))

/cc @aschempp