### PR TITLE
Add the `csp_unsafe_inline_style` Twig filter

### DIFF
--- a/core-bundle/contao/library/Contao/TemplateTrait.php
+++ b/core-bundle/contao/library/Contao/TemplateTrait.php
@@ -190,9 +190,22 @@ trait TemplateTrait
 	}
 
 	/**
-	 * Adds a CSP hash for a given inline style and also adds the 'unsafe-hashes' source to the directive automatically.
+	 * @deprecated Deprecated since Contao 5.4, to be removed in Contao 6;
+	 *             use cspUnsafeInlineStyle() instead.
 	 */
 	public function cspInlineStyle(string $style, string $algorithm = 'sha384'): string
+	{
+		trigger_deprecation('contao/core-bundle', '5.4', 'Using "%s()" has been deprecated and will no longer work in Contao 6. Use "cspUnsafeInlineStyle()" instead.', __METHOD__);
+
+		return $this->cspUnsafeInlineStyle($style, $algorithm);
+	}
+
+	/**
+	 * Attention: only pass trusted styles to this method!
+	 *
+	 * Adds a CSP hash for a given inline style and also adds the 'unsafe-hashes' source to the directive automatically.
+	 */
+	public function cspUnsafeInlineStyle(string $style, string $algorithm = 'sha384'): string
 	{
 		$responseContext = System::getContainer()->get('contao.routing.response_context_accessor')->getResponseContext();
 
@@ -210,7 +223,7 @@ trait TemplateTrait
 
 	/**
 	 * Extracts all inline CSS style attributes of a given HTML string and automatically adds CSP hashes for those
-	 * to the current response context.
+	 * to the current response context. The list of allowed styles can be configured in contao.csp.allowed_inline_styles.
 	 */
 	public function cspInlineStyles(string|null $html): string|null
 	{

--- a/core-bundle/contao/library/Contao/TemplateTrait.php
+++ b/core-bundle/contao/library/Contao/TemplateTrait.php
@@ -201,9 +201,9 @@ trait TemplateTrait
 	}
 
 	/**
-	 * Attention: only pass trusted styles to this method!
-	 *
 	 * Adds a CSP hash for a given inline style and also adds the 'unsafe-hashes' source to the directive automatically.
+	 *
+	 * ATTENTION: Only pass trusted styles to this method!
 	 */
 	public function cspUnsafeInlineStyle(string $style, string $algorithm = 'sha384'): string
 	{

--- a/core-bundle/contao/library/Contao/TemplateTrait.php
+++ b/core-bundle/contao/library/Contao/TemplateTrait.php
@@ -190,12 +190,12 @@ trait TemplateTrait
 	}
 
 	/**
-	 * @deprecated Deprecated since Contao 5.4, to be removed in Contao 6;
+	 * @deprecated Deprecated since Contao 5.3, to be removed in Contao 6;
 	 *             use cspUnsafeInlineStyle() instead.
 	 */
 	public function cspInlineStyle(string $style, string $algorithm = 'sha384'): string
 	{
-		trigger_deprecation('contao/core-bundle', '5.4', 'Using "%s()" has been deprecated and will no longer work in Contao 6. Use "cspUnsafeInlineStyle()" instead.', __METHOD__);
+		trigger_deprecation('contao/core-bundle', '5.3', 'Using "%s()" has been deprecated and will no longer work in Contao 6. Use "cspUnsafeInlineStyle()" instead.', __METHOD__);
 
 		return $this->cspUnsafeInlineStyle($style, $algorithm);
 	}
@@ -253,7 +253,7 @@ trait TemplateTrait
 			$csp->addHash('style-src', $style);
 		}
 
-		$csp->addSource('style-src', 'unsafe-hashes');
+		$csp->addSource('style-src', "'unsafe-hashes'");
 
 		return $html;
 	}

--- a/core-bundle/contao/templates/forms/form_captcha.html5
+++ b/core-bundle/contao/templates/forms/form_captcha.html5
@@ -18,7 +18,7 @@
   <input type="hidden" name="<?= $this->name ?>_hash<?= $this->hasErrors() ? 1 + $this->sum ** 2 : '' ?>" value="<?= $this->hasErrors() ? $this->getHash() : '' ?>">
 
   <?php if (!$this->hasErrors()): ?>
