### PR TITLE
Use primary language for slug generation

### DIFF
--- a/core-bundle/src/Resources/contao/models/PageModel.php
+++ b/core-bundle/src/Resources/contao/models/PageModel.php
@@ -1482,7 +1482,8 @@ class PageModel extends Model
 	 */
 	public function getSlugOptions()
 	{
-		$slugOptions = array('locale'=>$this->language);
+		// Use primary language for slug generation, until fixed in ICU or ausi/slug-generator (see #2413)
+		$slugOptions = array('locale'=>LocaleUtil::getPrimaryLanguage($this->language));
 
 		if ($this->validAliasCharacters)
 		{


### PR DESCRIPTION
This is a temporary fix for https://github.com/contao/contao/issues/2413 as discussed with @ausi 

Until this issue is fixed directly in ICU or until the fallback chain is implemented in `ausi/slug-generator` there is likely no benefit in passing the full locale to the generator.
