### PR TITLE
Flag deprecated Twig functions as deprecated 

### DIFF
--- a/core-bundle/src/Twig/Extension/ContaoExtension.php
+++ b/core-bundle/src/Twig/Extension/ContaoExtension.php
@@ -177,7 +177,7 @@ final class ContaoExtension extends AbstractExtension implements GlobalsInterfac
             new TwigFunction(
                 'contao_figure',
                 [FigureRuntime::class, 'renderFigure'],
-                ['is_safe' => ['html']],
+                ['is_safe' => ['html'], 'deprecated' => true],
             ),
             new TwigFunction(
                 'picture_config',


### PR DESCRIPTION
The `contao_figure` function is already deprecated (see `FigureRuntime::renderFigure`), but there is also a `deprecated` flag in the options, which makes `TwigFunction#isDeprecated()` return `true`.

 This - for instance - allows to programmatically remove the function from the autocompletion data (see #7672).