### PR TITLE
Allow flysystem-bundle ^3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -69,7 +69,7 @@
         "lcobucci/jwt": "^4.0",
         "league/commonmark": "^2.2",
         "league/flysystem": "^2.4 || ^3.0",
-        "league/flysystem-bundle": "^2.0",
+        "league/flysystem-bundle": "^2.0 || ^3.0",
         "matthiasmullie/minify": "^1.3",
         "monolog/monolog": "^2.0",
         "nelmio/cors-bundle": "^2.0.1",

--- a/core-bundle/composer.json
+++ b/core-bundle/composer.json
@@ -68,7 +68,7 @@
         "lcobucci/jwt": "^4.0",
         "league/commonmark": "^2.2",
         "league/flysystem": "^2.4 || ^3.0",
-        "league/flysystem-bundle": "^2.0",
+        "league/flysystem-bundle": "^2.0 || ^3.0",
         "matthiasmullie/minify": "^1.3",
         "monolog/monolog": "^2.0",
         "nelmio/cors-bundle": "^2.0.1",


### PR DESCRIPTION
We should also allow version 3 of flysystem-bundle as we otherwise do not get any new features.
There are no BC breaks. See https://github.com/thephpleague/flysystem-bundle/releases/tag/3.0.0

> This release drops support for End-Of-Life versions of PHP, Symfony and Flysystem. No other backward incompatible changes have been introduced.