### PR TITLE
Make the slots concept compatible with Twig 3.15

### DIFF
--- a/core-bundle/src/Twig/Extension/ContaoExtension.php
+++ b/core-bundle/src/Twig/Extension/ContaoExtension.php
@@ -48,6 +48,7 @@ use Contao\StringUtil;
 use Contao\Template;
 use Symfony\Component\Filesystem\Path;
 use Twig\Environment;
+use Twig\Error\SyntaxError;
 use Twig\Extension\AbstractExtension;
 use Twig\Extension\CoreExtension;
 use Twig\Extension\GlobalsInterface;
@@ -239,6 +240,10 @@ final class ContaoExtension extends AbstractExtension implements GlobalsInterfac
             new TwigFunction(
                 'content_url',
                 [ContentUrlRuntime::class, 'generate'],
+            ),
+            new TwigFunction(
+                'slot',
+                static fn () => throw new SyntaxError('You cannot use the slot() function outside of a slot.'),
             ),
         ];
     }

--- a/core-bundle/src/Twig/Slots/SlotTokenParser.php
+++ b/core-bundle/src/Twig/Slots/SlotTokenParser.php
@@ -16,6 +16,7 @@ use Twig\Node\Expression\AbstractExpression;
 use Twig\Node\Expression\ConstantExpression;
 use Twig\Node\Expression\Filter\RawFilter;
 use Twig\Node\Expression\FilterExpression;
+use Twig\Node\Expression\FunctionExpression;
 use Twig\Node\Expression\GetAttrExpression;
 use Twig\Node\Expression\NameExpression;
 use Twig\Node\Node;
@@ -36,16 +37,10 @@ final class SlotTokenParser extends AbstractTokenParser
         $nameToken = $stream->expect(Token::NAME_TYPE, null, '');
         $stream->expect(Token::BLOCK_END_TYPE);
 
-        // Parse body: we inject a macro symbol with a marker expression to support the
-        // virtual slot() function when parsing the following tokens. Then the marker
-        // expression gets replaced again with a SlotContentNode that outputs the slot
-        // content at runtime.
-        $markerExpression = new ConstantExpression('', 0);
-        $this->parser->addImportedSymbol('function', 'slot', '', $markerExpression);
         $body = $this->parser->subparse($this->decideForFork(...));
 
         if ($body->count()) {
-            $this->traverseAndReplaceMarkerExpression($markerExpression, $nameToken->getValue(), $body);
+            $this->traverseAndReplaceSlotFunction($nameToken->getValue(), $body);
         } else {
             $line = $stream->getCurrent()->getLine();
             $body->setNode('body', new PrintNode($this->getSlotReferenceExpression($nameToken->getValue(), $line), $line));
@@ -79,11 +74,11 @@ final class SlotTokenParser extends AbstractTokenParser
         return 'slot';
     }
 
-    private function traverseAndReplaceMarkerExpression(AbstractExpression $markerExpression, string $name, Node $node, array $parents = []): void
+    private function traverseAndReplaceSlotFunction(string $name, Node $node, Node|null $parent = null): void
     {
-        if ($node === $markerExpression) {
+        if ($node instanceof FunctionExpression && 'slot' === $node->getAttribute('name')) {
             /** @var Node $target */
-            $target = $parents[1];
+            $target = $parent;
 
             foreach (array_keys(iterator_to_array($target)) as $key) {
                 $target->removeNode((string) $key);
@@ -95,7 +90,7 @@ final class SlotTokenParser extends AbstractTokenParser
         }
 
         foreach ($node as $child) {
-            $this->traverseAndReplaceMarkerExpression($markerExpression, $name, $child, [$node, ...$parents]);
+            $this->traverseAndReplaceSlotFunction($name, $child, $node);
         }
     }
 

--- a/core-bundle/tests/Twig/Extension/ContaoExtensionTest.php
+++ b/core-bundle/tests/Twig/Extension/ContaoExtensionTest.php
@@ -39,15 +39,16 @@ use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Fragment\FragmentHandler;
 use Twig\Attribute\FirstClassTwigCallableReady;
 use Twig\Environment;
+use Twig\Error\SyntaxError;
 use Twig\Extension\AbstractExtension;
 use Twig\Extension\CoreExtension;
 use Twig\Extension\EscaperExtension;
+use Twig\Loader\ArrayLoader;
 use Twig\Node\BodyNode;
 use Twig\Node\Expression\ConstantExpression;
 use Twig\Node\Expression\FilterExpression;
 use Twig\Node\ModuleNode;
 use Twig\Node\Node;
-use Twig\Node\TextNode;
 use Twig\NodeTraverser;
 use Twig\Runtime\EscaperRuntime;
 use Twig\Source;
@@ -109,6 +110,7 @@ class ContaoExtensionTest extends TestCase
             'csp_source' => [],
             'csp_hash' => [],
             'content_url' => [],
+            'slot' => [],
         ];
 
         $functions = $this->getContaoExtension()->getFunctions();
@@ -124,6 +126,20 @@ class ContaoExtensionTest extends TestCase
             $this->assertArrayHasKey($name, $expectedFunctions);
             $this->assertSame($expectedFunctions[$name], $function->getSafe($node), $name);
         }
+    }
+
+    public function testPreventsUseOfSlotFunction(): void
+    {
+        $environment = new Environment(
+            new ArrayLoader(['template.html.twig' => 'foo {{ slot() }} bar']),
+        );
+
+        $environment->addExtension($this->getContaoExtension());
+
+        $this->expectException(SyntaxError::class);
+        $this->expectExceptionMessage('You cannot use the slot() function outside of a slot');
+
+        $environment->render('template.html.twig');
     }
 
     public function testAddsTheFilters(): void
@@ -230,7 +246,7 @@ class ContaoExtensionTest extends TestCase
         $node = new ModuleNode(
             new BodyNode([
                 new FilterExpression(
-                    new TextNode('text', 1),
+                    new ConstantExpression('text', 1),
                     $filter,
                     new Node([
                         new ConstantExpression('html', 1),


### PR DESCRIPTION
This PR changes how we evaluate the virtual `slot()` function due to the changes in https://github.com/twigphp/Twig/pull/4398. Now it is a real function that prevents itself from being executed instead of a marker expression.
