### PR TITLE
Fix the `_token_check` logic

### DIFF
--- a/core-bundle/src/Controller/BackendController.php
+++ b/core-bundle/src/Controller/BackendController.php
@@ -31,7 +31,7 @@ use Symfony\Component\HttpKernel\UriSigner;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
- * @Route(path="%contao.backend.route_prefix%", defaults={"_scope" = "backend", "_token_check" = true})
+ * @Route(path="%contao.backend.route_prefix%", defaults={"_scope" = "backend"})
  *
  * @internal
  */

--- a/core-bundle/src/Controller/FrontendController.php
+++ b/core-bundle/src/Controller/FrontendController.php
@@ -23,7 +23,7 @@ use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Security\Core\Exception\LogoutException;
 
 /**
- * @Route(defaults={"_scope" = "frontend", "_token_check" = true})
+ * @Route(defaults={"_scope" = "frontend"})
  *
  * @internal
  */

--- a/core-bundle/src/EventListener/RequestTokenListener.php
+++ b/core-bundle/src/EventListener/RequestTokenListener.php
@@ -54,7 +54,7 @@ class RequestTokenListener
 
         // Only check the request token if a) the request is a POST request, b)
         // the request is not an Ajax request, c) the _token_check attribute is
-        // not false, d) the _token_check attribute is set or the request is a
+        // not false, d) the _token_check attribute is true or the request is a
         // Contao request and e) the request has cookies, an authenticated user
         // or the session has been started
         if (
@@ -62,7 +62,7 @@ class RequestTokenListener
             || $request->isXmlHttpRequest()
             || false === $request->attributes->get('_token_check')
             || $this->csrfTokenManager->canSkipTokenValidation($request, $this->csrfCookiePrefix.$this->csrfTokenName)
-            || (!$request->attributes->has('_token_check') && !$this->scopeMatcher->isContaoRequest($request))
+            || (true !== $request->attributes->get('_token_check') && !$this->scopeMatcher->isContaoRequest($request))
         ) {
             return;
         }

--- a/core-bundle/src/Routing/FrontendLoader.php
+++ b/core-bundle/src/Routing/FrontendLoader.php
@@ -38,7 +38,6 @@ class FrontendLoader extends Loader
         $routes = new RouteCollection();
 
         $defaults = [
-            '_token_check' => true,
             '_controller' => 'Contao\CoreBundle\Controller\FrontendController::indexAction',
             '_scope' => ContaoCoreBundle::SCOPE_FRONTEND,
         ];

--- a/core-bundle/src/Routing/LegacyRouteProvider.php
+++ b/core-bundle/src/Routing/LegacyRouteProvider.php
@@ -60,7 +60,6 @@ class LegacyRouteProvider implements RouteProviderInterface
                 '/',
                 [
                     '_scope' => 'frontend',
-                    '_token_check' => true,
                     '_controller' => 'Contao\CoreBundle\Controller\FrontendController::indexAction',
                 ]
             );
@@ -71,7 +70,6 @@ class LegacyRouteProvider implements RouteProviderInterface
                 '/{_url_fragment}',
                 [
                     '_scope' => 'frontend',
-                    '_token_check' => true,
                     '_controller' => 'Contao\CoreBundle\Controller\FrontendController::indexAction',
                 ],
                 ['_url_fragment' => '.*']

