### PR TITLE
Remove column from articles URL

### DIFF
--- a/core-bundle/contao/elements/ContentTeaser.php
+++ b/core-bundle/contao/elements/ContentTeaser.php
@@ -66,16 +66,8 @@ class ContentTeaser extends ContentElement
 	 */
 	protected function compile()
 	{
-		$link = '/articles/';
 		$objArticle = $this->objArticle;
-
-		if ($objArticle->inColumn != 'main')
-		{
-			$link .= $objArticle->inColumn . ':';
-		}
-
-		$link .= $objArticle->alias ?: $objArticle->id;
-		$this->Template->href = $this->objParent->getFrontendUrl($link);
+		$this->Template->href = $this->objParent->getFrontendUrl('/articles/' . ($objArticle->alias ?: $objArticle->id));
 
 		$this->Template->text = $objArticle->teaser;
 		$this->Template->headline = $objArticle->title;

--- a/core-bundle/contao/elements/ContentTeaser.php
+++ b/core-bundle/contao/elements/ContentTeaser.php
@@ -67,8 +67,8 @@ class ContentTeaser extends ContentElement
 	protected function compile()
 	{
 		$objArticle = $this->objArticle;
-		$this->Template->href = $this->objParent->getFrontendUrl('/articles/' . ($objArticle->alias ?: $objArticle->id));
 
+		$this->Template->href = $this->objParent->getFrontendUrl('/articles/' . ($objArticle->alias ?: $objArticle->id));
 		$this->Template->text = $objArticle->teaser;
 		$this->Template->headline = $objArticle->title;
 		$this->Template->readMore = StringUtil::specialchars(sprintf($GLOBALS['TL_LANG']['MSC']['readMore'], $objArticle->title));

--- a/core-bundle/contao/library/Contao/Controller.php
+++ b/core-bundle/contao/library/Contao/Controller.php
@@ -1205,9 +1205,9 @@ abstract class Controller extends System
 		$strParams = null;
 
 		// Add the /article/ fragment (see #673)
-		if ($strArticle !== null && ($objArticle = ArticleModel::findByAlias($strArticle)) !== null)
+		if ($strArticle)
 		{
-			$strParams = '/articles/' . (($objArticle->inColumn != 'main') ? $objArticle->inColumn . ':' : '') . $strArticle;
+			$strParams = '/articles/' . $strArticle;
 		}
 
 		$strUrl = $objPage->getPreviewUrl($strParams);

--- a/core-bundle/contao/modules/ModuleArticle.php
+++ b/core-bundle/contao/modules/ModuleArticle.php
@@ -138,12 +138,9 @@ class ModuleArticle extends Module
 				$this->cssID = $arrCss;
 			}
 
-			$article = $this->alias ?: $this->id;
-			$href = '/articles/' . (($this->inColumn != 'main') ? $this->inColumn . ':' : '') . $article;
-
 			$this->Template->teaserOnly = true;
 			$this->Template->headline = $this->headline;
-			$this->Template->href = $objPage->getFrontendUrl($href);
+			$this->Template->href = $objPage->getFrontendUrl('/articles/' . ($this->alias ?: $this->id));
 			$this->Template->teaser = $this->teaser ?? '';
 			$this->Template->readMore = StringUtil::specialchars(sprintf($GLOBALS['TL_LANG']['MSC']['readMore'], $this->headline), true);
 			$this->Template->more = $GLOBALS['TL_LANG']['MSC']['more'];
@@ -152,9 +149,7 @@ class ModuleArticle extends Module
 		}
 
 		// Get section and article alias
-		$chunks = explode(':', Input::get('articles') ?? '');
-		$strSection = $chunks[0] ?? null;
-		$strArticle = $chunks[1] ?? $strSection;
+		$strArticle = Input::get('articles');
 
 		// Overwrite the page metadata (see #2853, #4955 and #87)
 		if (!$this->blnNoMarkup && $strArticle && ($strArticle == $this->id || $strArticle == $this->alias) && $this->title)

