### PR TITLE
Use `setMetadata()` in the `addImageToTemplate()` method

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Controller.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Controller.php
@@ -1778,7 +1778,7 @@ abstract class Controller extends System
 			// Use source + metadata from files model (if not overwritten)
 			$figureBuilder
 				->fromFilesModel($filesModel)
-				->setOverwriteMetadata($createMetadataOverwriteFromRowData(true));
+				->setMetadata($createMetadataOverwriteFromRowData(true));
 
 			$includeFullMetadata = true;
 		}
@@ -1787,7 +1787,7 @@ abstract class Controller extends System
 			// Always ignore file metadata when building from path (BC)
 			$figureBuilder
 				->fromPath($rowData['singleSRC'], false)
-				->setOverwriteMetadata($createMetadataOverwriteFromRowData(false));
+				->setMetadata($createMetadataOverwriteFromRowData(false));
 
 			$includeFullMetadata = false;
 		}

--- a/core-bundle/tests/Contao/ControllerTest.php
+++ b/core-bundle/tests/Contao/ControllerTest.php
@@ -160,7 +160,7 @@ class ControllerTest extends TestCase
 
         $figureBuilder
             ->expects($this->once())
-            ->method('setOverwriteMetadata')
+            ->method('setMetadata')
             ->with($expectedMetadata)
             ->willReturn($figureBuilder)
         ;


### PR DESCRIPTION
Fixes #6094

@oexler Can you please check if this PR fixes your issue?
