### PR TITLE
Automatically set `ParameterType::BOOLEAN` for booleans

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Database/Statement.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Database/Statement.php
@@ -258,13 +258,16 @@ class Statement
 			throw new \Exception('Empty query string');
 		}
 
-		$arrTypes += array_fill(0, \count($arrParams), null);
+		if (empty($arrTypes)) {
+			$arrTypes = array_fill(0, \count($arrParams), ParameterType::STRING);
+		}
+
 		$arrParams = array_map(
 			static function ($key, $varParam) use (&$arrTypes)
 			{
 				// Automatically set type to boolean when no type is defined, otherwise
 				// PDO will convert "false" to an empty string (see https://bugs.php.net/bug.php?id=57157)
-				if (null === $arrTypes[$key] && \is_bool($varParam))
+				if (null === ($arrTypes[$key] ?? null) && \is_bool($varParam))
 				{
 					$arrTypes[$key] = ParameterType::BOOLEAN;
 				}

--- a/core-bundle/src/Resources/contao/library/Contao/Database/Statement.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Database/Statement.php
@@ -258,7 +258,7 @@ class Statement
 			throw new \Exception('Empty query string');
 		}
 
-		$arrTypes += array_fill(0, count($arrParams), null);
+		$arrTypes += array_fill(0, \count($arrParams), null);
 		$arrParams = array_map(
 			static function ($key, $varParam) use (&$arrTypes)
 			{

--- a/core-bundle/src/Resources/contao/library/Contao/Database/Statement.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Database/Statement.php
@@ -258,7 +258,8 @@ class Statement
 			throw new \Exception('Empty query string');
 		}
 
-		if (empty($arrTypes)) {
+		if (empty($arrTypes))
+		{
 			$arrTypes = array_fill(0, \count($arrParams), ParameterType::STRING);
 		}
 

--- a/core-bundle/src/Resources/contao/library/Contao/Database/Statement.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Database/Statement.php
@@ -258,27 +258,22 @@ class Statement
 			throw new \Exception('Empty query string');
 		}
 
-
-		$arrParams = array_map(
-			static function ($key, $varParam) use (&$arrTypes)
+		foreach ($arrParams as $key => $varParam)
+		{
+			// Automatically set type to boolean when no type is defined,
+			// otherwise "false" will be converted to an empty string.
+			if (null === ($arrTypes[$key] ?? null))
 			{
-				// Automatically set type to boolean when no type is defined,
-				// otherwise "false" will be converted to an empty string.
-				if (null === ($arrTypes[$key] ?? null))
-				{
-					$arrTypes[$key] = \is_bool($varParam) ? ParameterType::BOOLEAN : ParameterType::STRING;
-				}
+				$arrTypes[$key] = \is_bool($varParam) ? ParameterType::BOOLEAN : ParameterType::STRING;
+			}
 
-				if (\is_string($varParam) || \is_bool($varParam) || \is_float($varParam) || \is_int($varParam) || $varParam === null)
-				{
-					return $varParam;
-				}
+			if (\is_string($varParam) || \is_bool($varParam) || \is_float($varParam) || \is_int($varParam) || $varParam === null)
+			{
+				continue;
+			}
 
-				return serialize($varParam);
-			},
-			array_keys($arrParams),
-			$arrParams
-		);
+			$arrParams[$key] = serialize($varParam);
+		}
 
 		$this->arrLastUsedParams = $arrParams;
 

--- a/core-bundle/src/Resources/contao/library/Contao/Database/Statement.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Database/Statement.php
@@ -265,9 +265,9 @@ class Statement
 		$arrParams = array_map(
 			static function ($key, $varParam) use (&$arrTypes)
 			{
-				// Automatically set type to boolean when no type is defined, otherwise
-				// PDO will convert "false" to an empty string (see https://bugs.php.net/bug.php?id=57157)
-				if (null === ($arrTypes[$key] ?? null) && \is_bool($varParam))
+				// Automatically set type to boolean when no type or string type is defined,
+				// otherwise "false" will be converted to an empty string.
+				if (ParameterType::STRING === ($arrTypes[$key] ?? null) && \is_bool($varParam))
 				{
 					$arrTypes[$key] = ParameterType::BOOLEAN;
 				}

--- a/core-bundle/src/Resources/contao/library/Contao/Database/Statement.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Database/Statement.php
@@ -258,19 +258,15 @@ class Statement
 			throw new \Exception('Empty query string');
 		}
 
-		if (empty($arrTypes))
-		{
-			$arrTypes = array_fill(0, \count($arrParams), ParameterType::STRING);
-		}
 
 		$arrParams = array_map(
 			static function ($key, $varParam) use (&$arrTypes)
 			{
-				// Automatically set type to boolean when no type or string type is defined,
+				// Automatically set type to boolean when no type is defined,
 				// otherwise "false" will be converted to an empty string.
-				if (ParameterType::STRING === ($arrTypes[$key] ?? null) && \is_bool($varParam))
+				if (null === ($arrTypes[$key] ?? null))
 				{
-					$arrTypes[$key] = ParameterType::BOOLEAN;
+					$arrTypes[$key] = \is_bool($varParam) ? ParameterType::BOOLEAN : ParameterType::STRING;
 				}
 
 				if (\is_string($varParam) || \is_bool($varParam) || \is_float($varParam) || \is_int($varParam) || $varParam === null)

--- a/core-bundle/src/Resources/contao/library/Contao/Database/Statement.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Database/Statement.php
@@ -277,7 +277,7 @@ class Statement
 				return serialize($varParam);
 			},
 			array_keys($arrParams),
-			array_values($arrParams)
+			$arrParams
 		);
 
 		$this->arrLastUsedParams = $arrParams;

--- a/core-bundle/src/Resources/contao/library/Contao/Database/Statement.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Database/Statement.php
@@ -260,6 +260,13 @@ class Statement
 		$arrParams = array_map(
 			static function ($varParam)
 			{
+				// Automatically cast boolean to integer when no types are defined, otherwise
+				// PDO will convert "false" to an empty string (see https://bugs.php.net/bug.php?id=57157)
+				if (empty($arrTypes) && \is_bool($varParam))
+				{
+					return (int) $varParam;
+				}
+
 				if (\is_string($varParam) || \is_bool($varParam) || \is_float($varParam) || \is_int($varParam) || $varParam === null)
 				{
 					return $varParam;


### PR DESCRIPTION
Contao 4 already has support for `boolean` SQL fields. However, there is still one issue remaining: if you try to copy records, you might encounter the following error:

```
Doctrine\DBAL\Exception\DriverException:
An exception occurred while executing a query: SQLSTATE[22007]: Invalid datetime format: 1366 Incorrect integer value: '' for column `tl_content`.`foobar` at row 1
```

This can be reproduced by the following DCA:

```php
// contao/dca/tl_content.php
$GLOBALS['TL_DCA']['tl_content']['fields']['foobar'] = [
    'eval' => ['doNotCopy' => true],
    'sql' => ['type' => 'boolean', 'default' => false],
];
```

Update the database and then try to copy a page article that contains content elements.

This happens because the PDO driver automatically casts everything to strings, if no type is given - which for `false` means an empty string - which in turn is not compatible with a `boolean` (`tinyint(1)`) field.

To fix this we need to backport [this](https://github.com/contao/contao/blob/110d32fd52f5abfb58a07d15813d09dda7292e8e/core-bundle/contao/library/Contao/Database/Statement.php#L243-L248) from https://github.com/contao/contao/pull/4797.