### PR TITLE
Send an `X-Robots-Tag: noindex` header in the back end

### DIFF
--- a/core-bundle/src/EventListener/BackendNoindexListener.php
+++ b/core-bundle/src/EventListener/BackendNoindexListener.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\EventListener;
+
+use Contao\CoreBundle\Routing\ScopeMatcher;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+
+/**
+ * @internal
+ */
+class BackendNoindexListener
+{
+    private ScopeMatcher $scopeMatcher;
+
+    public function __construct(ScopeMatcher $scopeMatcher)
+    {
+        $this->scopeMatcher = $scopeMatcher;
+    }
+
+    /**
+     * Adds "X-Robots-Tag: noindex" to the response for the back end.
+     */
+    public function __invoke(ResponseEvent $event): void
+    {
+        if (!$this->scopeMatcher->isBackendMainRequest($event)) {
+            return;
+        }
+
+        $event->getResponse()->headers->set('X-Robots-Tag', 'noindex');
+    }
+}

--- a/core-bundle/src/Resources/config/listener.yml
+++ b/core-bundle/src/Resources/config/listener.yml
@@ -11,6 +11,13 @@ services:
             # The priority must be lower than the one of the firewall listener (defaults to 8)
             - { name: kernel.event_listener, priority: 7 }
 
+    contao.listener.backend_noindex:
+        class: Contao\CoreBundle\EventListener\BackendNoindexListener
+        arguments:
+            - '@contao.routing.scope_matcher'
+        tags:
+            - { name: kernel.event_listener }
+
     contao.listener.backend_preview_redirect:
         class: Contao\CoreBundle\EventListener\BackendPreviewRedirectListener
         arguments:

--- a/core-bundle/tests/EventListener/BackendNoindexListenerTest.php
+++ b/core-bundle/tests/EventListener/BackendNoindexListenerTest.php
@@ -30,7 +30,6 @@ class BackendNoindexListenerTest extends TestCase
         $request->attributes->set('_scope', 'backend');
 
         $response = new Response();
-
         $kernel = $this->createMock(KernelInterface::class);
         $event = new ResponseEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST, $response);
 
@@ -43,9 +42,7 @@ class BackendNoindexListenerTest extends TestCase
     public function testDoesNotAddNoindexIfNotBackendResponse(): void
     {
         $request = Request::create('/foobar');
-
         $response = new Response();
-
         $kernel = $this->createMock(KernelInterface::class);
         $event = new ResponseEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST, $response);
 

--- a/core-bundle/tests/EventListener/BackendNoindexListenerTest.php
+++ b/core-bundle/tests/EventListener/BackendNoindexListenerTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\EventListener;
+
+use Contao\CoreBundle\EventListener\BackendNoindexListener;
+use Contao\CoreBundle\Routing\ScopeMatcher;
+use Contao\CoreBundle\Tests\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcher;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+class BackendNoindexListenerTest extends TestCase
+{
+    public function testAddsNoindexToBackendResponse(): void
+    {
+        $request = Request::create('/contao');
+        $request->attributes->set('_scope', 'backend');
+
+        $response = new Response();
+
+        $kernel = $this->createMock(KernelInterface::class);
+        $event = new ResponseEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST, $response);
+
+        $listener = new BackendNoindexListener($this->getScopeMatcher());
+        $listener($event);
+
+        $this->assertSame('noindex', $response->headers->get('X-Robots-Tag'));
+    }
+
+    public function testDoesNotAddNoindexIfNotBackendResponse(): void
+    {
+        $request = Request::create('/foobar');
+
+        $response = new Response();
+
+        $kernel = $this->createMock(KernelInterface::class);
+        $event = new ResponseEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST, $response);
+
+        $listener = new BackendNoindexListener($this->getScopeMatcher());
+        $listener($event);
+
+        $this->assertNull($response->headers->get('X-Robots-Tag'));
+    }
+
+    private function getScopeMatcher(): ScopeMatcher
+    {
+        $frontendMatcher = new RequestMatcher();
+        $frontendMatcher->matchAttribute('_scope', 'frontend');
+
+        $backendMatcher = new RequestMatcher();
+        $backendMatcher->matchAttribute('_scope', 'backend');
+
+        return new ScopeMatcher($backendMatcher, $frontendMatcher);
+    }
+}


### PR DESCRIPTION
Alternative solution for https://github.com/contao/contao/pull/7148 - which will need to be reverted (the revert will fix #7159).

The problematic code is

https://github.com/contao/contao/blob/0792bf9cf7fd2d3a354b372b532e0a49661f7ed4/core-bundle/src/EventListener/SearchIndexListener.php#L95

which will be slow in the back end if you have a large site structure for instance - or a lot of files visible in the file manager etc.

Instead of checking for the `backend` scope in the `SearchIndexListener` (which is not possible) we can instead add `X-Robots-Tag: noindex` to any back end response, as this will be checked for before that: 

https://github.com/contao/contao/blob/0792bf9cf7fd2d3a354b372b532e0a49661f7ed4/core-bundle/src/EventListener/SearchIndexListener.php#L89-L92

And besides it probably makes sense to add this for back end responses in any case.