### PR TITLE
Make the `ParentAccessTrait::hasAccessToParent()` method private

### DIFF
--- a/core-bundle/src/Security/Voter/DataContainer/ParentAccessTrait.php
+++ b/core-bundle/src/Security/Voter/DataContainer/ParentAccessTrait.php
@@ -25,7 +25,7 @@ trait ParentAccessTrait
     {
     }
 
-    protected function hasAccessToParent(TokenInterface $token, string $attribute, CreateAction|DeleteAction|ReadAction|UpdateAction $action): bool
+    private function hasAccessToParent(TokenInterface $token, string $attribute, CreateAction|DeleteAction|ReadAction|UpdateAction $action): bool
     {
         $pids = [];
 


### PR DESCRIPTION
SInce the method is ever only used by the voter including the trait, it should never have been protected.