### PR TITLE
Cache lower key values in `Model::convertToPhpValue()`

### DIFF
--- a/core-bundle/contao/library/Contao/Model.php
+++ b/core-bundle/contao/library/Contao/Model.php
@@ -462,6 +462,19 @@ abstract class Model
 			return null;
 		}
 
+		static $loweredTables = array();
+		static $loweredKeys = array();
+
+		if (!isset($loweredTables[static::$strTable]))
+		{
+			$loweredTables[static::$strTable] = strtolower(static::$strTable);
+		}
+
+		if (!isset($loweredKeys[$strKey]))
+		{
+			$loweredKeys[$strKey] = strtolower($strKey);
+		}
+
 		if (!self::$arrColumnCastTypes)
 		{
 			$path = Path::join(System::getContainer()->getParameter('kernel.cache_dir'), 'contao/config/column-types.php');
@@ -476,7 +489,7 @@ abstract class Model
 			}
 		}
 
-		return match (self::$arrColumnCastTypes[strtolower(static::$strTable)][strtolower($strKey)] ?? null)
+		return match (self::$arrColumnCastTypes[$loweredTables[static::$strTable]][$loweredKeys[$strKey]] ?? null)
 		{
 			Types::INTEGER, Types::SMALLINT => (int) $varValue,
 			Types::FLOAT => (float) $varValue,

--- a/core-bundle/contao/library/Contao/Model.php
+++ b/core-bundle/contao/library/Contao/Model.php
@@ -462,6 +462,8 @@ abstract class Model
 			return null;
 		}
 
+		// This method is called thousands of times so the strtolower() calls would amount to a significant performance
+		// loss. Hence, we cache those values statically.
 		static $loweredTables = array();
 		static $loweredKeys = array();
 


### PR DESCRIPTION
This method is a very hot one when there are a lot of models loaded and most of the time is spent for lowering the same values over and over again. By caching them, this method becomes 5 times faster.