### PR TITLE
Use placeholders for URLs in translation strings

### DIFF
--- a/core-bundle/src/Resources/contao/controllers/BackendMain.php
+++ b/core-bundle/src/Resources/contao/controllers/BackendMain.php
@@ -204,7 +204,7 @@ class BackendMain extends Backend
 		$objTemplate->recordOfTable = StringUtil::specialchars(str_replace("'", "\\'", $GLOBALS['TL_LANG']['MSC']['recordOfTable']));
 		$objTemplate->systemMessages = $GLOBALS['TL_LANG']['MSC']['systemMessages'];
 		$objTemplate->shortcuts = $GLOBALS['TL_LANG']['MSC']['shortcuts'][0];
-		$objTemplate->shortcutsLink = $GLOBALS['TL_LANG']['MSC']['shortcuts'][1];
+		$objTemplate->shortcutsLink = sprintf($GLOBALS['TL_LANG']['MSC']['shortcuts'][1], 'https://to.contao.org/docs/shortcuts');
 		$objTemplate->editElement = StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['editElement']);
 
 		return $objTemplate->parse();

--- a/core-bundle/src/Resources/contao/languages/en/default.xlf
+++ b/core-bundle/src/Resources/contao/languages/en/default.xlf
@@ -1197,7 +1197,7 @@
         <source>Back end keyboard shortcuts</source>
       </trans-unit>
       <trans-unit id="MSC.shortcuts.1">
-        <source>Learn more about speeding up your workflow by using &lt;a href="https://to.contao.org/shortcuts" target="_blank" rel="noreferrer noopener"&gt;keyboard shortcuts&lt;/a&gt;.</source>
+        <source>Learn more about speeding up your workflow by using &lt;a href="%s" target="_blank" rel="noreferrer noopener"&gt;keyboard shortcuts&lt;/a&gt;.</source>
       </trans-unit>
       <trans-unit id="MSC.toggleAll.0">
         <source>Toggle all</source>

--- a/core-bundle/src/Resources/contao/languages/en/exception.xlf
+++ b/core-bundle/src/Resources/contao/languages/en/exception.xlf
@@ -24,7 +24,7 @@
         <source>Open the current log file in the &lt;code&gt;var/logs&lt;/code&gt; directory and find the associated error message (usually the last one).</source>
       </trans-unit>
       <trans-unit id="XPT.errorExplain">
-        <source>The script execution stopped, because something does not work properly. The actual error message is hidden by this notice for security reasons and can be found in the current log file (see above). If you do not understand the error message or do not know how to fix the problem, visit the &lt;a href="https://to.contao.org/support" target="_blank" rel="noreferrer noopener"&gt;Contao support page&lt;/a&gt;.</source>
+        <source>The script execution stopped, because something does not work properly. The actual error message is hidden by this notice for security reasons and can be found in the current log file (see above). If you do not understand the error message or do not know how to fix the problem, visit the &lt;a href="%s" target="_blank" rel="noreferrer noopener"&gt;Contao support page&lt;/a&gt;.</source>
       </trans-unit>
       <trans-unit id="XPT.requestToken">
         <source>Invalid request token</source>
@@ -39,7 +39,7 @@
         <source>This error occurs if there is a POST request without a valid authentication token. In Contao 2.10, the referer check has been replaced with a request token system. If the problem persists, you may be using an incompatible third-party extension or have not correctly updated your Contao installation.</source>
       </trans-unit>
       <trans-unit id="XPT.tokenExplainTwo">
-        <source>For more information, visit the &lt;a href="https://to.contao.org/support" target="_blank" rel="noreferrer noopener"&gt;Contao support page&lt;/a&gt;.</source>
+        <source>For more information, visit the &lt;a href="%s" target="_blank" rel="noreferrer noopener"&gt;Contao support page&lt;/a&gt;.</source>
       </trans-unit>
       <trans-unit id="XPT.unavailable">
         <source>Service unavailable</source>

--- a/core-bundle/src/Resources/views/Error/error.html.twig
+++ b/core-bundle/src/Resources/views/Error/error.html.twig
@@ -10,5 +10,5 @@
     <p>{{ 'XPT.errorFixOne'|trans|raw }}</p>
 {% endblock %}
 {% block explain %}
-    <p>{{ 'XPT.errorExplain'|trans|raw }}</p>
+    <p>{{ 'XPT.errorExplain'|trans|format('https://to.contao.org/support')|raw }}</p>
 {% endblock %}

--- a/core-bundle/src/Resources/views/Error/error.html.twig
+++ b/core-bundle/src/Resources/views/Error/error.html.twig
@@ -10,5 +10,5 @@
     <p>{{ 'XPT.errorFixOne'|trans|raw }}</p>
 {% endblock %}
 {% block explain %}
