### PR TITLE
Backport 'Fix non-existent "contao.image.image_factory" in FeedItem.php'

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/FeedItem.php
+++ b/core-bundle/src/Resources/contao/library/Contao/FeedItem.php
@@ -122,7 +122,7 @@ class FeedItem
 
 		if ($size && $objFile->isImage)
 		{
-			$image = System::getContainer()->get('contao.image.image_factory')->create(Path::join($rootDir, $strFile), $size);
+			$image = System::getContainer()->get('contao.image.factory')->create(Path::join($rootDir, $strFile), $size);
 			$fileUrl = $strUrl . $image->getUrl($rootDir);
 			$objFile = new File(Path::makeRelative($image->getPath(), $rootDir));
 		}


### PR DESCRIPTION
Backport fix for #7152

<!--
Bugfixes should be based on the 4.13 or 5.3 branch and features on the 5.x
branch. Select the correct branch in the "base:" drop-down menu above.

Replace this notice with a short README for your feature/bugfix. This will help
people to understand your PR and can be used as a start for the documentation.
-->
