### PR TITLE
Use ALTCHA by default

### DIFF
--- a/comments-bundle/contao/classes/Comments.php
+++ b/comments-bundle/contao/classes/Comments.php
@@ -209,7 +209,7 @@ class Comments extends Frontend
 			(
 				'name'      => 'captcha',
 				'label'     => $GLOBALS['TL_LANG']['MSC']['securityQuestion'],
-				'inputType' => 'captcha',
+				'inputType' => 'altcha',
 				'eval'      => array('mandatory'=>true)
 			);
 		}

--- a/core-bundle/contao/modules/ModuleLostPassword.php
+++ b/core-bundle/contao/modules/ModuleLostPassword.php
@@ -95,7 +95,7 @@ class ModuleLostPassword extends Module
 			(
 				'name' => 'lost_password',
 				'label' => $GLOBALS['TL_LANG']['MSC']['securityQuestion'],
-				'inputType' => 'captcha',
+				'inputType' => 'altcha',
 				'eval' => array('mandatory'=>true)
 			);
 		}

--- a/core-bundle/contao/modules/ModuleRegistration.php
+++ b/core-bundle/contao/modules/ModuleRegistration.php
@@ -124,18 +124,18 @@ class ModuleRegistration extends Module
 			(
 				'id' => 'registration',
 				'label' => $GLOBALS['TL_LANG']['MSC']['securityQuestion'],
-				'type' => 'captcha',
+				'type' => 'altcha',
 				'mandatory' => true,
 				'required' => true
 			);
 
-			/** @var class-string<FormCaptcha> $strClass */
-			$strClass = $GLOBALS['TL_FFL']['captcha'] ?? null;
+			/** @var class-string<FormAltcha> $strClass */
+			$strClass = $GLOBALS['TL_FFL']['altcha'] ?? null;
 
 			// Fallback to default if the class is not defined
 			if (!class_exists($strClass))
 			{
-				$strClass = 'FormCaptcha';
+				$strClass = 'FormAltcha';
 			}
 
 			$objCaptcha = new $strClass($arrCaptcha);

--- a/newsletter-bundle/contao/modules/ModuleSubscribe.php
+++ b/newsletter-bundle/contao/modules/ModuleSubscribe.php
@@ -93,11 +93,20 @@ class ModuleSubscribe extends Module
 			(
 				'name' => 'subscribe_' . $this->id,
 				'label' => $GLOBALS['TL_LANG']['MSC']['securityQuestion'],
-				'inputType' => 'captcha',
+				'inputType' => 'altcha',
 				'eval' => array('mandatory'=>true)
 			);
 
-			$objWidget = new FormCaptcha(FormCaptcha::getAttributesFromDca($arrField, $arrField['name']));
+			/** @var class-string<FormAltcha> $strClass */
+			$strClass = $GLOBALS['TL_FFL']['altcha'] ?? null;
+
+			// Fallback to default if the class is not defined
+			if (!class_exists($strClass))
+			{
+				$strClass = 'FormAltcha';
+			}
+
+			$objWidget = new $strClass($strClass::getAttributesFromDca($arrField, $arrField['name']));
 		}
 
 		$strFormId = 'tl_subscribe_' . $this->id;

--- a/newsletter-bundle/contao/modules/ModuleUnsubscribe.php
+++ b/newsletter-bundle/contao/modules/ModuleUnsubscribe.php
@@ -84,11 +84,20 @@ class ModuleUnsubscribe extends Module
 			(
 				'name' => 'unsubscribe_' . $this->id,
 				'label' => $GLOBALS['TL_LANG']['MSC']['securityQuestion'],
-				'inputType' => 'captcha',
+				'inputType' => 'altcha',
 				'eval' => array('mandatory'=>true)
 			);
 
-			$objWidget = new FormCaptcha(FormCaptcha::getAttributesFromDca($arrField, $arrField['name']));
+			/** @var class-string<FormAltcha> $strClass */
+			$strClass = $GLOBALS['TL_FFL']['altcha'] ?? null;
+
+			// Fallback to default if the class is not defined
+			if (!class_exists($strClass))
+			{
+				$strClass = 'FormAltcha';
+			}
+
+			$objWidget = new $strClass($strClass::getAttributesFromDca($arrField, $arrField['name']));
 		}
 
 		$strFormId = 'tl_unsubscribe_' . $this->id;


### PR DESCRIPTION
Implements #8237

Until there is a way to select the type of CAPTCHA per module, we should at least make ALTCHA the default.