### PR TITLE
Make `FrontendTemplateTrait::getTemplate()` static

### DIFF
--- a/core-bundle/src/Resources/contao/classes/FrontendTemplateTrait.php
+++ b/core-bundle/src/Resources/contao/classes/FrontendTemplateTrait.php
@@ -17,7 +17,7 @@ namespace Contao;
  * @property array   $sections
  * @property array   $positions
  * @property array   $matches
- * @method   string  getTemplate(string $strTemplate)
+ * @method   static  string  getTemplate(string $strTemplate)
  *
  * @internal
  */

--- a/core-bundle/src/Resources/contao/classes/FrontendTemplateTrait.php
+++ b/core-bundle/src/Resources/contao/classes/FrontendTemplateTrait.php
@@ -17,7 +17,8 @@ namespace Contao;
  * @property array   $sections
  * @property array   $positions
  * @property array   $matches
- * @method   static  string  getTemplate(string $strTemplate)
+ *
+ * @method static string getTemplate(string $strTemplate)
  *
  * @internal
  */


### PR DESCRIPTION
Very simple fix, this method references getTemplate of Controller, but in Controller it is static.
I noticed this because of phpstan type checking.
Related:
https://github.com/contao/contao/blob/3520a2348da1ac1c84935144258f019d938b4b9f/core-bundle/src/Resources/contao/library/Contao/Controller.php#L77