### PR TITLE
UrlResolver service

### DIFF
--- a/calendar-bundle/contao/classes/Calendar.php
+++ b/calendar-bundle/contao/classes/Calendar.php
@@ -373,14 +373,7 @@ class Calendar extends Frontend
 		switch ($objEvent->source)
 		{
 			case 'external':
-				$url = $objEvent->url;
-
-				if (Validator::isRelativeUrl($url))
-				{
-					$url = Environment::get('path') . '/' . $url;
-				}
-
-				$link = $url;
+				$link = System::getContainer()->get('contao.routing.url_resolver')->resolve($objEvent->url);
 				break;
 
 			case 'internal':

--- a/calendar-bundle/contao/classes/Events.php
+++ b/calendar-bundle/contao/classes/Events.php
@@ -422,14 +422,7 @@ abstract class Events extends Module
 				}
 				else
 				{
-					$url = $objEvent->url;
-
-					if (Validator::isRelativeUrl($url))
-					{
-						$url = Environment::get('path') . '/' . $url;
-					}
-
-					self::$arrUrlCache[$strCacheKey] = StringUtil::ampersand($url);
+					self::$arrUrlCache[$strCacheKey] = StringUtil::ampersand(System::getContainer()->get('contao.routing.url_resolver')->resolve($objEvent->url));
 				}
 				break;
 

--- a/calendar-bundle/contao/modules/ModuleEventReader.php
+++ b/calendar-bundle/contao/modules/ModuleEventReader.php
@@ -14,7 +14,6 @@ use Contao\CoreBundle\Exception\InternalServerErrorException;
 use Contao\CoreBundle\Exception\PageNotFoundException;
 use Contao\CoreBundle\Exception\RedirectResponseException;
 use Contao\CoreBundle\Routing\ResponseContext\HtmlHeadBag\HtmlHeadBag;
