### PR TITLE
Add `spellcheck="false"` to the search input field

### DIFF
--- a/core-bundle/contao/templates/modules/mod_search.html5
+++ b/core-bundle/contao/templates/modules/mod_search.html5
@@ -6,7 +6,7 @@
     <div class="formbody">
       <div class="widget widget-text">
         <label for="ctrl_keywords_<?= $this->uniqueId ?>" class="invisible"><?= $this->keywordLabel ?></label>
-        <input type="search" name="keywords" id="ctrl_keywords_<?= $this->uniqueId ?>" class="text" value="<?= $this->keyword ?>">
+        <input type="search" name="keywords" id="ctrl_keywords_<?= $this->uniqueId ?>" class="text" value="<?= $this->keyword ?>" spellcheck="false">
       </div>
       <div class="widget widget-submit">
         <button type="submit" id="ctrl_submit_<?= $this->uniqueId ?>" class="submit"><?= $this->search ?></button>


### PR DESCRIPTION
Apparently since iOS 11's "Smart Punctuation" feature, the default for quotes are [curly quotes](https://apple.stackexchange.com/questions/299505/ios-11-default-quotation-mark-changed-to-and). So if an iPhone user uses the search and wants to search for a phrase, they would write `“lorem ipsum”` instead of `"lorem ipsum"` - which of course would yield different search results.

There does not seem to be a standardized way to deal with this - however according to [this](https://stackoverflow.com/a/60046254/374996), WebKit will use standard quotes if you add `spellcheck="false"` to an input field.

It may make sense to disable spell checking for a search input field in general - wdyt?