### PR TITLE
Adjust the `service_unavailable` namespace for the maintenance mode

### DIFF
--- a/manager-bundle/src/Command/MaintenanceModeCommand.php
+++ b/manager-bundle/src/Command/MaintenanceModeCommand.php
@@ -78,7 +78,7 @@ class MaintenanceModeCommand extends Command
     private function enable(string $templateName, string $templateVars): void
     {
         // Change the error template namespace for backwards compatibility (see #8195)
-        if ($templateName === '@ContaoCore/Error/service_unavailable.html.twig' && !$this->twig->getLoader()->exists($templateName)) {
+        if ('@ContaoCore/Error/service_unavailable.html.twig' === $templateName && !$this->twig->getLoader()->exists($templateName)) {
             $templateName = '@Contao/error/service_unavailable.html.twig';
         }
 

--- a/manager-bundle/src/Command/MaintenanceModeCommand.php
+++ b/manager-bundle/src/Command/MaintenanceModeCommand.php
@@ -44,7 +44,7 @@ class MaintenanceModeCommand extends Command
     {
         $this
             ->addArgument('state', InputArgument::OPTIONAL, 'Use "enable" to enable and "disable" to disable the maintenance mode. If the state is already the desired one, nothing happens. You can also use "on" and "off".')
-            ->addOption('template', 't', InputOption::VALUE_REQUIRED, 'Allows to take a different Twig template name when enabling the maintenance mode.', '@ContaoCore/Error/service_unavailable.html.twig')
+            ->addOption('template', 't', InputOption::VALUE_REQUIRED, 'Allows to take a different Twig template name when enabling the maintenance mode.', '@Contao/error/service_unavailable.html.twig')
             ->addOption('templateVars', null, InputOption::VALUE_OPTIONAL, 'Add custom template variables to the Twig template when enabling the maintenance mode (provide as JSON).', '{}')
             ->addOption('format', null, InputOption::VALUE_REQUIRED, 'The output format (txt, json)', 'txt')
         ;

--- a/manager-bundle/src/Command/MaintenanceModeCommand.php
+++ b/manager-bundle/src/Command/MaintenanceModeCommand.php
@@ -77,7 +77,7 @@ class MaintenanceModeCommand extends Command
 
     private function enable(string $templateName, string $templateVars): void
     {
-        // Change the error template namespace (see #8195)
+        // Change the error template namespace for backwards compatibility (see #8195)
         if ($templateName === '@ContaoCore/Error/service_unavailable.html.twig' && !$this->twig->getLoader()->exists($templateName)) {
             $templateName = '@Contao/error/service_unavailable.html.twig';
         }

--- a/manager-bundle/src/Command/MaintenanceModeCommand.php
+++ b/manager-bundle/src/Command/MaintenanceModeCommand.php
@@ -44,7 +44,7 @@ class MaintenanceModeCommand extends Command
     {
         $this
             ->addArgument('state', InputArgument::OPTIONAL, 'Use "enable" to enable and "disable" to disable the maintenance mode. If the state is already the desired one, nothing happens. You can also use "on" and "off".')
-            ->addOption('template', 't', InputOption::VALUE_REQUIRED, 'Allows to take a different Twig template name when enabling the maintenance mode.', '@Contao/error/service_unavailable.html.twig')
+            ->addOption('template', 't', InputOption::VALUE_REQUIRED, 'Allows to take a different Twig template name when enabling the maintenance mode.', '@ContaoCore/Error/service_unavailable.html.twig')
             ->addOption('templateVars', null, InputOption::VALUE_OPTIONAL, 'Add custom template variables to the Twig template when enabling the maintenance mode (provide as JSON).', '{}')
             ->addOption('format', null, InputOption::VALUE_REQUIRED, 'The output format (txt, json)', 'txt')
         ;
@@ -77,6 +77,10 @@ class MaintenanceModeCommand extends Command
 
     private function enable(string $templateName, string $templateVars): void
     {
+        if (!$this->twig->getLoader()->exists($templateName)) {
+            $templateName = '@Contao/error/service_unavailable.html.twig';
+        }
+
         // Render the template and write it to maintenance.html
         $this->filesystem->dumpFile(
             $this->maintenanceFilePath,

--- a/manager-bundle/src/Command/MaintenanceModeCommand.php
+++ b/manager-bundle/src/Command/MaintenanceModeCommand.php
@@ -77,8 +77,9 @@ class MaintenanceModeCommand extends Command
 
     private function enable(string $templateName, string $templateVars): void
     {
-        if (!$this->twig->getLoader()->exists($templateName)) {
-            $templateName = '@Contao/error/service_unavailable.html.twig';
+        // Change the error template namespace (see #8195)
+        if (str_starts_with($templateName, '@ContaoCore/Error') && !$this->twig->getLoader()->exists($templateName)) {
+            $templateName = str_replace('@ContaoCore/Error', '@Contao/error', $templateName);
         }
 
         // Render the template and write it to maintenance.html

--- a/manager-bundle/src/Command/MaintenanceModeCommand.php
+++ b/manager-bundle/src/Command/MaintenanceModeCommand.php
@@ -78,8 +78,8 @@ class MaintenanceModeCommand extends Command
     private function enable(string $templateName, string $templateVars): void
     {
         // Change the error template namespace (see #8195)
-        if (str_starts_with($templateName, '@ContaoCore/Error') && !$this->twig->getLoader()->exists($templateName)) {
-            $templateName = str_replace('@ContaoCore/Error', '@Contao/error', $templateName);
+        if ($templateName === '@ContaoCore/Error/service_unavailable.html.twig' && !$this->twig->getLoader()->exists($templateName)) {
+            $templateName = '@Contao/error/service_unavailable.html.twig';
         }
 
         // Render the template and write it to maintenance.html

--- a/manager-bundle/tests/Command/MaintenanceModeCommandTest.php
+++ b/manager-bundle/tests/Command/MaintenanceModeCommandTest.php
@@ -173,11 +173,11 @@ class MaintenanceModeCommandTest extends ContaoTestCase
     public static function enableProvider(): iterable
     {
         yield 'Test defaults' => [
-            '@Contao/error/service_unavailable.html.twig',
+            '@ContaoCore/Error/service_unavailable.html.twig',
             [
                 'statusCode' => 503,
                 'language' => 'en',
-                'template' => '@Contao/error/service_unavailable.html.twig',
+                'template' => '@ContaoCore/Error/service_unavailable.html.twig',
                 'defaultLabels' => [],
             ],
         ];

--- a/manager-bundle/tests/Command/MaintenanceModeCommandTest.php
+++ b/manager-bundle/tests/Command/MaintenanceModeCommandTest.php
@@ -37,24 +37,18 @@ class MaintenanceModeCommandTest extends ContaoTestCase
      */
     public function testEnable(string $expectedTemplateName, array $expectedTemplateVars, string|null $customTemplateName = null, string|null $customTemplateVars = null): void
     {
+        $loader = $this->createMock(LoaderInterface::class);
+        $loader
+            ->expects('@ContaoCore/Error/service_unavailable.html.twig' === $expectedTemplateName ? $this->once() : $this->never())
+            ->method('exists')
+            ->willReturn(true)
+        ;
+
         $twig = $this->mockEnvironment();
-
-        $serviceUnavailable = '@ContaoCore/Error/service_unavailable.html.twig';
-
-        if ($expectedTemplateName === $serviceUnavailable) {
-            $loader = $this->createMock(LoaderInterface::class);
-            $loader
-                ->expects($this->once())
-                ->method('exists')
-                ->with($serviceUnavailable)
-                ->willReturn(true)
-            ;
-
-            $twig
-                ->method('getLoader')
-                ->willReturn($loader)
-            ;
-        }
+        $twig
+            ->method('getLoader')
+            ->willReturn($loader)
+        ;
 
         $twig
             ->expects($this->once())

--- a/manager-bundle/tests/Command/MaintenanceModeCommandTest.php
+++ b/manager-bundle/tests/Command/MaintenanceModeCommandTest.php
@@ -173,11 +173,11 @@ class MaintenanceModeCommandTest extends ContaoTestCase
     public static function enableProvider(): iterable
     {
         yield 'Test defaults' => [
-            '@ContaoCore/Error/service_unavailable.html.twig',
+            '@Contao/error/service_unavailable.html.twig',
             [
                 'statusCode' => 503,
                 'language' => 'en',
-                'template' => '@ContaoCore/Error/service_unavailable.html.twig',
+                'template' => '@Contao/error/service_unavailable.html.twig',
                 'defaultLabels' => [],
             ],
         ];

--- a/manager-bundle/tests/Command/MaintenanceModeCommandTest.php
+++ b/manager-bundle/tests/Command/MaintenanceModeCommandTest.php
@@ -79,23 +79,6 @@ class MaintenanceModeCommandTest extends ContaoTestCase
         $this->assertStringContainsString('[OK] Maintenance mode enabled', $commandTester->getDisplay(true));
     }
 
-    private function mockTwigLoader(Environment&MockObject $twig, string $expectedTemplateName): void
-    {
-        $serviceUnavailable = '@ContaoCore/Error/service_unavailable.html.twig';
-
-        if ($expectedTemplateName === $serviceUnavailable) {
-            $loader = $this->createMock(LoaderInterface::class);
-            $loader
-                ->expects($this->once())
-                ->method('exists')
-                ->with('@ContaoCore/Error/service_unavailable.html.twig')
-                ->willReturn(true)
-            ;
-
-            $twig->method('getLoader')->willReturn($loader);
-        }
-    }
-
     public function testDisable(): void
     {
         $filesystem = $this->mockFilesystem();
@@ -117,6 +100,26 @@ class MaintenanceModeCommandTest extends ContaoTestCase
         $commandTester->execute(['state' => 'disable']);
 
         $this->assertStringContainsString('[OK] Maintenance mode disabled', $commandTester->getDisplay(true));
+    }
+
+    private function mockTwigLoader(Environment&MockObject $twig, string $expectedTemplateName): void
+    {
+        $serviceUnavailable = '@ContaoCore/Error/service_unavailable.html.twig';
+
+        if ($expectedTemplateName === $serviceUnavailable) {
+            $loader = $this->createMock(LoaderInterface::class);
+            $loader
+                ->expects($this->once())
+                ->method('exists')
+                ->with('@ContaoCore/Error/service_unavailable.html.twig')
+                ->willReturn(true)
+            ;
+
+            $twig
+                ->method('getLoader')
+                ->willReturn($loader)
+            ;
+        }
     }
 
     public function testOutputIfEnabled(): void

--- a/manager-bundle/tests/Command/MaintenanceModeCommandTest.php
+++ b/manager-bundle/tests/Command/MaintenanceModeCommandTest.php
@@ -102,26 +102,6 @@ class MaintenanceModeCommandTest extends ContaoTestCase
         $this->assertStringContainsString('[OK] Maintenance mode disabled', $commandTester->getDisplay(true));
     }
 
-    private function mockTwigLoader(Environment&MockObject $twig, string $expectedTemplateName): void
-    {
-        $serviceUnavailable = '@ContaoCore/Error/service_unavailable.html.twig';
-
-        if ($expectedTemplateName === $serviceUnavailable) {
-            $loader = $this->createMock(LoaderInterface::class);
-            $loader
-                ->expects($this->once())
-                ->method('exists')
-                ->with('@ContaoCore/Error/service_unavailable.html.twig')
-                ->willReturn(true)
-            ;
-
-            $twig
-                ->method('getLoader')
-                ->willReturn($loader)
-            ;
-        }
-    }
-
     public function testOutputIfEnabled(): void
     {
         $filesystem = $this->mockFilesystem();
@@ -229,6 +209,26 @@ class MaintenanceModeCommandTest extends ContaoTestCase
             '@CustomBundle/maintenance.html.twig',
             '{"language":"de", "foo": "bar"}',
         ];
+    }
+
+    private function mockTwigLoader(Environment&MockObject $twig, string $expectedTemplateName): void
+    {
+        $serviceUnavailable = '@ContaoCore/Error/service_unavailable.html.twig';
+
+        if ($expectedTemplateName === $serviceUnavailable) {
+            $loader = $this->createMock(LoaderInterface::class);
+            $loader
+                ->expects($this->once())
+                ->method('exists')
+                ->with('@ContaoCore/Error/service_unavailable.html.twig')
+                ->willReturn(true)
+            ;
+
+            $twig
+                ->method('getLoader')
+                ->willReturn($loader)
+            ;
+        }
     }
 
     private function mockFilesystem(): Filesystem&MockObject

--- a/manager-bundle/tests/Command/MaintenanceModeCommandTest.php
+++ b/manager-bundle/tests/Command/MaintenanceModeCommandTest.php
@@ -39,7 +39,22 @@ class MaintenanceModeCommandTest extends ContaoTestCase
     {
         $twig = $this->mockEnvironment();
 
-        $this->mockTwigLoader($twig, $expectedTemplateName);
+        $serviceUnavailable = '@ContaoCore/Error/service_unavailable.html.twig';
+
+        if ($expectedTemplateName === $serviceUnavailable) {
+            $loader = $this->createMock(LoaderInterface::class);
+            $loader
+                ->expects($this->once())
+                ->method('exists')
+                ->with($serviceUnavailable)
+                ->willReturn(true)
+            ;
+
+            $twig
+                ->method('getLoader')
+                ->willReturn($loader)
+            ;
+        }
 
         $twig
             ->expects($this->once())
@@ -209,26 +224,6 @@ class MaintenanceModeCommandTest extends ContaoTestCase
             '@CustomBundle/maintenance.html.twig',
             '{"language":"de", "foo": "bar"}',
         ];
-    }
-
-    private function mockTwigLoader(Environment&MockObject $twig, string $expectedTemplateName): void
-    {
-        $serviceUnavailable = '@ContaoCore/Error/service_unavailable.html.twig';
-
-        if ($expectedTemplateName === $serviceUnavailable) {
-            $loader = $this->createMock(LoaderInterface::class);
-            $loader
-                ->expects($this->once())
-                ->method('exists')
-                ->with('@ContaoCore/Error/service_unavailable.html.twig')
-                ->willReturn(true)
-            ;
-
-            $twig
-                ->method('getLoader')
-                ->willReturn($loader)
-            ;
-        }
     }
 
     private function mockFilesystem(): Filesystem&MockObject


### PR DESCRIPTION
Fixes #8194

Regression from #8185 that did change the namespaces for the error templates.

/cc @m-vo 
