### PR TITLE
Simplify the "object or null" checks

### DIFF
--- a/calendar-bundle/src/EventListener/InsertTagsListener.php
+++ b/calendar-bundle/src/EventListener/InsertTagsListener.php
@@ -57,7 +57,7 @@ class InsertTagsListener
 
         $adapter = $this->framework->getAdapter(CalendarFeedModel::class);
 
-        if (null === ($feed = $adapter->findByPk($feedId))) {
+        if (!$feed = $adapter->findByPk($feedId)) {
             return '';
         }
 
@@ -70,7 +70,7 @@ class InsertTagsListener
 
         $adapter = $this->framework->getAdapter(CalendarEventsModel::class);
 
-        if (null === ($model = $adapter->findByIdOrAlias($idOrAlias))) {
+        if (!$model = $adapter->findByIdOrAlias($idOrAlias)) {
             return '';
         }
 

--- a/calendar-bundle/src/EventListener/PreviewUrlConvertListener.php
+++ b/calendar-bundle/src/EventListener/PreviewUrlConvertListener.php
@@ -36,7 +36,7 @@ class PreviewUrlConvertListener
             return;
         }
 
-        if (null === ($eventModel = $this->getEventModel($event->getRequest()))) {
+        if (!$eventModel = $this->getEventModel($event->getRequest())) {
             return;
         }
 

--- a/core-bundle/contao/library/Contao/TemplateInheritance.php
+++ b/core-bundle/contao/library/Contao/TemplateInheritance.php
@@ -363,7 +363,7 @@ trait TemplateInheritance
 	{
 		$container = System::getContainer();
 
-		if (null === ($twig = $container->get('twig', ContainerInterface::NULL_ON_INVALID_REFERENCE)))
+		if (!$twig = $container->get('twig', ContainerInterface::NULL_ON_INVALID_REFERENCE))
 		{
 			return null;
 		}

--- a/core-bundle/src/Asset/ContaoContext.php
+++ b/core-bundle/src/Asset/ContaoContext.php
@@ -30,7 +30,7 @@ class ContaoContext implements ContextInterface
 
     public function getBasePath(): string
     {
-        if (null === ($request = $this->requestStack->getCurrentRequest())) {
+        if (!$request = $this->requestStack->getCurrentRequest()) {
             return '';
         }
 

--- a/core-bundle/src/Command/Backup/BackupStreamContentCommand.php
+++ b/core-bundle/src/Command/Backup/BackupStreamContentCommand.php
@@ -39,7 +39,7 @@ class BackupStreamContentCommand extends Command
             return Command::FAILURE;
         }
 
-        if (null === ($backup = $this->backupManager->getBackupByName($input->getArgument('name')))) {
+        if (!$backup = $this->backupManager->getBackupByName($input->getArgument('name'))) {
             $io->error(sprintf('Backup "%s" not found.', $input->getArgument('name')));
 
             return Command::FAILURE;

--- a/core-bundle/src/Controller/BackendPreviewController.php
+++ b/core-bundle/src/Controller/BackendPreviewController.php
@@ -65,7 +65,7 @@ class BackendPreviewController
 
         $this->dispatcher->dispatch($urlConvertEvent, ContaoCoreEvents::PREVIEW_URL_CONVERT);
 
-        if (null !== ($response = $urlConvertEvent->getResponse())) {
+        if ($response = $urlConvertEvent->getResponse()) {
             return $response;
         }
 

--- a/core-bundle/src/Controller/ContentElement/DownloadsController.php
+++ b/core-bundle/src/Controller/ContentElement/DownloadsController.php
@@ -164,7 +164,7 @@ class DownloadsController extends AbstractContentElementController
         $path = $filesystemItem->getPath();
         $inline = $model->inline;
 
-        if (null !== ($publicUri = $this->filesStorage->generatePublicUri($path, new ContentDispositionOption($inline)))) {
+        if ($publicUri = $this->filesStorage->generatePublicUri($path, new ContentDispositionOption($inline))) {
             return (string) $publicUri;
         }
 
@@ -199,7 +199,7 @@ class DownloadsController extends AbstractContentElementController
         $getLightboxSize = function (): string|null {
             $this->initializeContaoFramework();
 
-            if (null === ($page = $this->getPageModel()) || null === $page->layout) {
+            if (!$page = $this->getPageModel() || null === $page->layout) {
                 return null;
             }
 

--- a/core-bundle/src/Controller/ContentElement/DownloadsController.php
+++ b/core-bundle/src/Controller/ContentElement/DownloadsController.php
@@ -199,7 +199,7 @@ class DownloadsController extends AbstractContentElementController
         $getLightboxSize = function (): string|null {
             $this->initializeContaoFramework();
 
-            if (!$page = $this->getPageModel() || null === $page->layout) {
+            if ((!$page = $this->getPageModel()) || null === $page->layout) {
                 return null;
             }
 

--- a/core-bundle/src/Controller/ContentElement/PlayerController.php
+++ b/core-bundle/src/Controller/ContentElement/PlayerController.php
@@ -197,7 +197,7 @@ class PlayerController extends AbstractContentElementController
                 continue;
             }
 
-            if (null === ($publicUri = $this->filesStorage->generatePublicUri($item->getPath()))) {
+            if (!$publicUri = $this->filesStorage->generatePublicUri($item->getPath())) {
                 continue;
             }
 

--- a/core-bundle/src/Controller/ContentElement/TeaserController.php
+++ b/core-bundle/src/Controller/ContentElement/TeaserController.php
@@ -59,7 +59,7 @@ class TeaserController extends AbstractContentElementController
 
         $articleModel = $this->getContaoAdapter(ArticleModel::class);
 
-        if (null === ($article = $articleModel->findPublishedById($model->article))) {
+        if (!$article = $articleModel->findPublishedById($model->article)) {
             return null;
         }
 

--- a/core-bundle/src/Controller/SitemapController.php
+++ b/core-bundle/src/Controller/SitemapController.php
@@ -126,7 +126,7 @@ class SitemapController extends AbstractController
                     $urls = [$pageModel->getAbsoluteUrl()];
 
                     // Get articles with teaser
-                    if (null !== ($articleModels = $articleModelAdapter->findPublishedWithTeaserByPid($pageModel->id, ['ignoreFePreview' => true]))) {
+                    if ($articleModels = $articleModelAdapter->findPublishedWithTeaserByPid($pageModel->id, ['ignoreFePreview' => true])) {
                         foreach ($articleModels as $articleModel) {
                             $urls[] = $pageModel->getAbsoluteUrl('/articles/'.($articleModel->alias ?: $articleModel->id));
                         }

--- a/core-bundle/src/DependencyInjection/Filesystem/FilesystemConfiguration.php
+++ b/core-bundle/src/DependencyInjection/Filesystem/FilesystemConfiguration.php
@@ -85,7 +85,7 @@ class FilesystemConfiguration
         $name ??= str_replace(['.', '/', '-'], '_', Container::underscore($mountPath));
         $adapterId = "contao.filesystem.adapter.$name";
 
-        if (null !== ($adapterDefinition = $this->adapterDefinitionFactory->createDefinition($adapter, $options))) {
+        if ($adapterDefinition = $this->adapterDefinitionFactory->createDefinition($adapter, $options)) {
             // Native adapter
             $this->container
                 ->setDefinition($adapterId, $adapterDefinition)

--- a/core-bundle/src/EventListener/ExceptionConverterListener.php
+++ b/core-bundle/src/EventListener/ExceptionConverterListener.php
@@ -65,7 +65,7 @@ class ExceptionConverterListener
             return;
         }
 
-        if (null !== ($httpException = $this->convertToHttpException($exception, $class))) {
+        if ($httpException = $this->convertToHttpException($exception, $class)) {
             $event->setThrowable($httpException);
         }
     }

--- a/core-bundle/src/EventListener/InsertTags/DateListener.php
+++ b/core-bundle/src/EventListener/InsertTags/DateListener.php
@@ -126,7 +126,7 @@ class DateListener
 
         $key = $dateFormat.'Format';
 
-        if (null !== ($request = $this->requestStack->getCurrentRequest())) {
+        if ($request = $this->requestStack->getCurrentRequest()) {
             $attributes = $request->attributes;
 
             if ($attributes->has('pageModel') && ($page = $attributes->get('pageModel')) instanceof PageModel) {

--- a/core-bundle/src/EventListener/PrettyErrorScreenListener.php
+++ b/core-bundle/src/EventListener/PrettyErrorScreenListener.php
@@ -179,7 +179,7 @@ class PrettyErrorScreenListener
             if ($exception instanceof InvalidRequestTokenException) {
                 $template = 'invalid_request_token';
             }
-        } while (null === $template && null !== ($exception = $exception->getPrevious()));
+        } while (null === $template && ($exception = $exception->getPrevious()));
 
         $this->renderTemplate($template ?: 'error', $statusCode, $event);
     }

--- a/core-bundle/src/Filesystem/Dbafs/DbafsManager.php
+++ b/core-bundle/src/Filesystem/Dbafs/DbafsManager.php
@@ -115,7 +115,7 @@ class DbafsManager
         if (
             null !== ($dbafs = $dbafsIterator->current())
             && $dbafs->getSupportedFeatures() & DbafsInterface::FEATURE_LAST_MODIFIED
-            && null !== ($record = $dbafs->getRecord(Path::makeRelative($path, $dbafsIterator->key())))
+            && ($record = $dbafs->getRecord(Path::makeRelative($path, $dbafsIterator->key())))
         ) {
             return $record->getLastModified();
         }
@@ -134,7 +134,7 @@ class DbafsManager
         if (
             null !== ($dbafs = $dbafsIterator->current())
             && $dbafs->getSupportedFeatures() & DbafsInterface::FEATURE_FILE_SIZE
-            && null !== ($record = $dbafs->getRecord(Path::makeRelative($path, $dbafsIterator->key())))
+            && ($record = $dbafs->getRecord(Path::makeRelative($path, $dbafsIterator->key())))
         ) {
             return $record->getFileSize();
         }
@@ -153,7 +153,7 @@ class DbafsManager
         if (
             null !== ($dbafs = $dbafsIterator->current())
             && $dbafs->getSupportedFeatures() & DbafsInterface::FEATURE_MIME_TYPE
-            && null !== ($record = $dbafs->getRecord(Path::makeRelative($path, $dbafsIterator->key())))
+            && ($record = $dbafs->getRecord(Path::makeRelative($path, $dbafsIterator->key())))
         ) {
             return $record->getMimeType();
         }
@@ -173,7 +173,7 @@ class DbafsManager
         $metadataKeys = [];
 
         foreach ($this->getDbafsForPath($path) as $prefix => $dbafs) {
-            if (null !== ($record = $dbafs->getRecord(Path::makeRelative($path, $prefix)))) {
+            if ($record = $dbafs->getRecord(Path::makeRelative($path, $prefix))) {
                 $chunk = $record->getExtraMetadata();
                 $keys = array_keys($chunk);
 

--- a/core-bundle/src/Filesystem/FileDownloadHelper.php
+++ b/core-bundle/src/Filesystem/FileDownloadHelper.php
@@ -105,7 +105,7 @@ class FileDownloadHelper
             return new Response('The provided file URL is not valid.', Response::HTTP_FORBIDDEN);
         }
 
-        if (null === ($file = $this->getFile($request, $storage))) {
+        if (!$file = $this->getFile($request, $storage)) {
             return new Response('The requested resource does not exist.', Response::HTTP_NOT_FOUND);
         }
 

--- a/core-bundle/src/Filesystem/FilesystemUtil.php
+++ b/core-bundle/src/Filesystem/FilesystemUtil.php
@@ -103,7 +103,7 @@ class FilesystemUtil
             try {
                 $uuidObject = Uuid::isValid($uuid) ? Uuid::fromString($uuid) : Uuid::fromBinary($uuid);
 
-                if (null === ($item = $storage->get($uuidObject))) {
+                if (!$item = $storage->get($uuidObject)) {
                     continue;
                 }
             } catch (\InvalidArgumentException|UnableToResolveUuidException) {

--- a/core-bundle/src/Filesystem/MountManager.php
+++ b/core-bundle/src/Filesystem/MountManager.php
@@ -357,7 +357,7 @@ class MountManager
         [$adapter, $adapterPath] = $this->getAdapterAndPath($path);
 
         foreach ($this->publicUriProviders as $provider) {
-            if (null !== ($uri = $provider->getUri($adapter, $adapterPath, $options))) {
+            if ($uri = $provider->getUri($adapter, $adapterPath, $options)) {
                 return $uri;
             }
         }

--- a/core-bundle/src/Filesystem/PublicUri/SymlinkedLocalFilesProvider.php
+++ b/core-bundle/src/Filesystem/PublicUri/SymlinkedLocalFilesProvider.php
@@ -41,7 +41,7 @@ class SymlinkedLocalFilesProvider implements PublicUriProviderInterface
 
     private function getSchemeAndHost(): string
     {
-        if (null === ($request = $this->requestStack->getCurrentRequest())) {
+        if (!$request = $this->requestStack->getCurrentRequest()) {
             return '';
         }
 

--- a/core-bundle/src/Image/ImageFactory.php
+++ b/core-bundle/src/Image/ImageFactory.php
@@ -198,7 +198,7 @@ class ImageFactory implements ImageFactoryInterface
             if (is_numeric($size[2])) {
                 $imageModel = $this->framework->getAdapter(ImageSizeModel::class);
 
-                if (null !== ($imageSize = $imageModel->findByPk($size[2]))) {
+                if ($imageSize = $imageModel->findByPk($size[2])) {
                     $this->enhanceResizeConfig($config, $imageSize->row());
                     $options->setSkipIfDimensionsMatch((bool) $imageSize->skipIfDimensionsMatch);
 

--- a/core-bundle/src/Image/Studio/FigureRenderer.php
+++ b/core-bundle/src/Image/Studio/FigureRenderer.php
@@ -48,7 +48,7 @@ class FigureRenderer
      */
     public function render(FilesModel|ImageInterface|int|string $from, PictureConfiguration|array|int|string|null $size, array $configuration = [], string $template = '@ContaoCore/Image/Studio/figure.html.twig'): string|null
     {
-        if (null === ($figure = $this->buildFigure($from, $size, $configuration))) {
+        if (!$figure = $this->buildFigure($from, $size, $configuration)) {
             return null;
         }
 

--- a/core-bundle/src/Intl/Countries.php
+++ b/core-bundle/src/Intl/Countries.php
@@ -41,7 +41,7 @@ class Countries
      */
     public function getCountries(string|null $displayLocale = null): array
     {
-        if (null === $displayLocale && null !== ($request = $this->requestStack->getCurrentRequest())) {
+        if (null === $displayLocale && ($request = $this->requestStack->getCurrentRequest())) {
             $displayLocale = $request->getLocale();
         }
 

--- a/core-bundle/src/Intl/Locales.php
+++ b/core-bundle/src/Intl/Locales.php
@@ -65,7 +65,7 @@ class Locales
      */
     public function getLanguages(string|null $displayLocale = null, bool $addNativeSuffix = false): array
     {
-        if (null === $displayLocale && null !== ($request = $this->requestStack->getCurrentRequest())) {
+        if (null === $displayLocale && ($request = $this->requestStack->getCurrentRequest())) {
             $displayLocale = $request->getLocale();
         }
 
@@ -117,7 +117,7 @@ class Locales
      */
     public function getDisplayNames(array $localeIds, string|null $displayLocale = null, bool $addNativeSuffix = false): array
     {
-        if (null === $displayLocale && null !== ($request = $this->requestStack->getCurrentRequest())) {
+        if (null === $displayLocale && ($request = $this->requestStack->getCurrentRequest())) {
             $displayLocale = $request->getLocale();
         }
 

--- a/core-bundle/src/Slug/Slug.php
+++ b/core-bundle/src/Slug/Slug.php
@@ -38,7 +38,7 @@ class Slug
         if (!is_iterable($options)) {
             $pageAdapter = $this->framework->getAdapter(PageModel::class);
 
-            if (null !== ($page = $pageAdapter->findWithDetails((int) $options))) {
+            if ($page = $pageAdapter->findWithDetails((int) $options)) {
                 $options = $page->getSlugOptions();
             } else {
                 $options = [];

--- a/news-bundle/src/EventListener/PreviewUrlConvertListener.php
+++ b/news-bundle/src/EventListener/PreviewUrlConvertListener.php
@@ -36,7 +36,7 @@ class PreviewUrlConvertListener
             return;
         }
 
-        if (null === ($news = $this->getNewsModel($event->getRequest()))) {
+        if (!$news = $this->getNewsModel($event->getRequest())) {
             return;
         }
 


### PR DESCRIPTION
The PR converts all `if (null !== $obj = $this->getObjectOrNull())` to `if ($obj = $this->getObjectOrNull())`. Extracted from #6314.