### PR TITLE
Use the user data instead of magic methods

### DIFF
--- a/core-bundle/src/Resources/contao/classes/BackendUser.php
+++ b/core-bundle/src/Resources/contao/classes/BackendUser.php
@@ -295,7 +295,7 @@ class BackendUser extends User
 	{
 		trigger_deprecation('contao/core-bundle', '4.13', 'Using "Contao\BackendUser::isAllowed()" has been deprecated and will no longer work in Contao 5. Use the "security.helper" service with the ContaoCorePermissions constants instead.');
 
-		if ($this->arrData['admin'])
+		if ($this->arrData['admin'] ?? false)
 		{
 			return true;
 		}

--- a/core-bundle/src/Resources/contao/classes/BackendUser.php
+++ b/core-bundle/src/Resources/contao/classes/BackendUser.php
@@ -240,7 +240,7 @@ class BackendUser extends User
 	 */
 	public function hasAccess($field, $array)
 	{
-		if ($this->arrData['admin'])
+		if ($this->arrData['admin'] ?? null)
 		{
 			return true;
 		}
@@ -250,7 +250,7 @@ class BackendUser extends User
 			$field = array($field);
 		}
 
-		if (\is_array($this->arrData[$array]) && array_intersect($field, $this->arrData[$array]))
+		if (\is_array($this->arrData[$array] ?? null) && array_intersect($field, $this->arrData[$array]))
 		{
 			return true;
 		}
@@ -401,7 +401,7 @@ class BackendUser extends User
 	 */
 	protected function setUserFromDb()
 	{
-		$this->intId = $this->arrData['id'];
+		$this->intId = $this->arrData['id'] ?? null;
 
 		// Unserialize values
 		foreach ($this->arrData as $k=>$v)
@@ -412,14 +412,14 @@ class BackendUser extends User
 			}
 		}
 
-		$GLOBALS['TL_USERNAME'] = $this->arrData['username'];
+		$GLOBALS['TL_USERNAME'] = $this->arrData['username'] ?? null;
 
-		Config::set('showHelp', $this->arrData['showHelp']);
-		Config::set('useRTE', $this->arrData['useRTE']);
-		Config::set('useCE', $this->arrData['useCE']);
-		Config::set('thumbnails', $this->arrData['thumbnails']);
-		Config::set('backendTheme', $this->arrData['backendTheme']);
-		Config::set('fullscreen', $this->arrData['fullscreen']);
+		Config::set('showHelp', $this->arrData['showHelp'] ?? true);
+		Config::set('useRTE', $this->arrData['useRTE'] ?? true);
+		Config::set('useCE', $this->arrData['useCE'] ?? true);
+		Config::set('thumbnails', $this->arrData['thumbnails'] ?? true);
+		Config::set('backendTheme', $this->arrData['backendTheme'] ?? 'flexible');
+		Config::set('fullscreen', $this->arrData['fullscreen'] ?? false);
 
 		// Inherit permissions
 		$always = array('alexf');
@@ -432,7 +432,7 @@ class BackendUser extends User
 		}
 
 		// Overwrite user permissions if only group permissions shall be inherited
-		if ($this->arrData['inherit'] == 'group')
+		if (($this->arrData['inherit'] ?? null) == 'group')
 		{
 			foreach ($depends as $field)
 			{
@@ -441,7 +441,7 @@ class BackendUser extends User
 		}
 
 		// Merge permissions
-		$inherit = \in_array($this->arrData['inherit'], array('group', 'extend')) ? array_merge($always, $depends) : $always;
+		$inherit = \in_array($this->arrData['inherit'] ?? null, array('group', 'extend')) ? array_merge($always, $depends) : $always;
 		$time = Date::floorToMinute();
 
 		foreach ((array) $this->arrData['groups'] as $id)
@@ -467,7 +467,7 @@ class BackendUser extends User
 		}
 
 		// Make sure pagemounts and filemounts are set!
-		if (!\is_array($this->arrData['pagemounts']))
+		if (!\is_array($this->arrData['pagemounts'] ?? null))
 		{
 			$this->arrData['pagemounts'] = array();
 		}
@@ -476,7 +476,7 @@ class BackendUser extends User
 			$this->arrData['pagemounts'] = array_filter($this->arrData['pagemounts']);
 		}
 
-		if (!\is_array($this->arrData['filemounts']))
+		if (!\is_array($this->arrData['filemounts'] ?? null))
 		{
 			$this->arrData['filemounts'] = array();
 		}

