### PR TITLE
Always use `System::importStatic()` for callbacks and hooks

### DIFF
--- a/calendar-bundle/contao/classes/Events.php
+++ b/calendar-bundle/contao/classes/Events.php
@@ -171,8 +171,7 @@ abstract class Events extends Module
 		{
 			foreach ($GLOBALS['TL_HOOKS']['getAllEvents'] as $callback)
 			{
-				$this->import($callback[0]);
-				$this->arrEvents = $this->{$callback[0]}->{$callback[1]}($this->arrEvents, $arrCalendars, $intStart, $intEnd, $this);
+				$this->arrEvents = System::importStatic($callback[0])->{$callback[1]}($this->arrEvents, $arrCalendars, $intStart, $intEnd, $this);
 			}
 		}
 

--- a/calendar-bundle/contao/modules/ModuleCalendar.php
+++ b/calendar-bundle/contao/modules/ModuleCalendar.php
@@ -130,8 +130,7 @@ class ModuleCalendar extends Events
 		{
 			foreach ($GLOBALS['TL_HOOKS']['findCalendarBoundaries'] as $callback)
 			{
-				$this->import($callback[0]);
-				$this->{$callback[0]}->{$callback[1]}($dateFrom, $dateTo, $repeatUntil, $this);
+				System::importStatic($callback[0])->{$callback[1]}($dateFrom, $dateTo, $repeatUntil, $this);
 			}
 		}
 

--- a/comments-bundle/contao/classes/Comments.php
+++ b/comments-bundle/contao/classes/Comments.php
@@ -352,8 +352,7 @@ class Comments extends Frontend
 			{
 				foreach ($GLOBALS['TL_HOOKS']['addComment'] as $callback)
 				{
-					$this->import($callback[0]);
-					$this->{$callback[0]}->{$callback[1]}($objComment->id, $arrSet, $this);
+					System::importStatic($callback[0])->{$callback[1]}($objComment->id, $arrSet, $this);
 				}
 			}
 

