### PR TITLE
Add more database indexes

### DIFF
--- a/calendar-bundle/contao/dca/tl_calendar.php
+++ b/calendar-bundle/contao/dca/tl_calendar.php
@@ -54,7 +54,8 @@ $GLOBALS['TL_DCA']['tl_calendar'] = array
 		(
 			'keys' => array
 			(
-				'id' => 'primary'
+				'id' => 'primary',
+				'tstamp' => 'index'
 			)
 		)
 	),

--- a/calendar-bundle/contao/dca/tl_calendar_events.php
+++ b/calendar-bundle/contao/dca/tl_calendar_events.php
@@ -66,6 +66,7 @@ $GLOBALS['TL_DCA']['tl_calendar_events'] = array
 			'keys' => array
 			(
 				'id' => 'primary',
+				'tstamp' => 'index',
 				'alias' => 'index',
 				'pid,published,featured,start,stop' => 'index'
 			)

--- a/calendar-bundle/contao/dca/tl_calendar_feed.php
+++ b/calendar-bundle/contao/dca/tl_calendar_feed.php
@@ -56,6 +56,7 @@ $GLOBALS['TL_DCA']['tl_calendar_feed'] = array
 			'keys' => array
 			(
 				'id' => 'primary',
+				'tstamp' => 'index',
 				'alias' => 'index'
 			)
 		),

--- a/comments-bundle/contao/dca/tl_comments_notify.php
+++ b/comments-bundle/contao/dca/tl_comments_notify.php
@@ -23,6 +23,7 @@ $GLOBALS['TL_DCA']['tl_comments_notify'] = array
 			'keys' => array
 			(
 				'id' => 'primary',
+				'tstamp' => 'index',
 				'source,parent,active,email' => 'index',
 				'tokenRemove' => 'index'
 			)

--- a/core-bundle/contao/dca/tl_article.php
+++ b/core-bundle/contao/dca/tl_article.php
@@ -51,6 +51,8 @@ $GLOBALS['TL_DCA']['tl_article'] = array
 			'keys' => array
 			(
 				'id' => 'primary',
+				'tstamp' => 'index',
+				'sorting' => 'index',
 				'alias' => 'index',
 				'pid,published,inColumn,start,stop' => 'index'
 			)

--- a/core-bundle/contao/dca/tl_article.php
+++ b/core-bundle/contao/dca/tl_article.php
@@ -52,7 +52,6 @@ $GLOBALS['TL_DCA']['tl_article'] = array
 			(
 				'id' => 'primary',
 				'tstamp' => 'index',
-				'sorting' => 'index',
 				'alias' => 'index',
 				'pid,published,inColumn,start,stop' => 'index'
 			)

--- a/core-bundle/contao/dca/tl_content.php
+++ b/core-bundle/contao/dca/tl_content.php
@@ -52,7 +52,7 @@ $GLOBALS['TL_DCA']['tl_content'] = array
 				'id' => 'primary',
 				'tstamp' => 'index',
 				'sorting' => 'index',
-				'pid,ptable,invisible,start,stop' => 'index',
+				'ptable,pid,invisible,start,stop' => 'index',
 				'type' => 'index',
 				'ptable' => 'index'
 			)

--- a/core-bundle/contao/dca/tl_content.php
+++ b/core-bundle/contao/dca/tl_content.php
@@ -50,8 +50,11 @@ $GLOBALS['TL_DCA']['tl_content'] = array
 			'keys' => array
 			(
 				'id' => 'primary',
+				'tstamp' => 'index',
+				'sorting' => 'index',
 				'pid,ptable,invisible,start,stop' => 'index',
-				'type' => 'index'
+				'type' => 'index',
+				'ptable' => 'index'
 			)
 		)
 	),

--- a/core-bundle/contao/dca/tl_content.php
+++ b/core-bundle/contao/dca/tl_content.php
@@ -53,8 +53,7 @@ $GLOBALS['TL_DCA']['tl_content'] = array
 				'tstamp' => 'index',
 				'sorting' => 'index',
 				'ptable,pid,invisible,start,stop' => 'index',
-				'type' => 'index',
-				'ptable' => 'index'
+				'type' => 'index'
 			)
 		)
 	),

