### PR TITLE
Make the template module more flexible

### DIFF
--- a/core-bundle/src/Controller/FrontendModule/TemplateController.php
+++ b/core-bundle/src/Controller/FrontendModule/TemplateController.php
@@ -22,9 +22,15 @@ class TemplateController extends AbstractFrontendModuleController
 {
     protected function getResponse(Template $template, ModuleModel $model, Request $request): Response
     {
-        $this->initializeContaoFramework();
+        $data = StringUtil::deserialize($model->data, true);
 
-        $template->data = StringUtil::deserialize($model->data, true);
+        $template->keys = array_combine(
+            array_column($data, 'key'),
+            array_column($data, 'value')
+        );
+
+        // Backwards compatibililty
+        $template->data = $data;
 
         return $template->getResponse();
     }

--- a/core-bundle/src/Resources/contao/templates/modules/mod_template.html5
+++ b/core-bundle/src/Resources/contao/templates/modules/mod_template.html5
@@ -2,10 +2,10 @@
 
 <?php $this->block('content'); ?>
 
-  <?php foreach ($this->data as $entry): ?>
+  <?php foreach ($this->keys as $key => $value): ?>
     <dl>
-      <dt><?= $entry['key'] ?></dt>
-      <dd><?= $entry['value'] ?></dd>
+      <dt><?= $key ?></dt>
+      <dd><?= $value ?></dd>
     </dl>
   <?php endforeach; ?>
 


### PR DESCRIPTION
Same as #4665 - but for the front end module. I am assuming it was an oversight that only the `template` _content element_ was adjusted instead of both the `template` content element _and_ front end module.

This PR brings the `template` front end module's functionality in line with the content element's.

/cc @doishub