### PR TITLE
Fix double inheritance of legacy templates in Twig

### DIFF
--- a/core-bundle/config/services.yaml
+++ b/core-bundle/config/services.yaml
@@ -1157,6 +1157,7 @@ services:
             - '@cache.system'
             - '@contao.twig.loader.template_locator'
             - '@contao.twig.loader.theme_namespace'
+            - '@contao.framework'
             - '%kernel.project_dir%'
         tags:
             - { name: twig.loader, priority: 2 }

--- a/core-bundle/src/Twig/Loader/ContaoFilesystemLoader.php
+++ b/core-bundle/src/Twig/Loader/ContaoFilesystemLoader.php
@@ -109,13 +109,7 @@ class ContaoFilesystemLoader implements LoaderInterface, ResetInterface
         }
 
         $getExtendedTemplate = static function ($path): string|null {
-            if (
-                1 === preg_match(
-                    '/\$this\s*->\s*extend\s*\(\s*[\'"]([a-z0-9_-]+)[\'"]\s*\)/i',
-                    (string) file_get_contents($path),
-                    $match,
-                )
-            ) {
+            if (1 === preg_match('/\$this\s*->\s*extend\s*\(\s*[\'"]([a-z0-9_-]+)[\'"]\s*\)/i', (string) file_get_contents($path), $match)) {
                 return $match[1];
             }
 
@@ -123,27 +117,17 @@ class ContaoFilesystemLoader implements LoaderInterface, ResetInterface
         };
 
         // Use the default path of the template if it extends itself
-        if (
-            ($extendedTemplate = $getExtendedTemplate($path))
-            && "@Contao/$extendedTemplate.html5" === $name
-        ) {
+        if (($extendedTemplate = $getExtendedTemplate($path)) && "@Contao/$extendedTemplate.html5" === $name) {
             $this->framework->initialize();
             $path = $this->framework->getAdapter(TemplateLoader::class)->getDefaultPath($extendedTemplate, 'html5');
         }
 
         // Look up the blocks of the parent template if present
-        if (
-            ($extendedTemplate = $getExtendedTemplate($path))
-            && "@Contao/$extendedTemplate.html5" !== $name
-        ) {
+        if (($extendedTemplate = $getExtendedTemplate($path)) && "@Contao/$extendedTemplate.html5" !== $name) {
             return new Source($this->getSourceContext("@Contao/$extendedTemplate.html5")->getCode(), $templateName, $path);
         }
 
-        preg_match_all(
-            '/\$this\s*->\s*block\s*\(\s*[\'"]([a-z0-9_-]+)[\'"]\s*\)/i',
-            (string) file_get_contents($path),
-            $matches,
-        );
+        preg_match_all('/\$this\s*->\s*block\s*\(\s*[\'"]([a-z0-9_-]+)[\'"]\s*\)/i', (string) file_get_contents($path), $matches);
 
         return new Source(implode("\n", $matches[1] ?? []), $templateName, $path);
     }

--- a/core-bundle/tests/Controller/ContentElement/ContentElementTestCase.php
+++ b/core-bundle/tests/Controller/ContentElement/ContentElementTestCase.php
@@ -259,7 +259,7 @@ class ContentElementTestCase extends TestCase
             $this->createMock(Connection::class),
         );
 
-        return new ContaoFilesystemLoader(new NullAdapter(), $templateLocator, $themeNamespace, $resourceBasePath);
+        return new ContaoFilesystemLoader(new NullAdapter(), $templateLocator, $themeNamespace, $this->createMock(ContaoFramework::class), $resourceBasePath);
     }
 
     protected function getEnvironment(ContaoFilesystemLoader $contaoFilesystemLoader, ContaoFramework $framework): Environment

--- a/core-bundle/tests/Twig/Inheritance/DynamicUseTokenParserTest.php
+++ b/core-bundle/tests/Twig/Inheritance/DynamicUseTokenParserTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Tests\Twig\Inheritance;
 
 use Contao\CoreBundle\Csrf\ContaoCsrfTokenManager;
+use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\CoreBundle\HttpKernel\Bundle\ContaoModuleBundle;
 use Contao\CoreBundle\Tests\TestCase;
 use Contao\CoreBundle\Twig\Extension\ContaoExtension;
