### PR TITLE
Remove entity mapping type for app bundle

### DIFF
--- a/manager-bundle/src/ContaoManager/Plugin.php
+++ b/manager-bundle/src/ContaoManager/Plugin.php
@@ -382,7 +382,6 @@ class Plugin implements BundlePluginInterface, ConfigPluginInterface, RoutingPlu
                     $defaultEntityManager => [
                         'mappings' => [
                             'App' => [
-                                'type' => 'annotation',
                                 'dir' => '%kernel.project_dir%/src/Entity',
                                 'is_bundle' => false,
                                 'prefix' => 'App\Entity',

--- a/manager-bundle/tests/ContaoManager/PluginTest.php
+++ b/manager-bundle/tests/ContaoManager/PluginTest.php
@@ -1181,7 +1181,6 @@ class PluginTest extends ContaoTestCase
                             $defaultEntityManager => [
                                 'mappings' => [
                                     'App' => [
-                                        'type' => 'annotation',
                                         'dir' => '%kernel.project_dir%/src/Entity',
                                         'is_bundle' => false,
                                         'prefix' => 'App\Entity',


### PR DESCRIPTION
Using `type = 'annotation'` will not work when using PHP8 attributes, but not specifying a type will use auto-detection.