### PR TITLE
Disable double encoding in the `HtmlAttributes` class

### DIFF
--- a/core-bundle/src/String/HtmlAttributes.php
+++ b/core-bundle/src/String/HtmlAttributes.php
@@ -405,7 +405,8 @@ class HtmlAttributes implements \Stringable, \JsonSerializable, \IteratorAggrega
             throw new \RuntimeException(sprintf('The value of property "%s" is not a valid UTF-8 string.', $name));
         }
 
-        $value = htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE);
+        // TODO: Enable double_encoding once Contao switches from input to output encoding.
+        $value = htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE, null, false);
 
         return str_replace(['{{', '}}'], ['&#123;&#123;', '&#125;&#125;'], $value);
     }

--- a/core-bundle/tests/String/HtmlAttributesTest.php
+++ b/core-bundle/tests/String/HtmlAttributesTest.php
@@ -511,7 +511,7 @@ class HtmlAttributesTest extends TestCase
             'property-without-value' => null,
         ]);
 
-        $expectedString = 'a="A B C" b="&#123;&#123;b&#125;&#125;" c="foo&amp;bar" d="foo&amp;amp;bar" property-without-value';
+        $expectedString = 'a="A B C" b="&#123;&#123;b&#125;&#125;" c="foo&amp;bar" d="foo&amp;bar" property-without-value';
 
         $this->assertSame(" $expectedString", $attributes->__toString());
         $this->assertSame(" $expectedString", $attributes->toString());


### PR DESCRIPTION
Fixes #5976
