### PR TITLE
Consider the `doNotDeleteRecords` setting when deleting child records

### DIFF
--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -3750,7 +3750,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 			}
 		}
 
-		// Delete all records of the current table that are not related to the parent table, unless configured not to
+		// Delete all records of the current table that are not related to the parent table
 		if ($ptable && !($GLOBALS['TL_DCA'][$this->strTable]['config']['doNotDeleteRecords'] ?? null))
 		{
 			if ($GLOBALS['TL_DCA'][$this->strTable]['config']['dynamicPtable'] ?? null)
@@ -3777,7 +3777,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 			}
 		}
 
-		// Delete all records of the child table that are not related to the current table, unless configured not to
+		// Delete all records of the child table that are not related to the current table
 		if (!empty($ctable) && \is_array($ctable))
 		{
 			foreach ($ctable as $v)
@@ -3787,10 +3787,10 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 					// Load the DCA configuration, so we can check for "dynamicPtable" and "doNotDeleteRecords"
 					$this->loadDataContainer($v);
 
-                    if ($GLOBALS['TL_DCA'][$v]['config']['doNotDeleteRecords'] ?? null)
-                    {
-                        continue;
-                    }
+					if ($GLOBALS['TL_DCA'][$v]['config']['doNotDeleteRecords'] ?? null)
+					{
+						continue;
+					}
 
 					if ($GLOBALS['TL_DCA'][$v]['config']['dynamicPtable'] ?? null)
 					{

--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -3750,8 +3750,8 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 			}
 		}
 
-		// Delete all records of the current table that are not related to the parent table
-		if ($ptable)
+		// Delete all records of the current table that are not related to the parent table, unless configured not to
+		if ($ptable && !($GLOBALS['TL_DCA'][$this->strTable]['config']['doNotDeleteRecords'] ?? null))
 		{
 			if ($GLOBALS['TL_DCA'][$this->strTable]['config']['dynamicPtable'] ?? null)
 			{
@@ -3777,15 +3777,20 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 			}
 		}
 
-		// Delete all records of the child table that are not related to the current table
+		// Delete all records of the child table that are not related to the current table, unless configured not to
 		if (!empty($ctable) && \is_array($ctable))
 		{
 			foreach ($ctable as $v)
 			{
 				if ($v)
 				{
-					// Load the DCA configuration, so we can check for "dynamicPtable"
+					// Load the DCA configuration, so we can check for "dynamicPtable" and "doNotDeleteRecords"
 					$this->loadDataContainer($v);
+
+                    if ($GLOBALS['TL_DCA'][$v]['config']['doNotDeleteRecords'] ?? null)
+                    {
+                        continue;
+                    }
 
 					if ($GLOBALS['TL_DCA'][$v]['config']['dynamicPtable'] ?? null)
 					{


### PR DESCRIPTION
Issue:
The "doNotDeleteRecords" dca setting does not keep records from being deleted. Stumbled upon this while programmatically creating records with pid 0 that kept disappearing seemingly at random.

Cause:
Once you view the affected table or its parent table in the backend, DC_Table's reviseTable method deletes orphaned records, without checking the "doNotDeleteRecords" setting.

How to reproduce:
1) Configure "doNotDeleteRecords" for e.g. tl_layout:
```php
$GLOBALS['TL_DCA']['tl_layout']['config']['doNotDeleteRecords'] = true;
```
2) Create a new theme
3) Create a new layout for said theme
4) Delete the theme

The record is now gone, despite the dca setting.