### PR TITLE
Merge the `Cache-Control` header in `PageRegular`

### DIFF
--- a/core-bundle/src/Resources/contao/pages/PageRegular.php
+++ b/core-bundle/src/Resources/contao/pages/PageRegular.php
@@ -62,7 +62,7 @@ class PageRegular extends Frontend
 
 		$response = $this->Template->getResponse($blnCheckRequest);
 
-        // Allow subrequests on this controller (fragments) to dynamically influence the Cache-Control header
+		// Allow subrequests on this controller (fragments) to dynamically influence the Cache-Control header
 		$response->headers->set(SubrequestCacheSubscriber::MERGE_CACHE_HEADER, true);
 
 		// Finalize the response context so it cannot be used anymore

--- a/core-bundle/src/Resources/contao/pages/PageRegular.php
+++ b/core-bundle/src/Resources/contao/pages/PageRegular.php
@@ -10,6 +10,7 @@
 
 namespace Contao;
 
+use Contao\CoreBundle\EventListener\SubrequestCacheSubscriber;
 use Contao\CoreBundle\Exception\NoLayoutSpecifiedException;
 use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\CoreBundle\Routing\ResponseContext\HtmlHeadBag\HtmlHeadBag;
@@ -60,6 +61,8 @@ class PageRegular extends Frontend
 		$this->prepare($objPage);
 
 		$response = $this->Template->getResponse($blnCheckRequest);
+
+		$response->headers->set(SubrequestCacheSubscriber::MERGE_CACHE_HEADER, true);
 
 		// Finalize the response context so it cannot be used anymore
 		System::getContainer()->get('contao.routing.response_context_accessor')->finalizeCurrentContext($response);

--- a/core-bundle/src/Resources/contao/pages/PageRegular.php
+++ b/core-bundle/src/Resources/contao/pages/PageRegular.php
@@ -62,6 +62,7 @@ class PageRegular extends Frontend
 
 		$response = $this->Template->getResponse($blnCheckRequest);
 
+        // Allow subrequests on this controller (fragments) to dynamically influence the Cache-Control header
 		$response->headers->set(SubrequestCacheSubscriber::MERGE_CACHE_HEADER, true);
 
 		// Finalize the response context so it cannot be used anymore


### PR DESCRIPTION
I want to return caching information in my frontent module controller and merge it with the page's cache time, as described here: https://docs.contao.org/dev/framework/caching/#inline-fragments. For this to work, the main response from `PageRegular` must also have the `Contao-Merge-Cache-Control` header set: https://github.com/contao/contao/blob/b706b7dbfb4a88a07c2e2adae98d553504fd7e34/core-bundle/src/EventListener/SubrequestCacheSubscriber.php#L72-L74