### PR TITLE
Revert the changes to `FormSelect` regarding `Chosen`

### DIFF
--- a/core-bundle/contao/forms/FormSelect.php
+++ b/core-bundle/contao/forms/FormSelect.php
@@ -195,7 +195,7 @@ class FormSelect extends Widget
 		// Chosen
 		if ($this->chosen)
 		{
-			$strClass .= ' init-choices';
+			$strClass .= ' tl_chosen';
 		}
 
 		// Custom class


### PR DESCRIPTION
As discussed in #7901 this reverts the changes to the **front end** `FormSelect` widget regarding the `Chosen` JavaScript.

The changes to `FormSelect` in #7408 and #7824 were erroneous as the intention in the front end was always to keep using the `moo_chosen` template (plus in 5.5 by manually requiring the `contao-components/chosen` package).

https://github.com/contao/contao/blob/d75af7cb27cc286f3f0db7be7d674de8170c1047/core-bundle/contao/templates/mootools/moo_chosen.html5#L8-L13
