### PR TITLE
Correctly set the tree root if `showRootTrails` is not enabled

### DIFF
--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -4021,9 +4021,9 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 
 		$topMostRootIds = $this->root;
 
-		if (isset($GLOBALS['TL_DCA']['tl_page']['list']['sorting']['visibleRoot']))
+		if (isset($GLOBALS['TL_DCA'][$table]['list']['sorting']['visibleRoot']))
 		{
-			$topMostRootIds = array($GLOBALS['TL_DCA']['tl_page']['list']['sorting']['visibleRoot']);
+			$topMostRootIds = array($GLOBALS['TL_DCA'][$table]['list']['sorting']['visibleRoot']);
 		}
 		elseif (!empty($this->visibleRootTrails))
 		{


### PR DESCRIPTION
Yet another fix for https://github.com/contao/contao/pull/8175 / https://github.com/contao/contao/pull/8161

Not urgent for a regular Contao installation. If a tree view does not have `showRootTrails` enabled (which is never the case in the core), `visibleRootTrails` will be empty and `root` might contain IDs that are not root pages. The tree will not be rendered in this case.

This is the case with our [folderpage](https://extensions.contao.org/?p=terminal42/contao-folderpage) extension < v3.3, because it overwrites the breadcrumb but did not implement the new `visibleRoot` filter.