### PR TITLE
Fix mov mime type

### DIFF
--- a/core-bundle/src/Resources/contao/config/mimetypes.php
+++ b/core-bundle/src/Resources/contao/config/mimetypes.php
@@ -131,7 +131,7 @@ $GLOBALS['TL_MIME'] = array
 	// Videos
 	'mp4'   => array('video/mp4', 'iconMP4.svg'),
 	'm4v'   => array('video/x-m4v', 'iconM4V.svg'),
-	'mov'   => array('video/mov', 'iconMOV.svg'),
+	'mov'   => array('video/quicktime', 'iconMOV.svg'),
 	'wmv'   => array('video/wmv', 'iconWMV.svg'),
 	'webm'  => array('video/webm', 'iconWEBM.svg'),
 	'qt'    => array('video/quicktime', 'iconQT.svg'),


### PR DESCRIPTION
There is no mime type called `video/mov`, this causes problems in the video content element as browsers do not download the video because of: `Specified “type” attribute of “video/mov” is not supported. Load of media resource files/….mov failed.`