### PR TITLE
Replace the deprecated newsletter recipient icon

### DIFF
--- a/newsletter-bundle/contao/dca/tl_newsletter_recipients.php
+++ b/newsletter-bundle/contao/dca/tl_newsletter_recipients.php
@@ -208,7 +208,7 @@ class tl_newsletter_recipients extends Backend
 		}
 
 		$icon = Image::getPath('member');
-		$icond = Image::getPath('member_');
+		$icond = Image::getPath('member--disabled');
 
 		return sprintf(
 			'<div class="tl_content_left"><div class="list_icon" style="background-image:url(\'%s\')" data-icon="%s" data-icon-disabled="%s">%s</div></div>' . "\n",


### PR DESCRIPTION
Disabled icon for newsletter recipients was still the old one.