### PR TITLE
Replace newlines in CSP headers

### DIFF
--- a/core-bundle/src/Csp/CspParser.php
+++ b/core-bundle/src/Csp/CspParser.php
@@ -32,7 +32,7 @@ class CspParser
 
         $parser = new ContentSecurityPolicyParser();
         $names = $directiveSet->getNames();
-        $directives = array_filter(array_map(static fn (string $item) => trim(preg_replace('/\s+/', ' ', $item)), explode(';', $header)));
+        $directives = explode(';', preg_replace('/\s+/', ' ', $header));
 
         foreach ($directives as $directive) {
             [$name, $value] = explode(' ', trim($directive), 2) + [null, null];

--- a/core-bundle/src/Csp/CspParser.php
+++ b/core-bundle/src/Csp/CspParser.php
@@ -32,7 +32,7 @@ class CspParser
 
         $parser = new ContentSecurityPolicyParser();
         $names = $directiveSet->getNames();
-        $directives = array_filter(array_map(trim(...), explode(';', $header)));
+        $directives = array_filter(array_map(static fn (string $item) => trim(preg_replace('/\s\s+/', ' ', $item)), explode(';', $header)));
 
         foreach ($directives as $directive) {
             [$name, $value] = explode(' ', trim($directive), 2) + [null, null];

--- a/core-bundle/src/Csp/CspParser.php
+++ b/core-bundle/src/Csp/CspParser.php
@@ -32,7 +32,7 @@ class CspParser
 
         $parser = new ContentSecurityPolicyParser();
         $names = $directiveSet->getNames();
-        $directives = array_filter(array_map(static fn (string $item) => trim(preg_replace('/\s\s+/', ' ', $item)), explode(';', $header)));
+        $directives = array_filter(array_map(static fn (string $item) => trim(preg_replace('/\s+/', ' ', $item)), explode(';', $header)));
 
         foreach ($directives as $directive) {
             [$name, $value] = explode(' ', trim($directive), 2) + [null, null];

--- a/core-bundle/tests/Csp/CspParserTest.php
+++ b/core-bundle/tests/Csp/CspParserTest.php
@@ -35,9 +35,11 @@ class CspParserTest extends TestCase
     {
         yield ["default-src self; script-src 'none'; style-src unsafe-inline", ['default-src' => "'self'", 'script-src' => "'none'", 'style-src' => "'unsafe-inline'"]];
         yield ["script-src 'self' example.com", ['script-src' => "'self' example.com"]];
+        yield ["script-src 'self'\n example.com", ['script-src' => "'self' example.com"]];
         yield ["style-src 'self' 'unsafe-inline'; upgrade-insecure-requests", ['style-src' => "'self' 'unsafe-inline'", 'upgrade-insecure-requests' => true]];
         yield ["frame-ancestors 'none'; script-src 'self' example.com", ['frame-ancestors' => "'none'", 'script-src' => "'self' example.com"]];
         yield ["img-src 'self' data:; script-src 'self' example.com", ['img-src' => "'self' data:", 'script-src' => "'self' example.com"]];
+        yield ["img-src 'self' data:; \nscript-src 'self' example.com", ['img-src' => "'self' data:", 'script-src' => "'self' example.com"]];
         yield ["frame-ancestors 'self' https://example.com https://store.example.com", ['frame-ancestors' => "'self' https://example.com https://store.example.com"]];
         yield ["base-uri 'self'; report-uri https://endpoint.com", ['base-uri' => "'self'", 'report-uri' => 'https://endpoint.com']];
         yield ['font-src https://example.com/', ['font-src' => 'https://example.com/']];

--- a/core-bundle/tests/Csp/CspParserTest.php
+++ b/core-bundle/tests/Csp/CspParserTest.php
@@ -34,6 +34,7 @@ class CspParserTest extends TestCase
     public static function directivesProvider(): iterable
     {
         yield ["default-src self; script-src 'none'; style-src unsafe-inline", ['default-src' => "'self'", 'script-src' => "'none'", 'style-src' => "'unsafe-inline'"]];
+        yield ["default-src self;\n\nscript-src 'none';\n\n\nstyle-src unsafe-inline", ['default-src' => "'self'", 'script-src' => "'none'", 'style-src' => "'unsafe-inline'"]];
         yield ["script-src 'self' example.com", ['script-src' => "'self' example.com"]];
         yield ["script-src 'self'\n example.com", ['script-src' => "'self' example.com"]];
         yield ["script-src 'self'\nexample.com", ['script-src' => "'self' example.com"]];

--- a/core-bundle/tests/Csp/CspParserTest.php
+++ b/core-bundle/tests/Csp/CspParserTest.php
@@ -36,10 +36,12 @@ class CspParserTest extends TestCase
         yield ["default-src self; script-src 'none'; style-src unsafe-inline", ['default-src' => "'self'", 'script-src' => "'none'", 'style-src' => "'unsafe-inline'"]];
         yield ["script-src 'self' example.com", ['script-src' => "'self' example.com"]];
         yield ["script-src 'self'\n example.com", ['script-src' => "'self' example.com"]];
+        yield ["script-src 'self'\nexample.com", ['script-src' => "'self' example.com"]];
         yield ["style-src 'self' 'unsafe-inline'; upgrade-insecure-requests", ['style-src' => "'self' 'unsafe-inline'", 'upgrade-insecure-requests' => true]];
         yield ["frame-ancestors 'none'; script-src 'self' example.com", ['frame-ancestors' => "'none'", 'script-src' => "'self' example.com"]];
         yield ["img-src 'self' data:; script-src 'self' example.com", ['img-src' => "'self' data:", 'script-src' => "'self' example.com"]];
         yield ["img-src 'self' data:; \nscript-src 'self' example.com", ['img-src' => "'self' data:", 'script-src' => "'self' example.com"]];
+        yield ["img-src 'self' data:;\nscript-src 'self' example.com", ['img-src' => "'self' data:", 'script-src' => "'self' example.com"]];
         yield ["frame-ancestors 'self' https://example.com https://store.example.com", ['frame-ancestors' => "'self' https://example.com https://store.example.com"]];
         yield ["base-uri 'self'; report-uri https://endpoint.com", ['base-uri' => "'self'", 'report-uri' => 'https://endpoint.com']];
         yield ['font-src https://example.com/', ['font-src' => 'https://example.com/']];


### PR DESCRIPTION
There is a multiline input in the Contao backend and it's even comfortable to have multiple lines of CSP directives but it will raise a warning when added to the response as a header:

`Warning: Header may not contain more than a single header, new line detected`

![Bildschirmfoto 2024-10-10 um 22 21 17](https://github.com/user-attachments/assets/0aa203c4-c70d-4d67-8d94-2f5502b0a29b)
