### PR TITLE
Sort the news feed in descending order

### DIFF
--- a/core-bundle/src/Controller/FrontendModule/FeedReaderController.php
+++ b/core-bundle/src/Controller/FrontendModule/FeedReaderController.php
@@ -88,7 +88,7 @@ class FeedReaderController extends AbstractFrontendModuleController
             ),
         );
 
-        usort($elements, static fn (array $a, array $b): int => $a['item']->getLastModified() <=> $b['item']->getLastModified());
+        usort($elements, static fn (array $a, array $b): int => $b['item']->getLastModified() <=> $a['item']->getLastModified());
 
         if ($model->perPage > 0) {
             $param = 'page_r'.$model->id;


### PR DESCRIPTION
### Description

* fixes #7905 

Basically reverses the usort to descending rather than ascending to match the old RSS feed
(who wants to see the oldest news first 🙃 -> 😊)