### PR TITLE
Add the missing `scroll-offset#store` action to the `all` button

### DIFF
--- a/core-bundle/src/EventListener/DataContainer/DefaultGlobalOperationsListener.php
+++ b/core-bundle/src/EventListener/DataContainer/DefaultGlobalOperationsListener.php
@@ -114,7 +114,7 @@ class DefaultGlobalOperationsListener
                 'all' => [
                     'href' => 'act=select',
                     'class' => 'header_edit_all',
-                    'attributes' => 'accesskey="e"',
+                    'attributes' => 'data-action="contao--scroll-offset#store" accesskey="e"',
                 ],
             ];
         }


### PR DESCRIPTION
### Description

Regression from #6672

The mentioned PR did remove `onclick="Backend.getScrollOffset()"` but the data-action was not added