### PR TITLE
Decode HTML entities in feed item titles

### DIFF
--- a/news-bundle/config/services.yaml
+++ b/news-bundle/config/services.yaml
@@ -12,6 +12,7 @@ services:
         arguments:
             - '@contao.assets.files_context'
             - '@contao_news.feed_specification'
+            - '%kernel.charset%'
 
     contao_news.feed_specification:
         class: FeedIo\Specification
@@ -60,6 +61,7 @@ services:
             - '@contao.insert_tag.parser'
             - '%kernel.project_dir%'
             - '@contao.cache.entity_tags'
+            - '%kernel.charset%'
 
     contao_news.listener.preview_url_convert:
         class: Contao\NewsBundle\EventListener\PreviewUrlConvertListener

--- a/news-bundle/src/Controller/Page/NewsFeedController.php
+++ b/news-bundle/src/Controller/Page/NewsFeedController.php
@@ -42,7 +42,7 @@ class NewsFeedController extends AbstractController implements DynamicRouteInter
         'rss' => '.xml',
     ];
 
-    public function __construct(private readonly ContaoContext $contaoContext, private readonly Specification $specification)
+    public function __construct(private readonly ContaoContext $contaoContext, private readonly Specification $specification, private readonly string $charset)
     {
     }
 
@@ -54,8 +54,8 @@ class NewsFeedController extends AbstractController implements DynamicRouteInter
         $baseUrl = $staticUrl ?: $request->getSchemeAndHttpHost();
 
         $feed = (new Feed())
-            ->setTitle(html_entity_decode($pageModel->title))
-            ->setDescription(html_entity_decode($pageModel->feedDescription ?? ''))
+            ->setTitle(html_entity_decode($pageModel->title, ENT_QUOTES, $this->charset))
+            ->setDescription(html_entity_decode($pageModel->feedDescription ?? '', ENT_QUOTES, $this->charset))
             ->setLanguage($pageModel->language)
         ;
 

--- a/news-bundle/src/Controller/Page/NewsFeedController.php
+++ b/news-bundle/src/Controller/Page/NewsFeedController.php
@@ -54,8 +54,8 @@ class NewsFeedController extends AbstractController implements DynamicRouteInter
         $baseUrl = $staticUrl ?: $request->getSchemeAndHttpHost();
 
         $feed = (new Feed())
-            ->setTitle($pageModel->title)
-            ->setDescription($pageModel->feedDescription)
+            ->setTitle(html_entity_decode($pageModel->title))
+            ->setDescription(html_entity_decode($pageModel->feedDescription ?? ''))
             ->setLanguage($pageModel->language)
         ;
 

--- a/news-bundle/src/Controller/Page/NewsFeedController.php
+++ b/news-bundle/src/Controller/Page/NewsFeedController.php
@@ -42,8 +42,11 @@ class NewsFeedController extends AbstractController implements DynamicRouteInter
         'rss' => '.xml',
     ];
 
-    public function __construct(private readonly ContaoContext $contaoContext, private readonly Specification $specification, private readonly string $charset)
-    {
+    public function __construct(
+        private readonly ContaoContext $contaoContext,
+        private readonly Specification $specification,
+        private readonly string $charset,
+    ) {
     }
 
     public function __invoke(Request $request, PageModel $pageModel): Response

--- a/news-bundle/src/EventListener/NewsFeedListener.php
+++ b/news-bundle/src/EventListener/NewsFeedListener.php
@@ -43,6 +43,7 @@ class NewsFeedListener
         private readonly InsertTagParser $insertTags,
         private readonly string $projectDir,
         private readonly EntityCacheTags $cacheTags,
+        private readonly string $charset,
     ) {
     }
 
@@ -71,7 +72,7 @@ class NewsFeedListener
 
         $item = new Item();
         $item
-            ->setTitle(html_entity_decode($article->headline, ENT_QUOTES, 'UTF-8'))
+            ->setTitle(html_entity_decode($article->headline, ENT_QUOTES, $this->charset))
             ->setLastModified((new \DateTime())->setTimestamp($article->date))
             ->setLink($this->getLink($article))
             ->setContent($this->getContent($article, $item, $event))

