### PR TITLE
Use a prefix for the passkey user handle

### DIFF
--- a/core-bundle/config/listener.yaml
+++ b/core-bundle/config/listener.yaml
@@ -562,14 +562,15 @@ services:
             - '@contao.routing.scope_matcher'
             - '@event_dispatcher'
 
-    contao.listener.webauthn_backend_route:
-        class: Contao\CoreBundle\EventListener\WebauthnBackendRouteListener
+    contao.listener.webauthn_route:
+        class: Contao\CoreBundle\EventListener\WebauthnRouteListener
         arguments:
             -
                 - webauthn.controller.creation.request.contao_backend_add_authenticator
                 - webauthn.controller.creation.response.contao_backend_add_authenticator
                 - webauthn.controller.security.contao_backend.request.options
                 - webauthn.controller.security.contao_backend.request.result
+            - backend
 
     contao.listener.widget.custom_rgxp:
         class: Contao\CoreBundle\EventListener\Widget\CustomRgxpListener

--- a/core-bundle/contao/classes/BackendUser.php
+++ b/core-bundle/contao/classes/BackendUser.php
@@ -459,4 +459,14 @@ class BackendUser extends User
 
 		return parent::isEqualTo($user);
 	}
+
+	public function getDisplayName(): string
+	{
+		return $this->name;
+	}
+
+	public function getPasskeyUserHandle(): string
+	{
+		return 'backend.' . $this->id;
+	}
 }

--- a/core-bundle/contao/classes/FrontendUser.php
+++ b/core-bundle/contao/classes/FrontendUser.php
@@ -217,4 +217,14 @@ class FrontendUser extends User
 	{
 		return $this->roles;
 	}
+
+	public function getDisplayName(): string
+	{
+		return implode(' ', array_filter(array($this->firstname, $this->lastname)));
+	}
+
+	public function getPasskeyUserHandle(): string
+	{
+		return 'frontend.' . $this->id;
+	}
 }

--- a/core-bundle/contao/classes/FrontendUser.php
+++ b/core-bundle/contao/classes/FrontendUser.php
@@ -220,7 +220,7 @@ class FrontendUser extends User
 
 	public function getDisplayName(): string
 	{
-		return implode(' ', array_filter(array($this->firstname, $this->lastname)));
+		return trim("$this->firstname $this->lastname");
 	}
 
 	public function getPasskeyUserHandle(): string

--- a/core-bundle/contao/library/Contao/User.php
+++ b/core-bundle/contao/library/Contao/User.php
@@ -457,4 +457,14 @@ abstract class User extends System implements UserInterface, EquatableInterface,
 
 		return true;
 	}
+
+	public function getDisplayName(): string
+	{
+		throw new \BadMethodCallException(\sprintf('%s not implemented in %s.', __FUNCTION__, self::class));
+	}
+
+	public function getPasskeyUserHandle(): string
+	{
+		throw new \BadMethodCallException(\sprintf('%s not implemented in %s.', __FUNCTION__, self::class));
+	}
 }

