### PR TITLE
Fix the cache warmer test

### DIFF
--- a/core-bundle/tests/Cache/ContaoCacheWarmerTest.php
+++ b/core-bundle/tests/Cache/ContaoCacheWarmerTest.php
@@ -111,21 +111,11 @@ class ContaoCacheWarmerTest extends TestCase
             file_get_contents(Path::join($this->getTempDir(), 'var/cache/contao/sql/tl_test.php')),
         );
 
-        $expected = <<<'TXT'
-            <?php
-            return array (
-              'en' =>
-              array (
-                'default' => true,
-                'tl_test' => true,
-              ),
-            );
+        $langs = include Path::join($this->getTempDir(), 'var/cache/contao/config/available-language-files.php');
 
-            TXT;
-
-        $file = Path::join($this->getTempDir(), 'var/cache/contao/config/available-language-files.php');
-
-        $this->assertSame($expected, preg_replace('/\s+\n/', "\n", file_get_contents($file)));
+        $this->assertArrayHasKey('en', $langs);
+        $this->assertArrayHasKey('default', $langs['en']);
+        $this->assertArrayHasKey('tl_test', $langs['en']);
     }
 
     public function testIsAnOptionalWarmer(): void


### PR DESCRIPTION
The array key order is not deterministic, therefore the test failed: https://github.com/contao/contao/actions/runs/7128661169/job/19411055590

We could also solve this by adding the following code in line 173:

```php
        ksort($processed);

        foreach ($processed as &$value) {
            krsort($value);
        }
```

I don't know whether this optimizes anything other than the unit tests though.