### PR TITLE
Fix more edge cases in the `HtmlAttributes` class

### DIFF
--- a/core-bundle/src/String/HtmlAttributes.php
+++ b/core-bundle/src/String/HtmlAttributes.php
@@ -102,11 +102,7 @@ class HtmlAttributes implements \Stringable, \JsonSerializable, \IteratorAggrega
 
         $name = strtolower($name);
 
-        if (
-            !preg_match('(^[^>\s/][^>\s/=]*$)', $name)
-            || !preg_match('//u', $name)
-            || str_contains($name, "\x00")
-        ) {
+        if (!preg_match('(^[^>\s/][^>\s/=]*$)', $name) || !preg_match('//u', $name) || str_contains($name, "\x00")) {
             throw new \InvalidArgumentException(sprintf('An HTML attribute name must be valid UTF-8 and not contain the characters >, /, = or whitespace, got "%s".', $name));
         }
 

--- a/core-bundle/src/String/HtmlAttributes.php
+++ b/core-bundle/src/String/HtmlAttributes.php
@@ -19,7 +19,7 @@ namespace Contao\CoreBundle\String;
 class HtmlAttributes implements \Stringable, \JsonSerializable, \IteratorAggregate, \ArrayAccess
 {
     /**
-     * @var array<string, string>
+     * @var array<array-key, string>
      */
     private array $attributes = [];
 
@@ -81,7 +81,7 @@ class HtmlAttributes implements \Stringable, \JsonSerializable, \IteratorAggrega
         }
 
         foreach ($attributes as $name => $value) {
-            $mergeSet($name, $value);
+            $mergeSet((string) $name, $value);
         }
 
         return $this;
@@ -102,11 +102,11 @@ class HtmlAttributes implements \Stringable, \JsonSerializable, \IteratorAggrega
 
         $name = strtolower($name);
 
-        // Even though the HTML 5 parser supports attribute names starting with an equal
-        // sign, we have to disallow that in order to support serializing boolean
-        // attributes. Otherwise, serializing and parsing back something like `hidden=""
-        // =attr="value"` would fail the roundtrip.
-        if (1 !== preg_match('(^[^>\s/=]+$)', $name) || 1 !== preg_match('//u', $name)) {
+        if (
+            !preg_match('(^[^>\s/][^>\s/=]*$)', $name)
+            || !preg_match('//u', $name)
+            || str_contains($name, "\x00")
+        ) {
             throw new \InvalidArgumentException(sprintf('An HTML attribute name must be valid UTF-8 and not contain the characters >, /, = or whitespace, got "%s".', $name));
         }
 
@@ -314,7 +314,13 @@ class HtmlAttributes implements \Stringable, \JsonSerializable, \IteratorAggrega
     {
         $attributes = [];
 
-        foreach ($this->attributes as $name => $value) {
+        foreach ($this->getIterator() as $name => $value) {
+            // Special case if the attribute name starts with an equals sign and the previous
+            // attribute was a boolean attribute
+            if ('=' === $name[0] && !str_ends_with($attributes[\count($attributes) - 1] ?? '"', '"')) {
+                $attributes[\count($attributes) - 1] .= '=""';
+            }
+
             $attributes[] = '' !== $value ? sprintf('%s="%s"', $name, $this->escapeValue($name, $value)) : $name;
         }
 
@@ -324,11 +330,13 @@ class HtmlAttributes implements \Stringable, \JsonSerializable, \IteratorAggrega
     }
 
     /**
-     * @return \ArrayIterator<string, string>
+     * @return \Generator<string, string>
      */
-    public function getIterator(): \Traversable
+    public function getIterator(): \Generator
     {
-        return new \ArrayIterator($this->attributes);
+        foreach ($this->attributes as $name => $value) {
+            yield (string) $name => $value;
+        }
     }
 
     public function offsetExists(mixed $offset): bool
@@ -355,9 +363,10 @@ class HtmlAttributes implements \Stringable, \JsonSerializable, \IteratorAggrega
         unset($this->attributes[$offset]);
     }
 
-    public function jsonSerialize(): array
+    public function jsonSerialize(): mixed
     {
-        return $this->attributes;
+        // Ensure string keys by casting to object
+        return (object) $this->attributes;
     }
 
     /**
@@ -387,6 +396,19 @@ class HtmlAttributes implements \Stringable, \JsonSerializable, \IteratorAggrega
      */
     private function parseString(string $attributesString): \Generator
     {
+        // Normalize to UTF-8 according to:
+        // https://encoding.spec.whatwg.org/#utf-8
+        // https://html.spec.whatwg.org/multipage/parsing.html#the-input-byte-stream
+        // https://html.spec.whatwg.org/multipage/parsing.html#preprocessing-the-input-stream
+        if (!preg_match('//u', $attributesString) || str_contains($attributesString, "\x00")) {
+            $substituteCharacter = mb_substitute_character();
+            mb_substitute_character(0xFFFD);
+
+            $attributesString = mb_convert_encoding(str_replace("\x00", "\u{FFFD}", $attributesString), 'UTF-8', 'UTF-8');
+
+            mb_substitute_character($substituteCharacter);
+        }
+
         // Regular expression to match attributes according to
         // https://html.spec.whatwg.org/#before-attribute-name-state
         $attributeRegex = '(
@@ -402,18 +424,24 @@ class HtmlAttributes implements \Stringable, \JsonSerializable, \IteratorAggrega
                     |([^\s>]*+)                        # Or unquoted or missing value
                 )                                      # Value end
             )?+                                        # Assignment is optional
+            |>(*COMMIT)(*FAIL)                         # End of HTML tag
         )ix';
 
         preg_match_all($attributeRegex, $attributesString, $matches, PREG_SET_ORDER | PREG_UNMATCHED_AS_NULL);
 
