### PR TITLE
Correctly detect empty HTML when generating DCA labels

### DIFF
--- a/core-bundle/src/Resources/contao/classes/DataContainer.php
+++ b/core-bundle/src/Resources/contao/classes/DataContainer.php
@@ -1764,7 +1764,7 @@ abstract class DataContainer extends Backend
 
 		// Remove empty brackets (), [], {}, <> and empty tags from the label
 		$label = preg_replace('/\( *\) ?|\[ *] ?|{ *} ?|< *> ?/', '', $label);
-		$label = preg_replace('/<[^>]+>\s*<\/[^>]+>/', '', $label);
+		$label = preg_replace('/<[^\/][^>]+>\s*<\/[^>]+>/', '', $label);
 
 		$mode = $GLOBALS['TL_DCA'][$table]['list']['sorting']['mode'] ?? self::MODE_SORTED;
 

--- a/core-bundle/src/Resources/contao/classes/DataContainer.php
+++ b/core-bundle/src/Resources/contao/classes/DataContainer.php
@@ -1764,7 +1764,7 @@ abstract class DataContainer extends Backend
 
 		// Remove empty brackets (), [], {}, <> and empty tags from the label
 		$label = preg_replace('/\( *\) ?|\[ *] ?|{ *} ?|< *> ?/', '', $label);
-		$label = preg_replace('/<[^\/][^>]+>\s*<\/[^>]+>/', '', $label);
+		$label = preg_replace('/<[^\/!][^>]+>\s*<\/[^>]+>/', '', $label);
 
 		$mode = $GLOBALS['TL_DCA'][$table]['list']['sorting']['mode'] ?? self::MODE_SORTED;
 


### PR DESCRIPTION
Contao incorrectly removes two closing tags from the label HTML.

see https://github.com/terminal42/contao-leads/issues/139