### PR TITLE
Enable double encoding for JSON in Twig

### DIFF
--- a/core-bundle/src/Twig/Interop/ContaoEscaper.php
+++ b/core-bundle/src/Twig/Interop/ContaoEscaper.php
@@ -43,12 +43,12 @@ final class ContaoEscaper
 
         $string = (string) $string;
 
-        return htmlspecialchars($string, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8', false);
+        return htmlspecialchars($string, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8', 1 === preg_match('/["\'<>]/', $string));
     }
 
     /**
-     * This implementation is a clone of Twig's html_attr escape strategy but
-     * replaces insert tags and decodes entities beforehand.
+     * This implementation is a clone of Twig's html_attr escape strategy but decodes
+     * entities beforehand.
      *
      * @param mixed $string
      *
@@ -61,7 +61,10 @@ final class ContaoEscaper
         }
 
         $string = (string) $string;
-        $string = StringUtil::decodeEntities($string);
+
+        if (1 !== preg_match('/["\'<>]/', $string)) {
+            $string = StringUtil::decodeEntities($string);
+        }
 
         // Original logic
         if (!preg_match('//u', $string)) {

--- a/core-bundle/src/Twig/Interop/ContaoEscaperNodeVisitor.php
+++ b/core-bundle/src/Twig/Interop/ContaoEscaperNodeVisitor.php
@@ -104,6 +104,17 @@ final class ContaoEscaperNodeVisitor implements NodeVisitorInterface
             return false;
         }
 
+        $doubleEncode = $node->getNode('arguments')->hasNode('double_encode') ? $node->getNode('arguments')->getNode('double_encode') : null;
+
+        if ($doubleEncode instanceof ConstantExpression && \is_bool($doubleEncode->getAttribute('value'))) {
+            $node->getNode('arguments')->removeNode('double_encode');
+
+            // Do not use the Contao escaper if `double_encode = true` is passed
+            if ($doubleEncode->getAttribute('value')) {
+                return false;
+            }
+        }
+
         // Do not use the Contao escaper after the `json_encode` filter to prevent issues
         // with `double_encode: false`
         if ($node->getNode('node') instanceof FilterExpression && 'json_encode' === $node->getNode('node')->getNode('filter')->getAttribute('value')) {

--- a/core-bundle/src/Twig/Interop/ContaoEscaperNodeVisitor.php
+++ b/core-bundle/src/Twig/Interop/ContaoEscaperNodeVisitor.php
@@ -104,6 +104,12 @@ final class ContaoEscaperNodeVisitor implements NodeVisitorInterface
             return false;
         }
 
+        // Do not use the Contao escaper after the `json_encode` filter to prevent issues
+        // with `double_encode: false`
+        if ($node->getNode('node') instanceof FilterExpression && 'json_encode' === $node->getNode('node')->getNode('filter')->getAttribute('value')) {
+            return false;
+        }
+
         $type = $argument->getAttribute('value');
 
         return true;

--- a/core-bundle/src/Twig/Interop/ContaoEscaperNodeVisitor.php
+++ b/core-bundle/src/Twig/Interop/ContaoEscaperNodeVisitor.php
@@ -115,12 +115,6 @@ final class ContaoEscaperNodeVisitor implements NodeVisitorInterface
             }
         }
 
-        // Do not use the Contao escaper after the `json_encode` filter to prevent issues
-        // with `double_encode: false`
-        if ($node->getNode('node') instanceof FilterExpression && 'json_encode' === $node->getNode('node')->getNode('filter')->getAttribute('value')) {
-            return false;
-        }
-
         $type = $argument->getAttribute('value');
 
         return true;

--- a/core-bundle/tests/Twig/Extension/ContaoExtensionTest.php
+++ b/core-bundle/tests/Twig/Extension/ContaoExtensionTest.php
@@ -189,6 +189,7 @@ class ContaoExtensionTest extends TestCase
         $node = new ModuleNode(
             /** @phpstan-ignore argument.type */
             new FilterExpression(
+                /** @phpstan-ignore argument.type */
                 new TextNode('text', 1),
                 new ConstantExpression('escape', 1),
                 new Node([

--- a/core-bundle/tests/Twig/Interop/ContaoEscaperNodeVisitorTest.php
+++ b/core-bundle/tests/Twig/Interop/ContaoEscaperNodeVisitorTest.php
@@ -76,6 +76,17 @@ class ContaoEscaperNodeVisitorTest extends TestCase
         $this->assertSame('<h1>&amp; will look like &amp;</h1><p>This is <i>raw HTML</i>.</p>', $output);
     }
 
+    public function testDoesDoubleEncodeJson(): void
+    {
+        $templateContent = '<div data-json="{{ data|json_encode }}">{{ data }}</div>';
+
+        $output = $this->getEnvironment($templateContent)->render('legacy.html.twig', [
+            'data' => 'foo &quot; bar &quot; baz',
+        ]);
+
+        $this->assertSame('<div data-json="&quot;foo &amp;quot; bar &amp;quot; baz&quot;">foo &quot; bar &quot; baz</div>', $output);
+    }
+
     public function testHandlesFiltersAndFunctions(): void
     {
         $templateContent = '{{ heart() }} {{ target|trim }}';

--- a/core-bundle/tests/Twig/Interop/ContaoEscaperNodeVisitorTest.php
+++ b/core-bundle/tests/Twig/Interop/ContaoEscaperNodeVisitorTest.php
@@ -87,6 +87,28 @@ class ContaoEscaperNodeVisitorTest extends TestCase
         $this->assertSame('<div data-json="&quot;foo &amp;quot; bar &amp;quot; baz&quot;">foo &quot; bar &quot; baz</div>', $output);
     }
 
+    public function testDoesDoubleEncodeByParameter(): void
+    {
+        $templateContent = '<div data-double-encoded="{{ data|e(\'html\', double_encode = true) }}">{{ data|escape(\'html\', double_encode = true) }}</div>';
+
+        $output = $this->getEnvironment($templateContent)->render('legacy.html.twig', [
+            'data' => 'foo &quot; bar &quot; baz',
+        ]);
+
+        $this->assertSame('<div data-double-encoded="foo &amp;quot; bar &amp;quot; baz">foo &amp;quot; bar &amp;quot; baz</div>', $output);
+    }
+
+    public function testDoesNotDoubleEncodeByParameter(): void
+    {
+        $templateContent = '<div data-not-double-encoded="{{ data|e(\'html\', double_encode = false) }}">{{ data|escape(\'html\', double_encode = false) }}</div>';
+
+        $output = $this->getEnvironment($templateContent)->render('legacy.html.twig', [
+            'data' => 'foo &quot; bar &quot; baz',
+        ]);
+
+        $this->assertSame('<div data-not-double-encoded="foo &quot; bar &quot; baz">foo &quot; bar &quot; baz</div>', $output);
+    }
+
     public function testHandlesFiltersAndFunctions(): void
     {
         $templateContent = '{{ heart() }} {{ target|trim }}';

--- a/core-bundle/tests/Twig/Interop/ContaoEscaperTest.php
+++ b/core-bundle/tests/Twig/Interop/ContaoEscaperTest.php
@@ -68,6 +68,16 @@ class ContaoEscaperTest extends TestCase
             '&amp; &AMP; &ZeroWidthSpace; &NotAnEntitiy; &123;',
             '&amp; &AMP; &ZeroWidthSpace; &amp;NotAnEntitiy; &amp;123;',
         ];
+
+        yield 'string with JSON and nested entities' => [
+            '"foo &quot; bar"',
+            '&quot;foo &amp;quot; bar&quot;',
+        ];
+
+        yield 'string with HTML and nested entities' => [
+            '<span data-foo="&quot;">',
+            '&lt;span data-foo=&quot;&amp;quot;&quot;&gt;',
+        ];
     }
 
     /**
@@ -121,6 +131,11 @@ class ContaoEscaperTest extends TestCase
         yield 'prevent double encoding' => [
             'A&amp;B',
             'A&amp;B',
+        ];
+
+        yield 'double encode JSON' => [
+            '"A&quot;B"',
+            '&quot;A&amp;quot&#x3B;B&quot;',
         ];
     }
 


### PR DESCRIPTION
Backport of https://github.com/contao/contao/pull/7556 for Contao 4.13