### PR TITLE
Add the `FigureBuilder::fromFilesystemItem()` method

### DIFF
--- a/core-bundle/src/Filesystem/FilesystemItem.php
+++ b/core-bundle/src/Filesystem/FilesystemItem.php
@@ -36,6 +36,7 @@ class FilesystemItem implements \Stringable
         private \Closure|int|null $fileSize = null,
         private \Closure|string|null $mimeType = null,
         private \Closure|array $extraMetadata = [],
+        private readonly VirtualFilesystemInterface|null $storage = null,
     ) {
     }
 
@@ -94,6 +95,7 @@ class FilesystemItem implements \Stringable
             $this->fileSize ?? $fileSize,
             $this->mimeType ?? $mimeType,
             $this->extraMetadata,
+            $this->storage,
         );
     }
 
@@ -106,7 +108,29 @@ class FilesystemItem implements \Stringable
             $this->fileSize,
             $this->mimeType,
             $this->extraMetadata,
+            $this->storage,
         );
+    }
+
+    public function withStorage(VirtualFilesystemInterface $storage): self
+    {
+        return new self(
+            $this->isFile,
+            $this->path,
+            $this->lastModified,
+            $this->fileSize,
+            $this->mimeType,
+            $this->extraMetadata,
+            $storage,
+        );
+    }
+
+    /**
+     * @internal
+     */
+    public function getStorage(): VirtualFilesystemInterface
+    {
+        return $this->storage ?? throw new \RuntimeException('No storage was set for this filesystem item.');
     }
 
     public function isFile(): bool

--- a/core-bundle/src/Filesystem/VirtualFilesystem.php
+++ b/core-bundle/src/Filesystem/VirtualFilesystem.php
@@ -174,6 +174,7 @@ class VirtualFilesystem implements VirtualFilesystemInterface
                 fn () => $this->getFileSize($relativePath, $accessFlags),
                 fn () => $this->getMimeType($relativePath, $accessFlags),
                 fn () => $this->getExtraMetadata($relativePath, $accessFlags),
+                $this,
             );
         }
 
@@ -185,6 +186,7 @@ class VirtualFilesystem implements VirtualFilesystemInterface
                 null,
                 null,
                 fn () => $this->getExtraMetadata($relativePath, $accessFlags),
+                $this,
             );
         }
 
