### PR TITLE
Remove superfluous domain encoding

### DIFF
--- a/core-bundle/contao/library/Contao/Widget.php
+++ b/core-bundle/contao/library/Contao/Widget.php
@@ -965,8 +965,6 @@ abstract class Widget extends Controller
 
 					foreach ($arrEmails as $strEmail)
 					{
-						$strEmail = Idna::encodeEmail($strEmail);
-
 						if (!Validator::isEmail($strEmail))
 						{
 							$this->addError(\sprintf($GLOBALS['TL_LANG']['ERR']['emails'], $this->strLabel));


### PR DESCRIPTION
Since the Validator::isValidEmail() method is already encoding, this step is not necessary here.