### PR TITLE
Allow page controllers to create the response context

### DIFF
--- a/core-bundle/src/Resources/config/services.yml
+++ b/core-bundle/src/Resources/config/services.yml
@@ -1160,14 +1160,6 @@ services:
             version: 4.13
             message: Using the "%alias_id%" service ID has been deprecated and will no longer work in Contao 5.0. Please use "contao.image.studio.figure_renderer" instead.
 
-    Contao\CoreBundle\Routing\ResponseContext\CoreResponseContextFactory:
-        alias: contao.routing.response_context_factory
-        public: true
-        deprecated:
-            package: contao/core-bundle
-            version: 4.13
-            message: Using the "%alias_id%" service ID has been deprecated and will no longer work in Contao 5.0. Please use "contao.routing.response_context_factory" instead.
-
     Contao\CoreBundle\Security\TwoFactor\BackupCodeManager:
         alias: contao.security.two_factor.backup_code_manager
         public: true

--- a/core-bundle/src/Resources/config/services.yml
+++ b/core-bundle/src/Resources/config/services.yml
@@ -1067,6 +1067,7 @@ services:
     Contao\CoreBundle\Routing\Page\PageRegistry:
         alias: contao.routing.page_registry
         public: true # backwards compatibility
+    Contao\CoreBundle\Routing\ResponseContext\CoreResponseContextFactory: '@contao.routing.response_context_factory'
     Contao\CoreBundle\Routing\ResponseContext\ResponseContextAccessor:
         alias: contao.routing.response_context_accessor
         public: true  # backwards compatibility

--- a/core-bundle/src/Resources/contao/pages/PageRegular.php
+++ b/core-bundle/src/Resources/contao/pages/PageRegular.php
@@ -91,7 +91,13 @@ class PageRegular extends Frontend
 		$request = $container->get('request_stack')->getCurrentRequest();
 		$request->setLocale($locale);
 
-		$this->responseContext = $container->get('contao.routing.response_context_factory')->createContaoWebpageResponseContext($objPage);
+		$responseContextAccessor = System::getContainer()->get('contao.routing.response_context_accessor');
+
+		if (!$this->responseContext = $responseContextAccessor->getResponseContext())
+		{
+			$this->responseContext = $container->get('contao.routing.response_context_factory')->createContaoWebpageResponseContext($objPage);
+		}
+
 		$blnShowUnpublished = $container->get('contao.security.token_checker')->isPreviewMode();
 
 		System::loadLanguageFile('default');
@@ -223,24 +229,24 @@ class PageRegular extends Frontend
 			}
 		}
 
-		$headBag = $this->responseContext->get(HtmlHeadBag::class);
+		$headBag = $this->responseContext->has(HtmlHeadBag::class) ? $this->responseContext->get(HtmlHeadBag::class) : null;
 
 		// Set the page title and description AFTER the modules have been generated
 		$this->Template->mainTitle = $objPage->rootPageTitle;
-		$this->Template->pageTitle = htmlspecialchars($headBag->getTitle(), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5);
+		$this->Template->pageTitle = htmlspecialchars($headBag?->getTitle() ?? '', ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5);
 
 		// Remove shy-entities (see #2709)
 		$this->Template->mainTitle = str_replace('[-]', '', $this->Template->mainTitle);
 		$this->Template->pageTitle = str_replace('[-]', '', $this->Template->pageTitle);
 
 		// Meta robots tag
-		$this->Template->robots = htmlspecialchars($headBag->getMetaRobots(), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5);
+		$this->Template->robots = htmlspecialchars($headBag?->getMetaRobots() ?? '', ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5);
 
 		// Canonical
 		if ($objPage->enableCanonical)
 		{
 			$this->Template->canonical = htmlspecialchars(
-				str_replace(array('{', '}'), array('%7B', '%7D'), $headBag->getCanonicalUriForRequest($request)),
+				str_replace(array('{', '}'), array('%7B', '%7D'), $headBag?->getCanonicalUriForRequest($request) ?? ''),
 				ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5
 			);
 		}
@@ -253,7 +259,7 @@ class PageRegular extends Frontend
 
 		// Assign the title and description
 		$this->Template->title = strip_tags(System::getContainer()->get('contao.insert_tag.parser')->replaceInline($objLayout->titleTag));
-		$this->Template->description = htmlspecialchars($headBag->getMetaDescription(), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5);
+		$this->Template->description = htmlspecialchars($headBag?->getMetaDescription() ?? '', ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5);
 
 		// Body onload and body classes
 		$this->Template->onload = trim($objLayout->onload);

--- a/core-bundle/src/Resources/contao/pages/PageRegular.php
+++ b/core-bundle/src/Resources/contao/pages/PageRegular.php
@@ -229,24 +229,24 @@ class PageRegular extends Frontend
 			}
 		}
 
-		$headBag = $this->responseContext->has(HtmlHeadBag::class) ? $this->responseContext->get(HtmlHeadBag::class) : null;
+		$headBag = $this->responseContext->get(HtmlHeadBag::class);
 
 		// Set the page title and description AFTER the modules have been generated
 		$this->Template->mainTitle = $objPage->rootPageTitle;
-		$this->Template->pageTitle = htmlspecialchars($headBag?->getTitle() ?? '', ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5);
+		$this->Template->pageTitle = htmlspecialchars($headBag->getTitle(), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5);
 
 		// Remove shy-entities (see #2709)
 		$this->Template->mainTitle = str_replace('[-]', '', $this->Template->mainTitle);
 		$this->Template->pageTitle = str_replace('[-]', '', $this->Template->pageTitle);
 
 		// Meta robots tag
-		$this->Template->robots = htmlspecialchars($headBag?->getMetaRobots() ?? '', ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5);
+		$this->Template->robots = htmlspecialchars($headBag->getMetaRobots(), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5);
 
 		// Canonical
 		if ($objPage->enableCanonical)
 		{
 			$this->Template->canonical = htmlspecialchars(
-				str_replace(array('{', '}'), array('%7B', '%7D'), $headBag?->getCanonicalUriForRequest($request) ?? ''),
+				str_replace(array('{', '}'), array('%7B', '%7D'), $headBag->getCanonicalUriForRequest($request)),
 				ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5
 			);
 		}
@@ -259,7 +259,7 @@ class PageRegular extends Frontend
 
 		// Assign the title and description
 		$this->Template->title = strip_tags(System::getContainer()->get('contao.insert_tag.parser')->replaceInline($objLayout->titleTag));
-		$this->Template->description = htmlspecialchars($headBag?->getMetaDescription() ?? '', ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5);
+		$this->Template->description = htmlspecialchars($headBag->getMetaDescription(), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5);
 
 		// Body onload and body classes
 		$this->Template->onload = trim($objLayout->onload);


### PR DESCRIPTION
Same as #7631, sans defensive `HeadBag` checks (due to PHP 7.4 compatibility).