### PR TITLE
Skip permissions checks for child records

### DIFF
--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -1870,8 +1870,6 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 				// Unset fields that no longer exist in the database
 				$row = array_intersect_key($row, $arrFields[$table]);
 
-				$this->denyAccessUnlessGranted(ContaoCorePermissions::DC_PREFIX . $table, new CreateAction($table, $row));
-
 				// Re-insert the data
 				$objInsertStmt = $db
 					->prepare("INSERT INTO " . $table . " %s")

--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -1163,15 +1163,6 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 						continue;
 					}
 
-					try
-					{
-						$this->denyAccessUnlessGranted(ContaoCorePermissions::DC_PREFIX . $v, new ReadAction($v, $objCTable->row()));
-					}
-					catch (AccessDeniedException)
-					{
-						continue;
-					}
-
 					foreach ($objCTable->row() as $kk=>$vv)
 					{
 						if ($kk == 'id')
@@ -1215,16 +1206,6 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 
 					$copy[$v][$objCTable->id]['pid'] = $insertID;
 					$copy[$v][$objCTable->id]['tstamp'] = $time;
-
-					try
-					{
-						$this->denyAccessUnlessGranted(ContaoCorePermissions::DC_PREFIX . $v, new CreateAction($v, $copy[$v][$objCTable->id]));
-					}
-					catch (AccessDeniedException)
-					{
-						unset($copy[$v][$objCTable->id]);
-						continue;
-					}
 				}
 			}
 		}
@@ -1809,7 +1790,6 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 	 */
 	public function deleteChildren($table, $id, &$delete)
 	{
-		$cctable = array();
 		$ctable = $GLOBALS['TL_DCA'][$table]['config']['ctable'] ?? array();
 
 		if (empty($ctable) || !\is_array($ctable))
@@ -1823,7 +1803,6 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 		foreach ($ctable as $v)
 		{
 			$this->loadDataContainer($v);
-			$cctable[$v] = $GLOBALS['TL_DCA'][$v]['config']['ctable'] ?? null;
 
 			// Consider the dynamic parent table (see #4867)
 			if ($GLOBALS['TL_DCA'][$v]['config']['dynamicPtable'] ?? null)
@@ -1839,36 +1818,12 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 					->execute($id);
 			}
 
-			if ($objDelete->numRows && !($GLOBALS['TL_DCA'][$v]['config']['doNotDeleteRecords'] ?? null) && \strlen($v))
+			if ($objDelete->numRows && !($GLOBALS['TL_DCA'][$v]['config']['doNotDeleteRecords'] ?? null))
 			{
-				$rows = $objDelete->fetchAllAssoc();
-
-				static::preloadCurrentRecords(array_column($rows, 'id'), $v);
-
-				foreach ($rows as $row)
+				foreach ($objDelete->fetchEach('id') as $id)
 				{
-					try
-					{
-						$currentRecord = $this->getCurrentRecord($row['id'], $v);
-
-						if ($currentRecord === null)
-						{
-							continue;
-						}
-
-						$this->denyAccessUnlessGranted(ContaoCorePermissions::DC_PREFIX . $v, new DeleteAction($v, $currentRecord));
-					}
-					catch (AccessDeniedException)
-					{
-						continue;
-					}
-
-					$delete[$v][] = $row['id'];
-
-					if (!empty($cctable[$v]))
-					{
-						$this->deleteChildren($v, $row['id'], $delete);
-					}
+					$delete[$v][] = $id;
+					$this->deleteChildren($v, $id, $delete);
 				}
 			}
 		}

--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -1820,10 +1820,10 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 
 			if ($objDelete->numRows && !($GLOBALS['TL_DCA'][$v]['config']['doNotDeleteRecords'] ?? null))
 			{
-				foreach ($objDelete->fetchEach('id') as $id)
+				foreach ($objDelete->fetchEach('id') as $childId)
 				{
-					$delete[$v][] = $id;
-					$this->deleteChildren($v, $id, $delete);
+					$delete[$v][] = $childId;
+					$this->deleteChildren($v, $childId, $delete);
 				}
 			}
 		}


### PR DESCRIPTION
This restores the permission handling we had in all previous Contao versions. After discussing with @Toflar, this is the only viable solution to fix our permission issues. Here are two examples that are imho impossible to fix otherwise. They are not a technical issue, but a logical one.

1. If you duplicate a page, its articles will be duplicated as well as its content elements. If you do not have access to some elements, the whole page and articles are duplicated, **but "random" content elements will be missing**.

2. even worse, when deleting a page, DC_Table tries to delete all child records and create an undo record for them. The ones that the user does not have access will not be deleted, **and will not be added to the undo record**. They are however still removed by our reviseTable, and will therefore be lost without the option to undo.

In the same sense we could discuss to adjust the `undo` method instead of what we discussed in https://github.com/contao/contao/pull/7056

FYI @Toflar and me discussed that the same handling will not be possible in a regular REST/CRUD API. It would require special APIs for that, which can always be added if necessary.


- Fixes https://github.com/contao/contao/issues/7101
- Probably also makes https://github.com/contao/contao/pull/7102 obsolete but correctly checking the IDs/updating the cache might still be correct.