### PR TITLE
Do not allow route parameters for redirect pages

### DIFF
--- a/core-bundle/src/Routing/Page/PageRegistry.php
+++ b/core-bundle/src/Routing/Page/PageRegistry.php
@@ -64,9 +64,13 @@ class PageRegistry
             $path = '';
             $options['compiler_class'] = UnroutablePageRouteCompiler::class;
         } elseif (null === $path) {
-            $path = '/'.($pageModel->alias ?: $pageModel->id).'{!parameters}';
-            $defaults['parameters'] = '';
-            $requirements['parameters'] = $pageModel->requireItem ? '/.+?' : '(/.+?)?';
+            if ('redirect' === $pageModel->type) {
+                $path = '/'.($pageModel->alias ?: $pageModel->id);
+            } else {
+                $path = '/'.($pageModel->alias ?: $pageModel->id).'{!parameters}';
+                $defaults['parameters'] = '';
+                $requirements['parameters'] = $pageModel->requireItem ? '/.+?' : '(/.+?)?';
+            }
         }
 
         $route = new PageRoute($pageModel, $path, $defaults, $requirements, $options, $config->getMethods());

--- a/core-bundle/tests/Routing/Page/PageRegistryTest.php
+++ b/core-bundle/tests/Routing/Page/PageRegistryTest.php
@@ -70,7 +70,7 @@ class PageRegistryTest extends TestCase
             'alias' => 'bar',
             'urlPrefix' => 'foo',
             'urlSuffix' => '.baz',
-            'requireItem' => '1',
+            'requireItem' => '',
             'language' => 'en',
             'rootLanguage' => 'en',
         ]);

--- a/core-bundle/tests/Routing/Page/PageRegistryTest.php
+++ b/core-bundle/tests/Routing/Page/PageRegistryTest.php
@@ -63,6 +63,25 @@ class PageRegistryTest extends TestCase
         $this->assertSame('/.+?', $route->getRequirement('parameters'));
     }
 
+    public function testReturnsUnparameteredPageRouteForRedirectPages(): void
+    {
+        $pageModel = $this->mockClassWithProperties(PageModel::class, [
+            'type' => 'redirect',
+            'alias' => 'bar',
+            'urlPrefix' => 'foo',
+            'urlSuffix' => '.baz',
+            'requireItem' => '1',
+            'language' => 'en',
+            'rootLanguage' => 'en',
+        ]);
+
+        $registry = new PageRegistry($this->createMock(Connection::class));
+        $route = $registry->getRoute($pageModel);
+
+        $this->assertSame('/foo/bar.baz', $route->getPath());
+        $this->assertNull($route->getDefault('parameters'));
+    }
+
     /**
      * @dataProvider pageRouteWithPathProvider
      */


### PR DESCRIPTION
Fixes #488 for (external) redirect pages.
