### PR TITLE
Remove an unnecessary line of code

### DIFF
--- a/core-bundle/contao/drivers/DC_Folder.php
+++ b/core-bundle/contao/drivers/DC_Folder.php
@@ -2012,9 +2012,6 @@ class DC_Folder extends DataContainer implements ListableDataContainerInterface,
 						$this->strPath . '/' . $this->varValue . $this->strExtension,
 						$this->strPath . '/' . $varValue . $this->strExtension,
 					);
-
-					// Update the model cache
-					FilesModel::findByPath($this->strPath . '/' . $varValue . $this->strExtension);
 				}
 
 				System::getContainer()->get('monolog.logger.contao.files')->info('File or folder "' . $this->strPath . '/' . $this->varValue . $this->strExtension . '" has been renamed to "' . $this->strPath . '/' . $varValue . $this->strExtension . '"');


### PR DESCRIPTION
Followup to #7855

I just realized, I added this line before I implemented always clearing the model cache in the `syncDbafsAndUpdateModelCache()` function. So this line does nothing now and can be removed.