### PR TITLE
Fix a PHP 8 error if there is no default palette

### DIFF
--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -3358,7 +3358,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 	public function getPalette()
 	{
 		$palette = 'default';
-		$strPalette = $GLOBALS['TL_DCA'][$this->strTable]['palettes'][$palette];
+		$strPalette = $GLOBALS['TL_DCA'][$this->strTable]['palettes'][$palette] ?? '';
 
 		// Check whether there are selector fields
 		if (!empty($GLOBALS['TL_DCA'][$this->strTable]['palettes']['__selector__']))


### PR DESCRIPTION
We have an extension that generates the palette of each table using `DC_Table::getPalette()`. Unfortunately, if a table does not have a `default` palette, `DC_Table` will generate a PHP8 error.