### PR TITLE
Fix the SEAL index name

### DIFF
--- a/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
+++ b/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
@@ -361,12 +361,9 @@ class ContaoCoreExtension extends Extension implements PrependExtensionInterface
         $engine
             ->setArgument(1, (new Definition(BackendSearch::class))
                 ->setFactory([null, 'getSearchEngineSchema'])
-                ->setArgument(0, $indexName),
+                ->setArgument('$indexName', $indexName),
             )
         ;
-
-        $factory = $container->getDefinition('contao.search.backend');
-        $factory->setArgument('$indexName', $indexName);
     }
 
     private function handleCrawlConfig(array $config, ContainerBuilder $container): void

--- a/core-bundle/src/Search/Backend/BackendSearch.php
+++ b/core-bundle/src/Search/Backend/BackendSearch.php
@@ -42,7 +42,6 @@ class BackendSearch
         private readonly MessageBusInterface $messageBus,
         private readonly WebWorker $webWorker,
         private readonly SealReindexProvider $reindexProvider,
-        private readonly string $indexName,
     ) {
     }
 
@@ -75,7 +74,7 @@ class BackendSearch
             }
         }
 
-        $this->engine->bulk($this->indexName, [], $documentIds);
+        $this->engine->bulk(self::SEAL_INTERNAL_INDEX_NAME, [], $documentIds);
 
         return $this;
     }
@@ -158,8 +157,8 @@ class BackendSearch
     public function clear(): void
     {
         // TODO: We need an API for that in SEAL
-        $this->engine->dropIndex($this->indexName);
-        $this->engine->createIndex($this->indexName);
+        $this->engine->dropIndex(self::SEAL_INTERNAL_INDEX_NAME);
+        $this->engine->createIndex(self::SEAL_INTERNAL_INDEX_NAME);
     }
 
     private function createSearchBuilder(Query $query): SearchBuilder

--- a/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
+++ b/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
@@ -712,8 +712,9 @@ class ContaoCoreExtensionTest extends TestCase
         $this->assertSame('whatever://search-adapter-you-like', $adapter->getArgument(0));
 
         $this->assertTrue($container->hasDefinition('contao.search.backend'));
-        $backendSearch = $container->getDefinition('contao.search.backend');
-        $this->assertSame('my_backend_search_index', $backendSearch->getArgument('$indexName'));
+        $this->assertTrue($container->hasDefinition('contao.search_backend.engine'));
+        $backendSearchEngine = $container->getDefinition('contao.search_backend.engine');
+        $this->assertSame('my_backend_search_index', $backendSearchEngine->getArgument(1)->getArgument('$indexName'));
     }
 
     public function testCspConfiguration(): void

--- a/core-bundle/tests/Search/Backend/BackendSearchTest.php
+++ b/core-bundle/tests/Search/Backend/BackendSearchTest.php
@@ -247,7 +247,6 @@ class BackendSearchTest extends TestCase
             $messageBus,
             $this->createMock(WebWorker::class),
             $this->createMock(SealReindexProvider::class),
-            $indexName,
         );
 
         $result = $backendSearch->search(new Query(20, 'search me'));

--- a/core-bundle/tests/Search/Backend/BackendSearchTest.php
+++ b/core-bundle/tests/Search/Backend/BackendSearchTest.php
@@ -56,7 +56,6 @@ class BackendSearchTest extends TestCase
             $this->createMock(MessageBusInterface::class),
             $webWorker,
             $this->createMock(SealReindexProvider::class),
-            'contao_backend_search',
         );
 
         $this->assertTrue($backendSearch->isAvailable());
@@ -97,7 +96,6 @@ class BackendSearchTest extends TestCase
             $this->createMock(MessageBusInterface::class),
             $this->createMock(WebWorker::class),
             $reindexProvider,
-            'contao_backend_search',
         );
 
         $backendSearch->reindex($reindexConfig, false);
@@ -126,7 +124,6 @@ class BackendSearchTest extends TestCase
             $messageBus,
             $this->createMock(WebWorker::class),
             $this->createMock(SealReindexProvider::class),
-            'contao_backend_search',
         );
 
         $backendSearch->reindex($reindexConfig);
@@ -188,7 +185,6 @@ class BackendSearchTest extends TestCase
             $this->createMock(MessageBusInterface::class),
             $this->createMock(WebWorker::class),
             $this->createMock(SealReindexProvider::class),
-            $indexName,
         );
         $result = $backendSearch->search(new Query(20, 'search me'));
 
@@ -284,7 +280,6 @@ class BackendSearchTest extends TestCase
             $this->createMock(MessageBusInterface::class),
             $this->createMock(WebWorker::class),
             $this->createMock(SealReindexProvider::class),
-            'contao_backend_search',
         );
 
         $backendSearch->deleteDocuments($documentTypesAndIds, false);
@@ -313,7 +308,6 @@ class BackendSearchTest extends TestCase
             $messageBus,
             $this->createMock(WebWorker::class),
             $this->createMock(SealReindexProvider::class),
-            'contao_backend_search',
         );
 
         $backendSearch->deleteDocuments($documentTypesAndIds);


### PR DESCRIPTION
The index name is only relevant for the schema. Internally, SEAL uses a hardcoded string which cannot be changed.

Is that correct like this @alexander-schranz? :) 