### PR TITLE
Fix an "access array offset on value of type null" error in the help wizard

### DIFF
--- a/core-bundle/src/Resources/contao/controllers/BackendHelp.php
+++ b/core-bundle/src/Resources/contao/controllers/BackendHelp.php
@@ -101,18 +101,9 @@ class BackendHelp extends Backend
 						$rows[] = array('headspan', $arrData['reference'][$key]);
 					}
 
-					foreach ($option as $id=>$opt)
+					foreach ($option as $opt)
 					{
-						if ($key == 'image_sizes')
-						{
-							// Allow using the ID (e.g. "_video_placeholder") as well as the generated
-							// name (e.g. "video_placeholder (1280x)") as key (see #5239)
-							$rows[] = $arrData['reference'][$opt] ?? $arrData['reference'][$id] ?? array($opt, '');
-						}
-						else
-						{
-							$rows[] = $arrData['reference'][$opt] ?? null;
-						}
+						$rows[] = $arrData['reference'][$opt] ?? array($opt, '');
 					}
 				}
 				elseif (isset($arrData['reference'][$key]))

--- a/core-bundle/src/Resources/contao/controllers/BackendHelp.php
+++ b/core-bundle/src/Resources/contao/controllers/BackendHelp.php
@@ -107,7 +107,7 @@ class BackendHelp extends Backend
 						{
 							// Allow using the ID (e.g. "_video_placeholder") as well as the generated
 							// name (e.g. "video_placeholder (1280x)") as key (see #5239)
-							$rows[] = $arrData['reference'][$opt] ?? $arrData['reference'][$id] ?? [$opt, ''];
+							$rows[] = $arrData['reference'][$opt] ?? $arrData['reference'][$id] ?? array($opt, '');
 						}
 						else
 						{

--- a/core-bundle/src/Resources/contao/controllers/BackendHelp.php
+++ b/core-bundle/src/Resources/contao/controllers/BackendHelp.php
@@ -101,9 +101,18 @@ class BackendHelp extends Backend
 						$rows[] = array('headspan', $arrData['reference'][$key]);
 					}
 
-					foreach ($option as $opt)
+					foreach ($option as $id=>$opt)
 					{
-						$rows[] = $arrData['reference'][$opt] ?? null;
+						if ($key == 'image_sizes')
+						{
+							// Allow using the ID (e.g. "_video_placeholder") as well as the generated
+							// name (e.g. "video_placeholder (1280x)") as key (see #5239)
+							$rows[] = $arrData['reference'][$opt] ?? $arrData['reference'][$id] ?? [$opt, ''];
+						}
+						else
+						{
+							$rows[] = $arrData['reference'][$opt] ?? null;
+						}
 					}
 				}
 				elseif (isset($arrData['reference'][$key]))


### PR DESCRIPTION
Fixes #5239

This fixes the `Trying to access array offset on value of type null` error when there is no translation for a predefined image size and it also allows using the the ID as translation key.

```php
// Using the generated name (status quo)
$GLOBALS['TL_LANG']['MSC']['video_placeholder (1280x)'] = ['Foo', 'Bar'];

// Using the ID of the predefined image size (new)
$GLOBALS['TL_LANG']['MSC']['_video_placeholder'] = ['Foo', 'Bar'];
```

<img width="901" alt="" src="https://github.com/contao/contao/assets/1192057/036038d3-864f-4047-9fe3-b70b115de425">
