### PR TITLE
Added a phpstan rule to detect trigger_deprecation() calls

### DIFF
--- a/tools/phpstan/composer.json
+++ b/tools/phpstan/composer.json
@@ -1,9 +1,16 @@
 {
+    "autoload": {
+        "psr-4": {
+            "Contao\\PhpStan\\": "src/"
+        }
+    },
     "require": {
+        "php": "^8.1",
         "phpstan/phpstan": "^1.0",
         "phpstan/phpstan-phpunit": "^1.0",
         "phpstan/phpstan-symfony": "^1.0",
         "slam/phpstan-extensions": "^6.0",
-        "thecodingmachine/phpstan-strict-rules": "^1.0"
+        "thecodingmachine/phpstan-strict-rules": "^1.0",
+        "composer/semver": "^3.4"
     }
 }

--- a/tools/phpstan/composer.lock
+++ b/tools/phpstan/composer.lock
@@ -4,8 +4,89 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d486d173d03a55118a8c0da4d83b639f",
+    "content-hash": "9b459a3028897c43ed57b4fddb11bcfc",
     "packages": [
+        {
+            "name": "composer/semver",
+            "version": "3.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/semver.git",
+                "reference": "35e8d0af4486141bc745f23a29cc2091eb624a32"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/semver/zipball/35e8d0af4486141bc745f23a29cc2091eb624a32",
+                "reference": "35e8d0af4486141bc745f23a29cc2091eb624a32",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.4",
+                "symfony/phpunit-bridge": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Semver\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nils Adermann",
+                    "email": "naderman@naderman.de",
+                    "homepage": "http://www.naderman.de"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                },
+                {
+                    "name": "Rob Bast",
+                    "email": "rob.bast@gmail.com",
+                    "homepage": "http://robbast.nl"
+                }
+            ],
+            "description": "Semver library that offers utilities, version constraint parsing and validation.",
+            "keywords": [
+                "semantic",
+                "semver",
+                "validation",
+                "versioning"
+            ],
+            "support": {
+                "irc": "ircs://irc.libera.chat:6697/composer",
+                "issues": "https://github.com/composer/semver/issues",
+                "source": "https://github.com/composer/semver/tree/3.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-08-31T09:50:34+00:00"
+        },
         {
             "name": "nikic/php-parser",
             "version": "v5.0.0",
@@ -66,16 +147,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.10.57",
+            "version": "1.10.58",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "1627b1d03446904aaa77593f370c5201d2ecc34e"
+                "reference": "a23518379ec4defd9e47cbf81019526861623ec2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/1627b1d03446904aaa77593f370c5201d2ecc34e",
-                "reference": "1627b1d03446904aaa77593f370c5201d2ecc34e",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/a23518379ec4defd9e47cbf81019526861623ec2",
+                "reference": "a23518379ec4defd9e47cbf81019526861623ec2",
                 "shasum": ""
             },
             "require": {
@@ -124,7 +205,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-01-24T11:51:34+00:00"
+            "time": "2024-02-12T20:02:57+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",
@@ -379,7 +460,9 @@
     "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
+    "platform": {
+        "php": "^8.1"
+    },
     "platform-dev": [],
     "plugin-api-version": "2.6.0"
 }

--- a/tools/phpstan/config/contao.neon
+++ b/tools/phpstan/config/contao.neon
@@ -63,3 +63,8 @@ parameters:
     treatPhpDocTypesAsCertain: false
     checkMissingIterableValueType: false
     rememberPossiblyImpureFunctionValues: false
+
+services:
+    -
+        class: Contao\PhpStan\TriggerDeprecationRule
+        tags: [phpstan.rules.rule]

--- a/tools/phpstan/src/TriggerDeprecationRule.php
+++ b/tools/phpstan/src/TriggerDeprecationRule.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Contao\PhpStan;
+
+use Composer\Semver\Constraint\Constraint;
+use Composer\Semver\Semver;
+use Composer\Semver\VersionParser;
+use PhpParser\Node;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Name;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+
+class TriggerDeprecationRule implements Rule
+{
+    private string|null $branchName = null;
+
+    public function getNodeType(): string
+    {
+        return FuncCall::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $targetBranch = $_SERVER['GITHUB_BASE_REF'] ?? null;
+
+        if (null === $targetBranch) {
+            return [];
+        }
+
+        if (!($node->name instanceof Name)) {
+            return [];
+        }
+
+        $args = $node->getArgs();
+        if (\count($args) < 3) {
+            return [];
+        }
+
+        $functionName = strtolower($node->name->toString());
+        if ('trigger_deprecation' !== $functionName) {
+            return [];
+        }
+
+        $errors = [];
+        $bundle = $args[0]->value->value;
+        $version = $args[1]->value->value;
+        $message = $args[2]->value->value;
+
+        $versionParser = new VersionParser();
+
+        try {
+            $normalizedBranchVersion = $versionParser->normalize(str_replace('x', '0', $targetBranch));
+            if (!Semver::satisfies($version, new Constraint('=', $normalizedBranchVersion))) {
+                $errors[] = sprintf('Deprecation needs to be removed in bundle "%s": %s',
+                    $bundle,
+                    $message,
+                );
+            }
+        } catch (\Exception $e) {
+            $errors[] = 'Something with your trigger_deprecation() format has gone wrong: '.$e->getMessage();
+        }
+
+        return $errors;
+    }
+}


### PR DESCRIPTION
Can be easily tested: Create a branch named `6.x` and then run phpstan. It will now report all `trigger_deprecation()` calls as errors so we'll never forget to remove a deprecated layer in any future major version again 😎 