### PR TITLE
Make full authentication optional in the personal data module

### DIFF
--- a/core-bundle/contao/dca/tl_module.php
+++ b/core-bundle/contao/dca/tl_module.php
@@ -76,7 +76,7 @@ $GLOBALS['TL_DCA']['tl_module'] = array
 		'sitemap'                     => '{title_legend},name,headline,type;{nav_legend},showProtected,showHidden;{reference_legend:hide},rootPage;{template_legend:hide},customTpl,navigationTpl;{protected_legend:hide},protected;{expert_legend:hide},cssID',
 		'login'                       => '{title_legend},name,headline,type;{config_legend},autologin,pwResetPage;{redirect_legend},jumpTo,redirectBack;{template_legend:hide},customTpl;{protected_legend:hide},protected;{expert_legend:hide},cssID',
 		'logout'                      => '{title_legend},name,type;{redirect_legend},jumpTo,redirectBack;{protected_legend:hide},protected;{expert_legend:hide},cssID',
-		'personalData'                => '{title_legend},name,headline,type;{config_legend},editable;{redirect_legend},jumpTo;{template_legend:hide},memberTpl;{protected_legend:hide},protected;{expert_legend:hide},cssID',
+		'personalData'                => '{title_legend},name,headline,type;{config_legend},editable,reqFullAuth;{redirect_legend},jumpTo;{template_legend:hide},memberTpl;{protected_legend:hide},protected;{expert_legend:hide},cssID',
 		'registration'                => '{title_legend},name,headline,type;{config_legend},editable,newsletters,disableCaptcha;{account_legend},reg_groups,reg_allowLogin,reg_assignDir;{redirect_legend},jumpTo;{email_legend},reg_activate;{template_legend:hide},memberTpl;{protected_legend:hide},protected;{expert_legend:hide},cssID',
 		'changePassword'              => '{title_legend},name,headline,type;{redirect_legend},jumpTo;{template_legend:hide},customTpl;{protected_legend:hide},protected;{expert_legend:hide},cssID',
 		'lostPassword'                => '{title_legend},name,headline,type;{config_legend},reg_skipName,disableCaptcha;{redirect_legend},jumpTo;{email_legend:hide},reg_jumpTo,reg_password;{template_legend:hide},customTpl;{protected_legend:hide},protected;{expert_legend:hide},cssID',
@@ -266,6 +266,11 @@ $GLOBALS['TL_DCA']['tl_module'] = array
 			'options_callback'        => array('tl_module', 'getEditableMemberProperties'),
 			'eval'                    => array('multiple'=>true),
 			'sql'                     => "blob NULL"
