### PR TITLE
Allow hyphens in custom legacy template names

### DIFF
--- a/core-bundle/contao/classes/Backend.php
+++ b/core-bundle/contao/classes/Backend.php
@@ -417,9 +417,7 @@ abstract class Backend extends Controller
 				}
 
 				$db = Database::getInstance();
-				/** @var \Symfony\Component\HttpFoundation\Request */
 				$request = $container->get('request_stack')->getCurrentRequest();
-				$request->getSession()->getId()
 
 				while ($ptable && !\in_array($GLOBALS['TL_DCA'][$table]['list']['sorting']['mode'] ?? null, array(DataContainer::MODE_TREE, DataContainer::MODE_TREE_EXTENDED)) && is_a($GLOBALS['TL_DCA'][$ptable]['config']['dataContainer'] ?? null, DC_Table::class, true))
 				{

--- a/core-bundle/contao/classes/Backend.php
+++ b/core-bundle/contao/classes/Backend.php
@@ -417,7 +417,9 @@ abstract class Backend extends Controller
 				}
 
 				$db = Database::getInstance();
+				/** @var \Symfony\Component\HttpFoundation\Request */
 				$request = $container->get('request_stack')->getCurrentRequest();
+				$request->getSession()->getId()
 
 				while ($ptable && !\in_array($GLOBALS['TL_DCA'][$table]['list']['sorting']['mode'] ?? null, array(DataContainer::MODE_TREE, DataContainer::MODE_TREE_EXTENDED)) && is_a($GLOBALS['TL_DCA'][$ptable]['config']['dataContainer'] ?? null, DC_Table::class, true))
 				{

--- a/core-bundle/contao/library/Contao/Controller.php
+++ b/core-bundle/contao/library/Contao/Controller.php
@@ -164,11 +164,6 @@ abstract class Controller extends System
 			{
 				$strTemplate = basename($strFile, strrchr($strFile, '.'));
 
-				if (str_contains($strTemplate, '-'))
-				{
-					throw new \RuntimeException(sprintf('Using hyphens in the template name "%s" is not allowed, use snake_case instead.', $strTemplate));
-				}
-
 				// Ignore bundle templates, e.g. mod_article and mod_article_list
 				if (\in_array($strTemplate, $arrBundleTemplates))
 				{

--- a/core-bundle/tests/Contao/TemplateLoaderTest.php
+++ b/core-bundle/tests/Contao/TemplateLoaderTest.php
@@ -239,20 +239,6 @@ class TemplateLoaderTest extends TestCase
         unset($GLOBALS['CTLG']);
     }
 
-    public function testThrowsIfThereAreHyphensInCustomTemplateNames(): void
-    {
-        (new Filesystem())->touch([
-            Path::join($this->getTempDir(), '/templates/mod_article-custom.html5'),
-        ]);
-
-        TemplateLoader::addFile('mod_article', 'core-bundle/contao/templates/modules');
-
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Using hyphens in the template name "mod_article-custom" is not allowed, use snake_case instead.');
-
-        Controller::getTemplateGroup('mod_article');
-    }
-
     /**
      * @group legacy
      */

--- a/core-bundle/tests/Contao/TemplateLoaderTest.php
+++ b/core-bundle/tests/Contao/TemplateLoaderTest.php
@@ -168,6 +168,7 @@ class TemplateLoaderTest extends TestCase
     {
         (new Filesystem())->touch([
             Path::join($this->getTempDir(), 'templates/mod_article_custom.html5'),
+            Path::join($this->getTempDir(), 'templates/mod_article_foo-bar.html5'),
             Path::join($this->getTempDir(), 'templates/mod_article_list_custom.html5'),
         ]);
 
@@ -182,6 +183,7 @@ class TemplateLoaderTest extends TestCase
                 'mod_article_bar' => 'mod_article_bar',
                 'mod_article_custom' => 'mod_article_custom (global)',
                 'mod_article_foo' => 'mod_article_foo',
+                'mod_article_foo-bar' => 'mod_article_foo-bar (global)',
             ],
             Controller::getTemplateGroup('mod_article'),
         );
@@ -191,6 +193,7 @@ class TemplateLoaderTest extends TestCase
                 'mod_article_bar' => 'mod_article_bar',
                 'mod_article_custom' => 'mod_article_custom (global)',
                 'mod_article_foo' => 'mod_article_foo',
+                'mod_article_foo-bar' => 'mod_article_foo-bar (global)',
             ],
             Controller::getTemplateGroup('mod_article_'),
         );


### PR DESCRIPTION
In https://github.com/contao/contao/pull/731 a deprecation for hyphens in template names was added which turned into an exception in Contao 5.

However it is unclear why this deprecation was added in the first place. The original issue https://github.com/contao/contao/issues/725 was fixed and this fix is still present in Contao 5. There are no actual issues with hyphens in template names, neither in Contao 4 nor in Contao 5.

Besides, the error suggests to use snake case instead, which is semantically incorrect. In legacy templates names the underscore semantically creates template name (sub) groups. If you have a template called `mod_newslist_three-columns` it would technically be semantically incorrect to rename it `mod_newslist_three_columns`.

As discussed on Slack it is unclear whether this deprecation was added in the first place. There are no actual issues with hyphens in template names. However, my guess is we added it because we wanted to change the template naming structure in Contao 5 - but this never happened for legacy PHP templates, as we switched to Twig templates. And Twig templates _do_ have a new structuring scheme.

Therefore this restriction can be removed completely.

_Note:_ I will do a separate PR for 4.13 to remove the deprecation.