### PR TITLE
Prevent useless messages in the search listener

### DIFF
--- a/core-bundle/config/listener.yaml
+++ b/core-bundle/config/listener.yaml
@@ -465,6 +465,7 @@ services:
         arguments:
             - '@messenger.bus.default'
             - '%fragment.path%'
+            - '%contao.backend.route_prefix%'
 
     contao.listener.security.logout:
         class: Contao\CoreBundle\EventListener\Security\LogoutListener

--- a/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
+++ b/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
@@ -319,7 +319,7 @@ class ContaoCoreExtension extends Extension implements PrependExtensionInterface
             $container->removeDefinition('contao.listener.search_index');
         } else {
             // Configure the search index listener
-            $container->getDefinition('contao.listener.search_index')->setArgument(2, $features);
+            $container->getDefinition('contao.listener.search_index')->setArgument('$enabledFeatures', $features);
         }
     }
 

--- a/core-bundle/src/EventListener/SearchIndexListener.php
+++ b/core-bundle/src/EventListener/SearchIndexListener.php
@@ -62,7 +62,7 @@ class SearchIndexListener
             return;
         }
 
-        // Do not Contao backend requests
+        // Do not handle Contao backend requests
         if (preg_match('~(?:^|/)'.preg_quote($this->contaoBackendRoutePrefix, '~').'~', $request->getPathInfo())) {
             return;
         }

--- a/core-bundle/src/EventListener/SearchIndexListener.php
+++ b/core-bundle/src/EventListener/SearchIndexListener.php
@@ -34,6 +34,7 @@ class SearchIndexListener
     public function __construct(
         private readonly MessageBusInterface $messageBus,
         private readonly string $fragmentPath = '_fragment',
+        private readonly string $contaoBackendRoutePrefix = '/contao',
         private readonly int $enabledFeatures = self::FEATURE_INDEX | self::FEATURE_DELETE,
     ) {
     }
@@ -53,6 +54,16 @@ class SearchIndexListener
 
         // Only handle GET requests (see #1194, #7240)
         if (!$request->isMethod(Request::METHOD_GET)) {
+            return;
+        }
+
+        // Do not handle fragments
+        if (preg_match('~(?:^|/)'.preg_quote($this->fragmentPath, '~').'/~', $request->getPathInfo())) {
+            return;
+        }
+
+        // Do not Contao backend requests
+        if (preg_match('~(?:^|/)'.preg_quote($this->contaoBackendRoutePrefix, '~').'~', $request->getPathInfo())) {
             return;
         }
 
@@ -78,11 +89,6 @@ class SearchIndexListener
 
         // Do not index if called by crawler
         if (Factory::USER_AGENT === $request->headers->get('User-Agent')) {
-            return false;
-        }
-
-        // Do not handle fragments
-        if (preg_match('~(?:^|/)'.preg_quote($this->fragmentPath, '~').'/~', $request->getPathInfo())) {
             return false;
         }
 

--- a/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
+++ b/core-bundle/tests/DependencyInjection/ContaoCoreExtensionTest.php
@@ -486,7 +486,7 @@ class ContaoCoreExtensionTest extends TestCase
         $definition = $container->getDefinition('contao.listener.search_index');
 
         $this->assertSame(SearchIndexListener::class, $definition->getClass());
-        $this->assertSame(SearchIndexListener::FEATURE_INDEX, $definition->getArgument(2));
+        $this->assertSame(SearchIndexListener::FEATURE_INDEX, $definition->getArgument('$enabledFeatures'));
     }
 
     public function testRemovesTheSearchIndexListenerIfItIsDisabled(): void

--- a/core-bundle/tests/EventListener/SearchIndexListenerTest.php
+++ b/core-bundle/tests/EventListener/SearchIndexListenerTest.php
@@ -50,7 +50,7 @@ class SearchIndexListenerTest extends TestCase
 
         $event = new TerminateEvent($this->createMock(HttpKernelInterface::class), $request, $response);
 
-        $listener = new SearchIndexListener($messenger, '_fragment', $features);
+        $listener = new SearchIndexListener($messenger, '_fragment', '/contao', $features);
         $listener($event);
     }
 
@@ -98,6 +98,14 @@ class SearchIndexListenerTest extends TestCase
 
         yield 'Should be skipped because it is a fragment request' => [
             Request::create('_fragment/foo/bar'),
+            new Response(),
+            SearchIndexListener::FEATURE_DELETE | SearchIndexListener::FEATURE_INDEX,
+            false,
+            false,
+        ];
+
+        yield 'Should be skipped because it is a contao backend request' => [
+            Request::create('contao?do=article'),
             new Response(),
             SearchIndexListener::FEATURE_DELETE | SearchIndexListener::FEATURE_INDEX,
             false,

--- a/core-bundle/tests/EventListener/SearchIndexListenerTest.php
+++ b/core-bundle/tests/EventListener/SearchIndexListenerTest.php
@@ -97,7 +97,7 @@ class SearchIndexListenerTest extends TestCase
         ];
 
         yield 'Should be skipped because it is a fragment request' => [
-            Request::create('_fragment/foo/bar'),
+            Request::create('/_fragment/foo/bar'),
             new Response(),
             SearchIndexListener::FEATURE_DELETE | SearchIndexListener::FEATURE_INDEX,
             false,
@@ -105,7 +105,7 @@ class SearchIndexListenerTest extends TestCase
         ];
 
         yield 'Should be skipped because it is a contao backend request' => [
-            Request::create('contao?do=article'),
+            Request::create('/contao?do=article'),
             new Response(),
             SearchIndexListener::FEATURE_DELETE | SearchIndexListener::FEATURE_INDEX,
             false,


### PR DESCRIPTION
Right now, all `_fragment` requests trigger a `SearchIndexMessage` for deletion. Moreover, all back end requests (so whenever you navigate) trigger a `SearchIndexMessage` which will always be thrown away as there's no JSON-LD and all of those message are just useless load for the MySQL server.

I've tried to fix this previously by using the scope matcher but in `kernel.terminate`, there is no `_scope` attribute anymore. So here we go, matching just like we do for `_fragment`.

This will reduce the messenger load drastically.