### PR TITLE
Disallow the web profiler in the `robots.txt` file

### DIFF
--- a/core-bundle/composer.json
+++ b/core-bundle/composer.json
@@ -150,7 +150,8 @@
         "phpunit/phpunit": "^9.3",
         "roave/better-reflection": "^4.12.2 || ^5.0",
         "symfony/browser-kit": "^5.4",
-        "symfony/phpunit-bridge": "^5.4"
+        "symfony/phpunit-bridge": "^5.4",
+        "symfony/web-profiler-bundle": "^5.4"
     },
     "conflict": {
         "contao-community-alliance/composer-plugin": "<3.0",

--- a/core-bundle/src/EventListener/RobotsTxtListener.php
+++ b/core-bundle/src/EventListener/RobotsTxtListener.php
@@ -15,6 +15,7 @@ namespace Contao\CoreBundle\EventListener;
 use Contao\CoreBundle\Event\RobotsTxtEvent;
 use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\PageModel;
+use Symfony\Bundle\WebProfilerBundle\EventListener\WebDebugToolbarListener;
 use webignition\RobotsTxt\Directive\Directive;
 use webignition\RobotsTxt\Directive\UserAgentDirective;
 use webignition\RobotsTxt\Inspector\Inspector;
@@ -26,11 +27,13 @@ use webignition\RobotsTxt\Record\Record;
 class RobotsTxtListener
 {
     private ContaoFramework $contaoFramework;
+    private ?WebDebugToolbarListener $webDebugToolbarListener;
     private string $routePrefix;
 
-    public function __construct(ContaoFramework $contaoFramework, string $routePrefix = '/contao')
+    public function __construct(ContaoFramework $contaoFramework, WebDebugToolbarListener $webDebugToolbarListener = null, string $routePrefix = '/contao')
     {
         $this->contaoFramework = $contaoFramework;
+        $this->webDebugToolbarListener = $webDebugToolbarListener;
         $this->routePrefix = $routePrefix;
     }
 
@@ -60,6 +63,11 @@ class RobotsTxtListener
             $directiveList = $record->getDirectiveList();
             $directiveList->add(new Directive('Disallow', $this->routePrefix.'/'));
             $directiveList->add(new Directive('Disallow', '/_contao/'));
+
+            if ($this->webDebugToolbarListener && $this->webDebugToolbarListener->isEnabled()) {
+                $directiveList->add(new Directive('Disallow', '/_profiler/'));
+                $directiveList->add(new Directive('Disallow', '/_wdt/'));
+            }
         }
 
         $pageModel = $this->contaoFramework->getAdapter(PageModel::class);

--- a/core-bundle/src/Resources/config/listener.yml
+++ b/core-bundle/src/Resources/config/listener.yml
@@ -456,6 +456,7 @@ services:
         class: Contao\CoreBundle\EventListener\RobotsTxtListener
         arguments:
             - '@contao.framework'
+            - '@?web_profiler.debug_toolbar'
             - '%contao.backend.route_prefix%'
         tags:
             - kernel.event_listener

--- a/core-bundle/tests/EventListener/RobotsTxtListenerTest.php
+++ b/core-bundle/tests/EventListener/RobotsTxtListenerTest.php
@@ -16,6 +16,7 @@ use Contao\CoreBundle\Event\RobotsTxtEvent;
 use Contao\CoreBundle\EventListener\RobotsTxtListener;
 use Contao\CoreBundle\Tests\TestCase;
 use Contao\PageModel;
+use Symfony\Bundle\WebProfilerBundle\EventListener\WebDebugToolbarListener;
 use Symfony\Component\HttpFoundation\Request;
 use webignition\RobotsTxt\Directive\Directive;
 use webignition\RobotsTxt\DirectiveList\DirectiveList;
@@ -28,7 +29,7 @@ class RobotsTxtListenerTest extends TestCase
     /**
      * @dataProvider disallowProvider
      */
-    public function testRobotsTxt(string $providedRobotsTxt, string $expectedRobotsTxt): void
+    public function testRobotsTxt(string $providedRobotsTxt, bool|null $withWebProfiler, string $expectedRobotsTxt): void
     {
         $rootPage = $this->mockClassWithProperties(PageModel::class);
         $rootPage->id = 42;
@@ -49,13 +50,24 @@ class RobotsTxtListenerTest extends TestCase
             ->method('initialize')
         ;
 
+        $webDebugToolbar = null;
+
+        if (\is_bool($withWebProfiler)) {
+            $webDebugToolbar = $this->createMock(WebDebugToolbarListener::class);
+            $webDebugToolbar
+                ->expects($this->atLeastOnce())
+                ->method('isEnabled')
+                ->willReturn($withWebProfiler)
+            ;
+        }
+
         $parser = new Parser();
         $parser->setSource($providedRobotsTxt);
         $file = $parser->getFile();
 
         $event = new RobotsTxtEvent($file, new Request(), $rootPage);
 
-        $listener = new RobotsTxtListener($framework);
+        $listener = new RobotsTxtListener($framework, $webDebugToolbar);
         $listener($event);
 
         // Output should be the same, if there is another listener
@@ -68,6 +80,7 @@ class RobotsTxtListenerTest extends TestCase
     {
         yield 'Empty robots.txt content in root page' => [
             '',
+            null,
             <<<'EOF'
                 user-agent:*
                 disallow:/contao/
@@ -83,6 +96,7 @@ class RobotsTxtListenerTest extends TestCase
                 allow:/
                 EOF
             ,
+            null,
             <<<'EOF'
                 user-agent:*
                 allow:/
@@ -99,12 +113,64 @@ class RobotsTxtListenerTest extends TestCase
                 allow:/
                 EOF
             ,
+            null,
             <<<'EOF'
                 user-agent:googlebot
                 allow:/
                 disallow:/contao/
                 disallow:/_contao/
 
+                user-agent:*
+                disallow:/contao/
+                disallow:/_contao/
+
+                sitemap:https://www.foobar.com/sitemap.xml
+                EOF,
+        ];
+
+        yield 'Empty robots.txt with web profiler enabled' => [
+            '',
+            true,
+            <<<'EOF'
+                user-agent:*
+                disallow:/contao/
+                disallow:/_contao/
+                disallow:/_profiler/
+                disallow:/_wdt/
+
+                sitemap:https://www.foobar.com/sitemap.xml
+                EOF,
+        ];
+
+        yield 'Multiple user-agents with web profiler enabled' => [
+            <<<'EOF'
+                user-agent:googlebot
+                allow:/
+                EOF
+            ,
+            true,
+            <<<'EOF'
+                user-agent:googlebot
+                allow:/
+                disallow:/contao/
+                disallow:/_contao/
+                disallow:/_profiler/
+                disallow:/_wdt/
+
+                user-agent:*
+                disallow:/contao/
+                disallow:/_contao/
+                disallow:/_profiler/
+                disallow:/_wdt/
+
+                sitemap:https://www.foobar.com/sitemap.xml
+                EOF,
+        ];
+
+        yield 'Empty robots.txt with web profiler disabled' => [
+            '',
+            false,
+            <<<'EOF'
                 user-agent:*
                 disallow:/contao/
                 disallow:/_contao/
@@ -155,7 +221,7 @@ class RobotsTxtListenerTest extends TestCase
 
         $framework = $this->mockContaoFramework([PageModel::class => $pageModelAdapter]);
 
-        $listener = new RobotsTxtListener($framework, $routePrefix);
+        $listener = new RobotsTxtListener($framework, null, $routePrefix);
         $listener($event);
     }
 

--- a/core-bundle/tests/EventListener/RobotsTxtListenerTest.php
+++ b/core-bundle/tests/EventListener/RobotsTxtListenerTest.php
@@ -29,7 +29,7 @@ class RobotsTxtListenerTest extends TestCase
     /**
      * @dataProvider disallowProvider
      */
-    public function testRobotsTxt(string $providedRobotsTxt, bool|null $withWebProfiler, string $expectedRobotsTxt): void
+    public function testRobotsTxt(string $providedRobotsTxt, ?bool $withWebProfiler, string $expectedRobotsTxt): void
     {
         $rootPage = $this->mockClassWithProperties(PageModel::class);
         $rootPage->id = 42;

--- a/core-bundle/tests/EventListener/RobotsTxtListenerTest.php
+++ b/core-bundle/tests/EventListener/RobotsTxtListenerTest.php
@@ -63,9 +63,8 @@ class RobotsTxtListenerTest extends TestCase
 
         $parser = new Parser();
         $parser->setSource($providedRobotsTxt);
-        $file = $parser->getFile();
 
-        $event = new RobotsTxtEvent($file, new Request(), $rootPage);
+        $event = new RobotsTxtEvent($parser->getFile(), new Request(), $rootPage);
 
         $listener = new RobotsTxtListener($framework, $webDebugToolbar);
         $listener($event);

--- a/tools/require-checker/config.json
+++ b/tools/require-checker/config.json
@@ -26,6 +26,7 @@
         "Michelf\\MarkdownExtra",
         "ProxyManager\\Configuration",
         "Roave\\BetterReflection\\BetterReflection",
-        "Symfony\\Bundle\\MonologBundle\\MonologBundle"
+        "Symfony\\Bundle\\MonologBundle\\MonologBundle",
+        "Symfony\\Bundle\\WebProfilerBundle\\EventListener\\WebDebugToolbarListener"
     ]
 }


### PR DESCRIPTION
Fixes https://github.com/contao/contao/issues/6592

Technically, the `/_profiler/` and `/_wdt` routes can be reconfigured, but I don't think we can _detect_ that and it's probably not worth the effort 🙃 