### PR TITLE
Fix PHPStan and the PHP 8.4 tests

### DIFF
--- a/calendar-bundle/src/Picker/EventPickerProvider.php
+++ b/calendar-bundle/src/Picker/EventPickerProvider.php
@@ -80,7 +80,7 @@ class EventPickerProvider extends AbstractInsertTagPickerProvider implements Dca
         return sprintf($this->getInsertTag($config), $value);
     }
 
-    protected function getRouteParameters(PickerConfig $config = null): array
+    protected function getRouteParameters(?PickerConfig $config = null): array
     {
         $params = ['do' => 'calendar'];
 

--- a/calendar-bundle/src/Resources/contao/classes/Calendar.php
+++ b/calendar-bundle/src/Resources/contao/classes/Calendar.php
@@ -669,7 +669,7 @@ class Calendar extends Frontend
 	/**
 	 * Creates a sub request for the given URI.
 	 */
-	private function createSubRequest(string $uri, Request $request = null): Request
+	private function createSubRequest(string $uri, ?Request $request = null): Request
 	{
 		$cookies = null !== $request ? $request->cookies->all() : array();
 		$server = null !== $request ? $request->server->all() : array();

--- a/calendar-bundle/tests/Picker/EventPickerProviderTest.php
+++ b/calendar-bundle/tests/Picker/EventPickerProviderTest.php
@@ -212,7 +212,7 @@ class EventPickerProviderTest extends ContaoTestCase
         $this->assertArrayNotHasKey('id', $params);
     }
 
-    private function getPicker(bool $accessGranted = null): EventPickerProvider
+    private function getPicker(?bool $accessGranted = null): EventPickerProvider
     {
         $security = $this->createMock(Security::class);
         $security

--- a/comments-bundle/src/Util/Node.php
+++ b/comments-bundle/src/Util/Node.php
@@ -47,7 +47,7 @@ final class Node
      */
     public $children = [];
 
-    public function __construct(self $parent = null, int $type = self::TYPE_ROOT)
+    public function __construct(?self $parent = null, int $type = self::TYPE_ROOT)
     {
         $this->parent = $parent;
         $this->type = $type;

--- a/composer.json
+++ b/composer.json
@@ -281,7 +281,7 @@
     "extra": {
         "bamarni-bin": {
             "bin-links": false,
-            "forward-command": true
+            "forward-command": false
         },
         "contao-manager-plugin": {
             "contao/calendar-bundle": "Contao\\CalendarBundle\\ContaoManager\\Plugin",

--- a/core-bundle/src/Cache/EntityCacheTags.php
+++ b/core-bundle/src/Cache/EntityCacheTags.php
@@ -38,7 +38,7 @@ class EntityCacheTags
      */
     private array $classMetadata = [];
 
-    public function __construct(EntityManagerInterface $entityManager, ResponseTagger $responseTagger = null, CacheInvalidator $cacheInvalidator = null)
+    public function __construct(EntityManagerInterface $entityManager, ?ResponseTagger $responseTagger = null, ?CacheInvalidator $cacheInvalidator = null)
     {
         $this->entityManager = $entityManager;
         $this->responseTagger = $responseTagger;

--- a/core-bundle/src/Command/AbstractLockedCommand.php
+++ b/core-bundle/src/Command/AbstractLockedCommand.php
@@ -29,7 +29,7 @@ abstract class AbstractLockedCommand extends Command implements ContainerAwareIn
 {
     private ?ContainerInterface $container = null;
 
-    public function setContainer(ContainerInterface $container = null): void
+    public function setContainer(?ContainerInterface $container = null): void
     {
         $this->container = $container;
     }

--- a/core-bundle/src/Command/DebugPagesCommand.php
+++ b/core-bundle/src/Command/DebugPagesCommand.php
@@ -57,7 +57,7 @@ class DebugPagesCommand extends Command
     /**
      * @param ContentCompositionInterface|bool $contentComposition
      */
-    public function add(string $type, RouteConfig $config, DynamicRouteInterface $routeEnhancer = null, $contentComposition = true): void
+    public function add(string $type, RouteConfig $config, ?DynamicRouteInterface $routeEnhancer = null, $contentComposition = true): void
     {
         $this->routeConfigs[$type] = $config;
 

--- a/core-bundle/src/Command/MigrateCommand.php
+++ b/core-bundle/src/Command/MigrateCommand.php
@@ -51,7 +51,7 @@ class MigrateCommand extends Command
     private ?Installer $installer;
     private ?SymfonyStyle $io = null;
 
-    public function __construct(MigrationCollection $migrations, FileLocator $fileLocator, string $projectDir, ContaoFramework $framework, BackupManager $backupManager, SchemaProvider $schemaProvider, MysqlInnodbRowSizeCalculator $rowSizeCalculator, Connection $connection, Installer $installer = null)
+    public function __construct(MigrationCollection $migrations, FileLocator $fileLocator, string $projectDir, ContaoFramework $framework, BackupManager $backupManager, SchemaProvider $schemaProvider, MysqlInnodbRowSizeCalculator $rowSizeCalculator, Connection $connection, ?Installer $installer = null)
     {
         $this->migrations = $migrations;
         $this->fileLocator = $fileLocator;
@@ -251,7 +251,7 @@ class MigrateCommand extends Command
         return false;
     }
 
-    private function executeMigrations(bool &$dryRun, bool $asJson, string $specifiedHash = null): bool
+    private function executeMigrations(bool &$dryRun, bool $asJson, ?string $specifiedHash = null): bool
     {
         $loopControl = 19;
 
@@ -407,7 +407,7 @@ class MigrateCommand extends Command
         (new Filesystem())->remove($filePath);
     }
 
-    private function executeSchemaDiff(bool $dryRun, bool $asJson, bool $withDeletesOption, string $specifiedHash = null): bool
+    private function executeSchemaDiff(bool $dryRun, bool $asJson, bool $withDeletesOption, ?string $specifiedHash = null): bool
     {
         if (null === $this->installer) {
             $this->io->error('Service "contao_installation.database.installer" not found. The installation bundle needs to be installed in order to execute schema diff migrations.');

--- a/core-bundle/src/Command/ResizeImagesCommand.php
+++ b/core-bundle/src/Command/ResizeImagesCommand.php
@@ -55,7 +55,7 @@ class ResizeImagesCommand extends Command
     private ?ConsoleSectionOutput $tableOutput = null;
     private ?Table $table = null;
 
-    public function __construct(ImageFactoryInterface $imageFactory, ResizerInterface $resizer, string $targetDir, DeferredImageStorageInterface $storage, Filesystem $filesystem = null)
+    public function __construct(ImageFactoryInterface $imageFactory, ResizerInterface $resizer, string $targetDir, DeferredImageStorageInterface $storage, ?Filesystem $filesystem = null)
     {
         $this->imageFactory = $imageFactory;
         $this->resizer = $resizer instanceof DeferredResizerInterface ? $resizer : null;

--- a/core-bundle/src/Command/UserCreateCommand.php
+++ b/core-bundle/src/Command/UserCreateCommand.php
@@ -192,7 +192,7 @@ class UserCreateCommand extends Command
         return 0;
     }
 
-    private function ask(string $label, InputInterface $input, OutputInterface $output, callable $callback = null): string
+    private function ask(string $label, InputInterface $input, OutputInterface $output, ?callable $callback = null): string
     {
         $question = new Question($label);
         $question->setMaxAttempts(3);
@@ -245,7 +245,7 @@ class UserCreateCommand extends Command
         return $this->connection->fetchAllKeyValue('SELECT id, name FROM tl_user_group');
     }
 
-    private function persistUser(string $username, string $name, string $email, string $password, string $language, bool $isAdmin = false, array $groups = null, bool $pwChange = false): void
+    private function persistUser(string $username, string $name, string $email, string $password, string $language, bool $isAdmin = false, ?array $groups = null, bool $pwChange = false): void
     {
         $time = time();
         $hash = $this->passwordHasherFactory->getPasswordHasher(BackendUser::class)->hash($password);

--- a/core-bundle/src/Config/Loader/PhpFileLoader.php
+++ b/core-bundle/src/Config/Loader/PhpFileLoader.php
@@ -37,7 +37,7 @@ use Symfony\Component\Filesystem\Path;
  */
 class PhpFileLoader extends Loader
 {
-    public function load($resource, string $type = null): string
+    public function load($resource, ?string $type = null): string
     {
         [$code, $namespace] = $this->parseFile((string) $resource);
 
@@ -48,7 +48,7 @@ class PhpFileLoader extends Loader
         return $code;
     }
 
-    public function supports($resource, string $type = null): bool
+    public function supports($resource, ?string $type = null): bool
     {
         return 'php' === Path::getExtension((string) $resource, true);
     }

--- a/core-bundle/src/Config/Loader/XliffFileLoader.php
+++ b/core-bundle/src/Config/Loader/XliffFileLoader.php
@@ -29,12 +29,12 @@ class XliffFileLoader extends Loader
         $this->addToGlobals = $addToGlobals;
     }
 
-    public function load($resource, string $type = null): string
+    public function load($resource, ?string $type = null): string
     {
         return $this->convertXlfToPhp((string) $resource, $type ?: 'en');
     }
 
-    public function supports($resource, string $type = null): bool
+    public function supports($resource, ?string $type = null): bool
     {
         return 'xlf' === Path::getExtension((string) $resource, true);
     }

--- a/core-bundle/src/Controller/AbstractBackendController.php
+++ b/core-bundle/src/Controller/AbstractBackendController.php
@@ -25,7 +25,7 @@ abstract class AbstractBackendController extends AbstractController
     /**
      * Renders a Twig template with additional context for "@Contao/be_main".
      */
-    protected function render(string $view, array $parameters = [], Response $response = null): Response
+    protected function render(string $view, array $parameters = [], ?Response $response = null): Response
     {
         $backendContext = (new class() extends BackendMain {
             public function __invoke(): array

--- a/core-bundle/src/Controller/AbstractFragmentController.php
+++ b/core-bundle/src/Controller/AbstractFragmentController.php
@@ -120,7 +120,7 @@ abstract class AbstractFragmentController extends AbstractController implements 
     /**
      * @param string|array $cssID
      */
-    protected function addCssAttributesToTemplate(Template $template, string $templateName, $cssID, array $classes = null): void
+    protected function addCssAttributesToTemplate(Template $template, string $templateName, $cssID, ?array $classes = null): void
     {
         $data = StringUtil::deserialize($cssID, true);
         $template->class = trim($templateName.' '.($data[1] ?? ''));
@@ -161,7 +161,7 @@ abstract class AbstractFragmentController extends AbstractController implements 
         return Container::underscore($className);
     }
 
-    protected function render(string $view, array $parameters = [], Response $response = null): Response
+    protected function render(string $view, array $parameters = [], ?Response $response = null): Response
     {
         if (null === $response) {
             $response = new Response();

--- a/core-bundle/src/Controller/BackendCsvImportController.php
+++ b/core-bundle/src/Controller/BackendCsvImportController.php
@@ -99,7 +99,7 @@ class BackendCsvImportController
         );
     }
 
-    private function importFromTemplate(callable $callback, string $table, string $field, int $id, string $submitLabel = null, bool $allowLinebreak = false): Response
+    private function importFromTemplate(callable $callback, string $table, string $field, int $id, ?string $submitLabel = null, bool $allowLinebreak = false): Response
     {
         $request = $this->requestStack->getCurrentRequest();
 

--- a/core-bundle/src/Controller/BackendCsvImportController.php
+++ b/core-bundle/src/Controller/BackendCsvImportController.php
@@ -169,7 +169,7 @@ class BackendCsvImportController
         foreach ($files as $file) {
             $fp = fopen($file, 'r');
 
-            while (false !== ($row = fgetcsv($fp, 0, $delimiter))) {
+            while (false !== ($row = fgetcsv($fp, 0, $delimiter, '"', '\\'))) {
                 $data = $callback($data, $row);
             }
         }

--- a/core-bundle/src/Controller/ContentElement/AbstractContentElementController.php
+++ b/core-bundle/src/Controller/ContentElement/AbstractContentElementController.php
@@ -20,7 +20,7 @@ use Symfony\Component\HttpFoundation\Response;
 
 abstract class AbstractContentElementController extends AbstractFragmentController
 {
-    public function __invoke(Request $request, ContentModel $model, string $section, array $classes = null): Response
+    public function __invoke(Request $request, ContentModel $model, string $section, ?array $classes = null): Response
     {
         $type = $this->getType();
         $template = $this->createTemplate($model, 'ce_'.$type);

--- a/core-bundle/src/Controller/FrontendModule/AbstractFrontendModuleController.php
+++ b/core-bundle/src/Controller/FrontendModule/AbstractFrontendModuleController.php
@@ -22,7 +22,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 abstract class AbstractFrontendModuleController extends AbstractFragmentController
 {
-    public function __invoke(Request $request, ModuleModel $model, string $section, array $classes = null): Response
+    public function __invoke(Request $request, ModuleModel $model, string $section, ?array $classes = null): Response
     {
         if ($this->container->get('contao.routing.scope_matcher')->isBackendRequest($request)) {
             return $this->getBackendWildcard($model);

--- a/core-bundle/src/Controller/FrontendModule/RootPageDependentModulesController.php
+++ b/core-bundle/src/Controller/FrontendModule/RootPageDependentModulesController.php
@@ -21,7 +21,7 @@ use Symfony\Component\HttpFoundation\Response;
 
 class RootPageDependentModulesController extends AbstractFrontendModuleController
 {
-    public function __invoke(Request $request, ModuleModel $model, string $section, array $classes = null): Response
+    public function __invoke(Request $request, ModuleModel $model, string $section, ?array $classes = null): Response
     {
         if ($this->container->get('contao.routing.scope_matcher')->isBackendRequest($request)) {
             return $this->getBackendWildcard($model);

--- a/core-bundle/src/Controller/FrontendModule/TwoFactorController.php
+++ b/core-bundle/src/Controller/FrontendModule/TwoFactorController.php
@@ -37,7 +37,7 @@ class TwoFactorController extends AbstractFrontendModuleController
 {
     protected ?PageModel $pageModel = null;
 
-    public function __invoke(Request $request, ModuleModel $model, string $section, array $classes = null, PageModel $pageModel = null): Response
+    public function __invoke(Request $request, ModuleModel $model, string $section, ?array $classes = null, ?PageModel $pageModel = null): Response
     {
         if (!$this->container->get('security.helper')->isGranted('IS_AUTHENTICATED_FULLY')) {
             // TODO: front end users should be able to re-authenticate after REMEMBERME

--- a/core-bundle/src/Controller/ImagesController.php
+++ b/core-bundle/src/Controller/ImagesController.php
@@ -33,7 +33,7 @@ class ImagesController
     private string $targetDir;
     private Filesystem $filesystem;
 
-    public function __construct(ImageFactoryInterface $imageFactory, ResizerInterface $resizer, string $targetDir, Filesystem $filesystem = null)
+    public function __construct(ImageFactoryInterface $imageFactory, ResizerInterface $resizer, string $targetDir, ?Filesystem $filesystem = null)
     {
         $this->imageFactory = $imageFactory;
         $this->resizer = $resizer;

--- a/core-bundle/src/Controller/Page/RootPageController.php
+++ b/core-bundle/src/Controller/Page/RootPageController.php
@@ -28,7 +28,7 @@ class RootPageController extends AbstractController
 {
     private ?LoggerInterface $logger;
 
-    public function __construct(LoggerInterface $logger = null)
+    public function __construct(?LoggerInterface $logger = null)
     {
         $this->logger = $logger;
     }

--- a/core-bundle/src/Crawl/Escargot/Factory.php
+++ b/core-bundle/src/Crawl/Escargot/Factory.php
@@ -57,7 +57,7 @@ class Factory
      */
     private ?\Closure $httpClientFactory;
 
-    public function __construct(Connection $connection, ContaoFramework $framework, RequestStack $requestStack, array $additionalUris = [], array $defaultHttpClientOptions = [], \Closure $httpClientFactory = null)
+    public function __construct(Connection $connection, ContaoFramework $framework, RequestStack $requestStack, array $additionalUris = [], array $defaultHttpClientOptions = [], ?\Closure $httpClientFactory = null)
     {
         $this->connection = $connection;
         $this->framework = $framework;

--- a/core-bundle/src/Crawl/Escargot/Subscriber/BrokenLinkCheckerSubscriber.php
+++ b/core-bundle/src/Crawl/Escargot/Subscriber/BrokenLinkCheckerSubscriber.php
@@ -115,7 +115,7 @@ class BrokenLinkCheckerSubscriber implements EscargotSubscriberInterface, Escarg
         // noop
     }
 
-    public function getResult(SubscriberResult $previousResult = null): SubscriberResult
+    public function getResult(?SubscriberResult $previousResult = null): SubscriberResult
     {
         $stats = $this->stats;
 

--- a/core-bundle/src/Crawl/Escargot/Subscriber/EscargotSubscriberInterface.php
+++ b/core-bundle/src/Crawl/Escargot/Subscriber/EscargotSubscriberInterface.php
@@ -26,5 +26,5 @@ interface EscargotSubscriberInterface extends SubscriberInterface
      * results might be e.g. stored between requests, so you might have a
      * previous result of your subscriber.
      */
-    public function getResult(SubscriberResult $previousResult = null): SubscriberResult;
+    public function getResult(?SubscriberResult $previousResult = null): SubscriberResult;
 }

--- a/core-bundle/src/Crawl/Escargot/Subscriber/SearchIndexSubscriber.php
+++ b/core-bundle/src/Crawl/Escargot/Subscriber/SearchIndexSubscriber.php
@@ -218,7 +218,7 @@ class SearchIndexSubscriber implements EscargotSubscriberInterface, EscargotAwar
         }
     }
 
-    public function getResult(SubscriberResult $previousResult = null): SubscriberResult
+    public function getResult(?SubscriberResult $previousResult = null): SubscriberResult
     {
         $stats = $this->stats;
 

--- a/core-bundle/src/Crawl/Monolog/CrawlCsvLogHandler.php
+++ b/core-bundle/src/Crawl/Monolog/CrawlCsvLogHandler.php
@@ -58,7 +58,7 @@ class CrawlCsvLogHandler extends StreamHandler
                 'Found on level',
                 'Tags',
                 'Message',
-            ]);
+            ], ',', '"', '\\');
         }
 
         $columns = [
@@ -71,6 +71,6 @@ class CrawlCsvLogHandler extends StreamHandler
             preg_replace('/\r\n|\n|\r/', ' ', $record['message']),
         ];
 
-        fputcsv($stream, $columns);
+        fputcsv($stream, $columns, ',', '"', '\\');
     }
 }

--- a/core-bundle/src/Cron/Cron.php
+++ b/core-bundle/src/Cron/Cron.php
@@ -45,7 +45,7 @@ class Cron
      * @param \Closure():CronJobRepository      $repository
      * @param \Closure():EntityManagerInterface $entityManager
      */
-    public function __construct(\Closure $repository, \Closure $entityManager, LoggerInterface $logger = null)
+    public function __construct(\Closure $repository, \Closure $entityManager, ?LoggerInterface $logger = null)
     {
         $this->repository = $repository;
         $this->entityManager = $entityManager;

--- a/core-bundle/src/Cron/CronJob.php
+++ b/core-bundle/src/Cron/CronJob.php
@@ -20,7 +20,7 @@ class CronJob
     private string $name;
     private \DateTimeInterface $previousRun;
 
-    public function __construct(object $service, string $interval, string $method = null)
+    public function __construct(object $service, string $interval, ?string $method = null)
     {
         $this->service = $service;
         $this->method = $method;

--- a/core-bundle/src/Csrf/ContaoCsrfTokenManager.php
+++ b/core-bundle/src/Csrf/ContaoCsrfTokenManager.php
@@ -40,7 +40,7 @@ class ContaoCsrfTokenManager extends CsrfTokenManager implements ResetInterface
     /**
      * @param string|RequestStack|callable|null $namespace
      */
-    public function __construct(RequestStack $requestStack, string $csrfCookiePrefix, TokenGeneratorInterface $generator = null, TokenStorageInterface $storage = null, $namespace = null, string $defaultTokenName = null)
+    public function __construct(RequestStack $requestStack, string $csrfCookiePrefix, ?TokenGeneratorInterface $generator = null, ?TokenStorageInterface $storage = null, $namespace = null, ?string $defaultTokenName = null)
     {
         $this->requestStack = $requestStack;
         $this->csrfCookiePrefix = $csrfCookiePrefix;

--- a/core-bundle/src/DataCollector/ContaoDataCollector.php
+++ b/core-bundle/src/DataCollector/ContaoDataCollector.php
@@ -48,7 +48,7 @@ class ContaoDataCollector extends DataCollector implements FrameworkAwareInterfa
         $this->urlSuffix = $urlSuffix;
     }
 
-    public function collect(Request $request, Response $response, \Throwable $exception = null): void
+    public function collect(Request $request, Response $response, ?\Throwable $exception = null): void
     {
         $this->data = ['contao_version' => ContaoCoreBundle::getVersion()];
 

--- a/core-bundle/src/DataContainer/PaletteManipulator.php
+++ b/core-bundle/src/DataContainer/PaletteManipulator.php
@@ -86,7 +86,7 @@ class PaletteManipulator
      *
      * @param string|array $name
      */
-    public function removeField($name, string $legend = null): self
+    public function removeField($name, ?string $legend = null): self
     {
         $this->removes[] = [
             'fields' => (array) $name,

--- a/core-bundle/src/DependencyInjection/Attribute/AsContentElement.php
+++ b/core-bundle/src/DependencyInjection/Attribute/AsContentElement.php
@@ -23,7 +23,7 @@ class AsContentElement
     /**
      * @param mixed ...$attributes
      */
-    public function __construct(string $type = null, string $category = 'miscellaneous', string $template = null, string $method = null, string $renderer = null, ...$attributes)
+    public function __construct(?string $type = null, string $category = 'miscellaneous', ?string $template = null, ?string $method = null, ?string $renderer = null, ...$attributes)
     {
         $attributes['type'] = $type;
         $attributes['category'] = $category;

--- a/core-bundle/src/DependencyInjection/Attribute/AsFrontendModule.php
+++ b/core-bundle/src/DependencyInjection/Attribute/AsFrontendModule.php
@@ -23,7 +23,7 @@ class AsFrontendModule
     /**
      * @param mixed ...$attributes
      */
-    public function __construct(string $type = null, string $category = 'miscellaneous', string $template = null, string $method = null, string $renderer = null, ...$attributes)
+    public function __construct(?string $type = null, string $category = 'miscellaneous', ?string $template = null, ?string $method = null, ?string $renderer = null, ...$attributes)
     {
         $attributes['type'] = $type;
         $attributes['category'] = $category;

--- a/core-bundle/src/DependencyInjection/Attribute/AsPage.php
+++ b/core-bundle/src/DependencyInjection/Attribute/AsPage.php
@@ -23,7 +23,7 @@ class AsPage
     /**
      * @param string|bool|null $path
      */
-    public function __construct(public ?string $type = null, public $path = null, public array $requirements = [], public array $options = [], public array $defaults = [], public array $methods = [], string $locale = null, string $format = null, public bool $contentComposition = true, public ?string $urlSuffix = null)
+    public function __construct(public ?string $type = null, public $path = null, public array $requirements = [], public array $options = [], public array $defaults = [], public array $methods = [], ?string $locale = null, ?string $format = null, public bool $contentComposition = true, public ?string $urlSuffix = null)
     {
         if (null !== $locale) {
             $this->defaults['_locale'] = $locale;

--- a/core-bundle/src/DependencyInjection/Compiler/IntlInstalledLocalesAndCountriesPass.php
+++ b/core-bundle/src/DependencyInjection/Compiler/IntlInstalledLocalesAndCountriesPass.php
@@ -28,6 +28,7 @@ class IntlInstalledLocalesAndCountriesPass implements CompilerPassInterface
             $definition = $container->findDefinition('contao.intl.locales');
 
             // Backwards compatibility for the deprecated contao.locales parameter
+            /** @var array<int, string> $enabledLocales */
             $enabledLocales = $container->getParameter('contao.locales') ?: $this->getEnabledLocales($container);
             $locales = array_values(array_unique(array_merge($enabledLocales, \ResourceBundle::getLocales(''))));
 

--- a/core-bundle/src/DependencyInjection/Compiler/RegisterFragmentsPass.php
+++ b/core-bundle/src/DependencyInjection/Compiler/RegisterFragmentsPass.php
@@ -41,7 +41,7 @@ class RegisterFragmentsPass implements CompilerPassInterface
     private ?string $proxyClass;
     private ?string $templateOptionsListener;
 
-    public function __construct(string $tag = null, string $globalsKey = null, string $proxyClass = null, string $templateOptionsListener = null)
+    public function __construct(?string $tag = null, ?string $globalsKey = null, ?string $proxyClass = null, ?string $templateOptionsListener = null)
     {
         if (null === $tag) {
             trigger_deprecation('contao/core-bundle', '4.9', 'Initializing "Contao\CoreBundle\DependencyInjection\Compiler\RegisterFragmentsPass" objects without passing the tag name as argument has been deprecated and will no longer work in Contao 5.0.');

--- a/core-bundle/src/DependencyInjection/Filesystem/FilesystemConfiguration.php
+++ b/core-bundle/src/DependencyInjection/Filesystem/FilesystemConfiguration.php
@@ -85,7 +85,7 @@ class FilesystemConfiguration
      * If you do not set a name, the id/alias for the adapter service will be
      * derived from the mount path.
      */
-    public function mountAdapter(string $adapter, array $options, string $mountPath, string $name = null): self
+    public function mountAdapter(string $adapter, array $options, string $mountPath, ?string $name = null): self
     {
         $name ??= str_replace(['.', '/', '-'], '_', Container::underscore($mountPath));
         $adapterId = "contao.filesystem.adapter.$name";
@@ -126,7 +126,7 @@ class FilesystemConfiguration
      * If you do not set a name, the id for the adapter service will be derived
      * from the mount path.
      */
-    public function mountLocalAdapter(string $filesystemPath, string $mountPath, string $name = null): self
+    public function mountLocalAdapter(string $filesystemPath, string $mountPath, ?string $name = null): self
     {
         $path = Path::isAbsolute($filesystemPath)
             ? Path::canonicalize($filesystemPath)

--- a/core-bundle/src/Doctrine/Backup/Backup.php
+++ b/core-bundle/src/Doctrine/Backup/Backup.php
@@ -60,7 +60,7 @@ class Backup
         return $this;
     }
 
-    public static function createNew(\DateTime $dateTime = null): self
+    public static function createNew(?\DateTime $dateTime = null): self
     {
         $now = $dateTime ?? new \DateTime('now');
         $now->setTimezone(new \DateTimeZone('UTC'));

--- a/core-bundle/src/Doctrine/Backup/BackupManager.php
+++ b/core-bundle/src/Doctrine/Backup/BackupManager.php
@@ -40,7 +40,7 @@ class BackupManager
         $this->retentionPolicy = $retentionPolicy;
     }
 
-    public function createNewBackup(\DateTime $dateTime = null): Backup
+    public function createNewBackup(?\DateTime $dateTime = null): Backup
     {
         $now = $dateTime ?? new \DateTime('now');
         $now->setTimezone(new \DateTimeZone('UTC'));

--- a/core-bundle/src/Entity/CronJob.php
+++ b/core-bundle/src/Entity/CronJob.php
@@ -43,7 +43,7 @@ class CronJob
      */
     protected \DateTimeInterface $lastRun;
 
-    public function __construct(string $name, \DateTimeInterface $lastRun = null)
+    public function __construct(string $name, ?\DateTimeInterface $lastRun = null)
     {
         $this->name = $name;
         $this->lastRun = $lastRun ?? new \DateTime();

--- a/core-bundle/src/Event/ImageSizesEvent.php
+++ b/core-bundle/src/Event/ImageSizesEvent.php
@@ -20,7 +20,7 @@ class ImageSizesEvent extends Event
     private array $imageSizes;
     private ?BackendUser $user;
 
-    public function __construct(array $imageSizes, BackendUser $user = null)
+    public function __construct(array $imageSizes, ?BackendUser $user = null)
     {
         $this->imageSizes = $imageSizes;
         $this->user = $user;

--- a/core-bundle/src/EventListener/DataContainer/ContentCompositionListener.php
+++ b/core-bundle/src/EventListener/DataContainer/ContentCompositionListener.php
@@ -152,7 +152,7 @@ class ContentCompositionListener
     /**
      * @Callback(table="tl_article", target="list.sorting.paste_button")
      */
-    public function renderArticlePasteButton(DataContainer $dc, array $row, string $table, bool $cr, array $clipboard = null): string
+    public function renderArticlePasteButton(DataContainer $dc, array $row, string $table, bool $cr, ?array $clipboard = null): string
     {
         if ($table === ($GLOBALS['TL_DCA'][$dc->table]['config']['ptable'] ?? null)) {
             return $this->renderArticlePasteIntoButton($dc, $row, $cr, $clipboard);
@@ -161,7 +161,7 @@ class ContentCompositionListener
         return $this->renderArticlePasteAfterButton($dc, $row, $cr, $clipboard);
     }
 
-    private function renderArticlePasteIntoButton(DataContainer $dc, array $row, bool $cr, array $clipboard = null): string
+    private function renderArticlePasteIntoButton(DataContainer $dc, array $row, bool $cr, ?array $clipboard = null): string
     {
         $pageModel = $this->framework->createInstance(PageModel::class);
         $pageModel->preventSaving(false);
@@ -184,7 +184,7 @@ class ContentCompositionListener
         );
     }
 
-    private function renderArticlePasteAfterButton(DataContainer $dc, array $row, bool $cr, array $clipboard = null): string
+    private function renderArticlePasteAfterButton(DataContainer $dc, array $row, bool $cr, ?array $clipboard = null): string
     {
         $pageAdapter = $this->framework->getAdapter(PageModel::class);
         $pageModel = $pageAdapter->findByPk($row['pid']);

--- a/core-bundle/src/EventListener/DataContainer/PageTypeOptionsListener.php
+++ b/core-bundle/src/EventListener/DataContainer/PageTypeOptionsListener.php
@@ -31,7 +31,7 @@ class PageTypeOptionsListener
     private Security $security;
     private ?EventDispatcherInterface $eventDispatcher;
 
-    public function __construct(PageRegistry $pageRegistry, Security $security, EventDispatcherInterface $eventDispatcher = null)
+    public function __construct(PageRegistry $pageRegistry, Security $security, ?EventDispatcherInterface $eventDispatcher = null)
     {
         $this->pageRegistry = $pageRegistry;
         $this->security = $security;

--- a/core-bundle/src/EventListener/DataContainer/TemplateOptionsListener.php
+++ b/core-bundle/src/EventListener/DataContainer/TemplateOptionsListener.php
@@ -33,7 +33,7 @@ class TemplateOptionsListener
      */
     private array $defaultIdentifiersByType = [];
 
-    public function __construct(FinderFactory $finderFactory, Connection $connection, ContaoFramework $framework, RequestStack $requestStack, string $legacyTemplatePrefix, string $legacyProxyClass = null)
+    public function __construct(FinderFactory $finderFactory, Connection $connection, ContaoFramework $framework, RequestStack $requestStack, string $legacyTemplatePrefix, ?string $legacyProxyClass = null)
     {
         $this->finderFactory = $finderFactory;
         $this->connection = $connection;

--- a/core-bundle/src/EventListener/MergeHttpHeadersListener.php
+++ b/core-bundle/src/EventListener/MergeHttpHeadersListener.php
@@ -37,7 +37,7 @@ class MergeHttpHeadersListener implements ResetInterface
         'cache-control',
     ];
 
-    public function __construct(ContaoFramework $framework, HeaderStorageInterface $headerStorage = null)
+    public function __construct(ContaoFramework $framework, ?HeaderStorageInterface $headerStorage = null)
     {
         $this->framework = $framework;
         $this->headerStorage = $headerStorage ?: new NativeHeaderStorage();

--- a/core-bundle/src/EventListener/PageTrailCacheTagsListener.php
+++ b/core-bundle/src/EventListener/PageTrailCacheTagsListener.php
@@ -22,7 +22,7 @@ class PageTrailCacheTagsListener
     private ScopeMatcher $scopeMatcher;
     private ?ResponseTagger $responseTagger;
 
-    public function __construct(ScopeMatcher $scopeMatcher, ResponseTagger $responseTagger = null)
+    public function __construct(ScopeMatcher $scopeMatcher, ?ResponseTagger $responseTagger = null)
     {
         $this->scopeMatcher = $scopeMatcher;
         $this->responseTagger = $responseTagger;

--- a/core-bundle/src/EventListener/RobotsTxtListener.php
+++ b/core-bundle/src/EventListener/RobotsTxtListener.php
@@ -30,7 +30,7 @@ class RobotsTxtListener
     private ?WebDebugToolbarListener $webDebugToolbarListener;
     private string $routePrefix;
 
-    public function __construct(ContaoFramework $contaoFramework, WebDebugToolbarListener $webDebugToolbarListener = null, string $routePrefix = '/contao')
+    public function __construct(ContaoFramework $contaoFramework, ?WebDebugToolbarListener $webDebugToolbarListener = null, string $routePrefix = '/contao')
     {
         $this->contaoFramework = $contaoFramework;
         $this->webDebugToolbarListener = $webDebugToolbarListener;

--- a/core-bundle/src/EventListener/StoreRefererListener.php
+++ b/core-bundle/src/EventListener/StoreRefererListener.php
@@ -100,7 +100,7 @@ class StoreRefererListener
     /**
      * @return array<string,array<string,string>>
      */
-    private function prepareBackendReferer(string $refererId, array $referers = null): array
+    private function prepareBackendReferer(string $refererId, ?array $referers = null): array
     {
         if (!\is_array($referers)) {
             $referers = [];

--- a/core-bundle/src/Exception/AjaxRedirectResponseException.php
+++ b/core-bundle/src/Exception/AjaxRedirectResponseException.php
@@ -16,7 +16,7 @@ use Symfony\Component\HttpFoundation\Response;
 
 class AjaxRedirectResponseException extends ResponseException
 {
-    public function __construct(string $location, int $status = 303, \Exception $previous = null)
+    public function __construct(string $location, int $status = 303, ?\Exception $previous = null)
     {
         parent::__construct(new Response($location, $status, ['X-Ajax-Location' => $location]), $previous);
     }

--- a/core-bundle/src/Exception/DuplicateAliasException.php
+++ b/core-bundle/src/Exception/DuplicateAliasException.php
@@ -19,7 +19,7 @@ class DuplicateAliasException extends \RuntimeException
     private string $url;
     private ?PageModel $pageModel = null;
 
-    public function __construct(string $url, string $message = '', int $code = 0, \Throwable $previous = null)
+    public function __construct(string $url, string $message = '', int $code = 0, ?\Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);
 

--- a/core-bundle/src/Exception/InternalServerErrorHttpException.php
+++ b/core-bundle/src/Exception/InternalServerErrorHttpException.php
@@ -16,7 +16,7 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class InternalServerErrorHttpException extends HttpException
 {
-    public function __construct(string $message = null, \Throwable $previous = null, int $code = 0)
+    public function __construct(?string $message = null, ?\Throwable $previous = null, int $code = 0)
     {
         parent::__construct(500, $message, $previous, [], $code);
     }

--- a/core-bundle/src/Exception/NoContentResponseException.php
+++ b/core-bundle/src/Exception/NoContentResponseException.php
@@ -16,7 +16,7 @@ use Symfony\Component\HttpFoundation\Response;
 
 class NoContentResponseException extends ResponseException
 {
-    public function __construct(\Exception $previous = null)
+    public function __construct(?\Exception $previous = null)
     {
         parent::__construct(new Response('', 204), $previous);
     }

--- a/core-bundle/src/Exception/RedirectResponseException.php
+++ b/core-bundle/src/Exception/RedirectResponseException.php
@@ -16,7 +16,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 
 class RedirectResponseException extends ResponseException
 {
-    public function __construct(string $location, int $status = 303, \Exception $previous = null)
+    public function __construct(string $location, int $status = 303, ?\Exception $previous = null)
     {
         parent::__construct(new RedirectResponse($location, $status), $previous);
     }

--- a/core-bundle/src/Exception/ResponseException.php
+++ b/core-bundle/src/Exception/ResponseException.php
@@ -18,7 +18,7 @@ class ResponseException extends \RuntimeException
 {
     private Response $response;
 
-    public function __construct(Response $response, \Exception $previous = null)
+    public function __construct(Response $response, ?\Exception $previous = null)
     {
         $this->response = $response;
 

--- a/core-bundle/src/File/Metadata.php
+++ b/core-bundle/src/File/Metadata.php
@@ -48,7 +48,7 @@ class Metadata
      * @param array<string, mixed>      $values
      * @param array<string, array>|null $schemaOrgJsonLd
      */
-    public function __construct(array $values, array $schemaOrgJsonLd = null)
+    public function __construct(array $values, ?array $schemaOrgJsonLd = null)
     {
         $this->values = $values;
         $this->schemaOrgJsonLd = $schemaOrgJsonLd;
@@ -136,7 +136,7 @@ class Metadata
         return empty($this->values);
     }
 
-    public function getSchemaOrgData(string $type = null): array
+    public function getSchemaOrgData(?string $type = null): array
     {
         // Lazy initialize
         if (null === $this->schemaOrgJsonLd) {

--- a/core-bundle/src/Filesystem/Dbafs/Hashing/Context.php
+++ b/core-bundle/src/Filesystem/Dbafs/Hashing/Context.php
@@ -29,7 +29,7 @@ final class Context
     /**
      * @internal
      */
-    public function __construct(string $fallback = null, int $oldLastModified = null)
+    public function __construct(?string $fallback = null, ?int $oldLastModified = null)
     {
         $this->oldHash = $fallback;
         $this->oldLastModified = $this->newLastModified = $oldLastModified;

--- a/core-bundle/src/Filesystem/FilesystemItem.php
+++ b/core-bundle/src/Filesystem/FilesystemItem.php
@@ -161,7 +161,7 @@ class FilesystemItem
         return $this->fileSize ?? 0;
     }
 
-    public function getMimeType(string $default = null): string
+    public function getMimeType(?string $default = null): string
     {
         $this->assertIsFile(__FUNCTION__);
         $exception = null;

--- a/core-bundle/src/Filesystem/MountManager.php
+++ b/core-bundle/src/Filesystem/MountManager.php
@@ -384,7 +384,7 @@ class MountManager
         }
     }
 
-    public function generatePublicUri(string $path, OptionsInterface $options = null): ?UriInterface
+    public function generatePublicUri(string $path, ?OptionsInterface $options = null): ?UriInterface
     {
         /** @var FilesystemAdapter $adapter */
         [$adapter, $adapterPath] = $this->getAdapterAndPath($path);

--- a/core-bundle/src/Filesystem/VirtualFilesystem.php
+++ b/core-bundle/src/Filesystem/VirtualFilesystem.php
@@ -272,7 +272,7 @@ class VirtualFilesystem implements VirtualFilesystemInterface
         $this->dbafsManager->setExtraMetadata($this->resolve($location), $metadata);
     }
 
-    public function generatePublicUri($location, OptionsInterface $options = null): ?UriInterface
+    public function generatePublicUri($location, ?OptionsInterface $options = null): ?UriInterface
     {
         $path = $this->resolve($location);
 

--- a/core-bundle/src/Filesystem/VirtualFilesystemException.php
+++ b/core-bundle/src/Filesystem/VirtualFilesystemException.php
@@ -31,7 +31,7 @@ class VirtualFilesystemException extends \RuntimeException
 
     private string $path;
 
-    private function __construct(string $path, string $message, int $code, \Throwable $previous = null)
+    private function __construct(string $path, string $message, int $code, ?\Throwable $previous = null)
     {
         $this->path = $path;
 
@@ -43,7 +43,7 @@ class VirtualFilesystemException extends \RuntimeException
         return $this->path;
     }
 
-    public static function unableToCheckIfFileExists(string $path, \Throwable $previous = null): self
+    public static function unableToCheckIfFileExists(string $path, ?\Throwable $previous = null): self
     {
         return new self(
             $path,
@@ -53,7 +53,7 @@ class VirtualFilesystemException extends \RuntimeException
         );
     }
 
-    public static function unableToCheckIfDirectoryExists(string $path, \Throwable $previous = null): self
+    public static function unableToCheckIfDirectoryExists(string $path, ?\Throwable $previous = null): self
     {
         return new self(
             $path,
@@ -63,7 +63,7 @@ class VirtualFilesystemException extends \RuntimeException
         );
     }
 
-    public static function unableToRead(string $path, \Throwable $previous = null): self
+    public static function unableToRead(string $path, ?\Throwable $previous = null): self
     {
         return new self(
             $path,
@@ -73,7 +73,7 @@ class VirtualFilesystemException extends \RuntimeException
         );
     }
 
-    public static function unableToWrite(string $path, \Throwable $previous = null): self
+    public static function unableToWrite(string $path, ?\Throwable $previous = null): self
     {
         return new self(
             $path,
@@ -83,7 +83,7 @@ class VirtualFilesystemException extends \RuntimeException
         );
     }
 
-    public static function unableToDelete(string $path, \Throwable $previous = null): self
+    public static function unableToDelete(string $path, ?\Throwable $previous = null): self
     {
         return new self(
             $path,
@@ -93,7 +93,7 @@ class VirtualFilesystemException extends \RuntimeException
         );
     }
 
-    public static function unableToDeleteDirectory(string $path, \Throwable $previous = null): self
+    public static function unableToDeleteDirectory(string $path, ?\Throwable $previous = null): self
     {
         return new self(
             $path,
@@ -103,7 +103,7 @@ class VirtualFilesystemException extends \RuntimeException
         );
     }
 
-    public static function unableToCreateDirectory(string $path, \Throwable $previous = null): self
+    public static function unableToCreateDirectory(string $path, ?\Throwable $previous = null): self
     {
         return new self(
             $path,
@@ -113,7 +113,7 @@ class VirtualFilesystemException extends \RuntimeException
         );
     }
 
-    public static function unableToCopy(string $pathFrom, string $pathTo, \Throwable $previous = null): self
+    public static function unableToCopy(string $pathFrom, string $pathTo, ?\Throwable $previous = null): self
     {
         return new self(
             $pathFrom,
@@ -123,7 +123,7 @@ class VirtualFilesystemException extends \RuntimeException
         );
     }
 
-    public static function unableToMove(string $pathFrom, string $pathTo, \Throwable $previous = null): self
+    public static function unableToMove(string $pathFrom, string $pathTo, ?\Throwable $previous = null): self
     {
         return new self(
             $pathFrom,
@@ -133,7 +133,7 @@ class VirtualFilesystemException extends \RuntimeException
         );
     }
 
-    public static function unableToListContents(string $path, \Throwable $previous = null): self
+    public static function unableToListContents(string $path, ?\Throwable $previous = null): self
     {
         return new self(
             $path,
@@ -143,7 +143,7 @@ class VirtualFilesystemException extends \RuntimeException
         );
     }
 
-    public static function unableToRetrieveMetadata(string $path, \Throwable $previous = null, string $reason = ''): self
+    public static function unableToRetrieveMetadata(string $path, ?\Throwable $previous = null, string $reason = ''): self
     {
         return new self(
             $path,

--- a/core-bundle/src/Filesystem/VirtualFilesystemInterface.php
+++ b/core-bundle/src/Filesystem/VirtualFilesystemInterface.php
@@ -186,5 +186,5 @@ interface VirtualFilesystemInterface
      *
      * @throws UnableToResolveUuidException
      */
-    public function generatePublicUri($location, OptionsInterface $options = null): ?UriInterface;
+    public function generatePublicUri($location, ?OptionsInterface $options = null): ?UriInterface;
 }

--- a/core-bundle/src/Framework/FrameworkAwareInterface.php
+++ b/core-bundle/src/Framework/FrameworkAwareInterface.php
@@ -14,5 +14,5 @@ namespace Contao\CoreBundle\Framework;
 
 interface FrameworkAwareInterface
 {
-    public function setFramework(ContaoFramework $framework = null);
+    public function setFramework(?ContaoFramework $framework = null);
 }

--- a/core-bundle/src/Framework/FrameworkAwareTrait.php
+++ b/core-bundle/src/Framework/FrameworkAwareTrait.php
@@ -16,7 +16,7 @@ trait FrameworkAwareTrait
 {
     protected ?ContaoFramework $framework = null;
 
-    public function setFramework(ContaoFramework $framework = null): void
+    public function setFramework(?ContaoFramework $framework = null): void
     {
         $this->framework = $framework;
     }

--- a/core-bundle/src/Image/ImageFactory.php
+++ b/core-bundle/src/Image/ImageFactory.php
@@ -46,7 +46,7 @@ class ImageFactory implements ImageFactoryInterface
     /**
      * @internal
      */
-    public function __construct(ResizerInterface $resizer, ImagineInterface $imagine, ImagineInterface $imagineSvg, Filesystem $filesystem, ContaoFramework $framework, bool $bypassCache, array $imagineOptions, array $validExtensions, string $uploadDir, LoggerInterface $logger = null)
+    public function __construct(ResizerInterface $resizer, ImagineInterface $imagine, ImagineInterface $imagineSvg, Filesystem $filesystem, ContaoFramework $framework, bool $bypassCache, array $imagineOptions, array $validExtensions, string $uploadDir, ?LoggerInterface $logger = null)
     {
         $this->resizer = $resizer;
         $this->imagine = $imagine;

--- a/core-bundle/src/Image/PictureFactory.php
+++ b/core-bundle/src/Image/PictureFactory.php
@@ -76,7 +76,7 @@ class PictureFactory implements PictureFactoryInterface
         $this->predefinedSizes = $predefinedSizes;
     }
 
-    public function create($path, $size = null, ResizeOptions $options = null): PictureInterface
+    public function create($path, $size = null, ?ResizeOptions $options = null): PictureInterface
     {
         $attributes = [];
 
@@ -270,7 +270,7 @@ class PictureFactory implements PictureFactoryInterface
     /**
      * Creates a picture configuration item.
      */
-    private function createConfigItem(array $imageSize = null): PictureConfigurationItem
+    private function createConfigItem(?array $imageSize = null): PictureConfigurationItem
     {
         $configItem = new PictureConfigurationItem();
         $resizeConfig = new ResizeConfiguration();

--- a/core-bundle/src/Image/Preview/PreviewFactory.php
+++ b/core-bundle/src/Image/Preview/PreviewFactory.php
@@ -167,7 +167,7 @@ class PreviewFactory
     /**
      * @param int|string|array|ResizeConfiguration|null $size
      */
-    public function createPreviewImage(string $path, $size = null, ResizeOptions $resizeOptions = null, int $page = 1, array $previewOptions = []): ImageInterface
+    public function createPreviewImage(string $path, $size = null, ?ResizeOptions $resizeOptions = null, int $page = 1, array $previewOptions = []): ImageInterface
     {
         return $this->imageFactory->create(
             $this->createPreview($path, $this->getPreviewSizeFromImageSize($size), $page, $previewOptions),
@@ -181,7 +181,7 @@ class PreviewFactory
      *
      * @return iterable<ImageInterface>
      */
-    public function createPreviewImages(string $path, $size = null, ResizeOptions $resizeOptions = null, int $lastPage = PHP_INT_MAX, int $firstPage = 1, array $previewOptions = []): iterable
+    public function createPreviewImages(string $path, $size = null, ?ResizeOptions $resizeOptions = null, int $lastPage = PHP_INT_MAX, int $firstPage = 1, array $previewOptions = []): iterable
     {
         $previews = $this->createPreviews(
             $path,
@@ -200,7 +200,7 @@ class PreviewFactory
     /**
      * @param int|string|array|PictureConfiguration|null $size
      */
-    public function createPreviewPicture(string $path, $size = null, ResizeOptions $resizeOptions = null, int $page = 1, array $previewOptions = []): PictureInterface
+    public function createPreviewPicture(string $path, $size = null, ?ResizeOptions $resizeOptions = null, int $page = 1, array $previewOptions = []): PictureInterface
     {
         $previewPath = $this->createPreview($path, $this->getPreviewSizeFromImageSize($size), $page, $previewOptions);
 
@@ -212,7 +212,7 @@ class PreviewFactory
      *
      * @return iterable<PictureInterface>
      */
-    public function createPreviewPictures(string $path, $size = null, ResizeOptions $resizeOptions = null, int $lastPage = PHP_INT_MAX, int $firstPage = 1, array $previewOptions = []): iterable
+    public function createPreviewPictures(string $path, $size = null, ?ResizeOptions $resizeOptions = null, int $lastPage = PHP_INT_MAX, int $firstPage = 1, array $previewOptions = []): iterable
     {
         return $this->convertPreviewsToPictures(
             $this->createPreviews(
@@ -230,7 +230,7 @@ class PreviewFactory
     /**
      * @param int|string|array|PictureConfiguration|null $size
      */
-    public function createPreviewFigure(string $path, $size = null, ResizeOptions $resizeOptions = null, int $page = 1, array $previewOptions = []): Figure
+    public function createPreviewFigure(string $path, $size = null, ?ResizeOptions $resizeOptions = null, int $page = 1, array $previewOptions = []): Figure
     {
         return $this->createPreviewFigureBuilder($path, $size, $resizeOptions, $page, $previewOptions)->build();
     }
@@ -240,7 +240,7 @@ class PreviewFactory
      *
      * @return iterable<Figure>
      */
-    public function createPreviewFigures(string $path, $size = null, ResizeOptions $resizeOptions = null, int $lastPage = PHP_INT_MAX, int $firstPage = 1, array $previewOptions = []): iterable
+    public function createPreviewFigures(string $path, $size = null, ?ResizeOptions $resizeOptions = null, int $lastPage = PHP_INT_MAX, int $firstPage = 1, array $previewOptions = []): iterable
     {
         $previews = $this->createPreviews(
             $path,
@@ -263,7 +263,7 @@ class PreviewFactory
     /**
      * @param int|string|array|PictureConfiguration|null $size
      */
-    public function createPreviewFigureBuilder(string $path, $size = null, ResizeOptions $resizeOptions = null, int $page = 1, array $previewOptions = []): FigureBuilder
+    public function createPreviewFigureBuilder(string $path, $size = null, ?ResizeOptions $resizeOptions = null, int $page = 1, array $previewOptions = []): FigureBuilder
     {
         $figureBuilder = $this->imageStudio
             ->createFigureBuilder()
@@ -384,7 +384,7 @@ class PreviewFactory
      *
      * @return iterable<PictureInterface>
      */
-    private function convertPreviewsToPictures(iterable $previews, $size, ResizeOptions $resizeOptions = null): iterable
+    private function convertPreviewsToPictures(iterable $previews, $size, ?ResizeOptions $resizeOptions = null): iterable
     {
         // Unlike the Contao\Image\PictureFactory, the PictureFactoryInterface
         // does not know about ResizeOptions. We therefore check if the third

--- a/core-bundle/src/Image/Studio/Figure.php
+++ b/core-bundle/src/Image/Studio/Figure.php
@@ -235,7 +235,7 @@ class Figure
      * @param string|null       $floating            Set/determine values for the "float_class" and "addBefore" keys
      * @param bool              $includeFullMetadata Make all metadata available in the first dimension of the returned data set (key-value pairs)
      */
-    public function getLegacyTemplateData($margin = null, string $floating = null, bool $includeFullMetadata = true): array
+    public function getLegacyTemplateData($margin = null, ?string $floating = null, bool $includeFullMetadata = true): array
     {
         // Create a key-value list of the metadata and apply some renaming and
         // formatting transformations to fit the legacy templates.
@@ -379,7 +379,7 @@ class Figure
      * @param string|null       $floating            Set/determine values for the template's "float_class" and "addBefore" properties
      * @param bool              $includeFullMetadata Make all metadata entries directly available in the template
      */
-    public function applyLegacyTemplateData(object $template, $margin = null, string $floating = null, bool $includeFullMetadata = true): void
+    public function applyLegacyTemplateData(object $template, $margin = null, ?string $floating = null, bool $includeFullMetadata = true): void
     {
         $new = $this->getLegacyTemplateData($margin, $floating, $includeFullMetadata);
         $existing = $template instanceof Template ? $template->getData() : get_object_vars($template);

--- a/core-bundle/src/Image/Studio/ImageResult.php
+++ b/core-bundle/src/Image/Studio/ImageResult.php
@@ -58,7 +58,7 @@ class ImageResult
      *
      * @internal Use the Contao\CoreBundle\Image\Studio\Studio factory to get an instance of this class
      */
-    public function __construct(ContainerInterface $locator, string $projectDir, $filePathOrImage, $sizeConfiguration = null, ResizeOptions $resizeOptions = null)
+    public function __construct(ContainerInterface $locator, string $projectDir, $filePathOrImage, $sizeConfiguration = null, ?ResizeOptions $resizeOptions = null)
     {
         $this->locator = $locator;
         $this->projectDir = $projectDir;

--- a/core-bundle/src/Image/Studio/LightboxResult.php
+++ b/core-bundle/src/Image/Studio/LightboxResult.php
@@ -34,7 +34,7 @@ class LightboxResult
      *
      * @internal Use the Contao\CoreBundle\Image\Studio\Studio factory to get an instance of this class
      */
-    public function __construct(ContainerInterface $locator, $filePathOrImage, ?string $url, $sizeConfiguration = null, string $groupIdentifier = null, ResizeOptions $resizeOptions = null)
+    public function __construct(ContainerInterface $locator, $filePathOrImage, ?string $url, $sizeConfiguration = null, ?string $groupIdentifier = null, ?ResizeOptions $resizeOptions = null)
     {
         if (1 !== \count(array_filter([$filePathOrImage, $url]))) {
             throw new \InvalidArgumentException('A lightbox must be either constructed with a resource or an URL.');

--- a/core-bundle/src/Image/Studio/Studio.php
+++ b/core-bundle/src/Image/Studio/Studio.php
@@ -47,7 +47,7 @@ class Studio
      * @param string|ImageInterface                      $filePathOrImage
      * @param array|PictureConfiguration|int|string|null $sizeConfiguration
      */
-    public function createImage($filePathOrImage, $sizeConfiguration, ResizeOptions $resizeOptions = null): ImageResult
+    public function createImage($filePathOrImage, $sizeConfiguration, ?ResizeOptions $resizeOptions = null): ImageResult
     {
         return new ImageResult($this->locator, $this->projectDir, $filePathOrImage, $sizeConfiguration, $resizeOptions);
     }
@@ -56,7 +56,7 @@ class Studio
      * @param string|ImageInterface|null                 $filePathOrImage
      * @param array|PictureConfiguration|int|string|null $sizeConfiguration
      */
-    public function createLightboxImage($filePathOrImage, string $url = null, $sizeConfiguration = null, string $groupIdentifier = null, ResizeOptions $resizeOptions = null): LightboxResult
+    public function createLightboxImage($filePathOrImage, ?string $url = null, $sizeConfiguration = null, ?string $groupIdentifier = null, ?ResizeOptions $resizeOptions = null): LightboxResult
     {
         return new LightboxResult($this->locator, $filePathOrImage, $url, $sizeConfiguration, $groupIdentifier, $resizeOptions);
     }

--- a/core-bundle/src/InsertTag/InsertTagParser.php
+++ b/core-bundle/src/InsertTag/InsertTagParser.php
@@ -21,7 +21,7 @@ class InsertTagParser implements ResetInterface
     private ContaoFramework $framework;
     private ?InsertTags $insertTags;
 
-    public function __construct(ContaoFramework $framework, InsertTags $insertTags = null)
+    public function __construct(ContaoFramework $framework, ?InsertTags $insertTags = null)
     {
         $this->framework = $framework;
         $this->insertTags = $insertTags;

--- a/core-bundle/src/Intl/Countries.php
+++ b/core-bundle/src/Intl/Countries.php
@@ -50,7 +50,7 @@ class Countries
     /**
      * @return array<string,string> Translated country names indexed by their uppercase ISO 3166-1 alpha-2 code
      */
-    public function getCountries(string $displayLocale = null): array
+    public function getCountries(?string $displayLocale = null): array
     {
         if (null === $displayLocale && null !== ($request = $this->requestStack->getCurrentRequest())) {
             $displayLocale = $request->getLocale();

--- a/core-bundle/src/Intl/Locales.php
+++ b/core-bundle/src/Intl/Locales.php
@@ -55,7 +55,7 @@ class Locales
     /**
      * @return array<string,string> Translated locales indexed by their ICU locale IDs
      */
-    public function getLocales(string $displayLocale = null, bool $addNativeSuffix = false): array
+    public function getLocales(?string $displayLocale = null, bool $addNativeSuffix = false): array
     {
         $locales = $this->getDisplayNamesWithoutHook($this->locales, $displayLocale, $addNativeSuffix);
 
@@ -69,7 +69,7 @@ class Locales
     /**
      * @return array<string,string> Translated enabled locales indexed by their ICU locale IDs
      */
-    public function getEnabledLocales(string $displayLocale = null, bool $addNativeSuffix = false): array
+    public function getEnabledLocales(?string $displayLocale = null, bool $addNativeSuffix = false): array
     {
         $locales = $this->getDisplayNamesWithoutHook($this->enabledLocales, $displayLocale, $addNativeSuffix);
 
@@ -83,7 +83,7 @@ class Locales
     /**
      * @return array<string,string> Translated languages (without regions) indexed by their ICU locale IDs
      */
-    public function getLanguages(string $displayLocale = null, bool $addNativeSuffix = false): array
+    public function getLanguages(?string $displayLocale = null, bool $addNativeSuffix = false): array
     {
         // If the legacy hook is used, it might add or remove locales
         if (!empty($GLOBALS['TL_HOOKS']['getLanguages'])) {
@@ -180,7 +180,7 @@ class Locales
     /**
      * @return array<string,string> Translated locales indexed by their ICU locale IDs
      */
-    public function getDisplayNames(array $localeIds, string $displayLocale = null, bool $addNativeSuffix = false): array
+    public function getDisplayNames(array $localeIds, ?string $displayLocale = null, bool $addNativeSuffix = false): array
     {
         $locales = $this->getDisplayNamesWithoutHook($localeIds, $displayLocale, $addNativeSuffix);
 
@@ -198,7 +198,7 @@ class Locales
         return $locales;
     }
 
-    private function getDisplayNamesWithoutHook(array $localeIds, string $displayLocale = null, bool $addNativeSuffix = false): array
+    private function getDisplayNamesWithoutHook(array $localeIds, ?string $displayLocale = null, bool $addNativeSuffix = false): array
     {
         if (null === $displayLocale && null !== ($request = $this->requestStack->getCurrentRequest())) {
             $displayLocale = $request->getLocale();
@@ -234,7 +234,7 @@ class Locales
     /**
      * Add, remove or replace locales as configured in the container configuration.
      */
-    private function filterLocales(array $locales, array $filter, string $default = null): array
+    private function filterLocales(array $locales, array $filter, ?string $default = null): array
     {
         $newList = array_filter($filter, static fn ($locale) => !\in_array($locale[0], ['-', '+'], true));
 

--- a/core-bundle/src/Mailer/AvailableTransports.php
+++ b/core-bundle/src/Mailer/AvailableTransports.php
@@ -24,7 +24,7 @@ class AvailableTransports
 
     private ?TranslatorInterface $translator;
 
-    public function __construct(TranslatorInterface $translator = null)
+    public function __construct(?TranslatorInterface $translator = null)
     {
         $this->translator = $translator;
     }

--- a/core-bundle/src/Mailer/ContaoMailer.php
+++ b/core-bundle/src/Mailer/ContaoMailer.php
@@ -36,7 +36,7 @@ final class ContaoMailer implements MailerInterface
         $this->framework = $framework;
     }
 
-    public function send(RawMessage $message, Envelope $envelope = null): void
+    public function send(RawMessage $message, ?Envelope $envelope = null): void
     {
         if ($message instanceof Message) {
             $this->setTransport($message);

--- a/core-bundle/src/Mailer/TransportConfig.php
+++ b/core-bundle/src/Mailer/TransportConfig.php
@@ -17,7 +17,7 @@ final class TransportConfig
     private string $name;
     private ?string $from;
 
-    public function __construct(string $name, string $from = null)
+    public function __construct(string $name, ?string $from = null)
     {
         $this->name = $name;
         $this->from = $from;

--- a/core-bundle/src/Migration/AbstractMigration.php
+++ b/core-bundle/src/Migration/AbstractMigration.php
@@ -19,7 +19,7 @@ abstract class AbstractMigration implements MigrationInterface
         return static::class;
     }
 
-    protected function createResult(bool $successful, string $message = null): MigrationResult
+    protected function createResult(bool $successful, ?string $message = null): MigrationResult
     {
         $message ??= $this->getName().' '.($successful ? 'executed successfully' : 'execution failed');
 

--- a/core-bundle/src/Monolog/ContaoContext.php
+++ b/core-bundle/src/Monolog/ContaoContext.php
@@ -32,7 +32,7 @@ class ContaoContext
     private ?string $browser;
     private ?string $source;
 
-    public function __construct(string $func, string $action = null, string $username = null, string $ip = null, string $browser = null, string $source = null)
+    public function __construct(string $func, ?string $action = null, ?string $username = null, ?string $ip = null, ?string $browser = null, ?string $source = null)
     {
         if ('' === $func) {
             throw new \InvalidArgumentException('The function name in the Contao context must not be empty');

--- a/core-bundle/src/Monolog/ContaoTableProcessor.php
+++ b/core-bundle/src/Monolog/ContaoTableProcessor.php
@@ -72,7 +72,7 @@ class ContaoTableProcessor implements ProcessorInterface
         }
     }
 
-    private function updateBrowser(ContaoContext $context, Request $request = null): void
+    private function updateBrowser(ContaoContext $context, ?Request $request = null): void
     {
         if (null !== $context->getBrowser()) {
             return;
@@ -92,7 +92,7 @@ class ContaoTableProcessor implements ProcessorInterface
         $context->setUsername(null === $token ? 'N/A' : $token->getUserIdentifier());
     }
 
-    private function updateSource(ContaoContext $context, Request $request = null): void
+    private function updateSource(ContaoContext $context, ?Request $request = null): void
     {
         if (null !== $context->getSource()) {
             return;

--- a/core-bundle/src/OptIn/OptInToken.php
+++ b/core-bundle/src/OptIn/OptInToken.php
@@ -100,7 +100,7 @@ class OptInToken implements OptInTokenInterface
         return $this->model->confirmedOn > 0;
     }
 
-    public function send(string $subject = null, string $text = null): void
+    public function send(?string $subject = null, ?string $text = null): void
     {
         if ($this->isConfirmed()) {
             throw new OptInTokenAlreadyConfirmedException();

--- a/core-bundle/src/OptIn/OptInTokenAlreadyConfirmedException.php
+++ b/core-bundle/src/OptIn/OptInTokenAlreadyConfirmedException.php
@@ -14,7 +14,7 @@ namespace Contao\CoreBundle\OptIn;
 
 class OptInTokenAlreadyConfirmedException extends \RuntimeException
 {
-    public function __construct(\Exception $previous = null)
+    public function __construct(?\Exception $previous = null)
     {
         parent::__construct('The token has already been confirmed', 0, $previous);
     }

--- a/core-bundle/src/OptIn/OptInTokenInterface.php
+++ b/core-bundle/src/OptIn/OptInTokenInterface.php
@@ -48,7 +48,7 @@ interface OptInTokenInterface
      * @throws OptInTokenAlreadyConfirmedException
      * @throws OptInTokenNoLongerValidException
      */
-    public function send(string $subject = null, string $text = null): void;
+    public function send(?string $subject = null, ?string $text = null): void;
 
     /**
      * Returns true if the token has been sent via e-mail.

--- a/core-bundle/src/OptIn/OptInTokenNoLongerValidException.php
+++ b/core-bundle/src/OptIn/OptInTokenNoLongerValidException.php
@@ -14,7 +14,7 @@ namespace Contao\CoreBundle\OptIn;
 
 class OptInTokenNoLongerValidException extends \RuntimeException
 {
-    public function __construct(\Exception $previous = null)
+    public function __construct(?\Exception $previous = null)
     {
         parent::__construct('The token is no longer valid', 0, $previous);
     }

--- a/core-bundle/src/Picker/AbstractPickerProvider.php
+++ b/core-bundle/src/Picker/AbstractPickerProvider.php
@@ -25,7 +25,7 @@ abstract class AbstractPickerProvider implements PickerProviderInterface
     private ?TranslatorInterface $translator;
     private ?TokenStorageInterface $tokenStorage = null;
 
-    public function __construct(FactoryInterface $menuFactory, RouterInterface $router, TranslatorInterface $translator = null)
+    public function __construct(FactoryInterface $menuFactory, RouterInterface $router, ?TranslatorInterface $translator = null)
     {
         $this->menuFactory = $menuFactory;
         $this->router = $router;
@@ -111,7 +111,7 @@ abstract class AbstractPickerProvider implements PickerProviderInterface
      *
      * @return array<string,string|int>
      */
-    abstract protected function getRouteParameters(PickerConfig $config = null)/*: array*/;
+    abstract protected function getRouteParameters(?PickerConfig $config = null)/*: array*/;
 
     /**
      * Generates the URL for the picker.

--- a/core-bundle/src/Picker/AbstractTablePickerProvider.php
+++ b/core-bundle/src/Picker/AbstractTablePickerProvider.php
@@ -134,7 +134,7 @@ abstract class AbstractTablePickerProvider implements PickerProviderInterface, D
         return 0 === strpos($config->getCurrent(), $this->getName().'.');
     }
 
-    public function getDcaTable(PickerConfig $config = null): string
+    public function getDcaTable(?PickerConfig $config = null): string
     {
         if (null === $config) {
             return '';
@@ -187,7 +187,7 @@ abstract class AbstractTablePickerProvider implements PickerProviderInterface, D
         return substr($context, self::PREFIX_LENGTH);
     }
 
-    protected function getUrlForValue(PickerConfig $config, string $module, string $table = null, int $pid = null): string
+    protected function getUrlForValue(PickerConfig $config, string $module, ?string $table = null, ?int $pid = null): string
     {
         $params = [
             'do' => $module,

--- a/core-bundle/src/Picker/ArticlePickerProvider.php
+++ b/core-bundle/src/Picker/ArticlePickerProvider.php
@@ -71,7 +71,7 @@ class ArticlePickerProvider extends AbstractInsertTagPickerProvider implements D
         return sprintf($this->getInsertTag($config), $value);
     }
 
-    protected function getRouteParameters(PickerConfig $config = null): array
+    protected function getRouteParameters(?PickerConfig $config = null): array
     {
         return ['do' => 'article'];
     }

--- a/core-bundle/src/Picker/FilePickerProvider.php
+++ b/core-bundle/src/Picker/FilePickerProvider.php
@@ -90,7 +90,7 @@ class FilePickerProvider extends AbstractInsertTagPickerProvider implements DcaP
         return $value;
     }
 
-    protected function getRouteParameters(PickerConfig $config = null): array
+    protected function getRouteParameters(?PickerConfig $config = null): array
     {
         return ['do' => 'files'];
     }

--- a/core-bundle/src/Picker/PagePickerProvider.php
+++ b/core-bundle/src/Picker/PagePickerProvider.php
@@ -101,7 +101,7 @@ class PagePickerProvider extends AbstractInsertTagPickerProvider implements DcaP
         return sprintf($this->getInsertTag($config), $value);
     }
 
-    protected function getRouteParameters(PickerConfig $config = null): array
+    protected function getRouteParameters(?PickerConfig $config = null): array
     {
         return ['do' => 'page'];
     }

--- a/core-bundle/src/Picker/PickerBuilder.php
+++ b/core-bundle/src/Picker/PickerBuilder.php
@@ -73,7 +73,7 @@ class PickerBuilder implements PickerBuilderInterface
         return $this->create($config);
     }
 
-    public function supportsContext($context, array $allowed = null): bool
+    public function supportsContext($context, ?array $allowed = null): bool
     {
         $providers = $this->providers;
 

--- a/core-bundle/src/Picker/PickerBuilderInterface.php
+++ b/core-bundle/src/Picker/PickerBuilderInterface.php
@@ -37,7 +37,7 @@ interface PickerBuilderInterface
      *
      * @return bool
      */
-    public function supportsContext(/*string */$context, array $allowed = null)/*: bool*/;
+    public function supportsContext(/*string */$context, ?array $allowed = null)/*: bool*/;
 
     /**
      * Returns the picker URL for the given context and configuration.

--- a/core-bundle/src/Resources/contao/classes/Backend.php
+++ b/core-bundle/src/Resources/contao/classes/Backend.php
@@ -308,7 +308,7 @@ abstract class Backend extends Controller
 	 *
 	 * @throws AccessDeniedException
 	 */
-	protected function getBackendModule($module, PickerInterface $picker = null)
+	protected function getBackendModule($module, ?PickerInterface $picker = null)
 	{
 		$arrModule = array();
 
@@ -1021,7 +1021,7 @@ abstract class Backend extends Controller
 	 *
 	 * @return string
 	 */
-	public static function addPageIcon($row, $label, DataContainer $dc=null, $imageAttribute='', $blnReturnImage=false, $blnProtected=false, $isVisibleRootTrailPage=false)
+	public static function addPageIcon($row, $label, ?DataContainer $dc=null, $imageAttribute='', $blnReturnImage=false, $blnProtected=false, $isVisibleRootTrailPage=false)
 	{
 		if ($blnProtected)
 		{

--- a/core-bundle/src/Resources/contao/classes/BackendModule.php
+++ b/core-bundle/src/Resources/contao/classes/BackendModule.php
@@ -40,7 +40,7 @@ abstract class BackendModule extends Backend
 	 *
 	 * @param DataContainer $dc
 	 */
-	public function __construct(DataContainer $dc=null)
+	public function __construct(?DataContainer $dc=null)
 	{
 		parent::__construct();
 		$this->objDc = $dc;

--- a/core-bundle/src/Resources/contao/classes/DataContainer.php
+++ b/core-bundle/src/Resources/contao/classes/DataContainer.php
@@ -1683,7 +1683,7 @@ abstract class DataContainer extends Backend
 	 *
 	 * @return string|array<string>
 	 */
-	public function generateRecordLabel(array $row, string $table = null, bool $protected = false, bool $isVisibleRootTrailPage = false)
+	public function generateRecordLabel(array $row, ?string $table = null, bool $protected = false, bool $isVisibleRootTrailPage = false)
 	{
 		$table = $table ?? $this->strTable;
 		$labelConfig = &$GLOBALS['TL_DCA'][$table]['list']['label'];

--- a/core-bundle/src/Resources/contao/dca/tl_image_size.php
+++ b/core-bundle/src/Resources/contao/dca/tl_image_size.php
@@ -392,7 +392,7 @@ class tl_image_size extends Backend
 	 *
 	 * @return array
 	 */
-	public function getFormats(DataContainer $dc=null)
+	public function getFormats(?DataContainer $dc=null)
 	{
 		$formats = array();
 		$missingSupport = array();

--- a/core-bundle/src/Resources/contao/dca/tl_page.php
+++ b/core-bundle/src/Resources/contao/dca/tl_page.php
@@ -1414,7 +1414,7 @@ class tl_page extends Backend
 	 *
 	 * @return string
 	 */
-	public function addIcon($row, $label, DataContainer $dc=null, $imageAttribute='', $blnReturnImage=false, $blnProtected=false, $isVisibleRootTrailPage=false)
+	public function addIcon($row, $label, ?DataContainer $dc=null, $imageAttribute='', $blnReturnImage=false, $blnProtected=false, $isVisibleRootTrailPage=false)
 	{
 		return Backend::addPageIcon($row, $label, $dc, $imageAttribute, $blnReturnImage, $blnProtected, $isVisibleRootTrailPage);
 	}

--- a/core-bundle/src/Resources/contao/dca/tl_style.php
+++ b/core-bundle/src/Resources/contao/dca/tl_style.php
@@ -714,7 +714,7 @@ class tl_style extends Backend
 	 * @param boolean       $blnVisible
 	 * @param DataContainer $dc
 	 */
-	public function toggleVisibility($intId, $blnVisible, DataContainer $dc=null)
+	public function toggleVisibility($intId, $blnVisible, ?DataContainer $dc=null)
 	{
 		// Set the ID and action
 		Input::setGet('id', $intId);

--- a/core-bundle/src/Resources/contao/library/Contao/Controller.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Controller.php
@@ -1629,7 +1629,7 @@ abstract class Controller extends System
 	 * @deprecated Deprecated since Contao 4.11, to be removed in Contao 5.0;
 	 *             use the Contao\CoreBundle\Image\Studio\FigureBuilder instead.
 	 */
-	public static function addImageToTemplate($template, array $rowData, $maxWidth = null, $lightboxGroupIdentifier = null, FilesModel $filesModel = null): void
+	public static function addImageToTemplate($template, array $rowData, $maxWidth = null, $lightboxGroupIdentifier = null, ?FilesModel $filesModel = null): void
 	{
 		trigger_deprecation('contao/core-bundle', '4.11', 'Using Controller::addImageToTemplate() is deprecated and will no longer work in Contao 5.0. Use the "Contao\CoreBundle\Image\Studio\FigureBuilder" class instead.');
 
@@ -1979,7 +1979,7 @@ abstract class Controller extends System
 	 *
 	 * @return string The script path with the static URL
 	 */
-	public static function addStaticUrlTo($script, ContaoContext $context = null)
+	public static function addStaticUrlTo($script, ?ContaoContext $context = null)
 	{
 		// Absolute URLs
 		if (preg_match('@^https?://@', $script))

--- a/core-bundle/src/Resources/contao/library/Contao/Database.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Database.php
@@ -135,7 +135,7 @@ class Database
 	 *
 	 * @return Database The Database object
 	 */
-	public static function getInstance(array $arrCustomConfig=null)
+	public static function getInstance(?array $arrCustomConfig=null)
 	{
 		$arrConfig = array();
 

--- a/core-bundle/src/Resources/contao/library/Contao/Image.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Image.php
@@ -182,7 +182,7 @@ class Image
 	 *
 	 * @throws \InvalidArgumentException If the settings array is malformed
 	 */
-	public function setImportantPart(array $importantPart = null)
+	public function setImportantPart(?array $importantPart = null)
 	{
 		if ($importantPart !== null)
 		{

--- a/core-bundle/src/Resources/contao/library/Contao/Pagination.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Pagination.php
@@ -127,7 +127,7 @@ class Pagination
 	 * @param Template $objTemplate      The template object
 	 * @param boolean  $blnForceParam    Force the URL parameter
 	 */
-	public function __construct($intRows, $intPerPage, $intNumberOfLinks=7, $strParameter='page', Template $objTemplate=null, $blnForceParam=false)
+	public function __construct($intRows, $intPerPage, $intNumberOfLinks=7, $strParameter='page', ?Template $objTemplate=null, $blnForceParam=false)
 	{
 		$this->intPage = 1;
 		$this->intRows = (int) $intRows;

--- a/core-bundle/src/Resources/contao/library/Contao/Picture.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Picture.php
@@ -166,7 +166,7 @@ class Picture
 	 *
 	 * @return $this The picture object
 	 */
-	public function setImportantPart(array $importantPart = null)
+	public function setImportantPart(?array $importantPart = null)
 	{
 		$this->image->setImportantPart($importantPart);
 

--- a/core-bundle/src/Resources/contao/library/Contao/Search.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Search.php
@@ -810,7 +810,7 @@ class Search
 	 *
 	 * @param string $strUrl The URL to be removed
 	 */
-	public static function removeEntry($strUrl, Connection $connection = null)
+	public static function removeEntry($strUrl, ?Connection $connection = null)
 	{
 		$connection = $connection ?? System::getContainer()->get('database_connection');
 		$result = $connection->executeQuery('SELECT id FROM tl_search WHERE url = :url', array('url' => $strUrl));

--- a/core-bundle/src/Resources/contao/library/Contao/StringUtil.php
+++ b/core-bundle/src/Resources/contao/library/Contao/StringUtil.php
@@ -1199,7 +1199,7 @@ class StringUtil
 	/**
 	 * @param float|int $number
 	 */
-	public static function numberToString($number, int $precision = null): string
+	public static function numberToString($number, ?int $precision = null): string
 	{
 		if (\is_int($number))
 		{

--- a/core-bundle/src/Resources/contao/library/Contao/TemplateInheritance.php
+++ b/core-bundle/src/Resources/contao/library/Contao/TemplateInheritance.php
@@ -158,7 +158,7 @@ trait TemplateInheritance
 		return $strBuffer;
 	}
 
-	public function setDebug(bool $debug = null): self
+	public function setDebug(?bool $debug = null): self
 	{
 		$this->blnDebug = $debug;
 
@@ -308,7 +308,7 @@ trait TemplateInheritance
 	 * @param string $name The template name
 	 * @param array  $data An optional data array
 	 */
-	public function insert($name, array $data=null)
+	public function insert($name, ?array $data=null)
 	{
 		/** @var Template $tpl */
 		if ($this instanceof Template)

--- a/core-bundle/src/Resources/contao/library/Contao/Widget.php
+++ b/core-bundle/src/Resources/contao/library/Contao/Widget.php
@@ -728,7 +728,7 @@ abstract class Widget extends Controller
 	 *
 	 * @return $this The widget object
 	 */
-	public function setInputCallback(callable $callback=null)
+	public function setInputCallback(?callable $callback=null)
 	{
 		$this->inputCallback = $callback;
 

--- a/core-bundle/src/Routing/AbstractPageRouteProvider.php
+++ b/core-bundle/src/Routing/AbstractPageRouteProvider.php
@@ -105,7 +105,7 @@ abstract class AbstractPageRouteProvider implements RouteProviderInterface
         return array_unique($ids);
     }
 
-    protected function compareRoutes(Route $a, Route $b, array $languages = null): int
+    protected function compareRoutes(Route $a, Route $b, ?array $languages = null): int
     {
         if ('' !== $a->getHost() && '' === $b->getHost()) {
             return -1;

--- a/core-bundle/src/Routing/FrontendLoader.php
+++ b/core-bundle/src/Routing/FrontendLoader.php
@@ -33,7 +33,7 @@ class FrontendLoader extends Loader
         $this->urlSuffix = $urlSuffix;
     }
 
-    public function load($resource, string $type = null): RouteCollection
+    public function load($resource, ?string $type = null): RouteCollection
     {
         $routes = new RouteCollection();
 
@@ -48,7 +48,7 @@ class FrontendLoader extends Loader
         return $routes;
     }
 
-    public function supports($resource, string $type = null): bool
+    public function supports($resource, ?string $type = null): bool
     {
         return 'contao_frontend' === $type;
     }

--- a/core-bundle/src/Routing/ImagesLoader.php
+++ b/core-bundle/src/Routing/ImagesLoader.php
@@ -30,7 +30,7 @@ class ImagesLoader extends Loader
         $this->pathPrefix = Path::makeRelative($imageTargetDir, $projectDir);
     }
 
-    public function load($resource, string $type = null): RouteCollection
+    public function load($resource, ?string $type = null): RouteCollection
     {
         $route = new Route(
             '/'.$this->pathPrefix.'/{path}',
@@ -47,7 +47,7 @@ class ImagesLoader extends Loader
         return $routes;
     }
 
-    public function supports($resource, string $type = null): bool
+    public function supports($resource, ?string $type = null): bool
     {
         return 'contao_images' === $type;
     }

--- a/core-bundle/src/Routing/Page/PageRegistry.php
+++ b/core-bundle/src/Routing/Page/PageRegistry.php
@@ -144,7 +144,7 @@ class PageRegistry implements ResetInterface
     /**
      * @param ContentCompositionInterface|bool $contentComposition
      */
-    public function add(string $type, RouteConfig $config, DynamicRouteInterface $routeEnhancer = null, $contentComposition = true): self
+    public function add(string $type, RouteConfig $config, ?DynamicRouteInterface $routeEnhancer = null, $contentComposition = true): self
     {
         // Override existing pages with the same identifier
         $this->routeConfigs[$type] = $config;

--- a/core-bundle/src/Routing/Page/RouteConfig.php
+++ b/core-bundle/src/Routing/Page/RouteConfig.php
@@ -34,7 +34,7 @@ final class RouteConfig
      * @param string|bool|null     $path
      * @param string|array<string> $methods
      */
-    public function __construct($path = null, string $pathRegex = null, string $urlSuffix = null, array $requirements = [], array $options = [], array $defaults = [], $methods = [])
+    public function __construct($path = null, ?string $pathRegex = null, ?string $urlSuffix = null, array $requirements = [], array $options = [], array $defaults = [], $methods = [])
     {
         $this->path = $path;
         $this->pathRegex = $pathRegex;

--- a/core-bundle/src/Routing/PageUrlGenerator.php
+++ b/core-bundle/src/Routing/PageUrlGenerator.php
@@ -30,7 +30,7 @@ class PageUrlGenerator extends SymfonyUrlGenerator
     private RouteProviderInterface $provider;
     private PageRegistry $pageRegistry;
 
-    public function __construct(RouteProviderInterface $provider, PageRegistry $pageRegistry, LoggerInterface $logger = null)
+    public function __construct(RouteProviderInterface $provider, PageRegistry $pageRegistry, ?LoggerInterface $logger = null)
     {
         parent::__construct(new RouteCollection(), new RequestContext(), $logger);
 

--- a/core-bundle/src/Routing/ResponseContext/ResponseContext.php
+++ b/core-bundle/src/Routing/ResponseContext/ResponseContext.php
@@ -43,7 +43,7 @@ final class ResponseContext
         return $this;
     }
 
-    public function addLazy(string $classname, \Closure $factory = null): self
+    public function addLazy(string $classname, ?\Closure $factory = null): self
     {
         $factory ??= fn () => new $classname($this);
 

--- a/core-bundle/src/Routing/Route404Provider.php
+++ b/core-bundle/src/Routing/Route404Provider.php
@@ -247,7 +247,7 @@ class Route404Provider extends AbstractPageRouteProvider
      * 2. Then sort by hostname, so the ones with empty host are only taken if no hostname matches
      * 3. Lastly pages must be sorted by accept language and fallback, so the best language matches first
      */
-    private function sortRoutes(array &$routes, array $languages = null): void
+    private function sortRoutes(array &$routes, ?array $languages = null): void
     {
         // Convert languages array so key is language and value is priority
         if (null !== $languages) {

--- a/core-bundle/src/Routing/RouteProvider.php
+++ b/core-bundle/src/Routing/RouteProvider.php
@@ -242,7 +242,7 @@ class RouteProvider extends AbstractPageRouteProvider
      * 3. Root/Index pages must be sorted by accept language and fallback, so the best language matches first
      * 4. Pages with longer alias (folder page) must come first to match if applicable
      */
-    private function sortRoutes(array &$routes, array $languages = null): void
+    private function sortRoutes(array &$routes, ?array $languages = null): void
     {
         // Convert languages array so key is language and value is priority
         if (null !== $languages) {

--- a/core-bundle/src/Security/Authentication/AuthenticationEntryPoint.php
+++ b/core-bundle/src/Security/Authentication/AuthenticationEntryPoint.php
@@ -39,7 +39,7 @@ class AuthenticationEntryPoint implements AuthenticationEntryPointInterface
         $this->scopeMatcher = $scopeMatcher;
     }
 
-    public function start(Request $request, AuthenticationException $authException = null): Response
+    public function start(Request $request, ?AuthenticationException $authException = null): Response
     {
         if ($this->scopeMatcher->isBackendRequest($request)) {
             return $this->redirectToBackend($request);

--- a/core-bundle/src/Security/Authentication/AuthenticationFailureHandler.php
+++ b/core-bundle/src/Security/Authentication/AuthenticationFailureHandler.php
@@ -27,7 +27,7 @@ class AuthenticationFailureHandler implements AuthenticationFailureHandlerInterf
 {
     private ?LoggerInterface $logger;
 
-    public function __construct(LoggerInterface $logger = null)
+    public function __construct(?LoggerInterface $logger = null)
     {
         $this->logger = $logger;
     }

--- a/core-bundle/src/Security/Authentication/AuthenticationSuccessHandler.php
+++ b/core-bundle/src/Security/Authentication/AuthenticationSuccessHandler.php
@@ -45,7 +45,7 @@ class AuthenticationSuccessHandler implements AuthenticationSuccessHandlerInterf
     /**
      * @internal
      */
-    public function __construct(ContaoFramework $framework, TrustedDeviceManagerInterface $trustedDeviceManager, FirewallMap $firewallMap, LoggerInterface $logger = null)
+    public function __construct(ContaoFramework $framework, TrustedDeviceManagerInterface $trustedDeviceManager, FirewallMap $firewallMap, ?LoggerInterface $logger = null)
     {
         $this->framework = $framework;
         $this->trustedDeviceManager = $trustedDeviceManager;

--- a/core-bundle/src/Security/Authentication/ContaoLoginAuthenticationListener.php
+++ b/core-bundle/src/Security/Authentication/ContaoLoginAuthenticationListener.php
@@ -37,7 +37,7 @@ class ContaoLoginAuthenticationListener extends AbstractAuthenticationListener
 {
     private TokenStorageInterface $tokenStorage;
 
-    public function __construct(TokenStorageInterface $tokenStorage, AuthenticationManagerInterface $authenticationManager, SessionAuthenticationStrategyInterface $sessionStrategy, HttpUtils $httpUtils, string $providerKey, AuthenticationSuccessHandlerInterface $successHandler, AuthenticationFailureHandlerInterface $failureHandler, array $options, LoggerInterface $logger = null, EventDispatcherInterface $dispatcher = null)
+    public function __construct(TokenStorageInterface $tokenStorage, AuthenticationManagerInterface $authenticationManager, SessionAuthenticationStrategyInterface $sessionStrategy, HttpUtils $httpUtils, string $providerKey, AuthenticationSuccessHandlerInterface $successHandler, AuthenticationFailureHandlerInterface $failureHandler, array $options, ?LoggerInterface $logger = null, ?EventDispatcherInterface $dispatcher = null)
     {
         parent::__construct($tokenStorage, $authenticationManager, $sessionStrategy, $httpUtils, $providerKey, $successHandler, $failureHandler, $options, $logger, $dispatcher);
 

--- a/core-bundle/src/Security/Authentication/FrontendPreviewAuthenticator.php
+++ b/core-bundle/src/Security/Authentication/FrontendPreviewAuthenticator.php
@@ -36,7 +36,7 @@ class FrontendPreviewAuthenticator
     /**
      * @internal
      */
-    public function __construct(Security $security, TokenStorageInterface $tokenStorage, TokenChecker $tokenChecker, SessionInterface $session, UserProviderInterface $userProvider, LoggerInterface $logger = null)
+    public function __construct(Security $security, TokenStorageInterface $tokenStorage, TokenChecker $tokenChecker, SessionInterface $session, UserProviderInterface $userProvider, ?LoggerInterface $logger = null)
     {
         $this->security = $security;
         $this->tokenStorage = $tokenStorage;
@@ -61,7 +61,7 @@ class FrontendPreviewAuthenticator
         return true;
     }
 
-    public function authenticateFrontendGuest(bool $showUnpublished, int $previewLinkId = null): bool
+    public function authenticateFrontendGuest(bool $showUnpublished, ?int $previewLinkId = null): bool
     {
         $token = new FrontendPreviewToken(null, $showUnpublished, $previewLinkId);
 

--- a/core-bundle/src/Security/Authentication/RememberMe/ExpiringTokenBasedRememberMeServices.php
+++ b/core-bundle/src/Security/Authentication/RememberMe/ExpiringTokenBasedRememberMeServices.php
@@ -39,7 +39,7 @@ class ExpiringTokenBasedRememberMeServices extends AbstractRememberMeServices
     /**
      * @internal
      */
-    public function __construct(RememberMeRepository $repository, iterable $userProviders, string $secret, string $providerKey, array $options = [], LoggerInterface $logger = null)
+    public function __construct(RememberMeRepository $repository, iterable $userProviders, string $secret, string $providerKey, array $options = [], ?LoggerInterface $logger = null)
     {
         parent::__construct($userProviders, $secret, $providerKey, $options, $logger);
 

--- a/core-bundle/src/Security/Authentication/Token/FrontendPreviewToken.php
+++ b/core-bundle/src/Security/Authentication/Token/FrontendPreviewToken.php
@@ -20,7 +20,7 @@ class FrontendPreviewToken extends AbstractToken
     private bool $showUnpublished;
     private ?int $previewLinkId;
 
-    public function __construct(?FrontendUser $user, bool $showUnpublished, int $previewLinkId = null)
+    public function __construct(?FrontendUser $user, bool $showUnpublished, ?int $previewLinkId = null)
     {
         if (null === $user) {
             parent::__construct();

--- a/core-bundle/src/Security/Exception/LockedException.php
+++ b/core-bundle/src/Security/Exception/LockedException.php
@@ -18,7 +18,7 @@ class LockedException extends BaseLockedException
 {
     private int $lockedSeconds;
 
-    public function __construct(int $lockedSeconds, string $message = '', int $code = 0, \Throwable $previous = null)
+    public function __construct(int $lockedSeconds, string $message = '', int $code = 0, ?\Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);
 

--- a/core-bundle/src/Security/Logout/LogoutHandler.php
+++ b/core-bundle/src/Security/Logout/LogoutHandler.php
@@ -34,7 +34,7 @@ class LogoutHandler implements LogoutHandlerInterface
     /**
      * @internal
      */
-    public function __construct(ContaoFramework $framework, LoggerInterface $logger = null)
+    public function __construct(ContaoFramework $framework, ?LoggerInterface $logger = null)
     {
         $this->framework = $framework;
         $this->logger = $logger;

--- a/core-bundle/src/Security/TwoFactor/Authenticator.php
+++ b/core-bundle/src/Security/TwoFactor/Authenticator.php
@@ -26,7 +26,7 @@ class Authenticator
     /**
      * Validates the code which was entered by the user.
      */
-    public function validateCode(User $user, string $code, int $timestamp = null): bool
+    public function validateCode(User $user, string $code, ?int $timestamp = null): bool
     {
         $totp = TOTP::create($this->getUpperUnpaddedSecretForUser($user));
 

--- a/core-bundle/src/Security/User/ContaoUserProvider.php
+++ b/core-bundle/src/Security/User/ContaoUserProvider.php
@@ -38,7 +38,7 @@ class ContaoUserProvider implements UserProviderInterface, PasswordUpgraderInter
      */
     private string $userClass;
 
-    public function __construct(ContaoFramework $framework, SessionInterface $session, string $userClass, LoggerInterface $logger = null)
+    public function __construct(ContaoFramework $framework, SessionInterface $session, string $userClass, ?LoggerInterface $logger = null)
     {
         if (BackendUser::class !== $userClass && FrontendUser::class !== $userClass) {
             throw new \RuntimeException(sprintf('Unsupported class "%s".', $userClass));

--- a/core-bundle/src/Slug/Slug.php
+++ b/core-bundle/src/Slug/Slug.php
@@ -34,7 +34,7 @@ class Slug
     /**
      * @param int|iterable $options A page ID, object or options array {@see SlugGeneratorInterface::generate()}
      */
-    public function generate(string $text, $options = [], callable $duplicateCheck = null, string $integerPrefix = 'id-'): string
+    public function generate(string $text, $options = [], ?callable $duplicateCheck = null, string $integerPrefix = 'id-'): string
     {
         if (!is_iterable($options)) {
             $pageAdapter = $this->framework->getAdapter(PageModel::class);

--- a/core-bundle/src/String/SimpleTokenExpressionLanguage.php
+++ b/core-bundle/src/String/SimpleTokenExpressionLanguage.php
@@ -17,7 +17,7 @@ use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 
 class SimpleTokenExpressionLanguage extends ExpressionLanguage
 {
-    public function __construct(CacheItemPoolInterface $cache = null, \IteratorAggregate $taggedProviders = null)
+    public function __construct(?CacheItemPoolInterface $cache = null, ?\IteratorAggregate $taggedProviders = null)
     {
         $providers = null !== $taggedProviders ? iterator_to_array($taggedProviders->getIterator()) : [];
 

--- a/core-bundle/src/Twig/Interop/ContaoEscaperNodeVisitor.php
+++ b/core-bundle/src/Twig/Interop/ContaoEscaperNodeVisitor.php
@@ -91,7 +91,7 @@ final class ContaoEscaperNodeVisitor implements NodeVisitorInterface
     /**
      * @param-out string $type
      */
-    private function isEscaperFilterExpression(Node $node, string &$type = null): bool
+    private function isEscaperFilterExpression(Node $node, ?string &$type = null): bool
     {
         if (
             !$node instanceof FilterExpression

--- a/core-bundle/src/Twig/Loader/ContaoFilesystemLoader.php
+++ b/core-bundle/src/Twig/Loader/ContaoFilesystemLoader.php
@@ -212,7 +212,7 @@ class ContaoFilesystemLoader implements LoaderInterface, ResetInterface
     /**
      * Finds the next template in the hierarchy and returns the logical name.
      */
-    public function getDynamicParent(string $shortNameOrIdentifier, string $sourcePath, string $themeSlug = null): string
+    public function getDynamicParent(string $shortNameOrIdentifier, string $sourcePath, ?string $themeSlug = null): string
     {
         $hierarchy = $this->getInheritanceChains($themeSlug);
         $identifier = ContaoTwigUtil::getIdentifier($shortNameOrIdentifier);
@@ -235,7 +235,7 @@ class ContaoFilesystemLoader implements LoaderInterface, ResetInterface
     /**
      * Finds the first template in the hierarchy and returns the logical name.
      */
-    public function getFirst(string $shortNameOrIdentifier, string $themeSlug = null): string
+    public function getFirst(string $shortNameOrIdentifier, ?string $themeSlug = null): string
     {
         $identifier = ContaoTwigUtil::getIdentifier($shortNameOrIdentifier);
         $hierarchy = $this->getInheritanceChains($themeSlug);
@@ -266,7 +266,7 @@ class ContaoFilesystemLoader implements LoaderInterface, ResetInterface
      *
      * @return array<string, array<string, string>>
      */
-    public function getInheritanceChains(string $themeSlug = null): array
+    public function getInheritanceChains(?string $themeSlug = null): array
     {
         $this->ensureHierarchyIsBuilt();
 

--- a/core-bundle/src/Twig/Loader/ContaoFilesystemLoaderWarmer.php
+++ b/core-bundle/src/Twig/Loader/ContaoFilesystemLoaderWarmer.php
@@ -28,7 +28,7 @@ class ContaoFilesystemLoaderWarmer implements CacheWarmerInterface
     private string $environment;
     private ?Filesystem $filesystem;
 
-    public function __construct(ContaoFilesystemLoader $loader, string $cacheDir, string $environment, Filesystem $filesystem = null)
+    public function __construct(ContaoFilesystemLoader $loader, string $cacheDir, string $environment, ?Filesystem $filesystem = null)
     {
         $this->filesystem = $filesystem;
         $this->environment = $environment;
@@ -36,7 +36,7 @@ class ContaoFilesystemLoaderWarmer implements CacheWarmerInterface
         $this->loader = $loader;
     }
 
-    public function warmUp(string $cacheDir = null, string $buildDir = null): array
+    public function warmUp(?string $cacheDir = null, ?string $buildDir = null): array
     {
         $this->loader->warmUp();
 

--- a/core-bundle/src/Twig/Runtime/LegacyTemplateFunctionsRuntime.php
+++ b/core-bundle/src/Twig/Runtime/LegacyTemplateFunctionsRuntime.php
@@ -43,7 +43,7 @@ final class LegacyTemplateFunctionsRuntime implements RuntimeExtensionInterface
     /**
      * Makes the FrontendTemplate#sections() method available from within Twig templates.
      */
-    public function renderLayoutSections(array $context, string $key, string $template = null): string
+    public function renderLayoutSections(array $context, string $key, ?string $template = null): string
     {
         $this->framework->initialize();
 
@@ -61,7 +61,7 @@ final class LegacyTemplateFunctionsRuntime implements RuntimeExtensionInterface
     /**
      * Makes the FrontendTemplate#section() method available from within Twig templates.
      */
-    public function renderLayoutSection(array $context, string $key, string $template = null): string
+    public function renderLayoutSection(array $context, string $key, ?string $template = null): string
     {
         $this->framework->initialize();
 

--- a/core-bundle/src/Twig/Runtime/PictureConfigurationRuntime.php
+++ b/core-bundle/src/Twig/Runtime/PictureConfigurationRuntime.php
@@ -103,7 +103,7 @@ final class PictureConfigurationRuntime implements RuntimeExtensionInterface
         }
     }
 
-    private function throwInvalidArgumentException(array $unmappedConfig, string $prefix = null): void
+    private function throwInvalidArgumentException(array $unmappedConfig, ?string $prefix = null): void
     {
         $keys = array_keys($unmappedConfig);
 

--- a/core-bundle/src/Util/SimpleTokenExpressionLanguage.php
+++ b/core-bundle/src/Util/SimpleTokenExpressionLanguage.php
@@ -20,7 +20,7 @@ use Psr\Cache\CacheItemPoolInterface;
  */
 class SimpleTokenExpressionLanguage extends \Contao\CoreBundle\String\SimpleTokenExpressionLanguage
 {
-    public function __construct(CacheItemPoolInterface $cache = null, \IteratorAggregate $taggedProviders = null)
+    public function __construct(?CacheItemPoolInterface $cache = null, ?\IteratorAggregate $taggedProviders = null)
     {
         trigger_deprecation('contao/core-bundle', '4.13', 'Using the "Contao\CoreBundle\Util\SimpleTokenExpressionLanguage" class has been deprecated and will no longer work in Contao 5.0. Use the "Contao\CoreBundle\String\SimpleTokenExpressionLanguage" class instead.');
 

--- a/core-bundle/tests/Asset/ContaoContextTest.php
+++ b/core-bundle/tests/Asset/ContaoContextTest.php
@@ -326,7 +326,7 @@ class ContaoContextTest extends TestCase
         return $page->loadDetails();
     }
 
-    private function getContaoContext(string $field, RequestStack $requestStack = null): ContaoContext
+    private function getContaoContext(string $field, ?RequestStack $requestStack = null): ContaoContext
     {
         $requestStack ??= new RequestStack();
 

--- a/core-bundle/tests/Cache/ContaoCacheWarmerTest.php
+++ b/core-bundle/tests/Cache/ContaoCacheWarmerTest.php
@@ -147,7 +147,7 @@ class ContaoCacheWarmerTest extends TestCase
         $this->assertFileDoesNotExist(Path::join($this->getTempDir(), 'var/cache/contao'));
     }
 
-    private function getCacheWarmer(Connection $connection = null, ContaoFramework $framework = null, string $bundle = 'test-bundle'): ContaoCacheWarmer
+    private function getCacheWarmer(?Connection $connection = null, ?ContaoFramework $framework = null, string $bundle = 'test-bundle'): ContaoCacheWarmer
     {
         $connection ??= $this->createMock(Connection::class);
         $framework ??= $this->mockContaoFramework();

--- a/core-bundle/tests/Cache/EntityCacheTagsTest.php
+++ b/core-bundle/tests/Cache/EntityCacheTagsTest.php
@@ -250,7 +250,7 @@ class EntityCacheTagsTest extends DoctrineTestCase
         $entityCacheTags->invalidateTagsFor([$post, $page, 'foo']);
     }
 
-    private function getEntityCacheTags(ResponseTagger $responseTagger = null, CacheInvalidator $cacheInvalidator = null): EntityCacheTags
+    private function getEntityCacheTags(?ResponseTagger $responseTagger = null, ?CacheInvalidator $cacheInvalidator = null): EntityCacheTags
     {
         return new EntityCacheTags(
             $this->getTestEntityManager(),

--- a/core-bundle/tests/Command/CrawlCommandTest.php
+++ b/core-bundle/tests/Command/CrawlCommandTest.php
@@ -174,7 +174,7 @@ class CrawlCommandTest extends TestCase
     /**
      * @return Factory&MockObject
      */
-    private function mockEscargotFactory(BaseUriCollection $baseUriCollection = null): Factory
+    private function mockEscargotFactory(?BaseUriCollection $baseUriCollection = null): Factory
     {
         $baseUriCollection ??= $this->getBaseUriCollection();
 
@@ -191,7 +191,7 @@ class CrawlCommandTest extends TestCase
     /**
      * @return Factory&MockObject
      */
-    private function mockValidEscargotFactory(Escargot $escargot, BaseUriCollection $baseUriCollection = null): Factory
+    private function mockValidEscargotFactory(Escargot $escargot, ?BaseUriCollection $baseUriCollection = null): Factory
     {
         $escargotFactory = $this->mockEscargotFactory($baseUriCollection);
         $escargotFactory

--- a/core-bundle/tests/Command/DebugContaoTwigCommandTest.php
+++ b/core-bundle/tests/Command/DebugContaoTwigCommandTest.php
@@ -192,7 +192,7 @@ class DebugContaoTwigCommandTest extends TestCase
         ];
     }
 
-    private function getCommand(ContaoFilesystemLoader $filesystemLoader = null): DebugContaoTwigCommand
+    private function getCommand(?ContaoFilesystemLoader $filesystemLoader = null): DebugContaoTwigCommand
     {
         return new DebugContaoTwigCommand(
             $filesystemLoader ?? $this->createMock(ContaoFilesystemLoader::class),

--- a/core-bundle/tests/Command/FilesyncCommandTest.php
+++ b/core-bundle/tests/Command/FilesyncCommandTest.php
@@ -152,7 +152,7 @@ class FilesyncCommandTest extends TestCase
         ];
     }
 
-    private function getCommand(DbafsManager $manager = null): FilesyncCommand
+    private function getCommand(?DbafsManager $manager = null): FilesyncCommand
     {
         return new FilesyncCommand($manager ?? $this->createMock(DbafsManager::class));
     }

--- a/core-bundle/tests/Command/MigrateCommandTest.php
+++ b/core-bundle/tests/Command/MigrateCommandTest.php
@@ -557,7 +557,7 @@ class MigrateCommandTest extends TestCase
      * @param array<array<MigrationResult>> $migrationResults
      * @param array<array<string>>          $runonceFiles
      */
-    private function getCommand(array $pendingMigrations = [], array $migrationResults = [], array $runonceFiles = [], Installer $installer = null, BackupManager $backupManager = null, Connection $connection = null): MigrateCommand
+    private function getCommand(array $pendingMigrations = [], array $migrationResults = [], array $runonceFiles = [], ?Installer $installer = null, ?BackupManager $backupManager = null, ?Connection $connection = null): MigrateCommand
     {
         $migrations = $this->createMock(MigrationCollection::class);
         $migrations
@@ -625,7 +625,7 @@ class MigrateCommandTest extends TestCase
     /**
      * @return Connection&MockObject
      */
-    private function createDefaultConnection(string $sqlMode = 'TRADITIONAL', AbstractMySQLDriver $driver = null): Connection
+    private function createDefaultConnection(string $sqlMode = 'TRADITIONAL', ?AbstractMySQLDriver $driver = null): Connection
     {
         $connection = $this->createMock(Connection::class);
         $connection

--- a/core-bundle/tests/Command/ResizeImagesCommandTest.php
+++ b/core-bundle/tests/Command/ResizeImagesCommandTest.php
@@ -135,7 +135,7 @@ class ResizeImagesCommandTest extends TestCase
         $this->assertDoesNotMatchRegularExpression('/image2.jpg/', $display);
     }
 
-    private function getCommand(ImageFactoryInterface $factory = null, DeferredResizerInterface $resizer = null, DeferredImageStorageInterface $storage = null): ResizeImagesCommand
+    private function getCommand(?ImageFactoryInterface $factory = null, ?DeferredResizerInterface $resizer = null, ?DeferredImageStorageInterface $storage = null): ResizeImagesCommand
     {
         return new ResizeImagesCommand(
             $factory ?? $this->createMock(ImageFactoryInterface::class),

--- a/core-bundle/tests/Command/UserCreateCommandTest.php
+++ b/core-bundle/tests/Command/UserCreateCommandTest.php
@@ -151,7 +151,7 @@ class UserCreateCommandTest extends TestCase
         yield ['k.jones', 'Kevin Jones', 'k.jones@example.org', 'kevinjones'];
     }
 
-    private function getCommand(Connection $connection = null, string $password = null): UserCreateCommand
+    private function getCommand(?Connection $connection = null, ?string $password = null): UserCreateCommand
     {
         $connection ??= $this->createMock(Connection::class);
         $password ??= '12345678';

--- a/core-bundle/tests/Command/UserPasswordCommandTest.php
+++ b/core-bundle/tests/Command/UserPasswordCommandTest.php
@@ -240,7 +240,7 @@ class UserPasswordCommandTest extends TestCase
         (new CommandTester($command))->execute($input, ['interactive' => false]);
     }
 
-    private function getCommand(Connection $connection = null, string $password = null): UserPasswordCommand
+    private function getCommand(?Connection $connection = null, ?string $password = null): UserPasswordCommand
     {
         $connection ??= $this->createMock(Connection::class);
         $password ??= '12345678';

--- a/core-bundle/tests/Contao/Database/StatementTest.php
+++ b/core-bundle/tests/Contao/Database/StatementTest.php
@@ -128,7 +128,7 @@ class StatementTest extends TestCase
      * @group legacy
      * @dataProvider getQueriesWithParametersAndSets
      */
-    public function testBackwardsCompatibleReplacesParametersAndSets(string $query, string $expected, array $params = null, array $set = null): void
+    public function testBackwardsCompatibleReplacesParametersAndSets(string $query, string $expected, ?array $params = null, ?array $set = null): void
     {
         $doctrineResult = $this->createMock(Result::class);
         $doctrineResult

--- a/core-bundle/tests/Contao/RoutingTest.php
+++ b/core-bundle/tests/Contao/RoutingTest.php
@@ -593,7 +593,7 @@ class RoutingTest extends TestCase
      *
      * @return ContaoFramework&MockObject
      */
-    private function mockFrameworkWithPageAdapter(Adapter $pageAdapter = null): ContaoFramework
+    private function mockFrameworkWithPageAdapter(?Adapter $pageAdapter = null): ContaoFramework
     {
         if (null === $pageAdapter) {
             $pageAdapter = $this->mockAdapter(['findByAliases']);

--- a/core-bundle/tests/Contao/StringUtilTest.php
+++ b/core-bundle/tests/Contao/StringUtilTest.php
@@ -275,7 +275,7 @@ class StringUtilTest extends TestCase
     /**
      * @dataProvider getRevertInputEncoding
      */
-    public function testRevertInputEncoding(string $source, string $expected = null): void
+    public function testRevertInputEncoding(string $source, ?string $expected = null): void
     {
         Input::setGet('value', $source);
         $inputEncoded = Input::get('value');
@@ -303,7 +303,7 @@ class StringUtilTest extends TestCase
      *
      * @dataProvider validEncodingsProvider
      */
-    public function testConvertsEncodingOfAString($string, string $toEncoding, string $expected, string $fromEncoding = null): void
+    public function testConvertsEncodingOfAString($string, string $toEncoding, string $expected, ?string $fromEncoding = null): void
     {
         $prevSubstituteCharacter = mb_substitute_character();
 
@@ -441,7 +441,7 @@ class StringUtilTest extends TestCase
      *
      * @dataProvider numberToStringProvider
      */
-    public function testNumberToString($source, string $expected, int $precision = null): void
+    public function testNumberToString($source, string $expected, ?int $precision = null): void
     {
         $this->assertSame($expected, StringUtil::numberToString($source, $precision));
     }
@@ -474,7 +474,7 @@ class StringUtilTest extends TestCase
      *
      * @dataProvider numberToStringFailsProvider
      */
-    public function testNumberToStringFails($source, string $exception, int $precision = null): void
+    public function testNumberToStringFails($source, string $exception, ?int $precision = null): void
     {
         $this->expectException($exception);
 

--- a/core-bundle/tests/Contao/WidgetTest.php
+++ b/core-bundle/tests/Contao/WidgetTest.php
@@ -45,7 +45,7 @@ class WidgetTest extends TestCase
      *
      * @dataProvider postProvider
      */
-    public function testReadsThePostData(string $key, string $input, $value, string $expected = null): void
+    public function testReadsThePostData(string $key, string $input, $value, ?string $expected = null): void
     {
         // Prevent "undefined index" errors
         $errorReporting = error_reporting();

--- a/core-bundle/tests/Controller/BackendCsvImportControllerTest.php
+++ b/core-bundle/tests/Controller/BackendCsvImportControllerTest.php
@@ -356,7 +356,7 @@ class BackendCsvImportControllerTest extends TestCase
         return $framework;
     }
 
-    private function getController(Request $request = null): BackendCsvImportController
+    private function getController(?Request $request = null): BackendCsvImportController
     {
         $requestStack = new RequestStack();
         $requestStack->push($request ?: new Request());

--- a/core-bundle/tests/Controller/BackendPreviewSwitchControllerTest.php
+++ b/core-bundle/tests/Controller/BackendPreviewSwitchControllerTest.php
@@ -327,7 +327,7 @@ class BackendPreviewSwitchControllerTest extends TestCase
     /**
      * @return TokenChecker&MockObject
      */
-    private function mockTokenChecker(string $frontendUsername = null, bool $previewMode = true): TokenChecker
+    private function mockTokenChecker(?string $frontendUsername = null, bool $previewMode = true): TokenChecker
     {
         $tokenChecker = $this->createMock(TokenChecker::class);
         $tokenChecker

--- a/core-bundle/tests/Controller/FrontendModule/RootPageDependentModulesControllerTest.php
+++ b/core-bundle/tests/Controller/FrontendModule/RootPageDependentModulesControllerTest.php
@@ -166,7 +166,7 @@ class RootPageDependentModulesControllerTest extends TestCase
         );
     }
 
-    private function mockContainer(RequestStack $requestStack = null, string $content = null): ContainerBuilder
+    private function mockContainer(?RequestStack $requestStack = null, ?string $content = null): ContainerBuilder
     {
         $moduleAdapter = $this->mockAdapter(['findByPk']);
         $moduleAdapter

--- a/core-bundle/tests/Controller/FrontendModule/TwoFactorControllerTest.php
+++ b/core-bundle/tests/Controller/FrontendModule/TwoFactorControllerTest.php
@@ -392,7 +392,7 @@ class TwoFactorControllerTest extends TestCase
     /**
      * @return Authenticator&MockObject
      */
-    private function mockAuthenticator(FrontendUser $user = null, bool $return = null): Authenticator
+    private function mockAuthenticator(?FrontendUser $user = null, ?bool $return = null): Authenticator
     {
         $authenticator = $this->createMock(Authenticator::class);
 
@@ -411,7 +411,7 @@ class TwoFactorControllerTest extends TestCase
     /**
      * @return AuthenticationUtils&MockObject
      */
-    private function mockAuthenticationUtils(AuthenticationException $authenticationException = null): AuthenticationUtils
+    private function mockAuthenticationUtils(?AuthenticationException $authenticationException = null): AuthenticationUtils
     {
         $authenticationUtils = $this->createMock(AuthenticationUtils::class);
 
@@ -429,7 +429,7 @@ class TwoFactorControllerTest extends TestCase
     /**
      * @return Security&MockObject
      */
-    private function mockSecurityHelper(UserInterface $user = null, bool $isFullyAuthenticated = false): Security
+    private function mockSecurityHelper(?UserInterface $user = null, bool $isFullyAuthenticated = false): Security
     {
         $security = $this->createMock(Security::class);
         $security

--- a/core-bundle/tests/Controller/SitemapControllerTest.php
+++ b/core-bundle/tests/Controller/SitemapControllerTest.php
@@ -807,7 +807,7 @@ class SitemapControllerTest extends TestCase
     /**
      * @return ContaoFramework&MockObject
      */
-    private function mockFrameworkWithPages(array $pages, array $articles, array $hooks = null): ContaoFramework
+    private function mockFrameworkWithPages(array $pages, array $articles, ?array $hooks = null): ContaoFramework
     {
         /** @var PageModel $rootPage1 */
         $rootPage1 = $this->mockClassWithProperties(PageModel::class);
@@ -891,7 +891,7 @@ class SitemapControllerTest extends TestCase
     /**
      * @param array<int> $allowedPageIds
      */
-    private function getContainer(ContaoFramework $framework, array $allowedPageIds = null, string $baseUrl = 'https://www.foobar.com'): ContainerBuilder
+    private function getContainer(ContaoFramework $framework, ?array $allowedPageIds = null, string $baseUrl = 'https://www.foobar.com'): ContainerBuilder
     {
         $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
         $eventDispatcher
@@ -947,7 +947,7 @@ class SitemapControllerTest extends TestCase
         return $container;
     }
 
-    private function mockPage(array $data, array $absoluteUrls = null): PageModel
+    private function mockPage(array $data, ?array $absoluteUrls = null): PageModel
     {
         $page = $this->mockClassWithProperties(PageModel::class, $data);
         $page

--- a/core-bundle/tests/Crawl/Escargot/Subscriber/BrokenLinkCheckerSubscriberTest.php
+++ b/core-bundle/tests/Crawl/Escargot/Subscriber/BrokenLinkCheckerSubscriberTest.php
@@ -45,7 +45,7 @@ class BrokenLinkCheckerSubscriberTest extends TestCase
     /**
      * @dataProvider shouldRequestProvider
      */
-    public function testShouldRequest(CrawlUri $crawlUri, string $expectedDecision, string $expectedLogLevel = '', string $expectedLogMessage = '', CrawlUri $foundOnUri = null): void
+    public function testShouldRequest(CrawlUri $crawlUri, string $expectedDecision, string $expectedLogLevel = '', string $expectedLogMessage = '', ?CrawlUri $foundOnUri = null): void
     {
         $logger = $this->createMock(LoggerInterface::class);
 

--- a/core-bundle/tests/Crawl/Escargot/Subscriber/SearchIndexSubscriberTest.php
+++ b/core-bundle/tests/Crawl/Escargot/Subscriber/SearchIndexSubscriberTest.php
@@ -48,7 +48,7 @@ class SearchIndexSubscriberTest extends TestCase
     /**
      * @dataProvider shouldRequestProvider
      */
-    public function testShouldRequest(CrawlUri $crawlUri, string $expectedDecision, string $expectedLogLevel = '', string $expectedLogMessage = '', CrawlUri $foundOnUri = null): void
+    public function testShouldRequest(CrawlUri $crawlUri, string $expectedDecision, string $expectedLogLevel = '', string $expectedLogMessage = '', ?CrawlUri $foundOnUri = null): void
     {
         $logger = $this->createMock(LoggerInterface::class);
 
@@ -147,7 +147,7 @@ class SearchIndexSubscriberTest extends TestCase
     /**
      * @dataProvider needsContentProvider
      */
-    public function testNeedsContent(ResponseInterface $response, string $expectedDecision, string $expectedLogLevel = '', string $expectedLogMessage = '', CrawlUri $crawlUri = null): void
+    public function testNeedsContent(ResponseInterface $response, string $expectedDecision, string $expectedLogLevel = '', string $expectedLogMessage = '', ?CrawlUri $crawlUri = null): void
     {
         $logger = $this->createMock(LoggerInterface::class);
 
@@ -231,7 +231,7 @@ class SearchIndexSubscriberTest extends TestCase
     /**
      * @dataProvider onLastChunkProvider
      */
-    public function testOnLastChunk(?IndexerException $indexerException, string $expectedLogLevel, string $expectedLogMessage, array $expectedStats, array $previousStats = [], CrawlUri $crawlUri = null): void
+    public function testOnLastChunk(?IndexerException $indexerException, string $expectedLogLevel, string $expectedLogMessage, array $expectedStats, array $previousStats = [], ?CrawlUri $crawlUri = null): void
     {
         $logger = $this->createMock(LoggerInterface::class);
         $logger

--- a/core-bundle/tests/DataCollector/ContaoDataCollectorTest.php
+++ b/core-bundle/tests/DataCollector/ContaoDataCollectorTest.php
@@ -276,7 +276,7 @@ class ContaoDataCollectorTest extends TestCase
         $this->assertSame([], $method->invokeArgs($collector, ['foo']));
     }
 
-    private function getDataCollector(bool $legacyRouting = false, bool $prependLocale = false, string $urlSuffix = '.html', TokenChecker $tokenChecker = null): ContaoDataCollector
+    private function getDataCollector(bool $legacyRouting = false, bool $prependLocale = false, string $urlSuffix = '.html', ?TokenChecker $tokenChecker = null): ContaoDataCollector
     {
         return new ContaoDataCollector(
             $tokenChecker ?? $this->createMock(TokenChecker::class),

--- a/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
+++ b/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
@@ -955,7 +955,7 @@ class ContaoCoreExtensionTest extends TestCase
         yield 'callback' => [AsCallback::class];
     }
 
-    private function getContainerBuilder(array $params = null): ContainerBuilder
+    private function getContainerBuilder(?array $params = null): ContainerBuilder
     {
         $container = new ContainerBuilder(
             new ParameterBag([

--- a/core-bundle/tests/Doctrine/Backup/BackupManagerTest.php
+++ b/core-bundle/tests/Doctrine/Backup/BackupManagerTest.php
@@ -391,7 +391,7 @@ class BackupManagerTest extends ContaoTestCase
         ;
     }
 
-    private function getBackupManager(Connection $connection = null, DumperInterface $dumper = null, RetentionPolicyInterface $retentionPolicy = null): BackupManager
+    private function getBackupManager(?Connection $connection = null, ?DumperInterface $dumper = null, ?RetentionPolicyInterface $retentionPolicy = null): BackupManager
     {
         $connection ??= $this->createMock(Connection::class);
         $dumper ??= $this->createMock(DumperInterface::class);

--- a/core-bundle/tests/Doctrine/DoctrineTestCase.php
+++ b/core-bundle/tests/Doctrine/DoctrineTestCase.php
@@ -38,7 +38,7 @@ abstract class DoctrineTestCase extends TestCase
      *
      * @return Registry&MockObject
      */
-    protected function mockDoctrineRegistry(Connection $connection = null): Registry
+    protected function mockDoctrineRegistry(?Connection $connection = null): Registry
     {
         $connection ??= $this->createMock(Connection::class);
 

--- a/core-bundle/tests/Doctrine/Schema/DcaSchemaProviderTest.php
+++ b/core-bundle/tests/Doctrine/Schema/DcaSchemaProviderTest.php
@@ -346,7 +346,7 @@ class DcaSchemaProviderTest extends DoctrineTestCase
      *
      * @param bool|string $largePrefixes
      */
-    public function testAppendToSchemaAddsTheIndexLength(?int $expected, string $tableOptions, $largePrefixes = null, string $version = null, string $filePerTable = null, string $fileFormat = null): void
+    public function testAppendToSchemaAddsTheIndexLength(?int $expected, string $tableOptions, $largePrefixes = null, ?string $version = null, ?string $filePerTable = null, ?string $fileFormat = null): void
     {
         $dca = [
             'tl_files' => [

--- a/core-bundle/tests/EventListener/CommandSchedulerListenerTest.php
+++ b/core-bundle/tests/EventListener/CommandSchedulerListenerTest.php
@@ -230,7 +230,7 @@ class CommandSchedulerListenerTest extends TestCase
         return $connection;
     }
 
-    private function getTerminateEvent(string $route = null): TerminateEvent
+    private function getTerminateEvent(?string $route = null): TerminateEvent
     {
         $request = new Request();
 

--- a/core-bundle/tests/EventListener/CsrfTokenCookieSubscriberTest.php
+++ b/core-bundle/tests/EventListener/CsrfTokenCookieSubscriberTest.php
@@ -365,7 +365,7 @@ class CsrfTokenCookieSubscriberTest extends TestCase
         $this->assertSame('value="'.$tokenValue.'"', $response->getContent());
     }
 
-    public function getRequestEvent(Request $request = null): RequestEvent
+    public function getRequestEvent(?Request $request = null): RequestEvent
     {
         if (!$request) {
             $request = new Request();
@@ -374,7 +374,7 @@ class CsrfTokenCookieSubscriberTest extends TestCase
         return new RequestEvent($this->createMock(Kernel::class), $request, HttpKernelInterface::MAIN_REQUEST);
     }
 
-    public function getResponseEvent(Request $request = null, Response $response = null): ResponseEvent
+    public function getResponseEvent(?Request $request = null, ?Response $response = null): ResponseEvent
     {
         if (!$request) {
             $request = new Request();

--- a/core-bundle/tests/EventListener/DataContainer/ContentCompositionListenerTest.php
+++ b/core-bundle/tests/EventListener/DataContainer/ContentCompositionListenerTest.php
@@ -983,7 +983,7 @@ class ContentCompositionListenerTest extends TestCase
         ;
     }
 
-    private function expectRequest(bool $hasSession, array $newRecords = null): void
+    private function expectRequest(bool $hasSession, ?array $newRecords = null): void
     {
         $request = $this->createMock(Request::class);
         $request

--- a/core-bundle/tests/EventListener/DataContainer/DisableAppConfiguredSettingsListenerTest.php
+++ b/core-bundle/tests/EventListener/DataContainer/DisableAppConfiguredSettingsListenerTest.php
@@ -145,7 +145,7 @@ class DisableAppConfiguredSettingsListenerTest extends TestCase
         );
     }
 
-    private function createListener(array $localConfig = null, TranslatorInterface $translator = null, array $adapters = []): DisableAppConfiguredSettingsListener
+    private function createListener(?array $localConfig = null, ?TranslatorInterface $translator = null, array $adapters = []): DisableAppConfiguredSettingsListener
     {
         $this->mockContaoFramework()->initialize();
 

--- a/core-bundle/tests/EventListener/DataContainer/PageUrlListenerTest.php
+++ b/core-bundle/tests/EventListener/DataContainer/PageUrlListenerTest.php
@@ -1729,7 +1729,7 @@ class PageUrlListenerTest extends TestCase
     /**
      * @return TranslatorInterface&MockObject
      */
-    private function mockTranslator(string $messageKey = null, array $arguments = []): TranslatorInterface
+    private function mockTranslator(?string $messageKey = null, array $arguments = []): TranslatorInterface
     {
         $translator = $this->createMock(TranslatorInterface::class);
 

--- a/core-bundle/tests/EventListener/DataContainer/TemplateOptionsListenerTest.php
+++ b/core-bundle/tests/EventListener/DataContainer/TemplateOptionsListenerTest.php
@@ -210,7 +210,7 @@ class TemplateOptionsListenerTest extends TestCase
         );
     }
 
-    private function getDefaultTemplateOptionsListener(string $legacyTemplatePrefix, string $legacyProxyClass, RequestStack $requestStack = null, Connection $connection = null): TemplateOptionsListener
+    private function getDefaultTemplateOptionsListener(string $legacyTemplatePrefix, string $legacyProxyClass, ?RequestStack $requestStack = null, ?Connection $connection = null): TemplateOptionsListener
     {
         $filesystemLoader = $this->createMock(ContaoFilesystemLoader::class);
         $filesystemLoader
@@ -238,7 +238,7 @@ class TemplateOptionsListenerTest extends TestCase
         return $listener;
     }
 
-    private function getTemplateOptionsListener(string $legacyTemplatePrefix, string $legacyProxyClass, ContaoFramework $framework = null, RequestStack $requestStack = null, Connection $connection = null, ContaoFilesystemLoader $filesystemLoader = null): TemplateOptionsListener
+    private function getTemplateOptionsListener(string $legacyTemplatePrefix, string $legacyProxyClass, ?ContaoFramework $framework = null, ?RequestStack $requestStack = null, ?Connection $connection = null, ?ContaoFilesystemLoader $filesystemLoader = null): TemplateOptionsListener
     {
         $filesystemLoader = $filesystemLoader ?? $this->createMock(ContaoFilesystemLoader::class);
         $connection = $connection ?? $this->createMock(Connection::class);

--- a/core-bundle/tests/EventListener/DataContainer/ThemeTemplatesListenerTest.php
+++ b/core-bundle/tests/EventListener/DataContainer/ThemeTemplatesListenerTest.php
@@ -59,7 +59,7 @@ class ThemeTemplatesListenerTest extends TestCase
         $listener('<bad-path>');
     }
 
-    private function getListener(ContaoFilesystemLoader $filesystemLoader = null, ThemeNamespace $themeNamespace = null, TranslatorInterface $translator = null): ThemeTemplatesListener
+    private function getListener(?ContaoFilesystemLoader $filesystemLoader = null, ?ThemeNamespace $themeNamespace = null, ?TranslatorInterface $translator = null): ThemeTemplatesListener
     {
         return new ThemeTemplatesListener(
             $filesystemLoader ?? $this->createMock(ContaoFilesystemLoader::class),

--- a/core-bundle/tests/EventListener/DataContainer/ToggleNodesLabelListenerTest.php
+++ b/core-bundle/tests/EventListener/DataContainer/ToggleNodesLabelListenerTest.php
@@ -259,7 +259,7 @@ class ToggleNodesLabelListenerTest extends TestCase
     /**
      * @return RequestStack&MockObject
      */
-    private function mockRequestStackWithSession(Session $session = null): RequestStack
+    private function mockRequestStackWithSession(?Session $session = null): RequestStack
     {
         $requestStack = $this->mockRequestStack('backend');
 
@@ -283,7 +283,7 @@ class ToggleNodesLabelListenerTest extends TestCase
     /**
      * @return RequestStack&MockObject
      */
-    private function mockRequestStack(string $scope = null): RequestStack
+    private function mockRequestStack(?string $scope = null): RequestStack
     {
         $attributes = [];
 

--- a/core-bundle/tests/EventListener/FilterPageTypeListenerTest.php
+++ b/core-bundle/tests/EventListener/FilterPageTypeListenerTest.php
@@ -122,7 +122,7 @@ class FilterPageTypeListenerTest extends TestCase
     /**
      * @return DataContainer&MockObject
      */
-    private function mockDataContainer(?int $pid, int $id = null): DataContainer
+    private function mockDataContainer(?int $pid, ?int $id = null): DataContainer
     {
         $activeRecord = array_filter(compact('id', 'pid'), static fn ($v): bool => null !== $v);
 

--- a/core-bundle/tests/EventListener/InsecureInstallationListenerTest.php
+++ b/core-bundle/tests/EventListener/InsecureInstallationListenerTest.php
@@ -81,7 +81,7 @@ class InsecureInstallationListenerTest extends TestCase
         return $request;
     }
 
-    private function getResponseEvent(Request $request = null): RequestEvent
+    private function getResponseEvent(?Request $request = null): RequestEvent
     {
         $kernel = $this->createMock(KernelInterface::class);
 

--- a/core-bundle/tests/EventListener/InsertTags/TranslationListenerTest.php
+++ b/core-bundle/tests/EventListener/InsertTags/TranslationListenerTest.php
@@ -21,7 +21,7 @@ class TranslationListenerTest extends TestCase
     /**
      * @dataProvider insertTagsProvider
      */
-    public function testReplacesInsertTagsWithTranslation(string $id, string $result, string $domain = null, array $parameters = []): void
+    public function testReplacesInsertTagsWithTranslation(string $id, string $result, ?string $domain = null, array $parameters = []): void
     {
         $translator = $this->createMock(Translator::class);
         $translator

--- a/core-bundle/tests/EventListener/MergeHttpHeadersListenerTest.php
+++ b/core-bundle/tests/EventListener/MergeHttpHeadersListenerTest.php
@@ -304,7 +304,7 @@ class MergeHttpHeadersListenerTest extends TestCase
         $listener($this->getResponseEvent($response));
     }
 
-    private function getResponseEvent(Response $response = null, int $requestType = HttpKernelInterface::MAIN_REQUEST): ResponseEvent
+    private function getResponseEvent(?Response $response = null, int $requestType = HttpKernelInterface::MAIN_REQUEST): ResponseEvent
     {
         $kernel = $this->createMock(KernelInterface::class);
 

--- a/core-bundle/tests/EventListener/PrettyErrorScreenListenerTest.php
+++ b/core-bundle/tests/EventListener/PrettyErrorScreenListenerTest.php
@@ -486,7 +486,7 @@ class PrettyErrorScreenListenerTest extends TestCase
         return parent::mockContaoFramework($adapters);
     }
 
-    private function getListener(bool $isBackendUser = false, Environment $twig = null, PageModel $errorPage = null, HttpKernelInterface $httpKernel = null, PageModel $rootPage = null): PrettyErrorScreenListener
+    private function getListener(bool $isBackendUser = false, ?Environment $twig = null, ?PageModel $errorPage = null, ?HttpKernelInterface $httpKernel = null, ?PageModel $rootPage = null): PrettyErrorScreenListener
     {
         $twig ??= $this->createMock(Environment::class);
         $httpKernel ??= $this->createMock(HttpKernelInterface::class);
@@ -541,7 +541,7 @@ class PrettyErrorScreenListenerTest extends TestCase
         return $request;
     }
 
-    private function getResponseEvent(\Exception $exception, Request $request = null, bool $isSubRequest = false): ExceptionEvent
+    private function getResponseEvent(\Exception $exception, ?Request $request = null, bool $isSubRequest = false): ExceptionEvent
     {
         $kernel = $this->createMock(KernelInterface::class);
         $type = $isSubRequest ? HttpKernelInterface::SUB_REQUEST : HttpKernelInterface::MAIN_REQUEST;

--- a/core-bundle/tests/EventListener/PreviewAuthenticationListenerTest.php
+++ b/core-bundle/tests/EventListener/PreviewAuthenticationListenerTest.php
@@ -103,7 +103,7 @@ class PreviewAuthenticationListenerTest extends TestCase
         $this->assertInstanceOf(RedirectResponse::class, $requestEvent->getResponse());
     }
 
-    private function getRequestEvent(Request $request = null): RequestEvent
+    private function getRequestEvent(?Request $request = null): RequestEvent
     {
         $kernel = $this->createMock(KernelInterface::class);
 

--- a/core-bundle/tests/EventListener/PreviewUrlConverterListenerTest.php
+++ b/core-bundle/tests/EventListener/PreviewUrlConverterListenerTest.php
@@ -283,7 +283,7 @@ class PreviewUrlConverterListenerTest extends TestCase
     /**
      * @return PageRegistry&MockObject
      */
-    private function mockPageRegistry(PageRoute $route = null): PageRegistry
+    private function mockPageRegistry(?PageRoute $route = null): PageRegistry
     {
         $pageRegistry = $this->createMock(PageRegistry::class);
 

--- a/core-bundle/tests/EventListener/Security/LogoutSuccessListenerTest.php
+++ b/core-bundle/tests/EventListener/Security/LogoutSuccessListenerTest.php
@@ -414,7 +414,7 @@ class LogoutSuccessListenerTest extends TestCase
         $listener($event);
     }
 
-    private function mockLogoutSuccessListener(HttpUtils $httpUtils = null, ScopeMatcher $scopeMatcher = null, ContaoFramework $framework = null, Security $security = null, LoggerInterface $logger = null): LogoutSuccessListener
+    private function mockLogoutSuccessListener(?HttpUtils $httpUtils = null, ?ScopeMatcher $scopeMatcher = null, ?ContaoFramework $framework = null, ?Security $security = null, ?LoggerInterface $logger = null): LogoutSuccessListener
     {
         if (null === $httpUtils) {
             $httpUtils = $this->createMock(HttpUtils::class);

--- a/core-bundle/tests/EventListener/Security/SwitchUserListenerTest.php
+++ b/core-bundle/tests/EventListener/Security/SwitchUserListenerTest.php
@@ -55,7 +55,7 @@ class SwitchUserListenerTest extends TestCase
     /**
      * @return LoggerInterface&MockObject
      */
-    private function mockLogger(string $message = null): LoggerInterface
+    private function mockLogger(?string $message = null): LoggerInterface
     {
         $logger = $this->createMock(LoggerInterface::class);
 
@@ -75,7 +75,7 @@ class SwitchUserListenerTest extends TestCase
     /**
      * @return TokenStorageInterface&MockObject
      */
-    private function mockTokenStorage(string $username = null): TokenStorageInterface
+    private function mockTokenStorage(?string $username = null): TokenStorageInterface
     {
         $tokenStorage = $this->createMock(TokenStorageInterface::class);
 
@@ -97,7 +97,7 @@ class SwitchUserListenerTest extends TestCase
         return $tokenStorage;
     }
 
-    private function mockSwitchUserEvent(string $username = null): SwitchUserEvent
+    private function mockSwitchUserEvent(?string $username = null): SwitchUserEvent
     {
         $user = $this->createPartialMock(BackendUser::class, ['getUserIdentifier']);
 

--- a/core-bundle/tests/EventListener/Security/TwoFactorFrontendListenerTest.php
+++ b/core-bundle/tests/EventListener/Security/TwoFactorFrontendListenerTest.php
@@ -475,7 +475,7 @@ class TwoFactorFrontendListenerTest extends TestCase
      *
      * @return T&MockObject
      */
-    private function mockToken(string $class, bool $withFrontendUser = false, FrontendUser $user = null)
+    private function mockToken(string $class, bool $withFrontendUser = false, ?FrontendUser $user = null)
     {
         $token = $this->createMock($class);
         $user ??= $this->createMock(FrontendUser::class);
@@ -497,7 +497,7 @@ class TwoFactorFrontendListenerTest extends TestCase
         return $token;
     }
 
-    private function getRequest(bool $withPageModel = false, PageModel $pageModel = null): Request
+    private function getRequest(bool $withPageModel = false, ?PageModel $pageModel = null): Request
     {
         $request = new Request();
         $request->attributes->set('pageModel', null);
@@ -516,7 +516,7 @@ class TwoFactorFrontendListenerTest extends TestCase
     /**
      * @return TokenStorageInterface&MockObject
      */
-    private function mockTokenStorageWithToken(TokenInterface $token = null): TokenStorageInterface
+    private function mockTokenStorageWithToken(?TokenInterface $token = null): TokenStorageInterface
     {
         $tokenStorage = $this->createMock(TokenStorage::class);
         $tokenStorage
@@ -544,7 +544,7 @@ class TwoFactorFrontendListenerTest extends TestCase
         return $scopeMatcher;
     }
 
-    private function getRequestEvent(Request $request = null, Response $response = null): RequestEvent
+    private function getRequestEvent(?Request $request = null, ?Response $response = null): RequestEvent
     {
         $kernel = $this->createMock(Kernel::class);
         $event = new RequestEvent($kernel, $request ?? new Request(), HttpKernelInterface::MAIN_REQUEST);

--- a/core-bundle/tests/EventListener/StoreRefererListenerTest.php
+++ b/core-bundle/tests/EventListener/StoreRefererListenerTest.php
@@ -173,7 +173,7 @@ class StoreRefererListenerTest extends TestCase
     /**
      * @dataProvider noContaoUserProvider
      */
-    public function testDoesNotStoreTheRefererIfThereIsNoContaoUser(UserInterface $user = null): void
+    public function testDoesNotStoreTheRefererIfThereIsNoContaoUser(?UserInterface $user = null): void
     {
         $session = $this->createMock(SessionInterface::class);
         $session
@@ -260,7 +260,7 @@ class StoreRefererListenerTest extends TestCase
         $listener($this->getResponseEvent($request));
     }
 
-    private function getListener(UserInterface $user = null, bool $expectsSecurityCall = false): StoreRefererListener
+    private function getListener(?UserInterface $user = null, bool $expectsSecurityCall = false): StoreRefererListener
     {
         $security = $this->createMock(Security::class);
         $security
@@ -272,7 +272,7 @@ class StoreRefererListenerTest extends TestCase
         return new StoreRefererListener($security, $this->mockScopeMatcher());
     }
 
-    private function getResponseEvent(Request $request = null): ResponseEvent
+    private function getResponseEvent(?Request $request = null): ResponseEvent
     {
         $kernel = $this->createMock(KernelInterface::class);
 

--- a/core-bundle/tests/EventListener/UserSessionListenerTest.php
+++ b/core-bundle/tests/EventListener/UserSessionListenerTest.php
@@ -339,7 +339,7 @@ class UserSessionListenerTest extends TestCase
         $listener->write($this->getResponseEvent($request));
     }
 
-    private function getListener(Connection $connection = null, Security $security = null, EventDispatcherInterface $eventDispatcher = null): UserSessionListener
+    private function getListener(?Connection $connection = null, ?Security $security = null, ?EventDispatcherInterface $eventDispatcher = null): UserSessionListener
     {
         $connection ??= $this->createMock(Connection::class);
         $security ??= $this->createMock(Security::class);
@@ -349,14 +349,14 @@ class UserSessionListenerTest extends TestCase
         return new UserSessionListener($connection, $security, $scopeMatcher, $eventDispatcher);
     }
 
-    private function getRequestEvent(Request $request = null): RequestEvent
+    private function getRequestEvent(?Request $request = null): RequestEvent
     {
         $kernel = $this->createMock(KernelInterface::class);
 
         return new RequestEvent($kernel, $request ?? new Request(), HttpKernelInterface::MAIN_REQUEST);
     }
 
-    private function getResponseEvent(Request $request = null): ResponseEvent
+    private function getResponseEvent(?Request $request = null): ResponseEvent
     {
         $kernel = $this->createMock(KernelInterface::class);
 

--- a/core-bundle/tests/Filesystem/Dbafs/DbafsTest.php
+++ b/core-bundle/tests/Filesystem/Dbafs/DbafsTest.php
@@ -1390,7 +1390,7 @@ class DbafsTest extends TestCase
         return (new MountManager())->mount(new InMemoryFilesystemAdapter());
     }
 
-    private function getDbafs(Connection $connection = null, VirtualFilesystemInterface $filesystem = null, EventDispatcherInterface $eventDispatcher = null): Dbafs
+    private function getDbafs(?Connection $connection = null, ?VirtualFilesystemInterface $filesystem = null, ?EventDispatcherInterface $eventDispatcher = null): Dbafs
     {
         $connection ??= $this->createMock(Connection::class);
 

--- a/core-bundle/tests/Filesystem/VirtualFilesystemTest.php
+++ b/core-bundle/tests/Filesystem/VirtualFilesystemTest.php
@@ -999,7 +999,7 @@ class VirtualFilesystemTest extends TestCase
         return $mountManager;
     }
 
-    private function getVirtualFilesystem(MountManager $mountManager, array $sync = null): VirtualFilesystem
+    private function getVirtualFilesystem(MountManager $mountManager, ?array $sync = null): VirtualFilesystem
     {
         $dbafsManager = $this->createMock(DbafsManager::class);
         $dbafsManager

--- a/core-bundle/tests/Fixtures/Image/PictureFactoryWithRandomArgumentStub.php
+++ b/core-bundle/tests/Fixtures/Image/PictureFactoryWithRandomArgumentStub.php
@@ -22,7 +22,7 @@ class PictureFactoryWithRandomArgumentStub implements PictureFactoryInterface
         throw new \RuntimeException('not implemented');
     }
 
-    public function create($path, $size = null, array $options = null): PictureInterface
+    public function create($path, $size = null, ?array $options = null): PictureInterface
     {
         throw new \RuntimeException('not implemented');
     }

--- a/core-bundle/tests/Fixtures/Image/PictureFactoryWithResizeOptionsStub.php
+++ b/core-bundle/tests/Fixtures/Image/PictureFactoryWithResizeOptionsStub.php
@@ -23,7 +23,7 @@ class PictureFactoryWithResizeOptionsStub implements PictureFactoryInterface
         throw new \RuntimeException('not implemented');
     }
 
-    public function create($path, $size = null, ResizeOptions $options = null): PictureInterface
+    public function create($path, $size = null, ?ResizeOptions $options = null): PictureInterface
     {
         throw new \RuntimeException('not implemented');
     }

--- a/core-bundle/tests/Fragment/FragmentHandlerTest.php
+++ b/core-bundle/tests/Fragment/FragmentHandlerTest.php
@@ -241,7 +241,7 @@ class FragmentHandlerTest extends TestCase
         $fragmentHandler->render($uri);
     }
 
-    private function getFragmentHandler(FragmentRegistry $registry = null, ServiceLocator $renderers = null, ServiceLocator $preHandlers = null, Request $request = null, BaseFragmentHandler $fragmentHandler = null): FragmentHandler
+    private function getFragmentHandler(?FragmentRegistry $registry = null, ?ServiceLocator $renderers = null, ?ServiceLocator $preHandlers = null, ?Request $request = null, ?BaseFragmentHandler $fragmentHandler = null): FragmentHandler
     {
         $registry ??= new FragmentRegistry();
         $renderers ??= new ServiceLocator([]);
@@ -258,7 +258,7 @@ class FragmentHandlerTest extends TestCase
     /**
      * @return ServiceLocator&MockObject
      */
-    private function mockServiceLocatorWithRenderer(string $name, array $with = null, Response $response = null): ServiceLocator
+    private function mockServiceLocatorWithRenderer(string $name, ?array $with = null, ?Response $response = null): ServiceLocator
     {
         $renderer = $this->createMock(FragmentRendererInterface::class);
         $renderer

--- a/core-bundle/tests/Framework/ContaoFrameworkTest.php
+++ b/core-bundle/tests/Framework/ContaoFrameworkTest.php
@@ -743,7 +743,7 @@ class ContaoFrameworkTest extends TestCase
         $this->assertCount(0, $registry);
     }
 
-    private function getFramework(Request $request = null, ScopeMatcher $scopeMatcher = null, TokenChecker $tokenChecker = null): ContaoFramework
+    private function getFramework(?Request $request = null, ?ScopeMatcher $scopeMatcher = null, ?TokenChecker $tokenChecker = null): ContaoFramework
     {
         $requestStack = new RequestStack();
 

--- a/core-bundle/tests/Image/ImageFactoryTest.php
+++ b/core-bundle/tests/Image/ImageFactoryTest.php
@@ -832,7 +832,7 @@ class ImageFactoryTest extends TestCase
     {
     }
 
-    private function getImageFactory(ResizerInterface $resizer = null, ImagineInterface $imagine = null, ImagineInterface $imagineSvg = null, Filesystem $filesystem = null, ContaoFramework $framework = null, bool $bypassCache = null, array $imagineOptions = null, array $validExtensions = null, string $uploadDir = null): ImageFactory
+    private function getImageFactory(?ResizerInterface $resizer = null, ?ImagineInterface $imagine = null, ?ImagineInterface $imagineSvg = null, ?Filesystem $filesystem = null, ?ContaoFramework $framework = null, ?bool $bypassCache = null, ?array $imagineOptions = null, ?array $validExtensions = null, ?string $uploadDir = null): ImageFactory
     {
         $resizer ??= $this->createMock(ResizerInterface::class);
         $imagine ??= $this->createMock(ImagineInterface::class);

--- a/core-bundle/tests/Image/PictureFactoryTest.php
+++ b/core-bundle/tests/Image/PictureFactoryTest.php
@@ -769,7 +769,7 @@ class PictureFactoryTest extends TestCase
         yield [false, 20, 100, 22, 100];
     }
 
-    private function getPictureFactory(PictureGeneratorInterface $pictureGenerator = null, ImageFactoryInterface $imageFactory = null, ContaoFramework $framework = null): PictureFactory
+    private function getPictureFactory(?PictureGeneratorInterface $pictureGenerator = null, ?ImageFactoryInterface $imageFactory = null, ?ContaoFramework $framework = null): PictureFactory
     {
         $pictureGenerator ??= $this->createMock(PictureGeneratorInterface::class);
         $imageFactory ??= $this->createMock(ImageFactoryInterface::class);

--- a/core-bundle/tests/Image/Preview/ImaginePreviewProviderTest.php
+++ b/core-bundle/tests/Image/Preview/ImaginePreviewProviderTest.php
@@ -117,7 +117,7 @@ class ImaginePreviewProviderTest extends TestCase
         $provider->generatePreviews($sourcePath, 512, $targetPathCallback);
     }
 
-    private function createProvider(ImagineInterface $imagine = null): ImaginePreviewProvider
+    private function createProvider(?ImagineInterface $imagine = null): ImaginePreviewProvider
     {
         return new ImaginePreviewProvider($imagine ?? new Imagine());
     }

--- a/core-bundle/tests/Image/Preview/PreviewFactoryTest.php
+++ b/core-bundle/tests/Image/Preview/PreviewFactoryTest.php
@@ -372,7 +372,7 @@ class PreviewFactoryTest extends TestCase
         }
     }
 
-    private function createFactoryWithExampleProvider(ContaoFramework $framework = null): PreviewFactory
+    private function createFactoryWithExampleProvider(?ContaoFramework $framework = null): PreviewFactory
     {
         $pdfProvider = new class() implements PreviewProviderInterface {
             public function getFileHeaderSize(): int

--- a/core-bundle/tests/Image/Studio/FigureBuilderTest.php
+++ b/core-bundle/tests/Image/Studio/FigureBuilderTest.php
@@ -694,7 +694,7 @@ class FigureBuilderTest extends TestCase
     /**
      * @dataProvider provideMetadataAutoFetchCases
      */
-    public function testAutoFetchMetadataFromFilesModel(string $serializedMetadata, ?string $locale, array $expectedMetadata, Metadata $overwriteMetadata = null): void
+    public function testAutoFetchMetadataFromFilesModel(string $serializedMetadata, ?string $locale, array $expectedMetadata, ?Metadata $overwriteMetadata = null): void
     {
         $container = $this->getContainerWithContaoConfiguration();
         $container->set('contao.insert_tag.parser', new InsertTagParser($this->createMock(ContaoFramework::class)));
@@ -1390,7 +1390,7 @@ class FigureBuilderTest extends TestCase
         $this->assertSame([Metadata::VALUE_TITLE => 'bar'], $figure->getMetadata()->all());
     }
 
-    private function getFigure(\Closure $configureBuilderCallback = null, Studio $studio = null): Figure
+    private function getFigure(?\Closure $configureBuilderCallback = null, ?Studio $studio = null): Figure
     {
         [$absoluteFilePath] = $this->getTestFilePaths();
 
@@ -1407,7 +1407,7 @@ class FigureBuilderTest extends TestCase
     /**
      * @return Studio&MockObject
      */
-    private function mockStudioForImage(string $expectedFilePath, string $expectedSizeConfiguration = null, ResizeOptions $resizeOptions = null): Studio
+    private function mockStudioForImage(string $expectedFilePath, ?string $expectedSizeConfiguration = null, ?ResizeOptions $resizeOptions = null): Studio
     {
         $image = $this->createMock(ImageResult::class);
 
@@ -1427,7 +1427,7 @@ class FigureBuilderTest extends TestCase
      *
      * @return Studio&MockObject
      */
-    private function mockStudioForLightbox($expectedResource, ?string $expectedUrl, string $expectedSizeConfiguration = null, string $expectedGroupIdentifier = null, ResizeOptions $resizeOptions = null): Studio
+    private function mockStudioForLightbox($expectedResource, ?string $expectedUrl, ?string $expectedSizeConfiguration = null, ?string $expectedGroupIdentifier = null, ?ResizeOptions $resizeOptions = null): Studio
     {
         $lightbox = $this->createMock(LightboxResult::class);
 
@@ -1442,7 +1442,7 @@ class FigureBuilderTest extends TestCase
         return $studio;
     }
 
-    private function getFigureBuilder(Studio $studio = null, ContaoFramework $framework = null, EventDispatcher $eventDispatcher = null): FigureBuilder
+    private function getFigureBuilder(?Studio $studio = null, ?ContaoFramework $framework = null, ?EventDispatcher $eventDispatcher = null): FigureBuilder
     {
         [, , $projectDir, $uploadPath, $webDir] = $this->getTestFilePaths();
         $validExtensions = $this->getTestFileExtensions();

--- a/core-bundle/tests/Image/Studio/ImageResultTest.php
+++ b/core-bundle/tests/Image/Studio/ImageResultTest.php
@@ -524,7 +524,7 @@ class ImageResultTest extends TestCase
     /**
      * @return ContainerInterface&MockObject
      */
-    private function mockLocator(PictureFactoryInterface $pictureFactory = null, string $staticUrl = null): ContainerInterface
+    private function mockLocator(?PictureFactoryInterface $pictureFactory = null, ?string $staticUrl = null): ContainerInterface
     {
         $locator = $this->createMock(ContainerInterface::class);
         $context = null;

--- a/core-bundle/tests/Image/Studio/TwigMacrosTest.php
+++ b/core-bundle/tests/Image/Studio/TwigMacrosTest.php
@@ -569,7 +569,7 @@ class TwigMacrosTest extends TestCase
         ];
     }
 
-    private function renderMacro(string $call, array $context = [], ResponseContextAccessor $responseContextAccessor = null): string
+    private function renderMacro(string $call, array $context = [], ?ResponseContextAccessor $responseContextAccessor = null): string
     {
         $templates = [
             '_macros.html.twig' => file_get_contents(

--- a/core-bundle/tests/Intl/CountriesTest.php
+++ b/core-bundle/tests/Intl/CountriesTest.php
@@ -86,7 +86,7 @@ class CountriesTest extends TestCase
         $translator
             ->method('trans')
             ->willReturnCallback(
-                function (string $label, array $parameters, string $domain, string $locale = null) {
+                function (string $label, array $parameters, string $domain, ?string $locale = null) {
                     $this->assertSame('contao_countries', $domain);
                     $this->assertSame('de', $locale);
 
@@ -220,7 +220,7 @@ class CountriesTest extends TestCase
         ];
     }
 
-    private function getCountriesService(Translator $translator = null, array $configCountries = []): Countries
+    private function getCountriesService(?Translator $translator = null, array $configCountries = []): Countries
     {
         if (null === $translator) {
             $translator = $this->createMock(Translator::class);

--- a/core-bundle/tests/Intl/LocalesTest.php
+++ b/core-bundle/tests/Intl/LocalesTest.php
@@ -190,7 +190,7 @@ class LocalesTest extends TestCase
         $translator
             ->method('trans')
             ->willReturnCallback(
-                function (string $label, array $parameters, string $domain, string $locale = null) {
+                function (string $label, array $parameters, string $domain, ?string $locale = null) {
                     $this->assertSame('contao_languages', $domain);
                     $this->assertSame('de', $locale);
 
@@ -493,7 +493,7 @@ class LocalesTest extends TestCase
         }
     }
 
-    private function getLocalesService(Translator $translator = null, RequestStack $requestStack = null, array $defaultEnabledLocales = null, array $configLocales = [], array $configEnabledLocales = [], string $defaultLocale = null): Locales
+    private function getLocalesService(?Translator $translator = null, ?RequestStack $requestStack = null, ?array $defaultEnabledLocales = null, array $configLocales = [], array $configEnabledLocales = [], ?string $defaultLocale = null): Locales
     {
         if (null === $translator) {
             $translator = $this->createMock(Translator::class);

--- a/core-bundle/tests/Monolog/ContaoTableProcessorTest.php
+++ b/core-bundle/tests/Monolog/ContaoTableProcessorTest.php
@@ -301,7 +301,7 @@ class ContaoTableProcessorTest extends TestCase
         yield [ContaoCoreBundle::SCOPE_BACKEND, null, 'BE'];
     }
 
-    private function getContaoTableProcessor(RequestStack $requestStack = null, TokenStorageInterface $tokenStorage = null): ContaoTableProcessor
+    private function getContaoTableProcessor(?RequestStack $requestStack = null, ?TokenStorageInterface $tokenStorage = null): ContaoTableProcessor
     {
         $requestStack ??= $this->createMock(RequestStack::class);
         $tokenStorage ??= $this->createMock(TokenStorageInterface::class);

--- a/core-bundle/tests/OptIn/OptInTokenTest.php
+++ b/core-bundle/tests/OptIn/OptInTokenTest.php
@@ -304,7 +304,7 @@ class OptInTokenTest extends TestCase
         $this->assertTrue($token->hasBeenSent());
     }
 
-    private function getToken(OptInModel $model, ContaoFramework $framework = null): OptInTokenInterface
+    private function getToken(OptInModel $model, ?ContaoFramework $framework = null): OptInTokenInterface
     {
         return new OptInToken($model, $framework ?? $this->mockContaoFramework());
     }

--- a/core-bundle/tests/Picker/ArticlePickerProviderTest.php
+++ b/core-bundle/tests/Picker/ArticlePickerProviderTest.php
@@ -152,7 +152,7 @@ class ArticlePickerProviderTest extends ContaoTestCase
         );
     }
 
-    private function getPicker(bool $accessGranted = null): ArticlePickerProvider
+    private function getPicker(?bool $accessGranted = null): ArticlePickerProvider
     {
         $security = $this->createMock(Security::class);
         $security

--- a/core-bundle/tests/Picker/FilePickerProviderTest.php
+++ b/core-bundle/tests/Picker/FilePickerProviderTest.php
@@ -216,7 +216,7 @@ class FilePickerProviderTest extends TestCase
         );
     }
 
-    private function getPicker(bool $accessGranted = null): FilePickerProvider
+    private function getPicker(?bool $accessGranted = null): FilePickerProvider
     {
         $security = $this->createMock(Security::class);
         $security

--- a/core-bundle/tests/Picker/PagePickerProviderTest.php
+++ b/core-bundle/tests/Picker/PagePickerProviderTest.php
@@ -178,7 +178,7 @@ class PagePickerProviderTest extends ContaoTestCase
         );
     }
 
-    private function getPicker(bool $accessGranted = null): PagePickerProvider
+    private function getPicker(?bool $accessGranted = null): PagePickerProvider
     {
         $security = $this->createMock(Security::class);
         $security

--- a/core-bundle/tests/Picker/TablePickerProviderTest.php
+++ b/core-bundle/tests/Picker/TablePickerProviderTest.php
@@ -472,7 +472,7 @@ class TablePickerProviderTest extends ContaoTestCase
         $provider->getUrl($config);
     }
 
-    private function createTableProvider(ContaoFramework $framework = null, RouterInterface $router = null, Connection $connection = null): TablePickerProvider
+    private function createTableProvider(?ContaoFramework $framework = null, ?RouterInterface $router = null, ?Connection $connection = null): TablePickerProvider
     {
         return new TablePickerProvider(
             $framework ?: $this->createMock(ContaoFramework::class),
@@ -483,7 +483,7 @@ class TablePickerProviderTest extends ContaoTestCase
         );
     }
 
-    private function createMenuTableProvider(array $modules, string $current, ItemInterface $menu = null): TablePickerProvider
+    private function createMenuTableProvider(array $modules, string $current, ?ItemInterface $menu = null): TablePickerProvider
     {
         $expectedItems = [];
         $expectedParams = [];
@@ -532,7 +532,7 @@ class TablePickerProviderTest extends ContaoTestCase
     /**
      * @return PickerConfig&MockObject
      */
-    private function mockPickerConfig(string $table = '', string $value = '', string $current = '', array $expectedCurrent = null): PickerConfig
+    private function mockPickerConfig(string $table = '', string $value = '', string $current = '', ?array $expectedCurrent = null): PickerConfig
     {
         if (!$expectedCurrent && '' !== $current) {
             $expectedCurrent = [[$current]];

--- a/core-bundle/tests/Routing/Candidates/PageCandidatesTest.php
+++ b/core-bundle/tests/Routing/Candidates/PageCandidatesTest.php
@@ -528,7 +528,7 @@ class PageCandidatesTest extends TestCase
      *
      * @return Connection&MockObject
      */
-    private function mockConnection(QueryBuilder $queryBuilder = null): Connection
+    private function mockConnection(?QueryBuilder $queryBuilder = null): Connection
     {
         $queryBuilder ??= $this->createMock(QueryBuilder::class);
 

--- a/core-bundle/tests/Routing/Matcher/LegacyMatcherTest.php
+++ b/core-bundle/tests/Routing/Matcher/LegacyMatcherTest.php
@@ -576,7 +576,7 @@ class LegacyMatcherTest extends TestCase
      *
      * @return ContaoFramework&MockObject
      */
-    private function mockFrameworkWithAdapters(Adapter $configAdapter = null, string $language = null, array $hooks = []): ContaoFramework
+    private function mockFrameworkWithAdapters(?Adapter $configAdapter = null, ?string $language = null, array $hooks = []): ContaoFramework
     {
         $classes = [];
         $callbacks = [];
@@ -627,7 +627,7 @@ class LegacyMatcherTest extends TestCase
     /**
      * @return RequestMatcherInterface&MockObject
      */
-    private function mockRequestMatcher(string $pathInfo = null, array $match = []): RequestMatcherInterface
+    private function mockRequestMatcher(?string $pathInfo = null, array $match = []): RequestMatcherInterface
     {
         $expectCalls = null === $pathInfo ? 1 : 2;
 

--- a/core-bundle/tests/Routing/RouteProviderTest.php
+++ b/core-bundle/tests/Routing/RouteProviderTest.php
@@ -814,7 +814,7 @@ class RouteProviderTest extends TestCase
      *
      * @return ContaoFramework&MockObject
      */
-    private function mockFramework(Adapter $pageAdapter = null): ContaoFramework
+    private function mockFramework(?Adapter $pageAdapter = null): ContaoFramework
     {
         return $this->mockContaoFramework([PageModel::class => $pageAdapter]);
     }
@@ -822,7 +822,7 @@ class RouteProviderTest extends TestCase
     /**
      * @return PageModel&MockObject
      */
-    private function mockPage(string $language, string $alias, bool $fallback = true, string $domain = '', string $scheme = null, string $urlSuffix = '.html'): PageModel
+    private function mockPage(string $language, string $alias, bool $fallback = true, string $domain = '', ?string $scheme = null, string $urlSuffix = '.html'): PageModel
     {
         mt_srand(++$this->pageModelAutoIncrement);
 
@@ -873,7 +873,7 @@ class RouteProviderTest extends TestCase
         return $page;
     }
 
-    private function getRouteProvider(ContaoFramework $framework = null, PageRegistry $pageRegistry = null, bool $prependLocale = false): RouteProvider
+    private function getRouteProvider(?ContaoFramework $framework = null, ?PageRegistry $pageRegistry = null, bool $prependLocale = false): RouteProvider
     {
         $candidates = $this->createMock(CandidatesInterface::class);
         $candidates

--- a/core-bundle/tests/Search/Indexer/DefaultIndexerTest.php
+++ b/core-bundle/tests/Search/Indexer/DefaultIndexerTest.php
@@ -28,7 +28,7 @@ class DefaultIndexerTest extends TestCase
     /**
      * @dataProvider indexProvider
      */
-    public function testIndexesADocument(Document $document, ?array $expectedIndexParams, string $expectedMessage = null, bool $indexProtected = false): void
+    public function testIndexesADocument(Document $document, ?array $expectedIndexParams, ?string $expectedMessage = null, bool $indexProtected = false): void
     {
         $searchAdapter = $this->mockAdapter(['indexPage']);
 
@@ -216,7 +216,7 @@ class DefaultIndexerTest extends TestCase
      * @group legacy
      * @dataProvider indexProviderDeprecated
      */
-    public function testIndexesADocumentWithDeprecatedJsonLd(Document $document, ?array $expectedIndexParams, string $expectedMessage = null, bool $indexProtected = false): void
+    public function testIndexesADocumentWithDeprecatedJsonLd(Document $document, ?array $expectedIndexParams, ?string $expectedMessage = null, bool $indexProtected = false): void
     {
         $this->expectDeprecation('Since contao/core-bundle 4.9: Using the JSON-LD type "RegularPage" has been deprecated and will no longer work in Contao 5.0. Use "Page" instead.');
 

--- a/core-bundle/tests/Security/Authentication/AuthenticationSuccessHandlerTest.php
+++ b/core-bundle/tests/Security/Authentication/AuthenticationSuccessHandlerTest.php
@@ -424,7 +424,7 @@ class AuthenticationSuccessHandlerTest extends TestCase
         $this->getHandler()->onAuthenticationSuccess($request, $token);
     }
 
-    private function getHandler(ContaoFramework $framework = null, LoggerInterface $logger = null): AuthenticationSuccessHandler
+    private function getHandler(?ContaoFramework $framework = null, ?LoggerInterface $logger = null): AuthenticationSuccessHandler
     {
         $framework ??= $this->mockContaoFramework();
         $trustedDeviceManager = $this->createMock(TrustedDeviceManagerInterface::class);

--- a/core-bundle/tests/Security/Authentication/ContaoLoginAuthenticationListenerTest.php
+++ b/core-bundle/tests/Security/Authentication/ContaoLoginAuthenticationListenerTest.php
@@ -143,7 +143,7 @@ class ContaoLoginAuthenticationListenerTest extends TestCase
         $listener($this->getRequestEvent($request));
     }
 
-    private function createListener(AuthenticationManagerInterface $authenticationManager, TokenStorageInterface $tokenStorage = null): ContaoLoginAuthenticationListener
+    private function createListener(AuthenticationManagerInterface $authenticationManager, ?TokenStorageInterface $tokenStorage = null): ContaoLoginAuthenticationListener
     {
         $failureHandler = $this->createMock(AuthenticationFailureHandlerInterface::class);
         $failureHandler
@@ -170,7 +170,7 @@ class ContaoLoginAuthenticationListenerTest extends TestCase
     /**
      * @return Request&MockObject
      */
-    private function mockRequest(bool $isPost = true, SessionInterface $session = null): Request
+    private function mockRequest(bool $isPost = true, ?SessionInterface $session = null): Request
     {
         $session ??= $this->createMock(SessionInterface::class);
 
@@ -210,7 +210,7 @@ class ContaoLoginAuthenticationListenerTest extends TestCase
     /**
      * @return AuthenticationManagerInterface&MockObject
      */
-    private function mockAuthenticationManager(?string $username, string $password = null): AuthenticationManagerInterface
+    private function mockAuthenticationManager(?string $username, ?string $password = null): AuthenticationManagerInterface
     {
         $authenticationManager = $this->createMock(AuthenticationManagerInterface::class);
         $authenticationManager

--- a/core-bundle/tests/Security/Authentication/FrontendPreviewAuthenticatorTest.php
+++ b/core-bundle/tests/Security/Authentication/FrontendPreviewAuthenticatorTest.php
@@ -257,7 +257,7 @@ class FrontendPreviewAuthenticatorTest extends TestCase
         $this->assertFalse($authenticator->removeFrontendAuthentication());
     }
 
-    private function getAuthenticator(Security $security = null, TokenStorageInterface $tokenStorage = null, TokenChecker $tokenChecker = null, SessionInterface $session = null, UserProviderInterface $userProvider = null, LoggerInterface $logger = null): FrontendPreviewAuthenticator
+    private function getAuthenticator(?Security $security = null, ?TokenStorageInterface $tokenStorage = null, ?TokenChecker $tokenChecker = null, ?SessionInterface $session = null, ?UserProviderInterface $userProvider = null, ?LoggerInterface $logger = null): FrontendPreviewAuthenticator
     {
         if (null === $session) {
             $session = $this->createMock(SessionInterface::class);

--- a/core-bundle/tests/Security/Authentication/Provider/AuthenticationProviderTest.php
+++ b/core-bundle/tests/Security/Authentication/Provider/AuthenticationProviderTest.php
@@ -531,7 +531,7 @@ class AuthenticationProviderTest extends TestCase
         return false;
     }
 
-    private function createUsernamePasswordProvider(ContaoFramework $framework = null, AuthenticationHandlerInterface $twoFactorHandler = null, TrustedDeviceManagerInterface $trustedDeviceManager = null): AuthenticationProvider
+    private function createUsernamePasswordProvider(?ContaoFramework $framework = null, ?AuthenticationHandlerInterface $twoFactorHandler = null, ?TrustedDeviceManagerInterface $trustedDeviceManager = null): AuthenticationProvider
     {
         $userProvider = $this->createMock(UserProviderInterface::class);
         $userChecker = $this->createMock(UserCheckerInterface::class);
@@ -569,7 +569,7 @@ class AuthenticationProviderTest extends TestCase
         );
     }
 
-    private function createTwoFactorProvider(AuthenticationProviderInterface $twoFactorAuthenticationProvider = null, UserCheckerInterface $userChecker = null): AuthenticationProvider
+    private function createTwoFactorProvider(?AuthenticationProviderInterface $twoFactorAuthenticationProvider = null, ?UserCheckerInterface $userChecker = null): AuthenticationProvider
     {
         $userProvider = $this->createMock(UserProviderInterface::class);
         $providerKey = 'contao_frontend';

--- a/core-bundle/tests/Security/Authentication/RememberMe/ExpiringTokenBasedRememberMeServicesTest.php
+++ b/core-bundle/tests/Security/Authentication/RememberMe/ExpiringTokenBasedRememberMeServicesTest.php
@@ -268,7 +268,7 @@ class ExpiringTokenBasedRememberMeServicesTest extends TestCase
     /**
      * @return RememberMe&MockObject
      */
-    private function mockEntity(string $value, \DateTime $expires = null, \DateTime $lastUsed = null): RememberMe
+    private function mockEntity(string $value, ?\DateTime $expires = null, ?\DateTime $lastUsed = null): RememberMe
     {
         $entity = $this->createMock(RememberMe::class);
         $entity

--- a/core-bundle/tests/Security/Authentication/Token/TokenCheckerTest.php
+++ b/core-bundle/tests/Security/Authentication/Token/TokenCheckerTest.php
@@ -485,7 +485,7 @@ class TokenCheckerTest extends TestCase
     /**
      * @return RequestStack&MockObject
      */
-    private function mockRequestStack(Request $request = null): RequestStack
+    private function mockRequestStack(?Request $request = null): RequestStack
     {
         $request ??= $this->createMock(Request::class);
 

--- a/core-bundle/tests/Security/User/ContaoUserProviderTest.php
+++ b/core-bundle/tests/Security/User/ContaoUserProviderTest.php
@@ -277,7 +277,7 @@ class ContaoUserProviderTest extends TestCase
         // Dummy method to test the postAuthenticate hook
     }
 
-    private function getProvider(ContaoFramework $framework = null, string $userClass = BackendUser::class): ContaoUserProvider
+    private function getProvider(?ContaoFramework $framework = null, string $userClass = BackendUser::class): ContaoUserProvider
     {
         $framework ??= $this->mockContaoFramework();
         $session = $this->createMock(SessionInterface::class);

--- a/core-bundle/tests/String/SimpleTokenParserTest.php
+++ b/core-bundle/tests/String/SimpleTokenParserTest.php
@@ -661,7 +661,7 @@ class SimpleTokenParserTest extends TestCase
         );
     }
 
-    private function getParser(SimpleTokenExpressionLanguage $expressionLanguage = null): SimpleTokenParser
+    private function getParser(?SimpleTokenExpressionLanguage $expressionLanguage = null): SimpleTokenParser
     {
         return new SimpleTokenParser($expressionLanguage ?? new SimpleTokenExpressionLanguage());
     }

--- a/core-bundle/tests/Translation/MessageCatalogueTest.php
+++ b/core-bundle/tests/Translation/MessageCatalogueTest.php
@@ -279,7 +279,7 @@ class MessageCatalogueTest extends TestCase
         ];
     }
 
-    private function createCatalogue(MessageCatalogueInterface $catalogue = null, ContaoFramework $framework = null, ResourceFinder $resourceFinder = null): MessageCatalogue
+    private function createCatalogue(?MessageCatalogueInterface $catalogue = null, ?ContaoFramework $framework = null, ?ResourceFinder $resourceFinder = null): MessageCatalogue
     {
         if (null === $catalogue) {
             $catalogue = $this->createMock(MessageCatalogueInterface::class);

--- a/core-bundle/tests/Translation/TranslatorTest.php
+++ b/core-bundle/tests/Translation/TranslatorTest.php
@@ -267,7 +267,7 @@ class TranslatorTest extends TestCase
         $translator->trans('foobar', [], 'contao_default', 'de');
     }
 
-    private function createTranslator(TranslatorInterface $translator = null, ContaoFramework $framework = null, ResourceFinder $resourceFinder = null): Translator
+    private function createTranslator(?TranslatorInterface $translator = null, ?ContaoFramework $framework = null, ?ResourceFinder $resourceFinder = null): Translator
     {
         if (null === $translator) {
             $translator = $this->createMock(BaseTranslator::class);

--- a/core-bundle/tests/Twig/Extension/ContaoExtensionTest.php
+++ b/core-bundle/tests/Twig/Extension/ContaoExtensionTest.php
@@ -397,7 +397,7 @@ class ContaoExtensionTest extends TestCase
     /**
      * @param Environment&MockObject $environment
      */
-    private function getContaoExtension(Environment $environment = null, ContaoFilesystemLoader $filesystemLoader = null): ContaoExtension
+    private function getContaoExtension(?Environment $environment = null, ?ContaoFilesystemLoader $filesystemLoader = null): ContaoExtension
     {
         $environment ??= $this->createMock(Environment::class);
         $filesystemLoader ??= $this->createMock(ContaoFilesystemLoader::class);

--- a/core-bundle/tests/Twig/Inheritance/InheritanceTest.php
+++ b/core-bundle/tests/Twig/Inheritance/InheritanceTest.php
@@ -80,7 +80,7 @@ class InheritanceTest extends TestCase
         $this->getDemoEnvironment(['InvalidBundle2' => ['path' => $bundlePath]]);
     }
 
-    private function getDemoEnvironment(array $bundlesMetadata = null): Environment
+    private function getDemoEnvironment(?array $bundlesMetadata = null): Environment
     {
         $projectDir = Path::canonicalize(__DIR__.'/../../Fixtures/Twig/inheritance');
 

--- a/core-bundle/tests/Twig/Loader/ContaoFilesystemLoaderTest.php
+++ b/core-bundle/tests/Twig/Loader/ContaoFilesystemLoaderTest.php
@@ -563,7 +563,7 @@ class ContaoFilesystemLoaderTest extends TestCase
      * @param array<string, string> $templates
      * @param array<string, string> $themeTemplates
      */
-    private function getContaoFilesystemLoaderWithTemplates(array $templates, array $themeTemplates = null): ContaoFilesystemLoader
+    private function getContaoFilesystemLoaderWithTemplates(array $templates, ?array $themeTemplates = null): ContaoFilesystemLoader
     {
         $templateLocator = $this->createMock(TemplateLocator::class);
         $templateLocator
@@ -606,7 +606,7 @@ class ContaoFilesystemLoaderTest extends TestCase
      * @param list<string> $additionalPaths
      * @param list<string> $themePaths
      */
-    private function getContaoFilesystemLoaderWithPaths(string $projectDir = null, array $additionalPaths = [], array $themePaths = []): ContaoFilesystemLoader
+    private function getContaoFilesystemLoaderWithPaths(?string $projectDir = null, array $additionalPaths = [], array $themePaths = []): ContaoFilesystemLoader
     {
         $projectDir ??= Path::canonicalize(__DIR__.'/../../Fixtures/Twig/default-project');
 

--- a/core-bundle/tests/Twig/Loader/ContaoFilesystemLoaderWarmerTest.php
+++ b/core-bundle/tests/Twig/Loader/ContaoFilesystemLoaderWarmerTest.php
@@ -118,7 +118,7 @@ class ContaoFilesystemLoaderWarmerTest extends TestCase
         $warmer->warmUp();
     }
 
-    private function getContaoFilesystemLoaderWarmer(ContaoFilesystemLoader $filesystemLoader = null, string $environment = null, Filesystem $filesystem = null): ContaoFilesystemLoaderWarmer
+    private function getContaoFilesystemLoaderWarmer(?ContaoFilesystemLoader $filesystemLoader = null, ?string $environment = null, ?Filesystem $filesystem = null): ContaoFilesystemLoaderWarmer
     {
         return new ContaoFilesystemLoaderWarmer(
             $filesystemLoader ?? $this->createMock(ContaoFilesystemLoader::class),

--- a/core-bundle/tests/Twig/Runtime/LegacyTemplateFunctionsRuntimeTest.php
+++ b/core-bundle/tests/Twig/Runtime/LegacyTemplateFunctionsRuntimeTest.php
@@ -107,7 +107,7 @@ class LegacyTemplateFunctionsRuntimeTest extends TestCase
         $this->assertEmpty($this->getRuntime(null, 'frontend')->renderContaoBackendTemplate());
     }
 
-    private function getRuntime(ContaoFramework $framework = null, string $scope = 'backend'): LegacyTemplateFunctionsRuntime
+    private function getRuntime(?ContaoFramework $framework = null, string $scope = 'backend'): LegacyTemplateFunctionsRuntime
     {
         $request = new Request();
         $request->attributes->set('_scope', $scope);

--- a/core-bundle/tests/Util/CachingTraversableTest.php
+++ b/core-bundle/tests/Util/CachingTraversableTest.php
@@ -129,7 +129,7 @@ class CachingTraversableTest extends TestCase
      *
      * @return \Generator<TKey, TValue>
      */
-    private function generateItems(array $items, array &$generatorLog = null): \Generator
+    private function generateItems(array $items, ?array &$generatorLog = null): \Generator
     {
         $generatorLog = [];
 

--- a/faq-bundle/src/Picker/FaqPickerProvider.php
+++ b/faq-bundle/src/Picker/FaqPickerProvider.php
@@ -80,7 +80,7 @@ class FaqPickerProvider extends AbstractInsertTagPickerProvider implements DcaPi
         return sprintf($this->getInsertTag($config), $value);
     }
 
-    protected function getRouteParameters(PickerConfig $config = null): array
+    protected function getRouteParameters(?PickerConfig $config = null): array
     {
         $params = ['do' => 'faq'];
 

--- a/faq-bundle/src/Resources/contao/modules/ModuleFaq.php
+++ b/faq-bundle/src/Resources/contao/modules/ModuleFaq.php
@@ -124,7 +124,7 @@ class ModuleFaq extends Frontend
 	 *
 	 * @return array
 	 */
-	public static function getSchemaOrgData(iterable $arrFaqs, string $identifier = null): array
+	public static function getSchemaOrgData(iterable $arrFaqs, ?string $identifier = null): array
 	{
 		$jsonLd = array(
 			'@type' => 'FAQPage',

--- a/faq-bundle/tests/Picker/FaqPickerProviderTest.php
+++ b/faq-bundle/tests/Picker/FaqPickerProviderTest.php
@@ -212,7 +212,7 @@ class FaqPickerProviderTest extends ContaoTestCase
         $this->assertArrayNotHasKey('id', $params);
     }
 
-    private function getPicker(bool $accessGranted = null): FaqPickerProvider
+    private function getPicker(?bool $accessGranted = null): FaqPickerProvider
     {
         $security = $this->createMock(Security::class);
         $security

--- a/installation-bundle/src/Config/ParameterDumper.php
+++ b/installation-bundle/src/Config/ParameterDumper.php
@@ -22,7 +22,7 @@ class ParameterDumper
     private Filesystem $filesystem;
     private array $parameters = ['parameters' => []];
 
-    public function __construct(string $projectDir, Filesystem $filesystem = null)
+    public function __construct(string $projectDir, ?Filesystem $filesystem = null)
     {
         $this->configFile = Path::join($projectDir, 'config/parameters.yml');
         $this->filesystem = $filesystem ?: new Filesystem();

--- a/installation-bundle/tests/Database/InstallerTest.php
+++ b/installation-bundle/tests/Database/InstallerTest.php
@@ -514,7 +514,7 @@ class InstallerTest extends TestCase
         $this->assertSame($expected, $commands[$key]);
     }
 
-    private function getInstaller(Schema $fromSchema = null, Schema $toSchema = null, array $tables = [], string $filePerTable = 'ON'): Installer
+    private function getInstaller(?Schema $fromSchema = null, ?Schema $toSchema = null, array $tables = [], string $filePerTable = 'ON'): Installer
     {
         $platform = new MySQLPlatform();
         $comparator = (new MySQLSchemaManager($this->createMock(Connection::class), $platform))->createComparator();

--- a/installation-bundle/tests/InstallToolTest.php
+++ b/installation-bundle/tests/InstallToolTest.php
@@ -90,7 +90,7 @@ class InstallToolTest extends TestCase
         ];
     }
 
-    private function getInstallTool(string $sqlMode, AbstractMySQLDriver $driver = null): InstallTool
+    private function getInstallTool(string $sqlMode, ?AbstractMySQLDriver $driver = null): InstallTool
     {
         $connection = $this->createMock(Connection::class);
         $connection

--- a/manager-bundle/src/Api/ManagerConfig.php
+++ b/manager-bundle/src/Api/ManagerConfig.php
@@ -25,7 +25,7 @@ class ManagerConfig
     private Filesystem $filesystem;
     private ?array $config = null;
 
-    public function __construct(string $projectDir, Filesystem $filesystem = null)
+    public function __construct(string $projectDir, ?Filesystem $filesystem = null)
     {
         if (false !== ($realpath = realpath($projectDir))) {
             $projectDir = (string) $realpath;

--- a/manager-bundle/src/Cache/BundleCacheClearer.php
+++ b/manager-bundle/src/Cache/BundleCacheClearer.php
@@ -23,7 +23,7 @@ class BundleCacheClearer implements CacheClearerInterface
     /**
      * @internal
      */
-    public function __construct(Filesystem $filesystem = null)
+    public function __construct(?Filesystem $filesystem = null)
     {
         $this->filesystem = $filesystem ?: new Filesystem();
     }

--- a/manager-bundle/src/Command/ContaoSetupCommand.php
+++ b/manager-bundle/src/Command/ContaoSetupCommand.php
@@ -48,7 +48,7 @@ class ContaoSetupCommand extends Command
     /**
      * @param (\Closure(array<string>):Process)|null $createProcessHandler
      */
-    public function __construct(string $projectDir, string $webDir, ?string $kernelSecret, \Closure $createProcessHandler = null)
+    public function __construct(string $projectDir, string $webDir, ?string $kernelSecret, ?\Closure $createProcessHandler = null)
     {
         $this->projectDir = $projectDir;
         $this->webDir = Path::makeRelative($webDir, $projectDir);

--- a/manager-bundle/src/Command/MaintenanceModeCommand.php
+++ b/manager-bundle/src/Command/MaintenanceModeCommand.php
@@ -33,7 +33,7 @@ class MaintenanceModeCommand extends Command
     private Environment $twig;
     private Filesystem $filesystem;
 
-    public function __construct(string $maintenanceFilePath, Environment $twig, Filesystem $filesystem = null)
+    public function __construct(string $maintenanceFilePath, Environment $twig, ?Filesystem $filesystem = null)
     {
         $this->maintenanceFilePath = $maintenanceFilePath;
         $this->twig = $twig;

--- a/manager-bundle/src/ContaoManager/ApiCommand/GenerateJwtCookieCommand.php
+++ b/manager-bundle/src/ContaoManager/ApiCommand/GenerateJwtCookieCommand.php
@@ -29,7 +29,7 @@ class GenerateJwtCookieCommand extends Command
 
     private JwtManager $jwtManager;
 
-    public function __construct(Application $application, JwtManager $jwtManager = null)
+    public function __construct(Application $application, ?JwtManager $jwtManager = null)
     {
         parent::__construct();
 

--- a/manager-bundle/src/ContaoManager/ApiCommand/ParseJwtCookieCommand.php
+++ b/manager-bundle/src/ContaoManager/ApiCommand/ParseJwtCookieCommand.php
@@ -29,7 +29,7 @@ class ParseJwtCookieCommand extends Command
 
     private JwtManager $jwtManager;
 
-    public function __construct(Application $application, JwtManager $jwtManager = null)
+    public function __construct(Application $application, ?JwtManager $jwtManager = null)
     {
         parent::__construct();
 

--- a/manager-bundle/src/Dotenv/DotenvDumper.php
+++ b/manager-bundle/src/Dotenv/DotenvDumper.php
@@ -23,7 +23,7 @@ class DotenvDumper
     private array $setParameters = [];
     private array $unsetParameters = [];
 
-    public function __construct(string $dotenvFile, Filesystem $filesystem = null)
+    public function __construct(string $dotenvFile, ?Filesystem $filesystem = null)
     {
         $this->dotenvFile = $dotenvFile;
         $this->filesystem = $filesystem ?? new Filesystem();

--- a/manager-bundle/src/HttpKernel/ContaoCache.php
+++ b/manager-bundle/src/HttpKernel/ContaoCache.php
@@ -34,7 +34,7 @@ class ContaoCache extends HttpCache implements CacheInvalidation
 {
     use EventDispatchingHttpCache;
 
-    public function __construct(ContaoKernel $kernel, string $cacheDir = null)
+    public function __construct(ContaoKernel $kernel, ?string $cacheDir = null)
     {
         parent::__construct($kernel, $cacheDir);
 

--- a/manager-bundle/src/HttpKernel/ContaoKernel.php
+++ b/manager-bundle/src/HttpKernel/ContaoKernel.php
@@ -351,7 +351,7 @@ class ContaoKernel extends Kernel implements HttpCacheProvider
         }
     }
 
-    private static function create(string $projectDir, string $env = null): self
+    private static function create(string $projectDir, ?string $env = null): self
     {
         $env ??= $_SERVER['APP_ENV'] ?? 'prod';
 

--- a/manager-bundle/src/HttpKernel/JwtManager.php
+++ b/manager-bundle/src/HttpKernel/JwtManager.php
@@ -31,7 +31,7 @@ class JwtManager
 
     private Configuration $config;
 
-    public function __construct(string $projectDir, Filesystem $filesystem = null, Configuration $config = null)
+    public function __construct(string $projectDir, ?Filesystem $filesystem = null, ?Configuration $config = null)
     {
         $secret = null;
         $filesystem ??= new Filesystem();

--- a/manager-bundle/src/Security/Logout/LogoutHandler.php
+++ b/manager-bundle/src/Security/Logout/LogoutHandler.php
@@ -25,7 +25,7 @@ class LogoutHandler implements LogoutHandlerInterface
     /**
      * @internal
      */
-    public function __construct(JwtManager $jwtManager = null)
+    public function __construct(?JwtManager $jwtManager = null)
     {
         $this->jwtManager = $jwtManager;
     }

--- a/manager-bundle/tests/Api/ApplicationTest.php
+++ b/manager-bundle/tests/Api/ApplicationTest.php
@@ -138,7 +138,7 @@ class ApplicationTest extends ContaoTestCase
         $application->all();
     }
 
-    private function getApplication(string $path = null): Application
+    private function getApplication(?string $path = null): Application
     {
         return new Application($path ?? $this->getTempDir());
     }

--- a/manager-bundle/tests/Command/ContaoSetupCommandTest.php
+++ b/manager-bundle/tests/Command/ContaoSetupCommandTest.php
@@ -253,7 +253,7 @@ class ContaoSetupCommandTest extends ContaoTestCase
     /**
      * @return (\Closure(array<string>):Process)
      */
-    private function getCreateProcessHandler(array $processes, array $validateCommandArguments = null, &$invocationCount = null): callable
+    private function getCreateProcessHandler(array $processes, ?array $validateCommandArguments = null, &$invocationCount = null): callable
     {
         $invocationCount ??= 0;
 

--- a/manager-bundle/tests/Command/MaintenanceModeCommandTest.php
+++ b/manager-bundle/tests/Command/MaintenanceModeCommandTest.php
@@ -35,7 +35,7 @@ class MaintenanceModeCommandTest extends ContaoTestCase
     /**
      * @dataProvider enableProvider
      */
-    public function testEnable(string $expectedTemplateName, array $expectedTemplateVars, string $customTemplateName = null, string $customTemplateVars = null): void
+    public function testEnable(string $expectedTemplateName, array $expectedTemplateVars, ?string $customTemplateName = null, ?string $customTemplateVars = null): void
     {
         $twig = $this->mockEnvironment();
         $twig

--- a/manager-bundle/tests/Controller/DebugControllerTest.php
+++ b/manager-bundle/tests/Controller/DebugControllerTest.php
@@ -103,7 +103,7 @@ class DebugControllerTest extends ContaoTestCase
     /**
      * @return RequestStack&MockObject
      */
-    private function mockRequestStack(string $path = '', string $referer = null): RequestStack
+    private function mockRequestStack(string $path = '', ?string $referer = null): RequestStack
     {
         $request = Request::create($path);
 
@@ -124,7 +124,7 @@ class DebugControllerTest extends ContaoTestCase
     /**
      * @return JwtManager&MockObject
      */
-    private function mockJwtManager(bool $expectAddsCookie, bool $debug = null): JwtManager
+    private function mockJwtManager(bool $expectAddsCookie, ?bool $debug = null): JwtManager
     {
         $jwtManager = $this->createMock(JwtManager::class);
         $jwtManager

--- a/news-bundle/src/Picker/NewsPickerProvider.php
+++ b/news-bundle/src/Picker/NewsPickerProvider.php
@@ -80,7 +80,7 @@ class NewsPickerProvider extends AbstractInsertTagPickerProvider implements DcaP
         return sprintf($this->getInsertTag($config), $value);
     }
 
-    protected function getRouteParameters(PickerConfig $config = null): array
+    protected function getRouteParameters(?PickerConfig $config = null): array
     {
         $params = ['do' => 'news'];
 

--- a/news-bundle/src/Resources/contao/classes/News.php
+++ b/news-bundle/src/Resources/contao/classes/News.php
@@ -606,7 +606,7 @@ class News extends Frontend
 	/**
 	 * Creates a sub request for the given URI.
 	 */
-	private function createSubRequest(string $uri, Request $request = null): Request
+	private function createSubRequest(string $uri, ?Request $request = null): Request
 	{
 		$cookies = null !== $request ? $request->cookies->all() : array();
 		$server = null !== $request ? $request->server->all() : array();

--- a/news-bundle/tests/Picker/NewsPickerProviderTest.php
+++ b/news-bundle/tests/Picker/NewsPickerProviderTest.php
@@ -212,7 +212,7 @@ class NewsPickerProviderTest extends ContaoTestCase
         $this->assertArrayNotHasKey('id', $params);
     }
 
-    private function getPicker(bool $accessGranted = null): NewsPickerProvider
+    private function getPicker(?bool $accessGranted = null): NewsPickerProvider
     {
         $security = $this->createMock(Security::class);
         $security

--- a/newsletter-bundle/src/Resources/contao/modules/ModuleSubscribe.php
+++ b/newsletter-bundle/src/Resources/contao/modules/ModuleSubscribe.php
@@ -241,7 +241,7 @@ class ModuleSubscribe extends Module
 	 *
 	 * @return array|bool
 	 */
-	protected function validateForm(Widget $objWidget=null)
+	protected function validateForm(?Widget $objWidget=null)
 	{
 		// Validate the e-mail address
 		$varInput = Idna::encodeEmail(Input::post('email', true));

--- a/newsletter-bundle/src/Resources/contao/modules/ModuleUnsubscribe.php
+++ b/newsletter-bundle/src/Resources/contao/modules/ModuleUnsubscribe.php
@@ -155,7 +155,7 @@ class ModuleUnsubscribe extends Module
 	 *
 	 * @return array|bool
 	 */
-	protected function validateForm(Widget $objWidget=null)
+	protected function validateForm(?Widget $objWidget=null)
 	{
 		// Validate the e-mail address
 		$varInput = Idna::encodeEmail(Input::post('email', true));

--- a/vendor-bin/ecs/composer.lock
+++ b/vendor-bin/ecs/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "contao/easy-coding-standard",
-            "version": "5.4.2",
+            "version": "5.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/contao/easy-coding-standard.git",
-                "reference": "55d47f7b08e60199b32e9e9cbaffd5d1bd2bb620"
+                "reference": "e631502cf7eeaaa1deebaa464b4e15e08290366f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/contao/easy-coding-standard/zipball/55d47f7b08e60199b32e9e9cbaffd5d1bd2bb620",
-                "reference": "55d47f7b08e60199b32e9e9cbaffd5d1bd2bb620",
+                "url": "https://api.github.com/repos/contao/easy-coding-standard/zipball/e631502cf7eeaaa1deebaa464b4e15e08290366f",
+                "reference": "e631502cf7eeaaa1deebaa464b4e15e08290366f",
                 "shasum": ""
             },
             "require": {
@@ -47,7 +47,7 @@
             "description": "EasyCodingStandard configurations for Contao",
             "support": {
                 "issues": "https://github.com/contao/easy-coding-standard/issues",
-                "source": "https://github.com/contao/easy-coding-standard/tree/5.4.2"
+                "source": "https://github.com/contao/easy-coding-standard/tree/5.4.3"
             },
             "funding": [
                 {
@@ -55,7 +55,7 @@
                     "type": "custom"
                 }
             ],
-            "time": "2023-01-06T10:46:16+00:00"
+            "time": "2024-09-30T13:59:26+00:00"
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
@@ -137,16 +137,16 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "1.30.1",
+            "version": "1.32.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "51b95ec8670af41009e2b2b56873bad96682413e"
+                "reference": "6ca22b154efdd9e3c68c56f5d94670920a1c19a4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/51b95ec8670af41009e2b2b56873bad96682413e",
-                "reference": "51b95ec8670af41009e2b2b56873bad96682413e",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/6ca22b154efdd9e3c68c56f5d94670920a1c19a4",
+                "reference": "6ca22b154efdd9e3c68c56f5d94670920a1c19a4",
                 "shasum": ""
             },
             "require": {
@@ -178,9 +178,9 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.30.1"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.32.0"
             },
-            "time": "2024-09-07T20:13:05+00:00"
+            "time": "2024-09-26T07:23:32+00:00"
         },
         {
             "name": "slevomat/coding-standard",

--- a/vendor-bin/isolated-tests/composer.lock
+++ b/vendor-bin/isolated-tests/composer.lock
@@ -97,16 +97,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v5.4.43",
+            "version": "v5.4.44",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "e86f8554de667c16dde8aeb89a3990cfde924df9"
+                "reference": "5b5a0aa66e3296e303e22490f90f521551835a83"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/e86f8554de667c16dde8aeb89a3990cfde924df9",
-                "reference": "e86f8554de667c16dde8aeb89a3990cfde924df9",
+                "url": "https://api.github.com/repos/symfony/console/zipball/5b5a0aa66e3296e303e22490f90f521551835a83",
+                "reference": "5b5a0aa66e3296e303e22490f90f521551835a83",
                 "shasum": ""
             },
             "require": {
@@ -176,7 +176,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v5.4.43"
+                "source": "https://github.com/symfony/console/tree/v5.4.44"
             },
             "funding": [
                 {
@@ -192,20 +192,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-08-13T16:31:56+00:00"
+            "time": "2024-09-20T07:56:40+00:00"
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v5.4.43",
+            "version": "v5.4.44",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "8c946c5c1d1692d5378cb722060969730cebc96d"
+                "reference": "23eb9f3803a931aef16a65f362a9aeb0640a1374"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/8c946c5c1d1692d5378cb722060969730cebc96d",
-                "reference": "8c946c5c1d1692d5378cb722060969730cebc96d",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/23eb9f3803a931aef16a65f362a9aeb0640a1374",
+                "reference": "23eb9f3803a931aef16a65f362a9aeb0640a1374",
                 "shasum": ""
             },
             "require": {
@@ -265,7 +265,7 @@
             "description": "Allows you to standardize and centralize the way objects are constructed in your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/dependency-injection/tree/v5.4.43"
+                "source": "https://github.com/symfony/dependency-injection/tree/v5.4.44"
             },
             "funding": [
                 {
@@ -281,7 +281,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-08-27T00:56:45+00:00"
+            "time": "2024-09-12T20:01:35+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -965,16 +965,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v5.4.40",
+            "version": "v5.4.44",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "deedcb3bb4669cae2148bc920eafd2b16dc7c046"
+                "reference": "1b9fa82b5c62cd49da8c9e3952dd8531ada65096"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/deedcb3bb4669cae2148bc920eafd2b16dc7c046",
-                "reference": "deedcb3bb4669cae2148bc920eafd2b16dc7c046",
+                "url": "https://api.github.com/repos/symfony/process/zipball/1b9fa82b5c62cd49da8c9e3952dd8531ada65096",
+                "reference": "1b9fa82b5c62cd49da8c9e3952dd8531ada65096",
                 "shasum": ""
             },
             "require": {
@@ -1007,7 +1007,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v5.4.40"
+                "source": "https://github.com/symfony/process/tree/v5.4.44"
             },
             "funding": [
                 {
@@ -1023,7 +1023,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-05-31T14:33:22+00:00"
+            "time": "2024-09-17T12:46:43+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -1110,16 +1110,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v6.4.11",
+            "version": "v6.4.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "5bc3eb632cf9c8dbfd6529d89be9950d1518883b"
+                "reference": "f8a1ccebd0997e16112dfecfd74220b78e5b284b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/5bc3eb632cf9c8dbfd6529d89be9950d1518883b",
-                "reference": "5bc3eb632cf9c8dbfd6529d89be9950d1518883b",
+                "url": "https://api.github.com/repos/symfony/string/zipball/f8a1ccebd0997e16112dfecfd74220b78e5b284b",
+                "reference": "f8a1ccebd0997e16112dfecfd74220b78e5b284b",
                 "shasum": ""
             },
             "require": {
@@ -1176,7 +1176,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v6.4.11"
+                "source": "https://github.com/symfony/string/tree/v6.4.12"
             },
             "funding": [
                 {
@@ -1192,20 +1192,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-08-12T09:55:28+00:00"
+            "time": "2024-09-20T08:15:52+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v5.4.43",
+            "version": "v5.4.44",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "62f96e1cfd4cf518882a36bfedcf1fe4093c1299"
+                "reference": "7025b964f123bbf1896d7563db6ec7f1f63e918a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/62f96e1cfd4cf518882a36bfedcf1fe4093c1299",
-                "reference": "62f96e1cfd4cf518882a36bfedcf1fe4093c1299",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/7025b964f123bbf1896d7563db6ec7f1f63e918a",
+                "reference": "7025b964f123bbf1896d7563db6ec7f1f63e918a",
                 "shasum": ""
             },
             "require": {
@@ -1251,7 +1251,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v5.4.43"
+                "source": "https://github.com/symfony/yaml/tree/v5.4.44"
             },
             "funding": [
                 {
@@ -1267,7 +1267,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-08-11T17:40:32+00:00"
+            "time": "2024-09-16T14:36:56+00:00"
         }
     ],
     "packages-dev": [],

--- a/vendor-bin/monorepo-tools/composer.lock
+++ b/vendor-bin/monorepo-tools/composer.lock
@@ -334,16 +334,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v5.4.43",
+            "version": "v5.4.44",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "e86f8554de667c16dde8aeb89a3990cfde924df9"
+                "reference": "5b5a0aa66e3296e303e22490f90f521551835a83"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/e86f8554de667c16dde8aeb89a3990cfde924df9",
-                "reference": "e86f8554de667c16dde8aeb89a3990cfde924df9",
+                "url": "https://api.github.com/repos/symfony/console/zipball/5b5a0aa66e3296e303e22490f90f521551835a83",
+                "reference": "5b5a0aa66e3296e303e22490f90f521551835a83",
                 "shasum": ""
             },
             "require": {
@@ -413,7 +413,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v5.4.43"
+                "source": "https://github.com/symfony/console/tree/v5.4.44"
             },
             "funding": [
                 {
@@ -429,7 +429,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-08-13T16:31:56+00:00"
+            "time": "2024-09-20T07:56:40+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -500,16 +500,16 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v5.4.41",
+            "version": "v5.4.44",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "6d29dd9340b372fa603f04e6df4dd76bb808591e"
+                "reference": "76c3818964e9d32be3862c9318ae3ba9aa280ddc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/6d29dd9340b372fa603f04e6df4dd76bb808591e",
-                "reference": "6d29dd9340b372fa603f04e6df4dd76bb808591e",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/76c3818964e9d32be3862c9318ae3ba9aa280ddc",
+                "reference": "76c3818964e9d32be3862c9318ae3ba9aa280ddc",
                 "shasum": ""
             },
             "require": {
@@ -547,7 +547,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v5.4.41"
+                "source": "https://github.com/symfony/filesystem/tree/v5.4.44"
             },
             "funding": [
                 {
@@ -563,7 +563,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-06-28T09:36:24+00:00"
+            "time": "2024-09-16T14:52:48+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -1117,16 +1117,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v5.4.40",
+            "version": "v5.4.44",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "deedcb3bb4669cae2148bc920eafd2b16dc7c046"
+                "reference": "1b9fa82b5c62cd49da8c9e3952dd8531ada65096"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/deedcb3bb4669cae2148bc920eafd2b16dc7c046",
-                "reference": "deedcb3bb4669cae2148bc920eafd2b16dc7c046",
+                "url": "https://api.github.com/repos/symfony/process/zipball/1b9fa82b5c62cd49da8c9e3952dd8531ada65096",
+                "reference": "1b9fa82b5c62cd49da8c9e3952dd8531ada65096",
                 "shasum": ""
             },
             "require": {
@@ -1159,7 +1159,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v5.4.40"
+                "source": "https://github.com/symfony/process/tree/v5.4.44"
             },
             "funding": [
                 {
@@ -1175,7 +1175,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-05-31T14:33:22+00:00"
+            "time": "2024-09-17T12:46:43+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -1262,16 +1262,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v6.4.11",
+            "version": "v6.4.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "5bc3eb632cf9c8dbfd6529d89be9950d1518883b"
+                "reference": "f8a1ccebd0997e16112dfecfd74220b78e5b284b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/5bc3eb632cf9c8dbfd6529d89be9950d1518883b",
-                "reference": "5bc3eb632cf9c8dbfd6529d89be9950d1518883b",
+                "url": "https://api.github.com/repos/symfony/string/zipball/f8a1ccebd0997e16112dfecfd74220b78e5b284b",
+                "reference": "f8a1ccebd0997e16112dfecfd74220b78e5b284b",
                 "shasum": ""
             },
             "require": {
@@ -1328,7 +1328,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v6.4.11"
+                "source": "https://github.com/symfony/string/tree/v6.4.12"
             },
             "funding": [
                 {
@@ -1344,20 +1344,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-08-12T09:55:28+00:00"
+            "time": "2024-09-20T08:15:52+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v5.4.43",
+            "version": "v5.4.44",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "62f96e1cfd4cf518882a36bfedcf1fe4093c1299"
+                "reference": "7025b964f123bbf1896d7563db6ec7f1f63e918a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/62f96e1cfd4cf518882a36bfedcf1fe4093c1299",
-                "reference": "62f96e1cfd4cf518882a36bfedcf1fe4093c1299",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/7025b964f123bbf1896d7563db6ec7f1f63e918a",
+                "reference": "7025b964f123bbf1896d7563db6ec7f1f63e918a",
                 "shasum": ""
             },
             "require": {
@@ -1403,7 +1403,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v5.4.43"
+                "source": "https://github.com/symfony/yaml/tree/v5.4.44"
             },
             "funding": [
                 {
@@ -1419,7 +1419,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-08-11T17:40:32+00:00"
+            "time": "2024-09-16T14:36:56+00:00"
         }
     ],
     "packages-dev": [],

--- a/vendor-bin/phpstan/composer.lock
+++ b/vendor-bin/phpstan/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "nikic/php-parser",
-            "version": "v4.19.2",
+            "version": "v4.19.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "0ed4c8949a32986043e977dbe14776c14d644c45"
+                "reference": "715f4d25e225bc47b293a8b997fe6ce99bf987d2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/0ed4c8949a32986043e977dbe14776c14d644c45",
-                "reference": "0ed4c8949a32986043e977dbe14776c14d644c45",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/715f4d25e225bc47b293a8b997fe6ce99bf987d2",
+                "reference": "715f4d25e225bc47b293a8b997fe6ce99bf987d2",
                 "shasum": ""
             },
             "require": {
@@ -26,7 +26,7 @@
             },
             "require-dev": {
                 "ircmaxell/php-yacc": "^0.0.7",
-                "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0 || ^9.0"
+                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
             },
             "bin": [
                 "bin/php-parse"
@@ -58,22 +58,22 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.19.2"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.19.4"
             },
-            "time": "2024-09-17T19:36:00+00:00"
+            "time": "2024-09-29T15:01:53+00:00"
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.12.4",
+            "version": "1.12.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "ffa517cb918591b93acc9b95c0bebdcd0e4538bd"
+                "reference": "7e6c6cb7cecb0a6254009a1a8a7d54ec99812b17"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/ffa517cb918591b93acc9b95c0bebdcd0e4538bd",
-                "reference": "ffa517cb918591b93acc9b95c0bebdcd0e4538bd",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/7e6c6cb7cecb0a6254009a1a8a7d54ec99812b17",
+                "reference": "7e6c6cb7cecb0a6254009a1a8a7d54ec99812b17",
                 "shasum": ""
             },
             "require": {
@@ -118,7 +118,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-09-19T07:58:01+00:00"
+            "time": "2024-09-26T12:45:22+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",
@@ -174,16 +174,16 @@
         },
         {
             "name": "phpstan/phpstan-symfony",
-            "version": "1.4.9",
+            "version": "1.4.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan-symfony.git",
-                "reference": "51ab2438fb2695467cf96b58d2f8f28d4dd1e3e9"
+                "reference": "f7d5782044bedf93aeb3f38e09c91148ee90e5a1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-symfony/zipball/51ab2438fb2695467cf96b58d2f8f28d4dd1e3e9",
-                "reference": "51ab2438fb2695467cf96b58d2f8f28d4dd1e3e9",
+                "url": "https://api.github.com/repos/phpstan/phpstan-symfony/zipball/f7d5782044bedf93aeb3f38e09c91148ee90e5a1",
+                "reference": "f7d5782044bedf93aeb3f38e09c91148ee90e5a1",
                 "shasum": ""
             },
             "require": {
@@ -240,9 +240,9 @@
             "description": "Symfony Framework extensions and rules for PHPStan",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan-symfony/issues",
-                "source": "https://github.com/phpstan/phpstan-symfony/tree/1.4.9"
+                "source": "https://github.com/phpstan/phpstan-symfony/tree/1.4.10"
             },
-            "time": "2024-09-05T16:15:09+00:00"
+            "time": "2024-09-26T18:14:50+00:00"
         },
         {
             "name": "slam/phpstan-extensions",

--- a/vendor-bin/require-checker/composer.lock
+++ b/vendor-bin/require-checker/composer.lock
@@ -88,16 +88,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.19.2",
+            "version": "v4.19.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "0ed4c8949a32986043e977dbe14776c14d644c45"
+                "reference": "715f4d25e225bc47b293a8b997fe6ce99bf987d2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/0ed4c8949a32986043e977dbe14776c14d644c45",
-                "reference": "0ed4c8949a32986043e977dbe14776c14d644c45",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/715f4d25e225bc47b293a8b997fe6ce99bf987d2",
+                "reference": "715f4d25e225bc47b293a8b997fe6ce99bf987d2",
                 "shasum": ""
             },
             "require": {
@@ -106,7 +106,7 @@
             },
             "require-dev": {
                 "ircmaxell/php-yacc": "^0.0.7",
-                "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0 || ^9.0"
+                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
             },
             "bin": [
                 "bin/php-parse"
@@ -138,9 +138,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.19.2"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.19.4"
             },
-            "time": "2024-09-17T19:36:00+00:00"
+            "time": "2024-09-29T15:01:53+00:00"
         },
         {
             "name": "psr/container",
@@ -197,16 +197,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v6.4.11",
+            "version": "v6.4.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "42686880adaacdad1835ee8fc2a9ec5b7bd63998"
+                "reference": "72d080eb9edf80e36c19be61f72c98ed8273b765"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/42686880adaacdad1835ee8fc2a9ec5b7bd63998",
-                "reference": "42686880adaacdad1835ee8fc2a9ec5b7bd63998",
+                "url": "https://api.github.com/repos/symfony/console/zipball/72d080eb9edf80e36c19be61f72c98ed8273b765",
+                "reference": "72d080eb9edf80e36c19be61f72c98ed8273b765",
                 "shasum": ""
             },
             "require": {
@@ -271,7 +271,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v6.4.11"
+                "source": "https://github.com/symfony/console/tree/v6.4.12"
             },
             "funding": [
                 {
@@ -287,7 +287,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-08-15T22:48:29+00:00"
+            "time": "2024-09-20T08:15:52+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -759,16 +759,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v6.4.11",
+            "version": "v6.4.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "5bc3eb632cf9c8dbfd6529d89be9950d1518883b"
+                "reference": "f8a1ccebd0997e16112dfecfd74220b78e5b284b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/5bc3eb632cf9c8dbfd6529d89be9950d1518883b",
-                "reference": "5bc3eb632cf9c8dbfd6529d89be9950d1518883b",
+                "url": "https://api.github.com/repos/symfony/string/zipball/f8a1ccebd0997e16112dfecfd74220b78e5b284b",
+                "reference": "f8a1ccebd0997e16112dfecfd74220b78e5b284b",
                 "shasum": ""
             },
             "require": {
@@ -825,7 +825,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v6.4.11"
+                "source": "https://github.com/symfony/string/tree/v6.4.12"
             },
             "funding": [
                 {
@@ -841,7 +841,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-08-12T09:55:28+00:00"
+            "time": "2024-09-20T08:15:52+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/vendor-bin/service-linter/composer.lock
+++ b/vendor-bin/service-linter/composer.lock
@@ -97,16 +97,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v5.4.43",
+            "version": "v5.4.44",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "e86f8554de667c16dde8aeb89a3990cfde924df9"
+                "reference": "5b5a0aa66e3296e303e22490f90f521551835a83"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/e86f8554de667c16dde8aeb89a3990cfde924df9",
-                "reference": "e86f8554de667c16dde8aeb89a3990cfde924df9",
+                "url": "https://api.github.com/repos/symfony/console/zipball/5b5a0aa66e3296e303e22490f90f521551835a83",
+                "reference": "5b5a0aa66e3296e303e22490f90f521551835a83",
                 "shasum": ""
             },
             "require": {
@@ -176,7 +176,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v5.4.43"
+                "source": "https://github.com/symfony/console/tree/v5.4.44"
             },
             "funding": [
                 {
@@ -192,20 +192,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-08-13T16:31:56+00:00"
+            "time": "2024-09-20T07:56:40+00:00"
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v5.4.43",
+            "version": "v5.4.44",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "8c946c5c1d1692d5378cb722060969730cebc96d"
+                "reference": "23eb9f3803a931aef16a65f362a9aeb0640a1374"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/8c946c5c1d1692d5378cb722060969730cebc96d",
-                "reference": "8c946c5c1d1692d5378cb722060969730cebc96d",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/23eb9f3803a931aef16a65f362a9aeb0640a1374",
+                "reference": "23eb9f3803a931aef16a65f362a9aeb0640a1374",
                 "shasum": ""
             },
             "require": {
@@ -265,7 +265,7 @@
             "description": "Allows you to standardize and centralize the way objects are constructed in your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/dependency-injection/tree/v5.4.43"
+                "source": "https://github.com/symfony/dependency-injection/tree/v5.4.44"
             },
             "funding": [
                 {
@@ -281,7 +281,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-08-27T00:56:45+00:00"
+            "time": "2024-09-12T20:01:35+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -1048,16 +1048,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v6.4.11",
+            "version": "v6.4.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "5bc3eb632cf9c8dbfd6529d89be9950d1518883b"
+                "reference": "f8a1ccebd0997e16112dfecfd74220b78e5b284b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/5bc3eb632cf9c8dbfd6529d89be9950d1518883b",
-                "reference": "5bc3eb632cf9c8dbfd6529d89be9950d1518883b",
+                "url": "https://api.github.com/repos/symfony/string/zipball/f8a1ccebd0997e16112dfecfd74220b78e5b284b",
+                "reference": "f8a1ccebd0997e16112dfecfd74220b78e5b284b",
                 "shasum": ""
             },
             "require": {
@@ -1114,7 +1114,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v6.4.11"
+                "source": "https://github.com/symfony/string/tree/v6.4.12"
             },
             "funding": [
                 {
@@ -1130,20 +1130,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-08-12T09:55:28+00:00"
+            "time": "2024-09-20T08:15:52+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v5.4.43",
+            "version": "v5.4.44",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "62f96e1cfd4cf518882a36bfedcf1fe4093c1299"
+                "reference": "7025b964f123bbf1896d7563db6ec7f1f63e918a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/62f96e1cfd4cf518882a36bfedcf1fe4093c1299",
-                "reference": "62f96e1cfd4cf518882a36bfedcf1fe4093c1299",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/7025b964f123bbf1896d7563db6ec7f1f63e918a",
+                "reference": "7025b964f123bbf1896d7563db6ec7f1f63e918a",
                 "shasum": ""
             },
             "require": {
@@ -1189,7 +1189,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v5.4.43"
+                "source": "https://github.com/symfony/yaml/tree/v5.4.44"
             },
             "funding": [
                 {
@@ -1205,7 +1205,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-08-11T17:40:32+00:00"
+            "time": "2024-09-16T14:36:56+00:00"
         }
     ],
     "packages-dev": [],


### PR DESCRIPTION
Nullable argument fixes were done using easy-coding-standards. ECS tests are failing because https://github.com/contao/easy-coding-standard/pull/18 is needed.