### PR TITLE
Skip sleeping in messenger web worker

### DIFF
--- a/core-bundle/src/Messenger/WebWorker.php
+++ b/core-bundle/src/Messenger/WebWorker.php
@@ -118,6 +118,7 @@ class WebWorker
         $input = new ArrayInput([
             'receivers' => [$transportName],
             '--time-limit' => 30,
+            '--sleep' => 0,
         ]);
 
         // No need to log anything because this is done by the messenger:consume command


### PR DESCRIPTION
I noticed a huge increase in response time on systems that don’t have `fastcgi_finish_request()` available. The reason for it is that the `messenger:consume` command in the web worker sleeps one second for each transport. I think we should disable that sleep :)

Response time went from 3396ms down to 154ms after this change on my system (Apache mod_php).