### PR TITLE
Remove the `title` attribute from the breadcrumb elements

### DIFF
--- a/core-bundle/contao/templates/modules/mod_breadcrumb.html5
+++ b/core-bundle/contao/templates/modules/mod_breadcrumb.html5
@@ -14,7 +14,7 @@
         <?php if ($item['isActive']): ?>
           <li class="active" aria-current="page"><?= $item['link'] ?></li>
         <?php else: ?>
-          <li><a href="<?= $item['href'] ?>" title="<?= $item['title'] ?>"><?= $item['link'] ?></a></li>
+          <li><a href="<?= $item['href'] ?>"><?= $item['link'] ?></a></li>
         <?php endif; ?>
       <?php endforeach; ?>
     </ul>


### PR DESCRIPTION
Just as in https://github.com/contao/contao/pull/7839, https://github.com/contao/contao/pull/8240 this removes the `title` attribute from the breadcrumb elements. The `title` would be the same as the link name, if no `pageTitle` was set - and even if the `pageTitle` is set, the `title` should not be used. And it likely also does not make sense to use the meta `pageTitle` as `aria-label`.