### PR TITLE
Add a button to the "invalid request token" template

### DIFF
--- a/core-bundle/contao/languages/en/exception.xlf
+++ b/core-bundle/contao/languages/en/exception.xlf
@@ -39,7 +39,7 @@
         <source>Use the button above to reload the page and try again. Do not use the back button of your browser.</source>
       </trans-unit>
       <trans-unit id="XPT.tokenExplainOne">
-        <source>This error occurs if there is a POST request without a valid authentication token. If the problem persists, you may be using an incompatible third-party extension or have not correctly updated your Contao installation.</source>
+        <source>This error occurs if there is a POST request without a valid request token. If the problem persists, you may be using an incompatible third-party extension or have not correctly updated your Contao installation.</source>
       </trans-unit>
       <trans-unit id="XPT.tokenExplainTwo">
         <source>For more information, visit the &lt;a href="%s" target="_blank" rel="noreferrer noopener"&gt;Contao support page&lt;/a&gt;.</source>

--- a/core-bundle/contao/languages/en/exception.xlf
+++ b/core-bundle/contao/languages/en/exception.xlf
@@ -32,11 +32,14 @@
       <trans-unit id="XPT.invalidToken">
         <source>The request token could not be verified.</source>
       </trans-unit>
+      <trans-unit id="XPT.tokenReload">
+        <source>Reload the page</source>
+      </trans-unit>
       <trans-unit id="XPT.tokenRetry">
-        <source>Please &lt;a href="javascript:window.location.href=window.location.href"&gt;click here&lt;/a&gt; and try again. Do not use the back button of your browser.</source>
+        <source>Use the button above to reload the page and try again. Do not use the back button of your browser.</source>
       </trans-unit>
       <trans-unit id="XPT.tokenExplainOne">
-        <source>This error occurs if there is a POST request without a valid authentication token. In Contao 2.10, the referer check has been replaced with a request token system. If the problem persists, you may be using an incompatible third-party extension or have not correctly updated your Contao installation.</source>
+        <source>This error occurs if there is a POST request without a valid authentication token. If the problem persists, you may be using an incompatible third-party extension or have not correctly updated your Contao installation.</source>
       </trans-unit>
       <trans-unit id="XPT.tokenExplainTwo">
         <source>For more information, visit the &lt;a href="%s" target="_blank" rel="noreferrer noopener"&gt;Contao support page&lt;/a&gt;.</source>

--- a/core-bundle/templates/Error/invalid_request_token.html.twig
+++ b/core-bundle/templates/Error/invalid_request_token.html.twig
@@ -7,6 +7,7 @@
     <p>{{ 'XPT.invalidToken'|trans }}</p>
 {% endblock %}
 {% block howToFix %}
+    <p><a href="javascript:window.location.href=window.location.href" class="button">{{ 'XPT.tokenReload'|trans }}</a></p>
     <p>{{ 'XPT.tokenRetry'|trans|raw }}</p>
 {% endblock %}
 {% block explain %}

--- a/core-bundle/templates/Error/layout.html.twig
+++ b/core-bundle/templates/Error/layout.html.twig
@@ -39,6 +39,19 @@
                 a:hover {
                     text-decoration: underline;
                 }
+                a.button {
+                    line-height: 16px;
+                    display: inline-block;
+                    color: #fff;
+                    background-color: #f47c00;
+                    padding: 8px 10px;
+                    border-radius: 3px;
+                    transition: background-color .5s;
+                }
+                a.button:hover {
+                    text-decoration: none;
+                    background-color: #db6f00;
+                }
                 h1 {
                     margin: 0;
                     padding-bottom: 2%;


### PR DESCRIPTION
Fixes #6924

<img width="953" alt="" src="https://github.com/contao/contao/assets/1192057/571031ac-a141-4211-8ccd-b521bd1c5f09">

I don‘t know if we really need a button though.