### PR TITLE
Register the `dotenv:dump` command by default in the Contao managed edition

### DIFF
--- a/manager-bundle/config/services.yaml
+++ b/manager-bundle/config/services.yaml
@@ -74,3 +74,8 @@ services:
 
     # Autowiring aliases
     Contao\ManagerBundle\HttpKernel\JwtManager: '@contao_manager.jwt_manager'
+    
+    # Register the dotenv:dump command
+    Symfony\Component\Dotenv\Command\DotenvDumpCommand:
+        - '%kernel.project_dir%/.env'
+        - '%kernel.environment%'

--- a/manager-bundle/config/services.yaml
+++ b/manager-bundle/config/services.yaml
@@ -12,6 +12,13 @@ services:
         arguments:
             - '@kernel'
 
+    # Register the dotenv:dump command
+    contao_manager.command.dotenv_dump:
+        class: Symfony\Component\Dotenv\Command\DotenvDumpCommand
+        arguments:
+            - '%kernel.project_dir%/.env'
+            - '%kernel.environment%'
+
     contao_manager.command.install_skeleton:
         class: Contao\ManagerBundle\Command\InstallSkeletonCommand
         arguments:
@@ -74,8 +81,3 @@ services:
 
     # Autowiring aliases
     Contao\ManagerBundle\HttpKernel\JwtManager: '@contao_manager.jwt_manager'
-    
-    # Register the dotenv:dump command
-    Symfony\Component\Dotenv\Command\DotenvDumpCommand:
-        - '%kernel.project_dir%/.env'
-        - '%kernel.environment%'

--- a/manager-bundle/config/services.yaml
+++ b/manager-bundle/config/services.yaml
@@ -12,7 +12,6 @@ services:
         arguments:
             - '@kernel'
 
-    # Register the dotenv:dump command
     contao_manager.command.dotenv_dump:
         class: Symfony\Component\Dotenv\Command\DotenvDumpCommand
         arguments:


### PR DESCRIPTION
We know that Contao is mostly deployed on hosting providers that do not support real environment variables but we also rely on the `Dotenv` component ourselves for e.g. Mailer configuration etc.

For performance reasons, on those systems I would like to run `dotenv:dump` so Symfony dumps `.env.local.php` which is way faster as it can be cached in OPCode cache. Of course, you cannot change `.env.local` anymore without also updating that file then. But you will have to add `dotenv:dump` to your deploy chain manually anyway so you'll know that - it doesn't happen just like that.

However, the command is not registered by default in Symfony even though it has been around since Symfony 5.4. See https://github.com/symfony/symfony/pull/42610. This means that right now I have to add this configuration to every ME but given the fact of our hosting provider situation, I think this qualifies to be a good default.
Again, it just makes sure the command is around, you'll still have to use it yourself.