### PR TITLE
Generate news URLs using the content URL generator

### DIFF
--- a/news-bundle/config/services.yaml
+++ b/news-bundle/config/services.yaml
@@ -50,6 +50,7 @@ services:
         class: Contao\NewsBundle\EventListener\InsertTagsListener
         arguments:
             - '@contao.framework'
+            - '@contao.routing.content_url_generator'
             - '@logger'
         tags:
             - { name: contao.hook, hook: replaceInsertTags }
@@ -59,6 +60,7 @@ services:
         arguments:
             - '@contao.framework'
             - '@contao.image.factory'
+            - '@contao.routing.content_url_generator'
             - '@contao.insert_tag.parser'
             - '%kernel.project_dir%'
             - '@contao.cache.entity_tags'
@@ -68,6 +70,7 @@ services:
         class: Contao\NewsBundle\EventListener\PreviewUrlConvertListener
         arguments:
             - '@contao.framework'
+            - '@contao.routing.content_url_generator'
         tags:
             - kernel.event_listener
 

--- a/news-bundle/config/services.yaml
+++ b/news-bundle/config/services.yaml
@@ -42,6 +42,7 @@ services:
         class: Contao\NewsBundle\EventListener\GeneratePageListener
         arguments:
             - '@contao.framework'
+            - '@contao.routing.content_url_generator'
         tags:
             - { name: contao.hook, hook: generatePage }
 
@@ -83,6 +84,7 @@ services:
         arguments:
             - '@contao.framework'
             - '@security.helper'
+            - '@contao.routing.content_url_generator'
         tags:
             - kernel.event_listener
 
@@ -103,6 +105,11 @@ services:
             - '@security.helper'
         tags:
             - { name: contao.picker_provider, priority: 128 }
+
+    contao_news.routing.news_resolver:
+        class: Contao\NewsBundle\Routing\NewsResolver
+        arguments:
+            - '@contao.framework'
 
     contao_news.security.news_access_voter:
         class: Contao\NewsBundle\Security\Voter\NewsAccessVoter

--- a/news-bundle/contao/classes/News.php
+++ b/news-bundle/contao/classes/News.php
@@ -26,10 +26,13 @@ class News extends Frontend
 	 * @param boolean   $blnAbsolute
 	 *
 	 * @return string
