### PR TITLE
Introduce a `SearchResultEvent`

### DIFF
--- a/core-bundle/src/Event/SearchResultEvent.php
+++ b/core-bundle/src/Event/SearchResultEvent.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Event;
+
+use Contao\ModuleModel;
+use Contao\SearchResult;
+use Symfony\Contracts\EventDispatcher\Event;
+
+class SearchResultEvent extends Event
+{
+    /**
+     * @param list<int> $pageIds
+     */
+    public function __construct(
+        private readonly SearchResult $searchResult,
+        private readonly ModuleModel $searchModuleModel,
+        private readonly array $pageIds,
+        private readonly string $keywords,
+        private readonly string $queryType,
+    ) {
+    }
+
+    public function getSearchResult(): SearchResult
+    {
+        return $this->searchResult;
+    }
+
+    public function getSearchModuleModel(): ModuleModel
+    {
+        return $this->searchModuleModel;
+    }
+
+    public function getPageIds(): array
+    {
+        return $this->pageIds;
+    }
+
+    public function getKeywords(): string
+    {
+        return $this->keywords;
+    }
+
+    public function getQueryType(): string
+    {
+        return $this->queryType;
+    }
+}


### PR DESCRIPTION
Currently there is no way to filter front end search results easily (except by replacing `ModuleSearch` completely). This PR would introduce a `SearchResultEvent` where you could then do something like this:

```php
// src/EventListener/SearchResultEventListener.php
namespace App\EventListener;

use Contao\CoreBundle\Event\SearchResultEvent;
use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
use Symfony\Component\HttpFoundation\RequestStack;

#[AsEventListener]
class SearchResultEventListener
{
    public function __construct(private readonly RequestStack $requestStack)
    {
    }

    public function __invoke(SearchResultEvent $event): void
    {
        $request = $this->requestStack->getCurrentRequest();

        $event->getSearchResult()->applyFilter(static function(array $result) use ($request): bool {
            if ($request->query->get('foobar')) {
                // Filter by some custom condition 
                // …
            }

            return true;
        });
    }
}
```