### PR TITLE
Correctly initialize the CAPTCHA widget

### DIFF
--- a/core-bundle/contao/modules/ModuleLostPassword.php
+++ b/core-bundle/contao/modules/ModuleLostPassword.php
@@ -222,7 +222,7 @@ class ModuleLostPassword extends Module
 		// Fallback to default if the class is not defined
 		if (!class_exists($strClass))
 		{
-			$strClass = 'FormPassword';
+			$strClass = FormPassword::class;
 		}
 
 		$objWidget = new $strClass($strClass::getAttributesFromDca($arrField, 'password'));

--- a/core-bundle/contao/modules/ModuleRegistration.php
+++ b/core-bundle/contao/modules/ModuleRegistration.php
@@ -134,7 +134,7 @@ class ModuleRegistration extends Module
 			// Fallback to default if the class is not defined
 			if (!class_exists($strClass))
 			{
-				$strClass = 'FormCaptcha';
+				$strClass = FormCaptcha::class;
 			}
 
 			$objCaptcha = new $strClass($strClass::getAttributesFromDca($arrCaptcha, $arrCaptcha['name']));

--- a/core-bundle/contao/modules/ModuleRegistration.php
+++ b/core-bundle/contao/modules/ModuleRegistration.php
@@ -122,11 +122,10 @@ class ModuleRegistration extends Module
 		{
 			$arrCaptcha = array
 			(
-				'id' => 'registration',
+				'name' => 'registration',
 				'label' => $GLOBALS['TL_LANG']['MSC']['securityQuestion'],
-				'type' => 'captcha',
-				'mandatory' => true,
-				'required' => true
+				'inputType' => 'captcha',
+				'eval' => array('mandatory'=>true, 'required'=>true)
 			);
 
 			/** @var class-string<FormCaptcha> $strClass */
@@ -138,7 +137,7 @@ class ModuleRegistration extends Module
 				$strClass = 'FormCaptcha';
 			}
 
-			$objCaptcha = new $strClass($arrCaptcha);
+			$objCaptcha = new $strClass($strClass::getAttributesFromDca($arrCaptcha, $arrCaptcha['name']));
 
 			if (Input::post('FORM_SUBMIT') == $strFormId)
 			{

--- a/newsletter-bundle/contao/modules/ModuleSubscribe.php
+++ b/newsletter-bundle/contao/modules/ModuleSubscribe.php
@@ -103,7 +103,7 @@ class ModuleSubscribe extends Module
 			// Fallback to default if the class is not defined
 			if (!class_exists($strClass))
 			{
-				$strClass = 'FormCaptcha';
+				$strClass = FormCaptcha::class;
 			}
 
 			$objWidget = new $strClass($strClass::getAttributesFromDca($arrField, $arrField['name']));

--- a/newsletter-bundle/contao/modules/ModuleSubscribe.php
+++ b/newsletter-bundle/contao/modules/ModuleSubscribe.php
@@ -94,10 +94,19 @@ class ModuleSubscribe extends Module
 				'name' => 'subscribe_' . $this->id,
 				'label' => $GLOBALS['TL_LANG']['MSC']['securityQuestion'],
 				'inputType' => 'captcha',
-				'eval' => array('mandatory'=>true)
+				'eval' => array('mandatory'=>true, 'required'=>true)
 			);
 
-			$objWidget = new FormCaptcha(FormCaptcha::getAttributesFromDca($arrField, $arrField['name']));
+			/** @var class-string<FormCaptcha> $strClass */
+			$strClass = $GLOBALS['TL_FFL']['captcha'] ?? null;
+
+			// Fallback to default if the class is not defined
+			if (!class_exists($strClass))
+			{
+				$strClass = 'FormCaptcha';
+			}
+
+			$objWidget = new $strClass($strClass::getAttributesFromDca($arrField, $arrField['name']));
 		}
 
 		$strFormId = 'tl_subscribe_' . $this->id;

--- a/newsletter-bundle/contao/modules/ModuleUnsubscribe.php
+++ b/newsletter-bundle/contao/modules/ModuleUnsubscribe.php
@@ -85,10 +85,19 @@ class ModuleUnsubscribe extends Module
 				'name' => 'unsubscribe_' . $this->id,
 				'label' => $GLOBALS['TL_LANG']['MSC']['securityQuestion'],
 				'inputType' => 'captcha',
-				'eval' => array('mandatory'=>true)
+				'eval' => array('mandatory'=>true, 'required'=>true)
 			);
 
-			$objWidget = new FormCaptcha(FormCaptcha::getAttributesFromDca($arrField, $arrField['name']));
+			/** @var class-string<FormCaptcha> $strClass */
+			$strClass = $GLOBALS['TL_FFL']['captcha'] ?? null;
+
+			// Fallback to default if the class is not defined
+			if (!class_exists($strClass))
+			{
+				$strClass = 'FormCaptcha';
+			}
+
+			$objWidget = new $strClass($strClass::getAttributesFromDca($arrField, $arrField['name']));
 		}
 
 		$strFormId = 'tl_unsubscribe_' . $this->id;

--- a/newsletter-bundle/contao/modules/ModuleUnsubscribe.php
+++ b/newsletter-bundle/contao/modules/ModuleUnsubscribe.php
@@ -94,7 +94,7 @@ class ModuleUnsubscribe extends Module
 			// Fallback to default if the class is not defined
 			if (!class_exists($strClass))
 			{
-				$strClass = 'FormCaptcha';
+				$strClass = FormCaptcha::class;
 			}
 
 			$objWidget = new $strClass($strClass::getAttributesFromDca($arrField, $arrField['name']));


### PR DESCRIPTION
While working on #8253, I realized that we don't initialize the CAPTCHA widget consistently. It should always be

```php
$config = […];

// Use the class that matches the input type
$class = $GLOBALS['TL_FFL'][$config['inputType']];

// Initialize the widget calling getAttributesFromDca()
$widget = new $class($class::getAttributesFromDca($config, $config['name']));
```

| Element | CAPTCHA initialization |
|---|---|
| Form generator | correct |
| Comments module | correct |
| Registration module | **incorrect** |
| Lost password module | correct |
| Subscribe module | **incorrect** |
| Unsubscribe module | **incorrect** |

Once the PR is merged, @contaoacademy can simply do the following in his `contao/config/config.php` file and every module will use ALTCHA instead of the security question:

```php
$GLOBALS['TL_FFL']['captcha'] = Contao\FormAltcha::class;
```
