### PR TITLE
Allow to set `field` and `inputName` on DataContainer

### DIFF
--- a/core-bundle/src/Resources/contao/classes/DataContainer.php
+++ b/core-bundle/src/Resources/contao/classes/DataContainer.php
@@ -276,6 +276,14 @@ abstract class DataContainer extends Backend
 				$this->intId = $varValue;
 				break;
 
+			case 'field':
+				$this->strField = $varValue;
+				break;
+
+			case 'inputName':
+				$this->strInputName = $varValue;
+				break;
+
 			default:
 				$this->$strKey = $varValue; // backwards compatibility
 				break;


### PR DESCRIPTION
I got this error in Sentry

> Creation of dynamic property Contao\DC_Table::$inputName is deprecated

The source is our `Ajax.php` which reads and writes the field a lot, e.g. in https://github.com/contao/contao/blob/4.13/core-bundle/src/Resources/contao/classes/Ajax.php#L292

An alternative would be to change `Ajax.php` to write to `$dc->strField` but I don't think that would be better.