### PR TITLE
Add the current member groups to the schema.org output

### DIFF
--- a/core-bundle/config/services.yaml
+++ b/core-bundle/config/services.yaml
@@ -932,6 +932,7 @@ services:
             - '@contao.insert_tag.parser'
             - '@contao.routing.response_context.csp_handler_factory'
             - '@router'
+            - '@security.helper'
 
     contao.routing.route_404_provider:
         class: Contao\CoreBundle\Routing\Route404Provider

--- a/core-bundle/src/Routing/ResponseContext/CoreResponseContextFactory.php
+++ b/core-bundle/src/Routing/ResponseContext/CoreResponseContextFactory.php
@@ -21,8 +21,11 @@ use Contao\CoreBundle\Routing\ResponseContext\JsonLd\JsonLdManager;
 use Contao\CoreBundle\Security\Authentication\Token\TokenChecker;
 use Contao\CoreBundle\String\HtmlDecoder;
 use Contao\CoreBundle\Util\UrlUtil;
+use Contao\FrontendUser;
 use Contao\PageModel;
+use Contao\StringUtil;
 use Spatie\SchemaOrg\WebPage;
+use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\Exception\RouteNotFoundException;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -39,6 +42,7 @@ class CoreResponseContextFactory
         private readonly InsertTagParser $insertTagParser,
         private readonly CspHandlerFactory $cspHandlerFactory,
         private readonly UrlGeneratorInterface $urlGenerator,
+        private readonly Security $security,
     ) {
     }
 
@@ -115,6 +119,7 @@ class CoreResponseContextFactory
                     $pageModel->protected,
                     array_map(\intval(...), array_filter((array) $pageModel->groups)),
                     $this->tokenChecker->isPreviewMode(),
+                    $this->getMemberGroups(),
                 ),
             )
         ;
@@ -152,5 +157,19 @@ class CoreResponseContextFactory
         }
 
         $context->add($cspHandler);
+    }
+
+    /**
+     * @return array<int>
+     */
+    private function getMemberGroups(): array
+    {
+        $user = $this->security->getUser();
+
+        if (!$user instanceof FrontendUser) {
+            return [];
+        }
+
+        return array_map(\intval(...), array_filter((array) StringUtil::deserialize($user->groups, true)));
     }
 }

--- a/core-bundle/src/Routing/ResponseContext/JsonLd/ContaoPageSchema.php
+++ b/core-bundle/src/Routing/ResponseContext/JsonLd/ContaoPageSchema.php
@@ -18,11 +18,9 @@ use Spatie\SchemaOrg\BaseType;
 class ContaoPageSchema extends BaseType
 {
     /**
-     * ContaoPageSchema constructor.
-     *
      * @param array<int> $groups
      */
-    public function __construct(string $title, int $pageId, bool $noSearch, bool $protected, array $groups, bool $fePreview, array $currentGroups = [])
+    public function __construct(string $title, int $pageId, bool $noSearch, bool $protected, array $groups, bool $fePreview, array $memberGroups = [])
     {
         $this->setTitle($title);
         $this->setPageId($pageId);
@@ -30,7 +28,7 @@ class ContaoPageSchema extends BaseType
         $this->setProtected($protected);
         $this->setGroups($groups);
         $this->setFePreview($fePreview);
-        $this->setCurrentGroups($currentGroups);
+        $this->setMemberGroups($memberGroups);
     }
 
     public function getContext(): string
@@ -102,9 +100,9 @@ class ContaoPageSchema extends BaseType
     /**
      * @return array<int>
      */
-    public function getCurrentGroups(): array
+    public function getMemberGroups(): array
     {
-        return $this->properties['currentGroups'];
+        return $this->properties['memberGroups'];
     }
 
     /**
@@ -118,11 +116,11 @@ class ContaoPageSchema extends BaseType
     }
 
     /**
-     * @param array<int> $currentGroups
+     * @param array<int> $memberGroups
      */
-    public function setCurrentGroups(array $currentGroups): self
+    public function setMemberGroups(array $memberGroups): self
     {
-        $this->properties['currentGroups'] = array_map(\intval(...), $currentGroups);
+        $this->properties['memberGroups'] = array_map(\intval(...), $memberGroups);
 
         return $this;
     }

--- a/core-bundle/src/Routing/ResponseContext/JsonLd/ContaoPageSchema.php
+++ b/core-bundle/src/Routing/ResponseContext/JsonLd/ContaoPageSchema.php
@@ -22,7 +22,7 @@ class ContaoPageSchema extends BaseType
      *
      * @param array<int> $groups
      */
-    public function __construct(string $title, int $pageId, bool $noSearch, bool $protected, array $groups, bool $fePreview)
+    public function __construct(string $title, int $pageId, bool $noSearch, bool $protected, array $groups, bool $fePreview, array $currentGroups = [])
     {
         $this->setTitle($title);
         $this->setPageId($pageId);
@@ -30,6 +30,7 @@ class ContaoPageSchema extends BaseType
         $this->setProtected($protected);
         $this->setGroups($groups);
         $this->setFePreview($fePreview);
+        $this->setCurrentGroups($currentGroups);
     }
 
     public function getContext(): string
@@ -99,11 +100,29 @@ class ContaoPageSchema extends BaseType
     }
 
     /**
+     * @return array<int>
+     */
+    public function getCurrentGroups(): array
+    {
+        return $this->properties['currentGroups'];
+    }
+
+    /**
      * @param array<int> $groups
      */
     public function setGroups(array $groups): self
     {
         $this->properties['groups'] = array_map(\intval(...), $groups);
+
+        return $this;
+    }
+
+    /**
+     * @param array<int> $currentGroups
+     */
+    public function setCurrentGroups(array $currentGroups): self
+    {
+        $this->properties['currentGroups'] = array_map(\intval(...), $currentGroups);
 
         return $this;
     }

