### PR TITLE
Improve the performance of the database dumper

### DIFF
--- a/core-bundle/src/Doctrine/Backup/Dumper.php
+++ b/core-bundle/src/Doctrine/Backup/Dumper.php
@@ -164,11 +164,7 @@ class Dumper implements DumperInterface
             return '0x'.bin2hex($value);
         }
 
-        if (isset($this->quoteCache[$value])) {
-            return $this->quoteCache[$value];
-        }
-
-        return $this->quoteCache[$value] = $connection->quote($value);
+        return $this->quoteCache[$value] ?? ($this->quoteCache[$value] = $connection->quote($value));
     }
 
     /**

--- a/core-bundle/src/Doctrine/Backup/Dumper.php
+++ b/core-bundle/src/Doctrine/Backup/Dumper.php
@@ -164,7 +164,16 @@ class Dumper implements DumperInterface
             return '0x'.bin2hex($value);
         }
 
-        return $this->quoteCache[$value] ?? ($this->quoteCache[$value] = $connection->quote($value));
+        if (isset($this->quoteCache[$value])) {
+            return $this->quoteCache[$value];
+        }
+
+        // Prevent the in-memory cache from growing forever on big databases
+        if (\count($this->quoteCache) >= 100000) {
+            $this->quoteCache = [];
+        }
+
+        return $this->quoteCache[$value] = $connection->quote($value);
     }
 
     /**

--- a/core-bundle/src/Doctrine/Backup/Dumper.php
+++ b/core-bundle/src/Doctrine/Backup/Dumper.php
@@ -80,7 +80,7 @@ class Dumper implements DumperInterface
     }
 
     /**
-     * @phpstan-param AbstractSchemaManager<AbstractPlatform> $schemaManager
+     * @param AbstractSchemaManager<AbstractPlatform> $schemaManager
      */
     private function dumpViews(AbstractSchemaManager $schemaManager, AbstractPlatform $platform): \Generator
     {


### PR DESCRIPTION
Seems like with the latest changes in Doctrine DBAL a lot of internal deprecations are suppressed because it uses `getWrappedConnection()` inside `quote()` itself. Also, it seems to do in-memory caching there as well.

By reducing the calls to `quote()` and using an in-memory cache ourselves, we can cut both, the time needed to create a backup and the memory usage in half 🥳 

<img width="344" alt="Bildschirmfoto 2024-02-27 um 17 03 50" src="https://github.com/contao/contao/assets/481937/a783add3-71b6-4bc3-a4cb-9ada5f530a52">
