### PR TITLE
Improve the language cache warmer performance

### DIFF
--- a/core-bundle/src/Cache/ContaoCacheWarmer.php
+++ b/core-bundle/src/Cache/ContaoCacheWarmer.php
@@ -123,10 +123,10 @@ class ContaoCacheWarmer implements CacheWarmerInterface
         $processed = [];
 
         foreach ($this->locales as $language) {
-            $files = $this->findLanguageFiles($language);
+            $files = iterator_to_array($this->findLanguageFiles($language));
 
             foreach ($files as $file) {
-                $name = substr($file->getBasename(), 0, -4);
+                $name = $file->getFilenameWithoutExtension();
 
                 if (isset($processed[$language][$name])) {
                     continue;
@@ -134,14 +134,8 @@ class ContaoCacheWarmer implements CacheWarmerInterface
 
                 $processed[$language][$name] = true;
 
-                $subfiles = $this->finder
-                    ->findIn(Path::join('languages', $language))
-                    ->files()
-                    ->name("/^$name\\.(php|xlf)$/")
-                ;
-
                 $dumper->dump(
-                    iterator_to_array($subfiles),
+                    array_filter($files, static fn (SplFileInfo $f): bool => $f->getFilenameWithoutExtension() === $name),
                     Path::join('languages', $language, "$name.php"),
                     ['type' => $language],
                 );

--- a/core-bundle/src/Cache/ContaoCacheWarmer.php
+++ b/core-bundle/src/Cache/ContaoCacheWarmer.php
@@ -123,7 +123,13 @@ class ContaoCacheWarmer implements CacheWarmerInterface
         $processed = [];
 
         foreach ($this->locales as $language) {
-            $files = iterator_to_array($this->findLanguageFiles($language));
+            $files = $this->findLanguageFiles($language);
+
+            // findLanguageFiles might return an empty array instead of a Traversable object
+            // which we cannot pass to iterator_to_array in PHP 8.1 directly.
+            if ($files instanceof \Traversable) {
+                $files = iterator_to_array($files);
+            }
 
             foreach ($files as $file) {
                 $name = $file->getFilenameWithoutExtension();

--- a/core-bundle/tests/Cache/ContaoCacheWarmerTest.php
+++ b/core-bundle/tests/Cache/ContaoCacheWarmerTest.php
@@ -198,7 +198,7 @@ class ContaoCacheWarmerTest extends TestCase
         $finder = $this->createMock(Finder::class);
         $finder
             ->method('getIterator')
-            ->willReturn(new \ArrayIterator([]))
+            ->willReturn(new \EmptyIterator())
         ;
 
         $resourceFinder = $this->createMock(ResourceFinder::class);


### PR DESCRIPTION
In a project with a lot of extensions I noticed that the generation of the Contao language cache took __60 (!) seconds__. I was able to cut that time down to __30 seconds__ by using `contao.intl.enabled_locales: [en, de]`. However, I investigated further and found the following issue in our `ContaoCacheWarmer::generateLanguageCache()` method. I was able to further reduce it to __10 seconds__ with this PR.

We first search for all language files of a language via:

https://github.com/contao/contao/blob/7b080945f0a5fff05745a27cb188a098805a823f/core-bundle/src/Cache/ContaoCacheWarmer.php#L291-L295

Then we iterate over all language files and extract the filename - but then search for all language files _again_ - just with an additional filter on the name - via:

https://github.com/contao/contao/blob/7b080945f0a5fff05745a27cb188a098805a823f/core-bundle/src/Cache/ContaoCacheWarmer.php#L137-L141

This Finder search is done for all language file names (`default`, `tl_content`, `tl_news`, etc.) and thus the search time accumulates.

This PR filters the already available list of language files instead of searching for the files again. Even in a vanilla Contao 5.3 setup this cuts down the language cache generation from __15 seconds__ to just __4 seconds__ on my system.

