### PR TITLE
Backport 'Set a low priority for the back end fallback route'

### DIFF
--- a/core-bundle/src/Controller/BackendController.php
+++ b/core-bundle/src/Controller/BackendController.php
@@ -207,6 +207,23 @@ class BackendController extends AbstractController
         return new RedirectResponse($picker->getCurrentUrl());
     }
 
+    /**
+     * @Route("/{parameters}", name="contao_backend_fallback", requirements={"parameters" = ".*"}, priority=-1000)
+     */
+    public function backendFallback(): Response
+    {
+        return $this->render(
+            '@ContaoCore/Error/backend.html.twig',
+            [
+                'language' => 'en',
+                'statusName' => 'Page Not Found',
+                'exception' => 'The requested page does not exist.',
+                'template' => '@ContaoCore/Error/backend.html.twig',
+            ],
+            new Response('', 404),
+        );
+    }
+
     public static function getSubscribedServices(): array
     {
         $services = parent::getSubscribedServices();

--- a/core-bundle/src/Controller/BackendController.php
+++ b/core-bundle/src/Controller/BackendController.php
@@ -208,7 +208,7 @@ class BackendController extends AbstractController
     }
 
     /**
-     * @Route("/{parameters}", name="contao_backend_fallback", requirements={"parameters" = ".*"}, priority=-1000)
+     * @Route("/{parameters}", name="contao_backend_fallback", requirements={"parameters" = ".*"}, defaults={"_store_referrer" = false}, priority=-1000)
      */
     public function backendFallback(): Response
     {

--- a/core-bundle/src/Resources/config/routes.yml
+++ b/core-bundle/src/Resources/config/routes.yml
@@ -14,18 +14,3 @@ contao_backend_redirect:
         _controller: Symfony\Bundle\FrameworkBundle\Controller\RedirectController::redirectAction
         route: contao_backend
         permanent: true
-
-contao_backend_fallback:
-    path: '%contao.backend.route_prefix%/{parameters}'
-    defaults:
-        _scope: backend
-        _controller: Symfony\Bundle\FrameworkBundle\Controller\TemplateController
-        template: '@ContaoCore\Error\backend.html.twig'
-        context:
-            template: '@ContaoCore\Error\backend.html.twig'
-            language: en
-            statusName: Page Not Found
-            exception: The requested page does not exist.
-        statusCode: 404
-    requirements:
-        parameters: .*


### PR DESCRIPTION
This backports #7222 and #7223 to Contao 4.13.

~However, I must note that I actually could not reproduce the original problem after all. In theory the original problem cannot occur if you have~

```php
use Contao\CoreBundle\ContaoCoreBundle;
// …

class Plugin implements BundlePluginInterface, RoutingPluginInterface
{
    public function getBundles(ParserInterface $parser)
    {
        return [
            BundleConfig::create(ExampleBundle::class)
                ->setLoadAfter([ContaoCoreBundle::class]),
        ];
    }

    public function getRouteCollection(LoaderResolverInterface $resolver, KernelInterface $kernel): RouteCollection|null
    {
        // …
    }
}
```

~in the Contao Manager Plugin of your bundle, as the routes will be loaded in reverse order. Thus the `contao_backend_fallback` should only ever appear after every other (regular) route.~

~@veronikaplenta may be your Contao Manager Plugin was not correct after all? Or do you have dynamically loaded routes (via CMF router) for the back end?~

// never mind - the routes order depends on the (reverse) Contao Manager _Plugin_ order (which can be influenced via the `DependentPluginInterface`).

Nevertheless, it does not hurt to give the `contao_backend_fallback` a lower priority I suppose.