### PR TITLE
Allow page controllers to create the response context

### DIFF
--- a/core-bundle/config/services.yaml
+++ b/core-bundle/config/services.yaml
@@ -1287,6 +1287,7 @@ services:
     Contao\CoreBundle\Routing\ContentUrlGenerator: '@contao.routing.content_url_generator'
     Contao\CoreBundle\Routing\PageFinder: '@contao.routing.page_finder'
     Contao\CoreBundle\Routing\Page\PageRegistry: '@contao.routing.page_registry'
+    Contao\CoreBundle\Routing\ResponseContext\CoreResponseContextFactory: '@contao.routing.response_context_factory'
     Contao\CoreBundle\Routing\ResponseContext\ResponseContextAccessor: '@contao.routing.response_context_accessor'
     Contao\CoreBundle\Routing\ScopeMatcher: '@contao.routing.scope_matcher'
     Contao\CoreBundle\Security\Authentication\Token\TokenChecker: '@contao.security.token_checker'

--- a/core-bundle/contao/pages/PageRegular.php
+++ b/core-bundle/contao/pages/PageRegular.php
@@ -211,24 +211,24 @@ class PageRegular extends Frontend
 			}
 		}
 
-		$headBag = $this->responseContext->get(HtmlHeadBag::class);
+		$headBag = $this->responseContext->has(HtmlHeadBag::class) ? $this->responseContext->get(HtmlHeadBag::class) : null;
 
 		// Set the page title and description AFTER the modules have been generated
 		$this->Template->mainTitle = $objPage->rootPageTitle;
-		$this->Template->pageTitle = htmlspecialchars($headBag->getTitle(), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5);
+		$this->Template->pageTitle = htmlspecialchars($headBag?->getTitle() ?? '', ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5);
 
 		// Remove shy-entities (see #2709)
 		$this->Template->mainTitle = str_replace('[-]', '', $this->Template->mainTitle);
 		$this->Template->pageTitle = str_replace('[-]', '', $this->Template->pageTitle);
 
 		// Meta robots tag
-		$this->Template->robots = htmlspecialchars($headBag->getMetaRobots(), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5);
+		$this->Template->robots = htmlspecialchars($headBag?->getMetaRobots() ?? '', ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5);
 
 		// Canonical
 		if ($objPage->enableCanonical)
 		{
 			$this->Template->canonical = htmlspecialchars(
-				str_replace(array('{', '}'), array('%7B', '%7D'), $headBag->getCanonicalUriForRequest($request)),
+				str_replace(array('{', '}'), array('%7B', '%7D'), $headBag?->getCanonicalUriForRequest($request) ?? ''),
 				ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5
 			);
 		}
@@ -241,7 +241,7 @@ class PageRegular extends Frontend
 
 		// Assign the title and description
 		$this->Template->title = strip_tags(System::getContainer()->get('contao.insert_tag.parser')->replaceInline($objLayout->titleTag));
-		$this->Template->description = htmlspecialchars($headBag->getMetaDescription(), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5);
+		$this->Template->description = htmlspecialchars($headBag?->getMetaDescription() ?? '', ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5);
 
 		// Body onload and body classes
 		$this->Template->onload = trim($objLayout->onload);

--- a/core-bundle/contao/pages/PageRegular.php
+++ b/core-bundle/contao/pages/PageRegular.php
@@ -75,7 +75,13 @@ class PageRegular extends Frontend
 		$request = $container->get('request_stack')->getCurrentRequest();
 		$request->setLocale($locale);
 
-		$this->responseContext = $container->get('contao.routing.response_context_factory')->createContaoWebpageResponseContext($objPage);
+		$responseContextAccessor = System::getContainer()->get('contao.routing.response_context_accessor');
+
+		if (!$this->responseContext = $responseContextAccessor->getResponseContext())
+		{
+			$this->responseContext = $container->get('contao.routing.response_context_factory')->createContaoWebpageResponseContext($objPage);
+		}
+
 		$blnShowUnpublished = $container->get('contao.security.token_checker')->isPreviewMode();
 
 		System::loadLanguageFile('default');


### PR DESCRIPTION
Currently it is not possible for Page controllers to initialize the response context. The response context for regular pages is always created by `PageRegular`. This artificially limits the usefulnes of Page controllers that have `contentComposition` enabled. This is especially important for custom reader page controllers, as they will want to set the `<title>` for example.

This PR fixes that by changing `PageRegular` in such a way that it instead checks if a response context is present and if not, it will create one. It also introduces an autowiring alias for the response context factory.

This will allow you to create a content composition page controller like this:

```php
namespace App\Controller\Page;

use Contao\CoreBundle\DependencyInjection\Attribute\AsPage;
use Contao\CoreBundle\Routing\ResponseContext\CoreResponseContextFactory;
use Contao\FrontendIndex;
use Contao\PageModel;
use Symfony\Component\HttpFoundation\Response;

#[AsPage]
class CustomPageController
{
    public function __construct(private readonly CoreResponseContextFactory $coreResponseContextFactory)
    {
    }

    public function __invoke(PageModel $page): Response
    {
        $responseContext = $this->coreResponseContextFactory->createContaoWebpageResponseContext($page);

        // Initialize the response context with values here

        return (new FrontendIndex())->renderPage($page);
    }
}
```