### PR TITLE
Backport the boolean fields migration

### DIFF
--- a/core-bundle/src/Migration/Version413/BooleanFieldsMigration.php
+++ b/core-bundle/src/Migration/Version413/BooleanFieldsMigration.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Migration\Version413;
+
+use Contao\Controller;
+use Contao\CoreBundle\Config\ResourceFinder;
+use Contao\CoreBundle\Framework\ContaoFramework;
+use Contao\CoreBundle\Migration\AbstractMigration;
+use Contao\CoreBundle\Migration\MigrationResult;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Types\StringType;
+use Doctrine\DBAL\Types\Types;
+
+/**
+ * Converts empty string values of boolean fields to zeros.
+ * 
+ * @internal
+ */
+class BooleanFieldsMigration extends AbstractMigration
+{
+    private Connection $connection;
+    private ContaoFramework $framework;
+    private ResourceFinder $resourceFinder;
+
+    public function __construct(Connection $connection, ContaoFramework $framework, ResourceFinder $resourceFinder)
+    {
+        $this->connection = $connection;
+        $this->framework = $framework;
+        $this->resourceFinder = $resourceFinder;
+    }
+
+    public function shouldRun(): bool
+    {
+        foreach ($this->getTargets() as [$table, $column]) {
+            $test = $this->connection->fetchOne("SELECT TRUE FROM $table WHERE `$column` = '' LIMIT 1");
+
+            if (false !== $test) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function run(): MigrationResult
+    {
+        foreach ($this->getTargets() as [$table, $column]) {
+            $this->connection->update($table, [$column => '0'], [$column => '']);
+        }
+
+        return $this->createResult(true);
+    }
+
+    private function getTargets(): array
+    {
+        $this->framework->initialize();
+
+        $schemaManager = $this->connection->createSchemaManager();
+        $targets = [];
+        $processed = [];
+
+        $files = $this->resourceFinder->findIn('dca')->depth(0)->files()->name('*.php');
+
+        foreach ($files as $file) {
+            $tableName = $file->getBasename('.php');
+
+            if (\in_array($tableName, $processed, true)) {
+                continue;
+            }
+
+            $processed[] = $tableName;
+
+            if (!$schemaManager->tablesExist([$tableName])) {
+                continue;
+            }
+
+            $columns = $schemaManager->listTableColumns($tableName);
+
+            Controller::loadDataContainer($tableName);
+
+            foreach ($GLOBALS['TL_DCA'][$tableName]['fields'] ?? [] as $fieldName => $fieldConfig) {
+                $fieldName = strtolower($fieldName);
+
+                if (!isset($columns[$fieldName]) || Types::BOOLEAN !== ($fieldConfig['sql']['type'] ?? null)) {
+                    continue;
+                }
+
+                $field = $columns[$fieldName];
+
+                if ($field->getType() instanceof StringType) {
+                    $targets[] = [$tableName, $fieldName];
+                }
+            }
+        }
+
+        return $targets;
+    }
+}

--- a/core-bundle/src/Migration/Version413/BooleanFieldsMigration.php
+++ b/core-bundle/src/Migration/Version413/BooleanFieldsMigration.php
@@ -23,7 +23,7 @@ use Doctrine\DBAL\Types\Types;
 
 /**
  * Converts empty string values of boolean fields to zeros.
- * 
+ *
  * @internal
  */
 class BooleanFieldsMigration extends AbstractMigration

--- a/core-bundle/src/Resources/config/migrations.yml
+++ b/core-bundle/src/Resources/config/migrations.yml
@@ -119,6 +119,13 @@ services:
         arguments:
             - '@database_connection'
 
+    contao.migration.version_413.boolean_fields:
+        class: Contao\CoreBundle\Migration\Version413\BooleanFieldsMigration
+        arguments:
+            - '@database_connection'
+            - '@contao.framework'
+            - '@contao.resource_finder'
+
     contao.migration.version_413.file_extension:
         class: Contao\CoreBundle\Migration\Version413\FileExtensionMigration
         arguments:


### PR DESCRIPTION
Contao 4.13 already supports `boolean` SQL fields. However, there is still one issue: if you adjust your DCA from

```php
'sql' => "char(1) NOT NULL default ''",
```

or

```php
'sql' => ['type' => 'string', 'length' => 1, 'default' => '', 'options' => ['fixed' => true]],
```

to

```php
'sql' => ['type' => 'boolean', 'default' => false],
```

the following error will occur during migration (if you already have records in the affected DCA in your database):

```
[ERROR] An exception occurred while executing a query: SQLSTATE[22007]: Invalid datetime     
         format: 1292 Truncated incorrect INTEGER value: '    ' 
```

This is something we fixed in Contao 5 with the `BooleanFieldsMigration` as it was needed there since we made that switch there as well. However, any project or extension in Contao 4.13 that makes that same switch will always run into this error. For example this error will happen if you update `terminal42/notification_center` from `1.x` to `2.x` (given that you already had entries in your database):

```
 * ALTER TABLE tl_nc_language CHANGE fallback fallback TINYINT(1) DEFAULT 0 NOT NULL......FAILED
 * ALTER TABLE tl_nc_message CHANGE published published TINYINT(1) DEFAULT 0 NOT NULL......FAILED
                                                                           
 [OK] Executed 0 SQL queries.                                                   
                                                                                
 [ERROR] An exception occurred while executing a query: SQLSTATE[22007]: Invalid
         datetime format: 1292 Truncated incorrect INTEGER value: '    '        
                                                                                                                                                          
 [ERROR] An exception occurred while executing a query: SQLSTATE[22007]: Invalid
         datetime format: 1292 Truncated incorrect INTEGER value: '    '      
```

Now you could of course implement the `BooleanFieldsMigration` in those extensions or projects. But it would definitely be more convenient if Contao already supports you in this and not every extension has to implement this on their own.

To reproduce you can do the following:

1. Create the following DCA adjustment:
  ```php
  // contao/dca/tl_content.php
  $GLOBALS['TL_DCA']['tl_content']['fields']['foobar'] = [
      'sql' => "char(1) NOT NULL default ''",
  ];
  ```
2. Execute `contao:migrate --no-interaction`.
3. Create a new content element, if you have no content elements yet in your database.
4. Change the DCA to:
  ```php
  // contao/dca/tl_content.php
  $GLOBALS['TL_DCA']['tl_content']['fields']['foobar'] = [
      'sql' => ['type' => 'boolean', 'default' => false],
  ];
  ```
5. Execute `contao:migrate --no-interaction`.

_Note:_ we could provide this migration in perpetuity, i.e. moving it to the `Contao\CoreBundle\Migration\` namespace. wdyt?