### PR TITLE
Encode mailto addresses in the Markdown element

### DIFF
--- a/core-bundle/contao/templates/twig/content_element/markdown.html.twig
+++ b/core-bundle/contao/templates/twig/content_element/markdown.html.twig
@@ -1,5 +1,5 @@
 {% extends "@Contao/content_element/_base.html.twig" %}
 
 {% block content %}
-    {{ content|raw }}
+    {{ content|encode_email|raw }}
 {% endblock %}


### PR DESCRIPTION
Fixes https://github.com/contao/contao/issues/7414

In markdown, you can have `mailto` adresses with subject etc. and we should also encode those:

```
Hello [foo\@bar.com](mailto:foo@bar.com?subject=Test) whatever.
```