### PR TITLE
Compare the actual row format instead of the create options

### DIFF
--- a/installation-bundle/src/Database/Installer.php
+++ b/installation-bundle/src/Database/Installer.php
@@ -239,7 +239,7 @@ class Installer
                 $deleteIndexes = true;
                 $alterTables[md5($command)] = $command;
             } elseif ($innodb && $dynamic) {
-                if (strtolower($tableOptions['Row_format']) !== 'dynamic') {
+                if ('dynamic' !== strtolower($tableOptions['Row_format'])) {
                     $command = 'ALTER TABLE '.$tableName.' ENGINE = '.$engine.' ROW_FORMAT = DYNAMIC';
 
                     if (false !== stripos($tableOptions['Create_options'], 'key_block_size=')) {

--- a/installation-bundle/src/Database/Installer.php
+++ b/installation-bundle/src/Database/Installer.php
@@ -239,7 +239,7 @@ class Installer
                 $deleteIndexes = true;
                 $alterTables[md5($command)] = $command;
             } elseif ($innodb && $dynamic) {
-                if (false === stripos($tableOptions['Create_options'], 'row_format=dynamic')) {
+                if (strtolower($tableOptions['Row_format']) !== 'dynamic') {
                     $command = 'ALTER TABLE '.$tableName.' ENGINE = '.$engine.' ROW_FORMAT = DYNAMIC';
 
                     if (false !== stripos($tableOptions['Create_options'], 'key_block_size=')) {

--- a/installation-bundle/tests/Database/InstallerTest.php
+++ b/installation-bundle/tests/Database/InstallerTest.php
@@ -219,6 +219,7 @@ class InstallerTest extends TestCase
         $fromSchema
             ->createTable('tl_bar')
             ->addOption('engine', 'InnoDB')
+            ->addOption('row_format', 'COMPACT')
             ->addOption('charset', 'utf8mb4')
             ->addOption('collate', 'utf8mb4_unicode_ci')
             ->addOption('Create_options', 'row_format=COMPACT')
@@ -562,6 +563,7 @@ class InstallerTest extends TestCase
                             if ($table->hasOption('engine')) {
                                 return [
                                     'Engine' => $table->getOption('engine'),
+                                    'Row_format' => $table->hasOption('row_format') ? $table->getOption('row_format') : '',
                                     'Create_options' => implode(', ', $table->getOption('create_options')),
                                     'Collation' => $table->hasOption('collate') ? $table->getOption('collate') : '',
                                 ];


### PR DESCRIPTION
This fixes the issue that after restoring a backup you get migrations like `ALTER TABLE … ENGINE = InnoDB ROW_FORMAT = DYNAMIC`

I checked the docs and the `Row_format` column was already part of `SHOW TABLE STATUS` in MySQL 5.1, so this should work everywhere I think.