### PR TITLE
Add `type="button"` to the accordion toggler

### DIFF
--- a/core-bundle/contao/templates/twig/content_element/accordion.html.twig
+++ b/core-bundle/contao/templates/twig/content_element/accordion.html.twig
@@ -6,7 +6,7 @@
         {% block element %}
             {% block element_header %}
                 <{{ element.header_tag }}{{ attrs(accordion_header_attributes|default).addClass('handorgel__header') }}>
-                    <button{{ attrs(accordion_header_button_attributes|default).addClass('handorgel__header__button') }}>
+                    <button{{ attrs(accordion_header_button_attributes|default).addClass('handorgel__header__button').set('type', 'button') }}>
                         {{- element.header -}}
                     </button>
                 </{{ element.header_tag }}>

--- a/core-bundle/tests/Controller/ContentElement/AccordionControllerTest.php
+++ b/core-bundle/tests/Controller/ContentElement/AccordionControllerTest.php
@@ -49,7 +49,7 @@ class AccordionControllerTest extends ContentElementTestCase
         $expectedOutput = <<<'HTML'
             <div class="content-accordion">
                 <h3 class="handorgel__header">
-                    <button class="handorgel__header__button">Text</button>
+                    <button class="handorgel__header__button" type="button">Text</button>
                 </h3>
                 <div class="handorgel__content" data-open>
                     <div class="handorgel__content__inner">
@@ -57,7 +57,7 @@ class AccordionControllerTest extends ContentElementTestCase
                     </div>
                 </div>
                 <h3 class="handorgel__header">
-                    <button class="handorgel__header__button">Image</button>
+                    <button class="handorgel__header__button" type="button">Image</button>
                 </h3>
                 <div class="handorgel__content">
                     <div class="handorgel__content__inner">
@@ -103,7 +103,7 @@ class AccordionControllerTest extends ContentElementTestCase
         $expectedOutput = <<<'HTML'
             <div class="content-accordion">
                 <h3 class="handorgel__header">
-                    <button class="handorgel__header__button">Text</button>
+                    <button class="handorgel__header__button" type="button">Text</button>
                 </h3>
                 <div class="handorgel__content">
                     <div class="handorgel__content__inner">
@@ -111,7 +111,7 @@ class AccordionControllerTest extends ContentElementTestCase
                     </div>
                 </div>
                 <h3 class="handorgel__header">
-                    <button class="handorgel__header__button">Image</button>
+                    <button class="handorgel__header__button" type="button">Image</button>
                 </h3>
                 <div class="handorgel__content">
                     <div class="handorgel__content__inner">


### PR DESCRIPTION
If you happen to insert an accordion content element in a form, e.g. in an HTML code form field with the `{{insert_content::*}}` insert tag, the toggler of the accordion will currently submit the form when clicked, instead of just opening/closing the accordion.

This is because any `<button>` without a specific `type` will be treated as a `type="submit"` button by default: https://html.spec.whatwg.org/multipage/form-elements.html#the-button-element

> The attribute's missing value default and invalid value default are both the _Submit Button state_.

Since our toggler button is not supposed to submit anything but rather just act "as a button", it needs `type="button"`.