### PR TITLE
Add a null check for a possible empty array

### DIFF
--- a/core-bundle/src/EventListener/DataContainer/LegacyGalleryPaletteListener.php
+++ b/core-bundle/src/EventListener/DataContainer/LegacyGalleryPaletteListener.php
@@ -25,7 +25,7 @@ class LegacyGalleryPaletteListener
 {
     public function __invoke(): void
     {
-        if (!is_a($GLOBALS['TL_CTE']['media']['gallery'], ContentGallery::class, true)) {
+        if (!is_a($GLOBALS['TL_CTE']['media']['gallery'] ?? null, ContentGallery::class, true)) {
             return;
         }
 

--- a/core-bundle/tests/EventListener/DataContainer/LegacyGalleryPaletteListenerTest.php
+++ b/core-bundle/tests/EventListener/DataContainer/LegacyGalleryPaletteListenerTest.php
@@ -50,4 +50,13 @@ class LegacyGalleryPaletteListenerTest extends TestCase
 
         $this->assertSame('customTpl', $GLOBALS['TL_DCA']['tl_content']['palettes']['gallery']);
     }
+
+    public function testDoesNothingIfElementIsNotDefined(): void
+    {
+        $GLOBALS['TL_CTE']['media'] = null;
+
+        (new LegacyGalleryPaletteListener())();
+
+        $this->assertSame('customTpl', $GLOBALS['TL_DCA']['tl_content']['palettes']['gallery']);
+    }
 }


### PR DESCRIPTION
If you unset the gallery element to be not available in the system for usage, you'll get an `Undefined array key "gallery"` error.

![image (6)](https://github.com/user-attachments/assets/36d90f1f-c0b5-40d7-9605-57df3fce6be0)
