### PR TITLE
Improve `download.html.twig` template

### DIFF
--- a/core-bundle/contao/templates/_new/content_element/download.html.twig
+++ b/core-bundle/contao/templates/_new/content_element/download.html.twig
@@ -1,12 +1,10 @@
 {% extends "@Contao/content_element/_base.html.twig" %}
 {% use "@Contao/component/_download.html.twig" %}
 
-{% if downloads %}
-    {% set attributes = attrs(attributes|default).addClass(['download-element', "ext-#{(downloads|first).file.extension(true)}"]) %}
-{% endif %}
-
 {% block content %}
     {% if downloads %}
-        {% with {download: downloads|first} %}{{ block('download_component') }}{% endwith %}
+        <p{{ attrs(download_attributes|default).addClass(['download-element', "ext-#{(downloads|first).file.extension(true)}"]) }}>
+            {% with {download: downloads|first} %}{{ block('download_component') }}{% endwith %}
+        </p>
     {% endif %}
 {% endblock %}

--- a/core-bundle/tests/Controller/ContentElement/DownloadsControllerTest.php
+++ b/core-bundle/tests/Controller/ContentElement/DownloadsControllerTest.php
@@ -36,8 +36,10 @@ class DownloadsControllerTest extends ContentElementTestCase
         );
 
         $expectedOutput = <<<'HTML'
-            <div class="download-element ext-jpg content-download">
-                <a href="https://example.com/files/image1.jpg" title="translated(contao_default:MSC.download[image1 title])" type="image/jpg">image1 title</a>
+            <div class="content-download">
+                <p class="download-element ext-jpg">
+                    <a href="https://example.com/files/image1.jpg" title="translated(contao_default:MSC.download[image1 title])" type="image/jpg">image1 title</a>
+                </p>
             </div>
             HTML;
 
@@ -62,8 +64,10 @@ class DownloadsControllerTest extends ContentElementTestCase
         );
 
         $expectedOutput = <<<'HTML'
-            <div class="download-element ext-jpg content-download">
-                <a href="https://example.com/files/image1.jpg" title="translated(contao_default:MSC.download[Download the file])" type="image/jpg">The file</a>
+            <div class="content-download">
+                <p class="download-element ext-jpg">
+                    <a href="https://example.com/files/image1.jpg" title="translated(contao_default:MSC.download[Download the file])" type="image/jpg">The file</a>
+                </p>
             </div>
             HTML;
 


### PR DESCRIPTION
Fixes #6792

This change brings the HTML output of the `download` content element in line with its previous legacy form again, so that you can style download links from both the `download` and `downloads` content element in a unified way via the `.download-element` class.
