### PR TITLE
Allow fragment override of legacy elements again

### DIFF
--- a/core-bundle/src/EventListener/GlobalsMapListener.php
+++ b/core-bundle/src/EventListener/GlobalsMapListener.php
@@ -17,8 +17,10 @@ namespace Contao\CoreBundle\EventListener;
  */
 class GlobalsMapListener
 {
-    public function __construct(private readonly array $globals)
-    {
+    public function __construct(
+        private readonly array $globals,
+        private readonly array $forceGlobals,
+    ) {
     }
 
     /**
@@ -33,6 +35,14 @@ class GlobalsMapListener
         foreach ($this->globals as $key => $value) {
             if (\is_array($value) && isset($GLOBALS[$key]) && \is_array($GLOBALS[$key])) {
                 $GLOBALS[$key] = array_replace_recursive($GLOBALS[$key], $value, $GLOBALS[$key]);
+            } else {
+                $GLOBALS[$key] = $value;
+            }
+        }
+
+        foreach ($this->forceGlobals as $key => $value) {
+            if (\is_array($value) && isset($GLOBALS[$key]) && \is_array($GLOBALS[$key])) {
+                $GLOBALS[$key] = array_replace_recursive($GLOBALS[$key], $value);
             } else {
                 $GLOBALS[$key] = $value;
             }

--- a/core-bundle/tests/DependencyInjection/Compiler/RegisterFragmentsPassTest.php
+++ b/core-bundle/tests/DependencyInjection/Compiler/RegisterFragmentsPassTest.php
@@ -253,8 +253,12 @@ class RegisterFragmentsPassTest extends TestCase
         $contentController = new Definition('App\Fragments\Text');
         $contentController->addTag('contao.content_element', ['category' => 'content']);
 
+        $overrideController = new Definition('Contao\Frontend');
+        $overrideController->addTag('contao.content_element', ['type' => 'image', 'category' => 'media']);
+
         $container = $this->getContainerWithFragmentServices();
-        $container->setDefinition('app.fragments.content_controller', $contentController);
+        $container->setDefinition('app.fragments.content_controller.text', $contentController);
+        $container->setDefinition('app.fragments.content_controller.override', $overrideController);
 
         (new ResolveClassPass())->process($container);
 
@@ -293,6 +297,17 @@ class RegisterFragmentsPassTest extends TestCase
                 ],
             ],
             $definition->getArguments()[0],
+        );
+
+        $this->assertSame(
+            [
+                'TL_CTE' => [
+                    'media' => [
+                        'image' => ContentProxy::class,
+                    ],
+                ],
+            ],
+            $definition->getArguments()[1],
         );
 
         $this->assertTrue($definition->isPublic());

--- a/core-bundle/tests/DependencyInjection/Compiler/RegisterFragmentsPassTest.php
+++ b/core-bundle/tests/DependencyInjection/Compiler/RegisterFragmentsPassTest.php
@@ -22,6 +22,7 @@ use Contao\CoreBundle\Fragment\FragmentRegistry;
 use Contao\CoreBundle\Fragment\Reference\ContentElementReference;
 use Contao\CoreBundle\Fragment\Reference\FrontendModuleReference;
 use Contao\CoreBundle\Tests\TestCase;
+use Contao\Frontend;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\DependencyInjection\ChildDefinition;
@@ -253,7 +254,7 @@ class RegisterFragmentsPassTest extends TestCase
         $contentController = new Definition('App\Fragments\Text');
         $contentController->addTag('contao.content_element', ['category' => 'content']);
 
-        $overrideController = new Definition('Contao\Frontend');
+        $overrideController = new Definition(Frontend::class);
         $overrideController->addTag('contao.content_element', ['type' => 'image', 'category' => 'media']);
 
         $container = $this->getContainerWithFragmentServices();

--- a/core-bundle/tests/EventListener/GlobalsMapListenerTest.php
+++ b/core-bundle/tests/EventListener/GlobalsMapListenerTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Tests\EventListener;
 
+use Contao\ContentProxy;
 use Contao\CoreBundle\EventListener\GlobalsMapListener;
 use Contao\CoreBundle\Tests\TestCase;
 
@@ -20,11 +21,11 @@ class GlobalsMapListenerTest extends TestCase
     /**
      * @dataProvider getValuesData
      */
-    public function testMergesTheValuesIntoTheGlobalsArray(array $existing, array $new, array $expected): void
+    public function testMergesTheValuesIntoTheGlobalsArray(array $existing, array $new, array $expected, array $forced = []): void
     {
         $GLOBALS['TL_CTE'] = $existing;
 
-        $listener = new GlobalsMapListener(['TL_CTE' => $new]);
+        $listener = new GlobalsMapListener(['TL_CTE' => $new], ['TL_CTE' => $forced]);
         $listener->onInitializeSystem();
 
         $this->assertSame($expected, $GLOBALS['TL_CTE']);
@@ -56,6 +57,13 @@ class GlobalsMapListenerTest extends TestCase
             ['texts' => ['headline' => 'LegacyHeadline']],
             ['texts' => ['headline' => 'HeadlineFragment']],
             ['texts' => ['headline' => 'LegacyHeadline']],
+        ];
+
+        yield 'prefer forced entries over existing entries' => [
+            ['texts' => ['headline' => 'LegacyHeadline']],
+            [],
+            ['texts' => ['headline' => ContentProxy::class]],
+            ['texts' => ['headline' => ContentProxy::class]],
         ];
     }
 }

--- a/core-bundle/tests/EventListener/GlobalsMapListenerTest.php
+++ b/core-bundle/tests/EventListener/GlobalsMapListenerTest.php
@@ -41,7 +41,21 @@ class GlobalsMapListenerTest extends TestCase
             ['text' => 'HeadlineFragment'],
         ];
 
+        yield 'add single forced' => [
+            [],
+            [],
+            ['text' => 'HeadlineFragment'],
+            ['text' => 'HeadlineFragment'],
+        ];
+
         yield 'add group' => [
+            [],
+            ['texts' => ['headline' => 'HeadlineFragment']],
+            ['texts' => ['headline' => 'HeadlineFragment']],
+        ];
+
+        yield 'add group forced' => [
+            [],
             [],
             ['texts' => ['headline' => 'HeadlineFragment']],
             ['texts' => ['headline' => 'HeadlineFragment']],


### PR DESCRIPTION
Fixes #7802

The solution is not very elegant.

It checks whether the registered fragment extends from `Contao\Frontend` - which means the fragment is extending from a legacy content element or module. Thus we allow it to override the existing entry in `$GLOBALS` by collecting these in a separate array that is then passed to the `GlobalMapListener`.