### PR TITLE
Check for parameter existence

### DIFF
--- a/core-bundle/src/Controller/AbstractController.php
+++ b/core-bundle/src/Controller/AbstractController.php
@@ -21,7 +21,6 @@ use Contao\PageModel;
 use FOS\HttpCacheBundle\Http\SymfonyResponseTagger;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController as SymfonyAbstractController;
-use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Response;
 

--- a/core-bundle/src/Controller/AbstractController.php
+++ b/core-bundle/src/Controller/AbstractController.php
@@ -21,6 +21,7 @@ use Contao\PageModel;
 use FOS\HttpCacheBundle\Http\SymfonyResponseTagger;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController as SymfonyAbstractController;
+use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -123,5 +124,14 @@ abstract class AbstractController extends SymfonyAbstractController
         }
 
         return $response;
+    }
+
+    protected function hasParameter(string $name): bool
+    {
+        if (!$this->container->has('parameter_bag')) {
+            return false;
+        }
+
+        return $this->container->get('parameter_bag')->has($name);
     }
 }

--- a/core-bundle/src/Controller/ContentElement/AbstractDownloadContentElementController.php
+++ b/core-bundle/src/Controller/ContentElement/AbstractDownloadContentElementController.php
@@ -100,7 +100,7 @@ abstract class AbstractDownloadContentElementController extends AbstractContentE
     {
         // Only allow certain file extensions
         $getAllowedFileExtensions = function (): array {
-            if (null !== $this->getParameter('contao.downloadable_files')) {
+            if ($this->hasParameter('contao.downloadable_files')) {
                 return $this->getParameter('contao.downloadable_files');
             }
 


### PR DESCRIPTION
We need to check for this parameter to exist. Unfortunately, Symfony itself does not provide a `hasParameter()` but `getParameter()` only which throws a `ServiceNotFoundException` in case there was no `parameter_bag` service registered. So one would always need to `try/catch` this. I figured, a `hasParameter()` can be useful for us.