### PR TITLE
Use a non-blocking table lock for `contao.cron`

### DIFF
--- a/core-bundle/src/Cron/Cron.php
+++ b/core-bundle/src/Cron/Cron.php
@@ -16,6 +16,7 @@ use Contao\CoreBundle\Entity\CronJob as CronJobEntity;
 use Contao\CoreBundle\Exception\CronExecutionSkippedException;
 use Contao\CoreBundle\Repository\CronJobRepository;
 use Cron\CronExpression;
+use Doctrine\DBAL\Exception\LockWaitTimeoutException;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
 
@@ -77,10 +78,14 @@ class Cron
         $cronJobsToBeRun = [];
         $now = new \DateTimeImmutable();
 
+        // Return if another cron process is already running
         try {
-            // Lock cron table
             $repository->lockTable();
+        } catch (LockWaitTimeoutException) {
+            return;
+        }
 
+        try {
             // Go through each cron job
             foreach ($this->cronJobs as $cron) {
                 $interval = $cron->getInterval();

--- a/core-bundle/src/Cron/Cron.php
+++ b/core-bundle/src/Cron/Cron.php
@@ -81,7 +81,7 @@ class Cron
         // Return if another cron process is already running
         try {
             $repository->lockTable();
-        } catch (LockWaitTimeoutException) {
+        } catch (LockWaitTimeoutException $e) {
             return;
         }
 

--- a/core-bundle/src/Repository/CronJobRepository.php
+++ b/core-bundle/src/Repository/CronJobRepository.php
@@ -15,6 +15,8 @@ namespace Contao\CoreBundle\Repository;
 use Contao\CoreBundle\Entity\CronJob;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception\LockWaitTimeoutException;
+use Doctrine\DBAL\Types\Types;
 use Symfony\Bridge\Doctrine\ManagerRegistry;
 
 /**
@@ -38,11 +40,30 @@ class CronJobRepository extends ServiceEntityRepository
         $this->connection = $connection;
     }
 
+    /**
+     * Locks the tl_cron_job table with a lock wait timeout of only 1 second.
+     *
+     * @throws LockWaitTimeoutException
+     */
     public function lockTable(): void
     {
         $table = $this->getClassMetadata()->getTableName();
 
-        $this->connection->executeStatement("LOCK TABLES $table WRITE, $table AS t0 WRITE, $table AS t0_ WRITE");
+        $defaultLockTimeout = $this->connection->fetchOne('SELECT @@lock_wait_timeout');
+
+        // Use default lock timeout from MariaDB, if it cannot be retrieved
+        if (false === $defaultLockTimeout) {
+            $defaultLockTimeout = 86400;
+        }
+
+        try {
+            // Set a short lock timeout, so that the next statement throws an exception sooner
+            $this->connection->executeStatement('SET SESSION lock_wait_timeout = 1');
+            $this->connection->executeStatement("LOCK TABLES $table WRITE, $table AS t0 WRITE, $table AS t0_ WRITE");
+        } finally {
+            // Restore the previous lock timeout
+            $this->connection->executeStatement('SET SESSION lock_wait_timeout = ?', [$defaultLockTimeout], [Types::INTEGER]);
+        }
     }
 
     public function unlockTable(): void

--- a/core-bundle/tests/Cron/CronTest.php
+++ b/core-bundle/tests/Cron/CronTest.php
@@ -19,6 +19,8 @@ use Contao\CoreBundle\Fixtures\Cron\TestCronJob;
 use Contao\CoreBundle\Fixtures\Cron\TestInvokableCronJob;
 use Contao\CoreBundle\Repository\CronJobRepository;
 use Contao\CoreBundle\Tests\TestCase;
+use Doctrine\DBAL\Driver\Exception as DriverException;
+use Doctrine\DBAL\Exception\LockWaitTimeoutException;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
 
@@ -226,6 +228,35 @@ class CronTest extends TestCase
         );
 
         $cron->addCronJob(new CronJob($cronjob, '@hourly', 'skippingMethod'));
+        $cron->run(Cron::SCOPE_CLI);
+    }
+
+    public function testSkipsIfLockWaitTimeOut(): void
+    {
+        $repository = $this->createMock(CronJobRepository::class);
+        $repository
+            ->expects($this->once())
+            ->method('lockTable')
+            ->willThrowException(new LockWaitTimeoutException($this->createMock(DriverException::class), null))
+        ;
+
+        $repository
+            ->expects($this->never())
+            ->method('__call')
+        ;
+
+        $cron = new Cron(
+            static fn () => $repository,
+            fn () => $this->createMock(EntityManagerInterface::class),
+        );
+
+        $cronjob = $this->createMock(TestCronJob::class);
+        $cronjob
+            ->expects($this->never())
+            ->method('onHourly')
+        ;
+
+        $cron->addCronJob(new CronJob($cronjob, '@hourly', 'onHourly'));
         $cron->run(Cron::SCOPE_CLI);
     }
 }


### PR DESCRIPTION
Implements #8001/#8053 for Contao 4.13.