### PR TITLE
Fix tests when `MAILER_DSN` env var is defined

### DIFF
--- a/manager-bundle/tests/ContaoManager/PluginTest.php
+++ b/manager-bundle/tests/ContaoManager/PluginTest.php
@@ -59,7 +59,7 @@ class PluginTest extends ContaoTestCase
 
         $this->backupServerEnvGetPost();
 
-        unset($_SERVER['DATABASE_URL'], $_SERVER['APP_SECRET'], $_ENV['DATABASE_URL']);
+        unset($_SERVER['DATABASE_URL'], $_SERVER['APP_SECRET'], $_ENV['DATABASE_URL'], $_SERVER['MAILER_DSN'], $_ENV['MAILER_DSN']);
     }
 
     protected function tearDown(): void


### PR DESCRIPTION
If a `MAILER_DSN` environment variable is defined in the system, the `PluginTest` tests of the `contao/manager-bundle` will fail:

```
1) Contao\ManagerBundle\Tests\ContaoManager\PluginTest::testSetsTheMailerDsn with data set #0 ('mail', null, null, null, null, null, 'native://default')
Undefined array key "env(MAILER_DSN)"

vendor\contao\contao\manager-bundle\tests\ContaoManager\PluginTest.php:835

2) Contao\ManagerBundle\Tests\ContaoManager\PluginTest::testSetsTheMailerDsn with data set #1 ('sendmail', '127.0.0.1', null, null, 25, null, 'native://default')
Undefined array key "env(MAILER_DSN)"

vendor\contao\contao\manager-bundle\tests\ContaoManager\PluginTest.php:835
```

This PR fixes that by unsetting the env var (just like with the `DATABASE_URL` env var).