### PR TITLE
Fix a PHP8 warning on undefined `$GLOBALS['TL_CSS']`

### DIFF
--- a/core-bundle/src/Resources/contao/classes/BackendTemplate.php
+++ b/core-bundle/src/Resources/contao/classes/BackendTemplate.php
@@ -198,7 +198,7 @@ class BackendTemplate extends Template
 					$css[$k] = $packages->getUrl($v);
 				}
 
-				if (!\is_array($GLOBALS['TL_CSS']))
+				if (!\is_array($GLOBALS['TL_CSS'] ?? null))
 				{
 					$GLOBALS['TL_CSS'] = array();
 				}
@@ -220,7 +220,7 @@ class BackendTemplate extends Template
 					$js[$k] = $packages->getUrl($v);
 				}
 
-				if (!\is_array($GLOBALS['TL_JAVASCRIPT']))
+				if (!\is_array($GLOBALS['TL_JAVASCRIPT'] ?? null))
 				{
 					$GLOBALS['TL_JAVASCRIPT'] = array();
 				}


### PR DESCRIPTION
https://terminal42.sentry.io/share/issue/8089ddcfcc3c44b59b3a22d3bc22482c/