### PR TITLE
Also check for dynamic ptable in picker provider

### DIFF
--- a/core-bundle/src/Picker/AbstractTablePickerProvider.php
+++ b/core-bundle/src/Picker/AbstractTablePickerProvider.php
@@ -44,7 +44,7 @@ abstract class AbstractTablePickerProvider implements PickerProviderInterface, D
         }
 
         $module = array_keys($modules)[0];
-        [$ptable, $pid] = $this->getPtableAndPid($table, $config->getValue());
+        [$ptable, $pid, $dynamicPtable] = $this->getPtableAndPid($table, $config->getValue());
 
         if ($ptable) {
             foreach ($modules as $key => $tables) {
@@ -61,7 +61,7 @@ abstract class AbstractTablePickerProvider implements PickerProviderInterface, D
         }
 
         // If the pid is missing for a child table do not add table=xy to the URL
-        if ($ptable && !$pid) {
+        if (($ptable || $dynamicPtable) && !$pid) {
             return $this->getUrlForValue($config, $module);
         }
 
@@ -208,10 +208,10 @@ abstract class AbstractTablePickerProvider implements PickerProviderInterface, D
         $this->framework->createInstance(DcaLoader::class, [$table])->load();
 
         $ptable = $GLOBALS['TL_DCA'][$table]['config']['ptable'] ?? null;
-        $dynamicPtable = $GLOBALS['TL_DCA'][$table]['config']['dynamicPtable'] ?? false;
+        $dynamicPtable = (bool) ($GLOBALS['TL_DCA'][$table]['config']['dynamicPtable'] ?? false);
 
         if (!$ptable && !$dynamicPtable) {
-            return [null, null];
+            return [null, null, $dynamicPtable];
         }
 
         $data = false;
@@ -232,10 +232,10 @@ abstract class AbstractTablePickerProvider implements PickerProviderInterface, D
         }
 
         if (false === $data) {
-            return [$ptable, null];
+            return [$ptable, null, $dynamicPtable];
         }
 
-        return [$ptable, (int) $data['pid']];
+        return [$ptable, (int) $data['pid'], $dynamicPtable];
     }
 
     /**


### PR DESCRIPTION
Fixes #6504

Currently if you open a picker without an existing value as described in #6504 the picker generates a URL like `contao?do=article&popup=1&picker=…,&table=tl_content` which would open the `tl_content` view without having a parent ID which is invalid (and makes the permission check fail as the parent ID is `null`).

For this case there is already a check present in the `AbstractTablePickerProvider` but it only checks for `ptable` and not `dynamicPtable`.