### PR TITLE
Show all search results in tree mode

### DIFF
--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -4411,8 +4411,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 
 		// Calculate label and add a toggle button
 		$level = $intMargin / $intSpacing + 1;
-		$found = \count($arrFound);
-		$blnIsOpen = ($found > 0 && $found < 50) || ($session[$node][$id] ?? null) == 1;
+		$blnIsOpen = !empty($arrFound) || ($session[$node][$id] ?? null) == 1;
 
 		// Always show selected nodes
 		if (!$blnIsOpen && !empty($this->arrPickerValue) && (($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] ?? null) == self::MODE_TREE || $table !== $this->strTable))

--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -4411,7 +4411,8 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 
 		// Calculate label and add a toggle button
 		$level = $intMargin / $intSpacing + 1;
-		$blnIsOpen = isset($session[$node][$id]) && $session[$node][$id] == 1;
+		$found = \count($arrFound);
+		$blnIsOpen = ($found > 0 && $found < 50) || ($session[$node][$id] ?? null) == 1;
 
 		// Always show selected nodes
 		if (!$blnIsOpen && !empty($this->arrPickerValue) && (($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] ?? null) == self::MODE_TREE || $table !== $this->strTable))


### PR DESCRIPTION
Fixes https://github.com/contao/contao/issues/7900

The limit is now set to 50, because the argument of "performance issue" should not happen here. Also be aware that I don't think it was an issue in the first place, because the page tree currently rendered **everything** but kept it collapsed, so if you actually do have 2000 search results, you would also have that HTML in the response 🤷 