### PR TITLE
Show a warning if a personal data module allows to change the password

### DIFF
--- a/core-bundle/config/listener.yaml
+++ b/core-bundle/config/listener.yaml
@@ -186,10 +186,8 @@ services:
     contao.listener.data_container.personal_data_password:
         class: Contao\CoreBundle\EventListener\DataContainer\PersonalDataPasswordListener
         arguments:
-            - '@contao.framework'
             - '@database_connection'
             - '@translator'
-            - '@request_stack'
 
     contao.listener.data_container.preview_link:
         class: Contao\CoreBundle\EventListener\DataContainer\PreviewLinkListener

--- a/core-bundle/config/listener.yaml
+++ b/core-bundle/config/listener.yaml
@@ -188,6 +188,7 @@ services:
         arguments:
             - '@database_connection'
             - '@translator'
+            - '@security.helper'
 
     contao.listener.data_container.preview_link:
         class: Contao\CoreBundle\EventListener\DataContainer\PreviewLinkListener

--- a/core-bundle/config/listener.yaml
+++ b/core-bundle/config/listener.yaml
@@ -183,6 +183,14 @@ services:
         arguments:
             - '@request_stack'
 
+    contao.listener.data_container.personal_data_password:
+        class: Contao\CoreBundle\EventListener\DataContainer\PersonalDataPasswordListener
+        arguments:
+            - '@contao.framework'
+            - '@database_connection'
+            - '@translator'
+            - '@request_stack'
+
     contao.listener.data_container.preview_link:
         class: Contao\CoreBundle\EventListener\DataContainer\PreviewLinkListener
         arguments:

--- a/core-bundle/contao/languages/en/default.xlf
+++ b/core-bundle/contao/languages/en/default.xlf
@@ -281,6 +281,9 @@
       <trans-unit id="ERR.noAdminEmail">
         <source>There is no administrator e-mail address set, please contact the site administrator.</source>
       </trans-unit>
+      <trans-unit id="ERR.personalDataPassword">
+        <source>There is at least one "personal data" module that allows the password to be changed. This is a security weakness and will no longer work in Contao 6. Use the "change password" module instead.</source>
+      </trans-unit>
       <trans-unit id="SEC.question1">
         <source>Please add %d and %d.</source>
       </trans-unit>

--- a/core-bundle/src/EventListener/DataContainer/PersonalDataPasswordListener.php
+++ b/core-bundle/src/EventListener/DataContainer/PersonalDataPasswordListener.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\EventListener\DataContainer;
+
+use Contao\CoreBundle\DependencyInjection\Attribute\AsCallback;
+use Contao\CoreBundle\Framework\ContaoFramework;
+use Contao\Message;
+use Doctrine\DBAL\Connection;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+#[AsCallback(table: 'tl_module', target: 'config.onload')]
+class PersonalDataPasswordListener
+{
+    public function __construct(
+        private readonly ContaoFramework $framework,
+        private readonly Connection $connection,
+        private readonly TranslatorInterface $translator,
+        private readonly RequestStack $requestStack,
+    ) {
+    }
+
+    public function __invoke(): void
+    {
+        $request = $this->requestStack->getCurrentRequest();
+
+        if ($request?->query->has('act') && 'select' !== $request?->query->get('act')) {
+            return;
+        }
+
+        $count = $this->connection
+            ->executeQuery("
+                SELECT COUNT(*)
+                FROM tl_module
+                WHERE
+                    type = 'personalData'
+                    AND editable LIKE '%\"password\"%'
+            ")
+            ->fetchOne()
+        ;
+
+        if ($count < 1) {
+            return;
+        }
+
+        $messages = $this->framework->getAdapter(Message::class);
+        $messages->addError($this->translator->trans('ERR.personalDataPassword', [], 'contao_default'));
+    }
+}

--- a/core-bundle/src/EventListener/DataContainer/PersonalDataPasswordListener.php
+++ b/core-bundle/src/EventListener/DataContainer/PersonalDataPasswordListener.php
@@ -34,7 +34,7 @@ class PersonalDataPasswordListener
     {
         $request = $this->requestStack->getCurrentRequest();
 
-        if ($request?->query->has('act') && 'select' !== $request?->query->get('act')) {
+        if ($request?->query->has('act') && 'select' !== $request->query->get('act')) {
             return;
         }
 

--- a/core-bundle/src/EventListener/DataContainer/PersonalDataPasswordListener.php
+++ b/core-bundle/src/EventListener/DataContainer/PersonalDataPasswordListener.php
@@ -13,7 +13,9 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\EventListener\DataContainer;
 
 use Contao\CoreBundle\DependencyInjection\Attribute\AsHook;
+use Contao\CoreBundle\Security\ContaoCorePermissions;
 use Doctrine\DBAL\Connection;
+use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
@@ -25,28 +27,40 @@ class PersonalDataPasswordListener
     public function __construct(
         private readonly Connection $connection,
         private readonly TranslatorInterface $translator,
+        private readonly Security $security,
     ) {
     }
 
     public function __invoke(): string|null
     {
-        $count = $this->connection
-            ->executeQuery("
-                SELECT COUNT(*)
-                FROM tl_module
-                WHERE
-                    type = 'personalData'
-                    AND editable LIKE '%\"password\"%'
-            ")
-            ->fetchOne()
-        ;
+        if (!$this->canAccessSettings()) {
+            return null;
+        }
 
-        if ($count < 1) {
+        $query = <<<'SQL'
+            SELECT COUNT(*)
+            FROM tl_module
+            WHERE
+                type = 'personalData'
+                AND editable LIKE '%"password"%'
+            SQL;
+
+        if ($this->connection->executeQuery($query)->fetchOne() < 1) {
             return null;
         }
 
         $message = $this->translator->trans('ERR.personalDataPassword', [], 'contao_default');
 
-        return '<p class="tl_error">' . $message . '</p>';
+        return '<p class="tl_error">'.$message.'</p>';
+    }
+
+    private function canAccessSettings(): bool
+    {
+        if (!isset($GLOBALS['BE_MOD']['design']['themes'])) {
+            return false;
+        }
+
+        return $this->security->isGranted(ContaoCorePermissions::USER_CAN_ACCESS_MODULE, 'themes')
+            && $this->security->isGranted(ContaoCorePermissions::USER_CAN_ACCESS_THEME, 'modules');
     }
 }


### PR DESCRIPTION
<img width="830" alt="" src="https://github.com/user-attachments/assets/55defc83-3406-474e-9b7e-baa3af2f8b69">

In contrast to the personal data module, the change password module requires to enter the old password when setting a new password.

Of course, we could adjust the personal data module accordingly (see #7442 for a proof of concept), but changing your password and editing your personal information in the same form seems like an anti-pattern and is not possible on any of the major websites I use. I am therefore against merging #7442. Changing your password should always be done separately from changing your personal data.
