### PR TITLE
Set `defaultSearchField` for `tl_page` to `title`

### DIFF
--- a/core-bundle/contao/dca/tl_page.php
+++ b/core-bundle/contao/dca/tl_page.php
@@ -84,7 +84,7 @@ $GLOBALS['TL_DCA']['tl_page'] = array
 			'showRootTrails'          => true,
 			'icon'                    => 'pagemounts.svg',
 			'panelLayout'             => 'filter;search',
-			'defaultSearchField'      => 'pageTitle'
+			'defaultSearchField'      => 'title'
 		),
 		'label' => array
 		(


### PR DESCRIPTION
The default search field for `tl_page` is currently set to the non-mandatory `pageTitle` field. It should be set to the mandatory `title` field instead, as that is the title shown in the back end and also the title you most likely want to search for, especially if you only ever need to fill the `pageTitle` for a small subset of pages.

This then also fixes #7987.