### PR TITLE
Throw an exception on backup errors

### DIFF
--- a/core-bundle/src/Doctrine/Backup/BackupManager.php
+++ b/core-bundle/src/Doctrine/Backup/BackupManager.php
@@ -191,7 +191,10 @@ class BackupManager
             $data = deflate_add($deflateContext, $data, ZLIB_NO_FLUSH);
         }
 
-        @fwrite($fileHandle, $data);
+        if (false === fwrite($fileHandle, $data)) {
+            throw new \RuntimeException('Could not write backup data.');
+        }
+
         fflush($fileHandle);
     }
 
@@ -201,7 +204,9 @@ class BackupManager
     private function finishWriting(Backup $backup, $fileHandle, \DeflateContext|null $deflateContext): void
     {
         if ($deflateContext) {
-            fwrite($fileHandle, deflate_add($deflateContext, '', ZLIB_FINISH));
+            if (false === fwrite($fileHandle, deflate_add($deflateContext, '', ZLIB_FINISH))) {
+                throw new \RuntimeException('Could not write backup data.');
+            }
         }
 
         $this->backupsStorage->writeStream($backup->getFilename(), $fileHandle);

--- a/core-bundle/src/Doctrine/Backup/BackupManager.php
+++ b/core-bundle/src/Doctrine/Backup/BackupManager.php
@@ -203,10 +203,8 @@ class BackupManager
      */
     private function finishWriting(Backup $backup, $fileHandle, \DeflateContext|null $deflateContext): void
     {
-        if ($deflateContext) {
-            if (false === fwrite($fileHandle, deflate_add($deflateContext, '', ZLIB_FINISH))) {
-                throw new \RuntimeException('Could not write backup data.');
-            }
+        if ($deflateContext && false === fwrite($fileHandle, deflate_add($deflateContext, '', ZLIB_FINISH))) {
+            throw new \RuntimeException('Could not write backup data.');
         }
 
         $this->backupsStorage->writeStream($backup->getFilename(), $fileHandle);


### PR DESCRIPTION
Fixes #6958

I also removed the error silencing on `fwrite` in `writeLine()`. This should then create an exception (due to `E_WARNING`) when you try to create the backup in debug mode.