### PR TITLE
Limit the CSP header size to avoid server errors

### DIFF
--- a/core-bundle/config/listener.yaml
+++ b/core-bundle/config/listener.yaml
@@ -489,7 +489,7 @@ services:
             - '@contao.security.token_checker'
             - '@twig'
             - '@router'
-            - '@contao.routing.response_context.csp.handler_factory'
+            - '@contao.routing.response_context.csp_handler_factory'
             - '%contao.preview_script%'
         tags:
             - kernel.event_listener

--- a/core-bundle/config/listener.yaml
+++ b/core-bundle/config/listener.yaml
@@ -489,7 +489,7 @@ services:
             - '@contao.security.token_checker'
             - '@twig'
             - '@router'
-            - '@contao.csp.parser'
+            - '@contao.routing.response_context.csp.handler_factory'
             - '%contao.preview_script%'
         tags:
             - kernel.event_listener

--- a/core-bundle/config/services.yaml
+++ b/core-bundle/config/services.yaml
@@ -806,8 +806,17 @@ services:
             - '@contao.string.html_decoder'
             - '@request_stack'
             - '@contao.insert_tag.parser'
-            - '@contao.csp.parser'
+            - '@contao.routing.response_context.csp.handler_factory'
             - '@router'
+
+    contao.routing.response_context.csp.handler_factory:
+        class: Contao\CoreBundle\Routing\ResponseContext\Csp\CspHandlerFactory
+        arguments:
+            - '@contao.csp.parser'
+            - 4096
+            - '@?logger'
+        tags:
+            - { name: monolog.logger, channel: contao.error }
 
     contao.routing.route_404_provider:
         class: Contao\CoreBundle\Routing\Route404Provider

--- a/core-bundle/config/services.yaml
+++ b/core-bundle/config/services.yaml
@@ -790,6 +790,15 @@ services:
             - '@contao.routing.page_registry'
             - '@?logger'
 
+    contao.routing.response_context.csp_handler_factory:
+        class: Contao\CoreBundle\Routing\ResponseContext\Csp\CspHandlerFactory
+        arguments:
+            - '@contao.csp.parser'
+            - 4096
+            - '@?logger'
+        tags:
+            - { name: monolog.logger, channel: contao.error }
+
     contao.routing.response_context_accessor:
         class: Contao\CoreBundle\Routing\ResponseContext\ResponseContextAccessor
         public: true
@@ -808,15 +817,6 @@ services:
             - '@contao.insert_tag.parser'
             - '@contao.routing.response_context.csp_handler_factory'
             - '@router'
-
-    contao.routing.response_context.csp_handler_factory:
-        class: Contao\CoreBundle\Routing\ResponseContext\Csp\CspHandlerFactory
-        arguments:
-            - '@contao.csp.parser'
-            - 4096
-            - '@?logger'
-        tags:
-            - { name: monolog.logger, channel: contao.error }
 
     contao.routing.route_404_provider:
         class: Contao\CoreBundle\Routing\Route404Provider

--- a/core-bundle/config/services.yaml
+++ b/core-bundle/config/services.yaml
@@ -806,10 +806,10 @@ services:
             - '@contao.string.html_decoder'
             - '@request_stack'
             - '@contao.insert_tag.parser'
-            - '@contao.routing.response_context.csp.handler_factory'
+            - '@contao.routing.response_context.csp_handler_factory'
             - '@router'
 
-    contao.routing.response_context.csp.handler_factory:
+    contao.routing.response_context.csp_handler_factory:
         class: Contao\CoreBundle\Routing\ResponseContext\Csp\CspHandlerFactory
         arguments:
             - '@contao.csp.parser'

--- a/core-bundle/config/services.yaml
+++ b/core-bundle/config/services.yaml
@@ -794,7 +794,7 @@ services:
         class: Contao\CoreBundle\Routing\ResponseContext\Csp\CspHandlerFactory
         arguments:
             - '@contao.csp.parser'
-            - 4096
+            - 8192
             - '@?logger'
         tags:
             - { name: monolog.logger, channel: contao.error }

--- a/core-bundle/config/services.yaml
+++ b/core-bundle/config/services.yaml
@@ -794,7 +794,7 @@ services:
         class: Contao\CoreBundle\Routing\ResponseContext\Csp\CspHandlerFactory
         arguments:
             - '@contao.csp.parser'
-            - 8192
+            - 3072
             - '@?logger'
         tags:
             - { name: monolog.logger, channel: contao.error }

--- a/core-bundle/src/DependencyInjection/Configuration.php
+++ b/core-bundle/src/DependencyInjection/Configuration.php
@@ -875,6 +875,10 @@ class Configuration implements ConfigurationInterface
                         )
                     ->end()
                 ->end()
+                ->integerNode('max_header_size')
+                    ->info('The CSP header can get pretty long when adding lots of automatically calculated hashes. Contao will automatically remove signatures in order to prevent the CSP header to exceed the configured limit. This will affect the functionality of affected URLs but ensure you do not run into 500 server errors.')
+                    ->defaultValue(4096) // Nginx default maximum header length
+                ->end()
             ->end()
         ;
     }

--- a/core-bundle/src/DependencyInjection/Configuration.php
+++ b/core-bundle/src/DependencyInjection/Configuration.php
@@ -876,8 +876,8 @@ class Configuration implements ConfigurationInterface
                     ->end()
                 ->end()
                 ->integerNode('max_header_size')
-                    ->info('The CSP header can get pretty long when adding lots of automatically calculated hashes. Contao will automatically remove signatures in order to prevent the CSP header to exceed the configured limit. This will affect the functionality of affected URLs but ensure you do not run into 500 server errors.')
-                    ->defaultValue(3072) // Most browsers have a limit of 8-16kb for **all** headers in total
+                    ->info('Do not increase this value beyond the allowed response headers size of your web server, as this will result in a 500 server error.')
+                    ->defaultValue(3072)
                 ->end()
             ->end()
         ;

--- a/core-bundle/src/DependencyInjection/Configuration.php
+++ b/core-bundle/src/DependencyInjection/Configuration.php
@@ -876,7 +876,7 @@ class Configuration implements ConfigurationInterface
                     ->end()
                 ->end()
                 ->integerNode('max_header_size')
-                    ->info('Do not increase this value beyond the allowed response headers size of your web server, as this will result in a 500 server error.')
+                    ->info('Do not increase this value beyond the allowed response header size of your web server, as this will result in a 500 server error.')
                     ->defaultValue(3072)
                 ->end()
             ->end()

--- a/core-bundle/src/DependencyInjection/Configuration.php
+++ b/core-bundle/src/DependencyInjection/Configuration.php
@@ -877,7 +877,7 @@ class Configuration implements ConfigurationInterface
                 ->end()
                 ->integerNode('max_header_size')
                     ->info('The CSP header can get pretty long when adding lots of automatically calculated hashes. Contao will automatically remove signatures in order to prevent the CSP header to exceed the configured limit. This will affect the functionality of affected URLs but ensure you do not run into 500 server errors.')
