### PR TITLE
Support themes from ZIP files

### DIFF
--- a/core-bundle/src/Resources/contao/classes/Theme.php
+++ b/core-bundle/src/Resources/contao/classes/Theme.php
@@ -68,8 +68,8 @@ class Theme extends Backend
 
 					$objFile = new File($strFile);
 
-					// Skip anything but .cto files
-					if ($objFile->extension != 'cto')
+					// Skip anything but .cto and .zip files
+					if ($objFile->extension != 'cto' && $objFile->extension != 'zip')
 					{
 						Message::addError(sprintf($GLOBALS['TL_LANG']['ERR']['filetype'], $objFile->extension));
 						continue;
@@ -178,7 +178,7 @@ class Theme extends Backend
   <h4>' . $GLOBALS['TL_LANG']['tl_theme']['tables_fields'] . '</h4>';
 
 			// Find the XML file
-			$objArchive = new ZipReader($strFile);
+			$objArchive = new ZipReader($strFile, true);
 
 			// Continue if there is no XML file
 			if ($objArchive->getFile('theme.xml') === false)
@@ -310,7 +310,7 @@ class Theme extends Backend
 			$xml = null;
 
 			// Open the archive
-			$objArchive = new ZipReader($strZipFile);
+			$objArchive = new ZipReader($strZipFile, true);
 
 			// Extract all files
 			while ($objArchive->next())
@@ -327,7 +327,6 @@ class Theme extends Backend
 				// Limit file operations to files and the templates directory
 				if (strncmp($objArchive->file_name, 'files/', 6) !== 0 && strncmp($objArchive->file_name, 'tl_files/', 9) !== 0 && strncmp($objArchive->file_name, 'templates/', 10) !== 0)
 				{
-					Message::addError(sprintf($GLOBALS['TL_LANG']['ERR']['invalidFile'], $objArchive->file_name));
 					continue;
 				}
 

--- a/core-bundle/src/Resources/contao/library/Contao/ZipReader.php
+++ b/core-bundle/src/Resources/contao/library/Contao/ZipReader.php
@@ -546,9 +546,11 @@ class ZipReader
 				}
 			}
 
+			$offset = strlen($strRoot);
+
 			foreach ($this->arrFiles as &$file)
 			{
-				$file['file_name'] = substr($file['file_name'], strlen($strRoot));
+				$file['file_name'] = substr($file['file_name'], $offset);
 			}
 		}
 	}

--- a/core-bundle/src/Resources/contao/library/Contao/ZipReader.php
+++ b/core-bundle/src/Resources/contao/library/Contao/ZipReader.php
@@ -119,7 +119,7 @@ class ZipReader
 	 *
 	 * @throws \Exception If $strFile does not exist or cannot be opened
 	 */
-	public function __construct($strFile)
+	public function __construct($strFile, $blnSkipRootFolder = false)
 	{
 		// Handle open_basedir restrictions
 		if ($strFile == '.')
@@ -144,7 +144,7 @@ class ZipReader
 			throw new \Exception("Could not open file $strFile");
 		}
 
-		$this->readCentralDirectory();
+		$this->readCentralDirectory($blnSkipRootFolder);
 	}
 
 	/**
@@ -416,7 +416,7 @@ class ZipReader
 	 *
 	 * @throws \Exception If the central directory cannot be found
 	 */
-	protected function readCentralDirectory()
+	protected function readCentralDirectory($blnSkipRootFolder = false)
 	{
 		$strMbCharset = null;
 
@@ -533,6 +533,24 @@ class ZipReader
 
 		// Restore the mbstring encoding (see #5842)
 		$strMbCharset && mb_internal_encoding($strMbCharset);
+
+		if ($blnSkipRootFolder && !empty($this->arrFiles))
+		{
+			$strRoot = strtok($this->arrFiles[0]['file_name'], '/').'/';
+
+			foreach ($this->arrFiles as $file)
+			{
+				if (!str_starts_with($file['file_name'], $strRoot))
+				{
+					return;
+				}
+			}
+
+			foreach ($this->arrFiles as &$file)
+			{
+				$file['file_name'] = substr($file['file_name'], strlen($strRoot));
+			}
+		}
 	}
 
 	/**

--- a/core-bundle/src/Resources/contao/library/Contao/ZipReader.php
+++ b/core-bundle/src/Resources/contao/library/Contao/ZipReader.php
@@ -536,7 +536,7 @@ class ZipReader
 
 		if ($blnSkipRootFolder && !empty($this->arrFiles))
 		{
-			$strRoot = strtok($this->arrFiles[0]['file_name'], '/').'/';
+			$strRoot = strtok($this->arrFiles[0]['file_name'], '/') . '/';
 
 			foreach ($this->arrFiles as $file)
 			{
@@ -546,7 +546,7 @@ class ZipReader
 				}
 			}
 
-			$offset = strlen($strRoot);
+			$offset = \strlen($strRoot);
 
 			foreach ($this->arrFiles as &$file)
 			{


### PR DESCRIPTION
While preparing for the new Contao demo website, my goal was to use the GitHub ZIP export functionality to directly get the theme file. This works 99% in Contao, there are only two issues:

1. ZIP files are currently not allowed, even though a `.cto` is a ZIP. I don't see a problem with allowing both
2. GitHub generates a root folder for the export. I therefore added ZIP root folder detection to ignore that.

The theme upload also only supports extracting `/templates` and `/files`. It generates a warning/error for any other file, which means our repository could e.g. not contain a `composer.json`. I don't really see why we would need to generate errors for files that are not extracted though?

@contao/developers wdyt? can we fix this support to allow such themes? A possible other solution would be to have a GitHub action build the .cto file somewhere to download, but that feels like a lot of overhead (and something any other theme developer would need to do as well).