### PR TITLE
Auto-generate the page aliases if multiple pages are duplicated

### DIFF
--- a/core-bundle/src/EventListener/DataContainer/PageUrlListener.php
+++ b/core-bundle/src/EventListener/DataContainer/PageUrlListener.php
@@ -94,6 +94,14 @@ class PageUrlListener
         return $value;
     }
 
+    #[AsCallback(table: 'tl_page', target: 'config.oncopy')]
+    public function generateAliasOnCopy(string $insertId, DataContainer $dc): void
+    {
+        $dc->id = (int) $insertId;
+
+        $this->connection->update('tl_page', ['alias' => $this->generateAlias('', $dc)], ['id' => $insertId]);
+    }
+
     #[AsCallback(table: 'tl_page', target: 'fields.urlPrefix.save')]
     public function validateUrlPrefix(string $value, DataContainer $dc): string
     {


### PR DESCRIPTION
This PR implements another long-running feature: https://github.com/contao/core/issues/6250

However, I still don‘t see the point of automatically generating the page aliases. They will mostly be either `original-alias-2` or `original-alias-copy`, which is just as unhelpful as no page alias at all. 🤷‍♂️ 

@contao/developers Can you think of a real use case?