### PR TITLE
Add IDE autocompletion for core templates

### DIFF
--- a/core-bundle/contao/templates/twig/ide-twig.json
+++ b/core-bundle/contao/templates/twig/ide-twig.json
@@ -1,0 +1,8 @@
+{
+  "namespaces": [
+    {
+      "namespace": "Contao",
+      "path": ""
+    }
+  ]
+}


### PR DESCRIPTION
I wanted to contribute this for a long time - now that the amount of core templates referencing each other is growing (looking at you 'backend templates'…), the time has come. :smile:  

This PR adds IDE autocompletion<sup>*)</sup> when developing for the core itself (=no app) which is extremely helpful DX wise. The only thing necessary to get this working is an additional static `ide-twig.json` file in the Twig templates directory.

<sup>*) and all the other things like navigating, highlighting missing templates, and so on…</sup>