### PR TITLE
Make Twig 3.10.2 the minimum requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -165,7 +165,7 @@
         "toflar/psr6-symfony-http-cache-store": "^4.0",
         "twig/extra-bundle": "^3.0",
         "twig/string-extra": "^3.0",
-        "twig/twig": "^3.8",
+        "twig/twig": "^3.10.2",
         "ua-parser/uap-php": "^3.9",
         "webignition/robots-txt-file": "^3.0",
         "wikimedia/less.php": "^1.7"
@@ -202,8 +202,6 @@
         "nikic/php-parser": "4.7.0",
         "terminal42/contao-ce-access": "<3.0",
         "thecodingmachine/safe": "<1.2",
-        "twig/intl-extra": "3.9.0",
-        "twig/twig": "3.9.0",
         "zendframework/zend-code": "<3.3.1"
     },
     "autoload": {

--- a/core-bundle/composer.json
+++ b/core-bundle/composer.json
@@ -151,7 +151,7 @@
         "terminal42/service-annotation-bundle": "^1.1",
         "toflar/cronjob-supervisor": "^2.0",
         "twig/string-extra": "^3.0",
-        "twig/twig": "^3.8",
+        "twig/twig": "^3.10.2",
         "ua-parser/uap-php": "^3.9",
         "webignition/robots-txt-file": "^3.0",
         "wikimedia/less.php": "^1.7"
@@ -179,9 +179,7 @@
         "contao/manager-plugin": "<2.0 || >=3.0",
         "doctrine/cache": "<1.10",
         "terminal42/contao-ce-access": "<3.0",
-        "thecodingmachine/safe": "<1.2",
-        "twig/intl-extra": "3.9.0",
-        "twig/twig": "3.9.0"
+        "thecodingmachine/safe": "<1.2"
     },
     "autoload": {
         "psr-4": {

--- a/core-bundle/src/Twig/Extension/ContaoExtension.php
+++ b/core-bundle/src/Twig/Extension/ContaoExtension.php
@@ -70,9 +70,9 @@ final class ContaoExtension extends AbstractExtension implements GlobalsInterfac
     ) {
         $contaoEscaper = new ContaoEscaper();
 
-        $runtime = $this->environment->getRuntime(EscaperRuntime::class);
-        $runtime->setEscaper('contao_html', $contaoEscaper->escapeHtml(...));
-        $runtime->setEscaper('contao_html_attr', $contaoEscaper->escapeHtmlAttr(...));
+        $escaperRuntime = $this->environment->getRuntime(EscaperRuntime::class);
+        $escaperRuntime->setEscaper('contao_html', $contaoEscaper->escapeHtml(...));
+        $escaperRuntime->setEscaper('contao_html_attr', $contaoEscaper->escapeHtmlAttr(...));
 
         // Use our escaper on all templates in the "@Contao" and "@Contao_*" namespaces,
         // as well as the existing bundle templates we're already shipping.
@@ -80,8 +80,8 @@ final class ContaoExtension extends AbstractExtension implements GlobalsInterfac
         $this->addContaoEscaperRule('%^@ContaoCore/%');
 
         // Mark classes as safe for HTML that already escape their output themselves
-        $runtime->addSafeClass(HtmlAttributes::class, ['html', 'contao_html']);
-        $runtime->addSafeClass(HighlightResult::class, ['html', 'contao_html']);
+        $escaperRuntime->addSafeClass(HtmlAttributes::class, ['html', 'contao_html']);
+        $escaperRuntime->addSafeClass(HighlightResult::class, ['html', 'contao_html']);
 
         $this->environment->addGlobal(
             'request_token',
@@ -237,8 +237,8 @@ final class ContaoExtension extends AbstractExtension implements GlobalsInterfac
 
     public function getFilters(): array
     {
-        $escaperFilter = function (Environment $env, $string, string $strategy = 'html', string|null $charset = null, bool $autoescape = false) {
-            $runtime = $this->environment->getRuntime(EscaperRuntime::class);
+        $escaperFilter = static function (Environment $env, $string, string $strategy = 'html', string|null $charset = null, bool $autoescape = false) {
+            $runtime = $env->getRuntime(EscaperRuntime::class);
 
             if ($string instanceof ChunkedText) {
                 $parts = [];

--- a/core-bundle/src/Twig/Extension/ContaoExtension.php
+++ b/core-bundle/src/Twig/Extension/ContaoExtension.php
@@ -48,7 +48,6 @@ use Symfony\Component\Filesystem\Path;
 use Twig\Environment;
 use Twig\Extension\AbstractExtension;
 use Twig\Extension\CoreExtension;
-use Twig\Extension\EscaperExtension;
 use Twig\Extension\GlobalsInterface;
 use Twig\Node\Expression\ConstantExpression;
 use Twig\Node\Node;
@@ -238,7 +237,7 @@ final class ContaoExtension extends AbstractExtension implements GlobalsInterfac
 
     public function getFilters(): array
     {
-        $escaperFilter = function (Environment $env, $string, $strategy = 'html', $charset = null, $autoescape = false) {
+        $escaperFilter = function (Environment $env, $string, string $strategy = 'html', string|null $charset = null, bool $autoescape = false) {
             $runtime = $this->environment->getRuntime(EscaperRuntime::class);
 
             if ($string instanceof ChunkedText) {

--- a/core-bundle/src/Twig/Extension/ContaoExtension.php
+++ b/core-bundle/src/Twig/Extension/ContaoExtension.php
@@ -48,6 +48,7 @@ use Symfony\Component\Filesystem\Path;
 use Twig\Environment;
 use Twig\Extension\AbstractExtension;
 use Twig\Extension\CoreExtension;
+use Twig\Extension\EscaperExtension;
 use Twig\Extension\GlobalsInterface;
 use Twig\Node\Expression\ConstantExpression;
 use Twig\Node\Node;
@@ -258,10 +259,10 @@ final class ContaoExtension extends AbstractExtension implements GlobalsInterfac
         };
 
         $twigEscaperFilterIsSafe = static function (Node $filterArgs): array {
-            $expression = iterator_to_array($filterArgs)[0] ?? null;
+            $arg = iterator_to_array($filterArgs)[0] ?? null;
 
-            if ($expression instanceof ConstantExpression) {
-                $value = $expression->getAttribute('value');
+            if ($arg instanceof ConstantExpression) {
+                $value = $arg->getAttribute('value');
 
                 // Our escaper strategy variants that tolerate input encoding are also safe in
                 // the original context (e.g. for the filter argument 'contao_html' we will
@@ -271,7 +272,7 @@ final class ContaoExtension extends AbstractExtension implements GlobalsInterfac
                 }
             }
 
-            return twig_escape_filter_is_safe($filterArgs);
+            return EscaperExtension::escapeFilterIsSafe($filterArgs);
         };
 
         return [

--- a/core-bundle/src/Twig/Interop/ContaoEscaper.php
+++ b/core-bundle/src/Twig/Interop/ContaoEscaper.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Twig\Interop;
 
 use Contao\StringUtil;
-use Twig\Environment;
 use Twig\Error\RuntimeError;
 
 /**
@@ -33,7 +32,7 @@ final class ContaoEscaper
      *
      * @see twig_escape_filter
      */
-    public function escapeHtml(Environment $environment, mixed $string, string|null $charset): string
+    public function escapeHtml(mixed $string, string|null $charset): string
     {
         if (null !== $charset && 'UTF-8' !== strtoupper($charset)) {
             throw new RuntimeError(sprintf('The "contao_html" escape filter does not support the %s charset, use UTF-8 instead.', $charset));
@@ -50,7 +49,7 @@ final class ContaoEscaper
      *
      * @see twig_escape_filter
      */
-    public function escapeHtmlAttr(Environment $environment, mixed $string, string|null $charset): string
+    public function escapeHtmlAttr(mixed $string, string|null $charset): string
     {
         if (null !== $charset && 'UTF-8' !== strtoupper($charset)) {
             throw new RuntimeError(sprintf('The "contao_html_attr" escape filter does not support the %s charset, use UTF-8 instead.', $charset));

--- a/core-bundle/tests/Twig/Extension/ContaoExtensionTest.php
+++ b/core-bundle/tests/Twig/Extension/ContaoExtensionTest.php
@@ -190,14 +190,6 @@ class ContaoExtensionTest extends TestCase
             ])
         ;
 
-        // Forward compatibility with twig/twig >=3.10.0
-        if (class_exists(EscaperRuntime::class)) {
-            $environment
-                ->method('getRuntime')
-                ->willReturn(new EscaperRuntime())
-            ;
-        }
-
         $extension = new ContaoExtension(
             $environment,
             $this->createMock(ContaoFilesystemLoader::class),
@@ -441,14 +433,6 @@ class ContaoExtensionTest extends TestCase
                 [CoreExtension::class, new CoreExtension()],
             ])
         ;
-
-        // Forward compatibility with twig/twig >=3.10.0
-        if (class_exists(EscaperRuntime::class)) {
-            $environment
-                ->method('getRuntime')
-                ->willReturn(new EscaperRuntime())
-            ;
-        }
 
         return new ContaoExtension(
             $environment,

--- a/core-bundle/tests/Twig/Extension/ContaoExtensionTest.php
+++ b/core-bundle/tests/Twig/Extension/ContaoExtensionTest.php
@@ -44,6 +44,7 @@ use Twig\Node\ModuleNode;
 use Twig\Node\Node;
 use Twig\Node\TextNode;
 use Twig\NodeTraverser;
+use Twig\Runtime\EscaperRuntime;
 use Twig\Source;
 use Twig\TwigFilter;
 use Twig\TwigFunction;
@@ -175,6 +176,11 @@ class ContaoExtensionTest extends TestCase
     public function testThrowsIfCoreIncludeFunctionIsNotFound(): void
     {
         $environment = $this->createMock(Environment::class);
+        $environment
+            ->method('getRuntime')
+            ->willReturn(new EscaperRuntime())
+        ;
+
         $environment
             ->method('getExtension')
             ->willReturnMap([
@@ -396,12 +402,7 @@ class ContaoExtensionTest extends TestCase
         // Make sure the functions outside the class scope are loaded
         new \ReflectionClass(EscaperExtension::class);
 
-        // Forward compatibility with twig/twig 4
-        if (method_exists(EscaperExtension::class, 'escape')) {
-            $escape = new \ReflectionMethod(EscaperExtension::class, 'escape');
-        } else {
-            $escape = new \ReflectionFunction('twig_escape_filter');
-        }
+        $escape = new \ReflectionFunction('twig_escape_filter');
 
         yield [
             $escape,
@@ -414,12 +415,7 @@ class ContaoExtensionTest extends TestCase
             ],
         ];
 
-        // Backwards compatibility with twig/twig <3.9
-        if (\function_exists('twig_escape_filter_is_safe')) {
-            $escapeIsSafe = new \ReflectionFunction('twig_escape_filter_is_safe');
-        } else {
-            $escapeIsSafe = new \ReflectionMethod(EscaperExtension::class, 'escapeFilterIsSafe');
-        }
+        $escapeIsSafe = new \ReflectionFunction('twig_escape_filter_is_safe');
 
         yield [$escapeIsSafe, [[Node::class, 'filterArgs']]];
     }
@@ -431,6 +427,11 @@ class ContaoExtensionTest extends TestCase
     {
         $environment ??= $this->createMock(Environment::class);
         $filesystemLoader ??= $this->createMock(ContaoFilesystemLoader::class);
+
+        $environment
+            ->method('getRuntime')
+            ->willReturn(new EscaperRuntime())
+        ;
 
         $environment
             ->method('getExtension')

--- a/core-bundle/tests/Twig/Extension/ContaoExtensionTest.php
+++ b/core-bundle/tests/Twig/Extension/ContaoExtensionTest.php
@@ -399,9 +399,6 @@ class ContaoExtensionTest extends TestCase
 
     public static function provideTwigFunctionSignatures(): iterable
     {
-        // Make sure the functions outside the class scope are loaded
-        new \ReflectionClass(EscaperExtension::class);
-
         $escape = new \ReflectionFunction('twig_escape_filter');
 
         yield [

--- a/core-bundle/tests/Twig/Extension/ContaoExtensionTest.php
+++ b/core-bundle/tests/Twig/Extension/ContaoExtensionTest.php
@@ -377,43 +377,6 @@ class ContaoExtensionTest extends TestCase
     }
 
     /**
-     * We need to adjust some of Twig's core functions (e.g. the escape filter) but
-     * still delegate to the original implementation for maximum compatibility. This
-     * test makes sure the function's signatures remains the same and changes to the
-     * original codebase do not stay unnoticed.
-     *
-     * @dataProvider provideTwigFunctionSignatures
-     */
-    public function testContaoUsesCorrectTwigFunctionSignatures(\ReflectionFunction|\ReflectionMethod $reflector, array $expectedParameters): void
-    {
-        $parameters = array_map(
-            static fn (\ReflectionParameter $parameter): array => [
-                ($type = $parameter->getType()) instanceof \ReflectionNamedType ? $type->getName() : null,
-                $parameter->getName(),
-            ],
-            $reflector->getParameters(),
-        );
-
-        $this->assertSame($parameters, $expectedParameters);
-    }
-
-    public static function provideTwigFunctionSignatures(): iterable
-    {
-        yield [
-            new \ReflectionFunction('twig_escape_filter'),
-            [
-                [Environment::class, 'env'],
-                [null, 'string'],
-                [null, 'strategy'],
-                [null, 'charset'],
-                [null, 'autoescape'],
-            ],
-        ];
-
-        yield [new \ReflectionFunction('twig_escape_filter_is_safe'), [[Node::class, 'filterArgs']]];
-    }
-
-    /**
      * @param Environment&MockObject $environment
      */
     private function getContaoExtension(Environment|null $environment = null, ContaoFilesystemLoader|null $filesystemLoader = null): ContaoExtension

--- a/core-bundle/tests/Twig/Interop/ContaoEscaperTest.php
+++ b/core-bundle/tests/Twig/Interop/ContaoEscaperTest.php
@@ -21,7 +21,6 @@ use Contao\System;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Fragment\FragmentHandler;
-use Twig\Environment;
 use Twig\Error\RuntimeError;
 
 class ContaoEscaperTest extends TestCase
@@ -140,11 +139,11 @@ class ContaoEscaperTest extends TestCase
 
     private function invokeEscapeHtml(int|string $input, string|null $charset): string
     {
-        return (new ContaoEscaper())->escapeHtml($this->createMock(Environment::class), $input, $charset);
+        return (new ContaoEscaper())->escapeHtml($input, $charset);
     }
 
     private function invokeEscapeHtmlAttr(int|string $input, string|null $charset): string
     {
-        return (new ContaoEscaper())->escapeHtmlAttr($this->createMock(Environment::class), $input, $charset);
+        return (new ContaoEscaper())->escapeHtmlAttr($input, $charset);
     }
 }

--- a/core-bundle/tests/Twig/Interop/PhpTemplateParentReferenceNodeTest.php
+++ b/core-bundle/tests/Twig/Interop/PhpTemplateParentReferenceNodeTest.php
@@ -14,7 +14,6 @@ namespace Contao\CoreBundle\Tests\Twig\Interop;
 
 use Contao\CoreBundle\Tests\TestCase;
 use Contao\CoreBundle\Twig\Interop\PhpTemplateParentReferenceNode;
-use Twig\Attribute\YieldReady;
 use Twig\Compiler;
 use Twig\Environment;
 
@@ -27,14 +26,9 @@ class PhpTemplateParentReferenceNodeTest extends TestCase
         (new PhpTemplateParentReferenceNode())->compile($compiler);
 
         $expectedSource = <<<'SOURCE'
-            echo sprintf('[[TL_PARENT_%s]]', \Contao\CoreBundle\Framework\ContaoFramework::getNonce());
+            yield sprintf('[[TL_PARENT_%s]]', \Contao\CoreBundle\Framework\ContaoFramework::getNonce());
 
             SOURCE;
-
-        // Forward compatibility with twig/twig >=3.9.0
-        if (class_exists(YieldReady::class)) {
-            $expectedSource = str_replace('echo', 'yield', $expectedSource);
-        }
 
         $this->assertSame($expectedSource, $compiler->getSource());
     }

--- a/core-bundle/tests/Twig/Interop/PhpTemplateProxyNodeTest.php
+++ b/core-bundle/tests/Twig/Interop/PhpTemplateProxyNodeTest.php
@@ -15,7 +15,6 @@ namespace Contao\CoreBundle\Tests\Twig\Interop;
 use Contao\CoreBundle\Tests\TestCase;
 use Contao\CoreBundle\Twig\Extension\ContaoExtension;
 use Contao\CoreBundle\Twig\Interop\PhpTemplateProxyNode;
-use Twig\Attribute\YieldReady;
 use Twig\Compiler;
 use Twig\Environment;
 
@@ -28,7 +27,7 @@ class PhpTemplateProxyNodeTest extends TestCase
         (new PhpTemplateProxyNode(ContaoExtension::class))->compile($compiler);
 
         $expectedSource = <<<'SOURCE'
-            echo $this->extensions["Contao\\CoreBundle\\Twig\\Extension\\ContaoExtension"]->renderLegacyTemplate(
+            yield $this->extensions["Contao\\CoreBundle\\Twig\\Extension\\ContaoExtension"]->renderLegacyTemplate(
                 $this->getTemplateName(),
                 array_map(
                     function(callable $block) use ($context): string {
@@ -46,11 +45,6 @@ class PhpTemplateProxyNodeTest extends TestCase
             );
 
             SOURCE;
-
-        // Forward compatibility with twig/twig >=3.9.0
-        if (class_exists(YieldReady::class)) {
-            $expectedSource = str_replace('echo', 'yield', $expectedSource);
-        }
 
         $this->assertSame($expectedSource, $compiler->getSource());
     }

--- a/core-bundle/tests/Twig/ResponseContext/AddNodeTest.php
+++ b/core-bundle/tests/Twig/ResponseContext/AddNodeTest.php
@@ -16,7 +16,6 @@ use Contao\CoreBundle\Tests\TestCase;
 use Contao\CoreBundle\Twig\Extension\ContaoExtension;
 use Contao\CoreBundle\Twig\ResponseContext\AddNode;
 use Contao\CoreBundle\Twig\ResponseContext\DocumentLocation;
-use Twig\Attribute\YieldReady;
 use Twig\Compiler;
 use Twig\Environment;
 use Twig\Node\Expression\ConstantExpression;
@@ -43,7 +42,7 @@ class AddNodeTest extends TestCase
                 $__contao_document_content = '';
                 foreach((function () use (&$context, $macros, $blocks) {
                     // line 42
-                    echo "foobar";
+                    yield "foobar";
                     yield '';
                 })() as $__contao_document_chunk) {
                     $__contao_document_content .= ob_get_contents() . $__contao_document_chunk;
@@ -55,11 +54,6 @@ class AddNodeTest extends TestCase
             );
 
             SOURCE;
-
-        // Forward compatibility with twig/twig >=3.9.0
-        if (class_exists(YieldReady::class)) {
-            $expectedSource = str_replace('echo', 'yield', $expectedSource);
-        }
 
         $this->assertSame($expectedSource, $compiler->getSource());
     }


### PR DESCRIPTION
This pull request makes Twig 3.10.2 the minimum version and therefore does not need all the BC layers.

@contao/developers Do we want to add this to Contao 5.3 or only in Contao 5.4?