### PR TITLE
Fix and improve logging deprecation messages

### DIFF
--- a/manager-bundle/src/Resources/skeleton/config/config_dev.yml
+++ b/manager-bundle/src/Resources/skeleton/config/config_dev.yml
@@ -18,7 +18,7 @@ web_profiler:
 # Monolog configuration
 monolog:
     channels:
-        - deprecation # Deprecations are logged in the dedicated "deprecation" channel when it exists
+        - deprecation
     handlers:
         contao:
             type: service
@@ -44,7 +44,7 @@ monolog:
                 VERBOSITY_VERY_VERBOSE: NOTICE
                 VERBOSITY_DEBUG: DEBUG
             channels: [doctrine]
-        # Do not log deprecation messages because they might flood the file system.
+        # Do not log deprecation messages by default because they might flood the file system.
         deprecation:
             type: 'null'
             channels: [deprecation]

--- a/manager-bundle/src/Resources/skeleton/config/config_dev.yml
+++ b/manager-bundle/src/Resources/skeleton/config/config_dev.yml
@@ -48,7 +48,7 @@ monolog:
             type: rotating_file
             max_files: 10
             path: '%kernel.logs_dir%/%kernel.environment%-deprecations.log'
-            channels: ['deprecation']
+            channels: [deprecation]
 
 # FOS HttpCache configuration
 fos_http_cache:

--- a/manager-bundle/src/Resources/skeleton/config/config_dev.yml
+++ b/manager-bundle/src/Resources/skeleton/config/config_dev.yml
@@ -17,6 +17,8 @@ web_profiler:
 
 # Monolog configuration
 monolog:
+    channels:
+        - deprecation # Deprecations are logged in the dedicated "deprecation" channel when it exists
     handlers:
         contao:
             type: service
@@ -26,14 +28,14 @@ monolog:
             max_files: 10
             path: '%kernel.logs_dir%/%kernel.environment%.log'
             level: debug
-            channels: ['!doctrine', '!event', '!php']
+            channels: ['!doctrine', '!event', '!php', '!deprecation']
         console:
             type: console
             bubble: false
             verbosity_levels:
                 VERBOSITY_VERBOSE: INFO
                 VERBOSITY_VERY_VERBOSE: DEBUG
-            channels: ['!doctrine']
+            channels: ['!doctrine', '!deprecation']
         console_very_verbose:
             type: console
             bubble: false
@@ -42,6 +44,11 @@ monolog:
                 VERBOSITY_VERY_VERBOSE: NOTICE
                 VERBOSITY_DEBUG: DEBUG
             channels: [doctrine]
+        deprecation:
+            type: rotating_file
+            max_files: 10
+            path: '%kernel.logs_dir%/%kernel.environment%-deprecations.log'
+            channels: ['deprecation']
 
 # FOS HttpCache configuration
 fos_http_cache:

--- a/manager-bundle/src/Resources/skeleton/config/config_dev.yml
+++ b/manager-bundle/src/Resources/skeleton/config/config_dev.yml
@@ -44,10 +44,9 @@ monolog:
                 VERBOSITY_VERY_VERBOSE: NOTICE
                 VERBOSITY_DEBUG: DEBUG
             channels: [doctrine]
+        # Do not log deprecation messages because they might flood the file system.
         deprecation:
-            type: rotating_file
-            max_files: 10
-            path: '%kernel.logs_dir%/%kernel.environment%-deprecations.log'
+            type: 'null'
             channels: [deprecation]
 
 # FOS HttpCache configuration

--- a/manager-bundle/src/Resources/skeleton/config/config_prod.yml
+++ b/manager-bundle/src/Resources/skeleton/config/config_prod.yml
@@ -26,10 +26,7 @@ monolog:
             level: info
         console:
             type: console
-        # Do not log deprecation messages in production because they might flood the file system. If you are a developer
-        # reading this and trying to get the messages logged in production in preparation for an update, checkout
-        # the default configuration for the "dev" environment that is shipped with Contao for reference and adjust "prod"
-        # to your needs accordingly.
+        # Do not log deprecation messages because they might flood the file system.
         deprecation:
             type: 'null'
             channels: [deprecation]

--- a/manager-bundle/src/Resources/skeleton/config/config_prod.yml
+++ b/manager-bundle/src/Resources/skeleton/config/config_prod.yml
@@ -32,4 +32,4 @@ monolog:
         # to your needs accordingly.
         deprecation:
             type: 'null'
-            channels: ['deprecation']
+            channels: [deprecation]

--- a/manager-bundle/src/Resources/skeleton/config/config_prod.yml
+++ b/manager-bundle/src/Resources/skeleton/config/config_prod.yml
@@ -8,7 +8,7 @@ contao:
 # Monolog configuration
 monolog:
     channels:
-        - deprecation # Deprecations are logged in the dedicated "deprecation" channel when it exists
+        - deprecation
     handlers:
         contao:
             type: service
@@ -26,7 +26,7 @@ monolog:
             level: info
         console:
             type: console
-        # Do not log deprecation messages because they might flood the file system.
+        # Do not log deprecation messages by default because they might flood the file system.
         deprecation:
             type: 'null'
             channels: [deprecation]

--- a/manager-bundle/src/Resources/skeleton/config/config_prod.yml
+++ b/manager-bundle/src/Resources/skeleton/config/config_prod.yml
@@ -7,6 +7,8 @@ contao:
 
 # Monolog configuration
 monolog:
+    channels:
+        - deprecation # Deprecations are logged in the dedicated "deprecation" channel when it exists
     handlers:
         contao:
             type: service
@@ -16,6 +18,7 @@ monolog:
             action_level: error
             handler: nested
             excluded_http_codes: [400, 401, 403, 404, 503]
+            channels: ['!deprecation']
         nested:
             type: rotating_file
             max_files: 10
@@ -23,3 +26,10 @@ monolog:
             level: info
         console:
             type: console
+        # Do not log deprecation messages in production because they might flood the file system. If you are a developer
+        # reading this and trying to get the messages logged in production in preparation for an update, checkout
+        # the default configuration for the "dev" environment that is shipped with Contao for reference and adjust "prod"
+        # to your needs accordingly.
+        deprecation:
+            type: 'null'
+            channels: ['deprecation']


### PR DESCRIPTION
Fixes https://github.com/contao/contao/issues/6534.

Deprecations are now logged as follows:

- In PROD, deprecations are never logged.
- In DEV, deprecations are logged into `/var/logs/dev-deprecations.log` and rotated

I've fiddled around with deduplication but there's not much value if it's only in DEV anyway. Also, I first did not add the `dev-` prefix because we only log in DEV by default but I think it makes it easier to distinguish if people adjust the configuration to also log in PROD for example.

This PR can be tested very easily. Adjust your `fe_page.html5` and add

```php
<?php
trigger_deprecation('vendor/package', '1.0', 'This deprecation message is a test message.');
throw new \RuntimeException('Exception that causes an error and thus the buffered messages to be written.');
```