### PR TITLE
Allow array for page parameters

### DIFF
--- a/core-bundle/contao/models/PageModel.php
+++ b/core-bundle/contao/models/PageModel.php
@@ -1071,7 +1071,7 @@ class PageModel extends Model
 	/**
 	 * Generate a front end URL
 	 *
-	 * @param string $strParams An optional string of URL parameters
+	 * @param string|array $strParams An optional array or string of URL parameters
 	 *
 	 * @throws RouteNotFoundException
 	 * @throws ResourceNotFoundException
@@ -1086,9 +1086,18 @@ class PageModel extends Model
 		$objRouter = System::getContainer()->get('router');
 		$referenceType = $this->domain && $objRouter->getContext()->getHost() !== $this->domain ? UrlGeneratorInterface::ABSOLUTE_URL : UrlGeneratorInterface::ABSOLUTE_PATH;
 
+		if (is_array($strParams))
+		{
+			$parameters = array_merge($strParams, array(RouteObjectInterface::CONTENT_OBJECT => $page));
+		}
+		else
+		{
+			$parameters = array(RouteObjectInterface::CONTENT_OBJECT => $page, 'parameters' => $strParams);
+		}
+
 		try
 		{
-			$strUrl = $objRouter->generate(PageRoute::PAGE_BASED_ROUTE_NAME, array(RouteObjectInterface::CONTENT_OBJECT => $page, 'parameters' => $strParams), $referenceType);
+			$strUrl = $objRouter->generate(PageRoute::PAGE_BASED_ROUTE_NAME, $parameters, $referenceType);
 		}
 		catch (RouteNotFoundException $e)
 		{
@@ -1108,7 +1117,7 @@ class PageModel extends Model
 	/**
 	 * Generate an absolute URL depending on the current rewriteURL setting
 	 *
-	 * @param string $strParams An optional string of URL parameters
+	 * @param string|array $strParams An optional array or string of URL parameters
 	 *
 	 * @throws RouteNotFoundException
 	 * @throws ResourceNotFoundException
@@ -1121,9 +1130,18 @@ class PageModel extends Model
 
 		$objRouter = System::getContainer()->get('router');
 
+		if (is_array($strParams))
+		{
+			$parameters = array_merge($strParams, array(RouteObjectInterface::CONTENT_OBJECT => $this));
+		}
+		else
+		{
+			$parameters = array(RouteObjectInterface::CONTENT_OBJECT => $this, 'parameters' => $strParams);
+		}
+
 		try
 		{
-			$strUrl = $objRouter->generate(PageRoute::PAGE_BASED_ROUTE_NAME, array(RouteObjectInterface::CONTENT_OBJECT => $this, 'parameters' => $strParams), UrlGeneratorInterface::ABSOLUTE_URL);
+			$strUrl = $objRouter->generate(PageRoute::PAGE_BASED_ROUTE_NAME, $parameters, UrlGeneratorInterface::ABSOLUTE_URL);
 		}
 		catch (RouteNotFoundException $e)
 		{
@@ -1143,7 +1161,7 @@ class PageModel extends Model
 	/**
 	 * Generate the front end preview URL
 	 *
-	 * @param string $strParams An optional string of URL parameters
+	 * @param string|array $strParams An optional array or string of URL parameters
 	 *
 	 * @throws RouteNotFoundException
 	 * @throws ResourceNotFoundException
@@ -1169,9 +1187,18 @@ class PageModel extends Model
 
 		$objRouter = System::getContainer()->get('router');
 
+		if (is_array($strParams))
+		{
+			$parameters = array_merge($strParams, array(RouteObjectInterface::CONTENT_OBJECT => $this));
+		}
+		else
+		{
+			$parameters = array(RouteObjectInterface::CONTENT_OBJECT => $this, 'parameters' => $strParams);
+		}
+
 		try
 		{
-			$strUrl = $objRouter->generate(PageRoute::PAGE_BASED_ROUTE_NAME, array(RouteObjectInterface::CONTENT_OBJECT => $this, 'parameters' => $strParams), UrlGeneratorInterface::ABSOLUTE_URL);
+			$strUrl = $objRouter->generate(PageRoute::PAGE_BASED_ROUTE_NAME, $parameters, UrlGeneratorInterface::ABSOLUTE_URL);
 		}
 		catch (RouteNotFoundException $e)
 		{

--- a/core-bundle/contao/models/PageModel.php
+++ b/core-bundle/contao/models/PageModel.php
@@ -1086,7 +1086,7 @@ class PageModel extends Model
 		$objRouter = System::getContainer()->get('router');
 		$referenceType = $this->domain && $objRouter->getContext()->getHost() !== $this->domain ? UrlGeneratorInterface::ABSOLUTE_URL : UrlGeneratorInterface::ABSOLUTE_PATH;
 
-		if (is_array($strParams))
+		if (\is_array($strParams))
 		{
 			$parameters = array_merge($strParams, array(RouteObjectInterface::CONTENT_OBJECT => $page));
 		}
@@ -1130,7 +1130,7 @@ class PageModel extends Model
 
 		$objRouter = System::getContainer()->get('router');
 
-		if (is_array($strParams))
+		if (\is_array($strParams))
 		{
 			$parameters = array_merge($strParams, array(RouteObjectInterface::CONTENT_OBJECT => $this));
 		}
@@ -1187,7 +1187,7 @@ class PageModel extends Model
 
 		$objRouter = System::getContainer()->get('router');
 
-		if (is_array($strParams))
+		if (\is_array($strParams))
 		{
 			$parameters = array_merge($strParams, array(RouteObjectInterface::CONTENT_OBJECT => $this));
 		}


### PR DESCRIPTION
While working with a custom page controller again, I realized it's a pita to generate frontend URLs, because on cannot pass custom parameters to the URL generator. By allowing an array instead of just a string, any page type could be generated by the Contao PageModel functions.

PS: not sure we could still make this into 5.2? 🙃 