### PR TITLE
Do not require CSRF token checks on preflight requests

### DIFF
--- a/core-bundle/src/EventListener/RequestTokenListener.php
+++ b/core-bundle/src/EventListener/RequestTokenListener.php
@@ -81,7 +81,7 @@ class RequestTokenListener
         $contentType = HeaderUtils::split($request->headers->get('content-type'), ';')[0] ?? '';
 
         return \in_array(
-            $contentType,
+            strtolower($contentType),
             [
                 'application/x-www-form-urlencoded',
                 'multipart/form-data',

--- a/core-bundle/src/EventListener/RequestTokenListener.php
+++ b/core-bundle/src/EventListener/RequestTokenListener.php
@@ -52,7 +52,7 @@ class RequestTokenListener
         // Only check the request token if
         // - the request is a POST request,
         // - the request is not an Ajax request,
-        // - the request is not a simple CORS Content-Type that does not require a preflight request,
+        // - the request is a CORS Content-Type that requires a preflight request,
         // - the _token_check attribute is not false,
         // - the _token_check attribute is true or the request is a Contao request and
         // - the request has cookies, an authenticated user or the session has been started.

--- a/core-bundle/src/EventListener/RequestTokenListener.php
+++ b/core-bundle/src/EventListener/RequestTokenListener.php
@@ -51,12 +51,14 @@ class RequestTokenListener
         // Only check the request token if
         // - the request is a POST request,
         // - the request is not an Ajax request,
+        // - the request is not a simple CORS Content-Type that does not require a preflight request,
         // - the _token_check attribute is not false,
         // - the _token_check attribute is true or the request is a Contao request and
         // - the request has cookies, an authenticated user or the session has been started.
         if (
             'POST' !== $request->getRealMethod()
             || $request->isXmlHttpRequest()
+            || !$this->isSimpleCorsRequest($request)
             || false === $request->attributes->get('_token_check')
             || $this->csrfTokenManager->canSkipTokenValidation($request, $this->csrfCookiePrefix.$this->csrfTokenName)
             || (true !== $request->attributes->get('_token_check') && !$this->scopeMatcher->isContaoRequest($request))
@@ -88,5 +90,18 @@ class RequestTokenListener
         }
 
         return null;
+    }
+
+    private function isSimpleCorsRequest(Request $request): bool
+    {
+        return \in_array(
+            $request->headers->get('content-type'),
+            [
+                'application/x-www-form-urlencoded',
+                'multipart/form-data',
+                'text/plain',
+            ],
+            true,
+        );
     }
 }

--- a/core-bundle/tests/EventListener/RequestTokenListenerTest.php
+++ b/core-bundle/tests/EventListener/RequestTokenListenerTest.php
@@ -356,6 +356,7 @@ class RequestTokenListenerTest extends TestCase
             'text plain with ISO' => ['text/plain; charset=ISO-8859-1'],
             'text plain flowed' => ['text/plain; format=flowed'],
             'text plain UTF-8 flowed' => ['text/plain; charset=UTF-8; format=flowed'],
+            'text plain uppercase' => ['TEXT/PLAIN'],
         ];
     }
 

--- a/core-bundle/tests/EventListener/RequestTokenListenerTest.php
+++ b/core-bundle/tests/EventListener/RequestTokenListenerTest.php
@@ -334,6 +334,31 @@ class RequestTokenListenerTest extends TestCase
         $listener($event);
     }
 
+    #[DataProvider('simpleCorsRequestContentTypeProvider')]
+    public function testSimpleCorsRequest(string $contentType): void
+    {
+        $request = $this->createPostRequest($contentType);
+
+        $this->assertTrue(RequestTokenListener::isSimpleCorsRequest($request));
+    }
+
+    public static function simpleCorsRequestContentTypeProvider(): array
+    {
+        return [
+            'urlencoded basic' => ['application/x-www-form-urlencoded'],
+            'urlencoded with UTF-8' => ['application/x-www-form-urlencoded; charset=UTF-8'],
+            'urlencoded with ISO' => ['application/x-www-form-urlencoded; charset=ISO-8859-1'],
+            'multipart basic' => ['multipart/form-data'],
+            'multipart with WebKit boundary' => ['multipart/form-data; boundary=----WebKitFormBoundary7MA4YWxkTrZu0gW'],
+            'multipart with charset and custom boundary' => ['multipart/form-data; charset=UTF-8; boundary=----MyCustomBoundary12345'],
+            'text plain basic' => ['text/plain'],
+            'text plain with UTF-8' => ['text/plain; charset=UTF-8'],
+            'text plain with ISO' => ['text/plain; charset=ISO-8859-1'],
+            'text plain flowed' => ['text/plain; format=flowed'],
+            'text plain UTF-8 flowed' => ['text/plain; charset=UTF-8; format=flowed'],
+        ];
+    }
+
     private function validateRequestTokenForRequest(Request $request, bool $shouldValidate = true): void
     {
         $scopeMatcher = $this->createMock(ScopeMatcher::class);

--- a/core-bundle/tests/EventListener/RequestTokenListenerTest.php
+++ b/core-bundle/tests/EventListener/RequestTokenListenerTest.php
@@ -402,7 +402,7 @@ class RequestTokenListenerTest extends TestCase
         $listener($event);
     }
 
-    private function createPostRequest(string $contentType = 'application/x-www-form-urlencoded')
+    private function createPostRequest(string $contentType = 'application/x-www-form-urlencoded'): Request
     {
         return Request::create('/account.html', 'POST', [], [], [], ['CONTENT_TYPE' => $contentType]);
     }


### PR DESCRIPTION
CSRF is only required for state modifying requests that are "simple requests" as per CORS definition. These are requests using one of the following `Content-Type` headers:

* `application/x-www-form-urlencoded`
* `multipart/form-data`
* `text/plain`

All the other requests require a preflight request and are thus not subject to CORS attacks.

We already ignore the check, if you add the `X-Requested-With: XMLHttpRequest` header but for some frameworks, this requires extra work. This PR should simplify working with those as the custom header is now not needed anymore. 