### PR TITLE
Fix unsetting uppercase attributes

### DIFF
--- a/core-bundle/src/String/HtmlAttributes.php
+++ b/core-bundle/src/String/HtmlAttributes.php
@@ -148,7 +148,7 @@ class HtmlAttributes implements \Stringable, \JsonSerializable, \IteratorAggrega
             return $this;
         }
 
-        unset($this->attributes[$name]);
+        unset($this->attributes[strtolower($name)]);
 
         return $this;
     }

--- a/core-bundle/tests/String/HtmlAttributesTest.php
+++ b/core-bundle/tests/String/HtmlAttributesTest.php
@@ -314,6 +314,12 @@ class HtmlAttributesTest extends TestCase
         $attributes->setIfExists('f', false); // should not alter the list
 
         $this->assertSame(['e' => ' ', 'f' => 'abc'], iterator_to_array($attributes));
+
+        // Uppercase names
+        $attributes->set('E', 'UPPER');
+        $attributes->unset('F');
+
+        $this->assertSame(['e' => 'UPPER'], iterator_to_array($attributes));
     }
 
     public function testSetAndUnsetConditionalProperties(): void


### PR DESCRIPTION
We lowercased the names only in `->set()` but not in `->unset()`.