### PR TITLE
Load template options for the active record

### DIFF
--- a/core-bundle/src/EventListener/DataContainer/TemplateOptionsListener.php
+++ b/core-bundle/src/EventListener/DataContainer/TemplateOptionsListener.php
@@ -50,7 +50,7 @@ class TemplateOptionsListener
 
         $type = $overrideAll
             ? $this->getCommonOverrideAllType($dc)
-            : $dc->getCurrentRecord()['type'] ?? null;
+            : $dc->activeRecord->type ?? null;
 
         if (null === $type) {
             // Add a blank option that allows to reset all custom templates to the default


### PR DESCRIPTION
This is an attempt to fix #7404

This still needs to be discussed rather this is the correct approach because `$objActiveRecord` seems to be deprecated and `$dc->getCurrentRecord()` should be used.

This might be more of a problem with [caching](https://github.com/contao/contao/blob/3e01a5ee81301920bd75a425c06f9aec50680871/core-bundle/contao/classes/DataContainer.php#L1860)

### The issue

What happens in that issue is that the template options for the currentRecord (the former) are being used out of the [cache](https://github.com/contao/contao/blob/3e01a5ee81301920bd75a425c06f9aec50680871/core-bundle/contao/classes/DataContainer.php#L1860) rather than the activeRecord that just has been created.

Since there's no template options for the `root_page_dependent_modules`, then switching to any module using fragments, the error is triggered (since it can't find any fragments aka twig templates for the previously 'saved' type of `root_page_dependent_modules`).

### Solution

This PR correctly checks the template options for the activeRecord