### PR TITLE
Fix the column name in the "remember me" migration

### DIFF
--- a/core-bundle/src/Migration/Version503/RememberMeMigration.php
+++ b/core-bundle/src/Migration/Version503/RememberMeMigration.php
@@ -47,7 +47,7 @@ class RememberMeMigration extends AbstractMigration
         );
 
         $schemaManager = $this->connection->createSchemaManager();
-        $username = isset($schemaManager->listTableColumns('tl_remember_me')['userIdentifier']) ? 'userIdentifier' : 'username';
+        $username = isset($schemaManager->listTableColumns('tl_remember_me')['useridentifier']) ? 'userIdentifier' : 'username';
 
         $this->connection->executeStatement(
             <<<SQL

--- a/core-bundle/src/Migration/Version503/RememberMeMigration.php
+++ b/core-bundle/src/Migration/Version503/RememberMeMigration.php
@@ -46,17 +46,20 @@ class RememberMeMigration extends AbstractMigration
                 SQL,
         );
 
+        $schemaManager = $this->connection->createSchemaManager();
+        $username = isset($schemaManager->listTableColumns('tl_remember_me')['userIdentifier']) ? 'userIdentifier' : 'username';
+
         $this->connection->executeStatement(
-            <<<'SQL'
+            <<<SQL
                 INSERT INTO rememberme_token (
                     SELECT
                         TRIM(TRAILING CHAR(0) FROM CAST(series AS char)),
                         TRIM(TRAILING CHAR(0) FROM CAST(value AS char)),
                         lastUsed,
                         class,
-                        userIdentifier
+                        $username
                     FROM tl_remember_me
-                    WHERE userIdentifier != ''
+                    WHERE $username != ''
                 )
                 SQL,
         );


### PR DESCRIPTION
The field has been renamed from `username` to `userIdentifier` in Contao 5.0 but apparently was never migrated.