### PR TITLE
Add a method to retrieve the original route path

### DIFF
--- a/core-bundle/src/Routing/Page/PageRoute.php
+++ b/core-bundle/src/Routing/Page/PageRoute.php
@@ -100,6 +100,11 @@ class PageRoute extends Route implements RouteObjectInterface
         return $path.$this->getUrlSuffix();
     }
 
+    public function getOriginalPath(): string
+    {
+        return parent::getPath();
+    }
+
     public function getUrlPrefix(): string
     {
         return $this->urlPrefix;


### PR DESCRIPTION
While building some custom routing behaviour, I noticed that our `PageRoute::getPath()` returns the route path with url prefix and suffix. However, this makes it impossible to manipulate the original path. `PageRoute::setPath()` changes only the path but not the prefix and suffix. Now at least one could do `PageRoute::setPath(/* ... */ PageRoute::getOriginalPath() /* ... */)`