### PR TITLE
Adjust the default location for Loupe

### DIFF
--- a/manager-bundle/src/ContaoManager/Plugin.php
+++ b/manager-bundle/src/ContaoManager/Plugin.php
@@ -510,7 +510,7 @@ class Plugin implements BundlePluginInterface, ConfigPluginInterface, RoutingPlu
 
         $extensionConfigs[] = [
             'backend_search' => [
-                'dsn' => 'loupe://%kernel.project_dir%/var/backend_search',
+                'dsn' => 'loupe://%kernel.project_dir%/var/loupe',
             ],
         ];
 


### PR DESCRIPTION
While working more with SEAL I noticed that `var/backend_search` was nonsense. SEAL places the index names within that folder so what we have now is `var/backend_search/contao_backend`. The idea of SEAL's Loupe implementation is that you can place more indexes within the same folder so e.g. symlinking across releases is easy. Hence, I have renamed it to `var/loupe` which gives us the ability to place more indexes in there in the future.