### PR TITLE
Use the translator language instead of the request language for the `iflng` and `ifnlng` insert tags

### DIFF
--- a/core-bundle/config/services.yaml
+++ b/core-bundle/config/services.yaml
@@ -470,7 +470,7 @@ services:
     contao.insert_tag.resolver.if_language:
         class: Contao\CoreBundle\InsertTag\Resolver\IfLanguageInsertTag
         arguments:
-            - '@request_stack'
+            - '@translator'
 
     contao.insert_tag.resolver.legacy:
         class: Contao\CoreBundle\InsertTag\Resolver\LegacyInsertTag

--- a/core-bundle/tests/Contao/InsertTagsTest.php
+++ b/core-bundle/tests/Contao/InsertTagsTest.php
@@ -30,7 +30,6 @@ use Contao\System;
 use Psr\Log\LoggerInterface;
 use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Config\FileLocatorInterface;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Fragment\FragmentHandler;
 use Symfony\Contracts\Translation\TranslatorInterface;

--- a/core-bundle/tests/Contao/InsertTagsTest.php
+++ b/core-bundle/tests/Contao/InsertTagsTest.php
@@ -33,6 +33,7 @@ use Symfony\Component\Config\FileLocatorInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Fragment\FragmentHandler;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 class InsertTagsTest extends TestCase
 {
@@ -779,18 +780,12 @@ class InsertTagsTest extends TestCase
      *
      * @group legacy
      */
-    public function testRemovesLanguageInsertTags(string $source, string $expected, string $pageLanguage = 'en'): void
+    public function testRemovesLanguageInsertTags(string $source, string $expected, string $translatorLocale = 'en'): void
     {
-        $request = $this->createMock(Request::class);
-        $request
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator
             ->method('getLocale')
-            ->willReturn($pageLanguage)
-        ;
-
-        $requestStack = $this->createMock(RequestStack::class);
-        $requestStack
-            ->method('getCurrentRequest')
-            ->willReturn($request)
+            ->willReturn($translatorLocale)
         ;
 
         $reflectionClass = new \ReflectionClass(InsertTags::class);
@@ -801,7 +796,7 @@ class InsertTagsTest extends TestCase
         System::getContainer()->set('contao.insert_tag.parser', $insertTagParser);
 
         $insertTagParser->addBlockSubscription(new InsertTagSubscription(
-            new IfLanguageInsertTag($requestStack),
+            new IfLanguageInsertTag($translator),
             '__invoke',
             'iflng',
             'iflng',
@@ -810,7 +805,7 @@ class InsertTagsTest extends TestCase
         ));
 
         $insertTagParser->addBlockSubscription(new InsertTagSubscription(
-            new IfLanguageInsertTag($requestStack),
+            new IfLanguageInsertTag($translator),
             '__invoke',
             'ifnlng',
             'ifnlng',

--- a/core-bundle/tests/DependencyInjection/Compiler/AddInsertTagsPassTest.php
+++ b/core-bundle/tests/DependencyInjection/Compiler/AddInsertTagsPassTest.php
@@ -176,10 +176,10 @@ class AddInsertTagsPassTest extends TestCase
 
         yield [
             [
-                'service_a' => (new Definition(IfLanguageInsertTag::class))->addTag('contao.insert_tag', get_object_vars(new AsInsertTag('date', method: 'languageMatchesPage'))),
+                'service_a' => (new Definition(IfLanguageInsertTag::class))->addTag('contao.insert_tag', get_object_vars(new AsInsertTag('date', method: 'languageMatchesTranslatorLocale'))),
             ],
             [],
-            new InvalidDefinitionException('The contao.insert_tag definition for service "service_a" is invalid. The "Contao\CoreBundle\InsertTag\Resolver\IfLanguageInsertTag::languageMatchesPage" method exists but is not public.'),
+            new InvalidDefinitionException('The contao.insert_tag definition for service "service_a" is invalid. The "Contao\CoreBundle\InsertTag\Resolver\IfLanguageInsertTag::languageMatchesTranslatorLocale" method exists but is not public.'),
         ];
 
         yield [

--- a/core-bundle/tests/InsertTag/InsertTagParserTest.php
+++ b/core-bundle/tests/InsertTag/InsertTagParserTest.php
@@ -32,6 +32,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Controller\ControllerReference;
 use Symfony\Component\HttpKernel\Fragment\FragmentHandler;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 class InsertTagParserTest extends TestCase
 {
@@ -214,7 +215,7 @@ class InsertTagParserTest extends TestCase
 
         $parser = new InsertTagParser($this->createMock(ContaoFramework::class), $this->createMock(LoggerInterface::class), $this->createMock(FragmentHandler::class), $this->createMock(RequestStack::class));
         $parser->addSubscription(new InsertTagSubscription(new LegacyInsertTag(System::getContainer()), '__invoke', 'br', null, true, false));
-        $parser->addBlockSubscription(new InsertTagSubscription(new IfLanguageInsertTag($this->createMock(RequestStack::class)), '__invoke', 'ifnlng', 'ifnlng', true, false));
+        $parser->addBlockSubscription(new InsertTagSubscription(new IfLanguageInsertTag($this->createMock(TranslatorInterface::class)), '__invoke', 'ifnlng', 'ifnlng', true, false));
         System::getContainer()->set('contao.insert_tag.parser', $parser);
 
         $this->assertSame($expected, $parser->replaceInline($source));


### PR DESCRIPTION
Currently, the `{{iflng}}` insert tags are using `$request->getLocale()`. 
This means, they are ignoring the locale they would get when using e.g. the `LocaleSwitcher` service. 
The insert tags are meant to use the same locale as the `Translator` does.