### PR TITLE
Split the `BackendMenuListener` class into two separate classes

### DIFF
--- a/core-bundle/config/listener.yaml
+++ b/core-bundle/config/listener.yaml
@@ -349,16 +349,6 @@ services:
         arguments:
             - '@contao.routing.scope_matcher'
 
-    contao.listener.menu.backend:
-        class: Contao\CoreBundle\EventListener\Menu\BackendMenuListener
-        arguments:
-            - '@security.helper'
-            - '@router'
-            - '@request_stack'
-            - '@translator'
-            - '@contao.framework'
-            - '%contao.template_studio.enabled%'
-
     contao.listener.menu.backend_favorites:
         class: Contao\CoreBundle\EventListener\Menu\BackendFavoritesListener
         arguments:
@@ -369,6 +359,15 @@ services:
             - '@translator'
             - '@contao.csrf.token_manager'
 
+    contao.listener.menu.backend_header:
+        class: Contao\CoreBundle\EventListener\Menu\BackendHeaderListener
+        arguments:
+            - '@security.helper'
+            - '@router'
+            - '@request_stack'
+            - '@translator'
+            - '@contao.framework'
+
     contao.listener.menu.backend_logout:
         class: Contao\CoreBundle\EventListener\Menu\BackendLogoutListener
         arguments:
@@ -376,6 +375,13 @@ services:
             - '@router'
             - '@security.logout_url_generator'
             - '@translator'
+
+    contao.listener.menu.backend_main:
+        class: Contao\CoreBundle\EventListener\Menu\BackendMainListener
+        arguments:
+            - '@security.helper'
+            - '@request_stack'
+            - '%contao.template_studio.enabled%'
 
     contao.listener.menu.backend_preview:
         class: Contao\CoreBundle\EventListener\Menu\BackendPreviewListener

--- a/core-bundle/src/EventListener/Menu/BackendMainListener.php
+++ b/core-bundle/src/EventListener/Menu/BackendMainListener.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\EventListener\Menu;
+
+use Contao\BackendUser;
+use Contao\CoreBundle\Controller\BackendTemplateStudioController;
+use Contao\CoreBundle\Event\MenuEvent;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Make sure this listener comes before the other ones adding to its tree.
+ *
+ * @internal
+ */
+#[AsEventListener(priority: 10)]
+class BackendMainListener
+{
+    public function __construct(
+        private readonly Security $security,
+        private readonly RequestStack $requestStack,
+        private readonly bool $templateStudioEnabled,
+    ) {
+    }
+
+    public function __invoke(MenuEvent $event): void
+    {
+        $user = $this->security->getUser();
+
+        if (!$user instanceof BackendUser) {
+            return;
+        }
+
+        $name = $event->getTree()->getName();
+
+        if ('mainMenu' !== $name) {
+            return;
+        }
+
+        $factory = $event->getFactory();
+        $tree = $event->getTree();
+        $modules = $user->navigation();
+
+        foreach ($modules as $categoryName => $categoryData) {
+            $categoryNode = $tree->getChild($categoryName);
+
+            if (!$categoryNode) {
+                $categoryNode = $factory
+                    ->createItem($categoryName)
+                    ->setLabel($categoryData['label'])
+                    ->setUri($categoryData['href'])
+                    ->setLinkAttribute('class', $this->getClassFromAttributes($categoryData))
+                    ->setLinkAttribute('title', $categoryData['title'])
+                    ->setLinkAttribute('data-action', 'contao--toggle-navigation#toggle:prevent')
+                    ->setLinkAttribute('data-contao--toggle-navigation-category-param', $categoryName)
+                    ->setLinkAttribute('aria-controls', $categoryName)
+                    ->setLinkAttribute('data-turbo-prefetch', 'false')
+                    ->setChildrenAttribute('id', $categoryName)
+                    ->setExtra('translation_domain', false)
+                ;
+
+                if (isset($categoryData['class']) && preg_match('/\bnode-collapsed\b/', (string) $categoryData['class'])) {
+                    $categoryNode->setAttribute('class', 'collapsed');
+                    $categoryNode->setLinkAttribute('aria-expanded', 'false');
+                } else {
+                    $categoryNode->setLinkAttribute('aria-expanded', 'true');
+                }
+
+                $tree->addChild($categoryNode);
+            }
+
+            // Create the child nodes
+            foreach ($categoryData['modules'] as $nodeName => $nodeData) {
+                $moduleNode = $factory
+                    ->createItem($nodeName)
+                    ->setLabel($nodeData['label'])
+                    ->setUri($nodeData['href'])
+                    ->setLinkAttribute('class', $this->getClassFromAttributes($nodeData))
+                    ->setLinkAttribute('title', $nodeData['title'])
+                    ->setCurrent((bool) $nodeData['isActive'])
+                    ->setExtra('translation_domain', false)
+                ;
+
+                $categoryNode->addChild($moduleNode);
+            }
+
+            if ($this->templateStudioEnabled && 'design' === $categoryName) {
+                $templateStudioNode = $factory
+                    ->createItem('template-studio')
+                    ->setLabel('Template Studio')
+                    ->setUri('/contao/template-studio')
+                    ->setCurrent(BackendTemplateStudioController::class === $this->requestStack->getCurrentRequest()?->get('_controller'))
+                ;
+
+                $categoryNode->addChild($templateStudioNode);
+            }
+        }
+    }
+
+    private function getClassFromAttributes(array $attributes): string
+    {
+        $classes = [];
+
+        // Remove the default CSS classes and keep potentially existing custom ones (see #1357)
+        if (isset($attributes['class'])) {
+            $classes = array_flip(array_filter(explode(' ', (string) $attributes['class'])));
+            unset($classes['node-expanded'], $classes['node-collapsed'], $classes['trail']);
+        }
+
+        return implode(' ', array_keys($classes));
+    }
+}

