### PR TITLE
Improve the debug message for `FigureBuilder` link attributes

### DIFF
--- a/core-bundle/src/Image/Studio/FigureBuilder.php
+++ b/core-bundle/src/Image/Studio/FigureBuilder.php
@@ -461,7 +461,7 @@ class FigureBuilder
 
         foreach ($attributes as $key => $value) {
             if (!\is_string($key) || !\is_string($value)) {
-                throw new \InvalidArgumentException('Link attributes must be an array of type <string, string>.');
+                throw new \InvalidArgumentException(sprintf('Link attributes must be an array of type <string, string>, <%s, %s> given.', get_debug_type($key), get_debug_type($value)));
             }
         }
 


### PR DESCRIPTION
This will help with debugging if a non-string is passed. Not sure why any scalar (e.g. int) would not be allowed though 🙃 