### PR TITLE
Make sure the correct test-case package is installed in Contao

### DIFF
--- a/test-case/composer.json
+++ b/test-case/composer.json
@@ -11,6 +11,7 @@
     ],
     "require": {
         "php": "^8.1",
+        "contao/core-bundle": "self.version",
         "phpunit/phpunit": "^9.5",
         "symfony/yaml": "^6.4"
     },
@@ -20,9 +21,6 @@
         "doctrine/dbal": "^3.6",
         "doctrine/orm": "^2.17",
         "symfony/http-client": "^6.4"
-    },
-    "conflict": {
-        "contao/core-bundle": "< 5.3 && >= 5.4"
     },
     "autoload": {
         "psr-4": {

--- a/test-case/composer.json
+++ b/test-case/composer.json
@@ -21,6 +21,9 @@
         "doctrine/orm": "^2.17",
         "symfony/http-client": "^6.4"
     },
+    "conflict": {
+        "contao/core-bundle": "< 5.3 && >= 5.4"
+    },
     "autoload": {
         "psr-4": {
             "Contao\\TestCase\\": "src/"


### PR DESCRIPTION
In https://github.com/terminal42/contao-notification_center, we require the `contao/test-case` library to test our extension against different versions of `contao/core-bundle`. If the dependency is `contao/test-case: ^4.13 || ^5.0`, Composer will happily install `contao/test-case: 5.3.x` in a Contao 4.13 setup. This will not work, because `contao/test-case: 5.3` does not support Contao 4.13 (e.g. because of path changes in https://github.com/contao/test-case/blob/5.x/src/ContaoTestCase.php#L401).

Fix bypass this in our own tests by requiring `self.version`, but a third-party package cannot do that. But adding a conflict to every maintained branch should fix this for everyone. So for all other branches in Contao the conflict obviously needs to be adjusted.