--- a/core-bundle/tests/EventListener/Menu/BackendHeaderListenerTest.php
+++ b/core-bundle/tests/EventListener/Menu/BackendHeaderListenerTest.php
@@ -15,7 +15,7 @@ namespace Contao\CoreBundle\Tests\EventListener\Menu;
 use Contao\Backend;
 use Contao\BackendUser;
 use Contao\CoreBundle\Event\MenuEvent;
-use Contao\CoreBundle\EventListener\Menu\BackendMenuListener;
+use Contao\CoreBundle\EventListener\Menu\BackendHeaderListener;
 use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\CoreBundle\Tests\TestCase;
 use Knp\Menu\MenuFactory;
@@ -25,211 +25,8 @@ use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class BackendMenuListenerTest extends TestCase
+class BackendHeaderListenerTest extends TestCase
 {
-    public function testBuildsTheMainMenu(): void
-    {
-        $user = $this->createMock(BackendUser::class);
-        $user
-            ->expects($this->once())
-            ->method('navigation')
-            ->willReturn($this->getNavigation())
-        ;
-
-        $security = $this->createMock(Security::class);
-        $security
-            ->method('getUser')
-            ->willReturn($user)
-        ;
-
-        $nodeFactory = new MenuFactory();
-        $event = new MenuEvent($nodeFactory, $nodeFactory->createItem('mainMenu'));
-
-        $listener = new BackendMenuListener(
-            $security,
-            $this->createMock(RouterInterface::class),
-            new RequestStack(),
-            $this->createMock(TranslatorInterface::class),
-            $this->createMock(ContaoFramework::class),
-            false,
-        );
-
-        $listener($event);
-
-        $tree = $event->getTree();
-
-        $this->assertSame('mainMenu', $tree->getName());
-
-        $children = $tree->getChildren();
-
-        $this->assertCount(2, $children);
-        $this->assertSame(['category1', 'category2'], array_keys($children));
-
-        // Category 1
-        $this->assertSame('Category 1', $children['category1']->getLabel());
-        $this->assertSame([], $children['category1']->getAttributes());
-        $this->assertSame(['id' => 'category1'], $children['category1']->getChildrenAttributes());
-        $this->assertSame(['translation_domain' => false], $children['category1']->getExtras());
-
-        $this->assertSame(
-            [
-                'class' => 'group-category1 custom-class',
-                'title' => 'Category 1 Title',
-                'data-action' => 'contao--toggle-navigation#toggle:prevent',
-                'data-contao--toggle-navigation-category-param' => 'category1',
-                'aria-controls' => 'category1',
-                'data-turbo-prefetch' => 'false',
-                'aria-expanded' => 'true',
-            ],
-            $children['category1']->getLinkAttributes(),
-        );
-
-        $grandChildren = $children['category1']->getChildren();
-
-        $this->assertCount(2, $grandChildren);
-        $this->assertSame(['node1', 'node2'], array_keys($grandChildren));
-
-        // Node 1
-        $this->assertSame('Node 1', $grandChildren['node1']->getLabel());
-        $this->assertSame('/node1', $grandChildren['node1']->getUri());
-        $this->assertSame(['class' => 'node1', 'title' => 'Node 1 Title'], $grandChildren['node1']->getLinkAttributes());
-        $this->assertSame(['translation_domain' => false], $grandChildren['node1']->getExtras());
-
-        // Node 1
-        $this->assertSame('Node 2', $grandChildren['node2']->getLabel());
-        $this->assertSame('/node2', $grandChildren['node2']->getUri());
-        $this->assertSame(['class' => 'node2', 'title' => 'Node 2 Title'], $grandChildren['node2']->getLinkAttributes());
-        $this->assertSame(['translation_domain' => false], $grandChildren['node2']->getExtras());
-
-        // Category 2
-        $this->assertSame('Category 2', $children['category2']->getLabel());
-        $this->assertSame(['class' => 'collapsed'], $children['category2']->getAttributes());
-        $this->assertSame(['id' => 'category2'], $children['category2']->getChildrenAttributes());
-        $this->assertSame(['translation_domain' => false], $children['category2']->getExtras());
-
-        $this->assertSame(
-            [
-                'class' => 'group-category2',
-                'title' => 'Category 2 Title',
-                'data-action' => 'contao--toggle-navigation#toggle:prevent',
-                'data-contao--toggle-navigation-category-param' => 'category2',
-                'aria-controls' => 'category2',
-                'data-turbo-prefetch' => 'false',
-                'aria-expanded' => 'false',
-            ],
-            $children['category2']->getLinkAttributes(),
-        );
-    }
-
-    public function testDoesNotBuildTheMainMenuIfNoUserIsGiven(): void
-    {
-        $security = $this->createMock(Security::class);
-        $security
-            ->method('getUser')
-            ->willReturn(null)
-        ;
-
-        $router = $this->createMock(RouterInterface::class);
-        $router
-            ->expects($this->never())
-            ->method('generate')
-        ;
-
-        $nodeFactory = new MenuFactory();
-        $event = new MenuEvent($nodeFactory, $nodeFactory->createItem('mainMenu'));
-
-        $listener = new BackendMenuListener(
-            $security,
-            $router,
-            new RequestStack(),
-            $this->createMock(TranslatorInterface::class),
-            $this->createMock(ContaoFramework::class),
-            false,
-        );
-
-        $listener($event);
-
-        $tree = $event->getTree();
-
-        $this->assertCount(0, $tree->getChildren());
-    }
-
-    public function testDoesNotBuildTheMainMenuIfTheNameDoesNotMatch(): void
-    {
-        $security = $this->createMock(Security::class);
-        $security
-            ->method('getUser')
-            ->willReturn(null)
-        ;
-
-        $router = $this->createMock(RouterInterface::class);
-        $router
-            ->expects($this->never())
-            ->method('generate')
-        ;
-
-        $nodeFactory = new MenuFactory();
-        $event = new MenuEvent($nodeFactory, $nodeFactory->createItem('root'));
-
-        $listener = new BackendMenuListener(
-            $security,
-            $router,
-            new RequestStack(),
-            $this->createMock(TranslatorInterface::class),
-            $this->createMock(ContaoFramework::class),
-            false,
-        );
-
-        $listener($event);
-
-        $tree = $event->getTree();
-
-        $this->assertCount(0, $tree->getChildren());
-    }
-
-    public function testAddsTheTemplateStudioMenuItemToTheMainMenu(): void
-    {
-        $user = $this->createMock(BackendUser::class);
-        $user
-            ->expects($this->once())
-            ->method('navigation')
-            ->willReturn([
-                'design' => [
-                    'label' => 'Layout',
-                    'title' => 'Layout',
-                    'href' => '/',
-                    'class' => 'design-category node-expanded trail',
-                    'modules' => [],
-                ],
-            ])
-        ;
-
-        $security = $this->createMock(Security::class);
-        $security
-            ->method('getUser')
-            ->willReturn($user)
-        ;
-
-        $nodeFactory = new MenuFactory();
-        $event = new MenuEvent($nodeFactory, $nodeFactory->createItem('mainMenu'));
-
-        $listener = new BackendMenuListener(
-            $security,
-            $this->createMock(RouterInterface::class),
-            new RequestStack(),
-            $this->createMock(TranslatorInterface::class),
-            $this->createMock(ContaoFramework::class),
-            true,
-        );
-
-        $listener($event);
-
-        $children = $event->getTree()->getChildren()['design']->getChildren();
-
-        $this->assertArrayHasKey('template-studio', $children);
-        $this->assertSame('Template Studio', $children['template-studio']->getLabel());
-    }
-
     public function testBuildsTheHeaderMenu(): void
     {
         $user = $this->mockClassWithProperties(BackendUser::class);
@@ -274,13 +71,12 @@ class BackendMenuListenerTest extends TestCase
         $nodeFactory = new MenuFactory();
         $event = new MenuEvent($nodeFactory, $nodeFactory->createItem('headerMenu'));
 
-        $listener = new BackendMenuListener(
+        $listener = new BackendHeaderListener(
             $security,
             $router,
             $requestStack,
             $this->getTranslator(),
             $this->mockContaoFramework([Backend::class => $systemMessages]),
-            false,
         );
 
         $listener($event);
@@ -384,13 +180,12 @@ class BackendMenuListenerTest extends TestCase
         $nodeFactory = new MenuFactory();
         $event = new MenuEvent($nodeFactory, $nodeFactory->createItem('headerMenu'));
 
-        $listener = new BackendMenuListener(
+        $listener = new BackendHeaderListener(
             $security,
             $router,
             new RequestStack(),
             $this->createMock(TranslatorInterface::class),
             $this->createMock(ContaoFramework::class),
-            false,
         );
 
         $listener($event);
@@ -417,13 +212,12 @@ class BackendMenuListenerTest extends TestCase
         $nodeFactory = new MenuFactory();
         $event = new MenuEvent($nodeFactory, $nodeFactory->createItem('root'));
 
-        $listener = new BackendMenuListener(
+        $listener = new BackendHeaderListener(
             $security,
             $router,
             new RequestStack(),
             $this->createMock(TranslatorInterface::class),
             $this->createMock(ContaoFramework::class),
-            false,
         );
 
         $listener($event);
@@ -431,44 +225,6 @@ class BackendMenuListenerTest extends TestCase
         $tree = $event->getTree();
 
         $this->assertCount(0, $tree->getChildren());
-    }
-
-    /**
-     * @return array<string, array<string, array<string, array<string, bool|string>>|string>>
-     */
-    private function getNavigation(): array
-    {
-        return [
-            'category1' => [
-                'label' => 'Category 1',
-                'title' => 'Category 1 Title',
-                'href' => '/',
-                'class' => 'group-category1 node-expanded trail custom-class',
-                'modules' => [
-                    'node1' => [
-                        'label' => 'Node 1',
-                        'title' => 'Node 1 Title',
-                        'href' => '/node1',
-                        'class' => 'node1',
-                        'isActive' => true,
-                    ],
-                    'node2' => [
-                        'label' => 'Node 2',
-                        'title' => 'Node 2 Title',
-                        'href' => '/node2',
-                        'class' => 'node2',
-                        'isActive' => false,
-                    ],
-                ],
-            ],
-            'category2' => [
-                'label' => 'Category 2',
-                'title' => 'Category 2 Title',
-                'href' => '/',
-                'class' => 'group-category2 node-collapsed',
-                'modules' => [],
-            ],
-        ];
     }
 
     private function getTranslator(): TranslatorInterface

--- a/core-bundle/tests/EventListener/Menu/BackendMainListenerTest.php
+++ b/core-bundle/tests/EventListener/Menu/BackendMainListenerTest.php
@@ -1,0 +1,234 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\EventListener\Menu;
+
+use Contao\BackendUser;
+use Contao\CoreBundle\Event\MenuEvent;
+use Contao\CoreBundle\EventListener\Menu\BackendMainListener;
+use Contao\CoreBundle\Tests\TestCase;
+use Knp\Menu\MenuFactory;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Routing\RouterInterface;
+
+class BackendMainListenerTest extends TestCase
+{
+    public function testBuildsTheMainMenu(): void
+    {
+        $user = $this->createMock(BackendUser::class);
+        $user
+            ->expects($this->once())
+            ->method('navigation')
+            ->willReturn($this->getNavigation())
+        ;
+
+        $security = $this->createMock(Security::class);
+        $security
+            ->method('getUser')
+            ->willReturn($user)
+        ;
+
+        $nodeFactory = new MenuFactory();
+        $event = new MenuEvent($nodeFactory, $nodeFactory->createItem('mainMenu'));
+
+        $listener = new BackendMainListener($security, new RequestStack(), false);
+        $listener($event);
+
+        $tree = $event->getTree();
+
+        $this->assertSame('mainMenu', $tree->getName());
+
+        $children = $tree->getChildren();
+
+        $this->assertCount(2, $children);
+        $this->assertSame(['category1', 'category2'], array_keys($children));
+
+        // Category 1
+        $this->assertSame('Category 1', $children['category1']->getLabel());
+        $this->assertSame([], $children['category1']->getAttributes());
+        $this->assertSame(['id' => 'category1'], $children['category1']->getChildrenAttributes());
+        $this->assertSame(['translation_domain' => false], $children['category1']->getExtras());
+
+        $this->assertSame(
+            [
+                'class' => 'group-category1 custom-class',
+                'title' => 'Category 1 Title',
+                'data-action' => 'contao--toggle-navigation#toggle:prevent',
+                'data-contao--toggle-navigation-category-param' => 'category1',
+                'aria-controls' => 'category1',
+                'data-turbo-prefetch' => 'false',
+                'aria-expanded' => 'true',
+            ],
+            $children['category1']->getLinkAttributes(),
+        );
+
+        $grandChildren = $children['category1']->getChildren();
+
+        $this->assertCount(2, $grandChildren);
+        $this->assertSame(['node1', 'node2'], array_keys($grandChildren));
+
+        // Node 1
+        $this->assertSame('Node 1', $grandChildren['node1']->getLabel());
+        $this->assertSame('/node1', $grandChildren['node1']->getUri());
+        $this->assertSame(['class' => 'node1', 'title' => 'Node 1 Title'], $grandChildren['node1']->getLinkAttributes());
+        $this->assertSame(['translation_domain' => false], $grandChildren['node1']->getExtras());
+
+        // Node 1
+        $this->assertSame('Node 2', $grandChildren['node2']->getLabel());
+        $this->assertSame('/node2', $grandChildren['node2']->getUri());
+        $this->assertSame(['class' => 'node2', 'title' => 'Node 2 Title'], $grandChildren['node2']->getLinkAttributes());
+        $this->assertSame(['translation_domain' => false], $grandChildren['node2']->getExtras());
+
+        // Category 2
+        $this->assertSame('Category 2', $children['category2']->getLabel());
+        $this->assertSame(['class' => 'collapsed'], $children['category2']->getAttributes());
+        $this->assertSame(['id' => 'category2'], $children['category2']->getChildrenAttributes());
+        $this->assertSame(['translation_domain' => false], $children['category2']->getExtras());
+
+        $this->assertSame(
+            [
+                'class' => 'group-category2',
+                'title' => 'Category 2 Title',
+                'data-action' => 'contao--toggle-navigation#toggle:prevent',
+                'data-contao--toggle-navigation-category-param' => 'category2',
+                'aria-controls' => 'category2',
+                'data-turbo-prefetch' => 'false',
+                'aria-expanded' => 'false',
+            ],
+            $children['category2']->getLinkAttributes(),
+        );
+    }
+
+    public function testDoesNotBuildTheMainMenuIfNoUserIsGiven(): void
+    {
+        $security = $this->createMock(Security::class);
+        $security
+            ->method('getUser')
+            ->willReturn(null)
+        ;
+
+        $router = $this->createMock(RouterInterface::class);
+        $router
+            ->expects($this->never())
+            ->method('generate')
+        ;
+
+        $nodeFactory = new MenuFactory();
+        $event = new MenuEvent($nodeFactory, $nodeFactory->createItem('mainMenu'));
+
+        $listener = new BackendMainListener($security, new RequestStack(), false);
+        $listener($event);
+
+        $tree = $event->getTree();
+
+        $this->assertCount(0, $tree->getChildren());
+    }
+
+    public function testDoesNotBuildTheMainMenuIfTheNameDoesNotMatch(): void
+    {
+        $security = $this->createMock(Security::class);
+        $security
+            ->method('getUser')
+            ->willReturn(null)
+        ;
+
+        $router = $this->createMock(RouterInterface::class);
+        $router
+            ->expects($this->never())
+            ->method('generate')
+        ;
+
+        $nodeFactory = new MenuFactory();
+        $event = new MenuEvent($nodeFactory, $nodeFactory->createItem('root'));
+
+        $listener = new BackendMainListener($security, new RequestStack(), false);
+        $listener($event);
+
+        $tree = $event->getTree();
+
+        $this->assertCount(0, $tree->getChildren());
+    }
+
+    public function testAddsTheTemplateStudioMenuItemToTheMainMenu(): void
+    {
+        $user = $this->createMock(BackendUser::class);
+        $user
+            ->expects($this->once())
+            ->method('navigation')
+            ->willReturn([
+                'design' => [
+                    'label' => 'Layout',
+                    'title' => 'Layout',
+                    'href' => '/',
+                    'class' => 'design-category node-expanded trail',
+                    'modules' => [],
+                ],
+            ])
+        ;
+
+        $security = $this->createMock(Security::class);
+        $security
+            ->method('getUser')
+            ->willReturn($user)
+        ;
+
+        $nodeFactory = new MenuFactory();
+        $event = new MenuEvent($nodeFactory, $nodeFactory->createItem('mainMenu'));
+
+        $listener = new BackendMainListener($security, new RequestStack(), true);
+        $listener($event);
+
+        $children = $event->getTree()->getChildren()['design']->getChildren();
+
+        $this->assertArrayHasKey('template-studio', $children);
+        $this->assertSame('Template Studio', $children['template-studio']->getLabel());
+    }
+
+    /**
+     * @return array<string, array<string, array<string, array<string, bool|string>>|string>>
+     */
+    private function getNavigation(): array
+    {
+        return [
+            'category1' => [
+                'label' => 'Category 1',
+                'title' => 'Category 1 Title',
+                'href' => '/',
+                'class' => 'group-category1 node-expanded trail custom-class',
+                'modules' => [
+                    'node1' => [
+                        'label' => 'Node 1',
+                        'title' => 'Node 1 Title',
+                        'href' => '/node1',
+                        'class' => 'node1',
+                        'isActive' => true,
+                    ],
+                    'node2' => [
+                        'label' => 'Node 2',
+                        'title' => 'Node 2 Title',
+                        'href' => '/node2',
+                        'class' => 'node2',
+                        'isActive' => false,
+                    ],
+                ],
+            ],
+            'category2' => [
+                'label' => 'Category 2',
+                'title' => 'Category 2 Title',
+                'href' => '/',
+                'class' => 'group-category2 node-collapsed',
+                'modules' => [],
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
This eventually splits the `BackendMenuListener` class into a `BackendMainListener` and a `BackendHeaderListener` class, so now we have

* `contao.listener.menu.backend_favorites`
* `contao.listener.menu.backend_header`
* `contao.listener.menu.backend_login` (see #7817)
* `contao.listener.menu.backend_logout`
* `contao.listener.menu.backend_main`
* `contao.listener.menu.backend_preview`.

Just a nitpick without any functional changes.
