### PR TITLE
Add the `playerColor` migration

### DIFF
--- a/core-bundle/src/Migration/Version413/PlayerColorMigration.php
+++ b/core-bundle/src/Migration/Version413/PlayerColorMigration.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Migration\Version413;
+
+use Contao\CoreBundle\Migration\AbstractMigration;
+use Contao\CoreBundle\Migration\MigrationResult;
+use Doctrine\DBAL\Connection;
+
+/**
+ * @internal
+ */
+class PlayerColorMigration extends AbstractMigration
+{
+    private Connection $connection;
+
+    public function __construct(Connection $connection)
+    {
+        $this->connection = $connection;
+    }
+
+    public function shouldRun(): bool
+    {
+        $schemaManager = $this->connection->createSchemaManager();
+
+        if (!$schemaManager->tablesExist(['tl_content'])) {
+            return false;
+        }
+
+        $columns = $schemaManager->listTableColumns('tl_content');
+
+        if (!isset($columns['playercolor'])) {
+            return false;
+        }
+
+        return (bool) $this->connection->fetchOne('SELECT TRUE from tl_content WHERE CHAR_LENGTH(playerColor) > 6');
+    }
+
+    public function run(): MigrationResult
+    {
+        $this->connection->executeQuery("UPDATE tl_content SET playerColor = '' WHERE CHAR_LENGTH(playerColor) > 6");
+
+        return $this->createResult(true);
+    }
+}

--- a/core-bundle/src/Migration/Version413/PlayerColorMigration.php
+++ b/core-bundle/src/Migration/Version413/PlayerColorMigration.php
@@ -47,7 +47,7 @@ class PlayerColorMigration extends AbstractMigration
 
     public function run(): MigrationResult
     {
-        $this->connection->executeQuery("UPDATE tl_content SET playerColor = '' WHERE CHAR_LENGTH(playerColor) > 6");
+        $this->connection->executeQuery("UPDATE tl_content SET playerColor = '' WHERE LENGTH(playerColor) > 6");
 
         return $this->createResult(true);
     }

--- a/core-bundle/src/Migration/Version413/PlayerColorMigration.php
+++ b/core-bundle/src/Migration/Version413/PlayerColorMigration.php
@@ -42,7 +42,7 @@ class PlayerColorMigration extends AbstractMigration
             return false;
         }
 
-        return (bool) $this->connection->fetchOne('SELECT TRUE from tl_content WHERE CHAR_LENGTH(playerColor) > 6');
+        return (bool) $this->connection->fetchOne('SELECT TRUE from tl_content WHERE LENGTH(playerColor) > 6');
     }
 
     public function run(): MigrationResult

--- a/core-bundle/src/Resources/config/migrations.yml
+++ b/core-bundle/src/Resources/config/migrations.yml
@@ -131,6 +131,11 @@ services:
         arguments:
             - '@database_connection'
 
+    contao.migration.version_413.player_color:
+        class: Contao\CoreBundle\Migration\Version413\PlayerColorMigration
+        arguments:
+            - '@database_connection'
+
     contao.migration.version_413.rel_lightbox:
         class: Contao\CoreBundle\Migration\Version413\RelLightboxMigration
         arguments:


### PR DESCRIPTION
Fixes #4449

This issue continues to plague some members of the community. Just to recap: in past Contao versions table fields were sometimes renamed during migration, if for example one field was dropped that has the same properties as another that was added. This might have been the case with the `com_default` field of `tl_content`, which under some circumstances might habe been renamed to `playerColor` at some point in the (distant) past - thus containing values that are longer than 6 characters. In Contao 4.13.2 we reduced the length of `playerColor` from `64` to `6` - which leads to

```
An exception occurred while executing a query: SQLSTATE[01000]: Warning: 1265    
Data truncated for column 'playerColor' at row 1
```

during the migration.

This PR alleviates that by introducing a simple migration that will take care of this specific issue.

We cannot take care of every such instance, as such issues can also occur by adding or removing extensions. However, I think we should at least take care of this specific issue as it looks like this is a common occurrence within the core bundles. Or - at most - we could introduce migrations for _all_ core fields, that we ever reduced in size at some point.