### PR TITLE
Correctly register the `AutoRefreshTemplateHierarchyListener`

### DIFF
--- a/core-bundle/config/listener.yaml
+++ b/core-bundle/config/listener.yaml
@@ -519,3 +519,9 @@ services:
         class: Contao\CoreBundle\Messenger\EventListener\WorkerListener
         arguments:
             - '@contao.messenger.auto_fallback_notifier'
+
+    contao.twig.loader.auto_refresh_template_hierarchy_listener:
+        class: Contao\CoreBundle\Twig\Loader\AutoRefreshTemplateHierarchyListener
+        arguments:
+            - '@contao.twig.filesystem_loader'
+            - '%kernel.environment%'


### PR DESCRIPTION
This declaration was accidentally missing in #6936.