### PR TITLE
Also check old password when setting new password in personal data

### DIFF
--- a/core-bundle/contao/modules/ModulePersonalData.php
+++ b/core-bundle/contao/modules/ModulePersonalData.php
@@ -331,7 +331,7 @@ class ModulePersonalData extends Module
 					}
 
 					// Set the new value
-					if ($varValue !== $user->$field)
+					if ($varValue !== $user->$field && $field !== 'oldPassword')
 					{
 						$user->$field = $varValue;
 


### PR DESCRIPTION
Currently you can change your password in `ModulePersonalData` without having to specify your old password. This PR fixes that by automatically adding an additional field to check the old password, if:

* The member already has a password set (apparently there is or was a use-case where that can not be the case).
* The `password` field was added to the editable fields.