--- a/core-bundle/src/Routing/Page/PageRoute.php
+++ b/core-bundle/src/Routing/Page/PageRoute.php
@@ -42,7 +42,6 @@ class PageRoute extends Route implements RouteObjectInterface
 
         $defaults = array_merge(
             [
-                '_token_check' => true,
                 '_controller' => 'Contao\FrontendIndex::renderPage',
                 '_scope' => ContaoCoreBundle::SCOPE_FRONTEND,
                 '_locale' => LocaleUtil::formatAsLocale($pageModel->rootLanguage ?? ''),

--- a/core-bundle/src/Routing/Route404Provider.php
+++ b/core-bundle/src/Routing/Route404Provider.php
@@ -154,7 +154,6 @@ class Route404Provider extends AbstractPageRouteProvider
         }
 
         $defaults = [
-            '_token_check' => true,
             '_controller' => 'Contao\FrontendIndex::renderPage',
             '_scope' => ContaoCoreBundle::SCOPE_FRONTEND,
             '_locale' => LocaleUtil::formatAsLocale($page->rootLanguage ?? ''),

--- a/core-bundle/tests/EventListener/RequestTokenListenerTest.php
+++ b/core-bundle/tests/EventListener/RequestTokenListenerTest.php
@@ -84,7 +84,7 @@ class RequestTokenListenerTest extends TestCase
     /**
      * @dataProvider getAttributeAndRequest
      */
-    public function testValidatesTheRequestTokenDependingOnTheRequest(bool $setAttribute, bool|null $tokenCheck, bool $isContaoRequest, bool $isValidToken): void
+    public function testValidatesTheRequestTokenDependingOnTheRequest(bool $setAttribute, ?bool $tokenCheck, bool $isContaoRequest, bool $isValidToken): void
     {
         $config = $this->mockConfiguredAdapter(['get' => false]);
         $framework = $this->mockContaoFramework([Config::class => $config]);

--- a/core-bundle/tests/EventListener/RequestTokenListenerTest.php
+++ b/core-bundle/tests/EventListener/RequestTokenListenerTest.php
@@ -33,7 +33,6 @@ class RequestTokenListenerTest extends TestCase
         $request = Request::create('/account.html', 'POST');
         $request->setMethod('POST');
         $request->request->set('REQUEST_TOKEN', 'foo');
-        $request->attributes->set('_token_check', true);
         $request->cookies = new InputBag(['unrelated-cookie' => 'to-activate-csrf']);
 
         $this->validateRequestTokenForRequest($request);
@@ -44,7 +43,6 @@ class RequestTokenListenerTest extends TestCase
         $request = Request::create('/account.html');
         $request->setMethod('POST');
         $request->request->set('REQUEST_TOKEN', 'foo');
-        $request->attributes->set('_token_check', true);
         $request->headers->set('PHP_AUTH_USER', 'user');
 
         $this->validateRequestTokenForRequest($request);
@@ -61,7 +59,6 @@ class RequestTokenListenerTest extends TestCase
         $request = Request::create('/account.html');
         $request->setMethod('POST');
         $request->request->set('REQUEST_TOKEN', 'foo');
-        $request->attributes->set('_token_check', true);
         $request->setSession($session);
 
         $this->validateRequestTokenForRequest($request);
@@ -71,7 +68,6 @@ class RequestTokenListenerTest extends TestCase
     {
         $request = Request::create('/account.html');
         $request->setMethod('POST');
-        $request->attributes->set('_token_check', true);
 
         $this->validateRequestTokenForRequest($request, false);
     }
@@ -80,27 +76,28 @@ class RequestTokenListenerTest extends TestCase
     {
         $request = Request::create('/account.html');
         $request->setMethod('POST');
-        $request->attributes->set('_token_check', true);
         $request->cookies = new InputBag(['csrf_contao_csrf_token' => 'value']);
 
         $this->validateRequestTokenForRequest($request, false);
     }
 
-    public function testValidatesTheRequestTokenUponContaoRequests(): void
+    /**
+     * @dataProvider getAttributeAndRequest
+     */
+    public function testValidatesTheRequestTokenDependingOnTheRequest(bool $setAttribute, bool|null $tokenCheck, bool $isContaoRequest, bool $isValidToken): void
     {
         $config = $this->mockConfiguredAdapter(['get' => false]);
         $framework = $this->mockContaoFramework([Config::class => $config]);
 
         $scopeMatcher = $this->createMock(ScopeMatcher::class);
         $scopeMatcher
-            ->expects($this->once())
             ->method('isContaoRequest')
-            ->willReturn(true)
+            ->willReturn($isContaoRequest)
         ;
 
         $csrfTokenManager = $this->createMock(ContaoCsrfTokenManager::class);
         $csrfTokenManager
-            ->expects($this->once())
+            ->expects($isValidToken ? $this->once() : $this->never())
             ->method('isTokenValid')
             ->willReturn(true)
         ;
@@ -109,6 +106,10 @@ class RequestTokenListenerTest extends TestCase
         $request->setMethod('POST');
         $request->request->set('REQUEST_TOKEN', 'foo');
         $request->cookies = new InputBag(['unrelated-cookie' => 'to-activate-csrf']);
+
+        if ($setAttribute) {
+            $request->attributes->set('_token_check', $tokenCheck);
+        }
 
         $event = $this->createMock(RequestEvent::class);
         $event
@@ -127,11 +128,25 @@ class RequestTokenListenerTest extends TestCase
         $listener($event);
     }
 
+    public static function getAttributeAndRequest(): \Generator
+    {
+        yield 'no attribute, Contao request' => [false, false, true, true];
+        yield 'no attribute, not a Contao request' => [false, false, false, false];
+        yield 'attribute, Contao request' => [true, true, true, true];
+        yield 'attribute, not a Contao request' => [true, true, false, true];
+        yield 'falsey attribute, not a Contao request' => [true, null, false, false];
+    }
+
     public function testFailsIfTheRequestTokenIsInvalid(): void
     {
         $config = $this->mockConfiguredAdapter(['get' => false]);
         $framework = $this->mockContaoFramework([Config::class => $config]);
+
         $scopeMatcher = $this->createMock(ScopeMatcher::class);
+        $scopeMatcher
+            ->method('isContaoRequest')
+            ->willReturn(true)
+        ;
 
         $csrfTokenManager = $this->createMock(ContaoCsrfTokenManager::class);
         $csrfTokenManager
@@ -143,7 +158,6 @@ class RequestTokenListenerTest extends TestCase
         $request = Request::create('/account.html');
         $request->setMethod('POST');
         $request->request->set('REQUEST_TOKEN', 'foo');
-        $request->attributes->set('_token_check', true);
         $request->cookies = new InputBag(['unrelated-cookie' => 'to-activate-csrf']);
 
         $event = $this->createMock(RequestEvent::class);
@@ -180,7 +194,6 @@ class RequestTokenListenerTest extends TestCase
 
         $request = Request::create('/account.html');
         $request->setMethod('GET');
-        $request->attributes->set('_token_check', true);
         $request->cookies = new InputBag(['unrelated-cookie' => 'to-activate-csrf']);
 
         $event = $this->createMock(RequestEvent::class);
@@ -213,7 +226,6 @@ class RequestTokenListenerTest extends TestCase
 
         $request = Request::create('/account.html');
         $request->setMethod('POST');
-        $request->attributes->set('_token_check', true);
         $request->cookies = new InputBag(['unrelated-cookie' => 'to-activate-csrf']);
         $request->headers->set('X-Requested-With', 'XMLHttpRequest');
 
@@ -336,7 +348,12 @@ class RequestTokenListenerTest extends TestCase
     {
         $config = $this->mockConfiguredAdapter(['get' => false]);
         $framework = $this->mockContaoFramework([Config::class => $config]);
+
         $scopeMatcher = $this->createMock(ScopeMatcher::class);
+        $scopeMatcher
+            ->method('isContaoRequest')
+            ->willReturn(true)
+        ;
 
         $csrfTokenManager = $this->createMock(ContaoCsrfTokenManager::class);
         $csrfTokenManager

--- a/core-bundle/tests/Routing/LegacyRouteProviderTest.php
+++ b/core-bundle/tests/Routing/LegacyRouteProviderTest.php
@@ -140,7 +140,6 @@ class LegacyRouteProviderTest extends TestCase
         $this->assertSame(
             [
                 '_scope' => 'frontend',
-                '_token_check' => true,
                 '_controller' => 'Contao\CoreBundle\Controller\FrontendController::indexAction',
             ],
             $route->getDefaults()
@@ -165,7 +164,6 @@ class LegacyRouteProviderTest extends TestCase
         $this->assertSame(
             [
                 '_scope' => 'frontend',
-                '_token_check' => true,
                 '_controller' => 'Contao\CoreBundle\Controller\FrontendController::indexAction',
             ],
             $route->getDefaults()

--- a/installation-bundle/src/Controller/InstallationController.php
+++ b/installation-bundle/src/Controller/InstallationController.php
@@ -30,7 +30,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
- * @Route("%contao.backend.route_prefix%", defaults={"_scope" = "backend", "_token_check" = true, "_store_referrer" = false})
+ * @Route("%contao.backend.route_prefix%", defaults={"_scope" = "backend", "_store_referrer" = false})
  *
  * @internal
  */


### PR DESCRIPTION
This is how the `RequestTokenListener` currently works:

* Check the request token if it is a Contao request and the `_token_check` attribute is not `false`.
* Check the request token if it is not a Contao request but the `_token_check` attribute **exists**.

However, the latter case should be implemented as _if the attribute **is true**_, otherwise the request token would also be checked in the following case:

```php
/**
 * @Route("/foo", defaults={"_token_check" = null})
 *
 * This is treated the same as "_token_check" = true, although null is falsey.
 */
```

---

The pull request also removes the redundant `"_scope" = "backend", "_token_check" = true` configuration, as `"_token_check" = true` is only required if the scope is not `backend` or `frontend`.