### PR TITLE
Handle quoted columns names in the boolean fields migration

### DIFF
--- a/core-bundle/src/Migration/Version500/BooleanFieldsMigration.php
+++ b/core-bundle/src/Migration/Version500/BooleanFieldsMigration.php
@@ -84,12 +84,11 @@ class BooleanFieldsMigration extends AbstractMigration
 
             foreach ($GLOBALS['TL_DCA'][$tableName]['fields'] ?? [] as $fieldName => $fieldConfig) {
                 $fieldName = strtolower($fieldName);
+                $field = $columns[$fieldName] ?? $columns["`$fieldName`"] ?? null;
 
-                if (!isset($columns[$fieldName]) || Types::BOOLEAN !== ($fieldConfig['sql']['type'] ?? null)) {
+                if (null === $field || Types::BOOLEAN !== ($fieldConfig['sql']['type'] ?? null)) {
                     continue;
                 }
-
-                $field = $columns[$fieldName];
 
                 if ($field->getType() instanceof StringType) {
                     $targets[] = [$tableName, $fieldName];


### PR DESCRIPTION
Fixes #7182
Same as #7194 for Contao 5.3