### PR TITLE
Handle failed `preg_split()` return values for image sources

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/StringUtil.php
+++ b/core-bundle/src/Resources/contao/library/Contao/StringUtil.php
@@ -719,6 +719,11 @@ class StringUtil
 		$return = '';
 		$paths = preg_split('/((src|href)="([^"]*){{file::([^"}|]+)[^"}]*}}")/i', $data, -1, PREG_SPLIT_DELIM_CAPTURE);
 
+		if (!$paths)
+		{
+			return $data;
+		}
+
 		for ($i=0, $c=\count($paths); $i<$c; $i+=5)
 		{
 			$return .= $paths[$i];

--- a/core-bundle/src/Resources/contao/library/Contao/StringUtil.php
+++ b/core-bundle/src/Resources/contao/library/Contao/StringUtil.php
@@ -716,13 +716,14 @@ class StringUtil
 	 */
 	public static function insertTagToSrc($data)
 	{
-		$return = '';
 		$paths = preg_split('/((src|href)="([^"]*){{file::([^"}|]+)[^"}]*}}")/i', $data, -1, PREG_SPLIT_DELIM_CAPTURE);
 
 		if (!$paths)
 		{
 			return $data;
 		}
+
+		$return = '';
 
 		for ($i=0, $c=\count($paths); $i<$c; $i+=5)
 		{


### PR DESCRIPTION
I had a client drag&drop images into tinyMCE which resultet in binary data in the `src` attribute. That's obviously not a good idea, but even worse was that the backend did break with a message that `\count($paths)` must be an array but was a boolean.