### PR TITLE
Fixed PHP8 warning in PageSelector

### DIFF
--- a/core-bundle/src/Resources/contao/widgets/PageSelector.php
+++ b/core-bundle/src/Resources/contao/widgets/PageSelector.php
@@ -239,7 +239,7 @@ class PageSelector extends Widget
 
 		// Return the tree
 		return '<ul class="tl_listing tree_view picker_selector' . ($this->strClass ? ' ' . $this->strClass : '') . '" id="' . $this->strId . '" data-callback="reloadPagetree" data-inserttag="link_url">
-    <li class="tl_folder_top"><div class="tl_left">' . Image::getHtml($GLOBALS['TL_DCA']['tl_page']['list']['sorting']['icon'] ?: 'pagemounts.svg') . ' ' . $GLOBALS['TL_LANG']['MOD']['page'][0] . '</div> <div class="tl_right">&nbsp;</div><div style="clear:both"></div></li><li class="parent" id="' . $this->strId . '_parent"><ul>' . $tree . $strReset . '
+    <li class="tl_folder_top"><div class="tl_left">' . Image::getHtml($GLOBALS['TL_DCA']['tl_page']['list']['sorting']['icon'] ?: 'pagemounts.svg') . ' ' . ($GLOBALS['TL_LANG']['MOD']['page'][0] ?? '') . '</div> <div class="tl_right">&nbsp;</div><div style="clear:both"></div></li><li class="parent" id="' . $this->strId . '_parent"><ul>' . $tree . $strReset . '
   </ul></li></ul>';
 	}
 


### PR DESCRIPTION
Got that because Isotope still works with the legacy widget in the current version 🙈 