### PR TITLE
Skip cron jobs in maintenance mode

### DIFF
--- a/manager-bundle/skeleton/bin/console
+++ b/manager-bundle/skeleton/bin/console
@@ -19,6 +19,15 @@ set_time_limit(0);
 @ini_set('zlib.output_compression', '0');
 @ini_set('display_errors', '0');
 
+// System maintenance mode comes first as it has to work even if the vendor directory does not exist
+if (
+    'contao:cron' === ($_SERVER['argv'][1] ?? null)
+    && file_exists(__DIR__.'/../var/maintenance.html')
+) {
+    echo 'Contao maintenance mode is enabled, skipping cron jobs.';
+    exit(-1);
+}
+
 require __DIR__.'/../vendor/autoload.php';
 
 $input = new ArgvInput();

--- a/manager-bundle/skeleton/bin/console
+++ b/manager-bundle/skeleton/bin/console
@@ -24,8 +24,7 @@ if (
     'contao:cron' === ($_SERVER['argv'][1] ?? null)
     && file_exists(__DIR__.'/../var/maintenance.html')
 ) {
-    echo 'Contao maintenance mode is enabled, skipping cron jobs.';
-    exit(-1);
+    exit;
 }
 
 require __DIR__.'/../vendor/autoload.php';

--- a/manager-bundle/skeleton/bin/console
+++ b/manager-bundle/skeleton/bin/console
@@ -20,10 +20,7 @@ set_time_limit(0);
 @ini_set('display_errors', '0');
 
 // System maintenance mode comes first as it has to work even if the vendor directory does not exist
-if (
-    'contao:cron' === ($_SERVER['argv'][1] ?? null)
-    && file_exists(__DIR__.'/../var/maintenance.html')
-) {
+if ('contao:cron' === ($_SERVER['argv'][1] ?? null) && file_exists(__DIR__.'/../var/maintenance.html')) {
     exit;
 }
 


### PR DESCRIPTION
I often have cron jobs failing while updating a Contao installation (through trakked.io or the Contao Manager). Even though the maintenance mode is enabled, the minutely cron job still tries to run.

I'm not sure if we want to generate a message at all. It could be helpful for debugging, but it would probably generate a notification mail for cronjob runs if you have error mailing enabled.