### PR TITLE
Fix a typo in `tl_files`

### DIFF
--- a/core-bundle/contao/dca/tl_files.php
+++ b/core-bundle/contao/dca/tl_files.php
@@ -485,7 +485,7 @@ class tl_files extends Backend
 		{
 			$strPalette = PaletteManipulator::create()
 				->removeField(array('importantPartX', 'importantPartY', 'importantPartWidth', 'importantPartHeight'))
-				->applytoString($strPalette)
+				->applyToString($strPalette)
 			;
 		}
 


### PR DESCRIPTION
Fixes a typo in `tl_files` introduced in https://github.com/contao/contao/commit/514050b03bd93b10f9e571e89de18bbacc015b65 (noticed via https://github.com/contao/contao/pull/7641).
