### PR TITLE
Remove leftover language strings from the CSS editor

### DIFF
--- a/core-bundle/contao/languages/en/tl_layout.xlf
+++ b/core-bundle/contao/languages/en/tl_layout.xlf
@@ -326,9 +326,6 @@
       <trans-unit id="tl_layout.html5">
         <source>HTML</source>
       </trans-unit>
-      <trans-unit id="tl_layout.edit_styles">
-        <source>Edit the style sheets</source>
-      </trans-unit>
       <trans-unit id="tl_layout.edit_module">
         <source>Edit the module</source>
       </trans-unit>

--- a/core-bundle/contao/languages/en/tl_theme.xlf
+++ b/core-bundle/contao/languages/en/tl_theme.xlf
@@ -128,9 +128,6 @@
       <trans-unit id="tl_theme.delete">
         <source>Delete theme ID %s</source>
       </trans-unit>
-      <trans-unit id="tl_theme.css">
-        <source>Edit the style sheets of theme ID %s</source>
-      </trans-unit>
       <trans-unit id="tl_theme.modules">
         <source>Edit the front end modules of theme ID %s</source>
       </trans-unit>


### PR DESCRIPTION
Found these leftovers from Contao 4 while working on #8372