### PR TITLE
Load the page details before manipulating root page data

### DIFF
--- a/core-bundle/src/EventListener/DataContainer/PageUrlListener.php
+++ b/core-bundle/src/EventListener/DataContainer/PageUrlListener.php
@@ -190,6 +190,7 @@ class PageUrlListener
         foreach ($pages as $page) {
             if ($page->alias && $this->pageRegistry->isRoutable($page)) {
                 // Inherit root page settings from post data
+                $page->loadDetails();
                 $page->domain = $rootPage->domain;
                 $page->urlPrefix = $rootPage->urlPrefix;
                 $page->urlSuffix = $rootPage->urlSuffix;
@@ -240,6 +241,7 @@ class PageUrlListener
 
             // If page has the same root, inherit root page settings from post data
             if ($currentPage->rootId === $aliasPage->rootId) {
+                $aliasPage->loadDetails();
                 $aliasPage->domain = $currentPage->domain;
                 $aliasPage->urlPrefix = $currentPage->urlPrefix;
                 $aliasPage->urlSuffix = $currentPage->urlSuffix;


### PR DESCRIPTION
While updating a website from Contao 4.9 to 4.13 with multiple root pages, I had issues changing the route prefix once `legacy_routing` was disabled. It always told me a change in prefix or suffix would result in a conflict with an existing page, whos URL was not reflecting the just-changed prefix.

If page details are not loaded when changing the settings inherited from the root page, the changes will be overridden when page details are automatically loaded by the routing system.