### PR TITLE
Make Twig 3.12 the minimum version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -167,7 +167,7 @@
         "toflar/psr6-symfony-http-cache-store": "^4.0",
         "twig/extra-bundle": "^3.0",
         "twig/string-extra": "^3.0",
-        "twig/twig": "^3.10.2",
+        "twig/twig": "^3.12",
         "ua-parser/uap-php": "^3.9",
         "webignition/robots-txt-file": "^3.0",
         "wikimedia/less.php": "^1.7"

--- a/core-bundle/composer.json
+++ b/core-bundle/composer.json
@@ -153,7 +153,7 @@
         "terminal42/service-annotation-bundle": "^1.1",
         "toflar/cronjob-supervisor": "^2.0",
         "twig/string-extra": "^3.0",
-        "twig/twig": "^3.10.2",
+        "twig/twig": "^3.12",
         "ua-parser/uap-php": "^3.9",
         "webignition/robots-txt-file": "^3.0",
         "wikimedia/less.php": "^1.7"

--- a/core-bundle/src/Twig/Extension/DeprecationsNodeVisitor.php
+++ b/core-bundle/src/Twig/Extension/DeprecationsNodeVisitor.php
@@ -75,7 +75,6 @@ class DeprecationsNodeVisitor implements NodeVisitorInterface
         $deprecatedNode = new DeprecatedNode(
             new ConstantExpression("Since contao/core-bundle 4.13: $message", $line),
             $line,
-            $node->getNodeTag(),
         );
 
         // Set the source context, so that the template name can be inserted when

--- a/core-bundle/src/Twig/Inheritance/DynamicIncludeTokenParser.php
+++ b/core-bundle/src/Twig/Inheritance/DynamicIncludeTokenParser.php
@@ -45,7 +45,7 @@ final class DynamicIncludeTokenParser extends AbstractTokenParser
         // Handle Contao includes
         $this->traverseAndAdjustTemplateNames($expr);
 
-        return new IncludeNode($expr, $variables, $only, $ignoreMissing, $token->getLine(), $this->getTag());
+        return new IncludeNode($expr, $variables, $only, $ignoreMissing, $token->getLine());
     }
 
     public function getTag(): string

--- a/core-bundle/tests/Twig/Extension/ContaoExtensionTest.php
+++ b/core-bundle/tests/Twig/Extension/ContaoExtensionTest.php
@@ -41,6 +41,7 @@ use Twig\Environment;
 use Twig\Extension\AbstractExtension;
 use Twig\Extension\CoreExtension;
 use Twig\Extension\EscaperExtension;
+use Twig\Node\BodyNode;
 use Twig\Node\Expression\ConstantExpression;
 use Twig\Node\Expression\FilterExpression;
 use Twig\Node\ModuleNode;
@@ -220,16 +221,18 @@ class ContaoExtensionTest extends TestCase
         );
 
         $node = new ModuleNode(
-            new FilterExpression(
-                new TextNode('text', 1),
-                new ConstantExpression('escape', 1),
-                new Node([
-                    new ConstantExpression('html', 1),
-                    new ConstantExpression(null, 1),
-                    new ConstantExpression(true, 1),
-                ]),
-                1,
-            ),
+            new BodyNode([
+                new FilterExpression(
+                    new TextNode('text', 1),
+                    new ConstantExpression('escape', 1),
+                    new Node([
+                        new ConstantExpression('html', 1),
+                        new ConstantExpression(null, 1),
+                        new ConstantExpression(true, 1),
+                    ]),
+                    1,
+                ),
+            ]),
             null,
             new Node(),
             new Node(),


### PR DESCRIPTION
However, I‘m not sure how to fix this:

<img width="1023" alt="" src="https://github.com/user-attachments/assets/91ce0f39-398c-46f7-bc0d-ef41abe77f1b">

`FilterExpression` extends `CallExpression` extends `AbstractExpression` extends `Node`. If you ask me, this would have to be changed to `BodyNode` in Twig itself. @m-vo /cc