### PR TITLE
Ignore duplicate opt-in submissions

### DIFF
--- a/comments-bundle/src/Resources/contao/classes/Comments.php
+++ b/comments-bundle/src/Resources/contao/classes/Comments.php
@@ -542,13 +542,6 @@ class Comments extends Frontend
 				return;
 			}
 
-			if ($optInToken->isConfirmed())
-			{
-				$objTemplate->confirm = $GLOBALS['TL_LANG']['MSC']['tokenConfirmed'];
-
-				return;
-			}
-
 			if ($optInToken->getEmail() != $objNotify->email)
 			{
 				$objTemplate->confirm = $GLOBALS['TL_LANG']['MSC']['tokenEmailMismatch'];
@@ -556,10 +549,13 @@ class Comments extends Frontend
 				return;
 			}
 
-			$objNotify->active = '1';
-			$objNotify->save();
+			if (!$optInToken->isConfirmed())
+			{
+				$objNotify->active = '1';
+				$objNotify->save();
 
-			$optInToken->confirm();
+				$optInToken->confirm();
+			}
 
 			$objTemplate->confirm = $GLOBALS['TL_LANG']['MSC']['com_optInConfirm'];
 		}

--- a/core-bundle/src/Resources/contao/modules/ModuleRegistration.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleRegistration.php
@@ -538,14 +538,6 @@ class ModuleRegistration extends Module
 			return;
 		}
 
-		if ($optInToken->isConfirmed())
-		{
-			$this->Template->type = 'error';
-			$this->Template->message = $GLOBALS['TL_LANG']['MSC']['tokenConfirmed'];
-
-			return;
-		}
-
 		if ($optInToken->getEmail() != $objMember->email)
 		{
 			$this->Template->type = 'error';
@@ -554,22 +546,25 @@ class ModuleRegistration extends Module
 			return;
 		}
 
-		$objMember->disable = '';
-		$objMember->save();
-
-		$optInToken->confirm();
-
-		// HOOK: post activation callback
-		if (isset($GLOBALS['TL_HOOKS']['activateAccount']) && \is_array($GLOBALS['TL_HOOKS']['activateAccount']))
+		if (!$optInToken->isConfirmed())
 		{
-			foreach ($GLOBALS['TL_HOOKS']['activateAccount'] as $callback)
-			{
-				$this->import($callback[0]);
-				$this->{$callback[0]}->{$callback[1]}($objMember, $this);
-			}
-		}
+			$objMember->disable = '';
+			$objMember->save();
 
-		System::getContainer()->get('monolog.logger.contao.access')->info('User account ID ' . $objMember->id . ' (' . Idna::decodeEmail($objMember->email) . ') has been activated');
+			$optInToken->confirm();
+
+			// HOOK: post activation callback
+			if (isset($GLOBALS['TL_HOOKS']['activateAccount']) && \is_array($GLOBALS['TL_HOOKS']['activateAccount']))
+			{
+				foreach ($GLOBALS['TL_HOOKS']['activateAccount'] as $callback)
+				{
+					$this->import($callback[0]);
+					$this->{$callback[0]}->{$callback[1]}($objMember, $this);
+				}
+			}
+
+			System::getContainer()->get('monolog.logger.contao.access')->info('User account ID ' . $objMember->id . ' (' . Idna::decodeEmail($objMember->email) . ') has been activated');
+		}
 
 		// Redirect to the jumpTo page
 		if (($objTarget = $this->objModel->getRelated('reg_jumpTo')) instanceof PageModel)

--- a/newsletter-bundle/src/Resources/contao/modules/ModuleSubscribe.php
+++ b/newsletter-bundle/src/Resources/contao/modules/ModuleSubscribe.php
@@ -175,62 +175,57 @@ class ModuleSubscribe extends Module
 			return;
 		}
 
