### PR TITLE
Do not render news/event details multiple times

### DIFF
--- a/calendar-bundle/src/Resources/contao/modules/ModuleEventReader.php
+++ b/calendar-bundle/src/Resources/contao/modules/ModuleEventReader.php
@@ -284,7 +284,7 @@ class ModuleEventReader extends Events
 		{
 			$id = $objEvent->id;
 
-			$objTemplate->details = function () use ($id)
+			$objTemplate->details = function () use ($id, $objTemplate)
 			{
 				$strDetails = '';
 				$objElement = ContentModel::findPublishedByPidAndTable($id, 'tl_calendar_events');
@@ -297,7 +297,7 @@ class ModuleEventReader extends Events
 					}
 				}
 
-				return $strDetails;
+				return $objTemplate->details = $strDetails;
 			};
 
 			$objTemplate->hasDetails = static function () use ($id)

--- a/news-bundle/src/Resources/contao/modules/ModuleNews.php
+++ b/news-bundle/src/Resources/contao/modules/ModuleNews.php
@@ -116,7 +116,7 @@ abstract class ModuleNews extends Module
 		{
 			$id = $objArticle->id;
 
-			$objTemplate->text = function () use ($id)
+			$objTemplate->text = function () use ($id, $objTemplate)
 			{
 				$strText = '';
 				$objElement = ContentModel::findPublishedByPidAndTable($id, 'tl_news');
@@ -129,7 +129,7 @@ abstract class ModuleNews extends Module
 					}
 				}
 
-				return $strText;
+				return $objTemplate->text = $strText;
 			};
 
 			$objTemplate->hasText = static function () use ($objArticle)


### PR DESCRIPTION
Fixes #7311 

The callable now overwrites itself with the final result, preventing the content elements to be loaded and rendered multiple times when `$this->text`/`$this->details` is used multiple times in the same news/event detail template (which happens by default as the detail text is used again for the JSON-LD).