-use Contao\CoreBundle\Util\UrlUtil;
 
 /**
  * Front end module "event reader".
@@ -118,8 +117,7 @@ class ModuleEventReader extends Events
 			case 'external':
 				if ($objEvent->url)
 				{
-					$url = System::getContainer()->get('contao.insert_tag.parser')->replaceInline($objEvent->url);
-					$url = UrlUtil::makeAbsolute($url, Environment::get('base'));
+					$url = System::getContainer()->get('contao.routing.url_resolver')->resolve($objEvent->url, true);
 
 					throw new RedirectResponseException($url, 301);
 				}

--- a/core-bundle/config/controller.yaml
+++ b/core-bundle/config/controller.yaml
@@ -83,7 +83,7 @@ services:
     Contao\CoreBundle\Controller\ContentElement\HyperlinkController:
         arguments:
             - '@contao.image.studio'
-            - '@contao.insert_tag.parser'
+            - '@contao.routing.url_resolver'
 
     Contao\CoreBundle\Controller\ContentElement\ImagesController:
         arguments:

--- a/core-bundle/config/services.yaml
+++ b/core-bundle/config/services.yaml
@@ -760,8 +760,7 @@ services:
             - '@event_dispatcher'
             - '@contao.security.token_checker'
             - '@contao.string.html_decoder'
-            - '@request_stack'
-            - '@contao.insert_tag.parser'
+            - '@contao.routing.url_resolver'
 
     contao.routing.route_404_provider:
         class: Contao\CoreBundle\Routing\Route404Provider
@@ -786,6 +785,14 @@ services:
 
     contao.routing.url_matcher:
         class: Contao\CoreBundle\Routing\Matcher\UrlMatcher
+
+    contao.routing.url_resolver:
+        class: Contao\CoreBundle\Routing\UrlResolver
+        public: true
+        arguments:
+            - '@contao.insert_tag.parser'
+            - '@router.request_context'
+            - '@request_stack'
 
     contao.search.default_indexer:
         class: Contao\CoreBundle\Search\Indexer\DefaultIndexer
@@ -1169,6 +1176,7 @@ services:
     Contao\CoreBundle\Routing\Page\PageRegistry: '@contao.routing.page_registry'
     Contao\CoreBundle\Routing\ResponseContext\ResponseContextAccessor: '@contao.routing.response_context_accessor'
     Contao\CoreBundle\Routing\ScopeMatcher: '@contao.routing.scope_matcher'
+    Contao\CoreBundle\Routing\UrlResolver: '@contao.routing.url_resolver'
     Contao\CoreBundle\Security\Authentication\Token\TokenChecker: '@contao.security.token_checker'
     Contao\CoreBundle\Security\TwoFactor\Authenticator: '@contao.security.two_factor.authenticator'
     Contao\CoreBundle\Security\TwoFactor\BackupCodeManager: '@contao.security.two_factor.backup_code_manager'

--- a/core-bundle/contao/models/FilesModel.php
+++ b/core-bundle/contao/models/FilesModel.php
@@ -444,7 +444,7 @@ class FilesModel extends Model
 			// Make sure we resolve insert tags pointing to files
 			if (isset($data[Metadata::VALUE_URL]))
 			{
-				$data[Metadata::VALUE_URL] = System::getContainer()->get('contao.insert_tag.parser')->replaceInline($data[Metadata::VALUE_URL] ?? '');
+				$data[Metadata::VALUE_URL] = System::getContainer()->get('contao.routing.url_resolver')->resolve($data[Metadata::VALUE_URL] ?? '');
 			}
 
 			// Fill missing meta fields with empty values

--- a/core-bundle/contao/pages/PageRedirect.php
+++ b/core-bundle/contao/pages/PageRedirect.php
@@ -10,7 +10,6 @@
 
 namespace Contao;
 
-use Contao\CoreBundle\Util\UrlUtil;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 
 /**
@@ -29,8 +28,7 @@ class PageRedirect extends Frontend
 	{
 		$this->prepare($objPage);
 
-		$url = System::getContainer()->get('contao.insert_tag.parser')->replaceInline($objPage->url);
-		$url = UrlUtil::makeAbsolute($url, Environment::get('base'));
+		$url = System::getContainer()->get('contao.routing.url_resolver')->resolve($objPage->url, true);
 
 		return new RedirectResponse($url, $this->getRedirectStatusCode($objPage));
 	}

--- a/core-bundle/src/Controller/ContentElement/HyperlinkController.php
+++ b/core-bundle/src/Controller/ContentElement/HyperlinkController.php
@@ -15,10 +15,9 @@ namespace Contao\CoreBundle\Controller\ContentElement;
 use Contao\ContentModel;
 use Contao\CoreBundle\DependencyInjection\Attribute\AsContentElement;
 use Contao\CoreBundle\Image\Studio\Studio;
-use Contao\CoreBundle\InsertTag\InsertTagParser;
+use Contao\CoreBundle\Routing\UrlResolver;
 use Contao\CoreBundle\String\HtmlAttributes;
 use Contao\CoreBundle\Twig\FragmentTemplate;
-use Contao\Validator;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -27,18 +26,13 @@ class HyperlinkController extends AbstractContentElementController
 {
     public function __construct(
         private readonly Studio $studio,
-        private readonly InsertTagParser $insertTagParser,
+        private readonly UrlResolver $urlResolver,
     ) {
     }
 
     protected function getResponse(FragmentTemplate $template, ContentModel $model, Request $request): Response
     {
-        // Link with attributes
-        $href = $this->insertTagParser->replaceInline($model->url ?? '');
-
-        if (Validator::isRelativeUrl($href)) {
-            $href = $request->getBasePath().'/'.$href;
-        }
+        $href = $this->urlResolver->resolve($model->url ?? '');
 
         $linkAttributes = (new HtmlAttributes())
             ->set('href', $href)

--- a/core-bundle/src/Controller/ContentElement/MarkdownController.php
+++ b/core-bundle/src/Controller/ContentElement/MarkdownController.php
@@ -16,7 +16,7 @@ use Contao\Config;
 use Contao\ContentModel;
 use Contao\CoreBundle\DependencyInjection\Attribute\AsContentElement;
 use Contao\CoreBundle\InsertTag\CommonMarkExtension;
-use Contao\CoreBundle\InsertTag\InsertTagParser;
+use Contao\CoreBundle\Routing\UrlResolver;
 use Contao\FilesModel;
 use Contao\Input;
 use Contao\Template;
@@ -40,7 +40,7 @@ class MarkdownController extends AbstractContentElementController
     {
         $services = parent::getSubscribedServices();
 
-        $services['contao.insert_tag.parser'] = InsertTagParser::class;
+        $services['contao.routing.url_resolver'] = UrlResolver::class;
 
         return $services;
     }
@@ -85,7 +85,7 @@ class MarkdownController extends AbstractContentElementController
             ],
         ]);
 
-        $environment->addExtension(new CommonMarkExtension($this->container->get('contao.insert_tag.parser')));
+        $environment->addExtension(new CommonMarkExtension($this->container->get('contao.routing.url_resolver')));
         $environment->addExtension(new CommonMarkCoreExtension());
 
         // Support GitHub flavoured Markdown (using the individual extensions because we don't want the

--- a/core-bundle/src/File/ModelMetadataTrait.php
+++ b/core-bundle/src/File/ModelMetadataTrait.php
@@ -54,7 +54,7 @@ trait ModelMetadataTrait
 
         // Make sure we resolve insert tags pointing to files
         if (isset($data[Metadata::VALUE_URL])) {
-            $data[Metadata::VALUE_URL] = System::getContainer()->get('contao.insert_tag.parser')->replaceInline($data[Metadata::VALUE_URL] ?? '');
+            $data[Metadata::VALUE_URL] = System::getContainer()->get('contao.routing.url_resolver')->resolve($data[Metadata::VALUE_URL] ?? '');
         }
 
         // Strip superfluous fields by intersecting with tl_files.meta.eval.metaFields

--- a/core-bundle/src/InsertTag/CommonMarkExtension.php
+++ b/core-bundle/src/InsertTag/CommonMarkExtension.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\InsertTag;
 
+use Contao\CoreBundle\Routing\UrlResolver;
 use League\CommonMark\Environment\EnvironmentBuilderInterface;
 use League\CommonMark\Event\DocumentParsedEvent;
 use League\CommonMark\Extension\CommonMark\Node\Inline\Link;
@@ -20,7 +21,7 @@ use League\CommonMark\Util\UrlEncoder;
 
 class CommonMarkExtension implements ExtensionInterface
 {
-    public function __construct(private readonly InsertTagParser $insertTagParser)
+    public function __construct(private readonly UrlResolver $urlResolver)
     {
     }
 
@@ -37,7 +38,7 @@ class CommonMarkExtension implements ExtensionInterface
                     // Parser already encodes link contents, so we have to
                     // decode it first in order to replace insert tags
                     $url = rawurldecode($link->getUrl());
-                    $url = $this->insertTagParser->replaceInline($url);
+                    $url = $this->urlResolver->resolve($url);
 
                     $link->setUrl(UrlEncoder::unescapeAndEncode($url));
                 }

--- a/core-bundle/src/Routing/UrlResolver.php
+++ b/core-bundle/src/Routing/UrlResolver.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Routing;
+
+use Contao\CoreBundle\InsertTag\InsertTagParser;
+use Contao\CoreBundle\Util\UrlUtil;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Routing\RequestContext;
+
+class UrlResolver
+{
+    public function __construct(
+        private readonly InsertTagParser $insertTagParser,
+        private readonly RequestContext $requestContext,
+        private readonly RequestStack $requestStack,
+    ) {
+    }
+
+    /**
+     * Resolves insert tags in the given URL and converts it to an absolute or
+     * path-absolute URL.
+     *
+     * @param bool $absoluteUrl If true the scheme and host will be included
+     *                          (https://example.com/foo/bar) otherwise a
+     *                          path-absolut URL will be returned (/foo/bar).
+     */
+    public function resolve(string $url, bool $absoluteUrl = false): string
+    {
+        return UrlUtil::makeAbsolute(
+            $this->insertTagParser->replaceInline($url),
+            $absoluteUrl ? $this->getBaseUrl() : '/',
+        );
+    }
+
+    /**
+     * Same as Environment::get('base').
+     */
+    public function getBaseUrl(): string
+    {
+        if ($request = $this->requestStack->getMainRequest()) {
+            return $request->getSchemeAndHttpHost().$request->getBasePath().'/';
+        }
+
+        return $this->requestContext->getBaseUrl().'/';
+    }
+}

