### PR TITLE
Allow adding a source to multiple CSP directives at once

### DIFF
--- a/core-bundle/contao/library/Contao/TemplateTrait.php
+++ b/core-bundle/contao/library/Contao/TemplateTrait.php
@@ -173,7 +173,8 @@ trait TemplateTrait
 		/** @var CspHandler $csp */
 		$csp = $responseContext->get(CspHandler::class);
 
-		foreach ((array) $directives as $directive) {
+		foreach ((array) $directives as $directive)
+		{
 			$csp->addSource($directive, $source);
 		}
 	}

--- a/core-bundle/contao/library/Contao/TemplateTrait.php
+++ b/core-bundle/contao/library/Contao/TemplateTrait.php
@@ -161,7 +161,7 @@ trait TemplateTrait
 	/**
 	 * Adds a source to the given CSP directive.
 	 */
-	public function addCspSource(string $directive, string $source): void
+	public function addCspSource(string|array $directives, string $source): void
 	{
 		$responseContext = System::getContainer()->get('contao.routing.response_context_accessor')->getResponseContext();
 
@@ -172,7 +172,10 @@ trait TemplateTrait
 
 		/** @var CspHandler $csp */
 		$csp = $responseContext->get(CspHandler::class);
-		$csp->addSource($directive, $source);
+
+		foreach ((array) $directives as $directive) {
+			$csp->addSource($directive, $source);
+		}
 	}
 
 	/**

--- a/core-bundle/src/Twig/Runtime/CspRuntime.php
+++ b/core-bundle/src/Twig/Runtime/CspRuntime.php
@@ -73,7 +73,7 @@ final class CspRuntime implements RuntimeExtensionInterface
         return $csp->getNonce($directive);
     }
 
-    public function addSource(string $directive, string $source): void
+    public function addSource(string|array $directives, string $source): void
     {
         $responseContext = $this->responseContextAccessor->getResponseContext();
 
@@ -83,7 +83,10 @@ final class CspRuntime implements RuntimeExtensionInterface
 
         /** @var CspHandler $csp */
         $csp = $responseContext->get(CspHandler::class);
-        $csp->addSource($directive, $source);
+
+        foreach ((array) $directives as $directive) {
+            $csp->addSource($directive, $source);
+        }
     }
 
     public function addHash(string $directive, string $source, string $algorithm = 'sha256'): void

--- a/core-bundle/src/Twig/Runtime/CspRuntime.php
+++ b/core-bundle/src/Twig/Runtime/CspRuntime.php
@@ -73,7 +73,7 @@ final class CspRuntime implements RuntimeExtensionInterface
         return $csp->getNonce($directive);
     }
 
-    public function addSource(string|array $directives, string $source): void
+    public function addSource(array|string $directives, string $source): void
     {
         $responseContext = $this->responseContextAccessor->getResponseContext();
 

--- a/core-bundle/tests/Twig/Runtime/CspRuntimeTest.php
+++ b/core-bundle/tests/Twig/Runtime/CspRuntimeTest.php
@@ -66,6 +66,30 @@ class CspRuntimeTest extends TestCase
         $this->assertSame("'self' https://example.com/files/foo/foobar.js", $directives->getDirective('script-src'));
     }
 
+    public function testAddsMultipleCspSources(): void
+    {
+        $directives = new DirectiveSet(new PolicyManager());
+        $directives->setDirective('script-src', "'self'");
+        $directives->setDirective('style-src', "'self'");
+
+        $cspHandler = new CspHandler($directives);
+        $responseContext = (new ResponseContext())->add($cspHandler);
+
+        $responseContextAccessor = $this->createMock(ResponseContextAccessor::class);
+        $responseContextAccessor
+            ->expects($this->once())
+            ->method('getResponseContext')
+            ->willReturn($responseContext)
+        ;
+
+        $runtime = new CspRuntime($responseContextAccessor, new WysiwygStyleProcessor([]));
+
+        $runtime->addSource(['script-src', 'style-src'], 'https://cdn.example.com/');
+
+        $this->assertSame("'self' https://cdn.example.com/", $directives->getDirective('script-src'));
+        $this->assertSame("'self' https://cdn.example.com/", $directives->getDirective('style-src'));
+    }
+
     public function testAddsCspHash(): void
     {
         $directives = new DirectiveSet(new PolicyManager());


### PR DESCRIPTION
I need to whitelist a CDN in my CSP, and need to whitelist both javascript and style sheets. It would be less error-prone to write this in one instead of two lines.

```
{% do csp_source(['script-src', 'style-src'], 'https://www.example.com') %}
```