-                    ->defaultValue(4096) // Nginx default maximum header length
+                    ->defaultValue(8192) // Nginx default maximum header length
                 ->end()
             ->end()
         ;

--- a/core-bundle/src/DependencyInjection/Configuration.php
+++ b/core-bundle/src/DependencyInjection/Configuration.php
@@ -877,7 +877,7 @@ class Configuration implements ConfigurationInterface
                 ->end()
                 ->integerNode('max_header_size')
                     ->info('The CSP header can get pretty long when adding lots of automatically calculated hashes. Contao will automatically remove signatures in order to prevent the CSP header to exceed the configured limit. This will affect the functionality of affected URLs but ensure you do not run into 500 server errors.')
-                    ->defaultValue(8192) // Nginx default maximum header length
+                    ->defaultValue(3072) // Most browsers have a limit of 8-16kb for **all** headers in total
                 ->end()
             ->end()
         ;

--- a/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
+++ b/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
@@ -540,8 +540,8 @@ class ContaoCoreExtension extends Extension implements PrependExtensionInterface
 
     private function handleCspConfig(array $config, ContainerBuilder $container): void
     {
-        if ($container->hasDefinition('contao.routing.response_context.csp.handler_factory')) {
-            $factory = $container->getDefinition('contao.routing.response_context.csp.handler_factory');
+        if ($container->hasDefinition('contao.routing.response_context.csp_handler_factory')) {
+            $factory = $container->getDefinition('contao.routing.response_context.csp_handler_factory');
             $factory->setArgument(1, $config['csp']['max_header_size']);
         }
 

--- a/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
+++ b/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
@@ -540,11 +540,14 @@ class ContaoCoreExtension extends Extension implements PrependExtensionInterface
 
     private function handleCspConfig(array $config, ContainerBuilder $container): void
     {
-        if (!$container->hasDefinition('contao.csp.wysiwyg_style_processor')) {
-            return;
+        if ($container->hasDefinition('contao.routing.response_context.csp.handler_factory')) {
+            $factory = $container->getDefinition('contao.routing.response_context.csp.handler_factory');
+            $factory->setArgument(1, $config['csp']['max_header_size']);
         }
 
-        $processor = $container->getDefinition('contao.csp.wysiwyg_style_processor');
-        $processor->setArgument(0, $config['csp']['allowed_inline_styles']);
+        if ($container->hasDefinition('contao.csp.wysiwyg_style_processor')) {
+            $processor = $container->getDefinition('contao.csp.wysiwyg_style_processor');
+            $processor->setArgument(0, $config['csp']['allowed_inline_styles']);
+        }
     }
 }

--- a/core-bundle/src/EventListener/PreviewToolbarListener.php
+++ b/core-bundle/src/EventListener/PreviewToolbarListener.php
@@ -12,8 +12,8 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\EventListener;
 
-use Contao\CoreBundle\Csp\CspParser;
 use Contao\CoreBundle\Routing\ResponseContext\Csp\CspHandler;
+use Contao\CoreBundle\Routing\ResponseContext\Csp\CspHandlerFactory;
 use Contao\CoreBundle\Routing\ScopeMatcher;
 use Contao\CoreBundle\Security\Authentication\Token\TokenChecker;
 use Symfony\Component\HttpFoundation\Request;
@@ -40,7 +40,7 @@ class PreviewToolbarListener
         private readonly TokenChecker $tokenChecker,
         private readonly TwigEnvironment $twig,
         private readonly RouterInterface $router,
-        private readonly CspParser $cspParser,
+        private readonly CspHandlerFactory $cspHandlerFactory,
         private readonly string $previewScript = '',
     ) {
     }
@@ -106,9 +106,10 @@ class PreviewToolbarListener
             $cspHeader = $response->headers->get('Content-Security-Policy', '');
         }
 
-        $directives = $this->cspParser->parseHeader($cspHeader);
-        $directives->setLevel1Fallback(false);
+        $cspHandler = $this->cspHandlerFactory->create($cspHeader);
+        $cspHandler->getDirectives()->setLevel1Fallback(false);
+        $cspHandler->setReportOnly($reportOnly ?? false);
 
-        return new CspHandler($directives, $reportOnly ?? false);
+        return $cspHandler;
     }
 }

--- a/core-bundle/src/Routing/ResponseContext/Csp/CspHandler.php
+++ b/core-bundle/src/Routing/ResponseContext/Csp/CspHandler.php
@@ -37,7 +37,7 @@ final class CspHandler
 
     public function __construct(
         private DirectiveSet $directives,
-        private readonly int $maxHeaderLength = 4096,
+        private readonly int $maxHeaderLength = 8192,
         private readonly LoggerInterface|null $logger = null,
     ) {
     }

