### PR TITLE
Fix the login state for two-factor authentication

### DIFF
--- a/core-bundle/src/Security/Voter/MemberGroupVoter.php
+++ b/core-bundle/src/Security/Voter/MemberGroupVoter.php
@@ -15,6 +15,7 @@ namespace Contao\CoreBundle\Security\Voter;
 use Contao\CoreBundle\Security\ContaoCorePermissions;
 use Contao\FrontendUser;
 use Contao\StringUtil;
+use Scheb\TwoFactorBundle\Security\Authentication\Token\TwoFactorToken;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\Voter;
 
@@ -39,7 +40,7 @@ class MemberGroupVoter extends Voter
 
         $user = $token->getUser();
 
-        if (!$user instanceof FrontendUser) {
+        if (!$user instanceof FrontendUser || $token instanceof TwoFactorToken) {
             return \in_array(-1, array_map('intval', $subject), true);
         }
 

--- a/core-bundle/src/Security/Voter/MemberGroupVoter.php
+++ b/core-bundle/src/Security/Voter/MemberGroupVoter.php
@@ -15,7 +15,7 @@ namespace Contao\CoreBundle\Security\Voter;
 use Contao\CoreBundle\Security\ContaoCorePermissions;
 use Contao\FrontendUser;
 use Contao\StringUtil;
-use Scheb\TwoFactorBundle\Security\Authentication\Token\TwoFactorToken;
+use Scheb\TwoFactorBundle\Security\Authentication\Token\TwoFactorTokenInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\Voter;
 
@@ -40,7 +40,7 @@ class MemberGroupVoter extends Voter
 
         $user = $token->getUser();
 
-        if (!$user instanceof FrontendUser || $token instanceof TwoFactorToken) {
+        if (!$user instanceof FrontendUser || $token instanceof TwoFactorTokenInterface) {
             return \in_array(-1, array_map('intval', $subject), true);
         }
 

--- a/core-bundle/tests/Security/Voter/MemberGroupVoterTest.php
+++ b/core-bundle/tests/Security/Voter/MemberGroupVoterTest.php
@@ -16,6 +16,7 @@ use Contao\CoreBundle\Security\ContaoCorePermissions;
 use Contao\CoreBundle\Security\Voter\MemberGroupVoter;
 use Contao\CoreBundle\Tests\TestCase;
 use Contao\FrontendUser;
+use Scheb\TwoFactorBundle\Security\Authentication\Token\TwoFactorToken;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
@@ -115,5 +116,19 @@ class MemberGroupVoterTest extends TestCase
         ;
 
         $this->assertSame(VoterInterface::ACCESS_GRANTED, $this->voter->vote($token, $ids, [ContaoCorePermissions::MEMBER_IN_GROUPS]));
+    }
+
+    public function testDeniesAccessIfTheTokenIsTwoFactor(): void
+    {
+        $user = $this->createMock(FrontendUser::class);
+
+        $token = $this->createMock(TwoFactorToken::class);
+        $token
+            ->expects($this->once())
+            ->method('getUser')
+            ->willReturn($user)
+        ;
+
+        $this->assertSame(VoterInterface::ACCESS_DENIED, $this->voter->vote($token, '1', [ContaoCorePermissions::MEMBER_IN_GROUPS]));
     }
 }

--- a/core-bundle/tests/Security/Voter/MemberGroupVoterTest.php
+++ b/core-bundle/tests/Security/Voter/MemberGroupVoterTest.php
@@ -16,7 +16,7 @@ use Contao\CoreBundle\Security\ContaoCorePermissions;
 use Contao\CoreBundle\Security\Voter\MemberGroupVoter;
 use Contao\CoreBundle\Tests\TestCase;
 use Contao\FrontendUser;
-use Scheb\TwoFactorBundle\Security\Authentication\Token\TwoFactorToken;
+use Scheb\TwoFactorBundle\Security\Authentication\Token\TwoFactorTokenInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
@@ -122,7 +122,7 @@ class MemberGroupVoterTest extends TestCase
     {
         $user = $this->createMock(FrontendUser::class);
 
-        $token = $this->createMock(TwoFactorToken::class);
+        $token = $this->createMock(TwoFactorTokenInterface::class);
         $token
             ->expects($this->once())
             ->method('getUser')


### PR DESCRIPTION
Fixes #6265, #7272

As discussed in the Contao call on 2024-07-04 the solution is fairly simple. By treating logged in users that haven't fully authenticated themselves via 2FA yet (i.e. when the token is a `TwoFactorTokenInterface`, as also checked by the `AuthenticationSuccessHandler`) as guests, both issues are solved.

#6265 is fixed, because the 401 page will be rendered again after the login - and the login module on the 401 page will then show the 2FA form.

#7272 is fixed because only the pages (and content) visible to guests will be shown.