### PR TITLE
Remove `<turbo-frame>` in the DC drivers

### DIFF
--- a/core-bundle/contao/drivers/DC_File.php
+++ b/core-bundle/contao/drivers/DC_File.php
@@ -307,10 +307,10 @@ class DC_File extends DataContainer implements EditableDataContainerInterface
 		}
 
 		$return = '
-<turbo-frame id="tl_edit_form_frame" target="_top" data-turbo-action="advance" data-controller="contao--jump-targets">
+<div data-controller="contao--jump-targets">
 	<div class="jump-targets"><div class="inner" data-contao--jump-targets-target="navigation"></div></div>
 	' . $return . '
-</turbo-frame>';
+</div>';
 
 		return $return;
 	}

--- a/core-bundle/contao/drivers/DC_Folder.php
+++ b/core-bundle/contao/drivers/DC_Folder.php
@@ -1365,12 +1365,10 @@ class DC_Folder extends DataContainer implements ListableDataContainerInterface,
 		$return .= '
 </div>
   ' . $strButtons . '
-</form>
-</turbo-frame>';
+</form>';
 
 		// Begin the form (-> DO NOT CHANGE THIS ORDER -> this way the onsubmit attribute of the form can be changed by a field)
-		$return = '
-<turbo-frame id="tl_edit_form_frame" target="_top" data-turbo-action="advance">' . $version . Message::generate() . ($this->noReload ? '
+		$return = $version . Message::generate() . ($this->noReload ? '
 <p class="tl_error">' . $GLOBALS['TL_LANG']['ERR']['submit'] . '</p>' : '') . '
 <div id="tl_buttons">
 ' . DataContainerOperationsBuilder::generateBackButton() . '

--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -2368,10 +2368,10 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 <input type="hidden" name="REQUEST_TOKEN" value="' . htmlspecialchars(System::getContainer()->get('contao.csrf.token_manager')->getDefaultTokenValue(), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5) . '">' . $strVersionField . $return;
 
 		$return = '
-<turbo-frame id="tl_edit_form_frame" target="_top" data-turbo-action="advance" data-controller="contao--jump-targets">
+<div data-controller="contao--jump-targets">
 	<div class="jump-targets"><div class="inner" data-contao--jump-targets-target="navigation"></div></div>
 	' . $return . '
-</turbo-frame>';
+</div>';
 
 		return $return;
 	}

--- a/core-bundle/src/DataContainer/ButtonsBuilder.php
+++ b/core-bundle/src/DataContainer/ButtonsBuilder.php
@@ -33,7 +33,7 @@ class ButtonsBuilder
     public function generateEditButtons(string $strTable, bool $hasPtable, bool $hasCreatePermission, bool $hasCopyPermission, DataContainer $dc): string
     {
         $arrButtons = [];
-        $arrButtons['save'] = '<button type="submit" name="save" id="save" class="tl_submit" accesskey="s" data-turbo-frame="_self">'.$GLOBALS['TL_LANG']['MSC']['save'].'</button>';
+        $arrButtons['save'] = '<button type="submit" name="save" id="save" class="tl_submit" accesskey="s">'.$GLOBALS['TL_LANG']['MSC']['save'].'</button>';
 
         if (!Input::get('nb')) {
             $arrButtons['saveNclose'] = '<button type="submit" name="saveNclose" id="saveNclose" class="tl_submit" accesskey="c" data-action="contao--scroll-offset#discard">'.$GLOBALS['TL_LANG']['MSC']['saveNclose'].'</button>';


### PR DESCRIPTION
Now that the scroll offset was fixed in https://github.com/contao/contao/pull/7996 we can revert parts of https://github.com/contao/contao/pull/7419. This will also fix an issue that currently exists where the backend breadcrumb does not automatically update after saving a new record.
