### PR TITLE
Do not lowercase table and column names in type cache

### DIFF
--- a/core-bundle/contao/library/Contao/Model.php
+++ b/core-bundle/contao/library/Contao/Model.php
@@ -436,7 +436,7 @@ abstract class Model
 
 				if (\in_array($type, array(Types::INTEGER, Types::SMALLINT, Types::FLOAT, Types::BOOLEAN), true))
 				{
-					$types[strtolower($table->getName())][strtolower($column->getName())] = $type;
+					$types[$table->getName()][$column->getName()] = $type;
 				}
 			}
 		}
@@ -462,21 +462,6 @@ abstract class Model
 			return null;
 		}
 
-		// This method is called thousands of times, so the strtolower() calls would amount
-		// to a significant performance loss. Hence, we cache those values statically.
-		static $loweredTables = array();
-		static $loweredKeys = array();
-
-		if (!isset($loweredTables[static::$strTable]))
-		{
-			$loweredTables[static::$strTable] = strtolower(static::$strTable);
-		}
-
-		if (!isset($loweredKeys[$strKey]))
-		{
-			$loweredKeys[$strKey] = strtolower($strKey);
-		}
-
 		if (!self::$arrColumnCastTypes)
 		{
 			$path = Path::join(System::getContainer()->getParameter('kernel.cache_dir'), 'contao/config/column-types.php');
@@ -491,7 +476,7 @@ abstract class Model
 			}
 		}
 
-		return match (self::$arrColumnCastTypes[$loweredTables[static::$strTable]][$loweredKeys[$strKey]] ?? null)
+		return match (self::$arrColumnCastTypes[static::$strTable][$strKey] ?? null)
 		{
 			Types::INTEGER, Types::SMALLINT => (int) $varValue,
 			Types::FLOAT => (float) $varValue,

--- a/core-bundle/tests/Contao/ModelTest.php
+++ b/core-bundle/tests/Contao/ModelTest.php
@@ -63,7 +63,7 @@ class ModelTest extends TestCase
     {
         $this->assertSame(
             [
-                'tl_foo' => [
+                'tl_Foo' => [
                     'int_not_null' => Types::INTEGER,
                     'int_null' => Types::INTEGER,
                     'smallint_not_null' => Types::SMALLINT,
@@ -72,6 +72,7 @@ class ModelTest extends TestCase
                     'float_null' => Types::FLOAT,
                     'bool_not_null' => Types::BOOLEAN,
                     'bool_null' => Types::BOOLEAN,
+                    'floatNotNullCamelCase' => Types::FLOAT,
                     'dca_only' => Types::INTEGER,
                 ],
             ],
@@ -83,7 +84,7 @@ class ModelTest extends TestCase
     {
         $this->assertSame(
             [
-                'tl_foo' => [
+                'tl_Foo' => [
                     'int_not_null' => Types::INTEGER,
                     'int_null' => Types::INTEGER,
                     'smallint_not_null' => Types::SMALLINT,
@@ -92,6 +93,7 @@ class ModelTest extends TestCase
                     'float_null' => Types::FLOAT,
                     'bool_not_null' => Types::BOOLEAN,
                     'bool_null' => Types::BOOLEAN,
+                    'floatNotNullCamelCase' => Types::FLOAT,
                     'database_only' => Types::INTEGER,
                 ],
             ],
@@ -105,7 +107,7 @@ class ModelTest extends TestCase
     public function testConvertToPhpValue(string $key, mixed $value, mixed $expected): void
     {
         $fooModel = new class() extends Model {
-            protected static $strTable = 'tl_foo';
+            protected static $strTable = 'tl_Foo';
 
             public function __construct()
             {
@@ -146,12 +148,14 @@ class ModelTest extends TestCase
         yield ['float_null', null, null];
 
         yield ['bool_null', null, null];
+
+        yield ['floatNotNullCamelCase', '12.3', 12.3];
     }
 
     private function createSchema(bool $fromDatabase): Schema
     {
         $schema = new Schema();
-        $table = $schema->createTable('tl_foo');
+        $table = $schema->createTable('tl_Foo');
         $table->addColumn('string_not_null', Types::STRING, ['notnull' => true]);
         $table->addColumn('string_null', Types::STRING, ['notnull' => false]);
         $table->addColumn('int_not_null', Types::INTEGER, ['notnull' => true]);
@@ -162,6 +166,7 @@ class ModelTest extends TestCase
         $table->addColumn('float_null', Types::FLOAT, ['notnull' => false]);
         $table->addColumn('bool_not_null', Types::BOOLEAN, ['notnull' => true]);
         $table->addColumn('bool_null', Types::BOOLEAN, ['notnull' => false]);
+        $table->addColumn('floatNotNullCamelCase', Types::FLOAT, ['notnull' => true]);
 
         if ($fromDatabase) {
             $table->addColumn('database_only', Types::INTEGER, ['notnull' => false]);


### PR DESCRIPTION
Followup to #6438

Lowercasing table and column names is not necessary as doctrine reports these names correctly.
I probably got confused by the fact that `SchemaManager::listTableColumns()` does lowercase the array indexes, but not the column names in `$column->getName()`.