### PR TITLE
Replace non-routable URLs with an empty string for the `{{link*}}` insert tags

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/InsertTags.php
+++ b/core-bundle/src/Resources/contao/library/Contao/InsertTags.php
@@ -571,6 +571,9 @@ class InsertTags extends Controller
 										}
 										catch (ExceptionInterface $exception)
 										{
+											$arrCache[$strTag] = '';
+
+											break 2;
 										}
 										break;
 									}
@@ -583,6 +586,9 @@ class InsertTags extends Controller
 									}
 									catch (ExceptionInterface $exception)
 									{
+										$arrCache[$strTag] = '';
+
+										break 2;
 									}
 									break;
 							}

--- a/core-bundle/src/Resources/contao/library/Contao/InsertTags.php
+++ b/core-bundle/src/Resources/contao/library/Contao/InsertTags.php
@@ -572,7 +572,6 @@ class InsertTags extends Controller
 										catch (ExceptionInterface $exception)
 										{
 											$arrCache[$strTag] = '';
-
 											break 2;
 										}
 										break;
@@ -587,7 +586,6 @@ class InsertTags extends Controller
 									catch (ExceptionInterface $exception)
 									{
 										$arrCache[$strTag] = '';
-
 										break 2;
 									}
 									break;


### PR DESCRIPTION
Fixes #7250

Before:

| Type | `{{link_url::*}}` | `{{link::*}}` | `{{link_title::*}}` | `{{link_name::*}}` |
| --- | --- | --- | --- | --- |
| Page with require item: | `./` | [Detail](./) | Detail | Detail |
| Page with index: | `./` | [Index](./) | Index | Index
| Regular page: | `page` | [Page](page) | Page | Page

After:

| Type | `{{link_url::*}}` | `{{link::*}}` | `{{link_title::*}}` | `{{link_name::*}}` |
| --- | --- | --- | --- | --- |
| Page with require item: | | | Detail | Detail |
| Page with index: | `./` | [Index](./) | Index | Index
| Regular page: | `page` | [Page](page) | Page | Page