### PR TITLE
Add `no-store` to back end responses

### DIFF
--- a/core-bundle/config/listener.yaml
+++ b/core-bundle/config/listener.yaml
@@ -330,6 +330,11 @@ services:
             - '@contao.routing.scope_matcher'
             - '@contao.intl.locales'
 
+    contao.listener.make_backend_response_uncacheable:
+        class: Contao\CoreBundle\EventListener\MakeBackendResponseUncacheableListener
+        arguments:
+            - '@contao.routing.scope_matcher'
+
     contao.listener.make_response_private:
         class: Contao\CoreBundle\EventListener\MakeResponsePrivateListener
         arguments:

--- a/core-bundle/contao/classes/BackendTemplate.php
+++ b/core-bundle/contao/classes/BackendTemplate.php
@@ -56,10 +56,7 @@ class BackendTemplate extends Template
 	{
 		$this->compile();
 
-		$response = parent::getResponse();
-		$response->headers->set('Cache-Control', 'no-cache, no-store');
-
-		return $response->setPrivate();
+		return parent::getResponse();
 	}
 
 	/**

--- a/core-bundle/src/EventListener/MakeBackendResponseUncacheableListener.php
+++ b/core-bundle/src/EventListener/MakeBackendResponseUncacheableListener.php
@@ -29,9 +29,6 @@ class MakeBackendResponseUncacheableListener
             return;
         }
 
-        $event->getResponse()
-            ->headers
-            ->set('Cache-Control', 'no-cache, no-store, must-revalidate')
-        ;
+        $event->getResponse()->headers->set('Cache-Control', 'no-cache, no-store, must-revalidate');
     }
 }

--- a/core-bundle/src/EventListener/MakeBackendResponseUncacheableListener.php
+++ b/core-bundle/src/EventListener/MakeBackendResponseUncacheableListener.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\EventListener;
+
+use Contao\CoreBundle\Routing\ScopeMatcher;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+
+#[AsEventListener]
+class MakeBackendResponseUncacheableListener
+{
+    public function __construct(private readonly ScopeMatcher $scopeMatcher)
+    {
+    }
+
+    public function __invoke(ResponseEvent $event): void
+    {
+        if (!$this->scopeMatcher->isBackendMainRequest($event)) {
+            return;
+        }
+
+        $event->getResponse()
+            ->headers
+            ->set('Cache-Control', 'no-cache, no-store, must-revalidate')
+        ;
+    }
+}

--- a/core-bundle/tests/EventListener/MakeBackendResponseUncacheableListenerTest.php
+++ b/core-bundle/tests/EventListener/MakeBackendResponseUncacheableListenerTest.php
@@ -55,7 +55,7 @@ class MakeBackendResponseUncacheableListenerTest extends TestCase
         $this->assertFalse($response->headers->hasCacheControlDirective('no-store'));
     }
 
-    public function testMakesResponseUncachableForMainBackendRequest(): void
+    public function testMakesResponseUncacheableForMainBackendRequest(): void
     {
         $response = new Response();
 

--- a/core-bundle/tests/EventListener/MakeBackendResponseUncacheableListenerTest.php
+++ b/core-bundle/tests/EventListener/MakeBackendResponseUncacheableListenerTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\EventListener;
+
+use Contao\CoreBundle\EventListener\MakeBackendResponseUncacheableListener;
+use Contao\CoreBundle\Routing\ScopeMatcher;
+use Contao\CoreBundle\Tests\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+class MakeBackendResponseUncacheableListenerTest extends TestCase
+{
+    public function testIgnoresNonMainRequests(): void
+    {
+        $response = new Response();
+
+        $event = new ResponseEvent(
+            $this->createMock(KernelInterface::class),
+            new Request(),
+            HttpKernelInterface::SUB_REQUEST,
+            $response,
+        );
+
+        (new MakeBackendResponseUncacheableListener($this->createScopeMatcher(false)))($event);
+
+        $this->assertFalse($response->headers->hasCacheControlDirective('no-store'));
+    }
+
+    public function testIgnoresNonContaoBackendMainRequests(): void
+    {
+        $response = new Response();
+
+        $event = new ResponseEvent(
+            $this->createMock(KernelInterface::class),
+            new Request(),
+            HttpKernelInterface::MAIN_REQUEST,
+            $response,
+        );
+
+        (new MakeBackendResponseUncacheableListener($this->createScopeMatcher(false)))($event);
+
+        $this->assertFalse($response->headers->hasCacheControlDirective('no-store'));
+    }
+
+    public function testMakesResponseUncachableForMainBackendRequest(): void
+    {
+        $response = new Response();
+
+        $event = new ResponseEvent(
+            $this->createMock(KernelInterface::class),
+            new Request(),
+            HttpKernelInterface::MAIN_REQUEST,
+            $response,
+        );
+
+        (new MakeBackendResponseUncacheableListener($this->createScopeMatcher(true)))($event);
+
+        $this->assertTrue($response->headers->hasCacheControlDirective('no-store'));
+    }
+
+    private function createScopeMatcher(bool $isBackendMainRequest): ScopeMatcher
+    {
+        $scopeMatcher = $this->createMock(ScopeMatcher::class);
+        $scopeMatcher
+            ->expects($this->once())
+            ->method('isBackendMainRequest')
+            ->willReturn($isBackendMainRequest)
+        ;
+
+        return $scopeMatcher;
+    }
+}


### PR DESCRIPTION
Fixes #7733

This adds `no-store` (plus `no-cache, must-revalidate` as discussed) to all responses of requests within the `backend` `_scope`.