### PR TITLE
Add an optional class attribute to the figure builder

### DIFF
--- a/core-bundle/src/Image/Studio/Figure.php
+++ b/core-bundle/src/Image/Studio/Figure.php
@@ -350,6 +350,10 @@ class Figure
             $templateData['floatClass'] = " float_$floating";
         }
 
+        if (isset($this->getOptions()['attr']['class'])) {
+            $templateData['floatClass'] = ($templateData['floatClass'] ?? '').' '.$this->getOptions()['attr']['class'];
+        }
+
         // Add arbitrary template options
         return array_merge($templateData, $this->getOptions());
     }


### PR DESCRIPTION
Fixes #5367

The example for `setOptions` in the [documentation](https://docs.contao.org/dev/framework/image-processing/image-studio/#setting-options) for the Image Studio now works as described: `['attr' => ['class' => 'my_figure']]` adds the class 'my_figure' to the figure.
