### PR TITLE
Add new page speed rules to the .htaccess file

### DIFF
--- a/manager-bundle/skeleton/public/.htaccess
+++ b/manager-bundle/skeleton/public/.htaccess
@@ -1,20 +1,3 @@
-<IfModule mod_headers.c>
-    # Assets in /assets and /bundles either contain a hash in their filename
-    # or are called with a ?version suffix, therefore cache them for 1 year.
-    RewriteRule ^(assets|bundles)/ - [ENV=CONTAO_ASSETS:true]
-    Header set Cache-Control "max-age=31536000" env=CONTAO_ASSETS
-
-    # Allow CORS on the Contao TinyMCE skin.
-    RewriteRule ^assets/tinymce4/js/skins/contao/fonts/ - [ENV=CONTAO_TINYMCE_SKIN:true]
-    Header set Access-Control-Allow-Origin "*" env=CONTAO_TINYMCE_SKIN
-
-    # Do not cache source map files
-    <FilesMatch "\.map$">
-        Header set Expires "0"
-        Header set Cache-Control "no-cache, no-store, must-revalidate, max-age=0, proxy-revalidate, no-transform"
-    </FilesMatch>
-</IfModule>
-
 <IfModule mod_mime.c>
     # Data interchange
     AddType application/atom+xml                        atom
@@ -158,8 +141,27 @@
     </IfModule>
 </IfModule>
 
+<IfModule mod_headers.c>
+    # Do not cache source map files
+    <FilesMatch "\.map$">
+        Header set Expires "0"
+        Header set Cache-Control "no-cache, no-store, must-revalidate, max-age=0, proxy-revalidate, no-transform"
+    </FilesMatch>
+</IfModule>
+
 <IfModule mod_rewrite.c>
     RewriteEngine On
+
+    <IfModule mod_headers.c>
+        # Assets in /assets and /bundles either contain a hash in their filename
+        # or are called with a ?version suffix, therefore cache them for 1 year.
+        RewriteRule ^(assets|bundles)/ - [ENV=CONTAO_ASSETS:true]
+        Header set Cache-Control "max-age=31536000" env=CONTAO_ASSETS
+
+        # Allow CORS on the Contao TinyMCE skin.
+        RewriteRule ^assets/tinymce4/js/skins/contao/fonts/ - [ENV=CONTAO_TINYMCE_SKIN:true]
+        Header set Access-Control-Allow-Origin "*" env=CONTAO_TINYMCE_SKIN
+    </IfModule>
 
     # Determine the RewriteBase automatically and set it as environment variable.
     # If you are using Apache aliases to do mass virtual hosting or installed the

