### PR TITLE
Do not add default operations when loading a non-existent DCA

### DIFF
--- a/core-bundle/src/EventListener/DataContainer/DefaultOperationsListener.php
+++ b/core-bundle/src/EventListener/DataContainer/DefaultOperationsListener.php
@@ -36,6 +36,11 @@ class DefaultOperationsListener
 
     public function __invoke(string $table): void
     {
+        // Do not add default operations if a DCA was "loaded" that does not exist
+        if (!isset($GLOBALS['TL_DCA'][$table])) {
+            return;
+        }
+
         $GLOBALS['TL_DCA'][$table]['list']['operations'] = $this->getForTable($table);
     }
 


### PR DESCRIPTION
If one calls `Controller::loadDataContainer('tl_foobar')`, it currently adds buttons to the DCA even though no files exists and have been loaded for that name.