### PR TITLE
Use `ENT_QUOTES|ENT_SUBSTITUTE|ENT_HTML5` instead of just `ENT_QUOTES`

### DIFF
--- a/core-bundle/src/Controller/CaptchaController.php
+++ b/core-bundle/src/Controller/CaptchaController.php
@@ -47,7 +47,7 @@ class CaptchaController extends AbstractController
         $captcha = new FormCaptcha();
 
         return new JsonResponse([
-            'question' => html_entity_decode($captcha->question),
+            'question' => html_entity_decode($captcha->question, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5),
             'sum' => $captcha->sum,
             'hash' => $captcha->sum.$captcha->hash,
         ]);

--- a/core-bundle/src/Image/Preview/FallbackPreviewProvider.php
+++ b/core-bundle/src/Image/Preview/FallbackPreviewProvider.php
@@ -42,7 +42,7 @@ class FallbackPreviewProvider implements PreviewProviderInterface
         $svgCode .= '<path d="M11.61 1.79H2.7V16.2h12.6V5.51zm2.69 3.72h-2.67V2.82zm.28 10H3.42v-13h7.38v3.86h3.78z" fill="#ccc"/>';
         $svgCode .= '<path d="M14.25 11.88a1.83 1.83 0 0 1-1.83 1.83H2.83A1.83 1.83 0 0 1 1 11.89v-2.3a1.83 1.83 0 0 1 1.83-1.83h9.59a1.83 1.83 0 0 1 1.83 1.83z" fill="#c9473d"/>';
         $svgCode .= '<text fill="#fff" text-anchor="middle" x="7.7" y="12.2" style="font: bold 4px -apple-system, BlinkMacSystemFont, avenir next, avenir, segoe ui, helvetica neue, helvetica, Ubuntu, roboto, noto, arial, sans-serif;">';
-        $svgCode .= htmlspecialchars(strtoupper(pathinfo($sourcePath, PATHINFO_EXTENSION)), ENT_XML1);
+        $svgCode .= htmlspecialchars(strtoupper(pathinfo($sourcePath, PATHINFO_EXTENSION)), ENT_QUOTES | ENT_SUBSTITUTE | ENT_XML1);
         $svgCode .= '</text>';
         $svgCode .= '</svg>';
 

--- a/core-bundle/src/Resources/contao/classes/DataContainer.php
+++ b/core-bundle/src/Resources/contao/classes/DataContainer.php
@@ -1342,7 +1342,7 @@ abstract class DataContainer extends Backend
 		$values = array_map($this->objPickerCallback, $this->arrPickerValue);
 		$values = array_map('strval', $values);
 		$values = json_encode($values);
-		$values = htmlspecialchars($values);
+		$values = htmlspecialchars($values, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5);
 
 		return ' data-picker-value="' . $values . '"';
 	}

--- a/core-bundle/src/Resources/contao/drivers/DC_File.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_File.php
@@ -441,7 +441,7 @@ class DC_File extends DataContainer implements EditableDataContainerInterface
 		}
 		elseif (\is_string($strCurrent))
 		{
-			$strCurrent = html_entity_decode($this->varValue, ENT_QUOTES | ENT_HTML5, System::getContainer()->getParameter('kernel.charset'));
+			$strCurrent = html_entity_decode($this->varValue, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, System::getContainer()->getParameter('kernel.charset'));
 		}
 
 		// Save the value if there was no error

--- a/core-bundle/src/Resources/contao/drivers/DC_File.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_File.php
@@ -220,13 +220,13 @@ class DC_File extends DataContainer implements EditableDataContainerInterface
 
 						if (!\is_array($this->varValue))
 						{
-							$this->varValue = htmlspecialchars($this->varValue);
+							$this->varValue = htmlspecialchars($this->varValue, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5);
 						}
 						else
 						{
 							foreach ($this->varValue as $key=>$val)
 							{
-								$this->varValue[$key] = htmlspecialchars($val);
+								$this->varValue[$key] = htmlspecialchars($val, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5);
 							}
 						}
 					}

--- a/core-bundle/src/Resources/contao/drivers/DC_File.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_File.php
@@ -441,7 +441,7 @@ class DC_File extends DataContainer implements EditableDataContainerInterface
 		}
 		elseif (\is_string($strCurrent))
 		{
-			$strCurrent = html_entity_decode($this->varValue, ENT_QUOTES, System::getContainer()->getParameter('kernel.charset'));
+			$strCurrent = html_entity_decode($this->varValue, ENT_QUOTES|ENT_HTML5, System::getContainer()->getParameter('kernel.charset'));
 		}
 
 		// Save the value if there was no error

--- a/core-bundle/src/Resources/contao/drivers/DC_File.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_File.php
@@ -441,7 +441,7 @@ class DC_File extends DataContainer implements EditableDataContainerInterface
 		}
 		elseif (\is_string($strCurrent))
 		{
-			$strCurrent = html_entity_decode($this->varValue, ENT_QUOTES|ENT_HTML5, System::getContainer()->getParameter('kernel.charset'));
+			$strCurrent = html_entity_decode($this->varValue, ENT_QUOTES | ENT_HTML5, System::getContainer()->getParameter('kernel.charset'));
 		}
 
 		// Save the value if there was no error

