### PR TITLE
Prevent useless database connections

### DIFF
--- a/core-bundle/config/listener.yaml
+++ b/core-bundle/config/listener.yaml
@@ -550,6 +550,7 @@ services:
         class: Contao\CoreBundle\Messenger\EventListener\MessageListener
         arguments:
             - '@monolog.logger.contao.error'
+            - '@database_connection'
 
     contao.twig.loader.auto_refresh_template_hierarchy_listener:
         class: Contao\CoreBundle\Twig\Loader\AutoRefreshTemplateHierarchyListener

--- a/core-bundle/src/Command/SuperviseWorkersCommand.php
+++ b/core-bundle/src/Command/SuperviseWorkersCommand.php
@@ -53,7 +53,8 @@ class SuperviseWorkersCommand extends Command
             $this->supervisor = $this->supervisor->withCommand($this->createCommandForWorker('worker-'.($k + 1), $worker));
         }
 
-        // Close database connection if it was opened by some other service to free connections
+        // Close the database connection if it was opened by some other service to
+        // free connections.
         $this->connection->close();
 
         $io->info('Starting to supervise workers for a minute.');

--- a/core-bundle/src/Command/SuperviseWorkersCommand.php
+++ b/core-bundle/src/Command/SuperviseWorkersCommand.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Command;
 
 use Contao\CoreBundle\Util\ProcessUtil;
+use Doctrine\DBAL\Connection;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -37,6 +38,7 @@ class SuperviseWorkersCommand extends Command
     public function __construct(
         private readonly ContainerInterface $messengerTransportLocator,
         private readonly ProcessUtil $processUtil,
+        private readonly Connection $connection,
         private Supervisor $supervisor,
         private readonly array $workers,
     ) {
@@ -50,6 +52,9 @@ class SuperviseWorkersCommand extends Command
         foreach ($this->workers as $k => $worker) {
             $this->supervisor = $this->supervisor->withCommand($this->createCommandForWorker('worker-'.($k + 1), $worker));
         }
+
+        // Close database connection if it was opened by some other service to free connections
+        $this->connection->close();
 
         $io->info('Starting to supervise workers for a minute.');
         $this->supervisor->supervise();

--- a/core-bundle/src/Cron/Cron.php
+++ b/core-bundle/src/Cron/Cron.php
@@ -232,7 +232,7 @@ class Cron
         }
 
         if ($promises) {
-            // Close DB connection to free them until async promises have completed.
+            // Close the DB connection until async promises have completed.
             $entityManager->getConnection()->close();
 
             Utils::settle($promises)->wait();

--- a/core-bundle/src/Cron/Cron.php
+++ b/core-bundle/src/Cron/Cron.php
@@ -184,13 +184,13 @@ class Cron
             $entityManager->flush();
         };
 
-        $this->executeCrons($cronJobsToBeRun, $scope, $onSkip);
+        $this->executeCrons($cronJobsToBeRun, $scope, $entityManager, $onSkip);
     }
 
     /**
      * @param array<CronJob> $crons
      */
-    private function executeCrons(array $crons, string $scope, \Closure $onSkip): void
+    private function executeCrons(array $crons, string $scope, EntityManagerInterface $entityManager, \Closure $onSkip): void
     {
         $promises = [];
         $exception = null;
@@ -232,6 +232,9 @@ class Cron
         }
 
         if ($promises) {
+            // Close DB connection to free them until async promises have completed.
+            $entityManager->getConnection()->close();
+
             Utils::settle($promises)->wait();
         }
 

--- a/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
+++ b/core-bundle/src/DependencyInjection/ContaoCoreExtension.php
@@ -272,8 +272,8 @@ class ContaoCoreExtension extends Extension implements PrependExtensionInterface
             $supervisor->addArgument('%kernel.cache_dir%/worker-supervisor');
 
             $command = $container->getDefinition('contao.command.supervise_workers');
-            $command->setArgument(2, $supervisor);
-            $command->setArgument(3, $config['messenger']['workers']);
+            $command->setArgument('$supervisor', $supervisor);
+            $command->setArgument('$workers', $config['messenger']['workers']);
         }
 
         // No workers defined -> remove our cron job and the command

--- a/core-bundle/src/Messenger/EventListener/MessageListener.php
+++ b/core-bundle/src/Messenger/EventListener/MessageListener.php
@@ -33,7 +33,7 @@ class MessageListener
             return;
         }
 
