### PR TITLE
Add an optional "path" argument to the `DebugDcaCommand`

### DIFF
--- a/core-bundle/src/Command/DebugDcaCommand.php
+++ b/core-bundle/src/Command/DebugDcaCommand.php
@@ -37,6 +37,8 @@ class DebugDcaCommand extends Command
     protected function configure(): void
     {
         $this->addArgument('table', InputArgument::REQUIRED, 'The table name');
+        $this->addArgument('path', InputArgument::IS_ARRAY, 'The path of the DCA configuration to dump');
+        $this->addUsage('tl_member fields username');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -55,8 +57,21 @@ class DebugDcaCommand extends Command
         $cloner = new VarCloner();
         $dumper = new CliDumper();
 
-        $dumper->dump($cloner->cloneVar($GLOBALS['TL_DCA'][$table]));
+        $dumper->dump($cloner->cloneVar($this->getArray($input->getArgument('path') ?? [], $table)));
 
         return Command::SUCCESS;
     }
+
+    private function getArray(array $path, string $table): mixed
+    {
+        $current = $GLOBALS['TL_DCA'][$table];
+        foreach ($path as $key) {
+            if (!is_array($current) || !array_key_exists($key, $current)) {
+                throw new InvalidArgumentException('Invalid path: '.$key);
+            }
+            $current = $current[$key];
+        }
+        return $current;
+    }
+
 }

--- a/core-bundle/src/Command/DebugDcaCommand.php
+++ b/core-bundle/src/Command/DebugDcaCommand.php
@@ -65,6 +65,7 @@ class DebugDcaCommand extends Command
     private function getArray(array $path, string $table): mixed
     {
         $current = $GLOBALS['TL_DCA'][$table];
+
         foreach ($path as $key) {
             if (!\is_array($current) || !\array_key_exists($key, $current)) {
                 throw new InvalidArgumentException('Invalid path: '.$key);

--- a/core-bundle/src/Command/DebugDcaCommand.php
+++ b/core-bundle/src/Command/DebugDcaCommand.php
@@ -71,7 +71,7 @@ class DebugDcaCommand extends Command
             }
             $current = $current[$key];
         }
+
         return $current;
     }
-
 }

--- a/core-bundle/src/Command/DebugDcaCommand.php
+++ b/core-bundle/src/Command/DebugDcaCommand.php
@@ -66,7 +66,7 @@ class DebugDcaCommand extends Command
     {
         $current = $GLOBALS['TL_DCA'][$table];
         foreach ($path as $key) {
-            if (!is_array($current) || !array_key_exists($key, $current)) {
+            if (!\is_array($current) || !\array_key_exists($key, $current)) {
                 throw new InvalidArgumentException('Invalid path: '.$key);
             }
             $current = $current[$key];

--- a/core-bundle/src/Command/DebugDcaCommand.php
+++ b/core-bundle/src/Command/DebugDcaCommand.php
@@ -37,7 +37,7 @@ class DebugDcaCommand extends Command
     protected function configure(): void
     {
         $this->addArgument('table', InputArgument::REQUIRED, 'The table name');
-        $this->addArgument('path', InputArgument::OPTIONAL, 'Dot-notation for a portion of the DCA to dump');
+        $this->addArgument('path', InputArgument::OPTIONAL, 'Reference a DCA subsection using dot notation');
         $this->addUsage('tl_member fields.username');
     }
 


### PR DESCRIPTION
The DebugDcaCommand now allows specifying a path to dump specific parts of the DCA configuration. This enhances debugging flexibility by enabling targeted output of nested DCA structures. An exception is thrown for invalid paths to ensure robust error handling.

Now you can use something like:

```bash
php bin/console debug:dca tl_member config         
array:7 [
  "dataContainer" => "Contao\DC_Table"
  "enableVersioning" => true
  "onsubmit_callback" => array:1 [
    0 => array:2 [
      0 => "tl_member"
      1 => "storeDateAdded"
    ]
  ]
  "sql" => array:1 [
    "keys" => array:5 [
      "id" => "primary"
      "tstamp" => "index"
      "username" => "unique"
      "email" => "index"
      "login,disable,start,stop" => "index"
    ]
  ]
  "onload_callback" => array:1 [
    0 => array:2 [
      0 => "Contao\Newsletter"
      1 => "updateAccount"
    ]
  ]
  "ondelete_callback" => array:1 [
    0 => array:2 [
      0 => "contao.listener.data_container.record_preview"
      1 => "storePrecompiledRecordPreview"
    ]
  ]
  "onbeforesubmit_callback" => array:3 [
    0 => array:2 [
      0 => "contao.listener.data_container.start_stop_validation"                                                                                                                                                    
      1 => "__invoke"                                                                                                                                                                                                
    ]                                                                                                                                                                                                                
    1 => array:2 [                                                                                                                                                                                                   
      0 => "contao_news.listener.data_container.start_stop_validation"                                                                                                                                               
      1 => "__invoke"                                                                                                                                                                                                
    ]                                                                                                                                                                                                                
    2 => array:2 [                                                                                                                                                                                                   
      0 => "contao_calendar.listener.data_container.start_stop_validation"                                                                                                                                           
      1 => "__invoke"                                                                                                                                                                                                
    ]                                                                                                                                                                                                                
  ]                                                                                                                                                                                                                  
]
```

You can go further is you add more keys:

```bash
php bin/console debug:dca tl_member config sql keys
array:5 [
  "id" => "primary"                                                                                                                                                                                                  
  "tstamp" => "index"                                                                                                                                                                                                
  "username" => "unique"                                                                                                                                                                                             
  "email" => "index"                                                                                                                                                                                                 
  "login,disable,start,stop" => "index"                                                                                                                                                                              
]
```

If the path is not available an exception is thrown:

```bash
php bin/console debug:dca tl_member config sql keys impossible
13:54:24 CRITICAL  [console] Error thrown while running command "debug:dca tl_member config sql keys impossible". Message: "Invalid path: impossible" ["exception" => Symfony\Component\Console\Exception\InvalidArgumentException { …},"command" => "debug:dca tl_member config sql keys impossible","message" => "Invalid path: impossible"]                                                                                            

                            
  Invalid path: impossible  
                            

debug:dca <table> [<path>...]
```