### PR TITLE
Always define a reference type in `PageModel::getFrontendUrl()`

### DIFF
--- a/core-bundle/src/Resources/contao/models/PageModel.php
+++ b/core-bundle/src/Resources/contao/models/PageModel.php
@@ -1220,6 +1220,9 @@ class PageModel extends Model
 			$this->folderUrl = $folderUrl;
 		}
 
+		$container = System::getContainer();
+		$request = $container->get('request_stack')->getCurrentRequest();
+
 		// Set the root ID and title
 		if ($objParentPage !== null && $objParentPage->type == 'root')
 		{
@@ -1268,17 +1271,17 @@ class PageModel extends Model
 				}
 			}
 
-			if (System::getContainer()->getParameter('contao.legacy_routing'))
+			if ($container->getParameter('contao.legacy_routing'))
 			{
-				$this->urlPrefix = System::getContainer()->getParameter('contao.prepend_locale') ? LocaleUtil::formatAsLanguageTag($objParentPage->language) : '';
-				$this->urlSuffix = System::getContainer()->getParameter('contao.url_suffix');
+				$this->urlPrefix = $container->getParameter('contao.prepend_locale') ? LocaleUtil::formatAsLanguageTag($objParentPage->language) : '';
+				$this->urlSuffix = $container->getParameter('contao.url_suffix');
 			}
 		}
 
 		// No root page found
-		elseif (TL_MODE == 'FE' && $this->type != 'root')
+		elseif ($request && $container->get('contao.routing.scope_matcher')->isFrontendRequest($request) && $this->type != 'root')
 		{
-			System::getContainer()->get('monolog.logger.contao.error')->error('Page ID "' . $this->id . '" does not belong to a root page');
+			$container->get('monolog.logger.contao.error')->error('Page ID "' . $this->id . '" does not belong to a root page');
 
 			throw new NoRootPageFoundException('No root page found');
 		}

--- a/core-bundle/src/Resources/contao/models/PageModel.php
+++ b/core-bundle/src/Resources/contao/models/PageModel.php
@@ -1360,10 +1360,11 @@ class PageModel extends Model
 		}
 
 		$objRouter = System::getContainer()->get('router');
+		$referenceType = $this->domain && $objRouter->getContext()->getHost() !== $this->domain ? UrlGeneratorInterface::ABSOLUTE_URL : UrlGeneratorInterface::ABSOLUTE_PATH;
 
 		try
 		{
-			$strUrl = $objRouter->generate(PageRoute::PAGE_BASED_ROUTE_NAME, array(RouteObjectInterface::CONTENT_OBJECT => $this, 'parameters' => $strParams));
+			$strUrl = $objRouter->generate(PageRoute::PAGE_BASED_ROUTE_NAME, array(RouteObjectInterface::CONTENT_OBJECT => $this, 'parameters' => $strParams), $referenceType);
 		}
 		catch (RouteNotFoundException $e)
 		{

--- a/core-bundle/src/Resources/contao/models/PageModel.php
+++ b/core-bundle/src/Resources/contao/models/PageModel.php
@@ -1382,7 +1382,7 @@ class PageModel extends Model
 		}
 
 		// Make the URL relative to the base path
-		if (0 === strncmp($strUrl, '/', 1) && 0 !== strncmp($strUrl, '//', 2))
+		if (0 === strncmp($strUrl, '/', 1))
 		{
 			$strUrl = substr($strUrl, \strlen(Environment::get('path')) + 1);
 		}

--- a/core-bundle/tests/Contao/PageModelTest.php
+++ b/core-bundle/tests/Contao/PageModelTest.php
@@ -369,78 +369,6 @@ class PageModelTest extends TestCase
         $this->assertSame($expectedLayout, $page->layout);
     }
 
