### PR TITLE
Use the module ID for flash bag variables in the newsletter modules

### DIFF
--- a/newsletter-bundle/contao/modules/ModuleSubscribe.php
+++ b/newsletter-bundle/contao/modules/ModuleSubscribe.php
@@ -126,9 +126,9 @@ class ModuleSubscribe extends Module
 		{
 			$flashBag = $session->getFlashBag();
 
-			if ($flashBag->has('nl_confirm'))
+			if ($flashBag->has('nl_confirm_'.$this->id))
 			{
-				$arrMessages = $flashBag->get('nl_confirm');
+				$arrMessages = $flashBag->get('nl_confirm_'.$this->id);
 
 				$this->Template->mclass = 'confirm';
 				$this->Template->message = $arrMessages[0];
@@ -383,7 +383,7 @@ class ModuleSubscribe extends Module
 			}
 		}
 
-		System::getContainer()->get('request_stack')->getSession()->getFlashBag()->set('nl_confirm', $GLOBALS['TL_LANG']['MSC']['nl_confirm']);
+		System::getContainer()->get('request_stack')->getSession()->getFlashBag()->set('nl_confirm_'.$this->id, $GLOBALS['TL_LANG']['MSC']['nl_confirm']);
 
 		$this->reload();
 	}

--- a/newsletter-bundle/contao/modules/ModuleUnsubscribe.php
+++ b/newsletter-bundle/contao/modules/ModuleUnsubscribe.php
@@ -117,9 +117,9 @@ class ModuleUnsubscribe extends Module
 		{
 			$flashBag = $session->getFlashBag();
 
-			if ($flashBag->has('nl_removed'))
+			if ($flashBag->has('nl_removed_'.$this->id))
 			{
-				$arrMessages = $flashBag->get('nl_removed');
+				$arrMessages = $flashBag->get('nl_removed_'.$this->id);
 
 				$this->Template->mclass = 'confirm';
 				$this->Template->message = $arrMessages[0];
@@ -293,7 +293,7 @@ class ModuleUnsubscribe extends Module
 			}
 		}
 
-		System::getContainer()->get('request_stack')->getSession()->getFlashBag()->set('nl_removed', $GLOBALS['TL_LANG']['MSC']['nl_removed']);
+		System::getContainer()->get('request_stack')->getSession()->getFlashBag()->set('nl_removed_'.$this->id, $GLOBALS['TL_LANG']['MSC']['nl_removed']);
 
 		$this->reload();
 	}


### PR DESCRIPTION
Fixes #7015

This PR appends the module ID to fix the issue - just as with `FORM_SUBMIT`.