### PR TITLE
Generate newsletter URLs using the content URL generator

### DIFF
--- a/newsletter-bundle/config/services.yaml
+++ b/newsletter-bundle/config/services.yaml
@@ -1,4 +1,7 @@
 services:
+    _defaults:
+        autoconfigure: true
+
     contao_newsletter.cron.purge_subscriptions:
         class: Contao\NewsletterBundle\Cron\PurgeSubscriptionsCron
         arguments:
@@ -17,8 +20,12 @@ services:
         arguments:
             - '@contao.framework'
             - '@security.helper'
+            - '@contao.routing.content_url_generator'
         tags:
             - kernel.event_listener
+
+    contao_newsletter.routing.newsletter_resolver:
+        class: Contao\NewsletterBundle\Routing\NewsletterResolver
 
     contao_newsletter.security.newsletter_access_voter:
         class: Contao\NewsletterBundle\Security\Voter\NewsletterAccessVoter

--- a/newsletter-bundle/config/services.yaml
+++ b/newsletter-bundle/config/services.yaml
@@ -26,6 +26,8 @@ services:
 
     contao_newsletter.routing.newsletter_resolver:
         class: Contao\NewsletterBundle\Routing\NewsletterResolver
+        arguments:
+            - '@contao.framework'
 
     contao_newsletter.security.newsletter_access_voter:
         class: Contao\NewsletterBundle\Security\Voter\NewsletterAccessVoter

--- a/newsletter-bundle/contao/modules/ModuleNewsletterList.php
+++ b/newsletter-bundle/contao/modules/ModuleNewsletterList.php
@@ -10,6 +10,8 @@
 
 namespace Contao;
 
+use Symfony\Component\Routing\Exception\ExceptionInterface;
+
 /**
  * Front end module "newsletter list".
  *
@@ -89,26 +91,11 @@ class ModuleNewsletterList extends Module
 
 			while ($objNewsletter->next())
 			{
-				/** @var NewsletterChannelModel $objTarget */
-				if (!($objTarget = $objNewsletter->getRelated('pid')) instanceof NewsletterChannelModel)
+				try
 				{
-					continue;
+					$strUrl = System::getContainer()->get('contao.routing.content_url_generator')->generate($objNewsletter->current());
 				}
-
-				$jumpTo = $objTarget->jumpTo;
-
-				// Skip channels without a jumpTo page (see #6521 and #494)
-				if ($jumpTo < 1)
-				{
-					continue;
-				}
-
-				if (($objJumpTo = $this->getPageWithDetails($jumpTo)) instanceof PageModel)
-				{
-					/** @var PageModel $objJumpTo */
-					$strUrl = $objJumpTo->getFrontendUrl('/' . ($objNewsletter->alias ?: $objNewsletter->id));
-				}
-				else
+				catch (ExceptionInterface)
 				{
 					$strUrl = $strRequest;
 				}

--- a/newsletter-bundle/contao/modules/ModuleNewsletterReader.php
+++ b/newsletter-bundle/contao/modules/ModuleNewsletterReader.php
@@ -71,9 +71,9 @@ class ModuleNewsletterReader extends Module
 	{
 		$this->Template->content = '';
 
-		if ($this->overviewPage)
+		if ($this->overviewPage && ($overviewPage = PageModel::findById($this->overviewPage)))
 		{
-			$this->Template->referer = PageModel::findById($this->overviewPage)->getFrontendUrl();
+			$this->Template->referer = System::getContainer()->get('contao.routing.content_url_generator')->generate($overviewPage);
 			$this->Template->back = $this->customLabel ?: $GLOBALS['TL_LANG']['MSC']['nl_overview'];
 		}
 

--- a/newsletter-bundle/contao/modules/ModuleSubscribe.php
+++ b/newsletter-bundle/contao/modules/ModuleSubscribe.php
@@ -10,6 +10,8 @@
 
 namespace Contao;
 
+use Symfony\Component\Routing\Exception\ExceptionInterface;
+
 /**
  * Front end module "newsletter subscribe".
  *
@@ -376,8 +378,14 @@ class ModuleSubscribe extends Module
 		// Redirect to the jumpTo page
 		if (($objTarget = $this->objModel->getRelated('jumpTo')) instanceof PageModel)
 		{
-			/** @var PageModel $objTarget */
-			$this->redirect($objTarget->getFrontendUrl());
+			try
+			{
+				$this->redirect(System::getContainer()->get('contao.routing.content_url_generator')->generate($objTarget));
+			}
+			catch (ExceptionInterface)
+			{
+				// Ignore if target URL cannot be generated and reload the page
+			}
 		}
 
 		System::getContainer()->get('request_stack')->getSession()->getFlashBag()->set('nl_confirm', $GLOBALS['TL_LANG']['MSC']['nl_confirm']);

