### PR TITLE
Correctly update the file name when synchronizing the DBAFS

### DIFF
--- a/core-bundle/src/Filesystem/Dbafs/ChangeSet/ChangeSet.php
+++ b/core-bundle/src/Filesystem/Dbafs/ChangeSet/ChangeSet.php
@@ -152,6 +152,7 @@ class ChangeSet
                     (string) $existingPath,
                     $item[self::ATTR_HASH] ?? null,
                     $item[self::ATTR_PATH] ?? null,
+                    self::TYPE_FILE === $item[self::ATTR_TYPE],
                     $lastModified,
                 );
             },
@@ -166,6 +167,7 @@ class ChangeSet
         return [...array_map(
             static fn (string|int $existingPath, int $lastModified) => new ItemToUpdate(
                 (string) $existingPath,
+                null,
                 null,
                 null,
                 $lastModified

--- a/core-bundle/src/Filesystem/Dbafs/ChangeSet/ChangeSet.php
+++ b/core-bundle/src/Filesystem/Dbafs/ChangeSet/ChangeSet.php
@@ -16,7 +16,7 @@ use Symfony\Component\Filesystem\Path;
 
 /**
  * @phpstan-type CreateItemDefinition array{hash: string, path: string, type: self::TYPE_*}
- * @phpstan-type UpdateItemDefinition array{hash?: string, path?: string, lastModified?: int|null}
+ * @phpstan-type UpdateItemDefinition array{hash?: string, path?: string, type?: self::TYPE_*, lastModified?: int|null}
  * @phpstan-type DeleteItemDefinition self::TYPE_*
  *
  * @experimental

--- a/core-bundle/src/Filesystem/Dbafs/ChangeSet/ItemToUpdate.php
+++ b/core-bundle/src/Filesystem/Dbafs/ChangeSet/ItemToUpdate.php
@@ -21,6 +21,7 @@ class ItemToUpdate
         private readonly string $existingPath,
         private readonly string|null $newHash,
         private readonly string|null $newPath,
+        private readonly bool|null $isFile,
         private readonly int|false|null $lastModified = false,
     ) {
     }
@@ -56,6 +57,15 @@ class ItemToUpdate
         }
 
         return $this->newPath;
+    }
+
+    public function isFile(): bool
+    {
+        if (null === $this->isFile) {
+            throw new \LogicException(sprintf('The update to item "%s" does not include a new path.', $this->existingPath));
+        }
+
+        return $this->isFile;
     }
 
     public function updatesLastModified(): bool

--- a/core-bundle/src/Filesystem/Dbafs/Dbafs.php
+++ b/core-bundle/src/Filesystem/Dbafs/Dbafs.php
@@ -365,7 +365,7 @@ class Dbafs implements DbafsInterface, ResetInterface
                 }
 
                 // Hash has changed; update the record
-                $itemsToUpdate[$path] = [ChangeSet::ATTR_HASH => $hash];
+                $itemsToUpdate[$path] = [ChangeSet::ATTR_HASH => $hash, ChangeSet::ATTR_TYPE => $type];
             }
 
             unset($itemsToDelete[$path]);
@@ -411,7 +411,7 @@ class Dbafs implements DbafsInterface, ResetInterface
             $oldPath = reset($candidates);
 
             // We identified a move, transfer to update list
-            $itemsToUpdate[$oldPath] = [ChangeSet::ATTR_PATH => (string) $path];
+            $itemsToUpdate[$oldPath] = [ChangeSet::ATTR_PATH => (string) $path, ChangeSet::ATTR_TYPE => $dataToInsert['type']];
             unset($itemsToCreate[$path], $itemsToDelete[$oldPath]);
 
             if (null !== ($lastModified = $lastModifiedUpdates[$path] ?? null)) {
@@ -606,6 +606,7 @@ class Dbafs implements DbafsInterface, ResetInterface
                 // Backwards compatibility
                 if ('tl_files' === $this->table) {
                     $dataToUpdate['name'] = basename($itemToUpdate->getNewPath());
+                    $dataToUpdate['extension'] = $itemToUpdate->isFile() ? Path::getExtension($itemToUpdate->getNewPath()) : '';
                 }
             }
 

--- a/core-bundle/src/Filesystem/Dbafs/Dbafs.php
+++ b/core-bundle/src/Filesystem/Dbafs/Dbafs.php
@@ -602,6 +602,11 @@ class Dbafs implements DbafsInterface, ResetInterface
             if ($itemToUpdate->updatesPath()) {
                 $dataToUpdate['path'] = $this->convertToDatabasePath($itemToUpdate->getNewPath());
                 $dataToUpdate['pid'] = $getParentUuid($itemToUpdate->getNewPath());
+
+                // Backwards compatibility
+                if ('tl_files' === $this->table) {
+                    $dataToUpdate['name'] = basename($itemToUpdate->getNewPath());
+                }
             }
 
             if ($itemToUpdate->updatesHash()) {

--- a/core-bundle/tests/Command/FilesyncCommandTest.php
+++ b/core-bundle/tests/Command/FilesyncCommandTest.php
@@ -90,9 +90,11 @@ class FilesyncCommandTest extends TestCase
                         [
                             'bar/old_path' => [
                                 ChangeSet::ATTR_PATH => 'bar/updated_path',
+                                ChangeSet::ATTR_TYPE => ChangeSet::TYPE_FILE,
                             ],
                             'bar/file_that_changes' => [
                                 ChangeSet::ATTR_HASH => '8a1631a4eacf47253f3ebb5aea2ccce7',
+                                ChangeSet::ATTR_TYPE => ChangeSet::TYPE_FILE,
                             ],
                         ],
                         [

--- a/core-bundle/tests/Filesystem/Dbafs/ChangeSet/ChangeSetTest.php
+++ b/core-bundle/tests/Filesystem/Dbafs/ChangeSet/ChangeSetTest.php
@@ -37,8 +37,8 @@ class ChangeSetTest extends TestCase
                 [ChangeSet::ATTR_HASH => 'd821', ChangeSet::ATTR_PATH => 'foo/new2', ChangeSet::ATTR_TYPE => ChangeSet::TYPE_DIRECTORY],
             ],
             [
-                'bar/old_path' => [ChangeSet::ATTR_PATH => 'bar/updated_path'],
-                'bar/file_that_changes' => [ChangeSet::ATTR_HASH => 'e127'],
+                'bar/old_path' => [ChangeSet::ATTR_PATH => 'bar/updated_path', ChangeSet::ATTR_TYPE => ChangeSet::TYPE_FILE],
+                'bar/file_that_changes' => [ChangeSet::ATTR_HASH => 'e127', ChangeSet::ATTR_TYPE => ChangeSet::TYPE_FILE],
             ],
             [
                 'baz' => ChangeSet::TYPE_DIRECTORY,
@@ -92,8 +92,8 @@ class ChangeSetTest extends TestCase
         $changeSet = new ChangeSet(
             [],
             [
-                'bar/old_path' => [ChangeSet::ATTR_PATH => 'bar/updated_path'],
-                'bar/file_that_changes' => [ChangeSet::ATTR_HASH => 'e127'],
+                'bar/old_path' => [ChangeSet::ATTR_PATH => 'bar/updated_path', ChangeSet::ATTR_TYPE => ChangeSet::TYPE_FILE],
+                'bar/file_that_changes' => [ChangeSet::ATTR_HASH => 'e127', ChangeSet::ATTR_TYPE => ChangeSet::TYPE_FILE],
             ],
             [],
             [
@@ -142,8 +142,8 @@ class ChangeSetTest extends TestCase
                 [ChangeSet::ATTR_HASH => '98c1', ChangeSet::ATTR_PATH => 'foo/new2', ChangeSet::ATTR_TYPE => ChangeSet::TYPE_FILE],
             ],
             [
-                'foo' => [ChangeSet::ATTR_HASH => 'e127'],
-                'foo/old_path' => [ChangeSet::ATTR_PATH => 'foo/updated_path'],
+                'foo' => [ChangeSet::ATTR_HASH => 'e127', ChangeSet::ATTR_TYPE => ChangeSet::TYPE_DIRECTORY],
+                'foo/old_path' => [ChangeSet::ATTR_PATH => 'foo/updated_path', ChangeSet::ATTR_TYPE => ChangeSet::TYPE_FILE],
             ],
             [
                 'foo/baz' => ChangeSet::TYPE_DIRECTORY,
@@ -168,9 +168,9 @@ class ChangeSetTest extends TestCase
                     [ChangeSet::ATTR_HASH => 'bf6e', ChangeSet::ATTR_PATH => 'new3', ChangeSet::ATTR_TYPE => ChangeSet::TYPE_FILE],
                 ],
                 [
-                    '' => [ChangeSet::ATTR_HASH => '6628'],
-                    'old_path' => [ChangeSet::ATTR_HASH => '8bba'],
-                    'boring_file' => [ChangeSet::ATTR_PATH => 'interesting_file'],
+                    '' => [ChangeSet::ATTR_HASH => '6628', 'type' => ChangeSet::TYPE_FILE],
+                    'old_path' => [ChangeSet::ATTR_HASH => '8bba', ChangeSet::ATTR_TYPE => ChangeSet::TYPE_FILE],
+                    'boring_file' => [ChangeSet::ATTR_PATH => 'interesting_file', ChangeSet::ATTR_TYPE => ChangeSet::TYPE_FILE],
                 ],
                 [
                     'baz' => ChangeSet::TYPE_DIRECTORY,
@@ -281,7 +281,7 @@ class ChangeSetTest extends TestCase
         $changeSet = new ChangeSet(
             [],
             [
-                1 => [ChangeSet::ATTR_HASH => '6628'],
+                1 => [ChangeSet::ATTR_HASH => '6628', ChangeSet::ATTR_TYPE => ChangeSet::TYPE_FILE],
             ],
             [
                 2 => ChangeSet::TYPE_DIRECTORY,
@@ -295,7 +295,7 @@ class ChangeSetTest extends TestCase
             new ChangeSet(
                 [],
                 [
-                    4 => [ChangeSet::ATTR_PATH => 'file'],
+                    4 => [ChangeSet::ATTR_PATH => 'file', ChangeSet::ATTR_TYPE => ChangeSet::TYPE_FILE],
                 ],
                 [
                     5 => ChangeSet::TYPE_FILE,

--- a/core-bundle/tests/Filesystem/Dbafs/ChangeSet/ItemToUpdateTest.php
+++ b/core-bundle/tests/Filesystem/Dbafs/ChangeSet/ItemToUpdateTest.php
@@ -20,7 +20,7 @@ class ItemToUpdateTest extends TestCase
     public function testCreateAndReadFromItem(): void
     {
         // Everything changes
-        $item1 = new ItemToUpdate('a', 'e3ff', 'b', null);
+        $item1 = new ItemToUpdate('a', 'e3ff', 'b', true, null);
 
         $this->assertSame('a', $item1->getExistingPath());
         $this->assertTrue($item1->updatesPath());
@@ -31,7 +31,7 @@ class ItemToUpdateTest extends TestCase
         $this->assertNull($item1->getLastModified());
 
         // Only path changes
-        $item2 = new ItemToUpdate('a', null, 'b', false);
+        $item2 = new ItemToUpdate('a', null, 'b', true, false);
 
         $this->assertTrue($item2->updatesPath());
         $this->assertFalse($item2->updatesHash());
@@ -39,7 +39,7 @@ class ItemToUpdateTest extends TestCase
         $this->assertSame('b', $item2->getNewPath());
 
         // Only hash changes
-        $item3 = new ItemToUpdate('a', 'fa25', null, false);
+        $item3 = new ItemToUpdate('a', 'fa25', null, true, false);
 
         $this->assertFalse($item3->updatesPath());
         $this->assertTrue($item3->updatesHash());
@@ -47,7 +47,7 @@ class ItemToUpdateTest extends TestCase
         $this->assertSame('fa25', $item3->getNewHash());
 
         // Only last modified changes
-        $item3 = new ItemToUpdate('a', null, null, 6789);
+        $item3 = new ItemToUpdate('a', null, null, null, 6789);
 
         $this->assertFalse($item3->updatesPath());
         $this->assertFalse($item3->updatesHash());
@@ -57,7 +57,7 @@ class ItemToUpdateTest extends TestCase
 
     public function testThrowsWhenAccessingPathThatWasNotSet(): void
     {
-        $item = new ItemToUpdate('a', '12de', null, null);
+        $item = new ItemToUpdate('a', '12de', null, true, null);
 
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('The update to item "a" does not include a new path.');
@@ -67,7 +67,7 @@ class ItemToUpdateTest extends TestCase
 
     public function testThrowsWhenAccessingHashThatWasNotSet(): void
     {
-        $item = new ItemToUpdate('a', null, 'b', null);
+        $item = new ItemToUpdate('a', null, 'b', true, null);
 
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('The update to item "a" does not include a new hash.');
@@ -77,7 +77,7 @@ class ItemToUpdateTest extends TestCase
 
     public function testThrowsWhenAccessingLastModifiedThatWasNotSet(): void
     {
-        $item = new ItemToUpdate('a', '12de', null, false);
+        $item = new ItemToUpdate('a', '12de', null, true, false);
 
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('The update to item "a" does not include a last modified date.');

--- a/core-bundle/tests/Filesystem/Dbafs/DbafsTest.php
+++ b/core-bundle/tests/Filesystem/Dbafs/DbafsTest.php
@@ -602,7 +602,7 @@ class DbafsTest extends TestCase
                 ['hash' => '22af645d1859cb5ca6da0c484f1f37ea', 'path' => 'bar/new-file', 'type' => ChangeSet::TYPE_FILE],
             ],
             [
-                'bar' => ['hash' => 'c9baa6dc5b9218fb7bb83349ace1517b'],
+                'bar' => ['hash' => 'c9baa6dc5b9218fb7bb83349ace1517b', 'type' => ChangeSet::TYPE_DIRECTORY],
             ],
             []
         );
@@ -619,8 +619,8 @@ class DbafsTest extends TestCase
         $changeSet3 = new ChangeSet(
             [],
             [
-                'foo' => ['hash' => '9579cd3e9ff37b98c0bc5c702e4e5beb'],
-                'foo/baz' => ['hash' => 'd41d8cd98f00b204e9800998ecf8427e'],
+                'foo' => ['hash' => '9579cd3e9ff37b98c0bc5c702e4e5beb', 'type' => ChangeSet::TYPE_DIRECTORY],
+                'foo/baz' => ['hash' => 'd41d8cd98f00b204e9800998ecf8427e', 'type' => ChangeSet::TYPE_FILE],
             ],
             [
                 'file1' => ChangeSet::TYPE_FILE,
@@ -637,8 +637,8 @@ class DbafsTest extends TestCase
             new ChangeSet(
                 [],
                 [
-                    'foo' => ['hash' => '9579cd3e9ff37b98c0bc5c702e4e5beb'],
-                    'foo/baz' => ['hash' => 'd41d8cd98f00b204e9800998ecf8427e'],
+                    'foo' => ['hash' => '9579cd3e9ff37b98c0bc5c702e4e5beb', 'type' => ChangeSet::TYPE_DIRECTORY],
+                    'foo/baz' => ['hash' => 'd41d8cd98f00b204e9800998ecf8427e', 'type' => ChangeSet::TYPE_FILE],
                 ],
                 [
                     'foo/baz/file4' => ChangeSet::TYPE_FILE,
@@ -664,9 +664,9 @@ class DbafsTest extends TestCase
         $changeSet4 = new ChangeSet(
             [],
             [
-                'bar' => ['hash' => '8a33fd03a58a6e8e82c8bb5c38bde45f'],
-                'foo' => ['hash' => '0a12dc23f78b213ee41428f3c1090724'],
-                'foo/file3' => ['path' => 'bar/file3'],
+                'bar' => ['hash' => '8a33fd03a58a6e8e82c8bb5c38bde45f', 'type' => ChangeSet::TYPE_DIRECTORY],
+                'foo' => ['hash' => '0a12dc23f78b213ee41428f3c1090724', 'type' => ChangeSet::TYPE_DIRECTORY],
+                'foo/file3' => ['path' => 'bar/file3', 'type' => ChangeSet::TYPE_FILE],
             ],
             []
         );
@@ -680,7 +680,7 @@ class DbafsTest extends TestCase
             new ChangeSet(
                 [],
                 [
-                    'foo' => ['hash' => '0a12dc23f78b213ee41428f3c1090724'],
+                    'foo' => ['hash' => '0a12dc23f78b213ee41428f3c1090724', 'type' => ChangeSet::TYPE_DIRECTORY],
                 ],
                 [
                     'foo/file3' => ChangeSet::TYPE_FILE,
@@ -694,9 +694,9 @@ class DbafsTest extends TestCase
         $changeSet5 = new ChangeSet(
             [],
             [
-                'foo' => ['hash' => '7d4ff96366c1f971c052a092fca4a72e'],
-                'foo/baz' => ['hash' => '241e718d4016fe98aca816485e513129'],
-                'foo/file3' => ['path' => 'foo/baz/track-me'],
+                'foo' => ['hash' => '7d4ff96366c1f971c052a092fca4a72e', 'type' => ChangeSet::TYPE_DIRECTORY],
+                'foo/baz' => ['hash' => '241e718d4016fe98aca816485e513129', 'type' => ChangeSet::TYPE_FILE],
+                'foo/file3' => ['path' => 'foo/baz/track-me', 'type' => ChangeSet::TYPE_FILE],
             ],
             []
         );
@@ -714,9 +714,9 @@ class DbafsTest extends TestCase
             new ChangeSet(
                 [],
                 [
-                    'foo' => ['hash' => '9158456b71197cf99a5b59fba00f77f1'],
-                    'foo/file3' => ['hash' => 'e92c4f27d783ac09065352d0e0f7cb8b'],
-                    'file1' => ['hash' => 'e92c4f27d783ac09065352d0e0f7cb8b'],
+                    'foo' => ['hash' => '9158456b71197cf99a5b59fba00f77f1', 'type' => ChangeSet::TYPE_DIRECTORY],
+                    'foo/file3' => ['hash' => 'e92c4f27d783ac09065352d0e0f7cb8b', 'type' => ChangeSet::TYPE_FILE],
+                    'file1' => ['hash' => 'e92c4f27d783ac09065352d0e0f7cb8b', 'type' => ChangeSet::TYPE_FILE],
                 ],
                 []
             ),
@@ -728,8 +728,8 @@ class DbafsTest extends TestCase
             new ChangeSet(
                 [],
                 [
-                    'foo' => ['hash' => '9158456b71197cf99a5b59fba00f77f1'],
-                    'foo/file3' => ['hash' => 'e92c4f27d783ac09065352d0e0f7cb8b'],
+                    'foo' => ['hash' => '9158456b71197cf99a5b59fba00f77f1', 'type' => ChangeSet::TYPE_DIRECTORY],
+                    'foo/file3' => ['hash' => 'e92c4f27d783ac09065352d0e0f7cb8b', 'type' => ChangeSet::TYPE_FILE],
                 ],
                 []
             ),
@@ -766,11 +766,11 @@ class DbafsTest extends TestCase
             new ChangeSet(
                 [],
                 [
-                    'bar' => ['hash' => '1bc91408dac4048892e3603f6e7f80b4'],
-                    'foo' => ['path' => 'bar/foo'],
-                    'foo/baz' => ['path' => 'bar/foo/baz'],
-                    'foo/baz/file4' => ['path' => 'bar/foo/baz/file4'],
-                    'foo/file3' => ['path' => 'bar/foo/file3'],
+                    'bar' => ['hash' => '1bc91408dac4048892e3603f6e7f80b4', 'type' => ChangeSet::TYPE_DIRECTORY],
+                    'foo' => ['path' => 'bar/foo', 'type' => ChangeSet::TYPE_DIRECTORY],
+                    'foo/baz' => ['path' => 'bar/foo/baz', 'type' => ChangeSet::TYPE_DIRECTORY],
+                    'foo/baz/file4' => ['path' => 'bar/foo/baz/file4', 'type' => ChangeSet::TYPE_FILE],
+                    'foo/file3' => ['path' => 'bar/foo/file3', 'type' => ChangeSet::TYPE_FILE],
                 ],
                 []
             ),
@@ -786,9 +786,9 @@ class DbafsTest extends TestCase
             new ChangeSet(
                 [],
                 [
-                    'bar' => ['hash' => 'd41d8cd98f00b204e9800998ecf8427e'],
-                    'bar/file5a' => ['path' => 'file5a'],
-                    'bar/file5b' => ['path' => 'file5b'],
+                    'bar' => ['hash' => 'd41d8cd98f00b204e9800998ecf8427e', 'type' => ChangeSet::TYPE_DIRECTORY],
+                    'bar/file5a' => ['path' => 'file5a', 'type' => ChangeSet::TYPE_FILE],
+                    'bar/file5b' => ['path' => 'file5b', 'type' => ChangeSet::TYPE_FILE],
                 ],
                 []
             ),
@@ -806,7 +806,7 @@ class DbafsTest extends TestCase
                     ['hash' => 'd41d8cd98f00b204e9800998ecf8427e', 'path' => 'foo/file3', 'type' => ChangeSet::TYPE_DIRECTORY],
                 ],
                 [
-                    'foo' => ['hash' => '5d93d7dddf717617c820c623e9b3168c'],
+                    'foo' => ['hash' => '5d93d7dddf717617c820c623e9b3168c', 'type' => ChangeSet::TYPE_DIRECTORY],
                 ],
                 [
                     'foo/file3' => ChangeSet::TYPE_FILE,
@@ -835,11 +835,11 @@ class DbafsTest extends TestCase
                     ['hash' => '900150983cd24fb0d6963f7d28e17f72', 'path' => 'new/thing', 'type' => ChangeSet::TYPE_FILE],
                 ],
                 [
-                    'bar' => ['hash' => '10a3f34a1736690a9dad608c53740aa5'],
-                    'file1' => ['path' => 'new/file1'],
-                    'file2' => ['path' => 'new/new-name'],
-                    'foo' => ['hash' => '9158456b71197cf99a5b59fba00f77f1'],
-                    'foo/file3' => ['hash' => 'e92c4f27d783ac09065352d0e0f7cb8b'],
+                    'bar' => ['hash' => '10a3f34a1736690a9dad608c53740aa5', 'type' => ChangeSet::TYPE_DIRECTORY],
+                    'file1' => ['path' => 'new/file1', 'type' => ChangeSet::TYPE_FILE],
+                    'file2' => ['path' => 'new/new-name', 'type' => ChangeSet::TYPE_FILE],
+                    'foo' => ['hash' => '9158456b71197cf99a5b59fba00f77f1', 'type' => ChangeSet::TYPE_DIRECTORY],
+                    'foo/file3' => ['hash' => 'e92c4f27d783ac09065352d0e0f7cb8b', 'type' => ChangeSet::TYPE_FILE],
                 ],
                 [
                     'bar/file5a' => ChangeSet::TYPE_FILE,
@@ -853,8 +853,8 @@ class DbafsTest extends TestCase
             new ChangeSet(
                 [],
                 [
-                    'foo' => ['hash' => '9158456b71197cf99a5b59fba00f77f1'],
-                    'foo/file3' => ['hash' => 'e92c4f27d783ac09065352d0e0f7cb8b'],
+                    'foo' => ['hash' => '9158456b71197cf99a5b59fba00f77f1', 'type' => ChangeSet::TYPE_DIRECTORY],
+                    'foo/file3' => ['hash' => 'e92c4f27d783ac09065352d0e0f7cb8b', 'type' => ChangeSet::TYPE_FILE],
                 ],
                 []
             ),

--- a/core-bundle/tests/Filesystem/Dbafs/DbafsTest.php
+++ b/core-bundle/tests/Filesystem/Dbafs/DbafsTest.php
@@ -1188,7 +1188,7 @@ class DbafsTest extends TestCase
             ],
             [
                 ['path' => 'a/file'],
-                ['path' => 'b/file', 'pid' => 'ab54'], // updated path and uuid of "files/b"
+                ['path' => 'b/file', 'pid' => 'ab54', 'name' => 'file'], // updated path and uuid of "files/b"
             ],
             [
                 ['path' => 'b'],

--- a/core-bundle/tests/Filesystem/Dbafs/DbafsTest.php
+++ b/core-bundle/tests/Filesystem/Dbafs/DbafsTest.php
@@ -1188,7 +1188,7 @@ class DbafsTest extends TestCase
             ],
             [
                 ['path' => 'a/file'],
-                ['path' => 'b/file', 'pid' => 'ab54', 'name' => 'file'], // updated path and uuid of "files/b"
+                ['path' => 'b/file', 'pid' => 'ab54', 'name' => 'file', 'extension' => ''],
             ],
             [
                 ['path' => 'b'],


### PR DESCRIPTION
Fixes #6862

This is an alternative to #6872 which additionally adds an `isFile()` method to the `ItemToUpdate` class. Not sure if that is correct though.