### PR TITLE
Disable pasting data images by default in tinyMCE

### DIFF
--- a/core-bundle/contao/templates/backend/be_tinyMCE.html5
+++ b/core-bundle/contao/templates/backend/be_tinyMCE.html5
@@ -70,6 +70,10 @@ window.tinymce && tinymce.init({
     contextmenu: false,
   <?php $this->endblock(); ?>
 
+  <?php $this->block('paste_data_images'); ?>
+    paste_data_images: false,
+  <?php $this->endblock(); ?>
+
   <?php $this->block('cache_suffix'); ?>
     cache_suffix: '?v=<?= $this->assetVersion('js/tinymce.min.js', 'contao-components/tinymce4') ?>',
   <?php $this->endblock(); ?>


### PR DESCRIPTION
Currently, you can just drag n' drop any kind of image in tinyMCE (easy to reproduce on demo) which will cause tinyMCE to store those images as base64 encoded binary data.
This creates huge HTML responses, which are a problem for HTTP caching as well as search indexing (https://github.com/contao/contao/issues/8197) and also are just nonsense because if you place such content e.g. in a footer element, a visitor would re-download the data over and over again instead of having it properly referred to using e.g. `<img src="files...">`.

I think we should disable this feature by default. If you want this, you should explicitly enable it, not the other way around.