### PR TITLE
Redirect in the `BackendConfirm` controller if there is no `INVALID_TOKEN_URL` in the session

### DIFF
--- a/core-bundle/src/Resources/contao/controllers/BackendConfirm.php
+++ b/core-bundle/src/Resources/contao/controllers/BackendConfirm.php
@@ -50,6 +50,11 @@ class BackendConfirm extends Backend
 	{
 		$objSession = System::getContainer()->get('session');
 
+		if (!$objSession->has('INVALID_TOKEN_URL'))
+		{
+			$this->redirect(System::getContainer()->get('router')->generate('contao_backend'));
+		}
+
 		// Redirect to the back end home page
 		if (Input::post('FORM_SUBMIT') == 'invalid_token_url')
 		{


### PR DESCRIPTION
Fixes #6104