--- a/core-bundle/contao/dca/tl_content.php
+++ b/core-bundle/contao/dca/tl_content.php
@@ -51,7 +51,6 @@ $GLOBALS['TL_DCA']['tl_content'] = array
 			(
 				'id' => 'primary',
 				'tstamp' => 'index',
-				'sorting' => 'index',
 				'ptable,pid,invisible,start,stop' => 'index',
 				'type' => 'index'
 			)

--- a/core-bundle/contao/dca/tl_favorites.php
+++ b/core-bundle/contao/dca/tl_favorites.php
@@ -26,7 +26,6 @@ $GLOBALS['TL_DCA']['tl_favorites'] = array
 			(
 				'id' => 'primary',
 				'tstamp' => 'index',
-				'sorting' => 'index',
 				'pid,user' => 'index',
 				'url' => 'index'
 			)

--- a/core-bundle/contao/dca/tl_favorites.php
+++ b/core-bundle/contao/dca/tl_favorites.php
@@ -25,6 +25,8 @@ $GLOBALS['TL_DCA']['tl_favorites'] = array
 			'keys' => array
 			(
 				'id' => 'primary',
+				'tstamp' => 'index',
+				'sorting' => 'index',
 				'pid,user' => 'index',
 				'url' => 'index'
 			)

--- a/core-bundle/contao/dca/tl_files.php
+++ b/core-bundle/contao/dca/tl_files.php
@@ -58,6 +58,7 @@ $GLOBALS['TL_DCA']['tl_files'] = array
 			(
 				'id' => 'primary',
 				'pid' => 'index',
+				'tstamp' => 'index',
 				'uuid' => 'unique',
 				'path' => 'index', // not unique (see #7725)
 				'extension' => 'index'

--- a/core-bundle/contao/dca/tl_form.php
+++ b/core-bundle/contao/dca/tl_form.php
@@ -46,6 +46,7 @@ $GLOBALS['TL_DCA']['tl_form'] = array
 			'keys' => array
 			(
 				'id' => 'primary',
+				'tstamp' => 'index',
 				'alias' => 'index'
 			)
 		)

--- a/core-bundle/contao/dca/tl_form_field.php
+++ b/core-bundle/contao/dca/tl_form_field.php
@@ -43,7 +43,9 @@ $GLOBALS['TL_DCA']['tl_form_field'] = array
 			'keys' => array
 			(
 				'id' => 'primary',
-				'pid,invisible' => 'index'
+				'pid,invisible' => 'index',
+				'tstamp' => 'index',
+				'sorting' => 'index',
 			)
 		)
 	),

--- a/core-bundle/contao/dca/tl_form_field.php
+++ b/core-bundle/contao/dca/tl_form_field.php
@@ -44,7 +44,7 @@ $GLOBALS['TL_DCA']['tl_form_field'] = array
 			(
 				'id' => 'primary',
 				'pid,invisible' => 'index',
-				'tstamp' => 'index',
+				'tstamp' => 'index'
 			)
 		)
 	),

--- a/core-bundle/contao/dca/tl_form_field.php
+++ b/core-bundle/contao/dca/tl_form_field.php
@@ -45,7 +45,6 @@ $GLOBALS['TL_DCA']['tl_form_field'] = array
 				'id' => 'primary',
 				'pid,invisible' => 'index',
 				'tstamp' => 'index',
-				'sorting' => 'index',
 			)
 		)
 	),

--- a/core-bundle/contao/dca/tl_image_size.php
+++ b/core-bundle/contao/dca/tl_image_size.php
@@ -52,7 +52,8 @@ $GLOBALS['TL_DCA']['tl_image_size'] = array
 			'keys' => array
 			(
 				'id' => 'primary',
-				'pid' => 'index'
+				'pid' => 'index',
+				'tstamp' => 'index'
 			)
 		)
 	),

--- a/core-bundle/contao/dca/tl_image_size_item.php
+++ b/core-bundle/contao/dca/tl_image_size_item.php
@@ -34,7 +34,9 @@ $GLOBALS['TL_DCA']['tl_image_size_item'] = array
 			'keys' => array
 			(
 				'id' => 'primary',
-				'pid' => 'index'
+				'pid' => 'index',
+				'tstamp' => 'index',
+				'sorting' => 'index',
 			)
 		)
 	),

--- a/core-bundle/contao/dca/tl_image_size_item.php
+++ b/core-bundle/contao/dca/tl_image_size_item.php
@@ -35,7 +35,7 @@ $GLOBALS['TL_DCA']['tl_image_size_item'] = array
 			(
 				'id' => 'primary',
 				'pid' => 'index',
-				'tstamp' => 'index',
+				'tstamp' => 'index'
 			)
 		)
 	),

