### PR TITLE
Correctly check if the core modules are installed for comments

### DIFF
--- a/comments-bundle/src/EventListener/DataContainer/AddCommentFieldsListener.php
+++ b/comments-bundle/src/EventListener/DataContainer/AddCommentFieldsListener.php
@@ -69,6 +69,17 @@ class AddCommentFieldsListener
 
     private function applyParentFields(string $table): void
     {
+        $isInstalled = match ($table) {
+            'tl_news_archive' => isset($this->bundles['ContaoNewsBundle']),
+            'tl_calendar' => isset($this->bundles['ContaoCalendarBundle']),
+            'tl_faq_category' => isset($this->bundles['ContaoFaqBundle']),
+            default => throw new \RuntimeException('Unsupported table '.$table),
+        };
+
+        if (!$isInstalled) {
+            return;
+        }
+
         $GLOBALS['TL_DCA'][$table]['palettes']['__selector__'][] = 'allowComments';
         $GLOBALS['TL_DCA'][$table]['subpalettes']['allowComments'] = 'notify,sortOrder,perPage,moderate,bbcode,requireLogin,disableCaptcha';
 
@@ -134,6 +145,18 @@ class AddCommentFieldsListener
 
     private function applyChildFields(string $table): void
     {
+        $isInstalled = match ($table) {
+            'tl_news' => isset($this->bundles['ContaoNewsBundle']),
+            'tl_calendar_events' => isset($this->bundles['ContaoCalendarBundle']),
+            'tl_faq' => isset($this->bundles['ContaoFaqBundle']),
+            default => throw new \RuntimeException('Unsupported table '.$table),
+        };
+        dump($table, $this->bundles, $isInstalled);
+
+        if (!$isInstalled) {
+            return;
+        }
+
         $GLOBALS['TL_DCA'][$table]['list']['sorting']['headerFields'][] = 'allowComments';
 
         $GLOBALS['TL_DCA'][$table]['fields']['noComments'] = [

--- a/comments-bundle/src/EventListener/DataContainer/AddCommentFieldsListener.php
+++ b/comments-bundle/src/EventListener/DataContainer/AddCommentFieldsListener.php
@@ -151,7 +151,6 @@ class AddCommentFieldsListener
             'tl_faq' => isset($this->bundles['ContaoFaqBundle']),
             default => throw new \RuntimeException('Unsupported table '.$table),
         };
-        dump($table, $this->bundles, $isInstalled);
 
         if (!$isInstalled) {
             return;

--- a/comments-bundle/tests/EventListener/DataContainer/AddCommentFieldsListenerTest.php
+++ b/comments-bundle/tests/EventListener/DataContainer/AddCommentFieldsListenerTest.php
@@ -18,6 +18,7 @@ use Contao\CoreBundle\HttpKernel\Bundle\ContaoModuleBundle;
 use Contao\FaqBundle\ContaoFaqBundle;
 use Contao\NewsBundle\ContaoNewsBundle;
 use Contao\TestCase\ContaoTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class AddCommentFieldsListenerTest extends ContaoTestCase
 {
@@ -81,37 +82,10 @@ class AddCommentFieldsListenerTest extends ContaoTestCase
         $this->assertSame($palettes, $GLOBALS['TL_DCA']['tl_module']['palettes']['fooreader']);
     }
 
-    public function testAppliesNewsArchiveFields(): void
-    {
-        $this->testAppliesParentFields(['ContaoNewsBundle' => ContaoNewsBundle::class], 'tl_news_archive');
-    }
-
-    public function testAppliesCalendarFields(): void
-    {
-        $this->testAppliesParentFields(['ContaoCalendarBundle' => ContaoCalendarBundle::class], 'tl_calendar');
-    }
-
-    public function testAppliesFaqCategoryFields(): void
-    {
-        $this->testAppliesParentFields(['ContaoFaqBundle' => ContaoFaqBundle::class], 'tl_faq_category');
-    }
-
-    public function testAppliesNewsFields(): void
-    {
-        $this->testAppliesChildrenFields(['ContaoNewsBundle' => ContaoNewsBundle::class], 'tl_news', true);
-    }
-
-    public function testAppliesCalendarEventFields(): void
-    {
-        $this->testAppliesChildrenFields(['ContaoCalendarBundle' => ContaoCalendarBundle::class], 'tl_calendar_events', true);
-    }
-
-    public function testAppliesFaqFields(): void
-    {
-        $this->testAppliesChildrenFields(['ContaoFaqBundle' => ContaoFaqBundle::class], 'tl_faq');
-    }
-
-    private function testAppliesParentFields(array $bundles, string $table): void
+    /**
+     * @dataProvider appliesParentFieldsValues
+     */
+    public function testAppliesParentFields(array $bundles, string $table): void
     {
         $palettes = '{foo_legend},bar';
         $expected = '{foo_legend},bar;{comments_legend:hide},allowComments';
@@ -137,7 +111,28 @@ class AddCommentFieldsListenerTest extends ContaoTestCase
         }
     }
 
-    private function testAppliesChildrenFields(array $bundles, string $table, bool $extended = false): void
+    public static function appliesParentFieldsValues(): iterable
+    {
+        yield [
+            ['ContaoNewsBundle' => ContaoNewsBundle::class],
+            'tl_news_archive',
+        ];
+
+        yield [
+            ['ContaoCalendarBundle' => ContaoCalendarBundle::class],
+            'tl_calendar',
+        ];
+
+        yield [
+            ['ContaoFaqBundle' => ContaoFaqBundle::class],
+            'tl_faq_category',
+        ];
+    }
+
+    /**
+     * @dataProvider appliesChildFieldsValues
+     */
+    public function testAppliesChildFields(array $bundles, string $table, bool $extended = false): void
     {
         $palettes = '{foo_legend},bar;{publish_legend},baz';
         $expected = '{foo_legend},bar;{expert_legend:hide},noComments;{publish_legend},baz';
@@ -170,5 +165,25 @@ class AddCommentFieldsListenerTest extends ContaoTestCase
             $this->assertSame($expected, $GLOBALS['TL_DCA'][$table]['palettes']['article']);
             $this->assertSame($expected, $GLOBALS['TL_DCA'][$table]['palettes']['external']);
         }
+    }
+
+    public static function appliesChildFieldsValues(): iterable
+    {
+        yield [
+            ['ContaoNewsBundle' => ContaoNewsBundle::class],
+            'tl_news',
+            true,
+        ];
+
+        yield [
+            ['ContaoCalendarBundle' => ContaoCalendarBundle::class],
+            'tl_calendar_events',
+            true,
+        ];
+
+        yield [
+            ['ContaoFaqBundle' => ContaoFaqBundle::class],
+            'tl_faq',
+        ];
     }
 }


### PR DESCRIPTION
Fixes #8408

Checking for bundles is already present in that listener, just not executed for the parent and child fields.

The tests are still exactly the same, I just refactored them to use a `dataProvider` instead of a private teste function (which I think is "more correct").