### PR TITLE
Fix rendering a wrong template in the back end fallback route

### DIFF
--- a/core-bundle/src/Controller/BackendController.php
+++ b/core-bundle/src/Controller/BackendController.php
@@ -160,8 +160,9 @@ class BackendController extends AbstractController
     public function backendFallback(): Response
     {
         // Backwards compatibility: render the legacy bundle template if it exists
-        $template = $this->container->get('twig')->getLoader()->exists('@ContaoCore/Error/backend.html.twig') ?
-            '@ContaoCore/Error/backend.html.twig' : '@Contao/error/backend.html.twig';
+        $template = $this->container->get('twig')->getLoader()->exists('@ContaoCore/Error/backend.html.twig')
+            ? '@ContaoCore/Error/backend.html.twig'
+            : '@Contao/error/backend.html.twig';
 
         return $this->render(
             $template,

--- a/core-bundle/src/Controller/BackendController.php
+++ b/core-bundle/src/Controller/BackendController.php
@@ -159,13 +159,17 @@ class BackendController extends AbstractController
     #[Route('/{parameters}', name: 'contao_backend_fallback', requirements: ['parameters' => '.*'], defaults: ['_store_referrer' => false], priority: -1000)]
     public function backendFallback(): Response
     {
+        // Backwards compatibility: render the legacy bundle template if it exists
+        $template = $this->container->get('twig')->getLoader()->exists('@ContaoCore/Error/backend.html.twig') ?
+            '@ContaoCore/Error/backend.html.twig' : '@Contao/error/backend.html.twig';
+
         return $this->render(
-            '@ContaoCore/Error/backend.html.twig',
+            $template,
             [
                 'language' => 'en',
                 'statusName' => 'Page Not Found',
                 'exception' => 'The requested page does not exist.',
-                'template' => '@ContaoCore/Error/backend.html.twig',
+                'template' => $template,
             ],
             new Response('', 404),
         );

--- a/core-bundle/src/Controller/BackendPreviewSwitchController.php
+++ b/core-bundle/src/Controller/BackendPreviewSwitchController.php
@@ -97,8 +97,9 @@ class BackendPreviewSwitchController
         }
 
         // Backwards compatibility: render the legacy bundle template if it exists
-        $template = $this->twig->getLoader()->exists('@ContaoCore/Frontend/preview_toolbar_base.html.twig') ?
-            '@ContaoCore/Frontend/preview_toolbar_base.html.twig' : '@Contao/frontend_preview/toolbar.html.twig';
+        $template = $this->twig->getLoader()->exists('@ContaoCore/Frontend/preview_toolbar_base.html.twig')
+            ? '@ContaoCore/Frontend/preview_toolbar_base.html.twig'
+            : '@Contao/frontend_preview/toolbar.html.twig';
 
         try {
             return $this->twig->render($template, [

--- a/core-bundle/src/Controller/BackendPreviewSwitchController.php
+++ b/core-bundle/src/Controller/BackendPreviewSwitchController.php
@@ -96,8 +96,12 @@ class BackendPreviewSwitchController
             ]);
         }
 
+        // Backwards compatibility: render the legacy bundle template if it exists
+        $template = $this->twig->getLoader()->exists('@ContaoCore/Frontend/preview_toolbar_base.html.twig') ?
+            '@ContaoCore/Frontend/preview_toolbar_base.html.twig' : '@Contao/frontend_preview/toolbar.html.twig';
+
         try {
-            return $this->twig->render('@ContaoCore/Frontend/preview_toolbar_base.html.twig', [
+            return $this->twig->render($template, [
                 'request_token' => $this->tokenManager->getDefaultTokenValue(),
                 'action' => $this->router->generate('contao_backend_switch'),
                 'canSwitchUser' => $canSwitchUser,

--- a/core-bundle/src/EventListener/PreviewToolbarListener.php
+++ b/core-bundle/src/EventListener/PreviewToolbarListener.php
@@ -90,8 +90,9 @@ class PreviewToolbarListener
         $cspHandler = $this->createCspHandler($response);
 
         // Backwards compatibility: render the legacy bundle template if it exists
-        $template = $this->twig->getLoader()->exists('@ContaoCore/Frontend/preview_toolbar_base_js.html.twig') ?
-            '@ContaoCore/Frontend/preview_toolbar_base_js.html.twig' : '@Contao/frontend_preview/toolbar_js.html.twig';
+        $template = $this->twig->getLoader()->exists('@ContaoCore/Frontend/preview_toolbar_base_js.html.twig')
+            ? '@ContaoCore/Frontend/preview_toolbar_base_js.html.twig'
+            : '@Contao/frontend_preview/toolbar_js.html.twig';
 
         $toolbar = $this->twig->render($template, [
             'action' => $this->router->generate('contao_backend_switch'),

--- a/core-bundle/src/EventListener/PreviewToolbarListener.php
+++ b/core-bundle/src/EventListener/PreviewToolbarListener.php
@@ -89,7 +89,11 @@ class PreviewToolbarListener
 
         $cspHandler = $this->createCspHandler($response);
 
-        $toolbar = $this->twig->render('@ContaoCore/Frontend/preview_toolbar_base_js.html.twig', [
+        // Backwards compatibility: render the legacy bundle template if it exists
+        $template = $this->twig->getLoader()->exists('@ContaoCore/Frontend/preview_toolbar_base_js.html.twig') ?
+            '@ContaoCore/Frontend/preview_toolbar_base_js.html.twig' : '@Contao/frontend_preview/toolbar_js.html.twig';
+
+        $toolbar = $this->twig->render($template, [
             'action' => $this->router->generate('contao_backend_switch'),
             'request' => $request,
             'preview_script' => $this->previewScript,

--- a/core-bundle/templates/Frontend/preview_toolbar_base.html.twig
+++ b/core-bundle/templates/Frontend/preview_toolbar_base.html.twig
@@ -1,8 +1,0 @@
-{% extends "@Contao/frontend_preview/toolbar.html.twig" %}
-
-{#
-    ! DEPRECATED !
-
-    The "@ContaoCore/Frontend/preview_toolbar_base.html.twig" template will be removed in Contao 6.
-    Use the "@Contao/frontend_preview/toolbar.html.twig" template from the @Contao namespace instead.
-#}

--- a/core-bundle/templates/Frontend/preview_toolbar_base_js.html.twig
+++ b/core-bundle/templates/Frontend/preview_toolbar_base_js.html.twig
@@ -1,8 +1,0 @@
-{% extends "@Contao/frontend_preview/toolbar_js.html.twig" %}
-
-{#
-    ! DEPRECATED !
-
-    The "@ContaoCore/Frontend/preview_toolbar_base_js.html.twig" template will be removed in Contao 6.
-    Use the "@Contao/frontend_preview/toolbar_js.html.twig" template from the @Contao namespace instead.
-#}


### PR DESCRIPTION
This is a followup-PR to #8185.

There was still the wrong template rendered in the `BackendController#backendFallback()`. I now added the same fallback as we did in the `PrettyErrorScreenListener` and for the maintenance mode.

With these changes, there were only the old preview toolbar templates left - I therefore also removed them and did the same there, so that the behavior is now consistent for all error templates. As the preview toolbar templates don't have any blocks, extending was not an option, so it is IMHO safe to do so.