### PR TITLE
Fix double encoding/decoding in the `HtmlAttributes` class

### DIFF
--- a/core-bundle/src/String/HtmlAttributes.php
+++ b/core-bundle/src/String/HtmlAttributes.php
@@ -405,7 +405,7 @@ class HtmlAttributes implements \Stringable, \JsonSerializable, \IteratorAggrega
         preg_match_all($attributeRegex, $attributesString, $matches, PREG_SET_ORDER | PREG_UNMATCHED_AS_NULL);
 
         foreach ($matches as [1 => $name, 2 => $value]) {
-            yield strtolower($name) => html_entity_decode($value ?? '', ENT_QUOTES);
+            yield strtolower($name) => html_entity_decode($value ?? '', ENT_QUOTES | ENT_HTML5);
         }
     }
 
@@ -415,7 +415,7 @@ class HtmlAttributes implements \Stringable, \JsonSerializable, \IteratorAggrega
             throw new \RuntimeException(sprintf('The value of property "%s" is not a valid UTF-8 string.', $name));
         }
 
-        $value = htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE, null, $this->doubleEncoding);
+        $value = htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, null, $this->doubleEncoding);
 
         return str_replace(['{{', '}}'], ['&#123;&#123;', '&#125;&#125;'], $value);
     }

--- a/core-bundle/tests/String/HtmlAttributesTest.php
+++ b/core-bundle/tests/String/HtmlAttributesTest.php
@@ -89,8 +89,8 @@ class HtmlAttributesTest extends TestCase
         ];
 
         yield 'decode values' => [
-            'foo=&quot; bar="b&auml;z"',
-            ['foo' => '"', 'bar' => 'bäz'],
+            'foo=&quot; bar="b&auml;z" baz=&ZeroWidthSpace;',
+            ['foo' => '"', 'bar' => 'bäz', 'baz' => "\u{200B}"],
         ];
 
         yield 'no attributes' => [
@@ -532,10 +532,11 @@ class HtmlAttributesTest extends TestCase
             'b' => '{{b}}',
             'c' => 'foo&bar',
             'd' => 'foo&amp;bar',
+            'e' => '&ZeroWidthSpace;',
             'property-without-value' => null,
         ]);
 
-        $expectedString = 'a="A B C" b="&#123;&#123;b&#125;&#125;" c="foo&amp;bar" d="foo&amp;bar" property-without-value';
+        $expectedString = 'a="A B C" b="&#123;&#123;b&#125;&#125;" c="foo&amp;bar" d="foo&amp;bar" e="&ZeroWidthSpace;" property-without-value';
 
         $this->assertSame(" $expectedString", (string) $attributes);
         $this->assertSame(" $expectedString", $attributes->toString());
@@ -543,7 +544,7 @@ class HtmlAttributesTest extends TestCase
 
         // With double encoding
         $this->assertSame($attributes, $attributes->setDoubleEncoding(true));
-        $expectedString = 'a="A B C" b="&#123;&#123;b&#125;&#125;" c="foo&amp;bar" d="foo&amp;amp;bar" property-without-value';
+        $expectedString = 'a="A B C" b="&#123;&#123;b&#125;&#125;" c="foo&amp;bar" d="foo&amp;amp;bar" e="&amp;ZeroWidthSpace;" property-without-value';
 
         $this->assertSame(" $expectedString", (string) $attributes);
         $this->assertSame(" $expectedString", $attributes->toString());


### PR DESCRIPTION
Followup to #6808 _(Was probably missed there because 4.13 does not have the HtmlAttributes class)_