### PR TITLE
Add a missing database connection argument

### DIFF
--- a/core-bundle/config/commands.yaml
+++ b/core-bundle/config/commands.yaml
@@ -109,6 +109,7 @@ services:
         arguments:
             - '@messenger.receiver_locator'
             - '@contao.process_util'
+            - '@database_connection'
             - ~
             - ~
 


### PR DESCRIPTION
Follow-up to #8201, fixes:

```
Contao\CoreBundle\Command\SuperviseWorkersCommand::__construct(): Argument #3 ($connection) must be of type Doctrine\DBAL\Connection, null given, called in var\cache\dev\Container1c5jDfM\getContao_Command_SuperviseWorkersService.php on line 26
```