### PR TITLE
Fix a PHP8 error when sending newsletters

### DIFF
--- a/newsletter-bundle/src/Resources/contao/classes/Newsletter.php
+++ b/newsletter-bundle/src/Resources/contao/classes/Newsletter.php
@@ -222,7 +222,7 @@ class Newsletter extends Backend
 					}
 				}
 
-				if ($intSkipped = \count($_SESSION['SKIPPED_RECIPIENTS']))
+				if ($intSkipped = \count($_SESSION['SKIPPED_RECIPIENTS'] ?? 0))
 				{
 					$intTotal -= $intSkipped;
 					Message::addInfo(sprintf($GLOBALS['TL_LANG']['tl_newsletter']['skipped'], $intSkipped));


### PR DESCRIPTION
Sentry reported the error `Warning: Undefined array key "SKIPPED_RECIPIENTS"`. I guess this can happen if you are sending a large newsletter and run into a timeout. Or you restart/continue the sending process.

This obviously does not fix the issue that potentially skipped recipients are lost, but at least it correctly checks for the array key.