### PR TITLE
Do not encode custom regular expression characters

### DIFF
--- a/core-bundle/contao/dca/tl_form_field.php
+++ b/core-bundle/contao/dca/tl_form_field.php
@@ -226,7 +226,7 @@ $GLOBALS['TL_DCA']['tl_form_field'] = array
 		'customRgxp' => array
 		(
 			'inputType'               => 'text',
-			'eval'                    => array('decodeEntities'=>true, 'maxlength'=>255, 'tl_class'=>'w50', 'mandatory'=>true),
+			'eval'                    => array('useRawRequestData'=>true, 'maxlength'=>255, 'tl_class'=>'w50', 'mandatory'=>true),
 			'sql'                     => "varchar(255) NOT NULL default ''"
 		),
 		'errorMsg' => array

--- a/core-bundle/src/EventListener/Widget/CustomRgxpListener.php
+++ b/core-bundle/src/EventListener/Widget/CustomRgxpListener.php
@@ -14,6 +14,7 @@ namespace Contao\CoreBundle\EventListener\Widget;
 
 use Contao\CoreBundle\DependencyInjection\Attribute\AsHook;
 use Contao\Widget;
+use Contao\StringUtil;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 #[AsHook('addCustomRegexp')]
@@ -35,7 +36,7 @@ class CustomRgxpListener
             return true;
         }
 
-        if (!preg_match($widget->customRgxp, $input)) {
+        if (!preg_match($widget->customRgxp, StringUtil::decodeEntities($input))) {
             $widget->addError($widget->errorMsg ?: $this->translator->trans('ERR.customRgxp', [$widget->customRgxp], 'contao_default'));
         }
 


### PR DESCRIPTION
Fixes Issue# https://github.com/contao/contao/issues/7322

Basically, do not encode custom regular expression characters in the backend form field custom validation and decode users input from the frontend form field before matching with the regex.
