### PR TITLE
Fix book navigation in PHP 8

### DIFF
--- a/core-bundle/src/Resources/contao/modules/ModuleBooknav.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleBooknav.php
@@ -129,9 +129,9 @@ class ModuleBooknav extends Module
 			$intKey = $arrLookup[($current - 1)];
 
 			// Skip forward pages (see #5074)
-			while ($this->arrPages[$intKey]->type == 'forward' && isset($arrLookup[--$current]))
+			while (isset($this->arrPages[$intKey]) && $this->arrPages[$intKey]->type == 'forward' && isset($arrLookup[--$current]))
 			{
-				$intKey = $arrLookup[($current - 1)];
+				$intKey = $arrLookup[($current - 1)] ?? null;
 			}
 
 			if ($intKey === null)


### PR DESCRIPTION
Currently the book navigation module does not work in debug mode under PHP 8. This PR fixes the following issues:

```
ErrorException:
Warning: Undefined array key -1

  at vendor\contao\core-bundle\src\Resources\contao\modules\ModuleBooknav.php:134
```
```
ErrorException:
Warning: Undefined array key ""

  at vendor\contao\core-bundle\src\Resources\contao\modules\ModuleBooknav.php:132
```