### PR TITLE
Unwrap Twig exceptions

### DIFF
--- a/core-bundle/src/EventListener/ExceptionConverterListener.php
+++ b/core-bundle/src/EventListener/ExceptionConverterListener.php
@@ -64,9 +64,7 @@ class ExceptionConverterListener
             return;
         }
 
-        if ($httpException = $this->convertToHttpException($exception, $class)) {
-            $event->setThrowable($httpException);
-        }
+        $event->setThrowable($this->convertToHttpException($exception, $class));
     }
 
     private function getTargetClass(\Throwable $exception): string|null

--- a/core-bundle/src/EventListener/ExceptionConverterListener.php
+++ b/core-bundle/src/EventListener/ExceptionConverterListener.php
@@ -80,9 +80,10 @@ class ExceptionConverterListener
 
     private function convertToHttpException(\Throwable $exception, string $class): HttpException
     {
-        return match ($class) {
-            ServiceUnavailableHttpException::class => new ServiceUnavailableHttpException('', $exception->getMessage(), $exception),
-            default => new $class($exception->getMessage(), $exception),
-        };
+        if (ServiceUnavailableHttpException::class === $class) {
+            return new ServiceUnavailableHttpException('', $exception->getMessage(), $exception);
+        }
+
+        return new $class($exception->getMessage(), $exception);
     }
 }

