### PR TITLE
Fix the randomImage caption bug

### DIFF
--- a/core-bundle/src/Resources/contao/modules/ModuleRandomImage.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleRandomImage.php
@@ -134,7 +134,7 @@ class ModuleRandomImage extends Module
 		$this->Template->setData(array_merge(
 			$this->Template->getData(),
 			$imageData,
-			array('caption' => $this->useCaption ? $imageData['title'] ?? '' : null)
+			array('caption' => $this->useCaption ? $imageData['caption'] ?? '' : null)
 		));
 	}
 }


### PR DESCRIPTION
Fixes #6055 

The module uses a wrong key, which leads to the caption not being shown in the frontend.

