### PR TITLE
Replace insert tag flags based on the context

### DIFF
--- a/core-bundle/contao/templates/twig/component/_headline.html.twig
+++ b/core-bundle/contao/templates/twig/component/_headline.html.twig
@@ -21,7 +21,7 @@
 
     <{{ tag_name }}{% block headline_attributes %}{{ headline.attributes|default }}{% endblock %}>
     {%- block headline_inner -%}
-        {{ headline.text|insert_tag_raw(as_editor_view) }}
+        {{ headline.text|insert_tag_raw }}
     {%- endblock -%}
     </{{ tag_name }}>
 {% endblock %}

--- a/core-bundle/contao/templates/twig/component/_headline.html.twig
+++ b/core-bundle/contao/templates/twig/component/_headline.html.twig
@@ -21,11 +21,7 @@
 
     <{{ tag_name }}{% block headline_attributes %}{{ headline.attributes|default }}{% endblock %}>
     {%- block headline_inner -%}
-        {%- if as_editor_view -%}
-            {{ headline.text }}
-        {%- else -%}
-            {{ headline.text|insert_tag_raw }}
-        {%- endif -%}
+        {{ headline.text|insert_tag_raw(as_editor_view) }}
     {%- endblock -%}
     </{{ tag_name }}>
 {% endblock %}

--- a/core-bundle/contao/templates/twig/content_element/list.html.twig
+++ b/core-bundle/contao/templates/twig/content_element/list.html.twig
@@ -6,9 +6,5 @@
 {% endblock %}
 
 {% block list_item %}
-    {%- if as_editor_view -%}
-        {{ item|raw }}
-    {%- else -%}
-        {{ item|insert_tag|raw }}
-    {%- endif -%}
+    {{- item|insert_tag(as_editor_view)|raw -}}
 {% endblock %}

--- a/core-bundle/contao/templates/twig/content_element/list.html.twig
+++ b/core-bundle/contao/templates/twig/content_element/list.html.twig
@@ -6,5 +6,5 @@
 {% endblock %}
 
 {% block list_item %}
-    {{- item|insert_tag(as_editor_view)|raw -}}
+    {{- item|insert_tag|raw -}}
 {% endblock %}

--- a/core-bundle/contao/templates/twig/content_element/table.html.twig
+++ b/core-bundle/contao/templates/twig/content_element/table.html.twig
@@ -10,5 +10,5 @@
 {% endblock -%}
 
 {%- block table_cell_content %}
-    {{- cell|trim|replace({'\n': '<br>\n'})|insert_tag(as_editor_view)|raw -}}
+    {{- cell|trim|replace({'\n': '<br>\n'})|insert_tag|raw -}}
 {% endblock -%}

--- a/core-bundle/contao/templates/twig/content_element/table.html.twig
+++ b/core-bundle/contao/templates/twig/content_element/table.html.twig
@@ -10,9 +10,5 @@
 {% endblock -%}
 
 {%- block table_cell_content %}
-    {%- if as_editor_view -%}
-        {{ cell|trim|replace({'\n': '<br>\n'})|raw }}
-    {%- else -%}
-        {{ cell|trim|replace({'\n': '<br>\n'})|insert_tag|raw }}
-    {%- endif -%}
+    {{- cell|trim|replace({'\n': '<br>\n'})|insert_tag(as_editor_view)|raw -}}
 {% endblock -%}

--- a/core-bundle/contao/templates/twig/content_element/teaser.html.twig
+++ b/core-bundle/contao/templates/twig/content_element/teaser.html.twig
@@ -8,7 +8,7 @@
 
 {% block content %}
     {% block teaser %}
-        {{ article.teaser|default|insert_tag(as_editor_view)|raw }}
+        {{ article.teaser|default|insert_tag|raw }}
     {% endblock %}
 
     {% block link %}

