### PR TITLE
Add `authorModel` to the news templates

### DIFF
--- a/news-bundle/src/Resources/contao/modules/ModuleNews.php
+++ b/news-bundle/src/Resources/contao/modules/ModuleNews.php
@@ -147,6 +147,7 @@ abstract class ModuleNews extends Module
 		$objTemplate->commentCount = $arrMeta['comments'] ?? null;
 		$objTemplate->timestamp = $objArticle->date;
 		$objTemplate->author = $arrMeta['author'] ?? null;
+		$objTemplate->authorModel = $arrMeta['authorModel'] ?? null;
 		$objTemplate->datetime = date('Y-m-d\TH:i:sP', $objArticle->date);
 		$objTemplate->addImage = false;
 		$objTemplate->addBefore = false;


### PR DESCRIPTION
In https://github.com/contao/contao/pull/3119 we introduced an `'authorModel'` entry to `ModuleNews::getMetaFields`. However, this was then actually never passed on to the template and thus `'authorModel'` is completely unused. While the JSON-LD does output an author as this was later on fixed in https://github.com/contao/contao/pull/3161 - but the `'authorModel'` remains unused now. This fixes that by actually passing the `authorModel` to the news template (which can be useful, if you need just the author's name somewhere, without the "by" from the translation).