### PR TITLE
Allow setting a custom redirect route when unauthenticated

### DIFF
--- a/core-bundle/src/Controller/BackendTemplateStudioController.php
+++ b/core-bundle/src/Controller/BackendTemplateStudioController.php
@@ -90,7 +90,7 @@ class BackendTemplateStudioController extends AbstractBackendController
     #[Route(
         '/%contao.backend.route_prefix%/template-studio-tree',
         name: '_contao_template_studio_tree.stream',
-        defaults: ['_scope' => 'backend'],
+        defaults: ['_scope' => 'backend', '_unauthenticated_redirect_route' => 'contao_template_studio'],
         methods: ['GET'],
         condition: "'text/vnd.turbo-stream.html' in request.getAcceptableContentTypes()",
     )]
@@ -109,7 +109,7 @@ class BackendTemplateStudioController extends AbstractBackendController
     #[Route(
         '/%contao.backend.route_prefix%/template-studio/select_theme',
         name: '_contao_template_studio_select_theme.stream',
-        defaults: ['_scope' => 'backend', '_token_check' => false],
+        defaults: ['_scope' => 'backend', '_token_check' => false, '_unauthenticated_redirect_route' => 'contao_template_studio'],
         methods: ['POST'],
         condition: "'text/vnd.turbo-stream.html' in request.getAcceptableContentTypes()",
     )]
@@ -138,7 +138,7 @@ class BackendTemplateStudioController extends AbstractBackendController
         '/%contao.backend.route_prefix%/template-studio/resource/{identifier}',
         name: '_contao_template_studio_editor_tab.stream',
         requirements: ['identifier' => '.+'],
-        defaults: ['_scope' => 'backend'],
+        defaults: ['_scope' => 'backend', '_unauthenticated_redirect_route' => 'contao_template_studio'],
         methods: ['GET'],
         condition: "'text/vnd.turbo-stream.html' in request.getAcceptableContentTypes()",
     )]
@@ -190,7 +190,7 @@ class BackendTemplateStudioController extends AbstractBackendController
     #[Route(
         '/%contao.backend.route_prefix%/template-studio-follow',
         name: '_contao_template_studio_follow.stream',
-        defaults: ['_scope' => 'backend'],
+        defaults: ['_scope' => 'backend', '_unauthenticated_redirect_route' => 'contao_template_studio'],
         methods: ['GET'],
         condition: "'text/vnd.turbo-stream.html' in request.getAcceptableContentTypes()",
     )]
@@ -211,7 +211,7 @@ class BackendTemplateStudioController extends AbstractBackendController
     #[Route(
         '/%contao.backend.route_prefix%/template-studio-block-info',
         name: '_contao_template_studio_block_info.stream',
-        defaults: ['_scope' => 'backend'],
+        defaults: ['_scope' => 'backend', '_unauthenticated_redirect_route' => 'contao_template_studio'],
         methods: ['GET'],
         condition: "'text/vnd.turbo-stream.html' in request.getAcceptableContentTypes()",
     )]
@@ -297,7 +297,7 @@ class BackendTemplateStudioController extends AbstractBackendController
     #[Route(
         '/%contao.backend.route_prefix%/template-studio-autocomplete-data',
         name: '_contao_template_studio_autocomplete_data.stream',
-        defaults: ['_scope' => 'backend'],
+        defaults: ['_scope' => 'backend', '_unauthenticated_redirect_route' => 'contao_template_studio'],
         methods: ['GET'],
         condition: "'text/vnd.turbo-stream.html' in request.getAcceptableContentTypes()",
     )]
@@ -325,7 +325,7 @@ class BackendTemplateStudioController extends AbstractBackendController
         '/%contao.backend.route_prefix%/template-studio/resource/{identifier}',
         name: '_contao_template_studio_operation.stream',
         requirements: ['identifier' => '.+'],
