### PR TITLE
Update the DBAFS cache when creating files

### DIFF
--- a/core-bundle/src/Filesystem/Dbafs/Dbafs.php
+++ b/core-bundle/src/Filesystem/Dbafs/Dbafs.php
@@ -216,6 +216,12 @@ class Dbafs implements DbafsInterface, ResetInterface
         $this->applyChangeSet($changeSet, $allUuidsByPath);
 
         // Update previously cached items
+        foreach ($changeSet->getItemsToCreate() as $itemToCreate) {
+            if (\array_key_exists($path = $itemToCreate->getPath(), $this->records)) {
+                unset($this->records[$path]);
+            }
+        }
+
         foreach ($changeSet->getItemsToUpdate() as $itemToUpdate) {
             $path = $itemToUpdate->getExistingPath();
 

--- a/core-bundle/tests/Functional/DbafsTest.php
+++ b/core-bundle/tests/Functional/DbafsTest.php
@@ -118,6 +118,7 @@ class DbafsTest extends FunctionalTestCase
         $this->assertTrue($this->filesystem->has('foo'));
 
         $contents = $this->filesystem->listContents('')->toArray();
+
         $this->assertCount(1, $contents);
         $this->assertSame('foo', $contents[0]->getPath());
     }

--- a/core-bundle/tests/Functional/DbafsTest.php
+++ b/core-bundle/tests/Functional/DbafsTest.php
@@ -108,7 +108,7 @@ class DbafsTest extends FunctionalTestCase
 
     public function testCreateAndAccessFile(): void
     {
-        // Make the DBAFS cache, that 'foo' does not exist
+        // Ensure that "foo" is marked as non-existent resource in the DBFAS cache
         $this->assertFalse($this->filesystem->fileExists('foo'));
 
         // Creating a file should update the cache

--- a/core-bundle/tests/Functional/DbafsTest.php
+++ b/core-bundle/tests/Functional/DbafsTest.php
@@ -116,6 +116,10 @@ class DbafsTest extends FunctionalTestCase
 
         $this->assertTrue($this->filesystem->fileExists('foo'));
         $this->assertTrue($this->filesystem->has('foo'));
+
+        $contents = $this->filesystem->listContents('')->toArray();
+        $this->assertCount(1, $contents);
+        $this->assertSame('foo', $contents[0]->getPath());
     }
 
     private function assertFile1MovedAndFile3Created(ChangeSet $changeSet): void

--- a/core-bundle/tests/Functional/DbafsTest.php
+++ b/core-bundle/tests/Functional/DbafsTest.php
@@ -106,6 +106,18 @@ class DbafsTest extends FunctionalTestCase
         $this->assertCount(0, $contents);
     }
 
+    public function testCreateAndAccessFile(): void
+    {
+        // Make the DBAFS cache, that 'foo' does not exist
+        $this->assertFalse($this->filesystem->fileExists('foo'));
+
+        // Creating a file should update the cache
+        $this->filesystem->write('foo', 'bar');
+
+        $this->assertTrue($this->filesystem->fileExists('foo'));
+        $this->assertTrue($this->filesystem->has('foo'));
+    }
+
     private function assertFile1MovedAndFile3Created(ChangeSet $changeSet): void
     {
         // Items to create


### PR DESCRIPTION
I agree with the general idea of the changes in #6973. IMHO we should keep generating cache entries lazy, though + the fix must also be applied to 4.13. This is why I created this PR as an alternative.

/cc @Toflar 