### PR TITLE
Deprecate the `MergeHttpHeadersListener` class

### DIFF
--- a/core-bundle/src/EventListener/MergeHttpHeadersListener.php
+++ b/core-bundle/src/EventListener/MergeHttpHeadersListener.php
@@ -97,7 +97,13 @@ class MergeHttpHeadersListener implements ResetInterface
      */
     private function fetchHttpHeaders(): void
     {
-        $this->headers = [...$this->headers, ...$this->headerStorage->all()];
+        $headers = $this->headerStorage->all();
+
+        if ([] !== $headers) {
+            trigger_deprecation('contao/core-bundle', '5.3', 'Using the PHP header() function to set HTTP headers has been deprecated and will no longer work in Contao 6. Use the response object instead.');
+        }
+
+        $this->headers = [...$this->headers, ...$headers];
         $this->headerStorage->clear();
     }
 

--- a/core-bundle/src/HttpKernel/Header/HeaderStorageInterface.php
+++ b/core-bundle/src/HttpKernel/Header/HeaderStorageInterface.php
@@ -12,6 +12,9 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\HttpKernel\Header;
 
+/**
+ * @internal
+ */
 interface HeaderStorageInterface
 {
     /**

--- a/core-bundle/src/HttpKernel/Header/MemoryHeaderStorage.php
+++ b/core-bundle/src/HttpKernel/Header/MemoryHeaderStorage.php
@@ -14,6 +14,8 @@ namespace Contao\CoreBundle\HttpKernel\Header;
 
 /**
  * Handles HTTP headers in memory (for unit tests).
+ *
+ * @internal
  */
 class MemoryHeaderStorage implements HeaderStorageInterface
 {

--- a/core-bundle/src/HttpKernel/Header/NativeHeaderStorage.php
+++ b/core-bundle/src/HttpKernel/Header/NativeHeaderStorage.php
@@ -14,6 +14,8 @@ namespace Contao\CoreBundle\HttpKernel\Header;
 
 /**
  * Handles HTTP headers in PHP's native methods.
+ *
+ * @internal
  */
 class NativeHeaderStorage implements HeaderStorageInterface
 {


### PR DESCRIPTION
It seems we forgot to remove this in Contao 5.