### PR TITLE
Unset PID for copy button callbacks

### DIFF
--- a/core-bundle/src/EventListener/DataContainer/DefaultOperationsListener.php
+++ b/core-bundle/src/EventListener/DataContainer/DefaultOperationsListener.php
@@ -227,6 +227,15 @@ class DefaultOperationsListener
         unset($new['id']);
         $new['tstamp'] = 0;
 
+        // Unset the PID field for the copy operation (act=paste&mode=copy), so a voter can differentiate
+        // between the copy operation (without PID) and the paste button (with new target PID)
+        if (
+            ($GLOBALS['TL_DCA'][$table]['list']['sorting']['mode'] ?? null) === DataContainer::MODE_TREE
+            || !empty($GLOBALS['TL_DCA'][$table]['config']['ptable'] ?? null)
+        ) {
+            unset($new['pid']);
+        }
+
         return new CreateAction($table, $new);
     }
 

--- a/core-bundle/src/EventListener/DataContainer/DefaultOperationsListener.php
+++ b/core-bundle/src/EventListener/DataContainer/DefaultOperationsListener.php
@@ -228,9 +228,9 @@ class DefaultOperationsListener
         $new['tstamp'] = 0;
 
         // Unset the PID field for the copy operation (act=paste&mode=copy), so a voter can differentiate
-        // between the copy operation (without PID) and the paste button (with new target PID)
+        // between the copy operation (without PID) and the paste operation (with new target PID)
         if (
-            ($GLOBALS['TL_DCA'][$table]['list']['sorting']['mode'] ?? null) === DataContainer::MODE_TREE
+            DataContainer::MODE_TREE === ($GLOBALS['TL_DCA'][$table]['list']['sorting']['mode'] ?? null)
             || !empty($GLOBALS['TL_DCA'][$table]['config']['ptable'])
         ) {
             unset($new['pid'], $new['sorting']);

--- a/core-bundle/src/EventListener/DataContainer/DefaultOperationsListener.php
+++ b/core-bundle/src/EventListener/DataContainer/DefaultOperationsListener.php
@@ -231,7 +231,7 @@ class DefaultOperationsListener
         // between the copy operation (without PID) and the paste button (with new target PID)
         if (
             ($GLOBALS['TL_DCA'][$table]['list']['sorting']['mode'] ?? null) === DataContainer::MODE_TREE
-            || !empty($GLOBALS['TL_DCA'][$table]['config']['ptable'] ?? null)
+            || !empty($GLOBALS['TL_DCA'][$table]['config']['ptable'])
         ) {
             unset($new['pid']);
         }

--- a/core-bundle/src/EventListener/DataContainer/DefaultOperationsListener.php
+++ b/core-bundle/src/EventListener/DataContainer/DefaultOperationsListener.php
@@ -233,7 +233,7 @@ class DefaultOperationsListener
             ($GLOBALS['TL_DCA'][$table]['list']['sorting']['mode'] ?? null) === DataContainer::MODE_TREE
             || !empty($GLOBALS['TL_DCA'][$table]['config']['ptable'])
         ) {
-            unset($new['pid']);
+            unset($new['pid'], $new['sorting']);
         }
 
         return new CreateAction($table, $new);

--- a/core-bundle/tests/EventListener/DataContainer/DefaultOperationsListenerTest.php
+++ b/core-bundle/tests/EventListener/DataContainer/DefaultOperationsListenerTest.php
@@ -594,7 +594,7 @@ class DefaultOperationsListenerTest extends TestCase
         yield 'copy operation with parent table' => [
             'copy',
             CreateAction::class,
-            ['id' => 15, 'pid' => 42, 'foo' => 'bar'],
+            ['id' => 15, 'pid' => 42, 'sorting' => 128, 'foo' => 'bar'],
             ['config' => ['ptable' => 'tl_bar']],
             ['foo' => 'bar', 'tstamp' => 0],
         ];
@@ -602,7 +602,7 @@ class DefaultOperationsListenerTest extends TestCase
         yield 'copyChilds operation in tree mode' => [
             'copyChilds',
             CreateAction::class,
-            ['id' => 15, 'pid' => 42, 'foo' => 'bar'],
+            ['id' => 15, 'pid' => 42, 'sorting' => 128, 'foo' => 'bar'],
             ['list' => ['sorting' => ['mode' => DataContainer::MODE_TREE]]],
             ['foo' => 'bar', 'tstamp' => 0],
         ];

--- a/core-bundle/tests/EventListener/DataContainer/DefaultOperationsListenerTest.php
+++ b/core-bundle/tests/EventListener/DataContainer/DefaultOperationsListenerTest.php
@@ -604,7 +604,7 @@ class DefaultOperationsListenerTest extends TestCase
             CreateAction::class,
             ['id' => 15, 'pid' => 42, 'foo' => 'bar'],
             ['list' => ['sorting' => ['mode' => DataContainer::MODE_TREE]]],
-            ['pid' => 42, 'foo' => 'bar', 'tstamp' => 0],
+            ['foo' => 'bar', 'tstamp' => 0],
         ];
 
         yield 'cut operation in tree mode' => [

--- a/core-bundle/tests/EventListener/DataContainer/DefaultOperationsListenerTest.php
+++ b/core-bundle/tests/EventListener/DataContainer/DefaultOperationsListenerTest.php
@@ -572,9 +572,9 @@ class DefaultOperationsListenerTest extends TestCase
         yield 'copy operation' => [
             'copy',
             CreateAction::class,
-            ['id' => 15, 'foo' => 'bar'],
+            ['id' => 15, 'pid' => 42, 'foo' => 'bar'],
             [],
-            ['foo' => 'bar', 'tstamp' => 0],
+            ['pid' => 42, 'foo' => 'bar', 'tstamp' => 0],
         ];
 
         yield 'delete operation' => [
@@ -586,7 +586,7 @@ class DefaultOperationsListenerTest extends TestCase
         yield 'copy operation in tree mode' => [
             'copy',
             CreateAction::class,
-            ['id' => 15, 'foo' => 'bar'],
+            ['id' => 15, 'pid' => 0, 'foo' => 'bar'],
             ['list' => ['sorting' => ['mode' => DataContainer::MODE_TREE]]],
             ['foo' => 'bar', 'tstamp' => 0],
         ];
@@ -594,7 +594,7 @@ class DefaultOperationsListenerTest extends TestCase
         yield 'copy operation with parent table' => [
             'copy',
             CreateAction::class,
-            ['id' => 15, 'foo' => 'bar'],
+            ['id' => 15, 'pid' => 42, 'foo' => 'bar'],
             ['config' => ['ptable' => 'tl_bar']],
             ['foo' => 'bar', 'tstamp' => 0],
         ];


### PR DESCRIPTION
Unset the PID field for the copy operation (act=paste&mode=copy), so a voter can differentiate between the copy operation (without PID) and the paste button (with new target PID)