### PR TITLE
Add events to modify indexed documents and search hits

### DIFF
--- a/core-bundle/config/backend_search.yaml
+++ b/core-bundle/config/backend_search.yaml
@@ -20,6 +20,7 @@ services:
             - !tagged_iterator contao.backend_search_provider
             - '@security.helper'
             - '@contao.search_backend.engine'
+            - '@event_dispatcher'
 
     contao.search.backend.files_provider:
         class: Contao\CoreBundle\Search\Backend\Provider\FilesProvider

--- a/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
+++ b/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
@@ -367,7 +367,7 @@ class ContaoCoreExtension extends Extension implements PrependExtensionInterface
         ;
 
         $factory = $container->getDefinition('contao.search.backend');
-        $factory->setArgument(3, $indexName);
+        $factory->setArgument(4, $indexName);
     }
 
     private function handleCrawlConfig(array $config, ContainerBuilder $container): void

--- a/core-bundle/src/Event/BackendSearch/EnhanceHitEvent.php
+++ b/core-bundle/src/Event/BackendSearch/EnhanceHitEvent.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Contao\CoreBundle\Event\BackendSearch;
+
+use Contao\CoreBundle\Search\Backend\Hit;
+
+final class EnhanceHitEvent
+{
+    public function __construct(private Hit|null $hit)
+    {
+    }
+
+    public function setHit(Hit|null $hit): self
+    {
+        $this->hit = $hit;
+
+        return $this;
+    }
+
+    public function getHit(): Hit|null
+    {
+        return $this->hit;
+    }
+}

--- a/core-bundle/src/Event/BackendSearch/IndexDocumentEvent.php
+++ b/core-bundle/src/Event/BackendSearch/IndexDocumentEvent.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Contao\CoreBundle\Event\BackendSearch;
+
+use Contao\CoreBundle\Search\Backend\Document;
+
+final class IndexDocumentEvent
+{
+    public function __construct(private Document|null $document)
+    {
+    }
+
+    public function setDocument(Document|null $document): self
+    {
+        $this->document = $document;
+
+        return $this;
+    }
+
+    public function getDocument(): Document|null
+    {
+        return $this->document;
+    }
+}

--- a/core-bundle/src/Search/Backend/BackendSearch.php
+++ b/core-bundle/src/Search/Backend/BackendSearch.php
@@ -47,7 +47,7 @@ class BackendSearch
                 $this->eventDispatcher->dispatch($event);
                 $document = $event->getDocument();
 
-                if (null === $document) {
+                if (!$document) {
                     continue;
                 }
 

--- a/core-bundle/src/Search/Backend/BackendSearch.php
+++ b/core-bundle/src/Search/Backend/BackendSearch.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Search\Backend;
 
+use Contao\CoreBundle\Event\BackendSearch\EnhanceHitEvent;
+use Contao\CoreBundle\Event\BackendSearch\IndexDocumentEvent;
 use Contao\CoreBundle\Search\Backend\IndexUpdateConfig\IndexUpdateConfigInterface;
 use Contao\CoreBundle\Search\Backend\Provider\ProviderInterface;
 use Contao\CoreBundle\Security\ContaoCorePermissions;
@@ -16,6 +18,7 @@ use Schranz\Search\SEAL\Search\Condition\EqualCondition;
 use Schranz\Search\SEAL\Search\Condition\SearchCondition;
 use Schranz\Search\SEAL\Search\SearchBuilder;
 use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
  * @experimental
@@ -29,6 +32,7 @@ class BackendSearch
         private readonly iterable $providers,
         private readonly Security $security,
         private readonly EngineInterface $engine,
+        private readonly EventDispatcherInterface $eventDispatcher,
         private readonly string $indexName,
     ) {
     }
@@ -39,11 +43,18 @@ class BackendSearch
         foreach ($this->providers as $provider) {
             /** @var Document $document */
             foreach ($provider->updateIndex($trigger) as $document) {
-                // TODO: Dispatch an event here. This will allow third-party developers to
-                // add/modify a document from a pre-existing provider. E.g. adding your own data
-                // from files to the existing provider
+                $event = new IndexDocumentEvent($document);
+                $this->eventDispatcher->dispatch($event);
+                $document = $event->getDocument();
 
-                $this->engine->saveDocument($this->indexName, $this->convertProviderDocumentForSearchIndex($document));
+                if (null === $document) {
+                    continue;
+                }
+
+                $this->engine->saveDocument(
+                    $this->indexName,
+                    $this->convertProviderDocumentForSearchIndex($document),
+                );
             }
         }
     }
@@ -142,7 +153,10 @@ class BackendSearch
             return null;
         }
 
-        return $hit;
+        $event = new EnhanceHitEvent($hit);
+        $this->eventDispatcher->dispatch($event);
+
+        return $event->getHit();
     }
 
     private function getProviderForType(string $type): ProviderInterface|null