--- a/core-bundle/src/Routing/ResponseContext/Csp/CspHandler.php
+++ b/core-bundle/src/Routing/ResponseContext/Csp/CspHandler.php
@@ -149,12 +149,6 @@ final class CspHandler
 
     public function applyHeaders(Response $response, Request|null $request = null): void
     {
-        $signatures = $this->signatures;
-
-        foreach ($this->directiveNonces as $name => $nonce) {
-            $signatures[$name][] = 'nonce-'.$nonce;
-        }
-
         $headerValue = $this->buildHeaderConsideringMaxlength($request);
 
         if (!$headerValue) {

--- a/core-bundle/src/Routing/ResponseContext/Csp/CspHandler.php
+++ b/core-bundle/src/Routing/ResponseContext/Csp/CspHandler.php
@@ -37,7 +37,7 @@ final class CspHandler
 
     public function __construct(
         private DirectiveSet $directives,
-        private readonly int $maxHeaderLength = 8192,
+        private readonly int $maxHeaderLength = 3072,
         private readonly LoggerInterface|null $logger = null,
     ) {
     }
@@ -85,7 +85,7 @@ final class CspHandler
         return $this->nonce;
     }
 
-    public function addHash(string $directive, string $script, string $algorithm = 'sha384'): self
+    public function addHash(string $directive, string $script, string $algorithm = 'sha256'): self
     {
         if (!\in_array($directive, self::$validHashDirectives, true)) {
             throw new \InvalidArgumentException('Invalid directive');

--- a/core-bundle/src/Routing/ResponseContext/Csp/CspHandler.php
+++ b/core-bundle/src/Routing/ResponseContext/Csp/CspHandler.php
@@ -175,10 +175,9 @@ final class CspHandler
             return $headerValue;
         }
 
-        // Now let's try to not cause a 500 Internal Server error by removing some signatures. Let's remove some style-src
-        // signatures first because they likely have the least impact.
+        // Now let's try to not cause a 500 Internal Server error by removing some signatures. Let's remove some
+        // style-src signatures first because they likely have the least impact.
         $removedStyleSrc = $this->reduceHashSignatures('style-src');
-
         $headerValue = $this->buildHeaderValue($request);
 
         if (\strlen($headerValue) < $this->maxHeaderLength) {
@@ -187,9 +186,8 @@ final class CspHandler
             return $headerValue;
         }
 
-        // We still exceed our limit, we have to reduce script-src now.
+        // If we still exceed the limit, we have to reduce script-src now.
         $removedScriptSrc = $this->reduceHashSignatures('script-src');
-
         $headerValue = $this->buildHeaderValue($request);
 
         if (\strlen($headerValue) < $this->maxHeaderLength) {
@@ -199,12 +197,12 @@ final class CspHandler
         }
 
         // Still couldn't make it - we have to throw an exception now.
-        throw new \LogicException(sprintf('The generated Content Security Policy header exceeds %d bytes. It is highly unlikely that your webserver will be able to handle such a big header value. Check the policy and ensure it stays below the %d bytes: %s', $this->maxHeaderLength, $this->maxHeaderLength, $headerValue));
+        throw new \LogicException(sprintf('The generated Content Security Policy header exceeds %d bytes. It is very unlikely that your web server will be able to handle such a big header value. Check the policy and ensure it stays below %d bytes: %s', $this->maxHeaderLength, $this->maxHeaderLength, $headerValue));
     }
 
     private function logCspHeaderExceeded(int $headerLength, array $removedStyleSrc, array $removedScriptSrc): void
     {
-        $this->logger?->critical(sprintf('Allowed CSP header size of %d bytes exhausted (tried to write %d bytes). Removed style-src hashes: %s. Removed script-src hashes: %s.',
+        $this->logger?->critical(sprintf('Allowed CSP header size of %d bytes exceeded (tried to write %d bytes). Removed style-src hashes: %s. Removed script-src hashes: %s.',
             $this->maxHeaderLength,
             $headerLength,
             [] === $removedStyleSrc ? 'none' : implode(', ', $removedStyleSrc),
@@ -234,8 +232,8 @@ final class CspHandler
 
         $removed = [];
 
-        // Unset the ones added last first (in case of style-src, that would mean that the top inline styles would still
-        // work while towards the footer they might not work anymore)
+        // First unset the ones added last. In case of style-src, that means that the top inline styles would still
+        // work while towards the footer they might not work anymore.
         do {
             $removed[] = array_pop($this->signatures[$source]);
         } while (\strlen($this->buildHeaderValue()) > $this->maxHeaderLength && [] !== $this->signatures[$source]);

--- a/core-bundle/src/Routing/ResponseContext/Csp/CspHandlerFactory.php
+++ b/core-bundle/src/Routing/ResponseContext/Csp/CspHandlerFactory.php
@@ -11,7 +11,7 @@ class CspHandlerFactory
 {
     public function __construct(
         private readonly CspParser $cspParser,
-        private readonly int $maxHeaderLength = 8192,
+        private readonly int $maxHeaderLength = 3072,
         private readonly LoggerInterface|null $logger = null,
     ) {
     }

--- a/core-bundle/src/Routing/ResponseContext/Csp/CspHandlerFactory.php
+++ b/core-bundle/src/Routing/ResponseContext/Csp/CspHandlerFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Contao\CoreBundle\Routing\ResponseContext\Csp;
+
+use Contao\CoreBundle\Csp\CspParser;
+use Psr\Log\LoggerInterface;
+
+class CspHandlerFactory
+{
+    public function __construct(
+        private readonly CspParser $cspParser,
+        private readonly int $maxHeaderLength = 4096,
+        private readonly LoggerInterface|null $logger = null,
+    ) {
+    }
+
+    /**
+     * @param string|null $csp Existing CSP header if any
+     */
+    public function create(string|null $csp = null): CspHandler
+    {
+        return new CspHandler(
+            $this->cspParser->parseHeader($csp),
+            $this->maxHeaderLength,
+            $this->logger,
+        );
+    }
+}

--- a/core-bundle/src/Routing/ResponseContext/Csp/CspHandlerFactory.php
+++ b/core-bundle/src/Routing/ResponseContext/Csp/CspHandlerFactory.php
@@ -11,7 +11,7 @@ class CspHandlerFactory
 {
     public function __construct(
         private readonly CspParser $cspParser,
-        private readonly int $maxHeaderLength = 4096,
+        private readonly int $maxHeaderLength = 8192,
         private readonly LoggerInterface|null $logger = null,
     ) {
     }

--- a/core-bundle/src/Routing/ResponseContext/Csp/CspHandlerFactory.php
+++ b/core-bundle/src/Routing/ResponseContext/Csp/CspHandlerFactory.php
@@ -21,10 +21,6 @@ class CspHandlerFactory
      */
     public function create(string|null $csp = null): CspHandler
     {
-        return new CspHandler(
-            $this->cspParser->parseHeader($csp),
-            $this->maxHeaderLength,
-            $this->logger,
-        );
+        return new CspHandler($this->cspParser->parseHeader($csp), $this->maxHeaderLength, $this->logger);
     }
 }

--- a/core-bundle/src/Twig/Runtime/CspRuntime.php
+++ b/core-bundle/src/Twig/Runtime/CspRuntime.php
@@ -86,7 +86,7 @@ final class CspRuntime implements RuntimeExtensionInterface
         $csp->addSource($directive, $source);
     }
 
-    public function addHash(string $directive, string $source, string $algorithm = 'sha384'): void
+    public function addHash(string $directive, string $source, string $algorithm = 'sha256'): void
     {
         $responseContext = $this->responseContextAccessor->getResponseContext();
 

--- a/core-bundle/src/Twig/Runtime/CspRuntime.php
+++ b/core-bundle/src/Twig/Runtime/CspRuntime.php
@@ -42,10 +42,6 @@ final class CspRuntime implements RuntimeExtensionInterface
             return $htmlFragment;
         }
 
-        if (!$styles = $this->wysiwygProcessor->extractStyles($htmlFragment)) {
-            return $htmlFragment;
-        }
-
         /** @var CspHandler $csp */
         $csp = $responseContext->get(CspHandler::class);
 

--- a/core-bundle/src/Twig/Runtime/CspRuntime.php
+++ b/core-bundle/src/Twig/Runtime/CspRuntime.php
@@ -42,6 +42,10 @@ final class CspRuntime implements RuntimeExtensionInterface
             return $htmlFragment;
         }
 
+        if (!$styles = $this->wysiwygProcessor->extractStyles($htmlFragment)) {
+            return $htmlFragment;
+        }
+
         /** @var CspHandler $csp */
         $csp = $responseContext->get(CspHandler::class);
 

--- a/core-bundle/tests/Contao/TemplateTest.php
+++ b/core-bundle/tests/Contao/TemplateTest.php
@@ -565,7 +565,7 @@ class TemplateTest extends TestCase
         $response = new Response();
         $cspHandler->applyHeaders($response);
 
-        $algorithm = 'sha384';
+        $algorithm = 'sha256';
         $expectedHash = base64_encode(hash($algorithm, 'text-decoration: underline;', true));
 
         $this->assertSame(sprintf("style-src 'self' 'unsafe-hashes' '%s-%s'", $algorithm, $expectedHash), $response->headers->get('Content-Security-Policy'));

--- a/core-bundle/tests/EventListener/PreviewToolbarListenerTest.php
+++ b/core-bundle/tests/EventListener/PreviewToolbarListenerTest.php
@@ -14,6 +14,7 @@ namespace Contao\CoreBundle\Tests\EventListener;
 
 use Contao\CoreBundle\Csp\CspParser;
 use Contao\CoreBundle\EventListener\PreviewToolbarListener;
+use Contao\CoreBundle\Routing\ResponseContext\Csp\CspHandlerFactory;
 use Contao\CoreBundle\Security\Authentication\Token\TokenChecker;
 use Contao\CoreBundle\Tests\TestCase;
 use Nelmio\SecurityBundle\ContentSecurityPolicy\PolicyManager;
@@ -42,7 +43,7 @@ class PreviewToolbarListenerTest extends TestCase
             $this->mockTokenChecker(),
             $this->mockTwig(),
             $this->mockRouterWithContext(),
-            new CspParser(new PolicyManager()),
+            new CspHandlerFactory(new CspParser(new PolicyManager())),
         );
 
         $response = new Response($content);
@@ -83,7 +84,7 @@ class PreviewToolbarListenerTest extends TestCase
             $this->mockTokenChecker(),
             $this->mockTwig(),
             $this->mockRouterWithContext(),
-            new CspParser(new PolicyManager()),
+            new CspHandlerFactory(new CspParser(new PolicyManager())),
         );
 
         $listener($event);
@@ -108,7 +109,7 @@ class PreviewToolbarListenerTest extends TestCase
             $this->mockTokenChecker(),
             $this->mockTwig(),
             $this->mockRouterWithContext(),
-            new CspParser(new PolicyManager()),
+            new CspHandlerFactory(new CspParser(new PolicyManager())),
         );
 
         $listener($event);
@@ -133,7 +134,7 @@ class PreviewToolbarListenerTest extends TestCase
             $this->mockTokenChecker(),
             $this->mockTwig(),
             $this->mockRouterWithContext(),
-            new CspParser(new PolicyManager()),
+            new CspHandlerFactory(new CspParser(new PolicyManager())),
         );
 
         $listener($event);
@@ -158,7 +159,7 @@ class PreviewToolbarListenerTest extends TestCase
             $this->mockTokenChecker(),
             $this->mockTwig(),
             $this->mockRouterWithContext(),
-            new CspParser(new PolicyManager()),
+            new CspHandlerFactory(new CspParser(new PolicyManager())),
         );
 
         $listener($event);
