### PR TITLE
Remove field permissions on favorites table

### DIFF
--- a/core-bundle/contao/dca/tl_favorites.php
+++ b/core-bundle/contao/dca/tl_favorites.php
@@ -103,6 +103,7 @@ $GLOBALS['TL_DCA']['tl_favorites'] = array
 		),
 		'title' => array
 		(
+			'exclude'                 => false,
 			'search'                  => true,
 			'inputType'               => 'text',
 			'eval'                    => array('mandatory'=>true, 'maxlength'=>255, 'tl_class'=>'w50'),
@@ -110,6 +111,7 @@ $GLOBALS['TL_DCA']['tl_favorites'] = array
 		),
 		'url' => array
 		(
+			'exclude'                 => false,
 			'search'                  => true,
 			'inputType'               => 'text',
 			'eval'                    => array('mandatory'=>true, 'readonly'=>true, 'rgxp'=>'url', 'decodeEntities'=>true, 'maxlength'=>1022, 'tl_class'=>'w50'),

--- a/core-bundle/src/Security/Voter/DataContainer/FavoritesVoter.php
+++ b/core-bundle/src/Security/Voter/DataContainer/FavoritesVoter.php
@@ -21,13 +21,12 @@ use Contao\CoreBundle\Security\DataContainer\UpdateAction;
 use Doctrine\DBAL\Connection;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\CacheableVoterInterface;
-use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 use Symfony\Component\Security\Core\Security;
 
 /**
  * @internal
  */
-class FavoritesVoter implements VoterInterface, CacheableVoterInterface
+class FavoritesVoter implements CacheableVoterInterface
 {
     public function __construct(private Security $security, private Connection $connection)
     {


### PR DESCRIPTION
Since favorites are always personal, it does not really make sense to add permissions to the table fields. Without both fields, the whole "thing" wouldn't work anyway.

In the current implementation, one must explicitly give a user both fields in the `tl_favorites` table, otherwise they will have the "add to favorites" button in the menu but cannot paste the new favorite anywhere.