### PR TITLE
Handle legacy keywords when rendering an article in the back end

### DIFF
--- a/core-bundle/src/Resources/contao/modules/ModuleArticle.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleArticle.php
@@ -202,7 +202,7 @@ class ModuleArticle extends Module
 		$this->Template->elements = $arrElements;
 
 		// Backwards compatibility
-		if ($this->keywords)
+		if ($this->keywords && isset($GLOBALS['TL_KEYWORDS']))
 		{
 			$GLOBALS['TL_KEYWORDS'] .= ($GLOBALS['TL_KEYWORDS'] ? ', ' : '') . $this->keywords;
 		}


### PR DESCRIPTION
If a `tl_article` record still contains `keywords` from previous Contao versions and you reference this article in an `article` content element, the following warning will appear in the back end:

```
ErrorException: Warning: Undefined global variable $TL_KEYWORDS
#24 /vendor/contao/core-bundle/src/Resources/contao/modules/ModuleArticle.php(207): Contao\ModuleArticle::compile
#23 /vendor/contao/core-bundle/src/Resources/contao/modules/Module.php(214): Contao\Module::generate
#22 /vendor/contao/core-bundle/src/Resources/contao/modules/ModuleArticle.php(70): Contao\ModuleArticle::generate
#21 /vendor/contao/core-bundle/src/Resources/contao/library/Contao/Controller.php(550): Contao\Controller::getArticle
#20 /vendor/contao/core-bundle/src/Resources/contao/elements/ContentArticle.php(30): Contao\ContentArticle::generate
#19 /vendor/contao/core-bundle/src/Resources/contao/library/Contao/Controller.php(622): Contao\Controller::getContentElement
#18 /var/cache/prod/contao/dca/tl_content.php(318): tl_content::addCteType
#17 /vendor/contao/core-bundle/src/Resources/contao/drivers/DC_Table.php(4717): Contao\DC_Table::parentView
#16 /vendor/contao/core-bundle/src/Resources/contao/drivers/DC_Table.php(313): Contao\DC_Table::showAll
#15 /vendor/contao/core-bundle/src/Resources/contao/classes/Backend.php(667): Contao\Backend::getBackendModule
#14 /vendor/contao/core-bundle/src/Resources/contao/controllers/BackendMain.php(168): Contao\BackendMain::run
#13 /vendor/contao/core-bundle/src/Controller/BackendController.php(49): Contao\CoreBundle\Controller\BackendController::mainAction
#12 /vendor/symfony/http-kernel/HttpKernel.php(163): Symfony\Component\HttpKernel\HttpKernel::handleRaw
#11 /vendor/symfony/http-kernel/HttpKernel.php(75): Symfony\Component\HttpKernel\HttpKernel::handle
#10 /vendor/symfony/http-kernel/Kernel.php(202): Symfony\Component\HttpKernel\Kernel::handle
#9 /vendor/symfony/http-kernel/HttpCache/SubRequestHandler.php(86): Symfony\Component\HttpKernel\HttpCache\SubRequestHandler::handle
#8 /vendor/symfony/http-kernel/HttpCache/HttpCache.php(481): Symfony\Component\HttpKernel\HttpCache\HttpCache::forward
#7 /vendor/symfony/framework-bundle/HttpCache/HttpCache.php(73): Symfony\Bundle\FrameworkBundle\HttpCache\HttpCache::forward
#6 /vendor/symfony/http-kernel/HttpCache/HttpCache.php(454): Symfony\Component\HttpKernel\HttpCache\HttpCache::fetch
#5 /vendor/contao/manager-bundle/src/HttpKernel/ContaoCache.php(66): Contao\ManagerBundle\HttpKernel\ContaoCache::fetch
#4 /vendor/symfony/http-kernel/HttpCache/HttpCache.php(348): Symfony\Component\HttpKernel\HttpCache\HttpCache::lookup
#3 /vendor/symfony/http-kernel/HttpCache/HttpCache.php(226): Symfony\Component\HttpKernel\HttpCache\HttpCache::handle
#2 /vendor/friendsofsymfony/http-cache/src/SymfonyCache/EventDispatchingHttpCache.php(96): Contao\ManagerBundle\HttpKernel\ContaoCache::handle
#1 /web/index.php(44): require
#0 /web/app.php(13): null
```

This is because `$GLOBALS['TL_KEYWORDS']` is only initialised in the front end within `PageRegular::prepare()`. This PR simply ignores it if not set.