### PR TITLE
Do not load the sitemap from cache for authenticated users

### DIFF
--- a/core-bundle/src/Controller/SitemapController.php
+++ b/core-bundle/src/Controller/SitemapController.php
@@ -95,6 +95,9 @@ class SitemapController extends AbstractController
         $response = new Response((string) $sitemap->saveXML(), 200, ['Content-Type' => 'application/xml; charset=UTF-8']);
         $response->setSharedMaxAge(2592000); // will be unset by the MakeResponsePrivateListener if a user is logged in
 
+        // Make sure an authorized request does not retrieve the sitemap from the HTTP cache
+        $response->setVary('Cookie');
+
         $this->tagResponse($tags);
 
         return $response;

--- a/core-bundle/src/Controller/SitemapController.php
+++ b/core-bundle/src/Controller/SitemapController.php
@@ -95,7 +95,7 @@ class SitemapController extends AbstractController
         $response = new Response((string) $sitemap->saveXML(), 200, ['Content-Type' => 'application/xml; charset=UTF-8']);
         $response->setSharedMaxAge(2592000); // will be unset by the MakeResponsePrivateListener if a user is logged in
 
-        // Make sure an authorized request does not retrieve the sitemap from the HTTP cache
+        // Make sure an authorized request does not retrieve the sitemap from the HTTP cache (see #6832)
         $response->setVary('Cookie');
 
         $this->tagResponse($tags);

--- a/core-bundle/tests/Controller/SitemapControllerTest.php
+++ b/core-bundle/tests/Controller/SitemapControllerTest.php
@@ -130,6 +130,7 @@ class SitemapControllerTest extends TestCase
         $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
         $this->assertSame('public, s-maxage=2592000', $response->headers->get('Cache-Control'));
         $this->assertSame($this->getExpectedSitemapContent(['https://www.foobar.com/en/page1.html']), $response->getContent());
+        $this->assertSame(['Cookie'], $response->getVary());
     }
 
     public function testRecursivelyWalksThePageTree(): void


### PR DESCRIPTION
In the Contao back end we have the ability to let the crawler crawl your Contao website(s) with an authorized session of a front end user.

However, under certain circumstances it can happen that the crawler does not retrieve the protected pages from the `/sitemap.xml` route - if it happened to be cached before. This is because the response of the `/sitemap.xml` currently does not set a `Vary` on `Cookie` meaning that despite a session cookie being present the reverse proxy will serve the `/sitemap.xml` always from the cache.

## Reproduction

* In your Contao website create a page and protect it for a member group.
* Also hide the protected page from the menu (and make sure it's not linked to from anywhere else).
* Access the sitemap (`https://example.com/sitemap.xml`) via an unauthorized request (e.g. private browser window) so it is stored in the HTTP cache.
* In the Contao back end go to _Maintenance_ » **Crawler**, enable _Update the search index_, select a member from the select that has access to the previously generated protected page and _Start crawling_.
* Download the debug CSV after the Crawler has finished.

The protected page will not have been indexed, as the Crawler received a cached response from the `SitemapController`.