### PR TITLE
Introduce the Twig variable "headline_attributes"

### DIFF
--- a/core-bundle/contao/templates/twig/component/_headline.html.twig
+++ b/core-bundle/contao/templates/twig/component/_headline.html.twig
@@ -19,7 +19,7 @@
     {% set headline = headline|default(_context) %}
     {% set tag_name = headline.tag_name|default('h1') %}
 
-    <{{ tag_name }}{% block headline_attributes %}{{ headline.attributes|default }}{% endblock %}>
+    <{{ tag_name }}{% block headline_attributes %}{{ headline_attributes|default }}{% endblock %}>
     {%- block headline_inner -%}
         {{ headline.text|insert_tag_raw }}
     {%- endblock -%}

--- a/core-bundle/contao/templates/twig/component/_headline.html.twig
+++ b/core-bundle/contao/templates/twig/component/_headline.html.twig
@@ -9,6 +9,7 @@
     Optional variables:
         @var string tag_name
         @var \Contao\CoreBundle\String\HtmlAttributes attributes
+        @var \Contao\CoreBundle\String\HtmlAttributes headline_attributes
 
     Note:
         You can either group all variables in an object named "headline" or

--- a/core-bundle/contao/templates/twig/content_element/headline.html.twig
+++ b/core-bundle/contao/templates/twig/content_element/headline.html.twig
@@ -4,7 +4,7 @@
 {% block wrapper %}
     {# The "headline" content element does not have a wrapper element, so the
        wrapper attributes must be applied to the "_headline" component. #}
-    {% with {headline: headline|default(_context)|merge({attributes})} %}
+    {% with {headline: headline|default(_context), headline_attributes: attributes} %}
         {{ block('headline_component') }}
     {% endwith %}
 {% endblock %}


### PR DESCRIPTION
Fixes #7518

<!--
Bugfixes should be based on the 4.13 or 5.3 branch and features on the 5.x
branch. Select the correct branch in the "base:" drop-down menu above.

Replace this notice with a short README for your feature/bugfix. This will help
people to understand your PR and can be used as a start for the documentation.
-->

This PR fixes that the headline attributes can be overriden within the inhertence chain (similiar to existing variables like "text_atributes", "image_attributes, ...).

This is a bugfix, because the template did not work as intended 🤔 

Might be a low to no impact change, because, as stated in https://github.com/contao/contao/issues/7518#issuecomment-2333819257, people were overriding the entire block already.
