### PR TITLE
Use the name of the related field when getting options from another record

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Widget.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Widget.php
@@ -1336,7 +1336,8 @@ abstract class Widget extends Controller
 		elseif (isset($arrData['foreignKey']))
 		{
 			$arrKey = explode('.', $arrData['foreignKey'], 2);
-			$objOptions = Database::getInstance()->query("SELECT id, " . $arrKey[1] . " AS value FROM " . $arrKey[0] . " WHERE tstamp>0 ORDER BY value");
+			$strField = Database::quoteIdentifier($arrData['relation']['field'] ?? 'id');
+			$objOptions = Database::getInstance()->query("SELECT $strField as id, " . $arrKey[1] . " AS value FROM " . $arrKey[0] . " WHERE tstamp>0 ORDER BY value"); 
 			$arrData['options'] = array();
 
 			while ($objOptions->next())


### PR DESCRIPTION
Fixes #6619

Fixes issue with ID field being hard coded and ignoring the 'field' value set in the relation array.