### PR TITLE
Update `box-size` translation for image-size

### DIFF
--- a/core-bundle/src/Resources/contao/languages/en/default.xlf
+++ b/core-bundle/src/Resources/contao/languages/en/default.xlf
@@ -1029,7 +1029,7 @@
         <source>Fit the box</source>
       </trans-unit>
       <trans-unit id="MSC.box.1">
-        <source>The image will be resized proportionally so that neither side exceeds any of the given dimensions. Same as &lt;em&gt;contain&lt;/em&gt; in CSS.</source>
+        <source>The image will be resized proportionally so that neither side exceeds any of the given dimensions. This is similar to the &lt;em&gt;contain&lt;/em&gt; property in CSS.</source>
       </trans-unit>
       <trans-unit id="MSC.exact.0">
         <source>Exact dimensions</source>

--- a/core-bundle/src/Resources/contao/languages/en/default.xlf
+++ b/core-bundle/src/Resources/contao/languages/en/default.xlf
@@ -1029,7 +1029,7 @@
         <source>Fit the box</source>
       </trans-unit>
       <trans-unit id="MSC.box.1">
-        <source>The image will be resized proportionally so that neither side exceeds any of the given dimensions. This is similar to the &lt;em&gt;contain&lt;/em&gt; property in CSS.</source>
+        <source>The image will be resized proportionally so that neither side exceeds any of the given dimensions. This is similar to the &lt;em&gt;contain&lt;/em&gt; value in CSS.</source>
       </trans-unit>
       <trans-unit id="MSC.exact.0">
         <source>Exact dimensions</source>
@@ -1041,7 +1041,7 @@
         <source>Important part</source>
       </trans-unit>
       <trans-unit id="MSC.crop.1">
-        <source>The image will be resized to the exact dimensions given, cropping the image if necessary while preserving the important part if specified. This is similar to the &lt;em&gt;cover&lt;/em&gt; property in CSS.</source>
+        <source>The image will be resized to the exact dimensions given, cropping the image if necessary while preserving the important part if specified. This is similar to the &lt;em&gt;cover&lt;/em&gt; value in CSS.</source>
       </trans-unit>
       <trans-unit id="MSC.left_top.0">
         <source>Left | Top</source>

--- a/core-bundle/src/Resources/contao/languages/en/default.xlf
+++ b/core-bundle/src/Resources/contao/languages/en/default.xlf
@@ -1029,7 +1029,7 @@
         <source>Fit the box</source>
       </trans-unit>
       <trans-unit id="MSC.box.1">
-        <source>The image will be resized proportionally so that both sides do not exceed the given dimensions. Same as &lt;em&gt;contain&lt;/em&gt; in CSS.</source>
+        <source>The image will be resized proportionally so that both sides do not exceed the given dimensions. Same as &lt;code&gt;contain&lt;/code&gt; in CSS.</source>
       </trans-unit>
       <trans-unit id="MSC.exact.0">
         <source>Exact dimensions</source>

--- a/core-bundle/src/Resources/contao/languages/en/default.xlf
+++ b/core-bundle/src/Resources/contao/languages/en/default.xlf
@@ -1029,7 +1029,7 @@
         <source>Fit the box</source>
       </trans-unit>
       <trans-unit id="MSC.box.1">
-        <source>The image will be resized proportionally so that both sides do not exceed the given dimensions.</source>
+        <source>The image will be resized proportionally so that both sides do not exceed the given dimensions. Same as &lt;em&gt;contain&lt;/em&gt; in CSS.</source>
       </trans-unit>
       <trans-unit id="MSC.exact.0">
         <source>Exact dimensions</source>

--- a/core-bundle/src/Resources/contao/languages/en/default.xlf
+++ b/core-bundle/src/Resources/contao/languages/en/default.xlf
@@ -1041,7 +1041,7 @@
         <source>Important part</source>
       </trans-unit>
       <trans-unit id="MSC.crop.1">
-        <source>The image will be resized to the exact dimensions given. The image will be cropped if necessary, preserving the important part (if specified in the file manager). This is similar to the &lt;em&gt;cover&lt;/em&gt; property in CSS.</source>
+        <source>The image will be resized to the exact dimensions given, cropping the image if necessary while preserving the important part if specified. This is similar to the &lt;em&gt;cover&lt;/em&gt; property in CSS.</source>
       </trans-unit>
       <trans-unit id="MSC.left_top.0">
         <source>Left | Top</source>

--- a/core-bundle/src/Resources/contao/languages/en/default.xlf
+++ b/core-bundle/src/Resources/contao/languages/en/default.xlf
@@ -1029,7 +1029,7 @@
         <source>Fit the box</source>
       </trans-unit>
       <trans-unit id="MSC.box.1">
