### PR TITLE
Fix the description list markup for `template` templates

### DIFF
--- a/core-bundle/src/Resources/contao/templates/elements/ce_template.html5
+++ b/core-bundle/src/Resources/contao/templates/elements/ce_template.html5
@@ -2,11 +2,13 @@
 
 <?php $this->block('content'); ?>
 
-  <?php foreach ($this->keys as $key => $value): ?>
+  <?php if ($this->keys): ?>
     <dl>
-      <dt><?= $key ?></dt>
-      <dd><?= $value ?></dd>
+      <?php foreach ($this->keys as $key => $value): ?>
+        <dt><?= $key ?></dt>
+        <dd><?= $value ?></dd>
+      <?php endforeach; ?>
     </dl>
-  <?php endforeach; ?>
+  <?php endif; ?>
 
 <?php $this->endblock(); ?>

--- a/core-bundle/src/Resources/contao/templates/modules/mod_template.html5
+++ b/core-bundle/src/Resources/contao/templates/modules/mod_template.html5
@@ -2,11 +2,13 @@
 
 <?php $this->block('content'); ?>
 
-  <?php foreach ($this->keys as $key => $value): ?>
+  <?php if ($this->keys): ?>
     <dl>
-      <dt><?= $key ?></dt>
-      <dd><?= $value ?></dd>
+      <?php foreach ($this->keys as $key => $value): ?>
+        <dt><?= $key ?></dt>
+        <dd><?= $value ?></dd>
+      <?php endforeach; ?>
     </dl>
-  <?php endforeach; ?>
+  <?php endif; ?>
 
 <?php $this->endblock(); ?>


### PR DESCRIPTION
I noticed that currently our `template` content element and module produces markup like this:

```html
<div class="ce_template block">
  <dl>
    <dt>…</dt>
    <dd>…</dd>
  </dl>
  <dl>
    <dt>…</dt>
    <dd>…</dd>
  </dl>
  <dl>
    <dt>…</dt>
    <dd>…</dd>
  </dl>
  <dl>
    <dt>…</dt>
    <dd>…</dd>
  </dl>
  …
</div>
```

But a [description list](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dl) can have multiple term and description pairs, i.e.

```html
<div class="ce_template block">
  <dl>
    <dt>…</dt>
    <dd>…</dd>
    <dt>…</dt>
    <dd>…</dd>
    <dt>…</dt>
    <dd>…</dd>
    <dt>…</dt>
    <dd>…</dd>
  </dl>
  …
</div>
```

Among other combinations.
