### PR TITLE
Clone content elements with all data

### DIFF
--- a/core-bundle/contao/elements/ContentAlias.php
+++ b/core-bundle/contao/elements/ContentAlias.php
@@ -36,7 +36,7 @@ class ContentAlias extends ContentElement
 		System::getContainer()->get('contao.cache.entity_tags')->tagWithModelInstance($objElement);
 
 		// Clone the model, so we do not modify the shared model in the registry
-		$objModel = $objElement->cloneOriginal();
+		$objModel = $objElement->cloneDetached();
 		$objModel->origId = $objModel->origId ?: $objModel->id;
 		$objModel->id = $this->id;
 

--- a/core-bundle/contao/elements/ContentModule.php
+++ b/core-bundle/contao/elements/ContentModule.php
@@ -33,7 +33,7 @@ class ContentModule extends ContentElement
 		}
 
 		// Clone the model, so we do not modify the shared model in the registry
-		$objModel = $objModule->cloneOriginal();
+		$objModel = $objModule->cloneDetached();
 		$cssID = StringUtil::deserialize($objModel->cssID, true);
 
 		// Override the CSS ID (see #305)

--- a/core-bundle/contao/library/Contao/Controller.php
+++ b/core-bundle/contao/library/Contao/Controller.php
@@ -563,7 +563,7 @@ abstract class Controller extends System
 			return '';
 		}
 
-		$objRow = clone $objRow;
+		$objRow = $objRow->cloneDetached();
 		$objRow->typePrefix = 'ce_';
 		$strStopWatchId = 'contao.content_element.' . $objRow->type . ' (ID ' . $objRow->id . ')';
 

--- a/core-bundle/contao/library/Contao/Model.php
+++ b/core-bundle/contao/library/Contao/Model.php
@@ -224,6 +224,20 @@ abstract class Model
 	}
 
 	/**
+	 * Clone a model with all data and prevent saving
+	 *
+	 * @return static The model
+	 */
+	public function cloneDetached()
+	{
+		$clone = clone $this;
+		$clone->setRow($this->row());
+		$clone->preventSaving(false);
+
+		return $clone;
+	}
+
+	/**
 	 * Set an object property
 	 *
 	 * @param string $strKey   The property name

--- a/core-bundle/contao/library/Contao/Model.php
+++ b/core-bundle/contao/library/Contao/Model.php
@@ -231,7 +231,7 @@ abstract class Model
 	public function cloneDetached()
 	{
 		$clone = clone $this;
-		$clone->setRow($this->row());
+		$clone->arrData[static::$strPk] = $this->arrData[static::$strPk];
 		$clone->preventSaving(false);
 
 		return $clone;

--- a/core-bundle/contao/widgets/SerpPreview.php
+++ b/core-bundle/contao/widgets/SerpPreview.php
@@ -152,7 +152,7 @@ class SerpPreview extends Widget
 		$placeholder = bin2hex(random_bytes(10));
 
 		// Pass a detached clone with the alias set to the placeholder
-		$tempModel = $model->cloneOriginal();
+		$tempModel = $model->cloneDetached();
 		$tempModel->origAlias = $tempModel->$aliasField;
 		$tempModel->$aliasField = $placeholder;
 		$tempModel->preventSaving(false);


### PR DESCRIPTION
Unfortunately, https://github.com/contao/contao/pull/7364 completely breaks stuff (e.g. the fragment compositor) because it removes the primary key (ID) when cloning.

What we actually want in all cases where we previously used `Model::cloneOriginal` was to make a copy of the current object, with all its data, but prevent it from being saved because we will add "invalid" properties.