### PR TITLE
Fix the front end module permissions

### DIFF
--- a/core-bundle/config/services.yaml
+++ b/core-bundle/config/services.yaml
@@ -917,7 +917,7 @@ services:
     contao.security.data_container.frontend_modules_voter:
         class: Contao\CoreBundle\Security\Voter\DataContainer\FrontendModulesVoter
         arguments:
-            - '@security.helper'
+            - '@security.access.decision_manager'
 
     contao.security.data_container.image_size_access_voter:
         class: Contao\CoreBundle\Security\Voter\DataContainer\ImageSizeAccessVoter

--- a/core-bundle/config/services.yaml
+++ b/core-bundle/config/services.yaml
@@ -914,8 +914,8 @@ services:
         arguments:
             - '@security.access.decision_manager'
 
-    contao.security.data_container.frontend_modules_voter:
-        class: Contao\CoreBundle\Security\Voter\DataContainer\FrontendModulesVoter
+    contao.security.data_container.frontend_module_voter:
+        class: Contao\CoreBundle\Security\Voter\DataContainer\FrontendModuleVoter
         arguments:
             - '@security.access.decision_manager'
 

--- a/core-bundle/contao/dca/tl_content.php
+++ b/core-bundle/contao/dca/tl_content.php
@@ -1401,8 +1401,18 @@ class tl_content extends Backend
 			return '';
 		}
 
-		$title = sprintf($GLOBALS['TL_LANG']['tl_content']['editalias'], $dc->value);
-		$href = System::getContainer()->get('router')->generate('contao_backend', array('do'=>'themes', 'table'=>'tl_module', 'act'=>'edit', 'id'=>$dc->value, 'popup'=>'1', 'nb'=>'1'));
+		// DataContainer::getCurrentRecord() will check permission on the record
+		try
+		{
+			$module = $dc->getCurrentRecord($dc->value, 'tl_module');
+		}
+		catch (AccessDeniedException)
+		{
+			return '';
+		}
+
+		$title = sprintf($GLOBALS['TL_LANG']['tl_content']['editalias'], $module['id']);
+		$href = System::getContainer()->get('router')->generate('contao_backend', array('do'=>'themes', 'table'=>'tl_module', 'act'=>'edit', 'id'=>$module['id'], 'popup'=>'1', 'nb'=>'1'));
 
 		return ' <a href="' . StringUtil::specialcharsUrl($href) . '" title="' . StringUtil::specialchars($title) . '" onclick="Backend.openModalIframe({\'title\':\'' . StringUtil::specialchars(str_replace("'", "\\'", $title)) . '\',\'url\':this.href});return false">' . Image::getHtml('alias.svg', $title) . '</a>';
 	}

--- a/core-bundle/contao/dca/tl_module.php
+++ b/core-bundle/contao/dca/tl_module.php
@@ -30,7 +30,6 @@ $GLOBALS['TL_DCA']['tl_module'] = array
 		'markAsCopy'                  => 'name',
 		'onload_callback' => array
 		(
-			array('tl_module', 'checkPermission'),
 			array('tl_module', 'addCustomLayoutSectionReferences')
 		),
 		'sql' => array
