### PR TITLE
Fix `Undefined array key 1` on `contao/confirm` without parameters.

### DIFF
--- a/core-bundle/src/Resources/contao/controllers/BackendConfirm.php
+++ b/core-bundle/src/Resources/contao/controllers/BackendConfirm.php
@@ -64,12 +64,12 @@ class BackendConfirm extends Backend
 		$objTemplate->href = StringUtil::ampersand($url . ((strpos($url, '?') !== false) ? '&rt=' : '?rt=') . REQUEST_TOKEN);
 
 		$vars = array();
-		list(, $request) = explode('?', $url, 2);
+		list(, $request) = explode('?', $url, 2) + ["", ""];
 
 		// Extract the arguments
 		foreach (explode('&', $request) as $arg)
 		{
-			list($key, $value) = explode('=', $arg, 2);
+			list($key, $value) = explode('=', $arg, 2) + ["", ""];
 			$vars[$key] = $value;
 		}
 


### PR DESCRIPTION
Version: `4.13.24`
URL: `contao/confirm`

Steps that will reproduce the problem?
1. Open https://localhost/contao/confirm
2. Login

What is the expected result?
Dashboard

What happens instead?
Warning: Undefined array key 1

Possible workaround:
See patch. Following https://www.php.net/manual/en/function.array-merge.php: The keys from the first array will be preserved. If an array key exists in both arrays, then the element from the first array will be used and the matching key's element from the second array will be ignored.

Any additional information:

```
in vendor/core-bundle/src/Resources/contao/controllers/BackendConfirm.php (line 67)
in vendor/core-bundle/src/Controller/BackendController.php (line 108)
in vendor/symfony/http-kernel/HttpKernel.php -> confirmAction (line 163)
in vendor/symfony/http-kernel/HttpKernel.php -> handleRaw (line 75)
in vendor/symfony/http-kernel/Kernel.php -> handle (line 202)
in web/index.php (line 44)
```