### PR TITLE
Inconsistent use of `findById()` and `findByPk()`

### DIFF
--- a/calendar-bundle/contao/classes/Calendar.php
+++ b/calendar-bundle/contao/classes/Calendar.php
@@ -254,7 +254,7 @@ class Calendar extends Frontend
 						$objItem->guid = $event['link'] . '#' . date('Y-m-d', $event['startTime']);
 					}
 
-					if (($objAuthor = UserModel::findById($event['author'])) !== null)
+					if ($objAuthor = UserModel::findByPk($event['author']))
 					{
 						$objItem->author = $objAuthor->name;
 					}

--- a/calendar-bundle/contao/modules/ModuleEventReader.php
+++ b/calendar-bundle/contao/modules/ModuleEventReader.php
@@ -83,7 +83,7 @@ class ModuleEventReader extends Events
 
 		$urlGenerator = System::getContainer()->get('contao.routing.content_url_generator');
 
-		if ($this->overviewPage && ($overviewPage = PageModel::findById($this->overviewPage)))
+		if ($this->overviewPage && ($overviewPage = PageModel::findByPk($this->overviewPage)))
 		{
 			$this->Template->referer = $urlGenerator->generate($overviewPage);
 			$this->Template->back = $this->customLabel ?: $GLOBALS['TL_LANG']['MSC']['eventOverview'];

--- a/calendar-bundle/src/Picker/EventPickerProvider.php
+++ b/calendar-bundle/src/Picker/EventPickerProvider.php
@@ -107,7 +107,7 @@ class EventPickerProvider extends AbstractInsertTagPickerProvider implements Dca
     {
         $eventAdapter = $this->framework->getAdapter(CalendarEventsModel::class);
 
-        if (!$eventsModel = $eventAdapter->findById($id)) {
+        if (!$eventsModel = $eventAdapter->findByPk($id)) {
             return null;
         }
 

--- a/calendar-bundle/tests/Picker/EventPickerProviderTest.php
+++ b/calendar-bundle/tests/Picker/EventPickerProviderTest.php
@@ -146,7 +146,7 @@ class EventPickerProviderTest extends ContaoTestCase
 
         $adapters = [
             CalendarModel::class => $this->mockConfiguredAdapter(['findByPk' => $calendarModel]),
-            CalendarEventsModel::class => $this->mockConfiguredAdapter(['findById' => $calendarEvents]),
+            CalendarEventsModel::class => $this->mockConfiguredAdapter(['findByPk' => $calendarEvents]),
         ];
 
         $picker = $this->getPicker();
@@ -165,7 +165,7 @@ class EventPickerProviderTest extends ContaoTestCase
         $config = new PickerConfig('link', [], '{{event_url::1}}', 'eventPicker');
 
         $adapters = [
-            CalendarEventsModel::class => $this->mockConfiguredAdapter(['findById' => null]),
+            CalendarEventsModel::class => $this->mockConfiguredAdapter(['findByPk' => null]),
         ];
 
         $picker = $this->getPicker();
@@ -186,7 +186,7 @@ class EventPickerProviderTest extends ContaoTestCase
 
         $adapters = [
             CalendarModel::class => $this->mockConfiguredAdapter(['findByPk' => null]),
-            CalendarEventsModel::class => $this->mockConfiguredAdapter(['findById' => $calendarEvents]),
+            CalendarEventsModel::class => $this->mockConfiguredAdapter(['findByPk' => $calendarEvents]),
         ];
 
         $picker = $this->getPicker();

--- a/core-bundle/contao/forms/Form.php
+++ b/core-bundle/contao/forms/Form.php
@@ -310,7 +310,7 @@ class Form extends Hybrid
 		{
 			foreach ($arrFiles as $upload)
 			{
-				if (!empty($upload['uuid']) && null !== ($file = FilesModel::findById($upload['uuid'])))
+				if (!empty($upload['uuid']) && null !== ($file = FilesModel::findByPk($upload['uuid'])))
 				{
 					$file->delete();
 				}

--- a/core-bundle/src/EventListener/DataContainer/Undo/LabelListener.php
+++ b/core-bundle/src/EventListener/DataContainer/Undo/LabelListener.php
@@ -51,7 +51,7 @@ class LabelListener
 
     private function getTemplateData(string $table, array $row, array $originalRow): array
     {
-        $user = $this->framework->getAdapter(UserModel::class)->findById($row['pid']);
+        $user = $this->framework->getAdapter(UserModel::class)->findByPk($row['pid']);
         $config = $this->framework->getAdapter(Config::class);
 
         $parent = null;

--- a/core-bundle/src/Security/Voter/BackendAccessVoter.php
+++ b/core-bundle/src/Security/Voter/BackendAccessVoter.php
@@ -197,7 +197,7 @@ class BackendAccessVoter extends Voter implements ResetInterface
             $row['cuser'] = false;
             $row['cgroup'] = false;
 
-            $parentPage = $this->framework->getAdapter(PageModel::class)->findById($pid);
+            $parentPage = $this->framework->getAdapter(PageModel::class)->findByPk($pid);
 
             while ($parentPage && false === $row['chmod'] && $pid > 0) {
                 $cacheIds[] = $parentPage->id;
@@ -207,7 +207,7 @@ class BackendAccessVoter extends Voter implements ResetInterface
                 $row['cuser'] = $parentPage->includeChmod ? $parentPage->cuser : false;
                 $row['cgroup'] = $parentPage->includeChmod ? $parentPage->cgroup : false;
 
-                $parentPage = $this->framework->getAdapter(PageModel::class)->findById($pid);
+                $parentPage = $this->framework->getAdapter(PageModel::class)->findByPk($pid);
             }
 
             // Set default values

--- a/core-bundle/tests/EventListener/DataContainer/Undo/LabelListenerTest.php
+++ b/core-bundle/tests/EventListener/DataContainer/Undo/LabelListenerTest.php
@@ -35,7 +35,7 @@ class LabelListenerTest extends TestCase
     {
         $row = $this->setupDataSet();
 
-        $userModelAdapter = $this->mockAdapter(['findById']);
+        $userModelAdapter = $this->mockAdapter(['findByPk']);
         $userModel = $this->mockClassWithProperties(UserModel::class, [
             'id' => 1,
             'username' => 'k.jones',
@@ -43,7 +43,7 @@ class LabelListenerTest extends TestCase
 
         $userModelAdapter
             ->expects($this->once())
-            ->method('findById')
+            ->method('findByPk')
             ->with(1)
             ->willReturn($userModel)
         ;
@@ -72,7 +72,7 @@ class LabelListenerTest extends TestCase
     {
         $row = $this->setupTabularDataSet();
 
-        $userModelAdapter = $this->mockAdapter(['findById']);
+        $userModelAdapter = $this->mockAdapter(['findByPk']);
         $userModel = $this->mockClassWithProperties(UserModel::class, [
             'id' => 1,
             'username' => 'k.jones',
@@ -80,7 +80,7 @@ class LabelListenerTest extends TestCase
 
         $userModelAdapter
             ->expects($this->once())
-            ->method('findById')
+            ->method('findByPk')
             ->with(1)
             ->willReturn($userModel)
         ;

--- a/faq-bundle/contao/modules/ModuleFaqReader.php
+++ b/faq-bundle/contao/modules/ModuleFaqReader.php
@@ -73,7 +73,7 @@ class ModuleFaqReader extends Module
 	{
 		global $objPage;
 
-		if ($this->overviewPage && ($overviewPage = PageModel::findById($this->overviewPage)))
+		if ($this->overviewPage && ($overviewPage = PageModel::findByPk($this->overviewPage)))
 		{
 			$this->Template->referer = System::getContainer()->get('contao.routing.content_url_generator')->generate($overviewPage);
 			$this->Template->back = $this->customLabel ?: $GLOBALS['TL_LANG']['MSC']['faqOverview'];

--- a/faq-bundle/src/Picker/FaqPickerProvider.php
+++ b/faq-bundle/src/Picker/FaqPickerProvider.php
@@ -107,7 +107,7 @@ class FaqPickerProvider extends AbstractInsertTagPickerProvider implements DcaPi
     {
         $faqAdapter = $this->framework->getAdapter(FaqModel::class);
 
-        if (!$faqModel = $faqAdapter->findById($id)) {
+        if (!$faqModel = $faqAdapter->findByPk($id)) {
             return null;
         }
 

--- a/faq-bundle/tests/Picker/FaqPickerProviderTest.php
+++ b/faq-bundle/tests/Picker/FaqPickerProviderTest.php
@@ -145,7 +145,7 @@ class FaqPickerProviderTest extends ContaoTestCase
         $config = new PickerConfig('link', [], '{{faq_url::1}}', 'faqPicker');
 
         $adapters = [
-            FaqModel::class => $this->mockConfiguredAdapter(['findById' => $faq]),
+            FaqModel::class => $this->mockConfiguredAdapter(['findByPk' => $faq]),
             FaqCategoryModel::class => $this->mockConfiguredAdapter(['findByPk' => $model]),
         ];
 
@@ -165,7 +165,7 @@ class FaqPickerProviderTest extends ContaoTestCase
         $config = new PickerConfig('link', [], '{{faq_url::1}}', 'faqPicker');
 
         $adapters = [
-            FaqModel::class => $this->mockConfiguredAdapter(['findById' => null]),
+            FaqModel::class => $this->mockConfiguredAdapter(['findByPk' => null]),
         ];
 
         $picker = $this->getPicker();
@@ -185,7 +185,7 @@ class FaqPickerProviderTest extends ContaoTestCase
         $config = new PickerConfig('link', [], '{{faq_url::1}}', 'faqPicker');
 
         $adapters = [
-            FaqModel::class => $this->mockConfiguredAdapter(['findById' => $faq]),
+            FaqModel::class => $this->mockConfiguredAdapter(['findByPk' => $faq]),
             FaqCategoryModel::class => $this->mockConfiguredAdapter(['findByPk' => null]),
         ];
 

--- a/news-bundle/contao/modules/ModuleNewsReader.php
+++ b/news-bundle/contao/modules/ModuleNewsReader.php
@@ -80,7 +80,7 @@ class ModuleNewsReader extends ModuleNews
 
 		$urlGenerator = System::getContainer()->get('contao.routing.content_url_generator');
 
-		if ($this->overviewPage && ($overviewPage = PageModel::findById($this->overviewPage)))
+		if ($this->overviewPage && ($overviewPage = PageModel::findByPk($this->overviewPage)))
 		{
 			$this->Template->referer = $urlGenerator->generate($overviewPage);
 			$this->Template->back = $this->customLabel ?: $GLOBALS['TL_LANG']['MSC']['newsOverview'];

--- a/news-bundle/src/Picker/NewsPickerProvider.php
+++ b/news-bundle/src/Picker/NewsPickerProvider.php
@@ -107,7 +107,7 @@ class NewsPickerProvider extends AbstractInsertTagPickerProvider implements DcaP
     {
         $newsAdapter = $this->framework->getAdapter(NewsModel::class);
 
-        if (!$newsModel = $newsAdapter->findById($id)) {
+        if (!$newsModel = $newsAdapter->findByPk($id)) {
             return null;
         }
 

--- a/news-bundle/tests/Picker/NewsPickerProviderTest.php
+++ b/news-bundle/tests/Picker/NewsPickerProviderTest.php
@@ -145,7 +145,7 @@ class NewsPickerProviderTest extends ContaoTestCase
         $config = new PickerConfig('link', [], '{{news_url::1}}', 'newsPicker');
 
         $adapters = [
-            NewsModel::class => $this->mockConfiguredAdapter(['findById' => $news]),
+            NewsModel::class => $this->mockConfiguredAdapter(['findByPk' => $news]),
             NewsArchiveModel::class => $this->mockConfiguredAdapter(['findByPk' => $model]),
         ];
 
@@ -165,7 +165,7 @@ class NewsPickerProviderTest extends ContaoTestCase
         $config = new PickerConfig('link', [], '{{news_url::1}}', 'newsPicker');
 
         $adapters = [
-            NewsModel::class => $this->mockConfiguredAdapter(['findById' => null]),
+            NewsModel::class => $this->mockConfiguredAdapter(['findByPk' => null]),
         ];
 
         $picker = $this->getPicker();
@@ -185,7 +185,7 @@ class NewsPickerProviderTest extends ContaoTestCase
         $config = new PickerConfig('link', [], '{{news_url::1}}', 'newsPicker');
 
         $adapters = [
-            NewsModel::class => $this->mockConfiguredAdapter(['findById' => $news]),
+            NewsModel::class => $this->mockConfiguredAdapter(['findByPk' => $news]),
             NewsArchiveModel::class => $this->mockConfiguredAdapter(['findByPk' => null]),
         ];
 

--- a/newsletter-bundle/contao/modules/ModuleNewsletterReader.php
+++ b/newsletter-bundle/contao/modules/ModuleNewsletterReader.php
@@ -71,7 +71,7 @@ class ModuleNewsletterReader extends Module
 	{
 		$this->Template->content = '';
 
-		if ($this->overviewPage && ($overviewPage = PageModel::findById($this->overviewPage)))
+		if ($this->overviewPage && ($overviewPage = PageModel::findByPk($this->overviewPage)))
 		{
 			$this->Template->referer = System::getContainer()->get('contao.routing.content_url_generator')->generate($overviewPage);
 			$this->Template->back = $this->customLabel ?: $GLOBALS['TL_LANG']['MSC']['nl_overview'];


### PR DESCRIPTION
There were a few places where we used `findById()` instead of `findByPk()`, which we normally use to find a model by ID. This would not work if we ever renamed the primary key, even though that will most likely never happen.
