### PR TITLE
Close the search bar on the input `blur` event

### DIFF
--- a/core-bundle/contao/templates/twig/backend/search/_container.html.twig
+++ b/core-bundle/contao/templates/twig/backend/search/_container.html.twig
@@ -21,7 +21,7 @@
     .set('placeholder', 'MSC.search'|trans)
     .set('name', 'keywords')
     .set('data-contao--backend-search-target', 'input')
-    .set('data-action', 'focus->contao--backend-search#open input->contao--backend-search#performSearch')
+    .set('data-action', 'focus->contao--backend-search#open input->contao--backend-search#performSearch blur->contao--backend-search#close')
 %}
 
 <div {{ search_container_attributes }}>


### PR DESCRIPTION
### Description

Closes the search on the input blur event (keyboard navigation)
