### PR TITLE
Fix the order of the content elements

### DIFF
--- a/core-bundle/contao/config/config.php
+++ b/core-bundle/contao/config/config.php
@@ -265,6 +265,18 @@ $GLOBALS['FE_MOD'] = array
 // Content elements
 $GLOBALS['TL_CTE'] = array
 (
+	'texts' => array(),
+	'links' => array(),
+	'files' => array(),
+	'media' => array(),
+	'miscellaneous' => array(),
+	'includes' => array
+	(
+		'article'         => ContentArticle::class,
+		'alias'           => ContentAlias::class,
+		'form'            => Form::class,
+		'module'          => ContentModule::class,
+	),
 	'legacy' => array
 	(
 		'accordionSingle' => ContentAccordion::class,
@@ -272,13 +284,6 @@ $GLOBALS['TL_CTE'] = array
 		'accordionStop'   => ContentAccordionStop::class,
 		'sliderStart'     => ContentSliderStart::class,
 		'sliderStop'      => ContentSliderStop::class
-	),
-	'includes' => array
-	(
-		'article'         => ContentArticle::class,
-		'alias'           => ContentAlias::class,
-		'form'            => Form::class,
-		'module'          => ContentModule::class,
 	)
 );
 

--- a/core-bundle/contao/library/Contao/Widget.php
+++ b/core-bundle/contao/library/Contao/Widget.php
@@ -1388,12 +1388,6 @@ abstract class Widget extends Controller
 				}
 			}
 
-			// Sort the options by key if they use language references
-			if ($blnIsAssociative && $blnUseReference)
-			{
-				ksort($arrAttributes['options']);
-			}
-
 			$arrAttributes['unknownOption'] = array_filter($unknown);
 		}
 

--- a/core-bundle/src/EventListener/GlobalsMapListener.php
+++ b/core-bundle/src/EventListener/GlobalsMapListener.php
@@ -33,7 +33,7 @@ class GlobalsMapListener
     {
         foreach ($this->globals as $key => $value) {
             if (\is_array($value) && isset($GLOBALS[$key]) && \is_array($GLOBALS[$key])) {
-                $GLOBALS[$key] = array_replace_recursive($value, $GLOBALS[$key]);
+                $GLOBALS[$key] = array_replace_recursive($GLOBALS[$key], $value, $GLOBALS[$key]);
             } else {
                 $GLOBALS[$key] = $value;
             }

--- a/core-bundle/tests/EventListener/GlobalsMapListenerTest.php
+++ b/core-bundle/tests/EventListener/GlobalsMapListenerTest.php
@@ -49,7 +49,7 @@ class GlobalsMapListenerTest extends TestCase
         yield 'add to existing group' => [
             ['texts' => ['text' => 'LegacyText']],
             ['texts' => ['headline' => 'HeadlineFragment']],
-            ['texts' => ['headline' => 'HeadlineFragment', 'text' => 'LegacyText']],
+            ['texts' => ['text' => 'LegacyText', 'headline' => 'HeadlineFragment']],
         ];
 
         yield 'prefer existing entries' => [


### PR DESCRIPTION
Reverts https://github.com/contao/contao/pull/6652 because that caused **every dropdown widget** from being alphabetically sorted, even if a developer had a custom sorting. It also now has a more consistent sorting of elements as people are used to.