### PR TITLE
Fix backtracking in insert tags regular expressions

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/InsertTags.php
+++ b/core-bundle/src/Resources/contao/library/Contao/InsertTags.php
@@ -129,10 +129,10 @@ class InsertTags extends Controller
 		$strRegExpStart = '{{'           // Starts with two opening curly braces
 			. '('                        // Match the contents of the tag
 				. '[a-zA-Z0-9\x80-\xFF]' // The first letter must not be a reserved character of Twig, Mustache or similar template engines (see #805)
-				. '(?:[^{}]|'            // Match any character not curly brace or a nested insert tag
+				. '(?>[^{}]|'            // Match any character not curly brace or a nested insert tag
 		;
 
-		$strRegExpEnd = ')*)}}';         // Ends with two closing curly braces
+		$strRegExpEnd = ')*+)}}';        // Ends with two closing curly braces
 
 		$tags = preg_split(
 			'(' . $strRegExpStart . str_repeat('{{(?:' . substr($strRegExpStart, 3), 9) . str_repeat($strRegExpEnd, 10) . ')',
@@ -140,6 +140,11 @@ class InsertTags extends Controller
 			-1,
 			PREG_SPLIT_DELIM_CAPTURE
 		);
+
+		if ($tags === false)
+		{
+			throw new \RuntimeException(sprintf('PCRE: %s', preg_last_error_msg()), preg_last_error());
+		}
 
 		if (\count($tags) < 2)
 		{

--- a/core-bundle/tests/Contao/InsertTagsTest.php
+++ b/core-bundle/tests/Contao/InsertTagsTest.php
@@ -957,7 +957,6 @@ class InsertTagsTest extends TestCase
         InsertTags::reset();
 
         $insertTagParser = new InsertTagParser($this->mockContaoFramework());
-
         $insertTag = '{{'.str_repeat('a', (int) \ini_get('pcre.backtrack_limit') * 2).'::replaced}}';
 
         $this->assertSame(
@@ -971,14 +970,13 @@ class InsertTagsTest extends TestCase
         InsertTags::reset();
 
         $insertTagParser = new InsertTagParser($this->mockContaoFramework());
-
         $insertTag = '{{'.str_repeat('a', 1024).'::replaced}}';
-
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('PCRE: Backtrack limit exhausted');
 
         $backtrackLimit = \ini_get('pcre.backtrack_limit');
         ini_set('pcre.backtrack_limit', '0');
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('PCRE: Backtrack limit exhausted');
 
         try {
             $insertTagParser->replaceInline($insertTag);

--- a/core-bundle/tests/Contao/InsertTagsTest.php
+++ b/core-bundle/tests/Contao/InsertTagsTest.php
@@ -978,7 +978,7 @@ class InsertTagsTest extends TestCase
         $this->expectExceptionMessage('PCRE: Backtrack limit exhausted');
 
         $backtrackLimit = \ini_get('pcre.backtrack_limit');
-        ini_set('pcre.backtrack_limit', 0);
+        ini_set('pcre.backtrack_limit', '0');
 
         try {
             $insertTagParser->replaceInline($insertTag);


### PR DESCRIPTION
With these changes the configured `pcre.backtrack_limit` should not be a problem anymore for replacing insert tags, see #6011.

@LBeckX it would be great if you could confirm that these changes fix your issue (using your old setting for `pcre.backtrack_limit`).