### PR TITLE
Allow saving serialized strings in DC_File again

### DIFF
--- a/core-bundle/contao/drivers/DC_File.php
+++ b/core-bundle/contao/drivers/DC_File.php
@@ -383,12 +383,6 @@ class DC_File extends DataContainer implements EditableDataContainerInterface
 				$objDate = new Date($varValue, Date::getFormatFromRgxp($arrData['eval']['rgxp']));
 				$varValue = $objDate->tstamp;
 			}
-
-			// Handle entities
-			if (($arrData['inputType'] ?? null) == 'text' || ($arrData['inputType'] ?? null) == 'textarea')
-			{
-				$varValue = StringUtil::deserialize($varValue);
-			}
 		}
 
 		// Trigger the save_callback


### PR DESCRIPTION
- Remove entity handling as deserialize is not needed anymore

Fixes https://github.com/contao/contao/issues/6105

(Cherry-picked from [#6106](https://github.com/contao/contao/pull/6106))