### PR TITLE
Fix tree rendering with filters and trails

### DIFF
--- a/core-bundle/src/Resources/contao/classes/Backend.php
+++ b/core-bundle/src/Resources/contao/classes/Backend.php
@@ -1030,6 +1030,7 @@ abstract class Backend extends Controller
 
 		$image = Controller::getPageStatusIcon((object) $row);
 		$imageAttribute = trim($imageAttribute . ' data-icon="' . Image::getPath(Controller::getPageStatusIcon((object) array_merge($row, array('published'=>'1')))) . '" data-icon-disabled="' . Image::getPath(Controller::getPageStatusIcon((object) array_merge($row, array('published'=>'')))) . '"');
+		$objUser = BackendUser::getInstance();
 
 		// Return the image only
 		if ($blnReturnImage)
@@ -1044,7 +1045,7 @@ abstract class Backend extends Controller
 		}
 
 		// Add the breadcrumb link if you have access to that page
-		if (!$isVisibleRootTrailPage)
+		if ($objUser->hasAccess($row['id'], 'pagemounts'))
 		{
 			$label = '<a href="' . self::addToUrl('pn=' . $row['id']) . '" title="' . StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['selectNode']) . '">' . $label . '</a>';
 		}

--- a/core-bundle/src/Resources/contao/drivers/DC_Table.php
+++ b/core-bundle/src/Resources/contao/drivers/DC_Table.php
@@ -3760,12 +3760,12 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 					}
 				}
 
-				$this->updateRoot($arrFound);
+				$this->updateRoot($arrFound, true);
 			}
 			else
 			{
 				$arrFound = $objFound->fetchEach('id');
-				$this->updateRoot($arrFound);
+				$this->updateRoot($arrFound, true);
 			}
 		}
 
@@ -4094,17 +4094,12 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 			{
 				$allowedChildIds = array();
 
-				if (!empty($arrFound))
-				{
-					$allowedChildIds = array_merge($arrFound, $this->visibleRootTrails);
-				}
-
-				$objChilds = $this->Database->prepare("SELECT id FROM " . $table . " WHERE pid=?" . (!empty($allowedChildIds) ? " AND id IN(" . implode(',', array_map('\intval', $allowedChildIds)) . ")" : '') . ($blnHasSorting ? " ORDER BY sorting, id" : ''))
+				$objChilds = $this->Database->prepare("SELECT id FROM " . $table . " WHERE pid=?" . ($blnHasSorting ? " ORDER BY sorting, id" : ''))
 											->execute($id);
 
 				if ($objChilds->numRows)
 				{
-					$childs = $objChilds->fetchEach('id');
+					$childs = array_values(array_intersect($objChilds->fetchEach('id'), array_merge($this->visibleRootTrails, $this->root, $this->rootChildren)));
 				}
 			}
 		}
@@ -6295,8 +6290,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 	 */
 	protected function initRoots()
 	{
-		$table = $this->strTable;
-		$this->rootPaste = $GLOBALS['TL_DCA'][$table]['list']['sorting']['rootPaste'] ?? false;
+		$this->rootPaste = $GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['rootPaste'] ?? false;
 
 		// Get the IDs of all root records (tree view)
 		if ($this->treeView)
@@ -6320,7 +6314,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 				}
 			}
 
-			// Get root records from global configuration file
+			// Get root records from DCA
 			elseif (\is_array($GLOBALS['TL_DCA'][$table]['list']['sorting']['root'] ?? null))
 			{
 				if ($GLOBALS['TL_DCA'][$table]['list']['sorting']['root'] == array(0))
@@ -6335,38 +6329,53 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 		}
 
 		// Get the IDs of all root records (list view or parent view)
-		elseif (\is_array($GLOBALS['TL_DCA'][$table]['list']['sorting']['root'] ?? null))
+		elseif (\is_array($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['root'] ?? null))
 		{
-			$this->updateRoot(array_unique($GLOBALS['TL_DCA'][$table]['list']['sorting']['root']));
+			$this->updateRoot(array_unique($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['root']));
 		}
 	}
 
-	protected function updateRoot(array $root)
+	protected function updateRoot(array $root, bool $isSearch = false)
 	{
-		$this->root = $root;
-
 		$table = ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] ?? null) == self::MODE_TREE_EXTENDED ? $this->ptable : $this->strTable;
+		$this->root = $this->eliminateNestedPages($root, $table);
+		$this->visibleRootTrails = [];
+		$this->rootChildren = [];
 