--- a/manager-bundle/skeleton/public/.htaccess
+++ b/manager-bundle/skeleton/public/.htaccess
@@ -1,165 +1,165 @@
+<IfModule mod_headers.c>
+    # Assets in /assets and /bundles either contain a hash in their filename
+    # or are called with a ?version suffix, therefore cache them for 1 year.
+    RewriteRule ^(assets|bundles)/ - [ENV=CONTAO_ASSETS:true]
+    Header set Cache-Control "max-age=31536000" env=CONTAO_ASSETS
+
+    # Allow CORS on the Contao TinyMCE skin.
+    RewriteRule ^assets/tinymce4/js/skins/contao/fonts/ - [ENV=CONTAO_TINYMCE_SKIN:true]
+    Header set Access-Control-Allow-Origin "*" env=CONTAO_TINYMCE_SKIN
+
+    # Do not cache source map files
+    <FilesMatch "\.map$">
+        Header set Expires "0"
+        Header set Cache-Control "no-cache, no-store, must-revalidate, max-age=0, proxy-revalidate, no-transform"
+    </FilesMatch>
+</IfModule>
+
+<IfModule mod_mime.c>
+    # Data interchange
+    AddType application/atom+xml                        atom
+    AddType application/json                            json map topojson
+    AddType application/ld+json                         jsonld
+    AddType application/rss+xml                         rss
+    AddType application/geo+json                        geojson
+    AddType application/rdf+xml                         rdf
+    AddType application/xml                             xml
+
+    # JavaScript
+    AddType text/javascript                             js mjs
+
+    # Manifest files
+    AddType application/manifest+json                   webmanifest
+    AddType application/x-web-app-manifest+json         webapp
+    AddType text/cache-manifest                         appcache
+
+    # Media files
+    AddType audio/mp4                                   f4a f4b m4a
+    AddType audio/ogg                                   oga ogg opus
+    AddType image/avif                                  avif avifs
+    AddType image/bmp                                   bmp
+    AddType image/jxl                                   jxl
+    AddType image/svg+xml                               svg svgz
+    AddType image/webp                                  webp
+    AddType image/x-icon                                cur ico
+    AddType video/mp4                                   f4v f4p m4v mp4
+    AddType video/ogg                                   ogv
+    AddType video/webm                                  webm
+    AddType video/x-flv                                 flv
+
+    # WebAssembly
+    AddType application/wasm                            wasm
+
+    # Web fonts
+    AddType font/woff                                   woff
+    AddType font/woff2                                  woff2
+    AddType application/vnd.ms-fontobject               eot
+    AddType font/ttf                                    ttf
+    AddType font/collection                             ttc
+    AddType font/otf                                    otf
+
+    # Other
+    AddType application/octet-stream                    safariextz
+    AddType application/x-bb-appworld                   bbaw
+    AddType application/x-chrome-extension              crx
+    AddType application/x-opera-extension               oex
+    AddType application/x-xpinstall                     xpi
+    AddType text/calendar                               ics
+    AddType text/markdown                               markdown md
+    AddType text/vcard                                  vcard vcf
+    AddType text/vnd.rim.location.xloc                  xloc
+    AddType text/vtt                                    vtt
+    AddType text/x-component                            htc
+</IfModule>
+
+<IfModule mod_filter.c>
+    # Brotli compression
+    <IfModule mod_brotli.c>
+        AddOutputFilterByType BROTLI_COMPRESS "application/atom+xml" \
+                                              "application/javascript" \
+                                              "application/json" \
+                                              "application/ld+json" \
+                                              "application/manifest+json" \
+                                              "application/rdf+xml" \
+                                              "application/rss+xml" \
+                                              "application/schema+json" \
+                                              "application/geo+json" \
+                                              "application/vnd.ms-fontobject" \
+                                              "application/wasm" \
+                                              "application/x-font-ttf" \
+                                              "application/x-javascript" \
+                                              "application/x-web-app-manifest+json" \
+                                              "application/xhtml+xml" \
+                                              "application/xml" \
+                                              "font/eot" \
+                                              "font/opentype" \
+                                              "font/otf" \
+                                              "font/ttf" \
+                                              "font/woff2" \
+                                              "image/bmp" \
+                                              "image/svg+xml" \
+                                              "image/vnd.microsoft.icon" \
+                                              "image/x-icon" \
+                                              "text/cache-manifest" \
+                                              "text/calendar" \
+                                              "text/css" \
+                                              "text/html" \
+                                              "text/javascript" \
+                                              "text/plain" \
+                                              "text/markdown" \
+                                              "text/vcard" \
+                                              "text/vnd.rim.location.xloc" \
+                                              "text/vtt" \
+                                              "text/x-component" \
+                                              "text/x-cross-domain-policy" \
+                                              "text/xml"
+    </IfModule>
+
+    # Gzip compression
+    <IfModule mod_deflate.c>
+        AddOutputFilterByType DEFLATE "application/atom+xml" \
+                                      "application/javascript" \
+                                      "application/json" \
+                                      "application/ld+json" \
+                                      "application/manifest+json" \
+                                      "application/rdf+xml" \
+                                      "application/rss+xml" \
+                                      "application/schema+json" \
+                                      "application/geo+json" \
+                                      "application/vnd.ms-fontobject" \
+                                      "application/wasm" \
+                                      "application/x-font-ttf" \
+                                      "application/x-javascript" \
+                                      "application/x-web-app-manifest+json" \
+                                      "application/xhtml+xml" \
+                                      "application/xml" \
+                                      "font/eot" \
+                                      "font/opentype" \
+                                      "font/otf" \
+                                      "font/ttf" \
+                                      "font/woff2" \
+                                      "image/bmp" \
+                                      "image/svg+xml" \
+                                      "image/vnd.microsoft.icon" \
+                                      "image/x-icon" \
+                                      "text/cache-manifest" \
+                                      "text/calendar" \
+                                      "text/css" \
+                                      "text/html" \
+                                      "text/javascript" \
+                                      "text/plain" \
+                                      "text/markdown" \
+                                      "text/vcard" \
+                                      "text/vnd.rim.location.xloc" \
+                                      "text/vtt" \
+                                      "text/x-component" \
+                                      "text/x-cross-domain-policy" \
+                                      "text/xml"
+    </IfModule>
+</IfModule>
+
 <IfModule mod_rewrite.c>
     RewriteEngine On
