### PR TITLE
Do not replace insert tags in the editor view in the back end

### DIFF
--- a/core-bundle/contao/templates/_new/component/_headline.html.twig
+++ b/core-bundle/contao/templates/_new/component/_headline.html.twig
@@ -21,7 +21,7 @@
 
     <{{ tag_name }}{% block headline_attributes %}{{ headline.attributes|default }}{% endblock %}>
     {%- block headline_inner -%}
-        {{ headline.text|insert_tag_raw }}
+        {% if as_editor_view %}{{ headline }}{% else %}{{ headline.text|insert_tag_raw }}{% endif %}
     {%- endblock -%}
     </{{ tag_name }}>
 {% endblock %}

--- a/core-bundle/contao/templates/_new/component/_headline.html.twig
+++ b/core-bundle/contao/templates/_new/component/_headline.html.twig
@@ -21,7 +21,7 @@
 
     <{{ tag_name }}{% block headline_attributes %}{{ headline.attributes|default }}{% endblock %}>
     {%- block headline_inner -%}
-        {% if as_editor_view %}{{ headline }}{% else %}{{ headline.text|insert_tag_raw }}{% endif %}
+        {% if as_editor_view %}{{ headline.text }}{% else %}{{ headline.text|insert_tag_raw }}{% endif %}
     {%- endblock -%}
     </{{ tag_name }}>
 {% endblock %}

--- a/core-bundle/contao/templates/_new/component/_headline.html.twig
+++ b/core-bundle/contao/templates/_new/component/_headline.html.twig
@@ -21,7 +21,11 @@
 
     <{{ tag_name }}{% block headline_attributes %}{{ headline.attributes|default }}{% endblock %}>
     {%- block headline_inner -%}
-        {% if as_editor_view %}{{ headline.text }}{% else %}{{ headline.text|insert_tag_raw }}{% endif %}
+        {%- if as_editor_view -%}
+            {{ headline.text }}
+        {%- else -%}
+            {{ headline.text|insert_tag_raw }}
+        {%- endif -%}
     {%- endblock -%}
     </{{ tag_name }}>
 {% endblock %}

--- a/core-bundle/contao/templates/_new/content_element/list.html.twig
+++ b/core-bundle/contao/templates/_new/content_element/list.html.twig
@@ -6,5 +6,5 @@
 {% endblock %}
 
 {% block list_item %}
-    {% if as_editor_view %}{{- item|raw -}}{% else %}{{- item|insert_tag|raw -}}{% endif %}
+    {%- if as_editor_view %}{{ item|raw }}{% else %}{{ item|insert_tag|raw }}{% endif -%}
 {% endblock %}

--- a/core-bundle/contao/templates/_new/content_element/list.html.twig
+++ b/core-bundle/contao/templates/_new/content_element/list.html.twig
@@ -6,5 +6,5 @@
 {% endblock %}
 
 {% block list_item %}
-    {{- item|insert_tag|raw -}}
+    {% if as_editor_view %}{{- item|raw -}}{% else %}{{- item|insert_tag|raw -}}{% endif %}
 {% endblock %}

--- a/core-bundle/contao/templates/_new/content_element/list.html.twig
+++ b/core-bundle/contao/templates/_new/content_element/list.html.twig
@@ -6,5 +6,9 @@
 {% endblock %}
 
 {% block list_item %}
-    {%- if as_editor_view %}{{ item|raw }}{% else %}{{ item|insert_tag|raw }}{% endif -%}
+    {%- if as_editor_view -%}
+        {{ item|raw }}
+    {%- else -%}
+        {{ item|insert_tag|raw }}
+    {%- endif -%}
 {% endblock %}

--- a/core-bundle/contao/templates/_new/content_element/table.html.twig
+++ b/core-bundle/contao/templates/_new/content_element/table.html.twig
@@ -10,5 +10,9 @@
 {% endblock -%}
 
 {%- block table_cell_content %}
-    {%- if as_editor_view %}{{ cell|trim|replace({'\n': '<br>\n'})|raw }}{% else %}{{ cell|trim|replace({'\n': '<br>\n'})|insert_tag|raw }}{% endif -%}
+    {%- if as_editor_view -%}
+        {{ cell|trim|replace({'\n': '<br>\n'})|raw }}
+    {%- else -%}
+        {{ cell|trim|replace({'\n': '<br>\n'})|insert_tag|raw }}
+    {%- endif -%}
 {% endblock -%}

--- a/core-bundle/contao/templates/_new/content_element/table.html.twig
+++ b/core-bundle/contao/templates/_new/content_element/table.html.twig
@@ -10,5 +10,5 @@
 {% endblock -%}
 
 {%- block table_cell_content %}
-    {{- cell|trim|replace({'\n': '<br>\n'})|insert_tag|raw -}}
+    {% if as_editor_view %}{{- cell|trim|replace({'\n': '<br>\n'})|raw -}}{% else %}{{- cell|trim|replace({'\n': '<br>\n'})|insert_tag|raw -}}{% endif %}
 {% endblock -%}

