### PR TITLE
Improve UX on edit multiple

### DIFF
--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -2698,9 +2698,11 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 						continue;
 					}
 
-					$return .= Message::generateUnwrapped() . '
-<div class="' . $class . ' cf">' . $box . '
-</div>';
+					$return .= Message::generateUnwrapped() . \sprintf('<fieldset data-controller="contao--toggle-fieldset" data-contao--toggle-fieldset-collapsed-class="collapsed" class="%s cf"><legend><button type="button" data-action="contao--toggle-fieldset#toggle">%s</button></legend>%s</fieldset>',
+						$class,
+						StringUtil::specialchars(System::getContainer()->get('contao.data_container.record_labeler')->getLabel('contao.db.' . $this->strTable . '.id', $currentRecord)),
+						$box
+					);
 
 					$class = 'tl_box';
 				}

--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -2700,7 +2700,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 
 					$return .= Message::generateUnwrapped() . \sprintf('<fieldset data-controller="contao--toggle-fieldset" data-contao--toggle-fieldset-collapsed-class="collapsed" class="%s cf"><legend><button type="button" data-action="contao--toggle-fieldset#toggle">%s</button></legend>%s</fieldset>',
 						$class,
-						StringUtil::specialchars(System::getContainer()->get('contao.data_container.record_labeler')->getLabel('contao.db.' . $this->strTable . '.id', $currentRecord)),
+						StringUtil::specialchars(System::getContainer()->get('contao.data_container.record_labeler')->getLabel('contao.db.' . $this->strTable . '.' . $currentRecord['id'], $currentRecord)),
 						$box
 					);
 

--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -2698,7 +2698,8 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 						continue;
 					}
 
-					$return .= Message::generateUnwrapped() . \sprintf('<fieldset data-controller="contao--toggle-fieldset" data-contao--toggle-fieldset-collapsed-class="collapsed" class="%s cf"><legend><button type="button" data-action="contao--toggle-fieldset#toggle">%s</button></legend>%s</fieldset>',
+					$return .= Message::generateUnwrapped() . \sprintf(
+						'<fieldset data-controller="contao--toggle-fieldset" data-contao--toggle-fieldset-collapsed-class="collapsed" class="%s cf"><legend><button type="button" data-action="contao--toggle-fieldset#toggle">%s</button></legend>%s</fieldset>',
 						$class,
 						StringUtil::specialchars(System::getContainer()->get('contao.data_container.record_labeler')->getLabel('contao.db.' . $this->strTable . '.' . $currentRecord['id'], $currentRecord)),
 						$box


### PR DESCRIPTION
Now that we have a record labeler service, we can easily improve the UX of the edit multiple view.
Currently, you always have to e.g. select the "page name" field to know, which row you are editing. If you don't, then your view is like this:


<img width="576" alt="Bildschirmfoto 2024-10-08 um 15 36 24" src="https://github.com/user-attachments/assets/5e32135c-c2d6-4f06-845a-8a64a8cfb9d5">

No idea which field belongs to what page.

With this PR, the edit multiple view will look like this which not only gives you the information of which row you are editing but you can also toggle the boxes 😎 

<img width="551" alt="Bildschirmfoto 2024-10-08 um 15 36 38" src="https://github.com/user-attachments/assets/c27d0df4-5713-40a9-bf16-5e14ef783bb9">

We will need to improve the record labeler service and add more and better information (e.g. maybe we should always include the ID? @ausi) but this will then automatically get represented in the edit multiple mask.