--- a/newsletter-bundle/contao/modules/ModuleUnsubscribe.php
+++ b/newsletter-bundle/contao/modules/ModuleUnsubscribe.php
@@ -10,6 +10,8 @@
 
 namespace Contao;
 
+use Symfony\Component\Routing\Exception\ExceptionInterface;
+
 /**
  * Front end module "newsletter unsubscribe".
  *
@@ -281,8 +283,14 @@ class ModuleUnsubscribe extends Module
 		// Redirect to the jumpTo page
 		if (($objTarget = $this->objModel->getRelated('jumpTo')) instanceof PageModel)
 		{
-			/** @var PageModel $objTarget */
-			$this->redirect($objTarget->getFrontendUrl());
+			try
+			{
+				$this->redirect(System::getContainer()->get('contao.routing.content_url_generator')->generate($objTarget));
+			}
+			catch (ExceptionInterface)
+			{
+				// Ignore if target URL cannot be generated and reload the page
+			}
 		}
 
 		System::getContainer()->get('request_stack')->getSession()->getFlashBag()->set('nl_removed', $GLOBALS['TL_LANG']['MSC']['nl_removed']);

--- a/newsletter-bundle/src/EventListener/SitemapListener.php
+++ b/newsletter-bundle/src/EventListener/SitemapListener.php
@@ -14,18 +14,21 @@ namespace Contao\NewsletterBundle\EventListener;
 
 use Contao\CoreBundle\Event\SitemapEvent;
 use Contao\CoreBundle\Framework\ContaoFramework;
+use Contao\CoreBundle\Routing\ContentUrlGenerator;
 use Contao\CoreBundle\Security\ContaoCorePermissions;
 use Contao\Database;
 use Contao\NewsletterChannelModel;
 use Contao\NewsletterModel;
 use Contao\PageModel;
 use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\Routing\Exception\ExceptionInterface;
 
 class SitemapListener
 {
     public function __construct(
         private readonly ContaoFramework $framework,
         private readonly Security $security,
+        private readonly ContentUrlGenerator $urlGenerator,
     ) {
     }
 
@@ -89,7 +92,10 @@ class SitemapListener
             }
 
             foreach ($objItems as $objItem) {
-                $arrPages[] = $objParent->getAbsoluteUrl('/'.($objItem->alias ?: $objItem->id));
+                try {
+                    $arrPages[] = $this->urlGenerator->generate($objItem);
+                } catch (ExceptionInterface) {
+                }
             }
         }
 

