### PR TITLE
Catch the URL generator exception in the news insert tag

### DIFF
--- a/news-bundle/src/EventListener/InsertTagsListener.php
+++ b/news-bundle/src/EventListener/InsertTagsListener.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Contao\NewsBundle\EventListener;
 
 use Contao\CoreBundle\DependencyInjection\Attribute\AsHook;
+use Contao\CoreBundle\Exception\ForwardPageNotFoundException;
 use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\CoreBundle\Routing\ContentUrlGenerator;
 use Contao\NewsModel;
@@ -72,21 +73,30 @@ class InsertTagsListener
         return match ($insertTag) {
             'news' => sprintf(
                 '<a href="%s" title="%s"%s>%s</a>',
-                $this->urlGenerator->generate($model, [], \in_array('absolute', $arguments, true) ? UrlGeneratorInterface::ABSOLUTE_URL : UrlGeneratorInterface::ABSOLUTE_PATH),
+                $this->generateNewsUrl($model, $arguments),
                 StringUtil::specialcharsAttribute($model->headline),
                 \in_array('blank', $arguments, true) ? ' target="_blank" rel="noreferrer noopener"' : '',
                 $model->headline,
             ),
             'news_open' => sprintf(
                 '<a href="%s" title="%s"%s>',
-                $this->urlGenerator->generate($model, [], \in_array('absolute', $arguments, true) ? UrlGeneratorInterface::ABSOLUTE_URL : UrlGeneratorInterface::ABSOLUTE_PATH),
+                $this->generateNewsUrl($model, $arguments),
                 StringUtil::specialcharsAttribute($model->headline),
                 \in_array('blank', $arguments, true) ? ' target="_blank" rel="noreferrer noopener"' : '',
             ),
-            'news_url' => $this->urlGenerator->generate($model, [], \in_array('absolute', $arguments, true) ? UrlGeneratorInterface::ABSOLUTE_URL : UrlGeneratorInterface::ABSOLUTE_PATH),
+            'news_url' => $this->generateNewsUrl($model, $arguments),
             'news_title' => StringUtil::specialcharsAttribute($model->headline),
             'news_teaser' => $model->teaser,
             default => '',
         };
+    }
+
+    private function generateNewsUrl(NewsModel $model, array $arguments): string
+    {
+        try {
+            return $this->urlGenerator->generate($model, [], \in_array('absolute', $arguments, true) ? UrlGeneratorInterface::ABSOLUTE_URL : UrlGeneratorInterface::ABSOLUTE_PATH);
+        } catch (ForwardPageNotFoundException) {
+            return '';
+        }
     }
 }

--- a/news-bundle/tests/EventListener/InsertTagsListenerTest.php
+++ b/news-bundle/tests/EventListener/InsertTagsListenerTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\NewsBundle\Tests\EventListener;
 
+use Contao\CoreBundle\Exception\ForwardPageNotFoundException;
 use Contao\CoreBundle\Routing\ContentUrlGenerator;
 use Contao\NewsBundle\EventListener\InsertTagsListener;
 use Contao\NewsModel;
@@ -163,5 +164,25 @@ class InsertTagsListenerTest extends ContaoTestCase
         $listener = new InsertTagsListener($this->mockContaoFramework($adapters), $urlGenerator, $logger);
 
         $this->assertSame('', $listener('news_url::3', false, null, []));
+    }
+
+    public function testReturnsAnEmptyUrlIfTheUrlGeneratorThrowsException(): void
+    {
+        $newsModel = $this->mockClassWithProperties(NewsModel::class);
+
+        $adapters = [
+            NewsModel::class => $this->mockConfiguredAdapter(['findByIdOrAlias' => $newsModel]),
+        ];
+
+        $urlGenerator = $this->createMock(ContentUrlGenerator::class);
+        $urlGenerator
+            ->method('generate')
+            ->willThrowException(new ForwardPageNotFoundException());
+        ;
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $listener = new InsertTagsListener($this->mockContaoFramework($adapters), $urlGenerator, $logger);
+
+        $this->assertSame('', $listener('news_url::4', false, null, []));
     }
 }

--- a/news-bundle/tests/EventListener/InsertTagsListenerTest.php
+++ b/news-bundle/tests/EventListener/InsertTagsListenerTest.php
@@ -177,7 +177,7 @@ class InsertTagsListenerTest extends ContaoTestCase
         $urlGenerator = $this->createMock(ContentUrlGenerator::class);
         $urlGenerator
             ->method('generate')
-            ->willThrowException(new ForwardPageNotFoundException());
+            ->willThrowException(new ForwardPageNotFoundException())
         ;
 
         $logger = $this->createMock(LoggerInterface::class);


### PR DESCRIPTION
The `{{news_url::ID}}` insert tag will throw an exception and break the page completely, if the reader page for this news archive is unpublished. Instead, we should likely return an empty string.