### PR TITLE
Handle routing errors when trying to render the error screen

### DIFF
--- a/core-bundle/src/EventListener/PrettyErrorScreenListener.php
+++ b/core-bundle/src/EventListener/PrettyErrorScreenListener.php
@@ -31,6 +31,7 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\Exception\ServiceUnavailableHttpException;
 use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\Routing\Exception\ExceptionInterface;
 use Symfony\Component\Routing\Matcher\RequestMatcherInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException;
 use Symfony\Component\Security\Core\Security;
@@ -255,7 +256,12 @@ class PrettyErrorScreenListener
         if (!$pageModel instanceof PageModel) {
             $rootRequest = Request::create('http://'.$request->getHost());
             $rootRequest->headers->set('Accept-Language', $rootRequest->headers->get('Accept-Language'));
-            $parameters = $this->requestMatcher->matchRequest($rootRequest);
+
+            try {
+                $parameters = $this->requestMatcher->matchRequest($rootRequest);
+            } catch (ExceptionInterface $exception) {
+                return null;
+            }
 
             if (($parameters['pageModel'] ?? null) instanceof PageModel) {
                 $pageModel = $parameters['pageModel'];

--- a/core-bundle/tests/EventListener/PrettyErrorScreenListenerTest.php
+++ b/core-bundle/tests/EventListener/PrettyErrorScreenListenerTest.php
@@ -174,7 +174,6 @@ class PrettyErrorScreenListenerTest extends TestCase
     public function testHandlesRoutingExceptionWhenFindingPageModel(int $type, \Exception $exception): void
     {
         $request = $this->getRequest('frontend');
-
         $twig = $this->createMock(Environment::class);
         $httpKernel = $this->createMock(HttpKernelInterface::class);
         $pageRegistry = $this->createMock(PageRegistry::class);
@@ -187,7 +186,6 @@ class PrettyErrorScreenListenerTest extends TestCase
         ;
 
         $pageAdapter = $this->mockAdapter(['findFirstPublishedByTypeAndPid']);
-
         $framework = $this->mockContaoFramework([PageModel::class => $pageAdapter]);
 
         $security = $this->createMock(Security::class);

--- a/core-bundle/tests/EventListener/PrettyErrorScreenListenerTest.php
+++ b/core-bundle/tests/EventListener/PrettyErrorScreenListenerTest.php
@@ -38,6 +38,7 @@ use Symfony\Component\HttpKernel\Exception\ServiceUnavailableHttpException;
 use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\Routing\Exception\RouteNotFoundException;
 use Symfony\Component\Routing\Matcher\RequestMatcherInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException;
 use Symfony\Component\Security\Core\Security;
@@ -165,6 +166,43 @@ class PrettyErrorScreenListenerTest extends TestCase
 
         $this->assertTrue($event->hasResponse());
         $this->assertSame($type, $event->getResponse()->getStatusCode());
+    }
+
+    /**
+     * @dataProvider getErrorTypes
+     */
+    public function testHandlesRoutingExceptionWhenFindingPageModel(int $type, \Exception $exception): void
+    {
+        $request = $this->getRequest('frontend');
+
+        $twig = $this->createMock(Environment::class);
+        $httpKernel = $this->createMock(HttpKernelInterface::class);
+        $pageRegistry = $this->createMock(PageRegistry::class);
+
+        $requestMatcher = $this->createMock(RequestMatcherInterface::class);
+        $requestMatcher
+            ->expects($this->once())
+            ->method('matchRequest')
+            ->willThrowException(new RouteNotFoundException())
+        ;
+
+        $pageAdapter = $this->mockAdapter(['findFirstPublishedByTypeAndPid']);
+
+        $framework = $this->mockContaoFramework([PageModel::class => $pageAdapter]);
+
+        $security = $this->createMock(Security::class);
+        $security
+            ->method('isGranted')
+            ->with('ROLE_USER')
+            ->willReturn(false)
+        ;
+
+        $event = $this->getResponseEvent($exception, $request);
+
+        $listener = new PrettyErrorScreenListener(true, $twig, $framework, $security, $pageRegistry, $httpKernel, $requestMatcher);
+        $listener($event);
+
+        $this->assertFalse($event->hasResponse());
     }
 
     public function getErrorTypes(): \Generator


### PR DESCRIPTION
If a domain is mapped to a Contao installation, but it has no root page for it, that currently throws an internal server error instead of a 404 page. Because our pretty error screen renderer tries to render a 404 page for the current domain, but can't find its root page.