### PR TITLE
Do not set the unsubscribe header for test newsletters

### DIFF
--- a/newsletter-bundle/src/Resources/contao/classes/Newsletter.php
+++ b/newsletter-bundle/src/Resources/contao/classes/Newsletter.php
@@ -392,7 +392,10 @@ class Newsletter extends Backend
 		$simpleTokenParser = System::getContainer()->get('contao.string.simple_token_parser');
 
 		// Newsletters with an unsubscribe header are less likely to be blocked (see #2174)
-		$objEmail->addHeader('List-Unsubscribe', '<mailto:' . $objNewsletter->sender . '?subject=Unsubscribe%20ID%20' . $arrRecipient['recipient'] . '%20Channel%20' . $objNewsletter->pid . '>');
+		if (isset($arrRecipient['recipient']))
+		{
+			$objEmail->addHeader('List-Unsubscribe', '<mailto:'.$objNewsletter->sender.'?subject=Unsubscribe%20ID%20'.$arrRecipient['recipient'].'%20Channel%20'.$objNewsletter->pid.'>');
+		}
 
 		// Prepare the text content
 		$objEmail->text = $simpleTokenParser->parse($text, $arrRecipient);

--- a/newsletter-bundle/src/Resources/contao/classes/Newsletter.php
+++ b/newsletter-bundle/src/Resources/contao/classes/Newsletter.php
@@ -394,7 +394,7 @@ class Newsletter extends Backend
 		// Newsletters with an unsubscribe header are less likely to be blocked (see #2174)
 		if (isset($arrRecipient['recipient']))
 		{
-			$objEmail->addHeader('List-Unsubscribe', '<mailto:'.$objNewsletter->sender.'?subject=Unsubscribe%20ID%20'.$arrRecipient['recipient'].'%20Channel%20'.$objNewsletter->pid.'>');
+			$objEmail->addHeader('List-Unsubscribe', '<mailto:' . $objNewsletter->sender . '?subject=Unsubscribe%20ID%20' . $arrRecipient['recipient'] . '%20Channel%20' . $objNewsletter->pid . '>');
 		}
 
 		// Prepare the text content


### PR DESCRIPTION
I got a warning in [Sentry](https://www.sentry.io)

```
Warning: Undefined array key "recipient"
```

For test newsletters, the array key is not defined. I think it also does not make sense to set the header at all in this case 😆 