### PR TITLE
Harden mime type handling in the `FilesystemItem` class

### DIFF
--- a/core-bundle/src/Filesystem/FilesystemItem.php
+++ b/core-bundle/src/Filesystem/FilesystemItem.php
@@ -125,7 +125,7 @@ class FilesystemItem implements \Stringable
             return false;
         }
 
-        return str_starts_with($this->getMimeType(), 'video/');
+        return str_starts_with($this->getMimeType(''), 'video/');
     }
 
     public function isAudio(): bool
@@ -134,7 +134,7 @@ class FilesystemItem implements \Stringable
             return false;
         }
 
-        return str_starts_with($this->getMimeType(), 'audio/');
+        return str_starts_with($this->getMimeType(''), 'audio/');
     }
 
     public function isImage(): bool
@@ -143,7 +143,7 @@ class FilesystemItem implements \Stringable
             return false;
         }
 
-        return str_starts_with($this->getMimeType(), 'image/');
+        return str_starts_with($this->getMimeType(''), 'image/');
     }
 
     public function isPdf(): bool
@@ -152,7 +152,7 @@ class FilesystemItem implements \Stringable
             return false;
         }
 
-        return 'application/pdf' === $this->getMimeType();
+        return 'application/pdf' === $this->getMimeType('');
     }
 
     public function isSpreadsheet(): bool
@@ -162,7 +162,7 @@ class FilesystemItem implements \Stringable
         }
 
         return \in_array(
-            $this->getMimeType(),
+            $this->getMimeType(''),
             [
                 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
                 'application/vnd.ms-excel',
@@ -246,12 +246,12 @@ class FilesystemItem implements \Stringable
             default => 'MediaObject',
         };
 
-        $jsonLd = [
+        $jsonLd = array_filter([
             '@type' => $type,
             'identifier' => $fileIdentifier,
             'contentUrl' => $this->getPath(),
-            'encodingFormat' => $this->getMimeType(),
-        ];
+            'encodingFormat' => $this->getMimeType(''),
+        ]);
 
         if ($this->getMetaData()) {
             $jsonLd = [...$this->getMetaData()->getSchemaOrgData($type), ...$jsonLd];

--- a/core-bundle/tests/Filesystem/FilesystemItemTest.php
+++ b/core-bundle/tests/Filesystem/FilesystemItemTest.php
@@ -97,7 +97,7 @@ class FilesystemItemTest extends TestCase
     /**
      * @dataProvider provideSchemaOrgData
      */
-    public function testGettingSchemaOrgData(string $path, string $mimeType, array $expectedSchema): void
+    public function testGettingSchemaOrgData(string $path, string|null $mimeType, array $expectedSchema): void
     {
         $fileItem = new FilesystemItem(
             true,
@@ -386,6 +386,17 @@ class FilesystemItemTest extends TestCase
                 '@type' => 'MediaObject',
                 'contentUrl' => 'foo/bar.sql',
                 'encodingFormat' => 'application/sql',
+                'identifier' => '#/schema/file/2fcae369-c955-4b43-bcf9-d069f9d25542',
+                'name' => 'My title!',
+            ],
+        ];
+
+        yield 'Test a file with unknown mime type' => [
+            'foo/bar.whatisthis',
+            null,
+            [
+                '@type' => 'MediaObject',
+                'contentUrl' => 'foo/bar.whatisthis',
                 'identifier' => '#/schema/file/2fcae369-c955-4b43-bcf9-d069f9d25542',
                 'name' => 'My title!',
             ],


### PR DESCRIPTION
Fixes #6992 by adding a fallback to the `getMimeType()` calls that are issued when compiling schema org data.

@greenertux Can you check if this fixes your issue?