### PR TITLE
Twig Finder improvements

### DIFF
--- a/core-bundle/src/EventListener/DataContainer/TemplateOptionsListener.php
+++ b/core-bundle/src/EventListener/DataContainer/TemplateOptionsListener.php
@@ -72,6 +72,7 @@ class TemplateOptionsListener
             ->identifier((string) $identifier)
             ->extension('html.twig')
             ->withVariants()
+            ->excludePartials()
             ->asTemplateOptions()
         ;
 

--- a/core-bundle/src/Twig/Finder/Finder.php
+++ b/core-bundle/src/Twig/Finder/Finder.php
@@ -36,6 +36,12 @@ final class Finder implements \IteratorAggregate, \Countable
 
     private bool $variants = false;
 
+    private string|null $identifierExpression = null;
+
+    private bool|null $identifierExpressionIsInclude = null;
+
+    private bool $excludePartials = false;
+
     /**
      * @var array<string, list<string>>
      */
@@ -79,6 +85,35 @@ final class Finder implements \IteratorAggregate, \Countable
     {
         $this->identifier = ContaoTwigUtil::getIdentifier($name);
         $this->extension = ContaoTwigUtil::getExtension($name);
+
+        return $this;
+    }
+
+    /**
+     * Includes only or excludes identifiers matching the given expression.
+     *
+     * E.g. use "%^backend/%" with $include set to false in order to suppress anything
+     * from the "backend" directories or "%/foo/%" with $include set to true to only
+     * consider identifiers containing a directory "foo" in their name.
+     *
+     * The given $regularExpression is passed to preg_match - it must include the
+     * delimiters and can include modifiers.
+     */
+    public function identifierRegex(string $regularExpression, bool $include = true): self
+    {
+        $this->identifierExpression = $regularExpression;
+        $this->identifierExpressionIsInclude = $include;
+
+        return $this;
+    }
+
+    /**
+     * Do not list partial templates. Partial templates are identified by their
+     * filename starting with an underscore, e.g. "@Contao/foo/_bar.html.twig".
+     */
+    public function excludePartials(): self
+    {
+        $this->excludePartials = true;
 
         return $this;
     }
@@ -160,6 +195,8 @@ final class Finder implements \IteratorAggregate, \Countable
     }
 
     /**
+     * Yield identifier => extension.
+     *
      * @return \Generator<string, string>
      */
     public function getIterator(): \Generator
@@ -194,6 +231,14 @@ final class Finder implements \IteratorAggregate, \Countable
 
         foreach ($chains as $identifier => $chain) {
             if ($this->identifier && !$matchIdentifier($identifier)) {
+                continue;
+            }
+
+            if (null !== $this->identifierExpression && (1 === preg_match($this->identifierExpression, $identifier)) !== $this->identifierExpressionIsInclude) {
+                continue;
+            }
+
+            if ($this->excludePartials && 1 === preg_match('%^.*_[^/]+$%', $identifier)) {
                 continue;
             }
 

--- a/core-bundle/src/Twig/Finder/Finder.php
+++ b/core-bundle/src/Twig/Finder/Finder.php
@@ -108,7 +108,7 @@ final class Finder implements \IteratorAggregate, \Countable
     }
 
     /**
-     * Do not list partial templates. Partial templates are identified by their
+     * Do not include partial templates. Partial templates are identified by their
      * filename starting with an underscore, e.g. "@Contao/foo/_bar.html.twig".
      */
     public function excludePartials(): self
@@ -195,7 +195,7 @@ final class Finder implements \IteratorAggregate, \Countable
     }
 
     /**
-     * Yield identifier => extension.
+     * Yields key-value pairs "identifier" => "extension".
      *
      * @return \Generator<string, string>
      */

--- a/core-bundle/tests/EventListener/DataContainer/TemplateOptionsListenerTest.php
+++ b/core-bundle/tests/EventListener/DataContainer/TemplateOptionsListenerTest.php
@@ -228,6 +228,9 @@ class TemplateOptionsListenerTest extends TestCase
                 'content_element/foo/variant' => [
                     '/templates/content_element/foo/variant.html.twig' => '@Contao_Global/content_element/foo/variant.html.twig',
                 ],
+                'frontend_module/_partial' => [
+                    '/templates/frontend_module/_partial.html.twig' => '@Contao_App/frontend_module/_partial.html.twig',
+                ],
                 'frontend_module/foo' => [
                     '/templates/frontend_module/foo.html.twig' => '@Contao_App/frontend_module/foo.html.twig',
                 ],

