### PR TITLE
Fix symlinked file not inside root directory

### DIFF
--- a/core-bundle/config/services.yaml
+++ b/core-bundle/config/services.yaml
@@ -413,6 +413,7 @@ services:
               contao.image.resizer: '@contao.image.resizer'
               contao.assets.files_context: '@contao.assets.files_context'
               contao.framework: '@contao.framework'
+              contao.filesystem.virtual.files: '@contao.filesystem.virtual.files'
               event_dispatcher: '@event_dispatcher'
             - '%kernel.project_dir%'
             - '%contao.upload_path%'

--- a/core-bundle/src/Image/Studio/FigureBuilder.php
+++ b/core-bundle/src/Image/Studio/FigureBuilder.php
@@ -330,6 +330,18 @@ class FigureBuilder
      */
     public function fromStorage(VirtualFilesystemInterface $storage, Uuid|string $location): self
     {
+        // TODO: After contao/image supports a virtual storage, remove this workaround
+        // and replace it with something that can use $storage->generatePublicUri(). This
+        // workaround is currently required to support paths to symlinked folders inside
+        // the files directory.
+        if ($storage === $this->locator->get('contao.filesystem.virtual.files')) {
+            $path = Path::join($this->webDir, $this->uploadPath, $storage->get($location)->getPath());
+
+            if ($this->filesystem->exists($path)) {
+                return $this->fromPath($path);
+            }
+        }
+
         try {
             $stream = $storage->readStream($location);
         } catch (VirtualFilesystemException|UnableToResolveUuidException $e) {


### PR DESCRIPTION
Fixes #5869 by using a workaround until our image library supports virtual storages and/or streams.

@m-vo the solution outlined in https://github.com/contao/contao/issues/5869#issuecomment-1691961542 seemed too complex for a temporary workaround for me. In the end I think our image factory should return a filesystem item that can properly be used to pass it to `generatePublicUri()` or something like that.