### PR TITLE
Remove superfluous `image_container` class from the `contao_figure` function

### DIFF
--- a/core-bundle/templates/Image/Studio/figure.html.twig
+++ b/core-bundle/templates/Image/Studio/figure.html.twig
@@ -1,5 +1,3 @@
 {% import "@ContaoCore/Image/Studio/_macros.html.twig" as studio %}
 
-{{- studio.figure(figure, figure.options|default({})|merge({
-    attr: {class: ('image_container ' ~ figure.options.attr.class|default(''))|trim}
-})) -}}
+{{- studio.figure(figure) -}}


### PR DESCRIPTION
### Description

* fixes #8421

Can literally drop everything and just insert the figure into the twig macro as there's no need to recursively merge the class anymore (rest happens in the macro).