--- a/core-bundle/tests/Twig/Finder/FinderTest.php
+++ b/core-bundle/tests/Twig/Finder/FinderTest.php
@@ -29,6 +29,7 @@ class FinderTest extends TestCase
         $expected = [
             'ce_table' => 'html.twig',
             'content_element/text' => 'html.twig',
+            'content_element/text/_button' => 'html.twig',
             'content_element/text/foo' => 'html.twig',
             'content_element/text/bar' => 'html.twig',
             'json/thing' => 'json.twig',
@@ -79,6 +80,7 @@ class FinderTest extends TestCase
 
         $expected = [
             'content_element/text' => 'html.twig',
+            'content_element/text/_button' => 'html.twig',
             'content_element/text/foo' => 'html.twig',
             'content_element/text/bar' => 'html.twig',
         ];
@@ -94,6 +96,7 @@ class FinderTest extends TestCase
         ;
 
         $expected = [
+            'content_element/text/_button' => 'html.twig',
             'content_element/text/foo' => 'html.twig',
             'content_element/text/bar' => 'html.twig',
         ];
@@ -111,6 +114,7 @@ class FinderTest extends TestCase
 
         $expected = [
             'content_element/text' => 'html.twig',
+            'content_element/text/_button' => 'html.twig',
             'content_element/text/foo' => 'html.twig',
             'content_element/text/bar' => 'html.twig',
             'content_element/text/baz' => 'html.twig',
@@ -119,9 +123,67 @@ class FinderTest extends TestCase
         $this->assertSame($expected, iterator_to_array($finder));
     }
 
+    public function testFindExcludingPartials(): void
+    {
+        $finder = $this->getFinder()
+            ->identifier('content_element/text')
+            ->withVariants()
+            ->withTheme('my_theme')
+            ->excludePartials()
+        ;
+
+        $expected = [
+            'content_element/text' => 'html.twig',
+            'content_element/text/foo' => 'html.twig',
+            'content_element/text/bar' => 'html.twig',
+            'content_element/text/baz' => 'html.twig',
+        ];
+
+        $this->assertSame($expected, iterator_to_array($finder));
+    }
+
+    /**
+     * @dataProvider provideRegexCases
+     */
+    public function testFindWithRegularExpression(string $regex, bool $include, array $expected): void
+    {
+        $finder = $this->getFinder()
+            ->identifierRegex($regex, $include)
+        ;
+
+        $this->assertSame($expected, iterator_to_array($finder));
+    }
+
+    public static function provideRegexCases(): iterable
+    {
+        yield 'containing "on" anywhere' => [
+            '%on%',
+            true,
+            [
+                'content_element/text' => 'html.twig',
+                'content_element/text/_button' => 'html.twig',
+                'content_element/text/foo' => 'html.twig',
+                'content_element/text/bar' => 'html.twig',
+                'json/thing' => 'json.twig',
+            ],
+        ];
+
+        yield 'without "json" directory' => [
+            '%^json/%',
+            false,
+            [
+                'ce_table' => 'html.twig',
+                'content_element/text' => 'html.twig',
+                'content_element/text/_button' => 'html.twig',
+                'content_element/text/foo' => 'html.twig',
+                'content_element/text/bar' => 'html.twig',
+            ],
+        ];
+    }
+
     public function testCount(): void
     {
-        $this->assertCount(5, $this->getFinder());
+        $this->assertCount(6, $this->getFinder());
     }
 
     public function testGetAsTemplateOptions(): void
@@ -130,6 +192,7 @@ class FinderTest extends TestCase
             ->identifier('content_element/text')
             ->withVariants()
             ->withTheme('my_theme')
+            ->excludePartials()
             ->asTemplateOptions()
         ;
 
@@ -153,6 +216,7 @@ class FinderTest extends TestCase
         $options = $this->getFinder($translations)
             ->identifier('content_element/text')
             ->withVariants()
+            ->excludePartials()
             ->asTemplateOptions()
         ;
 
@@ -182,6 +246,9 @@ class FinderTest extends TestCase
                         'content_element/text' => [
                             '/app/templates/content_element/text.html.twig' => '@Contao_App/content_element/text.html.twig',
                             '/templates/content_element/text.html.twig' => '@Contao_ContaoCoreBundle/content_element/text.html.twig',
+                        ],
+                        'content_element/text/_button' => [
+                            '/app/templates/content_element/text/_button.html.twig' => '@Contao_App/content_element/text/_button.html.twig',
                         ],
                         'content_element/text/foo' => [
                             '/app/templates/content_element/text/foo.html.twig' => '@Contao_App/content_element/text/foo.html.twig',


### PR DESCRIPTION
This PR adds two new functions to the `Twig\Finder\Finder` class:

* `excludePartials()` excludes, partial templates - i.e. templates where the filename starts with an underscore - from the result.
* `identifierRegex()` allows to filter identifiers by a given regex. You can chose to [only include everything that is matched] or [exclude everything that is matched].

I also made our `TemplateOptionsListener` use the new `excludePartials()` feature (see #6694).