### PR TITLE
Fix splitting grouped document IDs

### DIFF
--- a/core-bundle/src/Search/Backend/GroupedDocumentIds.php
+++ b/core-bundle/src/Search/Backend/GroupedDocumentIds.php
@@ -97,6 +97,11 @@ final class GroupedDocumentIds
      */
     public function split(int $maxBytes): array
     {
+        // No IDs provided at all, make sure we return ourselves as a chunk
+        if ([] === $this->typeToIds) {
+            return [$this];
+        }
+
         $chunks = [];
         $currentChunk = [];
         $currentSize = 0;

--- a/core-bundle/tests/Search/Backend/GroupedDocumentIdsTest.php
+++ b/core-bundle/tests/Search/Backend/GroupedDocumentIdsTest.php
@@ -138,5 +138,10 @@ class GroupedDocumentIdsTest extends TestCase
         $chunks = $groupedDocumentIds->split(65536);
         $this->assertCount(1, $chunks);
         $this->assertSame($typeToIds, $chunks[0]->toArray());
+
+        // Test splitting without typeToIds at all
+        $groupedDocumentIds = new GroupedDocumentIds();
+        $chunks = $groupedDocumentIds->split(65536);
+        $this->assertCount(1, $chunks);
     }
 }


### PR DESCRIPTION
Fixes rebuilding the back end search from the system maintenance area in the back end not working.