### PR TITLE
Disable copying and deleting of tl_undo records

### DIFF
--- a/core-bundle/src/Resources/contao/dca/tl_undo.php
+++ b/core-bundle/src/Resources/contao/dca/tl_undo.php
@@ -26,6 +26,8 @@ $GLOBALS['TL_DCA']['tl_undo'] = array
 		'dataContainer'               => DC_Table::class,
 		'closed'                      => true,
 		'notEditable'                 => true,
+		'notCopyable'                 => true,
+		'notDeletable'                => true,
 		'sql' => array
 		(
 			'keys' => array


### PR DESCRIPTION
Since Contao 5 the tl_undo records can be deleted and copied via the all operation. In Contao 4.13 this was not the case.
Deleting could maybe make sense, but copying does not even do anything because the records can not be pasted, so this is definitely a bug.
I guess this was introduced by #6528.

Contao 5:
<img width="1437" alt="image" src="https://github.com/user-attachments/assets/3bdc0b98-ab1e-4b27-8b18-2bc24b6a9ebb">
<img width="1434" alt="image" src="https://github.com/user-attachments/assets/984a1e0b-686c-47e5-b9fd-cf7cf262943c">


Contao 4.13:
<img width="1216" alt="image" src="https://github.com/user-attachments/assets/507ad263-2109-4604-907d-f3dfa62b067c">
