### PR TITLE
Fix CSRF cookie always being set

### DIFF
--- a/core-bundle/contao/forms/Form.php
+++ b/core-bundle/contao/forms/Form.php
@@ -153,7 +153,9 @@ class Form extends Hybrid
 		$this->Template->formSubmit = $formId;
 		$this->Template->method = ($this->method == 'GET') ? 'get' : 'post';
 
-		if (($request = System::getContainer()->get('request_stack')->getCurrentRequest()) && $request->hasPreviousSession())
+		$request = System::getContainer()->get('request_stack')->getCurrentRequest();
+
+		if ($request && $request->hasPreviousSession())
 		{
 			$flashBag = $request->getSession()->getFlashBag();
 

--- a/core-bundle/contao/forms/Form.php
+++ b/core-bundle/contao/forms/Form.php
@@ -153,16 +153,19 @@ class Form extends Hybrid
 		$this->Template->formSubmit = $formId;
 		$this->Template->method = ($this->method == 'GET') ? 'get' : 'post';
 
-		$flashBag = System::getContainer()->get('request_stack')->getSession()->getFlashBag();
-
-		// Add a confirmation to the template and remove it afterward
-		if ($flashBag->has(self::SESSION_CONFIRMATION_KEY))
+		if (($request = System::getContainer()->get('request_stack')->getCurrentRequest()) && $request->hasPreviousSession())
 		{
-			$confirmationData = $flashBag->peek(self::SESSION_CONFIRMATION_KEY);
+			$flashBag = $request->getSession()->getFlashBag();
 
-			if (isset($confirmationData['id']) && $this->id === $confirmationData['id'])
+			// Add a confirmation to the template and remove it afterward
+			if ($flashBag->has(self::SESSION_CONFIRMATION_KEY))
 			{
-				$this->Template->message = $flashBag->get(self::SESSION_CONFIRMATION_KEY)['message'];
+				$confirmationData = $flashBag->peek(self::SESSION_CONFIRMATION_KEY);
+
+				if (isset($confirmationData['id']) && $this->id === $confirmationData['id'])
+				{
+					$this->Template->message = $flashBag->get(self::SESSION_CONFIRMATION_KEY)['message'];
+				}
 			}
 		}
 

--- a/core-bundle/src/Security/Authentication/Token/TokenChecker.php
+++ b/core-bundle/src/Security/Authentication/Token/TokenChecker.php
@@ -72,8 +72,14 @@ class TokenChecker
      */
     public function hasFrontendGuest(): bool
     {
+        $request = $this->requestStack->getCurrentRequest();
+
+        if (!$request || !$request->hasPreviousSession()) {
+            return false;
+        }
+
         try {
-            $session = $this->requestStack->getSession();
+            $session = $request->getSession();
         } catch (SessionNotFoundException) {
             return false;
         }

--- a/core-bundle/tests/Security/Authentication/Token/TokenCheckerTest.php
+++ b/core-bundle/tests/Security/Authentication/Token/TokenCheckerTest.php
@@ -504,7 +504,6 @@ class TokenCheckerTest extends TestCase
         ;
 
         $request = $this->createMock(Request::class);
-
         $request
             ->method('getSession')
             ->willReturn($session)

--- a/core-bundle/tests/Security/Authentication/Token/TokenCheckerTest.php
+++ b/core-bundle/tests/Security/Authentication/Token/TokenCheckerTest.php
@@ -195,6 +195,7 @@ class TokenCheckerTest extends TestCase
         ;
 
         $request->setSession($session);
+        $request->cookies->set($session->getName(), 'foo');
 
         $connection = $this->createMock(Connection::class);
         $connection
@@ -492,18 +493,27 @@ class TokenCheckerTest extends TestCase
     /**
      * @dataProvider getFrontendGuestData
      */
-    public function testIfAFrontendGuestIsAvailable(bool $expected, bool $hasFrontendGuest): void
+    public function testIfAFrontendGuestIsAvailable(bool $expected, bool $hasFrontendGuest, bool $hasPreviousSession): void
     {
         $session = $this->createMock(SessionInterface::class);
         $session
-            ->expects($this->once())
+            ->expects($hasPreviousSession ? $this->once() : $this->never())
             ->method('get')
             ->with(FrontendPreviewAuthenticator::SESSION_NAME)
             ->willReturn($hasFrontendGuest ? ['showUnpublished' => false, 'previewLinkId' => 123] : null)
         ;
 
-        $request = new Request();
-        $request->setSession($session);
+        $request = $this->createMock(Request::class);
+
+        $request
+            ->method('getSession')
+            ->willReturn($session)
+        ;
+
+        $request
+            ->method('hasPreviousSession')
+            ->willReturn($hasPreviousSession)
+        ;
 
         $connection = $this->createMock(Connection::class);
         $connection
@@ -529,8 +539,9 @@ class TokenCheckerTest extends TestCase
 
     public function getFrontendGuestData(): \Generator
     {
-        yield [false, false];
-        yield [true, true];
+        yield [false, false, false];
+        yield [false, false, true];
+        yield [true, true, true];
     }
 
     /**


### PR DESCRIPTION
Neither the form confirmation message nor having a frontend guest should be checked or could be true if no previous session exists. Otherwise we would initialize the session and set a CSRF token.