### PR TITLE
Update page registry when generating multiple page aliases

### DIFF
--- a/core-bundle/src/Resources/contao/dca/tl_page.php
+++ b/core-bundle/src/Resources/contao/dca/tl_page.php
@@ -1710,6 +1710,9 @@ class tl_page extends Backend
 
 				// Create a new version
 				$objVersions->create();
+
+				// Update the record stored in the page registry (see #6542)
+				PageModel::findByPk($id)->alias = $strAlias;
 			}
 
 			$this->redirect($this->getReferer());


### PR DESCRIPTION
Fixes #6542

`PageModel::findWithDetails` will keep a clone of the original page model before loading the details. That clone will be used by child pages to generate the trail, which will incorrectly still use the old page alias.