### PR TITLE
Set status code 422 for widget errors in `AbstractBackendController::render()`

### DIFF
--- a/core-bundle/contao/controllers/BackendMain.php
+++ b/core-bundle/contao/controllers/BackendMain.php
@@ -149,7 +149,7 @@ class BackendMain extends Backend
 		// Turbo can handle form errors.
 		$response = $this->output();
 
-		if (System::getContainer()->get('request_stack')?->getMainRequest()->attributes->has('_contao_widget_error'))
+		if (200 === $response->getStatusCode() && System::getContainer()->get('request_stack')?->getMainRequest()->attributes->has('_contao_widget_error'))
 		{
 			$response->setStatusCode(Response::HTTP_UNPROCESSABLE_ENTITY);
 		}

--- a/core-bundle/contao/controllers/BackendMain.php
+++ b/core-bundle/contao/controllers/BackendMain.php
@@ -149,7 +149,7 @@ class BackendMain extends Backend
 		// Turbo can handle form errors.
 		$response = $this->output();
 
-		if (200 === $response->getStatusCode() && System::getContainer()->get('request_stack')?->getMainRequest()->attributes->has('_contao_widget_error'))
+		if (200 === $response->getStatusCode() && System::getContainer()->get('request_stack')->getMainRequest()->attributes->has('_contao_widget_error'))
 		{
 			$response->setStatusCode(Response::HTTP_UNPROCESSABLE_ENTITY);
 		}

--- a/core-bundle/src/Controller/AbstractBackendController.php
+++ b/core-bundle/src/Controller/AbstractBackendController.php
@@ -86,7 +86,7 @@ abstract class AbstractBackendController extends AbstractController
 
         // Set the status code to 422 if a widget did not validate, so that Turbo can
         // handle form errors.
-        if ($this->container->get('request_stack')->getMainRequest()->attributes->has('_contao_widget_error')) {
+        if (200 === $response->getStatusCode() && $this->container->get('request_stack')->getMainRequest()->attributes->has('_contao_widget_error')) {
             $response->setStatusCode(Response::HTTP_UNPROCESSABLE_ENTITY);
         }
 

--- a/core-bundle/src/Controller/AbstractBackendController.php
+++ b/core-bundle/src/Controller/AbstractBackendController.php
@@ -82,7 +82,15 @@ abstract class AbstractBackendController extends AbstractController
             $parameters = [...$getBackendContext(), ...$parameters];
         }
 
-        return parent::render($view, $parameters, $response);
+        $response = parent::render($view, $parameters, $response);
+
+        // Set the status code to 422 if a widget did not validate, so that Turbo can
+        // handle form errors.
+        if ($this->container->get('request_stack')->getMainRequest()->attributes->has('_contao_widget_error')) {
+            $response->setStatusCode(Response::HTTP_UNPROCESSABLE_ENTITY);
+        }
+
+        return $response;
     }
 
     protected function getBackendSessionBag(): AttributeBagInterface|null

--- a/core-bundle/tests/Controller/AbstractBackendControllerTest.php
+++ b/core-bundle/tests/Controller/AbstractBackendControllerTest.php
@@ -113,14 +113,15 @@ class AbstractBackendControllerTest extends TestCase
     /**
      * @dataProvider provideRequests
      */
