### PR TITLE
Make `tl_newsletter_subscriptions.email` nullable

### DIFF
--- a/newsletter-bundle/contao/dca/tl_newsletter_recipients.php
+++ b/newsletter-bundle/contao/dca/tl_newsletter_recipients.php
@@ -99,7 +99,7 @@ $GLOBALS['TL_DCA']['tl_newsletter_recipients'] = array
 				array('tl_newsletter_recipients', 'checkUniqueRecipient'),
 				array('tl_newsletter_recipients', 'checkDenyList')
 			),
-			'sql'                     => "varchar(255) NOT NULL default ''"
+			'sql'                     => ['type'=>'string', 'length'=>255, 'notnull'=>false],
 		),
 		'active' => array
 		(


### PR DESCRIPTION
Fixes #7211

Basically the same fix as in https://github.com/contao/contao/pull/7219. I haven't noticed any issues with it.