### PR TITLE
Move the `ModelMetadataTrait` to the correct namespace

### DIFF
--- a/calendar-bundle/contao/models/CalendarEventsModel.php
+++ b/calendar-bundle/contao/models/CalendarEventsModel.php
@@ -10,8 +10,8 @@
 
 namespace Contao;
 
-use Contao\CoreBundle\File\ModelMetadataTrait;
 use Contao\Model\Collection;
+use Contao\Model\MetadataTrait;
 
 /**
  * Reads and writes events
@@ -203,7 +203,7 @@ use Contao\Model\Collection;
  */
 class CalendarEventsModel extends Model
 {
-	use ModelMetadataTrait;
+	use MetadataTrait;
 
 	/**
 	 * Table name

--- a/core-bundle/contao/library/Contao/Model/MetadataTrait.php
+++ b/core-bundle/contao/library/Contao/Model/MetadataTrait.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\Model;
+
+use Contao\CoreBundle\File\Metadata;
+use Contao\FilesModel;
+use Contao\System;
+use Contao\Validator;
+
+/**
+ * @property string $overwriteMeta
+ *
+ * @method array row()
+ */
+trait MetadataTrait
+{
+	/**
+	 * Get the default metadata or null if not applicable.
+	 */
+	public function getOverwriteMetadata(): Metadata|null
+	{
+		// Ignore if "overwriteMeta" is not set
+		if (!$this->overwriteMeta)
+		{
+			return null;
+		}
+
+		$data = $this->row();
+
+		// Normalize keys
+		if (isset($data['imageTitle']))
+		{
+			$data[Metadata::VALUE_TITLE] = $data['imageTitle'];
+		}
+
+		if (isset($data['imageUrl']))
+		{
+			$url = $data['imageUrl'];
+
+			if (Validator::isRelativeUrl($url))
+			{
+				$url = System::getContainer()->get('contao.assets.files_context')->getStaticUrl() . $url;
+			}
+
+			$data[Metadata::VALUE_URL] = $url;
+		}
+
+		unset($data['imageTitle'], $data['imageUrl']);
+
+		// Make sure we resolve insert tags pointing to files
+		if (isset($data[Metadata::VALUE_URL]))
+		{
+			$data[Metadata::VALUE_URL] = System::getContainer()->get('contao.insert_tag.parser')->replaceInline($data[Metadata::VALUE_URL] ?? '');
+		}
+
+		// Strip superfluous fields by intersecting with tl_files.meta.eval.metaFields
+		return new Metadata(array_intersect_key($data, array_flip(FilesModel::getMetaFields())));
+	}
+}

--- a/core-bundle/contao/models/ContentModel.php
+++ b/core-bundle/contao/models/ContentModel.php
@@ -10,8 +10,8 @@
 
 namespace Contao;
 
-use Contao\CoreBundle\File\ModelMetadataTrait;
 use Contao\Model\Collection;
+use Contao\Model\MetadataTrait;
 
 /**
  * Reads and writes content elements
@@ -374,7 +374,7 @@ use Contao\Model\Collection;
  */
 class ContentModel extends Model
 {
-	use ModelMetadataTrait;
+	use MetadataTrait;
 
 	/**
 	 * Table name

--- a/core-bundle/src/File/ModelMetadataTrait.php
+++ b/core-bundle/src/File/ModelMetadataTrait.php
@@ -12,52 +12,15 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\File;
 
-use Contao\FilesModel;
-use Contao\System;
-use Contao\Validator;
+use Contao\Model\MetadataTrait;
+
+trigger_deprecation('contao/core-bundle', '5.3', 'Using "Contao\CoreBundle\File\ModelMetadataTrait" has been deprecated and will no longer work in Contao 6. Use "Contao\Model\MetadataTrait" instead.');
 
 /**
- * @property string $overwriteMeta
- *
- * @method array row()
+ * @deprecated Deprecated since Contao 5.3, to be removed in Contao 6;
+ *             use Contao\Model\MetadataTrait instead.
  */
 trait ModelMetadataTrait
 {
-    /**
-     * Get the default metadata or null if not applicable.
-     */
-    public function getOverwriteMetadata(): Metadata|null
-    {
-        // Ignore if "overwriteMeta" is not set
-        if (!$this->overwriteMeta) {
-            return null;
-        }
-
-        $data = $this->row();
-
-        // Normalize keys
-        if (isset($data['imageTitle'])) {
-            $data[Metadata::VALUE_TITLE] = $data['imageTitle'];
-        }
-
-        if (isset($data['imageUrl'])) {
-            $url = $data['imageUrl'];
-
-            if (Validator::isRelativeUrl($url)) {
-                $url = System::getContainer()->get('contao.assets.files_context')->getStaticUrl().$url;
-            }
-
-            $data[Metadata::VALUE_URL] = $url;
-        }
-
-        unset($data['imageTitle'], $data['imageUrl']);
-
-        // Make sure we resolve insert tags pointing to files
-        if (isset($data[Metadata::VALUE_URL])) {
-            $data[Metadata::VALUE_URL] = System::getContainer()->get('contao.insert_tag.parser')->replaceInline($data[Metadata::VALUE_URL] ?? '');
-        }
-
-        // Strip superfluous fields by intersecting with tl_files.meta.eval.metaFields
-        return new Metadata(array_intersect_key($data, array_flip(FilesModel::getMetaFields())));
-    }
+    use MetadataTrait;
 }

--- a/faq-bundle/contao/models/FaqModel.php
+++ b/faq-bundle/contao/models/FaqModel.php
@@ -10,8 +10,8 @@
 
 namespace Contao;
 
-use Contao\CoreBundle\File\ModelMetadataTrait;
 use Contao\Model\Collection;
+use Contao\Model\MetadataTrait;
 
 /**
  * Reads and writes FAQs
@@ -127,7 +127,7 @@ use Contao\Model\Collection;
  */
 class FaqModel extends Model
 {
-	use ModelMetadataTrait;
+	use MetadataTrait;
 
 	/**
 	 * Table name

--- a/news-bundle/contao/models/NewsModel.php
+++ b/news-bundle/contao/models/NewsModel.php
@@ -10,8 +10,8 @@
 
 namespace Contao;
 
-use Contao\CoreBundle\File\ModelMetadataTrait;
 use Contao\Model\Collection;
+use Contao\Model\MetadataTrait;
 
 /**
  * Reads and writes news
@@ -171,7 +171,7 @@ use Contao\Model\Collection;
  */
 class NewsModel extends Model
 {
-	use ModelMetadataTrait;
+	use MetadataTrait;
 
 	/**
 	 * Table name

--- a/tools/phpstan/config/contao.neon
+++ b/tools/phpstan/config/contao.neon
@@ -17,8 +17,6 @@ parameters:
         alwaysTrueAlwaysReported: false
         detectDeadTypeInMultiCatch: false
         disableCheckMissingIterableValueType: false
-        # TODO: Remove after the ModelMetadataTrait has been moved to the legacy code
-        notAnalysedTrait: false
 
     paths:
         - %currentWorkingDirectory%/calendar-bundle/src
@@ -51,6 +49,9 @@ parameters:
             # Ignore the unexpected type hint required for the tagged_locator
             message: '#type array<Symfony\\Component\\HttpKernel\\Fragment\\FragmentRendererInterface> is incompatible with native type Psr\\Container\\ContainerInterface#'
             path: %currentWorkingDirectory%/core-bundle/src/Fragment/FragmentHandler.php
+
+        # Ignore the unused ModelMetadataTrait that will be removed in Contao 6
+        - '#Trait Contao\\CoreBundle\\File\\ModelMetadataTrait is used zero times and is not analysed\.#'
 
         # Ignore the wrong return type hint of the UrlGeneratorInterface::generate() method
         - '#Method Contao\\CoreBundle\\Picker\\AbstractPickerProvider::generateUrl\(\) never returns null so it can be removed from the return type\.#'


### PR DESCRIPTION
It is only used by the legacy code and it uses legacy code itself, therefore it should be in the legacy namespace.

<img width="697" alt="" src="https://github.com/contao/contao/assets/1192057/511c6f64-6d5f-4b93-9586-9bba745baacb">
