### PR TITLE
Deprecate the service annotations

### DIFF
--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -1,5 +1,10 @@
 # Deprecated features
 
+## Service annotations
+
+All of Contao's service annotations have been deprecated in Contao 5.4 and will no longer work in Contao 6. Use the
+respective PHP attributes instead, e.g. `#[AsCallback(…)]` instead of `@Callback(…)` etc.
+
 ## $GLOBALS['objPage']
 
 Both `$GLOBALS['objPage']` and `global $objPage` have been deprecated in Contao 5.4 and will no longer work in Contao 6.
@@ -16,8 +21,8 @@ for links and assets instead.
 
 ## $GLOBALS['TL_LANGUAGE']
 
-Using the global `$GLOBALS['TL_LANGUAGE']` has been deprecated in Contao 4.0 and
-will no longer work in Contao 6. Use the locale from the request object instead:
+Using the global `$GLOBALS['TL_LANGUAGE']` has been deprecated in Contao 4.0 and will no longer work in Contao 6. Use
+the locale from the request object instead:
 
 ```php
 $locale = System::getContainer()->get('request_stack')->getCurrentRequest()->getLocale();

--- a/core-bundle/src/ServiceAnnotation/Callback.php
+++ b/core-bundle/src/ServiceAnnotation/Callback.php
@@ -29,6 +29,8 @@ use Terminal42\ServiceAnnotationBundle\Annotation\ServiceTagInterface;
  *     @Attribute("target", type="string", required=true),
  *     @Attribute("priority", type="int"),
  * })
+ *
+ * @deprecated Use the #[AsCallback] attribute instead.
  */
 final class Callback implements ServiceTagInterface
 {
@@ -40,6 +42,8 @@ final class Callback implements ServiceTagInterface
 
     public function getName(): string
     {
+        trigger_deprecation('contao/core-bundle', '5.4', 'Using the @Callback annotation has been deprecated and will no longer work in Contao 6. Use the #[AsCallback] attribute instead.');
+
         return 'contao.callback';
     }
 

--- a/core-bundle/src/ServiceAnnotation/Callback.php
+++ b/core-bundle/src/ServiceAnnotation/Callback.php
@@ -30,7 +30,8 @@ use Terminal42\ServiceAnnotationBundle\Annotation\ServiceTagInterface;
  *     @Attribute("priority", type="int"),
  * })
  *
- * @deprecated Use the #[AsCallback] attribute instead.
+ * @deprecated Deprecated since Contao 5.4, to be removed in Contao 6;
+ *             use the #[AsCallback] attribute instead
  */
 final class Callback implements ServiceTagInterface
 {

--- a/core-bundle/src/ServiceAnnotation/ContentElement.php
+++ b/core-bundle/src/ServiceAnnotation/ContentElement.php
@@ -32,7 +32,8 @@ use Doctrine\Common\Annotations\Annotation\Target;
  *     @Attribute("attributes", type = "array"),
  * })
  *
- * @deprecated Use the #[AsContentElement] attribute instead.
+ * @deprecated Deprecated since Contao 5.4, to be removed in Contao 6;
+ *             use the #[AsContentElement] attribute instead
  */
 final class ContentElement extends AbstractFragmentAnnotation
 {

--- a/core-bundle/src/ServiceAnnotation/ContentElement.php
+++ b/core-bundle/src/ServiceAnnotation/ContentElement.php
@@ -31,11 +31,15 @@ use Doctrine\Common\Annotations\Annotation\Target;
  *     @Attribute("renderer", type = "string"),
  *     @Attribute("attributes", type = "array"),
  * })
+ *
+ * @deprecated Use the #[AsContentElement] attribute instead.
  */
 final class ContentElement extends AbstractFragmentAnnotation
 {
     public function getName(): string
     {
+        trigger_deprecation('contao/core-bundle', '5.4', 'Using the @ContentElement annotation has been deprecated and will no longer work in Contao 6. Use the #[AsContentElement] attribute instead.');
+
         return ContentElementReference::TAG_NAME;
     }
 }

--- a/core-bundle/src/ServiceAnnotation/CronJob.php
+++ b/core-bundle/src/ServiceAnnotation/CronJob.php
@@ -28,7 +28,8 @@ use Terminal42\ServiceAnnotationBundle\Annotation\ServiceTagInterface;
  *     @Attribute("value", type="string", required=true)
  * })
  *
- * @deprecated Use the #[AsCronJob] attribute instead.
+ * @deprecated Deprecated since Contao 5.4, to be removed in Contao 6;
+ *             use the #[AsCronJob] attribute instead
  */
 final class CronJob implements ServiceTagInterface
 {

--- a/core-bundle/src/ServiceAnnotation/CronJob.php
+++ b/core-bundle/src/ServiceAnnotation/CronJob.php
@@ -27,6 +27,8 @@ use Terminal42\ServiceAnnotationBundle\Annotation\ServiceTagInterface;
  * @Attributes({
  *     @Attribute("value", type="string", required=true)
  * })
+ *
+ * @deprecated Use the #[AsCronJob] attribute instead.
  */
 final class CronJob implements ServiceTagInterface
 {
@@ -34,6 +36,8 @@ final class CronJob implements ServiceTagInterface
 
     public function getName(): string
     {
+        trigger_deprecation('contao/core-bundle', '5.4', 'Using the @CronJob annotation has been deprecated and will no longer work in Contao 6. Use the #[AsCronJob] attribute instead.');
+
         return 'contao.cronjob';
     }
 

--- a/core-bundle/src/ServiceAnnotation/FrontendModule.php
+++ b/core-bundle/src/ServiceAnnotation/FrontendModule.php
@@ -30,11 +30,15 @@ use Doctrine\Common\Annotations\Annotation\Target;
  *     @Attribute("template", type="string"),
  *     @Attribute("renderer", type="string"),
  * })
+ *
+ * @deprecated Use the #[AsFrontendModule] attribute instead.
  */
 final class FrontendModule extends AbstractFragmentAnnotation
 {
     public function getName(): string
     {
+        trigger_deprecation('contao/core-bundle', '5.4', 'Using the @FrontendModule annotation has been deprecated and will no longer work in Contao 6. Use the #[AsFrontendModule] attribute instead.');
+
         return FrontendModuleReference::TAG_NAME;
     }
 }

--- a/core-bundle/src/ServiceAnnotation/FrontendModule.php
+++ b/core-bundle/src/ServiceAnnotation/FrontendModule.php
@@ -31,7 +31,8 @@ use Doctrine\Common\Annotations\Annotation\Target;
  *     @Attribute("renderer", type="string"),
  * })
  *
- * @deprecated Use the #[AsFrontendModule] attribute instead.
+ * @deprecated Deprecated since Contao 5.4, to be removed in Contao 6;
+ *             use the #[AsFrontendModule] attribute instead
  */
 final class FrontendModule extends AbstractFragmentAnnotation
 {

--- a/core-bundle/src/ServiceAnnotation/Hook.php
+++ b/core-bundle/src/ServiceAnnotation/Hook.php
@@ -28,6 +28,8 @@ use Terminal42\ServiceAnnotationBundle\Annotation\ServiceTagInterface;
  *     @Attribute("value", type="string", required=true),
  *     @Attribute("priority", type="int"),
  * })
+ *
+ * @deprecated Use the #[AsHook] attribute instead.
  */
 final class Hook implements ServiceTagInterface
 {
@@ -37,6 +39,8 @@ final class Hook implements ServiceTagInterface
 
     public function getName(): string
     {
+        trigger_deprecation('contao/core-bundle', '5.4', 'Using the @Hook annotation has been deprecated and will no longer work in Contao 6. Use the #[AsHook] attribute instead.');
+
         return 'contao.hook';
     }
 

--- a/core-bundle/src/ServiceAnnotation/Hook.php
+++ b/core-bundle/src/ServiceAnnotation/Hook.php
@@ -29,7 +29,8 @@ use Terminal42\ServiceAnnotationBundle\Annotation\ServiceTagInterface;
  *     @Attribute("priority", type="int"),
  * })
  *
- * @deprecated Use the #[AsHook] attribute instead.
+ * @deprecated Deprecated since Contao 5.4, to be removed in Contao 6;
+ *             use the #[AsHook] attribute instead
  */
 final class Hook implements ServiceTagInterface
 {

--- a/core-bundle/src/ServiceAnnotation/Page.php
+++ b/core-bundle/src/ServiceAnnotation/Page.php
@@ -24,6 +24,8 @@ use Terminal42\ServiceAnnotationBundle\Annotation\ServiceTagInterface;
  * @Target({"CLASS", "METHOD"})
  *
  * @see Route
+ *
+ * @deprecated Use the #[AsPage] attribute instead.
  */
 final class Page implements ServiceTagInterface
 {
@@ -78,6 +80,8 @@ final class Page implements ServiceTagInterface
 
     public function getName(): string
     {
+        trigger_deprecation('contao/core-bundle', '5.4', 'Using the @Page annotation has been deprecated and will no longer work in Contao 6. Use the #[AsPage] attribute instead.');
+
         return 'contao.page';
     }
 

--- a/core-bundle/src/ServiceAnnotation/Page.php
+++ b/core-bundle/src/ServiceAnnotation/Page.php
@@ -25,7 +25,8 @@ use Terminal42\ServiceAnnotationBundle\Annotation\ServiceTagInterface;
  *
  * @see Route
  *
- * @deprecated Use the #[AsPage] attribute instead.
+ * @deprecated Deprecated since Contao 5.4, to be removed in Contao 6;
+ *             use the #[AsPage] attribute instead
  */
 final class Page implements ServiceTagInterface
 {

--- a/core-bundle/src/ServiceAnnotation/PickerProvider.php
+++ b/core-bundle/src/ServiceAnnotation/PickerProvider.php
@@ -27,6 +27,8 @@ use Terminal42\ServiceAnnotationBundle\Annotation\ServiceTagInterface;
  * @Attributes({
  *     @Attribute("priority", type="int"),
  * })
+ *
+ * @deprecated Use the #[AsPickerProvider] attribute instead.
  */
 final class PickerProvider implements ServiceTagInterface
 {
@@ -34,6 +36,8 @@ final class PickerProvider implements ServiceTagInterface
 
     public function getName(): string
     {
+        trigger_deprecation('contao/core-bundle', '5.4', 'Using the @PickerProvider annotation has been deprecated and will no longer work in Contao 6. Use the #[AsPickerProvider] attribute instead.');
+
         return 'contao.picker_provider';
     }
 

--- a/core-bundle/src/ServiceAnnotation/PickerProvider.php
+++ b/core-bundle/src/ServiceAnnotation/PickerProvider.php
@@ -28,7 +28,8 @@ use Terminal42\ServiceAnnotationBundle\Annotation\ServiceTagInterface;
  *     @Attribute("priority", type="int"),
  * })
  *
- * @deprecated Use the #[AsPickerProvider] attribute instead.
+ * @deprecated Deprecated since Contao 5.4, to be removed in Contao 6;
+ *             use the #[AsPickerProvider] attribute instead
  */
 final class PickerProvider implements ServiceTagInterface
 {

--- a/core-bundle/tests/ServiceAnnotation/CallbackTest.php
+++ b/core-bundle/tests/ServiceAnnotation/CallbackTest.php
@@ -14,11 +14,19 @@ namespace Contao\CoreBundle\Tests\ServiceAnnotation;
 
 use Contao\CoreBundle\ServiceAnnotation\Callback;
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 
 class CallbackTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
+    /**
+     * @group legacy
+     */
     public function testReturnsTheTagName(): void
     {
+        $this->expectDeprecation('Since contao/core-bundle 5.4: %s Use the #[AsCallback] attribute instead.');
+
         $annotation = new Callback();
         $annotation->table = 'tl_foobar';
         $annotation->target = 'foo.bar';

--- a/core-bundle/tests/ServiceAnnotation/ContentElementTest.php
+++ b/core-bundle/tests/ServiceAnnotation/ContentElementTest.php
@@ -15,11 +15,19 @@ namespace Contao\CoreBundle\Tests\ServiceAnnotation;
 use Contao\CoreBundle\Fragment\Reference\ContentElementReference;
 use Contao\CoreBundle\ServiceAnnotation\ContentElement;
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 
 class ContentElementTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
+    /**
+     * @group legacy
+     */
     public function testReturnsTheTagName(): void
     {
+        $this->expectDeprecation('Since contao/core-bundle 5.4: %s Use the #[AsContentElement] attribute instead.');
+
         $annotation = new ContentElement(['category' => 'foobar']);
 
         $this->assertSame(ContentElementReference::TAG_NAME, $annotation->getName());

--- a/core-bundle/tests/ServiceAnnotation/FrontendModuleTest.php
+++ b/core-bundle/tests/ServiceAnnotation/FrontendModuleTest.php
@@ -15,11 +15,19 @@ namespace Contao\CoreBundle\Tests\ServiceAnnotation;
 use Contao\CoreBundle\Fragment\Reference\FrontendModuleReference;
 use Contao\CoreBundle\ServiceAnnotation\FrontendModule;
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 
 class FrontendModuleTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
+    /**
+     * @group legacy
+     */
     public function testReturnsTheTagName(): void
     {
+        $this->expectDeprecation('Since contao/core-bundle 5.4: %s Use the #[AsFrontendModule] attribute instead.');
+
         $annotation = new FrontendModule(['category' => 'foobar']);
 
         $this->assertSame(FrontendModuleReference::TAG_NAME, $annotation->getName());

--- a/core-bundle/tests/ServiceAnnotation/HookTest.php
+++ b/core-bundle/tests/ServiceAnnotation/HookTest.php
@@ -14,11 +14,19 @@ namespace Contao\CoreBundle\Tests\ServiceAnnotation;
 
 use Contao\CoreBundle\ServiceAnnotation\Hook;
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 
 class HookTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
+    /**
+     * @group legacy
+     */
     public function testReturnsTheTagName(): void
     {
+        $this->expectDeprecation('Since contao/core-bundle 5.4: %s Use the #[AsHook] attribute instead.');
+
         $annotation = new Hook();
 
         $this->assertSame('contao.hook', $annotation->getName());

--- a/core-bundle/tests/ServiceAnnotation/PickerProviderTest.php
+++ b/core-bundle/tests/ServiceAnnotation/PickerProviderTest.php
@@ -14,11 +14,19 @@ namespace Contao\CoreBundle\Tests\ServiceAnnotation;
 
 use Contao\CoreBundle\ServiceAnnotation\PickerProvider;
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 
 class PickerProviderTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
+    /**
+     * @group legacy
+     */
     public function testReturnsTheTagName(): void
     {
+        $this->expectDeprecation('Since contao/core-bundle 5.4: %s Use the #[AsPickerProvider] attribute instead.');
+
         $annotation = new PickerProvider();
 
         $this->assertSame('contao.picker_provider', $annotation->getName());


### PR DESCRIPTION
Symfony has removed the Doctrine annotations library in version 7.0 (see [UPGRADE-7.0.md](https://github.com/symfony/symfony/blob/a8098b242ba3889c4f3c5b648dcd3e355af51ba5/UPGRADE-7.0.md#frameworkbundle)), so their service annotations no longer work. Our own service annotations will continue to work until Contao 6.0 but they are deprecated from now on.