### PR TITLE
Fix the metadata for breadcrumbs

### DIFF
--- a/core-bundle/contao/modules/ModuleBreadcrumb.php
+++ b/core-bundle/contao/modules/ModuleBreadcrumb.php
@@ -188,7 +188,7 @@ class ModuleBreadcrumb extends Module
 				'isRoot'   => false,
 				'isActive' => true,
 				// Use the current request without query string for the current page (see #3450)
-				'href'     => $request->getBasePath().$request->getPathInfo(),
+				'href'     => $request->getBaseUrl().$request->getPathInfo(),
 				'title'    => StringUtil::specialchars($pages[0]->pageTitle ?: $pages[0]->title),
 				'link'     => $pages[0]->title,
 				'data'     => $pages[0]->row(),

--- a/core-bundle/contao/modules/ModuleBreadcrumb.php
+++ b/core-bundle/contao/modules/ModuleBreadcrumb.php
@@ -85,7 +85,7 @@ class ModuleBreadcrumb extends Module
 			(
 				'isRoot'   => true,
 				'isActive' => false,
-				'href'     => (($objFirstPage !== null) ? $this->generateContentUrl($objFirstPage) : $request->getBasePath()),
+				'href'     => (($objFirstPage !== null) ? $this->generateContentUrl($objFirstPage) : $request?->getBasePath()),
 				'title'    => StringUtil::specialchars($objPages->pageTitle ?: $objPages->title, true),
 				'link'     => $objPages->title,
 				'data'     => (($objFirstPage !== null) ? $objFirstPage->row() : array()),
@@ -188,7 +188,7 @@ class ModuleBreadcrumb extends Module
 				'isRoot'   => false,
 				'isActive' => true,
 				// Use the current request without query string for the current page (see #3450)
-				'href'     => $request->getBaseUrl().$request->getPathInfo(),
+				'href'     => $request?->getBaseUrl().$request?->getPathInfo(),
 				'title'    => StringUtil::specialchars($pages[0]->pageTitle ?: $pages[0]->title),
 				'link'     => $pages[0]->title,
 				'data'     => $pages[0]->row(),


### PR DESCRIPTION
Fixes #7274

* The `index` page will not be output in the schema.org metadata (_note:_ we need to check for `isActive` in addition to alias is `index` because the root entry also has `index` as its alias).
* The URL for the last breadcrumb entry (the active page) is now fixed and also uses a forward slash.