### PR TITLE
Decode entities for favorites labels

### DIFF
--- a/core-bundle/src/EventListener/Menu/BackendFavoritesListener.php
+++ b/core-bundle/src/EventListener/Menu/BackendFavoritesListener.php
@@ -15,6 +15,7 @@ namespace Contao\CoreBundle\EventListener\Menu;
 use Contao\BackendUser;
 use Contao\CoreBundle\Csrf\ContaoCsrfTokenManager;
 use Contao\CoreBundle\Event\MenuEvent;
+use Contao\StringUtil;
 use Doctrine\DBAL\Connection;
 use Knp\Menu\FactoryInterface;
 use Knp\Menu\ItemInterface;
@@ -170,10 +171,10 @@ class BackendFavoritesListener
 
             $item = $factory
                 ->createItem('favorite_'.$node['id'])
-                ->setLabel($node['title'])
+                ->setLabel(StringUtil::decodeEntities($node['title']))
                 ->setUri($node['url'].(str_contains((string) $node['url'], '?') ? '&' : '?').'ref='.$ref)
                 ->setLinkAttribute('class', 'navigation')
-                ->setLinkAttribute('title', $node['title'])
+                ->setLinkAttribute('title', StringUtil::decodeEntities($node['title']))
                 ->setCurrent($node['url'] === $requestUri)
                 ->setExtra('translation_domain', false)
             ;

--- a/core-bundle/tests/EventListener/Menu/BackendFavoritesListenerTest.php
+++ b/core-bundle/tests/EventListener/Menu/BackendFavoritesListenerTest.php
@@ -108,7 +108,7 @@ class BackendFavoritesListenerTest extends TestCase
                         'id' => 8,
                         'pid' => 7,
                         'tstamp' => 1671538402,
-                        'title' => 'Edit fe_page',
+                        'title' => 'Edit &quot;fe_page&quot;',
                         'url' => '/contao?do=tpl_editor&act=source&id=templates%2Ffe_page.html5',
                     ],
                 ],
@@ -180,13 +180,13 @@ class BackendFavoritesListenerTest extends TestCase
         );
 
         $this->assertSame('favorite_8', $grandChildren[1]->getName());
-        $this->assertSame('Edit fe_page', $grandChildren[1]->getLabel());
+        $this->assertSame('Edit "fe_page"', $grandChildren[1]->getLabel());
         $this->assertSame('/contao?do=tpl_editor&act=source&id=templates%2Ffe_page.html5&ref=foobar', $grandChildren[1]->getUri());
 
         $this->assertSame(
             [
                 'class' => 'navigation',
-                'title' => 'Edit fe_page',
+                'title' => 'Edit "fe_page"',
             ],
             $grandChildren[1]->getLinkAttributes(),
         );


### PR DESCRIPTION
Fixes #7706 

Contao uses input encoding, thus we need to decode the entities when adding them to the navigation.