### PR TITLE
Sync the logic to generate multiple aliases

### DIFF
--- a/core-bundle/contao/dca/tl_article.php
+++ b/core-bundle/contao/dca/tl_article.php
@@ -749,7 +749,7 @@ class tl_article extends Backend
 	/**
 	 * Automatically generate the folder URL aliases
 	 *
-	 * @param array $arrButtons
+	 * @param array         $arrButtons
 	 * @param DataContainer $dc
 	 *
 	 * @return array
@@ -806,7 +806,7 @@ class tl_article extends Backend
 					continue;
 				}
 
-				if (!$security->isGranted(ContaoCorePermissions::DC_PREFIX.'tl_article', new UpdateAction('tl_article', $objArticle->row(), ['alias' => $strAlias])))
+				if (!$security->isGranted(ContaoCorePermissions::DC_PREFIX . 'tl_article', new UpdateAction('tl_article', $objArticle->row(), array('alias' => $strAlias))))
 				{
 					continue;
 				}

--- a/core-bundle/contao/dca/tl_page.php
+++ b/core-bundle/contao/dca/tl_page.php
@@ -1485,7 +1485,7 @@ class tl_page extends Backend
 					continue;
 				}
 
-				if (!$security->isGranted(ContaoCorePermissions::DC_PREFIX.'tl_article', new UpdateAction('tl_page', $objPage->row(), ['alias' => $strAlias])))
+				if (!$security->isGranted(ContaoCorePermissions::DC_PREFIX . 'tl_article', new UpdateAction('tl_page', $objPage->row(), array('alias' => $strAlias))))
 				{
 					continue;
 				}

--- a/core-bundle/contao/dca/tl_page.php
+++ b/core-bundle/contao/dca/tl_page.php
@@ -14,6 +14,7 @@ use Contao\BackendUser;
 use Contao\Config;
 use Contao\CoreBundle\Exception\AccessDeniedException;
 use Contao\CoreBundle\Security\ContaoCorePermissions;
+use Contao\CoreBundle\Security\DataContainer\UpdateAction;
 use Contao\CoreBundle\Util\LocaleUtil;
 use Contao\Database;
 use Contao\DataContainer;
@@ -1434,7 +1435,9 @@ class tl_page extends Backend
 	 */
 	public function addAliasButton($arrButtons, DataContainer $dc)
 	{
-		if (!System::getContainer()->get('security.helper')->isGranted(ContaoCorePermissions::USER_CAN_EDIT_FIELD_OF_TABLE, 'tl_page::alias'))
+		$security = System::getContainer()->get('security.helper');
+
+		if (!$security->isGranted(ContaoCorePermissions::USER_CAN_EDIT_FIELD_OF_TABLE, 'tl_page::alias'))
 		{
 			return $arrButtons;
 		}
@@ -1478,6 +1481,11 @@ class tl_page extends Backend
 
 				// The alias has not changed
 				if ($strAlias == $objPage->alias)
+				{
+					continue;
+				}
+
+				if (!$security->isGranted(ContaoCorePermissions::DC_PREFIX.'tl_article', new UpdateAction('tl_page', $objPage->row(), ['alias' => $strAlias])))
 				{
 					continue;
 				}


### PR DESCRIPTION
Back in 2014 (https://github.com/contao/core/pull/7114 !!), we changed our logic to generate multiple aliases for `tl_page` to use the `save_callback`. But we never applied the same logic to `tl_article`.

This PR also adds permission checks if the alias can be updated for each record.