### PR TITLE
Fix warnings when using `Image::get`

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Image.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Image.php
@@ -843,10 +843,10 @@ class Image
 		}
 
 		$imageSize = new \stdClass();
-		$imageSize->width = $predefinedSizes[$size]['width'];
-		$imageSize->height = $predefinedSizes[$size]['height'];
-		$imageSize->resizeMode = $predefinedSizes[$size]['resizeMode'];
-		$imageSize->zoom = $predefinedSizes[$size]['zoom'];
+		$imageSize->width = $predefinedSizes[$size]['width'] ?? 0;
+		$imageSize->height = $predefinedSizes[$size]['height'] ?? 0;
+		$imageSize->resizeMode = $predefinedSizes[$size]['resizeMode'] ?? 'proportional';
+		$imageSize->zoom = $predefinedSizes[$size]['zoom'] ?? 0;
 
 		return $imageSize;
 	}
@@ -889,6 +889,7 @@ class Image
 		catch (\Exception $e)
 		{
 			System::getContainer()->get('monolog.logger.contao.error')->error('Image "' . $image . '" could not be processed: ' . $e->getMessage());
+			throw $e;
 		}
 
 		return null;

--- a/core-bundle/src/Resources/contao/library/Contao/Image.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Image.php
@@ -845,7 +845,7 @@ class Image
 		$imageSize = new \stdClass();
 		$imageSize->width = $predefinedSizes[$size]['width'] ?? 0;
 		$imageSize->height = $predefinedSizes[$size]['height'] ?? 0;
-		$imageSize->resizeMode = $predefinedSizes[$size]['resizeMode'] ?? 'proportional';
+		$imageSize->resizeMode = $predefinedSizes[$size]['resizeMode'] ?? 'crop';
 		$imageSize->zoom = $predefinedSizes[$size]['zoom'] ?? 0;
 
 		return $imageSize;

--- a/core-bundle/src/Resources/contao/library/Contao/Image.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Image.php
@@ -889,7 +889,6 @@ class Image
 		catch (\Exception $e)
 		{
 			System::getContainer()->get('monolog.logger.contao.error')->error('Image "' . $image . '" could not be processed: ' . $e->getMessage());
-			throw $e;
 		}
 
 		return null;


### PR DESCRIPTION
If you use `Image::get` with a predefined image size, the following warning may occur:

```
ErrorException:
Warning: Undefined array key "height"

  at vendor\contao\core-bundle\src\Resources\contao\library\Contao\Image.php:847
  at Contao\Image::getImageSizeConfig('_test')
     (vendor\contao\core-bundle\src\Resources\contao\library\Contao\Image.php:790)
  at Contao\Image::create(object(File), '_test')
     (vendor\contao\core-bundle\src\Resources\contao\library\Contao\Image.php:880)
  at Contao\Image::get('files/content/test.jpg', 0, 0, '_test')
```

This warning is only logged to the system log.

#### Reproduction

```yaml
contao:
    image:
        sizes:
            test:
                width: 100
```
```php
<!-- templates/ce_html_test.html5 -->
<img src="<?= Contao\Image::get('files/content/test.jpg', 0, 0, '_test') ?>">
```