--- a/core-bundle/contao/templates/twig/content_element/teaser.html.twig
+++ b/core-bundle/contao/templates/twig/content_element/teaser.html.twig
@@ -8,11 +8,7 @@
 
 {% block content %}
     {% block teaser %}
-        {% if as_editor_view %}
-            {{ article.teaser|default|raw }}
-        {% else %}
-            {{ article.teaser|default|insert_tag|raw }}
-        {% endif %}
+        {{ article.teaser|default|insert_tag(as_editor_view)|raw }}
     {% endblock %}
 
     {% block link %}

--- a/core-bundle/contao/templates/twig/content_element/text.html.twig
+++ b/core-bundle/contao/templates/twig/content_element/text.html.twig
@@ -23,11 +23,7 @@
     {% block text %}
         {% set text_attributes = attrs(text_attributes|default).addClass('rte') %}
         <div{% block text_attributes %}{{ text_attributes }}{% endblock %}>
-            {% if as_editor_view %}
-                {{ text|raw }}
-            {% else %}
-                {{ text|insert_tag|raw }}
-            {% endif %}
+            {{ text|insert_tag(as_editor_view)|raw }}
         </div>
     {% endblock %}
 {% endblock %}

--- a/core-bundle/contao/templates/twig/content_element/text.html.twig
+++ b/core-bundle/contao/templates/twig/content_element/text.html.twig
@@ -23,7 +23,7 @@
     {% block text %}
         {% set text_attributes = attrs(text_attributes|default).addClass('rte') %}
         <div{% block text_attributes %}{{ text_attributes }}{% endblock %}>
-            {{ text|insert_tag(as_editor_view)|raw }}
+            {{ text|insert_tag|raw }}
         </div>
     {% endblock %}
 {% endblock %}

--- a/core-bundle/src/Twig/Extension/ContaoExtension.php
+++ b/core-bundle/src/Twig/Extension/ContaoExtension.php
@@ -238,12 +238,12 @@ final class ContaoExtension extends AbstractExtension
             new TwigFilter(
                 'insert_tag',
                 [InsertTagRuntime::class, 'replaceInsertTags'],
-                ['preserves_safety' => ['html']],
+                ['needs_context' => true, 'preserves_safety' => ['html']],
             ),
             new TwigFilter(
                 'insert_tag_raw',
                 [InsertTagRuntime::class, 'replaceInsertTagsChunkedRaw'],
-                ['preserves_safety' => ['html']],
+                ['needs_context' => true, 'preserves_safety' => ['html']],
             ),
             new TwigFilter(
                 'highlight',

--- a/core-bundle/src/Twig/Runtime/InsertTagRuntime.php
+++ b/core-bundle/src/Twig/Runtime/InsertTagRuntime.php
@@ -30,8 +30,12 @@ final class InsertTagRuntime implements RuntimeExtensionInterface
         return $this->insertTagParser->renderTag($insertTag)->getValue();
     }
 
-    public function replaceInsertTags(string $text, bool $asEditorView = false): string
+    public function replaceInsertTags(array $context, string $text, bool|null $asEditorView = null): string
     {
+        if (null === $asEditorView) {
+            $asEditorView = $context['as_editor_view'] ?? false;
+        }
+
         if ($asEditorView) {
             return $text;
         }
@@ -39,8 +43,12 @@ final class InsertTagRuntime implements RuntimeExtensionInterface
         return $this->insertTagParser->replaceInline($text);
     }
 
-    public function replaceInsertTagsChunkedRaw(string $text, bool $asEditorView = false): ChunkedText
+    public function replaceInsertTagsChunkedRaw(array $context, string $text, bool|null $asEditorView = null): ChunkedText
     {
+        if (null === $asEditorView) {
+            $asEditorView = $context['as_editor_view'] ?? false;
+        }
+
         if ($asEditorView) {
             return new ChunkedText([$text, '']);
         }

--- a/core-bundle/src/Twig/Runtime/InsertTagRuntime.php
+++ b/core-bundle/src/Twig/Runtime/InsertTagRuntime.php
@@ -30,22 +30,22 @@ final class InsertTagRuntime implements RuntimeExtensionInterface
         return $this->insertTagParser->renderTag($insertTag)->getValue();
     }
 
