### PR TITLE
Store the referrer by default in `backend` scope

### DIFF
--- a/core-bundle/src/Controller/BackendController.php
+++ b/core-bundle/src/Controller/BackendController.php
@@ -31,14 +31,14 @@ use Symfony\Component\HttpKernel\UriSigner;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
- * @Route(path="%contao.backend.route_prefix%", defaults={"_scope" = "backend", "_token_check" = true})
+ * @Route(path="%contao.backend.route_prefix%", defaults={"_scope" = "backend", "_token_check" = true, "_store_referrer" = false})
  *
  * @internal
  */
 class BackendController extends AbstractController
 {
     /**
-     * @Route("", name="contao_backend")
+     * @Route("", name="contao_backend", defaults={"_store_referrer" = true})
      */
     public function mainAction(): Response
     {

--- a/core-bundle/src/Controller/BackendController.php
+++ b/core-bundle/src/Controller/BackendController.php
@@ -31,14 +31,14 @@ use Symfony\Component\HttpKernel\UriSigner;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
- * @Route(path="%contao.backend.route_prefix%", defaults={"_scope" = "backend", "_token_check" = true, "_store_referrer" = false})
+ * @Route(path="%contao.backend.route_prefix%", defaults={"_scope" = "backend", "_token_check" = true})
  *
  * @internal
  */
 class BackendController extends AbstractController
 {
     /**
-     * @Route("", name="contao_backend", defaults={"_store_referrer" = true})
+     * @Route("", name="contao_backend")
      */
     public function mainAction(): Response
     {
@@ -50,7 +50,7 @@ class BackendController extends AbstractController
     }
 
     /**
-     * @Route("/login", name="contao_backend_login")
+     * @Route("/login", name="contao_backend_login", defaults={"_store_referrer" = false})
      */
     public function loginAction(Request $request): Response
     {
@@ -77,7 +77,7 @@ class BackendController extends AbstractController
     /**
      * Symfony will un-authenticate the user automatically by calling this route.
      *
-     * @Route("/logout", name="contao_backend_logout")
+     * @Route("/logout", name="contao_backend_logout", defaults={"_store_referrer" = false})
      */
     public function logoutAction(): RedirectResponse
     {
@@ -85,7 +85,7 @@ class BackendController extends AbstractController
     }
 
     /**
-     * @Route("/password", name="contao_backend_password")
+     * @Route("/password", name="contao_backend_password", defaults={"_store_referrer" = false})
      */
     public function passwordAction(): Response
     {
@@ -97,7 +97,7 @@ class BackendController extends AbstractController
     }
 
     /**
-     * @Route("/confirm", name="contao_backend_confirm")
+     * @Route("/confirm", name="contao_backend_confirm", defaults={"_store_referrer" = false})
      */
     public function confirmAction(): Response
     {
@@ -109,7 +109,7 @@ class BackendController extends AbstractController
     }
 
     /**
-     * @Route("/file", name="contao_backend_file")
+     * @Route("/file", name="contao_backend_file", defaults={"_store_referrer" = false})
      *
      * @deprecated Deprecated since Contao 4.13, to be removed in Contao 5.0.
      *             Use the picker instead.
@@ -126,7 +126,7 @@ class BackendController extends AbstractController
     }
 
     /**
-     * @Route("/help", name="contao_backend_help")
+     * @Route("/help", name="contao_backend_help", defaults={"_store_referrer" = false})
      */
     public function helpAction(): Response
     {
@@ -138,7 +138,7 @@ class BackendController extends AbstractController
     }
 
     /**
-     * @Route("/page", name="contao_backend_page")
+     * @Route("/page", name="contao_backend_page", defaults={"_store_referrer" = false})
      *
      * @deprecated Deprecated since Contao 4.13, to be removed in Contao 5.0.
      *             Use the picker instead.
@@ -155,7 +155,7 @@ class BackendController extends AbstractController
     }
 
     /**
-     * @Route("/popup", name="contao_backend_popup")
+     * @Route("/popup", name="contao_backend_popup", defaults={"_store_referrer" = false})
      */
     public function popupAction(): Response
     {
@@ -167,7 +167,7 @@ class BackendController extends AbstractController
     }
 
     /**
-     * @Route("/alerts", name="contao_backend_alerts")
+     * @Route("/alerts", name="contao_backend_alerts", defaults={"_store_referrer" = false})
      */
     public function alertsAction(): Response
     {
@@ -183,7 +183,7 @@ class BackendController extends AbstractController
      * It will determine the current provider URL based on the value, which is usually
      * read dynamically via JavaScript.
      *
-     * @Route("/picker", name="contao_backend_picker")
+     * @Route("/picker", name="contao_backend_picker", defaults={"_store_referrer" = false})
      */
     public function pickerAction(Request $request): RedirectResponse
     {

--- a/core-bundle/src/Controller/BackendPreviewController.php
+++ b/core-bundle/src/Controller/BackendPreviewController.php
@@ -27,7 +27,7 @@ use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
  * requested front end page while ensuring that the /preview.php entry point is
  * used. When requested, the front end user gets authenticated.
  *
- * @Route(path="%contao.backend.route_prefix%", defaults={"_scope" = "backend", "_allow_preview" = true})
+ * @Route(path="%contao.backend.route_prefix%", defaults={"_scope" = "backend", "_allow_preview" = true, "_store_referrer" = false})
  */
 class BackendPreviewController
 {

--- a/core-bundle/src/Controller/BackendPreviewSwitchController.php
+++ b/core-bundle/src/Controller/BackendPreviewSwitchController.php
@@ -37,7 +37,7 @@ use Twig\Error\Error as TwigError;
  * b) Provide the member usernames for the datalist
  * c) Process the switch action (i.e. log in a specific front end user).
  *
- * @Route(path="%contao.backend.route_prefix%", defaults={"_scope" = "backend", "_allow_preview" = true})
+ * @Route(path="%contao.backend.route_prefix%", defaults={"_scope" = "backend", "_allow_preview" = true, "_store_referrer" = false})
  */
 class BackendPreviewSwitchController
 {

--- a/core-bundle/src/EventListener/StoreRefererListener.php
+++ b/core-bundle/src/EventListener/StoreRefererListener.php
@@ -92,7 +92,8 @@ class StoreRefererListener
             && !$request->query->has('token')
             && !$request->query->has('state')
             && 'feRedirect' !== $request->query->get('do')
-            && 'contao_backend' === $request->attributes->get('_route')
+            && 'backend' === $request->attributes->get('_scope')
+            && false !== $request->attributes->get('_store_referrer')
             && !$request->isXmlHttpRequest();
     }
 

--- a/core-bundle/src/Resources/config/routes.yml
+++ b/core-bundle/src/Resources/config/routes.yml
@@ -12,6 +12,7 @@ contao_backend_redirect:
     defaults:
         _scope: backend
         _controller: Symfony\Bundle\FrameworkBundle\Controller\RedirectController::redirectAction
+        _store_referrer: false
         route: contao_backend
         permanent: true
 
@@ -20,6 +21,7 @@ contao_backend_fallback:
     defaults:
         _scope: backend
         _controller: Symfony\Bundle\FrameworkBundle\Controller\TemplateController
+        _store_referrer: false
         template: '@ContaoCore\Error\backend.html.twig'
         context:
             template: '@ContaoCore\Error\backend.html.twig'

--- a/core-bundle/tests/EventListener/StoreRefererListenerTest.php
+++ b/core-bundle/tests/EventListener/StoreRefererListenerTest.php
@@ -240,6 +240,7 @@ class StoreRefererListenerTest extends TestCase
         $request = new Request();
         $request->setSession($session);
         $request->attributes->set('_scope', ContaoCoreBundle::SCOPE_BACKEND);
+        $request->attributes->set('_store_referrer', false);
 
         $listener = $this->getListener($this->createMock(User::class));
         $listener($this->getResponseEvent($request));

--- a/installation-bundle/src/Controller/InstallationController.php
+++ b/installation-bundle/src/Controller/InstallationController.php
@@ -30,7 +30,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
- * @Route("%contao.backend.route_prefix%", defaults={"_scope" = "backend", "_token_check" = true})
+ * @Route("%contao.backend.route_prefix%", defaults={"_scope" = "backend", "_token_check" = true, "_store_referrer" = false})
  *
  * @internal
  */


### PR DESCRIPTION
#7190

This implements my opt-out suggestion from https://github.com/contao/contao/issues/7190#issuecomment-2094788128.

Any back end route will now store the referrer by default - but you can opt-out via `_store_referrer: false` in your route defaults/attributes.

/cc @ameotoko 