-		// Fetch visible root trails if enabled
-		if ($GLOBALS['TL_DCA'][$table]['list']['sorting']['showRootTrails'] ?? null)
+		if ($this->treeView)
 		{
-			foreach ($this->root as $id)
+			// Fetch visible root trails if enabled
+			if ($GLOBALS['TL_DCA'][$table]['list']['sorting']['showRootTrails'] ?? null)
 			{
-				$this->visibleRootTrails = array_unique(array_merge($this->visibleRootTrails, $this->Database->getParentRecords($id, $table, true)));
+				foreach ($this->root as $id)
+				{
+					$this->visibleRootTrails[] = $this->Database->getParentRecords($id, $table, true);
+				}
+
+				$this->visibleRootTrails = array_unique(array_merge(...$this->visibleRootTrails));
+			}
+
+			// Fetch all children of the root
+			$this->rootChildren = $this->Database->getChildRecords($this->root, $table);
+
+			if ($isSearch)
+			{
+				$parents = [];
+
+				foreach ($root as $id)
+				{
+					$parents[] = $this->Database->getParentRecords($id, $table);
+				}
+
+				$this->rootChildren = array_intersect($this->rootChildren, array_merge(...$parents));
+				$this->visibleRootTrails = array_merge($this->visibleRootTrails, array_diff($this->rootChildren, $root));
 			}
 		}
 
-		// $this->root might not have a correct order here, let's make sure it's ordered by sorting but only in case there are no visible root trails (aka
-		// the array does contain only top-level ids)
-		if ($this->root && empty($this->visibleRootTrails) && $this->Database->fieldExists('sorting', $table))
+		// $this->root might not have a correct order here, let's make sure it's ordered by sorting
+		elseif ($this->root && $this->Database->fieldExists('sorting', $table))
 		{
 			$this->root = $this->Database->execute("SELECT id FROM $table WHERE id IN (" . implode(',', $this->root) . ") ORDER BY sorting, id")->fetchEach('id');
-		}
-
-		// Fetch all children of the root
-		if ($this->treeView)
-		{
-			$this->rootChildren = $this->Database->getChildRecords($this->root, $table, $this->Database->fieldExists('sorting', $table));
 		}
 	}
 


### PR DESCRIPTION
This is the actually correct fix for https://github.com/contao/contao/pull/7480 (and https://github.com/contao/contao/issues/7366). I have a client which has a `list.sorting.filter` applied by default on the tree, which caused incorrect results, so I had to find a fix.

Trying to explain how it works (copy from whiteboard on my wall 😅):
 - `$dc->root` contains the topmost allowed IDs (`eliminateNestedPages`)
 - `$dc->visibleRootTrails` contains IDs above `$dc->root`
 - `$dc->rootChildren` contains IDs below `$dc->root`
 - when IDs are updated from search results, `$dc->rootChildren` will only contain IDs between `$dc->root` and nested IDs, so we only generate the tree from tomost root until last found node
 - also on search results, `$dc->visibleRootTrails` will contain all IDs that are _between_ nested root nodes, causing their operations not to be rendered (because they are considered root trails).

Initially (`DC_Table::initRoots()`), the arrays will contain the user permissions. `DC_Table::treeView()` will then update `$dc->root` from search results, including the already given permissions. 

Since the original PR was for 4.13, and my client uses 4.13, I had to initially find a fix for their case. This obviously needs to be forward-ported to 5.3 as well, but I guess the same code will run there just fine.

## Some examples from Contao demo

### Admin searching for _slider_, which matches a subpage
Notice how the page `Content elements` does not have operations, because it did not match the search results

<img width="800" alt="Bildschirmfoto 2025-01-14 um 15 20 46" src="https://github.com/user-attachments/assets/e0d188d6-f8c3-43d6-a3ba-fb61f3f9b66f" />

### Admin searching for _elements_, which matches a parent and subpages
Notice how the page `Content elements` now does have operations, because it **did** match the search results, but the _slider_ page is hidden because it does not match

<img width="798" alt="Bildschirmfoto 2025-01-14 um 15 21 02" src="https://github.com/user-attachments/assets/347feaf9-236e-415e-b89f-38ee91998dcb" />

### Admin searching for _detail_, which matches two pages in separate parent nodes
Only the acutal matches have operations

<img width="789" alt="Bildschirmfoto 2025-01-14 um 15 21 35" src="https://github.com/user-attachments/assets/6b6a25e1-f7b1-4e55-ae83-0bd6859f17da" />

### Admin searching for _detail_, while having breadcrumb applied
The _detail_ page of news does not show up because of the breadcrumb menu

<img width="790" alt="Bildschirmfoto 2025-01-14 um 15 25 04" src="https://github.com/user-attachments/assets/16d6da20-c2ec-4922-bc5a-bb88073ba19d" />


### Fancy search for _news|detail_ (regex) 
Operations are now available on the `News` and `News Detail`, as well as `Event Detail`, but not on `Events`!

<img width="880" alt="Bildschirmfoto 2025-01-14 um 15 27 17" src="https://github.com/user-attachments/assets/3de19260-1842-44ab-a697-46cedfe2b67a" />
