### PR TITLE
Revert "Allow data-lightbox in TinyMCE by default"

### DIFF
--- a/core-bundle/src/Resources/contao/templates/backend/be_tinyMCE.html5
+++ b/core-bundle/src/Resources/contao/templates/backend/be_tinyMCE.html5
@@ -53,7 +53,7 @@ window.tinymce && tinymce.init({
   <?php $this->endblock(); ?>
 
   <?php $this->block('valid_elements'); ?>
-    extended_valid_elements: 'q[cite|class|title],article,section,hgroup,figure,figcaption,a[rel|rev|charset|hreflang|tabindex|accesskey|type|name|href|target|title|class|onfocus|onblur|data-lightbox]',
+    extended_valid_elements: 'q[cite|class|title],article,section,hgroup,figure,figcaption',
   <?php $this->endblock(); ?>
 
   <?php $this->block('menubar'); ?>


### PR DESCRIPTION
This reverts commit 46339e0074e5ea9eb0b8b9c6f886475a825f510f.

Fixes #6618

It is unclear why this was necessary in the first place. All attributes, including `data-lightbox`, `id`, `rel` and `style` for example, work out of the box with our current default TinyMCE configuration.
