### PR TITLE
Do not normalize the `resampling-filter` array key

### DIFF
--- a/core-bundle/src/DependencyInjection/Configuration.php
+++ b/core-bundle/src/DependencyInjection/Configuration.php
@@ -152,6 +152,7 @@ class Configuration implements ConfigurationInterface
                 ->end()
                 ->arrayNode('imagine_options')
                     ->addDefaultsIfNotSet()
+                    ->normalizeKeys(false)
                     ->children()
                         ->integerNode('jpeg_quality')
                             ->defaultValue(80)

--- a/core-bundle/src/DependencyInjection/Configuration.php
+++ b/core-bundle/src/DependencyInjection/Configuration.php
@@ -152,7 +152,6 @@ class Configuration implements ConfigurationInterface
                 ->end()
                 ->arrayNode('imagine_options')
                     ->addDefaultsIfNotSet()
-                    ->normalizeKeys(false)
                     ->children()
                         ->integerNode('jpeg_quality')
                             ->defaultValue(80)
@@ -188,9 +187,21 @@ class Configuration implements ConfigurationInterface
                             ->info('One of the Imagine\Image\ImageInterface::INTERLACE_* constants.')
                             ->defaultValue(ImageInterface::INTERLACE_PLANE)
                         ->end()
-                        ->scalarNode('resampling-filter')
+                        ->scalarNode('resampling_filter')
                             ->info('Filter used when downsampling images. One of the Imagine\Image\ImageInterface::FILTER_* constants. It has no effect with Gd or SVG as Imagine service.')
                         ->end()
+                    ->end()
+                    ->validate()
+                        ->always(
+                            static function (array $options): array {
+                                if (isset($options['resampling_filter'])) {
+                                    $options['resampling-filter'] = $options['resampling_filter'];
+                                    unset($options['resampling_filter']);
+                                }
+
+                                return $options;
+                            }
+                        )
                     ->end()
                 ->end()
                 ->scalarNode('imagine_service')

--- a/core-bundle/tests/DependencyInjection/ConfigurationTest.php
+++ b/core-bundle/tests/DependencyInjection/ConfigurationTest.php
@@ -276,7 +276,7 @@ class ConfigurationTest extends TestCase
         (new Processor())->processConfiguration($this->configuration, $params);
     }
 
-    public function testDoesNotNormalizeResamplingFilter(): void
+    public function testDoesNormalizeResamplingFilter(): void
     {
         $params = [
             [
@@ -292,6 +292,21 @@ class ConfigurationTest extends TestCase
 
         $this->assertArrayHasKey('resampling-filter', $configuration['image']['imagine_options']);
         $this->assertSame(ImageInterface::FILTER_LANCZOS, $configuration['image']['imagine_options']['resampling-filter']);
+
+        $params = [
+            [
+                'image' => [
+                    'imagine_options' => [
+                        'resampling_filter' => ImageInterface::FILTER_UNDEFINED,
+                    ],
+                ],
+            ],
+        ];
+
+        $configuration = (new Processor())->processConfiguration($this->configuration, $params);
+
+        $this->assertArrayHasKey('resampling-filter', $configuration['image']['imagine_options']);
+        $this->assertSame(ImageInterface::FILTER_UNDEFINED, $configuration['image']['imagine_options']['resampling-filter']);
     }
 
     /**

--- a/core-bundle/tests/DependencyInjection/ConfigurationTest.php
+++ b/core-bundle/tests/DependencyInjection/ConfigurationTest.php
@@ -276,6 +276,24 @@ class ConfigurationTest extends TestCase
         (new Processor())->processConfiguration($this->configuration, $params);
     }
 
+    public function testDoesNotNormalizeResamplingFilter(): void
+    {
+        $params = [
+            [
+                'image' => [
+                    'imagine_options' => [
+                        'resampling-filter' => ImageInterface::FILTER_LANCZOS,
+                    ],
+                ],
+            ],
+        ];
+
+        $configuration = (new Processor())->processConfiguration($this->configuration, $params);
+
+        $this->assertArrayHasKey('resampling-filter', $configuration['image']['imagine_options']);
+        $this->assertSame(ImageInterface::FILTER_LANCZOS, $configuration['image']['imagine_options']['resampling-filter']);
+    }
+
     /**
      * Ensure that all non-deprecated configuration keys are in lower case and
      * separated by underscores (aka snake_case).
@@ -297,23 +315,5 @@ class ConfigurationTest extends TestCase
                 $this->assertMatchesRegularExpression('/^[a-z][a-z_]+[a-z]$/', $key);
             }
         }
-    }
-
-    public function testDoesNotNormalizeResamplingFilter(): void
-    {
-        $params = [
-            [
-                'image' => [
-                    'imagine_options' => [
-                        'resampling-filter' => ImageInterface::FILTER_LANCZOS,
-                    ],
-                ],
-            ],
-        ];
-
-        $configuration = (new Processor())->processConfiguration($this->configuration, $params);
-
-        $this->assertArrayHasKey('resampling-filter', $configuration['image']['imagine_options']);
-        $this->assertSame(ImageInterface::FILTER_LANCZOS, $configuration['image']['imagine_options']['resampling-filter']);
     }
 }

--- a/core-bundle/tests/DependencyInjection/ConfigurationTest.php
+++ b/core-bundle/tests/DependencyInjection/ConfigurationTest.php
@@ -15,6 +15,7 @@ namespace Contao\CoreBundle\Tests\DependencyInjection;
 use Contao\CoreBundle\DependencyInjection\Configuration;
 use Contao\CoreBundle\Tests\TestCase;
 use Contao\Image\ResizeConfiguration;
+use Imagine\Image\ImageInterface;
 use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Config\Definition\ArrayNode;
 use Symfony\Component\Config\Definition\BaseNode;
@@ -296,5 +297,23 @@ class ConfigurationTest extends TestCase
                 $this->assertMatchesRegularExpression('/^[a-z][a-z_]+[a-z]$/', $key);
             }
         }
+    }
+
+    public function testDoesNotNormalizeResamplingFilter(): void
+    {
+        $params = [
+            [
+                'image' => [
+                    'imagine_options' => [
+                        'resampling-filter' => ImageInterface::FILTER_LANCZOS,
+                    ],
+                ],
+            ],
+        ];
+
+        $configuration = (new Processor())->processConfiguration($this->configuration, $params);
+
+        $this->assertArrayHasKey('resampling-filter', $configuration['image']['imagine_options']);
+        $this->assertSame(ImageInterface::FILTER_LANCZOS, $configuration['image']['imagine_options']['resampling-filter']);
     }
 }


### PR DESCRIPTION
Same as #7778 for Contao 4.13