### PR TITLE
Deprecate inheriting CSS classes in nested elements

### DIFF
--- a/core-bundle/contao/elements/ContentElement.php
+++ b/core-bundle/contao/elements/ContentElement.php
@@ -259,6 +259,8 @@ abstract class ContentElement extends Frontend
 
 		if (!empty($this->objModel->classes) && \is_array($this->objModel->classes))
 		{
+			trigger_deprecation('contao/core-bundle', '5.0', 'Using $model->classes is deprecated, update the `cssID` property instead.');
+
 			$this->Template->class .= ' ' . implode(' ', $this->objModel->classes);
 		}
 

--- a/core-bundle/contao/elements/ContentElement.php
+++ b/core-bundle/contao/elements/ContentElement.php
@@ -259,7 +259,7 @@ abstract class ContentElement extends Frontend
 
 		if (!empty($this->objModel->classes) && \is_array($this->objModel->classes))
 		{
-			trigger_deprecation('contao/core-bundle', '5.0', 'Using $model->classes is deprecated, update the `cssID` property instead.');
+			trigger_deprecation('contao/core-bundle', '5.0', 'Using $model->classes is deprecated, update the "cssID" property instead.');
 
 			$this->Template->class .= ' ' . implode(' ', $this->objModel->classes);
 		}

--- a/core-bundle/contao/elements/ContentElement.php
+++ b/core-bundle/contao/elements/ContentElement.php
@@ -259,7 +259,7 @@ abstract class ContentElement extends Frontend
 
 		if (!empty($this->objModel->classes) && \is_array($this->objModel->classes))
 		{
-			trigger_deprecation('contao/core-bundle', '5.0', 'Using $model->classes is deprecated, update the "cssID" property instead.');
+			trigger_deprecation('contao/core-bundle', '5.0', 'Using "$model->classes" is deprecated, update the "cssID" property instead.');
 
 			$this->Template->class .= ' ' . implode(' ', $this->objModel->classes);
 		}

--- a/core-bundle/contao/library/Contao/Controller.php
+++ b/core-bundle/contao/library/Contao/Controller.php
@@ -593,6 +593,11 @@ abstract class Controller extends System
 		}
 		else
 		{
+			if ($contentElementReference?->attributes['classes'] ?? null)
+			{
+				$objRow->classes = $contentElementReference->attributes['classes'];
+			}
+
 			$objElement = new $strClass($objRow, $strColumn);
 		}
 

--- a/core-bundle/contao/library/Contao/Controller.php
+++ b/core-bundle/contao/library/Contao/Controller.php
@@ -593,11 +593,6 @@ abstract class Controller extends System
 		}
 		else
 		{
-			if ($contentElementReference?->attributes['classes'] ?? null)
-			{
-				$objRow->classes = $contentElementReference->attributes['classes'];
-			}
-
 			$objElement = new $strClass($objRow, $strColumn);
 		}
 


### PR DESCRIPTION
The `ContentElementReference` has a special attribute `classes`, which is then forwarded to the content element. The same should apply when rendering a regular content element from a reference (e.g. for nested elements).

The class is added to the template by all legacy elements: https://github.com/contao/contao/blob/5.x/core-bundle/contao/elements/ContentElement.php#L260