### PR TITLE
Remove the `popstate` listener for table revision

### DIFF
--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -2455,12 +2455,6 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 		if ((string) $currentRecord['tstamp'] === '0')
 		{
 			$strBackUrl = preg_replace('/&(?:amp;)?revise=[^&]+|$/', '&amp;revise=' . $this->strTable . '.' . ((int) $this->intId), $strBackUrl, 1);
-
-			$return .= '
-<script>
-  history.pushState({}, "");
-  window.addEventListener("popstate", () => fetch(document.querySelector(".header_back").href).then(() => history.back()));
-</script>';
 		}
 
 		// Begin the form (-> DO NOT CHANGE THIS ORDER -> this way the onsubmit attribute of the form can be changed by a field)


### PR DESCRIPTION
This removes the non-working code mentioned in https://github.com/contao/contao/issues/8435 and will fix https://github.com/contao/contao/issues/8426 once merged upstream to `5.5`.

_Note:_ in 5.3 you will directly see the not-deleted content element. In 5.5+ you won't, because Turbo loads the previous state from the cache. Only after a full page load you will see the not-deleted content element.