### PR TITLE
Encode e-mails in the `MarkdownController`

### DIFF
--- a/core-bundle/src/Controller/ContentElement/MarkdownController.php
+++ b/core-bundle/src/Controller/ContentElement/MarkdownController.php
@@ -18,6 +18,7 @@ use Contao\CoreBundle\InsertTag\CommonMarkExtension;
 use Contao\CoreBundle\InsertTag\InsertTagParser;
 use Contao\FilesModel;
 use Contao\Input;
+use Contao\StringUtil;
 use Contao\Template;
 use League\CommonMark\ConverterInterface;
 use League\CommonMark\Environment\Environment;
@@ -61,7 +62,9 @@ class MarkdownController extends AbstractContentElementController
         $input = $this->getContaoAdapter(Input::class);
         $html = $this->createConverter($model, $request)->convert($markdown)->getContent();
 
-        $template->content = $input->stripTags($html, $config->get('allowedTags'), $config->get('allowedAttributes'));
+        $template->content = StringUtil::encodeEmail(
+            $input->stripTags($html, $config->get('allowedTags'), $config->get('allowedAttributes'))
+        );
 
         return $template->getResponse();
     }


### PR DESCRIPTION
Same as https://github.com/contao/contao/pull/7416 for 4.13. I didn't bother adding it to the old Markdown element because there's a solution already: Switch to the new Markdown element which you'll have to do to upgrade to v5 anyway.