### PR TITLE
Correctly check the theme export permissions

### DIFF
--- a/core-bundle/src/Resources/contao/classes/Theme.php
+++ b/core-bundle/src/Resources/contao/classes/Theme.php
@@ -10,6 +10,8 @@
 
 namespace Contao;
 
+use Contao\CoreBundle\Exception\AccessDeniedException;
+use Contao\CoreBundle\Security\ContaoCorePermissions;
 use Contao\Database\Result;
 use Symfony\Component\String\UnicodeString;
 
@@ -39,6 +41,11 @@ class Theme extends Backend
 	 */
 	public function importTheme()
 	{
+		if (!System::getContainer()->get('security.helper')->isGranted(ContaoCorePermissions::USER_CAN_IMPORT_THEMES))
+		{
+			throw new AccessDeniedException('Not enough permissions to import themes.');
+		}
+
 		$objUploader = new FileUpload();
 
 		if (Input::post('FORM_SUBMIT') == 'tl_theme_import')
@@ -700,6 +707,11 @@ class Theme extends Backend
 	 */
 	public function exportTheme(DataContainer $dc)
 	{
+		if (!System::getContainer()->get('security.helper')->isGranted(ContaoCorePermissions::USER_CAN_EXPORT_THEMES))
+		{
+			throw new AccessDeniedException('Not enough permissions to export themes.');
+		}
+
 		// Get the theme metadata
 		$objTheme = $this->Database->prepare("SELECT * FROM tl_theme WHERE id=?")
 								   ->limit(1)

--- a/core-bundle/src/Resources/contao/dca/tl_theme.php
+++ b/core-bundle/src/Resources/contao/dca/tl_theme.php
@@ -10,14 +10,12 @@
 
 use Contao\Backend;
 use Contao\BackendUser;
-use Contao\CoreBundle\Exception\AccessDeniedException;
 use Contao\CoreBundle\Security\ContaoCorePermissions;
 use Contao\DataContainer;
 use Contao\DC_Table;
 use Contao\FilesModel;
 use Contao\Folder;
 use Contao\Image;
-use Contao\Input;
 use Contao\StringUtil;
 use Contao\StyleSheets;
 use Contao\System;

--- a/core-bundle/src/Resources/contao/dca/tl_theme.php
+++ b/core-bundle/src/Resources/contao/dca/tl_theme.php
@@ -40,7 +40,6 @@ $GLOBALS['TL_DCA']['tl_theme'] = array
 		),
 		'onload_callback' => array
 		(
-			array('tl_theme', 'checkPermission'),
 			array('tl_theme', 'updateStyleSheet')
 		),
 		'oncopy_callback' => array
@@ -222,37 +221,6 @@ class tl_theme extends Backend
 	{
 		parent::__construct();
 		$this->import(BackendUser::class, 'User');
-	}
-
-	/**
-	 * Check permissions to edit the table
-	 *
-	 * @throws AccessDeniedException
-	 */
-	public function checkPermission()
-	{
-		if ($this->User->isAdmin)
-		{
-			return;
-		}
-
-		// Check the theme import and export permissions (see #5835)
-		switch (Input::get('key'))
-		{
-			case 'importTheme':
-				if (!System::getContainer()->get('security.helper')->isGranted(ContaoCorePermissions::USER_CAN_IMPORT_THEMES))
-				{
-					throw new AccessDeniedException('Not enough permissions to import themes.');
-				}
-				break;
-
-			case 'exportTheme':
-				if (!System::getContainer()->get('security.helper')->isGranted(ContaoCorePermissions::USER_CAN_IMPORT_THEMES))
-				{
-					throw new AccessDeniedException('Not enough permissions to export themes.');
-				}
-				break;
-		}
 	}
 
 	/**


### PR DESCRIPTION
Yet another find while working on voters.

1. The `checkPermission` incorrectly voted on the import permission instead of export permission. The row button applied the correct permission, but if a user would have export but not import permissions, it would currently fail.
2. Checking permissions should be a responsibility of the controller, not the DCA that renders the buttons. So I moved the permission checks to the correct place.