### PR TITLE
Return to the list view after adding items to the clipboard

### DIFF
--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -392,6 +392,8 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 			);
 
 			$objSession->set('CLIPBOARD', $arrClipboard);
+
+			$this->redirect($this->getReferer());
 		}
 
 		// Custom filter


### PR DESCRIPTION
A move or copy operation currently has a `href` like `act=paste&mode=copy&children=1`. When clicking the button, DC_Table will execute the `act = paste` handler, but render the view again because no actual action is given. But this means the `act=paste&mode=copy` will remain in the URL, even though is is completely unnecessary, because DC_Table will check the session for the clipboard information.

Having the properties in the URL however breaks all operations that do not explicitly remove them, e.g. moving to child records of a nested element.

I think we can safely return to the list view after copying, same as we do when selecting multiple records to copy.