### PR TITLE
Consider subfolders and Twig templates within the theme export

### DIFF
--- a/core-bundle/contao/classes/Theme.php
+++ b/core-bundle/contao/classes/Theme.php
@@ -1193,7 +1193,7 @@ class Theme extends Backend
 		}
 
 		// Add all template files to the archive (see #7048)
-		$this->addFiles($objArchive, $strFolder);
+		$this->addTemplateFiles($objArchive, $strFolder);
 	}
 
 	/**
@@ -1204,7 +1204,7 @@ class Theme extends Backend
 	 *
 	 * @throws \Exception
 	 */
-	protected function addFiles(ZipWriter $objArchive, $strFolder): void
+	protected function addTemplateFiles(ZipWriter $objArchive, $strFolder): void
 	{
 		$path = $this->strRootDir . '/' . $strFolder;
 
@@ -1213,7 +1213,7 @@ class Theme extends Backend
 			// Recursive call of templates (see #7472)
 			if (is_dir($path . '/' . $item))
 			{
-				$this->addFiles($objArchive, $strFolder . '/' . $item);
+				$this->addTemplateFiles($objArchive, $strFolder . '/' . $item);
 			}
 			else if (preg_match('/\.(html5|sql|twig)$/', $item) && !str_starts_with($item, 'be_') && !str_starts_with($item, 'nl_'))
 			{

--- a/core-bundle/contao/classes/Theme.php
+++ b/core-bundle/contao/classes/Theme.php
@@ -1193,11 +1193,31 @@ class Theme extends Backend
 		}
 
 		// Add all template files to the archive (see #7048)
-		foreach (Folder::scan($this->strRootDir . '/' . $strFolder) as $strFile)
+		$this->addFiles($objArchive, $strFolder);
+	}
+
+	/**
+	 * Add files to an archive
+	 *
+	 * @param ZipWriter $objArchive
+	 * @param string $strFolder
+	 *
+	 * @throws \Exception
+	 */
+	protected function addFiles(ZipWriter $objArchive, $strFolder): void
+	{
+		$path = $this->strRootDir . '/' . $strFolder;
+
+		foreach (Folder::scan($path) as $item)
 		{
-			if (preg_match('/\.(html5|sql)$/', $strFile) && !str_starts_with($strFile, 'be_') && !str_starts_with($strFile, 'nl_'))
+			// Recursive call of templates (see #7472)
+			if (is_dir($path . '/' . $item))
 			{
-				$objArchive->addFile($strFolder . '/' . $strFile);
+				$this->addFiles($objArchive, $strFolder . '/' . $item);
+			}
+			else if (preg_match('/\.(html5|sql|twig)$/', $item) && !str_starts_with($item, 'be_') && !str_starts_with($item, 'nl_'))
+			{
+				$objArchive->addFile($strFolder . '/' . $item);
 			}
 		}
 	}

--- a/core-bundle/contao/classes/Theme.php
+++ b/core-bundle/contao/classes/Theme.php
@@ -1210,12 +1210,12 @@ class Theme extends Backend
 
 		foreach (Folder::scan($path) as $item)
 		{
-			// Recursive call of templates (see #7472)
+			// Add subfolders recursively (see #7472)
 			if (is_dir($path . '/' . $item))
 			{
 				$this->addTemplateFiles($objArchive, $strFolder . '/' . $item);
 			}
-			else if (preg_match('/\.(html5|sql|twig)$/', $item) && !str_starts_with($item, 'be_') && !str_starts_with($item, 'nl_'))
+			elseif (preg_match('/\.(html5|sql|twig)$/', $item) && !str_starts_with($item, 'be_') && !str_starts_with($item, 'nl_'))
 			{
 				$objArchive->addFile($strFolder . '/' . $item);
 			}


### PR DESCRIPTION
* implements #6934

* Also allows `.twig` files as we previously only allowed `.html5` and `.sql` files

TL;DR - If no theme folder has been selected, this will also export structures like this:
![image](https://github.com/user-attachments/assets/7ef25d06-117a-4172-88e2-900407e85a6d)
