### PR TITLE
Do not overwrite `id`, `pid`, `ptable` and `sorting` when restoring a version

### DIFF
--- a/core-bundle/src/Resources/contao/classes/Versions.php
+++ b/core-bundle/src/Resources/contao/classes/Versions.php
@@ -311,6 +311,9 @@ class Versions extends Controller
 			}
 		}
 
+		// Do not overwrite ID, PID, ptable and sorting (see #6426)
+		unset($data['id'], $data['pid'], $data['ptable'], $data['sorting']);
+
 		try
 		{
 			$this->Database->prepare("UPDATE " . $this->strTable . " %s WHERE id=?")


### PR DESCRIPTION
Fixes #6426

