### PR TITLE
Fix the length of the `tl_remember_me.value` column

### DIFF
--- a/core-bundle/src/Entity/RememberMe.php
+++ b/core-bundle/src/Entity/RememberMe.php
@@ -35,7 +35,7 @@ class RememberMe
     #[Column(type: 'binary_string', length: 88, nullable: false, options: ['fixed' => true])]
     protected string $series;
 
-    #[Column(type: 'binary_string', length: 64, nullable: false, options: ['fixed' => true])]
+    #[Column(type: 'binary_string', length: 88, nullable: false, options: ['fixed' => true])]
     protected string $value;
 
     #[Column(type: 'datetime', nullable: false)]


### PR DESCRIPTION
<img width="593" alt="" src="https://github.com/contao/contao/assets/1192057/f9b4bf83-8251-4959-a759-1b1814012f2d">

See [Symfony/Bridge/Doctrine/Security/RememberMe/DoctrineTokenProvider](https://github.com/symfony/symfony/blob/6f21d072a2a7d0ee42fe7c0168385794acb1f018/src/Symfony/Bridge/Doctrine/Security/RememberMe/DoctrineTokenProvider.php#L36-L42).