--- a/core-bundle/contao/dca/tl_image_size_item.php
+++ b/core-bundle/contao/dca/tl_image_size_item.php
@@ -36,7 +36,6 @@ $GLOBALS['TL_DCA']['tl_image_size_item'] = array
 				'id' => 'primary',
 				'pid' => 'index',
 				'tstamp' => 'index',
-				'sorting' => 'index',
 			)
 		)
 	),

--- a/core-bundle/contao/dca/tl_layout.php
+++ b/core-bundle/contao/dca/tl_layout.php
@@ -37,7 +37,7 @@ $GLOBALS['TL_DCA']['tl_layout'] = array
 			'keys' => array
 			(
 				'id' => 'primary',
-				'tstamp' => 'index',
+				'tstamp' => 'index'
 			)
 		)
 	),

--- a/core-bundle/contao/dca/tl_layout.php
+++ b/core-bundle/contao/dca/tl_layout.php
@@ -36,7 +36,8 @@ $GLOBALS['TL_DCA']['tl_layout'] = array
 		(
 			'keys' => array
 			(
-				'id' => 'primary'
+				'id' => 'primary',
+				'tstamp' => 'index',
 			)
 		)
 	),

--- a/core-bundle/contao/dca/tl_log.php
+++ b/core-bundle/contao/dca/tl_log.php
@@ -27,7 +27,7 @@ $GLOBALS['TL_DCA']['tl_log'] = array
 			'keys' => array
 			(
 				'id' => 'primary',
-				'tstamp' => 'index',
+				'tstamp' => 'index'
 			)
 		)
 	),

--- a/core-bundle/contao/dca/tl_log.php
+++ b/core-bundle/contao/dca/tl_log.php
@@ -26,7 +26,8 @@ $GLOBALS['TL_DCA']['tl_log'] = array
 		(
 			'keys' => array
 			(
-				'id' => 'primary'
+				'id' => 'primary',
+				'tstamp' => 'index',
 			)
 		)
 	),

--- a/core-bundle/contao/dca/tl_member.php
+++ b/core-bundle/contao/dca/tl_member.php
@@ -39,6 +39,7 @@ $GLOBALS['TL_DCA']['tl_member'] = array
 			'keys' => array
 			(
 				'id' => 'primary',
+				'tstamp' => 'index',
 				'username' => 'unique',
 				'email' => 'index',
 				'login,disable,start,stop' => 'index'

--- a/core-bundle/contao/dca/tl_member_group.php
+++ b/core-bundle/contao/dca/tl_member_group.php
@@ -25,6 +25,7 @@ $GLOBALS['TL_DCA']['tl_member_group'] = array
 			'keys' => array
 			(
 				'id' => 'primary',
+				'tstamp' => 'index',
 				'disable,start,stop' => 'index'
 			)
 		)

--- a/core-bundle/contao/dca/tl_module.php
+++ b/core-bundle/contao/dca/tl_module.php
@@ -38,7 +38,7 @@ $GLOBALS['TL_DCA']['tl_module'] = array
 			'keys' => array
 			(
 				'id' => 'primary',
-				'tstamp' => 'index',
+				'tstamp' => 'index'
 			)
 		)
 	),

--- a/core-bundle/contao/dca/tl_module.php
+++ b/core-bundle/contao/dca/tl_module.php
@@ -37,7 +37,8 @@ $GLOBALS['TL_DCA']['tl_module'] = array
 		(
 			'keys' => array
 			(
-				'id' => 'primary'
+				'id' => 'primary',
+				'tstamp' => 'index',
 			)
 		)
 	),

--- a/core-bundle/contao/dca/tl_opt_in.php
+++ b/core-bundle/contao/dca/tl_opt_in.php
@@ -38,6 +38,7 @@ $GLOBALS['TL_DCA']['tl_opt_in'] = array
 			'keys' => array
 			(
 				'id' => 'primary',
+				'tstamp' => 'index',
 				'token' => 'unique',
 				'removeOn' => 'index'
 			)

