### PR TITLE
Add a `deserialize` Twig filter

### DIFF
--- a/core-bundle/src/Twig/Extension/ContaoExtension.php
+++ b/core-bundle/src/Twig/Extension/ContaoExtension.php
@@ -342,7 +342,7 @@ final class ContaoExtension extends AbstractExtension implements GlobalsInterfac
             ),
             new TwigFilter(
                 'deserialize',
-                static fn (mixed $value) => StringUtil::deserialize($value),
+                static fn (mixed $value) => StringUtil::deserialize($value, true),
             ),
         ];
     }

--- a/core-bundle/src/Twig/Extension/ContaoExtension.php
+++ b/core-bundle/src/Twig/Extension/ContaoExtension.php
@@ -42,6 +42,7 @@ use Contao\CoreBundle\Twig\Runtime\SchemaOrgRuntime;
 use Contao\CoreBundle\Twig\Runtime\StringRuntime;
 use Contao\CoreBundle\Twig\Runtime\UrlRuntime;
 use Contao\FrontendTemplateTrait;
+use Contao\StringUtil;
 use Contao\Template;
 use Symfony\Component\Filesystem\Path;
 use Twig\Environment;
@@ -338,6 +339,10 @@ final class ContaoExtension extends AbstractExtension implements GlobalsInterfac
                 'encode_email',
                 [StringRuntime::class, 'encodeEmail'],
                 ['preserves_safety' => ['contao_html', 'html']],
+            ),
+            new TwigFilter(
+                'deserialize',
+                static fn (mixed $value) => StringUtil::deserialize($value),
             ),
         ];
     }

--- a/core-bundle/tests/Twig/Extension/ContaoExtensionTest.php
+++ b/core-bundle/tests/Twig/Extension/ContaoExtensionTest.php
@@ -134,6 +134,7 @@ class ContaoExtensionTest extends TestCase
             'csp_unsafe_inline_style',
             'csp_inline_styles',
             'encode_email',
+            'deserialize',
         ];
 
         $this->assertCount(\count($expectedFilters), $filters);


### PR DESCRIPTION
As discussed on the Contao camp, we need a way to work with serialized data coming from the DB in Twig templates, e.g.

```twig
{% for index, value in 'a:2:{i:0;s:3:"foo";i:1;s:3:"bar";}'|deserialize %}
    {{ index }}: {{ value }}
{% endfor %}
```

1. Is a Twig filter the best option or do we need a Twig function so we can pass the `$force` argument?
2. Is deserializing in the template the best option or should we try to deserialize the data when passing it to the template?
