### PR TITLE
Catch exceptions in the `DelegatingIndexer`

### DIFF
--- a/core-bundle/src/Search/Indexer/DelegatingIndexer.php
+++ b/core-bundle/src/Search/Indexer/DelegatingIndexer.php
@@ -65,6 +65,7 @@ class DelegatingIndexer implements IndexerInterface
                 $function($indexer);
             } catch (IndexerException $exception) {
                 $indexerExceptions[] = $exception;
+
                 if (!$exception->isOnlyWarning()) {
                     $warningsOnly = false;
                 }

--- a/core-bundle/src/Search/Indexer/DelegatingIndexer.php
+++ b/core-bundle/src/Search/Indexer/DelegatingIndexer.php
@@ -59,7 +59,6 @@ class DelegatingIndexer implements IndexerInterface
     {
         $warningsOnly = true;
         $indexerExceptions = [];
-        $generalExceptions = [];
 
         foreach ($this->indexers as $indexer) {
             try {
@@ -69,21 +68,15 @@ class DelegatingIndexer implements IndexerInterface
                 if (!$exception->isOnlyWarning()) {
                     $warningsOnly = false;
                 }
-            } catch (\Throwable $exception) {
-                $generalExceptions[] = $exception;
             }
-        }
-
-        if ([] !== $generalExceptions) {
-            throw new \LogicException($this->getMergedExceptionMessage($generalExceptions));
         }
 
         if ([] !== $indexerExceptions) {
             if ($warningsOnly) {
-                throw IndexerException::createAsWarning($this->getMergedExceptionMessage($indexerExceptions));
+                throw IndexerException::createAsWarning($this->getMergedExceptionMessage($indexerExceptions), 0, $indexerExceptions[0]);
             }
 
-            throw new IndexerException($this->getMergedExceptionMessage($indexerExceptions));
+            throw new IndexerException($this->getMergedExceptionMessage($indexerExceptions), 0, $indexerExceptions[0]);
         }
     }
 

--- a/core-bundle/src/Search/Indexer/IndexerException.php
+++ b/core-bundle/src/Search/Indexer/IndexerException.php
@@ -21,9 +21,9 @@ class IndexerException extends \RuntimeException
         return $this->isOnlyWarning;
     }
 