@@ -183,7 +184,7 @@ class PreviewToolbarListenerTest extends TestCase
             $this->mockTokenChecker(),
             $this->mockTwig(),
             $this->mockRouterWithContext(),
-            new CspParser(new PolicyManager()),
+            new CspHandlerFactory(new CspParser(new PolicyManager())),
         );
 
         $listener($event);
@@ -211,7 +212,7 @@ class PreviewToolbarListenerTest extends TestCase
             $this->mockTokenChecker(),
             $this->mockTwig(),
             $this->mockRouterWithContext(),
-            new CspParser(new PolicyManager()),
+            new CspHandlerFactory(new CspParser(new PolicyManager())),
         );
 
         $listener($event);
@@ -252,7 +253,7 @@ class PreviewToolbarListenerTest extends TestCase
             $this->mockTokenChecker(),
             $this->mockTwig(),
             $this->mockRouterWithContext(),
-            new CspParser(new PolicyManager()),
+            new CspHandlerFactory(new CspParser(new PolicyManager())),
         );
 
         $listener($event);
@@ -293,7 +294,7 @@ class PreviewToolbarListenerTest extends TestCase
             $this->mockTokenChecker(),
             $this->mockTwig(),
             $this->mockRouterWithContext(),
-            new CspParser(new PolicyManager()),
+            new CspHandlerFactory(new CspParser(new PolicyManager())),
         );
 
         $listener($event);
@@ -318,7 +319,7 @@ class PreviewToolbarListenerTest extends TestCase
             $this->mockTokenChecker(),
             $this->mockTwig(),
             $this->mockRouterWithContext(),
-            new CspParser(new PolicyManager()),
+            new CspHandlerFactory(new CspParser(new PolicyManager())),
         );
 
         $listener($event);
@@ -343,7 +344,7 @@ class PreviewToolbarListenerTest extends TestCase
             $this->mockTokenChecker(),
             $this->mockTwig(),
             $this->mockRouterWithContext(),
-            new CspParser(new PolicyManager()),
+            new CspHandlerFactory(new CspParser(new PolicyManager())),
         );
 
         $listener($event);

--- a/core-bundle/tests/Routing/ResponseContext/CoreResponseContextFactoryTest.php
+++ b/core-bundle/tests/Routing/ResponseContext/CoreResponseContextFactoryTest.php
@@ -18,6 +18,7 @@ use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\CoreBundle\InsertTag\InsertTagParser;
 use Contao\CoreBundle\Routing\ResponseContext\CoreResponseContextFactory;
 use Contao\CoreBundle\Routing\ResponseContext\Csp\CspHandler;
+use Contao\CoreBundle\Routing\ResponseContext\Csp\CspHandlerFactory;
 use Contao\CoreBundle\Routing\ResponseContext\HtmlHeadBag\HtmlHeadBag;
 use Contao\CoreBundle\Routing\ResponseContext\JsonLd\ContaoPageSchema;
 use Contao\CoreBundle\Routing\ResponseContext\JsonLd\JsonLdManager;
@@ -60,7 +61,7 @@ class CoreResponseContextFactoryTest extends TestCase
             new HtmlDecoder($this->createMock(InsertTagParser::class)),
             $this->createMock(RequestStack::class),
             $this->createMock(InsertTagParser::class),
-            $this->createMock(CspParser::class),
+            $this->createMock(CspHandlerFactory::class),
             $this->createMock(UrlGeneratorInterface::class),
         );
 
@@ -84,7 +85,7 @@ class CoreResponseContextFactoryTest extends TestCase
             new HtmlDecoder($this->createMock(InsertTagParser::class)),
             $this->createMock(RequestStack::class),
             $this->createMock(InsertTagParser::class),
-            $this->createMock(CspParser::class),
+            $this->createMock(CspHandlerFactory::class),
             $this->createMock(UrlGeneratorInterface::class),
         );
 
@@ -130,7 +131,7 @@ class CoreResponseContextFactoryTest extends TestCase
         $requestStack = new RequestStack();
         $requestStack->push(Request::create('https://example.com/'));
 
-        $cspParser = new CspParser(new PolicyManager());
+        $cpHandlerFactory = new CspHandlerFactory(new CspParser(new PolicyManager()));
 
         $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
         $urlGenerator
@@ -161,7 +162,7 @@ class CoreResponseContextFactoryTest extends TestCase
             new HtmlDecoder($insertTagsParser),
             $requestStack,
             $insertTagsParser,