-
-    <IfModule mod_headers.c>
-        # Assets in /assets and /bundles either contain a hash in their filename
-        # or are called with a ?version suffix, therefore cache them for 1 year.
-        RewriteRule ^(assets|bundles)/ - [ENV=CONTAO_ASSETS:true]
-        Header set Cache-Control "max-age=31536000" env=CONTAO_ASSETS
-
-        # Allow CORS on the Contao TinyMCE skin.
-        RewriteRule ^assets/tinymce4/js/skins/contao/fonts/ - [ENV=CONTAO_TINYMCE_SKIN:true]
-        Header set Access-Control-Allow-Origin "*" env=CONTAO_TINYMCE_SKIN
-
-        # Do not cache source map files
-        <FilesMatch "\.map$">
-            Header set Expires "0"
-            Header set Cache-Control "no-cache, no-store, must-revalidate, max-age=0, proxy-revalidate, no-transform"
-        </FilesMatch>
-    </IfModule>
-
-    <IfModule mod_mime.c>
-        # Data interchange
-        AddType application/atom+xml                        atom
-        AddType application/json                            json map topojson
-        AddType application/ld+json                         jsonld
-        AddType application/rss+xml                         rss
-        AddType application/geo+json                        geojson
-        AddType application/rdf+xml                         rdf
-        AddType application/xml                             xml
-
-        # JavaScript
-        AddType text/javascript                             js mjs
-
-        # Manifest files
-        AddType application/manifest+json                   webmanifest
-        AddType application/x-web-app-manifest+json         webapp
-        AddType text/cache-manifest                         appcache
-
-        # Media files
-        AddType audio/mp4                                   f4a f4b m4a
-        AddType audio/ogg                                   oga ogg opus
-        AddType image/avif                                  avif avifs
-        AddType image/bmp                                   bmp
-        AddType image/jxl                                   jxl
-        AddType image/svg+xml                               svg svgz
-        AddType image/webp                                  webp
-        AddType image/x-icon                                cur ico
-        AddType video/mp4                                   f4v f4p m4v mp4
-        AddType video/ogg                                   ogv
-        AddType video/webm                                  webm
-        AddType video/x-flv                                 flv
-
-        # WebAssembly
-        AddType application/wasm                            wasm
-
-        # Web fonts
-        AddType font/woff                                   woff
-        AddType font/woff2                                  woff2
-        AddType application/vnd.ms-fontobject               eot
-        AddType font/ttf                                    ttf
-        AddType font/collection                             ttc
-        AddType font/otf                                    otf
-
-        # Other
-        AddType application/octet-stream                    safariextz
-        AddType application/x-bb-appworld                   bbaw
-        AddType application/x-chrome-extension              crx
-        AddType application/x-opera-extension               oex
-        AddType application/x-xpinstall                     xpi
-        AddType text/calendar                               ics
-        AddType text/markdown                               markdown md
-        AddType text/vcard                                  vcard vcf
-        AddType text/vnd.rim.location.xloc                  xloc
-        AddType text/vtt                                    vtt
-        AddType text/x-component                            htc
-    </IfModule>
-
-    <IfModule mod_filter.c>
-        # Brotli compression
-        <IfModule mod_brotli.c>
-            AddOutputFilterByType BROTLI_COMPRESS "application/atom+xml" \
-                                                  "application/javascript" \
-                                                  "application/json" \
-                                                  "application/ld+json" \
-                                                  "application/manifest+json" \
-                                                  "application/rdf+xml" \
-                                                  "application/rss+xml" \
-                                                  "application/schema+json" \
-                                                  "application/geo+json" \
-                                                  "application/vnd.ms-fontobject" \
-                                                  "application/wasm" \
-                                                  "application/x-font-ttf" \
-                                                  "application/x-javascript" \
-                                                  "application/x-web-app-manifest+json" \
-                                                  "application/xhtml+xml" \
-                                                  "application/xml" \
-                                                  "font/eot" \
-                                                  "font/opentype" \
-                                                  "font/otf" \
-                                                  "font/ttf" \
-                                                  "font/woff2" \
-                                                  "image/bmp" \
-                                                  "image/svg+xml" \
-                                                  "image/vnd.microsoft.icon" \
-                                                  "image/x-icon" \
-                                                  "text/cache-manifest" \
-                                                  "text/calendar" \
-                                                  "text/css" \
-                                                  "text/html" \
-                                                  "text/javascript" \
-                                                  "text/plain" \
-                                                  "text/markdown" \
-                                                  "text/vcard" \
-                                                  "text/vnd.rim.location.xloc" \
-                                                  "text/vtt" \
-                                                  "text/x-component" \
-                                                  "text/x-cross-domain-policy" \
-                                                  "text/xml"
-        </IfModule>
-
-        # Gzip compression
-        <IfModule mod_deflate.c>
-            AddOutputFilterByType DEFLATE "application/atom+xml" \
-                                          "application/javascript" \
-                                          "application/json" \
-                                          "application/ld+json" \
-                                          "application/manifest+json" \
-                                          "application/rdf+xml" \
-                                          "application/rss+xml" \
-                                          "application/schema+json" \
-                                          "application/geo+json" \
-                                          "application/vnd.ms-fontobject" \
-                                          "application/wasm" \
-                                          "application/x-font-ttf" \
-                                          "application/x-javascript" \
-                                          "application/x-web-app-manifest+json" \
-                                          "application/xhtml+xml" \
-                                          "application/xml" \
-                                          "font/eot" \
-                                          "font/opentype" \
-                                          "font/otf" \
-                                          "font/ttf" \
-                                          "font/woff2" \
-                                          "image/bmp" \
-                                          "image/svg+xml" \
-                                          "image/vnd.microsoft.icon" \
-                                          "image/x-icon" \
-                                          "text/cache-manifest" \
-                                          "text/calendar" \
-                                          "text/css" \
-                                          "text/html" \
-                                          "text/javascript" \
-                                          "text/plain" \
-                                          "text/markdown" \
-                                          "text/vcard" \
-                                          "text/vnd.rim.location.xloc" \
-                                          "text/vtt" \
-                                          "text/x-component" \
-                                          "text/x-cross-domain-policy" \
-                                          "text/xml"
-        </IfModule>
-    </IfModule>
 
     # Determine the RewriteBase automatically and set it as environment variable.
     # If you are using Apache aliases to do mass virtual hosting or installed the

