### PR TITLE
Fix DCA voters not checking module and parent update access

### DIFF
--- a/calendar-bundle/src/Security/ContaoCalendarPermissions.php
+++ b/calendar-bundle/src/Security/ContaoCalendarPermissions.php
@@ -14,6 +14,8 @@ namespace Contao\CalendarBundle\Security;
 
 final class ContaoCalendarPermissions
 {
+    public const USER_CAN_ACCESS_MODULE = 'contao_user.modules.calendar';
+
     public const USER_CAN_EDIT_CALENDAR = 'contao_user.calendars';
 
     public const USER_CAN_CREATE_CALENDARS = 'contao_user.calendarp.create';

--- a/calendar-bundle/src/Security/Voter/CalendarAccessVoter.php
+++ b/calendar-bundle/src/Security/Voter/CalendarAccessVoter.php
@@ -20,6 +20,9 @@ use Contao\CoreBundle\Security\DataContainer\UpdateAction;
 use Contao\CoreBundle\Security\Voter\DataContainer\AbstractDataContainerVoter;
 use Symfony\Bundle\SecurityBundle\Security;
 
+/**
+ * @internal
+ */
 class CalendarAccessVoter extends AbstractDataContainerVoter
 {
     public function __construct(private readonly Security $security)
@@ -33,6 +36,10 @@ class CalendarAccessVoter extends AbstractDataContainerVoter
 
     protected function isGranted(CreateAction|DeleteAction|ReadAction|UpdateAction $action): bool
     {
+        if (!$this->security->isGranted(ContaoCalendarPermissions::USER_CAN_ACCESS_MODULE)) {
+            return false;
+        }
+
         return match (true) {
             $action instanceof CreateAction => $this->security->isGranted(ContaoCalendarPermissions::USER_CAN_CREATE_CALENDARS),
             $action instanceof ReadAction,

--- a/calendar-bundle/src/Security/Voter/CalendarEventsAccessVoter.php
+++ b/calendar-bundle/src/Security/Voter/CalendarEventsAccessVoter.php
@@ -18,13 +18,14 @@ use Contao\CoreBundle\Security\DataContainer\DeleteAction;
 use Contao\CoreBundle\Security\DataContainer\ReadAction;
 use Contao\CoreBundle\Security\DataContainer\UpdateAction;
 use Contao\CoreBundle\Security\Voter\DataContainer\AbstractDataContainerVoter;
-use Symfony\Bundle\SecurityBundle\Security;
+use Contao\CoreBundle\Security\Voter\DataContainer\ParentAccessTrait;
 
+/**
+ * @internal
+ */
 class CalendarEventsAccessVoter extends AbstractDataContainerVoter
 {
-    public function __construct(private readonly Security $security)
-    {
-    }
+    use ParentAccessTrait;
 
     protected function getTable(): string
     {
@@ -33,13 +34,7 @@ class CalendarEventsAccessVoter extends AbstractDataContainerVoter
 
     protected function isGranted(CreateAction|DeleteAction|ReadAction|UpdateAction $action): bool
     {
-        $pid = match (true) {
-            $action instanceof CreateAction => $action->getNewPid(),
-            $action instanceof ReadAction,
-            $action instanceof UpdateAction,
-            $action instanceof DeleteAction => $action->getCurrentPid(),
-        };
-
-        return $this->security->isGranted(ContaoCalendarPermissions::USER_CAN_EDIT_CALENDAR, $pid);
+        return $this->security->isGranted(ContaoCalendarPermissions::USER_CAN_ACCESS_MODULE)
+            && $this->canAccessParent(ContaoCalendarPermissions::USER_CAN_EDIT_CALENDAR, $action);
     }
 }

--- a/calendar-bundle/tests/Security/Voter/CalendarEventsAccessVoterTest.php
+++ b/calendar-bundle/tests/Security/Voter/CalendarEventsAccessVoterTest.php
@@ -111,7 +111,6 @@ class CalendarEventsAccessVoterTest extends TestCase
         ;
 
         $token = $this->createMock(TokenInterface::class);
-
         $voter = new CalendarEventsAccessVoter($security);
 
         $this->assertSame(

--- a/calendar-bundle/tests/Security/Voter/CalendarEventsAccessVoterTest.php
+++ b/calendar-bundle/tests/Security/Voter/CalendarEventsAccessVoterTest.php
@@ -19,21 +19,27 @@ use Contao\CoreBundle\Security\DataContainer\CreateAction;
 use Contao\CoreBundle\Security\DataContainer\DeleteAction;
 use Contao\CoreBundle\Security\DataContainer\ReadAction;
 use Contao\CoreBundle\Security\DataContainer\UpdateAction;
-use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
-class CalendarEventsAccessVoterTest extends WebTestCase
+class CalendarEventsAccessVoterTest extends TestCase
 {
     public function testVoter(): void
     {
         $security = $this->createMock(Security::class);
         $security
-            ->expects($this->exactly(2))
+            ->expects($this->exactly(5))
             ->method('isGranted')
-            ->with(ContaoCalendarPermissions::USER_CAN_EDIT_CALENDAR, 42)
-            ->willReturnOnConsecutiveCalls(true, false)
+            ->withConsecutive(
+                [ContaoCalendarPermissions::USER_CAN_ACCESS_MODULE],
+                [ContaoCalendarPermissions::USER_CAN_EDIT_CALENDAR, 42],
+                [ContaoCalendarPermissions::USER_CAN_ACCESS_MODULE],
+                [ContaoCalendarPermissions::USER_CAN_ACCESS_MODULE],
+                [ContaoCalendarPermissions::USER_CAN_EDIT_CALENDAR, 42],
+            )
+            ->willReturnOnConsecutiveCalls(true, true, false, true, false)
         ;
 
         $voter = new CalendarEventsAccessVoter($security);
@@ -53,7 +59,7 @@ class CalendarEventsAccessVoterTest extends WebTestCase
             VoterInterface::ACCESS_ABSTAIN,
             $voter->vote(
                 $token,
-                new ReadAction('foo', ['pid' => 42]),
+                new ReadAction('tl_calendar_events', ['pid' => 42]),
                 ['whatever'],
             ),
         );
@@ -64,17 +70,55 @@ class CalendarEventsAccessVoterTest extends WebTestCase
             VoterInterface::ACCESS_ABSTAIN,
             $voter->vote(
                 $token,
-                new ReadAction('foo', ['pid' => 42]),
+                new ReadAction('tl_calendar_events', ['pid' => 42]),
                 [ContaoCorePermissions::DC_PREFIX.'tl_calendar_events'],
             ),
         );
 
-        // Permission denied
+        // Permission denied on back end module
         $this->assertSame(
             VoterInterface::ACCESS_DENIED,
             $voter->vote(
                 $token,
-                new ReadAction('foo', ['pid' => 42]),
+                new ReadAction('tl_calendar_events', ['pid' => 42]),
+                [ContaoCorePermissions::DC_PREFIX.'tl_calendar_events'],
+            ),
+        );
+
+        // Permission denied on calendar
+        $this->assertSame(
+            VoterInterface::ACCESS_DENIED,
+            $voter->vote(
+                $token,
+                new ReadAction('tl_calendar_events', ['pid' => 42]),
+                [ContaoCorePermissions::DC_PREFIX.'tl_calendar_events'],
+            ),
+        );
+    }
+
+    public function testDeniesUpdateActionToNewParent(): void
+    {
+        $security = $this->createMock(Security::class);
+        $security
+            ->expects($this->exactly(3))
+            ->method('isGranted')
+            ->withConsecutive(
+                [ContaoCalendarPermissions::USER_CAN_ACCESS_MODULE],
+                [ContaoCalendarPermissions::USER_CAN_EDIT_CALENDAR, 42],
+                [ContaoCalendarPermissions::USER_CAN_EDIT_CALENDAR, 43],
+            )
+            ->willReturnOnConsecutiveCalls(true, true, false)
+        ;
+
+        $token = $this->createMock(TokenInterface::class);
+
+        $voter = new CalendarEventsAccessVoter($security);
+
+        $this->assertSame(
+            VoterInterface::ACCESS_DENIED,
+            $voter->vote(
+                $token,
+                new UpdateAction('tl_calendar_events', ['pid' => 42], ['pid' => 43]),
                 [ContaoCorePermissions::DC_PREFIX.'tl_calendar_events'],
             ),
         );

--- a/core-bundle/src/Security/Voter/DataContainer/FormAccessVoter.php
+++ b/core-bundle/src/Security/Voter/DataContainer/FormAccessVoter.php
@@ -19,6 +19,9 @@ use Contao\CoreBundle\Security\DataContainer\ReadAction;
 use Contao\CoreBundle\Security\DataContainer\UpdateAction;
 use Symfony\Bundle\SecurityBundle\Security;
 
+/**
+ * @internal
+ */
 class FormAccessVoter extends AbstractDataContainerVoter
 {
     public function __construct(private readonly Security $security)
@@ -32,6 +35,10 @@ class FormAccessVoter extends AbstractDataContainerVoter
 
     protected function isGranted(CreateAction|DeleteAction|ReadAction|UpdateAction $action): bool
     {
+        if (!$this->security->isGranted(ContaoCorePermissions::USER_CAN_ACCESS_MODULE, 'form')) {
+            return false;
+        }
+
         return match (true) {
             $action instanceof CreateAction => $this->security->isGranted(ContaoCorePermissions::USER_CAN_CREATE_FORMS),
             $action instanceof ReadAction,

--- a/core-bundle/src/Security/Voter/DataContainer/FormFieldAccessVoter.php
+++ b/core-bundle/src/Security/Voter/DataContainer/FormFieldAccessVoter.php
@@ -17,13 +17,13 @@ use Contao\CoreBundle\Security\DataContainer\CreateAction;
 use Contao\CoreBundle\Security\DataContainer\DeleteAction;
 use Contao\CoreBundle\Security\DataContainer\ReadAction;
 use Contao\CoreBundle\Security\DataContainer\UpdateAction;
-use Symfony\Bundle\SecurityBundle\Security;
 
+/**
+ * @internal
+ */
 class FormFieldAccessVoter extends AbstractDataContainerVoter
 {
-    public function __construct(private readonly Security $security)
-    {
-    }
+    use ParentAccessTrait;
 
     protected function getTable(): string
     {
@@ -32,13 +32,7 @@ class FormFieldAccessVoter extends AbstractDataContainerVoter
 
     protected function isGranted(CreateAction|DeleteAction|ReadAction|UpdateAction $action): bool
     {
-        $pid = match (true) {
-            $action instanceof CreateAction => $action->getNewPid(),
-            $action instanceof ReadAction,
-            $action instanceof UpdateAction,
-            $action instanceof DeleteAction => $action->getCurrentPid(),
-        };
-
-        return $this->security->isGranted(ContaoCorePermissions::USER_CAN_EDIT_FORM, $pid);
+        return $this->security->isGranted(ContaoCorePermissions::USER_CAN_ACCESS_MODULE, 'form')
+            && $this->canAccessParent(ContaoCorePermissions::USER_CAN_EDIT_FORM, $action);
     }
 }

--- a/core-bundle/src/Security/Voter/DataContainer/ParentAccessTrait.php
+++ b/core-bundle/src/Security/Voter/DataContainer/ParentAccessTrait.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Security\Voter\DataContainer;
+
+use Contao\CoreBundle\Security\DataContainer\CreateAction;
+use Contao\CoreBundle\Security\DataContainer\DeleteAction;
+use Contao\CoreBundle\Security\DataContainer\ReadAction;
+use Contao\CoreBundle\Security\DataContainer\UpdateAction;
+use Symfony\Bundle\SecurityBundle\Security;
+
+trait ParentAccessTrait
+{
+    public function __construct(private readonly Security $security)
+    {
+    }
+
+    protected function canAccessParent(string $attribute, CreateAction|DeleteAction|ReadAction|UpdateAction $action): bool
+    {
+        $pids = [];
+
+        $pids[] = match (true) {
+            $action instanceof CreateAction => $action->getNewPid(),
+            $action instanceof ReadAction,
+            $action instanceof UpdateAction,
+            $action instanceof DeleteAction => $action->getCurrentPid(),
+        };
+
+        if (
+            $action instanceof UpdateAction
+            && ($newPid = (int) $action->getNewPid())
+            && $newPid !== (int) $action->getCurrentPid()
+        ) {
+            $pids[] = $newPid;
+        }
+
+        foreach ($pids as $pid) {
+            if (!$this->security->isGranted($attribute, $pid)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/core-bundle/tests/Security/Voter/DataContainer/FormFieldAccessVoterTest.php
+++ b/core-bundle/tests/Security/Voter/DataContainer/FormFieldAccessVoterTest.php
@@ -18,21 +18,27 @@ use Contao\CoreBundle\Security\DataContainer\DeleteAction;
 use Contao\CoreBundle\Security\DataContainer\ReadAction;
 use Contao\CoreBundle\Security\DataContainer\UpdateAction;
 use Contao\CoreBundle\Security\Voter\DataContainer\FormFieldAccessVoter;
-use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
-class FormFieldAccessVoterTest extends WebTestCase
+class FormFieldAccessVoterTest extends TestCase
 {
     public function testVoter(): void
     {
         $security = $this->createMock(Security::class);
         $security
-            ->expects($this->exactly(2))
+            ->expects($this->exactly(5))
             ->method('isGranted')
-            ->with(ContaoCorePermissions::USER_CAN_EDIT_FORM, 42)
-            ->willReturnOnConsecutiveCalls(true, false)
+            ->withConsecutive(
+                [ContaoCorePermissions::USER_CAN_ACCESS_MODULE, 'form'],
+                [ContaoCorePermissions::USER_CAN_EDIT_FORM, 42],
+                [ContaoCorePermissions::USER_CAN_ACCESS_MODULE, 'form'],
+                [ContaoCorePermissions::USER_CAN_ACCESS_MODULE, 'form'],
+                [ContaoCorePermissions::USER_CAN_EDIT_FORM, 42],
+            )
+            ->willReturnOnConsecutiveCalls(true, true, false, true, false)
         ;
 
         $voter = new FormFieldAccessVoter($security);
@@ -52,7 +58,7 @@ class FormFieldAccessVoterTest extends WebTestCase
             VoterInterface::ACCESS_ABSTAIN,
             $voter->vote(
                 $token,
-                new ReadAction('foo', ['pid' => 42]),
+                new ReadAction('tl_form_field', ['pid' => 42]),
                 ['whatever'],
             ),
         );
@@ -63,17 +69,55 @@ class FormFieldAccessVoterTest extends WebTestCase
             VoterInterface::ACCESS_ABSTAIN,
             $voter->vote(
                 $token,
-                new ReadAction('foo', ['pid' => 42]),
+                new ReadAction('tl_form_field', ['pid' => 42]),
                 [ContaoCorePermissions::DC_PREFIX.'tl_form_field'],
             ),
         );
 
-        // Permission denied
+        // Permission denied on back end module
         $this->assertSame(
             VoterInterface::ACCESS_DENIED,
             $voter->vote(
                 $token,
-                new ReadAction('foo', ['pid' => 42]),
+                new ReadAction('tl_form_field', ['pid' => 42]),
+                [ContaoCorePermissions::DC_PREFIX.'tl_form_field'],
+            ),
+        );
+
+        // Permission denied on form
+        $this->assertSame(
+            VoterInterface::ACCESS_DENIED,
+            $voter->vote(
+                $token,
+                new ReadAction('tl_form_field', ['pid' => 42]),
+                [ContaoCorePermissions::DC_PREFIX.'tl_form_field'],
+            ),
+        );
+    }
+
+    public function testDeniesUpdateActionToNewParent(): void
+    {
+        $security = $this->createMock(Security::class);
+        $security
+            ->expects($this->exactly(3))
+            ->method('isGranted')
+            ->withConsecutive(
+                [ContaoCorePermissions::USER_CAN_ACCESS_MODULE],
+                [ContaoCorePermissions::USER_CAN_EDIT_FORM, 42],
+                [ContaoCorePermissions::USER_CAN_EDIT_FORM, 43],
+            )
+            ->willReturnOnConsecutiveCalls(true, true, false)
+        ;
+
+        $token = $this->createMock(TokenInterface::class);
+
+        $voter = new FormFieldAccessVoter($security);
+
+        $this->assertSame(
+            VoterInterface::ACCESS_DENIED,
+            $voter->vote(
+                $token,
+                new UpdateAction('tl_form_field', ['pid' => 42], ['pid' => 43]),
                 [ContaoCorePermissions::DC_PREFIX.'tl_form_field'],
             ),
         );

--- a/core-bundle/tests/Security/Voter/DataContainer/FormFieldAccessVoterTest.php
+++ b/core-bundle/tests/Security/Voter/DataContainer/FormFieldAccessVoterTest.php
@@ -110,7 +110,6 @@ class FormFieldAccessVoterTest extends TestCase
         ;
 
         $token = $this->createMock(TokenInterface::class);
-
         $voter = new FormFieldAccessVoter($security);
 
         $this->assertSame(

--- a/faq-bundle/src/Security/ContaoFaqPermissions.php
+++ b/faq-bundle/src/Security/ContaoFaqPermissions.php
@@ -14,6 +14,8 @@ namespace Contao\FaqBundle\Security;
 
 final class ContaoFaqPermissions
 {
+    public const USER_CAN_ACCESS_MODULE = 'contao_user.modules.faq';
+
     public const USER_CAN_EDIT_CATEGORY = 'contao_user.faqs';
 
     public const USER_CAN_CREATE_CATEGORIES = 'contao_user.faqp.create';

--- a/faq-bundle/src/Security/Voter/FaqAccessVoter.php
+++ b/faq-bundle/src/Security/Voter/FaqAccessVoter.php
@@ -17,14 +17,15 @@ use Contao\CoreBundle\Security\DataContainer\DeleteAction;
 use Contao\CoreBundle\Security\DataContainer\ReadAction;
 use Contao\CoreBundle\Security\DataContainer\UpdateAction;
 use Contao\CoreBundle\Security\Voter\DataContainer\AbstractDataContainerVoter;
+use Contao\CoreBundle\Security\Voter\DataContainer\ParentAccessTrait;
 use Contao\FaqBundle\Security\ContaoFaqPermissions;
-use Symfony\Bundle\SecurityBundle\Security;
 
+/**
+ * @internal
+ */
 class FaqAccessVoter extends AbstractDataContainerVoter
 {
-    public function __construct(private readonly Security $security)
-    {
-    }
+    use ParentAccessTrait;
 
     protected function getTable(): string
     {
@@ -33,13 +34,7 @@ class FaqAccessVoter extends AbstractDataContainerVoter
 
     protected function isGranted(CreateAction|DeleteAction|ReadAction|UpdateAction $action): bool
     {
-        $pid = match (true) {
-            $action instanceof CreateAction => $action->getNewPid(),
-            $action instanceof ReadAction,
-            $action instanceof UpdateAction,
-            $action instanceof DeleteAction => $action->getCurrentPid(),
-        };
-
-        return $this->security->isGranted(ContaoFaqPermissions::USER_CAN_EDIT_CATEGORY, $pid);
+        return $this->security->isGranted(ContaoFaqPermissions::USER_CAN_ACCESS_MODULE)
+            && $this->canAccessParent(ContaoFaqPermissions::USER_CAN_EDIT_CATEGORY, $action);
     }
 }

--- a/faq-bundle/src/Security/Voter/FaqCategoryAccessVoter.php
+++ b/faq-bundle/src/Security/Voter/FaqCategoryAccessVoter.php
@@ -20,6 +20,9 @@ use Contao\CoreBundle\Security\Voter\DataContainer\AbstractDataContainerVoter;
 use Contao\FaqBundle\Security\ContaoFaqPermissions;
 use Symfony\Bundle\SecurityBundle\Security;
 
+/**
+ * @internal
+ */
 class FaqCategoryAccessVoter extends AbstractDataContainerVoter
 {
     public function __construct(private readonly Security $security)
@@ -33,6 +36,10 @@ class FaqCategoryAccessVoter extends AbstractDataContainerVoter
 
     protected function isGranted(CreateAction|DeleteAction|ReadAction|UpdateAction $action): bool
     {
+        if (!$this->security->isGranted(ContaoFaqPermissions::USER_CAN_ACCESS_MODULE)) {
+            return false;
+        }
+
         return match (true) {
             $action instanceof CreateAction => $this->security->isGranted(ContaoFaqPermissions::USER_CAN_CREATE_CATEGORIES),
             $action instanceof ReadAction,

--- a/faq-bundle/tests/Security/Voter/FaqAccessVoterTest.php
+++ b/faq-bundle/tests/Security/Voter/FaqAccessVoterTest.php
@@ -111,7 +111,6 @@ class FaqAccessVoterTest extends TestCase
         ;
 
         $token = $this->createMock(TokenInterface::class);
-
         $voter = new FaqAccessVoter($security);
 
         $this->assertSame(

--- a/faq-bundle/tests/Security/Voter/FaqAccessVoterTest.php
+++ b/faq-bundle/tests/Security/Voter/FaqAccessVoterTest.php
@@ -19,21 +19,27 @@ use Contao\CoreBundle\Security\DataContainer\ReadAction;
 use Contao\CoreBundle\Security\DataContainer\UpdateAction;
 use Contao\FaqBundle\Security\ContaoFaqPermissions;
 use Contao\FaqBundle\Security\Voter\FaqAccessVoter;
-use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
-class FaqAccessVoterTest extends WebTestCase
+class FaqAccessVoterTest extends TestCase
 {
     public function testVoter(): void
     {
         $security = $this->createMock(Security::class);
         $security
-            ->expects($this->exactly(2))
+            ->expects($this->exactly(5))
             ->method('isGranted')
-            ->with(ContaoFaqPermissions::USER_CAN_EDIT_CATEGORY, 42)
-            ->willReturnOnConsecutiveCalls(true, false)
+            ->withConsecutive(
+                [ContaoFaqPermissions::USER_CAN_ACCESS_MODULE],
+                [ContaoFaqPermissions::USER_CAN_EDIT_CATEGORY, 42],
+                [ContaoFaqPermissions::USER_CAN_ACCESS_MODULE],
+                [ContaoFaqPermissions::USER_CAN_ACCESS_MODULE],
+                [ContaoFaqPermissions::USER_CAN_EDIT_CATEGORY, 42],
+            )
+            ->willReturnOnConsecutiveCalls(true, true, false, true, false)
         ;
 
         $voter = new FaqAccessVoter($security);
@@ -53,7 +59,7 @@ class FaqAccessVoterTest extends WebTestCase
             VoterInterface::ACCESS_ABSTAIN,
             $voter->vote(
                 $token,
-                new ReadAction('foo', ['pid' => 42]),
+                new ReadAction('tl_faq', ['pid' => 42]),
                 ['whatever'],
             ),
         );
@@ -64,17 +70,55 @@ class FaqAccessVoterTest extends WebTestCase
             VoterInterface::ACCESS_ABSTAIN,
             $voter->vote(
                 $token,
-                new ReadAction('foo', ['pid' => 42]),
+                new ReadAction('tl_faq', ['pid' => 42]),
                 [ContaoCorePermissions::DC_PREFIX.'tl_faq'],
             ),
         );
 
-        // Permission denied
+        // Permission denied on back end module
         $this->assertSame(
             VoterInterface::ACCESS_DENIED,
             $voter->vote(
                 $token,
-                new ReadAction('foo', ['pid' => 42]),
+                new ReadAction('tl_faq', ['pid' => 42]),
+                [ContaoCorePermissions::DC_PREFIX.'tl_faq'],
+            ),
+        );
+
+        // Permission denied on faq category
+        $this->assertSame(
+            VoterInterface::ACCESS_DENIED,
+            $voter->vote(
+                $token,
+                new ReadAction('tl_faq', ['pid' => 42]),
+                [ContaoCorePermissions::DC_PREFIX.'tl_faq'],
+            ),
+        );
+    }
+
+    public function testDeniesUpdateActionToNewParent(): void
+    {
+        $security = $this->createMock(Security::class);
+        $security
+            ->expects($this->exactly(3))
+            ->method('isGranted')
+            ->withConsecutive(
+                [ContaoFaqPermissions::USER_CAN_ACCESS_MODULE],
+                [ContaoFaqPermissions::USER_CAN_EDIT_CATEGORY, 42],
+                [ContaoFaqPermissions::USER_CAN_EDIT_CATEGORY, 43],
+            )
+            ->willReturnOnConsecutiveCalls(true, true, false)
+        ;
+
+        $token = $this->createMock(TokenInterface::class);
+
+        $voter = new FaqAccessVoter($security);
+
+        $this->assertSame(
+            VoterInterface::ACCESS_DENIED,
+            $voter->vote(
+                $token,
+                new UpdateAction('tl_faq', ['pid' => 42], ['pid' => 43]),
                 [ContaoCorePermissions::DC_PREFIX.'tl_faq'],
             ),
         );

--- a/news-bundle/src/Security/ContaoNewsPermissions.php
+++ b/news-bundle/src/Security/ContaoNewsPermissions.php
@@ -14,6 +14,8 @@ namespace Contao\NewsBundle\Security;
 
 final class ContaoNewsPermissions
 {
+    public const USER_CAN_ACCESS_MODULE = 'contao_user.modules.news';
+
     public const USER_CAN_EDIT_ARCHIVE = 'contao_user.news';
 
     public const USER_CAN_CREATE_ARCHIVES = 'contao_user.newp.create';

--- a/news-bundle/src/Security/Voter/NewsAccessVoter.php
+++ b/news-bundle/src/Security/Voter/NewsAccessVoter.php
@@ -17,14 +17,15 @@ use Contao\CoreBundle\Security\DataContainer\DeleteAction;
 use Contao\CoreBundle\Security\DataContainer\ReadAction;
 use Contao\CoreBundle\Security\DataContainer\UpdateAction;
 use Contao\CoreBundle\Security\Voter\DataContainer\AbstractDataContainerVoter;
+use Contao\CoreBundle\Security\Voter\DataContainer\ParentAccessTrait;
 use Contao\NewsBundle\Security\ContaoNewsPermissions;
-use Symfony\Bundle\SecurityBundle\Security;
 
+/**
+ * @internal
+ */
 class NewsAccessVoter extends AbstractDataContainerVoter
 {
-    public function __construct(private readonly Security $security)
-    {
-    }
+    use ParentAccessTrait;
 
     protected function getTable(): string
     {
@@ -33,13 +34,7 @@ class NewsAccessVoter extends AbstractDataContainerVoter
 
     protected function isGranted(CreateAction|DeleteAction|ReadAction|UpdateAction $action): bool
     {
-        $pid = match (true) {
-            $action instanceof CreateAction => $action->getNewPid(),
-            $action instanceof ReadAction,
-            $action instanceof UpdateAction,
-            $action instanceof DeleteAction => $action->getCurrentPid(),
-        };
-
-        return $this->security->isGranted(ContaoNewsPermissions::USER_CAN_EDIT_ARCHIVE, $pid);
+        return $this->security->isGranted(ContaoNewsPermissions::USER_CAN_ACCESS_MODULE)
+            && $this->canAccessParent(ContaoNewsPermissions::USER_CAN_EDIT_ARCHIVE, $action);
     }
 }

--- a/news-bundle/src/Security/Voter/NewsArchiveAccessVoter.php
+++ b/news-bundle/src/Security/Voter/NewsArchiveAccessVoter.php
@@ -20,6 +20,9 @@ use Contao\CoreBundle\Security\Voter\DataContainer\AbstractDataContainerVoter;
 use Contao\NewsBundle\Security\ContaoNewsPermissions;
 use Symfony\Bundle\SecurityBundle\Security;
 
+/**
+ * @internal
+ */
 class NewsArchiveAccessVoter extends AbstractDataContainerVoter
 {
     public function __construct(private readonly Security $security)
@@ -33,6 +36,10 @@ class NewsArchiveAccessVoter extends AbstractDataContainerVoter
 
     protected function isGranted(CreateAction|DeleteAction|ReadAction|UpdateAction $action): bool
     {
+        if (!$this->security->isGranted(ContaoNewsPermissions::USER_CAN_ACCESS_MODULE)) {
+            return false;
+        }
+
         return match (true) {
             $action instanceof CreateAction => $this->security->isGranted(ContaoNewsPermissions::USER_CAN_CREATE_ARCHIVES),
             $action instanceof ReadAction,

--- a/news-bundle/tests/Security/Voter/NewsAccessVoterTest.php
+++ b/news-bundle/tests/Security/Voter/NewsAccessVoterTest.php
@@ -19,21 +19,27 @@ use Contao\CoreBundle\Security\DataContainer\ReadAction;
 use Contao\CoreBundle\Security\DataContainer\UpdateAction;
 use Contao\NewsBundle\Security\ContaoNewsPermissions;
 use Contao\NewsBundle\Security\Voter\NewsAccessVoter;
-use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
-class NewsAccessVoterTest extends WebTestCase
+class NewsAccessVoterTest extends TestCase
 {
     public function testVoter(): void
     {
         $security = $this->createMock(Security::class);
         $security
-            ->expects($this->exactly(2))
+            ->expects($this->exactly(5))
             ->method('isGranted')
-            ->with(ContaoNewsPermissions::USER_CAN_EDIT_ARCHIVE, 42)
-            ->willReturnOnConsecutiveCalls(true, false)
+            ->withConsecutive(
+                [ContaoNewsPermissions::USER_CAN_ACCESS_MODULE],
+                [ContaoNewsPermissions::USER_CAN_EDIT_ARCHIVE, 42],
+                [ContaoNewsPermissions::USER_CAN_ACCESS_MODULE],
+                [ContaoNewsPermissions::USER_CAN_ACCESS_MODULE],
+                [ContaoNewsPermissions::USER_CAN_EDIT_ARCHIVE, 42],
+            )
+            ->willReturnOnConsecutiveCalls(true, true, false, true, false)
         ;
 
         $voter = new NewsAccessVoter($security);
@@ -53,7 +59,7 @@ class NewsAccessVoterTest extends WebTestCase
             VoterInterface::ACCESS_ABSTAIN,
             $voter->vote(
                 $token,
-                new ReadAction('foo', ['pid' => 42]),
+                new ReadAction('tl_news', ['pid' => 42]),
                 ['whatever'],
             ),
         );
@@ -64,17 +70,55 @@ class NewsAccessVoterTest extends WebTestCase
             VoterInterface::ACCESS_ABSTAIN,
             $voter->vote(
                 $token,
-                new ReadAction('foo', ['pid' => 42]),
+                new ReadAction('tl_news', ['pid' => 42]),
                 [ContaoCorePermissions::DC_PREFIX.'tl_news'],
             ),
         );
 
-        // Permission denied
+        // Permission denied on back end module
         $this->assertSame(
             VoterInterface::ACCESS_DENIED,
             $voter->vote(
                 $token,
-                new ReadAction('foo', ['pid' => 42]),
+                new ReadAction('tl_news', ['pid' => 42]),
+                [ContaoCorePermissions::DC_PREFIX.'tl_news'],
+            ),
+        );
+
+        // Permission denied on news archive
+        $this->assertSame(
+            VoterInterface::ACCESS_DENIED,
+            $voter->vote(
+                $token,
+                new ReadAction('tl_news', ['pid' => 42]),
+                [ContaoCorePermissions::DC_PREFIX.'tl_news'],
+            ),
+        );
+    }
+
+    public function testDeniesUpdateActionToNewParent(): void
+    {
+        $security = $this->createMock(Security::class);
+        $security
+            ->expects($this->exactly(3))
+            ->method('isGranted')
+            ->withConsecutive(
+                [ContaoNewsPermissions::USER_CAN_ACCESS_MODULE],
+                [ContaoNewsPermissions::USER_CAN_EDIT_ARCHIVE, 42],
+                [ContaoNewsPermissions::USER_CAN_EDIT_ARCHIVE, 43],
+            )
+            ->willReturnOnConsecutiveCalls(true, true, false)
+        ;
+
+        $token = $this->createMock(TokenInterface::class);
+
+        $voter = new NewsAccessVoter($security);
+
+        $this->assertSame(
+            VoterInterface::ACCESS_DENIED,
+            $voter->vote(
+                $token,
+                new UpdateAction('tl_news', ['pid' => 42], ['pid' => 43]),
                 [ContaoCorePermissions::DC_PREFIX.'tl_news'],
             ),
         );

--- a/news-bundle/tests/Security/Voter/NewsAccessVoterTest.php
+++ b/news-bundle/tests/Security/Voter/NewsAccessVoterTest.php
@@ -111,7 +111,6 @@ class NewsAccessVoterTest extends TestCase
         ;
 
         $token = $this->createMock(TokenInterface::class);
-
         $voter = new NewsAccessVoter($security);
 
         $this->assertSame(

--- a/news-bundle/tests/Security/Voter/NewsArchiveAccessVoterTest.php
+++ b/news-bundle/tests/Security/Voter/NewsArchiveAccessVoterTest.php
@@ -19,21 +19,27 @@ use Contao\CoreBundle\Security\DataContainer\ReadAction;
 use Contao\CoreBundle\Security\DataContainer\UpdateAction;
 use Contao\NewsBundle\Security\ContaoNewsPermissions;
 use Contao\NewsBundle\Security\Voter\NewsArchiveAccessVoter;
-use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
-class NewsArchiveAccessVoterTest extends WebTestCase
+class NewsArchiveAccessVoterTest extends TestCase
 {
     public function testVoter(): void
     {
         $security = $this->createMock(Security::class);
         $security
-            ->expects($this->exactly(2))
+            ->expects($this->exactly(5))
             ->method('isGranted')
-            ->with(ContaoNewsPermissions::USER_CAN_EDIT_ARCHIVE, 42)
-            ->willReturnOnConsecutiveCalls(true, false)
+            ->withConsecutive(
+                [ContaoNewsPermissions::USER_CAN_ACCESS_MODULE],
+                [ContaoNewsPermissions::USER_CAN_EDIT_ARCHIVE, 42],
+                [ContaoNewsPermissions::USER_CAN_ACCESS_MODULE],
+                [ContaoNewsPermissions::USER_CAN_ACCESS_MODULE],
+                [ContaoNewsPermissions::USER_CAN_EDIT_ARCHIVE, 42],
+            )
+            ->willReturnOnConsecutiveCalls(true, true, false, true, false)
         ;
 
         $voter = new NewsArchiveAccessVoter($security);
@@ -53,7 +59,7 @@ class NewsArchiveAccessVoterTest extends WebTestCase
             VoterInterface::ACCESS_ABSTAIN,
             $voter->vote(
                 $token,
-                new ReadAction('foo', ['id' => 42]),
+                new ReadAction('tl_news_archive', ['id' => 42]),
                 ['whatever'],
             ),
         );
@@ -64,17 +70,27 @@ class NewsArchiveAccessVoterTest extends WebTestCase
             VoterInterface::ACCESS_ABSTAIN,
             $voter->vote(
                 $token,
-                new ReadAction('foo', ['id' => 42]),
+                new ReadAction('tl_news_archive', ['id' => 42]),
                 [ContaoCorePermissions::DC_PREFIX.'tl_news_archive'],
             ),
         );
 
-        // Permission denied
+        // Permission denied on back end module
         $this->assertSame(
             VoterInterface::ACCESS_DENIED,
             $voter->vote(
                 $token,
-                new ReadAction('foo', ['id' => 42]),
+                new ReadAction('tl_news_archive', ['id' => 42]),
+                [ContaoCorePermissions::DC_PREFIX.'tl_news_archive'],
+            ),
+        );
+
+        // Permission denied on news archive
+        $this->assertSame(
+            VoterInterface::ACCESS_DENIED,
+            $voter->vote(
+                $token,
+                new ReadAction('tl_news_archive', ['id' => 42]),
                 [ContaoCorePermissions::DC_PREFIX.'tl_news_archive'],
             ),
         );

--- a/newsletter-bundle/src/Security/ContaoNewsletterPermissions.php
+++ b/newsletter-bundle/src/Security/ContaoNewsletterPermissions.php
@@ -14,6 +14,8 @@ namespace Contao\NewsletterBundle\Security;
 
 final class ContaoNewsletterPermissions
 {
+    public const USER_CAN_ACCESS_MODULE = 'contao_user.modules.newsletter';
+
     public const USER_CAN_EDIT_CHANNEL = 'contao_user.newsletters';
 
     public const USER_CAN_CREATE_CHANNELS = 'contao_user.newsletterp.create';

--- a/newsletter-bundle/src/Security/Voter/NewsletterAccessVoter.php
+++ b/newsletter-bundle/src/Security/Voter/NewsletterAccessVoter.php
@@ -17,14 +17,15 @@ use Contao\CoreBundle\Security\DataContainer\DeleteAction;
 use Contao\CoreBundle\Security\DataContainer\ReadAction;
 use Contao\CoreBundle\Security\DataContainer\UpdateAction;
 use Contao\CoreBundle\Security\Voter\DataContainer\AbstractDataContainerVoter;
+use Contao\CoreBundle\Security\Voter\DataContainer\ParentAccessTrait;
 use Contao\NewsletterBundle\Security\ContaoNewsletterPermissions;
-use Symfony\Bundle\SecurityBundle\Security;
 
+/**
+ * @internal
+ */
 class NewsletterAccessVoter extends AbstractDataContainerVoter
 {
-    public function __construct(private readonly Security $security)
-    {
-    }
+    use ParentAccessTrait;
 
     protected function getTable(): string
     {
@@ -33,13 +34,7 @@ class NewsletterAccessVoter extends AbstractDataContainerVoter
 
     protected function isGranted(CreateAction|DeleteAction|ReadAction|UpdateAction $action): bool
     {
-        $pid = match (true) {
-            $action instanceof CreateAction => $action->getNewPid(),
-            $action instanceof ReadAction,
-            $action instanceof UpdateAction,
-            $action instanceof DeleteAction => $action->getCurrentPid(),
-        };
-
-        return $this->security->isGranted(ContaoNewsletterPermissions::USER_CAN_EDIT_CHANNEL, $pid);
+        return $this->security->isGranted(ContaoNewsletterPermissions::USER_CAN_ACCESS_MODULE)
+            && $this->canAccessParent(ContaoNewsletterPermissions::USER_CAN_EDIT_CHANNEL, $action);
     }
 }

--- a/newsletter-bundle/src/Security/Voter/NewsletterChannelAccessVoter.php
+++ b/newsletter-bundle/src/Security/Voter/NewsletterChannelAccessVoter.php
@@ -20,6 +20,9 @@ use Contao\CoreBundle\Security\Voter\DataContainer\AbstractDataContainerVoter;
 use Contao\NewsletterBundle\Security\ContaoNewsletterPermissions;
 use Symfony\Bundle\SecurityBundle\Security;
 
+/**
+ * @internal
+ */
 class NewsletterChannelAccessVoter extends AbstractDataContainerVoter
 {
     public function __construct(private readonly Security $security)
@@ -33,6 +36,10 @@ class NewsletterChannelAccessVoter extends AbstractDataContainerVoter
 
     protected function isGranted(CreateAction|DeleteAction|ReadAction|UpdateAction $action): bool
     {
+        if (!$this->security->isGranted(ContaoNewsletterPermissions::USER_CAN_ACCESS_MODULE)) {
+            return false;
+        }
+
         return match (true) {
             $action instanceof CreateAction => $this->security->isGranted(ContaoNewsletterPermissions::USER_CAN_CREATE_CHANNELS),
             $action instanceof ReadAction,

--- a/newsletter-bundle/tests/Security/Voter/NewsletterAccessVoterTest.php
+++ b/newsletter-bundle/tests/Security/Voter/NewsletterAccessVoterTest.php
@@ -111,7 +111,6 @@ class NewsletterAccessVoterTest extends TestCase
         ;
 
         $token = $this->createMock(TokenInterface::class);
-
         $voter = new NewsletterAccessVoter($security);
 
         $this->assertSame(

--- a/newsletter-bundle/tests/Security/Voter/NewsletterAccessVoterTest.php
+++ b/newsletter-bundle/tests/Security/Voter/NewsletterAccessVoterTest.php
@@ -19,21 +19,27 @@ use Contao\CoreBundle\Security\DataContainer\ReadAction;
 use Contao\CoreBundle\Security\DataContainer\UpdateAction;
 use Contao\NewsletterBundle\Security\ContaoNewsletterPermissions;
 use Contao\NewsletterBundle\Security\Voter\NewsletterAccessVoter;
-use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
-class NewsletterAccessVoterTest extends WebTestCase
+class NewsletterAccessVoterTest extends TestCase
 {
     public function testVoter(): void
     {
         $security = $this->createMock(Security::class);
         $security
-            ->expects($this->exactly(2))
+            ->expects($this->exactly(5))
             ->method('isGranted')
-            ->with(ContaoNewsletterPermissions::USER_CAN_EDIT_CHANNEL, 42)
-            ->willReturnOnConsecutiveCalls(true, false)
+            ->withConsecutive(
+                [ContaoNewsletterPermissions::USER_CAN_ACCESS_MODULE],
+                [ContaoNewsletterPermissions::USER_CAN_EDIT_CHANNEL, 42],
+                [ContaoNewsletterPermissions::USER_CAN_ACCESS_MODULE],
+                [ContaoNewsletterPermissions::USER_CAN_ACCESS_MODULE],
+                [ContaoNewsletterPermissions::USER_CAN_EDIT_CHANNEL, 42],
+            )
+            ->willReturnOnConsecutiveCalls(true, true, false, true, false)
         ;
 
         $voter = new NewsletterAccessVoter($security);
@@ -53,7 +59,7 @@ class NewsletterAccessVoterTest extends WebTestCase
             VoterInterface::ACCESS_ABSTAIN,
             $voter->vote(
                 $token,
-                new ReadAction('foo', ['id' => 42]),
+                new ReadAction('tl_newsletter', ['id' => 42]),
                 ['whatever'],
             ),
         );
@@ -64,17 +70,55 @@ class NewsletterAccessVoterTest extends WebTestCase
             VoterInterface::ACCESS_ABSTAIN,
             $voter->vote(
                 $token,
-                new ReadAction('foo', ['pid' => 42]),
+                new ReadAction('tl_newsletter', ['pid' => 42]),
                 [ContaoCorePermissions::DC_PREFIX.'tl_newsletter'],
             ),
         );
 
-        // Permission denied
+        // Permission denied on back end module
         $this->assertSame(
             VoterInterface::ACCESS_DENIED,
             $voter->vote(
                 $token,
-                new ReadAction('foo', ['pid' => 42]),
+                new ReadAction('tl_newsletter', ['pid' => 42]),
+                [ContaoCorePermissions::DC_PREFIX.'tl_newsletter'],
+            ),
+        );
+
+        // Permission denied on newsletter channel
+        $this->assertSame(
+            VoterInterface::ACCESS_DENIED,
+            $voter->vote(
+                $token,
+                new ReadAction('tl_newsletter', ['pid' => 42]),
+                [ContaoCorePermissions::DC_PREFIX.'tl_newsletter'],
+            ),
+        );
+    }
+
+    public function testDeniesUpdateActionToNewParent(): void
+    {
+        $security = $this->createMock(Security::class);
+        $security
+            ->expects($this->exactly(3))
+            ->method('isGranted')
+            ->withConsecutive(
+                [ContaoNewsletterPermissions::USER_CAN_ACCESS_MODULE],
+                [ContaoNewsletterPermissions::USER_CAN_EDIT_CHANNEL, 42],
+                [ContaoNewsletterPermissions::USER_CAN_EDIT_CHANNEL, 43],
+            )
+            ->willReturnOnConsecutiveCalls(true, true, false)
+        ;
+
+        $token = $this->createMock(TokenInterface::class);
+
+        $voter = new NewsletterAccessVoter($security);
+
+        $this->assertSame(
+            VoterInterface::ACCESS_DENIED,
+            $voter->vote(
+                $token,
+                new UpdateAction('tl_newsletter', ['pid' => 42], ['pid' => 43]),
                 [ContaoCorePermissions::DC_PREFIX.'tl_newsletter'],
             ),
         );


### PR DESCRIPTION
I wanted to implement new voters… but came across a lot of issues in the current ones 🙈.

1. Voters must also check if a user has access to the respective back end modules
2. A child table voter must make sure an `UpdateAction` does not modify the parent ID or changes it to an allowed parent ID

As soon as this and https://github.com/contao/contao/pull/6627 is merged I'll also need to refactor the `isGranted` check, but I'll keep this separate to be easier to review.