--- a/core-bundle/src/Resources/contao/classes/BackendUser.php
+++ b/core-bundle/src/Resources/contao/classes/BackendUser.php
@@ -621,7 +621,7 @@ class BackendUser extends User
 
 	public function __serialize(): array
 	{
-		return array('admin' => $this->arrData['admin'], 'amg' => $this->arrData['amg'], 'parent' => parent::__serialize());
+		return array('admin' => $this->arrData['admin'] ?? null, 'amg' => $this->arrData['amg'] ?? null, 'parent' => parent::__serialize());
 	}
 
 	/**

--- a/core-bundle/src/Resources/contao/classes/BackendUser.php
+++ b/core-bundle/src/Resources/contao/classes/BackendUser.php
@@ -459,7 +459,7 @@ class BackendUser extends User
 					// The new page/file picker can return integers instead of arrays, so use empty() instead of is_array() and StringUtil::deserialize(true) here
 					if (!empty($value))
 					{
-						$this->arrData[$field] = array_merge((\is_array($this->arrData[$field]) ? $this->arrData[$field] : ($this->arrData[$field] ? array($this->arrData[$field]) : array())), $value);
+						$this->arrData[$field] = array_merge((\is_array($this->arrData[$field] ?? null) ? $this->arrData[$field] : ($this->arrData[$field] ?? null ? array($this->arrData[$field]) : array())), $value);
 						$this->arrData[$field] = array_unique($this->arrData[$field]);
 					}
 				}

--- a/core-bundle/src/Resources/contao/classes/FrontendUser.php
+++ b/core-bundle/src/Resources/contao/classes/FrontendUser.php
@@ -190,7 +190,7 @@ class FrontendUser extends User
 			return false;
 		}
 
-		$this->arrGroups = $this->arrData['groups'];
+		$this->arrGroups = $this->groups;
 
 		return true;
 	}
@@ -200,10 +200,10 @@ class FrontendUser extends User
 	 */
 	public function save()
 	{
-		$groups = $this->arrData['groups'];
+		$groups = $this->groups;
 		$this->arrData['groups'] = $this->arrGroups;
 		parent::save();
-		$this->arrData['groups'] = $groups;
+		$this->groups = $groups;
 	}
 
 	/**
@@ -211,7 +211,7 @@ class FrontendUser extends User
 	 */
 	protected function setUserFromDb()
 	{
-		$this->intId = $this->arrData['id'];
+		$this->intId = $this->id;
 
 		// Unserialize values
 		foreach ($this->arrData as $k=>$v)
@@ -222,24 +222,24 @@ class FrontendUser extends User
 			}
 		}
 
-		$GLOBALS['TL_USERNAME'] = $this->arrData['username'];
+		$GLOBALS['TL_USERNAME'] = $this->username;
 
 		// Make sure that groups is an array
-		if (!\is_array($this->arrData['groups']))
+		if (!\is_array($this->groups))
 		{
-			$this->arrData['groups'] = $this->arrData['groups'] ? array($this->arrData['groups']) : array();
+			$this->groups = $this->groups ? array($this->groups) : array();
 		}
 
 		// Skip inactive groups
 		if (($objGroups = MemberGroupModel::findAllActive()) !== null)
 		{
-			$this->arrData['groups'] = array_intersect($this->arrData['groups'], $objGroups->fetchEach('id'));
+			$this->groups = array_intersect($this->groups, $objGroups->fetchEach('id'));
 		}
 
 		// Get the group login page
-		if (($this->arrData['groups'][0] ?? 0) > 0)
+		if (($this->groups[0] ?? 0) > 0)
 		{
-			$objGroup = MemberGroupModel::findPublishedById($this->arrData['groups'][0]);
+			$objGroup = MemberGroupModel::findPublishedById($this->groups[0]);
 
 			if ($objGroup !== null && $objGroup->redirect && $objGroup->jumpTo)
 			{

--- a/core-bundle/src/Resources/contao/classes/FrontendUser.php
+++ b/core-bundle/src/Resources/contao/classes/FrontendUser.php
@@ -190,7 +190,7 @@ class FrontendUser extends User
 			return false;
 		}
 
-		$this->arrGroups = $this->groups;
+		$this->arrGroups = $this->arrData['groups'];
 
 		return true;
 	}
