### PR TITLE
Correctly generate the URLs to subscribe to comments

### DIFF
--- a/comments-bundle/contao/classes/Comments.php
+++ b/comments-bundle/contao/classes/Comments.php
@@ -12,6 +12,7 @@ namespace Contao;
 
 use Contao\CoreBundle\EventListener\Widget\HttpUrlListener;
 use Contao\CoreBundle\Exception\PageNotFoundException;
+use Contao\CoreBundle\Util\UrlUtil;
 use Nyholm\Psr7\Uri;
 
 /**
@@ -564,7 +565,7 @@ class Comments extends Frontend
 		$objNotify = new CommentsNotifyModel();
 		$objNotify->setRow($arrSet)->save();
 
-		$strUrl = Idna::decode(Environment::get('base')) . ltrim($request, '/');
+		$strUrl = UrlUtil::makeAbsolute($request, Idna::decode(Environment::get('base')));
 		$strConnector = (str_contains($strUrl, '?')) ? '&' : '?';
 
 		$optIn = System::getContainer()->get('contao.opt_in');
@@ -649,6 +650,7 @@ class Comments extends Frontend
 		{
 			$request = System::getContainer()->get('request_stack')->getCurrentRequest();
 			$isFrontend = $request && System::getContainer()->get('contao.routing.scope_matcher')->isFrontendRequest($request);
+			$baseUrl = Idna::decode(Environment::get('base'));
 
 			while ($objNotify->next())
 			{
@@ -666,7 +668,7 @@ class Comments extends Frontend
 				}
 
 				// Prepare the URL
-				$strUrl = Idna::decode(Environment::get('base')) . ltrim($objNotify->url, '/');
+				$strUrl = UrlUtil::makeAbsolute($objNotify->url, $baseUrl);
 
 				$objEmail = new Email();
 				$objEmail->from = $GLOBALS['TL_ADMIN_EMAIL'] ?? null;

--- a/comments-bundle/contao/classes/Comments.php
+++ b/comments-bundle/contao/classes/Comments.php
@@ -564,7 +564,7 @@ class Comments extends Frontend
 		$objNotify = new CommentsNotifyModel();
 		$objNotify->setRow($arrSet)->save();
 
-		$strUrl = Idna::decode(Environment::get('base')) . $request;
+		$strUrl = Idna::decode(Environment::get('base')) . ltrim($request, '/');
 		$strConnector = (str_contains($strUrl, '?')) ? '&' : '?';
 
 		$optIn = System::getContainer()->get('contao.opt_in');
@@ -666,7 +666,7 @@ class Comments extends Frontend
 				}
 
 				// Prepare the URL
-				$strUrl = Idna::decode(Environment::get('base')) . $objNotify->url;
+				$strUrl = Idna::decode(Environment::get('base')) . ltrim($objNotify->url, '/');
 
 				$objEmail = new Email();
 				$objEmail->from = $GLOBALS['TL_ADMIN_EMAIL'] ?? null;

--- a/comments-bundle/contao/dca/tl_comments.php
+++ b/comments-bundle/contao/dca/tl_comments.php
@@ -19,6 +19,7 @@ use Contao\Controller;
 use Contao\CoreBundle\EventListener\Widget\HttpUrlListener;
 use Contao\CoreBundle\Exception\AccessDeniedException;
 use Contao\CoreBundle\Security\ContaoCorePermissions;
+use Contao\CoreBundle\Util\UrlUtil;
 use Contao\Database;
 use Contao\DataContainer;
 use Contao\Date;
@@ -327,10 +328,12 @@ class tl_comments extends Backend
 
 		if ($objNotify !== null)
 		{
+			$baseUrl = Idna::decode(Environment::get('base'));
+
 			while ($objNotify->next())
 			{
 				// Prepare the URL
-				$strUrl = Idna::decode(Environment::get('base')) . ltrim($objNotify->url, '/');
+				$strUrl = UrlUtil::makeAbsolute($objNotify->url, $baseUrl);
 
 				$objEmail = new Email();
 				$objEmail->from = $GLOBALS['TL_ADMIN_EMAIL'] ?? null;

--- a/comments-bundle/contao/dca/tl_comments.php
+++ b/comments-bundle/contao/dca/tl_comments.php
@@ -330,7 +330,7 @@ class tl_comments extends Backend
 			while ($objNotify->next())
 			{
 				// Prepare the URL
-				$strUrl = Idna::decode(Environment::get('base')) . $objNotify->url;
+				$strUrl = Idna::decode(Environment::get('base')) . ltrim($objNotify->url, '/');
 
 				$objEmail = new Email();
 				$objEmail->from = $GLOBALS['TL_ADMIN_EMAIL'] ?? null;

--- a/core-bundle/tests/Util/UrlUtilTest.php
+++ b/core-bundle/tests/Util/UrlUtilTest.php
@@ -64,10 +64,16 @@ class UrlUtilTest extends TestCase
         yield ['data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7', '', 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7'];
     }
 
-    public function testMakeAbsoluteFailsForRelativeBasePath(): void
+    public function testFailsForRelativeBasePath(): void
     {
         $this->expectException(\InvalidArgumentException::class);
 
         UrlUtil::makeAbsolute('foo', 'path/foo');
+    }
+
+    public function testHandlesPunycodeDomains(): void
+    {
+        $this->assertSame('https://fööbar.de/foo', UrlUtil::makeAbsolute('/foo', 'https://fööbar.de/'));
+        $this->assertSame('https://xn--fbar-5qaa.de/foo', UrlUtil::makeAbsolute('/foo', 'https://xn--fbar-5qaa.de/'));
     }
 }

--- a/newsletter-bundle/contao/classes/Newsletter.php
+++ b/newsletter-bundle/contao/classes/Newsletter.php
@@ -12,6 +12,7 @@ namespace Contao;
 
 use Contao\CoreBundle\Exception\InternalServerErrorException;
 use Contao\CoreBundle\Monolog\ContaoContext;
+use Contao\CoreBundle\Util\UrlUtil;
 use Contao\Database\Result;
 use Contao\NewsletterBundle\Event\SendNewsletterEvent;
 use Symfony\Component\Mailer\Exception\TransportException;
@@ -242,7 +243,7 @@ class Newsletter extends Backend
 
 				Message::addConfirmation(sprintf($GLOBALS['TL_LANG']['tl_newsletter']['confirm'], $intTotal));
 
-				$href = Environment::get('base') . ltrim($referer, '/');
+				$href = UrlUtil::makeAbsolute($referer, Environment::get('base'));
 
 				echo '<script>setTimeout(\'window.location="' . $href . '"\',1000)</script>';
 				echo '<a href="' . $href . '">Please click here to proceed if you are not using JavaScript</a>';
@@ -252,7 +253,7 @@ class Newsletter extends Backend
 			else
 			{
 				$url = preg_replace('/&(amp;)?(start|mpc|recipient)=[^&]*/', '', Environment::get('requestUri')) . '&start=' . ($intStart + $intPages) . '&mpc=' . $intPages;
-				$href = Environment::get('base') . ltrim($url, '/');
+				$href = UrlUtil::makeAbsolute($url, Environment::get('base'));
 
 				echo '<script>setTimeout(\'window.location="' . $href . '"\',' . ($intTimeout * 1000) . ')</script>';
 				echo '<a href="' . $href . '">Please click here to proceed if you are not using JavaScript</a>';


### PR DESCRIPTION
This prevents double slashes in URLs when subscribing to comments now that we use absolute paths everywhere. We did the same here already:

https://github.com/contao/contao/blob/0eac53c903c296d0b2fb7725c4eda8bf1b418e25/newsletter-bundle/contao/classes/Newsletter.php#L245