--- a/manager-bundle/skeleton/public/.htaccess
+++ b/manager-bundle/skeleton/public/.htaccess
@@ -21,13 +21,6 @@
     <IfModule mod_filter.c>
         # Brotli compression
         <IfModule mod_brotli.c>
-            # Force proxies to cache compressed and non-compressed files separately
-            <IfModule mod_headers.c>
-                <FilesMatch ".(appcache|bmp|css|eot|geojson|html|htm|htc|ics|ico|js|json|jsonld|manifest|md|rdf|rss|svg|ttf|txt|vcard|vtt|wasm|webapp|webmanifest|woff2|xdr|xml|xht|xhtml|xloc)$">
-                    Header append Vary "Accept-Encoding"
-                </FilesMatch>
-            </IfModule>
-
             AddOutputFilterByType BROTLI_COMPRESS "application/atom+xml" \
                                                   "application/javascript" \
                                                   "application/json" \
@@ -70,13 +63,6 @@
 
         # Gzip compression
         <IfModule mod_deflate.c>
-            # Force proxies to cache compressed and non-compressed files separately
-            <IfModule mod_headers.c>
-                <FilesMatch ".(appcache|bmp|css|eot|geojson|html|htm|htc|ics|ico|js|json|jsonld|manifest|md|rdf|rss|svg|ttf|txt|vcard|vtt|wasm|webapp|webmanifest|woff2|xdr|xml|xht|xhtml|xloc)$">
-                    Header append Vary "Accept-Encoding"
-                </FilesMatch>
-            </IfModule>
-
             AddOutputFilterByType DEFLATE "application/atom+xml" \
                                           "application/javascript" \
                                           "application/json" \

