### PR TITLE
Fix page sorting with same languages across domains

### DIFF
--- a/core-bundle/src/Routing/AbstractPageRouteProvider.php
+++ b/core-bundle/src/Routing/AbstractPageRouteProvider.php
@@ -125,7 +125,7 @@ abstract class AbstractPageRouteProvider implements RouteProviderInterface
         $langA = null;
         $langB = null;
 
-        if (null !== $languages && $pageA->rootLanguage !== $pageB->rootLanguage) {
+        if (null !== $languages && ($pageA->rootLanguage !== $pageB->rootLanguage || $pageA->domain !== $pageB->domain)) {
             $fallbackA = LocaleUtil::getFallbacks($pageA->rootLanguage);
             $fallbackB = LocaleUtil::getFallbacks($pageB->rootLanguage);
             $langA = $this->getLocalePriority($fallbackA, $fallbackB, $languages);
@@ -148,22 +148,14 @@ abstract class AbstractPageRouteProvider implements RouteProviderInterface
             if ($pageB->rootIsFallback && !$pageA->rootIsFallback) {
                 return 1;
             }
-        } else {
-            if (null === $langA && null !== $langB) {
-                return 1;
-            }
-
-            if (null !== $langA && null === $langB) {
-                return -1;
-            }
-
-            if ($langA < $langB) {
-                return -1;
-            }
-
-            if ($langA > $langB) {
-                return 1;
-            }
+        } elseif (null === $langA && null !== $langB) {
+            return 1;
+        } elseif (null !== $langA && null === $langB) {
+            return -1;
+        } elseif ($langA < $langB) {
+            return -1;
+        } elseif ($langA > $langB) {
+            return 1;
         }
 
         if ('root' !== $pageA->type && 'root' === $pageB->type) {

--- a/core-bundle/tests/Fixtures/Functional/Routing/multidomain-languages.yaml
+++ b/core-bundle/tests/Fixtures/Functional/Routing/multidomain-languages.yaml
@@ -1,0 +1,1676 @@
+tl_page:
+    -
+        id: 1
+        fallback: 1
+        includeLayout: 1
+        layout: 1
+        published: 1
+        pid: 0
+        sorting: 128
+        title: Foo
+        type: root
+        alias: de
+        language: de
+        dns: example.com
+        urlPrefix: de
+    -
+        id: 6
+        published: 1
+        pid: 1
+        sorting: 640
+        title: Foo
+        type: regular
+        alias: index
+    -
+        id: 159
+        fallback: 1
+        includeLayout: 1
+        layout: 1
+        published: 1
+        pid: 0
+        sorting: 512
+        title: Foo
+        type: root
+        alias: de
+        language: de
+        dns: s1.example.com
+        urlPrefix: de
+    -
+        id: 164
+        published: 1
+        pid: 159
+        sorting: 640
+        title: Foo
+        type: regular
+        alias: index
+    -
+        id: 176
+        fallback: 1
+        includeLayout: 1
+        layout: 1
+        published: 1
+        pid: 0
+        sorting: 768
+        title: Foo
+        type: root
+        alias: de
+        language: de
+        dns: s2.example.com
+        urlPrefix: de
+    -
+        id: 220
+        published: 1
+        pid: 176
+        sorting: 576
+        title: Foo
+        type: regular
+        alias: index
+    -
+        id: 222
+        fallback: 1
+        includeLayout: 1
+        layout: 1
+        published: 1
+        pid: 0
+        sorting: 640
+        title: Foo
+        type: root
+        alias: de
+        language: de
+        dns: s9.example.com
+    -
+        id: 227
+        includeLayout: 1
+        layout: 1
+        published: 1
+        pid: 222
+        sorting: 640
+        title: Foo
+        type: regular
+        alias: index
+    -
+        id: 280
+        fallback: 1
+        includeLayout: 1
+        layout: 1
+        published: 0
+        pid: 0
+        sorting: 1152
+        title: Foo
+        type: root
+        alias: en
+        language: en
+        dns: s10.example.com
+    -
+        id: 285
+        published: 1
+        pid: 280
+        sorting: 576
+        title: Foo
+        type: regular
+        alias: index
+    -
+        id: 318
+        fallback: 1
+        includeLayout: 1
+        layout: 1
+        published: 1
+        pid: 0
+        sorting: 1280
+        title: Foo
+        type: root
+        alias: de
+        language: de
+        dns: s5.example.com
+        urlPrefix: de
+    -
+        id: 323
+        includeLayout: 1
+        layout: 1
+        published: 1
+        pid: 318
+        sorting: 640
+        title: Foo
+        type: regular
+        alias: index
+    -
+        id: 382
+        fallback: 1
+        includeLayout: 1
+        layout: 1
+        published: 1
+        pid: 0
+        sorting: 1536
+        title: Foo
+        type: root
+        alias: de
+        language: de
+        dns: s6.example.com
+        urlPrefix: de
+    -
+        id: 392
+        layout: 1
+        published: 1
+        pid: 382
+        sorting: 640
+        title: Foo
+        type: regular
+        alias: index
+    -
+        id: 449
+        fallback: 1
+        includeLayout: 1
+        layout: 1
+        published: 1
+        pid: 0
+        sorting: 1664
+        title: Foo
+        type: root
+        alias: de
+        language: de
+        dns: s7.example.com
+        urlPrefix: de
+    -
+        id: 454
+        published: 1
+        pid: 449
+        sorting: 704
+        title: Foo
+        type: redirect
+        alias: index
+    -
+        id: 597
+        fallback: 1
+        includeLayout: 1
+        layout: 1
+        published: 1
+        pid: 0
+        sorting: 2048
+        title: Foo
+        type: root
+        alias: de
+        language: de
+        dns: example.org
+        urlPrefix: de
+    -
+        id: 602
+        published: 1
+        pid: 597
+        sorting: 640
+        title: Foo
+        type: regular
+        alias: index
+    -
+        id: 708
+        fallback: 1
+        includeLayout: 1
+        layout: 1
+        published: 1
+        pid: 0
+        sorting: 2816
+        title: Foo
+        type: root
+        alias: de
+        language: de
+        dns: domain2.org
+        urlPrefix: de
+    -
+        id: 713
+        published: 1
+        pid: 708
+        sorting: 640
+        title: Foo
+        type: regular
+        alias: index
+    -
+        id: 784
+        fallback: 1
+        includeLayout: 1
+        layout: 1
+        published: 1
+        pid: 0
+        sorting: 3200
+        title: Foo
+        type: root
+        alias: de
+        language: de
+        dns: domain3.org
+        urlPrefix: de
+    -
+        id: 789
+        published: 1
+        pid: 784
+        sorting: 640
+        title: Foo
+        type: regular
+        alias: index
+    -
+        id: 860
+        fallback: 1
+        includeLayout: 1
+        layout: 1
+        published: 1
+        pid: 0
+        sorting: 3584
+        title: Foo
+        type: root
+        alias: de
+        language: de
+        dns: domain4.org
+        urlPrefix: de
+    -
+        id: 865
+        includeLayout: 1
+        layout: 1
+        published: 1
+        pid: 860
+        sorting: 640
+        title: Foo
+        type: regular
+        alias: index
+    -
+        id: 936
+        fallback: 1
+        includeLayout: 1
+        layout: 1
+        published: 1
+        pid: 0
+        sorting: 3968
+        title: Foo
+        type: root
+        alias: de
+        language: de
+        dns: domain5.org
+        urlPrefix: de
+    -
+        id: 941
+        published: 1
+        pid: 936
+        sorting: 640
+        title: Foo
+        type: regular
+        alias: index
+    -
+        id: 1557
+        includeLayout: 1
+        layout: 1
+        published: 1
+        pid: 0
+        sorting: 256
+        title: Foo
+        type: root
+        alias: en
+        language: en
+        dns: example.com
+        urlPrefix: en
+    -
+        id: 1562
+        published: 1
+        pid: 1557
+        sorting: 640
+        title: Foo
+        type: regular
+        alias: index
+    -
+        id: 1848
+        includeLayout: 1
+        layout: 1
+        published: 1
+        pid: 0
+        sorting: 384
+        title: Foo
+        type: root
+        alias: fr
+        language: fr
+        dns: example.com
+        urlPrefix: fr
+    -
+        id: 1853
+        published: 1
+        pid: 1848
+        sorting: 640
+        title: Foo
+        type: regular
+        alias: index
+    -
+        id: 2138
+        includeLayout: 1
+        layout: 1
+        published: 1
+        pid: 0
+        sorting: 2176
+        title: Foo
+        type: root
+        alias: en
+        language: en
+        dns: example.org
+        urlPrefix: en
+    -
+        id: 2143
+        published: 1
+        pid: 2138
+        sorting: 640
+        title: Foo
+        type: regular
+        alias: index
+    -
+        id: 2317
+        includeLayout: 1
+        layout: 1
+        published: 1
+        pid: 0
+        sorting: 2304
+        title: Foo
+        type: root
+        alias: fr
+        language: fr
+        dns: example.org
+        urlPrefix: fr
+    -
+        id: 2322
+        published: 1
+        pid: 2317
+        sorting: 640
+        title: Foo
+        type: regular
+        alias: index
+    -
+        id: 2524
+        includeLayout: 1
+        layout: 1
+        published: 1
+        pid: 0
+        sorting: 2944
+        title: Foo
+        type: root
+        alias: en
+        language: en
+        dns: domain2.org
+        urlPrefix: en
+    -
+        id: 2529
+        published: 1
+        pid: 2524
+        sorting: 640
+        title: Foo
+        type: regular
+        alias: index
+    -
+        id: 2683
+        includeLayout: 1
+        layout: 1
+        published: 1
+        pid: 0
+        sorting: 3072
+        title: Foo
+        type: root
+        alias: fr
+        language: fr
+        dns: domain2.org
+        urlPrefix: fr
+    -
+        id: 2688
+        published: 1
+        pid: 2683
+        sorting: 640
+        title: Foo
+        type: regular
+        alias: index
+    -
+        id: 2870
+        includeLayout: 1
+        layout: 1
+        published: 1
+        pid: 0
+        sorting: 3328
+        title: Foo
+        type: root
+        alias: en
+        language: en
+        dns: domain3.org
+        urlPrefix: en
+    -
+        id: 2875
+        published: 1
+        pid: 2870
+        sorting: 640
+        title: Foo
+        type: regular
+        alias: index
+    -
+        id: 3025
+        includeLayout: 1
+        layout: 1
+        published: 1
+        pid: 0
+        sorting: 3456
+        title: Foo
+        type: root
+        alias: fr
+        language: fr
+        dns: domain3.org
+        urlPrefix: fr
+    -
+        id: 3030
+        published: 1
+        pid: 3025
+        sorting: 640
+        title: Foo
+        type: regular
+        alias: index
+    -
+        id: 3208
+        includeLayout: 1
+        layout: 1
+        published: 1
+        pid: 0
+        sorting: 3712
+        title: Foo
+        type: root
+        alias: en
+        language: en
+        dns: domain4.org
+        urlPrefix: en
+    -
+        id: 3213
+        includeLayout: 1
+        layout: 1
+        published: 1
+        pid: 3208
+        sorting: 640
+        title: Foo
+        type: regular
+        alias: index
+    -
+        id: 3359
+        includeLayout: 1
+        layout: 1
+        published: 1
+        pid: 0
+        sorting: 3840
+        title: Foo
+        type: root
+        alias: fr
+        language: fr
+        dns: domain4.org
+        urlPrefix: fr
+    -
+        id: 3364
+        includeLayout: 1
+        layout: 1
+        published: 1
+        pid: 3359
+        sorting: 640
+        title: Foo
+        type: regular
+        alias: index
+    -
+        id: 3538
+        includeLayout: 1
+        layout: 1
+        published: 1
+        pid: 0
+        sorting: 4096
+        title: Foo
+        type: root
+        alias: en
+        language: en
+        dns: domain5.org
+        urlPrefix: en
+    -
+        id: 3543
+        published: 1
+        pid: 3538
+        sorting: 640
+        title: Foo
+        type: regular
+        alias: index
+    -
+        id: 3695
+        includeLayout: 1
+        layout: 1
+        published: 1
+        pid: 0
+        sorting: 4224
+        title: Foo
+        type: root
+        alias: fr
+        language: fr
+        dns: domain5.org
+        urlPrefix: fr
+    -
+        id: 3700
+        published: 1
+        pid: 3695
+        sorting: 640
+        title: Foo
+        type: regular
+        alias: index
+    -
+        id: 3917
+        includeLayout: 1
+        layout: 1
+        published: 1
+        pid: 0
+        sorting: 896
+        title: Foo
+        type: root
+        alias: en
+        language: en
+        dns: s2.example.com
+        urlPrefix: en
+    -
+        id: 3922
+        published: 1
+        pid: 3917
+        sorting: 576
+        title: Foo
+        type: regular
+        alias: index
+    -
+        id: 3950
+        includeLayout: 1
+        layout: 1
+        published: 1
+        pid: 0
+        sorting: 1024
+        title: Foo
+        type: root
+        alias: fr
+        language: fr
+        dns: s2.example.com
+        urlPrefix: fr
+    -
+        id: 3955
+        published: 1
+        pid: 3950
+        sorting: 576
+        title: Foo
+        type: regular
+        alias: index
+    -
+        id: 4012
+        fallback: 1
+        includeLayout: 1
+        layout: 1
+        published: 1
+        pid: 0
+        sorting: 2432
+        title: Foo
+        type: root
+        alias: de
+        language: de
+        dns: domain6.org
+        urlPrefix: de
+    -
+        id: 4017
+        published: 1
+        pid: 4012
+        sorting: 640
+        title: Foo
+        type: regular
+        alias: index
+    -
+        id: 4180
+        fallback: 1
+        includeLayout: 1
+        layout: 1
+        published: 1
+        pid: 0
+        sorting: 2560
+        title: Foo
+        type: root
+        alias: de
+        language: de
+        dns: domain7.org
+        urlPrefix: de
+    -
+        id: 4185
+        published: 1
+        pid: 4180
+        sorting: 640
+        title: Foo
+        type: regular
+        alias: index
+    -
+        id: 4194
+        includeLayout: 1
+        layout: 1
+        published: 1
+        pid: 0
+        sorting: 2688
+        title: Foo
+        type: root
+        alias: en
+        language: en
+        dns: domain7.org
+        urlPrefix: en
+    -
+        id: 4199
+        published: 1
+        pid: 4194
+        sorting: 640
+        title: Foo
+        type: regular
+        alias: home
+    -
+        id: 4221
+        fallback: 1
+        includeLayout: 1
+        layout: 1
+        published: 1
+        pid: 0
+        sorting: 1792
+        title: Foo
+        type: root
+        alias: de
+        language: de_CH
+        dns: s3.example.com
+        urlPrefix: de
+    -
+        id: 4226
+        includeLayout: 1
+        layout: 1
+        published: 1
+        pid: 4221
+        sorting: 640
+        title: Foo
+        type: regular
+        alias: index
+    -
+        id: 4293
+        fallback: 1
+        includeLayout: 1
+        layout: 1
+        published: 1
+        pid: 0
+        sorting: 2752
+        title: Foo
+        type: root
+        alias: de
+        language: de
+        dns: s4.example.org
+        urlPrefix: de
+    -
+        id: 4298
+        includeLayout: 1
+        layout: 1
+        published: 1
+        pid: 4293
+        sorting: 640
+        title: Foo
+        type: regular
+        alias: index
+    -
+        id: 4378
+        includeLayout: 1
+        layout: 1
+        published: 1
+        pid: 0
+        sorting: 1344
+        title: Foo
+        type: root
+        alias: en
+        language: en
+        dns: s5.example.com
+        urlPrefix: en
+    -
+        id: 4383
+        includeLayout: 1
+        layout: 1
+        published: 1
+        pid: 4378
+        sorting: 640
+        title: Foo
+        type: regular
+        alias: index
+    -
+        id: 4480
+        fallback: 1
+        includeLayout: 1
+        layout: 1
+        published: 1
+        pid: 0
+        sorting: 1920
+        title: Foo
+        type: root
+        alias: de
+        language: de
+        dns: domain8.org
+        urlPrefix: de
+    -
+        id: 4485
+        includeLayout: 1
+        layout: 1
+        published: 1
+        pid: 4480
+        sorting: 640
+        title: Foo
+        type: regular
+        alias: index
+    -
+        id: 4602
+        fallback: 1
+        includeLayout: 1
+        layout: 1
+        published: 1
+        pid: 0
+        sorting: 4352
+        title: Foo
+        type: root
+        alias: de
+        language: de
+        dns: domain9.org
+        urlPrefix: de
+    -
+        id: 4607
+        includeLayout: 1
+        layout: 1
+        published: 1
+        pid: 4602
+        sorting: 640
+        title: Foo
+        type: regular
+        alias: index
+    -
+        id: 4646
+        fallback: 1
+        includeLayout: 1
+        layout: 1
+        published: 1
+        pid: 0
+        sorting: 4480
+        title: Foo
+        type: root
+        alias: de
+        language: de
+        dns: domain10.org
+        urlPrefix: de
+    -
+        id: 4651
+        includeLayout: 1
+        layout: 1
+        published: 1
+        pid: 4646
+        sorting: 640
+        title: Foo
+        type: regular
+        alias: index
+    -
+        id: 4679
+        fallback: 1
+        includeLayout: 1
+        layout: 1
+        published: 1
+        pid: 0
+        sorting: 2784
+        title: Foo
+        type: root
+        alias: de
+        language: de
+        dns: s8.example.org
+        urlPrefix: de
+    -
+        id: 4827
+        published: 1
+        pid: 4679
+        sorting: 576
+        title: Foo
+        type: regular
+        alias: index
+    -
+        id: 4901
+        fallback: 1
+        includeLayout: 1
+        layout: 1
+        published: 1
+        pid: 0
+        sorting: 4608
+        title: Foo
+        type: root
+        alias: de
+        language: de
+        dns: domain1.org
+        urlPrefix: de
+    -
+        id: 4906
+        includeLayout: 1
+        layout: 1
+        published: 1
+        pid: 4901
+        sorting: 640
+        title: Foo
+        type: regular
+        alias: index
+    -
+        id: 4954
+        includeLayout: 1
+        layout: 1
+        published: 1
+        pid: 0
+        sorting: 4736
+        title: Foo
+        type: root
+        alias: en
+        language: en
+        dns: domain1.org
+        urlPrefix: en
+    -
+        id: 4959
+        includeLayout: 1
+        layout: 1
+        published: 1
+        pid: 4954
+        sorting: 640
+        title: Foo
+        type: regular
+        alias: index
+    -
+        id: 4960
+        published: 0
+        pid: 4959
+        sorting: 128
+        title: Foo
+        type: regular
+        alias: foo
+    -
+        id: 4961
+        requireItem: 1
+        published: 0
+        pid: 4960
+        sorting: 128
+        title: Foo
+        type: regular
+        alias: foo/foo
+    -
+        id: 4962
+        includeLayout: 1
+        layout: 1
+        published: 0
+        pid: 4959
+        sorting: 384
+        title: Foo
+        type: regular
+        alias: foo
+    -
+        id: 4963
+        includeLayout: 1
+        layout: 1
+        published: 0
+        pid: 4962
+        sorting: 128
+        title: Foo
+        type: regular
+        alias: foo/foo
+    -
+        id: 4964
+        published: 1
+        pid: 4954
+        sorting: 848
+        title: Foo
+        type: regular
+        alias: foo
+    -
+        id: 4965
+        published: 1
+        pid: 4954
+        sorting: 1888
+        title: Foo
+        type: regular
+        alias: foo
+    -
+        id: 4966
+        layout: 1
+        published: 1
+        pid: 4965
+        sorting: 128
+        title: Foo
+        type: regular
+        alias: foo/foo
+    -
+        id: 4967
+        layout: 1
+        published: 1
+        pid: 4966
+        sorting: 256
+        title: Foo
+        type: regular
+        alias: foo
+    -
+        id: 4968
+        layout: 1
+        published: 1
+        pid: 4966
+        sorting: 384
+        title: Foo
+        type: regular
+        alias: foo
+    -
+        id: 4969
+        layout: 1
+        published: 1
+        pid: 4965
+        sorting: 256
+        title: Foo
+        type: regular
+        alias: foo/foo
+    -
+        id: 4970
+        layout: 1
+        published: 1
+        pid: 4965
+        sorting: 384
+        title: Foo
+        type: regular
+        alias: foo/foo
+    -
+        id: 4971
+        published: 1
+        pid: 4954
+        sorting: 2096
+        title: Foo
+        type: regular
+        alias: foo
+    -
+        id: 4972
+        layout: 1
+        published: 1
+        pid: 4971
+        sorting: 64
+        title: Foo
+        type: regular
+        alias: foo/foo
+    -
+        id: 4973
+        layout: 1
+        published: 1
+        pid: 4971
+        sorting: 96
+        title: Foo
+        type: regular
+        alias: foo/foo
+    -
+        id: 4974
+        layout: 1
+        published: 1
+        pid: 4971
+        sorting: 256
+        title: Foo
+        type: regular
+        alias: foo/foo
+    -
+        id: 4975
+        layout: 1
+        published: 1
+        pid: 4971
+        sorting: 384
+        title: Foo
+        type: regular
+        alias: foo/foo
+    -
+        id: 4976
+        published: 1
+        pid: 4954
+        sorting: 2304
+        title: Foo
+        type: folder
+    -
+        id: 4977
+        layout: 1
+        published: 1
+        pid: 4976
+        sorting: 128
+        title: Foo
+        type: regular
+        alias: search
+    -
+        id: 4978
+        published: 1
+        pid: 4976
+        sorting: 256
+        title: Foo
+        type: forward
+        alias: register
+    -
+        id: 4979
+        published: 1
+        pid: 4954
+        sorting: 2432
+        title: Foo
+        type: folder
+    -
+        id: 4980
+        published: 1
+        pid: 4954
+        sorting: 2560
+        title: Foo
+        type: folder
+    -
+        id: 4981
+        published: 0
+        pid: 4980
+        sorting: 64
+        title: Foo
+        type: regular
+        alias: foo
+    -
+        id: 4982
+        published: 0
+        pid: 4980
+        sorting: 96
+        title: Foo
+        type: regular
+        alias: foo
+    -
+        id: 4983
+        includeLayout: 1
+        layout: 1
+        published: 0
+        pid: 4980
+        sorting: 128
+        title: Foo
+        type: regular
+        alias: foo
+    -
+        id: 4986
+        published: 1
+        pid: 635
+        sorting: 320
+        title: Foo
+        type: regular
+        alias: foo
+    -
+        id: 4987
+        published: 1
+        pid: 2306
+        sorting: 256
+        title: Foo
+        type: regular
+        alias: foo
+    -
+        id: 4988
+        published: 1
+        pid: 2485
+        sorting: 256
+        title: Foo
+        type: regular
+        alias: foo
+    -
+        id: 4989
+        includeLayout: 1
+        layout: 1
+        published: 1
+        pid: 4152
+        sorting: 192
+        title: Foo
+        type: regular
+        alias: foo/foo
+    -
+        id: 4990
+        includeLayout: 1
+        layout: 1
+        published: 1
+        pid: 4408
+        sorting: 192
+        title: Foo
+        type: regular
+        alias: foo/foo
+    -
+        id: 5000
+        includeLayout: 1
+        layout: 1
+        published: 1
+        pid: 449
+        sorting: 728
+        title: Foo
+        type: regular
+        alias: foo
+    -
+        id: 5006
+        published: 1
+        pid: 5005
+        sorting: 128
+        title: Foo
+        type: regular
+    -
+        id: 5009
+        includeLayout: 1
+        layout: 1
+        published: 1
+        pid: 5008
+        sorting: 128
+        title: Foo
+        type: regular
+    -
+        id: 5010
+        includeLayout: 1
+        layout: 1
+        published: 1
+        pid: 5008
+        sorting: 256
+        title: Foo
+        type: regular
+    -
+        id: 5011
+        published: 1
+        pid: 5008
+        sorting: 384
+        title: Foo
+        type: regular
+    -
+        id: 5033
+        published: 1
+        pid: 636
+        sorting: 288
+        title: Foo
+        type: regular
+        alias: foo
+    -
+        id: 5035
+        layout: 1
+        published: 1
+        pid: 777
+        sorting: 64
+        title: Foo
+        type: regular
+        alias: foo
+    -
+        id: 5036
+        published: 1
+        pid: 2309
+        sorting: 288
+        title: Foo
+        type: regular
+        alias: foo
+    -
+        id: 5037
+        published: 1
+        pid: 2488
+        sorting: 288
+        title: Foo
+        type: regular
+        alias: foo
+    -
+        id: 5045
+        published: 1
+        pid: 1789
+        sorting: 128
+        title: Foo
+        type: regular
+        alias: foo/foo/foo
+    -
+        id: 5046
+        published: 1
+        pid: 1789
+        sorting: 256
+        title: Foo
+        type: regular
+        alias: foo/foo/foo
+    -
+        id: 5047
+        published: 1
+        pid: 1789
+        sorting: 384
+        title: Foo
+        type: regular
+        alias: foo/foo/foo
+    -
+        id: 5048
+        published: 1
+        pid: 1789
+        sorting: 512
+        title: Foo
+        type: regular
+        alias: foo/foo/foo
+    -
+        id: 5049
+        published: 1
+        pid: 1789
+        sorting: 640
+        title: Foo
+        type: regular
+        alias: foo/foo/foo
+    -
+        id: 5050
+        published: 1
+        pid: 1789
+        sorting: 768
+        title: Foo
+        type: regular
+        alias: foo/foo/foo
+    -
+        id: 5051
+        published: 1
+        pid: 1789
+        sorting: 896
+        title: Foo
+        type: regular
+        alias: foo/foo/foo
+    -
+        id: 5052
+        published: 1
+        pid: 2080
+        sorting: 128
+        title: Foo
+        type: regular
+        alias: foo/foo/foo
+    -
+        id: 5053
+        published: 1
+        pid: 2080
+        sorting: 256
+        title: Foo
+        type: regular
+        alias: foo/foo/foo
+    -
+        id: 5054
+        published: 1
+        pid: 2080
+        sorting: 384
+        title: Foo
+        type: regular
+        alias: foo/foo/foo
+    -
+        id: 5055
+        published: 1
+        pid: 2080
+        sorting: 512
+        title: Foo
+        type: regular
+        alias: foo/foo/foo
+    -
+        id: 5056
+        published: 1
+        pid: 2080
+        sorting: 640
+        title: Foo
+        type: regular
+        alias: foo/foo/foo
+    -
+        id: 5057
+        published: 1
+        pid: 2080
+        sorting: 768
+        title: Foo
+        type: regular
+        alias: foo/foo/foo
+    -
+        id: 5058
+        published: 1
+        pid: 2080
+        sorting: 896
+        title: Foo
+        type: regular
+        alias: foo/foo/foo
+    -
+        id: 5059
+        includeLayout: 1
+        layout: 1
+        published: 1
+        pid: 4408
+        sorting: 224
+        title: Foo
+        type: regular
+        alias: foo/foo
+    -
+        id: 5067
+        includeLayout: 1
+        layout: 1
+        published: 1
+        pid: 1801
+        sorting: 32
+        title: Foo
+        type: regular
+        alias: foo/foo
+    -
+        id: 5068
+        includeLayout: 1
+        layout: 1
+        published: 1
+        pid: 635
+        sorting: 64
+        title: Foo
+        type: regular
+        alias: foo
+    -
+        id: 5069
+        includeLayout: 1
+        layout: 1
+        published: 1
+        pid: 2306
+        sorting: 64
+        title: Foo
+        type: regular
+        alias: foo
+    -
+        id: 5073
+        includeLayout: 1
+        layout: 1
+        published: 1
+        pid: 1801
+        sorting: 16
+        title: Foo
+        type: regular
+        alias: foo/foo
+    -
+        id: 5074
+        includeLayout: 1
+        layout: 1
+        published: 1
+        pid: 2092
+        sorting: 32
+        title: Foo
+        type: regular
+        alias: foo/foo
+    -
+        id: 5079
+        published: 1
+        pid: 9
+        sorting: 256
+        title: Foo
+        type: regular
+        alias: foo
+    -
+        id: 5080
+        includeLayout: 1
+        layout: 1
+        published: 0
+        pid: 929
+        sorting: 1024
+        title: Foo
+        type: regular
+        alias: foo
+    -
+        id: 5103
+        includeLayout: 1
+        layout: 1
+        published: 0
+        pid: 929
+        sorting: 256
+        title: Foo
+        type: regular
+        alias: foo
+    -
+        id: 5106
+        published: 1
+        pid: 635
+        sorting: 32
+        title: Foo
+        type: regular
+        alias: foo
+    -
+        id: 5107
+        fallback: 1
+        includeLayout: 1
+        layout: 1
+        published: 1
+        pid: 0
+        sorting: 4864
+        title: Foo
+        type: root
+        alias: de
+        language: de_CH
+        dns: domain11.org
+        urlPrefix: de
+    -
+        id: 5108
+        published: 1
+        pid: 5107
+        sorting: 128
+        title: Foo
+        type: regular
+        alias: index
+    -
+        id: 5229
+        fallback: 1
+        includeLayout: 1
+        layout: 1
+        published: 1
+        pid: 0
+        sorting: 4992
+        title: Foo
+        type: root
+        alias: de
+        language: de
+        dns: example.ch
+        urlPrefix: de
+    -
+        id: 5234
+        published: 1
+        pid: 5229
+        sorting: 128
+        title: Foo
+        type: regular
+        alias: index
+    -
+        id: 5299
+        includeLayout: 1
+        layout: 1
+        published: 1
+        pid: 0
+        sorting: 5120
+        title: Foo
+        type: root
+        alias: en
+        language: en
+        dns: example.ch
+        urlPrefix: en
+    -
+        id: 5300
+        published: 1
+        pid: 5299
+        sorting: 128
+        title: Foo
+        type: regular
+        alias: index
+    -
+        id: 5301
+        published: 1
+        pid: 5299
+        sorting: 256
+        title: Foo
+        type: regular
+        alias: foo
+    -
+        id: 5303
+        published: 0
+        pid: 5296
+        sorting: 128
+        title: Foo
+        type: regular
+        alias: foo/foo
+    -
+        id: 5304
+        published: 0
+        pid: 5296
+        sorting: 256
+        title: Foo
+        type: regular
+        alias: foo/foo
+    -
+        id: 5305
+        published: 1
+        pid: 5229
+        sorting: 608
+        title: Foo
+        type: regular
+        alias: bar
+    -
+        id: 5306
+        published: 1
+        pid: 5305
+        sorting: 64
+        title: Bar
+        type: regular
+        alias: bar/bar
+    -
+        id: 5313
+        published: 0
+        pid: 5311
+        sorting: 256
+        title: Foo
+        type: regular
+    -
+        id: 5315
+        published: 0
+        pid: 5313
+        sorting: 256
+        title: Foo
+        type: regular
+    -
+        id: 5316
+        published: 0
+        pid: 5313
+        sorting: 384
+        title: Foo
+        type: regular
+    -
+        id: 5317
+        published: 0
+        pid: 5313
+        sorting: 512
+        title: Foo
+        type: regular
+    -
+        id: 5318
+        published: 0
+        pid: 5311
+        sorting: 896
+        title: Foo
+        type: regular
+    -
+        id: 5319
+        includeLayout: 1
+        layout: 1
+        published: 0
+        pid: 5311
+        sorting: 1024
+        title: Foo
+        type: regular
+    -
+        id: 5320
+        includeLayout: 1
+        layout: 1
+        published: 0
+        pid: 5311
+        sorting: 1152
+        title: Foo
+        type: regular
+    -
+        id: 5321
+        includeLayout: 1
+        layout: 1
+        published: 0
+        pid: 5311
+        sorting: 1280
+        title: Foo
+        type: regular
+    -
+        id: 5323
+        includeLayout: 1
+        layout: 1
+        published: 0
+        pid: 5322
+        sorting: 128
+        title: Foo
+        type: regular
+    -
+        id: 5324
+        published: 0
+        pid: 5322
+        sorting: 256
+        title: Foo
+        type: regular
+    -
+        id: 5325
+        published: 0
+        pid: 5324
+        sorting: 128
+        title: Foo
+        type: regular
+    -
+        id: 5326
+        published: 0
+        pid: 5324
+        sorting: 256
+        title: Foo
+        type: regular
+    -
+        id: 5327
+        published: 0
+        pid: 5324
+        sorting: 384
+        title: Foo
+        type: regular
+    -
+        id: 5328
+        published: 0
+        pid: 5322
+        sorting: 768
+        title: Foo
+        type: regular
+    -
+        id: 5329
+        includeLayout: 1
+        layout: 1
+        published: 0
+        pid: 5322
+        sorting: 896
+        title: Foo
+        type: regular
+    -
+        id: 5330
+        includeLayout: 1
+        layout: 1
+        published: 0
+        pid: 5322
+        sorting: 1024
+        title: Foo
+        type: regular
+    -
+        id: 5331
+        includeLayout: 1
+        layout: 1
+        published: 0
+        pid: 5322
+        sorting: 1152
+        title: Foo
+        type: regular
+    -
+        id: 5341
+        published: 1
+        pid: 5290
+        sorting: 256
+        title: Foo
+        type: regular
+        alias: foo
+    -
+        id: 5342
+        includeLayout: 1
+        layout: 1
+        published: 1
+        pid: 9
+        sorting: 64
+        title: Foo
+        type: regular
+        alias: foo
+    -
+        id: 5343
+        includeLayout: 1
+        layout: 1
+        published: 1
+        pid: 1801
+        sorting: 8
+        title: Foo
+        type: regular
+        alias: foo/foo
+    -
+        id: 5350
+        includeLayout: 1
+        layout: 1
+        published: 1
+        pid: 929
+        sorting: 4
+        title: Foo
+        type: regular
+        alias: foo

--- a/core-bundle/tests/Functional/RoutingTest.php
+++ b/core-bundle/tests/Functional/RoutingTest.php
@@ -1167,6 +1167,27 @@ class RoutingTest extends FunctionalTestCase
         ];
     }
 
+    public function testMultidomainWithLanguages(): void
+    {
+        $request = '/de/bar/bar';
+        $_SERVER['REQUEST_URI'] = $request;
+        $_SERVER['HTTP_HOST'] = 'example.ch';
+        $_SERVER['HTTP_ACCEPT_LANGUAGE'] = 'en_US,en';
+        $_SERVER['HTTP_ACCEPT'] = 'text/html';
+
+        $client = $this->createClient([], $_SERVER);
+        System::setContainer($client->getContainer());
+
+        $this->loadFixtureFiles(['theme', 'multidomain-languages']);
+
+        $crawler = $client->request('GET', "https://example.ch$request");
+        $title = trim($crawler->filterXPath('//head/title')->text());
+        $response = $client->getResponse();
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertStringContainsString('Bar -', $title);
+    }
+
     private function loadFixtureFiles(array $fileNames): void
     {
         // Do not reload the fixtures if they have not changed


### PR DESCRIPTION
Today we had a very edge case on a client system with incorrect sorting of pages / incorrect match in the front end. I was able to reproduce and write a test case including anonymized data. The test data is pretty extensive, but I removed what was possible without causing the issue to be gone.

Basically, I think the page results were not fully sorted because it did not sort the same language across different domains.