### PR TITLE
Use the `attributes_callback` to make the logout redirect mandatory

### DIFF
--- a/core-bundle/config/listener.yaml
+++ b/core-bundle/config/listener.yaml
@@ -110,6 +110,9 @@ services:
         arguments:
             - '@database_connection'
 
+    contao.listener.data_container.logout_page_redirect:
+        class: Contao\CoreBundle\EventListener\DataContainer\LogoutPageRedirectListener
+
     contao.listener.data_container.member_groups:
         class: Contao\CoreBundle\EventListener\DataContainer\MemberGroupsListener
         arguments:

--- a/core-bundle/contao/dca/tl_page.php
+++ b/core-bundle/contao/dca/tl_page.php
@@ -45,7 +45,6 @@ $GLOBALS['TL_DCA']['tl_page'] = array
 			array('tl_page', 'addBreadcrumb'),
 			array('tl_page', 'setRootType'),
 			array('tl_page', 'showFallbackWarning'),
-			array('tl_page', 'makeRedirectPageMandatory'),
 		),
 		'oncut_callback' => array
 		(
@@ -1030,26 +1029,6 @@ class tl_page extends Backend
 		{
 			$messages = new Messages();
 			Message::addRaw($messages->languageFallback());
-		}
-	}
-
-	/**
-	 * Make the redirect page mandatory if the page is a logout page
-	 *
-	 * @param DataContainer $dc
-	 *
-	 * @throws Exception
-	 */
-	public function makeRedirectPageMandatory(DataContainer $dc)
-	{
-		$objPage = Database::getInstance()
-			->prepare("SELECT * FROM " . $dc->table . " WHERE id=?")
-			->limit(1)
-			->execute($dc->id);
-
-		if ($objPage->numRows && $objPage->type == 'logout')
-		{
-			$GLOBALS['TL_DCA']['tl_page']['fields']['jumpTo']['eval']['mandatory'] = true;
 		}
 	}
 

--- a/core-bundle/src/EventListener/DataContainer/LogoutPageRedirectListener.php
+++ b/core-bundle/src/EventListener/DataContainer/LogoutPageRedirectListener.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\EventListener\DataContainer;
+
+use Contao\CoreBundle\DependencyInjection\Attribute\AsCallback;
+use Contao\DataContainer;
+use Contao\Module;
+
+#[AsCallback(table: 'tl_page', target: 'fields.jumpTo.attributes')]
+class LogoutPageRedirectListener
+{
+    /**
+     * @param DataContainer|Module|null $dc
+     */
+    public function __invoke(array $attributes, $dc): array
+    {
+        if ($dc instanceof DataContainer && 'logout' === ($dc->getCurrentRecord()['type'] ?? null)) {
+            $attributes['mandatory'] = true;
+        }
+
+        return $attributes;
+    }
+}

--- a/core-bundle/src/EventListener/DataContainer/LogoutPageRedirectListener.php
+++ b/core-bundle/src/EventListener/DataContainer/LogoutPageRedirectListener.php
@@ -14,15 +14,11 @@ namespace Contao\CoreBundle\EventListener\DataContainer;
 
 use Contao\CoreBundle\DependencyInjection\Attribute\AsCallback;
 use Contao\DataContainer;
