### PR TITLE
Add a default `ptable` to `tl_content` again

### DIFF
--- a/core-bundle/contao/dca/tl_content.php
+++ b/core-bundle/contao/dca/tl_content.php
@@ -34,6 +34,7 @@ $GLOBALS['TL_DCA']['tl_content'] = array
 	(
 		'dataContainer'               => DC_Table::class,
 		'enableVersioning'            => true,
+		'ptable'                      => 'tl_article',
 		'ctable'                      => array('tl_content'),
 		'dynamicPtable'               => true,
 		'markAsCopy'                  => 'headline',

--- a/core-bundle/src/EventListener/DataContainer/ContentElementTypeListener.php
+++ b/core-bundle/src/EventListener/DataContainer/ContentElementTypeListener.php
@@ -56,7 +56,7 @@ class ContentElementTypeListener implements ResetInterface
     /**
      * Return elements that can be created in the current context (e.g. nested fragments).
      */
-    private function getAllowedElements(string $ptable, int $pid): array
+    private function getAllowedElements(string $ptable, int|null $pid): array
     {
         $cacheKey = $ptable.'.'.$pid;
 


### PR DESCRIPTION
Fixes #7689

This is a follow-up on #7690 that fixes the underlying problem by adding the default `ptable` again. The default was removed in #6645.

@ausi I'm not sure if adding this back causes any side-effects?

@aschempp Even though this works, I'm not sure if `$pid` can be `null` in the `CreateAction`?