### PR TITLE
Register theme templates in the global namespace, too

### DIFF
--- a/core-bundle/src/Twig/Loader/ContaoFilesystemLoader.php
+++ b/core-bundle/src/Twig/Loader/ContaoFilesystemLoader.php
@@ -332,33 +332,28 @@ class ContaoFilesystemLoader implements LoaderInterface, ResetInterface
      */
     private function buildInheritanceChains(): array
     {
-        /** @var list<array{string, string, string}> $sources */
+        /** @var list<array{string, string}> $sources */
         $sources = [];
 
         foreach ($this->templateLocator->findThemeDirectories() as $slug => $path) {
-            $sources[] = [$path, "Contao_Theme_$slug", ''];
-
-            // Register theme templates in the global namespace too for backwards compatibility
-            $sources[] = [$path, 'Contao_Global', Path::makeRelative($path, Path::join($this->projectDir, 'templates')).'/'];
+            $sources[] = [$path, "Contao_Theme_$slug"];
         }
 
-        $sources[] = [Path::join($this->projectDir, 'templates'), 'Contao_Global', ''];
+        $sources[] = [Path::join($this->projectDir, 'templates'), 'Contao_Global'];
 
         foreach ($this->templateLocator->findResourcesPaths() as $name => $resourcesPaths) {
             foreach ($resourcesPaths as $path) {
-                $sources[] = [$path, "Contao_$name", ''];
+                $sources[] = [$path, "Contao_$name"];
             }
         }
 
         // Lookup templates and build hierarchy
         $templatesByNamespace = [];
 
-        foreach ($sources as [$searchPath, $namespace, $shortNamePrefix]) {
+        foreach ($sources as [$searchPath, $namespace]) {
             $templates = $this->templateLocator->findTemplates($searchPath);
 
             foreach ($templates as $shortName => $templatePath) {
-                $shortName = $shortNamePrefix.$shortName;
-
                 if (null !== ($existingPath = $templatesByNamespace[$namespace][$shortName] ?? null)) {
                     $basePath = Path::getLongestCommonBasePath($templatePath, $existingPath);
 

--- a/core-bundle/src/Twig/Loader/TemplateLocator.php
+++ b/core-bundle/src/Twig/Loader/TemplateLocator.php
@@ -120,18 +120,10 @@ class TemplateLocator
             return [];
         }
 
-        $isThemePath = $this->isThemePath($path);
-
         $finder = (new Finder())
             ->files()
             ->in($path)
             ->name('/(\.twig|\.html5)$/')
-            ->filter(
-                // Never list templates from theme directories unless $path is a theme path. This
-                // ensures that you can still have theme directories inside any directory that is
-                // a namespace root.
-                fn (\SplFileInfo $info): bool => $isThemePath || !$this->isThemePath($info->getPath()),
-            )
             ->sortByName()
         ;
 
@@ -207,16 +199,5 @@ class TemplateLocator
 
         // Require a marker file everywhere else
         return $this->filesystem->exists(Path::join($path, self::FILE_MARKER_NAMESPACE_ROOT));
-    }
-
-    private function isThemePath(string $path): bool
-    {
-        foreach ($this->themeDirectories ?? $this->findThemeDirectories() as $themeBasePath) {
-            if ($themeBasePath === $path || Path::isBasePath($themeBasePath, $path)) {
-                return true;
-            }
-        }
-
-        return false;
     }
 }

--- a/core-bundle/tests/Twig/Loader/ContaoFilesystemLoaderTest.php
+++ b/core-bundle/tests/Twig/Loader/ContaoFilesystemLoaderTest.php
@@ -335,6 +335,7 @@ class ContaoFilesystemLoaderTest extends TestCase
                 Path::join($projectDir, 'templates/text.html.twig') => '@Contao_Global/text.html.twig',
                 Path::join($projectDir, 'contao/templates/some/random/text.html.twig') => '@Contao_App/text.html.twig',
             ],
+            'my/theme/text' => [Path::join($projectDir, 'templates/my/theme/text.html.twig') => '@Contao_Global/my/theme/text.html.twig'],
             'nested-dir/foo' => [Path::join($projectDir, 'contao/templates/other/nested-dir/foo.html.twig') => '@Contao_App/nested-dir/foo.html.twig'],
             'bar' => [Path::join($projectDir, 'src/Resources/contao/templates/bar.html.twig') => '@Contao_App/bar.html.twig'],
         ];
@@ -357,6 +358,7 @@ class ContaoFilesystemLoaderTest extends TestCase
                     Path::join($projectDir, 'templates/text.html.twig') => '@Contao_Global/text.html.twig',
                     Path::join($projectDir, 'contao/templates/some/random/text.html.twig') => '@Contao_App/text.html.twig',
                 ],
+                'my/theme/text' => [Path::join($projectDir, 'templates/my/theme/text.html.twig') => '@Contao_Global/my/theme/text.html.twig'],
                 'nested-dir/foo' => [Path::join($projectDir, 'contao/templates/other/nested-dir/foo.html.twig') => '@Contao_App/nested-dir/foo.html.twig'],
                 'bar' => [Path::join($projectDir, 'src/Resources/contao/templates/bar.html.twig') => '@Contao_App/bar.html.twig'],
             ],
@@ -437,6 +439,7 @@ class ContaoFilesystemLoaderTest extends TestCase
                 $fooPath = Path::join($projectDir, 'vendor-bundles/FooBundle/templates/any/text.html.twig') => '@Contao_FooBundle/text.html.twig',
                 $corePath = Path::join($projectDir, 'vendor-bundles/CoreBundle/Resources/contao/templates/text.html.twig') => '@Contao_CoreBundle/text.html.twig',
             ],
+            'my/theme/text' => [Path::join($projectDir, 'templates/my/theme/text.html.twig') => '@Contao_Global/my/theme/text.html.twig'],
             'nested-dir/foo' => [Path::join($projectDir, 'contao/templates/other/nested-dir/foo.html.twig') => '@Contao_App/nested-dir/foo.html.twig'],
             'bar' => [Path::join($projectDir, 'src/Resources/contao/templates/bar.html.twig') => '@Contao_App/bar.html.twig'],
         ];

--- a/core-bundle/tests/Twig/Loader/TemplateLocatorTest.php
+++ b/core-bundle/tests/Twig/Loader/TemplateLocatorTest.php
@@ -183,6 +183,7 @@ class TemplateLocatorTest extends TestCase
 
         $expectedTemplates = [
             'content_element/foo.html.twig' => Path::join($projectDir, 'templates/content_element/foo.html.twig'),
+            'my/theme/content_element/bar.html.twig' => Path::join($projectDir, 'templates/my/theme/content_element/bar.html.twig'),
         ];
 
         $expectedThemeTemplates = [


### PR DESCRIPTION
Followup to #6936

Not sure if this is the correct thing to do, but it restores the behavior of 5.3.0 and fixes https://github.com/madeyourday/contao-rocksolid-custom-elements/issues/172

Before Contao 5.3.1 a template in a theme folder was registered as `@Contao_Global/my_theme/foo.html.twig` as well as `@Contao_Theme_my_theme/foo.html.twig`. I think we should restore this behavior for backwards compatibility.

The current behavior would also be confusing for people that use folders like `content_element` in the theme configuration for export purposes.

@m-vo Are there any downsides in doing this?