### PR TITLE
Prevent errors in the images controller if images are missing

### DIFF
--- a/core-bundle/src/Controller/ContentElement/ImagesController.php
+++ b/core-bundle/src/Controller/ContentElement/ImagesController.php
@@ -74,7 +74,7 @@ class ImagesController extends AbstractContentElementController
         }
 
         $imageList = array_filter(array_map(
-            fn (FilesystemItem $filesystemItem): ?Figure => $figureBuilder
+            fn (FilesystemItem $filesystemItem): Figure|null => $figureBuilder
                 ->fromStorage($this->filesStorage, $filesystemItem->getPath())
                 ->buildIfResourceExists(),
             iterator_to_array($filesystemItems)),

--- a/core-bundle/src/Controller/ContentElement/ImagesController.php
+++ b/core-bundle/src/Controller/ContentElement/ImagesController.php
@@ -73,11 +73,11 @@ class ImagesController extends AbstractContentElementController
             $figureBuilder->setOverwriteMetadata($model->getOverwriteMetadata());
         }
 
-        $imageList = array_map(
-            fn (FilesystemItem $filesystemItem): Figure => $figureBuilder
+        $imageList = array_filter(array_map(
+            fn (FilesystemItem $filesystemItem): ?Figure => $figureBuilder
                 ->fromStorage($this->filesStorage, $filesystemItem->getPath())
-                ->build(),
-            iterator_to_array($filesystemItems)
+                ->buildIfResourceExists(),
+            iterator_to_array($filesystemItems)),
         );
 
         if (!$imageList) {

--- a/core-bundle/tests/Controller/ContentElement/ContentElementTestCase.php
+++ b/core-bundle/tests/Controller/ContentElement/ContentElementTestCase.php
@@ -73,6 +73,7 @@ class ContentElementTestCase extends TestCase
     final public const FILE_IMAGE1 = '0a2073bc-c966-4e7b-83b9-163a06aa87e7';
     final public const FILE_IMAGE2 = '7ebca224-553f-4f36-b853-e6f3af3eff42';
     final public const FILE_IMAGE3 = '3045209c-b73d-4a69-b30b-cda8c8008099';
+    final public const FILE_IMAGE_MISSING = '33389f37-b15c-4990-910d-49fd93adcf93';
     final public const FILE_VIDEO_MP4 = 'e802b519-8e08-4075-913c-7603ec6f2376';
     final public const FILE_VIDEO_OGV = 'd950e33a-dacc-42ad-ba97-6387d05348c4';
     final public const ARTICLE1 = 123;
@@ -319,6 +320,7 @@ class ContentElementTestCase extends TestCase
                         ),
                         self::FILE_IMAGE2 => new FilesystemItem(true, 'image2.jpg'),
                         self::FILE_IMAGE3 => new FilesystemItem(true, 'image3.jpg'),
+                        self::FILE_IMAGE_MISSING => new FilesystemItem(true, 'image_missing.jpg'),
                         self::FILE_VIDEO_MP4 => new FilesystemItem(true, 'video.mp4'),
                         self::FILE_VIDEO_OGV => new FilesystemItem(true, 'video.ogv'),
                     ];

--- a/core-bundle/tests/Controller/ContentElement/ImagesControllerTest.php
+++ b/core-bundle/tests/Controller/ContentElement/ImagesControllerTest.php
@@ -153,4 +153,40 @@ class ImagesControllerTest extends ContentElementTestCase
 
         $this->assertSame('', $response->getContent());
     }
+
+    public function testIgnoresMissingImages(): void
+    {
+        $security = $this->createMock(Security::class);
+
+        $response = $this->renderWithModelData(
+            new ImagesController($security, $this->getDefaultStorage(), $this->getDefaultStudio(), ['svg', 'jpg', 'png']),
+            [
+                'type' => 'gallery',
+                'multiSRC' => serialize([
+                    StringUtil::uuidToBin(ContentElementTestCase::FILE_IMAGE1),
+                    StringUtil::uuidToBin(ContentElementTestCase::FILE_IMAGE_MISSING),
+                ]),
+                'sortBy' => 'name_desc',
+                'numberOfItems' => 0,
+                'size' => '',
+                'fullsize' => true,
+                'perPage' => 1,
+                'perRow' => 1,
+            ],
+        );
+
+        $expectedOutput = <<<'HTML'
+            <div class="content-gallery--cols-1 content-gallery">
+                <ul>
+                    <li>
+                        <figure>
+                            <img src="files/image1.jpg" alt>
+                        </figure>
+                    </li>
+                </ul>
+            </div>
+            HTML;
+
+        $this->assertSameHtml($expectedOutput, $response->getContent());
+    }
 }

--- a/core-bundle/tests/Image/Studio/FigureBuilderStub.php
+++ b/core-bundle/tests/Image/Studio/FigureBuilderStub.php
@@ -102,12 +102,16 @@ class FigureBuilderStub extends FigureBuilder
             throw new InvalidResourceException('No path set.');
         }
 
+        if (!isset($this->imageMap[$this->path])) {
+            throw new InvalidResourceException('Resource does not exist.');
+        }
+
         return new Figure($this->imageMap[$this->path], $this->metadata, $this->linkAttributes);
     }
 
     public function buildIfResourceExists(): Figure|null
     {
-        if (null === $this->path) {
+        if (null === $this->path || !isset($this->imageMap[$this->path])) {
             return null;
         }
 


### PR DESCRIPTION
Similar to https://github.com/contao/contao/pull/6697 an exception will also occur in Contao 5 if the actual resource to an existing DBAFS entry does not exist anymore:

```
Contao\CoreBundle\Exception\InvalidResourceException:
Could not read resource from storage: Unable to read from "files/foo/bar.png".

  at vendor\contao\contao\core-bundle\src\Image\Studio\FigureBuilder.php:340
  at Contao\CoreBundle\Image\Studio\FigureBuilder->fromStorage(object(VirtualFilesystem), 'foo/bar.png')
     (vendor\contao\contao\core-bundle\src\Controller\ContentElement\ImagesController.php:78)
  at Contao\CoreBundle\Controller\ContentElement\ImagesController->Contao\CoreBundle\Controller\ContentElement\{closure}(object(FilesystemItem))
  at array_map(object(Closure), array(object(FilesystemItem)))
     (vendor\contao\contao\core-bundle\src\Controller\ContentElement\ImagesController.php:76)
  at Contao\CoreBundle\Controller\ContentElement\ImagesController->getResponse(object(FragmentTemplate), object(ContentModel), object(Request))
     (vendor\contao\contao\core-bundle\src\Controller\ContentElement\AbstractContentElementController.php:39)
```

This PR fixes that by ignoring non-existent resources, to restore the previous behavior.