### PR TITLE
Specify the dev tools how-to in the readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,10 @@ from your application.
 
 ## Running scripts
 
-First install the code quality tools:
+First install the code quality tools in `vendor/contao/contao`:
 
 ```bash
+composer update
 composer bin all install
 ```
 


### PR DESCRIPTION
Die Anleitung war nicht ganz eindeutig, daher eine Konkretisierung.

`composer bin all install` ist - zumindest mit einer aktuellen Composer-Version - auch obsolet, da das `composer update` schon die Dependencies für alle Tools in `vendor-bin` zieht. Aber es schadet ja auch nicht.
