### PR TITLE
Add the `PageFinder::getCurrentPage()` method

### DIFF
--- a/core-bundle/config/services.yaml
+++ b/core-bundle/config/services.yaml
@@ -750,6 +750,7 @@ services:
         arguments:
             - '@contao.framework'
             - '@router'
+            - '@request_stack'
 
     contao.routing.page_registry:
         class: Contao\CoreBundle\Routing\Page\PageRegistry

--- a/core-bundle/config/services.yaml
+++ b/core-bundle/config/services.yaml
@@ -411,6 +411,7 @@ services:
               contao.image.factory: '@contao.image.factory'
               contao.image.resizer: '@contao.image.resizer'
               contao.assets.files_context: '@contao.assets.files_context'
+              contao.routing.page_finder: '@contao.routing.page_finder'
               contao.framework: '@contao.framework'
               event_dispatcher: '@event_dispatcher'
             - '%kernel.project_dir%'

--- a/core-bundle/src/Controller/AbstractFragmentController.php
+++ b/core-bundle/src/Controller/AbstractFragmentController.php
@@ -16,6 +16,7 @@ use Contao\CoreBundle\Controller\ContentElement\AbstractContentElementController
 use Contao\CoreBundle\Controller\FrontendModule\AbstractFrontendModuleController;
 use Contao\CoreBundle\EventListener\SubrequestCacheSubscriber;
 use Contao\CoreBundle\Fragment\FragmentOptionsAwareInterface;
+use Contao\CoreBundle\Routing\PageFinder;
 use Contao\CoreBundle\Routing\ScopeMatcher;
 use Contao\CoreBundle\Twig\FragmentTemplate;
 use Contao\CoreBundle\Twig\Interop\ContextFactory;
@@ -49,6 +50,7 @@ abstract class AbstractFragmentController extends AbstractController implements 
         $services = parent::getSubscribedServices();
 
         $services['request_stack'] = RequestStack::class;
+        $services['contao.routing.page_finder'] = PageFinder::class;
         $services['contao.routing.scope_matcher'] = ScopeMatcher::class;
         $services['contao.twig.filesystem_loader'] = ContaoFilesystemLoader::class;
         $services['contao.twig.interop.context_factory'] = ContextFactory::class;
