### PR TITLE
Correctly cache Contao translations that only exist as Symfony translations

### DIFF
--- a/core-bundle/src/Cache/ContaoCacheWarmer.php
+++ b/core-bundle/src/Cache/ContaoCacheWarmer.php
@@ -170,7 +170,8 @@ class ContaoCacheWarmer implements CacheWarmerInterface
             }
         }
 
-        // Add Contao translations that only exist as Symfony translations for the available language file cache (see #6741)
+        // Add Contao translations that only exist as Symfony translations for the
+        // available language file cache (see #6741)
         foreach ($this->translator->getCatalogues() as $catalogue) {
             $domains = array_filter($catalogue->getDomains(), static fn (string $domain): bool => str_starts_with($domain, 'contao_'));
 

--- a/core-bundle/src/Cache/ContaoCacheWarmer.php
+++ b/core-bundle/src/Cache/ContaoCacheWarmer.php
@@ -170,6 +170,15 @@ class ContaoCacheWarmer implements CacheWarmerInterface
             }
         }
 
+        // Add Contao translations that only exist as Symfony translations for the available language file cache (see #6741)
+        foreach ($this->translator->getCatalogues() as $catalogue) {
+            $domains = array_filter($catalogue->getDomains(), static fn (string $domain): bool => str_starts_with($domain, 'contao_'));
+
+            foreach ($domains as $domain) {
+                $processed[$catalogue->getLocale()][substr($domain, 7)] = true;
+            }
+        }
+
         // Cache the available Contao language files (see #6454)
         $this->filesystem->dumpFile(
             Path::join($cacheDir, 'contao/config/available-language-files.php'),

--- a/core-bundle/src/Cache/ContaoCacheWarmer.php
+++ b/core-bundle/src/Cache/ContaoCacheWarmer.php
@@ -152,6 +152,10 @@ class ContaoCacheWarmer implements CacheWarmerInterface
 
             if ($catalogue instanceof MessageCatalogue) {
                 foreach (array_unique($catalogue->getDomains()) as $domain) {
+                    if (!str_starts_with($domain, 'contao_')) {
+                        continue;
+                    }
+
                     $php = $catalogue->getGlobalsString($domain);
 
                     if (!$php) {
@@ -166,17 +170,11 @@ class ContaoCacheWarmer implements CacheWarmerInterface
                     } else {
                         $this->filesystem->dumpFile($path, "<?php\n\n".$php);
                     }
+
+                    // Add Contao translations that only exist as Symfony translations for the
+                    // available language file cache (see #6741)
+                    $processed[$language][$name] = true;
                 }
-            }
-        }
-
-        // Add Contao translations that only exist as Symfony translations for the
-        // available language file cache (see #6741)
-        foreach ($this->translator->getCatalogues() as $catalogue) {
-            $domains = array_filter($catalogue->getDomains(), static fn (string $domain): bool => str_starts_with($domain, 'contao_'));
-
-            foreach ($domains as $domain) {
-                $processed[$catalogue->getLocale()][substr($domain, 7)] = true;
             }
         }
 

--- a/core-bundle/tests/Cache/ContaoCacheWarmerTest.php
+++ b/core-bundle/tests/Cache/ContaoCacheWarmerTest.php
@@ -80,13 +80,18 @@ class ContaoCacheWarmerTest extends TestCase
             ->willReturn('en')
         ;
 
+        $parentCatalogue
+            ->method('all')
+            ->with('contao_tl_foobar')
+            ->willReturn(['tl_foobar.new.0' => 'Create new foobar'])
+        ;
+
         $catalogue = new MessageCatalogue($parentCatalogue, $this->mockContaoFramework(), $this->createMock(ResourceFinder::class));
 
         $translator = $this->createMock(Translator::class);
         $translator
-            ->expects($this->once())
-            ->method('getCatalogues')
-            ->willReturn([$catalogue])
+            ->method('getCatalogue')
+            ->willReturn($catalogue)
         ;
 
         $warmer = $this->getCacheWarmer(translator: $translator);

--- a/core-bundle/tests/Cache/ContaoCacheWarmerTest.php
+++ b/core-bundle/tests/Cache/ContaoCacheWarmerTest.php
@@ -69,7 +69,27 @@ class ContaoCacheWarmerTest extends TestCase
 
     public function testCreatesTheCacheFolder(): void
     {
-        $warmer = $this->getCacheWarmer();
+        $parentCatalogue = $this->createMock(MessageCatalogueInterface::class);
+        $parentCatalogue
+            ->method('getDomains')
+            ->willReturn(['contao_tl_foobar'])
+        ;
+
+        $parentCatalogue
+            ->method('getLocale')
+            ->willReturn('en')
+        ;
+
+        $catalogue = new MessageCatalogue($parentCatalogue, $this->mockContaoFramework(), $this->createMock(ResourceFinder::class));
+
+        $translator = $this->createMock(Translator::class);
+        $translator
+            ->expects($this->once())
+            ->method('getCatalogues')
+            ->willReturn([$catalogue])
+        ;
+
+        $warmer = $this->getCacheWarmer(translator: $translator);
         $warmer->warmUp(Path::join($this->getTempDir(), 'var/cache'));
 
         $this->assertFileExists(Path::join($this->getTempDir(), 'var/cache/contao'));
@@ -116,6 +136,7 @@ class ContaoCacheWarmerTest extends TestCase
         $this->assertArrayHasKey('en', $langs);
         $this->assertArrayHasKey('default', $langs['en']);
         $this->assertArrayHasKey('tl_test', $langs['en']);
+        $this->assertArrayHasKey('tl_foobar', $langs['en']);
     }
 
     public function testIsAnOptionalWarmer(): void


### PR DESCRIPTION
Fixes #6741