### PR TITLE
Do not use Turbo Drive for the `exportTheme` link

### DIFF
--- a/core-bundle/contao/dca/tl_theme.php
+++ b/core-bundle/contao/dca/tl_theme.php
@@ -267,6 +267,6 @@ class tl_theme extends Backend
 	 */
 	public function exportTheme($row, $href, $label, $title, $icon, $attributes)
 	{
-		return System::getContainer()->get('security.helper')->isGranted(ContaoCorePermissions::USER_CAN_EXPORT_THEMES) ? '<a href="' . $this->addToUrl($href . '&amp;id=' . $row['id']) . '"' . $attributes . '>' . Image::getHtml($icon, $title) . '</a> ' : Image::getHtml(str_replace('.svg', '--disabled.svg', $icon)) . ' ';
+		return System::getContainer()->get('security.helper')->isGranted(ContaoCorePermissions::USER_CAN_EXPORT_THEMES) ? '<a href="' . $this->addToUrl($href . '&amp;id=' . $row['id']) . '"' . $attributes . ' data-turbo="false">' . Image::getHtml($icon, $title) . '</a> ' : Image::getHtml(str_replace('.svg', '--disabled.svg', $icon)) . ' ';
 	}
 }


### PR DESCRIPTION
### Description

* Fixes #8047 

This disables the prefetch of the download as mentioned in https://github.com/contao/contao/issues/8047#issuecomment-2646090568.

The current behavior tries to prefetch the download and Turbo tries to wait till we reach the destination URL (which we will never do). Disabling turbo is the way to go as we wouldn't want to download just by hovering over a link anyways.