### PR TITLE
Update FileExtensionMigration.php

### DIFF
--- a/core-bundle/src/Migration/Version503/FileExtensionMigration.php
+++ b/core-bundle/src/Migration/Version503/FileExtensionMigration.php
@@ -38,7 +38,7 @@ class FileExtensionMigration extends AbstractMigration
 
     public function run(): MigrationResult
     {
-        $this->connection->executeStatement("UPDATE tl_files SET extension = LOWER(extension) WHERE CAST(extension AS BINARY) REGEXP CAST('[[:upper:]] AS BINARY)'");
+        $this->connection->executeStatement("UPDATE tl_files SET extension = LOWER(extension) WHERE CAST(extension AS BINARY) REGEXP CAST('[[:upper:]]' AS BINARY)");
 
         return $this->createResult(true);
     }


### PR DESCRIPTION
Fehler in der Abfrage für das Umschreiben der Dateierweiterung in tl_files behoben.

Fixes #7877

<!--
Bugfixes should be based on the 5.3 branch and features on the 5.x branch.
Select the correct branch in the "base:" drop-down menu above.

Pull requests for Contao 4.13 are no longer merged upstream into Contao 5!
If you want to fix a bug in Contao 4.13, please create a pull request for
Contao 5.3 first and then a separate backport pull request for Contao 4.13.
-->
