### PR TITLE
Make the maintenance tasks in the user profile configurable

### DIFF
--- a/core-bundle/contao/dca/tl_user.php
+++ b/core-bundle/contao/dca/tl_user.php
@@ -631,7 +631,7 @@ class tl_user extends Backend
 
 		foreach ($allowedOperations as $i => $operation)
 		{
-			$operations[] = sprintf('<span><input type="checkbox" name="purge[]" id="opt_purge_%d" class="tl_checkbox" value="%s" data-action="focus->contao--scroll-offset#store"> <label for="opt_purge_%d">%s</label></span>',
+			$operations[] = sprintf('<input type="checkbox" name="purge[]" id="opt_purge_%d" class="tl_checkbox" value="%s" data-action="focus->contao--scroll-offset#store"> <label for="opt_purge_%d">%s</label>',
 				$i,
 				$operation,
 				$i,
@@ -645,7 +645,7 @@ class tl_user extends Backend
 <div class="widget">
   <fieldset class="tl_checkbox_container">
     <legend>' . $GLOBALS['TL_LANG']['tl_user']['session'][0] . '</legend>
-    <span><input type="checkbox" id="check_all_purge" class="tl_checkbox" onclick="Backend.toggleCheckboxGroup(this, \'ctrl_purge\')"> <label for="check_all_purge" class="check-all"><em>' . $GLOBALS['TL_LANG']['MSC']['selectAll'] . '</em></label><br>
+    <input type="checkbox" id="check_all_purge" class="tl_checkbox" onclick="Backend.toggleCheckboxGroup(this, \'ctrl_purge\')"> <label for="check_all_purge" class="check-all"><em>' . $GLOBALS['TL_LANG']['MSC']['selectAll'] . '</em></label><br>
     ' . $operations . '
   </fieldset>' . $dc->help() . '
 </div>';

--- a/core-bundle/contao/dca/tl_user.php
+++ b/core-bundle/contao/dca/tl_user.php
@@ -350,7 +350,7 @@ $GLOBALS['TL_DCA']['tl_user'] = array
 		'session' => array
 		(
 			'input_field_callback'    => array('tl_user', 'sessionField'),
-			'options' 				  => array('purge_session', 'purge_images', 'purge_previews', 'purge_pages'),
+			'options'                 => array('purge_session', 'purge_images', 'purge_previews', 'purge_pages'),
 			'eval'                    => array('doNotShow'=>true, 'doNotCopy'=>true),
 			'sql'                     => array('type' => 'blob', 'length' => MySQLPlatform::LENGTH_LIMIT_MEDIUMBLOB, 'notnull' => false)
 		),
@@ -583,7 +583,7 @@ class tl_user extends Backend
 	 */
 	public function sessionField(DataContainer $dc)
 	{
-		$allowedOperations = $GLOBALS['TL_DCA']['tl_user']['fields']['session']['options'] ?? array();
+		$allowedOptions = $GLOBALS['TL_DCA']['tl_user']['fields']['session']['options'] ?? array();
 
 		if (Input::post('FORM_SUBMIT') == 'tl_user')
 		{
@@ -591,9 +591,8 @@ class tl_user extends Backend
 
 			if (is_array($arrPurge))
 			{
-				$arrPurge = array_values(array_intersect($arrPurge, $allowedOperations));
-
 				$automator = new Automator();
+				$arrPurge = array_values(array_intersect($arrPurge, $allowedOptions));
 
 				if (in_array('purge_session', $arrPurge))
 				{
@@ -624,7 +623,8 @@ class tl_user extends Backend
 			}
 		}
 
-		$operations = array();
+		$options = array();
+
 		$labels = array(
 			'purge_session' => $GLOBALS['TL_LANG']['tl_user']['sessionLabel'],
 			'purge_images' => $GLOBALS['TL_LANG']['tl_user']['htmlLabel'],
@@ -632,9 +632,10 @@ class tl_user extends Backend
 			'purge_pages' => $GLOBALS['TL_LANG']['tl_user']['tempLabel'],
 		);
 
-		foreach ($allowedOperations as $i => $operation)
+		foreach ($allowedOptions as $i => $operation)
 		{
-			$operations[] = sprintf('<input type="checkbox" name="purge[]" id="opt_purge_%d" class="tl_checkbox" value="%s" data-action="focus->contao--scroll-offset#store"> <label for="opt_purge_%d">%s</label>',
+			$options[] = sprintf(
+				'<input type="checkbox" name="purge[]" id="opt_purge_%d" class="tl_checkbox" value="%s" data-action="focus->contao--scroll-offset#store"> <label for="opt_purge_%d">%s</label>',
 				$i,
 				$operation,
 				$i,
@@ -642,14 +643,12 @@ class tl_user extends Backend
 			);
 		}
 
-		$operations = implode('<br>', $operations);
-
 		return '
 <div class="widget">
   <fieldset class="tl_checkbox_container">
     <legend>' . $GLOBALS['TL_LANG']['tl_user']['session'][0] . '</legend>
     <input type="checkbox" id="check_all_purge" class="tl_checkbox" onclick="Backend.toggleCheckboxGroup(this, \'ctrl_purge\')"> <label for="check_all_purge" class="check-all"><em>' . $GLOBALS['TL_LANG']['MSC']['selectAll'] . '</em></label><br>
-    ' . $operations . '
+    ' . implode('<br>', $options) . '
   </fieldset>' . $dc->help() . '
 </div>';
 	}

--- a/core-bundle/contao/dca/tl_user.php
+++ b/core-bundle/contao/dca/tl_user.php
@@ -586,10 +586,12 @@ class tl_user extends Backend
 
 		if (Input::post('FORM_SUBMIT') == 'tl_user')
 		{
-			$arrPurge = array_values(array_intersect(Input::post('purge'), $allowedOperations));
+			$arrPurge = Input::post('purge');
 
 			if (is_array($arrPurge))
 			{
+				$arrPurge = array_values(array_intersect($arrPurge, $allowedOperations));
+
 				$automator = new Automator();
 
 				if (in_array('purge_session', $arrPurge))

--- a/core-bundle/contao/dca/tl_user.php
+++ b/core-bundle/contao/dca/tl_user.php
@@ -350,7 +350,7 @@ $GLOBALS['TL_DCA']['tl_user'] = array
 		'session' => array
 		(
 			'input_field_callback'    => array('tl_user', 'sessionField'),
-			'eval'                    => array('doNotShow'=>true, 'doNotCopy'=>true),
+			'eval'                    => array('doNotShow'=>true, 'doNotCopy'=>true, 'operations' => array('purge_session', 'purge_images', 'purge_previews', 'purge_pages')),
 			'sql'                     => array('type' => 'blob', 'length' => MySQLPlatform::LENGTH_LIMIT_MEDIUMBLOB, 'notnull' => false)
 		),
 		'dateAdded' => array
@@ -582,9 +582,11 @@ class tl_user extends Backend
 	 */
 	public function sessionField(DataContainer $dc)
 	{
+		$allowedOperations = $GLOBALS['TL_DCA']['tl_user']['fields']['session']['eval']['operations'] ?? array();
+
 		if (Input::post('FORM_SUBMIT') == 'tl_user')
 		{
-			$arrPurge = Input::post('purge');
+			$arrPurge = array_values(array_intersect(Input::post('purge'), $allowedOperations));
 
 			if (is_array($arrPurge))
 			{
@@ -619,15 +621,32 @@ class tl_user extends Backend
 			}
 		}
 
+		$operations = array();
+		$labels = array(
+			'purge_session' => $GLOBALS['TL_LANG']['tl_user']['sessionLabel'],
+			'purge_images' => $GLOBALS['TL_LANG']['tl_user']['htmlLabel'],
+			'purge_previews' => $GLOBALS['TL_LANG']['tl_user']['previewLabel'],
+			'purge_pages' => $GLOBALS['TL_LANG']['tl_user']['tempLabel'],
+		);
+
+		foreach ($allowedOperations as $i => $operation)
+		{
+			$operations[] = sprintf('<span><input type="checkbox" name="purge[]" id="opt_purge_%d" class="tl_checkbox" value="%s" data-action="focus->contao--scroll-offset#store"> <label for="opt_purge_%d">%s</label></span>',
+				$i,
+				$operation,
+				$i,
+				$labels[$operation]
+			);
+		}
+
+		$operations = implode('<br>', $operations);
+
 		return '
 <div class="widget">
   <fieldset class="tl_checkbox_container">
     <legend>' . $GLOBALS['TL_LANG']['tl_user']['session'][0] . '</legend>
-    <input type="checkbox" id="check_all_purge" class="tl_checkbox" onclick="Backend.toggleCheckboxGroup(this, \'ctrl_purge\')"> <label for="check_all_purge" class="check-all"><em>' . $GLOBALS['TL_LANG']['MSC']['selectAll'] . '</em></label><br>
-    <input type="checkbox" name="purge[]" id="opt_purge_0" class="tl_checkbox" value="purge_session" data-action="focus->contao--scroll-offset#store"> <label for="opt_purge_0">' . $GLOBALS['TL_LANG']['tl_user']['sessionLabel'] . '</label><br>
-    <input type="checkbox" name="purge[]" id="opt_purge_1" class="tl_checkbox" value="purge_images" data-action="focus->contao--scroll-offset#store"> <label for="opt_purge_1">' . $GLOBALS['TL_LANG']['tl_user']['htmlLabel'] . '</label><br>
-    <input type="checkbox" name="purge[]" id="opt_purge_2" class="tl_checkbox" value="purge_previews" data-action="focus->contao--scroll-offset#store"> <label for="opt_purge_2">' . $GLOBALS['TL_LANG']['tl_user']['previewLabel'] . '</label><br>
-    <input type="checkbox" name="purge[]" id="opt_purge_3" class="tl_checkbox" value="purge_pages" data-action="focus->contao--scroll-offset#store"> <label for="opt_purge_3">' . $GLOBALS['TL_LANG']['tl_user']['tempLabel'] . '</label>
+    <span><input type="checkbox" id="check_all_purge" class="tl_checkbox" onclick="Backend.toggleCheckboxGroup(this, \'ctrl_purge\')"> <label for="check_all_purge" class="check-all"><em>' . $GLOBALS['TL_LANG']['MSC']['selectAll'] . '</em></label><br>
+    ' . $operations . '
   </fieldset>' . $dc->help() . '
 </div>';
 	}

--- a/core-bundle/contao/dca/tl_user.php
+++ b/core-bundle/contao/dca/tl_user.php
@@ -350,7 +350,8 @@ $GLOBALS['TL_DCA']['tl_user'] = array
 		'session' => array
 		(
 			'input_field_callback'    => array('tl_user', 'sessionField'),
-			'eval'                    => array('doNotShow'=>true, 'doNotCopy'=>true, 'operations' => array('purge_session', 'purge_images', 'purge_previews', 'purge_pages')),
+			'options' 				  => array('purge_session', 'purge_images', 'purge_previews', 'purge_pages'),
+			'eval'                    => array('doNotShow'=>true, 'doNotCopy'=>true),
 			'sql'                     => array('type' => 'blob', 'length' => MySQLPlatform::LENGTH_LIMIT_MEDIUMBLOB, 'notnull' => false)
 		),
 		'dateAdded' => array
@@ -582,7 +583,7 @@ class tl_user extends Backend
 	 */
 	public function sessionField(DataContainer $dc)
 	{
-		$allowedOperations = $GLOBALS['TL_DCA']['tl_user']['fields']['session']['eval']['operations'] ?? array();
+		$allowedOperations = $GLOBALS['TL_DCA']['tl_user']['fields']['session']['options'] ?? array();
 
 		if (Input::post('FORM_SUBMIT') == 'tl_user')
 		{


### PR DESCRIPTION
We have those operations in the user profile because we have no permissions in the system maintenance area. However, we also currently cannot configure which tasks are available to regular users there. In my case, I have 20 GB of `asset/images` which are cleaned by cronjobs on a regular basis anyway or it is a super admin task. Regular users should never do that so I need a way to remove that option.

Currently, I have to override the entire `input_field_callback` :/ 