### PR TITLE
Fix the BC layer for error templates

### DIFF
--- a/core-bundle/contao/templates/twig/error/backend.html.twig
+++ b/core-bundle/contao/templates/twig/error/backend.html.twig
@@ -1,5 +1,5 @@
 {% trans_default_domain "contao_exception" %}
-{% extends "@Contao/error/_layout.html.twig" %}
+{% extends ["@ContaoCore/Error/layout.html.twig", "@Contao/error/_layout.html.twig"] %}
 
 {% block title %}
     {{ statusName }}

--- a/core-bundle/contao/templates/twig/error/general.html.twig
+++ b/core-bundle/contao/templates/twig/error/general.html.twig
@@ -1,5 +1,5 @@
 {% trans_default_domain "contao_exception" %}
-{% extends "@Contao/error/_layout.html.twig" %}
+{% extends ["@ContaoCore/Error/layout.html.twig", "@Contao/error/_layout.html.twig"] %}
 
 {% block title %}
     {{ 'XPT.error'|trans }}

--- a/core-bundle/contao/templates/twig/error/invalid_request_token.html.twig
+++ b/core-bundle/contao/templates/twig/error/invalid_request_token.html.twig
@@ -1,5 +1,5 @@
 {% trans_default_domain "contao_exception" %}
-{% extends "@Contao/error/_layout.html.twig" %}
+{% extends ["@ContaoCore/Error/layout.html.twig", "@Contao/error/_layout.html.twig"] %}
 
 {% block title %}
     {{ 'XPT.requestToken'|trans }}

--- a/core-bundle/contao/templates/twig/error/missing_route_parameters.html.twig
+++ b/core-bundle/contao/templates/twig/error/missing_route_parameters.html.twig
@@ -1,5 +1,5 @@
 {% trans_default_domain "contao_exception" %}
-{% extends "@Contao/error/_layout.html.twig" %}
+{% extends ["@ContaoCore/Error/layout.html.twig", "@Contao/error/_layout.html.twig"] %}
 
 {% block title %}
     {{ 'XPT.missingRouteParameters.title'|trans }}

--- a/core-bundle/contao/templates/twig/error/service_unavailable.html.twig
+++ b/core-bundle/contao/templates/twig/error/service_unavailable.html.twig
@@ -1,5 +1,5 @@
 {% trans_default_domain "contao_exception" %}
-{% extends "@Contao/error/_layout.html.twig" %}
+{% extends ["@ContaoCore/Error/layout.html.twig", "@Contao/error/_layout.html.twig"] %}
 
 {% block title %}
     {{ 'XPT.unavailable'|trans }}

--- a/core-bundle/src/EventListener/PrettyErrorScreenListener.php
+++ b/core-bundle/src/EventListener/PrettyErrorScreenListener.php
@@ -182,7 +182,7 @@ class PrettyErrorScreenListener
             return;
         }
 
-        // For BC reasons, check if a bundle template exists
+        // Backwards compatibility: check if a bundle template exists
         $view = '@ContaoCore/Error/'.$template.'.html.twig';
         $parameters = $this->getTemplateParameters($view, $statusCode, $event);
 

--- a/core-bundle/src/EventListener/PrettyErrorScreenListener.php
+++ b/core-bundle/src/EventListener/PrettyErrorScreenListener.php
@@ -182,13 +182,24 @@ class PrettyErrorScreenListener
             return;
         }
 
+        // For BC reasons, check if a bundle template exists
         $view = '@ContaoCore/Error/'.$template.'.html.twig';
         $parameters = $this->getTemplateParameters($view, $statusCode, $event);
+
+        if (!$this->twig->getLoader()->exists($view)) {
+            $view = match ($template) {
+                'backend' => '@Contao/error/backend.html.twig',
+                'invalid_request_token' => '@Contao/error/invalid_request_token.html.twig',
+                'missing_route_parameters' => '@Contao/error/missing_route_parameters.html.twig',
+                'service_unavailable' => '@Contao/error/service_unavailable.html.twig',
+                default => '@Contao/error/general.html.twig',
+            };
+        }
 
         try {
             $event->setResponse(new Response($this->twig->render($view, $parameters), $statusCode));
         } catch (Error) {
-            $event->setResponse(new Response($this->twig->render('@ContaoCore/Error/error.html.twig'), 500));
+            $event->setResponse(new Response($this->twig->render('@Contao/error/general.html.twig'), 500));
         }
     }
 

