### PR TITLE
Fix missing reference when editing children

### DIFF
--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -241,9 +241,17 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 		{
 			$strKey = Input::get('popup') ? 'popupReferer' : 'referer';
 			$strRefererId = $request->attributes->get('_contao_referer_id');
-
 			$session = $objSession->get($strKey);
+
+			// Store previous URL
+			if (($previous = end($session)) && $previous['current'] ?? null) {
+				$session[$strRefererId]['last'] = $previous['current'];
+			}
+
+			// Store the current URL
 			$session[$strRefererId][$this->strTable] = Environment::get('requestUri');
+			$session[$strRefererId]['current'] = $session[$strRefererId][$this->strTable];
+
 			$objSession->set($strKey, $session);
 		}
 


### PR DESCRIPTION
Fixes #8137

The issue is, that when doing _Save and edit children_, `DC_Table` will only put an entry for `tl_content` into the `referer` array for the resulting new reference. Thus there won't be any URL for the _Go back_ link to use.

This PR fixes that by letting `DC_Table` also set the `current` and `last` entries. Only then can `System::getReferer()` retrieve the correct referrer URL.