-            $cspParser,
+            $cpHandlerFactory,
             $urlGenerator,
         );
 
@@ -235,7 +236,7 @@ class CoreResponseContextFactoryTest extends TestCase
             new HtmlDecoder($insertTagsParser),
             $requestStack,
             $insertTagsParser,
-            $this->createMock(CspParser::class),
+            $this->createMock(CspHandlerFactory::class),
             $this->createMock(UrlGeneratorInterface::class),
         );
 
@@ -281,7 +282,7 @@ class CoreResponseContextFactoryTest extends TestCase
             new HtmlDecoder($insertTagsParser),
             $this->createMock(RequestStack::class),
             $insertTagsParser,
-            $this->createMock(CspParser::class),
+            $this->createMock(CspHandlerFactory::class),
             $this->createMock(UrlGeneratorInterface::class),
         );
 

--- a/core-bundle/tests/Routing/ResponseContext/Csp/CspHandlerTest.php
+++ b/core-bundle/tests/Routing/ResponseContext/Csp/CspHandlerTest.php
@@ -196,7 +196,7 @@ class CspHandlerTest extends TestCase
                 'script-ebdca00f',
                 'script-096ccf1e',
             ],
-            'Allowed CSP header size of 480 bytes exhausted (tried to write 499 bytes)',
+            'Allowed CSP header size of 480 bytes exhausted (tried to write 499 bytes). Removed style-src hashes: sha384-6EpNvRkpzXKc0/GqaxbbUjVVMY7ihAahgNJolwHhuXbgncyGzHtMDoKymvNwecrl. Removed script-src hashes: none.',
             "default-src 'self'; script-src 'self' 'sha384-WiH70QJ//IwHzEEazDLD3ib/HCBX/w5DVK7iLcwNctCgC1gny3WZhpHYVc6MjM9p' 'sha384-2C5rO1BSGnvaxlQR9JaYInkYkxIBgqypaFa5W2Ers/2Uo+TF7HaOLeGTGhv2OFqL' 'sha384-H4X1/C0N5XroCPXG9EsrS7uyO3Gr2++QGudhEO0BrXuRgO83gfa1jegPJfs9Pr7f'; style-src 'self' 'sha384-6ygZ/e3B2JsYp8JUU2hp06kb4zU3aV3N9xgzeKjSvx0RhCkYBh3hG3gS9+iaa/Pc' 'sha384-SfjF7vhH3AekJ2O/KUjiHQg3wZ1GvMZKSio0AbFkBjoq8JmX2VeOp++Jg+j6DmSZ'",
         ];
 
@@ -212,7 +212,7 @@ class CspHandlerTest extends TestCase
                 'script-ebdca00f',
                 'script-096ccf1e',
             ],
-            'Allowed CSP header size of 350 bytes exhausted (tried to write 499 bytes)',
+            'Allowed CSP header size of 350 bytes exhausted (tried to write 499 bytes). Removed style-src hashes: sha384-6EpNvRkpzXKc0/GqaxbbUjVVMY7ihAahgNJolwHhuXbgncyGzHtMDoKymvNwecrl, sha384-SfjF7vhH3AekJ2O/KUjiHQg3wZ1GvMZKSio0AbFkBjoq8JmX2VeOp++Jg+j6DmSZ, sha384-6ygZ/e3B2JsYp8JUU2hp06kb4zU3aV3N9xgzeKjSvx0RhCkYBh3hG3gS9+iaa/Pc. Removed script-src hashes: none.',
             "default-src 'self'; script-src 'self' 'sha384-WiH70QJ//IwHzEEazDLD3ib/HCBX/w5DVK7iLcwNctCgC1gny3WZhpHYVc6MjM9p' 'sha384-2C5rO1BSGnvaxlQR9JaYInkYkxIBgqypaFa5W2Ers/2Uo+TF7HaOLeGTGhv2OFqL' 'sha384-H4X1/C0N5XroCPXG9EsrS7uyO3Gr2++QGudhEO0BrXuRgO83gfa1jegPJfs9Pr7f'; style-src 'self'",
         ];
 
@@ -228,7 +228,7 @@ class CspHandlerTest extends TestCase
                 'script-ebdca00f',
                 'script-096ccf1e',
             ],
-            'Allowed CSP header size of 200 bytes exhausted (tried to write 499 bytes)',
+            'Allowed CSP header size of 200 bytes exhausted (tried to write 499 bytes). Removed style-src hashes: sha384-6EpNvRkpzXKc0/GqaxbbUjVVMY7ihAahgNJolwHhuXbgncyGzHtMDoKymvNwecrl, sha384-SfjF7vhH3AekJ2O/KUjiHQg3wZ1GvMZKSio0AbFkBjoq8JmX2VeOp++Jg+j6DmSZ, sha384-6ygZ/e3B2JsYp8JUU2hp06kb4zU3aV3N9xgzeKjSvx0RhCkYBh3hG3gS9+iaa/Pc. Removed script-src hashes: sha384-H4X1/C0N5XroCPXG9EsrS7uyO3Gr2++QGudhEO0BrXuRgO83gfa1jegPJfs9Pr7f, sha384-2C5rO1BSGnvaxlQR9JaYInkYkxIBgqypaFa5W2Ers/2Uo+TF7HaOLeGTGhv2OFqL.',
             "default-src 'self'; script-src 'self' 'sha384-WiH70QJ//IwHzEEazDLD3ib/HCBX/w5DVK7iLcwNctCgC1gny3WZhpHYVc6MjM9p'; style-src 'self'",
         ];
 
@@ -244,7 +244,7 @@ class CspHandlerTest extends TestCase
                 'script-ebdca00f',
                 'script-096ccf1e',
             ],
-            'Allowed CSP header size of 100 bytes exhausted (tried to write 499 bytes)',
+            'Allowed CSP header size of 100 bytes exhausted (tried to write 499 bytes). Removed style-src hashes: sha384-6EpNvRkpzXKc0/GqaxbbUjVVMY7ihAahgNJolwHhuXbgncyGzHtMDoKymvNwecrl, sha384-SfjF7vhH3AekJ2O/KUjiHQg3wZ1GvMZKSio0AbFkBjoq8JmX2VeOp++Jg+j6DmSZ, sha384-6ygZ/e3B2JsYp8JUU2hp06kb4zU3aV3N9xgzeKjSvx0RhCkYBh3hG3gS9+iaa/Pc. Removed script-src hashes: sha384-H4X1/C0N5XroCPXG9EsrS7uyO3Gr2++QGudhEO0BrXuRgO83gfa1jegPJfs9Pr7f, sha384-2C5rO1BSGnvaxlQR9JaYInkYkxIBgqypaFa5W2Ers/2Uo+TF7HaOLeGTGhv2OFqL, sha384-WiH70QJ//IwHzEEazDLD3ib/HCBX/w5DVK7iLcwNctCgC1gny3WZhpHYVc6MjM9p.',
             "default-src 'self'; script-src 'self' ; style-src 'self'",
         ];
     }

