### PR TITLE
Fix a typo in `ContaoCoreExtension::handleTemplateStudioConfig()`

### DIFF
--- a/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
+++ b/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
@@ -159,7 +159,7 @@ class ContaoCoreExtension extends Extension implements PrependExtensionInterface
         $this->handleSecurityConfig($config, $container);
         $this->handleCspConfig($config, $container);
         $this->handleAltcha($config, $container);
-        $this->handTemplateStudioConfig($config, $container, $loader);
+        $this->handleTemplateStudioConfig($config, $container, $loader);
 
         $container
             ->registerForAutoconfiguration(PickerProviderInterface::class)
@@ -626,7 +626,7 @@ class ContaoCoreExtension extends Extension implements PrependExtensionInterface
         $altcha->setArgument(5, $config['altcha']['challenge_expiry']);
     }
 
-    private function handTemplateStudioConfig(array $config, ContainerBuilder $container, LoaderInterface $loader): void
+    private function handleTemplateStudioConfig(array $config, ContainerBuilder $container, LoaderInterface $loader): void
     {
         // Used to display/hide the menu entry in the back end
         $container->setParameter('contao.template_studio.enabled', $config['template_studio']['enabled']);


### PR DESCRIPTION
Fixes a minor typo in our `ContaoCoreExtension`. The method for handling the template studio config currently says ✋ instead of [🍗](https://en.wikipedia.org/wiki/Roast_chicken#Hendl).

@m-vo unless `hand` was deliberate? 🙃 
