### PR TITLE
Revert 'Allow multiple label callbacks'

### DIFF
--- a/comments-bundle/contao/dca/tl_comments.php
+++ b/comments-bundle/contao/dca/tl_comments.php
@@ -78,10 +78,7 @@ $GLOBALS['TL_DCA']['tl_comments'] = array
 		(
 			'fields'                  => array('name'),
 			'format'                  => '%s',
-			'label_callback'          => array
-			(
-				array('tl_comments', 'listComments')
-			)
+			'label_callback'          => array('tl_comments', 'listComments')
 		),
 		'global_operations' => array
 		(

--- a/core-bundle/contao/classes/DataContainer.php
+++ b/core-bundle/contao/classes/DataContainer.php
@@ -1688,55 +1688,40 @@ abstract class DataContainer extends Backend
 
 		$mode = $GLOBALS['TL_DCA'][$table]['list']['sorting']['mode'] ?? self::MODE_SORTED;
 
-		if (\is_callable($labelConfig['label_callback'] ?? null))
-		{
-			trigger_deprecation('contao/core-bundle', '5.2', 'Using a single callback for "list.label.label_callback" instead of an array of callbacks has been deprecated and will no longer work in Contao 6.');
-			$labelConfig['label_callback'] = array($labelConfig['label_callback']);
-		}
-
 		// Execute label_callback
-		if (\is_array($labelConfig['label_callback'] ?? null))
+		if (\is_array($labelConfig['label_callback'] ?? null) || \is_callable($labelConfig['label_callback'] ?? null))
 		{
-			if (\count($labelConfig['label_callback']) === 2 && \is_string($labelConfig['label_callback'][0]) && \is_string($labelConfig['label_callback'][1]))
+			if (\in_array($mode, array(self::MODE_TREE, self::MODE_TREE_EXTENDED)))
 			{
-				trigger_deprecation('contao/core-bundle', '5.2', 'Using a single callback for "list.label.label_callback" instead of an array of callbacks has been deprecated and will no longer work in Contao 6.');
-				$labelConfig['label_callback'] = array($labelConfig['label_callback']);
+				if (\is_array($labelConfig['label_callback']))
+				{
+					$label = System::importStatic($labelConfig['label_callback'][0])->{$labelConfig['label_callback'][1]}($row, $label, $this, '', false, $protected, $isVisibleRootTrailPage);
+				}
+				elseif (\is_callable($labelConfig['label_callback']))
+				{
+					$label = $labelConfig['label_callback']($row, $label, $this, '', false, $protected, $isVisibleRootTrailPage);
+				}
 			}
-
-			foreach ($labelConfig['label_callback'] as $callback)
+			elseif ($mode === self::MODE_PARENT)
 			{
-				if (\in_array($mode, array(self::MODE_TREE, self::MODE_TREE_EXTENDED)))
+				if (\is_array($labelConfig['label_callback']))
 				{
-					if (\is_array($callback))
-					{
-						$label = System::importStatic($callback[0])->{$callback[1]}($row, $label, $this, '', false, $protected, $isVisibleRootTrailPage);
-					}
-					elseif (\is_callable($callback))
-					{
-						$label = $callback($row, $label, $this, '', false, $protected, $isVisibleRootTrailPage);
-					}
+					$label = System::importStatic($labelConfig['label_callback'][0])->{$labelConfig['label_callback'][1]}($row, $label, $this);
 				}
-				elseif ($mode === self::MODE_PARENT)
+				elseif (\is_callable($labelConfig['label_callback']))
 				{
-					if (\is_array($callback))
-					{
-						$label = System::importStatic($callback[0])->{$callback[1]}($row, $label, $this);
-					}
-					elseif (\is_callable($callback))
-					{
-						$label = $callback($row, $label, $this);
-					}
+					$label = $labelConfig['label_callback']($row, $label, $this);
 				}
-				else
+			}
+			else
+			{
+				if (\is_array($labelConfig['label_callback']))
 				{
-					if (\is_array($callback))
-					{
-						$label = System::importStatic($callback[0])->{$callback[1]}($row, $label, $this, $args);
-					}
-					elseif (\is_callable($callback))
-					{
-						$label = $callback($row, $label, $this, $args);
-					}
+					$label = System::importStatic($labelConfig['label_callback'][0])->{$labelConfig['label_callback'][1]}($row, $label, $this, $args);
+				}
+				elseif (\is_callable($labelConfig['label_callback']))
+				{
+					$label = $labelConfig['label_callback']($row, $label, $this, $args);
 				}
 			}
 		}

--- a/core-bundle/contao/dca/tl_article.php
+++ b/core-bundle/contao/dca/tl_article.php
@@ -69,10 +69,7 @@ $GLOBALS['TL_DCA']['tl_article'] = array
 		(
 			'fields'                  => array('title', 'inColumn'),
 			'format'                  => '%s <span class="label-info">[%s]</span>',
-			'label_callback'          => array
-			(
-				array('tl_article', 'addIcon')
-			)
+			'label_callback'          => array('tl_article', 'addIcon')
 		),
 		'global_operations' => array
 		(

--- a/core-bundle/contao/dca/tl_log.php
+++ b/core-bundle/contao/dca/tl_log.php
@@ -45,10 +45,7 @@ $GLOBALS['TL_DCA']['tl_log'] = array
 		(
 			'fields'                  => array('tstamp', 'text'),
 			'format'                  => '<span class="label-date">[%s]</span> %s',
-			'label_callback'          => array
-			(
-				array('tl_log', 'colorize')
-			)
+			'label_callback'          => array('tl_log', 'colorize')
 		),
 		'global_operations' => array
 		(

--- a/core-bundle/contao/dca/tl_member.php
+++ b/core-bundle/contao/dca/tl_member.php
@@ -60,10 +60,7 @@ $GLOBALS['TL_DCA']['tl_member'] = array
 		(
 			'fields'                  => array('', 'firstname', 'lastname', 'username', 'dateAdded'),
 			'showColumns'             => true,
-			'label_callback' => array
-			(
-				array('tl_member', 'addIcon')
-			)
+			'label_callback'          => array('tl_member', 'addIcon')
 		),
 		'global_operations' => array
 		(

--- a/core-bundle/contao/dca/tl_member_group.php
+++ b/core-bundle/contao/dca/tl_member_group.php
@@ -45,10 +45,7 @@ $GLOBALS['TL_DCA']['tl_member_group'] = array
 		(
 			'fields'                  => array('name'),
 			'format'                  => '%s',
-			'label_callback'          => array
-			(
-				array('tl_member_group', 'addIcon')
-			)
+			'label_callback'          => array('tl_member_group', 'addIcon')
 		),
 		'global_operations' => array
 		(

--- a/core-bundle/contao/dca/tl_module.php
+++ b/core-bundle/contao/dca/tl_module.php
@@ -56,10 +56,7 @@ $GLOBALS['TL_DCA']['tl_module'] = array
 		),
 		'label' => array
 		(
-			'group_callback' => array
-			(
-				array('tl_module', 'getGroupHeader')
-			)
+			'group_callback'          => array('tl_module', 'getGroupHeader')
 		),
 		'global_operations' => array
 		(

--- a/core-bundle/contao/dca/tl_page.php
+++ b/core-bundle/contao/dca/tl_page.php
@@ -92,10 +92,7 @@ $GLOBALS['TL_DCA']['tl_page'] = array
 		(
 			'fields'                  => array('title'),
 			'format'                  => '%s',
-			'label_callback'          => array
-			(
-				array('tl_page', 'addIcon')
-			)
+			'label_callback'          => array('tl_page', 'addIcon')
 		),
 		'global_operations' => array
 		(

--- a/core-bundle/contao/dca/tl_theme.php
+++ b/core-bundle/contao/dca/tl_theme.php
@@ -57,10 +57,7 @@ $GLOBALS['TL_DCA']['tl_theme'] = array
 		(
 			'fields'                  => array('name'),
 			'format'                  => '%s',
-			'label_callback'          => array
-			(
-				array('tl_theme', 'addPreviewImage')
-			)
+			'label_callback'          => array('tl_theme', 'addPreviewImage')
 		),
 		'global_operations' => array
 		(

--- a/core-bundle/contao/dca/tl_user.php
+++ b/core-bundle/contao/dca/tl_user.php
@@ -69,10 +69,7 @@ $GLOBALS['TL_DCA']['tl_user'] = array
 		(
 			'fields'                  => array('', 'name', 'username', 'dateAdded'),
 			'showColumns'             => true,
-			'label_callback'          => array
-			(
-				array('tl_user', 'addIcon')
-			)
+			'label_callback'          => array('tl_user', 'addIcon')
 		),
 		'global_operations' => array
 		(

--- a/core-bundle/contao/dca/tl_user_group.php
+++ b/core-bundle/contao/dca/tl_user_group.php
@@ -56,10 +56,7 @@ $GLOBALS['TL_DCA']['tl_user_group'] = array
 		(
 			'fields'                  => array('name'),
 			'format'                  => '%s',
-			'label_callback'          => array
-			(
-				array('tl_user_group', 'addIcon')
-			)
+			'label_callback'          => array('tl_user_group', 'addIcon')
 		),
 		'global_operations' => array
 		(

--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -4648,32 +4648,14 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 				}
 			}
 
-			if (\is_callable($GLOBALS['TL_DCA'][$table]['list']['sorting']['header_callback'] ?? null))
-			{
-				trigger_deprecation('contao/core-bundle', '5.2', 'Using a single callback for "list.sorting.header_callback" instead of an array of callbacks has been deprecated and will no longer work in Contao 6.');
-				$GLOBALS['TL_DCA'][$table]['list']['sorting']['header_callback'] = array($GLOBALS['TL_DCA'][$table]['list']['sorting']['header_callback']);
-			}
-
 			// Trigger the header_callback (see #3417)
 			if (\is_array($GLOBALS['TL_DCA'][$table]['list']['sorting']['header_callback'] ?? null))
 			{
-				if (\count($GLOBALS['TL_DCA'][$table]['list']['sorting']['header_callback']) === 2 && \is_string($GLOBALS['TL_DCA'][$table]['list']['sorting']['header_callback'][0]) && \is_string($GLOBALS['TL_DCA'][$table]['list']['sorting']['header_callback'][1]))
-				{
-					trigger_deprecation('contao/core-bundle', '5.2', 'Using a single callback for "list.sorting.header_callback" instead of an array of callbacks has been deprecated and will no longer work in Contao 6.');
-					$GLOBALS['TL_DCA'][$table]['list']['sorting']['header_callback'] = array($GLOBALS['TL_DCA'][$table]['list']['sorting']['header_callback']);
-				}
-
-				foreach ($GLOBALS['TL_DCA'][$table]['list']['sorting']['header_callback'] as $callback)
-				{
-					if (\is_array($callback))
-					{
-						$add = System::importStatic($callback[0])->{$callback[1]}($add, $this);
-					}
-					elseif (\is_callable($callback))
-					{
-						$add = $callback($add, $this);
-					}
-				}
+				$add = System::importStatic($GLOBALS['TL_DCA'][$table]['list']['sorting']['header_callback'][0])->{$GLOBALS['TL_DCA'][$table]['list']['sorting']['header_callback'][1]}($add, $this);
+			}
+			elseif (\is_callable($GLOBALS['TL_DCA'][$table]['list']['sorting']['header_callback'] ?? null))
+			{
+				$add = $GLOBALS['TL_DCA'][$table]['list']['sorting']['header_callback']($add, $this);
 			}
 
 			// Output the header data
@@ -6513,32 +6495,14 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 			}
 		}
 
-		if (\is_callable($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['group_callback'] ?? null))
-		{
-			trigger_deprecation('contao/core-bundle', '5.2', 'Using a single callback for "list.label.group_callback" instead of an array of callbacks has been deprecated and will no longer work in Contao 6.');
-			$GLOBALS['TL_DCA'][$this->strTable]['list']['label']['group_callback'] = array($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['group_callback']);
-		}
-
 		// Call the group callback ($group, $sortingMode, $firstOrderBy, $row, $this)
 		if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['group_callback'] ?? null))
 		{
-			if (\count($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['group_callback']) === 2 && \is_string($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['group_callback'][0]) && \is_string($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['group_callback'][1]))
-			{
-				trigger_deprecation('contao/core-bundle', '5.2', 'Using a single callback for "list.label.group_callback" instead of an array of callbacks has been deprecated and will no longer work in Contao 6.');
-				$GLOBALS['TL_DCA'][$this->strTable]['list']['label']['group_callback'] = array($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['group_callback']);
-			}
-
-			foreach ($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['group_callback'] as $callback)
-			{
-				if (\is_array($callback))
-				{
-					$group = System::importStatic($callback[0])->{$callback[1]}($group, $mode, $field, $row, $this);
-				}
-				elseif (\is_callable($callback))
-				{
-					$group = $callback($group, $mode, $field, $row, $this);
-				}
-			}
+			$group = System::importStatic($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['group_callback'][0])->{$GLOBALS['TL_DCA'][$this->strTable]['list']['label']['group_callback'][1]}($group, $mode, $field, $row, $this);
+		}
+		elseif (\is_callable($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['group_callback'] ?? null))
+		{
+			$group = $GLOBALS['TL_DCA'][$this->strTable]['list']['label']['group_callback']($group, $mode, $field, $row, $this);
 		}
 
 		return $group;

--- a/core-bundle/src/EventListener/DataContainerCallbackListener.php
+++ b/core-bundle/src/EventListener/DataContainerCallbackListener.php
@@ -21,9 +21,12 @@ class DataContainerCallbackListener
         'panel_callback',
         'paste_button_callback',
         'button_callback',
+        'label_callback',
+        'header_callback',
         'child_record_callback',
         'input_field_callback',
         'options_callback',
+        'group_callback',
         'url_callback',
         'title_tag_callback',
     ];


### PR DESCRIPTION
This reverts #6054 because it is a breaking change. To be added again in Contao 6 (see #6204).