### PR TITLE
Do not redirect if the two-factor page is the current page

### DIFF
--- a/core-bundle/src/EventListener/Security/TwoFactorFrontendListener.php
+++ b/core-bundle/src/EventListener/Security/TwoFactorFrontendListener.php
@@ -78,8 +78,10 @@ class TwoFactorFrontendListener
                 throw new ForwardPageNotFoundException('No two-factor authentication page found');
             }
 
+            $currentPage = $request->attributes->get('pageModel');
+
             // Redirect to two-factor page
-            if ($rootPage->id !== $twoFactorPage->id) {
+            if ($currentPage?->id !== $twoFactorPage->id) {
                 $event->setResponse(new RedirectResponse($this->urlGenerator->generate($twoFactorPage, [], UrlGeneratorInterface::ABSOLUTE_URL)));
             }
 


### PR DESCRIPTION
### Description

* fixes #8223

We checked for the current page in Contao 4.13 but that was changed to rootPage to get the id for the twoFactorPage.

*In future versions, we can use `$pageFinder->getCurrentPage` but it does not exist in 5.3 yet*