@@ -47,7 +48,7 @@ class DynamicUseTokenParserTest extends TestCase
             $this->createMock(Connection::class),
         );
 
-        $filesystemLoader = new ContaoFilesystemLoader(new NullAdapter(), $templateLocator, $themeNamespace, $projectDir);
+        $filesystemLoader = new ContaoFilesystemLoader(new NullAdapter(), $templateLocator, $themeNamespace, $this->createMock(ContaoFramework::class), $projectDir);
 
         $environment = new Environment($filesystemLoader);
         $environment->addExtension(

--- a/core-bundle/tests/Twig/Inheritance/InheritanceTest.php
+++ b/core-bundle/tests/Twig/Inheritance/InheritanceTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Tests\Twig\Inheritance;
 
 use Contao\CoreBundle\Csrf\ContaoCsrfTokenManager;
+use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\CoreBundle\HttpKernel\Bundle\ContaoModuleBundle;
 use Contao\CoreBundle\Tests\TestCase;
 use Contao\CoreBundle\Twig\Extension\ContaoExtension;
@@ -106,7 +107,7 @@ class InheritanceTest extends TestCase
         $themeNamespace = new ThemeNamespace();
 
         $templateLocator = new TemplateLocator($projectDir, $bundles, $bundlesMetadata, $themeNamespace, $connection);
-        $loader = new ContaoFilesystemLoader(new NullAdapter(), $templateLocator, $themeNamespace, $projectDir);
+        $loader = new ContaoFilesystemLoader(new NullAdapter(), $templateLocator, $themeNamespace, $this->createMock(ContaoFramework::class), $projectDir);
 
         $environment = new Environment($loader);
         $environment->addExtension(

--- a/core-bundle/tests/Twig/Loader/ContaoFilesystemLoaderTest.php
+++ b/core-bundle/tests/Twig/Loader/ContaoFilesystemLoaderTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Tests\Twig\Loader;
 
 use Contao\CoreBundle\Exception\InvalidThemePathException;
+use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\CoreBundle\HttpKernel\Bundle\ContaoModuleBundle;
 use Contao\CoreBundle\Tests\TestCase;
 use Contao\CoreBundle\Twig\Loader\ContaoFilesystemLoader;
@@ -368,6 +369,7 @@ class ContaoFilesystemLoaderTest extends TestCase
             new NullAdapter(),
             $this->createMock(TemplateLocator::class),
             new ThemeNamespace(),
+            $this->createMock(ContaoFramework::class),
             '/',
         );
 
@@ -422,6 +424,7 @@ class ContaoFilesystemLoaderTest extends TestCase
             new NullAdapter(),
             $templateLocator,
             new ThemeNamespace(),
+            $this->createMock(ContaoFramework::class),
             $projectDir,
         );
 
@@ -535,6 +538,7 @@ class ContaoFilesystemLoaderTest extends TestCase
             $cacheAdapter,
             $templateLocator1,
             new ThemeNamespace(),
+            $this->createMock(ContaoFramework::class),
             '/',
         );
 
@@ -563,6 +567,7 @@ class ContaoFilesystemLoaderTest extends TestCase
             $cacheAdapter,
             $templateLocator2,
             new ThemeNamespace(),
+            $this->createMock(ContaoFramework::class),
             '/',
         );
 
@@ -612,6 +617,7 @@ class ContaoFilesystemLoaderTest extends TestCase
             new NullAdapter(),
             $templateLocator,
             new ThemeNamespace(),
+            $this->createMock(ContaoFramework::class),
             '/',
         );
     }
@@ -656,6 +662,7 @@ class ContaoFilesystemLoaderTest extends TestCase
             new NullAdapter(),
             $templateLocator,
             new ThemeNamespace(),
+            $this->createMock(ContaoFramework::class),
             $projectDir,
         );
     }


### PR DESCRIPTION
Fixes usecases like:

1. `templates/custom_backend.html.twig` extends from `@Contao/be_main`
2. `templates/be_main.html5` extends from `be_main` (meaning from the default in `vendor/contao/core-bundle/contao/templates/backend/be_main.html5`)

/cc @Toflar