+        $usedNames = [];
+
         foreach ($matches as [1 => $name, 2 => $value]) {
-            yield strtolower($name) => html_entity_decode($value ?? '', ENT_QUOTES | ENT_HTML5);
+            if (!isset($usedNames[$name = strtolower($name)])) {
+                $usedNames[$name] = true;
+                yield $name => html_entity_decode($value ?? '', ENT_QUOTES | ENT_HTML5, 'UTF-8');
+            }
         }
     }
 
     private function escapeValue(string $name, string $value): string
     {
-        if (!preg_match('//u', $value)) {
+        if (!preg_match('//u', $value) || str_contains($value, "\x00")) {
             throw new \RuntimeException(sprintf('The value of property "%s" is not a valid UTF-8 string.', $name));
         }
 

--- a/core-bundle/tests/String/HtmlAttributesTest.php
+++ b/core-bundle/tests/String/HtmlAttributesTest.php
@@ -74,13 +74,13 @@ class HtmlAttributesTest extends TestCase
         ];
 
         yield 'special html parsing rules' => [
-            "/X===.._-/\n/Y/-==",
-            ['x' => '==.._-/', 'y' => '', '-' => '='],
+            "/X===.._-/\n/Y/-== bool='' ===",
+            ['x' => '==.._-/', 'y' => '', '-' => '=', 'bool' => '', '=' => '='],
         ];
 
-        yield 'skip closing and keep opening tags as per html parsing rules' => [
-            '>foo=<bar>baz>/</<attr=<value',
-            ['foo' => '<bar', 'baz' => '', '<' => '', '<attr' => '<value'],
+        yield 'terminate closing and keep opening tags as per html parsing rules' => [
+            '/</<attr=<value foo="bar>"baz>foo',
+            ['<' => '', '<attr' => '<value', 'foo' => 'bar>', 'baz' => ''],
         ];
 
         yield 'skip unclosed attributes completely' => [
@@ -89,8 +89,8 @@ class HtmlAttributesTest extends TestCase
         ];
 
         yield 'decode values' => [
-            'foo=&quot; bar="b&auml;z" baz=&ZeroWidthSpace;',
-            ['foo' => '"', 'bar' => 'bäz', 'baz' => "\u{200B}"],
+            'foo=&quot; bar="b&auml;z" baz=&ZeroWidthSpace; &lt;=&gt;',
+            ['foo' => '"', 'bar' => 'bäz', 'baz' => "\u{200B}", '&lt;' => '>'],
         ];
 
         yield 'no attributes' => [
@@ -103,8 +103,13 @@ class HtmlAttributesTest extends TestCase
             [],
         ];
 
+        yield 'duplicate attributes' => [
+            'foo=1 bar=2 bar=3 FOO=4',
+            ['foo' => '1', 'bar' => '2'],
+        ];
+
         yield 'complex styles' => [
-            'style=" content:&quot; foo : bar ; baz ( &quot;; foo : url(https://example.com/foo;bar) ; " STYLE=color:red',
+            'style=" content:&quot; foo : bar ; baz ( &quot;; foo : url(https://example.com/foo;bar) ;color:red" STYLE=color:blue',
             ['style' => 'content: " foo : bar ; baz ( "; foo: url(https://example.com/foo;bar); color: red;'],
         ];
 
@@ -270,14 +275,11 @@ class HtmlAttributesTest extends TestCase
         $this->assertSame($expectedProperties, iterator_to_array($attributes));
     }
 
-    /**
-     * @dataProvider provideInvalidAttributeNames
-     */
-    public function testSkipsInvalidAttributeNamesWhenParsingString(string $name): void
+    public function testSkipsInvalidAttributeNamesWhenParsingString(): void
     {
-        $attributes = new HtmlAttributes(sprintf('foo="bar" %s="bar" baz=42', $name));
+        $attributes = new HtmlAttributes("foo=bar f\xC2o\x00o=b&#xC2;ar baz=42");
 
-        $this->assertSame(['foo' => 'bar', 'baz' => '42'], iterator_to_array($attributes));
+        $this->assertSame(['foo' => 'bar', "f\u{FFFD}o\u{FFFD}o" => "b\u{C2}ar", 'baz' => '42'], iterator_to_array($attributes));
     }
 
     /**
@@ -308,8 +310,10 @@ class HtmlAttributesTest extends TestCase
     {
         yield 'invalid non-utf8 character' => ["f\xC2"];
         yield 'empty string' => [''];
-        yield 'equal sign' => ['='];
-        yield 'starts with an equal sign' => ['=foo'];
+        yield 'greater-than sign' => ['>'];
+        yield 'includes a slash' => ['f/oo'];
+        yield 'includes an equals sign' => ['f=oo'];
+        yield 'includes a space' => ['f oo'];
     }
 
     public function testSetAndUnsetProperties(): void
@@ -632,6 +636,48 @@ class HtmlAttributesTest extends TestCase
         $this->assertSame('', (new HtmlAttributes())->toString(false));
     }
 
+    /**
+     * @dataProvider provideBooleanAttributes
+     */
+    public function testCorrectlySerializesBooleanAttributes(array $attrArray, string $attrString): void
+    {
+        $this->assertSame($attrString, (new HtmlAttributes($attrArray))->toString(false));
+        $this->assertSame($attrArray, iterator_to_array(new HtmlAttributes($attrString)));
+    }
+
+    public static function provideBooleanAttributes(): iterable
+    {
+        yield [
+            ['foo' => ''],
+            'foo',
+        ];
+
+        yield [
+            ['foo' => '', '=' => ''],
+            'foo="" =',
+        ];
+
+        yield [
+            ['=' => '', 'foo' => ''],
+            '= foo',
+        ];
+
+        yield [
+            ['=' => '', '=foo' => ''],
+            '=="" =foo',
+        ];
+
+        yield [
+            ['=foo' => '', '=' => ''],
+            '=foo="" =',
+        ];
+
+        yield [
+            ['1' => '', '=' => '', '2' => ''],
+            '1="" = 2',
+        ];
+    }
+
     public function testThrowsIfValueContainsInvalidUtf8Characters(): void
     {
         $attributes = new HtmlAttributes(['foo' => "\xC2"]);
@@ -663,9 +709,9 @@ class HtmlAttributesTest extends TestCase
         $attributes = new HtmlAttributes();
 
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('An HTML attribute name must be valid UTF-8 and not contain the characters >, /, = or whitespace, got "=foo".');
+        $this->expectExceptionMessage('An HTML attribute name must be valid UTF-8 and not contain the characters >, /, = or whitespace, got ">foo".');
 
-        $attributes['=foo'] = 'bar';
+        $attributes['>foo'] = 'bar';
     }
 
     public function testThrowsIfPropertyDoesNotExistWhenUsingArrayAccess(): void
@@ -684,6 +730,20 @@ class HtmlAttributesTest extends TestCase
         $attributes = new HtmlAttributes(['foo' => 'bar', 'baz' => 42]);
 
         $this->assertSame('{"foo":"bar","baz":"42"}', json_encode($attributes, JSON_THROW_ON_ERROR));
+
+        $attributes = new HtmlAttributes('0=foo 1=bar');
+
+        $this->assertSame('{"0":"foo","1":"bar"}', json_encode($attributes, JSON_THROW_ON_ERROR));
+    }
+
+    public function testIteratorStringKeys(): void
+    {
+        $attributes = new HtmlAttributes('0=foo 1=bar');
+
+        foreach ($attributes as $key => $value) {
+            $this->assertIsString($key);
+            $this->assertIsString($value);
+        }
     }
 
     private function toStringable(string $string): \Stringable


### PR DESCRIPTION
Fixes some bugs in the `HtmlAttributes` class:

1. Numerical attributes like `123="foo"` caused type errors
2. Invalid UTF-8 and null bytes were not handled correctly
3. Attributes starting with `=` were not supported