### PR TITLE
Generate event URLs using the content URL generator

### DIFF
--- a/calendar-bundle/config/services.yaml
+++ b/calendar-bundle/config/services.yaml
@@ -53,6 +53,7 @@ services:
         arguments:
             - '@contao.framework'
             - '@security.helper'
+            - '@contao.routing.content_url_generator'
         tags:
             - kernel.event_listener
 
@@ -65,6 +66,11 @@ services:
             - '@security.helper'
         tags:
             - { name: contao.picker_provider, priority: 96 }
+
+    contao_calendar.routing.calendar_events_resolver:
+        class: Contao\CalendarBundle\Routing\CalendarEventsResolver
+        arguments:
+            - '@contao.framework'
 
     contao_calendar.security.calendar_access_voter:
         class: Contao\CalendarBundle\Security\Voter\CalendarAccessVoter

--- a/calendar-bundle/config/services.yaml
+++ b/calendar-bundle/config/services.yaml
@@ -30,6 +30,7 @@ services:
         class: Contao\CalendarBundle\EventListener\InsertTagsListener
         arguments:
             - '@contao.framework'
+            - '@contao.routing.content_url_generator'
         tags:
             - { name: contao.hook, hook: replaceInsertTags }
 
@@ -37,6 +38,7 @@ services:
         class: Contao\CalendarBundle\EventListener\PreviewUrlConvertListener
         arguments:
             - '@contao.framework'
+            - '@contao.routing.content_url_generator'
         tags:
             - kernel.event_listener
 

--- a/calendar-bundle/contao/classes/Calendar.php
+++ b/calendar-bundle/contao/classes/Calendar.php
@@ -14,6 +14,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+use Symfony\Component\Routing\Exception\ExceptionInterface;
 
 /**
  * Provide methods regarding calendars.
@@ -372,40 +373,14 @@ class Calendar extends Frontend
 
 		// Add title and link
 		$title .= ' ' . $objEvent->title;
-		$link = '';
 
-		switch ($objEvent->source)
+		try
 		{
-			case 'external':
-				$url = $objEvent->url;
-
-				if (Validator::isRelativeUrl($url))
-				{
-					$url = Environment::get('path') . '/' . $url;
-				}
-
-				$link = $url;
-				break;
-
-			case 'internal':
-				if (($objTarget = $objEvent->getRelated('jumpTo')) instanceof PageModel)
-				{
-					/** @var PageModel $objTarget */
-					$link = $objTarget->getAbsoluteUrl();
-				}
-				break;
-
-			case 'article':
-				if (($objArticle = ArticleModel::findByPk($objEvent->articleId)) instanceof ArticleModel && ($objPid = $objArticle->getRelated('pid')) instanceof PageModel)
-				{
-					/** @var PageModel $objPid */
-					$link = StringUtil::ampersand($objPid->getAbsoluteUrl('/articles/' . ($objArticle->alias ?: $objArticle->id)));
-				}
-				break;
-
-			default:
-				$link = $objParent->getAbsoluteUrl('/' . ($objEvent->alias ?: $objEvent->id));
-				break;
+			$link = System::getContainer()->get('contao.routing.content_url_generator')->generate($objEvent);
+		}
+		catch (ExceptionInterface)
+		{
+			$link = '';
 		}
 
 		// Store the whole row (see #5085)

