### PR TITLE
Only prepend the protocol in the page finder if the hostname is not empty

### DIFF
--- a/core-bundle/src/Routing/PageFinder.php
+++ b/core-bundle/src/Routing/PageFinder.php
@@ -32,11 +32,11 @@ class PageFinder
      */
     public function findRootPageForHostAndLanguage(string $hostname, string|null $acceptLanguage = null): PageModel|null
     {
-        if ('' === $hostname) {
-            return null;
+        if ($hostname) {
+            $hostname = "http://$hostname";
         }
 
-        $request = Request::create('http://'.$hostname);
+        $request = Request::create($hostname);
         $request->headers->set('Accept-Language', $acceptLanguage ?? '');
 
         return $this->matchRootPageForRequest($request);
@@ -64,10 +64,6 @@ class PageFinder
      */
     public function findRootPagesForHost(string $hostname): array
     {
-        if ('' === $hostname) {
-            return [];
-        }
-
         $pageModel = $this->findRootPageForHostAndLanguage($hostname);
 
         if (null === $pageModel) {

--- a/core-bundle/src/Routing/PageFinder.php
+++ b/core-bundle/src/Routing/PageFinder.php
@@ -32,6 +32,10 @@ class PageFinder
      */
     public function findRootPageForHostAndLanguage(string $hostname, string|null $acceptLanguage = null): PageModel|null
     {
+        if ('' === $hostname) {
+            return null;
+        }
+
         $request = Request::create('http://'.$hostname);
         $request->headers->set('Accept-Language', $acceptLanguage ?? '');
 
@@ -60,6 +64,10 @@ class PageFinder
      */
     public function findRootPagesForHost(string $hostname): array
     {
+        if ('' === $hostname) {
+            return [];
+        }
+
         $pageModel = $this->findRootPageForHostAndLanguage($hostname);
 
         if (null === $pageModel) {

--- a/core-bundle/tests/Routing/PageFinderTest.php
+++ b/core-bundle/tests/Routing/PageFinderTest.php
@@ -31,7 +31,7 @@ class PageFinderTest extends TestCase
         ;
 
         $pageFinder = new PageFinder($framework, $this->mockRequestMatcher(null));
-        $result = $pageFinder->findRootPageForHostAndLanguage('https://www.example.org');
+        $result = $pageFinder->findRootPageForHostAndLanguage('www.example.org');
 
         $this->assertNull($result);
     }
@@ -51,7 +51,7 @@ class PageFinderTest extends TestCase
         ;
 
         $pageFinder = new PageFinder($framework, $requestMatcher);
-        $result = $pageFinder->findRootPageForHostAndLanguage('https://www.example.org');
+        $result = $pageFinder->findRootPageForHostAndLanguage('www.example.org');
 
         $this->assertNull($result);
     }
@@ -67,7 +67,7 @@ class PageFinderTest extends TestCase
         ;
 
         $pageFinder = new PageFinder($framework, $this->mockRequestMatcher($pageModel));
-        $result = $pageFinder->findRootPageForHostAndLanguage('https://www.example.org');
+        $result = $pageFinder->findRootPageForHostAndLanguage('www.example.org');
 
         $this->assertSame($pageModel, $result);
     }
@@ -98,7 +98,7 @@ class PageFinderTest extends TestCase
         ;
 
         $pageFinder = new PageFinder($framework, $this->mockRequestMatcher($regularPage));
-        $result = $pageFinder->findRootPageForHostAndLanguage('https://www.example.org');
+        $result = $pageFinder->findRootPageForHostAndLanguage('www.example.org');
 
         $this->assertSame($rootPage, $result);
     }
@@ -178,6 +178,13 @@ class PageFinderTest extends TestCase
             $requestMatcher
                 ->expects($this->once())
                 ->method('matchRequest')
+                ->with($this->callback(
+                    function (Request $request) {
+                        $this->assertSame('http://www.example.org', $request->getSchemeAndHttpHost());
+
+                        return true;
+                    }
+                ))
                 ->willReturn($pageModel ? ['pageModel' => $pageModel] : [])
             ;
         }

--- a/core-bundle/tests/Routing/PageFinderTest.php
+++ b/core-bundle/tests/Routing/PageFinderTest.php
@@ -162,10 +162,26 @@ class PageFinderTest extends TestCase
         $this->assertSame($rootPage, $result);
     }
 
+    public function testDoesNotPrependTheProtocolIfTheHostnameIsEmpty(): void
+    {
+        $pageModel = $this->mockClassWithProperties(PageModel::class, ['type' => 'root']);
+
+        $framework = $this->mockContaoFramework();
+        $framework
+            ->expects($this->never())
+            ->method('initialize')
+        ;
+
+        $pageFinder = new PageFinder($framework, $this->mockRequestMatcher($pageModel, 'http://localhost'));
+        $result = $pageFinder->findRootPageForHostAndLanguage('');
+
+        $this->assertSame($pageModel, $result);
+    }
+
     /**
      * @return RequestMatcherInterface&MockObject
      */
-    private function mockRequestMatcher(PageModel|false|null $pageModel): RequestMatcherInterface
+    private function mockRequestMatcher(PageModel|false|null $pageModel, string|null $requestUri = null): RequestMatcherInterface
     {
         $requestMatcher = $this->createMock(RequestMatcherInterface::class);
 
@@ -179,8 +195,8 @@ class PageFinderTest extends TestCase
                 ->expects($this->once())
                 ->method('matchRequest')
                 ->with($this->callback(
-                    function (Request $request) {
-                        $this->assertSame('http://www.example.org', $request->getSchemeAndHttpHost());
+                    function (Request $request) use ($requestUri) {
+                        $this->assertSame($requestUri ?? 'http://www.example.org', $request->getSchemeAndHttpHost());
 
                         return true;
                     }

--- a/core-bundle/tests/Routing/PageFinderTest.php
+++ b/core-bundle/tests/Routing/PageFinderTest.php
@@ -106,7 +106,7 @@ class PageFinderTest extends TestCase
     public function testFindRootPageForRequestCreatesNewRequest(): void
     {
         $pageModel = $this->mockClassWithProperties(PageModel::class, ['type' => 'root']);
-        $request = new Request();
+        $request = Request::create('https://www.example.org');
 
         $framework = $this->mockContaoFramework();
         $framework
@@ -160,6 +160,25 @@ class PageFinderTest extends TestCase
         $result = $pageFinder->findRootPageForRequest($request);
 
         $this->assertSame($rootPage, $result);
+    }
+
+    public function testReturnsNullIfTheRequestHostnameIsEmpty(): void
+    {
+        $framework = $this->mockContaoFramework();
+        $framework
+            ->expects($this->never())
+            ->method('initialize')
+        ;
+
+        $requestMatcher = $this->createMock(RequestMatcherInterface::class);
+        $requestMatcher
+            ->expects($this->never())
+            ->method('matchRequest')
+        ;
+
+        $pageFinder = new PageFinder($framework, $requestMatcher);
+
+        $this->assertNull($pageFinder->findRootPageForRequest(new Request()));
     }
 
     /**

--- a/core-bundle/tests/Routing/PageFinderTest.php
+++ b/core-bundle/tests/Routing/PageFinderTest.php
@@ -106,7 +106,7 @@ class PageFinderTest extends TestCase
     public function testFindRootPageForRequestCreatesNewRequest(): void
     {
         $pageModel = $this->mockClassWithProperties(PageModel::class, ['type' => 'root']);
-        $request = Request::create('https://www.example.org');
+        $request = new Request();
 
         $framework = $this->mockContaoFramework();
         $framework
@@ -160,25 +160,6 @@ class PageFinderTest extends TestCase
         $result = $pageFinder->findRootPageForRequest($request);
 
         $this->assertSame($rootPage, $result);
-    }
-
-    public function testReturnsNullIfTheRequestHostnameIsEmpty(): void
-    {
-        $framework = $this->mockContaoFramework();
-        $framework
-            ->expects($this->never())
-            ->method('initialize')
-        ;
-
-        $requestMatcher = $this->createMock(RequestMatcherInterface::class);
-        $requestMatcher
-            ->expects($this->never())
-            ->method('matchRequest')
-        ;
-
-        $pageFinder = new PageFinder($framework, $requestMatcher);
-
-        $this->assertNull($pageFinder->findRootPageForRequest(new Request()));
     }
 
     /**


### PR DESCRIPTION
Otherwise we will trigger a `Since symfony/http-foundation 6.3: Calling "Symfony\Component\HttpFoundation\Request::create()" with an invalid URI is deprecated.` warning and later and exception.