### PR TITLE
Handle `null` in the `html.html.twig` template

### DIFF
--- a/core-bundle/contao/templates/_new/content_element/html.html.twig
+++ b/core-bundle/contao/templates/_new/content_element/html.html.twig
@@ -3,5 +3,5 @@
         <pre>{{ html }}</pre>
     {% endblock %}
 {% else %}
-    {% block html %}{{ html|insert_tag|raw }}{% endblock %}
+    {% block html %}{{ html|default|insert_tag|raw }}{% endblock %}
 {% endif %}


### PR DESCRIPTION
`tl_content.html` is nullable and thus the following error can occur:

```
TypeError:
Contao\CoreBundle\Twig\Runtime\InsertTagRuntime::replaceInsertTags(): Argument #1 ($text) must be of type string, null given, called in var\cache\dev\twig\d3\d3515c7374c86e1675c9bdc71501583c.php on line 95

  at vendor\contao\contao\core-bundle\src\Twig\Runtime\InsertTagRuntime.php:33
  at Contao\CoreBundle\Twig\Runtime\InsertTagRuntime->replaceInsertTags(null)
     (var\cache\dev\twig\d3\d3515c7374c86e1675c9bdc71501583c.php:95)
  at __TwigTemplate_ec9b51ce37f7fdfbb114fb5f8d792795->block_html(array('type' => 'html', 'template' => 'content_element/html', … 
```
