### PR TITLE
Correctly track whether config files exist

### DIFF
--- a/manager-bundle/src/HttpKernel/ContaoKernel.php
+++ b/manager-bundle/src/HttpKernel/ContaoKernel.php
@@ -182,7 +182,7 @@ class ContaoKernel extends Kernel implements HttpCacheProvider
                 $loader->load($servicesFile);
             }
 
-            if (is_dir(Path::join($this->getProjectDir(), 'src'))) {
+            if ($container->fileExists(Path::join($this->getProjectDir(), 'src'), false)) {
                 $loader->load(__DIR__.'/../Resources/skeleton/config/services.php');
             }
         });

--- a/manager-bundle/src/HttpKernel/ContaoKernel.php
+++ b/manager-bundle/src/HttpKernel/ContaoKernel.php
@@ -154,7 +154,7 @@ class ContaoKernel extends Kernel implements HttpCacheProvider
     public function registerContainerConfiguration(LoaderInterface $loader): void
     {
         $loader->load(
-            function (ContainerBuilder $container) use ($loader) {
+            function (ContainerBuilder $container) use ($loader): void {
                 if ($parametersFile = $this->getConfigFile('parameters', $container)) {
                     $loader->load($parametersFile);
                 }
@@ -322,7 +322,8 @@ class ContaoKernel extends Kernel implements HttpCacheProvider
         foreach (['.yaml', '.yml'] as $ext) {
             $path = Path::join($projectDir, 'app/config', $file.$ext);
 
-            if ($container->fileExists($path)) {
+            // Only trigger deprecation if no file exists in the root config folder
+            if ($container->fileExists($path) && [] === $exists) {
                 trigger_deprecation('contao/manager-bundle', '4.9', sprintf('Storing the "%s" file in the "app/config" folder has been deprecated and will no longer work in Contao 5.0. Move it to the "config" folder instead.', $file.$ext));
 
                 $exists[] = $path;

--- a/manager-bundle/src/HttpKernel/ContaoKernel.php
+++ b/manager-bundle/src/HttpKernel/ContaoKernel.php
@@ -153,39 +153,41 @@ class ContaoKernel extends Kernel implements HttpCacheProvider
 
     public function registerContainerConfiguration(LoaderInterface $loader): void
     {
-        $loader->load(function (ContainerBuilder $container) use ($loader) {
-            if ($parametersFile = $this->getConfigFile('parameters', $container)) {
-                $loader->load($parametersFile);
-            }
+        $loader->load(
+            function (ContainerBuilder $container) use ($loader) {
+                if ($parametersFile = $this->getConfigFile('parameters', $container)) {
+                    $loader->load($parametersFile);
+                }
 
-            $config = $this->getManagerConfig()->all();
-            $plugins = $this->getPluginLoader()->getInstancesOf(PluginLoader::CONFIG_PLUGINS);
+                $config = $this->getManagerConfig()->all();
+                $plugins = $this->getPluginLoader()->getInstancesOf(PluginLoader::CONFIG_PLUGINS);
 
-            /** @var array<ConfigPluginInterface> $plugins */
-            foreach ($plugins as $plugin) {
-                $plugin->registerContainerConfiguration($loader, $config);
-            }
+                /** @var array<ConfigPluginInterface> $plugins */
+                foreach ($plugins as $plugin) {
+                    $plugin->registerContainerConfiguration($loader, $config);
+                }
 
-            // Reload the parameters.yml file
-            if ($parametersFile) {
-                $loader->load($parametersFile);
-            }
+                // Reload the parameters.yml file
+                if ($parametersFile) {
+                    $loader->load($parametersFile);
+                }
 
-            if ($configFile = $this->getConfigFile('config_'.$this->getEnvironment(), $container)) {
-                $loader->load($configFile);
-            } elseif ($configFile = $this->getConfigFile('config', $container)) {
-                $loader->load($configFile);
-            }
+                if ($configFile = $this->getConfigFile('config_'.$this->getEnvironment(), $container)) {
+                    $loader->load($configFile);
+                } elseif ($configFile = $this->getConfigFile('config', $container)) {
+                    $loader->load($configFile);
+                }
 
-            // Automatically load the services.yml file if it exists
-            if ($servicesFile = $this->getConfigFile('services', $container)) {
-                $loader->load($servicesFile);
-            }
+                // Automatically load the services.yml file if it exists
+                if ($servicesFile = $this->getConfigFile('services', $container)) {
+                    $loader->load($servicesFile);
+                }
 
-            if ($container->fileExists(Path::join($this->getProjectDir(), 'src'), false)) {
-                $loader->load(__DIR__.'/../Resources/skeleton/config/services.php');
+                if ($container->fileExists(Path::join($this->getProjectDir(), 'src'), false)) {
+                    $loader->load(__DIR__.'/../Resources/skeleton/config/services.php');
+                }
             }
-        });
+        );
     }
 
     public function getHttpCache(): ContaoCache

--- a/manager-bundle/src/HttpKernel/ContaoKernel.php
+++ b/manager-bundle/src/HttpKernel/ContaoKernel.php
@@ -325,7 +325,6 @@ class ContaoKernel extends Kernel implements HttpCacheProvider
             // Only trigger deprecation if no file exists in the root config folder
             if ($container->fileExists($path) && [] === $exists) {
                 trigger_deprecation('contao/manager-bundle', '4.9', sprintf('Storing the "%s" file in the "app/config" folder has been deprecated and will no longer work in Contao 5.0. Move it to the "config" folder instead.', $file.$ext));
-
                 $exists[] = $path;
             }
         }

--- a/manager-bundle/tests/HttpKernel/ContaoKernelTest.php
+++ b/manager-bundle/tests/HttpKernel/ContaoKernelTest.php
@@ -199,7 +199,7 @@ class ContaoKernelTest extends ContaoTestCase
         $container
             ->expects($this->atLeast(19))
             ->method('fileExists')
-            ->willReturnCallback(fn (string $path) => \in_array(basename($path), $expectedResult, true))
+            ->willReturnCallback(static fn (string $path) => \in_array(basename($path), $expectedResult, true))
         ;
 
         $loader = $this->createMock(LoaderInterface::class);

--- a/manager-bundle/tests/HttpKernel/ContaoKernelTest.php
+++ b/manager-bundle/tests/HttpKernel/ContaoKernelTest.php
@@ -218,8 +218,6 @@ class ContaoKernelTest extends ContaoTestCase
             )
         ;
 
-        $this->expectDeprecation('file in the "app/config" folder has been deprecated');
-
         $kernel = $this->getKernel($projectDir, $env);
         $kernel->registerContainerConfiguration($loader);
 

--- a/manager-bundle/tests/HttpKernel/ContaoKernelTest.php
+++ b/manager-bundle/tests/HttpKernel/ContaoKernelTest.php
@@ -206,7 +206,7 @@ class ContaoKernelTest extends ContaoTestCase
         $loader
             ->method('load')
             ->willReturnCallback(
-                static function ($resource) use (&$files, $container, $env) {
+                static function ($resource) use ($container, $env, &$files) {
                     if ($resource instanceof \Closure) {
                         return $resource($container, $env);
                     }

--- a/manager-bundle/tests/HttpKernel/ContaoKernelTest.php
+++ b/manager-bundle/tests/HttpKernel/ContaoKernelTest.php
@@ -218,6 +218,8 @@ class ContaoKernelTest extends ContaoTestCase
             )
         ;
 
+        $this->expectDeprecation('file in the "app/config" folder has been deprecated');
+
         $kernel = $this->getKernel($projectDir, $env);
         $kernel->registerContainerConfiguration($loader);
 

--- a/manager-bundle/tests/HttpKernel/ContaoKernelTest.php
+++ b/manager-bundle/tests/HttpKernel/ContaoKernelTest.php
@@ -28,6 +28,7 @@ use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\Config\Resource\ClassExistenceResource;
 use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ParameterBag\EnvPlaceholderParameterBag;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Filesystem\Path;
@@ -194,12 +195,25 @@ class ContaoKernelTest extends ContaoTestCase
     {
         $files = [];
 
+        $container = $this->createMock(ContainerBuilder::class);
+        $container
+            ->expects($this->atLeast(19))
+            ->method('fileExists')
+            ->willReturnCallback(fn (string $path) => \in_array(basename($path), $expectedResult, true))
+        ;
+
         $loader = $this->createMock(LoaderInterface::class);
         $loader
             ->method('load')
             ->willReturnCallback(
-                static function ($resource) use (&$files): void {
+                static function ($resource) use (&$files, $container, $env) {
+                    if ($resource instanceof \Closure) {
+                        return $resource($container, $env);
+                    }
+
                     $files[] = basename($resource);
+
+                    return null;
                 }
             )
         ;
@@ -263,7 +277,21 @@ class ContaoKernelTest extends ContaoTestCase
 
     public function testRegisterContainerConfigurationLoadsPlugins(): void
     {
+        $container = $this->createMock(ContainerBuilder::class);
+
         $loader = $this->createMock(LoaderInterface::class);
+        $loader
+            ->method('load')
+            ->willReturnCallback(
+                static function ($resource) use ($container) {
+                    if ($resource instanceof \Closure) {
+                        return $resource($container, 'prod');
+                    }
+
+                    return null;
+                }
+            )
+        ;
 
         $pluginLoader = $this->createMock(PluginLoader::class);
         $pluginLoader


### PR DESCRIPTION
In the current state, if you create a new config file (e.g. `config/parameters.yml`) that did not exist before, the dev cache is not automatically rebuilt because it does not "track that resource". We currently only track the first config file that exists for changes.