### PR TITLE
Add method to transform Contao URL to UrlUtil

### DIFF
--- a/calendar-bundle/contao/modules/ModuleEventReader.php
+++ b/calendar-bundle/contao/modules/ModuleEventReader.php
@@ -118,8 +118,7 @@ class ModuleEventReader extends Events
 			case 'external':
 				if ($objEvent->url)
 				{
-					$url = System::getContainer()->get('contao.insert_tag.parser')->replaceInline($objEvent->url);
-					$url = UrlUtil::makeAbsolute($url, Environment::get('base'));
+					$url = System::getContainer()->get('contao.url_util')->parseContaoUrl($objEvent->url);
 
 					throw new RedirectResponseException($url, 301);
 				}

--- a/calendar-bundle/contao/modules/ModuleEventReader.php
+++ b/calendar-bundle/contao/modules/ModuleEventReader.php
@@ -14,7 +14,6 @@ use Contao\CoreBundle\Exception\InternalServerErrorException;
 use Contao\CoreBundle\Exception\PageNotFoundException;
 use Contao\CoreBundle\Exception\RedirectResponseException;
 use Contao\CoreBundle\Routing\ResponseContext\HtmlHeadBag\HtmlHeadBag;
-use Contao\CoreBundle\Util\UrlUtil;
 
 /**
  * Front end module "event reader".
@@ -119,6 +118,7 @@ class ModuleEventReader extends Events
 				if ($objEvent->url)
 				{
 					$url = System::getContainer()->get('contao.url_util')->parseContaoUrl($objEvent->url);
+
 
 					throw new RedirectResponseException($url, 301);
 				}

--- a/core-bundle/config/services.yaml
+++ b/core-bundle/config/services.yaml
@@ -760,8 +760,7 @@ services:
             - '@event_dispatcher'
             - '@contao.security.token_checker'
             - '@contao.string.html_decoder'
-            - '@request_stack'
-            - '@contao.insert_tag.parser'
+            - '@contao.url_util'
 
     contao.routing.route_404_provider:
         class: Contao\CoreBundle\Routing\Route404Provider
@@ -1149,6 +1148,13 @@ services:
         arguments:
             - '@request_stack'
 
+    contao.url_util:
+        class: Contao\CoreBundle\Util\UrlUtil
+        public: true
+        arguments:
+            - '@contao.insert_tag.parser'
+            - '@request_stack'
+
     # Autowiring aliases
     Contao\CoreBundle\Cache\EntityCacheTags: '@contao.cache.entity_tags'
     Contao\CoreBundle\Config\ResourceFinderInterface: '@contao.resource_finder'
@@ -1180,3 +1186,4 @@ services:
     Contao\CoreBundle\Twig\Interop\ContextFactory: '@contao.twig.interop.context_factory'
     Contao\CoreBundle\Twig\Loader\ContaoFilesystemLoader: '@contao.twig.filesystem_loader'
     Contao\CoreBundle\Util\ProcessUtil: '@contao.process_util'
+    Contao\CoreBundle\Util\UrlUtil: '@contao.url_util'

--- a/core-bundle/config/services.yaml
+++ b/core-bundle/config/services.yaml
@@ -1153,7 +1153,7 @@ services:
         public: true
         arguments:
             - '@contao.insert_tag.parser'
-            - '@request_stack'
+            - '@router.request_context'
 
     # Autowiring aliases
     Contao\CoreBundle\Cache\EntityCacheTags: '@contao.cache.entity_tags'

--- a/core-bundle/contao/pages/PageRedirect.php
+++ b/core-bundle/contao/pages/PageRedirect.php
@@ -29,8 +29,7 @@ class PageRedirect extends Frontend
 	{
 		$this->prepare($objPage);
 
-		$url = System::getContainer()->get('contao.insert_tag.parser')->replaceInline($objPage->url);
-		$url = UrlUtil::makeAbsolute($url, Environment::get('base'));
+		$url = System::getContainer()->get('contao.url_util')->parseContaoUrl($objPage->url);
 
 		return new RedirectResponse($url, $this->getRedirectStatusCode($objPage));
 	}

--- a/core-bundle/contao/pages/PageRedirect.php
+++ b/core-bundle/contao/pages/PageRedirect.php
@@ -10,7 +10,6 @@
 
 namespace Contao;
 
-use Contao\CoreBundle\Util\UrlUtil;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 
 /**

--- a/core-bundle/src/Routing/ResponseContext/CoreResponseContextFactory.php
+++ b/core-bundle/src/Routing/ResponseContext/CoreResponseContextFactory.php
@@ -31,8 +31,7 @@ class CoreResponseContextFactory
         private readonly EventDispatcherInterface $eventDispatcher,
         private readonly TokenChecker $tokenChecker,
         private readonly HtmlDecoder $htmlDecoder,
-        private readonly RequestStack $requestStack,
-        private readonly InsertTagParser $insertTagParser,
+        private readonly UrlUtil $urlUtil,
     ) {
     }
 
@@ -82,18 +81,7 @@ class CoreResponseContextFactory
         }
 
         if ($pageModel->enableCanonical && $pageModel->canonicalLink) {
-            $url = $this->insertTagParser->replaceInline($pageModel->canonicalLink);
-
-            // Ensure absolute links
-            if (!preg_match('#^https?://#', $url)) {
-                if (!$request = $this->requestStack->getCurrentRequest()) {
-                    throw new \RuntimeException('The request stack did not contain a request');
-                }
-
-                $url = UrlUtil::makeAbsolute($url, $request->getUri());
-            }
-
-            $htmlHeadBag->setCanonicalUri($url);
+            $htmlHeadBag->setCanonicalUri($this->urlUtil->parseContaoUrl($pageModel->canonicalLink));
         }
 
         if ($pageModel->enableCanonical && $pageModel->canonicalKeepParams) {

--- a/core-bundle/src/Routing/ResponseContext/CoreResponseContextFactory.php
+++ b/core-bundle/src/Routing/ResponseContext/CoreResponseContextFactory.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Routing\ResponseContext;
 
-use Contao\CoreBundle\InsertTag\InsertTagParser;
 use Contao\CoreBundle\Routing\ResponseContext\HtmlHeadBag\HtmlHeadBag;
 use Contao\CoreBundle\Routing\ResponseContext\JsonLd\ContaoPageSchema;
 use Contao\CoreBundle\Routing\ResponseContext\JsonLd\JsonLdManager;
@@ -21,7 +20,6 @@ use Contao\CoreBundle\String\HtmlDecoder;
 use Contao\CoreBundle\Util\UrlUtil;
 use Contao\PageModel;
 use Spatie\SchemaOrg\WebPage;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 class CoreResponseContextFactory

--- a/core-bundle/src/Util/UrlUtil.php
+++ b/core-bundle/src/Util/UrlUtil.php
@@ -15,28 +15,20 @@ namespace Contao\CoreBundle\Util;
 use Contao\CoreBundle\InsertTag\InsertTagParser;
 use Nyholm\Psr7\Uri;
 use Symfony\Component\Filesystem\Path;
-use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Routing\RequestContext;
 
 class UrlUtil
 {
     public function __construct(
         private readonly InsertTagParser $insertTagParser,
-        private readonly RequestStack $requestStack,
+        private readonly RequestContext $requestContext,
     ) {
     }
 
     public function parseContaoUrl(string $url): string
     {
         $url = $this->insertTagParser->replaceInline($url);
-
-        // Ensure absolute links
-        if (!preg_match('#^https?://#', $url)) {
-            if (!$request = $this->requestStack->getCurrentRequest()) {
-                throw new \RuntimeException('The request stack did not contain a request');
-            }
-
-            $url = static::makeAbsolute($url, $request->getUri());
-        }
+        $url = static::makeAbsolute($url, $this->requestContext->getBaseUrl());
 
         return $url;
     }

--- a/core-bundle/src/Util/UrlUtil.php
+++ b/core-bundle/src/Util/UrlUtil.php
@@ -12,11 +12,35 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Util;
 
+use Contao\CoreBundle\InsertTag\InsertTagParser;
 use Nyholm\Psr7\Uri;
 use Symfony\Component\Filesystem\Path;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 class UrlUtil
 {
+    public function __construct(
+        private readonly InsertTagParser $insertTagParser,
+        private readonly RequestStack $requestStack,
+    ) {
+    }
+
+    public function parseContaoUrl(string $url): string
+    {
+        $url = $this->insertTagParser->replaceInline($url);
+
+        // Ensure absolute links
+        if (!preg_match('#^https?://#', $url)) {
+            if (!$request = $this->requestStack->getCurrentRequest()) {
+                throw new \RuntimeException('The request stack did not contain a request');
+            }
+
+            $url = static::makeAbsolute($url, $request->getUri());
+        }
+
+        return $url;
+    }
+
     /**
      * Creates an absolute URL from the given relative and base URL according to the URL standard.
      *

--- a/core-bundle/tests/Util/UrlUtilTest.php
+++ b/core-bundle/tests/Util/UrlUtilTest.php
@@ -15,8 +15,7 @@ namespace Contao\CoreBundle\Tests\Util;
 use Contao\CoreBundle\InsertTag\InsertTagParser;
 use Contao\CoreBundle\Tests\TestCase;
 use Contao\CoreBundle\Util\UrlUtil;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Routing\RequestContext;
 
 class UrlUtilTest extends TestCase
 {
@@ -33,10 +32,14 @@ class UrlUtilTest extends TestCase
             ->willReturn($url)
         ;
 
-        $requestStack = new RequestStack();
-        $requestStack->push(Request::create('https://example.com/'));
+        $requestContext = $this->createMock(RequestContext::class);
+        $requestContext
+            ->expects($this->once())
+            ->method('getBaseUrl')
+            ->willReturn('https://example.com/')
+        ;
 
-        $urlUtil = new UrlUtil($insertTagsParser, $requestStack);
+        $urlUtil = new UrlUtil($insertTagsParser, $requestContext);
 
         $this->assertSame($expected, $urlUtil->parseContaoUrl('{{link_url::42}}'));
     }

--- a/news-bundle/contao/modules/ModuleNewsReader.php
+++ b/news-bundle/contao/modules/ModuleNewsReader.php
@@ -14,7 +14,6 @@ use Contao\CoreBundle\Exception\InternalServerErrorException;
 use Contao\CoreBundle\Exception\PageNotFoundException;
 use Contao\CoreBundle\Exception\RedirectResponseException;
 use Contao\CoreBundle\Routing\ResponseContext\HtmlHeadBag\HtmlHeadBag;
-use Contao\CoreBundle\Util\UrlUtil;
 
 /**
  * Front end module "newsreader".

--- a/news-bundle/contao/modules/ModuleNewsReader.php
+++ b/news-bundle/contao/modules/ModuleNewsReader.php
@@ -114,8 +114,7 @@ class ModuleNewsReader extends ModuleNews
 			case 'external':
 				if ($objArticle->url)
 				{
-					$url = System::getContainer()->get('contao.insert_tag.parser')->replaceInline($objArticle->url);
-					$url = UrlUtil::makeAbsolute($url, Environment::get('base'));
+					$url = System::getContainer()->get('contao.url_util')->parseContaoUrl($objArticle->url);
 
 					throw new RedirectResponseException($url, 301);
 				}


### PR DESCRIPTION
I tried implementing what we discussed today in https://github.com/contao/contao/pull/6215#issuecomment-1814811583 but realized that's absolutely not what we need. We only need a universal service to parse Contao URL... because that's the code we need to reuse all over the place, likely in a lot of other places as well.

I don't really like the method name `parseContaoUrl` but I couldn't come up with anything better yet … @contao/developers any ideas?