### PR TITLE
Check if `$upload['tmp_name']` is set before using it

### DIFF
--- a/core-bundle/contao/forms/Form.php
+++ b/core-bundle/contao/forms/Form.php
@@ -310,7 +310,7 @@ class Form extends Hybrid
 					$file->delete();
 				}
 
-				if (!empty($upload['tmp_name']) && is_file($upload['tmp_name']))
+				if (is_file($upload['tmp_name'] ?? null))
 				{
 					unlink($upload['tmp_name']);
 				}

--- a/core-bundle/contao/forms/Form.php
+++ b/core-bundle/contao/forms/Form.php
@@ -310,7 +310,7 @@ class Form extends Hybrid
 					$file->delete();
 				}
 
-				if (is_file($upload['tmp_name'] ?? null))
+				if (isset($upload['tmp_name']) && is_file($upload['tmp_name']))
 				{
 					unlink($upload['tmp_name']);
 				}

--- a/core-bundle/contao/forms/Form.php
+++ b/core-bundle/contao/forms/Form.php
@@ -310,7 +310,7 @@ class Form extends Hybrid
 					$file->delete();
 				}
 
-				if (is_file($upload['tmp_name']))
+				if (!empty($upload['tmp_name']) && is_file($upload['tmp_name']))
 				{
 					unlink($upload['tmp_name']);
 				}


### PR DESCRIPTION
We use the [terminal42/contao-fineuploader](https://packagist.org/packages/terminal42/contao-fineuploader) extension, which provides the files as string values. The Contao form will try to cleanup the temporary files on error, which will result in a TypeError here:

![CleanShot 2023-11-03 at 15 29 33](https://github.com/contao/contao/assets/193483/fb3ef0bb-b6ab-45c8-b266-b0b85ee075e3)

/cc @Toflar 