### PR TITLE
Replace newsletter insert tags in front end scope

### DIFF
--- a/newsletter-bundle/contao/classes/Newsletter.php
+++ b/newsletter-bundle/contao/classes/Newsletter.php
@@ -98,14 +98,26 @@ class Newsletter extends Backend
 			}
 		}
 
-		// Replace insert tags
-		$html = System::getContainer()->get('contao.insert_tag.parser')->replaceInline($objNewsletter->content ?? '');
-		$text = System::getContainer()->get('contao.insert_tag.parser')->replaceInline($objNewsletter->text ?? '');
+		$requestStack = System::getContainer()->get('request_stack');
+		$subRequest = $requestStack->getCurrentRequest()->duplicate();
+		$subRequest->attributes->set('_scope', 'frontend');
+		$requestStack->push($subRequest);
+
+		try
+		{
+			// Replace insert tags
+			$html = System::getContainer()->get('contao.insert_tag.parser')->replaceInline($objNewsletter->content ?? '');
+			$text = System::getContainer()->get('contao.insert_tag.parser')->replaceInline($objNewsletter->text ?? '');
+		}
+		finally
+		{
+			$requestStack->pop();
+		}
 
 		// Convert relative URLs
 		$html = $this->convertRelativeUrls($html);
 
-		$objSession = System::getContainer()->get('request_stack')->getCurrentRequest()->getSession();
+		$objSession = $requestStack->getCurrentRequest()->getSession();
 		$token = Input::get('token');
 
 		// Send newsletter


### PR DESCRIPTION
Using something like `{{insert_article::*}}` in a newsletter causes all the nested elements to be rendered with `as_editor_view = true` which causes issues like nested insert tag not geting replaced and so on.