### PR TITLE
Remove a superfluous space from the article insert tags

### DIFF
--- a/core-bundle/src/InsertTag/Resolver/LegacyInsertTag.php
+++ b/core-bundle/src/InsertTag/Resolver/LegacyInsertTag.php
@@ -310,11 +310,11 @@ class LegacyInsertTag implements InsertTagResolverNestedResolvedInterface
                 // Replace the tag
                 switch ($insertTag->getName()) {
                     case 'article':
-                        $result = \sprintf('<a href="%s" %s>%s</a>', $strUrl, $strTarget, $objArticle->title);
+                        $result = \sprintf('<a href="%s"%s>%s</a>', $strUrl, $strTarget, $objArticle->title);
                         break;
 
                     case 'article_open':
-                        $result = \sprintf('<a href="%s" %s>', $strUrl, $strTarget);
+                        $result = \sprintf('<a href="%s"%s>', $strUrl, $strTarget);
                         break;
 
                     case 'article_url':


### PR DESCRIPTION
Currently the `article` and `article_open` insert tags have a superfluous space in the output (introduced in #7839):

```html
<a href="/page/articles/foobar" >
```

This is because `$strTarget` already incorporates the space (so that there is no space, when `$strTarget` is empty). This PR removes that space.