### PR TITLE
Fix a regression with icons in dark mode

### DIFF
--- a/core-bundle/contao/library/Contao/Image.php
+++ b/core-bundle/contao/library/Contao/Image.php
@@ -159,10 +159,21 @@ class Image
 		$search = array('{alt}', '{attributes}');
 		$replace = array(StringUtil::specialchars($alt), $attributes ? ' ' . $attributes : '');
 
+		$darkAttributes = new HtmlAttributes($attributes);
+
+		foreach (array('data-icon', 'data-icon-disabled') as $icon)
+		{
+			if (isset($darkAttributes[$icon]))
+			{
+				$pathinfo = pathinfo($darkAttributes[$icon]);
+				$darkAttributes[$icon] = $pathinfo['filename'] . '--dark.' . $pathinfo['extension'];
+			}
+		}
+
 		if (str_contains($template, '{darkAttributes}'))
 		{
 			$search[] = '{darkAttributes}';
-			$replace[] = (new HtmlAttributes($attributes))->mergeWith(array('class' => 'color-scheme--dark', 'loading' => 'lazy'))->toString();
+			$replace[] = $darkAttributes->mergeWith(array('class' => 'color-scheme--dark', 'loading' => 'lazy'))->toString();
 		}
 
 		if (str_contains($template, '{lightAttributes}'))

--- a/core-bundle/contao/library/Contao/Image.php
+++ b/core-bundle/contao/library/Contao/Image.php
@@ -159,19 +159,19 @@ class Image
 		$search = array('{alt}', '{attributes}');
 		$replace = array(StringUtil::specialchars($alt), $attributes ? ' ' . $attributes : '');
 
-		$darkAttributes = new HtmlAttributes($attributes);
-
-		foreach (array('data-icon', 'data-icon-disabled') as $icon)
-		{
-			if (isset($darkAttributes[$icon]))
-			{
-				$pathinfo = pathinfo($darkAttributes[$icon]);
-				$darkAttributes[$icon] = $pathinfo['filename'] . '--dark.' . $pathinfo['extension'];
-			}
-		}
-
 		if (str_contains($template, '{darkAttributes}'))
 		{
+			$darkAttributes = new HtmlAttributes($attributes);
+
+			foreach (array('data-icon', 'data-icon-disabled') as $icon)
+			{
+				if (isset($darkAttributes[$icon]))
+				{
+					$pathinfo = pathinfo($darkAttributes[$icon]);
+					$darkAttributes[$icon] = $pathinfo['filename'] . '--dark.' . $pathinfo['extension'];
+				}
+			}
+
 			$search[] = '{darkAttributes}';
 			$replace[] = $darkAttributes->mergeWith(array('class' => 'color-scheme--dark', 'loading' => 'lazy'))->toString();
 		}


### PR DESCRIPTION
Fixes #7018 

#6982 reverted #6880 so the logic was reintroduced within the new getHtml method