### PR TITLE
Make the `PhpTemplateProxyNode` class compatible with Twig 3.9

### DIFF
--- a/core-bundle/src/Twig/Interop/PhpTemplateParentReferenceNode.php
+++ b/core-bundle/src/Twig/Interop/PhpTemplateParentReferenceNode.php
@@ -26,7 +26,7 @@ final class PhpTemplateParentReferenceNode extends Node implements NodeOutputInt
 {
     public function compile(Compiler $compiler): void
     {
-        // echo sprintf('[[TL_PARENT_%s]]', \[…]\ContaoFramework::getNonce());'
+        /** @see PhpTemplateParentReferenceNodeTest::testCompilesParentReferenceCode() */
         $compiler
             ->write(class_exists(YieldReady::class) ? 'yield' : 'echo') // Backwards compatibility
             ->write(' sprintf(\'[[TL_PARENT_%s]]\', \\')

--- a/core-bundle/src/Twig/Interop/PhpTemplateParentReferenceNode.php
+++ b/core-bundle/src/Twig/Interop/PhpTemplateParentReferenceNode.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Twig\Interop;
 
 use Contao\CoreBundle\Framework\ContaoFramework;
+use Twig\Attribute\YieldReady;
 use Twig\Compiler;
 use Twig\Node\Node;
 use Twig\Node\NodeOutputInterface;
@@ -20,13 +21,15 @@ use Twig\Node\NodeOutputInterface;
 /**
  * @experimental
  */
+#[YieldReady]
 final class PhpTemplateParentReferenceNode extends Node implements NodeOutputInterface
 {
     public function compile(Compiler $compiler): void
     {
         // echo sprintf('[[TL_PARENT_%s]]', \[…]\ContaoFramework::getNonce());'
         $compiler
-            ->write('echo sprintf(\'[[TL_PARENT_%s]]\', \\')
+            ->write(class_exists(YieldReady::class) ? 'yield' : 'echo') // Backwards compatibility
+            ->write(' sprintf(\'[[TL_PARENT_%s]]\', \\')
             ->raw(ContaoFramework::class)
             ->raw('::getNonce());'."\n")
         ;

--- a/core-bundle/src/Twig/Interop/PhpTemplateProxyNode.php
+++ b/core-bundle/src/Twig/Interop/PhpTemplateProxyNode.php
@@ -34,22 +34,7 @@ final class PhpTemplateProxyNode extends Node
      */
     public function compile(Compiler $compiler): void
     {
-        // yield $this->extensions["Contao\\…\\ContaoExtension"]->renderLegacyTemplate(
-        //     $this->getTemplateName(),
-        //     array_map(
-        //         function(callable $block) use ($context): string {
-        //             if ($this->env->isDebug()) { ob_start(); } else { ob_start(static function () { return ''; }); }
-        //             try {
-        //                 $content = '';
-        //                 foreach ($block($context) ?? [''] as $chunk) {
-        //                     $content .= ob_get_contents() . $chunk;
-        //                     ob_clean();
-        //                 }
-        //                 return $content . ob_get_contents();
-        //             } finally { ob_end_clean(); }
-        //         }, $blocks
-        //     ), $context
-        // );
+        /** @see PhpTemplateProxyNodeTest::testCompilesProxyCode() */
         $compiler
             ->write(class_exists(YieldReady::class) ? 'yield' : 'echo') // Backwards compatibility
             ->write(' $this->extensions[')

--- a/core-bundle/src/Twig/Interop/PhpTemplateProxyNode.php
+++ b/core-bundle/src/Twig/Interop/PhpTemplateProxyNode.php
@@ -12,12 +12,14 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Twig\Interop;
 
+use Twig\Attribute\YieldReady;
 use Twig\Compiler;
 use Twig\Node\Node;
 
 /**
  * @experimental
  */
+#[YieldReady]
 final class PhpTemplateProxyNode extends Node
 {
     public function __construct(string $extensionName)
@@ -27,19 +29,30 @@ final class PhpTemplateProxyNode extends Node
         ]);
     }
 
+    /**
+     * @todo Remove output buffer handling once Twig is yield-only (probably version 4.0)
+     */
     public function compile(Compiler $compiler): void
     {
-        // echo $this->extensions["Contao\\…\\ContaoExtension"]->renderLegacyTemplate(
+        // yield $this->extensions["Contao\\…\\ContaoExtension"]->renderLegacyTemplate(
         //     $this->getTemplateName(),
         //     array_map(
         //         function(callable $block) use ($context): string {
         //             if ($this->env->isDebug()) { ob_start(); } else { ob_start(static function () { return ''; }); }
-        //             try { $block($context); return ob_get_contents(); } finally { ob_end_clean(); }
+        //             try {
+        //                 $content = '';
+        //                 foreach ($block($context) ?? [''] as $chunk) {
+        //                     $content .= ob_get_contents() . $chunk;
+        //                     ob_clean();
+        //                 }
+        //                 return $content . ob_get_contents();
+        //             } finally { ob_end_clean(); }
         //         }, $blocks
         //     ), $context
         // );
         $compiler
-            ->write('echo $this->extensions[')
+            ->write(class_exists(YieldReady::class) ? 'yield' : 'echo') // Backwards compatibility
+            ->write(' $this->extensions[')
             ->repr($this->getAttribute('extension_name'))
             ->raw(']->renderLegacyTemplate('."\n")
             ->indent()
@@ -49,7 +62,18 @@ final class PhpTemplateProxyNode extends Node
             ->write('function(callable $block) use ($context): string {'."\n")
             ->indent()
             ->write('if ($this->env->isDebug()) { ob_start(); } else { ob_start(static function () { return \'\'; }); }'."\n")
-            ->write('try { $block($context); return ob_get_contents(); } finally { ob_end_clean(); }'."\n")
+            ->write('try {'."\n")
+            ->indent()
+            ->write('$content = \'\';'."\n")
+            ->write('foreach ($block($context) ?? [\'\'] as $chunk) {'."\n")
+            ->indent()
+            ->write('$content .= ob_get_contents() . $chunk;'."\n")
+            ->write('ob_clean();'."\n")
+            ->outdent()
+            ->write('}'."\n")
+            ->write('return $content . ob_get_contents();'."\n")
+            ->outdent()
+            ->write('} finally { ob_end_clean(); }'."\n")
             ->outdent()
             ->write('}, $blocks'."\n")
             ->outdent()

--- a/core-bundle/tests/Twig/Interop/PhpTemplateParentReferenceNodeTest.php
+++ b/core-bundle/tests/Twig/Interop/PhpTemplateParentReferenceNodeTest.php
@@ -31,7 +31,7 @@ class PhpTemplateParentReferenceNodeTest extends TestCase
 
             SOURCE;
 
-        // Backwards compatibility
+        // Forward compatibility with twig/twig >=3.9.0
         if (class_exists(YieldReady::class)) {
             $expectedSource = str_replace('echo', 'yield', $expectedSource);
         }

--- a/core-bundle/tests/Twig/Interop/PhpTemplateParentReferenceNodeTest.php
+++ b/core-bundle/tests/Twig/Interop/PhpTemplateParentReferenceNodeTest.php
@@ -14,6 +14,7 @@ namespace Contao\CoreBundle\Tests\Twig\Interop;
 
 use Contao\CoreBundle\Tests\TestCase;
 use Contao\CoreBundle\Twig\Interop\PhpTemplateParentReferenceNode;
+use Twig\Attribute\YieldReady;
 use Twig\Compiler;
 use Twig\Environment;
 
@@ -29,6 +30,11 @@ class PhpTemplateParentReferenceNodeTest extends TestCase
             echo sprintf('[[TL_PARENT_%s]]', \Contao\CoreBundle\Framework\ContaoFramework::getNonce());
 
             SOURCE;
+
+        // Backwards compatibility
+        if (class_exists(YieldReady::class)) {
+            $expectedSource = str_replace('echo', 'yield', $expectedSource);
+        }
 
         $this->assertSame($expectedSource, $compiler->getSource());
     }

--- a/core-bundle/tests/Twig/Interop/PhpTemplateProxyNodeTest.php
+++ b/core-bundle/tests/Twig/Interop/PhpTemplateProxyNodeTest.php
@@ -15,6 +15,7 @@ namespace Contao\CoreBundle\Tests\Twig\Interop;
 use Contao\CoreBundle\Tests\TestCase;
 use Contao\CoreBundle\Twig\Extension\ContaoExtension;
 use Contao\CoreBundle\Twig\Interop\PhpTemplateProxyNode;
+use Twig\Attribute\YieldReady;
 use Twig\Compiler;
 use Twig\Environment;
 
@@ -32,12 +33,24 @@ class PhpTemplateProxyNodeTest extends TestCase
                 array_map(
                     function(callable $block) use ($context): string {
                         if ($this->env->isDebug()) { ob_start(); } else { ob_start(static function () { return ''; }); }
-                        try { $block($context); return ob_get_contents(); } finally { ob_end_clean(); }
+                        try {
+                            $content = '';
+                            foreach ($block($context) ?? [''] as $chunk) {
+                                $content .= ob_get_contents() . $chunk;
+                                ob_clean();
+                            }
+                            return $content . ob_get_contents();
+                        } finally { ob_end_clean(); }
                     }, $blocks
                 ), $context
             );
 
             SOURCE;
+
+        // Backwards compatibility
+        if (class_exists(YieldReady::class)) {
+            $expectedSource = str_replace('echo', 'yield', $expectedSource);
+        }
 
         $this->assertSame($expectedSource, $compiler->getSource());
     }

--- a/core-bundle/tests/Twig/Interop/PhpTemplateProxyNodeTest.php
+++ b/core-bundle/tests/Twig/Interop/PhpTemplateProxyNodeTest.php
@@ -47,7 +47,7 @@ class PhpTemplateProxyNodeTest extends TestCase
 
             SOURCE;
 
-        // Backwards compatibility
+        // Forward compatibility with twig/twig >=3.9.0
         if (class_exists(YieldReady::class)) {
             $expectedSource = str_replace('echo', 'yield', $expectedSource);
         }

--- a/core-bundle/tests/Twig/TwigIntegrationTest.php
+++ b/core-bundle/tests/Twig/TwigIntegrationTest.php
@@ -129,14 +129,9 @@ class TwigIntegrationTest extends TestCase
         );
 
         $filesystemLoader = new ContaoFilesystemLoader(new NullAdapter(), $templateLocator, $themeNamespace, $this->getTempDir());
