### PR TITLE
Correctly show past events if "hide running events" is active

### DIFF
--- a/calendar-bundle/src/Resources/contao/modules/ModuleEventlist.php
+++ b/calendar-bundle/src/Resources/contao/modules/ModuleEventlist.php
@@ -220,7 +220,7 @@ class ModuleEventlist extends Events
 					}
 
 					// Hide running non-recurring events (see #30)
-					if ($this->cal_hideRunning && !$event['recurring'] && $event['effectiveEndTime'] > time())
+					if ($this->cal_hideRunning && !$event['recurring'] && $event['startTime'] < time() && $event['effectiveEndTime'] > time())
 					{
 						continue;
 					}

--- a/calendar-bundle/src/Resources/contao/modules/ModuleEventlist.php
+++ b/calendar-bundle/src/Resources/contao/modules/ModuleEventlist.php
@@ -219,9 +219,13 @@ class ModuleEventlist extends Events
 						continue;
 					}
 
-					// Hide running non-recurring events (see #30)
-					if ($this->cal_hideRunning && !$event['recurring'] && $event['startTime'] < time())
-					{
+					// Hide running non-recurring events (see #30) for next_ 
+					if (preg_match("#^next_(.*)$#i", $this->cal_format) && $this->cal_hideRunning && !$event['recurring'] && $event['startTime'] < time()) {
+						continue;
+					}
+
+					// Hide running non-recurring events for past_ (see #6387)
+					if (preg_match("#^past_(.*)$#i", $this->cal_format) && $this->cal_hideRunning && !$event['recurring'] && $event['endTime'] > time()) {
 						continue;
 					}
 

--- a/calendar-bundle/src/Resources/contao/modules/ModuleEventlist.php
+++ b/calendar-bundle/src/Resources/contao/modules/ModuleEventlist.php
@@ -219,13 +219,9 @@ class ModuleEventlist extends Events
 						continue;
 					}
 
-					// Hide running non-recurring events (see #30) for next_ 
-					if (preg_match("#^next_(.*)$#i", $this->cal_format) && $this->cal_hideRunning && !$event['recurring'] && $event['startTime'] < time()) {
-						continue;
-					}
-
-					// Hide running non-recurring events for past_ (see #6387)
-					if (preg_match("#^past_(.*)$#i", $this->cal_format) && $this->cal_hideRunning && !$event['recurring'] && $event['endTime'] > time()) {
+					// Hide running non-recurring events (see #30)
+					if ($this->cal_hideRunning && !$event['recurring'] && $event['effectiveEndTime'] > time())
+					{
 						continue;
 					}
 


### PR DESCRIPTION
Fixes #6387

this change fixes a bug in the behavior of the "hide running events". when showing past events.

