### PR TITLE
Keep login module errors

### DIFF
--- a/core-bundle/contao/modules/ModuleLogin.php
+++ b/core-bundle/contao/modules/ModuleLogin.php
@@ -153,7 +153,7 @@ class ModuleLogin extends Module
 		}
 
 		// Only call the authentication utils if there is an active session to prevent starting an empty session
-		if ($request && $request->hasSession() && ($request->hasPreviousSession() || $request->getSession()->isStarted()))
+		if ($request?->hasSession() && ($request->hasPreviousSession() || $request->getSession()->isStarted()))
 		{
 			$authUtils = $container->get('security.authentication_utils');
 			$exception = $authUtils->getLastAuthenticationError();

--- a/core-bundle/contao/modules/ModuleLogin.php
+++ b/core-bundle/contao/modules/ModuleLogin.php
@@ -17,6 +17,7 @@ use Scheb\TwoFactorBundle\Security\TwoFactor\Event\TwoFactorAuthenticationEvents
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\Exception\TooManyLoginAttemptsAuthenticationException;
+use Symfony\Component\Security\Http\SecurityRequestAttributes;
 
 /**
  * Front end module "login".
@@ -152,11 +153,22 @@ class ModuleLogin extends Module
 		}
 
 		// Only call the authentication utils if there is an active session to prevent starting an empty session
-		if ($request?->hasSession() && ($request->hasPreviousSession() || $request->getSession()->isStarted()))
+		if ($request && $request->hasSession() && ($request->hasPreviousSession() || $request->getSession()->isStarted()))
 		{
 			$authUtils = $container->get('security.authentication_utils');
 			$exception = $authUtils->getLastAuthenticationError();
 			$lastUsername = $authUtils->getLastUsername();
+
+			// Store exception and username again to make it available for additional login modules on the page (see contao/contao#6275)
+			if ($exception)
+			{
+				$request->attributes->set(SecurityRequestAttributes::AUTHENTICATION_ERROR, $exception);
+			}
+
+			if ($lastUsername)
+			{
+				$request->attributes->set(SecurityRequestAttributes::LAST_USERNAME, $lastUsername);
+			}
 		}
 
 		if ($exception instanceof TooManyLoginAttemptsAuthenticationException)


### PR DESCRIPTION
Since we already improved a lot of the login functionality in 5.3, and I'm currently familiar with the topic, I think we should add https://github.com/contao/contao/issues/6275 as well.