### PR TITLE
Set `$dc->table` and `$dc->id` in the `FallbackRecordLabelListener`

### DIFF
--- a/core-bundle/src/EventListener/DataContainer/FallbackRecordLabelListener.php
+++ b/core-bundle/src/EventListener/DataContainer/FallbackRecordLabelListener.php
@@ -47,8 +47,8 @@ class FallbackRecordLabelListener
 
         $dc = (new \ReflectionClass(DC_Table::class))->newInstanceWithoutConstructor();
         $dc->table = $table;
-        $dc->id = $id;
-        
+        $dc->id = (int) $id;
+
         $mode = $GLOBALS['TL_DCA'][$table]['list']['sorting']['mode'] ?? DataContainer::MODE_SORTED;
 
         if (DataContainer::MODE_PARENT === $mode && ($GLOBALS['TL_DCA'][$table]['list']['sorting']['child_record_callback'] ?? null)) {

--- a/core-bundle/src/EventListener/DataContainer/FallbackRecordLabelListener.php
+++ b/core-bundle/src/EventListener/DataContainer/FallbackRecordLabelListener.php
@@ -46,6 +46,9 @@ class FallbackRecordLabelListener
         (new DcaLoader($table))->load();
 
         $dc = (new \ReflectionClass(DC_Table::class))->newInstanceWithoutConstructor();
+        $dc->table = $table;
+        $dc->id = $id;
+        
         $mode = $GLOBALS['TL_DCA'][$table]['list']['sorting']['mode'] ?? DataContainer::MODE_SORTED;
 
         if (DataContainer::MODE_PARENT === $mode && ($GLOBALS['TL_DCA'][$table]['list']['sorting']['child_record_callback'] ?? null)) {


### PR DESCRIPTION
This PR fixes an issue where $dc->table (or id) in a list.label.label callback is undefined, because the properties are not set when creating a DC_Table instance in FallbackRecordLabelListener.

Example stack trace 

```ErrorException:
Warning: Undefined array key ""

  at /var/www/contao4-modules/contao-immobilien/src/EventListener/DataContainer/ImmobilienLabelCallbackListener.php:23
  at Clickpress\ContaoImmobilien\EventListener\DataContainer\ImmobilienLabelCallbackListener->__invoke()
     (vendor/contao/core-bundle/contao/classes/DataContainer.php:1791)
  at Contao\DataContainer->generateRecordLabel()
     (vendor/contao/core-bundle/src/EventListener/DataContainer/FallbackRecordLabelListener.php:57)
  at Contao\CoreBundle\EventListener\DataContainer\FallbackRecordLabelListener->__invoke()
     (vendor/symfony/event-dispatcher/Debug/WrappedListener.php:116)
  at Symfony\Component\EventDispatcher\Debug\WrappedListener->__invoke()
     (vendor/symfony/event-dispatcher/EventDispatcher.php:220)
  at Symfony\Component\EventDispatcher\EventDispatcher->callListeners()
     (vendor/symfony/event-dispatcher/EventDispatcher.php:56)
  at Symfony\Component\EventDispatcher\EventDispatcher->dispatch()
     (vendor/symfony/event-dispatcher/Debug/TraceableEventDispatcher.php:139)
  at Symfony\Component\EventDispatcher\Debug\TraceableEventDispatcher->dispatch()
     (vendor/contao/core-bundle/src/DataContainer/RecordLabeler.php:28)
  at Contao\CoreBundle\DataContainer\RecordLabeler->getLabel()
     (vendor/contao/core-bundle/src/DataContainer/DcaUrlAnalyzer.php:111)
  at Contao\CoreBundle\DataContainer\DcaUrlAnalyzer->getTrail()
     (vendor/contao/core-bundle/contao/classes/Backend.php:410)
  at Contao\Backend->getBackendModule()
     (vendor/contao/core-bundle/contao/controllers/BackendMain.php:144)
  at Contao\BackendMain->run()
     (vendor/contao/core-bundle/src/Controller/BackendController.php:44)
  at Contao\CoreBundle\Controller\BackendController->mainAction()
     (vendor/symfony/http-kernel/HttpKernel.php:181)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw()
     (vendor/symfony/http-kernel/HttpKernel.php:76)
  at Symfony\Component\HttpKernel\HttpKernel->handle()
     (vendor/symfony/http-kernel/Kernel.php:197)
  at Symfony\Component\HttpKernel\Kernel->handle()
     (public/index.php:42)
  at require('/var/www/schrammek/public/index.php')
     (public/app.php:13) 
```

As discussed on Slack https://contao.slack.com/archives/CK4J0KNDB/p1736337436509069 