### PR TITLE
Document limitation for altcha widget within insecure environments

### DIFF
--- a/LIMITATIONS.md
+++ b/LIMITATIONS.md
@@ -14,7 +14,7 @@ item or from a news item to an event. They can only copy or move elements from e
 
 More information: https://github.com/contao/core/issues/5234
 
-## ALTCHA form field not working on unsafe environments within chromium based browsers
+## ALTCHA form field not working on unsafe environments
 
 The ALTCHA captcha does not work in insecure environments because it uses methods of the Web Crypto API.
 

--- a/LIMITATIONS.md
+++ b/LIMITATIONS.md
@@ -13,3 +13,9 @@ Non-admin users cannot copy or move content elements between different parent ty
 item or from a news item to an event. They can only copy or move elements from e.g. one article to another article.
 
 More information: https://github.com/contao/core/issues/5234
+
+## ALTCHA form field not working on unsafe environments within chromium based browsers
+
+The ALTCHA captcha does not work in insecure environments because it uses methods of the Web Crypto API.
+
+More information: https://github.com/contao/contao/issues/7369


### PR DESCRIPTION
Fixes #7369

ALTCHA widget can not be used within insecure environments on chromium based browsers.