### PR TITLE
Correctly support the `:collapsed` keyword in the palette manipulator

### DIFF
--- a/core-bundle/src/DataContainer/PaletteManipulator.php
+++ b/core-bundle/src/DataContainer/PaletteManipulator.php
@@ -184,9 +184,9 @@ class PaletteManipulator
             $hide = false;
             $fields = StringUtil::trimsplit(',', $group);
 
-            if (preg_match('#{(.+?)(:hide)?}#', (string) $fields[0], $matches)) {
+            if (preg_match('#{(.+?)(:(collapsed|hide))?}#', (string) $fields[0], $matches)) {
                 $legend = $matches[1];
-                $hide = \count($matches) > 2 && ':hide' === $matches[2];
+                $hide = \count($matches) > 2 && (':collapsed' === $matches[2] || ':hide' === $matches[2]);
                 array_shift($fields);
             } else {
                 $legend = $legendCount++;

--- a/core-bundle/src/DataContainer/PaletteManipulator.php
+++ b/core-bundle/src/DataContainer/PaletteManipulator.php
@@ -184,7 +184,7 @@ class PaletteManipulator
             $hide = false;
             $fields = StringUtil::trimsplit(',', $group);
 
-            if (preg_match('#{(.+?)(:(collapsed|hide))?}#', (string) $fields[0], $matches)) {
+            if (preg_match('#{(.+?)(:collapsed|:hide)?}#', (string) $fields[0], $matches)) {
                 $legend = $matches[1];
                 $hide = \count($matches) > 2 && (':collapsed' === $matches[2] || ':hide' === $matches[2]);
                 array_shift($fields);

--- a/core-bundle/src/DataContainer/PaletteManipulator.php
+++ b/core-bundle/src/DataContainer/PaletteManipulator.php
@@ -186,7 +186,7 @@ class PaletteManipulator
 
             if (preg_match('#{(.+?)(:collapsed|:hide)?}#', (string) $fields[0], $matches)) {
                 $legend = $matches[1];
-                $hide = \count($matches) > 2 && (':collapsed' === $matches[2] || ':hide' === $matches[2]);
+                $hide = isset($matches[2]);
                 array_shift($fields);
             } else {
                 $legend = $legendCount++;


### PR DESCRIPTION
### Description

Whilst using the palette manipulator to add legends, I noticed that the newly created legend would not be appended to the parent if the newly introduced `:collapsed` was being used instead of the old deprecated `:hide`.

We are internally changing `:hide` to `:collapsed`, however, own DCA do not work with this when already having migrated towards the new way.

https://github.com/contao/contao/blob/de4b81a11ef416ca1d7553bbf642121d24541aa8/core-bundle/contao/drivers/DC_Table.php#L2127-L2131

https://github.com/contao/contao/blob/de4b81a11ef416ca1d7553bbf642121d24541aa8/core-bundle/assets/controllers/toggle-fieldset-controller.js#L64-L66
