### PR TITLE
Add example content to the auto-generated `.env` file

### DIFF
--- a/manager-bundle/src/Command/ContaoSetupCommand.php
+++ b/manager-bundle/src/Command/ContaoSetupCommand.php
@@ -81,7 +81,7 @@ class ContaoSetupCommand extends Command
             $io->info('An APP_SECRET was generated and written to your .env.local file.');
 
             if (!$filesystem->exists($envPath = Path::join($this->projectDir, '.env'))) {
-                $filesystem->touch($envPath);
+                $filesystem->dumpFile($envPath, "#DATABASE_URL='mysql://username:password@localhost/database_name'\n#MAILER_DSN=");
 
                 $io->info('An empty .env file was created.');
             }


### PR DESCRIPTION
[As discussed in Slack](https://contao.slack.com/archives/CJT61P8R1/p1702491282482099), there is curerntly no example what .env variables should be setup for an installation. We could add some defaults if an empty `.env` is created on the fly (which is the default for a new system).

Not sure if these defaults make sense or the formatting is acceptable 🙃 