-    public function replaceInsertTags(array $context, string $text, bool|null $asEditorView = null): string
+    public function replaceInsertTags(array $context, string $text, bool|null $bypass = null): string
     {
-        $asEditorView ??= $context['as_editor_view'] ?? false;
+        $bypass ??= $context['as_editor_view'] ?? false;
 
-        if ($asEditorView) {
+        if ($bypass) {
             return $text;
         }
 
         return $this->insertTagParser->replaceInline($text);
     }
 
-    public function replaceInsertTagsChunkedRaw(array $context, string $text, bool|null $asEditorView = null): ChunkedText
+    public function replaceInsertTagsChunkedRaw(array $context, string $text, bool|null $bypass = null): ChunkedText
     {
-        $asEditorView ??= $context['as_editor_view'] ?? false;
+        $bypass ??= $context['as_editor_view'] ?? false;
 
-        if ($asEditorView) {
+        if ($bypass) {
             return new ChunkedText([$text, '']);
         }
 

--- a/core-bundle/src/Twig/Runtime/InsertTagRuntime.php
+++ b/core-bundle/src/Twig/Runtime/InsertTagRuntime.php
@@ -32,9 +32,7 @@ final class InsertTagRuntime implements RuntimeExtensionInterface
 
     public function replaceInsertTags(array $context, string $text, bool|null $asEditorView = null): string
     {
-        if (null === $asEditorView) {
-            $asEditorView = $context['as_editor_view'] ?? false;
-        }
+        $asEditorView ??= $context['as_editor_view'] ?? false;
 
         if ($asEditorView) {
             return $text;
@@ -45,9 +43,7 @@ final class InsertTagRuntime implements RuntimeExtensionInterface
 
     public function replaceInsertTagsChunkedRaw(array $context, string $text, bool|null $asEditorView = null): ChunkedText
     {
-        if (null === $asEditorView) {
-            $asEditorView = $context['as_editor_view'] ?? false;
-        }
+        $asEditorView ??= $context['as_editor_view'] ?? false;
 
         if ($asEditorView) {
             return new ChunkedText([$text, '']);

--- a/core-bundle/src/Twig/Runtime/InsertTagRuntime.php
+++ b/core-bundle/src/Twig/Runtime/InsertTagRuntime.php
@@ -30,13 +30,21 @@ final class InsertTagRuntime implements RuntimeExtensionInterface
         return $this->insertTagParser->renderTag($insertTag)->getValue();
     }
 
-    public function replaceInsertTags(string $text): string
+    public function replaceInsertTags(string $text, bool $asEditorView = false): string
     {
+        if ($asEditorView) {
+            return $text;
+        }
+
         return $this->insertTagParser->replaceInline($text);
     }
 
-    public function replaceInsertTagsChunkedRaw(string $text): ChunkedText
+    public function replaceInsertTagsChunkedRaw(string $text, bool $asEditorView = false): ChunkedText
     {
+        if ($asEditorView) {
+            return new ChunkedText([$text, '']);
+        }
+
         return $this->insertTagParser->replaceChunked($text);
     }
 }

--- a/core-bundle/tests/Twig/Runtime/InsertTagRuntimeTest.php
+++ b/core-bundle/tests/Twig/Runtime/InsertTagRuntimeTest.php
@@ -64,4 +64,30 @@ class InsertTagRuntimeTest extends TestCase
 
         $this->assertSame('<replaced-tag> foo', (string) $runtime->replaceInsertTagsChunkedRaw('{{tag}} foo'));
     }
+
+    public function testDoesNotReplaceInsertTagsInEditorView(): void
+    {
+        $insertTags = $this->createMock(InsertTagParser::class);
+        $insertTags
+            ->expects($this->never())
+            ->method('replaceInline')
+        ;
+
+        $runtime = new InsertTagRuntime($insertTags);
+
+        $this->assertSame('foo {{tag}}', $runtime->replaceInsertTags('foo {{tag}}', true));
+    }
+
+    public function testDoesNotReplaceInsertTagsChunkedRawInEditorView(): void
+    {
+        $insertTags = $this->createMock(InsertTagParser::class);
+        $insertTags
+            ->expects($this->never())
+            ->method('replaceChunked')
+        ;
+
+        $runtime = new InsertTagRuntime($insertTags);
+
+        $this->assertSame('{{tag}} foo', (string) $runtime->replaceInsertTagsChunkedRaw('{{tag}} foo', true));
+    }
 }

--- a/core-bundle/tests/Twig/Runtime/InsertTagRuntimeTest.php
+++ b/core-bundle/tests/Twig/Runtime/InsertTagRuntimeTest.php
@@ -47,7 +47,10 @@ class InsertTagRuntimeTest extends TestCase
 
         $runtime = new InsertTagRuntime($insertTags);
 
-        $this->assertSame('foo replaced-tag', $runtime->replaceInsertTags('foo {{tag}}'));
+        $this->assertSame(
+            'foo replaced-tag',
+            $runtime->replaceInsertTags(['as_editor_view' => false], 'foo {{tag}}'),
+        );
     }
 
     public function testReplaceInsertTagsChunkedRaw(): void
@@ -62,7 +65,10 @@ class InsertTagRuntimeTest extends TestCase
 
         $runtime = new InsertTagRuntime($insertTags);
 
-        $this->assertSame('<replaced-tag> foo', (string) $runtime->replaceInsertTagsChunkedRaw('{{tag}} foo'));
+        $this->assertSame(
+            '<replaced-tag> foo',
+            (string) $runtime->replaceInsertTagsChunkedRaw(['as_editor_view' => false], '{{tag}} foo'),
+        );
     }
 
     public function testDoesNotReplaceInsertTagsInEditorView(): void
@@ -75,7 +81,10 @@ class InsertTagRuntimeTest extends TestCase
 
         $runtime = new InsertTagRuntime($insertTags);
 
-        $this->assertSame('foo {{tag}}', $runtime->replaceInsertTags('foo {{tag}}', true));
+        $this->assertSame(
+            'foo {{tag}}',
+            $runtime->replaceInsertTags(['as_editor_view' => true], 'foo {{tag}}'),
+        );
     }
 
     public function testDoesNotReplaceInsertTagsChunkedRawInEditorView(): void
