### PR TITLE
Allow insert tags in link titles

### DIFF
--- a/core-bundle/contao/templates/_new/content_element/hyperlink.html.twig
+++ b/core-bundle/contao/templates/_new/content_element/hyperlink.html.twig
@@ -6,7 +6,7 @@
         {# Link wrapping text #}
         {% block text_link %}
             {{- text_before -}}
-            <a{{ attrs(link_attributes|default) }}>{{ link_text }}</a>
+            <a{{ attrs(link_attributes|default) }}>{{ link_text|insert_tag }}</a>
             {{- text_after -}}
         {% endblock %}
     {% else %}


### PR DESCRIPTION
I often use `{{link_url::42}}` for the page link, and then use `{{link_title::42}}` for the link title. That does not seem to work anymore with the Twig templates.

Not sure if that should also work on the link title (the HTML attribute) and how that would be accomplished in `attrs`...