--- a/core-bundle/contao/templates/_new/content_element/table.html.twig
+++ b/core-bundle/contao/templates/_new/content_element/table.html.twig
@@ -10,5 +10,5 @@
 {% endblock -%}
 
 {%- block table_cell_content %}
-    {% if as_editor_view %}{{- cell|trim|replace({'\n': '<br>\n'})|raw -}}{% else %}{{- cell|trim|replace({'\n': '<br>\n'})|insert_tag|raw -}}{% endif %}
+    {%- if as_editor_view %}{{ cell|trim|replace({'\n': '<br>\n'})|raw }}{% else %}{{ cell|trim|replace({'\n': '<br>\n'})|insert_tag|raw }}{% endif -%}
 {% endblock -%}

--- a/core-bundle/contao/templates/_new/content_element/teaser.html.twig
+++ b/core-bundle/contao/templates/_new/content_element/teaser.html.twig
@@ -8,7 +8,7 @@
 
 {% block content %}
     {% block teaser %}
-        {{ article.teaser|default|insert_tag|raw }}
+        {% if as_editor_view %}{{ article.teaser|default|raw }}{% else %}{{ article.teaser|default|insert_tag|raw }}{% endif %}
     {% endblock %}
 
     {% block link %}

--- a/core-bundle/contao/templates/_new/content_element/teaser.html.twig
+++ b/core-bundle/contao/templates/_new/content_element/teaser.html.twig
@@ -8,11 +8,11 @@
 
 {% block content %}
     {% block teaser %}
-        {%- if as_editor_view -%}
+        {% if as_editor_view %}
             {{ article.teaser|default|raw }}
-        {%- else -%}
+        {% else %}
             {{ article.teaser|default|insert_tag|raw }}
-        {%- endif -%}
+        {% endif %}
     {% endblock %}
 
     {% block link %}

--- a/core-bundle/contao/templates/_new/content_element/teaser.html.twig
+++ b/core-bundle/contao/templates/_new/content_element/teaser.html.twig
@@ -8,7 +8,11 @@
 
 {% block content %}
     {% block teaser %}
-        {% if as_editor_view %}{{ article.teaser|default|raw }}{% else %}{{ article.teaser|default|insert_tag|raw }}{% endif %}
+        {%- if as_editor_view -%}
+            {{ article.teaser|default|raw }}
+        {%- else -%}
+            {{ article.teaser|default|insert_tag|raw }}
+        {%- endif -%}
     {% endblock %}
 
     {% block link %}

--- a/core-bundle/contao/templates/_new/content_element/text.html.twig
+++ b/core-bundle/contao/templates/_new/content_element/text.html.twig
@@ -23,11 +23,11 @@
     {% block text %}
         {% set text_attributes = attrs(text_attributes|default).addClass('rte') %}
         <div{% block text_attributes %}{{ text_attributes }}{% endblock %}>
-            {%- if as_editor_view -%}
+            {% if as_editor_view %}
                 {{ text|raw }}
-            {%- else -%}
+            {% else %}
                 {{ text|insert_tag|raw }}
-            {%- endif -%}
+            {% endif %}
         </div>
     {% endblock %}
 {% endblock %}

--- a/core-bundle/contao/templates/_new/content_element/text.html.twig
+++ b/core-bundle/contao/templates/_new/content_element/text.html.twig
@@ -23,7 +23,7 @@
     {% block text %}
         {% set text_attributes = attrs(text_attributes|default).addClass('rte') %}
         <div{% block text_attributes %}{{ text_attributes }}{% endblock %}>
-            {{ text|insert_tag|raw }}
+            {% if as_editor_view %}{{ text|raw }}{% else %}{{ text|insert_tag|raw }}{% endif %}
         </div>
     {% endblock %}
 {% endblock %}

--- a/core-bundle/contao/templates/_new/content_element/text.html.twig
+++ b/core-bundle/contao/templates/_new/content_element/text.html.twig
@@ -23,7 +23,11 @@
     {% block text %}
         {% set text_attributes = attrs(text_attributes|default).addClass('rte') %}
         <div{% block text_attributes %}{{ text_attributes }}{% endblock %}>
-            {% if as_editor_view %}{{ text|raw }}{% else %}{{ text|insert_tag|raw }}{% endif %}
+            {%- if as_editor_view -%}
+                {{ text|raw }}
+            {%- else -%}
+                {{ text|insert_tag|raw }}
+            {%- endif -%}
         </div>
     {% endblock %}
 {% endblock %}


### PR DESCRIPTION
Via #6478 I noticed that insert tags are being replaced in the back end again, at least for certain content elements. This PR adds the missing `as_editor_view` checks to the affected templates (see also https://github.com/contao/contao/pull/4671).