### PR TITLE
Strip root dir from normalized path

### DIFF
--- a/core-bundle/contao/library/Contao/StringUtil.php
+++ b/core-bundle/contao/library/Contao/StringUtil.php
@@ -1070,7 +1070,7 @@ class StringUtil
 			throw new \InvalidArgumentException(\sprintf('Path "%s" is not inside the Contao root dir "%s"', $path, $projectDir));
 		}
 
-		return substr($path, $length + 1);
+		return substr($normalizedPath, $length + 1);
 	}
 
 	/**

--- a/core-bundle/tests/Contao/StringUtilTest.php
+++ b/core-bundle/tests/Contao/StringUtilTest.php
@@ -197,9 +197,9 @@ class StringUtilTest extends TestCase
         $this->assertSame('foo', StringUtil::stripRootDir($this->getFixturesDir().'/foo'));
         $this->assertSame('foo', StringUtil::stripRootDir($this->getFixturesDir().'\foo'));
         $this->assertSame('foo/', StringUtil::stripRootDir($this->getFixturesDir().'/foo/'));
-        $this->assertSame('foo\\', StringUtil::stripRootDir($this->getFixturesDir().'\foo\\'));
+        $this->assertSame('foo/', StringUtil::stripRootDir($this->getFixturesDir().'\foo\\'));
         $this->assertSame('foo/bar', StringUtil::stripRootDir($this->getFixturesDir().'/foo/bar'));
-        $this->assertSame('foo\bar', StringUtil::stripRootDir($this->getFixturesDir().'\foo\bar'));
+        $this->assertSame('foo/bar', StringUtil::stripRootDir($this->getFixturesDir().'\foo\bar'));
         $this->assertSame('../../foo/bar', StringUtil::stripRootDir($this->getFixturesDir().'/../../foo/bar'));
     }
 


### PR DESCRIPTION
In #1918 we changed `StringUtil::stripRootDir()` so that it normalizes both the `kernel.project_dir` and the given `$path` before stripping the the former from the latter.

However, in actuality the root dir is still stripped from the original, pre-normalized path. This still works, because normalizing would not change the length of the path - unless you have a weird operating-/filesystem with multiple character directory separators :) (not that that would be supported by PHP anyways).

However, I do think that technically we should strip from the _normalized_ path - and thus also return a normalized path (just like all `Path` methods would).

Btw. alternatively we could also use `Path::makeRelative($path, $projectDir)` instead and then for the exception check if the path starts with `../`?

@m-vo wdyt?

Changing this would also automatically fix another minor issue: in https://github.com/contao/contao/pull/7094 a new feature was introduced where you can now use container parameters for the `TL_PURGE` tasks, like so:

```php
// contao/config/config.php
use App\Maintenance\PurgeFoobarFolder;

$GLOBALS['TL_PURGE']['folders']['foobar'] = [
    'callback' => [PurgeFoobarFolder::class, '__invoke'],
    'affected' => ['%kernel.cache_dir%/foobar'],
];
```

However, this results in mixed directory separators:

![Screen Shot 2024-11-10 at 10 30 09](https://github.com/user-attachments/assets/2db1e069-c7f2-4fd2-a96c-a59cf73420d7)

Merging this PR upstream would automatically fix this, since `PurgeData` uses `StringUtil::stripRootDir()` and then the path would already be normalized.