### PR TITLE
Fix an invalid array access in the `Model::cloneOriginal()` method

### DIFF
--- a/core-bundle/contao/library/Contao/Model.php
+++ b/core-bundle/contao/library/Contao/Model.php
@@ -231,7 +231,11 @@ abstract class Model
 	public function cloneDetached()
 	{
 		$clone = clone $this;
-		$clone->arrData[static::$strPk] = $this->arrData[static::$strPk];
+
+		if (isset($this->arrData[static::$strPk])) {
+			$clone->arrData[static::$strPk] = $this->arrData[static::$strPk];
+		}
+
 		$clone->preventSaving(false);
 
 		return $clone;


### PR DESCRIPTION
This issue was introduced in https://github.com/contao/contao/commit/18219730fb7d4bbc5243ee08e780d9f559e78d4a.

You now get an invalid array access warning if you use e.g. the `content_element()` Twig helper or you work with "virtual" models in any form.