-    <div style="<?= $this->cspInlineStyle('display:none') ?>">
+    <div style="<?= $this->cspUnsafeInlineStyle('display:none') ?>">
       <label for="ctrl_<?= $this->id ?>_hp">Do not fill in this field</label>
       <input type="text" name="<?= $this->name ?>_name" id="ctrl_<?= $this->id ?>_hp" value="">
     </div>

--- a/core-bundle/contao/templates/modules/mod_two_factor.html5
+++ b/core-bundle/contao/templates/modules/mod_two_factor.html5
@@ -20,7 +20,7 @@
         </div>
         <div class="widget">
           <p><?= $this->trans('MSC.twoFactorTextCode') ?></p>
-          <code style="<?= $this->cspInlineStyle('word-break:break-all') ?>"><?= $this->secret ?></code>
+          <code style="<?= $this->cspUnsafeInlineStyle('word-break:break-all') ?>"><?= $this->secret ?></code>
         </div>
         <div class="widget widget-text">
           <label for="verify"><?= $this->trans('MSC.twoFactorVerification') ?></label>

--- a/core-bundle/src/Twig/Extension/ContaoExtension.php
+++ b/core-bundle/src/Twig/Extension/ContaoExtension.php
@@ -308,6 +308,11 @@ final class ContaoExtension extends AbstractExtension implements GlobalsInterfac
                 ['is_safe' => ['html']],
             ),
             new TwigFilter(
+                'csp_unsafe_inline_style',
+                [CspRuntime::class, 'unsafeInlineStyle'],
+                ['preserves_safety' => ['html']],
+            ),
+            new TwigFilter(
                 'csp_inline_styles',
                 [CspRuntime::class, 'inlineStyles'],
                 ['preserves_safety' => ['html']],

--- a/core-bundle/src/Twig/FragmentTemplate.php
+++ b/core-bundle/src/Twig/FragmentTemplate.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Twig;
 
 use Contao\CoreBundle\Asset\ContaoContext;
+use Contao\CoreBundle\String\HtmlAttributes;
 use Contao\Model;
 use Contao\Template;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -467,6 +468,62 @@ final class FragmentTemplate extends Template
      * @internal
      */
     public function addSchemaOrg(array $jsonLd): never
+    {
+        self::throwOnAccess();
+    }
+
+    /**
+     * @internal
+     */
+    public function attr(HtmlAttributes|iterable|string|null $attributes = null): never
+    {
+        self::throwOnAccess();
+    }
+
+    /**
+     * @internal
+     */
+    public function nonce(string $directive): never
+    {
+        self::throwOnAccess();
+    }
+
+    /**
+     * @internal
+     */
+    public function addCspSource(array|string $directives, string $source): never
+    {
+        self::throwOnAccess();
+    }
+
+    /**
+     * @internal
+     */
+    public function addCspHash(string $directive, string $script, string $algorithm = 'sha384'): never
+    {
+        self::throwOnAccess();
+    }
+
+    /**
+     * @internal
+     */
+    public function cspInlineStyle(string $style, string $algorithm = 'sha384'): never
+    {
+        self::throwOnAccess();
+    }
+
+    /**
+     * @internal
+     */
+    public function cspUnsafeInlineStyle(string $style, string $algorithm = 'sha384'): never
+    {
+        self::throwOnAccess();
+    }
+
+    /**
+     * @internal
+     */
+    public function cspInlineStyles(string|null $html): never
     {
         self::throwOnAccess();
     }

--- a/core-bundle/src/Twig/Runtime/CspRuntime.php
+++ b/core-bundle/src/Twig/Runtime/CspRuntime.php
@@ -88,7 +88,7 @@ final class CspRuntime implements RuntimeExtensionInterface
             $csp->addHash('style-src', $style);
         }
 
-        $csp->addSource('style-src', 'unsafe-hashes');
+        $csp->addSource('style-src', "'unsafe-hashes'");
 
         return $htmlOrAttributes;
     }

