### PR TITLE
Make sure valid URLs start with a slash

### DIFF
--- a/core-bundle/src/Routing/Route404Provider.php
+++ b/core-bundle/src/Routing/Route404Provider.php
@@ -193,7 +193,9 @@ class Route404Provider extends AbstractPageRouteProvider
 
     private function getLocaleFallbackRoutes(Request $request): array
     {
-        if ('/' === $request->getPathInfo()) {
+        $pathInfo = $request->getPathInfo();
+
+        if ('/' === $pathInfo || !str_starts_with($pathInfo, '/')) {
             return [];
         }
 

--- a/core-bundle/src/Routing/RouteProvider.php
+++ b/core-bundle/src/Routing/RouteProvider.php
@@ -47,8 +47,8 @@ class RouteProvider extends AbstractPageRouteProvider
 
         $pathInfo = rawurldecode($request->getPathInfo());
 
-        // The request string must not contain "auto_item" (see #4012)
-        if (false !== strpos($pathInfo, '/auto_item/')) {
+        // The request string must start with "/" not contain "auto_item" (see #4012)
+        if (!str_starts_with($pathInfo, '/') || false !== strpos($pathInfo, '/auto_item/')) {
             return new RouteCollection();
         }
 

--- a/core-bundle/src/Routing/RouteProvider.php
+++ b/core-bundle/src/Routing/RouteProvider.php
@@ -47,7 +47,7 @@ class RouteProvider extends AbstractPageRouteProvider
 
         $pathInfo = rawurldecode($request->getPathInfo());
 
-        // The request string must start with "/" not contain "auto_item" (see #4012)
+        // The request string must start with "/" and must not contain "auto_item" (see #4012)
         if (!str_starts_with($pathInfo, '/') || false !== strpos($pathInfo, '/auto_item/')) {
             return new RouteCollection();
         }


### PR DESCRIPTION
I've had a strange error in my logs, where someone called `www.example.com/index.php~` which was routed in Contao. Symfony then strips `index.php` as entry point script, and the remaining route is `~`. This generates issues (e.g. in `AbstractCandidates`) because we assume a route always starts with slash.

After this change, we'll simply show the 404 page for such URls.

(similar to https://github.com/contao/contao/pull/4631)