### PR TITLE
Added missing index on "sorting" column

### DIFF
--- a/core-bundle/contao/dca/tl_article.php
+++ b/core-bundle/contao/dca/tl_article.php
@@ -51,6 +51,7 @@ $GLOBALS['TL_DCA']['tl_article'] = array
 			(
 				'id' => 'primary',
 				'tstamp' => 'index',
+				'sorting' => 'index',
 				'alias' => 'index',
 				'pid,published,inColumn,start,stop' => 'index'
 			)

--- a/core-bundle/contao/dca/tl_content.php
+++ b/core-bundle/contao/dca/tl_content.php
@@ -48,6 +48,7 @@ $GLOBALS['TL_DCA']['tl_content'] = array
 			(
 				'id' => 'primary',
 				'tstamp' => 'index',
+				'sorting' => 'index',
 				'ptable,pid,invisible,start,stop' => 'index',
 				'type' => 'index'
 			)

--- a/core-bundle/contao/dca/tl_favorites.php
+++ b/core-bundle/contao/dca/tl_favorites.php
@@ -26,6 +26,7 @@ $GLOBALS['TL_DCA']['tl_favorites'] = array
 			(
 				'id' => 'primary',
 				'tstamp' => 'index',
+				'sorting' => 'index',
 				'pid,user' => 'index',
 				'url' => 'index'
 			)

--- a/core-bundle/contao/dca/tl_form_field.php
+++ b/core-bundle/contao/dca/tl_form_field.php
@@ -44,7 +44,8 @@ $GLOBALS['TL_DCA']['tl_form_field'] = array
 			(
 				'id' => 'primary',
 				'pid,invisible' => 'index',
-				'tstamp' => 'index'
+				'tstamp' => 'index',
+				'sorting' => 'index'
 			)
 		)
 	),

--- a/core-bundle/contao/dca/tl_image_size_item.php
+++ b/core-bundle/contao/dca/tl_image_size_item.php
@@ -29,7 +29,8 @@ $GLOBALS['TL_DCA']['tl_image_size_item'] = array
 			(
 				'id' => 'primary',
 				'pid' => 'index',
-				'tstamp' => 'index'
+				'tstamp' => 'index',
+				'sorting' => 'index'
 			)
 		)
 	),

--- a/core-bundle/contao/dca/tl_page.php
+++ b/core-bundle/contao/dca/tl_page.php
@@ -67,6 +67,7 @@ $GLOBALS['TL_DCA']['tl_page'] = array
 			(
 				'id' => 'primary',
 				'tstamp' => 'index',
+				'sorting' => 'index',
 				'alias' => 'index',
 				'type,dns,fallback,published,start,stop' => 'index',
 				'pid,published,type,start,stop' => 'index'

--- a/faq-bundle/contao/dca/tl_faq.php
+++ b/faq-bundle/contao/dca/tl_faq.php
@@ -41,7 +41,8 @@ $GLOBALS['TL_DCA']['tl_faq'] = array
 			(
 				'id' => 'primary',
 				'pid,published' => 'index',
-				'tstamp' => 'index'
+				'tstamp' => 'index',
+				'sorting' => 'index'
 			)
 		)
 	),


### PR DESCRIPTION
Noticed those in the MySQL slow query log. For example when adding a new content element, determining the new position (`DC_Table::getNewPosition()`)  executes queries like `SELECT MIN(sorting) AS sorting FROM ...` and also in other places, we `ORDER BY sorting` (which is the whole purpose of having a `sorting` column). No idea why we never had an index on those 🤯 