### PR TITLE
Add a foreign key declaration for form and module fields

### DIFF
--- a/core-bundle/src/Resources/contao/dca/tl_content.php
+++ b/core-bundle/src/Resources/contao/dca/tl_content.php
@@ -805,6 +805,7 @@ $GLOBALS['TL_DCA']['tl_content'] = array
 		(
 			'exclude'                 => true,
 			'inputType'               => 'select',
+			'foreignKey'              => 'tl_form.title',
 			'options_callback'        => array('tl_content', 'getForms'),
 			'eval'                    => array('mandatory'=>true, 'chosen'=>true, 'submitOnChange'=>true, 'tl_class'=>'w50 wizard'),
 			'wizard' => array
@@ -817,6 +818,7 @@ $GLOBALS['TL_DCA']['tl_content'] = array
 		(
 			'exclude'                 => true,
 			'inputType'               => 'select',
+			'foreignKey'              => 'tl_module.name',
 			'options_callback'        => array('tl_content', 'getModules'),
 			'eval'                    => array('mandatory'=>true, 'chosen'=>true, 'submitOnChange'=>true, 'tl_class'=>'w50 wizard'),
 			'wizard' => array


### PR DESCRIPTION
As asked in the [slack support channel](https://contao.slack.com/archives/CK4J0KNDB/p1706188166398299), there seems to be no reason why the tl_content fields form and module do not have a foreignKey declaration. For the use of "getRelated" method or other logic following the "foreignKey" DCA standards there should be a declaration in my opinion. Hence the pull request.