### PR TITLE
Implement visible root trails for DC_Folder

### DIFF
--- a/core-bundle/contao/dca/tl_files.php
+++ b/core-bundle/contao/dca/tl_files.php
@@ -70,7 +70,8 @@ $GLOBALS['TL_DCA']['tl_files'] = array
 	(
 		'sorting' => array
 		(
-			'panelLayout'             => 'search'
+			'panelLayout'             => 'search',
+			'showRootTrails'          => true
 		),
 		'global_operations' => array
 		(


### PR DESCRIPTION
This is an alternative to #6124, which makes only the changes necessary to implement the feature and skips all the additional optimizations such as the extended `isValid()` method.

As the original PR, it is best viewed hiding whitespace changes: https://github.com/contao/contao/pull/6191/files?diff=unified&w=1