### PR TITLE
Unwrap response exceptions thrown while rendering a template

### DIFF
--- a/core-bundle/config/listener.yaml
+++ b/core-bundle/config/listener.yaml
@@ -589,6 +589,12 @@ services:
         tags:
             - kernel.event_listener
 
+    contao.listener.unwrap_twig_exception:
+        class: Contao\CoreBundle\EventListener\UnwrapTwigExceptionListener
+        tags:
+            # The priority must be higher than the exception converter listener (defaults to 96)
+            - { name: kernel.event_listener, priority: 128 }
+
     contao.listener.widget.custom_rgxp:
         class: Contao\CoreBundle\EventListener\Widget\CustomRgxpListener
         arguments:

--- a/core-bundle/src/EventListener/UnwrapTwigExceptionListener.php
+++ b/core-bundle/src/EventListener/UnwrapTwigExceptionListener.php
@@ -34,12 +34,17 @@ class UnwrapTwigExceptionListener
     {
         if (
             !($throwable = $event->getThrowable()) instanceof RuntimeError ||
-            ($previous = $throwable->getPrevious()) === null ||
-            !\in_array(\get_class($previous), self::$exceptionsToUnwrap, true)
+            ($previous = $throwable->getPrevious()) === null
         ) {
             return;
         }
 
-        $event->setThrowable($previous);
+        foreach (self::$exceptionsToUnwrap as $exceptionToUnwrap) {
+            if ($previous instanceof $exceptionToUnwrap) {
+                $event->setThrowable($previous);
+
+                return;
+            }
+        }
     }
 }

--- a/core-bundle/src/EventListener/UnwrapTwigExceptionListener.php
+++ b/core-bundle/src/EventListener/UnwrapTwigExceptionListener.php
@@ -12,39 +12,27 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\EventListener;
 
-use Contao\CoreBundle\Exception\NoContentResponseException;
-use Contao\CoreBundle\Exception\RedirectResponseException;
+use Contao\CoreBundle\Exception\ResponseException;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Twig\Error\RuntimeError;
 
 class UnwrapTwigExceptionListener
 {
-    private static array $exceptionsToUnwrap = [
-        NoContentResponseException::class,
-        RedirectResponseException::class,
-    ];
-
     /**
      * If an exception is encountered while rendering a Twig template, Twig
-     * will wrap the exception in a Twig\Error\RuntimeError. For cases that we
-     * want the exception to bubble, we need to unwrap the original exception
-     * again.
+     * will wrap the exception in a Twig\Error\RuntimeError. In case of our
+     * response exceptions, we need them to bubble, though. Therefore, we
+     * unwrap them again, here.
      */
     public function __invoke(ExceptionEvent $event): void
     {
         if (
             !($throwable = $event->getThrowable()) instanceof RuntimeError ||
-            ($previous = $throwable->getPrevious()) === null
+            !is_a($previous = $throwable->getPrevious(), ResponseException::class)
         ) {
             return;
         }
 
-        foreach (self::$exceptionsToUnwrap as $exceptionToUnwrap) {
-            if ($previous instanceof $exceptionToUnwrap) {
-                $event->setThrowable($previous);
-
-                return;
-            }
-        }
+        $event->setThrowable($previous);
     }
 }

