### PR TITLE
Recursively implode fields when generating record labels

### DIFF
--- a/core-bundle/src/Resources/contao/classes/DataContainer.php
+++ b/core-bundle/src/Resources/contao/classes/DataContainer.php
@@ -1735,7 +1735,7 @@ abstract class DataContainer extends Backend
 
 					$implode = static function ($v) use (&$implode)
 					{
-						return implode(', ', array_map(static fn($vv) => \is_array($vv) ? $implode($vv) : $vv, $v));
+						return implode(', ', array_map(static fn ($vv) => \is_array($vv) ? $implode($vv) : $vv, $v));
 					};
 
 					$args[$k] = $implode($args_k);

--- a/core-bundle/src/Resources/contao/classes/DataContainer.php
+++ b/core-bundle/src/Resources/contao/classes/DataContainer.php
@@ -1733,7 +1733,8 @@ abstract class DataContainer extends Backend
 						$args_k[] = $GLOBALS['TL_DCA'][$table]['fields'][$v]['reference'][$option] ?? $option;
 					}
 
-					$implode = static function ($v) use (&$implode) {
+					$implode = static function ($v) use (&$implode)
+					{
 						return implode(', ', array_map(static fn($vv) => \is_array($vv) ? $implode($vv) : $vv, $v));
 					};
 

--- a/core-bundle/src/Resources/contao/classes/DataContainer.php
+++ b/core-bundle/src/Resources/contao/classes/DataContainer.php
@@ -1733,7 +1733,11 @@ abstract class DataContainer extends Backend
 						$args_k[] = $GLOBALS['TL_DCA'][$table]['fields'][$v]['reference'][$option] ?? $option;
 					}
 
-					$args[$k] = implode(', ', $args_k);
+					$implode = static function ($v) use (&$implode) {
+						return implode(', ', array_map(static fn($vv) => \is_array($vv) ? $implode($vv) : $vv, $v));
+					};
+
+					$args[$k] = $implode($args_k);
 				}
 				elseif (isset($GLOBALS['TL_DCA'][$table]['fields'][$v]['reference'][$row[$v]]))
 				{

--- a/core-bundle/src/Resources/contao/classes/DataContainer.php
+++ b/core-bundle/src/Resources/contao/classes/DataContainer.php
@@ -1733,12 +1733,7 @@ abstract class DataContainer extends Backend
 						$args_k[] = $GLOBALS['TL_DCA'][$table]['fields'][$v]['reference'][$option] ?? $option;
 					}
 
-					$implode = static function ($v) use (&$implode)
-					{
-						return implode(', ', array_map(static fn ($vv) => \is_array($vv) ? $implode($vv) : $vv, $v));
-					};
-
-					$args[$k] = $implode($args_k);
+					$args[$k] = implode(', ', iterator_to_array(new \RecursiveIteratorIterator(new \RecursiveArrayIterator($args_k)), false));
 				}
 				elseif (isset($GLOBALS['TL_DCA'][$table]['fields'][$v]['reference'][$row[$v]]))
 				{


### PR DESCRIPTION
I have fixed this issue in Isotope core previously in https://github.com/isotope/core/issues/2324, but now realized this is actually a Contao bug to me. This issue resurfaced in https://github.com/isotope/core/issues/2340 because of the new `DataContainer::generateRecordLabel`, which overrides the default Isotope label fix.