@@ -58,17 +60,7 @@ abstract class AbstractFragmentController extends AbstractController implements 
 
     protected function getPageModel(): PageModel|null
     {
-        if (!$request = $this->container->get('request_stack')->getCurrentRequest()) {
-            return null;
-        }
-
-        $pageModel = $request->attributes->get('pageModel');
-
-        if ($pageModel instanceof PageModel) {
-            return $pageModel;
-        }
-
-        return null;
+        return $this->container->get('contao.routing.page_finder')->getCurrentPage();
     }
 
     /**

--- a/core-bundle/src/Image/Studio/FigureBuilder.php
+++ b/core-bundle/src/Image/Studio/FigureBuilder.php
@@ -818,7 +818,7 @@ class FigureBuilder
      */
     private function getFallbackLocaleList(): array
     {
-        $page = $GLOBALS['objPage'] ?? null;
+        $page = $this->locator->get('contao.routing.page_finder')->getCurrentPage();
 
         if (!$page instanceof PageModel) {
             return [];

--- a/core-bundle/src/Image/Studio/LightboxResult.php
+++ b/core-bundle/src/Image/Studio/LightboxResult.php
@@ -96,7 +96,7 @@ class LightboxResult
      */
     private function getDefaultLightboxSizeConfiguration(): array|null
     {
-        $page = $GLOBALS['objPage'] ?? null;
+        $page = $this->locator->get('contao.routing.page_finder')->getCurrentPage();
 
         if (!$page instanceof PageModel || null === $page->layout) {
             return null;

--- a/core-bundle/src/Routing/PageFinder.php
+++ b/core-bundle/src/Routing/PageFinder.php
@@ -24,7 +24,7 @@ class PageFinder
     public function __construct(
         private readonly ContaoFramework $framework,
         private readonly RequestMatcherInterface $requestMatcher,
-        private readonly RequestStack|null $requestStack = null,
+        private readonly RequestStack $requestStack,
     ) {
     }
 
@@ -33,11 +33,7 @@ class PageFinder
      */
     public function getCurrentPage(Request|null $request = null): PageModel|null
     {
-        if (!$request && $this->requestStack) {
-            $request = $this->requestStack->getCurrentRequest();
-        }
-
-        $pageModel = $request?->attributes->get('pageModel');
+        $pageModel = ($request ?? $this->requestStack->getCurrentRequest())?->attributes->get('pageModel');
 
         if ($pageModel instanceof PageModel) {
             return $pageModel;

--- a/core-bundle/src/Routing/PageFinder.php
+++ b/core-bundle/src/Routing/PageFinder.php
@@ -15,6 +15,7 @@ namespace Contao\CoreBundle\Routing;
 use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\PageModel;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\Exception\ExceptionInterface as RoutingExceptionInterface;
 use Symfony\Component\Routing\Matcher\RequestMatcherInterface;
 
@@ -23,7 +24,26 @@ class PageFinder
     public function __construct(
         private readonly ContaoFramework $framework,
         private readonly RequestMatcherInterface $requestMatcher,
+        private readonly RequestStack|null $requestStack = null,
     ) {
+    }
+
+    /**
+     * Returns the current page model from the given request or the current request.
+     */
+    public function getCurrentPage(Request|null $request = null): PageModel|null
+    {
+        if (!$request && $this->requestStack) {
+            $request = $this->requestStack->getCurrentRequest();
+        }
+
+        $pageModel = $request?->attributes->get('pageModel');
+
+        if ($pageModel instanceof PageModel) {
+            return $pageModel;
+        }
+
+        return null;
     }
 
     /**

--- a/core-bundle/tests/Controller/FrontendModule/RootPageDependentModulesControllerTest.php
+++ b/core-bundle/tests/Controller/FrontendModule/RootPageDependentModulesControllerTest.php
@@ -16,6 +16,7 @@ use Contao\Config;
 use Contao\Controller;
 use Contao\CoreBundle\Cache\EntityCacheTags;
 use Contao\CoreBundle\Controller\FrontendModule\RootPageDependentModulesController;
+use Contao\CoreBundle\Routing\PageFinder;
 use Contao\CoreBundle\Tests\TestCase;
 use Contao\ModuleModel;
 use Contao\PageModel;
@@ -26,6 +27,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Routing\Matcher\RequestMatcherInterface;
 
 class RootPageDependentModulesControllerTest extends TestCase
 {
@@ -134,10 +136,17 @@ class RootPageDependentModulesControllerTest extends TestCase
 
         $framework = $this->mockContaoFramework([Controller::class => $controllerAdapter, ModuleModel::class => $moduleAdapter]);
 
+        $pageFinder = new PageFinder(
+            $framework,
+            $this->createMock(RequestMatcherInterface::class),
+            $requestStack,
+        );
+
         $this->container->set('contao.framework', $framework);
+        $this->container->set('contao.routing.page_finder', $pageFinder);
         $this->container->set('contao.routing.scope_matcher', $this->mockScopeMatcher());
 
-        if ($requestStack instanceof RequestStack) {
+        if ($requestStack) {
             $this->container->set('request_stack', $requestStack);
         }
 

--- a/core-bundle/tests/Controller/FrontendModule/RootPageDependentModulesControllerTest.php
+++ b/core-bundle/tests/Controller/FrontendModule/RootPageDependentModulesControllerTest.php
@@ -139,7 +139,7 @@ class RootPageDependentModulesControllerTest extends TestCase
         $pageFinder = new PageFinder(
             $framework,
             $this->createMock(RequestMatcherInterface::class),
-            $requestStack,
+            $requestStack ?? new RequestStack(),
         );
 
         $this->container->set('contao.framework', $framework);

--- a/core-bundle/tests/Image/Studio/FigureBuilderTest.php
+++ b/core-bundle/tests/Image/Studio/FigureBuilderTest.php
@@ -27,6 +27,7 @@ use Contao\CoreBundle\Image\Studio\ImageResult;
 use Contao\CoreBundle\Image\Studio\LightboxResult;
 use Contao\CoreBundle\Image\Studio\Studio;
 use Contao\CoreBundle\InsertTag\InsertTagParser;
+use Contao\CoreBundle\Routing\PageFinder;
 use Contao\CoreBundle\String\HtmlAttributes;
 use Contao\CoreBundle\Tests\TestCase;
 use Contao\DcaLoader;
@@ -45,8 +46,10 @@ use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Filesystem\Path;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Fragment\FragmentHandler;
+use Symfony\Component\Routing\Matcher\RequestMatcherInterface;
 
 class FigureBuilderTest extends TestCase
 {
@@ -744,7 +747,11 @@ class FigureBuilderTest extends TestCase
         $currentPage->language = 'es';
         $currentPage->rootFallbackLanguage = 'de';
 
-        $GLOBALS['objPage'] = $currentPage;
+        $request = Request::create('https://localhost');
+        $request->attributes->set('pageModel', $currentPage);
+
+        $requestStack = $container->get('request_stack');
+        $requestStack->push($request);
 
         [$absoluteFilePath, $relativeFilePath] = $this->getTestFilePaths();
 
@@ -764,7 +771,7 @@ class FigureBuilderTest extends TestCase
         $framework = $this->mockContaoFramework([FilesModel::class => $filesModelAdapter]);
         $studio = $this->mockStudioForImage($absoluteFilePath);
 
-        $figure = $this->getFigureBuilder($studio, $framework)
+        $figure = $this->getFigureBuilder($studio, $framework, null, $requestStack)
             ->fromFilesModel($filesModel)
             ->setLocale($locale)
             ->setOverwriteMetadata($overwriteMetadata)
@@ -773,7 +780,7 @@ class FigureBuilderTest extends TestCase
 
         $this->assertSame($expectedMetadata, $figure->getMetadata()->all());
 
-        unset($GLOBALS['TL_DCA'], $GLOBALS['objPage']);
+        unset($GLOBALS['TL_DCA']);
     }
 
     public function provideMetadataAutoFetchCases(): \Generator
@@ -917,7 +924,6 @@ class FigureBuilderTest extends TestCase
             Metadata::VALUE_CAPTION => '',
         ];
 
-        // Note: $GLOBALS['objPage'] is not set at this point
         $this->assertSame($emptyMetadata, $figure->getMetadata()->all());
     }
 
@@ -926,7 +932,8 @@ class FigureBuilderTest extends TestCase
      */
     public function testAutoSetUuidFromFilesModelWhenDefiningMetadata(FilesModel|ImageInterface|string|null $resource, Metadata|null $metadataToSet, string|null $locale, array $expectedMetadata): void
     {
-        System::setContainer($this->getContainerWithContaoConfiguration());
+        $container = $this->getContainerWithContaoConfiguration();
+        System::setContainer($container);
 
         $GLOBALS['TL_DCA']['tl_files']['fields']['meta']['eval']['metaFields'] = ['title' => ''];
 
@@ -934,7 +941,10 @@ class FigureBuilderTest extends TestCase
         $currentPage->language = 'en';
         $currentPage->rootFallbackLanguage = 'de';
 
-        $GLOBALS['objPage'] = $currentPage;
+        $request = Request::create('https://localhost');
+        $request->attributes->set('pageModel', $currentPage);
+
+        $container->get('request_stack')->push($request);
 
         [$absoluteFilePath] = $this->getTestFilePaths();
 
@@ -965,7 +975,7 @@ class FigureBuilderTest extends TestCase
 
         $this->assertSame($expectedMetadata, $figure->getMetadata()->all());
 
-        unset($GLOBALS['TL_DCA'], $GLOBALS['objPage']);
+        unset($GLOBALS['TL_DCA']);
     }
 
     public function provideUuidMetadataAutoFetchCases(): \Generator
@@ -1470,16 +1480,23 @@ class FigureBuilderTest extends TestCase
         return $studio;
     }
 
-    private function getFigureBuilder(Studio|null $studio = null, ContaoFramework|null $framework = null, EventDispatcher|null $eventDispatcher = null): FigureBuilder
+    private function getFigureBuilder(Studio|null $studio = null, ContaoFramework|null $framework = null, EventDispatcher|null $eventDispatcher = null, RequestStack|null $requestStack = null): FigureBuilder
     {
         [, , $projectDir, $uploadPath, $webDir] = $this->getTestFilePaths();
         $validExtensions = $this->getTestFileExtensions();
+
+        $pageFinder = new PageFinder(
+            $framework ?? $this->mockContaoFramework(),
+            $this->createMock(RequestMatcherInterface::class),
+            $requestStack,
+        );
 
         $locator = $this->createMock(ContainerInterface::class);
         $locator
             ->method('get')
             ->willReturnMap([
                 ['contao.image.studio', $studio],
+                ['contao.routing.page_finder', $pageFinder],
                 ['contao.framework', $framework],
                 ['event_dispatcher', $eventDispatcher ?? new EventDispatcher()],
             ])

--- a/core-bundle/tests/Image/Studio/FigureBuilderTest.php
+++ b/core-bundle/tests/Image/Studio/FigureBuilderTest.php
@@ -747,12 +747,6 @@ class FigureBuilderTest extends TestCase
         $currentPage->language = 'es';
         $currentPage->rootFallbackLanguage = 'de';
 
-        $request = Request::create('https://localhost');
-        $request->attributes->set('pageModel', $currentPage);
-
-        $requestStack = $container->get('request_stack');
-        $requestStack->push($request);
-
         [$absoluteFilePath, $relativeFilePath] = $this->getTestFilePaths();
 
         $filesModel = $this->mockClassWithProperties(FilesModel::class, except: ['getMetadata']);
@@ -771,7 +765,7 @@ class FigureBuilderTest extends TestCase
         $framework = $this->mockContaoFramework([FilesModel::class => $filesModelAdapter]);
         $studio = $this->mockStudioForImage($absoluteFilePath);
 
-        $figure = $this->getFigureBuilder($studio, $framework, null, $requestStack)
+        $figure = $this->getFigureBuilder($studio, $framework, null, $currentPage)
             ->fromFilesModel($filesModel)
             ->setLocale($locale)
             ->setOverwriteMetadata($overwriteMetadata)
@@ -1480,10 +1474,16 @@ class FigureBuilderTest extends TestCase
         return $studio;
     }
 
-    private function getFigureBuilder(Studio|null $studio = null, ContaoFramework|null $framework = null, EventDispatcher|null $eventDispatcher = null, RequestStack|null $requestStack = null): FigureBuilder
+    private function getFigureBuilder(Studio|null $studio = null, ContaoFramework|null $framework = null, EventDispatcher|null $eventDispatcher = null, PageModel|null $pageModel = null): FigureBuilder
     {
         [, , $projectDir, $uploadPath, $webDir] = $this->getTestFilePaths();
         $validExtensions = $this->getTestFileExtensions();
+
+        $request = Request::create('https://localhost');
+        $request->attributes->set('pageModel', $pageModel);
+
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
 
         $pageFinder = new PageFinder(
             $framework ?? $this->mockContaoFramework(),

--- a/core-bundle/tests/Image/Studio/LightboxResultTest.php
+++ b/core-bundle/tests/Image/Studio/LightboxResultTest.php
@@ -15,12 +15,16 @@ namespace Contao\CoreBundle\Tests\Image\Studio;
 use Contao\CoreBundle\Image\Studio\ImageResult;
 use Contao\CoreBundle\Image\Studio\LightboxResult;
 use Contao\CoreBundle\Image\Studio\Studio;
+use Contao\CoreBundle\Routing\PageFinder;
 use Contao\CoreBundle\Tests\TestCase;
 use Contao\Image\ImageInterface;
 use Contao\Image\ResizeOptions;
 use Contao\LayoutModel;
 use Contao\PageModel;
 use Psr\Container\ContainerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Routing\Matcher\RequestMatcherInterface;
 
 class LightboxResultTest extends TestCase
 {
@@ -64,7 +68,17 @@ class LightboxResultTest extends TestCase
         $pageModel = $this->mockClassWithProperties(PageModel::class);
         $pageModel->layout = $layoutId;
 
-        $GLOBALS['objPage'] = $pageModel;
+        $request = Request::create('https://localhost');
+        $request->attributes->set('pageModel', $pageModel);
+
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
+        $pageFinder = new PageFinder(
+            $framework,
+            $this->createMock(RequestMatcherInterface::class),
+            $requestStack,
+        );
 
         $image = $this->createMock(ImageResult::class);
 
@@ -78,17 +92,15 @@ class LightboxResultTest extends TestCase
 
         $locator = $this->createMock(ContainerInterface::class);
         $locator
-            ->expects($this->exactly(2))
             ->method('get')
             ->willReturnMap([
                 ['contao.framework', $framework],
                 ['contao.image.studio', $studio],
+                ['contao.routing.page_finder', $pageFinder],
             ])
         ;
 
         new LightboxResult($locator, $resource, null);
-
-        unset($GLOBALS['objPage']);
     }
 
     public function testFallBackLightboxSizeConfigurationFailsIfNoLightboxSizeSet(): void
@@ -111,7 +123,17 @@ class LightboxResultTest extends TestCase
         $pageModel = $this->mockClassWithProperties(PageModel::class);
         $pageModel->layout = $layoutId;
 
-        $GLOBALS['objPage'] = $pageModel;
+        $request = Request::create('https://localhost');
+        $request->attributes->set('pageModel', $pageModel);
+
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
+        $pageFinder = new PageFinder(
+            $framework,
+            $this->createMock(RequestMatcherInterface::class),
+            $requestStack,
+        );
 
         $image = $this->createMock(ImageResult::class);
 
@@ -125,17 +147,15 @@ class LightboxResultTest extends TestCase
 
         $locator = $this->createMock(ContainerInterface::class);
         $locator
-            ->expects($this->exactly(2))
             ->method('get')
             ->willReturnMap([
                 ['contao.framework', $framework],
                 ['contao.image.studio', $studio],
+                ['contao.routing.page_finder', $pageFinder],
             ])
         ;
 
         new LightboxResult($locator, $resource, null);
-
-        unset($GLOBALS['objPage']);
     }
 
     public function testFallBackLightboxSizeConfigurationFailsIfNoPage(): void
@@ -154,15 +174,14 @@ class LightboxResultTest extends TestCase
 
         $locator = $this->createMock(ContainerInterface::class);
         $locator
-            ->expects($this->once())
             ->method('get')
             ->willReturnMap([
                 ['contao.framework', $framework],
                 ['contao.image.studio', $studio],
+                ['contao.routing.page_finder', $this->createMock(PageFinder::class)],
             ])
         ;
 
-        // Note: $GLOBALS['objPage'] is not set at this point
         new LightboxResult($locator, $resource, null);
     }
 

--- a/core-bundle/tests/Routing/PageFinderTest.php
+++ b/core-bundle/tests/Routing/PageFinderTest.php
@@ -64,16 +64,6 @@ class PageFinderTest extends TestCase
         $this->assertSame($pageModel, $pageFinder->getCurrentPage());
     }
 
-    public function testReturnsNullIfThereIsNoRequestStack(): void
-    {
-        $pageFinder = new PageFinder(
-            $this->mockContaoFramework(),
-            $this->createMock(RequestMatcherInterface::class),
-        );
-
-        $this->assertNull($pageFinder->getCurrentPage());
-    }
-
     public function testFindRootPageForHostReturnsNullIfRoutingHasNoPageModel(): void
     {
         $framework = $this->mockContaoFramework();
@@ -82,7 +72,7 @@ class PageFinderTest extends TestCase
             ->method('initialize')
         ;
 
-        $pageFinder = new PageFinder($framework, $this->mockRequestMatcher(null));
+        $pageFinder = new PageFinder($framework, $this->mockRequestMatcher(null), new RequestStack());
         $result = $pageFinder->findRootPageForHostAndLanguage('www.example.org');
 
         $this->assertNull($result);
@@ -102,7 +92,7 @@ class PageFinderTest extends TestCase
             ->willThrowException($this->createMock(ExceptionInterface::class))
         ;
 
-        $pageFinder = new PageFinder($framework, $requestMatcher);
+        $pageFinder = new PageFinder($framework, $requestMatcher, new RequestStack());
         $result = $pageFinder->findRootPageForHostAndLanguage('www.example.org');
 
         $this->assertNull($result);
@@ -118,7 +108,7 @@ class PageFinderTest extends TestCase
             ->method('initialize')
         ;
 
-        $pageFinder = new PageFinder($framework, $this->mockRequestMatcher($pageModel));
+        $pageFinder = new PageFinder($framework, $this->mockRequestMatcher($pageModel), new RequestStack());
         $result = $pageFinder->findRootPageForHostAndLanguage('www.example.org');
 
         $this->assertSame($pageModel, $result);
@@ -149,7 +139,7 @@ class PageFinderTest extends TestCase
             ->method('initialize')
         ;
 
-        $pageFinder = new PageFinder($framework, $this->mockRequestMatcher($regularPage));
+        $pageFinder = new PageFinder($framework, $this->mockRequestMatcher($regularPage), new RequestStack());
         $result = $pageFinder->findRootPageForHostAndLanguage('www.example.org');
 
         $this->assertSame($rootPage, $result);
@@ -174,7 +164,7 @@ class PageFinderTest extends TestCase
             ->willReturn(['pageModel' => $pageModel])
         ;
 
-        $pageFinder = new PageFinder($framework, $requestMatcher);
+        $pageFinder = new PageFinder($framework, $requestMatcher, new RequestStack());
         $result = $pageFinder->findRootPageForRequest($request);
 
         $this->assertSame($pageModel, $result);
@@ -208,7 +198,7 @@ class PageFinderTest extends TestCase
         $request = new Request();
         $request->attributes->set('pageModel', $regularPage);
 
-        $pageFinder = new PageFinder($framework, $this->mockRequestMatcher(false));
+        $pageFinder = new PageFinder($framework, $this->mockRequestMatcher(false), new RequestStack());
         $result = $pageFinder->findRootPageForRequest($request);
 
         $this->assertSame($rootPage, $result);
@@ -224,7 +214,7 @@ class PageFinderTest extends TestCase
             ->method('initialize')
         ;
 
-        $pageFinder = new PageFinder($framework, $this->mockRequestMatcher($pageModel, 'http://localhost'));
+        $pageFinder = new PageFinder($framework, $this->mockRequestMatcher($pageModel, 'http://localhost'), new RequestStack());
         $result = $pageFinder->findRootPageForHostAndLanguage('');
 
         $this->assertSame($pageModel, $result);


### PR DESCRIPTION
This is the first step towards deprecating `global $objPage`.