--- a/core-bundle/tests/Routing/ResponseContext/CoreResponseContextFactoryTest.php
+++ b/core-bundle/tests/Routing/ResponseContext/CoreResponseContextFactoryTest.php
@@ -130,7 +130,7 @@ class CoreResponseContextFactoryTest extends TestCase
     }
 
     #[DataProvider('contaoWebpageResponseContext')]
-    public function testContaoWebpageResponseContext(array $groups, array $currentGroups): void
+    public function testContaoWebpageResponseContext(array $groups, array $memberGroups): void
     {
         $responseAccessor = $this->createMock(ResponseContextAccessor::class);
         $responseAccessor
@@ -163,13 +163,13 @@ class CoreResponseContextFactoryTest extends TestCase
         ;
 
         $user = $this->mockClassWithProperties(FrontendUser::class);
-        $user->groups = serialize($currentGroups);
+        $user->groups = serialize($memberGroups);
 
         $security = $this->createMock(Security::class);
         $security
             ->expects($this->once())
             ->method('getUser')
-            ->willReturn([] === $currentGroups ? null : $user)
+            ->willReturn([] === $memberGroups ? null : $user)
         ;
 
         $pageModel = $this->mockClassWithProperties(PageModel::class);
@@ -224,7 +224,7 @@ class CoreResponseContextFactoryTest extends TestCase
                 'protected' => [] !== $groups,
                 'groups' => $groups,
                 'fePreview' => false,
-                'currentGroups' => $currentGroups,
+                'memberGroups' => $memberGroups,
             ],
             $jsonLdManager->getGraphForSchema(JsonLdManager::SCHEMA_CONTAO)->get(ContaoPageSchema::class)->toArray(),
         );
@@ -346,7 +346,7 @@ class CoreResponseContextFactoryTest extends TestCase
                 'protected' => false,
                 'groups' => [],
                 'fePreview' => false,
-                'currentGroups' => [],
+                'memberGroups' => [],
             ],
             $jsonLdManager->getGraphForSchema(JsonLdManager::SCHEMA_CONTAO)->get(ContaoPageSchema::class)->toArray(),
         );

