### PR TITLE
Handle empty news feed items in the news feed controller

### DIFF
--- a/news-bundle/src/Controller/Page/NewsFeedController.php
+++ b/news-bundle/src/Controller/Page/NewsFeedController.php
@@ -66,16 +66,18 @@ class NewsFeedController extends AbstractController implements DynamicRouteInter
         $dispatcher = $this->container->get('event_dispatcher');
         $dispatcher->dispatch($event);
 
-        if (null !== ($articles = $event->getArticles())) {
-            foreach ($articles as $article) {
-                $event = new TransformArticleForFeedEvent($article, $feed, $pageModel, $request, $baseUrl);
-                $dispatcher->dispatch($event);
+        foreach ($event->getArticles() ?? [] as $article) {
+            $event = new TransformArticleForFeedEvent($article, $feed, $pageModel, $request, $baseUrl);
+            $dispatcher->dispatch($event);
 
-                $feed->add($event->getItem());
-
-                $this->tagResponse($article);
-                $this->tagResponse('contao.db.tl_news_archive.'.$article->pid);
+            if (!$item = $event->getItem()) {
+                continue;
             }
+
+            $feed->add($item);
+
+            $this->tagResponse($article);
+            $this->tagResponse('contao.db.tl_news_archive.'.$article->pid);
         }
 
         $formatter = $this->specification->getStandard($pageModel->feedFormat)->getFormatter();


### PR DESCRIPTION
`TransformArticleForFeedEvent::getItem()` allows to return `null` - i.e. an event listener could decide to not set a feed item - or set it to `null`.

However, the `NewsFeedController` currently does not take this into account (`Feed::add()` does not allow `null`). This PR fixes that.

This PR also simplifies the code style a bit, by eliminating an `if` block.