### PR TITLE
Use the return value of the `InvalidateCacheTagsEvent`

### DIFF
--- a/core-bundle/src/Cache/CacheTagInvalidator.php
+++ b/core-bundle/src/Cache/CacheTagInvalidator.php
@@ -25,8 +25,10 @@ class CacheTagInvalidator
             return $this;
         }
 
-        $this->eventDispatcher->dispatch(new InvalidateCacheTagsEvent($tags));
-        $this->cacheInvalidator?->invalidateTags($tags);
+        $event = new InvalidateCacheTagsEvent($tags);
+
+        $this->eventDispatcher->dispatch($event);
+        $this->cacheInvalidator?->invalidateTags($event->getTags());
 
         return $this;
     }


### PR DESCRIPTION
I may be missing something, but shouldn‘t we use the return value of the event here?