### PR TITLE
Do not show the Swiper buttons in the back end preview

### DIFF
--- a/core-bundle/contao/templates/twig/content_element/swiper.html.twig
+++ b/core-bundle/contao/templates/twig/content_element/swiper.html.twig
@@ -33,23 +33,25 @@
             {% endblock %}
         </div>
         {% block controls %}
-            {% set button_prev_attributes = attrs()
-                .set('type', 'button')
-                .addClass('swiper-button-prev')
-                .mergeWith(button_prev_attributes|default)
-            %}
-            <button{{ button_prev_attributes }}></button>
-            {% set button_next_attributes = attrs()
-                .set('type', 'button')
-                .addClass('swiper-button-next')
-                .mergeWith(button_next_attributes|default)
-            %}
-            <button{{ button_next_attributes }}></button>
-            {% set pagination_attributes = attrs()
-                .addClass('swiper-pagination')
-                .mergeWith(pagination_attributes|default)
-            %}
-            <div{{ pagination_attributes }}></div>
+            {% if not as_editor_view %}
+                {% set button_prev_attributes = attrs()
+                    .set('type', 'button')
+                    .addClass('swiper-button-prev')
+                    .mergeWith(button_prev_attributes|default)
+                %}
+                <button{{ button_prev_attributes }}></button>
+                {% set button_next_attributes = attrs()
+                    .set('type', 'button')
+                    .addClass('swiper-button-next')
+                    .mergeWith(button_next_attributes|default)
+                %}
+                <button{{ button_next_attributes }}></button>
+                {% set pagination_attributes = attrs()
+                    .addClass('swiper-pagination')
+                    .mergeWith(pagination_attributes|default)
+                %}
+                <div{{ pagination_attributes }}></div>
+            {% endif %}
         {% endblock %}
     </div>
 {% endblock %}
@@ -73,7 +75,7 @@
 
                     let delay = el.getAttribute('data-delay');
                     if (delay > 0) {
-                        opts['autoplay'] = { 
+                        opts['autoplay'] = {
                             delay: delay,
                             pauseOnMouseEnter: true,
                         };


### PR DESCRIPTION
Currently the back end always show these empty buttons from the swiper template:

<img src="https://github.com/user-attachments/assets/2cfd2698-70f2-40d7-99a0-643391447864" width="364">

These buttons only make sense in the front end where the swiper is actually initialized and the CSS is applied. Thus I think we should just hide them in the back end.

The accordion also has buttons that only work in the front end. However, those buttons actually have content and therefore I do not think we need to adjust anything there.