### PR TITLE
Replace the deprecated global variable `request_token`

### DIFF
--- a/core-bundle/templates/Backend/be_menu.html.twig
+++ b/core-bundle/templates/Backend/be_menu.html.twig
@@ -4,7 +4,7 @@
     data-controller="contao--toggle-navigation"
     data-contao--toggle-navigation-collapsed-class="collapsed"
     data-contao--toggle-navigation-url-value="{{ path('contao_backend') }}"
-    data-contao--toggle-navigation-request-token-value="{{ request_token }}"
+    data-contao--toggle-navigation-request-token-value="{{ contao.request_token }}"
     data-contao--toggle-navigation-expand-title-value="{{ 'MSC.expandNode'|trans }}"
     data-contao--toggle-navigation-collapse-title-value="{{ 'MSC.collapseNode'|trans }}"
     aria-label="{{ 'MSC.mainNavigation'|trans }}"

--- a/core-bundle/templates/Frontend/preview_toolbar_base.html.twig
+++ b/core-bundle/templates/Frontend/preview_toolbar_base.html.twig
@@ -14,7 +14,7 @@
                 <span class="badge-title">{{ badgeTitle }}</span>
             {% endif %}
             <input type="hidden" name="FORM_SUBMIT" value="tl_switch">
-            <input type="hidden" name="REQUEST_TOKEN" value="{{ request_token }}">
+            <input type="hidden" name="REQUEST_TOKEN" value="{{ contao.request_token }}">
             <div>
                 <button type="button" id="copyPublishedPath" class="tl_submit">{{ 'MSC.copyURL'|trans([], 'contao_default') }}</button>
                 {% if share is not empty %}


### PR DESCRIPTION
`The "request_token" Twig variable has been deprecated and will no longer work in Contao 6. Use the "contao.request_token" variable instead.`

https://github.com/contao/contao/blob/1f008d5d22be163e754ba835296b5702aa82d82f/core-bundle/src/Twig/Extension/ContaoExtension.php#L97