### PR TITLE
Also `Vary` on `Authorization` header and move logic to `MakeResponsePrivateListener`

### DIFF
--- a/core-bundle/contao/classes/FrontendTemplate.php
+++ b/core-bundle/contao/classes/FrontendTemplate.php
@@ -165,27 +165,6 @@ class FrontendTemplate extends Template
 		{
 			$response->setSharedMaxAge($objPage->cache); // Automatically sets the response to public
 
-			/**
-			 * We vary on cookies if a response is cacheable by the shared
-			 * cache, so a reverse proxy does not load a response from cache if
-			 * the _request_ contains a cookie.
-			 *
-			 * This DOES NOT mean that we generate a cache entry for every
-			 * response containing a cookie! Responses with cookies will always
-			 * be private.
-			 *
-			 * @see MakeResponsePrivateListener
-			 *
-			 * However, we want to be able to force the reverse proxy to load a
-			 * response from cache, even if the request contains a cookie – in
-			 * case the admin has configured to do so. A typical use case would
-			 * be serving public pages from cache to logged in members.
-			 */
-			if (!$objPage->alwaysLoadFromCache)
-			{
-				$response->setVary(array('Cookie'));
-			}
-
 			// Tag the page (see #2137)
 			System::getContainer()->get('contao.cache.entity_tags')->tagWithModelInstance($objPage);
 		}

--- a/core-bundle/src/Controller/AbstractController.php
+++ b/core-bundle/src/Controller/AbstractController.php
@@ -98,26 +98,6 @@ abstract class AbstractController extends SymfonyAbstractController
         if ($pageModel->cache > 0) {
             $response->setSharedMaxAge($pageModel->cache); // Automatically sets the response to public
 
-            /**
-             * We vary on cookies if a response is cacheable by the shared
-             * cache, so a reverse proxy does not load a response from cache if
-             * the _request_ contains a cookie.
-             *
-             * This DOES NOT mean that we generate a cache entry for every
-             * response containing a cookie! Responses with cookies will always
-             * be private.
-             *
-             * @see MakeResponsePrivateListener
-             *
-             * However, we want to be able to force the reverse proxy to load a
-             * response from cache, even if the request contains a cookie – in
-             * case the admin has configured to do so. A typical use case would
-             * be serving public pages from cache to logged in members.
-             */
-            if (!$pageModel->alwaysLoadFromCache) {
-                $response->setVary(['Cookie']);
-            }
-
             // Tag the page (see #2137)
             $this->container->get('contao.cache.entity_tags')->tagWithModelInstance($pageModel);
         }

--- a/core-bundle/src/EventListener/MakeResponsePrivateListener.php
+++ b/core-bundle/src/EventListener/MakeResponsePrivateListener.php
@@ -125,7 +125,7 @@ class MakeResponsePrivateListener
              * – in case the admin has configured to do so. A typical use case would be 
              * serving public pages from cache to logged in members.
              */
-            if ($page->alwaysLoadFromCache) {
+            if ($page->cache && $page->alwaysLoadFromCache) {
                 return;
             }
         }

--- a/core-bundle/src/EventListener/MakeResponsePrivateListener.php
+++ b/core-bundle/src/EventListener/MakeResponsePrivateListener.php
@@ -13,7 +13,9 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\EventListener;
 
 use Contao\CoreBundle\Routing\ScopeMatcher;
+use Contao\PageModel;
 use Symfony\Component\HttpFoundation\Cookie;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\EventListener\AbstractSessionListener;
@@ -40,6 +42,10 @@ class MakeResponsePrivateListener
      *
      * Some of this logic is also already implemented in the HttpCache (1, 2 and 3), but we
      * want to make sure it works for any reverse proxy without having to configure too much.
+     * 
+     * Additionally we also apply Vary headers for Contao requests here, to ensure the reverse
+     * proxy does not load responses from the cache if it was an authorized request (unless this
+     * was specifically forced via the page's settings).
      */
     public function __invoke(ResponseEvent $event): void
     {
@@ -85,6 +91,9 @@ class MakeResponsePrivateListener
             return;
         }
 
+        // Apply Vary header at this point
+        $this->applyVary($request, $response);
+
         // 4) The response has a "Vary: Cookie" header and the request provides at least one cookie
         if ($request->cookies->count() && \in_array('cookie', array_map('strtolower', $response->getVary()), true)) {
             $this->makePrivate(
@@ -98,5 +107,29 @@ class MakeResponsePrivateListener
     {
         $response->setPrivate();
         $response->headers->set(self::DEBUG_HEADER, $reason);
+    }
+
+    private function applyVary(Request $request, Response $response): void
+    {
+        if (($page = $request->attributes->get('pageModel')) instanceof PageModel) {
+            /**
+             * We vary on cookies and the authorization header if a response is cacheable 
+             * by the shared cache, so a reverse proxy does not load a response from cache 
+             * if the _request_ contains a cookie or an authorization header.
+             *
+             * This DOES NOT mean that we generate a cache entry for every authorized
+             * response! These responses will always be private (see above).
+             *
+             * However, we want to be able to force the reverse proxy to load a response 
+             * from cache, even if the request contains a cookie or an authorization header 
+             * – in case the admin has configured to do so. A typical use case would be 
+             * serving public pages from cache to logged in members.
+             */
+            if ($page->alwaysLoadFromCache) {
+                return;
+            }
+        }
+
+        $response->setVary(['Cookie', 'Authorization'], false);
     }
 }


### PR DESCRIPTION
Currently our `MakeResponsePrivateListener` makes sure that any response to a Contao `frontend` request with an `Authorization` header does not end up in the shared cache. However, we only `Vary` on `Cookie` currently which means that requests with an `Authorization` header will still be served from the cache. Thus if you implemented a Symfony Authenticator that does not rely on the PHP session cookie for example (like Basic Auth or Token based authentication) your requests might get served from the cache (including requests to the `sitemap.xml` for example).

As discussed we want to fix this by moving the `Vary` logic to the `MakeResponsePrivateListener` - because only there we can be sure to apply it. Previously Controllers could use the Contao `AbstractController` and its `setCacheHeaders` method - however, this does not ensure that the Controller actually uses the `frontend` `_scope`.