### PR TITLE
Do not treat subdirectories of Twig namespace roots as template paths

### DIFF
--- a/core-bundle/src/Twig/Loader/TemplateLocator.php
+++ b/core-bundle/src/Twig/Loader/TemplateLocator.php
@@ -160,6 +160,12 @@ class TemplateLocator
      */
     private function expandSubdirectories(string $path): array
     {
+        $paths = [$path];
+
+        if ($this->isNamespaceRoot($path)) {
+            return $paths;
+        }
+
         $namespaceRoots = [];
 
         $finder = (new Finder())
@@ -184,8 +190,6 @@ class TemplateLocator
                 }
             )
         ;
-
-        $paths = [$path];
 
         foreach ($finder as $item) {
             $paths[] = Path::canonicalize($item->getPathname());


### PR DESCRIPTION
Same as #5941 but for Contao 4.13 (virtually the same but no tests).