### PR TITLE
Fix the `dotenv:dump` command

### DIFF
--- a/manager-bundle/config/services.yaml
+++ b/manager-bundle/config/services.yaml
@@ -14,9 +14,7 @@ services:
 
     contao_manager.command.dotenv_dump:
         class: Symfony\Component\Dotenv\Command\DotenvDumpCommand
-        arguments:
-            - '%kernel.project_dir%/.env'
-            - '%kernel.environment%'
+        factory: '@contao_manager.dotenv.dump_command_factory'
 
     contao_manager.command.install_skeleton:
         class: Contao\ManagerBundle\Command\InstallSkeletonCommand
@@ -37,6 +35,12 @@ services:
             - '%kernel.project_dir%'
             - '%contao.web_dir%'
             - '%kernel.secret%'
+
+    contao_manager.dotenv.dump_command_factory:
+        class: Contao\ManagerBundle\Dotenv\DotenvDumpCommandFactory
+        arguments:
+            - '%kernel.project_dir%'
+            - '%kernel.environment%'
 
     contao_manager.jwt_manager:
         public: true

--- a/manager-bundle/src/Dotenv/DotenvDumpCommandFactory.php
+++ b/manager-bundle/src/Dotenv/DotenvDumpCommandFactory.php
@@ -18,8 +18,10 @@ use Symfony\Component\Filesystem\Path;
 
 class DotenvDumpCommandFactory
 {
-    public function __construct(private readonly string $projectDir, private readonly string $environment)
-    {
+    public function __construct(
+        private readonly string $projectDir,
+        private readonly string $environment,
+    ) {
     }
 
     public function __invoke(): DotenvDumpCommand

--- a/manager-bundle/src/Dotenv/DotenvDumpCommandFactory.php
+++ b/manager-bundle/src/Dotenv/DotenvDumpCommandFactory.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\ManagerBundle\Dotenv;
+
+use Symfony\Component\Dotenv\Command\DotenvDumpCommand;
+use Symfony\Component\Dotenv\Dotenv;
+use Symfony\Component\Filesystem\Path;
+
+class DotenvDumpCommandFactory
+{
+    public function __construct(private readonly string $projectDir, private readonly string $environment)
+    {
+    }
+
+    public function __invoke(): DotenvDumpCommand
+    {
+        $env = $this->environment;
+
+        if (file_exists($filePath = Path::join($this->projectDir, '.env'))) {
+            $globalsBackup = [$_SERVER, $_ENV];
+
+            try {
+                unset($_SERVER['APP_ENV']);
+                $_ENV = [];
+                (new Dotenv())->loadEnv($filePath, 'APP_ENV', 'jwt');
+                $env = $_ENV['APP_ENV'];
+            } finally {
+                [$_SERVER, $_ENV] = $globalsBackup;
+            }
+        }
+
+        return new DotenvDumpCommand($this->projectDir, $env);
+    }
+}

--- a/manager-bundle/src/HttpKernel/ContaoKernel.php
+++ b/manager-bundle/src/HttpKernel/ContaoKernel.php
@@ -255,7 +255,7 @@ class ContaoKernel extends Kernel implements HttpCacheProvider
                 $env = 'dev';
             }
 
-            self::loadEnv($projectDir, $env);
+            $_SERVER['APP_ENV'] = $_ENV['APP_ENV'] = $env;
         }
 
         $kernel = static::create($projectDir, $env);
@@ -364,8 +364,12 @@ class ContaoKernel extends Kernel implements HttpCacheProvider
     {
         // Load cached env vars if the .env.local.php file exists.
         // https://github.com/symfony/recipes/blob/master/symfony/framework-bundle/4.4/config/bootstrap.php
-        if (\is_array($env = @include Path::join($projectDir, '.env.local.php')) && (!isset($env['APP_ENV']) || $defaultEnv === $env['APP_ENV'])) {
+        if (\is_array($env = @include Path::join($projectDir, '.env.local.php'))) {
             (new Dotenv())->populate($env);
+
+            if ('jwt' === ($_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? null)) {
+                $_SERVER['APP_ENV'] = $_ENV['APP_ENV'] = $defaultEnv;
+            }
         } elseif (file_exists($filePath = Path::join($projectDir, '.env'))) {
             (new Dotenv())->loadEnv($filePath, 'APP_ENV', $defaultEnv);
         }


### PR DESCRIPTION
This will dynamically dump `APP_ENV=jwt` into the `.env.local.php` file, if the `.env` and `.env.local` do not contain `APP_ENV`.