### PR TITLE
Fix an SQL syntax error in the `FileExtensionMigration`

### DIFF
--- a/core-bundle/src/Migration/Version503/FileExtensionMigration.php
+++ b/core-bundle/src/Migration/Version503/FileExtensionMigration.php
@@ -38,7 +38,7 @@ class FileExtensionMigration extends AbstractMigration
 
     public function run(): MigrationResult
     {
-        $this->connection->executeStatement("UPDATE tl_files SET extension = LOWER(extension) WHERE CAST(extension AS BINARY) REGEXP CAST('[[:upper:]] AS BINARY)'");
+        $this->connection->executeStatement("UPDATE tl_files SET extension = LOWER(extension) WHERE CAST(extension AS BINARY) REGEXP CAST('[[:upper:]]' AS BINARY)");
 
         return $this->createResult(true);
     }


### PR DESCRIPTION
In https://github.com/contao/contao/pull/7785 the CAST(... AS BINARY) was added. However the syntax is not correct, so the migration wont run.

Stacktrace:
``` [PDOException (42000)]
  SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds
   to your MariaDB server version for the right syntax to use near '' at line 1
Exception trace:
  at /var/www/html/vendor/doctrine/dbal/src/Driver/PDO/Connection.php:33
 PDO->exec() at /var/www/html/vendor/doctrine/dbal/src/Driver/PDO/Connection.php:33
 Doctrine\DBAL\Driver\PDO\Connection->exec() at /var/www/html/vendor/doctrine/dbal/src/Connection.php:1211
 Doctrine\DBAL\Connection->executeStatement() at /var/www/html/vendor/contao/core-bundle/src/Migration/Version503/FileExtensionMigration.php:41
 Contao\CoreBundle\Migration\Version503\FileExtensionMigration->run() at /var/www/html/vendor/contao/core-bundle/src/Migration/MigrationCollection.php:63
 Contao\CoreBundle\Migration\MigrationCollection->run() at /var/www/html/vendor/contao/core-bundle/src/Command/MigrateCommand.php:269
 Contao\CoreBundle\Command\MigrateCommand->executeMigrations() at /var/www/html/vendor/contao/core-bundle/src/Command/MigrateCommand.php:192
 Contao\CoreBundle\Command\MigrateCommand->executeCommand() at /var/www/html/vendor/contao/core-bundle/src/Command/MigrateCommand.php:92
 Contao\CoreBundle\Command\MigrateCommand->execute() at /var/www/html/vendor/symfony/console/Command/Command.php:326
 Symfony\Component\Console\Command\Command->run() at /var/www/html/vendor/symfony/console/Application.php:1096
 Symfony\Component\Console\Application->doRunCommand() at /var/www/html/vendor/symfony/framework-bundle/Console/Application.php:126
 Symfony\Bundle\FrameworkBundle\Console\Application->doRunCommand() at /var/www/html/vendor/symfony/console/Application.php:324
 Symfony\Component\Console\Application->doRun() at /var/www/html/vendor/symfony/framework-bundle/Console/Application.php:80
 Symfony\Bundle\FrameworkBundle\Console\Application->doRun() at /var/www/html/vendor/symfony/console/Application.php:175
 Symfony\Component\Console\Application->run() at /var/www/html/vendor/contao/manager-bundle/bin/contao-console:40
 include() at /var/www/html/vendor/bin/contao-console:119```