### PR TITLE
Fetch visible root trail record from database

### DIFF
--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -4323,7 +4323,12 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 		}
 		catch (AccessDeniedException)
 		{
-			$currentRecord = null;
+			$currentRecord = Database::getInstance()->prepare("SELECT * FROM ".$table." WHERE id=?")->execute($id);
+
+			if ($checkIdAllowed ? !\in_array($id, $this->visibleRootTrails) : !\in_array($currentRecord['pid'] ?? null, $this->visibleRootTrails))
+			{
+				$currentRecord = null;
+			}
 		}
 
 		// Return if there is no result

--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -4327,22 +4327,24 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 		}
 
 		// Special handling for visible root trails, which are tree nodes the user does not have access to.
-		// $this->>getCurrentRecord() would deny access, but we still need the record to render a label.
+		// $this->getCurrentRecord() can deny access, but we still need the record to render a label.
 		if (null === $currentRecord && !empty($this->visibleRootTrails))
 		{
-			$currentRecord = Database::getInstance()->prepare("SELECT * FROM " . $table . " WHERE id=?")->execute($id);
+			$currentRecord = Database::getInstance()
+				->prepare("SELECT * FROM " . $table . " WHERE id=?")
+				->execute($id)
+				->fetchAssoc()
+			;
 
-			if ($checkIdAllowed ? !\in_array($id, $this->visibleRootTrails) : !\in_array($currentRecord['pid'] ?? null, $this->visibleRootTrails))
+			if (!$currentRecord || $checkIdAllowed ? !\in_array($id, $this->visibleRootTrails) : !\in_array($currentRecord['pid'] ?? null, $this->visibleRootTrails))
 			{
-				$currentRecord = null;
+				return '';
 			}
 		}
 
 		// Return if there is no result
 		if (null === $currentRecord)
 		{
-			$objSessionBag->replace($session);
-
 			return '';
 		}
 

--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -4323,7 +4323,14 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 		}
 		catch (AccessDeniedException)
 		{
-			$currentRecord = Database::getInstance()->prepare("SELECT * FROM ".$table." WHERE id=?")->execute($id);
+			$currentRecord = null;
+		}
+
+		// Special handling for visible root trails, which are tree nodes the user does not have access to.
+		// $this->>getCurrentRecord() would deny access, but we still need the record to render a label.
+		if (null === $currentRecord && !empty($this->visibleRootTrails))
+		{
+			$currentRecord = Database::getInstance()->prepare("SELECT * FROM " . $table . " WHERE id=?")->execute($id);
 
 			if ($checkIdAllowed ? !\in_array($id, $this->visibleRootTrails) : !\in_array($currentRecord['pid'] ?? null, $this->visibleRootTrails))
 			{


### PR DESCRIPTION
Rendering visible root trails in a tree is a very special case. Because the user actually does not have read permissions on the given record.

We currently use `DataContainer::getCurrentRecord` to fetch visible trail pages. However, if correct permissions are implemented (e.g. on tl_page), the user would not have access to that page. It would therefore not render this node, and therefore not render any nodes of any trees (because the root records are not readable).

I first tried to add a `$checkPermissions` property to `getCurrentRecord`, but that does not really work with our cache of either records or exception.