### PR TITLE
Correctly set the project directory when setting up Cypress

### DIFF
--- a/manager-bundle/bin/contao-console
+++ b/manager-bundle/bin/contao-console
@@ -19,17 +19,15 @@ set_time_limit(0);
 @ini_set('zlib.output_compression', '0');
 @ini_set('display_errors', '0');
 
-if (file_exists(__DIR__.'/../autoload.php')) {
-    $projectDir = \dirname(__DIR__, 2);
-} elseif (file_exists(__DIR__.'/../../../autoload.php')) {
-    $projectDir = \dirname(__DIR__, 4);
-} elseif (file_exists(__DIR__.'/../../../../autoload.php')) {
-    $projectDir = \dirname(__DIR__, 5);
-} elseif (false !== ($cwd = getcwd()) && file_exists($cwd.'/vendor/autoload.php')) {
-    $projectDir = $cwd;
-} else {
-    $projectDir = \dirname(__DIR__, 4);
-}
+$cwd = getcwd();
+
+$projectDir = match (true) {
+    false !== $cwd && str_ends_with($cwd, '/tools/cypress/webspace') => $cwd,
+    file_exists(__DIR__.'/../autoload.php') => \dirname(__DIR__, 2),
+    file_exists(__DIR__.'/../../../../autoload.php') => \dirname(__DIR__, 5),
+    false !== $cwd && file_exists($cwd.'/vendor/autoload.php') => $cwd,
+    default => \dirname(__DIR__, 4)
+};
 
 require $projectDir.'/vendor/autoload.php';
 

--- a/tools/cypress/composer.json
+++ b/tools/cypress/composer.json
@@ -1,11 +1,9 @@
 {
     "scripts": {
         "post-install-cmd": [
-            "rm -rf webspace/vendor/contao/manager-bundle",
             "composer update --working-dir=webspace"
         ],
         "post-update-cmd": [
-            "rm -rf webspace/vendor/contao/manager-bundle",
             "composer update --working-dir=webspace"
         ]
     }

--- a/tools/cypress/webspace/composer.json
+++ b/tools/cypress/webspace/composer.json
@@ -15,10 +15,7 @@
     "repositories": [
         {
             "type": "path",
-            "url": "../../../manager-bundle",
-            "options": {
-                "symlink": false
-            }
+            "url": "../../../manager-bundle"
         },
         {
             "type": "path",


### PR DESCRIPTION
This allows us to symlink the manager bundle instead of mirroring it.