--- a/core-bundle/tests/Routing/ResponseContext/Csp/CspHandlerTest.php
+++ b/core-bundle/tests/Routing/ResponseContext/Csp/CspHandlerTest.php
@@ -53,7 +53,7 @@ class CspHandlerTest extends TestCase
         $response = new Response();
         $cspHandler->applyHeaders($response);
 
-        $this->assertStringContainsString("script-src 'self' 'sha384-", $response->headers->get('Content-Security-Policy'));
+        $this->assertStringContainsString("script-src 'self' 'sha256-", $response->headers->get('Content-Security-Policy'));
     }
 
     public function testDoesNotGenerateHashIfNoDirectiveSet(): void
@@ -169,7 +169,7 @@ class CspHandlerTest extends TestCase
     public function cspExceedsMaximumLengthIsProperlyReducedProvider(): \Generator
     {
         yield 'All hashes fit into the header, nothing should be reduced' => [
-            8192,
+            3072,
             [
                 'style-d9813b22',
                 'style-194c5b63',
@@ -181,7 +181,7 @@ class CspHandlerTest extends TestCase
                 'script-096ccf1e',
             ],
             '',
-            "default-src 'self'; script-src 'self' 'sha384-WiH70QJ//IwHzEEazDLD3ib/HCBX/w5DVK7iLcwNctCgC1gny3WZhpHYVc6MjM9p' 'sha384-2C5rO1BSGnvaxlQR9JaYInkYkxIBgqypaFa5W2Ers/2Uo+TF7HaOLeGTGhv2OFqL' 'sha384-H4X1/C0N5XroCPXG9EsrS7uyO3Gr2++QGudhEO0BrXuRgO83gfa1jegPJfs9Pr7f'; style-src 'self' 'sha384-6ygZ/e3B2JsYp8JUU2hp06kb4zU3aV3N9xgzeKjSvx0RhCkYBh3hG3gS9+iaa/Pc' 'sha384-SfjF7vhH3AekJ2O/KUjiHQg3wZ1GvMZKSio0AbFkBjoq8JmX2VeOp++Jg+j6DmSZ' 'sha384-6EpNvRkpzXKc0/GqaxbbUjVVMY7ihAahgNJolwHhuXbgncyGzHtMDoKymvNwecrl'",
+            "default-src 'self'; script-src 'self' 'sha256-a+0mzhM4TeUQTtFmlsaWPB988SYUV2n2vnFXp+JBoIQ=' 'sha256-3a7iEPAV/ivWCZtx6AriA82DkQuvKMcVKpKNj8ILy04=' 'sha256-aRR6Dmh6a7drNxbn9I/k9WmmJJqniT7Y8zeO36vFbhA='; style-src 'self' 'sha256-tVK6wOK9HGGNBOgrFlQj13so1JXwU7ex6nIwakWTERI=' 'sha256-kMZYJvKUwoVGHauo0TBrvrFT3ty0htezb0TsPp/eEcs=' 'sha256-PMMzh0dRoh0SVsGuNP+MiMGUaR3DGUF8b7J99b9RXFc='",
         ];
 
         yield 'Not all hashes fit in the header. Should reduce the last style hash' => [
@@ -196,8 +196,8 @@ class CspHandlerTest extends TestCase
                 'script-ebdca00f',
                 'script-096ccf1e',
             ],
-            'Allowed CSP header size of 480 bytes exhausted (tried to write 499 bytes). Removed style-src hashes: sha384-6EpNvRkpzXKc0/GqaxbbUjVVMY7ihAahgNJolwHhuXbgncyGzHtMDoKymvNwecrl. Removed script-src hashes: none.',
-            "default-src 'self'; script-src 'self' 'sha384-WiH70QJ//IwHzEEazDLD3ib/HCBX/w5DVK7iLcwNctCgC1gny3WZhpHYVc6MjM9p' 'sha384-2C5rO1BSGnvaxlQR9JaYInkYkxIBgqypaFa5W2Ers/2Uo+TF7HaOLeGTGhv2OFqL' 'sha384-H4X1/C0N5XroCPXG9EsrS7uyO3Gr2++QGudhEO0BrXuRgO83gfa1jegPJfs9Pr7f'; style-src 'self' 'sha384-6ygZ/e3B2JsYp8JUU2hp06kb4zU3aV3N9xgzeKjSvx0RhCkYBh3hG3gS9+iaa/Pc' 'sha384-SfjF7vhH3AekJ2O/KUjiHQg3wZ1GvMZKSio0AbFkBjoq8JmX2VeOp++Jg+j6DmSZ'",
+            '',
+            "default-src 'self'; script-src 'self' 'sha256-a+0mzhM4TeUQTtFmlsaWPB988SYUV2n2vnFXp+JBoIQ=' 'sha256-3a7iEPAV/ivWCZtx6AriA82DkQuvKMcVKpKNj8ILy04=' 'sha256-aRR6Dmh6a7drNxbn9I/k9WmmJJqniT7Y8zeO36vFbhA='; style-src 'self' 'sha256-tVK6wOK9HGGNBOgrFlQj13so1JXwU7ex6nIwakWTERI=' 'sha256-kMZYJvKUwoVGHauo0TBrvrFT3ty0htezb0TsPp/eEcs=' 'sha256-PMMzh0dRoh0SVsGuNP+MiMGUaR3DGUF8b7J99b9RXFc='",
         ];
 
         yield 'None of the style hashes fit' => [
@@ -212,8 +212,8 @@ class CspHandlerTest extends TestCase
                 'script-ebdca00f',
                 'script-096ccf1e',
             ],
-            'Allowed CSP header size of 350 bytes exhausted (tried to write 499 bytes). Removed style-src hashes: sha384-6EpNvRkpzXKc0/GqaxbbUjVVMY7ihAahgNJolwHhuXbgncyGzHtMDoKymvNwecrl, sha384-SfjF7vhH3AekJ2O/KUjiHQg3wZ1GvMZKSio0AbFkBjoq8JmX2VeOp++Jg+j6DmSZ, sha384-6ygZ/e3B2JsYp8JUU2hp06kb4zU3aV3N9xgzeKjSvx0RhCkYBh3hG3gS9+iaa/Pc. Removed script-src hashes: none.',
-            "default-src 'self'; script-src 'self' 'sha384-WiH70QJ//IwHzEEazDLD3ib/HCBX/w5DVK7iLcwNctCgC1gny3WZhpHYVc6MjM9p' 'sha384-2C5rO1BSGnvaxlQR9JaYInkYkxIBgqypaFa5W2Ers/2Uo+TF7HaOLeGTGhv2OFqL' 'sha384-H4X1/C0N5XroCPXG9EsrS7uyO3Gr2++QGudhEO0BrXuRgO83gfa1jegPJfs9Pr7f'; style-src 'self'",
+            'Allowed CSP header size of 350 bytes exhausted (tried to write 379 bytes). Removed style-src hashes: sha256-PMMzh0dRoh0SVsGuNP+MiMGUaR3DGUF8b7J99b9RXFc=. Removed script-src hashes: none.',
+            "default-src 'self'; script-src 'self' 'sha256-a+0mzhM4TeUQTtFmlsaWPB988SYUV2n2vnFXp+JBoIQ=' 'sha256-3a7iEPAV/ivWCZtx6AriA82DkQuvKMcVKpKNj8ILy04=' 'sha256-aRR6Dmh6a7drNxbn9I/k9WmmJJqniT7Y8zeO36vFbhA='; style-src 'self' 'sha256-tVK6wOK9HGGNBOgrFlQj13so1JXwU7ex6nIwakWTERI=' 'sha256-kMZYJvKUwoVGHauo0TBrvrFT3ty0htezb0TsPp/eEcs='",
         ];
 
         yield 'Not all of the script hashes fit either' => [
@@ -228,8 +228,8 @@ class CspHandlerTest extends TestCase
                 'script-ebdca00f',
                 'script-096ccf1e',
             ],
