### PR TITLE
Handle null result in 404 router provider

### DIFF
--- a/core-bundle/src/Routing/Route404Provider.php
+++ b/core-bundle/src/Routing/Route404Provider.php
@@ -99,6 +99,10 @@ class Route404Provider extends AbstractPageRouteProvider
             $pages = $pageAdapter->findBy('tl_page.id IN ('.implode(',', $ids).')', []);
         }
 
+        if (null === $pages) {
+            return [];
+        }
+
         $routes = [];
 
         foreach ($pages as $page) {


### PR DESCRIPTION
No idea how we never noticed… but the router fails if `tl_page` is empty.

Can we cherry-pick this for Contao 5.3?