### PR TITLE
Set the email message priority to "high"

### DIFF
--- a/manager-bundle/skeleton/config/config.yaml
+++ b/manager-bundle/skeleton/config/config.yaml
@@ -54,7 +54,7 @@ framework:
             contao_prio_normal_doctrine: doctrine://default?table_name=tl_message_queue&queue_name=prio_normal&auto_setup=false
             contao_prio_low_doctrine: doctrine://default?table_name=tl_message_queue&queue_name=prio_low&auto_setup=false
         routing:
-            'Symfony\Component\Mailer\Messenger\SendEmailMessage': contao_prio_low
+            'Symfony\Component\Mailer\Messenger\SendEmailMessage': contao_prio_high
             'Contao\CoreBundle\Messenger\Message\HighPriorityMessageInterface': contao_prio_high
             'Contao\CoreBundle\Messenger\Message\NormalPriorityMessageInterface': contao_prio_normal
             'Contao\CoreBundle\Messenger\Message\LowPriorityMessageInterface': contao_prio_low


### PR DESCRIPTION
I think we've discussed that e-mails should be treated with priority on the queue but seems like we forgot to adjust the default config? 😊 
