### PR TITLE
Switch to a stable ALTCHA version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "ausi/slug-generator": "^1.1",
         "bacon/bacon-qr-code": "^2.0",
         "contao-components/ace": "^1.8",
-        "contao-components/altcha": "^0.6.2 || ^0.7 || ^0.8 || ^0.9",
+        "contao-components/altcha": "^1.0",
         "contao-components/chosen": "^2.0",
         "contao-components/colorbox": "^1.6",
         "contao-components/colorpicker": "^1.5",

--- a/core-bundle/composer.json
+++ b/core-bundle/composer.json
@@ -42,7 +42,7 @@
         "ausi/slug-generator": "^1.1",
         "bacon/bacon-qr-code": "^2.0",
         "contao-components/ace": "^1.8",
-        "contao-components/altcha": "^0.6.2 || ^0.7 || ^0.8 || ^0.9",
+        "contao-components/altcha": "^1.0",
         "contao-components/chosen": "^2.0",
         "contao-components/colorbox": "^1.6",
         "contao-components/colorpicker": "^1.5",


### PR DESCRIPTION
Now that there is a stable version, we should drop the pre-release versions IMHO. @contao/developers WDYT?