### PR TITLE
Fix variadic parameters with string keys

### DIFF
--- a/core-bundle/src/EventListener/GlobalsMapListener.php
+++ b/core-bundle/src/EventListener/GlobalsMapListener.php
@@ -37,7 +37,7 @@ class GlobalsMapListener
 
             ksort($priorities);
 
-            $GLOBALS[$key] = array_replace_recursive($GLOBALS[$key] ?? [], ...$priorities);
+            $GLOBALS[$key] = array_replace_recursive($GLOBALS[$key] ?? [], ...array_values($priorities));
         }
     }
 }

--- a/core-bundle/src/Framework/ContaoFramework.php
+++ b/core-bundle/src/Framework/ContaoFramework.php
@@ -238,14 +238,14 @@ class ContaoFramework implements ResetInterface
         foreach ($this->hookListeners as $hookName => $priorities) {
             if (isset($GLOBALS['TL_HOOKS'][$hookName]) && \is_array($GLOBALS['TL_HOOKS'][$hookName])) {
                 if (isset($priorities[0])) {
-                    $priorities[0] = [...$GLOBALS['TL_HOOKS'][$hookName], ...$priorities[0]];
+                    $priorities[0] = [...array_values($GLOBALS['TL_HOOKS'][$hookName]), ...$priorities[0]];
                 } else {
                     $priorities[0] = $GLOBALS['TL_HOOKS'][$hookName];
                     krsort($priorities);
                 }
             }
 
-            $GLOBALS['TL_HOOKS'][$hookName] = array_merge(...$priorities);
+            $GLOBALS['TL_HOOKS'][$hookName] = array_merge(...array_values($priorities));
         }
     }
 }


### PR DESCRIPTION
Error report from slack got this exception:

```php
Exception in file vendor/contao/core-bundle/src/EventListener/GlobalsMapListener.php on line 40

array_replace_recursive() does not accept unknown named parameters


#0 vendor/contao/core-bundle/src/EventListener/GlobalsMapListener.php(40): array_replace_recursive(Array, Array, application: Array, miscellaneous: Array, newsletter: Array, user: Array)
#1 vendor/contao/core-bundle/src/Framework/ContaoFramework.php(224): Contao\CoreBundle\EventListener\GlobalsMapListener->onInitializeSystem()
#2 vendor/contao/core-bundle/src/Framework/ContaoFramework.php(175): Contao\CoreBundle\Framework\ContaoFramework->triggerInitializeSystemHook()
#3 vendor/contao/core-bundle/src/Framework/ContaoFramework.php(95): Contao\CoreBundle\Framework\ContaoFramework->initializeFramework()
#4 vendor/contao/core-bundle/src/Migration/Version500/BooleanFieldsMigration.php(60): Contao\CoreBundle\Framework\ContaoFramework->initialize()
#5 vendor/contao/core-bundle/src/Migration/Version500/BooleanFieldsMigration.php(38): Contao\CoreBundle\Migration\Version500\BooleanFieldsMigration->getTargets()
#6 vendor/contao/core-bundle/src/Migration/MigrationCollection.php(41): Contao\CoreBundle\Migration\Version500\BooleanFieldsMigration->shouldRun()
#7 vendor/contao/core-bundle/src/Migration/MigrationCollection.php(52): Contao\CoreBundle\Migration\MigrationCollection->getPending()
#8 vendor/contao/core-bundle/src/Command/MigrateCommand.php(229): Contao\CoreBundle\Migration\MigrationCollection->getPendingNames()
#9 vendor/contao/core-bundle/src/Command/MigrateCommand.php(192): Contao\CoreBundle\Command\MigrateCommand->executeMigrations(true, true, NULL)
#10 vendor/contao/core-bundle/src/Command/MigrateCommand.php(92): Contao\CoreBundle\Command\MigrateCommand->executeCommand(Object(Symfony\Component\Console\Input\ArgvInput))
#11 vendor/symfony/console/Command/Command.php(326): Contao\CoreBundle\Command\MigrateCommand->execute(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#12 vendor/symfony/console/Application.php(1096): Symfony\Component\Console\Command\Command->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#13 vendor/symfony/framework-bundle/Console/Application.php(126): Symfony\Component\Console\Application->doRunCommand(Object(Contao\CoreBundle\Command\MigrateCommand), Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#14 vendor/symfony/console/Application.php(324): Symfony\Bundle\FrameworkBundle\Console\Application->doRunCommand(Object(Contao\CoreBundle\Command\MigrateCommand), Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#15 vendor/symfony/framework-bundle/Console/Application.php(80): Symfony\Component\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#16 vendor/symfony/console/Application.php(175): Symfony\Bundle\FrameworkBundle\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#17 vendor/contao/manager-bundle/bin/contao-console(40): Symfony\Component\Console\Application->run(Object(Symfony\Component\Console\Input\ArgvInput))
#18 {main}
```

The problem is that PHP8 is trying to map function arguments to array string keys when unpacking variadic arrays. By using `array_values` we make sure this never is an issue. Since the array is already correctly sorted by priority, resetting the priority keys is irrelevant.

/cc @denniserdmann 