### PR TITLE
Use the title instead of the filename in the download component

### DIFF
--- a/core-bundle/contao/templates/_new/component/_download.html.twig
+++ b/core-bundle/contao/templates/_new/component/_download.html.twig
@@ -35,7 +35,7 @@
 
     {# Derive title and link text if not explicitly set #}
     {% set title = download.title|default(download.file.extraMetadata['metadata'].default.title|default(download.file.name)) %}
-    {% set text = download.text|default(download.file.name) %}
+    {% set text = download.text|default(title) %}
 
     {% block download_link %}
         {% set dowload_link_attributes = attrs(dowload.link_attributes|default)

--- a/core-bundle/tests/Controller/ContentElement/DownloadsControllerTest.php
+++ b/core-bundle/tests/Controller/ContentElement/DownloadsControllerTest.php
@@ -37,7 +37,7 @@ class DownloadsControllerTest extends ContentElementTestCase
 
         $expectedOutput = <<<'HTML'
             <div class="download-element ext-jpg content-download">
-                <a href="https://example.com/files/image1.jpg" title="translated(contao_default:MSC.download[image1 title])" type="image/jpg">image1.jpg</a>
+                <a href="https://example.com/files/image1.jpg" title="translated(contao_default:MSC.download[image1 title])" type="image/jpg">image1 title</a>
             </div>
             HTML;
 
@@ -111,7 +111,7 @@ class DownloadsControllerTest extends ContentElementTestCase
             <div class="content-downloads">
                 <ul>
                     <li class="download-element ext-jpg">
-                        <a href="https://example.com/files/image1.jpg" title="translated(contao_default:MSC.download[image1 title])" type="image/jpg">image1.jpg</a>
+                        <a href="https://example.com/files/image1.jpg" title="translated(contao_default:MSC.download[image1 title])" type="image/jpg">image1 title</a>
                     </li>
                     <li class="download-element ext-jpg">
                         <a href="https://example.com/files/image2.jpg" title="translated(contao_default:MSC.download[image2.jpg])">image2.jpg</a>


### PR DESCRIPTION
Fixes #5975

Although this can be easily adjusted in the template, the change wasn't intended. Now, if a text wasn't explicitly specified for an element, we default to the title. 

So a with a derived title `Lunch Menu`, you'll get something like `<a href="…" title="Download Lunch Menu">Lunch Menu</a>` instead of `<a href="…" title="Download Lunch Menu">lunch_menu_final_version1(1).pdf</a>`.

Note, that the file name will still be visible when downloading and should therefore be part of the editorial work.