### PR TITLE
Make the support link language-agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,4 +140,4 @@ Visit the [support page][3] to learn about the available support options.
 
 [1]: https://contao.org
 [2]: https://github.com/contao/managed-edition
-[3]: https://contao.org/en/support.html
+[3]: https://to.contao.org/support

--- a/calendar-bundle/README.md
+++ b/calendar-bundle/README.md
@@ -18,4 +18,4 @@ Contao is licensed under the terms of the LGPLv3.
 Visit the [support page][2] to learn about the available support options.
 
 [1]: https://contao.org
-[2]: https://contao.org/en/support.html
+[2]: https://to.contao.org/support

--- a/comments-bundle/README.md
+++ b/comments-bundle/README.md
@@ -18,4 +18,4 @@ Contao is licensed under the terms of the LGPLv3.
 Visit the [support page][2] to learn about the available support options.
 
 [1]: https://contao.org
-[2]: https://contao.org/en/support.html
+[2]: https://to.contao.org/support

--- a/core-bundle/README.md
+++ b/core-bundle/README.md
@@ -139,6 +139,6 @@ Visit the [support page][5] to learn about the available support options.
 [2]: https://symfony.com
 [3]: https://github.com/contao/managed-edition
 [4]: https://packagist.org/providers/php-http/client-implementation
-[5]: https://contao.org/en/support.html
+[5]: https://to.contao.org/support
 [6]: https://github.com/symfony/recipes-contrib
 [7]: http://symfony.com/doc/current/components/dotenv.html

--- a/core-bundle/src/Resources/views/Collector/contao.html.twig
+++ b/core-bundle/src/Resources/views/Collector/contao.html.twig
@@ -49,7 +49,7 @@
             </div>
             <div class="sf-toolbar-info-piece">
                 <b>Help</b>
-                <span><a href="https://contao.org/en/support.html" target="_blank" rel="help">Contao support channels</a></span>
+                <span><a href="https://to.contao.org/support" target="_blank" rel="help">Contao support channels</a></span>
             </div>
         </div>
     {% endset %}

--- a/faq-bundle/README.md
+++ b/faq-bundle/README.md
@@ -18,4 +18,4 @@ Contao is licensed under the terms of the LGPLv3.
 Visit the [support page][2] to learn about the available support options.
 
 [1]: https://contao.org
-[2]: https://contao.org/en/support.html
+[2]: https://to.contao.org/support

--- a/installation-bundle/README.md
+++ b/installation-bundle/README.md
@@ -18,4 +18,4 @@ Contao is licensed under the terms of the LGPLv3.
 Visit the [support page][2] to learn about the available support options.
 
 [1]: https://contao.org
-[2]: https://contao.org/en/support.html
+[2]: https://to.contao.org/support

--- a/listing-bundle/README.md
+++ b/listing-bundle/README.md
@@ -18,4 +18,4 @@ Contao is licensed under the terms of the LGPLv3.
 Visit the [support page][2] to learn about the available support options.
 
 [1]: https://contao.org
-[2]: https://contao.org/en/support.html
+[2]: https://to.contao.org/support

--- a/maker-bundle/README.md
+++ b/maker-bundle/README.md
@@ -43,4 +43,4 @@ Contao is licensed under the terms of the LGPLv3.
 Visit the [support page][2] to learn about the available support options.
 
 [1]: https://contao.org
-[2]: https://contao.org/en/support.html
+[2]: https://to.contao.org/support

--- a/manager-bundle/README.md
+++ b/manager-bundle/README.md
@@ -22,4 +22,4 @@ Visit the [support page][4] to learn about the available support options.
 [1]: https://symfony.com
 [2]: https://github.com/contao/contao-manager
 [3]: https://contao.org
-[4]: https://contao.org/en/support.html
+[4]: https://to.contao.org/support

--- a/news-bundle/README.md
+++ b/news-bundle/README.md
@@ -18,4 +18,4 @@ Contao is licensed under the terms of the LGPLv3.
 Visit the [support page][2] to learn about the available support options.
 
 [1]: https://contao.org
-[2]: https://contao.org/en/support.html
+[2]: https://to.contao.org/support

--- a/newsletter-bundle/README.md
+++ b/newsletter-bundle/README.md
@@ -18,4 +18,4 @@ Contao is licensed under the terms of the LGPLv3.
 Visit the [support page][2] to learn about the available support options.
 
 [1]: https://contao.org
-[2]: https://contao.org/en/support.html
+[2]: https://to.contao.org/support


### PR DESCRIPTION
I noticed this in the Symfony web inspector and search results als showed up in all README files 🙃 