### PR TITLE
Fix the `ContentElementTypeListener`

### DIFF
--- a/core-bundle/src/EventListener/DataContainer/ContentElementTypeListener.php
+++ b/core-bundle/src/EventListener/DataContainer/ContentElementTypeListener.php
@@ -67,7 +67,7 @@ class ContentElementTypeListener implements ResetInterface
         $groups = [];
 
         foreach ($GLOBALS['TL_CTE'] as $k => $v) {
-            foreach ($v as $vv) {
+            foreach (array_keys($v) as $vv) {
                 $action = new CreateAction('tl_content', [
                     'ptable' => $ptable,
                     'pid' => $pid,
@@ -80,6 +80,6 @@ class ContentElementTypeListener implements ResetInterface
             }
         }
 
-        return $groups;
+        return $this->cache[$cacheKey] = $groups;
     }
 }

--- a/core-bundle/tests/EventListener/DataContainer/ContentElementTypeListenerTest.php
+++ b/core-bundle/tests/EventListener/DataContainer/ContentElementTypeListenerTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Tests\EventListener\DataContainer;
 
+use Contao\ContentProxy;
 use Contao\CoreBundle\EventListener\DataContainer\ContentElementTypeListener;
 use Contao\CoreBundle\Security\ContaoCorePermissions;
 use Contao\CoreBundle\Security\DataContainer\CreateAction;
@@ -31,8 +32,14 @@ class ContentElementTypeListenerTest extends TestCase
     public function testGetOptions(): void
     {
         $GLOBALS['TL_CTE'] = [
-            'foo' => ['bar', 'baz'],
-            'fii' => ['bas', 'bat'],
+            'foo' => [
+                'bar' => ContentProxy::class,
+                'baz' => ContentProxy::class,
+            ],
+            'fii' => [
+                'bas' => ContentProxy::class,
+                'bat' => ContentProxy::class,
+            ],
         ];
 
         $security = $this->createMock(Security::class);
@@ -62,8 +69,12 @@ class ContentElementTypeListenerTest extends TestCase
     public function testOverridesTheDefaultType(): void
     {
         $GLOBALS['TL_DCA']['tl_content']['fields']['type']['sql']['default'] = 'bar';
-        $GLOBALS['TL_CTE'] = ['foo' => ['bar', 'baz']];
-
+        $GLOBALS['TL_CTE'] = [
+            'foo' => [
+                'bar' => ContentProxy::class,
+                'baz' => ContentProxy::class,
+            ],
+        ];
         $security = $this->createMock(Security::class);
         $security
             ->expects($this->exactly(2))


### PR DESCRIPTION
Fixes https://github.com/contao/contao/issues/7664.

And adds the cache key without which the whole point of https://github.com/contao/contao/pull/7516 was ignored 🤦‍♂️ 
