### PR TITLE
Fix root page dependent module when there is no module for a root page

### DIFF
--- a/core-bundle/src/Controller/FrontendModule/RootPageDependentModulesController.php
+++ b/core-bundle/src/Controller/FrontendModule/RootPageDependentModulesController.php
@@ -28,13 +28,13 @@ class RootPageDependentModulesController extends AbstractFrontendModuleControlle
         }
 
         if (!$pageModel = $this->getPageModel()) {
-            return new Response('');
+            return new Response();
         }
 
-        $modules = array_filter(StringUtil::deserialize($model->rootPageDependentModules, true));
+        $modules = StringUtil::deserialize($model->rootPageDependentModules, true);
 
-        if (empty($modules) || !\array_key_exists($pageModel->rootId, $modules)) {
-            return new Response('');
+        if (empty($modules[$pageModel->rootId])) {
+            return new Response();
         }
 
         $framework = $this->container->get('contao.framework');
@@ -42,6 +42,10 @@ class RootPageDependentModulesController extends AbstractFrontendModuleControlle
         /** @var ModuleModel $moduleModel */
         $moduleModel = $framework->getAdapter(ModuleModel::class);
         $module = $moduleModel->findByPk($modules[$pageModel->rootId]);
+
+        if (null === $module) {
+            return new Response();
+        }
 
         $cssID = StringUtil::deserialize($module->cssID, true);
 

--- a/core-bundle/src/Controller/FrontendModule/RootPageDependentModulesController.php
+++ b/core-bundle/src/Controller/FrontendModule/RootPageDependentModulesController.php
@@ -31,9 +31,9 @@ class RootPageDependentModulesController extends AbstractFrontendModuleControlle
             return new Response('');
         }
 
-        $modules = StringUtil::deserialize($model->rootPageDependentModules);
+        $modules = array_filter(StringUtil::deserialize($model->rootPageDependentModules, true));
 
-        if (empty($modules) || !\is_array($modules) || !\array_key_exists($pageModel->rootId, $modules)) {
+        if (empty($modules) || !\array_key_exists($pageModel->rootId, $modules)) {
             return new Response('');
         }
 


### PR DESCRIPTION
The selects of the `RootPageDependentSelect` are not mandatory and you do not have to define a module for each root page (which is important for multidomain setups with multiple languages).

```
ErrorException:
Warning: Attempt to read property "cssID" on null

  at vendor\contao\core-bundle\src\Controller\FrontendModule\RootPageDependentModulesController.php:46
```

The current code has a check for this in place. However, it does not actually work, because the `RootPageDependentSelect` stores a serialised array with the following data in such a case:

```
array:4 [▼
  1 => "50"
  2 => "50"
  7 => ""
  5 => ""
]
```

This PR fixes that.