### PR TITLE
Add the template studio config

### DIFF
--- a/core-bundle/config/controller.yaml
+++ b/core-bundle/config/controller.yaml
@@ -36,11 +36,6 @@ services:
             - '@translator'
             - '%kernel.project_dir%'
 
-    Contao\CoreBundle\Controller\BackendTemplateStudioController:
-        arguments:
-            - '@contao.twig.filesystem_loader'
-            - '@contao.twig.finder_factory'
-
     Contao\CoreBundle\Controller\BackendPreviewController:
         arguments:
             - '%contao.preview_script%'

--- a/core-bundle/config/listener.yaml
+++ b/core-bundle/config/listener.yaml
@@ -349,6 +349,7 @@ services:
             - '@request_stack'
             - '@translator'
             - '@contao.framework'
+            - '%contao.template_studio.enabled%'
 
     contao.listener.menu.backend_favorites:
         class: Contao\CoreBundle\EventListener\Menu\BackendFavoritesListener

--- a/core-bundle/config/template_studio.yaml
+++ b/core-bundle/config/template_studio.yaml
@@ -1,0 +1,13 @@
+services:
+    _defaults:
+        autoconfigure: true
+
+    _instanceof:
+        Symfony\Bundle\FrameworkBundle\Controller\AbstractController:
+            calls:
+                - [setContainer, ['@Psr\Container\ContainerInterface']]
+
+    Contao\CoreBundle\Controller\BackendTemplateStudioController:
+        arguments:
+            - '@contao.twig.filesystem_loader'
+            - '@contao.twig.finder_factory'

--- a/core-bundle/src/DependencyInjection/Configuration.php
+++ b/core-bundle/src/DependencyInjection/Configuration.php
@@ -977,6 +977,6 @@ class Configuration implements ConfigurationInterface
             ->getRootNode()
             ->addDefaultsIfNotSet()
             ->canBeDisabled()
-            ;
+        ;
     }
 }

--- a/core-bundle/src/DependencyInjection/Configuration.php
+++ b/core-bundle/src/DependencyInjection/Configuration.php
@@ -116,6 +116,7 @@ class Configuration implements ConfigurationInterface
                 ->append($this->addCronNode())
                 ->append($this->addCspNode())
                 ->append($this->addAltchaNode())
+                ->append($this->addTemplateStudioNode())
             ->end()
         ;
 
@@ -968,5 +969,14 @@ class Configuration implements ConfigurationInterface
                 ->end()
             ->end()
         ;
+    }
+
+    private function addTemplateStudioNode(): NodeDefinition
+    {
+        return (new TreeBuilder('template_studio'))
+            ->getRootNode()
+            ->addDefaultsIfNotSet()
+            ->canBeDisabled()
+            ;
     }
 }

--- a/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
+++ b/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
@@ -641,5 +641,7 @@ class ContaoCoreExtension extends Extension implements PrependExtensionInterface
         if (!$config['template_studio']['enabled']) {
             return;
         }
+
+        $loader->load('template_studio.yaml');
     }
 }

--- a/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
+++ b/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
@@ -158,6 +158,7 @@ class ContaoCoreExtension extends Extension implements PrependExtensionInterface
         $this->handleSecurityConfig($config, $container);
         $this->handleCspConfig($config, $container);
         $this->handleAltcha($config, $container);
+        $this->handTemplateStudioConfig($config, $container, $loader);
 
         $container
             ->registerForAutoconfiguration(PickerProviderInterface::class)
@@ -630,5 +631,15 @@ class ContaoCoreExtension extends Extension implements PrependExtensionInterface
         $altcha->setArgument(3, $config['altcha']['algorithm']);
         $altcha->setArgument(4, $config['altcha']['range_max']);
         $altcha->setArgument(5, $config['altcha']['challenge_expiry']);
+    }
+
+    private function handTemplateStudioConfig(array $config, ContainerBuilder $container, LoaderInterface $loader): void
+    {
+        // Used to display/hide the menu entry in the back end
+        $container->setParameter('contao.template_studio.enabled', $config['template_studio']['enabled']);
+
+        if (!$config['template_studio']['enabled']) {
+            return;
+        }
     }
 }

--- a/core-bundle/src/EventListener/Menu/BackendMenuListener.php
+++ b/core-bundle/src/EventListener/Menu/BackendMenuListener.php
@@ -14,6 +14,7 @@ namespace Contao\CoreBundle\EventListener\Menu;
 
 use Contao\Backend;
 use Contao\BackendUser;
+use Contao\CoreBundle\Controller\BackendTemplateStudioController;
 use Contao\CoreBundle\Event\MenuEvent;
 use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\StringUtil;
@@ -37,6 +38,7 @@ class BackendMenuListener
         private readonly RequestStack $requestStack,
         private readonly TranslatorInterface $translator,
         private readonly ContaoFramework $framework,
+        private readonly bool $templateStudioEnabled,
     ) {
     }
 
@@ -104,6 +106,17 @@ class BackendMenuListener
                 ;
 
                 $categoryNode->addChild($moduleNode);
+            }
+
+            if ($this->templateStudioEnabled && 'design' === $categoryName) {
+                $templateStudioNode = $factory
+                    ->createItem('template-studio')
+                    ->setLabel('Template Studio')
+                    ->setUri('/contao/template-studio')
+                    ->setCurrent(BackendTemplateStudioController::class === $this->requestStack->getCurrentRequest()?->get('_controller'))
+                ;
+
+                $categoryNode->addChild($templateStudioNode);
             }
         }
     }

