### PR TITLE
Fix a bug in `setIfExists()` with Stringable objects

### DIFF
--- a/core-bundle/src/String/HtmlAttributes.php
+++ b/core-bundle/src/String/HtmlAttributes.php
@@ -134,7 +134,7 @@ class HtmlAttributes implements \Stringable, \JsonSerializable, \IteratorAggrega
      */
     public function setIfExists(string $name, \Stringable|bool|int|string|null $value): self
     {
-        if (!empty($value)) {
+        if ($this->test($value)) {
             $this->set($name, $value);
         }
 

--- a/core-bundle/tests/String/HtmlAttributesTest.php
+++ b/core-bundle/tests/String/HtmlAttributesTest.php
@@ -310,16 +310,19 @@ class HtmlAttributesTest extends TestCase
         $attributes->setIfExists('b', false);
         $attributes->setIfExists('c', 0);
         $attributes->setIfExists('d', '');
+        $attributes->setIfExists('s', $this->toStringable(''));
 
         // Set values that should be used
         $attributes->setIfExists('e', ' ');
         $attributes->setIfExists('f', 'abc');
+        $attributes->setIfExists('g', $this->toStringable(' '));
 
-        $this->assertSame(['bar' => '42', 'e' => ' ', 'f' => 'abc'], iterator_to_array($attributes));
+        $this->assertSame(['bar' => '42', 'e' => ' ', 'f' => 'abc', 'g' => ' '], iterator_to_array($attributes));
 
         // Unset properties by setting them to false
         $attributes->set('bar', false);
         $attributes->setIfExists('f', false); // should not alter the list
+        $attributes->mergeWith(['g' => false]);
 
         $this->assertSame(['e' => ' ', 'f' => 'abc'], iterator_to_array($attributes));
 
@@ -339,12 +342,7 @@ class HtmlAttributesTest extends TestCase
             '1',
             ['test'],
             new \stdClass(),
-            new class() implements \Stringable {
-                public function __toString(): string
-                {
-                    return 'foo';
-                }
-            },
+            $this->toStringable('foo'),
         ];
 
         $falsyValues = [
@@ -353,12 +351,7 @@ class HtmlAttributesTest extends TestCase
             0,
             '',
             [],
-            new class() implements \Stringable {
-                public function __toString(): string
-                {
-                    return '';
-                }
-            },
+            $this->toStringable(''),
         ];
 
         // Test truthy values fulfil the condition
@@ -609,5 +602,19 @@ class HtmlAttributesTest extends TestCase
         $attributes = new HtmlAttributes(['foo' => 'bar', 'baz' => 42]);
 
         $this->assertSame('{"foo":"bar","baz":"42"}', json_encode($attributes, JSON_THROW_ON_ERROR));
+    }
+
+    private function toStringable(string $string): \Stringable
+    {
+        return new class($string) implements \Stringable {
+            public function __construct(private readonly string $string)
+            {
+            }
+
+            public function __toString(): string
+            {
+                return $this->string;
+            }
+        };
     }
 }


### PR DESCRIPTION
`setIfExists()` always considered `Stringable`s to be “existing” even if they resolve to the empty string.