### PR TITLE
Only assume a self-referencing table in mode 5 when deleting records

### DIFF
--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -1697,7 +1697,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 		}
 
 		// If there is a PID field but no parent table
-		if (!$this->ptable && $db->fieldExists('pid', $this->strTable))
+		if (!$this->ptable && self::MODE_TREE === ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] ?? null) && $db->fieldExists('pid', $this->strTable))
 		{
 			$delete[$this->strTable] = $db->getChildRecords($this->intId, $this->strTable);
 			array_unshift($delete[$this->strTable], $this->intId);


### PR DESCRIPTION
If there is a table without a `ptable` but with a `pid` column, Contao will automatically assume that it is self-referencing and it will delete the child records:

https://github.com/contao/contao/blob/f6d59c489f30561f4553fb1f4663aa6f6f087f01/core-bundle/contao/drivers/DC_Table.php#L1699-L1704

However, this assumption is only valid in `MODE_TREE`. I had a table with a `pid` column but without a `ptable` running in `MODE_PARENT`, and every time I deleted a record, Contao also deleted random "child records" that happened to match the ID of the deleted record 🙈
