### PR TITLE
Use `PhpSubprocess` instead of `Process` in the `ProcessUtil` class

### DIFF
--- a/core-bundle/src/Util/ProcessUtil.php
+++ b/core-bundle/src/Util/ProcessUtil.php
@@ -55,8 +55,8 @@ class ProcessUtil implements ResetInterface
 
     public function createSymfonyConsoleProcess(string $command, string ...$commandArguments): Process
     {
-        // Use PhpSubprocess introduced in Symfony 6.4 to respect command line arguments used to invoke the current
-        // process if possible.
+        // Use PhpSubprocess introduced in Symfony 6.4 to respect command line arguments
+        // used to invoke the current process if possible.
         if (class_exists(PhpSubprocess::class)) {
             return new PhpSubprocess([$this->getPhpBinary(), $this->getConsolePath(), $command, ...$commandArguments]);
         }

--- a/core-bundle/src/Util/ProcessUtil.php
+++ b/core-bundle/src/Util/ProcessUtil.php
@@ -15,6 +15,7 @@ namespace Contao\CoreBundle\Util;
 use GuzzleHttp\Promise\Promise;
 use GuzzleHttp\Promise\PromiseInterface;
 use Symfony\Component\Process\PhpExecutableFinder;
+use Symfony\Component\Process\PhpSubprocess;
 use Symfony\Component\Process\Process;
 use Symfony\Contracts\Service\ResetInterface;
 
@@ -54,6 +55,12 @@ class ProcessUtil implements ResetInterface
 
     public function createSymfonyConsoleProcess(string $command, string ...$commandArguments): Process
     {
+        // Use PhpSubprocess introduced in Symfony 6.4 to respect command line arguments used to invoke the current
+        // process if possible.
+        if (class_exists(PhpSubprocess::class)) {
+            return new PhpSubprocess([$this->getPhpBinary(), $this->getConsolePath(), $command, ...$commandArguments]);
+        }
+
         return new Process([$this->getPhpBinary(), $this->getConsolePath(), $command, ...$commandArguments]);
     }
 

--- a/core-bundle/tests/Util/ProcessUtilTest.php
+++ b/core-bundle/tests/Util/ProcessUtilTest.php
@@ -25,7 +25,7 @@ class ProcessUtilTest extends TestCase
         $util = new ProcessUtil('bin/console');
         $process = $util->createSymfonyConsoleProcess('foobar', 'argument-1', 'argument-2');
 
-        $this->assertSame('bin/console foobar argument-1 argument-2', $this->getCommandLine($process));
+        $this->assertStringEndsWith('bin/console foobar argument-1 argument-2', $this->getCommandLine($process));
     }
 
     public function testGetters(): void


### PR DESCRIPTION
We use this for our `messenger:consume` commands. So in case you configure the `contao:cron` cronjob with e.g. `-d memory_limit=-1`, it won't work. This is currently affecting my systems because the default `memory_limit` is configured to `128M` and I have heavier CLI jobs.

Details: https://symfony.com/blog/new-in-symfony-6-4-subprocess-handler 
