### PR TITLE
Correctly handle denied access in the firewall

### DIFF
--- a/core-bundle/README.md
+++ b/core-bundle/README.md
@@ -98,6 +98,7 @@ security:
             request_matcher: contao.routing.frontend_matcher
             provider: contao.security.frontend_user_provider
             user_checker: contao.security.user_checker
+            access_denied_handler: contao.security.access_denied_handler
             switch_user: false
             login_throttling: ~
 

--- a/core-bundle/config/listener.yaml
+++ b/core-bundle/config/listener.yaml
@@ -481,6 +481,7 @@ services:
         arguments:
             - '@contao.framework'
             - '@contao.routing.scope_matcher'
+            - '@contao.routing.page_finder'
             - '@contao.routing.content_url_generator'
             - '@security.token_storage'
             - '%scheb_two_factor.security_tokens%'

--- a/core-bundle/config/services.yaml
+++ b/core-bundle/config/services.yaml
@@ -851,6 +851,13 @@ services:
             - !tagged_iterator security.voter
             - '@contao.security.priority_strategy'
 
+    contao.security.access_denied_handler:
+        class: Contao\CoreBundle\Security\Authentication\AccessDeniedHandler
+        arguments:
+            - '@contao.routing.page_finder'
+            - '@contao.routing.page_registry'
+            - '@http_kernel'
+
     contao.security.authentication_failure_handler:
         class: Contao\CoreBundle\Security\Authentication\AuthenticationFailureHandler
         arguments:
@@ -974,7 +981,7 @@ services:
             - '@contao.routing.scope_matcher'
             - '@router.default'
             - '@uri_signer'
-            - '@contao.framework'
+            - '@contao.routing.page_finder'
             - '@security.token_storage'
             - '@contao.routing.page_registry'
             - '@http_kernel'

--- a/core-bundle/contao/languages/en/default.xlf
+++ b/core-bundle/contao/languages/en/default.xlf
@@ -128,6 +128,9 @@
       <trans-unit id="ERR.invalidLogin">
         <source>Login failed (note that usernames and passwords are case-sensitive)!</source>
       </trans-unit>
+      <trans-unit id="ERR.insufficientAuthentication">
+        <source>Full authentication is required to access this resource.</source>
+      </trans-unit>
       <trans-unit id="ERR.invalidColor">
         <source>Invalid color format!</source>
       </trans-unit>

--- a/core-bundle/contao/languages/en/default.xlf
+++ b/core-bundle/contao/languages/en/default.xlf
@@ -129,7 +129,7 @@
         <source>Login failed (note that usernames and passwords are case-sensitive)!</source>
       </trans-unit>
       <trans-unit id="ERR.insufficientAuthentication">
-        <source>Please re-authenticate to access this resource.</source>
+        <source>Please enter your password to continue.</source>
       </trans-unit>
       <trans-unit id="ERR.invalidColor">
         <source>Invalid color format!</source>

--- a/core-bundle/contao/languages/en/default.xlf
+++ b/core-bundle/contao/languages/en/default.xlf
@@ -128,9 +128,6 @@
       <trans-unit id="ERR.invalidLogin">
         <source>Login failed (note that usernames and passwords are case-sensitive)!</source>
       </trans-unit>
-      <trans-unit id="ERR.insufficientAuthentication">
-        <source>Please enter your password to continue.</source>
-      </trans-unit>
       <trans-unit id="ERR.invalidColor">
         <source>Invalid color format!</source>
       </trans-unit>
@@ -1789,6 +1786,12 @@
       </trans-unit>
       <trans-unit id="MSC.emptyField">
         <source>Please enter your username and password!</source>
+      </trans-unit>
+      <trans-unit id="MSC.reauthenticate">
+        <source>Please enter your password to verify your identity.</source>
+      </trans-unit>
+      <trans-unit id="MSC.verify">
+        <source>Verify</source>
       </trans-unit>
       <trans-unit id="MSC.confirmation">
         <source>Confirmation</source>

--- a/core-bundle/contao/languages/en/default.xlf
+++ b/core-bundle/contao/languages/en/default.xlf
@@ -129,7 +129,7 @@
         <source>Login failed (note that usernames and passwords are case-sensitive)!</source>
       </trans-unit>
       <trans-unit id="ERR.insufficientAuthentication">
-        <source>Full authentication is required to access this resource.</source>
+        <source>Please re-authenticate to access this resource.</source>
       </trans-unit>
       <trans-unit id="ERR.invalidColor">
         <source>Invalid color format!</source>

--- a/core-bundle/contao/models/PageModel.php
+++ b/core-bundle/contao/models/PageModel.php
@@ -475,10 +475,13 @@ class PageModel extends Model
 	 * @param array   $arrOptions An optional options array
 	 *
 	 * @return PageModel|null The model or null if there is no 401 page
