### PR TITLE
Fix events record label

### DIFF
--- a/calendar-bundle/config/services.yaml
+++ b/calendar-bundle/config/services.yaml
@@ -18,6 +18,11 @@ services:
             - '@contao.framework'
             - '@contao.routing.content_url_generator'
 
+    contao_calendar.listener.data_container.calendar_events_record_label:
+        class: Contao\CalendarBundle\EventListener\DataContainer\CalendarEventsRecordLabelListener
+        arguments:
+            - '@translator'
+
     contao_calendar.listener.data_container.start_stop_validation:
         class: Contao\CoreBundle\EventListener\DataContainer\StartStopValidationListener
         arguments:

--- a/calendar-bundle/contao/languages/en/tl_calendar_events.xlf
+++ b/calendar-bundle/contao/languages/en/tl_calendar_events.xlf
@@ -272,6 +272,9 @@
       <trans-unit id="tl_calendar_events.new.1">
         <source>Create a new event</source>
       </trans-unit>
+      <trans-unit id="tl_calendar_events.record_label">
+        <source>Event ID %s</source>
+      </trans-unit>
       <trans-unit id="tl_calendar_events.show">
         <source>Show the details of event ID %s</source>
       </trans-unit>

--- a/calendar-bundle/src/EventListener/DataContainer/CalendarEventsRecordLabelListener.php
+++ b/calendar-bundle/src/EventListener/DataContainer/CalendarEventsRecordLabelListener.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CalendarBundle\EventListener\DataContainer;
+
+use Contao\CoreBundle\Event\DataContainerRecordLabelEvent;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\Component\Translation\TranslatorBagInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * @internal
+ */
+#[AsEventListener]
+class CalendarEventsRecordLabelListener
+{
+    public function __construct(private readonly TranslatorInterface&TranslatorBagInterface $translator)
+    {
+    }
+
+    public function __invoke(DataContainerRecordLabelEvent $event): void
+    {
+        if (!str_starts_with($event->getIdentifier(), 'contao.db.tl_calendar_events.')) {
+            return;
+        }
+
+        $label = $event->getData()['title'] ?? null;
+
+        if (!$label) {
+            $label = $this->translator->trans('tl_calendar_events.record_label', [$event->getData()['id'] ?? ''], 'contao_tl_calendar_events');
+        }
+
+        $event->setLabel($label);
+    }
+}


### PR DESCRIPTION
Fixes #7887

An alternative would be to not skip the `child_record_callback` in `MODE_PARENT` but I thought that this callback might return rather complex HTML code (like in `tl_content`) so that is why I skip it in the fallback listener.