### PR TITLE
Bubble the back end log entries to file logs

### DIFF
--- a/core-bundle/src/Resources/config/services.yml
+++ b/core-bundle/src/Resources/config/services.yml
@@ -453,9 +453,6 @@ services:
 
     contao.monolog.handler:
         class: Contao\CoreBundle\Monolog\ContaoTableHandler
-        arguments:
-            - debug
-            - true
         tags:
             - { name: monolog.logger, channel: contao }
 

--- a/core-bundle/src/Resources/config/services.yml
+++ b/core-bundle/src/Resources/config/services.yml
@@ -455,7 +455,7 @@ services:
         class: Contao\CoreBundle\Monolog\ContaoTableHandler
         arguments:
             - debug
-            - false
+            - true
         tags:
             - { name: monolog.logger, channel: contao }
 


### PR DESCRIPTION
Currently, if something is logged to the Contao back end, it does not appear in the log files. With this change it will.