### PR TITLE
Remove empty locales in the meta wizard and add the primary language

### DIFF
--- a/core-bundle/contao/widgets/MetaWizard.php
+++ b/core-bundle/contao/widgets/MetaWizard.php
@@ -123,6 +123,11 @@ class MetaWizard extends Widget
 			}
 		}
 
+		// Remove empty locales (see #7569)
+		$varInput = array_filter($varInput, static function ($localeArray) {
+			return array_filter($localeArray, static fn ($value) => !empty($value));
+		});
+
 		// Sort the metadata by key (see #3818)
 		ksort($varInput);
 
@@ -137,11 +142,11 @@ class MetaWizard extends Widget
 	public function generate()
 	{
 		$count = 0;
-		$return = '';
 
-		// Only show the root page languages (see #7112, #7667)
+		// Only show the root page languages plus their primary language (see #7112, #7667, #7569)
 		$objRootLangs = Database::getInstance()->query("SELECT language FROM tl_page WHERE type='root' AND language!=''");
 		$existing = $objRootLangs->fetchEach('language');
+		$existing = array_unique(array_merge($existing, array_map(static fn ($locale) => LocaleUtil::getPrimaryLanguage($locale), $existing)));
 
 		foreach ($existing as $lang)
 		{


### PR DESCRIPTION
Fixes https://github.com/contao/contao/issues/7569

This PR does two things:

1. It removes completely empty locale meta data from the meta data array (fixes https://github.com/contao/contao/issues/7569)
2. It ensures that the main language is always editable. So if you only have `en_US` and `en_GB` domains for example, you now also get `en`. This will allow you to manage the contents only once as this is used as fallback in the FE anyway.

I also removed a useless leftover variable along the way.