--- a/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
+++ b/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Tests\DependencyInjection;
 
 use Contao\CoreBundle\Controller\BackendSearchController;
+use Contao\CoreBundle\Controller\BackendTemplateStudioController;
 use Contao\CoreBundle\Cron\CronJob;
 use Contao\CoreBundle\DependencyInjection\Attribute\AsCallback;
 use Contao\CoreBundle\DependencyInjection\Attribute\AsContentElement;
@@ -759,6 +760,26 @@ class ContaoCoreExtensionTest extends TestCase
         $processor = $container->findDefinition('contao.csp.wysiwyg_style_processor');
 
         $this->assertSame(['text-decoration' => 'underline'], $processor->getArgument(0));
+    }
+
+    public function testDoesNotRegisterTemplateStudioIfNotEnabled(): void
+    {
+        $container = $this->getContainerBuilder([
+            'contao' => [
+                'template_studio' => [
+                    'enabled' => false,
+                ],
+            ],
+        ]);
+
+        $this->assertFalse($container->hasDefinition(BackendTemplateStudioController::class));
+    }
+
+    public function testRegistersTheTemplateStudioRelatedServicesCorrectly(): void
+    {
+        $container = $this->getContainerBuilder();
+
+        $this->assertTrue($container->hasDefinition(BackendTemplateStudioController::class));
     }
 
     public function testRegistersAsContentElementAttribute(): void

--- a/core-bundle/tests/EventListener/Menu/BackendMenuListenerTest.php
+++ b/core-bundle/tests/EventListener/Menu/BackendMenuListenerTest.php
@@ -51,6 +51,7 @@ class BackendMenuListenerTest extends TestCase
             new RequestStack(),
             $this->createMock(TranslatorInterface::class),
             $this->createMock(ContaoFramework::class),
+            false,
         );
 
         $listener($event);
@@ -143,6 +144,7 @@ class BackendMenuListenerTest extends TestCase
             new RequestStack(),
             $this->createMock(TranslatorInterface::class),
             $this->createMock(ContaoFramework::class),
+            false,
         );
 
         $listener($event);
@@ -175,6 +177,7 @@ class BackendMenuListenerTest extends TestCase
             new RequestStack(),
             $this->createMock(TranslatorInterface::class),
             $this->createMock(ContaoFramework::class),
+            false,
         );
 
         $listener($event);
@@ -182,6 +185,49 @@ class BackendMenuListenerTest extends TestCase
         $tree = $event->getTree();
 
         $this->assertCount(0, $tree->getChildren());
+    }
+
+    public function testAddsTheTemplateStudioMenuItemToTheMainMenu(): void
+    {
+        $user = $this->createMock(BackendUser::class);
+        $user
+            ->expects($this->once())
+            ->method('navigation')
+            ->willReturn([
+                'design' => [
+                    'label' => 'Layout',
+                    'title' => 'Layout',
+                    'href' => '/',
+                    'class' => 'design-category node-expanded trail',
+                    'modules' => [],
+                ],
+            ])
+        ;
+
+        $security = $this->createMock(Security::class);
+        $security
+            ->method('getUser')
+            ->willReturn($user)
+        ;
+
+        $nodeFactory = new MenuFactory();
+        $event = new MenuEvent($nodeFactory, $nodeFactory->createItem('mainMenu'));
+
+        $listener = new BackendMenuListener(
+            $security,
+            $this->createMock(RouterInterface::class),
+            new RequestStack(),
+            $this->createMock(TranslatorInterface::class),
+            $this->createMock(ContaoFramework::class),
+            true,
+        );
+
+        $listener($event);
+
+        $children = $event->getTree()->getChildren()['design']->getChildren();
+
+        $this->assertArrayHasKey('template-studio', $children);
+        $this->assertSame('Template Studio', $children['template-studio']->getLabel());
     }
 
     public function testBuildsTheHeaderMenu(): void
@@ -234,6 +280,7 @@ class BackendMenuListenerTest extends TestCase
             $requestStack,
             $this->getTranslator(),
             $this->mockContaoFramework([Backend::class => $systemMessages]),
+            false,
         );
 
         $listener($event);
@@ -343,6 +390,7 @@ class BackendMenuListenerTest extends TestCase
             new RequestStack(),
             $this->createMock(TranslatorInterface::class),
             $this->createMock(ContaoFramework::class),
+            false,
         );
 
         $listener($event);
@@ -375,6 +423,7 @@ class BackendMenuListenerTest extends TestCase
             new RequestStack(),
             $this->createMock(TranslatorInterface::class),
             $this->createMock(ContaoFramework::class),
+            false,
         );
 
         $listener($event);


### PR DESCRIPTION
This PR adds a new container config for the template studio, that allows it to be disabled:
```yaml
contao:
  template_studio:
    enabled: false
```


If the config is enabled (default),  …
* the back end menu entry will get added.
* the `template_studio.yaml` file will get loaded. With the actions being services (controllers), there will be quite a lot of entries, so - like with the backend search - it IMHO makes sense to only load them when needed (thus a separate file).

(This is another prerequisite for the template studio extracted from https://github.com/contao/contao/pull/7598.)
