### PR TITLE
Implement Flysystem default public URI support

### DIFF
--- a/core-bundle/config/services.yaml
+++ b/core-bundle/config/services.yaml
@@ -301,6 +301,11 @@ services:
         arguments:
             - !tagged_iterator contao.public_file_uri_provider
 
+    contao.filesystem.public_uri.flysystem_default_provider:
+        class: Contao\CoreBundle\Filesystem\PublicUri\FlysystemDefaultProvider
+        tags:
+            - { name: contao.public_file_uri_provider }
+
     contao.filesystem.public_uri.symlinked_local_files_provider:
         class: Contao\CoreBundle\Filesystem\PublicUri\SymlinkedLocalFilesProvider
         arguments:
@@ -309,11 +314,6 @@ services:
             - '@request_stack'
         tags:
             - { name: contao.public_file_uri_provider }
-
-    contao.filesystem.public_uri.flysystem_default_provider:
-        class: Contao\CoreBundle\Filesystem\PublicUri\FlysystemDefaultProvider
-        tags:
-            - { name: contao.public_file_uri_provider}
 
     contao.filesystem.virtual_factory:
         class: Contao\CoreBundle\Filesystem\VirtualFilesystemFactory

--- a/core-bundle/config/services.yaml
+++ b/core-bundle/config/services.yaml
@@ -310,6 +310,11 @@ services:
         tags:
             - { name: contao.public_file_uri_provider }
 
+    contao.filesystem.public_uri.flysystem_default_provider:
+        class: Contao\CoreBundle\Filesystem\PublicUri\FlysystemDefaultProvider
+        tags:
+            - { name: contao.public_file_uri_provider}
+
     contao.filesystem.virtual_factory:
         class: Contao\CoreBundle\Filesystem\VirtualFilesystemFactory
         arguments:

--- a/core-bundle/src/Filesystem/PublicUri/FlysystemDefaultProvider.php
+++ b/core-bundle/src/Filesystem/PublicUri/FlysystemDefaultProvider.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Filesystem\PublicUri;
+
+use League\Flysystem\Config;
+use League\Flysystem\FilesystemAdapter;
+use League\Flysystem\UrlGeneration\PublicUrlGenerator;
+use Nyholm\Psr7\Uri;
+use Psr\Http\Message\UriInterface;
+
+class FlysystemDefaultProvider implements PublicUriProviderInterface
+{
+    /**
+     * Generate default public URLs for adapters that are a PublicUrlGenerator.
+     * See https://flysystem.thephpleague.com/docs/usage/public-urls/.
+     */
+    public function getUri(FilesystemAdapter $adapter, string $adapterPath, OptionsInterface|null $options): UriInterface|null
+    {
+        if ($options || !$adapter instanceof PublicUrlGenerator) {
+            return null;
+        }
+
+        return new Uri($adapter->publicUrl($adapterPath, new Config()));
+    }
+}

--- a/core-bundle/tests/Filesystem/PublicUri/FlysystemDefaultProviderTest.php
+++ b/core-bundle/tests/Filesystem/PublicUri/FlysystemDefaultProviderTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\Filesystem\PublicUri;
+
+use Contao\CoreBundle\Filesystem\PublicUri\FlysystemDefaultProvider;
+use Contao\CoreBundle\Tests\Fixtures\FilesystemAdapterAndPublicUrlGeneratorInterface;
+use Contao\CoreBundle\Tests\TestCase;
+use League\Flysystem\Local\LocalFilesystemAdapter;
+
+/**
+ * @experimental
+ */
+class FlysystemDefaultProviderTest extends TestCase
+{
+    public function testGetUri(): void
+    {
+        $adapter = $this->createMock(FilesystemAdapterAndPublicUrlGeneratorInterface::class);
+        $adapter
+            ->method('publicUrl')
+            ->with('path/to/resource.txt')
+            ->willReturn('https://some.bucket/some.key')
+        ;
+
+        $provider = new FlysystemDefaultProvider();
+        $uri = $provider->getUri($adapter, 'path/to/resource.txt', null);
+
+        $this->assertSame('https://some.bucket/some.key', (string) $uri);
+    }
+
+    public function testGetUriWithNonMatchingAdapter(): void
+    {
+        $provider = new FlysystemDefaultProvider();
+
+        $uri = $provider->getUri(
+            $this->createMock(LocalFilesystemAdapter::class),
+            'path/to/resource.txt',
+            null,
+        );
+
+        $this->assertNull($uri);
+    }
+}

--- a/core-bundle/tests/Fixtures/FilesystemAdapterAndPublicUrlGeneratorInterface.php
+++ b/core-bundle/tests/Fixtures/FilesystemAdapterAndPublicUrlGeneratorInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\Fixtures;
+
+use League\Flysystem\FilesystemAdapter;
+use League\Flysystem\UrlGeneration\PublicUrlGenerator;
+
+interface FilesystemAdapterAndPublicUrlGeneratorInterface extends FilesystemAdapter, PublicUrlGenerator
+{
+}


### PR DESCRIPTION
Closes #7636 

This adds default public uri support as outlined in #7636. Only a few lines of code but now we can generate URLs for AWS S3, Async AWS S3, Azure Blob Storage, Google Cloud Storage and WebDAV.