### PR TITLE
Fix an undefined index error for `href` in the news menu template

### DIFF
--- a/news-bundle/contao/templates/modules/mod_newsmenu.html5
+++ b/news-bundle/contao/templates/modules/mod_newsmenu.html5
@@ -33,7 +33,7 @@
         <?php foreach ($this->weeks as $class => $week): ?>
           <tr class="<?= $class ?>">
             <?php foreach ($week as $day): ?>
-              <?php if ($day['href']): ?>
+              <?php if ($day['href'] ?? false): ?>
                 <td class="<?= $day['class'] ?>"><a href="<?= $day['href'] ?>" title="<?= $day['title'] ?>"><?= $day['label'] ?></a></td>
               <?php else: ?>
                 <td class="<?= $day['class'] ?>"><?= $day['label'] ?></td>


### PR DESCRIPTION
Previously, the code assumed 'href' always existed, which could lead to undefined index errors. Added a null coalescing operator to safely handle cases where 'href' is not defined. This ensures better stability and avoids runtime errors.

Fixes `Warning: Undefined array key "href"`

In some specific cases the `href` can be missing (only in the day view). 

```
ErrorException:
Warning: Undefined array key "href"

  at D:\Laragon\www\contao-picocss\vendor\contao\news-bundle\contao\templates\modules\mod_newsmenu.html5:37
  at include('D:\\Laragon\\www\\contao-picocss\\vendor\\contao\\news-bundle\\contao\\templates\\modules\\mod_newsmenu.html5')
     (D:\Laragon\www\contao-picocss\vendor\contao\core-bundle\contao\library\Contao\TemplateInheritance.php:109)
  at Contao\Template->inherit()
     (D:\Laragon\www\contao-picocss\vendor\contao\core-bundle\contao\library\Contao\Template.php:322)
  at Contao\Template->parse()
     (D:\Laragon\www\contao-picocss\vendor\contao\core-bundle\contao\classes\FrontendTemplate.php:43)
  at Contao\FrontendTemplate->parse()
     (D:\Laragon\www\contao-picocss\vendor\contao\core-bundle\contao\modules\Module.php:244)
  at Contao\Module->generate()
     (D:\Laragon\www\contao-picocss\vendor\contao\news-bundle\contao\modules\ModuleNewsMenu.php:87)
  at Contao\ModuleNewsMenu->generate()
     (D:\Laragon\www\contao-picocss\vendor\contao\core-bundle\contao\library\Contao\Controller.php:405)
  at Contao\Controller::getFrontendModule(object(ModuleModel), 'main')
     (D:\Laragon\www\contao-picocss\vendor\contao\core-bundle\contao\elements\ContentModule.php:59)
  at Contao\ContentModule->generate()
     (D:\Laragon\www\contao-picocss\vendor\contao\core-bundle\contao\library\Contao\Controller.php:610)
  at Contao\Controller::getContentElement(object(ContentModel), 'main')
     (D:\Laragon\www\contao-picocss\vendor\contao\core-bundle\contao\modules\ModuleArticle.php:189)
  at Contao\ModuleArticle->compile()
     (D:\Laragon\www\contao-picocss\vendor\contao\core-bundle\contao\modules\Module.php:213)
  at Contao\Module->generate()
     (D:\Laragon\www\contao-picocss\vendor\contao\core-bundle\contao\modules\ModuleArticle.php:69)
  at Contao\ModuleArticle->generate(false)
     (D:\Laragon\www\contao-picocss\vendor\contao\core-bundle\contao\library\Contao\Controller.php:490)
  at Contao\Controller::getArticle(object(ArticleModel), false, false, 'main')
     (D:\Laragon\www\contao-picocss\vendor\contao\core-bundle\contao\library\Contao\Controller.php:356)
  at Contao\Controller::getFrontendModule('0', 'main')
     (D:\Laragon\www\contao-picocss\vendor\contao\core-bundle\contao\pages\PageRegular.php:183)
  at Contao\PageRegular->prepare(object(PageModel))
     (D:\Laragon\www\contao-picocss\vendor\contao\core-bundle\contao\pages\PageRegular.php:47)
  at Contao\PageRegular->getResponse(object(PageModel), true)
     (D:\Laragon\www\contao-picocss\vendor\contao\core-bundle\contao\controllers\FrontendIndex.php:65)
  at Contao\FrontendIndex->renderPage(object(PageModel))
     (D:\Laragon\www\contao-picocss\vendor\symfony\http-kernel\HttpKernel.php:181)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw(object(Request), 1)
     (D:\Laragon\www\contao-picocss\vendor\symfony\http-kernel\HttpKernel.php:76)
  at Symfony\Component\HttpKernel\HttpKernel->handle(object(Request), 1, true)
     (D:\Laragon\www\contao-picocss\vendor\symfony\http-kernel\Kernel.php:197)
  at Symfony\Component\HttpKernel\Kernel->handle(object(Request))
     (D:\Laragon\www\contao-picocss\public\index.php:42)    
```