### PR TITLE
Load default language file when initializing Contao framework

### DIFF
--- a/core-bundle/src/Framework/ContaoFramework.php
+++ b/core-bundle/src/Framework/ContaoFramework.php
@@ -173,6 +173,8 @@ class ContaoFramework implements ResetInterface
 
         $this->setTimezone();
         $this->triggerInitializeSystemHook();
+
+        System::loadLanguageFile('default');
     }
 
     /**


### PR DESCRIPTION
If you currently have a custom entry point like a console command, and you run `ContaoFramework::initialize()`, no default language files are loaded at all. Stuff like `System::getReadableSize()` will throw errors because of missing language parameters.

I think it makes a lot of sense to load languages by default – and it won't harm to preload them, even if the page controller might load it again (which is ignored since its cached).

This would probably also have fixed all the null-checks on the DCA delete operations, which triggered such errors in the `contao:migrate` command, even though I'm sure we do boot the framework there as well.