### PR TITLE
Add sitemap information to the `tl_page.robots` help text

### DIFF
--- a/core-bundle/contao/languages/en/tl_page.xlf
+++ b/core-bundle/contao/languages/en/tl_page.xlf
@@ -54,7 +54,7 @@
         <source>Robots tag</source>
       </trans-unit>
       <trans-unit id="tl_page.robots.1">
-        <source>Here you can define how search engines handle the page.</source>
+        <source>Here you can define how search engines handle the page and whether the page should appear in the sitemap.xml if necessary.</source>
       </trans-unit>
       <trans-unit id="tl_page.maintenanceMode.0">
         <source>Maintenance mode</source>

--- a/core-bundle/contao/languages/en/tl_page.xlf
+++ b/core-bundle/contao/languages/en/tl_page.xlf
@@ -54,7 +54,7 @@
         <source>Robots tag</source>
       </trans-unit>
       <trans-unit id="tl_page.robots.1">
-        <source>Here you can define how search engines handle the page and whether the page should appear in the sitemap.xml if necessary.</source>
+        <source>Here you can define how search engines handle the page. The setting also determines whether the page appears in the &lt;code&gt;sitemap.xml&lt;/code&gt; file or not.</source>
       </trans-unit>
       <trans-unit id="tl_page.maintenanceMode.0">
         <source>Maintenance mode</source>


### PR DESCRIPTION
As discussed in https://github.com/contao/contao/issues/6647 I added more information about the sitemaps to the robots field in tl_page 