--- a/core-bundle/src/Twig/Runtime/CspRuntime.php
+++ b/core-bundle/src/Twig/Runtime/CspRuntime.php
@@ -15,6 +15,7 @@ namespace Contao\CoreBundle\Twig\Runtime;
 use Contao\CoreBundle\Csp\WysiwygStyleProcessor;
 use Contao\CoreBundle\Routing\ResponseContext\Csp\CspHandler;
 use Contao\CoreBundle\Routing\ResponseContext\ResponseContextAccessor;
+use Contao\CoreBundle\String\HtmlAttributes;
 use Nelmio\SecurityBundle\Twig\CSPRuntime as NelmioCSPRuntime;
 use Twig\Extension\RuntimeExtensionInterface;
 
@@ -30,16 +31,55 @@ final class CspRuntime implements RuntimeExtensionInterface
     ) {
     }
 
-    public function inlineStyles(string $htmlFragment): string
+    /**
+     * Attention: only pass trusted styles to this filter!
+     *
+     * Adds a CSP hash for a given inline style or attributes object and also adds the 'unsafe-hashes' source to the directive automatically.
+     */
+    public function unsafeInlineStyle(HtmlAttributes|string $styleAttribute): HtmlAttributes|string
+    {
+        if ($styleAttribute instanceof HtmlAttributes) {
+            $style = $styleAttribute['style'] ?? '';
+        } else {
+            $style = $styleAttribute;
+        }
+
+        if ('' === $style) {
+            return $styleAttribute;
+        }
+
+        $responseContext = $this->responseContextAccessor->getResponseContext();
+
+        if ($responseContext?->has(CspHandler::class)) {
+            $csp = $responseContext->get(CspHandler::class);
+            $csp
+                ->addHash('style-src', $style)
+                ->addSource('style-src', "'unsafe-hashes'")
+            ;
+        }
+
+        return $styleAttribute;
+    }
+
+    /**
+     * Extracts all inline CSS style attributes of a given HTML string or attributes object and automatically adds CSP hashes for those to the current response context. The list of allowed styles can be configured in contao.csp.allowed_inline_styles.
+     */
+    public function inlineStyles(HtmlAttributes|string $htmlOrAttributes): HtmlAttributes|string
     {
         $responseContext = $this->responseContextAccessor->getResponseContext();
 
         if (!$responseContext?->has(CspHandler::class)) {
-            return $htmlFragment;
+            return $htmlOrAttributes;
+        }
+
+        if ($htmlOrAttributes instanceof HtmlAttributes) {
+            $htmlFragment = "<div$htmlOrAttributes></div>";
+        } else {
+            $htmlFragment = $htmlOrAttributes;
         }
 
         if (!$styles = $this->wysiwygProcessor->extractStyles($htmlFragment)) {
-            return $htmlFragment;
+            return $htmlOrAttributes;
         }
 
         $csp = $responseContext->get(CspHandler::class);
@@ -50,7 +90,7 @@ final class CspRuntime implements RuntimeExtensionInterface
 
         $csp->addSource('style-src', 'unsafe-hashes');
 
-        return $htmlFragment;
+        return $htmlOrAttributes;
     }
 
     public function getNonce(string $directive): string|null

