### PR TITLE
Override the access decision strategy instead of the manager

### DIFF
--- a/core-bundle/config/services.yaml
+++ b/core-bundle/config/services.yaml
@@ -838,21 +838,6 @@ services:
     contao.search.delegating_indexer:
         class: Contao\CoreBundle\Search\Indexer\DelegatingIndexer
 
-    contao.security.access_decision_manager:
-        decorates: security.access.decision_manager
-        class: Contao\CoreBundle\Security\Authentication\AccessDecisionManager
-        arguments:
-            - '@.inner'
-            - '@contao.security.access_decision_manager.priority'
-            - '@request_stack'
-            - '@security.firewall.map'
-
-    contao.security.access_decision_manager.priority:
-        class: Symfony\Component\Security\Core\Authorization\AccessDecisionManager
-        arguments:
-            - !tagged_iterator security.voter
-            - '@contao.security.priority_strategy'
-
     contao.security.access_denied_handler:
         class: Contao\CoreBundle\Security\Authentication\AccessDeniedHandler
         arguments:
@@ -1005,9 +990,6 @@ services:
 
     contao.security.member_group_voter:
         class: Contao\CoreBundle\Security\Voter\MemberGroupVoter
-
-    contao.security.priority_strategy:
-        class: Symfony\Component\Security\Core\Authorization\Strategy\PriorityStrategy
 
     contao.security.token_checker:
         class: Contao\CoreBundle\Security\Authentication\Token\TokenChecker

--- a/core-bundle/config/services_debug.yaml
+++ b/core-bundle/config/services_debug.yaml
@@ -1,6 +1,0 @@
-services:
-    contao.debug.security.access.decision_manager:
-        class: Symfony\Component\Security\Core\Authorization\TraceableAccessDecisionManager
-        decorates: security.access.decision_manager
-        arguments:
-            - '@.inner'

--- a/core-bundle/src/ContaoCoreBundle.php
+++ b/core-bundle/src/ContaoCoreBundle.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Contao\CoreBundle;
 
 use Composer\InstalledVersions;
+use Contao\CoreBundle\DependencyInjection\Compiler\AccessDecisionStrategyPass;
 use Contao\CoreBundle\DependencyInjection\Compiler\AddAssetsPackagesPass;
 use Contao\CoreBundle\DependencyInjection\Compiler\AddAvailableTransportsPass;
 use Contao\CoreBundle\DependencyInjection\Compiler\AddCronJobsPass;
@@ -122,6 +123,7 @@ class ContaoCoreBundle extends Bundle
         $container->addCompilerPass(new LoggerChannelPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, -1);
         $container->addCompilerPass(new ConfigureFilesystemPass());
         $container->addCompilerPass(new AddInsertTagsPass());
+        $container->addCompilerPass(new AccessDecisionStrategyPass());
     }
 
     public static function getVersion(): string

--- a/core-bundle/src/DependencyInjection/Compiler/AccessDecisionStrategyPass.php
+++ b/core-bundle/src/DependencyInjection/Compiler/AccessDecisionStrategyPass.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\DependencyInjection\Compiler;
+
+use Contao\CoreBundle\Security\Authentication\ContaoStrategy;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\Security\Core\Authorization\Strategy\PriorityStrategy;
+
+/**
+ * @internal
+ */
+class AccessDecisionStrategyPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$container->hasDefinition('security.access.decision_manager')) {
+            return;
+        }
+
+        $accessDecisionManager = $container->getDefinition('security.access.decision_manager');
+        $originalStrategy = $accessDecisionManager->getArgument(1);
+
+        $strategy = new Definition(ContaoStrategy::class, [
+            $originalStrategy,
+            new Definition(PriorityStrategy::class),
+            new Reference('request_stack'),
+            new Reference('security.firewall.map'),
+        ]);
+
+        $accessDecisionManager->replaceArgument(1, $strategy);
+    }
+}

--- a/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
+++ b/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
@@ -212,10 +212,6 @@ class ContaoCoreExtension extends Extension implements PrependExtensionInterface
                 },
             );
         }
-
-        if ($container->hasParameter('kernel.debug') && $container->getParameter('kernel.debug')) {
-            $loader->load('services_debug.yaml');
-        }
     }
 
     public function configureFilesystem(FilesystemConfiguration $config): void

