### PR TITLE
Fix relative asset paths in feeds

### DIFF
--- a/calendar-bundle/src/Resources/contao/classes/Calendar.php
+++ b/calendar-bundle/src/Resources/contao/classes/Calendar.php
@@ -240,6 +240,10 @@ class Calendar extends Frontend
 					// Override the global page object (#2946)
 					$GLOBALS['objPage'] = $this->getPageWithDetails(CalendarModel::findByPk($event['pid'])->jumpTo);
 
+					// Override the assets and files context (#6563)
+					$GLOBALS['objPage']->staticFiles = rtrim($GLOBALS['objPage']->staticFiles ?: $strLink, '/');
+					$GLOBALS['objPage']->staticPlugins = rtrim($GLOBALS['objPage']->staticPlugins ?: $strLink, '/');
+
 					// Push a new request to the request stack (#3856)
 					$request = $this->createSubRequest($event['link'], $currentRequest);
 					$request->attributes->set('_scope', 'frontend');

--- a/news-bundle/src/Resources/contao/classes/News.php
+++ b/news-bundle/src/Resources/contao/classes/News.php
@@ -185,6 +185,10 @@ class News extends Frontend
 				// Override the global page object (#2946)
 				$GLOBALS['objPage'] = $objParent;
 
+				// Override the assets and files context (#6563)
+				$GLOBALS['objPage']->staticFiles = rtrim($GLOBALS['objPage']->staticFiles ?: $strLink, '/');
+				$GLOBALS['objPage']->staticPlugins = rtrim($GLOBALS['objPage']->staticPlugins ?: $strLink, '/');
+
 				// Get the jumpTo URL
 				if (!isset($arrUrls[$jumpTo]))
 				{


### PR DESCRIPTION
Fixes #6563 by setting the feed base as the `staticFiles` and `staticPlugins` base URL in the current `$objPage`.