### PR TITLE
Fix warning if reference page of navigation module gets deleted

### DIFF
--- a/core-bundle/src/Resources/contao/modules/ModuleNavigation.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleNavigation.php
@@ -71,10 +71,8 @@ class ModuleNavigation extends Module
 		$host = null;
 
 		// Overwrite the domain and language if the reference page belongs to a different root page (see #3765)
-		if ($this->defineRoot && $this->rootPage > 0)
+		if ($this->defineRoot && $this->rootPage > 0 && ($objRootPage = PageModel::findWithDetails($this->rootPage)))
 		{
-			$objRootPage = PageModel::findWithDetails($this->rootPage);
-
 			$lang = $objRootPage->rootLanguage;
 			$host = $objRootPage->domain;
 		}

--- a/core-bundle/src/Resources/contao/modules/ModuleQuicknav.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleQuicknav.php
@@ -75,7 +75,7 @@ class ModuleQuicknav extends Module
 			$objRootPage = PageModel::findWithDetails($this->rootPage);
 
 			// Set the domain
-			if ($objRootPage->rootId != $objPage->rootId && $objRootPage->domain && $objRootPage->domain != $objPage->domain)
+			if ($objRootPage && $objRootPage->rootId != $objPage->rootId && $objRootPage->domain && $objRootPage->domain != $objPage->domain)
 			{
 				$host = $objRootPage->domain;
 			}


### PR DESCRIPTION
If you define a reference page in the navigation module - but later on delete that page, the following warning is generated in the debug mode:

```
ErrorException:
Warning: Attempt to read property "rootLanguage" on null

  at vendor\contao\core-bundle\src\Resources\contao\modules\ModuleNavigation.php:78
  at Contao\ModuleNavigation->compile()
     (vendor\contao\core-bundle\src\Resources\contao\modules\Module.php:214)
  at Contao\Module->generate()
     (vendor\contao\core-bundle\src\Resources\contao\modules\ModuleNavigation.php:45)
  at Contao\ModuleNavigation->generate()
```

(in prod the navigation is simply empty).