### PR TITLE
Fix bug in Hybrid::generate() with missing ID

### DIFF
--- a/core-bundle/contao/classes/Hybrid.php
+++ b/core-bundle/contao/classes/Hybrid.php
@@ -219,7 +219,7 @@ abstract class Hybrid extends Frontend
 	 */
 	public function generate()
 	{
-		if ($this->isHidden())
+		if ($this->isHidden() || !$this->arrData)
 		{
 			return '';
 		}


### PR DESCRIPTION
Fix for the first half of #5858