### PR TITLE
Cast the template identifier to string

### DIFF
--- a/core-bundle/src/EventListener/DataContainer/TemplateOptionsListener.php
+++ b/core-bundle/src/EventListener/DataContainer/TemplateOptionsListener.php
@@ -66,7 +66,7 @@ class TemplateOptionsListener
 
         $templateOptions = $this->finderFactory
             ->create()
-            ->identifier($identifier)
+            ->identifier((string) $identifier)
             ->extension('html.twig')
             ->withVariants()
             ->asTemplateOptions()


### PR DESCRIPTION
`$identifier` can be null but the method only allows strings.