-            'Allowed CSP header size of 200 bytes exhausted (tried to write 499 bytes). Removed style-src hashes: sha384-6EpNvRkpzXKc0/GqaxbbUjVVMY7ihAahgNJolwHhuXbgncyGzHtMDoKymvNwecrl, sha384-SfjF7vhH3AekJ2O/KUjiHQg3wZ1GvMZKSio0AbFkBjoq8JmX2VeOp++Jg+j6DmSZ, sha384-6ygZ/e3B2JsYp8JUU2hp06kb4zU3aV3N9xgzeKjSvx0RhCkYBh3hG3gS9+iaa/Pc. Removed script-src hashes: sha384-H4X1/C0N5XroCPXG9EsrS7uyO3Gr2++QGudhEO0BrXuRgO83gfa1jegPJfs9Pr7f, sha384-2C5rO1BSGnvaxlQR9JaYInkYkxIBgqypaFa5W2Ers/2Uo+TF7HaOLeGTGhv2OFqL.',
-            "default-src 'self'; script-src 'self' 'sha384-WiH70QJ//IwHzEEazDLD3ib/HCBX/w5DVK7iLcwNctCgC1gny3WZhpHYVc6MjM9p'; style-src 'self'",
+            'Allowed CSP header size of 200 bytes exhausted (tried to write 379 bytes). Removed style-src hashes: sha256-PMMzh0dRoh0SVsGuNP+MiMGUaR3DGUF8b7J99b9RXFc=, sha256-kMZYJvKUwoVGHauo0TBrvrFT3ty0htezb0TsPp/eEcs=, sha256-tVK6wOK9HGGNBOgrFlQj13so1JXwU7ex6nIwakWTERI=. Removed script-src hashes: sha256-aRR6Dmh6a7drNxbn9I/k9WmmJJqniT7Y8zeO36vFbhA=.',
+            "default-src 'self'; script-src 'self' 'sha256-a+0mzhM4TeUQTtFmlsaWPB988SYUV2n2vnFXp+JBoIQ=' 'sha256-3a7iEPAV/ivWCZtx6AriA82DkQuvKMcVKpKNj8ILy04='; style-src 'self'",
         ];
 
         yield 'None of the hashes fit' => [
@@ -244,12 +244,12 @@ class CspHandlerTest extends TestCase
                 'script-ebdca00f',
                 'script-096ccf1e',
             ],
-            'Allowed CSP header size of 100 bytes exhausted (tried to write 499 bytes). Removed style-src hashes: sha384-6EpNvRkpzXKc0/GqaxbbUjVVMY7ihAahgNJolwHhuXbgncyGzHtMDoKymvNwecrl, sha384-SfjF7vhH3AekJ2O/KUjiHQg3wZ1GvMZKSio0AbFkBjoq8JmX2VeOp++Jg+j6DmSZ, sha384-6ygZ/e3B2JsYp8JUU2hp06kb4zU3aV3N9xgzeKjSvx0RhCkYBh3hG3gS9+iaa/Pc. Removed script-src hashes: sha384-H4X1/C0N5XroCPXG9EsrS7uyO3Gr2++QGudhEO0BrXuRgO83gfa1jegPJfs9Pr7f, sha384-2C5rO1BSGnvaxlQR9JaYInkYkxIBgqypaFa5W2Ers/2Uo+TF7HaOLeGTGhv2OFqL, sha384-WiH70QJ//IwHzEEazDLD3ib/HCBX/w5DVK7iLcwNctCgC1gny3WZhpHYVc6MjM9p.',
+            'Allowed CSP header size of 100 bytes exhausted (tried to write 379 bytes). Removed style-src hashes: sha256-PMMzh0dRoh0SVsGuNP+MiMGUaR3DGUF8b7J99b9RXFc=, sha256-kMZYJvKUwoVGHauo0TBrvrFT3ty0htezb0TsPp/eEcs=, sha256-tVK6wOK9HGGNBOgrFlQj13so1JXwU7ex6nIwakWTERI=. Removed script-src hashes: sha256-aRR6Dmh6a7drNxbn9I/k9WmmJJqniT7Y8zeO36vFbhA=, sha256-3a7iEPAV/ivWCZtx6AriA82DkQuvKMcVKpKNj8ILy04=, sha256-a+0mzhM4TeUQTtFmlsaWPB988SYUV2n2vnFXp+JBoIQ=.',
             "default-src 'self'; script-src 'self' ; style-src 'self'",
         ];
     }
 
