### PR TITLE
Fix exception 'implode()_ Argument #1 ($pieces) must be of type array…

### DIFF
--- a/core-bundle/src/Resources/contao/classes/DataContainer.php
+++ b/core-bundle/src/Resources/contao/classes/DataContainer.php
@@ -441,7 +441,7 @@ abstract class DataContainer extends Backend
 			$key = (Input::get('act') == 'editAll') ? 'FORM_FIELDS_' . $suffix : 'FORM_FIELDS';
 
 			// Calculate the current palette
-			$postPaletteFields = implode(',', Input::post($key));
+			$postPaletteFields = is_array(Input::post($key)) ? implode(',', Input::post($key)) : Input::post($key);
 			$postPaletteFields = array_unique(StringUtil::trimsplit('[,;]', $postPaletteFields));
 
 			// Compile the palette if there is none

--- a/core-bundle/src/Resources/contao/classes/DataContainer.php
+++ b/core-bundle/src/Resources/contao/classes/DataContainer.php
@@ -441,7 +441,7 @@ abstract class DataContainer extends Backend
 			$key = (Input::get('act') == 'editAll') ? 'FORM_FIELDS_' . $suffix : 'FORM_FIELDS';
 
 			// Calculate the current palette
-			$postPaletteFields = is_array(Input::post($key)) ? implode(',', Input::post($key)) : Input::post($key);
+			$postPaletteFields = implode(',', (array) Input::post($key));
 			$postPaletteFields = array_unique(StringUtil::trimsplit('[,;]', $postPaletteFields));
 
 			// Compile the palette if there is none


### PR DESCRIPTION
This is a patch as part of a patch set that addresses several issues we have encountered in various customer projects.

The problem addressed here can occur when attributes of several modules are edited in bulk in the backend.