### PR TITLE
Do not override `error_reporting` in `contao-api`

### DIFF
--- a/manager-bundle/bin/contao-api
+++ b/manager-bundle/bin/contao-api
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 use Contao\ManagerBundle\Api\Application;
 
-error_reporting(-1);
 set_time_limit(0);
 @ini_set('display_startup_errors', '1');
 @ini_set('display_errors', '1');


### PR DESCRIPTION
Same as #8344 for the `contao-api`, otherwise the deprecation message spam breaks the output for the Contao Manager.