### PR TITLE
Make Choices instance accessible to 3rd parties

### DIFF
--- a/core-bundle/assets/controllers/choices-controller.js
+++ b/core-bundle/assets/controllers/choices-controller.js
@@ -43,7 +43,16 @@ export default class ChoicesController extends Controller {
             removeItemLabelText: function (value) {
                 return Contao.lang.removeItem.concat(' ').concat(value);
             },
-        })
+        });
+
+        // Trigger a custom "choicesInit" event to allow third parties to interact with the Choices instance
+        const initEvent = new CustomEvent('choicesInit', {
+            detail: {
+                choices: this.choices
+            }
+        });
+
+        select.dispatchEvent(initEvent);
     }
 
     disconnect() {


### PR DESCRIPTION
I'd appreciate a way to access the Choices instance of any Select element that has `chosen` set.

Currently, there is no way to do this. 
In some of our extensions (e.g., [numero2/contao-tags](https://github.com/numero2/contao-tags)), we want to use the Core's "chosen" feature (with all its settings) while also allowing users to add custom values on the fly. Previously, this functionality was missing in "Chosen," but "Choices" includes it by default—it just needs to be enabled 😊

To address this, I've added a custom event that triggers after Choices has been initialized. 
This event carries a reference to the Choices instance, making it easy to access and modify—for example, to enable the addition of custom values.

```js
select.addEventListener('choicesInit',(e)=>{

    const c = e.detail.choices;

    c._canAddUserChoices = true;
    c.config.addItems = true;
    c.config.addChoices = true;
});
```