--- a/core-bundle/contao/dca/tl_page.php
+++ b/core-bundle/contao/dca/tl_page.php
@@ -68,9 +68,12 @@ $GLOBALS['TL_DCA']['tl_page'] = array
 			'keys' => array
 			(
 				'id' => 'primary',
+				'tstamp' => 'index',
+				'sorting' => 'index',
 				'alias' => 'index',
 				'type,dns' => 'index',
-				'pid,published,type,start,stop' => 'index'
+				'pid,published,type,start,stop' => 'index',
+				'dns,fallback,published,start,stop' => 'index',
 			)
 		)
 	),

--- a/core-bundle/contao/dca/tl_page.php
+++ b/core-bundle/contao/dca/tl_page.php
@@ -71,9 +71,8 @@ $GLOBALS['TL_DCA']['tl_page'] = array
 				'tstamp' => 'index',
 				'sorting' => 'index',
 				'alias' => 'index',
-				'type,dns' => 'index',
+				'type,dns,fallback,published,start,stop' => 'index',
 				'pid,published,type,start,stop' => 'index',
-				'dns,fallback,published,start,stop' => 'index',
 			)
 		)
 	),

--- a/core-bundle/contao/dca/tl_page.php
+++ b/core-bundle/contao/dca/tl_page.php
@@ -69,7 +69,6 @@ $GLOBALS['TL_DCA']['tl_page'] = array
 			(
 				'id' => 'primary',
 				'tstamp' => 'index',
-				'sorting' => 'index',
 				'alias' => 'index',
 				'type,dns,fallback,published,start,stop' => 'index',
 				'pid,published,type,start,stop' => 'index',

--- a/core-bundle/contao/dca/tl_page.php
+++ b/core-bundle/contao/dca/tl_page.php
@@ -71,7 +71,7 @@ $GLOBALS['TL_DCA']['tl_page'] = array
 				'tstamp' => 'index',
 				'alias' => 'index',
 				'type,dns,fallback,published,start,stop' => 'index',
-				'pid,published,type,start,stop' => 'index',
+				'pid,published,type,start,stop' => 'index'
 			)
 		)
 	),

--- a/core-bundle/contao/dca/tl_preview_link.php
+++ b/core-bundle/contao/dca/tl_preview_link.php
@@ -25,6 +25,7 @@ $GLOBALS['TL_DCA']['tl_preview_link'] = array
 			'keys' => array
 			(
 				'id' => 'primary',
+				'tstamp' => 'index',
 				'id,published,expiresAt' => 'index'
 			)
 		)

--- a/core-bundle/contao/dca/tl_search.php
+++ b/core-bundle/contao/dca/tl_search.php
@@ -18,6 +18,7 @@ $GLOBALS['TL_DCA']['tl_search'] = array
 			'keys' => array
 			(
 				'id' => 'primary',
+				'tstamp' => 'index',
 				'url' => 'unique',
 				'pid,checksum' => 'unique'
 			)

--- a/core-bundle/contao/dca/tl_theme.php
+++ b/core-bundle/contao/dca/tl_theme.php
@@ -34,7 +34,7 @@ $GLOBALS['TL_DCA']['tl_theme'] = array
 			'keys' => array
 			(
 				'id' => 'primary',
-				'tstamp' => 'index',
+				'tstamp' => 'index'
 			)
 		),
 		'onload_callback' => array

--- a/core-bundle/contao/dca/tl_theme.php
+++ b/core-bundle/contao/dca/tl_theme.php
@@ -33,7 +33,8 @@ $GLOBALS['TL_DCA']['tl_theme'] = array
 		(
 			'keys' => array
 			(
-				'id' => 'primary'
+				'id' => 'primary',
+				'tstamp' => 'index',
 			)
 		),
 		'onload_callback' => array

--- a/core-bundle/contao/dca/tl_undo.php
+++ b/core-bundle/contao/dca/tl_undo.php
@@ -29,7 +29,8 @@ $GLOBALS['TL_DCA']['tl_undo'] = array
 			'keys' => array
 			(
 				'id' => 'primary',
-				'pid' => 'index'
+				'pid' => 'index',
+				'tstamp' => 'index',
 			)
 		),
 		'onload_callback' => array

--- a/core-bundle/contao/dca/tl_undo.php
+++ b/core-bundle/contao/dca/tl_undo.php
@@ -30,7 +30,7 @@ $GLOBALS['TL_DCA']['tl_undo'] = array
 			(
 				'id' => 'primary',
 				'pid' => 'index',
-				'tstamp' => 'index',
+				'tstamp' => 'index'
 			)
 		),
 		'onload_callback' => array

