### PR TITLE
Handle union and intersection types when autoloading app services

### DIFF
--- a/depcheck.php
+++ b/depcheck.php
@@ -10,6 +10,12 @@ declare(strict_types=1);
  * @license LGPL-3.0-or-later
  */
 
+use App\Entity\FooEntity;
+use App\EventListener\InvalidListener;
+use App\EventListener\ValidListener;
+use App\FrontendModule\LegacyModule;
+use App\Messenger\UnionTypeMessage;
+use App\Model\FooModel;
 use AppBundle\AppBundle;
 use ShipMonk\ComposerDependencyAnalyser\Config\Configuration;
 use ShipMonk\ComposerDependencyAnalyser\Config\ErrorType;
@@ -17,6 +23,12 @@ use ShipMonk\ComposerDependencyAnalyser\Config\ErrorType;
 return (new Configuration())
     ->ignoreUnknownClasses([
         AppBundle::class,
+        FooEntity::class,
+        InvalidListener::class,
+        ValidListener::class,
+        LegacyModule::class,
+        UnionTypeMessage::class,
+        FooModel::class,
         'Imagick',
         'Gmagick',
         'SensitiveParameter',

--- a/depcheck.php
+++ b/depcheck.php
@@ -24,18 +24,18 @@ return (new Configuration())
     ->ignoreUnknownClasses([
         AppBundle::class,
         FooEntity::class,
-        InvalidListener::class,
-        ValidListener::class,
-        LegacyModule::class,
-        UnionTypeMessage::class,
         FooModel::class,
-        'Imagick',
         'Gmagick',
+        'Imagick',
+        InvalidListener::class,
+        LegacyModule::class,
         'SensitiveParameter',
         'Swift_Attachment',
         'Swift_EmbeddedFile',
         'Swift_Mailer',
         'Swift_Message',
+        UnionTypeMessage::class,
+        ValidListener::class,
     ])
     ->disableExtensionsAnalysis()
     ->disableReportingUnmatchedIgnores()
@@ -65,7 +65,7 @@ return (new Configuration())
     // managed edition.
     ->ignoreErrorsOnPackage('contao/manager-plugin', [ErrorType::DEV_DEPENDENCY_IN_PROD])
 
-    // This packages provides the trigger_deprecation() function.
+    // This package provides the trigger_deprecation() function.
     ->ignoreErrorsOnPackage('symfony/deprecation-contracts', [ErrorType::UNUSED_DEPENDENCY])
 
     // This package provides the "sanitize_html" Twig filter.

--- a/manager-bundle/skeleton/config/services.php
+++ b/manager-bundle/skeleton/config/services.php
@@ -86,13 +86,25 @@ return static function (ContainerConfigurator $configurator) use ($container): v
                 continue;
             }
 
+            $isLegacyClass = static function (\ReflectionType $type) use (&$isLegacyClass) {
+                if ($type instanceof \ReflectionUnionType || $type instanceof \ReflectionIntersectionType) {
+                    foreach ($type->getTypes() as $iType) {
+                        if ($isLegacyClass($iType)) {
+                            return true;
+                        }
+                    }
+
+                    return false;
+                }
+
+                return $type instanceof \ReflectionNamedType
+                    && !$type->isBuiltin()
+                    && (is_a($type->getName(), System::class, true) || is_a($type->getName(), Model::class, true));
+            };
+
             $type = $parameter->getType();
 
-            if (
-                $type
-                && !$type->isBuiltin()
-                && (is_a($type->getName(), System::class, true) || is_a($type->getName(), Model::class, true))
-            ) {
+            if ($type && $isLegacyClass($type)) {
                 $container->removeDefinition($id);
                 --$serviceCount;
                 break;

--- a/manager-bundle/tests/Fixtures/HttpKernel/AutowireSrc/src/Entity/FooEntity.php
+++ b/manager-bundle/tests/Fixtures/HttpKernel/AutowireSrc/src/Entity/FooEntity.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace App\Entity;
+
+class FooEntity
+{
+}

--- a/manager-bundle/tests/Fixtures/HttpKernel/AutowireSrc/src/EventListener/InvalidListener.php
+++ b/manager-bundle/tests/Fixtures/HttpKernel/AutowireSrc/src/EventListener/InvalidListener.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\EventListener;
+
+use Contao\ModuleNavigation;
+
+class InvalidListener
+{
+    public function __construct(private readonly ModuleNavigation|ValidListener $invalid)
+    {
+    }
+
+    public function __invoke(): void
+    {
+        // Do something
+    }
+}

--- a/manager-bundle/tests/Fixtures/HttpKernel/AutowireSrc/src/EventListener/ValidListener.php
+++ b/manager-bundle/tests/Fixtures/HttpKernel/AutowireSrc/src/EventListener/ValidListener.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace App\EventListener;
+
+use Symfony\Component\Translation\TranslatorBagInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class ValidListener
+{
+    public function __construct(private readonly TranslatorInterface&TranslatorBagInterface $translator)
+    {
+    }
+
+    public function __invoke(): void
+    {
+        // Do something
+    }
+}

--- a/manager-bundle/tests/Fixtures/HttpKernel/AutowireSrc/src/FrontendModule/LegacyModule.php
+++ b/manager-bundle/tests/Fixtures/HttpKernel/AutowireSrc/src/FrontendModule/LegacyModule.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace App\FrontendModule;
+
+use Contao\Module;
+
+class LegacyModule extends Module
+{
+    protected function compile(): void
+    {
+        // do something
+    }
+}

--- a/manager-bundle/tests/Fixtures/HttpKernel/AutowireSrc/src/FrontendModule/LegacyModule.php
+++ b/manager-bundle/tests/Fixtures/HttpKernel/AutowireSrc/src/FrontendModule/LegacyModule.php
@@ -18,6 +18,6 @@ class LegacyModule extends Module
 {
     protected function compile(): void
     {
-        // do something
+        // Do something
     }
 }

--- a/manager-bundle/tests/Fixtures/HttpKernel/AutowireSrc/src/Messenger/UnionTypeMessage.php
+++ b/manager-bundle/tests/Fixtures/HttpKernel/AutowireSrc/src/Messenger/UnionTypeMessage.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Messenger;
+
+class UnionTypeMessage
+{
+    public function __construct(int|string $id)
+    {
+    }
+}

--- a/manager-bundle/tests/Fixtures/HttpKernel/AutowireSrc/src/Model/FooModel.php
+++ b/manager-bundle/tests/Fixtures/HttpKernel/AutowireSrc/src/Model/FooModel.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace App\Model;
+
+use Contao\Model;
+
+class FooModel extends Model
+{
+}

--- a/manager-bundle/tests/HttpKernel/ContaoKernelTest.php
+++ b/manager-bundle/tests/HttpKernel/ContaoKernelTest.php
@@ -12,6 +12,12 @@ declare(strict_types=1);
 
 namespace Contao\ManagerBundle\Tests\HttpKernel;
 
+use App\Entity\FooEntity;
+use App\EventListener\InvalidListener;
+use App\EventListener\ValidListener;
+use App\FrontendModule\LegacyModule;
+use App\Messenger\UnionTypeMessage;
+use App\Model\FooModel;
 use AppBundle\AppBundle;
 use Contao\ManagerBundle\Api\ManagerConfig;
 use Contao\ManagerBundle\ContaoManager\Plugin as ManagerPlugin;
@@ -25,11 +31,15 @@ use Contao\ManagerPlugin\PluginLoader;
 use Contao\TestCase\ContaoTestCase;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
+use Symfony\Component\Config\FileLocatorInterface;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\Config\Resource\ClassExistenceResource;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Symfony\Component\DependencyInjection\ParameterBag\EnvPlaceholderParameterBag;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Filesystem\Path;
 use Symfony\Component\HttpFoundation\Request;
@@ -272,6 +282,102 @@ class ContaoKernelTest extends ContaoTestCase
             'prod',
             [],
         ];
+    }
+
+    public function testAutowiresSrcFiles(): void
+    {
+        // preload for autoloading
+        include_once __DIR__.'/../Fixtures/HttpKernel/AutowireSrc/src/Entity/FooEntity.php';
+        include_once __DIR__.'/../Fixtures/HttpKernel/AutowireSrc/src/EventListener/InvalidListener.php';
+        include_once __DIR__.'/../Fixtures/HttpKernel/AutowireSrc/src/EventListener/ValidListener.php';
+        include_once __DIR__.'/../Fixtures/HttpKernel/AutowireSrc/src/FrontendModule/LegacyModule.php';
+        include_once __DIR__.'/../Fixtures/HttpKernel/AutowireSrc/src/Messenger/UnionTypeMessage.php';
+        include_once __DIR__.'/../Fixtures/HttpKernel/AutowireSrc/src/Model/FooModel.php';
+
+        $projectDir = __DIR__.'/../Fixtures/HttpKernel/AutowireSrc';
+        $container = new ContainerBuilder(new ParameterBag(['kernel.project_dir' => $projectDir]));
+
+        $locator = $this->createMock(FileLocatorInterface::class);
+        $locator
+            ->method('locate')
+            ->willReturnArgument(0)
+        ;
+
+        $innerLoader = new PhpFileLoader($container, $locator);
+
+        $loader = $this->createMock(LoaderInterface::class);
+        $loader
+            ->expects($this->exactly(2))
+            ->method('load')
+            ->willReturnCallback(
+                function ($resource) use ($container, $innerLoader) {
+                    if ($resource instanceof \Closure) {
+                        return $resource($container, 'prod');
+                    }
+
+                    $this->assertSame(\dirname(__DIR__, 2).'/src/HttpKernel/../../skeleton/config/services.php', $resource);
+
+                    return $innerLoader->load($resource);
+                },
+            )
+        ;
+
+        $kernel = $this->getKernel($projectDir);
+        $kernel->registerContainerConfiguration($loader);
+
+        $this->assertFalse($container->hasDefinition(FooEntity::class));
+        $this->assertFalse($container->hasDefinition(InvalidListener::class));
+        $this->assertTrue($container->hasDefinition(ValidListener::class));
+        $this->assertFalse($container->hasDefinition(LegacyModule::class));
+        $this->assertTrue($container->hasDefinition(UnionTypeMessage::class));
+        $this->assertFalse($container->hasDefinition(FooModel::class));
+    }
+
+    public function testDoesNotAutowireSrcFilesIfAppNamespaceIsRegistered(): void
+    {
+        // preload for autoloading
+        include_once __DIR__.'/../Fixtures/HttpKernel/AutowireSrc/src/Entity/FooEntity.php';
+        include_once __DIR__.'/../Fixtures/HttpKernel/AutowireSrc/src/EventListener/InvalidListener.php';
+        include_once __DIR__.'/../Fixtures/HttpKernel/AutowireSrc/src/EventListener/ValidListener.php';
+        include_once __DIR__.'/../Fixtures/HttpKernel/AutowireSrc/src/FrontendModule/LegacyModule.php';
+        include_once __DIR__.'/../Fixtures/HttpKernel/AutowireSrc/src/Messenger/UnionTypeMessage.php';
+        include_once __DIR__.'/../Fixtures/HttpKernel/AutowireSrc/src/Model/FooModel.php';
+
+        $projectDir = __DIR__.'/../Fixtures/HttpKernel/AutowireSrc';
+        $container = new ContainerBuilder(new ParameterBag(['kernel.project_dir' => $projectDir]));
+
+        // Create a fake definition to stop services.php from loading anything
+        $container->setDefinition('App\\Foobar', new Definition());
+
+        $locator = $this->createMock(FileLocatorInterface::class);
+        $locator
+            ->method('locate')
+            ->willReturnArgument(0)
+        ;
+
+        $innerLoader = new PhpFileLoader($container, $locator);
+
+        $loader = $this->createMock(LoaderInterface::class);
+        $loader
+            ->expects($this->exactly(2))
+            ->method('load')
+            ->willReturnCallback(
+                function ($resource) use ($container, $innerLoader) {
+                    if ($resource instanceof \Closure) {
+                        return $resource($container, 'prod');
+                    }
+
+                    $this->assertSame(\dirname(__DIR__, 2).'/src/HttpKernel/../../skeleton/config/services.php', $resource);
+
+                    return $innerLoader->load($resource);
+                },
+            )
+        ;
+
+        $kernel = $this->getKernel($projectDir);
+        $kernel->registerContainerConfiguration($loader);
+
+        $this->assertSame(['service_container', 'App\\Foobar'], array_keys($container->getDefinitions()));
     }
 
     public function testRegisterContainerConfigurationLoadsPlugins(): void

--- a/manager-bundle/tests/HttpKernel/ContaoKernelTest.php
+++ b/manager-bundle/tests/HttpKernel/ContaoKernelTest.php
@@ -286,7 +286,6 @@ class ContaoKernelTest extends ContaoTestCase
 
     public function testAutowiresSrcFiles(): void
     {
-        // preload for autoloading
         include_once __DIR__.'/../Fixtures/HttpKernel/AutowireSrc/src/Entity/FooEntity.php';
         include_once __DIR__.'/../Fixtures/HttpKernel/AutowireSrc/src/EventListener/InvalidListener.php';
         include_once __DIR__.'/../Fixtures/HttpKernel/AutowireSrc/src/EventListener/ValidListener.php';
@@ -335,7 +334,6 @@ class ContaoKernelTest extends ContaoTestCase
 
     public function testDoesNotAutowireSrcFilesIfAppNamespaceIsRegistered(): void
     {
-        // preload for autoloading
         include_once __DIR__.'/../Fixtures/HttpKernel/AutowireSrc/src/Entity/FooEntity.php';
         include_once __DIR__.'/../Fixtures/HttpKernel/AutowireSrc/src/EventListener/InvalidListener.php';
         include_once __DIR__.'/../Fixtures/HttpKernel/AutowireSrc/src/EventListener/ValidListener.php';


### PR DESCRIPTION
If you currently have a class in your App `/src/` folder, which has union or intersection types in the constructor, you get this error: `Call to undefined method ReflectionUnionType::isBuiltin() in vendor/contao/manager-bundle/skeleton/config/services.php:93`

This PR fixes the issue and adds unit tests for the `services.php` 😎 