### PR TITLE
Fix the `tl_remember_me` column lengths

### DIFF
--- a/core-bundle/src/Entity/RememberMe.php
+++ b/core-bundle/src/Entity/RememberMe.php
@@ -39,12 +39,12 @@ class RememberMe
     protected int $id;
 
     /**
-     * @ORM\Column(type="binary_string", length=32, nullable=false, options={"fixed"=true})
+     * @ORM\Column(type="binary_string", length=88, nullable=false, options={"fixed"=true})
      */
     protected string $series;
 
     /**
-     * @ORM\Column(type="binary_string", length=64, nullable=false, options={"fixed"=true})
+     * @ORM\Column(type="binary_string", length=88, nullable=false, options={"fixed"=true})
      */
     protected string $value;
 


### PR DESCRIPTION
<img width="584" alt="" src="https://github.com/contao/contao/assets/1192057/6aa47d72-0f69-454a-974a-d1f9701f4090">

See [Symfony/Bridge/Doctrine/Security/RememberMe/DoctrineTokenProvider](https://github.com/symfony/symfony/blob/a67e8bd2d69e61d90e5c8fae028d0326d3f9b06a/src/Symfony/Bridge/Doctrine/Security/RememberMe/DoctrineTokenProvider.php#L36-L42)