### PR TITLE
Adjust the deprecation for custom template names

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Controller.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Controller.php
@@ -193,10 +193,11 @@ abstract class Controller extends System
 			foreach ($arrCustomized as $strFile)
 			{
 				$strTemplate = basename($strFile, strrchr($strFile, '.'));
+				$legacyPrefix = substr($strPrefix, 0, -1) . '-';
 
-				if (strpos($strTemplate, '-') !== false)
+				if (str_starts_with($strTemplate, $legacyPrefix))
 				{
-					trigger_deprecation('contao/core-bundle', '4.9', 'Using hyphens in the template name "' . $strTemplate . '.html5" has been deprecated and will no longer work in Contao 5.0. Use snake_case instead.');
+					trigger_deprecation('contao/core-bundle', '4.9', 'The template "' . $strTemplate . '.html5" uses a deprecated name that will no longer work in Contao 5.0. Name it "' . str_replace($legacyPrefix, $strPrefix, $strTemplate) . '.html5" instead.');
 				}
 
 				// Ignore bundle templates, e.g. mod_article and mod_article_list

--- a/core-bundle/tests/Contao/TemplateLoaderTest.php
+++ b/core-bundle/tests/Contao/TemplateLoaderTest.php
@@ -241,7 +241,7 @@ class TemplateLoaderTest extends TestCase
      */
     public function testSupportsHyphensInCustomTemplateNames(): void
     {
-        $this->expectDeprecation('Since contao/core-bundle 4.9: Using hyphens in the template name "mod_article-custom.html5" has been deprecated %s.');
+        $this->expectDeprecation('Since contao/core-bundle 4.9: The template "mod_article-custom.html5" uses a deprecated name that will no longer work in Contao 5.0. Name it "mod_article_custom.html5" instead.');
 
         (new Filesystem())->touch([
             Path::join($this->getTempDir(), '/templates/mod_article-custom.html5'),


### PR DESCRIPTION
Follow-up on #7145

Instead of suggesting to use snake_case, the deprecation message now says `The template "mod_article-custom--with-columns.html5" uses a deprecated name that will no longer work in Contao 5.0. Name it "mod_article_custom--with-columns.html5" instead.`