### PR TITLE
Prevent double slashes in version URLs

### DIFF
--- a/core-bundle/contao/classes/Versions.php
+++ b/core-bundle/contao/classes/Versions.php
@@ -692,7 +692,7 @@ class Versions extends Controller
 					$arrRow['editUrl'] = preg_replace('/id=[^&]+/', 'id=' . $filesModel->path, $arrRow['editUrl']);
 				}
 
-				$arrRow['editUrl'] = $request->getBasePath() . '/' . preg_replace(array('/&(amp;)?popup=1/', '/&(amp;)?rt=[^&]+/'), array('', '&amp;rt=' . htmlspecialchars(System::getContainer()->get('contao.csrf.token_manager')->getDefaultTokenValue())), StringUtil::ampersand($arrRow['editUrl']));
+				$arrRow['editUrl'] = $request->getBasePath() . '/' . preg_replace(array('/&(amp;)?popup=1/', '/&(amp;)?rt=[^&]+/'), array('', '&amp;rt=' . htmlspecialchars(System::getContainer()->get('contao.csrf.token_manager')->getDefaultTokenValue())), StringUtil::ampersand(ltrim($arrRow['editUrl'], '/')));
 			}
 
 			$arrVersions[] = $arrRow;


### PR DESCRIPTION
Otherwise the link will be `<a href="//contao?do…">` and that will be treated as an absolute path instead of a relative one.