--- a/manager-bundle/skeleton/public/.htaccess
+++ b/manager-bundle/skeleton/public/.htaccess
@@ -10,6 +10,112 @@
         # Allow CORS on the Contao TinyMCE skin.
         RewriteRule ^assets/tinymce4/js/skins/contao/fonts/ - [ENV=CONTAO_TINYMCE_SKIN:true]
         Header set Access-Control-Allow-Origin "*" env=CONTAO_TINYMCE_SKIN
+
+        # Do not cache source map files
+        <FilesMatch "\.map$">
+            Header set Expires "0"
+            Header set Cache-Control "no-cache, no-store, must-revalidate, max-age=0, proxy-revalidate, no-transform"
+        </FilesMatch>
+    </IfModule>
+
+    <IfModule mod_filter.c>
+        # Brotli compression
+        <IfModule mod_brotli.c>
+            # Force proxies to cache compressed and non-compressed files separately
+            <IfModule mod_headers.c>
+                <FilesMatch ".(appcache|bmp|css|eot|geojson|html|htm|htc|ics|ico|js|json|jsonld|manifest|md|rdf|rss|svg|ttf|txt|vcard|vtt|wasm|webapp|webmanifest|woff2|xdr|xml|xht|xhtml|xloc)$">
+                    Header append Vary "Accept-Encoding"
+                </FilesMatch>
+            </IfModule>
+
+            AddOutputFilterByType BROTLI_COMPRESS "application/atom+xml" \
+                                                  "application/javascript" \
+                                                  "application/json" \
+                                                  "application/ld+json" \
+                                                  "application/manifest+json" \
+                                                  "application/rdf+xml" \
+                                                  "application/rss+xml" \
+                                                  "application/schema+json" \
+                                                  "application/geo+json" \
+                                                  "application/vnd.ms-fontobject" \
+                                                  "application/wasm" \
+                                                  "application/x-font-ttf" \
+                                                  "application/x-javascript" \
+                                                  "application/x-web-app-manifest+json" \
+                                                  "application/xhtml+xml" \
+                                                  "application/xml" \
+                                                  "font/eot" \
+                                                  "font/opentype" \
+                                                  "font/otf" \
+                                                  "font/ttf" \
+                                                  "font/woff2" \
+                                                  "image/bmp" \
+                                                  "image/svg+xml" \
+                                                  "image/vnd.microsoft.icon" \
+                                                  "image/x-icon" \
+                                                  "text/cache-manifest" \
+                                                  "text/calendar" \
+                                                  "text/css" \
+                                                  "text/html" \
+                                                  "text/javascript" \
+                                                  "text/plain" \
+                                                  "text/markdown" \
+                                                  "text/vcard" \
+                                                  "text/vnd.rim.location.xloc" \
+                                                  "text/vtt" \
+                                                  "text/x-component" \
+                                                  "text/x-cross-domain-policy" \
+                                                  "text/xml"
+        </IfModule>
+
+        # Gzip compression
+        <IfModule mod_deflate.c>
+            # Force proxies to cache compressed and non-compressed files separately
+            <IfModule mod_headers.c>
+                <FilesMatch ".(appcache|bmp|css|eot|geojson|html|htm|htc|ics|ico|js|json|jsonld|manifest|md|rdf|rss|svg|ttf|txt|vcard|vtt|wasm|webapp|webmanifest|woff2|xdr|xml|xht|xhtml|xloc)$">
+                    Header append Vary "Accept-Encoding"
+                </FilesMatch>
+            </IfModule>
+
+            AddOutputFilterByType DEFLATE "application/atom+xml" \
+                                          "application/javascript" \
+                                          "application/json" \
+                                          "application/ld+json" \
+                                          "application/manifest+json" \
+                                          "application/rdf+xml" \
+                                          "application/rss+xml" \
+                                          "application/schema+json" \
+                                          "application/geo+json" \
+                                          "application/vnd.ms-fontobject" \
+                                          "application/wasm" \
+                                          "application/x-font-ttf" \
+                                          "application/x-javascript" \
+                                          "application/x-web-app-manifest+json" \
+                                          "application/xhtml+xml" \
+                                          "application/xml" \
+                                          "font/eot" \
+                                          "font/opentype" \
+                                          "font/otf" \
+                                          "font/ttf" \
+                                          "font/woff2" \
+                                          "image/bmp" \
+                                          "image/svg+xml" \
+                                          "image/vnd.microsoft.icon" \
+                                          "image/x-icon" \
+                                          "text/cache-manifest" \
+                                          "text/calendar" \
+                                          "text/css" \
+                                          "text/html" \
+                                          "text/javascript" \
+                                          "text/plain" \
+                                          "text/markdown" \
+                                          "text/vcard" \
+                                          "text/vnd.rim.location.xloc" \
+                                          "text/vtt" \
+                                          "text/x-component" \
+                                          "text/x-cross-domain-policy" \
+                                          "text/xml"
+        </IfModule>
     </IfModule>
 
     # Determine the RewriteBase automatically and set it as environment variable.

