### PR TITLE
Fix the CSS class of legacy templates in new elements and modules

### DIFF
--- a/core-bundle/src/Controller/ContentElement/AbstractContentElementController.php
+++ b/core-bundle/src/Controller/ContentElement/AbstractContentElementController.php
@@ -72,7 +72,7 @@ abstract class AbstractContentElementController extends AbstractFragmentControll
         if ($this->isLegacyTemplate($template->getName())) {
             // Legacy fragments
             $this->addHeadlineToTemplate($template, $modelData['headline'] ?? null);
-            $this->addCssAttributesToTemplate($template, $template->getName(), $modelData['cssID'] ?? null, $classes);
+            $this->addCssAttributesToTemplate($template, 'ce_'.$this->getType(), $modelData['cssID'] ?? null, $classes);
             $this->addPropertiesToTemplate($template, $properties);
             $this->addSectionToTemplate($template, $section);
 

--- a/core-bundle/src/Controller/FrontendModule/AbstractFrontendModuleController.php
+++ b/core-bundle/src/Controller/FrontendModule/AbstractFrontendModuleController.php
@@ -77,7 +77,7 @@ abstract class AbstractFrontendModuleController extends AbstractFragmentControll
         if ($this->isLegacyTemplate($template->getName())) {
             // Legacy fragments
             $this->addHeadlineToTemplate($template, $modelData['headline'] ?? null);
-            $this->addCssAttributesToTemplate($template, $template->getName(), $modelData['cssID'] ?? null, $classes);
+            $this->addCssAttributesToTemplate($template, 'mod_'.$this->getType(), $modelData['cssID'] ?? null, $classes);
             $this->addPropertiesToTemplate($template, $properties);
             $this->addSectionToTemplate($template, $section);
 


### PR DESCRIPTION
Fixes using the complete template name instead of the frontend module/content element type as CSS class for legacy template variants

<!--
Bugfixes should be based on the 4.13 or 5.3 branch and features on the 5.x
branch. Select the correct branch in the "base:" drop-down menu above.

Replace this notice with a short README for your feature/bugfix. This will help
people to understand your PR and can be used as a start for the documentation.
-->
