### PR TITLE
Incorrect cached paths in Dbafs

### DIFF
--- a/core-bundle/src/Filesystem/Dbafs/Dbafs.php
+++ b/core-bundle/src/Filesystem/Dbafs/Dbafs.php
@@ -155,7 +155,7 @@ class Dbafs implements DbafsInterface, ResetInterface
         foreach ($rows as $row) {
             $itemPath = $this->convertToFilesystemPath($row['path']);
 
-            if (!\array_key_exists($itemPath, $this->records)) {
+            if (!\array_key_exists($itemPath, $this->records) || null === $this->records[$itemPath]) {
                 $this->populateRecord($row);
             }
 
@@ -230,6 +230,10 @@ class Dbafs implements DbafsInterface, ResetInterface
 
             $this->pathById = array_diff($this->pathById, [$itemToDelete->getPath()]);
             $this->pathByUuid = array_diff($this->pathByUuid, [$itemToDelete->getPath()]);
+        }
+
+        foreach ($changeSet->getItemsToCreate() as $itemToCreate) {
+            $this->loadRecordByPath($itemToCreate->getPath());
         }
 
         return $changeSet;


### PR DESCRIPTION
Not sure this is the correct fix and also not sure I caught all the places and if this should also go to 4.13 but I thought I would create a draft PR anyway just to illustrate the problem better. I think the final PR with the fix probably has to be provided by @m-vo 🙈 

Issue:

If you call `$vfs->fileExists($path)` and the file does not exist, the `Dbafs` will internally call `loadRecordByPath()` and cache `this->records[$path] = null;`. If you then call `vfs->write($path)`, this internal cache will not get updated so all the other methods like `has()` or `listContents()` will return `false` or fail because of `null` access on the previously cached item.