### PR TITLE
Add the `turbo-root` meta tag to the back end

### DIFF
--- a/core-bundle/contao/controllers/BackendMain.php
+++ b/core-bundle/contao/controllers/BackendMain.php
@@ -249,6 +249,8 @@ class BackendMain extends Backend
 		$data['menu'] = $twig->render('@ContaoCore/Backend/be_menu.html.twig');
 		$data['headerMenu'] = $twig->render('@ContaoCore/Backend/be_header_menu.html.twig');
 
+		$data['turboRoot'] = System::getContainer()->getParameter('contao.backend.route_prefix');
+
 		return $data;
 	}
 }

--- a/core-bundle/contao/templates/backend/be_main.html5
+++ b/core-bundle/contao/templates/backend/be_main.html5
@@ -36,6 +36,7 @@
 
   <?php /* If the following hash changes, Turbo will reload the entire page instead of merging contents. */ ?>
   <meta data-turbo-track="reload" content="<?= md5($this->stylesheets."\0".$this->javascripts); ?>">
+  <meta name="turbo-root" content="<?= $this->turboRoot ?>">
 </head>
 <body id="top" class="be_main<?php if ($this->isPopup): ?> popup<?php endif; ?>"<?= $this->attributes ?> data-controller="contao--tooltip">
 

--- a/core-bundle/tests/Controller/AbstractBackendControllerTest.php
+++ b/core-bundle/tests/Controller/AbstractBackendControllerTest.php
@@ -95,6 +95,7 @@ class AbstractBackendControllerTest extends TestCase
             'learnMore' => 'learn more',
             'menu' => '<menu>',
             'headerMenu' => '<header_menu>',
+            'turboRoot' => '/contao',
             'badgeTitle' => '',
             'foo' => 'bar',
         ];


### PR DESCRIPTION
https://turbo.hotwired.dev/handbook/drive#setting-a-root-location

Without this meta tag, Turbo would load any link to the front end with Turbo Drive. Not a problem if we open a new window, but it sure should be fixed.