### PR TITLE
Add a `count()` helper method to the `FilesystemItemIterator`

### DIFF
--- a/core-bundle/src/Filesystem/FilesystemItemIterator.php
+++ b/core-bundle/src/Filesystem/FilesystemItemIterator.php
@@ -166,6 +166,11 @@ class FilesystemItemIterator implements \IteratorAggregate
         return null;
     }
 
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+
     /**
      * @return \Traversable<FilesystemItem>
      */

--- a/core-bundle/tests/Filesystem/FilesystemItemIteratorTest.php
+++ b/core-bundle/tests/Filesystem/FilesystemItemIteratorTest.php
@@ -231,6 +231,21 @@ class FilesystemItemIteratorTest extends TestCase
         $this->assertSame([], $iterator->toArray());
     }
 
+    public function testCount(): void
+    {
+        $this->assertSame(0, (new FilesystemItemIterator([]))->count());
+
+        $iterator = new FilesystemItemIterator($this->generateItems());
+        $this->assertSame(2, $iterator->count());
+
+        $this->assertSame(
+            1,
+            $iterator
+                ->filter(static fn (FilesystemItem $f): bool => 'foo' === $f->getName())
+                ->count(),
+        );
+    }
+
     /**
      * @param array<string>         $expected
      * @param array<FilesystemItem> $actual

--- a/core-bundle/tests/Filesystem/FilesystemItemIteratorTest.php
+++ b/core-bundle/tests/Filesystem/FilesystemItemIteratorTest.php
@@ -237,13 +237,7 @@ class FilesystemItemIteratorTest extends TestCase
 
         $iterator = new FilesystemItemIterator($this->generateItems());
         $this->assertSame(2, $iterator->count());
-
-        $this->assertSame(
-            1,
-            $iterator
-                ->filter(static fn (FilesystemItem $f): bool => 'foo' === $f->getName())
-                ->count(),
-        );
+        $this->assertSame(1, $iterator->filter(static fn (FilesystemItem $f): bool => 'foo' === $f->getName())->count());
     }
 
     /**


### PR DESCRIPTION
This PR adds a new `count()` method to the `FilesystemItemIterator` as a bit of syntactic sugar over calling `\count($iterator->toArray())` yourself.