### PR TITLE
Update the `tstamp` column only on `tl_files` in the DBAFS

### DIFF
--- a/core-bundle/src/Filesystem/Dbafs/Dbafs.php
+++ b/core-bundle/src/Filesystem/Dbafs/Dbafs.php
@@ -614,9 +614,12 @@ class Dbafs implements DbafsInterface, ResetInterface
 
         // Updates
         foreach ($changeSet->getItemsToUpdate($this->useLastModified) as $itemToUpdate) {
-            $dataToUpdate = [
-                'tstamp' => $currentTime,
-            ];
+            $dataToUpdate = [];
+
+            // Backwards compatibility
+            if ('tl_files' === $this->table) {
+                $dataToUpdate['tstamp'] = $currentTime;
+            }
 
             if ($itemToUpdate->updatesPath()) {
                 $dataToUpdate['path'] = $this->convertToDatabasePath($itemToUpdate->getNewPath());


### PR DESCRIPTION
The tstamp column is only expected to be available for tl_files.
https://github.com/contao/contao/blob/970a1ed0b65dc2613a95b726a00f5fb60700418e/core-bundle/src/Filesystem/Dbafs/Dbafs.php#L587

DBAFS sync runs on exceptions when on another table than tl_files.