@@ -324,7 +326,10 @@ class VirtualFilesystem implements VirtualFilesystemInterface
         if (!($accessFlags & self::BYPASS_DBAFS) && $this->dbafsManager->match($path)) {
             foreach ($this->dbafsManager->listContents($path, $deep) as $item) {
                 $path = $item->getPath();
-                $item = $item->withPath(Path::makeRelative($path, $this->prefix));
+                $item = $item
+                    ->withPath(Path::makeRelative($path, $this->prefix))
+                    ->withStorage($this)
+                ;
 
                 if (!$item->isFile()) {
                     yield $item;
@@ -353,6 +358,7 @@ class VirtualFilesystem implements VirtualFilesystemInterface
 
             yield $item
                 ->withPath(Path::makeRelative($path, $this->prefix))
+                ->withStorage($this)
                 ->withExtraMetadata(fn () => $this->dbafsManager->getExtraMetadata($path))
             ;
         }

--- a/core-bundle/src/Filesystem/VirtualFilesystem.php
+++ b/core-bundle/src/Filesystem/VirtualFilesystem.php
@@ -326,6 +326,7 @@ class VirtualFilesystem implements VirtualFilesystemInterface
         if (!($accessFlags & self::BYPASS_DBAFS) && $this->dbafsManager->match($path)) {
             foreach ($this->dbafsManager->listContents($path, $deep) as $item) {
                 $path = $item->getPath();
+
                 $item = $item
                     ->withPath(Path::makeRelative($path, $this->prefix))
                     ->withStorage($this)

--- a/core-bundle/src/Image/Studio/FigureBuilder.php
+++ b/core-bundle/src/Image/Studio/FigureBuilder.php
@@ -16,6 +16,7 @@ use Contao\CoreBundle\Event\FileMetadataEvent;
 use Contao\CoreBundle\Exception\InvalidResourceException;
 use Contao\CoreBundle\File\Metadata;
 use Contao\CoreBundle\Filesystem\Dbafs\UnableToResolveUuidException;
+use Contao\CoreBundle\Filesystem\FilesystemItem;
 use Contao\CoreBundle\Filesystem\VirtualFilesystemException;
 use Contao\CoreBundle\Filesystem\VirtualFilesystemInterface;
 use Contao\CoreBundle\Framework\Adapter;
@@ -294,16 +295,28 @@ class FigureBuilder
     }
 
     /**
+     * Sets the image resource from a virtual filesystem item.
+     */
+    public function fromFilesystemItem(FilesystemItem $item): self
+    {
+        return $this->fromStorage($item->getStorage(), $item->getPath());
+    }
+
+    /**
      * Sets the image resource by guessing the identifier type.
      *
-     * @param int|string|FilesModel|ImageInterface|null $identifier Can be a FilesModel, an ImageInterface, a tl_files UUID/ID/path or a file system path
+     * @param int|string|FilesModel|FilesystemItem|ImageInterface|null $identifier Can be a FilesModel, a FilesystemItem, an ImageInterface, a tl_files UUID/ID/path or a file system path
      */
-    public function from(FilesModel|ImageInterface|int|string|null $identifier): self
+    public function from(FilesModel|FilesystemItem|ImageInterface|int|string|null $identifier): self
     {
         if (null === $identifier) {
             $this->lastException = new InvalidResourceException('The defined resource is "null".');
 
             return $this;
+        }
+
+        if ($identifier instanceof FilesystemItem) {
+            return $this->fromFilesystemItem($identifier);
         }
 
         if ($identifier instanceof FilesModel) {
@@ -326,7 +339,7 @@ class FigureBuilder
     }
 
     /**
-     * Sets the image resource from a path inside a VFS storage.
+     * Sets the image resource from a path inside a virtual filesystem storage.
      */
     public function fromStorage(VirtualFilesystemInterface $storage, Uuid|string $location): self
     {

--- a/core-bundle/src/Image/Studio/FigureRenderer.php
+++ b/core-bundle/src/Image/Studio/FigureRenderer.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Image\Studio;
 
 use Contao\CoreBundle\File\Metadata;
+use Contao\CoreBundle\Filesystem\FilesystemItem;
 use Contao\FilesModel;
 use Contao\FrontendTemplate;
 use Contao\Image\ImageInterface;
@@ -40,12 +41,12 @@ class FigureRenderer
      *
      * Returns null if the resource is invalid.
      *
-     * @param int|string|FilesModel|ImageInterface       $from          Can be a FilesModel, an ImageInterface, a tl_files UUID/ID/path or a file system path
-     * @param int|string|array|PictureConfiguration|null $size          A picture size configuration or reference
-     * @param array<string, mixed>                       $configuration Configuration for the FigureBuilder
-     * @param string                                     $template      A Contao or Twig template
+     * @param int|string|FilesModel|FilesystemItem|ImageInterface $from          Can be a FilesModel, a FilesystemItem, an ImageInterface, a tl_files UUID/ID/path or a file system path
+     * @param int|string|array|PictureConfiguration|null          $size          A picture size configuration or reference
+     * @param array<string, mixed>                                $configuration Configuration for the FigureBuilder
+     * @param string                                              $template      A Contao or Twig template
      */
-    public function render(FilesModel|ImageInterface|int|string $from, PictureConfiguration|array|int|string|null $size, array $configuration = [], string $template = '@ContaoCore/Image/Studio/figure.html.twig'): string|null
+    public function render(FilesModel|FilesystemItem|ImageInterface|int|string $from, PictureConfiguration|array|int|string|null $size, array $configuration = [], string $template = '@ContaoCore/Image/Studio/figure.html.twig'): string|null
     {
         if (!$figure = $this->buildFigure($from, $size, $configuration)) {
             return null;

--- a/core-bundle/src/Twig/Runtime/FigureRuntime.php
+++ b/core-bundle/src/Twig/Runtime/FigureRuntime.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Twig\Runtime;
 
+use Contao\CoreBundle\Filesystem\FilesystemItem;
 use Contao\CoreBundle\Image\Studio\Figure;
 use Contao\CoreBundle\Image\Studio\FigureRenderer;
 use Contao\FilesModel;
@@ -36,13 +37,13 @@ final class FigureRuntime implements RuntimeExtensionInterface
      *
      * Returns null if the resource is invalid.
      *
-     * @param int|string|FilesModel|ImageInterface       $from          Can be a FilesModel, an ImageInterface, a tl_files UUID/ID/path or a file system path
-     * @param int|string|array|PictureConfiguration|null $size          A picture size configuration or reference
-     * @param array<string, mixed>                       $configuration Configuration for the FigureBuilder
+     * @param int|string|FilesModel|FilesystemItem|ImageInterface $from          Can be a FilesModel, a FilesystemItem, an ImageInterface, a tl_files UUID/ID/path or a file system path
+     * @param int|string|array|PictureConfiguration|null          $size          A picture size configuration or reference
+     * @param array<string, mixed>                                $configuration Configuration for the FigureBuilder
      *
      * @deprecated Deprecated since Contao 5.0, to be removed in Contao 6.
      */
-    public function renderFigure(FilesModel|ImageInterface|int|string $from, PictureConfiguration|array|int|string|null $size, array $configuration = [], string $template = '@ContaoCore/Image/Studio/figure.html.twig'): string|null
+    public function renderFigure(FilesModel|FilesystemItem|ImageInterface|int|string $from, PictureConfiguration|array|int|string|null $size, array $configuration = [], string $template = '@ContaoCore/Image/Studio/figure.html.twig'): string|null
     {
         trigger_deprecation('contao/core-bundle', '5.0', 'Using the "contao_figure" Twig function has been deprecated and will no longer work in Contao 6. Use the "figure" Twig function instead.');
 
@@ -56,11 +57,11 @@ final class FigureRuntime implements RuntimeExtensionInterface
      *
      * Returns null if the resource is invalid.
      *
-     * @param int|string|FilesModel|ImageInterface       $from          Can be a FilesModel, an ImageInterface, a tl_files UUID/ID/path or a file system path
-     * @param int|string|array|PictureConfiguration|null $size          A picture size configuration or reference
-     * @param array<string, mixed>                       $configuration Configuration for the FigureBuilder
+     * @param int|string|FilesModel|FilesystemItem|ImageInterface $from          Can be a FilesModel, a FilesystemItem, an ImageInterface, a tl_files UUID/ID/path or a file system path
+     * @param int|string|array|PictureConfiguration|null          $size          A picture size configuration or reference
+     * @param array<string, mixed>                                $configuration Configuration for the FigureBuilder
      */
-    public function buildFigure(FilesModel|ImageInterface|int|string $from, PictureConfiguration|array|int|string|null $size, array $configuration = []): Figure|null
+    public function buildFigure(FilesModel|FilesystemItem|ImageInterface|int|string $from, PictureConfiguration|array|int|string|null $size, array $configuration = []): Figure|null
     {
         return $this->figureRenderer->buildFigure($from, $size, $configuration);
     }

--- a/core-bundle/tests/Filesystem/FilesystemItemTest.php
+++ b/core-bundle/tests/Filesystem/FilesystemItemTest.php
@@ -16,6 +16,7 @@ use Contao\CoreBundle\File\Metadata;
 use Contao\CoreBundle\File\MetadataBag;
 use Contao\CoreBundle\Filesystem\FilesystemItem;
 use Contao\CoreBundle\Filesystem\VirtualFilesystemException;
+use Contao\CoreBundle\Filesystem\VirtualFilesystemInterface;
 use Contao\CoreBundle\Tests\TestCase;
 use League\Flysystem\DirectoryAttributes;
 use League\Flysystem\FileAttributes;
@@ -26,6 +27,7 @@ class FilesystemItemTest extends TestCase
     public function testSetAndGetAttributes(): void
     {
         $uuid = Uuid::fromString('2fcae369-c955-4b43-bcf9-d069f9d25542');
+        $storage = $this->createMock(VirtualFilesystemInterface::class);
 
         $fileItem = new FilesystemItem(
             true,
@@ -34,6 +36,7 @@ class FilesystemItemTest extends TestCase
             1024,
             'image/png',
             ['foo' => 'bar', 'uuid' => $uuid],
+            $storage,
         );
 
         $this->assertTrue($fileItem->isFile());
@@ -47,6 +50,7 @@ class FilesystemItemTest extends TestCase
         $this->assertSame('bar.PNG', $fileItem->getName());
         $this->assertSame('bar', $fileItem->getExtraMetadata()['foo']);
         $this->assertSame('2fcae369-c955-4b43-bcf9-d069f9d25542', $fileItem->getUuid()->toRfc4122());
+        $this->assertSame($storage, $fileItem->getStorage());
     }
 
     public function testTypeHelperShortcuts(): void
@@ -315,6 +319,16 @@ class FilesystemItemTest extends TestCase
         $this->assertSame(123450, $item->getLastModified());
         $this->assertSame(1024, $item->getFileSize());
         $this->assertSame('image/png', $item->getMimeType());
+    }
+
+    public function testAccessingStorageIFNotSetResultsInAnException(): void
+    {
+        $item = new FilesystemItem(true, 'some/path');
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('No storage was set for this filesystem item.');
+
+        $item->getStorage();
     }
 
     public static function provideSchemaOrgData(): iterable


### PR DESCRIPTION
This PR…
* enables filesystem items to be aware of their storage.
* adds a `FigureBuilder#fromFilesystemItem()` method.

This allows doing the following in Twig, now:
```twig
{% use "@Contao/component/_figure.html.twig" %}

{# @var \Contao\CoreBundle\Filesystem\FilesystemItem item #}
{% if item.isImage %}
    {% with {figure: figure(item, [200,200])} %}
        {{ block('figure_component') }}
    {% endwith %}
{% endif %}
