### PR TITLE
Do not remove request tokens from the HTML response anymore

### DIFF
--- a/core-bundle/config/listener.yaml
+++ b/core-bundle/config/listener.yaml
@@ -53,7 +53,6 @@ services:
     contao.listener.csrf_token_cookie:
         class: Contao\CoreBundle\EventListener\CsrfTokenCookieSubscriber
         arguments:
-            - '@contao.csrf.token_manager'
             - '@contao.csrf.token_storage'
             - '%contao.csrf_cookie_prefix%'
 

--- a/core-bundle/tests/EventListener/CsrfTokenCookieSubscriberTest.php
+++ b/core-bundle/tests/EventListener/CsrfTokenCookieSubscriberTest.php
@@ -12,15 +12,12 @@ declare(strict_types=1);
 
 namespace Contao\CoreBundle\Tests\EventListener;
 
-use Contao\CoreBundle\Csrf\ContaoCsrfTokenManager;
 use Contao\CoreBundle\Csrf\MemoryTokenStorage;
 use Contao\CoreBundle\EventListener\CsrfTokenCookieSubscriber;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\InputBag;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
@@ -43,8 +40,6 @@ class CsrfTokenCookieSubscriberTest extends TestCase
             'csrf_bar' => '"<>!&', // ignore invalid characters
         ]);
 
-        $tokenManager = $this->createMock(ContaoCsrfTokenManager::class);
-
         $tokenStorage = $this->createMock(MemoryTokenStorage::class);
         $tokenStorage
             ->expects($this->once())
@@ -55,7 +50,7 @@ class CsrfTokenCookieSubscriberTest extends TestCase
             ])
         ;
 
-        $listener = new CsrfTokenCookieSubscriber($tokenManager, $tokenStorage);
+        $listener = new CsrfTokenCookieSubscriber($tokenStorage);
         $listener->onKernelRequest($this->getRequestEvent($request));
     }
 
@@ -67,15 +62,13 @@ class CsrfTokenCookieSubscriberTest extends TestCase
             ->willReturn(false)
         ;
 
-        $tokenManager = $this->createMock(ContaoCsrfTokenManager::class);
-
         $tokenStorage = $this->createMock(MemoryTokenStorage::class);
         $tokenStorage
             ->expects($this->never())
             ->method('initialize')
         ;
 
-        $listener = new CsrfTokenCookieSubscriber($tokenManager, $tokenStorage);
+        $listener = new CsrfTokenCookieSubscriber($tokenStorage);
         $listener->onKernelRequest($requestEvent);
     }
 
@@ -83,8 +76,6 @@ class CsrfTokenCookieSubscriberTest extends TestCase
     {
         $request = Request::create('https://foobar.com');
         $request->cookies = new InputBag(['unrelated-cookie' => 'to-activate-csrf']);
-
-        $tokenManager = $this->createMock(ContaoCsrfTokenManager::class);
 
         $tokenStorage = $this->createMock(MemoryTokenStorage::class);
         $tokenStorage
@@ -95,7 +86,7 @@ class CsrfTokenCookieSubscriberTest extends TestCase
 
         $response = new Response();
 
-        $listener = new CsrfTokenCookieSubscriber($tokenManager, $tokenStorage);
+        $listener = new CsrfTokenCookieSubscriber($tokenStorage);
         $listener->onKernelResponse($this->getResponseEvent($request, $response));
 
         $cookies = $response->headers->getCookies();
@@ -118,8 +109,6 @@ class CsrfTokenCookieSubscriberTest extends TestCase
         $request = Request::create('https://foobar.com');
         $request->cookies = new InputBag(['unrelated-cookie' => 'to-activate-csrf']);
 
-        $tokenManager = $this->createMock(ContaoCsrfTokenManager::class);
-
         $tokenStorage = $this->createMock(MemoryTokenStorage::class);
         $tokenStorage
             ->expects($this->never())
@@ -129,7 +118,7 @@ class CsrfTokenCookieSubscriberTest extends TestCase
         $response = new Response();
         $response->headers->clearCookie('unrelated-cookie');
 
-        $listener = new CsrfTokenCookieSubscriber($tokenManager, $tokenStorage);
+        $listener = new CsrfTokenCookieSubscriber($tokenStorage);
         $listener->onKernelResponse($this->getResponseEvent($request, $response));
 
         $cookies = $response->headers->getCookies();
@@ -147,8 +136,6 @@ class CsrfTokenCookieSubscriberTest extends TestCase
             'unrelated-cookie' => 'to-activate-csrf',
         ]);
 
