### PR TITLE
Make VFS tests compatible with `league/flysystem-bundle` 3.4.0

### DIFF
--- a/core-bundle/tests/DependencyInjection/Filesystem/FilesystemConfigurationTest.php
+++ b/core-bundle/tests/DependencyInjection/Filesystem/FilesystemConfigurationTest.php
@@ -79,7 +79,7 @@ class FilesystemConfigurationTest extends TestCase
     {
         $container = $this->getContainerBuilder();
 
-        $config = new FilesystemConfiguration($container, new AdapterDefinitionFactory());
+        $config = new FilesystemConfiguration($container);
         $config->mountAdapter('local', ['directory' => '/some/path'], 'path', 'foo');
 
         $this->assertTrue($container->hasDefinition('contao.filesystem.adapter.foo'));
@@ -100,7 +100,7 @@ class FilesystemConfigurationTest extends TestCase
     {
         $container = $this->getContainerBuilder();
 
-        $config = new FilesystemConfiguration($container, new AdapterDefinitionFactory());
+        $config = new FilesystemConfiguration($container);
         $config->mountAdapter('some-custom-adapter', ['some' => 'options'], 'path', 'foo');
 
         $this->assertTrue($container->hasAlias('contao.filesystem.adapter.foo'));
@@ -157,7 +157,7 @@ class FilesystemConfigurationTest extends TestCase
             'bar' => 'path/to/bar',
         ]);
 
-        $config = new FilesystemConfiguration($container, new AdapterDefinitionFactory());
+        $config = new FilesystemConfiguration($container);
         $config->mountLocalAdapter($filesystemPath, 'mount/path', 'my_adapter');
 
         $this->assertTrue($container->hasDefinition('contao.filesystem.adapter.my_adapter'));
@@ -264,18 +264,6 @@ class FilesystemConfigurationTest extends TestCase
         $this->expectExceptionMessage('A virtual filesystem with the name "foo" does not exist.');
 
         $config->addDefaultDbafs('foo', 'tl_foo');
-    }
-
-    private function getConfigurationWithAdapterDefinitionFactory(ContainerBuilder $container, AdapterDefinitionFactory $adapterDefinitionFactory): FilesystemConfiguration
-    {
-        $config = new FilesystemConfiguration($container);
-
-        $class = new \ReflectionClass(FilesystemConfiguration::class);
-        $property = $class->getProperty('adapterDefinitionFactory');
-        $property->setAccessible(true);
-        $property->setValue($config, $adapterDefinitionFactory);
-
-        return $config;
     }
 
     private function getContainerBuilder(array $parameters = []): ContainerBuilder

--- a/core-bundle/tests/DependencyInjection/Filesystem/FilesystemConfigurationTest.php
+++ b/core-bundle/tests/DependencyInjection/Filesystem/FilesystemConfigurationTest.php
@@ -20,6 +20,7 @@ use Contao\CoreBundle\Filesystem\MountManager;
 use Contao\CoreBundle\Filesystem\VirtualFilesystem;
 use Contao\CoreBundle\Filesystem\VirtualFilesystemInterface;
 use Contao\CoreBundle\Tests\TestCase;
+use League\Flysystem\Local\LocalFilesystemAdapter;
 use League\FlysystemBundle\Adapter\AdapterDefinitionFactory;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -78,25 +79,14 @@ class FilesystemConfigurationTest extends TestCase
     {
         $container = $this->getContainerBuilder();
 
-        $adapterDefinition = $this->createMock(Definition::class);
-        $adapterDefinition
-            ->expects($this->once())
-            ->method('setPublic')
-            ->with(false)
-        ;
-
-        $adapterDefinitionFactory = $this->createMock(AdapterDefinitionFactory::class);
-        $adapterDefinitionFactory
-            ->method('createDefinition')
-            ->with('some-native-adapter', ['some' => 'options'])
-            ->willReturn($adapterDefinition)
-        ;
-
-        $config = $this->getConfigurationWithAdapterDefinitionFactory($container, $adapterDefinitionFactory);
-        $config->mountAdapter('some-native-adapter', ['some' => 'options'], 'path', 'foo');
+        $config = new FilesystemConfiguration($container, new AdapterDefinitionFactory());
+        $config->mountAdapter('local', ['directory' => '/some/path'], 'path', 'foo');
 
         $this->assertTrue($container->hasDefinition('contao.filesystem.adapter.foo'));
-        $this->assertSame($adapterDefinition, $container->getDefinition('contao.filesystem.adapter.foo'));
+
+        $adapterDefinition = $container->getDefinition('contao.filesystem.adapter.foo');
+        $this->assertSame(LocalFilesystemAdapter::class, $adapterDefinition->getClass());
+        $this->assertFalse($adapterDefinition->isPublic());
 
         $calls = $container->getDefinition('contao.filesystem.mount_manager')->getMethodCalls();
 
@@ -110,14 +100,7 @@ class FilesystemConfigurationTest extends TestCase
     {
         $container = $this->getContainerBuilder();
 
-        $adapterDefinitionFactory = $this->createMock(AdapterDefinitionFactory::class);
-        $adapterDefinitionFactory
-            ->method('createDefinition')
-            ->with('some-custom-adapter', ['some' => 'options'])
-            ->willReturn(null)
-        ;
-
-        $config = $this->getConfigurationWithAdapterDefinitionFactory($container, $adapterDefinitionFactory);
+        $config = new FilesystemConfiguration($container, new AdapterDefinitionFactory());
         $config->mountAdapter('some-custom-adapter', ['some' => 'options'], 'path', 'foo');
 
         $this->assertTrue($container->hasAlias('contao.filesystem.adapter.foo'));
@@ -174,17 +157,24 @@ class FilesystemConfigurationTest extends TestCase
             'bar' => 'path/to/bar',
         ]);
 
-        $adapterDefinitionFactory = $this->createMock(AdapterDefinitionFactory::class);
-        $adapterDefinitionFactory
-            ->method('createDefinition')
-            ->with('local', ['directory' => $expected, 'skip_links' => true])
-            ->willReturn($this->createMock(Definition::class))
-        ;
-
-        $config = $this->getConfigurationWithAdapterDefinitionFactory($container, $adapterDefinitionFactory);
+        $config = new FilesystemConfiguration($container, new AdapterDefinitionFactory());
         $config->mountLocalAdapter($filesystemPath, 'mount/path', 'my_adapter');
 
         $this->assertTrue($container->hasDefinition('contao.filesystem.adapter.my_adapter'));
+
+        $adapterDefinition = $container->getDefinition('contao.filesystem.adapter.my_adapter');
+
+        $this->assertSame(
+            $expected,
+            $adapterDefinition->getArgument(0),
+            'directory should be set',
+        );
+
+        $this->assertSame(
+            LocalFilesystemAdapter::SKIP_LINKS,
+            $adapterDefinition->getArgument(3),
+            'link handling should be set to skip links',
+        );
     }
 
     public function provideFilesystemPaths(): \Generator

--- a/core-bundle/tests/DependencyInjection/Filesystem/FilesystemConfigurationTest.php
+++ b/core-bundle/tests/DependencyInjection/Filesystem/FilesystemConfigurationTest.php
@@ -21,7 +21,6 @@ use Contao\CoreBundle\Filesystem\VirtualFilesystem;
 use Contao\CoreBundle\Filesystem\VirtualFilesystemInterface;
 use Contao\CoreBundle\Tests\TestCase;
 use League\Flysystem\Local\LocalFilesystemAdapter;
-use League\FlysystemBundle\Adapter\AdapterDefinitionFactory;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;


### PR DESCRIPTION
Backports #7947 for Contao 4.13.