-    public function testHandlesTurboRequests(Request $request, bool|null $includeChromeContext, array $expectedContext, string $expectedRequestFormat = 'html', int $expectedStatus = Response::HTTP_OK): void
+    public function testHandlesTurboRequests(Request $request, bool|null $includeChromeContext, array $expectedContext, string $expectedRequestFormat = 'html', int $expectedStatus = Response::HTTP_OK, Response|null $response = null): void
     {
         $controller = new class() extends AbstractBackendController {
-            public function fooAction(bool|null $includeChromeContext): Response
+            public function fooAction(bool|null $includeChromeContext, Response|null $response = null): Response
             {
                 return $this->render(
                     'custom_be.html.twig',
                     ['version' => 'my version'],
+                    $response,
                     includeChromeContext: $includeChromeContext,
                 );
             }
@@ -148,7 +149,7 @@ class AbstractBackendControllerTest extends TestCase
 
         System::setContainer($container);
         $controller->setContainer($container);
-        $response = $controller->fooAction($includeChromeContext);
+        $response = $controller->fooAction($includeChromeContext, $response);
 
         $this->assertSame('<custom_be_main>', $response->getContent());
         $this->assertSame($expectedRequestFormat, $request->getRequestFormat());
@@ -247,6 +248,15 @@ class AbstractBackendControllerTest extends TestCase
             $customContext,
             'html',
             Response::HTTP_UNPROCESSABLE_ENTITY,
+        ];
+
+        yield 'request with widget error and 500 response' => [
+            new Request(attributes: ['_contao_widget_error' => true], server: ['HTTP_HOST' => 'localhost']),
+            false,
+            $customContext,
+            'html',
+            Response::HTTP_INTERNAL_SERVER_ERROR,
+            (new Response(status: Response::HTTP_INTERNAL_SERVER_ERROR))
         ];
     }
 

--- a/core-bundle/tests/Controller/AbstractBackendControllerTest.php
+++ b/core-bundle/tests/Controller/AbstractBackendControllerTest.php
@@ -113,7 +113,7 @@ class AbstractBackendControllerTest extends TestCase
     /**
      * @dataProvider provideRequests
      */
-    public function testHandlesTurboRequests(Request $request, bool|null $includeChromeContext, array $expectedContext, string $expectedRequestFormat = 'html'): void
+    public function testHandlesTurboRequests(Request $request, bool|null $includeChromeContext, array $expectedContext, string $expectedRequestFormat = 'html', int $expectedStatus = Response::HTTP_OK): void
     {
         $controller = new class() extends AbstractBackendController {
             public function fooAction(bool|null $includeChromeContext): Response
@@ -148,9 +148,11 @@ class AbstractBackendControllerTest extends TestCase
 
         System::setContainer($container);
         $controller->setContainer($container);
+        $response = $controller->fooAction($includeChromeContext);
 
-        $this->assertSame('<custom_be_main>', $controller->fooAction($includeChromeContext)->getContent());
+        $this->assertSame('<custom_be_main>', $response->getContent());
         $this->assertSame($expectedRequestFormat, $request->getRequestFormat());
+        $this->assertSame($expectedStatus, $response->getStatusCode());
     }
 
     public static function provideRequests(): iterable
@@ -237,6 +239,14 @@ class AbstractBackendControllerTest extends TestCase
             $plainRequest,
             false,
             $customContext,
+        ];
+
+        yield 'request with widget error' => [
+            new Request(attributes: ['_contao_widget_error' => true], server: ['HTTP_HOST' => 'localhost']),
+            false,
+            $customContext,
+            'html',
+            Response::HTTP_UNPROCESSABLE_ENTITY,
         ];
     }
 

--- a/core-bundle/tests/Controller/AbstractBackendControllerTest.php
+++ b/core-bundle/tests/Controller/AbstractBackendControllerTest.php
@@ -256,7 +256,7 @@ class AbstractBackendControllerTest extends TestCase
             $customContext,
             'html',
             Response::HTTP_INTERNAL_SERVER_ERROR,
-            (new Response(status: Response::HTTP_INTERNAL_SERVER_ERROR))
+            new Response(status: Response::HTTP_INTERNAL_SERVER_ERROR),
         ];
     }
 


### PR DESCRIPTION
In https://github.com/contao/contao/pull/7011 we have introduced the `_contao_widget_error` request attribute according to which we set the response status to `422` if present. However, currently this only happens in `BackendMain`:

https://github.com/contao/contao/blob/4f485fe5410d7ec1e7c9efc9ee5972844d094aec/core-bundle/contao/controllers/BackendMain.php#L148-L155

This PR also sets the status code automatically, when using `AbstractBackendController::render()`.

Alternatively we could also implement a response listener and always set this status code for the back end, wdyt?