--- a/core-bundle/tests/Routing/ResponseContext/CoreResponseContextFactoryTest.php
+++ b/core-bundle/tests/Routing/ResponseContext/CoreResponseContextFactoryTest.php
@@ -28,7 +28,6 @@ use Contao\CoreBundle\String\HtmlDecoder;
 use Contao\CoreBundle\Tests\TestCase;
 use Contao\FrontendUser;
 use Contao\PageModel;
-use Contao\StringUtil;
 use Contao\System;
 use Nelmio\SecurityBundle\ContentSecurityPolicy\PolicyManager;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -121,12 +120,12 @@ class CoreResponseContextFactoryTest extends TestCase
     {
         yield 'Unprotected page' => [
             [],
-            []
+            [],
         ];
 
         yield 'Protected page' => [
             [1, 2, 3],
-            [2]
+            [2],
         ];
     }
 

--- a/core-bundle/tests/Routing/ResponseContext/JsonLd/ContaoPageSchemaTest.php
+++ b/core-bundle/tests/Routing/ResponseContext/JsonLd/ContaoPageSchemaTest.php
@@ -20,13 +20,14 @@ class ContaoPageSchemaTest extends TestCase
 {
     public function testGeneralSettersAndGetters(): void
     {
-        $schema = new ContaoPageSchema('title', 42, false, false, [], false);
+        $schema = new ContaoPageSchema('title', 42, false, false, [1, 2, 3], false, [2]);
 
         $this->assertSame('title', $schema->getTitle());
         $this->assertSame(42, $schema->getPageId());
         $this->assertFalse($schema->isNoSearch());
         $this->assertFalse($schema->isProtected());
-        $this->assertSame([], $schema->getGroups());
+        $this->assertSame([1, 2, 3], $schema->getGroups());
+        $this->assertSame([2], $schema->getCurrentGroups());
         $this->assertFalse($schema->isFePreview());
 
         $schema->setTitle('Foobar');

--- a/core-bundle/tests/Routing/ResponseContext/JsonLd/ContaoPageSchemaTest.php
+++ b/core-bundle/tests/Routing/ResponseContext/JsonLd/ContaoPageSchemaTest.php
@@ -27,7 +27,7 @@ class ContaoPageSchemaTest extends TestCase
         $this->assertFalse($schema->isNoSearch());
         $this->assertFalse($schema->isProtected());
         $this->assertSame([1, 2, 3], $schema->getGroups());
-        $this->assertSame([2], $schema->getCurrentGroups());
+        $this->assertSame([2], $schema->getMemberGroups());
         $this->assertFalse($schema->isFePreview());
 
         $schema->setTitle('Foobar');

--- a/core-bundle/tests/Routing/ResponseContext/JsonLd/JsonLdManagerTest.php
+++ b/core-bundle/tests/Routing/ResponseContext/JsonLd/JsonLdManagerTest.php
@@ -104,9 +104,9 @@ class JsonLdManagerTest extends TestCase
                     "@graph": [
                         {
                             "@type": "Page",
-                            "currentGroups": [],
                             "fePreview": false,
                             "groups": [],
+                            "memberGroups": [],
                             "noSearch": false,
                             "pageId": 42,
                             "protected": false,

--- a/core-bundle/tests/Routing/ResponseContext/JsonLd/JsonLdManagerTest.php
+++ b/core-bundle/tests/Routing/ResponseContext/JsonLd/JsonLdManagerTest.php
@@ -104,6 +104,7 @@ class JsonLdManagerTest extends TestCase
                     "@graph": [
                         {
                             "@type": "Page",
+                            "currentGroups": [],
                             "fePreview": false,
                             "groups": [],
                             "noSearch": false,


### PR DESCRIPTION
This allows search indexers to know which member groups were assigned to the member that accessed a protected page.
We need to add this to the document itself because the `SearchIndexListener` pushes the data to the messenger queue, in which case the indexer does not know which member was logged in anymore.

Basically `groups` contains the member groups the page was restricted to and `currentGroups` now contains one (or more) that intersect this information 😊 

Or because a screenshot says it all:
<img width="446" alt="Bildschirmfoto 2025-06-05 um 16 39 57" src="https://github.com/user-attachments/assets/3994169d-dc15-4755-b7a7-84c7c2f40b2a" />
