### PR TITLE
Always allow the "read" action in the front end modules voter

### DIFF
--- a/core-bundle/src/Security/Voter/DataContainer/FrontendModulesVoter.php
+++ b/core-bundle/src/Security/Voter/DataContainer/FrontendModulesVoter.php
@@ -30,6 +30,10 @@ class FrontendModulesVoter extends AbstractDataContainerVoter
             return true;
         }
 
+        if ($action instanceof ReadAction) {
+            return true;
+        }
+
         return $this->isAllowedModuleType($action, $user);
     }
 

--- a/core-bundle/src/Security/Voter/DataContainer/FrontendModulesVoter.php
+++ b/core-bundle/src/Security/Voter/DataContainer/FrontendModulesVoter.php
@@ -20,6 +20,10 @@ class FrontendModulesVoter extends AbstractDataContainerVoter
 
     protected function hasAccess(TokenInterface $token, CreateAction|DeleteAction|ReadAction|UpdateAction $action): bool
     {
+        if ($action instanceof ReadAction) {
+            return true;
+        }
+
         $user = $token->getUser();
 
         if (!$user instanceof BackendUser) {
@@ -27,10 +31,6 @@ class FrontendModulesVoter extends AbstractDataContainerVoter
         }
 
         if ($user->isAdmin || empty($user->frontendModules)) {
-            return true;
-        }
-
-        if ($action instanceof ReadAction) {
             return true;
         }
 

--- a/core-bundle/tests/Security/Voter/DataContainer/FrontendModulesVoterTest.php
+++ b/core-bundle/tests/Security/Voter/DataContainer/FrontendModulesVoterTest.php
@@ -71,12 +71,12 @@ class FrontendModulesVoterTest extends TestCase
 
         $voter = new FrontendModulesVoter();
 
-        // Reading is always permitted
+        // Reading is always permitted, although type `listing` is not explicitly allowed
         $this->assertSame(
             VoterInterface::ACCESS_ABSTAIN,
             $voter->vote(
                 $token,
-                new ReadAction('foo', ['id' => 42, 'type' => 'navigation']),
+                new ReadAction('foo', ['id' => 42, 'type' => 'listing']),
                 [ContaoCorePermissions::DC_PREFIX.'tl_module'],
             ),
         );


### PR DESCRIPTION
Fixes #6887

Following a comment in the test case I was aware that I always have to allow `ReadAction` for any type, but the implementation was not quite there yet …