@@ -200,10 +200,10 @@ class FrontendUser extends User
 	 */
 	public function save()
 	{
-		$groups = $this->groups;
+		$groups = $this->arrData['groups'];
 		$this->arrData['groups'] = $this->arrGroups;
 		parent::save();
-		$this->groups = $groups;
+		$this->arrData['groups'] = $groups;
 	}
 
 	/**
@@ -211,35 +211,35 @@ class FrontendUser extends User
 	 */
 	protected function setUserFromDb()
 	{
-		$this->intId = $this->id;
+		$this->intId = $this->arrData['id'];
 
 		// Unserialize values
 		foreach ($this->arrData as $k=>$v)
 		{
 			if (!is_numeric($v))
 			{
-				$this->$k = StringUtil::deserialize($v);
+				$this->arrData[$k] = StringUtil::deserialize($v);
 			}
 		}
 
-		$GLOBALS['TL_USERNAME'] = $this->username;
+		$GLOBALS['TL_USERNAME'] = $this->arrData['username'];
 
 		// Make sure that groups is an array
-		if (!\is_array($this->groups))
+		if (!\is_array($this->arrData['groups']))
 		{
-			$this->groups = $this->groups ? array($this->groups) : array();
+			$this->arrData['groups'] = $this->arrData['groups'] ? array($this->arrData['groups']) : array();
 		}
 
 		// Skip inactive groups
 		if (($objGroups = MemberGroupModel::findAllActive()) !== null)
 		{
-			$this->groups = array_intersect($this->groups, $objGroups->fetchEach('id'));
+			$this->arrData['groups'] = array_intersect($this->arrData['groups'], $objGroups->fetchEach('id'));
 		}
 
 		// Get the group login page
-		if (($this->groups[0] ?? 0) > 0)
+		if (($this->arrData['groups'][0] ?? 0) > 0)
 		{
-			$objGroup = MemberGroupModel::findPublishedById($this->groups[0]);
+			$objGroup = MemberGroupModel::findPublishedById($this->arrData['groups'][0]);
 
 			if ($objGroup !== null && $objGroup->redirect && $objGroup->jumpTo)
 			{

--- a/core-bundle/src/Resources/contao/library/Contao/User.php
+++ b/core-bundle/src/Resources/contao/library/Contao/User.php
@@ -220,7 +220,7 @@ abstract class User extends System implements UserInterface, EquatableInterface,
 			return 'anon.';
 		}
 
-		return (string) ($this->arrData['username'] ?: ($this->getTable() . '.' . $this->intId));
+		return $this->username ?: ($this->getTable() . '.' . $this->intId);
 	}
 
 	/**
@@ -348,7 +348,7 @@ abstract class User extends System implements UserInterface, EquatableInterface,
 
 		$this->Database->prepare("UPDATE " . $this->strTable . " %s WHERE id=?")
 					   ->set($arrSet)
-					   ->execute($this->intId);
+					   ->execute($this->id);
 	}
 
 	/**
@@ -428,7 +428,7 @@ abstract class User extends System implements UserInterface, EquatableInterface,
 			return false;
 		}
 
-		$groups = StringUtil::deserialize($this->arrData['groups'], true);
+		$groups = StringUtil::deserialize($this->groups, true);
 
 		// No groups assigned
 		if (empty($groups))
@@ -519,7 +519,7 @@ abstract class User extends System implements UserInterface, EquatableInterface,
 
 	public function setUsername($username)
 	{
-		$this->arrData['username'] = $username;
+		$this->username = $username;
 
 		return $this;
 	}
@@ -529,17 +529,17 @@ abstract class User extends System implements UserInterface, EquatableInterface,
 	 */
 	public function getUserIdentifier(): string
 	{
-		if (null === $this->arrData['username'] ?? null)
+		if (null === $this->username)
 		{
 			throw new \RuntimeException('Missing username in User object');
 		}
 
-		if (!\is_string($this->arrData['username']))
+		if (!\is_string($this->username))
 		{
-			throw new \RuntimeException(sprintf('Invalid type "%s" for username', \gettype($this->arrData['username'])));
+			throw new \RuntimeException(sprintf('Invalid type "%s" for username', \gettype($this->username)));
 		}
 
-		return $this->arrData['username'];
+		return $this->username;
 	}
 
 	/**
@@ -547,12 +547,12 @@ abstract class User extends System implements UserInterface, EquatableInterface,
 	 */
 	public function getPassword(): ?string
 	{
-		return $this->arrData['password'] ?? null;
+		return $this->password;
 	}
 
 	public function setPassword($password)
 	{
-		$this->arrData['password'] = $password;
+		$this->password = $password;
 
 		return $this;
 	}
@@ -584,12 +584,12 @@ abstract class User extends System implements UserInterface, EquatableInterface,
 	{
 		return array
 		(
-			'id' => $this->arrData['id'] ?? null,
-			'username' => $this->arrData['username'] ?? null,
-			'password' => $this->arrData['password'] ?? null,
-			'disable' => $this->arrData['disable'] ?? null,
-			'start' => $this->arrData['start'] ?? null,
-			'stop' => $this->arrData['stop'] ?? null
+			'id' => $this->id,
+			'username' => $this->username,
+			'password' => $this->password,
+			'disable' => $this->disable,
+			'start' => $this->start,
+			'stop' => $this->stop
 		);
 	}
 
@@ -608,7 +608,7 @@ abstract class User extends System implements UserInterface, EquatableInterface,
 			return;
 		}
 