--- a/core-bundle/src/EventListener/ExceptionConverterListener.php
+++ b/core-bundle/src/EventListener/ExceptionConverterListener.php
@@ -39,7 +39,7 @@ use Symfony\Component\HttpKernel\Exception\ServiceUnavailableHttpException;
 #[AsEventListener(priority: 96)]
 class ExceptionConverterListener
 {
-    private const MAPPER = [
+    public const MAPPER = [
         ForwardPageNotFoundException::class => 'InternalServerErrorHttpException',
         InsecureInstallationException::class => 'InternalServerErrorHttpException',
         InternalServerErrorException::class => 'InternalServerErrorHttpException',

--- a/core-bundle/src/EventListener/ExceptionConverterListener.php
+++ b/core-bundle/src/EventListener/ExceptionConverterListener.php
@@ -40,16 +40,16 @@ use Symfony\Component\HttpKernel\Exception\ServiceUnavailableHttpException;
 class ExceptionConverterListener
 {
     public const MAPPER = [
-        ForwardPageNotFoundException::class => 'InternalServerErrorHttpException',
-        InsecureInstallationException::class => 'InternalServerErrorHttpException',
-        InternalServerErrorException::class => 'InternalServerErrorHttpException',
-        InvalidRequestTokenException::class => 'BadRequestHttpException',
-        NoActivePageFoundException::class => 'NotFoundHttpException',
-        NoLayoutSpecifiedException::class => 'InternalServerErrorHttpException',
-        NoRootPageFoundException::class => 'NotFoundHttpException',
-        PageNotFoundException::class => 'NotFoundHttpException',
-        ServiceUnavailableException::class => 'ServiceUnavailableHttpException',
-        UnusedArgumentsException::class => 'NotFoundHttpException',
+        ForwardPageNotFoundException::class => InternalServerErrorHttpException::class,
+        InsecureInstallationException::class => InternalServerErrorHttpException::class,
+        InternalServerErrorException::class => InternalServerErrorHttpException::class,
+        InvalidRequestTokenException::class => BadRequestHttpException::class,
+        NoActivePageFoundException::class => NotFoundHttpException::class,
+        NoLayoutSpecifiedException::class => InternalServerErrorHttpException::class,
+        NoRootPageFoundException::class => NotFoundHttpException::class,
+        PageNotFoundException::class => NotFoundHttpException::class,
+        ServiceUnavailableException::class => ServiceUnavailableHttpException::class,
+        UnusedArgumentsException::class => NotFoundHttpException::class,
     ];
 
     /**
@@ -80,14 +80,11 @@ class ExceptionConverterListener
         return null;
     }
 
-    private function convertToHttpException(\Throwable $exception, string $target): HttpException|null
+    private function convertToHttpException(\Throwable $exception, string $class): HttpException
     {
-        return match ($target) {
-            'BadRequestHttpException' => new BadRequestHttpException($exception->getMessage(), $exception),
-            'InternalServerErrorHttpException' => new InternalServerErrorHttpException($exception->getMessage(), $exception),
-            'NotFoundHttpException' => new NotFoundHttpException($exception->getMessage(), $exception),
-            'ServiceUnavailableHttpException' => new ServiceUnavailableHttpException('', $exception->getMessage(), $exception),
-            default => null,
+        return match ($class) {
+            ServiceUnavailableHttpException::class => new ServiceUnavailableHttpException('', $exception->getMessage(), $exception),
+            default => new $class($exception->getMessage(), $exception),
         };
     }
 }

--- a/core-bundle/src/EventListener/UnwrapTwigExceptionListener.php
+++ b/core-bundle/src/EventListener/UnwrapTwigExceptionListener.php
@@ -15,6 +15,7 @@ namespace Contao\CoreBundle\EventListener;
 use Contao\CoreBundle\Exception\ResponseException;
 use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 use Twig\Error\RuntimeError;
 
 /**
@@ -39,10 +40,26 @@ class UnwrapTwigExceptionListener
 
         $previous = $throwable->getPrevious();
 
-        if (!$previous instanceof ResponseException) {
-            return;
+        if ($previous && $this->shouldUnwrap($previous)) {
+            $event->setThrowable($previous);
+        }
+    }
+
+    private function shouldUnwrap(\Throwable $throwable): bool
+    {
+        if (
+            $throwable instanceof ResponseException
+            || $throwable instanceof HttpExceptionInterface
+        ) {
+            return true;
         }
 
-        $event->setThrowable($previous);
+        foreach (array_keys(ExceptionConverterListener::MAPPER) as $class) {
+            if (\is_a($throwable, $class)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/core-bundle/src/EventListener/UnwrapTwigExceptionListener.php
+++ b/core-bundle/src/EventListener/UnwrapTwigExceptionListener.php
@@ -47,10 +47,7 @@ class UnwrapTwigExceptionListener
 
     private function shouldUnwrap(\Throwable $throwable): bool
     {
-        if (
-            $throwable instanceof ResponseException
-            || $throwable instanceof HttpExceptionInterface
-        ) {
+        if ($throwable instanceof ResponseException || $throwable instanceof HttpExceptionInterface) {
             return true;
         }
 

--- a/core-bundle/src/EventListener/UnwrapTwigExceptionListener.php
+++ b/core-bundle/src/EventListener/UnwrapTwigExceptionListener.php
@@ -55,7 +55,7 @@ class UnwrapTwigExceptionListener
         }
 
         foreach (array_keys(ExceptionConverterListener::MAPPER) as $class) {
-            if (\is_a($throwable, $class)) {
+            if (is_a($throwable, $class)) {
                 return true;
             }
         }

--- a/core-bundle/src/Exception/InternalServerErrorHttpException.php
+++ b/core-bundle/src/Exception/InternalServerErrorHttpException.php
@@ -16,7 +16,7 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class InternalServerErrorHttpException extends HttpException
 {
-    public function __construct(string|null $message = null, \Throwable|null $previous = null, int $code = 0)
+    public function __construct(string $message = '', \Throwable|null $previous = null, int $code = 0)
     {
         parent::__construct(500, $message, $previous, [], $code);
     }

--- a/core-bundle/tests/EventListener/UnwrapTwigExceptionListenerTest.php
+++ b/core-bundle/tests/EventListener/UnwrapTwigExceptionListenerTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Tests\EventListener;
 
+use Contao\CoreBundle\EventListener\ExceptionConverterListener;
 use Contao\CoreBundle\EventListener\UnwrapTwigExceptionListener;
 use Contao\CoreBundle\Exception\NoContentResponseException;
 use Contao\CoreBundle\Exception\RedirectResponseException;
@@ -50,6 +51,10 @@ class UnwrapTwigExceptionListenerTest extends TestCase
         yield 'RedirectResponseException' => [
             new RedirectResponseException('/foo'),
         ];
+
+        foreach (array_unique(ExceptionConverterListener::MAPPER) as $exception) {
+            yield $exception => [new $exception()];
+        }
     }
 
     /**


### PR DESCRIPTION
fixes https://github.com/contao/contao/issues/7783

This unwraps all Twig exceptions supported by our `PrettyErrorScreenListener`. Not sure if that is the correct approach, but also not sure why these exceptions are wrapped in Twig at all?

An alternative could be to unwrap everything in production (e.g. when the pretty error screen is rendered anyway), to correctly allow the `ExceptionConverterListener` and `PrettyErrorScreenListener` to handle the exception.