### PR TITLE
Handle DCAs without fields in `tl_user_group`

### DIFF
--- a/core-bundle/src/Resources/contao/dca/tl_user_group.php
+++ b/core-bundle/src/Resources/contao/dca/tl_user_group.php
@@ -431,7 +431,7 @@ class tl_user_group extends Backend
 		// Get all excluded fields
 		foreach ($GLOBALS['TL_DCA'] as $k=>$v)
 		{
-			if (array_key_exists('fields', $v) && is_array($v['fields']))
+			if (is_array($v['fields'] ?? null))
 			{
 				foreach ($v['fields'] as $kk=>$vv)
 				{

--- a/core-bundle/src/Resources/contao/dca/tl_user_group.php
+++ b/core-bundle/src/Resources/contao/dca/tl_user_group.php
@@ -431,7 +431,7 @@ class tl_user_group extends Backend
 		// Get all excluded fields
 		foreach ($GLOBALS['TL_DCA'] as $k=>$v)
 		{
-			if (is_array($v['fields']))
+			if (array_key_exists('fields', $v) && is_array($v['fields']))
 			{
 				foreach ($v['fields'] as $kk=>$vv)
 				{


### PR DESCRIPTION
This PR fixes a warning that occurs when an extension has a DCA without fields.
There are a few extensions that might cause this, for example [terminal42/contao-shortlink](https://github.com/terminal42/contao-shortlink/blob/main/contao/dca/tl_terminal42_shortlink_log.php) or [mediamotionag/contao-backend-optim-bundle](https://github.com/mediamotionag/contao-backend-optim-bundle/blob/master/src/Resources/contao/dca/tl_node.php).
If one of those extensions is installed, user groups can no longer be edited when debug mode is enabled.

This affects Contao 4.13, 5.3 and 5.4.

```
ErrorException:
Warning: Undefined array key "fields"

  at vendor/contao/core-bundle/contao/dca/tl_user_group.php:387
  at tl_user_group->getExcludedFields()
     (vendor/contao/core-bundle/contao/library/Contao/Widget.php:1308)
  at Contao\Widget::getAttributesFromDca()
     (vendor/contao/core-bundle/contao/classes/DataContainer.php:481)
  at Contao\DataContainer->row()
     (vendor/contao/core-bundle/contao/drivers/DC_Table.php:2175)
  at Contao\DC_Table->edit()
     (vendor/contao/core-bundle/contao/classes/Backend.php:546)
  at Contao\Backend->getBackendModule()
     (vendor/contao/core-bundle/contao/controllers/BackendMain.php:144)
  at Contao\BackendMain->run()
     (vendor/contao/core-bundle/src/Controller/BackendController.php:44)
  at Contao\CoreBundle\Controller\BackendController->mainAction()
     (vendor/symfony/http-kernel/HttpKernel.php:181)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw()
     (vendor/symfony/http-kernel/HttpKernel.php:76)
  at Symfony\Component\HttpKernel\HttpKernel->handle()
     (vendor/symfony/http-kernel/Kernel.php:197)
  at Symfony\Component\HttpKernel\Kernel->handle()
     (public/index.php:42)       
```