-        $environment = new Environment($filesystemLoader);
 
-        $environment->addExtension(
-            new ContaoExtension(
-                $environment,
-                $filesystemLoader,
-            ),
-        );
+        $environment = new Environment($filesystemLoader);
+        $environment->addExtension(new ContaoExtension($environment, $filesystemLoader));
 
         $container = $this->getContainerWithContaoConfiguration($this->getTempDir());
         $container->set('twig', $environment);

--- a/core-bundle/tests/Twig/TwigIntegrationTest.php
+++ b/core-bundle/tests/Twig/TwigIntegrationTest.php
@@ -13,13 +13,19 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Tests\Twig;
 
 use Contao\Config;
+use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\CoreBundle\Tests\TestCase;
 use Contao\CoreBundle\Twig\Extension\ContaoExtension;
 use Contao\CoreBundle\Twig\Interop\ContextFactory;
 use Contao\CoreBundle\Twig\Loader\ContaoFilesystemLoader;
+use Contao\CoreBundle\Twig\Loader\TemplateLocator;
+use Contao\CoreBundle\Twig\Loader\ThemeNamespace;
 use Contao\FormTextField;
+use Contao\FrontendTemplate;
 use Contao\System;
 use Contao\TemplateLoader;
+use Doctrine\DBAL\Connection;
+use Symfony\Component\Cache\Adapter\NullAdapter;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Filesystem\Path;
 use Twig\Environment;
