### PR TITLE
Enable `enableKeyboardAccessibility` for the ace editor

### DIFF
--- a/core-bundle/contao/templates/backend/be_ace.html5
+++ b/core-bundle/contao/templates/backend/be_ace.html5
@@ -22,7 +22,7 @@ window.ace && window.addEvent('domready', function() {
   ta.style['display'] = 'none';
 
   // Instantiate the editor
-  let editor = ace.edit('<?= $this->selector ?>_div', {maxLines: Infinity});
+  let editor = ace.edit('<?= $this->selector ?>_div', {maxLines: Infinity, enableKeyboardAccessibility: true});
   editor.$blockScrolling = Infinity;
   editor.setTheme((document.documentElement.dataset.colorScheme === 'dark' ? 'ace/theme/twilight' : 'ace/theme/clouds'));
   editor.renderer.setScrollMargin(3, 3, 0, 0);


### PR DESCRIPTION
### Description

Whilst tabbing through the layout, I realized that the ace editor acts as a keyboard trap where you'd be trapped forever.
This PR fixes it by focusing into the editor with Enter and being able to leave it with ESC.

https://github.com/ajaxorg/ace/pull/5114

Old behavior:

https://github.com/user-attachments/assets/f657c050-7a27-4b99-baae-ff30b1dc88fb

New:

https://github.com/user-attachments/assets/3ed41c7e-54db-4b71-ac68-04d8c6fca846


