### PR TITLE
Fix an endless loop in the `DC_Folder::getParentFilemounts()` method

### DIFF
--- a/core-bundle/contao/drivers/DC_Folder.php
+++ b/core-bundle/contao/drivers/DC_Folder.php
@@ -3134,9 +3134,10 @@ class DC_Folder extends DataContainer implements ListableDataContainerInterface,
 		$parents = array();
 		$uploadPath = Path::canonicalize($this->strUploadPath);
 
-		while (($filemount = Path::getDirectory($filemount)) !== $uploadPath)
+		while ($filemount !== $uploadPath)
 		{
 			$parents[] = $filemount;
+			$filemount = Path::getDirectory($filemount);
 		}
 
 		return $parents;


### PR DESCRIPTION
To reproduce, create the following structure:

```
files/
    image1.jpg
    images/
        image2.jpg
```

Now open the picker and search for `image`. Since one of the files is in the root directory, `$filemount` will be `files` and `Path::getDirectory($filemount)` will be an empty string causing the endless loop.