--- a/calendar-bundle/contao/classes/Calendar.php
+++ b/calendar-bundle/contao/classes/Calendar.php
@@ -377,7 +377,7 @@ class Calendar extends Frontend
 
 		try
 		{
-			$link = System::getContainer()->get('contao.routing.content_url_generator')->generate($objEvent, [], UrlGeneratorInterface::ABSOLUTE_URL);
+			$link = System::getContainer()->get('contao.routing.content_url_generator')->generate($objEvent, array(), UrlGeneratorInterface::ABSOLUTE_URL);
 		}
 		catch (ExceptionInterface)
 		{

--- a/calendar-bundle/contao/classes/Calendar.php
+++ b/calendar-bundle/contao/classes/Calendar.php
@@ -15,6 +15,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 use Symfony\Component\Routing\Exception\ExceptionInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
  * Provide methods regarding calendars.
@@ -376,7 +377,7 @@ class Calendar extends Frontend
 
 		try
 		{
-			$link = System::getContainer()->get('contao.routing.content_url_generator')->generate($objEvent);
+			$link = System::getContainer()->get('contao.routing.content_url_generator')->generate($objEvent, [], UrlGeneratorInterface::ABSOLUTE_URL);
 		}
 		catch (ExceptionInterface)
 		{

--- a/calendar-bundle/contao/classes/Events.php
+++ b/calendar-bundle/contao/classes/Events.php
@@ -11,7 +11,6 @@
 namespace Contao;
 
 use Contao\CoreBundle\Security\ContaoCorePermissions;
-use Contao\CoreBundle\Util\UrlUtil;
 use Symfony\Component\Routing\Exception\ExceptionInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
@@ -412,7 +411,7 @@ abstract class Events extends Module
 
 		try
 		{
-			$url = System::getContainer()->get('contao.routing.content_url_generator')->generate($objEvent, [], $blnAbsolute ? UrlGeneratorInterface::ABSOLUTE_URL : UrlGeneratorInterface::ABSOLUTE_PATH);
+			$url = System::getContainer()->get('contao.routing.content_url_generator')->generate($objEvent, array(), $blnAbsolute ? UrlGeneratorInterface::ABSOLUTE_URL : UrlGeneratorInterface::ABSOLUTE_PATH);
 		}
 		catch (ExceptionInterface)
 		{

--- a/calendar-bundle/contao/classes/Events.php
+++ b/calendar-bundle/contao/classes/Events.php
@@ -13,6 +13,7 @@ namespace Contao;
 use Contao\CoreBundle\Security\ContaoCorePermissions;
 use Contao\CoreBundle\Util\UrlUtil;
 use Symfony\Component\Routing\Exception\ExceptionInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
  * Provide methods to get all events of a certain period from the database.
@@ -411,14 +412,14 @@ abstract class Events extends Module
 
 		try
 		{
-			$url = System::getContainer()->get('contao.routing.content_url_generator')->generate($objEvent);
+			$url = System::getContainer()->get('contao.routing.content_url_generator')->generate($objEvent, [], $blnAbsolute ? UrlGeneratorInterface::ABSOLUTE_URL : UrlGeneratorInterface::ABSOLUTE_PATH);
 		}
 		catch (ExceptionInterface)
 		{
 			return StringUtil::ampersand(Environment::get('requestUri'));
 		}
 
-		return UrlUtil::makeAbsolutePath($url, Environment::get('base'));
+		return $url;
 	}
 
 	/**

--- a/calendar-bundle/contao/classes/Events.php
+++ b/calendar-bundle/contao/classes/Events.php
@@ -285,7 +285,7 @@ abstract class Events extends Module
 		$arrEvent['link'] = $objEvents->title;
 		$arrEvent['target'] = '';
 		$arrEvent['title'] = StringUtil::specialchars($objEvents->title, true);
-		$arrEvent['href'] = $this->generateEventUrl($objEvents);
+		$arrEvent['href'] = System::getContainer()->get('contao.routing.content_url_generator')->generate($objEvents);
 		$arrEvent['class'] = $objEvents->cssClass ? ' ' . $objEvents->cssClass : '';
 		$arrEvent['recurring'] = $recurring;
 		$arrEvent['until'] = $until;
@@ -431,12 +431,13 @@ abstract class Events extends Module
 	public static function getSchemaOrgData(CalendarEventsModel $objEvent): array
 	{
 		$htmlDecoder = System::getContainer()->get('contao.string.html_decoder');
+		$urlGenerator = System::getContainer()->get('contao.routing.content_url_generator');
 
 		$jsonLd = array(
 			'@type' => 'Event',
 			'identifier' => '#/schema/events/' . $objEvent->id,
 			'name' => $htmlDecoder->inputEncodedToPlainText($objEvent->title),
-			'url' => self::generateEventUrl($objEvent),
+			'url' => $urlGenerator->generate($objEvent),
 			'startDate' => $objEvent->addTime ? date('Y-m-d\TH:i:sP', $objEvent->startTime) : date('Y-m-d', $objEvent->startTime)
 		);
 

--- a/calendar-bundle/contao/classes/Events.php
+++ b/calendar-bundle/contao/classes/Events.php
@@ -404,10 +404,13 @@ abstract class Events extends Module
 	 * @param boolean             $blnAbsolute
 	 *
 	 * @return string
+	 *
+	 * @deprecated Deprecated since Contao 5.3, to be removed in Contao 6;
+	 *             use the content URL generator instead.
 	 */
 	public static function generateEventUrl($objEvent, $blnAbsolute=false)
 	{
-		trigger_deprecation('contao/core-bundle', '5.3', __METHOD__ . ' is deprecated, use the content URL generator instead.');
+		trigger_deprecation('contao/core-bundle', '5.3', 'Using "%s()" has been deprecated and will no longer work in Contao 6. Use the content URL generator instead.', __METHOD__);
 
 		try
 		{

--- a/calendar-bundle/contao/classes/Events.php
+++ b/calendar-bundle/contao/classes/Events.php
@@ -11,6 +11,8 @@
 namespace Contao;
 
 use Contao\CoreBundle\Security\ContaoCorePermissions;
+use Contao\CoreBundle\Util\UrlUtil;
+use Symfony\Component\Routing\Exception\ExceptionInterface;
 
 /**
  * Provide methods to get all events of a certain period from the database.
@@ -42,12 +44,6 @@ abstract class Events extends Module
 	 * @var array
 	 */
 	protected $arrEvents = array();
-
-	/**
-	 * URL cache array
-	 * @var array
-	 */
-	private static $arrUrlCache = array();
 
 	/**
 	 * Sort out protected archives
@@ -411,77 +407,18 @@ abstract class Events extends Module
 	 */
 	public static function generateEventUrl($objEvent, $blnAbsolute=false)
 	{
-		$strCacheKey = 'id_' . $objEvent->id . ($blnAbsolute ? '_absolute' : '');
+		trigger_deprecation('contao/core-bundle', '5.3', __METHOD__ . ' is deprecated, use the content URL generator instead.');
 
-		// Load the URL from cache
-		if (isset(self::$arrUrlCache[$strCacheKey]))
+		try
 		{
-			return self::$arrUrlCache[$strCacheKey];
+			$url = System::getContainer()->get('contao.routing.content_url_generator')->generate($objEvent);
+		}
+		catch (ExceptionInterface)
+		{
+			return StringUtil::ampersand(Environment::get('requestUri'));
 		}
 
-		// Initialize the cache
-		self::$arrUrlCache[$strCacheKey] = null;
-
-		switch ($objEvent->source)
-		{
-			// Link to an external page
-			case 'external':
-				if (str_starts_with($objEvent->url, 'mailto:'))
-				{
-					self::$arrUrlCache[$strCacheKey] = StringUtil::encodeEmail($objEvent->url);
-				}
-				else
-				{
-					$url = $objEvent->url;
-
-					if (Validator::isRelativeUrl($url))
-					{
-						$url = Environment::get('path') . '/' . $url;
-					}
-
-					self::$arrUrlCache[$strCacheKey] = StringUtil::ampersand($url);
-				}
-				break;
-
-			// Link to an internal page
-			case 'internal':
-				if (($objTarget = $objEvent->getRelated('jumpTo')) instanceof PageModel)
-				{
-					/** @var PageModel $objTarget */
-					self::$arrUrlCache[$strCacheKey] = StringUtil::ampersand($blnAbsolute ? $objTarget->getAbsoluteUrl() : $objTarget->getFrontendUrl());
-				}
-				break;
-
-			// Link to an article
-			case 'article':
-				if (($objArticle = ArticleModel::findByPk($objEvent->articleId)) instanceof ArticleModel && ($objPid = $objArticle->getRelated('pid')) instanceof PageModel)
-				{
-					$params = '/articles/' . ($objArticle->alias ?: $objArticle->id);
-
-					/** @var PageModel $objPid */
-					self::$arrUrlCache[$strCacheKey] = StringUtil::ampersand($blnAbsolute ? $objPid->getAbsoluteUrl($params) : $objPid->getFrontendUrl($params));
-				}
-				break;
-		}
-
-		// Link to the default page
-		if (self::$arrUrlCache[$strCacheKey] === null)
-		{
-			$objPage = PageModel::findByPk($objEvent->getRelated('pid')->jumpTo);
-
-			if (!$objPage instanceof PageModel)
-			{
-				self::$arrUrlCache[$strCacheKey] = StringUtil::ampersand(Environment::get('requestUri'));
-			}
-			else
-			{
-				$params = '/' . ($objEvent->alias ?: $objEvent->id);
-
-				self::$arrUrlCache[$strCacheKey] = StringUtil::ampersand($blnAbsolute ? $objPage->getAbsoluteUrl($params) : $objPage->getFrontendUrl($params));
-			}
-		}
-
-		return self::$arrUrlCache[$strCacheKey];
+		return UrlUtil::makeAbsolutePath($url, Environment::get('base'));
 	}
 
 	/**

--- a/calendar-bundle/contao/dca/tl_calendar_events.php
+++ b/calendar-bundle/contao/dca/tl_calendar_events.php
@@ -255,7 +255,7 @@ $GLOBALS['TL_DCA']['tl_calendar_events'] = array
 		(
 			'label'                   => &$GLOBALS['TL_LANG']['MSC']['serpPreview'],
 			'inputType'               => 'serpPreview',
-			'eval'                    => array('url_callback'=>array('tl_calendar_events', 'getSerpUrl'), 'title_tag_callback'=>array('tl_calendar_events', 'getTitleTag'), 'titleFields'=>array('pageTitle', 'title'), 'descriptionFields'=>array('description', 'teaser')),
+			'eval'                    => array('title_tag_callback'=>array('tl_calendar_events', 'getTitleTag'), 'titleFields'=>array('pageTitle', 'title'), 'descriptionFields'=>array('description', 'teaser')),
 			'sql'                     => null
 		),
 		'canonicalLink' => array
@@ -580,18 +580,6 @@ class tl_calendar_events extends Backend
 		}
 
 		return $varValue;
-	}
-
-	/**
-	 * Return the SERP URL
-	 *
-	 * @param CalendarEventsModel $model
-	 *
-	 * @return string
-	 */
-	public function getSerpUrl(CalendarEventsModel $model)
-	{
-		return Events::generateEventUrl($model, true);
 	}
 
 	/**

--- a/calendar-bundle/contao/dca/tl_calendar_events.php
+++ b/calendar-bundle/contao/dca/tl_calendar_events.php
@@ -19,7 +19,6 @@ use Contao\Database;
 use Contao\DataContainer;
 use Contao\Date;
 use Contao\DC_Table;
-use Contao\Events;
 use Contao\Input;
 use Contao\LayoutModel;
 use Contao\PageModel;

--- a/calendar-bundle/contao/modules/ModuleCalendar.php
+++ b/calendar-bundle/contao/modules/ModuleCalendar.php
@@ -11,6 +11,7 @@
 namespace Contao;
 
 use Contao\CoreBundle\Exception\PageNotFoundException;
+use Symfony\Component\Routing\Exception\ExceptionInterface;
 
 /**
  * Front end module "calendar".
@@ -74,8 +75,14 @@ class ModuleCalendar extends Events
 
 		if (($objTarget = $this->objModel->getRelated('jumpTo')) instanceof PageModel)
 		{
-			/** @var PageModel $objTarget */
-			$this->strLink = $objTarget->getFrontendUrl();
+			try
+			{
+				$this->strLink = System::getContainer()->get('contao.routing.content_url_generator')->generate($objTarget);
+			}
+			catch (ExceptionInterface)
+			{
+				// Ignore if target URL cannot be generated and use the current request URL
+			}
 		}
 
 		// Tag the calendars (see #2137)

--- a/calendar-bundle/contao/modules/ModuleEventReader.php
+++ b/calendar-bundle/contao/modules/ModuleEventReader.php
@@ -103,7 +103,7 @@ class ModuleEventReader extends Events
 			case 'internal':
 			case 'article':
 			case 'external':
-				throw new RedirectResponseException(System::getContainer()->get('contao.routing.content_url_generator')->generate($objEvent, [], UrlGeneratorInterface::ABSOLUTE_URL), 301);
+				throw new RedirectResponseException(System::getContainer()->get('contao.routing.content_url_generator')->generate($objEvent, array(), UrlGeneratorInterface::ABSOLUTE_URL), 301);
 		}
 
 		// Overwrite the page metadata (see #2853, #4955 and #87)

--- a/calendar-bundle/contao/modules/ModuleEventReader.php
+++ b/calendar-bundle/contao/modules/ModuleEventReader.php
@@ -77,6 +77,8 @@ class ModuleEventReader extends Events
 	 */
 	protected function compile()
 	{
+		$urlGenerator = System::getContainer()->get('contao.routing.content_url_generator');
+
 		/** @var PageModel $objPage */
 		global $objPage;
 
@@ -84,7 +86,7 @@ class ModuleEventReader extends Events
 
 		if ($this->overviewPage && ($overviewPage = PageModel::findById($this->overviewPage)))
 		{
-			$this->Template->referer = System::getContainer()->get('contao.routing.content_url_generator')->generate($overviewPage);
+			$this->Template->referer = $urlGenerator->generate($overviewPage);
 			$this->Template->back = $this->customLabel ?: $GLOBALS['TL_LANG']['MSC']['eventOverview'];
 		}
 
@@ -103,7 +105,7 @@ class ModuleEventReader extends Events
 			case 'internal':
 			case 'article':
 			case 'external':
-				throw new RedirectResponseException(System::getContainer()->get('contao.routing.content_url_generator')->generate($objEvent, array(), UrlGeneratorInterface::ABSOLUTE_URL), 301);
+				throw new RedirectResponseException($urlGenerator->generate($objEvent, array(), UrlGeneratorInterface::ABSOLUTE_URL), 301);
 		}
 
 		// Overwrite the page metadata (see #2853, #4955 and #87)
@@ -157,7 +159,7 @@ class ModuleEventReader extends Events
 			}
 			elseif (!$this->cal_keepCanonical)
 			{
-				$htmlHeadBag->setCanonicalUri(Events::generateEventUrl($objEvent, true));
+				$htmlHeadBag->setCanonicalUri($urlGenerator->generate($objEvent, array(), UrlGeneratorInterface::ABSOLUTE_URL));
 			}
 		}
 

