### PR TITLE
Handle empty strings in the `StringResolver` class

### DIFF
--- a/core-bundle/src/Routing/Content/StringResolver.php
+++ b/core-bundle/src/Routing/Content/StringResolver.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Routing\Content;
 
+use Contao\CoreBundle\Exception\ForwardPageNotFoundException;
 use Contao\CoreBundle\InsertTag\InsertTagParser;
 use Contao\PageModel;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -37,7 +38,7 @@ class StringResolver implements ContentUrlResolverInterface
         $url = $this->insertTagParser->replaceInline($content->value);
 
         if ($url === '') {
-            return null;
+            throw new ForwardPageNotFoundException();
         }
 
         if (!parse_url($url, PHP_URL_SCHEME)) {

--- a/core-bundle/src/Routing/Content/StringResolver.php
+++ b/core-bundle/src/Routing/Content/StringResolver.php
@@ -37,7 +37,7 @@ class StringResolver implements ContentUrlResolverInterface
 
         $url = $this->insertTagParser->replaceInline($content->value);
 
-        if ($url === '') {
+        if ('' === $url) {
             throw new ForwardPageNotFoundException();
         }
 

--- a/core-bundle/src/Routing/Content/StringResolver.php
+++ b/core-bundle/src/Routing/Content/StringResolver.php
@@ -36,6 +36,10 @@ class StringResolver implements ContentUrlResolverInterface
 
         $url = $this->insertTagParser->replaceInline($content->value);
 
+        if ($url === '') {
+            return null;
+        }
+
         if (!parse_url($url, PHP_URL_SCHEME)) {
             $url = $this->urlHelper->getAbsoluteUrl($url);
         }

--- a/core-bundle/tests/Routing/Content/StringResolverTest.php
+++ b/core-bundle/tests/Routing/Content/StringResolverTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Tests\Routing\Content;
 
 use Contao\ArticleModel;
+use Contao\CoreBundle\Exception\ForwardPageNotFoundException;
 use Contao\CoreBundle\InsertTag\InsertTagParser;
 use Contao\CoreBundle\Routing\Content\StringResolver;
 use Contao\CoreBundle\Routing\Content\StringUrl;
@@ -41,6 +42,28 @@ class StringResolverTest extends TestCase
         $result = $resolver->resolve($content);
 
         $this->assertNull($result);
+    }
+
+    public function testAbstainsIfInsertTagIsEmpty(): void
+    {
+        $this->expectException(ForwardPageNotFoundException::class);
+
+        $content = new StringUrl('{{link_url::42}}');
+
+        $insertTagParser = $this->createMock(InsertTagParser::class);
+        $insertTagParser
+            ->expects($this->once())
+            ->method('replaceInline')
+            ->with($content->value)
+            ->willReturn('')
+        ;
+
+        $requestStack = new RequestStack();
+        $requestContext = new RequestContext();
+        $urlHelper = new UrlHelper($requestStack, $requestContext);
+
+        $resolver = new StringResolver($insertTagParser, $urlHelper, $requestStack, $requestContext);
+        $resolver->resolve($content);
     }
 
     /**

--- a/core-bundle/tests/Routing/Content/StringResolverTest.php
+++ b/core-bundle/tests/Routing/Content/StringResolverTest.php
@@ -44,7 +44,7 @@ class StringResolverTest extends TestCase
         $this->assertNull($result);
     }
 
-    public function testAbstainsIfInsertTagIsEmpty(): void
+    public function testThrowsExceptionIfInsertTagIsEmpty(): void
     {
         $this->expectException(ForwardPageNotFoundException::class);
 

--- a/core-bundle/tests/Routing/Content/StringResolverTest.php
+++ b/core-bundle/tests/Routing/Content/StringResolverTest.php
@@ -46,8 +46,6 @@ class StringResolverTest extends TestCase
 
     public function testThrowsExceptionIfInsertTagIsEmpty(): void
     {
-        $this->expectException(ForwardPageNotFoundException::class);
-
         $content = new StringUrl('{{link_url::42}}');
 
         $insertTagParser = $this->createMock(InsertTagParser::class);
@@ -63,6 +61,9 @@ class StringResolverTest extends TestCase
         $urlHelper = new UrlHelper($requestStack, $requestContext);
 
         $resolver = new StringResolver($insertTagParser, $urlHelper, $requestStack, $requestContext);
+
+        $this->expectException(ForwardPageNotFoundException::class);
+
         $resolver->resolve($content);
     }
 


### PR DESCRIPTION
We encountered an `ErrorException` when the page of external redirect type has an insert tag that returns an empty string.

The problem in fact happens in the `UrlHelper` component of Symfony, but I think we should fix it on our side nevertheless.

Stack trace:

```
ErrorException: Warning: Uninitialized string offset 0
#36 /vendor/symfony/http-foundation/UrlHelper.php(42): Symfony\Component\HttpFoundation\UrlHelper::getAbsoluteUrl
#35 /vendor/contao/core-bundle/src/Routing/Content/StringResolver.php(40): Contao\CoreBundle\Routing\Content\StringResolver::resolve
#34 /vendor/contao/core-bundle/src/Routing/ContentUrlGenerator.php(150): Contao\CoreBundle\Routing\ContentUrlGenerator::resolveContent
#33 /vendor/contao/core-bundle/src/Routing/ContentUrlGenerator.php(161): Contao\CoreBundle\Routing\ContentUrlGenerator::resolveContent
#32 /vendor/contao/core-bundle/src/Routing/ContentUrlGenerator.php(70): Contao\CoreBundle\Routing\ContentUrlGenerator::generate
#31 /vendor/contao/core-bundle/contao/modules/Module.php(349): Contao\Module::renderNavigation
#30 /vendor/contao/core-bundle/contao/modules/Module.php(326): Contao\Module::renderNavigation
#29 /vendor/contao/core-bundle/contao/modules/Module.php(326): Contao\Module::renderNavigation
#28 /vendor/contao/core-bundle/contao/modules/ModuleNavigation.php(82): Contao\ModuleNavigation::compile
#27 /vendor/contao/core-bundle/contao/modules/Module.php(213): Contao\Module::generate
#26 /vendor/contao/core-bundle/contao/modules/ModuleNavigation.php(45): Contao\ModuleNavigation::generate
#25 /vendor/contao/core-bundle/contao/library/Contao/Controller.php(410): Contao\Controller::getFrontendModule
…
#1 /vendor/friendsofsymfony/http-cache/src/SymfonyCache/EventDispatchingHttpCache.php(96): Contao\ManagerBundle\HttpKernel\ContaoCache::handle
#0 /public/index.php(42): null
```