### PR TITLE
Also show the edit-all operation if a table is only sortable

### DIFF
--- a/core-bundle/src/EventListener/DataContainer/DefaultGlobalOperationsListener.php
+++ b/core-bundle/src/EventListener/DataContainer/DefaultGlobalOperationsListener.php
@@ -84,11 +84,13 @@ class DefaultGlobalOperationsListener
         $operations = [];
 
         $hasLimitHeight = ($GLOBALS['TL_DCA'][$table]['list']['sorting']['limitHeight'] ?? null) > 0;
+        $isParentMode = DataContainer::MODE_PARENT === ($GLOBALS['TL_DCA'][$table]['list']['sorting']['mode'] ?? null);
         $isTreeMode = DataContainer::MODE_TREE === ($GLOBALS['TL_DCA'][$table]['list']['sorting']['mode'] ?? null);
         $isExtendedTreeMode = DataContainer::MODE_TREE_EXTENDED === ($GLOBALS['TL_DCA'][$table]['list']['sorting']['mode'] ?? null);
 
         $canEdit = !($GLOBALS['TL_DCA'][$table]['config']['notEditable'] ?? false);
         $canCopy = !($GLOBALS['TL_DCA'][$table]['config']['closed'] ?? false) && !($GLOBALS['TL_DCA'][$table]['config']['notCopyable'] ?? false);
+        $canSort = !($GLOBALS['TL_DCA'][$table]['config']['notSortable'] ?? false);
         $canDelete = !($GLOBALS['TL_DCA'][$table]['config']['notDeletable'] ?? false);
 
         if ($isDcFolder || $isTreeMode || $isExtendedTreeMode) {
@@ -109,7 +111,7 @@ class DefaultGlobalOperationsListener
             ];
         }
 
-        if ($canEdit || $canCopy || $canDelete) {
+        if ($canEdit || $canCopy || $canDelete || ($canSort && ($isParentMode || $isTreeMode || $isExtendedTreeMode))) {
             $operations += [
                 'all' => [
                     'href' => 'act=select',


### PR DESCRIPTION
If have a `MODE_PARENT` table that is closed, not editable, not copyable and not deletable. But the records are sortable.
When no operations or global_operations are defined, the sorting operation is correctly added, but the edit-all operation is missing. If I manually add it, sorting works correctly and only the sorting button is correctly shown in select mode.