### PR TITLE
Fix a type error in `CalendarContentVoter`

### DIFF
--- a/calendar-bundle/src/Security/Voter/CalendarContentVoter.php
+++ b/calendar-bundle/src/Security/Voter/CalendarContentVoter.php
@@ -60,10 +60,10 @@ class CalendarContentVoter extends AbstractDynamicPtableVoter
             && $this->accessDecisionManager->decide($token, [ContaoCalendarPermissions::USER_CAN_EDIT_CALENDAR], $calendarId);
     }
 
-    private function getCalendarId(int $eventId): int|null
+    private function getCalendarId(int $eventId): int
     {
         if (!isset($this->calendars[$eventId])) {
-            $this->calendars[$eventId] = $this->connection->fetchOne('SELECT pid FROM tl_calendar_events WHERE id=?', [$eventId]);
+            $this->calendars[$eventId] = (int) $this->connection->fetchOne('SELECT pid FROM tl_calendar_events WHERE id=?', [$eventId]);
         }
 
         return $this->calendars[$eventId] ?: null;

--- a/calendar-bundle/src/Security/Voter/CalendarContentVoter.php
+++ b/calendar-bundle/src/Security/Voter/CalendarContentVoter.php
@@ -66,6 +66,6 @@ class CalendarContentVoter extends AbstractDynamicPtableVoter
             $this->calendars[$eventId] = (int) $this->connection->fetchOne('SELECT pid FROM tl_calendar_events WHERE id=?', [$eventId]);
         }
 
-        return $this->calendars[$eventId] ?: null;
+        return $this->calendars[$eventId];
     }
 }

--- a/calendar-bundle/tests/Security/Voter/CalendarContentVoterTest.php
+++ b/calendar-bundle/tests/Security/Voter/CalendarContentVoterTest.php
@@ -50,7 +50,7 @@ class CalendarContentVoterTest extends TestCase
         $accessDecisionMap = [[$token, [ContaoCalendarPermissions::USER_CAN_ACCESS_MODULE], null, true]];
 
         foreach ($events as $calendarId) {
-            $accessDecisionMap[] = [$token, [ContaoCalendarPermissions::USER_CAN_EDIT_CALENDAR], $calendarId, true];
+            $accessDecisionMap[] = [$token, [ContaoCalendarPermissions::USER_CAN_EDIT_CALENDAR], (int) $calendarId, true];
         }
 
         $accessDecisionManager = $this->createMock(AccessDecisionManagerInterface::class);
@@ -124,7 +124,7 @@ class CalendarContentVoterTest extends TestCase
         yield 'Check access to calendar when creating element in events' => [
             new CreateAction('tl_content', ['ptable' => 'tl_calendar_events', 'pid' => 1]),
             [],
-            [1 => 1],
+            [1 => '1'],
         ];
 
         yield 'Check access to news archive when creating nested element' => [


### PR DESCRIPTION
Same as #7561 for the `CalendarContentVoter`.