--- a/manager-bundle/skeleton/public/.htaccess
+++ b/manager-bundle/skeleton/public/.htaccess
@@ -18,6 +18,63 @@
         </FilesMatch>
     </IfModule>
 
+    <IfModule mod_mime.c>
+        # Data interchange
+        AddType application/atom+xml                        atom
+        AddType application/json                            json map topojson
+        AddType application/ld+json                         jsonld
+        AddType application/rss+xml                         rss
+        AddType application/geo+json                        geojson
+        AddType application/rdf+xml                         rdf
+        AddType application/xml                             xml
+
+        # JavaScript
+        AddType text/javascript                             js mjs
+
+        # Manifest files
+        AddType application/manifest+json                   webmanifest
+        AddType application/x-web-app-manifest+json         webapp
+        AddType text/cache-manifest                         appcache
+
+        # Media files
+        AddType audio/mp4                                   f4a f4b m4a
+        AddType audio/ogg                                   oga ogg opus
+        AddType image/avif                                  avif avifs
+        AddType image/bmp                                   bmp
+        AddType image/jxl                                   jxl
+        AddType image/svg+xml                               svg svgz
+        AddType image/webp                                  webp
+        AddType image/x-icon                                cur ico
+        AddType video/mp4                                   f4v f4p m4v mp4
+        AddType video/ogg                                   ogv
+        AddType video/webm                                  webm
+        AddType video/x-flv                                 flv
+
+        # WebAssembly
+        AddType application/wasm                            wasm
+
+        # Web fonts
+        AddType font/woff                                   woff
+        AddType font/woff2                                  woff2
+        AddType application/vnd.ms-fontobject               eot
+        AddType font/ttf                                    ttf
+        AddType font/collection                             ttc
+        AddType font/otf                                    otf
+
+        # Other
+        AddType application/octet-stream                    safariextz
+        AddType application/x-bb-appworld                   bbaw
+        AddType application/x-chrome-extension              crx
+        AddType application/x-opera-extension               oex
+        AddType application/x-xpinstall                     xpi
+        AddType text/calendar                               ics
+        AddType text/markdown                               markdown md
+        AddType text/vcard                                  vcard vcf
+        AddType text/vnd.rim.location.xloc                  xloc
+        AddType text/vtt                                    vtt
+        AddType text/x-component                            htc
+    </IfModule>
+
     <IfModule mod_filter.c>
         # Brotli compression
         <IfModule mod_brotli.c>


