### PR TITLE
Fix a PHP 8 issue in the `tl_user_group::getExcludedFields()` method

### DIFF
--- a/core-bundle/contao/dca/tl_user_group.php
+++ b/core-bundle/contao/dca/tl_user_group.php
@@ -387,7 +387,7 @@ class tl_user_group extends Backend
 		// Get all excluded fields
 		foreach ($GLOBALS['TL_DCA'] as $k=>$v)
 		{
-			if (is_array($v['fields']))
+			if (is_array($v['fields'] ?? null))
 			{
 				foreach ($v['fields'] as $kk=>$vv)
 				{


### PR DESCRIPTION
Fixes https://github.com/contao/contao/issues/7806