--- a/calendar-bundle/contao/modules/ModuleEventReader.php
+++ b/calendar-bundle/contao/modules/ModuleEventReader.php
@@ -13,10 +13,8 @@ namespace Contao;
 use Contao\CoreBundle\Exception\InternalServerErrorException;
 use Contao\CoreBundle\Exception\PageNotFoundException;
 use Contao\CoreBundle\Exception\RedirectResponseException;
-use Contao\CoreBundle\Routing\Content\StringUrl;
 use Contao\CoreBundle\Routing\ResponseContext\HtmlHeadBag\HtmlHeadBag;
 use Contao\CoreBundle\Util\UrlUtil;
-use Symfony\Component\Routing\Exception\ExceptionInterface;
 
 /**
  * Front end module "event reader".

--- a/calendar-bundle/contao/modules/ModuleEventReader.php
+++ b/calendar-bundle/contao/modules/ModuleEventReader.php
@@ -15,6 +15,7 @@ use Contao\CoreBundle\Exception\PageNotFoundException;
 use Contao\CoreBundle\Exception\RedirectResponseException;
 use Contao\CoreBundle\Routing\ResponseContext\HtmlHeadBag\HtmlHeadBag;
 use Contao\CoreBundle\Util\UrlUtil;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
  * Front end module "event reader".
@@ -102,7 +103,7 @@ class ModuleEventReader extends Events
 			case 'internal':
 			case 'article':
 			case 'external':
-				throw new RedirectResponseException(System::getContainer()->get('contao.routing.content_url_generator')->generate($objEvent), 301);
+				throw new RedirectResponseException(System::getContainer()->get('contao.routing.content_url_generator')->generate($objEvent, [], UrlGeneratorInterface::ABSOLUTE_URL), 301);
 		}
 
 		// Overwrite the page metadata (see #2853, #4955 and #87)

--- a/calendar-bundle/contao/modules/ModuleEventReader.php
+++ b/calendar-bundle/contao/modules/ModuleEventReader.php
@@ -77,12 +77,12 @@ class ModuleEventReader extends Events
 	 */
 	protected function compile()
 	{
-		$urlGenerator = System::getContainer()->get('contao.routing.content_url_generator');
-
 		/** @var PageModel $objPage */
 		global $objPage;
 
 		$this->Template->event = '';
+
+		$urlGenerator = System::getContainer()->get('contao.routing.content_url_generator');
 
 		if ($this->overviewPage && ($overviewPage = PageModel::findById($this->overviewPage)))
 		{

--- a/calendar-bundle/src/EventListener/InsertTagsListener.php
+++ b/calendar-bundle/src/EventListener/InsertTagsListener.php
@@ -15,8 +15,9 @@ namespace Contao\CalendarBundle\EventListener;
 use Contao\CalendarEventsModel;
 use Contao\CalendarFeedModel;
 use Contao\CoreBundle\Framework\ContaoFramework;
-use Contao\Events;
+use Contao\CoreBundle\Routing\ContentUrlGenerator;
 use Contao\StringUtil;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
  * @internal
@@ -31,8 +32,10 @@ class InsertTagsListener
         'event_teaser',
     ];
 
-    public function __construct(private readonly ContaoFramework $framework)
-    {
+    public function __construct(
+        private readonly ContaoFramework $framework,
+        private readonly ContentUrlGenerator $urlGenerator,
+    ) {
     }
 
     public function __invoke(string $tag, bool $useCache, mixed $cacheValue, array $flags): string|false
@@ -74,23 +77,21 @@ class InsertTagsListener
             return '';
         }
 
-        $events = $this->framework->getAdapter(Events::class);
-
         return match ($insertTag) {
             'event' => sprintf(
                 '<a href="%s" title="%s"%s>%s</a>',
-                $events->generateEventUrl($model, \in_array('absolute', $arguments, true)) ?: './',
+                $this->urlGenerator->generate($model, [], \in_array('absolute', $arguments, true) ? UrlGeneratorInterface::ABSOLUTE_URL : UrlGeneratorInterface::ABSOLUTE_PATH),
                 StringUtil::specialcharsAttribute($model->title),
                 \in_array('blank', $arguments, true) ? ' target="_blank" rel="noreferrer noopener"' : '',
                 $model->title,
             ),
             'event_open' => sprintf(
                 '<a href="%s" title="%s"%s>',
-                $events->generateEventUrl($model, \in_array('absolute', $arguments, true)) ?: './',
+                $this->urlGenerator->generate($model, [], \in_array('absolute', $arguments, true) ? UrlGeneratorInterface::ABSOLUTE_URL : UrlGeneratorInterface::ABSOLUTE_PATH),
                 StringUtil::specialcharsAttribute($model->title),
                 \in_array('blank', $arguments, true) ? ' target="_blank" rel="noreferrer noopener"' : '',
             ),
-            'event_url' => $events->generateEventUrl($model, \in_array('absolute', $arguments, true)) ?: './',
+            'event_url' => $this->urlGenerator->generate($model, [], \in_array('absolute', $arguments, true) ? UrlGeneratorInterface::ABSOLUTE_URL : UrlGeneratorInterface::ABSOLUTE_PATH),
             'event_title' => StringUtil::specialcharsAttribute($model->title),
             'event_teaser' => $model->teaser,
             default => '',

--- a/calendar-bundle/src/EventListener/PreviewUrlConvertListener.php
+++ b/calendar-bundle/src/EventListener/PreviewUrlConvertListener.php
@@ -15,16 +15,19 @@ namespace Contao\CalendarBundle\EventListener;
 use Contao\CalendarEventsModel;
 use Contao\CoreBundle\Event\PreviewUrlConvertEvent;
 use Contao\CoreBundle\Framework\ContaoFramework;
-use Contao\Events;
+use Contao\CoreBundle\Routing\ContentUrlGenerator;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
  * @internal
  */
 class PreviewUrlConvertListener
 {
-    public function __construct(private readonly ContaoFramework $framework)
-    {
+    public function __construct(
+        private readonly ContaoFramework $framework,
+        private readonly ContentUrlGenerator $urlGenerator,
+    ) {
     }
 
     /**
@@ -40,7 +43,7 @@ class PreviewUrlConvertListener
             return;
         }
 
-        $event->setUrl($this->framework->getAdapter(Events::class)->generateEventUrl($eventModel, true));
+        $event->setUrl($this->urlGenerator->generate($eventModel, [], UrlGeneratorInterface::ABSOLUTE_URL));
     }
 
     private function getEventModel(Request $request): CalendarEventsModel|null

--- a/calendar-bundle/src/EventListener/SitemapListener.php
+++ b/calendar-bundle/src/EventListener/SitemapListener.php
@@ -16,16 +16,19 @@ use Contao\CalendarEventsModel;
 use Contao\CalendarModel;
 use Contao\CoreBundle\Event\SitemapEvent;
 use Contao\CoreBundle\Framework\ContaoFramework;
+use Contao\CoreBundle\Routing\ContentUrlGenerator;
 use Contao\CoreBundle\Security\ContaoCorePermissions;
 use Contao\Database;
 use Contao\PageModel;
 use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\Routing\Exception\ExceptionInterface;
 
 class SitemapListener
 {
     public function __construct(
         private readonly ContaoFramework $framework,
         private readonly Security $security,
+        private readonly ContentUrlGenerator $urlGenerator,
     ) {
     }
 
@@ -103,7 +106,10 @@ class SitemapListener
                     continue;
                 }
 
-                $arrPages[] = $objParent->getAbsoluteUrl('/'.($objEvent->alias ?: $objEvent->id));
+                try {
+                    $arrPages[] = $this->urlGenerator->generate($objEvent);
+                } catch (ExceptionInterface) {
+                }
             }
         }
 

--- a/calendar-bundle/src/EventListener/SitemapListener.php
+++ b/calendar-bundle/src/EventListener/SitemapListener.php
@@ -22,6 +22,7 @@ use Contao\Database;
 use Contao\PageModel;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Routing\Exception\ExceptionInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class SitemapListener
 {
@@ -107,7 +108,7 @@ class SitemapListener
                 }
 
                 try {
-                    $arrPages[] = $this->urlGenerator->generate($objEvent);
+                    $arrPages[] = $this->urlGenerator->generate($objEvent, [], UrlGeneratorInterface::ABSOLUTE_URL);
                 } catch (ExceptionInterface) {
                 }
             }

--- a/calendar-bundle/src/Routing/CalendarEventsResolver.php
+++ b/calendar-bundle/src/Routing/CalendarEventsResolver.php
@@ -25,10 +25,10 @@ class CalendarEventsResolver implements ContentUrlResolverInterface
     {
     }
 
-    public function resolve(object $content): ContentUrlResult
+    public function resolve(object $content): ContentUrlResult|null
     {
         if (!$content instanceof CalendarEventsModel) {
-            return ContentUrlResult::abstain();
+            return null;
         }
 
         switch ($content->source) {

--- a/calendar-bundle/src/Routing/CalendarEventsResolver.php
+++ b/calendar-bundle/src/Routing/CalendarEventsResolver.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CalendarBundle\Routing;
+
+use Contao\ArticleModel;
+use Contao\CalendarEventsModel;
+use Contao\CoreBundle\Framework\ContaoFramework;
+use Contao\CoreBundle\Routing\Content\ContentUrlResolverInterface;
+use Contao\CoreBundle\Routing\Content\ContentUrlResult;
+use Contao\PageModel;
+
+class CalendarEventsResolver implements ContentUrlResolverInterface
+{
+    public function __construct(private readonly ContaoFramework $framework)
+    {
+    }
+
+    public function resolve(object $content): ContentUrlResult
+    {
+        if (!$content instanceof CalendarEventsModel) {
+            return ContentUrlResult::abstain();
+        }
+
+        switch ($content->source) {
+            // Link to an external page
+            case 'external':
+                return ContentUrlResult::url($content->url);
+
+            // Link to an internal page
+            case 'internal':
+                $pageAdapter = $this->framework->getAdapter(PageModel::class);
+
+                return ContentUrlResult::redirect($pageAdapter->findPublishedById($content->jumpTo));
+
+            // Link to an article
+            case 'article':
+                $articleAdapter = $this->framework->getAdapter(ArticleModel::class);
+
+                return ContentUrlResult::redirect($articleAdapter->findPublishedById($content->articleId));
+        }
+
+        $pageAdapter = $this->framework->getAdapter(PageModel::class);
+
+        // Link to the default page
+        return ContentUrlResult::resolve($pageAdapter->findPublishedById((int) $content->getRelated('pid')?->jumpTo));
+    }
+
+    public function getParametersForContent(object $content, PageModel $pageModel): array
+    {
+        if (!$content instanceof CalendarEventsModel) {
+            return [];
+        }
+
+        return [
+            'parameters' => '/'.($content->alias ?: $content->id),
+        ];
+    }
+}

--- a/calendar-bundle/src/Routing/CalendarEventsResolver.php
+++ b/calendar-bundle/src/Routing/CalendarEventsResolver.php
@@ -61,8 +61,6 @@ class CalendarEventsResolver implements ContentUrlResolverInterface
             return [];
         }
 
-        return [
-            'parameters' => '/'.($content->alias ?: $content->id),
-        ];
+        return ['parameters' => '/'.($content->alias ?: $content->id)];
     }
 }

--- a/calendar-bundle/tests/EventListener/SitemapListenerTest.php
+++ b/calendar-bundle/tests/EventListener/SitemapListenerTest.php
@@ -16,6 +16,7 @@ use Contao\CalendarBundle\EventListener\SitemapListener;
 use Contao\CalendarEventsModel;
 use Contao\CalendarModel;
 use Contao\CoreBundle\Event\SitemapEvent;
+use Contao\CoreBundle\Routing\ContentUrlGenerator;
 use Contao\Database;
 use Contao\PageModel;
 use Contao\TestCase\ContaoTestCase;
@@ -50,10 +51,6 @@ class SitemapListenerTest extends ContaoTestCase
     public function testCalendarEventIsAdded(array $pageProperties, array $calendarProperties, bool $hasAuthenticatedMember): void
     {
         $jumpToPage = $this->mockClassWithProperties(PageModel::class, $pageProperties);
-        $jumpToPage
-            ->method('getAbsoluteUrl')
-            ->willReturn('https://contao.org')
-        ;
 
         $adapters = [
             CalendarModel::class => $this->mockConfiguredAdapter([
@@ -143,7 +140,13 @@ class SitemapListenerTest extends ContaoTestCase
             ;
         }
 
-        return new SitemapListener($framework, $security);
+        $urlGenerator = $this->createMock(ContentUrlGenerator::class);
+        $urlGenerator
+            ->method('generate')
+            ->willReturn('https://contao.org')
+        ;
+
+        return new SitemapListener($framework, $security, $urlGenerator);
     }
 
     private function createSitemapEvent(array $rootPages): SitemapEvent

--- a/calendar-bundle/tests/Routing/CalendarEventsResolverTest.php
+++ b/calendar-bundle/tests/Routing/CalendarEventsResolverTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CalendarBundle\Tests\Routing;
+
+use Contao\ArticleModel;
+use Contao\CalendarBundle\Routing\CalendarEventsResolver;
+use Contao\CalendarEventsModel;
+use Contao\CalendarModel;
+use Contao\CoreBundle\Routing\Content\StringUrl;
+use Contao\PageModel;
+use Contao\TestCase\ContaoTestCase;
+
+class CalendarEventsResolverTest extends ContaoTestCase
+{
+    public function testResolveEventWithExternalSource(): void
+    {
+        $content = $this->mockClassWithProperties(CalendarEventsModel::class, ['source' => 'external', 'url' => 'foobar']);
+
+        $resolver = new CalendarEventsResolver($this->mockContaoFramework());
+        $result = $resolver->resolve($content);
+
+        $this->assertTrue($result->isRedirect());
+        $this->assertInstanceOf(StringUrl::class, $result->content);
+        $this->assertSame('foobar', $result->content->value);
+    }
+
+    public function testResolveEventWithInternalSource(): void
+    {
+        $jumpTo = $this->mockClassWithProperties(PageModel::class);
+        $content = $this->mockClassWithProperties(CalendarEventsModel::class, ['source' => 'internal', 'jumpTo' => 42]);
+
+        $pageAdapter = $this->mockAdapter(['findPublishedById']);
+        $pageAdapter
+            ->expects($this->once())
+            ->method('findPublishedById')
+            ->with(42)
+            ->willReturn($jumpTo)
+        ;
+
+        $framework = $this->mockContaoFramework([PageModel::class => $pageAdapter]);
+
+        $resolver = new CalendarEventsResolver($framework);
+        $result = $resolver->resolve($content);
+
+        $this->assertTrue($result->isRedirect());
+        $this->assertSame($jumpTo, $result->content);
+    }
+
+    public function testResolveEventWithArticleSource(): void
+    {
+        $article = $this->mockClassWithProperties(ArticleModel::class);
+        $content = $this->mockClassWithProperties(CalendarEventsModel::class, ['source' => 'article', 'articleId' => 42]);
+
+        $articleAdapter = $this->mockAdapter(['findPublishedById']);
+        $articleAdapter
+            ->expects($this->once())
+            ->method('findPublishedById')
+            ->with(42)
+            ->willReturn($article)
+        ;
+
+        $framework = $this->mockContaoFramework([ArticleModel::class => $articleAdapter]);
+
+        $resolver = new CalendarEventsResolver($framework);
+        $result = $resolver->resolve($content);
+
+        $this->assertTrue($result->isRedirect());
+        $this->assertSame($article, $result->content);
+    }
+
+    public function testResolveEventWithoutSource(): void
+    {
+        $target = $this->mockClassWithProperties(PageModel::class);
+
+        $calendar = $this->mockClassWithProperties(CalendarModel::class, ['jumpTo' => 42]);
+
+        $content = $this->mockClassWithProperties(CalendarEventsModel::class, ['source' => '']);
+        $content
+            ->expects($this->once())
+            ->method('getRelated')
+            ->with('pid')
+            ->willReturn($calendar)
+        ;
+
+        $pageAdapter = $this->mockAdapter(['findPublishedById']);
+        $pageAdapter
+            ->expects($this->once())
+            ->method('findPublishedById')
+            ->with(42)
+            ->willReturn($target)
+        ;
+
+        $framework = $this->mockContaoFramework([PageModel::class => $pageAdapter]);
+
+        $resolver = new CalendarEventsResolver($framework);
+        $result = $resolver->resolve($content);
+
+        $this->assertFalse($result->isRedirect());
+        $this->assertSame($target, $result->content);
+    }
+
+    /**
+     * @dataProvider getParametersForContentProvider
+     */
+    public function testGetParametersForContent(object $content, array $expected): void
+    {
+        $pageModel = $this->mockClassWithProperties(PageModel::class);
+
+        $resolver = new CalendarEventsResolver($this->mockContaoFramework());
+
+        $this->assertSame($expected, $resolver->getParametersForContent($content, $pageModel));
+    }
+
+    public function getParametersForContentProvider(): \Generator
+    {
+        yield 'Uses the event alias' => [
+            $this->mockClassWithProperties(CalendarEventsModel::class, ['id' => 42, 'alias' => 'foobar']),
+            ['parameters' => '/foobar']
+        ];
+
+        yield 'Uses event ID if alias is empty' => [
+            $this->mockClassWithProperties(CalendarEventsModel::class, ['id' => 42, 'alias' => '']),
+            ['parameters' => '/42'],
+        ];
+
+        yield 'Only supports CalendarEventsModel' => [
+            $this->mockClassWithProperties(PageModel::class),
+            [],
+        ];
+    }
+}

--- a/calendar-bundle/tests/Routing/CalendarEventsResolverTest.php
+++ b/calendar-bundle/tests/Routing/CalendarEventsResolverTest.php
@@ -81,7 +81,6 @@ class CalendarEventsResolverTest extends ContaoTestCase
     public function testResolveEventWithoutSource(): void
     {
         $target = $this->mockClassWithProperties(PageModel::class);
-
         $calendar = $this->mockClassWithProperties(CalendarModel::class, ['jumpTo' => 42]);
 
         $content = $this->mockClassWithProperties(CalendarEventsModel::class, ['source' => '']);
@@ -115,7 +114,6 @@ class CalendarEventsResolverTest extends ContaoTestCase
     public function testGetParametersForContent(object $content, array $expected): void
     {
         $pageModel = $this->mockClassWithProperties(PageModel::class);
-
         $resolver = new CalendarEventsResolver($this->mockContaoFramework());
 
         $this->assertSame($expected, $resolver->getParametersForContent($content, $pageModel));

--- a/calendar-bundle/tests/Routing/CalendarEventsResolverTest.php
+++ b/calendar-bundle/tests/Routing/CalendarEventsResolverTest.php
@@ -125,7 +125,7 @@ class CalendarEventsResolverTest extends ContaoTestCase
     {
         yield 'Uses the event alias' => [
             $this->mockClassWithProperties(CalendarEventsModel::class, ['id' => 42, 'alias' => 'foobar']),
-            ['parameters' => '/foobar']
+            ['parameters' => '/foobar'],
         ];
 
         yield 'Uses event ID if alias is empty' => [


### PR DESCRIPTION
same as https://github.com/contao/contao/pull/6597 but for event URLs.
This obviously fails in all places because it requires https://github.com/contao/contao/pull/6596 to be merged first.