### PR TITLE
Normalize the Twig CSP method names

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -84,7 +84,7 @@
         "matthiasmullie/minify": "^1.3",
         "monolog/monolog": "^2.0",
         "nelmio/cors-bundle": "^2.0.1",
-        "nelmio/security-bundle": "^2.12 || ^3.0",
+        "nelmio/security-bundle": "^3.0",
         "nikic/php-parser": "^4.9",
         "nyholm/psr7": "^1.2",
         "paragonie/constant_time_encoding": "^2.2",

--- a/core-bundle/composer.json
+++ b/core-bundle/composer.json
@@ -83,7 +83,7 @@
         "matthiasmullie/minify": "^1.3",
         "monolog/monolog": "^2.0",
         "nelmio/cors-bundle": "^2.0.1",
-        "nelmio/security-bundle": "^2.12 || ^3.0",
+        "nelmio/security-bundle": "^3.0",
         "nikic/php-parser": "^4.9",
         "nyholm/psr7": "^1.2",
         "paragonie/constant_time_encoding": "^2.2",

--- a/core-bundle/config/services.yaml
+++ b/core-bundle/config/services.yaml
@@ -1132,6 +1132,7 @@ services:
         class: Contao\CoreBundle\Twig\Runtime\CspRuntime
         arguments:
             - '@contao.routing.response_context_accessor'
+            - '@?nelmio_security.csp.runtime'
 
     contao.twig.extension:
         class: Contao\CoreBundle\Twig\Extension\ContaoExtension

--- a/core-bundle/contao/templates/twig/component/_list.html.twig
+++ b/core-bundle/contao/templates/twig/component/_list.html.twig
@@ -94,7 +94,7 @@
     {% if randomize_order or add_pagination or limit_elements %}
         {% block list_script %}
             {% add "list_script" to body %}
-                <script{{ attrs(script_attributes|default).setIfExists('nonce', contao_csp_nonce('script-src')) }}>
+                <script{{ attrs(script_attributes|default).setIfExists('nonce', csp_nonce('script-src')) }}>
                     {# Shuffle lists #}
                     document.querySelectorAll('*[data-list-random]').forEach(list => {
                         {# Shuffle order of children by appending them at a random position. #}

--- a/core-bundle/contao/templates/twig/component/_splash_screen.html.twig
+++ b/core-bundle/contao/templates/twig/component/_splash_screen.html.twig
@@ -41,7 +41,7 @@
 
     {% block splash_screen_script %}
         {% add "splash_screen_script" to body %}
-            <script{{ attrs(script_attributes|default).setIfExists('nonce', contao_csp_nonce('script-src')) }}>
+            <script{{ attrs(script_attributes|default).setIfExists('nonce', csp_nonce('script-src')) }}>
                 document.querySelectorAll('*[data-splash-screen]').forEach(button => {
                     button.addEventListener('click', () => {
                         button.insertAdjacentHTML('afterend', button.querySelector('template').innerHTML);

--- a/core-bundle/contao/templates/twig/component/_table.html.twig
+++ b/core-bundle/contao/templates/twig/component/_table.html.twig
@@ -149,7 +149,7 @@
     {% block table_script %}
         {% if sorting %}
             {% add "tablesort_script" to head %}
-                <script{{ attrs(script_attributes|default).setIfExists('nonce', contao_csp_nonce('script-src')) }}>
+                <script{{ attrs(script_attributes|default).setIfExists('nonce', csp_nonce('script-src')) }}>
                     {
                         const instances = new WeakMap();
 

--- a/core-bundle/contao/templates/twig/content_element/_video.html.twig
+++ b/core-bundle/contao/templates/twig/content_element/_video.html.twig
@@ -19,7 +19,7 @@
                     {% set iframe_attrs = attrs({width, height, src: source.url, allowfullscreen: true})
                         .mergeWith(iframe_attrs|default)
                     %}
-                    {% do add_csp_source('frame-src', iframe_attrs.src) %}
+                    {% do csp_source('frame-src', iframe_attrs.src) %}
                     <iframe{{ iframe_attrs }}></iframe>
                 {% endblock %}
             {% endif %}

--- a/core-bundle/contao/templates/twig/content_element/player.html.twig
+++ b/core-bundle/contao/templates/twig/content_element/player.html.twig
@@ -21,7 +21,7 @@
 {% block media %}
     <{{ figure.media.type }}{{ figure.media.attributes }}>
         {% for source_attributes in figure.media.sources %}
-            {% do add_csp_source('media-src', source_attributes.src) %}
+            {% do csp_source('media-src', source_attributes.src) %}
             <source{{ source_attributes }}>
         {% endfor %}
     </{{ figure.media.type }}>

--- a/core-bundle/contao/templates/twig/content_element/toplink.html.twig
+++ b/core-bundle/contao/templates/twig/content_element/toplink.html.twig
@@ -18,7 +18,7 @@
     {% block script %}
         {% if not as_editor_view %}
             {% add "toplink_script" to body %}
-                <script{{ attrs(script_attributes|default).setIfExists('nonce', contao_csp_nonce('script-src')) }}>
+                <script{{ attrs(script_attributes|default).setIfExists('nonce', csp_nonce('script-src')) }}>
                     document.querySelectorAll('*[data-toplink]').forEach(link => {
                         link.href = location.href;
                         link.hash = '#top';

--- a/core-bundle/src/Twig/Extension/ContaoExtension.php
+++ b/core-bundle/src/Twig/Extension/ContaoExtension.php
@@ -205,16 +205,17 @@ final class ContaoExtension extends AbstractExtension
                 [FragmentRuntime::class, 'renderContent'],
                 ['is_safe' => ['html']],
             ),
+            // Overwrites the 'csp_nonce' method from nelmio/security-bundle
             new TwigFunction(
-                'contao_csp_nonce',
+                'csp_nonce',
                 [CspRuntime::class, 'getNonce'],
             ),
             new TwigFunction(
-                'add_csp_source',
+                'csp_source',
                 [CspRuntime::class, 'addSource'],
             ),
             new TwigFunction(
-                'add_csp_hash',
+                'csp_hash',
                 [CspRuntime::class, 'addHash'],
             ),
         ];

--- a/core-bundle/tests/Twig/Extension/ContaoExtensionTest.php
+++ b/core-bundle/tests/Twig/Extension/ContaoExtensionTest.php
@@ -96,9 +96,9 @@ class ContaoExtensionTest extends TestCase
             'prefix_url' => [],
             'frontend_module' => ['html'],
             'content_element' => ['html'],
-            'contao_csp_nonce' => [],
-            'add_csp_source' => [],
-            'add_csp_hash' => [],
+            'csp_nonce' => [],
+            'csp_source' => [],
+            'csp_hash' => [],
         ];
 
         $functions = $this->getContaoExtension()->getFunctions();


### PR DESCRIPTION
As discussed on Slack this normalises the Twig CSP method names.

The reason why the nonce method was called `contao_csp_nonce` and not `csp_nonce` originally is that `nelmio/security-bundle` provides its own `csp_nonce` method. This PR renames the `contao_csp_nonce` method now to `csp_nonce`, overwriting the `csp_nonce` method from Nelmio - but forwarding to Nelmio's `CSPRuntime` if the method is called without a Contao response context. This also requires the minimum version of `nelmio/security-bundle` to be raised to `^3.0`, since the `CSPRuntime` service will not exist otherwise.