### PR TITLE
Canonicalize purge paths

### DIFF
--- a/core-bundle/contao/classes/PurgeData.php
+++ b/core-bundle/contao/classes/PurgeData.php
@@ -10,6 +10,7 @@
 
 namespace Contao;
 
+use Symfony\Component\Filesystem\Path;
 use Symfony\Component\Finder\Finder;
 
 /**
@@ -104,7 +105,7 @@ class PurgeData extends Backend implements MaintenanceModuleInterface
 			{
 				if (str_contains($folder, '%'))
 				{
-					$folder = StringUtil::stripRootDir($parameterBag->resolveValue($folder));
+					$folder = Path::canonicalize(StringUtil::stripRootDir($parameterBag->resolveValue($folder)));
 				}
 
 				$total = 0;


### PR DESCRIPTION
In https://github.com/contao/contao/pull/7094 a new feature was introduced where you can now use container parameters for the `TL_PURGE` tasks, like so:

```php
// contao/config/config.php
use App\Maintenance\PurgeFoobarFolder;

$GLOBALS['TL_PURGE']['folders']['foobar'] = [
    'callback' => [PurgeFoobarFolder::class, '__invoke'],
    'affected' => ['%kernel.cache_dir%/foobar'],
];
```

However, this results in mixed directory separators in the back end display:

![Screen Shot 2024-11-10 at 10 30 09](https://github.com/user-attachments/assets/2db1e069-c7f2-4fd2-a96c-a59cf73420d7)

This PR fixes that by normalizing the path. It also canonicalizes the path, so that something like `%kernel.cache_dir%/../foobar` would automatically resolve to `var/cache/foobar` instead of `var/cache/prod/../foobar`.