### PR TITLE
Check the cookie headers in the `isSessionEmpty()` method

### DIFF
--- a/core-bundle/src/EventListener/CsrfTokenCookieSubscriber.php
+++ b/core-bundle/src/EventListener/CsrfTokenCookieSubscriber.php
@@ -126,6 +126,15 @@ class CsrfTokenCookieSubscriber implements EventSubscriberInterface
 
     private function isSessionEmpty(SessionInterface $session): bool
     {
+        foreach (headers_list() as $header) {
+            if (
+                str_starts_with($header, "Set-Cookie: {$session->getName()}=")
+                && !str_starts_with($header, "Set-Cookie: {$session->getName()}=deleted;")
+            ) {
+                return false;
+            }
+        }
+
         if (!$session->isStarted()) {
             return true;
         }

--- a/core-bundle/src/EventListener/MakeResponsePrivateListener.php
+++ b/core-bundle/src/EventListener/MakeResponsePrivateListener.php
@@ -109,6 +109,15 @@ class MakeResponsePrivateListener
 
     private function isSessionEmpty(SessionInterface $session): bool
     {
+        foreach (headers_list() as $header) {
+            if (
+                str_starts_with($header, "Set-Cookie: {$session->getName()}=")
+                && !str_starts_with($header, "Set-Cookie: {$session->getName()}=deleted;")
+            ) {
+                return false;
+            }
+        }
+
         if (!$session->isStarted()) {
             return true;
         }


### PR DESCRIPTION
Attempt to fix #7167