### PR TITLE
Cache `Image::getHtml()` to speed up the tree view

### DIFF
--- a/core-bundle/contao/library/Contao/Image.php
+++ b/core-bundle/contao/library/Contao/Image.php
@@ -58,7 +58,7 @@ class Image
 		'visible_',
 	);
 
-	private static $htmlTemplateCache = array();
+	private static array $htmlTemplateCache = array();
 
 	/**
 	 * Get the relative path to an image
@@ -157,18 +157,18 @@ class Image
 		$template = self::getHtmlTemplate($src);
 
 		$search = array('{alt}', '{attributes}');
-		$replace = array(StringUtil::specialchars($alt), ($attributes === '') ? '' : (' ' . $attributes));
+		$replace = array(StringUtil::specialchars($alt), $attributes ? ' ' . $attributes : '');
 
 		if (str_contains($template, '{darkAttributes}'))
 		{
 			$search[] = '{darkAttributes}';
-			$replace[] = (new HtmlAttributes($attributes))->mergeWith(array('class' => 'color-scheme--dark', 'loading' => 'lazy'))->toString(true);
+			$replace[] = (new HtmlAttributes($attributes))->mergeWith(array('class' => 'color-scheme--dark', 'loading' => 'lazy'))->toString();
 		}
 
 		if (str_contains($template, '{lightAttributes}'))
 		{
 			$search[] = '{lightAttributes}';
-			$replace[] = (new HtmlAttributes($attributes))->mergeWith(array('class' => 'color-scheme--light', 'loading' => 'lazy'))->toString(true);
+			$replace[] = (new HtmlAttributes($attributes))->mergeWith(array('class' => 'color-scheme--light', 'loading' => 'lazy'))->toString();
 		}
 
 		return str_replace($search, $replace, $template);

--- a/core-bundle/contao/library/Contao/Image.php
+++ b/core-bundle/contao/library/Contao/Image.php
@@ -58,6 +58,8 @@ class Image
 		'visible_',
 	);
 
+	private static $htmlTemplateCache = array();
+
 	/**
 	 * Get the relative path to an image
 	 *
@@ -152,11 +154,45 @@ class Image
 	 */
 	public static function getHtml($src, $alt='', $attributes='')
 	{
+		$template = self::getHtmlTemplate($src);
+
+		$search = array('{alt}', '{attributes}');
+		$replace = array(StringUtil::specialchars($alt), ($attributes === '') ? '' : (' ' . $attributes));
+
+		if (str_contains($template, '{darkAttributes}'))
+		{
+			$search[] = '{darkAttributes}';
+			$replace[] = (new HtmlAttributes($attributes))->mergeWith(array('class' => 'color-scheme--dark', 'loading' => 'lazy'))->toString(true);
+		}
+
+		if (str_contains($template, '{lightAttributes}'))
+		{
+			$search[] = '{lightAttributes}';
+			$replace[] = (new HtmlAttributes($attributes))->mergeWith(array('class' => 'color-scheme--light', 'loading' => 'lazy'))->toString(true);
+		}
+
+		return str_replace($search, $replace, $template);
+	}
+
+	private static function getHtmlTemplate($src): string
+	{
+		if (!$src)
+		{
+			return '';
+		}
+
+		$cacheKey = $src;
+
+		if (isset(self::$htmlTemplateCache[$cacheKey]))
+		{
+			return self::$htmlTemplateCache[$cacheKey];
+		}
+
 		$src = static::getPath($src);
 
 		if (!$src)
 		{
-			return '';
+			return self::$htmlTemplateCache[$cacheKey] = '';
 		}
 
 		$container = System::getContainer();
@@ -181,7 +217,7 @@ class Image
 			}
 			elseif (!$deferredImage instanceof DeferredImageInterface)
 			{
-				return '';
+				return self::$htmlTemplateCache[$cacheKey] = '';
 			}
 		}
 
@@ -204,24 +240,9 @@ class Image
 				$darkSrc = substr($darkSrc, \strlen($webDir) + 1);
 			}
 
-			$darkAttributes = new HtmlAttributes($attributes);
-			$darkAttributes->mergeWith(array('class' => 'color-scheme--dark', 'loading' => 'lazy'));
-
-			foreach (array('data-icon', 'data-icon-disabled') as $icon)
-			{
-				if (isset($darkAttributes[$icon]))
-				{
-					$pathinfo = pathinfo($darkAttributes[$icon]);
-					$darkAttributes[$icon] = $pathinfo['filename'] . '--dark.' . $pathinfo['extension'];
-				}
-			}
-
-			$lightAttributes = new HtmlAttributes($attributes);
-			$lightAttributes->mergeWith(array('class' => 'color-scheme--light', 'loading' => 'lazy'));
-
-			return '<img src="' . self::getUrl($darkSrc) . '" width="' . $objFile->width . '" height="' . $objFile->height . '" alt="' . StringUtil::specialchars($alt) . '"' . $darkAttributes . '><img src="' . self::getUrl($src) . '" width="' . $objFile->width . '" height="' . $objFile->height . '" alt="' . StringUtil::specialchars($alt) . '"' . $lightAttributes . '>';
+			return self::$htmlTemplateCache[$cacheKey] = '<img src="' . self::getUrl($darkSrc) . '" width="' . $objFile->width . '" height="' . $objFile->height . '" alt="{alt}"{darkAttributes}><img src="' . self::getUrl($src) . '" width="' . $objFile->width . '" height="' . $objFile->height . '" alt="{alt}"{lightAttributes}>';
 		}
 
-		return '<img src="' . self::getUrl($src) . '" width="' . $objFile->width . '" height="' . $objFile->height . '" alt="' . StringUtil::specialchars($alt) . '"' . ($attributes ? ' ' . $attributes : '') . '>';
+		return self::$htmlTemplateCache[$cacheKey] = '<img src="' . self::getUrl($src) . '" width="' . $objFile->width . '" height="' . $objFile->height . '" alt="{alt}"{attributes}>';
 	}
 }

--- a/core-bundle/tests/EventListener/Widget/RootPageDependentSelectListenerTest.php
+++ b/core-bundle/tests/EventListener/Widget/RootPageDependentSelectListenerTest.php
@@ -15,6 +15,7 @@ namespace Contao\CoreBundle\Tests\EventListener\Widget;
 use Contao\CoreBundle\EventListener\Widget\RootPageDependentSelectListener;
 use Contao\CoreBundle\Tests\TestCase;
 use Contao\DataContainer;
+use Contao\Image;
 use Contao\System;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Result;
@@ -28,7 +29,7 @@ class RootPageDependentSelectListenerTest extends TestCase
     {
         unset($GLOBALS['TL_DCA']);
 
-        $this->resetStaticProperties([System::class]);
+        $this->resetStaticProperties([System::class, Image::class]);
 
         parent::tearDown();
     }


### PR DESCRIPTION
Huge tree views (or also list views) with lots of operations will slow down considerably at the moment because (amongst other stuff) expensive `Image::getHtml()` calls. I've tried to fix this using some kind of template per `$src` and then only replace the attributes and alt stuff dynamically.

<img width="346" alt="Bildschirmfoto 2024-03-07 um 17 50 25" src="https://github.com/contao/contao/assets/481937/c8536468-fb72-4f65-b31c-60c44c06a22b">