-use Contao\Module;
 
 #[AsCallback(table: 'tl_page', target: 'fields.jumpTo.attributes')]
 class LogoutPageRedirectListener
 {
-    /**
-     * @param DataContainer|Module|null $dc
-     */
-    public function __invoke(array $attributes, $dc): array
+    public function __invoke(array $attributes, mixed $dc): array
     {
         if ($dc instanceof DataContainer && 'logout' === ($dc->getCurrentRecord()['type'] ?? null)) {
             $attributes['mandatory'] = true;

--- a/core-bundle/tests/EventListener/DataContainer/LogoutPageRedirectListenerTest.php
+++ b/core-bundle/tests/EventListener/DataContainer/LogoutPageRedirectListenerTest.php
@@ -23,9 +23,9 @@ class LogoutPageRedirectListenerTest extends TestCase
      */
     public function testListener(array $attributes, array|null $currentRecord, bool|null $expected): void
     {
-        if (null === $currentRecord) {
-            $dataContainer = null;
-        } else {
+        $dataContainer = null;
+
+        if (null !== $currentRecord) {
             $dataContainer = $this->createMock(DC_Table::class);
             $dataContainer
                 ->method('getCurrentRecord')

--- a/core-bundle/tests/EventListener/DataContainer/LogoutPageRedirectListenerTest.php
+++ b/core-bundle/tests/EventListener/DataContainer/LogoutPageRedirectListenerTest.php
@@ -12,12 +12,9 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Tests\EventListener\DataContainer;
 
-use Contao\CoreBundle\EventListener\DataContainer\LayoutOptionsListener;
 use Contao\CoreBundle\EventListener\DataContainer\LogoutPageRedirectListener;
 use Contao\CoreBundle\Tests\TestCase;
 use Contao\DC_Table;
-use Doctrine\DBAL\Connection;
-use Symfony\Contracts\Service\ResetInterface;
 
 class LogoutPageRedirectListenerTest extends TestCase
 {
@@ -52,43 +49,43 @@ class LogoutPageRedirectListenerTest extends TestCase
         yield 'Keeps true mandatory value for logout pages' => [
             [],
             ['type' => 'logout'],
-            true
+            true,
         ];
 
         yield 'Overrides false mandatory value for logout pages' => [
             ['mandatory' => false],
             ['type' => 'logout'],
-            true
+            true,
         ];
 
         yield 'Overrides any mandatory value for logout pages' => [
             ['mandatory' => 'foobar'],
             ['type' => 'logout'],
-            true
+            true,
         ];
 
         yield 'Does not change true mandatory property for non-logout pages' => [
             ['mandatory' => true],
             ['type' => 'regular'],
-            true
+            true,
         ];
 
         yield 'Does not change false mandatory property for non-logout pages' => [
             ['mandatory' => false],
             ['type' => 'regular'],
-            false
+            false,
         ];
 
         yield 'Does not add the mandatory property for non-logout pages' => [
             [],
             ['type' => 'regular'],
-            null
+            null,
         ];
 
         yield 'Does nothing without DataContainer' => [
             [],
             null,
-            null
+            null,
         ];
     }
 }

--- a/core-bundle/tests/EventListener/DataContainer/LogoutPageRedirectListenerTest.php
+++ b/core-bundle/tests/EventListener/DataContainer/LogoutPageRedirectListenerTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\EventListener\DataContainer;
+
+use Contao\CoreBundle\EventListener\DataContainer\LayoutOptionsListener;
+use Contao\CoreBundle\EventListener\DataContainer\LogoutPageRedirectListener;
+use Contao\CoreBundle\Tests\TestCase;
+use Contao\DC_Table;
+use Doctrine\DBAL\Connection;
+use Symfony\Contracts\Service\ResetInterface;
+
+class LogoutPageRedirectListenerTest extends TestCase
+{
+    /**
+     * @dataProvider listenerProvider
+     */
+    public function testListener(array $attributes, array|null $currentRecord, bool|null $expected): void
+    {
+        if (null === $currentRecord) {
+            $dataContainer = null;
+        } else {
+            $dataContainer = $this->createMock(DC_Table::class);
+            $dataContainer
+                ->method('getCurrentRecord')
+                ->willReturn($currentRecord)
+            ;
+        }
+
+        $listener = new LogoutPageRedirectListener();
+        $attributes = $listener($attributes, $dataContainer);
+
+        if (null === $expected) {
+            $this->assertArrayNotHasKey('mandatory', $attributes);
+        } else {
+            $this->assertArrayHasKey('mandatory', $attributes);
+            $this->assertSame($expected, $attributes['mandatory']);
+        }
+    }
+
+    public function listenerProvider(): \Generator
+    {
+        yield 'Keeps true mandatory value for logout pages' => [
+            [],
+            ['type' => 'logout'],
+            true
+        ];
+
+        yield 'Overrides false mandatory value for logout pages' => [
+            ['mandatory' => false],
+            ['type' => 'logout'],
+            true
+        ];
+
+        yield 'Overrides any mandatory value for logout pages' => [
+            ['mandatory' => 'foobar'],
+            ['type' => 'logout'],
+            true
+        ];
+
+        yield 'Does not change true mandatory property for non-logout pages' => [
+            ['mandatory' => true],
+            ['type' => 'regular'],
+            true
+        ];
+
+        yield 'Does not change false mandatory property for non-logout pages' => [
+            ['mandatory' => false],
+            ['type' => 'regular'],
+            false
+        ];
+
+        yield 'Does not add the mandatory property for non-logout pages' => [
+            [],
+            ['type' => 'regular'],
+            null
+        ];
+
+        yield 'Does nothing without DataContainer' => [
+            [],
+            null,
+            null
+        ];
+    }
+}


### PR DESCRIPTION
The new `attributes_callback` in Contao 5.3 allows us to correctly modify attributes for the logout page. The current implementation cannot work in edit-all mode for example because it globally changes the configuration.