-        defaults: ['_scope' => 'backend', '_token_check' => false],
+        defaults: ['_scope' => 'backend', '_token_check' => false, '_unauthenticated_redirect_route' => 'contao_template_studio'],
         methods: ['POST'],
         condition: "'text/vnd.turbo-stream.html' in request.getAcceptableContentTypes()",
     )]

--- a/core-bundle/src/Security/Authenticator/ContaoLoginAuthenticator.php
+++ b/core-bundle/src/Security/Authenticator/ContaoLoginAuthenticator.php
@@ -220,6 +220,8 @@ class ContaoLoginAuthenticator extends AbstractAuthenticator implements Authenti
         // without any parameters.
         if ('contao_backend' === $request->attributes->get('_route') && [] === $request->query->all()) {
             $loginParams = [];
+        } elseif (null !== ($redirectRoute = $request->attributes->get('_unauthenticated_redirect_route'))) {
+            $loginParams = ['redirect' => $this->router->generate($redirectRoute, referenceType: UrlGeneratorInterface::ABSOLUTE_URL)];
         } else {
             $loginParams = ['redirect' => $request->getUri()];
         }

--- a/core-bundle/tests/Security/Authenticator/ContaoLoginAuthenticatorTest.php
+++ b/core-bundle/tests/Security/Authenticator/ContaoLoginAuthenticatorTest.php
@@ -355,6 +355,46 @@ class ContaoLoginAuthenticatorTest extends TestCase
         $this->assertSame('/contao/login', $response->getTargetUrl());
     }
 
+    public function testUsesCustomRedirectParameter(): void
+    {
+        $scopeMatcher = $this->createMock(ScopeMatcher::class);
+        $scopeMatcher
+            ->expects($this->once())
+            ->method('isBackendRequest')
+            ->willReturn(true)
+        ;
+
+        $router = $this->createMock(RouterInterface::class);
+        $router
+            ->expects($this->exactly(2))
+            ->method('generate')
+            ->willReturnMap([
+                ['my_fallback_route', [], UrlGeneratorInterface::ABSOLUTE_URL, 'https://example.com/my_fallback'],
+                ['contao_backend_login', ['redirect' => 'https://example.com/my_fallback'], UrlGeneratorInterface::ABSOLUTE_URL, '/contao/login?redirect=https://example.com/my_fallback'],
+            ])
+        ;
+
+        $uriSigner = $this->createMock(UriSigner::class);
+        $uriSigner
+            ->method('sign')
+            ->willReturnArgument(0)
+        ;
+
+        $authenticator = $this->getContaoLoginAuthenticator(
+            scopeMatcher: $scopeMatcher,
+            router: $router,
+            uriSigner: $uriSigner,
+        );
+
+        $request = Request::create('https://example.com/foo/bar');
+        $request->attributes->set('_unauthenticated_redirect_route', 'my_fallback_route');
+
+        $response = $authenticator->start($request);
+
+        $this->assertInstanceOf(RedirectResponse::class, $response);
+        $this->assertSame('/contao/login?redirect=https://example.com/my_fallback', $response->getTargetUrl());
+    }
+
     /**
      * @dataProvider getAuthenticationData
      */


### PR DESCRIPTION
Currently, when the back end session expires (or the cookie is removed otherwise), a redirect to the login mask happens. We are adding a request parameter `redirect` to allow redirecting back to the last requested URL. This works fine until the requested URL is not supposed to be visited in the browser, which is the case for every Turbo stream request or any generic Ajax request. 

**Example:** Your session has expired and you try to open the text content element in the template studio. Your redirect URL will now be `/contao/template-studio/resource/content_element/text`, which is a route requiring a specific content type and thus will produce a 404.

This PR introduces a new `_unauthenticated_redirect_route` request attribute. When set, the `ContaoLoginAuthenticator` uses this route for the `redirect=…` request parameter. This allows controllers to specify a dedicated fallback route, which I made use of in the `BackendTemplateStudioController`.