### PR TITLE
Do not display deleted authors in news

### DIFF
--- a/news-bundle/contao/modules/ModuleNews.php
+++ b/news-bundle/contao/modules/ModuleNews.php
@@ -92,6 +92,7 @@ abstract class ModuleNews extends Module
 		$objTemplate->text = '';
 		$objTemplate->hasTeaser = false;
 		$objTemplate->hasReader = true;
+		$objTemplate->author = null; // see #6827
 
 		// Clean the RTE output
 		if ($objArticle->teaser)

--- a/news-bundle/contao/modules/ModuleNews.php
+++ b/news-bundle/contao/modules/ModuleNews.php
@@ -92,7 +92,6 @@ abstract class ModuleNews extends Module
 		$objTemplate->text = '';
 		$objTemplate->hasTeaser = false;
 		$objTemplate->hasReader = true;
-        $objTemplate->author = null; // see #6827
 
 		// Clean the RTE output
 		if ($objArticle->teaser)
@@ -141,7 +140,8 @@ abstract class ModuleNews extends Module
 		$objTemplate->date = Date::parse($objPage->datimFormat, $objArticle->date);
 
 		/** @var UserModel $objAuthor */
-		if (($objAuthor = $objArticle->getRelated('author')) instanceof UserModel) {
+		if (($objAuthor = $objArticle->getRelated('author')) instanceof UserModel)
+		{
 			$objTemplate->author = $GLOBALS['TL_LANG']['MSC']['by'] . ' ' . $objAuthor->name;
 			$objTemplate->authorModel = $objAuthor;
 		}
@@ -234,7 +234,7 @@ abstract class ModuleNews extends Module
 		}
 
 		// schema.org information
-		$objTemplate->getSchemaOrgData = static function () use ($objArticle, $objTemplate): array {
+		$objTemplate->getSchemaOrgData = static function () use ($objTemplate, $objArticle): array {
 			$jsonLd = News::getSchemaOrgData($objArticle);
 
 			if ($objTemplate->addImage && $objTemplate->figure)
@@ -302,7 +302,7 @@ abstract class ModuleNews extends Module
 	{
 		$blnIsInternal = $objArticle->source != 'external';
 		$strReadMore = $blnIsInternal ? $GLOBALS['TL_LANG']['MSC']['readMore'] : $GLOBALS['TL_LANG']['MSC']['open'];
-		$strArticleUrl = $this->generateContentUrl($objArticle, $blnAddArchive);
+		$strArticleUrl = News::generateNewsUrl($objArticle, $blnAddArchive);
 
 		return sprintf(
 			'<a href="%s" title="%s"%s>%s%s</a>',
@@ -312,18 +312,5 @@ abstract class ModuleNews extends Module
 			$strLink,
 			$blnIsReadMore && $blnIsInternal ? '<span class="invisible"> ' . $objArticle->headline . '</span>' : ''
 		);
-	}
-
-	private function generateContentUrl(NewsModel $content, bool $addArchive): string
-	{
-		$parameters = array();
-
-		// Add the current archive parameter (news archive)
-		if ($addArchive && Input::get('month'))
-		{
-			$parameters['month'] = Input::get('month');
-		}
-
-		return System::getContainer()->get('contao.routing.content_url_generator')->generate($content, $parameters);
 	}
 }


### PR DESCRIPTION
Fixes #6827

Users that have been deleted were shown with an Id  as a news-author. Setting the default to `null` makes sure that only real objects are set as authors.