### PR TITLE
Skip type error when trying to assign DCA label to string

### DIFF
--- a/core-bundle/contao/library/Contao/DcaLoader.php
+++ b/core-bundle/contao/library/Contao/DcaLoader.php
@@ -159,7 +159,7 @@ class DcaLoader extends Controller
 
 			foreach ($GLOBALS['TL_DCA'][$this->strTable]['list'][$key] as $k=>&$v)
 			{
-				if (\is_array($v) && \array_key_exists('label', $v))
+				if (!\is_array($v) || \array_key_exists('label', $v))
 				{
 					continue;
 				}


### PR DESCRIPTION
I got the following error in my unit test setup, because `$v` was a string and not an array.

```
TypeError: Cannot access offset of type string on string
```

This most likely happened because the `DefaultOperationsListener` did not convert a DCA operation into an array (likely `tl_page.list.operations.show`). However, I still think this error should be skipped if it happens for any reason.