### PR TITLE
Correctly set the status code of the fallback route to 404

### DIFF
--- a/core-bundle/src/Controller/BackendController.php
+++ b/core-bundle/src/Controller/BackendController.php
@@ -159,7 +159,8 @@ class BackendController extends AbstractController
     #[Route('/{parameters}', name: 'contao_backend_fallback', requirements: ['parameters' => '.*'], priority: -1000)]
     public function backendFallback(): Response
     {
-        return $this->render('@ContaoCore/Error/backend.html.twig', [
+        return $this->render('@ContaoCore/Error/backend.html.twig',
+        [
             'language' => 'en',
             'statusName' => 'Page Not Found',
             'exception' => 'The requested page does not exist.',

--- a/core-bundle/src/Controller/BackendController.php
+++ b/core-bundle/src/Controller/BackendController.php
@@ -159,13 +159,16 @@ class BackendController extends AbstractController
     #[Route('/{parameters}', name: 'contao_backend_fallback', requirements: ['parameters' => '.*'], priority: -1000)]
     public function backendFallback(): Response
     {
-        return $this->render('@ContaoCore/Error/backend.html.twig',
-        [
-            'language' => 'en',
-            'statusName' => 'Page Not Found',
-            'exception' => 'The requested page does not exist.',
-            'template' => '@ContaoCore/Error/backend.html.twig',
-        ], new Response('', 404));
+        return $this->render(
+            '@ContaoCore/Error/backend.html.twig',
+            [
+                'language' => 'en',
+                'statusName' => 'Page Not Found',
+                'exception' => 'The requested page does not exist.',
+                'template' => '@ContaoCore/Error/backend.html.twig',
+            ],
+            new Response('', 404)
+        );
     }
 
     public static function getSubscribedServices(): array

--- a/core-bundle/src/Controller/BackendController.php
+++ b/core-bundle/src/Controller/BackendController.php
@@ -167,7 +167,7 @@ class BackendController extends AbstractController
                 'exception' => 'The requested page does not exist.',
                 'template' => '@ContaoCore/Error/backend.html.twig',
             ],
-            new Response('', 404)
+            new Response('', 404),
         );
     }
 

--- a/core-bundle/src/Controller/BackendController.php
+++ b/core-bundle/src/Controller/BackendController.php
@@ -164,7 +164,7 @@ class BackendController extends AbstractController
             'statusName' => 'Page Not Found',
             'exception' => 'The requested page does not exist.',
             'template' => '@ContaoCore/Error/backend.html.twig',
-        ]);
+        ], new Response('', 404));
     }
 
     public static function getSubscribedServices(): array

--- a/core-bundle/src/Controller/BackendController.php
+++ b/core-bundle/src/Controller/BackendController.php
@@ -156,7 +156,7 @@ class BackendController extends AbstractController
         return new RedirectResponse($picker->getCurrentUrl());
     }
 
-    #[Route('/{parameters}', name: 'contao_backend_fallback', requirements: ['parameters' => '.*'], defaults: ['statusCode' => 404], priority: -1000)]
+    #[Route('/{parameters}', name: 'contao_backend_fallback', requirements: ['parameters' => '.*'], priority: -1000)]
     public function backendFallback(): Response
     {
         return $this->render('@ContaoCore/Error/backend.html.twig', [


### PR DESCRIPTION
As a follow up to #7222, this sets the status code of the fallback route correctly to 404 again.

<!--
Bugfixes should be based on the 4.13 or 5.3 branch and features on the 5.x
branch. Select the correct branch in the "base:" drop-down menu above.

Replace this notice with a short README for your feature/bugfix. This will help
people to understand your PR and can be used as a start for the documentation.
-->
