### PR TITLE
Harden CSP header parsing

### DIFF
--- a/core-bundle/src/Csp/CspParser.php
+++ b/core-bundle/src/Csp/CspParser.php
@@ -32,7 +32,7 @@ class CspParser
 
         $parser = new ContentSecurityPolicyParser();
         $names = $directiveSet->getNames();
-        $directives = explode(';', preg_replace('/\s+/', ' ', $header));
+        $directives = array_filter(explode(';', preg_replace('/\s+/', ' ', $header)));
 
         foreach ($directives as $directive) {
             [$name, $value] = explode(' ', trim($directive), 2) + [null, null];

--- a/core-bundle/tests/Csp/CspParserTest.php
+++ b/core-bundle/tests/Csp/CspParserTest.php
@@ -36,8 +36,10 @@ class CspParserTest extends TestCase
         yield ["default-src self; script-src 'none'; style-src unsafe-inline", ['default-src' => "'self'", 'script-src' => "'none'", 'style-src' => "'unsafe-inline'"]];
         yield ["default-src self;\n\nscript-src 'none';\n\n\nstyle-src unsafe-inline", ['default-src' => "'self'", 'script-src' => "'none'", 'style-src' => "'unsafe-inline'"]];
         yield ["script-src 'self' example.com", ['script-src' => "'self' example.com"]];
+        yield ["script-src 'self' example.com;", ['script-src' => "'self' example.com"]];
         yield ["script-src 'self'\n example.com", ['script-src' => "'self' example.com"]];
         yield ["script-src 'self'\nexample.com", ['script-src' => "'self' example.com"]];
+        yield ["script-src 'self'\nexample.com;", ['script-src' => "'self' example.com"]];
         yield ["style-src 'self' 'unsafe-inline'; upgrade-insecure-requests", ['style-src' => "'self' 'unsafe-inline'", 'upgrade-insecure-requests' => true]];
         yield ["frame-ancestors 'none'; script-src 'self' example.com", ['frame-ancestors' => "'none'", 'script-src' => "'self' example.com"]];
         yield ["img-src 'self' data:; script-src 'self' example.com", ['img-src' => "'self' data:", 'script-src' => "'self' example.com"]];
@@ -45,6 +47,7 @@ class CspParserTest extends TestCase
         yield ["img-src 'self' data:;\nscript-src 'self' example.com", ['img-src' => "'self' data:", 'script-src' => "'self' example.com"]];
         yield ["frame-ancestors 'self' https://example.com https://store.example.com", ['frame-ancestors' => "'self' https://example.com https://store.example.com"]];
         yield ["base-uri 'self'; report-uri https://endpoint.com", ['base-uri' => "'self'", 'report-uri' => 'https://endpoint.com']];
+        yield ["base-uri 'self'; report-uri https://endpoint.com;", ['base-uri' => "'self'", 'report-uri' => 'https://endpoint.com']];
         yield ['font-src https://example.com/', ['font-src' => 'https://example.com/']];
         yield ['script-src unsafe-hashed-attributes', ['script-src' => 'unsafe-hashed-attributes']];
         yield ['plugin-types application/x-java-applet', ['plugin-types' => 'application/x-java-applet']];


### PR DESCRIPTION
Fix the issue when you have a trailing `;` in your CSP directive (which is valid):

```
InvalidArgumentException
Unknown CSP directive name: 
```

This PR partly reverts the proposed change in https://github.com/contao/contao/pull/7622#discussion_r1797155101.

If you have a trailing `;` at the end, `explode()` will return an array with an empty string last element:

```
array:2 [
  0 => "default-src 'self'"
  1 => ""
]
```

Workaround: Remove trailing `;` in the last directive.