### PR TITLE
Handle NULL values in the code element

### DIFF
--- a/core-bundle/contao/templates/_new/content_element/code.html.twig
+++ b/core-bundle/contao/templates/_new/content_element/code.html.twig
@@ -16,7 +16,7 @@
 
             {% block code %}
                 {# @var \Contao\CoreBundle\Twig\Runtime\HighlightResult highlighted #}
-                {% set highlighted = code|default('')|highlight(language) %}
+                {% set highlighted = code|highlight(language) %}
                 {% set code_attributes = attrs(code_attributes|default)
                     .addClass('hljs')
                     .addClass(highlighted.language)

--- a/core-bundle/contao/templates/_new/content_element/code.html.twig
+++ b/core-bundle/contao/templates/_new/content_element/code.html.twig
@@ -16,7 +16,7 @@
 
             {% block code %}
                 {# @var \Contao\CoreBundle\Twig\Runtime\HighlightResult highlighted #}
-                {% set highlighted = code|highlight(language) %}
+                {% set highlighted = code|default('')|highlight(language) %}
                 {% set code_attributes = attrs(code_attributes|default)
                     .addClass('hljs')
                     .addClass(highlighted.language)

--- a/core-bundle/src/Controller/ContentElement/CodeController.php
+++ b/core-bundle/src/Controller/ContentElement/CodeController.php
@@ -23,7 +23,7 @@ class CodeController extends AbstractContentElementController
 {
     protected function getResponse(FragmentTemplate $template, ContentModel $model, Request $request): Response
     {
-        $template->set('code', $model->code);
+        $template->set('code', $model->code ?: '');
         $template->set('language', $model->highlight);
 
         return $template->getResponse();


### PR DESCRIPTION
`tl_content.code` is a TEXT field that is nullable, but the `HighlighterRuntime` does not accept a null value for code highlighting.