### PR TITLE
Remove the BC layers in the `ContaoCache` class

### DIFF
--- a/manager-bundle/src/HttpKernel/ContaoCache.php
+++ b/manager-bundle/src/HttpKernel/ContaoCache.php
@@ -61,12 +61,7 @@ class ContaoCache extends HttpCache implements CacheInvalidation
         $options['trace_level'] = $_SERVER['TRACE_LEVEL'] ?? 'short';
         $options['trace_header'] = 'Contao-Cache';
 
-        /**
-         * symfony/http-kernel ^6.2 still executes terminate by default, which is deprecated however.
-         * It will default to false in Symfony 7.
-         *
-         * @todo Remove once symfony/http-kernel is required in at least ^7.0
-         */
+        // TODO: Remove once symfony/http-kernel is required in at least ^7.0
         $options['terminate_on_cache_hit'] = false;
 
         return $options;

--- a/manager-bundle/src/HttpKernel/ContaoCache.php
+++ b/manager-bundle/src/HttpKernel/ContaoCache.php
@@ -60,6 +60,13 @@ class ContaoCache extends HttpCache implements CacheInvalidation
 
         $options['trace_level'] = $_SERVER['TRACE_LEVEL'] ?? 'short';
         $options['trace_header'] = 'Contao-Cache';
+
+        /**
+         * symfony/http-kernel ^6.2 still executes terminate by default, which is deprecated however.
+         * It will be default to false in Symfony 7.
+         * 
+         * @todo Remove once symfony/http-kernel is required in at least ^7.0
+         */
         $options['terminate_on_cache_hit'] = false;
 
         return $options;

--- a/manager-bundle/src/HttpKernel/ContaoCache.php
+++ b/manager-bundle/src/HttpKernel/ContaoCache.php
@@ -24,6 +24,8 @@ use Symfony\Bundle\FrameworkBundle\HttpCache\HttpCache;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\Cache\Adapter\TagAwareAdapter;
 use Symfony\Component\Filesystem\Path;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Toflar\Psr6HttpCacheStore\Psr6Store;
 
 class ContaoCache extends HttpCache implements CacheInvalidation
@@ -45,6 +47,11 @@ class ContaoCache extends HttpCache implements CacheInvalidation
         $this->addSubscriber(new PurgeListener());
         $this->addSubscriber(new PurgeTagsListener());
         $this->addSubscriber(new CleanupCacheTagsListener());
+    }
+
+    public function fetch(Request $request, $catch = false): Response
+    {
+        return parent::fetch($request, $catch);
     }
 
     protected function getOptions(): array

--- a/manager-bundle/src/HttpKernel/ContaoCache.php
+++ b/manager-bundle/src/HttpKernel/ContaoCache.php
@@ -63,7 +63,7 @@ class ContaoCache extends HttpCache implements CacheInvalidation
 
         /**
          * symfony/http-kernel ^6.2 still executes terminate by default, which is deprecated however.
-         * It will be default to false in Symfony 7.
+         * It will default to false in Symfony 7.
          * 
          * @todo Remove once symfony/http-kernel is required in at least ^7.0
          */

--- a/manager-bundle/src/HttpKernel/ContaoCache.php
+++ b/manager-bundle/src/HttpKernel/ContaoCache.php
@@ -64,7 +64,7 @@ class ContaoCache extends HttpCache implements CacheInvalidation
         /**
          * symfony/http-kernel ^6.2 still executes terminate by default, which is deprecated however.
          * It will default to false in Symfony 7.
-         * 
+         *
          * @todo Remove once symfony/http-kernel is required in at least ^7.0
          */
         $options['terminate_on_cache_hit'] = false;

--- a/manager-bundle/src/HttpKernel/ContaoCache.php
+++ b/manager-bundle/src/HttpKernel/ContaoCache.php
@@ -23,11 +23,7 @@ use FOS\HttpCache\TagHeaderFormatter\TagHeaderFormatter;
 use Symfony\Bundle\FrameworkBundle\HttpCache\HttpCache;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\Cache\Adapter\TagAwareAdapter;
-use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Filesystem\Path;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\TerminableInterface;
 use Toflar\Psr6HttpCacheStore\Psr6Store;
 
 class ContaoCache extends HttpCache implements CacheInvalidation
@@ -51,48 +47,13 @@ class ContaoCache extends HttpCache implements CacheInvalidation
         $this->addSubscriber(new CleanupCacheTagsListener());
     }
 
-    /**
-     * Overwrites the getEventDispatcher() method of the EventDispatchingHttpCache
-     * trait, so the LegacyEventDispatcherProxy is not used. Once we have upgraded
-     * to Symfony 6, the method can be removed again.
-     */
-    public function getEventDispatcher(): EventDispatcher
-    {
-        return $this->eventDispatcher ??= new EventDispatcher();
-    }
-
-    public function fetch(Request $request, $catch = false): Response
-    {
-        return parent::fetch($request, $catch);
-    }
-
-    /**
-     * Override default terminate method in order to never call the
-     * "kernel.terminate" event on cache hit.
-     *
-     * @todo Remove once symfony/http-kernel is required in at least ^6.2
-     */
-    public function terminate(Request $request, Response $response): void
-    {
-        $traces = $this->getTraces();
-
-        if (\in_array('fresh', $traces[$this->getTraceKey($request)] ?? [], true)) {
-            return;
-        }
-
-        $kernel = $this->getKernel();
-
-        if ($kernel instanceof TerminableInterface) {
-            $kernel->terminate($request, $response);
-        }
-    }
-
     protected function getOptions(): array
     {
         $options = parent::getOptions();
 
         $options['trace_level'] = $_SERVER['TRACE_LEVEL'] ?? 'short';
         $options['trace_header'] = 'Contao-Cache';
+        $options['terminate_on_cache_hit'] = false;
 
         return $options;
     }
@@ -112,21 +73,5 @@ class ContaoCache extends HttpCache implements CacheInvalidation
     private function readEnvCsv(string $key): array
     {
         return array_filter(explode(',', (string) ($_SERVER[$key] ?? '')));
-    }
-
-    /**
-     * Unfortunately, we need to copy this from the parent as it is private.
-     *
-     * @todo Remove once symfony/http-kernel is required in at least ^6.2
-     */
-    private function getTraceKey(Request $request): string
-    {
-        $path = $request->getPathInfo();
-
-        if ($qs = $request->getQueryString()) {
-            $path .= '?'.$qs;
-        }
-
-        return $request->getMethod().' '.$path;
     }
 }


### PR DESCRIPTION
Now that we are requiring at least `symfony/http-kernel: ^6.3` we can remove some adjustments in our `ContaoCache` kernel.
