### PR TITLE
Register a web processor to add log extras

### DIFF
--- a/core-bundle/config/services.yaml
+++ b/core-bundle/config/services.yaml
@@ -557,14 +557,6 @@ services:
             - '@security.token_storage'
             - '@contao.routing.scope_matcher'
 
-    contao.monolog.web_processor:
-        class: Symfony\Bridge\Monolog\Processor\WebProcessor
-        arguments:
-            - { url: REQUEST_URI }
-        tags:
-            - { name: monolog.processor }
-            - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest }
-
     contao.opt_in:
         class: Contao\CoreBundle\OptIn\OptIn
         public: true

--- a/core-bundle/config/services.yaml
+++ b/core-bundle/config/services.yaml
@@ -557,6 +557,14 @@ services:
             - '@security.token_storage'
             - '@contao.routing.scope_matcher'
 
+    contao.monolog.web_processor:
+        class: Symfony\Bridge\Monolog\Processor\WebProcessor
+        arguments:
+            - { url: REQUEST_URI }
+        tags:
+            - { name: monolog.processor }
+            - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest }
+
     contao.opt_in:
         class: Contao\CoreBundle\OptIn\OptIn
         public: true

--- a/manager-bundle/config/services.yaml
+++ b/manager-bundle/config/services.yaml
@@ -54,6 +54,14 @@ services:
         tags:
             - { name: doctrine.event_listener, event: onSchemaAlterTableRenameColumn }
 
+    contao_manager.monolog.web_processor:
+        class: Symfony\Bridge\Monolog\Processor\WebProcessor
+        arguments:
+            - { request_uri: REQUEST_URI, request_method: REQUEST_METHOD }
+        tags:
+            - { name: monolog.processor }
+            - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest }
+
     contao_manager.plugin_loader:
         public: true
         synthetic: true


### PR DESCRIPTION
This adds the current request URL to every log entry, making it possible to see where an error occurent in the website.