### PR TITLE
Simplify whitespace control in headline component template

### DIFF
--- a/core-bundle/contao/templates/_new/component/_headline.html.twig
+++ b/core-bundle/contao/templates/_new/component/_headline.html.twig
@@ -20,10 +20,8 @@
     {% set tag_name = headline.tag_name|default('h1') %}
 
     <{{ tag_name }}{% block headline_attributes %}{{ headline.attributes|default }}{% endblock %}>
-    {%- block headline_inner %}
-        {%- apply spaceless %}
-            {{ headline.text|insert_tag_raw }}
-        {% endapply -%}
-    {% endblock -%}
+    {%- block headline_inner -%}
+        {{ headline.text|insert_tag_raw }}
+    {%- endblock -%}
     </{{ tag_name }}>
 {% endblock %}


### PR DESCRIPTION
Fixes #6441

The `spaceless` filter is overly complicated here. :slightly_smiling_face: 