### PR TITLE
Handle insert tags in news and event URLs

### DIFF
--- a/calendar-bundle/src/Resources/contao/modules/ModuleEventReader.php
+++ b/calendar-bundle/src/Resources/contao/modules/ModuleEventReader.php
@@ -129,7 +129,15 @@ class ModuleEventReader extends Events
 			case 'external':
 				if ($objEvent->url)
 				{
-					throw new RedirectResponseException($objEvent->url, 301);
+					$url = System::getContainer()->get('contao.insert_tag.parser')->replaceInline($objEvent->url);
+
+					// Make the URL absolute
+					if (!preg_match('@^https?://@i', $url))
+					{
+						$url = Environment::get('base') . ltrim($url, '/');
+					}
+
+					throw new RedirectResponseException($url, 301);
 				}
 
 				throw new InternalServerErrorException('Empty target URL');

--- a/calendar-bundle/src/Resources/contao/modules/ModuleEventReader.php
+++ b/calendar-bundle/src/Resources/contao/modules/ModuleEventReader.php
@@ -14,6 +14,7 @@ use Contao\CoreBundle\Exception\InternalServerErrorException;
 use Contao\CoreBundle\Exception\PageNotFoundException;
 use Contao\CoreBundle\Exception\RedirectResponseException;
 use Contao\CoreBundle\Routing\ResponseContext\HtmlHeadBag\HtmlHeadBag;
+use Contao\CoreBundle\Util\UrlUtil;
 
 /**
  * Front end module "event reader".
@@ -130,12 +131,7 @@ class ModuleEventReader extends Events
 				if ($objEvent->url)
 				{
 					$url = System::getContainer()->get('contao.insert_tag.parser')->replaceInline($objEvent->url);
-
-					// Make the URL absolute
-					if (!preg_match('@^https?://@i', $url))
-					{
-						$url = Environment::get('base') . ltrim($url, '/');
-					}
+					$url = UrlUtil::makeAbsolute($url, Environment::get('base'));
 
 					throw new RedirectResponseException($url, 301);
 				}

--- a/news-bundle/src/Resources/contao/modules/ModuleNewsReader.php
+++ b/news-bundle/src/Resources/contao/modules/ModuleNewsReader.php
@@ -14,6 +14,7 @@ use Contao\CoreBundle\Exception\InternalServerErrorException;
 use Contao\CoreBundle\Exception\PageNotFoundException;
 use Contao\CoreBundle\Exception\RedirectResponseException;
 use Contao\CoreBundle\Routing\ResponseContext\HtmlHeadBag\HtmlHeadBag;
+use Contao\CoreBundle\Util\UrlUtil;
 
 /**
  * Front end module "news reader".
@@ -126,12 +127,7 @@ class ModuleNewsReader extends ModuleNews
 				if ($objArticle->url)
 				{
 					$url = System::getContainer()->get('contao.insert_tag.parser')->replaceInline($objArticle->url);
-
-					// Make the URL absolute
-					if (!preg_match('@^https?://@i', $url))
-					{
-						$url = Environment::get('base') . ltrim($url, '/');
-					}
+					$url = UrlUtil::makeAbsolute($url, Environment::get('base'));
 
 					throw new RedirectResponseException($url, 301);
 				}

--- a/news-bundle/src/Resources/contao/modules/ModuleNewsReader.php
+++ b/news-bundle/src/Resources/contao/modules/ModuleNewsReader.php
@@ -125,7 +125,15 @@ class ModuleNewsReader extends ModuleNews
 			case 'external':
 				if ($objArticle->url)
 				{
-					throw new RedirectResponseException($objArticle->url, 301);
+					$url = System::getContainer()->get('contao.insert_tag.parser')->replaceInline($objArticle->url);
+
+					// Make the URL absolute
+					if (!preg_match('@^https?://@i', $url))
+					{
+						$url = Environment::get('base') . ltrim($url, '/');
+					}
+
+					throw new RedirectResponseException($url, 301);
 				}
 
 				throw new InternalServerErrorException('Empty target URL');


### PR DESCRIPTION
Fixes #6248

- We could additionally check if the URL contains `{{` before replacing insert tags.
- I‘m not sure about the "Make the URL absolute", because an external URL is absolute by definition. Maybe the picker should return `{{news_url::8::absolute}}` instead of `{{news_url::8}}`?

@contao/developers WDYT?