### PR TITLE
Turbo request/response improvements

### DIFF
--- a/core-bundle/src/ContaoCoreBundle.php
+++ b/core-bundle/src/ContaoCoreBundle.php
@@ -50,6 +50,7 @@ use Symfony\Cmf\Component\Routing\DependencyInjection\Compiler\RegisterRouteEnha
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\EventDispatcher\DependencyInjection\AddEventAliasesPass;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class ContaoCoreBundle extends Bundle
@@ -57,6 +58,11 @@ class ContaoCoreBundle extends Bundle
     final public const SCOPE_BACKEND = 'backend';
 
     final public const SCOPE_FRONTEND = 'frontend';
+
+    public function boot(): void
+    {
+        (new Request())->setFormat('turbo_stream', 'text/vnd.turbo-stream.html');
+    }
 
     public function getContainerExtension(): ContaoCoreExtension
     {

--- a/core-bundle/src/Controller/AbstractBackendController.php
+++ b/core-bundle/src/Controller/AbstractBackendController.php
@@ -18,16 +18,22 @@ use Contao\BackendTemplate;
 use Contao\CoreBundle\ContaoCoreBundle;
 use Contao\Environment;
 use Contao\Input;
+use Contao\System;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 abstract class AbstractBackendController extends AbstractController
 {
     /**
      * Renders a Twig template with additional context for "@Contao/be_main".
+     *
+     * If the request was initiated by a Turbo frame or was set to accept a Turbo
+     * stream, no additional context will be created by default. To overwrite the
+     * behavior set $includeChromeContext to true/false.
      */
-    protected function render(string $view, array $parameters = [], Response|null $response = null): Response
+    protected function render(string $view, array $parameters = [], Response|null $response = null, bool|null $includeChromeContext = null): Response
     {
-        $backendContext = (new class() extends BackendMain {
+        $getBackendContext = (new class() extends BackendMain {
             public function __invoke(): array
             {
                 $this->Template = new BackendTemplate('be_main');
@@ -46,8 +52,27 @@ abstract class AbstractBackendController extends AbstractController
 
                 return $this->Template->getData();
             }
-        })();
+        });
 
-        return parent::render($view, [...$backendContext, ...$parameters], $response);
+        /** @var Request $request */
+        $request = System::getContainer()->get('request_stack')?->getCurrentRequest();
+
+        if (\in_array('text/vnd.turbo-stream.html', $request->getAcceptableContentTypes(), true)) {
+            // Setting the request format will add the correct ContentType header and make
+            // sure Symfony renders error pages correctly.
+            $request->setRequestFormat('turbo_stream');
+
+            $includeChromeContext ??= false;
+        }
+
+        if ($request->headers->has('turbo-frame')) {
+            $includeChromeContext ??= false;
+        }
+
+        if ($includeChromeContext ?? true) {
+            $parameters = [...$getBackendContext(), ...$parameters];
+        }
+
+        return parent::render($view, $parameters, $response);
     }
 }

--- a/core-bundle/tests/ContaoCoreBundleTest.php
+++ b/core-bundle/tests/ContaoCoreBundleTest.php
@@ -48,9 +48,24 @@ use Symfony\Cmf\Component\Routing\DependencyInjection\Compiler\RegisterRouteEnha
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\EventDispatcher\DependencyInjection\AddEventAliasesPass;
+use Symfony\Component\HttpFoundation\Request;
 
 class ContaoCoreBundleTest extends TestCase
 {
+    /**
+     * @runInSeparateProcess because request attributes are static
+     */
+    public function testAddsTheTurboStreamRequestFormatOnBoot(): void
+    {
+        $request = new Request();
+
+        $this->assertNull($request->getMimeType('turbo_stream'));
+
+        (new ContaoCoreBundle())->boot();
+
+        $this->assertSame('text/vnd.turbo-stream.html', $request->getMimeType('turbo_stream'));
+    }
+
     public function testAddsTheCompilerPasses(): void
     {
         $passes = [

--- a/core-bundle/tests/Controller/AbstractBackendControllerTest.php
+++ b/core-bundle/tests/Controller/AbstractBackendControllerTest.php
@@ -148,7 +148,6 @@ class AbstractBackendControllerTest extends TestCase
         $controller->setContainer($container);
 
         $this->assertSame('<custom_be_main>', $controller->fooAction($includeChromeContext)->getContent());
-
         $this->assertSame($expectedRequestFormat, $request->getRequestFormat());
     }
 

--- a/core-bundle/tests/Controller/AbstractBackendControllerTest.php
+++ b/core-bundle/tests/Controller/AbstractBackendControllerTest.php
@@ -108,7 +108,139 @@ class AbstractBackendControllerTest extends TestCase
         $this->assertSame('<custom_be_main>', $controller->fooAction()->getContent());
     }
 
-    private function getContainerWithDefaultConfiguration(array $expectedContext): ContainerBuilder
+    /**
+     * @dataProvider provideRequests
+     */
+    public function testHandlesTurboRequests(Request $request, bool|null $includeChromeContext, array $expectedContext, string $expectedRequestFormat = 'html'): void
+    {
+        $controller = new class() extends AbstractBackendController {
+            public function fooAction(bool|null $includeChromeContext): Response
+            {
+                return $this->render(
+                    'custom_be.html.twig',
+                    ['version' => 'my version'],
+                    includeChromeContext: $includeChromeContext,
+                );
+            }
+        };
+
+        // Legacy setup
+        ContaoEnvironment::reset();
+
+        $filesystem = new Filesystem();
+        $filesystem->mkdir(Path::join($this->getTempDir(), 'languages/en'));
+        $filesystem->touch(Path::join($this->getTempDir(), 'be_main.html5'));
+
+        $GLOBALS['TL_LANG']['MSC'] = [
+            'version' => 'version',
+            'dashboard' => 'dashboard',
+            'home' => 'home',
+            'learnMore' => 'learn more',
+        ];
+
+        $GLOBALS['TL_LANGUAGE'] = 'en';
+
+        TemplateLoader::addFile('be_main', '');
+
+        $container = $this->getContainerWithDefaultConfiguration($expectedContext, $request);
+
+        System::setContainer($container);
+        $controller->setContainer($container);
+
+        $this->assertSame('<custom_be_main>', $controller->fooAction($includeChromeContext)->getContent());
+
+        $this->assertSame($expectedRequestFormat, $request->getRequestFormat());
+    }
+
+    public static function provideRequests(): iterable
+    {
+        $defaultContext = [
+            'headline' => 'dashboard',
+            'title' => '',
+            'theme' => 'flexible',
+            'language' => 'en',
+            'host' => 'localhost',
+            'charset' => 'UTF-8',
+            'home' => 'home',
+            'isPopup' => null,
+            'learnMore' => 'learn more',
+            'menu' => '<menu>',
+            'headerMenu' => '<header_menu>',
+            'searchEnabled' => false,
+            'badgeTitle' => '',
+        ];
+
+        $customContext = [
+            'version' => 'my version',
+        ];
+
+        $turboFrameRequest = new Request(server: ['HTTP_HOST' => 'localhost']);
+        $turboFrameRequest->headers->set('Turbo-Frame', 'id');
+
+        yield 'default turbo frame' => [
+            $turboFrameRequest,
+            null,
+            $customContext,
+        ];
+
+        yield 'turbo frame with chrome' => [
+            $turboFrameRequest,
+            true,
+            [...$customContext, ...$defaultContext],
+        ];
+
+        yield 'default turbo frame explicitly without chrome' => [
+            $turboFrameRequest,
+            false,
+            $customContext,
+        ];
+
+        $turboStreamRequest = new Request(server: ['HTTP_HOST' => 'localhost']);
+        $turboStreamRequest->headers->set('Accept', 'text/vnd.turbo-stream.html; charset=utf-8');
+
+        yield 'default turbo stream' => [
+            $turboStreamRequest,
+            null,
+            $customContext,
+            'turbo_stream',
+        ];
+
+        yield 'turbo stream with chrome' => [
+            $turboStreamRequest,
+            true,
+            [...$customContext, ...$defaultContext],
+            'turbo_stream',
+        ];
+
+        yield 'turbo stream explicitly without chrome' => [
+            $turboStreamRequest,
+            false,
+            $customContext,
+            'turbo_stream',
+        ];
+
+        $plainRequest = new Request(server: ['HTTP_HOST' => 'localhost']);
+
+        yield 'plain request' => [
+            $plainRequest,
+            null,
+            [...$customContext, ...$defaultContext],
+        ];
+
+        yield 'plain request explicitly with chrome' => [
+            $plainRequest,
+            true,
+            [...$customContext, ...$defaultContext],
+        ];
+
+        yield 'plain request without chrome' => [
+            $plainRequest,
+            false,
+            $customContext,
+        ];
+    }
+
+    private function getContainerWithDefaultConfiguration(array $expectedContext, Request|null $request = null): ContainerBuilder
     {
         $container = $this->getContainerWithContaoConfiguration($this->getTempDir());
 
@@ -121,7 +253,6 @@ class AbstractBackendControllerTest extends TestCase
 
         $twig = $this->createMock(Environment::class);
         $twig
-            ->expects($this->exactly(3))
             ->method('render')
             ->willReturnCallback(
                 function (string $template, array $context) use ($expectedContext) {
@@ -141,7 +272,7 @@ class AbstractBackendControllerTest extends TestCase
         ;
 
         $requestStack = new RequestStack();
-        $requestStack->push(new Request(server: $_SERVER));
+        $requestStack->push($request ?? new Request(server: $_SERVER));
 
         $container->set('security.authorization_checker', $authorizationChecker);
         $container->set('security.token_storage', $this->createMock(TokenStorageInterface::class));


### PR DESCRIPTION
This PR brings two new Turbo improvements:

1) It adds a new `turbo_stream` request format analogous to what the Symfony UX TurboBundle does (see https://github.com/symfony/ux/blob/c9bf5ee9f82b93a39981794386bdd6fbbefc5a8b/src/Turbo/src/TurboBundle.php#L28-L31). This will make sure responses get the correct mime type + Symfony uses it to know what to render in case of an exception.

2) I also improved the render logic in the `AbstractBackendController`. Now the context for the default chrome is - by default - only added for non-Turbo requests (it can be overridden, though). Also we're making use of 1) and are now automatically setting the request format if applicable.  

(This is another prerequisite for the template studio extracted from #7598.)
