### PR TITLE
Disable the search index listener in the back end

### DIFF
--- a/core-bundle/config/listener.yaml
+++ b/core-bundle/config/listener.yaml
@@ -444,6 +444,7 @@ services:
     contao.listener.search_index:
         class: Contao\CoreBundle\EventListener\SearchIndexListener
         arguments:
+            - '@contao.routing.scope_matcher'
             - '@messenger.bus.default'
             - '%fragment.path%'
 

--- a/core-bundle/src/EventListener/SearchIndexListener.php
+++ b/core-bundle/src/EventListener/SearchIndexListener.php
@@ -14,6 +14,7 @@ namespace Contao\CoreBundle\EventListener;
 
 use Contao\CoreBundle\Crawl\Escargot\Factory;
 use Contao\CoreBundle\Messenger\Message\SearchIndexMessage;
+use Contao\CoreBundle\Routing\ScopeMatcher;
 use Contao\CoreBundle\Search\Document;
 use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
 use Symfony\Component\HttpFoundation\Request;
@@ -32,6 +33,7 @@ class SearchIndexListener
     final public const FEATURE_DELETE = 0b10;
 
     public function __construct(
+        private readonly ScopeMatcher $scopeMatcher,
         private readonly MessageBusInterface $messageBus,
         private readonly string $fragmentPath = '_fragment',
         private readonly int $enabledFeatures = self::FEATURE_INDEX | self::FEATURE_DELETE,
@@ -43,6 +45,10 @@ class SearchIndexListener
      */
     public function __invoke(TerminateEvent $event): void
     {
+        if (!$this->scopeMatcher->isFrontendMainRequest($event)) {
+            return;
+        }
+
         $response = $event->getResponse();
 
         if ($response->isRedirection()) {

--- a/core-bundle/tests/EventListener/SearchIndexListenerTest.php
+++ b/core-bundle/tests/EventListener/SearchIndexListenerTest.php
@@ -54,7 +54,6 @@ class SearchIndexListenerTest extends TestCase
         ;
 
         $event = new TerminateEvent($this->createMock(HttpKernelInterface::class), $request, $response);
-
         $scopeMatcher = new ScopeMatcher(new BackendMatcher(), new FrontendMatcher());
 
         $listener = new SearchIndexListener($scopeMatcher, $messenger, '_fragment', $features);
@@ -63,7 +62,7 @@ class SearchIndexListenerTest extends TestCase
 
     public static function getRequestResponse(): iterable
     {
-        yield 'Should be skipped because it is not a frontend scope request' => [
+        yield 'Should be skipped because it is not a front end scope request' => [
             Request::create('/foobar'),
             new Response('<html><body><script type="application/ld+json">{"@context":"https:\/\/contao.org\/","@type":"Page","pageId":2,"noSearch":false,"protected":false,"groups":[],"fePreview":false}</script></body></html>'),
             SearchIndexListener::FEATURE_DELETE | SearchIndexListener::FEATURE_INDEX,

--- a/core-bundle/tests/EventListener/SearchIndexListenerTest.php
+++ b/core-bundle/tests/EventListener/SearchIndexListenerTest.php
@@ -69,7 +69,7 @@ class SearchIndexListenerTest extends TestCase
             SearchIndexListener::FEATURE_DELETE | SearchIndexListener::FEATURE_INDEX,
             false,
             false,
-            'backend'
+            'backend',
         ];
 
         yield 'Should index because the response was successful and contains ld+json information' => [

--- a/core-bundle/tests/EventListener/SearchIndexListenerTest.php
+++ b/core-bundle/tests/EventListener/SearchIndexListenerTest.php
@@ -15,6 +15,9 @@ namespace Contao\CoreBundle\Tests\EventListener;
 use Contao\CoreBundle\Crawl\Escargot\Factory;
 use Contao\CoreBundle\EventListener\SearchIndexListener;
 use Contao\CoreBundle\Messenger\Message\SearchIndexMessage;
+use Contao\CoreBundle\Routing\Matcher\BackendMatcher;
+use Contao\CoreBundle\Routing\Matcher\FrontendMatcher;
+use Contao\CoreBundle\Routing\ScopeMatcher;
 use Contao\CoreBundle\Tests\TestCase;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -29,8 +32,10 @@ class SearchIndexListenerTest extends TestCase
     /**
      * @dataProvider getRequestResponse
      */
-    public function testIndexesOrDeletesTheDocument(Request $request, Response $response, int $features, bool $index, bool $delete): void
+    public function testIndexesOrDeletesTheDocument(Request $request, Response $response, int $features, bool $index, bool $delete, string $scope = 'frontend'): void
     {
+        $request->attributes->set('_scope', $scope);
+
         $dispatchCount = (int) $index + (int) $delete;
         $messenger = $this->createMock(MessageBusInterface::class);
 
@@ -50,12 +55,23 @@ class SearchIndexListenerTest extends TestCase
 
         $event = new TerminateEvent($this->createMock(HttpKernelInterface::class), $request, $response);
 
-        $listener = new SearchIndexListener($messenger, '_fragment', $features);
+        $scopeMatcher = new ScopeMatcher(new BackendMatcher(), new FrontendMatcher());
+
+        $listener = new SearchIndexListener($scopeMatcher, $messenger, '_fragment', $features);
         $listener($event);
     }
 
     public static function getRequestResponse(): iterable
     {
+        yield 'Should be skipped because it is not a frontend scope request' => [
+            Request::create('/foobar'),
+            new Response('<html><body><script type="application/ld+json">{"@context":"https:\/\/contao.org\/","@type":"Page","pageId":2,"noSearch":false,"protected":false,"groups":[],"fePreview":false}</script></body></html>'),
+            SearchIndexListener::FEATURE_DELETE | SearchIndexListener::FEATURE_INDEX,
+            false,
+            false,
+            'backend'
+        ];
+
         yield 'Should index because the response was successful and contains ld+json information' => [
             Request::create('/foobar'),
             new Response('<html><body><script type="application/ld+json">{"@context":"https:\/\/contao.org\/","@type":"Page","pageId":2,"noSearch":false,"protected":false,"groups":[],"fePreview":false}</script></body></html>'),


### PR DESCRIPTION
Accessing the `$document->getContentCrawler()`  is a very heavy operation if you have `masterminds/html5` installed because Symfony's DomCrawler component will use this parser automatically to parse the entire HTML.
This can be very heavy, especially in the back end. I noticed that this listener is not needed in the back end at all, it's only wasted resources.

I didn't bother fixing it in 4.13 because I don't use it anywhere anymore and by default, Contao does not have that problem because it does not require `masterminds/html5` itself. You will only have this useless slow-down when having it installed.