### PR TITLE
Correctly check if an error page can be duplicated

### DIFF
--- a/core-bundle/tests/Security/Voter/DataContainer/PageTypeAccessVoterTest.php
+++ b/core-bundle/tests/Security/Voter/DataContainer/PageTypeAccessVoterTest.php
@@ -166,19 +166,19 @@ class PageTypeAccessVoterTest extends TestCase
         $errorTypes = ['error_401', 'error_403', 'error_404', 'error_503'];
 
         yield 'Abstain if new type is not an error page' => [
-            new CreateAction('tl_page', ['pid' => 42, 'type' => 'regular']),
+            new CreateAction('tl_page', ['pid' => 42, 'sorting' => 128, 'type' => 'regular']),
             [],
             VoterInterface::ACCESS_ABSTAIN,
         ];
 
         yield 'Abstain if current type is not an error page' => [
-            new UpdateAction('tl_page', ['pid' => 42, 'type' => 'regular']),
+            new UpdateAction('tl_page', ['pid' => 42, 'sorting' => 128, 'type' => 'regular']),
             [],
             VoterInterface::ACCESS_ABSTAIN,
         ];
 
         yield 'Abstain if current and new type is not an error page' => [
-            new UpdateAction('tl_page', ['pid' => 42, 'type' => 'regular'], ['type' => 'forward']),
+            new UpdateAction('tl_page', ['pid' => 42, 'sorting' => 128, 'type' => 'regular'], ['type' => 'forward']),
             [],
             VoterInterface::ACCESS_ABSTAIN,
         ];
@@ -215,13 +215,21 @@ class PageTypeAccessVoterTest extends TestCase
             ];
 
             yield "Deny to create $type page if pid is not set" => [
-                new CreateAction('tl_page', ['type' => $type, 'foo' => 'bar']),
+                new CreateAction('tl_page', ['type' => $type, 'sorting' => 128, 'foo' => 'bar']),
                 [],
                 VoterInterface::ACCESS_DENIED,
             ];
 
+            yield "Allow to copy $type page if sorting is NULL (copy button)" => [
+                new CreateAction('tl_page', ['pid' => 42, 'sorting' => null, 'type' => $type]),
+                [
+                    [$type, 21],
+                ],
+                VoterInterface::ACCESS_ABSTAIN,
+            ];
+
             yield "Allow to change page type if no $type exists in root page" => [
-                new UpdateAction('tl_page', ['pid' => 42, 'type' => 'regular'], ['type' => $type]),
+                new UpdateAction('tl_page', ['pid' => 42, 'sorting' => 128, 'type' => 'regular'], ['type' => $type]),
                 [
                     [42, 'root'],
                     [[$type, 42], false],
@@ -230,7 +238,7 @@ class PageTypeAccessVoterTest extends TestCase
             ];
 
             yield "Deny to change page type if $type exists in root page" => [
-                new UpdateAction('tl_page', ['pid' => 42, 'type' => 'regular'], ['type' => $type]),
+                new UpdateAction('tl_page', ['pid' => 42, 'sorting' => 128, 'type' => 'regular'], ['type' => $type]),
                 [
                     [42, 'root'],
                     [[$type, 42], 21],
@@ -239,31 +247,31 @@ class PageTypeAccessVoterTest extends TestCase
             ];
 
             yield "Deny to change page type if $type parent is not a root page" => [
-                new UpdateAction('tl_page', ['pid' => 42, 'type' => 'regular'], ['type' => $type]),
+                new UpdateAction('tl_page', ['pid' => 42, 'sorting' => 128, 'type' => 'regular'], ['type' => $type]),
                 [[42, 'regular']],
                 VoterInterface::ACCESS_DENIED,
             ];
 
             yield "Deny to change page type if new parent of $type is not a root page" => [
-                new UpdateAction('tl_page', ['pid' => 21, 'type' => 'regular'], ['pid' => 42, 'type' => $type]),
+                new UpdateAction('tl_page', ['pid' => 21, 'sorting' => 128, 'type' => 'regular'], ['pid' => 42, 'type' => $type]),
                 [[42, 'regular']],
                 VoterInterface::ACCESS_DENIED,
             ];
 
             yield "Change page type ignores current $type type" => [
-                new UpdateAction('tl_page', ['pid' => 21, 'type' => $type], ['type' => 'regular']),
+                new UpdateAction('tl_page', ['pid' => 21, 'sorting' => 128, 'type' => $type], ['type' => 'regular']),
                 [],
                 VoterInterface::ACCESS_ABSTAIN,
             ];
 
             yield "Abstain if parent page of $type is not changed" => [
-                new UpdateAction('tl_page', ['pid' => 42, 'type' => $type, 'foo' => 'bar']),
+                new UpdateAction('tl_page', ['pid' => 42, 'sorting' => 128, 'type' => $type, 'foo' => 'bar']),
                 [],
                 VoterInterface::ACCESS_ABSTAIN,
             ];
 
             yield "Deny if only parent ID of $type is changed" => [
-                new UpdateAction('tl_page', ['pid' => 42, 'type' => $type], ['pid' => 21]),
+                new UpdateAction('tl_page', ['pid' => 42, 'sorting' => 128, 'type' => $type], ['pid' => 21]),
                 [
                     [21, 'root'],
                     [[$type, 21], 1],
@@ -272,7 +280,7 @@ class PageTypeAccessVoterTest extends TestCase
             ];
 
             yield "Deny if only sorting of $type is changed" => [
-                new UpdateAction('tl_page', ['pid' => 42, 'type' => $type], ['sorting' => 256]),
+                new UpdateAction('tl_page', ['pid' => 42, 'sorting' => 128, 'type' => $type], ['sorting' => 256]),
                 [
                     [42, 'root'],
                     [[$type, 42], 1],


### PR DESCRIPTION
Currently, if you have an error_404 (or other error) page in a root page, you cannot duplicate it. That's because the voter checks if such a page already exists in the current root. We need to allow copying if any other root page does not have that type.