### PR TITLE
Unify the autoloader in CLI scripts

### DIFF
--- a/manager-bundle/bin/contao-api
+++ b/manager-bundle/bin/contao-api
@@ -19,8 +19,14 @@ set_time_limit(0);
 @ini_set('display_errors', '1');
 @ini_set('zlib.output_compression', '0');
 
-if (file_exists(__DIR__.'/../../../../autoload.php')) {
+if (file_exists(__DIR__.'/../autoload.php')) {
+    $projectDir = \dirname(__DIR__, 2);
+} elseif (file_exists(__DIR__.'/../../../autoload.php')) {
+    $projectDir = \dirname(__DIR__, 4);
+} elseif (file_exists(__DIR__.'/../../../../autoload.php')) {
     $projectDir = \dirname(__DIR__, 5);
+} elseif (false !== ($cwd = getcwd()) && file_exists($cwd.'/vendor/autoload.php')) {
+    $projectDir = $cwd;
 } else {
     $projectDir = \dirname(__DIR__, 4);
 }

--- a/manager-bundle/bin/contao-setup
+++ b/manager-bundle/bin/contao-setup
@@ -24,6 +24,8 @@ set_time_limit(0);
 
 if (file_exists(__DIR__.'/../autoload.php')) {
     $projectDir = \dirname(__DIR__, 2);
+} elseif (file_exists(__DIR__.'/../../../autoload.php')) {
+    $projectDir = \dirname(__DIR__, 4);
 } elseif (file_exists(__DIR__.'/../../../../autoload.php')) {
     $projectDir = \dirname(__DIR__, 5);
 } elseif (false !== ($cwd = getcwd()) && file_exists($cwd.'/vendor/autoload.php')) {


### PR DESCRIPTION
The command line autoloading is currently inconsistent accross our entry points. An additional path was added in https://github.com/contao/contao/pull/6196 but I saw no reason not to backport that ~and keep the fix upstream-compatible~.