### PR TITLE
Ignore secret check in Install Tool

### DIFF
--- a/core-bundle/src/EventListener/InsecureInstallationListener.php
+++ b/core-bundle/src/EventListener/InsecureInstallationListener.php
@@ -47,7 +47,7 @@ class InsecureInstallationListener
         }
 
         // The secret is still at its default value or empty
-        if (empty($this->secret) || 'ThisTokenIsNotSoSecretChangeIt' === $this->secret) {
+        if ('contao_install' !== $request->attributes->get('_route') && (empty($this->secret) || 'ThisTokenIsNotSoSecretChangeIt' === $this->secret)) {
             throw new InsecureInstallationException('Your installation is not secure. Please set the "secret" in your parameters.yml or "APP_SECRET" in your .env.local.');
         }
     }

--- a/core-bundle/tests/EventListener/InsecureInstallationListenerTest.php
+++ b/core-bundle/tests/EventListener/InsecureInstallationListenerTest.php
@@ -70,6 +70,19 @@ class InsecureInstallationListenerTest extends TestCase
         $this->addToAssertionCount(1); // does not throw an exception
     }
 
+    public function testDoesNotThrowAnExceptionInInstallTool(): void
+    {
+        $request = $this->getRequest();
+        $request->server->set('REQUEST_URI', '/index.php?do=test');
+        $request->server->set('SCRIPT_FILENAME', $this->getTempDir().'/index.php');
+        $request->attributes->set('_route', 'contao_install');
+
+        $listener = new InsecureInstallationListener(self::DEFAULT_SECRET);
+        $listener($this->getResponseEvent($request));
+
+        $this->addToAssertionCount(1); // does not throw an exception
+    }
+
     private function getRequest(): Request
     {
         $request = new Request();


### PR DESCRIPTION
If you do a fresh install of Contao in a non-local environment and then immediately delete the `APP_SECRET`, accessing the Install Tool is not possible anymore due to the secret check. Since the Install Tool would generate a secret for you in the `parameters.yml` and since only the `/_fragment` route is the one that would be exposed by a missing secret, it should be safe to ignore the secret check on the `/contao/install` route.