### PR TITLE
Correctly tag cached responses with forms

### DIFF
--- a/core-bundle/src/Resources/contao/classes/Hybrid.php
+++ b/core-bundle/src/Resources/contao/classes/Hybrid.php
@@ -250,6 +250,12 @@ abstract class Hybrid extends Frontend
 			$this->Template->class .= ' ' . implode(' ', $this->objParent->classes);
 		}
 
+		// Tag the hybrid
+		if ($this->objModel !== null)
+		{
+			System::getContainer()->get('contao.cache.entity_tags')->tagWithModelInstance($this->objModel);
+		}
+
 		return $this->Template->parse();
 	}
 

--- a/core-bundle/src/Resources/contao/forms/Form.php
+++ b/core-bundle/src/Resources/contao/forms/Form.php
@@ -129,6 +129,8 @@ class Form extends Hybrid
 					$arrFields[] = $objFields->current();
 				}
 			}
+
+			System::getContainer()->get('contao.cache.entity_tags')->tagWith($objFields);
 		}
 
 		// HOOK: compile form fields


### PR DESCRIPTION
Pages are currently not cleared in the cache when form fields are changed.