### PR TITLE
Check actual file existence instead of DBAFS record

### DIFF
--- a/core-bundle/src/Filesystem/FilesystemUtil.php
+++ b/core-bundle/src/Filesystem/FilesystemUtil.php
@@ -103,7 +103,7 @@ class FilesystemUtil
             try {
                 $uuidObject = Uuid::isValid($uuid) ? Uuid::fromString($uuid) : Uuid::fromBinary($uuid);
 
-                if (!$item = $storage->get($uuidObject)) {
+                if (!$item = $storage->get($uuidObject, VirtualFilesystemInterface::BYPASS_DBAFS)) {
                     continue;
                 }
             } catch (\InvalidArgumentException|UnableToResolveUuidException) {


### PR DESCRIPTION
Fixes https://github.com/contao/contao/issues/7544

`FilesystemUtil::listContentsFromSerialized` currently always returns files if they exist in the DBAFS (`tl_files`) instead of checking if the file actually exists. This can be changed through the flag, but I have no idea if this is the right place.

Since the mentioned method is also (and exclusively) used by the `images` and `download(s)` element, I would think this PR would also fix similar issues like #7544 afecting these elements.