### PR TITLE
Fix relative redirects

### DIFF
--- a/core-bundle/src/Resources/contao/pages/PageRedirect.php
+++ b/core-bundle/src/Resources/contao/pages/PageRedirect.php
@@ -10,6 +10,7 @@
 
 namespace Contao;
 
+use Contao\CoreBundle\Util\UrlUtil;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 
 /**
@@ -31,7 +32,9 @@ class PageRedirect extends Frontend
 
 		$this->prepare($objPage);
 
-		$this->redirect(System::getContainer()->get('contao.insert_tag.parser')->replaceInline($objPage->url), $this->getRedirectStatusCode($objPage));
+		$url = UrlUtil::makeAbsolute(System::getContainer()->get('contao.insert_tag.parser')->replaceInline($objPage->url), Environment::get('path'));
+
+		$this->redirect($url, $this->getRedirectStatusCode($objPage));
 	}
 
 	/**
@@ -45,7 +48,9 @@ class PageRedirect extends Frontend
 	{
 		$this->prepare($objPage);
 
-		return new RedirectResponse(System::getContainer()->get('contao.insert_tag.parser')->replaceInline($objPage->url), $this->getRedirectStatusCode($objPage));
+		$url = UrlUtil::makeAbsolute(System::getContainer()->get('contao.insert_tag.parser')->replaceInline($objPage->url), Environment::get('path'));
+
+		return new RedirectResponse($url, $this->getRedirectStatusCode($objPage));
 	}
 
 	/**

--- a/core-bundle/src/Resources/contao/pages/PageRedirect.php
+++ b/core-bundle/src/Resources/contao/pages/PageRedirect.php
@@ -32,7 +32,7 @@ class PageRedirect extends Frontend
 
 		$this->prepare($objPage);
 
-		$url = UrlUtil::makeAbsolute(System::getContainer()->get('contao.insert_tag.parser')->replaceInline($objPage->url), Environment::get('path'));
+		$url = UrlUtil::makeAbsolute(System::getContainer()->get('contao.insert_tag.parser')->replaceInline($objPage->url), Environment::get('path') . '/');
 
 		$this->redirect($url, $this->getRedirectStatusCode($objPage));
 	}
@@ -48,7 +48,7 @@ class PageRedirect extends Frontend
 	{
 		$this->prepare($objPage);
 
-		$url = UrlUtil::makeAbsolute(System::getContainer()->get('contao.insert_tag.parser')->replaceInline($objPage->url), Environment::get('path'));
+		$url = UrlUtil::makeAbsolute(System::getContainer()->get('contao.insert_tag.parser')->replaceInline($objPage->url), Environment::get('path') . '/');
 
 		return new RedirectResponse($url, $this->getRedirectStatusCode($objPage));
 	}

--- a/core-bundle/src/Resources/contao/pages/PageRoot.php
+++ b/core-bundle/src/Resources/contao/pages/PageRoot.php
@@ -91,7 +91,7 @@ class PageRoot extends Frontend
 	 */
 	protected function getRedirectUrl($rootPageId)
 	{
-		return $this->getNextPage($rootPageId)->getFrontendUrl();
+		return $this->getNextPage($rootPageId)->getAbsoluteUrl();
 	}
 }
 


### PR DESCRIPTION
Fixes #6179, replaces #3468

This PR fixes #6179 and also replaces #3468:

* Our `Controller::redirect` method already makes the URLs always absolute.
* I could not find any other instance of creating a `RedirectResponse` where a purely relative URL would be used. <sup>1</sup>

<sup>1</sup> except in some edge cases like `PageLogout` if the mandatory `jumpTo` page does not exist for example.