### PR TITLE
Consider the `addImage` checkbox when collecting RSS enclosures

### DIFF
--- a/news-bundle/src/EventListener/NewsFeedListener.php
+++ b/news-bundle/src/EventListener/NewsFeedListener.php
@@ -143,7 +143,7 @@ class NewsFeedListener
     {
         $uuids = [];
 
-        if ($article->addImage == true && $article->singleSRC) {
+        if ($article->addImage && $article->singleSRC) {
             $uuids[] = $article->singleSRC;
         }
 

--- a/news-bundle/src/EventListener/NewsFeedListener.php
+++ b/news-bundle/src/EventListener/NewsFeedListener.php
@@ -143,7 +143,7 @@ class NewsFeedListener
     {
         $uuids = [];
 
-        if ($article->singleSRC) {
+        if ($article->addImage == true && $article->singleSRC) {
             $uuids[] = $article->singleSRC;
         }
 

--- a/news-bundle/tests/EventListener/NewsFeedListenerTest.php
+++ b/news-bundle/tests/EventListener/NewsFeedListenerTest.php
@@ -166,6 +166,7 @@ class NewsFeedListenerTest extends ContaoTestCase
             'date' => 1656578758,
             'headline' => $headline[0],
             'teaser' => $content[0],
+            'addImage' => true,
             'singleSRC' => 'binary_uuid',
             'addEnclosure' => serialize(['binary_uuid2']),
         ]);


### PR DESCRIPTION
Fixes #7787