### PR TITLE
Pass the ID to `getCurrentRecord()` in "override all" mode

### DIFF
--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -2908,7 +2908,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 					{
 						try
 						{
-							$currentRecord = $this->getCurrentRecord();
+							$currentRecord = $this->getCurrentRecord($id);
 
 							if ($currentRecord === null)
 							{


### PR DESCRIPTION
As we do in "edit all" mode, because `$this->intId = $id` is only set after we call `$this->getCurrentRecord()`.

https://github.com/contao/contao/blob/d04f01103c6779e04e3ca3f9121db4e33ebeae5f/core-bundle/contao/drivers/DC_Table.php#L2409
