### PR TITLE
Do not mark as copy more than once

### DIFF
--- a/core-bundle/src/Resources/contao/classes/DataContainer.php
+++ b/core-bundle/src/Resources/contao/classes/DataContainer.php
@@ -1821,7 +1821,7 @@ abstract class DataContainer extends Backend
 	protected function markAsCopy(string $label, string $value): string
 	{
 		// Do not mark as copy more than once (see #6058)
-		if (preg_match('/' . str_replace('%s', '', preg_quote($label, '/')) . '/', StringUtil::decodeEntities($value)))
+		if (preg_match('/' . preg_quote(sprintf($label, ''), '/') . '/', StringUtil::decodeEntities($value)))
 		{
 			return $value;
 		}

--- a/core-bundle/src/Resources/contao/classes/DataContainer.php
+++ b/core-bundle/src/Resources/contao/classes/DataContainer.php
@@ -1817,6 +1817,17 @@ abstract class DataContainer extends Backend
 
 		return $label;
 	}
+
+	protected function markAsCopy(string $label, string $value): string
+	{
+		// Do not mark as copy more than once (see #6058)
+		if (preg_match('/' . str_replace('%s', '', preg_quote($label, '/')) . '/', StringUtil::decodeEntities($value)))
+		{
+			return $value;
+		}
+
+		return sprintf($label, $value);
+	}
 }
 
 class_alias(DataContainer::class, 'DataContainer');

--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -911,13 +911,13 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 
 					if (!empty($value['value']))
 					{
-						$value['value'] = sprintf($GLOBALS['TL_LANG']['MSC']['copyOf'], $value['value']);
+						$value['value'] = $this->markAsCopy($GLOBALS['TL_LANG']['MSC']['copyOf'], $value['value']);
 						$this->set[$strKey] = serialize($value);
 					}
 				}
 				elseif (!empty($this->set[$strKey]))
 				{
-					$this->set[$strKey] = sprintf($GLOBALS['TL_LANG']['MSC']['copyOf'], $this->set[$strKey]);
+					$this->set[$strKey] = $this->markAsCopy($GLOBALS['TL_LANG']['MSC']['copyOf'], $this->set[$strKey]);
 				}
 			}
 


### PR DESCRIPTION
Imho there is not much value in having headlines and form field labels like

* Original
* Original (copy)
* Original (copy) (copy)
* Original (copy) (copy) (copy)

if you use "Save and duplicate" more than once or if you manually copy the copy etc.

This PR would make it so the suffix is only added once. This would alleviate the issue in #6058.