### PR TITLE
Ensure that `Widget::$arrOptions` is always an array

### DIFF
--- a/core-bundle/contao/forms/FormCheckbox.php
+++ b/core-bundle/contao/forms/FormCheckbox.php
@@ -56,7 +56,7 @@ class FormCheckbox extends Widget
 		switch ($strKey)
 		{
 			case 'options':
-				$this->arrOptions = StringUtil::deserialize($varValue);
+				$this->arrOptions = StringUtil::deserialize($varValue, true);
 				break;
 
 			case 'rgxp':

--- a/core-bundle/contao/forms/FormRadio.php
+++ b/core-bundle/contao/forms/FormRadio.php
@@ -69,7 +69,7 @@ class FormRadio extends Widget
 				break;
 
 			case 'options':
-				$this->arrOptions = StringUtil::deserialize($varValue);
+				$this->arrOptions = StringUtil::deserialize($varValue, true);
 				break;
 
 			case 'rgxp':

--- a/core-bundle/contao/forms/FormSelect.php
+++ b/core-bundle/contao/forms/FormSelect.php
@@ -86,7 +86,7 @@ class FormSelect extends Widget
 				break;
 
 			case 'options':
-				$this->arrOptions = StringUtil::deserialize($varValue);
+				$this->arrOptions = StringUtil::deserialize($varValue, true);
 				break;
 
 			case 'rgxp':
@@ -220,7 +220,7 @@ class FormSelect extends Widget
 		$blnHasGroups = false;
 
 		// Add empty option if there are none
-		if (empty($this->arrOptions) || !\is_array($this->arrOptions))
+		if (empty($this->arrOptions))
 		{
 			$this->arrOptions = array(array('value' => '', 'label' => '-'));
 		}
@@ -290,7 +290,7 @@ class FormSelect extends Widget
 		}
 
 		// Add empty option if there are none
-		if (empty($this->arrOptions) || !\is_array($this->arrOptions))
+		if (empty($this->arrOptions))
 		{
 			$this->arrOptions = array(array('value'=>'', 'label'=>'-'));
 		}

--- a/core-bundle/contao/widgets/CheckBox.php
+++ b/core-bundle/contao/widgets/CheckBox.php
@@ -53,7 +53,7 @@ class CheckBox extends Widget
 	{
 		if ($strKey == 'options')
 		{
-			$this->arrOptions = StringUtil::deserialize($varValue);
+			$this->arrOptions = StringUtil::deserialize($varValue, true);
 		}
 		else
 		{

--- a/core-bundle/contao/widgets/CheckBoxWizard.php
+++ b/core-bundle/contao/widgets/CheckBoxWizard.php
@@ -52,7 +52,7 @@ class CheckBoxWizard extends Widget
 	{
 		if ($strKey == 'options')
 		{
-			$this->arrOptions = StringUtil::deserialize($varValue);
+			$this->arrOptions = StringUtil::deserialize($varValue, true);
 		}
 		else
 		{

--- a/core-bundle/contao/widgets/ImageSize.php
+++ b/core-bundle/contao/widgets/ImageSize.php
@@ -57,7 +57,7 @@ class ImageSize extends Widget
 				break;
 
 			case 'options':
-				$this->arrOptions = StringUtil::deserialize($varValue);
+				$this->arrOptions = StringUtil::deserialize($varValue, true);
 				break;
 
 			default:

--- a/core-bundle/contao/widgets/InputUnit.php
+++ b/core-bundle/contao/widgets/InputUnit.php
@@ -66,7 +66,7 @@ class InputUnit extends Widget
 				break;
 
 			case 'options':
-				$this->arrOptions = StringUtil::deserialize($varValue);
+				$this->arrOptions = StringUtil::deserialize($varValue, true);
 				break;
 
 			default:

--- a/core-bundle/contao/widgets/RadioButton.php
+++ b/core-bundle/contao/widgets/RadioButton.php
@@ -65,7 +65,7 @@ class RadioButton extends Widget
 				break;
 
 			case 'options':
-				$this->arrOptions = StringUtil::deserialize($varValue);
+				$this->arrOptions = StringUtil::deserialize($varValue, true);
 				break;
 
 			default:

--- a/core-bundle/contao/widgets/RadioTable.php
+++ b/core-bundle/contao/widgets/RadioTable.php
@@ -65,7 +65,7 @@ class RadioTable extends Widget
 				break;
 
 			case 'options':
-				$this->arrOptions = StringUtil::deserialize($varValue);
+				$this->arrOptions = StringUtil::deserialize($varValue, true);
 				break;
 
 			default:

--- a/core-bundle/contao/widgets/SelectMenu.php
+++ b/core-bundle/contao/widgets/SelectMenu.php
@@ -82,7 +82,7 @@ class SelectMenu extends Widget
 				break;
 
 			case 'options':
-				$this->arrOptions = StringUtil::deserialize($varValue);
+				$this->arrOptions = StringUtil::deserialize($varValue, true);
 				break;
 
 			default:

--- a/core-bundle/contao/widgets/TimePeriod.php
+++ b/core-bundle/contao/widgets/TimePeriod.php
@@ -61,7 +61,7 @@ class TimePeriod extends Widget
 				break;
 
 			case 'options':
-				$this->arrOptions = StringUtil::deserialize($varValue);
+				$this->arrOptions = StringUtil::deserialize($varValue, true);
 				break;
 
 			default:

--- a/core-bundle/contao/widgets/TrblField.php
+++ b/core-bundle/contao/widgets/TrblField.php
@@ -48,7 +48,7 @@ class TrblField extends Widget
 				break;
 
 			case 'options':
-				$this->arrOptions = StringUtil::deserialize($varValue);
+				$this->arrOptions = StringUtil::deserialize($varValue, true);
 				break;
 
 			default:


### PR DESCRIPTION
This is an alternative approach to #7794 which ensures that `$this->arrOptions` is always an array.

- We don't need the `is_array()` checks anymore.
- It will also work if `$this->arrOptions` is passed to functions like `count()` that only allow an array argument.
- `$widget->options` will always be an array instead of possibly `null`.

@qzminski /cc