### PR TITLE
Do not wrap exceptions in the Twig `ContextFactory::__toString()` method

### DIFF
--- a/core-bundle/src/Twig/Interop/ContextFactory.php
+++ b/core-bundle/src/Twig/Interop/ContextFactory.php
@@ -149,11 +149,7 @@ final class ContextFactory
              */
             public function __toString(): string
             {
-                try {
-                    return (string) $this();
-                } catch (\Throwable $e) {
-                    throw new \RuntimeException(sprintf('Error evaluating "%s": %s', $this->name, $e->getMessage()), 0, $e);
-                }
+                return (string) $this();
             }
 
             /**

--- a/core-bundle/tests/Twig/Interop/ContextFactoryTest.php
+++ b/core-bundle/tests/Twig/Interop/ContextFactoryTest.php
@@ -179,7 +179,7 @@ class ContextFactoryTest extends TestCase
 
         $this->expectExceptionMessage(
             'An exception has been thrown during the rendering of a template ("'.
-            'Error evaluating "lazy": Object of class stdClass could not be converted to string'.
+            'Object of class stdClass could not be converted to string'.
             '") in "test.html.twig" at line 1.'
         );
 


### PR DESCRIPTION
Fixes #6548

This fix remove the wrapping of the thrown exception, when a variable is used in a TWIG template.

Also, this will allow the ResponseException from the download content element in a news/calendar event TWIG template to bubble up so Contao can correctly handle it and initiate the file download.

With this fix, one can directly use `{{ text|raw }}` in a news/calendar event TWIG template instead of the work-around with `{{ text.invoke()|raw }}`.
