### PR TITLE
Do not save long file extensions during filesync

### DIFF
--- a/core-bundle/src/Filesystem/Dbafs/Dbafs.php
+++ b/core-bundle/src/Filesystem/Dbafs/Dbafs.php
@@ -571,8 +571,9 @@ class Dbafs implements DbafsInterface, ResetInterface
 
             // Backwards compatibility
             if ('tl_files' === $this->table) {
-                $dataToInsert['name'] = basename($itemToCreate->getPath());
                 $extension = Path::getExtension($itemToCreate->getPath(), true);
+
+                $dataToInsert['name'] = basename($itemToCreate->getPath());
                 $dataToInsert['extension'] = $itemToCreate->isFile() && \strlen($extension) <= 16 ? $extension : '';
                 $dataToInsert['tstamp'] = $currentTime;
             }

--- a/core-bundle/src/Filesystem/Dbafs/Dbafs.php
+++ b/core-bundle/src/Filesystem/Dbafs/Dbafs.php
@@ -573,7 +573,7 @@ class Dbafs implements DbafsInterface, ResetInterface
             if ('tl_files' === $this->table) {
                 $dataToInsert['name'] = basename($itemToCreate->getPath());
                 $extension = Path::getExtension($itemToCreate->getPath(), true);
-                $dataToInsert['extension'] = $itemToCreate->isFile() && \strlen($extension) <= 16 ? Path::getExtension($itemToCreate->getPath(), true) : '';
+                $dataToInsert['extension'] = $itemToCreate->isFile() && \strlen($extension) <= 16 ? $extension : '';
                 $dataToInsert['tstamp'] = $currentTime;
             }
 

--- a/core-bundle/src/Filesystem/Dbafs/Dbafs.php
+++ b/core-bundle/src/Filesystem/Dbafs/Dbafs.php
@@ -572,7 +572,8 @@ class Dbafs implements DbafsInterface, ResetInterface
             // Backwards compatibility
             if ('tl_files' === $this->table) {
                 $dataToInsert['name'] = basename($itemToCreate->getPath());
-                $dataToInsert['extension'] = $itemToCreate->isFile() ? Path::getExtension($itemToCreate->getPath(), true) : '';
+                $extension = Path::getExtension($itemToCreate->getPath(), true);
+                $dataToInsert['extension'] = $itemToCreate->isFile() && \strlen($extension) <= 16 ? Path::getExtension($itemToCreate->getPath(), true) : '';
                 $dataToInsert['tstamp'] = $currentTime;
             }
 


### PR DESCRIPTION
Fixes #7396

I have hardcoded the maximum file extension length. Imho it's not worth detecting the actual length of `tl_files.extension` in case someone customized it.

@m-vo I need some help adding a test case for this 🙈 