### PR TITLE
Remove the `kernel.reset` tag

### DIFF
--- a/core-bundle/src/Resources/config/listener.yml
+++ b/core-bundle/src/Resources/config/listener.yml
@@ -80,8 +80,6 @@ services:
         class: Contao\CoreBundle\EventListener\DataContainer\LayoutOptionsListener
         arguments:
             - '@database_connection'
-        tags:
-            - { name: kernel.reset, method: reset }
 
     contao.listener.data_container.member_groups:
         class: Contao\CoreBundle\EventListener\DataContainer\MemberGroupsListener
@@ -353,7 +351,6 @@ services:
             - '@contao.framework'
         tags:
             - { name: kernel.event_listener, priority: 256 }
-            - { name: kernel.reset, method: reset }
 
     contao.listener.module_template_options:
         class: Contao\CoreBundle\EventListener\DataContainer\TemplateOptionsListener
@@ -522,7 +519,6 @@ services:
         class: Contao\CoreBundle\EventListener\SubrequestCacheSubscriber
         tags:
             - kernel.event_subscriber
-            - { name: kernel.reset, method: reset }
 
     contao.listener.user_session:
         class: Contao\CoreBundle\EventListener\UserSessionListener

--- a/core-bundle/src/Resources/config/services.yml
+++ b/core-bundle/src/Resources/config/services.yml
@@ -125,13 +125,9 @@ services:
             - '@contao.csrf.token_storage'
             - ~
             - '%contao.csrf_token_name%'
-        tags:
-            - { name: kernel.reset, method: reset }
 
     contao.csrf.token_storage:
         class: Contao\CoreBundle\Csrf\MemoryTokenStorage
-        tags:
-            - { name: kernel.reset, method: reset }
 
     contao.data_collector:
         class: Contao\CoreBundle\DataCollector\ContaoDataCollector
@@ -257,8 +253,6 @@ services:
             - '%kernel.project_dir%'
             - '%contao.error_level%'
             - '%contao.legacy_routing%'
-        tags:
-            - { name: kernel.reset, method: reset }
 
     contao.image.deferred_image_storage:
         class: Contao\Image\DeferredImageStorageFilesystem
@@ -360,8 +354,6 @@ services:
             - '@event_dispatcher'
             - '@contao.framework'
             - '@contao.translation.translator'
-        tags:
-            - { name: kernel.reset, method: reset }
 
     contao.image.studio:
         class: Contao\CoreBundle\Image\Studio\Studio
@@ -762,8 +754,6 @@ services:
         class: Contao\CoreBundle\Security\Voter\BackendAccessVoter
         arguments:
             - '@contao.framework'
-        tags:
-            - { name: kernel.reset, method: reset }
 
     contao.security.backend_user_provider:
         class: Contao\CoreBundle\Security\User\ContaoUserProvider
@@ -938,8 +928,6 @@ services:
         autoconfigure: false
         arguments:
             - '@contao.translation.data_collector_translator.inner'
-        tags:
-            - { name: kernel.reset, method: reset }
 
     contao.translation.translator:
         class: Contao\CoreBundle\Translation\Translator
@@ -979,7 +967,6 @@ services:
             - '%kernel.project_dir%'
         tags:
             - { name: twig.loader, priority: 2 }
-            - { name: kernel.reset, method: reset }
 
     contao.twig.filesystem_loader_warmer:
         class: Contao\CoreBundle\Twig\Loader\ContaoFilesystemLoaderWarmer


### PR DESCRIPTION
These are no longer necessary since we enabled autoconfiguration in https://github.com/contao/contao/commit/99199e583d37c3cf478053a0c4c368b4f10276fe

see https://github.com/contao/contao/pull/6434#discussion_r1369194131