### PR TITLE
Add more default values to the autogenerated `.env` files

### DIFF
--- a/manager-bundle/src/Command/ContaoSetupCommand.php
+++ b/manager-bundle/src/Command/ContaoSetupCommand.php
@@ -119,6 +119,7 @@ class ContaoSetupCommand extends Command
             ['cache:clear', '--no-warmup', '--env=prod'],
             ['cache:clear', '--no-warmup', '--env=dev'],
             ['cache:warmup', '--env=prod'],
+            ['cmsig:seal:index-create', '--env=prod'],
         ];
 
         $commandFlags = array_filter([

--- a/manager-bundle/tests/Command/ContaoSetupCommandTest.php
+++ b/manager-bundle/tests/Command/ContaoSetupCommandTest.php
@@ -30,6 +30,9 @@ class ContaoSetupCommandTest extends ContaoTestCase
     {
         $this->resetStaticProperties([Terminal::class]);
 
+        $dir = $this->getTempDir();
+        (new Filesystem())->remove([Path::join($dir, '.env'), Path::join($dir, '.env.local')]);
+
         parent::tearDown();
     }
 
@@ -75,7 +78,8 @@ class ContaoSetupCommandTest extends ContaoTestCase
 
         $memoryLimit = ini_set('memory_limit', '1G');
         $createProcessHandler = $this->getCreateProcessHandler($processes, $commandArguments, $invocationCount);
-        $command = new ContaoSetupCommand('project/dir', 'project/dir/public', 'secret', $createProcessHandler);
+        $projectDir = $this->getTempDir();
+        $command = new ContaoSetupCommand($projectDir, Path::join($projectDir, 'public'), 'secret', $createProcessHandler);
 
         (new CommandTester($command))->execute([], $options);
 
@@ -125,9 +129,11 @@ class ContaoSetupCommandTest extends ContaoTestCase
 
     public function testThrowsIfCommandFails(): void
     {
+        $projectDir = $this->getTempDir();
+
         $command = new ContaoSetupCommand(
-            'project/dir',
-            'project/dir/public',
+            $projectDir,
+            Path::join($projectDir, 'public'),
             'secret',
             $this->getCreateProcessHandler($this->getProcessMocks(false)),
         );
@@ -142,9 +148,11 @@ class ContaoSetupCommandTest extends ContaoTestCase
 
     public function testDelegatesOutputOfSubProcesses(): void
     {
+        $projectDir = $this->getTempDir();
+
         $command = new ContaoSetupCommand(
-            'project/dir',
-            'project/dir/public',
+            $projectDir,
+            Path::join($projectDir, 'public'),
             'secret',
             $this->getCreateProcessHandler($this->getProcessMocks()),
         );
@@ -170,6 +178,7 @@ class ContaoSetupCommandTest extends ContaoTestCase
 
         if ($existingDotEnvFile) {
             $filesystem->touch($dotEnvFile);
+            $filesystem->touch($dotEnvLocalFile);
         }
 
         $command = new ContaoSetupCommand(
@@ -197,12 +206,15 @@ class ContaoSetupCommandTest extends ContaoTestCase
 
         if (!$existingDotEnvFile) {
             $this->assertStringContainsString(
-                '[INFO] An empty .env file was created.',
+                'An empty .env file was created.',
+                $commandTester->getDisplay(),
+            );
+
+            $this->assertStringContainsString(
+                'An empty .env.local file was created.',
                 $commandTester->getDisplay(),
             );
         }
-
-        $filesystem->remove([$dotEnvFile, $dotEnvLocalFile]);
     }
 
     public function testKeepsSymlinkedDotEnv(): void


### PR DESCRIPTION
This also adds the basic `COOKIE_ALLOW_LIST` to the generated `.env` (disabled of course). wdyt?