### PR TITLE
Fix legacy route matching for unpublished pages

### DIFF
--- a/core-bundle/src/Routing/Matcher/LegacyMatcher.php
+++ b/core-bundle/src/Routing/Matcher/LegacyMatcher.php
@@ -194,8 +194,8 @@ class LegacyMatcher implements RequestMatcherInterface
     {
         $server = $request->server->all();
 
-        if ($request->getBaseUrl()) {
-            $pathinfo = $request->getBaseUrl().$pathinfo;
+        if ($baseUrl = $request->getBaseUrl()) {
+            $pathinfo = $baseUrl.$pathinfo;
         }
 
         if ($qs = $request->getQueryString()) {

--- a/core-bundle/src/Routing/Matcher/LegacyMatcher.php
+++ b/core-bundle/src/Routing/Matcher/LegacyMatcher.php
@@ -192,19 +192,14 @@ class LegacyMatcher implements RequestMatcherInterface
      */
     private function rebuildRequest(string $pathinfo, Request $request): Request
     {
-        $uri = $pathinfo;
-        $server = [];
+        $server = $request->server->all();
 
         if ($request->getBaseUrl()) {
-            $uri = $request->getBaseUrl().$pathinfo;
-            $server['SCRIPT_FILENAME'] = $request->getBaseUrl();
-            $server['PHP_SELF'] = $request->getBaseUrl();
+            $pathinfo = $request->getBaseUrl().$pathinfo;
         }
 
-        $host = $request->getHttpHost() ?: 'localhost';
-        $scheme = $request->getScheme() ?: 'http';
-        $uri = $scheme.'://'.$host.$uri.'?'.$request->getQueryString();
+        $server['REQUEST_URI'] = $pathinfo;
 
-        return Request::create($uri, $request->getMethod(), [], [], [], $server);
+        return $request->duplicate(null, null, null, null, null, $server);
     }
 }

--- a/core-bundle/src/Routing/Matcher/LegacyMatcher.php
+++ b/core-bundle/src/Routing/Matcher/LegacyMatcher.php
@@ -198,8 +198,8 @@ class LegacyMatcher implements RequestMatcherInterface
             $pathinfo = $request->getBaseUrl().$pathinfo;
         }
 
-        if ($request->getQueryString()) {
-            $pathinfo .= '?'.$request->getQueryString();
+        if ($qs = $request->getQueryString()) {
+            $pathinfo .= '?'.$qs;
         }
 
         $server['REQUEST_URI'] = $pathinfo;

--- a/core-bundle/src/Routing/Matcher/LegacyMatcher.php
+++ b/core-bundle/src/Routing/Matcher/LegacyMatcher.php
@@ -198,6 +198,10 @@ class LegacyMatcher implements RequestMatcherInterface
             $pathinfo = $request->getBaseUrl().$pathinfo;
         }
 
+        if ($request->getQueryString()) {
+            $pathinfo .= '?'.$request->getQueryString();
+        }
+
         $server['REQUEST_URI'] = $pathinfo;
 
         return $request->duplicate(null, null, null, null, null, $server);


### PR DESCRIPTION
### Description

In https://github.com/contao/contao/pull/6332 we introduced a fix so that unpublished pages can always be accessed via `preview.php` - rather than checking for `isPreviewMode` (which requires you to enable to show unpublished elements beforehand). However this leads to a regression where unpublished pages cannot be accessed at all anymore under certain circumstances (even with "show unpublished" enabled).

### Reproduction

1. Create a `regular` page with the alias `page` and publish it.
2. Create another `regular` page with the alias `page/subpage`, but do _not_ publish it.
3. Register a dummy `getPageIdFromUrl` hook:
  ```php
  // src/EventListener/GetPageIdFromUrlListener.php
  namespace App\EventListener;
  
  use Contao\CoreBundle\DependencyInjection\Attribute\AsHook;
  
  #[AsHook('getPageIdFromUrl')]
  class GetPageIdFromUrlListener
  {
      public function __invoke(array $fragments): array
      {
          return $fragments;
      }
  }
  ```
4. Click the preview icon in the site structure for the unpublished sub page. This will show the 404 page.
5. Set "Unpublished" to "show" and "Apply" in the Contao toolbar. This will still show the 404 page.

### Cause

Since #6332 we are now checking for the `_preview` request attribute which is set via the preview entry point. However, when legacy routing is not disabled _and_ there is a `getPageIdFromUrl` hook present, the `LegacyMatcher` will be executed. Within the `LegacyMatcher` we dynamically alter the request path in case a `getPageIdFromUrl` hook altered the path fragments:

https://github.com/contao/contao/blob/93d3e39c08716429dec4f92ee624e42b3d95fb46/core-bundle/src/Routing/Matcher/LegacyMatcher.php#L85-L88

https://github.com/contao/contao/blob/93d3e39c08716429dec4f92ee624e42b3d95fb46/core-bundle/src/Routing/Matcher/LegacyMatcher.php#L193-L209

During this process all the attributes of the request get lost and thus are not available anymore in the `PublishedFilter`.

### Proposed Fix

This PR fixes this by instead cloning the original request completely - while only altering the request path. Thus everything from the original request is retained - including the request attributes.
