### PR TITLE
Cast `$alexf` data to array

### DIFF
--- a/core-bundle/src/Resources/contao/classes/BackendUser.php
+++ b/core-bundle/src/Resources/contao/classes/BackendUser.php
@@ -175,6 +175,9 @@ class BackendUser extends User
 
 			case 'fop':
 				return \is_array($this->arrData['fop']) ? $this->arrData['fop'] : ($this->arrData['fop'] ? array($this->arrData['fop']) : false);
+
+			case 'alexf':
+				return \is_array($this->arrData[$strKey] ?? null) ? $this->arrData[$strKey] : array();
 		}
 
 		return parent::__get($strKey);

--- a/core-bundle/src/Resources/contao/classes/BackendUser.php
+++ b/core-bundle/src/Resources/contao/classes/BackendUser.php
@@ -177,7 +177,7 @@ class BackendUser extends User
 				return \is_array($this->arrData['fop']) ? $this->arrData['fop'] : ($this->arrData['fop'] ? array($this->arrData['fop']) : false);
 
 			case 'alexf':
-				return \is_array($this->arrData[$strKey] ?? null) ? $this->arrData[$strKey] : array();
+				return $this->arrData['alexf'] ?? array();
 		}
 
 		return parent::__get($strKey);


### PR DESCRIPTION
Fixes #7432

Removing the `$alexf` member variable in #7365 turns out to be overzealous. The member variable needs to stay in order to ensure that it is always an array.