### PR TITLE
Automatically load routes in app controllers

### DIFF
--- a/manager-bundle/src/Routing/RouteLoader.php
+++ b/manager-bundle/src/Routing/RouteLoader.php
@@ -48,6 +48,12 @@ class RouteLoader implements RouteLoaderInterface
             if ($routes instanceof RouteCollection) {
                 $collection->addCollection($routes);
             }
+        } elseif (is_dir($path = Path::join($this->projectDir, 'src/Controller'))) {
+            $routes = $this->loader->getResolver()->resolve($path)->load($path);
+
+            if ($routes instanceof RouteCollection) {
+                $collection->addCollection($routes);
+            }
         }
 
         $collection = array_reduce(

--- a/manager-bundle/tests/Fixtures/Routing/WithAppController/src/Controller/BarController.php
+++ b/manager-bundle/tests/Fixtures/Routing/WithAppController/src/Controller/BarController.php
@@ -2,6 +2,14 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
 namespace App\Controller;
 
 use Symfony\Component\HttpFoundation\Response;

--- a/manager-bundle/tests/Fixtures/Routing/WithAppController/src/Controller/BarController.php
+++ b/manager-bundle/tests/Fixtures/Routing/WithAppController/src/Controller/BarController.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+#[Route(path: '/bar', name: 'bar')]
+class BarController
+{
+    public function __invoke(): Response
+    {
+        return new Response('bar');
+    }
+}

--- a/manager-bundle/tests/Fixtures/Routing/WithRoutingYaml/config/routes.yaml
+++ b/manager-bundle/tests/Fixtures/Routing/WithRoutingYaml/config/routes.yaml
@@ -1,0 +1,2 @@
+App:
+    resource: ../src/Controller

--- a/manager-bundle/tests/Routing/RouteLoaderTest.php
+++ b/manager-bundle/tests/Routing/RouteLoaderTest.php
@@ -33,7 +33,7 @@ class RouteLoaderTest extends ContaoTestCase
         $loader
             ->expects($this->once())
             ->method('load')
-            ->with(dirname(__DIR__).'/Fixtures/Routing/WithRoutingYaml/config/routes.yaml')
+            ->with(\dirname(__DIR__).'/Fixtures/Routing/WithRoutingYaml/config/routes.yaml')
         ;
 
         $loaderResolver = $this->createMock(LoaderResolverInterface::class);
@@ -74,7 +74,7 @@ class RouteLoaderTest extends ContaoTestCase
         $loader
             ->expects($this->once())
             ->method('load')
-            ->with(dirname(__DIR__).'/Fixtures/Routing/WithAppController/src/Controller')
+            ->with(\dirname(__DIR__).'/Fixtures/Routing/WithAppController/src/Controller')
         ;
 
         $loaderResolver = $this->createMock(LoaderResolverInterface::class);

--- a/manager-bundle/tests/Routing/RouteLoaderTest.php
+++ b/manager-bundle/tests/Routing/RouteLoaderTest.php
@@ -20,11 +20,95 @@ use Contao\TestCase\ContaoTestCase;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\Config\Loader\LoaderResolverInterface;
+use Symfony\Component\Routing\Loader\AnnotationDirectoryLoader;
+use Symfony\Component\Routing\Loader\YamlFileLoader;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
 
 class RouteLoaderTest extends ContaoTestCase
 {
+    public function testLoadsRoutesYaml(): void
+    {
+        $loader = $this->createMock(YamlFileLoader::class);
+        $loader
+            ->expects($this->once())
+            ->method('load')
+            ->with(dirname(__DIR__).'/Fixtures/Routing/WithRoutingYaml/config/routes.yaml')
+        ;
+
+        $loaderResolver = $this->createMock(LoaderResolverInterface::class);
+        $loaderResolver
+            ->expects($this->once())
+            ->method('resolve')
+            ->willReturn($loader)
+        ;
+
+        $loader = $this->createMock(LoaderInterface::class);
+        $loader
+            ->expects($this->exactly(1))
+            ->method('getResolver')
+            ->willReturn($loaderResolver)
+        ;
+
+        $pluginLoader = $this->createMock(PluginLoader::class);
+        $pluginLoader
+            ->expects($this->once())
+            ->method('getInstancesOf')
+            ->with(PluginLoader::ROUTING_PLUGINS, true)
+            ->willReturn([])
+        ;
+
+        $routeLoader = new RouteLoader(
+            $loader,
+            $pluginLoader,
+            $this->createMock(ContaoKernel::class),
+            __DIR__.'/../Fixtures/Routing/WithRoutingYaml',
+        );
+
+        $routeLoader->loadFromPlugins();
+    }
+
+    public function testLoadsAppController(): void
+    {
+        $loader = $this->createMock(AnnotationDirectoryLoader::class);
+        $loader
+            ->expects($this->once())
+            ->method('load')
+            ->with(dirname(__DIR__).'/Fixtures/Routing/WithAppController/src/Controller')
+        ;
+
+        $loaderResolver = $this->createMock(LoaderResolverInterface::class);
+        $loaderResolver
+            ->expects($this->once())
+            ->method('resolve')
+            ->willReturn($loader)
+        ;
+
+        $loader = $this->createMock(LoaderInterface::class);
+        $loader
+            ->expects($this->exactly(1))
+            ->method('getResolver')
+            ->willReturn($loaderResolver)
+        ;
+
+        $pluginLoader = $this->createMock(PluginLoader::class);
+        $pluginLoader
+            ->expects($this->once())
+            ->method('getInstancesOf')
+            ->with(PluginLoader::ROUTING_PLUGINS, true)
+            ->willReturn([])
+        ;
+
+        $routeLoader = new RouteLoader(
+            $loader,
+            $pluginLoader,
+            $this->createMock(ContaoKernel::class),
+            __DIR__.'/../Fixtures/Routing/WithAppController',
+        );
+
+        $routeLoader->loadFromPlugins();
+    }
+
     public function testLoadFromPlugins(): void
     {
         $loaderResolver = $this->createMock(LoaderResolverInterface::class);


### PR DESCRIPTION
If you have controllers with Symfony routes, you currently need to manually add a `routes.yaml` to your project to load that folder. This would automatically load controller routes if no `routes.yaml` exists. Loading both is problematic because they could override each other.