### PR TITLE
Add `alwaysSave` to `tl_calendar_feed.feedBase`

### DIFF
--- a/calendar-bundle/contao/dca/tl_calendar_feed.php
+++ b/calendar-bundle/contao/dca/tl_calendar_feed.php
@@ -176,7 +176,7 @@ $GLOBALS['TL_DCA']['tl_calendar_feed'] = array
 		(
 			'search'                  => true,
 			'inputType'               => 'text',
-			'eval'                    => array('trailingSlash'=>true, 'rgxp'=>HttpUrlListener::RGXP_NAME, 'decodeEntities'=>true, 'maxlength'=>255, 'tl_class'=>'w50'),
+			'eval'                    => array('trailingSlash'=>true, 'rgxp'=>HttpUrlListener::RGXP_NAME, 'decodeEntities'=>true, 'maxlength'=>255, 'tl_class'=>'w50', 'alwaysSave'=>true),
 			'load_callback' => array
 			(
 				array('tl_calendar_feed', 'addFeedBase')


### PR DESCRIPTION
Fixes #6570

When using a `load_callback` to set a _default value_ you also need to enable `alwaysSave`:

https://github.com/contao/contao/blob/29fcfb538baa600c0c6398b7e76a78a301341ea8/core-bundle/contao/drivers/DC_Table.php#L3381-L3397

(see also [here](https://docs.contao.org/dev/reference/dca/fields/#:~:text=alwaysSave)).