### PR TITLE
Fix routes with parameters in the SERP widget

### DIFF
--- a/core-bundle/contao/widgets/SerpPreview.php
+++ b/core-bundle/contao/widgets/SerpPreview.php
@@ -10,6 +10,7 @@
 
 namespace Contao;
 
+use Contao\CoreBundle\Exception\RouteParametersException;
 use Symfony\Component\Routing\Exception\ExceptionInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
@@ -160,6 +161,10 @@ class SerpPreview extends Widget
 			try
 			{
 				$url = System::getContainer()->get('contao.routing.content_url_generator')->generate($tempModel, array(), UrlGeneratorInterface::ABSOLUTE_URL);
+			}
+			catch (RouteParametersException $exception)
+			{
+				throw $exception;
 			}
 			catch (ExceptionInterface $exception)
 			{


### PR DESCRIPTION
Currently, the back end would show an exception when trying to edit a page with parameters. The widget previously handled routing errors and did show a `no preview available` message. The new exception handling when generating the URL was added for if a route is generated for a content that does not have a content route provider. But we must not handle the route parameter exception here.