### PR TITLE
Initialize the Contao framework when working with opt-in tokens

### DIFF
--- a/core-bundle/src/OptIn/OptIn.php
+++ b/core-bundle/src/OptIn/OptIn.php
@@ -42,6 +42,8 @@ class OptIn implements OptInInterface
             $token = $prefix.'-'.substr($token, \strlen($prefix) + 1);
         }
 
+        $this->framework->initialize();
+
         $optIn = $this->framework->createInstance(OptInModel::class);
         $optIn->tstamp = time();
         $optIn->token = $token;
@@ -60,6 +62,8 @@ class OptIn implements OptInInterface
 
     public function find(string $identifier): OptInTokenInterface|null
     {
+        $this->framework->initialize();
+
         $adapter = $this->framework->getAdapter(OptInModel::class);
 
         if (!$model = $adapter->findByToken($identifier)) {
@@ -71,6 +75,8 @@ class OptIn implements OptInInterface
 
     public function purgeTokens(): void
     {
+        $this->framework->initialize();
+
         $adapter = $this->framework->getAdapter(OptInModel::class);
 
         if (!$tokens = $adapter->findExpiredTokens()) {


### PR DESCRIPTION
Got this erro in my logs:

```
RuntimeException: The Symfony container is not available, did you initialize the Contao framework? in vendor/contao/core-bundle/contao/library/Contao/System.php:143 Stack trace:
#0 vendor/contao/core-bundle/contao/library/Contao/System.php(97): Contao\System->import('Contao\\Config', 'Config')
#1 vendor/contao/core-bundle/contao/library/Contao/DcaExtractor.php(105): Contao\System->__construct()
#2 vendor/contao/core-bundle/contao/library/Contao/DcaExtractor.php(140): Contao\DcaExtractor->__construct('tl_opt_in')
#3 vendor/contao/core-bundle/contao/library/Contao/Model.php(291): Contao\DcaExtractor::getInstance('tl_opt_in')
#4 vendor/contao/core-bundle/contao/library/Contao/Model.php(1084): Contao\Model::getUniqueFields()
#5 vendor/contao/core-bundle/contao/models/OptInModel.php(87): Contao\Model::findBy(Array, 1716888783, Array)
#6 vendor/contao/core-bundle/src/Framework/Adapter.php(38): Contao\OptInModel::findExpiredTokens()
#7 vendor/contao/core-bundle/src/OptIn/OptIn.php(76): Contao\CoreBundle\Framework\Adapter->__call('findExpiredToke...', Array)
#8 vendor/contao/core-bundle/src/Cron/PurgeOptInTokensCron.php(30): Contao\CoreBundle\OptIn\OptIn->purgeTokens()
#9 vendor/contao/core-bundle/src/Cron/CronJob.php(44): Contao\CoreBundle\Cron\PurgeOptInTokensCron->__invoke('cli')
#10 vendor/contao/core-bundle/src/Cron/Cron.php(197): Contao\CoreBundle\Cron\CronJob->__invoke('cli')
#11 vendor/contao/core-bundle/src/Cron/Cron.php(182): Contao\CoreBundle\Cron\Cron->executeCrons(Array, 'cli', Object(Closure))
#12 vendor/contao/core-bundle/src/Cron/Cron.php(97): Contao\CoreBundle\Cron\Cron->doRun(Array, 'cli', false)
#13 vendor/contao/core-bundle/src/Command/CronCommand.php(53): Contao\CoreBundle\Cron\Cron->run('cli', false)
#14 vendor/symfony/console/Command/Command.php(326): Contao\CoreBundle\Command\CronCommand->execute(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#15 vendor/symfony/console/Application.php(1096): Symfony\Component\Console\Command\Command->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#16 vendor/symfony/framework-bundle/Console/Application.php(126): Symfony\Component\Console\Application->doRunCommand(Object(Contao\CoreBundle\Command\CronCommand), Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#17 vendor/symfony/console/Application.php(324): Symfony\Bundle\FrameworkBundle\Console\Application->doRunCommand(Object(Contao\CoreBundle\Command\CronCommand), Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#18 vendor/symfony/framework-bundle/Console/Application.php(80): Symfony\Component\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#19 vendor/symfony/console/Application.php(175): Symfony\Bundle\FrameworkBundle\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#20 vendor/contao/manager-bundle/bin/contao-console(40): Symfony\Component\Console\Application->run(Object(Symfony\Component\Console\Input\ArgvInput))
#21 vendor/bin/contao-console(119):  #22
```