### PR TITLE
Use `calls:` instead of `_instanceof:`

### DIFF
--- a/core-bundle/config/template_studio.yaml
+++ b/core-bundle/config/template_studio.yaml
@@ -2,11 +2,6 @@ services:
     _defaults:
         autoconfigure: true
 
-    _instanceof:
-        Symfony\Bundle\FrameworkBundle\Controller\AbstractController:
-            calls:
-                - [setContainer, ['@Psr\Container\ContainerInterface']]
-
     Contao\CoreBundle\Controller\BackendTemplateStudioController:
         arguments:
             - '@contao.twig.filesystem_loader'
@@ -17,6 +12,8 @@ services:
             - '@contao.twig.studio.autocomplete'
             - '@database_connection'
             - !tagged_iterator { tag: contao.operation.template_studio_element, index_by: name }
+        calls:
+            - [setContainer, ['@Psr\Container\ContainerInterface']]
 
     contao.twig.studio.autocomplete:
         class: Contao\CoreBundle\Twig\Studio\Autocomplete


### PR DESCRIPTION
Using `_instanceof:` makes sense in our `controller.yaml` file where there are multiple controllers. However, if we group services by topic like in the `backend_search.yaml` or `template_studio.yaml` file, there is only one controller.