### PR TITLE
Disable Turbo drive for the whole backend

### DIFF
--- a/core-bundle/assets/backend.js
+++ b/core-bundle/assets/backend.js
@@ -1,6 +1,8 @@
 import { Application } from '@hotwired/stimulus';
 import { definitionForModuleAndIdentifier, identifierForContextKey } from '@hotwired/stimulus-webpack-helpers';
-import '@hotwired/turbo';
+
+import * as Turbo from '@hotwired/turbo';
+Turbo.session.drive = false;
 
 import './scripts/mootao.js';
 import './scripts/core.js';
@@ -36,7 +38,7 @@ const mooDomready = () => {
     if (!document.body.mooDomreadyFired) {
         document.body.mooDomreadyFired = true;
         window.fireEvent('domready');
-    }  
+    }
 }
 
 document.documentElement.addEventListener('turbo:render', mooDomready);


### PR DESCRIPTION
This disables the global Turbo Drive (https://turbo.hotwired.dev/reference/drive) in the back end. We can still use Turbo Frames (https://turbo.hotwired.dev/reference/frames) e.g. for the edit view or Turbo Streams (https://turbo.hotwired.dev/reference/streams) for advanced stuff. But globally enabling Drive breaks a lot of core stuff and a lot of extensions. It only works if **all** scripts are built for it (e.g. using Stimulus), which certainly is not the case yet.

This PR just shows how simple the solution would be 😉 