### PR TITLE
Fix the regex for partials in the Twig template finder

### DIFF
--- a/core-bundle/src/Twig/Finder/Finder.php
+++ b/core-bundle/src/Twig/Finder/Finder.php
@@ -249,7 +249,7 @@ final class Finder implements \IteratorAggregate, \Countable
                 continue;
             }
 
-            if ($this->excludePartials && 1 === preg_match('%^.*_[^/]+$%', $identifier)) {
+            if ($this->excludePartials && 1 === preg_match('%[^/]+/_[^/\s]+$%', $identifier)) {
                 continue;
             }
 

--- a/core-bundle/src/Twig/Finder/Finder.php
+++ b/core-bundle/src/Twig/Finder/Finder.php
@@ -249,7 +249,7 @@ final class Finder implements \IteratorAggregate, \Countable
                 continue;
             }
 
-            if ($this->excludePartials && 1 === preg_match('%[^/]+/_[^/\s]+$%', $identifier)) {
+            if ($this->excludePartials && 1 === preg_match('%(?:/|^)_[^/]+$%', $identifier)) {
                 continue;
             }
 

--- a/core-bundle/tests/Twig/Finder/FinderTest.php
+++ b/core-bundle/tests/Twig/Finder/FinderTest.php
@@ -32,6 +32,7 @@ class FinderTest extends TestCase
             'content_element/text/_button' => 'html.twig',
             'content_element/text/foo' => 'html.twig',
             'content_element/text/bar' => 'html.twig',
+            'content_element/text/foo_bar' => 'html.twig',
             'json/thing' => 'json.twig',
         ];
 
@@ -83,6 +84,7 @@ class FinderTest extends TestCase
             'content_element/text/_button' => 'html.twig',
             'content_element/text/foo' => 'html.twig',
             'content_element/text/bar' => 'html.twig',
+            'content_element/text/foo_bar' => 'html.twig',
         ];
 
         $this->assertSame($expected, iterator_to_array($finder));
@@ -99,6 +101,7 @@ class FinderTest extends TestCase
             'content_element/text/_button' => 'html.twig',
             'content_element/text/foo' => 'html.twig',
             'content_element/text/bar' => 'html.twig',
+            'content_element/text/foo_bar' => 'html.twig',
         ];
 
         $this->assertSame($expected, iterator_to_array($finder));
@@ -117,6 +120,7 @@ class FinderTest extends TestCase
             'content_element/text/_button' => 'html.twig',
             'content_element/text/foo' => 'html.twig',
             'content_element/text/bar' => 'html.twig',
+            'content_element/text/foo_bar' => 'html.twig',
             'content_element/text/baz' => 'html.twig',
         ];
 
@@ -136,6 +140,7 @@ class FinderTest extends TestCase
             'content_element/text' => 'html.twig',
             'content_element/text/foo' => 'html.twig',
             'content_element/text/bar' => 'html.twig',
+            'content_element/text/foo_bar' => 'html.twig',
             'content_element/text/baz' => 'html.twig',
         ];
 
@@ -164,6 +169,7 @@ class FinderTest extends TestCase
                 'content_element/text/_button' => 'html.twig',
                 'content_element/text/foo' => 'html.twig',
                 'content_element/text/bar' => 'html.twig',
+                'content_element/text/foo_bar' => 'html.twig',
                 'json/thing' => 'json.twig',
             ],
         ];
@@ -177,13 +183,14 @@ class FinderTest extends TestCase
                 'content_element/text/_button' => 'html.twig',
                 'content_element/text/foo' => 'html.twig',
                 'content_element/text/bar' => 'html.twig',
+                'content_element/text/foo_bar' => 'html.twig',
             ],
         ];
     }
 
     public function testCount(): void
     {
-        $this->assertCount(6, $this->getFinder());
+        $this->assertCount(7, $this->getFinder());
     }
 
     public function testGetAsTemplateOptions(): void
@@ -201,6 +208,7 @@ class FinderTest extends TestCase
             'content_element/text/bar' => 'content_element/text/bar [App]',
             'content_element/text/baz' => 'content_element/text/baz [Theme my_theme]',
             'content_element/text/foo' => 'content_element/text/foo [App]',
+            'content_element/text/foo_bar' => 'content_element/text/foo_bar [App]',
         ];
 
         $this->assertSame($expected, $options);
@@ -221,6 +229,7 @@ class FinderTest extends TestCase
             'content_element/text/bar',
             'content_element/text/baz',
             'content_element/text/foo',
+            'content_element/text/foo_bar',
         ];
 
         $this->assertSame($expected, $options);
@@ -244,6 +253,7 @@ class FinderTest extends TestCase
             '' => 'Text default [content_element/text • App, ContaoCore]',
             'content_element/text/bar' => 'content_element/text/bar [App]',
             'content_element/text/foo' => 'Foo variant [content_element/text/foo • App]',
+            'content_element/text/foo_bar' => 'content_element/text/foo_bar [App]',
         ];
 
         $this->assertSame($expected, $options);
@@ -275,6 +285,9 @@ class FinderTest extends TestCase
                         ],
                         'content_element/text/bar' => [
                             '/app/templates/content_element/text/bar.html.twig' => '@Contao_App/content_element/text/bar.html.twig',
+                        ],
+                        'content_element/text/foo_bar' => [
+                            '/app/templates/content_element/text/foo_bar.html.twig' => '@Contao_App/content_element/text/foo_bar.html.twig',
                         ],
                         'json/thing' => [
                             '/app/templates/json/thing.json.twig' => '@Contao_SomeJsonBundle/app/templates/json/thing.json.twig',


### PR DESCRIPTION
Currently the following error occurs in `5.x` when trying to create a `description_list` content element:

```
LogicException:
Tried to list template options for the modern fragment type "content_element/description_list" but could not find any template. Did you forget to create the default template?

  at vendor\contao\contao\core-bundle\src\EventListener\DataContainer\TemplateOptionsListener.php:94
  at Contao\CoreBundle\EventListener\DataContainer\TemplateOptionsListener->__invoke()
     (vendor\contao\contao\core-bundle\contao\library\Contao\Widget.php:1310)
  at Contao\Widget::getAttributesFromDca()
     (vendor\contao\contao\core-bundle\contao\classes\DataContainer.php:482)
  at Contao\DataContainer->row()
     (vendor\contao\contao\core-bundle\contao\drivers\DC_Table.php:2131)
  at Contao\DC_Table->edit()
     (vendor\contao\contao\core-bundle\contao\classes\Backend.php:546)
  at Contao\Backend->getBackendModule()
     (vendor\contao\contao\core-bundle\contao\controllers\BackendMain.php:144)
  at Contao\BackendMain->run()
     (vendor\contao\contao\core-bundle\src\Controller\BackendController.php:44)
  at Contao\CoreBundle\Controller\BackendController->mainAction()
     (vendor\symfony\http-kernel\HttpKernel.php:183)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw()
     (vendor\symfony\http-kernel\HttpKernel.php:76)
  at Symfony\Component\HttpKernel\HttpKernel->handle()
     (vendor\symfony\http-kernel\Kernel.php:182)
  at Symfony\Component\HttpKernel\Kernel->handle()
     (public\index.php:42)
```

This is because the regex for partials introduced in https://github.com/contao/contao/pull/7621 also matches `content_element/description_list` (due to the underscore in the content element's type).

This PR changes the regex. It will match

* `content_element/foo/_bar`

But it won't match

* `content_element/foo_bar`
* `content_element/_foo/bar`

Feel free to edit the regex to something more clever 🙃. The tests are updated to include templates with underscore in their name.
