### PR TITLE
Correctly close the `header_outlets` block

### DIFF
--- a/core-bundle/contao/templates/backend/be_main.html5
+++ b/core-bundle/contao/templates/backend/be_main.html5
@@ -58,7 +58,7 @@
       <?php $this->block('header_outlets'); ?>
         <?php $this->insert('@Contao/backend/component/message/_outlet.html.twig') ?>
         <?php $this->insert('@Contao/backend/component/dialog/_outlet.html.twig') ?>
-      <?php $this->block('header_outlets'); ?>
+      <?php $this->endblock(); ?>
     <?php endif; ?>
   <?php $this->endblock(); ?>
 


### PR DESCRIPTION
Introduced in https://github.com/contao/contao/pull/8064 for 5.x.