### PR TITLE
Hide fields that are not to be displayed in the undo details

### DIFF
--- a/core-bundle/contao/dca/tl_undo.php
+++ b/core-bundle/contao/dca/tl_undo.php
@@ -181,7 +181,7 @@ class tl_undo extends Backend
 			foreach ($arrTableData as $arrRow)
 			{
 				// Unset fields that are not to be displayed
-				foreach (($GLOBALS['TL_DCA'][$strTable]['fields'] ?? []) as $key=>$config)
+				foreach (($GLOBALS['TL_DCA'][$strTable]['fields'] ?? array()) as $key=>$config)
 				{
 					if ($config['eval']['doNotShow'] ?? false)
 					{

--- a/core-bundle/contao/dca/tl_undo.php
+++ b/core-bundle/contao/dca/tl_undo.php
@@ -180,6 +180,15 @@ class tl_undo extends Backend
 
 			foreach ($arrTableData as $arrRow)
 			{
+				// Unset fields that are not to be displayed
+				foreach (($GLOBALS['TL_DCA'][$strTable]['fields'] ?? []) as $key=>$config)
+				{
+					if ($config['eval']['doNotShow'] ?? false)
+					{
+						unset($arrRow[$key]);
+					}
+				}
+
 				$arrBuffer = array();
 
 				foreach ($arrRow as $i=>$v)


### PR DESCRIPTION
Especially nested arrays like `tl_member.session` cannot be displayed properly and therefore have the `doNotShow` flag. Now the undo details handle the flag, too.