### PR TITLE
Allow `contao.insert_tag` tags without method and priority

### DIFF
--- a/core-bundle/src/DependencyInjection/Compiler/AddInsertTagsPass.php
+++ b/core-bundle/src/DependencyInjection/Compiler/AddInsertTagsPass.php
@@ -49,7 +49,7 @@ class AddInsertTagsPass implements CompilerPassInterface
                     }
 
                     $class = $container->findDefinition($serviceId)->getClass();
-                    $method = $this->getMethod($attributes['method'], $serviceTag, $class, $serviceId);
+                    $method = $this->getMethod($attributes['method'] ?? null, $serviceTag, $class, $serviceId);
                     $attributes['resolveNestedTags'] ??= $this->getResolveNestedTagsFromMethod($class, $method);
 
                     $subscriptions[] = new Definition(InsertTagSubscription::class, [
@@ -61,7 +61,7 @@ class AddInsertTagsPass implements CompilerPassInterface
                         $attributes['asFragment'] ?? false,
                     ]);
 
-                    $priorities[] = $attributes['priority'];
+                    $priorities[] = $attributes['priority'] ?? 0;
                 }
             }
 


### PR DESCRIPTION
As mentioned in https://github.com/contao/contao/issues/7185#issuecomment-2093299790 if you add a `contao.insert_tag` service tag without the `AsInsertTag` attribute, e.g. directly via your `services.yaml` for example 

```yaml
services:
    App\InsertTag\MyInsertTag:
        tags:
            - contao.insert_tag:
                name: my_tag
```

you will get warnings for missing `method` and `priority` array keys. This PR fixes that by falling back to the same values as in the `AsInsertTag` attribute (`null` and `0` respectively).
