### PR TITLE
Show errors for failed elements in the back end

### DIFF
--- a/core-bundle/contao/dca/tl_content.php
+++ b/core-bundle/contao/dca/tl_content.php
@@ -965,7 +965,15 @@ class tl_content extends Backend
 		$objModel->setRow($arrRow);
 
 		$class = 'cte_preview';
-		$preview = StringUtil::insertTagToSrc($this->getContentElement($objModel));
+
+		try
+		{
+			$preview = StringUtil::insertTagToSrc($this->getContentElement($objModel));
+		}
+		catch (Throwable $exception)
+		{
+			$preview = '<p class="tl_error">' . StringUtil::specialchars($exception->getMessage()) . '</p>';
+		}
 
 		if (!empty($arrRow['sectionHeadline']))
 		{


### PR DESCRIPTION
Fixes #7544 for the backend. 

Having a general try/catch for the content element preview makes sense IMO as this would always make it possible to edit the element and fix a potential misconfiguration.

The frontend is not affected for the audio/video element because the error only happens in the `editor_view` block. Image and download elements already failed gracefully in my test. We should not add a general try/catch for the frontend because only the content element itself can know if it should fail gracefully or not.