### PR TITLE
Fix the PHP subprocess call once again

### DIFF
--- a/core-bundle/src/Util/ProcessUtil.php
+++ b/core-bundle/src/Util/ProcessUtil.php
@@ -57,7 +57,13 @@ class ProcessUtil implements ResetInterface
     {
         // Use PhpSubprocess introduced in Symfony 6.4 to respect command line arguments
         // used to invoke the current process.
-        return new PhpSubprocess([$this->getPhpBinary(), $this->getConsolePath(), $command, ...$commandArguments]);
+        return new PhpSubprocess(
+            [$this->getConsolePath(), $command, ...$commandArguments],
+            null,
+            null,
+            60,
+            [$this->getPhpBinary()],
+        );
     }
 
     public function reset(): void

--- a/core-bundle/src/Util/ProcessUtil.php
+++ b/core-bundle/src/Util/ProcessUtil.php
@@ -57,13 +57,7 @@ class ProcessUtil implements ResetInterface
     {
         // Use PhpSubprocess introduced in Symfony 6.4 to respect command line arguments
         // used to invoke the current process.
-        return new PhpSubprocess(
-            [$this->getConsolePath(), $command, ...$commandArguments],
-            null,
-            null,
-            60,
-            [$this->getPhpBinary()],
-        );
+        return new PhpSubprocess([$this->getConsolePath(), $command, ...$commandArguments], php: [$this->getPhpBinary()]);
     }
 
     public function reset(): void


### PR DESCRIPTION
The binary is determined by `PhpSubprocess` itself or it has to be passed as a separate parameter which I think we should do here as we're caching it. Now we should finally have gotten this right.