### PR DESCRIPTION
This pull request is a proposal to add several new page speed rules to the `.htaccess` file:

1. Do not cache the source map files.
2. Support the Brotli compression, if available.
3. Support the Gzip compression, if available.

Regarding the compression, it will take a list of the MIME types (see table below) and compress them using Brotli or Gzip depending on which one is available. In addition to that, we have to set the `Vary: Accept-Encoding` header to avoid problems with proxies which might not cache the compressed and non-compressed files separately.

There are likely some of MIME types we could (like `application/rdf+xml`) but I would like to hear your opinions on the full list first.

| MIME type                          | File extension    |
|-----------------------------------|------------------------|
| application/atom+xml              | .atom                  |
| application/javascript            | .js                    |
| application/json                  | .json                  |
| application/ld+json               | .jsonld                |
| application/manifest+json         | .webmanifest           |
| application/rdf+xml               | .rdf                   |
| application/rss+xml               | .rss                   |
| application/schema+json           | .json                  |
| application/geo+json              | .geojson               |
| application/vnd.ms-fontobject     | .eot                   |
| application/wasm                  | .wasm                  |
| application/x-font-ttf            | .ttf                   |
| application/x-javascript          | .js                    |
| application/x-web-app-manifest+json | .webapp              |
| application/xhtml+xml             | .xhtml, .xht           |
| application/xml                   | .xml                   |
| font/eot                          | .eot                   |
| font/opentype                     | .otf                   |
| font/otf                          | .otf                   |
| font/ttf                          | .ttf                   |
| font/woff2                        | .woff2                 |
| image/bmp                         | .bmp                   |
| image/svg+xml                     | .svg                   |
| image/vnd.microsoft.icon          | .ico                   |
| image/x-icon                      | .ico                   |
| text/cache-manifest               | .appcache, .manifest   |
| text/calendar                     | .ics                   |
| text/css                          | .css                   |
| text/html                         | .html, .htm            |
| text/javascript                   | .js                    |
| text/plain                        | .txt                   |
| text/markdown                     | .md                    |
| text/vcard                        | .vcf                   |
| text/vnd.rim.location.xloc        | .xloc                  |
| text/vtt                          | .vtt                   |
| text/x-component                  | .htc                   |
| text/x-cross-domain-policy        | .xml, .xdr             |
| text/xml                          | .xml                   |

The list of MIME types is mostly a courtesy of [HTML5 Boilerplate](https://github.com/h5bp/server-configs-apache/blob/main/dist/.htaccess#L862).