-        $tokenManager = $this->createMock(ContaoCsrfTokenManager::class);
-
         $tokenStorage = $this->createMock(MemoryTokenStorage::class);
         $tokenStorage
             ->expects($this->once())
@@ -158,7 +145,7 @@ class CsrfTokenCookieSubscriberTest extends TestCase
 
         $response = new Response();
 
-        $listener = new CsrfTokenCookieSubscriber($tokenManager, $tokenStorage);
+        $listener = new CsrfTokenCookieSubscriber($tokenStorage);
         $listener->onKernelResponse($this->getResponseEvent($request, $response));
 
         $this->assertCount(0, $response->headers->getCookies());
@@ -173,8 +160,6 @@ class CsrfTokenCookieSubscriberTest extends TestCase
         $request = Request::create('https://foobar.com');
         $request->setSession($session);
 
-        $tokenManager = $this->createMock(ContaoCsrfTokenManager::class);
-
         $tokenStorage = $this->createMock(MemoryTokenStorage::class);
         $tokenStorage
             ->expects($this->never())
@@ -183,7 +168,7 @@ class CsrfTokenCookieSubscriberTest extends TestCase
 
         $response = new Response();
 
-        $listener = new CsrfTokenCookieSubscriber($tokenManager, $tokenStorage);
+        $listener = new CsrfTokenCookieSubscriber($tokenStorage);
         $listener->onKernelResponse($this->getResponseEvent($request, $response));
 
         $this->assertCount(0, $response->headers->getCookies());
@@ -195,8 +180,6 @@ class CsrfTokenCookieSubscriberTest extends TestCase
         $request->cookies = new InputBag(['unrelated-cookie' => 'to-activate-csrf']);
         $request->attributes->set('_token_check', false);
 
-        $tokenManager = $this->createMock(ContaoCsrfTokenManager::class);
-
         $tokenStorage = $this->createMock(MemoryTokenStorage::class);
         $tokenStorage
             ->expects($this->never())
@@ -205,13 +188,13 @@ class CsrfTokenCookieSubscriberTest extends TestCase
 
         $response = new Response();
 
-        $listener = new CsrfTokenCookieSubscriber($tokenManager, $tokenStorage);
+        $listener = new CsrfTokenCookieSubscriber($tokenStorage);
         $listener->onKernelResponse($this->getResponseEvent($request, $response));
 
         $this->assertCount(0, $response->headers->getCookies());
     }
 
