### PR TITLE
Do not filter folders named `0` in the file manager

### DIFF
--- a/core-bundle/src/Resources/contao/dca/tl_files.php
+++ b/core-bundle/src/Resources/contao/dca/tl_files.php
@@ -613,7 +613,7 @@ class tl_files extends Backend
 	public function checkFilename($varValue, DataContainer $dc)
 	{
 		$varValue = str_replace('"', '', $varValue);
-		$chunks = array_filter(explode('/', $varValue));
+		$chunks = array_filter(explode('/', $varValue), 'strlen');
 
 		if (count($chunks) < 1)
 		{

--- a/core-bundle/src/Resources/contao/library/Contao/Dbafs.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Dbafs.php
@@ -84,7 +84,7 @@ class Dbafs
 		}
 
 		$arrPaths    = array();
-		$arrChunks   = array_filter(explode('/', Path::makeRelative($strResource, $uploadPath)));
+		$arrChunks   = array_filter(explode('/', Path::makeRelative($strResource, $uploadPath)), 'strlen');
 		$strPath     = $uploadPath;
 		$arrPids     = array($strPath => null);
 		$arrUpdate   = array($strResource);
@@ -445,7 +445,7 @@ class Dbafs
 			self::validateUtf8Path($strResource);
 
 			$strResource = Path::normalize($strResource);
-			$arrChunks   = array_filter(explode('/', Path::makeRelative($strResource, $uploadPath)));
+			$arrChunks   = array_filter(explode('/', Path::makeRelative($strResource, $uploadPath)), 'strlen');
 			$strPath     = $uploadPath;
 
 			// Do not check files


### PR DESCRIPTION
Fixes #5550

