### PR TITLE
Fix the `ParsedSequence::serialize()` method

### DIFF
--- a/core-bundle/src/InsertTag/ParsedSequence.php
+++ b/core-bundle/src/InsertTag/ParsedSequence.php
@@ -64,7 +64,11 @@ final class ParsedSequence implements \IteratorAggregate, \Countable
         $serialized = '';
 
         foreach ($this as $item) {
-            $serialized .= \is_string($item) ? $item : $item->serialize();
+            $serialized .= match (true) {
+                $item instanceof InsertTag => $item->serialize(),
+                $item instanceof InsertTagResult => $item->getValue(),
+                default => (string) $item,
+            };
         }
 
         return $serialized;

--- a/core-bundle/tests/InsertTag/ParsedSequenceTest.php
+++ b/core-bundle/tests/InsertTag/ParsedSequenceTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\InsertTag;
+
+use Contao\CoreBundle\InsertTag\InsertTagResult;
+use Contao\CoreBundle\InsertTag\ParsedSequence;
+use Contao\CoreBundle\InsertTag\ResolvedInsertTag;
+use Contao\CoreBundle\InsertTag\ResolvedParameters;
+use Contao\CoreBundle\Tests\TestCase;
+
+class ParsedSequenceTest extends TestCase
+{
+    public function testGetCountSerialize(): void
+    {
+        $insertTag = new ResolvedInsertTag('tag', new ResolvedParameters([]), []);
+        $result = new InsertTagResult('result');
+        $sequence = new ParsedSequence(['string', $insertTag, $result, '']);
+
+        $this->assertCount(3, $sequence);
+
+        $this->assertSame('string', $sequence->get(0));
+        $this->assertSame($insertTag, $sequence->get(1));
+        $this->assertSame($result, $sequence->get(2));
+
+        $this->assertSame(['string', $insertTag, $result], iterator_to_array($sequence));
+
+        $this->assertSame('string{{tag}}result', $sequence->serialize());
+    }
+
+    /**
+     * @dataProvider getHasInsertTags
+     */
+    public function testHasInsertTag(bool $expected, array $items): void
+    {
+        $sequence = new ParsedSequence($items);
+        $this->assertSame($expected, $sequence->hasInsertTags());
+
+        $sequence = new ParsedSequence([...$items, ...$items]);
+        $this->assertSame($expected, $sequence->hasInsertTags());
+    }
+
+    public static function getHasInsertTags(): iterable
+    {
+        $insertTag = new ResolvedInsertTag('tag', new ResolvedParameters([]), []);
+        $result = new InsertTagResult('result');
+
+        yield [true, ['string', $insertTag, $result]];
+        yield [false, ['string', $result]];
+        yield [true, [$insertTag, $result]];
+        yield [true, ['string', $insertTag]];
+        yield [true, [$insertTag]];
+        yield [false, []];
+    }
+}

--- a/core-bundle/tests/InsertTag/ParsedSequenceTest.php
+++ b/core-bundle/tests/InsertTag/ParsedSequenceTest.php
@@ -33,7 +33,6 @@ class ParsedSequenceTest extends TestCase
         $this->assertSame($result, $sequence->get(2));
 
         $this->assertSame(['string', $insertTag, $result], iterator_to_array($sequence));
-
         $this->assertSame('string{{tag}}result', $sequence->serialize());
     }
 


### PR DESCRIPTION
Fixes #7184