### PR TITLE
Copy the session in the DCA request switcher

### DIFF
--- a/core-bundle/config/services.yaml
+++ b/core-bundle/config/services.yaml
@@ -217,7 +217,6 @@ services:
         public: true
         arguments:
             - '@contao.framework'
-            - '@request_stack'
             - '@security.helper'
             - '@router'
             - '@contao.translation.translator'


### PR DESCRIPTION
Fixes

```
Symfony\Component\HttpFoundation\Exception\SessionNotFoundException:
There is currently no session available.

  at vendor/symfony/http-foundation/RequestStack.php:115
  at Symfony\Component\HttpFoundation\RequestStack->getSession()
     (vendor/symfony/security-core/Authentication/Token/Storage/UsageTrackingTokenStorage.php:74)
…
  at Contao\CoreBundle\DataContainer\DcaRequestSwitcher->runWithRequest()
     (/var/www/html/bundle-dev/contao/master/core-bundle/src/DataContainer/DcaUrlAnalyzer.php:89)
  at Contao\CoreBundle\DataContainer\DcaUrlAnalyzer->getViewUrl()
     (/var/www/html/bundle-dev/contao/master/core-bundle/src/Search/Backend/Provider/TableDataContainerProvider.php:107)
…
```