### PR TITLE
Use the new `onpalette_callback` to unset fields in the file manager

### DIFF
--- a/core-bundle/contao/dca/tl_files.php
+++ b/core-bundle/contao/dca/tl_files.php
@@ -42,7 +42,6 @@ $GLOBALS['TL_DCA']['tl_files'] = array
 		(
 			array('tl_files', 'checkPermission'),
 			array('tl_files', 'addBreadcrumb'),
-			array('tl_files', 'adjustPalettes')
 		),
 		'oncreate_version_callback' => array
 		(
@@ -51,6 +50,10 @@ $GLOBALS['TL_DCA']['tl_files'] = array
 		'onrestore_version_callback' => array
 		(
 			array('tl_files', 'restoreVersion')
+		),
+		'onpalette_callback' => array
+		(
+			array('tl_files', 'adjustPalettes')
 		),
 		'sql' => array
 		(
@@ -456,11 +459,11 @@ class tl_files extends Backend
 	 *
 	 * @param DataContainer $dc
 	 */
-	public function adjustPalettes(DataContainer $dc)
+	public function adjustPalettes(string $strPalette, DataContainer $dc)
 	{
 		if (!$dc->id)
 		{
-			return;
+			return $strPalette;
 		}
 
 		$projectDir = System::getContainer()->getParameter('kernel.project_dir');
@@ -469,20 +472,22 @@ class tl_files extends Backend
 		// Remove the metadata when editing folders
 		if ($blnIsFolder)
 		{
-			PaletteManipulator::create()
+			$strPalette = PaletteManipulator::create()
 				->removeField('meta')
-				->applyToPalette('default', $dc->table)
+				->applyToString($strPalette)
 			;
 		}
 
 		// Only show the important part fields for images
 		if ($blnIsFolder || !in_array(strtolower(substr($dc->id, strrpos($dc->id, '.') + 1)), System::getContainer()->getParameter('contao.image.valid_extensions')))
 		{
-			PaletteManipulator::create()
+			$strPalette = PaletteManipulator::create()
 				->removeField(array('importantPartX', 'importantPartY', 'importantPartWidth', 'importantPartHeight'))
-				->applyToPalette('default', $dc->table)
+				->applytoString($strPalette)
 			;
 		}
+
+		return $strPalette;
 	}
 
 	/**


### PR DESCRIPTION
Noticed this while working on https://github.com/contao/contao/issues/7038, it is currently possible to set metadata for folders etc. The new `onpalette_callback` in Contao 5.3 allows to apply this correctly for each individual record in multi-edit mode.