@@ -51,7 +57,7 @@ class TwigIntegrationTest extends TestCase
 
         unset($GLOBALS['TL_LANG'], $GLOBALS['TL_FFL'], $GLOBALS['TL_MIME']);
 
-        $this->resetStaticProperties([System::class, Config::class]);
+        $this->resetStaticProperties([ContaoFramework::class, System::class, Config::class]);
 
         parent::tearDown();
     }
@@ -78,5 +84,70 @@ class TwigIntegrationTest extends TestCase
         $textField->addError('bar');
 
         $this->assertSame("my_class error\nfoo foo\n bar", $textField->parse());
+    }
+
+    public function testRendersTwigTemplateWithLegacyParent(): void
+    {
+        (new Filesystem())->dumpFile(
+            Path::join($this->getTempDir(), 'templates/legacy_template.html5'),
+            <<<'EOF'
+                <?php
+                    echo $this->value;
+                    echo ',test1';
+                    $this->block('a');
+                    echo ',test2';
+                    $this->endblock('a');
+                    echo ',test3';
+                    $this->block('b');
+                    echo ',test4';
+                    $this->block('b1');
+                    echo ',test5';
+                    $this->endblock('b1');
+                    echo ',test6';
+                    $this->endblock('b');
+                    echo ',test7';
+                EOF,
+        );
+        TemplateLoader::addFile('legacy_template', 'templates');
+
+        (new Filesystem())->dumpFile(
+            Path::join($this->getTempDir(), 'templates/twig_template.html.twig'),
+            <<<'EOF'
+                {% extends "@Contao/legacy_template.html5" %}
+                {% block a %}<<{{ parent() }}>>{% endblock %}
+                {% block b1 %}{{ parent() }},({{ value }}){% endblock %}
+                EOF,
+        );
+
+        $templateLocator = new TemplateLocator(
+            $this->getTempDir(),
+            [],
+            [],
+            $themeNamespace = new ThemeNamespace(),
+            $this->createMock(Connection::class),
+        );
+
+        $filesystemLoader = new ContaoFilesystemLoader(new NullAdapter(), $templateLocator, $themeNamespace, $this->getTempDir());
+        $environment = new Environment($filesystemLoader);
+
+        $environment->addExtension(
+            new ContaoExtension(
+                $environment,
+                $filesystemLoader,
+            ),
+        );
+
+        $container = $this->getContainerWithContaoConfiguration($this->getTempDir());
+        $container->set('twig', $environment);
+        $container->set(ContextFactory::class, new ContextFactory());
+
+        System::setContainer($container);
+
+        $template = new FrontendTemplate('twig_template');
+        $template->setData(['value' => 'value']);
+
+        $obLevel = ob_get_level();
+        $this->assertSame('value,test1<<,test2>>,test3,test4,test5,(value),test6,test7', $template->parse());
+        $this->assertSame($obLevel, ob_get_level());
     }
 }

--- a/core-bundle/tests/Twig/TwigIntegrationTest.php
+++ b/core-bundle/tests/Twig/TwigIntegrationTest.php
@@ -108,6 +108,7 @@ class TwigIntegrationTest extends TestCase
                     echo ',test7';
                 EOF,
         );
+
         TemplateLoader::addFile('legacy_template', 'templates');
 
         (new Filesystem())->dumpFile(


### PR DESCRIPTION
Same as https://github.com/contao/contao/pull/7129 for Contao 4.13