--- a/core-bundle/contao/dca/tl_user.php
+++ b/core-bundle/contao/dca/tl_user.php
@@ -49,6 +49,7 @@ $GLOBALS['TL_DCA']['tl_user'] = array
 			'keys' => array
 			(
 				'id' => 'primary',
+				'tstamp' => 'index',
 				'username' => 'unique',
 				'email' => 'index'
 			)

--- a/core-bundle/contao/dca/tl_user_group.php
+++ b/core-bundle/contao/dca/tl_user_group.php
@@ -37,7 +37,7 @@ $GLOBALS['TL_DCA']['tl_user_group'] = array
 			'keys' => array
 			(
 				'id' => 'primary',
-				'tstamp' => 'index',
+				'tstamp' => 'index'
 			)
 		)
 	),

--- a/core-bundle/contao/dca/tl_user_group.php
+++ b/core-bundle/contao/dca/tl_user_group.php
@@ -36,7 +36,8 @@ $GLOBALS['TL_DCA']['tl_user_group'] = array
 		(
 			'keys' => array
 			(
-				'id' => 'primary'
+				'id' => 'primary',
+				'tstamp' => 'index',
 			)
 		)
 	),

--- a/core-bundle/contao/dca/tl_version.php
+++ b/core-bundle/contao/dca/tl_version.php
@@ -19,6 +19,7 @@ $GLOBALS['TL_DCA']['tl_version'] = array
 			(
 				'id' => 'primary',
 				'pid,fromTable,version' => 'unique',
+				'tstamp' => 'index',
 				'userid' => 'index'
 			)
 		)

--- a/core-bundle/contao/models/PageModel.php
+++ b/core-bundle/contao/models/PageModel.php
@@ -708,7 +708,7 @@ class PageModel extends Model
 		}
 
 		$t = static::$strTable;
-		$arrColumns = array("$t.dns=? AND $t.fallback=1");
+		$arrColumns = array("$t.type='root' AND $t.dns=? AND $t.fallback=1");
 
 		if (isset($arrOptions['fallbackToEmpty']) && $arrOptions['fallbackToEmpty'] === true)
 		{

--- a/core-bundle/contao/models/PageModel.php
+++ b/core-bundle/contao/models/PageModel.php
@@ -712,7 +712,7 @@ class PageModel extends Model
 
 		if (isset($arrOptions['fallbackToEmpty']) && $arrOptions['fallbackToEmpty'] === true)
 		{
-			$arrColumns = array("($t.dns=? OR $t.dns='') AND $t.fallback=1");
+			$arrColumns = array("$t.type='root' AND ($t.dns=? OR $t.dns='') AND $t.fallback=1");
 
 			if (!isset($arrOptions['order']))
 			{

--- a/faq-bundle/contao/dca/tl_faq.php
+++ b/faq-bundle/contao/dca/tl_faq.php
@@ -45,7 +45,6 @@ $GLOBALS['TL_DCA']['tl_faq'] = array
 				'id' => 'primary',
 				'pid,published' => 'index',
 				'tstamp' => 'index',
-				'sorting' => 'index',
 			)
 		)
 	),

--- a/faq-bundle/contao/dca/tl_faq.php
+++ b/faq-bundle/contao/dca/tl_faq.php
@@ -44,7 +44,9 @@ $GLOBALS['TL_DCA']['tl_faq'] = array
 			'keys' => array
 			(
 				'id' => 'primary',
-				'pid,published' => 'index'
+				'pid,published' => 'index',
+				'tstamp' => 'index',
+				'sorting' => 'index',
 			)
 		)
 	),

--- a/faq-bundle/contao/dca/tl_faq.php
+++ b/faq-bundle/contao/dca/tl_faq.php
@@ -44,7 +44,7 @@ $GLOBALS['TL_DCA']['tl_faq'] = array
 			(
 				'id' => 'primary',
 				'pid,published' => 'index',
-				'tstamp' => 'index',
+				'tstamp' => 'index'
 			)
 		)
 	),

--- a/faq-bundle/contao/dca/tl_faq_category.php
+++ b/faq-bundle/contao/dca/tl_faq_category.php
@@ -45,7 +45,7 @@ $GLOBALS['TL_DCA']['tl_faq_category'] = array
 			(
 				'id' => 'primary',
 				'tstamp' => 'index',
-				'jumpTo' => 'index',
+				'jumpTo' => 'index'
 			)
 		)
 	),

