### PR TITLE
Decouple the locale subscriber test from the request implementation

### DIFF
--- a/core-bundle/tests/EventListener/LocaleSubscriberTest.php
+++ b/core-bundle/tests/EventListener/LocaleSubscriberTest.php
@@ -33,7 +33,6 @@ class LocaleSubscriberTest extends TestCase
     {
         $request = $this->createMock(Request::class);
         $request->attributes = $this->createMock(ParameterBag::class);
-
         $request->attributes
             ->expects($this->atLeastOnce())
             ->method('get')

--- a/core-bundle/tests/EventListener/LocaleSubscriberTest.php
+++ b/core-bundle/tests/EventListener/LocaleSubscriberTest.php
@@ -12,9 +12,9 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Tests\EventListener;
 
-use Contao\CoreBundle\ContaoCoreBundle;
 use Contao\CoreBundle\EventListener\LocaleSubscriber;
 use Contao\CoreBundle\Intl\Locales;
+use Contao\CoreBundle\Routing\ScopeMatcher;
 use Contao\CoreBundle\Tests\TestCase;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\HttpFoundation\ParameterBag;
@@ -31,22 +31,40 @@ class LocaleSubscriberTest extends TestCase
      */
     public function testReadsTheLocaleFromTheRequest(string|null $locale, string $expected): void
     {
-        $request = Request::create('/');
-        $request->attributes->set('_locale', $locale);
-        $request->attributes->set('_scope', ContaoCoreBundle::SCOPE_FRONTEND);
+        $request = $this->createMock(Request::class);
+        $request->attributes = $this->createMock(ParameterBag::class);
+
+        $request->attributes
+            ->expects($this->atLeastOnce())
+            ->method('get')
+            ->with('_locale')
+            ->willReturn($expected)
+        ;
+
+        $request->attributes
+            ->expects($this->once())
+            ->method('set')
+            ->with('_locale', $expected)
+        ;
+
+        $scopeMatcher = $this->createMock(ScopeMatcher::class);
+        $scopeMatcher
+            ->expects($this->once())
+            ->method('isContaoRequest')
+            ->with($request)
+            ->willReturn(true)
+        ;
 
         $kernel = $this->createMock(KernelInterface::class);
         $event = new RequestEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST);
 
         $listener = new LocaleSubscriber(
             $this->createMock(LocaleAwareInterface::class),
-            $this->mockScopeMatcher(),
+            $scopeMatcher,
             $this->mockLocales(['en']),
         );
 
         $listener->onKernelRequest($event);
-
-        $this->assertSame($expected, $request->attributes->get('_locale'));
     }
 
     public static function getLocaleRequestData(): iterable
@@ -64,9 +82,23 @@ class LocaleSubscriberTest extends TestCase
      */
     public function testReadsTheLocaleFromTheAcceptLanguageHeader(string|null $locale, string $expected, array $available): void
     {
-        $request = Request::create('/');
-        $request->headers->set('Accept-Language', $locale);
-        $request->attributes->set('_scope', ContaoCoreBundle::SCOPE_FRONTEND);
+        $request = $this->createMock(Request::class);
+        $request->attributes = new ParameterBag();
+
+        $request
+            ->expects($this->once())
+            ->method('getPreferredLanguage')
+            ->with($available)
+            ->willReturn($expected)
+        ;
+
+        $scopeMatcher = $this->createMock(ScopeMatcher::class);
+        $scopeMatcher
+            ->expects($this->once())
+            ->method('isContaoRequest')
+            ->with($request)
+            ->willReturn(true)
+        ;
 
         $event = new RequestEvent(
             $this->createMock(KernelInterface::class),
@@ -76,7 +108,7 @@ class LocaleSubscriberTest extends TestCase
 
         $listener = new LocaleSubscriber(
             $this->createMock(LocaleAwareInterface::class),
-            $this->mockScopeMatcher(),
+            $scopeMatcher,
             $this->mockLocales($available),
         );
 
@@ -121,8 +153,13 @@ class LocaleSubscriberTest extends TestCase
 
     public function testSetsTheTranslatorLocale(): void
     {
-        $request = Request::create('/');
-        $request->headers->set('Accept-Language', 'de');
+        $request = $this->createMock(Request::class);
+        $request
+            ->expects($this->once())
+            ->method('getPreferredLanguage')
+            ->with(['en', 'de'])
+            ->willReturn('de')
+        ;
 
         $event = new RequestEvent(
             $this->createMock(KernelInterface::class),


### PR DESCRIPTION
The LocaleSubscriperTest should not test the implementation details of the Request class. Fixes issues with https://github.com/contao/contao/pull/7279