### PR TITLE
Always tag the news archives in the news feed controller

### DIFF
--- a/news-bundle/src/Controller/Page/NewsFeedController.php
+++ b/news-bundle/src/Controller/Page/NewsFeedController.php
@@ -20,6 +20,7 @@ use Contao\CoreBundle\Routing\Page\PageRoute;
 use Contao\NewsBundle\Event\FetchArticlesForFeedEvent;
 use Contao\NewsBundle\Event\TransformArticleForFeedEvent;
 use Contao\PageModel;
+use Contao\StringUtil;
 use FeedIo\Feed;
 use FeedIo\Specification;
 use Symfony\Component\HttpFoundation\Request;
@@ -74,7 +75,6 @@ class NewsFeedController extends AbstractController implements DynamicRouteInter
                 $feed->add($event->getItem());
 
                 $this->tagResponse($article);
-                $this->tagResponse('contao.db.tl_news_archive.'.$article->pid);
             }
         }
 
@@ -84,6 +84,10 @@ class NewsFeedController extends AbstractController implements DynamicRouteInter
         $response->headers->set('Content-Type', self::$contentTypes[$pageModel->feedFormat]);
 
         $this->setCacheHeaders($response, $pageModel);
+
+        // Always add the reponse tags for the selected archives
+        $archiveIds = StringUtil::deserialize($pageModel->newsArchives, true);
+        $this->tagResponse(array_map(static fn ($id): string => 'contao.db.tl_news_archive.'.$id, $archiveIds));
 
         return $response;
     }

--- a/news-bundle/tests/Controller/Page/NewsFeedControllerTest.php
+++ b/news-bundle/tests/Controller/Page/NewsFeedControllerTest.php
@@ -102,7 +102,7 @@ class NewsFeedControllerTest extends ContaoTestCase
             'feedDescription' => 'Get latest news',
             'feedFormat' => 'rss',
             'language' => 'en',
-            'newsArchives' => serialize([8472])
+            'newsArchives' => serialize([8472]),
         ]);
 
         $container = $this->getContainerWithContaoConfiguration();

--- a/news-bundle/tests/Controller/Page/NewsFeedControllerTest.php
+++ b/news-bundle/tests/Controller/Page/NewsFeedControllerTest.php
@@ -102,11 +102,21 @@ class NewsFeedControllerTest extends ContaoTestCase
             'feedDescription' => 'Get latest news',
             'feedFormat' => 'rss',
             'language' => 'en',
+            'newsArchives' => serialize([8472])
         ]);
 
         $container = $this->getContainerWithContaoConfiguration();
         $container->set('contao.framework', $this->mockContaoFramework());
         $container->set('event_dispatcher', $this->createMock(EventDispatcher::class));
+
+        $entityCacheTags = $this->createMock(EntityCacheTags::class);
+        $entityCacheTags
+            ->expects($this->once())
+            ->method('tagWith')
+            ->with(['contao.db.tl_news_archive.8472'])
+        ;
+
+        $container->set('contao.cache.entity_tags', $entityCacheTags);
 
         $controller = $this->getController();
         $controller->setContainer($container);
@@ -134,6 +144,15 @@ class NewsFeedControllerTest extends ContaoTestCase
         $container = $this->getContainerWithContaoConfiguration();
         $container->set('contao.framework', $this->mockContaoFramework());
         $container->set('event_dispatcher', $this->createMock(EventDispatcher::class));
+
+        $entityCacheTags = $this->createMock(EntityCacheTags::class);
+        $entityCacheTags
+            ->expects($this->once())
+            ->method('tagWith')
+            ->with([])
+        ;
+
+        $container->set('contao.cache.entity_tags', $entityCacheTags);
 
         $controller = $this->getController();
         $controller->setContainer($container);


### PR DESCRIPTION
1. Create an empty news archive.
2. Create a news feed for that news archive (via the news feed page).
3. Set the cache of that news feed to 1 year.
4. Open the (still empty) news feed in the front end so that the response is put into the shared cache.
5. Create a new news item in that news archive.
6. Open the news feed in the front end (with a clear browser session).

The news feed will not show the newly added news item.

This is because currently no tags for the news archive are added if there are no news items to begin with. This PR fixes that by always tagging the response with the selected news archives.