### PR TITLE
Make sure the `.env.local.php` is loaded correctly

### DIFF
--- a/manager-bundle/src/HttpKernel/ContaoKernel.php
+++ b/manager-bundle/src/HttpKernel/ContaoKernel.php
@@ -255,7 +255,7 @@ class ContaoKernel extends Kernel implements HttpCacheProvider
                 $env = 'dev';
             }
 
-            $_SERVER['APP_ENV'] = $_ENV['APP_ENV'] = $env;
+            self::loadEnv($projectDir, $env);
         }
 
         $kernel = static::create($projectDir, $env);
@@ -363,13 +363,11 @@ class ContaoKernel extends Kernel implements HttpCacheProvider
     private static function loadEnv(string $projectDir, string $defaultEnv = 'prod'): void
     {
         // Load cached env vars if the .env.local.php file exists.
-        // https://github.com/symfony/recipes/blob/master/symfony/framework-bundle/4.2/config/bootstrap.php
-        if (\is_array($env = @include Path::join($projectDir, '.env.local.php'))) {
-            foreach ($env as $k => $v) {
-                $_ENV[$k] ??= isset($_SERVER[$k]) && !str_starts_with($k, 'HTTP_') ? $_SERVER[$k] : $v;
-            }
+        // https://github.com/symfony/recipes/blob/master/symfony/framework-bundle/4.4/config/bootstrap.php
+        if (\is_array($env = @include Path::join($projectDir, '.env.local.php')) && (!isset($env['APP_ENV']) || $defaultEnv === $env['APP_ENV'])) {
+            (new Dotenv())->populate($env);
         } elseif (file_exists($filePath = Path::join($projectDir, '.env'))) {
-            (new Dotenv())->usePutenv(false)->loadEnv($filePath, 'APP_ENV', $defaultEnv);
+            (new Dotenv())->loadEnv($filePath, 'APP_ENV', $defaultEnv);
         }
 
         $_SERVER += $_ENV;


### PR DESCRIPTION
This fixes a few issues:

- if you had a `.env.prod.local` for example, this was never loaded because of the missing second `self::loadEnv()` call
- the `.env.local.php` was never correctly loaded either
- we now use `Dotenv::populate()` which correctly populates all variables instead of our manual old code
- Passing `false` as argument to `Dotenv` is deprecated, this is not needed anymore