### PR TITLE
Cleanup a leftover service argument

### DIFF
--- a/core-bundle/config/services.yaml
+++ b/core-bundle/config/services.yaml
@@ -558,7 +558,6 @@ services:
         arguments:
             - '@cache.app'
             - '@console.command.messenger_consume_messages'
-            - '@messenger.receiver_locator'
 
     contao.model_argument_resolver:
         class: Contao\CoreBundle\HttpKernel\ModelArgumentResolver


### PR DESCRIPTION
This is a leftover. The arguments are set via extension and are different now so it had no effect but it was confusing to me when reading the `services.yaml` :D 