### PR TITLE
Mark TwigComponent's attributes as safe html

### DIFF
--- a/core-bundle/src/Twig/Extension/ContaoExtension.php
+++ b/core-bundle/src/Twig/Extension/ContaoExtension.php
@@ -82,6 +82,7 @@ final class ContaoExtension extends AbstractExtension implements GlobalsInterfac
         // Mark classes as safe for HTML that already escape their output themselves
         $escaperRuntime->addSafeClass(HtmlAttributes::class, ['html', 'contao_html']);
         $escaperRuntime->addSafeClass(HighlightResult::class, ['html', 'contao_html']);
+        $escaperRuntime->addSafeClass('\Symfony\UX\TwigComponent\ComponentAttributes', ['html', 'contao_html']);
 
         $this->environment->addGlobal(
             'request_token',


### PR DESCRIPTION
I am using Twig Components (or Live Componets) since a while now but I just recently moved the templates to the Contao namespace for better DX/extensibility.

Unfortunately, the Contao escaper runs over everything in the template and escapes the TwigComponent's `{{ attributes() }}` function outputs.

Just as a side note, the Twig functions like `{{ stimulus_target() }}` and so on seem to work (no escaping) which lets me whonder why it is unaffected 🤔 

---

<img width="620" alt="Screenshot 2024-09-07 at 16 38 18" src="https://github.com/user-attachments/assets/69015532-eaba-4e74-bd19-eefd05ac9c1f">

<img width="693" alt="Screenshot 2024-09-07 at 16 38 15" src="https://github.com/user-attachments/assets/48903a85-f1c5-4c86-a2eb-69a65c77a30e">
