### PR TITLE
Support HTML5 entities with `double_encode: false`

### DIFF
--- a/core-bundle/src/Resources/contao/helper/functions.php
+++ b/core-bundle/src/Resources/contao/helper/functions.php
@@ -85,7 +85,7 @@ function specialchars($strString, $blnStripInsertTags=false)
 		$strString = strip_insert_tags($strString);
 	}
 
-	return htmlspecialchars($strString, ENT_QUOTES, System::getContainer()->getParameter('kernel.charset'), false);
+	return htmlspecialchars($strString, ENT_QUOTES | ENT_HTML5, System::getContainer()->getParameter('kernel.charset'), false);
 }
 
 /**

--- a/core-bundle/src/Resources/contao/library/Contao/StringUtil.php
+++ b/core-bundle/src/Resources/contao/library/Contao/StringUtil.php
@@ -870,7 +870,7 @@ class StringUtil
 			$strString = static::stripInsertTags($strString);
 		}
 
-		return htmlspecialchars((string) $strString, ENT_QUOTES, $GLOBALS['TL_CONFIG']['characterSet'] ?? 'UTF-8', $blnDoubleEncode);
+		return htmlspecialchars((string) $strString, ENT_QUOTES | ENT_HTML5, $GLOBALS['TL_CONFIG']['characterSet'] ?? 'UTF-8', $blnDoubleEncode);
 	}
 
 	/**

--- a/core-bundle/src/Twig/Interop/ContaoEscaper.php
+++ b/core-bundle/src/Twig/Interop/ContaoEscaper.php
@@ -43,10 +43,7 @@ final class ContaoEscaper
 
         $string = (string) $string;
 
-        // Handle uppercase entities
-        $string = str_replace(['&AMP;', '&QUOT;', '&LT;', '&GT;'], ['&amp;', '&quot;', '&lt;', '&gt;'], $string);
-
-        return htmlspecialchars($string, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8', false);
+        return htmlspecialchars($string, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8', false);
     }
 
     /**

--- a/core-bundle/tests/Contao/InputTest.php
+++ b/core-bundle/tests/Contao/InputTest.php
@@ -97,7 +97,7 @@ class InputTest extends TestCase
 
         yield 'Reformats attributes' => [
             "<span \n \t title = \nwith-spaces class\n=' with \" and &#039; quotes' lang \t =\"with &quot; and ' quotes \t \n \" data-boolean-flag data-int = 0>",
-            "<span title=\"with-spaces\" class=\" with &quot; and &#039; quotes\" lang=\"with &quot; and &#039; quotes \t \n \" data-boolean-flag=\"\" data-int=\"0\">",
+            "<span title=\"with-spaces\" class=\" with &quot; and &#039; quotes\" lang=\"with &quot; and &apos; quotes \t \n \" data-boolean-flag=\"\" data-int=\"0\">",
         ];
 
         yield 'Encodes insert tags in attributes' => [
@@ -237,12 +237,12 @@ class InputTest extends TestCase
 
         yield [
             '<IMG SRC="javascript:alert(\'XSS\');">',
-            '<img src="javascript%3Aalert(&#039;XSS&#039;);">',
+            '<img src="javascript%3Aalert(&apos;XSS&apos;);">',
         ];
 
         yield [
             '<IMG SRC=JaVaScRiPt:alert(\'XSS\')>',
-            '<img src="JaVaScRiPt%3Aalert(&#039;XSS&#039;)">',
+            '<img src="JaVaScRiPt%3Aalert(&apos;XSS&apos;)">',
         ];
 
         yield [
@@ -287,12 +287,12 @@ class InputTest extends TestCase
 
         yield [
             '<IMG SRC="jav&#x0A;ascript:alert(\'XSS\');">',
-            '<img src="jav&#x0A;ascript%3Aalert(&#039;XSS&#039;);">',
+            '<img src="jav&#x0A;ascript%3Aalert(&apos;XSS&apos;);">',
         ];
 
         yield [
             '<IMG SRC=" &#14; javascript:alert(\'XSS\');">',
-            '<img src=" &#14; javascript%3Aalert(&#039;XSS&#039;);">',
+            '<img src=" &#14; javascript%3Aalert(&apos;XSS&apos;);">',
         ];
 
         yield [

--- a/core-bundle/tests/Contao/InsertTagsTest.php
+++ b/core-bundle/tests/Contao/InsertTagsTest.php
@@ -454,7 +454,7 @@ class InsertTagsTest extends TestCase
 
         yield 'Quote in single quoted attribute' => [
             '<span title="{{plain::\'}}">',
-            '<span title="&#039;">',
+            '<span title="&apos;">',
         ];
 
         yield 'Quote outside attribute' => [
@@ -489,7 +489,7 @@ class InsertTagsTest extends TestCase
 
         yield 'Trick tag detection with two tags' => [
             '<span /="notanattribute title="> {{plain::\'}} " > {{plain::\'}}',
-            '<span /="notanattribute title="> &#039; " > \'',
+            '<span /="notanattribute title="> &apos; " > \'',
         ];
 
         yield 'Trick tag detection with not a tag' => [

--- a/core-bundle/tests/Twig/Interop/ContaoEscaperNodeVisitorTest.php
+++ b/core-bundle/tests/Twig/Interop/ContaoEscaperNodeVisitorTest.php
@@ -99,7 +99,7 @@ class ContaoEscaperNodeVisitorTest extends TestCase
             ]
         );
 
-        $this->assertSame('&quot;A&quot; &amp; &lt;B&gt;', $output);
+        $this->assertSame('&QUOT;A&QUOT; &AMP; &LT;B&GT;', $output);
     }
 
     public function testHtmlAttrFilter(): void

--- a/core-bundle/tests/Twig/Interop/ContaoEscaperTest.php
+++ b/core-bundle/tests/Twig/Interop/ContaoEscaperTest.php
@@ -61,7 +61,12 @@ class ContaoEscaperTest extends TestCase
 
         yield 'string with uppercase entities' => [
             '&AMP; &QUOT; &LT; &GT;',
-            '&amp; &quot; &lt; &gt;',
+            '&AMP; &QUOT; &LT; &GT;',
+        ];
+
+        yield 'string with known and unknown entities' => [
+            '&amp; &AMP; &ZeroWidthSpace; &NotAnEntitiy; &123;',
+            '&amp; &AMP; &ZeroWidthSpace; &amp;NotAnEntitiy; &amp;123;',
         ];
     }
 


### PR DESCRIPTION
When using `htmlspecialchars()` with `double_encode: false` we should always set `ENT_HTML5` so that all valid HTML entities do not get double encoded.

Without this fix, `&ZeroWidthSpace;` for example would get encoded to `&amp;ZeroWidthSpace;`