-        // Close database connection when the worker is idle (#8199)
+        // Close the database connection when the worker is idle (see #8199)
         $this->connection->close();
     }
 

--- a/core-bundle/src/Messenger/EventListener/MessageListener.php
+++ b/core-bundle/src/Messenger/EventListener/MessageListener.php
@@ -31,9 +31,7 @@ class MessageListener
             return;
         }
 
-        // In case Doctrine is used as message broker, we want to close the connection when
-        // the worker is idle. Actually, this also seems useful when Doctrine is not used
-        // as message broker anyway to prevent dangling connections.
+        // Close database connection when the worker is idle (#8199)
         $this->connection->close();
     }
 

--- a/core-bundle/src/Messenger/EventListener/MessageListener.php
+++ b/core-bundle/src/Messenger/EventListener/MessageListener.php
@@ -20,8 +20,10 @@ use Symfony\Component\Messenger\Event\WorkerRunningEvent;
 
 class MessageListener
 {
-    public function __construct(private readonly LoggerInterface $logger, private readonly Connection $connection)
-    {
+    public function __construct(
+        private readonly LoggerInterface $logger,
+        private readonly Connection $connection
+    ) {
     }
 
     #[AsEventListener]

--- a/core-bundle/src/Messenger/EventListener/MessageListener.php
+++ b/core-bundle/src/Messenger/EventListener/MessageListener.php
@@ -22,7 +22,7 @@ class MessageListener
 {
     public function __construct(
         private readonly LoggerInterface $logger,
-        private readonly Connection $connection
+        private readonly Connection $connection,
     ) {
     }
 

--- a/core-bundle/tests/Command/SuperviseWorkersCommandTest.php
+++ b/core-bundle/tests/Command/SuperviseWorkersCommandTest.php
@@ -15,6 +15,7 @@ namespace Contao\CoreBundle\Tests\Command;
 use Contao\CoreBundle\Command\SuperviseWorkersCommand;
 use Contao\CoreBundle\Tests\TestCase;
 use Contao\CoreBundle\Util\ProcessUtil;
+use Doctrine\DBAL\Connection;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\Messenger\Transport\Receiver\MessageCountAwareInterface;
@@ -63,9 +64,16 @@ class SuperviseWorkersCommandTest extends TestCase
             )
         ;
 
+        $connection = $this->createMock(Connection::class);
+        $connection
+            ->expects($this->once())
+            ->method('close')
+        ;
+
         $command = new SuperviseWorkersCommand(
             $messengerTransportLocator,
             $processUtil,
+            $connection,
             $supervisor,
             $this->getWorkers($desiredSize, $max, $min),
         );

--- a/core-bundle/tests/Cron/CronTest.php
+++ b/core-bundle/tests/Cron/CronTest.php
@@ -528,7 +528,7 @@ class CronTest extends TestCase
 
         $cron = new Cron(
             static fn () => $repository,
-            fn () =>$this->createEntityManagerMock(false),
+            fn () => $this->createEntityManagerMock(false),
             $this->createMock(CacheItemPoolInterface::class),
         );
 
@@ -553,7 +553,8 @@ class CronTest extends TestCase
         $entityManager = $this->createMock(EntityManagerInterface::class);
         $entityManager
             ->method('getConnection')
-            ->willReturn($connection);
+            ->willReturn($connection)
+        ;
 
         return $entityManager;
     }

--- a/core-bundle/tests/Cron/CronTest.php
+++ b/core-bundle/tests/Cron/CronTest.php
@@ -19,9 +19,11 @@ use Contao\CoreBundle\Fixtures\Cron\TestCronJob;
 use Contao\CoreBundle\Fixtures\Cron\TestInvokableCronJob;
 use Contao\CoreBundle\Repository\CronJobRepository;
 use Contao\CoreBundle\Tests\TestCase;
+use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver\Exception as DriverException;
 use Doctrine\DBAL\Exception\LockWaitTimeoutException;
 use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Cache\CacheItemPoolInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
@@ -38,7 +40,7 @@ class CronTest extends TestCase
 
         $cron = new Cron(
             fn () => $this->createMock(CronJobRepository::class),
-            fn () => $this->createMock(EntityManagerInterface::class),
+            fn () => $this->createEntityManagerMock(false),
             $this->createMock(CacheItemPoolInterface::class),
         );
 
@@ -56,7 +58,7 @@ class CronTest extends TestCase
 
         $cron = new Cron(
             fn () => $this->createMock(CronJobRepository::class),
-            fn () => $this->createMock(EntityManagerInterface::class),
+            fn () => $this->createEntityManagerMock(false),
             $this->createMock(CacheItemPoolInterface::class),
         );
 
@@ -94,7 +96,7 @@ class CronTest extends TestCase
 
         $cron = new Cron(
             fn () => $this->createMock(CronJobRepository::class),
-            fn () => $this->createMock(EntityManagerInterface::class),
+            fn () => $this->createEntityManagerMock(false),
             $this->createMock(CacheItemPoolInterface::class),
             $logger,
         );
@@ -141,7 +143,7 @@ class CronTest extends TestCase
             ->method('onHourly')
         ;
 
-        $manager = $this->createMock(EntityManagerInterface::class);
+        $manager = $this->createEntityManagerMock(false);
         $manager
             ->expects($this->once())
             ->method('flush')
@@ -168,7 +170,7 @@ class CronTest extends TestCase
 
         $cron = new Cron(
             fn () => $this->createMock(CronJobRepository::class),
-            fn () => $this->createMock(EntityManagerInterface::class),
+            fn () => $this->createEntityManagerMock(false),
             $this->createMock(CacheItemPoolInterface::class),
         );
 
@@ -180,7 +182,7 @@ class CronTest extends TestCase
     {
         $cron = new Cron(
             fn () => $this->createMock(CronJobRepository::class),
-            fn () => $this->createMock(EntityManagerInterface::class),
+            fn () => $this->createEntityManagerMock(false),
             $this->createMock(CacheItemPoolInterface::class),
         );
 
@@ -251,7 +253,7 @@ class CronTest extends TestCase
 
         $cron = new Cron(
             static fn () => $repository,
-            fn () => $this->createMock(EntityManagerInterface::class),
+            fn () => $this->createEntityManagerMock(false),
             $this->createMock(CacheItemPoolInterface::class),
         );
 
@@ -298,7 +300,7 @@ class CronTest extends TestCase
 
         $cron = new Cron(
             static fn () => $repository,
-            fn () => $this->createMock(EntityManagerInterface::class),
+            fn () => $this->createEntityManagerMock(false),
             $this->createMock(CacheItemPoolInterface::class),
         );
 
@@ -351,7 +353,7 @@ class CronTest extends TestCase
 
         $cron = new Cron(
             static fn () => $repository,
-            fn () => $this->createMock(EntityManagerInterface::class),
+            fn () => $this->createEntityManagerMock(true),
             $cache,
             $logger,
         );
@@ -402,7 +404,7 @@ class CronTest extends TestCase
 
         $cron = new Cron(
             static fn () => $repository,
-            fn () => $this->createMock(EntityManagerInterface::class),
+            fn () => $this->createEntityManagerMock(false),
             $cache,
         );
 
@@ -444,7 +446,7 @@ class CronTest extends TestCase
 
         $cronjob = new TestCronJob();
 
-        $manager = $this->createMock(EntityManagerInterface::class);
+        $manager = $this->createEntityManagerMock(false);
         $manager
             ->expects($this->exactly(2))
             ->method('flush')
@@ -494,7 +496,7 @@ class CronTest extends TestCase
 
         $cronjob = new TestCronJob();
 
-        $manager = $this->createMock(EntityManagerInterface::class);
+        $manager = $this->createEntityManagerMock(true);
         $manager
             ->expects($this->exactly(2))
             ->method('flush')
@@ -526,7 +528,7 @@ class CronTest extends TestCase
 
         $cron = new Cron(
             static fn () => $repository,
-            fn () => $this->createMock(EntityManagerInterface::class),
+            fn () =>$this->createEntityManagerMock(false),
             $this->createMock(CacheItemPoolInterface::class),
         );
 
@@ -538,5 +540,21 @@ class CronTest extends TestCase
 
         $cron->addCronJob(new CronJob($cronjob, '@hourly', 'onHourly'));
         $cron->run(Cron::SCOPE_CLI);
+    }
+
+    private function createEntityManagerMock(bool $expectsClose): MockObject&EntityManagerInterface
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection
+            ->expects($expectsClose ? $this->once() : $this->never())
+            ->method('close')
+        ;
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager
+            ->method('getConnection')
+            ->willReturn($connection);
+
+        return $entityManager;
     }
 }


### PR DESCRIPTION
Attempt to fix https://github.com/contao/contao/issues/8199.
Reduced the 6 connections that are constantly kept open to, well 0 if the queue is empty.