### PR TITLE
Support MODIFY queries in the database installer

### DIFF
--- a/installation-bundle/src/Database/Installer.php
+++ b/installation-bundle/src/Database/Installer.php
@@ -163,6 +163,7 @@ class Installer
 
                             case 0 === strncmp($part, 'CHANGE ', 7):
                             case 0 === strncmp($part, 'RENAME ', 7):
+                            case 0 === strncmp($part, 'MODIFY ', 7):
                                 $return['ALTER_CHANGE'][md5($command)] = $command;
                                 $order[] = md5($command);
                                 break;


### PR DESCRIPTION
Encountered this while upgrading a setup from 4.9 to 4.13. For some reason it extracted `ALTER TABLE tl_search_index MODIFY id INT UNSIGNED NOT NULL` as an SQL query causing the migration to fail with `  Warning: Undefined array key 1  `.

With this fix, all migrations ran smoothly :) 