### PR TITLE
Vote on the current token in the voters

### DIFF
--- a/calendar-bundle/config/services.yaml
+++ b/calendar-bundle/config/services.yaml
@@ -69,9 +69,9 @@ services:
     contao_calendar.security.calendar_access_voter:
         class: Contao\CalendarBundle\Security\Voter\CalendarAccessVoter
         arguments:
-            - '@security.helper'
+            - '@security.access.decision_manager'
 
     contao_calendar.security.calendar_events_access_voter:
         class: Contao\CalendarBundle\Security\Voter\CalendarEventsAccessVoter
         arguments:
-            - '@security.helper'
+            - '@security.access.decision_manager'

--- a/calendar-bundle/src/Security/Voter/CalendarAccessVoter.php
+++ b/calendar-bundle/src/Security/Voter/CalendarAccessVoter.php
@@ -18,14 +18,15 @@ use Contao\CoreBundle\Security\DataContainer\DeleteAction;
 use Contao\CoreBundle\Security\DataContainer\ReadAction;
 use Contao\CoreBundle\Security\DataContainer\UpdateAction;
 use Contao\CoreBundle\Security\Voter\DataContainer\AbstractDataContainerVoter;
-use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
 
 /**
  * @internal
  */
 class CalendarAccessVoter extends AbstractDataContainerVoter
 {
-    public function __construct(private readonly Security $security)
+    public function __construct(private readonly AccessDecisionManagerInterface $accessDecisionManager)
     {
     }
 
@@ -34,18 +35,18 @@ class CalendarAccessVoter extends AbstractDataContainerVoter
         return 'tl_calendar';
     }
 
-    protected function isGranted(CreateAction|DeleteAction|ReadAction|UpdateAction $action): bool
+    protected function hasAccess(TokenInterface $token, CreateAction|DeleteAction|ReadAction|UpdateAction $action): bool
     {
-        if (!$this->security->isGranted(ContaoCalendarPermissions::USER_CAN_ACCESS_MODULE)) {
+        if (!$this->accessDecisionManager->decide($token, [ContaoCalendarPermissions::USER_CAN_ACCESS_MODULE])) {
             return false;
         }
 
         return match (true) {
-            $action instanceof CreateAction => $this->security->isGranted(ContaoCalendarPermissions::USER_CAN_CREATE_CALENDARS),
+            $action instanceof CreateAction => $this->accessDecisionManager->decide($token, [ContaoCalendarPermissions::USER_CAN_CREATE_CALENDARS]),
             $action instanceof ReadAction,
-            $action instanceof UpdateAction => $this->security->isGranted(ContaoCalendarPermissions::USER_CAN_EDIT_CALENDAR, $action->getCurrentId()),
-            $action instanceof DeleteAction => $this->security->isGranted(ContaoCalendarPermissions::USER_CAN_EDIT_CALENDAR, $action->getCurrentId())
-                && $this->security->isGranted(ContaoCalendarPermissions::USER_CAN_DELETE_CALENDARS),
+            $action instanceof UpdateAction => $this->accessDecisionManager->decide($token, [ContaoCalendarPermissions::USER_CAN_EDIT_CALENDAR], $action->getCurrentId()),
+            $action instanceof DeleteAction => $this->accessDecisionManager->decide($token, [ContaoCalendarPermissions::USER_CAN_EDIT_CALENDAR], $action->getCurrentId())
+                && $this->accessDecisionManager->decide($token, [ContaoCalendarPermissions::USER_CAN_DELETE_CALENDARS]),
         };
     }
 }

