### PR TITLE
Fix rootNodes for table picker

### DIFF
--- a/core-bundle/src/Picker/TablePickerProvider.php
+++ b/core-bundle/src/Picker/TablePickerProvider.php
@@ -25,4 +25,15 @@ class TablePickerProvider extends AbstractTablePickerProvider
     {
         return DC_Table::class;
     }
+
+    public function getDcaAttributes(PickerConfig $config): array
+    {
+        $attributes = parent::getDcaAttributes($config);
+
+        if (\is_array($rootNodes = $config->getExtra('rootNodes'))) {
+            $attributes['rootNodes'] = $rootNodes;
+        }
+
+        return $attributes;
+    }
 }

--- a/core-bundle/src/Picker/TablePickerProvider.php
+++ b/core-bundle/src/Picker/TablePickerProvider.php
@@ -21,11 +21,6 @@ class TablePickerProvider extends AbstractTablePickerProvider
         return 'tablePicker';
     }
 
-    protected function getDataContainer(): string
-    {
-        return DC_Table::class;
-    }
-
     public function getDcaAttributes(PickerConfig $config): array
     {
         $attributes = parent::getDcaAttributes($config);
@@ -35,5 +30,10 @@ class TablePickerProvider extends AbstractTablePickerProvider
         }
 
         return $attributes;
+    }
+
+    protected function getDataContainer(): string
+    {
+        return DC_Table::class;
     }
 }

--- a/core-bundle/src/Resources/contao/widgets/Picker.php
+++ b/core-bundle/src/Resources/contao/widgets/Picker.php
@@ -325,6 +325,11 @@ class Picker extends Widget
 		$extras['fieldType'] = $this->multiple ? 'checkbox' : 'radio';
 		$extras['source'] = $this->strTable . '.' . $this->currentRecord;
 
+		if (\is_array($this->rootNodes))
+		{
+			$extras['rootNodes'] = array_values($this->rootNodes);
+		}
+
 		return $extras;
 	}
 }


### PR DESCRIPTION
The `rootNodes` attribute is currently supported by the [`PagePickerProvider`](https://github.com/contao/contao/blob/4.13/core-bundle/src/Picker/PagePickerProvider.php#L68), but would be handled in [`DC_Table`](https://github.com/contao/contao/blob/4.13/core-bundle/src/Resources/contao/drivers/DC_Table.php#L6399). I therefore think this should also be in the generic `TablePicker`.