### PR TITLE
Fix the encoded umlauts in JSON-LD data

### DIFF
--- a/core-bundle/src/Search/Document.php
+++ b/core-bundle/src/Search/Document.php
@@ -112,7 +112,7 @@ class Document
             ->filterXPath('descendant-or-self::script[@type = "application/ld+json"]')
             ->each(
                 static function (Crawler $node) {
-                    $data = json_decode($node->text(), true);
+                    $data = json_decode(html_entity_decode($node->text()), true);
 
                     if (JSON_ERROR_NONE !== json_last_error()) {
                         return null;


### PR DESCRIPTION
We have the following code to add the page image to schema.org data:

```php
if (($image = $this->designManager->getLinkedDataPageImage($page)) === null) {
    return;
}

$context = $this->responseContextAccessor->getResponseContext();

if (!$context || !$context->has(JsonLdManager::class)) {
    return;
}

/** @var JsonLdManager $jsonLdManager */
$jsonLdManager = $context->get(JsonLdManager::class);
$graph = $jsonLdManager->getGraphForSchema(JsonLdManager::SCHEMA_ORG);

$webPage = new WebPage();
if ($graph->has(WebPage::class)) {
    $webPage = $graph->get(WebPage::class);
}

$imageObject = new ImageObject();
$imageObject->contentUrl($image);

$webPage->primaryImageOfPage($imageObject);
```

… which results in this output:

```html
<script type="application/ld+json">
{
    "@context": "https:\/\/schema.org",
    "@graph": [
        {
            "@type": "WebPage",
            "primaryImageOfPage": {
                "@type": "ImageObject",
                "contentUrl": "files\/websites\/medien\/Reiseführer_5_4.jpg"
            }
        }
    ]
}
</script>
```

The problem is that [upon extracting the JSON data](https://github.com/contao/contao/blob/4.13/core-bundle/src/Search/Document.php#L115), the umlauts are getting encoded:

```
Reiseführer_5_4.jpg -> Reisef&#252;hrer_5_4.jpg
```

And this encoded value is being saved to the database in the `tl_search.meta` column. Then, when displaying the search results in the frontend, the image [will not be computed because](https://github.com/contao/contao/blob/4.13/core-bundle/src/Resources/contao/modules/ModuleSearch.php#L316) it will be not found by the system, due to encoded characters (`Reisef&#252;hrer_5_4.jpg` instead of `Reiseführer_5_4.jpg`). The search meta data stored in the database should probably be stored decoded then.

The encoding is either related to the `\DOMDocument` or the `Symfony\Component\DomCrawler\Crawler` itself.

Alternatively, we could also decode entities here, but I don't think that's the way to go:

```diff
- $figureBuilder->fromUrl($v['https://schema.org/primaryImageOfPage']['contentUrl'], $baseUrls);
+ $figureBuilder->fromUrl(StringUtil::decodeEntities($v['https://schema.org/primaryImageOfPage']['contentUrl']), $baseUrls);
```

PS. Although we found out the issue in Contao 5.2, the 4.13 seems to be affected as well.

/cc @Toflar