### PR TITLE
Improve logging of request parameters

### DIFF
--- a/core-bundle/src/Migration/Version503/RememberMeMigration.php
+++ b/core-bundle/src/Migration/Version503/RememberMeMigration.php
@@ -47,7 +47,7 @@ class RememberMeMigration extends AbstractMigration
         );
 
         $schemaManager = $this->connection->createSchemaManager();
-        $username = isset($schemaManager->listTableColumns('tl_remember_me')['userIdentifier']) ? 'userIdentifier' : 'username';
+        $username = isset($schemaManager->listTableColumns('tl_remember_me')['useridentifier']) ? 'userIdentifier' : 'username';
 
         $this->connection->executeStatement(
             <<<SQL

--- a/core-bundle/src/Migration/Version503/RememberMeMigration.php
+++ b/core-bundle/src/Migration/Version503/RememberMeMigration.php
@@ -46,17 +46,20 @@ class RememberMeMigration extends AbstractMigration
                 SQL,
         );
 
+        $schemaManager = $this->connection->createSchemaManager();
+        $username = isset($schemaManager->listTableColumns('tl_remember_me')['userIdentifier']) ? 'userIdentifier' : 'username';
+
         $this->connection->executeStatement(
-            <<<'SQL'
+            <<<SQL
                 INSERT INTO rememberme_token (
                     SELECT
                         TRIM(TRAILING CHAR(0) FROM CAST(series AS char)),
                         TRIM(TRAILING CHAR(0) FROM CAST(value AS char)),
                         lastUsed,
                         class,
-                        userIdentifier
+                        $username
                     FROM tl_remember_me
-                    WHERE userIdentifier != ''
+                    WHERE $username != ''
                 )
                 SQL,
         );

--- a/manager-bundle/config/services.yaml
+++ b/manager-bundle/config/services.yaml
@@ -50,12 +50,8 @@ services:
     contao_manager.listener.doctrine_alter_table:
         class: Contao\ManagerBundle\EventListener\DoctrineAlterTableListener
 
-    contao_manager.monolog.web_processor:
-        class: Symfony\Bridge\Monolog\Processor\WebProcessor
-        arguments:
-            - { request_uri: REQUEST_URI, request_method: REQUEST_METHOD }
-        tags:
-            - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest }
+    contao_manager.monolog.request_processor:
+        class: Contao\ManagerBundle\Monolog\RequestProcessor
 
     contao_manager.plugin_loader:
         public: true

--- a/manager-bundle/src/Monolog/RequestProcessor.php
+++ b/manager-bundle/src/Monolog/RequestProcessor.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\ManagerBundle\Monolog;
+
+use Monolog\Processor\ProcessorInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+class RequestProcessor implements ProcessorInterface, EventSubscriberInterface
+{
+    private Request|null $request = null;
+
+    public function __invoke(array $record): array
+    {
+        if ($this->request) {
+            $record['extra']['request_uri'] = $this->request->getUri();
+            $record['extra']['request_method'] = $this->request->getMethod();
+        }
+
+        return $record;
+    }
+
+    public function onKernelRequest(RequestEvent $event): void
+    {
+        if ($event->isMainRequest()) {
+            $this->request = $event->getRequest();
+        }
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::REQUEST => ['onKernelRequest', 4096],
+        ];
+    }
+}

--- a/manager-bundle/tests/Monolog/RequestProcessorTest.php
+++ b/manager-bundle/tests/Monolog/RequestProcessorTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\ManagerBundle\Tests\Monolog;
+
+use Contao\ManagerBundle\Monolog\RequestProcessor;
+use Contao\TestCase\ContaoTestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+class RequestProcessorTest extends ContaoTestCase
+{
+    /**
+     * @dataProvider logExtrasProvider
+     */
+    public function testAddsLogExtras(string $uri, string $method): void
+    {
+        $request = Request::create($uri, $method);
+        $event = new RequestEvent($this->createMock(KernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST);
+
+        $processor = new RequestProcessor();
+        $processor->onKernelRequest($event);
+
+        $record = ['extra' => []];
+        $record = $processor($record);
+
+        $this->assertSame($uri, $record['extra']['request_uri']);
+        $this->assertSame($method, $record['extra']['request_method']);
+    }
+
+    /**
+     * @dataProvider logExtrasProvider
+     */
+    public function testIgnoresSubRequests(string $uri, string $method): void
+    {
+        $request = Request::create($uri, $method);
+        $event = new RequestEvent($this->createMock(KernelInterface::class), $request, HttpKernelInterface::SUB_REQUEST);
+
+        $processor = new RequestProcessor();
+        $processor->onKernelRequest($event);
+
+        $record = ['extra' => []];
+        $record = $processor($record);
+
+        $this->assertArrayNotHasKey('request_uri', $record['extra']);
+        $this->assertArrayNotHasKey('request_method', $record['extra']);
+    }
+
+    /**
+     * @dataProvider logExtrasProvider
+     */
+    public function testIgnoresIfRequestIsNotSet(): void
+    {
+        $processor = new RequestProcessor();
+
+        $record = ['extra' => []];
+        $record = $processor($record);
+
+        $this->assertArrayNotHasKey('request_uri', $record['extra']);
+        $this->assertArrayNotHasKey('request_method', $record['extra']);
+    }
+
+    public function logExtrasProvider(): \Generator
+    {
+        yield [
+            'https://example.com/foo/bar',
+            'GET'
+        ];
+
+        yield [
+            'https://example.com/foo/bar?bar=baz',
+            'GET'
+        ];
+
+        yield [
+            'https://example.com/foo/bar',
+            'POST'
+        ];
+    }
+}

--- a/manager-bundle/tests/Monolog/RequestProcessorTest.php
+++ b/manager-bundle/tests/Monolog/RequestProcessorTest.php
@@ -75,17 +75,17 @@ class RequestProcessorTest extends ContaoTestCase
     {
         yield [
             'https://example.com/foo/bar',
-            'GET'
+            'GET',
         ];
 
         yield [
             'https://example.com/foo/bar?bar=baz',
-            'GET'
+            'GET',
         ];
 
         yield [
             'https://example.com/foo/bar',
-            'POST'
+            'POST',
         ];
     }
 }


### PR DESCRIPTION
Unfortunately, I noticed two flaws in https://github.com/contao/contao/pull/6533

1. the logged `request_uri` is currently **not** absolute, which is potentially problematic in our CMS that supports multi-domains
2. the logged `request_method` is the _actual_ method, which ignores any _HTTP Method Overrides_. I think it makes more sense to log what our application receives though.

Unfortunately, neither can be accomplished with any default processor in Symfony or Monolog, so we need our own.