### PR TITLE
Fix undefined array key warning in `DC_Table::deleteAll`

### DIFF
--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -1593,7 +1593,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 		$session = $objSession->all();
 		$ids = $session['CURRENT']['IDS'] ?? array();
 
-		if (\is_array($ids) && \strlen($ids[0]))
+		if (\is_array($ids) && \array_filter($ids))
 		{
 			foreach ($ids as $id)
 			{

--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -1593,7 +1593,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 		$session = $objSession->all();
 		$ids = $session['CURRENT']['IDS'] ?? array();
 
-		if (\is_array($ids) && \array_filter($ids))
+		if (\is_array($ids) && array_filter($ids))
 		{
 			foreach ($ids as $id)
 			{


### PR DESCRIPTION
If you have 2 content elements where the second is a `cteAlias` that references the first - and then you want to delete both via edit multiple, the following error will occur:

```
ErrorException:
Warning: Undefined array key 0

  at vendor\contao\contao\core-bundle\src\Resources\contao\drivers\DC_Table.php:1596
  at Contao\DC_Table->deleteAll()
     (vendor\contao\contao\core-bundle\src\Resources\contao\classes\Backend.php:667)
```

This happens because the referenced element will be automatically removed form `$session['CURRENT']['IDS']`. The error would also occur if `$session['CURRENT']['IDS']` is not defined or null (for whatever reason). As discussed with @ausi the original intention of the `\strlen($ids[0])` check was probably to ignore a singular empty array value (which apparently might happen under some circumstances).

This PR fixes that by using `\array_filter` instead.