### PR TITLE
Do not overwrite the referer if the current table is self-referencing

### DIFF
--- a/core-bundle/contao/drivers/DC_Table.php
+++ b/core-bundle/contao/drivers/DC_Table.php
@@ -237,7 +237,7 @@ class DC_Table extends DataContainer implements ListableDataContainerInterface, 
 		$route = $request->attributes->get('_route');
 
 		// Store the current referer
-		if (!empty($this->ctable) && !Input::get('ptable') && $route == 'contao_backend' && !Input::get('act') && !Input::get('key') && !Input::get('token') && !Environment::get('isAjaxRequest'))
+		if ((!empty($this->ctable) && !\in_array($this->strTable, $this->ctable)) && !Input::get('ptable') && $route == 'contao_backend' && !Input::get('act') && !Input::get('key') && !Input::get('token') && !Environment::get('isAjaxRequest'))
 		{
 			$strKey = Input::get('popup') ? 'popupReferer' : 'referer';
 			$strRefererId = $request->attributes->get('_contao_referer_id');


### PR DESCRIPTION
Fixes #8137

The issue was caused by 2d8430f2d5b02218a017f8a7b88962a36669a96f which turned `tl_content` into a self-referencing table. This is now taken into account when overwriting the referrer.

Note that this only restores the previous behavior and does not fix other issues such as https://github.com/contao/contao/issues/8137#issuecomment-2677118654, which are unrelated to the mentioned change.