-        <source>The shorter side of the image is adjusted to the given dimensions and the image is resized proportionally.</source>
+        <source>Both sides of the image are adjusted to the given dimensions without exceeding them, and the image is resized proportionally.</source>
       </trans-unit>
       <trans-unit id="MSC.exact.0">
         <source>Exact dimensions</source>

--- a/core-bundle/src/Resources/contao/languages/en/default.xlf
+++ b/core-bundle/src/Resources/contao/languages/en/default.xlf
@@ -1029,7 +1029,7 @@
         <source>Fit the box</source>
       </trans-unit>
       <trans-unit id="MSC.box.1">
-        <source>The image will be resized proportionally so that both sides do not exceed the given dimensions. Same as &lt;code&gt;contain&lt;/code&gt; in CSS.</source>
+        <source>The image will be resized proportionally so that both sides do not exceed the given dimensions. Same as &lt;em&gt;contain&lt;/em&gt; in CSS.</source>
       </trans-unit>
       <trans-unit id="MSC.exact.0">
         <source>Exact dimensions</source>
@@ -1041,7 +1041,7 @@
         <source>Important part</source>
       </trans-unit>
       <trans-unit id="MSC.crop.1">
-        <source>Preserves the important part of an image as specified in the file manager.</source>
+        <source>Preserves the important part of an image as specified in the file manager. If necessary, the image will be cropped. Same as &lt;em&gt;cover&lt;/em&gt; in CSS.</source>
       </trans-unit>
       <trans-unit id="MSC.left_top.0">
         <source>Left | Top</source>

--- a/core-bundle/src/Resources/contao/languages/en/default.xlf
+++ b/core-bundle/src/Resources/contao/languages/en/default.xlf
@@ -1029,7 +1029,7 @@
         <source>Fit the box</source>
       </trans-unit>
       <trans-unit id="MSC.box.1">
-        <source>Both sides of the image are adjusted to the given dimensions without exceeding them, and the image is resized proportionally.</source>
+        <source>The image will be resized proportionally so that both sides do not exceed the given dimensions.</source>
       </trans-unit>
       <trans-unit id="MSC.exact.0">
         <source>Exact dimensions</source>

--- a/core-bundle/src/Resources/contao/languages/en/default.xlf
+++ b/core-bundle/src/Resources/contao/languages/en/default.xlf
@@ -1041,7 +1041,7 @@
         <source>Important part</source>
       </trans-unit>
       <trans-unit id="MSC.crop.1">
-        <source>Preserves the important part of an image as specified in the file manager. If necessary, the image will be cropped. Same as &lt;em&gt;cover&lt;/em&gt; in CSS.</source>
+        <source>Preserves the important part of an image as specified in the file manager. The image will be resized to the exact dimensions given and cropped if necessary, preserving the important part. This is similar to the &lt;em&gt;cover&lt;/em&gt; property in CSS.</source>
       </trans-unit>
       <trans-unit id="MSC.left_top.0">
         <source>Left | Top</source>

--- a/core-bundle/src/Resources/contao/languages/en/default.xlf
+++ b/core-bundle/src/Resources/contao/languages/en/default.xlf
@@ -1029,7 +1029,7 @@
         <source>Fit the box</source>
       </trans-unit>
       <trans-unit id="MSC.box.1">
-        <source>The image will be resized proportionally so that both sides do not exceed the given dimensions. Same as &lt;em&gt;contain&lt;/em&gt; in CSS.</source>
+        <source>The image will be resized proportionally so that neither side exceeds any of the given dimensions. Same as &lt;em&gt;contain&lt;/em&gt; in CSS.</source>
       </trans-unit>
       <trans-unit id="MSC.exact.0">
         <source>Exact dimensions</source>
@@ -1041,7 +1041,7 @@
         <source>Important part</source>
       </trans-unit>
       <trans-unit id="MSC.crop.1">
-        <source>Preserves the important part of an image as specified in the file manager. The image will be resized to the exact dimensions given and cropped if necessary, preserving the important part. This is similar to the &lt;em&gt;cover&lt;/em&gt; property in CSS.</source>
+        <source>The image will be resized to the exact dimensions given. The image will be cropped if necessary, preserving the important part (if specified in the file manager). This is similar to the &lt;em&gt;cover&lt;/em&gt; property in CSS.</source>
       </trans-unit>
       <trans-unit id="MSC.left_top.0">
         <source>Left | Top</source>


### PR DESCRIPTION
#### Description

This PR aims to update the description of the `box`-crop method for image-sizes that supersedes the removed `proportional`-method due to being similar.



