### PR TITLE
Set form action to response URL

### DIFF
--- a/core-bundle/contao/templates/forms/form_wrapper.html5
+++ b/core-bundle/contao/templates/forms/form_wrapper.html5
@@ -70,6 +70,11 @@
 
             const newForm = template.content.firstElementChild;
             form.replaceWith(newForm);
+
+            if (!newForm.getAttribute('action')) {
+              newForm.action = xhr.responseURL;
+            }
+
             initForm(newForm);
           });
         });


### PR DESCRIPTION
Fixes #6609 by setting the form action of the returned form to the response URL of the preceding AJAX request.