### PR TITLE
Check access to `fieldsOfTable` for the file edit operation

### DIFF
--- a/core-bundle/contao/dca/tl_files.php
+++ b/core-bundle/contao/dca/tl_files.php
@@ -15,6 +15,7 @@ use Contao\Config;
 use Contao\CoreBundle\DataContainer\PaletteManipulator;
 use Contao\CoreBundle\Exception\AccessDeniedException;
 use Contao\CoreBundle\Security\ContaoCorePermissions;
+use Contao\CoreBundle\Security\DataContainer\UpdateAction;
 use Contao\Database;
 use Contao\DataContainer;
 use Contao\DC_Folder;
@@ -671,7 +672,10 @@ class tl_files extends Backend
 	 */
 	public function editFile($row, $href, $label, $title, $icon, $attributes)
 	{
-		return System::getContainer()->get('security.helper')->isGranted(ContaoCorePermissions::USER_CAN_RENAME_FILE) ? '<a href="' . $this->addToUrl($href . '&amp;id=' . $row['id']) . '" title="' . StringUtil::specialchars($title) . '"' . $attributes . '>' . Image::getHtml($icon, $label) . '</a> ' : Image::getHtml(str_replace('.svg', '--disabled.svg', $icon)) . ' ';
+		$security = System::getContainer()->get('security.helper');
+		$subject = new UpdateAction('tl_files', $row);
+
+		return $security->isGranted(ContaoCorePermissions::DC_PREFIX.'tl_files', $subject) && $security->isGranted(ContaoCorePermissions::USER_CAN_RENAME_FILE) ? '<a href="' . $this->addToUrl($href . '&amp;id=' . $row['id']) . '" title="' . StringUtil::specialchars($title) . '"' . $attributes . '>' . Image::getHtml($icon, $label) . '</a> ' : Image::getHtml(str_replace('.svg', '--disabled.svg', $icon)) . ' ';
 	}
 
 	/**

--- a/core-bundle/contao/dca/tl_files.php
+++ b/core-bundle/contao/dca/tl_files.php
@@ -675,7 +675,7 @@ class tl_files extends Backend
 		$security = System::getContainer()->get('security.helper');
 		$subject = new UpdateAction('tl_files', $row);
 
-		return $security->isGranted(ContaoCorePermissions::DC_PREFIX.'tl_files', $subject) && $security->isGranted(ContaoCorePermissions::USER_CAN_RENAME_FILE) ? '<a href="' . $this->addToUrl($href . '&amp;id=' . $row['id']) . '" title="' . StringUtil::specialchars($title) . '"' . $attributes . '>' . Image::getHtml($icon, $label) . '</a> ' : Image::getHtml(str_replace('.svg', '--disabled.svg', $icon)) . ' ';
+		return $security->isGranted(ContaoCorePermissions::DC_PREFIX . 'tl_files', $subject) && $security->isGranted(ContaoCorePermissions::USER_CAN_RENAME_FILE) ? '<a href="' . $this->addToUrl($href . '&amp;id=' . $row['id']) . '" title="' . StringUtil::specialchars($title) . '"' . $attributes . '>' . Image::getHtml($icon, $label) . '</a> ' : Image::getHtml(str_replace('.svg', '--disabled.svg', $icon)) . ' ';
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/contao/contao/issues/7038

The permission check is applied by the `TableAccessVoter` here. It is intentionally only applied to the edit operation, because move or copy should not check for `canEditFieldsOfTable`.

Also does not work with Contao 4.13 – not sure we want to backport that. We don't check any such permissions in 4.13. Contrary to 5.3, where an access denied exception is thrown by the `TableAccessVoter`, in Contao 4.13 we just render an empty list of fields to edit everywhere.

---

Side note: I also started working on actual file permissions in https://github.com/contao/contao/compare/5.3...aschempp:contao:fix/files-permissions. There are a number of unknowns though, e.g. is editing a file (content) not the same as editing file metadata. It also related to the virtual file system and a possible redesign of the file manager by @m-vo. After discussing stuff like the `UploadAction` I postponed that for now and setteled for this "quick fix".