### PR TITLE
Camelize the file system service argument

### DIFF
--- a/core-bundle/src/DependencyInjection/Filesystem/FilesystemConfiguration.php
+++ b/core-bundle/src/DependencyInjection/Filesystem/FilesystemConfiguration.php
@@ -62,8 +62,9 @@ class FilesystemConfiguration
         $definition->setFactory(new Reference('contao.filesystem.virtual_factory'));
         $definition->addTag('contao.virtual_filesystem', compact('name', 'prefix'));
 
+        $aliasName = lcfirst(Container::camelize($name));
         $this->container->setDefinition($id = "contao.filesystem.virtual.$name", $definition);
-        $this->container->registerAliasForArgument($id, VirtualFilesystemInterface::class, "{$name}Storage");
+        $this->container->registerAliasForArgument($id, VirtualFilesystemInterface::class, "{$aliasName}Storage");
 
         return $definition;
     }

--- a/core-bundle/src/DependencyInjection/Filesystem/FilesystemConfiguration.php
+++ b/core-bundle/src/DependencyInjection/Filesystem/FilesystemConfiguration.php
@@ -63,6 +63,7 @@ class FilesystemConfiguration
         $definition->addTag('contao.virtual_filesystem', compact('name', 'prefix'));
 
         $aliasName = lcfirst(Container::camelize($name));
+
         $this->container->setDefinition($id = "contao.filesystem.virtual.$name", $definition);
         $this->container->registerAliasForArgument($id, VirtualFilesystemInterface::class, "{$aliasName}Storage");
 


### PR DESCRIPTION
I think it is convention hat arguments are camel-cased rather than snake-cased.

When you create a virtual filesystem of name `news_media`, the service is `contao.filesystem.virtual.news_media` which is correct, but the argument for argument resolving should be `$newsMediaStorage` (currently: `news_mediaStorage`).

might also be a bugfix?
cc @m-vo 