--- a/core-bundle/contao/modules/ModuleBreadcrumb.php
+++ b/core-bundle/contao/modules/ModuleBreadcrumb.php
@@ -163,20 +163,7 @@ class ModuleBreadcrumb extends Module
 				'data'     => $pages[0]->row(),
 			);
 
-			list($strSection, $strArticle) = explode(':', Input::get('articles')) + array(null, null);
-
-			if ($strArticle === null)
-			{
-				$strArticle = $strSection;
-			}
-
-			$objArticle = ArticleModel::findByIdOrAlias($strArticle);
-			$strAlias = $objArticle->alias ?: $objArticle->id;
-
-			if ($objArticle->inColumn != 'main')
-			{
-				$strAlias = $objArticle->inColumn . ':' . $strAlias;
-			}
+			$objArticle = ArticleModel::findByIdOrAlias(Input::get('articles'));
 
 			if ($objArticle !== null)
 			{
@@ -184,7 +171,7 @@ class ModuleBreadcrumb extends Module
 				(
 					'isRoot'   => false,
 					'isActive' => true,
-					'href'     => $this->getPageFrontendUrl($pages[0], '/articles/' . $strAlias),
+					'href'     => $this->getPageFrontendUrl($pages[0], '/articles/' . ($objArticle->alias ?: $objArticle->id)),
 					'title'    => StringUtil::specialchars($objArticle->title, true),
 					'link'     => $objArticle->title,
 					'data'     => $objArticle->row(),

--- a/core-bundle/src/Controller/ContentElement/TeaserController.php
+++ b/core-bundle/src/Controller/ContentElement/TeaserController.php
@@ -35,11 +35,9 @@ class TeaserController extends AbstractContentElementController
 
         [$article, $page] = $articleAndPage;
 
-        $href = $page->getFrontendUrl('/articles/'.($article->alias ?: $article->id));
-
         $template->set('article', $article);
         $template->set('page', $page);
-        $template->set('href', $href);
+        $template->set('href', $page->getFrontendUrl('/articles/'.($article->alias ?: $article->id)));
 
         return $template->getResponse();
     }

--- a/core-bundle/src/Controller/ContentElement/TeaserController.php
+++ b/core-bundle/src/Controller/ContentElement/TeaserController.php
@@ -35,13 +35,7 @@ class TeaserController extends AbstractContentElementController
 
         [$article, $page] = $articleAndPage;
 
-        $href = $page->getFrontendUrl(
-            sprintf(
-                '/articles/%s%s',
-                'main' !== $article->inColumn ? "$article->inColumn:" : '',
-                $article->alias ?: $article->id,
-            ),
-        );
+        $href = $page->getFrontendUrl('/articles/'.($article->alias ?: $article->id));
 
         $template->set('article', $article);
         $template->set('page', $page);

--- a/core-bundle/src/EventListener/PreviewUrlConvertListener.php
+++ b/core-bundle/src/EventListener/PreviewUrlConvertListener.php
@@ -88,7 +88,7 @@ class PreviewUrlConvertListener
         }
 
         // Add the /article/ fragment (see contao/core-bundle#673)
-        return sprintf('/articles/%s%s', 'main' !== $article->inColumn ? $article->inColumn.':' : '', $article->alias);
+        return '/articles/'.($article->alias ?: $article->id);
     }
 
     private function getFragmentUrl(Request $request, PageModel $pageModel): string


### PR DESCRIPTION
While preparing for the _Content URL Generator_, I noticed this: did you know that (sometimes) Contao generates the URL to an article as `.../articles/section:alias` and not just `.../articles/alias`?

The reason behind this is, that `Controller::getFrontendModule` will ignore the articles parameter if it does not belong the the given column (section). **However**, this was

a) not applied in all place
b) totally unnecessary because we can achieve the same correct thing without having it in the URL (see PR code)
c) allowed for URL manipulation, I could theoretically generate an article in the wrong section (not saying that would be a real problem, but … )

This PR removes the need for passing the section in the article alias, because it was irrelevant to most places anyway. This makes generating the URL of an article easier and probably also fixes bugs because no third-party developer I know would currently have generated a correct URL 😅 