### PR TITLE
Fix the safe analysis for the `contao_html`  and `contao_html_attr` strategies

### DIFF
--- a/core-bundle/src/Twig/Extension/ContaoExtension.php
+++ b/core-bundle/src/Twig/Extension/ContaoExtension.php
@@ -33,6 +33,8 @@ use Twig\Environment;
 use Twig\Extension\AbstractExtension;
 use Twig\Extension\CoreExtension;
 use Twig\Extension\EscaperExtension;
+use Twig\Node\Expression\ConstantExpression;
+use Twig\Node\Node;
 use Twig\TwigFilter;
 use Twig\TwigFunction;
 
@@ -177,17 +179,32 @@ final class ContaoExtension extends AbstractExtension
             return twig_escape_filter($env, $string, $strategy, $charset, $autoescape);
         };
 
+        $twigEscaperFilterIsSafe = static function (Node $filterArgs): array {
+            // Our escaper strategy variants that tolerate input encoding are
+            // also safe in the original context (e.g. for the filter argument
+            // 'contao_html' we will return ['contao_html', 'html']).
+            if (
+                ($expression = iterator_to_array($filterArgs)[0] ?? null) instanceof ConstantExpression
+                && \in_array($value = $expression->getAttribute('value'), ['contao_html', 'contao_html_attr'], true)
+            ) {
+                return [$value, substr($value, 7)];
+            }
+
+            return twig_escape_filter_is_safe($filterArgs);
+        };
+
         return [
-            // Overwrite the "escape" filter to additionally support chunked text
+            // Overwrite the "escape" filter to additionally support chunked
+            // text and our escaper strategies
             new TwigFilter(
                 'escape',
                 $escaperFilter,
-                ['needs_environment' => true, 'is_safe_callback' => 'twig_escape_filter_is_safe']
+                ['needs_environment' => true, 'is_safe_callback' => $twigEscaperFilterIsSafe],
             ),
             new TwigFilter(
                 'e',
                 $escaperFilter,
-                ['needs_environment' => true, 'is_safe_callback' => 'twig_escape_filter_is_safe']
+                ['needs_environment' => true, 'is_safe_callback' => $twigEscaperFilterIsSafe],
             ),
             new TwigFilter(
                 'insert_tag',

--- a/core-bundle/tests/Twig/Extension/ContaoExtensionTest.php
+++ b/core-bundle/tests/Twig/Extension/ContaoExtensionTest.php
@@ -343,6 +343,50 @@ class ContaoExtensionTest extends TestCase
     }
 
     /**
+     * We need to adjust some of Twig's core functions (e.g. the escape filter)
+     * but still delegate to the original implementation for maximum compatibility.
+     * This test makes sure the function's signatures remains the same and changes
+     * to the original codebase do not stay unnoticed.
+     *
+     * @dataProvider provideTwigFunctionSignatures
+     */
+    public function testContaoUsesCorrectTwigFunctionSignatures(string $function, array $expectedParameters): void
+    {
+        // Make sure the functions outside the class scope are loaded
+        new \ReflectionClass(EscaperExtension::class);
+
+        $parameters = array_map(
+            static fn (\ReflectionParameter $parameter): array => [
+                $parameter->hasType() ? $parameter->getType()->getName() : null,
+                $parameter->getName(),
+            ],
+            (new \ReflectionFunction($function))->getParameters()
+        );
+        $this->assertSame($parameters, $expectedParameters);
+    }
+
+    public function provideTwigFunctionSignatures(): \Generator
+    {
+        yield [
+            'twig_escape_filter',
+            [
+                [Environment::class, 'env'],
+                [null, 'string'],
+                [null, 'strategy'],
+                [null, 'charset'],
+                [null, 'autoescape'],
+            ],
+        ];
+
+        yield [
+            'twig_escape_filter_is_safe',
+            [
+                [Node::class, 'filterArgs'],
+            ],
+        ];
+    }
+
+    /**
      * @param Environment&MockObject $environment
      */
     private function getContaoExtension(Environment $environment = null, TemplateHierarchyInterface $hierarchy = null): ContaoExtension

--- a/core-bundle/tests/Twig/Extension/ContaoExtensionTest.php
+++ b/core-bundle/tests/Twig/Extension/ContaoExtensionTest.php
@@ -357,7 +357,7 @@ class ContaoExtensionTest extends TestCase
 
         $parameters = array_map(
             static fn (\ReflectionParameter $parameter): array => [
-                $parameter->hasType() ? $parameter->getType()->getName() : null,
+                ($type = $parameter->getType()) instanceof \ReflectionNamedType ? $type->getName() : null,
                 $parameter->getName(),
             ],
             (new \ReflectionFunction($function))->getParameters()


### PR DESCRIPTION
Our `contao_html` and `contao_html_attr` escaper strategies do not form a new context (like `js` or `css`) but rather enhance the existing to also work with already input encoded data. Thus we also need to mark them as safe in their respective original context. 

Otherwise the auto escaper will wrap every print node twice (which I did not notice before - it still works in the Contao context due to `double_encode: false`). This gets apparent if your html template is outside the Contao context (= no  escaper rule matches  the current template name) and you are using something like `{{ foo|escape('contao_html') }}`. Without this PR you would end up with `{{ foo|escape('contao_html')|escape('html') }}` and your already encoded data in `foo` would get encoded a second time.

/cc @Toflar 
