### PR TITLE
Use `Path::join` instead of `Path::makeAbsolute`

### DIFF
--- a/manager-bundle/src/HttpKernel/ContaoKernel.php
+++ b/manager-bundle/src/HttpKernel/ContaoKernel.php
@@ -181,7 +181,7 @@ class ContaoKernel extends Kernel implements HttpCacheProvider
                 }
 
                 if ($container->fileExists(Path::join($this->getProjectDir(), 'src'), false)) {
-                    $loader->load(Path::makeAbsolute('../../skeleton/config/services.php', __DIR__));
+                    $loader->load(Path::join(__DIR__, '../../skeleton/config/services.php'));
                 }
             },
         );

--- a/manager-bundle/tests/HttpKernel/ContaoKernelTest.php
+++ b/manager-bundle/tests/HttpKernel/ContaoKernelTest.php
@@ -314,7 +314,7 @@ class ContaoKernelTest extends ContaoTestCase
                         return $resource($container, 'prod');
                     }
 
-                    $this->assertSame(Path::makeAbsolute('../../skeleton/config/services.php', __DIR__), $resource);
+                    $this->assertSame(Path::join(__DIR__, '../../skeleton/config/services.php'), $resource);
 
                     return $innerLoader->load($resource);
                 },
@@ -365,7 +365,7 @@ class ContaoKernelTest extends ContaoTestCase
                         return $resource($container, 'prod');
                     }
 
-                    $this->assertSame(Path::makeAbsolute('../../skeleton/config/services.php', __DIR__), $resource);
+                    $this->assertSame(Path::join(__DIR__, '../../skeleton/config/services.php'), $resource);
 
                     return $innerLoader->load($resource);
                 },


### PR DESCRIPTION
See https://github.com/contao/contao/pull/8375#issuecomment-2913140126

Using `Path::makeAbsolute()` here is just a roundabout way of normalizing the path - which `Path::join()` would take care of also.