### PR TITLE
Fix a typo in the `_download` component

### DIFF
--- a/core-bundle/contao/templates/_new/component/_download.html.twig
+++ b/core-bundle/contao/templates/_new/component/_download.html.twig
@@ -38,11 +38,11 @@
     {% set text = download.text|default(title) %}
 
     {% block download_link %}
-        {% set dowload_link_attributes = attrs(dowload.link_attributes|default)
+        {% set download_link_attributes = attrs(download.link_attributes|default)
             .set('href', download.href)
             .set('title','MSC.download'|trans([title]))
             .setIfExists('type', download.file.mimeType('')) %}
-        <a{% block download_link_attributes %}{{ dowload_link_attributes }}{% endblock %}>
+        <a{% block download_link_attributes %}{{ download_link_attributes }}{% endblock %}>
             {%- block download_link_inner %}{{ text }}{% endblock -%}
         </a>
     {% endblock %}


### PR DESCRIPTION
🙈 

@m-vo btw. I notice a discrepancy here. The `_download` component gets its HTML attributes only from the `download` context:

```twig
{% set download_link_attributes = attrs(download.link_attributes|default) … %}
```

Whereas in the `_figure` component we merge the attributes from the `figure` context with existing attributes from `figure_attributes`, if set:

```twig
{% set figure_attributes = attrs()
    .mergeWith(figure.options.attr|default)
    .mergeWith(figure_attributes|default)
%}
```

Shouldn't we use the latter everywhere? e.g.

```twig
{% set download_link_attributes = attrs()
    .mergeWith(download.link_attributes|default)
    .mergeWith(download_link_attributes|default)
%}
```

Not sure if that is necessary though.