### PR TITLE
Add missing `ref` for edit profile redirect

### DIFF
--- a/core-bundle/contao/controllers/BackendMain.php
+++ b/core-bundle/contao/controllers/BackendMain.php
@@ -74,7 +74,7 @@ class BackendMain extends Backend
 				'do' => 'login',
 				'act' => 'edit',
 				'id' => $user->id,
-				'ref' => $container->get('request_stack')->getCurrentRequest()->attributes->get('_contao_referer_id'),
+				'ref' => Input::get('ref') ?: $container->get('request_stack')->getCurrentRequest()->attributes->get('_contao_referer_id'),
 			));
 
 			$this->redirect($strUrl);

--- a/core-bundle/src/EventListener/Menu/BackendMenuListener.php
+++ b/core-bundle/src/EventListener/Menu/BackendMenuListener.php
@@ -185,7 +185,7 @@ class BackendMenuListener
         $login = $factory
             ->createItem('login')
             ->setLabel('MSC.profile')
-            ->setUri($this->router->generate('contao_backend', ['do' => 'login', 'ref' => $ref]))
+            ->setUri($this->router->generate('contao_backend', ['do' => 'login', 'act' => 'edit', 'id' => $user->id, 'ref' => $ref]))
             ->setLinkAttribute('class', 'icon-profile')
             ->setExtra('translation_domain', 'contao_default')
         ;

--- a/core-bundle/tests/EventListener/Menu/BackendMenuListenerTest.php
+++ b/core-bundle/tests/EventListener/Menu/BackendMenuListenerTest.php
@@ -185,6 +185,7 @@ class BackendMenuListenerTest extends TestCase
     public function testBuildsTheHeaderMenu(): void
     {
         $user = $this->mockClassWithProperties(BackendUser::class);
+        $user->id = 1;
         $user->name = 'Foo Bar';
         $user->username = 'foo';
         $user->email = 'foo@bar.com';
@@ -296,7 +297,7 @@ class BackendMenuListenerTest extends TestCase
 
         // Login
         $this->assertSame('MSC.profile', $grandChildren['login']->getLabel());
-        $this->assertSame('/contao?do=login&ref=bar', $grandChildren['login']->getUri());
+        $this->assertSame('/contao?do=login&act=edit&id=1&ref=bar', $grandChildren['login']->getUri());
         $this->assertSame(['class' => 'icon-profile'], $grandChildren['login']->getLinkAttributes());
         $this->assertSame(['translation_domain' => 'contao_default'], $grandChildren['login']->getExtras());
 


### PR DESCRIPTION
Fixes #7965

As mentioned by @ausi in https://github.com/contao/contao/issues/7965#issuecomment-2625722429 this issue also occurs in 5.3 (and 4.13) if you open any other link in a new tab before clicking on _Profile_ in the header menu. This is because that profile link will actually then redirect you elsewhere, using the wrong `ref` parameter.

Additionally I changed the link in the header menu so that it does not cause a redirect and instead passes all necessary parameters to the URL generator in the first place, which also fixes the issue. 