### PR TITLE
Allow legacy url parameters without alias in conflicting routes

### DIFF
--- a/core-bundle/src/Routing/AbstractPageRouteProvider.php
+++ b/core-bundle/src/Routing/AbstractPageRouteProvider.php
@@ -186,11 +186,11 @@ abstract class AbstractPageRouteProvider implements RouteProviderInterface
             $paramA = $a->getRequirement('parameters');
             $paramB = $b->getRequirement('parameters');
 
-            if ('/.+?' === $paramA && '(/.+?)?' === $paramB) {
+            if (PageRegistry::REGEX_REQUIRE_ITEM === $paramA && PageRegistry::REGEX === $paramB) {
                 return -1;
             }
 
-            if ('(/.+?)?' === $paramA && '/.+?' === $paramB) {
+            if (PageRegistry::REGEX === $paramA && PageRegistry::REGEX_REQUIRE_ITEM === $paramB) {
                 return 1;
             }
         }

--- a/core-bundle/src/Routing/Page/PageRegistry.php
+++ b/core-bundle/src/Routing/Page/PageRegistry.php
@@ -18,6 +18,10 @@ use Symfony\Contracts\Service\ResetInterface;
 
 class PageRegistry implements ResetInterface
 {
+    public const REGEX_REQUIRE_ITEM = '/[^/]*(/[^/]*/[^/]*)*[^/]*?';
+
+    public const REGEX = '(/.+?)?';
+
     private const DISABLE_CONTENT_COMPOSITION = ['forward', 'logout'];
 
     private array|null $urlPrefixes = null;
@@ -69,7 +73,7 @@ class PageRegistry implements ResetInterface
             } else {
                 $path = '/'.($pageModel->alias ?: $pageModel->id).'{!parameters}';
                 $defaults['parameters'] = '';
-                $requirements['parameters'] = $pageModel->requireItem ? '/.+?' : '(/.+?)?';
+                $requirements['parameters'] = $pageModel->requireItem ? self::REGEX_REQUIRE_ITEM : self::REGEX;
             }
         }
 

--- a/core-bundle/src/Routing/Page/PageRegistry.php
+++ b/core-bundle/src/Routing/Page/PageRegistry.php
@@ -18,7 +18,7 @@ use Symfony\Contracts\Service\ResetInterface;
 
 class PageRegistry implements ResetInterface
 {
-    public const REGEX_REQUIRE_ITEM = '/[^/]*(/[^/]*/[^/]*)*[^/]*?';
+    public const REGEX_REQUIRE_ITEM = '/[^/]+(/[^/]+/[^/]+)*?';
 
     public const REGEX = '(/.+?)?';
 

--- a/core-bundle/tests/Routing/AbstractPageRouteProviderTest.php
+++ b/core-bundle/tests/Routing/AbstractPageRouteProviderTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Tests\Routing;
 
 use Contao\CoreBundle\Routing\AbstractPageRouteProvider;
+use Contao\CoreBundle\Routing\Page\PageRegistry;
 use Contao\CoreBundle\Tests\TestCase;
 use Contao\PageModel;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -189,22 +190,22 @@ class AbstractPageRouteProviderTest extends TestCase
         ];
 
         yield 'Sorts route with required parameters first (1)' => [
-            new Route('/foo{!parameters}', ['pageModel' => $this->mockPageModel('de')], ['parameters' => '/.+?']),
-            new Route('/foo{!parameters}', ['pageModel' => $this->mockPageModel('de')], ['parameters' => '(/.+?)?']),
+            new Route('/foo{!parameters}', ['pageModel' => $this->mockPageModel('de')], ['parameters' => PageRegistry::REGEX_REQUIRE_ITEM]),
+            new Route('/foo{!parameters}', ['pageModel' => $this->mockPageModel('de')], ['parameters' => PageRegistry::REGEX]),
             ['de', 'de'],
             -1,
         ];
 
         yield 'Sorts route with required parameters first (2)' => [
-            new Route('/foo{!parameters}', ['pageModel' => $this->mockPageModel('de')], ['parameters' => '(/.+?)?']),
-            new Route('/foo{!parameters}', ['pageModel' => $this->mockPageModel('de')], ['parameters' => '/.+?']),
+            new Route('/foo{!parameters}', ['pageModel' => $this->mockPageModel('de')], ['parameters' => PageRegistry::REGEX]),
+            new Route('/foo{!parameters}', ['pageModel' => $this->mockPageModel('de')], ['parameters' => PageRegistry::REGEX_REQUIRE_ITEM]),
             ['de', 'de'],
             1,
         ];
 
         yield 'Ignores required parameters with equal requirement' => [
-            new Route('/foo{!parameters}', ['pageModel' => $this->mockPageModel('de')], ['parameters' => '/.+?']),
-            new Route('/foo{!parameters}', ['pageModel' => $this->mockPageModel('de')], ['parameters' => '/.+?']),
+            new Route('/foo{!parameters}', ['pageModel' => $this->mockPageModel('de')], ['parameters' => PageRegistry::REGEX_REQUIRE_ITEM]),
+            new Route('/foo{!parameters}', ['pageModel' => $this->mockPageModel('de')], ['parameters' => PageRegistry::REGEX_REQUIRE_ITEM]),
             ['de', 'de'],
             0,
         ];

--- a/core-bundle/tests/Routing/Page/PageRegistryTest.php
+++ b/core-bundle/tests/Routing/Page/PageRegistryTest.php
@@ -37,7 +37,7 @@ class PageRegistryTest extends TestCase
 
         $this->assertSame('/foo/bar{!parameters}.baz', $route->getPath());
         $this->assertSame('', $route->getDefault('parameters'));
-        $this->assertSame('(/.+?)?', $route->getRequirement('parameters'));
+        $this->assertSame(PageRegistry::REGEX, $route->getRequirement('parameters'));
     }
 
     public function testReturnsParameteredPageRouteIfPathIsNullWithRequireItem(): void
@@ -55,7 +55,7 @@ class PageRegistryTest extends TestCase
 
         $this->assertSame('/foo/bar{!parameters}.baz', $route->getPath());
         $this->assertSame('', $route->getDefault('parameters'));
-        $this->assertSame('/.+?', $route->getRequirement('parameters'));
+        $this->assertSame(PageRegistry::REGEX_REQUIRE_ITEM, $route->getRequirement('parameters'));
     }
 
     public function testReturnsUnparameteredPageRouteForForwardPages(): void


### PR DESCRIPTION
Currently, if there are two pages with the same alias (one with required item, one without), you cannot use legacy url parameters on the page without item because the `parameters`-regex for the page with item matches.
This PR finetunes the regex to only match when there's an odd number of slashes.