--- a/core-bundle/src/Search/Backend/BackendSearch.php
+++ b/core-bundle/src/Search/Backend/BackendSearch.php
@@ -45,9 +45,8 @@ class BackendSearch
             foreach ($provider->updateIndex($trigger) as $document) {
                 $event = new IndexDocumentEvent($document);
                 $this->eventDispatcher->dispatch($event);
-                $document = $event->getDocument();
 
-                if (!$document) {
+                if (!$document = $event->getDocument()) {
                     continue;
                 }
 

--- a/core-bundle/src/Search/Backend/Document.php
+++ b/core-bundle/src/Search/Backend/Document.php
@@ -30,7 +30,7 @@ final class Document
     public function __construct(
         private readonly string $id,
         private readonly string $type,
-        private readonly string $searchableContent,
+        private string $searchableContent,
     ) {
     }
 
@@ -57,6 +57,14 @@ final class Document
     public function getMetadata(): array
     {
         return $this->metadata;
+    }
+
+    public function withSearchableContent(string $searchableContent): self
+    {
+        $clone = clone $this;
+        $clone->searchableContent = $searchableContent;
+
+        return $clone;
     }
 
     /**

--- a/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
+++ b/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
@@ -712,7 +712,7 @@ class ContaoCoreExtensionTest extends TestCase
 
         $this->assertTrue($container->hasDefinition('contao.search.backend'));
         $backendSearch = $container->getDefinition('contao.search.backend');
-        $this->assertSame('my_backend_search_index', $backendSearch->getArgument(3));
+        $this->assertSame('my_backend_search_index', $backendSearch->getArgument(4));
     }
 
     public function testCspConfiguration(): void

--- a/core-bundle/tests/Event/BackendSearch/EnhanceHitEventTest.php
+++ b/core-bundle/tests/Event/BackendSearch/EnhanceHitEventTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\Event\BackendSearch;
+
+use Contao\CoreBundle\Event\BackendSearch\EnhanceHitEvent;
+use Contao\CoreBundle\Search\Backend\Document;
+use Contao\CoreBundle\Search\Backend\Hit;
+use Contao\CoreBundle\Tests\TestCase;
+
+class EnhanceHitEventTest extends TestCase
+{
+    public function testCanModifyHit(): void
+    {
+        $hit = new Hit(new Document('42', 'type', 'searchable'), 'title', 'https://example.com');
+        $event = new EnhanceHitEvent($hit);
+        $this->assertSame($hit, $event->getHit());
+        $this->assertSame([], $event->getHit()->getMetadata());
+
+        $hit = $hit->withMetadata(['something-on-top-for-my-template' => 'foobar']);
+        $this->assertSame([], $event->getHit()->getMetadata());
+        $event->setHit($hit);
+        $this->assertSame(['something-on-top-for-my-template' => 'foobar'], $event->getHit()->getMetadata());
+    }
+
+    public function testCanRemoveHitCompletelyFromResults(): void
+    {
+        $hit = new Hit(new Document('42', 'type', 'searchable'), 'title', 'https://example.com');
+        $event = new EnhanceHitEvent($hit);
+        $event->setHit(null);
+        $this->assertNull($event->getHit());
+    }
+}

--- a/core-bundle/tests/Event/BackendSearch/IndexDocumentEventTest.php
+++ b/core-bundle/tests/Event/BackendSearch/IndexDocumentEventTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\Event\BackendSearch;
+
+use Contao\CoreBundle\Event\BackendSearch\IndexDocumentEvent;
+use Contao\CoreBundle\Search\Backend\Document;
+use Contao\CoreBundle\Tests\TestCase;
+
+class IndexDocumentEventTest extends TestCase
+{
+    public function testCanModifyDocument(): void
+    {
+        $document = new Document('42', 'type', 'searchable');
+        $event = new IndexDocumentEvent($document);
+        $this->assertSame($document, $event->getDocument());
+        $this->assertSame([], $event->getDocument()->getMetadata());
+
+        $document = $document->withMetadata(['something-on-top-for-my-template' => 'foobar']);
+        $this->assertSame([], $event->getDocument()->getMetadata());
+        $event->setDocument($document);
+        $this->assertSame(['something-on-top-for-my-template' => 'foobar'], $event->getDocument()->getMetadata());
+    }
+
+    public function testCanPreventDocumentFromBeingIndexedCompletely(): void
+    {
+        $document = new Document('42', 'type', 'searchable');
+        $event = new IndexDocumentEvent($document);
+        $event->setDocument(null);
+        $this->assertNull($event->getDocument());
+    }
+}

--- a/core-bundle/tests/Search/Backend/DocumentTest.php
+++ b/core-bundle/tests/Search/Backend/DocumentTest.php
@@ -31,9 +31,11 @@ class DocumentTest extends TestCase
             ->withTags(['tag-one', 'tag-two'])
         ;
 
+        $document = $document->withSearchableContent($document->getSearchableContent().' more data');
+
         $this->assertSame('id', $document->getId());
         $this->assertSame('type', $document->getType());
-        $this->assertSame('searchContent', $document->getSearchableContent());
+        $this->assertSame('searchContent more data', $document->getSearchableContent());
         $this->assertSame(['meta' => 'data', 'recursive' => ['also' => 'works']], $document->getMetadata());
         $this->assertSame(['tag-one', 'tag-two'], $document->getTags());
     }


### PR DESCRIPTION
This addresses the TODO of being able to modify a search document before it's being indexed and accordingly, the hit before it is displayed to the user 😎 