### PR TITLE
Remove the fallback to `$GLOBALS['objPage']` in the page access listener

### DIFF
--- a/core-bundle/src/EventListener/PageAccessListener.php
+++ b/core-bundle/src/EventListener/PageAccessListener.php
@@ -76,17 +76,6 @@ class PageAccessListener
 
         $pageModel = $request->attributes->get('pageModel');
 
-        if (
-            isset($GLOBALS['objPage'])
-            && $GLOBALS['objPage'] instanceof PageModel
-            && (
-                ($pageModel instanceof PageModel && (int) $pageModel->id === $GLOBALS['objPage']->id)
-                || (!$pageModel instanceof PageModel && $GLOBALS['objPage']->id === (int) $pageModel)
-            )
-        ) {
-            return $GLOBALS['objPage'];
-        }
-
         if ($pageModel instanceof PageModel) {
             return $pageModel;
         }

--- a/core-bundle/tests/EventListener/PageAccessListenerTest.php
+++ b/core-bundle/tests/EventListener/PageAccessListenerTest.php
@@ -49,34 +49,6 @@ class PageAccessListenerTest extends TestCase
         $this->assertFalse($request->attributes->has('pageModel'));
     }
 
-    public function testSetsPageModelFromGlobalWithIdInRequest(): void
-    {
-        $security = $this->createMock(Security::class);
-        $security
-            ->expects($this->never())
-            ->method('isGranted')
-        ;
-
-        $request = new Request();
-        $request->attributes->set('pageModel', 42);
-
-        $event = $this->createMock(RequestEvent::class);
-        $event
-            ->expects($this->once())
-            ->method('getRequest')
-            ->willReturn($request)
-        ;
-
-        $GLOBALS['objPage'] = $this->mockClassWithProperties(PageModel::class, ['id' => 42]);
-
-        $listener = new PageAccessListener($this->mockFramework(), $security);
-        $listener($event);
-
-        $this->assertSame($GLOBALS['objPage'], $request->attributes->get('pageModel'));
-
-        unset($GLOBALS['objPage']);
-    }
-
     public function testSetsPageModelFromModelWithIdInRequest(): void
     {
         $security = $this->createMock(Security::class);
@@ -101,37 +73,6 @@ class PageAccessListenerTest extends TestCase
         $listener($event);
 
         $this->assertSame($pageModel, $request->attributes->get('pageModel'));
-    }
-
-    public function testSetsPageModelFromGlobalWithModelInRequest(): void
-    {
-        $security = $this->createMock(Security::class);
-        $security
-            ->expects($this->never())
-            ->method('isGranted')
-        ;
-
-        $pageModel = $this->mockClassWithProperties(PageModel::class, ['id' => 42]);
-
-        $request = new Request();
-        $request->attributes->set('pageModel', $pageModel);
-
-        $event = $this->createMock(RequestEvent::class);
-        $event
-            ->expects($this->once())
-            ->method('getRequest')
-            ->willReturn($request)
-        ;
-
-        $GLOBALS['objPage'] = $this->mockClassWithProperties(PageModel::class, ['id' => 42]);
-
-        $listener = new PageAccessListener($this->mockFramework(), $security);
-        $listener($event);
-
-        $this->assertNotSame($pageModel, $request->attributes->get('pageModel'));
-        $this->assertSame($GLOBALS['objPage'], $request->attributes->get('pageModel'));
-
-        unset($GLOBALS['objPage']);
     }
 
     public function testSetsPageModelFromModelInRequest(): void


### PR DESCRIPTION
Falling back to `$GLOBALS['objPage']` is a left-over from Contao 4 and has already been removed everywhere else.