### PR TITLE
Do not force HTTP method parameter override

### DIFF
--- a/manager-bundle/src/HttpKernel/ContaoKernel.php
+++ b/manager-bundle/src/HttpKernel/ContaoKernel.php
@@ -238,9 +238,6 @@ class ContaoKernel extends Kernel implements HttpCacheProvider
             Request::setTrustedProxies(explode(',', (string) $trustedProxies), $trustedHeaderSet);
         }
 
-        // TODO: Remove this line in Contao 5.4 with Symfony 7 only
-        Request::enableHttpMethodParameterOverride();
-
         $jwtManager = null;
         $env = null;
         $parseJwt = 'jwt' === $_SERVER['APP_ENV'];

--- a/manager-bundle/tests/HttpKernel/ContaoKernelTest.php
+++ b/manager-bundle/tests/HttpKernel/ContaoKernelTest.php
@@ -342,13 +342,13 @@ class ContaoKernelTest extends ContaoTestCase
         unset($_SERVER['TRUSTED_HOSTS']);
     }
 
-    public function testEnablesRequestHttpMethodParameterOverride(): void
+    public function testDoesNotEnableRequestHttpMethodParameterOverride(): void
     {
         $this->assertFalse(Request::getHttpMethodParameterOverride());
 
         ContaoKernel::fromRequest($this->getTempDir(), Request::create('/'));
 
-        $this->assertTrue(Request::getHttpMethodParameterOverride());
+        $this->assertFalse(Request::getHttpMethodParameterOverride());
     }
 
     public function testSetsProjectDirFromInput(): void


### PR DESCRIPTION
In https://github.com/contao/contao/pull/152 we force-enabled the HTTP method override ability via the `_method` parameter. However, Contao itself does not need that (or the Contao Manager when requesting its Contao API).

This PR removes it, as discussed in the last Contao call. This allows you to control whether it is enabled or not via the Symfony Framework Bundle config:

```yaml
framework:
    http_method_override: …
```

By default it is enabled in Symfony 5 and 6 anyway, so nothing will change in Contao 4.13 and 5.3. It is disabled in Symfony 7, so it will be disabled by default in Contao 5.4 and up, if you have Symfony 7 installed.

For reference: it is enabled depending on the bundle config by the Symfony Framework Bundle [here](https://github.com/symfony/symfony/blob/2e85f07bced3b6d433b27bd6b9185a096e99ed2e/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php#L106-L108).