### PR TITLE
Ignore tokens from Contao 4 in the `RememberMeMigration`

### DIFF
--- a/core-bundle/src/Migration/Version503/RememberMeMigration.php
+++ b/core-bundle/src/Migration/Version503/RememberMeMigration.php
@@ -60,6 +60,7 @@ class RememberMeMigration extends AbstractMigration
                         class,
                         userIdentifier
                     FROM tl_remember_me
+                    WHERE userIdentifier != ''
                 )
                 SQL,
             );

--- a/core-bundle/src/Migration/Version503/RememberMeMigration.php
+++ b/core-bundle/src/Migration/Version503/RememberMeMigration.php
@@ -46,21 +46,24 @@ class RememberMeMigration extends AbstractMigration
         );
 
         $schemaManager = $this->connection->createSchemaManager();
-        $username = isset($schemaManager->listTableColumns('tl_remember_me')['useridentifier']) ? 'userIdentifier' : 'username';
 
-        $this->connection->executeStatement(<<<SQL
-            INSERT INTO rememberme_token (
-                SELECT
-                    TRIM(TRAILING CHAR(0) FROM CAST(series AS char)),
-                    TRIM(TRAILING CHAR(0) FROM CAST(value AS char)),
-                    lastUsed,
-                    class,
-                    $username
-                FROM tl_remember_me
-                WHERE $username != ''
-            )
-            SQL,
-        );
+        // If tl_remember_me.userIdentifier exists, the database is from Contao 5 and the
+        // existing tokens can be migrated. Otherwise, it is a Contao 4 database and the
+        // tokens would not work anyway and therefore do not need to be migrated.
+        if (isset($schemaManager->listTableColumns('tl_remember_me')['useridentifier'])) {
+            $this->connection->executeStatement(<<<'SQL'
+                INSERT INTO rememberme_token (
+                    SELECT
+                        TRIM(TRAILING CHAR(0) FROM CAST(series AS char)),
+                        TRIM(TRAILING CHAR(0) FROM CAST(value AS char)),
+                        lastUsed,
+                        class,
+                        userIdentifier
+                    FROM tl_remember_me
+                )
+                SQL,
+            );
+        }
 
         $this->connection->executeStatement('DROP TABLE tl_remember_me');
 


### PR DESCRIPTION
![](https://github.com/user-attachments/assets/98340074-7a0f-451f-807a-ee9e6bdb59f0)

Since "remember me" tokens from Contao 4 do not work in Contao 5 anyway, we can simply ignore them in the migration.