### PR TITLE
Render partial tree instead of disabling root trails with breadcrumb

### DIFF
--- a/core-bundle/src/Resources/contao/classes/Backend.php
+++ b/core-bundle/src/Resources/contao/classes/Backend.php
@@ -992,7 +992,7 @@ abstract class Backend extends Controller
 
 		// Limit tree and disable root trails
 		$GLOBALS['TL_DCA']['tl_page']['list']['sorting']['root'] = array($intNode);
-		$GLOBALS['TL_DCA']['tl_page']['list']['sorting']['showRootTrails'] = false;
+		$GLOBALS['TL_DCA']['tl_page']['list']['sorting']['visibleRoot'] = $intNode;
 
 		// Add root link
 		$arrLinks[] = Image::getHtml('pagemounts.svg') . ' <a href="' . self::addToUrl('pn=0') . '" title="' . StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['selectAllNodes']) . '">' . $GLOBALS['TL_LANG']['MSC']['filterAll'] . '</a>';

--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -3782,7 +3782,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 			}
 			else
 			{
-				// Make sure we use the topmost root IDs only from all the visible root trail ids and also ensure correct sorting
+				// Make sure we use the topmost root IDs only from all the visible root trail IDs and also ensure correct sorting
 				$topMostRootIds = $this->Database->prepare("SELECT id FROM $table WHERE (pid=0 OR pid IS NULL) AND id IN (".implode(',', array_merge($this->visibleRootTrails, $this->root)).")".($this->Database->fieldExists('sorting', $table) ? ' ORDER BY sorting, id' : ''))
 												 ->execute()
 												 ->fetchEach('id')

--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -3776,10 +3776,18 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 
 		if (!empty($this->visibleRootTrails))
 		{
-			// Make sure we use the topmost root IDs only from all the visible root trail ids and also ensure correct sorting
-			$topMostRootIds = $this->Database->prepare("SELECT id FROM $table WHERE (pid=0 OR pid IS NULL) AND id IN (" . implode(',', array_merge($this->visibleRootTrails, $this->root)) . ")" . ($this->Database->fieldExists('sorting', $table) ? ' ORDER BY sorting, id' : ''))
-											 ->execute()
-											 ->fetchEach('id');
+			if (isset($GLOBALS['TL_DCA']['tl_page']['list']['sorting']['visibleRoot']))
+			{
+				$topMostRootIds = array($GLOBALS['TL_DCA']['tl_page']['list']['sorting']['visibleRoot']);
+			}
+			else
+			{
+				// Make sure we use the topmost root IDs only from all the visible root trail ids and also ensure correct sorting
+				$topMostRootIds = $this->Database->prepare("SELECT id FROM $table WHERE (pid=0 OR pid IS NULL) AND id IN (".implode(',', array_merge($this->visibleRootTrails, $this->root)).")".($this->Database->fieldExists('sorting', $table) ? ' ORDER BY sorting, id' : ''))
+												 ->execute()
+												 ->fetchEach('id')
+				;
+			}
 		}
 
 		// Call a recursive function that builds the tree


### PR DESCRIPTION
Fixes https://github.com/contao/contao/issues/7366

As I tried to describe in the call, everything works fine if the tree is rendered from the root. You can see this in the current system by not filtering the tree for `Page_1`. The problem happens when the breadcrumb helper disables `showRootTrails`.

/cc @zoglo 