### PR TITLE
Add missing `searchable = false` definitions for content elements

### DIFF
--- a/core-bundle/src/Controller/ContentElement/ImagesController.php
+++ b/core-bundle/src/Controller/ContentElement/ImagesController.php
@@ -52,6 +52,7 @@ class ImagesController extends AbstractContentElementController
 
         $template->set('sort_mode', $sortMode);
         $template->set('randomize_order', $randomize = 'random' === $model->sortBy);
+        $template->set('searchable', 'image' === $model->type || !$randomize);
 
         // Limit elements; use client-side logic for only displaying the first $limit
         // elements in case we are dealing with a random order

--- a/core-bundle/src/Controller/ContentElement/PlayerController.php
+++ b/core-bundle/src/Controller/ContentElement/PlayerController.php
@@ -66,6 +66,7 @@ class PlayerController extends AbstractContentElementController
 
         $template->set('figure', (object) $figureData);
         $template->set('source_files', $sourceFiles);
+        $template->set('searchable', false);
 
         return $template->getResponse();
     }

--- a/core-bundle/src/Controller/ContentElement/VideoController.php
+++ b/core-bundle/src/Controller/ContentElement/VideoController.php
@@ -67,6 +67,7 @@ class VideoController extends AbstractContentElementController
         ;
 
         $template->set('splash_image', $figure);
+        $template->set('searchable', false);
 
         return $template->getResponse();
     }

--- a/core-bundle/tests/Controller/ContentElement/ImagesControllerTest.php
+++ b/core-bundle/tests/Controller/ContentElement/ImagesControllerTest.php
@@ -89,6 +89,34 @@ class ImagesControllerTest extends ContentElementTestCase
         $this->assertSameHtml($expectedOutput, $response->getContent());
     }
 
+    public function testOutputsUnsearchableRandomGallery(): void
+    {
+        $security = $this->createMock(Security::class);
+
+        $response = $this->renderWithModelData(
+            new ImagesController($security, $this->getDefaultStorage(), $this->getDefaultStudio(), ['jpg']),
+            [
+                'type' => 'gallery',
+                'multiSRC' => serialize([
+                    StringUtil::uuidToBin(ContentElementTestCase::FILE_IMAGE1),
+                    StringUtil::uuidToBin(ContentElementTestCase::FILE_IMAGE2),
+                    StringUtil::uuidToBin(ContentElementTestCase::FILE_IMAGE3),
+                ]),
+                'sortBy' => 'random',
+                'numberOfItems' => 2,
+                'size' => '',
+                'fullsize' => true,
+                'perPage' => 4,
+                'perRow' => 2,
+            ],
+        );
+
+        $output = $response->getContent();as
+
+        $this->assertStringContainsString('<!-- indexer::stop -->', $output);
+        $this->assertStringContainsString('<!-- indexer::continue -->', $output);
+    }
+
     public function testIgnoresInvalidTypes(): void
     {
         $security = $this->createMock(Security::class);

--- a/core-bundle/tests/Controller/ContentElement/ImagesControllerTest.php
+++ b/core-bundle/tests/Controller/ContentElement/ImagesControllerTest.php
@@ -99,11 +99,9 @@ class ImagesControllerTest extends ContentElementTestCase
                 'type' => 'gallery',
                 'multiSRC' => serialize([
                     StringUtil::uuidToBin(ContentElementTestCase::FILE_IMAGE1),
-                    StringUtil::uuidToBin(ContentElementTestCase::FILE_IMAGE2),
-                    StringUtil::uuidToBin(ContentElementTestCase::FILE_IMAGE3),
                 ]),
                 'sortBy' => 'random',
-                'numberOfItems' => 2,
+                'numberOfItems' => 1,
                 'size' => '',
                 'fullsize' => true,
                 'perPage' => 4,
@@ -111,10 +109,21 @@ class ImagesControllerTest extends ContentElementTestCase
             ],
         );
 