--- a/comments-bundle/contao/dca/tl_comments.php
+++ b/comments-bundle/contao/dca/tl_comments.php
@@ -449,9 +449,7 @@ class tl_comments extends Backend
 				{
 					foreach ($GLOBALS['TL_HOOKS']['isAllowedToEditComment'] as $callback)
 					{
-						$this->import($callback[0]);
-
-						if ($this->{$callback[0]}->{$callback[1]}($intParent, $strSource) === true)
+						if (System::importStatic($callback[0])->{$callback[1]}($intParent, $strSource) === true)
 						{
 							$cache[$strKey] = true;
 							break;
@@ -551,9 +549,7 @@ class tl_comments extends Backend
 				{
 					foreach ($GLOBALS['TL_HOOKS']['listComments'] as $callback)
 					{
-						$this->import($callback[0]);
-
-						if ($tmp = $this->{$callback[0]}->{$callback[1]}($arrRow))
+						if ($tmp = System::importStatic($callback[0])->{$callback[1]}($arrRow))
 						{
 							$title .= $tmp;
 							break;

--- a/core-bundle/contao/classes/Ajax.php
+++ b/core-bundle/contao/classes/Ajax.php
@@ -139,8 +139,7 @@ class Ajax extends Backend
 				{
 					foreach ($GLOBALS['TL_HOOKS']['executePreActions'] as $callback)
 					{
-						$this->import($callback[0]);
-						$this->{$callback[0]}->{$callback[1]}($this->strAction);
+						System::importStatic($callback[0])->{$callback[1]}($this->strAction);
 					}
 				}
 				break;
@@ -243,8 +242,7 @@ class Ajax extends Backend
 					{
 						if (\is_array($callback))
 						{
-							$this->import($callback[0]);
-							$varValue = $this->{$callback[0]}->{$callback[1]}($varValue, $dc);
+							$varValue = System::importStatic($callback[0])->{$callback[1]}($varValue, $dc);
 						}
 						elseif (\is_callable($callback))
 						{
@@ -390,8 +388,7 @@ class Ajax extends Backend
 		{
 			foreach ($GLOBALS['TL_HOOKS']['executePostActions'] as $callback)
 			{
-				$this->import($callback[0]);
-				$this->{$callback[0]}->{$callback[1]}($this->strAction, $dc);
+				System::importStatic($callback[0])->{$callback[1]}($this->strAction, $dc);
 			}
 		}
 	}

--- a/core-bundle/contao/classes/BackendTemplate.php
+++ b/core-bundle/contao/classes/BackendTemplate.php
@@ -40,8 +40,7 @@ class BackendTemplate extends Template
 		{
 			foreach ($GLOBALS['TL_HOOKS']['parseBackendTemplate'] as $callback)
 			{
-				$this->import($callback[0]);
-				$strBuffer = $this->{$callback[0]}->{$callback[1]}($strBuffer, $this->strTemplate);
+				$strBuffer = System::importStatic($callback[0])->{$callback[1]}($strBuffer, $this->strTemplate);
 			}
 		}
 
@@ -111,8 +110,7 @@ class BackendTemplate extends Template
 		{
 			foreach ($GLOBALS['TL_HOOKS']['outputBackendTemplate'] as $callback)
 			{
-				$this->import($callback[0]);
-				$strBuffer = $this->{$callback[0]}->{$callback[1]}($strBuffer, $this->strTemplate);
+				$strBuffer = System::importStatic($callback[0])->{$callback[1]}($strBuffer, $this->strTemplate);
 			}
 		}
 

--- a/core-bundle/contao/classes/BackendUser.php
+++ b/core-bundle/contao/classes/BackendUser.php
@@ -371,8 +371,7 @@ class BackendUser extends User
 		{
 			foreach ($GLOBALS['TL_HOOKS']['getUserNavigation'] as $callback)
 			{
-				$this->import($callback[0]);
-				$arrModules = $this->{$callback[0]}->{$callback[1]}($arrModules, true);
+				$arrModules = System::importStatic($callback[0])->{$callback[1]}($arrModules, true);
 			}
 		}
 

--- a/core-bundle/contao/classes/DataContainer.php
+++ b/core-bundle/contao/classes/DataContainer.php
@@ -408,8 +408,7 @@ abstract class DataContainer extends Backend
 			{
 				if (\is_array($callback))
 				{
-					$this->import($callback[0]);
-					$xlabel .= $this->{$callback[0]}->{$callback[1]}($this);
+					$xlabel .= System::importStatic($callback[0])->{$callback[1]}($this);
 				}
 				elseif (\is_callable($callback))
 				{
@@ -421,9 +420,7 @@ abstract class DataContainer extends Backend
 		// Input field callback
 		if (\is_array($arrData['input_field_callback'] ?? null))
 		{
-			$this->import($arrData['input_field_callback'][0]);
-
-			return $this->{$arrData['input_field_callback'][0]}->{$arrData['input_field_callback'][1]}($this, $xlabel);
+			return System::importStatic($arrData['input_field_callback'][0])->{$arrData['input_field_callback'][1]}($this, $xlabel);
 		}
 
 		if (\is_callable($arrData['input_field_callback'] ?? null))
@@ -624,8 +621,7 @@ abstract class DataContainer extends Backend
 			{
 				if (\is_array($callback))
 				{
-					$this->import($callback[0]);
-					$wizard .= $this->{$callback[0]}->{$callback[1]}($this);
+					$wizard .= System::importStatic($callback[0])->{$callback[1]}($this);
 				}
 				elseif (\is_callable($callback))
 				{
@@ -1078,8 +1074,7 @@ abstract class DataContainer extends Backend
 			// Call a custom function instead of using the default button
 			if (\is_array($v['button_callback'] ?? null))
 			{
-				$this->import($v['button_callback'][0]);
-				$return .= $this->{$v['button_callback'][0]}->{$v['button_callback'][1]}($v['href'] ?? null, $label, $title, $v['class'] ?? null, $attributes, $this->strTable, $this->root);
+				$return .= System::importStatic($v['button_callback'][0])->{$v['button_callback'][1]}($v['href'] ?? null, $label, $title, $v['class'] ?? null, $attributes, $this->strTable, $this->root);
 				continue;
 			}
 
@@ -1170,8 +1165,7 @@ abstract class DataContainer extends Backend
 			// Call a custom function instead of using the default button
 			if (\is_array($v['button_callback'] ?? null))
 			{
-				$this->import($v['button_callback'][0]);
-				$return .= $this->{$v['button_callback'][0]}->{$v['button_callback'][1]}($arrRow, $v['href'], $label, $title, $v['icon'], $attributes, $strPtable, array(), null, false, null, null, $this);
+				$return .= System::importStatic($v['button_callback'][0])->{$v['button_callback'][1]}($arrRow, $v['href'], $label, $title, $v['icon'], $attributes, $strPtable, array(), null, false, null, null, $this);
 				continue;
 			}
 
@@ -1392,8 +1386,7 @@ abstract class DataContainer extends Backend
 
 						if (\is_array($arrCallback))
 						{
-							$this->import($arrCallback[0]);
-							$panel = $this->{$arrCallback[0]}->{$arrCallback[1]}($this);
+							$panel = System::importStatic($arrCallback[0])->{$arrCallback[1]}($this);
 						}
 						elseif (\is_callable($arrCallback))
 						{
@@ -1494,8 +1487,7 @@ abstract class DataContainer extends Backend
 			{
 				if (\is_array($callback))
 				{
-					$this->import($callback[0]);
-					$tags = $this->{$callback[0]}->{$callback[1]}($this, $tags);
+					$tags = System::importStatic($callback[0])->{$callback[1]}($this, $tags);
 				}
 				elseif (\is_callable($callback))
 				{

--- a/core-bundle/contao/classes/DataContainer.php
+++ b/core-bundle/contao/classes/DataContainer.php
@@ -900,17 +900,16 @@ abstract class DataContainer extends Backend
 			// Call a custom function instead of using the default button
 			if (\is_array($v['button_callback'] ?? null))
 			{
-				$this->import($v['button_callback'][0]);
-
-				$ref = new \ReflectionMethod($this->{$v['button_callback'][0]}, $v['button_callback'][1]);
+				$callback = System::importStatic($v['button_callback'][0]);
+				$ref = new \ReflectionMethod($callback, $v['button_callback'][1]);
 
 				if ($ref->getNumberOfParameters() === 1 && ($type = $ref->getParameters()[0]->getType()) && $type->getName() === DataContainerOperation::class)
 				{
-					$this->{$v['button_callback'][0]}->{$v['button_callback'][1]}($config);
+					$callback->{$v['button_callback'][1]}($config);
 				}
 				else
 				{
-					$return .= $this->{$v['button_callback'][0]}->{$v['button_callback'][1]}($arrRow, $config['href'] ?? null, $config['label'], $config['title'], $config['icon'] ?? null, $config['attributes'], $strTable, $arrRootIds, $arrChildRecordIds, $blnCircularReference, $strPrevious, $strNext, $this);
+					$return .= $callback->{$v['button_callback'][1]}($arrRow, $config['href'] ?? null, $config['label'], $config['title'], $config['icon'] ?? null, $config['attributes'], $strTable, $arrRootIds, $arrChildRecordIds, $blnCircularReference, $strPrevious, $strNext, $this);
 					continue;
 				}
 			}

--- a/core-bundle/contao/classes/FrontendTemplate.php
+++ b/core-bundle/contao/classes/FrontendTemplate.php
@@ -47,8 +47,7 @@ class FrontendTemplate extends Template
 		{
 			foreach ($GLOBALS['TL_HOOKS']['parseFrontendTemplate'] as $callback)
 			{
-				$this->import($callback[0]);
-				$strBuffer = $this->{$callback[0]}->{$callback[1]}($strBuffer, $this->strTemplate, $this);
+				$strBuffer = System::importStatic($callback[0])->{$callback[1]}($strBuffer, $this->strTemplate, $this);
 			}
 		}
 
@@ -94,8 +93,7 @@ class FrontendTemplate extends Template
 		{
 			foreach ($GLOBALS['TL_HOOKS']['outputFrontendTemplate'] as $callback)
 			{
-				$this->import($callback[0]);
-				$this->strBuffer = $this->{$callback[0]}->{$callback[1]}($this->strBuffer, $this->strTemplate);
+				$this->strBuffer = System::importStatic($callback[0])->{$callback[1]}($this->strBuffer, $this->strTemplate);
 			}
 		}
 
@@ -106,8 +104,7 @@ class FrontendTemplate extends Template
 		{
 			foreach ($GLOBALS['TL_HOOKS']['modifyFrontendPage'] as $callback)
 			{
-				$this->import($callback[0]);
-				$this->strBuffer = $this->{$callback[0]}->{$callback[1]}($this->strBuffer, $this->strTemplate);
+				$this->strBuffer = System::importStatic($callback[0])->{$callback[1]}($this->strBuffer, $this->strTemplate);
 			}
 		}
 

--- a/core-bundle/contao/classes/PurgeData.php
+++ b/core-bundle/contao/classes/PurgeData.php
@@ -52,8 +52,7 @@ class PurgeData extends Backend implements MaintenanceModuleInterface
 					foreach ($jobs as $job)
 					{
 						list($class, $method) = $GLOBALS['TL_PURGE'][$group][$job]['callback'];
-						$this->import($class);
-						$this->$class->$method();
+						System::importStatic($class)->$method();
 					}
 				}
 			}

--- a/core-bundle/contao/classes/Versions.php
+++ b/core-bundle/contao/classes/Versions.php
@@ -236,8 +236,7 @@ class Versions extends Controller
 			{
 				if (\is_array($callback))
 				{
-					$this->import($callback[0]);
-					$this->{$callback[0]}->{$callback[1]}($this->strTable, $this->intPid, $intVersion, $data);
+					System::importStatic($callback[0])->{$callback[1]}($this->strTable, $this->intPid, $intVersion, $data);
 				}
 				elseif (\is_callable($callback))
 				{
@@ -341,8 +340,7 @@ class Versions extends Controller
 			{
 				if (\is_array($callback))
 				{
-					$this->import($callback[0]);
-					$this->{$callback[0]}->{$callback[1]}($this->strTable, $this->intPid, $intVersion, $data);
+					System::importStatic($callback[0])->{$callback[1]}($this->strTable, $this->intPid, $intVersion, $data);
 				}
 				elseif (\is_callable($callback))
 				{

--- a/core-bundle/contao/controllers/BackendHelp.php
+++ b/core-bundle/contao/controllers/BackendHelp.php
@@ -71,8 +71,7 @@ class BackendHelp extends Backend
 			}
 			elseif (\is_array($arrData['options_callback'] ?? null))
 			{
-				$this->import($arrData['options_callback'][0]);
-				$options = $this->{$arrData['options_callback'][0]}->{$arrData['options_callback'][1]}(new DC_Table($table));
+				$options = System::importStatic($arrData['options_callback'][0])->{$arrData['options_callback'][1]}(new DC_Table($table));
 			}
 			elseif (\is_callable($arrData['options_callback'] ?? null))
 			{

--- a/core-bundle/contao/controllers/BackendPassword.php
+++ b/core-bundle/contao/controllers/BackendPassword.php
@@ -106,8 +106,7 @@ class BackendPassword extends Backend
 						{
 							if (\is_array($callback))
 							{
-								$this->import($callback[0]);
-								$pw = $this->{$callback[0]}->{$callback[1]}($pw, $dc);
+								$pw = System::importStatic($callback[0])->{$callback[1]}($pw, $dc);
 							}
 							elseif (\is_callable($callback))
 							{

--- a/core-bundle/contao/dca/tl_log.php
+++ b/core-bundle/contao/dca/tl_log.php
@@ -11,6 +11,7 @@
 use Contao\Backend;
 use Contao\DataContainer;
 use Contao\DC_Table;
+use Contao\System;
 
 $GLOBALS['TL_DCA']['tl_log'] = array
 (
@@ -167,8 +168,7 @@ class tl_log extends Backend
 				{
 					foreach ($GLOBALS['TL_HOOKS']['colorizeLogEntries'] as $callback)
 					{
-						$this->import($callback[0]);
-						$label = $this->{$callback[0]}->{$callback[1]}($row, $label);
+						$label = System::importStatic($callback[0])->{$callback[1]}($row, $label);
 					}
 				}
 				break;

--- a/core-bundle/contao/dca/tl_member.php
+++ b/core-bundle/contao/dca/tl_member.php
@@ -488,8 +488,7 @@ class tl_member extends Backend
 		{
 			foreach ($GLOBALS['TL_HOOKS']['setNewPassword'] as $callback)
 			{
-				$this->import($callback[0]);
-				$this->{$callback[0]}->{$callback[1]}($objUser, $strPassword);
+				System::importStatic($callback[0])->{$callback[1]}($objUser, $strPassword);
 			}
 		}
 

--- a/core-bundle/contao/dca/tl_page.php
+++ b/core-bundle/contao/dca/tl_page.php
@@ -1473,8 +1473,7 @@ class tl_page extends Backend
 					{
 						if (is_array($callback))
 						{
-							$this->import($callback[0]);
-							$strAlias = $this->{$callback[0]}->{$callback[1]}($strAlias, $dc);
+							$strAlias = System::importStatic($callback[0])->{$callback[1]}($strAlias, $dc);
 						}
 						elseif (is_callable($callback))
 						{

--- a/core-bundle/contao/drivers/DC_File.php
+++ b/core-bundle/contao/drivers/DC_File.php
@@ -46,8 +46,7 @@ class DC_File extends DataContainer implements EditableDataContainerInterface
 			{
 				if (\is_array($callback))
 				{
-					$this->import($callback[0]);
-					$this->{$callback[0]}->{$callback[1]}($this);
+					System::importStatic($callback[0])->{$callback[1]}($this);
 				}
 				elseif (\is_callable($callback))
 				{
@@ -226,8 +225,7 @@ class DC_File extends DataContainer implements EditableDataContainerInterface
 						{
 							if (\is_array($callback))
 							{
-								$this->import($callback[0]);
-								$this->varValue = $this->{$callback[0]}->{$callback[1]}($this->varValue, $this);
+								$this->varValue = System::importStatic($callback[0])->{$callback[1]}($this->varValue, $this);
 							}
 							elseif (\is_callable($callback))
 							{
@@ -265,8 +263,7 @@ class DC_File extends DataContainer implements EditableDataContainerInterface
 			{
 				if (\is_array($callback))
 				{
-					$this->import($callback[0]);
-					$arrButtons = $this->{$callback[0]}->{$callback[1]}($arrButtons, $this);
+					$arrButtons = System::importStatic($callback[0])->{$callback[1]}($arrButtons, $this);
 				}
 				elseif (\is_callable($callback))
 				{
@@ -306,8 +303,7 @@ class DC_File extends DataContainer implements EditableDataContainerInterface
 				{
 					if (\is_array($callback))
 					{
-						$this->import($callback[0]);
-						$this->{$callback[0]}->{$callback[1]}($this);
+						System::importStatic($callback[0])->{$callback[1]}($this);
 					}
 					elseif (\is_callable($callback))
 					{
@@ -392,8 +388,7 @@ class DC_File extends DataContainer implements EditableDataContainerInterface
 			{
 				if (\is_array($callback))
 				{
-					$this->import($callback[0]);
-					$varValue = $this->{$callback[0]}->{$callback[1]}($varValue, $this);
+					$varValue = System::importStatic($callback[0])->{$callback[1]}($varValue, $this);
 				}
 				elseif (\is_callable($callback))
 				{

--- a/core-bundle/contao/drivers/DC_Folder.php
+++ b/core-bundle/contao/drivers/DC_Folder.php
@@ -229,8 +229,7 @@ class DC_Folder extends DataContainer implements ListableDataContainerInterface,
 			{
 				if (\is_array($callback))
 				{
-					$this->import($callback[0]);
-					$this->{$callback[0]}->{$callback[1]}($this);
+					System::importStatic($callback[0])->{$callback[1]}($this);
 				}
 				elseif (\is_callable($callback))
 				{
@@ -537,8 +536,7 @@ class DC_Folder extends DataContainer implements ListableDataContainerInterface,
 				{
 					if (\is_array($callback))
 					{
-						$this->import($callback[0]);
-						$arrButtons = $this->{$callback[0]}->{$callback[1]}($arrButtons, $this);
+						$arrButtons = System::importStatic($callback[0])->{$callback[1]}($arrButtons, $this);
 					}
 					elseif (\is_callable($callback))
 					{
@@ -745,8 +743,7 @@ class DC_Folder extends DataContainer implements ListableDataContainerInterface,
 				{
 					if (\is_array($callback))
 					{
-						$this->import($callback[0]);
-						$this->{$callback[0]}->{$callback[1]}($source, $destination, $this);
+						System::importStatic($callback[0])->{$callback[1]}($source, $destination, $this);
 					}
 					elseif (\is_callable($callback))
 					{
@@ -934,8 +931,7 @@ class DC_Folder extends DataContainer implements ListableDataContainerInterface,
 			{
 				if (\is_array($callback))
 				{
-					$this->import($callback[0]);
-					$this->{$callback[0]}->{$callback[1]}($source, $destination, $this);
+					System::importStatic($callback[0])->{$callback[1]}($source, $destination, $this);
 				}
 				elseif (\is_callable($callback))
 				{
@@ -1042,8 +1038,7 @@ class DC_Folder extends DataContainer implements ListableDataContainerInterface,
 			{
 				if (\is_array($callback))
 				{
-					$this->import($callback[0]);
-					$this->{$callback[0]}->{$callback[1]}($source, $this);
+					System::importStatic($callback[0])->{$callback[1]}($source, $this);
 				}
 				elseif (\is_callable($callback))
 				{
@@ -1218,8 +1213,7 @@ class DC_Folder extends DataContainer implements ListableDataContainerInterface,
 				{
 					if (\is_array($callback))
 					{
-						$this->import($callback[0]);
-						$this->{$callback[0]}->{$callback[1]}($arrUploaded);
+						System::importStatic($callback[0])->{$callback[1]}($arrUploaded);
 					}
 					elseif (\is_callable($callback))
 					{
@@ -1286,8 +1280,7 @@ class DC_Folder extends DataContainer implements ListableDataContainerInterface,
 			{
 				if (\is_array($callback))
 				{
-					$this->import($callback[0]);
-					$arrButtons = $this->{$callback[0]}->{$callback[1]}($arrButtons, $this);
+					$arrButtons = System::importStatic($callback[0])->{$callback[1]}($arrButtons, $this);
 				}
 				elseif (\is_callable($callback))
 				{
@@ -1480,8 +1473,7 @@ class DC_Folder extends DataContainer implements ListableDataContainerInterface,
 						{
 							if (\is_array($callback))
 							{
-								$this->import($callback[0]);
-								$this->varValue = $this->{$callback[0]}->{$callback[1]}($this->varValue, $this);
+								$this->varValue = System::importStatic($callback[0])->{$callback[1]}($this->varValue, $this);
 							}
 							elseif (\is_callable($callback))
 							{
@@ -1527,8 +1519,7 @@ class DC_Folder extends DataContainer implements ListableDataContainerInterface,
 			{
 				if (\is_array($callback))
 				{
-					$this->import($callback[0]);
-					$arrButtons = $this->{$callback[0]}->{$callback[1]}($arrButtons, $this);
+					$arrButtons = System::importStatic($callback[0])->{$callback[1]}($arrButtons, $this);
 				}
 				elseif (\is_callable($callback))
 				{
@@ -1592,8 +1583,7 @@ class DC_Folder extends DataContainer implements ListableDataContainerInterface,
 				{
 					if (\is_array($callback))
 					{
-						$this->import($callback[0]);
-						$this->{$callback[0]}->{$callback[1]}($this);
+						System::importStatic($callback[0])->{$callback[1]}($this);
 					}
 					elseif (\is_callable($callback))
 					{
@@ -1776,8 +1766,7 @@ class DC_Folder extends DataContainer implements ListableDataContainerInterface,
 						{
 							if (\is_array($callback))
 							{
-								$this->import($callback[0]);
-								$this->varValue = $this->{$callback[0]}->{$callback[1]}($this->varValue, $this);
+								$this->varValue = System::importStatic($callback[0])->{$callback[1]}($this->varValue, $this);
 							}
 							elseif (\is_callable($callback))
 							{
@@ -1810,8 +1799,7 @@ class DC_Folder extends DataContainer implements ListableDataContainerInterface,
 						{
 							if (\is_array($callback))
 							{
-								$this->import($callback[0]);
-								$this->{$callback[0]}->{$callback[1]}($this);
+								System::importStatic($callback[0])->{$callback[1]}($this);
 							}
 							elseif (\is_callable($callback))
 							{
@@ -1847,8 +1835,7 @@ class DC_Folder extends DataContainer implements ListableDataContainerInterface,
 				{
 					if (\is_array($callback))
 					{
-						$this->import($callback[0]);
-						$arrButtons = $this->{$callback[0]}->{$callback[1]}($arrButtons, $this);
+						$arrButtons = System::importStatic($callback[0])->{$callback[1]}($arrButtons, $this);
 					}
 					elseif (\is_callable($callback))
 					{
@@ -2121,8 +2108,7 @@ class DC_Folder extends DataContainer implements ListableDataContainerInterface,
 			{
 				if (\is_array($callback))
 				{
-					$this->import($callback[0]);
-					$arrButtons = $this->{$callback[0]}->{$callback[1]}($arrButtons, $this);
+					$arrButtons = System::importStatic($callback[0])->{$callback[1]}($arrButtons, $this);
 				}
 				elseif (\is_callable($callback))
 				{
@@ -2254,8 +2240,7 @@ class DC_Folder extends DataContainer implements ListableDataContainerInterface,
 				{
 					if (\is_array($callback))
 					{
-						$this->import($callback[0]);
-						$varValue = $this->{$callback[0]}->{$callback[1]}($varValue, $this);
+						$varValue = System::importStatic($callback[0])->{$callback[1]}($varValue, $this);
 					}
 					elseif (\is_callable($callback))
 					{
@@ -2400,8 +2385,7 @@ class DC_Folder extends DataContainer implements ListableDataContainerInterface,
 				{
 					if (\is_array($callback))
 					{
-						$this->import($callback[0]);
-						$varValue = $this->{$callback[0]}->{$callback[1]}($varValue, $this);
+						$varValue = System::importStatic($callback[0])->{$callback[1]}($varValue, $this);
 					}
 					elseif (\is_callable($callback))
 					{

--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -208,8 +208,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 			{
 				if (\is_array($callback))
 				{
-					$this->import($callback[0]);
-					$this->{$callback[0]}->{$callback[1]}($this);
+					System::importStatic($callback[0])->{$callback[1]}($this);
 				}
 				elseif (\is_callable($callback))
 				{
@@ -562,8 +561,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 			{
 				if (\is_array($callback))
 				{
-					$this->import($callback[0]);
-					$data = $this->{$callback[0]}->{$callback[1]}($data, $currentRecord, $this);
+					$data = System::importStatic($callback[0])->{$callback[1]}($data, $currentRecord, $this);
 				}
 				elseif (\is_callable($callback))
 				{
@@ -702,8 +700,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 					{
 						if (\is_array($callback))
 						{
-							$this->import($callback[0]);
-							$this->{$callback[0]}->{$callback[1]}($this->strTable, $insertID, $this->set, $this);
+							System::importStatic($callback[0])->{$callback[1]}($this->strTable, $insertID, $this->set, $this);
 						}
 						elseif (\is_callable($callback))
 						{
@@ -809,8 +806,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 			{
 				if (\is_array($callback))
 				{
-					$this->import($callback[0]);
-					$this->{$callback[0]}->{$callback[1]}($this);
+					System::importStatic($callback[0])->{$callback[1]}($this);
 				}
 				elseif (\is_callable($callback))
 				{
@@ -1009,8 +1005,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 					{
 						if (\is_array($callback))
 						{
-							$this->import($callback[0]);
-							$this->{$callback[0]}->{$callback[1]}($insertID, $this);
+							System::importStatic($callback[0])->{$callback[1]}($insertID, $this);
 						}
 						elseif (\is_callable($callback))
 						{
@@ -1188,8 +1183,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 
 								if (\is_array($callback))
 								{
-									$this->import($callback[0]);
-									$this->{$callback[0]}->{$callback[1]}($insertID, $dc);
+									System::importStatic($callback[0])->{$callback[1]}($insertID, $dc);
 								}
 								elseif (\is_callable($callback))
 								{
@@ -1635,8 +1629,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 				{
 					if (\is_array($callback))
 					{
-						$this->import($callback[0]);
-						$this->{$callback[0]}->{$callback[1]}($this, $undoId);
+						System::importStatic($callback[0])->{$callback[1]}($this, $undoId);
 					}
 					elseif (\is_callable($callback))
 					{
@@ -1840,8 +1833,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 					{
 						if (\is_array($callback))
 						{
-							$this->import($callback[0]);
-							$this->{$callback[0]}->{$callback[1]}($table, $row, $this);
+							System::importStatic($callback[0])->{$callback[1]}($table, $row, $this);
 						}
 						elseif (\is_callable($callback))
 						{
@@ -2065,8 +2057,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 						{
 							if (\is_array($callback))
 							{
-								$this->import($callback[0]);
-								$this->varValue = $this->{$callback[0]}->{$callback[1]}($this->varValue, $this);
+								$this->varValue = System::importStatic($callback[0])->{$callback[1]}($this->varValue, $this);
 							}
 							elseif (\is_callable($callback))
 							{
@@ -2256,8 +2247,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 			{
 				if (\is_array($callback))
 				{
-					$this->import($callback[0]);
-					$arrButtons = $this->{$callback[0]}->{$callback[1]}($arrButtons, $this);
+					$arrButtons = System::importStatic($callback[0])->{$callback[1]}($arrButtons, $this);
 				}
 				elseif (\is_callable($callback))
 				{
@@ -2571,8 +2561,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 							{
 								if (\is_array($callback))
 								{
-									$this->import($callback[0]);
-									$this->varValue = $this->{$callback[0]}->{$callback[1]}($this->varValue, $this);
+									$this->varValue = System::importStatic($callback[0])->{$callback[1]}($this->varValue, $this);
 								}
 								elseif (\is_callable($callback))
 								{
@@ -2649,8 +2638,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 				{
 					if (\is_array($callback))
 					{
-						$this->import($callback[0]);
-						$arrButtons = $this->{$callback[0]}->{$callback[1]}($arrButtons, $this);
+						$arrButtons = System::importStatic($callback[0])->{$callback[1]}($arrButtons, $this);
 					}
 					elseif (\is_callable($callback))
 					{
@@ -3029,8 +3017,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 				{
 					if (\is_array($callback))
 					{
-						$this->import($callback[0]);
-						$arrButtons = $this->{$callback[0]}->{$callback[1]}($arrButtons, $this);
+						$arrButtons = System::importStatic($callback[0])->{$callback[1]}($arrButtons, $this);
 					}
 					elseif (\is_callable($callback))
 					{
@@ -3194,8 +3181,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 				{
 					if (\is_array($callback))
 					{
-						$this->import($callback[0]);
-						$old = $this->{$callback[0]}->{$callback[1]}($old, $this);
+						$old = System::importStatic($callback[0])->{$callback[1]}($old, $this);
 					}
 					elseif (\is_callable($callback))
 					{
@@ -3242,8 +3228,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 			{
 				if (\is_array($callback))
 				{
-					$this->import($callback[0]);
-					$varValue = $this->{$callback[0]}->{$callback[1]}($varValue, $this);
+					$varValue = System::importStatic($callback[0])->{$callback[1]}($varValue, $this);
 				}
 				elseif (\is_callable($callback))
 				{
@@ -3305,8 +3290,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 					{
 						if (\is_array($callback))
 						{
-							$this->import($callback[0]);
-							$arrValues = $this->{$callback[0]}->{$callback[1]}($arrValues, $this);
+							$arrValues = System::importStatic($callback[0])->{$callback[1]}($arrValues, $this);
 						}
 						elseif (\is_callable($callback))
 						{
@@ -3403,8 +3387,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 			{
 				if (\is_array($callback))
 				{
-					$this->import($callback[0]);
-					$this->{$callback[0]}->{$callback[1]}($this);
+					System::importStatic($callback[0])->{$callback[1]}($this);
 				}
 				elseif (\is_callable($callback))
 				{
@@ -3567,8 +3550,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 
 				if (\is_array($callback))
 				{
-					$this->import($callback[0]);
-					$status = $this->{$callback[0]}->{$callback[1]}($this->strTable, $new_records[$this->strTable] ?? null, $ptable, $ctable);
+					$status = System::importStatic($callback[0])->{$callback[1]}($this->strTable, $new_records[$this->strTable] ?? null, $ptable, $ctable);
 				}
 				elseif (\is_callable($callback))
 				{
@@ -3919,8 +3901,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 				$strClass = $GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['paste_button_callback'][0];
 				$strMethod = $GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['paste_button_callback'][1];
 
-				$this->import($strClass);
-				$_buttons = $this->$strClass->$strMethod($this, array('id'=>0), $table, false, $arrClipboard);
+				$_buttons = System::importStatic($strClass)->$strMethod($this, array('id'=>0), $table, false, $arrClipboard);
 			}
 			elseif (\is_callable($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['paste_button_callback'] ?? null))
 			{
@@ -3985,8 +3966,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 				{
 					if (\is_array($callback))
 					{
-						$this->import($callback[0]);
-						$arrButtons = $this->{$callback[0]}->{$callback[1]}($arrButtons, $this);
+						$arrButtons = System::importStatic($callback[0])->{$callback[1]}($arrButtons, $this);
 					}
 					elseif (\is_callable($callback))
 					{
@@ -4287,8 +4267,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 				$strClass = $GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['paste_button_callback'][0];
 				$strMethod = $GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['paste_button_callback'][1];
 
-				$this->import($strClass);
-				$_buttons .= $this->$strClass->$strMethod($this, $currentRecord, $table, $blnCircularReference, $arrClipboard, $childs, $previous, $next);
+				$_buttons .= System::importStatic($strClass)->$strMethod($this, $currentRecord, $table, $blnCircularReference, $arrClipboard, $childs, $previous, $next);
 			}
 			elseif (\is_callable($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['paste_button_callback'] ?? null))
 			{
@@ -4586,8 +4565,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 					$strClass = $GLOBALS['TL_DCA'][$this->ptable]['fields'][$v]['options_callback'][0];
 					$strMethod = $GLOBALS['TL_DCA'][$this->ptable]['fields'][$v]['options_callback'][1];
 
-					$this->import($strClass);
-					$options_callback = $this->$strClass->$strMethod($this);
+					$options_callback = System::importStatic($strClass)->$strMethod($this);
 
 					$_v = $options_callback[$_v] ?? '-';
 				}
@@ -4620,8 +4598,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 				$strClass = $GLOBALS['TL_DCA'][$table]['list']['sorting']['header_callback'][0];
 				$strMethod = $GLOBALS['TL_DCA'][$table]['list']['sorting']['header_callback'][1];
 
-				$this->import($strClass);
-				$add = $this->$strClass->$strMethod($add, $this);
+				$add = System::importStatic($strClass)->$strMethod($add, $this);
 			}
 			elseif (\is_callable($GLOBALS['TL_DCA'][$table]['list']['sorting']['header_callback'] ?? null))
 			{
@@ -4853,8 +4830,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 					$strClass = $GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['child_record_callback'][0];
 					$strMethod = $GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['child_record_callback'][1];
 
-					$this->import($strClass);
-					$return .= '</div>' . $this->$strClass->$strMethod($row[$i]) . '</div>';
+					$return .= '</div>' . System::importStatic($strClass)->$strMethod($row[$i]) . '</div>';
 				}
 				elseif (\is_callable($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['child_record_callback'] ?? null))
 				{
@@ -4941,8 +4917,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 				{
 					if (\is_array($callback))
 					{
-						$this->import($callback[0]);
-						$arrButtons = $this->{$callback[0]}->{$callback[1]}($arrButtons, $this);
+						$arrButtons = System::importStatic($callback[0])->{$callback[1]}($arrButtons, $this);
 					}
 					elseif (\is_callable($callback))
 					{
@@ -5058,8 +5033,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 						$strClass = $GLOBALS['TL_DCA'][$this->strTable]['fields'][$key]['options_callback'][0];
 						$strMethod = $GLOBALS['TL_DCA'][$this->strTable]['fields'][$key]['options_callback'][1];
 
-						$this->import($strClass);
-						$keys = $this->$strClass->$strMethod($this);
+						$keys = System::importStatic($strClass)->$strMethod($this);
 					}
 					elseif (\is_callable($GLOBALS['TL_DCA'][$this->strTable]['fields'][$key]['options_callback'] ?? null))
 					{
@@ -5339,8 +5313,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 					{
 						if (\is_array($callback))
 						{
-							$this->import($callback[0]);
-							$arrButtons = $this->{$callback[0]}->{$callback[1]}($arrButtons, $this);
+							$arrButtons = System::importStatic($callback[0])->{$callback[1]}($arrButtons, $this);
 						}
 						elseif (\is_callable($callback))
 						{
@@ -6139,8 +6112,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 						$strClass = $GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['options_callback'][0];
 						$strMethod = $GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['options_callback'][1];
 
-						$this->import($strClass);
-						$options_callback = $this->$strClass->$strMethod($this);
+						$options_callback = System::importStatic($strClass)->$strMethod($this);
 					}
 					elseif (\is_callable($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['options_callback'] ?? null))
 					{
@@ -6433,8 +6405,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 				$strClass = $GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['options_callback'][0];
 				$strMethod = $GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['options_callback'][1];
 
-				$this->import($strClass);
-				$lookup[$field] = $this->$strClass->$strMethod($this);
+				$lookup[$field] = System::importStatic($strClass)->$strMethod($this);
 			}
 
 			$group = $lookup[$field][$value] ?? null;
@@ -6470,8 +6441,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 			$strClass = $GLOBALS['TL_DCA'][$this->strTable]['list']['label']['group_callback'][0];
 			$strMethod = $GLOBALS['TL_DCA'][$this->strTable]['list']['label']['group_callback'][1];
 
-			$this->import($strClass);
-			$group = $this->$strClass->$strMethod($group, $mode, $field, $row, $this);
+			$group = System::importStatic($strClass)->$strMethod($group, $mode, $field, $row, $this);
 		}
 		elseif (\is_callable($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['group_callback'] ?? null))
 		{

--- a/core-bundle/contao/forms/Form.php
+++ b/core-bundle/contao/forms/Form.php
@@ -194,8 +194,7 @@ class Form extends Hybrid
 		{
 			foreach ($GLOBALS['TL_HOOKS']['compileFormFields'] as $callback)
 			{
-				$this->import($callback[0]);
-				$arrFields = $this->{$callback[0]}->{$callback[1]}($arrFields, $formId, $this);
+				$arrFields = System::importStatic($callback[0])->{$callback[1]}($arrFields, $formId, $this);
 			}
 		}
 
@@ -239,8 +238,7 @@ class Form extends Hybrid
 				{
 					foreach ($GLOBALS['TL_HOOKS']['loadFormField'] as $callback)
 					{
-						$this->import($callback[0]);
-						$objWidget = $this->{$callback[0]}->{$callback[1]}($objWidget, $formId, $this->arrData, $this);
+						$objWidget = System::importStatic($callback[0])->{$callback[1]}($objWidget, $formId, $this->arrData, $this);
 					}
 				}
 
@@ -254,8 +252,7 @@ class Form extends Hybrid
 					{
 						foreach ($GLOBALS['TL_HOOKS']['validateFormField'] as $callback)
 						{
-							$this->import($callback[0]);
-							$objWidget = $this->{$callback[0]}->{$callback[1]}($objWidget, $formId, $this->arrData, $this);
+							$objWidget = System::importStatic($callback[0])->{$callback[1]}($objWidget, $formId, $this->arrData, $this);
 						}
 					}
 
@@ -390,8 +387,7 @@ class Form extends Hybrid
 		{
 			foreach ($GLOBALS['TL_HOOKS']['prepareFormData'] as $callback)
 			{
-				$this->import($callback[0]);
-				$this->{$callback[0]}->{$callback[1]}($arrSubmitted, $arrLabels, $arrFields, $this, $arrFiles);
+				System::importStatic($callback[0])->{$callback[1]}($arrSubmitted, $arrLabels, $arrFields, $this, $arrFiles);
 			}
 		}
 
@@ -589,8 +585,7 @@ class Form extends Hybrid
 			{
 				foreach ($GLOBALS['TL_HOOKS']['storeFormData'] as $callback)
 				{
-					$this->import($callback[0]);
-					$arrSet = $this->{$callback[0]}->{$callback[1]}($arrSet, $this);
+					$arrSet = System::importStatic($callback[0])->{$callback[1]}($arrSet, $this);
 				}
 			}
 
@@ -615,8 +610,7 @@ class Form extends Hybrid
 		{
 			foreach ($GLOBALS['TL_HOOKS']['processFormData'] as $callback)
 			{
-				$this->import($callback[0]);
-				$this->{$callback[0]}->{$callback[1]}($arrSubmitted, $this->arrData, $arrFiles, $arrLabels, $this);
+				System::importStatic($callback[0])->{$callback[1]}($arrSubmitted, $this->arrData, $arrFiles, $arrLabels, $this);
 			}
 		}
 

--- a/core-bundle/contao/library/Contao/Automator.php
+++ b/core-bundle/contao/library/Contao/Automator.php
@@ -280,8 +280,7 @@ class Automator extends System
 		{
 			foreach ($GLOBALS['TL_HOOKS']['removeOldFeeds'] as $callback)
 			{
-				$this->import($callback[0]);
-				$arrFeeds = array_merge($arrFeeds, $this->{$callback[0]}->{$callback[1]}());
+				$arrFeeds = array(...$arrFeeds, ...System::importStatic($callback[0])->{$callback[1]}());
 			}
 		}
 
@@ -348,8 +347,7 @@ class Automator extends System
 		{
 			foreach ($GLOBALS['TL_HOOKS']['generateXmlFiles'] as $callback)
 			{
-				$this->import($callback[0]);
-				$this->{$callback[0]}->{$callback[1]}();
+				System::importStatic($callback[0])->{$callback[1]}();
 			}
 		}
 

--- a/core-bundle/contao/library/Contao/Combiner.php
+++ b/core-bundle/contao/library/Contao/Combiner.php
@@ -343,8 +343,7 @@ class Combiner extends System
 			{
 				foreach ($GLOBALS['TL_HOOKS']['getCombinedFile'] as $callback)
 				{
-					$this->import($callback[0]);
-					$content = $this->{$callback[0]}->{$callback[1]}($content, $strKey, $this->strMode, $arrFile);
+					$content = System::importStatic($callback[0])->{$callback[1]}($content, $strKey, $this->strMode, $arrFile);
 				}
 			}
 

--- a/core-bundle/contao/library/Contao/Database/Installer.php
+++ b/core-bundle/contao/library/Contao/Database/Installer.php
@@ -154,8 +154,7 @@ class Installer extends Controller
 		{
 			foreach ($GLOBALS['TL_HOOKS']['sqlCompileCommands'] as $callback)
 			{
-				$this->import($callback[0]);
-				$return = $this->{$callback[0]}->{$callback[1]}($return);
+				$return = System::importStatic($callback[0])->{$callback[1]}($return);
 			}
 		}
 
@@ -200,8 +199,7 @@ class Installer extends Controller
 		{
 			foreach ($GLOBALS['TL_HOOKS']['sqlGetFromDca'] as $callback)
 			{
-				$this->import($callback[0]);
-				$return = $this->{$callback[0]}->{$callback[1]}($return);
+				$return = System::importStatic($callback[0])->{$callback[1]}($return);
 			}
 		}
 
@@ -329,8 +327,7 @@ class Installer extends Controller
 		{
 			foreach ($GLOBALS['TL_HOOKS']['sqlGetFromDB'] as $callback)
 			{
-				$this->import($callback[0]);
-				$return = $this->{$callback[0]}->{$callback[1]}($return);
+				$return = System::importStatic($callback[0])->{$callback[1]}($return);
 			}
 		}
 

--- a/core-bundle/contao/library/Contao/DcaLoader.php
+++ b/core-bundle/contao/library/Contao/DcaLoader.php
@@ -136,8 +136,7 @@ class DcaLoader extends Controller
 		{
 			foreach ($GLOBALS['TL_HOOKS']['loadDataContainer'] as $callback)
 			{
-				$this->import($callback[0]);
-				$this->{$callback[0]}->{$callback[1]}($this->strTable);
+				System::importStatic($callback[0])->{$callback[1]}($this->strTable);
 			}
 		}
 

--- a/core-bundle/contao/library/Contao/InsertTags.php
+++ b/core-bundle/contao/library/Contao/InsertTags.php
@@ -1105,8 +1105,7 @@ class InsertTags extends Controller
 					{
 						foreach ($GLOBALS['TL_HOOKS']['replaceInsertTags'] as $callback)
 						{
-							$this->import($callback[0]);
-							$varValue = $this->{$callback[0]}->{$callback[1]}($tag, $blnCache, '', $flags, $tags, array(), $_rit, $_cnt); // see #6672
+							$varValue = System::importStatic($callback[0])->{$callback[1]}($tag, $blnCache, '', $flags, $tags, array(), $_rit, $_cnt); // see #6672
 
 							// Replace the tag and stop the loop
 							if ($varValue !== false)
@@ -1226,8 +1225,7 @@ class InsertTags extends Controller
 							{
 								foreach ($GLOBALS['TL_HOOKS']['insertTagFlags'] as $callback)
 								{
-									$this->import($callback[0]);
-									$varValue = $this->{$callback[0]}->{$callback[1]}($flag, $tag, $arrCache[$strTag], $flags, $blnCache, $tags, array(), $_rit, $_cnt); // see #5806
+									$varValue = System::importStatic($callback[0])->{$callback[1]}($flag, $tag, $arrCache[$strTag], $flags, $blnCache, $tags, array(), $_rit, $_cnt); // see #5806
 
 									// Replace the tag and stop the loop
 									if ($varValue !== false)

--- a/core-bundle/contao/library/Contao/Template.php
+++ b/core-bundle/contao/library/Contao/Template.php
@@ -282,8 +282,7 @@ abstract class Template extends Controller
 		{
 			foreach ($GLOBALS['TL_HOOKS']['parseTemplate'] as $callback)
 			{
-				$this->import($callback[0]);
-				$this->{$callback[0]}->{$callback[1]}($this);
+				System::importStatic($callback[0])->{$callback[1]}($this);
 			}
 		}
 

--- a/core-bundle/contao/library/Contao/Widget.php
+++ b/core-bundle/contao/library/Contao/Widget.php
@@ -598,8 +598,7 @@ abstract class Widget extends Controller
 		{
 			foreach ($GLOBALS['TL_HOOKS']['parseWidget'] as $callback)
 			{
-				$this->import($callback[0]);
-				$strBuffer = $this->{$callback[0]}->{$callback[1]}($strBuffer, $this);
+				$strBuffer = System::importStatic($callback[0])->{$callback[1]}($strBuffer, $this);
 			}
 		}
 
@@ -1044,11 +1043,7 @@ abstract class Widget extends Controller
 					{
 						foreach ($GLOBALS['TL_HOOKS']['addCustomRegexp'] as $callback)
 						{
-							$this->import($callback[0]);
-							$break = $this->{$callback[0]}->{$callback[1]}($this->rgxp, $varInput, $this);
-
-							// Stop the loop if a callback returned true
-							if ($break === true)
+							if (System::importStatic($callback[0])->{$callback[1]}($this->rgxp, $varInput, $this) === true)
 							{
 								break;
 							}

--- a/core-bundle/contao/modules/ModuleArticle.php
+++ b/core-bundle/contao/modules/ModuleArticle.php
@@ -245,8 +245,7 @@ class ModuleArticle extends Module
 		{
 			foreach ($GLOBALS['TL_HOOKS']['compileArticle'] as $callback)
 			{
-				$this->import($callback[0]);
-				$this->{$callback[0]}->{$callback[1]}($this->Template, $this->arrData, $this);
+				System::importStatic($callback[0])->{$callback[1]}($this->Template, $this->arrData, $this);
 			}
 		}
 	}

--- a/core-bundle/contao/modules/ModuleBreadcrumb.php
+++ b/core-bundle/contao/modules/ModuleBreadcrumb.php
@@ -212,8 +212,7 @@ class ModuleBreadcrumb extends Module
 		{
 			foreach ($GLOBALS['TL_HOOKS']['generateBreadcrumb'] as $callback)
 			{
-				$this->import($callback[0]);
-				$items = $this->{$callback[0]}->{$callback[1]}($items, $this);
+				$items = System::importStatic($callback[0])->{$callback[1]}($items, $this);
 			}
 		}
 

--- a/core-bundle/contao/modules/ModuleChangePassword.php
+++ b/core-bundle/contao/modules/ModuleChangePassword.php
@@ -69,8 +69,7 @@ class ModuleChangePassword extends Module
 			{
 				if (\is_array($callback))
 				{
-					$this->import($callback[0]);
-					$this->{$callback[0]}->{$callback[1]}();
+					System::importStatic($callback[0])->{$callback[1]}();
 				}
 				elseif (\is_callable($callback))
 				{
@@ -179,8 +178,7 @@ class ModuleChangePassword extends Module
 			{
 				foreach ($GLOBALS['TL_HOOKS']['setNewPassword'] as $callback)
 				{
-					$this->import($callback[0]);
-					$this->{$callback[0]}->{$callback[1]}($objMember, $objNewPassword->value, $this);
+					System::importStatic($callback[0])->{$callback[1]}($objMember, $objNewPassword->value, $this);
 				}
 			}
 

--- a/core-bundle/contao/modules/ModuleCloseAccount.php
+++ b/core-bundle/contao/modules/ModuleCloseAccount.php
@@ -95,8 +95,7 @@ class ModuleCloseAccount extends Module
 				{
 					foreach ($GLOBALS['TL_HOOKS']['closeAccount'] as $callback)
 					{
-						$this->import($callback[0]);
-						$this->{$callback[0]}->{$callback[1]}($this->User->id, $this->reg_close, $this);
+						System::importStatic($callback[0])->{$callback[1]}($this->User->id, $this->reg_close, $this);
 					}
 				}
 

--- a/core-bundle/contao/modules/ModuleLostPassword.php
+++ b/core-bundle/contao/modules/ModuleLostPassword.php
@@ -60,8 +60,7 @@ class ModuleLostPassword extends Module
 			{
 				if (\is_array($callback))
 				{
-					$this->import($callback[0]);
-					$this->{$callback[0]}->{$callback[1]}();
+					System::importStatic($callback[0])->{$callback[1]}();
 				}
 				elseif (\is_callable($callback))
 				{
@@ -257,8 +256,7 @@ class ModuleLostPassword extends Module
 				{
 					foreach ($GLOBALS['TL_HOOKS']['setNewPassword'] as $callback)
 					{
-						$this->import($callback[0]);
-						$this->{$callback[0]}->{$callback[1]}($objMember, $objWidget->value, $this);
+						System::importStatic($callback[0])->{$callback[1]}($objMember, $objWidget->value, $this);
 					}
 				}
 

--- a/core-bundle/contao/modules/ModuleMaintenance.php
+++ b/core-bundle/contao/modules/ModuleMaintenance.php
@@ -37,16 +37,16 @@ class ModuleMaintenance extends BackendModule
 
 		foreach ($GLOBALS['TL_MAINTENANCE'] as $callback)
 		{
-			$this->import($callback);
+			$module = System::importStatic($callback);
 
-			if (!$this->$callback instanceof MaintenanceModuleInterface)
+			if (!$module instanceof MaintenanceModuleInterface)
 			{
 				throw new \Exception("$callback is not an executable class");
 			}
 
-			$buffer = $this->$callback->run();
+			$buffer = $module->run();
 
-			if ($this->$callback->isActive())
+			if ($module->isActive())
 			{
 				$this->Template->content = $buffer;
 				break;

--- a/core-bundle/contao/modules/ModulePersonalData.php
+++ b/core-bundle/contao/modules/ModulePersonalData.php
@@ -80,8 +80,7 @@ class ModulePersonalData extends Module
 			{
 				if (\is_array($callback))
 				{
-					$this->import($callback[0]);
-					$this->{$callback[0]}->{$callback[1]}();
+					System::importStatic($callback[0])->{$callback[1]}();
 				}
 				elseif (\is_callable($callback))
 				{
@@ -182,8 +181,7 @@ class ModulePersonalData extends Module
 				{
 					if (\is_array($callback))
 					{
-						$this->import($callback[0]);
-						$varValue = $this->{$callback[0]}->{$callback[1]}($varValue, $this->User, $this);
+						$varValue = System::importStatic($callback[0])->{$callback[1]}($varValue, $this->User, $this);
 					}
 					elseif (\is_callable($callback))
 					{
@@ -248,8 +246,7 @@ class ModulePersonalData extends Module
 						{
 							if (\is_array($callback))
 							{
-								$this->import($callback[0]);
-								$varValue = $this->{$callback[0]}->{$callback[1]}($varValue, $this->User, $this);
+								$varValue = System::importStatic($callback[0])->{$callback[1]}($varValue, $this->User, $this);
 							}
 							elseif (\is_callable($callback))
 							{
@@ -331,8 +328,7 @@ class ModulePersonalData extends Module
 			{
 				foreach ($GLOBALS['TL_HOOKS']['updatePersonalData'] as $callback)
 				{
-					$this->import($callback[0]);
-					$this->{$callback[0]}->{$callback[1]}($this->User, $arrSubmitted, $this, $arrFiles);
+					System::importStatic($callback[0])->{$callback[1]}($this->User, $arrSubmitted, $this, $arrFiles);
 				}
 			}
 
@@ -343,8 +339,7 @@ class ModulePersonalData extends Module
 				{
 					if (\is_array($callback))
 					{
-						$this->import($callback[0]);
-						$this->{$callback[0]}->{$callback[1]}($this->User, $this);
+						System::importStatic($callback[0])->{$callback[1]}($this->User, $this);
 					}
 					elseif (\is_callable($callback))
 					{

--- a/core-bundle/contao/modules/ModuleRegistration.php
+++ b/core-bundle/contao/modules/ModuleRegistration.php
@@ -71,8 +71,7 @@ class ModuleRegistration extends Module
 			{
 				if (\is_array($callback))
 				{
-					$this->import($callback[0]);
-					$this->{$callback[0]}->{$callback[1]}();
+					System::importStatic($callback[0])->{$callback[1]}();
 				}
 				elseif (\is_callable($callback))
 				{
@@ -256,8 +255,7 @@ class ModuleRegistration extends Module
 						{
 							if (\is_array($callback))
 							{
-								$this->import($callback[0]);
-								$varValue = $this->{$callback[0]}->{$callback[1]}($varValue, null);
+								$varValue = System::importStatic($callback[0])->{$callback[1]}($varValue, null);
 							}
 							elseif (\is_callable($callback))
 							{
@@ -414,8 +412,7 @@ class ModuleRegistration extends Module
 		{
 			foreach ($GLOBALS['TL_HOOKS']['createNewUser'] as $callback)
 			{
-				$this->import($callback[0]);
-				$this->{$callback[0]}->{$callback[1]}($objNewUser->id, $arrData, $this);
+				System::importStatic($callback[0])->{$callback[1]}($objNewUser->id, $arrData, $this);
 			}
 		}
 
@@ -520,8 +517,7 @@ class ModuleRegistration extends Module
 		{
 			foreach ($GLOBALS['TL_HOOKS']['activateAccount'] as $callback)
 			{
-				$this->import($callback[0]);
-				$this->{$callback[0]}->{$callback[1]}($objMember, $this);
+				System::importStatic($callback[0])->{$callback[1]}($objMember, $this);
 			}
 		}
 

--- a/core-bundle/contao/modules/ModuleSearch.php
+++ b/core-bundle/contao/modules/ModuleSearch.php
@@ -130,8 +130,7 @@ class ModuleSearch extends Module
 			{
 				foreach ($GLOBALS['TL_HOOKS']['customizeSearch'] as $callback)
 				{
-					$this->import($callback[0]);
-					$this->{$callback[0]}->{$callback[1]}($arrPages, $strKeywords, $strQueryType, $blnFuzzy, $this);
+					System::importStatic($callback[0])->{$callback[1]}($arrPages, $strKeywords, $strQueryType, $blnFuzzy, $this);
 				}
 			}
 

--- a/core-bundle/contao/pages/PageRegular.php
+++ b/core-bundle/contao/pages/PageRegular.php
@@ -195,8 +195,7 @@ class PageRegular extends Frontend
 		{
 			foreach ($GLOBALS['TL_HOOKS']['generatePage'] as $callback)
 			{
-				$this->import($callback[0]);
-				$this->{$callback[0]}->{$callback[1]}($objPage, $objLayout, $this);
+				System::importStatic($callback[0])->{$callback[1]}($objPage, $objLayout, $this);
 			}
 		}
 
@@ -265,8 +264,7 @@ class PageRegular extends Frontend
 		{
 			foreach ($GLOBALS['TL_HOOKS']['getPageLayout'] as $callback)
 			{
-				$this->import($callback[0]);
-				$this->{$callback[0]}->{$callback[1]}($objPage, $objLayout, $this);
+				System::importStatic($callback[0])->{$callback[1]}($objPage, $objLayout, $this);
 			}
 		}
 

--- a/core-bundle/contao/widgets/Picker.php
+++ b/core-bundle/contao/widgets/Picker.php
@@ -239,9 +239,7 @@ class Picker extends Widget
 
 			if (\is_array($callback))
 			{
-				$this->import($callback[0]);
-
-				return $this->{$callback[0]}->{$callback[1]}($arrRow);
+				return System::importStatic($callback[0])->{$callback[1]}($arrRow);
 			}
 
 			if (\is_callable($callback))

--- a/news-bundle/contao/modules/ModuleNews.php
+++ b/news-bundle/contao/modules/ModuleNews.php
@@ -222,8 +222,7 @@ abstract class ModuleNews extends Module
 		{
 			foreach ($GLOBALS['TL_HOOKS']['parseArticles'] as $callback)
 			{
-				$this->import($callback[0]);
-				$this->{$callback[0]}->{$callback[1]}($objTemplate, $objArticle->row(), $this);
+				System::importStatic($callback[0])->{$callback[1]}($objTemplate, $objArticle->row(), $this);
 			}
 		}
 

--- a/newsletter-bundle/contao/modules/ModuleSubscribe.php
+++ b/newsletter-bundle/contao/modules/ModuleSubscribe.php
@@ -228,8 +228,7 @@ class ModuleSubscribe extends Module
 		{
 			foreach ($GLOBALS['TL_HOOKS']['activateRecipient'] as $callback)
 			{
-				$this->import($callback[0]);
-				$this->{$callback[0]}->{$callback[1]}($optInToken->getEmail(), $arrAdd, $arrCids, $this);
+				System::importStatic($callback[0])->{$callback[1]}($optInToken->getEmail(), $arrAdd, $arrCids, $this);
 			}
 		}
 

--- a/newsletter-bundle/contao/modules/ModuleUnsubscribe.php
+++ b/newsletter-bundle/contao/modules/ModuleUnsubscribe.php
@@ -261,8 +261,7 @@ class ModuleUnsubscribe extends Module
 		{
 			foreach ($GLOBALS['TL_HOOKS']['removeRecipient'] as $callback)
 			{
-				$this->import($callback[0]);
-				$this->{$callback[0]}->{$callback[1]}($strEmail, $arrRemove, $this);
+				System::importStatic($callback[0])->{$callback[1]}($strEmail, $arrRemove, $this);
 			}
 		}
 


### PR DESCRIPTION
This is a first step to get rid of the `System::import()` method, which I hope everyone agrees that we should. 😉 

Of course we have to keep known class properties such as `$this->Database` or `$this->User` to remain backwards compatible, so this pull request only handles dynamic class properties. The next step would be to replace all the remaining usages and to deprecate the method. I will create a follow-up pull request for that.

