### PR TITLE
Allow to move an error page within its root

### DIFF
--- a/core-bundle/src/Security/Voter/DataContainer/PageTypeAccessVoter.php
+++ b/core-bundle/src/Security/Voter/DataContainer/PageTypeAccessVoter.php
@@ -89,8 +89,8 @@ class PageTypeAccessVoter extends AbstractDataContainerVoter implements ResetInt
         }
 
         $type = $action->getNew()['type'] ?? ($action instanceof UpdateAction ? $action->getCurrent()['type'] : null);
-        $pid = (int) ($action->getNewPid() ?? ($action instanceof UpdateAction ? $action->getCurrentPid() : null));
         $currentPid = $action instanceof UpdateAction ? (int) $action->getCurrentPid() : null;
+        $pid = (int) ($action->getNewPid() ?? $currentPid);
 
         if (
             (null !== $action->getNewPid() || null !== ($action->getNew()['sorting'] ?? null))

--- a/core-bundle/src/Security/Voter/DataContainer/PageTypeAccessVoter.php
+++ b/core-bundle/src/Security/Voter/DataContainer/PageTypeAccessVoter.php
@@ -90,10 +90,12 @@ class PageTypeAccessVoter extends AbstractDataContainerVoter implements ResetInt
 
         $type = $action->getNew()['type'] ?? ($action instanceof UpdateAction ? $action->getCurrent()['type'] : null);
         $pid = (int) ($action->getNewPid() ?? ($action instanceof UpdateAction ? $action->getCurrentPid() : null));
+        $currentPid = $action instanceof UpdateAction ? (int) $action->getCurrentPid() : null;
 
         if (
             (null !== $action->getNewPid() || null !== ($action->getNew()['sorting'] ?? null))
             && (!$action instanceof UpdateAction || \in_array($type, self::FIRST_LEVEL_TYPES, true))
+            && ($pid !== $currentPid)
             && (!$this->isRootPage($pid) || $this->hasPageTypeInRoot($type, $pid))
         ) {
             return false;

--- a/core-bundle/tests/Security/Voter/DataContainer/PageTypeAccessVoterTest.php
+++ b/core-bundle/tests/Security/Voter/DataContainer/PageTypeAccessVoterTest.php
@@ -269,11 +269,11 @@ class PageTypeAccessVoterTest extends TestCase
                 VoterInterface::ACCESS_DENIED,
             ];
 
-            yield "Deny if only sorting of $type is changed" => [
+            yield "Allow if page of type $type is moved within the same root" => [
                 new UpdateAction('tl_page', ['pid' => 42, 'type' => $type], ['sorting' => 256]),
-                [42],
-                [[42, $type]],
-                VoterInterface::ACCESS_DENIED,
+                null,
+                null,
+                VoterInterface::ACCESS_ABSTAIN,
             ];
         }
     }


### PR DESCRIPTION
Fixes https://github.com/contao/contao/issues/7116
