### PR TITLE
Do not use `DC_Table::generateRecordLabel()` for breadcrumbs

### DIFF
--- a/core-bundle/src/EventListener/DataContainer/FallbackRecordLabelListener.php
+++ b/core-bundle/src/EventListener/DataContainer/FallbackRecordLabelListener.php
@@ -13,8 +13,6 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\EventListener\DataContainer;
 
 use Contao\CoreBundle\Event\DataContainerRecordLabelEvent;
-use Contao\DataContainer;
-use Contao\DC_Table;
 use Contao\DcaLoader;
 use Contao\StringUtil;
 use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
@@ -45,25 +43,16 @@ class FallbackRecordLabelListener
 
         (new DcaLoader($table))->load();
 
-        $dc = (new \ReflectionClass(DC_Table::class))->newInstanceWithoutConstructor();
-        $dc->table = $table;
-        $dc->id = (int) $id;
-
-        $mode = $GLOBALS['TL_DCA'][$table]['list']['sorting']['mode'] ?? DataContainer::MODE_SORTED;
-
-        if (DataContainer::MODE_PARENT === $mode && ($GLOBALS['TL_DCA'][$table]['list']['sorting']['child_record_callback'] ?? null)) {
+        if (
+            ($defaultSearchField = $GLOBALS['TL_DCA'][$table]['list']['sorting']['defaultSearchField'] ?? null)
+            && $label = $event->getData()[$defaultSearchField] ?? null
+        ) {
+            $event->setLabel(trim(StringUtil::decodeEntities(strip_tags((string) $label))));
+        } else {
             $messageDomain = "contao_$table";
             $labelKey = $this->translator->getCatalogue()->has("$table.edit", $messageDomain) ? "$table.edit" : 'DCA.edit';
 
             $event->setLabel($this->translator->trans($labelKey, [$event->getData()['id']], $messageDomain));
-        } else {
-            $label = $dc->generateRecordLabel($event->getData(), $table);
-
-            if (\is_array($label)) {
-                $label = trim(implode(' ', $label));
-            }
-
-            $event->setLabel(trim(StringUtil::decodeEntities(strip_tags((string) $label))) ?: null);
         }
     }
 }

--- a/core-bundle/tests/EventListener/DataContainer/FallbackRecordLabelListenerTest.php
+++ b/core-bundle/tests/EventListener/DataContainer/FallbackRecordLabelListenerTest.php
@@ -17,7 +17,6 @@ use Contao\CoreBundle\Event\DataContainerRecordLabelEvent;
 use Contao\CoreBundle\EventListener\DataContainer\FallbackRecordLabelListener;
 use Contao\CoreBundle\Tests\Fixtures\TranslatorStub;
 use Contao\CoreBundle\Tests\TestCase;
-use Contao\DataContainer;
 use Contao\DcaLoader;
 use Contao\System;
 use Symfony\Component\Translation\MessageCatalogueInterface;
@@ -43,9 +42,6 @@ class FallbackRecordLabelListenerTest extends TestCase
 
     public function testGetsLabelFromTranslator(): void
     {
-        $GLOBALS['TL_DCA']['tl_foo']['list']['sorting']['mode'] = DataContainer::MODE_PARENT;
-        $GLOBALS['TL_DCA']['tl_foo']['list']['sorting']['child_record_callback'] = static fn () => null;
-
         System::setContainer($this->getContainerWithContaoConfiguration());
         (new \ReflectionClass(DcaLoader::class))->setStaticPropertyValue('arrLoaded', ['dcaFiles' => ['tl_foo' => true]]);
 
@@ -76,10 +72,9 @@ class FallbackRecordLabelListenerTest extends TestCase
         $this->assertSame('Edit 123', $event->getLabel());
     }
 
-    public function testGetsLabelFromDcaWithShowColumnsEnabled(): void
+    public function testGetsLabelFromDcaWithDefaultSearchField(): void
     {
-        $GLOBALS['TL_DCA']['tl_foo']['list']['label']['showColumns'] = true;
-        $GLOBALS['TL_DCA']['tl_foo']['list']['label']['fields'] = ['fieldA', 'fieldB'];
+        $GLOBALS['TL_DCA']['tl_foo']['list']['sorting']['defaultSearchField'] = 'fieldA';
 
         System::setContainer($this->getContainerWithContaoConfiguration());
         (new \ReflectionClass(DcaLoader::class))->setStaticPropertyValue('arrLoaded', ['dcaFiles' => ['tl_foo' => true]]);
@@ -87,7 +82,7 @@ class FallbackRecordLabelListenerTest extends TestCase
         $translator = $this->createMock(TranslatorStub::class);
 
         $listener = new FallbackRecordLabelListener($translator);
-        $listener($event = new DataContainerRecordLabelEvent('contao.db.tl_foo.123', ['id' => 123, 'fieldA' => 'A', 'fieldB' => '<span>(B &amp; B)</span>']));
+        $listener($event = new DataContainerRecordLabelEvent('contao.db.tl_foo.123', ['id' => 123, 'fieldA' => 'A <span>(B &amp; B)</span>']));
 
         $this->assertSame('A (B & B)', $event->getLabel());
     }

