### PR TITLE
Fix binary UUIDs in the back end search results

### DIFF
--- a/core-bundle/config/backend_search.yaml
+++ b/core-bundle/config/backend_search.yaml
@@ -40,6 +40,9 @@ services:
             - '@router'
             - '%contao.upload_path%'
 
+    contao.search.backend.format_binary_uuid_results_listener:
+        class: Contao\CoreBundle\Search\Backend\EventListener\FormatBinaryUuidSearchResultsListener
+
     contao.search.backend.format_core_widget_results_listener:
         class: Contao\CoreBundle\Search\Backend\EventListener\FormatCoreWidgetSearchResultsListener
 

--- a/core-bundle/src/Search/Backend/EventListener/FormatBinaryUuidSearchResultsListener.php
+++ b/core-bundle/src/Search/Backend/EventListener/FormatBinaryUuidSearchResultsListener.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Search\Backend\EventListener;
+
+use Contao\CoreBundle\Search\Backend\Event\FormatTableDataContainerDocumentEvent;
+use Contao\StringUtil;
+use Contao\Validator;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+
+#[AsEventListener]
+class FormatBinaryUuidSearchResultsListener
+{
+    public function __invoke(FormatTableDataContainerDocumentEvent $event): void
+    {
+        $event->setSearchableContent($this->convertBinaryUuidToHex($event->getSearchableContent()));
+    }
+
+    private function convertBinaryUuidToHex(string $uuid): string
+    {
+        if (Validator::isBinaryUuid($uuid)) {
+            return StringUtil::binToUuid($uuid);
+        }
+
+        return $uuid;
+    }
+}

--- a/core-bundle/tests/Search/Backend/EventListener/FormatBinaryUuidSearchResultsListenerTest.php
+++ b/core-bundle/tests/Search/Backend/EventListener/FormatBinaryUuidSearchResultsListenerTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\CoreBundle\Tests\Search\Backend\EventListener;
+
+use Contao\CoreBundle\Search\Backend\Event\FormatTableDataContainerDocumentEvent;
+use Contao\CoreBundle\Search\Backend\EventListener\FormatBinaryUuidSearchResultsListener;
+use Contao\StringUtil;
+use PHPUnit\Framework\TestCase;
+
+class FormatBinaryUuidSearchResultsListenerTest extends TestCase
+{
+    public function testInvokeWithRegularContent(): void
+    {
+        $event = new FormatTableDataContainerDocumentEvent('This is some content', []);
+        $listener = new FormatBinaryUuidSearchResultsListener();
+        $listener($event);
+        $this->assertSame('This is some content', $event->getSearchableContent());
+    }
+
+    public function testInvokeWithBinaryUuid(): void
+    {
+        $uuid = '9e474bae-ce18-11ec-9465-cadae3e5cf5d';
+        $event = new FormatTableDataContainerDocumentEvent(StringUtil::uuidToBin($uuid), []);
+        $listener = new FormatBinaryUuidSearchResultsListener();
+        $listener($event);
+        $this->assertSame($uuid, $event->getSearchableContent());
+    }
+}


### PR DESCRIPTION
If you have a binary UUID in a table and mark this as `search -> true` you currently get an error in the backend search because nobody is converting the binary data into a indexable/JSON compatible string.

This will convert them all to the hexadecimal notation and thus you may search for the UUID in the backend search.
