### PR TITLE
Deprecate the `System::setCookie()` method

### DIFF
--- a/core-bundle/contao/library/Contao/System.php
+++ b/core-bundle/contao/library/Contao/System.php
@@ -592,9 +592,10 @@ abstract class System
 		// HOOK: allow adding custom logic
 		if (isset($GLOBALS['TL_HOOKS']['setCookie']) && \is_array($GLOBALS['TL_HOOKS']['setCookie']))
 		{
+			trigger_deprecation('contao/core-bundle', '5.3', 'Using the "setCookie" hook has been deprecated and will no longer work in Contao 6. Use kernel.response events instead.');
+
 			foreach ($GLOBALS['TL_HOOKS']['setCookie'] as $callback)
 			{
-				trigger_deprecation('contao/core-bundle', '5.3', 'Using the "setCookie" hook has been deprecated and will no longer work in Contao 6. Use kernel.response events instead.');
 				$objCookie = static::importStatic($callback[0])->{$callback[1]}($objCookie);
 			}
 		}

--- a/core-bundle/contao/library/Contao/System.php
+++ b/core-bundle/contao/library/Contao/System.php
@@ -562,6 +562,8 @@ abstract class System
 	 */
 	public static function setCookie($strName, $varValue, $intExpires, $strPath=null, $strDomain=null, $blnSecure=null, $blnHttpOnly=false)
 	{
+		trigger_deprecation('contao/core-bundle', '5.3', 'Using "Contao\System::setCookie()" has been deprecated and will no longer work in Contao 6. Use Symfony\'s HttpFoundation and kernel.response events instead.');
+
 		if (!$strPath)
 		{
 			$strPath = Environment::get('path') ?: '/'; // see #4390
@@ -592,6 +594,7 @@ abstract class System
 		{
 			foreach ($GLOBALS['TL_HOOKS']['setCookie'] as $callback)
 			{
+				trigger_deprecation('contao/core-bundle', '5.3', 'Using the "setCookie" hook has been deprecated and will no longer work in Contao 6. Use kernel.response events instead.');
 				$objCookie = static::importStatic($callback[0])->{$callback[1]}($objCookie);
 			}
 		}


### PR DESCRIPTION
Saw this by chance and was puzzled that this still exists :) 