### PR TITLE
Fix erroneous tag on `contao.listener.make_response_private`

### DIFF
--- a/core-bundle/src/Resources/config/listener.yml
+++ b/core-bundle/src/Resources/config/listener.yml
@@ -327,7 +327,7 @@ services:
             # The priority must be lower than the one of MergeHttpHeadersListener (defaults to 256)
             # and must be lower than the one of the ClearSessionDataListener listener (defaults to -768)
             # and must be lower than the one of the CsrfTokenCookieSubscriber listener (defaults to -1006)
-            - and must be higher than the one of the StreamedResponseListener listener (defaults to -1024)
+            # and must be higher than the one of the StreamedResponseListener listener (defaults to -1024)
             - { name: kernel.event_listener, method: makeResponsePrivate, priority: -1012 }
 
     contao.listener.menu.backend:


### PR DESCRIPTION
🙈 

```diff
Information for Service "contao.listener.make_response_private"
===============================================================

 ---------------- ---------------------------------------------------------------------------------------------- 
  Option           Value                                                                                         
 ---------------- ---------------------------------------------------------------------------------------------- 
  Service ID       contao.listener.make_response_private                                                         
  Class            Contao\CoreBundle\EventListener\MakeResponsePrivateListener                                   
  Tags             kernel.event_listener (method: disableSymfonyAutoCacheControl, priority: -896)                
                   kernel.event_listener (method: makeResponsePrivate, priority: -1012)                          
-                  and must be higher than the one of the StreamedResponseListener listener (defaults to -1024)  
                   container.hot_path                                                                            
                   container.hot_path                                                                            
  Public           no                                                                                            
  Synthetic        no                                                                                            
  Lazy             no                                                                                            
  Shared           yes                                                                                           
  Abstract         no                                                                                            
  Autowired        no                                                                                            
  Autoconfigured   yes                                                                                           
 ---------------- ---------------------------------------------------------------------------------------------- 
```

