### PR TITLE
Try to fix the unit tests

### DIFF
--- a/core-bundle/src/Event/SitemapEvent.php
+++ b/core-bundle/src/Event/SitemapEvent.php
@@ -40,6 +40,7 @@ class SitemapEvent extends Event
 
         $loc = $sitemap->createElement('loc', $url);
         $urlEl = $sitemap->createElement('url');
+        $urlEl->removeAttribute('xmlns'); // PHP 8.3 fix
         $urlEl->appendChild($loc);
         $urlSet->appendChild($urlEl);
 


### PR DESCRIPTION
For some reason, PHP 8.3 suddenly adds `<url xmlns="">` instead of `<url>` here:

https://github.com/contao/contao/blob/d0e22df547706875d3df32c5ec3ba4d95eba56a7/core-bundle/src/Event/SitemapEvent.php#L42