### PR TITLE
Only handle `GET` requests in the search index listener

### DIFF
--- a/core-bundle/src/EventListener/SearchIndexListener.php
+++ b/core-bundle/src/EventListener/SearchIndexListener.php
@@ -51,6 +51,12 @@ class SearchIndexListener
         }
 
         $request = $event->getRequest();
+
+        // Only handle GET requests (see #1194)
+        if (!$request->isMethod(Request::METHOD_GET)) {
+            return;
+        }
+
         $document = Document::createFromRequestResponse($request, $response);
         $needsIndex = $this->needsIndex($request, $response, $document);
 
@@ -71,11 +77,6 @@ class SearchIndexListener
 
     private function needsIndex(Request $request, Response $response, Document $document): bool
     {
-        // Only handle GET requests (see #1194)
-        if (!$request->isMethod(Request::METHOD_GET)) {
-            return false;
-        }
-
         // Do not index if called by crawler
         if (Factory::USER_AGENT === $request->headers->get('User-Agent')) {
             return false;

--- a/core-bundle/src/EventListener/SearchIndexListener.php
+++ b/core-bundle/src/EventListener/SearchIndexListener.php
@@ -52,7 +52,7 @@ class SearchIndexListener
 
         $request = $event->getRequest();
 
-        // Only handle GET requests (see #1194)
+        // Only handle GET requests (see #1194, #7240)
         if (!$request->isMethod(Request::METHOD_GET)) {
             return;
         }

--- a/core-bundle/tests/EventListener/SearchIndexListenerTest.php
+++ b/core-bundle/tests/EventListener/SearchIndexListenerTest.php
@@ -69,7 +69,7 @@ class SearchIndexListenerTest extends TestCase
 
         yield 'Should be skipped because it is not a GET request' => [
             Request::create('/foobar', 'POST'),
-            new Response(),
+            new Response('', Response::HTTP_INTERNAL_SERVER_ERROR),
             SearchIndexListener::FEATURE_DELETE | SearchIndexListener::FEATURE_INDEX,
             false,
             false,


### PR DESCRIPTION
I noticed that `$this->indexer->delete($document);` is still executed for `POST` requests - if the response has a failure status code. Thus it is currently possible to remove pages from the index via `POST` requests, if you can make the `POST` request fail - which is easy, as you just have to send a cookie with the request and omit the request token.

I noticed this via spam attacks that invoked error responses (since there were so many request, a deadlock error occured during `$this->indexer->delete($document)`).

The _"Should be skipped because it is not a GET request"_ test did not pick up on this as it only tested for a sucessful response. I have adjusted the test accordingly. Or should we split it up into two tests instead? One with a succesful response and one with an unsuccesful response.