-		list($this->arrData['id'], $this->arrData['username'], $this->arrData['password'], $this->arrData['disable'], $this->arrData['start'], $this->arrData['stop']) = array_values($data);
+		list($this->id, $this->username, $this->password, $this->disable, $this->start, $this->stop) = array_values($data);
 	}
 
 	/**
@@ -633,22 +633,22 @@ abstract class User extends System implements UserInterface, EquatableInterface,
 			return false;
 		}
 
-		if ($this->arrData['password'] ?? null !== $user->password)
+		if ($this->password !== $user->password)
 		{
 			return false;
 		}
 
-		if ((bool) ($this->arrData['disable'] ?? false) !== (bool) $user->disable)
+		if ((bool) $this->disable !== (bool) $user->disable)
 		{
 			return false;
 		}
 
-		if ($this->arrData['start'] ?? null !== '' && $this->arrData['start'] ?? null > time())
+		if ($this->start !== '' && $this->start > time())
 		{
 			return false;
 		}
 
-		if ($this->arrData['stop'] ?? null !== '' && $this->arrData['stop'] ?? null <= time())
+		if ($this->stop !== '' && $this->stop <= time())
 		{
 			return false;
 		}

--- a/core-bundle/src/Resources/contao/library/Contao/User.php
+++ b/core-bundle/src/Resources/contao/library/Contao/User.php
@@ -584,12 +584,12 @@ abstract class User extends System implements UserInterface, EquatableInterface,
 	{
 		return array
 		(
-			'id' => $this->arrData['id'],
-			'username' => $this->arrData['username'],
-			'password' => $this->arrData['password'],
-			'disable' => $this->arrData['disable'],
-			'start' => $this->arrData['start'],
-			'stop' => $this->arrData['stop']
+			'id' => $this->arrData['id'] ?? null,
+			'username' => $this->arrData['username'] ?? null,
+			'password' => $this->arrData['password'] ?? null,
+			'disable' => $this->arrData['disable'] ?? null,
+			'start' => $this->arrData['start'] ?? null,
+			'stop' => $this->arrData['stop'] ?? null
 		);
 	}
 

--- a/core-bundle/src/Resources/contao/library/Contao/User.php
+++ b/core-bundle/src/Resources/contao/library/Contao/User.php
@@ -529,7 +529,7 @@ abstract class User extends System implements UserInterface, EquatableInterface,
 	 */
 	public function getUserIdentifier(): string
 	{
-		if (null === $this->arrData['username'])
+		if (null === $this->arrData['username'] ?? null)
 		{
 			throw new \RuntimeException('Missing username in User object');
 		}
@@ -547,7 +547,7 @@ abstract class User extends System implements UserInterface, EquatableInterface,
 	 */
 	public function getPassword(): ?string
 	{
-		return $this->arrData['password'];
+		return $this->arrData['password'] ?? null;
 	}
 
 	public function setPassword($password)
@@ -633,22 +633,22 @@ abstract class User extends System implements UserInterface, EquatableInterface,
 			return false;
 		}
 
-		if ($this->arrData['password'] !== $user->password)
+		if ($this->arrData['password'] ?? null !== $user->password)
 		{
 			return false;
 		}
 
-		if ((bool) $this->arrData['disable'] !== (bool) $user->disable)
+		if ((bool) ($this->arrData['disable'] ?? false) !== (bool) $user->disable)
 		{
 			return false;
 		}
 
-		if ($this->arrData['start'] !== '' && $this->arrData['start'] > time())
+		if ($this->arrData['start'] ?? null !== '' && $this->arrData['start'] ?? null > time())
 		{
 			return false;
 		}
 
-		if ($this->arrData['stop'] !== '' && $this->arrData['stop'] <= time())
+		if ($this->arrData['stop'] ?? null !== '' && $this->arrData['stop'] ?? null <= time())
 		{
 			return false;
 		}

--- a/core-bundle/src/Resources/contao/library/Contao/User.php
+++ b/core-bundle/src/Resources/contao/library/Contao/User.php
@@ -220,7 +220,7 @@ abstract class User extends System implements UserInterface, EquatableInterface,
 			return 'anon.';
 		}
 
