### PR TITLE
Fix the traceable access decision manager

### DIFF
--- a/core-bundle/src/Security/Authentication/AccessDecisionManager.php
+++ b/core-bundle/src/Security/Authentication/AccessDecisionManager.php
@@ -21,6 +21,11 @@ use Symfony\Component\Security\Http\FirewallMapInterface;
 
 class AccessDecisionManager implements AccessDecisionManagerInterface
 {
+    /**
+     * Temporary workaround for symfony/symfony#54225.
+     *
+     * @phpstan-ignore-next-line
+     */
     private iterable $voters;
 
     /**

--- a/core-bundle/src/Security/Authentication/AccessDecisionManager.php
+++ b/core-bundle/src/Security/Authentication/AccessDecisionManager.php
@@ -21,6 +21,8 @@ use Symfony\Component\Security\Http\FirewallMapInterface;
 
 class AccessDecisionManager implements AccessDecisionManagerInterface
 {
+    private iterable $voters;
+
     /**
      * @internal
      */
@@ -30,6 +32,10 @@ class AccessDecisionManager implements AccessDecisionManagerInterface
         private readonly RequestStack $requestStack,
         private readonly FirewallMapInterface $firewallMap,
     ) {
+        if (property_exists($inner, 'voters')) {
+            $reflection = new \ReflectionProperty($inner::class, 'voters');
+            $this->voters = $reflection->getValue($inner);
+        }
     }
 
     public function decide(TokenInterface $token, array $attributes, $object = null): bool


### PR DESCRIPTION
Temporary fixes https://github.com/symfony/symfony/issues/54225 with a workaround, otherwise the security profiler is broken in Contao 5.3. The now-available data is technically correct (since all voters are always the same in the system), but it sure is not a nice solution…