### PR TITLE
Use table lock for the `contao.cron` service again

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -130,7 +130,6 @@
         "symfony/http-foundation": "^6.4",
         "symfony/http-kernel": "^6.4",
         "symfony/intl": "^6.4",
-        "symfony/lock": "^6.4",
         "symfony/mailer": "^6.4",
         "symfony/maker-bundle": "^1.1",
         "symfony/messenger": "^6.4",

--- a/core-bundle/composer.json
+++ b/core-bundle/composer.json
@@ -124,7 +124,6 @@
         "symfony/http-foundation": "^6.4",
         "symfony/http-kernel": "^6.4",
         "symfony/intl": "^6.4",
-        "symfony/lock": "^6.4",
         "symfony/mailer": "^6.4",
         "symfony/messenger": "^6.4",
         "symfony/mime": "^6.4",

--- a/core-bundle/config/services.yaml
+++ b/core-bundle/config/services.yaml
@@ -91,7 +91,6 @@ services:
             - !service_closure '@contao.repository.cron_job'
             - !service_closure '@doctrine.orm.entity_manager'
             - '@cache.app'
-            - '@lock.factory'
             - '@?logger'
 
     contao.cron.purge_expired_data:

--- a/core-bundle/src/Cron/Cron.php
+++ b/core-bundle/src/Cron/Cron.php
@@ -16,13 +16,13 @@ use Contao\CoreBundle\Entity\CronJob as CronJobEntity;
 use Contao\CoreBundle\Exception\CronExecutionSkippedException;
 use Contao\CoreBundle\Repository\CronJobRepository;
 use Cron\CronExpression;
+use Doctrine\DBAL\Exception\LockWaitTimeoutException;
 use Doctrine\ORM\EntityManagerInterface;
 use GuzzleHttp\Promise\Promise;
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Promise\Utils;
 use Psr\Cache\CacheItemPoolInterface;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\Lock\LockFactory;
 
 class Cron
 {
@@ -45,7 +45,6 @@ class Cron
         private readonly \Closure $repository,
         private readonly \Closure $entityManager,
         private readonly CacheItemPoolInterface $cachePool,
-        private readonly LockFactory $lockFactory,
         private readonly LoggerInterface|null $logger = null,
     ) {
     }
@@ -131,9 +130,10 @@ class Cron
 
         $now = new \DateTimeImmutable();
 
-        $lock = $this->lockFactory->createLock(__METHOD__, 3600);
-
-        if (!$lock->acquire()) {
+        // Return if another cron process is already running
+        try {
+            $repository->lockTable();
+        } catch (LockWaitTimeoutException) {
             return;
         }
 
@@ -173,7 +173,7 @@ class Cron
 
             $entityManager->flush();
         } finally {
-            $lock->release();
+            $repository->unlockTable();
         }
 
         // Callback to restore previous run date in case cronjob skips itself

--- a/core-bundle/tests/Cron/CronTest.php
+++ b/core-bundle/tests/Cron/CronTest.php
@@ -23,8 +23,6 @@ use Doctrine\ORM\EntityManagerInterface;
 use Psr\Cache\CacheItemPoolInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
-use Symfony\Component\Lock\LockFactory;
-use Symfony\Component\Lock\SharedLockInterface;
 
 class CronTest extends TestCase
 {
@@ -40,7 +38,6 @@ class CronTest extends TestCase
             fn () => $this->createMock(CronJobRepository::class),
             fn () => $this->createMock(EntityManagerInterface::class),
             $this->createMock(CacheItemPoolInterface::class),
-            $this->createLockFactory(),
         );
 
         $cron->addCronJob(new CronJob($cronjob, '@hourly', 'onHourly'));
@@ -59,7 +56,6 @@ class CronTest extends TestCase
             fn () => $this->createMock(CronJobRepository::class),
             fn () => $this->createMock(EntityManagerInterface::class),
             $this->createMock(CacheItemPoolInterface::class),
-            $this->createLockFactory(),
         );
 
         $cron->addCronJob(new CronJob($cronjob, '@hourly', 'onHourly'));
@@ -98,7 +94,6 @@ class CronTest extends TestCase
             fn () => $this->createMock(CronJobRepository::class),
             fn () => $this->createMock(EntityManagerInterface::class),
             $this->createMock(CacheItemPoolInterface::class),
-            $this->createLockFactory(),
             $logger,
         );
 
