### PR TITLE
Issues with insert tags in 5.3+

### DIFF
--- a/core-bundle/src/Controller/InsertTagsController.php
+++ b/core-bundle/src/Controller/InsertTagsController.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Controller;
 
+use Contao\CoreBundle\EventListener\SubrequestCacheSubscriber;
 use Contao\CoreBundle\InsertTag\InsertTagParser;
 use Contao\CoreBundle\InsertTag\OutputType;
 use Contao\StringUtil;
@@ -61,6 +62,7 @@ class InsertTagsController
             $response->setPublic();
             $response->setExpires($result->getExpiresAt());
             $response->headers->removeCacheControlDirective('no-store');
+            $response->headers->set(SubrequestCacheSubscriber::MERGE_CACHE_HEADER, '1');
         }
 
         $this->responseTagger?->addTags($result->getCacheTags());

--- a/core-bundle/src/InsertTag/DefaultParametersInterface.php
+++ b/core-bundle/src/InsertTag/DefaultParametersInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\InsertTag;
+
+interface DefaultParametersInterface
+{
+    /**
+     * Use this interface to apply default values to an insert tag. You should always
+     * use this interface rather than dynamically evaluate defaults in the controller.
+     */
+    public function applyDefaults(InsertTag $tag): Inserttag;
+}

--- a/core-bundle/src/InsertTag/InsertTag.php
+++ b/core-bundle/src/InsertTag/InsertTag.php
@@ -37,6 +37,11 @@ abstract class InsertTag
         return $this->parameters;
     }
 
+    public function withParameters(InsertTagParameters $parameters): static
+    {
+        return new static($this->getName(), $parameters, $this->getFlags());
+    }
+
     /**
      * @return list<InsertTagFlag>
      */

--- a/core-bundle/src/InsertTag/Resolver/DateInsertTag.php
+++ b/core-bundle/src/InsertTag/Resolver/DateInsertTag.php
@@ -14,13 +14,16 @@ namespace Contao\CoreBundle\InsertTag\Resolver;
 
 use Contao\CoreBundle\DependencyInjection\Attribute\AsInsertTag;
 use Contao\CoreBundle\Framework\ContaoFramework;
+use Contao\CoreBundle\InsertTag\InsertTag;
 use Contao\CoreBundle\InsertTag\InsertTagResult;
 use Contao\CoreBundle\InsertTag\OutputType;
+use Contao\CoreBundle\InsertTag\DefaultParametersInterface;
 use Contao\CoreBundle\InsertTag\ResolvedInsertTag;
+use Contao\CoreBundle\InsertTag\ResolvedParameters;
 use Contao\Date;
 
 #[AsInsertTag('date', asFragment: true)]
-class DateInsertTag implements InsertTagResolverNestedResolvedInterface
+class DateInsertTag implements InsertTagResolverNestedResolvedInterface, DefaultParametersInterface
 {
     private const MAPPER = [
         'd' => ['d', 'j', 'l', 'D'],
@@ -37,7 +40,7 @@ class DateInsertTag implements InsertTagResolverNestedResolvedInterface
         $this->framework->initialize();
 
         $date = $this->framework->getAdapter(Date::class);
-        $format = $insertTag->getParameters()->get(0) ?? $GLOBALS['objPage']->dateFormat ?? $GLOBALS['TL_CONFIG']['dateFormat'] ?? '';
+        $format = $insertTag->getParameters()->get(0); // Always here, ensured by defaults
         $result = new InsertTagResult($date->parse($format), OutputType::text);
 
         // Add caching headers for supported formats
@@ -86,5 +89,18 @@ class DateInsertTag implements InsertTagResolverNestedResolvedInterface
         }
 
         return null;
+    }
+
+    public function applyDefaults(InsertTag $tag): InsertTag
+    {
+        // Format is set, all good
+        if ($tag->getParameters()->get(0)) {
+            return $tag;
+        }
+
+        $parameters = $tag->getParameters()->all();
+        $parameters[0] = $GLOBALS['objPage']->dateFormat ?? $GLOBALS['TL_CONFIG']['dateFormat'] ?? '';
+
+        return $tag->withParameters(new ResolvedParameters($parameters));
     }
 }

--- a/core-bundle/src/InsertTag/UriModifyingFragmentInsertTagInterface.php
+++ b/core-bundle/src/InsertTag/UriModifyingFragmentInsertTagInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\InsertTag;
+
+interface UriModifyingFragmentInsertTagInterface
+{
+    public function getQueryForTag(InsertTag $tag, array $query): array;
+}

--- a/core-bundle/src/Twig/Runtime/InsertTagRuntime.php
+++ b/core-bundle/src/Twig/Runtime/InsertTagRuntime.php
@@ -38,7 +38,7 @@ final class InsertTagRuntime implements RuntimeExtensionInterface
             return $text;
         }
 
-        return $this->insertTagParser->replaceInline($text);
+        return $this->insertTagParser->replace($text);
     }
 
     public function replaceInsertTagsChunkedRaw(array $context, string $text, bool|null $bypass = null): ChunkedText


### PR DESCRIPTION
We have multiple problems to solve in 5.3+:

- First of all, I noticed that all Twig templates using `|insert_tag` will currently use `replaceInline()`. This means, `{{date::whatever}}` will never work reliably as it never uses a fragment at the moment. 
- As far as I can see, we never allow `inline` fragments to affect the cache settings. Meaning you can create an `InsertTagResult` with `getExpiresAt()` or cache tags but it will never affect anything unless you specified `asFragment: true`. We should probably always use the `inline` renderer if `asFragment` is set to `false` (which would require all insert tags to be registered as fragments though, otherwise our `FragmentHandler` won't care).
- Currently, the automated query parameters for fragment insert tags will cause cache flooding because on every single page there's both, the `pageId` and also the `request` which will cause a cache entry for every single page even though they are - in case of `{{date::Y}}` - completely irrelevant.

Imho we should not pass on any request parameters. I know this would be kind of a BC break but on the other hand, it's also a bugfix. If you want a fragment insert tag, you should make sure, the insert tag contains all of its information needed to render. So instead of dynamically resolving some format based on the page ID, the format should be part of the insert tag. 

But not sure here as currently the implementation by @ausi assumes, insert tag instances are immutable.

This is just a quick hack here to simplify discussion.


Related: https://github.com/contao/contao/issues/7178