### PR TITLE
Move the HTTP cache subscribers to the manager bundle

### DIFF
--- a/manager-bundle/src/EventListener/HttpCache/StripCookiesSubscriber.php
+++ b/manager-bundle/src/EventListener/HttpCache/StripCookiesSubscriber.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
  * @license LGPL-3.0-or-later
  */
 
-namespace Contao\CoreBundle\EventListener\HttpCache;
+namespace Contao\ManagerBundle\EventListener\HttpCache;
 
 use FOS\HttpCache\SymfonyCache\CacheEvent;
 use FOS\HttpCache\SymfonyCache\Events;

--- a/manager-bundle/src/EventListener/HttpCache/StripQueryParametersSubscriber.php
+++ b/manager-bundle/src/EventListener/HttpCache/StripQueryParametersSubscriber.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
  * @license LGPL-3.0-or-later
  */
 
-namespace Contao\CoreBundle\EventListener\HttpCache;
+namespace Contao\ManagerBundle\EventListener\HttpCache;
 
 use FOS\HttpCache\SymfonyCache\CacheEvent;
 use FOS\HttpCache\SymfonyCache\Events;

--- a/manager-bundle/src/HttpKernel/ContaoCache.php
+++ b/manager-bundle/src/HttpKernel/ContaoCache.php
@@ -12,8 +12,8 @@ declare(strict_types=1);
 
 namespace Contao\ManagerBundle\HttpKernel;
 
-use Contao\CoreBundle\EventListener\HttpCache\StripCookiesSubscriber;
-use Contao\CoreBundle\EventListener\HttpCache\StripQueryParametersSubscriber;
+use Contao\ManagerBundle\EventListener\HttpCache\StripCookiesSubscriber;
+use Contao\ManagerBundle\EventListener\HttpCache\StripQueryParametersSubscriber;
 use FOS\HttpCache\SymfonyCache\CacheInvalidation;
 use FOS\HttpCache\SymfonyCache\CleanupCacheTagsListener;
 use FOS\HttpCache\SymfonyCache\EventDispatchingHttpCache;

--- a/manager-bundle/tests/EventListener/HttpCache/StripCookiesSubscriberTest.php
+++ b/manager-bundle/tests/EventListener/HttpCache/StripCookiesSubscriberTest.php
@@ -10,9 +10,9 @@ declare(strict_types=1);
  * @license LGPL-3.0-or-later
  */
 
-namespace Contao\CoreBundle\Tests\EventListener\HttpCache;
+namespace Contao\ManagerBundle\Tests\EventListener\HttpCache;
 
-use Contao\CoreBundle\EventListener\HttpCache\StripCookiesSubscriber;
+use Contao\ManagerBundle\EventListener\HttpCache\StripCookiesSubscriber;
 use FOS\HttpCache\SymfonyCache\CacheEvent;
 use FOS\HttpCache\SymfonyCache\CacheInvalidation;
 use FOS\HttpCache\SymfonyCache\Events;

--- a/manager-bundle/tests/EventListener/HttpCache/StripQueryParametersSubscriberTest.php
+++ b/manager-bundle/tests/EventListener/HttpCache/StripQueryParametersSubscriberTest.php
@@ -10,9 +10,9 @@ declare(strict_types=1);
  * @license LGPL-3.0-or-later
  */
 
-namespace Contao\CoreBundle\Tests\EventListener\HttpCache;
+namespace Contao\ManagerBundle\Tests\EventListener\HttpCache;
 
-use Contao\CoreBundle\EventListener\HttpCache\StripQueryParametersSubscriber;
+use Contao\ManagerBundle\EventListener\HttpCache\StripQueryParametersSubscriber;
 use FOS\HttpCache\SymfonyCache\CacheEvent;
 use FOS\HttpCache\SymfonyCache\CacheInvalidation;
 use FOS\HttpCache\SymfonyCache\Events;

--- a/manager-bundle/tests/HttpKernel/ContaoCacheTest.php
+++ b/manager-bundle/tests/HttpKernel/ContaoCacheTest.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\ManagerBundle\Tests\HttpKernel;
 
-use Contao\CoreBundle\EventListener\HttpCache\StripCookiesSubscriber;
+use Contao\ManagerBundle\EventListener\HttpCache\StripCookiesSubscriber;
 use Contao\ManagerBundle\HttpKernel\ContaoCache;
 use Contao\ManagerBundle\HttpKernel\ContaoKernel;
 use Contao\TestCase\ContaoTestCase;


### PR DESCRIPTION
<img width="983" alt="" src="https://github.com/contao/contao/assets/1192057/4e5b9748-6cf2-4d16-89a4-ad8469e99c9e">

This is because the two subscribers are defined in the core bundle but only used in the manager bundle. So can we move them to the manager bundle (this PR) or should they not be marked `@internal`?