### PR TITLE
Add a basic entity for zero-width whitespaces

### DIFF
--- a/core-bundle/contao/library/Contao/StringUtil.php
+++ b/core-bundle/contao/library/Contao/StringUtil.php
@@ -228,7 +228,7 @@ class StringUtil
 	 */
 	public static function convertBasicEntities($strBuffer)
 	{
-		return str_replace(array('&amp;', '&lt;', '&gt;', '&nbsp;', '&shy;', '&#8203;'), array('[&]', '[lt]', '[gt]', '[nbsp]', '[-]', '[ ]'), $strBuffer);
+		return str_replace(array('&amp;', '&lt;', '&gt;', '&nbsp;', '&shy;', '&ZeroWidthSpace;'), array('[&]', '[lt]', '[gt]', '[nbsp]', '[-]', '[zwsp]'), $strBuffer);
 	}
 
 	/**
@@ -240,7 +240,7 @@ class StringUtil
 	 */
 	public static function restoreBasicEntities($strBuffer)
 	{
-		return str_replace(array('[&]', '[&amp;]', '[lt]', '[gt]', '[nbsp]', '[-]', '[ ]'), array('&amp;', '&amp;', '&lt;', '&gt;', '&nbsp;', '&shy;', '&#8203;'), $strBuffer);
+		return str_replace(array('[&]', '[&amp;]', '[lt]', '[gt]', '[nbsp]', '[-]', '[zwsp]'), array('&amp;', '&amp;', '&lt;', '&gt;', '&nbsp;', '&shy;', '&ZeroWidthSpace;'), $strBuffer);
 	}
 
 	/**

--- a/core-bundle/contao/library/Contao/StringUtil.php
+++ b/core-bundle/contao/library/Contao/StringUtil.php
@@ -228,7 +228,7 @@ class StringUtil
 	 */
 	public static function convertBasicEntities($strBuffer)
 	{
-		return str_replace(array('&amp;', '&lt;', '&gt;', '&nbsp;', '&shy;'), array('[&]', '[lt]', '[gt]', '[nbsp]', '[-]'), $strBuffer);
+		return str_replace(array('&amp;', '&lt;', '&gt;', '&nbsp;', '&shy;', '&#8203;'), array('[&]', '[lt]', '[gt]', '[nbsp]', '[-]', '[ ]'), $strBuffer);
 	}
 
 	/**
@@ -240,7 +240,7 @@ class StringUtil
 	 */
 	public static function restoreBasicEntities($strBuffer)
 	{
-		return str_replace(array('[&]', '[&amp;]', '[lt]', '[gt]', '[nbsp]', '[-]'), array('&amp;', '&amp;', '&lt;', '&gt;', '&nbsp;', '&shy;'), $strBuffer);
+		return str_replace(array('[&]', '[&amp;]', '[lt]', '[gt]', '[nbsp]', '[-]', '[ ]'), array('&amp;', '&amp;', '&lt;', '&gt;', '&nbsp;', '&shy;', '&#8203;'), $strBuffer);
 	}
 
 	/**


### PR DESCRIPTION
A zero-width whitespace is as useful as `[-]` but does not add a dash if the word breaks.

I have no idea why basic entities work out of the box in Twig and if this would add support for it as well, maybe @m-vo can shed some light on that.

Also, would obviously be happy to have this in 5.3, but 🤷 😬 