### PR TITLE
Add a double encoding setting to the HtmlAttributes class

### DIFF
--- a/core-bundle/src/String/HtmlAttributes.php
+++ b/core-bundle/src/String/HtmlAttributes.php
@@ -26,8 +26,11 @@ class HtmlAttributes implements \Stringable, \JsonSerializable, \IteratorAggrega
     /**
      * @param iterable<string, string|int|bool|\Stringable|null>|string|self|null $attributes
      */
-    public function __construct(self|iterable|string|null $attributes = null)
-    {
+    public function __construct(
+        self|iterable|string|null $attributes = null,
+        // TODO: Enable double_encoding once Contao switches from input to output encoding.
+        private bool $doubleEncoding = false,
+    ) {
         $this->mergeWith($attributes);
     }
 
@@ -405,7 +408,7 @@ class HtmlAttributes implements \Stringable, \JsonSerializable, \IteratorAggrega
             throw new \RuntimeException(sprintf('The value of property "%s" is not a valid UTF-8 string.', $name));
         }
 
-        $value = htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE);
+        $value = htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE, null, $this->doubleEncoding);
 
         return str_replace(['{{', '}}'], ['&#123;&#123;', '&#125;&#125;'], $value);
     }

--- a/core-bundle/src/String/HtmlAttributes.php
+++ b/core-bundle/src/String/HtmlAttributes.php
@@ -23,14 +23,13 @@ class HtmlAttributes implements \Stringable, \JsonSerializable, \IteratorAggrega
      */
     private array $attributes = [];
 
+    private bool $doubleEncoding = false;
+
     /**
      * @param iterable<string, string|int|bool|\Stringable|null>|string|self|null $attributes
      */
-    public function __construct(
-        self|iterable|string|null $attributes = null,
-        // TODO: Enable double_encoding once Contao switches from input to output encoding.
-        private bool $doubleEncoding = false,
-    ) {
+    public function __construct(self|iterable|string|null $attributes = null)
+    {
         $this->mergeWith($attributes);
     }
 
@@ -292,6 +291,13 @@ class HtmlAttributes implements \Stringable, \JsonSerializable, \IteratorAggrega
         if (empty($this->attributes['style'])) {
             unset($this->attributes['style']);
         }
+
+        return $this;
+    }
+
+    public function setDoubleEncoding(bool $doubleEncoding): self
+    {
+        $this->doubleEncoding = $doubleEncoding;
 
         return $this;
     }

--- a/core-bundle/tests/String/HtmlAttributesTest.php
+++ b/core-bundle/tests/String/HtmlAttributesTest.php
@@ -518,7 +518,7 @@ class HtmlAttributesTest extends TestCase
         $this->assertSame($expectedString, $attributes->toString(false));
 
         // With double encoding
-        $attributes = new HtmlAttributes($attributes, true);
+        $this->assertSame($attributes, $attributes->setDoubleEncoding(true));
         $expectedString = 'a="A B C" b="&#123;&#123;b&#125;&#125;" c="foo&amp;bar" d="foo&amp;amp;bar" property-without-value';
 
         $this->assertSame(" $expectedString", $attributes->__toString());

--- a/core-bundle/tests/String/HtmlAttributesTest.php
+++ b/core-bundle/tests/String/HtmlAttributesTest.php
@@ -511,6 +511,14 @@ class HtmlAttributesTest extends TestCase
             'property-without-value' => null,
         ]);
 
+        $expectedString = 'a="A B C" b="&#123;&#123;b&#125;&#125;" c="foo&amp;bar" d="foo&amp;bar" property-without-value';
+
+        $this->assertSame(" $expectedString", $attributes->__toString());
+        $this->assertSame(" $expectedString", $attributes->toString());
+        $this->assertSame($expectedString, $attributes->toString(false));
+
+        // With double encoding
+        $attributes = new HtmlAttributes($attributes, true);
         $expectedString = 'a="A B C" b="&#123;&#123;b&#125;&#125;" c="foo&amp;bar" d="foo&amp;amp;bar" property-without-value';
 
         $this->assertSame(" $expectedString", $attributes->__toString());


### PR DESCRIPTION
Alternative/followup to https://github.com/contao/contao/pull/5997

This would make it possible to explicitly enable double encoding for places where you need it.