-    public function testUsesAbsolutePathReferenceForFrontendUrl(): void
-    {
-        $page = new PageModel();
-        $page->pid = 42;
-        $page->domain = 'example.com';
-
-        $context = RequestContext::fromUri('https://example.com');
-
-        $router = $this->createMock(RouterInterface::class);
-        $router
-            ->expects($this->once())
-            ->method('generate')
-            ->with(PageRoute::PAGE_BASED_ROUTE_NAME, [RouteObjectInterface::CONTENT_OBJECT => $page, 'parameters' => null], UrlGeneratorInterface::ABSOLUTE_PATH)
-            ->willReturn('/page')
-        ;
-
-        $router
-            ->expects($this->once())
-            ->method('getContext')
-            ->willReturn($context)
-        ;
-
-        System::getContainer()->set('router', $router);
-
-        $this->assertSame('page', $page->getFrontendUrl());
-    }
-
-    public function testUsesAbsoluteUrlReferenceForFrontendUrlOnOtherDomain(): void
-    {
-        $page = new PageModel();
-        $page->pid = 42;
-        $page->domain = 'foobar.com';
-
-        $context = RequestContext::fromUri('https://example.com');
-
-        $router = $this->createMock(RouterInterface::class);
-        $router
-            ->expects($this->once())
-            ->method('generate')
-            ->with(PageRoute::PAGE_BASED_ROUTE_NAME, [RouteObjectInterface::CONTENT_OBJECT => $page, 'parameters' => null], UrlGeneratorInterface::ABSOLUTE_URL)
-            ->willReturn('https://foobar.com/page')
-        ;
-
-        $router
-            ->expects($this->once())
-            ->method('getContext')
-            ->willReturn($context)
-        ;
-
-        System::getContainer()->set('router', $router);
-
-        $this->assertSame('https://foobar.com/page', $page->getFrontendUrl());
-    }
-
-    public function testUsesAbsoluteUrlReferenceForAbsoluteUrl(): void
-    {
-        $page = new PageModel();
-        $page->pid = 42;
-
-        $router = $this->createMock(RouterInterface::class);
-        $router
-            ->expects($this->once())
-            ->method('generate')
-            ->with(PageRoute::PAGE_BASED_ROUTE_NAME, [RouteObjectInterface::CONTENT_OBJECT => $page, 'parameters' => null], UrlGeneratorInterface::ABSOLUTE_URL)
-            ->willReturn('https://example.com/page')
-        ;
-
-        System::getContainer()->set('router', $router);
-
-        $this->assertSame('https://example.com/page', $page->getAbsoluteUrl());
-    }
-
     public function layoutInheritanceParentPagesProvider(): \Generator
     {
         yield 'no parent with an inheritable layout' => [
@@ -548,6 +476,78 @@ class PageModelTest extends TestCase
             ],
             '',
         ];
+    }
+
+    public function testUsesAbsolutePathReferenceForFrontendUrl(): void
+    {
+        $page = new PageModel();
+        $page->pid = 42;
+        $page->domain = 'example.com';
+
+        $context = RequestContext::fromUri('https://example.com');
+
+        $router = $this->createMock(RouterInterface::class);
+        $router
+            ->expects($this->once())
+            ->method('generate')
+            ->with(PageRoute::PAGE_BASED_ROUTE_NAME, [RouteObjectInterface::CONTENT_OBJECT => $page, 'parameters' => null], UrlGeneratorInterface::ABSOLUTE_PATH)
+            ->willReturn('/page')
+        ;
+
+        $router
+            ->expects($this->once())
+            ->method('getContext')
+            ->willReturn($context)
+        ;
+
+        System::getContainer()->set('router', $router);
+
+        $this->assertSame('page', $page->getFrontendUrl());
+    }
+
+    public function testUsesAbsoluteUrlReferenceForFrontendUrlOnOtherDomain(): void
+    {
+        $page = new PageModel();
+        $page->pid = 42;
+        $page->domain = 'foobar.com';
+
+        $context = RequestContext::fromUri('https://example.com');
+
+        $router = $this->createMock(RouterInterface::class);
+        $router
+            ->expects($this->once())
+            ->method('generate')
+            ->with(PageRoute::PAGE_BASED_ROUTE_NAME, [RouteObjectInterface::CONTENT_OBJECT => $page, 'parameters' => null], UrlGeneratorInterface::ABSOLUTE_URL)
+            ->willReturn('https://foobar.com/page')
+        ;
+
+        $router
+            ->expects($this->once())
+            ->method('getContext')
+            ->willReturn($context)
+        ;
+
+        System::getContainer()->set('router', $router);
+
+        $this->assertSame('https://foobar.com/page', $page->getFrontendUrl());
+    }
+
+    public function testUsesAbsoluteUrlReferenceForAbsoluteUrl(): void
+    {
+        $page = new PageModel();
+        $page->pid = 42;
+
+        $router = $this->createMock(RouterInterface::class);
+        $router
+            ->expects($this->once())
+            ->method('generate')
+            ->with(PageRoute::PAGE_BASED_ROUTE_NAME, [RouteObjectInterface::CONTENT_OBJECT => $page, 'parameters' => null], UrlGeneratorInterface::ABSOLUTE_URL)
+            ->willReturn('https://example.com/page')
+        ;
+
+        System::getContainer()->set('router', $router);
+
+        $this->assertSame('https://example.com/page', $page->getAbsoluteUrl());
     }
 
     private function mockDatabase(Database $database): void

