### PR TITLE
Overwrite the page metadata before parsing the news article

### DIFF
--- a/news-bundle/contao/modules/ModuleNewsReader.php
+++ b/news-bundle/contao/modules/ModuleNewsReader.php
@@ -110,9 +110,6 @@ class ModuleNewsReader extends ModuleNews
 			$this->news_template = 'news_full';
 		}
 
-		$arrArticle = $this->parseArticle($objArticle);
-		$this->Template->articles = $arrArticle;
-
 		// Overwrite the page metadata (see #2853, #4955 and #87)
 		$responseContext = System::getContainer()->get('contao.routing.response_context_accessor')->getResponseContext();
 
@@ -166,6 +163,9 @@ class ModuleNewsReader extends ModuleNews
 				$htmlHeadBag->setCanonicalUri($urlGenerator->generate($objArticle, array(), UrlGeneratorInterface::ABSOLUTE_URL));
 			}
 		}
+
+		$arrArticle = $this->parseArticle($objArticle);
+		$this->Template->articles = $arrArticle;
 
 		$bundles = System::getContainer()->getParameter('kernel.bundles');
 


### PR DESCRIPTION
This PR fixes the fact that the page metadata is overwritten after the content has been generated. The sequence is relevant, for example, if an insert tag is used in the content that outputs the page metadata, e.g. `{{page::pageTitle}}`.
If the page metadata is overwritten afterwards the insert tag will be replaced with the page title set in tl_page, with this PR the insert tag is replaced with the title of the news, as it should be IMO.