### PR TITLE
Use UTC in `BackupListCommandTest`

### DIFF
--- a/core-bundle/tests/Command/Backup/BackupListCommandTest.php
+++ b/core-bundle/tests/Command/Backup/BackupListCommandTest.php
@@ -56,7 +56,7 @@ class BackupListCommandTest extends TestCase
             [],
             <<<'OUTPUT'
                  --------------------- ----------- ------------------------------
-                  Created (UTC)      Size        Name
+                  Created (+00:00)      Size        Name
                  --------------------- ----------- ------------------------------
                   2021-11-01 14:12:54   48.83 KiB   test__20211101141254.sql.gz
                   2021-10-31 14:12:54   5.73 MiB    test2__20211031141254.sql.gz

--- a/core-bundle/tests/Command/Backup/BackupListCommandTest.php
+++ b/core-bundle/tests/Command/Backup/BackupListCommandTest.php
@@ -37,15 +37,14 @@ class BackupListCommandTest extends TestCase
     {
         $command = new BackupListCommand($this->mockBackupManager());
 
+        $tz = date_default_timezone_get();
+        date_default_timezone_set('UTC');
+
         $commandTester = new CommandTester($command);
         $code = $commandTester->execute($arguments);
         $normalizedOutput = preg_replace("/\\s+\n/", "\n", $commandTester->getDisplay(true));
 
-        $expectedOutput = str_replace(
-            '<TIMEZONE>',
-            BackupListCommand::getFormattedTimeZoneOffset(new \DateTimeZone(date_default_timezone_get())),
-            $normalizedOutput
-        );
+        date_default_timezone_set($tz);
 
         $this->assertStringContainsString($expectedOutput, $normalizedOutput);
         $this->assertSame(0, $code);

--- a/core-bundle/tests/Command/Backup/BackupListCommandTest.php
+++ b/core-bundle/tests/Command/Backup/BackupListCommandTest.php
@@ -56,7 +56,7 @@ class BackupListCommandTest extends TestCase
             [],
             <<<'OUTPUT'
                  --------------------- ----------- ------------------------------
-                  Created (<TIMEZONE>)      Size        Name
+                  Created (UTC)      Size        Name
                  --------------------- ----------- ------------------------------
                   2021-11-01 14:12:54   48.83 KiB   test__20211101141254.sql.gz
                   2021-10-31 14:12:54   5.73 MiB    test2__20211031141254.sql.gz


### PR DESCRIPTION
Same as #7628 for Contao 4.13.

This also fixes the test in general - it actually did not compare the expected output with the actual output (instead it compared the actual output with itself). This was fixed in Contao 5 in https://github.com/contao/contao/commit/bd2dad58611003066f8528c88ef9c3d0b0528476#diff-7c67e10f0ecc1349ef63485e29d1d426fac9224f900f44ba302c5c903c469b85R47