### PR TITLE
Improve the `ConfigureFilesystemPass` performance

### DIFF
--- a/core-bundle/src/DependencyInjection/Compiler/ConfigureFilesystemPass.php
+++ b/core-bundle/src/DependencyInjection/Compiler/ConfigureFilesystemPass.php
@@ -18,6 +18,7 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\Filesystem\Path;
+use Symfony\Component\Finder\Exception\DirectoryNotFoundException;
 use Symfony\Component\Finder\Finder;
 
 class ConfigureFilesystemPass implements CompilerPassInterface
@@ -55,7 +56,11 @@ class ConfigureFilesystemPass implements CompilerPassInterface
         $projectDir = $parameterBag->resolveValue($parameterBag->get('kernel.project_dir'));
         $uploadDir = $parameterBag->resolveValue($parameterBag->get('contao.upload_path'));
 
-        $finder = (new Finder())->in(Path::join($projectDir, $uploadDir))->directories();
+        try {
+            $finder = (new Finder())->in(Path::join($projectDir, $uploadDir))->directories();
+        } catch (DirectoryNotFoundException $e) {
+            return;
+        }
 
         foreach ($finder as $item) {
             if (!$item->isLink()) {

--- a/core-bundle/src/DependencyInjection/Compiler/ConfigureFilesystemPass.php
+++ b/core-bundle/src/DependencyInjection/Compiler/ConfigureFilesystemPass.php
@@ -70,7 +70,7 @@ class ConfigureFilesystemPass implements CompilerPassInterface
             }
 
             // Mount a local adapter in place of the symlink
-            $config->mountLocalAdapter($target, $item->getRelativePathname());
+            $config->mountLocalAdapter($target, Path::join($uploadDir, $item->getRelativePathname()));
         }
     }
 }

--- a/core-bundle/src/DependencyInjection/Compiler/ConfigureFilesystemPass.php
+++ b/core-bundle/src/DependencyInjection/Compiler/ConfigureFilesystemPass.php
@@ -55,7 +55,7 @@ class ConfigureFilesystemPass implements CompilerPassInterface
         $projectDir = $parameterBag->resolveValue($parameterBag->get('kernel.project_dir'));
         $uploadDir = $parameterBag->resolveValue($parameterBag->get('contao.upload_path'));
 
-        $finder = (new Finder())->in($projectDir)->directories()->path('/^'.preg_quote($uploadDir, '/').'\//');
+        $finder = (new Finder())->in(Path::join($projectDir, $uploadDir))->directories();
 
         foreach ($finder as $item) {
             if (!$item->isLink()) {


### PR DESCRIPTION
I noticed on my system that calling `vendor/bin/contao-setup` is very slow. I found the culprit to be `ConfigureFilesystemPass::mountAdaptersForSymlinks` - and in particular it happens because of the regex path filtering we use here: 

https://github.com/contao/contao/blob/477ca9e95767212c6c4d507e700654f483778af1/core-bundle/src/DependencyInjection/Compiler/ConfigureFilesystemPass.php#L58

On my system this method can take up to 60 seconds (!) in total. And since this is a compiler pass that is executed _every time_ the kernel initializes the container - and since during `contao-setup` the kernel is initialized multiple times, it consumes _a lot_ of time.

The regex isn't even necessary, since we can just tell the Finder to look in `files/` in the first place. This PR does that.

This improves the execution time of this method from 60000ms to 40ms 🚀 