@@ -565,19 +564,6 @@ $GLOBALS['TL_DCA']['tl_module'] = array
  */
 class tl_module extends Backend
 {
-	/**
-	 * Check permissions to edit the table
-	 *
-	 * @throws AccessDeniedException
-	 */
-	public function checkPermission()
-	{
-		if (!System::getContainer()->get('security.helper')->isGranted(ContaoCorePermissions::USER_CAN_ACCESS_FRONTEND_MODULES))
-		{
-			throw new AccessDeniedException('Not enough permissions to access the front end modules module.');
-		}
-	}
-
 	/**
 	 * Return all front end modules as array
 	 *

--- a/core-bundle/contao/dca/tl_module.php
+++ b/core-bundle/contao/dca/tl_module.php
@@ -11,7 +11,6 @@
 use Contao\Backend;
 use Contao\BackendUser;
 use Contao\Controller;
-use Contao\CoreBundle\Exception\AccessDeniedException;
 use Contao\CoreBundle\Security\ContaoCorePermissions;
 use Contao\Database;
 use Contao\DataContainer;

--- a/core-bundle/src/Security/ContaoCorePermissions.php
+++ b/core-bundle/src/Security/ContaoCorePermissions.php
@@ -33,12 +33,6 @@ final class ContaoCorePermissions
     public const USER_CAN_DELETE_PAGE = 'contao_user.can_delete_page';
 
     /**
-     * Access is granted if the current user can delete the given fron end module.
-     * Subject must be a module ID, a FrontendModule or a tl_module record as array.
-     */
-    public const USER_CAN_DELETE_FRONTEND_MODULE = 'contao_user.can_delete_frontend_module';
-
-    /**
      * Access is granted if the current user can edit articles of the given page.
      * Subject must be a page ID, a PageModel or a tl_page record as array.
      */

--- a/core-bundle/src/Security/Voter/DataContainer/FrontendModuleVoter.php
+++ b/core-bundle/src/Security/Voter/DataContainer/FrontendModuleVoter.php
@@ -15,8 +15,10 @@ use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface
 /**
  * @internal
  */
-class FrontendModulesVoter extends AbstractDataContainerVoter
+class FrontendModuleVoter extends AbstractDataContainerVoter
 {
+    use TypeAccessTrait;
+
     public function __construct(private readonly AccessDecisionManagerInterface $accessDecisionManager)
     {
     }
@@ -39,16 +41,6 @@ class FrontendModulesVoter extends AbstractDataContainerVoter
             return true;
         }
 
-        if ($action instanceof CreateAction) {
-            $type = $action->getNew()['type'] ?? null;
-
-            if (null === $type) {
-                return true;
-            }
-        } else {
-            $type = $action->getCurrent()['type'];
-        }
-
-        return $this->accessDecisionManager->decide($token, [ContaoCorePermissions::USER_CAN_ACCESS_FRONTEND_MODULE_TYPE], $type);
+        return $this->hasAccessToType($token, ContaoCorePermissions::USER_CAN_ACCESS_FRONTEND_MODULE_TYPE, $action);
     }
 }

--- a/core-bundle/src/Security/Voter/DataContainer/FrontendModulesVoter.php
+++ b/core-bundle/src/Security/Voter/DataContainer/FrontendModulesVoter.php
@@ -12,6 +12,9 @@ use Contao\CoreBundle\Security\DataContainer\UpdateAction;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
 
