### PR TITLE
Remove a useless if condition

### DIFF
--- a/core-bundle/src/Util/ProcessUtil.php
+++ b/core-bundle/src/Util/ProcessUtil.php
@@ -56,12 +56,8 @@ class ProcessUtil implements ResetInterface
     public function createSymfonyConsoleProcess(string $command, string ...$commandArguments): Process
     {
         // Use PhpSubprocess introduced in Symfony 6.4 to respect command line arguments
-        // used to invoke the current process if possible.
-        if (class_exists(PhpSubprocess::class)) {
-            return new PhpSubprocess([$this->getPhpBinary(), $this->getConsolePath(), $command, ...$commandArguments]);
-        }
-
-        return new Process([$this->getPhpBinary(), $this->getConsolePath(), $command, ...$commandArguments]);
+        // used to invoke the current process.
+        return new PhpSubprocess([$this->getPhpBinary(), $this->getConsolePath(), $command, ...$commandArguments]);
     }
 
     public function reset(): void


### PR DESCRIPTION
Just noticed we are on 6.4 in 5.3 anway so the condition is not needed. See https://github.com/contao/contao/pull/7127