### PR TITLE
Replace insert tags when parsing widget templates

### DIFF
--- a/core-bundle/contao/library/Contao/TemplateInheritance.php
+++ b/core-bundle/contao/library/Contao/TemplateInheritance.php
@@ -143,7 +143,7 @@ trait TemplateInheritance
 		}
 
 		// Replace insert tags
-		if ($this instanceof FrontendTemplate)
+		if ($this instanceof FrontendTemplate || $this instanceof Widget)
 		{
 			$container = System::getContainer();
 			$request = $container->get('request_stack')->getCurrentRequest();


### PR DESCRIPTION
Fixes #6770

However, I could not actually reproduce #6770. `Contao\Form` still uses a regular `FrontendTemplate` instance - so when the form gets rendered, the insert tags of all the widgets get replaced. Do we want to make the change regardless?

@aschempp did you render the explanation widget outside of `Contao\Form` somewhere?