### PR TITLE
Prevent from submitting the ajax form twice

### DIFF
--- a/core-bundle/contao/templates/forms/form_wrapper.html5
+++ b/core-bundle/contao/templates/forms/form_wrapper.html5
@@ -49,6 +49,12 @@
         form.addEventListener('submit', e => {
           e.preventDefault();
 
+          if (form.dataset.formSubmitted) {
+            return;
+          }
+
+          form.dataset.formSubmitted = '1';
+
           const formData = new FormData(form);
 
           // Send the triggered button data as well


### PR DESCRIPTION
It may happen that the form processing takes a while, and it may happen that the visitor will not notice that and submit the form again. This could result in a double form submission. This improvement should solve that.

One open question is: should we disable the form fields right after submission, for the better UX?

/cc @Toflar 