### PR TITLE
PHP 8.4 compatibility

### DIFF
--- a/calendar-bundle/contao/classes/Calendar.php
+++ b/calendar-bundle/contao/classes/Calendar.php
@@ -531,7 +531,7 @@ class Calendar extends Frontend
 	/**
 	 * Creates a sub request for the given URI.
 	 */
-	private function createSubRequest(string $uri, ?Request $request = null): Request
+	private function createSubRequest(string $uri, Request|null $request = null): Request
 	{
 		$cookies = null !== $request ? $request->cookies->all() : array();
 		$server = null !== $request ? $request->server->all() : array();

--- a/calendar-bundle/contao/classes/Calendar.php
+++ b/calendar-bundle/contao/classes/Calendar.php
@@ -531,7 +531,7 @@ class Calendar extends Frontend
 	/**
 	 * Creates a sub request for the given URI.
 	 */
-	private function createSubRequest(string $uri, Request $request = null): Request
+	private function createSubRequest(string $uri, ?Request $request = null): Request
 	{
 		$cookies = null !== $request ? $request->cookies->all() : array();
 		$server = null !== $request ? $request->server->all() : array();

--- a/core-bundle/contao/classes/Backend.php
+++ b/core-bundle/contao/classes/Backend.php
@@ -210,7 +210,7 @@ abstract class Backend extends Controller
 	 *
 	 * @throws AccessDeniedException
 	 */
-	protected function getBackendModule($module, PickerInterface $picker = null)
+	protected function getBackendModule($module, ?PickerInterface $picker = null)
 	{
 		$arrModule = array();
 
@@ -672,7 +672,7 @@ abstract class Backend extends Controller
 	 *
 	 * @return string
 	 */
-	public static function addPageIcon($row, $label, DataContainer $dc=null, $imageAttribute='', $blnReturnImage=false, $blnProtected=false, $isVisibleRootTrailPage=false)
+	public static function addPageIcon($row, $label, ?DataContainer $dc=null, $imageAttribute='', $blnReturnImage=false, $blnProtected=false, $isVisibleRootTrailPage=false)
 	{
 		if ($blnProtected)
 		{

--- a/core-bundle/contao/classes/Backend.php
+++ b/core-bundle/contao/classes/Backend.php
@@ -210,7 +210,7 @@ abstract class Backend extends Controller
 	 *
 	 * @throws AccessDeniedException
 	 */
-	protected function getBackendModule($module, ?PickerInterface $picker = null)
+	protected function getBackendModule($module, PickerInterface|null $picker = null)
 	{
 		$arrModule = array();
 
@@ -672,7 +672,7 @@ abstract class Backend extends Controller
 	 *
 	 * @return string
 	 */
-	public static function addPageIcon($row, $label, ?DataContainer $dc=null, $imageAttribute='', $blnReturnImage=false, $blnProtected=false, $isVisibleRootTrailPage=false)
+	public static function addPageIcon($row, $label, DataContainer|null $dc=null, $imageAttribute='', $blnReturnImage=false, $blnProtected=false, $isVisibleRootTrailPage=false)
 	{
 		if ($blnProtected)
 		{

--- a/core-bundle/contao/classes/BackendModule.php
+++ b/core-bundle/contao/classes/BackendModule.php
@@ -40,7 +40,7 @@ abstract class BackendModule extends Backend
 	 *
 	 * @param DataContainer $dc
 	 */
-	public function __construct(DataContainer $dc=null)
+	public function __construct(?DataContainer $dc=null)
 	{
 		parent::__construct();
 		$this->objDc = $dc;

--- a/core-bundle/contao/classes/BackendModule.php
+++ b/core-bundle/contao/classes/BackendModule.php
@@ -40,7 +40,7 @@ abstract class BackendModule extends Backend
 	 *
 	 * @param DataContainer $dc
 	 */
-	public function __construct(?DataContainer $dc=null)
+	public function __construct(DataContainer|null $dc=null)
 	{
 		parent::__construct();
 		$this->objDc = $dc;

--- a/core-bundle/contao/classes/DataContainer.php
+++ b/core-bundle/contao/classes/DataContainer.php
@@ -1648,7 +1648,7 @@ abstract class DataContainer extends Backend
 	 *
 	 * @return string|array<string>
 	 */
-	public function generateRecordLabel(array $row, ?string $table = null, bool $protected = false, bool $isVisibleRootTrailPage = false)
+	public function generateRecordLabel(array $row, string|null $table = null, bool $protected = false, bool $isVisibleRootTrailPage = false)
 	{
 		$table = $table ?? $this->strTable;
 		$labelConfig = &$GLOBALS['TL_DCA'][$table]['list']['label'];
@@ -1846,7 +1846,7 @@ abstract class DataContainer extends Backend
 	/**
 	 * @param array<string, mixed>|null $row Pass null to remove a given cache entry
 	 */
-	protected static function setCurrentRecordCache(string|int $id, string $table, array $row): void
+	protected static function setCurrentRecordCache(int|string $id, string $table, array $row): void
 	{
 		self::$arrCurrentRecordCache[$table . '.' . $id] = $row;
 	}
@@ -1855,7 +1855,7 @@ abstract class DataContainer extends Backend
 	 * @throws AccessDeniedException     if the current user has no read permission
 	 * @return array<string, mixed>|null
 	 */
-	public function getCurrentRecord(string|int|null $id = null, ?string $table = null): array|null
+	public function getCurrentRecord(int|string|null $id = null, string|null $table = null): array|null
 	{
 		$id = $id ?: $this->intId;
 		$table = $table ?: $this->strTable;
@@ -1894,7 +1894,7 @@ abstract class DataContainer extends Backend
 		return self::$arrCurrentRecordCache[$key];
 	}
 
-	public static function clearCurrentRecordCache(string|int|null $id = null, ?string $table = null): void
+	public static function clearCurrentRecordCache(int|string|null $id = null, string|null $table = null): void
 	{
 		if (null === $table)
 		{

--- a/core-bundle/contao/classes/DataContainer.php
+++ b/core-bundle/contao/classes/DataContainer.php
@@ -1648,7 +1648,7 @@ abstract class DataContainer extends Backend
 	 *
 	 * @return string|array<string>
 	 */
-	public function generateRecordLabel(array $row, string $table = null, bool $protected = false, bool $isVisibleRootTrailPage = false)
+	public function generateRecordLabel(array $row, ?string $table = null, bool $protected = false, bool $isVisibleRootTrailPage = false)
 	{
 		$table = $table ?? $this->strTable;
 		$labelConfig = &$GLOBALS['TL_DCA'][$table]['list']['label'];
@@ -1855,7 +1855,7 @@ abstract class DataContainer extends Backend
 	 * @throws AccessDeniedException     if the current user has no read permission
 	 * @return array<string, mixed>|null
 	 */
-	public function getCurrentRecord(string|int $id = null, string $table = null): array|null
+	public function getCurrentRecord(string|int|null $id = null, ?string $table = null): array|null
 	{
 		$id = $id ?: $this->intId;
 		$table = $table ?: $this->strTable;
@@ -1894,7 +1894,7 @@ abstract class DataContainer extends Backend
 		return self::$arrCurrentRecordCache[$key];
 	}
 
-	public static function clearCurrentRecordCache(string|int $id = null, string $table = null): void
+	public static function clearCurrentRecordCache(string|int|null $id = null, ?string $table = null): void
 	{
 		if (null === $table)
 		{

--- a/core-bundle/contao/dca/tl_image_size.php
+++ b/core-bundle/contao/dca/tl_image_size.php
@@ -318,7 +318,7 @@ class tl_image_size extends Backend
 	 *
 	 * @return array
 	 */
-	public function getFormats(DataContainer $dc=null)
+	public function getFormats(?DataContainer $dc=null)
 	{
 		$formats = array();
 		$missingSupport = array();
@@ -380,7 +380,7 @@ class tl_image_size extends Backend
 	 *
 	 * @return array
 	 */
-	public function getMetadataFields(DataContainer $dc=null)
+	public function getMetadataFields(?DataContainer $dc=null)
 	{
 		$options = array();
 

--- a/core-bundle/contao/dca/tl_image_size.php
+++ b/core-bundle/contao/dca/tl_image_size.php
@@ -318,7 +318,7 @@ class tl_image_size extends Backend
 	 *
 	 * @return array
 	 */
-	public function getFormats(?DataContainer $dc=null)
+	public function getFormats(DataContainer|null $dc=null)
 	{
 		$formats = array();
 		$missingSupport = array();
@@ -380,7 +380,7 @@ class tl_image_size extends Backend
 	 *
 	 * @return array
 	 */
-	public function getMetadataFields(?DataContainer $dc=null)
+	public function getMetadataFields(DataContainer|null $dc=null)
 	{
 		$options = array();
 

--- a/core-bundle/contao/dca/tl_page.php
+++ b/core-bundle/contao/dca/tl_page.php
@@ -964,7 +964,7 @@ class tl_page extends Backend
 	 *
 	 * @return string
 	 */
-	public function addIcon($row, $label, ?DataContainer $dc=null, $imageAttribute='', $blnReturnImage=false, $blnProtected=false, $isVisibleRootTrailPage=false)
+	public function addIcon($row, $label, DataContainer|null $dc=null, $imageAttribute='', $blnReturnImage=false, $blnProtected=false, $isVisibleRootTrailPage=false)
 	{
 		return Backend::addPageIcon($row, $label, $dc, $imageAttribute, $blnReturnImage, $blnProtected, $isVisibleRootTrailPage);
 	}

--- a/core-bundle/contao/dca/tl_page.php
+++ b/core-bundle/contao/dca/tl_page.php
@@ -964,7 +964,7 @@ class tl_page extends Backend
 	 *
 	 * @return string
 	 */
-	public function addIcon($row, $label, DataContainer $dc=null, $imageAttribute='', $blnReturnImage=false, $blnProtected=false, $isVisibleRootTrailPage=false)
+	public function addIcon($row, $label, ?DataContainer $dc=null, $imageAttribute='', $blnReturnImage=false, $blnProtected=false, $isVisibleRootTrailPage=false)
 	{
 		return Backend::addPageIcon($row, $label, $dc, $imageAttribute, $blnReturnImage, $blnProtected, $isVisibleRootTrailPage);
 	}

--- a/core-bundle/contao/library/Contao/Controller.php
+++ b/core-bundle/contao/library/Contao/Controller.php
@@ -1477,7 +1477,7 @@ abstract class Controller extends System
 	 *
 	 * @return string The script path with the static URL
 	 */
-	public static function addStaticUrlTo($script, ContaoContext $context = null)
+	public static function addStaticUrlTo($script, ?ContaoContext $context = null)
 	{
 		// Absolute URLs
 		if (preg_match('@^https?://@', $script))

--- a/core-bundle/contao/library/Contao/Controller.php
+++ b/core-bundle/contao/library/Contao/Controller.php
@@ -1477,7 +1477,7 @@ abstract class Controller extends System
 	 *
 	 * @return string The script path with the static URL
 	 */
-	public static function addStaticUrlTo($script, ?ContaoContext $context = null)
+	public static function addStaticUrlTo($script, ContaoContext|null $context = null)
 	{
 		// Absolute URLs
 		if (preg_match('@^https?://@', $script))

--- a/core-bundle/contao/library/Contao/Pagination.php
+++ b/core-bundle/contao/library/Contao/Pagination.php
@@ -129,7 +129,7 @@ class Pagination
 	 * @param Template $objTemplate      The template object
 	 * @param boolean  $blnForceParam    Force the URL parameter
 	 */
-	public function __construct($intRows, $intPerPage, $intNumberOfLinks=7, $strParameter='page', Template $objTemplate=null, $blnForceParam=false)
+	public function __construct($intRows, $intPerPage, $intNumberOfLinks=7, $strParameter='page', ?Template $objTemplate=null, $blnForceParam=false)
 	{
 		$this->intPage = 1;
 		$this->intRows = (int) $intRows;

--- a/core-bundle/contao/library/Contao/Pagination.php
+++ b/core-bundle/contao/library/Contao/Pagination.php
@@ -129,7 +129,7 @@ class Pagination
 	 * @param Template $objTemplate      The template object
 	 * @param boolean  $blnForceParam    Force the URL parameter
 	 */
-	public function __construct($intRows, $intPerPage, $intNumberOfLinks=7, $strParameter='page', ?Template $objTemplate=null, $blnForceParam=false)
+	public function __construct($intRows, $intPerPage, $intNumberOfLinks=7, $strParameter='page', Template|null $objTemplate=null, $blnForceParam=false)
 	{
 		$this->intPage = 1;
 		$this->intRows = (int) $intRows;

--- a/core-bundle/contao/library/Contao/Search.php
+++ b/core-bundle/contao/library/Contao/Search.php
@@ -764,7 +764,7 @@ class Search
 	 *
 	 * @param string $strUrl The URL to be removed
 	 */
-	public static function removeEntry($strUrl, ?Connection $connection = null)
+	public static function removeEntry($strUrl, Connection|null $connection = null)
 	{
 		$connection = $connection ?? System::getContainer()->get('database_connection');
 		$result = $connection->executeQuery('SELECT id FROM tl_search WHERE url = :url', array('url' => $strUrl));

--- a/core-bundle/contao/library/Contao/Search.php
+++ b/core-bundle/contao/library/Contao/Search.php
@@ -764,7 +764,7 @@ class Search
 	 *
 	 * @param string $strUrl The URL to be removed
 	 */
-	public static function removeEntry($strUrl, Connection $connection = null)
+	public static function removeEntry($strUrl, ?Connection $connection = null)
 	{
 		$connection = $connection ?? System::getContainer()->get('database_connection');
 		$result = $connection->executeQuery('SELECT id FROM tl_search WHERE url = :url', array('url' => $strUrl));

--- a/core-bundle/contao/library/Contao/TemplateInheritance.php
+++ b/core-bundle/contao/library/Contao/TemplateInheritance.php
@@ -164,7 +164,7 @@ trait TemplateInheritance
 		return $strBuffer;
 	}
 
-	public function setDebug(?bool $debug = null): self
+	public function setDebug(bool|null $debug = null): self
 	{
 		$this->blnDebug = $debug;
 
@@ -313,7 +313,7 @@ trait TemplateInheritance
 	 * @param string $name The template name
 	 * @param array  $data An optional data array
 	 */
-	public function insert($name, ?array $data=null)
+	public function insert($name, array|null $data=null)
 	{
 		if ($this instanceof Template)
 		{

--- a/core-bundle/contao/library/Contao/TemplateInheritance.php
+++ b/core-bundle/contao/library/Contao/TemplateInheritance.php
@@ -164,7 +164,7 @@ trait TemplateInheritance
 		return $strBuffer;
 	}
 
-	public function setDebug(bool $debug = null): self
+	public function setDebug(?bool $debug = null): self
 	{
 		$this->blnDebug = $debug;
 
@@ -313,7 +313,7 @@ trait TemplateInheritance
 	 * @param string $name The template name
 	 * @param array  $data An optional data array
 	 */
-	public function insert($name, array $data=null)
+	public function insert($name, ?array $data=null)
 	{
 		if ($this instanceof Template)
 		{

--- a/core-bundle/contao/library/Contao/TemplateTrait.php
+++ b/core-bundle/contao/library/Contao/TemplateTrait.php
@@ -156,7 +156,7 @@ trait TemplateTrait
 	/**
 	 * Adds a source to the given CSP directive.
 	 */
-	public function addCspSource(string|array $directives, string $source): void
+	public function addCspSource(array|string $directives, string $source): void
 	{
 		$responseContext = System::getContainer()->get('contao.routing.response_context_accessor')->getResponseContext();
 

--- a/core-bundle/contao/library/Contao/Widget.php
+++ b/core-bundle/contao/library/Contao/Widget.php
@@ -714,7 +714,7 @@ abstract class Widget extends Controller
 	 *
 	 * @return $this The widget object
 	 */
-	public function setInputCallback(callable $callback=null)
+	public function setInputCallback(?callable $callback=null)
 	{
 		$this->inputCallback = $callback;
 

--- a/core-bundle/contao/library/Contao/Widget.php
+++ b/core-bundle/contao/library/Contao/Widget.php
@@ -714,7 +714,7 @@ abstract class Widget extends Controller
 	 *
 	 * @return $this The widget object
 	 */
-	public function setInputCallback(?callable $callback=null)
+	public function setInputCallback(callable|null $callback=null)
 	{
 		$this->inputCallback = $callback;
 

--- a/core-bundle/contao/pages/PageError401.php
+++ b/core-bundle/contao/pages/PageError401.php
@@ -26,7 +26,7 @@ class PageError401 extends Frontend
 	 *
 	 * @return Response
 	 */
-	public function getResponse(?PageModel $objRootPage=null)
+	public function getResponse(PageModel|null $objRootPage=null)
 	{
 		global $objPage;
 
@@ -55,7 +55,7 @@ class PageError401 extends Frontend
 	 *
 	 * @throws InsufficientAuthenticationException
 	 */
-	private function prepare(?PageModel $objRootPage=null)
+	private function prepare(PageModel|null $objRootPage=null)
 	{
 		// Use the given root page object if available (thanks to Andreas Schempp)
 		if ($objRootPage === null)

--- a/core-bundle/contao/pages/PageError401.php
+++ b/core-bundle/contao/pages/PageError401.php
@@ -26,7 +26,7 @@ class PageError401 extends Frontend
 	 *
 	 * @return Response
 	 */
-	public function getResponse(PageModel $objRootPage=null)
+	public function getResponse(?PageModel $objRootPage=null)
 	{
 		global $objPage;
 
@@ -55,7 +55,7 @@ class PageError401 extends Frontend
 	 *
 	 * @throws InsufficientAuthenticationException
 	 */
-	private function prepare(PageModel $objRootPage=null)
+	private function prepare(?PageModel $objRootPage=null)
 	{
 		// Use the given root page object if available (thanks to Andreas Schempp)
 		if ($objRootPage === null)

--- a/core-bundle/contao/pages/PageError403.php
+++ b/core-bundle/contao/pages/PageError403.php
@@ -26,7 +26,7 @@ class PageError403 extends Frontend
 	 *
 	 * @return Response
 	 */
-	public function getResponse(PageModel $objRootPage=null)
+	public function getResponse(?PageModel $objRootPage=null)
 	{
 		global $objPage;
 
@@ -55,7 +55,7 @@ class PageError403 extends Frontend
 	 *
 	 * @throws AccessDeniedException
 	 */
-	private function prepare(PageModel $objRootPage=null)
+	private function prepare(?PageModel $objRootPage=null)
 	{
 		// Use the given root page object if available (thanks to Andreas Schempp)
 		if ($objRootPage === null)

--- a/core-bundle/contao/pages/PageError403.php
+++ b/core-bundle/contao/pages/PageError403.php
@@ -26,7 +26,7 @@ class PageError403 extends Frontend
 	 *
 	 * @return Response
 	 */
-	public function getResponse(?PageModel $objRootPage=null)
+	public function getResponse(PageModel|null $objRootPage=null)
 	{
 		global $objPage;
 
@@ -55,7 +55,7 @@ class PageError403 extends Frontend
 	 *
 	 * @throws AccessDeniedException
 	 */
-	private function prepare(?PageModel $objRootPage=null)
+	private function prepare(PageModel|null $objRootPage=null)
 	{
 		// Use the given root page object if available (thanks to Andreas Schempp)
 		if ($objRootPage === null)

--- a/faq-bundle/contao/modules/ModuleFaq.php
+++ b/faq-bundle/contao/modules/ModuleFaq.php
@@ -24,7 +24,7 @@ class ModuleFaq extends Frontend
 	 *
 	 * @return array
 	 */
-	public static function getSchemaOrgData(iterable $arrFaqs, ?string $identifier = null): array
+	public static function getSchemaOrgData(iterable $arrFaqs, string|null $identifier = null): array
 	{
 		$jsonLd = array(
 			'@type' => 'FAQPage',

--- a/faq-bundle/contao/modules/ModuleFaq.php
+++ b/faq-bundle/contao/modules/ModuleFaq.php
@@ -24,7 +24,7 @@ class ModuleFaq extends Frontend
 	 *
 	 * @return array
 	 */
-	public static function getSchemaOrgData(iterable $arrFaqs, string $identifier = null): array
+	public static function getSchemaOrgData(iterable $arrFaqs, ?string $identifier = null): array
 	{
 		$jsonLd = array(
 			'@type' => 'FAQPage',

--- a/newsletter-bundle/contao/modules/ModuleSubscribe.php
+++ b/newsletter-bundle/contao/modules/ModuleSubscribe.php
@@ -246,7 +246,7 @@ class ModuleSubscribe extends Module
 	 *
 	 * @return array|bool
 	 */
-	protected function validateForm(Widget $objWidget=null)
+	protected function validateForm(?Widget $objWidget=null)
 	{
 		// Validate the e-mail address
 		$varInput = Idna::encodeEmail(Input::post('email', true));

--- a/newsletter-bundle/contao/modules/ModuleSubscribe.php
+++ b/newsletter-bundle/contao/modules/ModuleSubscribe.php
@@ -246,7 +246,7 @@ class ModuleSubscribe extends Module
 	 *
 	 * @return array|bool
 	 */
-	protected function validateForm(?Widget $objWidget=null)
+	protected function validateForm(Widget|null $objWidget=null)
 	{
 		// Validate the e-mail address
 		$varInput = Idna::encodeEmail(Input::post('email', true));

--- a/newsletter-bundle/contao/modules/ModuleUnsubscribe.php
+++ b/newsletter-bundle/contao/modules/ModuleUnsubscribe.php
@@ -156,7 +156,7 @@ class ModuleUnsubscribe extends Module
 	 *
 	 * @return array|bool
 	 */
-	protected function validateForm(Widget $objWidget=null)
+	protected function validateForm(?Widget $objWidget=null)
 	{
 		// Validate the e-mail address
 		$varInput = Idna::encodeEmail(Input::post('email', true));

--- a/newsletter-bundle/contao/modules/ModuleUnsubscribe.php
+++ b/newsletter-bundle/contao/modules/ModuleUnsubscribe.php
@@ -156,7 +156,7 @@ class ModuleUnsubscribe extends Module
 	 *
 	 * @return array|bool
 	 */
-	protected function validateForm(?Widget $objWidget=null)
+	protected function validateForm(Widget|null $objWidget=null)
 	{
 		// Validate the e-mail address
 		$varInput = Idna::encodeEmail(Input::post('email', true));

--- a/test-case/src/DeprecatedClassesPhpunitExtension.php
+++ b/test-case/src/DeprecatedClassesPhpunitExtension.php
@@ -61,7 +61,7 @@ abstract class DeprecatedClassesPhpunitExtension implements AfterLastTestHook, B
         $unhandledErrors = [];
 
         $previousHandler = set_error_handler(
-            static function ($errno, $errstr) use (&$expectedDeprecations, &$previousHandler, &$unhandledErrors) {
+            static function ($errno, $errstr) use (&$expectedDeprecations, &$unhandledErrors, &$previousHandler) {
                 foreach ($expectedDeprecations as $key => $expectedDeprecation) {
                     if ((new StringMatchesFormatDescription($expectedDeprecation))->evaluate($errstr, '', true)) {
                         unset($expectedDeprecations[$key]);

--- a/vendor-bin/ecs/config/legacy.php
+++ b/vendor-bin/ecs/config/legacy.php
@@ -27,7 +27,6 @@ use PhpCsFixer\Fixer\ControlStructure\ControlStructureContinuationPositionFixer;
 use PhpCsFixer\Fixer\ControlStructure\TrailingCommaInMultilineFixer;
 use PhpCsFixer\Fixer\ControlStructure\YodaStyleFixer;
 use PhpCsFixer\Fixer\FunctionNotation\NoSpacesAfterFunctionNameFixer;
-use PhpCsFixer\Fixer\FunctionNotation\NullableTypeDeclarationForDefaultNullValueFixer;
 use PhpCsFixer\Fixer\FunctionNotation\UseArrowFunctionsFixer;
 use PhpCsFixer\Fixer\FunctionNotation\VoidReturnFixer;
 use PhpCsFixer\Fixer\LanguageConstruct\GetClassToClassKeywordFixer;
@@ -87,7 +86,6 @@ return ECSConfig::configure()
         MultilineWhitespaceBeforeSemicolonsFixer::class,
         NoSpacesAfterFunctionNameFixer::class,
         NoSuperfluousPhpdocTagsFixer::class,
-        NullableTypeDeclarationForDefaultNullValueFixer::class,
         OrderedClassElementsFixer::class,
         PhpdocOrderFixer::class,
         PhpdocScalarFixer::class,

--- a/vendor-bin/ecs/config/legacy.php
+++ b/vendor-bin/ecs/config/legacy.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 use Contao\EasyCodingStandard\Fixer\ChainedMethodBlockFixer;
 use Contao\EasyCodingStandard\Fixer\CommentLengthFixer;
 use Contao\EasyCodingStandard\Fixer\MultiLineLambdaFunctionArgumentsFixer;
-use Contao\EasyCodingStandard\Fixer\TypeHintOrderFixer;
 use Contao\EasyCodingStandard\Set\SetList;
 use Contao\EasyCodingStandard\Sniffs\UseSprintfInExceptionsSniff;
 use PhpCsFixer\Fixer\Alias\ModernizeStrposFixer;
@@ -102,7 +101,6 @@ return ECSConfig::configure()
         StrictComparisonFixer::class,
         StrictParamFixer::class,
         TrailingCommaInMultilineFixer::class,
-        TypeHintOrderFixer::class,
         UnusedVariableSniff::class,
         UseArrowFunctionsFixer::class,
         UselessParenthesesSniff::class,


### PR DESCRIPTION
This fixes the `Implicitly marking parameter … as nullable is deprecated, the explicit nullable type must be used instead` deprecations in PHP 8.4.