### PR TITLE
Fix force language in `PageModel::getFrontendUrl()`

### DIFF
--- a/core-bundle/src/Resources/contao/models/PageModel.php
+++ b/core-bundle/src/Resources/contao/models/PageModel.php
@@ -1363,7 +1363,7 @@ class PageModel extends Model
 
 		try
 		{
-			$strUrl = $objRouter->generate(PageRoute::PAGE_BASED_ROUTE_NAME, array(RouteObjectInterface::CONTENT_OBJECT => $this, 'parameters' => $strParams));
+			$strUrl = $objRouter->generate(PageRoute::PAGE_BASED_ROUTE_NAME, array(RouteObjectInterface::CONTENT_OBJECT => $page, 'parameters' => $strParams));
 		}
 		catch (RouteNotFoundException $e)
 		{


### PR DESCRIPTION
While working on #6140 I noticed that the (deprecated) second parameter of `PageModel::getFrontendUrl` is actually not working anymore. For the `$strForceLang` parameter we clone the original `PageModel` instance and force its language:

https://github.com/contao/contao/blob/8fca9e49714006921d9cdcaec5006141233b0f87/core-bundle/src/Resources/contao/models/PageModel.php#L1342-L1354

However, later on when we let the router generate the URL, we pass `$this` instead of `$page`, i.e. the original instance, instead of the cloned instance with the overridden language parameters.

https://github.com/contao/contao/blob/8fca9e49714006921d9cdcaec5006141233b0f87/core-bundle/src/Resources/contao/models/PageModel.php#L1366

This PR fixes that.

### Reproduction

1. Change your `config.yaml`:
  ```yaml
  contao:
      url_suffix: ''
      prepend_locale: true
      legacy_routing: true
  ```
2. Load a `PageModel` somewhere and use `getFrontendUrl` with the second parameter:
  ```php
  echo Contao\PageModel::findById(3)->getFrontendUrl(null, 'xx');
  ```

The URL will be `<original-language>/<alias>` instead of `xx/<alias>`.
