### PR TITLE
Cast boolean to integer in `DC_Table::copy`

### DIFF
--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -862,6 +862,12 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 						{
 							$v = Encryption::encrypt($v);
 						}
+
+						// Cast boolean to integers (see #6473)
+						if (\is_bool($v))
+						{
+							$v = (int) $v;
+						}
 					}
 
 					$this->set[$k] = $v;

--- a/core-bundle/src/Resources/contao/library/Contao/Database/Statement.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Database/Statement.php
@@ -258,15 +258,8 @@ class Statement
 		}
 
 		$arrParams = array_map(
-			static function ($varParam) use ($arrTypes)
+			static function ($varParam)
 			{
-				// Automatically cast boolean to integer when no types are defined, otherwise
-				// PDO will convert "false" to an empty string (see https://bugs.php.net/bug.php?id=57157)
-				if (empty($arrTypes) && \is_bool($varParam))
-				{
-					return (int) $varParam;
-				}
-
 				if (\is_string($varParam) || \is_bool($varParam) || \is_float($varParam) || \is_int($varParam) || $varParam === null)
 				{
 					return $varParam;

--- a/core-bundle/src/Resources/contao/library/Contao/Database/Statement.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Database/Statement.php
@@ -258,8 +258,15 @@ class Statement
 		}
 
 		$arrParams = array_map(
-			static function ($varParam)
+			static function ($varParam) use ($arrTypes)
 			{
+				// Automatically cast boolean to integer when no types are defined, otherwise
+				// PDO will convert "false" to an empty string (see https://bugs.php.net/bug.php?id=57157)
+				if (empty($arrTypes) && \is_bool($varParam))
+				{
+					return (int) $varParam;
+				}
+
 				if (\is_string($varParam) || \is_bool($varParam) || \is_float($varParam) || \is_int($varParam) || $varParam === null)
 				{
 					return $varParam;


### PR DESCRIPTION
Suppose you have the following DCA adjustment within Contao 4.13:

```php
// contao/dca/tl_content.php
use Contao\CoreBundle\DataContainer\PaletteManipulator;

$GLOBALS['TL_DCA']['tl_content']['fields']['foobar'] = [
    'inputType' => 'checkbox',
    'eval' => [
        'doNotCopy' => true,
    ],
    'sql' => [
        'type' => 'boolean',
        'default' => false,
    ],
];

PaletteManipulator::create()
    ->addField('foobar', 'expert_legend', PaletteManipulator::POSITION_APPEND)
    ->applyToPalette('text', 'tl_content')
;
```

If you then copy a content element, the following error will occur:

```
PDOException:
SQLSTATE[22007]: Invalid datetime format: 1366 Incorrect integer value: '' for column `c413`.`tl_content`.`foobar` at row 1

  at vendor\doctrine\dbal\src\Driver\PDO\Statement.php:121
  at PDOStatement->execute(null)
     (vendor\doctrine\dbal\src\Driver\PDO\Statement.php:121)
  at Doctrine\DBAL\Driver\PDO\Statement->execute(null)
     (vendor\doctrine\dbal\src\Driver\Middleware\AbstractStatementMiddleware.php:69)
  at Doctrine\DBAL\Driver\Middleware\AbstractStatementMiddleware->execute(null)
     (vendor\doctrine\dbal\src\Logging\Statement.php:98)
  at Doctrine\DBAL\Logging\Statement->execute(null)
     (vendor\doctrine\dbal\src\Driver\Middleware\AbstractStatementMiddleware.php:69)
  at Doctrine\DBAL\Driver\Middleware\AbstractStatementMiddleware->execute(null)
     (vendor\symfony\doctrine-bridge\Middleware\Debug\Statement.php:72)
  at Symfony\Bridge\Doctrine\Middleware\Debug\Statement->execute()
     (vendor\doctrine\dbal\src\Connection.php:1096)
  at Doctrine\DBAL\Connection->executeQuery('INSERT INTO tl_content (array(…), array())
     (vendor\contao\contao\core-bundle\src\Resources\contao\library\Contao\Database\Statement.php:286)
  at Contao\Database\Statement->query('', array('text', false, 1, 'tl_article', 24, 0, '…', '', '', '', 'ascending', 0, '', '', '', '', '', ''))
     (vendor\contao\contao\core-bundle\src\Resources\contao\library\Contao\Database\Statement.php:235)
  at Contao\Database\Statement->execute()
     (vendor\contao\contao\core-bundle\src\Resources\contao\drivers\DC_Table.php:929)
  at Contao\DC_Table->copy()
     (vendor\contao\contao\core-bundle\src\Resources\contao\classes\Backend.php:667)
  at Contao\Backend->getBackendModule('article', null)
     (vendor\contao\contao\core-bundle\src\Resources\contao\controllers\BackendMain.php:168)
  at Contao\BackendMain->run()
     (vendor\contao\contao\core-bundle\src\Controller\BackendController.php:49)
  at Contao\CoreBundle\Controller\BackendController->mainAction()
     (vendor\symfony\http-kernel\HttpKernel.php:163)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw(object(Request), 1)
     (vendor\symfony\http-kernel\HttpKernel.php:75)
  at Symfony\Component\HttpKernel\HttpKernel->handle(object(Request), 1, true)
     (vendor\symfony\http-kernel\Kernel.php:202)
  at Symfony\Component\HttpKernel\Kernel->handle(object(Request))
     (public\index.php:44)
```

This PR would fix this - by backporting a change we introduced in https://github.com/contao/contao/commit/94c2febf9e9da4aca45cc39077ee12e229014c9e.

_Note:_ checkbox fields with `boolean` database types are supported since Contao `4.9.11`.