### PR TITLE
Skip fragments which inherit legacy modules in debug:fragments

### DIFF
--- a/core-bundle/src/Command/DebugFragmentsCommand.php
+++ b/core-bundle/src/Command/DebugFragmentsCommand.php
@@ -42,7 +42,13 @@ class DebugFragmentsCommand extends Command
 
         foreach ($fragments as $identifier => $config) {
             $class = new \ReflectionClass(AbstractFragmentController::class);
-            $attributes = $class->getProperty('options')->getValue($this->container->get($config->getController()));
+
+            try {
+                $attributes = $class->getProperty('options')->getValue($this->container->get($config->getController()));
+            } catch (\ReflectionException $e) {
+                continue; // skip fragments which don't inherit from AbstractFragmentController
+            }
+
             $controller = $attributes['debugController'] ?? $config->getController();
 
             unset($attributes['debugController']);

--- a/core-bundle/src/Command/DebugFragmentsCommand.php
+++ b/core-bundle/src/Command/DebugFragmentsCommand.php
@@ -45,7 +45,7 @@ class DebugFragmentsCommand extends Command
 
             try {
                 $attributes = $class->getProperty('options')->getValue($this->container->get($config->getController()));
-            } catch (\ReflectionException $e) {
+            } catch (\ReflectionException) {
                 continue; // skip fragments which don't inherit from AbstractFragmentController
             }
 

--- a/core-bundle/tests/Command/DebugFragmentsCommandTest.php
+++ b/core-bundle/tests/Command/DebugFragmentsCommandTest.php
@@ -138,7 +138,7 @@ class DebugFragmentsCommandTest extends TestCase
                 OUTPUT,
         ];
 
-        yield 'Old Contao Modules' => [
+        yield 'Legacy modules' => [
             [
                 ['contao.foo.bar', new FragmentConfig(ModuleArticle::class), []],
             ],

--- a/core-bundle/tests/Command/DebugFragmentsCommandTest.php
+++ b/core-bundle/tests/Command/DebugFragmentsCommandTest.php
@@ -19,6 +19,7 @@ use Contao\CoreBundle\Fragment\FragmentConfig;
 use Contao\CoreBundle\Fragment\FragmentOptionsAwareInterface;
 use Contao\CoreBundle\Fragment\FragmentRegistry;
 use Contao\CoreBundle\Tests\TestCase;
+use Contao\ModuleArticle;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Terminal;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -59,7 +60,10 @@ class DebugFragmentsCommandTest extends TestCase
 
             /** @var FragmentOptionsAwareInterface $instance */
             $instance = (new \ReflectionClass($config->getController()))->newInstanceWithoutConstructor();
-            $instance->setFragmentOptions($options);
+
+            if ($instance instanceof FragmentOptionsAwareInterface) {
+                $instance->setFragmentOptions($options);
+            }
 
             $container->set($config->getController(), $instance);
         }
@@ -129,6 +133,23 @@ class DebugFragmentsCommandTest extends TestCase
                   contao.foo.bar   Contao\CoreBundle\Fixtures\Controller\FrontendModule\TestController   esi        ignore_errors : false   category : esi
                                                                                                                                             foo      : bar
                  ---------------- --------------------------------------------------------------------- ---------- ----------------------- ------------------
+
+
+                OUTPUT,
+        ];
+
+        yield 'Old Contao Modules' => [
+            [
+                ['contao.foo.bar', new FragmentConfig(ModuleArticle::class), []],
+            ],
+            <<<'OUTPUT'
+
+                Contao Fragments
+                ================
+
+                 ------------ ------------ ---------- ---------------- ------------------
+                  Identifier   Controller   Renderer   Render Options   Fragment Options
+                 ------------ ------------ ---------- ---------------- ------------------
 
 
                 OUTPUT,


### PR DESCRIPTION
After installation of the `terminal42/notification_center` (just as an example) my `debug:fragments` command is broken:

```
In DebugFragmentsCommand.php line 46:
                                                                              
  Given object is not an instance of the class this property was declared in  
                                                                              

debug:fragments
```

The `LostPasswordController` is registered as a fragment but extends a legacy module (which is fine!):

https://github.com/terminal42/contao-notification_center/blob/ffffe5f78743906de6ef09dcb1ccddda3a6ed190/src/Controller/FrontendModule/LostPasswordController.php#L20