### PR TITLE
Generate the file manager preview images with a 1x, 2x source set

### DIFF
--- a/core-bundle/src/Resources/contao/drivers/DC_Folder.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Folder.php
@@ -2826,13 +2826,13 @@ class DC_Folder extends DataContainer implements ListableDataContainerInterface,
 				{
 					try
 					{
-						$thumbnail .= '<br>' . $this->getPreviewImage($currentEncoded);
+						$thumbnail .= '<br>' . $this->getPreviewImage(rawurldecode($currentEncoded));
 
 						$importantPart = System::getContainer()->get('contao.image.factory')->create($this->strRootDir . '/' . rawurldecode($currentEncoded))->getImportantPart();
 
 						if ($importantPart->getX() > 0 || $importantPart->getY() > 0 || $importantPart->getWidth() < 1 || $importantPart->getHeight() < 1)
 						{
-							$thumbnail .= ' ' . $this->getPreviewImage($currentEncoded, true);
+							$thumbnail .= ' ' . $this->getPreviewImage(rawurldecode($currentEncoded), true);
 						}
 					}
 					catch (RuntimeException $e)
@@ -3170,7 +3170,7 @@ class DC_Folder extends DataContainer implements ListableDataContainerInterface,
 
 		$picture = $container
 			->get('contao.image.preview_factory')
-			->createPreviewPicture($this->strRootDir . '/' . rawurldecode($relpath), $pictureSize);
+			->createPreviewPicture($projectDir . '/' . $relpath, $pictureSize);
 
 		$srcset = '';
 		$img = $picture->getImg($projectDir);

--- a/core-bundle/src/Resources/contao/drivers/DC_Folder.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Folder.php
@@ -3172,15 +3172,9 @@ class DC_Folder extends DataContainer implements ListableDataContainerInterface,
 			->get('contao.image.preview_factory')
 			->createPreviewPicture($projectDir . '/' . $relpath, $pictureConfig);
 
-		$srcset = '';
 		$img = $picture->getImg($projectDir);
 
-		if ($img['srcset'] != $img['src'])
-		{
-			$srcset = sprintf(' srcset="%s"', $img['srcset']);
-		}
-
-		return sprintf('<img src="%s"%s width="%s" height="%s" alt class="%s" loading="lazy">', $img['src'], $srcset, $img['width'], $img['height'], $isImportantPath ? 'preview-important' : 'preview_image');
+		return sprintf('<img src="%s"%s width="%s" height="%s" alt class="%s" loading="lazy">', $img['src'], $img['srcset'] != $img['src'] ? ' srcset="' . $img['srcset'] . '"' : '', $img['width'], $img['height'], $isImportantPath ? 'preview-important' : 'preview_image');
 	}
 }
 

--- a/core-bundle/src/Resources/contao/drivers/DC_Folder.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Folder.php
@@ -3174,7 +3174,7 @@ class DC_Folder extends DataContainer implements ListableDataContainerInterface,
 
 		$img = $picture->getImg($projectDir);
 
-		return sprintf('<img src="%s"%s width="%s" height="%s" alt class="%s" loading="lazy">', $img['src'], $img['srcset'] != $img['src'] ? ' srcset="' . $img['srcset'] . '"' : '', $img['width'], $img['height'], $isImportantPath ? 'preview-important' : 'preview_image');
+		return sprintf('<img src="%s"%s width="%s" height="%s" alt class="%s" loading="lazy">', $img['src'], $img['srcset'] != $img['src'] ? ' srcset="' . $img['srcset'] . '"' : '', $img['width'], $img['height'], $isImportantPath ? 'preview-important' : 'preview-image');
 	}
 }
 

--- a/core-bundle/src/Resources/contao/drivers/DC_Folder.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Folder.php
@@ -3155,22 +3155,22 @@ class DC_Folder extends DataContainer implements ListableDataContainerInterface,
 		$container = System::getContainer();
 		$projectDir = $container->getParameter('kernel.project_dir');
 
-		$pictureConfig = (new ResizeConfiguration())
+		$resizeConfig = (new ResizeConfiguration())
 			->setWidth($isImportantPath ? 80 : 100)
 			->setHeight($isImportantPath ? 60 : 75)
 			->setMode(ResizeConfiguration::MODE_BOX)
 			->setZoomLevel($isImportantPath ? 100 : 0);
 
-		$pictureSize = (new PictureConfiguration())
+		$pictureConfig = (new PictureConfiguration())
 			->setSize(
 				(new PictureConfigurationItem())
-					->setResizeConfig($pictureConfig)
+					->setResizeConfig($resizeConfig)
 					->setDensities('1x, 2x')
 			);
 
 		$picture = $container
 			->get('contao.image.preview_factory')
-			->createPreviewPicture($projectDir . '/' . $relpath, $pictureSize);
+			->createPreviewPicture($projectDir . '/' . $relpath, $pictureConfig);
 
 		$srcset = '';
 		$img = $picture->getImg($projectDir);


### PR DESCRIPTION
The file manager preview images were missing a high resolution source for retina displays.