### PR TITLE
Fix the type hint in the Hybrid class

### DIFF
--- a/core-bundle/src/Resources/contao/classes/Hybrid.php
+++ b/core-bundle/src/Resources/contao/classes/Hybrid.php
@@ -75,8 +75,8 @@ abstract class Hybrid extends Frontend
 	/**
 	 * Initialize the object
 	 *
-	 * @param ContentModel|ModuleModel $objElement
-	 * @param string                   $strColumn
+	 * @param ContentModel|FormModel|ModuleModel $objElement
+	 * @param string                             $strColumn
 	 */
 	public function __construct($objElement, $strColumn='main')
 	{
@@ -85,7 +85,7 @@ abstract class Hybrid extends Frontend
 		// Store the parent element (see #4556)
 		if ($objElement instanceof Model || $objElement instanceof Collection)
 		{
-			/** @var ContentModel|ModuleModel $objModel */
+			/** @var ContentModel|FormModel|ModuleModel $objModel */
 			$objModel = $objElement;
 
 			if ($objModel instanceof Collection)


### PR DESCRIPTION
Because you obviously want to pass a `FormModel` when you have `new Form($model)`.