### PR TITLE
Recursively run StringUtil::decodeEntities on arrays

### DIFF
--- a/core-bundle/src/Resources/contao/classes/Versions.php
+++ b/core-bundle/src/Resources/contao/classes/Versions.php
@@ -572,7 +572,9 @@ class Versions extends Controller
 								array_walk_recursive($to[$k], static function (&$value) {
 									$value = StringUtil::decodeEntities($value);
 								});
-							} else {
+							}
+							else
+							{
 								$to[$k] = StringUtil::decodeEntities($to[$k]);
 							}
 
@@ -580,7 +582,9 @@ class Versions extends Controller
 								array_walk_recursive($from[$k], static function (&$value) {
 									$value = StringUtil::decodeEntities($value);
 								});
-							} else {
+							}
+							else
+							{
 								$from[$k] = StringUtil::decodeEntities($from[$k]);
 							}
 						}

--- a/core-bundle/src/Resources/contao/classes/Versions.php
+++ b/core-bundle/src/Resources/contao/classes/Versions.php
@@ -568,8 +568,21 @@ class Versions extends Controller
 						// Decode entities if the "decodeEntities" flag is not set (see #360)
 						if (empty($GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['eval']['decodeEntities']))
 						{
-							$to[$k] = StringUtil::decodeEntities($to[$k]);
-							$from[$k] = StringUtil::decodeEntities($from[$k]);
+							if (\is_array($to[$k])) {
+								array_walk_recursive($to[$k], static function (&$value) {
+									$value = StringUtil::decodeEntities($value);
+								});
+							} else {
+								$to[$k] = StringUtil::decodeEntities($to[$k]);
+							}
+
+							if (\is_array($from[$k])) {
+								array_walk_recursive($from[$k], static function (&$value) {
+									$value = StringUtil::decodeEntities($value);
+								});
+							} else {
+								$from[$k] = StringUtil::decodeEntities($from[$k]);
+							}
 						}
 
 						// Convert strings into arrays

--- a/core-bundle/src/Resources/contao/library/Contao/StringUtil.php
+++ b/core-bundle/src/Resources/contao/library/Contao/StringUtil.php
@@ -221,11 +221,6 @@ class StringUtil
 	 */
 	public static function decodeEntities($strString, $strQuoteStyle=ENT_QUOTES, $strCharset=null)
 	{
-		if (\is_array($strString))
-		{
-			return array_map(__METHOD__, $strString);
-		}
-
 		if ((string) $strString === '')
 		{
 			return '';

--- a/core-bundle/src/Resources/contao/library/Contao/StringUtil.php
+++ b/core-bundle/src/Resources/contao/library/Contao/StringUtil.php
@@ -221,6 +221,11 @@ class StringUtil
 	 */
 	public static function decodeEntities($strString, $strQuoteStyle=ENT_QUOTES, $strCharset=null)
 	{
+		if (\is_array($strString))
+		{
+			return array_map(__METHOD__, $strString);
+		}
+
 		if ((string) $strString === '')
 		{
 			return '';


### PR DESCRIPTION
I got this error in Sentry. Somehow, my version data contains an array in values (I'm using m-vo/group-widget).

<img width="924" alt="Bildschirmfoto 2024-07-26 um 17 39 05" src="https://github.com/user-attachments/assets/2aba5981-0e15-4529-ab36-295f278ec07b">

