### PR TITLE
Handle empty sessions in the CSRF cookie subscriber

### DIFF
--- a/core-bundle/src/EventListener/CsrfTokenCookieSubscriber.php
+++ b/core-bundle/src/EventListener/CsrfTokenCookieSubscriber.php
@@ -115,7 +115,7 @@ class CsrfTokenCookieSubscriber implements EventSubscriberInterface
             return true;
         }
 
-        if ($request->hasSession() && $request->getSession()->isStarted()) {
+        if ($request->hasSession() && $request->getSession()->isStarted() && [] !== $request->getSession()->all()) {
             return true;
         }
 

--- a/core-bundle/src/EventListener/CsrfTokenCookieSubscriber.php
+++ b/core-bundle/src/EventListener/CsrfTokenCookieSubscriber.php
@@ -22,6 +22,8 @@ use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
@@ -115,11 +117,25 @@ class CsrfTokenCookieSubscriber implements EventSubscriberInterface
             return true;
         }
 
-        if ($request->hasSession() && $request->getSession()->isStarted() && [] !== $request->getSession()->all()) {
+        if ($request->hasSession() && !$this->isSessionEmpty($request->getSession())) {
             return true;
         }
 
         return false;
+    }
+
+    private function isSessionEmpty(SessionInterface $session): bool
+    {
+        if (!$session->isStarted()) {
+            return true;
+        }
+
+        if ($session instanceof Session) {
+            // Marked @internal but no other way to check all attribute bags
+            return $session->isEmpty();
+        }
+
+        return [] === $session->all();
     }
 
     private function setCookies(Request $request, Response $response): void

--- a/core-bundle/tests/EventListener/CsrfTokenCookieSubscriberTest.php
+++ b/core-bundle/tests/EventListener/CsrfTokenCookieSubscriberTest.php
@@ -140,10 +140,11 @@ class CsrfTokenCookieSubscriberTest extends TestCase
 
     public function testDoesNotAddTheTokenCookiesIfTheSessionWasStartedButClearedAgain(): void
     {
-        $request = Request::create('https://foobar.com');
         $session = new Session(new MockArraySessionStorage());
         $session->set('foobar', 'foobaz'); // This starts the session
         $session->remove('foobar'); // This removes the value but the session remains started
+
+        $request = Request::create('https://foobar.com');
         $request->setSession($session);
 
         $tokenManager = $this->createMock(ContaoCsrfTokenManager::class);

--- a/core-bundle/tests/EventListener/CsrfTokenCookieSubscriberTest.php
+++ b/core-bundle/tests/EventListener/CsrfTokenCookieSubscriberTest.php
@@ -21,6 +21,8 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
@@ -126,6 +128,30 @@ class CsrfTokenCookieSubscriberTest extends TestCase
             ->expects($this->once())
             ->method('getUsedTokens')
             ->willReturn(['foo' => 'bar'])
+        ;
+
+        $response = new Response();
+
+        $listener = new CsrfTokenCookieSubscriber($tokenManager, $tokenStorage);
+        $listener->onKernelResponse($this->getResponseEvent($request, $response));
+
+        $this->assertCount(0, $response->headers->getCookies());
+    }
+
+    public function testDoesNotAddTheTokenCookiesIfTheSessionWasStartedButClearedAgain(): void
+    {
+        $request = Request::create('https://foobar.com');
+        $session = new Session(new MockArraySessionStorage());
+        $session->set('foobar', 'foobaz'); // This starts the session
+        $session->remove('foobar'); // This removes the value but the session remains started
+        $request->setSession($session);
+
+        $tokenManager = $this->createMock(ContaoCsrfTokenManager::class);
+
+        $tokenStorage = $this->createMock(MemoryTokenStorage::class);
+        $tokenStorage
+            ->expects($this->never())
+            ->method('getUsedTokens')
         ;
 
         $response = new Response();


### PR DESCRIPTION
If you have some code that adds something to the session (and thus starts it) and some code that removes it again, our CsrfTokenCookieSubscriber would still add the CSRF cookie token as the session was started. This makes no sense if the session is empty, thus we need to add this check on top :) 