### PR TITLE
Switch to first allowed type if default type is not allowed in element group

### DIFF
--- a/core-bundle/config/listener.yaml
+++ b/core-bundle/config/listener.yaml
@@ -93,7 +93,6 @@ services:
         class: Contao\CoreBundle\EventListener\DataContainer\CteAllowedTypeListener
         arguments:
             - '@contao.fragment.compositor'
-            - Contao\BackendUser
 
     contao.listener.data_container.default_global_operations:
         class: Contao\CoreBundle\EventListener\DataContainer\DefaultGlobalOperationsListener

--- a/core-bundle/config/listener.yaml
+++ b/core-bundle/config/listener.yaml
@@ -89,6 +89,12 @@ services:
             - '@database_connection'
             - '@contao.framework'
 
+    contao.listener.data_container.cte_allowed_type:
+        class: Contao\CoreBundle\EventListener\DataContainer\CteAllowedTypeListener
+        arguments:
+            - '@contao.fragment.compositor'
+            - Contao\BackendUser
+
     contao.listener.data_container.default_global_operations:
         class: Contao\CoreBundle\EventListener\DataContainer\DefaultGlobalOperationsListener
 

--- a/core-bundle/contao/dca/tl_content.php
+++ b/core-bundle/contao/dca/tl_content.php
@@ -1163,7 +1163,7 @@ class tl_content extends Backend
 		if ($compositor->supportsNesting('contao.content_element.' . $objCes->type))
 		{
 			$allowedTypes = $compositor->getAllowedTypes('contao.content_element.' . $objCes->type);
-			if ([] !== $allowedTypes && [] === array_intersect($user->elements, $allowedTypes))
+			if (array() !== $allowedTypes && array() === array_intersect($user->elements, $allowedTypes))
 			{
 				$GLOBALS['TL_DCA']['tl_content']['config']['closed'] = true;
 			}

--- a/core-bundle/contao/dca/tl_content.php
+++ b/core-bundle/contao/dca/tl_content.php
@@ -1168,7 +1168,7 @@ class tl_content extends Backend
 			{
 				$allowedTypes = $compositor->getAllowedTypes('contao.content_element.' . $parent->type);
 
-				if (empty(array_intersect($user->elements, $allowedTypes)))
+				if ([] === $allowedTypes && [] === array_intersect($user->elements, $allowedTypes))
 				{
 					$GLOBALS['TL_DCA']['tl_content']['config']['closed'] = true;
 				}

--- a/core-bundle/src/EventListener/DataContainer/CteAllowedTypeListener.php
+++ b/core-bundle/src/EventListener/DataContainer/CteAllowedTypeListener.php
@@ -25,7 +25,7 @@ use Contao\DataContainer;
 class CteAllowedTypeListener
 {
     public function __construct(
-        private readonly FragmentCompositor $compositor
+        private readonly FragmentCompositor $compositor,
     ) {
     }
 

--- a/core-bundle/src/EventListener/DataContainer/CteAllowedTypeListener.php
+++ b/core-bundle/src/EventListener/DataContainer/CteAllowedTypeListener.php
@@ -31,7 +31,7 @@ class CteAllowedTypeListener
     }
 
     /**
-     * Switch to first allowed type if default type is not allowed
+     * Switch to first allowed type if default type is not allowed.
      */
     #[AsCallback(table: 'tl_content', target: 'config.oncreate')]
     public function setAllowedType(string $strTable, int $insertID, array $values, DataContainer $dc): void

--- a/core-bundle/src/EventListener/DataContainer/CteAllowedTypeListener.php
+++ b/core-bundle/src/EventListener/DataContainer/CteAllowedTypeListener.php
@@ -12,12 +12,12 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\EventListener\DataContainer;
 
+use Contao\BackendUser;
 use Contao\ContentModel;
 use Contao\CoreBundle\DependencyInjection\Attribute\AsCallback;
 use Contao\CoreBundle\Exception\AccessDeniedException;
 use Contao\CoreBundle\Fragment\FragmentCompositor;
 use Contao\DataContainer;
-use Symfony\Component\Security\Core\Security;
 
 /**
  * @internal
@@ -25,8 +25,7 @@ use Symfony\Component\Security\Core\Security;
 class CteAllowedTypeListener
 {
     public function __construct(
-        private readonly FragmentCompositor $compositor,
-        private readonly Security $security,
+        private readonly FragmentCompositor $compositor
     ) {
     }
 
@@ -44,7 +43,7 @@ class CteAllowedTypeListener
             return;
         }
 
-        $user = $this->security->getUser();
+        $user = BackendUser::getInstance();
 
         if ($user->isAdmin) {
             if (!\in_array($objCte->type, $allowedTypes, true)) {

--- a/core-bundle/src/EventListener/DataContainer/CteAllowedTypeListener.php
+++ b/core-bundle/src/EventListener/DataContainer/CteAllowedTypeListener.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\EventListener\DataContainer;
+
+use Contao\ContentModel;
+use Contao\CoreBundle\DependencyInjection\Attribute\AsCallback;
+use Contao\CoreBundle\Exception\AccessDeniedException;
+use Contao\CoreBundle\Fragment\FragmentCompositor;
+use Contao\DataContainer;
+use Symfony\Component\Security\Core\Security;
+
+/**
+ * @internal
+ */
+class CteAllowedTypeListener
+{
+    public function __construct(
+        private readonly FragmentCompositor $compositor,
+        private readonly Security $security,
+    ) {
+    }
+
+    /**
+     * Switch to first allowed type if default type is not allowed (see #7100).
+     */
+    #[AsCallback(table: 'tl_content', target: 'config.oncreate')]
+    public function setAllowedType(string $strTable, int $insertID, array $values, DataContainer $dc): void
+    {
+        $objCte = ContentModel::findById($insertID);
+        $supportsNesting = 'tl_content' === $objCte->ptable && $this->compositor->supportsNesting('contao.content_element.'.$dc->getCurrentRecord()['type']);
+        $allowedTypes = $supportsNesting ? $this->compositor->getAllowedTypes('contao.content_element.'.$dc->getCurrentRecord()['type']) : [];
+
+        if ([] === $allowedTypes) {
+            return;
+        }
+
+        $user = $this->security->getUser();
+
+        if ($user->isAdmin) {
+            if (!\in_array($objCte->type, $allowedTypes, true)) {
+                $objCte->type = $allowedTypes[0];
+                $objCte->save();
+            }
+
+            return;
+        }
+
+        $allowedTypesIntersect = array_intersect($allowedTypes, $user->elements);
+
+        if ([] === $allowedTypesIntersect) {
+            throw new AccessDeniedException('Not enough permissions to create allowed type  ('.implode(', ', $allowedTypes).').');
+        }
+
+        if (!\in_array($objCte->type, $allowedTypesIntersect, true)) {
+            $objCte->type = $allowedTypesIntersect[0];
+            $objCte->save();
+        }
+    }
+}

--- a/core-bundle/src/EventListener/DataContainer/CteAllowedTypeListener.php
+++ b/core-bundle/src/EventListener/DataContainer/CteAllowedTypeListener.php
@@ -31,7 +31,7 @@ class CteAllowedTypeListener
     }
 
     /**
-     * Switch to first allowed type if default type is not allowed (see #7100).
+     * Switch to first allowed type if default type is not allowed
      */
     #[AsCallback(table: 'tl_content', target: 'config.oncreate')]
     public function setAllowedType(string $strTable, int $insertID, array $values, DataContainer $dc): void


### PR DESCRIPTION
Unfortunately, I broke my [last pull request](https://github.com/contao/contao/pull/7100). So here is the second attempt.

Currently, the type field of a content element is set to "article" by default, which leads to an unknown option being displayed in the drop-down list of the type if you create it in an element group where the type "article" is not contained in "allowedTypes".

```
#[AsContentElement(category: 'custom', template:'content_element/element_group', nestedFragments: ['allowedTypes' => ['image']])]
class ImageGroupController extends AbstractContentElementController
{
    protected function getResponse(FragmentTemplate $template, ContentModel $model, Request $request): Response
    {
        return $template->getResponse();
    }
}
```

![image](https://github.com/contao/contao/assets/87128053/829591e7-de5e-408d-a805-b796959b5921)

In this case, the added callback function automatically changes the value to the first supported type.

Furthermore the tl_content.php was modified to close the content element, if the user has no permission for the nested elements.