-		return $this->username ?: ($this->getTable() . '.' . $this->intId);
+		return (string) ($this->arrData['username'] ?: ($this->getTable() . '.' . $this->intId));
 	}
 
 	/**
@@ -348,7 +348,7 @@ abstract class User extends System implements UserInterface, EquatableInterface,
 
 		$this->Database->prepare("UPDATE " . $this->strTable . " %s WHERE id=?")
 					   ->set($arrSet)
-					   ->execute($this->id);
+					   ->execute($this->intId);
 	}
 
 	/**
@@ -428,7 +428,7 @@ abstract class User extends System implements UserInterface, EquatableInterface,
 			return false;
 		}
 
-		$groups = StringUtil::deserialize($this->groups, true);
+		$groups = StringUtil::deserialize($this->arrData['groups'], true);
 
 		// No groups assigned
 		if (empty($groups))
@@ -519,7 +519,7 @@ abstract class User extends System implements UserInterface, EquatableInterface,
 
 	public function setUsername($username)
 	{
-		$this->username = $username;
+		$this->arrData['username'] = $username;
 
 		return $this;
 	}
@@ -529,17 +529,17 @@ abstract class User extends System implements UserInterface, EquatableInterface,
 	 */
 	public function getUserIdentifier(): string
 	{
-		if (null === $this->username)
+		if (null === $this->arrData['username'])
 		{
 			throw new \RuntimeException('Missing username in User object');
 		}
 
-		if (!\is_string($this->username))
+		if (!\is_string($this->arrData['username']))
 		{
-			throw new \RuntimeException(sprintf('Invalid type "%s" for username', \gettype($this->username)));
+			throw new \RuntimeException(sprintf('Invalid type "%s" for username', \gettype($this->arrData['username'])));
 		}
 
-		return $this->username;
+		return $this->arrData['username'];
 	}
 
 	/**
@@ -547,12 +547,12 @@ abstract class User extends System implements UserInterface, EquatableInterface,
 	 */
 	public function getPassword(): ?string
 	{
-		return $this->password;
+		return $this->arrData['password'];
 	}
 
 	public function setPassword($password)
 	{
-		$this->password = $password;
+		$this->arrData['password'] = $password;
 
 		return $this;
 	}
@@ -584,12 +584,12 @@ abstract class User extends System implements UserInterface, EquatableInterface,
 	{
 		return array
 		(
-			'id' => $this->id,
-			'username' => $this->username,
-			'password' => $this->password,
-			'disable' => $this->disable,
-			'start' => $this->start,
-			'stop' => $this->stop
+			'id' => $this->arrData['id'],
+			'username' => $this->arrData['username'],
+			'password' => $this->arrData['password'],
+			'disable' => $this->arrData['disable'],
+			'start' => $this->arrData['start'],
+			'stop' => $this->arrData['stop']
 		);
 	}
 
@@ -608,7 +608,7 @@ abstract class User extends System implements UserInterface, EquatableInterface,
 			return;
 		}
 
-		list($this->id, $this->username, $this->password, $this->disable, $this->start, $this->stop) = array_values($data);
+		list($this->arrData['id'], $this->arrData['username'], $this->arrData['password'], $this->arrData['disable'], $this->arrData['start'], $this->arrData['stop']) = array_values($data);
 	}
 
 	/**
@@ -633,22 +633,22 @@ abstract class User extends System implements UserInterface, EquatableInterface,
 			return false;
 		}
 
-		if ($this->password !== $user->password)
+		if ($this->arrData['password'] !== $user->password)
 		{
 			return false;
 		}
 
-		if ((bool) $this->disable !== (bool) $user->disable)
+		if ((bool) $this->arrData['disable'] !== (bool) $user->disable)
 		{
 			return false;
 		}
 
-		if ($this->start !== '' && $this->start > time())
+		if ($this->arrData['start'] !== '' && $this->arrData['start'] > time())
 		{
 			return false;
 		}
 
-		if ($this->stop !== '' && $this->stop <= time())
+		if ($this->arrData['stop'] !== '' && $this->arrData['stop'] <= time())
 		{
 			return false;
 		}


### PR DESCRIPTION
The current implementation can confuse object properties with user data. We had a situation in Slack, where a user added a field `roles` to the `tl_member` table. This leads to invalid data, because we unserialize the user data into magic properties (e.g. in https://github.com/contao/contao/blob/4.13/core-bundle/src/Resources/contao/classes/FrontendUser.php#L221), which would overwrite actual class properties.

I changed all user classes to not use the magic properties, because we want to use the actual user data. Having the `alexf` property set on the `BackendUser` makes little sense to me. It was only ever filled because of this magic unserialize behaviour, but that would work exactly the same with user data.