### PR TITLE
Use the original ID for nested fragments if available

### DIFF
--- a/core-bundle/contao/library/Contao/Controller.php
+++ b/core-bundle/contao/library/Contao/Controller.php
@@ -584,7 +584,7 @@ abstract class Controller extends System
 			$objElement = new $strClass(
 				$objRow,
 				$strColumn,
-				$compositor->getNestedFragments(ContentElementReference::TAG_NAME . '.' . $objRow->type, $objRow->id)
+				$compositor->getNestedFragments(ContentElementReference::TAG_NAME . '.' . $objRow->type, $objRow->origId ?: $objRow->id)
 			);
 		}
 		else


### PR DESCRIPTION
Fixes https://github.com/contao/contao/issues/7198