### PR TITLE
Increase the `UnwrapTwigExceptionListener` priority

### DIFF
--- a/core-bundle/config/listener.yaml
+++ b/core-bundle/config/listener.yaml
@@ -595,7 +595,9 @@ services:
         class: Contao\CoreBundle\EventListener\UnwrapTwigExceptionListener
         tags:
             # The priority must be higher than the exception converter listener (defaults to 96)
-            - { name: kernel.event_listener, priority: 128 }
+            # For better integration with the popular error tracking sentry.io we use 256 as their own error listener
+            # defaults to 128
+            - { name: kernel.event_listener, priority: 256 }
 
     contao.listener.widget.custom_rgxp:
         class: Contao\CoreBundle\EventListener\Widget\CustomRgxpListener

--- a/core-bundle/config/listener.yaml
+++ b/core-bundle/config/listener.yaml
@@ -594,9 +594,8 @@ services:
     contao.listener.unwrap_twig_exception:
         class: Contao\CoreBundle\EventListener\UnwrapTwigExceptionListener
         tags:
-            # The priority must be higher than the exception converter listener (defaults to 96)
-            # For better integration with the popular error tracking sentry.io we use 256 as their own error listener
-            # defaults to 128
+            # The priority must be higher than the Symfony exception converter listener (defaults to 96)
+            # and higher than the Sentry error listener (defaults to 128)
             - { name: kernel.event_listener, priority: 256 }
 
     contao.listener.widget.custom_rgxp:


### PR DESCRIPTION
I think Sentry is big enough to qualify for a higher priority here. In order to not have the Contao `Contao\CoreBundle\Exception\ResponseException` reported, you would add this to the configured `ignore_exceptions`.

However, because they default their listener to priority 128 (see https://github.com/getsentry/sentry-symfony/blob/master/src/Resources/config/services.xml#L41), you will have `Twig\Error\RuntimeError` exceptions reported even though those are not really exceptions but also `ResponseException`s.

So for better integration, we should unwrap those errors before Sentry checks them 😊 