### PR TITLE
Prevent deep merging of `contao.messenger.web_worker.transports`

### DIFF
--- a/core-bundle/src/DependencyInjection/Configuration.php
+++ b/core-bundle/src/DependencyInjection/Configuration.php
@@ -134,6 +134,7 @@ class Configuration implements ConfigurationInterface
                     ->info('Contao provides a way to work on Messenger transports in the web process (kernel.terminate) if there is no real "messenger:consume" worker. You can configure its behavior here.')
                     ->children()
                         ->arrayNode('transports')
+                            ->performNoDeepMerging()
                             ->info('The transports to apply the web worker logic to.')
                             ->scalarPrototype()->end()
                             ->defaultValue([])


### PR DESCRIPTION
Fixes #8403

This fix prevents the deep merging, which is not desired, when wanting to override the transports or disable the web worker entirely.

In a default managed edition setup, this value should not be configured, thus getting the default value assigned. Therefore, it should not be a breaking change.

Developers which did rely on the current (and in accordance to the developer documentation, wrong) behaviour, would need to configure the default transports additionally to their currently set ones, like:
`[ 'contao_prio_high', 'contao_prio_normal', 'contao_prio_low', 'another_transport' ]`
(instead of only `[ 'another_transport' ]`).

<!--
Bugfixes should be based on the 5.3 branch and features on the 5.x branch.
Select the correct branch in the "base:" drop-down menu above.

Pull requests for Contao 4.13 are no longer merged upstream into Contao 5!
If you want to fix a bug in Contao 4.13, please create a pull request for
Contao 5.3 first and then a separate backport pull request for Contao 4.13.
-->
