### PR TITLE
Correctly set the link title in the hyperlink controller

### DIFF
--- a/core-bundle/src/Controller/ContentElement/HyperlinkController.php
+++ b/core-bundle/src/Controller/ContentElement/HyperlinkController.php
@@ -40,7 +40,7 @@ class HyperlinkController extends AbstractContentElementController
 
         $linkAttributes = (new HtmlAttributes())
             ->set('href', $href)
-            ->setIfExists('title', $model->linkTitle)
+            ->setIfExists('title', $model->titleText)
             ->setIfExists('data-lightbox', $model->rel)
         ;
 

--- a/core-bundle/tests/Controller/ContentElement/HyperlinkControllerTest.php
+++ b/core-bundle/tests/Controller/ContentElement/HyperlinkControllerTest.php
@@ -50,6 +50,7 @@ class HyperlinkControllerTest extends ContentElementTestCase
             [
                 'type' => 'hyperlink',
                 'url' => 'https://www.php.net/manual/en/function.sprintf.php',
+                'titleText' => 'See the sprintf() documentation',
                 'linkTitle' => 'sprintf() documentation',
                 'target' => true,
                 'embed' => 'See the %s on how to use the %s placeholder.',
@@ -62,7 +63,7 @@ class HyperlinkControllerTest extends ContentElementTestCase
 
         $expectedOutput = <<<'HTML'
             <div class="content-hyperlink">
-                See the <a href="https://www.php.net/manual/en/function.sprintf.php" title="sprintf() documentation" target="_blank" rel="noreferrer noopener">sprintf() documentation</a>
+                See the <a href="https://www.php.net/manual/en/function.sprintf.php" title="See the sprintf() documentation" target="_blank" rel="noreferrer noopener">sprintf() documentation</a>
                 on how to use the %s placeholder.
             </div>
             HTML;


### PR DESCRIPTION
Fixes #6174

@fritzmg @m-vo Do we have the same problem here on line 9?

https://github.com/contao/contao/blob/e41378f173b0e5d47ffe77ae058d305671b2f8b0/core-bundle/contao/templates/_new/content_element/toplink.html.twig#L6-L9