### PR TITLE
Do not add duplicate paths in our own Twig filesystem loader

### DIFF
--- a/core-bundle/src/Twig/Loader/ContaoFilesystemLoader.php
+++ b/core-bundle/src/Twig/Loader/ContaoFilesystemLoader.php
@@ -104,6 +104,11 @@ class ContaoFilesystemLoader extends FilesystemLoader implements TemplateHierarc
             throw new LoaderError(sprintf('Tried to register an invalid Contao namespace "%s".', $namespace));
         }
 
+        // Skip execution if the given path and namespace was already registered
+        if (\in_array(rtrim($path, '/\\'), $this->paths[$namespace] ?? [], true)) {
+            return;
+        }
+
         try {
             parent::addPath($path, $namespace);
         } catch (LoaderError $error) {

--- a/core-bundle/tests/Twig/Loader/ContaoFilesystemLoaderTest.php
+++ b/core-bundle/tests/Twig/Loader/ContaoFilesystemLoaderTest.php
@@ -46,6 +46,22 @@ class ContaoFilesystemLoaderTest extends TestCase
         $this->assertFalse($loader->exists('@Contao_foo-Bar_Baz2/2.html.twig'));
     }
 
+    public function testDoesNotAddPathTwice(): void
+    {
+        $loader = $this->getContaoFilesystemLoader();
+
+        $path1 = Path::canonicalize(__DIR__.'/../../Fixtures/Twig/paths/1');
+        $path2 = Path::canonicalize(__DIR__.'/../../Fixtures/Twig/paths/2');
+
+        $loader->addPath($path1);
+        $loader->addPath($path2, 'Contao_foo');
+        $loader->addPath($path1);
+        $loader->addPath($path2, 'Contao_foo');
+
+        $this->assertSame([$path1], $loader->getPaths());
+        $this->assertSame([$path2], $loader->getPaths('Contao_foo'));
+    }
+
     public function testPrependsPath(): void
     {
         $loader = $this->getContaoFilesystemLoader();


### PR DESCRIPTION
Fixes #6802, alternative to #6847.

The `ContaoFilesystemLoader` works on internal lists of paths/namespace configurations and template filenames  (that are also cached to reduce the amount of filesystem calls). Currently, the `ContaoFilesystemLoaderWarmer` - a mandatory cache warmer - propagates these lists. 

Calling a cache warmer multiple times must not change the outcome, so there are basically two ways this can be achieved: Either the state must be reset beforehand (= clear the loader and cache) or the calls must effectively be no-ops if the cache was already warmed (= skip). I opted for the latter, because it is really only the `addPath()` calls that change the outcome. With this PR, we are now ignoring duplicate path/namespace directly in the loader. 

*Side note: Our loader extends from the original Twig filesystem loader but it really should not. In the beginning I thought this was a good idea but with the added features, the two are very different now. So, in a future PR I would like to change this and subsequently remove some methods like `prependPath()` that do not make sense in our context and that I also did not touch in this PR. We probably need to discuss if we can/should do this break ("@experimental") or not.*