### PR TITLE
Do not override page requirements and defaults

### DIFF
--- a/core-bundle/src/Routing/Page/PageRegistry.php
+++ b/core-bundle/src/Routing/Page/PageRegistry.php
@@ -68,8 +68,8 @@ class PageRegistry implements ResetInterface
                 $path = '/'.($pageModel->alias ?: $pageModel->id);
             } else {
                 $path = '/'.($pageModel->alias ?: $pageModel->id).'{!parameters}';
-                $defaults['parameters'] = '';
-                $requirements['parameters'] = $pageModel->requireItem ? '/.+?' : '(/.+?)?';
+                $defaults['parameters'] ??= '';
+                $requirements['parameters'] ??= $pageModel->requireItem ? '/.+?' : '(/.+?)?';
             }
         }
 


### PR DESCRIPTION
Currently, it is not possible to override the requirements or defaults of a page route when keeping the default path.

Here's an example:

```php
#[AsPage(requirements: ['parameters' => '(/foo)?'])]
class MyController
{
    // ...
}
```

This would require the URL to be `example.com/page-alias` or `example.com/page-alias/foo`.