### PR TITLE
Convert protocol-relative URLs in the string resolver

### DIFF
--- a/core-bundle/config/services.yaml
+++ b/core-bundle/config/services.yaml
@@ -660,6 +660,7 @@ services:
             - '@contao.insert_tag.parser'
             - '@url_helper'
             - '@request_stack'
+            - '@router.request_context'
 
     contao.routing.content_url_generator:
         class: Contao\CoreBundle\Routing\ContentUrlGenerator

--- a/core-bundle/config/services.yaml
+++ b/core-bundle/config/services.yaml
@@ -659,6 +659,7 @@ services:
         arguments:
             - '@contao.insert_tag.parser'
             - '@url_helper'
+            - '@request_stack'
 
     contao.routing.content_url_generator:
         class: Contao\CoreBundle\Routing\ContentUrlGenerator

--- a/core-bundle/src/Routing/Content/ContentUrlResult.php
+++ b/core-bundle/src/Routing/Content/ContentUrlResult.php
@@ -14,7 +14,6 @@ namespace Contao\CoreBundle\Routing\Content;
 
 use Contao\CoreBundle\Exception\ForwardPageNotFoundException;
 use Contao\PageModel;
-use Nyholm\Psr7\Uri;
 
 final class ContentUrlResult
 {
@@ -22,7 +21,7 @@ final class ContentUrlResult
 
     public function __construct(public readonly object|string $content)
     {
-        if (\is_string($content) && !(new Uri($content))->getScheme()) {
+        if (\is_string($content) && !parse_url($content, PHP_URL_SCHEME)) {
             throw new \InvalidArgumentException('The content must not be a relative URL.');
         }
     }

--- a/core-bundle/src/Routing/Content/StringResolver.php
+++ b/core-bundle/src/Routing/Content/StringResolver.php
@@ -16,13 +16,15 @@ use Contao\CoreBundle\InsertTag\InsertTagParser;
 use Contao\PageModel;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\UrlHelper;
+use Symfony\Component\Routing\RequestContext;
 
 class StringResolver implements ContentUrlResolverInterface
 {
     public function __construct(
         private readonly InsertTagParser $insertTagParser,
         private readonly UrlHelper $urlHelper,
-        private readonly RequestStack $requestStack
+        private readonly RequestStack $requestStack,
+        private readonly RequestContext $requestContext,
     ) {
     }
 
@@ -40,7 +42,7 @@ class StringResolver implements ContentUrlResolverInterface
 
         // Resolve protocol-relative URLs that are ignored by the UrlHelper
         if (str_starts_with($url, '//')) {
-            $protocol = $this->requestStack->getCurrentRequest()?->getScheme() ?? 'http';
+            $protocol = $this->requestStack->getCurrentRequest()?->getScheme() ?? $this->requestContext->getScheme();
             $url = $protocol.':'.$url;
         }
 

--- a/core-bundle/src/Routing/Content/StringResolver.php
+++ b/core-bundle/src/Routing/Content/StringResolver.php
@@ -14,6 +14,7 @@ namespace Contao\CoreBundle\Routing\Content;
 
 use Contao\CoreBundle\InsertTag\InsertTagParser;
 use Contao\PageModel;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\UrlHelper;
 
 class StringResolver implements ContentUrlResolverInterface
@@ -21,6 +22,7 @@ class StringResolver implements ContentUrlResolverInterface
     public function __construct(
         private readonly InsertTagParser $insertTagParser,
         private readonly UrlHelper $urlHelper,
+        private readonly RequestStack $requestStack
     ) {
     }
 
@@ -34,6 +36,12 @@ class StringResolver implements ContentUrlResolverInterface
 
         if (!parse_url($url, PHP_URL_SCHEME)) {
             $url = $this->urlHelper->getAbsoluteUrl($url);
+        }
+
+        // Resolve protocol-relative URLs that are ignored by the UrlHelper
+        if (str_starts_with($url, '//')) {
+            $protocol = $this->requestStack->getCurrentRequest()?->getScheme() ?? 'http';
+            $url = $protocol.':'.$url;
         }
 
         return new ContentUrlResult($url);


### PR DESCRIPTION
The Symfony `UrlHelper::getAbsoluteUrl` ignores protocol relative URLs, but our `ContentUrlResult` does not.