--- a/news-bundle/src/EventListener/NewsFeedListener.php
+++ b/news-bundle/src/EventListener/NewsFeedListener.php
@@ -71,7 +71,7 @@ class NewsFeedListener
 
         $item = new Item();
         $item
-            ->setTitle(\html_entity_decode($article->headline, ENT_QUOTES, 'UTF-8'))
+            ->setTitle(html_entity_decode($article->headline, ENT_QUOTES, 'UTF-8'))
             ->setLastModified((new \DateTime())->setTimestamp($article->date))
             ->setLink($this->getLink($article))
             ->setContent($this->getContent($article, $item, $event))

--- a/news-bundle/src/EventListener/NewsFeedListener.php
+++ b/news-bundle/src/EventListener/NewsFeedListener.php
@@ -71,7 +71,7 @@ class NewsFeedListener
 
         $item = new Item();
         $item
-            ->setTitle($article->headline)
+            ->setTitle(\html_entity_decode($article->headline, ENT_QUOTES, 'UTF-8'))
             ->setLastModified((new \DateTime())->setTimestamp($article->date))
             ->setLink($this->getLink($article))
             ->setContent($this->getContent($article, $item, $event))

--- a/news-bundle/tests/Controller/Page/NewsFeedControllerTest.php
+++ b/news-bundle/tests/Controller/Page/NewsFeedControllerTest.php
@@ -226,7 +226,7 @@ class NewsFeedControllerTest extends ContaoTestCase
         $contaoContext = $this->createMock(ContaoContext::class);
         $specification = new Specification(new NullLogger());
 
-        return new NewsFeedController($contaoContext, $specification);
+        return new NewsFeedController($contaoContext, $specification, 'UTF-8');
     }
 
     private function getArticlesAsArray(int $count = 1): array

--- a/news-bundle/tests/Controller/Page/NewsFeedControllerTest.php
+++ b/news-bundle/tests/Controller/Page/NewsFeedControllerTest.php
@@ -153,6 +153,7 @@ class NewsFeedControllerTest extends ContaoTestCase
 
         $document = new \DOMDocument('1.0', 'utf-8');
         $document->loadXML($response->getContent());
+
         $this->assertSame('Latest News </channel>', $document->getElementsByTagName('title')->item(0)->textContent);
         $this->assertSame('Get latest news </channel>', $document->getElementsByTagName('description')->item(0)->textContent);
     }

--- a/news-bundle/tests/Controller/Page/NewsFeedControllerTest.php
+++ b/news-bundle/tests/Controller/Page/NewsFeedControllerTest.php
@@ -125,7 +125,7 @@ class NewsFeedControllerTest extends ContaoTestCase
     /**
      * @dataProvider getXMLFeedFormats
      */
