### PR TITLE
Index pages using their canonical URL

### DIFF
--- a/core-bundle/src/Search/Indexer/DefaultIndexer.php
+++ b/core-bundle/src/Search/Indexer/DefaultIndexer.php
@@ -39,10 +39,6 @@ class DefaultIndexer implements IndexerInterface
             $this->throwBecause('Cannot index empty response.');
         }
 
-        if (($canonical = $document->extractCanonicalUri()) && (string) $canonical !== (string) $document->getUri()) {
-            $this->throwBecause(\sprintf('Ignored because canonical URI "%s" does not match document URI.', $canonical));
-        }
-
         try {
             $title = $document->getContentCrawler()->filterXPath('//head/title')->first()->text();
         } catch (\Exception) {
@@ -89,7 +85,7 @@ class DefaultIndexer implements IndexerInterface
 
         try {
             $search->indexPage([
-                'url' => (string) $document->getUri(),
+                'url' => (string) ($document->extractCanonicalUri() ?? $document->getUri()),
                 'content' => $document->getBody(),
                 'protected' => (bool) $meta['protected'],
                 'groups' => $meta['groups'],

--- a/core-bundle/tests/Search/Indexer/DefaultIndexerTest.php
+++ b/core-bundle/tests/Search/Indexer/DefaultIndexerTest.php
@@ -68,10 +68,46 @@ class DefaultIndexerTest extends TestCase
             'Cannot index empty response.',
         ];
 
-        yield 'Test does not index if rel="canonical" does not match current page' => [
-            new Document(new Uri('https://example.com/page'), 200, [], '<html><head><link rel="canonical" href="https://example.com/other-page" /></head><body></body></html>'),
-            null,
-            'Ignored because canonical URI "https://example.com/other-page" does not match document URI.',
+        yield 'Test does index the canonical URL if rel="canonical" is set' => [
+            new Document(new Uri('https://example.com/page?with=query'), 200, [], '<html><head><link rel="canonical" href="https://example.com/page" /></head><body><script type="application/ld+json">{"@context":{"contao":"https:\/\/schema.contao.org\/"},"@type":"contao:Page","contao:title":"JSON-LD page title","contao:pageId":2}</script></body></html>'),
+            [
+                'url' => 'https://example.com/page',
+                'content' => '<html><head><link rel="canonical" href="https://example.com/page" /></head><body><script type="application/ld+json">{"@context":{"contao":"https:\/\/schema.contao.org\/"},"@type":"contao:Page","contao:title":"JSON-LD page title","contao:pageId":2}</script></body></html>',
+                'protected' => false,
+                'groups' => [],
+                'pid' => 2,
+                'title' => 'JSON-LD page title',
+                'language' => 'en',
+                'meta' => [
+                    [
+                        '@context' => ['contao' => 'https://schema.contao.org/'],
+                        '@type' => 'https://schema.contao.org/Page',
+                        'https://schema.contao.org/title' => 'JSON-LD page title',
+                        'https://schema.contao.org/pageId' => 2,
+                    ],
+                ],
+            ],
+        ];
+
+        yield 'Test does index the canonical URL if rel="canonical" is set to a different domain' => [
+            new Document(new Uri('https://example.com/page'), 200, [], '<html><head><link rel="canonical" href="https://example.org/other-page" /></head><body><script type="application/ld+json">{"@context":{"contao":"https:\/\/schema.contao.org\/"},"@type":"contao:Page","contao:title":"JSON-LD page title","contao:pageId":2}</script></body></html>'),
+            [
+                'url' => 'https://example.org/other-page',
+                'content' => '<html><head><link rel="canonical" href="https://example.org/other-page" /></head><body><script type="application/ld+json">{"@context":{"contao":"https:\/\/schema.contao.org\/"},"@type":"contao:Page","contao:title":"JSON-LD page title","contao:pageId":2}</script></body></html>',
+                'protected' => false,
+                'groups' => [],
+                'pid' => 2,
+                'title' => 'JSON-LD page title',
+                'language' => 'en',
+                'meta' => [
+                    [
+                        '@context' => ['contao' => 'https://schema.contao.org/'],
+                        '@type' => 'https://schema.contao.org/Page',
+                        'https://schema.contao.org/title' => 'JSON-LD page title',
+                        'https://schema.contao.org/pageId' => 2,
+                    ],
+                ],
+            ],
         ];
 
         yield 'Test does not index if page ID could not be determined' => [


### PR DESCRIPTION
Currently we do not index any pages if their canonical URL does not point to the exact same document URL.

Relying only on indexing via the terminate event, this can cause canonical pages to never get indexed if they are always requested using a query string or something similar.

Also if the canonical URL points to a different domain, that page would never get indexed.

This pull request allows such pages to get indexed, but it indexes them using the canonical URL instead of the requested URL. I think this way the original issue that was fixed by https://github.com/contao/contao/pull/3617 is still addressed, as superfluous query strings or duplicated content still does not show up in the search results.

- [ ] Backport PR to 4.13

/cc @Toflar 