-    <p>{{ 'XPT.errorExplain'|trans|format('https://to.contao.org/support')|raw }}</p>
+    <p>{{ 'XPT.errorExplain'|trans(['https://to.contao.org/support'])|raw }}</p>
 {% endblock %}

--- a/core-bundle/src/Resources/views/Error/invalid_request_token.html.twig
+++ b/core-bundle/src/Resources/views/Error/invalid_request_token.html.twig
@@ -11,5 +11,5 @@
 {% endblock %}
 {% block explain %}
     <p>{{ 'XPT.tokenExplainOne'|trans|raw }}</p>
-    <p>{{ 'XPT.tokenExplainTwo'|trans|raw }}</p>
+    <p>{{ 'XPT.tokenExplainTwo'|trans|format('https://to.contao.org/support')|raw }}</p>
 {% endblock %}

--- a/core-bundle/src/Resources/views/Error/invalid_request_token.html.twig
+++ b/core-bundle/src/Resources/views/Error/invalid_request_token.html.twig
@@ -11,5 +11,5 @@
 {% endblock %}
 {% block explain %}
     <p>{{ 'XPT.tokenExplainOne'|trans|raw }}</p>
-    <p>{{ 'XPT.tokenExplainTwo'|trans|format('https://to.contao.org/support')|raw }}</p>
+    <p>{{ 'XPT.tokenExplainTwo'|trans(['https://to.contao.org/support'])|raw }}</p>
 {% endblock %}

--- a/core-bundle/src/Resources/views/Error/layout.html.twig
+++ b/core-bundle/src/Resources/views/Error/layout.html.twig
@@ -159,7 +159,7 @@
     </div>
     <div id="footer">
         <div class="wrap">
-            {% block hint %}{{ 'XPT.hint'|trans|format(template)|raw }}{% endblock %}
+            {% block hint %}{{ 'XPT.hint'|trans([template])|raw }}{% endblock %}
         </div>
     </div>
 </body>

--- a/installation-bundle/src/Resources/views/configuration_error.html.twig
+++ b/installation-bundle/src/Resources/views/configuration_error.html.twig
@@ -6,10 +6,10 @@
     <h3>{{ 'an_error_occurred'|trans }}</h3>
     {% if errorCode == 1 %}
       <p class="tl_error">{{ 'unsupported_version'|trans }}</p>
-      <p>{{ 'unsupported_version_explain'|trans|format(version) }}</p>
+      <p>{{ 'unsupported_version_explain'|trans([version]) }}</p>
     {% elseif errorCode == 2 %}
       <p class="tl_error">{{ 'unsupported_collation'|trans }}</p>
-      <p>{{ 'unsupported_collation_explain'|trans|format(collation)|raw }}</p>
+      <p>{{ 'unsupported_collation_explain'|trans([collation])|raw }}</p>
       <div id="sql_wrapper">
         <pre>doctrine:
     dbal:
@@ -21,7 +21,7 @@
       </div>
     {% elseif errorCode == 3 %}
       <p class="tl_error">{{ 'unsupported_engine'|trans }}</p>
-      <p>{{ 'unsupported_engine_explain'|trans|format(engine)|raw }}</p>
+      <p>{{ 'unsupported_engine_explain'|trans([engine])|raw }}</p>
       <div id="sql_wrapper">
         <pre>doctrine:
     dbal:
@@ -33,7 +33,7 @@
       </div>
     {% elseif errorCode == 4 %}
       <p class="tl_error">{{ 'engine_mismatch'|trans }}</p>
-      <p>{{ 'engine_mismatch_explain'|trans|format(engine)|raw }}</p>
+      <p>{{ 'engine_mismatch_explain'|trans([engine])|raw }}</p>
       <div id="sql_wrapper">
         <pre>doctrine:
     dbal:

--- a/installation-bundle/src/Resources/views/main.html.twig
+++ b/installation-bundle/src/Resources/views/main.html.twig
@@ -70,7 +70,7 @@
       {% if import_error is defined %}
         <p class="tl_error">{{ import_error|nl2br }}</p>
       {% elseif import_date is defined %}
-        <p class="tl_confirm">{{ 'imported_on'|trans|format(import_date) }}</p>
+        <p class="tl_confirm">{{ 'imported_on'|trans([import_date]) }}</p>
       {% else %}
         <p class="tl_info">{{ 'import_data_will_be_deleted'|trans }}</p>
       {% endif %}


### PR DESCRIPTION
So that we can change the URLs without creating unnecessary work for the translators. See https://github.com/contao/to.contao.org/pull/80 for more information.