### PR TITLE
Correctly encode URLs in the sitemap

### DIFF
--- a/core-bundle/src/Controller/SitemapController.php
+++ b/core-bundle/src/Controller/SitemapController.php
@@ -34,10 +34,9 @@ class SitemapController extends AbstractController
     private PageRegistry $pageRegistry;
     private string $encoding;
 
-    public function __construct(PageRegistry $pageRegistry, string $encoding = 'UTF-8')
+    public function __construct(PageRegistry $pageRegistry)
     {
         $this->pageRegistry = $pageRegistry;
-        $this->encoding = $encoding;
     }
 
     /**

--- a/core-bundle/src/Controller/SitemapController.php
+++ b/core-bundle/src/Controller/SitemapController.php
@@ -32,10 +32,12 @@ use Symfony\Component\Routing\Exception\ExceptionInterface;
 class SitemapController extends AbstractController
 {
     private PageRegistry $pageRegistry;
+    private string $encoding;
 
-    public function __construct(PageRegistry $pageRegistry)
+    public function __construct(PageRegistry $pageRegistry, string $encoding = 'UTF-8')
     {
         $this->pageRegistry = $pageRegistry;
+        $this->encoding = $encoding;
     }
 
     /**
@@ -76,7 +78,7 @@ class SitemapController extends AbstractController
         $urlSet = $sitemap->createElementNS('https://www.sitemaps.org/schemas/sitemap/0.9', 'urlset');
 
         foreach ($urls as $url) {
-            $url = htmlspecialchars($url, ENT_XML1, $GLOBALS['TL_CONFIG']['characterSet'] ?? 'UTF-8', false);
+            $url = htmlspecialchars($url, ENT_XML1, $this->encoding, false);
             $loc = $sitemap->createElement('loc', $url);
             $urlEl = $sitemap->createElement('url');
             $urlEl->appendChild($loc);

--- a/core-bundle/src/Controller/SitemapController.php
+++ b/core-bundle/src/Controller/SitemapController.php
@@ -78,8 +78,8 @@ class SitemapController extends AbstractController
         $urlSet = $sitemap->createElementNS('https://www.sitemaps.org/schemas/sitemap/0.9', 'urlset');
 
         foreach ($urls as $url) {
-            $url = htmlspecialchars($url, ENT_XML1, $this->encoding, false);
-            $loc = $sitemap->createElement('loc', $url);
+            $loc = $sitemap->createElement('loc');
+            $loc->appendChild($sitemap->createTextNode($url));
             $urlEl = $sitemap->createElement('url');
             $urlEl->appendChild($loc);
             $urlSet->appendChild($urlEl);

--- a/core-bundle/src/Controller/SitemapController.php
+++ b/core-bundle/src/Controller/SitemapController.php
@@ -78,6 +78,7 @@ class SitemapController extends AbstractController
         foreach ($urls as $url) {
             $loc = $sitemap->createElement('loc');
             $loc->appendChild($sitemap->createTextNode($url));
+
             $urlEl = $sitemap->createElement('url');
             $urlEl->appendChild($loc);
             $urlSet->appendChild($urlEl);

--- a/core-bundle/src/Controller/SitemapController.php
+++ b/core-bundle/src/Controller/SitemapController.php
@@ -76,6 +76,7 @@ class SitemapController extends AbstractController
         $urlSet = $sitemap->createElementNS('https://www.sitemaps.org/schemas/sitemap/0.9', 'urlset');
 
         foreach ($urls as $url) {
+            $url = htmlspecialchars($url, ENT_XML1, $GLOBALS['TL_CONFIG']['characterSet'] ?? 'UTF-8', false);
             $loc = $sitemap->createElement('loc', $url);
             $urlEl = $sitemap->createElement('url');
             $urlEl->appendChild($loc);

--- a/core-bundle/src/Controller/SitemapController.php
+++ b/core-bundle/src/Controller/SitemapController.php
@@ -32,7 +32,6 @@ use Symfony\Component\Routing\Exception\ExceptionInterface;
 class SitemapController extends AbstractController
 {
     private PageRegistry $pageRegistry;
-    private string $encoding;
 
     public function __construct(PageRegistry $pageRegistry)
     {

--- a/core-bundle/src/Resources/config/controller.yml
+++ b/core-bundle/src/Resources/config/controller.yml
@@ -143,7 +143,6 @@ services:
     Contao\CoreBundle\Controller\SitemapController:
         arguments:
             - '@contao.routing.page_registry'
-            - '%kernel.charset%'
         tags:
             - controller.service_arguments
 

--- a/core-bundle/src/Resources/config/controller.yml
+++ b/core-bundle/src/Resources/config/controller.yml
@@ -143,6 +143,7 @@ services:
     Contao\CoreBundle\Controller\SitemapController:
         arguments:
             - '@contao.routing.page_registry'
+            - '%kernel.charset%'
         tags:
             - controller.service_arguments
 

--- a/core-bundle/tests/Controller/SitemapControllerTest.php
+++ b/core-bundle/tests/Controller/SitemapControllerTest.php
@@ -730,6 +730,7 @@ class SitemapControllerTest extends TestCase
 
         $controller = new SitemapController($registry);
         $controller->setContainer($container);
+
         $response = $controller(Request::create('https://www.foobar.com/sitemap.xml'));
 
         $this->assertSame(Response::HTTP_OK, $response->getStatusCode());

--- a/core-bundle/tests/Controller/SitemapControllerTest.php
+++ b/core-bundle/tests/Controller/SitemapControllerTest.php
@@ -710,6 +710,33 @@ class SitemapControllerTest extends TestCase
         unset($GLOBALS['TL_HOOKS']['getSearchablePages']);
     }
 
+    public function testEncodesTheUrl(): void
+    {
+        $page1 = $this->mockPage(
+            [
+                'id' => 43,
+                'pid' => 42,
+                'type' => 'regular',
+                'groups' => [],
+                'published' => '1',
+                'rootLanguage' => 'en',
+            ],
+            ['' => 'https://www.foobar.com/en/page1.html?foo=bar&bar=baz']
+        );
+
+        $framework = $this->mockFrameworkWithPages([42 => [$page1], 43 => null, 21 => null], [43 => null]);
+        $container = $this->getContainer($framework);
+        $registry = new PageRegistry($this->createMock(Connection::class));
+
+        $controller = new SitemapController($registry);
+        $controller->setContainer($container);
+        $response = $controller(Request::create('https://www.foobar.com/sitemap.xml'));
+
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertSame('public, s-maxage=2592000', $response->headers->get('Cache-Control'));
+        $this->assertSame($this->getExpectedSitemapContent(['https://www.foobar.com/en/page1.html?foo=bar&amp;bar=baz']), $response->getContent());
+    }
+
     public function testSkipsNonHtmlPages(): void
     {
         $page1 = $this->mockPage([


### PR DESCRIPTION
URLs with ampersands are no longer correctly encoded in the new Contao sitemap controller. See https://github.com/isotope/core/issues/2402

They were automatically encoded in Contao 4.9 (https://github.com/contao/contao/blob/4.9/core-bundle/src/Resources/contao/library/Contao/Automator.php#L377-L386), though I'm not exactly sure why that was so complicated 😂 