### PR TITLE
Allow to re-use the ProcessUtil data

### DIFF
--- a/core-bundle/src/Util/ProcessUtil.php
+++ b/core-bundle/src/Util/ProcessUtil.php
@@ -54,7 +54,7 @@ class ProcessUtil implements ResetInterface
 
     public function createSymfonyConsoleProcess(string $command, string ...$commandArguments): Process
     {
-        return new Process([$this->getPhpBinary(), $this->consolePath, $command, ...$commandArguments]);
+        return new Process([$this->getPhpBinary(), $this->getConsolePath(), $command, ...$commandArguments]);
     }
 
     public function reset(): void
@@ -62,7 +62,12 @@ class ProcessUtil implements ResetInterface
         $this->phpBinary = null;
     }
 
-    private function getPhpBinary(): string
+    public function getConsolePath(): string
+    {
+        return $this->consolePath;
+    }
+
+    public function getPhpBinary(): string
     {
         if (null === $this->phpBinary) {
             $executableFinder = new PhpExecutableFinder();

--- a/core-bundle/tests/Util/ProcessUtilTest.php
+++ b/core-bundle/tests/Util/ProcessUtilTest.php
@@ -28,6 +28,14 @@ class ProcessUtilTest extends TestCase
         $this->assertSame('bin/console foobar argument-1 argument-2', $this->getCommandLine($process));
     }
 
+    public function testGetters(): void
+    {
+        $util = new ProcessUtil('bin/console');
+
+        $this->assertSame('bin/console', $util->getConsolePath());
+        $this->assertNotEmpty($util->getPhpBinary());
+    }
+
     /**
      * @dataProvider promiseTestProvider
      */


### PR DESCRIPTION
Unfortunately, our `ProcessUtil` service currently cannot be used with custom flags such as `-d memory_limit=-1`.

You currently have to do something like this:

```php
$process = $this->processUtil->createSymfonyConsoleProcess('...');

$reflection = new \ReflectionClass($process);
$commandline = $reflection->getProperty('commandline');
$commandline = $commandline->getValue($process);
array_splice($commandline, 1, 0, ['-d', 'memory_limit=-1']);
$process = new Process($commandline);

return $this->processUtil->createPromise($process);
```

First, I thought we could add a new `createSymfonyConsoleProcessWithAdditonalDirectives()` but then, as soon as you want to use something else than `new Process()` (e.g. my new [`new PhpSubprocess()`](https://github.com/symfony/symfony/pull/48485)) then this wouldn't work either.

So I thought it would be best to expose the console path and binary path as getters.
