### PR TITLE
Remove the process timeout in the `SuperviseWorkersCommand`

### DIFF
--- a/core-bundle/src/Command/SuperviseWorkersCommand.php
+++ b/core-bundle/src/Command/SuperviseWorkersCommand.php
@@ -20,6 +20,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Messenger\Transport\Receiver\MessageCountAwareInterface;
+use Symfony\Component\Process\Process;
 use Toflar\CronjobSupervisor\BasicCommand;
 use Toflar\CronjobSupervisor\CommandInterface;
 use Toflar\CronjobSupervisor\Supervisor;
@@ -79,11 +80,15 @@ class SuperviseWorkersCommand extends Command
         return new BasicCommand(
             $identifier,
             $desiredWorkers,
-            fn () => $this->processUtil->createSymfonyConsoleProcess(
-                'messenger:consume',
-                ...$worker['options'],
-                ...$worker['transports'],
-            ),
+            function () use($worker): Process {
+                $process = $this->processUtil->createSymfonyConsoleProcess(
+                    'messenger:consume',
+                    ...$worker['options'],
+                    ...$worker['transports'],
+                );
+                $process->setTimeout(null);
+                return $process;
+            },
         );
     }
 

--- a/core-bundle/src/Command/SuperviseWorkersCommand.php
+++ b/core-bundle/src/Command/SuperviseWorkersCommand.php
@@ -86,6 +86,7 @@ class SuperviseWorkersCommand extends Command
                     ...$worker['options'],
                     ...$worker['transports'],
                 );
+
                 $process->setTimeout(null);
 
                 return $process;

--- a/core-bundle/src/Command/SuperviseWorkersCommand.php
+++ b/core-bundle/src/Command/SuperviseWorkersCommand.php
@@ -80,13 +80,14 @@ class SuperviseWorkersCommand extends Command
         return new BasicCommand(
             $identifier,
             $desiredWorkers,
-            function () use($worker): Process {
+            function () use ($worker): Process {
                 $process = $this->processUtil->createSymfonyConsoleProcess(
                     'messenger:consume',
                     ...$worker['options'],
                     ...$worker['transports'],
                 );
                 $process->setTimeout(null);
+
                 return $process;
             },
         );

--- a/core-bundle/src/Cron/SuperviseWorkersCron.php
+++ b/core-bundle/src/Cron/SuperviseWorkersCron.php
@@ -32,6 +32,7 @@ class SuperviseWorkersCron
 
         $process = $this->processUtil->createSymfonyConsoleProcess('contao:supervise-workers');
         $process->setTimeout(null);
+
         return $this->processUtil->createPromise($process);
     }
 }

--- a/core-bundle/src/Cron/SuperviseWorkersCron.php
+++ b/core-bundle/src/Cron/SuperviseWorkersCron.php
@@ -30,8 +30,8 @@ class SuperviseWorkersCron
             throw new CronExecutionSkippedException();
         }
 
-        return $this->processUtil->createPromise(
-            $this->processUtil->createSymfonyConsoleProcess('contao:supervise-workers'),
-        );
+        $process = $this->processUtil->createSymfonyConsoleProcess('contao:supervise-workers');
+        $process->setTimeout(null);
+        return $this->processUtil->createPromise($process);
     }
 }


### PR DESCRIPTION
Fixes #7260

The process timeout for the supervisor command and it's workers is removed when invoked via the cron framework to allow for long running messages and prevent orphaned temporary php.ini files, due to the killed worker processes, when the supervisor command is timed out.

The 60 seconds time limit for the workers is not touched, so they will shutdown after 60 seconds or after processing the last messages started before the 60 second limit.