-		if ($optInToken->isConfirmed())
+		if (!$optInToken->isConfirmed())
 		{
-			$this->Template->mclass = 'error';
-			$this->Template->message = $GLOBALS['TL_LANG']['MSC']['tokenConfirmed'];
+			$arrRecipients = array();
 
-			return;
-		}
-
-		$arrRecipients = array();
-
-		// Validate the token
-		foreach ($arrIds as $intId)
-		{
-			if (!$objRecipient = NewsletterRecipientsModel::findByPk($intId))
+			// Validate the token
+			foreach ($arrIds as $intId)
 			{
-				$this->Template->mclass = 'error';
-				$this->Template->message = $GLOBALS['TL_LANG']['MSC']['invalidToken'];
+				if (!$objRecipient = NewsletterRecipientsModel::findByPk($intId))
+				{
+					$this->Template->mclass = 'error';
+					$this->Template->message = $GLOBALS['TL_LANG']['MSC']['invalidToken'];
 
-				return;
+					return;
+				}
+
+				if ($optInToken->getEmail() != $objRecipient->email)
+				{
+					$this->Template->mclass = 'error';
+					$this->Template->message = $GLOBALS['TL_LANG']['MSC']['tokenEmailMismatch'];
+
+					return;
+				}
+
+				$arrRecipients[] = $objRecipient;
 			}
 
-			if ($optInToken->getEmail() != $objRecipient->email)
-			{
-				$this->Template->mclass = 'error';
-				$this->Template->message = $GLOBALS['TL_LANG']['MSC']['tokenEmailMismatch'];
+			$time = time();
+			$arrAdd = array();
+			$arrCids = array();
 
-				return;
+			// Activate the subscriptions
+			foreach ($arrRecipients as $objRecipient)
+			{
+				$arrAdd[] = $objRecipient->id;
+				$arrCids[] = $objRecipient->pid;
+
+				$objRecipient->tstamp = $time;
+				$objRecipient->active = '1';
+				$objRecipient->save();
 			}
 
-			$arrRecipients[] = $objRecipient;
-		}
+			$optInToken->confirm();
 
-		$time = time();
-		$arrAdd = array();
-		$arrCids = array();
-
-		// Activate the subscriptions
-		foreach ($arrRecipients as $objRecipient)
-		{
-			$arrAdd[] = $objRecipient->id;
-			$arrCids[] = $objRecipient->pid;
-
-			$objRecipient->tstamp = $time;
-			$objRecipient->active = '1';
-			$objRecipient->save();
-		}
-
-		$optInToken->confirm();
-
-		// HOOK: post activation callback
-		if (isset($GLOBALS['TL_HOOKS']['activateRecipient']) && \is_array($GLOBALS['TL_HOOKS']['activateRecipient']))
-		{
-			foreach ($GLOBALS['TL_HOOKS']['activateRecipient'] as $callback)
+			// HOOK: post activation callback
+			if (isset($GLOBALS['TL_HOOKS']['activateRecipient']) && \is_array($GLOBALS['TL_HOOKS']['activateRecipient']))
 			{
-				$this->import($callback[0]);
-				$this->{$callback[0]}->{$callback[1]}($optInToken->getEmail(), $arrAdd, $arrCids, $this);
+				foreach ($GLOBALS['TL_HOOKS']['activateRecipient'] as $callback)
+				{
+					$this->import($callback[0]);
+					$this->{$callback[0]}->{$callback[1]}($optInToken->getEmail(), $arrAdd, $arrCids, $this);
+				}
 			}
 		}
 


### PR DESCRIPTION
Yesterday I was doing some front end tests with a client of mine. They use Microsoft Outlook and some corporate servers for their emails. When they click a link in an email, Outlook (or whatever they use) does a security-check on the URL, which actually queries the URL in the background, before opening the browser tab. This causes problems with (some of) our opt-in tokens. In my case this was about the user registration, because they will receive a _token already confirmed_ error message.

I remember we discussed that in a public call a while ago. Dunno what solution we came up with (except for using POST requets, which isn't easy). The most simple solution I can think of (and this PR implements) is to simply ignore a second submission of a valid token (= within 24hrs). It now shows the same confirmation page or message, but simply does not execute the confirmation action twice.

PS: this does not apply to `ModulePassword`, because there the opt-in token is only confirmed after the form has been manually submitted (with a new password).