--- a/core-bundle/tests/Controller/ContentElement/ContentElementTestCase.php
+++ b/core-bundle/tests/Controller/ContentElement/ContentElementTestCase.php
@@ -62,6 +62,7 @@ use Symfony\Component\Filesystem\Path;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Fragment\FragmentHandler;
+use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Uid\Uuid;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Twig\Environment;
@@ -128,6 +129,7 @@ class ContentElementTestCase extends TestCase
         $container->set('contao.framework', $this->getDefaultFramework());
         $container->set('monolog.logger.contao.error', $this->createMock(LoggerInterface::class));
         $container->set('fragment.handler', $this->createMock(FragmentHandler::class));
+        $container->set('router.request_context', $this->createMock(RequestContext::class));
 
         if ($adjustedContainer) {
             $container->merge($adjustedContainer);

--- a/core-bundle/tests/Controller/ContentElement/HyperlinkControllerTest.php
+++ b/core-bundle/tests/Controller/ContentElement/HyperlinkControllerTest.php
@@ -13,14 +13,17 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Tests\Controller\ContentElement;
 
 use Contao\CoreBundle\Controller\ContentElement\HyperlinkController;
+use Contao\CoreBundle\Routing\UrlResolver;
 use Contao\StringUtil;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Routing\RequestContext;
 
 class HyperlinkControllerTest extends ContentElementTestCase
 {
     public function testOutputsSimpleLink(): void
     {
         $response = $this->renderWithModelData(
-            new HyperlinkController($this->getDefaultStudio(), $this->getDefaultInsertTagParser()),
+            new HyperlinkController($this->getDefaultStudio(), $this->getUrlResolver()),
             [
                 'type' => 'hyperlink',
                 'url' => 'my-link.html',
@@ -46,7 +49,7 @@ class HyperlinkControllerTest extends ContentElementTestCase
     public function testOutputsLinkWithBeforeAndAfterText(): void
     {
         $response = $this->renderWithModelData(
-            new HyperlinkController($this->getDefaultStudio(), $this->getDefaultInsertTagParser()),
+            new HyperlinkController($this->getDefaultStudio(), $this->getUrlResolver()),
             [
                 'type' => 'hyperlink',
                 'url' => 'https://www.php.net/manual/en/function.sprintf.php',
@@ -74,7 +77,7 @@ class HyperlinkControllerTest extends ContentElementTestCase
     public function testOutputsImageLink(): void
     {
         $response = $this->renderWithModelData(
-            new HyperlinkController($this->getDefaultStudio(), $this->getDefaultInsertTagParser()),
+            new HyperlinkController($this->getDefaultStudio(), $this->getUrlResolver()),
             [
                 'type' => 'hyperlink',
                 'url' => 'foo.html#{{demo}}',
@@ -106,7 +109,7 @@ class HyperlinkControllerTest extends ContentElementTestCase
     public function testOutputsEmptyLinkIfUrlIsNull(): void
     {
         $response = $this->renderWithModelData(
-            new HyperlinkController($this->getDefaultStudio(), $this->getDefaultInsertTagParser()),
+            new HyperlinkController($this->getDefaultStudio(), $this->getUrlResolver()),
             [
                 'type' => 'hyperlink',
                 'url' => null,
@@ -122,10 +125,19 @@ class HyperlinkControllerTest extends ContentElementTestCase
 
         $expectedOutput = <<<'HTML'
             <div class="content-hyperlink">
-                <a href></a>
+                <a href="/">/</a>
             </div>
             HTML;
 
         $this->assertSameHtml($expectedOutput, $response->getContent());
+    }
+
+    private function getUrlResolver(): UrlResolver
+    {
+        return new UrlResolver(
+            $this->getDefaultInsertTagParser(),
+            $this->createMock(RequestContext::class),
+            $this->createMock(RequestStack::class),
+        );
     }
 }

--- a/core-bundle/tests/Controller/ContentElement/MarkdownControllerTest.php
+++ b/core-bundle/tests/Controller/ContentElement/MarkdownControllerTest.php
@@ -27,6 +27,7 @@ use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Fragment\FragmentHandler;
+use Symfony\Component\Routing\RequestContext;
 
 class MarkdownControllerTest extends ContentElementTestCase
 {
@@ -200,6 +201,7 @@ class MarkdownControllerTest extends ContentElementTestCase
         $container->set('contao.cache.entity_tags', $this->createMock(EntityCacheTags::class));
         $container->set('monolog.logger.contao.error', $this->createMock(LoggerInterface::class));
         $container->set('fragment.handler', $this->createMock(FragmentHandler::class));
+        $container->set('router.request_context', $this->createMock(RequestContext::class));
 
         return $container;
     }

--- a/core-bundle/tests/File/MetadataTest.php
+++ b/core-bundle/tests/File/MetadataTest.php
@@ -24,6 +24,7 @@ use Contao\System;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Fragment\FragmentHandler;
+use Symfony\Component\Routing\RequestContext;
 
 class MetadataTest extends TestCase
 {
@@ -32,6 +33,7 @@ class MetadataTest extends TestCase
         parent::setUp();
 
         $container = $this->getContainerWithContaoConfiguration();
+        $container->set('router.request_context', $this->createMock(RequestContext::class));
         $container->set('contao.insert_tag.parser', new InsertTagParser($this->createMock(ContaoFramework::class), $this->createMock(LoggerInterface::class), $this->createMock(FragmentHandler::class), $this->createMock(RequestStack::class)));
 
         System::setContainer($container);
@@ -136,7 +138,7 @@ class MetadataTest extends TestCase
                 Metadata::VALUE_ALT => 'foo alt',
                 Metadata::VALUE_CAPTION => 'foo caption',
                 Metadata::VALUE_TITLE => 'foo title',
-                Metadata::VALUE_URL => 'foo://bar',
+                Metadata::VALUE_URL => 'foo://bar/',
             ],
             $model->getOverwriteMetadata()->all(),
         );
@@ -183,7 +185,7 @@ class MetadataTest extends TestCase
             [
                 Metadata::VALUE_TITLE => 'bar title',
                 Metadata::VALUE_ALT => 'bar alt',
-                Metadata::VALUE_URL => 'foo://bar',
+                Metadata::VALUE_URL => 'foo://bar/',
                 Metadata::VALUE_CAPTION => 'bar caption',
                 'custom' => 'foobar',
             ],

--- a/core-bundle/tests/Image/Studio/FigureBuilderTest.php
+++ b/core-bundle/tests/Image/Studio/FigureBuilderTest.php
@@ -47,6 +47,7 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Filesystem\Path;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Fragment\FragmentHandler;
+use Symfony\Component\Routing\RequestContext;
 
 class FigureBuilderTest extends TestCase
 {
@@ -732,6 +733,7 @@ class FigureBuilderTest extends TestCase
     public function testAutoFetchMetadataFromFilesModel(string $serializedMetadata, string|null $locale, array $expectedMetadata, Metadata|null $overwriteMetadata = null): void
     {
         $container = $this->getContainerWithContaoConfiguration();
+        $container->set('router.request_context', $this->createMock(RequestContext::class));
         $container->set('contao.insert_tag.parser', new InsertTagParser($this->createMock(ContaoFramework::class), $this->createMock(LoggerInterface::class), $this->createMock(FragmentHandler::class), $this->createMock(RequestStack::class)));
 
         System::setContainer($container);
@@ -786,7 +788,7 @@ class FigureBuilderTest extends TestCase
             [
                 Metadata::VALUE_TITLE => 't',
                 Metadata::VALUE_ALT => 'a',
-                Metadata::VALUE_URL => 'l',
+                Metadata::VALUE_URL => '/l',
                 Metadata::VALUE_CAPTION => 'c',
             ],
         ];
@@ -876,7 +878,7 @@ class FigureBuilderTest extends TestCase
             [
                 Metadata::VALUE_TITLE => 'tt',
                 Metadata::VALUE_ALT => 'a',
-                Metadata::VALUE_URL => 'l',
+                Metadata::VALUE_URL => '/l',
                 Metadata::VALUE_CAPTION => 'c',
             ],
             new Metadata([Metadata::VALUE_TITLE => 'tt']),

--- a/core-bundle/tests/InsertTag/CommonMarkExtensionTest.php
+++ b/core-bundle/tests/InsertTag/CommonMarkExtensionTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Tests\InsertTag;
 
 use Contao\CoreBundle\InsertTag\CommonMarkExtension;
-use Contao\CoreBundle\InsertTag\InsertTagParser;
+use Contao\CoreBundle\Routing\UrlResolver;
 use League\CommonMark\Environment\Environment;
 use League\CommonMark\Extension\Autolink\AutolinkExtension;
 use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
@@ -25,18 +25,18 @@ class CommonMarkExtensionTest extends TestCase
 {
     public function testReplacesInsertTags(): void
     {
-        $insertTagParser = $this->createMock(InsertTagParser::class);
-        $insertTagParser
+        $urlResolver = $this->createMock(UrlResolver::class);
+        $urlResolver
             ->expects($this->once())
-            ->method('replaceInline')
-            ->with('{{news_url::42}}')
+            ->method('resolve')
+            ->with('{{news_url::42}}', false)
             ->willReturn('https://contao.org/news-alias that-needs-encoding.html')
         ;
 
         $environment = new Environment();
         $environment->addExtension(new CommonMarkCoreExtension());
         $environment->addExtension(new AutolinkExtension());
-        $environment->addExtension(new CommonMarkExtension($insertTagParser));
+        $environment->addExtension(new CommonMarkExtension($urlResolver));
 
         $parser = new MarkdownParser($environment);
         $renderer = new HtmlRenderer($environment);

--- a/news-bundle/contao/modules/ModuleNewsReader.php
+++ b/news-bundle/contao/modules/ModuleNewsReader.php
@@ -14,7 +14,6 @@ use Contao\CoreBundle\Exception\InternalServerErrorException;
 use Contao\CoreBundle\Exception\PageNotFoundException;
 use Contao\CoreBundle\Exception\RedirectResponseException;
 use Contao\CoreBundle\Routing\ResponseContext\HtmlHeadBag\HtmlHeadBag;
-use Contao\CoreBundle\Util\UrlUtil;
 
 /**
  * Front end module "newsreader".
@@ -114,8 +113,7 @@ class ModuleNewsReader extends ModuleNews
 			case 'external':
 				if ($objArticle->url)
 				{
-					$url = System::getContainer()->get('contao.insert_tag.parser')->replaceInline($objArticle->url);
-					$url = UrlUtil::makeAbsolute($url, Environment::get('base'));
+					$url = System::getContainer()->get('contao.routing.url_resolver')->resolve($objArticle->url, true);
 
 					throw new RedirectResponseException($url, 301);
 				}


### PR DESCRIPTION
Alternative to #6544 

I agree with @aschempp that we need a service that handles URLs that are entered into the backend, they can be relative to the base, path-absolute or absolute and can contain insert tags.

We should use the service for both cases IMO (absolute as well as path-absolute URLs).

Differences to #6544:
- also uses the service in places where we need path-absolute URLs (important for our transition away from the `<base>` tag).
- does not convert `UrlUtil` into a service but creates a new `UrlResolver` service.
- uses the correct replacement for `Environment::get('base')` 

@aschempp WDYT?