### PR TITLE
Make named parameter matching in routing non-possessive

### DIFF
--- a/core-bundle/src/Routing/Page/PageRouteCompiler.php
+++ b/core-bundle/src/Routing/Page/PageRouteCompiler.php
@@ -33,8 +33,16 @@ class PageRouteCompiler extends RouteCompiler
         // Re-add the URL suffix to the original route
         $route->setUrlSuffix($urlSuffix);
 
+        // Make last pattern before suffix non-possessive
+        $regex = $compiledRoute->getRegex();
+        $lastParam = strrpos($regex, '[^/]++)$}sDu');
+
+        if (false !== $lastParam) {
+            $regex = substr_replace($regex, '[^/]+?', $lastParam, 6);
+        }
+
         // Manually add the URL suffix to regex and path tokens
-        $regex = preg_replace('/^{\^([^$]+)\$}/', '{^$1'.preg_quote($urlSuffix, null).'$}', $compiledRoute->getRegex());
+        $regex = preg_replace('/^{\^([^$]+)\$}/', '{^$1'.preg_quote($urlSuffix, null).'$}', $regex);
         $tokens = $compiledRoute->getTokens();
         array_unshift($tokens, ['text', $urlSuffix]);
 

--- a/core-bundle/src/Routing/Page/PageRouteCompiler.php
+++ b/core-bundle/src/Routing/Page/PageRouteCompiler.php
@@ -35,7 +35,7 @@ class PageRouteCompiler extends RouteCompiler
 
         // Make last pattern before suffix non-possessive
         $regex = $compiledRoute->getRegex();
-        $lastParam = strrpos($regex, '[^/]++)$}sDu');
+        $lastParam = strrpos($regex, '[^/]++');
 
         if (false !== $lastParam) {
             $regex = substr_replace($regex, '[^/]+?', $lastParam, 6);


### PR DESCRIPTION
If you have a `PageController` with a parameter in its route like so:

```php
namespace App\Controller\Page;

use Contao\CoreBundle\DependencyInjection\Attribute\AsPage;
use Symfony\Component\HttpFoundation\Response;

#[AsPage(path: '/example/{foobar}')]
class ExamplePageController
{
    public function __invoke(string $foobar): Response
    {
        return new Response($foobar);
    }
}
```

then the route cannot match when using a suffix due to Symfony's default regex which looks like this:

```
{^/example/(?P<foobar>[^/]++)$}sDu
```

Our adjusted regex adds the suffix, e.g.:

```
{^/example/(?P<foobar>[^/]++)\.html$}sDu
```

but that won't match because

> `++` matches the previous token between one and unlimited times, as many times as possible, without giving back **(possessive)**

While this is taken into account in `PageCandidates::getCandidates`, it was missing in the `PageRouteCompiler`. This PR fixes that by changing the regex for the last named parameter from `++` to `+?`, e.g.

```
{^/example/(?P<foobar>[^/]+?)\.html$}sDu
```