### PR TITLE
Make the theme icons forward compatible

### DIFF
--- a/core-bundle/contao/dca/tl_theme.php
+++ b/core-bundle/contao/dca/tl_theme.php
@@ -74,7 +74,6 @@ $GLOBALS['TL_DCA']['tl_theme'] = array
 		(
 			'edit',
 			'delete',
-			'show',
 			'modules' => array
 			(
 				'href'                => 'table=tl_module',
@@ -90,6 +89,7 @@ $GLOBALS['TL_DCA']['tl_theme'] = array
 				'href'                => 'table=tl_image_size',
 				'icon'                => 'sizes.svg',
 			),
+			'show',
 			'exportTheme' => array
 			(
 				'href'                => 'key=exportTheme',


### PR DESCRIPTION
Contao 5.3:

<img width="201" alt="" src="https://github.com/user-attachments/assets/41056e58-b026-41d5-9e01-6c8d208d4a0f">

Contao 5.4:

<img width="219" alt="" src="https://github.com/user-attachments/assets/8899e883-c1d8-4c4f-a56e-5c4cf3a0dc25">

Related discussion: https://contao.slack.com/archives/CJT61P8R1/p1722515496841189