--- a/core-bundle/src/Twig/Runtime/CspRuntime.php
+++ b/core-bundle/src/Twig/Runtime/CspRuntime.php
@@ -32,9 +32,10 @@ final class CspRuntime implements RuntimeExtensionInterface
     }
 
     /**
-     * Attention: only pass trusted styles to this filter!
+     * Adds a CSP hash for a given inline style or attributes object and also adds the
+     * 'unsafe-hashes' source to the directive automatically.
      *
-     * Adds a CSP hash for a given inline style or attributes object and also adds the 'unsafe-hashes' source to the directive automatically.
+     * ATTENTION: Only pass trusted styles to this filter!
      */
     public function unsafeInlineStyle(HtmlAttributes|string $styleAttribute): HtmlAttributes|string
     {
@@ -62,7 +63,9 @@ final class CspRuntime implements RuntimeExtensionInterface
     }
 
     /**
-     * Extracts all inline CSS style attributes of a given HTML string or attributes object and automatically adds CSP hashes for those to the current response context. The list of allowed styles can be configured in contao.csp.allowed_inline_styles.
+     * Extracts all inline CSS style attributes of a given HTML string or attributes object
+     * and automatically adds CSP hashes for those to the current response context. The list
+     * of allowed styles can be configured in contao.csp.allowed_inline_styles.
      */
     public function inlineStyles(HtmlAttributes|string $htmlOrAttributes): HtmlAttributes|string
     {

--- a/core-bundle/tests/Contao/TemplateTest.php
+++ b/core-bundle/tests/Contao/TemplateTest.php
@@ -524,7 +524,7 @@ class TemplateTest extends TestCase
         $style = 'display:none';
         $algorithm = 'sha384';
 
-        $result = (new FrontendTemplate())->cspInlineStyle($style, $algorithm);
+        $result = (new FrontendTemplate())->cspUnsafeInlineStyle($style, $algorithm);
 
         $response = new Response();
         $cspHandler->applyHeaders($response);

--- a/core-bundle/tests/Twig/Extension/ContaoExtensionTest.php
+++ b/core-bundle/tests/Twig/Extension/ContaoExtensionTest.php
@@ -131,6 +131,7 @@ class ContaoExtensionTest extends TestCase
             'highlight_auto',
             'format_bytes',
             'sanitize_html',
+            'csp_unsafe_inline_style',
             'csp_inline_styles',
             'encode_email',
         ];

--- a/core-bundle/tests/Twig/Runtime/CspRuntimeTest.php
+++ b/core-bundle/tests/Twig/Runtime/CspRuntimeTest.php
@@ -143,6 +143,7 @@ class CspRuntimeTest extends TestCase
 
         $response = new Response();
         $cspHandler->applyHeaders($response);
