### PR TITLE
Do not use the title attribute in the download content elements

### DIFF
--- a/core-bundle/contao/templates/twig/component/_download.html.twig
+++ b/core-bundle/contao/templates/twig/component/_download.html.twig
@@ -35,7 +35,7 @@
 
     {# Derive title and link text if not explicitly set #}
     {% set title = download.title|default(download.file.extraMetadata.localized.default.title|default('MSC.download'|trans([download.file.name]))) %}
-    {% set text = download.text|default(title) %}
+    {% set text = download.text|default(download.file.extraMetadata.localized.default.title|default(download.file.name)) %}
 
     {% block download_link %}
         {% set download_link_attributes = attrs(download.link_attributes|default)

--- a/core-bundle/contao/templates/twig/component/_download.html.twig
+++ b/core-bundle/contao/templates/twig/component/_download.html.twig
@@ -34,13 +34,13 @@
     {% set download = download|default(_context) %}
 
     {# Derive title and link text if not explicitly set #}
-    {% set title = download.title|default(download.file.extraMetadata.localized.default.title|default(download.file.name)) %}
+    {% set title = download.title|default(download.file.extraMetadata.localized.default.title|default('MSC.download'|trans([download.file.name]))) %}
     {% set text = download.text|default(title) %}
 
     {% block download_link %}
         {% set download_link_attributes = attrs(download.link_attributes|default)
             .set('href', download.href)
-            .set('title','MSC.download'|trans([title]))
+            .set('title', title)
             .setIfExists('type', download.file.mimeType(''))
             .mergeWith(download_link_attributes|default)
         %}

--- a/core-bundle/contao/templates/twig/component/_download.html.twig
+++ b/core-bundle/contao/templates/twig/component/_download.html.twig
@@ -34,13 +34,13 @@
     {% set download = download|default(_context) %}
 
     {# Derive title and link text if not explicitly set #}
-    {% set title = download.title|default(download.file.extraMetadata.localized.default.title|default('MSC.download'|trans([download.file.name]))) %}
+    {% set title = download.title|default %}
     {% set text = download.text|default(download.file.extraMetadata.localized.default.title|default(download.file.name)) %}
 
     {% block download_link %}
         {% set download_link_attributes = attrs(download.link_attributes|default)
             .set('href', download.href)
-            .set('title', title)
+            .setIfExists('title', title)
             .setIfExists('type', download.file.mimeType(''))
             .mergeWith(download_link_attributes|default)
         %}

--- a/core-bundle/src/Controller/ContentElement/DownloadsController.php
+++ b/core-bundle/src/Controller/ContentElement/DownloadsController.php
@@ -52,6 +52,10 @@ class DownloadsController extends AbstractDownloadContentElementController
 
         // Explicitly define title/text metadata for a single file
         if ('download' === $model->type && $model->overwriteLink && $downloads) {
+            if ($model->titleText) {
+                trigger_deprecation('contao/core-bundle', '5.3', 'Setting a download title attribute has been deprecated and will no longer work in Contao 6.');
+            }
+
             $downloads[0]['title'] = $model->titleText;
             $downloads[0]['text'] = $model->linkTitle;
         }

--- a/core-bundle/tests/Controller/ContentElement/ContentElementTestCase.php
+++ b/core-bundle/tests/Controller/ContentElement/ContentElementTestCase.php
@@ -343,7 +343,7 @@ abstract class ContentElementTestCase extends TestCase
                             'image1.jpg',
                             123456,
                             1024,
-                            'image/jpg',
+                            'image/jpeg',
                             new ExtraMetadata([
                                 'localized' => new MetadataBag(
                                     ['en' => new Metadata([Metadata::VALUE_TITLE => 'image1 title'])],

--- a/core-bundle/tests/Controller/ContentElement/DownloadsControllerTest.php
+++ b/core-bundle/tests/Controller/ContentElement/DownloadsControllerTest.php
@@ -78,6 +78,9 @@ class DownloadsControllerTest extends ContentElementTestCase
         $this->assertSameHtml($expectedOutput, $response->getContent());
     }
 
+    /**
+     * @group legacy
+     */
     public function testOutputsSingleDownloadWithCustomMetadata(): void
     {
         $response = $this->renderWithModelData(

--- a/core-bundle/tests/Controller/ContentElement/DownloadsControllerTest.php
+++ b/core-bundle/tests/Controller/ContentElement/DownloadsControllerTest.php
@@ -42,7 +42,36 @@ class DownloadsControllerTest extends ContentElementTestCase
 
         $expectedOutput = <<<'HTML'
             <div class="content-download download-element ext-jpg">
-                <a href="https://example.com/files/image1.jpg" title="translated(contao_default:MSC.download[image1 title])" type="image/jpg">image1 title</a>
+                <a href="https://example.com/files/image1.jpg" title="image1 title" type="image/jpeg">image1 title</a>
+            </div>
+            HTML;
+
+        $this->assertSameHtml($expectedOutput, $response->getContent());
+    }
+
+    public function testOutputsSingleDownloadWithNoMetaTitle(): void
+    {
+        $response = $this->renderWithModelData(
+            $this->getDownloadsController(),
+            [
+                'type' => 'download',
+                'singleSRC' => StringUtil::uuidToBin(ContentElementTestCase::FILE_IMAGE2),
+                'sortBy' => '',
+                'numberOfItems' => '0',
+                'showPreview' => '',
+                'overwriteLink' => '',
+                'inline' => false,
+                'fullsize' => false,
+            ],
+            null,
+            false,
+            $responseContext,
+            $this->getAdjustedContainer(),
+        );
+
+        $expectedOutput = <<<'HTML'
+            <div class="content-download download-element ext-jpg">
+                <a href="https://example.com/files/image2.jpg" title="translated(contao_default:MSC.download[image2.jpg])" type="image/jpeg">translated(contao_default:MSC.download[image2.jpg])</a>
             </div>
             HTML;
 
@@ -73,7 +102,7 @@ class DownloadsControllerTest extends ContentElementTestCase
 
         $expectedOutput = <<<'HTML'
             <div class="content-download download-element ext-jpg">
-                <a href="https://example.com/files/image1.jpg" title="translated(contao_default:MSC.download[Download the file])" type="image/jpg">The file</a>
+                <a href="https://example.com/files/image1.jpg" title="Download the file" type="image/jpeg">The file</a>
             </div>
             HTML;
 
@@ -131,10 +160,10 @@ class DownloadsControllerTest extends ContentElementTestCase
             <div class="content-downloads">
                 <ul>
                     <li class="download-element ext-jpg">
-                        <a href="https://example.com/files/image1.jpg" title="translated(contao_default:MSC.download[image1 title])" type="image/jpg">image1 title</a>
+                        <a href="https://example.com/files/image1.jpg" title="image1 title" type="image/jpeg">image1 title</a>
                     </li>
                     <li class="download-element ext-jpg">
-                        <a href="https://example.com/files/image2.jpg" title="translated(contao_default:MSC.download[image2.jpg])" type="image/jpeg">image2.jpg</a>
+                        <a href="https://example.com/files/image2.jpg" title="translated(contao_default:MSC.download[image2.jpg])" type="image/jpeg">translated(contao_default:MSC.download[image2.jpg])</a>
                     </li>
                 </ul>
             </div>

--- a/core-bundle/tests/Controller/ContentElement/DownloadsControllerTest.php
+++ b/core-bundle/tests/Controller/ContentElement/DownloadsControllerTest.php
@@ -42,7 +42,7 @@ class DownloadsControllerTest extends ContentElementTestCase
 
         $expectedOutput = <<<'HTML'
             <div class="content-download download-element ext-jpg">
-                <a href="https://example.com/files/image1.jpg" title="image1 title" type="image/jpeg">image1 title</a>
+                <a href="https://example.com/files/image1.jpg" type="image/jpeg">image1 title</a>
             </div>
             HTML;
 
@@ -71,7 +71,7 @@ class DownloadsControllerTest extends ContentElementTestCase
 
         $expectedOutput = <<<'HTML'
             <div class="content-download download-element ext-jpg">
-                <a href="https://example.com/files/image2.jpg" title="translated(contao_default:MSC.download[image2.jpg])" type="image/jpeg">image2.jpg</a>
+                <a href="https://example.com/files/image2.jpg" type="image/jpeg">image2.jpg</a>
             </div>
             HTML;
 
@@ -160,10 +160,10 @@ class DownloadsControllerTest extends ContentElementTestCase
             <div class="content-downloads">
                 <ul>
                     <li class="download-element ext-jpg">
-                        <a href="https://example.com/files/image1.jpg" title="image1 title" type="image/jpeg">image1 title</a>
+                        <a href="https://example.com/files/image1.jpg" type="image/jpeg">image1 title</a>
                     </li>
                     <li class="download-element ext-jpg">
-                        <a href="https://example.com/files/image2.jpg" title="translated(contao_default:MSC.download[image2.jpg])" type="image/jpeg">image2.jpg</a>
+                        <a href="https://example.com/files/image2.jpg" type="image/jpeg">image2.jpg</a>
                     </li>
                 </ul>
             </div>

--- a/core-bundle/tests/Controller/ContentElement/DownloadsControllerTest.php
+++ b/core-bundle/tests/Controller/ContentElement/DownloadsControllerTest.php
@@ -71,7 +71,7 @@ class DownloadsControllerTest extends ContentElementTestCase
 
         $expectedOutput = <<<'HTML'
             <div class="content-download download-element ext-jpg">
-                <a href="https://example.com/files/image2.jpg" title="translated(contao_default:MSC.download[image2.jpg])" type="image/jpeg">translated(contao_default:MSC.download[image2.jpg])</a>
+                <a href="https://example.com/files/image2.jpg" title="translated(contao_default:MSC.download[image2.jpg])" type="image/jpeg">image2.jpg</a>
             </div>
             HTML;
 
@@ -163,7 +163,7 @@ class DownloadsControllerTest extends ContentElementTestCase
                         <a href="https://example.com/files/image1.jpg" title="image1 title" type="image/jpeg">image1 title</a>
                     </li>
                     <li class="download-element ext-jpg">
-                        <a href="https://example.com/files/image2.jpg" title="translated(contao_default:MSC.download[image2.jpg])" type="image/jpeg">translated(contao_default:MSC.download[image2.jpg])</a>
+                        <a href="https://example.com/files/image2.jpg" title="translated(contao_default:MSC.download[image2.jpg])" type="image/jpeg">image2.jpg</a>
                     </li>
                 </ul>
             </div>

--- a/core-bundle/tests/Controller/ContentElement/DownloadsControllerTest.php
+++ b/core-bundle/tests/Controller/ContentElement/DownloadsControllerTest.php
@@ -49,7 +49,7 @@ class DownloadsControllerTest extends ContentElementTestCase
         $this->assertSameHtml($expectedOutput, $response->getContent());
     }
 
-    public function testOutputsSingleDownloadWithNoMetaTitle(): void
+    public function testOutputsSingleDownloadWithNoMetadata(): void
     {
         $response = $this->renderWithModelData(
             $this->getDownloadsController(),


### PR DESCRIPTION
Fixes #8230

Currently the `MSC.download` translation label is always added to the download's title. However, in the singular `download` content element you can specify a custom title - which would then also be prefixed with `'Download '`. This was not the case in previous Contao versions.

Now, the question is though whether we should apply the `MSC.download` label _only_ when falling back to the file's name for the title attribute - or also if there is a title set in the metadata for the file in the DBAFS? The PR implements the former.

Keep in mind that this change will also affect the download**s** content element (plural), as this is a change in the `_download` component, used by both content elements.
