### PR TITLE
Do not prefetch the "switch user" URLs

### DIFF
--- a/core-bundle/contao/dca/tl_member.php
+++ b/core-bundle/contao/dca/tl_member.php
@@ -440,7 +440,7 @@ class tl_member extends Backend
 
 		$url = System::getContainer()->get('router')->generate('contao_backend_preview', array('user'=>$row['username']));
 
-		return '<a href="' . StringUtil::specialcharsUrl($url) . '" title="' . StringUtil::specialchars($title) . '" target="_blank">' . Image::getHtml($icon, $label) . '</a> ';
+		return '<a href="' . StringUtil::specialcharsUrl($url) . '" title="' . StringUtil::specialchars($title) . '" target="_blank" data-turbo-prefetch="false">' . Image::getHtml($icon, $label) . '</a> ';
 	}
 
 	/**

--- a/core-bundle/contao/dca/tl_user.php
+++ b/core-bundle/contao/dca/tl_user.php
@@ -571,7 +571,7 @@ class tl_user extends Backend
 		$router = System::getContainer()->get('router');
 		$url = $router->generate('contao_backend', array('_switch_user'=>$row['username']));
 
-		return '<a href="' . $url . '" title="' . StringUtil::specialchars($title) . '">' . Image::getHtml($icon, $label) . '</a> ';
+		return '<a href="' . $url . '" title="' . StringUtil::specialchars($title) . '" data-turbo-prefetch="false">' . Image::getHtml($icon, $label) . '</a> ';
 	}
 
 	/**


### PR DESCRIPTION
When hovering over the user switch icons in the user list in the back end, Turbo currently prefetches the user switch. This PR fixes that.