### PR TITLE
Fix clipboard permission checks

### DIFF
--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -177,7 +177,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 			{
 				$arrClipboard = $objSession->get('CLIPBOARD');
 
-				$mode = (Input::post('cut') !== null ? 'cutAll' : 'copyAll');
+				$mode = Input::post('cut') !== null ? 'cutAll' : 'copyAll';
 				$ids = array_filter($ids, fn ($id) => $this->isGrantedClipboardMode($mode, (int) $id));
 
 				$arrClipboard[$strTable] = array

--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -336,7 +336,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 		// Add to clipboard
 		if (Input::get('act') == 'paste')
 		{
-			if (!$this->isGrantedClipboardMode(Input::get('mode'), (int) Input::get('id'), ['sorting' => null]))
+			if (!$this->isGrantedClipboardMode(Input::get('mode'), (int) Input::get('id'), array('sorting' => null)))
 			{
 				throw new AccessDeniedException();
 			}

--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -336,7 +336,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 		// Add to clipboard
 		if (Input::get('act') == 'paste')
 		{
-			if (!$this->isGrantedClipboardMode(Input::get('mode'), (int) Input::get('id'), array('sorting' => null)))
+			if (!$this->isGrantedClipboardMode(Input::get('mode'), (int) Input::get('id')))
 			{
 				throw new AccessDeniedException();
 			}
@@ -6650,7 +6650,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 		return $data;
 	}
 
-	private function canPasteClipboard(array $arrClipboard, array $new): bool
+	protected function canPasteClipboard(array $arrClipboard, array $new): bool
 	{
 		if ($arrClipboard['mode'] === 'create')
 		{
@@ -6668,15 +6668,15 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 		return true;
 	}
 
-	private function isGrantedClipboardMode(string $mode, int $id, array|null $new = null): bool
+	protected function isGrantedClipboardMode(string $mode, int $id): bool
 	{
 		$action = match ($mode)
 		{
-			'create' => new CreateAction($this->strTable, $new),
+			'create' => new CreateAction($this->strTable),
 			'cut',
-			'cutAll' => new UpdateAction($this->strTable, $this->getCurrentRecord($id, $this->strTable), $new),
+			'cutAll' => new UpdateAction($this->strTable, $this->getCurrentRecord($id, $this->strTable), array('sorting' => null)),
 			'copy',
-			'copyAll' => new CreateAction($this->strTable, array_merge($this->getCurrentRecord($id, $this->strTable), $new))
+			'copyAll' => new CreateAction($this->strTable, array_merge($this->getCurrentRecord($id, $this->strTable), array('tstamp' => null, 'sorting' => null)))
 		};
 
 		return System::getContainer()->get('security.helper')->isGranted(ContaoCorePermissions::DC_PREFIX . $this->strTable, $action);

--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -6644,9 +6644,9 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 
 	private function isGrantedToClipboard(array $arrClipboard, array $data): bool
 	{
-		$actions = match($arrClipboard['mod'])
+		$actions = match ($arrClipboard['mod'])
 		{
-			'create' => [new CreateAction($this->strTable, $data)],
+			'create' => array(new CreateAction($this->strTable, $data)),
 			'cut',
 			'cutAll' => array_map(fn ($clipboardId) => new UpdateAction($this->strTable, $this->getCurrentRecord($clipboardId, $this->strTable), $data), (array) $arrClipboard['id']),
 			'copy',

--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -3956,7 +3956,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 			{
 				$_buttons = $GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['paste_button_callback']($this, array('id'=>0), $table, false, $arrClipboard);
 			}
-			elseif (!System::getContainer()->get('security.helper')->isGranted(ContaoCorePermissions::DC_PREFIX . $this->strTable, new CreateAction($this->strTable, array('pid'=>0))))
+			elseif (!$this->isGrantedToClipboard($arrClipboard, array('pid'=>0)))
 			{
 				$_buttons = Image::getHtml('pasteinto--disabled.svg') . ' ';
 			}
@@ -4347,9 +4347,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 					}
 					else
 					{
-						$security = System::getContainer()->get('security.helper');
-
-						if ((!$this->rootPaste && \in_array($id, $this->root)) || !$security->isGranted(ContaoCorePermissions::DC_PREFIX . $this->strTable, new CreateAction($this->strTable, array('pid' => $currentRecord['pid'], 'sorting' => $currentRecord['sorting'] + 1))))
+						if ((!$this->rootPaste && \in_array($id, $this->root)) || !$this->isGrantedToClipboard($arrClipboard, array('pid' => $currentRecord['pid'], 'sorting' => $currentRecord['sorting'] + 1)))
 						{
 							$_buttons .= Image::getHtml('pasteafter--disabled.svg') . ' ';
 						}
@@ -4358,7 +4356,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 							$_buttons .= '<a href="' . $this->addToUrl('act=' . $arrClipboard['mode'] . '&amp;mode=1&amp;pid=' . $id . (!\is_array($arrClipboard['id']) ? '&amp;id=' . $arrClipboard['id'] : '')) . '" title="' . StringUtil::specialchars(sprintf($labelPasteAfter[1], $id)) . '" onclick="Backend.getScrollOffset()">' . $imagePasteAfter . '</a> ';
 						}
 
-						if (!$security->isGranted(ContaoCorePermissions::DC_PREFIX . $this->strTable, new CreateAction($this->strTable, array('pid' => $id))))
+						if (!$this->isGrantedToClipboard($arrClipboard, array('pid' => $id, 'sorting' => 0)))
 						{
 							$_buttons .= Image::getHtml('pasteinto--disabled.svg') . ' ';
 						}
@@ -4375,7 +4373,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 					// Paste after the selected record (e.g. paste article after article X)
 					if ($this->strTable == $table)
 					{
-						if (($arrClipboard['mode'] == 'cut' && ($blnCircularReference || $arrClipboard['id'] == $id)) || ($arrClipboard['mode'] == 'cutAll' && ($blnCircularReference || \in_array($id, $arrClipboard['id']))) || !System::getContainer()->get('security.helper')->isGranted(ContaoCorePermissions::DC_PREFIX . $this->strTable, new CreateAction($this->strTable, array('pid' => $currentRecord['pid'], 'sorting' => $currentRecord['sorting'] + 1))))
+						if (($arrClipboard['mode'] == 'cut' && ($blnCircularReference || $arrClipboard['id'] == $id)) || ($arrClipboard['mode'] == 'cutAll' && ($blnCircularReference || \in_array($id, $arrClipboard['id']))) || !$this->isGrantedToClipboard($arrClipboard, array('pid' => $currentRecord['pid'], 'sorting' => $currentRecord['sorting'] + 1)))
 						{
 							$_buttons .= Image::getHtml('pasteafter--disabled.svg') . ' ';
 						}
@@ -4388,7 +4386,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 					// Paste into the selected record (e.g. paste article into page X)
 					else
 					{
-						if (System::getContainer()->get('security.helper')->isGranted(ContaoCorePermissions::DC_PREFIX . $this->strTable, new CreateAction($this->strTable, array('pid'=>$id))))
+						if (!$this->isGrantedToClipboard($arrClipboard, array('pid' => $id, 'sorting' => 0)))
 						{
 							$_buttons .= Image::getHtml('pasteinto--disabled.svg') . ' ';
 						}
@@ -6642,5 +6640,29 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 		}
 
 		return $data;
+	}
+
+	private function isGrantedToClipboard(array $arrClipboard, array $data): bool
+	{
+		$actions = match($arrClipboard['mod'])
+		{
+			'create' => [new CreateAction($this->strTable, $data)],
+			'cut',
+			'cutAll' => array_map(fn ($clipboardId) => new UpdateAction($this->strTable, $this->getCurrentRecord($clipboardId, $this->strTable), $data), (array) $arrClipboard['id']),
+			'copy',
+			'copyAll' => array_map(fn ($clipboardId) => new CreateAction($this->strTable, array_merge($this->getCurrentRecord($clipboardId, $this->strTable), $data)), (array) $arrClipboard['id'])
+		};
+
+		$security = System::getContainer()->get('security.helper');
+
+		foreach ($actions as $action)
+		{
+			if (!$security->isGranted(ContaoCorePermissions::DC_PREFIX . $this->strTable, $action))
+			{
+				return false;
+			}
+		}
+
+		return true;
 	}
 }

--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -182,19 +182,27 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 				$mode = Input::post('cut') !== null ? 'cutAll' : 'copyAll';
 				$ids = array_filter($ids, fn ($id) => $security->isGranted(...$this->getClipboardPermission($mode, (int) $id)));
 
-				$arrClipboard[$strTable] = array
-				(
-					'id' => $ids,
-					'mode' => $mode,
-					'keep' => Input::post('copyMultiple') !== null
-				);
-
-				$objSession->set('CLIPBOARD', $arrClipboard);
-
-				// Support copyAll in the list view (see #7499)
-				if ((Input::post('copy') !== null || Input::post('copyMultiple') !== null) && ($GLOBALS['TL_DCA'][$strTable]['list']['sorting']['mode'] ?? 0) < self::MODE_PARENT)
+				if (empty($ids))
 				{
-					$this->redirect(str_replace('act=select', 'act=copyAll', Environment::get('requestUri')));
+					unset($arrClipboard[$strTable]);
+					$objSession->set('CLIPBOARD', $arrClipboard);
+				}
+				else
+				{
+					$arrClipboard[$strTable] = array
+					(
+						'id' => $ids,
+						'mode' => $mode,
+						'keep' => Input::post('copyMultiple') !== null
+					);
+
+					$objSession->set('CLIPBOARD', $arrClipboard);
+
+					// Support copyAll in the list view (see #7499)
+					if ((Input::post('copy') !== null || Input::post('copyMultiple') !== null) && ($GLOBALS['TL_DCA'][$strTable]['list']['sorting']['mode'] ?? 0) < self::MODE_PARENT)
+					{
+						$this->redirect(str_replace('act=select', 'act=copyAll', Environment::get('requestUri')));
+					}
 				}
 
 				$this->redirect($this->getReferer());

--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -123,6 +123,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 		}
 
 		$this->intId = Input::get('id');
+		$this->strTable = $strTable;
 
 		// Clear the clipboard
 		if (Input::get('clipboard') !== null)
@@ -199,7 +200,6 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 			}
 		}
 
-		$this->strTable = $strTable;
 		$this->ptable = $GLOBALS['TL_DCA'][$this->strTable]['config']['ptable'] ?? null;
 		$this->ctable = $GLOBALS['TL_DCA'][$this->strTable]['config']['ctable'] ?? null;
 		$this->treeView = \in_array($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] ?? null, array(self::MODE_TREE, self::MODE_TREE_EXTENDED));

