### PR TITLE
Add body template and attributes callback to the maker bundle

### DIFF
--- a/maker-bundle/config/callbacks.yaml
+++ b/maker-bundle/config/callbacks.yaml
@@ -150,6 +150,15 @@ callbacks:
         arguments:
             dataContainer: Contao\DataContainer
 
+    fields.{field}.attributes:
+        return_type: array
+        arguments:
+            attributes: array
+            dataContainer: Contao\DataContainer
+        body: >
+            // Do something
+            return $attributes;
+
     fields.{field}.input_field:
         return_type: string
         arguments:
@@ -158,16 +167,20 @@ callbacks:
     fields.{field}.load:
         return_type: ~
         arguments:
-            currentValue: ~
+            value: ~
             # Since there are multiple parameters for multiple calls, we cannot
             # safely assume the following correct parameter names and types
+        body: >
+            return $value;
 
     fields.{field}.save:
         return_type: ~
         arguments:
-            currentValue: ~
+            value: ~
             # Since there are multiple parameters for multiple calls, we cannot
             # safely assume the following correct parameter names and types
+        body: >
+            return $value;
 
     fields.{field}.wizard:
         return_type: string

--- a/maker-bundle/src/Maker/MakeDcaCallback.php
+++ b/maker-bundle/src/Maker/MakeDcaCallback.php
@@ -194,7 +194,7 @@ class MakeDcaCallback extends AbstractMaker
         $targets = [];
 
         foreach ($yaml['callbacks'] as $key => $config) {
-            $targets[$key] = new MethodDefinition($config['return_type'], $config['arguments']);
+            $targets[$key] = new MethodDefinition($config['return_type'], $config['arguments'], $config['body'] ?? null);
         }
 
         return $targets;

--- a/maker-bundle/src/Maker/MakeEventListener.php
+++ b/maker-bundle/src/Maker/MakeEventListener.php
@@ -114,7 +114,7 @@ class MakeEventListener extends AbstractMaker
         $events = [];
 
         foreach ($yaml['events'] as $key => $config) {
-            $events[$key] = new MethodDefinition($config['return_type'], $config['arguments']);
+            $events[$key] = new MethodDefinition($config['return_type'] ?? null, $config['arguments'] ?? [], $config['body'] ?? null);
         }
 
         return $events;

--- a/maker-bundle/src/Maker/MakeHook.php
+++ b/maker-bundle/src/Maker/MakeHook.php
@@ -116,7 +116,7 @@ class MakeHook extends AbstractMaker
         $hooks = [];
 
         foreach ($yaml['hooks'] as $key => $config) {
-            $hooks[$key] = new MethodDefinition($config['return_type'], $config['arguments']);
+            $hooks[$key] = new MethodDefinition($config['return_type'] ?? null, $config['arguments'] ?? [], $config['body'] ?? null);
         }
 
         return $hooks;

--- a/maker-bundle/src/Reflection/MethodDefinition.php
+++ b/maker-bundle/src/Reflection/MethodDefinition.php
@@ -20,6 +20,7 @@ class MethodDefinition
     public function __construct(
         private readonly string|null $returnType,
         private readonly array $parameters,
+        private readonly string|null $body = null,
     ) {
     }
 
@@ -38,6 +39,10 @@ class MethodDefinition
 
     public function getBody(): string
     {
+        if (null !== $this->body) {
+            return $this->body;
+        }
+
         return match ($this->returnType) {
             'string' => "return '';",
             '?string' => 'return null;',

--- a/maker-bundle/tests/Reflection/MethodDefinitionTest.php
+++ b/maker-bundle/tests/Reflection/MethodDefinitionTest.php
@@ -20,13 +20,13 @@ class MethodDefinitionTest extends TestCase
     /**
      * @dataProvider getReturnValues
      */
-    public function testSetsTheCorrectMethodBody(string|null $returnType, string $body): void
+    public function testSetsTheCorrectMethodBody(string|null $returnType, string $expected, string|null $body = null): void
     {
-        $hookDefinition = new MethodDefinition($returnType, []);
+        $hookDefinition = new MethodDefinition($returnType, [], $body);
 
         $this->assertSame($returnType, $hookDefinition->getReturnType());
         $this->assertSame([], $hookDefinition->getParameters());
-        $this->assertSame($body, $hookDefinition->getBody());
+        $this->assertSame($expected, $hookDefinition->getBody());
     }
 
     public static function getReturnValues(): iterable
@@ -37,5 +37,6 @@ class MethodDefinitionTest extends TestCase
         yield ['bool', 'return true;'];
         yield [null, '// Do something'];
         yield ['Foo\Bar\Class', '// Do something'];
+        yield ['string', 'return $foo;', 'return $foo;'];
     }
 }


### PR DESCRIPTION
This adds the missing `attribtues_callback` to the maker bundle. Since the callback is most likely supposed to return the first argument, I also added support for body content to the MethodDefinition/YAML files.