### PR TITLE
Deprecate the `PageModel::getPreviewUrl()` method

### DIFF
--- a/core-bundle/contao/library/Contao/Controller.php
+++ b/core-bundle/contao/library/Contao/Controller.php
@@ -1189,7 +1189,7 @@ abstract class Controller extends System
 	 */
 	protected function redirectToFrontendPage($intPage, $strArticle=null, $blnReturn=false)
 	{
-		trigger_deprecation('contao/core-bundle', '5.3', __METHOD__ . ' is deprecated and will be removed in Contao 6. Use the preview controller arguments instead.');
+		trigger_deprecation('contao/core-bundle', '5.3', __METHOD__ . ' is deprecated and will be removed in Contao 6. Use PageModel::getAbsoluteUrl() and the contao_backend_preview route instead.');
 
 		if (($intPage = (int) $intPage) <= 0)
 		{

--- a/core-bundle/contao/library/Contao/Controller.php
+++ b/core-bundle/contao/library/Contao/Controller.php
@@ -1189,6 +1189,8 @@ abstract class Controller extends System
 	 */
 	protected function redirectToFrontendPage($intPage, $strArticle=null, $blnReturn=false)
 	{
+		trigger_deprecation('contao/core-bundle', '5.3', __METHOD__ . ' is deprecated and will be removed in Contao 6. Use the preview controller arguments instead.');
+
 		if (($intPage = (int) $intPage) <= 0)
 		{
 			return '';

--- a/core-bundle/contao/models/PageModel.php
+++ b/core-bundle/contao/models/PageModel.php
@@ -1177,7 +1177,7 @@ class PageModel extends Model
 	 */
 	public function getPreviewUrl($strParams=null)
 	{
-		trigger_deprecation('contao/core-bundle', '5.3', __METHOD__ . ' is deprecated and will be removed in Contao 6. Use getAbsoluteUrl() and the preview controller instead.');
+		trigger_deprecation('contao/core-bundle', '5.3', __METHOD__ . ' is deprecated and will be removed in Contao 6. Use getAbsoluteUrl() and the contao_backend_preview route instead.');
 
 		$container = System::getContainer();
 

--- a/core-bundle/contao/models/PageModel.php
+++ b/core-bundle/contao/models/PageModel.php
@@ -1177,7 +1177,7 @@ class PageModel extends Model
 	 */
 	public function getPreviewUrl($strParams=null)
 	{
-		trigger_deprecation('contao/core-bundle', '5.3', __METHOD__ . ' is deprecated and will be removed in Contao 6. Use getAbsoluteUrl() and the contao_backend_preview route instead.');
+		trigger_deprecation('contao/core-bundle', '5.3', __METHOD__ . ' is deprecated and will be removed in Contao 6. Use PageModel::getAbsoluteUrl() and the contao_backend_preview route instead.');
 
 		$container = System::getContainer();
 

--- a/core-bundle/contao/models/PageModel.php
+++ b/core-bundle/contao/models/PageModel.php
@@ -1177,7 +1177,7 @@ class PageModel extends Model
 	 */
 	public function getPreviewUrl($strParams=null)
 	{
-		trigger_deprecation('contao/core-bundle', '5.3', __METHOD__ . ' is deprecated and will be removed in Contao 6. Use the preview controller arguments instead.');
+		trigger_deprecation('contao/core-bundle', '5.3', __METHOD__ . ' is deprecated and will be removed in Contao 6. Use getAbsoluteUrl() and the preview controller instead.');
 
 		$container = System::getContainer();
 

--- a/core-bundle/contao/models/PageModel.php
+++ b/core-bundle/contao/models/PageModel.php
@@ -1177,6 +1177,8 @@ class PageModel extends Model
 	 */
 	public function getPreviewUrl($strParams=null)
 	{
+		trigger_deprecation('contao/core-bundle', '5.3', __METHOD__ . ' is deprecated and will be removed in Contao 6. Use the preview controller arguments instead.');
+
 		$container = System::getContainer();
 
 		if (!$previewScript = $container->getParameter('contao.preview_script'))

--- a/core-bundle/src/EventListener/PreviewUrlConvertListener.php
+++ b/core-bundle/src/EventListener/PreviewUrlConvertListener.php
@@ -60,7 +60,7 @@ class PreviewUrlConvertListener
             }
 
             try {
-                $event->setUrl($page->getPreviewUrl($this->getParams($request, $page->id)));
+                $event->setUrl($page->getAbsoluteUrl($this->getParams($request, $page->id)));
             } catch (RouteParametersException $e) {
                 $route = $e->getRoute();
 

--- a/core-bundle/tests/EventListener/PreviewUrlConverterListenerTest.php
+++ b/core-bundle/tests/EventListener/PreviewUrlConverterListenerTest.php
@@ -96,7 +96,7 @@ class PreviewUrlConverterListenerTest extends TestCase
 
         $pageModel
             ->expects($this->once())
-            ->method('getPreviewUrl')
+            ->method('getAbsoluteUrl')
             ->with(null)
             ->willReturn('/en/content-elements.html')
         ;
@@ -157,7 +157,7 @@ class PreviewUrlConverterListenerTest extends TestCase
 
         $pageModel
             ->expects($this->once())
-            ->method('getPreviewUrl')
+            ->method('getAbsoluteUrl')
             ->with('/articles/foobar')
             ->willReturn('/en/content-elements/articles/foobar.html')
         ;
@@ -184,7 +184,7 @@ class PreviewUrlConverterListenerTest extends TestCase
         $pageModel = $this->mockClassWithProperties(PageModel::class, ['id' => 42, 'rootLanguage' => 'en']);
         $pageModel
             ->expects($this->once())
-            ->method('getPreviewUrl')
+            ->method('getAbsoluteUrl')
             ->willThrowException(new RouteNotFoundException())
         ;
 
@@ -241,7 +241,7 @@ class PreviewUrlConverterListenerTest extends TestCase
 
         $pageModel
             ->expects($this->once())
-            ->method('getPreviewUrl')
+            ->method('getAbsoluteUrl')
             ->willThrowException(
                 new RouteParametersException(
                     $route,


### PR DESCRIPTION
_Preparing for the content URL generator._

The `PageModel::getPreviewUrl` method is absolutely unnecessary. The correct approach to generating a front end preview URL is to use the `/contao/preview` controller. This controller [already appends the preview script](https://github.com/contao/contao/blob/5.x/core-bundle/src/Controller/BackendPreviewController.php#L49) before calling event listeners, so event listeners simply need to generate the current URL to get a preview link.