--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -6668,15 +6668,15 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 		return true;
 	}
 
-	protected function isGrantedClipboardMode(string $mode, int $id): bool
+	protected function isGrantedClipboardMode(string $mode, int $id, array|null $new = null): bool
 	{
 		$action = match ($mode)
 		{
-			'create' => new CreateAction($this->strTable),
+			'create' => new CreateAction($this->strTable, $new),
 			'cut',
-			'cutAll' => new UpdateAction($this->strTable, $this->getCurrentRecord($id, $this->strTable), array('sorting' => null)),
+			'cutAll' => new UpdateAction($this->strTable, $this->getCurrentRecord($id, $this->strTable), array_replace(array('sorting' => null), (array) $new)),
 			'copy',
-			'copyAll' => new CreateAction($this->strTable, array_merge($this->getCurrentRecord($id, $this->strTable), array('tstamp' => null, 'sorting' => null)))
+			'copyAll' => new CreateAction($this->strTable, array_replace($this->getCurrentRecord($id, $this->strTable), array('tstamp' => null, 'sorting' => null), (array) $new))
 		};
 
 		return System::getContainer()->get('security.helper')->isGranted(ContaoCorePermissions::DC_PREFIX . $this->strTable, $action);

--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -6687,6 +6687,6 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 			'copyAll' => new CreateAction($this->strTable, array_replace($this->getCurrentRecord($id, $this->strTable), array('tstamp' => null, 'sorting' => null), (array) $new))
 		};
 
-		return [ContaoCorePermissions::DC_PREFIX . $this->strTable, $action];
+		return array(ContaoCorePermissions::DC_PREFIX . $this->strTable, $action);
 	}
 }

--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -6644,7 +6644,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 
 	private function isGrantedToClipboard(array $arrClipboard, array $data): bool
 	{
-		$actions = match ($arrClipboard['mod'])
+		$actions = match ($arrClipboard['mode'])
 		{
 			'create' => array(new CreateAction($this->strTable, $data)),
 			'cut',


### PR DESCRIPTION
While working on voters in Contao 5.3, I noticed the permission checks for paste buttons are incorrect. The action currently contains the _current record_ (the one the paste button is on), but it should actually contain the record that is being copied/pasted. Depending on the clipboard new/copy/cut, the action is different and and it should contain the PID/Sorting position of the current record/paste button.

Additionally, the check on 4391/4389 was inverted (the button was disabled if access was granted).