### PR TITLE
Randomize CSRF tokens once per request

### DIFF
--- a/core-bundle/tests/Csrf/ContaoCsrfTokenManagerTest.php
+++ b/core-bundle/tests/Csrf/ContaoCsrfTokenManagerTest.php
@@ -37,8 +37,10 @@ class ContaoCsrfTokenManagerTest extends TestCase
         );
 
         $token = new CsrfToken('contao_csrf_token', $tokenManager->getDefaultTokenValue());
-
         $this->assertTrue($tokenManager->isTokenValid($token));
+
+        $secondToken = new CsrfToken('contao_csrf_token', $tokenManager->getDefaultTokenValue());
+        $this->assertSame($token->getValue(), $secondToken->getValue());
     }
 
     public function testGetDefaultTokenValueFailsIfTokenNameIsNotSet(): void


### PR DESCRIPTION
But I’m not sure if we actually need this. The `randomize()` call only takes one microsecond (0.001ms) on my machine.