### PR TITLE
Cache hot path in model

### DIFF
--- a/core-bundle/contao/library/Contao/Model.php
+++ b/core-bundle/contao/library/Contao/Model.php
@@ -375,11 +375,18 @@ abstract class Model
 	 */
 	public function setRow(array $arrData)
 	{
-		foreach ($arrData as $k=>$v)
+		// This is a hot path so caching those statically is worth a lot in big websites
+		static $keyToKeep = array();
+
+		foreach ($arrData as $k => $v)
 		{
-			if (str_contains($k, '__'))
+			if (!isset($keyToKeep[$k]) && str_contains($k, '__'))
 			{
 				unset($arrData[$k]);
+			}
+			else
+			{
+				$keyToKeep[$k] = true;
 			}
 		}
 

--- a/core-bundle/contao/library/Contao/Model.php
+++ b/core-bundle/contao/library/Contao/Model.php
@@ -1468,13 +1468,6 @@ abstract class Model
 	{
 		static $cache = array();
 
-		if (isset($cache[$key]))
-		{
-			return $cache[$key];
-		}
-
-		$cache[$key] = str_contains($key, '__');
-
-		return $cache[$key];
+		return $cache[$key] ??= str_contains($key, '__');
 	}
 }


### PR DESCRIPTION
For big websites with lots of content elements, `Model::setRow()` is a hot path. In my case `str_contains()` is called 394 000 times 🤯 A lot of those are coming from `Model::setRow()`.

Those calls can be reduced significantly because the keys (db columns) are the same no matter the model instance.
Bye, bye, 150 000 useless calls.


<img width="433" alt="Bildschirmfoto 2024-11-15 um 13 36 34" src="https://github.com/user-attachments/assets/62189ca3-5fee-493d-a490-3fb4af38fab5">
