### PR TITLE
Remove another left-over `errorInfo()` call

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Database.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Database.php
@@ -125,13 +125,6 @@ class Database
 	 */
 	public function __get($strKey)
 	{
-		if ($strKey == 'error')
-		{
-			$info = $this->resConnection->errorInfo();
-
-			return 'SQLSTATE ' . $info[0] . ': error ' . $info[1] . ': ' . $info[2];
-		}
-
 		return null;
 	}
 


### PR DESCRIPTION
Follow-up on #6297. Seems I have missed this one. 🙈 