### PR TITLE
Correctly resolve child definitions for callback tags

### DIFF
--- a/core-bundle/src/DependencyInjection/Compiler/DataContainerCallbackPass.php
+++ b/core-bundle/src/DependencyInjection/Compiler/DataContainerCallbackPass.php
@@ -53,11 +53,11 @@ class DataContainerCallbackPass implements CompilerPassInterface
             }
 
             $definition = $container->findDefinition($serviceId);
+            $definition->setPublic(true);
 
             while (!$definition->getClass() && $definition instanceof ChildDefinition) {
                 $definition = $container->findDefinition($definition->getParent());
             }
-            $definition->setPublic(true);
 
             foreach ($tags as $attributes) {
                 $this->addCallback($callbacks, $serviceId, $definition->getClass(), $attributes);

--- a/core-bundle/src/DependencyInjection/Compiler/DataContainerCallbackPass.php
+++ b/core-bundle/src/DependencyInjection/Compiler/DataContainerCallbackPass.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\DependencyInjection\Compiler;
 
 use Symfony\Component\Config\Definition\Exception\InvalidDefinitionException;
+use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -52,6 +53,10 @@ class DataContainerCallbackPass implements CompilerPassInterface
             }
 
             $definition = $container->findDefinition($serviceId);
+
+            while (!$definition->getClass() && $definition instanceof ChildDefinition) {
+                $definition = $container->findDefinition($definition->getParent());
+            }
             $definition->setPublic(true);
 
             foreach ($tags as $attributes) {

--- a/core-bundle/tests/DependencyInjection/Compiler/DataContainerCallbackPassTest.php
+++ b/core-bundle/tests/DependencyInjection/Compiler/DataContainerCallbackPassTest.php
@@ -99,7 +99,6 @@ class DataContainerCallbackPassTest extends TestCase
 
         $this->assertTrue($container->findDefinition('test.parent.listener')->isPublic());
         $this->assertTrue($container->findDefinition('test.child.listener')->isPublic());
-
     }
 
     public function testMakesHookListenersPublic(): void

--- a/core-bundle/tests/DependencyInjection/Compiler/DataContainerCallbackPassTest.php
+++ b/core-bundle/tests/DependencyInjection/Compiler/DataContainerCallbackPassTest.php
@@ -96,6 +96,10 @@ class DataContainerCallbackPassTest extends TestCase
             ],
             $this->getCallbacksFromDefinition($container)[0]
         );
+
+        $this->assertTrue($container->findDefinition('test.parent.listener')->isPublic());
+        $this->assertTrue($container->findDefinition('test.child.listener')->isPublic());
+
     }
 
     public function testMakesHookListenersPublic(): void

--- a/core-bundle/tests/Fixtures/src/EventListener/TestListener.php
+++ b/core-bundle/tests/Fixtures/src/EventListener/TestListener.php
@@ -50,6 +50,11 @@ class TestListener
     {
     }
 
+    public function onOptions(): array
+    {
+        return [];
+    }
+
     public function onLoadSecond(): void
     {
     }


### PR DESCRIPTION
I was trying to add another `imgSize` field to `tl_module` and wanted to re-use the `contao.listener.image_size_options` listener which would be super easy like so:

```php

    $services->set('my_listener')
        ->parent('contao.listener.image_size_options')
        ->tag('contao.callback', [
            'table' => 'tl_module',
            'target' => 'fields.my_image_sizes_field.options',
        ])
    ;
```

However, this currently fails because parent services are not correctly resolved. This PR fixes this.
The `while (!$definition->getClass() && $definition instanceof ChildDefinition) {` logic is Symfony standard and can be found in many other places for example the `RegisterEventListenersAndSubscribersPass` which has bascially more or less exactly the same responsibility as our `DataContainerCallbackPass` 😊 

I've also updated the `TestListener` which technically is not necessary. I could've used another method to mock this logic but I figured I wanted to work with my use case which as the options listener 😉 