### PR TITLE
Fix the referrer URL if elements are moved inside a nested element

### DIFF
--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -237,10 +237,10 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 		$route = $request->attributes->get('_route');
 
 		// Store the current referer
-		if (!empty($this->ctable) && $route == 'contao_backend' && !Input::get('act') && !Input::get('key') && !Input::get('token') && !Environment::get('isAjaxRequest'))
+		if (!empty($this->ctable) && !Input::get('ptable') && $route == 'contao_backend' && !Input::get('act') && !Input::get('key') && !Input::get('token') && !Environment::get('isAjaxRequest'))
 		{
 			$strKey = Input::get('popup') ? 'popupReferer' : 'referer';
-			$strRefererId = $container->get('request_stack')->getCurrentRequest()->attributes->get('_contao_referer_id');
+			$strRefererId = $request->attributes->get('_contao_referer_id');
 
 			$session = $objSession->get($strKey);
 			$session[$strRefererId][$this->strTable] = Environment::get('requestUri');


### PR DESCRIPTION
Fixes #6776

This fixes any issues at the first nesting level, e.g. if you move a content element into an accordion or slider element.

However, it will not fix elements nested beyond the first level, e.g. a content group in a slider element or an accordion in an accordion, as our current referrer management is not designed for such cases and I have not succeeded in adapting the logic.

I would rather revise the referrer management for Contao 5.4 and make it completely client-side.