### PR TITLE
Fix the sorting when copying multiple form fields as a non-admin user

### DIFF
--- a/core-bundle/contao/dca/tl_form_field.php
+++ b/core-bundle/contao/dca/tl_form_field.php
@@ -473,7 +473,7 @@ class tl_form_field extends Backend
 				else
 				{
 					$objFields = $db
-						->prepare("SELECT id, type FROM tl_form_field WHERE id IN(" . implode(',', array_map('\intval', $session['CLIPBOARD']['tl_form_field']['id'])) . ") AND type IN(" . implode(',', array_fill(0, count($user->fields), '?')) . ")")
+						->prepare("SELECT id, type FROM tl_form_field WHERE id IN(" . implode(',', array_map('\intval', $session['CLIPBOARD']['tl_form_field']['id'])) . ") AND type IN(" . implode(',', array_fill(0, count($user->fields), '?')) . ") ORDER BY sorting")
 						->execute(...$user->fields);
 
 					$session['CLIPBOARD']['tl_form_field']['id'] = $objFields->fetchEach('id');


### PR DESCRIPTION
If you are copying multiple `tl_form_field` records as a non-admin user, the original sorting/order of the elements is not kept, but they are ordered by ID instead. This results in an incorrect order after pasting them.

/cc @aschempp @Toflar 