--- a/core-bundle/src/EventListener/UnwrapTwigExceptionListener.php
+++ b/core-bundle/src/EventListener/UnwrapTwigExceptionListener.php
@@ -28,7 +28,7 @@ class UnwrapTwigExceptionListener
     {
         if (
             !($throwable = $event->getThrowable()) instanceof RuntimeError ||
-            !is_a($previous = $throwable->getPrevious(), ResponseException::class)
+            !($previous = $throwable->getPrevious()) instanceof ResponseException
         ) {
             return;
         }

--- a/core-bundle/src/EventListener/UnwrapTwigExceptionListener.php
+++ b/core-bundle/src/EventListener/UnwrapTwigExceptionListener.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\EventListener;
+
+use Contao\CoreBundle\Exception\NoContentResponseException;
+use Contao\CoreBundle\Exception\RedirectResponseException;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Twig\Error\RuntimeError;
+
+class UnwrapTwigExceptionListener
+{
+    private static array $exceptionsToUnwrap = [
+        NoContentResponseException::class,
+        RedirectResponseException::class,
+    ];
+
+    /**
+     * If an exception is encountered while rendering a Twig template, Twig
+     * will wrap the exception in a Twig\Error\RuntimeError. For cases that we
+     * want the exception to bubble, we need to unwrap the original exception
+     * again.
+     */
+    public function __invoke(ExceptionEvent $event): void
+    {
+        if (
+            !($throwable = $event->getThrowable()) instanceof RuntimeError ||
+            ($previous = $throwable->getPrevious()) === null ||
+            !\in_array(\get_class($previous), self::$exceptionsToUnwrap, true)
+        ) {
+            return;
+        }
+
+        $event->setThrowable($previous);
+    }
+}

--- a/core-bundle/tests/EventListener/UnwrapTwigExceptionListenerTest.php
+++ b/core-bundle/tests/EventListener/UnwrapTwigExceptionListenerTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\EventListener;
+
+use Contao\CoreBundle\EventListener\UnwrapTwigExceptionListener;
+use Contao\CoreBundle\Exception\NoContentResponseException;
+use Contao\CoreBundle\Exception\RedirectResponseException;
+use Contao\CoreBundle\Tests\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
+use Twig\Error\RuntimeError;
+
+class UnwrapTwigExceptionListenerTest extends TestCase
+{
+    /**
+     * @dataProvider provideExceptionsToUnwrap
+     */
+    public function testUnwrapsException(\Exception $exception): void
+    {
+        $wrappedException = new RuntimeError(
+            'An exception has been thrown during rendering of a template.',
+            -1,
+            null,
+            $exception
+        );
+
+        $event = new ExceptionEvent(
+            $this->createMock(KernelInterface::class),
+            new Request(),
+            HttpKernelInterface::MAIN_REQUEST,
+            $wrappedException,
+        );
+
+        (new UnwrapTwigExceptionListener())($event);
+
+        $this->assertSame($exception, $event->getThrowable(), 'exception should be unwrapped');
+    }
+
+    public function provideExceptionsToUnwrap(): \Generator
+    {
+        yield 'NoContentResponseException' => [
+            new NoContentResponseException(),
+        ];
+
+        yield 'RedirectResponseException' => [
+            new RedirectResponseException('/foo'),
+        ];
+    }
+
+    /**
+     * @dataProvider provideThrowablesToIgnore
+     */
+    public function testIgnoresOtherExceptions(\Throwable $throwable): void
+    {
+        $event = new ExceptionEvent(
+            $this->createMock(KernelInterface::class),
+            new Request(),
+            HttpKernelInterface::MAIN_REQUEST,
+            $throwable,
+        );
+
+        (new UnwrapTwigExceptionListener())($event);
+
+        $this->assertSame($throwable, $event->getThrowable(), 'throwable should be left untouched');
+    }
+
+    public function provideThrowablesToIgnore(): \Generator
+    {
+        $exception = new \LogicException('Something went wrong.');
+
+        yield 'arbitrary exception' => [$exception];
+
+        yield 'Twig RuntimeError with arbitrary exception' => [
+            new RuntimeError(
+                'An exception has been thrown during rendering of a template.',
+                -1,
+                null,
+                $exception
+            ),
+        ];
+    }
+}


### PR DESCRIPTION
Tries to fix #5977 

Here is an attempt at fixing #5977. There is no extension point for the exception handling in Twig (it happens in the `Template` base class), but we can convert the exception in a kernel exception listener. It's not ideal but the effort to do so, is also very minimal.

If we agree on the concept - which exceptions should we "unwrap"?

/cc @qzminski 