### PR TITLE
Allow to label the back end menu

### DIFF
--- a/core-bundle/config/services.yaml
+++ b/core-bundle/config/services.yaml
@@ -213,7 +213,6 @@ services:
             - '@request_stack'
             - '@security.helper'
             - '@router'
-            - '@contao.translation.translator'
             - '@contao.data_container.record_labeler'
 
     contao.data_container.operations_builder:

--- a/core-bundle/src/DataContainer/DcaUrlAnalyzer.php
+++ b/core-bundle/src/DataContainer/DcaUrlAnalyzer.php
@@ -66,7 +66,7 @@ class DcaUrlAnalyzer
             return [
                 [
                     'url' => $this->router->generate('contao_backend', ['do' => $do, 'table' => $table]),
-                    'label' => $this->translator->trans("MOD.$do.0", [], 'contao_modules'),
+                    'label' => $this->recordLabeler->getLabel("contao.mod.$do", []),
                 ],
             ];
         }
@@ -114,7 +114,7 @@ class DcaUrlAnalyzer
 
         $links[] = [
             'url' => $this->router->generate('contao_backend', ['do' => $do, 'table' => $table]),
-            'label' => $this->translator->trans("MOD.$do.0", [], 'contao_modules'),
+            'label' => $this->recordLabeler->getLabel("contao.mod.$do", []),
         ];
 
         return array_reverse($links);

--- a/core-bundle/src/DataContainer/DcaUrlAnalyzer.php
+++ b/core-bundle/src/DataContainer/DcaUrlAnalyzer.php
@@ -23,8 +23,6 @@ use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\RouterInterface;
-use Symfony\Component\Translation\TranslatorBagInterface;
-use Symfony\Contracts\Translation\TranslatorInterface;
 
 class DcaUrlAnalyzer
 {
@@ -35,7 +33,6 @@ class DcaUrlAnalyzer
         private readonly RequestStack $requestStack,
         private readonly Security $securityHelper,
         private readonly RouterInterface $router,
-        private readonly TranslatorBagInterface&TranslatorInterface $translator,
         private readonly RecordLabeler $recordLabeler,
     ) {
     }

--- a/core-bundle/src/EventListener/DataContainer/FallbackRecordLabelListener.php
+++ b/core-bundle/src/EventListener/DataContainer/FallbackRecordLabelListener.php
@@ -33,10 +33,19 @@ class FallbackRecordLabelListener
 
     public function __invoke(DataContainerRecordLabelEvent $event): void
     {
-        if (null !== $event->getLabel() || !str_starts_with($event->getIdentifier(), 'contao.db.')) {
+        if (null !== $event->getLabel()) {
             return;
         }
 
+        if (str_starts_with($event->getIdentifier(), 'contao.db.')) {
+            $this->setDcaLabel($event);
+        } elseif (str_starts_with($event->getIdentifier(), 'contao.mod.')) {
+            $this->setModuleLabel($event);
+        }
+    }
+
+    private function setDcaLabel(DataContainerRecordLabelEvent $event): void
+    {
         [, , $table, $id] = explode('.', $event->getIdentifier()) + [null, null, null, null];
 
         if (!$table || !$id) {
@@ -62,5 +71,12 @@ class FallbackRecordLabelListener
 
             $event->setLabel(trim(StringUtil::decodeEntities(strip_tags((string) $label))) ?: null);
         }
+    }
+
+    private function setModuleLabel(DataContainerRecordLabelEvent $event): void
+    {
+        [, , $do] = explode('.', $event->getIdentifier()) + [null, null, null];
+
+        $event->setLabel($this->translator->trans("MOD.$do.0", [], 'contao_modules'));
     }
 }


### PR DESCRIPTION
The `DcaUrlAnalyzer` currently hardcodes the first breadcrumb trail to the back end module. However, this is not always suitable. In `terminal42/contao-geipip2-country`, I have a second table in the page module that is accessible through a global operation. 

<img width="1055" alt="Bildschirmfoto 2025-01-14 um 10 21 23" src="https://github.com/user-attachments/assets/304f49b1-9bc4-40a4-8644-9f4a94a38d34" />

Previously, if you open the secondary table, it would show _Pages_ as the first menu trail. I am now able to change this accordingly.

<img width="1058" alt="Bildschirmfoto 2025-01-14 um 10 21 41" src="https://github.com/user-attachments/assets/e704a231-e94e-4083-a5e3-fcf3ba3acd66" />


Ideally, I would be able to add a custom trail item between pages, since the link of the trail item actually points to the pages. But this still looks much better than before.