--- a/core-bundle/src/Resources/contao/drivers/DC_Folder.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Folder.php
@@ -2698,7 +2698,7 @@ class DC_Folder extends DataContainer implements ListableDataContainerInterface,
 				$blnIsOpen = true;
 			}
 
-			$return .= "\n  " . '<li data-id="' . htmlspecialchars($currentFolder, ENT_QUOTES | ENT_HTML5) . '" class="tl_folder click2edit toggle_select hover-div"><div class="tl_left" style="padding-left:' . ($intMargin + (($countFiles < 1) ? 20 : 0)) . 'px">';
+			$return .= "\n  " . '<li data-id="' . htmlspecialchars($currentFolder, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5) . '" class="tl_folder click2edit toggle_select hover-div"><div class="tl_left" style="padding-left:' . ($intMargin + (($countFiles < 1) ? 20 : 0)) . 'px">';
 
 			// Add a toggle button if there are childs
 			if ($countFiles > 0)
@@ -2801,7 +2801,7 @@ class DC_Folder extends DataContainer implements ListableDataContainerInterface,
 			}
 
 			$currentEncoded = $this->urlEncode($currentFile);
-			$return .= "\n  " . '<li data-id="' . htmlspecialchars($currentFile, ENT_QUOTES | ENT_HTML5) . '" class="tl_file click2edit toggle_select hover-div"><div class="tl_left" style="padding-left:' . ($intMargin + $intSpacing) . 'px">';
+			$return .= "\n  " . '<li data-id="' . htmlspecialchars($currentFile, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5) . '" class="tl_file click2edit toggle_select hover-div"><div class="tl_left" style="padding-left:' . ($intMargin + $intSpacing) . 'px">';
 			$thumbnail .= ' <span class="tl_gray">(' . $this->getReadableSize($objFile->filesize);
 
 			if ($objFile->width && $objFile->height)

--- a/core-bundle/src/Resources/contao/drivers/DC_Folder.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Folder.php
@@ -2698,7 +2698,7 @@ class DC_Folder extends DataContainer implements ListableDataContainerInterface,
 				$blnIsOpen = true;
 			}
 
-			$return .= "\n  " . '<li data-id="' . htmlspecialchars($currentFolder, ENT_QUOTES|ENT_HTML5) . '" class="tl_folder click2edit toggle_select hover-div"><div class="tl_left" style="padding-left:' . ($intMargin + (($countFiles < 1) ? 20 : 0)) . 'px">';
+			$return .= "\n  " . '<li data-id="' . htmlspecialchars($currentFolder, ENT_QUOTES | ENT_HTML5) . '" class="tl_folder click2edit toggle_select hover-div"><div class="tl_left" style="padding-left:' . ($intMargin + (($countFiles < 1) ? 20 : 0)) . 'px">';
 
 			// Add a toggle button if there are childs
 			if ($countFiles > 0)
@@ -2801,7 +2801,7 @@ class DC_Folder extends DataContainer implements ListableDataContainerInterface,
 			}
 
 			$currentEncoded = $this->urlEncode($currentFile);
-			$return .= "\n  " . '<li data-id="' . htmlspecialchars($currentFile, ENT_QUOTES|ENT_HTML5) . '" class="tl_file click2edit toggle_select hover-div"><div class="tl_left" style="padding-left:' . ($intMargin + $intSpacing) . 'px">';
+			$return .= "\n  " . '<li data-id="' . htmlspecialchars($currentFile, ENT_QUOTES | ENT_HTML5) . '" class="tl_file click2edit toggle_select hover-div"><div class="tl_left" style="padding-left:' . ($intMargin + $intSpacing) . 'px">';
 			$thumbnail .= ' <span class="tl_gray">(' . $this->getReadableSize($objFile->filesize);
 
 			if ($objFile->width && $objFile->height)

