### PR TITLE
Add the `TemplateTrait::inlineStyle()` method

### DIFF
--- a/core-bundle/contao/library/Contao/TemplateTrait.php
+++ b/core-bundle/contao/library/Contao/TemplateTrait.php
@@ -194,7 +194,7 @@ trait TemplateTrait
 	/**
 	 * Adds a CSP hash for a given inline style and also adds the 'unsafe-hashes' source to the directive automatically.
 	 */
-	public function cspInlineStyle(string $style, string $algorithm = 'sha384'): string
+	public function inlineStyle(string $style, string $algorithm = 'sha384'): string
 	{
 		$responseContext = System::getContainer()->get('contao.routing.response_context_accessor')->getResponseContext();
 

--- a/core-bundle/contao/library/Contao/TemplateTrait.php
+++ b/core-bundle/contao/library/Contao/TemplateTrait.php
@@ -192,6 +192,26 @@ trait TemplateTrait
 	}
 
 	/**
+	 * Adds a CSP hash for a given inline style and also adds the 'unsafe-hashes' source to the directive automatically.
+	 */
+	public function cspInlineStyle(string $style, string $algorithm = 'sha384'): string
+	{
+		$responseContext = System::getContainer()->get('contao.routing.response_context_accessor')->getResponseContext();
+
+		if ($responseContext?->has(CspHandler::class))
+		{
+			/** @var CspHandler $csp */
+			$csp = $responseContext->get(CspHandler::class);
+			$csp
+				->addHash('style-src', $style, $algorithm)
+				->addSource('style-src', "'unsafe-hashes'")
+			;
+		}
+
+		return $style;
+	}
+
+	/**
 	 * Render a figure
 	 *
 	 * The provided configuration array is used to configure a FigureBuilder.

--- a/core-bundle/contao/templates/forms/form_captcha.html5
+++ b/core-bundle/contao/templates/forms/form_captcha.html5
@@ -18,9 +18,7 @@
   <input type="hidden" name="<?= $this->name ?>_hash" value="<?= $this->hasErrors() ? $this->getHash() : '' ?>">
 
   <?php if (!$this->hasErrors()): ?>
-    <?php $this->addCspHash('style-src', 'display:none'); ?>
-    <?php $this->addCspSource('style-src', 'unsafe-hashes'); ?>
-    <div style="display:none">
+    <div style="<?= $this->cspInlineStyle('display:none') ?>">
       <label for="ctrl_<?= $this->id ?>_hp">Do not fill in this field</label>
       <input type="text" name="<?= $this->name ?>_name" id="ctrl_<?= $this->id ?>_hp" value="">
     </div>

--- a/core-bundle/contao/templates/forms/form_captcha.html5
+++ b/core-bundle/contao/templates/forms/form_captcha.html5
@@ -18,7 +18,7 @@
   <input type="hidden" name="<?= $this->name ?>_hash" value="<?= $this->hasErrors() ? $this->getHash() : '' ?>">
 
   <?php if (!$this->hasErrors()): ?>
-    <div style="<?= $this->cspInlineStyle('display:none') ?>">
+    <div style="<?= $this->inlineStyle('display:none') ?>">
       <label for="ctrl_<?= $this->id ?>_hp">Do not fill in this field</label>
       <input type="text" name="<?= $this->name ?>_name" id="ctrl_<?= $this->id ?>_hp" value="">
     </div>

--- a/core-bundle/contao/templates/modules/mod_two_factor.html5
+++ b/core-bundle/contao/templates/modules/mod_two_factor.html5
@@ -20,9 +20,7 @@
         </div>
         <div class="widget">
           <p><?= $this->trans('MSC.twoFactorTextCode') ?></p>
-          <?php $this->addCspHash('style-src', 'word-break:break-all'); ?>
-          <?php $this->addCspSource('style-src', 'unsafe-hashes'); ?>
-          <code style="word-break:break-all"><?= $this->secret ?></code>
+          <code style="<?= $this->cspInlineStyle('word-break:break-all') ?>"><?= $this->secret ?></code>
         </div>
         <div class="widget widget-text">
           <label for="verify"><?= $this->trans('MSC.twoFactorVerification') ?></label>

--- a/core-bundle/contao/templates/modules/mod_two_factor.html5
+++ b/core-bundle/contao/templates/modules/mod_two_factor.html5
@@ -20,7 +20,7 @@
         </div>
         <div class="widget">
           <p><?= $this->trans('MSC.twoFactorTextCode') ?></p>
-          <code style="<?= $this->cspInlineStyle('word-break:break-all') ?>"><?= $this->secret ?></code>
+          <code style="<?= $this->inlineStyle('word-break:break-all') ?>"><?= $this->secret ?></code>
         </div>
         <div class="widget widget-text">
           <label for="verify"><?= $this->trans('MSC.twoFactorVerification') ?></label>

--- a/core-bundle/src/Routing/ResponseContext/Csp/CspHandler.php
+++ b/core-bundle/src/Routing/ResponseContext/Csp/CspHandler.php
@@ -88,9 +88,8 @@ final class CspHandler
             return $this;
         }
 
-        $hash = base64_encode(hash($algorithm, $script, true));
-
-        $this->signatures[$directive][] = $algorithm.'-'.$hash;
+        $this->signatures[$directive][] = $algorithm.'-'.base64_encode(hash($algorithm, $script, true));
+        $this->signatures[$directive] = array_unique($this->signatures[$directive]);
 
         return $this;
     }

--- a/core-bundle/tests/Contao/TemplateTest.php
+++ b/core-bundle/tests/Contao/TemplateTest.php
@@ -491,7 +491,7 @@ class TemplateTest extends TestCase
         $script = 'this.form.requestSubmit()';
         $algorithm = 'sha384';
 
-        (new FrontendTemplate())->addCspHash('script-src', 'this.form.requestSubmit()', $algorithm);
+        (new FrontendTemplate())->addCspHash('script-src', $script, $algorithm);
 
         $response = new Response();
         $cspHandler->applyHeaders($response);
@@ -499,5 +499,38 @@ class TemplateTest extends TestCase
         $expectedHash = base64_encode(hash($algorithm, $script, true));
 
         $this->assertSame(sprintf("script-src 'self' '%s-%s'", $algorithm, $expectedHash), $response->headers->get('Content-Security-Policy'));
+    }
+
+    public function testAddsCspInlineStyleHash(): void
+    {
+        $directives = new DirectiveSet(new PolicyManager());
+        $directives->setLevel1Fallback(false);
+        $directives->setDirective('style-src', "'self'");
+
+        $cspHandler = new CspHandler($directives);
+        $responseContext = (new ResponseContext())->add($cspHandler);
+
+        $responseContextAccessor = $this->createMock(ResponseContextAccessor::class);
+        $responseContextAccessor
+            ->expects($this->once())
+            ->method('getResponseContext')
+            ->willReturn($responseContext)
+        ;
+
+        System::getContainer()->set('contao.routing.response_context_accessor', $responseContextAccessor);
+        System::getContainer()->set('request_stack', new RequestStack());
+
+        $style = 'display:none';
+        $algorithm = 'sha384';
+
+        $result = (new FrontendTemplate())->cspInlineStyle($style, $algorithm);
+
+        $response = new Response();
+        $cspHandler->applyHeaders($response);
+
+        $expectedHash = base64_encode(hash($algorithm, $style, true));
+
+        $this->assertSame($style, $result);
+        $this->assertSame(sprintf("style-src 'self' 'unsafe-hashes' '%s-%s'", $algorithm, $expectedHash), $response->headers->get('Content-Security-Policy'));
     }
 }

--- a/core-bundle/tests/Contao/TemplateTest.php
+++ b/core-bundle/tests/Contao/TemplateTest.php
@@ -523,7 +523,7 @@ class TemplateTest extends TestCase
         $style = 'display:none';
         $algorithm = 'sha384';
 
-        $result = (new FrontendTemplate())->cspInlineStyle($style, $algorithm);
+        $result = (new FrontendTemplate())->inlineStyle($style, $algorithm);
 
         $response = new Response();
         $cspHandler->applyHeaders($response);

--- a/core-bundle/tests/Twig/FragmentTemplateTest.php
+++ b/core-bundle/tests/Twig/FragmentTemplateTest.php
@@ -78,7 +78,7 @@ class FragmentTemplateTest extends TestCase
 
     public function provideIllegalParentMethods(): \Generator
     {
-        $excluded = ['__construct', '__set', '__get', '__isset', 'setData', 'getData', 'setName', 'getName', 'getResponse', 'addCspSource', 'addCspHash', 'cspInlineStyle', 'nonce', 'attr'];
+        $excluded = ['__construct', '__set', '__get', '__isset', 'setData', 'getData', 'setName', 'getName', 'getResponse', 'addCspSource', 'addCspHash', 'inlineStyle', 'nonce', 'attr'];
         $parent = (new \ReflectionClass(FragmentTemplate::class))->getParentClass();
 
         foreach ($parent->getMethods(\ReflectionMethod::IS_PUBLIC) as $method) {

--- a/core-bundle/tests/Twig/FragmentTemplateTest.php
+++ b/core-bundle/tests/Twig/FragmentTemplateTest.php
@@ -78,7 +78,7 @@ class FragmentTemplateTest extends TestCase
 
     public function provideIllegalParentMethods(): \Generator
     {
-        $excluded = ['__construct', '__set', '__get', '__isset', 'setData', 'getData', 'setName', 'getName', 'getResponse', 'addCspSource', 'addCspHash', 'nonce', 'attr'];
+        $excluded = ['__construct', '__set', '__get', '__isset', 'setData', 'getData', 'setName', 'getName', 'getResponse', 'addCspSource', 'addCspHash', 'cspInlineStyle', 'nonce', 'attr'];
         $parent = (new \ReflectionClass(FragmentTemplate::class))->getParentClass();
 
         foreach ($parent->getMethods(\ReflectionMethod::IS_PUBLIC) as $method) {


### PR DESCRIPTION
This introduces a `cspInlineStyle` method as discussed.

This PR also fixes two bugs that occur if you - for example - have two forms with Contao's captcha on the same page:

* Previously this would have resulted in two  `'unsafe-hashes'` sources in the response CSP header.
* Previously this would have resulted in two of the same hashes in the response CSP header.
