### PR TITLE
Reduce redundant disallow rules in robots.txt

### DIFF
--- a/core-bundle/src/EventListener/RobotsTxtListener.php
+++ b/core-bundle/src/EventListener/RobotsTxtListener.php
@@ -58,8 +58,11 @@ class RobotsTxtListener
 
         foreach ($records as $record) {
             $directiveList = $record->getDirectiveList();
-            $directiveList->add(new Directive('Disallow', $this->routePrefix.'/'));
-            $directiveList->add(new Directive('Disallow', '/_contao/'));
+
+            if ( !(1 === $directiveList->getLength() && $directiveList->first()->getField() == 'disallow' && (string)$directiveList->first()->getValue() == '/') ) {
+                $directiveList->add(new Directive('Disallow', $this->routePrefix.'/'));
+                $directiveList->add(new Directive('Disallow', '/_contao/'));
+            }
 
             if ($this->webDebugToolbarListener?->isEnabled()) {
                 $directiveList->add(new Directive('Disallow', '/_profiler/'));

--- a/news-bundle/tests/EventListener/NewsFeedListenerTest.php
+++ b/news-bundle/tests/EventListener/NewsFeedListenerTest.php
@@ -166,6 +166,7 @@ class NewsFeedListenerTest extends ContaoTestCase
             'date' => 1656578758,
             'headline' => $headline[0],
             'teaser' => $content[0],
+            'addImage' => true,
             'singleSRC' => 'binary_uuid',
             'addEnclosure' => serialize(['binary_uuid2']),
         ]);

--- a/news-bundle/tests/EventListener/NewsFeedListenerTest.php
+++ b/news-bundle/tests/EventListener/NewsFeedListenerTest.php
@@ -166,7 +166,6 @@ class NewsFeedListenerTest extends ContaoTestCase
             'date' => 1656578758,
             'headline' => $headline[0],
             'teaser' => $content[0],
-            'addImage' => true,
             'singleSRC' => 'binary_uuid',
             'addEnclosure' => serialize(['binary_uuid2']),
         ]);


### PR DESCRIPTION
Do not add contao disallow rules to a directive when the directive contains only one line with disallow:/

Fixes #7742 

Explained:

The contao disallow rules are not added, when
- there is only one directive within the record (= one line)
`1 === $directiveList->getLength()`
- AND the field name of the record is 'disallow'
`$directiveList->first()->getField() == 'disallow'`
- AND the value is '/'
`(string)$directiveList->first()->getValue() == '/'`

getLenght(), first(), getField() etc. are used according to [webignition/robots-txt-file/[...]DirectiveList.php](https://github.com/webignition/robots-txt-file/blob/master/src/DirectiveList/DirectiveList.php)

The contao disallow rules are still added when there are multiple rules within the directive or the directive is not disallow:/