### PR TITLE
Clean up the code of the picture insert tag

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/InsertTags.php
+++ b/core-bundle/src/Resources/contao/library/Contao/InsertTags.php
@@ -1076,16 +1076,17 @@ class InsertTags extends Controller
 							$staticUrl = $container->get('contao.assets.files_context')->getStaticUrl();
 							$picture = $container->get('contao.image.picture_factory')->create($container->getParameter('kernel.project_dir') . '/' . $strFile, $size);
 
-							$picture = array
+							$data = array
 							(
 								'img' => $picture->getImg($container->getParameter('kernel.project_dir'), $staticUrl),
-								'sources' => $picture->getSources($container->getParameter('kernel.project_dir'), $staticUrl)
+								'sources' => $picture->getSources($container->getParameter('kernel.project_dir'), $staticUrl),
+								'alt' => StringUtil::specialcharsAttribute($alt),
+								'class' => StringUtil::specialcharsAttribute($class)
 							);
 
-							$picture['alt'] = StringUtil::specialcharsAttribute($alt);
-							$picture['class'] = StringUtil::specialcharsAttribute($class);
 							$pictureTemplate = new FrontendTemplate($strTemplate);
-							$pictureTemplate->setData($picture);
+							$pictureTemplate->setData($data);
+
 							$arrCache[$strTag] = $pictureTemplate->parse();
 						}
 


### PR DESCRIPTION
The code behaves exactly like before, it only does no longer reuse a variable (which makes static analysis more difficult) and it defines the data array in a cleaner way.