### PR TITLE
Move adding the schema.org data to the `_download.html.twig` component

### DIFF
--- a/core-bundle/contao/templates/twig/component/_download.html.twig
+++ b/core-bundle/contao/templates/twig/component/_download.html.twig
@@ -56,4 +56,11 @@
             {% endfor %}
         {% endblock %}
     {% endif %}
+
+    {# Add metadata #}
+    {% block schema_org %}
+        {% if download.file.schemaOrgData|default(false) %}
+            {% do add_schema_org(download.file.schemaOrgData) %}
+        {% endif %}
+    {% endblock %}
 {% endblock %}

--- a/core-bundle/contao/templates/twig/content_element/downloads.html.twig
+++ b/core-bundle/contao/templates/twig/content_element/downloads.html.twig
@@ -13,10 +13,3 @@
 {% block list_item %}
     {% with {download: item} %}{{ block('download_component') }}{% endwith %}
 {% endblock %}
-
-{# Add metadata #}
-{% block metadata %}
-    {% for download in downloads %}
-        {% do add_schema_org(download.file.schemaOrgData|default) %}
-    {% endfor %}
-{% endblock %}


### PR DESCRIPTION
Fixes #6888
