### PR TITLE
Enable `pauseOnMouseEnter` in the Swiper template by default

### DIFF
--- a/core-bundle/contao/templates/twig/content_element/swiper.html.twig
+++ b/core-bundle/contao/templates/twig/content_element/swiper.html.twig
@@ -75,7 +75,6 @@
                     if (delay > 0) {
                         opts['autoplay'] = { 
                             delay: delay,
-                            {# Enable `pauseOnMouseEnter` for accessibility #}
                             pauseOnMouseEnter: true,
                         };
                     }

--- a/core-bundle/contao/templates/twig/content_element/swiper.html.twig
+++ b/core-bundle/contao/templates/twig/content_element/swiper.html.twig
@@ -73,7 +73,11 @@
 
                     let delay = el.getAttribute('data-delay');
                     if (delay > 0) {
-                        opts['autoplay'] = { delay: delay };
+                        opts['autoplay'] = { 
+                            delay: delay,
+                            {# Enable `pauseOnMouseEnter` for accessibility #}
+                            pauseOnMouseEnter: true,
+                        };
                     }
 
                     new Swiper(el, Object.assign({


### PR DESCRIPTION
Same as #7649 for Contao 5.3.
