### PR TITLE
Do not update the `tstamp` column on cut/paste

### DIFF
--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -715,8 +715,6 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 			throw new InternalServerErrorException('Attempt to relate record ' . $this->intId . ' of table "' . $this->strTable . '" to its child record ' . Input::get('pid') . ' (circular reference).');
 		}
 
-		$this->set['tstamp'] = time();
-
 		// HOOK: style sheet category
 		if ($this->strTable == 'tl_style')
 		{
@@ -729,6 +727,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 			if ($category)
 			{
 				$this->set['category'] = $category;
+				$this->set['tstamp'] = time();
 			}
 		}
 


### PR DESCRIPTION
As discussed in https://github.com/contao/contao/issues/7085#issuecomment-2140122553

This also means, that the `tstamp` will not get updated if the `pid` or `ptable` changes, which is the correct behavior IMO.