### PR TITLE
Only check the first record to be restored

### DIFF
--- a/core-bundle/src/EventListener/DataContainer/Undo/UndoOperationListener.php
+++ b/core-bundle/src/EventListener/DataContainer/Undo/UndoOperationListener.php
@@ -33,6 +33,10 @@ class UndoOperationListener
     {
         $data = StringUtil::deserialize($operation->getRecord()['data'] ?? null);
         $table = $operation->getRecord()['fromTable'];
+
+        // We can only disable undo if the main record access is denied, because child records cannot
+        // check their permissions on a non-existing parent record. DC_Table::undo() will actually verify
+        // records again and skip the ones that are not allowed.
         $row = $data[$table][0] ?? null;
 
         if (

--- a/core-bundle/src/EventListener/DataContainer/Undo/UndoOperationListener.php
+++ b/core-bundle/src/EventListener/DataContainer/Undo/UndoOperationListener.php
@@ -32,21 +32,16 @@ class UndoOperationListener
     public function __invoke(DataContainerOperation $operation): void
     {
         $data = StringUtil::deserialize($operation->getRecord()['data'] ?? null);
+        $table = $operation->getRecord()['fromTable'];
+        $row = $data[$table][0] ?? null;
 
-        if (!\is_array($data)) {
-            $operation->disable();
-
+        if (
+            $row
+            && $this->security->isGranted(ContaoCorePermissions::DC_PREFIX.$table, new CreateAction($table, $row))
+        ) {
             return;
         }
 
-        foreach ($data as $table => $fields) {
-            foreach ($fields as $row) {
-                if (!$this->security->isGranted(ContaoCorePermissions::DC_PREFIX.$table, new CreateAction($table, $row))) {
-                    $operation->disable();
-
-                    return;
-                }
-            }
-        }
+        $operation->disable();
     }
 }

--- a/core-bundle/src/EventListener/DataContainer/Undo/UndoOperationListener.php
+++ b/core-bundle/src/EventListener/DataContainer/Undo/UndoOperationListener.php
@@ -31,8 +31,9 @@ class UndoOperationListener
     #[AsCallback(table: 'tl_undo', target: 'list.operations.undo.button')]
     public function __invoke(DataContainerOperation $operation): void
     {
-        $data = StringUtil::deserialize($operation->getRecord()['data'] ?? null);
-        $table = $operation->getRecord()['fromTable'];
+        $record = $operation->getRecord();
+        $data = StringUtil::deserialize($record['data'] ?? null);
+        $table = $record['fromTable'];
 
         // We can only disable undo if the main record access is denied, because child records cannot
         // check their permissions on a non-existing parent record. DC_Table::undo() will actually verify

--- a/core-bundle/src/EventListener/DataContainer/Undo/UndoOperationListener.php
+++ b/core-bundle/src/EventListener/DataContainer/Undo/UndoOperationListener.php
@@ -39,10 +39,7 @@ class UndoOperationListener
         // records again and skip the ones that are not allowed.
         $row = $data[$table][0] ?? null;
 
-        if (
-            $row
-            && $this->security->isGranted(ContaoCorePermissions::DC_PREFIX.$table, new CreateAction($table, $row))
-        ) {
+        if ($row && $this->security->isGranted(ContaoCorePermissions::DC_PREFIX.$table, new CreateAction($table, $row))) {
             return;
         }
 


### PR DESCRIPTION
I noticed a bug in my PR https://github.com/contao/contao/pull/6642

The undo table will contain data of a record and all its child records. However, we cannot check permissions on all child records, they will most likely fail because their parent is not present. We can only check the actualy record and have to assume its children can be added as well.

The actual `DC_Table::undo()` will check each record to be restored, but the operation callback cannot do that upfront.