+	 *
+	 * @deprecated Deprecated since Contao 5.3, to be removed in Contao 6;
+	 *             use the contao.routing.page_finder service instead.
 	 */
 	public static function find401ByPid($intPid, array $arrOptions=array())
 	{
-		trigger_deprecation('contao/core-bundle', '5.3', 'Using "%s()" has been deprecated and will no longer work in Contao 6. Use the contao.routing.page_finder service instead.', __METHOD__);
+		trigger_deprecation('contao/core-bundle', '5.3', 'Using "%s()" has been deprecated and will no longer work in Contao 6. Use the "contao.routing.page_finder" service instead.', __METHOD__);
 
 		$t = static::$strTable;
 		$arrColumns = array("$t.pid=? AND $t.type='error_401'");
@@ -504,10 +507,13 @@ class PageModel extends Model
 	 * @param array   $arrOptions An optional options array
 	 *
 	 * @return PageModel|null The model or null if there is no 403 page
+	 *
+	 * @deprecated Deprecated since Contao 5.3, to be removed in Contao 6;
+	 *             use the contao.routing.page_finder service instead.
 	 */
 	public static function find403ByPid($intPid, array $arrOptions=array())
 	{
-		trigger_deprecation('contao/core-bundle', '5.3', 'Using "%s()" has been deprecated and will no longer work in Contao 6. Use the contao.routing.page_finder service instead.', __METHOD__);
+		trigger_deprecation('contao/core-bundle', '5.3', 'Using "%s()" has been deprecated and will no longer work in Contao 6. Use the "contao.routing.page_finder" service instead.', __METHOD__);
 
 		$t = static::$strTable;
 		$arrColumns = array("$t.pid=? AND $t.type='error_403'");
@@ -533,10 +539,13 @@ class PageModel extends Model
 	 * @param array   $arrOptions An optional options array
 	 *
 	 * @return PageModel|null The model or null if there is no 404 page
+	 *
+	 * @deprecated Deprecated since Contao 5.3, to be removed in Contao 6;
+	 *             use the contao.routing.page_finder service instead.
 	 */
 	public static function find404ByPid($intPid, array $arrOptions=array())
 	{
-		trigger_deprecation('contao/core-bundle', '5.3', 'Using "%s()" has been deprecated and will no longer work in Contao 6. Use the contao.routing.page_finder service instead.', __METHOD__);
+		trigger_deprecation('contao/core-bundle', '5.3', 'Using "%s()" has been deprecated and will no longer work in Contao 6. Use the "contao.routing.page_finder" service instead.', __METHOD__);
 
 		$t = static::$strTable;
 		$arrColumns = array("$t.pid=? AND $t.type='error_404'");

--- a/core-bundle/contao/models/PageModel.php
+++ b/core-bundle/contao/models/PageModel.php
@@ -478,6 +478,8 @@ class PageModel extends Model
 	 */
 	public static function find401ByPid($intPid, array $arrOptions=array())
 	{
+		trigger_deprecation('contao/core-bundle', '5.3', 'Using "%s()" has been deprecated and will no longer work in Contao 6. Use the contao.routing.page_finder service instead.', __METHOD__);
+
 		$t = static::$strTable;
 		$arrColumns = array("$t.pid=? AND $t.type='error_401'");
 
@@ -505,6 +507,8 @@ class PageModel extends Model
 	 */
 	public static function find403ByPid($intPid, array $arrOptions=array())
 	{
+		trigger_deprecation('contao/core-bundle', '5.3', 'Using "%s()" has been deprecated and will no longer work in Contao 6. Use the contao.routing.page_finder service instead.', __METHOD__);
+
 		$t = static::$strTable;
 		$arrColumns = array("$t.pid=? AND $t.type='error_403'");
 
@@ -532,6 +536,8 @@ class PageModel extends Model
 	 */
 	public static function find404ByPid($intPid, array $arrOptions=array())
 	{
+		trigger_deprecation('contao/core-bundle', '5.3', 'Using "%s()" has been deprecated and will no longer work in Contao 6. Use the contao.routing.page_finder service instead.', __METHOD__);
+
 		$t = static::$strTable;
 		$arrColumns = array("$t.pid=? AND $t.type='error_404'");
 

--- a/core-bundle/contao/modules/ModuleChangePassword.php
+++ b/core-bundle/contao/modules/ModuleChangePassword.php
@@ -55,7 +55,7 @@ class ModuleChangePassword extends Module
 
 		if (!$security->isGranted('IS_AUTHENTICATED_FULLY'))
 		{
-			throw new AccessDeniedException('Full authentication is required to change the user password.');
+			throw new AccessDeniedException('Full authentication is required to change the password.');
 		}
 
 		return parent::generate();

--- a/core-bundle/contao/modules/ModuleChangePassword.php
+++ b/core-bundle/contao/modules/ModuleChangePassword.php
@@ -10,6 +10,8 @@
 
 namespace Contao;
 
+use Contao\CoreBundle\Exception\AccessDeniedException;
+
 /**
  * Front end module "change password".
  */
@@ -43,10 +45,17 @@ class ModuleChangePassword extends Module
 			return $objTemplate->parse();
 		}
 
+		$security = $container->get('security.helper');
+
 		// Return if there is no logged-in user
-		if (!$container->get('contao.security.token_checker')->hasFrontendUser())
+		if (!$security->getUser() instanceof FrontendUser)
 		{
 			return '';
+		}
+
+		if (!$security->isGranted('IS_AUTHENTICATED_FULLY'))
+		{
+			throw new AccessDeniedException('Full authentication is required to change the user password.');
 		}
 
 		return parent::generate();

--- a/core-bundle/contao/modules/ModuleLogin.php
+++ b/core-bundle/contao/modules/ModuleLogin.php
@@ -119,9 +119,7 @@ class ModuleLogin extends Module
 		$isRemembered = $security->isGranted('IS_REMEMBERED');
 		$isTwoFactorInProgress = $security->isGranted('IS_AUTHENTICATED_2FA_IN_PROGRESS');
 
-		/*
-		 * Do not show the logout button if the user is REMEMBERME, and we are on the 401 page or the redirect page of the 401
-		 */
+		// Do not show the logout button if the user is REMEMBERME, and we are on the 401 page or the redirect page of the 401
 		if ($user instanceof FrontendUser && !$isTwoFactorInProgress && (!$isRemembered || ($objPage->type != 'error_401' && $request && $this->targetPath !== $request->query->get('redirect'))))
 		{
 			$strRedirect = Environment::get('uri');

--- a/core-bundle/contao/modules/ModuleLogin.php
+++ b/core-bundle/contao/modules/ModuleLogin.php
@@ -14,7 +14,6 @@ use Nyholm\Psr7\Uri;
 use Scheb\TwoFactorBundle\Security\Authentication\Exception\InvalidTwoFactorCodeException;
 use Scheb\TwoFactorBundle\Security\TwoFactor\Event\TwoFactorAuthenticationEvent;
 use Scheb\TwoFactorBundle\Security\TwoFactor\Event\TwoFactorAuthenticationEvents;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\Exception\InsufficientAuthenticationException;

--- a/core-bundle/contao/modules/ModuleLogin.php
+++ b/core-bundle/contao/modules/ModuleLogin.php
@@ -119,7 +119,7 @@ class ModuleLogin extends Module
 		$isRemembered = $security->isGranted('IS_REMEMBERED');
 		$isTwoFactorInProgress = $security->isGranted('IS_AUTHENTICATED_2FA_IN_PROGRESS');
 
-		/**
+		/*
 		 * Do not show the logout button if the user is REMEMBERME, and we are on the 401 page or the redirect page of the 401
 		 */
 		if ($user instanceof FrontendUser && !$isTwoFactorInProgress && (!$isRemembered || ($objPage->type != 'error_401' && $request && $this->targetPath !== $request->query->get('redirect'))))

--- a/core-bundle/contao/modules/ModuleLogin.php
+++ b/core-bundle/contao/modules/ModuleLogin.php
@@ -119,8 +119,11 @@ class ModuleLogin extends Module
 		$isRemembered = $security->isGranted('IS_REMEMBERED');
 		$isTwoFactorInProgress = $security->isGranted('IS_AUTHENTICATED_2FA_IN_PROGRESS');
 
-		// Do not show the logout button if the user is REMEMBERME, and we are on the 401 page or the redirect page of the 401
-		if ($user instanceof FrontendUser && !$isTwoFactorInProgress && (!$isRemembered || ($objPage->type != 'error_401' && $request && $this->targetPath !== $request->query->get('redirect'))))
+		// The user can re-authenticate on the error_401 page or on the redirect page of the error_401 page
+		$canReauthenticate = $objPage->type == 'error_401' || $this->targetPath && $this->targetPath === $request?->query->get('redirect');
+
+		// Show the logout button if the user is fully authenticated or cannot re-authenticate on the current page
+		if ($user instanceof FrontendUser && !$isTwoFactorInProgress && (!$isRemembered || !$canReauthenticate))
 		{
 			$strRedirect = Environment::get('uri');
 

--- a/core-bundle/contao/modules/ModuleLogin.php
+++ b/core-bundle/contao/modules/ModuleLogin.php
@@ -122,7 +122,7 @@ class ModuleLogin extends Module
 		/**
 		 * Do not show the logout button if the user is REMEMBERME, and we are on the 401 page or the redirect page of the 401
 		 */
-		if ($user instanceof FrontendUser && !$isTwoFactorInProgress && (!$isRemembered || ($objPage->type != 'error_401' && $this->targetPath !== $request?->query->get('redirect'))))
+		if ($user instanceof FrontendUser && !$isTwoFactorInProgress && (!$isRemembered || ($objPage->type != 'error_401' && $request && $this->targetPath !== $request->query->get('redirect'))))
 		{
 			$strRedirect = Environment::get('uri');
 
@@ -154,7 +154,7 @@ class ModuleLogin extends Module
 		}
 
 		// Only call the authentication utils if there is an active session to prevent starting an empty session
-		if ($request?->hasSession() && ($request?->hasPreviousSession() || $request?->getSession()->isStarted()))
+		if ($request?->hasSession() && ($request->hasPreviousSession() || $request->getSession()->isStarted()))
 		{
 			$authUtils = $container->get('security.authentication_utils');
 			$exception = $authUtils->getLastAuthenticationError();

--- a/core-bundle/contao/modules/ModuleLogin.php
+++ b/core-bundle/contao/modules/ModuleLogin.php
@@ -122,7 +122,7 @@ class ModuleLogin extends Module
 		/**
 		 * Do not show the logout button if the user is REMEMBERME, and we are on the 401 page or the redirect page of the 401
 		 */
-		if ($request && $user instanceof FrontendUser && !$isTwoFactorInProgress && (!$isRemembered || ($objPage->type != 'error_401' && $this->targetPath !== $request->query->get('redirect'))))
+		if ($user instanceof FrontendUser && !$isTwoFactorInProgress && (!$isRemembered || ($objPage->type != 'error_401' && $this->targetPath !== $request?->query->get('redirect'))))
 		{
 			$strRedirect = Environment::get('uri');
 
@@ -154,7 +154,7 @@ class ModuleLogin extends Module
 		}
 
 		// Only call the authentication utils if there is an active session to prevent starting an empty session
-		if ($request?->hasSession() && ($request->hasPreviousSession() || $request->getSession()->isStarted()))
+		if ($request?->hasSession() && ($request?->hasPreviousSession() || $request?->getSession()->isStarted()))
 		{
 			$authUtils = $container->get('security.authentication_utils');
 			$exception = $authUtils->getLastAuthenticationError();
@@ -197,7 +197,7 @@ class ModuleLogin extends Module
 		$this->Template->forceTargetPath = (int) $blnRedirectBack;
 		$this->Template->targetPath = StringUtil::specialchars(base64_encode($strRedirect));
 
-		if ($isTwoFactorInProgress)
+		if ($isTwoFactorInProgress && $request)
 		{
 			// Dispatch 2FA form event to prepare 2FA providers
 			$token = $container->get('security.token_storage')->getToken();

--- a/core-bundle/contao/modules/ModuleLogin.php
+++ b/core-bundle/contao/modules/ModuleLogin.php
@@ -119,7 +119,10 @@ class ModuleLogin extends Module
 		$isRemembered = $security->isGranted('IS_REMEMBERED');
 		$isTwoFactorInProgress = $security->isGranted('IS_AUTHENTICATED_2FA_IN_PROGRESS');
 
-		if ($request && $user instanceof FrontendUser && !$isTwoFactorInProgress && (!$isRemembered || $objPage->type != 'error_401'))
+		/**
+		 * Do not show the logout button if the user is REMEMBERME, and we are on the 401 page or the redirect page of the 401
+		 */
+		if ($request && $user instanceof FrontendUser && !$isTwoFactorInProgress && (!$isRemembered || ($objPage->type != 'error_401' && $this->targetPath !== $request->query->get('redirect'))))
 		{
 			$strRedirect = Environment::get('uri');
 
@@ -228,6 +231,7 @@ class ModuleLogin extends Module
 		if ($isRemembered)
 		{
 			$this->Template->slabel = StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['verify']);
+			$this->Template->loggedInAs = sprintf($GLOBALS['TL_LANG']['MSC']['loggedInAs'], $user->getUserIdentifier());
 			$this->Template->reauthenticate = StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['reauthenticate']);
 			$this->Template->value = Input::encodeInsertTags(StringUtil::specialchars($user->getUserIdentifier()));
 			$this->Template->remembered = true;

--- a/core-bundle/contao/modules/ModuleLogin.php
+++ b/core-bundle/contao/modules/ModuleLogin.php
@@ -119,7 +119,7 @@ class ModuleLogin extends Module
 		$isRemembered = $security->isGranted('IS_REMEMBERED');
 		$isTwoFactorInProgress = $security->isGranted('IS_AUTHENTICATED_2FA_IN_PROGRESS');
 
-		if ($request && $user instanceof FrontendUser && !$isTwoFactorInProgress && (!$isRemembered || $objPage->type !== 'error_401'))
+		if ($request && $user instanceof FrontendUser && !$isTwoFactorInProgress && (!$isRemembered || $objPage->type != 'error_401'))
 		{
 			$strRedirect = Environment::get('uri');
 
@@ -173,11 +173,6 @@ class ModuleLogin extends Module
 			$this->Template->hasError = true;
 			$this->Template->message = $GLOBALS['TL_LANG']['ERR']['invalidLogin'];
 		}
-		elseif ($isRemembered)
-		{
-			$this->Template->hasError = true;
-			$this->Template->message = $GLOBALS['TL_LANG']['ERR']['insufficientAuthentication'];
-		}
 
 		$blnRedirectBack = false;
 		$strRedirect = Environment::get('uri');
@@ -227,12 +222,13 @@ class ModuleLogin extends Module
 		$this->Template->slabel = StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['login']);
 		$this->Template->value = Input::encodeInsertTags(StringUtil::specialchars($lastUsername));
 		$this->Template->autologin = $this->autologin;
-		$this->Template->remembered = false;
 		$this->Template->autoLabel = $GLOBALS['TL_LANG']['MSC']['autologin'];
+		$this->Template->remembered = false;
 
 		if ($isRemembered)
 		{
-			$this->Template->loggedInAs = sprintf($GLOBALS['TL_LANG']['MSC']['loggedInAs'], $user->getUserIdentifier());
+			$this->Template->slabel = StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['verify']);
+			$this->Template->reauthenticate = StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['reauthenticate']);
 			$this->Template->value = Input::encodeInsertTags(StringUtil::specialchars($user->getUserIdentifier()));
 			$this->Template->remembered = true;
 		}

--- a/core-bundle/contao/modules/ModuleLogin.php
+++ b/core-bundle/contao/modules/ModuleLogin.php
@@ -108,7 +108,6 @@ class ModuleLogin extends Module
 		$request = $container->get('request_stack')->getCurrentRequest();
 		$exception = null;
 		$lastUsername = '';
-		$isRememberMe = $this->isRememberMe();
 
 		// Only call the authentication utils if there is an active session to prevent starting an empty session
 		if ($request?->hasSession() && ($request->hasPreviousSession() || $request->getSession()->isStarted()))
@@ -150,6 +149,8 @@ class ModuleLogin extends Module
 
 			return;
 		}
+
+		$isRememberMe = $this->isRememberMe();
 
 		if ($exception instanceof TooManyLoginAttemptsAuthenticationException)
 		{
@@ -229,7 +230,6 @@ class ModuleLogin extends Module
 	private function isLoggedIn(AuthenticationException|null $authException): bool
 	{
 		$container = System::getContainer();
-
 		$token = $container->get('security.token_storage')->getToken();
 		$trustResolver = $container->get('security.authentication.trust_resolver');
 
@@ -249,7 +249,6 @@ class ModuleLogin extends Module
 	private function isRememberMe(): bool
 	{
 		$container = System::getContainer();
-
 		$token = $container->get('security.token_storage')->getToken();
 		$trustResolver = $container->get('security.authentication.trust_resolver');
 

--- a/core-bundle/contao/modules/ModulePersonalData.php
+++ b/core-bundle/contao/modules/ModulePersonalData.php
@@ -49,10 +49,17 @@ class ModulePersonalData extends Module
 		}
 
 		$this->editable = StringUtil::deserialize($this->editable);
+
+		// Return if there are no editable fields
+		if (empty($this->editable) || !\is_array($this->editable))
+		{
+			return '';
+		}
+
 		$security = $container->get('security.helper');
 
-		// Return if there are no editable fields or if there is no logged-in user
-		if (empty($this->editable) || !\is_array($this->editable) || !$security->getUser() instanceof FrontendUser)
+		// Return if there is no logged-in user
+		if (!$security->getUser() instanceof FrontendUser)
 		{
 			return '';
 		}

--- a/core-bundle/contao/modules/ModulePersonalData.php
+++ b/core-bundle/contao/modules/ModulePersonalData.php
@@ -10,6 +10,7 @@
 
 namespace Contao;
 
+use Contao\CoreBundle\Exception\AccessDeniedException;
 use Contao\CoreBundle\Exception\ResponseException;
 
 /**
@@ -48,11 +49,17 @@ class ModulePersonalData extends Module
 		}
 
 		$this->editable = StringUtil::deserialize($this->editable);
+		$security = $container->get('security.helper');
 
 		// Return if there are no editable fields or if there is no logged-in user
-		if (empty($this->editable) || !\is_array($this->editable) || !$container->get('contao.security.token_checker')->hasFrontendUser())
+		if (empty($this->editable) || !\is_array($this->editable) || !$security->getUser() instanceof FrontendUser)
 		{
 			return '';
+		}
+
+		if (!$security->isGranted('IS_AUTHENTICATED_FULLY'))
+		{
+			throw new AccessDeniedException('Full authentication is required to edit the personal data.');
 		}
 
 		if ($this->memberTpl)

--- a/core-bundle/contao/templates/modules/mod_login.html5
+++ b/core-bundle/contao/templates/modules/mod_login.html5
@@ -16,7 +16,7 @@
       <input type="hidden" name="_target_path" value="<?= $this->targetPath ?>">
       <input type="hidden" name="_always_use_target_path" value="<?= $this->forceTargetPath ?>">
       <?php if ($this->rememberMe): ?>
-      <input type="hidden" name="autologin" value="1">
+        <input type="hidden" name="autologin" value="1">
       <?php endif; ?>
       <?php if ($this->logout): ?>
         <p class="login_info"><?= $this->loggedInAs ?><br><?= $this->lastLogin ?></p>

--- a/core-bundle/contao/templates/modules/mod_login.html5
+++ b/core-bundle/contao/templates/modules/mod_login.html5
@@ -15,6 +15,9 @@
       <input type="hidden" name="REQUEST_TOKEN" value="<?= $this->requestToken ?>">
       <input type="hidden" name="_target_path" value="<?= $this->targetPath ?>">
       <input type="hidden" name="_always_use_target_path" value="<?= $this->forceTargetPath ?>">
+      <?php if ($this->rememberMe): ?>
+      <input type="hidden" name="autologin" value="1">
+      <?php endif; ?>
       <?php if ($this->logout): ?>
         <p class="login_info"><?= $this->loggedInAs ?><br><?= $this->lastLogin ?></p>
       <?php elseif ($this->twoFactorEnabled): ?>

--- a/core-bundle/contao/templates/modules/mod_login.html5
+++ b/core-bundle/contao/templates/modules/mod_login.html5
@@ -33,7 +33,7 @@
         </div>
       <?php else: ?>
         <?php if ($this->remembered): ?>
-          <p class="login_info"><?= $this->reauthenticate ?></p>
+          <p class="login_info"><?= $this->loggedInAs ?><br><?= $this->reauthenticate ?></p>
         <?php else: ?>
           <div class="widget widget-text">
             <label for="username"><?= $this->username ?></label>

--- a/core-bundle/contao/templates/modules/mod_login.html5
+++ b/core-bundle/contao/templates/modules/mod_login.html5
@@ -33,7 +33,7 @@
         </div>
       <?php else: ?>
         <?php if ($this->remembered): ?>
-          <p class="login_info"><?= $this->loggedInAs ?></p>
+          <p class="login_info"><?= $this->reauthenticate ?></p>
         <?php else: ?>
           <div class="widget widget-text">
             <label for="username"><?= $this->username ?></label>

--- a/core-bundle/contao/templates/modules/mod_login.html5
+++ b/core-bundle/contao/templates/modules/mod_login.html5
@@ -15,8 +15,9 @@
       <input type="hidden" name="REQUEST_TOKEN" value="<?= $this->requestToken ?>">
       <input type="hidden" name="_target_path" value="<?= $this->targetPath ?>">
       <input type="hidden" name="_always_use_target_path" value="<?= $this->forceTargetPath ?>">
-      <?php if ($this->rememberMe): ?>
-        <input type="hidden" name="autologin" value="1">
+      <?php if ($this->remembered): ?>
+        <input type="hidden" name="username" value="<?= $this->value ?>">
+        <input type="hidden" name="autologin" value="<?= $this->autologin ? '1' : '' ?>">
       <?php endif; ?>
       <?php if ($this->logout): ?>
         <p class="login_info"><?= $this->loggedInAs ?><br><?= $this->lastLogin ?></p>
@@ -31,15 +32,19 @@
           <label for="trusted"><?= $this->trans('MSC.twoFactorTrustDevice') ?></label>
         </div>
       <?php else: ?>
-        <div class="widget widget-text">
-          <label for="username"><?= $this->username ?></label>
-          <input type="text" name="username" id="username" class="text" value="<?= $this->value ?>" autocapitalize="off" autocomplete="username" required>
-        </div>
+        <?php if ($this->remembered): ?>
+          <p class="login_info"><?= $this->loggedInAs ?></p>
+        <?php else: ?>
+          <div class="widget widget-text">
+            <label for="username"><?= $this->username ?></label>
+            <input type="text" name="username" id="username" class="text" value="<?= $this->value ?>" autocapitalize="off" autocomplete="username" required>
+          </div>
+        <?php endif; ?>
         <div class="widget widget-password">
           <label for="password"><?= $this->password ?></label>
           <input type="password" name="password" id="password" class="text password" value="" autocomplete="current-password" required>
         </div>
-        <?php if ($this->autologin): ?>
+        <?php if ($this->autologin && !$this->remembered): ?>
           <div class="widget widget-checkbox">
             <fieldset class="checkbox_container">
               <span><input type="checkbox" name="autologin" id="autologin" value="1" class="checkbox"> <label for="autologin"><?= $this->autoLabel ?></label></span>

--- a/core-bundle/src/Controller/FrontendModule/TwoFactorController.php
+++ b/core-bundle/src/Controller/FrontendModule/TwoFactorController.php
@@ -38,24 +38,6 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 #[AsFrontendModule(category: 'user', template: 'mod_two_factor')]
 class TwoFactorController extends AbstractFrontendModuleController
 {
-    protected PageModel|null $pageModel = null;
-
-    public function __invoke(Request $request, ModuleModel $model, string $section, array|null $classes = null, PageModel|null $pageModel = null): Response
-    {
-        if (!$this->container->get('security.helper')->isGranted('IS_AUTHENTICATED_FULLY')) {
-            // TODO: front end users should be able to re-authenticate after REMEMBERME
-            return new Response('', Response::HTTP_NO_CONTENT);
-        }
-
-        if ($pageModel && $this->container->get('contao.routing.scope_matcher')->isFrontendRequest($request)) {
-            $pageModel->loadDetails();
-        }
-
-        $this->pageModel = $pageModel;
-
-        return parent::__invoke($request, $model, $section, $classes);
-    }
-
     public static function getSubscribedServices(): array
     {
         $services = parent::getSubscribedServices();
@@ -75,28 +57,31 @@ class TwoFactorController extends AbstractFrontendModuleController
     protected function getResponse(Template $template, ModuleModel $model, Request $request): Response
     {
         $user = $this->container->get('security.helper')->getUser();
+        $pageModel = $this->getPageModel();
 
-        if (!$user instanceof FrontendUser) {
+        if (!$user instanceof FrontendUser || !$pageModel) {
             return new Response('', Response::HTTP_NO_CONTENT);
         }
 
+        $this->denyAccessUnlessGranted('IS_AUTHENTICATED_FULLY', null, 'Full authentication is required to configure two-factor authentication.');
+
         $adapter = $this->getContaoAdapter(PageModel::class);
         $redirectPage = $model->jumpTo > 0 ? $adapter->findByPk($model->jumpTo) : null;
-        $return = $this->generateContentUrl($redirectPage instanceof PageModel ? $redirectPage : $this->pageModel, [], UrlGeneratorInterface::ABSOLUTE_URL);
+        $return = $this->generateContentUrl($redirectPage instanceof PageModel ? $redirectPage : $pageModel, [], UrlGeneratorInterface::ABSOLUTE_URL);
 
-        $template->enforceTwoFactor = $this->pageModel->enforceTwoFactor;
+        $template->enforceTwoFactor = $pageModel->enforceTwoFactor;
         $template->targetPath = $return;
 
         $translator = $this->container->get('translator');
 
         // Inform the user if 2FA is enforced
-        if ($this->pageModel->enforceTwoFactor) {
+        if ($pageModel->enforceTwoFactor) {
             $template->message = $translator->trans('MSC.twoFactorEnforced', [], 'contao_default');
         }
 
         $enable = 'enable' === $request->get('2fa');
 
-        if (!$user->useTwoFactor && $this->pageModel->enforceTwoFactor) {
+        if (!$user->useTwoFactor && $pageModel->enforceTwoFactor) {
             $enable = true;
         }
 
@@ -106,7 +91,7 @@ class TwoFactorController extends AbstractFrontendModuleController
 
         $formId = $request->request->get('FORM_SUBMIT');
 
-        if ('tl_two_factor_disable' === $formId && ($response = $this->disableTwoFactor($user))) {
+        if ('tl_two_factor_disable' === $formId && ($response = $this->disableTwoFactor($user, $pageModel))) {
             return $response;
         }
 
@@ -126,7 +111,7 @@ class TwoFactorController extends AbstractFrontendModuleController
         }
 
         $template->isEnabled = (bool) $user->useTwoFactor;
-        $template->href = $this->generateContentUrl($this->pageModel, [], UrlGeneratorInterface::ABSOLUTE_URL).'?2fa=enable';
+        $template->href = $this->generateContentUrl($pageModel, [], UrlGeneratorInterface::ABSOLUTE_URL).'?2fa=enable';
         $template->trustedDevices = $this->container->get('contao.security.two_factor.trusted_device_manager')->getTrustedDevices($user);
 
         return $template->getResponse();
@@ -173,7 +158,7 @@ class TwoFactorController extends AbstractFrontendModuleController
         return null;
     }
 
-    private function disableTwoFactor(FrontendUser $user): Response|null
+    private function disableTwoFactor(FrontendUser $user, PageModel $pageModel): Response|null
     {
         // Return if 2FA is disabled already
         if (!$user->useTwoFactor) {
@@ -188,6 +173,6 @@ class TwoFactorController extends AbstractFrontendModuleController
         // Clear all trusted devices
         $this->container->get('contao.security.two_factor.trusted_device_manager')->clearTrustedDevices($user);
 
-        return new RedirectResponse($this->generateContentUrl($this->pageModel, [], UrlGeneratorInterface::ABSOLUTE_URL));
+        return new RedirectResponse($this->generateContentUrl($pageModel, [], UrlGeneratorInterface::ABSOLUTE_URL));
     }
 }

--- a/core-bundle/src/Controller/FrontendModule/TwoFactorController.php
+++ b/core-bundle/src/Controller/FrontendModule/TwoFactorController.php
@@ -61,7 +61,7 @@ class TwoFactorController extends AbstractFrontendModuleController
             return new Response('', Response::HTTP_NO_CONTENT);
         }
 
-        $this->denyAccessUnlessGranted('IS_AUTHENTICATED_FULLY', null, 'Full authentication is required to configure two-factor authentication.');
+        $this->denyAccessUnlessGranted('IS_AUTHENTICATED_FULLY', null, 'Full authentication is required to configure the two-factor authentication.');
 
         $adapter = $this->getContaoAdapter(PageModel::class);
         $redirectPage = $model->jumpTo > 0 ? $adapter->findByPk($model->jumpTo) : null;

--- a/core-bundle/src/Controller/FrontendModule/TwoFactorController.php
+++ b/core-bundle/src/Controller/FrontendModule/TwoFactorController.php
@@ -24,7 +24,6 @@ use Contao\PageModel;
 use Contao\Template;
 use ParagonIE\ConstantTime\Base32;
 use Scheb\TwoFactorBundle\Security\Authentication\Exception\InvalidTwoFactorCodeException;
-use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -46,7 +45,6 @@ class TwoFactorController extends AbstractFrontendModuleController
         $services['contao.routing.scope_matcher'] = ScopeMatcher::class;
         $services['contao.security.two_factor.authenticator'] = Authenticator::class;
         $services['security.authentication_utils'] = AuthenticationUtils::class;
-        $services['security.helper'] = Security::class;
         $services['translator'] = TranslatorInterface::class;
         $services['contao.security.two_factor.trusted_device_manager'] = TrustedDeviceManager::class;
         $services['contao.security.two_factor.backup_code_manager'] = BackupCodeManager::class;
@@ -56,10 +54,10 @@ class TwoFactorController extends AbstractFrontendModuleController
 
     protected function getResponse(Template $template, ModuleModel $model, Request $request): Response
     {
-        $user = $this->container->get('security.helper')->getUser();
-        $pageModel = $this->getPageModel();
+        $user = $this->getUser();
+        $pageModel = $request->attributes->get('pageModel');
 
-        if (!$user instanceof FrontendUser || !$pageModel) {
+        if (!$user instanceof FrontendUser || !$pageModel instanceof PageModel) {
             return new Response('', Response::HTTP_NO_CONTENT);
         }
 

--- a/core-bundle/src/EventListener/ExceptionConverterListener.php
+++ b/core-bundle/src/EventListener/ExceptionConverterListener.php
@@ -12,10 +12,8 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\EventListener;
 
-use Contao\CoreBundle\Exception\AccessDeniedException;
 use Contao\CoreBundle\Exception\ForwardPageNotFoundException;
 use Contao\CoreBundle\Exception\InsecureInstallationException;
-use Contao\CoreBundle\Exception\InsufficientAuthenticationException;
 use Contao\CoreBundle\Exception\InternalServerErrorException;
 use Contao\CoreBundle\Exception\InternalServerErrorHttpException;
 use Contao\CoreBundle\Exception\InvalidRequestTokenException;
@@ -27,12 +25,10 @@ use Contao\CoreBundle\Exception\ServiceUnavailableException;
 use Contao\UnusedArgumentsException;
 use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
-use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\Exception\ServiceUnavailableHttpException;
-use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 
 /**
  * The priority must be higher than the one of the response exception listener (defaults to 64).
@@ -43,10 +39,8 @@ use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 class ExceptionConverterListener
 {
     private const MAPPER = [
-        AccessDeniedException::class => 'AccessDeniedHttpException',
         ForwardPageNotFoundException::class => 'InternalServerErrorHttpException',
         InsecureInstallationException::class => 'InternalServerErrorHttpException',
-        InsufficientAuthenticationException::class => 'UnauthorizedHttpException',
         InternalServerErrorException::class => 'InternalServerErrorHttpException',
         InvalidRequestTokenException::class => 'BadRequestHttpException',
         NoActivePageFoundException::class => 'NotFoundHttpException',
@@ -88,12 +82,10 @@ class ExceptionConverterListener
     private function convertToHttpException(\Throwable $exception, string $target): HttpException|null
     {
         return match ($target) {
-            'AccessDeniedHttpException' => new AccessDeniedHttpException($exception->getMessage(), $exception),
             'BadRequestHttpException' => new BadRequestHttpException($exception->getMessage(), $exception),
             'InternalServerErrorHttpException' => new InternalServerErrorHttpException($exception->getMessage(), $exception),
             'NotFoundHttpException' => new NotFoundHttpException($exception->getMessage(), $exception),
             'ServiceUnavailableHttpException' => new ServiceUnavailableHttpException('', $exception->getMessage(), $exception),
-            'UnauthorizedHttpException' => new UnauthorizedHttpException('', $exception->getMessage(), $exception),
             default => null,
         };
     }

--- a/core-bundle/src/EventListener/PrettyErrorScreenListener.php
+++ b/core-bundle/src/EventListener/PrettyErrorScreenListener.php
@@ -140,9 +140,6 @@ class PrettyErrorScreenListener
                 return;
             }
 
-            $errorPage->loadDetails();
-            $errorPage->protected = false;
-
             $route = $this->pageRegistry->getRoute($errorPage);
             $subRequest = $request->duplicate(null, null, $route->getDefaults());
 

--- a/core-bundle/src/EventListener/PrettyErrorScreenListener.php
+++ b/core-bundle/src/EventListener/PrettyErrorScreenListener.php
@@ -26,11 +26,9 @@ use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
 use Symfony\Component\HttpFoundation\AcceptHeader;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
-use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\Exception\ServiceUnavailableHttpException;
-use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException;
 use Twig\Environment;
@@ -90,14 +88,6 @@ class PrettyErrorScreenListener
         switch (true) {
             case $isBackendUser:
                 $this->renderBackendException($event);
-                break;
-
-            case $exception instanceof UnauthorizedHttpException:
-                $this->renderErrorScreenByType(401, $event);
-                break;
-
-            case $exception instanceof AccessDeniedHttpException:
-                $this->renderErrorScreenByType(403, $event);
                 break;
 
             case $exception instanceof NotFoundHttpException:

--- a/core-bundle/src/EventListener/Security/TwoFactorFrontendListener.php
+++ b/core-bundle/src/EventListener/Security/TwoFactorFrontendListener.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\EventListener\Security;
 
-use Contao\CoreBundle\Exception\PageNotFoundException;
+use Contao\CoreBundle\Exception\ForwardPageNotFoundException;
 use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\CoreBundle\Routing\ContentUrlGenerator;
 use Contao\CoreBundle\Routing\PageFinder;
@@ -75,7 +75,7 @@ class TwoFactorFrontendListener
             $twoFactorPage = $adapter->findPublishedById($rootPage->twoFactorJumpTo);
 
             if (!$twoFactorPage instanceof PageModel) {
-                throw new PageNotFoundException('No two-factor authentication page found');
+                throw new ForwardPageNotFoundException('No two-factor authentication page found');
             }
 
             // Redirect to two-factor page

--- a/core-bundle/src/EventListener/Security/TwoFactorFrontendListener.php
+++ b/core-bundle/src/EventListener/Security/TwoFactorFrontendListener.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\EventListener\Security;
 
 use Contao\CoreBundle\Exception\ForwardPageNotFoundException;
+use Contao\CoreBundle\Exception\InsufficientAuthenticationException;
 use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\CoreBundle\Routing\ContentUrlGenerator;
 use Contao\CoreBundle\Routing\PageFinder;
@@ -23,7 +24,6 @@ use Scheb\TwoFactorBundle\Security\Authentication\Token\TwoFactorToken;
 use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
-use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Http\Util\TargetPathTrait;
@@ -113,6 +113,6 @@ class TwoFactorFrontendListener
             return;
         }
 
-        throw new UnauthorizedHttpException('', 'Missing two-factor authentication');
+        throw new InsufficientAuthenticationException('Missing two-factor authentication');
     }
 }

--- a/core-bundle/src/Security/Authentication/AccessDeniedHandler.php
+++ b/core-bundle/src/Security/Authentication/AccessDeniedHandler.php
@@ -30,7 +30,7 @@ class AccessDeniedHandler implements AccessDeniedHandlerInterface
     ) {
     }
 
-    public function handle(Request $request, AccessDeniedException $accessDeniedException): ?Response
+    public function handle(Request $request, AccessDeniedException $accessDeniedException): Response|null
     {
         $errorPage = $this->pageFinder->findFirstPageOfTypeForRequest($request, 'error_403');
 

--- a/core-bundle/src/Security/Authentication/AccessDeniedHandler.php
+++ b/core-bundle/src/Security/Authentication/AccessDeniedHandler.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Security\Authentication;
+
+use Contao\CoreBundle\Exception\ResponseException;
+use Contao\CoreBundle\Routing\Page\PageRegistry;
+use Contao\CoreBundle\Routing\PageFinder;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+use Symfony\Component\Security\Http\Authorization\AccessDeniedHandlerInterface;
+
+class AccessDeniedHandler implements AccessDeniedHandlerInterface
+{
+    public function __construct(
+        private readonly PageFinder $pageFinder,
+        private readonly PageRegistry $pageRegistry,
+        private readonly HttpKernelInterface $httpKernel,
+    ) {
+    }
+
+    public function handle(Request $request, AccessDeniedException $accessDeniedException): ?Response
+    {
+        $errorPage = $this->pageFinder->findFirstPageOfTypeForRequest($request, 'error_403');
+
+        if (!$errorPage) {
+            return null;
+        }
+
+        $errorPage->loadDetails();
+        $errorPage->protected = false;
+
+        $route = $this->pageRegistry->getRoute($errorPage);
+        $subRequest = $request->duplicate(null, null, $route->getDefaults());
+
+        try {
+            return $this->httpKernel->handle($subRequest, HttpKernelInterface::SUB_REQUEST, false);
+        } catch (ResponseException $e) {
+            return $e->getResponse();
+        }
+    }
+}

--- a/core-bundle/src/Security/Authenticator/ContaoLoginAuthenticator.php
+++ b/core-bundle/src/Security/Authenticator/ContaoLoginAuthenticator.php
@@ -12,10 +12,9 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Security\Authenticator;
 
-use Contao\CoreBundle\Exception\PageNotFoundException;
 use Contao\CoreBundle\Exception\ResponseException;
-use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\CoreBundle\Routing\Page\PageRegistry;
+use Contao\CoreBundle\Routing\PageFinder;
 use Contao\CoreBundle\Routing\ScopeMatcher;
 use Contao\PageModel;
 use Scheb\TwoFactorBundle\Security\Authentication\Token\TwoFactorTokenInterface;
@@ -27,6 +26,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\UriSigner;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RouterInterface;
@@ -65,7 +65,7 @@ class ContaoLoginAuthenticator extends AbstractAuthenticator implements Authenti
         private readonly ScopeMatcher $scopeMatcher,
         private readonly RouterInterface $router,
         private readonly UriSigner $uriSigner,
-        private readonly ContaoFramework $framework,
+        private readonly PageFinder $pageFinder,
         private readonly TokenStorageInterface $tokenStorage,
         private readonly PageRegistry $pageRegistry,
         private readonly HttpKernelInterface $httpKernel,
@@ -91,10 +91,16 @@ class ContaoLoginAuthenticator extends AbstractAuthenticator implements Authenti
             return $this->redirectToBackend($request);
         }
 
-        $this->framework->initialize();
+        $errorPage = $this->pageFinder->findFirstPageOfTypeForRequest($request, 'error_401');
 
-        $page = $this->getPageForRequest($request);
-        $route = $this->pageRegistry->getRoute($page);
+        if (!$errorPage) {
+            throw new UnauthorizedHttpException('', 'No error page found.', $authException);
+        }
+
+        $errorPage->loadDetails();
+        $errorPage->protected = false;
+
+        $route = $this->pageRegistry->getRoute($errorPage);
         $subRequest = $request->duplicate(null, null, $route->getDefaults());
 
         try {
@@ -214,29 +220,5 @@ class ContaoLoginAuthenticator extends AbstractAuthenticator implements Authenti
         );
 
         return new RedirectResponse($this->uriSigner->sign($url));
-    }
-
-    private function getPageForRequest(Request $request): PageModel
-    {
-        $page = $request->attributes->get('pageModel');
-        $page->loadDetails();
-
-        $page->protected = false;
-
-        if (!$this->tokenStorage->getToken()) {
-            $pageAdapter = $this->framework->getAdapter(PageModel::class);
-            $errorPage = $pageAdapter->findFirstPublishedByTypeAndPid('error_401', $page->rootId);
-
-            if (!$errorPage) {
-                throw new PageNotFoundException('No error page found.');
-            }
-
-            $errorPage->loadDetails();
-            $errorPage->protected = false;
-
-            return $errorPage;
-        }
-
-        return $page;
     }
 }

--- a/core-bundle/src/Security/Authenticator/ContaoLoginAuthenticator.php
+++ b/core-bundle/src/Security/Authenticator/ContaoLoginAuthenticator.php
@@ -94,7 +94,7 @@ class ContaoLoginAuthenticator extends AbstractAuthenticator implements Authenti
         $errorPage = $this->pageFinder->findFirstPageOfTypeForRequest($request, 'error_401');
 
         if (!$errorPage) {
-            throw new UnauthorizedHttpException('', 'No error page found.', $authException);
+            throw new UnauthorizedHttpException('', 'No error_401 page found.', $authException);
         }
 
         $errorPage->loadDetails();
@@ -102,10 +102,6 @@ class ContaoLoginAuthenticator extends AbstractAuthenticator implements Authenti
 
         $route = $this->pageRegistry->getRoute($errorPage);
         $subRequest = $request->duplicate(null, null, $route->getDefaults());
-
-        if ($authException && !$subRequest->attributes->has(SecurityRequestAttributes::AUTHENTICATION_ERROR)) {
-            $subRequest->attributes->set(SecurityRequestAttributes::AUTHENTICATION_ERROR, $authException);
-        }
 
         try {
             return $this->httpKernel->handle($subRequest, HttpKernelInterface::SUB_REQUEST, false);

--- a/core-bundle/src/Security/Authenticator/ContaoLoginAuthenticator.php
+++ b/core-bundle/src/Security/Authenticator/ContaoLoginAuthenticator.php
@@ -103,6 +103,10 @@ class ContaoLoginAuthenticator extends AbstractAuthenticator implements Authenti
         $route = $this->pageRegistry->getRoute($errorPage);
         $subRequest = $request->duplicate(null, null, $route->getDefaults());
 
+        if ($authException && !$subRequest->attributes->has(SecurityRequestAttributes::AUTHENTICATION_ERROR)) {
+            $subRequest->attributes->set(SecurityRequestAttributes::AUTHENTICATION_ERROR, $authException);
+        }
+
         try {
             return $this->httpKernel->handle($subRequest, HttpKernelInterface::SUB_REQUEST, false);
         } catch (ResponseException $e) {

--- a/core-bundle/tests/Controller/FrontendModule/TwoFactorControllerTest.php
+++ b/core-bundle/tests/Controller/FrontendModule/TwoFactorControllerTest.php
@@ -51,12 +51,10 @@ class TwoFactorControllerTest extends TestCase
 
     public function testReturnsIfTheUserIsNotAFrontendUser(): void
     {
-        $user = $this->createMock(BackendUser::class);
-
         $container = $this->getContainerWithFrameworkTemplate(
             $this->mockAuthenticator(),
             $this->mockAuthenticationUtils(),
-            $user,
+            $this->createMock(BackendUser::class),
             true,
         );
 
@@ -76,12 +74,10 @@ class TwoFactorControllerTest extends TestCase
 
     public function testReturnsIfTheRequestHasNoPageModel(): void
     {
-        $user = $this->createMock(BackendUser::class);
-
         $container = $this->getContainerWithFrameworkTemplate(
             $this->mockAuthenticator(),
             $this->mockAuthenticationUtils(),
-            $user,
+            $this->createMock(BackendUser::class),
             true,
         );
 

--- a/core-bundle/tests/Controller/FrontendModule/TwoFactorControllerTest.php
+++ b/core-bundle/tests/Controller/FrontendModule/TwoFactorControllerTest.php
@@ -27,12 +27,14 @@ use Contao\PageModel;
 use Contao\System;
 use PHPUnit\Framework\MockObject\MockObject;
 use Scheb\TwoFactorBundle\Security\Authentication\Exception\InvalidTwoFactorCodeException;
-use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Security\Core\Authentication\Token\PreAuthenticatedToken;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
@@ -47,26 +49,6 @@ class TwoFactorControllerTest extends TestCase
         parent::tearDown();
     }
 
-    public function testReturnsEmptyResponseIfTheUserIsNotFullyAuthenticated(): void
-    {
-        $container = $this->getContainerWithFrameworkTemplate(
-            $this->mockAuthenticator(),
-            $this->mockAuthenticationUtils(),
-            $this->mockSecurityHelper(),
-        );
-
-        $controller = new TwoFactorController();
-        $controller->setContainer($container);
-
-        $module = $this->mockClassWithProperties(ModuleModel::class);
-        $page = $this->mockPageModel();
-
-        $response = $controller(new Request(), $module, 'main', null, $page);
-
-        $this->assertEmpty($response->getContent());
-        $this->assertSame(204, $response->getStatusCode());
-    }
-
     public function testReturnsIfTheUserIsNotAFrontendUser(): void
     {
         $user = $this->createMock(BackendUser::class);
@@ -74,7 +56,8 @@ class TwoFactorControllerTest extends TestCase
         $container = $this->getContainerWithFrameworkTemplate(
             $this->mockAuthenticator(),
             $this->mockAuthenticationUtils(),
-            $this->mockSecurityHelper($user, true),
+            $user,
+            true,
         );
 
         $controller = new TwoFactorController();
@@ -83,9 +66,56 @@ class TwoFactorControllerTest extends TestCase
         $module = $this->mockClassWithProperties(ModuleModel::class);
         $page = $this->mockPageModel();
 
-        $response = $controller(new Request(), $module, 'main', null, $page);
+        $request = new Request();
+        $request->attributes->set('pageModel', $page);
+
+        $response = $controller($request, $module, 'main');
 
         $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+    }
+
+    public function testReturnsIfTheRequestHasNoPageModel(): void
+    {
+        $user = $this->createMock(BackendUser::class);
+
+        $container = $this->getContainerWithFrameworkTemplate(
+            $this->mockAuthenticator(),
+            $this->mockAuthenticationUtils(),
+            $user,
+            true,
+        );
+
+        $controller = new TwoFactorController();
+        $controller->setContainer($container);
+
+        $module = $this->mockClassWithProperties(ModuleModel::class);
+        $request = new Request();
+
+        $response = $controller($request, $module, 'main');
+
+        $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+    }
+
+    public function testReturnsEmptyResponseIfTheUserIsNotFullyAuthenticated(): void
+    {
+        $container = $this->getContainerWithFrameworkTemplate(
+            $this->mockAuthenticator(),
+            $this->mockAuthenticationUtils(),
+        );
+
+        $controller = new TwoFactorController();
+        $controller->setContainer($container);
+
+        $module = $this->mockClassWithProperties(ModuleModel::class);
+        $page = $this->mockPageModel();
+
+        $request = new Request();
+        $request->attributes->set('pageModel', $page);
+
+        $response = $controller($request, $module, 'main');
+
+        $this->assertEmpty($response->getContent());
+        $this->assertSame(204, $response->getStatusCode());
     }
 
     public function testReturnsAResponseIfTheUserIsAFrontendUser(): void
@@ -97,7 +127,8 @@ class TwoFactorControllerTest extends TestCase
         $container = $this->getContainerWithFrameworkTemplate(
             $this->mockAuthenticator(),
             $this->mockAuthenticationUtils(),
-            $this->mockSecurityHelper($user, true),
+            $user,
+            true,
         );
 
         $controller = new TwoFactorController();
@@ -108,7 +139,10 @@ class TwoFactorControllerTest extends TestCase
         $page = $this->mockPageModel();
         $page->enforceTwoFactor = true;
 
-        $response = $controller(new Request(), $module, 'main', null, $page);
+        $request = new Request();
+        $request->attributes->set('pageModel', $page);
+
+        $response = $controller($request, $module, 'main');
 
         $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
     }
@@ -122,19 +156,21 @@ class TwoFactorControllerTest extends TestCase
         $container = $this->getContainerWithFrameworkTemplate(
             $this->mockAuthenticator(),
             $this->mockAuthenticationUtils(),
-            $this->mockSecurityHelper($user, true),
+            $user,
+            true,
         );
 
         $controller = new TwoFactorController();
         $controller->setContainer($container);
 
-        $request = new Request();
-        $request->request->set('FORM_SUBMIT', 'tl_two_factor_disable');
-
         $module = $this->mockClassWithProperties(ModuleModel::class);
         $page = $this->mockPageModel();
 
-        $response = $controller($request, $module, 'main', null, $page);
+        $request = new Request();
+        $request->attributes->set('pageModel', $page);
+        $request->request->set('FORM_SUBMIT', 'tl_two_factor_disable');
+
+        $response = $controller($request, $module, 'main');
 
         $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
     }
@@ -148,7 +184,8 @@ class TwoFactorControllerTest extends TestCase
         $container = $this->getContainerWithFrameworkTemplate(
             $this->mockAuthenticator(),
             $this->mockAuthenticationUtils(),
-            $this->mockSecurityHelper($user, true),
+            $user,
+            true,
         );
 
         $trustedDeviceManager = $this->createMock(TrustedDeviceManager::class);
@@ -163,11 +200,12 @@ class TwoFactorControllerTest extends TestCase
         $controller = new TwoFactorController();
         $controller->setContainer($container);
 
-        $request = new Request();
-        $request->request->set('FORM_SUBMIT', 'tl_two_factor_disable');
-
         $module = $this->mockClassWithProperties(ModuleModel::class);
         $page = $this->mockPageModel();
+
+        $request = new Request();
+        $request->attributes->set('pageModel', $page);
+        $request->request->set('FORM_SUBMIT', 'tl_two_factor_disable');
 
         $container
             ->get('contao.routing.content_url_generator')
@@ -176,7 +214,7 @@ class TwoFactorControllerTest extends TestCase
             ->willReturn('https://localhost.wip/foobar')
         ;
 
-        $response = $controller($request, $module, 'main', null, $page);
+        $response = $controller($request, $module, 'main');
 
         $this->assertNull($user->backupCodes);
         $this->assertFalse($user->useTwoFactor);
@@ -193,17 +231,19 @@ class TwoFactorControllerTest extends TestCase
         $container = $this->getContainerWithFrameworkTemplate(
             $this->mockAuthenticator(),
             $this->mockAuthenticationUtils(),
-            $this->mockSecurityHelper($user, true),
+            $user,
+            true,
         );
 
         $controller = new TwoFactorController();
         $controller->setContainer($container);
 
-        $request = new Request();
-        $request->request->set('2fa', 'enable');
-
         $module = $this->mockClassWithProperties(ModuleModel::class);
         $page = $this->mockPageModel();
+
+        $request = new Request();
+        $request->attributes->set('pageModel', $page);
+        $request->request->set('2fa', 'enable');
 
         $container
             ->get('contao.routing.content_url_generator')
@@ -211,7 +251,7 @@ class TwoFactorControllerTest extends TestCase
             ->willReturn('https://localhost.wip/foobar')
         ;
 
-        $response = $controller($request, $module, 'main', null, $page);
+        $response = $controller($request, $module, 'main');
 
         $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
     }
@@ -225,17 +265,19 @@ class TwoFactorControllerTest extends TestCase
         $container = $this->getContainerWithFrameworkTemplate(
             $this->mockAuthenticator(),
             $this->mockAuthenticationUtils(new InvalidTwoFactorCodeException()),
-            $this->mockSecurityHelper($user, true),
+            $user,
+            true,
         );
 
         $controller = new TwoFactorController();
         $controller->setContainer($container);
 
-        $request = new Request();
-        $request->request->set('2fa', 'enable');
-
         $module = $this->mockClassWithProperties(ModuleModel::class);
         $page = $this->mockPageModel();
+
+        $request = new Request();
+        $request->attributes->set('pageModel', $page);
+        $request->request->set('2fa', 'enable');
 
         $container
             ->get('contao.routing.content_url_generator')
@@ -245,7 +287,7 @@ class TwoFactorControllerTest extends TestCase
             ->willReturn('https://localhost.wip/foobar')
         ;
 
-        $controller($request, $module, 'main', null, $page);
+        $controller($request, $module, 'main');
     }
 
     public function testDoesNotRedirectIfTheTwoFactorCodeIsInvalid(): void
@@ -257,19 +299,21 @@ class TwoFactorControllerTest extends TestCase
         $container = $this->getContainerWithFrameworkTemplate(
             $this->mockAuthenticator($user, false),
             $this->mockAuthenticationUtils(),
-            $this->mockSecurityHelper($user, true),
+            $user,
+            true,
         );
 
         $controller = new TwoFactorController();
         $controller->setContainer($container);
 
+        $module = $this->mockClassWithProperties(ModuleModel::class);
+        $page = $this->mockPageModel();
+
         $request = new Request();
+        $request->attributes->set('pageModel', $page);
         $request->request->set('2fa', 'enable');
         $request->request->set('FORM_SUBMIT', 'tl_two_factor');
         $request->request->set('verify', '123456');
-
-        $module = $this->mockClassWithProperties(ModuleModel::class);
-        $page = $this->mockPageModel();
 
         $container
             ->get('contao.routing.content_url_generator')
@@ -279,7 +323,7 @@ class TwoFactorControllerTest extends TestCase
             ->willReturn('https://localhost.wip/foobar')
         ;
 
-        $controller($request, $module, 'main', null, $page);
+        $controller($request, $module, 'main');
     }
 
     public function testRedirectsIfTheTwoFactorCodeIsValid(): void
@@ -296,19 +340,21 @@ class TwoFactorControllerTest extends TestCase
         $container = $this->getContainerWithFrameworkTemplate(
             $this->mockAuthenticator($user, true),
             $this->mockAuthenticationUtils(),
-            $this->mockSecurityHelper($user, true),
+            $user,
+            true,
         );
 
         $controller = new TwoFactorController();
         $controller->setContainer($container);
 
+        $module = $this->mockClassWithProperties(ModuleModel::class);
+        $page = $this->mockPageModel();
+
         $request = new Request();
+        $request->attributes->set('pageModel', $page);
         $request->request->set('2fa', 'enable');
         $request->request->set('FORM_SUBMIT', 'tl_two_factor');
         $request->request->set('verify', '123456');
-
-        $module = $this->mockClassWithProperties(ModuleModel::class);
-        $page = $this->mockPageModel();
 
         $container
             ->get('contao.routing.content_url_generator')
@@ -318,7 +364,7 @@ class TwoFactorControllerTest extends TestCase
             ->willReturn('https://localhost.wip/foobar')
         ;
 
-        $response = $controller($request, $module, 'main', null, $page);
+        $response = $controller($request, $module, 'main');
 
         $this->assertInstanceOf(RedirectResponse::class, $response);
     }
@@ -332,19 +378,21 @@ class TwoFactorControllerTest extends TestCase
         $container = $this->getContainerWithFrameworkTemplate(
             $this->mockAuthenticator(),
             $this->mockAuthenticationUtils(),
-            $this->mockSecurityHelper($user, true),
+            $user,
+            true,
         );
 
         $controller = new TwoFactorController();
         $controller->setContainer($container);
 
-        $request = new Request();
-        $request->request->set('FORM_SUBMIT', 'tl_two_factor_show_backup_codes');
-
         $module = $this->mockClassWithProperties(ModuleModel::class);
         $page = $this->mockPageModel();
 
-        $response = $controller($request, $module, 'main', null, $page);
+        $request = new Request();
+        $request->attributes->set('pageModel', $page);
+        $request->request->set('FORM_SUBMIT', 'tl_two_factor_show_backup_codes');
+
+        $response = $controller($request, $module, 'main');
 
         $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
     }
@@ -358,7 +406,8 @@ class TwoFactorControllerTest extends TestCase
         $container = $this->getContainerWithFrameworkTemplate(
             $this->mockAuthenticator(),
             $this->mockAuthenticationUtils(),
-            $this->mockSecurityHelper($user, true),
+            $user,
+            true,
         );
 
         $backupCodeManager = $container->get('contao.security.two_factor.backup_code_manager');
@@ -371,13 +420,14 @@ class TwoFactorControllerTest extends TestCase
         $controller = new TwoFactorController();
         $controller->setContainer($container);
 
-        $request = new Request();
-        $request->request->set('FORM_SUBMIT', 'tl_two_factor_generate_backup_codes');
-
         $module = $this->mockClassWithProperties(ModuleModel::class);
         $page = $this->mockPageModel();
 
-        $response = $controller($request, $module, 'main', null, $page);
+        $request = new Request();
+        $request->attributes->set('pageModel', $page);
+        $request->request->set('FORM_SUBMIT', 'tl_two_factor_generate_backup_codes');
+
+        $response = $controller($request, $module, 'main');
 
         $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
     }
@@ -392,7 +442,6 @@ class TwoFactorControllerTest extends TestCase
         $this->assertArrayHasKey('contao.security.two_factor.backup_code_manager', $services);
         $this->assertArrayHasKey('contao.security.two_factor.trusted_device_manager', $services);
         $this->assertArrayHasKey('security.authentication_utils', $services);
-        $this->assertArrayHasKey('security.helper', $services);
         $this->assertArrayHasKey('translator', $services);
     }
 
@@ -427,23 +476,6 @@ class TwoFactorControllerTest extends TestCase
         return $authenticationUtils;
     }
 
-    private function mockSecurityHelper(UserInterface|null $user = null, bool $isFullyAuthenticated = false): Security&MockObject
-    {
-        $security = $this->createMock(Security::class);
-        $security
-            ->method('isGranted')
-            ->with('IS_AUTHENTICATED_FULLY')
-            ->willReturn($isFullyAuthenticated)
-        ;
-
-        $security
-            ->method('getUser')
-            ->willReturn($user)
-        ;
-
-        return $security;
-    }
-
     private function mockPageModel(): PageModel&MockObject
     {
         $page = $this->mockClassWithProperties(PageModel::class);
@@ -452,7 +484,7 @@ class TwoFactorControllerTest extends TestCase
         return $page;
     }
 
-    private function getContainerWithFrameworkTemplate(Authenticator $authenticator, AuthenticationUtils $authenticationUtils, Security $security): ContainerBuilder
+    private function getContainerWithFrameworkTemplate(Authenticator $authenticator, AuthenticationUtils $authenticationUtils, UserInterface|null $user = null, bool $isFullyAuthenticated = false): ContainerBuilder
     {
         $template = $this->createMock(FrontendTemplate::class);
         $template
@@ -473,6 +505,19 @@ class TwoFactorControllerTest extends TestCase
             ->willReturn($template)
         ;
 
+        $authorizationChecker = $this->createMock(AuthorizationCheckerInterface::class);
+        $authorizationChecker
+            ->method('isGranted')
+            ->with('IS_AUTHENTICATED_FULLY')
+            ->willReturn($isFullyAuthenticated)
+        ;
+
+        $tokenStorage = $this->createMock(TokenStorageInterface::class);
+        $tokenStorage
+            ->method('getToken')
+            ->willReturn($user ? new PreAuthenticatedToken($user, 'contao_frontend') : null)
+        ;
+
         $container = $this->getContainerWithContaoConfiguration();
         $container->set('contao.framework', $framework);
         $container->set('contao.routing.content_url_generator', $this->createMock(ContentUrlGenerator::class));
@@ -480,8 +525,9 @@ class TwoFactorControllerTest extends TestCase
         $container->set('contao.security.two_factor.authenticator', $authenticator);
         $container->set('contao.security.two_factor.trusted_device_manager', $this->createMock(TrustedDeviceManager::class));
         $container->set('security.authentication_utils', $authenticationUtils);
+        $container->set('security.authorization_checker', $authorizationChecker);
+        $container->set('security.token_storage', $tokenStorage);
         $container->set('contao.security.two_factor.backup_code_manager', $this->createMock(BackupCodeManager::class));
-        $container->set('security.helper', $security);
         $container->set('contao.cache.entity_tags', $this->createMock(EntityCacheTags::class));
 
         System::setContainer($container);

--- a/core-bundle/tests/EventListener/ExceptionConverterListenerTest.php
+++ b/core-bundle/tests/EventListener/ExceptionConverterListenerTest.php
@@ -13,10 +13,8 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Tests\EventListener;
 
 use Contao\CoreBundle\EventListener\ExceptionConverterListener;
-use Contao\CoreBundle\Exception\AccessDeniedException;
 use Contao\CoreBundle\Exception\ForwardPageNotFoundException;
 use Contao\CoreBundle\Exception\InsecureInstallationException;
-use Contao\CoreBundle\Exception\InsufficientAuthenticationException;
 use Contao\CoreBundle\Exception\InternalServerErrorHttpException;
 use Contao\CoreBundle\Exception\InvalidRequestTokenException;
 use Contao\CoreBundle\Exception\NoActivePageFoundException;
@@ -29,29 +27,14 @@ use Contao\UnusedArgumentsException;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
-use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\Exception\ServiceUnavailableHttpException;
-use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
 
 class ExceptionConverterListenerTest extends TestCase
 {
-    public function testConvertsAccessDeniedExceptions(): void
-    {
-        $event = $this->getResponseEvent(new AccessDeniedException());
-
-        $listener = new ExceptionConverterListener();
-        $listener($event);
-
-        $exception = $event->getThrowable();
-
-        $this->assertInstanceOf(AccessDeniedHttpException::class, $exception);
-        $this->assertInstanceOf(AccessDeniedException::class, $exception->getPrevious());
-    }
-
     public function testConvertsForwardPageNotFoundExceptions(): void
     {
         $event = $this->getResponseEvent(new ForwardPageNotFoundException());
@@ -76,19 +59,6 @@ class ExceptionConverterListenerTest extends TestCase
 
         $this->assertInstanceOf(InternalServerErrorHttpException::class, $exception);
         $this->assertInstanceOf(InsecureInstallationException::class, $exception->getPrevious());
-    }
-
-    public function testConvertsInsufficientAuthenticationExceptions(): void
-    {
-        $event = $this->getResponseEvent(new InsufficientAuthenticationException());
-
-        $listener = new ExceptionConverterListener();
-        $listener($event);
-
-        $exception = $event->getThrowable();
-
-        $this->assertInstanceOf(UnauthorizedHttpException::class, $exception);
-        $this->assertInstanceOf(InsufficientAuthenticationException::class, $exception->getPrevious());
     }
 
     public function testConvertsInvalidRequestTokenExceptions(): void

--- a/core-bundle/tests/EventListener/PrettyErrorScreenListenerTest.php
+++ b/core-bundle/tests/EventListener/PrettyErrorScreenListenerTest.php
@@ -13,10 +13,8 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Tests\EventListener;
 
 use Contao\CoreBundle\EventListener\PrettyErrorScreenListener;
-use Contao\CoreBundle\Exception\AccessDeniedException;
 use Contao\CoreBundle\Exception\ForwardPageNotFoundException;
 use Contao\CoreBundle\Exception\InsecureInstallationException;
-use Contao\CoreBundle\Exception\InsufficientAuthenticationException;
 use Contao\CoreBundle\Exception\InternalServerErrorException;
 use Contao\CoreBundle\Exception\InternalServerErrorHttpException;
 use Contao\CoreBundle\Exception\PageNotFoundException;
@@ -32,11 +30,9 @@ use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
-use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\Exception\ServiceUnavailableHttpException;
-use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException;
@@ -140,49 +136,15 @@ class PrettyErrorScreenListenerTest extends TestCase
 
     public function getErrorTypes(): \Generator
     {
-        yield [401, new UnauthorizedHttpException('', '', new InsufficientAuthenticationException())];
-        yield [403, new AccessDeniedHttpException('', new AccessDeniedException())];
+        yield [503, new ServiceUnavailableHttpException()];
         yield [404, new NotFoundHttpException('', new PageNotFoundException())];
-    }
-
-    public function testUnprotectsErrorPage(): void
-    {
-        $errorPage = $this->mockPageWithProperties([
-            'pid' => 1,
-            'type' => 'error_401',
-            'rootLanguage' => '',
-            'urlPrefix' => '',
-            'urlSuffix' => '',
-            'protected' => true,
-            'groups' => '',
-        ]);
-
-        $request = $this->getRequest('frontend');
-        $request->attributes->set('pageModel', $this->mockPageWithProperties(['rootId' => 1]));
-
-        $httpKernel = $this->createMock(HttpKernelInterface::class);
-        $httpKernel
-            ->expects($this->once())
-            ->method('handle')
-            ->willReturn(new Response('foo', 401))
-        ;
-
-        $exception = new UnauthorizedHttpException('', '', new InsufficientAuthenticationException());
-        $event = $this->getResponseEvent($exception, $request);
-
-        $listener = $this->getListener(false, null, $errorPage, $httpKernel);
-        $listener($event);
-
-        $this->assertTrue($event->hasResponse());
-        $this->assertSame(401, $event->getResponse()->getStatusCode());
-        $this->assertFalse($errorPage->protected);
     }
 
     public function testHandlesResponseExceptionsWhenForwarding(): void
     {
         $errorPage = $this->mockPageWithProperties([
             'pid' => 1,
-            'type' => 'error_403',
+            'type' => 'error_404',
             'rootLanguage' => '',
             'urlPrefix' => '',
             'urlSuffix' => '',
@@ -198,7 +160,7 @@ class PrettyErrorScreenListenerTest extends TestCase
             ->willThrowException(new ResponseException(new Response('foo')))
         ;
 
-        $exception = new AccessDeniedHttpException('', new AccessDeniedException());
+        $exception = new NotFoundHttpException();
         $event = $this->getResponseEvent($exception, $request);
 
         $listener = $this->getListener(false, null, $errorPage, $httpKernel);
@@ -212,7 +174,7 @@ class PrettyErrorScreenListenerTest extends TestCase
     {
         $errorPage = $this->mockPageWithProperties([
             'pid' => 1,
-            'type' => 'error_403',
+            'type' => 'error_404',
             'rootLanguage' => '',
             'urlPrefix' => '',
             'urlSuffix' => '',
@@ -230,7 +192,7 @@ class PrettyErrorScreenListenerTest extends TestCase
             ->willThrowException($throwable)
         ;
 
-        $exception = new AccessDeniedHttpException('', new AccessDeniedException());
+        $exception = new NotFoundHttpException();
         $event = $this->getResponseEvent($exception, $request);
 
         $listener = $this->getListener(false, null, $errorPage, $httpKernel);
@@ -391,7 +353,7 @@ class PrettyErrorScreenListenerTest extends TestCase
 
     public function testDoesNothingIfThePageHandlerDoesNotExist(): void
     {
-        $exception = new AccessDeniedHttpException('', new AccessDeniedException());
+        $exception = new NotFoundHttpException();
         $event = $this->getResponseEvent($exception);
 
         $listener = $this->getListener();

--- a/core-bundle/tests/EventListener/Security/TwoFactorFrontendListenerTest.php
+++ b/core-bundle/tests/EventListener/Security/TwoFactorFrontendListenerTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Tests\EventListener\Security;
 
 use Contao\CoreBundle\EventListener\Security\TwoFactorFrontendListener;
-use Contao\CoreBundle\Exception\PageNotFoundException;
+use Contao\CoreBundle\Exception\ForwardPageNotFoundException;
 use Contao\CoreBundle\Routing\ContentUrlGenerator;
 use Contao\CoreBundle\Routing\PageFinder;
 use Contao\CoreBundle\Routing\ScopeMatcher;
@@ -46,7 +46,7 @@ class TwoFactorFrontendListenerTest extends TestCase
         $listener = new TwoFactorFrontendListener(
             $this->mockContaoFramework(),
             $this->mockScopeMatcherWithEvent(false, $event),
-            $this->createMock(PageFinder::class),
+            $this->mockPageFinder(),
             $this->createMock(ContentUrlGenerator::class),
             $this->createMock(TokenStorage::class),
             [UsernamePasswordToken::class],
@@ -64,7 +64,7 @@ class TwoFactorFrontendListenerTest extends TestCase
         $listener = new TwoFactorFrontendListener(
             $this->mockContaoFramework(),
             $this->mockScopeMatcherWithEvent(true, $event),
-            $this->createMock(PageFinder::class),
+            $this->mockPageFinder(),
             $this->createMock(ContentUrlGenerator::class),
             $this->mockTokenStorageWithToken(),
             [UsernamePasswordToken::class],
@@ -83,7 +83,7 @@ class TwoFactorFrontendListenerTest extends TestCase
         $listener = new TwoFactorFrontendListener(
             $this->mockContaoFramework(),
             $this->mockScopeMatcherWithEvent(true, $event),
-            $this->createMock(PageFinder::class),
+            $this->mockPageFinder(),
             $this->createMock(ContentUrlGenerator::class),
             $this->mockTokenStorageWithToken($token),
             [UsernamePasswordToken::class],
@@ -94,37 +94,20 @@ class TwoFactorFrontendListenerTest extends TestCase
         $this->assertNotInstanceOf(RedirectResponse::class, $event->getResponse());
     }
 
-    public function testReturnsIfTheRequestHasNoPageModel(): void
+    public function testDoesNotEnforcesTwoFactorIfTheUserIsNotAFrontendUser(): void
     {
-        $token = $this->mockToken(TwoFactorToken::class);
-        $event = $this->getRequestEvent($this->getRequest());
+        $rootPage = $this->mockClassWithProperties(PageModel::class, ['enforceTwoFactor' => true]);
 
-        $listener = new TwoFactorFrontendListener(
-            $this->mockContaoFramework(),
-            $this->mockScopeMatcherWithEvent(true, $event),
-            $this->createMock(PageFinder::class),
-            $this->createMock(ContentUrlGenerator::class),
-            $this->mockTokenStorageWithToken($token),
-            [UsernamePasswordToken::class],
-        );
-
-        $listener($event);
-
-        $this->assertNotInstanceOf(RedirectResponse::class, $event->getResponse());
-    }
-
-    public function testReturnsIfTheUserIsNotAFrontendUser(): void
-    {
-        $token = $this->mockToken(TwoFactorToken::class);
+        $token = $this->mockToken(UsernamePasswordToken::class);
         $event = $this->getRequestEvent($this->getRequest(true));
 
         $listener = new TwoFactorFrontendListener(
             $this->mockContaoFramework(),
             $this->mockScopeMatcherWithEvent(true, $event),
-            $this->createMock(PageFinder::class),
+            $this->mockPageFinder($rootPage),
             $this->createMock(ContentUrlGenerator::class),
             $this->mockTokenStorageWithToken($token),
-            [UsernamePasswordToken::class],
+            [$token::class],
         );
 
         $listener($event);
@@ -137,9 +120,9 @@ class TwoFactorFrontendListenerTest extends TestCase
         $user = $this->mockClassWithProperties(FrontendUser::class);
         $user->useTwoFactor = false;
 
-        $pageModel = $this->mockClassWithProperties(PageModel::class);
-        $pageModel->enforceTwoFactor = true;
-        $pageModel->twoFactorJumpTo = 0;
+        $rootPage = $this->mockClassWithProperties(PageModel::class);
+        $rootPage->enforceTwoFactor = true;
+        $rootPage->twoFactorJumpTo = 0;
 
         $adapter = $this->mockAdapter(['findPublishedById']);
         $adapter
@@ -149,18 +132,18 @@ class TwoFactorFrontendListenerTest extends TestCase
         ;
 
         $token = $this->mockToken(TwoFactorToken::class, true, $user);
-        $event = $this->getRequestEvent($this->getRequest(true, $pageModel));
+        $event = $this->getRequestEvent($this->getRequest(true));
 
         $listener = new TwoFactorFrontendListener(
             $this->mockContaoFramework([PageModel::class => $adapter]),
             $this->mockScopeMatcherWithEvent(true, $event),
-            $this->createMock(PageFinder::class),
+            $this->mockPageFinder($rootPage),
             $this->createMock(ContentUrlGenerator::class),
             $this->mockTokenStorageWithToken($token),
-            [UsernamePasswordToken::class],
+            [$token::class],
         );
 
-        $this->expectException(PageNotFoundException::class);
+        $this->expectException(ForwardPageNotFoundException::class);
         $this->expectExceptionMessage('No two-factor authentication page found');
 
         $listener($event);
@@ -189,7 +172,7 @@ class TwoFactorFrontendListenerTest extends TestCase
         $listener = new TwoFactorFrontendListener(
             $this->mockContaoFramework([PageModel::class => $adapter]),
             $this->mockScopeMatcherWithEvent(true, $event),
-            $this->createMock(PageFinder::class),
+            $this->mockPageFinder($pageModel),
             $this->createMock(ContentUrlGenerator::class),
             $this->mockTokenStorageWithToken($token),
             [UsernamePasswordToken::class],
@@ -235,7 +218,7 @@ class TwoFactorFrontendListenerTest extends TestCase
         $listener = new TwoFactorFrontendListener(
             $this->mockContaoFramework([PageModel::class => $adapter]),
             $this->mockScopeMatcherWithEvent(true, $event),
-            $this->createMock(PageFinder::class),
+            $this->mockPageFinder($pageModel),
             $urlGenerator,
             $this->mockTokenStorageWithToken($token),
             [UsernamePasswordToken::class],
@@ -269,7 +252,7 @@ class TwoFactorFrontendListenerTest extends TestCase
         $listener = new TwoFactorFrontendListener(
             $this->mockContaoFramework([PageModel::class => $adapter]),
             $this->mockScopeMatcherWithEvent(true, $event),
-            $this->createMock(PageFinder::class),
+            $this->mockPageFinder($pageModel),
             $this->createMock(ContentUrlGenerator::class),
             $this->mockTokenStorageWithToken($token),
             [UsernamePasswordToken::class, $token::class],
@@ -300,13 +283,6 @@ class TwoFactorFrontendListenerTest extends TestCase
             ->willReturn('http://localhost/foobar')
         ;
 
-        $adapter = $this->mockAdapter(['find401ByPid']);
-        $adapter
-            ->expects($this->once())
-            ->method('find401ByPid')
-            ->willReturn($page401)
-        ;
-
         $response = new RedirectResponse('http://localhost/two_factor');
         $token = $this->mockToken(TwoFactorToken::class, true, $user);
 
@@ -316,9 +292,9 @@ class TwoFactorFrontendListenerTest extends TestCase
         $event = $this->getRequestEvent($request, $response);
 
         $listener = new TwoFactorFrontendListener(
-            $this->mockContaoFramework([PageModel::class => $adapter]),
+            $this->mockContaoFramework(),
             $this->mockScopeMatcherWithEvent(true, $event),
-            $this->createMock(PageFinder::class),
+            $this->mockPageFinder($pageModel, $page401),
             $this->createMock(ContentUrlGenerator::class),
             $this->mockTokenStorageWithToken($token),
             [UsernamePasswordToken::class],
@@ -346,21 +322,14 @@ class TwoFactorFrontendListenerTest extends TestCase
         $page401->autoforward = true;
         $page401->jumpTo = 1;
 
-        $adapter = $this->mockAdapter(['find401ByPid']);
-        $adapter
-            ->expects($this->once())
-            ->method('find401ByPid')
-            ->willReturn($page401)
-        ;
-
         $response = new RedirectResponse('http://localhost/two_factor');
         $token = $this->mockToken(TwoFactorToken::class, true, $user);
         $event = $this->getRequestEvent($this->getRequest(true, $pageModel), $response);
 
         $listener = new TwoFactorFrontendListener(
-            $this->mockContaoFramework([PageModel::class => $adapter]),
+            $this->mockContaoFramework(),
             $this->mockScopeMatcherWithEvent(true, $event),
-            $this->createMock(PageFinder::class),
+            $this->mockPageFinder($pageModel, $page401),
             $this->createMock(ContentUrlGenerator::class),
             $this->mockTokenStorageWithToken($token),
             [UsernamePasswordToken::class],
@@ -380,21 +349,14 @@ class TwoFactorFrontendListenerTest extends TestCase
         $pageModel->id = 1;
         $pageModel->enforceTwoFactor = false;
 
-        $adapter = $this->mockAdapter(['find401ByPid']);
-        $adapter
-            ->expects($this->once())
-            ->method('find401ByPid')
-            ->willReturn(null)
-        ;
-
         $response = new RedirectResponse('http://localhost/two_factor');
         $token = $this->mockToken(TwoFactorToken::class, true, $user);
         $event = $this->getRequestEvent($this->getRequest(true, $pageModel), $response);
 
         $listener = new TwoFactorFrontendListener(
-            $this->mockContaoFramework([PageModel::class => $adapter]),
+            $this->mockContaoFramework(),
             $this->mockScopeMatcherWithEvent(true, $event),
-            $this->createMock(PageFinder::class),
+            $this->mockPageFinder($pageModel),
             $this->createMock(ContentUrlGenerator::class),
             $this->mockTokenStorageWithToken($token),
             [UsernamePasswordToken::class],
@@ -421,13 +383,6 @@ class TwoFactorFrontendListenerTest extends TestCase
             ->willReturn('http://:')
         ;
 
-        $adapter = $this->mockAdapter(['find401ByPid']);
-        $adapter
-            ->expects($this->once())
-            ->method('find401ByPid')
-            ->willReturn(null)
-        ;
-
         $response = new RedirectResponse('http://localhost/two_factor');
         $token = $this->mockToken(TwoFactorToken::class, true, $user);
 
@@ -437,9 +392,9 @@ class TwoFactorFrontendListenerTest extends TestCase
         $event = $this->getRequestEvent($request, $response);
 
         $listener = new TwoFactorFrontendListener(
-            $this->mockContaoFramework([PageModel::class => $adapter]),
+            $this->mockContaoFramework(),
             $this->mockScopeMatcherWithEvent(true, $event),
-            $this->createMock(PageFinder::class),
+            $this->mockPageFinder($pageModel),
             $this->createMock(ContentUrlGenerator::class),
             $this->mockTokenStorageWithToken($token),
             [UsernamePasswordToken::class],
@@ -466,13 +421,6 @@ class TwoFactorFrontendListenerTest extends TestCase
             ->willReturn('http://localhost/foobar')
         ;
 
-        $adapter = $this->mockAdapter(['find401ByPid']);
-        $adapter
-            ->expects($this->once())
-            ->method('find401ByPid')
-            ->willReturn(null)
-        ;
-
         $response = new RedirectResponse('http://localhost/two_factor');
         $token = $this->mockToken(TwoFactorToken::class, true, $user);
 
@@ -482,9 +430,9 @@ class TwoFactorFrontendListenerTest extends TestCase
         $event = $this->getRequestEvent($request, $response);
 
         $listener = new TwoFactorFrontendListener(
-            $this->mockContaoFramework([PageModel::class => $adapter]),
+            $this->mockContaoFramework(),
             $this->mockScopeMatcherWithEvent(true, $event),
-            $this->createMock(PageFinder::class),
+            $this->mockPageFinder($pageModel),
             $this->createMock(ContentUrlGenerator::class),
             $this->mockTokenStorageWithToken($token),
             [UsernamePasswordToken::class],
@@ -530,6 +478,7 @@ class TwoFactorFrontendListenerTest extends TestCase
     private function getRequest(bool $withPageModel = false, PageModel|null $pageModel = null): Request
     {
         $request = new Request();
+        $request->attributes->set('_scope', 'frontend');
         $request->attributes->set('pageModel', null);
 
         $pageModel ??= $this->createMock(PageModel::class);
@@ -578,5 +527,26 @@ class TwoFactorFrontendListenerTest extends TestCase
         }
 
         return $event;
+    }
+
+    private function mockPageFinder(PageModel|null $rootPage = null, PageModel|null $errorPage = null): PageFinder&MockObject
+    {
+        $pageFinder = $this->createMock(PageFinder::class);
+
+        $pageFinder
+            ->expects($rootPage ? $this->once() : $this->any())
+            ->method('findRootPageForRequest')
+            ->with($this->isInstanceOf(Request::class))
+            ->willReturn($rootPage)
+        ;
+
+        $pageFinder
+            ->expects($errorPage ? $this->once() : $this->any())
+            ->method('findFirstPageOfTypeForRequest')
+            ->with($this->isInstanceOf(Request::class), 'error_401')
+            ->willReturn($errorPage)
+        ;
+
+        return $pageFinder;
     }
 }

--- a/core-bundle/tests/EventListener/Security/TwoFactorFrontendListenerTest.php
+++ b/core-bundle/tests/EventListener/Security/TwoFactorFrontendListenerTest.php
@@ -97,7 +97,6 @@ class TwoFactorFrontendListenerTest extends TestCase
     public function testDoesNotEnforcesTwoFactorIfTheUserIsNotAFrontendUser(): void
     {
         $rootPage = $this->mockClassWithProperties(PageModel::class, ['enforceTwoFactor' => true]);
-
         $token = $this->mockToken(UsernamePasswordToken::class);
         $event = $this->getRequestEvent($this->getRequest(true));
 
@@ -532,7 +531,6 @@ class TwoFactorFrontendListenerTest extends TestCase
     private function mockPageFinder(PageModel|null $rootPage = null, PageModel|null $errorPage = null): PageFinder&MockObject
     {
         $pageFinder = $this->createMock(PageFinder::class);
-
         $pageFinder
             ->expects($rootPage ? $this->once() : $this->any())
             ->method('findRootPageForRequest')

--- a/core-bundle/tests/EventListener/Security/TwoFactorFrontendListenerTest.php
+++ b/core-bundle/tests/EventListener/Security/TwoFactorFrontendListenerTest.php
@@ -15,6 +15,7 @@ namespace Contao\CoreBundle\Tests\EventListener\Security;
 use Contao\CoreBundle\EventListener\Security\TwoFactorFrontendListener;
 use Contao\CoreBundle\Exception\PageNotFoundException;
 use Contao\CoreBundle\Routing\ContentUrlGenerator;
+use Contao\CoreBundle\Routing\PageFinder;
 use Contao\CoreBundle\Routing\ScopeMatcher;
 use Contao\CoreBundle\Tests\TestCase;
 use Contao\FrontendUser;
@@ -45,6 +46,7 @@ class TwoFactorFrontendListenerTest extends TestCase
         $listener = new TwoFactorFrontendListener(
             $this->mockContaoFramework(),
             $this->mockScopeMatcherWithEvent(false, $event),
+            $this->createMock(PageFinder::class),
             $this->createMock(ContentUrlGenerator::class),
             $this->createMock(TokenStorage::class),
             [UsernamePasswordToken::class],
@@ -62,6 +64,7 @@ class TwoFactorFrontendListenerTest extends TestCase
         $listener = new TwoFactorFrontendListener(
             $this->mockContaoFramework(),
             $this->mockScopeMatcherWithEvent(true, $event),
+            $this->createMock(PageFinder::class),
             $this->createMock(ContentUrlGenerator::class),
             $this->mockTokenStorageWithToken(),
             [UsernamePasswordToken::class],
@@ -80,6 +83,7 @@ class TwoFactorFrontendListenerTest extends TestCase
         $listener = new TwoFactorFrontendListener(
             $this->mockContaoFramework(),
             $this->mockScopeMatcherWithEvent(true, $event),
+            $this->createMock(PageFinder::class),
             $this->createMock(ContentUrlGenerator::class),
             $this->mockTokenStorageWithToken($token),
             [UsernamePasswordToken::class],
@@ -98,6 +102,7 @@ class TwoFactorFrontendListenerTest extends TestCase
         $listener = new TwoFactorFrontendListener(
             $this->mockContaoFramework(),
             $this->mockScopeMatcherWithEvent(true, $event),
+            $this->createMock(PageFinder::class),
             $this->createMock(ContentUrlGenerator::class),
             $this->mockTokenStorageWithToken($token),
             [UsernamePasswordToken::class],
@@ -116,6 +121,7 @@ class TwoFactorFrontendListenerTest extends TestCase
         $listener = new TwoFactorFrontendListener(
             $this->mockContaoFramework(),
             $this->mockScopeMatcherWithEvent(true, $event),
+            $this->createMock(PageFinder::class),
             $this->createMock(ContentUrlGenerator::class),
             $this->mockTokenStorageWithToken($token),
             [UsernamePasswordToken::class],
@@ -148,6 +154,7 @@ class TwoFactorFrontendListenerTest extends TestCase
         $listener = new TwoFactorFrontendListener(
             $this->mockContaoFramework([PageModel::class => $adapter]),
             $this->mockScopeMatcherWithEvent(true, $event),
+            $this->createMock(PageFinder::class),
             $this->createMock(ContentUrlGenerator::class),
             $this->mockTokenStorageWithToken($token),
             [UsernamePasswordToken::class],
@@ -182,6 +189,7 @@ class TwoFactorFrontendListenerTest extends TestCase
         $listener = new TwoFactorFrontendListener(
             $this->mockContaoFramework([PageModel::class => $adapter]),
             $this->mockScopeMatcherWithEvent(true, $event),
+            $this->createMock(PageFinder::class),
             $this->createMock(ContentUrlGenerator::class),
             $this->mockTokenStorageWithToken($token),
             [UsernamePasswordToken::class],
@@ -227,6 +235,7 @@ class TwoFactorFrontendListenerTest extends TestCase
         $listener = new TwoFactorFrontendListener(
             $this->mockContaoFramework([PageModel::class => $adapter]),
             $this->mockScopeMatcherWithEvent(true, $event),
+            $this->createMock(PageFinder::class),
             $urlGenerator,
             $this->mockTokenStorageWithToken($token),
             [UsernamePasswordToken::class],
@@ -260,6 +269,7 @@ class TwoFactorFrontendListenerTest extends TestCase
         $listener = new TwoFactorFrontendListener(
             $this->mockContaoFramework([PageModel::class => $adapter]),
             $this->mockScopeMatcherWithEvent(true, $event),
+            $this->createMock(PageFinder::class),
             $this->createMock(ContentUrlGenerator::class),
             $this->mockTokenStorageWithToken($token),
             [UsernamePasswordToken::class, $token::class],
@@ -308,6 +318,7 @@ class TwoFactorFrontendListenerTest extends TestCase
         $listener = new TwoFactorFrontendListener(
             $this->mockContaoFramework([PageModel::class => $adapter]),
             $this->mockScopeMatcherWithEvent(true, $event),
+            $this->createMock(PageFinder::class),
             $this->createMock(ContentUrlGenerator::class),
             $this->mockTokenStorageWithToken($token),
             [UsernamePasswordToken::class],
@@ -349,6 +360,7 @@ class TwoFactorFrontendListenerTest extends TestCase
         $listener = new TwoFactorFrontendListener(
             $this->mockContaoFramework([PageModel::class => $adapter]),
             $this->mockScopeMatcherWithEvent(true, $event),
+            $this->createMock(PageFinder::class),
             $this->createMock(ContentUrlGenerator::class),
             $this->mockTokenStorageWithToken($token),
             [UsernamePasswordToken::class],
@@ -382,6 +394,7 @@ class TwoFactorFrontendListenerTest extends TestCase
         $listener = new TwoFactorFrontendListener(
             $this->mockContaoFramework([PageModel::class => $adapter]),
             $this->mockScopeMatcherWithEvent(true, $event),
+            $this->createMock(PageFinder::class),
             $this->createMock(ContentUrlGenerator::class),
             $this->mockTokenStorageWithToken($token),
             [UsernamePasswordToken::class],
@@ -426,6 +439,7 @@ class TwoFactorFrontendListenerTest extends TestCase
         $listener = new TwoFactorFrontendListener(
             $this->mockContaoFramework([PageModel::class => $adapter]),
             $this->mockScopeMatcherWithEvent(true, $event),
+            $this->createMock(PageFinder::class),
             $this->createMock(ContentUrlGenerator::class),
             $this->mockTokenStorageWithToken($token),
             [UsernamePasswordToken::class],
@@ -470,6 +484,7 @@ class TwoFactorFrontendListenerTest extends TestCase
         $listener = new TwoFactorFrontendListener(
             $this->mockContaoFramework([PageModel::class => $adapter]),
             $this->mockScopeMatcherWithEvent(true, $event),
+            $this->createMock(PageFinder::class),
             $this->createMock(ContentUrlGenerator::class),
             $this->mockTokenStorageWithToken($token),
             [UsernamePasswordToken::class],

--- a/core-bundle/tests/EventListener/Security/TwoFactorFrontendListenerTest.php
+++ b/core-bundle/tests/EventListener/Security/TwoFactorFrontendListenerTest.php
@@ -14,6 +14,7 @@ namespace Contao\CoreBundle\Tests\EventListener\Security;
 
 use Contao\CoreBundle\EventListener\Security\TwoFactorFrontendListener;
 use Contao\CoreBundle\Exception\ForwardPageNotFoundException;
+use Contao\CoreBundle\Exception\InsufficientAuthenticationException;
 use Contao\CoreBundle\Routing\ContentUrlGenerator;
 use Contao\CoreBundle\Routing\PageFinder;
 use Contao\CoreBundle\Routing\ScopeMatcher;
@@ -27,7 +28,6 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
-use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -339,7 +339,7 @@ class TwoFactorFrontendListenerTest extends TestCase
         $this->assertInstanceOf(RedirectResponse::class, $event->getResponse());
     }
 
-    public function testThrowsAnUnauthorizedHttpException(): void
+    public function testThrowsAnInsufficientAuthenticationException(): void
     {
         $user = $this->mockClassWithProperties(FrontendUser::class);
         $user->useTwoFactor = false;
@@ -361,7 +361,7 @@ class TwoFactorFrontendListenerTest extends TestCase
             [UsernamePasswordToken::class],
         );
 
-        $this->expectException(UnauthorizedHttpException::class);
+        $this->expectException(InsufficientAuthenticationException::class);
 
         $listener($event);
     }

--- a/core-bundle/tests/Functional/app/config/security.yaml
+++ b/core-bundle/tests/Functional/app/config/security.yaml
@@ -33,6 +33,7 @@ security:
             request_matcher: contao.routing.frontend_matcher
             provider: contao.security.frontend_user_provider
             user_checker: contao.security.user_checker
+            access_denied_handler: contao.security.access_denied_handler
             switch_user: false
             login_throttling: ~
 

--- a/core-bundle/tests/Security/Authenticator/ContaoLoginAuthenticatorTest.php
+++ b/core-bundle/tests/Security/Authenticator/ContaoLoginAuthenticatorTest.php
@@ -12,11 +12,10 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Tests\Security\Authenticator;
 
-use Contao\CoreBundle\Exception\PageNotFoundException;
 use Contao\CoreBundle\Exception\ResponseException;
-use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\CoreBundle\Routing\Page\PageRegistry;
 use Contao\CoreBundle\Routing\Page\PageRoute;
+use Contao\CoreBundle\Routing\PageFinder;
 use Contao\CoreBundle\Routing\ScopeMatcher;
 use Contao\CoreBundle\Security\Authenticator\ContaoLoginAuthenticator;
 use Contao\CoreBundle\Security\User\ContaoUserProvider;
@@ -33,6 +32,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpFoundation\UriSigner;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
@@ -53,7 +53,7 @@ class ContaoLoginAuthenticatorTest extends TestCase
 {
     public function testSupportsTheRequest(): void
     {
-        $authenticator = $this->mockContaoLoginAuthenticator();
+        $authenticator = $this->getContaoLoginAuthenticator();
 
         $this->assertFalse($authenticator->supports(new Request()));
 
@@ -83,14 +83,14 @@ class ContaoLoginAuthenticatorTest extends TestCase
 
     public function testIfAuthenticationIsInteractive(): void
     {
-        $authenticator = $this->mockContaoLoginAuthenticator();
+        $authenticator = $this->getContaoLoginAuthenticator();
 
         $this->assertFalse($authenticator->isInteractive());
 
         $requestStack = new RequestStack();
         $requestStack->push(new Request());
 
-        $authenticator = $this->mockContaoLoginAuthenticator(requestStack: $requestStack);
+        $authenticator = $this->getContaoLoginAuthenticator(requestStack: $requestStack);
 
         $this->assertFalse($authenticator->isInteractive());
 
@@ -100,7 +100,7 @@ class ContaoLoginAuthenticatorTest extends TestCase
         $requestStack = new RequestStack();
         $requestStack->push($request);
 
-        $authenticator = $this->mockContaoLoginAuthenticator(requestStack: $requestStack);
+        $authenticator = $this->getContaoLoginAuthenticator(requestStack: $requestStack);
 
         $this->assertTrue($authenticator->isInteractive());
     }
@@ -125,7 +125,7 @@ class ContaoLoginAuthenticatorTest extends TestCase
             ->with($request, $token)
         ;
 
-        $authenticator = $this->mockContaoLoginAuthenticator(
+        $authenticator = $this->getContaoLoginAuthenticator(
             null,
             $successHandler,
             $failureHandler,
@@ -137,7 +137,7 @@ class ContaoLoginAuthenticatorTest extends TestCase
 
     public function testTokenCreation(): void
     {
-        $authenticator = $this->mockContaoLoginAuthenticator();
+        $authenticator = $this->getContaoLoginAuthenticator();
 
         $this->assertInstanceOf(
             PostAuthenticationToken::class,
@@ -215,7 +215,7 @@ class ContaoLoginAuthenticatorTest extends TestCase
             ->willReturn($this->createMock(Passport::class))
         ;
 
-        $authenticator = $this->mockContaoLoginAuthenticator(
+        $authenticator = $this->getContaoLoginAuthenticator(
             tokenStorage: $tokenStorage,
             twoFactorAuthenticator: $twoFactorAuthenticator,
         );
@@ -249,7 +249,7 @@ class ContaoLoginAuthenticatorTest extends TestCase
             ->willReturn($token)
         ;
 
-        $authenticator = $this->mockContaoLoginAuthenticator(
+        $authenticator = $this->getContaoLoginAuthenticator(
             userProvider: $this->createMock(ContaoUserProvider::class),
             tokenStorage: $tokenStorage,
             options: ['enable_csrf' => true],
@@ -294,7 +294,7 @@ class ContaoLoginAuthenticatorTest extends TestCase
             ->willReturn('url')
         ;
 
-        $authenticator = $this->mockContaoLoginAuthenticator(
+        $authenticator = $this->getContaoLoginAuthenticator(
             scopeMatcher: $scopeMatcher,
             router: $router,
             uriSigner: $uriSigner,
@@ -312,20 +312,9 @@ class ContaoLoginAuthenticatorTest extends TestCase
     public function testStartsTheAuthenticationProcessOnCurrentPage(TokenInterface|null $token, ResponseException|null $exception): void
     {
         $pageModel = $this->createMock(PageModel::class);
-        $pageModel
-            ->expects($this->once())
-            ->method('loadDetails')
-        ;
 
         $request = new Request();
         $request->attributes->set('pageModel', $pageModel);
-
-        $tokenStorage = $this->createMock(TokenStorageInterface::class);
-        $tokenStorage
-            ->expects($this->once())
-            ->method('getToken')
-            ->willReturn($token)
-        ;
 
         $route = $this->createMock(PageRoute::class);
         $route
@@ -357,9 +346,9 @@ class ContaoLoginAuthenticatorTest extends TestCase
             ;
         }
 
-        $authenticator = $this->mockContaoLoginAuthenticator(
+        $authenticator = $this->getContaoLoginAuthenticator(
             userProvider: $this->createMock(ContaoUserProvider::class),
-            tokenStorage: $tokenStorage,
+            errorPage: $pageModel,
             pageRegistry: $pageRegistry,
             httpKernel: $httpKernel,
             options: ['enable_csrf' => true],
@@ -383,91 +372,54 @@ class ContaoLoginAuthenticatorTest extends TestCase
         yield [$token, $responseException];
     }
 
-    /**
-     * @dataProvider getErrorPageData
-     */
-    public function testRedirectsToErrorPageIfThereIsNoToken(PageModel|null $errorPage): void
+    public function testThrowsExceptionIfThereIsNoErrorPage(): void
     {
-        $pageModel = $this->createMock(PageModel::class);
-        $pageModel
-            ->expects($this->once())
-            ->method('loadDetails')
-        ;
-
-        $request = new Request();
-        $request->attributes->set('pageModel', $pageModel);
-
-        $pageModelAdapter = $this->mockAdapter(['findFirstPublishedByTypeAndPid']);
-        $pageModelAdapter
-            ->expects($this->once())
-            ->method('findFirstPublishedByTypeAndPid')
-            ->with('error_401', 0)
-            ->willReturn($errorPage)
-        ;
-
-        if (!$errorPage) {
-            $this->expectException(PageNotFoundException::class);
-        }
-
-        $framework = $this->mockContaoFramework([PageModel::class => $pageModelAdapter]);
-
-        $tokenStorage = $this->createMock(TokenStorageInterface::class);
-        $tokenStorage
-            ->expects($this->once())
-            ->method('getToken')
-            ->willReturn(null)
-        ;
+        $this->expectException(UnauthorizedHttpException::class);
 
         $route = $this->createMock(PageRoute::class);
         $route
-            ->expects($errorPage ? $this->once() : $this->never())
+            ->expects($this->never())
             ->method('getDefaults')
             ->willReturn([])
         ;
 
         $pageRegistry = $this->createMock(PageRegistry::class);
         $pageRegistry
-            ->expects($errorPage ? $this->once() : $this->never())
+            ->expects($this->never())
             ->method('getRoute')
             ->willReturn($route)
         ;
 
         $httpKernel = $this->createMock(HttpKernelInterface::class);
         $httpKernel
-            ->expects($errorPage ? $this->once() : $this->never())
+            ->expects($this->never())
             ->method('handle')
             ->willReturn($this->createMock(RedirectResponse::class))
         ;
 
-        $authenticator = $this->mockContaoLoginAuthenticator(
+        $authenticator = $this->getContaoLoginAuthenticator(
             userProvider: $this->createMock(ContaoUserProvider::class),
-            framework: $framework,
-            tokenStorage: $tokenStorage,
             pageRegistry: $pageRegistry,
             httpKernel: $httpKernel,
             options: ['enable_csrf' => true],
         );
 
-        $authenticator->start($request);
-    }
-
-    public function getErrorPageData(): \Generator
-    {
-        $errorPage = $this->createMock(PageModel::class);
-        $errorPage
-            ->expects($this->once())
-            ->method('loadDetails')
-        ;
-
-        yield [null];
-        yield [$errorPage];
+        $authenticator->start(new Request());
     }
 
     /**
      * @param UserProviderInterface<UserInterface>|null $userProvider
      */
-    private function mockContaoLoginAuthenticator(UserProviderInterface|null $userProvider = null, AuthenticationSuccessHandlerInterface|null $successHandler = null, AuthenticationFailureHandlerInterface|null $failureHandler = null, ScopeMatcher|null $scopeMatcher = null, RouterInterface|null $router = null, UriSigner|null $uriSigner = null, ContaoFramework|null $framework = null, TokenStorageInterface|null $tokenStorage = null, PageRegistry|null $pageRegistry = null, HttpKernelInterface|null $httpKernel = null, RequestStack|null $requestStack = null, TwoFactorAuthenticator|null $twoFactorAuthenticator = null, array $options = []): ContaoLoginAuthenticator
+    private function getContaoLoginAuthenticator(UserProviderInterface|null $userProvider = null, AuthenticationSuccessHandlerInterface|null $successHandler = null, AuthenticationFailureHandlerInterface|null $failureHandler = null, ScopeMatcher|null $scopeMatcher = null, RouterInterface|null $router = null, UriSigner|null $uriSigner = null, PageModel|null $errorPage = null, TokenStorageInterface|null $tokenStorage = null, PageRegistry|null $pageRegistry = null, HttpKernelInterface|null $httpKernel = null, RequestStack|null $requestStack = null, TwoFactorAuthenticator|null $twoFactorAuthenticator = null, array $options = []): ContaoLoginAuthenticator
     {
+        $pageFinder = $this->createMock(PageFinder::class);
+        $pageFinder
+            ->expects($errorPage ? $this->once() : $this->any())
+            ->method('findFirstPageOfTypeForRequest')
+            ->with($this->isInstanceOf(Request::class), 'error_401')
+            ->willReturn($errorPage)
+        ;
+
         return new ContaoLoginAuthenticator(
             $userProvider ?? $this->mockUserProvider(),
             $successHandler ?? $this->mockSuccessHandler(),
@@ -475,7 +427,7 @@ class ContaoLoginAuthenticatorTest extends TestCase
             $scopeMatcher ?? $this->mockScopeMatcher(),
             $router ?? $this->mockRouter(),
             $uriSigner ?? $this->mockUriSigner(),
-            $framework ?? $this->mockContaoFramework(),
+            $pageFinder,
             $tokenStorage ?? $this->mockTokenStorage(FrontendUser::class),
             $pageRegistry ?? $this->mockPageRegistry(),
             $httpKernel ?? $this->mockHttpKernel(),

--- a/manager-bundle/skeleton/config/security.yaml
+++ b/manager-bundle/skeleton/config/security.yaml
@@ -33,6 +33,7 @@ security:
             request_matcher: contao.routing.frontend_matcher
             provider: contao.security.frontend_user_provider
             user_checker: contao.security.user_checker
+            access_denied_handler: contao.security.access_denied_handler
             switch_user: false
             login_throttling: ~
 


### PR DESCRIPTION
This now fixes and improves a lot of things 🙈 

1. Fixes the authentication system to correctly render the Contao login page even if the current route is not a Contao page (e.g. a custom controller)
1. Fixes the `ContaoLoginAuthenticator` from rendering the wrong page for login (if the user is not fully authenticated).
2. ~Fixes the remember me authentication system~ (see https://github.com/contao/contao/pull/6815)
3. Adds an `AccessDeniedHandler` to render the 403 page via the firewall exception handler
4. Correctly enforces fully authentication for changing personal data, changing the user password and configuring two-factor authentication
5. Removes the ExceptionConverter and PrettyErrorScreen from rendering 401 and 403 pages, because these are rendered by the firewall

There are two "behaviour changes" I can think of
-  obviously the fully-authentication works and is now enforces as described in point 4
- If no 401 or 403 pages are configured in root page, we now render the generic error (through the pretty error screen listener) instead of the generic Symfony 401/403 message. Since we are in Contao frontend scope, I think that should be fine.

### TODO:
- [x] ~Needs a migration for existing RememberMe tokens (the migration tool cannot migrate binary data to string value because the binary data is null-padded and therefore longer than the new string field).~