### PR TITLE
Set the correct type on model ID

### DIFF
--- a/core-bundle/contao/library/Contao/Model.php
+++ b/core-bundle/contao/library/Contao/Model.php
@@ -597,7 +597,7 @@ abstract class Model
 
 			if (static::$strPk == 'id')
 			{
-				$this->id = $stmt->insertId;
+				$this->id = (int) $stmt->insertId;
 			}
 
 			$this->postSave(self::INSERT);


### PR DESCRIPTION
I got a lot of these deprecation warnings when creating a `PageModel` manually and calling `->save()` on it.

> Since contao/core-bundle 5.0: Setting "Contao\PageModel::$id" to type string has been deprecated and will no longer work in Contao 6.0. Use type int instead.