### PR TITLE
Store enum fields in the DCA extractor cache

### DIFF
--- a/core-bundle/src/Cache/ContaoCacheWarmer.php
+++ b/core-bundle/src/Cache/ContaoCacheWarmer.php
@@ -207,12 +207,13 @@ class ContaoCacheWarmer implements CacheWarmerInterface
             $this->filesystem->dumpFile(
                 Path::join($cacheDir, 'contao/sql', "$table.php"),
                 sprintf(
-                    "<?php\n\n%s\n\n%s\n\n%s\n\n%s\n\n%s\n\n\$this->blnIsDbTable = true;\n",
+                    "<?php\n\n%s\n\n%s\n\n%s\n\n%s\n\n%s\n\n%s\n\n\$this->blnIsDbTable = true;\n",
                     sprintf('$this->arrMeta = %s;', var_export($extract->getMeta(), true)),
                     sprintf('$this->arrFields = %s;', var_export($extract->getFields(), true)),
                     sprintf('$this->arrUniqueFields = %s;', var_export($extract->getUniqueFields(), true)),
                     sprintf('$this->arrKeys = %s;', var_export($extract->getKeys(), true)),
                     sprintf('$this->arrRelations = %s;', var_export($extract->getRelations(), true)),
+                    sprintf('$this->arrEnums = %s;', var_export($extract->getEnums(), true)),
                 ),
             );
         }


### PR DESCRIPTION
**Problem:**
The `DcaExtractor` is parsing DCA data and provides information about any enumeration fields within a DCA (see #6584 for the original feature). However, if the extracted data is cached by the `ContaoCacheWarmer`, the enum configuration is missing.

This results in an incorrect/incomplete configuration and it is not possible to resolve enumerations within a model if the extract is read from the cache.

**Solution:**
This PR adds the enumeration configuration to the cached data in `ContaoCacheWarmer`, making the information available in cached extracts.

**Additional optimisation & Tests**
Manually assembling the extract for the cache does not appear to be the most sustainable solution. However, this is outside the scope of this PR.

I have not made any adjustments to the tests in `ContaoCacheWarmerTest`, as so far only the output of `$this->arrFields` is tested in the extract and any other information (e.g. `arrRelations`, `arrKeys`, ...) is not checked explicitly.

If an addition to the test is desired, I can extend the test case and test data to include a field with an enum configuration.