### PR TITLE
Allow roave/better-reflection version 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -159,7 +159,7 @@
         "bamarni/composer-bin-plugin": "^1.4",
         "composer/composer": "^2.0",
         "league/flysystem-memory": "^2.0 || ^3.0",
-        "roave/better-reflection": "^4.12.2 || ^5.0",
+        "roave/better-reflection": "^4.12.2 || ^5.0 || ^6.0",
         "symfony/browser-kit": "^5.4",
         "symfony/phpunit-bridge": "^5.4"
     },
@@ -185,7 +185,7 @@
         "doctrine/dbal": "3.3.0",
         "nikic/php-parser": "4.7.0",
         "phpunit/phpunit": "<8.0",
-        "roave/better-reflection": "<4.12.2 || >=6.0",
+        "roave/better-reflection": "<4.12.2 || >=7.0",
         "symfony/dependency-injection": "5.4.16 || 6.0.16 || 6.1.8 || 6.2.0 || 6.2.1",
         "terminal42/contao-ce-access": "<3.0",
         "thecodingmachine/safe": "<1.2",

--- a/core-bundle/composer.json
+++ b/core-bundle/composer.json
@@ -148,7 +148,7 @@
         "contao/test-case": "self.version",
         "league/flysystem-memory": "^2.0 || ^3.0",
         "phpunit/phpunit": "^9.3",
-        "roave/better-reflection": "^4.12.2 || ^5.0",
+        "roave/better-reflection": "^4.12.2 || ^5.0 || ^6.0",
         "symfony/browser-kit": "^5.4",
         "symfony/phpunit-bridge": "^5.4",
         "symfony/web-profiler-bundle": "^5.4"

--- a/test-case/composer.json
+++ b/test-case/composer.json
@@ -22,7 +22,7 @@
     },
     "conflict": {
         "phpunit/phpunit": "<8.0",
-        "roave/better-reflection": "<4.12.2 || >=6.0"
+        "roave/better-reflection": "<4.12.2 || >=7.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
It is currently not possible to install the dev-dependencies on PHP 8.3 because of the `roave/better-reflection` dependency. Allowing version 6 of `roave/better-reflection` should not cause any problems AFAICS.