### PR TITLE
Show section headlines in the back end preview

### DIFF
--- a/core-bundle/contao/dca/tl_content.php
+++ b/core-bundle/contao/dca/tl_content.php
@@ -965,6 +965,16 @@ class tl_content extends Backend
 		$class = 'cte_preview';
 		$preview = StringUtil::insertTagToSrc($this->getContentElement($objModel));
 
+		if (!empty($arrRow['sectionHeadline']))
+		{
+			$sectionHeadline = StringUtil::deserialize($arrRow['sectionHeadline'], true);
+
+			if (!empty($sectionHeadline['value']) && !empty($sectionHeadline['unit']))
+			{
+				$preview = '<' . $sectionHeadline['unit'] . '>' . $sectionHeadline['value'] . '</' . $sectionHeadline['unit'] . '>' . $preview;
+			}
+		}
+
 		// Strip HTML comments to check if the preview is empty
 		if (trim(preg_replace('/<!--(.|\s)*?-->/', '', $preview)) == '')
 		{


### PR DESCRIPTION
Fixes #7392

<img width="666" alt="" src="https://github.com/user-attachments/assets/26d7fed8-62d2-419b-872c-f520935d49f1">