--- a/newsletter-bundle/src/EventListener/SitemapListener.php
+++ b/newsletter-bundle/src/EventListener/SitemapListener.php
@@ -22,6 +22,7 @@ use Contao\NewsletterModel;
 use Contao\PageModel;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Routing\Exception\ExceptionInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class SitemapListener
 {
@@ -93,7 +94,7 @@ class SitemapListener
 
             foreach ($objItems as $objItem) {
                 try {
-                    $arrPages[] = $this->urlGenerator->generate($objItem);
+                    $arrPages[] = $this->urlGenerator->generate($objItem, [], UrlGeneratorInterface::ABSOLUTE_URL);
                 } catch (ExceptionInterface) {
                 }
             }

--- a/newsletter-bundle/src/Routing/NewsletterResolver.php
+++ b/newsletter-bundle/src/Routing/NewsletterResolver.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\NewsletterBundle\Routing;
+
+use Contao\CoreBundle\Framework\ContaoFramework;
+use Contao\CoreBundle\Routing\Content\ContentUrlResolverInterface;
+use Contao\CoreBundle\Routing\Content\ContentUrlResult;
+use Contao\NewsletterModel;
+use Contao\PageModel;
+
+class NewsletterResolver implements ContentUrlResolverInterface
+{
+    public function __construct(private readonly ContaoFramework $framework)
+    {
+    }
+
+    public function resolve(object $content): ContentUrlResult
+    {
+        if (!$content instanceof NewsletterModel) {
+            return ContentUrlResult::abstain();
+        }
+
+        $pageAdapter = $this->framework->getAdapter(PageModel::class);
+
+        return ContentUrlResult::resolve($pageAdapter->findPublishedById((int) $content->getRelated('pid')?->jumpTo));
+    }
+
+    public function getParametersForContent(object $content, PageModel $pageModel): array
+    {
+        if (!$content instanceof NewsletterModel) {
+            return [];
+        }
+
+        return [
+            'parameters' => '/'.($content->alias ?: $content->id),
+        ];
+    }
+}

--- a/newsletter-bundle/src/Routing/NewsletterResolver.php
+++ b/newsletter-bundle/src/Routing/NewsletterResolver.php
@@ -41,8 +41,6 @@ class NewsletterResolver implements ContentUrlResolverInterface
             return [];
         }
 
-        return [
-            'parameters' => '/'.($content->alias ?: $content->id),
-        ];
+        return ['parameters' => '/'.($content->alias ?: $content->id)];
     }
 }

--- a/newsletter-bundle/src/Routing/NewsletterResolver.php
+++ b/newsletter-bundle/src/Routing/NewsletterResolver.php
@@ -24,10 +24,10 @@ class NewsletterResolver implements ContentUrlResolverInterface
     {
     }
 
-    public function resolve(object $content): ContentUrlResult
+    public function resolve(object $content): ContentUrlResult|null
     {
         if (!$content instanceof NewsletterModel) {
-            return ContentUrlResult::abstain();
+            return null;
         }
 
         $pageAdapter = $this->framework->getAdapter(PageModel::class);

--- a/newsletter-bundle/tests/EventListener/SitemapListenerTest.php
+++ b/newsletter-bundle/tests/EventListener/SitemapListenerTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Contao\NewsletterBundle\Tests\EventListener;
 
 use Contao\CoreBundle\Event\SitemapEvent;
+use Contao\CoreBundle\Routing\ContentUrlGenerator;
 use Contao\CoreBundle\Security\ContaoCorePermissions;
 use Contao\Database;
 use Contao\NewsletterBundle\EventListener\SitemapListener;
@@ -52,11 +53,6 @@ class SitemapListenerTest extends ContaoTestCase
             'protected' => 1,
             'groups' => [1],
         ]);
