### PR TITLE
Add a data container setting to hide the `orderBy` column in the back end listing

### DIFF
--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -5002,7 +5002,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 <table class="tl_listing' . (($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['showColumns'] ?? null) ? ' showColumns' : '') . ($this->strPickerFieldType ? ' picker unselectable' : '') . '">';
 
 			// Automatically add the "order by" field as last column if we do not have group headers
-			if (($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['showColumns'] ?? null) && false !== ($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['showFirstOrderBy'] ?? true))
+			if (($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['showColumns'] ?? null) && false !== ($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['showFirstOrderBy'] ?? null))
 			{
 				$blnFound = false;
 

--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -5002,7 +5002,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 <table class="tl_listing' . (($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['showColumns'] ?? null) ? ' showColumns' : '') . ($this->strPickerFieldType ? ' picker unselectable' : '') . '">';
 
 			// Automatically add the "order by" field as last column if we do not have group headers
-			if ($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['showColumns'] ?? null)
+			if (($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['showColumns'] ?? null) && ($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['showFirstOrderBy'] ?? true))
 			{
 				$blnFound = false;
 

--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -5002,7 +5002,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 <table class="tl_listing' . (($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['showColumns'] ?? null) ? ' showColumns' : '') . ($this->strPickerFieldType ? ' picker unselectable' : '') . '">';
 
 			// Automatically add the "order by" field as last column if we do not have group headers
-			if (($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['showColumns'] ?? null) && ($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['showFirstOrderBy'] ?? true))
+			if (($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['showColumns'] ?? null) && false !== ($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['showFirstOrderBy'] ?? true))
 			{
 				$blnFound = false;
 


### PR DESCRIPTION
Currently, in a `DC_Table`-driven data container, if you want to initially sort by a column which is not displayed in a listing – Contao will still force that column to appear in the list of displayed columns.

I.e. with the following DCA configuration:

```php
'list' => [
        'sorting' => [
            'mode' => DataContainer::MODE_SORTABLE,
            'fields' => ['tstamp', 'name', 'job'],
        ],
        'label' => [
            'fields' => ['name', 'job'],
            'showColumns' => true
        ],
```

the resulting `$GLOBALS['TL_DCA']['tl_table']['list']['label']['fields']` will equal to `['name', 'job', 'tstamp']`, and the last column will be added to backend listing with raw values.

However, there are cases when you might not want this, especially when building custom data containers. Examples:

1. Your data container is sorted manually. The sorting order is visual in this cases, and you don't need `sorting` column to be visible:

<img src="https://github.com/contao/contao/assets/10257912/50037177-99be-4af2-89c0-b78dea3cfeb2" width="170">

2. You want to display your most recent records on top, but your backend editors don't care about exact `tstamp` values

This PR adds a BC-compatible setting that allows to explicitly disable this behaviour by setting `list.label.showFirstOrderBy` to `false`. Missing setting defaults to current behaviour.

If this gets merged, I will update the docs as well.

Fixes #4942 