--- a/calendar-bundle/src/Security/Voter/CalendarEventsAccessVoter.php
+++ b/calendar-bundle/src/Security/Voter/CalendarEventsAccessVoter.php
@@ -19,6 +19,7 @@ use Contao\CoreBundle\Security\DataContainer\ReadAction;
 use Contao\CoreBundle\Security\DataContainer\UpdateAction;
 use Contao\CoreBundle\Security\Voter\DataContainer\AbstractDataContainerVoter;
 use Contao\CoreBundle\Security\Voter\DataContainer\ParentAccessTrait;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
 /**
  * @internal
@@ -32,9 +33,9 @@ class CalendarEventsAccessVoter extends AbstractDataContainerVoter
         return 'tl_calendar_events';
     }
 
-    protected function isGranted(CreateAction|DeleteAction|ReadAction|UpdateAction $action): bool
+    protected function hasAccess(TokenInterface $token, CreateAction|DeleteAction|ReadAction|UpdateAction $action): bool
     {
-        return $this->security->isGranted(ContaoCalendarPermissions::USER_CAN_ACCESS_MODULE)
-            && $this->canAccessParent(ContaoCalendarPermissions::USER_CAN_EDIT_CALENDAR, $action);
+        return $this->accessDecisionManager->decide($token, [ContaoCalendarPermissions::USER_CAN_ACCESS_MODULE])
+            && $this->hasAccessToParent($token, ContaoCalendarPermissions::USER_CAN_EDIT_CALENDAR, $action);
     }
 }

--- a/calendar-bundle/tests/Security/Voter/CalendarAccessVoterTest.php
+++ b/calendar-bundle/tests/Security/Voter/CalendarAccessVoterTest.php
@@ -20,29 +20,31 @@ use Contao\CoreBundle\Security\DataContainer\DeleteAction;
 use Contao\CoreBundle\Security\DataContainer\ReadAction;
 use Contao\CoreBundle\Security\DataContainer\UpdateAction;
 use PHPUnit\Framework\TestCase;
-use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
 class CalendarAccessVoterTest extends TestCase
 {
     public function testVoter(): void
     {
-        $security = $this->createMock(Security::class);
-        $security
+        $token = $this->createMock(TokenInterface::class);
+
+        $accessDecisionManager = $this->createMock(AccessDecisionManagerInterface::class);
+        $accessDecisionManager
             ->expects($this->exactly(5))
-            ->method('isGranted')
+            ->method('decide')
             ->withConsecutive(
-                [ContaoCalendarPermissions::USER_CAN_ACCESS_MODULE],
-                [ContaoCalendarPermissions::USER_CAN_EDIT_CALENDAR, 42],
-                [ContaoCalendarPermissions::USER_CAN_ACCESS_MODULE],
-                [ContaoCalendarPermissions::USER_CAN_ACCESS_MODULE],
-                [ContaoCalendarPermissions::USER_CAN_EDIT_CALENDAR, 42],
+                [$token, [ContaoCalendarPermissions::USER_CAN_ACCESS_MODULE]],
+                [$token, [ContaoCalendarPermissions::USER_CAN_EDIT_CALENDAR], 42],
+                [$token, [ContaoCalendarPermissions::USER_CAN_ACCESS_MODULE]],
+                [$token, [ContaoCalendarPermissions::USER_CAN_ACCESS_MODULE]],
+                [$token, [ContaoCalendarPermissions::USER_CAN_EDIT_CALENDAR], 42],
             )
             ->willReturnOnConsecutiveCalls(true, true, false, true, false)
         ;
 
-        $voter = new CalendarAccessVoter($security);
+        $voter = new CalendarAccessVoter($accessDecisionManager);
 
         $this->assertTrue($voter->supportsAttribute(ContaoCorePermissions::DC_PREFIX.'tl_calendar'));
         $this->assertFalse($voter->supportsAttribute(ContaoCorePermissions::DC_PREFIX.'tl_calendar_events'));
@@ -51,8 +53,6 @@ class CalendarAccessVoterTest extends TestCase
         $this->assertTrue($voter->supportsType(UpdateAction::class));
         $this->assertTrue($voter->supportsType(DeleteAction::class));
         $this->assertFalse($voter->supportsType(CalendarAccessVoter::class));
-
-        $token = $this->createMock(TokenInterface::class);
 
         // Unsupported attribute
         $this->assertSame(

--- a/core-bundle/config/services.yaml
+++ b/core-bundle/config/services.yaml
@@ -846,23 +846,21 @@ services:
 
     contao.security.data_container.favorites_voter:
         class: Contao\CoreBundle\Security\Voter\DataContainer\FavoritesVoter
-        arguments:
-            - '@security.helper'
 
     contao.security.data_container.form_access_voter:
         class: Contao\CoreBundle\Security\Voter\DataContainer\FormAccessVoter
         arguments:
-            - '@security.helper'
+            - '@security.access.decision_manager'
 
     contao.security.data_container.form_field_access_voter:
         class: Contao\CoreBundle\Security\Voter\DataContainer\FormFieldAccessVoter
         arguments:
-            - '@security.helper'
+            - '@security.access.decision_manager'
 
     contao.security.data_container.table_access_voter:
         class: Contao\CoreBundle\Security\Voter\DataContainer\TableAccessVoter
         arguments:
-            - '@security.helper'
+            - '@security.access.decision_manager'
         tags:
             - { name: security.voter, priority: 100 }
 

--- a/core-bundle/src/Security/Voter/DataContainer/AbstractDataContainerVoter.php
+++ b/core-bundle/src/Security/Voter/DataContainer/AbstractDataContainerVoter.php
@@ -44,7 +44,7 @@ abstract class AbstractDataContainerVoter implements VoterInterface, CacheableVo
                 $subject instanceof CreateAction,
                 $subject instanceof ReadAction,
                 $subject instanceof UpdateAction,
-                $subject instanceof DeleteAction => $this->isGranted($subject),
+                $subject instanceof DeleteAction => $this->hasAccess($token, $subject),
                 default => null,
             };
 
@@ -58,5 +58,5 @@ abstract class AbstractDataContainerVoter implements VoterInterface, CacheableVo
 
     abstract protected function getTable(): string;
 
-    abstract protected function isGranted(CreateAction|DeleteAction|ReadAction|UpdateAction $action): bool;
+    abstract protected function hasAccess(TokenInterface $token, CreateAction|DeleteAction|ReadAction|UpdateAction $action): bool;
 }

--- a/core-bundle/src/Security/Voter/DataContainer/FavoritesVoter.php
+++ b/core-bundle/src/Security/Voter/DataContainer/FavoritesVoter.php
@@ -17,25 +17,21 @@ use Contao\CoreBundle\Security\DataContainer\CreateAction;
 use Contao\CoreBundle\Security\DataContainer\DeleteAction;
 use Contao\CoreBundle\Security\DataContainer\ReadAction;
 use Contao\CoreBundle\Security\DataContainer\UpdateAction;
-use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
 /**
  * @internal
  */
 class FavoritesVoter extends AbstractDataContainerVoter
 {
-    public function __construct(private readonly Security $security)
-    {
-    }
-
     protected function getTable(): string
     {
         return 'tl_favorites';
     }
 
-    protected function isGranted(CreateAction|DeleteAction|ReadAction|UpdateAction $action): bool
+    protected function hasAccess(TokenInterface $token, CreateAction|DeleteAction|ReadAction|UpdateAction $action): bool
     {
-        $user = $this->security->getUser();
+        $user = $token->getUser();
 
         if (!$user instanceof BackendUser) {
             return false;

--- a/core-bundle/src/Security/Voter/DataContainer/FormFieldAccessVoter.php
+++ b/core-bundle/src/Security/Voter/DataContainer/FormFieldAccessVoter.php
@@ -17,6 +17,7 @@ use Contao\CoreBundle\Security\DataContainer\CreateAction;
 use Contao\CoreBundle\Security\DataContainer\DeleteAction;
 use Contao\CoreBundle\Security\DataContainer\ReadAction;
 use Contao\CoreBundle\Security\DataContainer\UpdateAction;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
 /**
  * @internal
@@ -30,9 +31,9 @@ class FormFieldAccessVoter extends AbstractDataContainerVoter
         return 'tl_form_field';
     }
 
-    protected function isGranted(CreateAction|DeleteAction|ReadAction|UpdateAction $action): bool
+    protected function hasAccess(TokenInterface $token, CreateAction|DeleteAction|ReadAction|UpdateAction $action): bool
     {
-        return $this->security->isGranted(ContaoCorePermissions::USER_CAN_ACCESS_MODULE, 'form')
-            && $this->canAccessParent(ContaoCorePermissions::USER_CAN_EDIT_FORM, $action);
+        return $this->accessDecisionManager->decide($token, [ContaoCorePermissions::USER_CAN_ACCESS_MODULE], 'form')
+            && $this->hasAccessToParent($token, ContaoCorePermissions::USER_CAN_EDIT_FORM, $action);
     }
 }

--- a/core-bundle/src/Security/Voter/DataContainer/ParentAccessTrait.php
+++ b/core-bundle/src/Security/Voter/DataContainer/ParentAccessTrait.php
@@ -16,15 +16,16 @@ use Contao\CoreBundle\Security\DataContainer\CreateAction;
 use Contao\CoreBundle\Security\DataContainer\DeleteAction;
 use Contao\CoreBundle\Security\DataContainer\ReadAction;
 use Contao\CoreBundle\Security\DataContainer\UpdateAction;
-use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
 
 trait ParentAccessTrait
 {
-    public function __construct(private readonly Security $security)
+    public function __construct(private readonly AccessDecisionManagerInterface $accessDecisionManager)
     {
     }
 
-    protected function canAccessParent(string $attribute, CreateAction|DeleteAction|ReadAction|UpdateAction $action): bool
+    protected function hasAccessToParent(TokenInterface $token, string $attribute, CreateAction|DeleteAction|ReadAction|UpdateAction $action): bool
     {
         $pids = [];
 
@@ -44,7 +45,7 @@ trait ParentAccessTrait
         }
 
         foreach ($pids as $pid) {
-            if (!$this->security->isGranted($attribute, $pid)) {
+            if (!$this->accessDecisionManager->decide($token, [$attribute], $pid)) {
                 return false;
             }
         }

--- a/core-bundle/src/Security/Voter/DataContainer/TableAccessVoter.php
+++ b/core-bundle/src/Security/Voter/DataContainer/TableAccessVoter.php
@@ -17,8 +17,8 @@ use Contao\CoreBundle\Security\DataContainer\CreateAction;
 use Contao\CoreBundle\Security\DataContainer\UpdateAction;
 use Contao\DataContainer;
 use Contao\DC_File;
-use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\CacheableVoterInterface;
 
 /**
@@ -26,7 +26,7 @@ use Symfony\Component\Security\Core\Authorization\Voter\CacheableVoterInterface;
  */
 class TableAccessVoter implements CacheableVoterInterface
 {
-    public function __construct(private readonly Security $security)
+    public function __construct(private readonly AccessDecisionManagerInterface $accessDecisionManager)
     {
     }
 
@@ -65,7 +65,7 @@ class TableAccessVoter implements CacheableVoterInterface
                 }
             }
 
-            if (!$hasNotExcluded && !$this->security->isGranted(ContaoCorePermissions::USER_CAN_EDIT_FIELDS_OF_TABLE, $subject->getDataSource())) {
+            if (!$hasNotExcluded && !$this->accessDecisionManager->decide($token, [ContaoCorePermissions::USER_CAN_EDIT_FIELDS_OF_TABLE], $subject->getDataSource())) {
                 return self::ACCESS_DENIED;
             }
         }

--- a/core-bundle/tests/Security/Voter/DataContainer/FormAccessVoterTest.php
+++ b/core-bundle/tests/Security/Voter/DataContainer/FormAccessVoterTest.php
@@ -19,29 +19,31 @@ use Contao\CoreBundle\Security\DataContainer\ReadAction;
 use Contao\CoreBundle\Security\DataContainer\UpdateAction;
 use Contao\CoreBundle\Security\Voter\DataContainer\FormAccessVoter;
 use PHPUnit\Framework\TestCase;
-use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
 class FormAccessVoterTest extends TestCase
 {
     public function testVoter(): void
     {
-        $security = $this->createMock(Security::class);
-        $security
+        $token = $this->createMock(TokenInterface::class);
+
+        $accessDecisionManager = $this->createMock(AccessDecisionManagerInterface::class);
+        $accessDecisionManager
             ->expects($this->exactly(5))
-            ->method('isGranted')
+            ->method('decide')
             ->withConsecutive(
-                [ContaoCorePermissions::USER_CAN_ACCESS_MODULE, 'form'],
-                [ContaoCorePermissions::USER_CAN_EDIT_FORM, 42],
-                [ContaoCorePermissions::USER_CAN_ACCESS_MODULE, 'form'],
-                [ContaoCorePermissions::USER_CAN_ACCESS_MODULE, 'form'],
-                [ContaoCorePermissions::USER_CAN_EDIT_FORM, 42],
+                [$token, [ContaoCorePermissions::USER_CAN_ACCESS_MODULE], 'form'],
+                [$token, [ContaoCorePermissions::USER_CAN_EDIT_FORM], 42],
+                [$token, [ContaoCorePermissions::USER_CAN_ACCESS_MODULE], 'form'],
+                [$token, [ContaoCorePermissions::USER_CAN_ACCESS_MODULE], 'form'],
+                [$token, [ContaoCorePermissions::USER_CAN_EDIT_FORM], 42],
             )
             ->willReturnOnConsecutiveCalls(true, true, false, true, false)
         ;
 
-        $voter = new FormAccessVoter($security);
+        $voter = new FormAccessVoter($accessDecisionManager);
 
         $this->assertTrue($voter->supportsAttribute(ContaoCorePermissions::DC_PREFIX.'tl_form'));
         $this->assertFalse($voter->supportsAttribute(ContaoCorePermissions::DC_PREFIX.'tl_form_fields'));
@@ -50,8 +52,6 @@ class FormAccessVoterTest extends TestCase
         $this->assertTrue($voter->supportsType(UpdateAction::class));
         $this->assertTrue($voter->supportsType(DeleteAction::class));
         $this->assertFalse($voter->supportsType(FormAccessVoter::class));
-
-        $token = $this->createMock(TokenInterface::class);
 
         // Unsupported attribute
         $this->assertSame(

--- a/core-bundle/tests/Security/Voter/DataContainer/FormFieldAccessVoterTest.php
+++ b/core-bundle/tests/Security/Voter/DataContainer/FormFieldAccessVoterTest.php
@@ -19,29 +19,31 @@ use Contao\CoreBundle\Security\DataContainer\ReadAction;
 use Contao\CoreBundle\Security\DataContainer\UpdateAction;
 use Contao\CoreBundle\Security\Voter\DataContainer\FormFieldAccessVoter;
 use PHPUnit\Framework\TestCase;
-use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
 class FormFieldAccessVoterTest extends TestCase
 {
     public function testVoter(): void
     {
-        $security = $this->createMock(Security::class);
-        $security
+        $token = $this->createMock(TokenInterface::class);
+
+        $accessDecisionManager = $this->createMock(AccessDecisionManagerInterface::class);
+        $accessDecisionManager
             ->expects($this->exactly(5))
-            ->method('isGranted')
+            ->method('decide')
             ->withConsecutive(
-                [ContaoCorePermissions::USER_CAN_ACCESS_MODULE, 'form'],
-                [ContaoCorePermissions::USER_CAN_EDIT_FORM, 42],
-                [ContaoCorePermissions::USER_CAN_ACCESS_MODULE, 'form'],
-                [ContaoCorePermissions::USER_CAN_ACCESS_MODULE, 'form'],
-                [ContaoCorePermissions::USER_CAN_EDIT_FORM, 42],
+                [$token, [ContaoCorePermissions::USER_CAN_ACCESS_MODULE], 'form'],
+                [$token, [ContaoCorePermissions::USER_CAN_EDIT_FORM], 42],
+                [$token, [ContaoCorePermissions::USER_CAN_ACCESS_MODULE], 'form'],
+                [$token, [ContaoCorePermissions::USER_CAN_ACCESS_MODULE], 'form'],
+                [$token, [ContaoCorePermissions::USER_CAN_EDIT_FORM], 42],
             )
             ->willReturnOnConsecutiveCalls(true, true, false, true, false)
         ;
 
-        $voter = new FormFieldAccessVoter($security);
+        $voter = new FormFieldAccessVoter($accessDecisionManager);
 
         $this->assertTrue($voter->supportsAttribute(ContaoCorePermissions::DC_PREFIX.'tl_form_field'));
         $this->assertFalse($voter->supportsAttribute(ContaoCorePermissions::DC_PREFIX.'tl_form'));
@@ -50,8 +52,6 @@ class FormFieldAccessVoterTest extends TestCase
         $this->assertTrue($voter->supportsType(UpdateAction::class));
         $this->assertTrue($voter->supportsType(DeleteAction::class));
         $this->assertFalse($voter->supportsType(FormFieldAccessVoter::class));
-
-        $token = $this->createMock(TokenInterface::class);
 
         // Unsupported attribute
         $this->assertSame(
@@ -97,20 +97,21 @@ class FormFieldAccessVoterTest extends TestCase
 
     public function testDeniesUpdateActionToNewParent(): void
     {
-        $security = $this->createMock(Security::class);
-        $security
+        $token = $this->createMock(TokenInterface::class);
+
+        $accessDecisionManager = $this->createMock(AccessDecisionManagerInterface::class);
+        $accessDecisionManager
             ->expects($this->exactly(3))
-            ->method('isGranted')
+            ->method('decide')
             ->withConsecutive(
-                [ContaoCorePermissions::USER_CAN_ACCESS_MODULE],
-                [ContaoCorePermissions::USER_CAN_EDIT_FORM, 42],
-                [ContaoCorePermissions::USER_CAN_EDIT_FORM, 43],
+                [$token, [ContaoCorePermissions::USER_CAN_ACCESS_MODULE]],
+                [$token, [ContaoCorePermissions::USER_CAN_EDIT_FORM], 42],
+                [$token, [ContaoCorePermissions::USER_CAN_EDIT_FORM], 43],
             )
             ->willReturnOnConsecutiveCalls(true, true, false)
         ;
 
-        $token = $this->createMock(TokenInterface::class);
-        $voter = new FormFieldAccessVoter($security);
+        $voter = new FormFieldAccessVoter($accessDecisionManager);
 
         $this->assertSame(
             VoterInterface::ACCESS_DENIED,

--- a/core-bundle/tests/Security/Voter/DataContainer/TableAccessVoterTest.php
+++ b/core-bundle/tests/Security/Voter/DataContainer/TableAccessVoterTest.php
@@ -20,15 +20,15 @@ use Contao\CoreBundle\Security\DataContainer\UpdateAction;
 use Contao\CoreBundle\Security\Voter\DataContainer\TableAccessVoter;
 use Contao\CoreBundle\Tests\TestCase;
 use PHPUnit\Framework\MockObject\MockObject;
-use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
 class TableAccessVoterTest extends TestCase
 {
     private TableAccessVoter $voter;
 
-    private Security&MockObject $security;
+    private AccessDecisionManagerInterface&MockObject $accessDecisionManager;
 
     private TokenInterface&MockObject $token;
 
@@ -36,8 +36,8 @@ class TableAccessVoterTest extends TestCase
     {
         parent::setUp();
 
-        $this->security = $this->createMock(Security::class);
-        $this->voter = new TableAccessVoter($this->security);
+        $this->accessDecisionManager = $this->createMock(AccessDecisionManagerInterface::class);
+        $this->voter = new TableAccessVoter($this->accessDecisionManager);
         $this->token = $this->createMock(TokenInterface::class);
 
         unset($GLOBALS['TL_DCA']);
@@ -87,10 +87,10 @@ class TableAccessVoterTest extends TestCase
             ],
         ];
 
-        $this->security
+        $this->accessDecisionManager
             ->expects($this->once())
-            ->method('isGranted')
-            ->with(ContaoCorePermissions::USER_CAN_EDIT_FIELDS_OF_TABLE, 'tl_foobar')
+            ->method('decide')
+            ->with($this->token, [ContaoCorePermissions::USER_CAN_EDIT_FIELDS_OF_TABLE], 'tl_foobar')
             ->willReturn(true)
         ;
 
@@ -108,10 +108,10 @@ class TableAccessVoterTest extends TestCase
             ],
         ];
 
-        $this->security
+        $this->accessDecisionManager
             ->expects($this->once())
-            ->method('isGranted')
-            ->with(ContaoCorePermissions::USER_CAN_EDIT_FIELDS_OF_TABLE, 'tl_foobar')
+            ->method('decide')
+            ->with($this->token, [ContaoCorePermissions::USER_CAN_EDIT_FIELDS_OF_TABLE], 'tl_foobar')
             ->willReturn(true)
         ;
 
@@ -134,9 +134,9 @@ class TableAccessVoterTest extends TestCase
             ],
         ];
 
-        $this->security
+        $this->accessDecisionManager
             ->expects($this->never())
-            ->method('isGranted')
+            ->method('decide')
         ;
 
         $this->assertSame(
@@ -158,10 +158,10 @@ class TableAccessVoterTest extends TestCase
             ],
         ];
 
-        $this->security
+        $this->accessDecisionManager
             ->expects($this->once())
-            ->method('isGranted')
-            ->with(ContaoCorePermissions::USER_CAN_EDIT_FIELDS_OF_TABLE, 'tl_foobar')
+            ->method('decide')
+            ->with($this->token, [ContaoCorePermissions::USER_CAN_EDIT_FIELDS_OF_TABLE], 'tl_foobar')
             ->willReturn(false)
         ;
 
@@ -183,10 +183,10 @@ class TableAccessVoterTest extends TestCase
             ],
         ];
 
-        $this->security
+        $this->accessDecisionManager
             ->expects($this->once())
-            ->method('isGranted')
-            ->with(ContaoCorePermissions::USER_CAN_EDIT_FIELDS_OF_TABLE, 'tl_foobar')
+            ->method('decide')
+            ->with($this->token, [ContaoCorePermissions::USER_CAN_EDIT_FIELDS_OF_TABLE], 'tl_foobar')
             ->willReturn(false)
         ;
 

--- a/faq-bundle/config/services.yaml
+++ b/faq-bundle/config/services.yaml
@@ -35,9 +35,9 @@ services:
     contao_faq.security.faq_access_voter:
         class: Contao\FaqBundle\Security\Voter\FaqAccessVoter
         arguments:
-            - '@security.helper'
+            - '@security.access.decision_manager'
 
     contao_faq.security.faq_category_access_voter:
         class: Contao\FaqBundle\Security\Voter\FaqCategoryAccessVoter
         arguments:
-            - '@security.helper'
+            - '@security.access.decision_manager'

--- a/faq-bundle/src/Security/Voter/FaqAccessVoter.php
+++ b/faq-bundle/src/Security/Voter/FaqAccessVoter.php
@@ -19,6 +19,7 @@ use Contao\CoreBundle\Security\DataContainer\UpdateAction;
 use Contao\CoreBundle\Security\Voter\DataContainer\AbstractDataContainerVoter;
 use Contao\CoreBundle\Security\Voter\DataContainer\ParentAccessTrait;
 use Contao\FaqBundle\Security\ContaoFaqPermissions;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
 /**
  * @internal
@@ -32,9 +33,9 @@ class FaqAccessVoter extends AbstractDataContainerVoter
         return 'tl_faq';
     }
 
-    protected function isGranted(CreateAction|DeleteAction|ReadAction|UpdateAction $action): bool
+    protected function hasAccess(TokenInterface $token, CreateAction|DeleteAction|ReadAction|UpdateAction $action): bool
     {
-        return $this->security->isGranted(ContaoFaqPermissions::USER_CAN_ACCESS_MODULE)
-            && $this->canAccessParent(ContaoFaqPermissions::USER_CAN_EDIT_CATEGORY, $action);
+        return $this->accessDecisionManager->decide($token, [ContaoFaqPermissions::USER_CAN_ACCESS_MODULE])
+            && $this->hasAccessToParent($token, ContaoFaqPermissions::USER_CAN_EDIT_CATEGORY, $action);
     }
 }

--- a/faq-bundle/src/Security/Voter/FaqCategoryAccessVoter.php
+++ b/faq-bundle/src/Security/Voter/FaqCategoryAccessVoter.php
@@ -18,14 +18,15 @@ use Contao\CoreBundle\Security\DataContainer\ReadAction;
 use Contao\CoreBundle\Security\DataContainer\UpdateAction;
 use Contao\CoreBundle\Security\Voter\DataContainer\AbstractDataContainerVoter;
 use Contao\FaqBundle\Security\ContaoFaqPermissions;
-use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
 
 /**
  * @internal
  */
 class FaqCategoryAccessVoter extends AbstractDataContainerVoter
 {
-    public function __construct(private readonly Security $security)
+    public function __construct(private readonly AccessDecisionManagerInterface $accessDecisionManager)
     {
     }
 
@@ -34,18 +35,18 @@ class FaqCategoryAccessVoter extends AbstractDataContainerVoter
         return 'tl_faq_category';
     }
 
-    protected function isGranted(CreateAction|DeleteAction|ReadAction|UpdateAction $action): bool
+    protected function hasAccess(TokenInterface $token, CreateAction|DeleteAction|ReadAction|UpdateAction $action): bool
     {
-        if (!$this->security->isGranted(ContaoFaqPermissions::USER_CAN_ACCESS_MODULE)) {
+        if (!$this->accessDecisionManager->decide($token, [ContaoFaqPermissions::USER_CAN_ACCESS_MODULE])) {
             return false;
         }
 
         return match (true) {
-            $action instanceof CreateAction => $this->security->isGranted(ContaoFaqPermissions::USER_CAN_CREATE_CATEGORIES),
+            $action instanceof CreateAction => $this->accessDecisionManager->decide($token, [ContaoFaqPermissions::USER_CAN_CREATE_CATEGORIES]),
             $action instanceof ReadAction,
-            $action instanceof UpdateAction => $this->security->isGranted(ContaoFaqPermissions::USER_CAN_EDIT_CATEGORY, $action->getCurrentId()),
-            $action instanceof DeleteAction => $this->security->isGranted(ContaoFaqPermissions::USER_CAN_EDIT_CATEGORY, $action->getCurrentId())
-                && $this->security->isGranted(ContaoFaqPermissions::USER_CAN_DELETE_CATEGORIES),
+            $action instanceof UpdateAction => $this->accessDecisionManager->decide($token, [ContaoFaqPermissions::USER_CAN_EDIT_CATEGORY], $action->getCurrentId()),
+            $action instanceof DeleteAction => $this->accessDecisionManager->decide($token, [ContaoFaqPermissions::USER_CAN_EDIT_CATEGORY], $action->getCurrentId())
+                && $this->accessDecisionManager->decide($token, [ContaoFaqPermissions::USER_CAN_DELETE_CATEGORIES]),
         };
     }
 }

--- a/faq-bundle/tests/Security/Voter/FaqAccessVoterTest.php
+++ b/faq-bundle/tests/Security/Voter/FaqAccessVoterTest.php
@@ -20,29 +20,31 @@ use Contao\CoreBundle\Security\DataContainer\UpdateAction;
 use Contao\FaqBundle\Security\ContaoFaqPermissions;
 use Contao\FaqBundle\Security\Voter\FaqAccessVoter;
 use PHPUnit\Framework\TestCase;
-use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
 class FaqAccessVoterTest extends TestCase
 {
     public function testVoter(): void
     {
-        $security = $this->createMock(Security::class);
-        $security
+        $token = $this->createMock(TokenInterface::class);
+
+        $accessDecisionManager = $this->createMock(AccessDecisionManagerInterface::class);
+        $accessDecisionManager
             ->expects($this->exactly(5))
-            ->method('isGranted')
+            ->method('decide')
             ->withConsecutive(
-                [ContaoFaqPermissions::USER_CAN_ACCESS_MODULE],
-                [ContaoFaqPermissions::USER_CAN_EDIT_CATEGORY, 42],
-                [ContaoFaqPermissions::USER_CAN_ACCESS_MODULE],
-                [ContaoFaqPermissions::USER_CAN_ACCESS_MODULE],
-                [ContaoFaqPermissions::USER_CAN_EDIT_CATEGORY, 42],
+                [$token, [ContaoFaqPermissions::USER_CAN_ACCESS_MODULE]],
+                [$token, [ContaoFaqPermissions::USER_CAN_EDIT_CATEGORY], 42],
+                [$token, [ContaoFaqPermissions::USER_CAN_ACCESS_MODULE]],
+                [$token, [ContaoFaqPermissions::USER_CAN_ACCESS_MODULE]],
+                [$token, [ContaoFaqPermissions::USER_CAN_EDIT_CATEGORY], 42],
             )
             ->willReturnOnConsecutiveCalls(true, true, false, true, false)
         ;
 
-        $voter = new FaqAccessVoter($security);
+        $voter = new FaqAccessVoter($accessDecisionManager);
 
         $this->assertTrue($voter->supportsAttribute(ContaoCorePermissions::DC_PREFIX.'tl_faq'));
         $this->assertFalse($voter->supportsAttribute(ContaoCorePermissions::DC_PREFIX.'tl_faq_category'));
@@ -51,8 +53,6 @@ class FaqAccessVoterTest extends TestCase
         $this->assertTrue($voter->supportsType(UpdateAction::class));
         $this->assertTrue($voter->supportsType(DeleteAction::class));
         $this->assertFalse($voter->supportsType(FaqAccessVoter::class));
-
-        $token = $this->createMock(TokenInterface::class);
 
         // Unsupported attribute
         $this->assertSame(
@@ -98,20 +98,21 @@ class FaqAccessVoterTest extends TestCase
 
     public function testDeniesUpdateActionToNewParent(): void
     {
-        $security = $this->createMock(Security::class);
-        $security
+        $token = $this->createMock(TokenInterface::class);
+
+        $accessDecisionManager = $this->createMock(AccessDecisionManagerInterface::class);
+        $accessDecisionManager
             ->expects($this->exactly(3))
-            ->method('isGranted')
+            ->method('decide')
             ->withConsecutive(
-                [ContaoFaqPermissions::USER_CAN_ACCESS_MODULE],
-                [ContaoFaqPermissions::USER_CAN_EDIT_CATEGORY, 42],
-                [ContaoFaqPermissions::USER_CAN_EDIT_CATEGORY, 43],
+                [$token, [ContaoFaqPermissions::USER_CAN_ACCESS_MODULE]],
+                [$token, [ContaoFaqPermissions::USER_CAN_EDIT_CATEGORY], 42],
+                [$token, [ContaoFaqPermissions::USER_CAN_EDIT_CATEGORY], 43],
             )
             ->willReturnOnConsecutiveCalls(true, true, false)
         ;
 
-        $token = $this->createMock(TokenInterface::class);
-        $voter = new FaqAccessVoter($security);
+        $voter = new FaqAccessVoter($accessDecisionManager);
 
         $this->assertSame(
             VoterInterface::ACCESS_DENIED,

--- a/news-bundle/config/services.yaml
+++ b/news-bundle/config/services.yaml
@@ -107,9 +107,9 @@ services:
     contao_news.security.news_access_voter:
         class: Contao\NewsBundle\Security\Voter\NewsAccessVoter
         arguments:
-            - '@security.helper'
+            - '@security.access.decision_manager'
 
     contao_news.security.news_archive_access_voter:
         class: Contao\NewsBundle\Security\Voter\NewsArchiveAccessVoter
         arguments:
-            - '@security.helper'
+            - '@security.access.decision_manager'

--- a/news-bundle/src/Security/Voter/NewsAccessVoter.php
+++ b/news-bundle/src/Security/Voter/NewsAccessVoter.php
@@ -19,6 +19,7 @@ use Contao\CoreBundle\Security\DataContainer\UpdateAction;
 use Contao\CoreBundle\Security\Voter\DataContainer\AbstractDataContainerVoter;
 use Contao\CoreBundle\Security\Voter\DataContainer\ParentAccessTrait;
 use Contao\NewsBundle\Security\ContaoNewsPermissions;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
 /**
  * @internal
@@ -32,9 +33,9 @@ class NewsAccessVoter extends AbstractDataContainerVoter
         return 'tl_news';
     }
 
-    protected function isGranted(CreateAction|DeleteAction|ReadAction|UpdateAction $action): bool
+    protected function hasAccess(TokenInterface $token, CreateAction|DeleteAction|ReadAction|UpdateAction $action): bool
     {
-        return $this->security->isGranted(ContaoNewsPermissions::USER_CAN_ACCESS_MODULE)
-            && $this->canAccessParent(ContaoNewsPermissions::USER_CAN_EDIT_ARCHIVE, $action);
+        return $this->accessDecisionManager->decide($token, [ContaoNewsPermissions::USER_CAN_ACCESS_MODULE])
+            && $this->hasAccessToParent($token, ContaoNewsPermissions::USER_CAN_EDIT_ARCHIVE, $action);
     }
 }

--- a/news-bundle/src/Security/Voter/NewsArchiveAccessVoter.php
+++ b/news-bundle/src/Security/Voter/NewsArchiveAccessVoter.php
@@ -18,14 +18,15 @@ use Contao\CoreBundle\Security\DataContainer\ReadAction;
 use Contao\CoreBundle\Security\DataContainer\UpdateAction;
 use Contao\CoreBundle\Security\Voter\DataContainer\AbstractDataContainerVoter;
 use Contao\NewsBundle\Security\ContaoNewsPermissions;
-use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
 
 /**
  * @internal
  */
 class NewsArchiveAccessVoter extends AbstractDataContainerVoter
 {
-    public function __construct(private readonly Security $security)
+    public function __construct(private readonly AccessDecisionManagerInterface $accessDecisionManager)
     {
     }
 
@@ -34,18 +35,18 @@ class NewsArchiveAccessVoter extends AbstractDataContainerVoter
         return 'tl_news_archive';
     }
 
-    protected function isGranted(CreateAction|DeleteAction|ReadAction|UpdateAction $action): bool
+    protected function hasAccess(TokenInterface $token, CreateAction|DeleteAction|ReadAction|UpdateAction $action): bool
     {
-        if (!$this->security->isGranted(ContaoNewsPermissions::USER_CAN_ACCESS_MODULE)) {
+        if (!$this->accessDecisionManager->decide($token, [ContaoNewsPermissions::USER_CAN_ACCESS_MODULE])) {
             return false;
         }
 
         return match (true) {
-            $action instanceof CreateAction => $this->security->isGranted(ContaoNewsPermissions::USER_CAN_CREATE_ARCHIVES),
+            $action instanceof CreateAction => $this->accessDecisionManager->decide($token, [ContaoNewsPermissions::USER_CAN_CREATE_ARCHIVES]),
             $action instanceof ReadAction,
-            $action instanceof UpdateAction => $this->security->isGranted(ContaoNewsPermissions::USER_CAN_EDIT_ARCHIVE, $action->getCurrentId()),
-            $action instanceof DeleteAction => $this->security->isGranted(ContaoNewsPermissions::USER_CAN_EDIT_ARCHIVE, $action->getCurrentId())
-                && $this->security->isGranted(ContaoNewsPermissions::USER_CAN_DELETE_ARCHIVES),
+            $action instanceof UpdateAction => $this->accessDecisionManager->decide($token, [ContaoNewsPermissions::USER_CAN_EDIT_ARCHIVE], $action->getCurrentId()),
+            $action instanceof DeleteAction => $this->accessDecisionManager->decide($token, [ContaoNewsPermissions::USER_CAN_EDIT_ARCHIVE], $action->getCurrentId())
+                && $this->accessDecisionManager->decide($token, [ContaoNewsPermissions::USER_CAN_DELETE_ARCHIVES]),
         };
     }
 }

--- a/news-bundle/tests/Security/Voter/NewsArchiveAccessVoterTest.php
+++ b/news-bundle/tests/Security/Voter/NewsArchiveAccessVoterTest.php
@@ -20,29 +20,31 @@ use Contao\CoreBundle\Security\DataContainer\UpdateAction;
 use Contao\NewsBundle\Security\ContaoNewsPermissions;
 use Contao\NewsBundle\Security\Voter\NewsArchiveAccessVoter;
 use PHPUnit\Framework\TestCase;
-use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
 class NewsArchiveAccessVoterTest extends TestCase
 {
     public function testVoter(): void
     {
-        $security = $this->createMock(Security::class);
-        $security
+        $token = $this->createMock(TokenInterface::class);
+
+        $accessDecisionManager = $this->createMock(AccessDecisionManagerInterface::class);
+        $accessDecisionManager
             ->expects($this->exactly(5))
-            ->method('isGranted')
+            ->method('decide')
             ->withConsecutive(
-                [ContaoNewsPermissions::USER_CAN_ACCESS_MODULE],
-                [ContaoNewsPermissions::USER_CAN_EDIT_ARCHIVE, 42],
-                [ContaoNewsPermissions::USER_CAN_ACCESS_MODULE],
-                [ContaoNewsPermissions::USER_CAN_ACCESS_MODULE],
-                [ContaoNewsPermissions::USER_CAN_EDIT_ARCHIVE, 42],
+                [$token, [ContaoNewsPermissions::USER_CAN_ACCESS_MODULE]],
+                [$token, [ContaoNewsPermissions::USER_CAN_EDIT_ARCHIVE], 42],
+                [$token, [ContaoNewsPermissions::USER_CAN_ACCESS_MODULE]],
+                [$token, [ContaoNewsPermissions::USER_CAN_ACCESS_MODULE]],
+                [$token, [ContaoNewsPermissions::USER_CAN_EDIT_ARCHIVE], 42],
             )
             ->willReturnOnConsecutiveCalls(true, true, false, true, false)
         ;
 
-        $voter = new NewsArchiveAccessVoter($security);
+        $voter = new NewsArchiveAccessVoter($accessDecisionManager);
 
         $this->assertTrue($voter->supportsAttribute(ContaoCorePermissions::DC_PREFIX.'tl_news_archive'));
         $this->assertFalse($voter->supportsAttribute(ContaoCorePermissions::DC_PREFIX.'tl_news'));
@@ -51,8 +53,6 @@ class NewsArchiveAccessVoterTest extends TestCase
         $this->assertTrue($voter->supportsType(UpdateAction::class));
         $this->assertTrue($voter->supportsType(DeleteAction::class));
         $this->assertFalse($voter->supportsType(NewsArchiveAccessVoter::class));
-
-        $token = $this->createMock(TokenInterface::class);
 
         // Unsupported attribute
         $this->assertSame(

--- a/newsletter-bundle/config/services.yaml
+++ b/newsletter-bundle/config/services.yaml
@@ -23,9 +23,9 @@ services:
     contao_newsletter.security.newsletter_access_voter:
         class: Contao\NewsletterBundle\Security\Voter\NewsletterAccessVoter
         arguments:
-            - '@security.helper'
+            - '@security.access.decision_manager'
 
     contao_newsletter.security.newsletter_channel_access_voter:
         class: Contao\NewsletterBundle\Security\Voter\NewsletterChannelAccessVoter
         arguments:
-            - '@security.helper'
+            - '@security.access.decision_manager'

--- a/newsletter-bundle/src/Security/Voter/NewsletterAccessVoter.php
+++ b/newsletter-bundle/src/Security/Voter/NewsletterAccessVoter.php
@@ -19,6 +19,7 @@ use Contao\CoreBundle\Security\DataContainer\UpdateAction;
 use Contao\CoreBundle\Security\Voter\DataContainer\AbstractDataContainerVoter;
 use Contao\CoreBundle\Security\Voter\DataContainer\ParentAccessTrait;
 use Contao\NewsletterBundle\Security\ContaoNewsletterPermissions;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
 /**
  * @internal
@@ -32,9 +33,9 @@ class NewsletterAccessVoter extends AbstractDataContainerVoter
         return 'tl_newsletter';
     }
 
-    protected function isGranted(CreateAction|DeleteAction|ReadAction|UpdateAction $action): bool
+    protected function hasAccess(TokenInterface $token, CreateAction|DeleteAction|ReadAction|UpdateAction $action): bool
     {
-        return $this->security->isGranted(ContaoNewsletterPermissions::USER_CAN_ACCESS_MODULE)
-            && $this->canAccessParent(ContaoNewsletterPermissions::USER_CAN_EDIT_CHANNEL, $action);
+        return $this->accessDecisionManager->decide($token, [ContaoNewsletterPermissions::USER_CAN_ACCESS_MODULE])
+            && $this->hasAccessToParent($token, ContaoNewsletterPermissions::USER_CAN_EDIT_CHANNEL, $action);
     }
 }

--- a/newsletter-bundle/tests/Security/Voter/NewsletterAccessVoterTest.php
+++ b/newsletter-bundle/tests/Security/Voter/NewsletterAccessVoterTest.php
@@ -20,29 +20,31 @@ use Contao\CoreBundle\Security\DataContainer\UpdateAction;
 use Contao\NewsletterBundle\Security\ContaoNewsletterPermissions;
 use Contao\NewsletterBundle\Security\Voter\NewsletterAccessVoter;
 use PHPUnit\Framework\TestCase;
-use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
 class NewsletterAccessVoterTest extends TestCase
 {
     public function testVoter(): void
     {
-        $security = $this->createMock(Security::class);
-        $security
+        $token = $this->createMock(TokenInterface::class);
+
+        $accessDecisionManager = $this->createMock(AccessDecisionManagerInterface::class);
+        $accessDecisionManager
             ->expects($this->exactly(5))
-            ->method('isGranted')
+            ->method('decide')
             ->withConsecutive(
-                [ContaoNewsletterPermissions::USER_CAN_ACCESS_MODULE],
-                [ContaoNewsletterPermissions::USER_CAN_EDIT_CHANNEL, 42],
-                [ContaoNewsletterPermissions::USER_CAN_ACCESS_MODULE],
-                [ContaoNewsletterPermissions::USER_CAN_ACCESS_MODULE],
-                [ContaoNewsletterPermissions::USER_CAN_EDIT_CHANNEL, 42],
+                [$token, [ContaoNewsletterPermissions::USER_CAN_ACCESS_MODULE]],
+                [$token, [ContaoNewsletterPermissions::USER_CAN_EDIT_CHANNEL], 42],
+                [$token, [ContaoNewsletterPermissions::USER_CAN_ACCESS_MODULE]],
+                [$token, [ContaoNewsletterPermissions::USER_CAN_ACCESS_MODULE]],
+                [$token, [ContaoNewsletterPermissions::USER_CAN_EDIT_CHANNEL], 42],
             )
             ->willReturnOnConsecutiveCalls(true, true, false, true, false)
         ;
 
-        $voter = new NewsletterAccessVoter($security);
+        $voter = new NewsletterAccessVoter($accessDecisionManager);
 
         $this->assertTrue($voter->supportsAttribute(ContaoCorePermissions::DC_PREFIX.'tl_newsletter'));
         $this->assertFalse($voter->supportsAttribute(ContaoCorePermissions::DC_PREFIX.'tl_newsletter_channel'));
@@ -51,8 +53,6 @@ class NewsletterAccessVoterTest extends TestCase
         $this->assertTrue($voter->supportsType(UpdateAction::class));
         $this->assertTrue($voter->supportsType(DeleteAction::class));
         $this->assertFalse($voter->supportsType(NewsletterAccessVoter::class));
-
-        $token = $this->createMock(TokenInterface::class);
 
         // Unsupported attribute
         $this->assertSame(
@@ -98,20 +98,21 @@ class NewsletterAccessVoterTest extends TestCase
 
     public function testDeniesUpdateActionToNewParent(): void
     {
-        $security = $this->createMock(Security::class);
-        $security
+        $token = $this->createMock(TokenInterface::class);
+
+        $accessDecisionManager = $this->createMock(AccessDecisionManagerInterface::class);
+        $accessDecisionManager
             ->expects($this->exactly(3))
-            ->method('isGranted')
+            ->method('decide')
             ->withConsecutive(
-                [ContaoNewsletterPermissions::USER_CAN_ACCESS_MODULE],
-                [ContaoNewsletterPermissions::USER_CAN_EDIT_CHANNEL, 42],
-                [ContaoNewsletterPermissions::USER_CAN_EDIT_CHANNEL, 43],
+                [$token, [ContaoNewsletterPermissions::USER_CAN_ACCESS_MODULE]],
+                [$token, [ContaoNewsletterPermissions::USER_CAN_EDIT_CHANNEL], 42],
+                [$token, [ContaoNewsletterPermissions::USER_CAN_EDIT_CHANNEL], 43],
             )
             ->willReturnOnConsecutiveCalls(true, true, false)
         ;
 
-        $token = $this->createMock(TokenInterface::class);
-        $voter = new NewsletterAccessVoter($security);
+        $voter = new NewsletterAccessVoter($accessDecisionManager);
 
         $this->assertSame(
             VoterInterface::ACCESS_DENIED,

--- a/newsletter-bundle/tests/Security/Voter/NewsletterChannelAccessVoterTest.php
+++ b/newsletter-bundle/tests/Security/Voter/NewsletterChannelAccessVoterTest.php
@@ -20,29 +20,31 @@ use Contao\CoreBundle\Security\DataContainer\UpdateAction;
 use Contao\NewsletterBundle\Security\ContaoNewsletterPermissions;
 use Contao\NewsletterBundle\Security\Voter\NewsletterChannelAccessVoter;
 use PHPUnit\Framework\TestCase;
-use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
 class NewsletterChannelAccessVoterTest extends TestCase
 {
     public function testVoter(): void
     {
-        $security = $this->createMock(Security::class);
-        $security
+        $token = $this->createMock(TokenInterface::class);
+
+        $accessDecisionManager = $this->createMock(AccessDecisionManagerInterface::class);
+        $accessDecisionManager
             ->expects($this->exactly(5))
-            ->method('isGranted')
+            ->method('decide')
             ->withConsecutive(
-                [ContaoNewsletterPermissions::USER_CAN_ACCESS_MODULE],
-                [ContaoNewsletterPermissions::USER_CAN_EDIT_CHANNEL, 42],
-                [ContaoNewsletterPermissions::USER_CAN_ACCESS_MODULE],
-                [ContaoNewsletterPermissions::USER_CAN_ACCESS_MODULE],
-                [ContaoNewsletterPermissions::USER_CAN_EDIT_CHANNEL, 42],
+                [$token, [ContaoNewsletterPermissions::USER_CAN_ACCESS_MODULE]],
+                [$token, [ContaoNewsletterPermissions::USER_CAN_EDIT_CHANNEL], 42],
+                [$token, [ContaoNewsletterPermissions::USER_CAN_ACCESS_MODULE]],
+                [$token, [ContaoNewsletterPermissions::USER_CAN_ACCESS_MODULE]],
+                [$token, [ContaoNewsletterPermissions::USER_CAN_EDIT_CHANNEL], 42],
             )
             ->willReturnOnConsecutiveCalls(true, true, false, true, false)
         ;
 
-        $voter = new NewsletterChannelAccessVoter($security);
+        $voter = new NewsletterChannelAccessVoter($accessDecisionManager);
 
         $this->assertTrue($voter->supportsAttribute(ContaoCorePermissions::DC_PREFIX.'tl_newsletter_channel'));
         $this->assertFalse($voter->supportsAttribute(ContaoCorePermissions::DC_PREFIX.'tl_newsletter'));
@@ -51,8 +53,6 @@ class NewsletterChannelAccessVoterTest extends TestCase
         $this->assertTrue($voter->supportsType(UpdateAction::class));
         $this->assertTrue($voter->supportsType(DeleteAction::class));
         $this->assertFalse($voter->supportsType(NewsletterChannelAccessVoter::class));
-
-        $token = $this->createMock(TokenInterface::class);
 
         // Unsupported attribute
         $this->assertSame(


### PR DESCRIPTION
While implementing https://github.com/contao/contao/pull/6628 and https://github.com/contao/contao/pull/6627 I noticed our voters are incorrectly forwarding the access decision checks. Since the voters do receive the token to vote on, they must also make sure this token is used to decide on by the follow-up checks.

If you call `Security::isGranted()`, the current token is fetched from the token storage and sent to all voters. However, one could in theory fetch the back end user token from the session and ask voters about permissions for that - even if the front end firewall is active!