### PR TITLE
Fix PHP8 warning

### DIFF
--- a/core-bundle/src/Resources/contao/dca/tl_article.php
+++ b/core-bundle/src/Resources/contao/dca/tl_article.php
@@ -643,7 +643,7 @@ class tl_article extends Backend
 				// Find all sections with an article module (see #6094)
 				foreach ($arrModules as $arrModule)
 				{
-					if ($arrModule['mod'] == 0 && $arrModule['enable'])
+					if ($arrModule['mod'] == 0 && !empty($arrModule['enable']))
 					{
 						$arrSections[] = $arrModule['col'];
 					}


### PR DESCRIPTION
Fix PHP8 warning

`$arrModule['mod'] == 0` should we change to type-save check