+	 *
+	 * @deprecated Deprecated since Contao 5.3, to be removed in Contao 6;
+	 *             use the content URL generator instead.
 	 */
 	public static function generateNewsUrl($objItem, $blnAddArchive=false, $blnAbsolute=false)
 	{
-		trigger_deprecation('contao/core-bundle', '5.3', 'Using "%s" is deprecated, use the content URL generator instead.', __METHOD__);
+		trigger_deprecation('contao/core-bundle', '5.3', 'Using "%s()" has been deprecated and will no longer work in Contao 6. Use the content URL generator instead.', __METHOD__);
 
 		try
 		{

--- a/news-bundle/contao/classes/News.php
+++ b/news-bundle/contao/classes/News.php
@@ -10,17 +10,14 @@
 
 namespace Contao;
 
+use Contao\CoreBundle\Util\UrlUtil;
+use Symfony\Component\Routing\Exception\ExceptionInterface;
+
 /**
  * Provide methods regarding news archives.
  */
 class News extends Frontend
 {
-	/**
-	 * URL cache array
-	 * @var array
-	 */
-	private static $arrUrlCache = array();
-
 	/**
 	 * Generate a URL and return it as string
 	 *
@@ -30,85 +27,33 @@ class News extends Frontend
 	 *
 	 * @return string
 	 */
-	public static function generateNewsUrl($objItem, $blnAddArchive=false, $blnAbsolute=false)
+	public static function generateNewsUrl($objItem, $blnAddArchive=false, $blnAbsolute=true)
 	{
-		$strCacheKey = 'id_' . $objItem->id . ($blnAbsolute ? '_absolute' : '') . (($blnAddArchive && Input::get('month')) ? '_' . Input::get('month') : '');
+		trigger_deprecation('contao/core-bundle', '5.3', 'Using "%s" is deprecated, use the content URL generator instead.', __METHOD__);
 
-		// Load the URL from cache
-		if (isset(self::$arrUrlCache[$strCacheKey]))
+		try
 		{
-			return self::$arrUrlCache[$strCacheKey];
-		}
-
-		// Initialize the cache
-		self::$arrUrlCache[$strCacheKey] = null;
-
-		switch ($objItem->source)
-		{
-			// Link to an external page
-			case 'external':
-				if (str_starts_with($objItem->url, 'mailto:'))
-				{
-					self::$arrUrlCache[$strCacheKey] = StringUtil::encodeEmail($objItem->url);
-				}
-				else
-				{
-					$url = $objItem->url;
-
-					if (Validator::isRelativeUrl($url))
-					{
-						$url = Environment::get('path') . '/' . $url;
-					}
-
-					self::$arrUrlCache[$strCacheKey] = StringUtil::ampersand($url);
-				}
-				break;
-
-			// Link to an internal page
-			case 'internal':
-				if (($objTarget = $objItem->getRelated('jumpTo')) instanceof PageModel)
-				{
-					/** @var PageModel $objTarget */
-					self::$arrUrlCache[$strCacheKey] = StringUtil::ampersand($blnAbsolute ? $objTarget->getAbsoluteUrl() : $objTarget->getFrontendUrl());
-				}
-				break;
-
-			// Link to an article
-			case 'article':
-				if (($objArticle = ArticleModel::findByPk($objItem->articleId)) instanceof ArticleModel && ($objPid = $objArticle->getRelated('pid')) instanceof PageModel)
-				{
-					$params = '/articles/' . ($objArticle->alias ?: $objArticle->id);
-
-					/** @var PageModel $objPid */
-					self::$arrUrlCache[$strCacheKey] = StringUtil::ampersand($blnAbsolute ? $objPid->getAbsoluteUrl($params) : $objPid->getFrontendUrl($params));
-				}
-				break;
-		}
-
-		// Link to the default page
-		if (self::$arrUrlCache[$strCacheKey] === null)
-		{
-			$objPage = PageModel::findByPk($objItem->getRelated('pid')->jumpTo);
-
-			if (!$objPage instanceof PageModel)
-			{
-				self::$arrUrlCache[$strCacheKey] = StringUtil::ampersand(Environment::get('requestUri'));
-			}
-			else
-			{
-				$params = '/' . ($objItem->alias ?: $objItem->id);
-
-				self::$arrUrlCache[$strCacheKey] = StringUtil::ampersand($blnAbsolute ? $objPage->getAbsoluteUrl($params) : $objPage->getFrontendUrl($params));
-			}
+			$parameters = array();
 
 			// Add the current archive parameter (news archive)
 			if ($blnAddArchive && Input::get('month'))
 			{
-				self::$arrUrlCache[$strCacheKey] .= '?month=' . Input::get('month');
+				$parameters['month'] = Input::get('month');
 			}
+
+			$url = System::getContainer()->get('contao.routing.content_url_generator')->generate($objItem, $parameters);
+		}
+		catch (ExceptionInterface)
+		{
+			return StringUtil::ampersand(Environment::get('requestUri'));
 		}
 
-		return self::$arrUrlCache[$strCacheKey];
+		if (!$blnAbsolute)
+		{
+			$url = UrlUtil::makeAbsolutePath($url, Environment::get('base'));
+		}
+
+		return $url;
 	}
 
 	/**

--- a/news-bundle/contao/classes/News.php
+++ b/news-bundle/contao/classes/News.php
@@ -27,7 +27,7 @@ class News extends Frontend
 	 *
 	 * @return string
 	 */
-	public static function generateNewsUrl($objItem, $blnAddArchive=false, $blnAbsolute=true)
+	public static function generateNewsUrl($objItem, $blnAddArchive=false, $blnAbsolute=false)
 	{
 		trigger_deprecation('contao/core-bundle', '5.3', 'Using "%s" is deprecated, use the content URL generator instead.', __METHOD__);
 

--- a/news-bundle/contao/classes/News.php
+++ b/news-bundle/contao/classes/News.php
@@ -61,11 +61,12 @@ class News extends Frontend
 	public static function getSchemaOrgData(NewsModel $objArticle): array
 	{
 		$htmlDecoder = System::getContainer()->get('contao.string.html_decoder');
+		$urlGenerator = System::getContainer()->get('contao.routing.content_url_generator');
 
 		$jsonLd = array(
 			'@type' => 'NewsArticle',
 			'identifier' => '#/schema/news/' . $objArticle->id,
-			'url' => self::generateNewsUrl($objArticle),
+			'url' => $urlGenerator->generate($objArticle),
 			'headline' => $htmlDecoder->inputEncodedToPlainText($objArticle->headline),
 			'datePublished' => date('Y-m-d\TH:i:sP', $objArticle->date),
 		);

--- a/news-bundle/contao/classes/News.php
+++ b/news-bundle/contao/classes/News.php
@@ -10,7 +10,6 @@
 
 namespace Contao;
 
-use Contao\CoreBundle\Util\UrlUtil;
 use Symfony\Component\Routing\Exception\ExceptionInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 

--- a/news-bundle/contao/classes/News.php
+++ b/news-bundle/contao/classes/News.php
@@ -12,6 +12,7 @@ namespace Contao;
 
 use Contao\CoreBundle\Util\UrlUtil;
 use Symfony\Component\Routing\Exception\ExceptionInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
  * Provide methods regarding news archives.
@@ -41,16 +42,11 @@ class News extends Frontend
 				$parameters['month'] = Input::get('month');
 			}
 
-			$url = System::getContainer()->get('contao.routing.content_url_generator')->generate($objItem, $parameters);
+			$url = System::getContainer()->get('contao.routing.content_url_generator')->generate($objItem, $parameters, $blnAbsolute ? UrlGeneratorInterface::ABSOLUTE_URL : UrlGeneratorInterface::ABSOLUTE_PATH);
 		}
 		catch (ExceptionInterface)
 		{
 			return StringUtil::ampersand(Environment::get('requestUri'));
-		}
-
-		if (!$blnAbsolute)
-		{
-			$url = UrlUtil::makeAbsolutePath($url, Environment::get('base'));
 		}
 
 		return $url;

--- a/news-bundle/contao/dca/tl_news.php
+++ b/news-bundle/contao/dca/tl_news.php
@@ -219,7 +219,7 @@ $GLOBALS['TL_DCA']['tl_news'] = array
 		(
 			'label'                   => &$GLOBALS['TL_LANG']['MSC']['serpPreview'],
 			'inputType'               => 'serpPreview',
-			'eval'                    => array('url_callback'=>array('tl_news', 'getSerpUrl'), 'title_tag_callback'=>array('tl_news', 'getTitleTag'), 'titleFields'=>array('pageTitle', 'headline'), 'descriptionFields'=>array('description', 'teaser')),
+			'eval'                    => array('title_tag_callback'=>array('tl_news', 'getTitleTag'), 'titleFields'=>array('pageTitle', 'headline'), 'descriptionFields'=>array('description', 'teaser')),
 			'sql'                     => null
 		),
 		'canonicalLink' => array
@@ -479,18 +479,6 @@ class tl_news extends Backend
 	public function loadTime($value)
 	{
 		return strtotime('1970-01-01 ' . date('H:i:s', $value));
-	}
-
-	/**
-	 * Return the SERP URL
-	 *
-	 * @param NewsModel $model
-	 *
-	 * @return string
-	 */
-	public function getSerpUrl(NewsModel $model)
-	{
-		return News::generateNewsUrl($model, false, true);
 	}
 
 	/**

--- a/news-bundle/contao/modules/ModuleNews.php
+++ b/news-bundle/contao/modules/ModuleNews.php
@@ -86,7 +86,7 @@ abstract class ModuleNews extends Module
 		$objTemplate->hasSubHeadline = $objArticle->subheadline ? true : false;
 		$objTemplate->linkHeadline = $this->generateLink($objArticle->headline, $objArticle, $blnAddArchive);
 		$objTemplate->more = $this->generateLink($objArticle->linkText ?: $GLOBALS['TL_LANG']['MSC']['more'], $objArticle, $blnAddArchive, true);
-		$objTemplate->link = News::generateNewsUrl($objArticle, $blnAddArchive);
+		$objTemplate->link = $this->generateContentUrl($objArticle, $blnAddArchive);
 		$objTemplate->archive = $objArticle->getRelated('pid');
 		$objTemplate->count = $intCount; // see #5708
 		$objTemplate->text = '';
@@ -302,7 +302,7 @@ abstract class ModuleNews extends Module
 	{
 		$blnIsInternal = $objArticle->source != 'external';
 		$strReadMore = $blnIsInternal ? $GLOBALS['TL_LANG']['MSC']['readMore'] : $GLOBALS['TL_LANG']['MSC']['open'];
-		$strArticleUrl = News::generateNewsUrl($objArticle, $blnAddArchive);
+		$strArticleUrl = $this->generateContentUrl($objArticle, $blnAddArchive);
 
 		return sprintf(
 			'<a href="%s" title="%s"%s>%s%s</a>',
@@ -312,5 +312,18 @@ abstract class ModuleNews extends Module
 			$strLink,
 			$blnIsReadMore && $blnIsInternal ? '<span class="invisible"> ' . $objArticle->headline . '</span>' : ''
 		);
+	}
+
+	private function generateContentUrl(NewsModel $content, bool $addArchive): string
+	{
+		$parameters = array();
+
+		// Add the current archive parameter (news archive)
+		if ($addArchive && Input::get('month'))
+		{
+			$parameters['month'] = Input::get('month');
+		}
+
+		return System::getContainer()->get('contao.routing.content_url_generator')->generate($content, $parameters);
 	}
 }

--- a/news-bundle/contao/modules/ModuleNewsMenu.php
+++ b/news-bundle/contao/modules/ModuleNewsMenu.php
@@ -11,6 +11,7 @@
 namespace Contao;
 
 use Contao\CoreBundle\Exception\PageNotFoundException;
+use Symfony\Component\Routing\Exception\ExceptionInterface;
 
 /**
  * Front end module "news archive".
@@ -74,8 +75,15 @@ class ModuleNewsMenu extends ModuleNews
 
 		if (($objTarget = $this->objModel->getRelated('jumpTo')) instanceof PageModel)
 		{
-			/** @var PageModel $objTarget */
-			$this->strUrl = $objTarget->getFrontendUrl();
+			try
+			{
+				$urlGenerator = System::getContainer()->get('contao.routing.content_url_generator');
+
+				$this->strUrl = $urlGenerator->generate($objTarget);
+			}
+			catch (ExceptionInterface)
+			{
+			}
 		}
 
 		return parent::generate();

--- a/news-bundle/contao/modules/ModuleNewsMenu.php
+++ b/news-bundle/contao/modules/ModuleNewsMenu.php
@@ -77,9 +77,7 @@ class ModuleNewsMenu extends ModuleNews
 		{
 			try
 			{
-				$urlGenerator = System::getContainer()->get('contao.routing.content_url_generator');
-
-				$this->strUrl = $urlGenerator->generate($objTarget);
+				$this->strUrl = System::getContainer()->get('contao.routing.content_url_generator')->generate($objTarget);
 			}
 			catch (ExceptionInterface)
 			{

--- a/news-bundle/contao/modules/ModuleNewsReader.php
+++ b/news-bundle/contao/modules/ModuleNewsReader.php
@@ -76,9 +76,9 @@ class ModuleNewsReader extends ModuleNews
 	 */
 	protected function compile()
 	{
-		$urlGenerator = System::getContainer()->get('contao.routing.content_url_generator');
-
 		$this->Template->articles = '';
+
+		$urlGenerator = System::getContainer()->get('contao.routing.content_url_generator');
 
 		if ($this->overviewPage && ($overviewPage = PageModel::findById($this->overviewPage)))
 		{

--- a/news-bundle/contao/modules/ModuleNewsReader.php
+++ b/news-bundle/contao/modules/ModuleNewsReader.php
@@ -99,7 +99,7 @@ class ModuleNewsReader extends ModuleNews
 			case 'internal':
 			case 'article':
 			case 'external':
-				throw new RedirectResponseException(System::getContainer()->get('contao.routing.content_url_generator')->generate($objArticle, [], UrlGeneratorInterface::ABSOLUTE_URL), 301);
+				throw new RedirectResponseException(System::getContainer()->get('contao.routing.content_url_generator')->generate($objArticle, array(), UrlGeneratorInterface::ABSOLUTE_URL), 301);
 		}
 
 		// Set the default template

--- a/news-bundle/contao/modules/ModuleNewsReader.php
+++ b/news-bundle/contao/modules/ModuleNewsReader.php
@@ -77,9 +77,9 @@ class ModuleNewsReader extends ModuleNews
 	{
 		$this->Template->articles = '';
 
-		if ($this->overviewPage)
+		if ($this->overviewPage && ($overviewPage = PageModel::findById($this->overviewPage)))
 		{
-			$this->Template->referer = PageModel::findById($this->overviewPage)->getFrontendUrl();
+			$this->Template->referer = System::getContainer()->get('contao.routing.content_url_generator')->generate($overviewPage);
 			$this->Template->back = $this->customLabel ?: $GLOBALS['TL_LANG']['MSC']['newsOverview'];
 		}
 

--- a/news-bundle/contao/modules/ModuleNewsReader.php
+++ b/news-bundle/contao/modules/ModuleNewsReader.php
@@ -96,31 +96,9 @@ class ModuleNewsReader extends ModuleNews
 		switch ($objArticle->source)
 		{
 			case 'internal':
-				if ($page = PageModel::findPublishedById($objArticle->jumpTo))
-				{
-					throw new RedirectResponseException($page->getAbsoluteUrl(), 301);
-				}
-
-				throw new InternalServerErrorException('Invalid "jumpTo" value or target page not public');
-
 			case 'article':
-				if (($article = ArticleModel::findByPk($objArticle->articleId)) && ($page = PageModel::findPublishedById($article->pid)))
-				{
-					throw new RedirectResponseException($page->getAbsoluteUrl('/articles/' . ($article->alias ?: $article->id)), 301);
-				}
-
-				throw new InternalServerErrorException('Invalid "articleId" value or target page not public');
-
 			case 'external':
-				if ($objArticle->url)
-				{
-					$url = System::getContainer()->get('contao.insert_tag.parser')->replaceInline($objArticle->url);
-					$url = UrlUtil::makeAbsolute($url, Environment::get('base'));
-
-					throw new RedirectResponseException($url, 301);
-				}
-
-				throw new InternalServerErrorException('Empty target URL');
+				throw new RedirectResponseException(System::getContainer()->get('contao.routing.content_url_generator')->generate($objArticle), 301);
 		}
 
 		// Set the default template

--- a/news-bundle/contao/modules/ModuleNewsReader.php
+++ b/news-bundle/contao/modules/ModuleNewsReader.php
@@ -76,11 +76,13 @@ class ModuleNewsReader extends ModuleNews
 	 */
 	protected function compile()
 	{
+		$urlGenerator = System::getContainer()->get('contao.routing.content_url_generator');
+
 		$this->Template->articles = '';
 
 		if ($this->overviewPage && ($overviewPage = PageModel::findById($this->overviewPage)))
 		{
-			$this->Template->referer = System::getContainer()->get('contao.routing.content_url_generator')->generate($overviewPage);
+			$this->Template->referer = $urlGenerator->generate($overviewPage);
 			$this->Template->back = $this->customLabel ?: $GLOBALS['TL_LANG']['MSC']['newsOverview'];
 		}
 
@@ -162,7 +164,7 @@ class ModuleNewsReader extends ModuleNews
 			}
 			elseif (!$this->news_keepCanonical)
 			{
-				$htmlHeadBag->setCanonicalUri(News::generateNewsUrl($objArticle, false, true));
+				$htmlHeadBag->setCanonicalUri($urlGenerator->generate($objArticle, array(), UrlGeneratorInterface::ABSOLUTE_URL));
 			}
 		}
 

--- a/news-bundle/contao/modules/ModuleNewsReader.php
+++ b/news-bundle/contao/modules/ModuleNewsReader.php
@@ -15,6 +15,7 @@ use Contao\CoreBundle\Exception\PageNotFoundException;
 use Contao\CoreBundle\Exception\RedirectResponseException;
 use Contao\CoreBundle\Routing\ResponseContext\HtmlHeadBag\HtmlHeadBag;
 use Contao\CoreBundle\Util\UrlUtil;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
  * Front end module "newsreader".
@@ -98,7 +99,7 @@ class ModuleNewsReader extends ModuleNews
 			case 'internal':
 			case 'article':
 			case 'external':
-				throw new RedirectResponseException(System::getContainer()->get('contao.routing.content_url_generator')->generate($objArticle), 301);
+				throw new RedirectResponseException(System::getContainer()->get('contao.routing.content_url_generator')->generate($objArticle, [], UrlGeneratorInterface::ABSOLUTE_URL), 301);
 		}
 
 		// Set the default template

--- a/news-bundle/src/EventListener/GeneratePageListener.php
+++ b/news-bundle/src/EventListener/GeneratePageListener.php
@@ -56,8 +56,8 @@ class GeneratePageListener
                 continue;
             }
 
-            // TODO: Use ResponseContext, once it supports appending to <head>
             try {
+                // TODO: Use ResponseContext, once it supports appending to <head>
                 $GLOBALS['TL_HEAD'][] = $this->generateFeedTag($this->urlGenerator->generate($feed, [], UrlGeneratorInterface::ABSOLUTE_URL), $feed->feedFormat, $feed->title);
             } catch (ExceptionInterface) {
             }

--- a/news-bundle/src/EventListener/GeneratePageListener.php
+++ b/news-bundle/src/EventListener/GeneratePageListener.php
@@ -13,18 +13,22 @@ declare(strict_types=1);
 namespace Contao\NewsBundle\EventListener;
 
 use Contao\CoreBundle\Framework\ContaoFramework;
+use Contao\CoreBundle\Routing\ContentUrlGenerator;
 use Contao\LayoutModel;
 use Contao\NewsBundle\Controller\Page\NewsFeedController;
 use Contao\PageModel;
 use Contao\StringUtil;
+use Symfony\Component\Routing\Exception\ExceptionInterface;
 
 /**
  * @internal
  */
 class GeneratePageListener
 {
-    public function __construct(private readonly ContaoFramework $framework)
-    {
+    public function __construct(
+        private readonly ContaoFramework $framework,
+        private readonly ContentUrlGenerator $urlGenerator,
+    ) {
     }
 
     /**
@@ -52,7 +56,10 @@ class GeneratePageListener
             }
 
             // TODO: Use ResponseContext, once it supports appending to <head>
-            $GLOBALS['TL_HEAD'][] = $this->generateFeedTag($feed->getAbsoluteUrl(), $feed->feedFormat, $feed->title);
+            try {
+                $GLOBALS['TL_HEAD'][] = $this->generateFeedTag($this->urlGenerator->generate($feed), $feed->feedFormat, $feed->title);
+            } catch (ExceptionInterface) {
+            }
         }
     }
 

--- a/news-bundle/src/EventListener/GeneratePageListener.php
+++ b/news-bundle/src/EventListener/GeneratePageListener.php
@@ -19,6 +19,7 @@ use Contao\NewsBundle\Controller\Page\NewsFeedController;
 use Contao\PageModel;
 use Contao\StringUtil;
 use Symfony\Component\Routing\Exception\ExceptionInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
  * @internal
@@ -57,7 +58,7 @@ class GeneratePageListener
 
             // TODO: Use ResponseContext, once it supports appending to <head>
             try {
-                $GLOBALS['TL_HEAD'][] = $this->generateFeedTag($this->urlGenerator->generate($feed), $feed->feedFormat, $feed->title);
+                $GLOBALS['TL_HEAD'][] = $this->generateFeedTag($this->urlGenerator->generate($feed, [], UrlGeneratorInterface::ABSOLUTE_URL), $feed->feedFormat, $feed->title);
             } catch (ExceptionInterface) {
             }
         }

--- a/news-bundle/src/EventListener/InsertTagsListener.php
+++ b/news-bundle/src/EventListener/InsertTagsListener.php
@@ -13,10 +13,11 @@ declare(strict_types=1);
 namespace Contao\NewsBundle\EventListener;
 
 use Contao\CoreBundle\Framework\ContaoFramework;
-use Contao\News;
+use Contao\CoreBundle\Routing\ContentUrlGenerator;
 use Contao\NewsModel;
 use Contao\StringUtil;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
  * @internal
@@ -33,6 +34,7 @@ class InsertTagsListener
 
     public function __construct(
         private readonly ContaoFramework $framework,
+        private readonly ContentUrlGenerator $urlGenerator,
         private readonly LoggerInterface $logger,
     ) {
     }
@@ -65,23 +67,21 @@ class InsertTagsListener
             return '';
         }
 
-        $news = $this->framework->getAdapter(News::class);
-
         return match ($insertTag) {
             'news' => sprintf(
                 '<a href="%s" title="%s"%s>%s</a>',
-                $news->generateNewsUrl($model, false, \in_array('absolute', $arguments, true)) ?: './',
+                $this->urlGenerator->generate($model, [], \in_array('absolute', $arguments, true) ? UrlGeneratorInterface::ABSOLUTE_URL : UrlGeneratorInterface::ABSOLUTE_PATH),
                 StringUtil::specialcharsAttribute($model->headline),
                 \in_array('blank', $arguments, true) ? ' target="_blank" rel="noreferrer noopener"' : '',
                 $model->headline,
             ),
             'news_open' => sprintf(
                 '<a href="%s" title="%s"%s>',
-                $news->generateNewsUrl($model, false, \in_array('absolute', $arguments, true)) ?: './',
+                $this->urlGenerator->generate($model, [], \in_array('absolute', $arguments, true) ? UrlGeneratorInterface::ABSOLUTE_URL : UrlGeneratorInterface::ABSOLUTE_PATH),
                 StringUtil::specialcharsAttribute($model->headline),
                 \in_array('blank', $arguments, true) ? ' target="_blank" rel="noreferrer noopener"' : '',
             ),
-            'news_url' => $news->generateNewsUrl($model, false, \in_array('absolute', $arguments, true)) ?: './',
+            'news_url' => $this->urlGenerator->generate($model, [], \in_array('absolute', $arguments, true) ? UrlGeneratorInterface::ABSOLUTE_URL : UrlGeneratorInterface::ABSOLUTE_PATH),
             'news_title' => StringUtil::specialcharsAttribute($model->headline),
             'news_teaser' => $model->teaser,
             default => '',

--- a/news-bundle/src/EventListener/NewsFeedListener.php
+++ b/news-bundle/src/EventListener/NewsFeedListener.php
@@ -18,10 +18,10 @@ use Contao\CoreBundle\Cache\EntityCacheTags;
 use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\CoreBundle\Image\ImageFactoryInterface;
 use Contao\CoreBundle\InsertTag\InsertTagParser;
+use Contao\CoreBundle\Routing\ContentUrlGenerator;
 use Contao\Environment;
 use Contao\File;
 use Contao\FilesModel;
-use Contao\News;
 use Contao\NewsBundle\Event\FetchArticlesForFeedEvent;
 use Contao\NewsBundle\Event\TransformArticleForFeedEvent;
 use Contao\NewsModel;
@@ -34,12 +34,14 @@ use FeedIo\Feed\Item\Media;
 use FeedIo\Feed\ItemInterface;
 use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
 use Symfony\Component\Filesystem\Path;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class NewsFeedListener
 {
     public function __construct(
         private readonly ContaoFramework $framework,
         private readonly ImageFactoryInterface $imageFactory,
+        private readonly ContentUrlGenerator $urlGenerator,
         private readonly InsertTagParser $insertTags,
         private readonly string $projectDir,
         private readonly EntityCacheTags $cacheTags,
@@ -73,7 +75,7 @@ class NewsFeedListener
         $item = new Item();
         $item->setTitle(html_entity_decode($article->headline, ENT_QUOTES, $this->charset));
         $item->setLastModified((new \DateTime())->setTimestamp($article->date));
-        $item->setLink($this->getLink($article));
+        $item->setLink($this->urlGenerator->generate($article, [], UrlGeneratorInterface::ABSOLUTE_URL));
         $item->setContent($this->getContent($article, $item, $event));
         $item->setPublicId($item->getLink());
 
@@ -88,11 +90,6 @@ class NewsFeedListener
         }
 
         $event->setItem($item);
-    }
-
-    private function getLink(NewsModel $article): string
-    {
-        return $this->framework->getAdapter(News::class)->generateNewsUrl($article, false, true);
     }
 
     private function getContent(NewsModel $article, ItemInterface $item, TransformArticleForFeedEvent $event): string

--- a/news-bundle/src/EventListener/NewsFeedListener.php
+++ b/news-bundle/src/EventListener/NewsFeedListener.php
@@ -36,6 +36,9 @@ use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
 use Symfony\Component\Filesystem\Path;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
+/**
+ * @internal
+ */
 class NewsFeedListener
 {
     public function __construct(

--- a/news-bundle/src/EventListener/PreviewUrlConvertListener.php
+++ b/news-bundle/src/EventListener/PreviewUrlConvertListener.php
@@ -14,17 +14,20 @@ namespace Contao\NewsBundle\EventListener;
 
 use Contao\CoreBundle\Event\PreviewUrlConvertEvent;
 use Contao\CoreBundle\Framework\ContaoFramework;
-use Contao\News;
+use Contao\CoreBundle\Routing\ContentUrlGenerator;
 use Contao\NewsModel;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
  * @internal
  */
 class PreviewUrlConvertListener
 {
-    public function __construct(private readonly ContaoFramework $framework)
-    {
+    public function __construct(
+        private readonly ContaoFramework $framework,
+        private readonly ContentUrlGenerator $urlGenerator,
+    ) {
     }
 
     /**
@@ -40,7 +43,7 @@ class PreviewUrlConvertListener
             return;
         }
 
-        $event->setUrl($this->framework->getAdapter(News::class)->generateNewsUrl($news, false, true));
+        $event->setUrl($this->urlGenerator->generate($news, [], UrlGeneratorInterface::ABSOLUTE_URL));
     }
 
     private function getNewsModel(Request $request): NewsModel|null

--- a/news-bundle/src/EventListener/SitemapListener.php
+++ b/news-bundle/src/EventListener/SitemapListener.php
@@ -14,12 +14,14 @@ namespace Contao\NewsBundle\EventListener;
 
 use Contao\CoreBundle\Event\SitemapEvent;
 use Contao\CoreBundle\Framework\ContaoFramework;
+use Contao\CoreBundle\Routing\ContentUrlGenerator;
 use Contao\CoreBundle\Security\ContaoCorePermissions;
 use Contao\Database;
 use Contao\NewsArchiveModel;
 use Contao\NewsModel;
 use Contao\PageModel;
 use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\Routing\Exception\ExceptionInterface;
 
 /**
  * @internal
@@ -29,6 +31,7 @@ class SitemapListener
     public function __construct(
         private readonly ContaoFramework $framework,
         private readonly Security $security,
+        private readonly ContentUrlGenerator $urlGenerator,
     ) {
     }
 
@@ -106,7 +109,10 @@ class SitemapListener
                     continue;
                 }
 
-                $arrPages[] = $objParent->getAbsoluteUrl('/'.($objNews->alias ?: $objNews->id));
+                try {
+                    $arrPages[] = $this->urlGenerator->generate($objNews);
+                } catch (ExceptionInterface) {
+                }
             }
         }
 

--- a/news-bundle/src/EventListener/SitemapListener.php
+++ b/news-bundle/src/EventListener/SitemapListener.php
@@ -22,6 +22,7 @@ use Contao\NewsModel;
 use Contao\PageModel;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Routing\Exception\ExceptionInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
  * @internal
@@ -110,7 +111,7 @@ class SitemapListener
                 }
 
                 try {
-                    $arrPages[] = $this->urlGenerator->generate($objNews);
+                    $arrPages[] = $this->urlGenerator->generate($objNews, [], UrlGeneratorInterface::ABSOLUTE_URL);
                 } catch (ExceptionInterface) {
                 }
             }

--- a/news-bundle/src/Routing/NewsResolver.php
+++ b/news-bundle/src/Routing/NewsResolver.php
@@ -25,10 +25,10 @@ class NewsResolver implements ContentUrlResolverInterface
     {
     }
 
-    public function resolve(object $content): ContentUrlResult
+    public function resolve(object $content): ContentUrlResult|null
     {
         if (!$content instanceof NewsModel) {
-            return ContentUrlResult::abstain();
+            return null;
         }
 
         switch ($content->source) {

--- a/news-bundle/src/Routing/NewsResolver.php
+++ b/news-bundle/src/Routing/NewsResolver.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\NewsBundle\Routing;
+
+use Contao\ArticleModel;
+use Contao\CoreBundle\Framework\ContaoFramework;
+use Contao\CoreBundle\Routing\Content\ContentUrlResolverInterface;
+use Contao\CoreBundle\Routing\Content\ContentUrlResult;
+use Contao\NewsModel;
+use Contao\PageModel;
+
+class NewsResolver implements ContentUrlResolverInterface
+{
+    public function __construct(private readonly ContaoFramework $framework)
+    {
+    }
+
+    public function resolve(object $content): ContentUrlResult
+    {
+        if (!$content instanceof NewsModel) {
+            return ContentUrlResult::abstain();
+        }
+
+        switch ($content->source) {
+            // Link to an external page
+            case 'external':
+                return ContentUrlResult::url($content->url);
+
+            // Link to an internal page
+            case 'internal':
+                $pageAdapter = $this->framework->getAdapter(PageModel::class);
+
+                return ContentUrlResult::redirect($pageAdapter->findPublishedById($content->jumpTo));
+
+            // Link to an article
+            case 'article':
+                $articleAdapter = $this->framework->getAdapter(ArticleModel::class);
+
+                return ContentUrlResult::redirect($articleAdapter->findPublishedById($content->articleId));
+        }
+
+        $pageAdapter = $this->framework->getAdapter(PageModel::class);
+
+        // Link to the default page
+        return ContentUrlResult::resolve($pageAdapter->findPublishedById((int) $content->getRelated('pid')?->jumpTo));
+    }
+
+    public function getParametersForContent(object $content, PageModel $pageModel): array
+    {
+        if (!$content instanceof NewsModel) {
+            return [];
+        }
+
+        return [
+            'parameters' => '/'.($content->alias ?: $content->id),
+        ];
+    }
+}

--- a/news-bundle/src/Routing/NewsResolver.php
+++ b/news-bundle/src/Routing/NewsResolver.php
@@ -61,8 +61,6 @@ class NewsResolver implements ContentUrlResolverInterface
             return [];
         }
 
-        return [
-            'parameters' => '/'.($content->alias ?: $content->id),
-        ];
+        return ['parameters' => '/'.($content->alias ?: $content->id)];
     }
 }

--- a/news-bundle/tests/EventListener/GeneratePageListenerTest.php
+++ b/news-bundle/tests/EventListener/GeneratePageListenerTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Contao\NewsBundle\Tests\EventListener;
 
 use Contao\CoreBundle\Framework\Adapter;
+use Contao\CoreBundle\Routing\ContentUrlGenerator;
 use Contao\Environment;
 use Contao\LayoutModel;
 use Contao\Model\Collection;
@@ -51,9 +52,11 @@ class GeneratePageListenerTest extends ContaoTestCase
             ])
         ;
 
-        $newsFeedModel
+        $urlGenerator = $this->createMock(ContentUrlGenerator::class);
+        $urlGenerator
             ->expects($this->once())
-            ->method('getAbsoluteUrl')
+            ->method('generate')
+            ->with($newsFeedModel)
             ->willReturn('http://localhost/news.xml')
         ;
 
@@ -68,7 +71,7 @@ class GeneratePageListenerTest extends ContaoTestCase
         $layoutModel = $this->mockClassWithProperties(LayoutModel::class);
         $layoutModel->newsfeeds = 'a:1:{i:0;i:3;}';
 
-        $listener = new GeneratePageListener($this->mockContaoFramework($adapters));
+        $listener = new GeneratePageListener($this->mockContaoFramework($adapters), $urlGenerator);
         $listener($this->createMock(PageModel::class), $layoutModel);
 
         $this->assertSame(
@@ -82,7 +85,7 @@ class GeneratePageListenerTest extends ContaoTestCase
         $layoutModel = $this->mockClassWithProperties(LayoutModel::class);
         $layoutModel->newsfeeds = '';
 
-        $listener = new GeneratePageListener($this->mockContaoFramework());
+        $listener = new GeneratePageListener($this->mockContaoFramework(), $this->createMock(ContentUrlGenerator::class));
         $listener($this->createMock(PageModel::class), $layoutModel);
 
         $this->assertEmpty($GLOBALS['TL_HEAD'] ?? null);
@@ -100,7 +103,7 @@ class GeneratePageListenerTest extends ContaoTestCase
         $layoutModel = $this->mockClassWithProperties(LayoutModel::class);
         $layoutModel->newsfeeds = 'a:1:{i:0;i:3;}';
 
-        $listener = new GeneratePageListener($this->mockContaoFramework($adapters));
+        $listener = new GeneratePageListener($this->mockContaoFramework($adapters), $this->createMock(ContentUrlGenerator::class));
         $listener($this->createMock(PageModel::class), $layoutModel);
 
         $this->assertEmpty($GLOBALS['TL_HEAD'] ?? null);

--- a/news-bundle/tests/EventListener/GeneratePageListenerTest.php
+++ b/news-bundle/tests/EventListener/GeneratePageListenerTest.php
@@ -21,6 +21,7 @@ use Contao\NewsBundle\EventListener\GeneratePageListener;
 use Contao\PageModel;
 use Contao\Template;
 use Contao\TestCase\ContaoTestCase;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class GeneratePageListenerTest extends ContaoTestCase
 {
@@ -56,7 +57,7 @@ class GeneratePageListenerTest extends ContaoTestCase
         $urlGenerator
             ->expects($this->once())
             ->method('generate')
-            ->with($newsFeedModel)
+            ->with($newsFeedModel, [], UrlGeneratorInterface::ABSOLUTE_URL)
             ->willReturn('http://localhost/news.xml')
         ;
 

--- a/news-bundle/tests/EventListener/InsertTagsListenerTest.php
+++ b/news-bundle/tests/EventListener/InsertTagsListenerTest.php
@@ -146,6 +146,7 @@ class InsertTagsListenerTest extends ContaoTestCase
     {
         $urlGenerator = $this->createMock(ContentUrlGenerator::class);
         $logger = $this->createMock(LoggerInterface::class);
+
         $listener = new InsertTagsListener($this->mockContaoFramework(), $urlGenerator, $logger);
 
         $this->assertFalse($listener('link_url::2', false, null, []));

--- a/news-bundle/tests/EventListener/InsertTagsListenerTest.php
+++ b/news-bundle/tests/EventListener/InsertTagsListenerTest.php
@@ -12,16 +12,19 @@ declare(strict_types=1);
 
 namespace Contao\NewsBundle\Tests\EventListener;
 
-use Contao\News;
+use Contao\CoreBundle\Routing\ContentUrlGenerator;
 use Contao\NewsBundle\EventListener\InsertTagsListener;
 use Contao\NewsModel;
 use Contao\TestCase\ContaoTestCase;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class InsertTagsListenerTest extends ContaoTestCase
 {
     public function testTriggersWarningForNewsFeedTag(): void
     {
+        $urlGenerator = $this->createMock(ContentUrlGenerator::class);
+
         $logger = $this->createMock(LoggerInterface::class);
         $logger
             ->expects($this->once())
@@ -29,7 +32,7 @@ class InsertTagsListenerTest extends ContaoTestCase
             ->with('The "news_feed" insert tag has been removed in Contao 5.0. Use "link_url" instead.')
         ;
 
-        $listener = new InsertTagsListener($this->mockContaoFramework(), $logger);
+        $listener = new InsertTagsListener($this->mockContaoFramework(), $urlGenerator, $logger);
         $url = $listener('news_feed::2', false, null, []);
 
         $this->assertFalse($url);
@@ -41,27 +44,42 @@ class InsertTagsListenerTest extends ContaoTestCase
         $newsModel->headline = '"Foo" is not "bar"';
         $newsModel->teaser = '<p>Foo does not equal bar.</p>';
 
-        $news = $this->mockAdapter(['generateNewsUrl']);
-        $news
-            ->method('generateNewsUrl')
-            ->willReturnCallback(
-                static function (NewsModel $model, bool $addArchive, bool $absolute): string {
-                    if ($absolute) {
-                        return 'http://domain.tld/news/foo-is-not-bar.html';
-                    }
+        $adapters = [
+            NewsModel::class => $this->mockConfiguredAdapter(['findByIdOrAlias' => $newsModel]),
+        ];
 
-                    return 'news/foo-is-not-bar.html';
-                },
+        $urlGenerator = $this->createMock(ContentUrlGenerator::class);
+        $urlGenerator
+            ->expects($this->exactly(10))
+            ->method('generate')
+            ->withConsecutive(
+                [$newsModel, [], UrlGeneratorInterface::ABSOLUTE_PATH],
+                [$newsModel, [], UrlGeneratorInterface::ABSOLUTE_PATH],
+                [$newsModel, [], UrlGeneratorInterface::ABSOLUTE_PATH],
+                [$newsModel, [], UrlGeneratorInterface::ABSOLUTE_PATH],
+                [$newsModel, [], UrlGeneratorInterface::ABSOLUTE_URL],
+                [$newsModel, [], UrlGeneratorInterface::ABSOLUTE_URL],
+                [$newsModel, [], UrlGeneratorInterface::ABSOLUTE_PATH],
+                [$newsModel, [], UrlGeneratorInterface::ABSOLUTE_URL],
+                [$newsModel, [], UrlGeneratorInterface::ABSOLUTE_URL],
+                [$newsModel, [], UrlGeneratorInterface::ABSOLUTE_URL],
+            )
+            ->willReturnOnConsecutiveCalls(
+                'news/foo-is-not-bar.html',
+                'news/foo-is-not-bar.html',
+                'news/foo-is-not-bar.html',
+                'news/foo-is-not-bar.html',
+                'http://domain.tld/news/foo-is-not-bar.html',
+                'http://domain.tld/news/foo-is-not-bar.html',
+                'news/foo-is-not-bar.html',
+                'http://domain.tld/news/foo-is-not-bar.html',
+                'http://domain.tld/news/foo-is-not-bar.html',
+                'http://domain.tld/news/foo-is-not-bar.html',
             )
         ;
 
-        $adapters = [
-            NewsModel::class => $this->mockConfiguredAdapter(['findByIdOrAlias' => $newsModel]),
-            News::class => $news,
-        ];
-
         $logger = $this->createMock(LoggerInterface::class);
-        $listener = new InsertTagsListener($this->mockContaoFramework($adapters), $logger);
+        $listener = new InsertTagsListener($this->mockContaoFramework($adapters), $urlGenerator, $logger);
 
         $this->assertSame(
             '<a href="news/foo-is-not-bar.html" title="&quot;Foo&quot; is not &quot;bar&quot;">"Foo" is not "bar"</a>',
@@ -124,46 +142,11 @@ class InsertTagsListenerTest extends ContaoTestCase
         );
     }
 
-    public function testHandlesEmptyUrls(): void
-    {
-        $newsModel = $this->mockClassWithProperties(NewsModel::class);
-        $newsModel->headline = '"Foo" is not "bar"';
-        $newsModel->teaser = '<p>Foo does not equal bar.</p>';
-
-        $news = $this->mockAdapter(['generateNewsUrl']);
-        $news
-            ->method('generateNewsUrl')
-            ->willReturn('')
-        ;
-
-        $adapters = [
-            NewsModel::class => $this->mockConfiguredAdapter(['findByIdOrAlias' => $newsModel]),
-            News::class => $news,
-        ];
-
-        $logger = $this->createMock(LoggerInterface::class);
-        $listener = new InsertTagsListener($this->mockContaoFramework($adapters), $logger);
-
-        $this->assertSame(
-            '<a href="./" title="&quot;Foo&quot; is not &quot;bar&quot;">"Foo" is not "bar"</a>',
-            $listener('news::2', false, null, []),
-        );
-
-        $this->assertSame(
-            '<a href="./" title="&quot;Foo&quot; is not &quot;bar&quot;">',
-            $listener('news_open::2', false, null, []),
-        );
-
-        $this->assertSame(
-            './',
-            $listener('news_url::2', false, null, []),
-        );
-    }
-
     public function testReturnsFalseIfTheTagIsUnknown(): void
     {
+        $urlGenerator = $this->createMock(ContentUrlGenerator::class);
         $logger = $this->createMock(LoggerInterface::class);
-        $listener = new InsertTagsListener($this->mockContaoFramework(), $logger);
+        $listener = new InsertTagsListener($this->mockContaoFramework(), $urlGenerator, $logger);
 
         $this->assertFalse($listener('link_url::2', false, null, []));
     }
@@ -174,8 +157,9 @@ class InsertTagsListenerTest extends ContaoTestCase
             NewsModel::class => $this->mockConfiguredAdapter(['findByIdOrAlias' => null]),
         ];
 
+        $urlGenerator = $this->createMock(ContentUrlGenerator::class);
         $logger = $this->createMock(LoggerInterface::class);
-        $listener = new InsertTagsListener($this->mockContaoFramework($adapters), $logger);
+        $listener = new InsertTagsListener($this->mockContaoFramework($adapters), $urlGenerator, $logger);
 
         $this->assertSame('', $listener('news_url::3', false, null, []));
     }

--- a/news-bundle/tests/EventListener/NewsFeedListenerTest.php
+++ b/news-bundle/tests/EventListener/NewsFeedListenerTest.php
@@ -17,12 +17,12 @@ use Contao\Controller;
 use Contao\CoreBundle\Cache\EntityCacheTags;
 use Contao\CoreBundle\Image\ImageFactoryInterface;
 use Contao\CoreBundle\InsertTag\InsertTagParser;
+use Contao\CoreBundle\Routing\ContentUrlGenerator;
 use Contao\Environment;
 use Contao\Files;
 use Contao\FilesModel;
 use Contao\Image\ImageInterface;
 use Contao\Model\Collection;
-use Contao\News;
 use Contao\NewsBundle\Event\FetchArticlesForFeedEvent;
 use Contao\NewsBundle\Event\TransformArticleForFeedEvent;
 use Contao\NewsBundle\EventListener\NewsFeedListener;
@@ -37,6 +37,7 @@ use Imagine\Image\Box;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Filesystem\Path;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class NewsFeedListenerTest extends ContaoTestCase
 {
@@ -75,6 +76,7 @@ class NewsFeedListenerTest extends ContaoTestCase
         $framework = $this->mockContaoFramework([NewsModel::class => $newsAdapter]);
         $feed = $this->createMock(Feed::class);
         $request = $this->createMock(Request::class);
+        $urlGenerator = $this->createMock(ContentUrlGenerator::class);
 
         $pageModel = $this->mockClassWithProperties(PageModel::class, [
             'newsArchives' => serialize([1]),
@@ -84,7 +86,7 @@ class NewsFeedListenerTest extends ContaoTestCase
 
         $event = new FetchArticlesForFeedEvent($feed, $request, $pageModel);
 
-        $listener = new NewsFeedListener($framework, $imageFactory, $insertTags, $this->getTempDir(), $cacheTags, 'UTF-8');
+        $listener = new NewsFeedListener($framework, $imageFactory, $urlGenerator, $insertTags, $this->getTempDir(), $cacheTags, 'UTF-8');
         $listener->onFetchArticlesForFeed($event);
 
         $this->assertSame([$newsModel], $event->getArticles());
@@ -175,14 +177,6 @@ class NewsFeedListenerTest extends ContaoTestCase
             ->willReturn($this->mockClassWithProperties(UserModel::class, ['name' => 'Jane Doe']))
         ;
 
-        $news = $this->mockAdapter(['generateNewsUrl']);
-        $news
-            ->expects($this->once())
-            ->method('generateNewsUrl')
-            ->with($article, false, true)
-            ->willReturn('https://example.org/news/example-title')
-        ;
-
         $environment = $this->mockAdapter(['set', 'get']);
 
         $controller = $this->mockAdapter(['getContentElement', 'convertRelativeUrls']);
@@ -210,7 +204,6 @@ class NewsFeedListenerTest extends ContaoTestCase
         System::setContainer($container);
 
         $framework = $this->mockContaoFramework([
-            News::class => $news,
             Environment::class => $environment,
             Controller::class => $controller,
             ContentModel::class => $contentModel,
@@ -222,6 +215,14 @@ class NewsFeedListenerTest extends ContaoTestCase
         $feed = $this->createMock(Feed::class);
         $cacheTags = $this->createMock(EntityCacheTags::class);
 
+        $urlGenerator = $this->createMock(ContentUrlGenerator::class);
+        $urlGenerator
+            ->expects($this->once())
+            ->method('generate')
+            ->with($article, [], UrlGeneratorInterface::ABSOLUTE_URL)
+            ->willReturn('https://example.org/news/example-title')
+        ;
+
         $pageModel = $this->mockClassWithProperties(PageModel::class, [
             'feedSource' => $feedSource,
             'imgSize' => serialize([100, 100, 'crop']),
@@ -231,7 +232,7 @@ class NewsFeedListenerTest extends ContaoTestCase
         $baseUrl = 'example.org';
         $event = new TransformArticleForFeedEvent($article, $feed, $pageModel, $request, $baseUrl);
 
-        $listener = new NewsFeedListener($framework, $imageFactory, $insertTags, $this->getTempDir(), $cacheTags, 'UTF-8');
+        $listener = new NewsFeedListener($framework, $imageFactory, $urlGenerator, $insertTags, $this->getTempDir(), $cacheTags, 'UTF-8');
         $listener->onTransformArticleForFeed($event);
 
         $item = $event->getItem();

--- a/news-bundle/tests/EventListener/SitemapListenerTest.php
+++ b/news-bundle/tests/EventListener/SitemapListenerTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Contao\NewsBundle\Tests\EventListener;
 
 use Contao\CoreBundle\Event\SitemapEvent;
+use Contao\CoreBundle\Routing\ContentUrlGenerator;
 use Contao\Database;
 use Contao\NewsArchiveModel;
 use Contao\NewsBundle\EventListener\SitemapListener;
@@ -50,10 +51,6 @@ class SitemapListenerTest extends ContaoTestCase
     public function testNewsArticleIsAdded(array $pageProperties, array $newsArchiveProperties, bool $hasAuthenticatedMember): void
     {
         $jumpToPage = $this->mockClassWithProperties(PageModel::class, $pageProperties);
-        $jumpToPage
-            ->method('getAbsoluteUrl')
-            ->willReturn('https://contao.org')
-        ;
 
         $adapters = [
             NewsArchiveModel::class => $this->mockConfiguredAdapter([
@@ -143,7 +140,13 @@ class SitemapListenerTest extends ContaoTestCase
             ;
         }
 
-        return new SitemapListener($framework, $security);
+        $urlGenerator = $this->createMock(ContentUrlGenerator::class);
+        $urlGenerator
+            ->method('generate')
+            ->willReturn('https://contao.org')
+        ;
+
+        return new SitemapListener($framework, $security, $urlGenerator);
     }
 
     private function createSitemapEvent(array $rootPages): SitemapEvent

--- a/news-bundle/tests/EventListener/SitemapListenerTest.php
+++ b/news-bundle/tests/EventListener/SitemapListenerTest.php
@@ -50,8 +50,6 @@ class SitemapListenerTest extends ContaoTestCase
      */
     public function testNewsArticleIsAdded(array $pageProperties, array $newsArchiveProperties, bool $hasAuthenticatedMember): void
     {
-        $jumpToPage = $this->mockClassWithProperties(PageModel::class, $pageProperties);
-
         $adapters = [
             NewsArchiveModel::class => $this->mockConfiguredAdapter([
                 'findByProtected' => [
@@ -62,7 +60,7 @@ class SitemapListenerTest extends ContaoTestCase
                 ],
             ]),
             PageModel::class => $this->mockConfiguredAdapter([
-                'findWithDetails' => $jumpToPage,
+                'findWithDetails' => $this->mockClassWithProperties(PageModel::class, $pageProperties),
             ]),
             NewsModel::class => $this->mockConfiguredAdapter([
                 'findPublishedDefaultByPid' => [

--- a/news-bundle/tests/Routing/NewsResolverTest.php
+++ b/news-bundle/tests/Routing/NewsResolverTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\NewsBundle\Tests\Routing;
+
+use Contao\ArticleModel;
+use Contao\CoreBundle\Routing\Content\StringUrl;
+use Contao\NewsArchiveModel;
+use Contao\NewsBundle\Routing\NewsResolver;
+use Contao\NewsModel;
+use Contao\PageModel;
+use Contao\TestCase\ContaoTestCase;
+
+class NewsResolverTest extends ContaoTestCase
+{
+    public function testResolveNewsWithExternalSource(): void
+    {
+        $content = $this->mockClassWithProperties(NewsModel::class, ['source' => 'external', 'url' => 'foobar']);
+
+        $resolver = new NewsResolver($this->mockContaoFramework());
+        $result = $resolver->resolve($content);
+
+        $this->assertTrue($result->isRedirect());
+        $this->assertInstanceOf(StringUrl::class, $result->content);
+        $this->assertSame('foobar', $result->content->value);
+    }
+
+    public function testResolveNewsWithInternalSource(): void
+    {
+        $jumpTo = $this->mockClassWithProperties(PageModel::class);
+        $content = $this->mockClassWithProperties(NewsModel::class, ['source' => 'internal', 'jumpTo' => 42]);
+
+        $pageAdapter = $this->mockAdapter(['findPublishedById']);
+        $pageAdapter
+            ->expects($this->once())
+            ->method('findPublishedById')
+            ->with(42)
+            ->willReturn($jumpTo)
+        ;
+
+        $framework = $this->mockContaoFramework([PageModel::class => $pageAdapter]);
+
+        $resolver = new NewsResolver($framework);
+        $result = $resolver->resolve($content);
+
+        $this->assertTrue($result->isRedirect());
+        $this->assertSame($jumpTo, $result->content);
+    }
+
+    public function testResolveNewsWithArticleSource(): void
+    {
+        $article = $this->mockClassWithProperties(ArticleModel::class);
+        $content = $this->mockClassWithProperties(NewsModel::class, ['source' => 'article', 'articleId' => 42]);
+
+        $articleAdapter = $this->mockAdapter(['findPublishedById']);
+        $articleAdapter
+            ->expects($this->once())
+            ->method('findPublishedById')
+            ->with(42)
+            ->willReturn($article)
+        ;
+
+        $framework = $this->mockContaoFramework([ArticleModel::class => $articleAdapter]);
+
+        $resolver = new NewsResolver($framework);
+        $result = $resolver->resolve($content);
+
+        $this->assertTrue($result->isRedirect());
+        $this->assertSame($article, $result->content);
+    }
+
+    public function testResolveNewsWithoutSource(): void
+    {
+        $target = $this->mockClassWithProperties(PageModel::class);
+
+        $newsArchive = $this->mockClassWithProperties(NewsArchiveModel::class, ['jumpTo' => 42]);
+
+        $content = $this->mockClassWithProperties(NewsModel::class, ['source' => '']);
+        $content
+            ->expects($this->once())
+            ->method('getRelated')
+            ->with('pid')
+            ->willReturn($newsArchive)
+        ;
+
+        $pageAdapter = $this->mockAdapter(['findPublishedById']);
+        $pageAdapter
+            ->expects($this->once())
+            ->method('findPublishedById')
+            ->with(42)
+            ->willReturn($target)
+        ;
+
+        $framework = $this->mockContaoFramework([PageModel::class => $pageAdapter]);
+
+        $resolver = new NewsResolver($framework);
+        $result = $resolver->resolve($content);
+
+        $this->assertFalse($result->isRedirect());
+        $this->assertSame($target, $result->content);
+    }
+
+    /**
+     * @dataProvider getParametersForContentProvider
+     */
+    public function testGetParametersForContent(object $content, array $expected): void
+    {
+        $pageModel = $this->mockClassWithProperties(PageModel::class);
+
+        $resolver = new NewsResolver($this->mockContaoFramework());
+
+        $this->assertSame($expected, $resolver->getParametersForContent($content, $pageModel));
+    }
+
+    public function getParametersForContentProvider(): \Generator
+    {
+        yield 'Uses the news alias' => [
+            $this->mockClassWithProperties(NewsModel::class, ['id' => 42, 'alias' => 'foobar']),
+            ['parameters' => '/foobar']
+        ];
+
+        yield 'Uses news ID if alias is empty' => [
+            $this->mockClassWithProperties(NewsModel::class, ['id' => 42, 'alias' => '']),
+            ['parameters' => '/42'],
+        ];
+
+        yield 'Only supports NewsModel' => [
+            $this->mockClassWithProperties(PageModel::class),
+            [],
+        ];
+    }
+}

--- a/news-bundle/tests/Routing/NewsResolverTest.php
+++ b/news-bundle/tests/Routing/NewsResolverTest.php
@@ -81,7 +81,6 @@ class NewsResolverTest extends ContaoTestCase
     public function testResolveNewsWithoutSource(): void
     {
         $target = $this->mockClassWithProperties(PageModel::class);
-
         $newsArchive = $this->mockClassWithProperties(NewsArchiveModel::class, ['jumpTo' => 42]);
 
         $content = $this->mockClassWithProperties(NewsModel::class, ['source' => '']);
@@ -115,7 +114,6 @@ class NewsResolverTest extends ContaoTestCase
     public function testGetParametersForContent(object $content, array $expected): void
     {
         $pageModel = $this->mockClassWithProperties(PageModel::class);
-
         $resolver = new NewsResolver($this->mockContaoFramework());
 
         $this->assertSame($expected, $resolver->getParametersForContent($content, $pageModel));

--- a/news-bundle/tests/Routing/NewsResolverTest.php
+++ b/news-bundle/tests/Routing/NewsResolverTest.php
@@ -125,7 +125,7 @@ class NewsResolverTest extends ContaoTestCase
     {
         yield 'Uses the news alias' => [
             $this->mockClassWithProperties(NewsModel::class, ['id' => 42, 'alias' => 'foobar']),
-            ['parameters' => '/foobar']
+            ['parameters' => '/foobar'],
         ];
 
         yield 'Uses news ID if alias is empty' => [


### PR DESCRIPTION
same as https://github.com/contao/contao/pull/6597 but for news URLs.
This obviously fails in all places because it requires https://github.com/contao/contao/pull/6596 to be merged first.