### PR TITLE
Allow special characters in HTML attributes

### DIFF
--- a/core-bundle/src/String/HtmlAttributes.php
+++ b/core-bundle/src/String/HtmlAttributes.php
@@ -102,8 +102,12 @@ class HtmlAttributes implements \Stringable, \JsonSerializable, \IteratorAggrega
 
         $name = strtolower($name);
 
-        if (1 !== preg_match('/^[a-z](?:[_-]?[a-z0-9])*$/', $name)) {
-            throw new \InvalidArgumentException(sprintf('A HTML attribute name must only consist of the characters [a-z0-9_-], must start with a letter, must not end with a underscore/hyphen and must not contain two underscores/hyphens in a row, got "%s".', $name));
+        // Even though the HTML 5 parser supports attribute names starting with
+        // an equal sign, we have to disallow that in order to support
+        // serializing boolean attributes. Otherwise, serializing and parsing
+        // back something like `hidden="" =attr="value"` would fail the roundtrip.
+        if (1 !== preg_match('(^[^>\s/=]+$)', $name) || 1 !== preg_match('//u', $name)) {
+            throw new \InvalidArgumentException(sprintf('An HTML attribute name must be valid UTF-8 and not contain the characters >, /, = or whitespace, got "%s".', $name));
         }
 
         // Unset if value is set to false

--- a/core-bundle/tests/String/HtmlAttributesTest.php
+++ b/core-bundle/tests/String/HtmlAttributesTest.php
@@ -65,7 +65,7 @@ class HtmlAttributesTest extends TestCase
 
         yield 'Vue.js attributes' => [
             'v-html="raw" v-bind:id="id" :disabled="dis" :[attr]="val" :[\'data-\'+key]="val"',
-            ['v-html' => 'raw', 'v-bind:id' => 'id', ':disabled' => 'dis', ':[attr]' => 'val', ':[\'data-\'+key]' => 'val'],
+            ['v-html' => 'raw', 'v-bind:id' => 'id', ':disabled' => 'dis', ':[attr]' => 'val', ":['data-'+key]" => 'val'],
         ];
 
         yield 'Vue.js events' => [

--- a/core-bundle/tests/String/HtmlAttributesTest.php
+++ b/core-bundle/tests/String/HtmlAttributesTest.php
@@ -58,14 +58,29 @@ class HtmlAttributesTest extends TestCase
             ['foo' => 'bar', 'baz' => '42'],
         ];
 
+        yield 'AlpineJS attributes' => [
+            '@click="open = true" x-on:click="open = !open"',
+            ['@click' => 'open = true', 'x-on:click' => 'open = !open'],
+        ];
+
+        yield 'Vue.js attributes' => [
+            'v-html="raw" v-bind:id="id" :disabled="dis" :[attr]="val" :[\'data-\'+key]="val"',
+            ['v-html' => 'raw', 'v-bind:id' => 'id', ':disabled' => 'dis', ':[attr]' => 'val', ':[\'data-\'+key]' => 'val'],
+        ];
+
+        yield 'Vue.js events' => [
+            '@click.prevent="start"  @[event]="run"',
+            ['@click.prevent' => 'start', '@[event]' => 'run'],
+        ];
+
         yield 'special html parsing rules' => [
-            "/X===.._-/\n/y/",
-            ['x' => '==.._-/', 'y' => ''],
+            "/X===.._-/\n/Y/-==",
+            ['x' => '==.._-/', 'y' => '', '-' => '='],
         ];
 
         yield 'skip closing and keep opening tags as per html parsing rules' => [
-            '>foo=<bar>baz>/</<ignore=<this-one',
-            ['foo' => '<bar', 'baz' => ''],
+            '>foo=<bar>baz>/</<attr=<value',
+            ['foo' => '<bar', 'baz' => '', '<' => '', '<attr' => '<value'],
         ];
 
         yield 'skip unclosed attributes completely' => [
@@ -245,7 +260,7 @@ class HtmlAttributesTest extends TestCase
     public function testRejectsInvalidAttributeNamesWhenConstructingFromArray(string $name): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('/A HTML attribute name must only consist of the characters \[a-z0-9_-\], must start with a letter, must not end with a underscore\/hyphen and must not contain two underscores\/hyphens in a row, got ".*"\./');
+        $this->expectExceptionMessageMatches('/An HTML attribute name must be valid UTF-8 and not contain the characters >, \/, = or whitespace, got ".*"\./');
 
         new HtmlAttributes([$name => 'bar']);
     }
@@ -258,24 +273,17 @@ class HtmlAttributesTest extends TestCase
         $attributes = new HtmlAttributes();
 
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('/A HTML attribute name must only consist of the characters \[a-z0-9_-\], must start with a letter, must not end with a underscore\/hyphen and must not contain two underscores\/hyphens in a row, got ".*"\./');
+        $this->expectExceptionMessageMatches('/An HTML attribute name must be valid UTF-8 and not contain the characters >, \/, = or whitespace, got ".*"\./');
 
         $attributes->set($name, 'bar');
     }
 
     public function provideInvalidAttributeNames(): \Generator
     {
-        yield 'invalid character' => ['föö'];
         yield 'invalid non-utf8 character' => ["f\xC2"];
-        yield 'does not start with a-z' => ['2foo'];
-        yield 'ends with a hyphen' => ['foo-'];
-        yield 'contains two hyphens in a row' => ['foo--bar'];
-        yield 'ends with an underscore' => ['foo_'];
-        yield 'contains two underscores in a row' => ['foo__bar'];
-        yield 'opening tag only' => ['<'];
-        yield 'contains opening tag as first char' => ['<foo'];
-        yield 'contains opening tag as second char' => ['f<oo'];
-        yield 'contains opening tag as last char' => ['foo<'];
+        yield 'empty string' => [''];
+        yield 'equal sign' => ['='];
+        yield 'starts with an equal sign' => ['=foo'];
     }
 
     public function testSetAndUnsetProperties(): void
@@ -574,9 +582,9 @@ class HtmlAttributesTest extends TestCase
         $attributes = new HtmlAttributes();
 
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('A HTML attribute name must only consist of the characters [a-z0-9_-], must start with a letter, must not end with a underscore/hyphen and must not contain two underscores/hyphens in a row, got "foo--2000".');
+        $this->expectExceptionMessage('An HTML attribute name must be valid UTF-8 and not contain the characters >, /, = or whitespace, got "=foo".');
 
-        $attributes['foo--2000'] = 'bar';
+        $attributes['=foo'] = 'bar';
     }
 
     public function testThrowsIfPropertyDoesNotExistWhenUsingArrayAccess(): void


### PR DESCRIPTION
Fixes #6445

All possible characters are allowed now. Only starting an attribute with an equal sign is not supported as it would break the serialize-parse roundtrip, e.g. `<div foo="" =bar="baz">` would turn into `<div foo="bar=&quot;baz&quot;">` (because we remove the `=""` for boolean attributes).

I also added some tests for the Vue.js attributes syntax.