--- a/faq-bundle/contao/dca/tl_faq_category.php
+++ b/faq-bundle/contao/dca/tl_faq_category.php
@@ -43,7 +43,9 @@ $GLOBALS['TL_DCA']['tl_faq_category'] = array
 		(
 			'keys' => array
 			(
-				'id' => 'primary'
+				'id' => 'primary',
+				'tstamp' => 'index',
+				'jumpTo' => 'index',
 			)
 		)
 	),

--- a/news-bundle/contao/dca/tl_news.php
+++ b/news-bundle/contao/dca/tl_news.php
@@ -52,6 +52,7 @@ $GLOBALS['TL_DCA']['tl_news'] = array
 			'keys' => array
 			(
 				'id' => 'primary',
+				'tstamp' => 'index',
 				'alias' => 'index',
 				'pid,published,featured,start,stop' => 'index'
 			)

--- a/news-bundle/contao/dca/tl_news_archive.php
+++ b/news-bundle/contao/dca/tl_news_archive.php
@@ -51,7 +51,7 @@ $GLOBALS['TL_DCA']['tl_news_archive'] = array
 			(
 				'id' => 'primary',
 				'tstamp' => 'index',
-				'jumpTo' => 'index',
+				'jumpTo' => 'index'
 			)
 		)
 	),

--- a/news-bundle/contao/dca/tl_news_archive.php
+++ b/news-bundle/contao/dca/tl_news_archive.php
@@ -49,7 +49,9 @@ $GLOBALS['TL_DCA']['tl_news_archive'] = array
 		(
 			'keys' => array
 			(
-				'id' => 'primary'
+				'id' => 'primary',
+				'tstamp' => 'index',
+				'jumpTo' => 'index',
 			)
 		)
 	),

--- a/newsletter-bundle/contao/dca/tl_newsletter.php
+++ b/newsletter-bundle/contao/dca/tl_newsletter.php
@@ -34,7 +34,8 @@ $GLOBALS['TL_DCA']['tl_newsletter'] = array
 			'keys' => array
 			(
 				'id' => 'primary',
-				'pid' => 'index'
+				'pid' => 'index',
+				'tstamp' => 'index',
 			)
 		)
 	),

--- a/newsletter-bundle/contao/dca/tl_newsletter.php
+++ b/newsletter-bundle/contao/dca/tl_newsletter.php
@@ -35,7 +35,7 @@ $GLOBALS['TL_DCA']['tl_newsletter'] = array
 			(
 				'id' => 'primary',
 				'pid' => 'index',
-				'tstamp' => 'index',
+				'tstamp' => 'index'
 			)
 		)
 	),

--- a/newsletter-bundle/contao/dca/tl_newsletter_channel.php
+++ b/newsletter-bundle/contao/dca/tl_newsletter_channel.php
@@ -45,7 +45,7 @@ $GLOBALS['TL_DCA']['tl_newsletter_channel'] = array
 			'keys' => array
 			(
 				'id' => 'primary',
-				'tstamp' => 'index',
+				'tstamp' => 'index'
 			)
 		)
 	),

--- a/newsletter-bundle/contao/dca/tl_newsletter_channel.php
+++ b/newsletter-bundle/contao/dca/tl_newsletter_channel.php
@@ -44,7 +44,8 @@ $GLOBALS['TL_DCA']['tl_newsletter_channel'] = array
 		(
 			'keys' => array
 			(
-				'id' => 'primary'
+				'id' => 'primary',
+				'tstamp' => 'index',
 			)
 		)
 	),

--- a/newsletter-bundle/contao/dca/tl_newsletter_recipients.php
+++ b/newsletter-bundle/contao/dca/tl_newsletter_recipients.php
@@ -35,6 +35,7 @@ $GLOBALS['TL_DCA']['tl_newsletter_recipients'] = array
 			(
 				'id' => 'primary',
 				'pid,email' => 'unique',
+				'tstamp' => 'index',
 				'email' => 'index',
 				'active' => 'index'
 			)


### PR DESCRIPTION
Fixes https://github.com/contao/contao/issues/6681

@contao/developers I've only added indexes to the columns that were part of my slow query log. Of course, that will probably be different in other setups. An alternative would be to automate adding the indexes for columns such as

* id
* pid
* sorting
* ptable
* fields with `relation` of `'type'=>'hasOne'` or `'type'=>'belongsTo'`

Not sure if we'd end up having too many indexes?
