### PR TITLE
Fix the description of the "template data" field

### DIFF
--- a/core-bundle/src/Resources/contao/languages/en/tl_content.xlf
+++ b/core-bundle/src/Resources/contao/languages/en/tl_content.xlf
@@ -234,7 +234,7 @@
         <source>Template data</source>
       </trans-unit>
       <trans-unit id="tl_content.data.1">
-        <source>These values are available as &lt;code&gt;$this->data&lt;/code&gt; in the template.</source>
+        <source>These values are available as &lt;code&gt;$this->keys&lt;/code&gt; in the template.</source>
       </trans-unit>
       <trans-unit id="tl_content.linkTitle.0">
         <source>Link text</source>


### PR DESCRIPTION
Fixes #6685 as explained [here](https://github.com/contao/contao/issues/6685#issuecomment-1877093881).

To my understanding, the fix in the `*.xlf` files would be done on transifex. I applied for access there and was asked for my language(s). As far as I understand transfix I would need to be member of each langauge's team in order to submit a translation.

In this special case however I think one could fix all languages without even speaking or reading the language.

You could tell that
```
<target>これらの値は&lt;code&gt;$this-&gt;data&lt;/code&gt;としてテンプレートで利用できます。</target>
```
would become 
```
<target>これらの値は&lt;code&gt;$this-&gt;keys&lt;/code&gt;としてテンプレートで利用できます。</target>
```
without understanding `これらの値は` etc.

Is there an easy way that I am missing; how to proceed from here?

