### PR TITLE
Add the possibility to move items using the BackendMenuListener

### DIFF
--- a/core-bundle/src/Event/MenuEvent.php
+++ b/core-bundle/src/Event/MenuEvent.php
@@ -37,20 +37,20 @@ class MenuEvent extends Event
         return $this->tree;
     }
 
-    public function moveItem(?ItemInterface $contentNode, ItemInterface $node, int $newIndex): void
+    public function moveItem(?ItemInterface $parentNode, ItemInterface $node, int $newIndex): void
     {
-        if (null === $contentNode)
+        if (null === $parentNode)
         {
             return;
         }
 
-        if (!$contentNode->hasChildren())
+        if (!$parentNode->hasChildren())
         {
             return;
         }
 
         $name = $node->getName();
-        $arrChildren = $contentNode->getChildren();
+        $arrChildren = $parentNode->getChildren();
 
         if (!\array_key_exists($name, $arrChildren))
         {
@@ -67,6 +67,6 @@ class MenuEvent extends Event
         $arrBuffer = array_splice($arrChildren, 0, $newIndex);
         $arrChildren = array_merge_recursive($arrBuffer, $arrNew, $arrChildren);
 
-        $contentNode->reorderChildren(array_keys($arrChildren));
+        $parentNode->reorderChildren(array_keys($arrChildren));
     }
 }

--- a/core-bundle/src/Event/MenuEvent.php
+++ b/core-bundle/src/Event/MenuEvent.php
@@ -36,4 +36,37 @@ class MenuEvent extends Event
     {
         return $this->tree;
     }
+
+    public function moveItem(?ItemInterface $contentNode, ItemInterface $node, int $newIndex): void
+    {
+        if (null === $contentNode)
+        {
+            return;
+        }
+
+        if (!$contentNode->hasChildren())
+        {
+            return;
+        }
+
+        $name = $node->getName();
+        $arrChildren = $contentNode->getChildren();
+
+        if (!\array_key_exists($name, $arrChildren))
+        {
+            return;
+        }
+
+        $arrNew = $arrChildren;
+
+        // Get offset of the menu item and splice it into $arrNew
+        $intOffset = array_search($name, array_keys($arrChildren), true);
+        $arrChildren = array_splice($arrNew, 0, $intOffset);
+
+        // Split current menu items again to insert the item at the given index
+        $arrBuffer = array_splice($arrChildren, 0, $newIndex);
+        $arrChildren = array_merge_recursive($arrBuffer, $arrNew, $arrChildren);
+
+        $contentNode->reorderChildren(array_keys($arrChildren));
+    }
 }