-    public static function createAsWarning(string $message): self
+    public static function createAsWarning(string $message, int $code = 0, \Throwable|null $previous = null): self
     {
-        $exception = new self($message);
+        $exception = new self($message, $code, $previous);
         $exception->isOnlyWarning = true;
 
         return $exception;

--- a/core-bundle/tests/Search/Indexer/DelegatingIndexerTest.php
+++ b/core-bundle/tests/Search/Indexer/DelegatingIndexerTest.php
@@ -36,6 +36,7 @@ class DelegatingIndexerTest extends TestCase
     public function testDelegatesAndCollectsIndexerExceptions(): void
     {
         $firstException = IndexerException::createAsWarning('Warning 1');
+
         $indexer1 = $this->createIndexer($firstException);
         $indexer2 = $this->createIndexer(new IndexerException('Failure 2'));
         $indexer3 = $this->createIndexer();
@@ -106,6 +107,7 @@ class DelegatingIndexerTest extends TestCase
     public function testWarningExceptionCollectionOnly(): void
     {
         $firstException = IndexerException::createAsWarning('Warning 1');
+
         $indexer1 = $this->createIndexer($firstException);
         $indexer2 = $this->createIndexer(IndexerException::createAsWarning('Warning 2'));
 
@@ -141,10 +143,12 @@ class DelegatingIndexerTest extends TestCase
     private function createIndexer(\Throwable|null $indexerException = null, bool $expectsCalls = true): IndexerInterface
     {
         $indexer = $this->createMock(IndexerInterface::class);
+
         $invocationMocker = $indexer
             ->expects($expectsCalls ? $this->once() : $this->never())
             ->method('index')
         ;
+
         $invocationMocker->with($this->isInstanceOf(Document::class));
 
         if ($indexerException) {
@@ -155,6 +159,7 @@ class DelegatingIndexerTest extends TestCase
             ->expects($expectsCalls ? $this->once() : $this->never())
             ->method('delete')
         ;
+
         $invocationMocker->with($this->isInstanceOf(Document::class));
 
         if ($indexerException) {

--- a/core-bundle/tests/Search/Indexer/DelegatingIndexerTest.php
+++ b/core-bundle/tests/Search/Indexer/DelegatingIndexerTest.php
@@ -14,6 +14,7 @@ namespace Contao\CoreBundle\Tests\Search\Indexer;
 
 use Contao\CoreBundle\Search\Document;
 use Contao\CoreBundle\Search\Indexer\DelegatingIndexer;
+use Contao\CoreBundle\Search\Indexer\IndexerException;
 use Contao\CoreBundle\Search\Indexer\IndexerInterface;
 use PHPUnit\Framework\TestCase;
 
@@ -21,41 +22,8 @@ class DelegatingIndexerTest extends TestCase
 {
     public function testDelegatesTheMethodCalls(): void
     {
-        $indexer1 = $this->createMock(IndexerInterface::class);
-        $indexer1
-            ->expects($this->once())
-            ->method('index')
-            ->with($this->isInstanceOf(Document::class))
-        ;
-
-        $indexer1
-            ->expects($this->once())
-            ->method('delete')
-            ->with($this->isInstanceOf(Document::class))
-        ;
-
-        $indexer1
-            ->expects($this->once())
-            ->method('clear')
-        ;
-
-        $indexer2 = $this->createMock(IndexerInterface::class);
-        $indexer2
-            ->expects($this->once())
-            ->method('index')
-            ->with($this->isInstanceOf(Document::class))
-        ;
-
-        $indexer2
-            ->expects($this->once())
-            ->method('delete')
-            ->with($this->isInstanceOf(Document::class))
-        ;
-
-        $indexer2
-            ->expects($this->once())
-            ->method('clear')
-        ;
+        $indexer1 = $this->createIndexer();
+        $indexer2 = $this->createIndexer();
 
         $delegating = new DelegatingIndexer();
         $delegating->addIndexer($indexer1);
@@ -63,5 +31,104 @@ class DelegatingIndexerTest extends TestCase
         $delegating->index($this->createMock(Document::class));
         $delegating->delete($this->createMock(Document::class));
         $delegating->clear();
+    }
+
+    public function testDelegatesAndCollectsExceptions(): void
+    {
+        $indexer1 = $this->createIndexer(IndexerException::createAsWarning('Warning 1'));
+        $indexer2 = $this->createIndexer(new IndexerException('Failure 2'));
+        $indexer3 = $this->createIndexer();
+
+        $delegating = new DelegatingIndexer();
+        $delegating->addIndexer($indexer1);
+        $delegating->addIndexer($indexer2);
+        $delegating->addIndexer($indexer3);
+
+        try {
+            $delegating->index($this->createMock(Document::class));
+        } catch (IndexerException $exception) {
+            $this->assertSame('Warning 1 | Failure 2', $exception->getMessage());
+            $this->assertFalse($exception->isOnlyWarning());
+        }
+
+        try {
+            $delegating->delete($this->createMock(Document::class));
+        } catch (IndexerException $exception) {
+            $this->assertSame('Warning 1 | Failure 2', $exception->getMessage());
+            $this->assertFalse($exception->isOnlyWarning());
+        }
+
+        try {
+            $delegating->clear();
+        } catch (IndexerException $exception) {
+            $this->assertSame('Warning 1 | Failure 2', $exception->getMessage());
+            $this->assertFalse($exception->isOnlyWarning());
+        }
+    }
+
+    public function testWarningExceptionCollectionOnly(): void
+    {
+        $indexer1 = $this->createIndexer(IndexerException::createAsWarning('Warning 1'));
+        $indexer2 = $this->createIndexer(IndexerException::createAsWarning('Warning 2'));
+
+        $delegating = new DelegatingIndexer();
+        $delegating->addIndexer($indexer1);
+        $delegating->addIndexer($indexer2);
+
+        try {
+            $delegating->index($this->createMock(Document::class));
+        } catch (IndexerException $exception) {
+            $this->assertSame('Warning 1 | Warning 2', $exception->getMessage());
+            $this->assertTrue($exception->isOnlyWarning());
+        }
+
+        try {
+            $delegating->delete($this->createMock(Document::class));
+        } catch (IndexerException $exception) {
+            $this->assertSame('Warning 1 | Warning 2', $exception->getMessage());
+            $this->assertTrue($exception->isOnlyWarning());
+        }
+
+        try {
+            $delegating->clear();
+        } catch (IndexerException $exception) {
+            $this->assertSame('Warning 1 | Warning 2', $exception->getMessage());
+            $this->assertTrue($exception->isOnlyWarning());
+        }
+    }
+
+    private function createIndexer(IndexerException|null $indexerException = null): IndexerInterface
+    {
+        $indexer = $this->createMock(IndexerInterface::class);
+        $invocationMocker = $indexer
+            ->expects($this->once())
+            ->method('index')
+        ;
+        $invocationMocker->with($this->isInstanceOf(Document::class));
+
+        if ($indexerException) {
+            $invocationMocker->willThrowException($indexerException);
+        }
+
+        $invocationMocker = $indexer
+            ->expects($this->once())
+            ->method('delete')
+        ;
+        $invocationMocker->with($this->isInstanceOf(Document::class));
+
+        if ($indexerException) {
+            $invocationMocker->willThrowException($indexerException);
+        }
+
+        $invocationMocker = $indexer
+            ->expects($this->once())
+            ->method('clear')
+        ;
+
+        if ($indexerException) {
+            $invocationMocker->willThrowException($indexerException);
+        }
+
+        return $indexer;
     }
 }


### PR DESCRIPTION
We have a `DelegatingIndexer` but it is actually not delegating if one of the indexers throws an exception (which is what our `DefaultIndexer` does by default).

We have to make sure, all of them are called and if any of them throws an exception, those have to be collected and their warningOnly state has to be merged.