### PR TITLE
Use UTC in `BackupListCommandTest`

### DIFF
--- a/core-bundle/tests/Command/Backup/BackupListCommandTest.php
+++ b/core-bundle/tests/Command/Backup/BackupListCommandTest.php
@@ -37,15 +37,14 @@ class BackupListCommandTest extends TestCase
     {
         $command = new BackupListCommand($this->mockBackupManager());
 
+        $tz = date_default_timezone_get();
+        date_default_timezone_set('UTC');
+
         $commandTester = new CommandTester($command);
         $code = $commandTester->execute($arguments);
         $normalizedOutput = preg_replace("/\\s+\n/", "\n", $commandTester->getDisplay(true));
 
-        $expectedOutput = str_replace(
-            '<TIMEZONE>',
-            BackupListCommand::getFormattedTimeZoneOffset(new \DateTimeZone(date_default_timezone_get())),
-            $expectedOutput,
-        );
+        date_default_timezone_set($tz);
 
         $this->assertStringContainsString($expectedOutput, $normalizedOutput);
         $this->assertSame(0, $code);
@@ -57,7 +56,7 @@ class BackupListCommandTest extends TestCase
             [],
             <<<'OUTPUT'
                  --------------------- ----------- ------------------------------
-                  Created (<TIMEZONE>)      Size        Name
+                  Created (+00:00)      Size        Name
                  --------------------- ----------- ------------------------------
                   2021-11-01 14:12:54   48.83 KiB   test__20211101141254.sql.gz
                   2021-10-31 14:12:54   5.73 MiB    test2__20211031141254.sql.gz


### PR DESCRIPTION
The `BackupListCommandTest` accounts for different timezones here:

https://github.com/contao/contao/blob/0a4ca17a35abf88dc86a8a62665dee93e0b02377/core-bundle/tests/Command/Backup/BackupListCommandTest.php#L60

However, it still uses UTC times in the actual expected output here:

https://github.com/contao/contao/blob/0a4ca17a35abf88dc86a8a62665dee93e0b02377/core-bundle/tests/Command/Backup/BackupListCommandTest.php#L62-L64

Thus the test fails if your `date.timezone` PHP setting is not `UTC`. This PR fixes that by always using UTC for the test.