### PR TITLE
Fix a type error in `FormInsertTag`

### DIFF
--- a/core-bundle/src/InsertTag/Resolver/FormInsertTag.php
+++ b/core-bundle/src/InsertTag/Resolver/FormInsertTag.php
@@ -30,7 +30,7 @@ class FormInsertTag
     public function replaceSessionData(ResolvedInsertTag $insertTag): InsertTagResult
     {
         return new InsertTagResult(
-            $this->requestStack->getCurrentRequest()?->getSession()->get(Form::SESSION_KEY)?->getValue()[$insertTag->getParameters()->get(0)],
+            $this->requestStack->getCurrentRequest()?->getSession()->get(Form::SESSION_KEY)?->getValue()[$insertTag->getParameters()->get(0)] ?? '',
             OutputType::text,
         );
     }


### PR DESCRIPTION
When you use the `{{form_session_data::*}}` insert tag the following error will occur:

```
TypeError:
Contao\CoreBundle\InsertTag\InsertTagResult::__construct(): Argument #1 ($value) must be of type Stringable|string, null given, called in vendor\contao\contao\core-bundle\src\InsertTag\Resolver\FormInsertTag.php on line 32

  at vendor\contao\contao\core-bundle\src\InsertTag\InsertTagResult.php:20
  at Contao\CoreBundle\InsertTag\InsertTagResult->__construct(null, object(OutputType))
     (vendor\contao\contao\core-bundle\src\InsertTag\Resolver\FormInsertTag.php:32)
  at Contao\CoreBundle\InsertTag\Resolver\FormInsertTag->replaceSessionData(object(ResolvedInsertTag))
     (vendor\contao\contao\core-bundle\src\InsertTag\InsertTagParser.php:419)
  at Contao\CoreBundle\InsertTag\InsertTagParser->renderSubscription(object(ResolvedInsertTag), false)
     (vendor\contao\contao\core-bundle\src\InsertTag\InsertTagParser.php:391)
  at Contao\CoreBundle\InsertTag\InsertTagParser->executeReplace(object(ParsedSequence), false, object(OutputType))
     (vendor\contao\contao\core-bundle\src\InsertTag\InsertTagParser.php:155)
  at Contao\CoreBundle\InsertTag\InsertTagParser->replaceInline('<p>{{form_session_data::foobar}}</p>')
     (vendor\contao\contao\core-bundle\src\Twig\Runtime\InsertTagRuntime.php:35)
  at Contao\CoreBundle\Twig\Runtime\InsertTagRuntime->replaceInsertTags('<p>{{form_session_data::foobar}}</p>')
     (var\cache\dev\twig\c0\c00587c3bfdf175108bed29053e23923.php:164)
```
