### PR TITLE
Prevent argument errors on malicious login attempts

### DIFF
--- a/core-bundle/src/Security/Authentication/ContaoLoginAuthenticationListener.php
+++ b/core-bundle/src/Security/Authentication/ContaoLoginAuthenticationListener.php
@@ -48,7 +48,7 @@ class ContaoLoginAuthenticationListener extends AbstractAuthenticationListener
     {
         return $request->isMethod('POST')
             && $request->request->has('FORM_SUBMIT')
-            && preg_match('/^tl_login(_[0-9]+)?$/', $request->request->get('FORM_SUBMIT'));
+            && preg_match('/^tl_login(_[0-9]+)?$/', (string) $request->request->get('FORM_SUBMIT'));
     }
 
     protected function attemptAuthentication(Request $request): ?TokenInterface

--- a/core-bundle/src/Security/Authentication/ContaoLoginAuthenticationListener.php
+++ b/core-bundle/src/Security/Authentication/ContaoLoginAuthenticationListener.php
@@ -48,7 +48,8 @@ class ContaoLoginAuthenticationListener extends AbstractAuthenticationListener
     {
         return $request->isMethod('POST')
             && $request->request->has('FORM_SUBMIT')
-            && preg_match('/^tl_login(_[0-9]+)?$/', (string) $request->request->get('FORM_SUBMIT'));
+            && \is_string($request->request->get('FORM_SUBMIT'));
+            && preg_match('/^tl_login(_[0-9]+)?$/', $request->request->get('FORM_SUBMIT'));
     }
 
     protected function attemptAuthentication(Request $request): ?TokenInterface

--- a/core-bundle/src/Security/Authentication/ContaoLoginAuthenticationListener.php
+++ b/core-bundle/src/Security/Authentication/ContaoLoginAuthenticationListener.php
@@ -48,7 +48,7 @@ class ContaoLoginAuthenticationListener extends AbstractAuthenticationListener
     {
         return $request->isMethod('POST')
             && $request->request->has('FORM_SUBMIT')
-            && \is_string($request->request->get('FORM_SUBMIT'));
+            && \is_string($request->request->get('FORM_SUBMIT'))
             && preg_match('/^tl_login(_[0-9]+)?$/', $request->request->get('FORM_SUBMIT'));
     }
 


### PR DESCRIPTION
Fixes #6702

This also makes the `ContaoLoginAuthenticationListener` of Contao 4.13 consistent with the `ContaoLoginAuthenticator` of Contao 5 (there the cast already exists).
