### PR TITLE
Fix an error if a record in the clipboard is deleted before pasting

### DIFF
--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -244,6 +244,24 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 			$session[$strRefererId][$this->strTable] = Environment::get('requestUri');
 			$objSession->set($strKey, $session);
 		}
+
+		$arrClipboard = $objSession->get('CLIPBOARD');
+		if (!empty($arrClipboard[$this->strTable]) && $arrClipboard[$this->strTable]['mode'] != 'create')
+		{
+			if (\is_array($arrClipboard[$this->strTable]['id']))
+			{
+				$arrClipboard[$this->strTable]['id'] = array_filter($arrClipboard[$this->strTable]['id'], fn ($record) => $this->getCurrentRecord($record) !== null);
+				if (empty($arrClipboard[$this->strTable]['id']))
+				{
+					unset($arrClipboard[$this->strTable]);
+				}
+			}
+			elseif ($this->getCurrentRecord($arrClipboard[$this->strTable]['id']) === null)
+			{
+				unset($arrClipboard[$this->strTable]);
+			}
+			$objSession->set('CLIPBOARD', $arrClipboard);
+		}
 	}
 
 	/**
@@ -3861,29 +3879,6 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 		{
 			$blnClipboard = true;
 			$arrClipboard = $arrClipboard[$this->strTable];
-			if (\is_array($arrClipboard['id']))
-			{
-				foreach ($arrClipboard['id'] as $k=>$v)
-				{
-					if ($this->getCurrentRecord($v) === null)
-					{
-						unset($arrClipboard['id'][$k]);
-					}
-				}
-				if (empty($arrClipboard['id']))
-				{
-					$blnClipboard = false;
-					$arrClipboard = null;
-				}
-			}
-			else
-			{
-				if ($this->getCurrentRecord($arrClipboard['id']) === null)
-				{
-					$blnClipboard = false;
-					$arrClipboard = null;
-				}
-			}
 		}
 		else
 		{

--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -245,33 +245,30 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 			$objSession->set($strKey, $session);
 		}
 
-		$blnClipboardModified = false;
 		if (!empty($arrClipboard[$this->strTable]) && $arrClipboard[$this->strTable]['mode'] != 'create')
 		{
 			if (\is_array($arrClipboard[$this->strTable]['id']))
 			{
 				$arrIds = $arrClipboard[$this->strTable]['id'];
 				$arrFilteredIds = array_filter($arrIds, fn ($id) => $this->getCurrentRecord($id) !== null);
+
 				if ($arrFilteredIds !== $arrIds)
 				{
-					$blnClipboardModified = true;
 					$arrClipboard[$this->strTable]['id'] = $arrFilteredIds;
+
 					if (empty($arrFilteredIds))
 					{
 						unset($arrClipboard[$this->strTable]);
 					}
+
+					$objSession->set('CLIPBOARD', $arrClipboard);
 				}
 			}
 			elseif ($this->getCurrentRecord($arrClipboard[$this->strTable]['id']) === null)
 			{
-				$blnClipboardModified = true;
 				unset($arrClipboard[$this->strTable]);
+				$objSession->set('CLIPBOARD', $arrClipboard);
 			}
-		}
-
-		if ($blnClipboardModified)
-		{
-			$objSession->set('CLIPBOARD', $arrClipboard);
 		}
 	}
 

--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -138,6 +138,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 		}
 
 		$ids = null;
+		$arrClipboard = $objSession->get('CLIPBOARD');
 
 		// Set IDs
 		if (Input::post('FORM_SUBMIT') == 'tl_select' || (\in_array(Input::post('FORM_SUBMIT'), array($strTable, $strTable . '_all')) && \in_array(Input::get('act'), array('editAll', 'overrideAll'))))
@@ -174,7 +175,6 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 			}
 			elseif (Input::post('cut') !== null || Input::post('copy') !== null || Input::post('copyMultiple') !== null)
 			{
-				$arrClipboard = $objSession->get('CLIPBOARD');
 				$security = $container->get('security.helper');
 
 				$mode = Input::post('cut') !== null ? 'cutAll' : 'copyAll';
@@ -245,7 +245,6 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 			$objSession->set($strKey, $session);
 		}
 
-		$arrClipboard = $objSession->get('CLIPBOARD');
 		if (!empty($arrClipboard[$this->strTable]) && $arrClipboard[$this->strTable]['mode'] != 'create')
 		{
 			if (\is_array($arrClipboard[$this->strTable]['id']))

--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -3861,17 +3861,19 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 		{
 			$blnClipboard = true;
 			$arrClipboard = $arrClipboard[$this->strTable];
-			if(is_array($arrClipboard['id']))
+			if (\is_array($arrClipboard['id']))
 			{
 				foreach ($arrClipboard['id'] as $k=>$v)
 				{
-					if($this->getCurrentRecord($v) === null)
+					if ($this->getCurrentRecord($v) === null)
 					{
 						unset($arrClipboard['id'][$k]);
 					}
 				}
-			}else{
-				if($this->getCurrentRecord($arrClipboard['id']) === null)
+			}
+			else
+			{
+				if ($this->getCurrentRecord($arrClipboard['id']) === null)
 				{
 					$blnClipboard = false;
 					$arrClipboard = null;

--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -3870,6 +3870,11 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 						unset($arrClipboard['id'][$k]);
 					}
 				}
+				if (empty($arrClipboard['id']))
+				{
+					$blnClipboard = false;
+					$arrClipboard = null;
+				}
 			}
 			else
 			{

--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -245,20 +245,32 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 			$objSession->set($strKey, $session);
 		}
 
+		$blnClipboardModified = false;
 		if (!empty($arrClipboard[$this->strTable]) && $arrClipboard[$this->strTable]['mode'] != 'create')
 		{
 			if (\is_array($arrClipboard[$this->strTable]['id']))
 			{
-				$arrClipboard[$this->strTable]['id'] = array_filter($arrClipboard[$this->strTable]['id'], fn ($record) => $this->getCurrentRecord($record) !== null);
-				if (empty($arrClipboard[$this->strTable]['id']))
+				$arrIds = $arrClipboard[$this->strTable]['id'];
+				$arrFilteredIds = array_filter($arrIds, fn ($id) => $this->getCurrentRecord($id) !== null);
+				if ($arrFilteredIds !== $arrIds)
 				{
-					unset($arrClipboard[$this->strTable]);
+					$blnClipboardModified = true;
+					$arrClipboard[$this->strTable]['id'] = $arrFilteredIds;
+					if (empty($arrFilteredIds))
+					{
+						unset($arrClipboard[$this->strTable]);
+					}
 				}
 			}
 			elseif ($this->getCurrentRecord($arrClipboard[$this->strTable]['id']) === null)
 			{
+				$blnClipboardModified = true;
 				unset($arrClipboard[$this->strTable]);
 			}
+		}
+
+		if ($blnClipboardModified)
+		{
 			$objSession->set('CLIPBOARD', $arrClipboard);
 		}
 	}

--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -3861,6 +3861,22 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 		{
 			$blnClipboard = true;
 			$arrClipboard = $arrClipboard[$this->strTable];
+			if(is_array($arrClipboard['id']))
+			{
+				foreach ($arrClipboard['id'] as $k=>$v)
+				{
+					if($this->getCurrentRecord($v) === null)
+					{
+						unset($arrClipboard['id'][$k]);
+					}
+				}
+			}else{
+				if($this->getCurrentRecord($arrClipboard['id']) === null)
+				{
+					$blnClipboard = false;
+					$arrClipboard = null;
+				}
+			}
 		}
 		else
 		{


### PR DESCRIPTION
Fixes https://community.contao.org/de/showthread.php?87194-Fehler-beim-%C3%96ffnen-von-Artikel
This does only affect Contao 5, not 4.13.

If a record is copied or cut and then deleted before it is removed from the clipboard by pasting, an internal server error is displayed with the stack trace below. This stack trace is from cutting an entry, when copying it looks a little different, but basically the same problem.

This PR clears the clipboard if the current record in DC_Table->getClipboardPermission() is null.

I'm not sure if this fix is ideal, especially because the return parameter, which should be an action, is null with this change.
```
at vendor/contao/core-bundle/src/Security/DataContainer/UpdateAction.php:20
at Contao\CoreBundle\Security\DataContainer\UpdateAct ion->__construct()
(vendor/contao/core-bundle/contao/drivers/DC_Table.php:6756)
at Contao\DC_Table->getClipboardPermission()
(vendor/contao/core-bundle/contao/drivers/DC_Table.php:6741)
at Contao\DC_Table->canPasteClipboard()
(vendor/contao/core-bundle/contao/drivers/DC_Table.php:4479)
at Contao\DC_Table->generateTree()
(vendor/contao/core-bundle/contao/drivers/DC_Table.php:3971)
at Contao\DC_Table->treeView()
(vendor/contao/core-bundle/contao/drivers/DC_Table.php:427)
at Contao\DC_Table->showAll()
(vendor/contao/core-bundle/contao/classes/Backend.php:546)
at Contao\Backend->getBackendModule()
(vendor/contao/core-bundle/contao/controllers/BackendMain.php:144)
at Contao\BackendMain->run()
(vendor/contao/core-bundle/src/Controller/BackendController.php:44)
at Contao\CoreBundle\Controller\BackendController->mainAction()
(vendor/symfony/http-kernel/HttpKernel.php:181)
at Symfony\Component\HttpKernel\HttpKernel->handleRaw()
(vendor/symfony/http-kernel/HttpKernel.php:76)
at Symfony\Component\HttpKernel\HttpKernel->handle()
(vendor/symfony/http-kernel/Kernel.php:197)
at Symfony\Component\HttpKernel\Kernel->handle()
(web/index.php:42)
```