@@ -154,7 +149,6 @@ class CronTest extends TestCase
             static fn () => $repository,
             static fn () => $manager,
             $this->createMock(CacheItemPoolInterface::class),
-            $this->createLockFactory(),
         );
 
         $cron->addCronJob(new CronJob($cronjob, '@hourly', 'onHourly'));
@@ -174,7 +168,6 @@ class CronTest extends TestCase
             fn () => $this->createMock(CronJobRepository::class),
             fn () => $this->createMock(EntityManagerInterface::class),
             $this->createMock(CacheItemPoolInterface::class),
-            $this->createLockFactory(),
         );
 
         $cron->addCronJob(new CronJob($cronjob, '@hourly'));
@@ -187,7 +180,6 @@ class CronTest extends TestCase
             fn () => $this->createMock(CronJobRepository::class),
             fn () => $this->createMock(EntityManagerInterface::class),
             $this->createMock(CacheItemPoolInterface::class),
-            $this->createMock(LockFactory::class),
         );
 
         try {
@@ -211,7 +203,6 @@ class CronTest extends TestCase
                 throw new \LogicException();
             },
             $this->createMock(CacheItemPoolInterface::class),
-            $this->createMock(LockFactory::class),
         );
 
         $this->expectException(\LogicException::class);
@@ -260,7 +251,6 @@ class CronTest extends TestCase
             static fn () => $repository,
             fn () => $this->createMock(EntityManagerInterface::class),
             $this->createMock(CacheItemPoolInterface::class),
-            $this->createLockFactory(),
         );
 
         $cron->addCronJob(new CronJob($cronjob, '@hourly', 'onHourly'));
@@ -308,7 +298,6 @@ class CronTest extends TestCase
             static fn () => $repository,
             fn () => $this->createMock(EntityManagerInterface::class),
             $this->createMock(CacheItemPoolInterface::class),
-            $this->createLockFactory(),
         );
 
         $cron->addCronJob(new CronJob($cronjob, '@hourly', 'onHourly'));
@@ -362,7 +351,6 @@ class CronTest extends TestCase
             static fn () => $repository,
             fn () => $this->createMock(EntityManagerInterface::class),
             $cache,
-            $this->createLockFactory(),
             $logger,
         );
 
@@ -414,7 +402,6 @@ class CronTest extends TestCase
             static fn () => $repository,
             fn () => $this->createMock(EntityManagerInterface::class),
             $cache,
-            $this->createLockFactory(),
         );
 
         $cron->addCronJob(new CronJob($cron, '* * * * *', 'updateMinutelyCliCron'));
@@ -465,7 +452,6 @@ class CronTest extends TestCase
             static fn () => $repository,
             static fn () => $manager,
             new ArrayAdapter(),
-            $this->createLockFactory(),
         );
 
         $cron->addCronJob(new CronJob($cronjob, '@hourly', 'skippingMethod'));
@@ -516,34 +502,9 @@ class CronTest extends TestCase
             static fn () => $repository,
             static fn () => $manager,
             $this->createMock(CacheItemPoolInterface::class),
-            $this->createLockFactory(),
         );
 
         $cron->addCronJob(new CronJob($cronjob, '@hourly', 'skippingAsyncMethod'));
         $cron->run(Cron::SCOPE_CLI);
-    }
-
-    private function createLockFactory(bool $locked = false): LockFactory
-    {
-        $lock = $this->createMock(SharedLockInterface::class);
-        $lock
-            ->expects($this->once())
-            ->method('acquire')
-            ->willReturn(!$locked)
-        ;
-
-        $lock
-            ->expects($this->exactly((int) !$locked))
-            ->method('release')
-        ;
-
-        $lockFactory = $this->createMock(LockFactory::class);
-        $lockFactory
-            ->expects($this->once())
-            ->method('createLock')
-            ->willReturn($lock)
-        ;
-
-        return $lockFactory;
     }
 }


### PR DESCRIPTION
There is an issue with #8001: the file lock would - by default - be a system wide lock, as the lock file would be generated in the system temp directory. So if multiple Contao instances share the same temp directory on the same server, the locking would interfere with each other.

Thus this PR reverts parts of #8001 and implements the proposed table locking with a short lock wait timeout instead. This has the added bonus that there will be more data consistency within `tl_cron_job` itself, in case any other process would want to write something in there.