### PR TITLE
Fix the incorrect formatting of numbers with decimal places

### DIFF
--- a/core-bundle/src/Resources/contao/languages/en/default.xlf
+++ b/core-bundle/src/Resources/contao/languages/en/default.xlf
@@ -21,10 +21,10 @@
         <source>Field "%s" must not be longer than %d characters!</source>
       </trans-unit>
       <trans-unit id="ERR.minval">
-        <source>Field "%s" has to be at least %d!</source>
+        <source>Field "%s" has to be at least %s!</source>
       </trans-unit>
       <trans-unit id="ERR.maxval">
-        <source>Field "%s" must not be greater than %d!</source>
+        <source>Field "%s" must not be greater than %s!</source>
       </trans-unit>
       <trans-unit id="ERR.digit">
         <source>Please enter digits only!</source>


### PR DESCRIPTION
The problem: when using the numbers with decimal places (e.g. `0.1`) in `minval` or `maxval`, the widget will incorrectly display the value in the error message by rounding it.

The solution: use a different specifier in the `sprintf()` function. See https://3v4l.org/pGJTE#v8.1.17

Before:

<img width="588" alt="CleanShot 2023-03-20 at 10 34 52" src="https://user-images.githubusercontent.com/193483/226300528-fbf09b56-ae4d-41a8-b063-c8b4a99a986c.png">

After:

<img width="592" alt="CleanShot 2023-03-20 at 10 35 10" src="https://user-images.githubusercontent.com/193483/226300604-508ccab2-5968-47a4-aef9-5c49732ee39d.png">
