### PR TITLE
Disable Turbo in `MODE_PARENT` content section

### DIFF
--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -4899,9 +4899,9 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 				}
 
 				$return .= '
-<div class="tl_content' . ($blnWrapperStart ? ' wrapper_start' : '') . ($blnWrapperSeparator ? ' wrapper_separator' : '') . ($blnWrapperStop ? ' wrapper_stop' : '') . ($blnIndent ? ' indent indent_' . $intWrapLevel : '') . ($blnIndentFirst ? ' indent_first' : '') . ($blnIndentLast ? ' indent_last' : '') . ((string) $row[$i]['tstamp'] === '0' ? ' draft' : '') . (!empty($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['child_record_class']) ? ' ' . $GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['child_record_class'] : '') . ' click2edit toggle_select">
+<div class="tl_content' . ($blnWrapperStart ? ' wrapper_start' : '') . ($blnWrapperSeparator ? ' wrapper_separator' : '') . ($blnWrapperStop ? ' wrapper_stop' : '') . ($blnIndent ? ' indent indent_' . $intWrapLevel : '') . ($blnIndentFirst ? ' indent_first' : '') . ($blnIndentLast ? ' indent_last' : '') . ((string) $row[$i]['tstamp'] === '0' ? ' draft' : '') . (!empty($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['child_record_class']) ? ' ' . $GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['child_record_class'] : '') . ' click2edit toggle_select" data-turbo="false">
 <div class="inside hover-div"' . ($limitHeight && !$blnWrapperStart && !$blnWrapperStop && !$blnWrapperSeparator ? ' data-contao--limit-height-target="node"' : '') . '>
-<div class="tl_content_right">';
+<div class="tl_content_right" data-turbo="true">';
 
 				// Opening wrappers
 				if ($blnWrapperStart && ++$intWrapLevel > 0)


### PR DESCRIPTION
We do not want Turbo to react to any preview that is output in the back end, e.g. for the parent view of articles where the content elements for the front end are rendered. With https://github.com/contao/contao/pull/7597 this should be a non-issue - however there is a bug in Turbo that prevents Turbo from working properly because of it. But irrespective of this issue it makes sense to disable Turbo for certain back end areas - like the previews in `MODE_PARENT`.

There is two ways to go about it: either add `data-turbo="false"` only to the `<div class="cte_preview">` (which would have to be implemented for each `label_callback` of every DCA) - or we disable it for the whole `tl_content` section of the parent view - and then re-enable Turbo for the operations for example (the `tl_content_right` section).

This PR implements the latter.