--- a/core-bundle/tests/Contao/PageModelTest.php
+++ b/core-bundle/tests/Contao/PageModelTest.php
@@ -21,6 +21,7 @@ use Contao\Database\Result;
 use Contao\Database\Statement;
 use Contao\DcaExtractor;
 use Contao\DcaLoader;
+use Contao\Environment;
 use Contao\Input;
 use Contao\Model;
 use Contao\Model\Collection;
@@ -67,7 +68,7 @@ class PageModelTest extends TestCase
 
         PageModel::reset();
 
-        $this->resetStaticProperties([Registry::class, Model::class, DcaExtractor::class, DcaLoader::class, Database::class, Input::class, System::class, Config::class]);
+        $this->resetStaticProperties([Registry::class, Model::class, DcaExtractor::class, DcaLoader::class, Database::class, Input::class, System::class, Config::class, Environment::class]);
 
         parent::tearDown();
     }

--- a/core-bundle/tests/Contao/PageModelTest.php
+++ b/core-bundle/tests/Contao/PageModelTest.php
@@ -380,7 +380,7 @@ class PageModelTest extends TestCase
         $router
             ->expects($this->once())
             ->method('generate')
-            ->with(PageRoute::PAGE_BASED_ROUTE_NAME,  array(RouteObjectInterface::CONTENT_OBJECT => $page, 'parameters' => null), UrlGeneratorInterface::ABSOLUTE_PATH)
+            ->with(PageRoute::PAGE_BASED_ROUTE_NAME, [RouteObjectInterface::CONTENT_OBJECT => $page, 'parameters' => null], UrlGeneratorInterface::ABSOLUTE_PATH)
             ->willReturn('/page')
         ;
 
@@ -407,7 +407,7 @@ class PageModelTest extends TestCase
         $router
             ->expects($this->once())
             ->method('generate')
-            ->with(PageRoute::PAGE_BASED_ROUTE_NAME,  array(RouteObjectInterface::CONTENT_OBJECT => $page, 'parameters' => null), UrlGeneratorInterface::ABSOLUTE_URL)
+            ->with(PageRoute::PAGE_BASED_ROUTE_NAME, [RouteObjectInterface::CONTENT_OBJECT => $page, 'parameters' => null], UrlGeneratorInterface::ABSOLUTE_URL)
             ->willReturn('https://foobar.com/page')
         ;
 
@@ -431,7 +431,7 @@ class PageModelTest extends TestCase
         $router
             ->expects($this->once())
             ->method('generate')
-            ->with(PageRoute::PAGE_BASED_ROUTE_NAME,  array(RouteObjectInterface::CONTENT_OBJECT => $page, 'parameters' => null), UrlGeneratorInterface::ABSOLUTE_URL)
+            ->with(PageRoute::PAGE_BASED_ROUTE_NAME, [RouteObjectInterface::CONTENT_OBJECT => $page, 'parameters' => null], UrlGeneratorInterface::ABSOLUTE_URL)
             ->willReturn('https://example.com/page')
         ;
 


### PR DESCRIPTION
Fixes #6081 

Alternative to https://github.com/contao/contao/pull/6134

Since we want `PageModel::getFrontendUrl` to always return either an absolute URL or an absolute path (and never a network path or a relative URL), shouldn't we specifically request this from the router then? This way we don't have to prepend the scheme manually afterwards.