@@ -88,6 +97,27 @@ class InsertTagRuntimeTest extends TestCase
 
         $runtime = new InsertTagRuntime($insertTags);
 
-        $this->assertSame('{{tag}} foo', (string) $runtime->replaceInsertTagsChunkedRaw('{{tag}} foo', true));
+        $this->assertSame(
+            '{{tag}} foo',
+            (string) $runtime->replaceInsertTagsChunkedRaw(['as_editor_view' => true], '{{tag}} foo'),
+        );
+    }
+
+    public function testAllowsToOverrideTheEditorView(): void
+    {
+        $insertTags = $this->createMock(InsertTagParser::class);
+        $insertTags
+            ->expects($this->once())
+            ->method('replaceInline')
+            ->with('foo {{tag}}')
+            ->willReturn('foo replaced-tag')
+        ;
+
+        $runtime = new InsertTagRuntime($insertTags);
+
+        $this->assertSame(
+            'foo replaced-tag',
+            $runtime->replaceInsertTags(['as_editor_view' => true], 'foo {{tag}}', false),
+        );
     }
 }


### PR DESCRIPTION
Implements #6482

> Thinking this further, would it be possible setting the default value of this parameter automatically to the value of `as_editor_view`?

I decided against this for now, because there might be cases in which you want an insert tag to be always replaced, even in the back end.