### PR TITLE
Also embed SVG images in emails

### DIFF
--- a/core-bundle/contao/library/Contao/Email.php
+++ b/core-bundle/contao/library/Contao/Email.php
@@ -460,7 +460,7 @@ class Email
 				$strBase = Environment::get('base');
 
 				// Thanks to @ofriedrich and @aschempp (see #4562)
-				preg_match_all('/<[a-z][a-z0-9]*\b[^>]*((src=|background=|url\()["\']??)(.+\.(jpe?g|png|gif|bmp|tiff?|swf))(["\' ]??(\)??))[^>]*>/Ui', $this->strHtml, $arrMatches);
+				preg_match_all('/<[a-z][a-z0-9]*\b[^>]*((src=|background=|url\()["\']??)(.+\.(jpe?g|png|gif|bmp|tiff?|swf|svg))(["\' ]??(\)??))[^>]*>/Ui', $this->strHtml, $arrMatches);
 
 				// Check for internal images
 				if (!empty($arrMatches) && isset($arrMatches[0]))


### PR DESCRIPTION
If you reference an SVG image in your `mail_*` template, it currently won't be automatically embedded (when embedding is enabled, e.g. for newsletters from `contao/newsletter-bundle`). This PR fixes this by also considering SVG files in the regex.