### PR TITLE
Fix warning in `ModuleRegistration` if editable field does not exist anymore

### DIFF
--- a/core-bundle/src/Resources/contao/modules/ModuleRegistration.php
+++ b/core-bundle/src/Resources/contao/modules/ModuleRegistration.php
@@ -183,7 +183,7 @@ class ModuleRegistration extends Module
 				$arrData['inputType'] = 'upload';
 			}
 
-			$strClass = $GLOBALS['TL_FFL'][$arrData['inputType']] ?? null;
+			$strClass = $GLOBALS['TL_FFL'][$arrData['inputType'] ?? null] ?? null;
 
 			// Continue if the class is not defined
 			if (!class_exists($strClass))


### PR DESCRIPTION
1. Create a new field in the `tl_member` DCA with `'feEditable' => true, 'feGroup' => personal`. 
2. Add this new field to the editable fields of a `registration` module.
3. Remove this field from the DCA again.
4. Open the registration module in the front end in the debug mode.

The following error will appear:

```
ErrorException:
Warning: Undefined array key "inputType"

  at vendor\contao\contao\core-bundle\src\Resources\contao\modules\ModuleRegistration.php:186
```

We are already using `$arrData['inputType'] ?? null` in the lines before:

https://github.com/contao/contao/blob/8df641cd3cc22962f289eea7b524f0902b20d102/core-bundle/src/Resources/contao/modules/ModuleRegistration.php#L174-L184

This PR adds the missing `?? null` to the `$GLOBALS['TL_FFL']` array access.