### PR TITLE
Use real path for `.env.local`

### DIFF
--- a/manager-bundle/src/Command/GenerateAppSecretCommand.php
+++ b/manager-bundle/src/Command/GenerateAppSecretCommand.php
@@ -77,7 +77,10 @@ class GenerateAppSecretCommand extends Command
 
         $filesystem = new Filesystem();
 
-        $dotenv = new DotenvDumper(Path::join($this->projectDir, '.env.local'), $filesystem);
+        $dotenvPath = Path::join($this->projectDir, '.env.local');
+        $dotenvPath = realpath($dotenvPath) ?: $dotenvPath;
+
+        $dotenv = new DotenvDumper($dotenvPath, $filesystem);
         $dotenv->setParameter('APP_SECRET', bin2hex(random_bytes($length)));
         $dotenv->dump();
 


### PR DESCRIPTION
Fixes #6065 

Same as https://github.com/contao/contao/pull/6066 for Contao 4.9.