### PR TITLE
Backport the `MSC.edit` translation

### DIFF
--- a/core-bundle/contao/languages/en/default.xlf
+++ b/core-bundle/contao/languages/en/default.xlf
@@ -2117,6 +2117,9 @@
       <trans-unit id="MSC.disable">
         <source>Disable</source>
       </trans-unit>
+      <trans-unit id="MSC.edit">
+        <source>Edit</source>
+      </trans-unit>
       <trans-unit id="MSC.serpPreview.0">
         <source>Google search results preview</source>
       </trans-unit>


### PR DESCRIPTION
This backports the `MSC.edit` translation from https://github.com/contao/contao/pull/8007. We are actually using it (accidentally) already here:

https://github.com/contao/contao/blob/b609b74d9fe9373b70cc440829623e47ccd80a85/core-bundle/contao/templates/backend/be_two_factor.html5#L153

Alternatively we could change it to `MSC.editSelected` (wich also translates to _Edit_).