### PR TITLE
Upgrade the Handorgel implementation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
         "contao-components/contao": "^9.1",
         "contao-components/datepicker": "^3.0",
         "contao-components/dropzone": "^5.0.1",
-        "contao-components/handorgel": "^0.5",
+        "contao-components/handorgel": "^1.0",
         "contao-components/jquery": "^3.5",
         "contao-components/jquery-ui": "^1.11.4",
         "contao-components/mediabox": "^1.5",

--- a/core-bundle/composer.json
+++ b/core-bundle/composer.json
@@ -48,7 +48,7 @@
         "contao-components/contao": "^9.1",
         "contao-components/datepicker": "^3.0",
         "contao-components/dropzone": "^5.0.1",
-        "contao-components/handorgel": "^0.5",
+        "contao-components/handorgel": "^1.0",
         "contao-components/jquery": "^3.5",
         "contao-components/jquery-ui": "^1.11.4",
         "contao-components/mediabox": "^1.5",

--- a/core-bundle/contao/templates/js/js_accordion.html5
+++ b/core-bundle/contao/templates/js/js_accordion.html5
@@ -21,7 +21,6 @@ $GLOBALS['TL_CSS'][] = $this->asset('css/handorgel.min.css', 'contao-components/
         button.type = 'button';
         button.append(...toggler.childNodes);
         toggler.appendChild(button);
-
         toggler.parentNode.classList.add('handorgel');
         contentElements.push(toggler.nextElementSibling);
       });
@@ -41,9 +40,8 @@ $GLOBALS['TL_CSS'][] = $this->asset('css/handorgel.min.css', 'contao-components/
       });
     }
 
-    // change this selector accordion to your template, or duplicate
+    // Change this selector accordion to your template, or duplicate
     // the line if you use multiple accordion element classes.
     initAccordion('.ce_accordion > .toggler');
-
   })();
 </script>

--- a/core-bundle/contao/templates/js/js_accordion.html5
+++ b/core-bundle/contao/templates/js/js_accordion.html5
@@ -40,7 +40,7 @@ $GLOBALS['TL_CSS'][] = $this->asset('css/handorgel.min.css', 'contao-components/
       });
     }
 
-    // Change this selector accordion to your template, or duplicate
+    // Change this selector according to your template, or duplicate
     // the line if you use multiple accordion element classes.
     initAccordion('.ce_accordion > .toggler');
   })();

--- a/core-bundle/contao/templates/js/js_accordion.html5
+++ b/core-bundle/contao/templates/js/js_accordion.html5
@@ -8,49 +8,42 @@ $GLOBALS['TL_CSS'][] = $this->asset('css/handorgel.min.css', 'contao-components/
 <script src="<?= $this->asset('js/handorgel.min.js', 'contao-components/handorgel') ?>"></script>
 <script>
   (function () {
-    const addNextAccordions = (el, accordion) => {
-      if (el && el.classList.contains('ce_accordion')) {
-        const toggler = el.querySelector('.toggler');
-        const element = el.querySelector('.accordion');
+    const initAccordion = function (selector) {
+      const headerElements = document.querySelectorAll(selector);
+      const contentElements = [];
 
-        if (!toggler || !element) {
-          return;
-        }
+      if (!headerElements) {
+        return;
+      }
 
+      headerElements.forEach((toggler) => {
         const button = document.createElement('button');
         button.type = 'button';
         button.append(...toggler.childNodes);
         toggler.appendChild(button);
 
-        addNextAccordions(el.nextElementSibling, accordion);
+        toggler.parentNode.classList.add('handorgel');
+        contentElements.push(toggler.nextElementSibling);
+      });
 
-        accordion.insertBefore(element, accordion.firstChild);
-        accordion.insertBefore(toggler, accordion.firstChild);
+      new handorgel(document.body, {
+        headerElements,
+        contentElements,
+        multiSelectable: false,
+        headerOpenClass: 'open',
+        contentOpenClass: 'open',
+        headerOpenedClass: 'active',
+        contentOpenedClass: 'active',
+        headerFocusClass: 'focus',
+        contentFocusClass: 'focus',
+        headerDisabledClass: 'disabled',
+        contentDisabledClass: 'disabled',
+      });
+    }
 
-        el.remove();
-      }
-    };
+    // change this selector accordion to your template, or duplicate
+    // the line if you use multiple accordion element classes.
+    initAccordion('.ce_accordion > .toggler');
 
-    document.querySelectorAll('.ce_accordion').forEach((el) => {
-      if (el.querySelector('.accordion')) {
-        const accordion = document.createElement('div');
-        accordion.className = 'ce_accordion handorgel';
-        el.parentNode.insertBefore(accordion, el);
-
-        addNextAccordions(el, accordion);
-
-        new handorgel(accordion, {
-          multiSelectable: false,
-          headerOpenClass: 'open',
-          contentOpenClass: 'open',
-          headerOpenedClass: 'active',
-          contentOpenedClass: 'active',
-          headerFocusClass: 'focus',
-          contentFocusClass: 'focus',
-          headerDisabledClass: 'disabled',
-          contentDisabledClass: 'disabled',
-        });
-      }
-    });
   })();
 </script>


### PR DESCRIPTION
[Handorgel.js](https://github.com/oncode/handorgel) has just been released version 1.0 with a feature request of mine. I noticed that our new Handorgel accordion implementation no longer has wrapper elemements around an accordion (because previous Handorgel versions had one parent node for all elements). Version 1 now supports custom header and content selectors, which allows us to keep our existing markup without modification.

Thanks a lot to @oncode for implementing this!

@leofeyer we also need to update the [`contao-components/handorgel`](https://github.com/contao-components/handorgel) repository, would you take care of that?