--- a/core-bundle/contao/modules/ModuleTwoFactor.php
+++ b/core-bundle/contao/modules/ModuleTwoFactor.php
@@ -94,7 +94,7 @@ class ModuleTwoFactor extends BackendModule
 			{
 				if ($credential = $credentialRepo->findOneById($deleteCredentialId))
 				{
-					$this->checkCredentialAccess($user, $credential);
+					$this->denyAccessUnlessGranted($user, $credential);
 
 					$credentialRepo->remove($credential);
 				}
@@ -103,7 +103,7 @@ class ModuleTwoFactor extends BackendModule
 			{
 				if ($credential = $credentialRepo->findOneById($editCredentialId))
 				{
-					$this->checkCredentialAccess($user, $credential);
+					$this->denyAccessUnlessGranted($user, $credential);
 
 					$this->redirect($this->addToUrl('edit_passkey=' . $editCredentialId));
 				}
@@ -117,7 +117,7 @@ class ModuleTwoFactor extends BackendModule
 			{
 				if ($credential = $credentialRepo->findOneById($saveCredentialId))
 				{
-					$this->checkCredentialAccess($user, $credential);
+					$this->denyAccessUnlessGranted($user, $credential);
 
 					$credential->name = Input::post('passkey_name') ?? '';
 					$credentialRepo->saveCredentialSource($credential);
@@ -218,7 +218,7 @@ class ModuleTwoFactor extends BackendModule
 		throw new RedirectResponseException($return);
 	}
 
-	private function checkCredentialAccess(BackendUser $user, WebauthnCredential $credential): void
+	private function denyAccessUnlessGranted(BackendUser $user, WebauthnCredential $credential): void
 	{
 		if ($credential->userHandle !== $user->getPasskeyUserHandle())
 		{

--- a/core-bundle/contao/modules/ModuleTwoFactor.php
+++ b/core-bundle/contao/modules/ModuleTwoFactor.php
@@ -94,10 +94,7 @@ class ModuleTwoFactor extends BackendModule
 			{
 				if ($credential = $credentialRepo->findOneById($deleteCredentialId))
 				{
-					if ((int) $credential->userHandle !== $user->id)
-					{
-						throw new AccessDeniedHttpException('Cannot delete credential ID ' . $deleteCredentialId);
-					}
+					$this->checkCredentialAccess($user, $credential);
 
 					$credentialRepo->remove($credential);
 				}
@@ -106,10 +103,7 @@ class ModuleTwoFactor extends BackendModule
 			{
 				if ($credential = $credentialRepo->findOneById($editCredentialId))
 				{
-					if ((int) $credential->userHandle !== $user->id)
-					{
-						throw new AccessDeniedHttpException('Cannot edit credential ID ' . $editCredentialId);
-					}
+					$this->checkCredentialAccess($user, $credential);
 
 					$this->redirect($this->addToUrl('edit_passkey=' . $editCredentialId));
 				}
@@ -123,10 +117,7 @@ class ModuleTwoFactor extends BackendModule
 			{
 				if ($credential = $credentialRepo->findOneById($saveCredentialId))
 				{
-					if ((int) $credential->userHandle !== $user->id)
-					{
-						throw new AccessDeniedHttpException('Cannot save credential ID ' . $saveCredentialId);
-					}
+					$this->checkCredentialAccess($user, $credential);
 
 					$credential->name = Input::post('passkey_name') ?? '';
 					$credentialRepo->saveCredentialSource($credential);
@@ -225,5 +216,13 @@ class ModuleTwoFactor extends BackendModule
 		System::getContainer()->get('contao.security.two_factor.trusted_device_manager')->clearTrustedDevices($user);
 
 		throw new RedirectResponseException($return);
+	}
+
+	private function checkCredentialAccess(BackendUser $user, WebauthnCredential $credential): void
+	{
+		if ($credential->userHandle !== $user->getPasskeyUserHandle())
+		{
+			throw new AccessDeniedHttpException('Cannot access credential ID ' . $credential->getId());
+		}
 	}
 }

--- a/core-bundle/src/Entity/WebauthnCredential.php
+++ b/core-bundle/src/Entity/WebauthnCredential.php
@@ -31,9 +31,6 @@ class WebauthnCredential extends PublicKeyCredentialSource
     #[Column(type: Types::STRING)]
     public string $name;
 
-    #[Column(type: Types::STRING)]
-    public string $userType;
-
     #[Column(type: Types::DATETIME_IMMUTABLE)]
     public readonly \DateTimeImmutable $createdAt;
 
@@ -42,12 +39,11 @@ class WebauthnCredential extends PublicKeyCredentialSource
     #[GeneratedValue(strategy: 'NONE')]
     private readonly string $id;
 
-    public function __construct(string $publicKeyCredentialId, string $type, array $transports, string $attestationType, TrustPath $trustPath, Uuid $aaguid, string $credentialPublicKey, string $userHandle, int $counter, string $userType)
+    public function __construct(string $publicKeyCredentialId, string $type, array $transports, string $attestationType, TrustPath $trustPath, Uuid $aaguid, string $credentialPublicKey, string $userHandle, int $counter)
     {
         $this->id = Ulid::generate();
         $this->name = '';
         $this->createdAt = new \DateTimeImmutable();
-        $this->userType = $userType;
 
         parent::__construct($publicKeyCredentialId, $type, $transports, $attestationType, $trustPath, $aaguid, $credentialPublicKey, $userHandle, $counter);
     }

--- a/core-bundle/src/EventListener/WebauthnRouteListener.php
+++ b/core-bundle/src/EventListener/WebauthnRouteListener.php
@@ -16,7 +16,7 @@ use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 
 /**
- * Adds the given scope to the given routes of the WebauthnBundle.
+ * Adds the "backend" scope to the back end routes of the WebauthnBundle.
  */
 #[AsEventListener(priority: 10)]
 class WebauthnRouteListener

--- a/core-bundle/src/EventListener/WebauthnRouteListener.php
+++ b/core-bundle/src/EventListener/WebauthnRouteListener.php
@@ -16,10 +16,10 @@ use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 
 /**
- * Adds the "backend" scope to the back end routes of the WebauthnBundle.
+ * Adds the given scope to the given routes of the WebauthnBundle.
  */
 #[AsEventListener(priority: 10)]
-class WebauthnBackendRouteListener
+class WebauthnRouteListener
 {
     /**
      * @param list<string> $routes

--- a/core-bundle/tests/EventListener/WebauthnRouteListenerTest.php
+++ b/core-bundle/tests/EventListener/WebauthnRouteListenerTest.php
@@ -12,14 +12,14 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Tests\EventListener;
 
-use Contao\CoreBundle\EventListener\WebauthnBackendRouteListener;
+use Contao\CoreBundle\EventListener\WebauthnRouteListener;
 use Contao\CoreBundle\Tests\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
 
-class WebauthnBackendRouteListenerTest extends TestCase
+class WebauthnRouteListenerTest extends TestCase
 {
     /**
      * @dataProvider routeProvider
@@ -39,7 +39,7 @@ class WebauthnBackendRouteListenerTest extends TestCase
             'webauthn.controller.security.contao_backend.request.result',
         ];
 
-        (new WebauthnBackendRouteListener($routes))($event);
+        (new WebauthnRouteListener($routes))($event);
 
         $this->assertSame($resultingScope, $request->attributes->get('_scope'));
     }

--- a/manager-bundle/skeleton/config/security.yaml
+++ b/manager-bundle/skeleton/config/security.yaml
@@ -22,8 +22,8 @@ security:
                     enabled: true
                     profile: contao_backend
                     routes:
-                        options_path: /_contao/login/webauthn/options
-                        result_path: /_contao/login/webauthn/result
+                        options_path: /_contao/webauthn/backend/login/options
+                        result_path: /_contao/webauthn/backend/login/result
 
             login_link:
                 check_route: contao_backend_login_link


### PR DESCRIPTION
This prefixes the `userHandle` for the passkeys (WebAuthn credentials) with `backend.`. This is done in preparation of https://github.com/contao/contao/pull/8011. The database ID of `tl_member` and `tl_user` won't be unique, so there can be situations where a passkey for the front end cannot be generated if there already exists a passkey for the back end under the same `userHandle` (i.e. user ID).

This in turn also backports a few other improvements and changes from #8011, so that they will be more forward compatible.

_Note:_ this will cause any existing Passkeys you have for your `5.5` RC instance to not work anymore. You will also need to execute

```
contao:migrate --no-interaction --with-deletes
```

as the `userType` field will be removed from the credential table, as it is not needed anymore.