+/**
+ * @internal
+ */
 class FrontendModulesVoter extends AbstractDataContainerVoter
 {
     public function __construct(private readonly AccessDecisionManagerInterface $accessDecisionManager)

--- a/core-bundle/src/Security/Voter/DataContainer/FrontendModulesVoter.php
+++ b/core-bundle/src/Security/Voter/DataContainer/FrontendModulesVoter.php
@@ -4,15 +4,20 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Security\Voter\DataContainer;
 
-use Contao\BackendUser;
+use Contao\CoreBundle\Security\ContaoCorePermissions;
 use Contao\CoreBundle\Security\DataContainer\CreateAction;
 use Contao\CoreBundle\Security\DataContainer\DeleteAction;
 use Contao\CoreBundle\Security\DataContainer\ReadAction;
 use Contao\CoreBundle\Security\DataContainer\UpdateAction;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
 
 class FrontendModulesVoter extends AbstractDataContainerVoter
 {
+    public function __construct(private readonly AccessDecisionManagerInterface $accessDecisionManager)
+    {
+    }
+
     protected function getTable(): string
     {
         return 'tl_module';
@@ -20,35 +25,27 @@ class FrontendModulesVoter extends AbstractDataContainerVoter
 
     protected function hasAccess(TokenInterface $token, CreateAction|DeleteAction|ReadAction|UpdateAction $action): bool
     {
+        if (
+            !$this->accessDecisionManager->decide($token, [ContaoCorePermissions::USER_CAN_ACCESS_MODULE], 'themes')
+            || !$this->accessDecisionManager->decide($token, [ContaoCorePermissions::USER_CAN_ACCESS_FRONTEND_MODULES])
+        ) {
+            return false;
+        }
+
         if ($action instanceof ReadAction) {
             return true;
         }
 
-        $user = $token->getUser();
-
-        if (!$user instanceof BackendUser) {
-            return false;
-        }
-
-        if ($user->isAdmin || empty($user->frontendModules)) {
-            return true;
-        }
-
-        return $this->isAllowedModuleType($action, $user);
-    }
-
-    private function isAllowedModuleType(CreateAction|DeleteAction|ReadAction|UpdateAction $subject, BackendUser $user): bool
-    {
-        if ($subject instanceof CreateAction) {
-            $type = $subject->getNew()['type'];
+        if ($action instanceof CreateAction) {
+            $type = $action->getNew()['type'];
 
             if (null === $type) {
                 return true;
             }
         } else {
-            $type = $subject->getCurrent()['type'];
+            $type = $action->getCurrent()['type'];
         }
 
-        return \in_array($type, $user->frontendModules, true);
+        return $this->accessDecisionManager->decide($token, [ContaoCorePermissions::USER_CAN_ACCESS_FRONTEND_MODULE_TYPE], $type);
     }
 }

--- a/core-bundle/src/Security/Voter/DataContainer/FrontendModulesVoter.php
+++ b/core-bundle/src/Security/Voter/DataContainer/FrontendModulesVoter.php
@@ -37,7 +37,7 @@ class FrontendModulesVoter extends AbstractDataContainerVoter
         }
 
         if ($action instanceof CreateAction) {
-            $type = $action->getNew()['type'];
+            $type = $action->getNew()['type'] ?? null;
 
             if (null === $type) {
                 return true;

--- a/core-bundle/src/Security/Voter/DataContainer/PageTypeAccessVoter.php
+++ b/core-bundle/src/Security/Voter/DataContainer/PageTypeAccessVoter.php
@@ -26,6 +26,8 @@ use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface
  */
 class PageTypeAccessVoter extends AbstractDataContainerVoter
 {
+    use TypeAccessTrait;
+
     private const FIRST_LEVEL_TYPES = ['error_401', 'error_403', 'error_404', 'error_503'];
 
     public function __construct(
@@ -52,29 +54,7 @@ class PageTypeAccessVoter extends AbstractDataContainerVoter
             return true;
         }
 
-        $types = [];
-
-        if (!$action instanceof CreateAction && isset($action->getCurrent()['type'])) {
-            $types[] = $action->getCurrent()['type'];
-        }
-
-        if (!$action instanceof DeleteAction && isset($action->getNew()['type'])) {
-            $types[] = $action->getNew()['type'];
-        }
-
-        if ([] === $types) {
-            return true;
-        }
-
-        // For the update action, the user needs access to both the current and the new
-        // page type, so if one is denied, return false.
-        foreach ($types as $type) {
-            if (!$this->accessDecisionManager->decide($token, [ContaoCorePermissions::USER_CAN_ACCESS_PAGE_TYPE], $type)) {
-                return false;
-            }
-        }
-
-        return true;
+        return $this->hasAccessToType($token, ContaoCorePermissions::USER_CAN_ACCESS_PAGE_TYPE, $action);
     }
 
     private function validateFirstLevelType(CreateAction|DeleteAction|ReadAction|UpdateAction $action): bool

--- a/core-bundle/src/Security/Voter/DataContainer/TypeAccessTrait.php
+++ b/core-bundle/src/Security/Voter/DataContainer/TypeAccessTrait.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Security\Voter\DataContainer;
+
+use Contao\CoreBundle\Security\DataContainer\CreateAction;
+use Contao\CoreBundle\Security\DataContainer\DeleteAction;
+use Contao\CoreBundle\Security\DataContainer\ReadAction;
+use Contao\CoreBundle\Security\DataContainer\UpdateAction;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
+
+trait TypeAccessTrait
+{
+    public function __construct(private readonly AccessDecisionManagerInterface $accessDecisionManager)
+    {
+    }
+
+    private function hasAccessToType(TokenInterface $token, string $attribute, CreateAction|DeleteAction|ReadAction|UpdateAction $action): bool
+    {
+        $types = [];
+
+        if (!$action instanceof CreateAction && isset($action->getCurrent()['type'])) {
+            $types[] = $action->getCurrent()['type'];
+        }
+
+        if (!$action instanceof DeleteAction && !$action instanceof ReadAction && isset($action->getNew()['type'])) {
+            $types[] = $action->getNew()['type'];
+        }
+
+        $types = array_unique($types);
+
+        if ([] === $types) {
+            return true;
+        }
+
+        foreach ($types as $type) {
+            if (!$this->accessDecisionManager->decide($token, [$attribute], $type)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/core-bundle/tests/Security/Voter/DataContainer/FrontendModulesVoterTest.php
+++ b/core-bundle/tests/Security/Voter/DataContainer/FrontendModulesVoterTest.php
@@ -27,9 +27,7 @@ class FrontendModulesVoterTest extends TestCase
 {
     public function testVoter(): void
     {
-        $accessDecisionManager = $this->createMock(AccessDecisionManagerInterface::class);
-
-        $voter = new FrontendModuleVoter($accessDecisionManager);
+        $voter = new FrontendModuleVoter($this->createMock(AccessDecisionManagerInterface::class));
 
         $this->assertTrue($voter->supportsAttribute(ContaoCorePermissions::DC_PREFIX.'tl_module'));
         $this->assertTrue($voter->supportsType(CreateAction::class));

--- a/core-bundle/tests/Security/Voter/DataContainer/FrontendModulesVoterTest.php
+++ b/core-bundle/tests/Security/Voter/DataContainer/FrontendModulesVoterTest.php
@@ -17,7 +17,7 @@ use Contao\CoreBundle\Security\DataContainer\CreateAction;
 use Contao\CoreBundle\Security\DataContainer\DeleteAction;
 use Contao\CoreBundle\Security\DataContainer\ReadAction;
 use Contao\CoreBundle\Security\DataContainer\UpdateAction;
-use Contao\CoreBundle\Security\Voter\DataContainer\FrontendModulesVoter;
+use Contao\CoreBundle\Security\Voter\DataContainer\FrontendModuleVoter;
 use Contao\CoreBundle\Tests\TestCase;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
@@ -29,7 +29,7 @@ class FrontendModulesVoterTest extends TestCase
     {
         $accessDecisionManager = $this->createMock(AccessDecisionManagerInterface::class);
 
-        $voter = new FrontendModulesVoter($accessDecisionManager);
+        $voter = new FrontendModuleVoter($accessDecisionManager);
 
         $this->assertTrue($voter->supportsAttribute(ContaoCorePermissions::DC_PREFIX.'tl_module'));
         $this->assertTrue($voter->supportsType(CreateAction::class));
@@ -68,7 +68,7 @@ class FrontendModulesVoterTest extends TestCase
             ])
         ;
 
-        $voter = new FrontendModulesVoter($accessDecisionManager);
+        $voter = new FrontendModuleVoter($accessDecisionManager);
 
         // Reading is always permitted, although type "listing" is not explicitly allowed
         $this->assertSame(


### PR DESCRIPTION
I have found several issues in the current frontend module permissions.

1. it did not check access to the module itself
2. I could not find that `USER_CAN_DELETE_FRONTEND_MODULE` would be for, I don't think that actually worked
3. Voters should not vote on the user object themselves, they all currently forward to the `BackendPermissionVoter`

/cc @bezin 