### PR TITLE
Handle `.<ext>.twig` file extensions in DC_Folder

### DIFF
--- a/core-bundle/contao/drivers/DC_Folder.php
+++ b/core-bundle/contao/drivers/DC_Folder.php
@@ -21,6 +21,7 @@ use Contao\CoreBundle\Security\DataContainer\CreateAction;
 use Contao\CoreBundle\Security\DataContainer\DeleteAction;
 use Contao\CoreBundle\Security\DataContainer\ReadAction;
 use Contao\CoreBundle\Security\DataContainer\UpdateAction;
+use Contao\CoreBundle\Twig\ContaoTwigUtil;
 use Contao\CoreBundle\Util\SymlinkUtil;
 use Contao\Image\PictureConfiguration;
 use Contao\Image\PictureConfigurationItem;
@@ -923,6 +924,11 @@ class DC_Folder extends DataContainer implements ListableDataContainerInterface,
 			$new = $destination;
 			$ext = strtolower(substr($destination, strrpos($destination, '.') + 1));
 
+			if ($ext === 'twig')
+			{
+				$ext = ContaoTwigUtil::getExtension($destination);
+			}
+
 			// Add a suffix if the file exists
 			while (file_exists($this->strRootDir . '/' . $new) && $count < 12)
 			{
@@ -1467,8 +1473,14 @@ class DC_Folder extends DataContainer implements ListableDataContainerInterface,
 						$objFile = is_dir($this->strRootDir . '/' . $this->intId) ? new Folder($this->intId) : new File($this->intId);
 
 						$this->strPath = StringUtil::stripRootDir($objFile->dirname);
-						$this->strExtension = $objFile->origext ? '.' . $objFile->origext : '';
-						$this->varValue = $objFile->filename;
+
+						if (($strExtension = $objFile->origext) === 'twig')
+						{
+							$strExtension = ContaoTwigUtil::getExtension($objFile->name);
+						}
+
+						$this->strExtension = $strExtension ? '.' . $strExtension : '';
+						$this->varValue = substr($objFile->name, 0, -\strlen($this->strExtension));
 
 						// Fix hidden Unix system files
 						if (str_starts_with($this->varValue, '.'))

--- a/core-bundle/contao/drivers/DC_Folder.php
+++ b/core-bundle/contao/drivers/DC_Folder.php
@@ -1480,7 +1480,7 @@ class DC_Folder extends DataContainer implements ListableDataContainerInterface,
 						}
 
 						$this->strExtension = $strExtension ? '.' . $strExtension : '';
-						$this->varValue = substr($objFile->name, 0, -\strlen($this->strExtension));
+						$this->varValue = substr($objFile->name, 0, -\strlen($this->strExtension) ?: null);
 
 						// Fix hidden Unix system files
 						if (str_starts_with($this->varValue, '.'))


### PR DESCRIPTION
Fixes #7290 by treating file names like `foo.xyz.twig` as `foo` with the extension `xyz.twig` instead of `foo.xyz` with the extension `twig` in `DC_Folder`.

In the future, there will be a template editor that does not have anything to do with `DC_Folder` anymore and this problem will basically be gone. But in the meantime I think we should just handle this specific case.

@sietsevandreven Can you check if this fixes your issue?