### PR TITLE
Fix an error if a gallery image does not exist

### DIFF
--- a/core-bundle/src/Resources/contao/elements/ContentGallery.php
+++ b/core-bundle/src/Resources/contao/elements/ContentGallery.php
@@ -12,6 +12,7 @@ namespace Contao;
 
 use Contao\CoreBundle\Exception\PageNotFoundException;
 use Contao\Model\Collection;
+use Symfony\Component\Filesystem\Path;
 
 /**
  * Front end content element "gallery".
@@ -89,7 +90,7 @@ class ContentGallery extends ContentElement
 		while ($objFiles->next())
 		{
 			// Continue if the files has been processed or does not exist
-			if (isset($images[$objFiles->path]) || !file_exists($projectDir . '/' . $objFiles->path))
+			if (isset($images[$objFiles->path]) || !file_exists(Path::join($projectDir, $objFiles->path)))
 			{
 				continue;
 			}
@@ -123,8 +124,8 @@ class ContentGallery extends ContentElement
 
 				while ($objSubfiles->next())
 				{
-					// Skip subfolders
-					if ($objSubfiles->type == 'folder')
+					// Skip subfolders and files that do not exist
+					if ($objSubfiles->type == 'folder' || !file_exists(Path::join($projectDir, $objSubfiles->path)))
 					{
 						continue;
 					}


### PR DESCRIPTION
If a folder is selected in a `gallery` content element and one of the images within that folder gets deleted outside of Contao (i.e. outside the DBAFS, via (S)FTP for example) then the following warning occurs in `dev`:

```
ErrorException:
Warning: filemtime(): stat failed for files/dts/_test.jpg

  at vendor\contao\contao\core-bundle\src\Resources\contao\library\Contao\File.php:228
  at Contao\File->__get('mtime')
     (vendor\contao\contao\core-bundle\src\Resources\contao\elements\ContentGallery.php:140)
  at Contao\ContentGallery->compile()
     (vendor\contao\contao\core-bundle\src\Resources\contao\elements\ContentElement.php:246)
  at Contao\ContentElement->generate()
     (vendor\contao\contao\core-bundle\src\Resources\contao\elements\ContentGallery.php:75)
```

and the following error occurs in `prod`:

```
Contao\CoreBundle\Exception\InvalidResourceException:
No resource could be located at path "files/dts/_test.jpg".

  at vendor\contao\contao\core-bundle\src\Image\Studio\FigureBuilder.php:175
  at Contao\CoreBundle\Image\Studio\FigureBuilder->fromFilesModel(object(FilesModel))
     (vendor\contao\contao\core-bundle\src\Image\Studio\FigureBuilder.php:215)
  at Contao\CoreBundle\Image\Studio\FigureBuilder->fromId(2611)
     (vendor\contao\contao\core-bundle\src\Resources\contao\elements\ContentGallery.php:276)
  at Contao\ContentGallery->compile()
     (vendor\contao\contao\core-bundle\src\Resources\contao\elements\ContentElement.php:246)
  at Contao\ContentElement->generate()
     (vendor\contao\contao\core-bundle\src\Resources\contao\elements\ContentGallery.php:76)
```

This PR fixes that by also checking in the `else` branch for the folder case if the respective file actually exists.