-        $output = $response->getContent();
+        $expectedOutput = <<<'HTML'
+            <!-- indexer::stop -->
+            <div class="content-gallery--cols-2 content-gallery">
+                <ul data-list-random data-list-paginate="4,1">
+                    <li>
+                        <figure>
+                            <img src="files/image1.jpg" alt>
+                        </figure>
+                    </li>
+                </ul>
+            </div>
+            <!-- indexer::continue -->
+            HTML;
 
-        $this->assertStringContainsString('<!-- indexer::stop -->', $output);
-        $this->assertStringContainsString('<!-- indexer::continue -->', $output);
+        $this->assertSameHtml($expectedOutput, $response->getContent());
     }
 
     public function testIgnoresInvalidTypes(): void

--- a/core-bundle/tests/Controller/ContentElement/ImagesControllerTest.php
+++ b/core-bundle/tests/Controller/ContentElement/ImagesControllerTest.php
@@ -111,7 +111,7 @@ class ImagesControllerTest extends ContentElementTestCase
             ],
         );
 
-        $output = $response->getContent();as
+        $output = $response->getContent();
 
         $this->assertStringContainsString('<!-- indexer::stop -->', $output);
         $this->assertStringContainsString('<!-- indexer::continue -->', $output);

--- a/core-bundle/tests/Controller/ContentElement/PlayerControllerTest.php
+++ b/core-bundle/tests/Controller/ContentElement/PlayerControllerTest.php
@@ -34,6 +34,7 @@ class PlayerControllerTest extends ContentElementTestCase
         );
 
         $expectedOutput = <<<'HTML'
+            <!-- indexer::stop -->
             <div class="content-player">
                 <figure>
                     <video controls autoplay loop>
@@ -43,6 +44,7 @@ class PlayerControllerTest extends ContentElementTestCase
                     <figcaption>Caption</figcaption>
                 </figure>
             </div>
+            <!-- indexer::continue -->
             HTML;
 
         $this->assertSameHtml($expectedOutput, $response->getContent());
@@ -75,6 +77,7 @@ class PlayerControllerTest extends ContentElementTestCase
         );
 
         $expectedOutput = <<<'HTML'
+            <!-- indexer::stop -->
             <div class="content-player">
                 <ul>
                     <li>
@@ -85,6 +88,7 @@ class PlayerControllerTest extends ContentElementTestCase
                     </li>
                 </ul>
             </div>
+            <!-- indexer::continue -->
             HTML;
 
         $this->assertSameHtml($expectedOutput, $response->getContent());

--- a/core-bundle/tests/Controller/ContentElement/VideoControllerTest.php
+++ b/core-bundle/tests/Controller/ContentElement/VideoControllerTest.php
@@ -43,6 +43,7 @@ class VideoControllerTest extends ContentElementTestCase
         );
 
         $expectedOutput = <<<'HTML'
+            <!-- indexer::stop -->
             <div class="content-youtube">
                 <figure class="aspect aspect--4:3">
                     <iframe
@@ -54,6 +55,7 @@ class VideoControllerTest extends ContentElementTestCase
                     <figcaption>Some caption</figcaption>
                 </figure>
             </div>
+            <!-- indexer::continue -->
             HTML;
 
         $this->assertSameHtml($expectedOutput, $response->getContent());
@@ -85,6 +87,7 @@ class VideoControllerTest extends ContentElementTestCase
         );
 
         $expectedOutput = <<<'HTML'
+            <!-- indexer::stop -->
             <div class="content-vimeo">
                 <figure>
                 <button data-splash-screen>
@@ -100,6 +103,7 @@ class VideoControllerTest extends ContentElementTestCase
                 </button>
                 </figure>
             </div>
+            <!-- indexer::continue -->
             HTML;
 
         $this->assertSameHtml($expectedOutput, $response->getContent());


### PR DESCRIPTION
The following content elements previously extended from `block_unsearchable`:

* `player`
* `youtube`
* `vimeo`
* `gallery` with random sorting
* `toplink`

From our new content element controllers only the `ToplinkController` defined `$template->set('searchable', false);` which is then taken into account in our `_base` template.

This PR adds the missing `searchable` definitions in the other controllers.

/cc @netzarbeiter 