### PR TITLE
Improve the docs of `quoteIdentifier()` and `findInSet()`

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/Database.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Database.php
@@ -220,6 +220,11 @@ class Database
 	/**
 	 * Auto-generate a FIND_IN_SET() statement
 	 *
+	 * Do not pass user input as $strKey to this method as only identifiers get
+	 * quoted and SQL expressions get returned as is!
+	 *
+	 * @internal Do not use this class in your code
+	 *
 	 * @param string  $strKey     The field name
 	 * @param mixed   $varSet     The set to find the key in
 	 * @param boolean $blnIsField If true, the set will not be quoted
@@ -717,6 +722,12 @@ class Database
 
 	/**
 	 * Quote the column name if it is a reserved word
+	 *
+	 * Do not pass user input to this method as only identifiers get quoted and
+	 * SQL expressions get returned as is!
+	 *
+	 * @internal Do not use this class in your code; use the "quoteIdentifier()"
+	 *           method of the "@database_connection" service instead
 	 *
 	 * @param string $strName
 	 *


### PR DESCRIPTION
This should bring more clarity to the usage of the methods `Database::quoteIdentifier()` and `Database::findInSet()`.