### PR TITLE
Fix login redirect and session usage

### DIFF
--- a/core-bundle/src/Security/Authentication/AuthenticationEntryPoint.php
+++ b/core-bundle/src/Security/Authentication/AuthenticationEntryPoint.php
@@ -71,8 +71,8 @@ class AuthenticationEntryPoint implements AuthenticationEntryPointInterface
             $location = $this->uriSigner->sign($location);
         }
 
-        // Our back end login controller will redirect based on the 'redirect' parameter, 
-        // ignoring Symfony's target path session value. Thus we remove the session variable 
+        // Our back end login controller will redirect based on the 'redirect' parameter,
+        // ignoring Symfony's target path session value. Thus we remove the session variable
         // here in order to not send an unnecessary session cookie.
         if ($request->hasSession()) {
             $this->removeTargetPath($request->getSession(), 'contao_backend');

--- a/core-bundle/src/Security/Authentication/AuthenticationEntryPoint.php
+++ b/core-bundle/src/Security/Authentication/AuthenticationEntryPoint.php
@@ -53,7 +53,8 @@ class AuthenticationEntryPoint implements AuthenticationEntryPointInterface
 
     private function redirectToBackend(Request $request): Response
     {
-        // No redirect parameter required if only the "/contao" route was requested
+        // No redirect parameter required if the 'contao_backend' route was requested
+        // without any parameters.
         if ('contao_backend' === $request->attributes->get('_route') && [] === $request->query->all()) {
             $loginParams = [];
         } else {

--- a/core-bundle/src/Security/Authentication/AuthenticationEntryPoint.php
+++ b/core-bundle/src/Security/Authentication/AuthenticationEntryPoint.php
@@ -22,9 +22,12 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
+use Symfony\Component\Security\Http\Util\TargetPathTrait;
 
 class AuthenticationEntryPoint implements AuthenticationEntryPointInterface
 {
+    use TargetPathTrait;
+
     private RouterInterface $router;
     private UriSigner $uriSigner;
     private ScopeMatcher $scopeMatcher;
@@ -50,13 +53,30 @@ class AuthenticationEntryPoint implements AuthenticationEntryPointInterface
 
     private function redirectToBackend(Request $request): Response
     {
-        $url = $this->router->generate(
+        // No redirect parameter required if only the "/contao" route was requested
+        if ('contao_backend' === $request->attributes->get('_route') && [] === $request->query->all()) {
+            $loginParams = [];
+        } else {
+            $loginParams = ['redirect' => $request->getUri()];
+        }
+
+        $location = $this->router->generate(
             'contao_backend_login',
-            ['redirect' => $request->getUri()],
+            $loginParams,
             UrlGeneratorInterface::ABSOLUTE_URL
         );
 
-        $location = $this->uriSigner->sign($url);
+        // No URL signing required if we do not have any parameters
+        if ([] !== $loginParams) {
+            $location = $this->uriSigner->sign($location);
+        }
+
+        // Our back end login controller will redirect based on the 'redirect' parameter, 
+        // ignoring Symfony's target path session value. Thus we remove the session variable 
+        // here in order to not send an unnecessary session cookie.
+        if ($request->hasSession()) {
+            $this->removeTargetPath($request->getSession(), 'contao_backend');
+        }
 
         if ($request->isXmlHttpRequest()) {
             return new Response($location, 401, ['X-Ajax-Location' => $location]);


### PR DESCRIPTION
Fixes #7585 

The first issue is fixed by checking whether the request is the `contao_backend` route _without_ any parameters. If that is the case, the `redirect` parameter will be ignored for the `contao_backend_login` route and no URL signing will take place - thus `/contao` will simply redirect to `/contao/login`.

The second issue is fixed by removing the "target path" session parameter, that Symfony always sets for non-stateless firewalls. However, since our `contao_backend_login` controller will simply redirect based on the `redirect` parameter this session variable can be removed - which in turn will not send a session cookie, as the session will then be empty again.