### PR TITLE
Allow entire tables to be excluded from the back end search

### DIFF
--- a/core-bundle/contao/dca/tl_favorites.php
+++ b/core-bundle/contao/dca/tl_favorites.php
@@ -20,6 +20,7 @@ $GLOBALS['TL_DCA']['tl_favorites'] = array
 		'enableVersioning'            => true,
 		'notCreatable'                => true,
 		'notCopyable'                 => true,
+		'backendSearchIgnore'         => true,
 		'sql' => array
 		(
 			'keys' => array

--- a/core-bundle/contao/dca/tl_log.php
+++ b/core-bundle/contao/dca/tl_log.php
@@ -22,6 +22,7 @@ $GLOBALS['TL_DCA']['tl_log'] = array
 		'closed'                      => true,
 		'notEditable'                 => true,
 		'notCopyable'                 => true,
+		'backendSearchIgnore'         => true,
 		'sql' => array
 		(
 			'keys' => array

--- a/core-bundle/contao/dca/tl_opt_in.php
+++ b/core-bundle/contao/dca/tl_opt_in.php
@@ -28,6 +28,7 @@ $GLOBALS['TL_DCA']['tl_opt_in'] = array
 		'notEditable'                 => true,
 		'notCopyable'                 => true,
 		'notDeletable'                => true,
+		'backendSearchIgnore'         => true,
 		'onshow_callback' => array
 		(
 			array('tl_opt_in', 'showRelatedRecords')

--- a/core-bundle/contao/dca/tl_preview_link.php
+++ b/core-bundle/contao/dca/tl_preview_link.php
@@ -20,6 +20,7 @@ $GLOBALS['TL_DCA']['tl_preview_link'] = array
 		'enableVersioning'            => true,
 		'notCreatable'                => true,
 		'notCopyable'                 => true,
+		'backendSearchIgnore'         => true,
 		'sql' => array
 		(
 			'keys' => array

--- a/core-bundle/contao/dca/tl_undo.php
+++ b/core-bundle/contao/dca/tl_undo.php
@@ -27,6 +27,7 @@ $GLOBALS['TL_DCA']['tl_undo'] = array
 		'notEditable'                 => true,
 		'notCopyable'                 => true,
 		'notDeletable'                => true,
+		'backendSearchIgnore'         => true,
 		'sql' => array
 		(
 			'keys' => array

--- a/core-bundle/src/Search/Backend/Provider/TableDataContainerProvider.php
+++ b/core-bundle/src/Search/Backend/Provider/TableDataContainerProvider.php
@@ -79,6 +79,11 @@ class TableDataContainerProvider implements ProviderInterface
                 continue;
             }
 
+            // Entire table is marked as to be ignored
+            if ($GLOBALS['TL_DCA'][$table]['config']['backendSearchIgnore'] ?? false) {
+                continue;
+            }
+
             foreach ($this->findDocuments($table, $config) as $document) {
                 yield $document;
             }

--- a/core-bundle/src/Search/Backend/Provider/TableDataContainerProvider.php
+++ b/core-bundle/src/Search/Backend/Provider/TableDataContainerProvider.php
@@ -79,7 +79,7 @@ class TableDataContainerProvider implements ProviderInterface
                 continue;
             }
 
-            // Entire table is marked as to be ignored
+            // The table is marked to be ignored
             if ($GLOBALS['TL_DCA'][$table]['config']['backendSearchIgnore'] ?? false) {
                 continue;
             }

--- a/core-bundle/tests/Fixtures/table-data-container-provider/dca/tl_undo.php
+++ b/core-bundle/tests/Fixtures/table-data-container-provider/dca/tl_undo.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+use Contao\DC_Table;
+
+$GLOBALS['TL_DCA']['tl_undo'] =
+[
+    'config' => [
+        'dataContainer' => DC_Table::class,
+        'backendSearchIgnore' => true,
+    ],
+
+    'fields' => [
+        'id' => [
+            'sql' => 'int(10) unsigned NOT NULL auto_increment',
+        ],
+        'data' => [
+            'search' => true,
+        ],
+    ],
+];

--- a/core-bundle/tests/Search/Backend/Provider/TableDataContainerProviderTest.php
+++ b/core-bundle/tests/Search/Backend/Provider/TableDataContainerProviderTest.php
@@ -70,6 +70,10 @@ class TableDataContainerProviderTest extends AbstractProviderTestCase
                     new Column('headline', Type::getType(Types::STRING)),
                     new Column('teaser', Type::getType(Types::STRING)),
                 ]),
+                new Table('tl_undo', [
+                    new Column('id', Type::getType(Types::INTEGER)),
+                    new Column('data', Type::getType(Types::BLOB)),
+                ]),
             ],
             [
                 'tl_content' => [
@@ -89,6 +93,12 @@ class TableDataContainerProviderTest extends AbstractProviderTestCase
                         'id' => 3,
                         'headline' => 'This is my news 3!',
                         'teaser' => 'Another great teaser!',
+                    ],
+                ],
+                'tl_undo' => [
+                    [
+                        'id' => 1,
+                        'data' => 'This should be ignored!',
                     ],
                 ],
             ],
@@ -120,6 +130,7 @@ class TableDataContainerProviderTest extends AbstractProviderTestCase
         // Sort the documents for deterministic tests
         /** @var array<Document> $documents */
         $documents = iterator_to_array($documentsIterator);
+        $this->assertCount(3, $documents);
         usort($documents, static fn (Document $a, Document $b) => $a->getId() <=> $b->getId());
 
         $this->assertSame('1', $documents[0]->getId());

--- a/core-bundle/tests/Search/Backend/Provider/TableDataContainerProviderTest.php
+++ b/core-bundle/tests/Search/Backend/Provider/TableDataContainerProviderTest.php
@@ -130,9 +130,9 @@ class TableDataContainerProviderTest extends AbstractProviderTestCase
         // Sort the documents for deterministic tests
         /** @var array<Document> $documents */
         $documents = iterator_to_array($documentsIterator);
-        $this->assertCount(3, $documents);
         usort($documents, static fn (Document $a, Document $b) => $a->getId() <=> $b->getId());
 
+        $this->assertCount(3, $documents);
         $this->assertSame('1', $documents[0]->getId());
         $this->assertSame('contao.db.tl_content', $documents[0]->getType());
         $this->assertSame('tl_content', $documents[0]->getMetadata()['table']);


### PR DESCRIPTION
Excludes `tl_undo` from the backend search completely and allow others to do the same using a simple DCA config.