### PR TITLE
Generate the file tree preview images with a 1x, 2x source set

### DIFF
--- a/core-bundle/src/Resources/contao/widgets/FileTree.php
+++ b/core-bundle/src/Resources/contao/widgets/FileTree.php
@@ -12,6 +12,8 @@ namespace Contao;
 
 use Contao\CoreBundle\Image\Preview\MissingPreviewProviderException;
 use Contao\CoreBundle\Image\Preview\UnableToGeneratePreviewException;
+use Contao\Image\PictureConfiguration;
+use Contao\Image\PictureConfigurationItem;
 use Contao\Image\ResizeConfiguration;
 
 /**
@@ -463,28 +465,31 @@ class FileTree extends Widget
 
 		if ($objFile->viewWidth && $objFile->viewHeight && ($objFile->isSvgImage || ($objFile->height <= Config::get('gdMaxImgHeight') && $objFile->width <= Config::get('gdMaxImgWidth'))))
 		{
-			// Inline the image if no preview image will be generated (see #636)
-			if ($objFile->height !== null && $objFile->height <= 75 && $objFile->width !== null && $objFile->width <= 100)
-			{
-				$image = $objFile->dataUri;
-			}
-			else
-			{
-				$projectDir = System::getContainer()->getParameter('kernel.project_dir');
-				$image = System::getContainer()->get('contao.image.factory')->create($projectDir . '/' . $objFile->path, array(100, 75, ResizeConfiguration::MODE_BOX))->getUrl($projectDir);
-			}
-		}
-		else
-		{
-			$image = Image::getPath('placeholder.svg');
+			$container = System::getContainer();
+			$projectDir = $container->getParameter('kernel.project_dir');
+
+			$resizeConfig = (new ResizeConfiguration())
+				->setWidth(100)
+				->setHeight(75)
+				->setMode(ResizeConfiguration::MODE_BOX);
+
+			$pictureConfig = (new PictureConfiguration())
+				->setSize(
+					(new PictureConfigurationItem())
+						->setResizeConfig($resizeConfig)
+						->setDensities('1x, 2x')
+				);
+
+			$picture = $container
+				->get('contao.image.preview_factory')
+				->createPreviewPicture($projectDir . '/' . $objFile->path, $pictureConfig);
+
+			$img = $picture->getImg($projectDir);
+
+			return sprintf('<img src="%s"%s width="%s" height="%s" alt class="%s" title="%s" loading="lazy">', $img['src'], $img['srcset'] != $img['src'] ? ' srcset="' . $img['srcset'] . '"' : '', $img['width'], $img['height'], $strClass, StringUtil::specialchars($strInfo));
 		}
 
-		if (strncmp($image, 'data:', 5) === 0)
-		{
-			return '<img src="' . $objFile->dataUri . '" width="' . $objFile->width . '" height="' . $objFile->height . '" alt="" class="' . $strClass . '" title="' . StringUtil::specialchars($strInfo) . '">';
-		}
-
-		return Image::getHtml($image, '', 'class="' . $strClass . '" title="' . StringUtil::specialchars($strInfo) . '"');
+		return Image::getHtml('placeholder.svg', '', 'class="' . $strClass . '" title="' . StringUtil::specialchars($strInfo) . '"');
 	}
 
 	private function getFilePreviewPath(string $path): ?string


### PR DESCRIPTION
This is the same as #6302 for the file tree. I missed that in the original pull request.