### PR TITLE
Fix undefined method `checkPermission`

### DIFF
--- a/core-bundle/contao/dca/tl_theme.php
+++ b/core-bundle/contao/dca/tl_theme.php
@@ -33,10 +33,6 @@ $GLOBALS['TL_DCA']['tl_theme'] = array
 			(
 				'id' => 'primary'
 			)
-		),
-		'onload_callback' => array
-		(
-			array('tl_theme', 'checkPermission'),
 		)
 	),
 


### PR DESCRIPTION
Fixes 
```
Attempted to call an undefined method named "checkPermission" of class "tl_theme".
```

The tl_theme onload callback has been reintroduced within this merge:
https://github.com/contao/contao/commit/d036d1f76b7615af7d78b9cb36b60eee2d54448f

Initial PR removed that line: 
https://github.com/contao/contao/pull/6644/files
