### PR TITLE
Do not force HTTP method parameter override

### DIFF
--- a/manager-bundle/src/HttpKernel/ContaoKernel.php
+++ b/manager-bundle/src/HttpKernel/ContaoKernel.php
@@ -240,8 +240,6 @@ class ContaoKernel extends Kernel implements HttpCacheProvider
             Request::setTrustedProxies(explode(',', $trustedProxies), $trustedHeaderSet);
         }
 
-        Request::enableHttpMethodParameterOverride();
-
         $jwtManager = null;
         $env = null;
         $parseJwt = 'jwt' === $_SERVER['APP_ENV'];

--- a/manager-bundle/tests/HttpKernel/ContaoKernelTest.php
+++ b/manager-bundle/tests/HttpKernel/ContaoKernelTest.php
@@ -343,13 +343,13 @@ class ContaoKernelTest extends ContaoTestCase
         unset($_SERVER['TRUSTED_HOSTS']);
     }
 
-    public function testEnablesRequestHttpMethodParameterOverride(): void
+    public function testDoesNotEnableRequestHttpMethodParameterOverride(): void
     {
         $this->assertFalse(Request::getHttpMethodParameterOverride());
 
         ContaoKernel::fromRequest($this->getTempDir(), Request::create('/'));
 
-        $this->assertTrue(Request::getHttpMethodParameterOverride());
+        $this->assertFalse(Request::getHttpMethodParameterOverride());
     }
 
     public function testSetsProjectDirFromInput(): void


### PR DESCRIPTION
Same as #7798 for Contao 4.13.