### PR TITLE
Use `HtmlAttributes` for `fe_page`

### DIFF
--- a/core-bundle/contao/templates/frontend/fe_page.html5
+++ b/core-bundle/contao/templates/frontend/fe_page.html5
@@ -1,5 +1,23 @@
+<?php
+
+$this->rootAttributes = $this
+    ->attr()
+    ->set('lang', $this->language)
+    ->set('dir', 'rtl', $this->isRTL)
+    ->mergeWith($this->rootAttributes)
+;
+
+$this->bodyAttributes = $this
+    ->attr()
+    ->set('id', 'top')
+    ->addClass($this->class)
+    ->setIfExists('onload', $this->onload)
+    ->mergeWith($this->bodyAttributes)
+;
+
+?>
 <!DOCTYPE html>
-<html lang="<?= $this->language ?>"<?php if ($this->isRTL): ?> dir="rtl"<?php endif; ?>>
+<html<?= $this->rootAttributes ?>>
 <head>
 
   <?php $this->block('head'); ?>
@@ -25,7 +43,7 @@
   <?php $this->endblock(); ?>
 
 </head>
-<body id="top"<?php if ($this->class): ?> class="<?= $this->class ?>"<?php endif; ?><?php if ($this->onload): ?> onload="<?= $this->onload ?>"<?php endif; ?>>
+<body<?= $this->bodyAttributes ?>>
 
   <?php $this->block('body'); ?>
     <?php $this->sections('top'); ?>


### PR DESCRIPTION
Since we don't have a replacement for our `fe_page.html5` in the pipeline yet - and inspired by #7218 I think it would be great if we could introduce the `HtmlAttributes` to the default `fe_page` as well.

Adding additional attributes to `<html>` or `<body>` without overwriting the `fe_page` template completely is currently pretty akward. These are the hacks that I use currently:

```php
$this->extend('fe_page');

// By adding a `"` in the beginning and omitting it at the end we can "inject" 
// additional attributes on the <html> node using the $this->language variable
$this->language .= '" data-turbo="false';

// Same concept for the <body> via the $this->class variable
$this->class .= '" data-controller="foobar';
```

With this PR it would be much nicer:

```php
$this->extend('fe_page'); 

$this->rootAttributes = $this->attr()
    ->set('data-turbo', false)
    ->mergeWith($this->rootAttributes)
;

$this->bodyAttributes = $this->attr()
    ->set('data-controller', 'foobar')
    ->mergeWith($this->bodyAttributes)
;
```