-    public function testProperlyEncodesXMLEntities(string $format):  void
+    public function testProperlyEncodesXMLEntities(string $format): void
     {
         $pageModel = $this->mockClassWithProperties(
             PageModel::class,

--- a/news-bundle/tests/EventListener/NewsFeedListenerTest.php
+++ b/news-bundle/tests/EventListener/NewsFeedListenerTest.php
@@ -88,7 +88,7 @@ class NewsFeedListenerTest extends ContaoTestCase
     /**
      * @dataProvider getFeedSource
      */
-    public function testTransformsArticlesToFeedItems(string $feedSource, string $expecedContent): void
+    public function testTransformsArticlesToFeedItems(string $feedSource, array $headline, array $content): void
     {
         $imageDir = Path::join($this->getTempDir(), 'files');
 
@@ -139,7 +139,7 @@ class NewsFeedListenerTest extends ContaoTestCase
         $insertTags
             ->expects($this->once())
             ->method('replaceInline')
-            ->willReturn($expecedContent)
+            ->willReturn($content[0])
         ;
 
         $element = $this->mockClassWithProperties(ContentModel::class, [
@@ -157,8 +157,8 @@ class NewsFeedListenerTest extends ContaoTestCase
         $article = $this->mockClassWithProperties(NewsModel::class, [
             'id' => 42,
             'date' => 1656578758,
-            'headline' => 'Example title &#40;Episode 1&#41;',
-            'teaser' => 'Example teaser &#40;Episode 1&#41;',
+            'headline' => $headline[0],
+            'teaser' => $content[0],
             'singleSRC' => 'binary_uuid',
             'addEnclosure' => serialize(['binary_uuid2']),
         ]);
@@ -183,7 +183,7 @@ class NewsFeedListenerTest extends ContaoTestCase
         $controller = $this->mockAdapter(['getContentElement', 'convertRelativeUrls']);
         $controller
             ->method('convertRelativeUrls')
-            ->willReturn($expecedContent)
+            ->willReturn($content[0])
         ;
 
         $filesModel = $this->mockAdapter(['findMultipleByUuids']);
@@ -234,11 +234,11 @@ class NewsFeedListenerTest extends ContaoTestCase
 
         $item = $event->getItem();
 
-        $this->assertSame('Example title (Episode 1)', $item->getTitle());
+        $this->assertSame($headline[1], $item->getTitle());
         $this->assertSame(1656578758, $item->getLastModified()->getTimestamp());
         $this->assertSame('https://example.org/news/example-title', $item->getLink());
         $this->assertSame('https://example.org/news/example-title', $item->getPublicId());
-        $this->assertSame($expecedContent, $item->getContent());
+        $this->assertSame($content[1], $item->getContent());
         $this->assertSame('Jane Doe', $item->getAuthor()->getName());
         $this->assertCount(2, $item->getMedias());
 
@@ -254,7 +254,7 @@ class NewsFeedListenerTest extends ContaoTestCase
 
     public function getFeedSource(): \Generator
     {
-        yield 'Teaser only' => ['source_teaser', 'Example teaser &#40;Episode 1&#41;'];
-        yield 'Text' => ['source_text', 'Example content'];
+        yield 'Teaser' => ['source_teaser', ['Example title &#40;Episode 1&#41;', 'Example title (Episode 1)'], ['Example teaser &#40;Episode 1&#41;', 'Example teaser &#40;Episode 1&#41;']];
+        yield 'Text' => ['source_text', ['Example title &#40;Episode 1&#41;', 'Example title (Episode 1)'], ['Example content &#40;Episode 1&#41;', 'Example content &#40;Episode 1&#41;']];
     }
 }

--- a/news-bundle/tests/EventListener/NewsFeedListenerTest.php
+++ b/news-bundle/tests/EventListener/NewsFeedListenerTest.php
@@ -79,7 +79,7 @@ class NewsFeedListenerTest extends ContaoTestCase
 
         $event = new FetchArticlesForFeedEvent($feed, $request, $pageModel);
 
-        $listener = new NewsFeedListener($this->mockContaoFramework([NewsModel::class => $newsModel]), $imageFactory, $insertTags, $this->getTempDir(), $cacheTags);
+        $listener = new NewsFeedListener($this->mockContaoFramework([NewsModel::class => $newsModel]), $imageFactory, $insertTags, $this->getTempDir(), $cacheTags, 'UTF-8');
         $listener->onFetchArticlesForFeed($event);
 
         $this->assertSame($collection, $event->getArticles());
@@ -229,7 +229,7 @@ class NewsFeedListenerTest extends ContaoTestCase
         $baseUrl = 'example.org';
         $event = new TransformArticleForFeedEvent($article, $feed, $pageModel, $request, $baseUrl);
 
-        $listener = new NewsFeedListener($framework, $imageFactory, $insertTags, $this->getTempDir(), $cacheTags);
+        $listener = new NewsFeedListener($framework, $imageFactory, $insertTags, $this->getTempDir(), $cacheTags, 'UTF-8');
         $listener->onTransformArticleForFeed($event);
 
         $item = $event->getItem();

--- a/news-bundle/tests/EventListener/NewsFeedListenerTest.php
+++ b/news-bundle/tests/EventListener/NewsFeedListenerTest.php
@@ -157,8 +157,8 @@ class NewsFeedListenerTest extends ContaoTestCase
         $article = $this->mockClassWithProperties(NewsModel::class, [
             'id' => 42,
             'date' => 1656578758,
-            'headline' => 'Example title',
-            'teaser' => 'Example teaser',
+            'headline' => 'Example title &#40;Episode 1&#41;',
+            'teaser' => 'Example teaser &#40;Episode 1&#41;',
             'singleSRC' => 'binary_uuid',
             'addEnclosure' => serialize(['binary_uuid2']),
         ]);
@@ -234,7 +234,7 @@ class NewsFeedListenerTest extends ContaoTestCase
 
         $item = $event->getItem();
 
-        $this->assertSame('Example title', $item->getTitle());
+        $this->assertSame('Example title (Episode 1)', $item->getTitle());
         $this->assertSame(1656578758, $item->getLastModified()->getTimestamp());
         $this->assertSame('https://example.org/news/example-title', $item->getLink());
         $this->assertSame('https://example.org/news/example-title', $item->getPublicId());
@@ -254,7 +254,7 @@ class NewsFeedListenerTest extends ContaoTestCase
 
     public function getFeedSource(): \Generator
     {
-        yield 'Teaser only' => ['source_teaser', 'Example teaser'];
+        yield 'Teaser only' => ['source_teaser', 'Example teaser &#40;Episode 1&#41;'];
         yield 'Text' => ['source_text', 'Example content'];
     }
 }

--- a/news-bundle/tests/EventListener/NewsFeedListenerTest.php
+++ b/news-bundle/tests/EventListener/NewsFeedListenerTest.php
@@ -65,6 +65,7 @@ class NewsFeedListenerTest extends ContaoTestCase
             ->willReturn($collection)
         ;
 
+        $framework = $this->mockContaoFramework([NewsModel::class => $newsModel]);
         $feed = $this->createMock(Feed::class);
         $request = $this->createMock(Request::class);
 
@@ -79,7 +80,7 @@ class NewsFeedListenerTest extends ContaoTestCase
 
         $event = new FetchArticlesForFeedEvent($feed, $request, $pageModel);
 
-        $listener = new NewsFeedListener($this->mockContaoFramework([NewsModel::class => $newsModel]), $imageFactory, $insertTags, $this->getTempDir(), $cacheTags, 'UTF-8');
+        $listener = new NewsFeedListener($framework, $imageFactory, $insertTags, $this->getTempDir(), $cacheTags, 'UTF-8');
         $listener->onFetchArticlesForFeed($event);
 
         $this->assertSame($collection, $event->getArticles());
@@ -254,7 +255,16 @@ class NewsFeedListenerTest extends ContaoTestCase
 
     public function getFeedSource(): \Generator
     {
-        yield 'Teaser' => ['source_teaser', ['Example title &#40;Episode 1&#41;', 'Example title (Episode 1)'], ['Example teaser &#40;Episode 1&#41;', 'Example teaser &#40;Episode 1&#41;']];
-        yield 'Text' => ['source_text', ['Example title &#40;Episode 1&#41;', 'Example title (Episode 1)'], ['Example content &#40;Episode 1&#41;', 'Example content &#40;Episode 1&#41;']];
+        yield 'Teaser' => [
+            'source_teaser',
+            ['Example title &#40;Episode 1&#41;', 'Example title (Episode 1)'],
+            ['Example teaser &#40;Episode 1&#41;', 'Example teaser &#40;Episode 1&#41;'],
+        ];
+
+        yield 'Text' => [
+            'source_text',
+            ['Example title &#40;Episode 1&#41;', 'Example title (Episode 1)'],
+            ['Example content &#40;Episode 1&#41;', 'Example content &#40;Episode 1&#41;'],
+        ];
     }
 }


### PR DESCRIPTION
The RSS spec does not mention HTML in item titles. As Contao encodes HTML entities on input, they are currently output as is in the feed item title. This PR converts them back before outputting the title to the feed. 

![2023-07-11 21_51_39](https://github.com/contao/contao/assets/4400435/4c67dcdd-a312-4684-beec-2523eb59afd1)
