### PR TITLE
Favorites voter must not grant access

### DIFF
--- a/core-bundle/src/Security/Voter/DataContainer/FavoritesVoter.php
+++ b/core-bundle/src/Security/Voter/DataContainer/FavoritesVoter.php
@@ -57,7 +57,9 @@ class FavoritesVoter implements CacheableVoterInterface
                 default => false,
             };
 
-            return $isGranted ? self::ACCESS_GRANTED : self::ACCESS_DENIED;
+            if (!$isGranted) {
+                return self::ACCESS_DENIED;
+            }
         }
 
         return self::ACCESS_ABSTAIN;

--- a/core-bundle/tests/Security/Voter/DataContainer/FavoritesVoterTest.php
+++ b/core-bundle/tests/Security/Voter/DataContainer/FavoritesVoterTest.php
@@ -60,6 +60,7 @@ class FavoritesVoterTest extends TestCase
 
         $token = $this->createMock(TokenInterface::class);
 
+        // Unsupported attribute
         $this->assertSame(
             VoterInterface::ACCESS_ABSTAIN,
             $voter->vote(
@@ -69,8 +70,10 @@ class FavoritesVoterTest extends TestCase
             )
         );
 
+        // Permission granted, so abstain! Our voters either deny or abstain,
+        // they must never grant access (see #6201).
         $this->assertSame(
-            VoterInterface::ACCESS_GRANTED,
+            VoterInterface::ACCESS_ABSTAIN,
             $voter->vote(
                 $token,
                 new ReadAction('foo', ['id' => 42]),
@@ -78,6 +81,7 @@ class FavoritesVoterTest extends TestCase
             )
         );
 
+        // Permission denied
         $this->assertSame(
             VoterInterface::ACCESS_DENIED,
             $voter->vote(


### PR DESCRIPTION
I think this will happen over and over again 🙈 

DCA voters must never grant access, because we have a priority strategy. The first voter that does not abstain will win the vote. Our voters must deny if access should not be allowed, but if they allow access, we must continue the priority chain and ask the next voter, until the `DefaultDataContainerVoter` would grant the default access.

In this current example, if https://github.com/contao/contao/pull/6177 was not merged, the `TableAccessVoter` would deny favorites if no fields are allowed. But this voter would override that permission check.