+		),
+		'reqFullAuth' => array
+		(
+			'inputType'               => 'checkbox',
+			'sql'                     => array('type' => 'boolean', 'default' => false),
 		),
 		'memberTpl' => array
 		(

--- a/core-bundle/contao/languages/en/tl_module.xlf
+++ b/core-bundle/contao/languages/en/tl_module.xlf
@@ -134,6 +134,12 @@
       <trans-unit id="tl_module.editable.1">
         <source>Show these fields in the front end form.</source>
       </trans-unit>
+      <trans-unit id="tl_module.reqFullAuth.0">
+        <source>Require full authentication</source>
+      </trans-unit>
+      <trans-unit id="tl_module.reqFullAuth.1">
+        <source>Require users to verify their identity if they are only authenticated based on a "remember me" cookie.</source>
+      </trans-unit>
       <trans-unit id="tl_module.memberTpl.0">
         <source>Form template</source>
       </trans-unit>

--- a/core-bundle/contao/models/ModuleModel.php
+++ b/core-bundle/contao/models/ModuleModel.php
@@ -38,6 +38,7 @@ use Contao\Model\Collection;
  * @property integer           $overviewPage
  * @property boolean           $redirectBack
  * @property string|array|null $editable
+ * @property boolean           $reqFullAuth
  * @property string            $memberTpl
  * @property integer           $form
  * @property string            $queryType
@@ -108,6 +109,7 @@ use Contao\Model\Collection;
  * @method static ModuleModel|null findOneByOverviewPage($val, array $opt=array())
  * @method static ModuleModel|null findOneByRedirectBack($val, array $opt=array())
  * @method static ModuleModel|null findOneByEditable($val, array $opt=array())
+ * @method static ModuleModel|null findOneByReqFullAuth($val, array $opt=array())
  * @method static ModuleModel|null findOneByMemberTpl($val, array $opt=array())
  * @method static ModuleModel|null findOneByTableless($val, array $opt=array())
  * @method static ModuleModel|null findOneByForm($val, array $opt=array())
@@ -172,6 +174,7 @@ use Contao\Model\Collection;
  * @method static Collection<ModuleModel>|ModuleModel[]|null findByOverviewPage($val, array $opt=array())
  * @method static Collection<ModuleModel>|ModuleModel[]|null findByRedirectBack($val, array $opt=array())
  * @method static Collection<ModuleModel>|ModuleModel[]|null findByEditable($val, array $opt=array())
+ * @method static Collection<ModuleModel>|ModuleModel[]|null findByReqFullAuth($val, array $opt=array())
  * @method static Collection<ModuleModel>|ModuleModel[]|null findByMemberTpl($val, array $opt=array())
  * @method static Collection<ModuleModel>|ModuleModel[]|null findByTableless($val, array $opt=array())
  * @method static Collection<ModuleModel>|ModuleModel[]|null findByForm($val, array $opt=array())
@@ -240,6 +243,7 @@ use Contao\Model\Collection;
  * @method static integer countByOverviewPage($val, array $opt=array())
  * @method static integer countByRedirectBack($val, array $opt=array())
  * @method static integer countByEditable($val, array $opt=array())
+ * @method static integer countByReqFullAuth($val, array $opt=array())
  * @method static integer countByMemberTpl($val, array $opt=array())
  * @method static integer countByTableless($val, array $opt=array())
  * @method static integer countByForm($val, array $opt=array())

--- a/core-bundle/contao/modules/Module.php
+++ b/core-bundle/contao/modules/Module.php
@@ -40,6 +40,7 @@ use Symfony\Component\Routing\Exception\ExceptionInterface;
  * @property boolean $redirectBack
  * @property string  $cols
  * @property array   $editable
+ * @property boolean $reqFullAuth
  * @property string  $memberTpl
  * @property integer $form
  * @property string  $queryType

--- a/core-bundle/contao/modules/ModulePersonalData.php
+++ b/core-bundle/contao/modules/ModulePersonalData.php
@@ -64,7 +64,9 @@ class ModulePersonalData extends Module
 			return '';
 		}
 
-		if ($this->reqFullAuth && !$security->isGranted('IS_AUTHENTICATED_FULLY'))
+		$reqFullAuth = $this->reqFullAuth || \in_array('password', $this->editable, true);
+
+		if ($reqFullAuth && !$security->isGranted('IS_AUTHENTICATED_FULLY'))
 		{
 			throw new AccessDeniedException('Full authentication is required to edit the personal data.');
 		}

--- a/core-bundle/contao/modules/ModulePersonalData.php
+++ b/core-bundle/contao/modules/ModulePersonalData.php
@@ -64,7 +64,7 @@ class ModulePersonalData extends Module
 			return '';
 		}
 
-		if (!$security->isGranted('IS_AUTHENTICATED_FULLY'))
+		if ($this->reqFullAuth && !$security->isGranted('IS_AUTHENTICATED_FULLY'))
 		{
 			throw new AccessDeniedException('Full authentication is required to edit the personal data.');
 		}

--- a/core-bundle/contao/modules/ModulePersonalData.php
+++ b/core-bundle/contao/modules/ModulePersonalData.php
@@ -64,6 +64,7 @@ class ModulePersonalData extends Module
 			return '';
 		}
 
+		// Always require full authentication if the module allows to set a new password
 		$reqFullAuth = $this->reqFullAuth || \in_array('password', $this->editable, true);
 
 		if ($reqFullAuth && !$security->isGranted('IS_AUTHENTICATED_FULLY'))


### PR DESCRIPTION
The fact that the personal data module always requires full authentication now breaks my application, so I added an option that makes the behavior optional. Alternatively, we can reverse the change and never require full authentication.

<img width="592" alt="" src="https://github.com/contao/contao/assets/1192057/18310d9b-c54f-4e41-a665-21e94802cdd8">
