### PR TITLE
Check if `CURRENT_ID` is defined in the DCA permission checks

### DIFF
--- a/calendar-bundle/src/Resources/contao/dca/tl_calendar_events.php
+++ b/calendar-bundle/src/Resources/contao/dca/tl_calendar_events.php
@@ -604,7 +604,8 @@ class tl_calendar_events extends Backend
 			$root = $this->User->calendars;
 		}
 
-		$id = strlen(Input::get('id')) ? Input::get('id') : CURRENT_ID;
+		$currentId = \defined('CURRENT_ID') ? CURRENT_ID : 0;
+		$id = strlen(Input::get('id')) ? Input::get('id') : $currentId;
 
 		// Check current action
 		switch (Input::get('act'))

--- a/core-bundle/src/Resources/contao/dca/tl_form_field.php
+++ b/core-bundle/src/Resources/contao/dca/tl_form_field.php
@@ -486,7 +486,8 @@ class tl_form_field extends Backend
 			$root = $this->User->forms;
 		}
 
-		$id = strlen(Input::get('id')) ? Input::get('id') : CURRENT_ID;
+		$currentId = \defined('CURRENT_ID') ? CURRENT_ID : 0;
+		$id = strlen(Input::get('id')) ? Input::get('id') : $currentId;
 
 		// Check current action
 		switch (Input::get('act'))

--- a/faq-bundle/src/Resources/contao/dca/tl_faq.php
+++ b/faq-bundle/src/Resources/contao/dca/tl_faq.php
@@ -401,7 +401,8 @@ class tl_faq extends Backend
 			$root = $this->User->faqs;
 		}
 
-		$id = strlen(Input::get('id')) ? Input::get('id') : CURRENT_ID;
+		$currentId = \defined('CURRENT_ID') ? CURRENT_ID : 0;
+		$id = strlen(Input::get('id')) ? Input::get('id') : $currentId;
 
 		// Check current action
 		switch (Input::get('act'))

--- a/news-bundle/src/Resources/contao/dca/tl_news.php
+++ b/news-bundle/src/Resources/contao/dca/tl_news.php
@@ -544,7 +544,8 @@ class tl_news extends Backend
 			$root = $this->User->news;
 		}
 
-		$id = strlen(Input::get('id')) ? Input::get('id') : CURRENT_ID;
+		$currentId = \defined('CURRENT_ID') ? CURRENT_ID : 0;
+		$id = strlen(Input::get('id')) ? Input::get('id') : $currentId;
 
 		// Check current action
 		switch (Input::get('act'))
@@ -552,7 +553,7 @@ class tl_news extends Backend
 			case 'paste':
 			case 'select':
 				// Check CURRENT_ID here (see #247)
-				if (!in_array(CURRENT_ID, $root))
+				if (!in_array($currentId, $root))
 				{
 					throw new AccessDeniedException('Not enough permissions to access news archive ID ' . $id . '.');
 				}

--- a/newsletter-bundle/src/Resources/contao/dca/tl_newsletter.php
+++ b/newsletter-bundle/src/Resources/contao/dca/tl_newsletter.php
@@ -309,7 +309,8 @@ class tl_newsletter extends Backend
 			$root = $this->User->newsletters;
 		}
 
-		$id = strlen(Input::get('id')) ? Input::get('id') : CURRENT_ID;
+		$currentId = \defined('CURRENT_ID') ? CURRENT_ID : 0;
+		$id = strlen(Input::get('id')) ? Input::get('id') : $currentId;
 
 		// Check current action
 		switch (Input::get('act'))

--- a/newsletter-bundle/src/Resources/contao/dca/tl_newsletter_recipients.php
+++ b/newsletter-bundle/src/Resources/contao/dca/tl_newsletter_recipients.php
@@ -204,7 +204,8 @@ class tl_newsletter_recipients extends Backend
 			$root = $this->User->newsletters;
 		}
 
-		$id = strlen(Input::get('id')) ? Input::get('id') : CURRENT_ID;
+		$currentId = \defined('CURRENT_ID') ? CURRENT_ID : 0;
+		$id = strlen(Input::get('id')) ? Input::get('id') : $currentId;
 
 		// Check current action
 		switch (Input::get('act'))


### PR DESCRIPTION
Fixes an issue reported by Sentry (see stack trace image). Apprently, our help dialog creates a new `DC_Table` object, which runs the `onload_callback` with permission checks.

<img width="1317" alt="Bildschirmfoto 2024-08-19 um 14 04 49" src="https://github.com/user-attachments/assets/81e648b9-4bf5-447b-a791-068b08bf1476">