--- a/core-bundle/tests/Fixtures/Functional/DcaUrlAnalyzer/default.yaml
+++ b/core-bundle/tests/Fixtures/Functional/DcaUrlAnalyzer/default.yaml
@@ -33,14 +33,14 @@ tl_content:
 tl_theme:
     - id: 1
       tstamp: 1234567890
-      name: Default
+      name: Default Theme
       author: Leo Feyer
 
 tl_layout:
     - id: 1
       pid: 1
       tstamp: 1234567890
-      name: Default
+      name: Default Layout
       rows: 1rw
       cols: 1cl
       modules: a:1:{i:0;a:3:{s:3:"mod";s:1:"0";s:3:"col";s:4:"main";s:6:"enable";s:1:"1";}}

--- a/core-bundle/tests/Functional/DcaUrlAnalyzerTest.php
+++ b/core-bundle/tests/Functional/DcaUrlAnalyzerTest.php
@@ -195,7 +195,7 @@ class DcaUrlAnalyzerTest extends FunctionalTestCase
             'do=article&act=edit&id=1',
             [
                 ['url' => '/contao?do=article&table=tl_article', 'label' => 'Articles'],
-                ['url' => '/contao?do=article&id=1&act=edit&table=tl_article', 'label' => 'Article 1 [Main column]'],
+                ['url' => '/contao?do=article&id=1&act=edit&table=tl_article', 'label' => 'Article 1'],
             ],
         ];
 
@@ -217,7 +217,7 @@ class DcaUrlAnalyzerTest extends FunctionalTestCase
             'do=article&act=show&id=1&popup=1',
             [
                 ['url' => '/contao?do=article&table=tl_article', 'label' => 'Articles'],
-                ['url' => '/contao?do=article&id=1&act=show&table=tl_article', 'label' => 'Article 1 [Main column]'],
+                ['url' => '/contao?do=article&id=1&act=show&table=tl_article', 'label' => 'Article 1'],
             ],
         ];
 
@@ -225,7 +225,7 @@ class DcaUrlAnalyzerTest extends FunctionalTestCase
             'do=article&table=tl_content&id=1',
             [
                 ['url' => '/contao?do=article&table=tl_article', 'label' => 'Articles'],
-                ['url' => '/contao?do=article&id=1&table=tl_content', 'label' => 'Article 1 [Main column]'],
+                ['url' => '/contao?do=article&id=1&table=tl_content', 'label' => 'Article 1'],
             ],
         ];
 
@@ -233,7 +233,7 @@ class DcaUrlAnalyzerTest extends FunctionalTestCase
             'do=article&id=1&table=tl_content&act=edit',
             [
                 ['url' => '/contao?do=article&table=tl_article', 'label' => 'Articles'],
-                ['url' => '/contao?do=article&id=1&table=tl_content', 'label' => 'Article 1 [Main column]'],
+                ['url' => '/contao?do=article&id=1&table=tl_content', 'label' => 'Article 1'],
                 ['url' => '/contao?do=article&id=1&act=edit&table=tl_content&ptable=tl_content', 'label' => 'Element group'],
             ],
         ];
@@ -242,7 +242,7 @@ class DcaUrlAnalyzerTest extends FunctionalTestCase
             'do=article&id=1&table=tl_content&act=show&popup=1',
             [
                 ['url' => '/contao?do=article&table=tl_article', 'label' => 'Articles'],
-                ['url' => '/contao?do=article&id=1&table=tl_content', 'label' => 'Article 1 [Main column]'],
+                ['url' => '/contao?do=article&id=1&table=tl_content', 'label' => 'Article 1'],
                 ['url' => '/contao?do=article&id=1&act=show&table=tl_content&ptable=tl_content', 'label' => 'Element group'],
             ],
         ];
