### PR TITLE
Ignore deleted cookies in the `CsrfTokenCookieSubscriber`

### DIFF
--- a/core-bundle/src/EventListener/CsrfTokenCookieSubscriber.php
+++ b/core-bundle/src/EventListener/CsrfTokenCookieSubscriber.php
@@ -106,15 +106,18 @@ class CsrfTokenCookieSubscriber implements EventSubscriberInterface
         $responseCookies = $response->headers->getCookies(ResponseHeaderBag::COOKIES_FLAT);
 
         // Ignore any cookies in the request and response that are being deleted (#7344)
-        $responseCookies = array_filter($responseCookies, static function (Cookie $responseCookie) use ($requestCookies): bool {
-            if ($responseCookie->isCleared()) {
-                unset($requestCookies[$responseCookie->getName()]);
+        $responseCookies = array_filter(
+            $responseCookies,
+            static function (Cookie $responseCookie) use ($requestCookies): bool {
+                if ($responseCookie->isCleared()) {
+                    unset($requestCookies[$responseCookie->getName()]);
 
-                return false;
+                    return false;
+                }
+
+                return true;
             }
-
-            return true;
-        });
+        );
 
         // Check if any of the remaining request cookies is not a CSRF cookie
         foreach ($requestCookies as $key => $value) {

--- a/core-bundle/src/EventListener/CsrfTokenCookieSubscriber.php
+++ b/core-bundle/src/EventListener/CsrfTokenCookieSubscriber.php
@@ -108,7 +108,7 @@ class CsrfTokenCookieSubscriber implements EventSubscriberInterface
         // Ignore any cookies in the request and response that are being deleted (#7344)
         $responseCookies = array_filter(
             $responseCookies,
-            static function (Cookie $responseCookie) use ($requestCookies): bool {
+            static function (Cookie $responseCookie) use (&$requestCookies): bool {
                 if ($responseCookie->isCleared()) {
                     unset($requestCookies[$responseCookie->getName()]);
 

--- a/core-bundle/src/EventListener/CsrfTokenCookieSubscriber.php
+++ b/core-bundle/src/EventListener/CsrfTokenCookieSubscriber.php
@@ -105,7 +105,7 @@ class CsrfTokenCookieSubscriber implements EventSubscriberInterface
         $requestCookies = $request->cookies->all();
         $responseCookies = $response->headers->getCookies(ResponseHeaderBag::COOKIES_FLAT);
 
-        // Ignore any cookies in the request and response that are being deleted (#7344)
+        // Ignore any cookies in the request and response that are being deleted (see #7344)
         $responseCookies = array_filter(
             $responseCookies,
             static function (Cookie $responseCookie) use (&$requestCookies): bool {

--- a/core-bundle/src/EventListener/CsrfTokenCookieSubscriber.php
+++ b/core-bundle/src/EventListener/CsrfTokenCookieSubscriber.php
@@ -102,21 +102,33 @@ class CsrfTokenCookieSubscriber implements EventSubscriberInterface
 
     private function requiresCsrf(Request $request, Response $response): bool
     {
-        foreach ($request->cookies as $key => $value) {
+        $requestCookies = $request->cookies->all();
+        $responseCookies = $response->headers->getCookies(ResponseHeaderBag::COOKIES_FLAT);
+
+        // Ignore any cookies in the request and response that are being deleted (#7344)
+        $responseCookies = array_filter($responseCookies, static function (Cookie $responseCookie) use ($requestCookies): bool {
+            if ($responseCookie->isCleared()) {
+                unset($requestCookies[$responseCookie->getName()]);
+
+                return false;
+            }
+
+            return true;
+        });
+
+        // Check if any of the remaining request cookies is not a CSRF cookie
+        foreach ($requestCookies as $key => $value) {
             if (!$this->isCsrfCookie($key, $value)) {
                 return true;
             }
         }
 
-        if (\count($response->headers->getCookies(ResponseHeaderBag::COOKIES_ARRAY))) {
+        // Check if there are any unexpired cookies remaining in the response
+        if ([] !== $responseCookies) {
             return true;
         }
 
-        if ($request->getUserInfo()) {
-            return true;
-        }
-
-        return false;
+        return (bool) $request->getUserInfo();
     }
 
     private function setCookies(Request $request, Response $response): void

--- a/core-bundle/tests/EventListener/CsrfTokenCookieSubscriberTest.php
+++ b/core-bundle/tests/EventListener/CsrfTokenCookieSubscriberTest.php
@@ -16,7 +16,6 @@ use Contao\CoreBundle\Csrf\ContaoCsrfTokenManager;
 use Contao\CoreBundle\Csrf\MemoryTokenStorage;
 use Contao\CoreBundle\EventListener\CsrfTokenCookieSubscriber;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\InputBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;

--- a/core-bundle/tests/EventListener/CsrfTokenCookieSubscriberTest.php
+++ b/core-bundle/tests/EventListener/CsrfTokenCookieSubscriberTest.php
@@ -135,11 +135,8 @@ class CsrfTokenCookieSubscriberTest extends TestCase
         $cookies = $response->headers->getCookies();
 
         $this->assertCount(1, $cookies);
-
-        $cookie = $cookies[0];
-
-        $this->assertSame('unrelated-cookie', $cookie->getName());
-        $this->asserTtrue($cookie->isCleared());
+        $this->assertSame('unrelated-cookie', $cookies[0]->getName());
+        $this->asserTtrue($cookies[0]->isCleared());
     }
 
     public function testDoesNotAddTheTokenCookiesToTheResponseIfTheyAlreadyExist(): void


### PR DESCRIPTION
Fixes #7344

This PR ignores any cookies that are about to be deleted in the response while checking the request and response cookies.

This PR is based against 4.13. While the original issue is directly observable in Contao 5.3 with the `AutoExpiringAttribute`, the same issue can also occur in 4.13.