-    private function getCspHandler(array $directives = ['script-src' => "'self'"], int $maxHeaderLength = 8192, LoggerInterface|null $logger = null): CspHandler
+    private function getCspHandler(array $directives = ['script-src' => "'self'"], int $maxHeaderLength = 3072, LoggerInterface|null $logger = null): CspHandler
     {
         $directiveSet = new DirectiveSet(new PolicyManager());
         $directiveSet->setDirectives($directives);

--- a/core-bundle/tests/Routing/ResponseContext/Csp/CspHandlerTest.php
+++ b/core-bundle/tests/Routing/ResponseContext/Csp/CspHandlerTest.php
@@ -169,7 +169,7 @@ class CspHandlerTest extends TestCase
     public function cspExceedsMaximumLengthIsProperlyReducedProvider(): \Generator
     {
         yield 'All hashes fit into the header, nothing should be reduced' => [
-            4096,
+            8192,
             [
                 'style-d9813b22',
                 'style-194c5b63',
@@ -249,7 +249,7 @@ class CspHandlerTest extends TestCase
         ];
     }
 
-    private function getCspHandler(array $directives = ['script-src' => "'self'"], int $maxHeaderLength = 4096, LoggerInterface|null $logger = null): CspHandler
+    private function getCspHandler(array $directives = ['script-src' => "'self'"], int $maxHeaderLength = 8192, LoggerInterface|null $logger = null): CspHandler
     {
         $directiveSet = new DirectiveSet(new PolicyManager());
         $directiveSet->setDirectives($directives);

--- a/core-bundle/tests/Routing/ResponseContext/Csp/CspHandlerTest.php
+++ b/core-bundle/tests/Routing/ResponseContext/Csp/CspHandlerTest.php
@@ -118,10 +118,6 @@ class CspHandlerTest extends TestCase
 
     public function testCspExceedsMaximumLengthAndCannotBeReduced(): void
     {
-        $this->expectException(\LogicException::class);
-        $this->expectExceptionMessageMatches('/^The generated Content Security Policy header exceeds 20 bytes. It is highly unlikely.+/');
-
-        $response = new Response();
         $cspHandler = $this->getCspHandler(
             [
                 'default-src' => "'self'",
@@ -135,7 +131,10 @@ class CspHandlerTest extends TestCase
             $cspHandler->addHash('style-src', bin2hex(random_bytes(20)));
         }
 
-        $cspHandler->applyHeaders($response);
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessageMatches('/^The generated Content Security Policy header exceeds 20 bytes..+/');
+
+        $cspHandler->applyHeaders(new Response());
     }
 
     /**
@@ -212,7 +211,7 @@ class CspHandlerTest extends TestCase
                 'script-ebdca00f',
                 'script-096ccf1e',
             ],
-            'Allowed CSP header size of 350 bytes exhausted (tried to write 379 bytes). Removed style-src hashes: sha256-PMMzh0dRoh0SVsGuNP+MiMGUaR3DGUF8b7J99b9RXFc=. Removed script-src hashes: none.',
+            'Allowed CSP header size of 350 bytes exceeded (tried to write 379 bytes). Removed style-src hashes: sha256-PMMzh0dRoh0SVsGuNP+MiMGUaR3DGUF8b7J99b9RXFc=. Removed script-src hashes: none.',
             "default-src 'self'; script-src 'self' 'sha256-a+0mzhM4TeUQTtFmlsaWPB988SYUV2n2vnFXp+JBoIQ=' 'sha256-3a7iEPAV/ivWCZtx6AriA82DkQuvKMcVKpKNj8ILy04=' 'sha256-aRR6Dmh6a7drNxbn9I/k9WmmJJqniT7Y8zeO36vFbhA='; style-src 'self' 'sha256-tVK6wOK9HGGNBOgrFlQj13so1JXwU7ex6nIwakWTERI=' 'sha256-kMZYJvKUwoVGHauo0TBrvrFT3ty0htezb0TsPp/eEcs='",
         ];
 
@@ -228,7 +227,7 @@ class CspHandlerTest extends TestCase
                 'script-ebdca00f',
                 'script-096ccf1e',
             ],
-            'Allowed CSP header size of 200 bytes exhausted (tried to write 379 bytes). Removed style-src hashes: sha256-PMMzh0dRoh0SVsGuNP+MiMGUaR3DGUF8b7J99b9RXFc=, sha256-kMZYJvKUwoVGHauo0TBrvrFT3ty0htezb0TsPp/eEcs=, sha256-tVK6wOK9HGGNBOgrFlQj13so1JXwU7ex6nIwakWTERI=. Removed script-src hashes: sha256-aRR6Dmh6a7drNxbn9I/k9WmmJJqniT7Y8zeO36vFbhA=.',
+            'Allowed CSP header size of 200 bytes exceeded (tried to write 379 bytes). Removed style-src hashes: sha256-PMMzh0dRoh0SVsGuNP+MiMGUaR3DGUF8b7J99b9RXFc=, sha256-kMZYJvKUwoVGHauo0TBrvrFT3ty0htezb0TsPp/eEcs=, sha256-tVK6wOK9HGGNBOgrFlQj13so1JXwU7ex6nIwakWTERI=. Removed script-src hashes: sha256-aRR6Dmh6a7drNxbn9I/k9WmmJJqniT7Y8zeO36vFbhA=.',
             "default-src 'self'; script-src 'self' 'sha256-a+0mzhM4TeUQTtFmlsaWPB988SYUV2n2vnFXp+JBoIQ=' 'sha256-3a7iEPAV/ivWCZtx6AriA82DkQuvKMcVKpKNj8ILy04='; style-src 'self'",
         ];
 
@@ -244,7 +243,7 @@ class CspHandlerTest extends TestCase
                 'script-ebdca00f',
                 'script-096ccf1e',
             ],
-            'Allowed CSP header size of 100 bytes exhausted (tried to write 379 bytes). Removed style-src hashes: sha256-PMMzh0dRoh0SVsGuNP+MiMGUaR3DGUF8b7J99b9RXFc=, sha256-kMZYJvKUwoVGHauo0TBrvrFT3ty0htezb0TsPp/eEcs=, sha256-tVK6wOK9HGGNBOgrFlQj13so1JXwU7ex6nIwakWTERI=. Removed script-src hashes: sha256-aRR6Dmh6a7drNxbn9I/k9WmmJJqniT7Y8zeO36vFbhA=, sha256-3a7iEPAV/ivWCZtx6AriA82DkQuvKMcVKpKNj8ILy04=, sha256-a+0mzhM4TeUQTtFmlsaWPB988SYUV2n2vnFXp+JBoIQ=.',
+            'Allowed CSP header size of 100 bytes exceeded (tried to write 379 bytes). Removed style-src hashes: sha256-PMMzh0dRoh0SVsGuNP+MiMGUaR3DGUF8b7J99b9RXFc=, sha256-kMZYJvKUwoVGHauo0TBrvrFT3ty0htezb0TsPp/eEcs=, sha256-tVK6wOK9HGGNBOgrFlQj13so1JXwU7ex6nIwakWTERI=. Removed script-src hashes: sha256-aRR6Dmh6a7drNxbn9I/k9WmmJJqniT7Y8zeO36vFbhA=, sha256-3a7iEPAV/ivWCZtx6AriA82DkQuvKMcVKpKNj8ILy04=, sha256-a+0mzhM4TeUQTtFmlsaWPB988SYUV2n2vnFXp+JBoIQ=.',
             "default-src 'self'; script-src 'self' ; style-src 'self'",
         ];
     }


### PR DESCRIPTION
With the latest PRs merged in the 5.3 branch, the probability of generating a large CSP header increased but it was also possible before: the CSP header can get pretty long. If you e.g. have a 50 bytes long inline style, a sha384 hash base64 encoded can get about 130 bytes long. (`echo strlen('sha384-' . base64_encode(hash('sha384', random_bytes(50))));`).

I found various different sources for the maximum header size of nginx, Apache and Co. but it ranges from 4kb to 16kb. If it is 4kb, you'll end up having a max of about 30 of those hashes and you will end up crashing the webserver for a header too long. 

I think, it would be great if Contao could limit this. It should be better to remove hashes and have CSP violations than having a server crash. Or in other words: better to not have a `text-decoration: underline` than a 500 Server Error.

So here's some proposal reducing the CSP header length automatically, starting with `style-src` hashes and then `script-src` hashes until the header size is okay. 