### PR TITLE
Disable Turbo on theme import forms

### DIFF
--- a/core-bundle/contao/classes/Theme.php
+++ b/core-bundle/contao/classes/Theme.php
@@ -131,7 +131,7 @@ class Theme extends Backend
 <div id="tl_buttons">
 <a href="' . StringUtil::ampersand(str_replace('&key=importTheme', '', Environment::get('requestUri'))) . '" class="header_back" title="' . StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['backBTTitle']) . '" accesskey="b">' . $GLOBALS['TL_LANG']['MSC']['backBT'] . '</a>
 </div>
-<form id="tl_theme_import" class="tl_form tl_edit_form" method="post" enctype="multipart/form-data">
+<form id="tl_theme_import" class="tl_form tl_edit_form" method="post" enctype="multipart/form-data" data-turbo="false">
 <div class="tl_formbody_edit">
 <input type="hidden" name="FORM_SUBMIT" value="tl_theme_import">
 <input type="hidden" name="REQUEST_TOKEN" value="' . htmlspecialchars(System::getContainer()->get('contao.csrf.token_manager')->getDefaultTokenValue(), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5) . '">


### PR DESCRIPTION
Fixes #7448

Importing a theme is something that doesn't happen regularly so disabling turbo on the form should be the way to go.

_KISS_ -> Since we can't throw any [422 errors](https://symfonycasts.com/screencast/turbo/forms) easily when submitting this form, there's probably no good way to handle the error.

