### PR TITLE
Fix relative front end preview links

### DIFF
--- a/core-bundle/src/Controller/BackendPreviewController.php
+++ b/core-bundle/src/Controller/BackendPreviewController.php
@@ -80,7 +80,7 @@ class BackendPreviewController
 
         $targetUri = new Uri($targetUrl);
 
-        if ($request->getHost() === $targetUri->getHost() || !($user = $this->security->getUser())) {
+        if (!$targetUri->getHost() || $request->getHost() === $targetUri->getHost() || !($user = $this->security->getUser())) {
             return new RedirectResponse($targetUrl);
         }
 

--- a/core-bundle/tests/Controller/BackendPreviewControllerTest.php
+++ b/core-bundle/tests/Controller/BackendPreviewControllerTest.php
@@ -200,6 +200,12 @@ class BackendPreviewControllerTest extends TestCase
             'https://www.example.com/en/foo.html',
         ];
 
+        yield 'Redirect relative to front end' => [
+            'https://www.example.com/preview.php/contao/preview?page=17',
+            '/en/foo.html',
+            '/en/foo.html',
+        ];
+
         yield 'Redirects to login link URL for cross-domain previews' => [
             'https://www.example.com/preview.php/contao/preview?page=42',
             'https://www.example.org/en/foo.html',


### PR DESCRIPTION
For relative links, the `Uri` host would be empty, therefore it would generate a link with `localhost` instead of just keeping the relative link.