### PR TITLE
Fix the missing icon for DCA operations again

### DIFF
--- a/core-bundle/contao/dca/tl_page.php
+++ b/core-bundle/contao/dca/tl_page.php
@@ -644,12 +644,6 @@ $GLOBALS['TL_DCA']['tl_page'] = array
 	)
 );
 
-// Disable the articles link in the modal window
-if (Input::get('popup'))
-{
-	unset($GLOBALS['TL_DCA']['tl_page']['list']['operations']['articles']);
-}
-
 /**
  * Provide miscellaneous methods that are used by the data configuration array.
  *

--- a/core-bundle/src/EventListener/DataContainer/ContentCompositionListener.php
+++ b/core-bundle/src/EventListener/DataContainer/ContentCompositionListener.php
@@ -20,6 +20,7 @@ use Contao\CoreBundle\Routing\Page\PageRegistry;
 use Contao\CoreBundle\Security\ContaoCorePermissions;
 use Contao\CoreBundle\Security\DataContainer\CreateAction;
 use Contao\DataContainer;
+use Contao\Input;
 use Contao\LayoutModel;
 use Contao\PageModel;
 use Contao\StringUtil;
@@ -42,6 +43,13 @@ class ContentCompositionListener
     #[AsCallback(table: 'tl_page', target: 'list.operations.articles.button')]
     public function renderPageArticlesOperation(DataContainerOperation $operation): void
     {
+        // Disable the articles link in the modal window
+        if (Input::get('popup')) {
+            $operation->setHtml('');
+
+            return;
+        }
+
         if (!$this->security->isGranted(ContaoCorePermissions::USER_CAN_ACCESS_MODULE, 'article')) {
             $operation->setHtml('');
 


### PR DESCRIPTION
The [Page Permissions](https://github.com/contao/contao/pull/6675/files#diff-b4f7341b29e12a41d5657cc301384e6f97262a73399555d8e0cbef0a6963af8aL60) removed the `NULL` checks on `icon` of the `tl_page.list.operations.article`, which caused https://github.com/contao/contao/issues/2787 / https://github.com/contao/contao/pull/2785 to resurface. Which is what I probably tried to fix in https://github.com/contao/contao/pull/6125 as well.

I debugged the origin, and it is actually because the `tl_page` DCA file dynamically unsets the `articles` operation, but the `ContentCompositionListener` still adds the button callback (and therefore the operation itself). "Unsetting" the operation in the listener is the correct solution imho.