### PR TITLE
Allow HEIC image format

### DIFF
--- a/core-bundle/src/DependencyInjection/Configuration.php
+++ b/core-bundle/src/DependencyInjection/Configuration.php
@@ -342,7 +342,7 @@ class Configuration implements ConfigurationInterface
                 ->end()
                 ->arrayNode('valid_extensions')
                     ->prototype('scalar')->end()
-                    ->defaultValue(['jpg', 'jpeg', 'gif', 'png', 'tif', 'tiff', 'bmp', 'svg', 'svgz', 'webp'])
+                    ->defaultValue(['jpg', 'jpeg', 'gif', 'png', 'tif', 'tiff', 'bmp', 'svg', 'svgz', 'webp', 'heic'])
                 ->end()
                 ->arrayNode('preview')
                     ->addDefaultsIfNotSet()


### PR DESCRIPTION
In `tl_image_size::getSupportedFormats()` we specifically check for `heic` (amongst others).

https://github.com/contao/contao/blob/0435a23d21a1c22fbc7e595fe5b3f56b91a42a2b/core-bundle/src/Resources/contao/dca/tl_image_size.php#L455-L463

However, in `tl_image_size::getFormats()` (the `options_callback` for `tl_image_size.formats`) we then filter these options according to `contao.image.valid_extensions`.

https://github.com/contao/contao/blob/0435a23d21a1c22fbc7e595fe5b3f56b91a42a2b/core-bundle/src/Resources/contao/dca/tl_image_size.php#L405-L410

I think we should add `heic` to the `contao.image.valid_extensions` by default as dealing with that image format is more common now (due to Apple devices). Also Instagram's API provides the images in HEIC (although allegedly these are just JPEGs with the wrong file extension; I haven't validated this). Thus there is a need to convert these images to `jpg` and `webp` for displaying them on a web page.

@ausi wdyt?