### PR TITLE
Replace the token in the storage for preview link authentication

### DIFF
--- a/core-bundle/src/Resources/config/services.yml
+++ b/core-bundle/src/Resources/config/services.yml
@@ -792,6 +792,7 @@ services:
         arguments:
             - '@security.helper'
             - '@security.token_storage'
+            - '@contao.security.token_checker'
             - '@session'
             - '@contao.security.frontend_user_provider'
             - '@?logger'

--- a/core-bundle/src/Resources/config/services.yml
+++ b/core-bundle/src/Resources/config/services.yml
@@ -791,6 +791,7 @@ services:
         public: true
         arguments:
             - '@security.helper'
+            - '@security.token_storage'
             - '@session'
             - '@contao.security.frontend_user_provider'
             - '@?logger'

--- a/core-bundle/src/Security/Authentication/FrontendPreviewAuthenticator.php
+++ b/core-bundle/src/Security/Authentication/FrontendPreviewAuthenticator.php
@@ -84,6 +84,10 @@ class FrontendPreviewAuthenticator
         return true;
     }
 
+    /**
+     * Replaces the current token if the frontend firewall is active.
+     * Otherwise, the token is stored in the session.
+     */
     private function updateToken(FrontendPreviewToken|null $token): void
     {
         if ($this->tokenChecker->isFrontendFirewall()) {

--- a/core-bundle/src/Security/Authentication/FrontendPreviewAuthenticator.php
+++ b/core-bundle/src/Security/Authentication/FrontendPreviewAuthenticator.php
@@ -18,6 +18,7 @@ use Contao\FrontendUser;
 use Contao\StringUtil;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
 use Symfony\Component\Security\Core\Security;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
@@ -25,6 +26,7 @@ use Symfony\Component\Security\Core\User\UserProviderInterface;
 class FrontendPreviewAuthenticator
 {
     private Security $security;
+    private TokenStorageInterface $tokenStorage;
     private SessionInterface $session;
     private UserProviderInterface $userProvider;
     private ?LoggerInterface $logger;
@@ -32,9 +34,10 @@ class FrontendPreviewAuthenticator
     /**
      * @internal
      */
-    public function __construct(Security $security, SessionInterface $session, UserProviderInterface $userProvider, LoggerInterface $logger = null)
+    public function __construct(Security $security, TokenStorageInterface $tokenStorage, SessionInterface $session, UserProviderInterface $userProvider, LoggerInterface $logger = null)
     {
         $this->security = $security;
+        $this->tokenStorage = $tokenStorage;
         $this->session = $session;
         $this->userProvider = $userProvider;
         $this->logger = $logger;
@@ -60,6 +63,10 @@ class FrontendPreviewAuthenticator
         $token = new FrontendPreviewToken(null, $showUnpublished, $previewLinkId);
 
         $this->session->set('_security_contao_frontend', serialize($token));
+
+        if (null !== $previewLinkId) {
+            $this->tokenStorage->setToken($token);
+        }
 
         return true;
     }

--- a/core-bundle/src/Security/Authentication/FrontendPreviewAuthenticator.php
+++ b/core-bundle/src/Security/Authentication/FrontendPreviewAuthenticator.php
@@ -88,7 +88,7 @@ class FrontendPreviewAuthenticator
      * Replaces the current token if the frontend firewall is active.
      * Otherwise, the token is stored in the session.
      */
-    private function updateToken(FrontendPreviewToken|null $token): void
+    private function updateToken(?FrontendPreviewToken $token): void
     {
         if ($this->tokenChecker->isFrontendFirewall()) {
             $this->tokenStorage->setToken($token);

--- a/core-bundle/src/Security/Authentication/FrontendPreviewAuthenticator.php
+++ b/core-bundle/src/Security/Authentication/FrontendPreviewAuthenticator.php
@@ -53,7 +53,7 @@ class FrontendPreviewAuthenticator
 
         $token = new FrontendPreviewToken($user, $showUnpublished);
 
-        $this->session->set('_security_contao_frontend', serialize($token));
+        $this->updateToken($token);
 
         return true;
     }
@@ -62,11 +62,7 @@ class FrontendPreviewAuthenticator
     {
         $token = new FrontendPreviewToken(null, $showUnpublished, $previewLinkId);
 
-        $this->session->set('_security_contao_frontend', serialize($token));
-
-        if (null !== $previewLinkId) {
-            $this->tokenStorage->setToken($token);
-        }
+        $this->updateToken($token);
 
         return true;
     }
@@ -80,9 +76,22 @@ class FrontendPreviewAuthenticator
             return false;
         }
 
-        $this->session->remove('_security_contao_frontend');
+        $this->updateToken(null);
 
         return true;
+    }
+
+    private function updateToken(FrontendPreviewToken|null $token): void
+    {
+        if (null === $token) {
+            $this->session->remove('_security_contao_frontend');
+        } else {
+            $this->session->set('_security_contao_frontend', serialize($token));
+        }
+
+        if ($this->security->getToken() instanceof FrontendPreviewToken) {
+            $this->tokenStorage->setToken($token);
+        }
     }
 
     /**

--- a/core-bundle/src/Security/Authentication/Token/TokenChecker.php
+++ b/core-bundle/src/Security/Authentication/Token/TokenChecker.php
@@ -178,7 +178,7 @@ class TokenChecker
         return $this->tokenStorage->getToken();
     }
 
-    private function getFirewallContext(): string|null
+    private function getFirewallContext(): ?string
     {
         $request = $this->requestStack->getMainRequest();
 

--- a/core-bundle/src/Security/Authentication/Token/TokenChecker.php
+++ b/core-bundle/src/Security/Authentication/Token/TokenChecker.php
@@ -140,6 +140,16 @@ class TokenChecker
         return $token instanceof FrontendPreviewToken && $token->showUnpublished();
     }
 
+    public function isFrontendFirewall(): bool
+    {
+        return self::FRONTEND_FIREWALL === $this->getFirewallContext();
+    }
+
+    public function isBackendFirewall(): bool
+    {
+        return self::BACKEND_FIREWALL === $this->getFirewallContext();
+    }
+
     private function getToken(string $context): ?TokenInterface
     {
         $token = $this->getTokenFromStorage($context);
@@ -161,6 +171,15 @@ class TokenChecker
 
     private function getTokenFromStorage(string $context): ?TokenInterface
     {
+        if ($this->getFirewallContext() !== $context) {
+            return null;
+        }
+
+        return $this->tokenStorage->getToken();
+    }
+
+    private function getFirewallContext(): string|null
+    {
         $request = $this->requestStack->getMainRequest();
 
         if (!$this->firewallMap instanceof FirewallMap || null === $request) {
@@ -169,11 +188,11 @@ class TokenChecker
 
         $config = $this->firewallMap->getFirewallConfig($request);
 
-        if (!$config instanceof FirewallConfig || $config->getContext() !== $context) {
+        if (!$config instanceof FirewallConfig) {
             return null;
         }
 
-        return $this->tokenStorage->getToken();
+        return $config->getContext();
     }
 
     private function getTokenFromSession(string $sessionKey): ?TokenInterface


### PR DESCRIPTION
~~Attempt to~~ fix #6223

This seems to work, ~~but I’m not sure if the `null !== $previewLinkId` is the correct way to distinguish if we want to replace the token or not.~~ ~~I think I got it: `$this->security->getToken() instanceof FrontendPreviewToken` is the check we need here I think. @aschempp WDYT?~~ __Update:__ see https://github.com/contao/contao/pull/6226#issuecomment-1642389214