--- a/core-bundle/src/Resources/contao/drivers/DC_Folder.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Folder.php
@@ -597,7 +597,7 @@ class DC_Folder extends DataContainer implements ListableDataContainerInterface,
 			$return .= '<script>'
 				. 'Dropzone.autoDiscover = false;'
 				. 'Backend.enableFileTreeUpload("tl_listing", ' . json_encode(array(
-					'url' => html_entity_decode($this->addToUrl('act=move&mode=2&pid=' . urlencode($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['root'][0] ?? $this->strUploadPath))),
+					'url' => html_entity_decode($this->addToUrl('act=move&mode=2&pid=' . urlencode($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['root'][0] ?? $this->strUploadPath)), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5),
 					'paramName' => 'files',
 					'maxFilesize' => $intMaxSize,
 					'acceptedFiles' => $strAccepted,
@@ -611,7 +611,7 @@ class DC_Folder extends DataContainer implements ListableDataContainerInterface,
 
 		$return .= '<script>'
 			. 'Backend.enableFileTreeDragAndDrop($("tl_listing").getChildren(".tl_file_manager")[0], ' . json_encode(array(
-				'url' => html_entity_decode($this->addToUrl('act=cut&mode=2&pid=' . urlencode($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['root'][0] ?? $this->strUploadPath))),
+				'url' => html_entity_decode($this->addToUrl('act=cut&mode=2&pid=' . urlencode($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['root'][0] ?? $this->strUploadPath)), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5),
 			)) . ')</script>'
 		;
 
@@ -657,7 +657,7 @@ class DC_Folder extends DataContainer implements ListableDataContainerInterface,
 		$objSession->set('CLIPBOARD', $arrClipboard);
 
 		$this->Files->mkdir($strFolder . '/__new__');
-		$this->redirect(html_entity_decode($this->switchToEdit($strFolder . '/__new__')));
+		$this->redirect(html_entity_decode($this->switchToEdit($strFolder . '/__new__'), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5));
 	}
 
 	/**
@@ -2153,7 +2153,7 @@ class DC_Folder extends DataContainer implements ListableDataContainerInterface,
 <div class="tl_tbox">
   <div class="widget">
     <h3><label for="ctrl_source">' . $GLOBALS['TL_LANG']['tl_files']['editor'][0] . '</label></h3>
-    <textarea name="source" id="ctrl_source" class="tl_textarea monospace" rows="12" cols="80" style="height:400px" onfocus="Backend.getScrollOffset()">' . "\n" . htmlspecialchars($strContent) . '</textarea>' . ((Config::get('showHelp') && isset($GLOBALS['TL_LANG']['tl_files']['editor'][1])) ? '
+    <textarea name="source" id="ctrl_source" class="tl_textarea monospace" rows="12" cols="80" style="height:400px" onfocus="Backend.getScrollOffset()">' . "\n" . htmlspecialchars($strContent, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5) . '</textarea>' . ((Config::get('showHelp') && isset($GLOBALS['TL_LANG']['tl_files']['editor'][1])) ? '
     <p class="tl_help tl_tip">' . $GLOBALS['TL_LANG']['tl_files']['editor'][1] . '</p>' : '') . '
   </div>
 </div>

--- a/core-bundle/src/Resources/contao/drivers/DC_Folder.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Folder.php
@@ -2698,7 +2698,7 @@ class DC_Folder extends DataContainer implements ListableDataContainerInterface,
 				$blnIsOpen = true;
 			}
 
-			$return .= "\n  " . '<li data-id="' . htmlspecialchars($currentFolder, ENT_QUOTES) . '" class="tl_folder click2edit toggle_select hover-div"><div class="tl_left" style="padding-left:' . ($intMargin + (($countFiles < 1) ? 20 : 0)) . 'px">';
+			$return .= "\n  " . '<li data-id="' . htmlspecialchars($currentFolder, ENT_QUOTES|ENT_HTML5) . '" class="tl_folder click2edit toggle_select hover-div"><div class="tl_left" style="padding-left:' . ($intMargin + (($countFiles < 1) ? 20 : 0)) . 'px">';
 
 			// Add a toggle button if there are childs
 			if ($countFiles > 0)
@@ -2801,7 +2801,7 @@ class DC_Folder extends DataContainer implements ListableDataContainerInterface,
 			}
 
 			$currentEncoded = $this->urlEncode($currentFile);
-			$return .= "\n  " . '<li data-id="' . htmlspecialchars($currentFile, ENT_QUOTES) . '" class="tl_file click2edit toggle_select hover-div"><div class="tl_left" style="padding-left:' . ($intMargin + $intSpacing) . 'px">';
+			$return .= "\n  " . '<li data-id="' . htmlspecialchars($currentFile, ENT_QUOTES|ENT_HTML5) . '" class="tl_file click2edit toggle_select hover-div"><div class="tl_left" style="padding-left:' . ($intMargin + $intSpacing) . 'px">';
 			$thumbnail .= ' <span class="tl_gray">(' . $this->getReadableSize($objFile->filesize);
 
 			if ($objFile->width && $objFile->height)

--- a/core-bundle/src/Resources/contao/elements/ContentCode.php
+++ b/core-bundle/src/Resources/contao/elements/ContentCode.php
@@ -34,7 +34,7 @@ class ContentCode extends ContentElement
 
 		if ($request && System::getContainer()->get('contao.routing.scope_matcher')->isBackendRequest($request))
 		{
-			$return = '<pre>' . htmlspecialchars($this->code) . '</pre>';
+			$return = '<pre>' . htmlspecialchars($this->code, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5) . '</pre>';
 
 			if ($this->headline)
 			{
@@ -69,7 +69,7 @@ class ContentCode extends ContentElement
 		}
 		catch (\DomainException $e)
 		{
-			$this->Template->code = htmlspecialchars($this->code);
+			$this->Template->code = htmlspecialchars($this->code, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5);
 		}
 
 		$this->Template->cssClass = 'hljs ' . (strtolower($this->highlight) ?: 'nohighlight');

--- a/core-bundle/src/Resources/contao/elements/ContentHtml.php
+++ b/core-bundle/src/Resources/contao/elements/ContentHtml.php
@@ -30,7 +30,7 @@ class ContentHtml extends ContentElement
 
 		if ($request && System::getContainer()->get('contao.routing.scope_matcher')->isBackendRequest($request))
 		{
-			$this->Template->html = '<pre>' . htmlspecialchars($this->html) . '</pre>';
+			$this->Template->html = '<pre>' . htmlspecialchars($this->html, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5) . '</pre>';
 		}
 		else
 		{

--- a/core-bundle/src/Resources/contao/forms/Form.php
+++ b/core-bundle/src/Resources/contao/forms/Form.php
@@ -438,7 +438,7 @@ class Form extends Hybrid
 			if ($this->format == 'xml')
 			{
 				// Encode the values (see #6053)
-				array_walk_recursive($fields, static function (&$value) { $value = htmlspecialchars($value, ENT_QUOTES|ENT_SUBSTITUTE|ENT_XML1); });
+				array_walk_recursive($fields, static function (&$value) { $value = htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE | ENT_XML1); });
 
 				$objTemplate = new FrontendTemplate('form_xml');
 				$objTemplate->fields = $fields;

--- a/core-bundle/src/Resources/contao/forms/Form.php
+++ b/core-bundle/src/Resources/contao/forms/Form.php
@@ -424,7 +424,7 @@ class Form extends Hybrid
 			// Fallback to default subject
 			if (!$email->subject)
 			{
-				$email->subject = html_entity_decode(System::getContainer()->get('contao.insert_tag.parser')->replaceInline($this->subject), ENT_QUOTES | ENT_HTML5, 'UTF-8');
+				$email->subject = html_entity_decode(System::getContainer()->get('contao.insert_tag.parser')->replaceInline($this->subject), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8');
 			}
 
 			// Send copy to sender

--- a/core-bundle/src/Resources/contao/forms/Form.php
+++ b/core-bundle/src/Resources/contao/forms/Form.php
@@ -424,7 +424,7 @@ class Form extends Hybrid
 			// Fallback to default subject
 			if (!$email->subject)
 			{
-				$email->subject = html_entity_decode(System::getContainer()->get('contao.insert_tag.parser')->replaceInline($this->subject), ENT_QUOTES, 'UTF-8');
+				$email->subject = html_entity_decode(System::getContainer()->get('contao.insert_tag.parser')->replaceInline($this->subject), ENT_QUOTES|ENT_HTML5, 'UTF-8');
 			}
 
 			// Send copy to sender

--- a/core-bundle/src/Resources/contao/forms/Form.php
+++ b/core-bundle/src/Resources/contao/forms/Form.php
@@ -424,7 +424,7 @@ class Form extends Hybrid
 			// Fallback to default subject
 			if (!$email->subject)
 			{
-				$email->subject = html_entity_decode(System::getContainer()->get('contao.insert_tag.parser')->replaceInline($this->subject), ENT_QUOTES|ENT_HTML5, 'UTF-8');
+				$email->subject = html_entity_decode(System::getContainer()->get('contao.insert_tag.parser')->replaceInline($this->subject), ENT_QUOTES | ENT_HTML5, 'UTF-8');
 			}
 
 			// Send copy to sender

--- a/core-bundle/src/Resources/contao/forms/FormHtml.php
+++ b/core-bundle/src/Resources/contao/forms/FormHtml.php
@@ -44,7 +44,7 @@ class FormHtml extends Widget
 
 		if ($request && System::getContainer()->get('contao.routing.scope_matcher')->isBackendRequest($request))
 		{
-			$this->html = htmlspecialchars($this->html);
+			$this->html = htmlspecialchars($this->html, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5);
 		}
 
 		return parent::parse($arrAttributes);
@@ -61,7 +61,7 @@ class FormHtml extends Widget
 
 		if ($request && System::getContainer()->get('contao.routing.scope_matcher')->isBackendRequest($request))
 		{
-			return htmlspecialchars($this->html);
+			return htmlspecialchars($this->html, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5);
 		}
 
 		return $this->html;

--- a/core-bundle/src/Resources/contao/helper/functions.php
+++ b/core-bundle/src/Resources/contao/helper/functions.php
@@ -85,7 +85,7 @@ function specialchars($strString, $blnStripInsertTags=false)
 		$strString = strip_insert_tags($strString);
 	}
 
-	return htmlspecialchars($strString, ENT_QUOTES | ENT_HTML5, System::getContainer()->getParameter('kernel.charset'), false);
+	return htmlspecialchars($strString, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, System::getContainer()->getParameter('kernel.charset'), false);
 }
 
 /**
@@ -106,7 +106,7 @@ function standardize($strString, $blnPreserveUppercase=false)
 	$arrSearch = array('/[^\pN\pL \.\&\/_-]+/u', '/[ \.\&\/-]+/');
 	$arrReplace = array('', '-');
 
-	$strString = html_entity_decode($strString, ENT_QUOTES | ENT_HTML5, System::getContainer()->getParameter('kernel.charset'));
+	$strString = html_entity_decode($strString, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, System::getContainer()->getParameter('kernel.charset'));
 	$strString = strip_insert_tags($strString);
 	$strString = preg_replace($arrSearch, $arrReplace, $strString);
 

--- a/core-bundle/src/Resources/contao/helper/functions.php
+++ b/core-bundle/src/Resources/contao/helper/functions.php
@@ -85,7 +85,7 @@ function specialchars($strString, $blnStripInsertTags=false)
 		$strString = strip_insert_tags($strString);
 	}
 
-	return htmlspecialchars($strString, ENT_QUOTES|ENT_HTML5, System::getContainer()->getParameter('kernel.charset'), false);
+	return htmlspecialchars($strString, ENT_QUOTES | ENT_HTML5, System::getContainer()->getParameter('kernel.charset'), false);
 }
 
 /**
@@ -106,7 +106,7 @@ function standardize($strString, $blnPreserveUppercase=false)
 	$arrSearch = array('/[^\pN\pL \.\&\/_-]+/u', '/[ \.\&\/-]+/');
 	$arrReplace = array('', '-');
 
-	$strString = html_entity_decode($strString, ENT_QUOTES|ENT_HTML5, System::getContainer()->getParameter('kernel.charset'));
+	$strString = html_entity_decode($strString, ENT_QUOTES | ENT_HTML5, System::getContainer()->getParameter('kernel.charset'));
 	$strString = strip_insert_tags($strString);
 	$strString = preg_replace($arrSearch, $arrReplace, $strString);
 

--- a/core-bundle/src/Resources/contao/helper/functions.php
+++ b/core-bundle/src/Resources/contao/helper/functions.php
@@ -85,7 +85,7 @@ function specialchars($strString, $blnStripInsertTags=false)
 		$strString = strip_insert_tags($strString);
 	}
 
-	return htmlspecialchars($strString, ENT_QUOTES | ENT_HTML5, System::getContainer()->getParameter('kernel.charset'), false);
+	return htmlspecialchars($strString, ENT_QUOTES|ENT_HTML5, System::getContainer()->getParameter('kernel.charset'), false);
 }
 
 /**
@@ -106,7 +106,7 @@ function standardize($strString, $blnPreserveUppercase=false)
 	$arrSearch = array('/[^\pN\pL \.\&\/_-]+/u', '/[ \.\&\/-]+/');
 	$arrReplace = array('', '-');
 
-	$strString = html_entity_decode($strString, ENT_QUOTES, System::getContainer()->getParameter('kernel.charset'));
+	$strString = html_entity_decode($strString, ENT_QUOTES|ENT_HTML5, System::getContainer()->getParameter('kernel.charset'));
 	$strString = strip_insert_tags($strString);
 	$strString = preg_replace($arrSearch, $arrReplace, $strString);
 

--- a/core-bundle/src/Resources/contao/library/Contao/Feed.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Feed.php
@@ -195,7 +195,7 @@ class Feed
 		{
 			$xml .= '<entry>';
 			$xml .= '<title>' . StringUtil::specialchars(strip_tags(StringUtil::stripInsertTags($objItem->title))) . '</title>';
-			$xml .= '<content type="html">' . preg_replace('/[\n\r]+/', ' ', htmlspecialchars($objItem->description, ENT_XML1, 'UTF-8')) . '</content>';
+			$xml .= '<content type="html">' . preg_replace('/[\n\r]+/', ' ', htmlspecialchars($objItem->description, ENT_QUOTES | ENT_SUBSTITUTE | ENT_XML1, 'UTF-8')) . '</content>';
 			$xml .= '<link rel="alternate" href="' . StringUtil::specialchars($objItem->link) . '" />';
 			$xml .= '<updated>' . date('Y-m-d\TH:i:sP', $objItem->published) . '</updated>';
 			$xml .= '<id>' . ($objItem->guid ?: StringUtil::specialchars($objItem->link)) . '</id>';

--- a/core-bundle/src/Resources/contao/library/Contao/Input.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Input.php
@@ -865,7 +865,7 @@ class Input
 
 		// Preserve basic entities
 		$varValue = static::preserveBasicEntities($varValue);
-		$varValue = html_entity_decode($varValue, ENT_QUOTES | ENT_HTML5, System::getContainer()->getParameter('kernel.charset'));
+		$varValue = html_entity_decode($varValue, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, System::getContainer()->getParameter('kernel.charset'));
 
 		return $varValue;
 	}

--- a/core-bundle/src/Resources/contao/library/Contao/Input.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Input.php
@@ -865,7 +865,7 @@ class Input
 
 		// Preserve basic entities
 		$varValue = static::preserveBasicEntities($varValue);
-		$varValue = html_entity_decode($varValue, ENT_QUOTES|ENT_HTML5, System::getContainer()->getParameter('kernel.charset'));
+		$varValue = html_entity_decode($varValue, ENT_QUOTES | ENT_HTML5, System::getContainer()->getParameter('kernel.charset'));
 
 		return $varValue;
 	}

--- a/core-bundle/src/Resources/contao/library/Contao/Input.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Input.php
@@ -865,7 +865,7 @@ class Input
 
 		// Preserve basic entities
 		$varValue = static::preserveBasicEntities($varValue);
-		$varValue = html_entity_decode($varValue, ENT_QUOTES, System::getContainer()->getParameter('kernel.charset'));
+		$varValue = html_entity_decode($varValue, ENT_QUOTES|ENT_HTML5, System::getContainer()->getParameter('kernel.charset'));
 
 		return $varValue;
 	}

--- a/core-bundle/src/Resources/contao/library/Contao/InsertTags.php
+++ b/core-bundle/src/Resources/contao/library/Contao/InsertTags.php
@@ -856,11 +856,11 @@ class InsertTags extends Controller
 						switch ($elements[1])
 						{
 							case 'pageTitle':
-								$arrCache[$strTag] = htmlspecialchars($htmlHeadBag->getTitle());
+								$arrCache[$strTag] = htmlspecialchars($htmlHeadBag->getTitle(), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5);
 								break;
 
 							case 'description':
-								$arrCache[$strTag] = htmlspecialchars($htmlHeadBag->getMetaDescription());
+								$arrCache[$strTag] = htmlspecialchars($htmlHeadBag->getMetaDescription(), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5);
 								break;
 						}
 					}

--- a/core-bundle/src/Resources/contao/library/Contao/StringUtil.php
+++ b/core-bundle/src/Resources/contao/library/Contao/StringUtil.php
@@ -219,7 +219,7 @@ class StringUtil
 	 *
 	 * @return string The decoded string
 	 */
-	public static function decodeEntities($strString, $strQuoteStyle=ENT_QUOTES|ENT_HTML5, $strCharset=null)
+	public static function decodeEntities($strString, $strQuoteStyle=ENT_QUOTES | ENT_HTML5, $strCharset=null)
 	{
 		if ((string) $strString === '')
 		{
@@ -870,7 +870,7 @@ class StringUtil
 			$strString = static::stripInsertTags($strString);
 		}
 
-		return htmlspecialchars((string) $strString, ENT_QUOTES|ENT_HTML5, $GLOBALS['TL_CONFIG']['characterSet'] ?? 'UTF-8', $blnDoubleEncode);
+		return htmlspecialchars((string) $strString, ENT_QUOTES | ENT_HTML5, $GLOBALS['TL_CONFIG']['characterSet'] ?? 'UTF-8', $blnDoubleEncode);
 	}
 
 	/**
@@ -985,7 +985,7 @@ class StringUtil
 		$arrSearch = array('/[^\pN\pL \.\&\/_-]+/u', '/[ \.\&\/-]+/');
 		$arrReplace = array('', '-');
 
-		$strString = html_entity_decode($strString, ENT_QUOTES|ENT_HTML5, $GLOBALS['TL_CONFIG']['characterSet'] ?? 'UTF-8');
+		$strString = html_entity_decode($strString, ENT_QUOTES | ENT_HTML5, $GLOBALS['TL_CONFIG']['characterSet'] ?? 'UTF-8');
 		$strString = static::stripInsertTags($strString);
 		$strString = preg_replace($arrSearch, $arrReplace, $strString);
 

--- a/core-bundle/src/Resources/contao/library/Contao/StringUtil.php
+++ b/core-bundle/src/Resources/contao/library/Contao/StringUtil.php
@@ -219,7 +219,7 @@ class StringUtil
 	 *
 	 * @return string The decoded string
 	 */
-	public static function decodeEntities($strString, $strQuoteStyle=ENT_QUOTES, $strCharset=null)
+	public static function decodeEntities($strString, $strQuoteStyle=ENT_QUOTES|ENT_HTML5, $strCharset=null)
 	{
 		if ((string) $strString === '')
 		{
@@ -870,7 +870,7 @@ class StringUtil
 			$strString = static::stripInsertTags($strString);
 		}
 
-		return htmlspecialchars((string) $strString, ENT_QUOTES | ENT_HTML5, $GLOBALS['TL_CONFIG']['characterSet'] ?? 'UTF-8', $blnDoubleEncode);
+		return htmlspecialchars((string) $strString, ENT_QUOTES|ENT_HTML5, $GLOBALS['TL_CONFIG']['characterSet'] ?? 'UTF-8', $blnDoubleEncode);
 	}
 
 	/**
@@ -985,7 +985,7 @@ class StringUtil
 		$arrSearch = array('/[^\pN\pL \.\&\/_-]+/u', '/[ \.\&\/-]+/');
 		$arrReplace = array('', '-');
 
-		$strString = html_entity_decode($strString, ENT_QUOTES, $GLOBALS['TL_CONFIG']['characterSet'] ?? 'UTF-8');
+		$strString = html_entity_decode($strString, ENT_QUOTES|ENT_HTML5, $GLOBALS['TL_CONFIG']['characterSet'] ?? 'UTF-8');
 		$strString = static::stripInsertTags($strString);
 		$strString = preg_replace($arrSearch, $arrReplace, $strString);
 

--- a/core-bundle/src/Resources/contao/library/Contao/StringUtil.php
+++ b/core-bundle/src/Resources/contao/library/Contao/StringUtil.php
@@ -219,7 +219,7 @@ class StringUtil
 	 *
 	 * @return string The decoded string
 	 */
-	public static function decodeEntities($strString, $strQuoteStyle=ENT_QUOTES | ENT_HTML5, $strCharset=null)
+	public static function decodeEntities($strString, $strQuoteStyle=ENT_QUOTES, $strCharset=null)
 	{
 		if ((string) $strString === '')
 		{
@@ -238,7 +238,7 @@ class StringUtil
 		$strString = preg_replace('/(&#*\w+)[\x00-\x20]+;/i', '$1;', $strString);
 		$strString = preg_replace('/(&#x*)([0-9a-f]+);/i', '$1$2;', $strString);
 
-		return html_entity_decode($strString, $strQuoteStyle, $strCharset);
+		return html_entity_decode($strString, $strQuoteStyle | ENT_SUBSTITUTE | ENT_HTML5, $strCharset);
 	}
 
 	/**
@@ -870,7 +870,7 @@ class StringUtil
 			$strString = static::stripInsertTags($strString);
 		}
 
-		return htmlspecialchars((string) $strString, ENT_QUOTES | ENT_HTML5, $GLOBALS['TL_CONFIG']['characterSet'] ?? 'UTF-8', $blnDoubleEncode);
+		return htmlspecialchars((string) $strString, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, $GLOBALS['TL_CONFIG']['characterSet'] ?? 'UTF-8', $blnDoubleEncode);
 	}
 
 	/**
@@ -985,7 +985,7 @@ class StringUtil
 		$arrSearch = array('/[^\pN\pL \.\&\/_-]+/u', '/[ \.\&\/-]+/');
 		$arrReplace = array('', '-');
 
-		$strString = html_entity_decode($strString, ENT_QUOTES | ENT_HTML5, $GLOBALS['TL_CONFIG']['characterSet'] ?? 'UTF-8');
+		$strString = html_entity_decode($strString, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, $GLOBALS['TL_CONFIG']['characterSet'] ?? 'UTF-8');
 		$strString = static::stripInsertTags($strString);
 		$strString = preg_replace($arrSearch, $arrReplace, $strString);
 

--- a/core-bundle/src/Resources/contao/library/Contao/Widget.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Widget.php
@@ -906,7 +906,7 @@ abstract class Widget extends Controller
 					break;
 
 				case 'extnd':
-					if (!Validator::isExtendedAlphanumeric(html_entity_decode($varInput)))
+					if (!Validator::isExtendedAlphanumeric(html_entity_decode($varInput, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5)))
 					{
 						$this->addError(sprintf($GLOBALS['TL_LANG']['ERR']['extnd'], $this->strLabel));
 					}
@@ -1018,7 +1018,7 @@ abstract class Widget extends Controller
 					break;
 
 				case 'phone':
-					if (!Validator::isPhone(html_entity_decode($varInput)))
+					if (!Validator::isPhone(html_entity_decode($varInput, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5)))
 					{
 						$this->addError(sprintf($GLOBALS['TL_LANG']['ERR']['phone'], $this->strLabel));
 					}

--- a/core-bundle/src/Resources/contao/modules/ModuleArticle.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleArticle.php
@@ -280,7 +280,7 @@ class ModuleArticle extends Module
 
 		// Generate article
 		$strArticle = $container->get('contao.insert_tag.parser')->replaceInline($this->generate());
-		$strArticle = html_entity_decode($strArticle, ENT_QUOTES | ENT_HTML5, $container->getParameter('kernel.charset'));
+		$strArticle = html_entity_decode($strArticle, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, $container->getParameter('kernel.charset'));
 		$strArticle = $this->convertRelativeUrls($strArticle, '', true);
 
 		if (empty($GLOBALS['TL_HOOKS']['printArticleAsPdf']))

--- a/core-bundle/src/Resources/contao/modules/ModuleArticle.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleArticle.php
@@ -280,7 +280,7 @@ class ModuleArticle extends Module
 
 		// Generate article
 		$strArticle = $container->get('contao.insert_tag.parser')->replaceInline($this->generate());
-		$strArticle = html_entity_decode($strArticle, ENT_QUOTES|ENT_HTML5, $container->getParameter('kernel.charset'));
+		$strArticle = html_entity_decode($strArticle, ENT_QUOTES | ENT_HTML5, $container->getParameter('kernel.charset'));
 		$strArticle = $this->convertRelativeUrls($strArticle, '', true);
 
 		if (empty($GLOBALS['TL_HOOKS']['printArticleAsPdf']))

--- a/core-bundle/src/Resources/contao/modules/ModuleArticle.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleArticle.php
@@ -280,7 +280,7 @@ class ModuleArticle extends Module
 
 		// Generate article
 		$strArticle = $container->get('contao.insert_tag.parser')->replaceInline($this->generate());
-		$strArticle = html_entity_decode($strArticle, ENT_QUOTES, $container->getParameter('kernel.charset'));
+		$strArticle = html_entity_decode($strArticle, ENT_QUOTES|ENT_HTML5, $container->getParameter('kernel.charset'));
 		$strArticle = $this->convertRelativeUrls($strArticle, '', true);
 
 		if (empty($GLOBALS['TL_HOOKS']['printArticleAsPdf']))

--- a/core-bundle/src/Resources/contao/modules/ModuleHtml.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleHtml.php
@@ -30,7 +30,7 @@ class ModuleHtml extends Module
 
 		if ($request && System::getContainer()->get('contao.routing.scope_matcher')->isBackendRequest($request))
 		{
-			$this->Template->html = '<pre>' . htmlspecialchars($this->html) . '</pre>';
+			$this->Template->html = '<pre>' . htmlspecialchars($this->html, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5) . '</pre>';
 		}
 		else
 		{

--- a/core-bundle/src/Resources/contao/pages/PageRegular.php
+++ b/core-bundle/src/Resources/contao/pages/PageRegular.php
@@ -227,19 +227,19 @@ class PageRegular extends Frontend
 
 		// Set the page title and description AFTER the modules have been generated
 		$this->Template->mainTitle = $objPage->rootPageTitle;
-		$this->Template->pageTitle = htmlspecialchars($headBag->getTitle());
+		$this->Template->pageTitle = htmlspecialchars($headBag->getTitle(), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5);
 
 		// Remove shy-entities (see #2709)
 		$this->Template->mainTitle = str_replace('[-]', '', $this->Template->mainTitle);
 		$this->Template->pageTitle = str_replace('[-]', '', $this->Template->pageTitle);
 
 		// Meta robots tag
-		$this->Template->robots = htmlspecialchars($headBag->getMetaRobots());
+		$this->Template->robots = htmlspecialchars($headBag->getMetaRobots(), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5);
 
 		// Canonical
 		if ($objPage->enableCanonical)
 		{
-			$this->Template->canonical = htmlspecialchars($headBag->getCanonicalUriForRequest($request));
+			$this->Template->canonical = htmlspecialchars($headBag->getCanonicalUriForRequest($request), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5);
 		}
 
 		// Fall back to the default title tag
@@ -250,7 +250,7 @@ class PageRegular extends Frontend
 
 		// Assign the title and description
 		$this->Template->title = strip_tags(System::getContainer()->get('contao.insert_tag.parser')->replaceInline($objLayout->titleTag));
-		$this->Template->description = htmlspecialchars($headBag->getMetaDescription());
+		$this->Template->description = htmlspecialchars($headBag->getMetaDescription(), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5);
 
 		// Body onload and body classes
 		$this->Template->onload = trim($objLayout->onload);

--- a/core-bundle/src/String/SimpleTokenParser.php
+++ b/core-bundle/src/String/SimpleTokenParser.php
@@ -67,7 +67,7 @@ class SimpleTokenParser implements LoggerAwareInterface
 
         foreach ($tags as $tag) {
             $decodedTag = $allowHtml
-                ? html_entity_decode(StringUtil::restoreBasicEntities($tag), ENT_QUOTES | ENT_HTML5, 'UTF-8')
+                ? html_entity_decode(StringUtil::restoreBasicEntities($tag), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8')
                 : $tag;
 
             // True if it is inside a matching if-tag

--- a/core-bundle/src/String/SimpleTokenParser.php
+++ b/core-bundle/src/String/SimpleTokenParser.php
@@ -67,7 +67,7 @@ class SimpleTokenParser implements LoggerAwareInterface
 
         foreach ($tags as $tag) {
             $decodedTag = $allowHtml
-                ? html_entity_decode(StringUtil::restoreBasicEntities($tag), ENT_QUOTES, 'UTF-8')
+                ? html_entity_decode(StringUtil::restoreBasicEntities($tag), ENT_QUOTES | ENT_HTML5, 'UTF-8')
                 : $tag;
 
             // True if it is inside a matching if-tag

--- a/core-bundle/tests/Contao/InsertTagsTest.php
+++ b/core-bundle/tests/Contao/InsertTagsTest.php
@@ -703,8 +703,8 @@ class InsertTagsTest extends TestCase
         $this->assertSame($expected, $insertTagParser->replace($source));
         $this->assertSame($expected.$expected, $insertTagParser->replace($source.$source));
 
-        $source = '<a href="'.htmlspecialchars($source).'" title="'.htmlspecialchars($source).'">';
-        $expected = '<a href="'.htmlspecialchars($expected).'" title="'.htmlspecialchars($expected).'">';
+        $source = '<a href="'.htmlspecialchars($source).'" title="'.htmlspecialchars($source, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5).'">';
+        $expected = '<a href="'.htmlspecialchars($expected).'" title="'.htmlspecialchars($expected, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5).'">';
 
         $this->assertSame($expected, $insertTagParser->replaceInline($source));
         $this->assertSame($expected.$expected, $insertTagParser->replaceInline($source.$source));


### PR DESCRIPTION
Fixes #7245

@ausi What about the function calls that use the default arguments?

https://github.com/contao/contao/blob/0a6e74ab81a0debe7594b1f4d787960ebbc329db/core-bundle/src/Controller/CaptchaController.php#L50

https://github.com/contao/contao/blob/0a6e74ab81a0debe7594b1f4d787960ebbc329db/core-bundle/src/Resources/contao/drivers/DC_Folder.php#L660

The default is `ENT_QUOTES | ENT_SUBSTITUTE` IIRC.