--- a/core-bundle/templates/Error/backend.html.twig
+++ b/core-bundle/templates/Error/backend.html.twig
@@ -1,8 +1,0 @@
-{% extends "@Contao/error/backend.html.twig" %}
-
-{#
-    ! DEPRECATED !
-
-    The "@ContaoCore/error/backend.html.twig" template will be removed in Contao 6.
-    Use the "@Contao/error/backend.html.twig" template from the @Contao namespace instead.
-#}

--- a/core-bundle/templates/Error/error.html.twig
+++ b/core-bundle/templates/Error/error.html.twig
@@ -1,8 +1,0 @@
-{% extends "@Contao/error/general.html.twig" %}
-
-{#
-    ! DEPRECATED !
-
-    The "@ContaoCore/error/error.html.twig" template will be removed in Contao 6.
-    Use the "@Contao/error/general.html.twig" template from the @Contao namespace instead.
-#}

--- a/core-bundle/templates/Error/invalid_request_token.html.twig
+++ b/core-bundle/templates/Error/invalid_request_token.html.twig
@@ -1,8 +1,0 @@
-{% extends "@Contao/error/invalid_request_token.html.twig" %}
-
-{#
-    ! DEPRECATED !
-
-    The "@ContaoCore/error/invalid_request_token.html.twig" template will be removed in Contao 6.
-    Use the "@Contao/error/invalid_request_token.html.twig" template from the @Contao namespace instead.
-#}

--- a/core-bundle/templates/Error/missing_route_parameters.html.twig
+++ b/core-bundle/templates/Error/missing_route_parameters.html.twig
@@ -1,8 +1,0 @@
-{% extends "@Contao/error/missing_route_parameters.html.twig" %}
-
-{#
-    ! DEPRECATED !
-
-    The "@ContaoCore/error/missing_route_parameters.html.twig" template will be removed in Contao 6.
-    Use the "@Contao/error/missing_route_parameters.html.twig" template from the @Contao namespace instead.
-#}

--- a/core-bundle/templates/Error/service_unavailable.html.twig
+++ b/core-bundle/templates/Error/service_unavailable.html.twig
@@ -1,8 +1,0 @@
-{% extends "@Contao/error/service_unavailable.html.twig" %}
-
-{#
-    ! DEPRECATED !
-
-    The "@ContaoCore/error/service_unavailable.html.twig" template will be removed in Contao 6.
-    Use the "@Contao/error/service_unavailable.html.twig" template from the @Contao namespace instead.
-#}

--- a/core-bundle/tests/EventListener/PrettyErrorScreenListenerTest.php
+++ b/core-bundle/tests/EventListener/PrettyErrorScreenListenerTest.php
@@ -38,6 +38,7 @@ use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException;
 use Twig\Environment;
 use Twig\Error\Error;
+use Twig\Loader\LoaderInterface;
 
 class PrettyErrorScreenListenerTest extends TestCase
 {
@@ -51,6 +52,7 @@ class PrettyErrorScreenListenerTest extends TestCase
 
         $this->assertTrue($event->hasResponse());
         $this->assertSame(500, $event->getResponse()->getStatusCode());
+        $this->assertSame('template: @Contao/error/backend.html.twig', $event->getResponse()->getContent());
     }
 
     public function testChecksIsGrantedBeforeRenderingBackEndExceptions(): void
@@ -81,6 +83,11 @@ class PrettyErrorScreenListenerTest extends TestCase
     public function testCatchesAuthenticationCredentialsNotFoundExceptionWhenRenderingBackEndExceptions(): void
     {
         $twig = $this->createMock(Environment::class);
+        $twig
+            ->method('render')
+            ->willReturnCallback(static fn (string $template) => "template: $template")
+        ;
+
         $framework = $this->mockContaoFramework();
         $pageRegistry = $this->createMock(PageRegistry::class);
         $httpKernel = $this->createMock(HttpKernelInterface::class);
@@ -100,6 +107,7 @@ class PrettyErrorScreenListenerTest extends TestCase
 
         $this->assertTrue($event->hasResponse());
         $this->assertSame(500, $event->getResponse()->getStatusCode());
+        $this->assertSame('template: @Contao/error/general.html.twig', $event->getResponse()->getContent());
     }
 
     /**
@@ -212,6 +220,7 @@ class PrettyErrorScreenListenerTest extends TestCase
 
         $this->assertTrue($event->hasResponse());
         $this->assertSame(503, $event->getResponse()->getStatusCode());
+        $this->assertSame('template: @Contao/error/service_unavailable.html.twig', $event->getResponse()->getContent());
     }
 
     public function testDoesNotRenderExceptionsIfDisabled(): void
@@ -271,6 +280,7 @@ class PrettyErrorScreenListenerTest extends TestCase
 
         $this->assertTrue($event->hasResponse());
         $this->assertSame(409, $event->getResponse()->getStatusCode());
+        $this->assertSame('template: @Contao/error/general.html.twig', $event->getResponse()->getContent());
     }
 
     public function testRendersTheErrorScreen(): void
@@ -283,12 +293,12 @@ class PrettyErrorScreenListenerTest extends TestCase
         $twig
             ->method('render')
             ->willReturnCallback(
-                static function () use (&$count): string {
+                static function (string $template) use (&$count): string {
                     if (0 === $count++) {
                         throw new Error('foo');
                     }
 
-                    return '';
+                    return "template: $template";
                 },
             )
         ;
@@ -298,6 +308,7 @@ class PrettyErrorScreenListenerTest extends TestCase
 
         $this->assertTrue($event->hasResponse());
         $this->assertSame(500, $event->getResponse()->getStatusCode());
+        $this->assertSame('template: @Contao/error/general.html.twig', $event->getResponse()->getContent());
     }
 
     public function testDoesNothingIfTheFormatIsNotHtml(): void
@@ -374,9 +385,46 @@ class PrettyErrorScreenListenerTest extends TestCase
         $this->assertSame(500, $event->getResponse()->getStatusCode());
     }
 
+    public function testRendersBCTemplateIfExists(): void
+    {
+        $exception = new InternalServerErrorHttpException('', new InternalServerErrorException());
+        $event = $this->getResponseEvent($exception);
+
+        $loader = $this->createMock(LoaderInterface::class);
+        $loader
+            ->expects($this->once())
+            ->method('exists')
+            ->with('@ContaoCore/Error/backend.html.twig')
+            ->willReturn(true)
+        ;
+
+        $twig = $this->createMock(Environment::class);
+        $twig
+            ->method('getLoader')
+            ->willReturn($loader)
+        ;
+
+        $twig
+            ->method('render')
+            ->willReturnCallback(static fn (string $template) => "template: $template")
+        ;
+
+        $listener = $this->getListener(true, $twig);
+        $listener($event);
+
+        $this->assertSame('template: @ContaoCore/Error/backend.html.twig', $event->getResponse()->getContent());
+    }
+
     private function getListener(bool $isBackendUser = false, Environment|null $twig = null, PageModel|null $errorPage = null, HttpKernelInterface|null $httpKernel = null): PrettyErrorScreenListener
     {
-        $twig ??= $this->createMock(Environment::class);
+        if (null === $twig) {
+            $twig = $this->createMock(Environment::class);
+            $twig
+                ->method('render')
+                ->willReturnCallback(static fn (string $template) => "template: $template")
+            ;
+        }
+
         $httpKernel ??= $this->createMock(HttpKernelInterface::class);
 
         $pageFinder = $this->createMock(PageFinder::class);


### PR DESCRIPTION
Fixes https://github.com/contao/docs/issues/1549

This PR…
* drops the existing bundle templates*
* directly renders the new ones if and only if a legacy one does not exist (BC)
* adds a conditional extends tag for the legacy bundle templates layout for all error templates**.

This way you can still have a `templates/bundles/ContaoCoreBundle/Error/layout.html.twig` and/or a `templates/bundles/ContaoCoreBundle/Error/service_unavailable.html.twig` etc.

*) For now except the legacy 'layout' base template, because otherwise adjusting _just_ a child template and extending from the legacy one would not work anymore.

**) This would technically work by not specifying the second argument (the new template), because currently the old one always exists. But this is IMHO cleaner, as it allows us to drop the old layout template without breaking anything but the above use case. Plus - when we remove the BC layer - the correct name is already in there.
