### PR TITLE
Add a directory filter VFS decorator

### DIFF
--- a/core-bundle/src/Filesystem/DirectoryFilterVirtualFilesystem.php
+++ b/core-bundle/src/Filesystem/DirectoryFilterVirtualFilesystem.php
@@ -363,11 +363,6 @@ class DirectoryFilterVirtualFilesystem implements VirtualFilesystemInterface
 
     private function getTrailItem(string $path): FilesystemItem
     {
-        return new FilesystemItem(
-            false,
-            $path,
-            extraMetadata: new ExtraMetadata([]),
-            storage: $this,
-        );
+        return new FilesystemItem(false, $path, extraMetadata: new ExtraMetadata([]), storage: $this);
     }
 }

--- a/core-bundle/src/Filesystem/DirectoryFilterVirtualFilesystem.php
+++ b/core-bundle/src/Filesystem/DirectoryFilterVirtualFilesystem.php
@@ -19,7 +19,7 @@ use Symfony\Component\Uid\Uuid;
 class DirectoryFilterVirtualFilesystem implements VirtualFilesystemInterface
 {
     /**
-     * @phpstan-use VirtualFilesystemDecoratorTrait<VirtualFilesystem>
+     * @phpstan-use VirtualFilesystemDecoratorTrait<VirtualFilesystemInterface>
      */
     use VirtualFilesystemDecoratorTrait;
 

--- a/core-bundle/src/Filesystem/DirectoryFilterVirtualFilesystem.php
+++ b/core-bundle/src/Filesystem/DirectoryFilterVirtualFilesystem.php
@@ -1,0 +1,373 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Contao\CoreBundle\Filesystem;
+
+use Contao\CoreBundle\Filesystem\Dbafs\UnableToResolveUuidException;
+use Contao\CoreBundle\Filesystem\PublicUri\OptionsInterface;
+use Psr\Http\Message\UriInterface;
+use Symfony\Component\Filesystem\Path;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * This decorator implements a view where only certain directories - including
+ * their root trails - are visible/accessible.
+ *
+ * @internal
+ */
+class DirectoryFilterVirtualFilesystem implements VirtualFilesystemInterface
+{
+    /**
+     * @phpstan-use VirtualFilesystemDecoratorTrait<VirtualFilesystem>
+     */
+    use VirtualFilesystemDecoratorTrait;
+
+    /**
+     * @var list<string>
+     */
+    private readonly array $prefixPaths;
+
+    /**
+     * @var list<string>
+     */
+    private readonly array $trailPaths;
+
+    /**
+     * @param list<string> $allowedDirectories
+     */
+    public function __construct(VirtualFilesystemInterface $virtualFilesystem, array $allowedDirectories)
+    {
+        $this->inner = $virtualFilesystem;
+
+        // Normalize
+        $allowedDirectories = array_map(static fn (string $path): string => Path::canonicalize($path), $allowedDirectories);
+        sort($allowedDirectories);
+
+        $prefixPaths = [];
+        $trailPaths = [''];
+
+        $previous = null;
+
+        foreach ($allowedDirectories as $current) {
+            if (null === $previous || !Path::isBasePath($previous, $current)) {
+                $prefixPaths[] = $previous = $trailPath = $current;
+
+                while ('' !== ($trailPath = Path::getDirectory($trailPath)) && !\in_array($trailPath, $trailPaths, true)) {
+                    $trailPaths[] = $trailPath;
+                }
+            }
+        }
+
+        $this->prefixPaths = $prefixPaths;
+        $this->trailPaths = $trailPaths;
+    }
+
+    public function has(Uuid|string $location, int $accessFlags = self::NONE): bool
+    {
+        $path = $this->resolveLocation($location);
+
+        return $this->fileExists($path, $accessFlags) || $this->directoryExists($path, $accessFlags);
+    }
+
+    public function fileExists(Uuid|string $location, int $accessFlags = self::NONE): bool
+    {
+        if (!$this->isAccessible($path = $this->resolveLocation($location), true)) {
+            return false;
+        }
+
+        return $this->inner->fileExists($path, $accessFlags);
+    }
+
+    public function directoryExists(Uuid|string $location, int $accessFlags = self::NONE): bool
+    {
+        $path = $this->resolveLocation($location);
+
+        if ($this->isTrailPath($path) || $this->isAllowedPath($path)) {
+            return true;
+        }
+
+        if (!$this->isAccessible($path, true)) {
+            return false;
+        }
+
+        return $this->inner->directoryExists($path, $accessFlags);
+    }
+
+    public function read(Uuid|string $location): string
+    {
+        if (!$this->isAccessible($path = $this->resolveLocation($location))) {
+            throw VirtualFilesystemException::unableToRead($path);
+        }
+
+        return $this->inner->read($path);
+    }
+
+    public function readStream(Uuid|string $location)
+    {
+        if (!$this->isAccessible($path = $this->resolveLocation($location))) {
+            throw VirtualFilesystemException::unableToRead($path);
+        }
+
+        return $this->inner->readStream($path);
+    }
+
+    public function write(Uuid|string $location, string $contents, array $options = []): void
+    {
+        if (!$this->isAccessible($path = $this->resolveLocation($location))) {
+            throw VirtualFilesystemException::unableToWrite($path);
+        }
+
+        $this->inner->write($path, $contents, $options);
+    }
+
+    public function writeStream(Uuid|string $location, $contents, array $options = []): void
+    {
+        if (!$this->isAccessible($path = $this->resolveLocation($location))) {
+            throw VirtualFilesystemException::unableToWrite($path);
+        }
+
+        $this->inner->writeStream($path, $contents, $options);
+    }
+
+    public function delete(Uuid|string $location): void
+    {
+        if (!$this->isAccessible($path = $this->resolveLocation($location))) {
+            throw VirtualFilesystemException::unableToDelete($path);
+        }
+
+        $this->inner->delete($path);
+    }
+
+    public function deleteDirectory(Uuid|string $location): void
+    {
+        $path = $this->resolveLocation($location);
+
+        if (!$this->isAccessible($path, true) || $this->isAllowedPath($location)) {
+            throw VirtualFilesystemException::unableToDeleteDirectory($path);
+        }
+
+        $this->inner->delete($path);
+    }
+
+    public function createDirectory(Uuid|string $location, array $options = []): void
+    {
+        $path = $this->resolveLocation($location);
+
+        if (!$this->isAccessible($path, true) || $this->isAllowedPath($location)) {
+            throw VirtualFilesystemException::unableToCreateDirectory($path);
+        }
+
+        $this->inner->createDirectory($path, $options);
+    }
+
+    public function copy(Uuid|string $source, string $destination, array $options = []): void
+    {
+        $sourcePath = $this->resolveLocation($source);
+        $destinationPath = $this->resolveLocation($destination);
+
+        if (!$this->isAccessible($sourcePath) || !$this->isAccessible($destinationPath, true)) {
+            throw VirtualFilesystemException::unableToCopy($sourcePath, $destinationPath);
+        }
+
+        $this->inner->copy($sourcePath, $destinationPath, $options);
+    }
+
+    public function move(Uuid|string $source, string $destination, array $options = []): void
+    {
+        $sourcePath = $this->resolveLocation($source);
+        $destinationPath = $this->resolveLocation($destination);
+
+        if (!$this->isAccessible($sourcePath) || !$this->isAccessible($destinationPath, true)) {
+            throw VirtualFilesystemException::unableToMove($sourcePath, $destinationPath);
+        }
+
+        $this->inner->move($sourcePath, $destinationPath, $options);
+    }
+
+    public function get(Uuid|string $location, int $accessFlags = self::NONE): FilesystemItem|null
+    {
+        $path = $this->resolveLocation($location);
+
+        if ($this->isTrailPath($path) || $this->isAllowedPath($path)) {
+            return $this->getTrailItem($path);
+        }
+
+        if (!$this->isAccessible($path, true)) {
+            return null;
+        }
+
+        return $this->inner->get($path, $accessFlags)?->withStorage($this);
+    }
+
+    public function listContents(Uuid|string $location, bool $deep = false, int $accessFlags = self::NONE): FilesystemItemIterator
+    {
+        return new FilesystemItemIterator($this->doListContents($this->resolveLocation($location), $deep, $accessFlags));
+    }
+
+    public function getLastModified(Uuid|string $location, int $accessFlags = self::NONE): int
+    {
+        if (!$this->isAccessible($path = $this->resolveLocation($location), true)) {
+            throw VirtualFilesystemException::unableToRetrieveMetadata($path);
+        }
+
+        return $this->inner->getLastModified($path, $accessFlags);
+    }
+
+    public function getFileSize(Uuid|string $location, int $accessFlags = self::NONE): int
+    {
+        if (!$this->isAccessible($path = $this->resolveLocation($location), true)) {
+            throw VirtualFilesystemException::unableToRetrieveMetadata($path);
+        }
+
+        return $this->inner->getFileSize($path, $accessFlags);
+    }
+
+    public function getMimeType(Uuid|string $location, int $accessFlags = self::NONE): string
+    {
+        if (!$this->isAccessible($path = $this->resolveLocation($location), true)) {
+            throw VirtualFilesystemException::unableToRetrieveMetadata($path);
+        }
+
+        return $this->inner->getMimeType($path, $accessFlags);
+    }
+
+    public function getExtraMetadata(Uuid|string $location, int $accessFlags = self::NONE): ExtraMetadata
+    {
+        $path = $this->resolveLocation($location);
+
+        if (!$this->isAccessible($path, true)) {
+            if (!$this->isTrailPath($path)) {
+                throw VirtualFilesystemException::unableToRetrieveMetadata($path);
+            }
+
+            // Any elements from the root trail cannot provide any extra metadata as this
+            // would expose information from outside the filtered scope.
+            return new ExtraMetadata([]);
+        }
+
+        return $this->inner->getExtraMetadata($path, $accessFlags);
+    }
+
+    public function resolveUuid(Uuid $uuid): string
+    {
+        if (!$this->isAccessible($path = $this->resolveLocation($uuid))) {
+            throw new UnableToResolveUuidException($uuid);
+        }
+
+        return $path;
+    }
+
+    public function generatePublicUri(Uuid|string $location, OptionsInterface|null $options = null): UriInterface|null
+    {
+        if (!$this->isAccessible($path = $this->resolveLocation($location))) {
+            return null;
+        }
+
+        return $this->inner->generatePublicUri($path, $options);
+    }
+
+    /**
+     * Returns the first non-virtual path or null if none exists.
+     */
+    public function getFirstNonVirtualDirectory(): string|null
+    {
+        foreach ($this->listContents('', true) as $item) {
+            if (!$this->isTrailPath($path = $item->getPath())) {
+                return $path;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return \Generator<FilesystemItem>
+     */
+    private function doListContents(string $path, bool $deep, int $accessFlags): \Generator
+    {
+        // Virtual root trail: yield items directly
+        if ($this->isTrailPath($path) && !\in_array('', $this->prefixPaths, true)) {
+            foreach ($this->getAccessibleDirectSubPaths($path) as $subPath) {
+                yield $this->getTrailItem($subPath);
+
+                if ($deep) {
+                    yield from $this->doListContents($subPath, true, $accessFlags);
+                }
+            }
+
+            return;
+        }
+
+        if (!$this->isAccessible($path, true)) {
+            return;
+        }
+
+        // Accessible directories: delegate to inner storage
+        foreach ($this->inner->listContents($path, $deep, $accessFlags) as $item) {
+            yield $item->withStorage($this);
+        }
+    }
+
+    /**
+     * @throws UnableToResolveUuidException
+     */
+    private function resolveLocation(Uuid|string $location): string
+    {
+        if ($location instanceof Uuid) {
+            return $this->inner->resolveUuid($location);
+        }
+
+        return $location;
+    }
+
+    /**
+     * Test if a given resource path is covered by the allowed prefix paths or part of the
+     * root trail. If $requireFullOwnership is set to true, the root trail is ignored.
+     */
+    private function isAccessible(string $path, bool $requireFullOwnership = false): bool
+    {
+        foreach ($this->prefixPaths as $prefixPath) {
+            if (Path::isBasePath($prefixPath, $path)) {
+                return true;
+            }
+        }
+
+        return !$requireFullOwnership && $this->isTrailPath($path);
+    }
+
+    private function isTrailPath(string $path): bool
+    {
+        return \in_array($path, $this->trailPaths, true);
+    }
+
+    private function isAllowedPath(string $path): bool
+    {
+        return \in_array($path, $this->prefixPaths, true);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function getAccessibleDirectSubPaths(string $trailPath): array
+    {
+        $accessiblePaths = array_filter(
+            [...$this->prefixPaths, ...$this->trailPaths],
+            static fn (string $path): bool => Path::getDirectory($path) === $trailPath && $path !== $trailPath,
+        );
+
+        sort($accessiblePaths);
+
+        return $accessiblePaths;
+    }
+
+    private function getTrailItem(string $path): FilesystemItem
+    {
+        return new FilesystemItem(
+            false,
+            $path,
+            extraMetadata: new ExtraMetadata([]),
+            storage: $this,
+        );
+    }
+}

--- a/core-bundle/tests/Filesystem/DirectoryFilterVirtualFilesystemTest.php
+++ b/core-bundle/tests/Filesystem/DirectoryFilterVirtualFilesystemTest.php
@@ -1,0 +1,246 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\Filesystem;
+
+use Contao\CoreBundle\Filesystem\Dbafs\DbafsManager;
+use Contao\CoreBundle\Filesystem\DirectoryFilterVirtualFilesystem;
+use Contao\CoreBundle\Filesystem\FilesystemItem;
+use Contao\CoreBundle\Filesystem\MountManager;
+use Contao\CoreBundle\Filesystem\VirtualFilesystem;
+use Contao\CoreBundle\Filesystem\VirtualFilesystemException;
+use Contao\CoreBundle\Filesystem\VirtualFilesystemInterface;
+use Contao\CoreBundle\Tests\TestCase;
+use League\Flysystem\InMemory\InMemoryFilesystemAdapter;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+class DirectoryFilterVirtualFilesystemTest extends TestCase
+{
+    public function testFiltersStorage(): void
+    {
+        $mountManager = new MountManager([]);
+        $mountManager
+            ->mount(new InMemoryFilesystemAdapter(), '')
+        ;
+
+        $baseStorage = new VirtualFilesystem(
+            $mountManager,
+            $this->createMock(DbafsManager::class),
+            '',
+        );
+
+        $baseStorage->createDirectory('images');
+        $baseStorage->createDirectory('images/photos');
+        $baseStorage->createDirectory('images/photos/foo');
+        $baseStorage->createDirectory('images/graphics');
+        $baseStorage->createDirectory('private');
+        $baseStorage->createDirectory('private/documents');
+        $baseStorage->createDirectory('private/documents/important');
+        $baseStorage->createDirectory('secret');
+
+        $baseStorage->write('root-file', 'root-file');
+        $baseStorage->write('images/i', 'i');
+        $baseStorage->write('images/photos/p1', 'p1');
+        $baseStorage->write('images/photos/foo/p2', 'p2');
+        $baseStorage->write('images/graphics/g1', 'g1');
+        $baseStorage->write('private/documents/d1', 'd1');
+        $baseStorage->write('private/documents/important/d2', 'd2');
+        $baseStorage->write('secret/s', 's');
+
+        $this->assertSame(
+            [
+                'images',
+                'images/photos',
+                'images/photos/foo',
+                'images/photos/foo/p2',
+                'images/photos/p1',
+                'images/graphics',
+                'images/graphics/g1',
+                'images/i',
+                'private',
+                'private/documents',
+                'private/documents/important',
+                'private/documents/important/d2',
+                'private/documents/d1',
+                'secret',
+                'secret/s',
+                'root-file',
+            ],
+            $this->getListingAsArray($baseStorage),
+        );
+
+        $filterStorage = new DirectoryFilterVirtualFilesystem($baseStorage, [
+            'images/photos',
+            'images/photos/foo',
+            'private/documents',
+            'random',
+        ]);
+
+        $this->assertSame(
+            [
+                'images',
+                'images/photos',
+                'images/photos/foo',
+                'images/photos/foo/p2',
+                'images/photos/p1',
+                'private',
+                'private/documents',
+                'private/documents/important',
+                'private/documents/important/d2',
+                'private/documents/d1',
+                'random',
+            ],
+            $this->getListingAsArray($filterStorage),
+        );
+
+        // Test that anything outside the filter scope does not exist
+        $this->assertFalse($filterStorage->directoryExists('secret'));
+        $this->assertFalse($filterStorage->fileExists('root-file'));
+        $this->assertFalse($filterStorage->fileExists('secret/s'));
+        $this->assertFalse($filterStorage->has('root-file'));
+        $this->assertFalse($filterStorage->has('secret'));
+
+        // Test that anything inside the allowed paths can be accessed
+        $this->assertTrue($filterStorage->directoryExists('private/documents'));
+        $this->assertTrue($filterStorage->fileExists('private/documents/important/d2'));
+        $this->assertTrue($filterStorage->has('images/photos'));
+        $this->assertTrue($filterStorage->get('images/photos/foo/p2')?->isFile());
+        $this->assertSame('p2', $filterStorage->read('images/photos/foo/p2'));
+
+        // Test virtual directories/root trail can be accessed
+        $this->assertTrue($filterStorage->directoryExists('random'));
+        $this->assertEmpty($filterStorage->get('random')?->getExtraMetadata()->all());
+        $this->assertNull($filterStorage->get('random')->getLastModified());
+        $this->assertTrue($filterStorage->directoryExists('private'));
+        $this->assertEmpty($filterStorage->get('private')?->getExtraMetadata()->all());
+        $this->assertNull($filterStorage->get('private')->getLastModified());
+        $this->assertEmpty($filterStorage->get('')?->getExtraMetadata()->all());
+        $this->assertNull($filterStorage->get('')->getLastModified());
+
+        // Test inspection
+        $this->assertSame('images/photos', $filterStorage->getFirstNonVirtualDirectory());
+
+        // Test writing to the storage
+        $filterStorage->write('private/documents/list', 'list');
+        $filterStorage->write('random/new', 'new');
+        $filterStorage->createDirectory('random/foo');
+        $filterStorage->write('random/foo/thing', 'thing');
+
+        $this->assertTrue($filterStorage->fileExists('random/new'));
+        $this->assertTrue($filterStorage->directoryExists('random/foo'));
+        $this->assertSame('list', $filterStorage->read('private/documents/list'));
+        $this->assertSame('thing', $filterStorage->read('random/foo/thing'));
+    }
+
+    #[DataProvider('provideIllegalOperations')]
+    public function testDeniesAccess(string $operation, array $arguments, string $expectedExceptionMessage): void
+    {
+        $filterStorage = new DirectoryFilterVirtualFilesystem($this->createMock(VirtualFilesystemInterface::class), [
+            'foo',
+            'bar/baz',
+        ]);
+
+        $this->expectException(VirtualFilesystemException::class);
+        $this->expectExceptionMessage($expectedExceptionMessage);
+
+        $filterStorage->$operation(...$arguments);
+    }
+
+    public static function provideIllegalOperations(): \Generator
+    {
+        yield 'create file in root' => [
+            'write', ['file', ''],
+            'Unable to write to "file".',
+        ];
+
+        yield 'create file in trail' => [
+            'write', ['bar/file', ''],
+            'Unable to write to "bar/file".',
+        ];
+
+        yield 'create directory in root' => [
+            'createDirectory', ['directory'],
+            'Unable to create directory at "directory".',
+        ];
+
+        yield 'create directory in trail' => [
+            'createDirectory', ['bar/directory'],
+            'Unable to create directory at "bar/directory".',
+        ];
+
+        yield 'delete directory in root' => [
+            'deleteDirectory', ['bar'],
+            'Unable to delete directory at "bar".',
+        ];
+
+        yield 'delete allowed directory in root' => [
+            'deleteDirectory', ['foo'],
+            'Unable to delete directory at "foo".',
+        ];
+
+        yield 'delete allowed directory in trail' => [
+            'deleteDirectory', ['bar/baz'],
+            'Unable to delete directory at "bar/baz".',
+        ];
+
+        yield 'copy to path in trail' => [
+            'copy', ['bar/baz/x', 'bar/x'],
+            'Unable to copy file from "bar/baz/x" to "bar/x".',
+        ];
+
+        yield 'copy to arbitrary uncovered path' => [
+            'copy', ['bar/baz/x', 'somewhere'],
+            'Unable to copy file from "bar/baz/x" to "somewhere".',
+        ];
+
+        yield 'move to path in trail' => [
+            'move', ['bar/baz/x', 'bar/x'],
+            'Unable to move file from "bar/baz/x" to "bar/x".',
+        ];
+
+        yield 'move to arbitrary uncovered path' => [
+            'move', ['bar/baz/x', 'somewhere'],
+            'Unable to move file from "bar/baz/x" to "somewhere".',
+        ];
+
+        yield 'get last modified from uncovered path' => [
+            'getLastModified', ['somewhere'],
+            'Unable to retrieve metadata from "somewhere".',
+        ];
+
+        yield 'get filesize from uncovered path' => [
+            'getFilesize', ['somewhere'],
+            'Unable to retrieve metadata from "somewhere".',
+        ];
+
+        yield 'get mime type from uncovered path' => [
+            'getMimeType', ['somewhere'],
+            'Unable to retrieve metadata from "somewhere".',
+        ];
+
+        yield 'get extra metadata from uncovered path' => [
+            'getExtraMetadata', ['somewhere'],
+            'Unable to retrieve metadata from "somewhere".',
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function getListingAsArray(VirtualFilesystemInterface $storage): array
+    {
+        return array_map(
+            static fn (FilesystemItem $item): string => $item->getPath(),
+            $storage->listContents('', true)->toArray(),
+        );
+    }
+}

--- a/core-bundle/tests/Filesystem/DirectoryFilterVirtualFilesystemTest.php
+++ b/core-bundle/tests/Filesystem/DirectoryFilterVirtualFilesystemTest.php
@@ -28,16 +28,9 @@ class DirectoryFilterVirtualFilesystemTest extends TestCase
     public function testFiltersStorage(): void
     {
         $mountManager = new MountManager([]);
-        $mountManager
-            ->mount(new InMemoryFilesystemAdapter(), '')
-        ;
+        $mountManager->mount(new InMemoryFilesystemAdapter());
 
-        $baseStorage = new VirtualFilesystem(
-            $mountManager,
-            $this->createMock(DbafsManager::class),
-            '',
-        );
-
+        $baseStorage = new VirtualFilesystem($mountManager, $this->createMock(DbafsManager::class), '');
         $baseStorage->createDirectory('images');
         $baseStorage->createDirectory('images/photos');
         $baseStorage->createDirectory('images/photos/foo');


### PR DESCRIPTION
This PR adds a new decorator to the VFS (similar to the `PermissionCheckingVirtualFilesystem`) that supports a filtered view/access to the underlying storage.

When listing contents, you'll only see/access everything inside the directories that were specified as `$allowedDirectories`. Contrary to a prefixed "regular" VFS, you'll also see a root trail of directories. Concept-wise, these are virtual directories - when accessing these, the decorator will generate the data and not ask the underlying storage. 

Covered edge cases:
* If an allowed directory was specified but does exist in the underlying storage at this point, you can still write to it -Flysystem will create it on the fly (if needed by the adapter - otherwise, like on S3, it will just write the file). 
* Deleting allowed directories themselves is prevented.
* When providing allowed paths that overlap, only the top-level path is considered (because it covers the others).

Usage in the new filemanager will look something like this:
```php
$filterStorage = new DirectoryFilterVirtualFilesystem(
    new PermissionCheckingVirtualFilesystem(…),
    allowedDirectories: ['path', 'another/path', …]
);

// There is also a new helper method, that will list the first path containing "real" data
$initialViewPath = $filterStorage->getFirstNonVirtualDirectory();
```
