### PR TITLE
Ensure that `$this->style` is never `null`

### DIFF
--- a/core-bundle/contao/templates/block/block_searchable.html5
+++ b/core-bundle/contao/templates/block/block_searchable.html5
@@ -3,7 +3,7 @@
 $this->wrapperAttributes = $this
     ->attr($this->cssID)
     ->addClass([$this->class, 'block'])
-    ->addStyle($this->style)
+    ->addStyle($this->style ?? '')
     ->mergeWith($this->wrapperAttributes)
 ;
 

--- a/core-bundle/contao/templates/elements/ce_accordionSingle.html5
+++ b/core-bundle/contao/templates/elements/ce_accordionSingle.html5
@@ -3,7 +3,7 @@
 $this->wrapperAttributes = $this
     ->attr($this->cssID)
     ->addClass([$this->class, 'ce_accordion', 'ce_text', 'block'])
-    ->addStyle($this->style)
+    ->addStyle($this->style ?? '')
     ->mergeWith($this->wrapperAttributes)
 ;
 

--- a/core-bundle/contao/templates/elements/ce_accordionStart.html5
+++ b/core-bundle/contao/templates/elements/ce_accordionStart.html5
@@ -3,7 +3,7 @@
 $this->wrapperAttributes = $this
     ->attr($this->cssID)
     ->addClass([$this->class, 'ce_accordion', 'block'])
-    ->addStyle($this->style)
+    ->addStyle($this->style ?? '')
     ->mergeWith($this->wrapperAttributes)
 ;
 

--- a/core-bundle/contao/templates/elements/ce_headline.html5
+++ b/core-bundle/contao/templates/elements/ce_headline.html5
@@ -3,7 +3,7 @@
 $this->wrapperAttributes = $this
     ->attr($this->cssID)
     ->addClass($this->class)
-    ->addStyle($this->style)
+    ->addStyle($this->style ?? '')
     ->mergeWith($this->wrapperAttributes)
 ;
 

--- a/core-bundle/contao/templates/elements/ce_sliderStart.html5
+++ b/core-bundle/contao/templates/elements/ce_sliderStart.html5
@@ -3,7 +3,7 @@
 $this->wrapperAttributes = $this
     ->attr($this->cssID)
     ->addClass([$this->class, 'block'])
-    ->addStyle($this->style)
+    ->addStyle($this->style ?? '')
     ->mergeWith($this->wrapperAttributes)
 ;
 

--- a/core-bundle/contao/templates/elements/ce_toplink.html5
+++ b/core-bundle/contao/templates/elements/ce_toplink.html5
@@ -3,7 +3,7 @@
 $this->wrapperAttributes = $this
     ->attr($this->cssID)
     ->addClass([$this->class, 'block'])
-    ->addStyle($this->style)
+    ->addStyle($this->style ?? '')
     ->mergeWith($this->wrapperAttributes)
 ;
 

--- a/core-bundle/contao/templates/forms/form_wrapper.html5
+++ b/core-bundle/contao/templates/forms/form_wrapper.html5
@@ -3,7 +3,7 @@
 $this->wrapperAttributes = $this
     ->attr($this->cssID)
     ->addClass([$this->class, 'block'])
-    ->addStyle($this->style)
+    ->addStyle($this->style ?? '')
     ->mergeWith($this->wrapperAttributes)
 ;
 

--- a/core-bundle/contao/templates/member/member_default.html5
+++ b/core-bundle/contao/templates/member/member_default.html5
@@ -5,7 +5,7 @@
 $this->wrapperAttributes = $this
     ->attr($this->cssID)
     ->addClass([$this->class, 'block'])
-    ->addStyle($this->style)
+    ->addStyle($this->style ?? '')
     ->mergeWith($this->wrapperAttributes)
 ;
 

--- a/core-bundle/contao/templates/member/member_grouped.html5
+++ b/core-bundle/contao/templates/member/member_grouped.html5
@@ -5,7 +5,7 @@
 $this->wrapperAttributes = $this
     ->attr($this->cssID)
     ->addClass([$this->class, 'block'])
-    ->addStyle($this->style)
+    ->addStyle($this->style ?? '')
     ->mergeWith($this->wrapperAttributes)
 ;
 

--- a/core-bundle/contao/templates/modules/mod_article.html5
+++ b/core-bundle/contao/templates/modules/mod_article.html5
@@ -3,7 +3,7 @@
 $this->wrapperAttributes = $this
     ->attr($this->cssID)
     ->addClass([$this->class, 'block'])
-    ->addStyle($this->style)
+    ->addStyle($this->style ?? '')
     ->mergeWith($this->wrapperAttributes)
 ;
 

--- a/core-bundle/contao/templates/modules/mod_breadcrumb.html5
+++ b/core-bundle/contao/templates/modules/mod_breadcrumb.html5
@@ -3,7 +3,7 @@
 $this->wrapperAttributes = $this
     ->attr($this->cssID)
     ->addClass([$this->class, 'block'])
-    ->addStyle($this->style)
+    ->addStyle($this->style ?? '')
     ->set('aria-label', $this->trans('MSC.breadcrumbMenu'))
     ->mergeWith($this->wrapperAttributes)
 ;

--- a/core-bundle/contao/templates/modules/mod_navigation.html5
+++ b/core-bundle/contao/templates/modules/mod_navigation.html5
@@ -3,7 +3,7 @@
 $this->wrapperAttributes = $this
     ->attr($this->cssID)
     ->addClass([$this->class, 'block'])
-    ->addStyle($this->style)
+    ->addStyle($this->style ?? '')
     ->setIfExists('aria-label', $this->ariaLabel)
     ->mergeWith($this->wrapperAttributes)
 ;


### PR DESCRIPTION
<img width="911" alt="" src="https://github.com/user-attachments/assets/45e7f67e-c378-46e4-be89-c9e1314071e2">

I stumbled over this with Haste forms, but I‘m not sure if we shouldn‘t consider this a bug in Contao. `$this->styles` could be `null` in other scenarios, too.