### PR TITLE
Consider tracks in player being empty

### DIFF
--- a/core-bundle/contao/templates/twig/content_element/player.html.twig
+++ b/core-bundle/contao/templates/twig/content_element/player.html.twig
@@ -24,7 +24,7 @@
             {% do csp_source('media-src', source_attributes.src) %}
             <source{{ source_attributes }}>
         {% endfor %}
-        {% for track_attributes in figure.media.tracks %}
+        {% for track_attributes in figure.media.tracks|default %}
             {% do csp_source('media-src', track_attributes.src) %}
             <track{{ track_attributes }}/>
         {% endfor %}


### PR DESCRIPTION
If a video file gets lost - or if you copy the database without also copying all files in `files/`, the following error will occur in the front end when a video file is missing for a video player:

```
Twig\Error\RuntimeError:
Key "tracks" for sequence/mapping with keys "type, attributes, sources" does not exist.

  at vendor/contao/core-bundle/contao/templates/twig/content_element/player.html.twig:27
```

This happens because `->isVideo()` will return `false` and thus the template will be rendered for audio data - for which there will be no tracks.

The same error presumably happens also if you choose audio files instead of video files.

This PR fixes that by allowing the `tracks` to be empty in the template.