@@ -251,7 +251,7 @@ class DcaUrlAnalyzerTest extends FunctionalTestCase
             'do=article&id=1&table=tl_content&ptable=tl_content',
             [
                 ['url' => '/contao?do=article&table=tl_article', 'label' => 'Articles'],
-                ['url' => '/contao?do=article&id=1&table=tl_content', 'label' => 'Article 1 [Main column]'],
+                ['url' => '/contao?do=article&id=1&table=tl_content', 'label' => 'Article 1'],
                 ['url' => '/contao?do=article&id=1&table=tl_content&ptable=tl_content', 'label' => 'Element group'],
             ],
         ];
@@ -260,7 +260,7 @@ class DcaUrlAnalyzerTest extends FunctionalTestCase
             'do=article&id=2&ptable=tl_content&table=tl_content&act=edit',
             [
                 ['url' => '/contao?do=article&table=tl_article', 'label' => 'Articles'],
-                ['url' => '/contao?do=article&id=1&table=tl_content', 'label' => 'Article 1 [Main column]'],
+                ['url' => '/contao?do=article&id=1&table=tl_content', 'label' => 'Article 1'],
                 ['url' => '/contao?do=article&id=1&table=tl_content&ptable=tl_content', 'label' => 'Element group'],
                 ['url' => '/contao?do=article&id=2&act=edit&table=tl_content&ptable=tl_content', 'label' => 'Element group'],
             ],
@@ -270,7 +270,7 @@ class DcaUrlAnalyzerTest extends FunctionalTestCase
             'do=article&id=3&ptable=tl_content&table=tl_content&act=edit',
             [
                 ['url' => '/contao?do=article&table=tl_article', 'label' => 'Articles'],
-                ['url' => '/contao?do=article&id=1&table=tl_content', 'label' => 'Article 1 [Main column]'],
+                ['url' => '/contao?do=article&id=1&table=tl_content', 'label' => 'Article 1'],
                 ['url' => '/contao?do=article&id=1&table=tl_content&ptable=tl_content', 'label' => 'Element group'],
                 ['url' => '/contao?do=article&id=2&table=tl_content&ptable=tl_content', 'label' => 'Element group'],
                 ['url' => '/contao?do=article&id=3&act=edit&table=tl_content&ptable=tl_content', 'label' => 'Headline'],
@@ -281,7 +281,7 @@ class DcaUrlAnalyzerTest extends FunctionalTestCase
             'do=themes&table=tl_image_size&id=1',
             [
                 ['url' => '/contao?do=themes&table=tl_theme', 'label' => 'Themes'],
-                ['url' => '/contao?do=themes&id=1&table=tl_image_size', 'label' => 'Default'],
+                ['url' => '/contao?do=themes&id=1&table=tl_image_size', 'label' => 'Default Theme'],
             ],
         ];
 
@@ -289,7 +289,7 @@ class DcaUrlAnalyzerTest extends FunctionalTestCase
             'do=themes&id=1&table=tl_layout',
             [
                 ['url' => '/contao?do=themes&table=tl_theme', 'label' => 'Themes'],
-                ['url' => '/contao?do=themes&id=1&table=tl_layout', 'label' => 'Default'],
+                ['url' => '/contao?do=themes&id=1&table=tl_layout', 'label' => 'Default Theme'],
             ],
         ];
 
@@ -297,8 +297,8 @@ class DcaUrlAnalyzerTest extends FunctionalTestCase
             'do=themes&id=1&table=tl_layout&act=edit',
             [
                 ['url' => '/contao?do=themes&table=tl_theme', 'label' => 'Themes'],
-                ['url' => '/contao?do=themes&id=1&table=tl_layout', 'label' => 'Default'],
-                ['url' => '/contao?do=themes&id=1&act=edit&table=tl_layout', 'label' => 'Edit page layout ID 1'],
+                ['url' => '/contao?do=themes&id=1&table=tl_layout', 'label' => 'Default Theme'],
+                ['url' => '/contao?do=themes&id=1&act=edit&table=tl_layout', 'label' => 'Default Layout'],
             ],
         ];
     }


### PR DESCRIPTION
Fixes #7870

This should be a more robus way to generate the title. It does no longer instantiate a `DC_Table` object so the issues from #7870 should be solved with that.

This also fixes #7887

It uses the `$GLOBALS['TL_DCA'][$table]['list']['sorting']['defaultSearchField']` as the default tilte and if this is not set or empty we fallback to the `tl_$table.edit` or `DCA.edit` label.