### PR TITLE
Prevent useless DB queries in the `CommandSchedulerListener`

### DIFF
--- a/core-bundle/src/EventListener/CommandSchedulerListener.php
+++ b/core-bundle/src/EventListener/CommandSchedulerListener.php
@@ -52,12 +52,12 @@ class CommandSchedulerListener
             return false;
         }
 
-        // Without the DB table, the cron framework cannot work
-        if (!$this->canRunDbQuery()) {
+        if ($this->autoMode && $this->cron->hasMinutelyCliCron()) {
             return false;
         }
 
-        if ($this->autoMode && $this->cron->hasMinutelyCliCron()) {
+        // Without the DB table, the cron framework cannot work
+        if (!$this->canRunDbQuery()) {
             return false;
         }
 


### PR DESCRIPTION
The `CommandSchedulerListener` currently executes a lot of nonsense `information_schema.TABLES` queries even if you have a real cronjob running. This is because we check for `canRunDbQuery()` before checking if the auto mode is enabled and a real CLI cron is running.