### PR TITLE
Fix "Warning Undefined array key reference"

### DIFF
--- a/core-bundle/src/Resources/contao/classes/DataContainer.php
+++ b/core-bundle/src/Resources/contao/classes/DataContainer.php
@@ -1730,7 +1730,9 @@ abstract class DataContainer extends Backend
 					foreach ($row_v as $option)
 					{
 						if ($GLOBALS['TL_DCA'][$table]['fields'][$v]['reference'] ?? null)
+						{
 							$args_k[] = $GLOBALS['TL_DCA'][$table]['fields'][$v]['reference'][$option] ?? $option;
+						}
 					}
 
 					$args[$k] = implode(', ', $args_k);

--- a/core-bundle/src/Resources/contao/classes/DataContainer.php
+++ b/core-bundle/src/Resources/contao/classes/DataContainer.php
@@ -1729,7 +1729,8 @@ abstract class DataContainer extends Backend
 
 					foreach ($row_v as $option)
 					{
-						$args_k[] = $GLOBALS['TL_DCA'][$table]['fields'][$v]['reference'][$option] ?? $option;
+						if ($GLOBALS['TL_DCA'][$table]['fields'][$v]['reference'] ?? null)
+							$args_k[] = $GLOBALS['TL_DCA'][$table]['fields'][$v]['reference'][$option] ?? $option;
 					}
 
 					$args[$k] = implode(', ', $args_k);


### PR DESCRIPTION
This is a patch as part of a patch set that addresses several issues we have encountered in various customer projects.

The problem addressed here can occur when specific Isotope products are modified.
