### PR TITLE
Remove the leftover BC layer in `System::__get()`

### DIFF
--- a/core-bundle/contao/library/Contao/System.php
+++ b/core-bundle/contao/library/Contao/System.php
@@ -107,29 +107,13 @@ abstract class System
 	/**
 	 * Get an object property
 	 *
-	 * Lazy load the Input and Environment libraries (which are now static) and
-	 * only include them as object property if an old module requires it
-	 *
 	 * @param string $strKey The property name
 	 *
 	 * @return mixed|null The property value or null
 	 */
 	public function __get($strKey)
 	{
-		if (!isset($this->arrObjects[$strKey]))
-		{
-			/** @var Input|Environment|Session|string $strKey */
-			if ($strKey == 'Input' || $strKey == 'Environment' || $strKey == 'Session')
-			{
-				$this->arrObjects[$strKey] = $strKey::getInstance();
-			}
-			else
-			{
-				return null;
-			}
-		}
-
-		return $this->arrObjects[$strKey];
+		return $this->arrObjects[$strKey] ?? null;
 	}
 
 	/**


### PR DESCRIPTION
This can never have worked in Contao 5, because the `Session` class has been removed entirely and the other two classes no longer have a `getInstance()` method.
