### PR TITLE
Remove `error_reporting` from `contao-setup`

### DIFF
--- a/manager-bundle/bin/contao-setup
+++ b/manager-bundle/bin/contao-setup
@@ -16,7 +16,6 @@ use Contao\ManagerBundle\HttpKernel\ContaoKernel;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Filesystem\Filesystem;
 
-error_reporting(-1);
 set_time_limit(0);
 @ini_set('display_startup_errors', '1');
 @ini_set('display_errors', '1');


### PR DESCRIPTION
Fixes #8317