### PR TITLE
Handle ampersands in the alt attribute of the picture insert tag

### DIFF
--- a/core-bundle/src/InsertTag/Resolver/LegacyInsertTag.php
+++ b/core-bundle/src/InsertTag/Resolver/LegacyInsertTag.php
@@ -501,12 +501,12 @@ class LegacyInsertTag implements InsertTagResolverNestedResolvedInterface
 
                 // Take arguments
                 if (str_contains($insertTag->getParameters()->get(0), '?')) {
-                    $arrChunks = explode('?', urldecode($insertTag->getParameters()->get(0)), 2);
+                    $arrChunks = explode('?', $insertTag->getParameters()->get(0), 2);
                     $strSource = StringUtil::decodeEntities($arrChunks[1]);
                     $arrParams = explode('&', $strSource);
 
                     foreach ($arrParams as $strParam) {
-                        [$key, $value] = explode('=', $strParam);
+                        [$key, $value] = explode('=', urldecode($strParam));
 
                         switch ($key) {
                             case 'width':

--- a/core-bundle/src/InsertTag/Resolver/LegacyInsertTag.php
+++ b/core-bundle/src/InsertTag/Resolver/LegacyInsertTag.php
@@ -506,7 +506,7 @@ class LegacyInsertTag implements InsertTagResolverNestedResolvedInterface
                     $arrParams = explode('&', $strSource);
 
                     foreach ($arrParams as $strParam) {
-                        [$key, $value] = explode('=', urldecode($strParam));
+                        [$key, $value] = explode('=', urldecode($strParam), 2);
 
                         switch ($key) {
                             case 'width':


### PR DESCRIPTION
Fixes https://github.com/contao/contao/issues/7754

When using the picture insert tag, an error message appears if the ALT attribute contains the ampersand. Even if this url was encoded. 

This fix should resolve the error by url decoding the string slightly later. 

But I would be glad if someone could review my fix.
