### PR TITLE
Skip database backups if the remaining migrations will not be executed

### DIFF
--- a/core-bundle/src/Command/MigrateCommand.php
+++ b/core-bundle/src/Command/MigrateCommand.php
@@ -110,9 +110,10 @@ class MigrateCommand extends Command
     private function backup(InputInterface $input): bool
     {
         $asJson = 'ndjson' === $input->getOption('format');
+        $skipDropStatements = !$input->isInteractive() && !$input->getOption('with-deletes');
 
         // Return early if there is no work to be done
-        if (!$this->hasWorkToDo()) {
+        if (!$this->hasWorkToDo($skipDropStatements)) {
             if (!$asJson) {
                 $this->io->info('Database dump skipped because there are no migrations to execute.');
             }
@@ -207,14 +208,14 @@ class MigrateCommand extends Command
         return Command::SUCCESS;
     }
 
-    private function hasWorkToDo(): bool
+    private function hasWorkToDo(bool $skipDropStatements = false): bool
     {
         // There are some pending migrations
         if ($this->migrations->hasPending()) {
             return true;
         }
 
-        return [] !== $this->commandCompiler->compileCommands();
+        return [] !== $this->commandCompiler->compileCommands($skipDropStatements);
     }
 
     private function executeMigrations(bool &$dryRun, bool $asJson, string|null $specifiedHash = null): bool

--- a/core-bundle/tests/Command/MigrateCommandTest.php
+++ b/core-bundle/tests/Command/MigrateCommandTest.php
@@ -80,9 +80,7 @@ class MigrateCommandTest extends TestCase
             ->expects($this->atLeastOnce())
             ->method('compileCommands')
             ->willReturnCallback(
-                function (bool $doNotDropColumns = false): array {
-                    return $doNotDropColumns ? [] : ['DROP QUERY'];
-                },
+                static fn (bool $doNotDropColumns = false): array => $doNotDropColumns ? [] : ['DROP QUERY'],
             )
         ;
 

--- a/core-bundle/tests/Command/MigrateCommandTest.php
+++ b/core-bundle/tests/Command/MigrateCommandTest.php
@@ -69,6 +69,24 @@ class MigrateCommandTest extends TestCase
     /**
      * @group legacy
      */
+    public function testAbortsEarlyIfNonInteractiveAndThereAreOnlyDropMigrations(): void
+    {
+        $this->expectDeprecation('%sgetWrappedConnection method is deprecated%s');
+
+        $backupManager = $this->createBackupManager(false);
+        $command = $this->getCommand([], [], null, $backupManager);
+        $tester = new CommandTester($command);
+        $code = $tester->execute([], ['interactive' => false]);
+        $display = $tester->getDisplay();
+
+        $this->assertSame(0, $code);
+        $this->assertMatchesRegularExpression('/Database dump skipped because there are no migrations to execute./', $display);
+        $this->assertMatchesRegularExpression('/All migrations completed/', $display);
+    }
+
+    /**
+     * @group legacy
+     */
     public function testExecutesBackupIfPendingSchemaDiff(): void
     {
         $this->expectDeprecation('%sgetWrappedConnection method is deprecated%s');

--- a/core-bundle/tests/Command/MigrateCommandTest.php
+++ b/core-bundle/tests/Command/MigrateCommandTest.php
@@ -80,7 +80,7 @@ class MigrateCommandTest extends TestCase
             ->expects($this->atLeastOnce())
             ->method('compileCommands')
             ->willReturnCallback(
-                static fn (bool $doNotDropColumns = false): array => $doNotDropColumns ? [] : ['DROP QUERY'],
+                static fn (bool $skipDropStatements = false): array => $skipDropStatements ? [] : ['DROP QUERY'],
             )
         ;
 

--- a/core-bundle/tests/Command/MigrateCommandTest.php
+++ b/core-bundle/tests/Command/MigrateCommandTest.php
@@ -74,7 +74,19 @@ class MigrateCommandTest extends TestCase
         $this->expectDeprecation('%sgetWrappedConnection method is deprecated%s');
 
         $backupManager = $this->createBackupManager(false);
-        $command = $this->getCommand([], [], null, $backupManager);
+
+        $commandCompiler = $this->createMock(CommandCompiler::class);
+        $commandCompiler
+            ->expects($this->atLeastOnce())
+            ->method('compileCommands')
+            ->willReturnCallback(
+                function (bool $doNotDropColumns = false): array {
+                    return $doNotDropColumns ? [] : ['DROP QUERY'];
+                },
+            )
+        ;
+
+        $command = $this->getCommand([], [], $commandCompiler, $backupManager);
         $tester = new CommandTester($command);
         $code = $tester->execute([], ['interactive' => false]);
         $display = $tester->getDisplay();


### PR DESCRIPTION
Same as https://github.com/contao/contao/pull/7357 for Contao 5.3.