+
         $this->assertSame(
             "style-src 'self' 'unsafe-hashes' 'unsafe-inline' 'sha256-w6uP8Tcg6K2QR905Rms8iXTlksL6OD1KOWBxTK7wxPI=' 'sha256-8f935d27GvUutRyY9yWScUMiFUk4WTdZURISiYfPOeQ='",
             $response->headers->get('Content-Security-Policy'),
@@ -189,6 +190,7 @@ class CspRuntimeTest extends TestCase
 
         $response = new Response();
         $cspHandler->applyHeaders($response);
+
         $this->assertSame(
             "style-src 'self' 'unsafe-hashes' 'unsafe-inline' 'sha256-G9KEe21cICJs7ADRF9jwf63CdC5OJI1mO2LVlv63cUY=' 'sha256-8f935d27GvUutRyY9yWScUMiFUk4WTdZURISiYfPOeQ='",
             $response->headers->get('Content-Security-Policy'),

--- a/core-bundle/tests/Twig/Runtime/CspRuntimeTest.php
+++ b/core-bundle/tests/Twig/Runtime/CspRuntimeTest.php
@@ -16,6 +16,7 @@ use Contao\CoreBundle\Csp\WysiwygStyleProcessor;
 use Contao\CoreBundle\Routing\ResponseContext\Csp\CspHandler;
 use Contao\CoreBundle\Routing\ResponseContext\ResponseContext;
 use Contao\CoreBundle\Routing\ResponseContext\ResponseContextAccessor;
+use Contao\CoreBundle\String\HtmlAttributes;
 use Contao\CoreBundle\Tests\TestCase;
 use Contao\CoreBundle\Twig\Runtime\CspRuntime;
 use Nelmio\SecurityBundle\ContentSecurityPolicy\DirectiveSet;
@@ -118,6 +119,36 @@ class CspRuntimeTest extends TestCase
         $this->assertSame(sprintf("script-src 'self' '%s-%s'", $algorithm, $expectedHash), $response->headers->get('Content-Security-Policy'));
     }
 
+    public function testAddsCspHashFromUnsafeInlineStyle(): void
+    {
+        $directives = new DirectiveSet(new PolicyManager());
+        $directives->setDirective('style-src', "'self'");
+
+        $cspHandler = new CspHandler($directives);
+        $responseContext = (new ResponseContext())->add($cspHandler);
+
+        $responseContextAccessor = $this->createMock(ResponseContextAccessor::class);
+        $responseContextAccessor
+            ->expects($this->exactly(2))
+            ->method('getResponseContext')
+            ->willReturn($responseContext)
+        ;
+
+        $runtime = new CspRuntime($responseContextAccessor, new WysiwygStyleProcessor([]));
+        $this->assertSame('foobar', $runtime->unsafeInlineStyle('foobar'));
+
+        $attrs = new HtmlAttributes('style="color:red"');
+        $runtime = new CspRuntime($responseContextAccessor, new WysiwygStyleProcessor([]));
+        $this->assertSame($attrs, $runtime->unsafeInlineStyle($attrs));
+
+        $response = new Response();
+        $cspHandler->applyHeaders($response);
+        $this->assertSame(
+            "style-src 'self' 'unsafe-hashes' 'unsafe-inline' 'sha256-w6uP8Tcg6K2QR905Rms8iXTlksL6OD1KOWBxTK7wxPI=' 'sha256-8f935d27GvUutRyY9yWScUMiFUk4WTdZURISiYfPOeQ='",
+            $response->headers->get('Content-Security-Policy'),
+        );
+    }
+
     public function testCallsWysiwygProcessor(): void
     {
         $directives = new DirectiveSet(new PolicyManager());
@@ -128,7 +159,7 @@ class CspRuntimeTest extends TestCase
 
         $responseContextAccessor = $this->createMock(ResponseContextAccessor::class);
         $responseContextAccessor
-            ->expects($this->once())
+            ->expects($this->exactly(2))
             ->method('getResponseContext')
             ->willReturn($responseContext)
         ;
@@ -138,9 +169,29 @@ class CspRuntimeTest extends TestCase
             ->expects($this->once())
             ->method('extractStyles')
             ->with('foobar')
+            ->willReturn(['foobarstyle'])
         ;
 
         $runtime = new CspRuntime($responseContextAccessor, $wysiwygProcessor);
-        $runtime->inlineStyles('foobar');
+        $this->assertSame('foobar', $runtime->inlineStyles('foobar'));
+
+        $wysiwygProcessor = $this->createMock(WysiwygStyleProcessor::class);
+        $wysiwygProcessor
+            ->expects($this->once())
+            ->method('extractStyles')
+            ->with('<div style="color:red"></div>')
+            ->willReturn(['color:red'])
+        ;
+
+        $attrs = new HtmlAttributes('style="color:red"');
+        $runtime = new CspRuntime($responseContextAccessor, $wysiwygProcessor);
+        $this->assertSame($attrs, $runtime->inlineStyles($attrs));
+
+        $response = new Response();
+        $cspHandler->applyHeaders($response);
+        $this->assertSame(
+            "style-src 'self' 'unsafe-hashes' 'unsafe-inline' 'sha256-G9KEe21cICJs7ADRF9jwf63CdC5OJI1mO2LVlv63cUY=' 'sha256-8f935d27GvUutRyY9yWScUMiFUk4WTdZURISiYfPOeQ='",
+            $response->headers->get('Content-Security-Policy'),
+        );
     }
 }


### PR DESCRIPTION
This adds the missing Twig filter counterpart to the legacy `$this->cspInlineStyle(…)` method.

Can be used like this:

```twig
<div style="{{ 'color: red'|csp_unsafe_inline_style }}">

<div{{ attrs().addStyle({ color: 'red' })|csp_unsafe_inline_style }}>

{% set attributes = attrs()
	.addStyle({ color: 'red' })
	|csp_unsafe_inline_style 
%}
<div{{ attributes }}>
```

I think having the term `_unsafe_` in the filter name is important here so that template authors know the potential harm (like `unsafe {}` in Rust or `dangerouslySetInnerHTML()` in React).

I also renamed `cspInlineStyle()` to `cspUnsafeInlineStyle()` so that the Twig filter and the legacy template method names are consistent.

I also added support for the `attrs()` object to the existing `|csp_inline_styles` filter. This can be used more broadly as it only allows the styles configured in `contao.csp.allowed_inline_styles` and is therefore a safe alternative:

```twig
{{ '<div style="color: #f00">'|csp_inline_styles }}

<div{{ attrs().addStyle({ color: '#f00' })|csp_inline_styles }}>

{% set attributes = attrs()
	.addStyle({ color: '#f00' })
	|csp_inline_styles
%}
<div{{ attributes }}>
```

Todo:
- [x] Tests
- [x] Backport to 5.3