### PR TITLE
Correctly generate record labels with foreign keys

### DIFF
--- a/core-bundle/src/Resources/contao/classes/DataContainer.php
+++ b/core-bundle/src/Resources/contao/classes/DataContainer.php
@@ -1707,7 +1707,7 @@ abstract class DataContainer extends Backend
 					->limit(1)
 					->execute($row[$strKey]);
 
-				$args[$k] = $objRef->numRows ? $objRef->$strField : '-';
+				$args[$k] = $objRef->numRows ? $objRef->$strField : '';
 			}
 			elseif (isset($row[$v], $GLOBALS['TL_DCA'][$table]['fields'][$v]['foreignKey']))
 			{
@@ -1718,7 +1718,7 @@ abstract class DataContainer extends Backend
 					->limit(1)
 					->execute($row[$v]);
 
-				$args[$k] = $objRef->numRows ? $objRef->value : '-';
+				$args[$k] = $objRef->numRows ? $objRef->value : '';
 			}
 			elseif (\in_array($GLOBALS['TL_DCA'][$table]['fields'][$v]['flag'] ?? null, array(self::SORT_DAY_ASC, self::SORT_DAY_DESC, self::SORT_MONTH_ASC, self::SORT_MONTH_DESC, self::SORT_YEAR_ASC, self::SORT_YEAR_DESC)))
 			{
@@ -1767,11 +1767,11 @@ abstract class DataContainer extends Backend
 					$args[$k] = $row[$v];
 				}
 
-				$args[$k] = (string) $args[$k] !== '' ? $args[$k] : '-';
+				$args[$k] = (string) $args[$k] !== '' ? $args[$k] : '';
 			}
 			else
 			{
-				$args[$k] = '-';
+				$args[$k] = '';
 			}
 		}
 

--- a/core-bundle/src/Resources/contao/classes/DataContainer.php
+++ b/core-bundle/src/Resources/contao/classes/DataContainer.php
@@ -1707,7 +1707,18 @@ abstract class DataContainer extends Backend
 					->limit(1)
 					->execute($row[$strKey]);
 
-				$args[$k] = $objRef->numRows ? $objRef->$strField : '';
+				$args[$k] = $objRef->numRows ? $objRef->$strField : '-';
+			}
+			elseif (isset($row[$v], $GLOBALS['TL_DCA'][$table]['fields'][$v]['foreignKey']))
+			{
+				$key = explode('.', $GLOBALS['TL_DCA'][$table]['fields'][$v]['foreignKey'], 2);
+
+				$objRef = Database::getInstance()
+					->prepare("SELECT " . Database::quoteIdentifier($key[1]) . " AS value FROM " . $key[0] . " WHERE id=?")
+					->limit(1)
+					->execute($row[$v]);
+
+				$args[$k] = $objRef->numRows ? $objRef->value : '-';
 			}
 			elseif (\in_array($GLOBALS['TL_DCA'][$table]['fields'][$v]['flag'] ?? null, array(self::SORT_DAY_ASC, self::SORT_DAY_DESC, self::SORT_MONTH_ASC, self::SORT_MONTH_DESC, self::SORT_YEAR_ASC, self::SORT_YEAR_DESC)))
 			{
@@ -1726,7 +1737,7 @@ abstract class DataContainer extends Backend
 			}
 			elseif (($GLOBALS['TL_DCA'][$table]['fields'][$v]['eval']['isBoolean'] ?? null) || (($GLOBALS['TL_DCA'][$table]['fields'][$v]['inputType'] ?? null) == 'checkbox' && !($GLOBALS['TL_DCA'][$table]['fields'][$v]['eval']['multiple'] ?? null)))
 			{
-				$args[$k] = $row[$v] ? $GLOBALS['TL_LANG']['MSC']['yes'] : $GLOBALS['TL_LANG']['MSC']['no'];
+				$args[$k] = ($row[$v] ?? null) ? $GLOBALS['TL_LANG']['MSC']['yes'] : $GLOBALS['TL_LANG']['MSC']['no'];
 			}
 			elseif (isset($row[$v]))
 			{
@@ -1755,10 +1766,12 @@ abstract class DataContainer extends Backend
 				{
 					$args[$k] = $row[$v];
 				}
+
+				$args[$k] = (string) $args[$k] !== '' ? $args[$k] : '-';
 			}
 			else
 			{
-				$args[$k] = null;
+				$args[$k] = '-';
 			}
 		}
 

--- a/core-bundle/src/Resources/contao/classes/DataContainer.php
+++ b/core-bundle/src/Resources/contao/classes/DataContainer.php
@@ -1766,12 +1766,10 @@ abstract class DataContainer extends Backend
 				{
 					$args[$k] = $row[$v];
 				}
-
-				$args[$k] = (string) $args[$k] !== '' ? $args[$k] : '';
 			}
 			else
 			{
-				$args[$k] = '';
+				$args[$k] = null;
 			}
 		}
 

--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -5106,30 +5106,6 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 					{
 						$field = $GLOBALS['TL_DCA'][$this->strTable]['list']['label']['fields'][$j] ?? null;
 
-						if (isset($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['foreignKey']))
-						{
-							if ($arg)
-							{
-								$key = explode('.', $GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['foreignKey'], 2);
-
-								$reference = $this->Database
-									->prepare("SELECT " . Database::quoteIdentifier($key[1]) . " AS value FROM " . $key[0] . " WHERE id=?")
-									->limit(1)
-									->execute($arg);
-
-								if ($reference->numRows)
-								{
-									$arg = $reference->value;
-								}
-							}
-
-							$value = $arg ?: '-';
-						}
-						else
-						{
-							$value = (string) $arg !== '' ? $arg : '-';
-						}
-
 						$return .= '<td colspan="' . $colspan . '" class="tl_file_list col_' . explode(':', $field, 2)[0] . ($field == $firstOrderBy ? ' ordered_by' : '') . '">' . $value . '</td>';
 					}
 				}

--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -5105,6 +5105,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 					foreach ($label as $j=>$arg)
 					{
 						$field = $GLOBALS['TL_DCA'][$this->strTable]['list']['label']['fields'][$j] ?? null;
+						$value = (string) $arg !== '' ? $arg : '-';
 
 						$return .= '<td colspan="' . $colspan . '" class="tl_file_list col_' . explode(':', $field, 2)[0] . ($field == $firstOrderBy ? ' ordered_by' : '') . '">' . $value . '</td>';
 					}


### PR DESCRIPTION
This fixes a long standing issue that record labels are not correctly generated from foreignKey. I noticed this because of a strange behaviour: I have a custom `label_callback`, but the column view did not show the value my callback returned. This was because the value I returned was used to look up the foreignKey! And for one of 10 records, it actually found something in the foreign tabel (for no good reason) and showed that instead.