### PR TITLE
Fix `$models` within `ContaoDataCollector` being `null`

### DIFF
--- a/core-bundle/src/DataCollector/ContaoDataCollector.php
+++ b/core-bundle/src/DataCollector/ContaoDataCollector.php
@@ -254,7 +254,7 @@ class ContaoDataCollector extends DataCollector implements FrameworkAwareInterfa
             return [];
         }
 
-        $models = $this->framework->getAdapter(ArticleModel::class)->findByPid($page->id, ['order' => 'tl_article.sorting']);
+        $models = $this->framework->getAdapter(ArticleModel::class)->findByPid($page->id, ['order' => 'tl_article.sorting']) ?? [];
         $articles = [];
 
         foreach ($models as $article) {


### PR DESCRIPTION
### Description

This PR fixes a PHP warning that happens when deleting all possible articles from a page (that's how you can reproduce it 🙃)
I was unable to reproduce the same behavior in the current 5.4 version

![image](https://github.com/user-attachments/assets/3c801292-b1e7-44d7-9eec-880e8e2e9623)

![image](https://github.com/user-attachments/assets/1fb444b4-a73a-4c66-adc1-e0a4a105b09b)

### Stacktrace

<details>
  <summary>
    Stacktrace
  </summary>

```
ErrorException:
Warning: foreach() argument must be of type array|object, null given

at C:\MyProjectPath\core-bundle\src\DataCollector\ContaoDataCollector.php:260
at Contao\CoreBundle\DataCollector\ContaoDataCollector->getArticles()
(C:\MyProjectPath\core-bundle\src\DataCollector\ContaoDataCollector.php:129)
at Contao\CoreBundle\DataCollector\ContaoDataCollector->addSummaryData()
(C:\MyProjectPath\core-bundle\src\DataCollector\ContaoDataCollector.php:55)
at Contao\CoreBundle\DataCollector\ContaoDataCollector->collect(object(Request), object(Response), null)
(C:\Projekte\Test_Environment\contao\55\vendor\symfony\http-kernel\Profiler\Profiler.php:158)
at Symfony\Component\HttpKernel\Profiler\Profiler->collect(object(Request), object(Response), null)
(C:\Projekte\Test_Environment\contao\55\vendor\symfony\http-kernel\EventListener\ProfilerListener.php:102)
at Symfony\Component\HttpKernel\EventListener\ProfilerListener->onKernelResponse(object(ResponseEvent), 'kernel.response', object(TraceableEventDispatcher))
(C:\Projekte\Test_Environment\contao\55\vendor\symfony\event-dispatcher\Debug\WrappedListener.php:115)
at Symfony\Component\EventDispatcher\Debug\WrappedListener->__invoke(object(ResponseEvent), 'kernel.response', object(TraceableEventDispatcher))
(C:\Projekte\Test_Environment\contao\55\vendor\symfony\event-dispatcher\EventDispatcher.php:206)
at Symfony\Component\EventDispatcher\EventDispatcher->callListeners(array(object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener)), 'kernel.response', object(ResponseEvent))
(C:\Projekte\Test_Environment\contao\55\vendor\symfony\event-dispatcher\EventDispatcher.php:56)
at Symfony\Component\EventDispatcher\EventDispatcher->dispatch(object(ResponseEvent), 'kernel.response')
(C:\Projekte\Test_Environment\contao\55\vendor\symfony\event-dispatcher\Debug\TraceableEventDispatcher.php:122)
at Symfony\Component\EventDispatcher\Debug\TraceableEventDispatcher->dispatch(object(ResponseEvent), 'kernel.response')
(C:\Projekte\Test_Environment\contao\55\vendor\symfony\http-kernel\HttpKernel.php:216)
at Symfony\Component\HttpKernel\HttpKernel->filterResponse(object(Response), object(Request), 2)
(C:\Projekte\Test_Environment\contao\55\vendor\symfony\http-kernel\HttpKernel.php:204)
at Symfony\Component\HttpKernel\HttpKernel->handleRaw(object(Request), 2)
(C:\Projekte\Test_Environment\contao\55\vendor\symfony\http-kernel\HttpKernel.php:76)
at Symfony\Component\HttpKernel\HttpKernel->handle(object(Request), 2, false)
(C:\Projekte\Test_Environment\contao\55\vendor\symfony\http-kernel\HttpCache\SubRequestHandler.php:86)
at Symfony\Component\HttpKernel\HttpCache\SubRequestHandler::handle(object(HttpKernel), object(Request), 2, false)
(C:\Projekte\Test_Environment\contao\55\vendor\symfony\http-kernel\Fragment\InlineFragmentRenderer.php:75)
at Symfony\Component\HttpKernel\Fragment\InlineFragmentRenderer->render('/_fragment?_path=_format%3Dhtml%26_locale%3Den%26_controller%3Dcontao.content_element.text', object(Request), array('ignore_errors' => false))
(C:\Projekte\Test_Environment\contao\55\vendor\symfony\http-kernel\Fragment\FragmentHandler.php:81)
at Symfony\Component\HttpKernel\Fragment\FragmentHandler->render(object(ContentElementReference), 'forward', array('ignore_errors' => false))
(C:\MyProjectPath\core-bundle\src\Fragment\FragmentHandler.php:67)
at Contao\CoreBundle\Fragment\FragmentHandler->render(object(ContentElementReference))
(C:\MyProjectPath\core-bundle\contao\elements\ContentProxy.php:74)
at Contao\ContentProxy->generate()
(C:\MyProjectPath\core-bundle\contao\library\Contao\Controller.php:601)
at Contao\Controller::getContentElement(object(ContentModel), 'main')
(C:\MyProjectPath\core-bundle\contao\modules\ModuleArticle.php:189)
at Contao\ModuleArticle->compile()
(C:\MyProjectPath\core-bundle\contao\modules\Module.php:214)
at Contao\Module->generate()
(C:\MyProjectPath\core-bundle\contao\modules\ModuleArticle.php:69)
at Contao\ModuleArticle->generate(true)
(C:\MyProjectPath\core-bundle\contao\library\Contao\Controller.php:490)
at Contao\Controller::getArticle('50', false, true)
(C:\MyProjectPath\core-bundle\src\InsertTag\Resolver\LegacyInsertTag.php:270)
at Contao\CoreBundle\InsertTag\Resolver\LegacyInsertTag->__invoke(object(ResolvedInsertTag))
(C:\MyProjectPath\core-bundle\src\InsertTag\InsertTagParser.php:420)
at Contao\CoreBundle\InsertTag\InsertTagParser->renderSubscription(object(ResolvedInsertTag), true)
(C:\MyProjectPath\core-bundle\src\InsertTag\InsertTagParser.php:392)
at Contao\CoreBundle\InsertTag\InsertTagParser->executeReplace(object(ParsedSequence), true, object(OutputType))
(C:\MyProjectPath\core-bundle\src\InsertTag\InsertTagParser.php:133)
at Contao\CoreBundle\InsertTag\InsertTagParser->replace('
<a href="{{env::path|urlattr}}" class="logo logo--footer">	<img src="files/contaodemo/theme/src/img/contao-official-demo.svg" alt="logo Contao Official Demo"></a><div id="footer-content-block" class="footer-content">	{{insert_article::50}}</div><span class="footer-claim">	Designed with 🧡 <span style="display: inline-block;">by&nbsp;<a href="https://www.borowiakziehe.de" rel="noopener noreferrer" target="_blank">borowiakziehe</a></span></span>{{insert_module::64}}')
(C:\MyProjectPath\core-bundle\contao\library\Contao\TemplateInheritance.php:153)
at Contao\Template->inherit()
(C:\MyProjectPath\core-bundle\contao\library\Contao\Template.php:322)
at Contao\Template->parse()
(C:\MyProjectPath\core-bundle\contao\classes\FrontendTemplate.php:43)
at Contao\FrontendTemplate->parse()
(C:\MyProjectPath\core-bundle\contao\modules\Module.php:245)
at Contao\Module->generate()
(C:\MyProjectPath\core-bundle\contao\library\Contao\Controller.php:405)
at Contao\Controller::getFrontendModule(object(ModuleModel), 'footer')
(C:\MyProjectPath\core-bundle\contao\pages\PageRegular.php:183)
at Contao\PageRegular->prepare(object(PageModel))
(C:\MyProjectPath\core-bundle\contao\pages\PageRegular.php:47)
at Contao\PageRegular->getResponse(object(PageModel), true)
(C:\MyProjectPath\core-bundle\contao\controllers\FrontendIndex.php:65)
at Contao\FrontendIndex->renderPage(object(PageModel))
(C:\Projekte\Test_Environment\contao\55\vendor\symfony\http-kernel\HttpKernel.php:183)
at Symfony\Component\HttpKernel\HttpKernel->handleRaw(object(Request), 1)
(C:\Projekte\Test_Environment\contao\55\vendor\symfony\http-kernel\HttpKernel.php:76)
at Symfony\Component\HttpKernel\HttpKernel->handle(object(Request), 1, true)
(C:\Projekte\Test_Environment\contao\55\vendor\symfony\http-kernel\Kernel.php:182)
at Symfony\Component\HttpKernel\Kernel->handle(object(Request))
(C:\Projekte\Test_Environment\contao\55\public\index.php:42)
```
</details>
