### PR TITLE
Do not load style sheets lazily by default

### DIFF
--- a/core-bundle/contao/templates/twig/component/_stylesheet.html.twig
+++ b/core-bundle/contao/templates/twig/component/_stylesheet.html.twig
@@ -21,7 +21,7 @@
 
     {% if stylesheet.lazy is defined ? stylesheet.lazy : false %}
         {# Lazy load, see https://web.dev/defer-non-critical-css/ #}
-        <link rel="preload" href="{{ stylesheet.file }}" as="style" onload="this.onload=null;this.rel='stylesheet'">
+        <link rel="preload" as="style" href="{{ stylesheet.file }}" onload="this.onload=null;this.rel='stylesheet'">
         <noscript><link rel="stylesheet" href="{{ stylesheet.file }}"></noscript>
     {% else %}
         <link rel="stylesheet" href="{{ stylesheet.file }}">

--- a/core-bundle/contao/templates/twig/component/_stylesheet.html.twig
+++ b/core-bundle/contao/templates/twig/component/_stylesheet.html.twig
@@ -19,12 +19,10 @@
 {% block stylesheet_component %}
     {% set stylesheet = stylesheet|default(_context) %}
 
-    {% if stylesheet.lazy is defined ? stylesheet.lazy : true %}
+    {% if stylesheet.lazy is defined ? stylesheet.lazy : false %}
         {# Lazy load, see https://web.dev/defer-non-critical-css/ #}
         <link rel="preload" href="{{ stylesheet.file }}" as="style" onload="this.onload=null;this.rel='stylesheet'">
-        <noscript>
-            <link rel="stylesheet" href="{{ stylesheet.file }}">
-        </noscript>
+        <noscript><link rel="stylesheet" href="{{ stylesheet.file }}"></noscript>
     {% else %}
         <link rel="stylesheet" href="{{ stylesheet.file }}">
     {% endif %}

--- a/core-bundle/contao/templates/twig/component/_stylesheet.html.twig
+++ b/core-bundle/contao/templates/twig/component/_stylesheet.html.twig
@@ -19,7 +19,7 @@
 {% block stylesheet_component %}
     {% set stylesheet = stylesheet|default(_context) %}
 
-    {% if stylesheet.lazy is defined ? stylesheet.lazy : false %}
+    {% if stylesheet.lazy|default %}
         {# Lazy load, see https://web.dev/defer-non-critical-css/ #}
         <link rel="preload" as="style" href="{{ stylesheet.file }}" onload="this.onload=null;this.rel='stylesheet'">
         <noscript><link rel="stylesheet" href="{{ stylesheet.file }}"></noscript>

--- a/core-bundle/tests/Controller/ContentElement/CodeControllerTest.php
+++ b/core-bundle/tests/Controller/ContentElement/CodeControllerTest.php
@@ -43,10 +43,7 @@ class CodeControllerTest extends ContentElementTestCase
         $this->assertSameHtml($expectedOutput, $response->getContent());
 
         $expectedHeadCode = <<<'HTML'
-            <link rel="preload" href="/foundation.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
-            <noscript>
-                <link rel="stylesheet" href="/foundation.css">
-            </noscript>
+            <link rel="stylesheet" href="/foundation.css">
             HTML;
 
         $additionalHeadCode = $responseContextData[DocumentLocation::head->value];


### PR DESCRIPTION
This PR changes the default in the `_stylesheet.html.twig` component to `false`, so the style sheets are loaded synchronously by default. There are a few cases such as the image gallery where loading styles asynchronously makes sense, but most elements like accordions, sliders, highlighted code etc. require the styles to be loaded initially.

In these specific cases, we should opt-in instead of having to opt-out in all other cases, don‘t you think?
