### PR TITLE
Add `chosen` to `tl_form_field.type`

### DIFF
--- a/core-bundle/contao/dca/tl_form_field.php
+++ b/core-bundle/contao/dca/tl_form_field.php
@@ -158,7 +158,7 @@ $GLOBALS['TL_DCA']['tl_form_field'] = array
 			'filter'                  => true,
 			'inputType'               => 'select',
 			'options_callback'        => array('tl_form_field', 'getFields'),
-			'eval'                    => array('helpwizard'=>true, 'submitOnChange'=>true, 'tl_class'=>'w50'),
+			'eval'                    => array('helpwizard'=>true, 'chosen'=>true, 'submitOnChange'=>true, 'tl_class'=>'w50'),
 			'reference'               => &$GLOBALS['TL_LANG']['FFL'],
 			'sql'                     => array('name'=>'type', 'type'=>'string', 'length'=>64, 'default'=>'text')
 		),


### PR DESCRIPTION
This PR adds the missing `chosen` to the form_field types same as in tl_content and tl_module

![image](https://github.com/user-attachments/assets/9aa7853c-ee35-4f50-b3ae-2251b4d79c23)

If this isn't considered a bug, we can simply switch to 5.x