--- a/core-bundle/src/Event/MenuEvent.php
+++ b/core-bundle/src/Event/MenuEvent.php
@@ -39,21 +39,18 @@ class MenuEvent extends Event
 
     public function moveItem(?ItemInterface $parentNode, ItemInterface $node, int $newIndex): void
     {
-        if (null === $parentNode)
-        {
+        if (null === $parentNode) {
             return;
         }
 
-        if (!$parentNode->hasChildren())
-        {
+        if (!$parentNode->hasChildren()) {
             return;
         }
 
         $name = $node->getName();
         $arrChildren = $parentNode->getChildren();
 
-        if (!\array_key_exists($name, $arrChildren))
-        {
+        if (!\array_key_exists($name, $arrChildren)) {
             return;
         }
 

--- a/core-bundle/tests/Event/BackendMenuEventTest.php
+++ b/core-bundle/tests/Event/BackendMenuEventTest.php
@@ -62,8 +62,7 @@ class BackendMenuEventTest extends TestCase
 
     private function createMenuItems(MenuItem $node, FactoryInterface $factory): void
     {
-        for ($i = 0; $i < 9; $i++)
-        {
+        for ($i = 0; $i < 9; $i++) {
             $node->addChild(new MenuItem('child_' . $i, $factory));
         }
     }

--- a/core-bundle/tests/Event/BackendMenuEventTest.php
+++ b/core-bundle/tests/Event/BackendMenuEventTest.php
@@ -15,6 +15,8 @@ namespace Contao\CoreBundle\Tests\Event;
 use Contao\CoreBundle\Event\MenuEvent;
 use Knp\Menu\FactoryInterface;
 use Knp\Menu\ItemInterface;
+use Knp\Menu\MenuFactory;
+use Knp\Menu\MenuItem;
 use PHPUnit\Framework\TestCase;
 
 class BackendMenuEventTest extends TestCase
@@ -35,5 +37,34 @@ class BackendMenuEventTest extends TestCase
         $event = new MenuEvent($factory, $tree);
 
         $this->assertSame($tree, $event->getTree());
+    }
+
+    public function testMovesTheLastMenuItemToSecondIndex(): void
+    {
+        $factory = new MenuFactory();
+        $tree = new MenuItem('content', $factory);
+        $event = new MenuEvent($factory, $tree);
+
+        $newIndex = 2;
+        $this->createMenuItems($tree, $factory);
+
+        // Save last item for testing
+        $lastMenuItem = $tree->getLastChild();
+
+        $event->moveItem($tree, $lastMenuItem, $newIndex);
+
+        // Reset keys to get the test object by index
+        $children = array_values($tree->getChildren());
+        $testItem = $children[$newIndex];
+
+        $this->assertSame($lastMenuItem, $testItem);
+    }
+
+    private function createMenuItems(MenuItem $node, FactoryInterface $factory): void
+    {
+        for ($i = 0; $i < 9; $i++)
+        {
+            $node->addChild(new MenuItem('child_' . $i, $factory));
+        }
     }
 }

--- a/core-bundle/tests/Event/BackendMenuEventTest.php
+++ b/core-bundle/tests/Event/BackendMenuEventTest.php
@@ -62,8 +62,8 @@ class BackendMenuEventTest extends TestCase
 
     private function createMenuItems(MenuItem $node, FactoryInterface $factory): void
     {
-        for ($i = 0; $i < 9; $i++) {
-            $node->addChild(new MenuItem('child_' . $i, $factory));
+        for ($i = 0; $i < 9; ++$i) {
+            $node->addChild(new MenuItem('child_'.$i, $factory));
         }
     }
 }


### PR DESCRIPTION
This PR adds the missing option to reorder the menu items when they are created with the [BackendMenuListener](https://docs.contao.org/dev/guides/back-end-routes/).

I'm not sure if this can be considered a feature, as this option is also possible in the "old way" with the BE_MOD array.

Contrary to Toflar's words in Slack:
> At the developer meeting we talked about an attribute for the custom BackendController that could be used to specify the position.  

I don't think this should be added as an attribute, but a method due to the ability to move each node as seen below:

___ 

### Usage
``$event->moveItem($parentNode, $node, $newIndex)``

___

### Examples

#### Moving the last main menu category to the first position

```php
#[AsEventListener(ContaoCoreEvents::BACKEND_MENU_BUILD, priority: -255)]
class BackendMenuListener
{
    public function __construct(protected RouterInterface $router, protected RequestStack $requestStack) {}

    public function __invoke(MenuEvent $event): void
    {
        $tree = $event->getTree();

        if ('mainMenu' !== $tree->getName()) {
            return;
        }

        $event->moveItem($tree, $tree->getLastChild(), 0);
    }
}
```
![MoveMainMenuItems](https://github.com/contao/contao/assets/55794780/a5b0670e-93d3-4d07-bb0a-7cd026b9860b)

#### Moving a newly created menuitem within a specific node

```php
#[AsEventListener(ContaoCoreEvents::BACKEND_MENU_BUILD, priority: -255)]
class BackendMenuListener
{
    public function __construct(protected RouterInterface $router, protected RequestStack $requestStack) {}

    public function __invoke(MenuEvent $event): void
    {
        $factory = $event->getFactory();
        $tree = $event->getTree();

        if ('mainMenu' !== $tree->getName()) {
            return;
        }

        $contentNode = $tree->getChild('content');

        $node = $factory
            ->createItem('testing-menu-item')
                ->setUri($this->router->generate(BackendController::class))
                ->setLabel('Testing: MenuItem')
                ->setLinkAttribute('title', 'Testing: MenuItem')
                ->setLinkAttribute('class', 'Testing: MenuItem')
                ->setCurrent($this->requestStack->getCurrentRequest()->get('_controller') === BackendController::class)
        ;

        $contentNode->addChild($node);

        $event->moveItem($contentNode, $node, 1);
    }
}
```
![MoveContentNodeItem](https://github.com/contao/contao/assets/55794780/0f9a88d8-ca9f-4d34-9eca-6e4f546c6966)