-
-        $jumpToPage
-            ->method('getAbsoluteUrl')
-            ->willReturn('https://contao.org')
-        ;
 
         $adapters = [
             NewsletterChannelModel::class => $this->mockConfiguredAdapter([
@@ -105,7 +101,13 @@ class SitemapListenerTest extends ContaoTestCase
             ;
         }
 
-        return new SitemapListener($framework, $security);
+        $urlGenerator = $this->createMock(ContentUrlGenerator::class);
+        $urlGenerator
+            ->method('generate')
+            ->willReturn('https://contao.org')
+        ;
+
+        return new SitemapListener($framework, $security, $urlGenerator);
     }
 
     private function createSitemapEvent(array $rootPages): SitemapEvent

--- a/newsletter-bundle/tests/Routing/NewsletterResolverTest.php
+++ b/newsletter-bundle/tests/Routing/NewsletterResolverTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\NewsletterBundle\Tests\Routing;
+
+use Contao\NewsletterBundle\Routing\NewsletterResolver;
+use Contao\NewsletterChannelModel;
+use Contao\NewsletterModel;
+use Contao\PageModel;
+use Contao\TestCase\ContaoTestCase;
+
+class NewsletterResolverTest extends ContaoTestCase
+{
+    public function testResolveNewsletter(): void
+    {
+        $target = $this->mockClassWithProperties(PageModel::class);
+
+        $newsletterChannel = $this->mockClassWithProperties(NewsletterChannelModel::class, ['jumpTo' => 42]);
+
+        $content = $this->mockClassWithProperties(NewsletterModel::class);
+        $content
+            ->expects($this->once())
+            ->method('getRelated')
+            ->with('pid')
+            ->willReturn($newsletterChannel)
+        ;
+
+        $pageAdapter = $this->mockAdapter(['findPublishedById']);
+        $pageAdapter
+            ->expects($this->once())
+            ->method('findPublishedById')
+            ->with(42)
+            ->willReturn($target)
+        ;
+
+        $framework = $this->mockContaoFramework([PageModel::class => $pageAdapter]);
+
+        $resolver = new NewsletterResolver($framework);
+        $result = $resolver->resolve($content);
+
+        $this->assertFalse($result->isRedirect());
+        $this->assertSame($target, $result->content);
+    }
+
+    /**
+     * @dataProvider getParametersForContentProvider
+     */
+    public function testGetParametersForContent(object $content, array $expected): void
+    {
+        $pageModel = $this->mockClassWithProperties(PageModel::class);
+
+        $resolver = new NewsletterResolver($this->mockContaoFramework());
+
+        $this->assertSame($expected, $resolver->getParametersForContent($content, $pageModel));
+    }
+
+    public function getParametersForContentProvider(): \Generator
+    {
+        yield 'Uses the newsletter alias' => [
+            $this->mockClassWithProperties(NewsletterModel::class, ['id' => 42, 'alias' => 'foobar']),
+            ['parameters' => '/foobar']
+        ];
+
+        yield 'Uses newsletter ID if alias is empty' => [
+            $this->mockClassWithProperties(NewsletterModel::class, ['id' => 42, 'alias' => '']),
+            ['parameters' => '/42'],
+        ];
+
+        yield 'Only supports NewsletterModel' => [
+            $this->mockClassWithProperties(PageModel::class),
+            [],
+        ];
+    }
+}

--- a/newsletter-bundle/tests/Routing/NewsletterResolverTest.php
+++ b/newsletter-bundle/tests/Routing/NewsletterResolverTest.php
@@ -67,7 +67,7 @@ class NewsletterResolverTest extends ContaoTestCase
     {
         yield 'Uses the newsletter alias' => [
             $this->mockClassWithProperties(NewsletterModel::class, ['id' => 42, 'alias' => 'foobar']),
-            ['parameters' => '/foobar']
+            ['parameters' => '/foobar'],
         ];
 
         yield 'Uses newsletter ID if alias is empty' => [

--- a/newsletter-bundle/tests/Routing/NewsletterResolverTest.php
+++ b/newsletter-bundle/tests/Routing/NewsletterResolverTest.php
@@ -23,7 +23,6 @@ class NewsletterResolverTest extends ContaoTestCase
     public function testResolveNewsletter(): void
     {
         $target = $this->mockClassWithProperties(PageModel::class);
-
         $newsletterChannel = $this->mockClassWithProperties(NewsletterChannelModel::class, ['jumpTo' => 42]);
 
         $content = $this->mockClassWithProperties(NewsletterModel::class);
@@ -57,7 +56,6 @@ class NewsletterResolverTest extends ContaoTestCase
     public function testGetParametersForContent(object $content, array $expected): void
     {
         $pageModel = $this->mockClassWithProperties(PageModel::class);
-
         $resolver = new NewsletterResolver($this->mockContaoFramework());
 
         $this->assertSame($expected, $resolver->getParametersForContent($content, $pageModel));


### PR DESCRIPTION
same as https://github.com/contao/contao/pull/6597 but for newsletter URLs.
This obviously fails in all places because it requires https://github.com/contao/contao/pull/6596 to be merged first.