### PR TITLE
Revert "Use real path for `.env.local`"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -108,7 +108,7 @@
         "symfony/event-dispatcher": "^5.4",
         "symfony/event-dispatcher-contracts": "^2.0 || ^3.0",
         "symfony/expression-language": "^5.4",
-        "symfony/filesystem": "^5.4",
+        "symfony/filesystem": "^5.4.25",
         "symfony/finder": "^5.4",
         "symfony/framework-bundle": "^5.4",
         "symfony/http-client": "^5.4",

--- a/manager-bundle/composer.json
+++ b/manager-bundle/composer.json
@@ -42,7 +42,7 @@
         "symfony/dotenv": "^5.4",
         "symfony/error-handler": "^5.4",
         "symfony/expression-language": "^5.4",
-        "symfony/filesystem": "^5.4",
+        "symfony/filesystem": "^5.4.25",
         "symfony/finder": "^5.4",
         "symfony/framework-bundle": "^5.4",
         "symfony/http-client": "^5.4",

--- a/manager-bundle/src/Command/ContaoSetupCommand.php
+++ b/manager-bundle/src/Command/ContaoSetupCommand.php
@@ -73,14 +73,8 @@ class ContaoSetupCommand extends Command
         // Auto-generate a kernel secret if none was set
         if (empty($this->kernelSecret) || 'ThisTokenIsNotSoSecretChangeIt' === $this->kernelSecret) {
             $filesystem = new Filesystem();
-            $localPath = Path::join($this->projectDir, '.env.local');
 
-            // Get the realpath in case it is a symlink (see #6066)
-            if ($realpath = realpath($localPath)) {
-                $localPath = $realpath;
-            }
-
-            $dotenv = new DotenvDumper($localPath, $filesystem);
+            $dotenv = new DotenvDumper(Path::join($this->projectDir, '.env.local'), $filesystem);
             $dotenv->setParameter('APP_SECRET', bin2hex(random_bytes(32)));
             $dotenv->dump();
 

--- a/manager-bundle/src/ContaoManager/ApiCommand/SetDotEnvCommand.php
+++ b/manager-bundle/src/ContaoManager/ApiCommand/SetDotEnvCommand.php
@@ -48,21 +48,14 @@ class SetDotEnvCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $filesystem = new Filesystem();
         $path = Path::join($this->projectDir, '.env');
-        $localPath = $path.'.local';
 
-        // Get the realpath in case it is a symlink (see #6066)
-        if ($realpath = realpath($localPath)) {
-            $localPath = $realpath;
-        }
-
-        $dumper = new DotenvDumper($localPath, $filesystem);
+        $dumper = new DotenvDumper($path.'.local');
         $dumper->setParameter($input->getArgument('key'), $input->getArgument('value'));
         $dumper->dump();
 
         if (!file_exists($path)) {
-            $filesystem->touch($path);
+            (new Filesystem())->touch($path);
         }
 
         return 0;

--- a/manager-bundle/tests/Command/ContaoSetupCommandTest.php
+++ b/manager-bundle/tests/Command/ContaoSetupCommandTest.php
@@ -199,41 +199,6 @@ class ContaoSetupCommandTest extends ContaoTestCase
         $filesystem->remove([$dotEnvFile, $dotEnvLocalFile]);
     }
 
-    public function testKeepsSymlinkedDotEnv(): void
-    {
-        $projectDir = $this->getTempDir();
-
-        $dotEnvFile = Path::join($projectDir, '.env');
-        $dotEnvLocalFile = Path::join($projectDir, '.env.local');
-        $dotEnvLocalTargetFile = Path::join($projectDir, '.env.local.target');
-
-        $filesystem = new Filesystem();
-        $filesystem->touch($dotEnvLocalTargetFile);
-        $filesystem->symlink($dotEnvLocalTargetFile, $dotEnvLocalFile);
-
-        $command = new ContaoSetupCommand(
-            $projectDir,
-            Path::join($projectDir, 'public'),
-            '',
-            $this->getCreateProcessHandler($this->getProcessMocks())
-        );
-
-        $commandTester = new CommandTester($command);
-        $commandTester->execute([]);
-
-        $this->assertFileExists($dotEnvFile);
-        $this->assertFileExists($dotEnvLocalFile);
-        $this->assertFileExists($dotEnvLocalTargetFile);
-        $this->assertTrue(is_link($dotEnvLocalFile));
-
-        $vars = (new Dotenv())->parse(file_get_contents($dotEnvLocalTargetFile));
-
-        $this->assertArrayHasKey('APP_SECRET', $vars);
-        $this->assertSame(64, \strlen((string) $vars['APP_SECRET']));
-
-        $filesystem->remove([$dotEnvFile, $dotEnvLocalFile, $dotEnvLocalTargetFile]);
-    }
-
     public function provideKernelSecretValues(): \Generator
     {
         yield 'no secret set, no .env file' => ['', false];

--- a/manager-bundle/tests/Command/ContaoSetupCommandTest.php
+++ b/manager-bundle/tests/Command/ContaoSetupCommandTest.php
@@ -199,6 +199,41 @@ class ContaoSetupCommandTest extends ContaoTestCase
         $filesystem->remove([$dotEnvFile, $dotEnvLocalFile]);
     }
 
+    public function testKeepsSymlinkedDotEnv(): void
+    {
+        $projectDir = $this->getTempDir();
+
+        $dotEnvFile = Path::join($projectDir, '.env');
+        $dotEnvLocalFile = Path::join($projectDir, '.env.local');
+        $dotEnvLocalTargetFile = Path::join($projectDir, '.env.local.target');
+
+        $filesystem = new Filesystem();
+        $filesystem->touch($dotEnvLocalTargetFile);
+        $filesystem->symlink($dotEnvLocalTargetFile, $dotEnvLocalFile);
+
+        $command = new ContaoSetupCommand(
+            $projectDir,
+            Path::join($projectDir, 'public'),
+            '',
+            $this->getCreateProcessHandler($this->getProcessMocks())
+        );
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute([]);
+
+        $this->assertFileExists($dotEnvFile);
+        $this->assertFileExists($dotEnvLocalFile);
+        $this->assertFileExists($dotEnvLocalTargetFile);
+        $this->assertTrue(is_link($dotEnvLocalFile));
+
+        $vars = (new Dotenv())->parse(file_get_contents($dotEnvLocalTargetFile));
+
+        $this->assertArrayHasKey('APP_SECRET', $vars);
+        $this->assertSame(64, \strlen((string) $vars['APP_SECRET']));
+
+        $filesystem->remove([$dotEnvFile, $dotEnvLocalFile, $dotEnvLocalTargetFile]);
+    }
+
     public function provideKernelSecretValues(): \Generator
     {
         yield 'no secret set, no .env file' => ['', false];


### PR DESCRIPTION
Now that Symfony `5.4.25` and `6.2.12` have been released, we can revert the usage of `realpath` again (#6066), as this has been fixed in https://github.com/symfony/symfony/pull/50437

This PR reverts the `realpath` usage, increases the `symfony/filesystem` dependency accordingly and keeps the symlink test from #6066.