--- a/core-bundle/src/Security/Authentication/ContaoStrategy.php
+++ b/core-bundle/src/Security/Authentication/ContaoStrategy.php
@@ -22,7 +22,7 @@ class ContaoStrategy implements AccessDecisionStrategyInterface, \Stringable
 {
     public function __construct(
         private readonly AccessDecisionStrategyInterface $originalStrategy,
-        private readonly AccessDecisionStrategyInterface $priorityStrategy,
+        private readonly AccessDecisionStrategyInterface $contaoStrategy,
         private readonly RequestStack $requestStack,
         private readonly FirewallMapInterface $firewallMap,
     ) {
@@ -30,21 +30,19 @@ class ContaoStrategy implements AccessDecisionStrategyInterface, \Stringable
 
     public function __toString(): string
     {
-        if (!$this->isContaoContext()) {
-            if (method_exists($this->originalStrategy, '__toString')) {
-                return (string) $this->originalStrategy;
-            }
+        $strategy = $this->isContaoContext() ? $this->contaoStrategy : $this->originalStrategy;
 
-            return get_debug_type($this->originalStrategy);
+        if (method_exists($strategy, '__toString')) {
+            return (string) $strategy;
         }
 
-        return (string) $this->priorityStrategy;
+        return get_debug_type($strategy);
     }
 
     public function decide(\Traversable $results): bool
     {
         if ($this->isContaoContext()) {
-            return $this->priorityStrategy->decide($results);
+            return $this->contaoStrategy->decide($results);
         }
 
         return $this->originalStrategy->decide($results);

--- a/core-bundle/src/Security/Authentication/ContaoStrategy.php
+++ b/core-bundle/src/Security/Authentication/ContaoStrategy.php
@@ -21,7 +21,7 @@ use Symfony\Component\Security\Http\FirewallMapInterface;
 class ContaoStrategy implements AccessDecisionStrategyInterface, \Stringable
 {
     public function __construct(
-        private readonly AccessDecisionStrategyInterface $originalStrategy,
+        private readonly AccessDecisionStrategyInterface $defaultStrategy,
         private readonly AccessDecisionStrategyInterface $contaoStrategy,
         private readonly RequestStack $requestStack,
         private readonly FirewallMapInterface $firewallMap,
@@ -30,7 +30,7 @@ class ContaoStrategy implements AccessDecisionStrategyInterface, \Stringable
 
     public function __toString(): string
     {
-        $strategy = $this->isContaoContext() ? $this->contaoStrategy : $this->originalStrategy;
+        $strategy = $this->isContaoContext() ? $this->contaoStrategy : $this->defaultStrategy;
 
         if (method_exists($strategy, '__toString')) {
             return (string) $strategy;
@@ -45,7 +45,7 @@ class ContaoStrategy implements AccessDecisionStrategyInterface, \Stringable
             return $this->contaoStrategy->decide($results);
         }
 
-        return $this->originalStrategy->decide($results);
+        return $this->defaultStrategy->decide($results);
     }
 
     private function isContaoContext(): bool

--- a/core-bundle/tests/ContaoCoreBundleTest.php
+++ b/core-bundle/tests/ContaoCoreBundleTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Tests;
 
 use Contao\CoreBundle\ContaoCoreBundle;
+use Contao\CoreBundle\DependencyInjection\Compiler\AccessDecisionStrategyPass;
 use Contao\CoreBundle\DependencyInjection\Compiler\AddAssetsPackagesPass;
 use Contao\CoreBundle\DependencyInjection\Compiler\AddAvailableTransportsPass;
 use Contao\CoreBundle\DependencyInjection\Compiler\AddCronJobsPass;
@@ -76,6 +77,7 @@ class ContaoCoreBundleTest extends TestCase
             LoggerChannelPass::class,
             ConfigureFilesystemPass::class,
             AddInsertTagsPass::class,
+            AccessDecisionStrategyPass::class,
         ];
 
         $security = $this->createMock(SecurityExtension::class);

--- a/core-bundle/tests/DependencyInjection/Compiler/AccessDecisionStrategyPassTest.php
+++ b/core-bundle/tests/DependencyInjection/Compiler/AccessDecisionStrategyPassTest.php
@@ -65,7 +65,7 @@ class AccessDecisionStrategyPassTest extends TestCase
                             && PriorityStrategy::class === $definition->getArgument(1)->getClass()
                             && 'request_stack' === (string) $definition->getArgument(2)
                             && 'security.firewall.map' === (string) $definition->getArgument(3);
-                    }
+                    },
                 ),
             )
         ;

--- a/core-bundle/tests/DependencyInjection/Compiler/AccessDecisionStrategyPassTest.php
+++ b/core-bundle/tests/DependencyInjection/Compiler/AccessDecisionStrategyPassTest.php
@@ -59,7 +59,7 @@ class AccessDecisionStrategyPassTest extends TestCase
             ->with(
                 1,
                 $this->callback(
-                    static fn(Definition $definition) => $definition->getArgument(0) === $strategy
+                    static fn (Definition $definition) => $definition->getArgument(0) === $strategy
                         && $definition->getArgument(1) instanceof Definition
                         && PriorityStrategy::class === $definition->getArgument(1)->getClass()
                         && 'request_stack' === (string) $definition->getArgument(2)

--- a/core-bundle/tests/DependencyInjection/Compiler/AccessDecisionStrategyPassTest.php
+++ b/core-bundle/tests/DependencyInjection/Compiler/AccessDecisionStrategyPassTest.php
@@ -59,13 +59,11 @@ class AccessDecisionStrategyPassTest extends TestCase
             ->with(
                 1,
                 $this->callback(
-                    static function (Definition $definition) use ($strategy) {
-                        return $definition->getArgument(0) === $strategy
-                            && $definition->getArgument(1) instanceof Definition
-                            && PriorityStrategy::class === $definition->getArgument(1)->getClass()
-                            && 'request_stack' === (string) $definition->getArgument(2)
-                            && 'security.firewall.map' === (string) $definition->getArgument(3);
-                    },
+                    static fn(Definition $definition) => $definition->getArgument(0) === $strategy
+                        && $definition->getArgument(1) instanceof Definition
+                        && PriorityStrategy::class === $definition->getArgument(1)->getClass()
+                        && 'request_stack' === (string) $definition->getArgument(2)
+                        && 'security.firewall.map' === (string) $definition->getArgument(3),
                 ),
             )
         ;

--- a/core-bundle/tests/DependencyInjection/Compiler/AccessDecisionStrategyPassTest.php
+++ b/core-bundle/tests/DependencyInjection/Compiler/AccessDecisionStrategyPassTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\DependencyInjection\Compiler;
+
+use Contao\CoreBundle\DependencyInjection\Compiler\AccessDecisionStrategyPass;
+use Contao\CoreBundle\Tests\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\Security\Core\Authorization\Strategy\AccessDecisionStrategyInterface;
+use Symfony\Component\Security\Core\Authorization\Strategy\PriorityStrategy;
+
+class AccessDecisionStrategyPassTest extends TestCase
+{
+    public function testDoesNothingWithoutAccessDecisionManager(): void
+    {
+        $container = $this->createMock(ContainerBuilder::class);
+        $container
+            ->expects($this->once())
+            ->method('hasDefinition')
+            ->with('security.access.decision_manager')
+            ->willReturn(false)
+        ;
+
+        $container
+            ->expects($this->never())
+            ->method('getDefinition')
+            ->with('security.access.decision_manager')
+        ;
+
+        $pass = new AccessDecisionStrategyPass();
+        $pass->process($container);
+    }
+
+    public function testReplacesTheAccessDecisionStrategy(): void
+    {
+        $strategy = $this->createMock(AccessDecisionStrategyInterface::class);
+
+        $definition = $this->createMock(Definition::class);
+        $definition
+            ->expects($this->once())
+            ->method('getArgument')
+            ->with(1)
+            ->willReturn($strategy)
+        ;
+
+        $definition
+            ->expects($this->once())
+            ->method('replaceArgument')
+            ->with(
+                1,
+                $this->callback(
+                    static function (Definition $definition) use ($strategy) {
+                        return $definition->getArgument(0) === $strategy
+                            && $definition->getArgument(1) instanceof Definition
+                            && PriorityStrategy::class === $definition->getArgument(1)->getClass()
+                            && 'request_stack' === (string) $definition->getArgument(2)
+                            && 'security.firewall.map' === (string) $definition->getArgument(3);
+                    }
+                ),
+            )
+        ;
+
+        $container = $this->createMock(ContainerBuilder::class);
+        $container
+            ->expects($this->once())
+            ->method('hasDefinition')
+            ->with('security.access.decision_manager')
+            ->willReturn(true)
+        ;
+
+        $container
+            ->expects($this->once())
+            ->method('getDefinition')
+            ->with('security.access.decision_manager')
+            ->willReturn($definition)
+        ;
+
+        $pass = new AccessDecisionStrategyPass();
+        $pass->process($container);
+    }
+}

--- a/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
+++ b/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
@@ -44,7 +44,6 @@ use Symfony\Component\HttpKernel\EventListener\AbstractSessionListener;
 use Symfony\Component\HttpKernel\EventListener\ErrorListener;
 use Symfony\Component\HttpKernel\EventListener\LocaleListener as BaseLocaleListener;
 use Symfony\Component\HttpKernel\EventListener\RouterListener;
-use Symfony\Component\Security\Core\Authorization\TraceableAccessDecisionManager;
 use Symfony\Component\Security\Http\Firewall;
 
 class ContaoCoreExtensionTest extends TestCase
@@ -629,26 +628,6 @@ class ContaoCoreExtensionTest extends TestCase
         ;
 
         (new ContaoCoreExtension())->configureFilesystem($config);
-    }
-
-    public function testRegistersTraceableAccessDecisionMangerInDebug(): void
-    {
-        $container = new ContainerBuilder(
-            new ParameterBag([
-                'kernel.debug' => true,
-                'kernel.charset' => 'UTF-8',
-                'kernel.project_dir' => Path::normalize($this->getTempDir()),
-            ]),
-        );
-
-        $extension = new ContaoCoreExtension();
-        $extension->load([], $container);
-
-        $this->assertTrue($container->hasDefinition('contao.debug.security.access.decision_manager'));
-
-        $definition = $container->findDefinition('contao.debug.security.access.decision_manager');
-        $this->assertSame(TraceableAccessDecisionManager::class, $definition->getClass());
-        $this->assertSame('security.access.decision_manager', $definition->getDecoratedService()[0]);
     }
 
     public function testHstsSecurityConfiguration(): void

--- a/core-bundle/tests/Security/Authentication/ContaoStrategyTest.php
+++ b/core-bundle/tests/Security/Authentication/ContaoStrategyTest.php
@@ -24,7 +24,7 @@ use Symfony\Component\Security\Http\FirewallMapInterface;
 
 class ContaoStrategyTest extends TestCase
 {
-    public function testUsesOriginalDecisionManagerOnWrongFirewallMap(): void
+    public function testUsesDefaultDecisionStrageyOnWrongFirewallMap(): void
     {
         $accessDecisionManager = new ContaoStrategy(
             $this->mockAccessDecisionStrategy(true),
@@ -36,7 +36,7 @@ class ContaoStrategyTest extends TestCase
         $accessDecisionManager->decide($this->createMock(\Traversable::class));
     }
 
-    public function testUsesOriginalDecisionManagerIfNoRequestAvailable(): void
+    public function testUsesDefaultDecisionStrategyIfNoRequestAvailable(): void
     {
         $accessDecisionManager = new ContaoStrategy(
             $this->mockAccessDecisionStrategy(true),
@@ -48,7 +48,7 @@ class ContaoStrategyTest extends TestCase
         $accessDecisionManager->decide($this->createMock(\Traversable::class));
     }
 
-    public function testUsesOriginalDecisionManagerIfFirewallMapHasNoConfig(): void
+    public function testUsesDefaultDecisionStrategyIfFirewallMapHasNoConfig(): void
     {
         $requestStack = new RequestStack();
         $requestStack->push(new Request());


### PR DESCRIPTION
Contao is decorating the Symfony access decision manager, because we require to use the priority strategy in our firewall, but we don't want to alter the strategy in a possible firewall outside of Contao. Unfortunately, Symfony does not allow to define the voter strategy per firewall.

Our decoration causes several issues, mostly described in https://github.com/symfony/symfony/issues/54225. A quick fix was added in https://github.com/contao/contao/pull/7008.

Decorating the access decision manager causes all kind of issues in the profiler toolbar. We worked around some by decorating our own access decision manager with the Symfony TraceableAccessDecisionManager in debug mode. But Symfony also decorates all voters automatically to trace the voter definition, and these traced voters are only replaced on the original access decision manager. Our profiler therefore did not show all relevant information.

Because we only need to influence the strategy, we can simply decorate that instead of the full manager. Tracing and everything then works out of the box as usual in Symfony. We can even show the correct strategy in the profiler depending on the firewall context 🎉 

@fritzmg I think that closes https://github.com/symfony/symfony/issues/54225 (at least for us)
Also fixes https://github.com/contao/contao/issues/6988