### PR TITLE
Fix the description list markup for `template` templates

### DIFF
--- a/core-bundle/contao/templates/twig/content_element/template.html.twig
+++ b/core-bundle/contao/templates/twig/content_element/template.html.twig
@@ -1,10 +1,12 @@
 {% extends "@Contao/content_element/_base.html.twig" %}
 
 {% block content %}
-    {% for key, value in keys %}
+    {% if keys|default %}
         <dl>
-            <dt>{{ key }}</dt>
-            <dd>{{ value }}</dd>
+            {% for key, value in keys %}
+                <dt>{{ key }}</dt>
+                <dd>{{ value }}</dd>
+            {% endfor %}
         </dl>
-    {% endfor %}
+    {% endif %}
 {% endblock %}

--- a/core-bundle/tests/Controller/ContentElement/TemplateControllerTest.php
+++ b/core-bundle/tests/Controller/ContentElement/TemplateControllerTest.php
@@ -24,6 +24,7 @@ class TemplateControllerTest extends ContentElementTestCase
                 'type' => 'template',
                 'data' => serialize([
                     ['key' => 'f&o', 'value' => '"bar"'],
+                    ['key' => 'lorem', 'value' => 'ipsum'],
                 ]),
             ],
         );
@@ -33,6 +34,8 @@ class TemplateControllerTest extends ContentElementTestCase
                 <dl>
                     <dt>f&amp;o</dt>
                     <dd>&quot;bar&quot;</dd>
+                    <dt>lorem</dt>
+                    <dd>ipsum</dd>
                 </dl>
             </div>
             HTML;


### PR DESCRIPTION
Same as #7483 for Contao 5.