### PR TITLE
Improve the template DX when overwriting variables

### DIFF
--- a/core-bundle/contao/templates/twig/content_element/accordion.html.twig
+++ b/core-bundle/contao/templates/twig/content_element/accordion.html.twig
@@ -63,9 +63,9 @@
 {% endblock %}
 
 {% block style %}
-    {% set handorgel_css_file = asset('css/handorgel.min.css', 'contao-components/handorgel') %}
-
     {% add "handorgel_css" to stylesheets %}
-        {% with {file: handorgel_css_file} %}{{ block('stylesheet_component') }}{% endwith %}
+        {% with {file: handorgel_css_file|default(asset('css/handorgel.min.css', 'contao-components/handorgel'))} %}
+            {{ block('stylesheet_component') }}
+        {% endwith %}
     {% endadd %}
 {% endblock %}

--- a/core-bundle/contao/templates/twig/content_element/code.html.twig
+++ b/core-bundle/contao/templates/twig/content_element/code.html.twig
@@ -1,8 +1,6 @@
 {% extends "@Contao/content_element/_base.html.twig" %}
 {% use "@Contao/component/_stylesheet.html.twig" %}
 
-{% set highlighter_css_file = asset('foundation.css', 'scrivo/highlight.php') %}
-
 {% block content %}
     {% if as_editor_view %}
         {% block editor_view %}<pre>{{ code }}</pre>{% endblock %}
@@ -24,6 +22,8 @@
 
 {% block style %}
     {% add "highlighter_css" to stylesheets %}
-        {% with {file: highlighter_css_file} %}{{ block('stylesheet_component') }}{% endwith %}
+        {% with {file: highlighter_css_file|default(asset('foundation.css', 'scrivo/highlight.php'))} %}
+            {{ block('stylesheet_component') }}
+        {% endwith %}
     {% endadd %}
 {% endblock %}

--- a/core-bundle/contao/templates/twig/content_element/swiper.html.twig
+++ b/core-bundle/contao/templates/twig/content_element/swiper.html.twig
@@ -96,9 +96,9 @@
 {% endblock %}
 
 {% block style %}
-    {% set swiper_css_file = asset('css/swiper-bundle.min.css', 'contao-components/swiper') %}
-
     {% add "swiper_css" to stylesheets %}
-        {% with {file: swiper_css_file} %}{{ block('stylesheet_component') }}{% endwith %}
+        {% with {file: swiper_css_file|default(asset('css/swiper-bundle.min.css', 'contao-components/swiper'))} %}
+            {{ block('stylesheet_component') }}
+        {% endwith %}
     {% endadd %}
 {% endblock %}

--- a/core-bundle/contao/templates/twig/content_element/teaser.html.twig
+++ b/core-bundle/contao/templates/twig/content_element/teaser.html.twig
@@ -2,7 +2,7 @@
 {% extends "@Contao/content_element/_base.html.twig" %}
 {% use "@Contao/component/_read_more.html.twig" %}
 
-{% set headline = headline|default({tag_name: 'h1', text: article.title}) %}
+{% set headline = teaser_headline|default({tag_name: 'h1', text: article.title}) %}
 
 {% block content %}
     {% block teaser %}

--- a/core-bundle/contao/templates/twig/content_element/teaser.html.twig
+++ b/core-bundle/contao/templates/twig/content_element/teaser.html.twig
@@ -2,7 +2,7 @@
 {% extends "@Contao/content_element/_base.html.twig" %}
 {% use "@Contao/component/_read_more.html.twig" %}
 
-{% set headline = {tag_name: 'h1', text: article.title} %}
+{% set headline = headline|default({tag_name: 'h1', text: article.title}) %}
 
 {% block content %}
     {% block teaser %}


### PR DESCRIPTION
This makes overwriting variables a bit easier in our templates.


### Example
Before:
```twig
{% extends "@Contao/content_element/code.html.twig" %}

{% block style %}
    {% set highlighter_css_file = asset('monokai-sublime.css', 'scrivo/highlight.php') %}
    {{ parent() }}
{% endblock %}
```

After:
```twig
{% extends "@Contao/content_element/code.html.twig" %}

{# No need to specify the block as the variable won't get overwritten in the "root" block anymore #}
{% set highlighter_css_file = asset('monokai-sublime.css', 'scrivo/highlight.php') %}
```