### PR TITLE
Update the language key for the "confirm" action

### DIFF
--- a/core-bundle/contao/languages/en/default.xlf
+++ b/core-bundle/contao/languages/en/default.xlf
@@ -1340,7 +1340,7 @@
       <trans-unit id="MSC.cancelBT">
         <source>Cancel</source>
       </trans-unit>
-      <trans-unit id="MSC.confirm">
+      <trans-unit id="MSC.confirmTitle">
           <source>Are you sure?</source>
       </trans-unit>
       <trans-unit id="MSC.deleteConfirm">

--- a/core-bundle/contao/templates/twig/backend/template_studio/_dialog.html.twig
+++ b/core-bundle/contao/templates/twig/backend/template_studio/_dialog.html.twig
@@ -3,7 +3,7 @@
 <dialog data-contao--template-studio-target="dialog">
     <div class="dialog_wrapper">
         <div class="header_wrapper">
-            <h3>{% block title %}{{ 'MSC.confirm'|trans }}{% endblock %}</h3>
+            <h3>{% block title %}{{ 'MSC.confirmTitle'|trans }}{% endblock %}</h3>
         </div>
         <form action="{{ app.request.uri }}" method="post">
             {% block content %}{% endblock %}


### PR DESCRIPTION
### Description

- fixes #7948

This PR makes sure that the old _confirm translation_ does not cause errors as explained in #7948 

Using `title` as a suffix here to match the action and the `h3` as well