### PR TITLE
Fix a small formatting issue in the Template Studio

### DIFF
--- a/core-bundle/contao/templates/twig/backend/template_studio/operation/save_result.stream.html.twig
+++ b/core-bundle/contao/templates/twig/backend/template_studio/operation/save_result.stream.html.twig
@@ -5,7 +5,10 @@
             {% trans_default_domain "contao_template_studio" %}
 
             {% block content %}
-                {{ 'message.save.success'|trans([identifier]) }}
+                {% set identifier_token -%}
+                    <span class="token">{{ identifier }}</span>
+                {%- endset %}
+                {{ 'message.save.success'|trans([identifier_token])|raw }}
             {% endblock %}
         {% endembed %}
     </template>


### PR DESCRIPTION
I forgot to make the identifier a formatted token in the message when a template is saved. 
It's only a cosmetic issue, though.