### PR TITLE
Fix Warning: Undefined array key "pages"

### DIFF
--- a/core-bundle/src/Resources/contao/classes/Versions.php
+++ b/core-bundle/src/Resources/contao/classes/Versions.php
@@ -517,12 +517,12 @@ class Versions extends Controller
 							else
 							{
 								// Convert serialized arrays into strings
-								if (!\is_array($to[$k]) && \is_array(($tmp = StringUtil::deserialize($to[$k]))))
+								if (!\is_array($to[$k] ?? null) && \is_array(($tmp = StringUtil::deserialize($to[$k] ?? null))))
 								{
 									$to[$k] = $this->implodeRecursive($tmp, $blnIsBinary);
 								}
 
-								if (!\is_array($from[$k]) && \is_array(($tmp = StringUtil::deserialize($from[$k]))))
+								if (!\is_array($from[$k] ?? null) && \is_array(($tmp = StringUtil::deserialize($from[$k] ?? null))))
 								{
 									$from[$k] = $this->implodeRecursive($tmp, $blnIsBinary);
 								}


### PR DESCRIPTION
This is a patch as part of a patch set that addresses several issues we have encountered in various customer projects.

The problem addressed here can occur when specific Isotope products are modified.
