### PR TITLE
Do not grant access in the news archive access voter

### DIFF
--- a/news-bundle/src/Security/Voter/NewsArchiveAccessVoter.php
+++ b/news-bundle/src/Security/Voter/NewsArchiveAccessVoter.php
@@ -55,7 +55,9 @@ class NewsArchiveAccessVoter implements VoterInterface, CacheableVoterInterface
                 default => false,
             };
 
-            return $isGranted ? self::ACCESS_GRANTED : self::ACCESS_DENIED;
+            if (!$isGranted) {
+                return self::ACCESS_DENIED;
+            }
         }
 
         return self::ACCESS_ABSTAIN;

--- a/news-bundle/tests/Security/Voter/NewsArchiveAccessVoterTest.php
+++ b/news-bundle/tests/Security/Voter/NewsArchiveAccessVoterTest.php
@@ -51,6 +51,7 @@ class NewsArchiveAccessVoterTest extends WebTestCase
 
         $token = $this->createMock(TokenInterface::class);
 
+        // Unsupported attribute
         $this->assertSame(
             VoterInterface::ACCESS_ABSTAIN,
             $voter->vote(
@@ -60,6 +61,8 @@ class NewsArchiveAccessVoterTest extends WebTestCase
             )
         );
 
+        // Permission granted, so abstain! Our voters either deny or abstain,
+        // they must never grant access (see #6201).
         $this->assertSame(
             VoterInterface::ACCESS_ABSTAIN,
             $voter->vote(
@@ -69,6 +72,7 @@ class NewsArchiveAccessVoterTest extends WebTestCase
             )
         );
 
+        // Permission denied
         $this->assertSame(
             VoterInterface::ACCESS_DENIED,
             $voter->vote(

--- a/news-bundle/tests/Security/Voter/NewsArchiveAccessVoterTest.php
+++ b/news-bundle/tests/Security/Voter/NewsArchiveAccessVoterTest.php
@@ -61,7 +61,7 @@ class NewsArchiveAccessVoterTest extends WebTestCase
         );
 
         $this->assertSame(
-            VoterInterface::ACCESS_GRANTED,
+            VoterInterface::ACCESS_ABSTAIN,
             $voter->vote(
                 $token,
                 new ReadAction('foo', ['id' => 42]),


### PR DESCRIPTION
This is the same issues as in #6201. We only fixed it for the `FavoritesVoter` there.