### PR TITLE
Correctly set the target path in the login module

### DIFF
--- a/core-bundle/contao/modules/ModuleLogin.php
+++ b/core-bundle/contao/modules/ModuleLogin.php
@@ -74,7 +74,7 @@ class ModuleLogin extends Module
 		{
 			$this->targetPath = base64_decode($request->request->get('_target_path'));
 		}
-		if ($request?->query->has('redirect'))
+		elseif ($request?->query->has('redirect'))
 		{
 			$uriSigner = System::getContainer()->get('uri_signer');
 

--- a/core-bundle/contao/modules/ModuleLogin.php
+++ b/core-bundle/contao/modules/ModuleLogin.php
@@ -74,28 +74,25 @@ class ModuleLogin extends Module
 		{
 			$this->targetPath = base64_decode($request->request->get('_target_path'));
 		}
-		elseif ($request && $this->redirectBack)
+		if ($request?->query->has('redirect'))
 		{
-			if ($request->query->has('redirect'))
-			{
-				$uriSigner = System::getContainer()->get('uri_signer');
+			$uriSigner = System::getContainer()->get('uri_signer');
 
-				// We cannot use $request->getUri() here as we want to work with the original URI (no query string reordering)
-				if ($uriSigner->check($request->getSchemeAndHttpHost() . $request->getBaseUrl() . $request->getPathInfo() . (null !== ($qs = $request->server->get('QUERY_STRING')) ? '?' . $qs : '')))
-				{
-					$this->targetPath = $request->query->get('redirect');
-				}
+			// We cannot use $request->getUri() here as we want to work with the original URI (no query string reordering)
+			if ($uriSigner->check($request->getSchemeAndHttpHost() . $request->getBaseUrl() . $request->getPathInfo() . (null !== ($qs = $request->server->get('QUERY_STRING')) ? '?' . $qs : '')))
+			{
+				$this->targetPath = $request->query->get('redirect');
 			}
-			elseif ($referer = $request->headers->get('referer'))
-			{
-				$refererUri = new Uri($referer);
-				$requestUri = new Uri($request->getUri());
+		}
+		elseif ($referer = $request?->headers->get('referer'))
+		{
+			$refererUri = new Uri($referer);
+			$requestUri = new Uri($request->getUri());
 
-				// Use the HTTP referer as a fallback, but only if scheme and host matches with the current request (see #5860)
-				if ($refererUri->getScheme() === $requestUri->getScheme() && $refererUri->getHost() === $requestUri->getHost() && $refererUri->getPort() === $requestUri->getPort())
-				{
-					$this->targetPath = (string) $refererUri;
-				}
+			// Use the HTTP referer as a fallback, but only if scheme and host matches with the current request (see #5860)
+			if ($refererUri->getScheme() === $requestUri->getScheme() && $refererUri->getHost() === $requestUri->getHost() && $refererUri->getPort() === $requestUri->getPort())
+			{
+				$this->targetPath = (string) $refererUri;
 			}
 		}
 


### PR DESCRIPTION
Best viewed with whitespaces ignored: https://github.com/contao/contao/pull/6831/files?w=1

This way the `$canReauthenticate` variable is set independently from the `$this->redirectBack` setting.
