### PR TITLE
Disallow creating or updating elements with invalid parent record

### DIFF
--- a/core-bundle/src/Security/Voter/DataContainer/AbstractDynamicPtableVoter.php
+++ b/core-bundle/src/Security/Voter/DataContainer/AbstractDynamicPtableVoter.php
@@ -64,7 +64,11 @@ abstract class AbstractDynamicPtableVoter extends AbstractDataContainerVoter imp
         [$table, $id] = [$record['ptable'], (int) $record['pid']];
 
         if ($record['ptable'] === $this->getTable()) {
-            [$table, $id] = $this->getParentTableAndId($id);
+            try {
+                [$table, $id] = $this->getParentTableAndId($id);
+            } catch (\RuntimeException) {
+                return false;
+            }
         }
 
         return $this->hasAccessToRecord($token, $table, $id);


### PR DESCRIPTION
We shouldn't throw an exception if the parent record is not found, but simply disallow the operation. This correctly fixes https://github.com/contao/contao/issues/7728 by disallowing to restore a record if the parent is missing.