### PR TITLE
Unset the default `UriSigner` parameters when generating download URLs

### DIFF
--- a/core-bundle/src/Filesystem/FileDownloadHelper.php
+++ b/core-bundle/src/Filesystem/FileDownloadHelper.php
@@ -142,6 +142,9 @@ class FileDownloadHelper
         parse_str($uri->getQuery(), $existingParams);
         $params = [...$existingParams, ...array_filter($params)];
 
+        // Unset default uri_signer parameters (#7989)
+        unset($params['_hash'], $params['_expiration']);
+
         return $this->signer->sign((string) $uri->withQuery(http_build_query($params)));
     }
 


### PR DESCRIPTION
Fixes #7989 

Unfortunately #7874 introduced a regression: when a download URL is handled inline by the content element itself, previous download elements are processed first. Thus they generate and sign their download URLs _with_ the `_hash` parameter of the current download URL. These generated download URLs would then be invalid of course. Typically this is not an issue in Contao 5.3 (Symfony 6.4), because normally your client would not get to see a rendered response with these invalid download URLs, as the client will instead receive the download response. However, if for whatever reason, the download URL is not handled, the page would be rendered as normal, with the invalid download URLs in place.

Furthermore, starting with Symfony 7.1, signing an URL that already contains a `_hash` parameter will lead to the exception described in #7989.

This PR fixes this by removing the parameters that are used by the `UriSigner` by default.

_Note:_ if you have an App customization or bundle that customizes the parameters used by the `UriSigner` service via a compiler pass for whatever reason, this would fail again. I am not sure how to handle this better.