-    public function testRemovesTheTokenCookiesAndReplacesTokenOccurrencesIfNoOtherCookiesArePresent(): void
+    public function testRemovesTheTokenCookiesIfNoOtherCookiesArePresent(): void
     {
         $request = Request::create('https://foobar.com');
         $request->cookies = new InputBag(['csrf_foo' => 'bar']);
@@ -219,31 +202,13 @@ class CsrfTokenCookieSubscriberTest extends TestCase
         $tokenStorage = new MemoryTokenStorage();
         $tokenStorage->initialize(['tokenName' => 'tokenValue']);
 
-        $tokenManager = new ContaoCsrfTokenManager(new RequestStack(), 'csrf_', null, $tokenStorage);
-        $tokenValue1 = $tokenManager->getToken('tokenName');
-        $tokenValue2 = $tokenManager->getToken('tokenName');
-
-        $response = new Response(
-            '<html><body><form>'
-                .'<input name="REQUEST_TOKEN" value="'.$tokenValue1.'">'
-                .'<input name="REQUEST_TOKEN" value="'.$tokenValue2.'">'
-                .'</form></body></html>',
+        $response = new Response('',
             200,
             ['Content-Type' => 'text/html', 'Content-Length' => 1234],
         );
 
-        $listener = new CsrfTokenCookieSubscriber($tokenManager, $tokenStorage);
+        $listener = new CsrfTokenCookieSubscriber($tokenStorage);
         $listener->onKernelResponse($this->getResponseEvent($request, $response));
-
-        $this->assertSame(
-            '<html><body><form>'
-                .'<input name="REQUEST_TOKEN" value="">'
-                .'<input name="REQUEST_TOKEN" value="">'
-                .'</form></body></html>',
-            $response->getContent(),
-        );
-
-        $this->assertFalse($response->headers->has('Content-Length'));
 
         $cookies = $response->headers->getCookies();
 
@@ -260,72 +225,8 @@ class CsrfTokenCookieSubscriberTest extends TestCase
         $this->assertNull($cookie->getSameSite());
     }
 
-    public function testDoesNotChangeTheResponseIfNoTokensArePresent(): void
-    {
-        $request = Request::create('https://foobar.com');
-        $request->cookies = new InputBag(['csrf_foo' => 'bar']);
-
-        $tokenManager = $this->createMock(ContaoCsrfTokenManager::class);
-
-        $tokenStorage = new MemoryTokenStorage();
-        $tokenStorage->initialize([]);
-
-        $response = new Response(
-            '<html><body><form><input name="REQUEST_TOKEN" value="tokenValue"></form></body></html>',
-            200,
-            ['Content-Type' => 'text/html', 'Content-Length' => 1234],
-        );
-
-        $listener = new CsrfTokenCookieSubscriber($tokenManager, $tokenStorage);
-        $listener->onKernelResponse($this->getResponseEvent($request, $response));
-
-        $this->assertSame(
-            '<html><body><form><input name="REQUEST_TOKEN" value="tokenValue"></form></body></html>',
-            $response->getContent(),
-        );
-
-        $this->assertTrue($response->headers->has('Content-Length'));
-    }
-
-    public function testDoesNotChangeTheResponseIfTokensAreNotFound(): void
-    {
-        $request = Request::create('https://foobar.com');
-        $request->cookies = new InputBag(['csrf_foo' => 'bar']);
-
-        $tokenManager = $this->createMock(ContaoCsrfTokenManager::class);
-
-        $tokenStorage = new MemoryTokenStorage();
-        $tokenStorage->initialize(['tokenName' => 'tokenValue']);
-        $tokenStorage->getToken('tokenName');
-
-        $response = $this->createMock(Response::class);
-        $response
-            ->expects($this->once())
-            ->method('isSuccessful')
-            ->willReturn(true)
-        ;
-
-        $response
-            ->expects($this->once())
-            ->method('getContent')
-            ->willReturn('<html><body><form><input name="REQUEST_TOKEN" value=""></form></body></html>')
-        ;
-
-        $response
-            ->expects($this->never())
-            ->method('setContent')
-        ;
-
-        $response->headers = new ResponseHeaderBag(['Content-Type' => 'text/html']);
-
-        $listener = new CsrfTokenCookieSubscriber($tokenManager, $tokenStorage);
-        $listener->onKernelResponse($this->getResponseEvent($request, $response));
-    }
-
     public function testDoesNotAddTheTokenCookiesToTheResponseUponSubrequests(): void
     {
-        $tokenManager = $this->createMock(ContaoCsrfTokenManager::class);
-
         $tokenStorage = $this->createMock(MemoryTokenStorage::class);
         $tokenStorage
             ->expects($this->never())
@@ -339,30 +240,8 @@ class CsrfTokenCookieSubscriberTest extends TestCase
             new Response(),
         );
 
-        $listener = new CsrfTokenCookieSubscriber($tokenManager, $tokenStorage);
+        $listener = new CsrfTokenCookieSubscriber($tokenStorage);
         $listener->onKernelResponse($responseEvent);
-    }
-
-    public function testDoesNotReplaceTheTokenOccurrencesIfNotAHtmlDocument(): void
-    {
-        $request = Request::create('https://foobar.com');
-
-        $tokenStorage = new MemoryTokenStorage();
-        $tokenStorage->initialize(['tokenName' => 'tokenValue']);
-
-        $tokenManager = new ContaoCsrfTokenManager(new RequestStack(), 'csrf_', null, $tokenStorage);
-        $tokenValue = $tokenManager->getToken('tokenName');
-
-        $response = new Response(
-            'value="'.$tokenValue.'"',
-            200,
-            ['Content-Type' => 'application/octet-stream'],
-        );
-
-        $listener = new CsrfTokenCookieSubscriber($tokenManager, $tokenStorage);
-        $listener->onKernelResponse($this->getResponseEvent($request, $response));
-
-        $this->assertSame('value="'.$tokenValue.'"', $response->getContent());
     }
 
     public function getRequestEvent(Request|null $request = null): RequestEvent


### PR DESCRIPTION
Fixes #8148 

The kernel.response event listener removes request token occurences from the html response, if request tokens are not required. 

For instance:
```html
<input name="REQUEST_TOKEN" value="M9kjqla1vKejfShFXX">
<!-- becomes -->
<input name="REQUEST_TOKEN" value="">
```

As the motivation for this is unclear, this mechanism should be removed, since it can have negative side effect. One negative side effect was described in #8148.

